### PR TITLE
feat(conductor): operator credential and enrollment-token lifecycle

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -83,11 +83,14 @@ using the same atomic rename. If no backup exists, it reports a clear error.
 
 ## Privileged install paths
 
-Before making any change, the updater checks that the target binary **and its
-directory** are writable by the current user. If Pipelock is installed to a
-root-owned location (for example `/usr/local/bin`), the update aborts early with
-a message to re-run with appropriate privileges (for example via `sudo`). The
-update is never partially applied.
+Before making any change, the updater checks that the target binary's
+**directory** can accept the temp-write-and-rename it uses to apply the update.
+It probes the directory because that is what the atomic replace actually
+requires; a writable binary in a non-writable directory could not be replaced
+anyway. If Pipelock is installed to a root-owned location (for example
+`/usr/local/bin`), the update aborts early with a message to re-run with
+appropriate privileges (for example via `sudo`). The update is never partially
+applied.
 
 ## Unsupported platforms
 

--- a/docs/guides/conductor-operator-runbook.md
+++ b/docs/guides/conductor-operator-runbook.md
@@ -237,6 +237,93 @@ The live bootstrap proof performs enrollment in-process:
 
 The operator does not have to run separate enrollment commands for the generated dev fleet; bootstrap proves that path before writing its quickstart.
 
+### Enrollment-token lifecycle (mint, list, status, revoke)
+
+For a real fleet you mint enrollment tokens out of band and hand each one to a
+starting follower. The `enrollment-token` subcommands manage that lifecycle. All
+of them are admin-authorized: they use the same mTLS client material plus the
+admin bearer token as the other operator reads.
+
+Mint a one-shot token for a follower identity. The token (the secret) is printed
+to stdout; the summary goes to stderr, so `> token.txt` captures only the token:
+
+```bash
+/tmp/pipelock-ent conductor enrollment-token mint \
+  --conductor-url https://127.0.0.1:8895 \
+  --admin-token-file "$FLEET_DIR/conductor/admin.token" \
+  --server-ca "$FLEET_DIR/ca/ca.crt" \
+  --tls-cert "$FLEET_DIR/follower/client.crt" \
+  --tls-key "$FLEET_DIR/follower/client.key" \
+  --token-id enroll-pl-prod-1 \
+  --org org-local --fleet dev --instance pl-prod-1 --env dev \
+  --ttl 1h
+```
+
+The server rejects an over-long `--ttl`. The maximum is set on `conductor serve`
+with `--enrollment-token-max-validity` (default 24h); a token requested past the
+ceiling is rejected before it is minted, so a leaked-but-unused token cannot have
+a multi-week exposure window.
+
+List, inspect, and revoke tokens by their stable `token_id`. These reads return
+lifecycle metadata only (`pending` / `consumed` / `revoked` / `expired`); the
+token secret is shown only once, at mint, and is never returned again:
+
+```bash
+# List all tokens (or filter by --org-id/--fleet-id/--instance-id/--environment).
+/tmp/pipelock-ent conductor enrollment-token list \
+  --server https://127.0.0.1:8895 \
+  --ca-file "$FLEET_DIR/ca/ca.crt" \
+  --client-cert "$FLEET_DIR/follower/client.crt" \
+  --client-key "$FLEET_DIR/follower/client.key" \
+  --token-file "$FLEET_DIR/conductor/admin.token"
+
+# Inspect one token's state.
+/tmp/pipelock-ent conductor enrollment-token status \
+  --server https://127.0.0.1:8895 \
+  --ca-file "$FLEET_DIR/ca/ca.crt" \
+  --client-cert "$FLEET_DIR/follower/client.crt" \
+  --client-key "$FLEET_DIR/follower/client.key" \
+  --token-file "$FLEET_DIR/conductor/admin.token" \
+  --token-id enroll-pl-prod-1
+
+# Revoke a still-pending token so it can no longer enroll a follower.
+/tmp/pipelock-ent conductor enrollment-token revoke \
+  --server https://127.0.0.1:8895 \
+  --ca-file "$FLEET_DIR/ca/ca.crt" \
+  --client-cert "$FLEET_DIR/follower/client.crt" \
+  --client-key "$FLEET_DIR/follower/client.key" \
+  --token-file "$FLEET_DIR/conductor/admin.token" \
+  --token-id enroll-pl-prod-1
+```
+
+Revoke only succeeds for a still-pending token. A consumed, already-revoked, or
+expired token is rejected (the enrollment already happened, or the token is
+already dead), and a revoked token fails closed if a leaked copy is later
+presented to `POST /api/v1/conductor/enroll`. The revocation is durable across a
+Conductor restart.
+
+## Operator Bearer Tokens (generation and rotation)
+
+The publisher, auditor, and admin bearer tokens are read from files on
+`conductor serve` (`--publisher-token-file`, `--auditor-token-file`,
+`--admin-token-file`). They are opaque shared secrets the Conductor compares in
+constant time; Pipelock does not mint or rotate them for you, so generate and
+rotate them out of band.
+
+Generate a high-entropy token (256 bits, URL-safe), written `0o600`:
+
+```bash
+umask 077
+openssl rand -base64 32 | tr -d '\n' > "$FLEET_DIR/conductor/admin.token"
+```
+
+`bootstrap` writes dev tokens into the generated layout for you; the command
+above is the production path where you control the secret store. To rotate a
+token: write the new value to the token file (or your secret store), then restart
+`conductor serve` so it reloads the file, and distribute the new value to the
+operators or automation that present it. Because the tokens are independent
+files, you can rotate one role without disturbing the others.
+
 ## Policy Publish
 
 Policy publication is an HTTP API surface, not a standalone CLI command in the current help output. The source-verified endpoint is:

--- a/docs/guides/conductor-operator-runbook.md
+++ b/docs/guides/conductor-operator-runbook.md
@@ -302,6 +302,14 @@ already dead), and a revoked token fails closed if a leaked copy is later
 presented to `POST /api/v1/conductor/enroll`. The revocation is durable across a
 Conductor restart.
 
+Note the connection flags differ between `mint` and the read commands. `mint`
+takes `--conductor-url`, `--admin-token-file`, `--server-ca`, `--tls-cert`, and
+`--tls-key`; `list`, `status`, and `revoke` take `--server`, `--token-file`,
+`--ca-file`, `--client-cert`, and `--client-key`. The read commands share the
+common operator-client flags used across all read endpoints (`fleet status`,
+`audit query`), while `mint` is a dedicated write operation with its own options.
+Use each command's flag names as written above rather than copying them across.
+
 ## Operator Bearer Tokens (generation and rotation)
 
 The publisher, auditor, and admin bearer tokens are read from files on

