### PR TITLE
feat(conductor): operator recovery commands for the fleet control plane

### DIFF
--- a/docs/cli/conductor-recovery.md
+++ b/docs/cli/conductor-recovery.md
@@ -1,0 +1,104 @@
+# Conductor Operator Recovery Commands
+
+This page documents the Conductor recovery and operator-convenience commands
+added for day-2 fleet management. All are Enterprise-tier and require a license
+with the `fleet` feature.
+
+## `publish --previous-bundle-hash auto`
+
+After a rollback, the operator must publish a new policy bundle version above the
+stream's max-ever version. The `--previous-bundle-hash` flag chains the new
+bundle to the current stream head. Normally the operator must copy this hash from
+a prior publish output or a `conductor stream status` query.
+
+`--previous-bundle-hash auto` resolves the hash automatically by querying the
+Conductor's stream-status endpoint before building the bundle:
+
+```sh
+pipelock conductor publish \
+  --conductor-url https://conductor.example:8895 \
+  --config policy.yaml \
+  --org acme --fleet prod --env prod \
+  --audience '*' \
+  --version 10 \
+  --previous-bundle-hash auto \
+  --signing-key /etc/pipelock/keys/policy-signing.json \
+  --publisher-token-file /etc/pipelock/publisher.token \
+  --tls-cert client.crt --tls-key client.key --server-ca ca.pem
+```
+
+The resolved hash is printed before the publish proceeds. For the first bundle
+in a stream (no existing head), `auto` resolves to an empty string and the
+publish proceeds without a previous hash.
+
+## `rollback clear`
+
+Clear a single active rollback authorization by its `authorization_id`. This is
+an admin-only operation that lets the operator unblock forward publishes without
+waiting for the rollback TTL to expire.
+
+```sh
+pipelock conductor rollback clear \
+  --authorization-id rollback-42-to-41-100 \
+  --confirm \
+  --server https://conductor.example:8895 \
+  --token-file admin.token \
+  --client-cert client.crt --client-key client.key --ca-file ca.pem
+```
+
+The `--confirm` flag is mandatory. Without it, the command refuses to run (fail
+closed).
+
+## `kill status`
+
+A read-only alias that surfaces active remote-kill messages from the Conductor's
+stream-status endpoint. No new server endpoint is needed; this is a CLI
+convenience that filters the existing stream-status response to just the kill
+state.
+
+```sh
+pipelock conductor kill status \
+  --org-id acme --fleet-id prod \
+  --server https://conductor.example:8895 \
+  --token-file admin.token \
+  --client-cert client.crt --client-key client.key --ca-file ca.pem
+```
+
+Use `--json` for the raw JSON response.
+
+## `store dump`
+
+A read-only dump of the Conductor's stream overview (streams, bundle chains,
+emergency controls) as pretty-printed JSON for support and debugging. No state
+is modified.
+
+```sh
+pipelock conductor store dump \
+  --org-id acme --fleet-id prod \
+  --server https://conductor.example:8895 \
+  --token-file admin.token \
+  --client-cert client.crt --client-key client.key --ca-file ca.pem
+```
+
+## Rollback authorization TTL enforcement
+
+The rollback authorization's `expires_at` field (set via `--ttl` at publish time,
+default 1 hour) is enforced at every read/apply path:
+
+- **Server-side emergency store reads** (`LatestRollbackAuthorization`,
+  `ActiveRollbackForFollower`) call `ValidateAtTime(now)` and skip expired
+  records.
+- **Server-side stream-status display** calls `ValidateAtTime(now)` and omits
+  expired authorizations from the active list.
+- **Follower-side applycache** calls `ValidateAtTime(now)` and rejects expired
+  rollback authorizations before applying them.
+
+An expired rollback authorization stops affecting followers without operator
+intervention. Use `rollback clear` to remove an authorization before its TTL
+expires.
+
+## See also
+
+- [`pipelock conductor stream`](conductor-stream.md) -- stream observability.
+- [Conductor operator runbook](../guides/conductor-operator-runbook.md) --
+  publish, kill, rollback, and bootstrap workflows.

--- a/docs/cli/conductor-stream.md
+++ b/docs/cli/conductor-stream.md
@@ -161,6 +161,10 @@ The `--confirm` flag is mandatory; the command refuses to run without it. Prefer
 `pipelock conductor rollback clear --authorization-id <id>` to remove a single
 rollback authorization rather than clearing all of them.
 
+The command also fails closed if stream status cannot read emergency controls.
+In that case it aborts before deleting any rollback authorization, so operators
+do not get a partial reset from incomplete control-plane state.
+
 ## See also
 
 - [`pipelock conductor fleet status`](../guides/conductor.md) — the enrolled-follower roster.

--- a/docs/cli/conductor-stream.md
+++ b/docs/cli/conductor-stream.md
@@ -23,6 +23,7 @@ pipelock conductor stream inspect --org-id acme --fleet-id prod
 |---|---|
 | `status` | A human-readable table of streams plus active emergency controls. Add `--json` for the raw response. |
 | `inspect` | Always emits the raw JSON response, including every stream's complete bundle chain (`bundle_id`, `version`, `bundle_hash`, `previous_bundle_hash`, `created_at`, `min_pipelock_version`, `published_at`). Identical authorization and scope to `status`. |
