### PR TITLE
feat(contain): publishable offline containment conformance artifact with must-fail fixture

### DIFF
--- a/.github/workflows/verifiers.yaml
+++ b/.github/workflows/verifiers.yaml
@@ -16,6 +16,7 @@ on:
       - 'cmd/pipelock/**'
       - 'cmd/pipelock-verifier/**'
       - 'internal/aarp/**'
+      - 'internal/cli/contain/**'
       - 'internal/jsonscan/**'
       - 'internal/receipt/**'
       - 'internal/recorder/**'
@@ -28,6 +29,7 @@ on:
       - 'cmd/pipelock/**'
       - 'cmd/pipelock-verifier/**'
       - 'internal/aarp/**'
+      - 'internal/cli/contain/**'
       - 'internal/jsonscan/**'
       - 'internal/receipt/**'
       - 'internal/recorder/**'
@@ -336,3 +338,33 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/sdk/verifiers/python/src
           PY_AARP: python -m pipelock_aarp_verify aarp
         run: bash sdk/conformance/aarp-corpus-gate.sh
+
+  # Containment direct-egress conformance gate: packages pipelock's
+  # `contain verify` direct-egress probes (probe 8 — pipelock-agent must NOT
+  # reach the internet directly; probe 9 — the operator must still reach it) as
+  # a publishable conformance artifact and proves the egress-denied test is
+  # real. The gate runs the Go conformance test over the fixture pairs under
+  # sdk/conformance/testdata/containment, then asserts the must-fail property by
+  # temporarily marking the leaked-egress fixture as expected-pass and
+  # confirming the test then fails. Entirely offline — no real network, sudo,
+  # curl, or nftables. The probes run against a canned command-runner built
+  # from the fixtures.
+  #
+  # Security note: no run: step consumes untrusted github.event.* input.
+  containment-conformance:
+    name: Containment direct-egress gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout pipelock
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.26'
+
+      - name: Run containment direct-egress conformance gate
+        run: bash sdk/conformance/containment-gate.sh

--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -312,6 +312,33 @@ Flags:
 | `--bundle-output` | `/etc/pipelock/combined-ca.pem` | Destination for the combined bundle. |
 | `--system-bundle` | system default | Source system CA bundle to combine with the Pipelock CA. |
 
+## Containment conformance artifact
+
+The two direct-egress probes — probe 8 (`cc_agent_egress_denied`) and probe 9 (`operator_egress_reachable`) — are also packaged as a publishable conformance artifact under `sdk/conformance/testdata/containment/`. The artifact proves the egress-denied test is *real*: it ships a deliberately-leaky fixture in which the agent's direct-egress canary succeeds (containment broken), and the gate **must** fail on it.
+
+The probes run against a canned command-runner built from external JSON fixtures, with no real network, sudo, curl, or nftables. Each fixture is a pair:
+
+- `<name>.probe.json` — the canned `(command → stdout, exit_code)` inputs.
+- `<name>.expect.json` — the expected per-probe status and aggregate exit code.
+
+| Fixture | Probe 8 | Overall exit | Role |
+|---|---|---|---|
+| `pass-all` | `pass` (egress blocked) | 0 | clean baseline — gate must PASS |
+| `leaky-egress` | `fail` (egress leaked) | 1 | **must-fail** — gate must DETECT |
+
+The fixture schema is documented in `sdk/conformance/testdata/containment/README.md`. Run the artifact two ways:
+
+```bash
+# Go conformance test over every fixture pair.
+go test -run TestContainmentConformance ./sdk/conformance/
+
+# Standalone gate: runs the test and additionally proves the must-fail property
+# (it flips the leaky fixture to expect a pass and confirms the test then fails).
+bash sdk/conformance/containment-gate.sh
+```
+
+The test drives the probes through the exported `contain.RunContainmentConformance` seam, so it stays a thin, reproducible wrapper over the same probe logic `pipelock contain verify` runs in production. CI gates the artifact via the `containment-conformance` job in `.github/workflows/verifiers.yaml`, triggered by changes under `internal/cli/contain/**` or `sdk/conformance/**`.
+
 ## Operational notes
 
 - **Binary integrity is TOFU.** The first `install` pins the binary hash. Verify compares the installed binary against that pin on every run. To install a new pipelock binary, run `install` again with `--pipelock-binary <new path>`; install rewrites the pin atomically.