--- a/enterprise/cli/conductor/cmd.go
+++ b/enterprise/cli/conductor/cmd.go
@@ -38,28 +38,29 @@ const (
 )
 
 type serveOptions struct {
-	listen              string
-	probeListen         string
-	storageDir          string
-	conductorID         string
-	followerTrustDomain string
-	publisherTokenFile  string
-	auditorTokenFile    string
-	adminTokenFile      string
-	auditorOrgID        string
-	auditorFleetID      string
-	adminOrgID          string
-	adminFleetID        string
-	trustedAuditKeys    []string
-	trustedControlKeys  []string
-	remoteKillMaxTTL    time.Duration
-	rollbackMaxTTL      time.Duration
-	auditRetention      time.Duration
-	licenseCRLFile      string
-	tlsCert             string
-	tlsKey              string
-	clientCA            string
-	logWriter           io.Writer
+	listen                string
+	probeListen           string
+	storageDir            string
+	conductorID           string
+	followerTrustDomain   string
+	publisherTokenFile    string
+	auditorTokenFile      string
+	adminTokenFile        string
+	auditorOrgID          string
+	auditorFleetID        string
+	adminOrgID            string
+	adminFleetID          string
+	trustedAuditKeys      []string
+	trustedControlKeys    []string
+	remoteKillMaxTTL      time.Duration
+	rollbackMaxTTL        time.Duration
+	enrollmentTokenMaxTTL time.Duration
+	auditRetention        time.Duration
+	licenseCRLFile        string
+	tlsCert               string
+	tlsKey                string
+	clientCA              string
+	logWriter             io.Writer
 }
 
 type auditKeySpec struct {
@@ -105,12 +106,13 @@ func Cmd() *cobra.Command {
 
 func serveCmd() *cobra.Command {
 	opts := serveOptions{
-		listen:              defaultListen,
-		probeListen:         defaultProbeListen,
-		conductorID:         "conductor",
-		followerTrustDomain: defaultTrustDomain,
-		remoteKillMaxTTL:    controlplane.DefaultRemoteKillMaxValidity,
-		rollbackMaxTTL:      controlplane.DefaultRollbackMaxValidity,
+		listen:                defaultListen,
+		probeListen:           defaultProbeListen,
+		conductorID:           "conductor",
+		followerTrustDomain:   defaultTrustDomain,
+		remoteKillMaxTTL:      controlplane.DefaultRemoteKillMaxValidity,
+		rollbackMaxTTL:        controlplane.DefaultRollbackMaxValidity,
+		enrollmentTokenMaxTTL: controlplane.DefaultEnrollmentTokenMaxValidity,
 	}
 	cmd := &cobra.Command{
 		Use:   "serve",
@@ -147,6 +149,7 @@ func serveCmd() *cobra.Command {
 		"trusted emergency control key as comma-separated kv pairs: 'id=ID,purpose=(remote-kill-signing|policy-bundle-rollback),(inline=HEX_OR_VERSIONED_PUBLIC_KEY|file=/path)'; repeatable")
 	cmd.Flags().DurationVar(&opts.remoteKillMaxTTL, "remote-kill-max-validity", opts.remoteKillMaxTTL, "maximum validity window for published Conductor remote-kill messages")
 	cmd.Flags().DurationVar(&opts.rollbackMaxTTL, "rollback-max-validity", opts.rollbackMaxTTL, "maximum validity window for published Conductor rollback authorizations")
+	cmd.Flags().DurationVar(&opts.enrollmentTokenMaxTTL, "enrollment-token-max-validity", opts.enrollmentTokenMaxTTL, "maximum validity window for minted Conductor follower enrollment tokens")
 	cmd.Flags().StringVar(&opts.licenseCRLFile, "license-crl-file", "", "signed license revocation list file; falls back to PIPELOCK_LICENSE_CRL_FILE")
 	cmd.Flags().StringVar(&opts.tlsCert, "tls-cert", "", "TLS server certificate file")
 	cmd.Flags().StringVar(&opts.tlsKey, "tls-key", "", "TLS server private key file")
@@ -255,6 +258,9 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 	if opts.auditRetention < 0 {
 		return nil, nil, nil, errors.New("--audit-retention must be non-negative")
 	}
+	if opts.enrollmentTokenMaxTTL < 0 {
+		return nil, nil, nil, errors.New("--enrollment-token-max-validity must be non-negative")
+	}
 	publisherToken, err := loadTokenFile("--publisher-token-file", opts.publisherTokenFile)
 	if err != nil {
 		return nil, nil, nil, err
@@ -353,24 +359,25 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 	}
 	m := metrics.New()
 	handler, err := controlplane.NewHandler(controlplane.HandlerOptions{
-		Store:               store,
-		Capabilities:        controlplane.DefaultCapabilities(opts.conductorID),
-		FollowerIdentity:    identity,
-		AuthorizePublisher:  authorizer,
-		AuthorizeBundle:     publishAuthorizer,
-		AuthorizeAuditQuery: auditQueryAuthorizer,
-		AuthorizeFollowers:  followerListAuthorizer,
-		AuthorizeStream:     streamStatusAuthorizer,
-		AuthorizeAdmin:      adminAuthorizer,
-		AuditSink:           auditStore,
-		AuditKeys:           controlplane.CompositeAuditKeyResolver(enrollments, auditKeys),
-		Enrollments:         enrollments,
-		EmergencyControls:   emergencyControls,
-		EmergencyKeys:       emergencyKeys,
-		RemoteKillMaxTTL:    opts.remoteKillMaxTTL,
-		RollbackMaxTTL:      opts.rollbackMaxTTL,
-		Metrics:             m,
-		Logger:              conductorRequestLogger(opts.logWriter),
+		Store:                 store,
+		Capabilities:          controlplane.DefaultCapabilities(opts.conductorID),
+		FollowerIdentity:      identity,
+		AuthorizePublisher:    authorizer,
+		AuthorizeBundle:       publishAuthorizer,
+		AuthorizeAuditQuery:   auditQueryAuthorizer,
+		AuthorizeFollowers:    followerListAuthorizer,
+		AuthorizeStream:       streamStatusAuthorizer,
+		AuthorizeAdmin:        adminAuthorizer,
+		AuditSink:             auditStore,
+		AuditKeys:             controlplane.CompositeAuditKeyResolver(enrollments, auditKeys),
+		Enrollments:           enrollments,
+		EmergencyControls:     emergencyControls,
+		EmergencyKeys:         emergencyKeys,
+		RemoteKillMaxTTL:      opts.remoteKillMaxTTL,
+		RollbackMaxTTL:        opts.rollbackMaxTTL,
+		EnrollmentTokenMaxTTL: opts.enrollmentTokenMaxTTL,
+		Metrics:               m,
+		Logger:                conductorRequestLogger(opts.logWriter),
 	})
 	if err != nil {
 		return nil, nil, nil, err

--- a/enterprise/cli/conductor/enrollment_token.go
+++ b/enterprise/cli/conductor/enrollment_token.go
@@ -5,8 +5,11 @@
 package conductor
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -43,12 +46,19 @@ func enrollmentTokenCmd() *cobra.Command {
 		Long: `enrollment-token manages the narrow, one-shot bearer tokens a follower
 presents once to enroll its audit-signing key with the Conductor.
 
-Only "mint" is available today: it issues a single-use token scoped to one
-follower identity (org / fleet / instance / environment). The Conductor marks
-the token consumed on first successful enroll, so a leaked-but-unused token
-cannot enroll a second follower, and an expired token is rejected.`,
+"mint" issues a single-use token scoped to one follower identity (org / fleet /
+instance / environment). The Conductor marks the token consumed on first
+successful enroll, so a leaked-but-unused token cannot enroll a second follower,
+and an expired token is rejected.
+
+"list" and "status" return token lifecycle metadata only (never the token
+secret). "revoke" invalidates a pending token by id so a leaked-but-unused token
+can be killed before it enrolls a follower.`,
 	}
 	cmd.AddCommand(enrollmentTokenMintCmd())
+	cmd.AddCommand(enrollmentTokenListCmd())
+	cmd.AddCommand(enrollmentTokenStatusCmd())
+	cmd.AddCommand(enrollmentTokenRevokeCmd())
 	return cmd
 }
 
@@ -148,4 +158,209 @@ type createEnrollmentTokenResponse struct {
 	TokenID   string    `json:"token_id"`
 	Token     string    `json:"token"`
 	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// enrollmentTokenReadOptions carries the connection + filter flags for the
+// metadata-only list/status reads and the revoke action. These admin endpoints
+// use the same mTLS + bearer client as the other operator reads (fleet status,
+// followers): the bearer is the Conductor admin token.
+type enrollmentTokenReadOptions struct {
+	client      clientOptions
+	tokenID     string
+	orgID       string
+	fleetID     string
+	instanceID  string
+	environment string
+	limit       int
+	jsonOut     bool
+}
+
+type enrollmentTokensResponse struct {
+	Tokens []controlplane.EnrollmentTokenSummary `json:"tokens"`
+	Count  int                                   `json:"count"`
+}
+
+func enrollmentTokenListCmd() *cobra.Command {
+	opts := enrollmentTokenReadOptions{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List enrollment tokens and their lifecycle state (metadata only)",
+		Long: `List the enrollment tokens minted on a Conductor with their lifecycle
+state (pending / consumed / revoked / expired). The token secret is shown only
+once at mint and is NEVER returned here; this is metadata only.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.client.licenseCRLFile}); err != nil {
+				return err
+			}
+			return runEnrollmentTokenList(cmd, opts)
+		},
+	}
+	bindEnrollmentTokenReadFlags(cmd, &opts, true)
+	return cmd
+}
+
+func enrollmentTokenStatusCmd() *cobra.Command {
+	opts := enrollmentTokenReadOptions{}
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show the lifecycle state of one enrollment token (metadata only)",
+		Long: `Show the lifecycle state of a single enrollment token by its token id.
+The token secret is never returned; this is metadata only.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.client.licenseCRLFile}); err != nil {
+				return err
+			}
+			return runEnrollmentTokenStatus(cmd, opts)
+		},
+	}
+	bindEnrollmentTokenReadFlags(cmd, &opts, false)
+	_ = cmd.MarkFlagRequired("token-id")
+	return cmd
+}
+
+func enrollmentTokenRevokeCmd() *cobra.Command {
+	opts := enrollmentTokenReadOptions{}
+	cmd := &cobra.Command{
+		Use:   "revoke",
+		Short: "Revoke a pending enrollment token by id",
+		Long: `Revoke a pending enrollment token so it can no longer enroll a follower.
+Only a still-pending token can be revoked; a consumed, already-revoked, or
+expired token is rejected. The response is metadata only.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.client.licenseCRLFile}); err != nil {
+				return err
+			}
+			return runEnrollmentTokenRevoke(cmd, opts)
+		},
+	}
+	opts.client.bindFlags(cmd)
+	cmd.Flags().StringVar(&opts.tokenID, "token-id", "", "id of the token to revoke (required)")
+	_ = cmd.MarkFlagRequired("token-id")
+	return cmd
+}
+
+func bindEnrollmentTokenReadFlags(cmd *cobra.Command, opts *enrollmentTokenReadOptions, includeListFilters bool) {
+	opts.client.bindFlags(cmd)
+	cmd.Flags().StringVar(&opts.tokenID, "token-id", "", "token id to query")
+	cmd.Flags().BoolVar(&opts.jsonOut, "json", false, "emit the raw JSON response instead of a table")
+	if includeListFilters {
+		cmd.Flags().StringVar(&opts.orgID, "org-id", "", "filter by org id")
+		cmd.Flags().StringVar(&opts.fleetID, "fleet-id", "", "filter by fleet id")
+		cmd.Flags().StringVar(&opts.instanceID, "instance-id", "", "filter by instance id")
+		cmd.Flags().StringVar(&opts.environment, "environment", "", "filter by environment")
+		cmd.Flags().IntVar(&opts.limit, "limit", 0, "maximum number of tokens to list (server rejects values above its configured ceiling)")
+	}
+}
+
+func runEnrollmentTokenList(cmd *cobra.Command, opts enrollmentTokenReadOptions) error {
+	if opts.limit < 0 {
+		return fmt.Errorf("--limit must be non-negative")
+	}
+	client, err := newConductorClient(opts.client)
+	if err != nil {
+		return err
+	}
+	body, err := fetchEnrollmentTokens(cmd.Context(), client, opts)
+	if err != nil {
+		return err
+	}
+	return renderEnrollmentTokens(cmd, body, opts.jsonOut)
+}
+
+func runEnrollmentTokenStatus(cmd *cobra.Command, opts enrollmentTokenReadOptions) error {
+	if strings.TrimSpace(opts.tokenID) == "" {
+		return fmt.Errorf("--token-id is required")
+	}
+	client, err := newConductorClient(opts.client)
+	if err != nil {
+		return err
+	}
+	body, err := fetchEnrollmentTokens(cmd.Context(), client, opts)
+	if err != nil {
+		return err
+	}
+	if opts.jsonOut {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
+		return nil
+	}
+	var parsed enrollmentTokensResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("decode enrollment tokens response: %w", err)
+	}
+	if parsed.Count == 0 {
+		return fmt.Errorf("no enrollment token found with id %q", opts.tokenID)
+	}
+	return writeEnrollmentTokenTable(cmd, parsed)
+}
+
+func runEnrollmentTokenRevoke(cmd *cobra.Command, opts enrollmentTokenReadOptions) error {
+	if strings.TrimSpace(opts.tokenID) == "" {
+		return fmt.Errorf("--token-id is required")
+	}
+	client, err := newConductorClient(opts.client)
+	if err != nil {
+		return err
+	}
+	body, err := client.deleteJSON(cmd.Context(), controlplane.EnrollmentTokensPath, map[string]string{
+		"token_id": opts.tokenID,
+	})
+	if err != nil {
+		return err
+	}
+	var summary controlplane.EnrollmentTokenSummary
+	if err := json.Unmarshal(body, &summary); err != nil {
+		return fmt.Errorf("decode revoke response: %w", err)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pipelock: enrollment token %s revoked (state=%s)\n", summary.TokenID, summary.State)
+	return nil
+}
+
+func fetchEnrollmentTokens(ctx context.Context, client *conductorClient, opts enrollmentTokenReadOptions) ([]byte, error) {
+	params := map[string]string{
+		"token_id":    opts.tokenID,
+		"org_id":      opts.orgID,
+		"fleet_id":    opts.fleetID,
+		"instance_id": opts.instanceID,
+		"environment": opts.environment,
+	}
+	if opts.limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.limit)
+	}
+	return client.getJSON(ctx, controlplane.EnrollmentTokensPath+encodeQuery(params))
+}
+
+func renderEnrollmentTokens(cmd *cobra.Command, body []byte, jsonOut bool) error {
+	if jsonOut {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
+		return nil
+	}
+	var parsed enrollmentTokensResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("decode enrollment tokens response: %w", err)
+	}
+	return writeEnrollmentTokenTable(cmd, parsed)
+}
+
+func writeEnrollmentTokenTable(cmd *cobra.Command, resp enrollmentTokensResponse) error {
+	out := cmd.OutOrStdout()
+	if resp.Count == 0 {
+		_, _ = fmt.Fprintln(out, "no enrollment tokens match the query")
+		return nil
+	}
+	tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "TOKEN_ID\tORG\tFLEET\tINSTANCE\tENVIRONMENT\tSTATE\tCREATED_AT\tEXPIRES_AT")
+	for _, tkn := range resp.Tokens {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			tkn.TokenID, tkn.OrgID, tkn.FleetID, tkn.InstanceID, tkn.Environment, tkn.State,
+			tkn.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			tkn.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z"))
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("write enrollment token table: %w", err)
+	}
+	_, _ = fmt.Fprintf(out, "%d token(s)\n", resp.Count)
+	return nil
 }