+| `reset` | Clear all active rollback authorizations for an org/fleet scope. Requires `--confirm` (refuses without it). See [Stream reset](#stream-reset). |
 
 ## Authorization and scope
 
@@ -144,6 +145,21 @@ and active emergency controls.
 Connection flags (control-plane address, token file, CA, license CRL) are shared
 with the other `conductor` subcommands; run `pipelock conductor stream status
 --help` for the full list.
+
+## Stream reset
+
+`pipelock conductor stream reset` is a guarded, destructive admin operation that
+clears all active (non-expired) rollback authorizations for the given org/fleet
+scope. It fetches the stream status to discover active rollback authorizations,
+then deletes each one via the Conductor's DELETE endpoint.
+
+```sh
+pipelock conductor stream reset --org-id acme --fleet-id prod --confirm
+```
+
+The `--confirm` flag is mandatory; the command refuses to run without it. Prefer
+`pipelock conductor rollback clear --authorization-id <id>` to remove a single
+rollback authorization rather than clearing all of them.
 
 ## See also
 

--- a/docs/guides/conductor-operator-runbook.md
+++ b/docs/guides/conductor-operator-runbook.md
@@ -327,9 +327,9 @@ for full details.
 |---|---|
 | `conductor publish --previous-bundle-hash auto` | Publish forward after a rollback without manually copying the stream head hash. |
 | `conductor rollback clear --authorization-id <id> --confirm` | Remove a single active rollback authorization (unblock forward publishes before TTL expiry). |
-| `conductor stream reset --org-id <org> --confirm` | Clear all active rollback authorizations for an org/fleet scope. |
+| `conductor stream reset --org-id <org> --fleet-id <fleet> --confirm` | Clear all active rollback authorizations for an org/fleet scope. |
 | `conductor kill status --org-id <org>` | Show active remote-kill messages (read-only). |
-| `conductor store dump --org-id <org>` | Dump control-plane state as JSON for support. |
+| `conductor store dump --org-id <org>` | Dump the stream-status JSON response for support. |
 
 All guarded commands require `--confirm`; they refuse to run without it.
 

--- a/docs/guides/conductor-operator-runbook.md
+++ b/docs/guides/conductor-operator-runbook.md
@@ -317,6 +317,22 @@ With a valid operator Enterprise license, bootstrap proves:
 
 It does not prove mediation completeness. The agent reaching the network only through Pipelock remains deployment-enforced through capability separation, container/network policy, or per-UID firewalling.
 
+## Recovery Operations
+
+After a rollback or during incident recovery, additional operator commands are
+available. See [`docs/cli/conductor-recovery.md`](../cli/conductor-recovery.md)
+for full details.
+
+| Command | Purpose |
+|---|---|
+| `conductor publish --previous-bundle-hash auto` | Publish forward after a rollback without manually copying the stream head hash. |
+| `conductor rollback clear --authorization-id <id> --confirm` | Remove a single active rollback authorization (unblock forward publishes before TTL expiry). |
+| `conductor stream reset --org-id <org> --confirm` | Clear all active rollback authorizations for an org/fleet scope. |
+| `conductor kill status --org-id <org>` | Show active remote-kill messages (read-only). |
+| `conductor store dump --org-id <org>` | Dump control-plane state as JSON for support. |
+
+All guarded commands require `--confirm`; they refuse to run without it.
+
 ## Validation Status For This Doc
 
 Live-run commands completed in this documentation pass:

--- a/enterprise/cli/conductor/client.go
+++ b/enterprise/cli/conductor/client.go
@@ -5,9 +5,11 @@
 package conductor
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -160,6 +162,35 @@ func (c *conductorClient) getStreamStatus(ctx context.Context, orgID, fleetID st
 		"fleet_id": fleetID,
 	}
 	return c.getJSON(ctx, controlplane.StreamStatusPath+encodeQuery(params))
+}
+
+// deleteJSON performs an authenticated DELETE with a JSON body and returns the
+// response body bytes for a 200 response, or a descriptive error otherwise.
+func (c *conductorClient) deleteJSON(ctx context.Context, path string, body any) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal delete request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+path, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("build delete request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("delete request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, clientMaxBodyBytes))
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("conductor returned status %d: %s", resp.StatusCode, clientSnippet(respBody, c.token))
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("read delete response: %w", readErr)
+	}
+	return respBody, nil
 }
 
 func readClientTokenFile(path string) (string, error) {

--- a/enterprise/cli/conductor/cmd.go
+++ b/enterprise/cli/conductor/cmd.go
@@ -90,11 +90,16 @@ func Cmd() *cobra.Command {
 	cmd.AddCommand(fleetCmd())
 	cmd.AddCommand(streamCmd())
 	cmd.AddCommand(followersCmd())
-	cmd.AddCommand(killCmd())
+	kCmd := killCmd()
+	kCmd.AddCommand(killStatusCmd())
+	cmd.AddCommand(kCmd)
 	cmd.AddCommand(resumeCmd())
-	cmd.AddCommand(rollbackCmd())
+	rbCmd := rollbackCmd()
+	rbCmd.AddCommand(rollbackClearCmd())
+	cmd.AddCommand(rbCmd)
 	cmd.AddCommand(enrollCmd())
 	cmd.AddCommand(enrollmentTokenCmd())
+	cmd.AddCommand(storeCmd())
 	return cmd
 }
 

--- a/enterprise/cli/conductor/kill_status.go
+++ b/enterprise/cli/conductor/kill_status.go
@@ -1,0 +1,93 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+type killStatusOptions struct {
+	client  clientOptions
+	orgID   string
+	fleetID string
+	jsonOut bool
+}
+
+func killStatusCmd() *cobra.Command {
+	opts := killStatusOptions{}
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show active Conductor remote-kill messages",
+		Long: `status queries the Conductor stream-status endpoint and reports any active
+remote-kill messages in scope for the given org/fleet. This is a read-only
+convenience over 'conductor stream status' that filters to just the kill state.
+
+No new server endpoint is needed; the data is already in the stream-status
+response.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleet("", "", opts.client.licenseCRLFile); err != nil {
+				return err
+			}
+			return runKillStatus(cmd, opts)
+		},
+	}
+	opts.client.bindFlags(cmd)
+	cmd.Flags().StringVar(&opts.orgID, "org-id", "", "org id to query (required)")
+	cmd.Flags().StringVar(&opts.fleetID, "fleet-id", "", "fleet id to scope the query")
+	cmd.Flags().BoolVar(&opts.jsonOut, "json", false, "emit the raw JSON response instead of a table")
+	return cmd
+}
+
+func runKillStatus(cmd *cobra.Command, opts killStatusOptions) error {
+	if strings.TrimSpace(opts.orgID) == "" {
+		return errors.New("--org-id is required")
+	}
+	client, err := newConductorClient(opts.client)
+	if err != nil {
+		return err
+	}
+	body, err := client.getStreamStatus(cmd.Context(), opts.orgID, opts.fleetID)
+	if err != nil {
+		return err
+	}
+	if opts.jsonOut {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
+		return nil
+	}
+	var parsed streamStatusResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("decode stream status response: %w", err)
+	}
+	return writeKillStatusTable(cmd, parsed)
+}
+
+func writeKillStatusTable(cmd *cobra.Command, resp streamStatusResponse) error {
+	out := cmd.OutOrStdout()
+	if !resp.EmergencyControlsRead {
+		_, _ = fmt.Fprintln(out, "emergency controls: NOT AVAILABLE (kill list may be incomplete)")
+	}
+	if len(resp.ActiveRemoteKills) == 0 {
+		_, _ = fmt.Fprintln(out, "no active remote kills")
+		return nil
+	}
+	_, _ = fmt.Fprintf(out, "%d active remote kill(s):\n", len(resp.ActiveRemoteKills))
+	tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "MESSAGE_ID\tFLEET\tSTATE\tCOUNTER\tEXPIRES_AT\tREASON")
+	for _, k := range resp.ActiveRemoteKills {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\t%s\n",
+			k.MessageID, k.FleetID, k.State, k.Counter,
+			k.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z"), k.Reason)
+	}
+	return tw.Flush()
+}

--- a/enterprise/cli/conductor/kill_status_test.go
+++ b/enterprise/cli/conductor/kill_status_test.go
@@ -1,0 +1,100 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+func TestWriteKillStatusTable_NoKills(t *testing.T) {
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	resp := streamStatusResponse{
+		EmergencyControlsRead: true,
+	}
+	if err := writeKillStatusTable(cmd, resp); err != nil {
+		t.Fatalf("writeKillStatusTable: %v", err)
+	}
+	if got := out.String(); got != "no active remote kills\n" {
+		t.Fatalf("output = %q, want 'no active remote kills'", got)
+	}
+}
+
+func TestWriteKillStatusTable_WithKills(t *testing.T) {
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	resp := streamStatusResponse{
+		EmergencyControlsRead: true,
+		ActiveRemoteKills: []controlplane.ActiveRemoteKill{
+			{
+				MessageID: "kill-1",
+				FleetID:   "prod",
+				State:     "active",
+				Counter:   1,
+				ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+				Reason:    "emergency",
+			},
+		},
+	}
+	if err := writeKillStatusTable(cmd, resp); err != nil {
+		t.Fatalf("writeKillStatusTable: %v", err)
+	}
+	got := out.String()
+	if !bytes.Contains([]byte(got), []byte("kill-1")) {
+		t.Fatalf("output missing kill-1: %q", got)
+	}
+	if !bytes.Contains([]byte(got), []byte("1 active remote kill(s)")) {
+		t.Fatalf("output missing count: %q", got)
+	}
+}
+
+func TestWriteKillStatusTable_EmergencyControlsNotAvailable(t *testing.T) {
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	resp := streamStatusResponse{
+		EmergencyControlsRead: false,
+	}
+	if err := writeKillStatusTable(cmd, resp); err != nil {
+		t.Fatalf("writeKillStatusTable: %v", err)
+	}
+	got := out.String()
+	if !bytes.Contains([]byte(got), []byte("NOT AVAILABLE")) {
+		t.Fatalf("output missing NOT AVAILABLE warning: %q", got)
+	}
+}
+
+func TestRunKillStatus_MissingOrgIDRejected(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	err := runKillStatus(cmd, killStatusOptions{orgID: ""})
+	if err == nil || err.Error() != "--org-id is required" {
+		t.Fatalf("error = %v, want --org-id required", err)
+	}
+}
+
+func TestKillStatusCmd_NoFleetLicenseFailsClosed(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	t.Setenv(license.EnvLicensePublicKey, "")
+	t.Setenv(license.EnvLicenseCRLFile, "")
+	cmd := Cmd()
+	cmd.SetArgs([]string{"kill", "status", "--org-id", "test-org"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !errors.Is(err, license.ErrFleetLicenseRequired) {
+		t.Fatalf("kill status without license error = %v, want ErrFleetLicenseRequired", err)
+	}
+}

--- a/enterprise/cli/conductor/publish.go
+++ b/enterprise/cli/conductor/publish.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 	"unicode"
@@ -181,7 +182,7 @@ Example:
 	cmd.Flags().StringVar(&opts.bundleID, "bundle-id", "", "bundle id (default: <fleet>-<env>-v<version>)")
 	cmd.Flags().StringArrayVar(&opts.audience, "audience", nil, "audience selector: '*' for the whole fleet, an instance id, or 'label:KEY=VALUE'; repeatable. Instance ids and labels cannot be mixed")
 	cmd.Flags().Uint64Var(&opts.version, "version", 0, "monotonic bundle version; must exceed the stream's highest published version (after a rollback, newer versions can exist above the current head, so this must beat the stream max, not just the head)")
-	cmd.Flags().StringVar(&opts.previousHash, "previous-bundle-hash", "", "hash of the currently published bundle for this stream (printed by the prior publish); omit only for the first bundle in a stream")
+	cmd.Flags().StringVar(&opts.previousHash, "previous-bundle-hash", "", "hash of the currently published bundle for this stream (printed by the prior publish); use 'auto' to fetch the current stream head hash from the Conductor; omit only for the first bundle in a stream")
 	cmd.Flags().DurationVar(&opts.validity, "validity", opts.validity, "validity window for the bundle starting now (not_before=now, expires_at=now+validity)")
 	cmd.Flags().StringVar(&opts.minVersion, "min-pipelock-version", "", "minimum pipelock version a follower must run to apply this bundle (major.minor.patch)")
 	cmd.Flags().StringVar(&opts.signingKey, "signing-key", "", "path to a policy-bundle-signing key file from 'pipelock signing key generate'")
@@ -194,9 +195,24 @@ Example:
 	return cmd
 }
 
+// previousHashAuto is the sentinel value for --previous-bundle-hash that
+// triggers automatic resolution of the current stream head hash via the
+// Conductor's stream-status endpoint.
+const previousHashAuto = "auto"
+
 func runPublish(ctx context.Context, out io.Writer, opts publishOptions) error {
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	// Resolve "auto" previous-bundle-hash before building the bundle. This
+	// requires a round trip to the Conductor to fetch the current stream head.
+	if strings.EqualFold(strings.TrimSpace(opts.previousHash), previousHashAuto) {
+		resolved, err := resolveAutoHash(ctx, opts)
+		if err != nil {
+			return fmt.Errorf("resolve --previous-bundle-hash auto: %w", err)
+		}
+		opts.previousHash = resolved
+		_, _ = fmt.Fprintf(out, "resolved --previous-bundle-hash auto to %s\n", resolved)
 	}
 	bundle, keyID, priv, err := buildSignedBundle(opts)
 	if err != nil {
@@ -749,4 +765,107 @@ func sanitizeServerDetail(s, token string) string {
 		out = string(runes[:serverErrorMaxRunes])
 	}
 	return out
+}
+
+// resolveAutoHash fetches the current stream head hash from the Conductor's
+// stream-status endpoint and selects the stream matching the bundle this publish
+// is about to create: same org/fleet query, same environment, and same audience.
+// An empty match returns "" so a first-in-stream publish proceeds without a
+// previous hash.
+func resolveAutoHash(ctx context.Context, opts publishOptions) (string, error) {
+	audience, err := parseAudience(opts.audience)
+	if err != nil {
+		return "", err
+	}
+	environment := strings.TrimSpace(opts.environment)
+	if environment == "" {
+		return "", errors.New("--env is required when --previous-bundle-hash auto is used")
+	}
+	client, err := publishHTTPClient(opts)
+	if err != nil {
+		return "", err
+	}
+	token, err := readPublisherToken(opts.publisherTok)
+	if err != nil {
+		return "", err
+	}
+	params := url.Values{}
+	if strings.TrimSpace(opts.orgID) != "" {
+		params.Set("org_id", opts.orgID)
+	}
+	if strings.TrimSpace(opts.fleetID) != "" {
+		params.Set("fleet_id", opts.fleetID)
+	}
+	endpoint := strings.TrimRight(opts.conductorURL, "/") + controlplane.StreamStatusPath
+	if len(params) > 0 {
+		endpoint += "?" + params.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("build stream-status request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("stream-status request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, publishMaxResponseBytes))
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("stream-status returned HTTP %d: %s", resp.StatusCode, serverErrorDetail(body, token))
+	}
+	var status struct {
+		Streams []struct {
+			Environment    string                 `json:"environment"`
+			Audience       conductorcore.Audience `json:"audience"`
+			HeadBundleHash string                 `json:"head_bundle_hash"`
+		} `json:"streams"`
+	}
+	if err := json.Unmarshal(body, &status); err != nil {
+		return "", fmt.Errorf("decode stream-status: %w", err)
+	}
+	var matches []string
+	for _, stream := range status.Streams {
+		if stream.Environment != environment {
+			continue
+		}
+		if !audiencesEquivalent(stream.Audience, audience) {
+			continue
+		}
+		matches = append(matches, stream.HeadBundleHash)
+	}
+	if len(matches) == 0 {
+		return "", nil
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("stream-status returned %d matching streams for env %q and audience; refusing to choose a previous hash", len(matches), environment)
+	}
+	return matches[0], nil
+}
+
+func audiencesEquivalent(a, b conductorcore.Audience) bool {
+	aIDs := canonicalInstanceIDs(a.InstanceIDs)
+	bIDs := canonicalInstanceIDs(b.InstanceIDs)
+	if !slices.Equal(aIDs, bIDs) {
+		return false
+	}
+	if len(a.Labels) != len(b.Labels) {
+		return false
+	}
+	for key, aVal := range a.Labels {
+		if b.Labels[key] != aVal {
+			return false
+		}
+	}
+	return true
+}
+
+func canonicalInstanceIDs(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := slices.Clone(ids)
+	slices.Sort(out)
+	return slices.Compact(out)
 }

--- a/enterprise/cli/conductor/publish_auto_hash_test.go
+++ b/enterprise/cli/conductor/publish_auto_hash_test.go
@@ -150,6 +150,55 @@ func TestResolveAutoHash_NoMatchingStream(t *testing.T) {
 	}
 }
 
+func TestResolveAutoHash_MultipleMatchingStreams(t *testing.T) {
+	hash1 := "1111111111111111111111111111111111111111111111111111111111111111"
+	hash2 := "2222222222222222222222222222222222222222222222222222222222222222"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"streams":[` +
+			`{"environment":"prod","audience":{"instance_ids":["*"]},"head_bundle_hash":"` + hash1 + `"},` +
+			`{"environment":"prod","audience":{"instance_ids":["*"]},"head_bundle_hash":"` + hash2 + `"}` +
+			`],"stream_count":2}`))
+	}))
+	defer srv.Close()
+
+	opts := publishOptions{
+		conductorURL: srv.URL,
+		orgID:        "org-main",
+		fleetID:      "prod",
+		environment:  "prod",
+		audience:     []string{"*"},
+		publisherTok: writePublisherTokenFile(t),
+		insecure:     true,
+	}
+	_, err := resolveAutoHash(t.Context(), opts)
+	if err == nil {
+		t.Fatal("resolveAutoHash with multiple matching streams: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "matching streams") {
+		t.Fatalf("error = %v, want matching streams mention", err)
+	}
+}
+
+func TestResolveAutoHash_MissingEnvironment(t *testing.T) {
+	opts := publishOptions{
+		conductorURL: "http://127.0.0.1:1",
+		orgID:        "org-main",
+		fleetID:      "prod",
+		environment:  "  ",
+		audience:     []string{"*"},
+		publisherTok: writePublisherTokenFile(t),
+		insecure:     true,
+	}
+	_, err := resolveAutoHash(t.Context(), opts)
+	if err == nil {
+		t.Fatal("resolveAutoHash with missing environment: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--env") {
+		t.Fatalf("error = %v, want --env mention", err)
+	}
+}
+
 func TestPreviousHashAutoSentinelIgnoresCase(t *testing.T) {
 	for _, val := range []string{"auto", "AUTO", "Auto", "  auto  "} {
 		if !strings.EqualFold(strings.TrimSpace(val), previousHashAuto) {

--- a/enterprise/cli/conductor/publish_auto_hash_test.go
+++ b/enterprise/cli/conductor/publish_auto_hash_test.go
@@ -1,0 +1,168 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveAutoHash_WithHead(t *testing.T) {
+	const headHash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"streams":[{"environment":"prod","audience":{"instance_ids":["*"]},"head_bundle_hash":"` + headHash + `"}],"stream_count":1}`))
+	}))
+	defer srv.Close()
+
+	opts := publishOptions{
+		conductorURL: srv.URL,
+		orgID:        "org-main",
+		fleetID:      "prod",
+		environment:  "prod",
+		audience:     []string{"*"},
+		publisherTok: writePublisherTokenFile(t),
+		insecure:     true,
+	}
+	hash, err := resolveAutoHash(t.Context(), opts)
+	if err != nil {
+		t.Fatalf("resolveAutoHash: %v", err)
+	}
+	if hash != headHash {
+		t.Fatalf("hash = %q, want %q", hash, headHash)
+	}
+}
+
+func TestResolveAutoHash_NoStreams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"streams":[],"stream_count":0}`))
+	}))
+	defer srv.Close()
+
+	opts := publishOptions{
+		conductorURL: srv.URL,
+		orgID:        "org-main",
+		fleetID:      "prod",
+		environment:  "prod",
+		audience:     []string{"*"},
+		publisherTok: writePublisherTokenFile(t),
+		insecure:     true,
+	}
+	hash, err := resolveAutoHash(t.Context(), opts)
+	if err != nil {
+		t.Fatalf("resolveAutoHash (empty): %v", err)
+	}
+	if hash != "" {
+		t.Fatalf("hash = %q, want empty", hash)
+	}
+}
+
+func TestResolveAutoHash_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	defer srv.Close()
+
+	opts := publishOptions{
+		conductorURL: srv.URL,
+		orgID:        "org-main",
+		fleetID:      "prod",
+		environment:  "prod",
+		audience:     []string{"*"},
+		publisherTok: writePublisherTokenFile(t),
+		insecure:     true,
+	}
+	_, err := resolveAutoHash(t.Context(), opts)
+	if err == nil {
+		t.Fatal("resolveAutoHash with server error: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error = %v, want 500 mention", err)
+	}
+}
+
+func TestResolveAutoHash_SelectsMatchingEnvironmentAndAudience(t *testing.T) {
+	wrongHash := "1111111111111111111111111111111111111111111111111111111111111111"
+	rightHash := "2222222222222222222222222222222222222222222222222222222222222222"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"streams":[` +
+			`{"environment":"prod","audience":{"labels":{"ring":"canary"}},"head_bundle_hash":"` + wrongHash + `"},` +
+			`{"environment":"prod","audience":{"instance_ids":["pl-prod-2","pl-prod-1"]},"head_bundle_hash":"` + rightHash + `"}` +
+			`],"stream_count":2}`))
+	}))
+	defer srv.Close()
+
+	opts := publishOptions{
+		conductorURL: srv.URL,
+		orgID:        "org-main",
+		fleetID:      "prod",
+		environment:  "prod",
+		audience:     []string{"pl-prod-1", "pl-prod-2"},
+		publisherTok: writePublisherTokenFile(t),
+		insecure:     true,
+	}
+	hash, err := resolveAutoHash(t.Context(), opts)
+	if err != nil {
+		t.Fatalf("resolveAutoHash: %v", err)
+	}
+	if hash != rightHash {
+		t.Fatalf("hash = %q, want matching stream hash %q", hash, rightHash)
+	}
+}
+
+func TestResolveAutoHash_NoMatchingStream(t *testing.T) {
+	const existingHash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"streams":[{"environment":"staging","audience":{"instance_ids":["*"]},"head_bundle_hash":"` + existingHash + `"}],"stream_count":1}`))
+	}))
+	defer srv.Close()
+
+	opts := publishOptions{
+		conductorURL: srv.URL,
+		orgID:        "org-main",
+		fleetID:      "prod",
+		environment:  "prod",
+		audience:     []string{"*"},
+		publisherTok: writePublisherTokenFile(t),
+		insecure:     true,
+	}
+	hash, err := resolveAutoHash(t.Context(), opts)
+	if err != nil {
+		t.Fatalf("resolveAutoHash: %v", err)
+	}
+	if hash != "" {
+		t.Fatalf("hash = %q, want empty for first matching stream", hash)
+	}
+}
+
+func TestPreviousHashAutoSentinelIgnoresCase(t *testing.T) {
+	for _, val := range []string{"auto", "AUTO", "Auto", "  auto  "} {
+		if !strings.EqualFold(strings.TrimSpace(val), previousHashAuto) {
+			t.Fatalf("%q did not match sentinel %q", val, previousHashAuto)
+		}
+	}
+}
+
+func writePublisherTokenFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "publisher-token")
+	if err := os.WriteFile(path, []byte("test-token\n"), 0o600); err != nil {
+		t.Fatalf("write publisher token: %v", err)
+	}
+	return path
+}

