### PR TITLE
fix(license): evaluate token expiry against the injected verification clock

### DIFF
--- a/internal/license/crl.go
+++ b/internal/license/crl.go
@@ -360,8 +360,21 @@ func (c CRL) CheckFreshness(now time.Time, maxAge time.Duration) error {
 	return nil
 }
 
+// VerifyWithCRL verifies a token against publicKey (expiry evaluated against the
+// wall clock) and checks it against the supplied CRL. It is the wall-clock
+// wrapper around verifyWithCRLAt; the intermediate chain uses verifyWithCRLAt so
+// token expiry shares the injected clock with the intermediate window and CRL
+// expiry/freshness.
 func VerifyWithCRL(token string, publicKey ed25519.PublicKey, crl *CRL) (License, error) {
-	lic, err := Verify(token, publicKey)
+	return verifyWithCRLAt(token, publicKey, crl, time.Now())
+}
+
+// verifyWithCRLAt is the clock-aware variant. now is the instant the license
+// expiry is evaluated against, threaded from the chain so every temporal check
+// (token expiry, intermediate validity window, CRL expiry/freshness) pivots on
+// one clock.
+func verifyWithCRLAt(token string, publicKey ed25519.PublicKey, crl *CRL, now time.Time) (License, error) {
+	lic, err := verifyAt(token, publicKey, now)
 	if err != nil {
 		return lic, err
 	}

--- a/internal/license/intermediate.go
+++ b/internal/license/intermediate.go
@@ -335,7 +335,7 @@ func decodeIntermediatePublicKey(hexKey string) (ed25519.PublicKey, error) {
 //     enforced on either path.
 func VerifyChain(token string, im *Intermediate, rootPub ed25519.PublicKey, crl *CRL, now time.Time) (License, error) {
 	if im == nil {
-		return VerifyWithCRL(token, rootPub, crl)
+		return verifyWithCRLAt(token, rootPub, crl, now)
 	}
 	verified, err := verifyIntermediateObject(*im, rootPub, now)
 	if err != nil {
@@ -347,7 +347,7 @@ func VerifyChain(token string, im *Intermediate, rootPub ed25519.PublicKey, crl 
 		}
 	}
 	// Primary path: token signed by the active intermediate.
-	lic, err := VerifyWithCRL(token, verified.PublicKey(), crl)
+	lic, err := verifyWithCRLAt(token, verified.PublicKey(), crl, now)
 	if err == nil {
 		return lic, nil
 	}
@@ -358,7 +358,7 @@ func VerifyChain(token string, im *Intermediate, rootPub ed25519.PublicKey, crl 
 	}
 	// Otherwise the signature simply did not match the intermediate key: try the
 	// legacy direct-root path for old root-signed tokens.
-	legacyLic, legacyErr := VerifyWithCRL(token, rootPub, crl)
+	legacyLic, legacyErr := verifyWithCRLAt(token, rootPub, crl, now)
 	if legacyErr == nil {
 		return legacyLic, nil
 	}
@@ -387,7 +387,7 @@ func VerifyChain(token string, im *Intermediate, rootPub ed25519.PublicKey, crl 
 //     verified against the intermediate key with legacy direct-root fallback.
 func VerifyTokenWithOptionalIntermediate(token string, intermediateCert []byte, rootPub ed25519.PublicKey, crl *CRL, now time.Time) (License, error) {
 	if len(intermediateCert) == 0 {
-		return VerifyWithCRL(token, rootPub, crl)
+		return verifyWithCRLAt(token, rootPub, crl, now)
 	}
 	im, err := ParseAndVerifyIntermediate(intermediateCert, rootPub, now)
 	if err != nil {

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -78,9 +78,19 @@ func Issue(l License, privateKey ed25519.PrivateKey) (string, error) {
 }
 
 // Verify decodes a license token, checks the Ed25519 signature against
-// the provided public key, and validates expiration. Returns the license
-// data on success.
+// the provided public key, and validates expiration against the wall clock.
+// Returns the license data on success. It is the wall-clock convenience
+// wrapper around verifyAt; callers that already carry an injected
+// verification time (the intermediate/CRL chain) use verifyAt so every
+// temporal check in the chain pivots on the same instant.
 func Verify(token string, publicKey ed25519.PublicKey) (License, error) {
+	return verifyAt(token, publicKey, time.Now())
+}
+
+// verifyAt is the clock-aware verification core. now is the verification
+// instant the license expiry is evaluated against, so the chain can share one
+// clock with the intermediate validity window and CRL expiry/freshness checks.
+func verifyAt(token string, publicKey ed25519.PublicKey, now time.Time) (License, error) {
 	if len(publicKey) != ed25519.PublicKeySize {
 		return License{}, errors.New("invalid public key")
 	}
@@ -120,7 +130,7 @@ func Verify(token string, publicKey ed25519.PublicKey) (License, error) {
 		return License{}, errors.New("license missing required field: sub")
 	}
 
-	if l.ExpiresAt > 0 && time.Now().Unix() > l.ExpiresAt {
+	if l.ExpiresAt > 0 && now.Unix() > l.ExpiresAt {
 		return l, fmt.Errorf("%w on %s", ErrLicenseExpired, time.Unix(l.ExpiresAt, 0).UTC().Format(time.DateOnly))
 	}
 

--- a/internal/license/verify_clock_test.go
+++ b/internal/license/verify_clock_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+	"time"
+)
+
+// issueTokenExpiring mints an intermediate-signed token with an explicit expiry
+// so the clock-injection tests can place the expiry boundary on either side of
+// the wall clock.
+func issueTokenExpiring(t *testing.T, signer ed25519.PrivateKey, id string, issuedAt, expiresAt time.Time) string {
+	t.Helper()
+	token, err := Issue(License{
+		ID:        id,
+		Email:     "customer@example.com",
+		IssuedAt:  issuedAt.Unix(),
+		ExpiresAt: expiresAt.Unix(),
+		Features:  []string{FeatureFleet},
+	}, signer)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	return token
+}
+
+// TestVerifyChain_TokenExpiryHonorsInjectedClock proves the license token's own
+// expiry is evaluated against the injected verification time, the SAME instant
+// that drives the intermediate validity window and CRL checks — not the wall
+// clock. Before the clock was threaded into the token-expiry check, Verify used
+// time.Now() directly, so both subtests below would have produced the wrong
+// verdict whenever the injected clock disagreed with the wall clock.
+func TestVerifyChain_TokenExpiryHonorsInjectedClock(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, intPriv := testKeyPair(t)
+	wall := time.Now().UTC()
+
+	// A deliberately wide intermediate window so the ONLY field crossing its
+	// boundary in each subtest is the token expiry, isolating the behavior under
+	// test from the intermediate-window check.
+	cert, _ := testIntermediate(t, rootPriv, intPub, wall.Add(-200*24*time.Hour), wall.Add(200*24*time.Hour))
+
+	t.Run("as-of future past expiry, wall clock not yet there", func(t *testing.T) {
+		// Token still valid by the wall clock (expires wall+1h) but we verify
+		// as-of wall+2h. The old time.Now()-based check would have ACCEPTED it.
+		token := issueTokenExpiring(t, intPriv, "lic_future_exp", wall, wall.Add(time.Hour))
+
+		if _, err := VerifyChain(token, &cert, rootPub, nil, wall); err != nil {
+			t.Fatalf("as-of wall (before expiry) should verify: %v", err)
+		}
+		_, err := VerifyChain(token, &cert, rootPub, nil, wall.Add(2*time.Hour))
+		if !errors.Is(err, ErrLicenseExpired) {
+			t.Fatalf("as-of wall+2h (after expiry) want ErrLicenseExpired, got %v", err)
+		}
+	})
+
+	t.Run("as-of past before expiry, wall clock already past it", func(t *testing.T) {
+		// Token already expired by the wall clock (expired wall-1h) but we verify
+		// as-of wall-2h, before its expiry. The old time.Now()-based check would
+		// have REJECTED a token that was valid at the injected instant.
+		token := issueTokenExpiring(t, intPriv, "lic_past_exp", wall.Add(-3*time.Hour), wall.Add(-time.Hour))
+
+		lic, err := VerifyChain(token, &cert, rootPub, nil, wall.Add(-2*time.Hour))
+		if err != nil {
+			t.Fatalf("as-of wall-2h (before expiry) should verify, got %v", err)
+		}
+		if lic.ID != "lic_past_exp" {
+			t.Fatalf("lic.ID = %q, want lic_past_exp", lic.ID)
+		}
+		if _, err := VerifyChain(token, &cert, rootPub, nil, wall); !errors.Is(err, ErrLicenseExpired) {
+			t.Fatalf("as-of wall (after expiry) want ErrLicenseExpired, got %v", err)
+		}
+	})
+}
+
+// TestVerifyChain_OneClockDrivesWindowAndExpiry confirms a single injected
+// instant drives BOTH the intermediate validity window and the token expiry: as
+// the clock advances we get the intermediate's verdict first (window), then the
+// token's (expiry), proving they share one clock rather than two.
+func TestVerifyChain_OneClockDrivesWindowAndExpiry(t *testing.T) {
+	rootPub, rootPriv := testKeyPair(t)
+	intPub, intPriv := testKeyPair(t)
+	base := time.Now().UTC()
+
+	// Intermediate valid [base-1h, base+10h]; token expires at base+5h.
+	cert, _ := testIntermediate(t, rootPriv, intPub, base.Add(-time.Hour), base.Add(10*time.Hour))
+	token := issueTokenExpiring(t, intPriv, "lic_pivot", base, base.Add(5*time.Hour))
+
+	// Within both windows: clean verify.
+	if _, err := VerifyChain(token, &cert, rootPub, nil, base.Add(time.Hour)); err != nil {
+		t.Fatalf("as-of base+1h should verify: %v", err)
+	}
+	// Past the token expiry but still inside the intermediate window: the token
+	// expiry must be the verdict, driven by the same injected clock.
+	if _, err := VerifyChain(token, &cert, rootPub, nil, base.Add(6*time.Hour)); !errors.Is(err, ErrLicenseExpired) {
+		t.Fatalf("as-of base+6h want ErrLicenseExpired, got %v", err)
+	}
+	// Past the intermediate NotAfter: now the intermediate window is the verdict,
+	// proving the same clock also drives the window check (fails closed before the
+	// token is even considered).
+	if _, err := VerifyChain(token, &cert, rootPub, nil, base.Add(11*time.Hour)); !errors.Is(err, ErrIntermediateExpired) {
+		t.Fatalf("as-of base+11h want ErrIntermediateExpired, got %v", err)
+	}
+}

--- a/internal/license/verify_options.go
+++ b/internal/license/verify_options.go
@@ -125,16 +125,18 @@ func VerifyTokenWithOptions(token string, opts VerifyOptions) (License, error) {
 	// Strict path: token MUST be signed by the active intermediate. No
 	// fall-back to direct-root verification — that is the whole point of require
 	// mode (a popped root cannot mint a token that bypasses the intermediate).
-	return verifyChainStrict(token, im, opts.CRL)
+	return verifyChainStrict(token, im, opts.CRL, now)
 }
 
 // verifyChainStrict verifies a token against the intermediate public key ONLY.
 // Unlike VerifyChain it never falls back to direct-root verification on a
 // signature mismatch, so under require-intermediate mode a legacy root-signed
 // token (or a token forged with a compromised root key) is rejected. The
-// intermediate must already be root-verified by the caller.
-func verifyChainStrict(token string, im Intermediate, crl *CRL) (License, error) {
-	return VerifyWithCRL(token, im.PublicKey(), crl)
+// intermediate must already be root-verified by the caller. now is the
+// verification clock, threaded so token expiry shares the instant already used
+// for the intermediate window and CRL freshness.
+func verifyChainStrict(token string, im Intermediate, crl *CRL, now time.Time) (License, error) {
+	return verifyWithCRLAt(token, im.PublicKey(), crl, now)
 }
 
 // ResolveInputs are the config/env-resolved inputs ResolveVerifyOptions turns


### PR DESCRIPTION
Verify hardcoded time.Now() for token expiry while the intermediate window and CRL checks used the injected `now`, leaving the chain not fully clock-injectable.
Thread `now` through verifyAt/verifyWithCRLAt so all temporal checks pivot on one instant; exported Verify/VerifyWithCRL keep their signatures as wall-clock
wrappers. Adds clock-injection regression tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved license verification architecture to use consistently-injected time for all temporal validation checks (token expiry, certificate validity, CRL revocation), ensuring checks evaluate at the same instant rather than inconsistent system clock calls.

* **Tests**
  * Added test coverage for license expiry behavior and certificate validity window verification with injected clock instances across multiple time scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->