--- a/enterprise/cli/conductor/enrollment_token.go
+++ b/enterprise/cli/conductor/enrollment_token.go
@@ -282,16 +282,19 @@ func runEnrollmentTokenStatus(cmd *cobra.Command, opts enrollmentTokenReadOption
 	if err != nil {
 		return err
 	}
-	if opts.jsonOut {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
-		return nil
-	}
 	var parsed enrollmentTokensResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return fmt.Errorf("decode enrollment tokens response: %w", err)
 	}
+	// Check not-found BEFORE the --json early return so `status --json` fails
+	// (non-zero exit) on a missing token instead of printing an empty result
+	// set and exiting 0, which would silently break scripts.
 	if parsed.Count == 0 {
 		return fmt.Errorf("no enrollment token found with id %q", opts.tokenID)
+	}
+	if opts.jsonOut {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(body))
+		return nil
 	}
 	return writeEnrollmentTokenTable(cmd, parsed)
 }

--- a/enterprise/cli/conductor/enrollment_token_lifecycle_test.go
+++ b/enterprise/cli/conductor/enrollment_token_lifecycle_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // fakeEnrollmentTokensHandler serves a canned enrollment-tokens list/revoke
@@ -89,6 +91,146 @@ func TestRunEnrollmentTokenRevoke_RequiresTokenID(t *testing.T) {
 	err := runEnrollmentTokenRevoke(cmd, enrollmentTokenReadOptions{})
 	if err == nil || !strings.Contains(err.Error(), "--token-id is required") {
 		t.Fatalf("revoke without token-id error = %v, want required", err)
+	}
+}
+
+func TestRunEnrollmentTokenList_JSONOutputEmitsRawBody(t *testing.T) {
+	listJSON := `{"tokens":[{"token_id":"t-1","org_id":"org-main","state":"pending"}],"count":1}`
+	handler, _, _ := fakeEnrollmentTokensHandler(t, listJSON, "")
+	clientOpts := newTestClientServer(t, "admin-token", handler)
+	cmd, out, _ := enrollmentCobra(t)
+	if err := runEnrollmentTokenList(cmd, enrollmentTokenReadOptions{client: clientOpts, jsonOut: true}); err != nil {
+		t.Fatalf("list --json error = %v", err)
+	}
+	// --json emits the raw server body verbatim, not the table header.
+	if !strings.Contains(out.String(), listJSON) {
+		t.Fatalf("list --json output = %q, want raw body", out.String())
+	}
+	if strings.Contains(out.String(), "TOKEN_ID") {
+		t.Fatalf("list --json should not render the table header: %q", out.String())
+	}
+}
+
+func TestRunEnrollmentTokenList_NegativeLimitRejected(t *testing.T) {
+	cmd, _, _ := enrollmentCobra(t)
+	err := runEnrollmentTokenList(cmd, enrollmentTokenReadOptions{limit: -1})
+	if err == nil || !strings.Contains(err.Error(), "--limit must be non-negative") {
+		t.Fatalf("negative limit error = %v, want non-negative message", err)
+	}
+}
+
+func TestRunEnrollmentTokenList_EmptyMatchMessage(t *testing.T) {
+	handler, _, _ := fakeEnrollmentTokensHandler(t, `{"tokens":[],"count":0}`, "")
+	clientOpts := newTestClientServer(t, "admin-token", handler)
+	cmd, out, _ := enrollmentCobra(t)
+	if err := runEnrollmentTokenList(cmd, enrollmentTokenReadOptions{client: clientOpts}); err != nil {
+		t.Fatalf("list empty error = %v", err)
+	}
+	if !strings.Contains(out.String(), "no enrollment tokens match the query") {
+		t.Fatalf("empty list output = %q, want no-match message", out.String())
+	}
+}
+
+func TestRunEnrollmentTokenList_LimitAndFiltersInQuery(t *testing.T) {
+	handler, _, gotPath := fakeEnrollmentTokensHandler(t, `{"tokens":[],"count":0}`, "")
+	clientOpts := newTestClientServer(t, "admin-token", handler)
+	cmd, _, _ := enrollmentCobra(t)
+	if err := runEnrollmentTokenList(cmd, enrollmentTokenReadOptions{
+		client: clientOpts, fleetID: "prod", environment: "prod", limit: 5,
+	}); err != nil {
+		t.Fatalf("list with filters error = %v", err)
+	}
+	for _, want := range []string{"fleet_id=prod", "environment=prod", "limit=5"} {
+		if !strings.Contains(*gotPath, want) {
+			t.Fatalf("list path = %q, missing %q", *gotPath, want)
+		}
+	}
+}
+
+func TestRunEnrollmentTokenList_ServerErrorPropagates(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	clientOpts := newTestClientServer(t, "admin-token", h)
+	cmd, _, _ := enrollmentCobra(t)
+	if err := runEnrollmentTokenList(cmd, enrollmentTokenReadOptions{client: clientOpts}); err == nil {
+		t.Fatal("list against a 500 server: want error, got nil")
+	}
+}
+
+func TestRunEnrollmentTokenStatus_RendersTableOnHit(t *testing.T) {
+	listJSON := `{"tokens":[{"token_id":"t-9","org_id":"org-main","fleet_id":"prod","instance_id":"pl-1","environment":"prod","state":"pending","created_at":"2026-05-24T12:00:00Z","expires_at":"2026-05-24T13:00:00Z"}],"count":1}`
+	handler, _, _ := fakeEnrollmentTokensHandler(t, listJSON, "")
+	clientOpts := newTestClientServer(t, "admin-token", handler)
+	cmd, out, _ := enrollmentCobra(t)
+	if err := runEnrollmentTokenStatus(cmd, enrollmentTokenReadOptions{client: clientOpts, tokenID: "t-9"}); err != nil {
+		t.Fatalf("status error = %v", err)
+	}
+	if !strings.Contains(out.String(), "t-9") || !strings.Contains(out.String(), "TOKEN_ID") {
+		t.Fatalf("status table output = %q", out.String())
+	}
+}
+
+func TestRunEnrollmentTokenStatus_JSONOutputEmitsRawBody(t *testing.T) {
+	listJSON := `{"tokens":[{"token_id":"t-9","state":"pending"}],"count":1}`
+	handler, _, _ := fakeEnrollmentTokensHandler(t, listJSON, "")
+	clientOpts := newTestClientServer(t, "admin-token", handler)
+	cmd, out, _ := enrollmentCobra(t)
+	if err := runEnrollmentTokenStatus(cmd, enrollmentTokenReadOptions{client: clientOpts, tokenID: "t-9", jsonOut: true}); err != nil {
+		t.Fatalf("status --json error = %v", err)
+	}
+	if !strings.Contains(out.String(), listJSON) {
+		t.Fatalf("status --json output = %q, want raw body", out.String())
+	}
+}
+
+// TestRunEnrollmentTokenStatus_JSONNotFoundIsError is the regression guard for
+// the bug where `status --json` returned success on a missing token: the
+// not-found check must run BEFORE the --json early return.
+func TestRunEnrollmentTokenStatus_JSONNotFoundIsError(t *testing.T) {
+	handler, _, _ := fakeEnrollmentTokensHandler(t, `{"tokens":[],"count":0}`, "")
+	clientOpts := newTestClientServer(t, "admin-token", handler)
+	cmd, out, _ := enrollmentCobra(t)
+	err := runEnrollmentTokenStatus(cmd, enrollmentTokenReadOptions{client: clientOpts, tokenID: "missing", jsonOut: true})
+	if err == nil || !strings.Contains(err.Error(), "no enrollment token found") {
+		t.Fatalf("status --json not-found error = %v, want not-found error", err)
+	}
+	if strings.Contains(out.String(), "count") {
+		t.Fatalf("status --json not-found should print nothing, got %q", out.String())
+	}
+}
+
+func TestRunEnrollmentTokenRevoke_DecodeErrorPropagates(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not-json"))
+	})
+	clientOpts := newTestClientServer(t, "admin-token", h)
+	cmd, _, _ := enrollmentCobra(t)
+	err := runEnrollmentTokenRevoke(cmd, enrollmentTokenReadOptions{client: clientOpts, tokenID: "t-1"})
+	if err == nil || !strings.Contains(err.Error(), "decode revoke response") {
+		t.Fatalf("revoke decode error = %v, want decode failure", err)
+	}
+}
+
+// TestEnrollmentTokenReadCmds_LicenseGatedRunE confirms the list/status/revoke
+// RunE closures hit the Enterprise license gate before doing any work: with no
+// license token or verifier key available, each must fail closed.
+func TestEnrollmentTokenReadCmds_LicenseGatedRunE(t *testing.T) {
+	t.Setenv("PIPELOCK_LICENSE_KEY", "")
+	t.Setenv("PIPELOCK_LICENSE_PUBLIC_KEY", "")
+	builders := map[string]func() *cobra.Command{
+		"list":   enrollmentTokenListCmd,
+		"status": enrollmentTokenStatusCmd,
+		"revoke": enrollmentTokenRevokeCmd,
+	}
+	for name, build := range builders {
+		t.Run(name, func(t *testing.T) {
+			cmd := build()
+			if err := cmd.RunE(cmd, nil); err == nil {
+				t.Fatalf("%s RunE without a license: want gate error, got nil", name)
+			}
+		})
 	}
 }
 