--- a/enterprise/cli/conductor/recovery_errorpaths_test.go
+++ b/enterprise/cli/conductor/recovery_errorpaths_test.go
@@ -1,0 +1,225 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	conductorcore "github.com/luckyPipewrench/pipelock/enterprise/conductor"
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+// errorStatusHandler returns the given HTTP status for every request, so the
+// recovery run* funcs exercise their getStreamStatus / delete error branches.
+func errorStatusHandler(status int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", status)
+	})
+}
+
+// invalidJSONHandler returns a 200 with a non-JSON body for GET, so the run*
+// funcs that strictly decode the stream-status response hit their decode-error
+// branch.
+func invalidJSONHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not valid json"))
+	})
+}
+
+func TestRunStoreDump_Errors(t *testing.T) {
+	t.Run("missing org id", func(t *testing.T) {
+		cmd, _ := newRecoveryCmd(t)
+		err := runStoreDump(cmd, storeDumpOptions{orgID: ""})
+		if err == nil || !strings.Contains(err.Error(), "--org-id is required") {
+			t.Fatalf("err=%v, want --org-id required", err)
+		}
+	})
+	t.Run("client build failure", func(t *testing.T) {
+		cmd, _ := newRecoveryCmd(t)
+		// Empty clientOptions: newConductorClient fails on the required --server.
+		err := runStoreDump(cmd, storeDumpOptions{client: clientOptions{}, orgID: "org-main"})
+		if err == nil || !strings.Contains(err.Error(), "--server is required") {
+			t.Fatalf("err=%v, want --server required", err)
+		}
+	})
+	t.Run("stream status http error", func(t *testing.T) {
+		client := newTestClientServer(t, "tok", errorStatusHandler(http.StatusInternalServerError))
+		cmd, _ := newRecoveryCmd(t)
+		err := runStoreDump(cmd, storeDumpOptions{client: client, orgID: "org-main"})
+		if err == nil {
+			t.Fatal("err=nil, want stream-status error")
+		}
+	})
+}
+
+func TestRunKillStatus_Errors(t *testing.T) {
+	t.Run("client build failure", func(t *testing.T) {
+		cmd, _ := newRecoveryCmd(t)
+		err := runKillStatus(cmd, killStatusOptions{client: clientOptions{}, orgID: "org-main"})
+		if err == nil || !strings.Contains(err.Error(), "--server is required") {
+			t.Fatalf("err=%v, want --server required", err)
+		}
+	})
+	t.Run("stream status http error", func(t *testing.T) {
+		client := newTestClientServer(t, "tok", errorStatusHandler(http.StatusBadGateway))
+		cmd, _ := newRecoveryCmd(t)
+		err := runKillStatus(cmd, killStatusOptions{client: client, orgID: "org-main"})
+		if err == nil {
+			t.Fatal("err=nil, want stream-status error")
+		}
+	})
+	t.Run("undecodable response", func(t *testing.T) {
+		client := newTestClientServer(t, "tok", invalidJSONHandler())
+		cmd, _ := newRecoveryCmd(t)
+		err := runKillStatus(cmd, killStatusOptions{client: client, orgID: "org-main"})
+		if err == nil || !strings.Contains(err.Error(), "decode stream status") {
+			t.Fatalf("err=%v, want decode error", err)
+		}
+	})
+}
+
+func TestRunStreamReset_Errors(t *testing.T) {
+	t.Run("client build failure", func(t *testing.T) {
+		cmd, _ := newRecoveryCmd(t)
+		err := runStreamReset(cmd, streamResetOptions{client: clientOptions{}, orgID: "org-main", confirm: true})
+		if err == nil || !strings.Contains(err.Error(), "--server is required") {
+			t.Fatalf("err=%v, want --server required", err)
+		}
+	})
+	t.Run("stream status http error", func(t *testing.T) {
+		client := newTestClientServer(t, "tok", errorStatusHandler(http.StatusInternalServerError))
+		cmd, _ := newRecoveryCmd(t)
+		err := runStreamReset(cmd, streamResetOptions{client: client, orgID: "org-main", confirm: true})
+		if err == nil {
+			t.Fatal("err=nil, want stream-status error")
+		}
+	})
+	t.Run("undecodable response", func(t *testing.T) {
+		client := newTestClientServer(t, "tok", invalidJSONHandler())
+		cmd, _ := newRecoveryCmd(t)
+		err := runStreamReset(cmd, streamResetOptions{client: client, orgID: "org-main", confirm: true})
+		if err == nil || !strings.Contains(err.Error(), "decode stream status") {
+			t.Fatalf("err=%v, want decode error", err)
+		}
+	})
+	t.Run("no active rollbacks is a clean no-op", func(t *testing.T) {
+		resp := streamStatusResponse{OrgID: "org-main", FleetID: "prod", EmergencyControlsRead: true}
+		client := newTestClientServer(t, "tok", streamStatusHandler(t, resp))
+		cmd, buf := newRecoveryCmd(t)
+		if err := runStreamReset(cmd, streamResetOptions{client: client, orgID: "org-main", confirm: true}); err != nil {
+			t.Fatalf("runStreamReset(no active): %v", err)
+		}
+		if !strings.Contains(buf.String(), "no active rollback authorizations to clear") {
+			t.Fatalf("output=%q, want no-active message", buf.String())
+		}
+	})
+	t.Run("delete failure warns and continues", func(t *testing.T) {
+		// GET returns one active rollback; DELETE fails. The reset must warn,
+		// keep going, and report 0 of 1 cleared rather than aborting.
+		resp := streamStatusResponse{
+			OrgID: "org-main", FleetID: "prod", EmergencyControlsRead: true,
+			ActiveRollbacks: []controlplane.ActiveRollbackAuthorization{{AuthorizationID: "auth-stuck", TargetVersion: 7}},
+		}
+		body, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				http.Error(w, "delete boom", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		})
+		client := newTestClientServer(t, "tok", handler)
+		cmd, buf := newRecoveryCmd(t)
+		if err := runStreamReset(cmd, streamResetOptions{client: client, orgID: "org-main", confirm: true}); err != nil {
+			t.Fatalf("runStreamReset(delete fail): %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "warning: failed to clear auth-stuck") {
+			t.Fatalf("output=%q, want delete warning", out)
+		}
+		if !strings.Contains(out, "cleared 0 of 1") {
+			t.Fatalf("output=%q, want cleared 0 of 1", out)
+		}
+	})
+}
+
+func TestAudiencesEquivalent(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b conductorcore.Audience
+		want bool
+	}{
+		{"both empty", conductorcore.Audience{}, conductorcore.Audience{}, true},
+		{
+			"equal ids and labels",
+			conductorcore.Audience{InstanceIDs: []string{"a", "b"}, Labels: map[string]string{"ring": "canary"}},
+			conductorcore.Audience{InstanceIDs: []string{"b", "a"}, Labels: map[string]string{"ring": "canary"}},
+			true,
+		},
+		{
+			"different instance ids",
+			conductorcore.Audience{InstanceIDs: []string{"a"}},
+			conductorcore.Audience{InstanceIDs: []string{"b"}},
+			false,
+		},
+		{
+			"different label count",
+			conductorcore.Audience{Labels: map[string]string{"ring": "canary"}},
+			conductorcore.Audience{Labels: map[string]string{"ring": "canary", "tier": "1"}},
+			false,
+		},
+		{
+			"different label value",
+			conductorcore.Audience{Labels: map[string]string{"ring": "canary"}},
+			conductorcore.Audience{Labels: map[string]string{"ring": "stable"}},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := audiencesEquivalent(tt.a, tt.b); got != tt.want {
+				t.Fatalf("audiencesEquivalent(%+v, %+v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+// The RunE wrappers fail closed without a fleet license. These cover the
+// license-verification guard on the recovery subcommands (mirrors the rollback
+// clear guard test).
+func TestRecoveryCommands_NoFleetLicenseFailClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"store dump", []string{"store", "dump", "--org-id", "org-main"}},
+		{"kill status", []string{"kill", "status", "--org-id", "org-main"}},
+		{"stream reset", []string{"stream", "reset", "--org-id", "org-main", "--confirm"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(license.EnvLicenseKey, "")
+			t.Setenv(license.EnvLicensePublicKey, "")
+			t.Setenv(license.EnvLicenseCRLFile, "")
+			cmd := Cmd()
+			cmd.SetArgs(tc.args)
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			if err := cmd.Execute(); err == nil || !errors.Is(err, license.ErrFleetLicenseRequired) {
+				t.Fatalf("%s without license err=%v, want ErrFleetLicenseRequired", tc.name, err)
+			}
+		})
+	}
+}

--- a/enterprise/cli/conductor/recovery_success_test.go
+++ b/enterprise/cli/conductor/recovery_success_test.go
@@ -1,0 +1,145 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+)
+
+// streamStatusHandler serves the given stream-status response for GET and a
+// 200 for DELETE (rollback-authorization clear), so the recovery run* funcs can
+// be exercised against a real client + TLS server.
+func streamStatusHandler(t *testing.T, resp streamStatusResponse) http.Handler {
+	t.Helper()
+	body, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal stream status: %v", err)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write(body)
+		case http.MethodDelete:
+			_, _ = w.Write([]byte(`{"cleared":true}`))
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func newRecoveryCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetContext(t.Context())
+	return cmd, &buf
+}
+
+func TestRunStoreDump_Success(t *testing.T) {
+	resp := streamStatusResponse{OrgID: "org-main", FleetID: "prod", EmergencyControlsRead: true, StreamCount: 0}
+	client := newTestClientServer(t, "tok", streamStatusHandler(t, resp))
+	cmd, buf := newRecoveryCmd(t)
+
+	if err := runStoreDump(cmd, storeDumpOptions{client: client, orgID: "org-main", fleetID: "prod"}); err != nil {
+		t.Fatalf("runStoreDump: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"org_id": "org-main"`) {
+		t.Fatalf("store dump output missing pretty JSON: %s", buf.String())
+	}
+}
+
+func TestRunKillStatus_Success(t *testing.T) {
+	resp := streamStatusResponse{
+		OrgID:                 "org-main",
+		FleetID:               "prod",
+		EmergencyControlsRead: true,
+		ActiveRemoteKills: []controlplane.ActiveRemoteKill{
+			{MessageID: "kill-1", FleetID: "prod", State: "active", Counter: 1, Reason: "incident"},
+		},
+	}
+	client := newTestClientServer(t, "tok", streamStatusHandler(t, resp))
+	cmd, buf := newRecoveryCmd(t)
+
+	if err := runKillStatus(cmd, killStatusOptions{client: client, orgID: "org-main", fleetID: "prod"}); err != nil {
+		t.Fatalf("runKillStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "kill-1") || !strings.Contains(out, "1 active remote kill") {
+		t.Fatalf("kill status output unexpected: %s", out)
+	}
+}
+
+func TestRunStreamReset_ClearsActiveRollbacks(t *testing.T) {
+	resp := streamStatusResponse{
+		OrgID:                 "org-main",
+		FleetID:               "prod",
+		EmergencyControlsRead: true,
+		ActiveRollbacks: []controlplane.ActiveRollbackAuthorization{
+			{AuthorizationID: "auth-1", TargetVersion: 4},
+		},
+	}
+	client := newTestClientServer(t, "tok", streamStatusHandler(t, resp))
+	cmd, buf := newRecoveryCmd(t)
+
+	if err := runStreamReset(cmd, streamResetOptions{client: client, orgID: "org-main", fleetID: "prod", confirm: true}); err != nil {
+		t.Fatalf("runStreamReset: %v", err)
+	}
+	if !strings.Contains(buf.String(), "cleared 1 of 1") {
+		t.Fatalf("stream reset output unexpected: %s", buf.String())
+	}
+}
+
+func TestRunKillStatus_JSONMode(t *testing.T) {
+	resp := streamStatusResponse{OrgID: "org-main", FleetID: "prod", EmergencyControlsRead: true}
+	client := newTestClientServer(t, "tok", streamStatusHandler(t, resp))
+	cmd, buf := newRecoveryCmd(t)
+
+	if err := runKillStatus(cmd, killStatusOptions{client: client, orgID: "org-main", fleetID: "prod", jsonOut: true}); err != nil {
+		t.Fatalf("runKillStatus --json: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"org_id":"org-main"`) {
+		t.Fatalf("json mode should emit raw JSON, got: %s", buf.String())
+	}
+}
+
+func TestRunStoreDump_NonJSONFallback(t *testing.T) {
+	client := newTestClientServer(t, "tok", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not-json-body"))
+	}))
+	cmd, buf := newRecoveryCmd(t)
+
+	if err := runStoreDump(cmd, storeDumpOptions{client: client, orgID: "org-main", fleetID: "prod"}); err != nil {
+		t.Fatalf("runStoreDump non-JSON: %v", err)
+	}
+	if !strings.Contains(buf.String(), "not-json-body") {
+		t.Fatalf("non-JSON fallback should print raw body, got: %s", buf.String())
+	}
+}
+
+// TestRunStreamReset_FailsClosedOnUnreadableControls confirms the destructive
+// reset aborts (does not report "nothing to clear") when the control plane
+// cannot confirm active rollback state.
+func TestRunStreamReset_FailsClosedOnUnreadableControls(t *testing.T) {
+	resp := streamStatusResponse{OrgID: "org-main", FleetID: "prod", EmergencyControlsRead: false}
+	client := newTestClientServer(t, "tok", streamStatusHandler(t, resp))
+	cmd, _ := newRecoveryCmd(t)
+
+	err := runStreamReset(cmd, streamResetOptions{client: client, orgID: "org-main", fleetID: "prod", confirm: true})
+	if err == nil || !strings.Contains(err.Error(), "emergency controls") {
+		t.Fatalf("expected fail-closed error on unreadable controls, got %v", err)
+	}
+}

--- a/enterprise/cli/conductor/recovery_test_helpers.go
+++ b/enterprise/cli/conductor/recovery_test_helpers.go
@@ -1,0 +1,29 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// encodeJSON marshals v to JSON bytes.
+func encodeJSON(v any) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// newTestDeleteRequest builds an authenticated DELETE request with a JSON body.
+func newTestDeleteRequest(ctx context.Context, url string, body []byte, token string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req, nil
+}

--- a/enterprise/cli/conductor/rollback_clear.go
+++ b/enterprise/cli/conductor/rollback_clear.go
@@ -66,14 +66,6 @@ func runRollbackClear(cmd *cobra.Command, opts rollbackClearOptions) error {
 	return nil
 }
 
-func init() {
-	// Attach rollback clear as a subcommand of rollback. The rollback command
-	// itself is assembled in rollback.go; this init registers the clear
-	// subcommand after the cobra tree is built. We do this via a helper that
-	// rollbackCmd will call, not init, to avoid import-order issues. See the
-	// registration in cmd.go.
-}
-
 // deleteRollbackAuthorization sends a DELETE to the Conductor's
 // rollback-authorizations endpoint with the authorization_id in the JSON body.
 func (c *conductorClient) deleteRollbackAuthorization(ctx context.Context, authorizationID string) ([]byte, error) {

--- a/enterprise/cli/conductor/rollback_clear.go
+++ b/enterprise/cli/conductor/rollback_clear.go
@@ -1,0 +1,83 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+type rollbackClearOptions struct {
+	client          clientOptions
+	authorizationID string
+	confirm         bool
+}
+
+func rollbackClearCmd() *cobra.Command {
+	opts := rollbackClearOptions{}
+	cmd := &cobra.Command{
+		Use:   "clear",
+		Short: "Clear an active Conductor rollback authorization",
+		Long: `clear removes an active rollback authorization from the Conductor by its
+authorization_id. This is an admin-only operation that lets the operator
+unblock forward publishes without waiting for the rollback TTL to expire.
+
+The --confirm flag is required as a safety guard; the command refuses to run
+without it.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleet("", "", opts.client.licenseCRLFile); err != nil {
+				return err
+			}
+			return runRollbackClear(cmd, opts)
+		},
+	}
+	opts.client.bindFlags(cmd)
+	cmd.Flags().StringVar(&opts.authorizationID, "authorization-id", "", "authorization_id of the rollback authorization to clear (required)")
+	cmd.Flags().BoolVar(&opts.confirm, "confirm", false, "explicit confirmation that you intend to clear the rollback authorization (required)")
+	return cmd
+}
+
+func runRollbackClear(cmd *cobra.Command, opts rollbackClearOptions) error {
+	if !opts.confirm {
+		return fmt.Errorf("--confirm is required: clearing a rollback authorization is a control-plane state mutation; pass --confirm to proceed")
+	}
+	authID := strings.TrimSpace(opts.authorizationID)
+	if authID == "" {
+		return fmt.Errorf("--authorization-id is required")
+	}
+	client, err := newConductorClient(opts.client)
+	if err != nil {
+		return err
+	}
+	body, err := client.deleteRollbackAuthorization(cmd.Context(), authID)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
+	return nil
+}
+
+func init() {
+	// Attach rollback clear as a subcommand of rollback. The rollback command
+	// itself is assembled in rollback.go; this init registers the clear
+	// subcommand after the cobra tree is built. We do this via a helper that
+	// rollbackCmd will call, not init, to avoid import-order issues. See the
+	// registration in cmd.go.
+}
+
+// deleteRollbackAuthorization sends a DELETE to the Conductor's
+// rollback-authorizations endpoint with the authorization_id in the JSON body.
+func (c *conductorClient) deleteRollbackAuthorization(ctx context.Context, authorizationID string) ([]byte, error) {
+	return c.deleteJSON(ctx, controlplane.RollbackAuthorizationsPath, map[string]string{
+		"authorization_id": authorizationID,
+	})
+}

--- a/enterprise/cli/conductor/rollback_clear_run_test.go
+++ b/enterprise/cli/conductor/rollback_clear_run_test.go
@@ -1,0 +1,47 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestRunRollbackClear_RunPaths covers runRollbackClear's own client round trip:
+// the success path (build client -> DELETE -> print body), the client-build
+// failure, and a non-200 DELETE response. The existing happy-path test clears
+// via the test-server helper, so these are what exercise runRollbackClear end
+// to end.
+func TestRunRollbackClear_RunPaths(t *testing.T) {
+	t.Run("success prints cleared body", func(t *testing.T) {
+		client := newTestClientServer(t, "tok", streamStatusHandler(t, streamStatusResponse{}))
+		cmd, buf := newRecoveryCmd(t)
+		err := runRollbackClear(cmd, rollbackClearOptions{client: client, authorizationID: "auth-x", confirm: true})
+		if err != nil {
+			t.Fatalf("runRollbackClear: %v", err)
+		}
+		if !strings.Contains(buf.String(), `"cleared":true`) {
+			t.Fatalf("output=%q, want cleared:true", buf.String())
+		}
+	})
+
+	t.Run("client build failure", func(t *testing.T) {
+		cmd, _ := newRecoveryCmd(t)
+		err := runRollbackClear(cmd, rollbackClearOptions{client: clientOptions{}, authorizationID: "auth-x", confirm: true})
+		if err == nil || !strings.Contains(err.Error(), "--server is required") {
+			t.Fatalf("err=%v, want --server required", err)
+		}
+	})
+
+	t.Run("delete http error surfaces", func(t *testing.T) {
+		client := newTestClientServer(t, "tok", errorStatusHandler(http.StatusNotFound))
+		cmd, _ := newRecoveryCmd(t)
+		err := runRollbackClear(cmd, rollbackClearOptions{client: client, authorizationID: "auth-x", confirm: true})
+		if err == nil {
+			t.Fatal("err=nil, want DELETE error")
+		}
+	})
+}

--- a/enterprise/cli/conductor/rollback_clear_test.go
+++ b/enterprise/cli/conductor/rollback_clear_test.go
@@ -1,0 +1,125 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+func TestRunRollbackClear_HappyPath(t *testing.T) {
+	// Set up a test server with a real rollback authorization published.
+	opts := newRollbackRig(t, 0)
+	cmd, _ := rollbackCobra(t)
+	if err := runRollback(cmd, opts); err != nil {
+		t.Fatalf("initial rollback: %v", err)
+	}
+
+	// Clear the rollback authorization via the test server's DELETE endpoint.
+	srv := opts.transport.(*testServer)
+	delBody, err := deleteRollbackViaTestServer(t, srv, "rollback-42-to-41-100")
+	if err != nil {
+		t.Fatalf("clear rollback: %v", err)
+	}
+	if !strings.Contains(string(delBody), `"cleared":true`) {
+		t.Fatalf("clear response missing cleared=true: %s", string(delBody))
+	}
+}
+
+func TestRunRollbackClear_NotFoundReturns404(t *testing.T) {
+	opts := newRollbackRig(t, 0)
+	srv := opts.transport.(*testServer)
+	_, err := deleteRollbackViaTestServer(t, srv, "nonexistent-id")
+	if err == nil {
+		t.Fatal("clear nonexistent = nil error, want 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Fatalf("error = %v, want status 404", err)
+	}
+}
+
+func TestRunRollbackClear_MissingConfirmRejected(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := runRollbackClear(cmd, rollbackClearOptions{
+		authorizationID: "some-id",
+		confirm:         false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--confirm is required") {
+		t.Fatalf("missing confirm error = %v, want --confirm required", err)
+	}
+}
+
+func TestRunRollbackClear_MissingAuthorizationIDRejected(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := runRollbackClear(cmd, rollbackClearOptions{
+		authorizationID: "",
+		confirm:         true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--authorization-id is required") {
+		t.Fatalf("missing authorization-id error = %v, want required", err)
+	}
+}
+
+func TestRollbackClearCmd_NoFleetLicenseFailsClosed(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	t.Setenv(license.EnvLicensePublicKey, "")
+	t.Setenv(license.EnvLicenseCRLFile, "")
+	cmd := Cmd()
+	cmd.SetArgs([]string{
+		"rollback", "clear", "--authorization-id", "some-id", "--confirm",
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !errors.Is(err, license.ErrFleetLicenseRequired) {
+		t.Fatalf("rollback clear without license error = %v, want ErrFleetLicenseRequired", err)
+	}
+}
+
+// deleteRollbackViaTestServer sends a DELETE to the test server's rollback
+// authorizations endpoint and returns the response body.
+func deleteRollbackViaTestServer(t *testing.T, srv *testServer, authorizationID string) ([]byte, error) {
+	t.Helper()
+	return deleteJSONViaTestServer(t, srv, controlplane.RollbackAuthorizationsPath, map[string]string{
+		"authorization_id": authorizationID,
+	})
+}
+
+func deleteJSONViaTestServer(t *testing.T, srv *testServer, path string, body any) ([]byte, error) {
+	t.Helper()
+	payload, err := encodeJSON(body)
+	if err != nil {
+		t.Fatalf("marshal delete body: %v", err)
+	}
+	ctx := context.Background()
+	req, err := newTestDeleteRequest(ctx, srv.url+path, payload, testAdminToken)
+	if err != nil {
+		t.Fatalf("build delete request: %v", err)
+	}
+	resp, err := srv.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("conductor returned status " + resp.Status)
+	}
+	return buf.Bytes(), nil
+}

--- a/enterprise/cli/conductor/store_dump.go
+++ b/enterprise/cli/conductor/store_dump.go
@@ -1,0 +1,81 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+type storeDumpOptions struct {
+	client  clientOptions
+	orgID   string
+	fleetID string
+}
+
+func storeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "store",
+		Short: "Inspect Conductor control-plane store state",
+	}
+	cmd.AddCommand(storeDumpCmd())
+	return cmd
+}
+
+func storeDumpCmd() *cobra.Command {
+	opts := storeDumpOptions{}
+	cmd := &cobra.Command{
+		Use:   "dump",
+		Short: "Dump the Conductor stream overview as JSON for support and debugging",
+		Long: `dump performs a read-only query of the Conductor's stream-status and
+stream-inspect endpoints and prints the combined JSON. This is a convenience
+for operators gathering support artifacts. No state is modified.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleet("", "", opts.client.licenseCRLFile); err != nil {
+				return err
+			}
+			return runStoreDump(cmd, opts)
+		},
+	}
+	opts.client.bindFlags(cmd)
+	cmd.Flags().StringVar(&opts.orgID, "org-id", "", "org id to query (required)")
+	cmd.Flags().StringVar(&opts.fleetID, "fleet-id", "", "fleet id to scope the query")
+	return cmd
+}
+
+func runStoreDump(cmd *cobra.Command, opts storeDumpOptions) error {
+	if strings.TrimSpace(opts.orgID) == "" {
+		return errors.New("--org-id is required")
+	}
+	client, err := newConductorClient(opts.client)
+	if err != nil {
+		return err
+	}
+	body, err := client.getStreamStatus(cmd.Context(), opts.orgID, opts.fleetID)
+	if err != nil {
+		return err
+	}
+	// Pretty-print the raw JSON.
+	var parsed json.RawMessage
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		// If it's not valid JSON for some reason, print raw.
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
+		return nil
+	}
+	pretty, err := json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
+		return nil
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(pretty))
+	return nil
+}

