### PR TITLE
fix(chart): render valid Conductor image refs (digest vs tag)

### DIFF
--- a/charts/pipelock/examples/values-enterprise-conductor.yaml
+++ b/charts/pipelock/examples/values-enterprise-conductor.yaml
@@ -5,6 +5,13 @@
 
 mode: conductor
 
+# Pin the control-plane image by digest. Leave tag empty so it does not combine
+# with the digest. Replace the digest with the one you have verified for the
+# release you are deploying.
+image:
+  tag: ""
+  digest: "sha256:e8e249d2dd1b579f995f0f5a75cfab13fb8505a8ffc33c2cec7a6418290d9098"
+
 license:
   enabled: true
   existingSecret: pipelock-enterprise-license

--- a/charts/pipelock/examples/values-enterprise-follower.yaml
+++ b/charts/pipelock/examples/values-enterprise-follower.yaml
@@ -6,6 +6,13 @@
 mode: proxy
 replicaCount: 2
 
+# Pin the follower image by digest. Leave tag empty so it does not combine with
+# the digest. Replace the digest with the one you have verified for the release
+# you are deploying.
+image:
+  tag: ""
+  digest: "sha256:e8e249d2dd1b579f995f0f5a75cfab13fb8505a8ffc33c2cec7a6418290d9098"
+
 license:
   enabled: true
   existingSecret: pipelock-enterprise-license

--- a/charts/pipelock/templates/_helpers.tpl
+++ b/charts/pipelock/templates/_helpers.tpl
@@ -67,6 +67,31 @@ Return the chart deployment mode.
 {{- end }}
 
 {{/*
+Build the container image reference. A digest pins by manifest hash
+(repository@sha256:...); otherwise the image is referenced by tag
+(repository:tag), with the tag falling through to .Chart.AppVersion when empty.
+A digest and a tag are never combined, so the ":@sha256:" malformed reference
+cannot be rendered. Fails loudly if image.tag itself contains a digest, the
+misconfiguration that produced ":@sha256:" before image.digest existed.
+*/}}
+{{- define "pipelock.image" -}}
+{{- $repository := required "image.repository is required" .Values.image.repository -}}
+{{- $digest := default "" .Values.image.digest -}}
+{{- $tag := default "" .Values.image.tag -}}
+{{- if or (hasPrefix "sha256:" $tag) (contains "@" $tag) -}}
+{{- fail "image.tag must not contain a digest; set the sha256 string in image.digest instead" -}}
+{{- end -}}
+{{- if $digest -}}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" $digest) -}}
+{{- fail "image.digest must be a sha256 digest like sha256:<64 lowercase hex chars>" -}}
+{{- end -}}
+{{- printf "%s@%s" $repository $digest -}}
+{{- else -}}
+{{- printf "%s:%s" $repository (default .Chart.AppVersion $tag) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Validate mode and security-critical enterprise chart requirements.
 */}}
 {{- define "pipelock.validate" -}}

