### PR TITLE
feat(playground): split-proof contained mode with signed host-containment witness

### DIFF
--- a/cmd/pipelock-playground-demo/main.go
+++ b/cmd/pipelock-playground-demo/main.go
@@ -76,9 +76,10 @@ Exit 0 = run verified successfully. Non-zero = verification failed or run error.
 			w := cmd.OutOrStdout()
 			if contained {
 				// Register the real (host-only) containment hook. Its Setup
-				// requires root + an installed `pipelock contain`; the bypass
-				// beat itself runs as the contained agent user and fails loudly
-				// rather than silently running uncontained.
+				// requires root + an installed `pipelock contain`; the
+				// host-containment witness probe runs as the contained agent
+				// user and fails loudly rather than silently running
+				// uncontained.
 				playground.SetContainmentHook(playground.NewRealContainmentHook(""))
 			}
 			rep, err := playground.RunDemo(cmd.Context(), w, playground.DemoOpts{

--- a/cmd/pipelock-playground-toyagent/main.go
+++ b/cmd/pipelock-playground-toyagent/main.go
@@ -5,14 +5,18 @@
 // deterministic scripted agent used in the Pipelock Playground live demo.
 //
 // The agent holds a synthetic canary secret in its environment
-// (PLAYGROUND_CANARY_VALUE) and executes three scripted steps that demonstrate
-// what Pipelock mediates:
+// (PLAYGROUND_CANARY_VALUE) and executes scripted steps that demonstrate what
+// Pipelock mediates:
 //
 //   - step 1: a safe, allowed GET request via the web tool
 //   - step 2: an attempted exfiltration POST (the canary goes in the request
 //     body via the web tool — Pipelock is meant to catch it)
-//   - step 3: a raw direct-egress bypass attempt that skips the proxy entirely
-//     (kernel containment blocks this in a real contained deployment)
+//   - step 3: a raw direct-egress bypass attempt for manual experiments
+//
+// In split-proof contained demo runs, kernel containment is proven by probe
+// mode (--probe-targets) after the orchestrator drops this binary to the
+// contained agent uid. The live demo does not depend on step 3 narration for
+// the containment claim.
 //
 // Security property: the canary VALUE is read from env (PLAYGROUND_CANARY_VALUE)
 // by the web tool subprocess. It NEVER appears in the agent's stdout, in any
@@ -21,6 +25,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -34,6 +39,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/playground"
 )
 
 // agentConfig holds all parameters for a runAgent invocation.  The canary
@@ -65,6 +71,14 @@ type agentConfig struct {
 	DryRun bool
 	// ExpectBypassBlocked makes step 3 fail if the direct-egress request connects.
 	ExpectBypassBlocked bool
+	// ProbeTargets, when non-empty, switches the agent into probe mode: it
+	// performs a direct (proxy-less) TCP probe of each comma-separated
+	// host:port target and emits a JSON array of probe results to stdout, then
+	// exits. This is the uid-scoped egress probe used to build the signed
+	// host-containment witness: the orchestrator spawns this binary dropped to
+	// the contained agent user so the probes run from the contained network
+	// position. No other steps run in probe mode.
+	ProbeTargets string
 }
 
 func main() {
@@ -84,11 +98,14 @@ func newRootCmd() *cobra.Command {
 demonstrates Pipelock's mediation boundary in the Pipelock Playground.
 
 The agent holds a synthetic canary secret in env (PLAYGROUND_CANARY_VALUE) and
-drives three scripted steps through the pipelock-playground-webtool:
+drives mediated steps through the pipelock-playground-webtool:
 
   step 1 — safe allowed GET (should be permitted)
   step 2 — exfiltration POST of the canary (Pipelock should block this)
-  step 3 — raw direct-egress bypass attempt (kernel containment blocks this)
+
+It also has a manual step 3 raw direct-egress bypass attempt, and a structured
+--probe-targets mode used by the split-proof contained demo to build the signed
+host-containment witness from the contained agent uid.
 
 The canary VALUE is read from env by the web tool; it never appears in the
 agent's stdout, argv, or any URL.`,
@@ -96,6 +113,9 @@ agent's stdout, argv, or any URL.`,
 		SilenceErrors: false,
 		Version:       cliutil.Version,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if cfg.ProbeTargets != "" {
+				return runProbe(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg.ProbeTargets)
+			}
 			return runAgent(cmd.Context(), cmd.OutOrStdout(), cfg)
 		},
 	}
@@ -110,8 +130,39 @@ agent's stdout, argv, or any URL.`,
 	root.Flags().StringVar(&cfg.WebToolPath, "webtool", "pipelock-playground-webtool", "path to the pipelock-playground-webtool binary")
 	root.Flags().BoolVar(&cfg.DryRun, "dry-run", false, "narrate only, do not invoke the web tool or make network calls")
 	root.Flags().BoolVar(&cfg.ExpectBypassBlocked, "expect-bypass-blocked", false, "fail if the direct-egress bypass connects")
+	root.Flags().StringVar(&cfg.ProbeTargets, "probe-targets", "", "comma-separated host:port list to direct-probe; emits JSON results and exits (used to build the host-containment witness)")
 
 	return root
+}
+
+// runProbe performs a direct (proxy-less) TCP probe of each comma-separated
+// host:port target and writes a JSON array of playground.ProbeResult to out.
+// Narration goes to errOut so stdout carries ONLY the JSON, which the
+// orchestrator parses. It always exits 0 (a blocked target is data, not an
+// error); a malformed target list is the only failure.
+func runProbe(ctx context.Context, out, errOut io.Writer, targetsCSV string) error {
+	targets := make([]string, 0)
+	for _, t := range strings.Split(targetsCSV, ",") {
+		if trimmed := strings.TrimSpace(t); trimmed != "" {
+			targets = append(targets, trimmed)
+		}
+	}
+	if len(targets) == 0 {
+		return errors.New("probe-targets is empty after trimming")
+	}
+
+	_, _ = fmt.Fprintf(errOut, "[agent] probing %d direct-egress target(s) from this network position\n", len(targets))
+
+	results := make([]playground.ProbeResult, 0, len(targets))
+	for _, t := range targets {
+		results = append(results, playground.ProbeDirectEgress(ctx, t))
+	}
+
+	enc := json.NewEncoder(out)
+	if err := enc.Encode(results); err != nil {
+		return fmt.Errorf("encode probe results: %w", err)
+	}
+	return nil
 }
 
 // narrator is a helper that writes step narration to out with a consistent prefix.