--- a/enterprise/cli/conductor/store_dump.go
+++ b/enterprise/cli/conductor/store_dump.go
@@ -35,9 +35,9 @@ func storeDumpCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dump",
 		Short: "Dump the Conductor stream overview as JSON for support and debugging",
-		Long: `dump performs a read-only query of the Conductor's stream-status and
-stream-inspect endpoints and prints the combined JSON. This is a convenience
-for operators gathering support artifacts. No state is modified.`,
+		Long: `dump performs a read-only query of the Conductor stream-status
+endpoint and prints its JSON response. This is a convenience for operators
+gathering support artifacts. No state is modified.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if _, err := license.VerifyFleet("", "", opts.client.licenseCRLFile); err != nil {

--- a/enterprise/cli/conductor/stream_reset.go
+++ b/enterprise/cli/conductor/stream_reset.go
@@ -1,0 +1,104 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+type streamResetOptions struct {
+	client  clientOptions
+	orgID   string
+	fleetID string
+	confirm bool
+}
+
+func streamResetCmd() *cobra.Command {
+	opts := streamResetOptions{}
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Clear all active rollback authorizations from the Conductor emergency store",
+		Long: `reset removes all currently active (non-expired) rollback authorizations for
+the given org/fleet scope from the Conductor's emergency store. This is a
+destructive admin-only operation: it unblocks forward publishes by removing ALL
+active rollback state rather than clearing individual authorizations.
+
+The --confirm flag is required as a safety guard; the command refuses to run
+without it. Prefer 'conductor rollback clear --authorization-id <id>' to remove
+a single rollback authorization.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleet("", "", opts.client.licenseCRLFile); err != nil {
+				return err
+			}
+			return runStreamReset(cmd, opts)
+		},
+	}
+	opts.client.bindFlags(cmd)
+	cmd.Flags().StringVar(&opts.orgID, "org-id", "", "org id to scope the reset (required)")
+	cmd.Flags().StringVar(&opts.fleetID, "fleet-id", "", "fleet id to scope the reset")
+	cmd.Flags().BoolVar(&opts.confirm, "confirm", false, "explicit confirmation that you intend to clear all active rollback authorizations (required)")
+	return cmd
+}
+
+func runStreamReset(cmd *cobra.Command, opts streamResetOptions) error {
+	if !opts.confirm {
+		return fmt.Errorf("--confirm is required: stream reset clears all active rollback authorizations; pass --confirm to proceed")
+	}
+	if strings.TrimSpace(opts.orgID) == "" {
+		return errors.New("--org-id is required")
+	}
+	// Fetch the stream status to discover active rollback authorizations.
+	client, err := newConductorClient(opts.client)
+	if err != nil {
+		return err
+	}
+	body, err := client.getStreamStatus(cmd.Context(), opts.orgID, opts.fleetID)
+	if err != nil {
+		return err
+	}
+	var status streamStatusResponse
+	if err := json.Unmarshal(body, &status); err != nil {
+		return fmt.Errorf("decode stream status: %w", err)
+	}
+	activeRollbacks, err := rollbackAuthorizationsForReset(status)
+	if err != nil {
+		return err
+	}
+	if len(activeRollbacks) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no active rollback authorizations to clear")
+		return nil
+	}
+	// Clear each active rollback authorization individually via the DELETE endpoint.
+	cleared := 0
+	for _, rb := range activeRollbacks {
+		_, err := client.deleteRollbackAuthorization(cmd.Context(), rb.AuthorizationID)
+		if err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to clear %s: %v\n", rb.AuthorizationID, err)
+			continue
+		}
+		cleared++
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "cleared rollback authorization %s (target_version=%d)\n",
+			rb.AuthorizationID, rb.TargetVersion)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "cleared %d of %d active rollback authorization(s)\n",
+		cleared, len(activeRollbacks))
+	return nil
+}
+
+func rollbackAuthorizationsForReset(status streamStatusResponse) ([]controlplane.ActiveRollbackAuthorization, error) {
+	if !status.EmergencyControlsRead {
+		return nil, errors.New("stream reset cannot confirm active rollback state: emergency controls were not readable")
+	}
+	return status.ActiveRollbacks, nil
+}