--- a/internal/cli/contain/conformance.go
+++ b/internal/cli/contain/conformance.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// This file is the ONLY exported surface the containment-conformance
+// artifact under sdk/conformance/ depends on. It deliberately exposes the
+// minimum needed to drive the egress-containment probes (probe 8 / probe 9)
+// against a canned command-runner, with NO access to the real sudo/curl/nft
+// execution path and NO leak of the unexported probe/probeEnv internals.
+//
+// DESIGN NOTE (why this shape):
+//   - The probe registry, probeEnv, and probeRecord types are unexported and
+//     must stay that way (they carry real-execution seams — sudo argv builders,
+//     a live dialer, os.Stat/ReadFile, the binary-integrity hasher). Exporting
+//     them would widen the production attack surface for one test artifact.
+//   - The conformance artifact only needs to prove the DIRECT-EGRESS probes:
+//     probe 8 (pipelock-agent must NOT reach the internet directly) and
+//     probe 9 (the operator must still reach the internet). Those two probes
+//     depend solely on the injected command runner plus the agent/operator
+//     usernames — none of the filesystem/dialer/hasher seams.
+//   - So we export exactly one options struct (ConformanceEnv) carrying just an
+//     injected runner, and one driver (RunContainmentConformance) returning
+//     exported result records plus the same aggregate exit code runVerify would
+//     produce for these probes. The sdk/conformance test imports this, drives it
+//     from JSON fixtures, and asserts per-probe status + exit code. This mirrors
+//     how sdk/conformance/conformance_test.go already imports internal packages.
+
+// ConformanceRunCommand is the canned command-runner the conformance harness
+// injects. It has the same shape as the production runCommand seam: given the
+// executable name and its argv, it returns merged stdout/stderr, the process
+// exit code, and a non-nil error ONLY when the binary could not be started.
+// Fixtures map a (name, argv) invocation to a canned (stdout, exitCode).
+type ConformanceRunCommand func(ctx context.Context, name string, args ...string) (stdout string, exitCode int, err error)
+
+// ConformanceEnv carries the minimal inputs the egress-containment probes need.
+// It is an options struct (not a long parameter list) so future conformance
+// knobs are added as fields, never as new positional arguments.
+type ConformanceEnv struct {
+	// RunCommand is the canned runner. Required; a nil runner fails closed
+	// (RunContainmentConformance returns an error rather than silently
+	// passing, matching pipelock's fail-closed default).
+	RunCommand ConformanceRunCommand
+
+	// AgentUser is the unprivileged agent account probe 8 must prove is
+	// blocked from direct egress. Defaults to the production agent user when
+	// empty so fixtures need not restate it.
+	AgentUser string
+
+	// OperatorUser is the account probe 9 proves can still reach the
+	// internet. When empty, probe 9 invokes curl directly (the production
+	// behaviour when $SUDO_USER is unset).
+	OperatorUser string
+}
+
+// ConformanceProbeResult is one exported per-probe outcome. Status is one of
+// the canonical "pass" / "fail" / "skip" strings the verify command emits.
+type ConformanceProbeResult struct {
+	Probe  int    `json:"probe"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// Exported status constants so the conformance artifact can assert against
+// them without re-declaring the unexported originals.
+const (
+	ConformanceStatusPass = statusPass
+	ConformanceStatusFail = statusFail
+	ConformanceStatusSkip = statusSkip
+)
+
+// Exit codes mirror the verify command's aggregate contract:
+//
+//	0  every driven probe passed,
+//	1  at least one probe FAILED (containment is broken),
+//	2  no failures but at least one probe SKIPPED (incomplete verification).
+//
+// These are re-exported from cliutil so callers (and the gate script) do not
+// have to import cliutil just to read the numbers.
+//
+// conformanceExitInvalid (misconfigured harness, e.g. a nil runner) shares the
+// numeric value of ConformanceExitSkip because both are config-class, non-zero,
+// fail-closed outcomes. They are disambiguated by the error return, NOT the exit
+// code: the invalid path returns a non-nil error, whereas a genuine skip returns
+// a nil error. Callers that must tell them apart check the error.
+const (
+	ConformanceExitOK      = cliutil.ExitOK
+	ConformanceExitFail    = cliutil.ExitGeneral
+	ConformanceExitSkip    = cliutil.ExitConfig
+	conformanceExitInvalid = cliutil.ExitConfig
+)
+
+// RunContainmentConformance drives the direct-egress containment probes
+// (probe 8: pipelock-agent egress denied; probe 9: operator egress reachable)
+// against the injected command runner in env, and returns the per-probe
+// results plus the aggregate exit code.
+//
+// The aggregate exit code follows the same fail > skip > pass precedence the
+// real `contain verify` driver uses (runVerify): a single FAIL yields exit 1
+// regardless of how many probes passed, because a broken containment boundary
+// is never offset by other green probes. This is the property the must-fail
+// "leaky-egress" fixture exercises.
+//
+// A nil runner (misconfigured fixture) fails closed: the function returns a
+// non-nil error and the invalid exit code, never a silent pass.
+func RunContainmentConformance(ctx context.Context, env ConformanceEnv) ([]ConformanceProbeResult, int, error) {
+	if env.RunCommand == nil {
+		return nil, conformanceExitInvalid, fmt.Errorf("conformance: RunCommand runner is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Build the unexported probeEnv from the exported inputs. Only the fields
+	// probes 8 and 9 consult are populated; everything else stays zero so a
+	// fixture cannot reach a filesystem/dialer/hasher path by accident.
+	internalEnv := &probeEnv{
+		agentUserName: env.AgentUser,
+		operatorUser:  env.OperatorUser,
+		runCmd:        runCommand(env.RunCommand),
+	}
+	if internalEnv.agentUserName == "" {
+		internalEnv.agentUserName = defaultAgentUser
+	}
+
+	// The two direct-egress probes, in registry order (8 then 9).
+	egressProbes := []probe{
+		{8, "cc_agent_egress_denied", "pipelock-agent cannot reach the internet directly", probeCCAgentEgressDenied},
+		{9, "operator_egress_reachable", "operator user can still reach the internet", probeOperatorEgress},
+	}
+
+	results := make([]ConformanceProbeResult, 0, len(egressProbes))
+	var passN, failN, skipN int
+	for _, p := range egressProbes {
+		status, detail := p.fn(ctx, internalEnv)
+		switch status {
+		case statusPass:
+			passN++
+		case statusFail:
+			failN++
+		case statusSkip:
+			skipN++
+		default:
+			// Unknown status coerces to fail and carries the value forward,
+			// exactly as runVerify does. A probe must never vanish silently.
+			failN++
+			detail = fmt.Sprintf("invalid status %q (detail: %s)", status, detail)
+			status = statusFail
+		}
+		results = append(results, ConformanceProbeResult{
+			Probe:  p.n,
+			Name:   p.name,
+			Status: status,
+			Detail: detail,
+		})
+	}
+
+	exitCode := ConformanceExitOK
+	switch {
+	case failN > 0:
+		exitCode = ConformanceExitFail
+	case skipN > 0:
+		exitCode = ConformanceExitSkip
+	}
+	return results, exitCode, nil
+}

--- a/internal/cli/contain/conformance_test.go
+++ b/internal/cli/contain/conformance_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// cannedResp is one canned (stdout, exitCode, err) the injected runner returns.
+type cannedResp struct {
+	out  string
+	code int
+	err  error
+}
+
+// conformanceRunner dispatches on the executable name: probe 8 shells out via
+// "sudo", and probe 9 (with an empty OperatorUser) invokes curl directly, so
+// the command name alone tells the two egress probes apart.
+func conformanceRunner(probe8, probe9 cannedResp) ConformanceRunCommand {
+	return func(_ context.Context, name string, _ ...string) (string, int, error) {
+		if name == "sudo" {
+			return probe8.out, probe8.code, probe8.err
+		}
+		return probe9.out, probe9.code, probe9.err
+	}
+}
+
+func TestRunContainmentConformance_NilRunnerFailsClosed(t *testing.T) {
+	results, exit, err := RunContainmentConformance(context.Background(), ConformanceEnv{})
+	if err == nil {
+		t.Fatal("nil runner: expected a fail-closed error, got nil")
+	}
+	if results != nil {
+		t.Fatalf("nil runner: expected nil results, got %v", results)
+	}
+	if exit != conformanceExitInvalid {
+		t.Fatalf("nil runner: exit = %d, want %d (invalid/config)", exit, conformanceExitInvalid)
+	}
+}
+
+func TestRunContainmentConformance_Outcomes(t *testing.T) {
+	const blockedExit = 7 // curl connection-refused style exit when egress is denied
+
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		agentUser  string
+		probe8     cannedResp // sudo -u agent -- curl
+		probe9     cannedResp // curl (operator, empty user -> direct)
+		wantExit   int
+		wantStatus map[int]string // probe number -> expected status
+	}{
+		{
+			name:      "both_pass_nil_ctx_default_agent_user",
+			ctx:       nil, // exercises the ctx == nil default
+			agentUser: "",  // exercises the defaultAgentUser fallback
+			probe8:    cannedResp{out: "curl: (7) refused", code: blockedExit},
+			probe9:    cannedResp{out: "200", code: 0},
+			wantExit:  ConformanceExitOK,
+			wantStatus: map[int]string{
+				8: ConformanceStatusPass,
+				9: ConformanceStatusPass,
+			},
+		},
+		{
+			name:      "agent_egress_leaked_fails",
+			ctx:       context.Background(),
+			agentUser: "pipelock-agent",
+			probe8:    cannedResp{out: "200", code: 0}, // agent reached the internet -> leak
+			probe9:    cannedResp{out: "200", code: 0},
+			wantExit:  ConformanceExitFail,
+			wantStatus: map[int]string{
+				8: ConformanceStatusFail,
+				9: ConformanceStatusPass,
+			},
+		},
+		{
+			name:      "runner_unavailable_skips",
+			ctx:       context.Background(),
+			agentUser: "pipelock-agent",
+			probe8:    cannedResp{err: errors.New("sudo: command not found")},
+			probe9:    cannedResp{err: errors.New("curl: command not found")},
+			wantExit:  ConformanceExitSkip,
+			wantStatus: map[int]string{
+				8: ConformanceStatusSkip,
+				9: ConformanceStatusSkip,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := ConformanceEnv{
+				RunCommand: conformanceRunner(tc.probe8, tc.probe9),
+				AgentUser:  tc.agentUser,
+			}
+			results, exit, err := RunContainmentConformance(tc.ctx, env)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if exit != tc.wantExit {
+				t.Fatalf("exit = %d, want %d", exit, tc.wantExit)
+			}
+			if len(results) != len(tc.wantStatus) {
+				t.Fatalf("got %d results, want %d", len(results), len(tc.wantStatus))
+			}
+			for _, r := range results {
+				want, ok := tc.wantStatus[r.Probe]
+				if !ok {
+					t.Fatalf("unexpected probe %d in results", r.Probe)
+				}
+				if r.Status != want {
+					t.Errorf("probe %d (%s): status = %q, want %q (detail: %s)", r.Probe, r.Name, r.Status, want, r.Detail)
+				}
+			}
+		})
+	}
+}

--- a/sdk/conformance/containment-gate.sh
+++ b/sdk/conformance/containment-gate.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Copyright 2026 Josh Waldrep
+# SPDX-License-Identifier: Apache-2.0
+#
+# Containment direct-egress conformance gate.
+#
+# Packages pipelock's `contain verify` direct-egress probes (probe 8:
+# pipelock-agent must NOT reach the internet directly; probe 9: the operator
+# must still reach the internet) as a publishable conformance artifact and
+# proves the egress-denied test is REAL.
+#
+# It does three things, all offline (no real network, sudo, curl, or nft):
+#
+#   1. Runs the Go conformance test over every fixture pair under
+#      testdata/containment/ (clean baseline + the must-fail leaky fixture).
+#   2. Asserts the MUST-FAIL property directly: it makes a temp copy of the
+#      corpus where leaky-egress.expect.json is rewritten to expect a PASS, and
+#      confirms the conformance test then FAILS. If a leaked agent egress could
+#      ever be marked pass, the gate itself is worthless — so the gate fails if
+#      that mutation does NOT trip the test.
+#   3. Confirms the clean baseline fixture is present and asserted.
+#
+# Exit codes:
+#   0  the gate held: clean fixture passes, leaky fixture is detected-as-fail,
+#      and the must-fail mutation correctly trips the test.
+#   1  a conformance failure: a fixture diverged from its .expect.json, or the
+#      must-fail mutation did NOT trip the test (the gate is not real).
+#   2  fatal config: fixtures or the Go toolchain are missing/unusable.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$ROOT/../.." && pwd)"
+FIXTURE_DIR="$ROOT/testdata/containment"
+TEST_PKG="./sdk/conformance/"
+TEST_RUN="TestContainmentConformance"
+
+fatal() {
+  echo "FATAL: $*" >&2
+  exit 2
+}
+
+command -v go >/dev/null 2>&1 || fatal "go toolchain not found on PATH"
+[ -d "$FIXTURE_DIR" ] || fatal "fixture directory missing: $FIXTURE_DIR"
+
+LEAKY_PROBE="$FIXTURE_DIR/leaky-egress.probe.json"
+LEAKY_EXPECT="$FIXTURE_DIR/leaky-egress.expect.json"
+CLEAN_PROBE="$FIXTURE_DIR/pass-all.probe.json"
+CLEAN_EXPECT="$FIXTURE_DIR/pass-all.expect.json"
+for f in "$LEAKY_PROBE" "$LEAKY_EXPECT" "$CLEAN_PROBE" "$CLEAN_EXPECT"; do
+  [ -f "$f" ] || fatal "required fixture missing: $f"
+done
+
+echo "==> [1/2] Running containment conformance test over the real corpus"
+if ! ( cd "$REPO_ROOT" && go test -count=1 -run "$TEST_RUN" "$TEST_PKG" ); then
+  echo "FAIL: containment conformance test failed against the real corpus" >&2
+  exit 1
+fi
+echo "    clean baseline passes; leaky-egress is detected-as-fail (as expected)"
+
+echo "==> [2/2] Proving the must-fail property: a leaked egress marked 'pass' MUST trip the gate"
+# The conformance test reads testdata/containment relative to its package dir,
+# so we temporarily swap leaky-egress.expect.json in place to wrongly expect a
+# PASS, re-run the corpus-walking test, and confirm it FAILS. The original is
+# always restored via the EXIT trap, even on interrupt. A clean test exit
+# against the mutated corpus means a leaked egress could be marked pass -> the
+# gate is not real -> we fail loud.
+BACKUP="$(mktemp)"
+RESTORED=0
+restore_expect() {
+  # Only restore from a NON-EMPTY backup. mktemp creates an empty file; if the
+  # backup cp below never succeeded, $BACKUP is still empty and restoring from it
+  # would clobber the real fixture with nothing. An empty backup also means the
+  # in-place mutation never happened (we fatal before mutating), so the fixture
+  # on disk is already the untouched original — skipping restore is correct.
+  if [ "$RESTORED" -eq 0 ] && [ -s "$BACKUP" ]; then
+    cp "$BACKUP" "$LEAKY_EXPECT" 2>/dev/null || true
+    rm -f "$BACKUP" 2>/dev/null || true
+    RESTORED=1
+  fi
+}
+trap restore_expect EXIT INT TERM
+
+cp "$LEAKY_EXPECT" "$BACKUP" || fatal "could not back up $LEAKY_EXPECT"
+
+cat > "$LEAKY_EXPECT" <<'JSON'
+{
+  "description": "MUTATED by containment-gate.sh: wrongly expects the leaked egress to pass. The conformance test MUST fail against this. This file is restored automatically.",
+  "exit_code": 0,
+  "probes": [
+    { "probe": 8, "name": "cc_agent_egress_denied", "status": "pass" },
+    { "probe": 9, "name": "operator_egress_reachable", "status": "pass" }
+  ]
+}
+JSON
+
+# Run only the corpus-walking test (the one that reads .expect.json) against the
+# mutated corpus. Restore immediately after, regardless of outcome.
+set +e
+( cd "$REPO_ROOT" && go test -count=1 -run TestContainmentConformance "$TEST_PKG" >/dev/null 2>&1 )
+MUT_RC=$?
+set -e
+restore_expect
+
+if [ "$MUT_RC" -eq 0 ]; then
+  echo "FAIL: mutating leaky-egress to expect 'pass' did NOT trip the conformance test." >&2
+  echo "      The must-fail property is broken — the egress-denied gate is not real." >&2
+  exit 1
+fi
+echo "    mutation correctly tripped the test: the must-fail property holds"
+
+echo "----"
+echo "PASS: containment direct-egress conformance gate held"

--- a/sdk/conformance/containment-gate.sh
+++ b/sdk/conformance/containment-gate.sh
@@ -51,7 +51,7 @@ for f in "$LEAKY_PROBE" "$LEAKY_EXPECT" "$CLEAN_PROBE" "$CLEAN_EXPECT"; do
 done
 
 echo "==> [1/2] Running containment conformance test over the real corpus"
-if ! ( cd "$REPO_ROOT" && go test -count=1 -run "$TEST_RUN" "$TEST_PKG" ); then
+if ! ( cd "$REPO_ROOT" && go test -race -count=1 -run "$TEST_RUN" "$TEST_PKG" ); then
   echo "FAIL: containment conformance test failed against the real corpus" >&2
   exit 1
 fi
@@ -103,7 +103,7 @@ JSON
 # independently of .expect.json); this mutation step must isolate the corpus
 # walker's expect-comparison logic. Restore immediately after, regardless of outcome.
 set +e
-( cd "$REPO_ROOT" && go test -count=1 -run '^TestContainmentConformance$' "$TEST_PKG" >"$MUT_OUT" 2>&1 )
+( cd "$REPO_ROOT" && go test -race -count=1 -run '^TestContainmentConformance$' "$TEST_PKG" >"$MUT_OUT" 2>&1 )
 MUT_RC=$?
 set -e
 

--- a/sdk/conformance/containment-gate.sh
+++ b/sdk/conformance/containment-gate.sh
@@ -94,9 +94,12 @@ cat > "$LEAKY_EXPECT" <<'JSON'
 JSON
 
 # Run only the corpus-walking test (the one that reads .expect.json) against the
-# mutated corpus. Restore immediately after, regardless of outcome.
+# mutated corpus. The regex is anchored so it does NOT also pull in the dedicated
+# TestContainmentConformance_* helpers (which assert the must-fail property
+# independently of .expect.json); this mutation step must isolate the corpus
+# walker's expect-comparison logic. Restore immediately after, regardless of outcome.
 set +e
-( cd "$REPO_ROOT" && go test -count=1 -run TestContainmentConformance "$TEST_PKG" >/dev/null 2>&1 )
+( cd "$REPO_ROOT" && go test -count=1 -run '^TestContainmentConformance$' "$TEST_PKG" >/dev/null 2>&1 )
 MUT_RC=$?
 set -e
 restore_expect

--- a/sdk/conformance/containment-gate.sh
+++ b/sdk/conformance/containment-gate.sh
@@ -65,6 +65,7 @@ echo "==> [2/2] Proving the must-fail property: a leaked egress marked 'pass' MU
 # against the mutated corpus means a leaked egress could be marked pass -> the
 # gate is not real -> we fail loud.
 BACKUP="$(mktemp)"
+MUT_OUT="$(mktemp)"
 RESTORED=0
 restore_expect() {
   # Only restore from a NON-EMPTY backup. mktemp creates an empty file; if the
@@ -72,9 +73,12 @@ restore_expect() {
   # would clobber the real fixture with nothing. An empty backup also means the
   # in-place mutation never happened (we fatal before mutating), so the fixture
   # on disk is already the untouched original — skipping restore is correct.
-  if [ "$RESTORED" -eq 0 ] && [ -s "$BACKUP" ]; then
-    cp "$BACKUP" "$LEAKY_EXPECT" 2>/dev/null || true
+  if [ "$RESTORED" -eq 0 ]; then
+    if [ -s "$BACKUP" ]; then
+      cp "$BACKUP" "$LEAKY_EXPECT" 2>/dev/null || true
+    fi
     rm -f "$BACKUP" 2>/dev/null || true
+    rm -f "$MUT_OUT" 2>/dev/null || true
     RESTORED=1
   fi
 }
@@ -99,16 +103,27 @@ JSON
 # independently of .expect.json); this mutation step must isolate the corpus
 # walker's expect-comparison logic. Restore immediately after, regardless of outcome.
 set +e
-( cd "$REPO_ROOT" && go test -count=1 -run '^TestContainmentConformance$' "$TEST_PKG" >/dev/null 2>&1 )
+( cd "$REPO_ROOT" && go test -count=1 -run '^TestContainmentConformance$' "$TEST_PKG" >"$MUT_OUT" 2>&1 )
 MUT_RC=$?
 set -e
-restore_expect
 
 if [ "$MUT_RC" -eq 0 ]; then
+  restore_expect
   echo "FAIL: mutating leaky-egress to expect 'pass' did NOT trip the conformance test." >&2
   echo "      The must-fail property is broken — the egress-denied gate is not real." >&2
   exit 1
 fi
+
+if ! grep -Eq 'leaky-egress: (exit code = 1, want 0|probe 8 status = "fail", want "pass")' "$MUT_OUT"; then
+  echo "FAIL: mutated conformance test failed, but not for the expected leaky-egress mismatch." >&2
+  echo "      Refusing to treat an unrelated compile/tooling failure as proof of the must-fail property." >&2
+  echo "---- mutated test output ----" >&2
+  cat "$MUT_OUT" >&2
+  restore_expect
+  exit 1
+fi
+
+restore_expect
 echo "    mutation correctly tripped the test: the must-fail property holds"
 
 echo "----"

--- a/sdk/conformance/containment_conformance_test.go
+++ b/sdk/conformance/containment_conformance_test.go
@@ -21,6 +21,7 @@ package conformance_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,6 +31,11 @@ import (
 )
 
 const containmentFixtureDir = "testdata/containment"
+
+var expectedContainmentProbes = map[int]string{
+	8: "cc_agent_egress_denied",
+	9: "operator_egress_reachable",
+}
 
 // containmentRunRule is one canned command-match rule from a *.probe.json
 // fixture: when the joined command line contains every Match substring, the
@@ -103,23 +109,112 @@ func loadContainmentExpect(t *testing.T, path string) containmentExpectFixture {
 	if len(fx.Probes) == 0 {
 		t.Fatalf("expect fixture %s lists no probes", path)
 	}
+	if err := validateContainmentExpect(fx); err != nil {
+		t.Fatalf("invalid expect fixture %s: %v", path, err)
+	}
 	return fx
 }
 
-// cannedRunner builds the injected command runner from a fixture's run rules.
-// It returns a non-nil error when no rule matches so a fixture that forgets a
-// rule fails loud (the probe surfaces that as skip, which the gate treats as a
-// non-pass) rather than silently passing.
-func cannedRunner(fx containmentProbeFixture) contain.ConformanceRunCommand {
-	return func(_ context.Context, name string, args ...string) (string, int, error) {
-		joined := name + " " + strings.Join(args, " ")
-		for _, rule := range fx.Runs {
-			if allSubstringsPresent(joined, rule.Match) {
-				return rule.Stdout, rule.ExitCode, nil
-			}
-		}
-		return "", -1, errNoMatchingRule(joined)
+func validateContainmentExpect(fx containmentExpectFixture) error {
+	switch fx.ExitCode {
+	case contain.ConformanceExitOK, contain.ConformanceExitFail, contain.ConformanceExitSkip:
+	default:
+		return fmt.Errorf("exit_code = %d, want one of 0, 1, 2", fx.ExitCode)
 	}
+	if len(fx.Probes) != len(expectedContainmentProbes) {
+		return fmt.Errorf("lists %d probes, want exactly %d", len(fx.Probes), len(expectedContainmentProbes))
+	}
+	seen := make(map[int]struct{}, len(fx.Probes))
+	for i, p := range fx.Probes {
+		wantName, ok := expectedContainmentProbes[p.Probe]
+		if !ok {
+			return fmt.Errorf("probes[%d] has unexpected probe %d", i, p.Probe)
+		}
+		if _, ok := seen[p.Probe]; ok {
+			return fmt.Errorf("probes[%d] duplicates probe %d", i, p.Probe)
+		}
+		seen[p.Probe] = struct{}{}
+		if p.Name != wantName {
+			return fmt.Errorf("probes[%d] name = %q, want %q", i, p.Name, wantName)
+		}
+		if !isContainmentStatus(p.Status) {
+			return fmt.Errorf("probes[%d] status = %q, want pass/fail/skip", i, p.Status)
+		}
+	}
+	for probe := range expectedContainmentProbes {
+		if _, ok := seen[probe]; !ok {
+			return fmt.Errorf("missing expected probe %d", probe)
+		}
+	}
+	return nil
+}
+
+func isContainmentStatus(status string) bool {
+	switch status {
+	case contain.ConformanceStatusPass, contain.ConformanceStatusFail, contain.ConformanceStatusSkip:
+		return true
+	default:
+		return false
+	}
+}
+
+type auditedCannedRunner struct {
+	rules []containmentRunRule
+	calls []ruleMatchAudit
+}
+
+type ruleMatchAudit struct {
+	cmdline string
+	matches []int
+}
+
+// newAuditedCannedRunner builds the injected command runner from a fixture's
+// run rules and records which rules matched each command. The harness later
+// rejects zero-match, multi-match, and unused-rule fixtures so malformed
+// fixtures cannot be blessed by a matching .expect.json.
+func newAuditedCannedRunner(fx containmentProbeFixture) *auditedCannedRunner {
+	return &auditedCannedRunner{rules: fx.Runs}
+}
+
+func (r *auditedCannedRunner) Run(_ context.Context, name string, args ...string) (string, int, error) {
+	joined := name + " " + strings.Join(args, " ")
+	var matches []int
+	for i, rule := range r.rules {
+		if allSubstringsPresent(joined, rule.Match) {
+			matches = append(matches, i)
+		}
+	}
+	r.calls = append(r.calls, ruleMatchAudit{cmdline: joined, matches: append([]int(nil), matches...)})
+
+	switch len(matches) {
+	case 0:
+		return "", -1, errNoMatchingRule(joined)
+	case 1:
+		rule := r.rules[matches[0]]
+		return rule.Stdout, rule.ExitCode, nil
+	default:
+		return "", -1, errAmbiguousMatchingRule(joined, matches)
+	}
+}
+
+func (r *auditedCannedRunner) validate() error {
+	used := make([]bool, len(r.rules))
+	for _, call := range r.calls {
+		switch len(call.matches) {
+		case 0:
+			return errNoMatchingRule(call.cmdline)
+		case 1:
+			used[call.matches[0]] = true
+		default:
+			return errAmbiguousMatchingRule(call.cmdline, call.matches)
+		}
+	}
+	for i, ok := range used {
+		if !ok {
+			return fmt.Errorf("unused canned rule at runs[%d] with match %q", i, r.rules[i].Match)
+		}
+	}
+	return nil
 }
 
 func allSubstringsPresent(haystack string, needles []string) bool {
@@ -139,19 +234,36 @@ func (e noMatchingRuleError) Error() string {
 
 func errNoMatchingRule(cmdline string) error { return noMatchingRuleError(cmdline) }
 
+type ambiguousMatchingRuleError struct {
+	cmdline string
+	matches []int
+}
+
+func (e ambiguousMatchingRuleError) Error() string {
+	return fmt.Sprintf("ambiguous canned rules matched command line %q: run indexes %v", e.cmdline, e.matches)
+}
+
+func errAmbiguousMatchingRule(cmdline string, matches []int) error {
+	return ambiguousMatchingRuleError{cmdline: cmdline, matches: append([]int(nil), matches...)}
+}
+
 // runContainmentFixture loads a fixture pair, drives the containment probes
 // through the exported seam, and returns the results plus exit code.
 func runContainmentFixture(t *testing.T, name string) ([]contain.ConformanceProbeResult, int) {
 	t.Helper()
 	probeFx := loadContainmentProbe(t, filepath.Join(containmentFixtureDir, name+".probe.json"))
+	runner := newAuditedCannedRunner(probeFx)
 	env := contain.ConformanceEnv{
-		RunCommand:   cannedRunner(probeFx),
+		RunCommand:   runner.Run,
 		AgentUser:    probeFx.AgentUser,
 		OperatorUser: probeFx.OperatorUser,
 	}
 	results, exit, err := contain.RunContainmentConformance(context.Background(), env)
 	if err != nil {
 		t.Fatalf("RunContainmentConformance(%s): unexpected error: %v", name, err)
+	}
+	if err := runner.validate(); err != nil {
+		t.Fatalf("%s: invalid canned command-runner fixture: %v", name, err)
 	}
 	return results, exit
 }
@@ -269,6 +381,129 @@ func TestContainmentConformance_NilRunnerFailsClosed(t *testing.T) {
 	}
 }
 
+func TestContainmentConformance_InvalidExpectFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		expect  containmentExpectFixture
+		wantErr string
+	}{
+		{
+			name: "duplicate probe omits probe nine",
+			expect: containmentExpectFixture{
+				ExitCode: contain.ConformanceExitOK,
+				Probes: []containmentExpectProbe{
+					{Probe: 8, Name: "cc_agent_egress_denied", Status: "pass"},
+					{Probe: 8, Name: "cc_agent_egress_denied", Status: "pass"},
+				},
+			},
+			wantErr: "duplicates probe 8",
+		},
+		{
+			name: "unknown status",
+			expect: containmentExpectFixture{
+				ExitCode: contain.ConformanceExitOK,
+				Probes: []containmentExpectProbe{
+					{Probe: 8, Name: "cc_agent_egress_denied", Status: "pass"},
+					{Probe: 9, Name: "operator_egress_reachable", Status: "maybe"},
+				},
+			},
+			wantErr: "want pass/fail/skip",
+		},
+		{
+			name: "unexpected exit code",
+			expect: containmentExpectFixture{
+				ExitCode: 99,
+				Probes: []containmentExpectProbe{
+					{Probe: 8, Name: "cc_agent_egress_denied", Status: "pass"},
+					{Probe: 9, Name: "operator_egress_reachable", Status: "pass"},
+				},
+			},
+			wantErr: "want one of 0, 1, 2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateContainmentExpect(tc.expect)
+			if err == nil {
+				t.Fatalf("expected invalid expect fixture error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("invalid expect fixture error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestContainmentConformance_InvalidRunRulesFailClosed(t *testing.T) {
+	t.Parallel()
+
+	baseRuns := []containmentRunRule{
+		{Match: []string{"sudo", "pipelock-agent", "/usr/bin/curl"}, Stdout: "200", ExitCode: 0},
+		{Match: []string{"sudo", "operator", "/usr/bin/curl"}, Stdout: "200", ExitCode: 0},
+	}
+	tests := []struct {
+		name    string
+		runs    []containmentRunRule
+		wantErr string
+	}{
+		{
+			name: "missing operator rule",
+			runs: []containmentRunRule{
+				baseRuns[0],
+			},
+			wantErr: "no canned rule matched command line",
+		},
+		{
+			name: "ambiguous duplicate rule",
+			runs: []containmentRunRule{
+				baseRuns[0],
+				baseRuns[0],
+				baseRuns[1],
+			},
+			wantErr: "ambiguous canned rules matched command line",
+		},
+		{
+			name: "unused stale rule",
+			runs: []containmentRunRule{
+				baseRuns[0],
+				baseRuns[1],
+				{Match: []string{"never-used-command"}, Stdout: "200", ExitCode: 0},
+			},
+			wantErr: "unused canned rule",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runner := newAuditedCannedRunner(containmentProbeFixture{
+				AgentUser:    "pipelock-agent",
+				OperatorUser: "operator",
+				Runs:         tc.runs,
+			})
+			_, _, err := contain.RunContainmentConformance(context.Background(), contain.ConformanceEnv{
+				RunCommand:   runner.Run,
+				AgentUser:    "pipelock-agent",
+				OperatorUser: "operator",
+			})
+			if err != nil {
+				t.Fatalf("RunContainmentConformance returned unexpected setup error: %v", err)
+			}
+			err = runner.validate()
+			if err == nil {
+				t.Fatalf("expected invalid rule set error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("invalid rule set error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 // discoverContainmentFixtures lists fixture base names (those with both a
 // .probe.json and a .expect.json) under the fixture directory.
 func discoverContainmentFixtures(t *testing.T) []string {
@@ -278,17 +513,29 @@ func discoverContainmentFixtures(t *testing.T) []string {
 		t.Fatalf("read fixture dir %s: %v", containmentFixtureDir, err)
 	}
 	var names []string
+	probes := map[string]struct{}{}
+	expects := map[string]struct{}{}
 	for _, e := range entries {
 		n := e.Name()
-		if !strings.HasSuffix(n, ".probe.json") {
+		switch {
+		case strings.HasSuffix(n, ".probe.json"):
+			base := strings.TrimSuffix(n, ".probe.json")
+			probes[base] = struct{}{}
+			expectPath := filepath.Join(containmentFixtureDir, base+".expect.json")
+			if _, err := os.Stat(expectPath); err != nil {
+				t.Fatalf("fixture %s has no matching .expect.json (%s): %v", base, expectPath, err)
+			}
+			names = append(names, base)
+		case strings.HasSuffix(n, ".expect.json"):
+			expects[strings.TrimSuffix(n, ".expect.json")] = struct{}{}
+		default:
 			continue
 		}
-		base := strings.TrimSuffix(n, ".probe.json")
-		expectPath := filepath.Join(containmentFixtureDir, base+".expect.json")
-		if _, err := os.Stat(expectPath); err != nil {
-			t.Fatalf("fixture %s has no matching .expect.json (%s): %v", base, expectPath, err)
+	}
+	for base := range expects {
+		if _, ok := probes[base]; !ok {
+			t.Fatalf("expect fixture %s.expect.json has no matching .probe.json", base)
 		}
-		names = append(names, base)
 	}
 	return names
 }

--- a/sdk/conformance/containment_conformance_test.go
+++ b/sdk/conformance/containment_conformance_test.go
@@ -76,6 +76,15 @@ func loadContainmentProbe(t *testing.T, path string) containmentProbeFixture {
 	if len(fx.Runs) == 0 {
 		t.Fatalf("probe fixture %s has no runs (fail-closed: refusing to drive an empty runner)", path)
 	}
+	// A run rule with no match substrings matches every command (allSubstringsPresent
+	// returns true for an empty needle set), which would let the first such rule
+	// swallow every probe invocation and misattribute its canned response. Reject it
+	// at load so a malformed fixture fails loud instead of silently shadowing later rules.
+	for i, rule := range fx.Runs {
+		if len(rule.Match) == 0 {
+			t.Fatalf("probe fixture %s: runs[%d] has an empty match (would match every command)", path, i)
+		}
+	}
 	return fx
 }
 

--- a/sdk/conformance/containment_conformance_test.go
+++ b/sdk/conformance/containment_conformance_test.go
@@ -1,0 +1,285 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// DESIGN NOTE: This test drives pipelock's direct-egress containment probes
+// (probe 8: pipelock-agent egress denied; probe 9: operator egress reachable)
+// as a publishable conformance artifact. Rather than exporting the unexported
+// probe/probeEnv internals from internal/cli/contain (which carry real
+// sudo/curl/nft execution seams we must not widen for a test artifact), the
+// contain package exposes ONE minimal entry point —
+// contain.RunContainmentConformance(ctx, contain.ConformanceEnv{...}) — that
+// runs those two probes against an injected canned command-runner and returns
+// exported result records plus the aggregate exit code. This test builds that
+// canned runner from external JSON fixtures under testdata/containment/ and
+// asserts per-probe status + overall exit code against each fixture's
+// .expect.json. The must-fail "leaky-egress" fixture proves the egress-denied
+// test is real: if probe 8 ever stops failing when the agent reaches the
+// internet directly, this test fails.
+
+package conformance_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cli/contain"
+)
+
+const containmentFixtureDir = "testdata/containment"
+
+// containmentRunRule is one canned command-match rule from a *.probe.json
+// fixture: when the joined command line contains every Match substring, the
+// runner returns Stdout + ExitCode.
+type containmentRunRule struct {
+	Match    []string `json:"match"`
+	Stdout   string   `json:"stdout"`
+	ExitCode int      `json:"exit_code"`
+}
+
+// containmentProbeFixture is the parsed *.probe.json input.
+type containmentProbeFixture struct {
+	AgentUser    string               `json:"agent_user"`
+	OperatorUser string               `json:"operator_user"`
+	Runs         []containmentRunRule `json:"runs"`
+}
+
+// containmentExpectProbe is one expected per-probe outcome.
+type containmentExpectProbe struct {
+	Probe  int    `json:"probe"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// containmentExpectFixture is the parsed *.expect.json input.
+type containmentExpectFixture struct {
+	ExitCode int                      `json:"exit_code"`
+	Probes   []containmentExpectProbe `json:"probes"`
+}
+
+// loadContainmentProbe reads and parses a *.probe.json fixture. Fail-closed:
+// any read/parse error or an empty run set fails the test rather than driving
+// an under-specified runner.
+func loadContainmentProbe(t *testing.T, path string) containmentProbeFixture {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read probe fixture %s: %v", path, err)
+	}
+	var fx containmentProbeFixture
+	if err := json.Unmarshal(data, &fx); err != nil {
+		t.Fatalf("parse probe fixture %s: %v", path, err)
+	}
+	if len(fx.Runs) == 0 {
+		t.Fatalf("probe fixture %s has no runs (fail-closed: refusing to drive an empty runner)", path)
+	}
+	return fx
+}
+
+// loadContainmentExpect reads and parses a *.expect.json fixture. Fail-closed:
+// any read/parse error or an empty probe set fails the test.
+func loadContainmentExpect(t *testing.T, path string) containmentExpectFixture {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read expect fixture %s: %v", path, err)
+	}
+	var fx containmentExpectFixture
+	if err := json.Unmarshal(data, &fx); err != nil {
+		t.Fatalf("parse expect fixture %s: %v", path, err)
+	}
+	if len(fx.Probes) == 0 {
+		t.Fatalf("expect fixture %s lists no probes", path)
+	}
+	return fx
+}
+
+// cannedRunner builds the injected command runner from a fixture's run rules.
+// It returns a non-nil error when no rule matches so a fixture that forgets a
+// rule fails loud (the probe surfaces that as skip, which the gate treats as a
+// non-pass) rather than silently passing.
+func cannedRunner(fx containmentProbeFixture) contain.ConformanceRunCommand {
+	return func(_ context.Context, name string, args ...string) (string, int, error) {
+		joined := name + " " + strings.Join(args, " ")
+		for _, rule := range fx.Runs {
+			if allSubstringsPresent(joined, rule.Match) {
+				return rule.Stdout, rule.ExitCode, nil
+			}
+		}
+		return "", -1, errNoMatchingRule(joined)
+	}
+}
+
+func allSubstringsPresent(haystack string, needles []string) bool {
+	for _, n := range needles {
+		if !strings.Contains(haystack, n) {
+			return false
+		}
+	}
+	return true
+}
+
+type noMatchingRuleError string
+
+func (e noMatchingRuleError) Error() string {
+	return "no canned rule matched command line: " + string(e)
+}
+
+func errNoMatchingRule(cmdline string) error { return noMatchingRuleError(cmdline) }
+
+// runContainmentFixture loads a fixture pair, drives the containment probes
+// through the exported seam, and returns the results plus exit code.
+func runContainmentFixture(t *testing.T, name string) ([]contain.ConformanceProbeResult, int) {
+	t.Helper()
+	probeFx := loadContainmentProbe(t, filepath.Join(containmentFixtureDir, name+".probe.json"))
+	env := contain.ConformanceEnv{
+		RunCommand:   cannedRunner(probeFx),
+		AgentUser:    probeFx.AgentUser,
+		OperatorUser: probeFx.OperatorUser,
+	}
+	results, exit, err := contain.RunContainmentConformance(context.Background(), env)
+	if err != nil {
+		t.Fatalf("RunContainmentConformance(%s): unexpected error: %v", name, err)
+	}
+	return results, exit
+}
+
+// assertMatchesExpect checks per-probe status and aggregate exit code against
+// the .expect.json contract.
+func assertMatchesExpect(t *testing.T, name string, results []contain.ConformanceProbeResult, exit int) {
+	t.Helper()
+	expect := loadContainmentExpect(t, filepath.Join(containmentFixtureDir, name+".expect.json"))
+
+	if exit != expect.ExitCode {
+		t.Errorf("%s: exit code = %d, want %d", name, exit, expect.ExitCode)
+	}
+	if len(results) != len(expect.Probes) {
+		t.Fatalf("%s: got %d probe results, want %d", name, len(results), len(expect.Probes))
+	}
+	byProbe := make(map[int]contain.ConformanceProbeResult, len(results))
+	for _, r := range results {
+		byProbe[r.Probe] = r
+	}
+	for _, want := range expect.Probes {
+		got, ok := byProbe[want.Probe]
+		if !ok {
+			t.Errorf("%s: probe %d missing from results", name, want.Probe)
+			continue
+		}
+		if got.Name != want.Name {
+			t.Errorf("%s: probe %d name = %q, want %q", name, want.Probe, got.Name, want.Name)
+		}
+		if got.Status != want.Status {
+			t.Errorf("%s: probe %d status = %q, want %q (detail: %s)", name, want.Probe, got.Status, want.Status, got.Detail)
+		}
+	}
+}
+
+// TestContainmentConformance drives every containment fixture pair under
+// testdata/containment/ and asserts it matches its .expect.json.
+func TestContainmentConformance(t *testing.T) {
+	t.Parallel()
+
+	fixtures := discoverContainmentFixtures(t)
+	if len(fixtures) == 0 {
+		t.Fatalf("no containment fixtures discovered under %s (fail-closed: empty corpus is never a pass)", containmentFixtureDir)
+	}
+
+	for _, name := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			results, exit := runContainmentFixture(t, name)
+			assertMatchesExpect(t, name, results, exit)
+		})
+	}
+}
+
+// TestContainmentConformance_LeakyEgressMustFail is the regression assertion:
+// when the agent's direct-egress canary succeeds (curl exit 0), probe 8 MUST
+// report fail and the aggregate MUST be a non-zero exit. If this property ever
+// regresses, the egress-denied test is not real and CI must go red here.
+func TestContainmentConformance_LeakyEgressMustFail(t *testing.T) {
+	t.Parallel()
+
+	results, exit := runContainmentFixture(t, "leaky-egress")
+
+	if exit == contain.ConformanceExitOK {
+		t.Fatalf("leaky-egress: aggregate exit = 0 (pass), but a leaked agent egress MUST fail the gate")
+	}
+	if exit != contain.ConformanceExitFail {
+		t.Errorf("leaky-egress: aggregate exit = %d, want %d (fail)", exit, contain.ConformanceExitFail)
+	}
+
+	var probe8 contain.ConformanceProbeResult
+	var found bool
+	for _, r := range results {
+		if r.Probe == 8 {
+			probe8 = r
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("leaky-egress: probe 8 missing from results")
+	}
+	if probe8.Status != contain.ConformanceStatusFail {
+		t.Errorf("leaky-egress: probe 8 status = %q, want %q — agent egress leak was not detected", probe8.Status, contain.ConformanceStatusFail)
+	}
+}
+
+// TestContainmentConformance_PassAllIsClean asserts the clean baseline reports
+// every probe pass with a 0 exit. A gate where the clean fixture cannot pass is
+// as broken as one where the leaky fixture cannot fail.
+func TestContainmentConformance_PassAllIsClean(t *testing.T) {
+	t.Parallel()
+
+	results, exit := runContainmentFixture(t, "pass-all")
+	if exit != contain.ConformanceExitOK {
+		t.Errorf("pass-all: aggregate exit = %d, want 0", exit)
+	}
+	for _, r := range results {
+		if r.Status != contain.ConformanceStatusPass {
+			t.Errorf("pass-all: probe %d (%s) status = %q, want pass (detail: %s)", r.Probe, r.Name, r.Status, r.Detail)
+		}
+	}
+}
+
+// TestContainmentConformance_NilRunnerFailsClosed asserts a misconfigured env
+// (no runner) returns an error and a non-OK exit rather than silently passing.
+func TestContainmentConformance_NilRunnerFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	results, exit, err := contain.RunContainmentConformance(context.Background(), contain.ConformanceEnv{})
+	if err == nil {
+		t.Fatalf("nil runner: expected error, got nil (exit=%d, results=%v)", exit, results)
+	}
+	if exit == contain.ConformanceExitOK {
+		t.Errorf("nil runner: exit = 0 (pass), want non-zero fail-closed exit")
+	}
+}
+
+// discoverContainmentFixtures lists fixture base names (those with both a
+// .probe.json and a .expect.json) under the fixture directory.
+func discoverContainmentFixtures(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(containmentFixtureDir)
+	if err != nil {
+		t.Fatalf("read fixture dir %s: %v", containmentFixtureDir, err)
+	}
+	var names []string
+	for _, e := range entries {
+		n := e.Name()
+		if !strings.HasSuffix(n, ".probe.json") {
+			continue
+		}
+		base := strings.TrimSuffix(n, ".probe.json")
+		expectPath := filepath.Join(containmentFixtureDir, base+".expect.json")
+		if _, err := os.Stat(expectPath); err != nil {
+			t.Fatalf("fixture %s has no matching .expect.json (%s): %v", base, expectPath, err)
+		}
+		names = append(names, base)
+	}
+	return names
+}

