### PR TITLE
fix(proxy): make redaction config key invariant to per-agent config deep-copy

### DIFF
--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -20,9 +20,10 @@ const CredentialSolicitationRegex = `(?i)(\b(?:send|provide|paste|return|supply|
 // Defaults returns a Config with sensible defaults for balanced mode.
 func Defaults() *Config {
 	cfg := &Config{
-		Version:            1,
-		Mode:               ModeBalanced,
-		canonicalHashCache: &canonicalHashCacheHolder{},
+		Version:                    1,
+		Mode:                       ModeBalanced,
+		canonicalHashCache:         &canonicalHashCacheHolder{},
+		canonicalRedactionKeyCache: &canonicalHashCacheHolder{},
 		// CRL freshness window default (consulted only under require-intermediate
 		// mode). The license_crl_max_age knob and EnvLicenseCRLMaxAge override it;
 		// a missing/non-positive value clamps back to this default in Load and at

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -120,6 +120,7 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 	cfg.canonicalHashCache = &canonicalHashCacheHolder{}
+	cfg.canonicalRedactionKeyCache = &canonicalHashCacheHolder{}
 
 	// Eagerly warm the canonical policy hash cache so the hash is
 	// computed once against the post-Validate / post-ApplyDefaults

--- a/internal/config/redaction_key.go
+++ b/internal/config/redaction_key.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/redact"
+)
+
+// CanonicalRedactionKey returns a stable identity hash of the redaction policy
+// that is invariant to nil-vs-empty collection representation. It returns
+// ("", nil) when redaction is disabled.
+//
+// Why canonicalization is required: the per-agent config path deep-copies a
+// Config through a YAML marshal/unmarshal round-trip (enterprise.deepCopyConfig)
+// which rewrites nil slices/maps as empty ones. A plain json.Marshal then emits
+// null for a pristine config but []/{} for the round-tripped copy, so the same
+// logical policy hashes differently. The proxy keys its startup redaction
+// runtime from the pristine config and every per-request lookup from the
+// deep-copied config; without a canonical key those never match and every
+// request body fails closed. Running the same round-trip here collapses nil and
+// empty to one form on both key derivations so they converge. The round-tripped
+// value is only an in-memory canonical form; the bytes hashed are json.Marshal
+// output, never the YAML emitter's (whose formatting is not a stable hash input).
+//
+// The result is memoised per Config because the round-trip is allocation-heavy
+// (~40us, hundreds of allocs) and the key is recomputed on the request-body hot
+// path. Config values are treated as immutable after Load()/Clone(); a mutation
+// after the first call returns a stale value, matching CanonicalPolicyHash.
+func (c *Config) CanonicalRedactionKey() (string, error) {
+	if c == nil || !c.Redaction.Enabled {
+		return "", nil
+	}
+	if c.canonicalRedactionKeyCache != nil {
+		if cached := c.canonicalRedactionKeyCache.Load(); cached != nil {
+			if s, ok := cached.(string); ok {
+				return s, nil
+			}
+		}
+	}
+	canonical, err := canonicalRedactionConfig(c.Redaction)
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("marshal canonical redaction config: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	key := hex.EncodeToString(sum[:])
+	if c.canonicalRedactionKeyCache != nil {
+		c.canonicalRedactionKeyCache.Store(key)
+	}
+	return key, nil
+}
+
+// canonicalRedactionConfig normalizes a redaction config through the same YAML
+// marshal/unmarshal round-trip that enterprise.deepCopyConfig applies to
+// per-agent configs, collapsing nil-vs-empty divergence across the whole
+// redact.Config tree (current and future fields) without enumerating individual
+// fields.
+func canonicalRedactionConfig(in redact.Config) (redact.Config, error) {
+	data, err := yaml.Marshal(in)
+	if err != nil {
+		return redact.Config{}, fmt.Errorf("canonicalize redaction config (marshal): %w", err)
+	}
+	var out redact.Config
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return redact.Config{}, fmt.Errorf("canonicalize redaction config (unmarshal): %w", err)
+	}
+	return out, nil
+}

--- a/internal/config/redaction_key_test.go
+++ b/internal/config/redaction_key_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/redact"
+)
+
+func enabledRedactionConfig() *Config {
+	c := Defaults()
+	c.Redaction = redact.Config{
+		Enabled:        true,
+		DefaultProfile: "code",
+		Profiles: map[string]redact.ProfileSpec{
+			"code": {Classes: []string{string(redact.ClassAWSAccessKey)}},
+		},
+		Limits: redact.DefaultLimits(),
+	}
+	return c
+}
+
+func TestCanonicalRedactionKey_DisabledAndNil(t *testing.T) {
+	// Disabled redaction yields the empty sentinel, not an error.
+	if got, err := Defaults().CanonicalRedactionKey(); err != nil || got != "" {
+		t.Fatalf("disabled: got (%q, %v), want (\"\", nil)", got, err)
+	}
+	// Nil receiver is safe and also yields the empty sentinel.
+	var nilCfg *Config
+	if got, err := nilCfg.CanonicalRedactionKey(); err != nil || got != "" {
+		t.Fatalf("nil receiver: got (%q, %v), want (\"\", nil)", got, err)
+	}
+}
+
+func TestCanonicalRedactionKey_StableAndCached(t *testing.T) {
+	c := enabledRedactionConfig()
+
+	k1, err := c.CanonicalRedactionKey()
+	if err != nil || k1 == "" {
+		t.Fatalf("first call: got (%q, %v), want a non-empty key", k1, err)
+	}
+	// Second call must hit the memo cache and return the same value.
+	k2, err := c.CanonicalRedactionKey()
+	if err != nil || k2 != k1 {
+		t.Fatalf("cached call: got (%q, %v), want %q", k2, err, k1)
+	}
+
+	// Invariant: the key is stable across the deep-copy YAML round-trip. The
+	// round-tripped config is a zero-value Config, so this also exercises the
+	// uncached path (no cache holder installed).
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		t.Fatalf("yaml marshal: %v", err)
+	}
+	var roundTripped Config
+	if err := yaml.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("yaml unmarshal: %v", err)
+	}
+	k3, err := roundTripped.CanonicalRedactionKey()
+	if err != nil {
+		t.Fatalf("round-tripped key: %v", err)
+	}
+	if k3 != k1 {
+		t.Fatalf("round-tripped key %q != pristine key %q", k3, k1)
+	}
+}
+
+func TestCanonicalRedactionKey_PolicyChangeChangesKey(t *testing.T) {
+	a := enabledRedactionConfig()
+	b := enabledRedactionConfig()
+	b.Redaction.AllowlistUnparseable = []string{"api.vendor.example"}
+
+	ka, err := a.CanonicalRedactionKey()
+	if err != nil {
+		t.Fatalf("key a: %v", err)
+	}
+	kb, err := b.CanonicalRedactionKey()
+	if err != nil {
+		t.Fatalf("key b: %v", err)
+	}
+	if ka == kb {
+		t.Fatal("a genuinely different redaction policy produced the same key")
+	}
+}

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -195,6 +195,7 @@ func (c *Config) Clone() *Config {
 	// starts with an empty cache and computes against its own
 	// post-resolve state.
 	clone.canonicalHashCache = &canonicalHashCacheHolder{}
+	clone.canonicalRedactionKeyCache = &canonicalHashCacheHolder{}
 
 	// Copy rawBytes so mutations to the clone's byte buffer do not alias
 	// back to the receiver. Hash() on the clone continues to reflect the

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -484,6 +484,14 @@ type Config struct {
 	// instances are treated as immutable after Load(); any mutation after
 	// a hash has been computed will return a stale value.
 	canonicalHashCache *canonicalHashCacheHolder `yaml:"-"`
+
+	// canonicalRedactionKeyCache memoises CanonicalRedactionKey() the same way
+	// canonicalHashCache memoises CanonicalPolicyHash(): the canonical redaction
+	// key requires a YAML round-trip + JSON marshal that is allocation-heavy and
+	// recomputed on the request-body hot path. Same immutability and copy
+	// semantics as canonicalHashCache - a fresh holder is installed on
+	// Defaults(), Load(), and Clone().
+	canonicalRedactionKeyCache *canonicalHashCacheHolder `yaml:"-"`
 }
 
 const (

--- a/internal/proxy/redaction_runtime.go
+++ b/internal/proxy/redaction_runtime.go
@@ -47,13 +47,17 @@ func (p *Proxy) buildRedactionRuntimeWithScanner(cfg *config.Config, sc *scanner
 	}
 	allowlist := append([]string(nil), cfg.Redaction.AllowlistUnparseable...)
 	routes := append([]redact.UnparseableRouteSpec(nil), cfg.Redaction.AllowlistUnparseableRoutes...)
+	configKey, err := redactionConfigKeyForScanner(cfg, sc)
+	if err != nil {
+		return nil, fmt.Errorf("compute redaction config key: %w", err)
+	}
 	rt := &redactionRuntime{
 		matcher:                    matcher,
 		limits:                     cfg.Redaction.Limits.ToLimits(),
 		allowlistUnparseable:       allowlist,
 		allowlistUnparseableRoutes: routes,
 		providers:                  providers,
-		configKey:                  redactionConfigKeyForScanner(cfg, sc),
+		configKey:                  configKey,
 		required:                   cfg.Redaction.Enabled,
 	}
 	if previous := p.redactionRuntimePtr.Load(); previous != nil && previous.matcher != nil && previous.configKey != rt.configKey {
@@ -98,11 +102,16 @@ func (p *Proxy) CurrentRedactionConfigFor(cfg *config.Config) (*redact.Matcher, 
 }
 
 func currentRedactionRuntimeForConfig(cfg *config.Config, ptr *atomic.Pointer[redactionRuntime], scanners ...*scanner.Scanner) *redactionRuntime {
-	expectedKey := redactionConfigKey(cfg)
+	var (
+		expectedKey string
+		keyErr      error
+	)
 	if len(scanners) > 0 && scanners[0] != nil {
-		expectedKey = redactionConfigKeyForScanner(cfg, scanners[0])
+		expectedKey, keyErr = redactionConfigKeyForScanner(cfg, scanners[0])
+	} else {
+		expectedKey, keyErr = redactionConfigKey(cfg)
 	}
-	if ptr != nil {
+	if keyErr == nil && ptr != nil {
 		if rt := ptr.Load(); rt != nil && rt.matcher != nil {
 			for candidate := rt; candidate != nil; candidate = candidate.previous {
 				if candidate.matcher == nil {
@@ -114,17 +123,19 @@ func currentRedactionRuntimeForConfig(cfg *config.Config, ptr *atomic.Pointer[re
 			}
 		}
 	}
-	// No runtime published yet (startup, or cfg disables redaction). Fall
-	// back to cfg so callers see the intended operator state. A populated
-	// runtime whose configKey does not match cfg is treated the same way:
-	// fail closed instead of mixing one policy's matcher with another
-	// policy's receipts and canonical hash.
+	// No matching runtime: startup before setup, cfg disables redaction, a
+	// reload-window key mismatch, or a key-computation error (keyErr != nil).
+	// Fall back to cfg intent. A populated runtime whose configKey does not
+	// match is treated the same way: fail closed instead of mixing one
+	// policy's matcher with another policy's receipts and canonical hash.
 	if cfg == nil || !cfg.Redaction.Enabled {
 		return nil
 	}
-	// cfg says redaction is required but no matcher is available - this can
-	// only happen before startup setup runs. Keep the fail-closed sentinel
-	// so request handlers block instead of silently skipping.
+	// cfg requires redaction but no matching matcher is available (startup not
+	// yet run, or the key could not be computed). Return the fail-closed
+	// sentinel so request handlers block instead of silently skipping. On a
+	// key error expectedKey is empty; the sentinel's nil matcher is what
+	// enforces the block, not its key.
 	return &redactionRuntime{
 		limits:                     cfg.Redaction.Limits.ToLimits(),
 		allowlistUnparseable:       append([]string(nil), cfg.Redaction.AllowlistUnparseable...),
@@ -135,23 +146,27 @@ func currentRedactionRuntimeForConfig(cfg *config.Config, ptr *atomic.Pointer[re
 	}
 }
 
-func redactionConfigKey(cfg *config.Config) string {
-	if cfg == nil || !cfg.Redaction.Enabled {
-		return ""
+// redactionConfigKey returns the canonical redaction-policy key for cfg, or ""
+// when redaction is disabled. The canonicalization that makes the key invariant
+// to the per-agent deep-copy YAML round-trip, plus its memoisation, live on
+// config.Config; see Config.CanonicalRedactionKey. A non-nil error means the
+// key could not be computed and callers must fail closed rather than treat the
+// empty string as "disabled".
+func redactionConfigKey(cfg *config.Config) (string, error) {
+	if cfg == nil {
+		return "", nil
 	}
-	payload, err := json.Marshal(cfg.Redaction)
-	if err != nil {
-		return ""
-	}
-	sum := sha256.Sum256(payload)
-	return hex.EncodeToString(sum[:])
+	return cfg.CanonicalRedactionKey()
 }
 
-func redactionConfigKeyForScanner(cfg *config.Config, sc *scanner.Scanner) string {
-	base := redactionConfigKey(cfg)
+func redactionConfigKeyForScanner(cfg *config.Config, sc *scanner.Scanner) (string, error) {
+	base, err := redactionConfigKey(cfg)
+	if err != nil {
+		return "", err
+	}
 	scannerKey := scannerRedactionKey(sc)
 	if base == "" || scannerKey == "" {
-		return base
+		return base, nil
 	}
 	payload, err := json.Marshal(struct {
 		Config  string `json:"config"`
@@ -161,10 +176,10 @@ func redactionConfigKeyForScanner(cfg *config.Config, sc *scanner.Scanner) strin
 		Scanner: scannerKey,
 	})
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("marshal redaction config+scanner key: %w", err)
 	}
 	sum := sha256.Sum256(payload)
-	return hex.EncodeToString(sum[:])
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func scannerRedactionKey(sc *scanner.Scanner) string {

--- a/internal/proxy/redaction_runtime_key_enterprise_test.go
+++ b/internal/proxy/redaction_runtime_key_enterprise_test.go
@@ -1,0 +1,50 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+
+	_ "github.com/luckyPipewrench/pipelock/enterprise/testinit"
+)
+
+// TestRedactionConfigKey_StableAcrossMergeAgentProfile exercises the real
+// production trigger for the fail-closed bug: the per-agent config path
+// (config.MergeAgentProfileFunc -> enterprise.deepCopyConfig). The startup
+// redaction runtime is keyed from the pristine config; every forward-proxy
+// request keys from the merged (deep-copied) config. If the two keys disagree
+// the request body is blocked with "redaction runtime unavailable". This also
+// covers the nil/default profile case, which still deep-copies the base.
+func TestRedactionConfigKey_StableAcrossMergeAgentProfile(t *testing.T) {
+	if config.MergeAgentProfileFunc == nil {
+		t.Fatal("config.MergeAgentProfileFunc not wired; enterprise testinit missing")
+	}
+	base := config.Defaults()
+	applyRedactionTestProfile(base)
+	baseKey := mustRedactionKey(t, base)
+	if baseKey == "" {
+		t.Fatal("base redaction key is empty; test setup did not enable redaction")
+	}
+
+	for _, tc := range []struct {
+		name    string
+		profile *config.AgentProfile
+	}{
+		{name: "nil profile (default agent)", profile: nil},
+		{name: "empty profile", profile: &config.AgentProfile{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			merged, err := config.MergeAgentProfileFunc(base, tc.profile)
+			if err != nil {
+				t.Fatalf("MergeAgentProfileFunc: %v", err)
+			}
+			if got := mustRedactionKey(t, merged); got != baseKey {
+				t.Fatalf("redactionConfigKey differs across MergeAgentProfile:\n  pristine = %s\n  merged   = %s", baseKey, got)
+			}
+		})
+	}
+}

--- a/internal/proxy/redaction_runtime_key_test.go
+++ b/internal/proxy/redaction_runtime_key_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/redact"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// yamlRoundTripConfig mirrors enterprise.deepCopyConfig: the per-agent config
+// path deep-copies a config via a YAML marshal/unmarshal round-trip, which
+// rewrites nil slices/maps as empty ones. Tests use it to reproduce that exact
+// transformation (the trigger for the redaction-runtime fail-closed) without
+// importing the enterprise package. The returned config has no cache holder
+// installed (zero-value Config), which also exercises CanonicalRedactionKey's
+// uncached path.
+func yamlRoundTripConfig(t *testing.T, cfg *config.Config) *config.Config {
+	t.Helper()
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("yaml marshal: %v", err)
+	}
+	var out config.Config
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("yaml unmarshal: %v", err)
+	}
+	return &out
+}
+
+func mustRedactionKey(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+	k, err := redactionConfigKey(cfg)
+	if err != nil {
+		t.Fatalf("redactionConfigKey: %v", err)
+	}
+	return k
+}
+
+func mustRedactionKeyForScanner(t *testing.T, cfg *config.Config, sc *scanner.Scanner) string {
+	t.Helper()
+	k, err := redactionConfigKeyForScanner(cfg, sc)
+	if err != nil {
+		t.Fatalf("redactionConfigKeyForScanner: %v", err)
+	}
+	return k
+}
+
+// TestRedactionConfigKey_StableAcrossYAMLRoundTrip is the regression for the
+// fail-closed bug: redactionConfigKey must produce the same value for a pristine
+// config and for the same config after the per-agent deep-copy YAML round-trip.
+// Before the canonicalization fix the startup runtime (keyed from the pristine
+// config) and every per-request lookup (keyed from the deep-copied config)
+// disagreed, so every request body returned the "redaction runtime unavailable"
+// sentinel.
+func TestRedactionConfigKey_StableAcrossYAMLRoundTrip(t *testing.T) {
+	cfg := config.Defaults()
+	applyRedactionTestProfile(cfg)
+
+	roundTripped := yamlRoundTripConfig(t, cfg)
+
+	// Guard: the RAW redaction json must actually drift across the round-trip
+	// (nil -> empty), proving this test exercises the real failure condition.
+	rawBefore, err := json.Marshal(cfg.Redaction)
+	if err != nil {
+		t.Fatalf("marshal pristine redaction: %v", err)
+	}
+	rawAfter, err := json.Marshal(roundTripped.Redaction)
+	if err != nil {
+		t.Fatalf("marshal round-tripped redaction: %v", err)
+	}
+	if string(rawBefore) == string(rawAfter) {
+		t.Fatalf("expected raw redaction json to drift across yaml round-trip; got identical: %s", rawBefore)
+	}
+
+	if got, want := mustRedactionKey(t, roundTripped), mustRedactionKey(t, cfg); got != want {
+		t.Fatalf("redactionConfigKey not stable across deep-copy round-trip:\n  pristine      = %s\n  round-tripped = %s", want, got)
+	}
+}
+
+// TestRedactionConfigKey_StableAcrossDeepCopy_WholeTree proves the invariance
+// holds for a fully-populated redact.Config (every collection field and nested
+// slice), not just the minimal profile, and that the canonical key is
+// idempotent under repeated round-trips. This guards the whole class, so a
+// future nil/empty-prone field cannot silently reintroduce the drift.
+func TestRedactionConfigKey_StableAcrossDeepCopy_WholeTree(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Redaction = redact.Config{
+		Enabled:        true,
+		DefaultProfile: "code",
+		Profiles: map[string]redact.ProfileSpec{
+			"code": {
+				Classes:      []string{string(redact.ClassAWSAccessKey), string(redact.ClassJWT)},
+				Dictionaries: []string{"vendor"},
+			},
+		},
+		Dictionaries: map[string]redact.DictionarySpec{
+			"vendor": {
+				Class:           "known-secret",
+				Entries:         []string{"placeholder-a", "placeholder-b"},
+				CaseInsensitive: true,
+				Priority:        10,
+			},
+		},
+		AllowlistUnparseable: []string{"api.vendor.example"},
+		AllowlistUnparseableRoutes: []redact.UnparseableRouteSpec{
+			{Host: "oauth.vendor.example", Methods: []string{"POST"}, PathPrefixes: []string{"/token"}},
+		},
+		Limits: redact.DefaultLimits(),
+		// Providers is json:",omitempty" so nil and empty marshal identically;
+		// it is not a drift source and is intentionally left unset.
+	}
+
+	once := yamlRoundTripConfig(t, cfg)
+	twice := yamlRoundTripConfig(t, once)
+
+	k0 := mustRedactionKey(t, cfg)
+	k1 := mustRedactionKey(t, once)
+	k2 := mustRedactionKey(t, twice)
+	if k0 == "" {
+		t.Fatal("whole-tree redaction key is empty; redaction not enabled in setup")
+	}
+	if k0 != k1 || k1 != k2 {
+		t.Fatalf("redactionConfigKey not stable/idempotent across deep-copy of a fully-populated config:\n  pristine      = %s\n  round-trip x1 = %s\n  round-trip x2 = %s", k0, k1, k2)
+	}
+}
+
+// TestRedactionConfigKey_RealPolicyChangeStillChangesKey proves the
+// canonicalization does not over-normalize: a genuinely different redaction
+// policy must still produce a different key so a stale runtime still fails
+// closed (the prior lockstep-fix invariant).
+func TestRedactionConfigKey_RealPolicyChangeStillChangesKey(t *testing.T) {
+	base := config.Defaults()
+	applyRedactionTestProfile(base)
+	baseKey := mustRedactionKey(t, base)
+	if baseKey == "" {
+		t.Fatal("base redaction key is empty; test setup did not enable redaction")
+	}
+
+	changed := config.Defaults()
+	applyRedactionTestProfile(changed)
+	// A real policy delta: narrowing which hosts may bypass non-JSON redaction.
+	changed.Redaction.AllowlistUnparseable = []string{"api.vendor.example"}
+
+	if mustRedactionKey(t, changed) == baseKey {
+		t.Fatal("changed redaction policy produced the same configKey; fail-closed invariant broken")
+	}
+
+	// Disabled redaction yields the empty sentinel key (no runtime required).
+	if got := mustRedactionKey(t, config.Defaults()); got != "" {
+		t.Fatalf("disabled redaction key = %q, want empty", got)
+	}
+}

--- a/internal/proxy/redaction_runtime_key_test.go
+++ b/internal/proxy/redaction_runtime_key_test.go
@@ -34,6 +34,12 @@ func yamlRoundTripConfig(t *testing.T, cfg *config.Config) *config.Config {
 	return &out
 }
 
+func TestRedactionConfigKey_NilConfig(t *testing.T) {
+	if got, err := redactionConfigKey(nil); err != nil || got != "" {
+		t.Fatalf("redactionConfigKey(nil) = (%q, %v), want (\"\", nil)", got, err)
+	}
+}
+
 func mustRedactionKey(t *testing.T, cfg *config.Config) string {
 	t.Helper()
 	k, err := redactionConfigKey(cfg)

--- a/internal/proxy/redaction_runtime_test.go
+++ b/internal/proxy/redaction_runtime_test.go
@@ -48,7 +48,7 @@ func TestCurrentRedactionRuntimeForConfig_MatchingRuntime(t *testing.T) {
 	applyRedactionTestProfile(cfg)
 	rt := &redactionRuntime{
 		matcher:   &redact.Matcher{},
-		configKey: redactionConfigKey(cfg),
+		configKey: mustRedactionKey(t, cfg),
 		required:  true,
 	}
 
@@ -129,7 +129,7 @@ func TestCurrentRedactionRuntimeForConfig_ScannerSecretMismatchFailsClosed(t *te
 
 	stored := &redactionRuntime{
 		matcher:   &redact.Matcher{},
-		configKey: redactionConfigKeyForScanner(cfg, oldScanner),
+		configKey: mustRedactionKeyForScanner(t, cfg, oldScanner),
 		required:  true,
 	}
 	var ptr atomic.Pointer[redactionRuntime]
@@ -381,7 +381,7 @@ func assertRedactionRuntimeMatchesScanner(t *testing.T, cfg *config.Config, sc *
 	if rt.matcher == nil {
 		t.Fatal("current redaction runtime has nil matcher")
 	}
-	want := redactionConfigKeyForScanner(cfg, sc)
+	want := mustRedactionKeyForScanner(t, cfg, sc)
 	if rt.configKey != want {
 		t.Fatalf("redaction runtime configKey = %q, want %q", rt.configKey, want)
 	}


### PR DESCRIPTION
## What changed

The redaction runtime's validity key was `sha256(json.Marshal(cfg.Redaction))`. The per-agent config path deep-copies the config through a YAML round-trip, which rewrites nil slices/maps as empty ones; `json.Marshal` then emits `null` for the pristine config but `[]`/`{}` for the round-tripped copy. The startup redaction runtime is keyed from the pristine config and every per-request lookup from the deep-copied config, so the keys never matched and the runtime fell back to its fail-closed sentinel, blocking every request with a non-empty body whenever redaction is enabled on a build that takes the per-agent config path.

This canonicalizes the redaction config through the same in-memory round-trip before hashing, so startup and per-request keys converge regardless of deep-copying. It covers the whole `redact.Config` tree, not just the fields observed to drift. The key derivation moves onto `config.Config.CanonicalRedactionKey()`, memoized per config (mirroring `CanonicalPolicyHash`) because it is on the request-body hot path and the canonicalization is allocation-heavy. The enabled-key path now returns an error instead of collapsing a compute failure to the empty string, so a key-computation error fails closed rather than reading as "redaction disabled".

## Scope

Affects only builds that take the per-agent config path with redaction enabled. The OSS edition returns the base config unchanged and is unaffected. No config, CLI, or API surface change. No new dependencies.

## Regression coverage

- Key is stable across the deep-copy YAML round-trip and across the real per-agent merge path (nil and empty profile); both fail on the pre-fix code.
- A fully-populated redaction config keys identically across one and two round-trips (whole-tree plus idempotency).
- A genuine redaction-policy change still changes the key, so a stale runtime still fails closed.

## Not included (follow-ups)

- The redaction runtime keys off the global scanner while body DLP uses the resolved per-agent scanner. Left to a follow-up; a naive partial change there would reintroduce this fail-closed.
- The canonical policy hash has the same nil/empty drift, but changing it alters emitted policy-hash values, so it belongs with the receipt/policy-hash work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability of redaction runtime selection by using a canonical, memoized redaction policy identity.
  * Enhanced fail-closed behavior when deriving the redaction identity encounters errors, preventing accidental mismatches.

* **Tests**
  * Added regression tests covering key stability across YAML round-trips and repeated deep-copy transformations.
  * Added coverage ensuring real policy changes still produce a different identity.
  * Added enterprise-only tests to verify stability across agent profile merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->