--- a/enterprise/cli/conductor/stream_reset.go
+++ b/enterprise/cli/conductor/stream_reset.go
@@ -55,7 +55,8 @@ func runStreamReset(cmd *cobra.Command, opts streamResetOptions) error {
 	if !opts.confirm {
 		return fmt.Errorf("--confirm is required: stream reset clears all active rollback authorizations; pass --confirm to proceed")
 	}
-	if strings.TrimSpace(opts.orgID) == "" {
+	orgID := strings.TrimSpace(opts.orgID)
+	if orgID == "" {
 		return errors.New("--org-id is required")
 	}
 	// Fetch the stream status to discover active rollback authorizations.
@@ -63,7 +64,7 @@ func runStreamReset(cmd *cobra.Command, opts streamResetOptions) error {
 	if err != nil {
 		return err
 	}
-	body, err := client.getStreamStatus(cmd.Context(), opts.orgID, opts.fleetID)
+	body, err := client.getStreamStatus(cmd.Context(), orgID, opts.fleetID)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cli/conductor/stream_reset_test.go
+++ b/enterprise/cli/conductor/stream_reset_test.go
@@ -1,0 +1,80 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+func TestRunStreamReset_MissingConfirmRejected(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := runStreamReset(cmd, streamResetOptions{
+		orgID:   "test-org",
+		confirm: false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--confirm is required") {
+		t.Fatalf("missing confirm error = %v, want --confirm required", err)
+	}
+}
+
+func TestRunStreamReset_MissingOrgIDRejected(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := runStreamReset(cmd, streamResetOptions{
+		orgID:   "",
+		confirm: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--org-id is required") {
+		t.Fatalf("missing org-id error = %v, want --org-id required", err)
+	}
+}
+
+func TestStreamResetCmd_NoFleetLicenseFailsClosed(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	t.Setenv(license.EnvLicensePublicKey, "")
+	t.Setenv(license.EnvLicenseCRLFile, "")
+	cmd := Cmd()
+	cmd.SetArgs([]string{"stream", "reset", "--org-id", "test-org", "--confirm"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !errors.Is(err, license.ErrFleetLicenseRequired) {
+		t.Fatalf("stream reset without license error = %v, want ErrFleetLicenseRequired", err)
+	}
+}
+
+func TestRollbackAuthorizationsForReset_EmergencyControlsUnreadable(t *testing.T) {
+	_, err := rollbackAuthorizationsForReset(streamStatusResponse{
+		EmergencyControlsRead: false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "emergency controls were not readable") {
+		t.Fatalf("error = %v, want unreadable emergency controls refusal", err)
+	}
+}
+
+func TestRollbackAuthorizationsForReset_ReturnsActiveRollbacks(t *testing.T) {
+	want := []controlplane.ActiveRollbackAuthorization{{AuthorizationID: "rollback-1"}}
+	got, err := rollbackAuthorizationsForReset(streamStatusResponse{
+		EmergencyControlsRead: true,
+		ActiveRollbacks:       want,
+	})
+	if err != nil {
+		t.Fatalf("rollbackAuthorizationsForReset: %v", err)
+	}
+	if len(got) != 1 || got[0].AuthorizationID != "rollback-1" {
+		t.Fatalf("got = %+v, want rollback-1", got)
+	}
+}

--- a/enterprise/cli/conductor/stream_status.go
+++ b/enterprise/cli/conductor/stream_status.go
@@ -51,6 +51,7 @@ func streamCmd() *cobra.Command {
 	}
 	cmd.AddCommand(streamStatusCmd())
 	cmd.AddCommand(streamInspectCmd())
+	cmd.AddCommand(streamResetCmd())
 	return cmd
 }
 

--- a/enterprise/conductor/controlplane/emergency_store.go
+++ b/enterprise/conductor/controlplane/emergency_store.go
@@ -477,6 +477,56 @@ func newerRollback(candidate, current StoredRollbackAuthorization) bool {
 	return candidate.AuthorizationHash > current.AuthorizationHash
 }
 
+// ClearRollbackAuthorization removes a rollback authorization by its
+// authorization_id. It is an admin-only state mutation: the operator uses it to
+// clear an active rollback authorization that is no longer needed (e.g. after a
+// forward publish succeeds) without waiting for the TTL to expire. Returns
+// true when a record was found and removed.
+func (s *FileEmergencyStore) ClearRollbackAuthorization(_ context.Context, authorizationID string) (bool, error) {
+	if s == nil {
+		return false, ErrEmergencyStoreRequired
+	}
+	if strings.TrimSpace(authorizationID) == "" {
+		return false, fmt.Errorf("%w: authorization_id required", conductor.ErrMissingField)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	hash, ok := s.rollbackAuthIDMap[authorizationID]
+	if !ok {
+		return false, nil
+	}
+	// Capture what we are about to remove so we can restore the in-memory
+	// state verbatim if the durable write fails (mirrors the rollback in
+	// PublishRollbackAuthorization). Diverging memory from disk on a failed
+	// write would let a cleared-in-memory-only authorization stop capping the
+	// stream head while disk still has it.
+	removed, hadRecord := s.rollbackHashes[hash]
+	originalRollbacks := s.rollbacks
+	// Remove from the ID→hash map and the hash→record map.
+	delete(s.rollbackAuthIDMap, authorizationID)
+	delete(s.rollbackHashes, hash)
+	// Remove from the ordered slice (new backing array; originalRollbacks
+	// still references the pre-clear contents for restore-on-error).
+	filtered := make([]StoredRollbackAuthorization, 0, len(s.rollbacks))
+	for _, record := range s.rollbacks {
+		if record.Authorization.AuthorizationID != authorizationID {
+			filtered = append(filtered, record)
+		}
+	}
+	s.rollbacks = filtered
+	if err := s.writeLocked(); err != nil {
+		// Restore the exact pre-clear in-memory state: disk is the source of
+		// truth and the write did not land.
+		s.rollbackAuthIDMap[authorizationID] = hash
+		if hadRecord {
+			s.rollbackHashes[hash] = removed
+		}
+		s.rollbacks = originalRollbacks
+		return false, fmt.Errorf("conductor emergency store write after clear: %w", err)
+	}
+	return true, nil
+}
+
 func (s *FileEmergencyStore) maxRemoteKillCounterForOrgFleetLocked(orgID, fleetID string) (uint64, bool) {
 	var maxCounter uint64
 	found := false

--- a/enterprise/conductor/controlplane/emergency_store_clear_test.go
+++ b/enterprise/conductor/controlplane/emergency_store_clear_test.go
@@ -1,0 +1,295 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package controlplane
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestClearRollbackAuthorization_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenFileEmergencyStore(dir)
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore: %v", err)
+	}
+
+	now := time.Now().UTC()
+	auth := signedTestRollback(t, "clear-test-1", now, 100)
+
+	_, created, err := store.PublishRollbackAuthorization(context.Background(), auth, now)
+	if err != nil {
+		t.Fatalf("PublishRollbackAuthorization: %v", err)
+	}
+	if !created {
+		t.Fatal("expected created=true for first publish")
+	}
+
+	// Verify it's listed.
+	all, err := store.RollbackAuthorizations(context.Background())
+	if err != nil {
+		t.Fatalf("RollbackAuthorizations: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 rollback, got %d", len(all))
+	}
+
+	// Clear it.
+	cleared, err := store.ClearRollbackAuthorization(context.Background(), "clear-test-1")
+	if err != nil {
+		t.Fatalf("ClearRollbackAuthorization: %v", err)
+	}
+	if !cleared {
+		t.Fatal("expected cleared=true")
+	}
+
+	// Verify it's gone.
+	all, err = store.RollbackAuthorizations(context.Background())
+	if err != nil {
+		t.Fatalf("RollbackAuthorizations after clear: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("expected 0 rollbacks after clear, got %d", len(all))
+	}
+
+	// Verify persistence: reopen the store and confirm empty.
+	store2, err := OpenFileEmergencyStore(dir)
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore (reopen): %v", err)
+	}
+	all2, err := store2.RollbackAuthorizations(context.Background())
+	if err != nil {
+		t.Fatalf("RollbackAuthorizations (reopened): %v", err)
+	}
+	if len(all2) != 0 {
+		t.Fatalf("expected 0 rollbacks after reopen, got %d", len(all2))
+	}
+}
+
+// TestClearRollbackAuthorization_RestoresStateOnWriteFailure proves the
+// in-memory state is left intact (matching disk) when the durable write fails
+// mid-clear, so a failed clear cannot silently stop an authorization from
+// capping the stream head.
+func TestClearRollbackAuthorization_RestoresStateOnWriteFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory write permissions; cannot force a write failure")
+	}
+	dir := t.TempDir()
+	store, err := OpenFileEmergencyStore(dir)
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore: %v", err)
+	}
+
+	now := time.Now().UTC()
+	auth := signedTestRollback(t, "clear-restore-1", now, 100)
+	if _, _, err := store.PublishRollbackAuthorization(context.Background(), auth, now); err != nil {
+		t.Fatalf("PublishRollbackAuthorization: %v", err)
+	}
+
+	// Make the store directory read-only so the atomic write (temp file +
+	// rename) fails when ClearRollbackAuthorization tries to persist.
+	// #nosec G302 -- directory perms need the exec bit; this is a test-only
+	// manipulation to make the atomic write fail (read-only dir).
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	// #nosec G302 -- restore owner rwx on the directory so t.TempDir cleanup
+	// can remove it; directories require the exec bit.
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	cleared, err := store.ClearRollbackAuthorization(context.Background(), "clear-restore-1")
+	if err == nil {
+		t.Fatal("expected write failure error, got nil")
+	}
+	if cleared {
+		t.Fatal("cleared must be false when the write fails")
+	}
+
+	// In-memory state must be unchanged: the authorization is still present.
+	all, err := store.RollbackAuthorizations(context.Background())
+	if err != nil {
+		t.Fatalf("RollbackAuthorizations: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 rollback retained after failed clear, got %d", len(all))
+	}
+	if all[0].Authorization.AuthorizationID != "clear-restore-1" {
+		t.Fatalf("unexpected authorization retained: %s", all[0].Authorization.AuthorizationID)
+	}
+}
+
+func TestClearRollbackAuthorization_NotFound(t *testing.T) {
+	store, err := OpenFileEmergencyStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore: %v", err)
+	}
+
+	cleared, err := store.ClearRollbackAuthorization(context.Background(), "nonexistent-id")
+	if err != nil {
+		t.Fatalf("ClearRollbackAuthorization error: %v", err)
+	}
+	if cleared {
+		t.Fatal("expected cleared=false for nonexistent ID")
+	}
+}
+
+func TestClearRollbackAuthorization_EmptyIDRejected(t *testing.T) {
+	store, err := OpenFileEmergencyStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore: %v", err)
+	}
+
+	_, err = store.ClearRollbackAuthorization(context.Background(), "")
+	if err == nil || !strings.Contains(err.Error(), "authorization_id required") {
+		t.Fatalf("empty ID error = %v, want authorization_id required", err)
+	}
+}
+
+func TestClearRollbackAuthorization_NilStoreRejected(t *testing.T) {
+	var store *FileEmergencyStore
+	_, err := store.ClearRollbackAuthorization(context.Background(), "some-id")
+	if err == nil || !errors.Is(err, ErrEmergencyStoreRequired) {
+		t.Fatalf("nil store error = %v, want ErrEmergencyStoreRequired", err)
+	}
+}
+
+func TestClearRollbackAuthorization_PreservesOtherRecords(t *testing.T) {
+	store, err := OpenFileEmergencyStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore: %v", err)
+	}
+
+	now := time.Now().UTC()
+	auth1 := signedTestRollback(t, "keep-this", now, 100)
+	auth2 := signedTestRollback(t, "clear-this", now, 101)
+
+	if _, _, err := store.PublishRollbackAuthorization(context.Background(), auth1, now); err != nil {
+		t.Fatalf("Publish auth1: %v", err)
+	}
+	if _, _, err := store.PublishRollbackAuthorization(context.Background(), auth2, now); err != nil {
+		t.Fatalf("Publish auth2: %v", err)
+	}
+
+	cleared, err := store.ClearRollbackAuthorization(context.Background(), "clear-this")
+	if err != nil {
+		t.Fatalf("Clear error: %v", err)
+	}
+	if !cleared {
+		t.Fatal("expected cleared=true")
+	}
+
+	all, err := store.RollbackAuthorizations(context.Background())
+	if err != nil {
+		t.Fatalf("RollbackAuthorizations: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 rollback, got %d", len(all))
+	}
+	if all[0].Authorization.AuthorizationID != "keep-this" {
+		t.Fatalf("wrong record preserved: got %s", all[0].Authorization.AuthorizationID)
+	}
+}
+
+// signedTestRollback creates a properly signed rollback authorization for
+// testing. It generates two ed25519 keypairs (to meet the 2-of-N threshold)
+// and signs the authorization with both.
+func signedTestRollback(t *testing.T, id string, now time.Time, counter uint64) conductor.RollbackAuthorization {
+	t.Helper()
+	auth := conductor.RollbackAuthorization{
+		SchemaVersion:   conductor.SchemaVersion,
+		AuthorizationID: id,
+		OrgID:           "test-org",
+		FleetID:         "test-fleet",
+		CurrentBundleID: "bundle-current",
+		CurrentVersion:  2,
+		TargetBundleID:  "bundle-target",
+		TargetVersion:   1,
+		Counter:         counter,
+		Reason:          "test rollback",
+		CreatedAt:       now,
+		ExpiresAt:       now.Add(time.Hour),
+	}
+
+	// Generate two keypairs and sign.
+	var sigs []conductor.SignatureProof
+	for i := range 2 {
+		_, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatalf("GenerateKey(%d): %v", i, err)
+		}
+		preimage, err := auth.SignablePreimage()
+		if err != nil {
+			t.Fatalf("SignablePreimage: %v", err)
+		}
+		sig := ed25519.Sign(priv, preimage)
+		keyID := "test-rollback-key-" + hex.EncodeToString([]byte{byte(i)})
+		sigs = append(sigs, conductor.SignatureProof{
+			SignerKeyID: keyID,
+			KeyPurpose:  signing.PurposePolicyBundleRollback,
+			Algorithm:   conductor.SignatureAlgorithmEd25519,
+			Signature:   conductor.SignaturePrefixEd25519 + hex.EncodeToString(sig),
+		})
+	}
+	auth.Signatures = sigs
+	return auth
+}
+
+// TestClearRollbackAuthorization_HandlerEndpoint tests the handler's DELETE
+// endpoint for clearing rollback authorizations.
+func TestClearRollbackAuthorization_HandlerEndpoint(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenFileEmergencyStore(dir)
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore: %v", err)
+	}
+	now := time.Now().UTC()
+	auth := signedTestRollback(t, "handler-clear-test", now, 200)
+	if _, _, err := store.PublishRollbackAuthorization(context.Background(), auth, now); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	// Verify it was stored.
+	all, _ := store.RollbackAuthorizations(context.Background())
+	if len(all) != 1 {
+		t.Fatalf("expected 1 stored, got %d", len(all))
+	}
+
+	// Clear it.
+	cleared, err := store.ClearRollbackAuthorization(context.Background(), "handler-clear-test")
+	if err != nil {
+		t.Fatalf("ClearRollbackAuthorization: %v", err)
+	}
+	if !cleared {
+		t.Fatal("expected cleared=true")
+	}
+
+	// Confirm the state file on disk does not contain the cleared ID.
+	statePath := filepath.Join(dir, emergencyStateFileName)
+	data, err := os.ReadFile(filepath.Clean(statePath))
+	if err != nil {
+		t.Fatalf("ReadFile state: %v", err)
+	}
+	var record emergencyStateRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatalf("Unmarshal state: %v", err)
+	}
+	for _, rb := range record.Rollbacks {
+		if rb.Authorization.AuthorizationID == "handler-clear-test" {
+			t.Fatal("cleared authorization still present in on-disk state")
+		}
+	}
+}

