### PR TITLE
feat(license): gate CLI issuance on paid capability + signed service import table

### DIFF
--- a/cmd/license-service/admin.go
+++ b/cmd/license-service/admin.go
@@ -6,10 +6,15 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/licenseservice"
@@ -21,8 +26,10 @@ import (
 // mutate revocation / high-water state without bringing up the HTTP server, so
 // an operator can run them as one-shot jobs against the live database.
 var adminSubcommands = map[string]bool{
-	"revoke-intermediate":    true,
-	"recover-crl-generation": true,
+	"revoke-intermediate":     true,
+	"recover-crl-generation":  true,
+	"import-issuance":         true,
+	"list-imported-issuances": true,
 }
 
 // dispatchAdmin runs an admin subcommand if os.Args names one, returning
@@ -39,6 +46,10 @@ func dispatchAdmin(log zerolog.Logger) (bool, error) {
 		return true, runRevokeIntermediate(log, args)
 	case "recover-crl-generation":
 		return true, runRecoverCRLGeneration(log, args)
+	case "import-issuance":
+		return true, runImportIssuance(log, args)
+	case "list-imported-issuances":
+		return true, runListImportedIssuances(log, args)
 	default:
 		return true, fmt.Errorf("unknown admin subcommand %q", sub)
 	}
@@ -131,4 +142,150 @@ func runRecoverCRLGeneration(log zerolog.Logger, args []string) error {
 	}
 	log.Info().Uint64("generation", recovered).Msg("CRL generation high-water recovered; next CRL will be strictly higher")
 	return nil
+}
+
+// runImportIssuance imports a SIGNED issuance export (produced by
+// `pipelock license issue --break-glass --export`) into the durable signed
+// import table, making an externally-minted paid token revocable. It verifies
+// the export's Ed25519 signature against the operator-supplied issuer public key
+// (the key that minted the break-glass token) and fails closed on a bad
+// signature, key-id mismatch, or malformed export. Replaying the identical
+// export is an idempotent no-op; a conflicting import (a unique-key collision
+// with a different record) is rejected.
+func runImportIssuance(log zerolog.Logger, args []string) error {
+	fs := flag.NewFlagSet("import-issuance", flag.ContinueOnError)
+	exportPath := fs.String("export", "", "path to the signed issuance export file (required)")
+	issuerKey := fs.String("issuer-pubkey", "", "issuer public key that signed the export: hex string or path to a .pub file (required)")
+	importID := fs.String("import-id", "", "unique import id (default: a random imp_ id)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *exportPath == "" {
+		return errors.New("--export is required")
+	}
+	if *issuerKey == "" {
+		return errors.New("--issuer-pubkey is required")
+	}
+	issuerPub, err := loadIssuerPublicKey(*issuerKey)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(filepath.Clean(*exportPath)) // #nosec G304 -- operator-supplied admin path
+	if err != nil {
+		return fmt.Errorf("read export %s: %w", *exportPath, err)
+	}
+	id := *importID
+	if id == "" {
+		id, err = randomImportID()
+		if err != nil {
+			return err
+		}
+	}
+
+	ctx := context.Background()
+	handler, cleanup, err := adminHandler(ctx, log)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	payload, outcome, importErr := handler.ImportSignedIssuance(ctx, data, issuerPub, id, time.Now())
+	switch outcome {
+	case licenseservice.ImportOutcomeImported:
+		log.Info().
+			Str("license_id", payload.LicenseID).
+			Str("import_id", id).
+			Msg("issuance imported; token is now revocable via the CRL")
+		return nil
+	case licenseservice.ImportOutcomeReplay:
+		log.Info().
+			Str("license_id", payload.LicenseID).
+			Str("import_id", id).
+			Msg("issuance already imported (idempotent no-op)")
+		return nil
+	case licenseservice.ImportOutcomeConflict:
+		// Rejected, fail closed. Surface as an error so the operator sees a
+		// non-zero exit and does not assume the token was recorded.
+		return fmt.Errorf("import rejected: %w", importErr)
+	default:
+		return fmt.Errorf("import issuance: %w", importErr)
+	}
+}
+
+// runListImportedIssuances prints every externally-minted issuance recorded in
+// the import table so an operator can SEE the revocation surface, not just the
+// Go methods. Output is one line per record with the load-bearing fields.
+func runListImportedIssuances(log zerolog.Logger, args []string) error {
+	fs := flag.NewFlagSet("list-imported-issuances", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	ctx := context.Background()
+	handler, cleanup, err := adminHandler(ctx, log)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	records, err := handler.ListImportedIssuances(ctx)
+	if err != nil {
+		return fmt.Errorf("list imported issuances: %w", err)
+	}
+	if len(records) == 0 {
+		_, _ = fmt.Fprintln(os.Stdout, "no imported issuances")
+		return nil
+	}
+	for _, r := range records {
+		expires := "never"
+		if r.ExpiresAt != nil {
+			expires = r.ExpiresAt.UTC().Format(time.RFC3339)
+		}
+		_, _ = fmt.Fprintf(os.Stdout,
+			"license_id=%s import_id=%s issuer_key_id=%s sub=%s issued=%s expires=%s token_sha256=%s imported=%s\n",
+			r.LicenseID, r.ImportID, r.IssuerKeyID, r.SubscriptionID,
+			r.IssuedAt.UTC().Format(time.RFC3339), expires, r.TokenSHA256,
+			r.ImportedAt.UTC().Format(time.RFC3339))
+	}
+	return nil
+}
+
+// loadIssuerPublicKey resolves the issuer public key from either a hex string
+// (64 hex chars = 32-byte Ed25519 key) or a path to a .pub file containing the
+// hex-encoded key. Fails closed on any malformed input.
+func loadIssuerPublicKey(spec string) (ed25519.PublicKey, error) {
+	raw := strings.TrimSpace(spec)
+	// Treat it as a hex key first; if that fails and it looks like a path, read
+	// the file and try again.
+	if key, err := decodeEd25519PublicHex(raw); err == nil {
+		return key, nil
+	}
+	data, readErr := os.ReadFile(filepath.Clean(raw)) // #nosec G304 -- operator-supplied admin path
+	if readErr != nil {
+		return nil, fmt.Errorf("issuer-pubkey is neither a valid hex key nor a readable file: %w", readErr)
+	}
+	key, err := decodeEd25519PublicHex(strings.TrimSpace(string(data)))
+	if err != nil {
+		return nil, fmt.Errorf("issuer-pubkey file %s does not contain a valid hex Ed25519 public key: %w", raw, err)
+	}
+	return key, nil
+}
+
+func decodeEd25519PublicHex(s string) (ed25519.PublicKey, error) {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("expected %d-byte Ed25519 public key, got %d bytes", ed25519.PublicKeySize, len(b))
+	}
+	return ed25519.PublicKey(b), nil
+}
+
+// randomImportID generates a unique import id (imp_ + 12 hex chars).
+func randomImportID() (string, error) {
+	idBytes := make([]byte, 6)
+	if _, err := rand.Read(idBytes); err != nil {
+		return "", fmt.Errorf("generate import id: %w", err)
+	}
+	return "imp_" + hex.EncodeToString(idBytes), nil
 }

