### PR TITLE
feat(conductor): offline fleet-report export and verification

### DIFF
--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -82,13 +82,26 @@ included signed audit batches and carry the mediated-fraction completeness
 metric. They do not claim non-bypass; they prove the signed report's source set
 and arithmetic for mediated actions inside that source set.
 
+Generate a dedicated fleet-report signing key once (the `fleet-report-signing`
+purpose is what `conductor fleet report --signing-key` requires):
+
+```bash
+pipelock signing key generate \
+  --purpose fleet-report-signing \
+  --out /etc/pipelock/keys/fleet-report.key \
+  --id fleet-report-key
+```
+
+The key file embeds the public key; distribute its hex to verifiers. Generating
+the key is free; minting a report is Enterprise-gated, verifying is free.
+
 Enterprise operators mint a report from the local Conductor audit store:
 
 ```bash
 pipelock conductor fleet report \
   --storage-dir /var/lib/pipelock/conductor \
-  --org-id pipelab \
-  --fleet-id dogfood \
+  --org-id example-org \
+  --fleet-id prod \
   --from 2026-06-13T00:00:00Z \
   --to 2026-06-14T00:00:00Z \
   --signing-key /etc/pipelock/keys/fleet-report.key \
@@ -98,9 +111,30 @@ pipelock conductor fleet report \
 The mint command reads stored audit-batch envelopes and payloads locally. The
 remote `conductor audit query` API stays metadata-only.
 
-Pin the fleet-report public key:
+Pin the fleet-report public key. Pass the signer's 64-hex Ed25519 public key (or
+a file containing it) to `--key`; the verifier binds it to the report's signer
+key id and checks the Ed25519 signature, so the report's key id can be a human
+label like `fleet-report-key` rather than the public-key hex:
 
 ```bash
+pipelock verify-receipt fleet-receipt.dsse.json --fleet-report --key fleet-report.pub
+```
+
+### Piping a report out of a distroless pod
+
+The Conductor ships as a distroless image with no shell, `cat`, or `tar`, so an
+operator cannot extract a minted file from the pod. Pass `--out -` to write the
+DSSE envelope to stdout (the human-readable summary then goes to stderr) and pipe
+it straight into the offline verifier:
+
+```bash
+kubectl exec deploy/conductor -- pipelock conductor fleet report \
+  --storage-dir /var/lib/pipelock/conductor \
+  --org-id example-org --fleet-id prod \
+  --from 2026-06-13T00:00:00Z --to 2026-06-14T00:00:00Z \
+  --signing-key /etc/pipelock/keys/fleet-report.key \
+  --out - > fleet-receipt.dsse.json
+
 pipelock verify-receipt fleet-receipt.dsse.json --fleet-report --key fleet-report.pub
 ```
 
@@ -108,9 +142,9 @@ Output on success:
 
 ```text
 FLEET RECEIPT OK: fleet-receipt.dsse.json
-  Signer:           70b991eb...
+  Signer:           fleet-report-key
   Payload SHA-256:  9c46a3...
-  Org/Fleet:        pipelab/dogfood
+  Org/Fleet:        example-org/prod
   Report ID:        019...
   Level:            L1
   Source batches:   12