--- a/enterprise/cli/conductor/enrollment_token_lifecycle_test.go
+++ b/enterprise/cli/conductor/enrollment_token_lifecycle_test.go
@@ -1,0 +1,113 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// fakeEnrollmentTokensHandler serves a canned enrollment-tokens list/revoke
+// response so the CLI render path can be exercised without a real Conductor. It
+// echoes the method and path for assertions.
+func fakeEnrollmentTokensHandler(t *testing.T, listJSON, revokeJSON string) (http.Handler, *string, *string) {
+	t.Helper()
+	var gotMethod, gotPath string
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodDelete:
+			_, _ = w.Write([]byte(revokeJSON))
+		default:
+			_, _ = w.Write([]byte(listJSON))
+		}
+	})
+	return h, &gotMethod, &gotPath
+}
+
+func TestRunEnrollmentTokenList_RendersTable(t *testing.T) {
+	listJSON := `{"tokens":[{"token_id":"t-1","org_id":"org-main","fleet_id":"prod","instance_id":"pl-1","environment":"prod","state":"pending","created_at":"2026-05-24T12:00:00Z","expires_at":"2026-05-24T13:00:00Z"}],"count":1}`
+	handler, _, gotPath := fakeEnrollmentTokensHandler(t, listJSON, "")
+	clientOpts := newTestClientServer(t, "admin-token", handler)
+	cmd, out, _ := enrollmentCobra(t)
+	if err := runEnrollmentTokenList(cmd, enrollmentTokenReadOptions{client: clientOpts, orgID: "org-main"}); err != nil {
+		t.Fatalf("list error = %v", err)
+	}
+	if !strings.Contains(out.String(), "t-1") || !strings.Contains(out.String(), "pending") {
+		t.Fatalf("list output missing token metadata: %q", out.String())
+	}
+	if !strings.Contains(*gotPath, "org_id=org-main") {
+		t.Fatalf("list path = %q, want org_id filter", *gotPath)
+	}
+	// The secret-bearing fields must never be requested or rendered.
+	if strings.Contains(out.String(), "token_hash") || strings.Contains(out.String(), "pl_enroll_") {
+		t.Fatalf("list output leaked a secret-shaped value: %q", out.String())
+	}
+}
+
+func TestRunEnrollmentTokenStatus_RequiresTokenID(t *testing.T) {
+	cmd, _, _ := enrollmentCobra(t)
+	err := runEnrollmentTokenStatus(cmd, enrollmentTokenReadOptions{})
+	if err == nil || !strings.Contains(err.Error(), "--token-id is required") {
+		t.Fatalf("status without token-id error = %v, want required", err)
+	}
+}
+
+func TestRunEnrollmentTokenStatus_NotFoundIsError(t *testing.T) {
+	handler, _, _ := fakeEnrollmentTokensHandler(t, `{"tokens":[],"count":0}`, "")
+	clientOpts := newTestClientServer(t, "admin-token", handler)
+	cmd, _, _ := enrollmentCobra(t)
+	err := runEnrollmentTokenStatus(cmd, enrollmentTokenReadOptions{client: clientOpts, tokenID: "missing"})
+	if err == nil || !strings.Contains(err.Error(), "no enrollment token found") {
+		t.Fatalf("status not-found error = %v, want not-found message", err)
+	}
+}
+
+func TestRunEnrollmentTokenRevoke_ReportsState(t *testing.T) {
+	revokeJSON := `{"token_id":"t-1","org_id":"org-main","fleet_id":"prod","instance_id":"pl-1","environment":"prod","state":"revoked","created_at":"2026-05-24T12:00:00Z","expires_at":"2026-05-24T13:00:00Z","revoked_at":"2026-05-24T12:30:00Z"}`
+	handler, gotMethod, _ := fakeEnrollmentTokensHandler(t, "", revokeJSON)
+	clientOpts := newTestClientServer(t, "admin-token", handler)
+	cmd, out, _ := enrollmentCobra(t)
+	if err := runEnrollmentTokenRevoke(cmd, enrollmentTokenReadOptions{client: clientOpts, tokenID: "t-1"}); err != nil {
+		t.Fatalf("revoke error = %v", err)
+	}
+	if *gotMethod != http.MethodDelete {
+		t.Fatalf("revoke method = %q, want DELETE", *gotMethod)
+	}
+	if !strings.Contains(out.String(), "revoked") || !strings.Contains(out.String(), "t-1") {
+		t.Fatalf("revoke output = %q, want revoked state for t-1", out.String())
+	}
+}
+
+func TestRunEnrollmentTokenRevoke_RequiresTokenID(t *testing.T) {
+	cmd, _, _ := enrollmentCobra(t)
+	err := runEnrollmentTokenRevoke(cmd, enrollmentTokenReadOptions{})
+	if err == nil || !strings.Contains(err.Error(), "--token-id is required") {
+		t.Fatalf("revoke without token-id error = %v, want required", err)
+	}
+}
+
+func TestEnrollmentTokenCmd_LifecycleSubcommandsRegistered(t *testing.T) {
+	cmd := Cmd()
+	want := map[string]bool{"mint": false, "list": false, "status": false, "revoke": false}
+	for _, c := range cmd.Commands() {
+		if c.Name() != "enrollment-token" {
+			continue
+		}
+		for _, sc := range c.Commands() {
+			if _, ok := want[sc.Name()]; ok {
+				want[sc.Name()] = true
+			}
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Fatalf("enrollment-token missing %q subcommand", name)
+		}
+	}
+}

--- a/enterprise/cli/conductor/enrollment_token_lifecycle_test.go
+++ b/enterprise/cli/conductor/enrollment_token_lifecycle_test.go
@@ -227,8 +227,12 @@ func TestEnrollmentTokenReadCmds_LicenseGatedRunE(t *testing.T) {
 	for name, build := range builders {
 		t.Run(name, func(t *testing.T) {
 			cmd := build()
-			if err := cmd.RunE(cmd, nil); err == nil {
+			err := cmd.RunE(cmd, nil)
+			if err == nil {
 				t.Fatalf("%s RunE without a license: want gate error, got nil", name)
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), "license") {
+				t.Fatalf("%s RunE without a license: got non-license error: %v", name, err)
 			}
 		})
 	}

--- a/enterprise/conductor/controlplane/enrollment.go
+++ b/enterprise/conductor/controlplane/enrollment.go
@@ -16,10 +16,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -45,6 +47,13 @@ var (
 	ErrEnrollmentTokenConsumed  = errors.New("conductor enrollment token consumed")
 	ErrEnrollmentTokenExpired   = errors.New("conductor enrollment token expired")
 	ErrEnrollmentActiveInstance = errors.New("conductor follower instance already enrolled")
+	ErrEnrollmentTokenNotFound  = errors.New("conductor enrollment token not found")
+	// ErrEnrollmentTokenNotPending is returned when a revoke targets a token
+	// that is no longer pending (already consumed or already revoked). Revoke is
+	// only meaningful for an outstanding, unused token; a consumed token has
+	// already done its one job and re-revoking it must fail loud rather than
+	// pretend to undo an enrollment.
+	ErrEnrollmentTokenNotPending = errors.New("conductor enrollment token is not pending")
 )
 
 type EnrollmentStore interface {
@@ -52,6 +61,70 @@ type EnrollmentStore interface {
 	ConsumeEnrollmentToken(context.Context, ConsumeEnrollmentTokenRequest) (EnrolledFollower, error)
 	ResolveEnrolledAuditKey(FollowerIdentity, string) (conductor.SignatureKey, error)
 	ListEnrolledFollowers(context.Context, FollowerListQuery) ([]FollowerSummary, error)
+	// ListEnrollmentTokens returns the metadata-only roster of enrollment
+	// tokens. It MUST NOT return token bytes or the token hash: the secret is
+	// write-once at mint time and never readable again.
+	ListEnrollmentTokens(context.Context, EnrollmentTokenListQuery) ([]EnrollmentTokenSummary, error)
+	// RevokeEnrollmentToken invalidates a single pending token by its stable
+	// token_id so a leaked-but-unused token can be killed before it enrolls a
+	// follower. It fails closed: a consumed or already-revoked token is not
+	// re-revoked (ErrEnrollmentTokenNotPending), and an unknown id is
+	// ErrEnrollmentTokenNotFound.
+	RevokeEnrollmentToken(context.Context, RevokeEnrollmentTokenRequest) (EnrollmentTokenSummary, error)
+}
+
+// EnrollmentTokenState is the lifecycle state reported for an enrollment token.
+// It is derived (not persisted) from the record's consumed/revoked/expiry
+// fields at read time so a single source of truth (the record) drives it.
+type EnrollmentTokenState string
+
+const (
+	EnrollmentTokenStatePending  EnrollmentTokenState = "pending"
+	EnrollmentTokenStateConsumed EnrollmentTokenState = "consumed"
+	EnrollmentTokenStateRevoked  EnrollmentTokenState = "revoked"
+	EnrollmentTokenStateExpired  EnrollmentTokenState = "expired"
+)
+
+// EnrollmentTokenListQuery scopes an enrollment-token metadata read. All filter
+// fields are optional exact-match filters; an empty query lists every token
+// (bounded by Limit). TokenID is the lookup key for the single-token status
+// read. Now is the reference time used to DERIVE each token's lifecycle state
+// (pending vs expired); zero falls back to the wall clock so a direct store
+// caller still works, but the handler passes its injected clock so state is
+// computed against the same clock the rest of the control plane uses.
+type EnrollmentTokenListQuery struct {
+	TokenID     string
+	OrgID       string
+	FleetID     string
+	InstanceID  string
+	Environment string
+	Limit       int
+	Now         time.Time
+}
+
+// RevokeEnrollmentTokenRequest names the token to revoke and the time to stamp
+// the revocation. TokenID is the stable mint-time id, never the secret.
+type RevokeEnrollmentTokenRequest struct {
+	TokenID string
+	Now     time.Time
+}
+
+// EnrollmentTokenSummary is the metadata-only view of one enrollment token. It
+// deliberately omits the token bytes AND the token hash: the secret is only ever
+// returned once, at mint, so an operator listing or inspecting tokens sees
+// lifecycle metadata, never anything that could re-derive or replay the
+// credential.
+type EnrollmentTokenSummary struct {
+	TokenID     string               `json:"token_id"`
+	OrgID       string               `json:"org_id"`
+	FleetID     string               `json:"fleet_id"`
+	InstanceID  string               `json:"instance_id"`
+	Environment string               `json:"environment"`
+	State       EnrollmentTokenState `json:"state"`
+	CreatedAt   time.Time            `json:"created_at"`
+	ExpiresAt   time.Time            `json:"expires_at"`
+	ConsumedAt  *time.Time           `json:"consumed_at,omitempty"`
+	RevokedAt   *time.Time           `json:"revoked_at,omitempty"`
 }
 
 // FollowerListQuery scopes a follower-roster read. OrgID is mandatory at the
@@ -128,6 +201,39 @@ type enrollmentTokenRecord struct {
 	ExpiresAt    time.Time        `json:"expires_at"`
 	ConsumedAt   *time.Time       `json:"consumed_at,omitempty"`
 	ConsumedByID string           `json:"consumed_by_instance_id,omitempty"`
+	RevokedAt    *time.Time       `json:"revoked_at,omitempty"`
+}
+
+// tokenState derives the lifecycle state of a token record relative to now.
+// Order matters: a consumed token stays "consumed" even past expiry (it did its
+// job); a revoked-but-unconsumed token is "revoked"; otherwise expiry wins over
+// pending. This is the single place the four states are decided.
+func (r enrollmentTokenRecord) tokenState(now time.Time) EnrollmentTokenState {
+	switch {
+	case r.ConsumedAt != nil:
+		return EnrollmentTokenStateConsumed
+	case r.RevokedAt != nil:
+		return EnrollmentTokenStateRevoked
+	case !now.Before(r.ExpiresAt):
+		return EnrollmentTokenStateExpired
+	default:
+		return EnrollmentTokenStatePending
+	}
+}
+
+func (r enrollmentTokenRecord) summary(now time.Time) EnrollmentTokenSummary {
+	return EnrollmentTokenSummary{
+		TokenID:     r.TokenID,
+		OrgID:       r.Identity.OrgID,
+		FleetID:     r.Identity.FleetID,
+		InstanceID:  r.Identity.InstanceID,
+		Environment: r.Identity.Environment,
+		State:       r.tokenState(now),
+		CreatedAt:   r.CreatedAt,
+		ExpiresAt:   r.ExpiresAt,
+		ConsumedAt:  r.ConsumedAt,
+		RevokedAt:   r.RevokedAt,
+	}
 }
 
 type enrolledFollowerRecord struct {
@@ -238,6 +344,11 @@ func (s *FileEnrollmentStore) ConsumeEnrollmentToken(_ context.Context, req Cons
 	if token.ConsumedAt != nil {
 		return EnrolledFollower{}, ErrEnrollmentTokenConsumed
 	}
+	if token.RevokedAt != nil {
+		// A revoked token must never enroll a follower. Treat it as invalid so a
+		// leaked-then-revoked token fails closed at consume time.
+		return EnrolledFollower{}, ErrEnrollmentTokenInvalid
+	}
 	if !now.Before(token.ExpiresAt) {
 		return EnrolledFollower{}, ErrEnrollmentTokenExpired
 	}
@@ -337,6 +448,101 @@ func (s *FileEnrollmentStore) ListEnrolledFollowers(_ context.Context, q Followe
 		return followerSummaryLess(out[i], out[j])
 	})
 	return []FollowerSummary(out), nil
+}
+
+// ListEnrollmentTokens returns the metadata-only roster of enrollment tokens
+// matching q, newest-first by creation time (ties broken by token_id). It NEVER
+// returns the token bytes or token hash; only lifecycle metadata. The result is
+// capped at q.Limit (clamped to [1, maxFollowerListLimit]) to bound the response
+// for a large or pathological store.
+func (s *FileEnrollmentStore) ListEnrollmentTokens(_ context.Context, q EnrollmentTokenListQuery) ([]EnrollmentTokenSummary, error) {
+	if s == nil {
+		return nil, ErrEnrollmentStoreRequired
+	}
+	limit := normalizeFollowerListLimit(q.Limit)
+	now := q.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]EnrollmentTokenSummary, 0, len(s.data.Tokens))
+	for _, token := range s.data.Tokens {
+		if q.TokenID != "" && token.TokenID != q.TokenID {
+			continue
+		}
+		if q.OrgID != "" && token.Identity.OrgID != q.OrgID {
+			continue
+		}
+		if q.FleetID != "" && token.Identity.FleetID != q.FleetID {
+			continue
+		}
+		if q.InstanceID != "" && token.Identity.InstanceID != q.InstanceID {
+			continue
+		}
+		if q.Environment != "" && token.Identity.Environment != q.Environment {
+			continue
+		}
+		out = append(out, token.summary(now))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].CreatedAt.After(out[j].CreatedAt)
+		}
+		return out[i].TokenID < out[j].TokenID
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// RevokeEnrollmentToken marks a single pending token revoked so it can no longer
+// be consumed. It fails closed: an unknown token_id is ErrEnrollmentTokenNotFound
+// and a token that is not pending (already consumed, already revoked, or
+// expired) is ErrEnrollmentTokenNotPending. The persisted RevokedAt stamp is
+// durable across restart, and ConsumeEnrollmentToken rejects a revoked token, so
+// a revoked token stays dead.
+func (s *FileEnrollmentStore) RevokeEnrollmentToken(_ context.Context, req RevokeEnrollmentTokenRequest) (EnrollmentTokenSummary, error) {
+	if s == nil {
+		return EnrollmentTokenSummary{}, ErrEnrollmentStoreRequired
+	}
+	tokenID := strings.TrimSpace(req.TokenID)
+	if err := conductor.ValidateIdentifier("token_id", tokenID); err != nil {
+		return EnrollmentTokenSummary{}, err
+	}
+	now := req.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	token, ok := s.data.Tokens[tokenID]
+	if !ok {
+		return EnrollmentTokenSummary{}, ErrEnrollmentTokenNotFound
+	}
+	// Only a still-pending token may be revoked. Deriving the gate from
+	// tokenState keeps the "what is pending" decision in one place.
+	if token.tokenState(now) != EnrollmentTokenStatePending {
+		return EnrollmentTokenSummary{}, ErrEnrollmentTokenNotPending
+	}
+	revokedAt := now
+	token.RevokedAt = &revokedAt
+	s.data.Tokens[tokenID] = token
+	if err := s.saveLocked(); err != nil {
+		// Roll back the in-memory mutation so a failed durable write does not
+		// leave a token that looks revoked in memory but is not on disk.
+		token.RevokedAt = nil
+		s.data.Tokens[tokenID] = token
+		return EnrollmentTokenSummary{}, err
+	}
+	return token.summary(now), nil
 }
 
 type followerSummaryMaxHeap []FollowerSummary