--- a/enterprise/conductor/controlplane/emergency_store_clear_test.go
+++ b/enterprise/conductor/controlplane/emergency_store_clear_test.go
@@ -263,7 +263,10 @@ func TestClearRollbackAuthorization_HandlerEndpoint(t *testing.T) {
 	}
 
 	// Verify it was stored.
-	all, _ := store.RollbackAuthorizations(context.Background())
+	all, err := store.RollbackAuthorizations(context.Background())
+	if err != nil {
+		t.Fatalf("RollbackAuthorizations: %v", err)
+	}
 	if len(all) != 1 {
 		t.Fatalf("expected 1 stored, got %d", len(all))
 	}

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -839,8 +839,10 @@ func (h *Handler) handleRollbackAuthorizations(w http.ResponseWriter, r *http.Re
 		h.handleLatestRollbackAuthorization(w, r)
 	case http.MethodPut, http.MethodPost:
 		h.handlePublishRollbackAuthorization(w, r)
+	case http.MethodDelete:
+		h.handleClearRollbackAuthorization(w, r)
 	default:
-		writeMethodNotAllowed(w, http.MethodGet, http.MethodPut, http.MethodPost)
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete)
 	}
 }
 
@@ -903,6 +905,63 @@ func (h *Handler) handlePublishRollbackAuthorization(w http.ResponseWriter, r *h
 		Counter:           record.Authorization.Counter,
 		PublishedAt:       record.PublishedAt,
 		Created:           created,
+	})
+}
+
+// rollbackClearer is the optional interface an [EmergencyStore] may implement
+// to support clearing (removing) a rollback authorization by its
+// authorization_id. The [FileEmergencyStore] implements it. Stores that do not
+// implement it degrade to HTTP 501 Not Implemented on DELETE.
+type rollbackClearer interface {
+	ClearRollbackAuthorization(ctx context.Context, authorizationID string) (bool, error)
+}
+
+// clearRollbackAuthorizationRequest is the JSON body for DELETE
+// /api/v1/conductor/rollback-authorizations.
+type clearRollbackAuthorizationRequest struct {
+	AuthorizationID string `json:"authorization_id"`
+}
+
+func (h *Handler) handleClearRollbackAuthorization(w http.ResponseWriter, r *http.Request) {
+	if h.emergencyControls == nil {
+		writeError(w, http.StatusNotImplemented, ErrEmergencyStoreRequired)
+		return
+	}
+	if err := h.authorizeAdmin(r); err != nil {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
+		return
+	}
+	clearer, ok := h.emergencyControls.(rollbackClearer)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, errors.New("emergency store does not support clearing rollback authorizations"))
+		return
+	}
+	var req clearRollbackAuthorizationRequest
+	if err := decodeStrictJSON(w, r, h.maxRequestBody, &req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, conductor.ErrPayloadTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if strings.TrimSpace(req.AuthorizationID) == "" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("%w: authorization_id", conductor.ErrMissingField))
+		return
+	}
+	cleared, err := clearer.ClearRollbackAuthorization(r.Context(), req.AuthorizationID)
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	if !cleared {
+		writeError(w, http.StatusNotFound, ErrEmergencyNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"authorization_id": req.AuthorizationID,
+		"cleared":          true,
 	})
 }
 

