### PR TITLE
fix(conductor): tolerate abandoned fork siblings + offline recovery

### DIFF
--- a/docs/cli/conductor-recovery.md
+++ b/docs/cli/conductor-recovery.md
@@ -80,6 +80,60 @@ pipelock conductor store dump \
   --client-cert client.crt --client-key client.key --ca-file ca.pem
 ```
 
+## `store inspect-offline` and `store repair` (offline recovery)
+
+`store dump`, `stream inspect`, `stream status`, and `stream reset` are all
+client-side: they require a live Conductor reachable over mTLS. If a corrupt
+bundle store crashes the Conductor at startup, none of them can run -- the store
+is unrecoverable without raw filesystem surgery.
+
+`store inspect-offline` and `store repair` operate directly on `--storage-dir`
+with **no running server**. `--storage-dir` is the same directory passed to
+`conductor serve`; the policy-bundle store lives under its `policy-bundles/`
+subdirectory.
+
+### `store inspect-offline`
+
+Read-only analysis of the on-disk bundle store. Reports each stream's head and
+chain, any record files that could not be parsed, and any provably-orphaned
+records that would fail startup validation. Always exits without modifying state.
+
+```sh
+pipelock conductor store inspect-offline --storage-dir /var/lib/pipelock/conductor
+```
+
+An *orphaned* record is one that is NOT reachable from its stream's head, NOT
+covered by a durable rollback marker, and NOT a tolerated historical fork sibling
+(a branch abandoned by an authorized rollback-then-publish cycle, which the store
+loads as audit history). Add `--json` for machine-readable output.
+
+### `store repair`
+
+Removes provably-orphaned records to unbrick startup. It mirrors the safety
+posture of `stream reset`:
+
+- **Without `--confirm` it is a dry run**: it lists what it would remove and
+  changes nothing.
+
+```sh
+pipelock conductor store repair --storage-dir /var/lib/pipelock/conductor
+```
+
+- **With `--confirm` it removes the orphans**, copying each removed record to a
+  backup directory first (default
+  `<storage-dir>/policy-bundles/offline-repair-backup/<timestamp>`; override with
+  `--backup-dir`).
+
+```sh
+pipelock conductor store repair --storage-dir /var/lib/pipelock/conductor --confirm
+```
+
+`store repair` NEVER removes a record reachable from a head, a rollback-covered
+record, a tolerated historical fork sibling, an unreadable record, an off-chain
+record whose own ancestry chain is corrupt (flagged for manual review), the
+stream-head markers, or the audit store. Records flagged for manual review are
+reported but left in place for the operator to investigate.
+
 ## Rollback authorization TTL enforcement
 
 The rollback authorization's `expires_at` field (set via `--ttl` at publish time,

--- a/docs/cli/conductor-recovery.md
+++ b/docs/cli/conductor-recovery.md
@@ -84,8 +84,8 @@ pipelock conductor store dump \
 
 `store dump`, `stream inspect`, `stream status`, and `stream reset` are all
 client-side: they require a live Conductor reachable over mTLS. If a corrupt
-bundle store crashes the Conductor at startup, none of them can run -- the store
-is unrecoverable without raw filesystem surgery.
+bundle store crashes the Conductor at startup, none of those live-server commands
+can run, so recovery needs an offline path.
 
 `store inspect-offline` and `store repair` operate directly on `--storage-dir`
 with **no running server**. `--storage-dir` is the same directory passed to

--- a/enterprise/cli/conductor/store_dump.go
+++ b/enterprise/cli/conductor/store_dump.go
@@ -27,6 +27,8 @@ func storeCmd() *cobra.Command {
 		Short: "Inspect Conductor control-plane store state",
 	}
 	cmd.AddCommand(storeDumpCmd())
+	cmd.AddCommand(storeInspectOfflineCmd())
+	cmd.AddCommand(storeRepairOfflineCmd())
 	return cmd
 }
 

--- a/enterprise/cli/conductor/store_offline.go
+++ b/enterprise/cli/conductor/store_offline.go
@@ -146,7 +146,7 @@ func runStoreInspectOffline(cmd *cobra.Command, opts storeOfflineOptions) error 
 	for _, o := range report.Orphans {
 		_, _ = fmt.Fprintf(out, "  %s (%s v%d): %s\n", o.BundleHash, o.BundleID, o.Version, o.Reason)
 	}
-	_, _ = fmt.Fprintln(out, "run 'conductor store repair --storage-dir <dir> --confirm' to remove the removable orphans (backed up first)")
+	_, _ = fmt.Fprintf(out, "run 'conductor store repair --storage-dir %s --confirm' to remove the removable orphans (backed up first)\n", opts.storageDir)
 	return nil
 }
 

--- a/enterprise/cli/conductor/store_offline.go
+++ b/enterprise/cli/conductor/store_offline.go
@@ -1,0 +1,195 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+// policyBundlesSubdir is the subdirectory under --storage-dir that holds the
+// policy-bundle store, matching what `conductor serve` passes to
+// OpenFileBundleStore.
+const policyBundlesSubdir = "policy-bundles"
+
+type storeOfflineOptions struct {
+	storageDir     string
+	backupDir      string
+	confirm        bool
+	jsonOut        bool
+	licenseCRLFile string
+}
+
+func (o *storeOfflineOptions) bindCommon(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.storageDir, "storage-dir", "", "Conductor storage directory (the same --storage-dir passed to 'conductor serve') (required)")
+	cmd.Flags().BoolVar(&o.jsonOut, "json", false, "emit the report as JSON")
+	cmd.Flags().StringVar(&o.licenseCRLFile, "license-crl-file", "", "signed license revocation list file; falls back to PIPELOCK_LICENSE_CRL_FILE")
+}
+
+func storeInspectOfflineCmd() *cobra.Command {
+	opts := storeOfflineOptions{}
+	cmd := &cobra.Command{
+		Use:   "inspect-offline",
+		Short: "Analyze the Conductor bundle store directly on disk, with no running server",
+		Long: `inspect-offline reads the Conductor policy-bundle store directly from
+--storage-dir without contacting (or requiring) a running Conductor. It reports
+each stream's head and chain plus any provably-orphaned records that would brick
+startup, and any record files that could not be parsed.
+
+This is the recovery counterpart to 'conductor store dump', which needs a live
+server over mTLS. When a store wedge crashes the server at startup, the live
+commands cannot run; inspect-offline still can. It is strictly read-only.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.licenseCRLFile}); err != nil {
+				return err
+			}
+			return runStoreInspectOffline(cmd, opts)
+		},
+	}
+	opts.bindCommon(cmd)
+	return cmd
+}
+
+func storeRepairOfflineCmd() *cobra.Command {
+	opts := storeOfflineOptions{}
+	cmd := &cobra.Command{
+		Use:   "repair",
+		Short: "Remove provably-orphaned bundle records on disk to unbrick startup (offline)",
+		Long: `repair removes provably-orphaned bundle records from the Conductor
+policy-bundle store under --storage-dir, operating directly on disk with no
+running server. An orphan is a record that is NOT reachable from its stream's
+head, NOT covered by a durable rollback marker, and NOT a tolerated historical
+fork sibling -- exactly the records that fail startup validation.
+
+Safety posture (mirrors 'conductor stream reset'):
+
+  - Without --confirm the command is a DRY RUN: it lists what it would remove and
+    changes nothing.
+  - With --confirm each removed record is first copied to a backup directory
+    (default: <storage-dir>/policy-bundles/offline-repair-backup/<timestamp>).
+  - It NEVER removes a record reachable from a head, a rollback-covered record, a
+    tolerated fork sibling, an unreadable record, an off-chain record with a
+    corrupt ancestry chain (flagged for manual review), the stream-head markers,
+    or the audit store.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.licenseCRLFile}); err != nil {
+				return err
+			}
+			return runStoreRepairOffline(cmd, opts)
+		},
+	}
+	opts.bindCommon(cmd)
+	cmd.Flags().StringVar(&opts.backupDir, "backup-dir", "", "directory to back up removed records into (default: <storage-dir>/policy-bundles/offline-repair-backup/<timestamp>)")
+	cmd.Flags().BoolVar(&opts.confirm, "confirm", false, "actually remove orphaned records; without it the command is a dry run")
+	return cmd
+}
+
+func resolvePolicyBundlesDir(storageDir string) (string, error) {
+	trimmed := strings.TrimSpace(storageDir)
+	if trimmed == "" {
+		return "", errors.New("--storage-dir is required")
+	}
+	abs, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve --storage-dir: %w", err)
+	}
+	return filepath.Join(abs, policyBundlesSubdir), nil
+}
+
+func runStoreInspectOffline(cmd *cobra.Command, opts storeOfflineOptions) error {
+	dir, err := resolvePolicyBundlesDir(opts.storageDir)
+	if err != nil {
+		return err
+	}
+	report, err := controlplane.InspectOfflineStore(dir)
+	if err != nil {
+		return err
+	}
+	if opts.jsonOut {
+		return writeJSON(cmd, report)
+	}
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "conductor bundle store: %s\n", report.BundlesDir)
+	_, _ = fmt.Fprintf(out, "streams: %d\n", len(report.Streams))
+	for _, s := range report.Streams {
+		_, _ = fmt.Fprintf(out, "  stream %s\n", s.StreamKey)
+		_, _ = fmt.Fprintf(out, "    head: %s v%d (%s)\n", s.HeadBundleID, s.HeadVersion, s.HeadBundleHash)
+		_, _ = fmt.Fprintf(out, "    max version: %d, records: %d\n", s.MaxVersion, s.RecordCount)
+		if s.RollbackMarker {
+			_, _ = fmt.Fprintf(out, "    rollback marker: superseded_version=%d\n", s.SupersededVersion)
+		}
+	}
+	if len(report.UnreadableRecords) > 0 {
+		_, _ = fmt.Fprintf(out, "unreadable records (manual review, NOT auto-removed): %d\n", len(report.UnreadableRecords))
+		for _, u := range report.UnreadableRecords {
+			_, _ = fmt.Fprintf(out, "  %s: %s\n", u.FileName, u.Err)
+		}
+	}
+	if len(report.Orphans) == 0 {
+		_, _ = fmt.Fprintln(out, "orphaned records: none (store would load cleanly)")
+		return nil
+	}
+	_, _ = fmt.Fprintf(out, "orphaned records: %d\n", len(report.Orphans))
+	for _, o := range report.Orphans {
+		_, _ = fmt.Fprintf(out, "  %s (%s v%d): %s\n", o.BundleHash, o.BundleID, o.Version, o.Reason)
+	}
+	_, _ = fmt.Fprintln(out, "run 'conductor store repair --storage-dir <dir> --confirm' to remove the removable orphans (backed up first)")
+	return nil
+}
+
+func runStoreRepairOffline(cmd *cobra.Command, opts storeOfflineOptions) error {
+	dir, err := resolvePolicyBundlesDir(opts.storageDir)
+	if err != nil {
+		return err
+	}
+	result, err := controlplane.RepairOfflineStore(dir, opts.backupDir, opts.confirm, time.Time{})
+	if err != nil {
+		return err
+	}
+	if opts.jsonOut {
+		return writeJSON(cmd, result)
+	}
+	out := cmd.OutOrStdout()
+	if result.DryRun {
+		if len(result.Removed) == 0 {
+			_, _ = fmt.Fprintln(out, "dry run: no removable orphaned records found; pass --confirm only when there are orphans to remove")
+			return nil
+		}
+		_, _ = fmt.Fprintf(out, "dry run: would remove %d orphaned record(s); pass --confirm to proceed (each is backed up first):\n", len(result.Removed))
+		for _, o := range result.Removed {
+			_, _ = fmt.Fprintf(out, "  %s (%s v%d): %s\n", o.BundleHash, o.BundleID, o.Version, o.Reason)
+		}
+		return nil
+	}
+	if len(result.Removed) == 0 {
+		_, _ = fmt.Fprintln(out, "no removable orphaned records found; nothing removed")
+		return nil
+	}
+	_, _ = fmt.Fprintf(out, "removed %d orphaned record(s); backups written to %s\n", len(result.Removed), result.BackupDir)
+	for _, o := range result.Removed {
+		_, _ = fmt.Fprintf(out, "  removed %s (%s v%d)\n", o.BundleHash, o.BundleID, o.Version)
+	}
+	return nil
+}
+
+func writeJSON(cmd *cobra.Command, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return nil
+}

--- a/enterprise/cli/conductor/store_offline_test.go
+++ b/enterprise/cli/conductor/store_offline_test.go
@@ -1,0 +1,167 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	conductorcore "github.com/luckyPipewrench/pipelock/enterprise/conductor"
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// seedCleanStore publishes one wildcard-audience bundle into a real policy-bundle
+// store under <storageDir>/policy-bundles, exercising the same on-disk layout the
+// offline commands read. It returns the storage dir to pass via --storage-dir.
+func seedCleanStore(t *testing.T) string {
+	t.Helper()
+	storageDir := t.TempDir()
+	pb := filepath.Join(storageDir, "policy-bundles")
+	store, err := controlplane.OpenFileBundleStore(pb)
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore: %v", err)
+	}
+	bundle := offlineTestBundle(t)
+	if _, _, err := store.Publish(t.Context(), bundle, controlplane.PublishOptions{Now: time.Now().UTC()}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	return storageDir
+}
+
+// offlineTestBundle builds a minimal valid, signed policy bundle.
+func offlineTestBundle(t *testing.T) conductorcore.PolicyBundle {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	now := time.Now().UTC()
+	payload := conductorcore.PolicyBundlePayload{ConfigYAML: "mode: strict\napi_allowlist:\n  - api.example.com\n"}
+	payloadHash, err := payload.PayloadHash()
+	if err != nil {
+		t.Fatalf("PayloadHash: %v", err)
+	}
+	policyHash, err := payload.PolicyHash()
+	if err != nil {
+		t.Fatalf("PolicyHash: %v", err)
+	}
+	bundle := conductorcore.PolicyBundle{
+		SchemaVersion:      conductorcore.SchemaVersion,
+		BundleID:           "bundle-offline-cli",
+		OrgID:              "org-cli",
+		FleetID:            "prod",
+		Environment:        "prod",
+		Audience:           conductorcore.Audience{InstanceIDs: []string{"*"}},
+		Version:            1,
+		CreatedAt:          now.Add(-time.Minute),
+		NotBefore:          now.Add(-time.Minute),
+		ExpiresAt:          now.Add(2 * time.Hour),
+		MinPipelockVersion: "1.2.3",
+		PolicyHash:         policyHash,
+		PayloadSHA256:      payloadHash,
+		Payload:            payload,
+	}
+	preimage, err := bundle.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage: %v", err)
+	}
+	bundle.Signatures = []conductorcore.SignatureProof{{
+		SignerKeyID: "policy-key-1",
+		KeyPurpose:  signing.PurposePolicyBundleSigning,
+		Algorithm:   conductorcore.SignatureAlgorithmEd25519,
+		Signature:   conductorcore.SignaturePrefixEd25519 + hex.EncodeToString(ed25519.Sign(priv, preimage)),
+	}}
+	if err := bundle.Validate(); err != nil {
+		t.Fatalf("bundle Validate: %v", err)
+	}
+	return bundle
+}
+
+func TestStoreInspectOfflineCmd_NoFleetLicenseFailsClosed(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	t.Setenv(license.EnvLicensePublicKey, "")
+	t.Setenv(license.EnvLicenseCRLFile, "")
+	cmd := Cmd()
+	cmd.SetArgs([]string{"store", "inspect-offline", "--storage-dir", t.TempDir()})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err == nil || !errors.Is(err, license.ErrFleetLicenseRequired) {
+		t.Fatalf("inspect-offline without fleet license: err = %v, want ErrFleetLicenseRequired", err)
+	}
+}
+
+func TestStoreRepairOfflineCmd_NoFleetLicenseFailsClosed(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	t.Setenv(license.EnvLicensePublicKey, "")
+	t.Setenv(license.EnvLicenseCRLFile, "")
+	cmd := Cmd()
+	cmd.SetArgs([]string{"store", "repair", "--storage-dir", t.TempDir(), "--confirm"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err == nil || !errors.Is(err, license.ErrFleetLicenseRequired) {
+		t.Fatalf("repair without fleet license: err = %v, want ErrFleetLicenseRequired", err)
+	}
+}
+
+func TestRunStoreInspectOffline_MissingStorageDir(t *testing.T) {
+	err := runStoreInspectOffline(newCapturingCmd(), storeOfflineOptions{})
+	if err == nil || !strings.Contains(err.Error(), "--storage-dir is required") {
+		t.Fatalf("missing storage-dir error = %v, want --storage-dir required", err)
+	}
+}
+
+func TestStoreInspectOfflineCmd_CleanStoreReportsNoOrphans(t *testing.T) {
+	setFleetLicenseEnv(t)
+	storageDir := seedCleanStore(t)
+	var out bytes.Buffer
+	cmd := Cmd()
+	cmd.SetArgs([]string{"store", "inspect-offline", "--storage-dir", storageDir})
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("inspect-offline: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"streams: 1", "orphaned records: none"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("inspect-offline output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+func TestStoreRepairOfflineCmd_CleanStoreDryRunNoOp(t *testing.T) {
+	setFleetLicenseEnv(t)
+	storageDir := seedCleanStore(t)
+	var out bytes.Buffer
+	cmd := Cmd()
+	// No --confirm: dry run.
+	cmd.SetArgs([]string{"store", "repair", "--storage-dir", storageDir})
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("repair dry run: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "dry run: no removable orphaned records found") {
+		t.Errorf("repair dry-run output = %q, want clean dry-run message", got)
+	}
+}
+
+func newCapturingCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	return cmd
+}

--- a/enterprise/conductor/controlplane/offline_recovery.go
+++ b/enterprise/conductor/controlplane/offline_recovery.go
@@ -189,7 +189,18 @@ func loadOfflineStore(policyBundlesDir string) (*FileBundleStore, []OfflineUnrea
 			unreadable = append(unreadable, OfflineUnreadableRecord{FileName: name, Err: err.Error()})
 			continue
 		}
+		rawHead, ok := store.streams[marker.StreamKey]
+		if !ok {
+			unreadable = append(unreadable, OfflineUnreadableRecord{
+				FileName: name,
+				Err:      "stream-head marker references unknown stream",
+			})
+			continue
+		}
 		store.rollbackHeads[marker.StreamKey] = marker
+		if rawHead.Bundle.Version <= marker.SupersededVersion {
+			store.streams[marker.StreamKey] = target
+		}
 	}
 	return store, unreadable, nil
 }

--- a/enterprise/conductor/controlplane/offline_recovery.go
+++ b/enterprise/conductor/controlplane/offline_recovery.go
@@ -1,0 +1,393 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package controlplane
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+const offlineBackupDirName = "offline-repair-backup"
+
+// OfflineOrphan is one bundle record that the offline analyzer found to be a
+// provably-orphaned, fatal record: not reachable from its stream's head, not
+// covered by a durable rollback marker, and not a tolerated historical fork
+// sibling. These are exactly the records that brick startup, and the only records
+// the offline repair is permitted to remove.
+type OfflineOrphan struct {
+	BundleHash string `json:"bundle_hash"`
+	BundleID   string `json:"bundle_id"`
+	Version    uint64 `json:"version"`
+	StreamKey  string `json:"stream_key"`
+	FileName   string `json:"file_name"`
+	Reason     string `json:"reason"`
+	// Removable is true only for the plain "not reachable / not covered" orphan
+	// class that repair is allowed to delete. Off-chain records whose own ancestry
+	// chain is corrupt are reported with Removable=false for manual review.
+	Removable bool `json:"removable"`
+}
+
+// OfflineStreamReport is the read-only view of one stream's chain topology as the
+// offline analyzer reconstructed it directly from disk.
+type OfflineStreamReport struct {
+	StreamKey         string   `json:"stream_key"`
+	HeadBundleID      string   `json:"head_bundle_id"`
+	HeadBundleHash    string   `json:"head_bundle_hash"`
+	HeadVersion       uint64   `json:"head_version"`
+	MaxVersion        uint64   `json:"max_version"`
+	RollbackMarker    bool     `json:"rollback_marker"`
+	SupersededVersion uint64   `json:"superseded_version,omitempty"`
+	ReachableHashes   []string `json:"reachable_hashes"`
+	RecordCount       int      `json:"record_count"`
+}
+
+// OfflineUnreadableRecord is a bundle-record file the analyzer could not parse or
+// validate. It is reported but NEVER removed by repair: an unreadable file may be
+// a transient IO issue or a partially-written record, and deleting it could lose
+// recoverable history. The operator must investigate these by hand.
+type OfflineUnreadableRecord struct {
+	FileName string `json:"file_name"`
+	Err      string `json:"error"`
+}
+
+// OfflineReport is the full read-only result of analyzing a Conductor bundle store
+// directory without a running server.
+type OfflineReport struct {
+	BundlesDir        string                    `json:"bundles_dir"`
+	StreamHeadsDir    string                    `json:"stream_heads_dir"`
+	Streams           []OfflineStreamReport     `json:"streams"`
+	Orphans           []OfflineOrphan           `json:"orphans"`
+	UnreadableRecords []OfflineUnreadableRecord `json:"unreadable_records"`
+}
+
+// OfflineRepairResult reports what a repair run removed (or, in dry-run mode,
+// would remove) and where each removed record was backed up.
+type OfflineRepairResult struct {
+	BackupDir string          `json:"backup_dir"`
+	Removed   []OfflineOrphan `json:"removed"`
+	DryRun    bool            `json:"dry_run"`
+}
+
+// loadOfflineStore reads every bundle record and rollback marker under the given
+// policy-bundles directory into an in-memory FileBundleStore WITHOUT running the
+// fatal chain verification. Unparseable records are collected and skipped rather
+// than aborting, so a single corrupt file never blinds the whole analysis. The
+// returned store has records, streams (heads), and rollbackHeads populated.
+//
+// policyBundlesDir is the directory passed to OpenFileBundleStore (i.e.
+// <storage-dir>/policy-bundles), inside which bundles/ and stream-heads/ live.
+func loadOfflineStore(policyBundlesDir string) (*FileBundleStore, []OfflineUnreadableRecord, error) {
+	clean := filepath.Clean(policyBundlesDir)
+	if !filepath.IsAbs(clean) {
+		return nil, nil, fmt.Errorf("conductor offline store dir must be absolute: %s", policyBundlesDir)
+	}
+	info, err := os.Stat(clean)
+	if err != nil {
+		return nil, nil, fmt.Errorf("conductor offline store dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, nil, fmt.Errorf("conductor offline store dir %s is not a directory", clean)
+	}
+	store := &FileBundleStore{
+		dir:            clean,
+		bundlesDir:     filepath.Join(clean, bundlesDirName),
+		streamHeadsDir: filepath.Join(clean, streamHeadsDirName),
+		records:        make(map[string]PublishedBundle),
+		streams:        make(map[string]PublishedBundle),
+		rollbackHeads:  make(map[string]streamHeadRecord),
+	}
+
+	var unreadable []OfflineUnreadableRecord
+	bundleEntries, err := os.ReadDir(store.bundlesDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("conductor offline read bundle dir: %w", err)
+	}
+	names := make([]string, 0, len(bundleEntries))
+	for _, entry := range bundleEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		record, err := readBundleRecord(filepath.Join(store.bundlesDir, name))
+		if err != nil {
+			unreadable = append(unreadable, OfflineUnreadableRecord{FileName: name, Err: err.Error()})
+			continue
+		}
+		if _, exists := store.records[record.BundleHash]; exists {
+			// A duplicate hash is genuine corruption, but offline analysis is
+			// tolerant: report it as unreadable context rather than aborting.
+			unreadable = append(unreadable, OfflineUnreadableRecord{
+				FileName: name,
+				Err:      fmt.Sprintf("%v: duplicate bundle_hash %q", ErrInvalidStoreRecord, record.BundleHash),
+			})
+			continue
+		}
+		store.records[record.BundleHash] = record
+		if current, ok := store.streams[record.StreamKey]; !ok || newerRecord(record, current) {
+			store.streams[record.StreamKey] = record
+		}
+	}
+
+	headEntries, err := os.ReadDir(store.streamHeadsDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, nil, fmt.Errorf("conductor offline read stream-head dir: %w", err)
+	}
+	headNames := make([]string, 0, len(headEntries))
+	for _, entry := range headEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		headNames = append(headNames, entry.Name())
+	}
+	slices.Sort(headNames)
+	for _, name := range headNames {
+		marker, err := readStreamHeadRecord(filepath.Join(store.streamHeadsDir, name))
+		if err != nil {
+			unreadable = append(unreadable, OfflineUnreadableRecord{FileName: name, Err: err.Error()})
+			continue
+		}
+		// Only honor a marker whose filename and target bundle match, mirroring
+		// loadStreamHeadRecordsLocked. A mismatched marker is reported but ignored
+		// for classification so it cannot cause a record to be wrongly tolerated.
+		if name != streamHeadRecordFileName(marker.StreamKey) {
+			unreadable = append(unreadable, OfflineUnreadableRecord{
+				FileName: name,
+				Err:      "stream-head marker filename does not match stream key",
+			})
+			continue
+		}
+		target, ok := store.records[marker.TargetBundleHash]
+		if !ok {
+			unreadable = append(unreadable, OfflineUnreadableRecord{
+				FileName: name,
+				Err:      "rollback target bundle missing",
+			})
+			continue
+		}
+		if err := validateStreamHeadRecord(marker, target); err != nil {
+			unreadable = append(unreadable, OfflineUnreadableRecord{FileName: name, Err: err.Error()})
+			continue
+		}
+		store.rollbackHeads[marker.StreamKey] = marker
+	}
+	return store, unreadable, nil
+}
+
+// classifyOfflineLocked reconstructs the per-stream chain topology and the set of
+// provably-orphaned records using the SAME reachability, rollback-coverage, and
+// tolerated-historical-fork predicates the live load path uses. A record is an
+// orphan only when it is fatal at load: not reachable from the head, not covered
+// by a rollback marker, AND not a tolerated fork sibling. A head whose own chain
+// is broken (missing/cross-stream/non-monotonic/cycle ancestor) is NOT silently
+// repaired: its records are left untouched and the stream is reported so the
+// operator investigates rather than the tool deleting head history.
+func (s *FileBundleStore) classifyOfflineLocked() ([]OfflineStreamReport, []OfflineOrphan) {
+	streamReports := make([]OfflineStreamReport, 0, len(s.streams))
+	var orphans []OfflineOrphan
+
+	for streamKey, head := range s.streams {
+		seen := make(map[string]struct{}, 4)
+		headChainOK := s.walkChainLocked(streamKey, head, seen) == nil
+		reachable := make([]string, 0, len(seen))
+		for h := range seen {
+			reachable = append(reachable, h)
+		}
+		slices.Sort(reachable)
+
+		marker, hasMarker := s.rollbackHeads[streamKey]
+		streamReports = append(streamReports, OfflineStreamReport{
+			StreamKey:         streamKey,
+			HeadBundleID:      head.Bundle.BundleID,
+			HeadBundleHash:    head.BundleHash,
+			HeadVersion:       head.Bundle.Version,
+			MaxVersion:        s.maxStreamVersionLocked(streamKey),
+			RollbackMarker:    hasMarker,
+			SupersededVersion: marker.SupersededVersion,
+			ReachableHashes:   reachable,
+			RecordCount:       s.streamRecordCountLocked(streamKey),
+		})
+
+		if !headChainOK {
+			// Do not classify orphans against an unverifiable head chain; deleting
+			// records here could destroy head history. Leave the stream for manual
+			// inspection.
+			continue
+		}
+
+		for hash, record := range s.records {
+			if record.StreamKey != streamKey {
+				continue
+			}
+			if _, ok := seen[hash]; ok {
+				continue
+			}
+			if s.rollbackSupersedesRecordLocked(record) {
+				continue
+			}
+			tolerated, err := s.isToleratedHistoricalForkLocked(streamKey, record, head, seen)
+			if err != nil {
+				// The sibling chain is itself corrupt. Do not auto-remove a record
+				// whose own chain is broken; report it but leave it for the operator.
+				orphans = append(orphans, OfflineOrphan{
+					BundleHash: hash,
+					BundleID:   record.Bundle.BundleID,
+					Version:    record.Bundle.Version,
+					StreamKey:  streamKey,
+					FileName:   hash + ".json",
+					Reason:     "off-chain record with a corrupt ancestry chain (manual review): " + err.Error(),
+					Removable:  false,
+				})
+				continue
+			}
+			if tolerated {
+				continue
+			}
+			orphans = append(orphans, OfflineOrphan{
+				BundleHash: hash,
+				BundleID:   record.Bundle.BundleID,
+				Version:    record.Bundle.Version,
+				StreamKey:  streamKey,
+				FileName:   hash + ".json",
+				Reason:     "not reachable from stream head and not covered by a rollback marker",
+				Removable:  true,
+			})
+		}
+	}
+
+	slices.SortFunc(streamReports, func(a, b OfflineStreamReport) int {
+		return strings.Compare(a.StreamKey, b.StreamKey)
+	})
+	slices.SortFunc(orphans, func(a, b OfflineOrphan) int {
+		return strings.Compare(a.BundleHash, b.BundleHash)
+	})
+	return streamReports, orphans
+}
+
+func (s *FileBundleStore) streamRecordCountLocked(streamKey string) int {
+	count := 0
+	for _, record := range s.records {
+		if record.StreamKey == streamKey {
+			count++
+		}
+	}
+	return count
+}
+
+// removableOrphans filters classified orphans to those the repair is allowed to
+// delete: only the plain "not reachable / not covered" class (Removable=true).
+// Off-chain records flagged for manual review (corrupt sibling chains) are excluded
+// so repair never deletes a record whose own chain is broken.
+func removableOrphans(orphans []OfflineOrphan) []OfflineOrphan {
+	out := make([]OfflineOrphan, 0, len(orphans))
+	for _, o := range orphans {
+		if o.Removable {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+// InspectOfflineStore analyzes a Conductor policy-bundle store directory without a
+// running server and returns its stream topology plus any provably-orphaned or
+// unreadable records. It is strictly read-only.
+//
+// policyBundlesDir is <storage-dir>/policy-bundles (the path serve passes to
+// OpenFileBundleStore).
+func InspectOfflineStore(policyBundlesDir string) (OfflineReport, error) {
+	store, unreadable, err := loadOfflineStore(policyBundlesDir)
+	if err != nil {
+		return OfflineReport{}, err
+	}
+	streams, orphans := store.classifyOfflineLocked()
+	return OfflineReport{
+		BundlesDir:        store.bundlesDir,
+		StreamHeadsDir:    store.streamHeadsDir,
+		Streams:           streams,
+		Orphans:           orphans,
+		UnreadableRecords: unreadable,
+	}, nil
+}
+
+// RepairOfflineStore removes provably-orphaned bundle records from a Conductor
+// policy-bundle store directory, backing up each removed record first. It NEVER
+// removes a record reachable from a head, a record covered by a rollback marker, a
+// tolerated historical fork sibling, an unreadable record, an off-chain record
+// flagged for manual review, or anything under stream-heads/ or the audit store.
+//
+// When confirm is false the function is a dry run: it reports what it WOULD remove
+// and writes no backups and deletes nothing. backupDir, when empty, defaults to
+// <storage-dir>/policy-bundles/offline-repair-backup/<RFC3339-UTC-timestamp>.
+func RepairOfflineStore(policyBundlesDir, backupDir string, confirm bool, now time.Time) (OfflineRepairResult, error) {
+	store, _, err := loadOfflineStore(policyBundlesDir)
+	if err != nil {
+		return OfflineRepairResult{}, err
+	}
+	_, orphans := store.classifyOfflineLocked()
+	removable := removableOrphans(orphans)
+
+	if !confirm {
+		return OfflineRepairResult{Removed: removable, DryRun: true}, nil
+	}
+	if len(removable) == 0 {
+		return OfflineRepairResult{Removed: nil, DryRun: false}, nil
+	}
+
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	resolvedBackup := strings.TrimSpace(backupDir)
+	if resolvedBackup == "" {
+		resolvedBackup = filepath.Join(store.dir, offlineBackupDirName, now.Format("20060102T150405Z"))
+	}
+	resolvedBackup = filepath.Clean(resolvedBackup)
+	if err := os.MkdirAll(resolvedBackup, bundleStoreDirMode); err != nil {
+		return OfflineRepairResult{}, fmt.Errorf("conductor offline repair create backup dir %s: %w", resolvedBackup, err)
+	}
+
+	removed := make([]OfflineOrphan, 0, len(removable))
+	for _, orphan := range removable {
+		src := filepath.Join(store.bundlesDir, orphan.FileName)
+		// Re-validate that this is exactly one of the records we classified and that
+		// the on-disk file still parses to the same orphan hash before touching it.
+		record, err := readBundleRecord(src)
+		if err != nil {
+			return finalizeRepair(resolvedBackup, removed), fmt.Errorf("conductor offline repair re-read %s: %w", orphan.FileName, err)
+		}
+		if record.BundleHash != orphan.BundleHash {
+			return finalizeRepair(resolvedBackup, removed), fmt.Errorf("conductor offline repair %s: on-disk hash %q does not match classified orphan %q",
+				orphan.FileName, record.BundleHash, orphan.BundleHash)
+		}
+		data, err := os.ReadFile(filepath.Clean(src))
+		if err != nil {
+			return finalizeRepair(resolvedBackup, removed), fmt.Errorf("conductor offline repair read %s: %w", orphan.FileName, err)
+		}
+		backupPath := filepath.Join(resolvedBackup, orphan.FileName)
+		if err := durableWrite(backupPath, data); err != nil {
+			return finalizeRepair(resolvedBackup, removed), fmt.Errorf("conductor offline repair back up %s: %w", orphan.FileName, err)
+		}
+		if err := os.Remove(src); err != nil {
+			return finalizeRepair(resolvedBackup, removed), fmt.Errorf("conductor offline repair remove %s: %w", orphan.FileName, err)
+		}
+		removed = append(removed, orphan)
+	}
+	if err := fsyncDir(store.bundlesDir); err != nil {
+		return finalizeRepair(resolvedBackup, removed), err
+	}
+	return finalizeRepair(resolvedBackup, removed), nil
+}
+
+func finalizeRepair(backupDir string, removed []OfflineOrphan) OfflineRepairResult {
+	return OfflineRepairResult{BackupDir: backupDir, Removed: removed, DryRun: false}
+}

--- a/enterprise/conductor/controlplane/offline_recovery.go
+++ b/enterprise/conductor/controlplane/offline_recovery.go
@@ -132,6 +132,17 @@ func loadOfflineStore(policyBundlesDir string) (*FileBundleStore, []OfflineUnrea
 			})
 			continue
 		}
+		if existing, err := store.bundleByIDVersionLocked(record.Bundle.BundleID, record.Bundle.Version); err == nil {
+			unreadable = append(unreadable, OfflineUnreadableRecord{
+				FileName: name,
+				Err: fmt.Sprintf("%v: duplicate bundle_id/version %q/%d already present as %s",
+					ErrInvalidStoreRecord, record.Bundle.BundleID, record.Bundle.Version, existing.BundleHash),
+			})
+			continue
+		} else if !errors.Is(err, ErrBundleNotFound) {
+			unreadable = append(unreadable, OfflineUnreadableRecord{FileName: name, Err: err.Error()})
+			continue
+		}
 		store.records[record.BundleHash] = record
 		if current, ok := store.streams[record.StreamKey]; !ok || newerRecord(record, current) {
 			store.streams[record.StreamKey] = record

--- a/enterprise/conductor/controlplane/offline_recovery_test.go
+++ b/enterprise/conductor/controlplane/offline_recovery_test.go
@@ -269,6 +269,60 @@ func TestRepairOfflineStoreDoesNotRemoveManualReviewSibling(t *testing.T) {
 	}
 }
 
+func TestRepairOfflineStoreDoesNotRemoveDuplicateIDVersion(t *testing.T) {
+	pb := newOfflineStoreDir(t)
+	signer := newTestSigner(t)
+	bundlesDir := filepath.Join(pb, bundlesDirName)
+	audience := conductor.Audience{InstanceIDs: []string{"*"}}
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:         "bundle-offline-dup-v1",
+		version:    1,
+		audience:   audience,
+		configYAML: "mode: strict\napi_allowlist:\n  - dup-v1.example.com\n",
+	})
+	v1Hash := writeForkRecord(t, bundlesDir, v1, testNow)
+	v2a := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-offline-dup-v2",
+		version:      2,
+		previousHash: v1Hash,
+		audience:     audience,
+		configYAML:   "mode: strict\napi_allowlist:\n  - dup-v2a.example.com\n",
+	})
+	v2b := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-offline-dup-v2",
+		version:      2,
+		previousHash: v1Hash,
+		audience:     audience,
+		configYAML:   "mode: strict\napi_allowlist:\n  - dup-v2b.example.com\n",
+	})
+	v2aHash := writeForkRecord(t, bundlesDir, v2a, testNow.Add(time.Minute))
+	v2bHash := writeForkRecord(t, bundlesDir, v2b, testNow.Add(2*time.Minute))
+
+	report, err := InspectOfflineStore(pb)
+	if err != nil {
+		t.Fatalf("InspectOfflineStore() error = %v", err)
+	}
+	if len(report.UnreadableRecords) != 1 {
+		t.Fatalf("unreadable records = %+v, want one duplicate bundle_id/version record", report.UnreadableRecords)
+	}
+	if len(report.Orphans) != 0 {
+		t.Fatalf("orphans = %+v, want none for ambiguous duplicate bundle_id/version corruption", report.Orphans)
+	}
+
+	result, err := RepairOfflineStore(pb, "", true, testNow)
+	if err != nil {
+		t.Fatalf("RepairOfflineStore() error = %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("repair removed %+v, want none for duplicate bundle_id/version", result.Removed)
+	}
+	for _, hash := range []string{v2aHash, v2bHash} {
+		if _, err := os.Stat(filepath.Join(bundlesDir, hash+".json")); err != nil {
+			t.Fatalf("repair removed duplicate record %s: %v", hash, err)
+		}
+	}
+}
+
 func TestInspectOfflineStoreReportsUnreadableRecord(t *testing.T) {
 	pb := newOfflineStoreDir(t)
 	signer := newTestSigner(t)

--- a/enterprise/conductor/controlplane/offline_recovery_test.go
+++ b/enterprise/conductor/controlplane/offline_recovery_test.go
@@ -102,6 +102,39 @@ func TestInspectOfflineStoreCleanStoreHasNoOrphans(t *testing.T) {
 	}
 }
 
+func TestInspectOfflineStoreAppliesActiveRollbackMarkerToHead(t *testing.T) {
+	pb := newOfflineStoreDir(t)
+	signer := newTestSigner(t)
+	recs := buildForkRecords(t, signer)
+	bundlesDir := filepath.Join(pb, bundlesDirName)
+	headsDir := filepath.Join(pb, streamHeadsDirName)
+	for _, v := range []uint64{1, 2, 3, 4} {
+		writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+	}
+	writeForkRollbackMarker(t, headsDir, PublishedBundle{
+		Bundle: recs[3].bundle, BundleHash: recs[3].hash, StreamKey: recs[3].stream,
+	}, testNow.Add(time.Hour))
+
+	report, err := InspectOfflineStore(pb)
+	if err != nil {
+		t.Fatalf("InspectOfflineStore() error = %v", err)
+	}
+	if len(report.Streams) != 1 {
+		t.Fatalf("streams = %d, want 1", len(report.Streams))
+	}
+	stream := report.Streams[0]
+	if stream.HeadBundleHash != recs[3].hash || stream.HeadVersion != 3 {
+		t.Fatalf("offline head version=%d hash=%s, want rollback target v3 %s",
+			stream.HeadVersion, stream.HeadBundleHash, recs[3].hash)
+	}
+	if stream.MaxVersion != 4 {
+		t.Fatalf("max version = %d, want 4", stream.MaxVersion)
+	}
+	if len(report.Orphans) != 0 {
+		t.Fatalf("orphans = %+v, want none (superseded v4 is rollback-covered)", report.Orphans)
+	}
+}
+
 func TestRepairOfflineStoreDryRunChangesNothing(t *testing.T) {
 	pb := newOfflineStoreDir(t)
 	signer := newTestSigner(t)

--- a/enterprise/conductor/controlplane/offline_recovery_test.go
+++ b/enterprise/conductor/controlplane/offline_recovery_test.go
@@ -1,0 +1,309 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package controlplane
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+)
+
+// newOfflineStoreDir builds a policy-bundle store directory laid out the way
+// `conductor serve` lays it out (<dir>/bundles, <dir>/stream-heads) and returns
+// the policy-bundles dir to pass to the offline functions.
+func newOfflineStoreDir(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	pb := filepath.Join(root, "policy-bundles")
+	for _, sub := range []string{bundlesDirName, streamHeadsDirName} {
+		if err := os.MkdirAll(filepath.Join(pb, sub), bundleStoreDirMode); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	return pb
+}
+
+// seedGraftStore writes a valid v1->v2->v3->v6 stream plus a DISCONNECTED graft
+// record (its own root, version 5, shares no ancestor with the head) and a
+// rollback marker. The graft is a genuine fatal orphan that bricks startup and
+// that the offline repair is allowed to remove. Returns the graft hash + a
+// reachable head hash for assertions.
+func seedGraftStore(t *testing.T, pb string, signer testSigner) (graftHash, headHash string) {
+	t.Helper()
+	recs := buildForkRecords(t, signer)
+	bundlesDir := filepath.Join(pb, bundlesDirName)
+	headsDir := filepath.Join(pb, streamHeadsDirName)
+	for _, v := range []uint64{1, 2, 3, 6} {
+		writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+	}
+	graft := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-offline-graft",
+		version:      5,
+		previousHash: "",
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - offline-graft.example.com\n",
+	})
+	graftHash = writeForkRecord(t, bundlesDir, graft, testNow.Add(5*time.Minute))
+	writeForkRollbackMarker(t, headsDir, PublishedBundle{
+		Bundle: recs[3].bundle, BundleHash: recs[3].hash, StreamKey: recs[3].stream,
+	}, testNow.Add(time.Hour))
+	return graftHash, recs[6].hash
+}
+
+func TestInspectOfflineStoreFindsGraftOrphan(t *testing.T) {
+	pb := newOfflineStoreDir(t)
+	signer := newTestSigner(t)
+	graftHash, headHash := seedGraftStore(t, pb, signer)
+
+	report, err := InspectOfflineStore(pb)
+	if err != nil {
+		t.Fatalf("InspectOfflineStore() error = %v", err)
+	}
+	if len(report.Streams) != 1 {
+		t.Fatalf("streams = %d, want 1", len(report.Streams))
+	}
+	if report.Streams[0].HeadBundleHash != headHash {
+		t.Fatalf("head hash = %s, want %s", report.Streams[0].HeadBundleHash, headHash)
+	}
+	if len(report.Orphans) != 1 || report.Orphans[0].BundleHash != graftHash {
+		t.Fatalf("orphans = %+v, want exactly the graft %s", report.Orphans, graftHash)
+	}
+	// Inspect is read-only: the graft file must still be present.
+	if _, err := os.Stat(filepath.Join(pb, bundlesDirName, graftHash+".json")); err != nil {
+		t.Fatalf("inspect removed a file (not read-only): %v", err)
+	}
+}
+
+func TestInspectOfflineStoreCleanStoreHasNoOrphans(t *testing.T) {
+	pb := newOfflineStoreDir(t)
+	signer := newTestSigner(t)
+	recs := buildForkRecords(t, signer)
+	bundlesDir := filepath.Join(pb, bundlesDirName)
+	headsDir := filepath.Join(pb, streamHeadsDirName)
+	// The abandoned-fork incident shape: tolerated, not orphaned.
+	for _, v := range []uint64{1, 2, 3, 4, 5, 6} {
+		writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+	}
+	writeForkRollbackMarker(t, headsDir, PublishedBundle{
+		Bundle: recs[3].bundle, BundleHash: recs[3].hash, StreamKey: recs[3].stream,
+	}, testNow.Add(time.Hour))
+
+	report, err := InspectOfflineStore(pb)
+	if err != nil {
+		t.Fatalf("InspectOfflineStore() error = %v", err)
+	}
+	if len(report.Orphans) != 0 {
+		t.Fatalf("orphans = %+v, want none (abandoned fork siblings are tolerated history)", report.Orphans)
+	}
+}
+
+func TestRepairOfflineStoreDryRunChangesNothing(t *testing.T) {
+	pb := newOfflineStoreDir(t)
+	signer := newTestSigner(t)
+	graftHash, _ := seedGraftStore(t, pb, signer)
+
+	result, err := RepairOfflineStore(pb, "", false, testNow)
+	if err != nil {
+		t.Fatalf("RepairOfflineStore(dry run) error = %v", err)
+	}
+	if !result.DryRun {
+		t.Fatal("RepairOfflineStore(confirm=false) DryRun=false, want true")
+	}
+	if len(result.Removed) != 1 || result.Removed[0].BundleHash != graftHash {
+		t.Fatalf("dry run removed = %+v, want the graft listed (not deleted)", result.Removed)
+	}
+	if _, err := os.Stat(filepath.Join(pb, bundlesDirName, graftHash+".json")); err != nil {
+		t.Fatalf("dry run deleted the file: %v", err)
+	}
+}
+
+func TestRepairOfflineStoreConfirmRemovesOnlyOrphanAndBacksUp(t *testing.T) {
+	pb := newOfflineStoreDir(t)
+	signer := newTestSigner(t)
+	graftHash, headHash := seedGraftStore(t, pb, signer)
+	bundlesDir := filepath.Join(pb, bundlesDirName)
+
+	// Snapshot reachable records before repair; none may be removed.
+	before, err := os.ReadDir(bundlesDir)
+	if err != nil {
+		t.Fatalf("ReadDir(before) error = %v", err)
+	}
+	if len(before) == 0 {
+		t.Fatal("no bundle records seeded")
+	}
+
+	result, err := RepairOfflineStore(pb, "", true, testNow)
+	if err != nil {
+		t.Fatalf("RepairOfflineStore(confirm) error = %v", err)
+	}
+	if result.DryRun {
+		t.Fatal("RepairOfflineStore(confirm=true) DryRun=true, want false")
+	}
+	if len(result.Removed) != 1 || result.Removed[0].BundleHash != graftHash {
+		t.Fatalf("removed = %+v, want exactly the graft %s", result.Removed, graftHash)
+	}
+
+	// The graft file is gone.
+	if _, err := os.Stat(filepath.Join(bundlesDir, graftHash+".json")); !os.IsNotExist(err) {
+		t.Fatalf("graft record still present after repair: err=%v", err)
+	}
+	// The head record (reachable) is untouched.
+	if _, err := os.Stat(filepath.Join(bundlesDir, headHash+".json")); err != nil {
+		t.Fatalf("repair removed a reachable record: %v", err)
+	}
+	// A backup of the removed record exists and parses back to the same hash.
+	backupPath := filepath.Join(result.BackupDir, graftHash+".json")
+	backup, err := readBundleRecord(backupPath)
+	if err != nil {
+		t.Fatalf("read backup %s: %v", backupPath, err)
+	}
+	if backup.BundleHash != graftHash {
+		t.Fatalf("backup hash = %s, want %s", backup.BundleHash, graftHash)
+	}
+	// stream-heads/ is untouched: the rollback marker survives.
+	headFiles, err := os.ReadDir(filepath.Join(pb, streamHeadsDirName))
+	if err != nil {
+		t.Fatalf("ReadDir(stream-heads) error = %v", err)
+	}
+	if len(headFiles) != 1 {
+		t.Fatalf("stream-head markers = %d, want 1 (repair must not touch markers)", len(headFiles))
+	}
+
+	// The proof: after repair the store opens cleanly through the real load path.
+	store, err := OpenFileBundleStore(pb)
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore(after repair) error = %v, want clean load", err)
+	}
+	if h := store.streams[result.Removed[0].StreamKey]; h.Bundle.Version != 6 {
+		t.Fatalf("post-repair head version = %d, want 6", h.Bundle.Version)
+	}
+}
+
+func TestRepairOfflineStoreLeavesAuditStoreUntouched(t *testing.T) {
+	pb := newOfflineStoreDir(t)
+	signer := newTestSigner(t)
+	graftHash, _ := seedGraftStore(t, pb, signer)
+
+	// Simulate the sibling audit store that lives under <storage-dir>, NOT under
+	// policy-bundles. Offline repair must never reach outside policy-bundles.
+	storageRoot := filepath.Dir(pb)
+	auditPath := filepath.Join(storageRoot, "audit.db")
+	if err := os.WriteFile(auditPath, []byte("audit-data"), bundleRecordFileMode); err != nil {
+		t.Fatalf("write fake audit.db: %v", err)
+	}
+
+	if _, err := RepairOfflineStore(pb, "", true, testNow); err != nil {
+		t.Fatalf("RepairOfflineStore() error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Clean(auditPath))
+	if err != nil || string(data) != "audit-data" {
+		t.Fatalf("audit.db changed or removed: data=%q err=%v", string(data), err)
+	}
+	_ = graftHash
+}
+
+func TestRepairOfflineStoreCustomBackupDir(t *testing.T) {
+	pb := newOfflineStoreDir(t)
+	signer := newTestSigner(t)
+	graftHash, _ := seedGraftStore(t, pb, signer)
+	backupDir := filepath.Join(t.TempDir(), "custom-backup")
+
+	result, err := RepairOfflineStore(pb, backupDir, true, testNow)
+	if err != nil {
+		t.Fatalf("RepairOfflineStore(custom backup) error = %v", err)
+	}
+	if result.BackupDir != filepath.Clean(backupDir) {
+		t.Fatalf("backup dir = %s, want %s", result.BackupDir, backupDir)
+	}
+	if _, err := os.Stat(filepath.Join(backupDir, graftHash+".json")); err != nil {
+		t.Fatalf("backup not written to custom dir: %v", err)
+	}
+}
+
+func TestRepairOfflineStoreDoesNotRemoveManualReviewSibling(t *testing.T) {
+	// A sibling whose own ancestry chain is corrupt (points at a missing parent)
+	// is flagged for manual review and must NOT be auto-removed by repair.
+	pb := newOfflineStoreDir(t)
+	signer := newTestSigner(t)
+	recs := buildForkRecords(t, signer)
+	bundlesDir := filepath.Join(pb, bundlesDirName)
+	headsDir := filepath.Join(pb, streamHeadsDirName)
+	for _, v := range []uint64{1, 2, 3, 6} {
+		writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+	}
+	// Sibling v5 chaining from a v4 hash that is never written -> corrupt chain.
+	badSibling := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-offline-badsibling",
+		version:      5,
+		previousHash: recs[4].hash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - badsibling.example.com\n",
+	})
+	badHash := writeForkRecord(t, bundlesDir, badSibling, testNow.Add(5*time.Minute))
+	writeForkRollbackMarker(t, headsDir, PublishedBundle{
+		Bundle: recs[3].bundle, BundleHash: recs[3].hash, StreamKey: recs[3].stream,
+	}, testNow.Add(time.Hour))
+
+	report, err := InspectOfflineStore(pb)
+	if err != nil {
+		t.Fatalf("InspectOfflineStore() error = %v", err)
+	}
+	if len(report.Orphans) != 1 || report.Orphans[0].BundleHash != badHash {
+		t.Fatalf("orphans = %+v, want the bad sibling flagged", report.Orphans)
+	}
+
+	result, err := RepairOfflineStore(pb, "", true, testNow)
+	if err != nil {
+		t.Fatalf("RepairOfflineStore() error = %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("repair removed %+v, want none (manual-review sibling must be preserved)", result.Removed)
+	}
+	if _, err := os.Stat(filepath.Join(bundlesDir, badHash+".json")); err != nil {
+		t.Fatalf("repair removed the manual-review sibling: %v", err)
+	}
+}
+
+func TestInspectOfflineStoreReportsUnreadableRecord(t *testing.T) {
+	pb := newOfflineStoreDir(t)
+	signer := newTestSigner(t)
+	recs := buildForkRecords(t, signer)
+	bundlesDir := filepath.Join(pb, bundlesDirName)
+	for _, v := range []uint64{1, 2, 3} {
+		writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+	}
+	// A garbage .json file that fails to parse.
+	if err := os.WriteFile(filepath.Join(bundlesDir, "garbage.json"), []byte("{not json"), bundleRecordFileMode); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+	report, err := InspectOfflineStore(pb)
+	if err != nil {
+		t.Fatalf("InspectOfflineStore() error = %v", err)
+	}
+	if len(report.UnreadableRecords) != 1 || report.UnreadableRecords[0].FileName != "garbage.json" {
+		t.Fatalf("unreadable = %+v, want garbage.json reported", report.UnreadableRecords)
+	}
+	// A garbage file is reported, not classified as a removable orphan, and repair
+	// must not delete it.
+	result, err := RepairOfflineStore(pb, "", true, testNow)
+	if err != nil {
+		t.Fatalf("RepairOfflineStore() error = %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("repair removed %+v, want none (garbage file is not a classified orphan)", result.Removed)
+	}
+	if _, err := os.Stat(filepath.Join(bundlesDir, "garbage.json")); err != nil {
+		t.Fatalf("repair removed the garbage file: %v", err)
+	}
+}
+
+func TestInspectOfflineStoreRejectsMissingDir(t *testing.T) {
+	if _, err := InspectOfflineStore(filepath.Join(t.TempDir(), "does-not-exist")); err == nil {
+		t.Fatal("InspectOfflineStore(missing dir) error = nil, want error")
+	}
+}

--- a/enterprise/conductor/controlplane/store.go
+++ b/enterprise/conductor/controlplane/store.go
@@ -665,12 +665,16 @@ func (s *FileBundleStore) loadStreamHeadRecordsLocked() error {
 }
 
 // verifyStreamChainsLocked walks each stream head back through
-// previous_bundle_hash, ensuring every non-superseded same-stream record on disk
-// is reachable from the selected head in strictly decreasing version order. Gap
-// publication (e.g., v1 then v3 with previous_bundle_hash=v1) is explicitly
-// allowed. Authorized rollback keeps superseded records on disk for audit, so a
-// same-stream record may be historical without being reachable when a durable
-// rollback marker covers its version.
+// previous_bundle_hash, ensuring every same-stream record on disk is either
+// reachable from the selected head in strictly decreasing version order, covered
+// by a durable rollback marker, or a tolerated historical fork sibling (see
+// isToleratedHistoricalForkLocked). Gap publication (e.g., v1 then v3 with
+// previous_bundle_hash=v1) is explicitly allowed.
+//
+// Genuine corruption stays fatal: a record whose chain references a missing
+// previous_bundle_hash, an ancestor in a different stream, a non-decreasing
+// version, or a cycle is rejected, as is a head whose own chain is broken and a
+// record that does not share a common ancestor with the head.
 //
 // The seen-map check is structurally unreachable for chains that pass the
 // strict-decrease check (a decreasing integer sequence cannot loop), but is
@@ -680,30 +684,8 @@ func (s *FileBundleStore) loadStreamHeadRecordsLocked() error {
 func (s *FileBundleStore) verifyStreamChainsLocked() error {
 	for streamKey, head := range s.streams {
 		seen := make(map[string]struct{}, 4)
-		cursor := head
-		for {
-			if _, cycle := seen[cursor.BundleHash]; cycle {
-				return fmt.Errorf("%w: stream %q chain has cycle at %s",
-					ErrInvalidStoreRecord, streamKey, cursor.BundleHash)
-			}
-			seen[cursor.BundleHash] = struct{}{}
-			if cursor.Bundle.PreviousBundleHash == "" {
-				break
-			}
-			prev, ok := s.records[cursor.Bundle.PreviousBundleHash]
-			if !ok {
-				return fmt.Errorf("%w: stream %q references missing previous_bundle_hash %s",
-					ErrInvalidStoreRecord, streamKey, cursor.Bundle.PreviousBundleHash)
-			}
-			if prev.StreamKey != cursor.StreamKey {
-				return fmt.Errorf("%w: stream %q ancestor %s belongs to different stream",
-					ErrInvalidStoreRecord, streamKey, prev.BundleHash)
-			}
-			if prev.Bundle.Version >= cursor.Bundle.Version {
-				return fmt.Errorf("%w: stream %q ancestor %s version %d does not decrease from %d",
-					ErrInvalidStoreRecord, streamKey, prev.BundleHash, prev.Bundle.Version, cursor.Bundle.Version)
-			}
-			cursor = prev
+		if err := s.walkChainLocked(streamKey, head, seen); err != nil {
+			return err
 		}
 		for hash, record := range s.records {
 			if record.StreamKey != streamKey {
@@ -715,11 +697,132 @@ func (s *FileBundleStore) verifyStreamChainsLocked() error {
 			if s.rollbackSupersedesRecordLocked(record) {
 				continue
 			}
+			tolerated, err := s.isToleratedHistoricalForkLocked(streamKey, record, head, seen)
+			if err != nil {
+				return err
+			}
+			if tolerated {
+				continue
+			}
 			return fmt.Errorf("%w: stream %q record %s is not reachable from stream head %s",
 				ErrInvalidStoreRecord, streamKey, hash, head.BundleHash)
 		}
 	}
 	return nil
+}
+
+// walkChainLocked follows record's previous_bundle_hash chain to its root,
+// recording every visited bundle hash in seen, and enforcing the structural
+// invariants of a valid chain: no cycle, every previous_bundle_hash present in
+// the store, every ancestor in the same stream, and strictly decreasing version
+// along the chain. Any violation is a genuine-corruption error. On success seen
+// holds the full set of hashes on this chain, which the fork-sibling check reuses
+// to test whether a sibling shares an ancestor with the head.
+func (s *FileBundleStore) walkChainLocked(streamKey string, record PublishedBundle, seen map[string]struct{}) error {
+	cursor := record
+	for {
+		if _, cycle := seen[cursor.BundleHash]; cycle {
+			return fmt.Errorf("%w: stream %q chain has cycle at %s",
+				ErrInvalidStoreRecord, streamKey, cursor.BundleHash)
+		}
+		seen[cursor.BundleHash] = struct{}{}
+		if cursor.Bundle.PreviousBundleHash == "" {
+			return nil
+		}
+		prev, ok := s.records[cursor.Bundle.PreviousBundleHash]
+		if !ok {
+			return fmt.Errorf("%w: stream %q references missing previous_bundle_hash %s",
+				ErrInvalidStoreRecord, streamKey, cursor.Bundle.PreviousBundleHash)
+		}
+		if prev.StreamKey != cursor.StreamKey {
+			return fmt.Errorf("%w: stream %q ancestor %s belongs to different stream",
+				ErrInvalidStoreRecord, streamKey, prev.BundleHash)
+		}
+		if prev.Bundle.Version >= cursor.Bundle.Version {
+			return fmt.Errorf("%w: stream %q ancestor %s version %d does not decrease from %d",
+				ErrInvalidStoreRecord, streamKey, prev.BundleHash, prev.Bundle.Version, cursor.Bundle.Version)
+		}
+		cursor = prev
+	}
+}
+
+// isToleratedHistoricalForkLocked decides whether an off-head, rollback-uncovered
+// same-stream record is a legitimately-superseded fork sibling that should be
+// treated as historical (non-fatal) rather than as corruption that bricks startup.
+//
+// This closes the gap where repeated "rollback-to-vN then publish" cycles leave
+// abandoned fork branches below the live head: the durable rollback marker records
+// only the LAST superseded version, so an earlier abandoned sibling (e.g. a v5 that
+// diverged from v3 while the head later advanced to v6 with the marker still at
+// superseded=4) is neither on the head chain nor covered by the marker. Such a
+// sibling is genuine audit history, not a broken store.
+//
+// The predicate is deliberately narrow. ALL of these must hold; any failure is
+// either fatal corruption (returned as err) or a non-tolerated orphan (false, nil):
+//
+//  1. The stream has a durable rollback marker. A fork sibling can only arise as a
+//     byproduct of authorized rollback, which always leaves a marker; tolerating an
+//     off-chain record on a stream that never underwent rollback would mask a graft.
+//  2. The record's version is strictly below the head version. The head is the
+//     highest forward version; an off-chain record at or above the head version is a
+//     real conflict (two live heads), not a superseded historical sibling.
+//  3. The record's own ancestry chain is structurally valid — walking it back
+//     re-runs every corruption check (missing prev, cross-stream, non-monotonic,
+//     cycle). A broken sibling chain is FATAL, returned as err.
+//  4. The record's chain rejoins the head's chain at a common ancestor. This proves
+//     the sibling forked from a shared point on THIS stream rather than being a
+//     disconnected graft.
+func (s *FileBundleStore) isToleratedHistoricalForkLocked(
+	streamKey string,
+	record PublishedBundle,
+	head PublishedBundle,
+	headSeen map[string]struct{},
+) (bool, error) {
+	if _, ok := s.rollbackHeads[streamKey]; !ok {
+		return false, nil
+	}
+	if record.Bundle.Version >= head.Bundle.Version {
+		return false, nil
+	}
+	// Walk the sibling's chain into its own seen set so a broken sibling chain is
+	// reported as corruption, and detect whether it rejoins the head chain at a
+	// shared ancestor. Each link is validated with the same structural checks the
+	// head walk applies; once a validated parent is found on the head chain the
+	// sibling has rejoined a chain the head walk already verified, so it is accepted.
+	forkSeen := make(map[string]struct{}, 4)
+	cursor := record
+	for {
+		if _, cycle := forkSeen[cursor.BundleHash]; cycle {
+			return false, fmt.Errorf("%w: stream %q fork sibling chain has cycle at %s",
+				ErrInvalidStoreRecord, streamKey, cursor.BundleHash)
+		}
+		forkSeen[cursor.BundleHash] = struct{}{}
+		if cursor.Bundle.PreviousBundleHash == "" {
+			// Reached a stream root without crossing the head chain: the sibling does
+			// not share an ancestor with the head, so it is a disconnected graft, not a
+			// tolerable historical fork.
+			return false, nil
+		}
+		prev, ok := s.records[cursor.Bundle.PreviousBundleHash]
+		if !ok {
+			return false, fmt.Errorf("%w: stream %q references missing previous_bundle_hash %s",
+				ErrInvalidStoreRecord, streamKey, cursor.Bundle.PreviousBundleHash)
+		}
+		if prev.StreamKey != cursor.StreamKey {
+			return false, fmt.Errorf("%w: stream %q ancestor %s belongs to different stream",
+				ErrInvalidStoreRecord, streamKey, prev.BundleHash)
+		}
+		if prev.Bundle.Version >= cursor.Bundle.Version {
+			return false, fmt.Errorf("%w: stream %q ancestor %s version %d does not decrease from %d",
+				ErrInvalidStoreRecord, streamKey, prev.BundleHash, prev.Bundle.Version, cursor.Bundle.Version)
+		}
+		if _, shared := headSeen[prev.BundleHash]; shared {
+			// The validated parent is on the head chain: the sibling forks from a
+			// shared, head-verified ancestor. Accept it as historical.
+			return true, nil
+		}
+		cursor = prev
+	}
 }
 
 func (s *FileBundleStore) rollbackSupersedesRecordLocked(record PublishedBundle) bool {

--- a/enterprise/conductor/controlplane/store_fork_recovery_test.go
+++ b/enterprise/conductor/controlplane/store_fork_recovery_test.go
@@ -1,0 +1,357 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package controlplane
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+)
+
+// writeForkRecord writes a signed bundle directly to the store's bundles dir,
+// bypassing the forward-publish authorization gate. This is the only way to
+// recreate the abandoned-fork on-disk topology that repeated rollback+publish
+// cycles leave behind (multiple siblings chaining from a shared ancestor below
+// the live head). It returns the bundle hash.
+func writeForkRecord(t *testing.T, dir string, bundle conductor.PolicyBundle, at time.Time) string {
+	t.Helper()
+	hash, err := bundle.CanonicalHash()
+	if err != nil {
+		t.Fatalf("CanonicalHash() error = %v", err)
+	}
+	sk, err := streamKey(bundle)
+	if err != nil {
+		t.Fatalf("streamKey() error = %v", err)
+	}
+	if err := writeBundleRecord(dir, PublishedBundle{
+		Bundle:      bundle,
+		BundleHash:  hash,
+		StreamKey:   sk,
+		PublishedAt: at,
+	}); err != nil {
+		t.Fatalf("writeBundleRecord() error = %v", err)
+	}
+	return hash
+}
+
+// forkMarkerSupersededVersion is the superseded version every fork-recovery
+// scenario uses: the rollback target is v3 and the marker records that v4 was the
+// head when the rollback was applied, so the marker covers v3+v4 only and leaves
+// the abandoned v5 sibling uncovered (the exact incident shape).
+const forkMarkerSupersededVersion = 4
+
+// writeForkRollbackMarker writes a durable rollback marker for the stream that
+// target describes, mirroring what ApplyRollbackHead persists. The superseded
+// version is fixed at forkMarkerSupersededVersion across all fork-recovery
+// scenarios (see the const doc).
+func writeForkRollbackMarker(t *testing.T, dir string, target PublishedBundle, at time.Time) {
+	t.Helper()
+	marker := streamHeadRecord{
+		Version:           streamHeadRecordVersion,
+		StreamKey:         target.StreamKey,
+		TargetBundleID:    target.Bundle.BundleID,
+		TargetVersion:     target.Bundle.Version,
+		TargetBundleHash:  target.BundleHash,
+		SupersededVersion: forkMarkerSupersededVersion,
+		AppliedAt:         at,
+	}
+	if err := writeStreamHeadRecord(dir, marker); err != nil {
+		t.Fatalf("writeStreamHeadRecord() error = %v", err)
+	}
+}
+
+// forkChain builds a linear v1->v2->v3 chain plus the fork siblings v4/v5/v6 all
+// chaining from v3, returning the records keyed by version. It does NOT write
+// them; callers choose what lands on disk to drive each scenario.
+type forkRecord struct {
+	bundle conductor.PolicyBundle
+	hash   string
+	stream string
+}
+
+func buildForkRecords(t *testing.T, signer testSigner) map[uint64]forkRecord {
+	t.Helper()
+	aud := conductor.Audience{InstanceIDs: []string{"*"}}
+	records := map[uint64]forkRecord{}
+	mk := func(version uint64, prev string, yaml string) forkRecord {
+		b := signedControlBundle(t, signer, bundleSpec{
+			id:           "bundle-fork-v" + itoa(version),
+			version:      version,
+			previousHash: prev,
+			audience:     aud,
+			configYAML:   yaml,
+		})
+		h, err := b.CanonicalHash()
+		if err != nil {
+			t.Fatalf("CanonicalHash(v%d) error = %v", version, err)
+		}
+		sk, err := streamKey(b)
+		if err != nil {
+			t.Fatalf("streamKey(v%d) error = %v", version, err)
+		}
+		return forkRecord{bundle: b, hash: h, stream: sk}
+	}
+	v1 := mk(1, "", "mode: strict\napi_allowlist:\n  - v1.example.com\n")
+	v2 := mk(2, v1.hash, "mode: strict\napi_allowlist:\n  - v2.example.com\n")
+	v3 := mk(3, v2.hash, "mode: strict\napi_allowlist:\n  - v3.example.com\n")
+	records[1] = v1
+	records[2] = v2
+	records[3] = v3
+	// v4, v5, v6 all chain from v3 (the rollback point), the abandoned-fork shape.
+	records[4] = mk(4, v3.hash, "mode: strict\napi_allowlist:\n  - v4.example.com\n")
+	records[5] = mk(5, v3.hash, "mode: strict\napi_allowlist:\n  - v5.example.com\n")
+	records[6] = mk(6, v3.hash, "mode: strict\napi_allowlist:\n  - v6.example.com\n")
+	return records
+}
+
+func itoa(v uint64) string {
+	if v == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[i:])
+}
+
+// TestFileBundleStoreToleratesAbandonedForkSiblingOnLoad is the regression for the
+// exact prod incident: a stream with v1->v2->v3, then v4/v5/v6 all chaining from
+// v3, the effective head at v6, and a durable rollback marker recording only
+// superseded_version=4. Before the fix, v5 (off the v6 chain and uncovered by the
+// superseded=4 marker) was a fatal uncovered orphan that bricked startup. After
+// the fix the store loads, selects v6 as head, and survives a reopen.
+func TestFileBundleStoreToleratesAbandonedForkSiblingOnLoad(t *testing.T) {
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	signer := newTestSigner(t)
+	recs := buildForkRecords(t, signer)
+
+	for _, v := range []uint64{1, 2, 3, 4, 5, 6} {
+		writeForkRecord(t, store.bundlesDir, recs[v].bundle, testNow)
+	}
+	// Durable rollback marker: target v3, superseded version 4 (covers v3, v4 only).
+	writeForkRollbackMarker(t, store.streamHeadsDir, PublishedBundle{
+		Bundle:     recs[3].bundle,
+		BundleHash: recs[3].hash,
+		StreamKey:  recs[3].stream,
+	}, testNow.Add(time.Hour))
+
+	reopened, err := OpenFileBundleStore(store.dir)
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore(abandoned fork) error = %v, want nil (tolerated historical sibling)", err)
+	}
+	head, ok := reopened.streams[recs[6].stream]
+	if !ok {
+		t.Fatal("reopened store has no head for the fork stream")
+	}
+	if head.Bundle.Version != 6 || head.BundleHash != recs[6].hash {
+		t.Fatalf("reopened head version=%d hash=%s, want v6 %s", head.Bundle.Version, head.BundleHash, recs[6].hash)
+	}
+
+	// Restart survival: reopen the just-loaded store directory a second time.
+	again, err := OpenFileBundleStore(reopened.dir)
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore(reopen again) error = %v, want nil", err)
+	}
+	if h := again.streams[recs[6].stream]; h.Bundle.Version != 6 {
+		t.Fatalf("second reopen head version=%d, want 6", h.Bundle.Version)
+	}
+}
+
+// TestFileBundleStoreForkSiblingGenuineCorruptionStaysFatal proves the toleration
+// predicate does NOT weaken genuine-corruption detection. Each case constructs a
+// stream with a rollback marker (so the toleration path is reachable) plus a record
+// that must still be rejected.
+func TestFileBundleStoreForkSiblingGenuineCorruptionStaysFatal(t *testing.T) {
+	signer := newTestSigner(t)
+
+	tests := []struct {
+		name string
+		// build writes records + marker to the given dirs and returns nothing; the
+		// test asserts the subsequent OpenFileBundleStore fails with ErrInvalidStoreRecord.
+		build func(t *testing.T, bundlesDir, headsDir string, recs map[uint64]forkRecord)
+	}{
+		{
+			name: "missing previous_bundle_hash in sibling chain",
+			build: func(t *testing.T, bundlesDir, headsDir string, recs map[uint64]forkRecord) {
+				// Head chain v1->v2->v3->v6 present, but v5 chains from a v4 that is
+				// NOT written. v5's previous_bundle_hash points at the missing v4.
+				v5FromV4 := signedControlBundle(t, signer, bundleSpec{
+					id:           "bundle-fork-v5-missingprev",
+					version:      5,
+					previousHash: recs[4].hash, // v4 deliberately not written
+					audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+					configYAML:   "mode: strict\napi_allowlist:\n  - v5mp.example.com\n",
+				})
+				for _, v := range []uint64{1, 2, 3, 6} {
+					writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+				}
+				writeForkRecord(t, bundlesDir, v5FromV4, testNow.Add(5*time.Minute))
+				writeForkRollbackMarker(t, headsDir, PublishedBundle{
+					Bundle: recs[3].bundle, BundleHash: recs[3].hash, StreamKey: recs[3].stream,
+				}, testNow.Add(time.Hour))
+			},
+		},
+		{
+			name: "sibling ancestor belongs to different stream",
+			build: func(t *testing.T, bundlesDir, headsDir string, recs map[uint64]forkRecord) {
+				// A sibling whose previous_bundle_hash points at a record in a DIFFERENT
+				// stream (different audience -> different stream key).
+				crossParent := signedControlBundle(t, signer, bundleSpec{
+					id:         "bundle-fork-crossparent",
+					version:    2,
+					audience:   conductor.Audience{Labels: map[string]string{"ring": "canary"}},
+					configYAML: "mode: strict\napi_allowlist:\n  - cross.example.com\n",
+				})
+				crossHash := writeForkRecord(t, bundlesDir, crossParent, testNow)
+				sibling := signedControlBundle(t, signer, bundleSpec{
+					id:           "bundle-fork-v5-crossstream",
+					version:      5,
+					previousHash: crossHash,
+					audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+					configYAML:   "mode: strict\napi_allowlist:\n  - v5cs.example.com\n",
+				})
+				for _, v := range []uint64{1, 2, 3, 6} {
+					writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+				}
+				writeForkRecord(t, bundlesDir, sibling, testNow.Add(5*time.Minute))
+				writeForkRollbackMarker(t, headsDir, PublishedBundle{
+					Bundle: recs[3].bundle, BundleHash: recs[3].hash, StreamKey: recs[3].stream,
+				}, testNow.Add(time.Hour))
+			},
+		},
+		{
+			name: "sibling version does not strictly decrease toward ancestor",
+			build: func(t *testing.T, bundlesDir, headsDir string, recs map[uint64]forkRecord) {
+				// A sibling at version 5 whose previous_bundle_hash points at v6
+				// (version 6): the chain does not decrease, which is corruption.
+				badOrder := signedControlBundle(t, signer, bundleSpec{
+					id:           "bundle-fork-v5-badorder",
+					version:      5,
+					previousHash: recs[6].hash, // ancestor version (6) >= record version (5)
+					audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+					configYAML:   "mode: strict\napi_allowlist:\n  - v5bo.example.com\n",
+				})
+				for _, v := range []uint64{1, 2, 3, 6} {
+					writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+				}
+				writeForkRecord(t, bundlesDir, badOrder, testNow.Add(5*time.Minute))
+				writeForkRollbackMarker(t, headsDir, PublishedBundle{
+					Bundle: recs[3].bundle, BundleHash: recs[3].hash, StreamKey: recs[3].stream,
+				}, testNow.Add(time.Hour))
+			},
+		},
+		{
+			name: "disconnected graft sibling shares no ancestor with head",
+			build: func(t *testing.T, bundlesDir, headsDir string, recs map[uint64]forkRecord) {
+				// A sibling whose chain roots at its own previous_bundle_hash="" record
+				// that is NOT on the head chain: a parallel root in the same stream.
+				graftRoot := signedControlBundle(t, signer, bundleSpec{
+					id:         "bundle-fork-graft-root",
+					version:    1,
+					audience:   conductor.Audience{InstanceIDs: []string{"*"}},
+					configYAML: "mode: strict\napi_allowlist:\n  - graftroot.example.com\n",
+				})
+				// Same stream (same audience) but a separate root: this collides on
+				// bundle_id/version uniqueness? No -- different id and version 1 already
+				// taken by recs[1]. Use version 5 with empty prev so it is its own root.
+				graft := signedControlBundle(t, signer, bundleSpec{
+					id:           "bundle-fork-graft",
+					version:      5,
+					previousHash: "",
+					audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+					configYAML:   "mode: strict\napi_allowlist:\n  - graft.example.com\n",
+				})
+				_ = graftRoot
+				for _, v := range []uint64{1, 2, 3, 6} {
+					writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+				}
+				writeForkRecord(t, bundlesDir, graft, testNow.Add(5*time.Minute))
+				writeForkRollbackMarker(t, headsDir, PublishedBundle{
+					Bundle: recs[3].bundle, BundleHash: recs[3].hash, StreamKey: recs[3].stream,
+				}, testNow.Add(time.Hour))
+			},
+		},
+		{
+			name: "off-chain sibling with no rollback marker on stream",
+			build: func(t *testing.T, bundlesDir, headsDir string, recs map[uint64]forkRecord) {
+				// v5 forks legitimately from v3, but NO rollback marker exists. Without
+				// the marker the sibling cannot be a byproduct of authorized rollback, so
+				// it must remain fatal (a graft on a stream that never rolled back).
+				for _, v := range []uint64{1, 2, 3, 5, 6} {
+					writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+				}
+				// No marker written.
+			},
+		},
+		{
+			name: "off-chain sibling at or above head version",
+			build: func(t *testing.T, bundlesDir, headsDir string, recs map[uint64]forkRecord) {
+				// Two version-6 records both chaining from v3: one becomes head, the
+				// other is an off-chain sibling AT the head version -- a real two-heads
+				// conflict, not historical supersession. Marker present.
+				sixB := signedControlBundle(t, signer, bundleSpec{
+					id:           "bundle-fork-v6b",
+					version:      6,
+					previousHash: recs[3].hash,
+					audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+					configYAML:   "mode: strict\napi_allowlist:\n  - v6b.example.com\n",
+				})
+				for _, v := range []uint64{1, 2, 3, 6} {
+					writeForkRecord(t, bundlesDir, recs[v].bundle, testNow)
+				}
+				writeForkRecord(t, bundlesDir, sixB, testNow.Add(7*time.Minute))
+				writeForkRollbackMarker(t, headsDir, PublishedBundle{
+					Bundle: recs[3].bundle, BundleHash: recs[3].hash, StreamKey: recs[3].stream,
+				}, testNow.Add(time.Hour))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := OpenFileBundleStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("OpenFileBundleStore() error = %v", err)
+			}
+			recs := buildForkRecords(t, signer)
+			tc.build(t, store.bundlesDir, store.streamHeadsDir, recs)
+			if _, err := OpenFileBundleStore(store.dir); !errors.Is(err, ErrInvalidStoreRecord) {
+				t.Fatalf("OpenFileBundleStore(%s) error = %v, want ErrInvalidStoreRecord", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestFileBundleStoreForkSiblingDoesNotMaskMissingHeadAncestor proves the head
+// chain is still validated independently: a broken head chain is fatal regardless
+// of the fork-sibling toleration path.
+func TestFileBundleStoreForkSiblingDoesNotMaskBrokenHead(t *testing.T) {
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	signer := newTestSigner(t)
+	recs := buildForkRecords(t, signer)
+	// Write v6 (head, chains from v3) and v3/v2 but OMIT v1: v3's chain references a
+	// missing v2->v1? No -- omit v2 so v3's previous_bundle_hash (v2) is missing.
+	for _, v := range []uint64{3, 6} {
+		writeForkRecord(t, store.bundlesDir, recs[v].bundle, testNow)
+	}
+	writeForkRollbackMarker(t, store.streamHeadsDir, PublishedBundle{
+		Bundle: recs[3].bundle, BundleHash: recs[3].hash, StreamKey: recs[3].stream,
+	}, testNow.Add(time.Hour))
+	if _, err := OpenFileBundleStore(store.dir); !errors.Is(err, ErrInvalidStoreRecord) {
+		t.Fatalf("OpenFileBundleStore(broken head chain) error = %v, want ErrInvalidStoreRecord", err)
+	}
+}

--- a/internal/cli/selfupdate/verify.go
+++ b/internal/cli/selfupdate/verify.go
@@ -242,9 +242,9 @@ func copyBounded(w io.Writer, r io.Reader) error {
 	return nil
 }
 
-// checkWritable confirms the target binary and its directory are writable by
-// the current user BEFORE any destructive step. Returns ErrNotWritable
-// otherwise so the caller can abort cleanly with a privileged-path message.
+// checkWritable confirms the target directory can accept the temp+rename update
+// path BEFORE any destructive step. Returns ErrNotWritable otherwise so the
+// caller can abort cleanly with a privileged-path message.
 func checkWritable(target string) error {
 	dir := filepath.Dir(target)
 	// Directory must be writable for the atomic temp+rename.
@@ -254,15 +254,6 @@ func checkWritable(target string) error {
 	}
 	_ = probe.Close()
 	_ = os.Remove(probe.Name())
-
-	// The target file itself must be writable if it already exists.
-	if info, statErr := os.Stat(target); statErr == nil && info.Mode().IsRegular() {
-		f, openErr := os.OpenFile(target, os.O_WRONLY, info.Mode().Perm()) // #nosec G304 -- target is the resolved running binary path
-		if openErr != nil {
-			return fmt.Errorf("%w: file %q: %s", ErrNotWritable, target, openErr.Error())
-		}
-		_ = f.Close()
-	}
 	return nil
 }
 

--- a/internal/cli/selfupdate/verify_test.go
+++ b/internal/cli/selfupdate/verify_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -272,6 +273,23 @@ func TestRun_TargetNotWritableAborts(t *testing.T) {
 	}
 	if string(readT(target)) != "ORIGINAL" {
 		t.Fatalf("target mutated despite not-writable: %q", readT(target))
+	}
+}
+
+func TestCheckWritable_AllowsReadOnlyTargetInWritableDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows replacement semantics depend on file locking and attributes")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permission bits don't gate writes")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "pipelock")
+	if err := os.WriteFile(target, []byte("ORIGINAL"), 0o500); err != nil { // #nosec G306 -- test fixture binary needs exec bit
+		t.Fatalf("write target: %v", err)
+	}
+	if err := checkWritable(target); err != nil {
+		t.Fatalf("checkWritable(read-only target in writable dir) = %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

Conductor store load and recovery:

- A rollback-then-republish cycle can leave an abandoned policy-bundle fork sibling below the live stream head. The startup validator treated that sibling as an unreachable orphan and refused to load, so an otherwise healthy stream could not boot. Store load now tolerates an abandoned sibling only when it provably forked from a rollback point on the same stream and sits below the head version. Every corruption shape stays fatal: a missing `previous_bundle_hash`, an ancestor on a different stream, a non-decreasing version along the chain, a cycle, a broken head chain, a sibling at or above the head version, a sibling on a stream with no rollback marker, and a duplicate `bundle_id`/version.
- Added offline recovery that operates directly on `--storage-dir` with no running server, for the case where a corrupt store crashes the control plane at startup. The existing `store dump` and `stream inspect|status|reset` are all client-side and need a reachable server, so none of them can run on a store that won't load.
  - `conductor store inspect-offline` reports stream heads, orphaned records, and unreadable files. Read-only.
  - `conductor store repair` removes only provably-removable orphans. It is a dry run by default; `--confirm` performs the removal, and every removed record is backed up first. It never touches reachable records, rollback-covered records, tolerated siblings, stream-head markers, duplicate or ambiguous records, or the audit store.

Self-update:

- `pipelock update` and `pipelock update --rollback` failed against the running binary with "text file busy". The writability preflight opened the target binary for write, which the kernel refuses for a running executable. The install path already replaces the binary with an atomic temp-and-rename, which needs a writable directory, not a writable target file. Removed the preflight. The directory write probe stays, and the final rename still fails closed on immutable, locked, or policy-blocked targets.

**Tests.** Reproduces the forked-stream load failure, confirms it loads after the fix, and survives a second reopen. Each corruption shape stays fatal (subtests). Offline inspect and repair: finds orphans read-only, dry run is a no-op, `--confirm` removes only the orphan and leaves reachable records, head markers, duplicates, and the audit store intact, writes a recoverable backup, and the store then loads cleanly through the normal path. Self-update writability against the running binary no longer errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a guide for offline Conductor day-2 recovery, including which store commands require a live server and how to run offline inspection/repair.

* **New Features**
  * Added enterprise-gated `store inspect-offline` to analyze on-disk policy bundles (supports `--json`).
  * Added enterprise-gated `store repair` to safely remove provably-orphaned records, with dry-run by default, plus `--confirm` and `--backup-dir`.

* **Improvements**
  * Enhanced fork recovery tolerance during store verification.
  * Improved software update preflight checks to require only directory writability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->