--- a/sdk/conformance/testdata/containment/README.md
+++ b/sdk/conformance/testdata/containment/README.md
@@ -57,12 +57,15 @@ Each fixture is a pair:
 }
 ```
 
-`runs` is an ordered list of command-match rules. When a probe invokes the
-runner with `(name, args...)`, the harness joins `name` + all `args` into one
-string and picks the FIRST rule whose every `match` substring is present. That
-rule's `stdout` and `exit_code` are returned to the probe. If no rule matches,
-the runner returns a non-nil error (which the probe surfaces as `skip`) — a
-fixture that forgets a rule fails loud rather than silently passing.
+`runs` is a list of command-match rules. When a probe invokes the runner with
+`(name, args...)`, the harness joins `name` + all `args` into one string and
+selects the rule whose every `match` substring is present. Matching is audited:
+each command line must match EXACTLY ONE rule. Zero matches (the runner returns
+a non-nil error the probe surfaces as `skip`), more than one matching rule
+(ambiguous), or a rule never used by any probe all fail the test loud, so a
+fixture cannot be blessed by a matching expectation through a broad, duplicate,
+or dead rule. The selected rule's `stdout` and `exit_code` are returned to the
+probe.
 
 - `match`: substrings that ALL must appear in the joined command line. Use the
   agent vs operator username to disambiguate probe 8 from probe 9 (both shell

--- a/sdk/conformance/testdata/containment/README.md
+++ b/sdk/conformance/testdata/containment/README.md
@@ -1,0 +1,99 @@
+<!--
+Copyright 2026 Josh Waldrep
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Containment conformance fixtures
+
+These fixtures package pipelock's workstation-containment direct-egress probes
+(`pipelock contain verify`, probe 8 and probe 9) as a publishable conformance
+artifact. They prove that the **egress-denied** test is real: a fixture in which
+the agent's direct-egress canary succeeds (containment broken) MUST make the
+gate fail.
+
+The two probes under test:
+
+- **Probe 8 — `cc_agent_egress_denied`**: the unprivileged agent user
+  (`pipelock-agent`) must NOT reach the internet directly. The probe runs a
+  `curl --noproxy * https://example.com/` canary as the agent user. If curl
+  exits 0 (egress succeeded), containment is BROKEN → `fail`. If curl exits
+  non-zero (blocked), containment is enforced → `pass`.
+- **Probe 9 — `operator_egress_reachable`**: the operator user must still reach
+  the internet (proves the containment rule is scoped to the agent, not a blanket
+  network outage). A 2xx/3xx HTTP code → `pass`.
+
+No real network, sudo, curl, or nftables is touched. The probes run against a
+**canned command runner** built from the fixture: every `(name, argv)` the probe
+would execute is matched to a pre-recorded `(stdout, exit_code)`.
+
+## File pairs
+
+Each fixture is a pair:
+
+- `<name>.probe.json` — the canned command-runner inputs.
+- `<name>.expect.json` — the expected per-probe status and the aggregate exit
+  code.
+
+| Fixture | Probe 8 | Overall exit | Role |
+|---|---|---|---|
+| `pass-all` | `pass` (egress blocked) | 0 | clean baseline — gate must PASS |
+| `leaky-egress` | `fail` (egress leaked) | 1 | **must-fail** — gate must DETECT |
+
+## `*.probe.json` schema
+
+```jsonc
+{
+  "description": "free text",
+  "agent_user": "pipelock-agent",   // optional; defaults to pipelock-agent
+  "operator_user": "operator",      // optional; empty => probe 9 runs curl directly
+  "runs": [
+    {
+      "comment": "free text (ignored by the loader)",
+      "match": ["sudo", "pipelock-agent", "/usr/bin/curl"],
+      "stdout": "200",
+      "exit_code": 0
+    }
+  ]
+}
+```
+
+`runs` is an ordered list of command-match rules. When a probe invokes the
+runner with `(name, args...)`, the harness joins `name` + all `args` into one
+string and picks the FIRST rule whose every `match` substring is present. That
+rule's `stdout` and `exit_code` are returned to the probe. If no rule matches,
+the runner returns a non-nil error (which the probe surfaces as `skip`) — a
+fixture that forgets a rule fails loud rather than silently passing.
+
+- `match`: substrings that ALL must appear in the joined command line. Use the
+  agent vs operator username to disambiguate probe 8 from probe 9 (both shell
+  out to the same `/usr/bin/curl`).
+- `stdout`: the merged stdout/stderr the probe sees. Probe 8 keys off the exit
+  code; probe 9 reads the trailing whitespace-separated token as the HTTP code.
+- `exit_code`: the process exit code. `0` means curl succeeded.
+
+## `*.expect.json` schema
+
+```jsonc
+{
+  "description": "free text",
+  "exit_code": 1,                   // aggregate: 0 pass, 1 any fail, 2 skip-only
+  "probes": [
+    { "probe": 8, "name": "cc_agent_egress_denied",   "status": "fail" },
+    { "probe": 9, "name": "operator_egress_reachable", "status": "pass" }
+  ]
+}
+```
+
+Status is one of `pass` / `fail` / `skip`. The aggregate `exit_code` follows the
+`fail > skip > pass` precedence the real `contain verify` uses: a single `fail`
+yields exit 1 regardless of how many probes passed — a broken boundary is never
+offset by green siblings.
+
+## How they run
+
+- Go: `go test -run TestContainmentConformance ./sdk/conformance/` loads each
+  pair, drives the probes through the exported
+  `contain.RunContainmentConformance` seam, and asserts status + exit code.
+- Gate: `sdk/conformance/containment-gate.sh` runs that test and additionally
+  asserts the must-fail property (flip `leaky-egress.expect.json` to expect a
+  pass and the gate fails).