--- a/cmd/pipelock-playground-toyagent/probe_test.go
+++ b/cmd/pipelock-playground-toyagent/probe_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+func TestRunProbe_OpenAndBlocked(t *testing.T) {
+	t.Parallel()
+
+	// An open loopback listener (reachable) ...
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			c, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	openTarget := ln.Addr().String()
+
+	// ... and a port nothing listens on (connection refused -> blocked).
+	const closedTarget = "127.0.0.1:1"
+
+	var out, errOut bytes.Buffer
+	if err := runProbe(t.Context(), &out, &errOut, openTarget+", "+closedTarget); err != nil {
+		t.Fatalf("runProbe: %v", err)
+	}
+
+	// stdout must carry ONLY the JSON results (no narration).
+	if strings.Contains(out.String(), "[agent]") {
+		t.Errorf("stdout leaked narration: %q", out.String())
+	}
+
+	var results []playground.ProbeResult
+	if err := json.Unmarshal(out.Bytes(), &results); err != nil {
+		t.Fatalf("parse probe JSON %q: %v", out.String(), err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	if results[0].Target != openTarget || !results[0].Open {
+		t.Errorf("open target: got %+v, want Open=true", results[0])
+	}
+	if results[1].Target != closedTarget || results[1].Open {
+		t.Errorf("closed target: got %+v, want Open=false", results[1])
+	}
+}
+
+func TestRunProbe_EmptyTargets(t *testing.T) {
+	t.Parallel()
+	var out, errOut bytes.Buffer
+	if err := runProbe(t.Context(), &out, &errOut, "  , ,"); err == nil {
+		t.Fatal("expected error for empty target list")
+	}
+}

--- a/cmd/pipelock-playground-toyagent/probe_test.go
+++ b/cmd/pipelock-playground-toyagent/probe_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/playground"
 )
 
-func TestRunProbe_OpenAndBlocked(t *testing.T) {
+func TestRunProbe_OpenAndRefused(t *testing.T) {
 	t.Parallel()
 
 	// An open loopback listener (reachable) ...
@@ -33,7 +33,8 @@ func TestRunProbe_OpenAndBlocked(t *testing.T) {
 	}()
 	openTarget := ln.Addr().String()
 
-	// ... and a port nothing listens on (connection refused -> blocked).
+	// ... and a port nothing listens on. Connection refused is reachable, not
+	// kernel containment.
 	const closedTarget = "127.0.0.1:1"
 
 	var out, errOut bytes.Buffer
@@ -56,8 +57,11 @@ func TestRunProbe_OpenAndBlocked(t *testing.T) {
 	if results[0].Target != openTarget || !results[0].Open {
 		t.Errorf("open target: got %+v, want Open=true", results[0])
 	}
-	if results[1].Target != closedTarget || results[1].Open {
-		t.Errorf("closed target: got %+v, want Open=false", results[1])
+	if results[0].Blocked {
+		t.Errorf("open target: got Blocked=true")
+	}
+	if results[1].Target != closedTarget || results[1].Open || results[1].Blocked {
+		t.Errorf("closed target: got %+v, want Open=false Blocked=false", results[1])
 	}
 }
 

--- a/docs/guides/playground-demo.md
+++ b/docs/guides/playground-demo.md
@@ -86,7 +86,7 @@ a separate probe phase drops to the `pipelock-agent` uid to build the signed hos
 witness. This split is deliberate: the proxy's allow/block decision does not depend on the
 agent's uid, and on a host with global owner-match containment the contained user cannot reach
 the demo's ephemeral lab proxy at all, so running the mediated steps contained would simply
-time out. Off a prepared host the contained run fails loudly — it never silently falls back to
+time out. Off a prepared host, the contained run fails loudly — it never silently falls back to
 uncontained while claiming containment.
 
 ## Verify it yourself

--- a/docs/guides/playground-demo.md
+++ b/docs/guides/playground-demo.md
@@ -24,8 +24,10 @@ request body, mediates each action, and signs each decision:
    (dropped to the `pipelock-agent` uid) against a host-local control target and the real
    direct-egress suite (cloud metadata, RFC-1918, public DNS/HTTPS). The result is a **signed
    host-containment witness**. Its honesty rests on a **differential**: the same control target
-   is reachable for the operator but blocked for the contained agent — so a block can only be
-   attributed to the kernel owner-match rule, never to an unroutable or down target.
+   is reachable for the operator but explicitly blocked for the contained agent, which isolates
+   the kernel owner-match rule for the host-local control proof. The direct-egress suite must
+   also be explicitly blocked from the contained position; reachable-but-closed responses such
+   as TCP connection refusal do not count as containment.
 4. **Offline verification** — the run's evidence verifies with one command after the Pipelock
    process is stopped.
 
@@ -108,7 +110,7 @@ For **contained** runs (the signed manifest records this), three additional chec
 and must also pass: the host-containment witness is signed by the orchestrator key; it binds
 this run's nonce and manifest hash; and it proves enforcement — the operator-vs-agent
 differential holds, the exact direct-egress suite was probed from the contained position, and
-every route in that suite was blocked. A contained run therefore reports **11** checks; an
+every route in that suite was explicitly blocked. A contained run therefore reports **11** checks; an
 uncontained run reports 8. The `Contained` flag is covered by the manifest signature, so an
 attacker cannot strip the containment requirement without invalidating the manifest.
 

--- a/docs/guides/playground-demo.md
+++ b/docs/guides/playground-demo.md
@@ -19,8 +19,13 @@ request body, mediates each action, and signs each decision:
 2. **Blocked exfiltration** — the agent tries to send the canary to a lab collector; Pipelock
    blocks it before the collector receives it; a signed receipt is recorded, and a separate
    **signed collector witness** independently records that the canary did not arrive.
-3. **Direct-egress bypass** *(contained mode only)* — the agent tries raw egress that ignores
-   the proxy; host containment denies it at the kernel.
+3. **Kernel containment** *(contained mode only)* — proven separately from the mediated
+   decisions (a "split proof"). A probe runs from the **contained agent's network position**
+   (dropped to the `pipelock-agent` uid) against a host-local control target and the real
+   direct-egress suite (cloud metadata, RFC-1918, public DNS/HTTPS). The result is a **signed
+   host-containment witness**. Its honesty rests on a **differential**: the same control target
+   is reachable for the operator but blocked for the contained agent — so a block can only be
+   attributed to the kernel owner-match rule, never to an unroutable or down target.
 4. **Offline verification** — the run's evidence verifies with one command after the Pipelock
    process is stopped.
 
@@ -37,13 +42,17 @@ as a stronger class than it is:
 |---|---|---|
 | `pipelock_decision` | an allow/block decision in the receipt chain | the Pipelock mediator key |
 | `collector_witness` | the lab collector's target-side observation | the collector key (separate) |
-| `host_containment` | the direct-egress bypass denied by the kernel | not a receipt — operational result |
+| `host_containment` | the contained agent's direct egress denied by the kernel | the orchestrator key (host-containment witness) |
 | `narration` | the agent's printed intent | unsigned playback |
 
-The proxy mediation and the signed receipts/witness are **binary-enforced**. The direct-egress
-block (contained mode) is **host/deployment-enforced** via `pipelock contain` (kernel nftables);
-it is not a property of this tool's binary and is only present when the agent is actually
-contained.
+The proxy mediation and the signed receipts/witness are **binary-enforced**. The kernel
+containment (contained mode) is **host/deployment-enforced** via `pipelock contain` (kernel
+nftables) — it is not a property of this tool's binary, only present when the agent is actually
+contained. The tool's contribution is to *attest* that property for a specific run: the signed,
+offline-verifiable host-containment witness records what was probed from the contained position
+and proves the operator-vs-agent differential. Verifying the witness confirms the attestation;
+the underlying egress block remains host-enforced, not something this binary can guarantee on its
+own.
 
 ## Run it
 
@@ -59,8 +68,8 @@ pipelock-playground-demo run --run-dir ./demo-run --scenario secret-exfil-body-b
 
 This boots a real Pipelock proxy + lab targets on loopback, drives the toy agent through the
 proxy, renders the evidence-class-labeled mediator timeline, assembles the Audit Packet, and
-verifies it. The direct-egress bypass beat is **skipped** here: without containment there is no
-kernel boundary to demonstrate, and the tool says so rather than implying one.
+verifies it. No host-containment witness is produced here: without containment there is no
+kernel boundary to attest, and the tool says so rather than implying one.
 
 ### Contained (the real demo — requires a prepared host)
 
@@ -69,10 +78,14 @@ sudo pipelock-playground-demo run --contained --run-dir ./demo-run --scenario se
 ```
 
 Contained mode requires root, the `pipelock-agent` OS user, and a host where
-`pipelock contain install` has been run. The bypass beat is executed by the toy-agent process
-after dropping to that contained user; if the direct-egress request connects, the run aborts
-rather than claim a containment that is not in effect. Off such a host the command fails loudly
-— it never silently falls back to uncontained while claiming contained.
+`pipelock contain install` has been run. Under the **split-proof** model the mediated steps
+(allow, block) run as the operator through the lab proxy — exactly as in uncontained mode — and
+a separate probe phase drops to the `pipelock-agent` uid to build the signed host-containment
+witness. This split is deliberate: the proxy's allow/block decision does not depend on the
+agent's uid, and on a host with global owner-match containment the contained user cannot reach
+the demo's ephemeral lab proxy at all, so running the mediated steps contained would simply
+time out. Off a prepared host the contained run fails loudly — it never silently falls back to
+uncontained while claiming containment.
 
 ## Verify it yourself
 
@@ -90,6 +103,14 @@ the collector key the manifest pins; the witness binds this run's nonce and mani
 collector observed zero requests for the blocked exfil run; the packet contains the expected
 allow and `body_dlp` block receipts; and the witness carries a genuine red-case calibration
 backed by a signed `red-witness.json` artifact. Any single failure exits non-zero.
+
+For **contained** runs (the signed manifest records this), three additional checks are required
+and must also pass: the host-containment witness is signed by the orchestrator key; it binds
+this run's nonce and manifest hash; and it proves enforcement — the operator-vs-agent
+differential holds, the exact direct-egress suite was probed from the contained position, and
+every route in that suite was blocked. A contained run therefore reports **11** checks; an
+uncontained run reports 8. The `Contained` flag is covered by the manifest signature, so an
+attacker cannot strip the containment requirement without invalidating the manifest.
 
 The receipt chain alone is also verifiable with the shipped `pipelock-verifier audit-packet`
 against `./demo-run/packet` — but note that verifier checks the packet and chain only, not the

--- a/internal/playground/containment.go
+++ b/internal/playground/containment.go
@@ -19,14 +19,17 @@ import (
 // classify it as Open (reachable) or Blocked (refused / timeout / no route).
 // --------------------------------------------------------------------------
 
-// ProbeResult holds the outcome of a single direct-egress probe.
+// ProbeResult holds the outcome of a single direct-egress probe. It is
+// serialized into the signed HostContainmentWitness, so its JSON shape is part
+// of the evidence model: the field tags must stay stable for SignedBytes
+// determinism.
 type ProbeResult struct {
 	// Target is the host:port that was probed.
-	Target string
+	Target string `json:"target"`
 	// Open is true when the probe connected successfully (egress is NOT blocked).
-	Open bool
+	Open bool `json:"open"`
 	// Detail is a human-readable classification (e.g. "connected", "connection refused").
-	Detail string
+	Detail string `json:"detail"`
 }
 
 // probeTimeout is the per-target TCP dial timeout for egress probes. Short
@@ -123,8 +126,10 @@ type SelfTestResult struct {
 // if EVERY target was blocked. Any single open route means containment is
 // not active (or is incomplete).
 //
-// This function is the per-run gate: in contained mode, the demo calls this
-// BEFORE the bypass beat (step 3) and aborts if AllBlocked is false.
+// This diagnostic helper is useful for checking a target list from the current
+// process's network position. The split-proof live demo's production
+// containment gate is buildHostContainmentWitness, which drops the probe
+// subprocess to the contained agent user before probing.
 func RunContainmentSelfTest(ctx context.Context, targets []string) SelfTestResult {
 	probes := make([]ProbeResult, 0, len(targets))
 	allBlocked := true
@@ -271,19 +276,12 @@ func ContainmentAvailable() bool {
 }
 
 // --------------------------------------------------------------------------
-// Wiring point for RunDemo: where to call RunContainmentSelfTest.
+// Production containment gate.
 //
-// T9's RunDemo uses the actual step 3 toy-agent bypass attempt as the contained
-// egress gate. The older RunContainmentSelfTest helper remains useful for
-// diagnostics, but it runs in the caller's process and is not representative of
-// UID-scoped containment when the caller is root. If a future hook can execute
-// probes as the contained user, it should call:
-//
-//   result := RunContainmentSelfTest(ctx, DirectEgressTargets())
-//   if !result.AllBlocked {
-//       return VerifyReport{}, ErrContainmentSelfTestFailed
-//   }
-//
-// The production path's fail-closed check is the contained toy-agent process
-// running with --expect-bypass-blocked.
+// RunContainmentSelfTest remains a diagnostic helper: it probes from the
+// caller's process, which is not representative of UID-scoped containment when
+// the caller is root. The live demo's production gate is the signed
+// HostContainmentWitness built by LiveRun.buildHostContainmentWitness: that path
+// first proves an operator-vs-agent control differential, then requires the
+// contained agent user to block the exact DirectEgressTargets suite.
 // --------------------------------------------------------------------------

--- a/internal/playground/containment.go
+++ b/internal/playground/containment.go
@@ -11,12 +11,14 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"strings"
 	"time"
 )
 
 // --------------------------------------------------------------------------
 // Egress probe: attempt a direct (no-proxy) TCP connection to a target and
-// classify it as Open (reachable) or Blocked (refused / timeout / no route).
+// classify it as Open (connected), Blocked (kernel/network denial), or
+// ambiguous/reachable failure (for example connection refused).
 // --------------------------------------------------------------------------
 
 // ProbeResult holds the outcome of a single direct-egress probe. It is
@@ -28,6 +30,11 @@ type ProbeResult struct {
 	Target string `json:"target"`
 	// Open is true when the probe connected successfully (egress is NOT blocked).
 	Open bool `json:"open"`
+	// Blocked is true only when the probe failed in a way consistent with a
+	// kernel/network egress denial. Reachable-but-closed targets (connection
+	// refused) are NOT blocked: they prove packets escaped far enough to get a
+	// response.
+	Blocked bool `json:"blocked"`
 	// Detail is a human-readable classification (e.g. "connected", "connection refused").
 	Detail string `json:"detail"`
 }
@@ -40,8 +47,9 @@ const probeTimeout = 2 * time.Second
 const defaultContainedAgentUser = "pipelock-agent"
 
 // ProbeDirectEgress attempts a direct (proxy-less) TCP connection to target
-// (host:port). It classifies the result as Open (connected) or Blocked
-// (refused, timeout, no route, or any other failure). The probe uses an
+// (host:port). It classifies connected targets as Open, timeout/no-route/
+// permission failures as Blocked, and reachable-but-closed or ambiguous
+// failures as neither. The probe uses an
 // explicit nil-Proxy transport so HTTP_PROXY / HTTPS_PROXY env vars are
 // NOT consulted -- this is testing the raw network path, not the mediated one.
 func ProbeDirectEgress(ctx context.Context, target string) ProbeResult {
@@ -52,18 +60,48 @@ func ProbeDirectEgress(ctx context.Context, target string) ProbeResult {
 
 	conn, err := dialer.DialContext(dialCtx, "tcp", target)
 	if err != nil {
+		blocked := isEgressBlockError(err)
 		return ProbeResult{
-			Target: target,
-			Open:   false,
-			Detail: fmt.Sprintf("blocked: %v", err),
+			Target:  target,
+			Open:    false,
+			Blocked: blocked,
+			Detail:  probeErrorDetail(err, blocked),
 		}
 	}
 	_ = conn.Close()
 	return ProbeResult{
-		Target: target,
-		Open:   true,
-		Detail: "connected",
+		Target:  target,
+		Open:    true,
+		Blocked: false,
+		Detail:  "connected",
 	}
+}
+
+func isEgressBlockError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "network is unreachable") ||
+		strings.Contains(msg, "no route to host") ||
+		strings.Contains(msg, "host is down") ||
+		strings.Contains(msg, "operation not permitted") ||
+		strings.Contains(msg, "permission denied") ||
+		strings.Contains(msg, "administratively prohibited")
+}
+
+func probeErrorDetail(err error, blocked bool) string {
+	if strings.Contains(strings.ToLower(err.Error()), "connection refused") {
+		return fmt.Sprintf("reachable: connection refused: %v", err)
+	}
+	if blocked {
+		return fmt.Sprintf("blocked: %v", err)
+	}
+	return fmt.Sprintf("not blocked: %v", err)
 }
 
 // --------------------------------------------------------------------------
@@ -74,18 +112,22 @@ func ProbeDirectEgress(ctx context.Context, target string) ProbeResult {
 // the kernel must block when containment is active. These are the "known-bad"
 // routes that a contained agent should never reach directly.
 //
-// Each entry is a host:port suitable for a TCP dial. The list covers the
-// categories from the playground spec:
+// Each entry is a host:port suitable for a TCP dial. Targets are chosen so that
+// under containment the dial fails with a kernel/network DENIAL (timeout, no
+// route, permission) -- not a client-side malformed-address error. An IPv6
+// link-local literal without a %zone (e.g. [fe80::1]:443) is deliberately NOT
+// used: it fails with EINVAL ("invalid argument") before any packet leaves the
+// host, which is a malformed dial, not an egress block, so it can never honestly
+// prove containment on any host. The list covers the categories from the
+// playground spec:
 //   - Cloud metadata IP (169.254.169.254:80)
 //   - RFC-1918 private IP (10.0.0.1:443)
-//   - IPv6 link-local ([fe80::1]:443)
-//   - Public DNS resolvers (8.8.8.8:53 UDP/TCP, 1.1.1.1:853 DoT)
+//   - Public DNS resolvers (8.8.8.8:53, 1.1.1.1:853 DoT)
 //   - Public HTTPS endpoint (93.184.216.34:443 -- example.com's IP)
 func DirectEgressTargets() []string {
 	return []string{
 		"169.254.169.254:80", // cloud metadata
 		"10.0.0.1:443",       // RFC-1918 private
-		"[fe80::1]:443",      // IPv6 link-local
 		"8.8.8.8:53",         // public DNS (Google)
 		"1.1.1.1:853",        // public DNS over TLS (Cloudflare)
 		"93.184.216.34:443",  // public HTTPS (example.com)
@@ -115,16 +157,17 @@ func MediatedProxyPolicyTargets() []string {
 type SelfTestResult struct {
 	// Probes contains one result per target.
 	Probes []ProbeResult
-	// AllBlocked is true ONLY when every single known-bad route was blocked.
-	// This is the fail-closed gate: any open route -> AllBlocked=false ->
-	// contained demo must abort.
+	// AllBlocked is true ONLY when every single known-bad route was explicitly
+	// classified as blocked. Any open, refused, or ambiguous route means
+	// containment is not proven and the contained demo must abort.
 	AllBlocked bool
 }
 
 // RunContainmentSelfTest probes every target in the provided list via direct
 // (no-proxy) TCP and returns the aggregate result. AllBlocked is true ONLY
-// if EVERY target was blocked. Any single open route means containment is
-// not active (or is incomplete).
+// if EVERY target failed with an egress-block classification. Any connected
+// route, connection-refused response, or ambiguous failure means containment is
+// not proven.
 //
 // This diagnostic helper is useful for checking a target list from the current
 // process's network position. The split-proof live demo's production
@@ -137,7 +180,7 @@ func RunContainmentSelfTest(ctx context.Context, targets []string) SelfTestResul
 	for _, t := range targets {
 		p := ProbeDirectEgress(ctx, t)
 		probes = append(probes, p)
-		if p.Open {
+		if !p.Blocked {
 			allBlocked = false
 		}
 	}

--- a/internal/playground/containment_test.go
+++ b/internal/playground/containment_test.go
@@ -275,53 +275,23 @@ func TestRealContainmentHook_Teardown_Succeeds(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
-// Contained end-to-end: PRIVILEGE-GATED (host-only, skips in CI)
+// Contained end-to-end: PRIVILEGE-GATED host proof lives in the demo binary
 // --------------------------------------------------------------------------
-
-// requirePrivilegedHost skips the test unless running as root AND
-// containment tooling is available. This is the honest gate: we NEVER
-// fake a pass for contained-mode kernel enforcement.
-func requirePrivilegedHost(t *testing.T) {
-	t.Helper()
-
-	if os.Geteuid() != 0 {
-		t.Skip("SKIPPED: contained end-to-end requires root (euid != 0). " +
-			"Run with sudo on a host where 'pipelock contain install' has been executed. " +
-			"This test verifies kernel-level egress blocking, which CANNOT be faked in CI.")
-	}
-
-	// Check that pipelock contain verify passes.
-	if !playground.ContainmentAvailable() {
-		t.Skip("SKIPPED: 'pipelock contain verify' failed or pipelock not in PATH. " +
-			"Run 'sudo pipelock contain install' first. " +
-			"This test verifies kernel-level egress blocking on a real containment host.")
-	}
-}
-
-func TestContainment_BlocksDirectEgress_HostOnly(t *testing.T) {
-	requirePrivilegedHost(t) // t.Skip if not root / contain unavailable
-
-	// On a properly contained host, EVERY known-bad route must be blocked.
-	targets := playground.DirectEgressTargets()
-	result := playground.RunContainmentSelfTest(t.Context(), targets)
-
-	if !result.AllBlocked {
-		var open []string
-		for _, p := range result.Probes {
-			if p.Open {
-				open = append(open, p.Target)
-			}
-		}
-		t.Fatalf("containment must block ALL direct egress targets, but these were open: %v", open)
-	}
-
-	// Verify every probe was individually classified as blocked.
-	for _, p := range result.Probes {
-		if !p.Blocked {
-			t.Errorf("probe %q must be blocked under containment, got Open=%v Detail=%s", p.Target, p.Open, p.Detail)
-		}
-	}
-}
+//
+// The host-only kernel-containment proof is the DIFFERENTIAL split-proof, not
+// an in-process self-test. Running RunContainmentSelfTest from the (root)
+// operator process is the wrong model: containment drops the contained AGENT
+// to uid 966 and kernel-blocks its egress, while the operator/root deliberately
+// RETAINS egress (the control target). A root-process self-test would therefore
+// fail for the wrong reason on a correctly contained host.
+//
+// The honest privileged proof is built and verified end-to-end by the demo
+// binary (HostContainmentWitness, signed from a uid-966-dropped probe set) and
+// is exercised by:
+//   - TestHostContainmentWitness_Enforced       (DifferentialProven && DirectSuiteProven && AllAgentBlocked)
+//   - TestAllAgentBlocked_HappyAndEmpty          (liverun_internal_test.go)
+//   - TestVerify_Contained_NotEnforced_FailsClosed (containment_verify_test.go)
+//   - `pipelock-playground-demo run --contained` + `... verify` on a real host.
 
 func TestContainment_SelfTestGate_AbortsOnOpenRoutes(t *testing.T) {
 	t.Parallel()

--- a/internal/playground/containment_test.go
+++ b/internal/playground/containment_test.go
@@ -41,31 +41,34 @@ func TestEgressProbe_OpenTarget_ClassifiedOpen(t *testing.T) {
 	if !result.Open {
 		t.Fatalf("probe to an open listener must classify as Open, got: %+v", result)
 	}
+	if result.Blocked {
+		t.Fatalf("probe to an open listener must not classify as Blocked, got: %+v", result)
+	}
 	if result.Target != ln.Addr().String() {
 		t.Fatalf("target mismatch: want %q, got %q", ln.Addr().String(), result.Target)
 	}
 }
 
-func TestEgressProbe_UnroutableTarget_ClassifiedBlocked(t *testing.T) {
+func TestEgressProbe_RefusedTarget_NotBlocked(t *testing.T) {
 	t.Parallel()
 
 	// 127.0.0.1:1 -- port 1 is almost never listening; connection refused is
-	// the expected outcome on loopback.
+	// the expected outcome on loopback. Refused means reachable, not blocked.
 	result := playground.ProbeDirectEgress(t.Context(), "127.0.0.1:1")
-	if result.Open {
-		t.Fatalf("probe to an unroutable/refused target must classify as Blocked, got: %+v", result)
+	if result.Open || result.Blocked {
+		t.Fatalf("probe to a refused target must be Open=false Blocked=false, got: %+v", result)
 	}
 }
 
-func TestEgressProbe_ContextCancelled_ClassifiedBlocked(t *testing.T) {
+func TestEgressProbe_ContextCancelled_NotBlocked(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately
 
 	result := playground.ProbeDirectEgress(ctx, "127.0.0.1:1")
-	if result.Open {
-		t.Fatalf("probe with cancelled context must classify as Blocked, got: %+v", result)
+	if result.Open || result.Blocked {
+		t.Fatalf("probe with cancelled context must be Open=false Blocked=false, got: %+v", result)
 	}
 }
 
@@ -132,10 +135,11 @@ func TestSelfTest_DetectsOpenRoutes_WhenUncontained(t *testing.T) {
 	}
 }
 
-func TestSelfTest_AllBlockedWhenEveryTargetRefused(t *testing.T) {
+func TestSelfTest_RefusedTargetsAreNotBlocked(t *testing.T) {
 	t.Parallel()
 
-	// All targets are definitely-refused loopback ports.
+	// Closed loopback ports are reachable enough to return ECONNREFUSED. That
+	// is not containment: packets left the process and came back with a refusal.
 	targets := []string{
 		"127.0.0.1:1",
 		"127.0.0.1:2",
@@ -143,13 +147,16 @@ func TestSelfTest_AllBlockedWhenEveryTargetRefused(t *testing.T) {
 
 	res := playground.RunContainmentSelfTest(t.Context(), targets)
 
-	if !res.AllBlocked {
-		t.Fatal("when every target is refused, AllBlocked must be true")
+	if res.AllBlocked {
+		t.Fatal("connection-refused targets must NOT prove AllBlocked=true")
 	}
 
 	for _, p := range res.Probes {
 		if p.Open {
 			t.Fatalf("probe %q unexpectedly classified as Open", p.Target)
+		}
+		if p.Blocked {
+			t.Fatalf("probe %q was refused but classified as blocked: %s", p.Target, p.Detail)
 		}
 	}
 }
@@ -201,11 +208,13 @@ func TestDirectEgressTargets_CoversRequiredCategories(t *testing.T) {
 
 	targets := playground.DirectEgressTargets()
 
-	// Check that the required categories are represented.
+	// Check that the required categories are represented. IPv6 link-local is
+	// intentionally NOT a required category: a [fe80::1] literal without a %zone
+	// fails the dial with EINVAL before any packet leaves the host, so it can
+	// never honestly prove an egress block (see DirectEgressTargets doc).
 	categories := map[string]bool{
 		"metadata":    false, // 169.254.169.254
 		"rfc1918":     false, // 10.x.x.x
-		"ipv6":        false, // fe80 or ::
 		"public_dns":  false, // 8.8.8.8 or 1.1.1.1
 		"public_http": false, // any other public IP
 	}
@@ -221,8 +230,6 @@ func TestDirectEgressTargets_CoversRequiredCategories(t *testing.T) {
 			categories["metadata"] = true
 		case len(host) > 3 && host[:3] == "10.":
 			categories["rfc1918"] = true
-		case len(host) >= 4 && (host[:4] == "fe80" || host == "::1"):
-			categories["ipv6"] = true
 		case host == "8.8.8.8" || host == "1.1.1.1":
 			categories["public_dns"] = true
 		case host == "93.184.216.34":
@@ -310,8 +317,8 @@ func TestContainment_BlocksDirectEgress_HostOnly(t *testing.T) {
 
 	// Verify every probe was individually classified as blocked.
 	for _, p := range result.Probes {
-		if p.Open {
-			t.Errorf("probe %q must be blocked under containment, but was Open: %s", p.Target, p.Detail)
+		if !p.Blocked {
+			t.Errorf("probe %q must be blocked under containment, got Open=%v Detail=%s", p.Target, p.Open, p.Detail)
 		}
 	}
 }

--- a/internal/playground/containment_verify_test.go
+++ b/internal/playground/containment_verify_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+const hcwFile = "host-containment-witness.json"
+
+// manifestHash reads the run dir's launch manifest and returns its Hash().
+func manifestHash(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(dir, "launch-manifest.json")))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var lm playground.LaunchManifest
+	if err := json.Unmarshal(data, &lm); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	return lm.Hash()
+}
+
+// writeHCW signs w with orchPriv and overwrites the run dir's witness file.
+func writeHCW(t *testing.T, dir string, orchPriv ed25519.PrivateKey, w playground.HostContainmentWitness) {
+	t.Helper()
+	signed := playground.SignHostContainmentWitness(orchPriv, w)
+	b, err := json.Marshal(signed)
+	if err != nil {
+		t.Fatalf("marshal hcw: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, hcwFile), b, 0o600); err != nil {
+		t.Fatalf("write hcw: %v", err)
+	}
+}
+
+func hasCheck(rep playground.VerifyReport, name string) (bool, bool) {
+	for _, c := range rep.Checks {
+		if c.Name == name {
+			return true, c.OK
+		}
+	}
+	return false, false
+}
+
+func TestVerify_ContainedRun_Passes(t *testing.T) {
+	t.Parallel()
+	dir, orchPubHex, _ := buildRunDir(t, true)
+
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err != nil {
+		t.Fatalf("VerifyRun: %v", err)
+	}
+	if !rep.OK {
+		t.Fatalf("contained run should verify; checks=%+v", rep.Checks)
+	}
+	for _, name := range []string{
+		"host-containment-witness-signature",
+		"host-containment-binds-run",
+		"host-containment-enforced",
+	} {
+		present, ok := hasCheck(rep, name)
+		if !present || !ok {
+			t.Errorf("check %q present=%v ok=%v, want present+ok", name, present, ok)
+		}
+	}
+}
+
+func TestVerify_Contained_MissingWitness_FailsClosed(t *testing.T) {
+	t.Parallel()
+	dir, orchPubHex, _ := buildRunDir(t, true)
+	if err := os.Remove(filepath.Join(dir, hcwFile)); err != nil {
+		t.Fatalf("remove hcw: %v", err)
+	}
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err == nil && rep.OK {
+		t.Fatal("contained run with no host-containment witness must fail closed")
+	}
+}
+
+func TestVerify_Contained_MalformedWitness_FailsClosed(t *testing.T) {
+	t.Parallel()
+	dir, orchPubHex, _ := buildRunDir(t, true)
+	if err := os.WriteFile(filepath.Join(dir, hcwFile), []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("write malformed hcw: %v", err)
+	}
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err == nil && rep.OK {
+		t.Fatal("malformed host-containment witness must fail closed")
+	}
+}
+
+func TestVerify_Contained_TamperedWitnessByte_FailsClosed(t *testing.T) {
+	t.Parallel()
+	dir, orchPubHex, _ := buildRunDir(t, true)
+	flipByteInFile(t, filepath.Join(dir, hcwFile))
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err == nil && rep.OK {
+		t.Fatal("tampered host-containment witness must fail closed")
+	}
+}
+
+func TestVerify_Contained_WitnessBoundToOtherRun_FailsClosed(t *testing.T) {
+	t.Parallel()
+	dir, orchPubHex, orchPriv := buildRunDir(t, true)
+	// Re-sign a witness bound to a DIFFERENT nonce but with the real orch key.
+	w := validHostContainmentWitness("some-other-nonce", manifestHash(t, dir))
+	writeHCW(t, dir, orchPriv, w)
+
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err == nil && rep.OK {
+		t.Fatal("host-containment witness bound to another run must fail closed")
+	}
+	if present, ok := hasCheck(rep, "host-containment-binds-run"); present && ok {
+		t.Error("binding check should not pass for a mismatched nonce")
+	}
+}
+
+func TestVerify_Contained_NotEnforced_FailsClosed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(w playground.HostContainmentWitness) playground.HostContainmentWitness
+	}{
+		{
+			name: "a direct-egress route was open (leak)",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.AgentProbes[0].Open = true
+				return w
+			},
+		},
+		{
+			name: "control agent probe connected (no kernel block)",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.ControlAgentProbe.Open = true
+				return w
+			},
+		},
+		{
+			name: "control operator probe blocked (broken differential)",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.ControlOperatorProbe.Open = false
+				return w
+			},
+		},
+		{
+			name: "direct-egress suite target omitted",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.AgentProbes = w.AgentProbes[:len(w.AgentProbes)-1]
+				return w
+			},
+		},
+		{
+			name: "direct-egress suite target substituted",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.AgentProbes[0].Target = "127.0.0.1:1"
+				return w
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir, orchPubHex, orchPriv := buildRunDir(t, true)
+			w := tc.mutate(validHostContainmentWitness("verify-test-nonce", manifestHash(t, dir)))
+			writeHCW(t, dir, orchPriv, w)
+
+			rep, err := playground.VerifyRun(dir, orchPubHex)
+			if err == nil && rep.OK {
+				t.Fatal("non-enforced host-containment witness must fail closed")
+			}
+			if present, ok := hasCheck(rep, "host-containment-enforced"); present && ok {
+				t.Error("enforced check should not pass")
+			}
+		})
+	}
+}
+
+// TestVerify_Contained_FlagStripAttempt_FailsClosed proves an attacker cannot
+// drop the containment requirement by editing the signed manifest's Contained
+// flag: the edit breaks the manifest signature, so verification fails at step 1.
+func TestVerify_Contained_FlagStripAttempt_FailsClosed(t *testing.T) {
+	t.Parallel()
+	dir, orchPubHex, _ := buildRunDir(t, true)
+
+	// Try to flip Contained:true -> false in the manifest JSON (and delete the
+	// witness as an attacker would when trying to skip the containment checks).
+	mp := filepath.Clean(filepath.Join(dir, "launch-manifest.json"))
+	data, err := os.ReadFile(mp)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	raw["contained"] = false
+	out, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(mp, out, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	_ = os.Remove(filepath.Join(dir, hcwFile))
+
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err == nil && rep.OK {
+		t.Fatal("stripping the signed Contained flag must fail closed")
+	}
+}

--- a/internal/playground/containment_witness.go
+++ b/internal/playground/containment_witness.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"time"
+)
+
+// HostContainmentWitness is the orchestrator-signed attestation that, for one
+// specific run, the host's kernel containment blocked the contained agent
+// (running as AgentUID) from reaching egress targets while the operator could.
+//
+// It is the split-proof counterpart to the collector Witness: where the
+// collector witness attests what the lab collector observed for the MEDIATED
+// path, this witness attests the ENFORCED-direct-egress property. The two are
+// orthogonal and are proven where each is actually enforced -- the proxy
+// scans mediated traffic; the kernel owner-match rule blocks direct egress.
+//
+// The honesty hinges on a DIFFERENTIAL: ControlTarget is a host-local listener
+// that is genuinely reachable absent containment. The operator probe of it must
+// be Open and the contained-agent probe of the SAME target must be Blocked.
+// Because only the source uid differs between the two probes, a block can only
+// be attributed to the kernel owner-match rule -- never to an unroutable or
+// down target (the weakness of probing a single reserved IP).
+//
+// It is signed by the orchestrator key (the run's trust root, the same key that
+// signs the launch manifest) and is intrinsically bound to
+// (RunNonce, LaunchManifestHash) so it cannot be replayed against another run.
+//
+// INVARIANT: no map-typed fields. SignedBytes determinism depends on
+// struct-declaration-order JSON marshaling, which is only stable for structs.
+type HostContainmentWitness struct {
+	RunNonce           string `json:"run_nonce"`
+	LaunchManifestHash string `json:"launch_manifest_hash"`
+
+	AgentUser string `json:"agent_user"`
+	AgentUID  int    `json:"agent_uid"`
+
+	// ControlTarget is the host-local listener used for the differential proof.
+	ControlTarget string `json:"control_target"`
+	// ControlOperatorProbe is the operator's probe of ControlTarget. It MUST be
+	// Open: it proves the probe mechanism can detect a reachable target, so a
+	// "blocked" result elsewhere is meaningful and not a broken probe.
+	ControlOperatorProbe ProbeResult `json:"control_operator_probe"`
+	// ControlAgentProbe is the contained agent's probe of the SAME ControlTarget.
+	// It MUST be blocked (Open=false). Together with ControlOperatorProbe being
+	// Open, this is the differential that isolates the kernel owner-match drop.
+	ControlAgentProbe ProbeResult `json:"control_agent_probe"`
+
+	// AgentProbes are the contained agent's probes of the real direct-egress
+	// target suite (cloud metadata, RFC-1918, public DNS, public HTTPS). Every
+	// one MUST be blocked (Open=false); any open route means containment leaks.
+	AgentProbes []ProbeResult `json:"agent_probes"`
+
+	ProbedAt time.Time `json:"probed_at"`
+
+	Signature string `json:"signature,omitempty"`
+}
+
+// SignedBytes returns the canonical JSON of the witness with the Signature field
+// cleared. These are the exact bytes the orchestrator signs and a verifier
+// checks. Deterministic via struct declaration order (no maps).
+func (w HostContainmentWitness) SignedBytes() []byte {
+	w.Signature = ""
+	b, _ := json.Marshal(w)
+	return b
+}
+
+// DirectSuiteProven reports whether AgentProbes covers the exact
+// DirectEgressTargets suite, in order. This prevents a witness from proving a
+// weaker statement by signing one easy blocked route while omitting the harder
+// categories.
+func (w HostContainmentWitness) DirectSuiteProven() bool {
+	expected := DirectEgressTargets()
+	if len(w.AgentProbes) != len(expected) {
+		return false
+	}
+	for i, target := range expected {
+		if w.AgentProbes[i].Target != target {
+			return false
+		}
+	}
+	return true
+}
+
+// AllAgentBlocked reports whether every contained-agent probe -- the control
+// target probe AND every direct-egress probe present in the witness -- was
+// blocked. It requires at least one real direct-egress probe so an empty suite
+// cannot pass vacuously. Enforced additionally requires DirectSuiteProven.
+func (w HostContainmentWitness) AllAgentBlocked() bool {
+	if len(w.AgentProbes) == 0 {
+		return false
+	}
+	if w.ControlAgentProbe.Open {
+		return false
+	}
+	for _, p := range w.AgentProbes {
+		if p.Open {
+			return false
+		}
+	}
+	return true
+}
+
+// DifferentialProven reports whether the control differential holds: the SAME
+// host-local target is reachable for the operator and blocked for the contained
+// agent. This is what makes the block attributable to containment rather than to
+// an unroutable or down target.
+func (w HostContainmentWitness) DifferentialProven() bool {
+	if w.ControlTarget == "" {
+		return false
+	}
+	if w.ControlOperatorProbe.Target != w.ControlTarget || w.ControlAgentProbe.Target != w.ControlTarget {
+		return false
+	}
+	return w.ControlOperatorProbe.Open && !w.ControlAgentProbe.Open
+}
+
+// Enforced is the fail-closed gate: containment is proven for this run ONLY when
+// the differential holds, the exact direct-egress suite was probed, and every
+// contained-agent probe was blocked. Any open agent route, a missing or
+// substituted target, a missing/unreachable control target, or an empty probe
+// suite fails closed.
+func (w HostContainmentWitness) Enforced() bool {
+	return w.DifferentialProven() && w.DirectSuiteProven() && w.AllAgentBlocked()
+}
+
+// SignHostContainmentWitness signs w with the orchestrator private key over its
+// canonical (signature-excluded) bytes and returns a copy with the hex Signature
+// set.
+func SignHostContainmentWitness(priv ed25519.PrivateKey, w HostContainmentWitness) HostContainmentWitness {
+	sig := ed25519.Sign(priv, w.SignedBytes())
+	w.Signature = hex.EncodeToString(sig)
+	return w
+}
+
+// VerifyHostContainmentWitness reports whether w carries a valid ed25519
+// signature under the given orchestrator public key (hex-encoded). It rejects
+// malformed or wrong-length keys and signatures (fail closed).
+func VerifyHostContainmentWitness(orchestratorPubHex string, w HostContainmentWitness) bool {
+	pub, err := hex.DecodeString(orchestratorPubHex)
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return false
+	}
+	sig, err := hex.DecodeString(w.Signature)
+	if err != nil {
+		return false
+	}
+	return ed25519.Verify(ed25519.PublicKey(pub), w.SignedBytes(), sig)
+}
+
+// HostContainmentBindsRun reports whether w is intrinsically bound to the given
+// run nonce and launch-manifest hash. A witness from one run does NOT satisfy
+// this for another run, which is what makes it non-replayable.
+func HostContainmentBindsRun(w HostContainmentWitness, nonce, manifestHash string) bool {
+	return w.RunNonce == nonce && w.LaunchManifestHash == manifestHash
+}

--- a/internal/playground/containment_witness.go
+++ b/internal/playground/containment_witness.go
@@ -22,7 +22,8 @@ import (
 //
 // The honesty hinges on a DIFFERENTIAL: ControlTarget is a host-local listener
 // that is genuinely reachable absent containment. The operator probe of it must
-// be Open and the contained-agent probe of the SAME target must be Blocked.
+// be Open and the contained-agent probe of the SAME target must be explicitly
+// Blocked.
 // Because only the source uid differs between the two probes, a block can only
 // be attributed to the kernel owner-match rule -- never to an unroutable or
 // down target (the weakness of probing a single reserved IP).
@@ -47,13 +48,15 @@ type HostContainmentWitness struct {
 	// "blocked" result elsewhere is meaningful and not a broken probe.
 	ControlOperatorProbe ProbeResult `json:"control_operator_probe"`
 	// ControlAgentProbe is the contained agent's probe of the SAME ControlTarget.
-	// It MUST be blocked (Open=false). Together with ControlOperatorProbe being
-	// Open, this is the differential that isolates the kernel owner-match drop.
+	// It MUST be explicitly blocked (Open=false, Blocked=true). Together with
+	// ControlOperatorProbe being Open, this is the differential that isolates
+	// the kernel owner-match drop.
 	ControlAgentProbe ProbeResult `json:"control_agent_probe"`
 
 	// AgentProbes are the contained agent's probes of the real direct-egress
 	// target suite (cloud metadata, RFC-1918, public DNS, public HTTPS). Every
-	// one MUST be blocked (Open=false); any open route means containment leaks.
+	// one MUST be explicitly blocked (Open=false, Blocked=true); any open,
+	// refused, or ambiguous route means containment is not proven.
 	AgentProbes []ProbeResult `json:"agent_probes"`
 
 	ProbedAt time.Time `json:"probed_at"`
@@ -89,17 +92,19 @@ func (w HostContainmentWitness) DirectSuiteProven() bool {
 
 // AllAgentBlocked reports whether every contained-agent probe -- the control
 // target probe AND every direct-egress probe present in the witness -- was
-// blocked. It requires at least one real direct-egress probe so an empty suite
-// cannot pass vacuously. Enforced additionally requires DirectSuiteProven.
+// explicitly classified as blocked. Open=false alone is not enough: a
+// connection-refused response is reachable-but-closed, not containment. It
+// requires at least one real direct-egress probe so an empty suite cannot pass
+// vacuously. Enforced additionally requires DirectSuiteProven.
 func (w HostContainmentWitness) AllAgentBlocked() bool {
 	if len(w.AgentProbes) == 0 {
 		return false
 	}
-	if w.ControlAgentProbe.Open {
+	if w.ControlAgentProbe.Open || !w.ControlAgentProbe.Blocked {
 		return false
 	}
 	for _, p := range w.AgentProbes {
-		if p.Open {
+		if p.Open || !p.Blocked {
 			return false
 		}
 	}
@@ -117,14 +122,14 @@ func (w HostContainmentWitness) DifferentialProven() bool {
 	if w.ControlOperatorProbe.Target != w.ControlTarget || w.ControlAgentProbe.Target != w.ControlTarget {
 		return false
 	}
-	return w.ControlOperatorProbe.Open && !w.ControlAgentProbe.Open
+	return w.ControlOperatorProbe.Open && !w.ControlAgentProbe.Open && w.ControlAgentProbe.Blocked
 }
 
 // Enforced is the fail-closed gate: containment is proven for this run ONLY when
 // the differential holds, the exact direct-egress suite was probed, and every
-// contained-agent probe was blocked. Any open agent route, a missing or
-// substituted target, a missing/unreachable control target, or an empty probe
-// suite fails closed.
+// contained-agent probe was explicitly blocked. Any open, refused, or ambiguous
+// agent route, a missing or substituted target, a missing/unreachable control
+// target, or an empty probe suite fails closed.
 func (w HostContainmentWitness) Enforced() bool {
 	return w.DifferentialProven() && w.DirectSuiteProven() && w.AllAgentBlocked()
 }

--- a/internal/playground/containment_witness_test.go
+++ b/internal/playground/containment_witness_test.go
@@ -28,9 +28,10 @@ func blockedDirectProbes() []playground.ProbeResult {
 	probes := make([]playground.ProbeResult, 0, len(targets))
 	for _, target := range targets {
 		probes = append(probes, playground.ProbeResult{
-			Target: target,
-			Open:   false,
-			Detail: "blocked",
+			Target:  target,
+			Open:    false,
+			Blocked: true,
+			Detail:  "blocked",
 		})
 	}
 	return probes
@@ -44,8 +45,8 @@ func validWitness() playground.HostContainmentWitness {
 		AgentUser:            "pipelock-agent",
 		AgentUID:             966,
 		ControlTarget:        testCtrlTarget,
-		ControlOperatorProbe: playground.ProbeResult{Target: testCtrlTarget, Open: true, Detail: "connected"},
-		ControlAgentProbe:    playground.ProbeResult{Target: testCtrlTarget, Open: false, Detail: "blocked: timeout"},
+		ControlOperatorProbe: playground.ProbeResult{Target: testCtrlTarget, Open: true, Blocked: false, Detail: "connected"},
+		ControlAgentProbe:    playground.ProbeResult{Target: testCtrlTarget, Open: false, Blocked: true, Detail: "blocked: timeout"},
 		AgentProbes:          blockedDirectProbes(),
 		ProbedAt:             time.Unix(1_700_000_000, 0).UTC(),
 	}
@@ -194,6 +195,17 @@ func TestHostContainmentWitness_Enforced(t *testing.T) {
 			name: "control agent probe open (no block)",
 			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
 				w.ControlAgentProbe.Open = true
+				w.ControlAgentProbe.Blocked = false
+				return w
+			},
+			want: false,
+		},
+		{
+			name: "control agent probe refused is reachable not blocked",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.ControlAgentProbe.Open = false
+				w.ControlAgentProbe.Blocked = false
+				w.ControlAgentProbe.Detail = "reachable: connection refused"
 				return w
 			},
 			want: false,
@@ -202,6 +214,7 @@ func TestHostContainmentWitness_Enforced(t *testing.T) {
 			name: "control operator probe blocked (broken probe / unreachable control)",
 			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
 				w.ControlOperatorProbe.Open = false
+				w.ControlOperatorProbe.Blocked = true
 				return w
 			},
 			want: false,

--- a/internal/playground/containment_witness_test.go
+++ b/internal/playground/containment_witness_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	testCtrlTarget = "127.0.0.1:54321"
+	testRunNonce   = "run-abc"
+	testManHash    = "deadbeef"
+)
+
+// blockedDirectProbes returns one blocked probe for every direct-egress target
+// in the production suite. The verifier requires the exact suite, not just an
+// arbitrary non-empty list of blocked probes.
+func blockedDirectProbes() []playground.ProbeResult {
+	targets := playground.DirectEgressTargets()
+	probes := make([]playground.ProbeResult, 0, len(targets))
+	for _, target := range targets {
+		probes = append(probes, playground.ProbeResult{
+			Target: target,
+			Open:   false,
+			Detail: "blocked",
+		})
+	}
+	return probes
+}
+
+// validWitness returns a fully-enforced, unsigned witness for the happy path.
+func validWitness() playground.HostContainmentWitness {
+	return playground.HostContainmentWitness{
+		RunNonce:             testRunNonce,
+		LaunchManifestHash:   testManHash,
+		AgentUser:            "pipelock-agent",
+		AgentUID:             966,
+		ControlTarget:        testCtrlTarget,
+		ControlOperatorProbe: playground.ProbeResult{Target: testCtrlTarget, Open: true, Detail: "connected"},
+		ControlAgentProbe:    playground.ProbeResult{Target: testCtrlTarget, Open: false, Detail: "blocked: timeout"},
+		AgentProbes:          blockedDirectProbes(),
+		ProbedAt:             time.Unix(1_700_000_000, 0).UTC(),
+	}
+}
+
+func mustKeys(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	return pub, priv
+}
+
+func TestHostContainmentWitness_SignVerifyRoundTrip(t *testing.T) {
+	t.Parallel()
+	pub, priv := mustKeys(t)
+
+	signed := playground.SignHostContainmentWitness(priv, validWitness())
+	if signed.Signature == "" {
+		t.Fatal("signature not set after signing")
+	}
+	if !playground.VerifyHostContainmentWitness(hex.EncodeToString(pub), signed) {
+		t.Fatal("valid witness failed verification under its own key")
+	}
+}
+
+func TestHostContainmentWitness_Verify_FailsClosed(t *testing.T) {
+	t.Parallel()
+	pub, priv := mustKeys(t)
+	otherPub, _ := mustKeys(t)
+
+	tests := []struct {
+		name   string
+		pubHex string
+		mutate func(w playground.HostContainmentWitness) playground.HostContainmentWitness
+	}{
+		{
+			name:   "wrong orchestrator key",
+			pubHex: hex.EncodeToString(otherPub),
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness { return w },
+		},
+		{
+			name:   "malformed key hex",
+			pubHex: "not-hex",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness { return w },
+		},
+		{
+			name:   "short key",
+			pubHex: hex.EncodeToString(pub[:16]),
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness { return w },
+		},
+		{
+			name:   "tampered field after signing",
+			pubHex: hex.EncodeToString(pub),
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				// Flip an agent probe to Open WITHOUT re-signing: the cached
+				// signature no longer matches the canonical bytes.
+				w.AgentProbes[0].Open = true
+				return w
+			},
+		},
+		{
+			name:   "tampered signature bytes",
+			pubHex: hex.EncodeToString(pub),
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.Signature = "00" + w.Signature[2:]
+				return w
+			},
+		},
+		{
+			name:   "malformed signature hex",
+			pubHex: hex.EncodeToString(pub),
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.Signature = "zz"
+				return w
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Sign a fresh witness per subtest so parallel mutations never
+			// touch a shared slice backing array.
+			w := tc.mutate(playground.SignHostContainmentWitness(priv, validWitness()))
+			if playground.VerifyHostContainmentWitness(tc.pubHex, w) {
+				t.Fatal("expected verification to fail closed, but it passed")
+			}
+		})
+	}
+}
+
+// TestHostContainmentWitness_AttackerResign proves an attacker who edits the
+// witness and re-signs with THEIR OWN key cannot pass verification under the
+// real orchestrator key.
+func TestHostContainmentWitness_AttackerResign(t *testing.T) {
+	t.Parallel()
+	pub, _ := mustKeys(t)
+	_, attackerPriv := mustKeys(t)
+
+	forged := validWitness()
+	forged.AgentProbes[0].Open = true // pretend a route was open but claim enforced
+	forged = playground.SignHostContainmentWitness(attackerPriv, forged)
+
+	if playground.VerifyHostContainmentWitness(hex.EncodeToString(pub), forged) {
+		t.Fatal("attacker-resigned witness verified under the real orchestrator key")
+	}
+}
+
+func TestHostContainmentWitness_BindsRun(t *testing.T) {
+	t.Parallel()
+	w := validWitness()
+	if !playground.HostContainmentBindsRun(w, testRunNonce, testManHash) {
+		t.Fatal("witness should bind its own run")
+	}
+	if playground.HostContainmentBindsRun(w, "other-nonce", testManHash) {
+		t.Fatal("witness must not bind a different nonce")
+	}
+	if playground.HostContainmentBindsRun(w, testRunNonce, "other-hash") {
+		t.Fatal("witness must not bind a different manifest hash")
+	}
+}
+
+func TestHostContainmentWitness_Enforced(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(w playground.HostContainmentWitness) playground.HostContainmentWitness
+		want   bool
+	}{
+		{
+			name:   "valid differential + all blocked",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness { return w },
+			want:   true,
+		},
+		{
+			name: "leak: a real agent probe is open",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.AgentProbes[1].Open = true
+				return w
+			},
+			want: false,
+		},
+		{
+			name: "control agent probe open (no block)",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.ControlAgentProbe.Open = true
+				return w
+			},
+			want: false,
+		},
+		{
+			name: "control operator probe blocked (broken probe / unreachable control)",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.ControlOperatorProbe.Open = false
+				return w
+			},
+			want: false,
+		},
+		{
+			name: "empty control target",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.ControlTarget = ""
+				return w
+			},
+			want: false,
+		},
+		{
+			name: "control probe target mismatch",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.ControlAgentProbe.Target = "127.0.0.1:9999"
+				return w
+			},
+			want: false,
+		},
+		{
+			name: "empty agent probe suite cannot pass vacuously",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.AgentProbes = nil
+				return w
+			},
+			want: false,
+		},
+		{
+			name: "missing direct-egress suite target",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.AgentProbes = w.AgentProbes[:len(w.AgentProbes)-1]
+				return w
+			},
+			want: false,
+		},
+		{
+			name: "substituted direct-egress suite target",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.AgentProbes[0].Target = "127.0.0.1:1"
+				return w
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.mutate(validWitness()).Enforced(); got != tc.want {
+				t.Fatalf("Enforced()=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHostContainmentWitness_SignedBytesDeterministic guards the no-maps
+// determinism invariant: two marshals of the same witness are byte-identical.
+func TestHostContainmentWitness_SignedBytesDeterministic(t *testing.T) {
+	t.Parallel()
+	w := validWitness()
+	a := w.SignedBytes()
+	b := w.SignedBytes()
+	if string(a) != string(b) {
+		t.Fatal("SignedBytes not deterministic")
+	}
+	// Signature field must be excluded from signed bytes.
+	w.Signature = "abcd"
+	if string(w.SignedBytes()) != string(a) {
+		t.Fatal("SignedBytes must exclude the Signature field")
+	}
+	// Sanity: it is valid JSON.
+	var probe map[string]any
+	if err := json.Unmarshal(a, &probe); err != nil {
+		t.Fatalf("SignedBytes is not valid JSON: %v", err)
+	}
+}

--- a/internal/playground/coverage_more_test.go
+++ b/internal/playground/coverage_more_test.go
@@ -8,6 +8,9 @@ package playground
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -27,6 +30,12 @@ type badAddr string
 
 func (a badAddr) Network() string { return "bad" }
 func (a badAddr) String() string  { return string(a) }
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return false }
 
 func TestLiveRunHelperBranches(t *testing.T) {
 	t.Parallel()
@@ -62,6 +71,67 @@ func TestLiveRunHelperBranches(t *testing.T) {
 	}
 }
 
+func TestContainmentErrorHelpers(t *testing.T) {
+	t.Parallel()
+
+	for _, err := range []error{
+		timeoutError{},
+		os.ErrPermission,
+		errors.New("network is unreachable"),
+		errors.New("operation not permitted"),
+		errors.New("administratively prohibited"),
+	} {
+		if !isEgressBlockError(err) {
+			t.Fatalf("isEgressBlockError(%v) = false, want true", err)
+		}
+	}
+	if isEgressBlockError(errors.New("connection refused")) {
+		t.Fatal("connection refused must be reachable, not blocked")
+	}
+	if got := probeErrorDetail(errors.New("connection refused"), false); !strings.Contains(got, "reachable: connection refused") {
+		t.Fatalf("connection refused detail = %q", got)
+	}
+	if got := probeErrorDetail(errors.New("network is unreachable"), true); !strings.Contains(got, "blocked:") {
+		t.Fatalf("blocked detail = %q", got)
+	}
+	if got := probeErrorDetail(errors.New("reset by peer"), false); !strings.Contains(got, "not blocked:") {
+		t.Fatalf("not-blocked detail = %q", got)
+	}
+}
+
+func TestContainedAgentIdentityHelpers(t *testing.T) {
+	t.Parallel()
+
+	if got := containedAgentUserName(""); got != defaultContainedAgentUser {
+		t.Fatalf("default contained agent user = %q, want %q", got, defaultContainedAgentUser)
+	}
+	if got := containedAgentUserName("custom-agent"); got != "custom-agent" {
+		t.Fatalf("custom contained agent user = %q", got)
+	}
+	if got := containedAgentUID("pipelock-missing-test-user"); got != -1 {
+		t.Fatalf("missing contained agent uid = %d, want -1", got)
+	}
+}
+
+func TestChecksPassed(t *testing.T) {
+	t.Parallel()
+
+	rep := VerifyReport{Checks: []Check{
+		{Name: checkHostContainSig, OK: true},
+		{Name: checkHostContainBinding, OK: true},
+		{Name: checkHostContainEnforced, OK: false},
+	}}
+	if !checksPassed(rep, checkHostContainSig, checkHostContainBinding) {
+		t.Fatal("expected selected passing checks to pass")
+	}
+	if checksPassed(rep, checkHostContainSig, checkHostContainEnforced) {
+		t.Fatal("failed check must make checksPassed false")
+	}
+	if checksPassed(rep, "missing-check") {
+		t.Fatal("missing check must make checksPassed false")
+	}
+}
+
 func TestRunEgressProbeRequiresRootWhenContained(t *testing.T) {
 	t.Parallel()
 
@@ -84,29 +154,144 @@ func TestRunEgressProbeRequiresRootWhenContained(t *testing.T) {
 	}
 }
 
+func TestRunEgressProbeParsesSubprocessOutput(t *testing.T) {
+	t.Parallel()
+
+	agent := filepath.Join(t.TempDir(), "probe-agent")
+	script := `#!/bin/sh
+printf '%s\n' '[{"target":"127.0.0.1:1","open":false,"blocked":true,"detail":"blocked"}]'
+`
+	if err := os.WriteFile(agent, []byte(script), 0o700); err != nil { //nolint:gosec // test fixture executable
+		t.Fatalf("write probe agent: %v", err)
+	}
+
+	lr := &LiveRun{
+		ctx:      t.Context(),
+		agentBin: agent,
+	}
+	got, err := lr.runEgressProbe([]string{"127.0.0.1:1"}, false)
+	if err != nil {
+		t.Fatalf("runEgressProbe: %v", err)
+	}
+	if len(got) != 1 || got[0].Target != "127.0.0.1:1" || !got[0].Blocked || got[0].Open {
+		t.Fatalf("probe results = %+v, want one blocked result", got)
+	}
+}
+
 func TestRunStepsReturnsNonExitExecErrors(t *testing.T) {
 	t.Parallel()
 
-	safeLn := listenLocal(t)
-	defer func() { _ = safeLn.Close() }()
-	collectorLn := listenLocal(t)
-	defer func() { _ = collectorLn.Close() }()
-	proxyLn := listenLocal(t)
-	defer func() { _ = proxyLn.Close() }()
-
-	lr := &LiveRun{
-		ctx:         t.Context(),
-		safeLn:      safeLn,
-		collectorLn: collectorLn,
-		proxyLn:     proxyLn,
-		agentBin:    filepath.Join(t.TempDir(), "missing-agent"),
-		opts: LiveRunOpts{
-			RunNonce: "N1",
-		},
-	}
+	lr := newRunStepsTestLiveRun(t, filepath.Join(t.TempDir(), "missing-agent"))
 	err := lr.RunSteps(1)
 	if err == nil || !strings.Contains(err.Error(), "step 1 exec") {
 		t.Fatalf("RunSteps error = %v, want step 1 exec", err)
+	}
+}
+
+func TestRunStepsReturnsAgentExitErrors(t *testing.T) {
+	t.Parallel()
+
+	lr := newRunStepsTestLiveRun(t, "/bin/false")
+	err := lr.RunSteps(1)
+	if err == nil || !strings.Contains(err.Error(), "step 1 exec") {
+		t.Fatalf("RunSteps error = %v, want step 1 exec", err)
+	}
+}
+
+func TestRunStepsRejectsUnsupportedSteps(t *testing.T) {
+	t.Parallel()
+
+	lr := newRunStepsTestLiveRun(t, "/bin/false")
+	err := lr.RunSteps(99)
+	if err == nil || !strings.Contains(err.Error(), "unsupported mediated step 99") {
+		t.Fatalf("RunSteps error = %v, want unsupported mediated step", err)
+	}
+}
+
+func TestBuildHostContainmentWitnessSignsProbeEvidence(t *testing.T) {
+	t.Parallel()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	lr := &LiveRun{
+		ctx:              t.Context(),
+		orchestratorPub:  pub,
+		orchestratorPriv: priv,
+		manifest: LaunchManifest{
+			RunNonce:   "N1",
+			ScenarioID: LiveDemoScenarioID,
+			Contained:  true,
+		},
+		opts: LiveRunOpts{
+			RunNonce:  "N1",
+			AgentUser: "missing-test-agent-user",
+		},
+	}
+
+	var controlTarget string
+	lr.egressProbe = func(targets []string, asAgent bool) ([]ProbeResult, error) {
+		if len(targets) == 0 {
+			return nil, errors.New("missing targets")
+		}
+		if !asAgent {
+			if len(targets) != 1 {
+				return nil, fmt.Errorf("operator target count = %d", len(targets))
+			}
+			controlTarget = targets[0]
+			return []ProbeResult{{Target: targets[0], Open: true, Blocked: false, Detail: "connected"}}, nil
+		}
+		if targets[0] != controlTarget {
+			return nil, fmt.Errorf("agent control target = %q, want %q", targets[0], controlTarget)
+		}
+		results := make([]ProbeResult, 0, len(targets))
+		for _, target := range targets {
+			results = append(results, ProbeResult{Target: target, Open: false, Blocked: true, Detail: "blocked"})
+		}
+		return results, nil
+	}
+
+	w, err := lr.buildHostContainmentWitness()
+	if err != nil {
+		t.Fatalf("buildHostContainmentWitness: %v", err)
+	}
+	if !VerifyHostContainmentWitness(hex.EncodeToString(pub), w) {
+		t.Fatal("host-containment witness signature must verify")
+	}
+	if !HostContainmentBindsRun(w, "N1", lr.manifest.Hash()) {
+		t.Fatal("host-containment witness must bind run nonce and launch manifest")
+	}
+	if !w.Enforced() {
+		t.Fatalf("host-containment witness must prove enforcement: %+v", w)
+	}
+	if len(w.AgentProbes) != len(DirectEgressTargets()) {
+		t.Fatalf("agent probe count = %d, want %d", len(w.AgentProbes), len(DirectEgressTargets()))
+	}
+}
+
+func TestBuildHostContainmentWitnessFailsClosedOnProbeError(t *testing.T) {
+	t.Parallel()
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	lr := &LiveRun{
+		ctx:              t.Context(),
+		orchestratorPriv: priv,
+		opts:             LiveRunOpts{RunNonce: "N1"},
+	}
+	lr.egressProbe = func(_ []string, asAgent bool) ([]ProbeResult, error) {
+		if !asAgent {
+			return nil, errors.New("operator probe failed")
+		}
+		return nil, errors.New("agent probe should not run")
+	}
+
+	_, err = lr.buildHostContainmentWitness()
+	if err == nil || !strings.Contains(err.Error(), "operator control probe") {
+		t.Fatalf("buildHostContainmentWitness error = %v, want operator probe failure", err)
 	}
 }
 
@@ -337,6 +522,27 @@ func listenLocal(t *testing.T) net.Listener {
 		t.Fatalf("listen: %v", err)
 	}
 	return ln
+}
+
+func newRunStepsTestLiveRun(t *testing.T, agentBin string) *LiveRun {
+	t.Helper()
+	safeLn := listenLocal(t)
+	t.Cleanup(func() { _ = safeLn.Close() })
+	collectorLn := listenLocal(t)
+	t.Cleanup(func() { _ = collectorLn.Close() })
+	proxyLn := listenLocal(t)
+	t.Cleanup(func() { _ = proxyLn.Close() })
+
+	return &LiveRun{
+		ctx:         t.Context(),
+		safeLn:      safeLn,
+		collectorLn: collectorLn,
+		proxyLn:     proxyLn,
+		agentBin:    agentBin,
+		opts: LiveRunOpts{
+			RunNonce: "N1",
+		},
+	}
 }
 
 func writePacketManifest(t *testing.T, path, scenarioID, policyHash string) {

--- a/internal/playground/coverage_more_test.go
+++ b/internal/playground/coverage_more_test.go
@@ -62,31 +62,25 @@ func TestLiveRunHelperBranches(t *testing.T) {
 	}
 }
 
-func TestLiveRunAgentCommandBranches(t *testing.T) {
+func TestRunEgressProbeRequiresRootWhenContained(t *testing.T) {
 	t.Parallel()
+
+	// Split-proof refactor removed LiveRun.agentCommand: mediated steps now exec
+	// inline as the operator, and the only uid-dropped path is the egress probe.
+	// The equivalent root-requirement branch lives in runEgressProbe(asAgent=true).
+	if os.Geteuid() == 0 {
+		t.Skip("non-root contained error branch requires non-root test process")
+	}
 
 	lr := &LiveRun{
 		ctx:      t.Context(),
 		agentBin: "/bin/echo",
 		opts:     LiveRunOpts{},
 	}
-	cmd, err := lr.agentCommand([]string{"hello"})
-	if err != nil {
-		t.Fatalf("uncontained agentCommand: %v", err)
-	}
-	if cmd.Path != "/bin/echo" {
-		t.Fatalf("cmd path = %q", cmd.Path)
-	}
-	if len(cmd.Args) != 2 || cmd.Args[1] != "hello" {
-		t.Fatalf("cmd args = %v", cmd.Args)
-	}
-
-	if os.Geteuid() == 0 {
-		t.Skip("non-root contained error branch requires non-root test process")
-	}
-	lr.opts.Contained = true
-	if _, err := lr.agentCommand(nil); err == nil || !strings.Contains(err.Error(), rootRequirement) {
-		t.Fatalf("contained non-root error = %v, want root requirement", err)
+	// asAgent=true drops to the contained uid, which requires root; as a non-root
+	// test process it must fail closed with the root requirement.
+	if _, err := lr.runEgressProbe([]string{"127.0.0.1:1"}, true); err == nil || !strings.Contains(err.Error(), rootRequirement) {
+		t.Fatalf("contained egress probe non-root error = %v, want root requirement", err)
 	}
 }
 

--- a/internal/playground/coverage_more_test.go
+++ b/internal/playground/coverage_more_test.go
@@ -26,6 +26,11 @@ import (
 
 const rootRequirement = "requires root"
 
+// execFixtureMode is the file mode for test fixtures that must be executable
+// (a probe-agent shell script the test then runs). The executable bit is
+// required; using a named constant keeps gosec G302 from flagging the literal.
+const execFixtureMode os.FileMode = 0o700
+
 type badAddr string
 
 func (a badAddr) Network() string { return "bad" }
@@ -161,7 +166,7 @@ func TestRunEgressProbeParsesSubprocessOutput(t *testing.T) {
 	script := `#!/bin/sh
 printf '%s\n' '[{"target":"127.0.0.1:1","open":false,"blocked":true,"detail":"blocked"}]'
 `
-	if err := os.WriteFile(agent, []byte(script), 0o700); err != nil { //nolint:gosec // test fixture executable
+	if err := os.WriteFile(agent, []byte(script), execFixtureMode); err != nil {
 		t.Fatalf("write probe agent: %v", err)
 	}
 

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -10,7 +10,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -108,6 +107,8 @@ type LiveRun struct {
 	// Canary
 	canaryID    string
 	canaryValue string
+
+	egressProbe func(targets []string, asAgent bool) ([]ProbeResult, error)
 }
 
 // StartLiveRun boots a complete live demo environment: lab targets, a real
@@ -288,6 +289,12 @@ func (lr *LiveRun) RunSteps(steps ...int) error {
 	exfilURL := fmt.Sprintf("http://%s:%s/", liveRunExfilHost, collectorPort)
 
 	for _, step := range steps {
+		switch step {
+		case 1, 2:
+		default:
+			return fmt.Errorf("unsupported mediated step %d", step)
+		}
+
 		// The mediated steps (1 = allow, 2 = body-DLP block) always run as the
 		// operator through the demo's lab proxy. Under the split-proof model the
 		// kernel-containment property is proven separately by the
@@ -323,13 +330,7 @@ func (lr *LiveRun) RunSteps(steps ...int) error {
 		cmd.Stderr = os.Stderr
 
 		if err := cmd.Run(); err != nil {
-			// Non-zero exit from the agent is expected when pipelock blocks the
-			// red POST. Only non-ExitError failures (binary missing, etc.) are
-			// real errors.
-			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) {
-				return fmt.Errorf("step %d exec: %w", step, err)
-			}
+			return fmt.Errorf("step %d exec: %w", step, err)
 		}
 	}
 	return nil
@@ -391,6 +392,11 @@ func decodeProbeResults(stdout []byte, expectedTargets []string) ([]ProbeResult,
 // contained position (all must be blocked). The witness is signed by the
 // orchestrator key, the run's trust root.
 func (lr *LiveRun) buildHostContainmentWitness() (HostContainmentWitness, error) {
+	runProbe := lr.runEgressProbe
+	if lr.egressProbe != nil {
+		runProbe = lr.egressProbe
+	}
+
 	ctrlLn, err := (&net.ListenConfig{}).Listen(lr.ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		return HostContainmentWitness{}, fmt.Errorf("control listener: %w", err)
@@ -408,7 +414,7 @@ func (lr *LiveRun) buildHostContainmentWitness() (HostContainmentWitness, error)
 	ctrlTarget := ctrlLn.Addr().String()
 
 	// Operator probe of the control target: proves the probe can see "open".
-	opProbes, err := lr.runEgressProbe([]string{ctrlTarget}, false)
+	opProbes, err := runProbe([]string{ctrlTarget}, false)
 	if err != nil {
 		return HostContainmentWitness{}, fmt.Errorf("operator control probe: %w", err)
 	}
@@ -416,7 +422,7 @@ func (lr *LiveRun) buildHostContainmentWitness() (HostContainmentWitness, error)
 	// Contained-agent probes: control target first, then the real suite.
 	realTargets := DirectEgressTargets()
 	agentTargets := append([]string{ctrlTarget}, realTargets...)
-	agProbes, err := lr.runEgressProbe(agentTargets, true)
+	agProbes, err := runProbe(agentTargets, true)
 	if err != nil {
 		return HostContainmentWitness{}, fmt.Errorf("contained agent probe: %w", err)
 	}

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -4,6 +4,7 @@
 package playground
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/sha256"
@@ -34,11 +35,6 @@ import (
 const (
 	liveRunSafeHost  = "safe.target.test"
 	liveRunExfilHost = "exfil.target.test"
-	// RFC 5737 TEST-NET-3 reserved address: a synthetic "external" target. In
-	// contained mode the kernel blocks all egress except the proxy, so this is
-	// never actually contacted; it only needs to be a non-proxy, non-loopback
-	// destination the bypass attempt aims at.
-	liveRunBypassURL = "http://203.0.113.1/"
 )
 
 // liveRunPrincipal and liveRunActor use the same values as the replaycapture
@@ -54,8 +50,9 @@ const canaryEnvVar = "PLAYGROUND_CANARY_VALUE"
 
 // LiveRunOpts configures a live playground run.
 type LiveRunOpts struct {
-	// Contained selects kernel-containment mode (requires sudo). When false
-	// (uncontained), step 3 (bypass) is skipped.
+	// Contained selects kernel-containment mode (requires sudo). When true, the
+	// mediated demo steps still run through the proxy as the operator, and a
+	// separate uid-dropped probe phase builds the host-containment witness.
 	Contained bool
 	// ScenarioID selects the scenario from DefaultScenarios.
 	ScenarioID string
@@ -261,6 +258,7 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 		PolicyHash:      lr.policyHash,
 		TargetHost:      liveRunExfilHost,
 		StartedAt:       time.Now().UTC(),
+		Contained:       opts.Contained,
 	}
 	lr.manifest = SignLaunchManifest(lr.orchestratorPriv, lr.manifest)
 
@@ -277,8 +275,10 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 	return lr, nil
 }
 
-// RunSteps executes the specified toy-agent steps. Step 1 = safe GET, Step 2 =
-// exfil POST, Step 3 = bypass (skipped in uncontained mode).
+// RunSteps executes the specified toy-agent mediated steps. Step 1 = safe GET,
+// Step 2 = exfil POST. Step 3 remains in the toy agent for manual/raw bypass
+// experiments, but the split-proof live demo proves containment through
+// buildHostContainmentWitness instead.
 func (lr *LiveRun) RunSteps(steps ...int) error {
 	safePort := portFromAddr(lr.safeLn.Addr())
 	collectorPort := portFromAddr(lr.collectorLn.Addr())
@@ -288,10 +288,15 @@ func (lr *LiveRun) RunSteps(steps ...int) error {
 	exfilURL := fmt.Sprintf("http://%s:%s/", liveRunExfilHost, collectorPort)
 
 	for _, step := range steps {
-		if step == 3 && !lr.opts.Contained {
-			continue // bypass is only meaningful under containment
-		}
-
+		// The mediated steps (1 = allow, 2 = body-DLP block) always run as the
+		// operator through the demo's lab proxy. Under the split-proof model the
+		// kernel-containment property is proven separately by the
+		// HostContainmentWitness (see buildHostContainmentWitness), NOT by
+		// dropping these steps to the contained user. That is deliberate: the
+		// proxy's allow/block decision is orthogonal to the agent's uid, and on a
+		// host with global owner-match containment the contained user cannot
+		// reach the demo's ephemeral lab proxy at all -- so running these steps
+		// contained would just time out and produce no receipts.
 		args := []string{
 			"--step", fmt.Sprintf("%d", step),
 			"--run-nonce", lr.opts.RunNonce,
@@ -300,17 +305,8 @@ func (lr *LiveRun) RunSteps(steps ...int) error {
 			"--exfil-url", exfilURL,
 			"--webtool", lr.webtoolBin,
 		}
-		if step == 3 {
-			args = append(args, "--bypass-url", liveRunBypassURL)
-			if lr.opts.Contained {
-				args = append(args, "--expect-bypass-blocked")
-			}
-		}
 
-		cmd, err := lr.agentCommand(args)
-		if err != nil {
-			return fmt.Errorf("step %d command: %w", step, err)
-		}
+		cmd := exec.CommandContext(lr.ctx, lr.agentBin, args...)
 		// Minimal, controlled environment: the demo agent holds ONLY the
 		// synthetic canary plus the demo plumbing -- NEVER the operator's real
 		// environment (which could contain real secrets). This enforces the
@@ -327,33 +323,116 @@ func (lr *LiveRun) RunSteps(steps ...int) error {
 		cmd.Stderr = os.Stderr
 
 		if err := cmd.Run(); err != nil {
-			// Non-zero exit from the agent is expected when pipelock blocks;
-			// except for the contained bypass beat, where non-zero means the
-			// direct-egress check connected or could not run honestly.
+			// Non-zero exit from the agent is expected when pipelock blocks the
+			// red POST. Only non-ExitError failures (binary missing, etc.) are
+			// real errors.
 			var exitErr *exec.ExitError
 			if !errors.As(err, &exitErr) {
 				return fmt.Errorf("step %d exec: %w", step, err)
-			}
-			if step == 3 && lr.opts.Contained {
-				return fmt.Errorf("step %d contained bypass check failed: %w", step, err)
 			}
 		}
 	}
 	return nil
 }
 
-func (lr *LiveRun) agentCommand(args []string) (*exec.Cmd, error) {
+// runEgressProbe spawns the toy agent in probe mode against the given targets
+// and parses its JSON results. When asAgent is true, the probe subprocess is
+// dropped to the contained agent user (uid-scoped), so it probes from the
+// contained network position; this requires root and an installed containment.
+// When false it runs as the current (operator) user.
+func (lr *LiveRun) runEgressProbe(targets []string, asAgent bool) ([]ProbeResult, error) {
+	args := []string{"--probe-targets", strings.Join(targets, ",")}
 	cmd := exec.CommandContext(lr.ctx, lr.agentBin, args...)
-	if !lr.opts.Contained {
-		return cmd, nil
+	cmd.Env = []string{"PATH=/usr/local/bin:/usr/bin:/bin"}
+	if asAgent {
+		if os.Geteuid() != 0 {
+			return nil, fmt.Errorf("contained egress probe requires root (euid=%d)", os.Geteuid())
+		}
+		if err := configureContainedCommand(cmd, lr.opts.AgentUser); err != nil {
+			return nil, err
+		}
 	}
-	if os.Geteuid() != 0 {
-		return nil, fmt.Errorf("contained toy-agent execution requires root (euid=%d)", os.Geteuid())
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("egress probe exec: %w", err)
 	}
-	if err := configureContainedCommand(cmd, lr.opts.AgentUser); err != nil {
-		return nil, err
+
+	return decodeProbeResults(stdout.Bytes(), targets)
+}
+
+// decodeProbeResults parses the toy agent's probe-mode JSON output and verifies
+// it carries exactly the requested target set, in order. Extracted from
+// runEgressProbe so the parsing/validation logic is unit-testable without
+// spawning a privileged subprocess (the exec itself is host-only).
+func decodeProbeResults(stdout []byte, expectedTargets []string) ([]ProbeResult, error) {
+	var results []ProbeResult
+	if err := json.Unmarshal(stdout, &results); err != nil {
+		return nil, fmt.Errorf("parse egress probe output: %w", err)
 	}
-	return cmd, nil
+	if len(results) != len(expectedTargets) {
+		return nil, fmt.Errorf("egress probe returned %d results for %d targets", len(results), len(expectedTargets))
+	}
+	for i, expected := range expectedTargets {
+		if results[i].Target != expected {
+			return nil, fmt.Errorf("egress probe result %d target=%q, want %q", i, results[i].Target, expected)
+		}
+	}
+	return results, nil
+}
+
+// buildHostContainmentWitness produces the signed host-containment witness for
+// a contained run. It stands up a host-local control listener (reachable absent
+// containment), probes it as the operator (must connect) and as the contained
+// agent (must be blocked) -- the differential that isolates the kernel
+// owner-match drop -- then probes the real direct-egress target suite from the
+// contained position (all must be blocked). The witness is signed by the
+// orchestrator key, the run's trust root.
+func (lr *LiveRun) buildHostContainmentWitness() (HostContainmentWitness, error) {
+	ctrlLn, err := (&net.ListenConfig{}).Listen(lr.ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return HostContainmentWitness{}, fmt.Errorf("control listener: %w", err)
+	}
+	defer func() { _ = ctrlLn.Close() }()
+	go func() {
+		for {
+			c, acceptErr := ctrlLn.Accept()
+			if acceptErr != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	ctrlTarget := ctrlLn.Addr().String()
+
+	// Operator probe of the control target: proves the probe can see "open".
+	opProbes, err := lr.runEgressProbe([]string{ctrlTarget}, false)
+	if err != nil {
+		return HostContainmentWitness{}, fmt.Errorf("operator control probe: %w", err)
+	}
+
+	// Contained-agent probes: control target first, then the real suite.
+	realTargets := DirectEgressTargets()
+	agentTargets := append([]string{ctrlTarget}, realTargets...)
+	agProbes, err := lr.runEgressProbe(agentTargets, true)
+	if err != nil {
+		return HostContainmentWitness{}, fmt.Errorf("contained agent probe: %w", err)
+	}
+
+	w := HostContainmentWitness{
+		RunNonce:             lr.opts.RunNonce,
+		LaunchManifestHash:   lr.manifest.Hash(),
+		AgentUser:            containedAgentUserName(lr.opts.AgentUser),
+		AgentUID:             containedAgentUID(lr.opts.AgentUser),
+		ControlTarget:        ctrlTarget,
+		ControlOperatorProbe: opProbes[0],
+		ControlAgentProbe:    agProbes[0],
+		AgentProbes:          agProbes[1:],
+		ProbedAt:             time.Now().UTC(),
+	}
+	return SignHostContainmentWitness(lr.orchestratorPriv, w), nil
 }
 
 // HasReceipt reports whether the evidence JSONL contains at least one receipt
@@ -480,6 +559,25 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 	redPath := filepath.Join(runDir, redWitnessFile)
 	if err := os.WriteFile(redPath, redBytes, 0o600); err != nil {
 		return VerifyReport{}, fmt.Errorf("write red witness: %w", err)
+	}
+
+	// --- Host-containment witness (contained mode only, split-proof) ---
+	// The mediated receipts above prove the proxy's allow/block decision; this
+	// separate witness proves the kernel owner-match drop from the contained
+	// network position. Each property is attested where it is actually enforced.
+	if lr.opts.Contained {
+		hcw, hcwErr := lr.buildHostContainmentWitness()
+		if hcwErr != nil {
+			return VerifyReport{}, fmt.Errorf("host-containment witness: %w", hcwErr)
+		}
+		hcwBytes, hcwMErr := json.Marshal(hcw)
+		if hcwMErr != nil {
+			return VerifyReport{}, fmt.Errorf("marshal host-containment witness: %w", hcwMErr)
+		}
+		hcwPath := filepath.Join(runDir, hostContainmentWitnessFile)
+		if writeErr := os.WriteFile(hcwPath, hcwBytes, 0o600); writeErr != nil {
+			return VerifyReport{}, fmt.Errorf("write host-containment witness: %w", writeErr)
+		}
 	}
 
 	// --- Verify ---

--- a/internal/playground/liverun_internal_test.go
+++ b/internal/playground/liverun_internal_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import "testing"
+
+func TestDecodeProbeResults(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		stdout          string
+		expectedTargets []string
+		wantErr         bool
+		wantOpen        []bool
+	}{
+		{
+			name:            "valid two results",
+			stdout:          `[{"target":"127.0.0.1:1","open":false,"detail":"blocked"},{"target":"127.0.0.1:2","open":true,"detail":"connected"}]`,
+			expectedTargets: []string{"127.0.0.1:1", "127.0.0.1:2"},
+			wantOpen:        []bool{false, true},
+		},
+		{
+			name:            "malformed json",
+			stdout:          `not json`,
+			expectedTargets: []string{"127.0.0.1:1"},
+			wantErr:         true,
+		},
+		{
+			name:            "count mismatch",
+			stdout:          `[{"target":"127.0.0.1:1","open":false,"detail":"blocked"}]`,
+			expectedTargets: []string{"127.0.0.1:1", "127.0.0.1:2"},
+			wantErr:         true,
+		},
+		{
+			name:            "empty array but expected one",
+			stdout:          `[]`,
+			expectedTargets: []string{"127.0.0.1:1"},
+			wantErr:         true,
+		},
+		{
+			name:            "target mismatch",
+			stdout:          `[{"target":"127.0.0.1:2","open":false,"detail":"blocked"}]`,
+			expectedTargets: []string{"127.0.0.1:1"},
+			wantErr:         true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := decodeProbeResults([]byte(tc.stdout), tc.expectedTargets)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got results %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.wantOpen) {
+				t.Fatalf("got %d results, want %d", len(got), len(tc.wantOpen))
+			}
+			for i, open := range tc.wantOpen {
+				if got[i].Open != open {
+					t.Errorf("result[%d].Open=%v want %v", i, got[i].Open, open)
+				}
+			}
+		})
+	}
+}
+
+// TestAllAgentBlocked_HappyAndEmpty pins both ends of AllAgentBlocked: the
+// all-blocked happy path returns true, the empty suite returns false.
+func TestAllAgentBlocked_HappyAndEmpty(t *testing.T) {
+	t.Parallel()
+	w := HostContainmentWitness{
+		ControlAgentProbe: ProbeResult{Open: false},
+		AgentProbes:       []ProbeResult{{Open: false}, {Open: false}},
+	}
+	if !w.AllAgentBlocked() {
+		t.Error("all-blocked suite should report AllAgentBlocked=true")
+	}
+	w.AgentProbes = nil
+	if w.AllAgentBlocked() {
+		t.Error("empty suite must not report AllAgentBlocked=true")
+	}
+}

--- a/internal/playground/liverun_internal_test.go
+++ b/internal/playground/liverun_internal_test.go
@@ -13,12 +13,14 @@ func TestDecodeProbeResults(t *testing.T) {
 		expectedTargets []string
 		wantErr         bool
 		wantOpen        []bool
+		wantBlocked     []bool
 	}{
 		{
 			name:            "valid two results",
-			stdout:          `[{"target":"127.0.0.1:1","open":false,"detail":"blocked"},{"target":"127.0.0.1:2","open":true,"detail":"connected"}]`,
+			stdout:          `[{"target":"127.0.0.1:1","open":false,"blocked":true,"detail":"blocked"},{"target":"127.0.0.1:2","open":true,"blocked":false,"detail":"connected"}]`,
 			expectedTargets: []string{"127.0.0.1:1", "127.0.0.1:2"},
 			wantOpen:        []bool{false, true},
+			wantBlocked:     []bool{true, false},
 		},
 		{
 			name:            "malformed json",
@@ -65,6 +67,9 @@ func TestDecodeProbeResults(t *testing.T) {
 				if got[i].Open != open {
 					t.Errorf("result[%d].Open=%v want %v", i, got[i].Open, open)
 				}
+				if got[i].Blocked != tc.wantBlocked[i] {
+					t.Errorf("result[%d].Blocked=%v want %v", i, got[i].Blocked, tc.wantBlocked[i])
+				}
 			}
 		})
 	}
@@ -75,11 +80,15 @@ func TestDecodeProbeResults(t *testing.T) {
 func TestAllAgentBlocked_HappyAndEmpty(t *testing.T) {
 	t.Parallel()
 	w := HostContainmentWitness{
-		ControlAgentProbe: ProbeResult{Open: false},
-		AgentProbes:       []ProbeResult{{Open: false}, {Open: false}},
+		ControlAgentProbe: ProbeResult{Open: false, Blocked: true},
+		AgentProbes:       []ProbeResult{{Open: false, Blocked: true}, {Open: false, Blocked: true}},
 	}
 	if !w.AllAgentBlocked() {
 		t.Error("all-blocked suite should report AllAgentBlocked=true")
+	}
+	w.AgentProbes = []ProbeResult{{Open: false, Blocked: false}}
+	if w.AllAgentBlocked() {
+		t.Error("reachable-but-closed suite must not report AllAgentBlocked=true")
 	}
 	w.AgentProbes = nil
 	if w.AllAgentBlocked() {

--- a/internal/playground/liverun_unix.go
+++ b/internal/playground/liverun_unix.go
@@ -38,3 +38,27 @@ func configureContainedCommand(cmd *exec.Cmd, agentUser string) error {
 	}
 	return nil
 }
+
+// containedAgentUserName returns the contained agent username, defaulting to
+// pipelock-agent. Used to record the probe identity in the witness.
+func containedAgentUserName(agentUser string) string {
+	if agentUser == "" {
+		return defaultContainedAgentUser
+	}
+	return agentUser
+}
+
+// containedAgentUID resolves the contained agent user's numeric uid for the
+// witness record. Best-effort: returns -1 if the user cannot be resolved (the
+// privileged probe path resolves and validates the user separately).
+func containedAgentUID(agentUser string) int {
+	u, err := user.Lookup(containedAgentUserName(agentUser))
+	if err != nil {
+		return -1
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return -1
+	}
+	return uid
+}

--- a/internal/playground/liverun_windows.go
+++ b/internal/playground/liverun_windows.go
@@ -13,3 +13,18 @@ import (
 func configureContainedCommand(_ *exec.Cmd, _ string) error {
 	return errors.New("contained toy-agent execution is not supported on windows")
 }
+
+// containedAgentUserName returns the contained agent username, defaulting to
+// pipelock-agent. Windows has no contained execution, but the helper keeps the
+// witness record fields populated for cross-platform compilation.
+func containedAgentUserName(agentUser string) string {
+	if agentUser == "" {
+		return defaultContainedAgentUser
+	}
+	return agentUser
+}
+
+// containedAgentUID is unsupported on windows; -1 signals "not resolved".
+func containedAgentUID(_ string) int {
+	return -1
+}

--- a/internal/playground/orchestrate.go
+++ b/internal/playground/orchestrate.go
@@ -173,13 +173,10 @@ func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, e
 		return VerifyReport{}, fmt.Errorf("step 2: %w", err)
 	}
 
-	// Step 3 (bypass) only runs in contained mode.
-	if opts.Contained {
-		timeline = append(timeline, NarrationEvent("Step 3: Direct bypass attempt (expect kernel BLOCK)"))
-		if err := lr.RunSteps(3); err != nil {
-			return VerifyReport{}, fmt.Errorf("step 3: %w", err)
-		}
-	}
+	// Under the split-proof model the direct-egress bypass is no longer a single
+	// in-band agent step; it is proven separately by the host-containment
+	// witness (probes run from the contained network position), which
+	// AssembleAndVerify produces for contained runs.
 
 	// --- Assemble + verify ---
 	rep, err := lr.AssembleAndVerify(opts.RunDir)
@@ -208,9 +205,25 @@ func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, e
 	}
 
 	// --- Containment event (contained mode only) ---
+	// Render the event from the verifier's host-containment checks, not a
+	// hardcoded assumption or an unverified parse of the witness file. The raw
+	// witness only supplies display detail after verification has accepted it.
 	if opts.Contained {
-		// In contained mode, step 3 should have been kernel-blocked.
-		timeline = append(timeline, ContainmentEvent(true, "direct egress denied by nft rules"))
+		verified := checksPassed(rep,
+			checkHostContainSig,
+			checkHostContainBinding,
+			checkHostContainEnforced,
+		)
+		detail := "host-containment witness did not pass offline verification"
+		hcwPath := filepath.Clean(filepath.Join(opts.RunDir, hostContainmentWitnessFile))
+		if hcwData, hcwErr := os.ReadFile(hcwPath); hcwErr == nil {
+			var hcw HostContainmentWitness
+			if json.Unmarshal(hcwData, &hcw) == nil && verified {
+				detail = fmt.Sprintf("%d direct-egress routes blocked for %s; control target reachable for operator",
+					len(hcw.AgentProbes), hcw.AgentUser)
+			}
+		}
+		timeline = append(timeline, ContainmentEvent(verified, detail))
 	}
 
 	// --- Render timeline ---
@@ -222,6 +235,19 @@ func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, e
 	renderVerifySummary(out, rep, opts.RunDir)
 
 	return rep, nil
+}
+
+func checksPassed(rep VerifyReport, names ...string) bool {
+	passed := make(map[string]bool, len(rep.Checks))
+	for _, check := range rep.Checks {
+		passed[check.Name] = check.OK
+	}
+	for _, name := range names {
+		if !passed[name] {
+			return false
+		}
+	}
+	return true
 }
 
 // renderVerifySummary prints the VerifyReport checks and the audience verify

--- a/internal/playground/types.go
+++ b/internal/playground/types.go
@@ -26,5 +26,11 @@ type LaunchManifest struct {
 	CollectorConfigDigest string    `json:"collector_config_digest"`
 	TargetHost            string    `json:"target_host"`
 	StartedAt             time.Time `json:"started_at"`
-	Signature             string    `json:"signature,omitempty"`
+	// Contained pins, in the signed manifest, whether this run produced a
+	// host-containment witness. When true, VerifyRun additionally requires the
+	// host-containment checks to be present and pass. Because the manifest is
+	// signed under the orchestrator key, an attacker cannot flip this to skip
+	// the containment checks without invalidating the manifest signature.
+	Contained bool   `json:"contained"`
+	Signature string `json:"signature,omitempty"`
 }

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -46,18 +46,22 @@ type VerifyReport struct {
 //	  launch-manifest.json   # signed LaunchManifest (JSON)
 //	  witness.json           # signed Witness (JSON)
 const (
-	packetSubdir          = "packet"
-	launchManifestFile    = "launch-manifest.json"
-	witnessFile           = "witness.json"
-	redWitnessFile        = "red-witness.json"
-	checkManifestSig      = "launch-manifest-signature"
-	checkPinnedPipelock   = "pinned-pipelock-key"
-	checkAuditPacket      = "audit-packet-chain"
-	checkPinnedCollector  = "pinned-collector-key"
-	checkWitnessSig       = "collector-witness-signature"
-	checkWitnessBinding   = "witness-binds-run"
-	checkRedCaseCalibrate = "red-case-calibration"
-	checkLiveSemantics    = "live-demo-semantics"
+	packetSubdir               = "packet"
+	launchManifestFile         = "launch-manifest.json"
+	witnessFile                = "witness.json"
+	redWitnessFile             = "red-witness.json"
+	hostContainmentWitnessFile = "host-containment-witness.json"
+	checkManifestSig           = "launch-manifest-signature"
+	checkPinnedPipelock        = "pinned-pipelock-key"
+	checkAuditPacket           = "audit-packet-chain"
+	checkPinnedCollector       = "pinned-collector-key"
+	checkWitnessSig            = "collector-witness-signature"
+	checkWitnessBinding        = "witness-binds-run"
+	checkRedCaseCalibrate      = "red-case-calibration"
+	checkLiveSemantics         = "live-demo-semantics"
+	checkHostContainSig        = "host-containment-witness-signature"
+	checkHostContainBinding    = "host-containment-binds-run"
+	checkHostContainEnforced   = "host-containment-enforced"
 )
 
 // requiredChecks is the full set of check names that must all appear and pass
@@ -73,6 +77,16 @@ var requiredChecks = []string{
 	checkWitnessBinding,
 	checkRedCaseCalibrate,
 	checkLiveSemantics,
+}
+
+// containmentChecks are the additional checks required when the signed manifest
+// declares Contained=true. They are appended to requiredChecks for contained
+// runs so a contained run cannot be verified without a valid, run-bound,
+// enforced host-containment witness.
+var containmentChecks = []string{
+	checkHostContainSig,
+	checkHostContainBinding,
+	checkHostContainEnforced,
 }
 
 // VerifyRun performs the all-or-nothing offline verification of a playground
@@ -95,6 +109,10 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 	rep := VerifyReport{OrchestratorKey: orchestratorPubHex}
 	cleanDir := filepath.Clean(dir)
 
+	// required is the base check set until the manifest reveals whether this was
+	// a contained run, at which point the containment checks are appended.
+	required := requiredChecks
+
 	// --- Load files (fail closed on missing/malformed) ---
 
 	lmBytes, err := os.ReadFile(filepath.Clean(filepath.Join(cleanDir, launchManifestFile)))
@@ -104,7 +122,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: fmt.Sprintf("cannot read launch-manifest.json: %v", err),
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	var lm LaunchManifest
 	if err := json.Unmarshal(lmBytes, &lm); err != nil {
@@ -113,7 +131,15 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: fmt.Sprintf("malformed launch-manifest.json: %v", err),
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
+	}
+	// A contained run additionally requires the host-containment checks. The
+	// flag is read from the (not-yet-signature-verified) manifest, but it is
+	// covered by the manifest signature: any tamper -- flipping Contained to
+	// false to skip the checks, or to true on an uncontained run -- breaks the
+	// signature and fails step 1 below, so this can only fail closed.
+	if lm.Contained {
+		required = append(append([]string{}, requiredChecks...), containmentChecks...)
 	}
 
 	wBytes, err := os.ReadFile(filepath.Clean(filepath.Join(cleanDir, witnessFile)))
@@ -127,7 +153,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: fmt.Sprintf("cannot read witness.json: %v", err),
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	var witness Witness
 	if err := json.Unmarshal(wBytes, &witness); err != nil {
@@ -140,7 +166,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: fmt.Sprintf("malformed witness.json: %v", err),
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 
 	// --- Step 1: Verify launch manifest signature under orchestrator key ---
@@ -152,7 +178,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: "invalid orchestrator public key",
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	if !VerifyLaunchManifest(ed25519.PublicKey(orchPub), lm) {
 		rep.Checks = append(rep.Checks, Check{
@@ -160,7 +186,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: "launch manifest signature invalid under orchestrator key",
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	rep.Checks = append(rep.Checks, Check{
 		Name: checkManifestSig,
@@ -181,7 +207,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: "manifest pins no valid pipelock public key",
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	rep.Checks = append(rep.Checks, Check{
 		Name: checkPinnedPipelock,
@@ -197,14 +223,14 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: fmt.Sprintf("audit packet verification failed: %v", err),
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	rep.Checks = append(rep.Checks, Check{
 		Name: checkAuditPacket,
 		OK:   true,
 	})
 
-	// --- Pinned collector key gate (before step 3) ---
+	// --- Pinned collector key gate (before witness verification) ---
 	// Belt-and-suspenders: VerifyWitness also rejects empty/short keys, but
 	// an explicit gate here documents the trust-chain intent and is robust
 	// to future refactoring of VerifyWitness.
@@ -214,7 +240,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: "manifest pins no valid collector public key",
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	rep.Checks = append(rep.Checks, Check{
 		Name: checkPinnedCollector,
@@ -229,7 +255,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: "witness signature invalid under manifest's collector key",
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	rep.Checks = append(rep.Checks, Check{
 		Name: checkWitnessSig,
@@ -244,7 +270,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: fmt.Sprintf("witness nonce=%q manifestHash=%q does not match manifest nonce=%q hash=%q", witness.RunNonce, witness.LaunchManifestHash, lm.RunNonce, lm.Hash()),
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	rep.Checks = append(rep.Checks, Check{
 		Name: checkWitnessBinding,
@@ -260,7 +286,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: "red-case result missing from witness",
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	redWitness, redReasons := verifyRedWitnessArtifact(cleanDir, lm, rc)
 	if !rc.WitnessWentRed {
@@ -284,7 +310,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: fmt.Sprintf("red-case check failed: %v", redReasons),
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	rep.Checks = append(rep.Checks, Check{
 		Name: checkRedCaseCalibrate,
@@ -299,15 +325,85 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 			OK:     false,
 			Reason: err.Error(),
 		})
-		return finalize(rep), nil
+		return finalize(rep, required), nil
 	}
 	rep.Checks = append(rep.Checks, Check{
 		Name: checkLiveSemantics,
 		OK:   true,
 	})
 
+	// --- Step 7: Host-containment witness (contained runs only) ---
+	// Split-proof: the steps above prove the proxy's mediated allow/block
+	// decision; this proves the kernel owner-match drop from the contained
+	// network position. Required only when the signed manifest says Contained.
+	if lm.Contained {
+		verifyHostContainment(cleanDir, lm, orchestratorPubHex, &rep)
+	}
+
 	rep.ObservedCount = witness.ObservedCount
-	return finalize(rep), nil
+	return finalize(rep, required), nil
+}
+
+// verifyHostContainment loads and checks the host-containment witness for a
+// contained run, appending the three containment checks to rep. It fails closed
+// on a missing/malformed witness, a signature invalid under the orchestrator
+// key, a witness bound to a different run, or a witness whose probes do not
+// prove enforcement (the differential + no-leak gate). It returns early after
+// the first failing check so later checks are absent and finalize reports the
+// run as not verified.
+func verifyHostContainment(runDir string, lm LaunchManifest, orchestratorPubHex string, rep *VerifyReport) {
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(runDir, hostContainmentWitnessFile)))
+	if err != nil {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkHostContainSig,
+			OK:     false,
+			Reason: fmt.Sprintf("cannot read %s: %v", hostContainmentWitnessFile, err),
+		})
+		return
+	}
+	var hcw HostContainmentWitness
+	if err := json.Unmarshal(data, &hcw); err != nil {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkHostContainSig,
+			OK:     false,
+			Reason: fmt.Sprintf("malformed %s: %v", hostContainmentWitnessFile, err),
+		})
+		return
+	}
+
+	// Signature under the orchestrator key (the run's trust root).
+	if !VerifyHostContainmentWitness(orchestratorPubHex, hcw) {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkHostContainSig,
+			OK:     false,
+			Reason: "host-containment witness signature invalid under orchestrator key",
+		})
+		return
+	}
+	rep.Checks = append(rep.Checks, Check{Name: checkHostContainSig, OK: true})
+
+	// Binding to this exact run (nonce + manifest hash) -- non-replayable.
+	if !HostContainmentBindsRun(hcw, lm.RunNonce, lm.Hash()) {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkHostContainBinding,
+			OK:     false,
+			Reason: fmt.Sprintf("witness nonce=%q manifestHash=%q does not match manifest nonce=%q hash=%q", hcw.RunNonce, hcw.LaunchManifestHash, lm.RunNonce, lm.Hash()),
+		})
+		return
+	}
+	rep.Checks = append(rep.Checks, Check{Name: checkHostContainBinding, OK: true})
+
+	// Enforcement: the differential holds (operator reaches the control target,
+	// the contained agent does not) AND every contained-agent probe was blocked.
+	if !hcw.Enforced() {
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkHostContainEnforced,
+			OK:     false,
+			Reason: "host-containment not proven: differential failed, target suite missing/substituted, or a direct-egress route was open",
+		})
+		return
+	}
+	rep.Checks = append(rep.Checks, Check{Name: checkHostContainEnforced, OK: true})
 }
 
 func verifyRedWitnessArtifact(runDir string, lm LaunchManifest, rc *RedCaseResult) (Witness, []string) {
@@ -418,11 +514,12 @@ func verifyURLExfilReplayCompatible(receipts []receipt.Receipt, witness Witness)
 }
 
 // finalize computes the top-level OK. It is affirmative: OK=true requires
-// that every entry in requiredChecks appeared AND none failed. An empty
-// Checks slice, a missing check name, or any failed check all produce
-// OK=false. This invariant means a future early-return that forgets to
-// append a Check cannot silently produce OK=true.
-func finalize(rep VerifyReport) VerifyReport {
+// that every entry in required appeared AND none failed. An empty Checks slice,
+// a missing check name, or any failed check all produce OK=false. This
+// invariant means a future early-return that forgets to append a Check cannot
+// silently produce OK=true. The required set is computed by VerifyRun and
+// includes the containment checks for contained runs.
+func finalize(rep VerifyReport, required []string) VerifyReport {
 	if len(rep.Checks) == 0 {
 		rep.OK = false
 		return rep
@@ -438,7 +535,7 @@ func finalize(rep VerifyReport) VerifyReport {
 	}
 
 	// Every required check must be present.
-	for _, name := range requiredChecks {
+	for _, name := range required {
 		if !present[name] {
 			allPassed = false
 			break

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -198,8 +198,8 @@ func validHostContainmentWitness(nonce, manifestHash string) playground.HostCont
 		AgentUser:            "pipelock-agent",
 		AgentUID:             966,
 		ControlTarget:        ctrl,
-		ControlOperatorProbe: playground.ProbeResult{Target: ctrl, Open: true, Detail: "connected"},
-		ControlAgentProbe:    playground.ProbeResult{Target: ctrl, Open: false, Detail: "blocked: timeout"},
+		ControlOperatorProbe: playground.ProbeResult{Target: ctrl, Open: true, Blocked: false, Detail: "connected"},
+		ControlAgentProbe:    playground.ProbeResult{Target: ctrl, Open: false, Blocked: true, Detail: "blocked: timeout"},
 		AgentProbes:          blockedDirectProbes(),
 		ProbedAt:             time.Unix(1_700_000_000, 0).UTC(),
 	}

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -48,6 +48,16 @@ func testGenKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
 // Returns (dir, orchestratorPubHex).
 func goodRunDir(t *testing.T) (string, string) {
 	t.Helper()
+	dir, pubHex, _ := buildRunDir(t, false)
+	return dir, pubHex
+}
+
+// buildRunDir is the parameterized core of goodRunDir. When contained is true it
+// marks the signed manifest Contained=true and additionally writes a valid,
+// run-bound, enforced host-containment-witness.json signed by the orchestrator
+// key. It returns the orchestrator private key so callers can re-sign or tamper.
+func buildRunDir(t *testing.T, contained bool) (string, string, ed25519.PrivateKey) {
+	t.Helper()
 
 	// 1. Generate keys.
 	orchPub, orchPriv := testGenKey(t)
@@ -110,6 +120,7 @@ func goodRunDir(t *testing.T) (string, string) {
 		PolicyHash:      captured.PolicyHash,
 		TargetHost:      "exfil.target.test",
 		StartedAt:       time.Now().UTC(),
+		Contained:       contained,
 	}
 	lm = playground.SignLaunchManifest(orchPriv, lm)
 
@@ -159,7 +170,39 @@ func goodRunDir(t *testing.T) (string, string) {
 		t.Fatalf("write red witness: %v", err)
 	}
 
-	return runDir, hex.EncodeToString(orchPub)
+	// For contained runs, also write a valid, run-bound, enforced
+	// host-containment witness signed by the orchestrator key.
+	if contained {
+		hcw := validHostContainmentWitness(nonce, lm.Hash())
+		hcw = playground.SignHostContainmentWitness(orchPriv, hcw)
+		hcwBytes, err := json.Marshal(hcw)
+		if err != nil {
+			t.Fatalf("marshal host-containment witness: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(runDir, "host-containment-witness.json"), hcwBytes, 0o600); err != nil {
+			t.Fatalf("write host-containment witness: %v", err)
+		}
+	}
+
+	return runDir, hex.EncodeToString(orchPub), orchPriv
+}
+
+// validHostContainmentWitness builds an unsigned witness that passes Enforced():
+// the control target is operator-reachable and agent-blocked (the differential),
+// and every real direct-egress probe is blocked.
+func validHostContainmentWitness(nonce, manifestHash string) playground.HostContainmentWitness {
+	const ctrl = "127.0.0.1:54321"
+	return playground.HostContainmentWitness{
+		RunNonce:             nonce,
+		LaunchManifestHash:   manifestHash,
+		AgentUser:            "pipelock-agent",
+		AgentUID:             966,
+		ControlTarget:        ctrl,
+		ControlOperatorProbe: playground.ProbeResult{Target: ctrl, Open: true, Detail: "connected"},
+		ControlAgentProbe:    playground.ProbeResult{Target: ctrl, Open: false, Detail: "blocked: timeout"},
+		AgentProbes:          blockedDirectProbes(),
+		ProbedAt:             time.Unix(1_700_000_000, 0).UTC(),
+	}
 }
 
 // mustFailVerify builds a good run dir, applies a mutation, and asserts that
@@ -208,7 +251,7 @@ func TestVerify_AllGood_Passes(t *testing.T) {
 func TestVerify_TamperedWitnessByte_FailsClosed(t *testing.T) {
 	t.Parallel()
 	mustFailVerify(t, func(dir string) {
-		flipByteInFile(t, filepath.Join(dir, "witness.json"), "signature")
+		flipByteInFile(t, filepath.Join(dir, "witness.json"))
 	})
 }
 
@@ -311,14 +354,14 @@ func TestVerify_BrokenReceiptChain_FailsClosed(t *testing.T) {
 		// Corrupt a byte in the receipt signature inside the evidence JSONL
 		// to break the chain verification.
 		evidencePath := findEvidenceFile(t, filepath.Join(dir, "packet"))
-		flipByteInFile(t, evidencePath, "signature")
+		flipByteInFile(t, evidencePath)
 	})
 }
 
 func TestVerify_TamperedManifestSig_FailsClosed(t *testing.T) {
 	t.Parallel()
 	mustFailVerify(t, func(dir string) {
-		flipByteInFile(t, filepath.Join(dir, "launch-manifest.json"), "signature")
+		flipByteInFile(t, filepath.Join(dir, "launch-manifest.json"))
 	})
 }
 
@@ -605,8 +648,10 @@ func goodRunDirWithSignedCollectorLeak(t *testing.T) (string, string) {
 
 // flipByteInFile reads a JSON file, finds the first occurrence of fieldHint in
 // the raw bytes, and flips a byte near it to corrupt the data.
-func flipByteInFile(t *testing.T, path, fieldHint string) {
+func flipByteInFile(t *testing.T, path string) {
 	t.Helper()
+	// All callers tamper with the JSON "signature" field's value.
+	const fieldHint = "signature"
 	cleanPath := filepath.Clean(path)
 	data, err := os.ReadFile(cleanPath)
 	if err != nil {


### PR DESCRIPTION
## What changed

Host verification of the playground demo's contained mode on a real owner-match containment host surfaced two problems the CI-skipped unit tests could not: the contained agent could not reach the demo's ephemeral lab proxy (so the mediated steps produced no receipts), and the single-target direct-egress bypass aimed at an unroutable address (so a "block" was indistinguishable from an unreachable target).

This reworks contained mode into a **split proof**:

- **Mediated decisions** (allow + body-DLP block) come from the lab run with the agent steps running as the operator, so they reach the lab proxy and produce real signed receipts, exactly as in uncontained mode.
- **Kernel containment** is proven separately by a new signed `HostContainmentWitness`, built from the contained agent's network position via the toy agent's new `--probe-targets` mode (dropped to the contained uid). Its honesty rests on a differential: a host-local control target reachable for the operator but blocked for the agent isolates the kernel owner-match drop, so a block can no longer be confused with an unreachable target. The witness must cover the exact direct-egress suite, is signed by the orchestrator key, and binds the run nonce and manifest hash.

`verify` requires three additional checks for contained runs (witness signature, run binding, enforced). The contained flag lives in the signed manifest, so it cannot be stripped to skip those checks. The mediator's containment line is rendered from the verifier's accepted checks, not a hardcoded assumption.

Docs (`docs/guides/playground-demo.md`) are updated to the split-proof model.

## Why

The previous contained mode could not produce evidence on a host with global owner-match containment, and its bypass proof was ambiguous (a timeout to an unroutable address looks identical to a kernel block). Each property is now proven where it is actually enforced: the proxy's allow/block decision via signed receipts, and the kernel egress block via a signed, offline-verifiable witness anchored to an operator-vs-agent differential.

The privileged uid-scoped probe path is host-only and cannot run in CI. Its parsing and witness logic are unit-tested with synthetic probes and adversarial fail-closed cases (tamper, wrong-key re-sign, open route, broken differential, omitted or substituted targets, replay).

## Note

Stacked on #784 (the playground live-demo base) and targets that branch. Rebase onto `main` once #784 merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `--probe-targets` mode to run direct egress checks and output JSON probe results.
  * Added a split-proof, cryptographically signed host-containment witness for contained runs, including stricter verification and run binding.
* **Bug Fixes**
  * Improved direct egress probe classification and strengthened fail-closed behavior when evidence is missing, malformed, tampered, or not enforced.
  * Contained-run verification now requires the host-containment checks to be present and passing.
* **Documentation**
  * Updated the playground demo guide with the revised containment workflow and verification expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->