--- a/cmd/license-service/admin.go
+++ b/cmd/license-service/admin.go
@@ -27,6 +27,7 @@ import (
 // an operator can run them as one-shot jobs against the live database.
 var adminSubcommands = map[string]bool{
 	"revoke-intermediate":     true,
+	"revoke-imported-license": true,
 	"recover-crl-generation":  true,
 	"import-issuance":         true,
 	"list-imported-issuances": true,
@@ -44,6 +45,8 @@ func dispatchAdmin(log zerolog.Logger) (bool, error) {
 	switch sub {
 	case "revoke-intermediate":
 		return true, runRevokeIntermediate(log, args)
+	case "revoke-imported-license":
+		return true, runRevokeImportedLicense(log, args)
 	case "recover-crl-generation":
 		return true, runRecoverCRLGeneration(log, args)
 	case "import-issuance":
@@ -114,6 +117,29 @@ func runRevokeIntermediate(log zerolog.Logger, args []string) error {
 		return fmt.Errorf("revoke intermediate: %w", err)
 	}
 	log.Info().Str("serial", *serial).Str("reason", *reason).Msg("intermediate revoked; next published CRL will carry it")
+	return nil
+}
+
+func runRevokeImportedLicense(log zerolog.Logger, args []string) error {
+	fs := flag.NewFlagSet("revoke-imported-license", flag.ContinueOnError)
+	licenseID := fs.String("license-id", "", "imported break-glass license id to revoke (required)")
+	reason := fs.String("reason", "operator_revoked", "human-readable revocation reason")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *licenseID == "" {
+		return errors.New("--license-id is required")
+	}
+	ctx := context.Background()
+	handler, cleanup, err := adminHandler(ctx, log)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if err := handler.RevokeImportedIssuance(ctx, *licenseID, *reason, time.Now()); err != nil {
+		return fmt.Errorf("revoke imported license: %w", err)
+	}
+	log.Info().Str("license_id", *licenseID).Str("reason", *reason).Msg("imported license revoked; next published CRL will carry it")
 	return nil
 }
 

--- a/cmd/license-service/admin_import_test.go
+++ b/cmd/license-service/admin_import_test.go
@@ -1,0 +1,254 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// writeBreakGlassExport mints a token with the service token key and writes a
+// signed issuance export for it. Returns the export path, the signer public key
+// hex, and the full token hash.
+func writeBreakGlassExport(t *testing.T, tokenKeyPath string, lic license.License) (exportPath, pubHex, tokenHash string) {
+	t.Helper()
+	priv, err := signing.LoadPrivateKeyFile(tokenKeyPath)
+	if err != nil {
+		t.Fatalf("load token key: %v", err)
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	export, err := license.SignIssuanceExport(
+		license.BuildIssuanceExportFromToken(token, lic, "", time.Now()), priv)
+	if err != nil {
+		t.Fatalf("sign export: %v", err)
+	}
+	data, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+	exportPath = filepath.Join(t.TempDir(), "export.json")
+	if err := os.WriteFile(exportPath, data, 0o600); err != nil {
+		t.Fatalf("write export: %v", err)
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		t.Fatal("priv has no public half")
+	}
+	return exportPath, hex.EncodeToString(pub), license.TokenSHA256Hex(token)
+}
+
+func importBreakGlassLicense() license.License {
+	now := time.Now()
+	return license.License{
+		ID:             "lic_cmd_break_glass",
+		Email:          "ops@vendor.example",
+		Org:            "Vendor Example",
+		IssuedAt:       now.Unix(),
+		ExpiresAt:      now.Add(365 * 24 * time.Hour).Unix(),
+		Features:       []string{license.FeatureFleet},
+		Tier:           "enterprise",
+		SubscriptionID: "sub_cmd_break_glass",
+	}
+}
+
+func TestRunImportIssuance_HappyPath(t *testing.T) {
+	tokenKeyPath, _, _ := setAdminEnv(t)
+	lic := importBreakGlassLicense()
+	exportPath, pubHex, tokenHash := writeBreakGlassExport(t, tokenKeyPath, lic)
+
+	if err := runImportIssuance(discardLog(), []string{
+		"--export", exportPath,
+		"--issuer-pubkey", pubHex,
+		"--import-id", "imp_cmd_1",
+	}); err != nil {
+		t.Fatalf("runImportIssuance: %v", err)
+	}
+
+	// Reopen and confirm the record persisted with the full token hash.
+	handler, cleanup, err := adminHandler(context.Background(), discardLog())
+	if err != nil {
+		t.Fatalf("adminHandler: %v", err)
+	}
+	defer cleanup()
+	got, err := handler.GetImportedIssuance(context.Background(), lic.ID)
+	if err != nil || got == nil {
+		t.Fatalf("get: %v %v", got, err)
+	}
+	if got.TokenSHA256 != tokenHash {
+		t.Fatal("imported record does not bind the full token hash")
+	}
+}
+
+func TestRunImportIssuance_PubkeyFromFile(t *testing.T) {
+	tokenKeyPath, _, _ := setAdminEnv(t)
+	lic := importBreakGlassLicense()
+	exportPath, pubHex, _ := writeBreakGlassExport(t, tokenKeyPath, lic)
+	pubPath := filepath.Join(t.TempDir(), "issuer.pub")
+	if err := os.WriteFile(pubPath, []byte(pubHex+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runImportIssuance(discardLog(), []string{
+		"--export", exportPath,
+		"--issuer-pubkey", pubPath, // path form, not hex
+	}); err != nil {
+		t.Fatalf("runImportIssuance (pubkey from file): %v", err)
+	}
+}
+
+func TestRunImportIssuance_ReplayNoError(t *testing.T) {
+	tokenKeyPath, _, _ := setAdminEnv(t)
+	exportPath, pubHex, _ := writeBreakGlassExport(t, tokenKeyPath, importBreakGlassLicense())
+	args := []string{"--export", exportPath, "--issuer-pubkey", pubHex, "--import-id", "imp_replay"}
+	if err := runImportIssuance(discardLog(), args); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	// Identical replay: idempotent no-op, no error.
+	if err := runImportIssuance(discardLog(), args); err != nil {
+		t.Fatalf("replay should not error: %v", err)
+	}
+}
+
+func TestRunImportIssuance_ConflictErrors(t *testing.T) {
+	tokenKeyPath, _, _ := setAdminEnv(t)
+	lic := importBreakGlassLicense()
+	exportPath, pubHex, _ := writeBreakGlassExport(t, tokenKeyPath, lic)
+	if err := runImportIssuance(discardLog(), []string{
+		"--export", exportPath, "--issuer-pubkey", pubHex, "--import-id", "imp_a",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Same license id, different token (changed email) => conflict, non-nil error.
+	conflicting := lic
+	conflicting.Email = "different@vendor.example"
+	conflictExport, _, _ := writeBreakGlassExport(t, tokenKeyPath, conflicting)
+	err := runImportIssuance(discardLog(), []string{
+		"--export", conflictExport, "--issuer-pubkey", pubHex, "--import-id", "imp_b",
+	})
+	if err == nil || !strings.Contains(err.Error(), "rejected") {
+		t.Fatalf("expected conflict rejection error, got %v", err)
+	}
+}
+
+func TestRunImportIssuance_BadSignatureRejected(t *testing.T) {
+	tokenKeyPath, _, _ := setAdminEnv(t)
+	exportPath, _, _ := writeBreakGlassExport(t, tokenKeyPath, importBreakGlassLicense())
+	// Supply a WRONG issuer pubkey (a fresh key the export was not signed with).
+	otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	importErr := runImportIssuance(discardLog(), []string{
+		"--export", exportPath,
+		"--issuer-pubkey", hex.EncodeToString(otherPub),
+	})
+	if importErr == nil {
+		t.Fatal("expected bad-signature import to fail closed")
+	}
+}
+
+func TestRunImportIssuance_MissingFlags(t *testing.T) {
+	setAdminEnv(t)
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"missing export", []string{"--issuer-pubkey", strings.Repeat("a", 64)}},
+		{"missing pubkey", []string{"--export", "x.json"}},
+		{"bad pubkey", []string{"--export", "x.json", "--issuer-pubkey", "not-a-key"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := runImportIssuance(discardLog(), tc.args); err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestRunImportIssuance_MissingExportFile(t *testing.T) {
+	setAdminEnv(t)
+	err := runImportIssuance(discardLog(), []string{
+		"--export", filepath.Join(t.TempDir(), "nope.json"),
+		"--issuer-pubkey", strings.Repeat("a", 64),
+	})
+	if err == nil || !strings.Contains(err.Error(), "read export") {
+		t.Fatalf("expected read-export error, got %v", err)
+	}
+}
+
+func TestRunListImportedIssuances(t *testing.T) {
+	tokenKeyPath, _, _ := setAdminEnv(t)
+	// Empty first.
+	if err := runListImportedIssuances(discardLog(), nil); err != nil {
+		t.Fatalf("list (empty): %v", err)
+	}
+	// Import one, then list.
+	exportPath, pubHex, _ := writeBreakGlassExport(t, tokenKeyPath, importBreakGlassLicense())
+	if err := runImportIssuance(discardLog(), []string{
+		"--export", exportPath, "--issuer-pubkey", pubHex, "--import-id", "imp_list",
+	}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if err := runListImportedIssuances(discardLog(), nil); err != nil {
+		t.Fatalf("list (populated): %v", err)
+	}
+}
+
+func TestLoadIssuerPublicKey(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubHex := hex.EncodeToString(pub)
+
+	t.Run("hex", func(t *testing.T) {
+		got, err := loadIssuerPublicKey(pubHex)
+		if err != nil || !got.Equal(pub) {
+			t.Fatalf("hex load: %v", err)
+		}
+	})
+	t.Run("file", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "k.pub")
+		if err := os.WriteFile(p, []byte("  "+pubHex+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := loadIssuerPublicKey(p)
+		if err != nil || !got.Equal(pub) {
+			t.Fatalf("file load: %v", err)
+		}
+	})
+	t.Run("garbage", func(t *testing.T) {
+		if _, err := loadIssuerPublicKey("not-hex-not-a-file"); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+	t.Run("wrong size hex", func(t *testing.T) {
+		if _, err := loadIssuerPublicKey("deadbeef"); err == nil {
+			t.Fatal("expected wrong-size rejection")
+		}
+	})
+}
+
+func TestDispatchAdmin_ImportSubcommandsRecognized(t *testing.T) {
+	for _, sub := range []string{"import-issuance", "list-imported-issuances"} {
+		if !adminSubcommands[sub] {
+			t.Fatalf("admin subcommand %q not registered", sub)
+		}
+	}
+}

--- a/cmd/license-service/admin_import_test.go
+++ b/cmd/license-service/admin_import_test.go
@@ -95,6 +95,39 @@ func TestRunImportIssuance_HappyPath(t *testing.T) {
 	}
 }
 
+func TestRunRevokeImportedLicense_PublishesInSignedCRL(t *testing.T) {
+	tokenKeyPath, _, _ := setAdminEnv(t)
+	lic := importBreakGlassLicense()
+	exportPath, pubHex, _ := writeBreakGlassExport(t, tokenKeyPath, lic)
+
+	if err := runImportIssuance(discardLog(), []string{
+		"--export", exportPath,
+		"--issuer-pubkey", pubHex,
+		"--import-id", "imp_cmd_revoke",
+	}); err != nil {
+		t.Fatalf("runImportIssuance: %v", err)
+	}
+	if err := runRevokeImportedLicense(discardLog(), []string{
+		"--license-id", lic.ID,
+		"--reason", "operator_test",
+	}); err != nil {
+		t.Fatalf("runRevokeImportedLicense: %v", err)
+	}
+
+	handler, cleanup, err := adminHandler(context.Background(), discardLog())
+	if err != nil {
+		t.Fatalf("adminHandler: %v", err)
+	}
+	defer cleanup()
+	crl, err := handler.SignedCRL(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("SignedCRL: %v", err)
+	}
+	if _, ok := crl.RevocationFor(lic.ID); !ok {
+		t.Fatalf("imported license %s missing from signed CRL", lic.ID)
+	}
+}
+
 func TestRunImportIssuance_PubkeyFromFile(t *testing.T) {
 	tokenKeyPath, _, _ := setAdminEnv(t)
 	lic := importBreakGlassLicense()
@@ -181,6 +214,16 @@ func TestRunImportIssuance_MissingFlags(t *testing.T) {
 	}
 }
 
+func TestRunRevokeImportedLicense_MissingOrUnknown(t *testing.T) {
+	setAdminEnv(t)
+	if err := runRevokeImportedLicense(discardLog(), nil); err == nil {
+		t.Fatal("missing --license-id must error")
+	}
+	if err := runRevokeImportedLicense(discardLog(), []string{"--license-id", "lic_missing"}); err == nil {
+		t.Fatal("unknown imported license must error")
+	}
+}
+
 func TestRunImportIssuance_MissingExportFile(t *testing.T) {
 	setAdminEnv(t)
 	err := runImportIssuance(discardLog(), []string{
@@ -246,7 +289,7 @@ func TestLoadIssuerPublicKey(t *testing.T) {
 }
 
 func TestDispatchAdmin_ImportSubcommandsRecognized(t *testing.T) {
-	for _, sub := range []string{"import-issuance", "list-imported-issuances"} {
+	for _, sub := range []string{"import-issuance", "list-imported-issuances", "revoke-imported-license"} {
 		if !adminSubcommands[sub] {
 			t.Fatalf("admin subcommand %q not registered", sub)
 		}

--- a/docs/cli/license.md
+++ b/docs/cli/license.md
@@ -167,7 +167,7 @@ directly, with or without an expiry.
 ### Break-glass (offline emergency signing)
 
 `--break-glass` preserves the offline emergency-signing capability the
-[key-custody runbook](license-intermediate-migration.md) depends on (e.g.
+[key-custody runbook](../guides/license-intermediate-migration.md) depends on (e.g.
 signing a replacement token directly from the offline root). To keep the token
 revocable, a break-glass paid mint **requires `--export <path>`**: it writes a
 **signed issuance export** that the license service imports into its durable

--- a/docs/cli/license.md
+++ b/docs/cli/license.md
@@ -173,9 +173,14 @@ revocable, a break-glass paid mint **requires `--export <path>`**: it writes a
 **signed issuance export** that the license service imports into its durable
 signed import table (keyed by license ID and the **full** token hash, with
 replay and conflict rejection). The local issuance ledger stores only a
-truncated, unsigned hash and **cannot** be the import source. Import the export
-into the service after the emergency so the break-glass token can be revoked like
-any other paid license.
+truncated, unsigned hash and **cannot** be the import source.
+
+Import the export into the service after the emergency so the break-glass token
+can be revoked like any other paid license — the service operator runs
+`license-service import-issuance --export <file> --issuer-pubkey <key>` and can
+review the import table with `license-service list-imported-issuances`. See the
+full issue → export → import → inspect flow in the
+[intermediate-key migration guide](../guides/license-intermediate-migration.md#break-glass-tokens-issue-offline-then-import-so-they-stay-revocable).
 
 ## `pipelock license intermediate issue`
 

--- a/docs/cli/license.md
+++ b/docs/cli/license.md
@@ -178,8 +178,11 @@ truncated, unsigned hash and **cannot** be the import source.
 Import the export into the service after the emergency so the break-glass token
 can be revoked like any other paid license — the service operator runs
 `license-service import-issuance --export <file> --issuer-pubkey <key>` and can
-review the import table with `license-service list-imported-issuances`. See the
-full issue → export → import → inspect flow in the
+review the import table with `license-service list-imported-issuances`. To
+revoke it later, run
+`license-service revoke-imported-license --license-id <license-id> --reason <reason>`;
+the next signed CRL carries that license ID. See the full issue → export →
+import → inspect → revoke flow in the
 [intermediate-key migration guide](../guides/license-intermediate-migration.md#break-glass-tokens-issue-offline-then-import-so-they-stay-revocable).
 
 ## `pipelock license intermediate issue`

--- a/docs/cli/license.md
+++ b/docs/cli/license.md
@@ -111,8 +111,15 @@ tokens against `PIPELOCK_LICENSE_PUBLIC_KEY`; official builds may embed the key.
 Sign a license token from a private key. Issuer-side.
 
 ```bash
+# Free token (no paid feature) — allowed directly:
+pipelock license issue --email customer@example.com --features "" \
+  --expires 2027-01-01
+
+# Paid token — minted by the license service in normal operation; the
+# standalone CLI requires --break-glass + --export (see the issuance gate):
 pipelock license issue --email customer@example.com --tier enterprise \
-  --features fleet --features agents --expires 2027-01-01
+  --features fleet --features agents --expires 2027-01-01 \
+  --break-glass --export break-glass-export.json
 ```
 
 | Flag | Default | Description |
@@ -121,15 +128,54 @@ pipelock license issue --email customer@example.com --tier enterprise \
 | `--email` | (required) | Customer email. |
 | `--org` | (none) | Organization name. |
 | `--expires` | (none, perpetual) | Expiration date, `YYYY-MM-DD`. Omit for no expiration. |
-| `--features` | `[agents]` | Feature list (repeat the flag for multiple). |
+| `--features` | `[agents]` | Feature list (repeat the flag for multiple). Pass `--features ""` for a featureless free token. |
 | `--ledger` | alongside the private key | Ledger file path. |
 | `--tier` | (none) | License tier (e.g. `pro`, `founding_pro`, `enterprise`). |
 | `--subscription-id` | (none) | External billing subscription ID. |
+| `--break-glass` | `false` | Override the issuance gate to mint a paid token offline (emergency only; requires `--export`). |
+| `--export` | (none) | Write a signed issuance export to this path so the service can import the break-glass token. |
 
 Prints the signed token and appends a truncated hash of it to the issuance
 ledger. The `--features` you sign decide what the token unlocks: `agents` for
 Pro, `fleet` for the Enterprise fleet control plane (see the
 [tier-gating audit matrix](../security/tier-gating-audit-matrix.md)).
+
+### Issuance gate (paid tokens must be revocable)
+
+A paid license is a *revocable* credential: the license service tracks every
+paid token it mints (in its database) so it can revoke a still-valid token via
+the signed CRL. A token minted by the standalone CLI is invisible to the service
+and therefore **cannot be revoked** — a popped signing host could mint perpetual
+paid tokens with no way to pull them back.
+
+To close that gap, `license issue` **refuses to mint a paid/revocable token**
+unless `--break-glass` is set. The gate keys on the *capability itself*, not on a
+label flag:
+
+- any non-free feature (every shipped feature — `agents`, `assess`, `fleet` — is
+  paid; the Free tier needs no license at all);
+- a non-empty `--tier`;
+- a non-empty `--subscription-id`;
+- a no-expiry (perpetual) token that carries any feature.
+
+Omitting `--tier`/`--subscription-id` does **not** slip a paid token past the
+gate — the feature alone trips it.
+
+A genuinely free token (no features, no tier, no subscription) is issued
+directly, with or without an expiry.
+
+### Break-glass (offline emergency signing)
+
+`--break-glass` preserves the offline emergency-signing capability the
+[key-custody runbook](license-intermediate-migration.md) depends on (e.g.
+signing a replacement token directly from the offline root). To keep the token
+revocable, a break-glass paid mint **requires `--export <path>`**: it writes a
+**signed issuance export** that the license service imports into its durable
+signed import table (keyed by license ID and the **full** token hash, with
+replay and conflict rejection). The local issuance ledger stores only a
+truncated, unsigned hash and **cannot** be the import source. Import the export
+into the service after the emergency so the break-glass token can be revoked like
+any other paid license.
 
 ## `pipelock license intermediate issue`
 

--- a/docs/guides/license-intermediate-migration.md
+++ b/docs/guides/license-intermediate-migration.md
@@ -185,7 +185,7 @@ token (any non-free feature, paid tier, subscription, or perpetual paid token)
 unless `--break-glass` is set — otherwise an offline mint would be invisible to
 revocation. See [`pipelock license issue`](../cli/license.md#pipelock-license-issue).
 
-The full operator flow — **issue → export → import → inspect**:
+The full operator flow — **issue → export → import → inspect → revoke**:
 
 ```bash
 # 1. ISSUE the break-glass token offline (e.g. from the offline root on the USB),
@@ -204,6 +204,11 @@ license-service import-issuance --export break-glass-export.json \
 
 # 3. INSPECT the import table to confirm the token is now in the revocation surface:
 license-service list-imported-issuances
+
+# 4. REVOKE the imported break-glass token if it must be pulled later. The next
+#    signed CRL carries the license ID:
+license-service revoke-imported-license --license-id lic_break_glass_123 \
+  --reason operator_revoked
 ```
 
 Import outcomes (also written to the audit ledger):
@@ -217,8 +222,8 @@ Import outcomes (also written to the audit ledger):
   never overwritten.
 
 A malformed, tampered, or wrong-key export **fails closed** — it never enters the
-import table. Revoke an imported break-glass token the same way as any other
-license (it appears in the published CRL once revoked).
+import table. Revoking an imported break-glass token writes a normal license
+revocation row, so it appears in the published CRL once revoked.
 
 ## Rollback
 

--- a/docs/guides/license-intermediate-migration.md
+++ b/docs/guides/license-intermediate-migration.md
@@ -176,6 +176,50 @@ generation (it never lowers it). The next published CRL is then strictly higher,
 so a consumer that accepted the old generation accepts the new one and the
 restore cannot un-revoke anything.
 
+## Break-glass tokens: issue offline, then import so they stay revocable
+
+A paid license is a **revocable** credential: the license service records every
+token it mints so it can later revoke a still-valid one via the signed CRL. The
+standalone `pipelock license issue` command refuses to mint a paid/revocable
+token (any non-free feature, paid tier, subscription, or perpetual paid token)
+unless `--break-glass` is set — otherwise an offline mint would be invisible to
+revocation. See [`pipelock license issue`](../cli/license.md#pipelock-license-issue).
+
+The full operator flow — **issue → export → import → inspect**:
+
+```bash
+# 1. ISSUE the break-glass token offline (e.g. from the offline root on the USB),
+#    emitting a SIGNED export alongside the token:
+pipelock license issue --key <offline-signing-key> \
+  --email customer@example.com --features fleet --tier enterprise \
+  --expires 2028-01-01 --break-glass --export break-glass-export.json
+
+# 2. IMPORT the export into the license service so the token becomes revocable.
+#    --issuer-pubkey is the PUBLIC half of the key that signed the token+export
+#    (hex string or a path to a .pub file). The service verifies the export's
+#    signature and the bound full token hash, then records it in the durable
+#    signed import table:
+license-service import-issuance --export break-glass-export.json \
+  --issuer-pubkey <signer-public-key-hex-or-path>
+
+# 3. INSPECT the import table to confirm the token is now in the revocation surface:
+license-service list-imported-issuances
+```
+
+Import outcomes (also written to the audit ledger):
+
+- **imported** — a new record was written; the token is now revocable.
+- **replay** — the identical export was already imported (idempotent no-op,
+  exit 0). Re-running the same import is safe.
+- **conflict** — the import collided with a *different* existing record on a
+  unique key (same license ID with a different token, a reused token hash, or a
+  reused import ID). This is **rejected** (non-zero exit); the existing record is
+  never overwritten.
+
+A malformed, tampered, or wrong-key export **fails closed** — it never enters the
+import table. Revoke an imported break-glass token the same way as any other
+license (it appears in the published CRL once revoked).
+
 ## Rollback
 
 Before step 6, rollback is just "set `license_require_intermediate` back to off /

--- a/enterprise/cli/license.go
+++ b/enterprise/cli/license.go
@@ -120,6 +120,8 @@ func licenseIssueCmd() *cobra.Command {
 		ledgerPath     string
 		tier           string
 		subscriptionID string
+		breakGlass     bool
+		exportPath     string
 	)
 
 	cmd := &cobra.Command{
@@ -136,13 +138,12 @@ func licenseIssueCmd() *cobra.Command {
 			if email == "" {
 				return fmt.Errorf("--email is required")
 			}
-			if len(features) == 0 {
+			// Drop empty feature entries (e.g. from `--features ""`) so a blank
+			// flag yields a genuinely featureless free token rather than a token
+			// carrying an empty-string "feature".
+			features = nonEmptyStrings(features)
+			if !cmd.Flags().Changed("features") {
 				features = []string{license.FeatureAgents}
-			}
-
-			priv, err := signing.LoadPrivateKeyFile(keyPath)
-			if err != nil {
-				return fmt.Errorf("load private key: %w", err)
 			}
 
 			var expiresAt int64
@@ -171,9 +172,44 @@ func licenseIssueCmd() *cobra.Command {
 				SubscriptionID: subscriptionID,
 			}
 
+			// ISSUANCE GATE. The standalone CLI must not mint a paid/revocable
+			// token the service cannot revoke. Gate on the CAPABILITY itself (any
+			// non-free feature, paid tier, subscription, or a no-expiry paid
+			// token), NOT on --tier/--subscription-id, which an issuer can omit.
+			// --break-glass is the audited offline emergency-signing escape the
+			// key-custody runbook depends on.
+			if reason, gated := paidIssuanceReason(lic); gated && !breakGlass {
+				return fmt.Errorf("refusing to issue a paid/revocable license from the standalone CLI: %s.\n"+
+					"Paid tokens must be minted by the license service so they land in the signed "+
+					"import table and can be revoked. For an offline emergency signing, re-run with "+
+					"--break-glass (audited) and import the emitted --export into the service",
+					reason)
+			}
+
+			priv, err := signing.LoadPrivateKeyFile(keyPath)
+			if err != nil {
+				return fmt.Errorf("load private key: %w", err)
+			}
+
 			token, err := license.Issue(lic, priv)
 			if err != nil {
 				return fmt.Errorf("issue license: %w", err)
+			}
+
+			// Break-glass paid issuance emits a SIGNED export so the service can
+			// import the token into its revocation surface. Refuse silent
+			// break-glass: an emergency paid mint that cannot be imported is a
+			// blind spot.
+			if breakGlass {
+				if reason, gated := paidIssuanceReason(lic); gated {
+					if exportPath == "" {
+						return fmt.Errorf("--break-glass minting a paid token (%s) requires --export "+
+							"<path> so the service can import it into the signed revocation table", reason)
+					}
+					if err := writeIssuanceExport(exportPath, token, lic, priv); err != nil {
+						return fmt.Errorf("write signed issuance export: %w", err)
+					}
+				}
 			}
 
 			// Append to ledger for tracking.
@@ -203,6 +239,9 @@ func licenseIssueCmd() *cobra.Command {
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Features: %v\n", lic.Features)
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Ledger:   %s\n", ledgerPath)
+			if breakGlass && exportPath != "" {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Export:   %s (break-glass; import into the license service)\n", exportPath)
+			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nToken (put this in license_key config field):\n%s\n", token)
 
 			return nil
@@ -217,7 +256,91 @@ func licenseIssueCmd() *cobra.Command {
 	cmd.Flags().StringVar(&ledgerPath, "ledger", "", "ledger file path (default: alongside private key)")
 	cmd.Flags().StringVar(&tier, "tier", "", "license tier (e.g. pro, founding_pro)")
 	cmd.Flags().StringVar(&subscriptionID, "subscription-id", "", "external billing subscription ID")
+	cmd.Flags().BoolVar(&breakGlass, "break-glass", false,
+		"override the issuance gate to mint a paid/revocable token offline (emergency only; requires --export)")
+	cmd.Flags().StringVar(&exportPath, "export", "",
+		"write a signed issuance export to this path (for importing a break-glass paid token into the license service)")
 	return cmd
+}
+
+// freeFeatures lists license features that do NOT require a paid subscription.
+// The Free tier needs no license at all, so this set is currently EMPTY: every
+// shipped feature (agents, assess, fleet) is a paid capability. The set exists
+// so a genuinely free feature, if one is ever introduced, can be issued by the
+// standalone CLI without break-glass.
+var freeFeatures = map[string]struct{}{}
+
+// paidIssuanceReason reports whether a license carries a paid/revocable
+// capability and, if so, a human-readable reason. It gates on the CAPABILITY
+// itself — never on the --tier/--subscription-id flags, which an issuer can omit
+// to slip a paid token past a label-based gate (the exact bypass class to
+// avoid). The checks, in order:
+//
+//   - any feature not in freeFeatures (all current features are paid);
+//   - a non-empty tier string;
+//   - a non-empty subscription id;
+//   - a token with NO expiry that still carries any paid marker (a perpetual
+//     paid token is the most dangerous to mint outside the revocation surface).
+func paidIssuanceReason(lic license.License) (string, bool) {
+	for _, f := range lic.Features {
+		if strings.TrimSpace(f) == "" {
+			continue // empty entry is not a capability
+		}
+		if _, free := freeFeatures[f]; !free {
+			return fmt.Sprintf("paid feature %q", f), true
+		}
+	}
+	if strings.TrimSpace(lic.Tier) != "" {
+		return fmt.Sprintf("paid tier %q", lic.Tier), true
+	}
+	if strings.TrimSpace(lic.SubscriptionID) != "" {
+		return fmt.Sprintf("subscription id %q", lic.SubscriptionID), true
+	}
+	// A no-expiry token with any feature at all is a perpetual paid grant.
+	if lic.ExpiresAt <= 0 && len(lic.Features) > 0 {
+		return "perpetual (no-expiry) token with features", true
+	}
+	return "", false
+}
+
+// nonEmptyStrings returns s with empty / whitespace-only entries removed.
+func nonEmptyStrings(s []string) []string {
+	out := s[:0:0]
+	for _, v := range s {
+		if strings.TrimSpace(v) != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// writeIssuanceExport signs an issuance export for a break-glass paid token and
+// atomically writes it to path (0600). The export lets the license service
+// import the token into its signed revocation table.
+func writeIssuanceExport(path, token string, lic license.License, priv ed25519.PrivateKey) error {
+	featuresJSON, err := json.Marshal(lic.Features)
+	if err != nil {
+		return fmt.Errorf("marshal features: %w", err)
+	}
+	export, err := license.SignIssuanceExport(
+		license.BuildIssuanceExportFromToken(token, lic, string(featuresJSON), time.Now()), priv)
+	if err != nil {
+		return fmt.Errorf("sign export: %w", err)
+	}
+	data, err := json.MarshalIndent(export, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal export: %w", err)
+	}
+	cleanPath := filepath.Clean(path)
+	tmpPath := cleanPath + ".tmp"
+	if err := os.WriteFile(tmpPath, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write export file: %w", err)
+	}
+	if err := os.Rename(tmpPath, cleanPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("install export file: %w", err)
+	}
+	return nil
 }
 
 func licenseInspectCmd() *cobra.Command {

--- a/enterprise/cli/license_gate_test.go
+++ b/enterprise/cli/license_gate_test.go
@@ -1,0 +1,321 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package entcli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// gateTestKey writes a fresh signing key and returns its path.
+func gateTestKey(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privPath := filepath.Join(dir, licensePrivKeyFile)
+	if err := signing.SavePrivateKey(priv, privPath); err != nil {
+		t.Fatal(err)
+	}
+	return privPath
+}
+
+func runIssue(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := licenseIssueCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+// --- paidIssuanceReason unit table (the gate predicate) ---
+
+func TestPaidIssuanceReason(t *testing.T) {
+	future := time.Now().Add(24 * time.Hour).Unix()
+	tests := []struct {
+		name      string
+		lic       license.License
+		wantGated bool
+	}{
+		{"agents feature", license.License{Features: []string{license.FeatureAgents}, ExpiresAt: future}, true},
+		{"assess feature", license.License{Features: []string{license.FeatureAssess}, ExpiresAt: future}, true},
+		{"fleet feature", license.License{Features: []string{license.FeatureFleet}, ExpiresAt: future}, true},
+		{"tier only, no features", license.License{Tier: "pro", ExpiresAt: future}, true},
+		{"subscription only, no features/tier", license.License{SubscriptionID: "sub_1", ExpiresAt: future}, true},
+		{"perpetual token with feature", license.License{Features: []string{license.FeatureAgents}}, true},
+		{"truly free: no feature, no tier, no sub, has expiry", license.License{ExpiresAt: future}, false},
+		{"truly free perpetual: nothing at all", license.License{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, gated := paidIssuanceReason(tc.lic)
+			if gated != tc.wantGated {
+				t.Fatalf("paidIssuanceReason gated=%v, want %v", gated, tc.wantGated)
+			}
+		})
+	}
+}
+
+// --- Fail-closed negative: paid token, no break-glass -> REFUSED ---
+
+func TestIssue_PaidFeature_NoBreakGlass_Refused(t *testing.T) {
+	key := gateTestKey(t)
+	out, err := runIssue(t,
+		"--key", key,
+		"--email", "buyer@vendor.example",
+		"--features", "agents",
+		"--expires", time.Now().Add(365*24*time.Hour).Format(time.DateOnly),
+	)
+	if err == nil {
+		t.Fatalf("expected paid issuance to be refused, got success:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "refusing to issue a paid/revocable license") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- THE KEY BYPASS TEST: omit --tier/--subscription-id, pass paid --features.
+// Must STILL be gated (gate keys on capability, not on label flags). ---
+
+func TestIssue_PaidFeature_NoTierNoSub_StillGated(t *testing.T) {
+	key := gateTestKey(t)
+	// Attacker tries to slip a paid token past a label-based gate by omitting the
+	// tier and subscription-id flags entirely; the feature alone is the paid
+	// capability.
+	out, err := runIssue(t,
+		"--key", key,
+		"--email", "attacker@vendor.example",
+		"--features", "fleet",
+		"--expires", time.Now().Add(365*24*time.Hour).Format(time.DateOnly),
+		// deliberately NO --tier, NO --subscription-id
+	)
+	if err == nil {
+		t.Fatalf("BYPASS: paid feature without tier/sub flags was issued:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "paid feature") {
+		t.Fatalf("expected gate to cite the paid feature, got: %v", err)
+	}
+}
+
+// The default --features is [agents] (paid). Issuing with no flags at all must
+// STILL be gated — the default cannot be a silent bypass.
+func TestIssue_DefaultFeaturesAreGated(t *testing.T) {
+	key := gateTestKey(t)
+	out, err := runIssue(t,
+		"--key", key,
+		"--email", "buyer@vendor.example",
+		"--expires", time.Now().Add(365*24*time.Hour).Format(time.DateOnly),
+	)
+	if err == nil {
+		t.Fatalf("BYPASS: default [agents] feature issued without break-glass:\n%s", out)
+	}
+}
+
+// Perpetual paid token (no --expires) without break-glass must be refused.
+func TestIssue_PerpetualPaid_NoBreakGlass_Refused(t *testing.T) {
+	key := gateTestKey(t)
+	out, err := runIssue(t,
+		"--key", key,
+		"--email", "buyer@vendor.example",
+		"--features", "agents",
+		// no --expires => perpetual
+	)
+	if err == nil {
+		t.Fatalf("expected perpetual paid token to be refused:\n%s", out)
+	}
+}
+
+// --- Free-only token (no paid feature, has expiry) -> ALLOWED ---
+
+func TestIssue_FreeOnly_Allowed(t *testing.T) {
+	key := gateTestKey(t)
+	out, err := runIssue(t,
+		"--key", key,
+		"--email", "free@vendor.example",
+		"--features", "", // explicitly empty: no paid capability
+		"--expires", time.Now().Add(30*24*time.Hour).Format(time.DateOnly),
+	)
+	if err != nil {
+		t.Fatalf("free issuance should be allowed, got: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "License issued") {
+		t.Fatalf("expected success output, got:\n%s", out)
+	}
+}
+
+// --- Break-glass path: paid token allowed AND emits a verifiable export ---
+
+func TestIssue_BreakGlass_PaidAllowed_EmitsValidExport(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	keyPath := filepath.Join(dir, licensePrivKeyFile)
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatal(err)
+	}
+	exportPath := filepath.Join(dir, "export.json")
+
+	out, err := runIssue(t,
+		"--key", keyPath,
+		"--email", "ops@vendor.example",
+		"--features", "fleet",
+		"--expires", time.Now().Add(365*24*time.Hour).Format(time.DateOnly),
+		"--break-glass",
+		"--export", exportPath,
+	)
+	if err != nil {
+		t.Fatalf("break-glass paid issuance failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "License issued") {
+		t.Fatalf("expected success, got:\n%s", out)
+	}
+
+	// Extract the token from output and confirm it is offline-signable / valid.
+	token := extractTokenFromOutput(t, out)
+	if _, err := license.Verify(token, pub); err != nil {
+		t.Fatalf("break-glass token is not offline-verifiable: %v", err)
+	}
+
+	// The emitted export must parse and verify against the signer key, and bind
+	// the FULL token hash.
+	data, err := os.ReadFile(filepath.Clean(exportPath))
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+	verified, err := license.ParseAndVerifyIssuanceExport(data, pub)
+	if err != nil {
+		t.Fatalf("export does not verify: %v", err)
+	}
+	if verified.Payload.TokenSHA256 != license.TokenSHA256Hex(token) {
+		t.Fatal("export token hash does not bind the issued token")
+	}
+}
+
+// Break-glass for a PAID token without --export must be refused (no blind mint).
+func TestIssue_BreakGlass_PaidWithoutExport_Refused(t *testing.T) {
+	key := gateTestKey(t)
+	out, err := runIssue(t,
+		"--key", key,
+		"--email", "ops@vendor.example",
+		"--features", "agents",
+		"--expires", time.Now().Add(365*24*time.Hour).Format(time.DateOnly),
+		"--break-glass",
+		// no --export
+	)
+	if err == nil {
+		t.Fatalf("break-glass paid mint without --export should be refused:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "requires --export") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Break-glass on a FREE token does not require --export (the gate never fired).
+func TestIssue_BreakGlass_FreeToken_NoExportNeeded(t *testing.T) {
+	key := gateTestKey(t)
+	out, err := runIssue(t,
+		"--key", key,
+		"--email", "free@vendor.example",
+		"--features", "",
+		"--expires", time.Now().Add(30*24*time.Hour).Format(time.DateOnly),
+		"--break-glass",
+	)
+	if err != nil {
+		t.Fatalf("break-glass free issuance should succeed without export: %v\n%s", err, out)
+	}
+}
+
+func extractTokenFromOutput(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "pipelock_lic_") {
+			return strings.TrimSpace(line)
+		}
+	}
+	t.Fatalf("no token in output:\n%s", out)
+	return ""
+}
+
+// Break-glass with an unwritable --export path surfaces the write error (does
+// not silently succeed with no export).
+func TestIssue_BreakGlass_UnwritableExport_Errors(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	keyPath := filepath.Join(dir, licensePrivKeyFile)
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatal(err)
+	}
+	// Point --export at a path whose parent is a file, not a directory.
+	notADir := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(notADir, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runIssue(t,
+		"--key", keyPath,
+		"--email", "ops@vendor.example",
+		"--features", "agents",
+		"--expires", time.Now().Add(24*time.Hour).Format(time.DateOnly),
+		"--break-glass",
+		"--export", filepath.Join(notADir, "export.json"),
+	)
+	if err == nil {
+		t.Fatalf("expected export write failure to error:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "write signed issuance export") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Sanity: the export written to disk is well-formed JSON with the wire shape.
+func TestIssue_ExportFileShape(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	keyPath := filepath.Join(dir, licensePrivKeyFile)
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatal(err)
+	}
+	exportPath := filepath.Join(dir, "export.json")
+	if _, err := runIssue(t,
+		"--key", keyPath,
+		"--email", "ops@vendor.example",
+		"--features", "agents",
+		"--expires", time.Now().Add(24*time.Hour).Format(time.DateOnly),
+		"--break-glass", "--export", exportPath,
+	); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Clean(exportPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wire struct {
+		Payload   string `json:"payload"`
+		Signature string `json:"signature"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("export is not valid wire JSON: %v", err)
+	}
+	if wire.Payload == "" || wire.Signature == "" {
+		t.Fatal("export missing payload or signature")
+	}
+}

--- a/enterprise/cli/license_test.go
+++ b/enterprise/cli/license_test.go
@@ -519,6 +519,10 @@ func TestLicenseIssue(t *testing.T) {
 		"--org", "Test Org",
 		"--expires", time.Now().Add(365 * 24 * time.Hour).Format(time.DateOnly),
 		"--ledger", ledgerPath,
+		// Default features are [agents] (paid); the issuance gate requires
+		// break-glass + a signed export to mint a paid token from the CLI.
+		"--break-glass",
+		"--export", filepath.Join(dir, "export.json"),
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -567,6 +571,9 @@ func TestLicenseIssue_WithTierAndSubscription(t *testing.T) {
 		"--subscription-id", "sub_polar_test123",
 		"--expires", time.Now().Add(45 * 24 * time.Hour).Format(time.DateOnly),
 		"--ledger", ledgerPath,
+		// Paid tier + subscription => gated; break-glass + export required.
+		"--break-glass",
+		"--export", filepath.Join(dir, "export.json"),
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -626,6 +633,8 @@ func TestLicenseIssue_NoExpiry(t *testing.T) {
 	cmd.SetArgs([]string{
 		"--key", privPath,
 		"--email", "test@example.com",
+		// Free token (no paid feature) so no-expiry is allowed without break-glass.
+		"--features", "",
 		"--ledger", filepath.Join(dir, licenseLedgerFile),
 	})
 
@@ -1088,9 +1097,10 @@ func TestLicenseIssue_DefaultKeyPath(t *testing.T) {
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
-	// No --key flag; should use default path.
+	// No --key flag; should use default path. Free token avoids the paid gate.
 	cmd.SetArgs([]string{
 		"--email", "default@example.com",
+		"--features", "",
 		"--ledger", filepath.Join(dir, licenseLedgerFile),
 	})
 
@@ -1132,6 +1142,9 @@ func TestLicenseIssue_MissingKeyFile(t *testing.T) {
 	cmd.SetArgs([]string{
 		"--key", missingKey,
 		"--email", "test@example.com",
+		// Free token so the issuance gate does not short-circuit before key load;
+		// this test asserts the key-load error path specifically.
+		"--features", "",
 	})
 
 	err := cmd.Execute()
@@ -1153,10 +1166,11 @@ func TestLicenseIssue_DefaultLedgerPath(t *testing.T) {
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
-	// No --ledger flag; should default to alongside the private key.
+	// No --ledger flag; should default to alongside the private key. Free token.
 	cmd.SetArgs([]string{
 		"--key", privPath,
 		"--email", "test@example.com",
+		"--features", "",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -1191,6 +1205,7 @@ func TestLicenseIssue_LedgerWriteFailWarns(t *testing.T) {
 	cmd.SetArgs([]string{
 		"--key", privPath,
 		"--email", "test@example.com",
+		"--features", "", // free token: not blocked by the issuance gate
 		"--ledger", ledgerDir, // directory, not a file
 	})
 

--- a/enterprise/licenseservice/audit.go
+++ b/enterprise/licenseservice/audit.go
@@ -29,8 +29,13 @@ const (
 	// AuditIntermediateRevoked records an intermediate signing-cert serial being
 	// revoked and added to the published CRL (rotation or compromise).
 	AuditIntermediateRevoked = "intermediate_revoked"
-	AuditFoundingCapHit      = "founding_cap_hit"
-	AuditError               = "error"
+	// AuditIssuanceImported records an externally-minted (break-glass /
+	// standalone-CLI) license token being imported into the durable signed
+	// import table so it becomes revocable. Detail carries the outcome
+	// (imported / replay / conflict) and the import id.
+	AuditIssuanceImported = "issuance_imported"
+	AuditFoundingCapHit   = "founding_cap_hit"
+	AuditError            = "error"
 
 	// Enterprise Eval fulfillment events.
 	AuditEvalMinted        = "eval_minted"
@@ -188,6 +193,22 @@ func (a *AuditLedger) LogIntermediateRevoked(serial, reason string) error {
 	return a.Log(AuditEntry{
 		Event:  AuditIntermediateRevoked,
 		Detail: detail,
+	})
+}
+
+// LogIssuanceImported records an externally-minted license token being imported
+// into the signed import table. outcome is the human-readable result
+// (imported / replay / conflict). A conflict is a rejection (fail closed) and
+// still gets logged so the operator has a durable record of the attempt.
+func (a *AuditLedger) LogIssuanceImported(licenseID, importID, outcome string) error {
+	detail := outcome
+	if importID != "" {
+		detail = outcome + " (import " + importID + ")"
+	}
+	return a.Log(AuditEntry{
+		Event:     AuditIssuanceImported,
+		LicenseID: licenseID,
+		Detail:    detail,
 	})
 }
 

--- a/enterprise/licenseservice/entitlement.go
+++ b/enterprise/licenseservice/entitlement.go
@@ -243,6 +243,32 @@ func (e *EntitlementDB) migrate(ctx context.Context) error {
 		id         INTEGER PRIMARY KEY CHECK (id = 0),
 		generation INTEGER NOT NULL DEFAULT 0
 	);
+
+	-- imported_issuances is the durable record of license tokens minted OUTSIDE
+	-- the service (the offline-root break-glass / standalone-CLI path) and then
+	-- imported via a SIGNED issuance export. It is the revocation surface for
+	-- those tokens: the service can only revoke a token it knows about, and the
+	-- local JSONL ledger (truncated, unsigned hash) cannot be the import source.
+	--
+	-- token_sha256 is the FULL 64-hex sha256 of the exact token string (not the
+	-- truncated ledger hash), so an import is bound to the real credential.
+	-- import_id is a unique, server-assigned id per import. The UNIQUE constraint
+	-- on token_sha256 plus the PRIMARY KEY on license_id make a replayed export
+	-- (same token, same id) a no-op and a conflicting export (same id, different
+	-- token, or same token, different id) a hard rejection.
+	CREATE TABLE IF NOT EXISTS imported_issuances (
+		license_id      TEXT PRIMARY KEY,
+		token_sha256    TEXT NOT NULL UNIQUE,
+		subscription_id TEXT NOT NULL DEFAULT '',
+		issuer_key_id   TEXT NOT NULL,
+		issued_at       DATETIME NOT NULL,
+		expires_at      DATETIME,
+		import_id       TEXT NOT NULL UNIQUE,
+		imported_at     DATETIME NOT NULL DEFAULT (datetime('now'))
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_imported_issuances_subscription ON imported_issuances(subscription_id);
+	CREATE INDEX IF NOT EXISTS idx_imported_issuances_issuer ON imported_issuances(issuer_key_id);
 	`
 	_, err := e.db.ExecContext(ctx, ddl)
 	return err

--- a/enterprise/licenseservice/import_signed_test.go
+++ b/enterprise/licenseservice/import_signed_test.go
@@ -10,6 +10,8 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -178,5 +180,39 @@ func TestListImportedIssuances_Empty(t *testing.T) {
 	}
 	if len(all) != 0 {
 		t.Fatalf("expected empty, got %d", len(all))
+	}
+}
+
+// An unexpected DB error (here: a pre-cancelled context) on a VERIFIED export must
+// fail closed (nothing imported) AND leave a forensic trace in the audit ledger, so
+// a presented-and-lost export does not vanish silently.
+func TestImportSignedIssuance_UnexpectedError_IsAuditedAndFailsClosed(t *testing.T) {
+	ts := newTestSetup(t)
+	lic := breakGlassLicense()
+	data, pub, _ := signTestExport(t, ts.privateKey, lic)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // force a non-replay/non-conflict DB error in ImportIssuance
+
+	_, outcome, err := ts.handler.ImportSignedIssuance(ctx, data, pub, "imp_err", time.Now())
+	if err == nil {
+		t.Fatal("expected an error on cancelled-context import, got nil")
+	}
+	if outcome != "" {
+		t.Fatalf("outcome = %q, want empty on unexpected error", outcome)
+	}
+
+	// Fail-closed: nothing was actually recorded.
+	if got, _ := ts.handler.GetImportedIssuance(context.Background(), lic.ID); got != nil {
+		t.Fatal("record was imported despite the error; expected fail-closed")
+	}
+
+	// Forensic trace: the verified-but-failed attempt is in the ledger.
+	entries, rerr := os.ReadFile(ts.ledger.path)
+	if rerr != nil {
+		t.Fatalf("read ledger: %v", rerr)
+	}
+	if !strings.Contains(string(entries), lic.ID) || !strings.Contains(string(entries), "error:") {
+		t.Fatalf("ledger missing audited error entry for %s:\n%s", lic.ID, entries)
 	}
 }

--- a/enterprise/licenseservice/import_signed_test.go
+++ b/enterprise/licenseservice/import_signed_test.go
@@ -1,0 +1,182 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package licenseservice
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+// signTestExport mints a token with priv and returns a signed issuance export
+// for it, plus the verifying public key.
+func signTestExport(t *testing.T, priv ed25519.PrivateKey, lic license.License) ([]byte, ed25519.PublicKey, string) {
+	t.Helper()
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	export, err := license.SignIssuanceExport(
+		license.BuildIssuanceExportFromToken(token, lic, "", time.Now()), priv)
+	if err != nil {
+		t.Fatalf("sign export: %v", err)
+	}
+	data, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		t.Fatal("priv has no public half")
+	}
+	return data, pub, license.TokenSHA256Hex(token)
+}
+
+func breakGlassLicense() license.License {
+	now := time.Now()
+	return license.License{
+		ID:             "lic_break_glass_import",
+		Email:          "ops@vendor.example",
+		Org:            "Vendor Example",
+		IssuedAt:       now.Unix(),
+		ExpiresAt:      now.Add(365 * 24 * time.Hour).Unix(),
+		Features:       []string{license.FeatureFleet},
+		Tier:           "enterprise",
+		SubscriptionID: "sub_break_glass",
+	}
+}
+
+func TestImportSignedIssuance_HappyPath(t *testing.T) {
+	ts := newTestSetup(t)
+	lic := breakGlassLicense()
+	data, pub, tokenHash := signTestExport(t, ts.privateKey, lic)
+
+	payload, outcome, err := ts.handler.ImportSignedIssuance(context.Background(), data, pub, "imp_1", time.Now())
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if outcome != ImportOutcomeImported {
+		t.Fatalf("outcome = %q, want imported", outcome)
+	}
+	if payload.LicenseID != lic.ID {
+		t.Fatalf("license id = %q", payload.LicenseID)
+	}
+	got, err := ts.handler.GetImportedIssuance(context.Background(), lic.ID)
+	if err != nil || got == nil {
+		t.Fatalf("get: %v %v", got, err)
+	}
+	if got.TokenSHA256 != tokenHash {
+		t.Fatal("imported record does not bind the full token hash")
+	}
+}
+
+func TestImportSignedIssuance_ReplayIsNoOp(t *testing.T) {
+	ts := newTestSetup(t)
+	data, pub, _ := signTestExport(t, ts.privateKey, breakGlassLicense())
+
+	if _, _, err := ts.handler.ImportSignedIssuance(context.Background(), data, pub, "imp_1", time.Now()); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	_, outcome, err := ts.handler.ImportSignedIssuance(context.Background(), data, pub, "imp_1", time.Now())
+	if err != nil {
+		t.Fatalf("replay should not error: %v", err)
+	}
+	if outcome != ImportOutcomeReplay {
+		t.Fatalf("outcome = %q, want replay", outcome)
+	}
+	all, _ := ts.handler.ListImportedIssuances(context.Background())
+	if len(all) != 1 {
+		t.Fatalf("replay created %d rows, want 1", len(all))
+	}
+}
+
+func TestImportSignedIssuance_ConflictRejected(t *testing.T) {
+	ts := newTestSetup(t)
+	lic := breakGlassLicense()
+	data, pub, _ := signTestExport(t, ts.privateKey, lic)
+	if _, _, err := ts.handler.ImportSignedIssuance(context.Background(), data, pub, "imp_1", time.Now()); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Same license id, DIFFERENT token (changed email -> different signed payload
+	// -> different token hash), new import id => conflict, fail closed.
+	conflicting := lic
+	conflicting.Email = "different@vendor.example"
+	data2, _, _ := signTestExport(t, ts.privateKey, conflicting)
+	_, outcome, err := ts.handler.ImportSignedIssuance(context.Background(), data2, pub, "imp_2", time.Now())
+	if !errors.Is(err, ErrIssuanceConflict) {
+		t.Fatalf("expected ErrIssuanceConflict, got %v (outcome %q)", err, outcome)
+	}
+	if outcome != ImportOutcomeConflict {
+		t.Fatalf("outcome = %q, want conflict", outcome)
+	}
+}
+
+func TestImportSignedIssuance_BadSignatureRejected(t *testing.T) {
+	ts := newTestSetup(t)
+	lic := breakGlassLicense()
+	data, _, _ := signTestExport(t, ts.privateKey, lic)
+	// Verify against the WRONG key (a fresh keypair the export was not signed with).
+	otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, importErr := ts.handler.ImportSignedIssuance(context.Background(), data, otherPub, "imp_1", time.Now())
+	if importErr == nil {
+		t.Fatal("expected wrong-key verification to fail closed")
+	}
+	all, _ := ts.handler.ListImportedIssuances(context.Background())
+	if len(all) != 0 {
+		t.Fatalf("a bad-signature export was imported: %d rows", len(all))
+	}
+}
+
+func TestImportSignedIssuance_MalformedExportRejected(t *testing.T) {
+	ts := newTestSetup(t)
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"not json", []byte("{not json")},
+		{"empty", []byte("")},
+		{"oversize", make([]byte, 128*1024)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := ts.handler.ImportSignedIssuance(context.Background(), tc.data, pub, "imp_x", time.Now())
+			if err == nil {
+				t.Fatalf("expected rejection for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestImportSignedIssuance_RequiresImportID(t *testing.T) {
+	ts := newTestSetup(t)
+	data, pub, _ := signTestExport(t, ts.privateKey, breakGlassLicense())
+	if _, _, err := ts.handler.ImportSignedIssuance(context.Background(), data, pub, "", time.Now()); err == nil {
+		t.Fatal("expected missing import id to be rejected")
+	}
+}
+
+func TestListImportedIssuances_Empty(t *testing.T) {
+	ts := newTestSetup(t)
+	all, err := ts.handler.ListImportedIssuances(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("expected empty, got %d", len(all))
+	}
+}

--- a/enterprise/licenseservice/import_signed_test.go
+++ b/enterprise/licenseservice/import_signed_test.go
@@ -80,6 +80,34 @@ func TestImportSignedIssuance_HappyPath(t *testing.T) {
 	}
 }
 
+func TestRevokeImportedIssuance_PublishesInSignedCRL(t *testing.T) {
+	ts := newTestSetup(t)
+	lic := breakGlassLicense()
+	data, pub, _ := signTestExport(t, ts.privateKey, lic)
+	now := time.Now()
+
+	if _, _, err := ts.handler.ImportSignedIssuance(context.Background(), data, pub, "imp_revoke", now); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if err := ts.handler.RevokeImportedIssuance(context.Background(), lic.ID, "break_glass_retired", now); err != nil {
+		t.Fatalf("revoke imported issuance: %v", err)
+	}
+	crl, err := ts.handler.SignedCRL(context.Background(), now)
+	if err != nil {
+		t.Fatalf("signed CRL: %v", err)
+	}
+	if _, ok := crl.RevocationFor(lic.ID); !ok {
+		t.Fatalf("imported license %s missing from signed CRL revocations", lic.ID)
+	}
+}
+
+func TestRevokeImportedIssuance_RejectsMissingRecord(t *testing.T) {
+	ts := newTestSetup(t)
+	if err := ts.handler.RevokeImportedIssuance(context.Background(), "lic_missing", "x", time.Now()); err == nil {
+		t.Fatal("expected missing imported issuance to be rejected")
+	}
+}
+
 func TestImportSignedIssuance_ReplayIsNoOp(t *testing.T) {
 	ts := newTestSetup(t)
 	data, pub, _ := signTestExport(t, ts.privateKey, breakGlassLicense())

--- a/enterprise/licenseservice/import_signed_test.go
+++ b/enterprise/licenseservice/import_signed_test.go
@@ -162,7 +162,10 @@ func TestImportSignedIssuance_BadSignatureRejected(t *testing.T) {
 	if importErr == nil {
 		t.Fatal("expected wrong-key verification to fail closed")
 	}
-	all, _ := ts.handler.ListImportedIssuances(context.Background())
+	all, err := ts.handler.ListImportedIssuances(context.Background())
+	if err != nil {
+		t.Fatalf("list imported issuances: %v", err)
+	}
 	if len(all) != 0 {
 		t.Fatalf("a bad-signature export was imported: %d rows", len(all))
 	}
@@ -231,7 +234,11 @@ func TestImportSignedIssuance_UnexpectedError_IsAuditedAndFailsClosed(t *testing
 	}
 
 	// Fail-closed: nothing was actually recorded.
-	if got, _ := ts.handler.GetImportedIssuance(context.Background(), lic.ID); got != nil {
+	got, err := ts.handler.GetImportedIssuance(context.Background(), lic.ID)
+	if err != nil {
+		t.Fatalf("get imported issuance: %v", err)
+	}
+	if got != nil {
 		t.Fatal("record was imported despite the error; expected fail-closed")
 	}
 

--- a/enterprise/licenseservice/import_table.go
+++ b/enterprise/licenseservice/import_table.go
@@ -7,6 +7,7 @@ package licenseservice
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
@@ -68,6 +69,9 @@ func (e *EntitlementDB) ImportIssuance(ctx context.Context, rec ImportedIssuance
 	}
 	if len(rec.TokenSHA256) != tokenSHA256HexLen {
 		return fmt.Errorf("token_sha256 must be a %d-char hex sha256", tokenSHA256HexLen)
+	}
+	if _, err := hex.DecodeString(rec.TokenSHA256); err != nil {
+		return fmt.Errorf("token_sha256 is not valid hex: %w", err)
 	}
 	if rec.IssuerKeyID == "" {
 		return errors.New("issuer_key_id is required")

--- a/enterprise/licenseservice/import_table.go
+++ b/enterprise/licenseservice/import_table.go
@@ -13,7 +13,22 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/license"
+	"modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
+
+// isUniqueConstraintError reports whether err is a SQLite UNIQUE/PRIMARY KEY
+// constraint violation. Only such a violation means "a concurrent import won the
+// race after our lookup" (a conflict); any other ExecContext error (disk full,
+// I/O, context cancellation) must NOT be mislabeled as a conflict.
+func isUniqueConstraintError(err error) bool {
+	var serr *sqlite.Error
+	if errors.As(err, &serr) {
+		code := serr.Code()
+		return code == sqlite3.SQLITE_CONSTRAINT_UNIQUE || code == sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY
+	}
+	return false
+}
 
 // ImportedIssuance is a license token minted outside the service (offline-root
 // break-glass / standalone CLI) and imported via a signed issuance export. It is
@@ -127,9 +142,13 @@ func (e *EntitlementDB) ImportIssuance(ctx context.Context, rec ImportedIssuance
 		rec.IssuedAt.UTC(), nullableTime(rec.ExpiresAt), rec.ImportID, rec.ImportedAt.UTC(),
 	); err != nil {
 		// A UNIQUE/PRIMARY KEY violation here means a concurrent import won the
-		// race after our lookup. Treat it as a conflict (fail closed) rather than
-		// swallowing it.
-		return fmt.Errorf("%w: %s", ErrIssuanceConflict, err.Error())
+		// race after our lookup: treat it as a conflict (fail closed). Any other
+		// ExecContext error (disk full, I/O, context cancellation) is NOT a
+		// conflict and must surface as a generic error so it is audited as such.
+		if isUniqueConstraintError(err) {
+			return fmt.Errorf("%w: license_id=%s", ErrIssuanceConflict, rec.LicenseID)
+		}
+		return fmt.Errorf("insert imported issuance: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/enterprise/licenseservice/import_table.go
+++ b/enterprise/licenseservice/import_table.go
@@ -1,0 +1,272 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package licenseservice
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+// ImportedIssuance is a license token minted outside the service (offline-root
+// break-glass / standalone CLI) and imported via a signed issuance export. It is
+// the revocation surface for those tokens.
+type ImportedIssuance struct {
+	LicenseID      string
+	TokenSHA256    string // FULL 64-hex sha256 of the exact token string
+	SubscriptionID string
+	IssuerKeyID    string
+	IssuedAt       time.Time
+	ExpiresAt      *time.Time
+	ImportID       string
+	ImportedAt     time.Time
+}
+
+var (
+	// ErrIssuanceReplay means the exact same issuance (same license id, token
+	// hash, and import id) was already imported. Re-importing is a no-op, not a
+	// fault, so a retried import does not error — but the caller is told it was a
+	// replay so it never double-counts.
+	ErrIssuanceReplay = errors.New("issuance already imported")
+
+	// ErrIssuanceConflict means an import collided with a DIFFERENT existing
+	// record on a unique key (license id reused for a different token, token hash
+	// reused for a different license, or import id reused). This is a hard
+	// rejection: it never silently overwrites a recorded credential.
+	ErrIssuanceConflict = errors.New("issuance import conflicts with an existing record")
+)
+
+// ImportIssuance durably records a license token minted outside the service.
+// Replaying the identical import is reported as ErrIssuanceReplay (idempotent
+// no-op); any unique-key collision with different data is ErrIssuanceConflict
+// (hard rejection). It never overwrites an existing record — an import only ever
+// adds a new credential to the revocation surface.
+func (e *EntitlementDB) ImportIssuance(ctx context.Context, rec ImportedIssuance) error {
+	if rec.LicenseID == "" {
+		return errors.New("license_id is required")
+	}
+	if len(rec.TokenSHA256) != tokenSHA256HexLen {
+		return fmt.Errorf("token_sha256 must be a %d-char hex sha256", tokenSHA256HexLen)
+	}
+	if rec.IssuerKeyID == "" {
+		return errors.New("issuer_key_id is required")
+	}
+	if rec.ImportID == "" {
+		return errors.New("import_id is required")
+	}
+	if rec.IssuedAt.IsZero() {
+		return errors.New("issued_at is required")
+	}
+	if rec.ImportedAt.IsZero() {
+		rec.ImportedAt = time.Now().UTC()
+	}
+
+	tx, err := e.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin import issuance transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Look up by EACH unique key independently. If any existing row matches one
+	// key, the rest of the record must be byte-identical for it to be a replay;
+	// otherwise it is a conflict. This catches every cross-collision (same
+	// license/different token, same token/different license, reused import id).
+	existing, found, err := lookupImportedIssuance(ctx, tx, rec)
+	if err != nil {
+		return err
+	}
+	if found {
+		// Either outcome is read-only: roll back to RELEASE the connection.
+		// Leaving the tx open here would leak the single pooled connection
+		// (SetMaxOpenConns(1)) and deadlock the next import. The deferred
+		// rollback handles this because committed stays false.
+		if importedIssuanceEqual(existing, rec) {
+			return ErrIssuanceReplay // idempotent no-op
+		}
+		return fmt.Errorf("%w: license_id=%s", ErrIssuanceConflict, rec.LicenseID)
+	}
+
+	const insert = `
+	INSERT INTO imported_issuances (
+		license_id, token_sha256, subscription_id, issuer_key_id,
+		issued_at, expires_at, import_id, imported_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`
+	if _, err := tx.ExecContext(ctx, insert,
+		rec.LicenseID, rec.TokenSHA256, rec.SubscriptionID, rec.IssuerKeyID,
+		rec.IssuedAt.UTC(), nullableTime(rec.ExpiresAt), rec.ImportID, rec.ImportedAt.UTC(),
+	); err != nil {
+		// A UNIQUE/PRIMARY KEY violation here means a concurrent import won the
+		// race after our lookup. Treat it as a conflict (fail closed) rather than
+		// swallowing it.
+		return fmt.Errorf("%w: %s", ErrIssuanceConflict, err.Error())
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit import issuance transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// lookupImportedIssuance returns any existing row that collides with rec on the
+// license id, the token hash, or the import id (the three unique keys).
+func lookupImportedIssuance(ctx context.Context, q entitlementQueryer, rec ImportedIssuance) (ImportedIssuance, bool, error) {
+	const query = `
+	SELECT license_id, token_sha256, subscription_id, issuer_key_id,
+	       issued_at, expires_at, import_id, imported_at
+	FROM imported_issuances
+	WHERE license_id = ? OR token_sha256 = ? OR import_id = ?
+	LIMIT 1
+	`
+	var (
+		got     ImportedIssuance
+		expires sql.NullTime
+	)
+	err := q.QueryRowContext(ctx, query, rec.LicenseID, rec.TokenSHA256, rec.ImportID).Scan(
+		&got.LicenseID, &got.TokenSHA256, &got.SubscriptionID, &got.IssuerKeyID,
+		&got.IssuedAt, &expires, &got.ImportID, &got.ImportedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ImportedIssuance{}, false, nil
+	}
+	if err != nil {
+		return ImportedIssuance{}, false, fmt.Errorf("lookup imported issuance: %w", err)
+	}
+	if expires.Valid {
+		t := expires.Time.UTC()
+		got.ExpiresAt = &t
+	}
+	return got, true, nil
+}
+
+// importedIssuanceEqual reports whether two records are the same import (so a
+// retry is a replay, not a conflict). Compares the identity fields; imported_at
+// is server-assigned and excluded.
+func importedIssuanceEqual(a, b ImportedIssuance) bool {
+	if a.LicenseID != b.LicenseID ||
+		a.TokenSHA256 != b.TokenSHA256 ||
+		a.SubscriptionID != b.SubscriptionID ||
+		a.IssuerKeyID != b.IssuerKeyID ||
+		a.ImportID != b.ImportID ||
+		!a.IssuedAt.UTC().Equal(b.IssuedAt.UTC()) {
+		return false
+	}
+	if (a.ExpiresAt == nil) != (b.ExpiresAt == nil) {
+		return false
+	}
+	if a.ExpiresAt != nil && !a.ExpiresAt.UTC().Equal(b.ExpiresAt.UTC()) {
+		return false
+	}
+	return true
+}
+
+// GetImportedIssuance returns a single imported issuance by license id, or
+// (nil, nil) when not found.
+func (e *EntitlementDB) GetImportedIssuance(ctx context.Context, licenseID string) (*ImportedIssuance, error) {
+	const query = `
+	SELECT license_id, token_sha256, subscription_id, issuer_key_id,
+	       issued_at, expires_at, import_id, imported_at
+	FROM imported_issuances
+	WHERE license_id = ?
+	`
+	var (
+		got     ImportedIssuance
+		expires sql.NullTime
+	)
+	err := e.db.QueryRowContext(ctx, query, licenseID).Scan(
+		&got.LicenseID, &got.TokenSHA256, &got.SubscriptionID, &got.IssuerKeyID,
+		&got.IssuedAt, &expires, &got.ImportID, &got.ImportedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get imported issuance %s: %w", licenseID, err)
+	}
+	if expires.Valid {
+		t := expires.Time.UTC()
+		got.ExpiresAt = &t
+	}
+	return &got, nil
+}
+
+// ListImportedIssuances returns every imported issuance, ordered by license id
+// for a deterministic listing.
+func (e *EntitlementDB) ListImportedIssuances(ctx context.Context) ([]ImportedIssuance, error) {
+	const query = `
+	SELECT license_id, token_sha256, subscription_id, issuer_key_id,
+	       issued_at, expires_at, import_id, imported_at
+	FROM imported_issuances
+	ORDER BY license_id ASC
+	`
+	rows, err := e.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list imported issuances: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []ImportedIssuance
+	for rows.Next() {
+		var (
+			rec     ImportedIssuance
+			expires sql.NullTime
+		)
+		if err := rows.Scan(
+			&rec.LicenseID, &rec.TokenSHA256, &rec.SubscriptionID, &rec.IssuerKeyID,
+			&rec.IssuedAt, &expires, &rec.ImportID, &rec.ImportedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan imported issuance: %w", err)
+		}
+		if expires.Valid {
+			t := expires.Time.UTC()
+			rec.ExpiresAt = &t
+		}
+		results = append(results, rec)
+	}
+	return results, rows.Err()
+}
+
+// importedIssuanceFromExport converts a VERIFIED issuance-export payload into an
+// import record. Callers must pass a payload returned by
+// license.ParseAndVerifyIssuanceExport (signature + issuer-key-id already
+// checked); this only maps fields. importID is the server-assigned unique id.
+func importedIssuanceFromExport(p license.IssuanceExportPayload, importID string) ImportedIssuance {
+	rec := ImportedIssuance{
+		LicenseID:      p.LicenseID,
+		TokenSHA256:    p.TokenSHA256,
+		SubscriptionID: p.SubscriptionID,
+		IssuerKeyID:    p.IssuerKeyID,
+		IssuedAt:       time.Unix(p.IssuedAt, 0).UTC(),
+		ImportID:       importID,
+		ImportedAt:     time.Now().UTC(),
+	}
+	if p.ExpiresAt > 0 {
+		exp := time.Unix(p.ExpiresAt, 0).UTC()
+		rec.ExpiresAt = &exp
+	}
+	return rec
+}
+
+func nullableTime(t *time.Time) any {
+	if t == nil || t.IsZero() {
+		return nil
+	}
+	return t.UTC()
+}
+
+// tokenSHA256HexLen is the length of a full hex-encoded sha256 (32 bytes -> 64
+// hex chars). The import key MUST be the full hash, never the truncated ledger
+// hash.
+const tokenSHA256HexLen = 64

--- a/enterprise/licenseservice/import_table.go
+++ b/enterprise/licenseservice/import_table.go
@@ -28,6 +28,21 @@ type ImportedIssuance struct {
 	ImportedAt     time.Time
 }
 
+// ImportOutcome is the result of an import attempt, for operator-facing
+// reporting and audit logging.
+type ImportOutcome string
+
+const (
+	// ImportOutcomeImported means a new record was durably written.
+	ImportOutcomeImported ImportOutcome = "imported"
+	// ImportOutcomeReplay means the identical issuance was already imported
+	// (idempotent no-op, not an error).
+	ImportOutcomeReplay ImportOutcome = "replay"
+	// ImportOutcomeConflict means the import collided with a different existing
+	// record on a unique key (rejected, fail closed).
+	ImportOutcomeConflict ImportOutcome = "conflict"
+)
+
 var (
 	// ErrIssuanceReplay means the exact same issuance (same license id, token
 	// hash, and import id) was already imported. Re-importing is a no-op, not a

--- a/enterprise/licenseservice/import_table_test.go
+++ b/enterprise/licenseservice/import_table_test.go
@@ -1,0 +1,292 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package licenseservice
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+func openImportTestDB(t *testing.T) *EntitlementDB {
+	t.Helper()
+	db, err := OpenEntitlementDB(t.Context(), ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func sampleImport() ImportedIssuance {
+	now := time.Now().UTC().Truncate(time.Second)
+	exp := now.Add(365 * 24 * time.Hour)
+	return ImportedIssuance{
+		LicenseID:      "lic_break_glass_1",
+		TokenSHA256:    strings.Repeat("a", tokenSHA256HexLen),
+		SubscriptionID: "sub_offline",
+		IssuerKeyID:    "deadbeefkeyid",
+		IssuedAt:       now,
+		ExpiresAt:      &exp,
+		ImportID:       "imp_1",
+	}
+}
+
+func TestImportIssuance_RoundTrip(t *testing.T) {
+	db := openImportTestDB(t)
+	rec := sampleImport()
+	if err := db.ImportIssuance(t.Context(), rec); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	got, err := db.GetImportedIssuance(t.Context(), rec.LicenseID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got == nil || got.TokenSHA256 != rec.TokenSHA256 || got.ImportID != rec.ImportID {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestImportIssuance_ReplayIsIdempotentNoOp(t *testing.T) {
+	db := openImportTestDB(t)
+	rec := sampleImport()
+	if err := db.ImportIssuance(t.Context(), rec); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	// Identical re-import: reported as replay, no second row.
+	err := db.ImportIssuance(t.Context(), rec)
+	if !errors.Is(err, ErrIssuanceReplay) {
+		t.Fatalf("expected ErrIssuanceReplay, got %v", err)
+	}
+	all, err := db.ListImportedIssuances(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("replay created %d rows, want 1", len(all))
+	}
+}
+
+func TestImportIssuance_ConflictRejections(t *testing.T) {
+	base := sampleImport()
+	tests := []struct {
+		name   string
+		mutate func(r *ImportedIssuance)
+	}{
+		{"same license id, different token", func(r *ImportedIssuance) {
+			r.TokenSHA256 = strings.Repeat("b", tokenSHA256HexLen)
+			r.ImportID = "imp_2"
+		}},
+		{"same token, different license", func(r *ImportedIssuance) {
+			r.LicenseID = "lic_other"
+			r.ImportID = "imp_2"
+		}},
+		{"reused import id, different token", func(r *ImportedIssuance) {
+			r.LicenseID = "lic_other"
+			r.TokenSHA256 = strings.Repeat("c", tokenSHA256HexLen)
+		}},
+		{"same keys, different subscription (silent overwrite attempt)", func(r *ImportedIssuance) {
+			r.SubscriptionID = "sub_attacker"
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openImportTestDB(t)
+			if err := db.ImportIssuance(t.Context(), base); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			bad := base
+			tc.mutate(&bad)
+			err := db.ImportIssuance(t.Context(), bad)
+			if !errors.Is(err, ErrIssuanceConflict) {
+				t.Fatalf("expected ErrIssuanceConflict, got %v", err)
+			}
+			// The original record must be intact (no silent overwrite).
+			got, _ := db.GetImportedIssuance(t.Context(), base.LicenseID)
+			if got == nil || got.SubscriptionID != base.SubscriptionID || got.TokenSHA256 != base.TokenSHA256 {
+				t.Fatalf("original record was mutated: %+v", got)
+			}
+		})
+	}
+}
+
+func TestImportIssuance_RejectsTruncatedHash(t *testing.T) {
+	db := openImportTestDB(t)
+	rec := sampleImport()
+	// The truncated ledger hash (32 hex chars) must be rejected — it cannot be
+	// the import key.
+	rec.TokenSHA256 = strings.Repeat("a", 32)
+	if err := db.ImportIssuance(t.Context(), rec); err == nil {
+		t.Fatal("expected truncated hash to be rejected")
+	}
+}
+
+func TestImportIssuance_RejectsMissingFields(t *testing.T) {
+	db := openImportTestDB(t)
+	tests := []struct {
+		name   string
+		mutate func(r *ImportedIssuance)
+	}{
+		{"missing license id", func(r *ImportedIssuance) { r.LicenseID = "" }},
+		{"missing issuer key id", func(r *ImportedIssuance) { r.IssuerKeyID = "" }},
+		{"missing import id", func(r *ImportedIssuance) { r.ImportID = "" }},
+		{"missing issued at", func(r *ImportedIssuance) { r.IssuedAt = time.Time{} }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := sampleImport()
+			tc.mutate(&rec)
+			if err := db.ImportIssuance(t.Context(), rec); err == nil {
+				t.Fatalf("expected rejection for %s", tc.name)
+			}
+		})
+	}
+}
+
+// TestImportIssuance_FromSignedExport proves the full break-glass flow: a token
+// minted by a standalone signer + a signed export -> verify -> import. The
+// import binds to the FULL token hash from the verified export.
+func TestImportIssuance_FromSignedExport(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	lic := license.License{
+		ID:             "lic_offline_xyz",
+		Email:          "ops@vendor.example",
+		Org:            "Vendor Example",
+		IssuedAt:       now.Unix(),
+		ExpiresAt:      now.Add(365 * 24 * time.Hour).Unix(),
+		Features:       []string{license.FeatureFleet},
+		Tier:           "enterprise",
+		SubscriptionID: "sub_break_glass",
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	export, err := license.SignIssuanceExport(
+		license.BuildIssuanceExportFromToken(token, lic, `["fleet"]`, now), priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(export)
+
+	verified, err := license.ParseAndVerifyIssuanceExport(data, pub)
+	if err != nil {
+		t.Fatalf("verify export: %v", err)
+	}
+
+	rec := importedIssuanceFromExport(verified.Payload, "imp_from_export")
+	db := openImportTestDB(t)
+	if err := db.ImportIssuance(t.Context(), rec); err != nil {
+		t.Fatalf("import from export: %v", err)
+	}
+	got, _ := db.GetImportedIssuance(t.Context(), lic.ID)
+	if got == nil || got.TokenSHA256 != license.TokenSHA256Hex(token) {
+		t.Fatalf("imported record does not bind the full token hash: %+v", got)
+	}
+}
+
+func TestImportedIssuanceEqual_ExpiryAndTimeBranches(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	exp := now.Add(time.Hour)
+	exp2 := now.Add(2 * time.Hour)
+	base := ImportedIssuance{
+		LicenseID: "lic_1", TokenSHA256: "h", SubscriptionID: "s", IssuerKeyID: "k",
+		IssuedAt: now, ImportID: "imp", ExpiresAt: &exp,
+	}
+	mkExpiry := func(e *time.Time) ImportedIssuance { r := base; r.ExpiresAt = e; return r }
+
+	if !importedIssuanceEqual(base, base) {
+		t.Fatal("identical records should be equal")
+	}
+	if importedIssuanceEqual(mkExpiry(nil), base) {
+		t.Fatal("nil vs set expiry should differ")
+	}
+	if importedIssuanceEqual(base, mkExpiry(nil)) {
+		t.Fatal("set vs nil expiry should differ")
+	}
+	if importedIssuanceEqual(base, mkExpiry(&exp2)) {
+		t.Fatal("different expiry should differ")
+	}
+	bothNilA, bothNilB := mkExpiry(nil), mkExpiry(nil)
+	if !importedIssuanceEqual(bothNilA, bothNilB) {
+		t.Fatal("both-nil expiry should be equal")
+	}
+	diffIssued := base
+	diffIssued.IssuedAt = now.Add(time.Minute)
+	if importedIssuanceEqual(base, diffIssued) {
+		t.Fatal("different issued_at should differ")
+	}
+}
+
+// TestImportIssuance_NoExpiryRoundTrip covers the nil-expires storage path.
+func TestImportIssuance_NoExpiryRoundTrip(t *testing.T) {
+	db := openImportTestDB(t)
+	rec := sampleImport()
+	rec.ExpiresAt = nil // perpetual import
+	if err := db.ImportIssuance(t.Context(), rec); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	got, err := db.GetImportedIssuance(t.Context(), rec.LicenseID)
+	if err != nil || got == nil {
+		t.Fatalf("get: %v %v", got, err)
+	}
+	if got.ExpiresAt != nil {
+		t.Fatalf("expected nil expiry, got %v", got.ExpiresAt)
+	}
+	// Replay the perpetual import: idempotent.
+	if err := db.ImportIssuance(t.Context(), rec); !errors.Is(err, ErrIssuanceReplay) {
+		t.Fatalf("expected replay, got %v", err)
+	}
+}
+
+func TestGetImportedIssuance_NotFound(t *testing.T) {
+	db := openImportTestDB(t)
+	got, err := db.GetImportedIssuance(t.Context(), "lic_missing")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != nil {
+		t.Fatal("expected nil for missing license")
+	}
+}
+
+// TestImportIssuance_DistinctRecordsNoCrossContamination imports many distinct
+// issuances and verifies each is stored independently (no unique-key
+// false-positive collisions across unrelated records).
+func TestImportIssuance_DistinctRecordsNoCrossContamination(t *testing.T) {
+	db := openImportTestDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	const n = 16
+	for i := 0; i < n; i++ {
+		rec := ImportedIssuance{
+			LicenseID:   fmt.Sprintf("lic_%02d", i),
+			TokenSHA256: fmt.Sprintf("%064x", i),
+			IssuerKeyID: "keyid",
+			IssuedAt:    now,
+			ImportID:    fmt.Sprintf("imp_%02d", i),
+		}
+		if err := db.ImportIssuance(t.Context(), rec); err != nil {
+			t.Fatalf("import %d: %v", i, err)
+		}
+	}
+	all, err := db.ListImportedIssuances(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != n {
+		t.Fatalf("stored %d distinct rows, want %d", len(all), n)
+	}
+}

--- a/enterprise/licenseservice/import_table_test.go
+++ b/enterprise/licenseservice/import_table_test.go
@@ -130,6 +130,15 @@ func TestImportIssuance_RejectsTruncatedHash(t *testing.T) {
 	}
 }
 
+func TestImportIssuance_RejectsNonHexHash(t *testing.T) {
+	db := openImportTestDB(t)
+	rec := sampleImport()
+	rec.TokenSHA256 = strings.Repeat("z", tokenSHA256HexLen)
+	if err := db.ImportIssuance(t.Context(), rec); err == nil {
+		t.Fatal("expected non-hex token hash to be rejected")
+	}
+}
+
 func TestImportIssuance_RejectsMissingFields(t *testing.T) {
 	db := openImportTestDB(t)
 	tests := []struct {

--- a/enterprise/licenseservice/import_table_test.go
+++ b/enterprise/licenseservice/import_table_test.go
@@ -111,7 +111,10 @@ func TestImportIssuance_ConflictRejections(t *testing.T) {
 				t.Fatalf("expected ErrIssuanceConflict, got %v", err)
 			}
 			// The original record must be intact (no silent overwrite).
-			got, _ := db.GetImportedIssuance(t.Context(), base.LicenseID)
+			got, gerr := db.GetImportedIssuance(t.Context(), base.LicenseID)
+			if gerr != nil {
+				t.Fatalf("get seeded record: %v", gerr)
+			}
 			if got == nil || got.SubscriptionID != base.SubscriptionID || got.TokenSHA256 != base.TokenSHA256 {
 				t.Fatalf("original record was mutated: %+v", got)
 			}
@@ -189,7 +192,10 @@ func TestImportIssuance_FromSignedExport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, _ := json.Marshal(export)
+	data, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
 
 	verified, err := license.ParseAndVerifyIssuanceExport(data, pub)
 	if err != nil {
@@ -201,7 +207,10 @@ func TestImportIssuance_FromSignedExport(t *testing.T) {
 	if err := db.ImportIssuance(t.Context(), rec); err != nil {
 		t.Fatalf("import from export: %v", err)
 	}
-	got, _ := db.GetImportedIssuance(t.Context(), lic.ID)
+	got, err := db.GetImportedIssuance(t.Context(), lic.ID)
+	if err != nil {
+		t.Fatalf("get imported issuance: %v", err)
+	}
 	if got == nil || got.TokenSHA256 != license.TokenSHA256Hex(token) {
 		t.Fatalf("imported record does not bind the full token hash: %+v", got)
 	}
@@ -297,5 +306,37 @@ func TestImportIssuance_DistinctRecordsNoCrossContamination(t *testing.T) {
 	}
 	if len(all) != n {
 		t.Fatalf("stored %d distinct rows, want %d", len(all), n)
+	}
+}
+
+// isUniqueConstraintError must detect a REAL driver-level UNIQUE/PRIMARY KEY
+// violation (so a race-lost INSERT is classified as a conflict) and must NOT
+// misclassify a generic error (so disk/IO/cancellation surfaces as an error,
+// not a phantom conflict).
+func TestIsUniqueConstraintError(t *testing.T) {
+	db := openImportTestDB(t)
+	rec := sampleImport()
+	if err := db.ImportIssuance(t.Context(), rec); err != nil {
+		t.Fatalf("seed import: %v", err)
+	}
+	// Insert the same row directly, bypassing ImportIssuance's pre-INSERT lookup,
+	// to force the driver to raise the constraint error.
+	const insert = `
+	INSERT INTO imported_issuances (
+		license_id, token_sha256, subscription_id, issuer_key_id,
+		issued_at, expires_at, import_id, imported_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	_, rawErr := db.db.ExecContext(t.Context(), insert,
+		rec.LicenseID, rec.TokenSHA256, rec.SubscriptionID, rec.IssuerKeyID,
+		rec.IssuedAt.UTC(), nullableTime(rec.ExpiresAt), rec.ImportID, rec.ImportedAt.UTC(),
+	)
+	if rawErr == nil {
+		t.Fatal("expected a UNIQUE constraint violation on duplicate insert")
+	}
+	if !isUniqueConstraintError(rawErr) {
+		t.Fatalf("real UNIQUE violation not detected: %v", rawErr)
+	}
+	if isUniqueConstraintError(errors.New("disk full")) {
+		t.Fatal("generic error misclassified as a constraint violation")
 	}
 }

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -633,6 +633,9 @@ func (h *WebhookHandler) ImportSignedIssuance(
 		// Fail closed: a malformed / forged / wrong-key export never imports.
 		return license.IssuanceExportPayload{}, "", fmt.Errorf("verify issuance export: %w", err)
 	}
+	if now.IsZero() {
+		now = time.Now()
+	}
 	rec := importedIssuanceFromExport(verified.Payload, importID)
 	rec.ImportedAt = now.UTC()
 

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -567,6 +567,42 @@ func (h *WebhookHandler) RevokeIntermediate(ctx context.Context, serial, reason 
 	return nil
 }
 
+// RevokeImportedIssuance adds an imported break-glass license to the signed CRL
+// revocation set. Importing proves the externally-minted token exists; this
+// method is the operator surface that makes "imported == revocable" true.
+func (h *WebhookHandler) RevokeImportedIssuance(ctx context.Context, licenseID, reason string, now time.Time) error {
+	if licenseID == "" {
+		return errors.New("license_id is required")
+	}
+	rec, err := h.db.GetImportedIssuance(ctx, licenseID)
+	if err != nil {
+		return fmt.Errorf("load imported issuance %s: %w", licenseID, err)
+	}
+	if rec == nil {
+		return fmt.Errorf("imported issuance %s not found", licenseID)
+	}
+	if reason == "" {
+		reason = "imported_license_revoked"
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	subID := rec.SubscriptionID
+	if subID == "" {
+		subID = "imported:" + rec.ImportID
+	}
+	if err := h.db.UpsertLicenseRevocation(ctx, RevokedLicenseRecord{
+		LicenseID:      rec.LicenseID,
+		SubscriptionID: subID,
+		Reason:         reason,
+		RevokedAt:      now.UTC(),
+	}); err != nil {
+		return fmt.Errorf("record imported issuance revocation: %w", err)
+	}
+	_ = h.ledger.LogLicenseRevoked(subID, "", rec.LicenseID, reason)
+	return nil
+}
+
 // ImportSignedIssuance verifies a SIGNED issuance export and durably records the
 // externally-minted license token in the import table so it becomes revocable.
 // This is the consumer of the break-glass / standalone-CLI export: a paid token

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -567,6 +567,66 @@ func (h *WebhookHandler) RevokeIntermediate(ctx context.Context, serial, reason 
 	return nil
 }
 
+// ImportSignedIssuance verifies a SIGNED issuance export and durably records the
+// externally-minted license token in the import table so it becomes revocable.
+// This is the consumer of the break-glass / standalone-CLI export: a paid token
+// minted outside the service is invisible to revocation until it is imported.
+//
+// issuerPub is the public half of the key that signed BOTH the token and the
+// export (the offline root, an intermediate, or the online signer, depending on
+// how the break-glass token was minted). The operator supplies it. Verification
+// fails closed on a bad signature, an issuer-key-id mismatch, or a malformed
+// export — a forged or tampered export cannot enter the revocation surface.
+//
+// Outcomes: ImportOutcomeImported (new record written), ImportOutcomeReplay (the
+// identical export was already imported — idempotent, returns a nil error), and
+// ImportOutcomeConflict (collides with a DIFFERENT record on a unique key —
+// returns ErrIssuanceConflict). Every attempt is recorded in the audit ledger.
+func (h *WebhookHandler) ImportSignedIssuance(
+	ctx context.Context,
+	signedExport []byte,
+	issuerPub ed25519.PublicKey,
+	importID string,
+	now time.Time,
+) (license.IssuanceExportPayload, ImportOutcome, error) {
+	if importID == "" {
+		return license.IssuanceExportPayload{}, "", errors.New("import id is required")
+	}
+	verified, err := license.ParseAndVerifyIssuanceExport(signedExport, issuerPub)
+	if err != nil {
+		// Fail closed: a malformed / forged / wrong-key export never imports.
+		return license.IssuanceExportPayload{}, "", fmt.Errorf("verify issuance export: %w", err)
+	}
+	rec := importedIssuanceFromExport(verified.Payload, importID)
+	rec.ImportedAt = now.UTC()
+
+	switch err := h.db.ImportIssuance(ctx, rec); {
+	case err == nil:
+		_ = h.ledger.LogIssuanceImported(rec.LicenseID, importID, string(ImportOutcomeImported))
+		return verified.Payload, ImportOutcomeImported, nil
+	case errors.Is(err, ErrIssuanceReplay):
+		_ = h.ledger.LogIssuanceImported(rec.LicenseID, importID, string(ImportOutcomeReplay))
+		return verified.Payload, ImportOutcomeReplay, nil
+	case errors.Is(err, ErrIssuanceConflict):
+		_ = h.ledger.LogIssuanceImported(rec.LicenseID, importID, string(ImportOutcomeConflict))
+		return verified.Payload, ImportOutcomeConflict, err
+	default:
+		return verified.Payload, "", fmt.Errorf("import issuance: %w", err)
+	}
+}
+
+// ListImportedIssuances returns every imported (externally-minted) issuance for
+// operator inspection.
+func (h *WebhookHandler) ListImportedIssuances(ctx context.Context) ([]ImportedIssuance, error) {
+	return h.db.ListImportedIssuances(ctx)
+}
+
+// GetImportedIssuance returns a single imported issuance by license id, or
+// (nil, nil) when not found.
+func (h *WebhookHandler) GetImportedIssuance(ctx context.Context, licenseID string) (*ImportedIssuance, error) {
+	return h.db.GetImportedIssuance(ctx, licenseID)
+}
+
 // HandleOrderEvent processes a Polar order.created webhook event for
 // one-time purchases (e.g., trial tier). Subscription-related billing
 // reasons are ignored because subscription.* events handle those.

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -611,6 +611,11 @@ func (h *WebhookHandler) ImportSignedIssuance(
 		_ = h.ledger.LogIssuanceImported(rec.LicenseID, importID, string(ImportOutcomeConflict))
 		return verified.Payload, ImportOutcomeConflict, err
 	default:
+		// Unexpected DB error (disk full, context cancellation, corruption): the
+		// import failed closed (nothing recorded, nothing revocable), but a verified
+		// export was presented and lost. Record the attempt so it leaves a forensic
+		// trace in the ledger rather than vanishing silently.
+		_ = h.ledger.LogIssuanceImported(rec.LicenseID, importID, "error: "+err.Error())
 		return verified.Payload, "", fmt.Errorf("import issuance: %w", err)
 	}
 }

--- a/internal/license/crl_highwater.go
+++ b/internal/license/crl_highwater.go
@@ -63,7 +63,7 @@ func LoadAndVerifyCRLMonotonic(path string, publicKey ed25519.PublicKey, now tim
 // The legacy (non-require) paths keep calling LoadAndVerifyCRLMonotonic so
 // behaviour is unchanged when require mode is off.
 func LoadAndVerifyCRLMonotonicFresh(path string, publicKey ed25519.PublicKey, now time.Time, maxAge time.Duration) (CRL, error) {
-	crl, err := LoadAndVerifyCRLMonotonic(path, publicKey, now)
+	crl, err := LoadAndVerifyCRL(path, publicKey, now)
 	if err != nil {
 		return CRL{}, err
 	}
@@ -71,6 +71,9 @@ func LoadAndVerifyCRLMonotonicFresh(path string, publicKey ed25519.PublicKey, no
 		maxAge = DefaultCRLMaxAge
 	}
 	if err := crl.CheckFreshness(now, maxAge); err != nil {
+		return CRL{}, err
+	}
+	if _, err := AdvanceCRLHighWater(path, crl.Payload.Generation); err != nil {
 		return CRL{}, err
 	}
 	return crl, nil

--- a/internal/license/crl_highwater_test.go
+++ b/internal/license/crl_highwater_test.go
@@ -6,6 +6,7 @@ package license
 import (
 	"crypto/ed25519"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -235,4 +236,45 @@ func TestLoadAndVerifyCRLMonotonic(t *testing.T) {
 			t.Fatal("load with wrong verifier key must error, got nil")
 		}
 	})
+}
+
+func TestLoadAndVerifyCRLMonotonicFresh_DoesNotAdvanceRejectedStaleCRL(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	now := time.Now().UTC()
+	path := filepath.Join(t.TempDir(), "crl.json")
+
+	stale, err := SignCRL(CRLPayload{
+		Version:    CRLVersion,
+		Generation: 10,
+		IssuedAt:   now.Add(-3 * time.Hour).Unix(),
+		ExpiresAt:  now.Add(24 * time.Hour).Unix(),
+	}, priv)
+	if err != nil {
+		t.Fatalf("sign stale CRL: %v", err)
+	}
+	data, err := json.Marshal(stale)
+	if err != nil {
+		t.Fatalf("marshal stale CRL: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write stale CRL: %v", err)
+	}
+
+	_, err = LoadAndVerifyCRLMonotonicFresh(path, pub, now, time.Hour)
+	if !errors.Is(err, ErrCRLStale) {
+		t.Fatalf("stale CRL must be rejected with ErrCRLStale, got %v", err)
+	}
+	if gen, found, readErr := ReadCRLHighWater(path); readErr != nil || found || gen != 0 {
+		t.Fatalf("rejected stale CRL advanced high-water: gen=%d found=%v err=%v", gen, found, readErr)
+	}
+
+	// A lower-generation but fresh CRL must still be acceptable because the
+	// stale generation-10 CRL was never accepted into the rollback high-water.
+	signCRLFile(t, path, priv, 5, now)
+	if _, err := LoadAndVerifyCRLMonotonicFresh(path, pub, now, 2*time.Hour); err != nil {
+		t.Fatalf("fresh gen-5 CRL should verify after rejected stale gen-10 CRL: %v", err)
+	}
+	if gen, found, readErr := ReadCRLHighWater(path); readErr != nil || !found || gen != 5 {
+		t.Fatalf("accepted fresh CRL high-water = (%d, %v, %v), want (5, true, nil)", gen, found, readErr)
+	}
 }

--- a/internal/license/issuance_export.go
+++ b/internal/license/issuance_export.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// IssuanceExportVersion is the wire version of a signed issuance export.
+const IssuanceExportVersion = 1
+
+// maxIssuanceExportSize caps the decoded export size to prevent memory
+// exhaustion from a maliciously large blob. An export is a small JSON record;
+// 64 KiB is generous.
+const maxIssuanceExportSize = 64 * 1024
+
+// IssuanceExportPayload is the signed record that lets a license token minted by
+// a standalone signer (the offline-root break-glass path) be durably imported
+// into the issuing service's revocation surface. It carries the FULL token hash
+// (sha256 of the exact token string) so the import is bound to the real
+// credential, not the truncated, unsigned local JSONL ledger hash.
+//
+// IssuerKeyID is the hex-encoded Ed25519 public key (or intermediate serial)
+// whose private half signed BOTH the license token and this export. Binding the
+// export and the token to the same signer means an attacker cannot pair a token
+// signed by key A with an export signed by key B.
+type IssuanceExportPayload struct {
+	Version        int    `json:"version"`
+	LicenseID      string `json:"license_id"`
+	TokenSHA256    string `json:"token_sha256"` // hex, full 32-byte sha256 of the token string
+	SubscriptionID string `json:"subscription_id,omitempty"`
+	IssuerKeyID    string `json:"issuer_key_id"`
+	IssuedAt       int64  `json:"issued_at"`
+	ExpiresAt      int64  `json:"expires_at,omitempty"`
+	Features       string `json:"features,omitempty"` // JSON array, informational
+	Org            string `json:"org,omitempty"`
+	Email          string `json:"email,omitempty"`
+}
+
+// IssuanceExport is a signed issuance export. The wire format stores the exact
+// signed payload bytes as base64url JSON; signature verification covers those
+// bytes, not a re-marshaled struct (so field reordering can never break it).
+type IssuanceExport struct {
+	Payload   IssuanceExportPayload
+	Signature string
+	SHA256    string
+	payload   []byte
+}
+
+type issuanceExportWire struct {
+	Payload   string `json:"payload"`
+	Signature string `json:"signature"`
+}
+
+// TokenSHA256Hex returns the full hex sha256 of a license token string. This is
+// the import-table key: it binds an import to the exact credential, unlike the
+// truncated, unsigned local JSONL ledger hash, which cannot be the import
+// source.
+func TokenSHA256Hex(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// SignIssuanceExport signs an issuance-export payload with the same private key
+// that signed the license token. The signer's public half is recorded as the
+// IssuerKeyID so a verifier can confirm token and export share one signer.
+func SignIssuanceExport(payload IssuanceExportPayload, privateKey ed25519.PrivateKey) (IssuanceExport, error) {
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return IssuanceExport{}, errors.New("invalid private key size")
+	}
+	if payload.Version == 0 {
+		payload.Version = IssuanceExportVersion
+	}
+	if payload.IssuerKeyID == "" {
+		pub, ok := privateKey.Public().(ed25519.PublicKey)
+		if !ok {
+			return IssuanceExport{}, errors.New("signing key has no public half")
+		}
+		payload.IssuerKeyID = hex.EncodeToString(pub)
+	}
+	if err := validateIssuanceExportPayload(payload); err != nil {
+		return IssuanceExport{}, err
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return IssuanceExport{}, fmt.Errorf("marshal issuance export payload: %w", err)
+	}
+	sig := ed25519.Sign(privateKey, data)
+	sum := sha256.Sum256(data)
+	export := IssuanceExport{
+		Payload:   payload,
+		Signature: base64.RawURLEncoding.EncodeToString(sig),
+		SHA256:    hex.EncodeToString(sum[:]),
+		payload:   append([]byte(nil), data...),
+	}
+	return export, nil
+}
+
+// MarshalJSON serializes the export to the wire format (base64url payload +
+// signature), preserving the exact signed bytes.
+func (x IssuanceExport) MarshalJSON() ([]byte, error) {
+	payload := x.payload
+	if len(payload) == 0 {
+		var err error
+		payload, err = json.Marshal(x.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal issuance export payload: %w", err)
+		}
+	}
+	return json.Marshal(issuanceExportWire{
+		Payload:   base64.RawURLEncoding.EncodeToString(payload),
+		Signature: x.Signature,
+	})
+}
+
+// ParseAndVerifyIssuanceExport decodes a signed export, verifies its Ed25519
+// signature against publicKey, and structurally validates the payload. It fails
+// closed on a bad signature, a payload/IssuerKeyID mismatch, or a malformed
+// record. publicKey must be the signer's public half (which also must equal the
+// payload's IssuerKeyID) so an attacker cannot present an export signed by a key
+// other than the one named in the record.
+func ParseAndVerifyIssuanceExport(data []byte, publicKey ed25519.PublicKey) (IssuanceExport, error) {
+	if len(publicKey) != ed25519.PublicKeySize {
+		return IssuanceExport{}, errors.New("invalid public key")
+	}
+	if len(data) > maxIssuanceExportSize {
+		return IssuanceExport{}, errors.New("issuance export exceeds maximum size")
+	}
+	var wire issuanceExportWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return IssuanceExport{}, fmt.Errorf("parse issuance export: %w", err)
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(wire.Payload)
+	if err != nil {
+		return IssuanceExport{}, fmt.Errorf("decode issuance export payload: %w", err)
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(wire.Signature)
+	if err != nil {
+		return IssuanceExport{}, fmt.Errorf("decode issuance export signature: %w", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return IssuanceExport{}, errors.New("invalid issuance export signature size")
+	}
+	if !ed25519.Verify(publicKey, payload, sig) {
+		return IssuanceExport{}, errors.New("invalid issuance export signature")
+	}
+	var claims IssuanceExportPayload
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return IssuanceExport{}, fmt.Errorf("parse issuance export payload: %w", err)
+	}
+	if err := validateIssuanceExportPayload(claims); err != nil {
+		return IssuanceExport{}, err
+	}
+	// The payload names its signer; the caller verified against publicKey. They
+	// MUST be the same key, otherwise a record signed by a trusted key could
+	// carry a forged IssuerKeyID (display/reality divergence).
+	if claims.IssuerKeyID != hex.EncodeToString(publicKey) {
+		return IssuanceExport{}, errors.New("issuance export issuer_key_id does not match verifying key")
+	}
+	sum := sha256.Sum256(payload)
+	return IssuanceExport{
+		Payload:   claims,
+		Signature: wire.Signature,
+		SHA256:    hex.EncodeToString(sum[:]),
+		payload:   append([]byte(nil), payload...),
+	}, nil
+}
+
+// validateIssuanceExportPayload enforces the structural invariants every export
+// must satisfy regardless of trust path.
+func validateIssuanceExportPayload(p IssuanceExportPayload) error {
+	if p.Version != IssuanceExportVersion {
+		return fmt.Errorf("unsupported issuance export version: %d", p.Version)
+	}
+	if p.LicenseID == "" {
+		return errors.New("issuance export missing license_id")
+	}
+	if p.IssuerKeyID == "" {
+		return errors.New("issuance export missing issuer_key_id")
+	}
+	if p.IssuedAt <= 0 {
+		return errors.New("issuance export missing issued_at")
+	}
+	// The full token hash is the load-bearing field: it binds the import to the
+	// real credential. Require it and require it to be a full sha256 in hex.
+	if len(p.TokenSHA256) != sha256.Size*2 {
+		return fmt.Errorf("issuance export token_sha256 must be a %d-char hex sha256", sha256.Size*2)
+	}
+	if _, err := hex.DecodeString(p.TokenSHA256); err != nil {
+		return fmt.Errorf("issuance export token_sha256 is not valid hex: %w", err)
+	}
+	return nil
+}
+
+// BuildIssuanceExportFromToken constructs an export payload from a token and its
+// decoded claims, computing the full token hash. The signer key id is filled in
+// by SignIssuanceExport from the private key.
+func BuildIssuanceExportFromToken(token string, lic License, features string, now time.Time) IssuanceExportPayload {
+	issued := lic.IssuedAt
+	if issued <= 0 {
+		issued = now.Unix()
+	}
+	return IssuanceExportPayload{
+		Version:        IssuanceExportVersion,
+		LicenseID:      lic.ID,
+		TokenSHA256:    TokenSHA256Hex(token),
+		SubscriptionID: lic.SubscriptionID,
+		IssuedAt:       issued,
+		ExpiresAt:      lic.ExpiresAt,
+		Features:       features,
+		Org:            lic.Org,
+		Email:          lic.Email,
+	}
+}

--- a/internal/license/issuance_export_test.go
+++ b/internal/license/issuance_export_test.go
@@ -1,0 +1,265 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mustKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub, priv
+}
+
+func mustToken(t *testing.T, priv ed25519.PrivateKey, lic License) string {
+	t.Helper()
+	token, err := Issue(lic, priv)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	return token
+}
+
+func TestSignAndParseIssuanceExport_RoundTrip(t *testing.T) {
+	pub, priv := mustKeypair(t)
+	now := time.Now()
+	lic := License{
+		ID:             "lic_abc123",
+		Email:          "buyer@vendor.example",
+		Org:            "Vendor Example",
+		IssuedAt:       now.Unix(),
+		ExpiresAt:      now.Add(365 * 24 * time.Hour).Unix(),
+		Features:       []string{FeatureAgents},
+		Tier:           "pro",
+		SubscriptionID: "sub_xyz",
+	}
+	token := mustToken(t, priv, lic)
+
+	payload := BuildIssuanceExportFromToken(token, lic, `["agents"]`, now)
+	export, err := SignIssuanceExport(payload, priv)
+	if err != nil {
+		t.Fatalf("sign export: %v", err)
+	}
+
+	if export.Payload.IssuerKeyID != hex.EncodeToString(pub) {
+		t.Errorf("issuer key id = %q, want %q", export.Payload.IssuerKeyID, hex.EncodeToString(pub))
+	}
+	if export.Payload.TokenSHA256 != TokenSHA256Hex(token) {
+		t.Error("token hash mismatch")
+	}
+
+	data, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+
+	got, err := ParseAndVerifyIssuanceExport(data, pub)
+	if err != nil {
+		t.Fatalf("parse export: %v", err)
+	}
+	if got.Payload.LicenseID != lic.ID {
+		t.Errorf("license id = %q, want %q", got.Payload.LicenseID, lic.ID)
+	}
+	if got.Payload.SubscriptionID != lic.SubscriptionID {
+		t.Errorf("subscription id = %q", got.Payload.SubscriptionID)
+	}
+	if got.Payload.TokenSHA256 != TokenSHA256Hex(token) {
+		t.Error("parsed token hash mismatch")
+	}
+}
+
+func TestParseIssuanceExport_WrongKeyRejected(t *testing.T) {
+	_, priv := mustKeypair(t)
+	otherPub, _ := mustKeypair(t)
+	now := time.Now()
+	lic := License{ID: "lic_1", Email: "a@vendor.example", IssuedAt: now.Unix()}
+	token := mustToken(t, priv, lic)
+	export, err := SignIssuanceExport(BuildIssuanceExportFromToken(token, lic, "", now), priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(export)
+
+	if _, err := ParseAndVerifyIssuanceExport(data, otherPub); err == nil {
+		t.Fatal("expected wrong-key verification to fail closed")
+	}
+}
+
+func TestParseIssuanceExport_TamperedPayloadRejected(t *testing.T) {
+	pub, priv := mustKeypair(t)
+	now := time.Now()
+	lic := License{ID: "lic_1", Email: "a@vendor.example", IssuedAt: now.Unix()}
+	token := mustToken(t, priv, lic)
+	export, err := SignIssuanceExport(BuildIssuanceExportFromToken(token, lic, "", now), priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tamper: re-encode the wire with a different payload (a swapped license id)
+	// but keep the original signature.
+	var wire issuanceExportWire
+	data, _ := json.Marshal(export)
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatal(err)
+	}
+	tampered := export.Payload
+	tampered.LicenseID = "lic_attacker"
+	tamperedBytes, _ := json.Marshal(tampered)
+	wire.Payload = base64.RawURLEncoding.EncodeToString(tamperedBytes)
+	bad, _ := json.Marshal(wire)
+
+	if _, err := ParseAndVerifyIssuanceExport(bad, pub); err == nil {
+		t.Fatal("expected tampered payload to fail closed")
+	}
+}
+
+func TestParseIssuanceExport_IssuerKeyIDMismatchRejected(t *testing.T) {
+	// An export signed by a trusted key but carrying a FORGED issuer_key_id that
+	// names a different key must be rejected even though the signature is valid:
+	// display/reality divergence.
+	pub, priv := mustKeypair(t)
+	otherPub, _ := mustKeypair(t)
+	now := time.Now()
+	lic := License{ID: "lic_1", Email: "a@vendor.example", IssuedAt: now.Unix()}
+	token := mustToken(t, priv, lic)
+
+	payload := BuildIssuanceExportFromToken(token, lic, "", now)
+	payload.IssuerKeyID = hex.EncodeToString(otherPub) // forge a different signer
+	// Sign with priv but keep the forged id (SignIssuanceExport keeps a non-empty id).
+	export, err := SignIssuanceExport(payload, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(export)
+
+	if _, err := ParseAndVerifyIssuanceExport(data, pub); err == nil {
+		t.Fatal("expected issuer_key_id mismatch to fail closed")
+	}
+}
+
+func TestSignIssuanceExport_RejectsBadInputs(t *testing.T) {
+	_, priv := mustKeypair(t)
+	now := time.Now()
+	tests := []struct {
+		name    string
+		payload IssuanceExportPayload
+	}{
+		{"missing license id", IssuanceExportPayload{Version: 1, TokenSHA256: strings.Repeat("a", 64), IssuedAt: now.Unix()}},
+		{"missing issued at", IssuanceExportPayload{Version: 1, LicenseID: "lic_1", TokenSHA256: strings.Repeat("a", 64)}},
+		{"short token hash", IssuanceExportPayload{Version: 1, LicenseID: "lic_1", TokenSHA256: "deadbeef", IssuedAt: now.Unix()}},
+		{"non-hex token hash", IssuanceExportPayload{Version: 1, LicenseID: "lic_1", TokenSHA256: strings.Repeat("z", 64), IssuedAt: now.Unix()}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := SignIssuanceExport(tc.payload, priv); err == nil {
+				t.Fatalf("expected sign to reject %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestSignIssuanceExport_RejectsBadKey(t *testing.T) {
+	now := time.Now()
+	p := IssuanceExportPayload{Version: 1, LicenseID: "lic_1", TokenSHA256: strings.Repeat("a", 64), IssuedAt: now.Unix(), IssuerKeyID: "x"}
+	if _, err := SignIssuanceExport(p, ed25519.PrivateKey("short")); err == nil {
+		t.Fatal("expected bad key to be rejected")
+	}
+}
+
+func TestParseIssuanceExport_OversizeRejected(t *testing.T) {
+	pub, _ := mustKeypair(t)
+	big := make([]byte, maxIssuanceExportSize+1)
+	if _, err := ParseAndVerifyIssuanceExport(big, pub); err == nil {
+		t.Fatal("expected oversize export to be rejected")
+	}
+}
+
+func TestParseIssuanceExport_MalformedInputsRejected(t *testing.T) {
+	pub, _ := mustKeypair(t)
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"not json", []byte("{not json")},
+		{"bad base64 payload", mustExportWire(t, "!!!notb64!!!", base64.RawURLEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)))},
+		{"bad base64 sig", mustExportWire(t, base64.RawURLEncoding.EncodeToString([]byte(`{"version":1}`)), "!!!")},
+		{"wrong sig size", mustExportWire(t, base64.RawURLEncoding.EncodeToString([]byte(`{"version":1}`)), base64.RawURLEncoding.EncodeToString([]byte("short")))},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseAndVerifyIssuanceExport(tc.data, pub); err == nil {
+				t.Fatalf("expected rejection for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestParseIssuanceExport_BadVerifyKeySize(t *testing.T) {
+	if _, err := ParseAndVerifyIssuanceExport([]byte("{}"), ed25519.PublicKey("short")); err == nil {
+		t.Fatal("expected bad public key size to be rejected")
+	}
+}
+
+func TestMarshalIssuanceExport_FallbackPath(t *testing.T) {
+	// An export built by hand (no cached signed bytes) must still marshal via the
+	// fallback that re-marshals the payload.
+	x := IssuanceExport{
+		Payload:   IssuanceExportPayload{Version: 1, LicenseID: "lic_1", TokenSHA256: strings.Repeat("a", 64), IssuedAt: 1, IssuerKeyID: "k"},
+		Signature: "sig",
+	}
+	data, err := x.MarshalJSON()
+	if err != nil {
+		t.Fatalf("fallback marshal: %v", err)
+	}
+	var wire issuanceExportWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatal(err)
+	}
+	if wire.Payload == "" || wire.Signature != "sig" {
+		t.Fatal("fallback marshal produced wrong wire")
+	}
+}
+
+func TestBuildIssuanceExportFromToken_DefaultsIssuedAt(t *testing.T) {
+	now := time.Now()
+	p := BuildIssuanceExportFromToken("pipelock_lic_"+"v1_x", License{ID: "lic_1"}, "", now)
+	if p.IssuedAt != now.Unix() {
+		t.Fatalf("IssuedAt = %d, want %d (defaulted from now)", p.IssuedAt, now.Unix())
+	}
+	if p.ExpiresAt != 0 {
+		t.Fatal("expected no expiry to map to 0")
+	}
+}
+
+func mustExportWire(t *testing.T, payloadB64, sigB64 string) []byte {
+	t.Helper()
+	data, err := json.Marshal(issuanceExportWire{Payload: payloadB64, Signature: sigB64})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestTokenSHA256Hex_MatchesFullSha(t *testing.T) {
+	token := "pipelock_lic_" + "v1_xyz"
+	sum := sha256.Sum256([]byte(token))
+	if TokenSHA256Hex(token) != hex.EncodeToString(sum[:]) {
+		t.Fatal("TokenSHA256Hex does not match full sha256")
+	}
+	if len(TokenSHA256Hex(token)) != sha256.Size*2 {
+		t.Fatal("hash not full length (truncated like the ledger hash)")
+	}
+}


### PR DESCRIPTION
## What changed
- `license issue` refuses to mint any paid/revocable capability (non-free feature, paid tier, subscription, or no-expiry paid grant) unless `--break-glass --export` is given. The gate keys on the capability itself, never on `--tier`/`--subscription-id` (an issuer can omit those).
- New signed issuance-export format: binds the full token sha256 + issuer key id, Ed25519-signed; fails closed on bad signature, key-id mismatch, or malformed/oversize input.
- New durable service import table (`imported_issuances`): records externally-minted break-glass tokens by full token hash with unique constraints; replay is an idempotent no-op, any conflicting record is rejected (no silent overwrite).
- Operator surface (offline `license-service` admin subcommands): `import-issuance` (verify + import, fail-closed), `list-imported-issuances` (inspect), and `revoke-imported-license` (publish an imported token into the signed CRL).
- Hardening: the require-mode CRL loader advances the rollback high-water only AFTER the freshness gate passes (a stale signed CRL can no longer poison the high-water); import storage validates token-hash hex; unexpected-error import attempts are audited.
- Docs: license CLI + intermediate-migration guide cover the issue -> export -> import -> inspect -> revoke flow.

## Why
A standalone `license issue` could mint paid, revocable tokens with no service-side record, so they could never be revoked via the CRL. This gates casual paid issuance behind an explicit, audited break-glass path and gives the service a durable, revocable record of every externally-minted token.

## Gating
Free detection/enforcement is untouched and compiles without the enterprise tag. All new gate/import code is behind `//go:build enterprise`; the gate covers the act of minting a paid credential.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enterprise offline break-glass license issuance with signed export files.
  * Added enterprise CLI operations to import signed issuances, list imported issuances, and revoke imported licenses.
* **Documentation**
  * Expanded license issue CLI documentation and added a break-glass migration/runbook covering import and revocation steps.
* **Bug Fixes**
  * Improved CRL high-water advancement so it only progresses after CRL freshness validation.
* **Tests**
  * Added extensive unit/integration coverage for the break-glass gate, import/export verification, replay/conflict handling, and revocation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->