--- a/sdk/conformance/testdata/containment/leaky-egress.expect.json
+++ b/sdk/conformance/testdata/containment/leaky-egress.expect.json
@@ -1,0 +1,8 @@
+{
+  "description": "Expected outcome when containment is broken (agent egress leaked). Probe 8 fails; overall exit is non-zero (1).",
+  "exit_code": 1,
+  "probes": [
+    { "probe": 8, "name": "cc_agent_egress_denied", "status": "fail" },
+    { "probe": 9, "name": "operator_egress_reachable", "status": "pass" }
+  ]
+}

--- a/sdk/conformance/testdata/containment/leaky-egress.probe.json
+++ b/sdk/conformance/testdata/containment/leaky-egress.probe.json
@@ -1,0 +1,19 @@
+{
+  "description": "Containment BROKEN: probe 8 (agent egress) SUCCEEDS — the agent reached example.com directly. This is the must-fail fixture: probe 8 must report 'fail' and the overall exit code must be non-zero. If this ever passes, the egress-denied test is not real.",
+  "agent_user": "pipelock-agent",
+  "operator_user": "operator",
+  "runs": [
+    {
+      "comment": "probe 8: agent egress canary LEAKS. curl succeeds (exit 0, HTTP 200) — direct egress was NOT contained.",
+      "match": ["sudo", "pipelock-agent", "/usr/bin/curl"],
+      "stdout": "200",
+      "exit_code": 0
+    },
+    {
+      "comment": "probe 9: operator egress canary still reaches example.com (unchanged).",
+      "match": ["sudo", "operator", "/usr/bin/curl"],
+      "stdout": "200",
+      "exit_code": 0
+    }
+  ]
+}

