### PR TITLE
refactor(license): extract splitToken helper and rename Decode to DecodeUnverified

### DIFF
--- a/enterprise/cli/license.go
+++ b/enterprise/cli/license.go
@@ -349,7 +349,7 @@ func licenseInspectCmd() *cobra.Command {
 		Short: "Decode and display a license token (does not verify signature)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			lic, err := license.Decode(args[0])
+			lic, err := license.DecodeUnverified(args[0])
 			if err != nil {
 				return fmt.Errorf("decode token: %w", err)
 			}
@@ -681,7 +681,7 @@ Default path: ~/.config/pipelock/license.token`,
 			token := args[0]
 
 			// Decode to validate format before writing.
-			lic, err := license.Decode(token)
+			lic, err := license.DecodeUnverified(token)
 			if err != nil {
 				return fmt.Errorf("invalid license token: %w", err)
 			}

--- a/enterprise/cli/license_test.go
+++ b/enterprise/cli/license_test.go
@@ -977,7 +977,7 @@ func TestLicenseInstall_OverwritesExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Decode the installed token to verify it's the new one.
-	installed, err := license.Decode(strings.TrimSpace(string(data)))
+	installed, err := license.DecodeUnverified(strings.TrimSpace(string(data)))
 	if err != nil {
 		t.Fatalf("decode installed token: %v", err)
 	}

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -1848,7 +1848,7 @@ func TestProcessSubscription_LicenseTierAndSubscriptionIDPopulated(t *testing.T)
 	tokenStart := strings.Index(html[preStart:], ">") + preStart + 1
 	token := html[tokenStart:preEnd]
 
-	decoded, err := license.Decode(token)
+	decoded, err := license.DecodeUnverified(token)
 	if err != nil {
 		t.Fatalf("decode minted token: %v", err)
 	}
@@ -2146,7 +2146,7 @@ func TestHandleOrderEvent_OneTimeTrial(t *testing.T) {
 	tokenStart := strings.Index(html[preStart:], ">") + preStart + 1
 	token := html[tokenStart:preEnd]
 
-	decoded, err := license.Decode(token)
+	decoded, err := license.DecodeUnverified(token)
 	if err != nil {
 		t.Fatalf("decode minted token: %v", err)
 	}

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -270,7 +270,7 @@ func doctorVerifiedLicense(cfg *config.Config) (license.License, bool, error) {
 		if cfg.LicensePublicKey != "" {
 			return license.License{}, false, err
 		}
-		lic, decodeErr := license.Decode(cfg.LicenseKey)
+		lic, decodeErr := license.DecodeUnverified(cfg.LicenseKey)
 		if decodeErr != nil {
 			return license.License{}, false, decodeErr
 		}

--- a/internal/license/coverage_boost_test.go
+++ b/internal/license/coverage_boost_test.go
@@ -67,9 +67,9 @@ func TestIssue_NoExpiration(t *testing.T) {
 		t.Fatalf("Issue: %v", err)
 	}
 
-	decoded, err := Decode(token)
+	decoded, err := DecodeUnverified(token)
 	if err != nil {
-		t.Fatalf("Decode: %v", err)
+		t.Fatalf("DecodeUnverified: %v", err)
 	}
 	if decoded.ExpiresAt != 0 {
 		t.Errorf("ExpiresAt = %d, want 0 for perpetual", decoded.ExpiresAt)
@@ -91,9 +91,9 @@ func TestIssue_EmptyFeatures(t *testing.T) {
 		t.Fatalf("Issue: %v", err)
 	}
 
-	decoded, err := Decode(token)
+	decoded, err := DecodeUnverified(token)
 	if err != nil {
-		t.Fatalf("Decode: %v", err)
+		t.Fatalf("DecodeUnverified: %v", err)
 	}
 	if len(decoded.Features) != 0 {
 		t.Errorf("Features length = %d, want 0", len(decoded.Features))
@@ -217,30 +217,30 @@ func TestVerify_InvalidPublicKeySize(t *testing.T) {
 	}
 }
 
-func TestDecode_EmptyToken(t *testing.T) {
-	_, err := Decode("")
+func TestDecodeUnverified_EmptyToken(t *testing.T) {
+	_, err := DecodeUnverified("")
 	if err == nil {
 		t.Error("expected error for empty token")
 	}
 }
 
-func TestDecode_BadPrefix(t *testing.T) {
-	_, err := Decode("bad_prefix_token")
+func TestDecodeUnverified_BadPrefix(t *testing.T) {
+	_, err := DecodeUnverified("bad_prefix_token")
 	if err == nil {
 		t.Error("expected error for bad prefix")
 	}
 }
 
-func TestDecode_InvalidBase64(t *testing.T) {
-	_, err := Decode(tokenPrefix + "!!!not-base64!!!")
+func TestDecodeUnverified_InvalidBase64(t *testing.T) {
+	_, err := DecodeUnverified(tokenPrefix + "!!!not-base64!!!")
 	if err == nil {
 		t.Error("expected error for invalid base64")
 	}
 }
 
-func TestDecode_TooShort(t *testing.T) {
+func TestDecodeUnverified_TooShort(t *testing.T) {
 	// Valid base64 but too short (less than signature size)
-	_, err := Decode(tokenPrefix + "AAAA")
+	_, err := DecodeUnverified(tokenPrefix + "AAAA")
 	if err == nil {
 		t.Error("expected error for token shorter than signature")
 	}

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -135,9 +135,12 @@ func (l License) HasFeature(feature string) bool {
 	return false
 }
 
-// Decode extracts the license payload from a token WITHOUT verifying the
-// signature. Use for inspection only, never for authorization decisions.
-func Decode(token string) (License, error) {
+// DecodeUnverified extracts the license payload from a token WITHOUT verifying
+// the signature. Use for inspection only, never for authorization decisions —
+// every authorization path uses Verify / VerifyWithCRL / VerifyTokenWithOptions,
+// which return a License only when the signature checks out. The Unverified
+// suffix makes accidental misuse in a trust path obvious at the call site.
+func DecodeUnverified(token string) (License, error) {
 	payload, _, err := splitToken(token)
 	if err != nil {
 		return License{}, err
@@ -152,8 +155,8 @@ func Decode(token string) (License, error) {
 // splitToken validates the token envelope (prefix, size cap, base64) and splits
 // the decoded bytes into the signed payload and its trailing Ed25519 signature.
 // It does NOT verify the signature or parse the payload, so verifyAt can check
-// the signature BEFORE unmarshalling untrusted JSON while Decode can inspect
-// without verifying. Shared by both so the wire format lives in one place.
+// the signature BEFORE unmarshalling untrusted JSON while DecodeUnverified can
+// inspect without verifying. Shared by both so the wire format lives in one place.
 func splitToken(token string) (payload, sig []byte, err error) {
 	if !strings.HasPrefix(token, tokenPrefix) {
 		return nil, nil, errors.New("invalid license format: missing prefix")

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -94,25 +94,13 @@ func verifyAt(token string, publicKey ed25519.PublicKey, now time.Time) (License
 	if len(publicKey) != ed25519.PublicKeySize {
 		return License{}, errors.New("invalid public key")
 	}
-	if !strings.HasPrefix(token, tokenPrefix) {
-		return License{}, errors.New("invalid license format: missing prefix")
-	}
-	encoded := strings.TrimPrefix(token, tokenPrefix)
-	// Reject oversized tokens before allocating memory for base64 decode.
-	if len(encoded) > maxTokenBytes {
-		return License{}, errors.New("license token exceeds maximum size")
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	payload, sig, err := splitToken(token)
 	if err != nil {
-		return License{}, fmt.Errorf("decode license: %w", err)
+		return License{}, err
 	}
-	// Minimum: 2 bytes of JSON + 64 bytes of signature.
-	if len(raw) <= ed25519.SignatureSize {
-		return License{}, errors.New("license token too short")
-	}
-	payload := raw[:len(raw)-ed25519.SignatureSize]
-	sig := raw[len(raw)-ed25519.SignatureSize:]
 
+	// Verify the signature BEFORE parsing: never unmarshal untrusted payload
+	// bytes until the root/intermediate signature over them has checked out.
 	if !ed25519.Verify(publicKey, payload, sig) {
 		return License{}, errors.New("invalid license signature")
 	}
@@ -150,27 +138,40 @@ func (l License) HasFeature(feature string) bool {
 // Decode extracts the license payload from a token WITHOUT verifying the
 // signature. Use for inspection only, never for authorization decisions.
 func Decode(token string) (License, error) {
-	if !strings.HasPrefix(token, tokenPrefix) {
-		return License{}, errors.New("invalid license format: missing prefix")
-	}
-	encoded := strings.TrimPrefix(token, tokenPrefix)
-	if len(encoded) > maxTokenBytes {
-		return License{}, errors.New("license token exceeds maximum size")
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	payload, _, err := splitToken(token)
 	if err != nil {
-		return License{}, fmt.Errorf("decode license: %w", err)
+		return License{}, err
 	}
-	if len(raw) <= ed25519.SignatureSize {
-		return License{}, errors.New("license token too short")
-	}
-	payload := raw[:len(raw)-ed25519.SignatureSize]
-
 	var l License
 	if err := json.Unmarshal(payload, &l); err != nil {
 		return License{}, fmt.Errorf("parse license payload: %w", err)
 	}
 	return l, nil
+}
+
+// splitToken validates the token envelope (prefix, size cap, base64) and splits
+// the decoded bytes into the signed payload and its trailing Ed25519 signature.
+// It does NOT verify the signature or parse the payload, so verifyAt can check
+// the signature BEFORE unmarshalling untrusted JSON while Decode can inspect
+// without verifying. Shared by both so the wire format lives in one place.
+func splitToken(token string) (payload, sig []byte, err error) {
+	if !strings.HasPrefix(token, tokenPrefix) {
+		return nil, nil, errors.New("invalid license format: missing prefix")
+	}
+	encoded := strings.TrimPrefix(token, tokenPrefix)
+	// Reject oversized tokens before allocating memory for base64 decode.
+	if len(encoded) > maxTokenBytes {
+		return nil, nil, errors.New("license token exceeds maximum size")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode license: %w", err)
+	}
+	// Minimum: 2 bytes of JSON + 64 bytes of signature.
+	if len(raw) <= ed25519.SignatureSize {
+		return nil, nil, errors.New("license token too short")
+	}
+	return raw[:len(raw)-ed25519.SignatureSize], raw[len(raw)-ed25519.SignatureSize:], nil
 }
 
 // PublicKeyHex is set at build time via ldflags:

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -293,9 +293,9 @@ func TestVerifyRejectsOversizedToken(t *testing.T) {
 	}
 }
 
-func TestDecodeRejectsOversizedToken(t *testing.T) {
+func TestDecodeUnverifiedRejectsOversizedToken(t *testing.T) {
 	huge := tokenPrefix + strings.Repeat("A", maxTokenBytes+1)
-	_, err := Decode(huge)
+	_, err := DecodeUnverified(huge)
 	if err == nil {
 		t.Fatal("expected error for oversized token")
 	}
@@ -304,7 +304,7 @@ func TestDecodeRejectsOversizedToken(t *testing.T) {
 	}
 }
 
-func TestDecodeValidToken(t *testing.T) {
+func TestDecodeUnverifiedValidToken(t *testing.T) {
 	_, priv := testKeyPair(t)
 	lic := License{
 		ID:        "lic_decode_test",
@@ -318,9 +318,9 @@ func TestDecodeValidToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := Decode(token)
+	got, err := DecodeUnverified(token)
 	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
+		t.Fatalf("DecodeUnverified failed: %v", err)
 	}
 	if got.ID != lic.ID {
 		t.Errorf("ID = %q, want %q", got.ID, lic.ID)
@@ -333,7 +333,7 @@ func TestDecodeValidToken(t *testing.T) {
 	}
 }
 
-func TestDecodeBadFormat(t *testing.T) {
+func TestDecodeUnverifiedBadFormat(t *testing.T) {
 	tests := []struct {
 		name  string
 		token string
@@ -344,7 +344,7 @@ func TestDecodeBadFormat(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := Decode(tt.token)
+			_, err := DecodeUnverified(tt.token)
 			if err == nil {
 				t.Error("expected error")
 			}
@@ -386,7 +386,7 @@ func TestBackwardCompatibility_NoTierFields(t *testing.T) {
 	}
 }
 
-func TestDecodeWithTierFields(t *testing.T) {
+func TestDecodeUnverifiedWithTierFields(t *testing.T) {
 	_, priv := testKeyPair(t)
 
 	lic := License{
@@ -404,9 +404,9 @@ func TestDecodeWithTierFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := Decode(token)
+	got, err := DecodeUnverified(token)
 	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
+		t.Fatalf("DecodeUnverified failed: %v", err)
 	}
 	if got.Tier != "founding_pro" {
 		t.Errorf("Tier = %q, want founding_pro", got.Tier)


### PR DESCRIPTION
Two non-behavioral cleanups from the Ed25519 licensing audit:

- **Extract `splitToken`.** `verifyAt` and `Decode` duplicated the same token-envelope parsing (prefix, size cap, base64, payload/signature split). Now shared in one helper so the bounds checks can't drift apart.
- **Rename `Decode` to `DecodeUnverified`.** It returns claims without checking the signature; the new name makes misuse in a trust path obvious. All three callers (`license inspect`/`install`, `doctor` with no key) are inspection-only. Authorization always goes through `Verify`.

No behavior change: `verifyAt` still verifies the signature before parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated license token handling and validation logic across CLI commands and internal systems.
  * Consolidated license token decoding for consistency across verification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->