--- a/charts/pipelock/templates/deployment-conductor.yaml
+++ b/charts/pipelock/templates/deployment-conductor.yaml
@@ -36,11 +36,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: conductor
-          {{- if .Values.image.digest }}
-          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-          {{- else }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- end }}
+          image: {{ include "pipelock.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - conductor

--- a/charts/pipelock/templates/deployment-fleetsink.yaml
+++ b/charts/pipelock/templates/deployment-fleetsink.yaml
@@ -36,11 +36,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: fleet-sink
-          {{- if .Values.image.digest }}
-          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-          {{- else }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- end }}
+          image: {{ include "pipelock.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - fleet-sink

--- a/charts/pipelock/templates/deployment.yaml
+++ b/charts/pipelock/templates/deployment.yaml
@@ -36,11 +36,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if .Values.image.digest }}
-          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-          {{- else }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- end }}
+          image: {{ include "pipelock.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - run

--- a/charts/pipelock/values.schema.json
+++ b/charts/pipelock/values.schema.json
@@ -17,8 +17,22 @@
       "required": ["repository", "pullPolicy"],
       "properties": {
         "repository": { "type": "string", "minLength": 1 },
-        "tag": { "type": "string" },
-        "digest": { "type": "string" },
+        "tag": {
+          "type": "string",
+          "not": {
+            "anyOf": [
+              { "pattern": "@" },
+              { "pattern": "^sha256:" }
+            ]
+          }
+        },
+        "digest": {
+          "type": "string",
+          "oneOf": [
+            { "const": "" },
+            { "pattern": "^sha256:[a-f0-9]{64}$" }
+          ]
+        },
         "pullPolicy": {
           "type": "string",
           "enum": ["Always", "IfNotPresent", "Never"]

--- a/charts/pipelock/values.yaml
+++ b/charts/pipelock/values.yaml
@@ -4,11 +4,11 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/luckypipewrench/pipelock
-  # Default tag tracks the chart appVersion. To pin by digest, set image.digest
-  # to a sha256 string and the chart will render repository@digest. The tag
-  # value falls through to .Chart.AppVersion when empty.
-  tag: "@sha256:e8e249d2dd1b579f995f0f5a75cfab13fb8505a8ffc33c2cec7a6418290d9098"  # defaults to .Chart.AppVersion
-  digest: ""  # optional sha256 multi-arch manifest digest
+  # Tag falls through to .Chart.AppVersion when empty. To pin by digest instead,
+  # set image.digest to a sha256 string and the chart renders repository@digest.
+  # A digest and a tag are never combined; a digest must not go in tag.
+  tag: ""  # defaults to .Chart.AppVersion
+  digest: ""  # optional sha256 multi-arch manifest digest, e.g. sha256:abc123...
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -84,7 +84,7 @@ fi
 # Every rendered image reference must be either repo:tag or repo@sha256:...,
 # never a malformed combination. This guards UX-001 (a digest concatenated as a
 # tag produced ":@sha256:") and the related empty-tag / double-separator shapes.
-image_refs="$(grep -Rh -- 'image:' "$render_dir" | grep -v -- 'imagePullSecrets\|imagePullPolicy' || true)"
+image_refs="$(grep -RhE '^[[:space:]]*image:[[:space:]]' "$render_dir" | grep -vE '^[[:space:]]*imagePull(Secrets|Policy):' || true)"
 if [ -z "$image_refs" ]; then
   echo "no image references found in rendered manifests" >&2
   exit 1

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -30,6 +30,18 @@ expect_template_error() {
   fi
 }
 
+expect_template_error "/image/tag" \
+  --set image.tag="@sha256:e8e249d2dd1b579f995f0f5a75cfab13fb8505a8ffc33c2cec7a6418290d9098"
+
+expect_template_error "/image/tag" \
+  --set image.tag="sha256:e8e249d2dd1b579f995f0f5a75cfab13fb8505a8ffc33c2cec7a6418290d9098"
+
+expect_template_error "/image/digest" \
+  --set image.digest="not-a-digest"
+
+expect_template_error "/image/digest" \
+  --set image.digest="sha256:e8e249d2dd1b579f995f0f5a75cfab13fb8505a8ffc33c2cec7a6418290d909Z"
+
 expect_template_error "conductorFollower.conductorURL is required" \
   --set conductorFollower.enabled=true
 
@@ -68,5 +80,28 @@ if grep -R "publisher.token:" "$render_dir" >/dev/null; then
   echo "rendered manifests must not contain inline publisher token values" >&2
   exit 1
 fi
+
+# Every rendered image reference must be either repo:tag or repo@sha256:...,
+# never a malformed combination. This guards UX-001 (a digest concatenated as a
+# tag produced ":@sha256:") and the related empty-tag / double-separator shapes.
+image_refs="$(grep -Rh -- 'image:' "$render_dir" | grep -v -- 'imagePullSecrets\|imagePullPolicy' || true)"
+if [ -z "$image_refs" ]; then
+  echo "no image references found in rendered manifests" >&2
+  exit 1
+fi
+if printf '%s\n' "$image_refs" | grep -E ':@sha256:|@@|: *"[^"]*:" *$|:" *$' >/dev/null; then
+  echo "rendered manifests contain a malformed image reference:" >&2
+  printf '%s\n' "$image_refs" | grep -E ':@sha256:|@@|: *"[^"]*:" *$|:" *$' >&2
+  exit 1
+fi
+
+# Digest-pinned examples must render repository@sha256:..., not a tag.
+for name in values-enterprise-conductor values-enterprise-follower; do
+  if ! grep -q -- 'image: "ghcr.io/luckypipewrench/pipelock@sha256:' "$render_dir/$name.yaml"; then
+    echo "$name should render a digest-pinned image (repository@sha256:...)" >&2
+    grep -- 'image:' "$render_dir/$name.yaml" >&2
+    exit 1
+  fi
+done
 
 echo "helm chart checks passed"


### PR DESCRIPTION
## What changed

The Helm chart concatenated a pinned digest into the tag position, rendering an invalid `image: repo:@sha256:...` for the default install and all three deployments (proxy, conductor, fleet-sink).

- Consolidates image-ref construction into one `pipelock.image` helper used by every deployment template.
- Validates image refs at two layers: `values.schema.json` and the template both reject a digest stuffed into `image.tag` and require `image.digest` to be `sha256:<64 lowercase hex>`.
- Adds `scripts/check-helm-chart.sh`: lints, renders the default plus every example, asserts digest-pinned examples render `repo@sha256:...`, and fails on any malformed reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pinning container images by digest in the Helm chart, improving reproducibility and supply-chain security.
  * Updated the enterprise conductor and follower example values to use digest-pinned images.
  * Tightened image configuration validation to prevent malformed image references.
* **Tests**
  * Expanded Helm chart checks with additional negative cases and post-render verification of correct image reference formatting for the example deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->