### PR TITLE
feat(playground): live demo engine with offline-verifiable evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ pipelock-audit.log
 # Temp build dir for generate.sh
 .gen-shadow-*
 /pipelock-playground-demo
+/pipelock-playground-toyagent
+/pipelock-playground-webtool

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ pipelock-audit.log
 
 # Temp build dir for generate.sh
 .gen-shadow-*
+/pipelock-playground-demo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,15 +39,33 @@ linters:
       # by CLAUDE.md do not regress on tests.
       - path: _test\.go$
         linters: [goconst]
-      # Playground demo/evidence tooling (not production firewall code) launches
-      # operator-configured binaries — the toy agent, the web tool, `pipelock
-      # contain`, and `go build` (G204) — provisions a cross-user-traversable temp
-      # dir so the contained agent user can execute those binaries (G302), and
-      # reads artifacts from its own temp/packet dirs (G122). These are by-design
-      # for the demo harness; scoped to the playground paths only.
-      - path: (internal/playground/|cmd/pipelock-playground-)
+      # Playground demo/evidence tooling launches only known local binaries:
+      # the web tool, toy agent, `pipelock contain`, and `go build`.
+      - path: cmd/pipelock-playground-toyagent/main\.go
         linters: [gosec]
-        text: "(G204|G302|G122)"
+        text: "G204"
+      - path: internal/playground/containment\.go
+        linters: [gosec]
+        text: "G204"
+      - path: internal/playground/liverun\.go
+        linters: [gosec]
+        text: "G204"
+      - path: internal/playground/liverun_test\.go
+        linters: [gosec]
+        text: "G204"
+      - path: internal/playground/orchestrate\.go
+        linters: [gosec]
+        text: "G204"
+      # The live-demo harness intentionally makes the temp binary directory
+      # cross-user executable so the contained agent user can run the built
+      # binaries after privilege drop. Artifact reads below are over freshly
+      # generated temp/packet dirs owned by the test/demo process.
+      - path: internal/playground/orchestrate\.go
+        linters: [gosec]
+        text: "(G302|G122)"
+      - path: internal/playground/liverun_test\.go
+        linters: [gosec]
+        text: "G122"
       # liverun.go pins an RFC 5737 reserved IP literal as the bypass target;
       # gosec G101 false-positives on the IP string — it is not a credential.
       - path: internal/playground/liverun\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,20 @@ linters:
       # by CLAUDE.md do not regress on tests.
       - path: _test\.go$
         linters: [goconst]
+      # Playground demo/evidence tooling (not production firewall code) launches
+      # operator-configured binaries — the toy agent, the web tool, `pipelock
+      # contain`, and `go build` (G204) — provisions a cross-user-traversable temp
+      # dir so the contained agent user can execute those binaries (G302), and
+      # reads artifacts from its own temp/packet dirs (G122). These are by-design
+      # for the demo harness; scoped to the playground paths only.
+      - path: (internal/playground/|cmd/pipelock-playground-)
+        linters: [gosec]
+        text: "(G204|G302|G122)"
+      # liverun.go pins an RFC 5737 reserved IP literal as the bypass target;
+      # gosec G101 false-positives on the IP string — it is not a credential.
+      - path: internal/playground/liverun\.go
+        linters: [gosec]
+        text: "G101"
   settings:
     gosec:
       excludes:

--- a/cmd/pipelock-playground-demo/main.go
+++ b/cmd/pipelock-playground-demo/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/playground"
 )
 
 func main() {
@@ -76,13 +77,44 @@ func newResetCmd() *cobra.Command {
 }
 
 func newVerifyCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "verify",
-		Short: "Verify a previously produced Audit Packet",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return fmt.Errorf("not implemented")
+	var orchKey string
+	cmd := &cobra.Command{
+		Use:   "verify <rundir>",
+		Short: "Verify a previously produced demo run (offline, all-or-nothing)",
+		Long: `Performs all-or-nothing offline verification of a playground demo run
+directory. The trust root is the single --orchestrator-key; pipelock and
+collector keys are taken from the verified manifest, NOT trusted blindly.
+
+Exit code 0 = every check passed. Non-zero = at least one check failed.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rep, err := playground.VerifyRun(args[0], orchKey)
+			if err != nil {
+				return err
+			}
+			w := cmd.OutOrStdout()
+			for _, c := range rep.Checks {
+				status := "PASS"
+				if !c.OK {
+					status = "FAIL"
+				}
+				_, _ = fmt.Fprintf(w, "[%s] %s", status, c.Name)
+				if c.Reason != "" {
+					_, _ = fmt.Fprintf(w, " -- %s", c.Reason)
+				}
+				_, _ = fmt.Fprintln(w)
+			}
+			_, _ = fmt.Fprintln(w)
+			if rep.OK {
+				_, _ = fmt.Fprintf(w, "VERIFY OK  run_nonce=%s observed=%d\n", rep.RunNonce, rep.ObservedCount)
+				return nil
+			}
+			return fmt.Errorf("VERIFY FAILED: one or more checks did not pass")
 		},
 	}
+	cmd.Flags().StringVar(&orchKey, "orchestrator-key", "", "hex-encoded orchestrator Ed25519 public key (trust root)")
+	_ = cmd.MarkFlagRequired("orchestrator-key")
+	return cmd
 }
 
 func newFallbackCmd() *cobra.Command {

--- a/cmd/pipelock-playground-demo/main.go
+++ b/cmd/pipelock-playground-demo/main.go
@@ -74,6 +74,13 @@ an offline-verifiable Audit Packet, and renders the mediator timeline.
 Exit 0 = run verified successfully. Non-zero = verification failed or run error.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			w := cmd.OutOrStdout()
+			if contained {
+				// Register the real (host-only) containment hook. Its Setup
+				// requires root + an installed `pipelock contain` and enforces
+				// the fail-closed egress self-test; without privileges it fails
+				// loudly rather than silently running uncontained.
+				playground.SetContainmentHook(playground.NewRealContainmentHook(""))
+			}
 			rep, err := playground.RunDemo(cmd.Context(), w, playground.DemoOpts{
 				Contained:  contained,
 				ScenarioID: scenario,

--- a/cmd/pipelock-playground-demo/main.go
+++ b/cmd/pipelock-playground-demo/main.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is the entry point for pipelock-playground-demo, a local
+// demonstration binary that drives a deterministic toy agent through a real
+// Pipelock proxy, captures signed decision receipts into an evidence JSONL,
+// and assembles them into an offline-verifiable Audit Packet.
+//
+// Subcommands:
+//
+//	run        Drive the demo agent through the proxy and produce evidence.
+//	reset      Clear state from a previous run.
+//	verify     Verify a previously produced Audit Packet directory.
+//	fallback   Run the demo in fallback (offline/replay) mode.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+func main() {
+	root := newRootCmd()
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "pipelock-playground-demo",
+		Short: "Pipelock Playground local demo engine",
+		Long: `pipelock-playground-demo runs a deterministic toy agent through a real
+Pipelock proxy, captures signed decision receipts, and assembles them into an
+offline-verifiable Audit Packet. It is used to produce live evidence for the
+Pipelock Playground.`,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		Version:       cliutil.Version,
+	}
+	root.SetVersionTemplate(fmt.Sprintf(
+		"pipelock-playground-demo %s (commit %s, built %s, %s)\n",
+		cliutil.Version, cliutil.GitCommit, cliutil.BuildDate, cliutil.GoVersion,
+	))
+
+	root.AddCommand(newRunCmd())
+	root.AddCommand(newResetCmd())
+	root.AddCommand(newVerifyCmd())
+	root.AddCommand(newFallbackCmd())
+
+	return root
+}
+
+func newRunCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "run",
+		Short: "Drive the demo agent and produce evidence",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fmt.Errorf("not implemented")
+		},
+	}
+}
+
+func newResetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reset",
+		Short: "Clear state from a previous demo run",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fmt.Errorf("not implemented")
+		},
+	}
+}
+
+func newVerifyCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "verify",
+		Short: "Verify a previously produced Audit Packet",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fmt.Errorf("not implemented")
+		},
+	}
+}
+
+func newFallbackCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "fallback",
+		Short: "Run the demo in fallback (offline/replay) mode",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fmt.Errorf("not implemented")
+		},
+	}
+}

--- a/cmd/pipelock-playground-demo/main.go
+++ b/cmd/pipelock-playground-demo/main.go
@@ -57,23 +57,67 @@ Pipelock Playground.`,
 }
 
 func newRunCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		contained bool
+		runDir    string
+		scenario  string
+		color     bool
+		runNonce  string
+	)
+	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Drive the demo agent and produce evidence",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return fmt.Errorf("not implemented")
+		Long: `Runs the playground demo: boots a real Pipelock proxy, drives a
+deterministic toy agent through it, captures signed decision receipts, assembles
+an offline-verifiable Audit Packet, and renders the mediator timeline.
+
+Exit 0 = run verified successfully. Non-zero = verification failed or run error.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			w := cmd.OutOrStdout()
+			rep, err := playground.RunDemo(cmd.Context(), w, playground.DemoOpts{
+				Contained:  contained,
+				ScenarioID: scenario,
+				RunNonce:   runNonce,
+				RunDir:     runDir,
+				Color:      color,
+			})
+			if err != nil {
+				return err
+			}
+			if !rep.OK {
+				return fmt.Errorf("demo run verification failed")
+			}
+			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&contained, "contained", false, "run in kernel-containment mode (requires Task 7 hook)")
+	cmd.Flags().StringVar(&runDir, "run-dir", "", "directory for run artifacts (required)")
+	cmd.Flags().StringVar(&scenario, "scenario", "secret-exfil-url-blocked", "scenario ID to run")
+	cmd.Flags().BoolVar(&color, "color", false, "enable ANSI color output")
+	cmd.Flags().StringVar(&runNonce, "run-nonce", "", "unique run identifier (default: generated)")
+	_ = cmd.MarkFlagRequired("run-dir")
+	return cmd
 }
 
 func newResetCmd() *cobra.Command {
-	return &cobra.Command{
+	var runDir string
+	cmd := &cobra.Command{
 		Use:   "reset",
 		Short: "Clear state from a previous demo run",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return fmt.Errorf("not implemented")
+		Long: `Removes all artifacts from a previous demo run directory, making it safe
+to reuse for a new run. Idempotent: calling reset on an empty or nonexistent
+directory succeeds.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := playground.Reset(runDir); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Reset complete: %s\n", runDir)
+			return nil
 		},
 	}
+	cmd.Flags().StringVar(&runDir, "run-dir", "", "directory to reset (required)")
+	_ = cmd.MarkFlagRequired("run-dir")
+	return cmd
 }
 
 func newVerifyCmd() *cobra.Command {
@@ -118,11 +162,29 @@ Exit code 0 = every check passed. Non-zero = at least one check failed.`,
 }
 
 func newFallbackCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "fallback",
-		Short: "Run the demo in fallback (offline/replay) mode",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return fmt.Errorf("not implemented")
+	var orchKey string
+	cmd := &cobra.Command{
+		Use:   "fallback <rundir>",
+		Short: "Replay a pre-recorded demo run with REPLAY watermark",
+		Long: `Replays a pre-recorded run directory with a visible REPLAY watermark,
+the packet hash, and the verifier command. Re-runs offline verification to
+confirm the recorded evidence is still valid.
+
+Exit 0 = recorded run verifies. Non-zero = verification failed.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := cmd.OutOrStdout()
+			rep, err := playground.Fallback(w, args[0], orchKey)
+			if err != nil {
+				return err
+			}
+			if !rep.OK {
+				return fmt.Errorf("fallback: recorded run verification failed")
+			}
+			return nil
 		},
 	}
+	cmd.Flags().StringVar(&orchKey, "orchestrator-key", "", "hex-encoded orchestrator Ed25519 public key (trust root)")
+	_ = cmd.MarkFlagRequired("orchestrator-key")
+	return cmd
 }

--- a/cmd/pipelock-playground-demo/main.go
+++ b/cmd/pipelock-playground-demo/main.go
@@ -76,9 +76,9 @@ Exit 0 = run verified successfully. Non-zero = verification failed or run error.
 			w := cmd.OutOrStdout()
 			if contained {
 				// Register the real (host-only) containment hook. Its Setup
-				// requires root + an installed `pipelock contain` and enforces
-				// the fail-closed egress self-test; without privileges it fails
-				// loudly rather than silently running uncontained.
+				// requires root + an installed `pipelock contain`; the bypass
+				// beat itself runs as the contained agent user and fails loudly
+				// rather than silently running uncontained.
 				playground.SetContainmentHook(playground.NewRealContainmentHook(""))
 			}
 			rep, err := playground.RunDemo(cmd.Context(), w, playground.DemoOpts{
@@ -99,7 +99,7 @@ Exit 0 = run verified successfully. Non-zero = verification failed or run error.
 	}
 	cmd.Flags().BoolVar(&contained, "contained", false, "run in kernel-containment mode (requires Task 7 hook)")
 	cmd.Flags().StringVar(&runDir, "run-dir", "", "directory for run artifacts (required)")
-	cmd.Flags().StringVar(&scenario, "scenario", "secret-exfil-url-blocked", "scenario ID to run")
+	cmd.Flags().StringVar(&scenario, "scenario", playground.LiveDemoScenarioID, "scenario ID to run")
 	cmd.Flags().BoolVar(&color, "color", false, "enable ANSI color output")
 	cmd.Flags().StringVar(&runNonce, "run-nonce", "", "unique run identifier (default: generated)")
 	_ = cmd.MarkFlagRequired("run-dir")

--- a/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
+++ b/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
@@ -16,46 +16,14 @@ func TestFallbackCmd_ShowsReplayWatermarkAndHash(t *testing.T) {
 		t.Skip("fallback test requires a pre-recorded run dir from a real live run")
 	}
 
-	// Produce a pre-recorded run dir via RunDemo.
-	recordedDir := t.TempDir()
-	var runBuf bytes.Buffer
-	rep, err := playground.RunDemo(t.Context(), &runBuf, playground.DemoOpts{
-		Contained:  false,
-		ScenarioID: playground.LiveDemoScenarioID,
-		RunDir:     recordedDir,
-	})
-	if err != nil {
-		t.Fatalf("pre-record run: %v", err)
-	}
-	if !rep.OK {
-		t.Fatalf("pre-record run must verify: %+v", rep)
-	}
-
-	// Now run the fallback command against the recorded dir.
-	cmd := newRootCmd()
 	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	// The orchestrator key is in the verify report; use the pipelock key from the run
-	// since that's what the manifest pins. But the fallback command needs the
-	// orchestrator key. We need to extract it. Since RunDemo's verify prints it,
-	// use the verify report's PipelockKey... but actually we need the orchestrator key.
-	// The fallback cmd reads from launch-manifest.json which was signed by the orchestrator.
-	// We need to pass the right key. Let's re-verify to get the orchestrator key.
-	//
-	// Actually, the fallback subcommand takes the orchestrator key as a flag.
-	// We can extract it by running verify first.
-	// For testing, let's just use the cmdTestRunDir helper pattern.
-
-	// Simpler approach: produce a proper run dir with known orchestrator key.
 	dir, orchKey := cmdTestRunDir(t)
 
-	cmd = newRootCmd()
-	buf.Reset()
+	cmd := newRootCmd()
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
 	cmd.SetArgs([]string{"fallback", dir, "--orchestrator-key", orchKey})
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("fallback must exit 0 on valid recorded dir, got: %v\noutput:\n%s", err, buf.String())
 	}

--- a/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
+++ b/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+func TestFallbackCmd_ShowsReplayWatermarkAndHash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("fallback test requires a pre-recorded run dir from a real live run")
+	}
+
+	// Produce a pre-recorded run dir via RunDemo.
+	recordedDir := t.TempDir()
+	var runBuf bytes.Buffer
+	rep, err := playground.RunDemo(t.Context(), &runBuf, playground.DemoOpts{
+		Contained:  false,
+		ScenarioID: "secret-exfil-url-blocked",
+		RunDir:     recordedDir,
+	})
+	if err != nil {
+		t.Fatalf("pre-record run: %v", err)
+	}
+	if !rep.OK {
+		t.Fatalf("pre-record run must verify: %+v", rep)
+	}
+
+	// Now run the fallback command against the recorded dir.
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	// The orchestrator key is in the verify report; use the pipelock key from the run
+	// since that's what the manifest pins. But the fallback command needs the
+	// orchestrator key. We need to extract it. Since RunDemo's verify prints it,
+	// use the verify report's PipelockKey... but actually we need the orchestrator key.
+	// The fallback cmd reads from launch-manifest.json which was signed by the orchestrator.
+	// We need to pass the right key. Let's re-verify to get the orchestrator key.
+	//
+	// Actually, the fallback subcommand takes the orchestrator key as a flag.
+	// We can extract it by running verify first.
+	// For testing, let's just use the cmdTestRunDir helper pattern.
+
+	// Simpler approach: produce a proper run dir with known orchestrator key.
+	dir, orchKey := cmdTestRunDir(t)
+
+	cmd = newRootCmd()
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"fallback", dir, "--orchestrator-key", orchKey})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("fallback must exit 0 on valid recorded dir, got: %v\noutput:\n%s", err, buf.String())
+	}
+
+	out := buf.String()
+
+	// Must contain REPLAY watermark.
+	if !strings.Contains(out, "REPLAY") {
+		t.Fatalf("output must contain REPLAY watermark, got:\n%s", out)
+	}
+
+	// Must contain the packet hash.
+	if !strings.Contains(out, "sha256:") {
+		t.Fatalf("output must contain packet hash (sha256:), got:\n%s", out)
+	}
+
+	// Must contain the verify command.
+	if !strings.Contains(out, "verify") {
+		t.Fatalf("output must contain verify command, got:\n%s", out)
+	}
+}
+
+func TestRunCmd_Uncontained_ExitZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("run test builds binaries and boots a real proxy")
+	}
+
+	rd := t.TempDir()
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"run", "--run-dir", rd, "--scenario", "secret-exfil-url-blocked"})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("run --uncontained must exit 0, got: %v\noutput:\n%s", err, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "VERIFY OK") {
+		t.Fatalf("output must contain VERIFY OK, got:\n%s", out)
+	}
+}

--- a/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
+++ b/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
@@ -21,7 +21,7 @@ func TestFallbackCmd_ShowsReplayWatermarkAndHash(t *testing.T) {
 	var runBuf bytes.Buffer
 	rep, err := playground.RunDemo(t.Context(), &runBuf, playground.DemoOpts{
 		Contained:  false,
-		ScenarioID: "secret-exfil-url-blocked",
+		ScenarioID: playground.LiveDemoScenarioID,
 		RunDir:     recordedDir,
 	})
 	if err != nil {
@@ -88,7 +88,7 @@ func TestRunCmd_Uncontained_ExitZero(t *testing.T) {
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"run", "--run-dir", rd, "--scenario", "secret-exfil-url-blocked"})
+	cmd.SetArgs([]string{"run", "--run-dir", rd, "--scenario", playground.LiveDemoScenarioID})
 	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("run --uncontained must exit 0, got: %v\noutput:\n%s", err, buf.String())

--- a/cmd/pipelock-playground-demo/verify_cmd_test.go
+++ b/cmd/pipelock-playground-demo/verify_cmd_test.go
@@ -77,13 +77,13 @@ func cmdTestRunDir(t *testing.T) (string, string) {
 		CanaryID:        "aws_canary",
 		PipelockPubKey:  engine.PublicKeyHex(),
 		CollectorPubKey: hex.EncodeToString(colPub),
-		PolicyHash:      "sha256:test",
+		PolicyHash:      captured.PolicyHash,
 		TargetHost:      "exfil.target.test",
 		StartedAt:       time.Now().UTC(),
 	})
 
 	ctx := context.Background()
-	rc, err := playground.RunRedCaseCalibration(ctx, colPriv, "aws_canary", cmdCanaryValue)
+	rc, redWitness, err := playground.RunRedCaseCalibrationWithWitness(ctx, colPriv, "aws_canary", cmdCanaryValue)
 	if err != nil {
 		t.Fatalf("redcase: %v", err)
 	}
@@ -102,6 +102,7 @@ func cmdTestRunDir(t *testing.T) (string, string) {
 
 	writeJSON(t, filepath.Join(runDir, "launch-manifest.json"), lm)
 	writeJSON(t, filepath.Join(runDir, "witness.json"), w)
+	writeJSON(t, filepath.Join(runDir, "red-witness.json"), redWitness)
 
 	return runDir, hex.EncodeToString(orchPub)
 }

--- a/cmd/pipelock-playground-demo/verify_cmd_test.go
+++ b/cmd/pipelock-playground-demo/verify_cmd_test.go
@@ -23,6 +23,8 @@ import (
 // cmdCanaryValue builds the canary at runtime (gosec G101).
 const cmdCanaryValue = "AKIA" + "IOSFODNN7EXAMPLE"
 
+const cmdReplayFixtureScenarioID = "secret-exfil-url-blocked"
+
 // cmdTestRunDir builds a good run dir for command-level testing.
 func cmdTestRunDir(t *testing.T) (string, string) {
 	t.Helper()
@@ -45,7 +47,7 @@ func cmdTestRunDir(t *testing.T) (string, string) {
 	scenarios := replaycapture.DefaultScenarios()
 	var exfil replaycapture.Scenario
 	for _, s := range scenarios {
-		if s.ID == "secret-exfil-url-blocked" {
+		if s.ID == cmdReplayFixtureScenarioID {
 			exfil = s
 			break
 		}

--- a/cmd/pipelock-playground-demo/verify_cmd_test.go
+++ b/cmd/pipelock-playground-demo/verify_cmd_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
+)
+
+// cmdCanaryValue builds the canary at runtime (gosec G101).
+const cmdCanaryValue = "AKIA" + "IOSFODNN7EXAMPLE"
+
+// cmdTestRunDir builds a good run dir for command-level testing.
+func cmdTestRunDir(t *testing.T) (string, string) {
+	t.Helper()
+
+	orchPub, orchPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	colPub, colPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	engineDir := t.TempDir()
+	engine, err := replaycapture.NewEngine(engineDir)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	scenarios := replaycapture.DefaultScenarios()
+	var exfil replaycapture.Scenario
+	for _, s := range scenarios {
+		if s.ID == "secret-exfil-url-blocked" {
+			exfil = s
+			break
+		}
+	}
+	if exfil.ID == "" {
+		t.Fatal("scenario not found")
+	}
+
+	captured, err := engine.Capture(exfil)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+
+	runDir := t.TempDir()
+	stageDir := t.TempDir()
+	result, err := playground.AssembleFromEvidence(
+		captured.EvidenceFile, engine.PublicKeyHex(), stageDir, time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatalf("AssembleFromEvidence: %v", err)
+	}
+	if err := os.Rename(result.PacketDir, filepath.Join(runDir, "packet")); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	lm := playground.SignLaunchManifest(orchPriv, playground.LaunchManifest{
+		RunNonce:        "cmd-test",
+		ScenarioID:      exfil.ID,
+		CanaryID:        "aws_canary",
+		PipelockPubKey:  engine.PublicKeyHex(),
+		CollectorPubKey: hex.EncodeToString(colPub),
+		PolicyHash:      "sha256:test",
+		TargetHost:      "exfil.target.test",
+		StartedAt:       time.Now().UTC(),
+	})
+
+	ctx := context.Background()
+	rc, err := playground.RunRedCaseCalibration(ctx, colPriv, "aws_canary", cmdCanaryValue)
+	if err != nil {
+		t.Fatalf("redcase: %v", err)
+	}
+
+	c := playground.NewCollector("aws_canary", cmdCanaryValue)
+	if err := c.OpenRun("cmd-test", lm.Hash()); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+	if err := c.AttachRedCase("cmd-test", rc); err != nil {
+		t.Fatalf("AttachRedCase: %v", err)
+	}
+	w, err := c.SealAndSign("cmd-test", colPriv, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("SealAndSign: %v", err)
+	}
+
+	writeJSON(t, filepath.Join(runDir, "launch-manifest.json"), lm)
+	writeJSON(t, filepath.Join(runDir, "witness.json"), w)
+
+	return runDir, hex.EncodeToString(orchPub)
+}
+
+func writeJSON(t *testing.T, path string, v interface{}) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestVerifyCmd_GoodDir_ExitZero(t *testing.T) {
+	t.Parallel()
+	dir, orchKey := cmdTestRunDir(t)
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"verify", dir, "--orchestrator-key", orchKey})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected exit 0 on good dir, got error: %v\noutput:\n%s", err, buf.String())
+	}
+	if !strings.Contains(buf.String(), "VERIFY OK") {
+		t.Fatalf("expected VERIFY OK in output, got:\n%s", buf.String())
+	}
+}
+
+func TestVerifyCmd_TamperedDir_ExitNonZero(t *testing.T) {
+	t.Parallel()
+	dir, orchKey := cmdTestRunDir(t)
+
+	// Tamper the manifest signature.
+	path := filepath.Clean(filepath.Join(dir, "launch-manifest.json"))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	m["run_nonce"] = json.RawMessage(`"tampered"`)
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"verify", dir, "--orchestrator-key", orchKey})
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected non-zero exit on tampered dir, got nil error\noutput:\n%s", buf.String())
+	}
+}

--- a/cmd/pipelock-playground-toyagent/main.go
+++ b/cmd/pipelock-playground-toyagent/main.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -61,6 +62,8 @@ type agentConfig struct {
 	// DryRun suppresses all subprocess invocations and network calls; only
 	// narration is emitted.  Used by tests.
 	DryRun bool
+	// ExpectBypassBlocked makes step 3 fail if the direct-egress request connects.
+	ExpectBypassBlocked bool
 }
 
 func main() {
@@ -105,6 +108,7 @@ agent's stdout, argv, or any URL.`,
 	root.Flags().StringVar(&cfg.BypassURL, "bypass-url", "", "target URL for the step-3 direct-egress bypass attempt")
 	root.Flags().StringVar(&cfg.WebToolPath, "webtool", "pipelock-playground-webtool", "path to the pipelock-playground-webtool binary")
 	root.Flags().BoolVar(&cfg.DryRun, "dry-run", false, "narrate only, do not invoke the web tool or make network calls")
+	root.Flags().BoolVar(&cfg.ExpectBypassBlocked, "expect-bypass-blocked", false, "fail if the direct-egress bypass connects")
 
 	return root
 }
@@ -245,6 +249,7 @@ func runStep3(ctx context.Context, n narrator, cfg agentConfig) error {
 	// Explicitly nil Proxy: this transport does NOT consult HTTPS_PROXY / HTTP_PROXY.
 	// In a kernel-contained deployment, the direct TCP connection is blocked by nftables.
 	directClient := &http.Client{
+		Timeout: probeTimeout,
 		Transport: &http.Transport{
 			Proxy: nil, // explicitly bypass proxy env
 		},
@@ -265,8 +270,13 @@ func runStep3(ctx context.Context, n narrator, cfg agentConfig) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	n.say("bypass CONNECTED (not running in contained environment): HTTP %d", resp.StatusCode)
+	if cfg.ExpectBypassBlocked {
+		return fmt.Errorf("bypass connected but contained mode expected a kernel block")
+	}
 	return nil
 }
+
+const probeTimeout = 2 * time.Second
 
 // invokeWebTool shells out to the configured web tool binary with the supplied
 // arguments.  The agent's environment is inherited by the subprocess, so the

--- a/cmd/pipelock-playground-toyagent/main.go
+++ b/cmd/pipelock-playground-toyagent/main.go
@@ -289,7 +289,7 @@ func invokeWebTool(ctx context.Context, n narrator, cfg agentConfig, args ...str
 		return errors.New("webtool path is not configured")
 	}
 
-	cmd := exec.CommandContext(ctx, cfg.WebToolPath, args...) //nolint:gosec // G204: web tool path is an operator-configured flag (demo tooling), not untrusted network input.
+	cmd := exec.CommandContext(ctx, cfg.WebToolPath, args...)
 	cmd.Stdout = cfg.webToolWriter(n)
 	cmd.Stderr = cfg.webToolWriter(n)
 	// Env is inherited from the parent process (includes PLAYGROUND_CANARY_VALUE).

--- a/cmd/pipelock-playground-toyagent/main.go
+++ b/cmd/pipelock-playground-toyagent/main.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -198,7 +199,7 @@ func runStep1(ctx context.Context, n narrator, cfg agentConfig) error {
 		return nil
 	}
 
-	return invokeWebTool(ctx, n, cfg, "get", cfg.SafeURL)
+	return invokeWebTool(ctx, n, cfg, false, "get", cfg.SafeURL)
 }
 
 // runStep2 performs an exfiltration POST of the canary to cfg.ExfilURL via
@@ -211,7 +212,11 @@ func runStep2(ctx context.Context, n narrator, cfg agentConfig) error {
 
 	target := cfg.ExfilURL
 	if cfg.RunNonce != "" {
-		target = target + "?run=" + cfg.RunNonce
+		var err error
+		target, err = addRunNonce(target, cfg.RunNonce)
+		if err != nil {
+			return err
+		}
 	}
 	if target != "" {
 		n.say("collector: %s", target)
@@ -222,7 +227,18 @@ func runStep2(ctx context.Context, n narrator, cfg agentConfig) error {
 		return nil
 	}
 
-	return invokeWebTool(ctx, n, cfg, "post", target, "--include-canary")
+	return invokeWebTool(ctx, n, cfg, true, "post", target, "--include-canary")
+}
+
+func addRunNonce(target, nonce string) (string, error) {
+	u, err := url.Parse(target)
+	if err != nil {
+		return "", fmt.Errorf("parse exfil url: %w", err)
+	}
+	q := u.Query()
+	q.Set("run", nonce)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }
 
 // runStep3 performs a raw direct-egress attempt that explicitly bypasses the
@@ -284,7 +300,7 @@ const probeTimeout = 2 * time.Second
 // touching the value itself.
 //
 // IMPORTANT: the canary VALUE must never appear in args.
-func invokeWebTool(ctx context.Context, n narrator, cfg agentConfig, args ...string) error {
+func invokeWebTool(ctx context.Context, n narrator, cfg agentConfig, allowBlockedExit bool, args ...string) error {
 	if cfg.WebToolPath == "" {
 		return errors.New("webtool path is not configured")
 	}
@@ -298,9 +314,13 @@ func invokeWebTool(ctx context.Context, n narrator, cfg agentConfig, args ...str
 	n.say("invoking web tool: %s %s", cfg.WebToolPath, strings.Join(args, " "))
 	if err := cmd.Run(); err != nil {
 		n.say("web tool exited with: %v", err)
-		// Non-zero exit from the web tool (e.g. Pipelock blocked the request)
-		// is reported as narration but is not a fatal agent error; the demo
-		// uses the exit code to distinguish blocked vs allowed.
+		var exitErr *exec.ExitError
+		if allowBlockedExit && errors.As(err, &exitErr) && ctx.Err() == nil {
+			// Pipelock blocking the red POST is the expected result. Startup
+			// errors still propagate because they are not ExitError.
+			return nil
+		}
+		return fmt.Errorf("web tool %s: %w", args[0], err)
 	}
 	return nil
 }

--- a/cmd/pipelock-playground-toyagent/main.go
+++ b/cmd/pipelock-playground-toyagent/main.go
@@ -1,0 +1,325 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is the entry point for pipelock-playground-toyagent, a
+// deterministic scripted agent used in the Pipelock Playground live demo.
+//
+// The agent holds a synthetic canary secret in its environment
+// (PLAYGROUND_CANARY_VALUE) and executes three scripted steps that demonstrate
+// what Pipelock mediates:
+//
+//   - step 1: a safe, allowed GET request via the web tool
+//   - step 2: an attempted exfiltration POST (the canary goes in the request
+//     body via the web tool — Pipelock is meant to catch it)
+//   - step 3: a raw direct-egress bypass attempt that skips the proxy entirely
+//     (kernel containment blocks this in a real contained deployment)
+//
+// Security property: the canary VALUE is read from env (PLAYGROUND_CANARY_VALUE)
+// by the web tool subprocess. It NEVER appears in the agent's stdout, in any
+// command-line argument, or in any URL.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// agentConfig holds all parameters for a runAgent invocation.  The canary
+// VALUE is intentionally absent: it is read from PLAYGROUND_CANARY_VALUE by
+// the web tool subprocess, never stored on this struct or passed as an arg.
+type agentConfig struct {
+	// Scenario is a human-readable label for the demo run (e.g. "live-demo").
+	Scenario string
+	// Step is the step to execute: "1", "2", "3", or "all".
+	Step string
+	// RunNonce is a unique identifier for this run, appended as a URL query
+	// param on the exfil POST so the collector can correlate evidence.
+	RunNonce string
+	// SecretLabel is the name of the synthetic secret being demonstrated (e.g.
+	// "aws_canary").  This label is printed in narration; the VALUE is never
+	// narrated.
+	SecretLabel string
+	// SafeURL is the target of step 1 (allowed GET).
+	SafeURL string
+	// ExfilURL is the base URL for the step 2 exfil POST collector.
+	ExfilURL string
+	// BypassURL is the target for the step 3 direct-egress attempt.
+	BypassURL string
+	// WebToolPath is the path to the pipelock-playground-webtool binary.
+	// In DryRun mode this is never invoked.
+	WebToolPath string
+	// DryRun suppresses all subprocess invocations and network calls; only
+	// narration is emitted.  Used by tests.
+	DryRun bool
+}
+
+func main() {
+	root := newRootCmd()
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newRootCmd() *cobra.Command {
+	var cfg agentConfig
+
+	root := &cobra.Command{
+		Use:   "pipelock-playground-toyagent",
+		Short: "Deterministic toy agent for the Pipelock Playground live demo",
+		Long: `pipelock-playground-toyagent is a scripted, deterministic agent that
+demonstrates Pipelock's mediation boundary in the Pipelock Playground.
+
+The agent holds a synthetic canary secret in env (PLAYGROUND_CANARY_VALUE) and
+drives three scripted steps through the pipelock-playground-webtool:
+
+  step 1 — safe allowed GET (should be permitted)
+  step 2 — exfiltration POST of the canary (Pipelock should block this)
+  step 3 — raw direct-egress bypass attempt (kernel containment blocks this)
+
+The canary VALUE is read from env by the web tool; it never appears in the
+agent's stdout, argv, or any URL.`,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		Version:       cliutil.Version,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAgent(cmd.Context(), cmd.OutOrStdout(), cfg)
+		},
+	}
+
+	root.Flags().StringVar(&cfg.Scenario, "scenario", "live-demo", "human-readable scenario label")
+	root.Flags().StringVar(&cfg.Step, "step", "all", `step to execute: "1", "2", "3", or "all"`)
+	root.Flags().StringVar(&cfg.RunNonce, "run-nonce", "", "unique run identifier (appended to exfil URL)")
+	root.Flags().StringVar(&cfg.SecretLabel, "canary-label", "aws_canary", "label for the synthetic canary secret (never the value)")
+	root.Flags().StringVar(&cfg.SafeURL, "safe-url", "", "target URL for the step-1 allowed GET")
+	root.Flags().StringVar(&cfg.ExfilURL, "exfil-url", "", "base URL for the step-2 exfiltration POST collector")
+	root.Flags().StringVar(&cfg.BypassURL, "bypass-url", "", "target URL for the step-3 direct-egress bypass attempt")
+	root.Flags().StringVar(&cfg.WebToolPath, "webtool", "pipelock-playground-webtool", "path to the pipelock-playground-webtool binary")
+	root.Flags().BoolVar(&cfg.DryRun, "dry-run", false, "narrate only, do not invoke the web tool or make network calls")
+
+	return root
+}
+
+// narrator is a helper that writes step narration to out with a consistent prefix.
+type narrator struct {
+	out io.Writer
+}
+
+func (n narrator) say(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	// Ensure each line is prefixed with the agent marker.
+	for _, line := range strings.Split(strings.TrimRight(msg, "\n"), "\n") {
+		_, _ = fmt.Fprintf(n.out, "[agent] %s\n", line)
+	}
+}
+
+// runAgent executes the scripted demo steps according to cfg.
+//
+// The canary VALUE is NEVER stored in cfg, printed to out, or passed as an
+// argv to the web tool — the web tool reads it from its inherited environment.
+func runAgent(ctx context.Context, out io.Writer, cfg agentConfig) error {
+	n := narrator{out: out}
+
+	n.say("=== Pipelock Playground Toy Agent ===")
+	if cfg.Scenario != "" {
+		n.say("scenario: %s", cfg.Scenario)
+	}
+	if cfg.RunNonce != "" {
+		n.say("run-nonce: %s", cfg.RunNonce)
+	}
+
+	steps := resolveSteps(cfg.Step)
+	if len(steps) == 0 {
+		return fmt.Errorf("unknown step %q: must be 1, 2, 3, or all", cfg.Step)
+	}
+
+	for _, step := range steps {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		var stepErr error
+		switch step {
+		case 1:
+			stepErr = runStep1(ctx, n, cfg)
+		case 2:
+			stepErr = runStep2(ctx, n, cfg)
+		case 3:
+			stepErr = runStep3(ctx, n, cfg)
+		}
+		if stepErr != nil {
+			return stepErr
+		}
+	}
+
+	n.say("=== agent finished ===")
+	return nil
+}
+
+// resolveSteps parses the step string into an ordered list of step numbers.
+func resolveSteps(step string) []int {
+	switch step {
+	case "1":
+		return []int{1}
+	case "2":
+		return []int{2}
+	case "3":
+		return []int{3}
+	case "all", "":
+		return []int{1, 2, 3}
+	default:
+		return nil
+	}
+}
+
+// runStep1 performs a safe, proxy-allowed GET request to cfg.SafeURL via the
+// web tool subprocess.  The canary is NOT involved in this step.
+func runStep1(ctx context.Context, n narrator, cfg agentConfig) error {
+	n.say("--- step 1: fetch safe lab URL ---")
+	n.say("intent: performing allowed GET to the lab safe endpoint")
+	if cfg.SafeURL != "" {
+		n.say("target: %s", cfg.SafeURL)
+	}
+
+	if cfg.DryRun {
+		n.say("(dry-run: skipping web tool invocation)")
+		return nil
+	}
+
+	return invokeWebTool(ctx, n, cfg, "get", cfg.SafeURL)
+}
+
+// runStep2 performs an exfiltration POST of the canary to cfg.ExfilURL via
+// the web tool.  The canary LABEL is narrated; the VALUE is NOT printed here —
+// it lives in the env and is read by the web tool subprocess.
+func runStep2(ctx context.Context, n narrator, cfg agentConfig) error {
+	n.say("--- step 2: exfiltration attempt ---")
+	n.say("intent: attempting to exfiltrate %s to the lab collector", cfg.SecretLabel)
+	n.say("(pipelock should block this — the canary value is in env, not argv/stdout)")
+
+	target := cfg.ExfilURL
+	if cfg.RunNonce != "" {
+		target = target + "?run=" + cfg.RunNonce
+	}
+	if target != "" {
+		n.say("collector: %s", target)
+	}
+
+	if cfg.DryRun {
+		n.say("(dry-run: skipping web tool invocation)")
+		return nil
+	}
+
+	return invokeWebTool(ctx, n, cfg, "post", target, "--include-canary")
+}
+
+// runStep3 performs a raw direct-egress attempt that explicitly bypasses the
+// proxy (Proxy: nil on the transport).  In a kernel-contained deployment this
+// will be blocked at the network layer; in a plain unit-test environment it
+// may succeed or fail depending on network availability.
+func runStep3(ctx context.Context, n narrator, cfg agentConfig) error {
+	n.say("--- step 3: direct-egress bypass attempt ---")
+	n.say("intent: attempting raw direct-egress, ignoring the proxy (no HTTPS_PROXY)")
+	if cfg.BypassURL != "" {
+		n.say("target: %s", cfg.BypassURL)
+	}
+
+	if cfg.DryRun {
+		n.say("(dry-run: skipping network call)")
+		return nil
+	}
+
+	if cfg.BypassURL == "" {
+		n.say("(bypass-url not set, skipping)")
+		return nil
+	}
+
+	// Explicitly nil Proxy: this transport does NOT consult HTTPS_PROXY / HTTP_PROXY.
+	// In a kernel-contained deployment, the direct TCP connection is blocked by nftables.
+	directClient := &http.Client{
+		Transport: &http.Transport{
+			Proxy: nil, // explicitly bypass proxy env
+		},
+	}
+
+	// A malformed bypass URL is an operator/config error (distinct from the
+	// expected "bypass blocked" outcome below), so surface it.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BypassURL, nil)
+	if err != nil {
+		return fmt.Errorf("building bypass request: %w", err)
+	}
+
+	resp, err := directClient.Do(req)
+	if err != nil {
+		n.say("bypass BLOCKED (as expected in contained environment): %v", err)
+		return nil // expected outcome — not an agent error
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	n.say("bypass CONNECTED (not running in contained environment): HTTP %d", resp.StatusCode)
+	return nil
+}
+
+// invokeWebTool shells out to the configured web tool binary with the supplied
+// arguments.  The agent's environment is inherited by the subprocess, so the
+// web tool has access to PLAYGROUND_CANARY_VALUE without the agent ever
+// touching the value itself.
+//
+// IMPORTANT: the canary VALUE must never appear in args.
+func invokeWebTool(ctx context.Context, n narrator, cfg agentConfig, args ...string) error {
+	if cfg.WebToolPath == "" {
+		return errors.New("webtool path is not configured")
+	}
+
+	cmd := exec.CommandContext(ctx, cfg.WebToolPath, args...) //nolint:gosec // G204: web tool path is an operator-configured flag (demo tooling), not untrusted network input.
+	cmd.Stdout = cfg.webToolWriter(n)
+	cmd.Stderr = cfg.webToolWriter(n)
+	// Env is inherited from the parent process (includes PLAYGROUND_CANARY_VALUE).
+	// We do NOT set cmd.Env so we don't have to handle the value at all.
+
+	n.say("invoking web tool: %s %s", cfg.WebToolPath, strings.Join(args, " "))
+	if err := cmd.Run(); err != nil {
+		n.say("web tool exited with: %v", err)
+		// Non-zero exit from the web tool (e.g. Pipelock blocked the request)
+		// is reported as narration but is not a fatal agent error; the demo
+		// uses the exit code to distinguish blocked vs allowed.
+	}
+	return nil
+}
+
+// webToolWriter returns a writer that prefixes web tool output with [webtool].
+func (cfg agentConfig) webToolWriter(n narrator) io.Writer {
+	return &prefixWriter{prefix: "[webtool] ", out: n.out}
+}
+
+// prefixWriter prepends a fixed prefix to each line written to it.
+type prefixWriter struct {
+	prefix string
+	out    io.Writer
+	buf    []byte
+}
+
+func (pw *prefixWriter) Write(p []byte) (int, error) {
+	pw.buf = append(pw.buf, p...)
+	for {
+		idx := strings.IndexByte(string(pw.buf), '\n')
+		if idx < 0 {
+			break
+		}
+		line := pw.buf[:idx+1]
+		_, err := fmt.Fprintf(pw.out, "%s%s", pw.prefix, string(line))
+		if err != nil {
+			return 0, err
+		}
+		pw.buf = pw.buf[idx+1:]
+	}
+	return len(p), nil
+}

--- a/cmd/pipelock-playground-toyagent/main_test.go
+++ b/cmd/pipelock-playground-toyagent/main_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -167,4 +168,73 @@ func TestToyAgent_UnknownStep(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown step")
 	}
+}
+
+func TestRootCmd_DryRunExecutesConfiguredStep(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := newRootCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--step", "1", "--safe-url", "http://safe.target.test/", "--dry-run"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("root command dry-run: %v", err)
+	}
+	if !strings.Contains(buf.String(), "safe") {
+		t.Fatalf("expected dry-run narration, got:\n%s", buf.String())
+	}
+}
+
+func TestPrefixWriter_PrefixesCompleteLines(t *testing.T) {
+	var buf bytes.Buffer
+	w := &prefixWriter{prefix: "[webtool] ", out: &buf}
+	if _, err := w.Write([]byte("one\ntwo\npartial")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got, want := buf.String(), "[webtool] one\n[webtool] two\n"; got != want {
+		t.Fatalf("prefixed output = %q, want %q", got, want)
+	}
+	if string(w.buf) != "partial" {
+		t.Fatalf("partial line buffer = %q", string(w.buf))
+	}
+}
+
+func TestAddRunNonce_EncodesAndPreservesExistingQuery(t *testing.T) {
+	got, err := addRunNonce("http://collector.test/ingest?existing=1", "run 1/2")
+	if err != nil {
+		t.Fatalf("addRunNonce: %v", err)
+	}
+	if got != "http://collector.test/ingest?existing=1&run=run+1%2F2" {
+		t.Fatalf("unexpected encoded URL: %s", got)
+	}
+}
+
+func TestInvokeWebTool_PropagatesSafeStepFailure(t *testing.T) {
+	t.Setenv("GO_WANT_PLAYGROUND_HELPER_PROCESS", "exit")
+
+	var buf bytes.Buffer
+	err := invokeWebTool(t.Context(), narrator{out: &buf}, agentConfig{
+		WebToolPath: os.Args[0],
+	}, false, "-test.run=TestHelperProcess")
+	if err == nil {
+		t.Fatal("safe step must propagate web tool exit errors")
+	}
+}
+
+func TestInvokeWebTool_AllowsBlockedRedPostExit(t *testing.T) {
+	t.Setenv("GO_WANT_PLAYGROUND_HELPER_PROCESS", "exit")
+
+	var buf bytes.Buffer
+	err := invokeWebTool(t.Context(), narrator{out: &buf}, agentConfig{
+		WebToolPath: os.Args[0],
+	}, true, "-test.run=TestHelperProcess")
+	if err != nil {
+		t.Fatalf("red POST should allow web tool exit error: %v", err)
+	}
+}
+
+func TestHelperProcess(_ *testing.T) {
+	if os.Getenv("GO_WANT_PLAYGROUND_HELPER_PROCESS") != "exit" {
+		return
+	}
+	os.Exit(7)
 }

--- a/cmd/pipelock-playground-toyagent/main_test.go
+++ b/cmd/pipelock-playground-toyagent/main_test.go
@@ -6,6 +6,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -112,6 +114,26 @@ func TestToyAgent_Step3_DryRun(t *testing.T) {
 	if !strings.Contains(strings.ToLower(out), "bypass") &&
 		!strings.Contains(strings.ToLower(out), "direct") {
 		t.Fatalf("step 3 narration should mention bypass attempt; got: %q", out)
+	}
+}
+
+func TestToyAgent_Step3_ExpectedBlockFailsOnConnectedBypass(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	err := runAgent(t.Context(), &buf, agentConfig{
+		Step:                "3",
+		BypassURL:           srv.URL,
+		ExpectBypassBlocked: true,
+	})
+	if err == nil {
+		t.Fatal("expected contained bypass check to fail when direct egress connects")
+	}
+	if strings.Contains(buf.String(), canaryValue()) {
+		t.Fatal("step 3 must not print the canary value")
 	}
 }
 

--- a/cmd/pipelock-playground-toyagent/main_test.go
+++ b/cmd/pipelock-playground-toyagent/main_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// canaryValue is split so the literal never appears in a string constant that
+// could end up in narration.  The value lives ONLY in the env var and (via the
+// web tool) in POST request bodies — never in argv, stdout, or URLs.
+const (
+	canaryPart1 = "AKIA"
+	canaryPart2 = "IOSFODNN7EXAMPLE"
+)
+
+// demoLabelParts are assembled at runtime to avoid gosec G101 false-positives
+// on string literals that contain credential-sounding words like "canary".
+const (
+	demoLabelPfx = "aws_"
+	demoLabelSfx = "canary"
+)
+
+// demoLabel returns the human-readable name for the synthetic secret used
+// across demo steps.  Built at runtime so gosec does not flag the literal.
+func demoLabel() string { return demoLabelPfx + demoLabelSfx }
+
+// canaryValue returns the synthetic canary assembled at runtime.
+func canaryValue() string { return canaryPart1 + canaryPart2 }
+
+// TestToyAgent_NarratesLabelNotValue verifies that the toy agent prints the
+// LABEL for the canary (e.g. "aws_canary") but NEVER the literal value, even
+// in DryRun mode where no subprocess is launched.
+func TestToyAgent_NarratesLabelNotValue(t *testing.T) {
+	t.Setenv("PLAYGROUND_CANARY_VALUE", canaryValue())
+
+	var buf bytes.Buffer
+	err := runAgent(t.Context(), &buf, agentConfig{
+		SecretLabel: demoLabel(),
+		Step:        "2",
+		RunNonce:    "N1",
+		DryRun:      true,
+	})
+	if err != nil {
+		t.Fatalf("runAgent: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, canaryValue()) {
+		t.Fatal("agent MUST NEVER print the canary value to stdout")
+	}
+	if !strings.Contains(out, demoLabel()) {
+		t.Fatal("agent must narrate the canary label")
+	}
+}
+
+// TestToyAgent_Step1_DryRun checks that step 1 narrates the safe URL fetch
+// intent without executing anything and without printing the canary.
+func TestToyAgent_Step1_DryRun(t *testing.T) {
+	t.Setenv("PLAYGROUND_CANARY_VALUE", canaryValue())
+
+	var buf bytes.Buffer
+	err := runAgent(t.Context(), &buf, agentConfig{
+		SecretLabel: demoLabel(),
+		Step:        "1",
+		SafeURL:     "http://lab.example/safe",
+		RunNonce:    "R1",
+		DryRun:      true,
+	})
+	if err != nil {
+		t.Fatalf("runAgent step 1: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, canaryValue()) {
+		t.Fatal("step 1 must not mention the canary value")
+	}
+	// Should mention fetching / safe URL concept in narration.
+	if !strings.Contains(strings.ToLower(out), "safe") &&
+		!strings.Contains(strings.ToLower(out), "fetch") &&
+		!strings.Contains(strings.ToLower(out), "lab") {
+		t.Fatalf("step 1 narration should mention the safe fetch; got: %q", out)
+	}
+}
+
+// TestToyAgent_Step3_DryRun checks that step 3 narrates bypass intent without
+// the canary value appearing.
+func TestToyAgent_Step3_DryRun(t *testing.T) {
+	t.Setenv("PLAYGROUND_CANARY_VALUE", canaryValue())
+
+	var buf bytes.Buffer
+	cfg3 := agentConfig{
+		Step:     "3",
+		DryRun:   true,
+		RunNonce: "step3test",
+	}
+	cfg3.BypassURL = "http://direct.example/test"
+	cfg3.SecretLabel = demoLabel()
+	err := runAgent(t.Context(), &buf, cfg3)
+	if err != nil {
+		t.Fatalf("runAgent step 3: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, canaryValue()) {
+		t.Fatal("step 3 must not mention the canary value")
+	}
+	if !strings.Contains(strings.ToLower(out), "bypass") &&
+		!strings.Contains(strings.ToLower(out), "direct") {
+		t.Fatalf("step 3 narration should mention bypass attempt; got: %q", out)
+	}
+}
+
+// TestToyAgent_ContextCancellation checks that a cancelled context causes
+// runAgent to return promptly (DryRun so no subprocesses involved).
+func TestToyAgent_ContextCancellation(t *testing.T) {
+	t.Setenv("PLAYGROUND_CANARY_VALUE", canaryValue())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // already cancelled
+
+	var buf bytes.Buffer
+	// In DryRun mode the agent should still complete (no blocking I/O);
+	// context cancellation should not cause a panic.
+	_ = runAgent(ctx, &buf, agentConfig{
+		SecretLabel: demoLabel(),
+		Step:        "1",
+		DryRun:      true,
+	})
+}
+
+// TestToyAgent_UnknownStep errors on an unknown step string.
+func TestToyAgent_UnknownStep(t *testing.T) {
+	t.Setenv("PLAYGROUND_CANARY_VALUE", canaryValue())
+
+	var buf bytes.Buffer
+	err := runAgent(t.Context(), &buf, agentConfig{
+		Step:   "99",
+		DryRun: true,
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown step")
+	}
+}

--- a/cmd/pipelock-playground-webtool/main.go
+++ b/cmd/pipelock-playground-webtool/main.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is the entry point for pipelock-playground-webtool, a minimal
+// HTTP utility used by pipelock-playground-toyagent to make requests that
+// travel through the Pipelock proxy.
+//
+// The web tool is a SEPARATE binary so the live demo visibly demonstrates the
+// agent→tool separation that Pipelock mediates.  It makes requests using
+// http.DefaultTransport, which respects HTTPS_PROXY / HTTP_PROXY, so all
+// traffic flows through whatever proxy the environment configures.
+//
+// Subcommands:
+//
+//	get  <url>                 Perform an HTTP GET to the given URL.
+//	post <url> [--include-canary]  Perform an HTTP POST.  With --include-canary,
+//	                               the canary value is read from
+//	                               PLAYGROUND_CANARY_VALUE (env) and placed in
+//	                               the request body.  The value is NEVER read
+//	                               from argv.
+//
+// Security property: the canary VALUE lives only in the environment and in the
+// POST body.  It is never passed as a command-line argument and never placed in
+// a URL.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	err := runWebTool(context.Background(), os.Stdout, os.Args[1:], os.Getenv)
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "[webtool] error:", err)
+		os.Exit(1)
+	}
+}
+
+// runWebTool is the testable core of pipelock-playground-webtool.
+//
+//   - ctx        request context
+//   - out        destination for status / diagnostic output
+//   - args       command-line arguments (does NOT include argv[0])
+//   - lookupEnv  function to look up an env variable (os.Getenv in production;
+//     injected in tests so the canary value never has to be in a real env var)
+//
+// Security property: the canary VALUE is obtained only from lookupEnv, never
+// from args.  Callers must not put the value in args.
+func runWebTool(ctx context.Context, out io.Writer, args []string, lookupEnv func(string) string) error {
+	if len(args) == 0 {
+		return errors.New("usage: webtool <get|post> <url> [--include-canary]")
+	}
+
+	subcmd := args[0]
+	rest := args[1:]
+
+	switch subcmd {
+	case "get":
+		return doGet(ctx, out, rest)
+	case "post":
+		return doPost(ctx, out, rest, lookupEnv)
+	default:
+		return fmt.Errorf("unknown subcommand %q: must be get or post", subcmd)
+	}
+}
+
+// doGet performs an HTTP GET to the URL in args[0].  The default http.Client
+// is used, which respects HTTPS_PROXY / HTTP_PROXY from the environment.
+func doGet(ctx context.Context, out io.Writer, args []string) error {
+	if len(args) == 0 {
+		return errors.New("get requires a URL")
+	}
+	targetURL := args[0]
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+	if err != nil {
+		return fmt.Errorf("build GET request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", targetURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	_, _ = fmt.Fprintf(out, "[webtool] GET %s -> HTTP %d\n", targetURL, resp.StatusCode)
+	return nil
+}
+
+// doPost performs an HTTP POST to the URL in args[0].  If args contains
+// "--include-canary", the canary value is read from PLAYGROUND_CANARY_VALUE
+// via lookupEnv and placed in the request body as a form-encoded field.
+//
+// Security: the canary VALUE is obtained from lookupEnv only.  It is never in
+// args, never in the URL, and never printed to out.
+func doPost(ctx context.Context, out io.Writer, args []string, lookupEnv func(string) string) error {
+	if len(args) == 0 {
+		return errors.New("post requires a URL")
+	}
+	targetURL := args[0]
+
+	// Check for --include-canary flag in the remaining args.
+	includeCanary := false
+	for _, a := range args[1:] {
+		if a == "--include-canary" {
+			includeCanary = true
+		}
+	}
+
+	var bodyStr string
+	if includeCanary {
+		// Read the canary VALUE from the environment — never from argv.
+		canaryVal := lookupEnv("PLAYGROUND_CANARY_VALUE")
+		// field=<value> is a minimal form body suitable for DLP detection testing.
+		bodyStr = "field=" + canaryVal
+	} else {
+		bodyStr = "field=ping"
+	}
+
+	body := strings.NewReader(bodyStr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, body)
+	if err != nil {
+		return fmt.Errorf("build POST request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST %s: %w", targetURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Report status but NEVER echo the body or the canary value.
+	_, _ = fmt.Fprintf(out, "[webtool] POST %s -> HTTP %d\n", targetURL, resp.StatusCode)
+	return nil
+}

--- a/cmd/pipelock-playground-webtool/main.go
+++ b/cmd/pipelock-playground-webtool/main.go
@@ -87,8 +87,8 @@ func runWebTool(ctx context.Context, out io.Writer, args []string, lookupEnv fun
 
 // doGet performs an HTTP GET to the URL in args[0].
 func doGet(ctx context.Context, out io.Writer, args []string, lookupEnv func(string) string) error {
-	if len(args) == 0 {
-		return errors.New("get requires a URL")
+	if len(args) != 1 {
+		return errors.New("get requires exactly one URL")
 	}
 	targetURL := args[0]
 
@@ -127,8 +127,11 @@ func doPost(ctx context.Context, out io.Writer, args []string, lookupEnv func(st
 	// Check for --include-canary flag in the remaining args.
 	includeCanary := false
 	for _, a := range args[1:] {
-		if a == "--include-canary" {
+		switch a {
+		case "--include-canary":
 			includeCanary = true
+		default:
+			return fmt.Errorf("unknown post argument %q", a)
 		}
 	}
 

--- a/cmd/pipelock-playground-webtool/main.go
+++ b/cmd/pipelock-playground-webtool/main.go
@@ -22,6 +22,10 @@
 // Security property: the canary VALUE lives only in the environment and in the
 // POST body.  It is never passed as a command-line argument and never placed in
 // a URL.
+//
+// Agent identity: if PLAYGROUND_AGENT_ID is set in the environment, the web
+// tool adds an X-Pipelock-Agent header on every request so the proxy records
+// the correct actor identity in its receipts.
 package main
 
 import (
@@ -33,6 +37,14 @@ import (
 	"os"
 	"strings"
 )
+
+// agentIDEnvVar, when set, causes the web tool to add an X-Pipelock-Agent
+// header on every request. This is how the playground's receipts record the
+// correct actor identity instead of "anonymous".
+const agentIDEnvVar = "PLAYGROUND_AGENT_ID"
+
+// agentHeader is the canonical Pipelock agent identity header.
+const agentHeader = "X-Pipelock-Agent"
 
 func main() {
 	err := runWebTool(context.Background(), os.Stdout, os.Args[1:], os.Getenv)
@@ -62,7 +74,7 @@ func runWebTool(ctx context.Context, out io.Writer, args []string, lookupEnv fun
 
 	switch subcmd {
 	case "get":
-		return doGet(ctx, out, rest)
+		return doGet(ctx, out, rest, lookupEnv)
 	case "post":
 		return doPost(ctx, out, rest, lookupEnv)
 	default:
@@ -72,7 +84,7 @@ func runWebTool(ctx context.Context, out io.Writer, args []string, lookupEnv fun
 
 // doGet performs an HTTP GET to the URL in args[0].  The default http.Client
 // is used, which respects HTTPS_PROXY / HTTP_PROXY from the environment.
-func doGet(ctx context.Context, out io.Writer, args []string) error {
+func doGet(ctx context.Context, out io.Writer, args []string, lookupEnv func(string) string) error {
 	if len(args) == 0 {
 		return errors.New("get requires a URL")
 	}
@@ -82,6 +94,7 @@ func doGet(ctx context.Context, out io.Writer, args []string) error {
 	if err != nil {
 		return fmt.Errorf("build GET request: %w", err)
 	}
+	setAgentHeader(req, lookupEnv)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -129,6 +142,7 @@ func doPost(ctx context.Context, out io.Writer, args []string, lookupEnv func(st
 		return fmt.Errorf("build POST request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	setAgentHeader(req, lookupEnv)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -139,4 +153,13 @@ func doPost(ctx context.Context, out io.Writer, args []string, lookupEnv func(st
 	// Report status but NEVER echo the body or the canary value.
 	_, _ = fmt.Fprintf(out, "[webtool] POST %s -> HTTP %d\n", targetURL, resp.StatusCode)
 	return nil
+}
+
+// setAgentHeader adds the X-Pipelock-Agent header to a request when the
+// PLAYGROUND_AGENT_ID env var is set. This ensures the proxy records the
+// correct actor identity in its receipts.
+func setAgentHeader(req *http.Request, lookupEnv func(string) string) {
+	if id := lookupEnv(agentIDEnvVar); id != "" {
+		req.Header.Set(agentHeader, id)
+	}
 }

--- a/cmd/pipelock-playground-webtool/main.go
+++ b/cmd/pipelock-playground-webtool/main.go
@@ -36,6 +36,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 )
 
 // agentIDEnvVar, when set, causes the web tool to add an X-Pipelock-Agent
@@ -45,6 +46,8 @@ const agentIDEnvVar = "PLAYGROUND_AGENT_ID"
 
 // agentHeader is the canonical Pipelock agent identity header.
 const agentHeader = "X-Pipelock-Agent"
+
+const webToolHTTPTimeout = 5 * time.Second
 
 func main() {
 	err := runWebTool(context.Background(), os.Stdout, os.Args[1:], os.Getenv)
@@ -82,8 +85,7 @@ func runWebTool(ctx context.Context, out io.Writer, args []string, lookupEnv fun
 	}
 }
 
-// doGet performs an HTTP GET to the URL in args[0].  The default http.Client
-// is used, which respects HTTPS_PROXY / HTTP_PROXY from the environment.
+// doGet performs an HTTP GET to the URL in args[0].
 func doGet(ctx context.Context, out io.Writer, args []string, lookupEnv func(string) string) error {
 	if len(args) == 0 {
 		return errors.New("get requires a URL")
@@ -96,7 +98,7 @@ func doGet(ctx context.Context, out io.Writer, args []string, lookupEnv func(str
 	}
 	setAgentHeader(req, lookupEnv)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := webToolHTTPClient().Do(req)
 	if err != nil {
 		return fmt.Errorf("GET %s: %w", targetURL, err)
 	}
@@ -104,6 +106,10 @@ func doGet(ctx context.Context, out io.Writer, args []string, lookupEnv func(str
 
 	_, _ = fmt.Fprintf(out, "[webtool] GET %s -> HTTP %d\n", targetURL, resp.StatusCode)
 	return nil
+}
+
+func webToolHTTPClient() *http.Client {
+	return &http.Client{Timeout: webToolHTTPTimeout}
 }
 
 // doPost performs an HTTP POST to the URL in args[0].  If args contains
@@ -144,7 +150,7 @@ func doPost(ctx context.Context, out io.Writer, args []string, lookupEnv func(st
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	setAgentHeader(req, lookupEnv)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := webToolHTTPClient().Do(req)
 	if err != nil {
 		return fmt.Errorf("POST %s: %w", targetURL, err)
 	}

--- a/cmd/pipelock-playground-webtool/main_test.go
+++ b/cmd/pipelock-playground-webtool/main_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// canaryPart1 + canaryPart2 compose the synthetic canary; split so the full
+// literal never appears as a single string constant (OPSEC guard).
+const (
+	canaryPart1 = "AKIA"
+	canaryPart2 = "IOSFODNN7EXAMPLE"
+)
+
+func canaryValue() string { return canaryPart1 + canaryPart2 }
+
+// TestWebTool_PostIncludesCanaryFromEnv asserts that when --include-canary is
+// set, the web tool reads the canary VALUE from the environment and places it
+// in the POST body, NOT from argv.  We verify that no argv passed to
+// runWebTool contains the canary value.
+func TestWebTool_PostIncludesCanaryFromEnv(t *testing.T) {
+	cv := canaryValue()
+	t.Setenv("PLAYGROUND_CANARY_VALUE", cv)
+
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		receivedBody = b
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	// argv must NOT contain the canary value.
+	args := []string{"post", srv.URL, "--include-canary"}
+	for _, a := range args {
+		if strings.Contains(a, cv) {
+			t.Fatalf("argv must not contain canary value; found in: %q", a)
+		}
+	}
+
+	var buf bytes.Buffer
+	err := runWebTool(t.Context(), &buf, args, func(key string) string {
+		if key == "PLAYGROUND_CANARY_VALUE" {
+			return cv
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("runWebTool: %v", err)
+	}
+
+	body := string(receivedBody)
+	if !strings.Contains(body, cv) {
+		t.Fatalf("POST body should contain canary value; got: %q", body)
+	}
+}
+
+// TestWebTool_GetDoesNotSendCanary verifies that a plain GET never sends the
+// canary value.
+func TestWebTool_GetDoesNotSendCanary(t *testing.T) {
+	cv := canaryValue()
+	t.Setenv("PLAYGROUND_CANARY_VALUE", cv)
+
+	var receivedURL string
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedURL = r.RequestURI
+		b, _ := io.ReadAll(r.Body)
+		receivedBody = b
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("safe"))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	err := runWebTool(t.Context(), &buf, []string{"get", srv.URL}, func(key string) string {
+		if key == "PLAYGROUND_CANARY_VALUE" {
+			return cv
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("runWebTool GET: %v", err)
+	}
+
+	if strings.Contains(receivedURL, cv) {
+		t.Fatalf("canary must not appear in GET URL; got: %q", receivedURL)
+	}
+	if strings.Contains(string(receivedBody), cv) {
+		t.Fatalf("canary must not appear in GET body; got: %q", string(receivedBody))
+	}
+}
+
+// TestWebTool_PostWithoutCanaryFlagOmitsCanary verifies that without
+// --include-canary the POST body does NOT contain the canary, even if the env
+// var is set.
+func TestWebTool_PostWithoutCanaryFlagOmitsCanary(t *testing.T) {
+	cv := canaryValue()
+	t.Setenv("PLAYGROUND_CANARY_VALUE", cv)
+
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		receivedBody = b
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	err := runWebTool(t.Context(), &buf, []string{"post", srv.URL}, func(key string) string {
+		if key == "PLAYGROUND_CANARY_VALUE" {
+			return cv
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("runWebTool POST without flag: %v", err)
+	}
+
+	if strings.Contains(string(receivedBody), cv) {
+		t.Fatalf("canary must NOT appear in body when --include-canary is absent; got: %q", string(receivedBody))
+	}
+}
+
+// TestWebTool_GetPrintsStatusLine checks that the GET output includes an HTTP
+// status indicator.
+func TestWebTool_GetPrintsStatusLine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	err := runWebTool(t.Context(), &buf, []string{"get", srv.URL}, func(_ string) string { return "" })
+	if err != nil {
+		t.Fatalf("runWebTool GET: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "200") {
+		t.Fatalf("expected status 200 in output; got: %q", out)
+	}
+}
+
+// TestWebTool_UnknownSubcommand returns an error for an unknown subcommand.
+func TestWebTool_UnknownSubcommand(t *testing.T) {
+	var buf bytes.Buffer
+	err := runWebTool(t.Context(), &buf, []string{"delete", "http://x.example"}, func(_ string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand")
+	}
+}
+
+// TestWebTool_MissingURL returns an error when no URL is given.
+func TestWebTool_MissingURL(t *testing.T) {
+	var buf bytes.Buffer
+	err := runWebTool(t.Context(), &buf, []string{"get"}, func(_ string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error for missing URL")
+	}
+}

--- a/cmd/pipelock-playground-webtool/main_test.go
+++ b/cmd/pipelock-playground-webtool/main_test.go
@@ -193,6 +193,14 @@ func TestWebTool_MissingURL(t *testing.T) {
 	}
 }
 
+func TestWebTool_PostMissingURL(t *testing.T) {
+	var buf bytes.Buffer
+	err := runWebTool(t.Context(), &buf, []string{"post"}, func(_ string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error for missing POST URL")
+	}
+}
+
 func TestWebTool_GetRejectsExtraArgs(t *testing.T) {
 	var buf bytes.Buffer
 	err := runWebTool(t.Context(), &buf, []string{"get", "http://x.example", "--include-canary"}, func(_ string) string { return "" })
@@ -206,6 +214,32 @@ func TestWebTool_PostRejectsUnknownArg(t *testing.T) {
 	err := runWebTool(t.Context(), &buf, []string{"post", "http://x.example", "--include-canery"}, func(_ string) string { return "" })
 	if err == nil {
 		t.Fatal("expected error for unknown POST argument")
+	}
+}
+
+func TestWebTool_RequestBuildErrors(t *testing.T) {
+	for _, args := range [][]string{
+		{"get", "http://[::1"},
+		{"post", "http://[::1"},
+	} {
+		var buf bytes.Buffer
+		err := runWebTool(t.Context(), &buf, args, func(_ string) string { return "" })
+		if err == nil {
+			t.Fatalf("expected request build error for args %v", args)
+		}
+	}
+}
+
+func TestWebTool_HTTPDoErrors(t *testing.T) {
+	for _, args := range [][]string{
+		{"get", "ftp://example.test/resource"},
+		{"post", "ftp://example.test/resource"},
+	} {
+		var buf bytes.Buffer
+		err := runWebTool(t.Context(), &buf, args, func(_ string) string { return "" })
+		if err == nil {
+			t.Fatalf("expected HTTP client error for args %v", args)
+		}
 	}
 }
 

--- a/cmd/pipelock-playground-webtool/main_test.go
+++ b/cmd/pipelock-playground-webtool/main_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // canaryPart1 + canaryPart2 compose the synthetic canary; split so the full
@@ -99,6 +100,29 @@ func TestWebTool_GetDoesNotSendCanary(t *testing.T) {
 	}
 }
 
+func TestWebTool_GetSendsAgentHeaderWhenConfigured(t *testing.T) {
+	var gotAgent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAgent = r.Header.Get(agentHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	err := runWebTool(t.Context(), &buf, []string{"get", srv.URL}, func(key string) string {
+		if key == agentIDEnvVar {
+			return "lab-agent"
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("runWebTool GET: %v", err)
+	}
+	if gotAgent != "lab-agent" {
+		t.Fatalf("agent header = %q", gotAgent)
+	}
+}
+
 // TestWebTool_PostWithoutCanaryFlagOmitsCanary verifies that without
 // --include-canary the POST body does NOT contain the canary, even if the env
 // var is set.
@@ -166,5 +190,11 @@ func TestWebTool_MissingURL(t *testing.T) {
 	err := runWebTool(t.Context(), &buf, []string{"get"}, func(_ string) string { return "" })
 	if err == nil {
 		t.Fatal("expected error for missing URL")
+	}
+}
+
+func TestWebTool_HTTPClientHasTimeout(t *testing.T) {
+	if webToolHTTPClient().Timeout != 5*time.Second {
+		t.Fatalf("web tool HTTP timeout = %s", webToolHTTPClient().Timeout)
 	}
 }

--- a/cmd/pipelock-playground-webtool/main_test.go
+++ b/cmd/pipelock-playground-webtool/main_test.go
@@ -193,6 +193,22 @@ func TestWebTool_MissingURL(t *testing.T) {
 	}
 }
 
+func TestWebTool_GetRejectsExtraArgs(t *testing.T) {
+	var buf bytes.Buffer
+	err := runWebTool(t.Context(), &buf, []string{"get", "http://x.example", "--include-canary"}, func(_ string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error for extra GET argument")
+	}
+}
+
+func TestWebTool_PostRejectsUnknownArg(t *testing.T) {
+	var buf bytes.Buffer
+	err := runWebTool(t.Context(), &buf, []string{"post", "http://x.example", "--include-canery"}, func(_ string) string { return "" })
+	if err == nil {
+		t.Fatal("expected error for unknown POST argument")
+	}
+}
+
 func TestWebTool_HTTPClientHasTimeout(t *testing.T) {
 	if webToolHTTPClient().Timeout != 5*time.Second {
 		t.Fatalf("web tool HTTP timeout = %s", webToolHTTPClient().Timeout)

--- a/docs/guides/playground-demo.md
+++ b/docs/guides/playground-demo.md
@@ -1,0 +1,119 @@
+# Playground live demo engine
+
+`pipelock-playground-demo` drives a **deterministic toy agent** through a real Pipelock
+proxy and produces an offline-verifiable evidence bundle. It is the live counterpart to the
+[replay-capture rig](playground-replay-capture.md): instead of pre-recording scenarios, it
+runs one live, and lets a viewer verify the result afterward — with Pipelock already stopped.
+
+It is demo/evidence tooling, not part of the production firewall.
+
+## What it shows
+
+A deterministic toy agent runs as a separate process, holds a **synthetic** canary secret in
+its environment, and uses a small "web tool" to make HTTP. Pipelock — a separate process
+holding none of the agent's secrets — mediates each action and signs each decision:
+
+1. **Allowed action** — the agent fetches a safe lab URL; Pipelock allows it; a signed receipt
+   is recorded.
+2. **Blocked exfiltration** — the agent tries to send the canary to a lab collector; Pipelock
+   blocks it before the collector receives it; a signed receipt is recorded, and a separate
+   **signed collector witness** independently records that the canary did not arrive.
+3. **Direct-egress bypass** *(contained mode only)* — the agent tries raw egress that ignores
+   the proxy; host containment denies it at the kernel.
+4. **Offline verification** — the run's evidence verifies with one command after the Pipelock
+   process is stopped.
+
+## What it proves (and does not)
+
+> This proves the **included mediated decisions** and the **lab collector's observation for
+> this lab run** — not universal session completeness, not global non-exfiltration, not that
+> no event was missed.
+
+Each on-screen claim carries one of four explicit **evidence classes**, and no element is shown
+as a stronger class than it is:
+
+| Class | Meaning | Signed by |
+|---|---|---|
+| `pipelock_decision` | an allow/block decision in the receipt chain | the Pipelock mediator key |
+| `collector_witness` | the lab collector's target-side observation | the collector key (separate) |
+| `host_containment` | the direct-egress bypass denied by the kernel | not a receipt — operational result |
+| `narration` | the agent's printed intent | unsigned playback |
+
+The proxy mediation and the signed receipts/witness are **binary-enforced**. The direct-egress
+block (contained mode) is **host/deployment-enforced** via `pipelock contain` (kernel nftables);
+it is not a property of this tool's binary and is only present when the agent is actually
+contained.
+
+## Run it
+
+The demo material is **synthetic by construction** — the canary is an inert published-example
+value and the lab targets are reserved `.test` hosts. Nothing real is ever in the agent's
+environment, on the wire, or in the artifacts.
+
+### Uncontained (development / iteration — no privileges)
+
+```bash
+pipelock-playground-demo run --run-dir ./demo-run --scenario secret-exfil-url-blocked
+```
+
+This boots a real Pipelock proxy + lab targets on loopback, drives the toy agent through the
+proxy, renders the evidence-class-labeled mediator timeline, assembles the Audit Packet, and
+verifies it. The direct-egress bypass beat is **skipped** here: without containment there is no
+kernel boundary to demonstrate, and the tool says so rather than implying one.
+
+### Contained (the real demo — requires a prepared host)
+
+```bash
+sudo pipelock-playground-demo run --contained --run-dir ./demo-run --scenario secret-exfil-url-blocked
+```
+
+Contained mode requires root and a host where `pipelock contain install` has been run. Before
+the bypass beat, it runs a **fail-closed egress self-test**: if any known-bad direct route is
+reachable, the run aborts rather than claim a containment that is not in effect. Off such a host
+the command fails loudly — it never silently falls back to uncontained while claiming contained.
+
+## Verify it yourself
+
+From the run directory, on a clean machine, with the Pipelock process stopped:
+
+```bash
+pipelock-playground-demo verify ./demo-run --orchestrator-key <published orchestrator key hex>
+```
+
+This is one all-or-nothing check rooted in a single published key. It passes only when **all**
+of the following hold: the launch manifest is signed by the orchestrator key; the Audit Packet's
+receipt chain and totals verify under the Pipelock key the manifest pins; the collector witness
+verifies under the collector key the manifest pins; the witness binds this run's nonce and
+manifest; and the witness carries a genuine red-case calibration. Any single failure exits
+non-zero.
+
+The receipt chain alone is also verifiable with the shipped `pipelock-verifier audit-packet`
+against `./demo-run/packet` — but note that verifier checks the packet and chain only, not the
+collector witness; the witness checks are part of `pipelock-playground-demo verify`.
+
+### Red-case calibration
+
+The collector witness is only trusted when the *same* collector build has been shown to detect
+the canary. The run includes a **red-case calibration**: a deliberately unmediated run in which
+the canary reaches the collector and the witness goes red (`observed > 0`). The calibration
+result is signed into the live run's witness, so verification can require proof that the
+collector demonstrably detects what it claims to have not observed.
+
+## Reset and fallback
+
+```bash
+pipelock-playground-demo reset --run-dir ./demo-run        # idempotent clean slate
+pipelock-playground-demo fallback ./demo-run --orchestrator-key <hex>   # replay a recorded run
+```
+
+`fallback` replays a previously recorded run with a prominent `*** REPLAY MODE ***` watermark,
+the recorded packet hash, and the verifier command — so a replayed run is never mistaken for a
+live one.
+
+## Public-safety model
+
+Inherited from the replay-capture rig: synthetic inputs only; receipts redacted before signing;
+a fail-closed field allowlist and artifact linter over the published text artifacts; the canary
+value lives only in the agent's environment and the request body Pipelock inspects, never on a
+command line, in a URL, or on screen. Screenshots and social images are a separate manual
+curation step (the text linter does not inspect pixels).

--- a/docs/guides/playground-demo.md
+++ b/docs/guides/playground-demo.md
@@ -9,9 +9,10 @@ It is demo/evidence tooling, not part of the production firewall.
 
 ## What it shows
 
-A deterministic toy agent runs as a separate process, holds a **synthetic** canary secret in
-its environment, and uses a small "web tool" to make HTTP. Pipelock — a separate process
-holding none of the agent's secrets — mediates each action and signs each decision:
+A deterministic toy agent runs as a separate process, holds an inert credential-shaped canary
+in its environment, and uses a small "web tool" to make HTTP. Pipelock runs as a separate
+process, is not preloaded with the exact canary value, detects the credential class in the
+request body, mediates each action, and signs each decision:
 
 1. **Allowed action** — the agent fetches a safe lab URL; Pipelock allows it; a signed receipt
    is recorded.
@@ -53,7 +54,7 @@ environment, on the wire, or in the artifacts.
 ### Uncontained (development / iteration — no privileges)
 
 ```bash
-pipelock-playground-demo run --run-dir ./demo-run --scenario secret-exfil-url-blocked
+pipelock-playground-demo run --run-dir ./demo-run --scenario secret-exfil-body-blocked
 ```
 
 This boots a real Pipelock proxy + lab targets on loopback, drives the toy agent through the
@@ -64,13 +65,14 @@ kernel boundary to demonstrate, and the tool says so rather than implying one.
 ### Contained (the real demo — requires a prepared host)
 
 ```bash
-sudo pipelock-playground-demo run --contained --run-dir ./demo-run --scenario secret-exfil-url-blocked
+sudo pipelock-playground-demo run --contained --run-dir ./demo-run --scenario secret-exfil-body-blocked
 ```
 
-Contained mode requires root and a host where `pipelock contain install` has been run. Before
-the bypass beat, it runs a **fail-closed egress self-test**: if any known-bad direct route is
-reachable, the run aborts rather than claim a containment that is not in effect. Off such a host
-the command fails loudly — it never silently falls back to uncontained while claiming contained.
+Contained mode requires root, the `pipelock-agent` OS user, and a host where
+`pipelock contain install` has been run. The bypass beat is executed by the toy-agent process
+after dropping to that contained user; if the direct-egress request connects, the run aborts
+rather than claim a containment that is not in effect. Off such a host the command fails loudly
+— it never silently falls back to uncontained while claiming contained.
 
 ## Verify it yourself
 
@@ -82,10 +84,12 @@ pipelock-playground-demo verify ./demo-run --orchestrator-key <published orchest
 
 This is one all-or-nothing check rooted in a single published key. It passes only when **all**
 of the following hold: the launch manifest is signed by the orchestrator key; the Audit Packet's
-receipt chain and totals verify under the Pipelock key the manifest pins; the collector witness
-verifies under the collector key the manifest pins; the witness binds this run's nonce and
-manifest; and the witness carries a genuine red-case calibration. Any single failure exits
-non-zero.
+receipt chain and totals verify under the Pipelock key the manifest pins; the packet manifest
+matches the launch manifest's scenario and policy hash; the collector witness verifies under
+the collector key the manifest pins; the witness binds this run's nonce and manifest; the
+collector observed zero requests for the blocked exfil run; the packet contains the expected
+allow and `body_dlp` block receipts; and the witness carries a genuine red-case calibration
+backed by a signed `red-witness.json` artifact. Any single failure exits non-zero.
 
 The receipt chain alone is also verifiable with the shipped `pipelock-verifier audit-packet`
 against `./demo-run/packet` — but note that verifier checks the packet and chain only, not the
@@ -96,8 +100,9 @@ collector witness; the witness checks are part of `pipelock-playground-demo veri
 The collector witness is only trusted when the *same* collector build has been shown to detect
 the canary. The run includes a **red-case calibration**: a deliberately unmediated run in which
 the canary reaches the collector and the witness goes red (`observed > 0`). The calibration
-result is signed into the live run's witness, so verification can require proof that the
-collector demonstrably detects what it claims to have not observed.
+result is signed into the live run's witness, and the signed red witness is written as
+`red-witness.json`, so verification can require proof that the collector demonstrably detects
+what it claims to have not observed.
 
 ## Reset and fallback
 

--- a/internal/playground/assemble_shared.go
+++ b/internal/playground/assemble_shared.go
@@ -13,6 +13,16 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
 )
 
+// AssembleFromEvidenceWithScenario is the same as AssembleFromEvidence but
+// accepts a full Scenario so the assembled CapturedScenario carries the real
+// Title, Category, ExpectedVerdict, etc. This is needed by the live-run path
+// where the caller knows the scenario and BuildManifest needs the full fields.
+// When sc is nil the function falls back to deriving a bare Scenario from the
+// evidence path (identical to AssembleFromEvidence).
+func AssembleFromEvidenceWithScenario(evidenceFile, pubKeyHex string, sc *replaycapture.Scenario, outDir string, generatedAt time.Time) (*replaycapture.AssembleResult, error) {
+	return assembleFromEvidenceCore(evidenceFile, pubKeyHex, sc, outDir, generatedAt)
+}
+
 // AssembleFromEvidence turns a live evidence JSONL file (written by a real
 // Pipelock proxy with receipt emission) into a verified Audit Packet directory.
 // This is the shared seam between the live-demo runner and the shipped
@@ -30,6 +40,10 @@ import (
 // evidence alone. AssemblePacket uses only Scenario.ID; callers that also need
 // BuildManifest must supply the full Scenario separately.
 func AssembleFromEvidence(evidenceFile, pubKeyHex, outDir string, generatedAt time.Time) (*replaycapture.AssembleResult, error) {
+	return assembleFromEvidenceCore(evidenceFile, pubKeyHex, nil, outDir, generatedAt)
+}
+
+func assembleFromEvidenceCore(evidenceFile, pubKeyHex string, sc *replaycapture.Scenario, outDir string, generatedAt time.Time) (*replaycapture.AssembleResult, error) {
 	cleanPath := filepath.Clean(evidenceFile)
 
 	if _, err := os.Stat(cleanPath); err != nil {
@@ -49,10 +63,17 @@ func AssembleFromEvidence(evidenceFile, pubKeyHex, outDir string, generatedAt ti
 		return nil, fmt.Errorf("chain verification failed: %s", chain.Error)
 	}
 
-	// Derive scenario ID from the evidence file's parent directory name.
-	scenarioID := filepath.Base(filepath.Dir(cleanPath))
-	if scenarioID == "." || scenarioID == "/" {
-		scenarioID = "live-evidence"
+	// Use the caller-supplied scenario when available; otherwise derive a
+	// bare Scenario from the evidence file's parent directory name.
+	var scenario replaycapture.Scenario
+	if sc != nil {
+		scenario = *sc
+	} else {
+		scenarioID := filepath.Base(filepath.Dir(cleanPath))
+		if scenarioID == "." || scenarioID == "/" {
+			scenarioID = "live-evidence"
+		}
+		scenario = replaycapture.Scenario{ID: scenarioID}
 	}
 
 	// Extract policy hash from the first receipt (all receipts in a single
@@ -60,9 +81,7 @@ func AssembleFromEvidence(evidenceFile, pubKeyHex, outDir string, generatedAt ti
 	policyHash := receipts[0].ActionRecord.PolicyHash
 
 	cs := &replaycapture.CapturedScenario{
-		Scenario: replaycapture.Scenario{
-			ID: scenarioID,
-		},
+		Scenario:     scenario,
 		Receipts:     receipts,
 		EvidenceFile: cleanPath,
 		SignerKeyHex: pubKeyHex,

--- a/internal/playground/assemble_shared.go
+++ b/internal/playground/assemble_shared.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
+)
+
+// AssembleFromEvidence turns a live evidence JSONL file (written by a real
+// Pipelock proxy with receipt emission) into a verified Audit Packet directory.
+// This is the shared seam between the live-demo runner and the shipped
+// replaycapture assembly pipeline.
+//
+// It reconstructs a replaycapture.CapturedScenario from the evidence file by
+// extracting receipts, verifying the chain, and populating the fields that
+// AssemblePacket/BuildManifest/WriteManifest need. The scenario ID is derived
+// from the evidence file's parent directory name (matching the convention that
+// Engine.Capture writes evidence into <workDir>/<scenarioID>/).
+//
+// Constraint: the Scenario field of the reconstructed CapturedScenario carries
+// only the ID (derived from the evidence path). Fields like Title, Category,
+// ExpectedVerdict, etc. are empty because they are not recoverable from the
+// evidence alone. AssemblePacket uses only Scenario.ID; callers that also need
+// BuildManifest must supply the full Scenario separately.
+func AssembleFromEvidence(evidenceFile, pubKeyHex, outDir string, generatedAt time.Time) (*replaycapture.AssembleResult, error) {
+	cleanPath := filepath.Clean(evidenceFile)
+
+	if _, err := os.Stat(cleanPath); err != nil {
+		return nil, fmt.Errorf("evidence file: %w", err)
+	}
+
+	receipts, err := receipt.ExtractReceipts(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("extract receipts: %w", err)
+	}
+	if len(receipts) == 0 {
+		return nil, fmt.Errorf("no receipts in %s", cleanPath)
+	}
+
+	chain := receipt.VerifyChain(receipts, pubKeyHex)
+	if !chain.Valid {
+		return nil, fmt.Errorf("chain verification failed: %s", chain.Error)
+	}
+
+	// Derive scenario ID from the evidence file's parent directory name.
+	scenarioID := filepath.Base(filepath.Dir(cleanPath))
+	if scenarioID == "." || scenarioID == "/" {
+		scenarioID = "live-evidence"
+	}
+
+	// Extract policy hash from the first receipt (all receipts in a single
+	// capture share the same policy hash).
+	policyHash := receipts[0].ActionRecord.PolicyHash
+
+	cs := &replaycapture.CapturedScenario{
+		Scenario: replaycapture.Scenario{
+			ID: scenarioID,
+		},
+		Receipts:     receipts,
+		EvidenceFile: cleanPath,
+		SignerKeyHex: pubKeyHex,
+		PolicyHash:   policyHash,
+		RootHash:     chain.RootHash,
+		FinalSeq:     chain.FinalSeq,
+		ReceiptCount: len(receipts),
+		ChainResult:  chain,
+	}
+
+	result, err := replaycapture.AssemblePacket(cs, outDir, generatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("assemble packet: %w", err)
+	}
+
+	// Read the written packet.json so BuildManifest can compute the binding
+	// SHA-256 over the exact bytes on disk.
+	packetPath := filepath.Join(result.PacketDir, "packet.json")
+	packetBytes, err := os.ReadFile(filepath.Clean(packetPath))
+	if err != nil {
+		return nil, fmt.Errorf("read packet.json for manifest binding: %w", err)
+	}
+
+	manifest := replaycapture.BuildManifest(cs, result, packetBytes, "")
+	if err := replaycapture.WriteManifest(result.PacketDir, manifest); err != nil {
+		return nil, fmt.Errorf("write manifest: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/playground/assemble_shared.go
+++ b/internal/playground/assemble_shared.go
@@ -70,7 +70,7 @@ func assembleFromEvidenceCore(evidenceFile, pubKeyHex string, sc *replaycapture.
 		scenario = *sc
 	} else {
 		scenarioID := filepath.Base(filepath.Dir(cleanPath))
-		if scenarioID == "." || scenarioID == "/" {
+		if scenarioID == "" || scenarioID == "." || scenarioID == ".." || scenarioID == "/" {
 			scenarioID = "live-evidence"
 		}
 		scenario = replaycapture.Scenario{ID: scenarioID}

--- a/internal/playground/assemble_shared_test.go
+++ b/internal/playground/assemble_shared_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
+)
+
+func TestAssembleFromEvidence_ProducesVerifiablePacket(t *testing.T) {
+	t.Parallel()
+
+	// Use a real scenario from DefaultScenarios (the AWS-key exfil one) driven
+	// through a real proxy to produce genuine signed evidence.
+	scenarios := replaycapture.DefaultScenarios()
+	var exfilScenario replaycapture.Scenario
+	for _, s := range scenarios {
+		if s.ID == "secret-exfil-url-blocked" {
+			exfilScenario = s
+			break
+		}
+	}
+	if exfilScenario.ID == "" {
+		t.Fatal("secret-exfil-url-blocked scenario not found in DefaultScenarios()")
+	}
+
+	// Capture: drive the scenario through a real proxy, producing signed
+	// receipts in an evidence JSONL file.
+	engine, err := replaycapture.NewEngine(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	captured, err := engine.Capture(exfilScenario)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+
+	// AssembleFromEvidence: the shared helper under test. It takes the raw
+	// evidence file + the signer public key and produces a verified Audit
+	// Packet directory.
+	outDir := t.TempDir()
+	generatedAt := time.Now().UTC()
+	result, err := playground.AssembleFromEvidence(
+		captured.EvidenceFile,
+		engine.PublicKeyHex(),
+		outDir,
+		generatedAt,
+	)
+	if err != nil {
+		t.Fatalf("AssembleFromEvidence: %v", err)
+	}
+
+	if result.PacketDir == "" {
+		t.Fatal("AssembleResult.PacketDir is empty")
+	}
+	if result.Receipts == 0 {
+		t.Fatal("AssembleResult.Receipts is zero")
+	}
+
+	// Verify: the produced packet directory must pass the same verification
+	// that the shipped pipelock-verifier uses.
+	if err := replaycapture.VerifyPacketDir(result.PacketDir, engine.PublicKeyHex()); err != nil {
+		t.Fatalf("VerifyPacketDir: %v", err)
+	}
+}

--- a/internal/playground/containment.go
+++ b/internal/playground/containment.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/user"
 	"time"
 )
 
@@ -32,6 +33,8 @@ type ProbeResult struct {
 // enough to keep the self-test fast, long enough that a real connection on
 // loopback or LAN completes.
 const probeTimeout = 2 * time.Second
+
+const defaultContainedAgentUser = "pipelock-agent"
 
 // ProbeDirectEgress attempts a direct (proxy-less) TCP connection to target
 // (host:port). It classifies the result as Open (connected) or Blocked
@@ -140,13 +143,6 @@ func RunContainmentSelfTest(ctx context.Context, targets []string) SelfTestResul
 	}
 }
 
-// selfTestTargets returns the direct-egress suite for use in self-tests.
-// This is the same list as DirectEgressTargets(); factored here so the
-// self-test call site reads clearly.
-func selfTestTargets() []string {
-	return DirectEgressTargets()
-}
-
 // --------------------------------------------------------------------------
 // ErrContainmentSelfTestFailed is returned when the per-run containment
 // self-test detects open routes, meaning containment is not fully enforced.
@@ -189,9 +185,8 @@ func NewRealContainmentHook(pipelockBin string) *RealContainmentHook {
 	}
 }
 
-// Setup prepares kernel containment: verifies privileges, runs
-// `pipelock contain install` (or verifies it was already run), then
-// executes the per-run containment self-test.
+// Setup prepares kernel containment: verifies privileges, verifies
+// `pipelock contain` is installed, and confirms the contained agent user exists.
 //
 // HOST-VERIFICATION-PENDING: this method only succeeds on a privileged
 // host with `pipelock contain` installed. It returns a descriptive error
@@ -213,27 +208,20 @@ func (h *RealContainmentHook) Setup(ctx context.Context, opts DemoOpts) error {
 		return fmt.Errorf("containment setup: pipelock binary %q not found: %w", bin, err)
 	}
 
+	agentUser := h.AgentUser
+	if agentUser == "" {
+		agentUser = defaultContainedAgentUser
+	}
+	if _, err := user.Lookup(agentUser); err != nil {
+		return fmt.Errorf("containment setup: contained agent user %q not found: %w", agentUser, err)
+	}
+
 	// --- Verify containment is installed (pipelock contain verify) ---
 	verifyCmd := exec.CommandContext(ctx, resolvedBin, "contain", "verify") //nolint:gosec // G204: resolvedBin is operator-configured, not untrusted input.
 	verifyOut, verifyErr := verifyCmd.CombinedOutput()
 	if verifyErr != nil {
 		return fmt.Errorf("containment setup: 'pipelock contain verify' failed "+
 			"(containment may not be installed): %w\noutput: %s", verifyErr, verifyOut)
-	}
-
-	// --- Per-run containment self-test ---
-	// Before showing the bypass beat, confirm known-bad routes are actually
-	// blocked. This is the fail-closed gate: if any route is open, the demo
-	// must not proceed in contained mode.
-	result := RunContainmentSelfTest(ctx, selfTestTargets())
-	if !result.AllBlocked {
-		var openTargets []string
-		for _, p := range result.Probes {
-			if p.Open {
-				openTargets = append(openTargets, p.Target)
-			}
-		}
-		return fmt.Errorf("%w: open routes: %v", ErrContainmentSelfTestFailed, openTargets)
 	}
 
 	return nil
@@ -285,20 +273,17 @@ func ContainmentAvailable() bool {
 // --------------------------------------------------------------------------
 // Wiring point for RunDemo: where to call RunContainmentSelfTest.
 //
-// T9's RunDemo must call RunContainmentSelfTest BEFORE step 3 (the bypass
-// beat) when opts.Contained is true. The call site is in orchestrate.go
-// between the containment hook Setup and the step 3 RunSteps call. The
-// RealContainmentHook.Setup already runs the self-test, so the gate is
-// enforced. If a different hook implementation is used (e.g. for testing),
-// the self-test should be called explicitly:
+// T9's RunDemo uses the actual step 3 toy-agent bypass attempt as the contained
+// egress gate. The older RunContainmentSelfTest helper remains useful for
+// diagnostics, but it runs in the caller's process and is not representative of
+// UID-scoped containment when the caller is root. If a future hook can execute
+// probes as the contained user, it should call:
 //
-//   result := RunContainmentSelfTest(ctx, selfTestTargets())
+//   result := RunContainmentSelfTest(ctx, DirectEgressTargets())
 //   if !result.AllBlocked {
 //       return VerifyReport{}, ErrContainmentSelfTestFailed
 //   }
 //
-// This is documented here rather than wired into orchestrate.go's step 3
-// path because T9 owns the RunDemo integration and may choose a different
-// call site. The self-test gate is ALREADY enforced by RealContainmentHook.
-// Setup for the production path.
+// The production path's fail-closed check is the contained toy-agent process
+// running with --expect-bypass-blocked.
 // --------------------------------------------------------------------------

--- a/internal/playground/containment.go
+++ b/internal/playground/containment.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// --------------------------------------------------------------------------
+// Egress probe: attempt a direct (no-proxy) TCP connection to a target and
+// classify it as Open (reachable) or Blocked (refused / timeout / no route).
+// --------------------------------------------------------------------------
+
+// ProbeResult holds the outcome of a single direct-egress probe.
+type ProbeResult struct {
+	// Target is the host:port that was probed.
+	Target string
+	// Open is true when the probe connected successfully (egress is NOT blocked).
+	Open bool
+	// Detail is a human-readable classification (e.g. "connected", "connection refused").
+	Detail string
+}
+
+// probeTimeout is the per-target TCP dial timeout for egress probes. Short
+// enough to keep the self-test fast, long enough that a real connection on
+// loopback or LAN completes.
+const probeTimeout = 2 * time.Second
+
+// ProbeDirectEgress attempts a direct (proxy-less) TCP connection to target
+// (host:port). It classifies the result as Open (connected) or Blocked
+// (refused, timeout, no route, or any other failure). The probe uses an
+// explicit nil-Proxy transport so HTTP_PROXY / HTTPS_PROXY env vars are
+// NOT consulted -- this is testing the raw network path, not the mediated one.
+func ProbeDirectEgress(ctx context.Context, target string) ProbeResult {
+	dialer := &net.Dialer{Timeout: probeTimeout}
+
+	dialCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
+	conn, err := dialer.DialContext(dialCtx, "tcp", target)
+	if err != nil {
+		return ProbeResult{
+			Target: target,
+			Open:   false,
+			Detail: fmt.Sprintf("blocked: %v", err),
+		}
+	}
+	_ = conn.Close()
+	return ProbeResult{
+		Target: target,
+		Open:   true,
+		Detail: "connected",
+	}
+}
+
+// --------------------------------------------------------------------------
+// Target suites: the two categories of egress targets the demo probes.
+// --------------------------------------------------------------------------
+
+// DirectEgressTargets returns the direct-egress containment suite: addresses
+// the kernel must block when containment is active. These are the "known-bad"
+// routes that a contained agent should never reach directly.
+//
+// Each entry is a host:port suitable for a TCP dial. The list covers the
+// categories from the playground spec:
+//   - Cloud metadata IP (169.254.169.254:80)
+//   - RFC-1918 private IP (10.0.0.1:443)
+//   - IPv6 link-local ([fe80::1]:443)
+//   - Public DNS resolvers (8.8.8.8:53 UDP/TCP, 1.1.1.1:853 DoT)
+//   - Public HTTPS endpoint (93.184.216.34:443 -- example.com's IP)
+func DirectEgressTargets() []string {
+	return []string{
+		"169.254.169.254:80", // cloud metadata
+		"10.0.0.1:443",       // RFC-1918 private
+		"[fe80::1]:443",      // IPv6 link-local
+		"8.8.8.8:53",         // public DNS (Google)
+		"1.1.1.1:853",        // public DNS over TLS (Cloudflare)
+		"93.184.216.34:443",  // public HTTPS (example.com)
+	}
+}
+
+// MediatedProxyPolicyTargets returns the mediated-proxy-policy suite: request
+// patterns that must be blocked by the proxy's policy engine (DLP, domain
+// blocklist, SSRF) even when traffic is routed through the proxy. These are
+// tested as URL patterns during the live run, not as raw TCP targets.
+func MediatedProxyPolicyTargets() []string {
+	return []string{
+		"http://exfil.target.test/redirect-to-forbidden",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://[::1]:8080/",
+		"http://metadata.google.internal/computeMetadata/v1/",
+		"ftp://exfil.target.test/data",
+		"http://10.0.0.1:8080/internal-api",
+	}
+}
+
+// --------------------------------------------------------------------------
+// Self-test: probe all known-bad routes and report whether containment holds.
+// --------------------------------------------------------------------------
+
+// SelfTestResult holds the aggregate result of probing all known-bad routes.
+type SelfTestResult struct {
+	// Probes contains one result per target.
+	Probes []ProbeResult
+	// AllBlocked is true ONLY when every single known-bad route was blocked.
+	// This is the fail-closed gate: any open route -> AllBlocked=false ->
+	// contained demo must abort.
+	AllBlocked bool
+}
+
+// RunContainmentSelfTest probes every target in the provided list via direct
+// (no-proxy) TCP and returns the aggregate result. AllBlocked is true ONLY
+// if EVERY target was blocked. Any single open route means containment is
+// not active (or is incomplete).
+//
+// This function is the per-run gate: in contained mode, the demo calls this
+// BEFORE the bypass beat (step 3) and aborts if AllBlocked is false.
+func RunContainmentSelfTest(ctx context.Context, targets []string) SelfTestResult {
+	probes := make([]ProbeResult, 0, len(targets))
+	allBlocked := true
+
+	for _, t := range targets {
+		p := ProbeDirectEgress(ctx, t)
+		probes = append(probes, p)
+		if p.Open {
+			allBlocked = false
+		}
+	}
+
+	return SelfTestResult{
+		Probes:     probes,
+		AllBlocked: allBlocked,
+	}
+}
+
+// selfTestTargets returns the direct-egress suite for use in self-tests.
+// This is the same list as DirectEgressTargets(); factored here so the
+// self-test call site reads clearly.
+func selfTestTargets() []string {
+	return DirectEgressTargets()
+}
+
+// --------------------------------------------------------------------------
+// ErrContainmentSelfTestFailed is returned when the per-run containment
+// self-test detects open routes, meaning containment is not fully enforced.
+// --------------------------------------------------------------------------
+
+// ErrContainmentSelfTestFailed signals that the per-run self-test found at
+// least one known-bad route is reachable, so the contained demo cannot proceed
+// honestly.
+var ErrContainmentSelfTestFailed = errors.New(
+	"playground: containment self-test failed: at least one known-bad route is reachable; " +
+		"contained demo cannot proceed (direct egress is not fully blocked)")
+
+// --------------------------------------------------------------------------
+// RealContainmentHook: integrates with the shipped `pipelock contain` mechanism.
+// --------------------------------------------------------------------------
+
+// RealContainmentHook implements ContainmentHook by delegating to the
+// shipped `pipelock contain` mechanism for kernel-level agent containment.
+//
+// HOST-VERIFICATION-PENDING: Setup and Teardown require root privileges and
+// a working `pipelock contain install` + nftables setup. They return
+// descriptive errors when privileges or tooling are unavailable. The actual
+// kernel-blocks-egress property is verified ONLY on a privileged host, not
+// in CI. Unit tests skip the end-to-end test with a clear message.
+type RealContainmentHook struct {
+	// PipelockBin is the path to the pipelock binary used for containment.
+	// When empty, "pipelock" is resolved via PATH.
+	PipelockBin string
+
+	// AgentUser is the contained agent username.
+	// When empty, defaults to "pipelock-agent".
+	AgentUser string
+}
+
+// NewRealContainmentHook creates a RealContainmentHook with the given
+// pipelock binary path. Pass "" to resolve "pipelock" via PATH.
+func NewRealContainmentHook(pipelockBin string) *RealContainmentHook {
+	return &RealContainmentHook{
+		PipelockBin: pipelockBin,
+	}
+}
+
+// Setup prepares kernel containment: verifies privileges, runs
+// `pipelock contain install` (or verifies it was already run), then
+// executes the per-run containment self-test.
+//
+// HOST-VERIFICATION-PENDING: this method only succeeds on a privileged
+// host with `pipelock contain` installed. It returns a descriptive error
+// when the prerequisites are not met.
+func (h *RealContainmentHook) Setup(ctx context.Context, opts DemoOpts) error {
+	// --- Privilege check ---
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("containment setup requires root privileges (euid=%d); "+
+			"run with sudo or as root", os.Geteuid())
+	}
+
+	// --- Resolve pipelock binary ---
+	bin := h.PipelockBin
+	if bin == "" {
+		bin = "pipelock"
+	}
+	resolvedBin, err := exec.LookPath(bin)
+	if err != nil {
+		return fmt.Errorf("containment setup: pipelock binary %q not found: %w", bin, err)
+	}
+
+	// --- Verify containment is installed (pipelock contain verify) ---
+	verifyCmd := exec.CommandContext(ctx, resolvedBin, "contain", "verify") //nolint:gosec // G204: resolvedBin is operator-configured, not untrusted input.
+	verifyOut, verifyErr := verifyCmd.CombinedOutput()
+	if verifyErr != nil {
+		return fmt.Errorf("containment setup: 'pipelock contain verify' failed "+
+			"(containment may not be installed): %w\noutput: %s", verifyErr, verifyOut)
+	}
+
+	// --- Per-run containment self-test ---
+	// Before showing the bypass beat, confirm known-bad routes are actually
+	// blocked. This is the fail-closed gate: if any route is open, the demo
+	// must not proceed in contained mode.
+	result := RunContainmentSelfTest(ctx, selfTestTargets())
+	if !result.AllBlocked {
+		var openTargets []string
+		for _, p := range result.Probes {
+			if p.Open {
+				openTargets = append(openTargets, p.Target)
+			}
+		}
+		return fmt.Errorf("%w: open routes: %v", ErrContainmentSelfTestFailed, openTargets)
+	}
+
+	return nil
+}
+
+// Teardown cleans up containment state for the run directory. On a real host,
+// this would remove nft chains and stop agent processes. The teardown is
+// best-effort: errors are returned but should not prevent cleanup of other
+// resources.
+//
+// HOST-VERIFICATION-PENDING: actual nft cleanup requires root.
+func (h *RealContainmentHook) Teardown(runDir string) error {
+	// The shipped containment model's nft chains are persistent (they survive
+	// across runs). Per-run teardown only needs to clean up agent processes
+	// if any were started. The playground demo's toy agent is ephemeral
+	// (exec.CommandContext with the run's context), so it is already dead by
+	// the time teardown runs.
+	//
+	// Future: if the playground ever starts long-lived contained processes,
+	// kill them here.
+	_ = runDir // reserved for future per-run state cleanup
+	return nil
+}
+
+// --------------------------------------------------------------------------
+// requirePrivilegedHost is a test helper that skips tests requiring root
+// and a working containment setup.
+// --------------------------------------------------------------------------
+
+// ContainmentAvailable checks whether `pipelock contain verify` can be run
+// successfully. Used by tests to gate host-only containment tests.
+func ContainmentAvailable() bool {
+	// Quick check: is pipelock in PATH?
+	_, err := exec.LookPath("pipelock")
+	if err != nil {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "pipelock", "contain", "verify") //nolint:gosec // G204: hardcoded "pipelock" binary name, not untrusted input.
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
+}
+
+// --------------------------------------------------------------------------
+// Wiring point for RunDemo: where to call RunContainmentSelfTest.
+//
+// T9's RunDemo must call RunContainmentSelfTest BEFORE step 3 (the bypass
+// beat) when opts.Contained is true. The call site is in orchestrate.go
+// between the containment hook Setup and the step 3 RunSteps call. The
+// RealContainmentHook.Setup already runs the self-test, so the gate is
+// enforced. If a different hook implementation is used (e.g. for testing),
+// the self-test should be called explicitly:
+//
+//   result := RunContainmentSelfTest(ctx, selfTestTargets())
+//   if !result.AllBlocked {
+//       return VerifyReport{}, ErrContainmentSelfTestFailed
+//   }
+//
+// This is documented here rather than wired into orchestrate.go's step 3
+// path because T9 owns the RunDemo integration and may choose a different
+// call site. The self-test gate is ALREADY enforced by RealContainmentHook.
+// Setup for the production path.
+// --------------------------------------------------------------------------

--- a/internal/playground/containment.go
+++ b/internal/playground/containment.go
@@ -217,7 +217,7 @@ func (h *RealContainmentHook) Setup(ctx context.Context, opts DemoOpts) error {
 	}
 
 	// --- Verify containment is installed (pipelock contain verify) ---
-	verifyCmd := exec.CommandContext(ctx, resolvedBin, "contain", "verify") //nolint:gosec // G204: resolvedBin is operator-configured, not untrusted input.
+	verifyCmd := exec.CommandContext(ctx, resolvedBin, "contain", "verify")
 	verifyOut, verifyErr := verifyCmd.CombinedOutput()
 	if verifyErr != nil {
 		return fmt.Errorf("containment setup: 'pipelock contain verify' failed "+
@@ -263,7 +263,7 @@ func ContainmentAvailable() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "pipelock", "contain", "verify") //nolint:gosec // G204: hardcoded "pipelock" binary name, not untrusted input.
+	cmd := exec.CommandContext(ctx, "pipelock", "contain", "verify")
 	if err := cmd.Run(); err != nil {
 		return false
 	}

--- a/internal/playground/containment_test.go
+++ b/internal/playground/containment_test.go
@@ -1,0 +1,354 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+// --------------------------------------------------------------------------
+// Probe classification tests (unit-testable without containment)
+// --------------------------------------------------------------------------
+
+func TestEgressProbe_OpenTarget_ClassifiedOpen(t *testing.T) {
+	t.Parallel()
+
+	// Start a local TCP listener on a free port -- this IS reachable.
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	// Accept connections so the probe can connect.
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return // listener closed
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	result := playground.ProbeDirectEgress(t.Context(), ln.Addr().String())
+	if !result.Open {
+		t.Fatalf("probe to an open listener must classify as Open, got: %+v", result)
+	}
+	if result.Target != ln.Addr().String() {
+		t.Fatalf("target mismatch: want %q, got %q", ln.Addr().String(), result.Target)
+	}
+}
+
+func TestEgressProbe_UnroutableTarget_ClassifiedBlocked(t *testing.T) {
+	t.Parallel()
+
+	// 127.0.0.1:1 -- port 1 is almost never listening; connection refused is
+	// the expected outcome on loopback.
+	result := playground.ProbeDirectEgress(t.Context(), "127.0.0.1:1")
+	if result.Open {
+		t.Fatalf("probe to an unroutable/refused target must classify as Blocked, got: %+v", result)
+	}
+}
+
+func TestEgressProbe_ContextCancelled_ClassifiedBlocked(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately
+
+	result := playground.ProbeDirectEgress(ctx, "127.0.0.1:1")
+	if result.Open {
+		t.Fatalf("probe with cancelled context must classify as Blocked, got: %+v", result)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Self-test detection tests (unit-testable without containment)
+// --------------------------------------------------------------------------
+
+func TestSelfTest_DetectsOpenRoutes_WhenUncontained(t *testing.T) {
+	t.Parallel()
+
+	// In an uncontained test environment, at least some of the self-test
+	// targets should be reachable (e.g. loopback ports, or public DNS if
+	// the host has network access). But the key property: the self-test
+	// must NOT report AllBlocked=true in an uncontained environment, because
+	// that would be a false containment claim.
+	//
+	// We use a custom target list that includes one definitely-open target
+	// (a local listener) to guarantee at least one is reachable.
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	targets := []string{
+		ln.Addr().String(), // definitely open
+		"127.0.0.1:1",      // definitely closed
+	}
+
+	res := playground.RunContainmentSelfTest(t.Context(), targets)
+
+	if res.AllBlocked {
+		t.Fatal("uncontained env with an open listener must NOT report AllBlocked " +
+			"(would be a false containment claim)")
+	}
+
+	// Verify individual probe results are populated.
+	if len(res.Probes) != len(targets) {
+		t.Fatalf("expected %d probes, got %d", len(targets), len(res.Probes))
+	}
+
+	// The open listener probe must be classified Open.
+	found := false
+	for _, p := range res.Probes {
+		if p.Target == ln.Addr().String() {
+			found = true
+			if !p.Open {
+				t.Fatalf("probe to open listener must be Open, got: %+v", p)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("open listener target not found in probe results")
+	}
+}
+
+func TestSelfTest_AllBlockedWhenEveryTargetRefused(t *testing.T) {
+	t.Parallel()
+
+	// All targets are definitely-refused loopback ports.
+	targets := []string{
+		"127.0.0.1:1",
+		"127.0.0.1:2",
+	}
+
+	res := playground.RunContainmentSelfTest(t.Context(), targets)
+
+	if !res.AllBlocked {
+		t.Fatal("when every target is refused, AllBlocked must be true")
+	}
+
+	for _, p := range res.Probes {
+		if p.Open {
+			t.Fatalf("probe %q unexpectedly classified as Open", p.Target)
+		}
+	}
+}
+
+func TestSelfTest_EmptyTargets_AllBlocked(t *testing.T) {
+	t.Parallel()
+
+	// Edge case: no targets -> vacuously all blocked (no open routes).
+	res := playground.RunContainmentSelfTest(t.Context(), nil)
+	if !res.AllBlocked {
+		t.Fatal("empty target list must report AllBlocked=true (vacuous truth)")
+	}
+	if len(res.Probes) != 0 {
+		t.Fatalf("expected 0 probes, got %d", len(res.Probes))
+	}
+}
+
+// --------------------------------------------------------------------------
+// Dual suite definition tests
+// --------------------------------------------------------------------------
+
+func TestEgressSuites_Defined(t *testing.T) {
+	t.Parallel()
+
+	direct := playground.DirectEgressTargets()
+	mediated := playground.MediatedProxyPolicyTargets()
+
+	if len(direct) == 0 {
+		t.Fatal("DirectEgressTargets must define at least one target")
+	}
+	if len(mediated) == 0 {
+		t.Fatal("MediatedProxyPolicyTargets must define at least one target")
+	}
+
+	// Verify direct targets are valid host:port pairs.
+	for _, tgt := range direct {
+		host, port, err := net.SplitHostPort(tgt)
+		if err != nil {
+			t.Fatalf("DirectEgressTargets entry %q is not a valid host:port: %v", tgt, err)
+		}
+		if host == "" || port == "" {
+			t.Fatalf("DirectEgressTargets entry %q has empty host or port", tgt)
+		}
+	}
+}
+
+func TestDirectEgressTargets_CoversRequiredCategories(t *testing.T) {
+	t.Parallel()
+
+	targets := playground.DirectEgressTargets()
+
+	// Check that the required categories are represented.
+	categories := map[string]bool{
+		"metadata":    false, // 169.254.169.254
+		"rfc1918":     false, // 10.x.x.x
+		"ipv6":        false, // fe80 or ::
+		"public_dns":  false, // 8.8.8.8 or 1.1.1.1
+		"public_http": false, // any other public IP
+	}
+
+	for _, tgt := range targets {
+		host, _, _ := net.SplitHostPort(tgt)
+		// Strip brackets from IPv6
+		if len(host) > 0 && host[0] == '[' {
+			host = host[1 : len(host)-1]
+		}
+		switch {
+		case host == "169.254.169.254":
+			categories["metadata"] = true
+		case len(host) > 3 && host[:3] == "10.":
+			categories["rfc1918"] = true
+		case len(host) >= 4 && (host[:4] == "fe80" || host == "::1"):
+			categories["ipv6"] = true
+		case host == "8.8.8.8" || host == "1.1.1.1":
+			categories["public_dns"] = true
+		case host == "93.184.216.34":
+			categories["public_http"] = true
+		}
+	}
+
+	for cat, found := range categories {
+		if !found {
+			t.Errorf("DirectEgressTargets missing required category: %s", cat)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// RealContainmentHook unit tests (non-privileged behavior)
+// --------------------------------------------------------------------------
+
+func TestRealContainmentHook_Setup_FailsWithoutPrivileges(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() == 0 {
+		t.Skip("test requires non-root to verify privilege check")
+	}
+
+	hook := playground.NewRealContainmentHook("")
+	err := hook.Setup(t.Context(), playground.DemoOpts{
+		Contained: true,
+		RunDir:    t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("Setup must fail without root privileges")
+	}
+}
+
+func TestRealContainmentHook_Teardown_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	hook := playground.NewRealContainmentHook("")
+	if err := hook.Teardown(t.TempDir()); err != nil {
+		t.Fatalf("Teardown must succeed (best-effort): %v", err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Contained end-to-end: PRIVILEGE-GATED (host-only, skips in CI)
+// --------------------------------------------------------------------------
+
+// requirePrivilegedHost skips the test unless running as root AND
+// containment tooling is available. This is the honest gate: we NEVER
+// fake a pass for contained-mode kernel enforcement.
+func requirePrivilegedHost(t *testing.T) {
+	t.Helper()
+
+	if os.Geteuid() != 0 {
+		t.Skip("SKIPPED: contained end-to-end requires root (euid != 0). " +
+			"Run with sudo on a host where 'pipelock contain install' has been executed. " +
+			"This test verifies kernel-level egress blocking, which CANNOT be faked in CI.")
+	}
+
+	// Check that pipelock contain verify passes.
+	if !playground.ContainmentAvailable() {
+		t.Skip("SKIPPED: 'pipelock contain verify' failed or pipelock not in PATH. " +
+			"Run 'sudo pipelock contain install' first. " +
+			"This test verifies kernel-level egress blocking on a real containment host.")
+	}
+}
+
+func TestContainment_BlocksDirectEgress_HostOnly(t *testing.T) {
+	requirePrivilegedHost(t) // t.Skip if not root / contain unavailable
+
+	// On a properly contained host, EVERY known-bad route must be blocked.
+	targets := playground.DirectEgressTargets()
+	result := playground.RunContainmentSelfTest(t.Context(), targets)
+
+	if !result.AllBlocked {
+		var open []string
+		for _, p := range result.Probes {
+			if p.Open {
+				open = append(open, p.Target)
+			}
+		}
+		t.Fatalf("containment must block ALL direct egress targets, but these were open: %v", open)
+	}
+
+	// Verify every probe was individually classified as blocked.
+	for _, p := range result.Probes {
+		if p.Open {
+			t.Errorf("probe %q must be blocked under containment, but was Open: %s", p.Target, p.Detail)
+		}
+	}
+}
+
+func TestContainment_SelfTestGate_AbortsOnOpenRoutes(t *testing.T) {
+	t.Parallel()
+
+	// Simulate what happens when the self-test detects open routes:
+	// the demo must abort with ErrContainmentSelfTestFailed.
+	// We test this by checking that RunContainmentSelfTest correctly
+	// reports AllBlocked=false when there are open routes, and verify
+	// the error constant is usable for error wrapping.
+
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	result := playground.RunContainmentSelfTest(t.Context(), []string{ln.Addr().String()})
+	if result.AllBlocked {
+		t.Fatal("self-test with an open listener must NOT report AllBlocked")
+	}
+
+	// Verify the error sentinel is available for wrapping/checking.
+	wrapped := playground.ErrContainmentSelfTestFailed
+	if wrapped == nil {
+		t.Fatal("ErrContainmentSelfTestFailed must be non-nil")
+	}
+}

--- a/internal/playground/coverage_more_test.go
+++ b/internal/playground/coverage_more_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !windows
+
 package playground
 
 import (

--- a/internal/playground/coverage_more_test.go
+++ b/internal/playground/coverage_more_test.go
@@ -1,0 +1,352 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+const rootRequirement = "requires root"
+
+type badAddr string
+
+func (a badAddr) Network() string { return "bad" }
+func (a badAddr) String() string  { return string(a) }
+
+func TestLiveRunHelperBranches(t *testing.T) {
+	t.Parallel()
+
+	if got := portFromAddr(badAddr("not-a-host-port")); got != "0" {
+		t.Fatalf("bad addr port = %q, want 0", got)
+	}
+	if got := portFromAddr(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}); got != "12345" {
+		t.Fatalf("tcp addr port = %q, want 12345", got)
+	}
+
+	if _, err := singleLiveEvidenceFile(t.TempDir()); err == nil {
+		t.Fatal("empty evidence dir must fail closed")
+	}
+
+	evidenceDir := t.TempDir()
+	want := filepath.Join(evidenceDir, "evidence-proxy-test.jsonl")
+	if err := os.WriteFile(want, nil, 0o600); err != nil {
+		t.Fatalf("write evidence file: %v", err)
+	}
+	got, err := singleLiveEvidenceFile(evidenceDir)
+	if err != nil {
+		t.Fatalf("singleLiveEvidenceFile: %v", err)
+	}
+	if got != want {
+		t.Fatalf("evidence file = %q, want %q", got, want)
+	}
+
+	cfg := config.Defaults()
+	hash := liveRunConfigHash(cfg)
+	if !strings.HasPrefix(hash, "sha256:") || len(hash) != len("sha256:")+64 {
+		t.Fatalf("policy hash has wrong shape: %q", hash)
+	}
+}
+
+func TestLiveRunAgentCommandBranches(t *testing.T) {
+	t.Parallel()
+
+	lr := &LiveRun{
+		ctx:      t.Context(),
+		agentBin: "/bin/echo",
+		opts:     LiveRunOpts{},
+	}
+	cmd, err := lr.agentCommand([]string{"hello"})
+	if err != nil {
+		t.Fatalf("uncontained agentCommand: %v", err)
+	}
+	if cmd.Path != "/bin/echo" {
+		t.Fatalf("cmd path = %q", cmd.Path)
+	}
+	if len(cmd.Args) != 2 || cmd.Args[1] != "hello" {
+		t.Fatalf("cmd args = %v", cmd.Args)
+	}
+
+	if os.Geteuid() == 0 {
+		t.Skip("non-root contained error branch requires non-root test process")
+	}
+	lr.opts.Contained = true
+	if _, err := lr.agentCommand(nil); err == nil || !strings.Contains(err.Error(), rootRequirement) {
+		t.Fatalf("contained non-root error = %v, want root requirement", err)
+	}
+}
+
+func TestRunStepsReturnsNonExitExecErrors(t *testing.T) {
+	t.Parallel()
+
+	safeLn := listenLocal(t)
+	defer func() { _ = safeLn.Close() }()
+	collectorLn := listenLocal(t)
+	defer func() { _ = collectorLn.Close() }()
+	proxyLn := listenLocal(t)
+	defer func() { _ = proxyLn.Close() }()
+
+	lr := &LiveRun{
+		ctx:         t.Context(),
+		safeLn:      safeLn,
+		collectorLn: collectorLn,
+		proxyLn:     proxyLn,
+		agentBin:    filepath.Join(t.TempDir(), "missing-agent"),
+		opts: LiveRunOpts{
+			RunNonce: "N1",
+		},
+	}
+	err := lr.RunSteps(1)
+	if err == nil || !strings.Contains(err.Error(), "step 1 exec") {
+		t.Fatalf("RunSteps error = %v, want step 1 exec", err)
+	}
+}
+
+func TestContainmentAvailableFalseWhenPipelockMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	if ContainmentAvailable() {
+		t.Fatal("empty PATH must report containment unavailable")
+	}
+}
+
+func TestVerifyBodyExfilLiveDemoSemantics(t *testing.T) {
+	t.Parallel()
+
+	receipts := []receipt.Receipt{
+		semanticReceipt(liveDemoAllowedVerdict, "domain_allow"),
+		semanticReceipt(liveDemoExpectedVerdict, liveDemoExpectedBlockLayer),
+	}
+	if err := verifyBodyExfilLiveDemo(receipts, Witness{}); err != nil {
+		t.Fatalf("valid body exfil semantics: %v", err)
+	}
+
+	if err := verifyBodyExfilLiveDemo(receipts, Witness{ObservedCount: 1}); err == nil ||
+		!strings.Contains(err.Error(), "must not reach the collector") {
+		t.Fatalf("collector-observed error = %v", err)
+	}
+
+	if err := verifyBodyExfilLiveDemo(receipts[:1], Witness{}); err == nil ||
+		!strings.Contains(err.Error(), "body_dlp block receipt") {
+		t.Fatalf("missing block error = %v", err)
+	}
+
+	if err := verifyBodyExfilLiveDemo(receipts[1:], Witness{}); err == nil ||
+		!strings.Contains(err.Error(), "allow receipt") {
+		t.Fatalf("missing allow error = %v", err)
+	}
+}
+
+func TestVerifyURLExfilReplayCompatibleSemantics(t *testing.T) {
+	t.Parallel()
+
+	receipts := []receipt.Receipt{semanticReceipt(liveDemoExpectedVerdict, "core_dlp")}
+	if err := verifyURLExfilReplayCompatible(receipts, Witness{}); err != nil {
+		t.Fatalf("valid URL exfil semantics: %v", err)
+	}
+
+	if err := verifyURLExfilReplayCompatible(receipts, Witness{ObservedCount: 1}); err == nil ||
+		!strings.Contains(err.Error(), "observed=1") {
+		t.Fatalf("collector-observed error = %v", err)
+	}
+
+	if err := verifyURLExfilReplayCompatible([]receipt.Receipt{semanticReceipt(liveDemoExpectedVerdict, "body_dlp")}, Witness{}); err == nil ||
+		!strings.Contains(err.Error(), "missing core_dlp block receipt") {
+		t.Fatalf("missing core_dlp error = %v", err)
+	}
+}
+
+func TestVerifyLiveDemoSemanticsRejectsBadPacketManifest(t *testing.T) {
+	t.Parallel()
+
+	runDir := t.TempDir()
+	lm := LaunchManifest{
+		ScenarioID: LiveDemoScenarioID,
+		PolicyHash: "sha256:test-policy",
+	}
+	if err := verifyLiveDemoSemantics(runDir, lm, Witness{}); err == nil ||
+		!strings.Contains(err.Error(), "cannot read packet manifest") {
+		t.Fatalf("missing manifest error = %v", err)
+	}
+
+	packetDir := filepath.Join(runDir, packetSubdir)
+	if err := os.MkdirAll(packetDir, 0o750); err != nil {
+		t.Fatalf("mkdir packet: %v", err)
+	}
+	manifestPath := filepath.Join(packetDir, "manifest.json")
+	if err := os.WriteFile(manifestPath, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write malformed manifest: %v", err)
+	}
+	if err := verifyLiveDemoSemantics(runDir, lm, Witness{}); err == nil ||
+		!strings.Contains(err.Error(), "malformed packet manifest") {
+		t.Fatalf("malformed manifest error = %v", err)
+	}
+
+	writePacketManifest(t, manifestPath, "other-scenario", lm.PolicyHash)
+	if err := verifyLiveDemoSemantics(runDir, lm, Witness{}); err == nil ||
+		!strings.Contains(err.Error(), "scenario_id") {
+		t.Fatalf("scenario mismatch error = %v", err)
+	}
+
+	writePacketManifest(t, manifestPath, lm.ScenarioID, "sha256:other-policy")
+	if err := verifyLiveDemoSemantics(runDir, lm, Witness{}); err == nil ||
+		!strings.Contains(err.Error(), "policy_hash") {
+		t.Fatalf("policy mismatch error = %v", err)
+	}
+
+	writePacketManifest(t, manifestPath, lm.ScenarioID, lm.PolicyHash)
+	if err := verifyLiveDemoSemantics(runDir, lm, Witness{}); err == nil ||
+		!strings.Contains(err.Error(), "extract packet receipts") {
+		t.Fatalf("missing evidence error = %v", err)
+	}
+}
+
+func TestConfigureContainedCommandNonRootPath(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("non-root error branch requires non-root test process")
+	}
+
+	cmd := exec.CommandContext(t.Context(), "/bin/true")
+	err := configureContainedCommand(cmd, "")
+	if err == nil || !strings.Contains(err.Error(), "requires root") {
+		t.Fatalf("configureContainedCommand error = %v, want root requirement", err)
+	}
+}
+
+func TestPreflightRunDirMustBeDirectory(t *testing.T) {
+	t.Parallel()
+
+	runDir := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(runDir, []byte("file"), 0o600); err != nil {
+		t.Fatalf("write run dir placeholder: %v", err)
+	}
+	err := Preflight(DemoOpts{RunDir: runDir, RunNonce: "N1"})
+	if err == nil || !strings.Contains(err.Error(), "not writable") {
+		t.Fatalf("preflight error = %v, want not writable", err)
+	}
+}
+
+func TestResetCallsContainmentTeardown(t *testing.T) {
+	runDir := t.TempDir()
+	hook := &recordingContainmentHook{}
+	SetContainmentHook(hook)
+	t.Cleanup(func() { SetContainmentHook(nil) })
+
+	if err := Reset(runDir); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	if hook.teardownRunDir != runDir {
+		t.Fatalf("teardown runDir = %q, want %q", hook.teardownRunDir, runDir)
+	}
+
+	hook.teardownErr = fmt.Errorf("teardown failed")
+	if err := Reset(runDir); err == nil || !strings.Contains(err.Error(), "containment teardown") {
+		t.Fatalf("Reset teardown error = %v, want containment teardown", err)
+	}
+}
+
+func TestRenderVerifySummaryFailureOutput(t *testing.T) {
+	t.Parallel()
+
+	rep := VerifyReport{
+		OrchestratorKey: "abc123",
+		Checks: []Check{{
+			Name:   checkManifestSig,
+			OK:     false,
+			Reason: "bad signature",
+		}},
+	}
+	var buf bytes.Buffer
+	renderVerifySummary(&buf, rep, "/tmp/playground-run")
+	out := buf.String()
+	for _, want := range []string{"[FAIL] launch-manifest-signature -- bad signature", "VERIFY FAILED", "--orchestrator-key abc123"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestWitnessVerificationRejectsMalformedInputs(t *testing.T) {
+	t.Parallel()
+
+	w := Witness{RunNonce: "N1"}
+	w.Signature = strings.Repeat("00", 64)
+
+	if VerifyWitness("not-hex", w) {
+		t.Fatal("non-hex collector key must fail")
+	}
+	if VerifyWitness(strings.Repeat("00", 31), w) {
+		t.Fatal("short collector key must fail")
+	}
+	pub, _ := genKey(t)
+	w.Signature = "not-hex"
+	if VerifyWitness(hexEnc(pub), w) {
+		t.Fatal("non-hex witness signature must fail")
+	}
+}
+
+func TestAssembleFromEvidenceRejectsMissingAndEmptyEvidence(t *testing.T) {
+	t.Parallel()
+
+	if _, err := assembleFromEvidenceCore(filepath.Join(t.TempDir(), "missing.jsonl"), "", nil, t.TempDir(), time.Now()); err == nil {
+		t.Fatal("missing evidence file must fail")
+	}
+
+	evidenceFile := filepath.Join(t.TempDir(), "evidence.jsonl")
+	if err := os.WriteFile(evidenceFile, nil, 0o600); err != nil {
+		t.Fatalf("write empty evidence: %v", err)
+	}
+	if _, err := assembleFromEvidenceCore(evidenceFile, "", nil, t.TempDir(), time.Now()); err == nil {
+		t.Fatal("empty evidence file must fail")
+	}
+}
+
+func semanticReceipt(verdict, layer string) receipt.Receipt {
+	return receipt.Receipt{
+		ActionRecord: receipt.ActionRecord{
+			Verdict: verdict,
+			Layer:   layer,
+		},
+	}
+}
+
+type recordingContainmentHook struct {
+	teardownRunDir string
+	teardownErr    error
+}
+
+func (h *recordingContainmentHook) Setup(context.Context, DemoOpts) error { return nil }
+
+func (h *recordingContainmentHook) Teardown(runDir string) error {
+	h.teardownRunDir = runDir
+	return h.teardownErr
+}
+
+func listenLocal(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln
+}
+
+func writePacketManifest(t *testing.T, path, scenarioID, policyHash string) {
+	t.Helper()
+	data := []byte(fmt.Sprintf(`{"scenario_id":%q,"policy_hash":%q}`, scenarioID, policyHash))
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write packet manifest: %v", err)
+	}
+}

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -1,0 +1,519 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// .test hostnames used by the live run. RFC 2606 reserved, safe to publish.
+const (
+	liveRunSafeHost  = "safe.target.test"
+	liveRunExfilHost = "exfil.target.test"
+)
+
+// liveRunPrincipal and liveRunActor use the same values as the replaycapture
+// lab so that the assembled audit packet passes the public-safe field
+// allowlist. These are synthetic, non-identifying labels.
+const (
+	liveRunPrincipal = "pipelock-lab"
+	liveRunActor     = "lab-agent"
+)
+
+// canaryEnvVar is the env var the toy agent/webtool reads.
+const canaryEnvVar = "PLAYGROUND_CANARY_VALUE"
+
+// LiveRunOpts configures a live playground run.
+type LiveRunOpts struct {
+	// Contained selects kernel-containment mode (requires sudo). When false
+	// (uncontained), step 3 (bypass) is skipped.
+	Contained bool
+	// ScenarioID selects the scenario from DefaultScenarios.
+	ScenarioID string
+	// RunNonce is the unique identifier for this run.
+	RunNonce string
+	// ToyAgentBin and WebToolBin are paths to the compiled binaries. When
+	// empty, StartLiveRun builds them into a temp dir.
+	ToyAgentBin string
+	WebToolBin  string
+}
+
+// LiveRun holds the state of a running live playground demo. All resources
+// (listeners, proxy, targets) are cleaned up by Close.
+type LiveRun struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// Keys
+	orchestratorPub  ed25519.PublicKey
+	orchestratorPriv ed25519.PrivateKey
+	collectorPub     ed25519.PublicKey
+	collectorPriv    ed25519.PrivateKey
+	pipelockPub      ed25519.PublicKey
+	pipelockPriv     ed25519.PrivateKey
+
+	// Infrastructure
+	safeTarget   *SafeTarget
+	safeLn       net.Listener
+	safeSrv      *http.Server
+	collector    *Collector
+	collectorLn  net.Listener
+	collectorSrv *http.Server
+	proxyLn      net.Listener
+	proxySrv     *http.Server
+	proxyObj     *proxy.Proxy
+	rec          *recorder.Recorder
+	sc           *scanner.Scanner
+
+	// Scenario / config
+	scenario    replaycapture.Scenario
+	manifest    LaunchManifest
+	opts        LiveRunOpts
+	evidenceDir string
+	policyHash  string
+
+	// Binaries
+	agentBin   string
+	webtoolBin string
+
+	// Canary
+	canaryID    string
+	canaryValue string
+}
+
+// StartLiveRun boots a complete live demo environment: lab targets, a real
+// Pipelock proxy with receipt emission, and prepares everything for running
+// the toy agent through it.
+func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	lr := &LiveRun{
+		ctx:    ctx,
+		cancel: cancel,
+		opts:   opts,
+	}
+
+	var err error
+	defer func() {
+		if err != nil {
+			lr.Close()
+		}
+	}()
+
+	// --- Key generation ---
+	lr.orchestratorPub, lr.orchestratorPriv, err = signing.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("orchestrator keygen: %w", err)
+	}
+	lr.collectorPub, lr.collectorPriv, err = signing.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("collector keygen: %w", err)
+	}
+	lr.pipelockPub, lr.pipelockPriv, err = signing.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("pipelock keygen: %w", err)
+	}
+
+	// --- Canary ---
+	lr.canaryID = "playground-canary"
+	lr.canaryValue = "SYNTH-CANARY-" + opts.RunNonce
+
+	// --- Look up the scenario ---
+	for _, s := range replaycapture.DefaultScenarios() {
+		if s.ID == opts.ScenarioID {
+			lr.scenario = s
+			break
+		}
+	}
+	if lr.scenario.ID == "" {
+		err = fmt.Errorf("unknown scenario %q", opts.ScenarioID)
+		return nil, err
+	}
+
+	// --- Start safe target on loopback :0 ---
+	lr.safeTarget = NewSafeTarget()
+	lr.safeLn, err = (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("safe target listen: %w", err)
+	}
+	lr.safeSrv = &http.Server{
+		Handler:           lr.safeTarget.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() { _ = lr.safeSrv.Serve(lr.safeLn) }()
+
+	// --- Start collector on loopback :0 ---
+	lr.collector = NewCollector(lr.canaryID, lr.canaryValue)
+	lr.collectorLn, err = (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("collector listen: %w", err)
+	}
+	lr.collectorSrv = &http.Server{
+		Handler:           lr.collector.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() { _ = lr.collectorSrv.Serve(lr.collectorLn) }()
+
+	// --- Build pipelock config ---
+	cfg := config.Defaults()
+	cfg.Internal = nil // disable SSRF/DNS lookups
+	cfg.ForwardProxy.Enabled = true
+
+	// Canary token for DLP detection. The canary value is set explicitly
+	// (not via env var) so the proxy detects it without depending on the
+	// test process's real environment.
+	cfg.CanaryTokens = config.CanaryTokens{
+		Enabled: true,
+		Tokens: []config.CanaryToken{
+			{
+				Name:  lr.canaryID,
+				Value: lr.canaryValue,
+			},
+		},
+	}
+
+	// DNS host overrides: .test hosts -> loopback
+	cfg.DNS.HostOverrides = map[string][]string{
+		liveRunSafeHost:  {"127.0.0.1"},
+		liveRunExfilHost: {"127.0.0.1"},
+	}
+
+	// Trust the .test hosts so they pass the domain check
+	cfg.TrustedDomains = append(cfg.TrustedDomains, liveRunSafeHost, liveRunExfilHost)
+
+	cfg.ApplyDefaults()
+
+	// --- Policy hash ---
+	lr.policyHash = liveRunConfigHash(cfg)
+
+	// --- Evidence dir ---
+	lr.evidenceDir, err = os.MkdirTemp("", "playground-live-evidence-*")
+	if err != nil {
+		return nil, fmt.Errorf("evidence dir: %w", err)
+	}
+
+	// --- Scanner + Recorder + Emitter ---
+	lr.sc = scanner.New(cfg)
+
+	lr.rec, err = recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                lr.evidenceDir,
+		CheckpointInterval: 1000,
+		Redact:             true,
+	}, lr.sc.ScanTextForDLP, lr.pipelockPriv)
+	if err != nil {
+		return nil, fmt.Errorf("recorder: %w", err)
+	}
+
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   lr.rec,
+		PrivKey:    lr.pipelockPriv,
+		ConfigHash: lr.policyHash,
+		Principal:  liveRunPrincipal,
+		Actor:      liveRunActor,
+	})
+	if emitter == nil {
+		err = fmt.Errorf("emitter construction failed")
+		return nil, err
+	}
+
+	// --- Proxy ---
+	lr.proxyObj, err = proxy.New(cfg, audit.NewNop(), lr.sc, metrics.New(),
+		proxy.WithRecorder(lr.rec),
+		proxy.WithReceiptEmitter(emitter),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("proxy: %w", err)
+	}
+
+	// Start proxy listening on loopback :0
+	lr.proxyLn, err = (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("proxy listen: %w", err)
+	}
+	lr.proxySrv = &http.Server{
+		Handler:           lr.proxyObj.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() { _ = lr.proxySrv.Serve(lr.proxyLn) }()
+
+	// --- Build + sign launch manifest ---
+	lr.manifest = LaunchManifest{
+		RunNonce:        opts.RunNonce,
+		ScenarioID:      opts.ScenarioID,
+		CanaryID:        lr.canaryID,
+		PipelockPubKey:  hex.EncodeToString(lr.pipelockPub),
+		CollectorPubKey: hex.EncodeToString(lr.collectorPub),
+		PolicyHash:      lr.policyHash,
+		TargetHost:      liveRunExfilHost,
+		StartedAt:       time.Now().UTC(),
+	}
+	lr.manifest = SignLaunchManifest(lr.orchestratorPriv, lr.manifest)
+
+	// Open the collector run with the manifest hash
+	if openErr := lr.collector.OpenRun(opts.RunNonce, lr.manifest.Hash()); openErr != nil {
+		err = fmt.Errorf("open collector run: %w", openErr)
+		return nil, err
+	}
+
+	// --- Binaries ---
+	lr.agentBin = opts.ToyAgentBin
+	lr.webtoolBin = opts.WebToolBin
+
+	return lr, nil
+}
+
+// RunSteps executes the specified toy-agent steps. Step 1 = safe GET, Step 2 =
+// exfil POST, Step 3 = bypass (skipped in uncontained mode).
+func (lr *LiveRun) RunSteps(steps ...int) error {
+	safePort := portFromAddr(lr.safeLn.Addr())
+	collectorPort := portFromAddr(lr.collectorLn.Addr())
+	proxyAddr := lr.proxyLn.Addr().String()
+
+	safeURL := fmt.Sprintf("http://%s:%s/", liveRunSafeHost, safePort)
+	exfilURL := fmt.Sprintf("http://%s:%s/", liveRunExfilHost, collectorPort)
+
+	for _, step := range steps {
+		if step == 3 && !lr.opts.Contained {
+			continue // bypass is only meaningful under containment
+		}
+
+		args := []string{
+			"--step", fmt.Sprintf("%d", step),
+			"--run-nonce", lr.opts.RunNonce,
+			"--canary-label", lr.canaryID,
+			"--safe-url", safeURL,
+			"--exfil-url", exfilURL,
+			"--webtool", lr.webtoolBin,
+		}
+
+		cmd := exec.CommandContext(lr.ctx, lr.agentBin, args...) //nolint:gosec // G204: agentBin is an operator-configured path from LiveRunOpts, not untrusted input.
+		// Minimal, controlled environment: the demo agent holds ONLY the
+		// synthetic canary plus the demo plumbing -- NEVER the operator's real
+		// environment (which could contain real secrets). This enforces the
+		// capability-separation story instead of merely narrating it: the agent
+		// genuinely possesses nothing sensitive except the planted synthetic canary.
+		cmd.Env = []string{
+			"PATH=/usr/local/bin:/usr/bin:/bin",
+			canaryEnvVar + "=" + lr.canaryValue,
+			"PLAYGROUND_AGENT_ID=" + liveRunActor,
+			"HTTP_PROXY=http://" + proxyAddr,
+			"HTTPS_PROXY=http://" + proxyAddr,
+		}
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			// Non-zero exit from the agent is expected when pipelock blocks;
+			// we only fail on exec errors.
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				return fmt.Errorf("step %d exec: %w", step, err)
+			}
+		}
+	}
+	return nil
+}
+
+// HasReceipt reports whether the evidence JSONL contains at least one receipt
+// with the given verdict (e.g. "allow", "block").
+func (lr *LiveRun) HasReceipt(verdict string) bool {
+	for _, v := range lr.Verdicts() {
+		if strings.EqualFold(v, verdict) {
+			return true
+		}
+	}
+	return false
+}
+
+// Verdicts returns all receipt verdicts from the evidence JSONL.
+func (lr *LiveRun) Verdicts() []string {
+	// Close the recorder so evidence is flushed before reading.
+	if lr.rec != nil {
+		_ = lr.rec.Close()
+		lr.rec = nil
+	}
+
+	evidenceFile, err := singleLiveEvidenceFile(lr.evidenceDir)
+	if err != nil {
+		return nil
+	}
+
+	receipts, err := receipt.ExtractReceipts(evidenceFile)
+	if err != nil {
+		return nil
+	}
+
+	var verdicts []string
+	for _, r := range receipts {
+		verdicts = append(verdicts, receipt.NormalizeVerdict(r.ActionRecord.Verdict))
+	}
+	return verdicts
+}
+
+// AssembleAndVerify performs the full end-to-end: red-case calibration, witness
+// seal, packet assembly, and offline verification. Returns the VerifyReport.
+func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
+	// Ensure recorder is closed so evidence is flushed.
+	if lr.rec != nil {
+		_ = lr.rec.Close()
+		lr.rec = nil
+	}
+
+	// --- Red-case calibration ---
+	rcResult, err := RunRedCaseCalibration(lr.ctx, lr.collectorPriv, lr.canaryID, lr.canaryValue)
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("red-case calibration: %w", err)
+	}
+	if err := lr.collector.AttachRedCase(lr.opts.RunNonce, rcResult); err != nil {
+		return VerifyReport{}, fmt.Errorf("attach red-case: %w", err)
+	}
+
+	// --- Seal witness ---
+	witness, err := lr.collector.SealAndSign(lr.opts.RunNonce, lr.collectorPriv, 2*time.Second)
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("seal witness: %w", err)
+	}
+
+	// --- Evidence file ---
+	evidenceFile, err := singleLiveEvidenceFile(lr.evidenceDir)
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("evidence file: %w", err)
+	}
+
+	// --- Assemble packet ---
+	// AssemblePacket creates a subdirectory named after the scenario ID inside
+	// outDir. VerifyRun expects the packet at <runDir>/packet/, so we pass
+	// runDir as outDir and then rename the result.
+	sc := lr.scenario
+	asmResult, asmErr := AssembleFromEvidenceWithScenario(
+		evidenceFile,
+		hex.EncodeToString(lr.pipelockPub),
+		&sc,
+		runDir,
+		time.Now().UTC(),
+	)
+	if asmErr != nil {
+		return VerifyReport{}, fmt.Errorf("assemble: %w", asmErr)
+	}
+	// Rename the assembly output dir to the canonical "packet/" location
+	// expected by VerifyRun.
+	packetDir := filepath.Join(runDir, "packet")
+	if asmResult.PacketDir != packetDir {
+		if renameErr := os.Rename(asmResult.PacketDir, packetDir); renameErr != nil {
+			return VerifyReport{}, fmt.Errorf("rename packet dir: %w", renameErr)
+		}
+	}
+
+	// --- Write launch manifest ---
+	lmBytes, err := json.Marshal(lr.manifest)
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("marshal launch manifest: %w", err)
+	}
+	lmPath := filepath.Join(runDir, "launch-manifest.json")
+	if err := os.WriteFile(lmPath, lmBytes, 0o600); err != nil {
+		return VerifyReport{}, fmt.Errorf("write launch manifest: %w", err)
+	}
+
+	// --- Write witness ---
+	wBytes, err := json.Marshal(witness)
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("marshal witness: %w", err)
+	}
+	wPath := filepath.Join(runDir, "witness.json")
+	if err := os.WriteFile(wPath, wBytes, 0o600); err != nil {
+		return VerifyReport{}, fmt.Errorf("write witness: %w", err)
+	}
+
+	// --- Verify ---
+	rep, err := VerifyRun(runDir, hex.EncodeToString(lr.orchestratorPub))
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("verify run: %w", err)
+	}
+
+	return rep, nil
+}
+
+// Close shuts down all infrastructure. Safe to call multiple times.
+func (lr *LiveRun) Close() {
+	lr.cancel()
+
+	if lr.proxySrv != nil {
+		_ = lr.proxySrv.Close()
+	}
+	if lr.proxyObj != nil {
+		lr.proxyObj.Close()
+	}
+	if lr.sc != nil {
+		lr.sc.Close()
+		lr.sc = nil
+	}
+	if lr.rec != nil {
+		_ = lr.rec.Close()
+		lr.rec = nil
+	}
+	if lr.safeSrv != nil {
+		_ = lr.safeSrv.Close()
+	}
+	if lr.collectorSrv != nil {
+		_ = lr.collectorSrv.Close()
+	}
+	if lr.evidenceDir != "" {
+		_ = os.RemoveAll(lr.evidenceDir)
+	}
+}
+
+// portFromAddr extracts the port string from a net.Addr.
+func portFromAddr(addr net.Addr) string {
+	_, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return "0"
+	}
+	return port
+}
+
+// singleLiveEvidenceFile returns the lone evidence JSONL file from the dir.
+func singleLiveEvidenceFile(dir string) (string, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "evidence-proxy-*.jsonl"))
+	if err != nil {
+		return "", fmt.Errorf("globbing evidence: %w", err)
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no evidence files in %s", dir)
+	}
+	// Use the first one (there should be exactly one per recorder session).
+	return matches[0], nil
+}
+
+// liveRunConfigHash returns a deterministic policy hash for the live-run config.
+func liveRunConfigHash(cfg *config.Config) string {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		data = []byte(cfg.Mode)
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -15,8 +15,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
@@ -34,6 +37,7 @@ import (
 const (
 	liveRunSafeHost  = "safe.target.test"
 	liveRunExfilHost = "exfil.target.test"
+	liveRunBypassURL = "http://93.184.216.34/" //nolint:gosec // G101: reserved example.com IP, not a credential.
 )
 
 // liveRunPrincipal and liveRunActor use the same values as the replaycapture
@@ -60,6 +64,9 @@ type LiveRunOpts struct {
 	// empty, StartLiveRun builds them into a temp dir.
 	ToyAgentBin string
 	WebToolBin  string
+	// AgentUser is the OS user used for contained-mode toy-agent execution.
+	// Empty means pipelock-agent.
+	AgentUser string
 }
 
 // LiveRun holds the state of a running live playground demo. All resources
@@ -139,16 +146,12 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 
 	// --- Canary ---
 	lr.canaryID = "playground-canary"
-	lr.canaryValue = "SYNTH-CANARY-" + opts.RunNonce
+	lr.canaryValue = liveCanaryValue(opts.RunNonce)
 
 	// --- Look up the scenario ---
-	for _, s := range replaycapture.DefaultScenarios() {
-		if s.ID == opts.ScenarioID {
-			lr.scenario = s
-			break
-		}
-	}
-	if lr.scenario.ID == "" {
+	if s, ok := lookupPlaygroundScenario(opts.ScenarioID); ok {
+		lr.scenario = s
+	} else {
 		err = fmt.Errorf("unknown scenario %q", opts.ScenarioID)
 		return nil, err
 	}
@@ -181,19 +184,6 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 	cfg := config.Defaults()
 	cfg.Internal = nil // disable SSRF/DNS lookups
 	cfg.ForwardProxy.Enabled = true
-
-	// Canary token for DLP detection. The canary value is set explicitly
-	// (not via env var) so the proxy detects it without depending on the
-	// test process's real environment.
-	cfg.CanaryTokens = config.CanaryTokens{
-		Enabled: true,
-		Tokens: []config.CanaryToken{
-			{
-				Name:  lr.canaryID,
-				Value: lr.canaryValue,
-			},
-		},
-	}
 
 	// DNS host overrides: .test hosts -> loopback
 	cfg.DNS.HostOverrides = map[string][]string{
@@ -309,8 +299,17 @@ func (lr *LiveRun) RunSteps(steps ...int) error {
 			"--exfil-url", exfilURL,
 			"--webtool", lr.webtoolBin,
 		}
+		if step == 3 {
+			args = append(args, "--bypass-url", liveRunBypassURL)
+			if lr.opts.Contained {
+				args = append(args, "--expect-bypass-blocked")
+			}
+		}
 
-		cmd := exec.CommandContext(lr.ctx, lr.agentBin, args...) //nolint:gosec // G204: agentBin is an operator-configured path from LiveRunOpts, not untrusted input.
+		cmd, err := lr.agentCommand(args)
+		if err != nil {
+			return fmt.Errorf("step %d command: %w", step, err)
+		}
 		// Minimal, controlled environment: the demo agent holds ONLY the
 		// synthetic canary plus the demo plumbing -- NEVER the operator's real
 		// environment (which could contain real secrets). This enforces the
@@ -328,14 +327,48 @@ func (lr *LiveRun) RunSteps(steps ...int) error {
 
 		if err := cmd.Run(); err != nil {
 			// Non-zero exit from the agent is expected when pipelock blocks;
-			// we only fail on exec errors.
+			// except for the contained bypass beat, where non-zero means the
+			// direct-egress check connected or could not run honestly.
 			var exitErr *exec.ExitError
 			if !errors.As(err, &exitErr) {
 				return fmt.Errorf("step %d exec: %w", step, err)
 			}
+			if step == 3 && lr.opts.Contained {
+				return fmt.Errorf("step %d contained bypass check failed: %w", step, err)
+			}
 		}
 	}
 	return nil
+}
+
+func (lr *LiveRun) agentCommand(args []string) (*exec.Cmd, error) {
+	cmd := exec.CommandContext(lr.ctx, lr.agentBin, args...) //nolint:gosec // G204: agentBin is an operator-configured path from LiveRunOpts, not untrusted input.
+	if !lr.opts.Contained {
+		return cmd, nil
+	}
+	if os.Geteuid() != 0 {
+		return nil, fmt.Errorf("contained toy-agent execution requires root (euid=%d)", os.Geteuid())
+	}
+	agentUser := lr.opts.AgentUser
+	if agentUser == "" {
+		agentUser = defaultContainedAgentUser
+	}
+	u, err := user.Lookup(agentUser)
+	if err != nil {
+		return nil, fmt.Errorf("lookup contained agent user %q: %w", agentUser, err)
+	}
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("parse uid for %q: %w", agentUser, err)
+	}
+	gid, err := strconv.ParseUint(u.Gid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("parse gid for %q: %w", agentUser, err)
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)},
+	}
+	return cmd, nil
 }
 
 // HasReceipt reports whether the evidence JSONL contains at least one receipt
@@ -384,7 +417,7 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 	}
 
 	// --- Red-case calibration ---
-	rcResult, err := RunRedCaseCalibration(lr.ctx, lr.collectorPriv, lr.canaryID, lr.canaryValue)
+	rcResult, redWitness, err := RunRedCaseCalibrationWithWitness(lr.ctx, lr.collectorPriv, lr.canaryID, lr.canaryValue)
 	if err != nil {
 		return VerifyReport{}, fmt.Errorf("red-case calibration: %w", err)
 	}
@@ -446,6 +479,16 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 	wPath := filepath.Join(runDir, "witness.json")
 	if err := os.WriteFile(wPath, wBytes, 0o600); err != nil {
 		return VerifyReport{}, fmt.Errorf("write witness: %w", err)
+	}
+
+	// --- Write red-case witness ---
+	redBytes, err := json.Marshal(redWitness)
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("marshal red witness: %w", err)
+	}
+	redPath := filepath.Join(runDir, redWitnessFile)
+	if err := os.WriteFile(redPath, redBytes, 0o600); err != nil {
+		return VerifyReport{}, fmt.Errorf("write red witness: %w", err)
 	}
 
 	// --- Verify ---

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -442,6 +442,12 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 	// outDir. VerifyRun expects the packet at <runDir>/packet/, so we pass
 	// runDir as outDir and then rename the result.
 	sc := lr.scenario
+	// Make re-runs on the same run dir idempotent: clear any stale assembly
+	// output (a prior packet/, or a partially-written scenario subdir from an
+	// aborted run) so the operator can re-run `run --run-dir X` without a
+	// manual reset. The manifest/witness JSON files are overwritten in place.
+	_ = os.RemoveAll(filepath.Join(runDir, "packet"))
+	_ = os.RemoveAll(filepath.Join(runDir, sc.ID))
 	asmResult, asmErr := AssembleFromEvidenceWithScenario(
 		evidenceFile,
 		hex.EncodeToString(lr.pipelockPub),

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -15,11 +15,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
@@ -353,24 +350,8 @@ func (lr *LiveRun) agentCommand(args []string) (*exec.Cmd, error) {
 	if os.Geteuid() != 0 {
 		return nil, fmt.Errorf("contained toy-agent execution requires root (euid=%d)", os.Geteuid())
 	}
-	agentUser := lr.opts.AgentUser
-	if agentUser == "" {
-		agentUser = defaultContainedAgentUser
-	}
-	u, err := user.Lookup(agentUser)
-	if err != nil {
-		return nil, fmt.Errorf("lookup contained agent user %q: %w", agentUser, err)
-	}
-	uid, err := strconv.ParseUint(u.Uid, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("parse uid for %q: %w", agentUser, err)
-	}
-	gid, err := strconv.ParseUint(u.Gid, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("parse gid for %q: %w", agentUser, err)
-	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)},
+	if err := configureContainedCommand(cmd, lr.opts.AgentUser); err != nil {
+		return nil, err
 	}
 	return cmd, nil
 }

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -37,7 +37,11 @@ import (
 const (
 	liveRunSafeHost  = "safe.target.test"
 	liveRunExfilHost = "exfil.target.test"
-	liveRunBypassURL = "http://93.184.216.34/" //nolint:gosec // G101: reserved example.com IP, not a credential.
+	// RFC 5737 TEST-NET-3 reserved address: a synthetic "external" target. In
+	// contained mode the kernel blocks all egress except the proxy, so this is
+	// never actually contacted; it only needs to be a non-proxy, non-loopback
+	// destination the bypass attempt aims at.
+	liveRunBypassURL = "http://203.0.113.1/"
 )
 
 // liveRunPrincipal and liveRunActor use the same values as the replaycapture
@@ -342,7 +346,7 @@ func (lr *LiveRun) RunSteps(steps ...int) error {
 }
 
 func (lr *LiveRun) agentCommand(args []string) (*exec.Cmd, error) {
-	cmd := exec.CommandContext(lr.ctx, lr.agentBin, args...) //nolint:gosec // G204: agentBin is an operator-configured path from LiveRunOpts, not untrusted input.
+	cmd := exec.CommandContext(lr.ctx, lr.agentBin, args...)
 	if !lr.opts.Contained {
 		return cmd, nil
 	}

--- a/internal/playground/liverun_test.go
+++ b/internal/playground/liverun_test.go
@@ -100,7 +100,7 @@ func TestLiveRun_Uncontained_ProducesVerifiableRun(t *testing.T) {
 
 	rc, err := playground.StartLiveRun(t.Context(), playground.LiveRunOpts{
 		Contained:   false,
-		ScenarioID:  "secret-exfil-url-blocked",
+		ScenarioID:  playground.LiveDemoScenarioID,
 		RunNonce:    "N1",
 		ToyAgentBin: agentBin,
 		WebToolBin:  webtoolBin,

--- a/internal/playground/liverun_test.go
+++ b/internal/playground/liverun_test.go
@@ -1,0 +1,272 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
+)
+
+// binDir holds the compiled toy-agent and web-tool binaries, built once per
+// test binary invocation via TestMain.
+var (
+	binOnce    sync.Once
+	binDir     string
+	binBuildOK bool
+)
+
+// buildBinaries compiles the toy-agent and webtool into a temp dir. It is
+// called at most once per test process via sync.Once.
+func buildBinaries(t *testing.T) (agentBin, webtoolBin string) {
+	t.Helper()
+	binOnce.Do(func() {
+		var err error
+		binDir, err = os.MkdirTemp("", "playground-bins-*")
+		if err != nil {
+			return
+		}
+
+		agentOut := filepath.Join(binDir, "toyagent")
+		webtoolOut := filepath.Join(binDir, "webtool")
+
+		// Build toy agent. The -o path is a test-controlled temp dir, not
+		// untrusted input.
+		buildCtx := context.Background()
+		agentArgs := []string{"build", "-o", agentOut, "./cmd/pipelock-playground-toyagent"}
+		cmd := exec.CommandContext(buildCtx, "go", agentArgs...) //nolint:gosec // G204: test-controlled build output path.
+		cmd.Dir = repoRoot(t)
+		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Logf("build toyagent: %s\n%s", err, out)
+			return
+		}
+
+		// Build web tool.
+		wtArgs := []string{"build", "-o", webtoolOut, "./cmd/pipelock-playground-webtool"}
+		cmd = exec.CommandContext(buildCtx, "go", wtArgs...) //nolint:gosec // G204: test-controlled build output path.
+		cmd.Dir = repoRoot(t)
+		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Logf("build webtool: %s\n%s", err, out)
+			return
+		}
+
+		binBuildOK = true
+	})
+
+	if !binBuildOK {
+		t.Fatal("failed to build playground binaries (see earlier log)")
+	}
+
+	return filepath.Join(binDir, "toyagent"), filepath.Join(binDir, "webtool")
+}
+
+// repoRoot returns the module root by walking up from the test file.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find go.mod")
+		}
+		dir = parent
+	}
+}
+
+func TestLiveRun_Uncontained_ProducesVerifiableRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("live run test builds binaries and boots a real proxy")
+	}
+
+	agentBin, webtoolBin := buildBinaries(t)
+
+	rc, err := playground.StartLiveRun(t.Context(), playground.LiveRunOpts{
+		Contained:   false,
+		ScenarioID:  "secret-exfil-url-blocked",
+		RunNonce:    "N1",
+		ToyAgentBin: agentBin,
+		WebToolBin:  webtoolBin,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+
+	// Step 1 = allowed GET, Step 2 = blocked exfil POST.
+	if err := rc.RunSteps(1, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	if !rc.HasReceipt("allow") || !rc.HasReceipt("block") {
+		t.Fatalf("need allow+block receipts; got %v", rc.Verdicts())
+	}
+
+	runDir := t.TempDir()
+	rep, err := rc.AssembleAndVerify(runDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.OK {
+		t.Fatalf("live run must verify end-to-end: %+v", rep)
+	}
+	if rep.ObservedCount != 0 {
+		t.Fatalf("blocked exfil -> collector must observe 0, got %d", rep.ObservedCount)
+	}
+
+	assertNoLoopbackInArtifacts(t, runDir)
+}
+
+// assertNoLoopbackInArtifacts greps all JSON/JSONL files in runDir for the
+// literal "127.0.0.1" to confirm no loopback IP leaks into signed artifacts.
+func assertNoLoopbackInArtifacts(t *testing.T, runDir string) {
+	t.Helper()
+
+	err := filepath.Walk(runDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(path))
+		switch ext {
+		case ".json", ".jsonl":
+			// check these files
+		default:
+			return nil
+		}
+
+		cleanPath := filepath.Clean(path)
+		data, readErr := os.ReadFile(cleanPath) //nolint:gosec // G122: path is within a test-owned temp dir, no symlink TOCTOU risk.
+		if readErr != nil {
+			t.Errorf("cannot read %s: %v", path, readErr)
+			return nil
+		}
+
+		// For JSON files, check the string content for loopback.
+		// We check both the raw bytes and unmarshaled string fields.
+		if strings.Contains(string(data), "127.0.0.1") {
+			// Allow it in specific non-artifact fields (like proxy addr configs),
+			// but NOT in packet.json, evidence.jsonl, manifest.json,
+			// launch-manifest.json, or witness.json.
+			baseName := filepath.Base(path)
+			switch baseName {
+			case "packet.json", "manifest.json", "launch-manifest.json", "witness.json":
+				t.Errorf("loopback IP found in signed artifact %s", path)
+			default:
+				// evidence.jsonl: check each line's receipt fields
+				if ext == ".jsonl" {
+					checkJSONLForLoopback(t, path, data)
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking runDir: %v", err)
+	}
+}
+
+// checkJSONLForLoopback checks evidence lines for loopback in receipt fields.
+func checkJSONLForLoopback(t *testing.T, path string, data []byte) {
+	t.Helper()
+	for i, line := range strings.Split(string(data), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		// Check the receipt's action_record target field specifically.
+		if rcRaw, ok := entry["receipt"]; ok {
+			var rc struct {
+				ActionRecord struct {
+					Target string `json:"target"`
+				} `json:"action_record"`
+			}
+			if err := json.Unmarshal(rcRaw, &rc); err == nil {
+				if strings.Contains(rc.ActionRecord.Target, "127.0.0.1") {
+					t.Errorf("loopback IP in receipt target at %s line %d: %s",
+						path, i+1, rc.ActionRecord.Target)
+				}
+			}
+		}
+	}
+}
+
+func TestAssembleFromEvidenceWithScenario_PreservesScenarioFields(t *testing.T) {
+	t.Parallel()
+
+	// Drive a real scenario through the capture engine.
+	scenarios := replaycapture.DefaultScenarios()
+	var exfilScenario replaycapture.Scenario
+	for _, s := range scenarios {
+		if s.ID == "secret-exfil-url-blocked" {
+			exfilScenario = s
+			break
+		}
+	}
+	if exfilScenario.ID == "" {
+		t.Fatal("scenario not found")
+	}
+
+	engine, err := replaycapture.NewEngine(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	captured, err := engine.Capture(exfilScenario)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+
+	// Assemble WITH the full scenario.
+	outDir := t.TempDir()
+	result, err := playground.AssembleFromEvidenceWithScenario(
+		captured.EvidenceFile,
+		engine.PublicKeyHex(),
+		&exfilScenario,
+		outDir,
+		time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatalf("AssembleFromEvidenceWithScenario: %v", err)
+	}
+
+	if result.PacketDir == "" {
+		t.Fatal("PacketDir is empty")
+	}
+
+	// The assembled result should carry the real scenario.
+	if result.Scenario.ID != exfilScenario.ID {
+		t.Errorf("scenario ID = %q, want %q", result.Scenario.ID, exfilScenario.ID)
+	}
+	if result.Scenario.Title != exfilScenario.Title {
+		t.Errorf("scenario Title = %q, want %q", result.Scenario.Title, exfilScenario.Title)
+	}
+
+	// Verify the packet is still valid.
+	if err := replaycapture.VerifyPacketDir(result.PacketDir, engine.PublicKeyHex()); err != nil {
+		t.Fatalf("VerifyPacketDir: %v", err)
+	}
+}

--- a/internal/playground/liverun_test.go
+++ b/internal/playground/liverun_test.go
@@ -170,7 +170,7 @@ func assertNoLoopbackInArtifacts(t *testing.T, runDir string) {
 			// launch-manifest.json, or witness.json.
 			baseName := filepath.Base(path)
 			switch baseName {
-			case "packet.json", "manifest.json", "launch-manifest.json", "witness.json":
+			case "packet.json", "manifest.json", "launch-manifest.json", "witness.json", "red-witness.json":
 				t.Errorf("loopback IP found in signed artifact %s", path)
 			default:
 				// evidence.jsonl: check each line's receipt fields

--- a/internal/playground/liverun_test.go
+++ b/internal/playground/liverun_test.go
@@ -44,7 +44,7 @@ func buildBinaries(t *testing.T) (agentBin, webtoolBin string) {
 		// untrusted input.
 		buildCtx := context.Background()
 		agentArgs := []string{"build", "-o", agentOut, "./cmd/pipelock-playground-toyagent"}
-		cmd := exec.CommandContext(buildCtx, "go", agentArgs...) //nolint:gosec // G204: test-controlled build output path.
+		cmd := exec.CommandContext(buildCtx, "go", agentArgs...)
 		cmd.Dir = repoRoot(t)
 		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 		if out, err := cmd.CombinedOutput(); err != nil {
@@ -54,7 +54,7 @@ func buildBinaries(t *testing.T) (agentBin, webtoolBin string) {
 
 		// Build web tool.
 		wtArgs := []string{"build", "-o", webtoolOut, "./cmd/pipelock-playground-webtool"}
-		cmd = exec.CommandContext(buildCtx, "go", wtArgs...) //nolint:gosec // G204: test-controlled build output path.
+		cmd = exec.CommandContext(buildCtx, "go", wtArgs...)
 		cmd.Dir = repoRoot(t)
 		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 		if out, err := cmd.CombinedOutput(); err != nil {
@@ -156,7 +156,7 @@ func assertNoLoopbackInArtifacts(t *testing.T, runDir string) {
 		}
 
 		cleanPath := filepath.Clean(path)
-		data, readErr := os.ReadFile(cleanPath) //nolint:gosec // G122: path is within a test-owned temp dir, no symlink TOCTOU risk.
+		data, readErr := os.ReadFile(cleanPath)
 		if readErr != nil {
 			t.Errorf("cannot read %s: %v", path, readErr)
 			return nil

--- a/internal/playground/liverun_unix.go
+++ b/internal/playground/liverun_unix.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package playground
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+func configureContainedCommand(cmd *exec.Cmd, agentUser string) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("contained toy-agent execution requires root (euid=%d)", os.Geteuid())
+	}
+	if agentUser == "" {
+		agentUser = defaultContainedAgentUser
+	}
+	u, err := user.Lookup(agentUser)
+	if err != nil {
+		return fmt.Errorf("lookup contained agent user %q: %w", agentUser, err)
+	}
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parse uid for %q: %w", agentUser, err)
+	}
+	gid, err := strconv.ParseUint(u.Gid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parse gid for %q: %w", agentUser, err)
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)},
+	}
+	return nil
+}

--- a/internal/playground/liverun_unix_test.go
+++ b/internal/playground/liverun_unix_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package playground
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestConfigureContainedCommandRequiresRoot(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root path depends on host user database")
+	}
+
+	err := configureContainedCommand(exec.CommandContext(t.Context(), "true"), defaultContainedAgentUser)
+	if err == nil {
+		t.Fatal("expected non-root contained command configuration to fail")
+	}
+	if !strings.Contains(err.Error(), "requires root") {
+		t.Fatalf("error = %v, want root requirement", err)
+	}
+}

--- a/internal/playground/liverun_windows.go
+++ b/internal/playground/liverun_windows.go
@@ -1,0 +1,15 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package playground
+
+import (
+	"errors"
+	"os/exec"
+)
+
+func configureContainedCommand(_ *exec.Cmd, _ string) error {
+	return errors.New("contained toy-agent execution is not supported on windows")
+}

--- a/internal/playground/mediator.go
+++ b/internal/playground/mediator.go
@@ -75,16 +75,10 @@ func RenderMediator(w io.Writer, events []MediatorEvent, color bool) {
 // renderPipelockDecision formats a ClassPipelockDecision event.
 // Block verdicts use the ">>> BLOCKED <<<" marker so they visually pop.
 func renderPipelockDecision(w io.Writer, ev MediatorEvent, color bool) {
+	_ = color
 	verdict := strings.ToLower(ev.Verdict)
 	if verdict == verdictBlock {
-		if color {
-			// Even with color disabled in most callers, preserve the hook for
-			// future ANSI support. Currently we just uppercase — the BLOCKED
-			// text is what the honesty test requires.
-			_, _ = fmt.Fprintf(w, "[pipelock_decision] >>> BLOCKED <<< %s\n", ev.Summary)
-		} else {
-			_, _ = fmt.Fprintf(w, "[pipelock_decision] >>> BLOCKED <<< %s\n", ev.Summary)
-		}
+		_, _ = fmt.Fprintf(w, "[pipelock_decision] >>> BLOCKED <<< %s\n", ev.Summary)
 	} else {
 		_, _ = fmt.Fprintf(w, "[pipelock_decision] %s %s\n",
 			strings.ToUpper(verdict), ev.Summary)

--- a/internal/playground/mediator.go
+++ b/internal/playground/mediator.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+// HONESTY RULE (enforced by the renderer):
+// Every on-screen line carries exactly one EVIDENCE CLASS label, and no line
+// may use a stronger class than the underlying evidence supports.
+//
+// Evidence classes (matching EvidenceClass constants in types.go):
+//   - pipelock_decision  : signed receipt in the hash-linked chain (allow/block/warn/…).
+//                          The ONLY cryptographically Pipelock-bound class.
+//   - collector_witness  : the collector's own signed statement (separate key).
+//                          "Target-side lab instrumentation."
+//   - host_containment   : bypass failing at the kernel. No receipt. Operational result.
+//   - narration          : the agent's printed intent. Unsigned, context only.
+
+// MediatorEvent is one event in the terminal mediator timeline.
+// Callers populate exactly the fields that apply to the class:
+//   - ClassPipelockDecision → Verdict + Summary (safe, redacted destination class)
+//   - ClassCollectorWitness → Summary
+//   - ClassHostContainment  → Summary
+//   - ClassNarration        → Text
+type MediatorEvent struct {
+	Class   EvidenceClass
+	Verdict string // "allow", "block", "warn", etc. — only for ClassPipelockDecision
+	Summary string // short, secret-free description
+	Text    string // raw text — only for ClassNarration (agent stdout)
+}
+
+// mediatorLegend is a one-line legend printed at the top of every mediator view.
+const mediatorLegend = "LEGEND: [pipelock_decision=signed receipt] " +
+	"[collector_witness=signed collector stmt] " +
+	"[host_containment=kernel-observed] " +
+	"[narration=unsigned agent intent]"
+
+// RenderMediator writes the mediator timeline to w. Each event occupies its
+// own block with a clear EVIDENCE-CLASS label. A block verdict is rendered
+// prominently with ">>> BLOCKED <<<". When color is true, blocks are rendered
+// in a bracket that stands out; tests always pass color=false for
+// deterministic output.
+//
+// The renderer never adds or enriches raw secret-shaped values — it only
+// formats the class, verdict, and summary/text fields provided by the caller.
+func RenderMediator(w io.Writer, events []MediatorEvent, color bool) {
+	_, _ = fmt.Fprintln(w, mediatorLegend)
+	_, _ = fmt.Fprintln(w, strings.Repeat("-", 72))
+
+	for _, ev := range events {
+		switch ev.Class {
+		case ClassPipelockDecision:
+			renderPipelockDecision(w, ev, color)
+		case ClassCollectorWitness:
+			renderCollectorWitness(w, ev)
+		case ClassHostContainment:
+			renderHostContainment(w, ev)
+		case ClassNarration:
+			renderNarration(w, ev)
+		default:
+			// Unknown class: render safely with label "unknown" — never
+			// upgrade to a stronger class.
+			_, _ = fmt.Fprintf(w, "[unknown] %s\n", ev.Summary)
+		}
+	}
+}
+
+// renderPipelockDecision formats a ClassPipelockDecision event.
+// Block verdicts use the ">>> BLOCKED <<<" marker so they visually pop.
+func renderPipelockDecision(w io.Writer, ev MediatorEvent, color bool) {
+	verdict := strings.ToLower(ev.Verdict)
+	if verdict == verdictBlock {
+		if color {
+			// Even with color disabled in most callers, preserve the hook for
+			// future ANSI support. Currently we just uppercase — the BLOCKED
+			// text is what the honesty test requires.
+			_, _ = fmt.Fprintf(w, "[pipelock_decision] >>> BLOCKED <<< %s\n", ev.Summary)
+		} else {
+			_, _ = fmt.Fprintf(w, "[pipelock_decision] >>> BLOCKED <<< %s\n", ev.Summary)
+		}
+	} else {
+		_, _ = fmt.Fprintf(w, "[pipelock_decision] %s %s\n",
+			strings.ToUpper(verdict), ev.Summary)
+	}
+}
+
+// renderCollectorWitness formats a ClassCollectorWitness event.
+// Deliberately distinct styling from pipelock_decision — no BLOCKED marker,
+// no verdict label.
+func renderCollectorWitness(w io.Writer, ev MediatorEvent) {
+	_, _ = fmt.Fprintf(w, "[collector_witness] %s\n", ev.Summary)
+}
+
+// renderHostContainment formats a ClassHostContainment event.
+// Must NOT use pipelock_decision styling or the BLOCKED marker — this is an
+// operational observation, not a cryptographic receipt.
+func renderHostContainment(w io.Writer, ev MediatorEvent) {
+	_, _ = fmt.Fprintf(w, "[host_containment] %s\n", ev.Summary)
+}
+
+// renderNarration formats a ClassNarration event.
+// Plaintext — unsigned agent output, no styling that implies enforcement.
+func renderNarration(w io.Writer, ev MediatorEvent) {
+	_, _ = fmt.Fprintf(w, "[narration] %s\n", ev.Text)
+}
+
+// verdictBlock is the normalized verdict string for a block decision.
+const verdictBlock = "block"
+
+// MediatorEventsFromEvidence reads a flight-recorder JSONL evidence file,
+// extracts all receipts, and maps each to a ClassPipelockDecision MediatorEvent.
+//
+// The summary for each event is built from the normalized verdict and the
+// transport layer field — raw target values are NOT included because they may
+// carry secret-shaped canary values. The caller must ensure the evidence file
+// was produced with redaction enabled.
+func MediatorEventsFromEvidence(evidenceFile string) ([]MediatorEvent, error) {
+	receipts, err := receipt.ExtractReceipts(evidenceFile)
+	if err != nil {
+		return nil, fmt.Errorf("mediator: extract receipts: %w", err)
+	}
+
+	events := make([]MediatorEvent, 0, len(receipts))
+	for _, r := range receipts {
+		ar := r.ActionRecord
+		verdict := receipt.NormalizeVerdict(ar.Verdict)
+
+		// Build a secret-free summary. We include:
+		//   - verdict  (allow/block/warn/…)
+		//   - transport (http-forward, mcp, etc.)
+		//   - layer    (dlp/ssrf/…) when present — never the raw target value
+		//   - signature presence (true/false) — proves this is a signed receipt
+		summary := buildSafeDecisionSummary(verdict, ar.Transport, ar.Layer, r.Signature != "")
+
+		events = append(events, MediatorEvent{
+			Class:   ClassPipelockDecision,
+			Verdict: verdict,
+			Summary: summary,
+		})
+	}
+	return events, nil
+}
+
+// buildSafeDecisionSummary constructs a short, secret-free description for a
+// pipelock decision event. It never includes the raw target URL or body values.
+func buildSafeDecisionSummary(verdict, transport, layer string, signed bool) string {
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "verdict=%s", verdict)
+	if transport != "" {
+		_, _ = fmt.Fprintf(&b, " transport=%s", transport)
+	}
+	if layer != "" {
+		_, _ = fmt.Fprintf(&b, " layer=%s", layer)
+	}
+	if signed {
+		b.WriteString(" sig=present")
+	}
+	return b.String()
+}
+
+// --- Helper constructors for T9 timeline assembly ---
+
+// WitnessEvent constructs a ClassCollectorWitness MediatorEvent from a Witness.
+// The summary reports the observed/total canary count. The Witness carries no
+// secret-shaped values by design — it only holds counts and hashes.
+func WitnessEvent(w Witness) MediatorEvent {
+	summary := fmt.Sprintf("canary observed=%d total=%d run=%s",
+		w.ObservedCount, w.TotalCount, safeNonce(w.RunNonce))
+	return MediatorEvent{
+		Class:   ClassCollectorWitness,
+		Summary: summary,
+	}
+}
+
+// ContainmentEvent constructs a ClassHostContainment MediatorEvent.
+// blocked=true means the direct-egress attempt was denied at the kernel level.
+// detail is a short, operator-supplied description (no secret values).
+func ContainmentEvent(blocked bool, detail string) MediatorEvent {
+	action := "allowed"
+	if blocked {
+		action = "blocked"
+	}
+	summary := fmt.Sprintf("kernel-containment=%s: %s", action, detail)
+	return MediatorEvent{
+		Class:   ClassHostContainment,
+		Summary: summary,
+	}
+}
+
+// NarrationEvent constructs a ClassNarration MediatorEvent from agent stdout text.
+// The text is passed through verbatim; the caller is responsible for ensuring it
+// does not contain raw secret values before passing to the renderer.
+func NarrationEvent(text string) MediatorEvent {
+	return MediatorEvent{
+		Class: ClassNarration,
+		Text:  text,
+	}
+}
+
+// safeNonce truncates a run nonce to 8 chars for display — enough to identify
+// the run without showing an unwieldy UUID or entropy blob.
+func safeNonce(nonce string) string {
+	if len(nonce) <= 8 {
+		return nonce
+	}
+	return nonce[:8] + "…"
+}

--- a/internal/playground/mediator_test.go
+++ b/internal/playground/mediator_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
+)
+
+const (
+	testSafeTarget   = "GET safe.target.test"
+	testExfilTarget  = "POST exfil.target.test (canary)"
+	testWitnessCount = "collector observed canary: 0"
+	testNarration    = "agent: I will exfiltrate aws_canary"
+)
+
+// bypassDesc() is the description used for host_containment events in tests.
+// Built at call sites via bypassDesc() to keep gosec G101 out of const scope.
+func bypassDesc() string { return "direct egress " + "denied by kernel" }
+
+// lineFor returns the line in out that contains sub, or "".
+func lineFor(out, sub string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, sub) {
+			return line
+		}
+	}
+	return ""
+}
+
+func TestMediator_LabelsEvidenceClasses(t *testing.T) {
+	var buf bytes.Buffer
+	ev := []MediatorEvent{
+		{Class: ClassNarration, Text: testNarration},
+		{Class: ClassPipelockDecision, Verdict: "allow", Summary: testSafeTarget},
+		{Class: ClassPipelockDecision, Verdict: "block", Summary: testExfilTarget},
+		{Class: ClassCollectorWitness, Summary: testWitnessCount},
+		{Class: ClassHostContainment, Summary: bypassDesc()},
+	}
+	RenderMediator(&buf, ev, false)
+	out := buf.String()
+
+	// All four evidence-class labels must appear.
+	for _, want := range []string{"pipelock_decision", "collector_witness", "host_containment", "narration"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing evidence-class label %q in output:\n%s", want, out)
+		}
+	}
+
+	// A blocked decision must visually pop.
+	if !strings.Contains(out, "BLOCKED") {
+		t.Fatalf("a blocked decision must visually pop (BLOCKED); output:\n%s", out)
+	}
+
+	// The bypass line must NOT be labeled as a signed pipelock decision.
+	bypassLine := lineFor(out, bypassDesc())
+	if bypassLine == "" {
+		t.Fatalf("no output line contains %q", bypassDesc())
+	}
+	if strings.Contains(bypassLine, "pipelock_decision") {
+		t.Fatalf("bypass line must not be labeled pipelock_decision, got: %q", bypassLine)
+	}
+
+	// The legend must be present somewhere in the output.
+	if !strings.Contains(out, "LEGEND") && !strings.Contains(out, "legend") {
+		t.Fatalf("output must contain a legend explaining the four evidence classes; output:\n%s", out)
+	}
+}
+
+func TestMediator_BlockVisuallyPops(t *testing.T) {
+	var buf bytes.Buffer
+	ev := []MediatorEvent{
+		{Class: ClassPipelockDecision, Verdict: "block", Summary: "POST secret.target.test"},
+	}
+	RenderMediator(&buf, ev, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "BLOCKED") {
+		t.Fatalf("block verdict must render BLOCKED; output:\n%s", out)
+	}
+}
+
+func TestMediator_AllowDoesNotShowBLOCKED(t *testing.T) {
+	var buf bytes.Buffer
+	ev := []MediatorEvent{
+		{Class: ClassPipelockDecision, Verdict: "allow", Summary: "GET safe.target.test"},
+	}
+	RenderMediator(&buf, ev, false)
+	out := buf.String()
+
+	// Allow must not use the block styling.
+	if strings.Contains(out, "BLOCKED") {
+		t.Fatalf("allow verdict must not render BLOCKED; output:\n%s", out)
+	}
+}
+
+func TestMediator_HostContainmentNotPipelockDecision(t *testing.T) {
+	var buf bytes.Buffer
+	ev := []MediatorEvent{
+		{Class: ClassHostContainment, Summary: bypassDesc()},
+	}
+	RenderMediator(&buf, ev, false)
+	out := buf.String()
+
+	bypassLine := lineFor(out, bypassDesc())
+	if bypassLine == "" {
+		t.Fatalf("no line contains %q", bypassDesc())
+	}
+	if strings.Contains(bypassLine, "pipelock_decision") {
+		t.Fatalf("host_containment must not be labeled pipelock_decision: %q", bypassLine)
+	}
+	if !strings.Contains(bypassLine, "host_containment") {
+		t.Fatalf("host_containment event must carry host_containment label: %q", bypassLine)
+	}
+}
+
+func TestMediator_NarrationNotPipelockDecision(t *testing.T) {
+	var buf bytes.Buffer
+	ev := []MediatorEvent{
+		{Class: ClassNarration, Text: testNarration},
+	}
+	RenderMediator(&buf, ev, false)
+	out := buf.String()
+
+	narLine := lineFor(out, "exfiltrate")
+	if narLine == "" {
+		t.Fatalf("no line contains narration text")
+	}
+	if strings.Contains(narLine, "pipelock_decision") {
+		t.Fatalf("narration must not be labeled pipelock_decision: %q", narLine)
+	}
+	if !strings.Contains(narLine, "narration") {
+		t.Fatalf("narration event must carry narration label: %q", narLine)
+	}
+}
+
+func TestMediator_NoRawSecretInOutput(t *testing.T) {
+	// A secret-shaped value in the Summary must not appear verbatim; the
+	// renderer receives only verdict/class/summary — the caller is responsible
+	// for not passing raw secrets as Summary. We verify the renderer does not
+	// add any enrichment that re-injects secret material.
+	// Split at build time so gosec G101 does not flag a hardcoded test value.
+	secretCanary := "SYNTH-CANARY-" + "abc123SECRETVALUE"
+	var buf bytes.Buffer
+	ev := []MediatorEvent{
+		// Summary already stripped of the secret; only safe text.
+		{Class: ClassPipelockDecision, Verdict: "block", Summary: "POST exfil.target.test [canary redacted]"},
+		// Narration text: may come from agent stdout, must pass through verbatim
+		// but the renderer must not add any secret-shaped enrichment on top.
+		{Class: ClassNarration, Text: "agent: sending data"},
+	}
+	RenderMediator(&buf, ev, false)
+	out := buf.String()
+
+	if strings.Contains(out, secretCanary) {
+		t.Fatalf("raw secret-shaped canary value appeared in mediator output")
+	}
+}
+
+// buildSmallEvidenceJSONL drives the first available scenario through a real
+// proxy and returns the path to the resulting evidence JSONL file. It uses
+// replaycapture.NewEngine so the evidence is genuinely signed.
+func buildSmallEvidenceJSONL(t *testing.T) string {
+	t.Helper()
+	engine, err := replaycapture.NewEngine(t.TempDir())
+	if err != nil {
+		t.Fatalf("buildSmallEvidenceJSONL: NewEngine: %v", err)
+	}
+	scenarios := replaycapture.DefaultScenarios()
+	if len(scenarios) == 0 {
+		t.Fatal("buildSmallEvidenceJSONL: no default scenarios")
+	}
+	captured, err := engine.Capture(scenarios[0])
+	if err != nil {
+		t.Fatalf("buildSmallEvidenceJSONL: Capture: %v", err)
+	}
+	return captured.EvidenceFile
+}
+
+func TestMediator_HelperConstructors(t *testing.T) {
+	w := WitnessEvent(Witness{ObservedCount: 0, TotalCount: 5})
+	if w.Class != ClassCollectorWitness {
+		t.Fatalf("WitnessEvent class = %q, want collector_witness", w.Class)
+	}
+	if !strings.Contains(w.Summary, "0") {
+		t.Fatalf("WitnessEvent summary should contain observed count; got %q", w.Summary)
+	}
+
+	c := ContainmentEvent(true, "kernel denied direct egress")
+	if c.Class != ClassHostContainment {
+		t.Fatalf("ContainmentEvent class = %q, want host_containment", c.Class)
+	}
+
+	n := NarrationEvent("agent says hello")
+	if n.Class != ClassNarration {
+		t.Fatalf("NarrationEvent class = %q, want narration", n.Class)
+	}
+}
+
+func TestMediator_FromEvidenceFile(t *testing.T) {
+	evidenceFile := buildSmallEvidenceJSONL(t)
+
+	events, err := MediatorEventsFromEvidence(evidenceFile)
+	if err != nil {
+		t.Fatalf("MediatorEventsFromEvidence: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatalf("expected at least one event from evidence file, got 0")
+	}
+
+	// All events from an evidence file are ClassPipelockDecision.
+	for i, ev := range events {
+		if ev.Class != ClassPipelockDecision {
+			t.Errorf("event[%d] class = %q, want pipelock_decision", i, ev.Class)
+		}
+		if ev.Verdict == "" {
+			t.Errorf("event[%d] has empty Verdict", i)
+		}
+	}
+
+	// Render them — must not error, must contain the class label.
+	var buf bytes.Buffer
+	RenderMediator(&buf, events, false)
+	out := buf.String()
+	if !strings.Contains(out, "pipelock_decision") {
+		t.Fatalf("rendered output from evidence must contain pipelock_decision label; output:\n%s", out)
+	}
+}

--- a/internal/playground/orchestrate.go
+++ b/internal/playground/orchestrate.go
@@ -128,7 +128,7 @@ func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, e
 	if err != nil {
 		return VerifyReport{}, fmt.Errorf("bin temp dir: %w", err)
 	}
-	if err := os.Chmod(binDir, 0o755); err != nil { //nolint:gosec // G302: contained agent user needs traverse/execute access to demo binaries.
+	if err := os.Chmod(binDir, 0o755); err != nil {
 		return VerifyReport{}, fmt.Errorf("bin temp dir permissions: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(binDir) }()
@@ -385,7 +385,7 @@ func findRepoRoot() (string, error) {
 func goBuild(ctx context.Context, dir, pkg, outPath string) error {
 	// All arguments are operator-controlled paths from DemoOpts, not untrusted input.
 	args := []string{"build", "-o", outPath, pkg}
-	cmd := exec.CommandContext(ctx, "go", args...) //nolint:gosec // G204: operator-controlled build paths, not untrusted input.
+	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -407,7 +407,7 @@ func hashDir(dir string) (string, error) {
 			return nil
 		}
 		cleanPath := filepath.Clean(path)
-		data, err := os.ReadFile(cleanPath) //nolint:gosec // G122: path is within an operator-controlled packet dir, no symlink TOCTOU risk.
+		data, err := os.ReadFile(cleanPath)
 		if err != nil {
 			return err
 		}

--- a/internal/playground/orchestrate.go
+++ b/internal/playground/orchestrate.go
@@ -1,0 +1,419 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// ErrContainmentNotWired is returned when Contained=true but no containment
+// hook has been registered via SetContainmentHook. Task 7 will wire the real
+// implementation; until then, contained mode visibly refuses to run rather
+// than silently falling back to uncontained.
+var ErrContainmentNotWired = errors.New(
+	"playground: containment mode requested but no containment hook is wired " +
+		"(Task 7 will provide the kernel-containment implementation)")
+
+// ContainmentHook is the interface Task 7 must implement to wire kernel
+// containment into the demo orchestrator. The orchestrator calls Setup before
+// the live run starts and Teardown during Reset/Close.
+//
+//	Setup: prepare nft chains, agent user, proxy routing. Returns nil on success.
+//	Teardown: remove nft chains, kill agent processes, clean state.
+type ContainmentHook interface {
+	Setup(ctx context.Context, opts DemoOpts) error
+	Teardown(runDir string) error
+}
+
+// containmentSetupHook is the pluggable containment seam. Nil means
+// containment is not available. Task 7 calls SetContainmentHook to wire it.
+// Protected by containmentMu for test-time concurrent access.
+var (
+	containmentSetupHook ContainmentHook
+	containmentMu        sync.RWMutex
+)
+
+// SetContainmentHook registers the containment implementation. Call this from
+// Task 7's init or setup code. Passing nil unregisters (reverts to uncontained-only).
+func SetContainmentHook(hook ContainmentHook) {
+	containmentMu.Lock()
+	defer containmentMu.Unlock()
+	containmentSetupHook = hook
+}
+
+// getContainmentHook returns the current containment hook (nil if not wired).
+func getContainmentHook() ContainmentHook {
+	containmentMu.RLock()
+	defer containmentMu.RUnlock()
+	return containmentSetupHook
+}
+
+// DemoOpts configures a full demo run (run/reset/fallback).
+type DemoOpts struct {
+	// Contained selects kernel-containment mode. When false, the demo runs
+	// in uncontained mode (MCP-wrapped only, no kernel enforcement). When
+	// true, the containment hook must be wired via SetContainmentHook.
+	Contained bool
+
+	// ScenarioID selects the scenario from DefaultScenarios.
+	ScenarioID string
+
+	// RunNonce is the unique identifier for this run. When empty, a fixed
+	// demo nonce is used (suitable for demos; real runs should supply a
+	// high-entropy nonce).
+	RunNonce string
+
+	// RunDir is the directory where the run artifacts (packet, manifest,
+	// witness) are written. Must be writable.
+	RunDir string
+
+	// Color enables ANSI color in the mediator timeline output.
+	Color bool
+}
+
+// defaultDemoNonce is used when DemoOpts.RunNonce is empty.
+const defaultDemoNonce = "playground-demo-run"
+
+// defaultScenarioID is the scenario used when DemoOpts.ScenarioID is empty.
+const defaultScenarioID = "secret-exfil-url-blocked"
+
+// RunDemo drives a full live demo: preflight, start infrastructure, run the
+// toy agent, collect evidence, render the mediator timeline, assemble the
+// audit packet, verify, and print the audience verify command.
+//
+// In uncontained mode (the default, fully working today), the demo runs the
+// toy agent through the proxy without kernel containment. In contained mode,
+// it delegates to the containment hook (Task 7) for nft/agent-user setup.
+//
+// Returns the VerifyReport so the caller can check .OK and set the exit code.
+func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, error) {
+	// --- Defaults ---
+	if opts.RunNonce == "" {
+		opts.RunNonce = defaultDemoNonce
+	}
+	if opts.ScenarioID == "" {
+		opts.ScenarioID = defaultScenarioID
+	}
+
+	// --- Preflight ---
+	if err := Preflight(opts); err != nil {
+		return VerifyReport{}, fmt.Errorf("preflight: %w", err)
+	}
+
+	// --- Containment setup (Task 7 seam) ---
+	if opts.Contained {
+		hook := getContainmentHook()
+		if hook == nil {
+			return VerifyReport{}, ErrContainmentNotWired
+		}
+		if err := hook.Setup(ctx, opts); err != nil {
+			return VerifyReport{}, fmt.Errorf("containment setup: %w", err)
+		}
+	}
+
+	// --- Build binaries into a temp dir ---
+	binDir, err := os.MkdirTemp("", "playground-demo-bins-*")
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("bin temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(binDir) }()
+
+	agentBin, webtoolBin, err := buildDemoBinaries(ctx, binDir)
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("build binaries: %w", err)
+	}
+
+	// --- Timeline events (narration first) ---
+	var timeline []MediatorEvent
+
+	timeline = append(timeline, NarrationEvent(
+		fmt.Sprintf("Starting demo run: scenario=%s nonce=%s contained=%v",
+			opts.ScenarioID, safeNonce(opts.RunNonce), opts.Contained)))
+
+	// --- Start live run ---
+	lr, err := StartLiveRun(ctx, LiveRunOpts{
+		Contained:   opts.Contained,
+		ScenarioID:  opts.ScenarioID,
+		RunNonce:    opts.RunNonce,
+		ToyAgentBin: agentBin,
+		WebToolBin:  webtoolBin,
+	})
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("start live run: %w", err)
+	}
+	defer lr.Close()
+
+	// --- Run agent steps ---
+	timeline = append(timeline, NarrationEvent("Step 1: Safe GET request (expect ALLOW)"))
+
+	if err := lr.RunSteps(1); err != nil {
+		return VerifyReport{}, fmt.Errorf("step 1: %w", err)
+	}
+
+	timeline = append(timeline, NarrationEvent("Step 2: Exfiltration POST with canary (expect BLOCK)"))
+
+	if err := lr.RunSteps(2); err != nil {
+		return VerifyReport{}, fmt.Errorf("step 2: %w", err)
+	}
+
+	// Step 3 (bypass) only runs in contained mode.
+	if opts.Contained {
+		timeline = append(timeline, NarrationEvent("Step 3: Direct bypass attempt (expect kernel BLOCK)"))
+		if err := lr.RunSteps(3); err != nil {
+			return VerifyReport{}, fmt.Errorf("step 3: %w", err)
+		}
+	}
+
+	// --- Assemble + verify ---
+	rep, err := lr.AssembleAndVerify(opts.RunDir)
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("assemble and verify: %w", err)
+	}
+
+	// --- Build evidence-based timeline events ---
+	evidenceFile, evidenceErr := singleLiveEvidenceFile(lr.evidenceDir)
+	if evidenceErr == nil {
+		evEvents, evErr := MediatorEventsFromEvidence(evidenceFile)
+		if evErr == nil {
+			timeline = append(timeline, evEvents...)
+		}
+	}
+
+	// --- Witness event ---
+	witnessPath := filepath.Join(opts.RunDir, witnessFile)
+	cleanWitnessPath := filepath.Clean(witnessPath)
+	wData, wErr := os.ReadFile(cleanWitnessPath)
+	if wErr == nil {
+		var w Witness
+		if json.Unmarshal(wData, &w) == nil {
+			timeline = append(timeline, WitnessEvent(w))
+		}
+	}
+
+	// --- Containment event (contained mode only) ---
+	if opts.Contained {
+		// In contained mode, step 3 should have been kernel-blocked.
+		timeline = append(timeline, ContainmentEvent(true, "direct egress denied by nft rules"))
+	}
+
+	// --- Render timeline ---
+	_, _ = fmt.Fprintln(out)
+	RenderMediator(out, timeline, opts.Color)
+	_, _ = fmt.Fprintln(out)
+
+	// --- Print verify summary ---
+	renderVerifySummary(out, rep, opts.RunDir)
+
+	return rep, nil
+}
+
+// renderVerifySummary prints the VerifyReport checks and the audience verify
+// command to out.
+func renderVerifySummary(out io.Writer, rep VerifyReport, runDir string) {
+	_, _ = fmt.Fprintln(out, strings.Repeat("=", 72))
+	_, _ = fmt.Fprintln(out, "VERIFICATION RESULTS")
+	_, _ = fmt.Fprintln(out, strings.Repeat("-", 72))
+
+	for _, c := range rep.Checks {
+		status := "PASS"
+		if !c.OK {
+			status = "FAIL"
+		}
+		_, _ = fmt.Fprintf(out, "[%s] %s", status, c.Name)
+		if c.Reason != "" {
+			_, _ = fmt.Fprintf(out, " -- %s", c.Reason)
+		}
+		_, _ = fmt.Fprintln(out)
+	}
+
+	_, _ = fmt.Fprintln(out)
+	if rep.OK {
+		_, _ = fmt.Fprintf(out, "VERIFY OK  run_nonce=%s observed=%d\n", rep.RunNonce, rep.ObservedCount)
+	} else {
+		_, _ = fmt.Fprintln(out, "VERIFY FAILED: one or more checks did not pass")
+	}
+
+	// Print the audience verify command so anyone can re-check offline.
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "To verify this run independently:")
+	_, _ = fmt.Fprintf(out, "  pipelock-playground-demo verify %s --orchestrator-key %s\n",
+		filepath.Clean(runDir), rep.PipelockKey)
+}
+
+// Reset clears all state from a previous run in runDir, making it safe to
+// reuse for a new run. It is idempotent: calling Reset on an empty or
+// nonexistent dir succeeds. Calling it 3x in a row before new runs must
+// produce 3 clean runs.
+//
+// Containment teardown (nft chains, agent processes) is a Task 7 concern;
+// a marked hook is called when wired.
+func Reset(runDir string) error {
+	cleanDir := filepath.Clean(runDir)
+
+	// If the dir exists, remove its contents entirely. This is the simplest
+	// way to guarantee no stale state (evidence, packets, manifests, witnesses)
+	// bleeds into a new run.
+	if _, err := os.Stat(cleanDir); err == nil {
+		if err := os.RemoveAll(cleanDir); err != nil {
+			return fmt.Errorf("reset: cannot remove %q: %w", runDir, err)
+		}
+	}
+
+	// Recreate the dir fresh.
+	if err := os.MkdirAll(cleanDir, 0o750); err != nil {
+		return fmt.Errorf("reset: cannot create %q: %w", runDir, err)
+	}
+
+	// Containment teardown hook (Task 7).
+	if hook := getContainmentHook(); hook != nil {
+		if err := hook.Teardown(runDir); err != nil {
+			return fmt.Errorf("reset: containment teardown: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Fallback replays a pre-recorded run directory with a visible REPLAY
+// watermark, the packet hash, and the verifier command. It re-runs
+// VerifyRun to confirm the recorded evidence is still valid.
+//
+// The output is clearly labeled as a replay so the audience knows they are
+// not watching a live run.
+func Fallback(out io.Writer, recordedRunDir, orchestratorKeyHex string) (VerifyReport, error) {
+	cleanDir := filepath.Clean(recordedRunDir)
+
+	// --- REPLAY watermark ---
+	_, _ = fmt.Fprintln(out, strings.Repeat("*", 72))
+	_, _ = fmt.Fprintln(out, "***                    REPLAY MODE                              ***")
+	_, _ = fmt.Fprintln(out, "*** This is a replay of a pre-recorded run, NOT a live demo.    ***")
+	_, _ = fmt.Fprintln(out, strings.Repeat("*", 72))
+	_, _ = fmt.Fprintln(out)
+
+	// --- Compute and print packet hash ---
+	packetDir := filepath.Join(cleanDir, packetSubdir)
+	packetHash, err := hashDir(packetDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "WARNING: cannot compute packet hash: %v\n", err)
+	} else {
+		_, _ = fmt.Fprintf(out, "Packet hash: %s\n", packetHash)
+	}
+	_, _ = fmt.Fprintln(out)
+
+	// --- Rebuild mediator timeline from evidence ---
+	evidencePattern := filepath.Join(packetDir, "evidence.jsonl")
+	if _, statErr := os.Stat(evidencePattern); statErr == nil {
+		evEvents, evErr := MediatorEventsFromEvidence(evidencePattern)
+		if evErr == nil && len(evEvents) > 0 {
+			RenderMediator(out, evEvents, false)
+			_, _ = fmt.Fprintln(out)
+		}
+	}
+
+	// --- Verify ---
+	rep, err := VerifyRun(cleanDir, orchestratorKeyHex)
+	if err != nil {
+		return VerifyReport{}, fmt.Errorf("fallback verify: %w", err)
+	}
+
+	// --- Print verify summary ---
+	renderVerifySummary(out, rep, recordedRunDir)
+
+	return rep, nil
+}
+
+// buildDemoBinaries compiles the toy agent and webtool into binDir.
+// This is the orchestrator's internal build step; the LiveRun itself
+// receives the paths.
+func buildDemoBinaries(ctx context.Context, binDir string) (agentBin, webtoolBin string, err error) {
+	agentBin = filepath.Join(binDir, "toyagent")
+	webtoolBin = filepath.Join(binDir, "webtool")
+
+	// Find repo root by walking up from the current working directory.
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return "", "", fmt.Errorf("find repo root: %w", err)
+	}
+
+	// Build toy agent.
+	if err := goBuild(ctx, repoRoot, "./cmd/pipelock-playground-toyagent", agentBin); err != nil {
+		return "", "", fmt.Errorf("build toyagent: %w", err)
+	}
+
+	// Build web tool.
+	if err := goBuild(ctx, repoRoot, "./cmd/pipelock-playground-webtool", webtoolBin); err != nil {
+		return "", "", fmt.Errorf("build webtool: %w", err)
+	}
+
+	return agentBin, webtoolBin, nil
+}
+
+// findRepoRoot walks up from cwd looking for go.mod.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not find go.mod walking up from cwd")
+		}
+		dir = parent
+	}
+}
+
+// goBuild runs `go build -o outPath pkg` in the given dir.
+func goBuild(ctx context.Context, dir, pkg, outPath string) error {
+	// All arguments are operator-controlled paths from DemoOpts, not untrusted input.
+	args := []string{"build", "-o", outPath, pkg}
+	cmd := exec.CommandContext(ctx, "go", args...) //nolint:gosec // G204: operator-controlled build paths, not untrusted input.
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s: %w\n%s", pkg, err, out)
+	}
+	return nil
+}
+
+// hashDir computes a sha256 hash over the concatenated contents of all files
+// in dir (sorted by path), producing a stable content fingerprint.
+func hashDir(dir string) (string, error) {
+	cleanDir := filepath.Clean(dir)
+	h := sha256.New()
+	err := filepath.Walk(cleanDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		cleanPath := filepath.Clean(path)
+		data, err := os.ReadFile(cleanPath) //nolint:gosec // G122: path is within an operator-controlled packet dir, no symlink TOCTOU risk.
+		if err != nil {
+			return err
+		}
+		_, _ = h.Write([]byte(path))
+		_, _ = h.Write(data)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/playground/orchestrate.go
+++ b/internal/playground/orchestrate.go
@@ -87,7 +87,7 @@ type DemoOpts struct {
 const defaultDemoNonce = "playground-demo-run"
 
 // defaultScenarioID is the scenario used when DemoOpts.ScenarioID is empty.
-const defaultScenarioID = "secret-exfil-url-blocked"
+const defaultScenarioID = LiveDemoScenarioID
 
 // RunDemo drives a full live demo: preflight, start infrastructure, run the
 // toy agent, collect evidence, render the mediator timeline, assemble the
@@ -127,6 +127,9 @@ func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, e
 	binDir, err := os.MkdirTemp("", "playground-demo-bins-*")
 	if err != nil {
 		return VerifyReport{}, fmt.Errorf("bin temp dir: %w", err)
+	}
+	if err := os.Chmod(binDir, 0o755); err != nil { //nolint:gosec // G302: contained agent user needs traverse/execute access to demo binaries.
+		return VerifyReport{}, fmt.Errorf("bin temp dir permissions: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(binDir) }()
 

--- a/internal/playground/orchestrate.go
+++ b/internal/playground/orchestrate.go
@@ -249,7 +249,7 @@ func renderVerifySummary(out io.Writer, rep VerifyReport, runDir string) {
 	_, _ = fmt.Fprintln(out)
 	_, _ = fmt.Fprintln(out, "To verify this run independently:")
 	_, _ = fmt.Fprintf(out, "  pipelock-playground-demo verify %s --orchestrator-key %s\n",
-		filepath.Clean(runDir), rep.PipelockKey)
+		filepath.Clean(runDir), rep.OrchestratorKey)
 }
 
 // Reset clears all state from a previous run in runDir, making it safe to

--- a/internal/playground/orchestrate.go
+++ b/internal/playground/orchestrate.go
@@ -128,6 +128,8 @@ func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, e
 	if err != nil {
 		return VerifyReport{}, fmt.Errorf("bin temp dir: %w", err)
 	}
+	// Contained mode executes these binaries after dropping to the
+	// pipelock-agent user, so the temp dir must be cross-user traversable.
 	if err := os.Chmod(binDir, 0o755); err != nil {
 		return VerifyReport{}, fmt.Errorf("bin temp dir permissions: %w", err)
 	}

--- a/internal/playground/orchestrate_test.go
+++ b/internal/playground/orchestrate_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/playground"
 )
 
-const testScenarioID = "secret-exfil-url-blocked"
+const testScenarioID = playground.LiveDemoScenarioID
 
 func TestRunDemo_Uncontained_VerifiesAndRendersTimeline(t *testing.T) {
 	if testing.Short() {
@@ -164,7 +164,7 @@ func TestPreflight_UncontainedSucceeds(t *testing.T) {
 func TestRunDemo_PrintedVerifyKey_ActuallyVerifies(t *testing.T) {
 	var buf bytes.Buffer
 	runDir := t.TempDir()
-	rep, err := playground.RunDemo(t.Context(), &buf, playground.DemoOpts{Contained: false, ScenarioID: "secret-exfil-url-blocked", RunDir: runDir})
+	rep, err := playground.RunDemo(t.Context(), &buf, playground.DemoOpts{Contained: false, ScenarioID: playground.LiveDemoScenarioID, RunDir: runDir})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/playground/orchestrate_test.go
+++ b/internal/playground/orchestrate_test.go
@@ -90,7 +90,7 @@ func TestFallback_VerifiesAndPrintsReplayEvidence(t *testing.T) {
 	}
 }
 
-func TestReset_RefusesEvidenceDirReuse(t *testing.T) {
+func TestReset_CleansStaleArtifactsForReuse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("orchestrate test builds binaries and boots a real proxy")
 	}
@@ -126,8 +126,6 @@ func TestReset_RefusesEvidenceDirReuse(t *testing.T) {
 }
 
 func TestRunDemo_ContainedMode_FailsLoudlyWithoutHook(t *testing.T) {
-	t.Parallel()
-
 	// Ensure no containment hook is wired (default state).
 	playground.SetContainmentHook(nil)
 
@@ -146,8 +144,6 @@ func TestRunDemo_ContainedMode_FailsLoudlyWithoutHook(t *testing.T) {
 }
 
 func TestPreflight_ContainedWithoutHook(t *testing.T) {
-	t.Parallel()
-
 	playground.SetContainmentHook(nil)
 
 	err := playground.Preflight(playground.DemoOpts{
@@ -184,6 +180,10 @@ func TestPreflight_UncontainedSucceeds(t *testing.T) {
 // key from the printed "verify ... --orchestrator-key <hex>" line and confirms
 // that key actually verifies the run dir standalone.
 func TestRunDemo_PrintedVerifyKey_ActuallyVerifies(t *testing.T) {
+	if testing.Short() {
+		t.Skip("orchestrate test builds binaries and boots a real proxy")
+	}
+
 	var buf bytes.Buffer
 	runDir := t.TempDir()
 	rep, err := playground.RunDemo(t.Context(), &buf, playground.DemoOpts{Contained: false, ScenarioID: playground.LiveDemoScenarioID, RunDir: runDir})
@@ -211,6 +211,10 @@ func TestRunDemo_PrintedVerifyKey_ActuallyVerifies(t *testing.T) {
 // `run --run-dir X` on the same dir failed at "rename packet dir: file exists".
 // Re-running on the same dir without a manual reset must succeed.
 func TestRunDemo_RerunSameDir_Idempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("orchestrate test builds binaries and boots a real proxy")
+	}
+
 	runDir := t.TempDir()
 	for i := 0; i < 2; i++ {
 		rep, err := playground.RunDemo(t.Context(), io.Discard, playground.DemoOpts{

--- a/internal/playground/orchestrate_test.go
+++ b/internal/playground/orchestrate_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -152,5 +153,34 @@ func TestPreflight_UncontainedSucceeds(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("preflight must succeed for uncontained: %v", err)
+	}
+}
+
+// TestRunDemo_PrintedVerifyKey_ActuallyVerifies guards the demo-breaking bug
+// where the run printed the Pipelock key (not the orchestrator key) as
+// --orchestrator-key, so the audience verify command failed. It extracts the
+// key from the printed "verify ... --orchestrator-key <hex>" line and confirms
+// that key actually verifies the run dir standalone.
+func TestRunDemo_PrintedVerifyKey_ActuallyVerifies(t *testing.T) {
+	var buf bytes.Buffer
+	runDir := t.TempDir()
+	rep, err := playground.RunDemo(t.Context(), &buf, playground.DemoOpts{Contained: false, ScenarioID: "secret-exfil-url-blocked", RunDir: runDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.OK {
+		t.Fatalf("run must verify: %+v", rep)
+	}
+	m := regexp.MustCompile(`--orchestrator-key ([0-9a-f]{64})`).FindStringSubmatch(buf.String())
+	if m == nil {
+		t.Fatalf("could not find printed orchestrator key in output:\n%s", buf.String())
+	}
+	printedKey := m[1]
+	got, err := playground.VerifyRun(runDir, printedKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.OK {
+		t.Fatalf("the PRINTED verify key must verify the run standalone, but it failed: %+v", got.Checks)
 	}
 }

--- a/internal/playground/orchestrate_test.go
+++ b/internal/playground/orchestrate_test.go
@@ -68,6 +68,28 @@ func TestReset_ThreeTimesClean(t *testing.T) {
 	}
 }
 
+func TestFallback_VerifiesAndPrintsReplayEvidence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("fallback test builds a recorded evidence dir")
+	}
+
+	dir, orchKey := goodRunDir(t)
+	var buf bytes.Buffer
+	rep, err := playground.Fallback(&buf, dir, orchKey)
+	if err != nil {
+		t.Fatalf("Fallback: %v", err)
+	}
+	if !rep.OK {
+		t.Fatalf("fallback verify must pass: %+v", rep)
+	}
+	out := buf.String()
+	for _, want := range []string{"REPLAY", "Packet hash: sha256:", "VERIFY OK", "verify"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("fallback output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestReset_RefusesEvidenceDirReuse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("orchestrate test builds binaries and boots a real proxy")

--- a/internal/playground/orchestrate_test.go
+++ b/internal/playground/orchestrate_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+const testScenarioID = "secret-exfil-url-blocked"
+
+func TestRunDemo_Uncontained_VerifiesAndRendersTimeline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("orchestrate test builds binaries and boots a real proxy")
+	}
+
+	var buf bytes.Buffer
+	rep, err := playground.RunDemo(t.Context(), &buf, playground.DemoOpts{
+		Contained:  false,
+		ScenarioID: testScenarioID,
+		RunDir:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.OK {
+		t.Fatalf("uncontained run must verify: %+v", rep)
+	}
+	out := buf.String()
+	// The rendered timeline shows the evidence classes + a blocked decision + the verifier command.
+	for _, want := range []string{"pipelock_decision", "collector_witness", "BLOCKED", "verify"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("timeline missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestReset_ThreeTimesClean(t *testing.T) {
+	if testing.Short() {
+		t.Skip("orchestrate test builds binaries and boots a real proxy")
+	}
+
+	base := t.TempDir()
+	for i := 0; i < 3; i++ {
+		rd := filepath.Join(base, fmt.Sprintf("run-%d", i))
+		if err := playground.Reset(rd); err != nil {
+			t.Fatalf("reset %d: %v", i, err)
+		}
+		rep, err := playground.RunDemo(t.Context(), io.Discard, playground.DemoOpts{
+			Contained:  false,
+			ScenarioID: testScenarioID,
+			RunDir:     rd,
+		})
+		if err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+		if !rep.OK {
+			t.Fatalf("run %d must be clean+verify: %+v", i, rep)
+		}
+	}
+}
+
+func TestReset_RefusesEvidenceDirReuse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("orchestrate test builds binaries and boots a real proxy")
+	}
+
+	// Do a real run, producing artifacts in the run dir.
+	rd := t.TempDir()
+	_, err := playground.RunDemo(t.Context(), io.Discard, playground.DemoOpts{
+		Contained:  false,
+		ScenarioID: testScenarioID,
+		RunDir:     rd,
+	})
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	// Reset cleans it so a second run works without stale state.
+	if err := playground.Reset(rd); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	// Second run on the same dir must succeed (no stale evidence bleed).
+	rep, err := playground.RunDemo(t.Context(), io.Discard, playground.DemoOpts{
+		Contained:  false,
+		ScenarioID: testScenarioID,
+		RunDir:     rd,
+	})
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if !rep.OK {
+		t.Fatalf("second run must verify: %+v", rep)
+	}
+}
+
+func TestRunDemo_ContainedMode_FailsLoudlyWithoutHook(t *testing.T) {
+	t.Parallel()
+
+	// Ensure no containment hook is wired (default state).
+	playground.SetContainmentHook(nil)
+
+	var buf bytes.Buffer
+	_, err := playground.RunDemo(t.Context(), &buf, playground.DemoOpts{
+		Contained:  true,
+		ScenarioID: testScenarioID,
+		RunDir:     t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("contained mode without hook must fail, got nil error")
+	}
+	if !strings.Contains(err.Error(), "containment") {
+		t.Fatalf("error must mention containment, got: %v", err)
+	}
+}
+
+func TestPreflight_ContainedWithoutHook(t *testing.T) {
+	t.Parallel()
+
+	playground.SetContainmentHook(nil)
+
+	err := playground.Preflight(playground.DemoOpts{
+		Contained:  true,
+		ScenarioID: testScenarioID,
+		RunNonce:   "test-nonce",
+		RunDir:     t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("preflight with contained=true and no hook must fail")
+	}
+	if !strings.Contains(err.Error(), "containment") {
+		t.Fatalf("error must mention containment, got: %v", err)
+	}
+}
+
+func TestPreflight_UncontainedSucceeds(t *testing.T) {
+	t.Parallel()
+
+	err := playground.Preflight(playground.DemoOpts{
+		Contained:  false,
+		ScenarioID: testScenarioID,
+		RunNonce:   "test-nonce",
+		RunDir:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("preflight must succeed for uncontained: %v", err)
+	}
+}

--- a/internal/playground/orchestrate_test.go
+++ b/internal/playground/orchestrate_test.go
@@ -184,3 +184,21 @@ func TestRunDemo_PrintedVerifyKey_ActuallyVerifies(t *testing.T) {
 		t.Fatalf("the PRINTED verify key must verify the run standalone, but it failed: %+v", got.Checks)
 	}
 }
+
+// TestRunDemo_RerunSameDir_Idempotent guards the operator-hit bug where a second
+// `run --run-dir X` on the same dir failed at "rename packet dir: file exists".
+// Re-running on the same dir without a manual reset must succeed.
+func TestRunDemo_RerunSameDir_Idempotent(t *testing.T) {
+	runDir := t.TempDir()
+	for i := 0; i < 2; i++ {
+		rep, err := playground.RunDemo(t.Context(), io.Discard, playground.DemoOpts{
+			Contained: false, ScenarioID: "secret-exfil-body-blocked", RunDir: runDir,
+		})
+		if err != nil {
+			t.Fatalf("run %d on reused dir must succeed: %v", i, err)
+		}
+		if !rep.OK {
+			t.Fatalf("run %d must verify: %+v", i, rep)
+		}
+	}
+}

--- a/internal/playground/preflight.go
+++ b/internal/playground/preflight.go
@@ -10,9 +10,17 @@ import (
 	"strings"
 )
 
-// preflightCanaryPrefix is the expected prefix for synthetic playground canary
-// values. Real secrets must not be used; this check catches operator mistakes.
-const preflightCanaryPrefix = "SYNTH-CANARY-"
+const (
+	liveCanaryPrefix              = "AKIA"
+	liveCanaryPublicExampleSuffix = "IOSFODNN7EXAMPLE"
+)
+
+func liveCanaryValue(runNonce string) string {
+	if runNonce == "" {
+		return liveCanaryPrefix + liveCanaryPublicExampleSuffix
+	}
+	return liveCanaryPrefix + liveCanaryPublicExampleSuffix + "-" + runNonce
+}
 
 // Preflight runs cheap stage-hygiene checks before a demo run. It confirms:
 //   - the canary value looks synthetic (not a real-looking secret),
@@ -20,12 +28,12 @@ const preflightCanaryPrefix = "SYNTH-CANARY-"
 //   - if contained mode is requested, the containment hook is wired.
 func Preflight(opts DemoOpts) error {
 	// --- Canary shape check ---
-	// The demo plants a synthetic canary. If someone passes a real-looking
-	// secret (e.g. starts with AKIA, ghp_, sk-), that's a misuse we catch
-	// before the proxy even boots.
-	canary := "SYNTH-CANARY-" + opts.RunNonce
-	if !strings.HasPrefix(canary, preflightCanaryPrefix) {
-		return fmt.Errorf("preflight: canary value does not have the expected synthetic prefix %q", preflightCanaryPrefix)
+	// The demo plants a credential-shaped but inert public example value. It is
+	// deliberately AWS-shaped so normal DLP catches the class; Pipelock is not
+	// configured with the exact value as a canary token.
+	canary := liveCanaryValue(opts.RunNonce)
+	if !strings.HasPrefix(canary, liveCanaryPrefix) || !strings.Contains(canary, liveCanaryPublicExampleSuffix) {
+		return fmt.Errorf("preflight: canary value is not the expected inert public example shape")
 	}
 
 	// --- RunDir writable check ---

--- a/internal/playground/preflight.go
+++ b/internal/playground/preflight.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// preflightCanaryPrefix is the expected prefix for synthetic playground canary
+// values. Real secrets must not be used; this check catches operator mistakes.
+const preflightCanaryPrefix = "SYNTH-CANARY-"
+
+// Preflight runs cheap stage-hygiene checks before a demo run. It confirms:
+//   - the canary value looks synthetic (not a real-looking secret),
+//   - the run directory is writable,
+//   - if contained mode is requested, the containment hook is wired.
+func Preflight(opts DemoOpts) error {
+	// --- Canary shape check ---
+	// The demo plants a synthetic canary. If someone passes a real-looking
+	// secret (e.g. starts with AKIA, ghp_, sk-), that's a misuse we catch
+	// before the proxy even boots.
+	canary := "SYNTH-CANARY-" + opts.RunNonce
+	if !strings.HasPrefix(canary, preflightCanaryPrefix) {
+		return fmt.Errorf("preflight: canary value does not have the expected synthetic prefix %q", preflightCanaryPrefix)
+	}
+
+	// --- RunDir writable check ---
+	cleanDir := filepath.Clean(opts.RunDir)
+	if err := os.MkdirAll(cleanDir, 0o750); err != nil {
+		return fmt.Errorf("preflight: run dir %q not writable: %w", opts.RunDir, err)
+	}
+	// Probe write by creating and removing a sentinel file.
+	probe := filepath.Join(cleanDir, ".preflight-probe")
+	if err := os.WriteFile(probe, []byte("probe"), 0o600); err != nil {
+		return fmt.Errorf("preflight: cannot write to run dir %q: %w", opts.RunDir, err)
+	}
+	_ = os.Remove(probe)
+
+	// --- Containment hook check ---
+	if opts.Contained {
+		if getContainmentHook() == nil {
+			return ErrContainmentNotWired
+		}
+	}
+
+	return nil
+}

--- a/internal/playground/redcase.go
+++ b/internal/playground/redcase.go
@@ -32,6 +32,14 @@ const calibrationNoncePrefix = "redcase-calib-"
 // can confirm a real signed witness existed and was produced by the same
 // collector key as the green witness.
 func RunRedCaseCalibration(ctx context.Context, colPriv ed25519.PrivateKey, canaryID, canaryValue string) (RedCaseResult, error) {
+	res, _, err := runRedCaseCalibrationCore(ctx, colPriv, canaryID, canaryValue, canaryValue)
+	return res, err
+}
+
+// RunRedCaseCalibrationWithWitness is the artifact-producing form used by live
+// runs. It returns both the signed summary embedded in the green witness and the
+// signed red witness artifact the offline verifier can independently check.
+func RunRedCaseCalibrationWithWitness(ctx context.Context, colPriv ed25519.PrivateKey, canaryID, canaryValue string) (RedCaseResult, Witness, error) {
 	return runRedCaseCalibrationCore(ctx, colPriv, canaryID, canaryValue, canaryValue)
 }
 
@@ -41,19 +49,20 @@ func RunRedCaseCalibration(ctx context.Context, colPriv ed25519.PrivateKey, cana
 // match the collector's canary, observed stays 0 and the function returns
 // ErrRedCaseNotDetected.
 func RunRedCaseCalibrationWithValue(ctx context.Context, colPriv ed25519.PrivateKey, canaryID, collectorExpectsValue, actuallySentValue string) (RedCaseResult, error) {
-	return runRedCaseCalibrationCore(ctx, colPriv, canaryID, collectorExpectsValue, actuallySentValue)
+	res, _, err := runRedCaseCalibrationCore(ctx, colPriv, canaryID, collectorExpectsValue, actuallySentValue)
+	return res, err
 }
 
 // runRedCaseCalibrationCore is the shared implementation for both public
 // calibration functions. collectorCanary is what the collector scans for;
 // sentValue is what gets POSTed.
-func runRedCaseCalibrationCore(ctx context.Context, colPriv ed25519.PrivateKey, canaryID, collectorCanary, sentValue string) (RedCaseResult, error) {
+func runRedCaseCalibrationCore(ctx context.Context, colPriv ed25519.PrivateKey, canaryID, collectorCanary, sentValue string) (RedCaseResult, Witness, error) {
 	calibNonce := calibrationNoncePrefix + canaryID
 
 	// Stand up a fresh collector scanning for collectorCanary.
 	c := NewCollector(canaryID, collectorCanary)
 	if err := c.OpenRun(calibNonce, "redcase"); err != nil {
-		return RedCaseResult{}, fmt.Errorf("red-case calibration: open run: %w", err)
+		return RedCaseResult{}, Witness{}, fmt.Errorf("red-case calibration: open run: %w", err)
 	}
 
 	// Spin up an httptest server so we can POST through the real Handler.
@@ -65,11 +74,11 @@ func runRedCaseCalibrationCore(ctx context.Context, colPriv ed25519.PrivateKey, 
 	body := strings.NewReader("payload=" + sentValue)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL+"/?run="+calibNonce, body)
 	if err != nil {
-		return RedCaseResult{}, fmt.Errorf("red-case calibration: build request: %w", err)
+		return RedCaseResult{}, Witness{}, fmt.Errorf("red-case calibration: build request: %w", err)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return RedCaseResult{}, fmt.Errorf("red-case calibration: POST canary: %w", err)
+		return RedCaseResult{}, Witness{}, fmt.Errorf("red-case calibration: POST canary: %w", err)
 	}
 	_ = resp.Body.Close()
 
@@ -77,12 +86,12 @@ func runRedCaseCalibrationCore(ctx context.Context, colPriv ed25519.PrivateKey, 
 	const drainWindow = 200 * time.Millisecond
 	witness, err := c.SealAndSign(calibNonce, colPriv, drainWindow)
 	if err != nil {
-		return RedCaseResult{}, fmt.Errorf("red-case calibration: seal: %w", err)
+		return RedCaseResult{}, Witness{}, fmt.Errorf("red-case calibration: seal: %w", err)
 	}
 
 	// Fail closed: the collector MUST have observed the canary.
 	if witness.ObservedCount < 1 {
-		return RedCaseResult{}, ErrRedCaseNotDetected
+		return RedCaseResult{}, Witness{}, ErrRedCaseNotDetected
 	}
 
 	// Build the verifiable result.
@@ -95,5 +104,5 @@ func runRedCaseCalibrationCore(ctx context.Context, colPriv ed25519.PrivateKey, 
 		At:               witness.RunClosedAt,
 		CollectorPubKey:  hex.EncodeToString(colPub),
 		RedWitnessDigest: hex.EncodeToString(digest[:]),
-	}, nil
+	}, witness, nil
 }

--- a/internal/playground/redcase.go
+++ b/internal/playground/redcase.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+)
+
+// calibrationNoncePrefix is the run-nonce prefix used for red-case calibration
+// runs. It is distinct from production run nonces to avoid collisions.
+const calibrationNoncePrefix = "redcase-calib-"
+
+// RunRedCaseCalibration performs a red-case calibration: it stands up a fresh
+// collector, POSTs the canary value DIRECTLY (no proxy -- this is the
+// "Pipelock OFF" leak), seals a witness, and confirms the collector went red.
+//
+// If the collector does NOT observe the canary (observed == 0), the function
+// returns ErrRedCaseNotDetected. This is the fail-closed guarantee: a broken
+// collector build cannot produce a green-looking RedCaseResult.
+//
+// The returned RedCaseResult carries the collector's public key and the sha256
+// digest of the signed red witness's SignedBytes(), so the offline verifier
+// can confirm a real signed witness existed and was produced by the same
+// collector key as the green witness.
+func RunRedCaseCalibration(ctx context.Context, colPriv ed25519.PrivateKey, canaryID, canaryValue string) (RedCaseResult, error) {
+	return runRedCaseCalibrationCore(ctx, colPriv, canaryID, canaryValue, canaryValue)
+}
+
+// RunRedCaseCalibrationWithValue is the same as RunRedCaseCalibration but lets
+// the caller specify a different value to POST vs what the collector scans for.
+// This is used in tests to prove fail-closed: when the posted value does not
+// match the collector's canary, observed stays 0 and the function returns
+// ErrRedCaseNotDetected.
+func RunRedCaseCalibrationWithValue(ctx context.Context, colPriv ed25519.PrivateKey, canaryID, collectorExpectsValue, actuallySentValue string) (RedCaseResult, error) {
+	return runRedCaseCalibrationCore(ctx, colPriv, canaryID, collectorExpectsValue, actuallySentValue)
+}
+
+// runRedCaseCalibrationCore is the shared implementation for both public
+// calibration functions. collectorCanary is what the collector scans for;
+// sentValue is what gets POSTed.
+func runRedCaseCalibrationCore(ctx context.Context, colPriv ed25519.PrivateKey, canaryID, collectorCanary, sentValue string) (RedCaseResult, error) {
+	calibNonce := calibrationNoncePrefix + canaryID
+
+	// Stand up a fresh collector scanning for collectorCanary.
+	c := NewCollector(canaryID, collectorCanary)
+	if err := c.OpenRun(calibNonce, "redcase"); err != nil {
+		return RedCaseResult{}, fmt.Errorf("red-case calibration: open run: %w", err)
+	}
+
+	// Spin up an httptest server so we can POST through the real Handler.
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	// POST the canary value DIRECTLY to the collector (no proxy -- this is
+	// the deliberate "Pipelock OFF" leak that makes the witness go red).
+	body := strings.NewReader("payload=" + sentValue)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL+"/?run="+calibNonce, body)
+	if err != nil {
+		return RedCaseResult{}, fmt.Errorf("red-case calibration: build request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return RedCaseResult{}, fmt.Errorf("red-case calibration: POST canary: %w", err)
+	}
+	_ = resp.Body.Close()
+
+	// Seal the witness with a real drain window.
+	const drainWindow = 200 * time.Millisecond
+	witness, err := c.SealAndSign(calibNonce, colPriv, drainWindow)
+	if err != nil {
+		return RedCaseResult{}, fmt.Errorf("red-case calibration: seal: %w", err)
+	}
+
+	// Fail closed: the collector MUST have observed the canary.
+	if witness.ObservedCount < 1 {
+		return RedCaseResult{}, ErrRedCaseNotDetected
+	}
+
+	// Build the verifiable result.
+	colPub := colPriv.Public().(ed25519.PublicKey)
+	digest := sha256.Sum256(witness.SignedBytes())
+
+	return RedCaseResult{
+		WitnessWentRed:   true,
+		ObservedCount:    witness.ObservedCount,
+		At:               witness.RunClosedAt,
+		CollectorPubKey:  hex.EncodeToString(colPub),
+		RedWitnessDigest: hex.EncodeToString(digest[:]),
+	}, nil
+}

--- a/internal/playground/redcase_test.go
+++ b/internal/playground/redcase_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRedCase_WitnessGoesRed_OnLeak(t *testing.T) {
+	colPub, colPriv := genKey(t)
+	res, err := RunRedCaseCalibration(t.Context(), colPriv, "aws_canary", "AKIA"+"IOSFODNN7EXAMPLE")
+	if err != nil {
+		t.Fatalf("calibration must succeed: %v", err)
+	}
+	if !res.WitnessWentRed || res.ObservedCount < 1 {
+		t.Fatalf("red-case must observe the canary: %+v", res)
+	}
+	if res.CollectorPubKey != hexEnc(colPub) {
+		t.Fatal("must bind the collector pubkey")
+	}
+	if res.RedWitnessDigest == "" {
+		t.Fatal("must carry the red-witness digest")
+	}
+}
+
+func TestRedCase_FailsIfCollectorDoesNotDetect(t *testing.T) {
+	// A deliberately-broken collector (wrong canary value) must make
+	// calibration ERROR (observed stays 0). Proves fail-closed.
+	_, colPriv := genKey(t)
+	_, err := RunRedCaseCalibrationWithValue(t.Context(), colPriv, "aws_canary", "AKIA"+"IOSFODNN7EXAMPLE", "WRONG-VALUE-NEVER-SENT")
+	if err == nil {
+		t.Fatal("calibration MUST fail closed when the collector does not detect the planted canary")
+	}
+	if !errors.Is(err, ErrRedCaseNotDetected) {
+		t.Fatalf("expected ErrRedCaseNotDetected, got: %v", err)
+	}
+}
+
+func TestGreenWitness_CarriesSignedRedCase(t *testing.T) {
+	colPub, colPriv := genKey(t)
+
+	// Run the red-case calibration.
+	rc, err := RunRedCaseCalibration(t.Context(), colPriv, "aws_canary", "AKIA"+"IOSFODNN7EXAMPLE")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Open a fresh green run, attach the red-case, seal.
+	c := NewCollector("aws_canary", "AKIA"+"IOSFODNN7EXAMPLE")
+	if err := c.OpenRun("N1", "hashA"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.AttachRedCase("N1", rc); err != nil {
+		t.Fatal(err)
+	}
+	w, err := c.SealAndSign("N1", colPriv, 200*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w.RedCaseResult == nil || !w.RedCaseResult.WitnessWentRed {
+		t.Fatal("green witness must carry the red-case")
+	}
+	if !ed25519Verify(colPub, w.SignedBytes(), w.Signature) {
+		t.Fatal("witness sig must still verify (red-case is signed in)")
+	}
+}
+
+func TestAttachRedCase_RejectsUnopenedRun(t *testing.T) {
+	c := NewCollector("aws_canary", canaryValueForTest)
+	rc := RedCaseResult{WitnessWentRed: true, ObservedCount: 1}
+	if err := c.AttachRedCase("never-opened", rc); !errors.Is(err, ErrRedCaseRunNotOpen) {
+		t.Fatalf("expected ErrRedCaseRunNotOpen, got: %v", err)
+	}
+}
+
+func TestAttachRedCase_RejectsSealedRun(t *testing.T) {
+	_, colPriv := genKey(t)
+	c := NewCollector("aws_canary", canaryValueForTest)
+	if err := c.OpenRun("N1", "hashA"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.SealAndSign("N1", colPriv, 50*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	rc := RedCaseResult{WitnessWentRed: true, ObservedCount: 1}
+	if err := c.AttachRedCase("N1", rc); !errors.Is(err, ErrRedCaseRunNotOpen) {
+		t.Fatalf("expected ErrRedCaseRunNotOpen on sealed run, got: %v", err)
+	}
+}

--- a/internal/playground/scenario.go
+++ b/internal/playground/scenario.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import "github.com/luckyPipewrench/pipelock/internal/replaycapture"
+
+// LiveDemoScenarioID is the playground live-demo scenario. It is intentionally
+// separate from the replay gallery's URL-exfil scenario because the live toy
+// agent sends the synthetic canary in a POST body.
+const LiveDemoScenarioID = "secret-exfil-body-blocked"
+
+const (
+	liveDemoExpectedBlockLayer = "body_dlp"
+	liveDemoExpectedVerdict    = "block"
+	liveDemoAllowedVerdict     = "allow"
+)
+
+func liveDemoScenario() replaycapture.Scenario {
+	return replaycapture.Scenario{
+		ID:               LiveDemoScenarioID,
+		Title:            "Blocked: secret exfiltration in a request body",
+		BenchCaseID:      "url-dlp-aws-key-001",
+		Transport:        replaycapture.TransportForward,
+		Category:         "Secret exfiltration",
+		ExpectedLayer:    liveDemoExpectedBlockLayer,
+		ExpectedVerdict:  liveDemoExpectedVerdict,
+		DestinationClass: "attacker-controlled collector (reserved example host)",
+		Without:          "A bare agent posts a credential-shaped value to a collector and the value escapes.",
+		With:             "Pipelock scans the request body, detects the credential-shaped value, blocks the request, and signs a receipt recording the block.",
+		RedactedShape:    "AKIA************EXAMPLE -> blocked",
+	}
+}
+
+func lookupPlaygroundScenario(id string) (replaycapture.Scenario, bool) {
+	if id == LiveDemoScenarioID {
+		return liveDemoScenario(), true
+	}
+	for _, s := range replaycapture.DefaultScenarios() {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return replaycapture.Scenario{}, false
+}

--- a/internal/playground/scenario_internal_test.go
+++ b/internal/playground/scenario_internal_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import "testing"
+
+func TestLiveCanaryValue(t *testing.T) {
+	if got := liveCanaryValue(""); got != liveCanaryPrefix+liveCanaryPublicExampleSuffix {
+		t.Fatalf("empty nonce canary = %q", got)
+	}
+	if got := liveCanaryValue("N1"); got != liveCanaryPrefix+liveCanaryPublicExampleSuffix+"-N1" {
+		t.Fatalf("nonce canary = %q", got)
+	}
+}
+
+func TestLookupPlaygroundScenario(t *testing.T) {
+	scenario, ok := lookupPlaygroundScenario(LiveDemoScenarioID)
+	if !ok {
+		t.Fatal("live demo scenario not found")
+	}
+	if scenario.ID != LiveDemoScenarioID {
+		t.Fatalf("scenario ID = %q", scenario.ID)
+	}
+
+	if _, ok := lookupPlaygroundScenario("missing-playground-scenario"); ok {
+		t.Fatal("unexpected scenario match")
+	}
+}

--- a/internal/playground/targets.go
+++ b/internal/playground/targets.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// runStats tracks per-run-nonce observation state.
+type runStats struct {
+	observedCount int
+	totalCount    int
+}
+
+// Collector is a lab HTTP target that detects whether a planted synthetic
+// canary secret arrives in incoming requests. The canary value is configured
+// at startup and NEVER exposed through any public method or HTTP response.
+//
+// The witness/status endpoint is keyed by an opaque run nonce only, so the
+// act of checking whether the canary arrived does not itself carry the
+// canary value.
+type Collector struct {
+	canaryID    string
+	canaryValue string // held internally; never returned to any caller
+
+	mu               sync.Mutex
+	runs             map[string]*runStats
+	lastWitnessQuery string
+}
+
+// NewCollector creates a Collector preconfigured with a canary identifier
+// and value. The value is held internally and never exposed.
+func NewCollector(canaryID, canaryValue string) *Collector {
+	return &Collector{
+		canaryID:    canaryID,
+		canaryValue: canaryValue,
+		runs:        make(map[string]*runStats),
+	}
+}
+
+// Handler returns the HTTP handler for the collector. Routes:
+//   - /witness?run=<nonce> -- witness query (returns JSON, never carries canary)
+//   - all other paths      -- ingestion endpoint (scans for canary)
+func (c *Collector) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/witness", c.handleWitness)
+	mux.HandleFunc("/", c.handleIngest)
+	return mux
+}
+
+// ObservedCount returns how many requests for the given run nonce contained
+// the canary value.
+func (c *Collector) ObservedCount(nonce string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if s, ok := c.runs[nonce]; ok {
+		return s.observedCount
+	}
+	return 0
+}
+
+// TotalCount returns the total number of ingestion requests for the given
+// run nonce (regardless of whether they contained the canary).
+func (c *Collector) TotalCount(nonce string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if s, ok := c.runs[nonce]; ok {
+		return s.totalCount
+	}
+	return 0
+}
+
+// LastWitnessQueryRaw returns the raw query string of the most recent
+// /witness request. Used in tests to verify the witness query never
+// carries the canary value.
+func (c *Collector) LastWitnessQueryRaw() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastWitnessQuery
+}
+
+// handleWitness serves the witness endpoint. It returns JSON with the run
+// nonce, observed count, and total count. It MUST NOT read or require the
+// canary value -- the query is keyed by run nonce only.
+func (c *Collector) handleWitness(w http.ResponseWriter, r *http.Request) {
+	c.mu.Lock()
+	c.lastWitnessQuery = r.URL.RawQuery
+	c.mu.Unlock()
+
+	nonce := r.URL.Query().Get("run")
+
+	type witnessResponse struct {
+		Run           string `json:"run"`
+		ObservedCount int    `json:"observed_count"`
+		TotalCount    int    `json:"total_count"`
+	}
+
+	resp := witnessResponse{
+		Run:           nonce,
+		ObservedCount: c.ObservedCount(nonce),
+		TotalCount:    c.TotalCount(nonce),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	_ = enc.Encode(resp)
+}
+
+// handleIngest handles all non-witness requests. It scans the full request
+// (URL query, headers, and body) for the canary value and records the
+// result per run nonce.
+func (c *Collector) handleIngest(w http.ResponseWriter, r *http.Request) {
+	nonce := r.URL.Query().Get("run")
+
+	observed := c.scanRequest(r)
+
+	c.mu.Lock()
+	s, ok := c.runs[nonce]
+	if !ok {
+		s = &runStats{}
+		c.runs[nonce] = s
+	}
+	s.totalCount++
+	if observed {
+		s.observedCount++
+	}
+	c.mu.Unlock()
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, "ingested run=%s observed=%t", nonce, observed)
+}
+
+// scanRequest checks whether the canary value appears anywhere in the
+// request: URL query string, any header value, or the body. The body is
+// read and then restored so downstream handlers (if any) can still read it.
+func (c *Collector) scanRequest(r *http.Request) bool {
+	target := c.canaryValue
+
+	// Check URL (full raw query).
+	if strings.Contains(r.URL.RawQuery, target) {
+		return true
+	}
+
+	// Check all header values.
+	for _, vals := range r.Header {
+		for _, v := range vals {
+			if strings.Contains(v, target) {
+				return true
+			}
+		}
+	}
+
+	// Check body.
+	if r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		if err == nil && strings.Contains(string(body), target) {
+			// Restore the body for any downstream handler.
+			r.Body = io.NopCloser(strings.NewReader(string(body)))
+			return true
+		}
+		// Restore the body even when canary not found.
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+	}
+
+	return false
+}
+
+// SafeTarget is a trivial HTTP target that returns a benign 200 response.
+// Used for the "allowed request" beat of the demo.
+type SafeTarget struct{}
+
+// NewSafeTarget creates a new SafeTarget.
+func NewSafeTarget() *SafeTarget {
+	return &SafeTarget{}
+}
+
+// Handler returns the HTTP handler for the safe target.
+func (s *SafeTarget) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = fmt.Fprintf(w, "ok")
+	})
+}

--- a/internal/playground/targets.go
+++ b/internal/playground/targets.go
@@ -4,18 +4,50 @@
 package playground
 
 import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 )
 
-// runStats tracks per-run-nonce observation state.
+// requestRecord is a per-ingest record that goes into the run's request log.
+// It deliberately records only metadata and the boolean observation, NEVER the
+// raw canary value, so the request-log digest cannot leak the secret.
+type requestRecord struct {
+	Seq      int    `json:"seq"`
+	Method   string `json:"method"`
+	Path     string `json:"path"`
+	Observed bool   `json:"observed"`
+}
+
+// runStats tracks per-run-nonce observation state and lifecycle.
 type runStats struct {
 	observedCount int
 	totalCount    int
+
+	// accepting is true between OpenRun and the start of SealAndSign's drain
+	// phase. Only an accepting run counts canary arrivals.
+	accepting bool
+	// opened is true once OpenRun has been called (distinguishes "never opened"
+	// from "opened then sealed").
+	opened bool
+	// sealed is true once SealAndSign has produced a witness for the run.
+	sealed bool
+
+	launchManifestHash string
+
+	// inFlight tracks ingest requests currently being processed for this run so
+	// SealAndSign can wait for them to drain (event-driven, not a sleep).
+	inFlight sync.WaitGroup
+
+	// log is the metadata-only record of ingest requests for this run.
+	log []requestRecord
 }
 
 // Collector is a lab HTTP target that detects whether a planted synthetic
@@ -32,6 +64,13 @@ type Collector struct {
 	mu               sync.Mutex
 	runs             map[string]*runStats
 	lastWitnessQuery string
+
+	// ingestHook, when non-nil, is called inside handleIngest after the
+	// in-flight registration (Add(1)) but BEFORE scanRequest. Tests use this
+	// to deterministically block a handler mid-flight so SealAndSign's drain
+	// timeout can be exercised without time.Sleep. Production code never sets
+	// this.
+	ingestHook func()
 }
 
 // NewCollector creates a Collector preconfigured with a canary identifier
@@ -118,18 +157,59 @@ func (c *Collector) handleWitness(w http.ResponseWriter, r *http.Request) {
 func (c *Collector) handleIngest(w http.ResponseWriter, r *http.Request) {
 	nonce := r.URL.Query().Get("run")
 
-	observed := c.scanRequest(r)
-
+	// Register the in-flight request against the run BEFORE scanning, while
+	// holding the lock, so the drain wait in SealAndSign cannot race past a
+	// request that has already begun but not yet been counted.
+	//
+	// A run auto-creates on first ingest and accepts by default (this preserves
+	// the collector's standalone counting contract). The ONLY state that stops
+	// counting is a run that has already been SEALED: once an honest,
+	// drain-bounded witness has been signed, a late request must not be able to
+	// mutate the counts the witness attested.
 	c.mu.Lock()
 	s, ok := c.runs[nonce]
 	if !ok {
-		s = &runStats{}
+		s = &runStats{accepting: true}
 		c.runs[nonce] = s
 	}
+	accepting := s.accepting && !s.sealed
+	if accepting {
+		s.inFlight.Add(1)
+	}
+	c.mu.Unlock()
+
+	if !accepting {
+		// Run is sealed (or explicitly closed): scan is irrelevant to the sealed
+		// witness. Reply benignly without recording, so a late/post-seal request
+		// cannot alter a signed witness.
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "ignored run=%s", nonce)
+		return
+	}
+	defer s.inFlight.Done()
+
+	// Test hook: called after in-flight registration, before scanning.
+	if c.ingestHook != nil {
+		c.ingestHook()
+	}
+
+	observed := c.scanRequest(r)
+
+	c.mu.Lock()
+	// Re-check accepting under the lock: SealAndSign may have flipped it while we
+	// were scanning. If it did, our inFlight.Done (deferred) lets the drain
+	// complete; we still record this request because we were admitted while
+	// accepting and the drain explicitly waits for us.
 	s.totalCount++
 	if observed {
 		s.observedCount++
 	}
+	s.log = append(s.log, requestRecord{
+		Seq:      s.totalCount,
+		Method:   r.Method,
+		Path:     r.URL.Path,
+		Observed: observed,
+	})
 	c.mu.Unlock()
 
 	w.WriteHeader(http.StatusOK)
@@ -169,6 +249,118 @@ func (c *Collector) scanRequest(r *http.Request) bool {
 	}
 
 	return false
+}
+
+// OpenRun marks a run nonce as accepting ingestion and pins the launch-manifest
+// hash it is bound to. Only an open/accepting run counts canary arrivals. The
+// manifest hash is the orchestrator-minted, pre-run-signed artifact the witness
+// will bind to, so the agent cannot influence what the witness attests against.
+//
+// Sealing is terminal: OpenRun returns ErrRunSealed if the nonce has already
+// been sealed. A sealed witness is bound to a specific manifest hash, so
+// re-opening would mix observations across different launch manifests. Use a
+// fresh nonce per run.
+func (c *Collector) OpenRun(nonce, launchManifestHash string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s, ok := c.runs[nonce]
+	if ok && s.sealed {
+		return ErrRunSealed
+	}
+	if !ok {
+		s = &runStats{}
+		c.runs[nonce] = s
+	}
+	s.opened = true
+	s.accepting = true
+	s.launchManifestHash = launchManifestHash
+	return nil
+}
+
+// requestLogDigest returns the sha256 hex digest over the canonical JSON of the
+// run's metadata-only request log. The input is a record (method/path/observed),
+// NEVER the raw canary value, so the digest cannot leak the secret. Caller must
+// hold c.mu.
+func requestLogDigest(log []requestRecord) string {
+	if log == nil {
+		log = []requestRecord{}
+	}
+	b, _ := json.Marshal(log)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// SealAndSign closes a run, waits for in-flight requests to drain, and produces
+// an ed25519-signed Witness under the collector key. The protocol:
+//
+//	(a) refuse if drain <= 0 -- a final witness cannot honestly attest "0
+//	    observed" without a real drain window, because a delayed request could
+//	    still land. This is the cannot-seal-while-accepting guarantee.
+//	(b) stop accepting new requests for the nonce (transition to draining).
+//	(c) wait for in-flight requests for that nonce to complete, bounded by
+//	    drain, using a WaitGroup signalled over a channel -- NOT a blind sleep.
+//	(d) seal: compute the request-log digest, set RunClosedAt and DrainDeadline.
+//	(e) build the Witness binding RunNonce + LaunchManifestHash + counts.
+//	(f) ed25519-sign SignedBytes() with colPriv and set the hex Signature.
+func (c *Collector) SealAndSign(nonce string, colPriv ed25519.PrivateKey, drain time.Duration) (Witness, error) {
+	// (a) A real drain window is mandatory.
+	if drain <= 0 {
+		return Witness{}, ErrNoDrainWindow
+	}
+
+	// (b) Stop accepting; capture the in-flight tracker.
+	c.mu.Lock()
+	s, ok := c.runs[nonce]
+	if !ok || !s.opened {
+		c.mu.Unlock()
+		return Witness{}, ErrRunNotOpen
+	}
+	closeStart := time.Now()
+	s.accepting = false
+	c.mu.Unlock()
+
+	// (c) Wait for in-flight requests to drain, event-driven via the WaitGroup,
+	// bounded by the drain deadline. No fixed sleep: we block on the WaitGroup
+	// completing via a channel, and FAIL CLOSED if the deadline elapses before
+	// all in-flight requests finish. Signing a witness while a request is still
+	// in progress could produce "0 observed" when the real count is 1, so the
+	// timeout branch REFUSES to seal -- it returns ErrDrainIncomplete.
+	drained := make(chan struct{})
+	go func() {
+		s.inFlight.Wait()
+		close(drained)
+	}()
+	timer := time.NewTimer(drain)
+	defer timer.Stop()
+	select {
+	case <-drained:
+		// All in-flight requests completed cleanly. Proceed to seal.
+	case <-timer.C:
+		// Drain deadline expired with requests still active. Fail closed:
+		// do NOT sign a witness with potentially stale counts.
+		return Witness{}, ErrDrainIncomplete
+	}
+
+	// (d) + (e) Seal under the lock so counts/log are stable.
+	c.mu.Lock()
+	s.sealed = true
+	digest := requestLogDigest(s.log)
+	w := Witness{
+		RunNonce:           nonce,
+		CanaryID:           c.canaryID,
+		ObservedCount:      s.observedCount,
+		TotalCount:         s.totalCount,
+		RequestLogDigest:   digest,
+		RunClosedAt:        time.Now(),
+		DrainDeadline:      closeStart.Add(drain),
+		LaunchManifestHash: s.launchManifestHash,
+	}
+	c.mu.Unlock()
+
+	// (f) Sign the canonical (signature-excluded) bytes under the collector key.
+	sig := ed25519.Sign(colPriv, w.SignedBytes())
+	w.Signature = hex.EncodeToString(sig)
+	return w, nil
 }
 
 // SafeTarget is a trivial HTTP target that returns a benign 200 response.

--- a/internal/playground/targets.go
+++ b/internal/playground/targets.go
@@ -48,6 +48,10 @@ type runStats struct {
 
 	// log is the metadata-only record of ingest requests for this run.
 	log []requestRecord
+
+	// redCase, when non-nil, is the red-case calibration result attached via
+	// AttachRedCase. SealAndSign includes it in the witness so it is signed.
+	redCase *RedCaseResult
 }
 
 // Collector is a lab HTTP target that detects whether a planted synthetic
@@ -277,6 +281,22 @@ func (c *Collector) OpenRun(nonce, launchManifestHash string) error {
 	return nil
 }
 
+// AttachRedCase stores a red-case calibration result on an open (not yet sealed)
+// run. SealAndSign will include it in the witness so it is covered by the
+// collector's ed25519 signature. The red-case proves the collector build actually
+// detects the canary; without it, a witness that always says "0 observed" could
+// be silently broken.
+func (c *Collector) AttachRedCase(nonce string, r RedCaseResult) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s, ok := c.runs[nonce]
+	if !ok || !s.opened || s.sealed {
+		return ErrRedCaseRunNotOpen
+	}
+	s.redCase = &r
+	return nil
+}
+
 // requestLogDigest returns the sha256 hex digest over the canonical JSON of the
 // run's metadata-only request log. The input is a record (method/path/observed),
 // NEVER the raw canary value, so the digest cannot leak the secret. Caller must
@@ -354,6 +374,7 @@ func (c *Collector) SealAndSign(nonce string, colPriv ed25519.PrivateKey, drain 
 		RunClosedAt:        time.Now(),
 		DrainDeadline:      closeStart.Add(drain),
 		LaunchManifestHash: s.launchManifestHash,
+		RedCaseResult:      s.redCase, // nil when no calibration attached; included in SignedBytes when present
 	}
 	c.mu.Unlock()
 

--- a/internal/playground/targets.go
+++ b/internal/playground/targets.go
@@ -271,6 +271,9 @@ func (c *Collector) OpenRun(nonce, launchManifestHash string) error {
 	if ok && s.sealed {
 		return ErrRunSealed
 	}
+	if ok && s.opened {
+		return ErrRunAlreadyOpen
+	}
 	if !ok {
 		s = &runStats{}
 		c.runs[nonce] = s

--- a/internal/playground/targets_test.go
+++ b/internal/playground/targets_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+const (
+	testCanaryID = "aws_canary"
+	testRunN1    = "run-nonce-1"
+	testRunN2    = "run-nonce-2"
+)
+
+// testCanaryValue builds the canary at runtime to dodge gosec G101.
+func testCanaryValue() string { return "AKIA" + "IOSFODNN7EXAMPLE" }
+
+// postBody sends a POST with the given body string to the URL.
+func postBody(t *testing.T, url, body string) *http.Response {
+	t.Helper()
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	return resp
+}
+
+// get sends a GET and returns the response.
+func get(t *testing.T, url string) *http.Response {
+	t.Helper()
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	return resp
+}
+
+func TestCollector_RecordsArrival_ByRunNonce(t *testing.T) {
+	t.Parallel()
+
+	canary := testCanaryValue()
+	c := playground.NewCollector(testCanaryID, canary)
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	// Agent posts the canary under run nonce N1.
+	resp := postBody(t, srv.URL+"/?run="+testRunN1, "secret="+canary)
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := c.ObservedCount(testRunN1); got != 1 {
+		t.Fatalf("want 1 observed for n1, got %d", got)
+	}
+	if c.ObservedCount(testRunN2) != 0 {
+		t.Fatalf("other run must be 0, got %d", c.ObservedCount(testRunN2))
+	}
+}
+
+func TestCollector_WitnessQuery_NeverCarriesCanaryValue(t *testing.T) {
+	t.Parallel()
+
+	canary := testCanaryValue()
+	c := playground.NewCollector(testCanaryID, canary)
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	// Query is by run nonce ONLY.
+	resp := get(t, srv.URL+"/witness?run="+testRunN1)
+	defer func() { _ = resp.Body.Close() }()
+
+	raw := c.LastWitnessQueryRaw()
+	if strings.Contains(raw, "AKIA") {
+		t.Fatal("witness query must never carry the canary value")
+	}
+}
+
+func TestCollector_DetectsCanary_InBodyHeaderQuery(t *testing.T) {
+	t.Parallel()
+
+	canary := testCanaryValue()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+		header map[string]string
+	}{
+		{
+			name:   "canary in POST body",
+			method: http.MethodPost,
+			path:   "/?run=body-test",
+			body:   "payload=" + canary,
+		},
+		{
+			name:   "canary in header",
+			method: http.MethodGet,
+			path:   "/?run=header-test",
+			header: map[string]string{"X-Secret": canary},
+		},
+		{
+			name:   "canary in query param",
+			method: http.MethodGet,
+			path:   "/?run=query-test&token=" + canary,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := playground.NewCollector(testCanaryID, canary)
+			srv := httptest.NewServer(c.Handler())
+			defer srv.Close()
+
+			ctx := context.Background()
+			var bodyReader io.Reader
+			if tt.body != "" {
+				bodyReader = strings.NewReader(tt.body)
+			}
+			req, err := http.NewRequestWithContext(ctx, tt.method, srv.URL+tt.path, bodyReader)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			for k, v := range tt.header {
+				req.Header.Set(k, v)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			// Extract run nonce from the path.
+			nonce := req.URL.Query().Get("run")
+			if got := c.ObservedCount(nonce); got != 1 {
+				t.Fatalf("want 1 observed for %s, got %d", nonce, got)
+			}
+		})
+	}
+}
+
+func TestCollector_WitnessEndpoint_ReturnsJSON(t *testing.T) {
+	t.Parallel()
+
+	canary := testCanaryValue()
+	c := playground.NewCollector(testCanaryID, canary)
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	// Send a request carrying the canary.
+	resp := postBody(t, srv.URL+"/?run="+testRunN1, "secret="+canary)
+	_ = resp.Body.Close()
+
+	// Also send one that does NOT carry the canary.
+	resp2 := get(t, srv.URL+"/?run="+testRunN1)
+	_ = resp2.Body.Close()
+
+	// Query witness.
+	witnessResp := get(t, srv.URL+"/witness?run="+testRunN1)
+	defer func() { _ = witnessResp.Body.Close() }()
+
+	if witnessResp.StatusCode != http.StatusOK {
+		t.Fatalf("witness want 200, got %d", witnessResp.StatusCode)
+	}
+
+	var result struct {
+		Run           string `json:"run"`
+		ObservedCount int    `json:"observed_count"`
+		TotalCount    int    `json:"total_count"`
+	}
+	if err := json.NewDecoder(witnessResp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode witness JSON: %v", err)
+	}
+	if result.Run != testRunN1 {
+		t.Fatalf("witness run want %s, got %s", testRunN1, result.Run)
+	}
+	if result.ObservedCount != 1 {
+		t.Fatalf("witness observed_count want 1, got %d", result.ObservedCount)
+	}
+	if result.TotalCount != 2 {
+		t.Fatalf("witness total_count want 2, got %d", result.TotalCount)
+	}
+}
+
+func TestCollector_TotalCount_TracksAllRequests(t *testing.T) {
+	t.Parallel()
+
+	canary := testCanaryValue()
+	c := playground.NewCollector(testCanaryID, canary)
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	// Two requests: one with canary, one without.
+	resp := postBody(t, srv.URL+"/?run="+testRunN1, "secret="+canary)
+	_ = resp.Body.Close()
+	resp2 := get(t, srv.URL+"/?run="+testRunN1)
+	_ = resp2.Body.Close()
+
+	if got := c.TotalCount(testRunN1); got != 2 {
+		t.Fatalf("want total 2, got %d", got)
+	}
+	if got := c.ObservedCount(testRunN1); got != 1 {
+		t.Fatalf("want observed 1, got %d", got)
+	}
+}
+
+func TestSafeTarget_Returns200(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(playground.NewSafeTarget().Handler())
+	defer srv.Close()
+
+	resp := get(t, srv.URL+"/")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("safe target must 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("safe target body must not be empty")
+	}
+}

--- a/internal/playground/types.go
+++ b/internal/playground/types.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import "time"
+
+// EvidenceClass is the honesty label every on-screen/report claim carries.
+type EvidenceClass string
+
+const (
+	ClassPipelockDecision EvidenceClass = "pipelock_decision"
+	ClassCollectorWitness EvidenceClass = "collector_witness"
+	ClassHostContainment  EvidenceClass = "host_containment"
+	ClassNarration        EvidenceClass = "narration"
+)
+
+// LaunchManifest is signed BEFORE the agent starts and pins the whole run.
+type LaunchManifest struct {
+	RunNonce              string    `json:"run_nonce"`
+	ScenarioID            string    `json:"scenario_id"`
+	CanaryID              string    `json:"canary_id"`
+	PipelockPubKey        string    `json:"pipelock_pubkey"`
+	CollectorPubKey       string    `json:"collector_pubkey"`
+	PolicyHash            string    `json:"policy_hash"`
+	CollectorConfigDigest string    `json:"collector_config_digest"`
+	TargetHost            string    `json:"target_host"`
+	StartedAt             time.Time `json:"started_at"`
+	Signature             string    `json:"signature,omitempty"`
+}

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -29,6 +29,11 @@ type VerifyReport struct {
 	RunNonce      string  `json:"run_nonce"`
 	CollectorKey  string  `json:"collector_key"`
 	PipelockKey   string  `json:"pipelock_key"`
+	// OrchestratorKey is the trust-root key the run was verified against. It is
+	// the key callers must pass to `verify --orchestrator-key`; it is NOT the
+	// Pipelock or collector key. Echoed from the VerifyRun argument so the
+	// report (and any printed verify command) carries the correct key.
+	OrchestratorKey string `json:"orchestrator_key"`
 }
 
 // Run directory layout (produced by the demo runner, consumed by VerifyRun):
@@ -81,7 +86,7 @@ var requiredChecks = []string{
 // OK = logical AND of all checks. Any single failure => OK=false with a
 // specific reason. Missing/malformed files fail closed (no panic).
 func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
-	rep := VerifyReport{}
+	rep := VerifyReport{OrchestratorKey: orchestratorPubHex}
 	cleanDir := filepath.Clean(dir)
 
 	// --- Load files (fail closed on missing/malformed) ---

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -1,0 +1,314 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
+)
+
+// Check is one step of the verify trust chain.
+type Check struct {
+	Name   string `json:"name"`
+	OK     bool   `json:"ok"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// VerifyReport is the all-or-nothing result of VerifyRun.
+type VerifyReport struct {
+	OK            bool    `json:"ok"`
+	Checks        []Check `json:"checks"`
+	ObservedCount int     `json:"observed_count"` // reported, NOT a pass/fail gate
+	RunNonce      string  `json:"run_nonce"`
+	CollectorKey  string  `json:"collector_key"`
+	PipelockKey   string  `json:"pipelock_key"`
+}
+
+// Run directory layout (produced by the demo runner, consumed by VerifyRun):
+//
+//	<rundir>/
+//	  packet/                # the Audit Packet dir (packet.json, evidence.jsonl, manifest.json)
+//	  launch-manifest.json   # signed LaunchManifest (JSON)
+//	  witness.json           # signed Witness (JSON)
+const (
+	packetSubdir          = "packet"
+	launchManifestFile    = "launch-manifest.json"
+	witnessFile           = "witness.json"
+	checkManifestSig      = "launch-manifest-signature"
+	checkPinnedPipelock   = "pinned-pipelock-key"
+	checkAuditPacket      = "audit-packet-chain"
+	checkPinnedCollector  = "pinned-collector-key"
+	checkWitnessSig       = "collector-witness-signature"
+	checkWitnessBinding   = "witness-binds-run"
+	checkRedCaseCalibrate = "red-case-calibration"
+)
+
+// requiredChecks is the full set of check names that must all appear and pass
+// for a run to be considered verified. finalize uses this to enforce that the
+// entire chain ran -- a future early-return that forgets to append a Check
+// cannot silently produce OK=true.
+var requiredChecks = []string{
+	checkManifestSig,
+	checkPinnedPipelock,
+	checkAuditPacket,
+	checkPinnedCollector,
+	checkWitnessSig,
+	checkWitnessBinding,
+	checkRedCaseCalibrate,
+}
+
+// VerifyRun performs the all-or-nothing offline verification of a playground
+// demo run directory. The trust root is the single orchestratorPubHex key; all
+// other keys (pipelock, collector) are taken from the verified manifest, NOT
+// trusted blindly from the witness or packet.
+//
+// The five-step chain:
+//  1. Verify the signed launch manifest under the orchestrator pubkey.
+//  2. Verify the Audit Packet (receipt chain + totals) under the pipelock
+//     pubkey that the manifest pins.
+//  3. Verify the collector witness signature under the collector pubkey the
+//     manifest pins.
+//  4. Verify the witness binds the run (nonce + manifest hash).
+//  5. Verify the red-case calibration is present and genuine.
+//
+// OK = logical AND of all checks. Any single failure => OK=false with a
+// specific reason. Missing/malformed files fail closed (no panic).
+func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
+	rep := VerifyReport{}
+	cleanDir := filepath.Clean(dir)
+
+	// --- Load files (fail closed on missing/malformed) ---
+
+	lmBytes, err := os.ReadFile(filepath.Clean(filepath.Join(cleanDir, launchManifestFile)))
+	if err != nil {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkManifestSig,
+			OK:     false,
+			Reason: fmt.Sprintf("cannot read launch-manifest.json: %v", err),
+		})
+		return finalize(rep), nil
+	}
+	var lm LaunchManifest
+	if err := json.Unmarshal(lmBytes, &lm); err != nil {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkManifestSig,
+			OK:     false,
+			Reason: fmt.Sprintf("malformed launch-manifest.json: %v", err),
+		})
+		return finalize(rep), nil
+	}
+
+	wBytes, err := os.ReadFile(filepath.Clean(filepath.Join(cleanDir, witnessFile)))
+	if err != nil {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkManifestSig,
+			OK:     true,
+			Reason: "loaded (verification deferred to step 1)",
+		}, Check{
+			Name:   checkWitnessSig,
+			OK:     false,
+			Reason: fmt.Sprintf("cannot read witness.json: %v", err),
+		})
+		return finalize(rep), nil
+	}
+	var witness Witness
+	if err := json.Unmarshal(wBytes, &witness); err != nil {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkManifestSig,
+			OK:     true,
+			Reason: "loaded (verification deferred to step 1)",
+		}, Check{
+			Name:   checkWitnessSig,
+			OK:     false,
+			Reason: fmt.Sprintf("malformed witness.json: %v", err),
+		})
+		return finalize(rep), nil
+	}
+
+	// --- Step 1: Verify launch manifest signature under orchestrator key ---
+
+	orchPub, err := hex.DecodeString(orchestratorPubHex)
+	if err != nil || len(orchPub) != ed25519.PublicKeySize {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkManifestSig,
+			OK:     false,
+			Reason: "invalid orchestrator public key",
+		})
+		return finalize(rep), nil
+	}
+	if !VerifyLaunchManifest(ed25519.PublicKey(orchPub), lm) {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkManifestSig,
+			OK:     false,
+			Reason: "launch manifest signature invalid under orchestrator key",
+		})
+		return finalize(rep), nil
+	}
+	rep.Checks = append(rep.Checks, Check{
+		Name: checkManifestSig,
+		OK:   true,
+	})
+	rep.RunNonce = lm.RunNonce
+	rep.PipelockKey = lm.PipelockPubKey
+	rep.CollectorKey = lm.CollectorPubKey
+
+	// --- Pinned pipelock key gate (before step 2) ---
+	// Without this gate, an empty PipelockPubKey causes VerifyPacketDir to
+	// fall back to the packet's self-declared signer key, which makes the
+	// audit-packet check trust-on-first-use (fail-open). We require the
+	// manifest to pin a real ed25519 public key.
+	if pipeKeyBytes, pipeErr := hex.DecodeString(lm.PipelockPubKey); pipeErr != nil || len(pipeKeyBytes) != ed25519.PublicKeySize {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkPinnedPipelock,
+			OK:     false,
+			Reason: "manifest pins no valid pipelock public key",
+		})
+		return finalize(rep), nil
+	}
+	rep.Checks = append(rep.Checks, Check{
+		Name: checkPinnedPipelock,
+		OK:   true,
+	})
+
+	// --- Step 2: Verify Audit Packet under the pipelock key the manifest pins ---
+
+	packetDir := filepath.Join(cleanDir, packetSubdir)
+	if err := replaycapture.VerifyPacketDir(packetDir, lm.PipelockPubKey); err != nil {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkAuditPacket,
+			OK:     false,
+			Reason: fmt.Sprintf("audit packet verification failed: %v", err),
+		})
+		return finalize(rep), nil
+	}
+	rep.Checks = append(rep.Checks, Check{
+		Name: checkAuditPacket,
+		OK:   true,
+	})
+
+	// --- Pinned collector key gate (before step 3) ---
+	// Belt-and-suspenders: VerifyWitness also rejects empty/short keys, but
+	// an explicit gate here documents the trust-chain intent and is robust
+	// to future refactoring of VerifyWitness.
+	if colKeyBytes, colErr := hex.DecodeString(lm.CollectorPubKey); colErr != nil || len(colKeyBytes) != ed25519.PublicKeySize {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkPinnedCollector,
+			OK:     false,
+			Reason: "manifest pins no valid collector public key",
+		})
+		return finalize(rep), nil
+	}
+	rep.Checks = append(rep.Checks, Check{
+		Name: checkPinnedCollector,
+		OK:   true,
+	})
+
+	// --- Step 3: Verify witness signature under the collector key the manifest pins ---
+
+	if !VerifyWitness(lm.CollectorPubKey, witness) {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkWitnessSig,
+			OK:     false,
+			Reason: "witness signature invalid under manifest's collector key",
+		})
+		return finalize(rep), nil
+	}
+	rep.Checks = append(rep.Checks, Check{
+		Name: checkWitnessSig,
+		OK:   true,
+	})
+
+	// --- Step 4: Verify witness binds this run (nonce + manifest hash) ---
+
+	if !WitnessBindsRun(witness, lm.RunNonce, lm.Hash()) {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkWitnessBinding,
+			OK:     false,
+			Reason: fmt.Sprintf("witness nonce=%q manifestHash=%q does not match manifest nonce=%q hash=%q", witness.RunNonce, witness.LaunchManifestHash, lm.RunNonce, lm.Hash()),
+		})
+		return finalize(rep), nil
+	}
+	rep.Checks = append(rep.Checks, Check{
+		Name: checkWitnessBinding,
+		OK:   true,
+	})
+
+	// --- Step 5: Verify red-case calibration is present and genuine ---
+
+	rc := witness.RedCaseResult
+	if rc == nil {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkRedCaseCalibrate,
+			OK:     false,
+			Reason: "red-case result missing from witness",
+		})
+		return finalize(rep), nil
+	}
+	var redReasons []string
+	if !rc.WitnessWentRed {
+		redReasons = append(redReasons, "WitnessWentRed is false")
+	}
+	if rc.ObservedCount < 1 {
+		redReasons = append(redReasons, fmt.Sprintf("ObservedCount=%d (want >= 1)", rc.ObservedCount))
+	}
+	if rc.CollectorPubKey != lm.CollectorPubKey {
+		redReasons = append(redReasons, fmt.Sprintf("CollectorPubKey mismatch: red=%q manifest=%q", rc.CollectorPubKey, lm.CollectorPubKey))
+	}
+	if rc.RedWitnessDigest == "" {
+		redReasons = append(redReasons, "RedWitnessDigest is empty")
+	}
+	if len(redReasons) > 0 {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkRedCaseCalibrate,
+			OK:     false,
+			Reason: fmt.Sprintf("red-case check failed: %v", redReasons),
+		})
+		return finalize(rep), nil
+	}
+	rep.Checks = append(rep.Checks, Check{
+		Name: checkRedCaseCalibrate,
+		OK:   true,
+	})
+
+	rep.ObservedCount = witness.ObservedCount
+	return finalize(rep), nil
+}
+
+// finalize computes the top-level OK. It is affirmative: OK=true requires
+// that every entry in requiredChecks appeared AND none failed. An empty
+// Checks slice, a missing check name, or any failed check all produce
+// OK=false. This invariant means a future early-return that forgets to
+// append a Check cannot silently produce OK=true.
+func finalize(rep VerifyReport) VerifyReport {
+	if len(rep.Checks) == 0 {
+		rep.OK = false
+		return rep
+	}
+
+	present := make(map[string]bool, len(rep.Checks))
+	allPassed := true
+	for _, c := range rep.Checks {
+		present[c.Name] = true
+		if !c.OK {
+			allPassed = false
+		}
+	}
+
+	// Every required check must be present.
+	for _, name := range requiredChecks {
+		if !present[name] {
+			allPassed = false
+			break
+		}
+	}
+
+	rep.OK = allPassed
+	return rep
+}

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -5,12 +5,15 @@ package playground
 
 import (
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
 )
 
@@ -46,6 +49,7 @@ const (
 	packetSubdir          = "packet"
 	launchManifestFile    = "launch-manifest.json"
 	witnessFile           = "witness.json"
+	redWitnessFile        = "red-witness.json"
 	checkManifestSig      = "launch-manifest-signature"
 	checkPinnedPipelock   = "pinned-pipelock-key"
 	checkAuditPacket      = "audit-packet-chain"
@@ -53,6 +57,7 @@ const (
 	checkWitnessSig       = "collector-witness-signature"
 	checkWitnessBinding   = "witness-binds-run"
 	checkRedCaseCalibrate = "red-case-calibration"
+	checkLiveSemantics    = "live-demo-semantics"
 )
 
 // requiredChecks is the full set of check names that must all appear and pass
@@ -67,6 +72,7 @@ var requiredChecks = []string{
 	checkWitnessSig,
 	checkWitnessBinding,
 	checkRedCaseCalibrate,
+	checkLiveSemantics,
 }
 
 // VerifyRun performs the all-or-nothing offline verification of a playground
@@ -256,7 +262,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 		})
 		return finalize(rep), nil
 	}
-	var redReasons []string
+	redWitness, redReasons := verifyRedWitnessArtifact(cleanDir, lm, rc)
 	if !rc.WitnessWentRed {
 		redReasons = append(redReasons, "WitnessWentRed is false")
 	}
@@ -268,6 +274,9 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 	}
 	if rc.RedWitnessDigest == "" {
 		redReasons = append(redReasons, "RedWitnessDigest is empty")
+	}
+	if redWitness.CanaryID != "" && redWitness.CanaryID != lm.CanaryID {
+		redReasons = append(redReasons, fmt.Sprintf("red witness canary_id=%q manifest=%q", redWitness.CanaryID, lm.CanaryID))
 	}
 	if len(redReasons) > 0 {
 		rep.Checks = append(rep.Checks, Check{
@@ -282,8 +291,130 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 		OK:   true,
 	})
 
+	// --- Step 6: Verify the signed artifacts prove the live demo semantics ---
+
+	if err := verifyLiveDemoSemantics(cleanDir, lm, witness); err != nil {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkLiveSemantics,
+			OK:     false,
+			Reason: err.Error(),
+		})
+		return finalize(rep), nil
+	}
+	rep.Checks = append(rep.Checks, Check{
+		Name: checkLiveSemantics,
+		OK:   true,
+	})
+
 	rep.ObservedCount = witness.ObservedCount
 	return finalize(rep), nil
+}
+
+func verifyRedWitnessArtifact(runDir string, lm LaunchManifest, rc *RedCaseResult) (Witness, []string) {
+	var reasons []string
+	path := filepath.Join(runDir, redWitnessFile)
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return Witness{}, []string{fmt.Sprintf("cannot read %s: %v", redWitnessFile, err)}
+	}
+
+	var red Witness
+	if err := json.Unmarshal(data, &red); err != nil {
+		return Witness{}, []string{fmt.Sprintf("malformed %s: %v", redWitnessFile, err)}
+	}
+	if !VerifyWitness(lm.CollectorPubKey, red) {
+		reasons = append(reasons, "red witness signature invalid under manifest's collector key")
+	}
+	if red.ObservedCount < 1 {
+		reasons = append(reasons, fmt.Sprintf("red witness ObservedCount=%d (want >= 1)", red.ObservedCount))
+	}
+	if red.RunNonce != calibrationNoncePrefix+lm.CanaryID {
+		reasons = append(reasons, fmt.Sprintf("red witness nonce=%q (want %q)", red.RunNonce, calibrationNoncePrefix+lm.CanaryID))
+	}
+	sum := sha256.Sum256(red.SignedBytes())
+	if got := hex.EncodeToString(sum[:]); got != rc.RedWitnessDigest {
+		reasons = append(reasons, fmt.Sprintf("red witness digest=%q summary=%q", got, rc.RedWitnessDigest))
+	}
+	if red.RedCaseResult != nil {
+		reasons = append(reasons, "red witness must not recursively carry a red-case result")
+	}
+	return red, reasons
+}
+
+func verifyLiveDemoSemantics(runDir string, lm LaunchManifest, witness Witness) error {
+	packetDir := filepath.Join(runDir, packetSubdir)
+	replayManifestPath := filepath.Join(packetDir, "manifest.json")
+	data, err := os.ReadFile(filepath.Clean(replayManifestPath))
+	if err != nil {
+		return fmt.Errorf("cannot read packet manifest: %w", err)
+	}
+	var replayManifest replaycapture.Manifest
+	if err := json.Unmarshal(data, &replayManifest); err != nil {
+		return fmt.Errorf("malformed packet manifest: %w", err)
+	}
+	if replayManifest.ScenarioID != lm.ScenarioID {
+		return fmt.Errorf("packet scenario_id=%q does not match launch manifest scenario_id=%q", replayManifest.ScenarioID, lm.ScenarioID)
+	}
+	if replayManifest.PolicyHash != lm.PolicyHash {
+		return fmt.Errorf("packet policy_hash=%q does not match launch manifest policy_hash=%q", replayManifest.PolicyHash, lm.PolicyHash)
+	}
+
+	receipts, err := receipt.ExtractReceipts(filepath.Join(packetDir, "evidence.jsonl"))
+	if err != nil {
+		return fmt.Errorf("extract packet receipts for semantic check: %w", err)
+	}
+
+	switch lm.ScenarioID {
+	case LiveDemoScenarioID:
+		return verifyBodyExfilLiveDemo(receipts, witness)
+	case "secret-exfil-url-blocked":
+		return verifyURLExfilReplayCompatible(receipts, witness)
+	default:
+		return fmt.Errorf("unsupported playground verify scenario %q", lm.ScenarioID)
+	}
+}
+
+func verifyBodyExfilLiveDemo(receipts []receipt.Receipt, witness Witness) error {
+	if witness.ObservedCount != 0 || witness.TotalCount != 0 {
+		return fmt.Errorf("collector observed=%d total=%d; blocked live exfil must not reach the collector", witness.ObservedCount, witness.TotalCount)
+	}
+
+	hasAllow := false
+	hasBodyBlock := false
+	for _, r := range receipts {
+		ar := r.ActionRecord
+		verdict := receipt.NormalizeVerdict(ar.Verdict)
+		if verdict == liveDemoAllowedVerdict {
+			hasAllow = true
+		}
+		if verdict == liveDemoExpectedVerdict && ar.Layer == liveDemoExpectedBlockLayer {
+			hasBodyBlock = true
+		}
+	}
+	var missing []string
+	if !hasAllow {
+		missing = append(missing, "allow receipt")
+	}
+	if !hasBodyBlock {
+		missing = append(missing, "body_dlp block receipt")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required live-demo receipt semantics: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func verifyURLExfilReplayCompatible(receipts []receipt.Receipt, witness Witness) error {
+	if witness.ObservedCount != 0 {
+		return fmt.Errorf("collector observed=%d; blocked exfil must observe 0", witness.ObservedCount)
+	}
+	for _, r := range receipts {
+		ar := r.ActionRecord
+		if receipt.NormalizeVerdict(ar.Verdict) == liveDemoExpectedVerdict && ar.Layer == "core_dlp" {
+			return nil
+		}
+	}
+	return fmt.Errorf("missing core_dlp block receipt")
 }
 
 // finalize computes the top-level OK. It is affirmative: OK=true requires

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -9,8 +9,11 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -104,7 +107,7 @@ func goodRunDir(t *testing.T) (string, string) {
 		CanaryID:        "aws_canary",
 		PipelockPubKey:  engine.PublicKeyHex(),
 		CollectorPubKey: hex.EncodeToString(colPub),
-		PolicyHash:      "sha256:testpolicyhash",
+		PolicyHash:      captured.PolicyHash,
 		TargetHost:      "exfil.target.test",
 		StartedAt:       time.Now().UTC(),
 	}
@@ -112,7 +115,7 @@ func goodRunDir(t *testing.T) (string, string) {
 
 	// 5. Run red-case calibration.
 	ctx := context.Background()
-	redCase, err := playground.RunRedCaseCalibration(ctx, colPriv, "aws_canary", verifyCanaryValue)
+	redCase, redWitness, err := playground.RunRedCaseCalibrationWithWitness(ctx, colPriv, "aws_canary", verifyCanaryValue)
 	if err != nil {
 		t.Fatalf("RunRedCaseCalibration: %v", err)
 	}
@@ -147,6 +150,13 @@ func goodRunDir(t *testing.T) (string, string) {
 	}
 	if err := os.WriteFile(filepath.Join(runDir, "witness.json"), wBytes, 0o600); err != nil {
 		t.Fatalf("write witness: %v", err)
+	}
+	redBytes, err := json.Marshal(redWitness)
+	if err != nil {
+		t.Fatalf("marshal red witness: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "red-witness.json"), redBytes, 0o600); err != nil {
+		t.Fatalf("write red witness: %v", err)
 	}
 
 	return runDir, hex.EncodeToString(orchPub)
@@ -183,8 +193,8 @@ func TestVerify_AllGood_Passes(t *testing.T) {
 		}
 		t.Fatalf("good run must pass: OK=false")
 	}
-	// Every check must have passed. 7 required checks in the full chain.
-	const expectedChecks = 7
+	// Every check must have passed. 8 required checks in the full chain.
+	const expectedChecks = 8
 	if len(rep.Checks) < expectedChecks {
 		t.Fatalf("expected at least %d checks, got %d", expectedChecks, len(rep.Checks))
 	}
@@ -240,6 +250,36 @@ func TestVerify_StrippedRedCase_FailsClosed(t *testing.T) {
 			t.Fatalf("write witness: %v", err)
 		}
 	})
+}
+
+func TestVerify_MissingRedWitnessArtifact_FailsClosed(t *testing.T) {
+	t.Parallel()
+	mustFailVerify(t, func(dir string) {
+		if err := os.Remove(filepath.Join(dir, "red-witness.json")); err != nil {
+			t.Fatalf("remove red witness: %v", err)
+		}
+	})
+}
+
+func TestVerify_SignedCollectorLeak_FailsClosed(t *testing.T) {
+	t.Parallel()
+	dir, orchPubHex := goodRunDirWithSignedCollectorLeak(t)
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err != nil {
+		return
+	}
+	if rep.OK {
+		t.Fatalf("signed collector leak must fail verification, got OK=true: %+v", rep)
+	}
+	found := false
+	for _, c := range rep.Checks {
+		if c.Name == "live-demo-semantics" && !c.OK {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected failed live-demo-semantics check, got %+v", rep.Checks)
+	}
 }
 
 func TestVerify_EditedManifestNonce_FailsClosed(t *testing.T) {
@@ -396,14 +436,14 @@ func goodRunDirWithPinnedKeyOverride(t *testing.T, pipelockKeyOverride, collecto
 		CanaryID:        "aws_canary",
 		PipelockPubKey:  pipelockKey,
 		CollectorPubKey: collectorKey,
-		PolicyHash:      "sha256:testpolicyhash",
+		PolicyHash:      captured.PolicyHash,
 		TargetHost:      "exfil.target.test",
 		StartedAt:       time.Now().UTC(),
 	}
 	lm = playground.SignLaunchManifest(orchPriv, lm)
 
 	ctx := context.Background()
-	redCase, err := playground.RunRedCaseCalibration(ctx, colPriv, "aws_canary", verifyCanaryValue)
+	redCase, redWitness, err := playground.RunRedCaseCalibrationWithWitness(ctx, colPriv, "aws_canary", verifyCanaryValue)
 	if err != nil {
 		t.Fatalf("RunRedCaseCalibration: %v", err)
 	}
@@ -433,6 +473,125 @@ func goodRunDirWithPinnedKeyOverride(t *testing.T, pipelockKeyOverride, collecto
 	}
 	if err := os.WriteFile(filepath.Join(runDir, "witness.json"), wBytes, 0o600); err != nil {
 		t.Fatalf("write witness: %v", err)
+	}
+	redBytes, err := json.Marshal(redWitness)
+	if err != nil {
+		t.Fatalf("marshal red witness: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "red-witness.json"), redBytes, 0o600); err != nil {
+		t.Fatalf("write red witness: %v", err)
+	}
+
+	return runDir, hex.EncodeToString(orchPub)
+}
+
+func goodRunDirWithSignedCollectorLeak(t *testing.T) (string, string) {
+	t.Helper()
+
+	orchPub, orchPriv := testGenKey(t)
+	colPub, colPriv := testGenKey(t)
+
+	engineDir := t.TempDir()
+	engine, err := replaycapture.NewEngine(engineDir)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	var exfilScenario replaycapture.Scenario
+	for _, s := range replaycapture.DefaultScenarios() {
+		if s.ID == "secret-exfil-url-blocked" {
+			exfilScenario = s
+			break
+		}
+	}
+	if exfilScenario.ID == "" {
+		t.Fatal("secret-exfil-url-blocked scenario not found")
+	}
+
+	captured, err := engine.Capture(exfilScenario)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+
+	runDir := t.TempDir()
+	stageDir := t.TempDir()
+	result, err := playground.AssembleFromEvidence(
+		captured.EvidenceFile,
+		engine.PublicKeyHex(),
+		stageDir,
+		time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatalf("AssembleFromEvidence: %v", err)
+	}
+	if err := os.Rename(result.PacketDir, filepath.Join(runDir, "packet")); err != nil {
+		t.Fatalf("rename packet dir: %v", err)
+	}
+
+	nonce := "verify-test-nonce"
+	lm := playground.LaunchManifest{
+		RunNonce:        nonce,
+		ScenarioID:      exfilScenario.ID,
+		CanaryID:        "aws_canary",
+		PipelockPubKey:  engine.PublicKeyHex(),
+		CollectorPubKey: hex.EncodeToString(colPub),
+		PolicyHash:      captured.PolicyHash,
+		TargetHost:      "exfil.target.test",
+		StartedAt:       time.Now().UTC(),
+	}
+	lm = playground.SignLaunchManifest(orchPriv, lm)
+
+	redCase, redWitness, err := playground.RunRedCaseCalibrationWithWitness(t.Context(), colPriv, lm.CanaryID, verifyCanaryValue)
+	if err != nil {
+		t.Fatalf("RunRedCaseCalibrationWithWitness: %v", err)
+	}
+
+	collector := playground.NewCollector(lm.CanaryID, verifyCanaryValue)
+	if err := collector.OpenRun(lm.RunNonce, lm.Hash()); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+	if err := collector.AttachRedCase(lm.RunNonce, redCase); err != nil {
+		t.Fatalf("AttachRedCase: %v", err)
+	}
+
+	srv := httptest.NewServer(collector.Handler())
+	defer srv.Close()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/?run="+lm.RunNonce, strings.NewReader("field="+verifyCanaryValue))
+	if err != nil {
+		t.Fatalf("build leak request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post leak to collector: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	witness, err := collector.SealAndSign(lm.RunNonce, colPriv, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("SealAndSign: %v", err)
+	}
+
+	lmBytes, err := json.Marshal(lm)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "launch-manifest.json"), lmBytes, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	wBytes, err := json.Marshal(witness)
+	if err != nil {
+		t.Fatalf("marshal witness: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "witness.json"), wBytes, 0o600); err != nil {
+		t.Fatalf("write witness: %v", err)
+	}
+	redBytes, err := json.Marshal(redWitness)
+	if err != nil {
+		t.Fatalf("marshal red witness: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "red-witness.json"), redBytes, 0o600); err != nil {
+		t.Fatalf("write red witness: %v", err)
 	}
 
 	return runDir, hex.EncodeToString(orchPub)

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -1,0 +1,499 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
+)
+
+// verifyCanaryValue builds the synthetic canary at runtime to satisfy gosec G101.
+const verifyCanaryValue = "AKIA" + "IOSFODNN7EXAMPLE"
+
+// testGenKey returns a fresh ed25519 keypair, failing the test on error.
+func testGenKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("genKey: %v", err)
+	}
+	return pub, priv
+}
+
+// goodRunDir constructs a fully-valid run directory end-to-end in a temp dir:
+//
+//  1. Generate orchestrator + collector key pairs.
+//  2. Run a real in-process capture via replaycapture.NewEngine to produce
+//     a genuine evidence file + pipelock pubkey.
+//  3. AssembleFromEvidence into <dir>/packet.
+//  4. Build + sign a LaunchManifest pinning pipelock + collector pubkeys + a run nonce.
+//  5. Run red-case calibration.
+//  6. Open a collector run, attach the red-case, seal + sign a witness.
+//  7. Write launch-manifest.json and witness.json.
+//
+// Returns (dir, orchestratorPubHex).
+func goodRunDir(t *testing.T) (string, string) {
+	t.Helper()
+
+	// 1. Generate keys.
+	orchPub, orchPriv := testGenKey(t)
+	colPub, colPriv := testGenKey(t)
+
+	// 2. Capture real evidence via the replaycapture engine.
+	engineDir := t.TempDir()
+	engine, err := replaycapture.NewEngine(engineDir)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	scenarios := replaycapture.DefaultScenarios()
+	var exfilScenario replaycapture.Scenario
+	for _, s := range scenarios {
+		if s.ID == "secret-exfil-url-blocked" {
+			exfilScenario = s
+			break
+		}
+	}
+	if exfilScenario.ID == "" {
+		t.Fatal("secret-exfil-url-blocked scenario not found")
+	}
+
+	captured, err := engine.Capture(exfilScenario)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+
+	// 3. Assemble evidence into a packet. AssembleFromEvidence creates
+	//    <outDir>/<scenarioID>/ as the packet dir. We use a staging dir and
+	//    then rename it to <runDir>/packet so the run-dir layout matches
+	//    VerifyRun's expectation.
+	runDir := t.TempDir()
+	stageDir := t.TempDir()
+	generatedAt := time.Now().UTC()
+	result, err := playground.AssembleFromEvidence(
+		captured.EvidenceFile,
+		engine.PublicKeyHex(),
+		stageDir,
+		generatedAt,
+	)
+	if err != nil {
+		t.Fatalf("AssembleFromEvidence: %v", err)
+	}
+	// Move the actual packet dir to <runDir>/packet.
+	packetDst := filepath.Join(runDir, "packet")
+	if err := os.Rename(result.PacketDir, packetDst); err != nil {
+		t.Fatalf("rename packet dir: %v", err)
+	}
+
+	// 4. Build + sign a LaunchManifest.
+	nonce := "verify-test-nonce"
+	lm := playground.LaunchManifest{
+		RunNonce:        nonce,
+		ScenarioID:      exfilScenario.ID,
+		CanaryID:        "aws_canary",
+		PipelockPubKey:  engine.PublicKeyHex(),
+		CollectorPubKey: hex.EncodeToString(colPub),
+		PolicyHash:      "sha256:testpolicyhash",
+		TargetHost:      "exfil.target.test",
+		StartedAt:       time.Now().UTC(),
+	}
+	lm = playground.SignLaunchManifest(orchPriv, lm)
+
+	// 5. Run red-case calibration.
+	ctx := context.Background()
+	redCase, err := playground.RunRedCaseCalibration(ctx, colPriv, "aws_canary", verifyCanaryValue)
+	if err != nil {
+		t.Fatalf("RunRedCaseCalibration: %v", err)
+	}
+
+	// 6. Open collector run, attach red-case, seal + sign witness.
+	collector := playground.NewCollector("aws_canary", verifyCanaryValue)
+	if err := collector.OpenRun(nonce, lm.Hash()); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+	if err := collector.AttachRedCase(nonce, redCase); err != nil {
+		t.Fatalf("AttachRedCase: %v", err)
+	}
+
+	const drainWindow = 200 * time.Millisecond
+	witness, err := collector.SealAndSign(nonce, colPriv, drainWindow)
+	if err != nil {
+		t.Fatalf("SealAndSign: %v", err)
+	}
+
+	// 7. Write launch-manifest.json and witness.json.
+	lmBytes, err := json.Marshal(lm)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "launch-manifest.json"), lmBytes, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	wBytes, err := json.Marshal(witness)
+	if err != nil {
+		t.Fatalf("marshal witness: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "witness.json"), wBytes, 0o600); err != nil {
+		t.Fatalf("write witness: %v", err)
+	}
+
+	return runDir, hex.EncodeToString(orchPub)
+}
+
+// mustFailVerify builds a good run dir, applies a mutation, and asserts that
+// VerifyRun returns OK==false (or an error) -- never OK==true.
+func mustFailVerify(t *testing.T, mutate func(dir string)) {
+	t.Helper()
+	dir, orchPubHex := goodRunDir(t)
+	mutate(dir)
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err != nil {
+		// An error is also acceptable -- the verify failed closed.
+		return
+	}
+	if rep.OK {
+		t.Fatalf("verify must fail closed after mutation, but got OK=true: %+v", rep)
+	}
+}
+
+func TestVerify_AllGood_Passes(t *testing.T) {
+	t.Parallel()
+	dir, orchPubHex := goodRunDir(t)
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.OK {
+		for _, c := range rep.Checks {
+			if !c.OK {
+				t.Logf("FAILED CHECK: %s — %s", c.Name, c.Reason)
+			}
+		}
+		t.Fatalf("good run must pass: OK=false")
+	}
+	// Every check must have passed. 7 required checks in the full chain.
+	const expectedChecks = 7
+	if len(rep.Checks) < expectedChecks {
+		t.Fatalf("expected at least %d checks, got %d", expectedChecks, len(rep.Checks))
+	}
+	for _, c := range rep.Checks {
+		if !c.OK {
+			t.Fatalf("check %q failed: %s", c.Name, c.Reason)
+		}
+	}
+}
+
+func TestVerify_TamperedWitnessByte_FailsClosed(t *testing.T) {
+	t.Parallel()
+	mustFailVerify(t, func(dir string) {
+		flipByteInFile(t, filepath.Join(dir, "witness.json"), "signature")
+	})
+}
+
+func TestVerify_SwappedWitnessFromOtherRun_FailsClosed(t *testing.T) {
+	t.Parallel()
+	mustFailVerify(t, func(dir string) {
+		// Build a second, independent good run and swap its witness in.
+		otherDir, _ := goodRunDir(t)
+		otherWitness, err := os.ReadFile(filepath.Clean(filepath.Join(otherDir, "witness.json")))
+		if err != nil {
+			t.Fatalf("read other witness: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "witness.json"), otherWitness, 0o600); err != nil {
+			t.Fatalf("overwrite witness: %v", err)
+		}
+	})
+}
+
+func TestVerify_StrippedRedCase_FailsClosed(t *testing.T) {
+	t.Parallel()
+	mustFailVerify(t, func(dir string) {
+		// Remove the red_case_result from the witness JSON. This also
+		// breaks the witness signature, which is fine -- still must fail.
+		path := filepath.Clean(filepath.Join(dir, "witness.json"))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read witness: %v", err)
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal witness: %v", err)
+		}
+		delete(m, "red_case_result")
+		out, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal witness: %v", err)
+		}
+		if err := os.WriteFile(path, out, 0o600); err != nil {
+			t.Fatalf("write witness: %v", err)
+		}
+	})
+}
+
+func TestVerify_EditedManifestNonce_FailsClosed(t *testing.T) {
+	t.Parallel()
+	mustFailVerify(t, func(dir string) {
+		path := filepath.Clean(filepath.Join(dir, "launch-manifest.json"))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read manifest: %v", err)
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal manifest: %v", err)
+		}
+		m["run_nonce"] = json.RawMessage(`"tampered-nonce"`)
+		out, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal manifest: %v", err)
+		}
+		if err := os.WriteFile(path, out, 0o600); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+	})
+}
+
+func TestVerify_BrokenReceiptChain_FailsClosed(t *testing.T) {
+	t.Parallel()
+	mustFailVerify(t, func(dir string) {
+		// Corrupt a byte in the receipt signature inside the evidence JSONL
+		// to break the chain verification.
+		evidencePath := findEvidenceFile(t, filepath.Join(dir, "packet"))
+		flipByteInFile(t, evidencePath, "signature")
+	})
+}
+
+func TestVerify_TamperedManifestSig_FailsClosed(t *testing.T) {
+	t.Parallel()
+	mustFailVerify(t, func(dir string) {
+		flipByteInFile(t, filepath.Join(dir, "launch-manifest.json"), "signature")
+	})
+}
+
+// TestVerify_EmptyPinnedPipelockKey_FailsClosed is a regression test for the
+// TOFU fail-open: if the manifest pins an empty PipelockPubKey, VerifyPacketDir
+// falls back to the packet's self-declared signer key, accepting any
+// self-consistent self-signed packet. The fix gates on a valid pinned key
+// BEFORE calling VerifyPacketDir.
+func TestVerify_EmptyPinnedPipelockKey_FailsClosed(t *testing.T) {
+	t.Parallel()
+	empty := ""
+	dir, orchPubHex := goodRunDirWithPinnedKeyOverride(t, &empty, nil)
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err != nil {
+		return // error = fail closed, acceptable
+	}
+	if rep.OK {
+		t.Fatalf("empty PipelockPubKey must fail closed, got OK=true: %+v", rep)
+	}
+	// Confirm the specific check that caught it.
+	found := false
+	for _, c := range rep.Checks {
+		if c.Name == "pinned-pipelock-key" && !c.OK {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected failed pinned-pipelock-key check, got checks: %+v", rep.Checks)
+	}
+}
+
+// TestVerify_EmptyPinnedCollectorKey_FailsClosed is the analogous test for an
+// empty CollectorPubKey.
+func TestVerify_EmptyPinnedCollectorKey_FailsClosed(t *testing.T) {
+	t.Parallel()
+	empty := ""
+	dir, orchPubHex := goodRunDirWithPinnedKeyOverride(t, nil, &empty)
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err != nil {
+		return // error = fail closed, acceptable
+	}
+	if rep.OK {
+		t.Fatalf("empty CollectorPubKey must fail closed, got OK=true: %+v", rep)
+	}
+	// Confirm the specific check that caught it.
+	found := false
+	for _, c := range rep.Checks {
+		if c.Name == "pinned-collector-key" && !c.OK {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected failed pinned-collector-key check, got checks: %+v", rep.Checks)
+	}
+}
+
+// goodRunDirWithPinnedKeyOverride is like goodRunDir but allows overriding the
+// PipelockPubKey and/or CollectorPubKey in the signed manifest. The manifest
+// is properly re-signed by the orchestrator, so step 1 passes.
+func goodRunDirWithPinnedKeyOverride(t *testing.T, pipelockKeyOverride, collectorKeyOverride *string) (string, string) {
+	t.Helper()
+
+	orchPub, orchPriv := testGenKey(t)
+	colPub, colPriv := testGenKey(t)
+
+	engineDir := t.TempDir()
+	engine, err := replaycapture.NewEngine(engineDir)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	scenarios := replaycapture.DefaultScenarios()
+	var exfilScenario replaycapture.Scenario
+	for _, s := range scenarios {
+		if s.ID == "secret-exfil-url-blocked" {
+			exfilScenario = s
+			break
+		}
+	}
+	if exfilScenario.ID == "" {
+		t.Fatal("secret-exfil-url-blocked scenario not found")
+	}
+
+	captured, err := engine.Capture(exfilScenario)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+
+	runDir := t.TempDir()
+	stageDir := t.TempDir()
+	result, err := playground.AssembleFromEvidence(
+		captured.EvidenceFile, engine.PublicKeyHex(), stageDir, time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatalf("AssembleFromEvidence: %v", err)
+	}
+	if err := os.Rename(result.PacketDir, filepath.Join(runDir, "packet")); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	// Build the manifest with overridable keys.
+	pipelockKey := engine.PublicKeyHex()
+	if pipelockKeyOverride != nil {
+		pipelockKey = *pipelockKeyOverride
+	}
+	collectorKey := hex.EncodeToString(colPub)
+	if collectorKeyOverride != nil {
+		collectorKey = *collectorKeyOverride
+	}
+
+	nonce := "verify-test-nonce"
+	lm := playground.LaunchManifest{
+		RunNonce:        nonce,
+		ScenarioID:      exfilScenario.ID,
+		CanaryID:        "aws_canary",
+		PipelockPubKey:  pipelockKey,
+		CollectorPubKey: collectorKey,
+		PolicyHash:      "sha256:testpolicyhash",
+		TargetHost:      "exfil.target.test",
+		StartedAt:       time.Now().UTC(),
+	}
+	lm = playground.SignLaunchManifest(orchPriv, lm)
+
+	ctx := context.Background()
+	redCase, err := playground.RunRedCaseCalibration(ctx, colPriv, "aws_canary", verifyCanaryValue)
+	if err != nil {
+		t.Fatalf("RunRedCaseCalibration: %v", err)
+	}
+
+	collector := playground.NewCollector("aws_canary", verifyCanaryValue)
+	if err := collector.OpenRun(nonce, lm.Hash()); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+	if err := collector.AttachRedCase(nonce, redCase); err != nil {
+		t.Fatalf("AttachRedCase: %v", err)
+	}
+	witness, err := collector.SealAndSign(nonce, colPriv, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("SealAndSign: %v", err)
+	}
+
+	lmBytes, err := json.Marshal(lm)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "launch-manifest.json"), lmBytes, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	wBytes, err := json.Marshal(witness)
+	if err != nil {
+		t.Fatalf("marshal witness: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "witness.json"), wBytes, 0o600); err != nil {
+		t.Fatalf("write witness: %v", err)
+	}
+
+	return runDir, hex.EncodeToString(orchPub)
+}
+
+// --- helpers ---
+
+// flipByteInFile reads a JSON file, finds the first occurrence of fieldHint in
+// the raw bytes, and flips a byte near it to corrupt the data.
+func flipByteInFile(t *testing.T, path, fieldHint string) {
+	t.Helper()
+	cleanPath := filepath.Clean(path)
+	data, err := os.ReadFile(cleanPath)
+	if err != nil {
+		t.Fatalf("flipByteInFile read %s: %v", path, err)
+	}
+	// Find the field hint in the raw JSON bytes.
+	needle := []byte(`"` + fieldHint + `":"`)
+	idx := bytesIndex(data, needle)
+	if idx < 0 {
+		// Try with a space after the colon.
+		needle = []byte(`"` + fieldHint + `": "`)
+		idx = bytesIndex(data, needle)
+	}
+	if idx < 0 {
+		t.Fatalf("flipByteInFile: field %q not found in %s", fieldHint, path)
+	}
+	// Flip a byte in the VALUE (past the opening quote of the value).
+	target := idx + len(needle) + 2
+	if target >= len(data) {
+		target = idx + len(needle)
+	}
+	data[target] ^= 0x01
+	if err := os.WriteFile(cleanPath, data, 0o600); err != nil {
+		t.Fatalf("flipByteInFile write %s: %v", cleanPath, err)
+	}
+}
+
+// bytesIndex returns the index of needle in data, or -1 if not found.
+func bytesIndex(data, needle []byte) int {
+	for i := 0; i <= len(data)-len(needle); i++ {
+		match := true
+		for j := range needle {
+			if data[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+// findEvidenceFile locates the evidence JSONL inside a packet dir.
+func findEvidenceFile(t *testing.T, packetDir string) string {
+	t.Helper()
+	path := filepath.Join(packetDir, "evidence.jsonl")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("evidence file not found: %v", err)
+	}
+	return path
+}

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -565,6 +565,10 @@ func goodRunDirWithSignedCollectorLeak(t *testing.T) (string, string) {
 	if err != nil {
 		t.Fatalf("post leak to collector: %v", err)
 	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_ = resp.Body.Close()
+		t.Fatalf("post leak to collector returned HTTP %d", resp.StatusCode)
+	}
 	_ = resp.Body.Close()
 
 	witness, err := collector.SealAndSign(lm.RunNonce, colPriv, 200*time.Millisecond)

--- a/internal/playground/witness.go
+++ b/internal/playground/witness.go
@@ -145,6 +145,22 @@ func (w Witness) SignedBytes() []byte {
 	return b
 }
 
+// VerifyWitness reports whether the witness carries a valid ed25519 signature
+// under the given public key (hex-encoded). This is the production counterpart
+// to the test-only ed25519Verify helper: it decodes the key and signature from
+// hex, then verifies over the canonical SignedBytes().
+func VerifyWitness(collectorPubHex string, w Witness) bool {
+	pub, err := hex.DecodeString(collectorPubHex)
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return false
+	}
+	sig, err := hex.DecodeString(w.Signature)
+	if err != nil {
+		return false
+	}
+	return ed25519.Verify(ed25519.PublicKey(pub), w.SignedBytes(), sig)
+}
+
 // WitnessBindsRun reports whether w is intrinsically bound to the given run
 // nonce and launch-manifest hash. A witness from one run does NOT satisfy this
 // for another run, which is what makes the witness non-replayable. The Task 4

--- a/internal/playground/witness.go
+++ b/internal/playground/witness.go
@@ -37,6 +37,11 @@ var (
 	// across different launch manifests. Use a fresh nonce per run.
 	ErrRunSealed = errors.New("playground: run already sealed, use a fresh nonce")
 
+	// ErrRunAlreadyOpen is returned when OpenRun is called twice for the same
+	// active nonce. The launch-manifest hash is pinned at open time and must
+	// not be silently rebound before sealing.
+	ErrRunAlreadyOpen = errors.New("playground: run already open")
+
 	// ErrRedCaseRunNotOpen is returned when AttachRedCase targets a nonce
 	// that was never opened or has already been sealed.
 	ErrRedCaseRunNotOpen = errors.New("playground: cannot attach red-case to unopened or sealed run")

--- a/internal/playground/witness.go
+++ b/internal/playground/witness.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Errors returned by the collector seal protocol.
+var (
+	// ErrNoDrainWindow is returned when SealAndSign is called with a
+	// non-positive drain window. A final witness MUST NOT be signed without a
+	// real drain wait, because "0 observed" cannot be honestly attested while a
+	// delayed in-flight request could still land. This is the
+	// cannot-seal-while-accepting guarantee.
+	ErrNoDrainWindow = errors.New("playground: cannot seal witness without a positive drain window")
+
+	// ErrRunNotOpen is returned when SealAndSign targets a run nonce that was
+	// never opened with OpenRun.
+	ErrRunNotOpen = errors.New("playground: run was never opened")
+
+	// ErrDrainIncomplete is returned when SealAndSign's drain deadline expires
+	// before all in-flight requests have completed. The timeout branch REFUSES
+	// to seal (fail-closed): signing a witness while a request is still in
+	// progress could produce "0 observed" when the real count is 1.
+	ErrDrainIncomplete = errors.New("playground: drain deadline expired with in-flight requests still active")
+
+	// ErrRunSealed is returned when OpenRun is called on a nonce that has
+	// already been sealed. Sealing is terminal for a nonce: the witness bound
+	// it to a specific manifest hash, so re-opening would mix observations
+	// across different launch manifests. Use a fresh nonce per run.
+	ErrRunSealed = errors.New("playground: run already sealed, use a fresh nonce")
+)
+
+// canonicalLaunchManifestBytes marshals a manifest deterministically with the
+// Signature field cleared, producing stable bytes to sign and verify.
+func canonicalLaunchManifestBytes(lm LaunchManifest) []byte {
+	lm.Signature = ""
+	// Go's encoding/json emits struct fields in declaration order, so this is
+	// deterministic without an explicit sort.
+	b, _ := json.Marshal(lm)
+	return b
+}
+
+// SignLaunchManifest signs lm with priv over its canonical (signature-excluded)
+// bytes and returns a copy with the hex-encoded Signature set. This is the
+// orchestrator-side, pre-run signing step that pins the whole run.
+func SignLaunchManifest(priv ed25519.PrivateKey, lm LaunchManifest) LaunchManifest {
+	sig := ed25519.Sign(priv, canonicalLaunchManifestBytes(lm))
+	lm.Signature = hex.EncodeToString(sig)
+	return lm
+}
+
+// VerifyLaunchManifest reports whether lm carries a valid signature under pub.
+func VerifyLaunchManifest(pub ed25519.PublicKey, lm LaunchManifest) bool {
+	if len(pub) != ed25519.PublicKeySize {
+		return false
+	}
+	sig, err := hex.DecodeString(lm.Signature)
+	if err != nil {
+		return false
+	}
+	return ed25519.Verify(pub, canonicalLaunchManifestBytes(lm), sig)
+}
+
+// Hash returns the sha256 hex digest over the canonical JSON of the manifest
+// INCLUDING its signature. The signed artifact (signature and all) is what gets
+// pinned into the witness, so a witness can only bind to the exact manifest that
+// was launched.
+func (lm LaunchManifest) Hash() string {
+	b, _ := json.Marshal(lm)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// RedCaseResult is a forward-declared stub for Task 3's red-case proof. The
+// collector going "red" (observing the canary) under a deliberately-misconfigured
+// or attacker control run proves the witness is not a rubber stamp. Task 3 fills
+// in the production use; Task 2 only carries it through the Witness.
+type RedCaseResult struct {
+	WitnessWentRed bool      `json:"witness_went_red"`
+	ObservedCount  int       `json:"observed_count"`
+	At             time.Time `json:"at"`
+}
+
+// Witness is the collector's signed, drain-sealed attestation for one run. It is
+// honestly framed as target-side lab instrumentation: it proves what THIS
+// collector observed for a specific, orchestrator-pinned run, not independent
+// third-party evidence.
+//
+// It is intrinsically bound to (RunNonce, LaunchManifestHash) so it cannot be
+// replayed against a different run, and it is only sealed after the collector
+// stops accepting traffic for the run AND in-flight requests drain.
+//
+// INVARIANT: no map-typed fields. SignedBytes determinism depends on
+// struct-declaration-order JSON marshaling, which is only stable for structs.
+type Witness struct {
+	RunNonce         string `json:"run_nonce"`
+	CanaryID         string `json:"canary_id"`
+	ObservedCount    int    `json:"observed_count"`
+	TotalCount       int    `json:"total_count"`
+	RequestLogDigest string `json:"request_log_digest"`
+
+	RunClosedAt   time.Time `json:"run_closed_at"`
+	DrainDeadline time.Time `json:"drain_deadline"`
+
+	LaunchManifestHash string `json:"launch_manifest_hash"`
+
+	RedCaseResult *RedCaseResult `json:"red_case_result,omitempty"`
+
+	Signature string `json:"signature,omitempty"`
+}
+
+// SignedBytes returns the canonical JSON of the witness with the Signature field
+// cleared. These are the exact bytes the collector signs and a verifier checks.
+// It excludes Signature and is deterministic (struct declaration order).
+func (w Witness) SignedBytes() []byte {
+	w.Signature = ""
+	b, _ := json.Marshal(w)
+	return b
+}
+
+// WitnessBindsRun reports whether w is intrinsically bound to the given run
+// nonce and launch-manifest hash. A witness from one run does NOT satisfy this
+// for another run, which is what makes the witness non-replayable. The Task 4
+// verify command uses this after checking the signature.
+func WitnessBindsRun(w Witness, nonce, manifestHash string) bool {
+	return w.RunNonce == nonce && w.LaunchManifestHash == manifestHash
+}

--- a/internal/playground/witness.go
+++ b/internal/playground/witness.go
@@ -36,6 +36,16 @@ var (
 	// it to a specific manifest hash, so re-opening would mix observations
 	// across different launch manifests. Use a fresh nonce per run.
 	ErrRunSealed = errors.New("playground: run already sealed, use a fresh nonce")
+
+	// ErrRedCaseRunNotOpen is returned when AttachRedCase targets a nonce
+	// that was never opened or has already been sealed.
+	ErrRedCaseRunNotOpen = errors.New("playground: cannot attach red-case to unopened or sealed run")
+
+	// ErrRedCaseNotDetected is returned by RunRedCaseCalibration when the
+	// collector does not observe the canary during calibration. This is the
+	// fail-closed guarantee: a calibration that does not go red is an error,
+	// never a green-looking result.
+	ErrRedCaseNotDetected = errors.New("playground: red-case calibration did not detect the canary (observed=0)")
 )
 
 // canonicalLaunchManifestBytes marshals a manifest deterministically with the
@@ -79,14 +89,23 @@ func (lm LaunchManifest) Hash() string {
 	return hex.EncodeToString(sum[:])
 }
 
-// RedCaseResult is a forward-declared stub for Task 3's red-case proof. The
-// collector going "red" (observing the canary) under a deliberately-misconfigured
-// or attacker control run proves the witness is not a rubber stamp. Task 3 fills
-// in the production use; Task 2 only carries it through the Witness.
+// RedCaseResult is the verifiable proof that a red-case calibration was
+// performed: the collector was run WITHOUT Pipelock (canary posted directly),
+// and it DID observe the canary. This proves the collector build is not a
+// rubber stamp that always reports "0 observed." The result is embedded and
+// SIGNED into the real (green) witness, so an offline verifier can require
+// proof that this specific collector binary actually detects the canary.
+//
+// Fields are chosen so the offline verifier (Task 4) can confirm:
+//   - WitnessWentRed + ObservedCount: the calibration run detected the canary.
+//   - CollectorPubKey: the same collector key signed both the red and green witnesses.
+//   - RedWitnessDigest: a real signed RED witness existed (sha256 of its SignedBytes).
 type RedCaseResult struct {
-	WitnessWentRed bool      `json:"witness_went_red"`
-	ObservedCount  int       `json:"observed_count"`
-	At             time.Time `json:"at"`
+	WitnessWentRed   bool      `json:"witness_went_red"`
+	ObservedCount    int       `json:"observed_count"`
+	At               time.Time `json:"at"`
+	CollectorPubKey  string    `json:"collector_pubkey"`   // hex; MUST equal the green witness's collector key
+	RedWitnessDigest string    `json:"red_witness_digest"` // sha256 hex of the signed RED witness's SignedBytes()
 }
 
 // Witness is the collector's signed, drain-sealed attestation for one run. It is

--- a/internal/playground/witness_test.go
+++ b/internal/playground/witness_test.go
@@ -95,11 +95,17 @@ func TestWitness_NotReplayableAcrossRuns(t *testing.T) {
 	if err := c.OpenRun("N1", "hashA"); err != nil {
 		t.Fatalf("OpenRun N1: %v", err)
 	}
-	w1, _ := c.SealAndSign("N1", colPriv, 100*time.Millisecond)
+	w1, err := c.SealAndSign("N1", colPriv, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("SealAndSign N1: %v", err)
+	}
 	if err := c.OpenRun("N2", "hashB"); err != nil {
 		t.Fatalf("OpenRun N2: %v", err)
 	}
-	w2, _ := c.SealAndSign("N2", colPriv, 100*time.Millisecond)
+	w2, err := c.SealAndSign("N2", colPriv, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("SealAndSign N2: %v", err)
+	}
 	// a witness is intrinsically bound to its run; cross-use must be detectable
 	if w1.RunNonce == w2.RunNonce || w1.LaunchManifestHash == w2.LaunchManifestHash {
 		t.Fatal("each witness must carry its own run binding")
@@ -314,5 +320,15 @@ func TestWitness_OpenRun_RefuseReopenSealed(t *testing.T) {
 	// Attempt to re-open N1 under a different manifest hash.
 	if openErr := c.OpenRun("N1", "hashB"); !errors.Is(openErr, ErrRunSealed) {
 		t.Fatalf("re-opening sealed nonce must return ErrRunSealed, got %v", openErr)
+	}
+}
+
+func TestWitness_OpenRun_RefusesManifestRebindBeforeSeal(t *testing.T) {
+	c := NewCollector("aws_canary", canaryValueForTest)
+	if err := c.OpenRun("N1", "hashA"); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+	if err := c.OpenRun("N1", "hashB"); !errors.Is(err, ErrRunAlreadyOpen) {
+		t.Fatalf("re-opening active nonce must return ErrRunAlreadyOpen, got %v", err)
 	}
 }

--- a/internal/playground/witness_test.go
+++ b/internal/playground/witness_test.go
@@ -1,0 +1,318 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// canaryValueForTest builds the synthetic canary at runtime to satisfy gosec
+// G101 (no hard-coded credential string literal in source).
+const canaryValueForTest = "AKIA" + "IOSFODNN7EXAMPLE"
+
+// genKey returns a fresh ed25519 keypair, failing the test on error.
+func genKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("genKey: %v", err)
+	}
+	return pub, priv
+}
+
+// hexEnc hex-encodes a byte slice.
+func hexEnc(b []byte) string { return hex.EncodeToString(b) }
+
+// signLaunchManifest signs a LaunchManifest with the orchestrator key using the
+// production helper, returning the signed copy.
+func signLaunchManifest(t *testing.T, priv ed25519.PrivateKey, lm LaunchManifest) LaunchManifest {
+	t.Helper()
+	return SignLaunchManifest(priv, lm)
+}
+
+// ed25519Verify verifies a hex-encoded signature over msg under pub.
+func ed25519Verify(pub ed25519.PublicKey, msg []byte, sigHex string) bool {
+	sig, err := hex.DecodeString(sigHex)
+	if err != nil {
+		return false
+	}
+	return ed25519.Verify(pub, msg, sig)
+}
+
+func TestWitness_SignedAfterDrain_BindsManifest(t *testing.T) {
+	orchPub, orchPriv := genKey(t)
+	colPub, colPriv := genKey(t)
+	pipePub, _ := genKey(t)
+	lm := signLaunchManifest(t, orchPriv, LaunchManifest{
+		RunNonce: "N1", ScenarioID: "exfil-canary", CanaryID: "aws_canary",
+		PipelockPubKey: hexEnc(pipePub), CollectorPubKey: hexEnc(colPub), TargetHost: "exfil.target.test",
+	})
+	c := NewCollector("aws_canary", canaryValueForTest)
+	if err := c.OpenRun("N1", lm.Hash()); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+	// no exfil arrives
+	w, err := c.SealAndSign("N1", colPriv, 200*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w.ObservedCount != 0 || w.RunNonce != "N1" || w.LaunchManifestHash != lm.Hash() {
+		t.Fatalf("witness must bind nonce+manifest and report 0 observed: %+v", w)
+	}
+	if w.RunClosedAt.IsZero() {
+		t.Fatal("witness must record RunClosedAt after drain")
+	}
+	if !ed25519Verify(colPub, w.SignedBytes(), w.Signature) {
+		t.Fatal("witness signature must verify under the collector key")
+	}
+	_ = orchPub
+}
+
+func TestWitness_CannotSealWithoutDrainWindow(t *testing.T) {
+	_, colPriv := genKey(t)
+	c := NewCollector("aws_canary", canaryValueForTest)
+	if err := c.OpenRun("N1", "deadbeef"); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+	if _, err := c.SealAndSign("N1", colPriv, 0); err == nil {
+		t.Fatal("must refuse to seal a final witness without a real drain window (cannot prove the listener drained)")
+	}
+}
+
+func TestWitness_NotReplayableAcrossRuns(t *testing.T) {
+	_, colPriv := genKey(t)
+	c := NewCollector("aws_canary", canaryValueForTest)
+	if err := c.OpenRun("N1", "hashA"); err != nil {
+		t.Fatalf("OpenRun N1: %v", err)
+	}
+	w1, _ := c.SealAndSign("N1", colPriv, 100*time.Millisecond)
+	if err := c.OpenRun("N2", "hashB"); err != nil {
+		t.Fatalf("OpenRun N2: %v", err)
+	}
+	w2, _ := c.SealAndSign("N2", colPriv, 100*time.Millisecond)
+	// a witness is intrinsically bound to its run; cross-use must be detectable
+	if w1.RunNonce == w2.RunNonce || w1.LaunchManifestHash == w2.LaunchManifestHash {
+		t.Fatal("each witness must carry its own run binding")
+	}
+	if WitnessBindsRun(w1, "N2", "hashB") {
+		t.Fatal("w1 must NOT validate against run N2/hashB")
+	}
+	if !WitnessBindsRun(w1, "N1", "hashA") {
+		t.Fatal("w1 must validate against its own run")
+	}
+}
+
+func TestWitness_ObservedWhenCanaryArrivesBeforeSeal(t *testing.T) {
+	_, colPriv := genKey(t)
+	c := NewCollector("aws_canary", canaryValueForTest)
+	if err := c.OpenRun("N1", "hashA"); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	// POST the canary value through the collector Handler under run N1.
+	body := strings.NewReader("payload=" + canaryValueForTest)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/?run=N1", body)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post canary: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	w, err := c.SealAndSign("N1", colPriv, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if w.ObservedCount != 1 {
+		t.Fatalf("expected ObservedCount==1 after canary arrival, got %d", w.ObservedCount)
+	}
+	if w.TotalCount != 1 {
+		t.Fatalf("expected TotalCount==1, got %d", w.TotalCount)
+	}
+
+	// The witness must never embed the raw canary value.
+	if strings.Contains(string(w.SignedBytes()), canaryValueForTest) {
+		t.Fatal("witness signed bytes must NOT contain the raw canary value")
+	}
+}
+
+func TestWitness_VerifyLaunchManifest(t *testing.T) {
+	orchPub, orchPriv := genKey(t)
+	otherPub, _ := genKey(t)
+	lm := SignLaunchManifest(orchPriv, LaunchManifest{
+		RunNonce: "N1", ScenarioID: "exfil-canary", CanaryID: "aws_canary",
+	})
+	if !VerifyLaunchManifest(orchPub, lm) {
+		t.Fatal("signed manifest must verify under the orchestrator key")
+	}
+	if VerifyLaunchManifest(otherPub, lm) {
+		t.Fatal("signed manifest must NOT verify under an unrelated key")
+	}
+	// Tampering with a field after signing must break verification.
+	tampered := lm
+	tampered.TargetHost = "attacker.test"
+	if VerifyLaunchManifest(orchPub, tampered) {
+		t.Fatal("tampered manifest must fail verification")
+	}
+	// Hash must include the signature: an unsigned copy hashes differently.
+	unsigned := lm
+	unsigned.Signature = ""
+	if unsigned.Hash() == lm.Hash() {
+		t.Fatal("Hash must include the signature field")
+	}
+}
+
+func TestWitness_SealRejectsUnopenedRun(t *testing.T) {
+	_, colPriv := genKey(t)
+	c := NewCollector("aws_canary", canaryValueForTest)
+	if _, err := c.SealAndSign("never-opened", colPriv, 50*time.Millisecond); err == nil {
+		t.Fatal("sealing a run that was never opened must error")
+	}
+}
+
+func TestWitness_NoCountAfterSeal(t *testing.T) {
+	_, colPriv := genKey(t)
+	c := NewCollector("aws_canary", canaryValueForTest)
+	if err := c.OpenRun("N1", "hashA"); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	w, err := c.SealAndSign("N1", colPriv, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if w.ObservedCount != 0 {
+		t.Fatalf("pre-seal observed should be 0, got %d", w.ObservedCount)
+	}
+
+	// After seal the run is no longer accepting: a late canary must NOT be counted.
+	body := strings.NewReader("payload=" + canaryValueForTest)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/?run=N1", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("late post: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if got := c.ObservedCount("N1"); got != 0 {
+		t.Fatalf("late canary after seal must not be counted, observed=%d", got)
+	}
+}
+
+func TestWitness_DrainTimeout_FailsClosed_NoSignedWitness(t *testing.T) {
+	// REGRESSION: a slow in-flight request that hasn't finished processing
+	// must cause SealAndSign to return ErrDrainIncomplete, NOT produce a
+	// signed witness with stale "0 observed" counts. The timeout branch must
+	// fail closed.
+	//
+	// Mechanism: the collector's ingestHook blocks the handler between
+	// inFlight.Add(1) and scanRequest, giving us a deterministic window
+	// where a request is in-flight but not yet counted. NO time.Sleep.
+	_, colPriv := genKey(t)
+	c := NewCollector("aws_canary", canaryValueForTest)
+
+	handlerEntered := make(chan struct{})
+	handlerRelease := make(chan struct{})
+	c.ingestHook = func() {
+		close(handlerEntered)
+		<-handlerRelease
+	}
+
+	if err := c.OpenRun("N1", "hashA"); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	// Fire the canary POST. The handler will register inFlight.Add(1) and
+	// then block on the hook before scanning.
+	var postWg sync.WaitGroup
+	postWg.Add(1)
+	go func() {
+		defer postWg.Done()
+		body := strings.NewReader("payload=" + canaryValueForTest)
+		req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/?run=N1", body)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	// Wait until the handler is in-flight (past Add(1), blocked on hook).
+	<-handlerEntered
+
+	// SealAndSign with a very short drain: the in-flight request will NOT
+	// complete before the deadline, so this MUST return ErrDrainIncomplete.
+	w, err := c.SealAndSign("N1", colPriv, 10*time.Millisecond)
+	if !errors.Is(err, ErrDrainIncomplete) {
+		t.Fatalf("expected ErrDrainIncomplete, got err=%v witness=%+v", err, w)
+	}
+	// The zero-value witness must NOT carry a valid signature.
+	if w.Signature != "" {
+		t.Fatal("drain-timeout must not produce a signed witness")
+	}
+
+	// Release the handler so the request completes and the test cleans up.
+	close(handlerRelease)
+	postWg.Wait()
+
+	// The canary DID arrive (the handler finishes scanning after release),
+	// so the real observed count should be 1. But no signed witness with "0"
+	// was ever produced -- that is the invariant.
+	if got := c.ObservedCount("N1"); got != 1 {
+		t.Fatalf("after release, real observed count should be 1, got %d", got)
+	}
+}
+
+func TestWitness_OpenRun_RefuseReopenSealed(t *testing.T) {
+	// REGRESSION: re-opening a sealed nonce under a new manifest hash must be
+	// refused. Otherwise the new witness would carry stale counts from the
+	// prior run under the old manifest, producing a WitnessBindsRun-valid
+	// attestation that lies about what was observed under which policy.
+	_, colPriv := genKey(t)
+	c := NewCollector("aws_canary", canaryValueForTest)
+
+	// Open, post a canary, seal under hashA.
+	if err := c.OpenRun("N1", "hashA"); err != nil {
+		t.Fatalf("OpenRun: %v", err)
+	}
+
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	body := strings.NewReader("payload=" + canaryValueForTest)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/?run=N1", body)
+	resp, _ := http.DefaultClient.Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	_, err := c.SealAndSign("N1", colPriv, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("first seal: %v", err)
+	}
+
+	// Attempt to re-open N1 under a different manifest hash.
+	if openErr := c.OpenRun("N1", "hashB"); !errors.Is(openErr, ErrRunSealed) {
+		t.Fatalf("re-opening sealed nonce must return ErrRunSealed, got %v", openErr)
+	}
+}


### PR DESCRIPTION
## What changed

Adds `pipelock-playground-demo`, a local demonstration engine that drives a deterministic toy agent through a real Pipelock proxy and produces an offline-verifiable evidence bundle. It is the live counterpart to the existing replay-capture rig: instead of pre-recording scenarios, it runs one live and lets a viewer verify the result afterward, with the Pipelock process already stopped.

New `internal/playground` package plus three command binaries (`pipelock-playground-demo`, `pipelock-playground-toyagent`, `pipelock-playground-webtool`) and an operator guide (`docs/guides/playground-demo.md`). This is demo/evidence tooling, not part of the production firewall.

### What it does

A deterministic toy agent runs as a separate process with a minimal, synthetic environment and uses a small web tool to make HTTP through the proxy:

1. Allowed action: a safe GET; Pipelock allows it; a signed receipt is recorded.
2. Blocked exfiltration: the agent POSTs an inert, published-example credential value; Pipelock blocks it (body DLP) before the lab collector receives it; a signed receipt is recorded, and a separate signed collector witness independently records that nothing arrived.
3. Direct-egress bypass (contained mode only): the agent attempts raw egress that ignores the proxy; host containment denies it at the kernel.
4. Offline verification: one all-or-nothing command verifies the run after the proxy is stopped.

### Security and honesty model

One offline `verify` command, rooted in a single published orchestrator key. It passes only when all of these hold: the signed launch manifest; the Audit Packet receipt chain (under the manifest-pinned Pipelock key); the collector witness (under the manifest-pinned collector key); the witness-to-run binding; the red-case calibration; and the scenario semantics (collector observed zero, an allow receipt, a body-DLP block receipt, matching scenario/policy). Any single failure exits non-zero. It does not claim `pipelock-verifier audit-packet` covers the witness; that verifier checks the packet and chain only.

The collector witness fails closed. It is sealed only after the listener stops accepting and in-flight requests drain; on an incomplete drain it refuses to sign rather than attest a stale count. A red-case calibration (a Pipelock-off run where the canary reaches the collector) is signed into the witness, so verification can require proof the collector demonstrably detects what it reports as unobserved.

Pipelock holds none of the agent's secrets: it catches the credential class via DLP, not a pre-shared value.

Every on-screen claim carries exactly one evidence class (signed Pipelock decision, signed collector witness, host-observed containment, or unsigned narration) and may not render as a stronger class than it is.

Public-safe by construction: synthetic inputs, reserved `.test` hosts, redact-before-sign, a fail-closed field allowlist and artifact linter over the text artifacts. The canary value lives only in the agent's environment and the request body, never on a command line, in a URL, or on screen.

### Scope and follow-ups

Contained mode's kernel egress block is host/deployment-enforced via `pipelock contain`; its end-to-end test is privilege-gated and skips off-host rather than faking a pass. The binary-enforced controls (proxy mediation, signed receipts and witness, offline verify) run without it.

A web view of this engine and a constrained public slice are tracked as separate follow-up work, not in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a playground demo toolkit with `run`, `reset`, `verify`, and `fallback`, including deterministic evidence generation and offline verification.
  * Added new demo binaries: a toy agent CLI and a lightweight HTTP GET/POST web utility.
  * Added containment diagnostics plus an evidence “mediator timeline” renderer for clearer demo output.
* **Documentation**
  * Added a playground demo guide covering the workflow, verification, and safety model.
* **Tests / Chores**
  * Added comprehensive integration/unit tests and updated ignore/lint configuration for the playground tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->