@@ -447,10 +653,19 @@ func CompositeAuditKeyResolver(primary EnrollmentStore, fallback AuditKeyResolve
 }
 
 func (h *Handler) handleEnrollmentTokens(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeMethodNotAllowed(w, http.MethodPost)
-		return
+	switch r.Method {
+	case http.MethodPost:
+		h.handleCreateEnrollmentToken(w, r)
+	case http.MethodGet:
+		h.handleListEnrollmentTokens(w, r)
+	case http.MethodDelete:
+		h.handleRevokeEnrollmentToken(w, r)
+	default:
+		writeMethodNotAllowed(w, http.MethodPost, http.MethodGet, http.MethodDelete)
 	}
+}
+
+func (h *Handler) handleCreateEnrollmentToken(w http.ResponseWriter, r *http.Request) {
 	if h.enrollments == nil {
 		writeError(w, http.StatusNotImplemented, ErrEnrollmentStoreRequired)
 		return
@@ -469,6 +684,18 @@ func (h *Handler) handleEnrollmentTokens(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
+	now := h.now()
+	// Enforce the server-side maximum validity window BEFORE the store mints a
+	// token. An operator cannot widen their leaked-credential exposure past the
+	// configured ceiling regardless of the --ttl they pass. A zero-width or
+	// already-expired window and an over-long window both surface here as
+	// ErrInvalidValidityWindow; route through writeEnrollmentError so the
+	// enrollment endpoint maps validity-window faults to 400 consistently with
+	// the store's own create-path validation.
+	if err := validateMaxValidity(now, req.ExpiresAt, h.enrollmentTokenMaxTTL); err != nil {
+		writeEnrollmentError(w, err)
+		return
+	}
 	issued, err := h.enrollments.CreateEnrollmentToken(r.Context(), EnrollmentTokenSpec{
 		TokenID: req.TokenID,
 		Identity: FollowerIdentity{
@@ -478,13 +705,127 @@ func (h *Handler) handleEnrollmentTokens(w http.ResponseWriter, r *http.Request)
 			Environment: req.Environment,
 		},
 		Expires: req.ExpiresAt,
-		Now:     h.now(),
+		Now:     now,
 	})
 	if err != nil {
 		writeEnrollmentError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, createEnrollmentTokenResponse(issued))
+}
+
+type listEnrollmentTokensResponse struct {
+	Tokens []EnrollmentTokenSummary `json:"tokens"`
+	Count  int                      `json:"count"`
+}
+
+// handleListEnrollmentTokens serves the admin enrollment-token metadata read
+// (GET). The same endpoint serves single-token "status" via the token_id query
+// filter. It returns lifecycle metadata only; the store never exposes the token
+// bytes or hash.
+func (h *Handler) handleListEnrollmentTokens(w http.ResponseWriter, r *http.Request) {
+	if h.enrollments == nil {
+		writeError(w, http.StatusNotImplemented, ErrEnrollmentStoreRequired)
+		return
+	}
+	if err := h.authorizeAdmin(r); err != nil {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
+		return
+	}
+	query, err := parseEnrollmentTokenListQuery(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	query.Now = h.now()
+	tokens, err := h.enrollments.ListEnrollmentTokens(r.Context(), query)
+	if err != nil {
+		if h.logger != nil {
+			h.logger.ErrorContext(r.Context(), "conductor_enrollment_tokens_list_failed",
+				slog.String("event", "conductor_enrollment_tokens_list_failed"),
+				slog.String("error", err.Error()),
+			)
+		}
+		writeError(w, http.StatusInternalServerError, errors.New("internal server error"))
+		return
+	}
+	if tokens == nil {
+		tokens = []EnrollmentTokenSummary{}
+	}
+	writeJSON(w, http.StatusOK, listEnrollmentTokensResponse{Tokens: tokens, Count: len(tokens)})
+}
+
+// handleRevokeEnrollmentToken serves the admin enrollment-token revoke (DELETE).
+// It invalidates a single pending token by token_id and returns the resulting
+// metadata-only summary.
+func (h *Handler) handleRevokeEnrollmentToken(w http.ResponseWriter, r *http.Request) {
+	if h.enrollments == nil {
+		writeError(w, http.StatusNotImplemented, ErrEnrollmentStoreRequired)
+		return
+	}
+	if err := h.authorizeAdmin(r); err != nil {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
+		return
+	}
+	var req revokeEnrollmentTokenRequest
+	if err := decodeStrictJSON(w, r, h.maxRequestBody, &req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, conductor.ErrPayloadTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	summary, err := h.enrollments.RevokeEnrollmentToken(r.Context(), RevokeEnrollmentTokenRequest{
+		TokenID: req.TokenID,
+		Now:     h.now(),
+	})
+	if err != nil {
+		writeEnrollmentError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, summary)
+}
+
+type revokeEnrollmentTokenRequest struct {
+	TokenID string `json:"token_id"`
+}
+
+func parseEnrollmentTokenListQuery(r *http.Request) (EnrollmentTokenListQuery, error) {
+	values := r.URL.Query()
+	if err := validateFollowerListValues(values, "token_id", "org_id", "fleet_id", "instance_id", "environment", "limit"); err != nil {
+		return EnrollmentTokenListQuery{}, err
+	}
+	q := EnrollmentTokenListQuery{
+		TokenID:     values.Get("token_id"),
+		OrgID:       values.Get("org_id"),
+		FleetID:     values.Get("fleet_id"),
+		InstanceID:  values.Get("instance_id"),
+		Environment: values.Get("environment"),
+	}
+	for _, c := range []struct{ field, value string }{
+		{"token_id", q.TokenID},
+		{"org_id", q.OrgID},
+		{"fleet_id", q.FleetID},
+		{"instance_id", q.InstanceID},
+		{"environment", q.Environment},
+	} {
+		if c.value == "" {
+			continue
+		}
+		if err := conductor.ValidateIdentifier(c.field, c.value); err != nil {
+			return EnrollmentTokenListQuery{}, err
+		}
+	}
+	if rawLimit := values.Get("limit"); rawLimit != "" {
+		limit, err := strconv.Atoi(rawLimit)
+		if err != nil || limit <= 0 || limit > maxFollowerListLimit {
+			return EnrollmentTokenListQuery{}, fmt.Errorf("invalid limit query parameter: %q (must be 1..%d)", rawLimit, maxFollowerListLimit)
+		}
+		q.Limit = limit
+	}
+	return q, nil
 }
 
 func (h *Handler) handleEnroll(w http.ResponseWriter, r *http.Request) {
@@ -538,7 +879,9 @@ func writeEnrollmentError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, ErrEnrollmentTokenInvalid), errors.Is(err, ErrEnrollmentTokenConsumed), errors.Is(err, ErrEnrollmentTokenExpired):
 		writeError(w, http.StatusUnauthorized, ErrEnrollmentTokenInvalid)
-	case errors.Is(err, ErrEnrollmentActiveInstance), errors.Is(err, ErrEnrollmentTokenConflict):
+	case errors.Is(err, ErrEnrollmentTokenNotFound):
+		writeError(w, http.StatusNotFound, err)
+	case errors.Is(err, ErrEnrollmentActiveInstance), errors.Is(err, ErrEnrollmentTokenConflict), errors.Is(err, ErrEnrollmentTokenNotPending):
 		writeError(w, http.StatusConflict, err)
 	case errors.Is(err, conductor.ErrInvalidValidityWindow),
 		errors.Is(err, conductor.ErrInvalidIdentifier),

--- a/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
+++ b/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
@@ -279,6 +279,13 @@ func TestHandlerEnrollmentTokenListAppliesFiltersAndLimit(t *testing.T) {
 	if missW.Code != http.StatusOK {
 		t.Fatalf("non-matching filter status = %d, want 200", missW.Code)
 	}
+	var missResp listEnrollmentTokensResponse
+	if err := json.Unmarshal(missW.Body.Bytes(), &missResp); err != nil {
+		t.Fatalf("decode non-matching filter response: %v", err)
+	}
+	if missResp.Count != 0 || len(missResp.Tokens) != 0 {
+		t.Fatalf("non-matching filter resp = %+v, want empty result set", missResp)
+	}
 }
 
 func TestHandlerEnrollmentTokenListRejectsBadQueryParams(t *testing.T) {

--- a/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
+++ b/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -146,7 +147,9 @@ func TestHandlerEnrollmentTokenListAndStatusNeverLeakSecret(t *testing.T) {
 	if statusW.Code != http.StatusOK {
 		t.Fatalf("status status = %d body=%s, want 200", statusW.Code, statusW.Body.String())
 	}
-	if strings.Contains(statusW.Body.String(), minted.Token) || strings.Contains(statusW.Body.String(), "token_hash") {
+	if strings.Contains(statusW.Body.String(), minted.Token) ||
+		strings.Contains(statusW.Body.String(), "token_hash") ||
+		strings.Contains(statusW.Body.String(), `"token"`) {
 		t.Fatalf("status response leaked secret: %s", statusW.Body.String())
 	}
 }
@@ -224,6 +227,95 @@ func TestHandlerEnrollmentTokenRevokeInvalidatesPendingToken(t *testing.T) {
 	}
 }
 
+func TestEnrollmentTokenRecordStateDerivation(t *testing.T) {
+	consumed := testNow
+	revoked := testNow
+	cases := []struct {
+		name string
+		rec  enrollmentTokenRecord
+		now  time.Time
+		want EnrollmentTokenState
+	}{
+		{"pending", enrollmentTokenRecord{ExpiresAt: testNow.Add(time.Hour)}, testNow, EnrollmentTokenStatePending},
+		{"expired", enrollmentTokenRecord{ExpiresAt: testNow.Add(time.Hour)}, testNow.Add(2 * time.Hour), EnrollmentTokenStateExpired},
+		{"consumed-wins-past-expiry", enrollmentTokenRecord{ExpiresAt: testNow.Add(time.Hour), ConsumedAt: &consumed}, testNow.Add(2 * time.Hour), EnrollmentTokenStateConsumed},
+		{"revoked-wins-over-expiry", enrollmentTokenRecord{ExpiresAt: testNow.Add(time.Hour), RevokedAt: &revoked}, testNow.Add(2 * time.Hour), EnrollmentTokenStateRevoked},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.rec.tokenState(tc.now); got != tc.want {
+				t.Fatalf("tokenState() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHandlerEnrollmentTokenListAppliesFiltersAndLimit(t *testing.T) {
+	handler, _ := newLifecycleTestHandler(t, 0)
+	mintToken(t, handler, "tok-a", testNow.Add(time.Hour))
+	mintToken(t, handler, "tok-b", testNow.Add(time.Hour))
+
+	// limit=1 bounds the result; the fleet_id filter matches both minted tokens.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, EnrollmentTokensPath+"?fleet_id=prod&limit=1", nil)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("filtered list status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	var resp listEnrollmentTokensResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode filtered list: %v", err)
+	}
+	if resp.Count != 1 {
+		t.Fatalf("limit=1 returned count=%d, want 1", resp.Count)
+	}
+
+	// A non-matching filter yields an empty set, not an error.
+	missReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, EnrollmentTokensPath+"?fleet_id=nope", nil)
+	missReq.Header.Set("Authorization", "Bearer admin-token")
+	missW := httptest.NewRecorder()
+	handler.ServeHTTP(missW, missReq)
+	if missW.Code != http.StatusOK {
+		t.Fatalf("non-matching filter status = %d, want 200", missW.Code)
+	}
+}
+
+func TestHandlerEnrollmentTokenListRejectsBadQueryParams(t *testing.T) {
+	handler, _ := newLifecycleTestHandler(t, 0)
+	for _, q := range []string{"?limit=0", "?limit=999999", "?limit=abc", "?org_id=bad%20id"} {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, EnrollmentTokensPath+q, nil)
+		req.Header.Set("Authorization", "Bearer admin-token")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("query %q status = %d body=%s, want 400", q, w.Code, w.Body.String())
+		}
+	}
+}
+
+func TestHandlerEnrollmentTokenMethodNotAllowed(t *testing.T) {
+	handler, _ := newLifecycleTestHandler(t, 0)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, EnrollmentTokensPath, strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("PUT status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandlerEnrollmentTokenRevokeRejectsBadBody(t *testing.T) {
+	handler, _ := newLifecycleTestHandler(t, 0)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, EnrollmentTokensPath, strings.NewReader("not-json"))
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("revoke bad body status = %d body=%s, want 400", w.Code, w.Body.String())
+	}
+}
+
 func TestFileEnrollmentStoreRevokeIsDurableAndConsumedNotRevokable(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "enrollments.json")
 	store, err := OpenFileEnrollmentStore(path)
@@ -257,7 +349,7 @@ func TestFileEnrollmentStoreRevokeIsDurableAndConsumedNotRevokable(t *testing.T)
 	}
 
 	// A second store cannot re-revoke a revoked token.
-	if _, err := reopened.RevokeEnrollmentToken(context.Background(), RevokeEnrollmentTokenRequest{TokenID: "durable-token", Now: testNow}); err == nil {
-		t.Fatalf("re-revoke after restart: want ErrEnrollmentTokenNotPending, got nil")
+	if _, err := reopened.RevokeEnrollmentToken(context.Background(), RevokeEnrollmentTokenRequest{TokenID: "durable-token", Now: testNow}); !errors.Is(err, ErrEnrollmentTokenNotPending) {
+		t.Fatalf("re-revoke after restart error = %v, want ErrEnrollmentTokenNotPending", err)
 	}
 }

--- a/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
+++ b/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
@@ -1,0 +1,263 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// newLifecycleTestHandler builds a handler wired to a fresh file enrollment
+// store with an admin authorizer that accepts only "Bearer admin-token" and the
+// supplied maximum enrollment-token TTL (0 = package default).
+func newLifecycleTestHandler(t *testing.T, maxTTL time.Duration) (*Handler, *FileEnrollmentStore) {
+	t.Helper()
+	enrollments, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	handler, err := NewHandler(HandlerOptions{
+		Store:        mustStore(t),
+		Capabilities: DefaultCapabilities("conductor-test"),
+		Now:          func() time.Time { return testNow },
+		FollowerIdentity: func(*http.Request) (FollowerIdentity, error) {
+			return defaultFollowerIdentity(), nil
+		},
+		AuthorizePublisher: func(*http.Request) error { return nil },
+		AuthorizeAdmin: func(r *http.Request) error {
+			if r.Header.Get("Authorization") != "Bearer admin-token" {
+				return ErrPublisherForbidden
+			}
+			return nil
+		},
+		AuditSink:             &captureAuditSink{},
+		AuditKeys:             CompositeAuditKeyResolver(enrollments, nil),
+		Enrollments:           enrollments,
+		EnrollmentTokenMaxTTL: maxTTL,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+	return handler, enrollments
+}
+
+func mintToken(t *testing.T, handler *Handler, tokenID string, expiresAt time.Time) createEnrollmentTokenResponse {
+	t.Helper()
+	body, err := json.Marshal(createEnrollmentTokenRequest{
+		TokenID:     tokenID,
+		OrgID:       "org-main",
+		FleetID:     "prod",
+		InstanceID:  "pl-prod-1",
+		Environment: "prod",
+		ExpiresAt:   expiresAt,
+	})
+	if err != nil {
+		t.Fatalf("Marshal(create) error = %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollmentTokensPath, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("mint token status = %d body=%s, want 201", w.Code, w.Body.String())
+	}
+	var issued createEnrollmentTokenResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &issued); err != nil {
+		t.Fatalf("decode minted token: %v", err)
+	}
+	return issued
+}
+
+func TestHandlerEnrollmentTokenRejectsOverMaxTTL(t *testing.T) {
+	handler, _ := newLifecycleTestHandler(t, time.Hour)
+	body, err := json.Marshal(createEnrollmentTokenRequest{
+		TokenID:     "too-long",
+		OrgID:       "org-main",
+		FleetID:     "prod",
+		InstanceID:  "pl-prod-1",
+		Environment: "prod",
+		ExpiresAt:   testNow.Add(2 * time.Hour), // exceeds the 1h max
+	})
+	if err != nil {
+		t.Fatalf("Marshal(create) error = %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollmentTokensPath, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("over-max TTL status = %d body=%s, want 400", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "exceeds max") {
+		t.Fatalf("over-max TTL body = %s, want mention of max", w.Body.String())
+	}
+
+	// A token exactly at the ceiling is accepted.
+	atCeiling := mintToken(t, handler, "at-ceiling", testNow.Add(time.Hour))
+	if atCeiling.TokenID != "at-ceiling" {
+		t.Fatalf("at-ceiling token = %+v", atCeiling)
+	}
+}
+
+func TestHandlerEnrollmentTokenListAndStatusNeverLeakSecret(t *testing.T) {
+	handler, _ := newLifecycleTestHandler(t, 0)
+	minted := mintToken(t, handler, "list-token-1", testNow.Add(time.Hour))
+
+	// List.
+	listReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, EnrollmentTokensPath, nil)
+	listReq.Header.Set("Authorization", "Bearer admin-token")
+	listW := httptest.NewRecorder()
+	handler.ServeHTTP(listW, listReq)
+	if listW.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s, want 200", listW.Code, listW.Body.String())
+	}
+	listBody := listW.Body.String()
+	if strings.Contains(listBody, minted.Token) {
+		t.Fatalf("list response leaked the token secret: %s", listBody)
+	}
+	// The token_hash JSON key must never appear either.
+	if strings.Contains(listBody, "token_hash") || strings.Contains(listBody, `"token"`) {
+		t.Fatalf("list response contains secret-bearing field: %s", listBody)
+	}
+	var listResp listEnrollmentTokensResponse
+	if err := json.Unmarshal(listW.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if listResp.Count != 1 || listResp.Tokens[0].TokenID != "list-token-1" || listResp.Tokens[0].State != EnrollmentTokenStatePending {
+		t.Fatalf("list resp = %+v", listResp)
+	}
+
+	// Status (single token via ?token_id=).
+	statusReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, EnrollmentTokensPath+"?token_id=list-token-1", nil)
+	statusReq.Header.Set("Authorization", "Bearer admin-token")
+	statusW := httptest.NewRecorder()
+	handler.ServeHTTP(statusW, statusReq)
+	if statusW.Code != http.StatusOK {
+		t.Fatalf("status status = %d body=%s, want 200", statusW.Code, statusW.Body.String())
+	}
+	if strings.Contains(statusW.Body.String(), minted.Token) || strings.Contains(statusW.Body.String(), "token_hash") {
+		t.Fatalf("status response leaked secret: %s", statusW.Body.String())
+	}
+}
+
+func TestHandlerEnrollmentTokenListRequiresAdmin(t *testing.T) {
+	handler, _ := newLifecycleTestHandler(t, 0)
+	for _, method := range []string{http.MethodGet, http.MethodDelete} {
+		req := httptest.NewRequestWithContext(context.Background(), method, EnrollmentTokensPath, strings.NewReader(`{"token_id":"x"}`))
+		req.Header.Set("Authorization", "Bearer not-the-admin-token")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("%s without admin token status = %d, want 403", method, w.Code)
+		}
+	}
+}
+
+func TestHandlerEnrollmentTokenRevokeInvalidatesPendingToken(t *testing.T) {
+	handler, _ := newLifecycleTestHandler(t, 0)
+	pub, _ := testAuditSigner(t)
+	minted := mintToken(t, handler, "revoke-me", testNow.Add(time.Hour))
+
+	// Revoke the pending token.
+	revokeBody, err := json.Marshal(revokeEnrollmentTokenRequest{TokenID: "revoke-me"})
+	if err != nil {
+		t.Fatalf("Marshal(revoke) error = %v", err)
+	}
+	revokeReq := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, EnrollmentTokensPath, bytes.NewReader(revokeBody))
+	revokeReq.Header.Set("Authorization", "Bearer admin-token")
+	revokeW := httptest.NewRecorder()
+	handler.ServeHTTP(revokeW, revokeReq)
+	if revokeW.Code != http.StatusOK {
+		t.Fatalf("revoke status = %d body=%s, want 200", revokeW.Code, revokeW.Body.String())
+	}
+	var summary EnrollmentTokenSummary
+	if err := json.Unmarshal(revokeW.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("decode revoke summary: %v", err)
+	}
+	if summary.State != EnrollmentTokenStateRevoked || summary.RevokedAt == nil {
+		t.Fatalf("revoke summary = %+v, want revoked with RevokedAt set", summary)
+	}
+
+	// Consuming the revoked token MUST fail closed.
+	enrollBody, err := json.Marshal(enrollRequest{
+		Token:          minted.Token,
+		AuditKeyID:     "audit-key-1",
+		AuditPublicKey: signing.EncodePublicKey(pub),
+	})
+	if err != nil {
+		t.Fatalf("Marshal(enroll) error = %v", err)
+	}
+	enrollW := httptest.NewRecorder()
+	handler.ServeHTTP(enrollW, httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollPath, bytes.NewReader(enrollBody)))
+	if enrollW.Code != http.StatusUnauthorized {
+		t.Fatalf("consume-after-revoke status = %d body=%s, want 401", enrollW.Code, enrollW.Body.String())
+	}
+
+	// Re-revoking a revoked token is rejected (not pending -> 409).
+	reRevokeReq := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, EnrollmentTokensPath, bytes.NewReader(revokeBody))
+	reRevokeReq.Header.Set("Authorization", "Bearer admin-token")
+	reRevokeW := httptest.NewRecorder()
+	handler.ServeHTTP(reRevokeW, reRevokeReq)
+	if reRevokeW.Code != http.StatusConflict {
+		t.Fatalf("re-revoke status = %d body=%s, want 409", reRevokeW.Code, reRevokeW.Body.String())
+	}
+
+	// Revoking an unknown token is 404.
+	unknownBody, _ := json.Marshal(revokeEnrollmentTokenRequest{TokenID: "no-such-token"})
+	unknownReq := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, EnrollmentTokensPath, bytes.NewReader(unknownBody))
+	unknownReq.Header.Set("Authorization", "Bearer admin-token")
+	unknownW := httptest.NewRecorder()
+	handler.ServeHTTP(unknownW, unknownReq)
+	if unknownW.Code != http.StatusNotFound {
+		t.Fatalf("revoke unknown status = %d body=%s, want 404", unknownW.Code, unknownW.Body.String())
+	}
+}
+
+func TestFileEnrollmentStoreRevokeIsDurableAndConsumedNotRevokable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := FollowerIdentity{OrgID: "org-main", FleetID: "prod", InstanceID: "pl-prod-1", Environment: "prod"}
+	if _, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "durable-token",
+		Identity: identity,
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	}); err != nil {
+		t.Fatalf("CreateEnrollmentToken() error = %v", err)
+	}
+	if _, err := store.RevokeEnrollmentToken(context.Background(), RevokeEnrollmentTokenRequest{TokenID: "durable-token", Now: testNow}); err != nil {
+		t.Fatalf("RevokeEnrollmentToken() error = %v", err)
+	}
+
+	// Reopen the store from disk and confirm the revocation survived restart.
+	reopened, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("reopen OpenFileEnrollmentStore() error = %v", err)
+	}
+	tokens, err := reopened.ListEnrollmentTokens(context.Background(), EnrollmentTokenListQuery{TokenID: "durable-token"})
+	if err != nil {
+		t.Fatalf("ListEnrollmentTokens() error = %v", err)
+	}
+	if len(tokens) != 1 || tokens[0].State != EnrollmentTokenStateRevoked {
+		t.Fatalf("after reopen tokens = %+v, want one revoked token", tokens)
+	}
+
+	// A second store cannot re-revoke a revoked token.
+	if _, err := reopened.RevokeEnrollmentToken(context.Background(), RevokeEnrollmentTokenRequest{TokenID: "durable-token", Now: testNow}); err == nil {
+		t.Fatalf("re-revoke after restart: want ErrEnrollmentTokenNotPending, got nil")
+	}
+}