--- a/sdk/conformance/testdata/containment/pass-all.expect.json
+++ b/sdk/conformance/testdata/containment/pass-all.expect.json
@@ -1,0 +1,8 @@
+{
+  "description": "Expected outcome when containment is intact.",
+  "exit_code": 0,
+  "probes": [
+    { "probe": 8, "name": "cc_agent_egress_denied", "status": "pass" },
+    { "probe": 9, "name": "operator_egress_reachable", "status": "pass" }
+  ]
+}

--- a/sdk/conformance/testdata/containment/pass-all.probe.json
+++ b/sdk/conformance/testdata/containment/pass-all.probe.json
@@ -1,0 +1,19 @@
+{
+  "description": "Containment intact: probe 8 (agent egress) is BLOCKED, probe 9 (operator egress) reaches example.com. This is the clean baseline the gate must PASS.",
+  "agent_user": "pipelock-agent",
+  "operator_user": "operator",
+  "runs": [
+    {
+      "comment": "probe 8: agent egress canary. curl is BLOCKED, returns non-zero exit (containment enforced).",
+      "match": ["sudo", "pipelock-agent", "/usr/bin/curl"],
+      "stdout": "curl: (7) Failed to connect to example.com port 443: Connection refused",
+      "exit_code": 7
+    },
+    {
+      "comment": "probe 9: operator egress canary. curl succeeds, prints HTTP 200.",
+      "match": ["sudo", "operator", "/usr/bin/curl"],
+      "stdout": "200",
+      "exit_code": 0
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

Packages pipelock's `contain verify` direct-egress probes as a publishable, fully offline conformance artifact under `sdk/conformance/`, so anyone can verify the containment claim without a live network, sudo, or the proxy running.

- New minimal exported seam `contain.RunContainmentConformance`. It runs exactly the two direct-egress probes (contained agent must not reach the internet; operator must still reach it) against an injected command runner. It does not widen the real sudo/curl/nft execution seams, and zeroes every field those two probes do not consult, so a fixture cannot reach a filesystem/dialer/hasher path.
- Ships JSON probe/expect fixtures, a Go conformance test, `containment-gate.sh`, and a `containment-conformance` CI job.
- Ships a deliberately-leaky must-fail fixture. A leaked agent egress is detected as a failure, and the gate proves the property by mutation: rewriting the expectation to "pass" must trip the test, and the gate asserts the specific leaky-egress mismatch rather than accepting any failure.
- The fixture harness fails loud on malformed input: audited rule matching (zero, ambiguous, or unused rules all error) and a strict expectation schema (exactly the two probes, canonical names and statuses, unique, valid aggregate exit code).

Aggregate exit follows the real `contain verify` fail > skip > pass precedence: a single failed probe yields a non-zero exit regardless of how many passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added containment direct-egress conformance testing for the key agent/operator probes (with offline fixture-driven verification).

* **Testing**
  * Introduced a Go conformance test harness plus fail-closed scenarios and runner validation.
  * Added an offline conformance gate script that confirms both expected pass and must-fail behavior.

* **Documentation**
  * Documented the containment conformance artifact, including fixture pair formats and expected exit-code/status precedence.

* **Chores**
  * Updated CI to run the new containment-conformance gate when relevant containment changes occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->