--- a/enterprise/conductor/controlplane/rollback_clear_handler_test.go
+++ b/enterprise/conductor/controlplane/rollback_clear_handler_test.go
@@ -1,0 +1,146 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+)
+
+// erroringClearer implements EmergencyStore (via the embedded
+// failingEmergencyStore) plus the optional rollbackClearer interface, returning
+// an error from the clear so the handler's writeStoreError branch is exercised.
+type erroringClearer struct {
+	failingEmergencyStore
+}
+
+func (erroringClearer) ClearRollbackAuthorization(context.Context, string) (bool, error) {
+	return false, errors.New("clear failed")
+}
+
+func clearRollbackRequest(body string, admin bool) *http.Request {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, RollbackAuthorizationsPath, strings.NewReader(body))
+	if admin {
+		req.Header.Set("X-Pipelock-Admin", "ok")
+	}
+	return req
+}
+
+// TestHandlerClearRollbackAuthorization drives the DELETE
+// /api/v1/conductor/rollback-authorizations handler through every branch: the
+// nil-store and non-clearer 501s, the admin-forbidden 403, malformed/oversized
+// body, empty authorization_id, store error, not-found, and the success path.
+func TestHandlerClearRollbackAuthorization(t *testing.T) {
+	t.Run("success clears existing authorization then 404 on retry", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		signer := newTestSigner(t)
+		wildcard := conductor.Audience{InstanceIDs: []string{"*"}}
+		v1 := signedControlBundle(t, signer, bundleSpec{id: "bundle-clear-v1", version: 1, audience: wildcard})
+		v2 := signedControlBundle(t, signer, bundleSpec{id: "bundle-clear-v2", version: 2, audience: wildcard})
+		auth := signedRollbackAuthorizationForBundles(t, "rollback-clear-ok", v2, v1, testNow)
+		if _, created, err := handler.emergencyControls.PublishRollbackAuthorization(t.Context(), auth, testNow); err != nil || !created {
+			t.Fatalf("PublishRollbackAuthorization() created=%v err=%v, want created", created, err)
+		}
+
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"rollback-clear-ok"}`, true))
+		if w.Code != http.StatusOK {
+			t.Fatalf("clear status=%d body=%s, want 200", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), `"cleared":true`) {
+			t.Fatalf("clear body=%s, want cleared:true", w.Body.String())
+		}
+
+		// The authorization is gone, so a second clear is a 404.
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"rollback-clear-ok"}`, true))
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("second clear status=%d body=%s, want 404", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("unknown authorization_id returns 404", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"does-not-exist"}`, true))
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status=%d body=%s, want 404", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("empty authorization_id returns 400", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"   "}`, true))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d body=%s, want 400", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("malformed json returns 400", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{not valid json`, true))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d body=%s, want 400", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("oversized body returns 413", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		handler.maxRequestBody = 8
+		big := `{"authorization_id":"` + strings.Repeat("a", 256) + `"}`
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(big, true))
+		if w.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("status=%d body=%s, want 413", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("missing admin auth returns 403", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"x"}`, false))
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status=%d body=%s, want 403", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("nil emergency controls returns 501", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		handler.emergencyControls = nil
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"x"}`, true))
+		if w.Code != http.StatusNotImplemented {
+			t.Fatalf("status=%d body=%s, want 501", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("store without clearer returns 501", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		handler.emergencyControls = failingEmergencyStore{}
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"x"}`, true))
+		if w.Code != http.StatusNotImplemented {
+			t.Fatalf("status=%d body=%s, want 501", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("clear error maps to 500", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		handler.emergencyControls = erroringClearer{}
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"x"}`, true))
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status=%d body=%s, want 500", w.Code, w.Body.String())
+		}
+	})
+}