--- a/enterprise/conductor/controlplane/enrollment_test.go
+++ b/enterprise/conductor/controlplane/enrollment_test.go
@@ -353,7 +353,7 @@ func TestHandlerEnrollmentEndpointErrors(t *testing.T) {
 		path   string
 		want   int
 	}{
-		{"token wrong method", http.MethodGet, EnrollmentTokensPath, http.StatusMethodNotAllowed},
+		{"token wrong method", http.MethodPut, EnrollmentTokensPath, http.StatusMethodNotAllowed},
 		{"enroll wrong method", http.MethodGet, EnrollPath, http.StatusMethodNotAllowed},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -42,6 +42,12 @@ const (
 
 	DefaultRemoteKillMaxValidity = 72 * time.Hour
 	DefaultRollbackMaxValidity   = 24 * time.Hour
+	// DefaultEnrollmentTokenMaxValidity caps how far in the future a minted
+	// enrollment token may expire. An enrollment token is a one-shot bearer
+	// credential handed to a starting follower; a multi-week window is a large
+	// leaked-credential exposure with no upside, so the server rejects an
+	// over-long --ttl rather than trusting the operator to keep it short.
+	DefaultEnrollmentTokenMaxValidity = 24 * time.Hour
 )
 
 // Publish-conflict codes. A policy-bundle publish can be rejected with HTTP 409
@@ -126,8 +132,11 @@ type HandlerOptions struct {
 	EmergencyKeys       conductor.SignatureKeyResolver
 	RemoteKillMaxTTL    time.Duration
 	RollbackMaxTTL      time.Duration
-	Metrics             *metrics.Metrics
-	Logger              *slog.Logger
+	// EnrollmentTokenMaxTTL caps the validity window of a minted enrollment
+	// token. Zero falls back to DefaultEnrollmentTokenMaxValidity.
+	EnrollmentTokenMaxTTL time.Duration
+	Metrics               *metrics.Metrics
+	Logger                *slog.Logger
 }
 
 type Handler struct {
@@ -146,15 +155,16 @@ type Handler struct {
 	auditSink           AuditBatchSink
 	// nil auditQuerier means the configured sink does not implement
 	// [AuditBatchQuerier], so GET returns 501 rather than a retryable 500.
-	auditQuerier      AuditBatchQuerier
-	auditKeys         AuditKeyResolver
-	enrollments       EnrollmentStore
-	emergencyControls EmergencyStore
-	emergencyKeys     conductor.SignatureKeyResolver
-	remoteKillMaxTTL  time.Duration
-	rollbackMaxTTL    time.Duration
-	metrics           *metrics.Metrics
-	logger            *slog.Logger
+	auditQuerier          AuditBatchQuerier
+	auditKeys             AuditKeyResolver
+	enrollments           EnrollmentStore
+	emergencyControls     EmergencyStore
+	emergencyKeys         conductor.SignatureKeyResolver
+	remoteKillMaxTTL      time.Duration
+	rollbackMaxTTL        time.Duration
+	enrollmentTokenMaxTTL time.Duration
+	metrics               *metrics.Metrics
+	logger                *slog.Logger
 }
 
 type rollbackAuthorizationEnumerator interface {
@@ -290,6 +300,10 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 	if rollbackMaxTTL <= 0 {
 		rollbackMaxTTL = DefaultRollbackMaxValidity
 	}
+	enrollmentTokenMaxTTL := opts.EnrollmentTokenMaxTTL
+	if enrollmentTokenMaxTTL <= 0 {
+		enrollmentTokenMaxTTL = DefaultEnrollmentTokenMaxValidity
+	}
 	authorizeAuditQuery := opts.AuthorizeAuditQuery
 	if authorizeAuditQuery == nil {
 		authorizeAuditQuery = func(*http.Request, AuditBatchQuery) error {
@@ -337,28 +351,29 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 		return nil, err
 	}
 	return &Handler{
-		store:               opts.Store,
-		capabilities:        capabilities,
-		now:                 now,
-		maxRequestBody:      maxBody,
-		maxAuditBody:        maxAuditBody,
-		followerIdentity:    opts.FollowerIdentity,
-		authorizePublisher:  opts.AuthorizePublisher,
-		authorizeBundle:     authorizeBundle,
-		authorizeAuditQuery: authorizeAuditQuery,
-		authorizeFollowers:  authorizeFollowers,
-		authorizeStream:     authorizeStream,
-		authorizeAdmin:      authorizeAdmin,
-		auditSink:           opts.AuditSink,
-		auditQuerier:        auditQuerier,
-		auditKeys:           opts.AuditKeys,
-		enrollments:         opts.Enrollments,
-		emergencyControls:   emergencyControls,
-		emergencyKeys:       opts.EmergencyKeys,
-		remoteKillMaxTTL:    remoteKillMaxTTL,
-		rollbackMaxTTL:      rollbackMaxTTL,
-		metrics:             opts.Metrics,
-		logger:              opts.Logger,
+		store:                 opts.Store,
+		capabilities:          capabilities,
+		now:                   now,
+		maxRequestBody:        maxBody,
+		maxAuditBody:          maxAuditBody,
+		followerIdentity:      opts.FollowerIdentity,
+		authorizePublisher:    opts.AuthorizePublisher,
+		authorizeBundle:       authorizeBundle,
+		authorizeAuditQuery:   authorizeAuditQuery,
+		authorizeFollowers:    authorizeFollowers,
+		authorizeStream:       authorizeStream,
+		authorizeAdmin:        authorizeAdmin,
+		auditSink:             opts.AuditSink,
+		auditQuerier:          auditQuerier,
+		auditKeys:             opts.AuditKeys,
+		enrollments:           opts.Enrollments,
+		emergencyControls:     emergencyControls,
+		emergencyKeys:         opts.EmergencyKeys,
+		remoteKillMaxTTL:      remoteKillMaxTTL,
+		rollbackMaxTTL:        rollbackMaxTTL,
+		enrollmentTokenMaxTTL: enrollmentTokenMaxTTL,
+		metrics:               opts.Metrics,
+		logger:                opts.Logger,
 	}, nil
 }
 

--- a/internal/license/fleet_gate.go
+++ b/internal/license/fleet_gate.go
@@ -5,11 +5,12 @@ package license
 
 import (
 	"crypto/ed25519"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 // EnvLicenseKey is the env variable carrying the signed license token. The
@@ -18,9 +19,12 @@ import (
 // the token from `cfg.LicenseKey` first and falls back to this env variable.
 const EnvLicenseKey = "PIPELOCK_LICENSE_KEY"
 
-// EnvLicensePublicKey is the optional env override for the verifier public key
-// in hex. Official builds embed the production key at build time; this env
-// variable is for development and self-hosted issuance.
+// EnvLicensePublicKey is the optional env override for the verifier public key.
+// It accepts either a raw 64-character hex Ed25519 key or the versioned
+// "pipelock-ed25519-public-v1\n<base64>" format written to license.pub, so a
+// self-hosted issuer can point it straight at the generated file. Official
+// builds embed the production key at build time; this env variable is for
+// development and self-hosted issuance.
 const EnvLicensePublicKey = "PIPELOCK_LICENSE_PUBLIC_KEY"
 
 // EnvLicenseCRLFile is the optional env variable pointing to a signed license
@@ -77,7 +81,9 @@ func VerifyFleet(licenseKey, publicKeyHex, crlFile string) (License, error) {
 var (
 	errNoLicenseToken = errors.New("no license token provided")
 	errNoVerifierKey  = errors.New("no verifier public key available " +
-		"(build-embedded key missing and PIPELOCK_LICENSE_PUBLIC_KEY unset)")
+		"(build-embedded key missing and PIPELOCK_LICENSE_PUBLIC_KEY unset, " +
+		"empty, or unparseable; accepts 64-char raw hex or the versioned " +
+		"\"pipelock-ed25519-public-v1\\n<base64>\" license.pub format)")
 )
 
 // FleetVerifyInputs groups the license-resolution inputs shared by the fleet
@@ -119,14 +125,19 @@ func verifyLicenseInputsOpts(in FleetVerifyInputs) (License, error) {
 	}
 	pubKey := EmbeddedPublicKey()
 	if pubKey == nil {
-		publicKeyHex := in.PublicKeyHex
-		if publicKeyHex == "" {
-			publicKeyHex = os.Getenv(EnvLicensePublicKey)
+		publicKey := in.PublicKeyHex
+		if publicKey == "" {
+			publicKey = os.Getenv(EnvLicensePublicKey)
 		}
-		if publicKeyHex != "" {
-			keyBytes, decErr := hex.DecodeString(publicKeyHex)
-			if decErr == nil && len(keyBytes) == ed25519.PublicKeySize {
-				pubKey = keyBytes
+		if publicKey != "" {
+			// signing.ParsePublicKey accepts BOTH the durable versioned
+			// "pipelock-ed25519-public-v1\n<base64>" form written by the signing
+			// CLI to license.pub AND a raw 64-hex Ed25519 key. It rejects
+			// malformed, short, or otherwise garbage keys, so the verifier still
+			// fails closed below when the override is unparseable.
+			parsed, parseErr := signing.ParsePublicKey(publicKey)
+			if parseErr == nil && len(parsed) == ed25519.PublicKeySize {
+				pubKey = parsed
 			}
 		}
 	}

--- a/internal/license/fleet_gate_test.go
+++ b/internal/license/fleet_gate_test.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 func mustIssue(t *testing.T, priv ed25519.PrivateKey, id string, features []string) string {
@@ -167,6 +169,65 @@ func TestRequireFleet_InvalidSignatureRejected(t *testing.T) {
 	err := RequireFleet(tok, hex.EncodeToString(pub1))
 	if !errors.Is(err, ErrFleetLicenseRequired) {
 		t.Fatalf("wrong-key signature: want ErrFleetLicenseRequired, got %v", err)
+	}
+}
+
+// The verifier public key override (PIPELOCK_LICENSE_PUBLIC_KEY /
+// FleetVerifyInputs.PublicKeyHex) must accept BOTH the durable versioned
+// license.pub format and a raw 64-hex key, while still failing closed on
+// malformed input. These tests exercise the signing.ParsePublicKey routing.
+func TestRequireFleet_AcceptsVersionedPublicKeyFile(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, "lic_versioned_pub", []string{FeatureFleet})
+	// The versioned form is exactly what signing.EncodePublicKey writes to a
+	// license.pub file: "pipelock-ed25519-public-v1\n<base64>\n".
+	versioned := signing.EncodePublicKey(pub)
+	if err := RequireFleet(tok, versioned); err != nil {
+		t.Fatalf("RequireFleet with versioned license.pub key: want nil, got %v", err)
+	}
+}
+
+func TestRequireFleet_AcceptsRawHexPublicKey(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, "lic_raw_hex_pub", []string{FeatureFleet})
+	// Raw lowercase hex is the historical form and must keep working.
+	if err := RequireFleet(tok, hex.EncodeToString(pub)); err != nil {
+		t.Fatalf("RequireFleet with raw hex key: want nil, got %v", err)
+	}
+}
+
+func TestRequireFleet_GarbagePublicKeyFailsClosed(t *testing.T) {
+	_, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, "lic_garbage_pub", []string{FeatureFleet})
+	t.Setenv(EnvLicensePublicKey, "")
+	cases := map[string]string{
+		"non-hex garbage":      "this-is-not-a-key",
+		"odd-length hex":       "abc",
+		"short hex":            hex.EncodeToString([]byte("too-short")),
+		"versioned bad b64":    "pipelock-ed25519-public-v1\n!!!notbase64!!!",
+		"versioned wrong size": "pipelock-ed25519-public-v1\n" + "QUJD", // base64("ABC"), 3 bytes
+	}
+	for name, key := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := RequireFleet(tok, key)
+			// An unparseable override leaves pubKey nil, so verification fails
+			// closed exactly as a missing key does.
+			if !errors.Is(err, ErrFleetLicenseRequired) {
+				t.Fatalf("garbage public key %q: want ErrFleetLicenseRequired, got %v", key, err)
+			}
+		})
+	}
+}
+
+func TestRequireFleet_VersionedWrongKeyFailsSignature(t *testing.T) {
+	pub1, _ := newKeyPair(t)
+	_, priv2 := newKeyPair(t)
+	tok := mustIssue(t, priv2, "lic_versioned_wrong_key", []string{FeatureFleet}) // signed by key 2
+	// A well-formed versioned key for the WRONG signer must still fail the
+	// signature check; routing through ParsePublicKey must not loosen trust.
+	err := RequireFleet(tok, signing.EncodePublicKey(pub1))
+	if !errors.Is(err, ErrFleetLicenseRequired) {
+		t.Fatalf("versioned wrong-key signature: want ErrFleetLicenseRequired, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Accepts the versioned `license.pub` public-key format (and still raw hex) for the fleet verifier key by routing the env/config override through `signing.ParsePublicKey`. The trust path stays fail-closed against malformed, short, or wrong keys.
- Adds an enrollment-token lifecycle to the Conductor: a server-side maximum token-validity window that rejects an over-long ttl before mint, plus admin-authorized `enrollment-token list`, `status`, and `revoke` subcommands that return metadata only and never the token secret or hash. Revoke invalidates only a still-pending token; a revoked token fails closed at consume time and survives a restart.
- Corrects the self-update doc to match the code: the updater probes the install directory, not the binary itself.
- Documents the operator bearer-token generation and rotation path and the new enrollment-token commands in the conductor operator runbook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `enrollment-token` subcommands for listing, inspecting status, and revoking tokens (including `--json` output for list/status).
  * Added `enrollment-token-max-validity` to cap maximum token lifetime for token minting.
* **Documentation**
  * Added an end-to-end operator runbook for enrollment token lifecycle, including bearer token guidance and rotation steps.
  * Refined privileged install path pre-check logic to better detect unsafe update locations early.
* **Security / License Verification**
  * Expanded fleet license public key input support to accept both versioned and raw formats, with strict failure on invalid keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->