--- a/enterprise/cli/conductor/fleet_report.go
+++ b/enterprise/cli/conductor/fleet_report.go
@@ -268,7 +268,9 @@ func writeFleetReportEnvelopeTo(w io.Writer, envelope any) error {
 	if err != nil {
 		return err
 	}
-	if _, err := w.Write(data); err != nil {
+	// io.Copy loops until all bytes are written, guarding against a short write
+	// that would emit a truncated DSSE envelope and break offline verification.
+	if _, err := io.Copy(w, bytes.NewReader(data)); err != nil {
 		return fmt.Errorf("write fleet report to stdout: %w", err)
 	}
 	return nil

--- a/enterprise/cli/conductor/fleet_report.go
+++ b/enterprise/cli/conductor/fleet_report.go
@@ -54,7 +54,14 @@ audit batches.
 
 This command reads the local SQLite audit store under --storage-dir. It does not
 use the remote audit query API and does not expose raw audit payloads over the
-network.`,
+network.
+
+Pass --out - to write the DSSE envelope to stdout instead of a file. The
+human-readable summary then goes to stderr, so the report can be piped straight
+into the offline verifier:
+
+  pipelock conductor fleet report --out - ... | \
+    pipelock verify-receipt /dev/stdin --fleet-report --key fleet-report.pub`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.licenseCRLFile}); err != nil {
@@ -70,7 +77,7 @@ network.`,
 	cmd.Flags().StringVar(&opts.to, "to", "", "exclusive received-at window end, RFC3339 (required)")
 	cmd.Flags().StringVar(&opts.signingKey, "signing-key", "", "fleet-report-signing private key file (required)")
 	cmd.Flags().StringVar(&opts.signingKeyID, "signing-key-id", "", "override fleet report signing key id")
-	cmd.Flags().StringVar(&opts.out, "out", "", "output DSSE envelope path (required)")
+	cmd.Flags().StringVar(&opts.out, "out", "", "output DSSE envelope path (required); use \"-\" to write the envelope to stdout for piping out of a distroless pod")
 	cmd.Flags().StringVar(&opts.conductorID, "conductor-id", opts.conductorID, "Conductor id to stamp into the report")
 	cmd.Flags().StringVar(&opts.conductorVersion, "conductor-version", "", "Conductor version to stamp into the report")
 	cmd.Flags().StringArrayVar(&opts.trustedAuditKeys, "trusted-audit-key", nil,
@@ -128,6 +135,21 @@ func runFleetReport(cmd *cobra.Command, opts fleetReportOptions) error {
 	if err != nil {
 		return err
 	}
+	// "--out -" writes the DSSE envelope to stdout so an operator can pipe the
+	// report out of a distroless pod (which has no shell/cat/tar to extract a
+	// file). The human-readable summary then goes to stderr to keep stdout a
+	// clean DSSE envelope for piping into the offline verifier.
+	if opts.out == stdoutSentinel {
+		if err := writeFleetReportEnvelopeTo(cmd.OutOrStdout(), result.Envelope); err != nil {
+			return err
+		}
+		summary := cmd.ErrOrStderr()
+		_, _ = fmt.Fprintln(summary, "fleet receipt report written: <stdout>")
+		_, _ = fmt.Fprintf(summary, "  report_id: %s\n", result.Statement.Predicate.ReportID)
+		_, _ = fmt.Fprintf(summary, "  source_batches: %d\n", len(result.Statement.Predicate.SourceBatches))
+		_, _ = fmt.Fprintf(summary, "  total_actions: %d\n", result.Statement.Predicate.Summary.TotalActions)
+		return nil
+	}
 	if err := writeFleetReportEnvelope(opts.out, result.Envelope); err != nil {
 		return err
 	}
@@ -137,6 +159,10 @@ func runFleetReport(cmd *cobra.Command, opts fleetReportOptions) error {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  total_actions: %d\n", result.Statement.Predicate.Summary.TotalActions)
 	return nil
 }
+
+// stdoutSentinel is the conventional "-" value for --out meaning "write to
+// stdout" rather than a file path.
+const stdoutSentinel = "-"
 
 func openFleetReportAuditStore(cmd *cobra.Command, storageDir string) (*controlplane.SQLiteAuditStore, error) {
 	auditPath := filepath.Join(storageDir, "audit.db")
@@ -218,13 +244,32 @@ func loadFleetReportSigningKey(path string) (string, ed25519.PrivateKey, error) 
 	return kf.KeyID, priv, nil
 }
 
-func writeFleetReportEnvelope(path string, envelope any) error {
+func marshalFleetReportEnvelope(envelope any) ([]byte, error) {
 	data, err := json.MarshalIndent(envelope, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal fleet report envelope: %w", err)
+		return nil, fmt.Errorf("marshal fleet report envelope: %w", err)
 	}
-	if err := os.WriteFile(filepath.Clean(path), append(data, '\n'), 0o600); err != nil {
+	return append(data, '\n'), nil
+}
+
+func writeFleetReportEnvelope(path string, envelope any) error {
+	data, err := marshalFleetReportEnvelope(envelope)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Clean(path), data, 0o600); err != nil {
 		return fmt.Errorf("write --out: %w", err)
+	}
+	return nil
+}
+
+func writeFleetReportEnvelopeTo(w io.Writer, envelope any) error {
+	data, err := marshalFleetReportEnvelope(envelope)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("write fleet report to stdout: %w", err)
 	}
 	return nil
 }

--- a/enterprise/cli/conductor/fleet_report_test.go
+++ b/enterprise/cli/conductor/fleet_report_test.go
@@ -10,8 +10,10 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -303,6 +305,104 @@ func TestRunFleetReportWritesVerifiedEnvelope(t *testing.T) {
 	if verified.Statement.Predicate.ReportID == "" || verified.Statement.Predicate.Summary.TotalActions != 1 {
 		t.Fatalf("verified predicate = %+v", verified.Statement.Predicate)
 	}
+}
+
+func TestRunFleetReportStdoutRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store, err := controlplane.OpenSQLiteAuditStore(context.Background(), filepath.Join(dir, "audit.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteAuditStore() error = %v", err)
+	}
+	auditPub, auditPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(audit) error = %v", err)
+	}
+	if _, err := store.IngestAuditBatch(context.Background(), cliTestAcceptedAuditBatch(t, auditPriv)); err != nil {
+		t.Fatalf("IngestAuditBatch() error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close(store) error = %v", err)
+	}
+
+	reportPub, reportPriv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair(report) error = %v", err)
+	}
+	keyPath := writeFleetReportKeyFile(t, dir, "report.key", "report-key-1", signing.PurposeFleetReportSigning, reportPriv)
+
+	cmd := fleetReportCmd()
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	err = runFleetReport(cmd, fleetReportOptions{
+		storageDir:       dir,
+		orgID:            "org-main",
+		fleetID:          "prod",
+		from:             "2026-06-13T00:00:00Z",
+		to:               "2026-06-13T01:00:00Z",
+		signingKey:       keyPath,
+		out:              "-",
+		conductorID:      "conductor-1",
+		trustedAuditKeys: []string{"id=audit-key-1,inline=" + hex.EncodeToString(auditPub) + ",org=org-main,fleet=prod,instance=pl-1"},
+		limit:            10,
+		signingKeyID:     "stdout-report-key",
+	})
+	if err != nil {
+		t.Fatalf("runFleetReport(--out -) error = %v", err)
+	}
+
+	// stdout must be a clean DSSE envelope with no summary text mixed in;
+	// the human-readable summary belongs on stderr.
+	if strings.Contains(stdout.String(), "fleet receipt report written") {
+		t.Fatalf("stdout leaked summary text: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "fleet receipt report written: <stdout>") || !strings.Contains(stderr.String(), "total_actions: 1") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+
+	envelopeBytes := stdout.Bytes()
+	var envelope fleetreceipt.Envelope
+	if err := json.Unmarshal(envelopeBytes, &envelope); err != nil {
+		t.Fatalf("Unmarshal(stdout envelope) error = %v", err)
+	}
+	trusted := map[string]ed25519.PublicKey{"stdout-report-key": reportPub}
+	verified, err := fleetreceipt.VerifyEnvelope(envelope, trusted)
+	if err != nil {
+		t.Fatalf("VerifyEnvelope(stdout) error = %v", err)
+	}
+	if verified.Statement.Predicate.Summary.TotalActions != 1 {
+		t.Fatalf("verified predicate = %+v", verified.Statement.Predicate)
+	}
+
+	// Tamper one byte of the signed payload: verification must fail closed.
+	tampered := envelope
+	payloadRaw, err := base64.StdEncoding.DecodeString(tampered.Payload)
+	if err != nil {
+		t.Fatalf("DecodeString(payload) error = %v", err)
+	}
+	payloadRaw[0] ^= 0x01
+	tampered.Payload = base64.StdEncoding.EncodeToString(payloadRaw)
+	if _, err := fleetreceipt.VerifyEnvelope(tampered, trusted); err == nil {
+		t.Fatal("VerifyEnvelope(tampered) succeeded, want fail-closed error")
+	}
+}
+
+func TestWriteFleetReportEnvelopeToPropagatesWriterError(t *testing.T) {
+	err := writeFleetReportEnvelopeTo(failingWriter{}, map[string]any{"ok": 1})
+	if err == nil || !strings.Contains(err.Error(), "write fleet report to stdout") {
+		t.Fatalf("writeFleetReportEnvelopeTo(failing writer) error = %v, want write error", err)
+	}
+	if err := writeFleetReportEnvelopeTo(&bytes.Buffer{}, map[string]any{"bad": make(chan int)}); err == nil ||
+		!strings.Contains(err.Error(), "marshal fleet report envelope") {
+		t.Fatalf("writeFleetReportEnvelopeTo(unmarshalable) error = %v, want marshal error", err)
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("boom")
 }
 
 func TestRunFleetReportPropagatesWriteFailure(t *testing.T) {

--- a/internal/cli/signing/key_generate.go
+++ b/internal/cli/signing/key_generate.go
@@ -118,6 +118,7 @@ The --purpose flag binds the key to one of the recognised wire purposes:
   trust-root-rotation            reserved Conductor trust-root rotation signing
   audit-batch-signing            Conductor follower audit batch signing
   enrollment-token-signing       reserved Conductor enrollment-token signing
+  fleet-report-signing           Fleet Receipt Report signing (verify is free; mint is Enterprise)
 
 Conductor rollback, remote-kill, and trust-root-rotation keys are threshold
 keys: generate independent keys for separate approvers and configure the

--- a/internal/cli/signing/key_generate_test.go
+++ b/internal/cli/signing/key_generate_test.go
@@ -247,6 +247,7 @@ func TestKeyGenerate_HelpListsConductorPurposes(t *testing.T) {
 		domsigning.PurposeTrustRootRotation,
 		domsigning.PurposeAuditBatchSigning,
 		domsigning.PurposeEnrollmentTokenSigning,
+		domsigning.PurposeFleetReportSigning,
 	} {
 		if !strings.Contains(help, purpose.String()) {
 			t.Errorf("help missing %q:\n%s", purpose, help)

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -147,11 +147,16 @@ func verifyFleetReportWithOptions(out io.Writer, path string, trustedKeys []stri
 	if err != nil {
 		return fmt.Errorf("reading fleet receipt: %w", err)
 	}
-	keyMap, err := fleetTrustedKeyMap(trustedKeys)
+	env, err := fleetreceipt.UnmarshalEnvelope(data)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "FAILED: %s: %v\n", path, err)
+		return fmt.Errorf("fleet receipt verification failed: %w", err)
+	}
+	keyMap, err := fleetTrustedKeyMap(env, trustedKeys)
 	if err != nil {
 		return err
 	}
-	result, err := fleetreceipt.Verify(data, keyMap)
+	result, err := fleetreceipt.VerifyEnvelope(env, keyMap)
 	if err != nil {
 		_, _ = fmt.Fprintf(out, "FAILED: %s: %v\n", path, err)
 		return fmt.Errorf("fleet receipt verification failed: %w", err)
@@ -176,11 +181,29 @@ func verifyFleetReportWithOptions(out io.Writer, path string, trustedKeys []stri
 	return nil
 }
 
-func fleetTrustedKeyMap(keys []string) (map[string]ed25519.PublicKey, error) {
+// fleetTrustedKeyMap builds the verifier's trusted-key map from the operator's
+// --key hex public keys. The verifier resolves the trusted public key by the
+// envelope's signer key id, which is an operator-chosen label (e.g.
+// "fleet-report-2026") that is NOT the hex of the public key. So a supplied key
+// is registered under BOTH the envelope's actual signer key id and its own hex
+// string: the former is what makes a real, human-labelled key id verify; the
+// latter preserves the historical hex-keyid convention. This stays fail-closed
+// because the signature must still verify against the resolved public key
+// (ed25519.Verify), so trusting a key for the wrong report id only succeeds if
+// the bytes genuinely signed the payload.
+func fleetTrustedKeyMap(env fleetreceipt.Envelope, keys []string) (map[string]ed25519.PublicKey, error) {
 	if len(keys) == 0 {
 		return nil, nil
 	}
-	out := make(map[string]ed25519.PublicKey, len(keys))
+	// A Fleet Receipt Report carries exactly one signature. Bind a lone --key to
+	// that signature's key id so a human-labelled key id verifies; with multiple
+	// keys we cannot pick which one the label maps to, so we register only by
+	// hex and leave id-binding to the historical hex==keyid convention.
+	var signerKeyID string
+	if len(keys) == 1 && len(env.Signatures) == 1 {
+		signerKeyID = strings.TrimSpace(env.Signatures[0].KeyID)
+	}
+	out := make(map[string]ed25519.PublicKey, len(keys)+1)
 	for _, key := range keys {
 		raw, err := hex.DecodeString(key)
 		if err != nil {
@@ -189,7 +212,11 @@ func fleetTrustedKeyMap(keys []string) (map[string]ed25519.PublicKey, error) {
 		if len(raw) != ed25519.PublicKeySize {
 			return nil, fmt.Errorf("trusted fleet report key length=%d want %d", len(raw), ed25519.PublicKeySize)
 		}
-		out[key] = ed25519.PublicKey(raw)
+		pub := ed25519.PublicKey(raw)
+		out[key] = pub
+		if signerKeyID != "" {
+			out[signerKeyID] = pub
+		}
 	}
 	return out, nil
 }

--- a/internal/cli/signing/receipt_test.go
+++ b/internal/cli/signing/receipt_test.go
@@ -8,7 +8,9 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -197,6 +199,49 @@ func TestVerifyReceiptCmd_FleetReportWithExpectedKey(t *testing.T) {
 	}
 }
 
+// TestVerifyReceiptCmd_FleetReportHumanKeyID proves --key <hex> verifies a
+// report whose signer key id is a human label (not the hex of the public key).
+// The trusted-key map is resolved by the envelope's signer key id, so a bare
+// hex key must be bound to that id; otherwise the offline-verify flow only ever
+// worked when the key id happened to equal the public-key hex.
+func TestVerifyReceiptCmd_FleetReportHumanKeyID(t *testing.T) {
+	t.Parallel()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	_, path := writeFleetReportFixtureSigned(t, "fleet-report-2026", pub, priv)
+
+	cmd := VerifyReceiptCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{path, "--fleet-report", "--key", hex.EncodeToString(pub)})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v\n%s", err, buf.String())
+	}
+	if !strings.Contains(buf.String(), "FLEET RECEIPT OK:") || !strings.Contains(buf.String(), "Signer:           fleet-report-2026") {
+		t.Fatalf("output:\n%s", buf.String())
+	}
+
+	// The same human key id with the WRONG public key must still fail closed:
+	// binding to the signer id does not bypass the Ed25519 signature check.
+	wrongPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(wrong): %v", err)
+	}
+	wrongCmd := VerifyReceiptCmd()
+	var wrongBuf bytes.Buffer
+	wrongCmd.SetOut(&wrongBuf)
+	wrongCmd.SetArgs([]string{path, "--fleet-report", "--key", hex.EncodeToString(wrongPub)})
+	if err := wrongCmd.Execute(); err == nil {
+		t.Fatalf("expected wrong-key verification to fail closed:\n%s", wrongBuf.String())
+	}
+	if !strings.Contains(wrongBuf.String(), "FAILED:") {
+		t.Fatalf("wrong-key output missing FAILED:\n%s", wrongBuf.String())
+	}
+}
+
 func TestVerifyReceiptCmd_FleetReportRequiresPinByDefault(t *testing.T) {
 	t.Parallel()
 
@@ -227,6 +272,64 @@ func TestVerifyReceiptCmd_FleetReportRejectsSessionSelector(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--fleet-report cannot be combined with --session") {
 		t.Fatalf("Execute error = %v, want --session conflict", err)
+	}
+}
+
+func TestVerifyReceiptCmd_FleetReportFailsClosedOnTamper(t *testing.T) {
+	t.Parallel()
+
+	pub, path := writeFleetReportFixture(t)
+	raw, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var env fleetreceipt.Envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	// Flip one byte of the signed payload; the Ed25519 signature must no
+	// longer verify and the command must exit non-zero with FAILED.
+	payload, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	payload[0] ^= 0x01
+	env.Payload = base64.StdEncoding.EncodeToString(payload)
+	tamperedBytes, err := fleetreceipt.MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	tamperedPath := filepath.Join(t.TempDir(), "tampered.dsse.json")
+	if err := os.WriteFile(tamperedPath, tamperedBytes, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := VerifyReceiptCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{tamperedPath, "--fleet-report", "--key", hex.EncodeToString(pub)})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected tampered fleet report verification to exit non-zero")
+	}
+	if !strings.Contains(buf.String(), "FAILED:") {
+		t.Fatalf("output missing FAILED marker:\n%s", buf.String())
+	}
+}
+
+func TestVerifyReceiptCmd_FleetReportRejectsChainSelector(t *testing.T) {
+	t.Parallel()
+
+	_, path := writeFleetReportFixture(t)
+	cmd := VerifyReceiptCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--fleet-report", "--chain", filepath.Dir(path)})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected --fleet-report with --chain to fail")
+	}
+	if !strings.Contains(err.Error(), "--fleet-report cannot be combined with --chain") {
+		t.Fatalf("Execute error = %v, want --chain conflict", err)
 	}
 }
 
@@ -920,7 +1023,11 @@ func writeFleetReportFixture(t *testing.T) (ed25519.PublicKey, string) {
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
-	keyID := hex.EncodeToString(pub)
+	return writeFleetReportFixtureSigned(t, hex.EncodeToString(pub), pub, priv)
+}
+
+func writeFleetReportFixtureSigned(t *testing.T, keyID string, pub ed25519.PublicKey, priv ed25519.PrivateKey) (ed25519.PublicKey, string) {
+	t.Helper()
 	statement := fleetreceipt.Statement{
 		Type: fleetreceipt.StatementType,
 		Subject: []fleetreceipt.Subject{{


### PR DESCRIPTION
## What changed

- Adds `--out -` to `conductor fleet report` so a distroless pod with no shell or cat can pipe a minted DSSE Fleet Receipt Report to stdout, routing the human-readable summary to stderr.
- Fixes `verify-receipt --fleet-report --key`: a bare `--key` public key now binds to the report's signer key id, so a human-labelled key id (such as `fleet-report-key`) verifies offline. Previously verification only succeeded when the key id equalled the public-key hex. The Ed25519 signature still gates, so the path stays fail-closed.
- Lists the `fleet-report-signing` purpose in `signing key generate --help`.
- Documents the keygen step and the distroless pipe flow in the receipt-verification guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added `fleet-report-signing` as a supported key-generation purpose.
  * `fleet report --out -` now prints only the DSSE envelope to stdout (summary to stderr) for offline verification.
  * Receipt verification can bind `--key` values to the report signer KeyID, supporting human-readable labels.
* **Documentation**
  * Updated the Fleet Receipt Report guide with a dedicated signing-key workflow, corrected commands/examples, and updated output.
* **Bug Fixes / Tests**
  * Verification now fails on tampered payloads and rejects conflicting receipt options (`--fleet-report` with `--chain`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->