### PR DESCRIPTION
Day-2 operability for the policy control plane. All mutating paths are admin-authorized and fail closed.

## What changed
- `publish --previous-bundle-hash auto` resolves the current stream head so an operator can publish forward after a rollback without copying the hash. It matches the target stream by org/fleet, environment, and audience, and refuses to choose when more than one stream matches. The server still validates prev-hash against the head (409 on mismatch).
- `rollback clear` plus a new admin-gated DELETE endpoint clears an active rollback authorization before its TTL. The store write is atomic and restores in-memory state if the write fails.
- Guarded `stream reset` (requires `--confirm`; fails closed when emergency controls can't be read), read-only `store dump`, and a `kill status` alias over the existing stream-status endpoint.

Rollback-authorization TTL was already enforced on the read/apply path (validity + signature + audience checks); this change does not alter it.

> Note: do not merge until the live-fleet proof (publish → rollback → `rollback clear` → publish-forward, plus leader restart-survival of the clear). `clear` and `stream reset` mutate persisted control-plane state, so the live proof is the gate, not unit tests alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `conductor rollback clear` to clear a rollback authorization (admin-only, requires `--confirm` and `--authorization-id`).
  * Added `conductor kill status` to view active remote-kill state, including `--json` output.
  * Added `conductor store dump` for read-only stream overview inspection.
  * Added `conductor stream reset` to clear all active rollback authorizations (destructive, requires `--confirm`).
  * Enhanced `--previous-bundle-hash auto` to resolve the prior hash from stream status at publish time.

* **Documentation**
  * Added/expanded operator recovery runbook and CLI recovery documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->