### PR TITLE
fix: operability, UX, and support-bundle secret-redaction fixes

### DIFF
--- a/internal/cli/diag/check.go
+++ b/internal/cli/diag/check.go
@@ -53,6 +53,12 @@ Examples:
 				cmd.Println("Using default config (no --config specified)")
 			}
 
+			// Surface semantic advisories (same checks as doctor,
+			// non-fatal so exit 0 is preserved unless already failing).
+			for _, advisory := range checkConfigAdvisories(cfg) {
+				cmd.Printf("\n  [ADVISORY] %s\n", advisory)
+			}
+
 			// Optionally scan a URL
 			if scanURL != "" {
 				cmd.Printf("\nScanning URL: %s\n", scanURL)
@@ -84,4 +90,25 @@ Examples:
 	cmd.Flags().StringVar(&scanURL, "url", "", "URL to scan through the configured scanners")
 
 	return cmd
+}
+
+// checkConfigAdvisories returns non-fatal advisory messages for the loaded
+// config. These mirror doctor checks but are surfaced in check so that CI
+// running only "pipelock check" still sees semantic inertness warnings.
+func checkConfigAdvisories(cfg *config.Config) []string {
+	var advisories []string
+
+	// Inert suppress entries (mirrors checkDoctorSuppressEntries).
+	for _, check := range checkDoctorConfigSemantics(cfg) {
+		if check.Status == doctorStatusWarn && check.Detail != "" {
+			advisories = append(advisories, check.Detail)
+		}
+	}
+
+	// Flight recorder enabled but inert (no dir configured).
+	if cfg.FlightRecorder.Enabled && cfg.FlightRecorder.Dir == "" {
+		advisories = append(advisories, "flight_recorder is enabled but dir is unset; no receipts will be written")
+	}
+
+	return advisories
 }

--- a/internal/cli/diag/coverage_boost_test.go
+++ b/internal/cli/diag/coverage_boost_test.go
@@ -523,19 +523,23 @@ func TestDoctorCmd_FlightRecorderInert(t *testing.T) {
 }
 
 // TestCheckDoctorFlightRecorder_AllBranches exercises every status branch of
-// checkDoctorFlightRecorder: disabled (info), enabled-but-no-dir (warn), and
-// enabled-with-dir (ok).
+// checkDoctorFlightRecorder: disabled (info), enabled-but-no-dir (warn),
+// enabled-with-dir (ok), and configured-but-unusable (fail).
 func TestCheckDoctorFlightRecorder_AllBranches(t *testing.T) {
 	dir := t.TempDir()
+	missingDir := filepath.Join(t.TempDir(), "missing")
 	tests := []struct {
 		name    string
 		enabled bool
 		dir     string
 		want    string
+		reach   bool
+		enforce bool
 	}{
 		{name: "disabled", enabled: false, dir: "", want: doctorStatusInfo},
 		{name: "enabled_no_dir", enabled: true, dir: "", want: doctorStatusWarn},
-		{name: "enabled_with_dir", enabled: true, dir: dir, want: doctorStatusOK},
+		{name: "enabled_with_dir", enabled: true, dir: dir, want: doctorStatusOK, reach: true, enforce: true},
+		{name: "enabled_missing_dir", enabled: true, dir: missingDir, want: doctorStatusFail},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -548,6 +552,12 @@ func TestCheckDoctorFlightRecorder_AllBranches(t *testing.T) {
 			}
 			if got.Status != tc.want {
 				t.Errorf("Status = %q, want %q", got.Status, tc.want)
+			}
+			if got.Reachable != tc.reach {
+				t.Errorf("Reachable = %v, want %v", got.Reachable, tc.reach)
+			}
+			if got.Enforcing != tc.enforce {
+				t.Errorf("Enforcing = %v, want %v", got.Enforcing, tc.enforce)
 			}
 		})
 	}

--- a/internal/cli/diag/coverage_boost_test.go
+++ b/internal/cli/diag/coverage_boost_test.go
@@ -443,6 +443,116 @@ func TestBuildSkipSet_Boost(t *testing.T) {
 	})
 }
 
+// TestCheckCmd_InertSuppressAdvisory verifies that the check command surfaces
+// an advisory when a suppress entry matches no active pattern.
+func TestCheckCmd_InertSuppressAdvisory(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "pipelock.yaml")
+	yaml := "mode: balanced\nsuppress:\n  - rule: Nonexistent Pattern\n    path: '*'\n    reason: test\n"
+	if err := os.WriteFile(cfgFile, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := &cobra.Command{Use: "pipelock"}
+	root.AddCommand(CheckCmd())
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"check", "--config", cfgFile})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "ADVISORY") {
+		t.Errorf("expected ADVISORY in check output for inert suppress; got: %s", output)
+	}
+	if !strings.Contains(output, "Nonexistent Pattern") {
+		t.Errorf("expected pattern name in advisory; got: %s", output)
+	}
+}
+
+// TestCheckCmd_FlightRecorderInertAdvisory verifies that the check command
+// surfaces an advisory when flight_recorder is enabled but dir is unset.
+func TestCheckCmd_FlightRecorderInertAdvisory(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "pipelock.yaml")
+	yaml := "mode: balanced\nflight_recorder:\n  enabled: true\n"
+	if err := os.WriteFile(cfgFile, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := &cobra.Command{Use: "pipelock"}
+	root.AddCommand(CheckCmd())
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"check", "--config", cfgFile})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "flight_recorder") {
+		t.Errorf("expected flight_recorder advisory; got: %s", output)
+	}
+}
+
+// TestDoctorCmd_FlightRecorderInert verifies that the doctor command warns
+// when flight_recorder is enabled but dir is unset.
+func TestDoctorCmd_FlightRecorderInert(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = ""
+
+	report := buildDoctorReport(cfg, "test")
+	var found bool
+	for _, check := range report.Checks {
+		if check.Name == "flight_recorder" && check.Status == doctorStatusWarn {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a warn flight_recorder check in the doctor report")
+	}
+}
+
+// TestCheckDoctorFlightRecorder_AllBranches exercises every status branch of
+// checkDoctorFlightRecorder: disabled (info), enabled-but-no-dir (warn), and
+// enabled-with-dir (ok).
+func TestCheckDoctorFlightRecorder_AllBranches(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name    string
+		enabled bool
+		dir     string
+		want    string
+	}{
+		{name: "disabled", enabled: false, dir: "", want: doctorStatusInfo},
+		{name: "enabled_no_dir", enabled: true, dir: "", want: doctorStatusWarn},
+		{name: "enabled_with_dir", enabled: true, dir: dir, want: doctorStatusOK},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.FlightRecorder.Enabled = tc.enabled
+			cfg.FlightRecorder.Dir = tc.dir
+			got := checkDoctorFlightRecorder(cfg)
+			if got.Name != "flight_recorder" {
+				t.Errorf("Name = %q, want flight_recorder", got.Name)
+			}
+			if got.Status != tc.want {
+				t.Errorf("Status = %q, want %q", got.Status, tc.want)
+			}
+		})
+	}
+}
+
 func TestConnectThroughProxy_BadAddress(t *testing.T) {
 	_, err := connectThroughProxy("http://127.0.0.1:1", "example.com:443")
 	if err == nil {

--- a/internal/cli/diag/coverage_boost_test.go
+++ b/internal/cli/diag/coverage_boost_test.go
@@ -563,6 +563,47 @@ func TestCheckDoctorFlightRecorder_AllBranches(t *testing.T) {
 	}
 }
 
+func TestFlightRecorderAccessDetail(t *testing.T) {
+	tests := []struct {
+		name       string
+		readable   bool
+		writable   bool
+		wantDetail string
+		wantNext   string
+	}{
+		{
+			name:       "neither_readable_nor_writable",
+			wantDetail: "not readable or writable",
+			wantNext:   "read/write/execute",
+		},
+		{
+			name:       "not_readable",
+			readable:   false,
+			writable:   true,
+			wantDetail: "not readable",
+			wantNext:   "read/execute",
+		},
+		{
+			name:       "not_writable",
+			readable:   true,
+			writable:   false,
+			wantDetail: "not writable",
+			wantNext:   "write/execute",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			detail, next := flightRecorderAccessDetail(tc.readable, tc.writable)
+			if !strings.Contains(detail, tc.wantDetail) {
+				t.Fatalf("detail = %q, want substring %q", detail, tc.wantDetail)
+			}
+			if !strings.Contains(next, tc.wantNext) {
+				t.Fatalf("next = %q, want substring %q", next, tc.wantNext)
+			}
+		})
+	}
+}
+
 func TestConnectThroughProxy_BadAddress(t *testing.T) {
 	_, err := connectThroughProxy("http://127.0.0.1:1", "example.com:443")
 	if err == nil {

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -626,12 +626,26 @@ func checkDoctorFlightRecorder(cfg *config.Config) doctorReportCheck {
 			Next:       "set flight_recorder.dir to a writable directory so receipts are persisted",
 		}
 	}
+	readable := pathReadable(cfg.FlightRecorder.Dir)
+	writable := pathWritableDir(cfg.FlightRecorder.Dir)
+	if !readable || !writable {
+		return doctorReportCheck{
+			Name:       "flight_recorder",
+			Surface:    doctorSurfaceConfig,
+			Status:     doctorStatusFail,
+			Configured: true,
+			Reachable:  readable,
+			Enforcing:  false,
+			Detail:     "flight_recorder.dir is configured but is not readable and writable; receipts will not persist reliably",
+			Next:       "create the directory and grant the pipelock service user read/write/execute access",
+		}
+	}
 	return doctorReportCheck{
 		Name:       "flight_recorder",
 		Surface:    doctorSurfaceConfig,
 		Status:     doctorStatusOK,
 		Configured: true,
-		Reachable:  pathReadable(cfg.FlightRecorder.Dir),
+		Reachable:  true,
 		Enforcing:  true,
 		Detail:     "flight_recorder is enabled with a configured directory",
 	}
@@ -719,6 +733,21 @@ func pathReadable(path string) bool {
 		return false
 	}
 	return openReadable(path)
+}
+
+func pathWritableDir(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	probe, err := os.CreateTemp(filepath.Clean(path), ".pipelock-doctor-writability-*") //nolint:gosec // doctor checks operator-visible config paths from local configuration.
+	if err != nil {
+		return false
+	}
+	probePath := probe.Name()
+	_ = probe.Close()
+	_ = os.Remove(probePath)
+	return true
 }
 
 func openReadable(path string) bool {

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -629,6 +629,7 @@ func checkDoctorFlightRecorder(cfg *config.Config) doctorReportCheck {
 	readable := pathReadable(cfg.FlightRecorder.Dir)
 	writable := pathWritableDir(cfg.FlightRecorder.Dir)
 	if !readable || !writable {
+		detail, next := flightRecorderAccessDetail(readable, writable)
 		return doctorReportCheck{
 			Name:       "flight_recorder",
 			Surface:    doctorSurfaceConfig,
@@ -636,8 +637,8 @@ func checkDoctorFlightRecorder(cfg *config.Config) doctorReportCheck {
 			Configured: true,
 			Reachable:  readable,
 			Enforcing:  false,
-			Detail:     "flight_recorder.dir is configured but is not readable and writable; receipts will not persist reliably",
-			Next:       "create the directory and grant the pipelock service user read/write/execute access",
+			Detail:     detail,
+			Next:       next,
 		}
 	}
 	return doctorReportCheck{
@@ -648,6 +649,20 @@ func checkDoctorFlightRecorder(cfg *config.Config) doctorReportCheck {
 		Reachable:  true,
 		Enforcing:  true,
 		Detail:     "flight_recorder is enabled with a configured directory",
+	}
+}
+
+func flightRecorderAccessDetail(readable, writable bool) (detail, next string) {
+	switch {
+	case !readable && !writable:
+		return "flight_recorder.dir is configured but is not readable or writable; receipts will not persist reliably",
+			"create the directory and grant the pipelock service user read/write/execute access"
+	case !readable:
+		return "flight_recorder.dir is configured but is not readable; existing receipts cannot be inspected reliably",
+			"grant the pipelock service user read/execute access to flight_recorder.dir"
+	default:
+		return "flight_recorder.dir is configured but is not writable; new receipts will not persist",
+			"grant the pipelock service user write/execute access to flight_recorder.dir"
 	}
 }
 

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -151,6 +151,7 @@ func buildDoctorReport(cfg *config.Config, cfgLabel string) doctorReport {
 		checkDoctorMCPBinaryIntegrity(cfg),
 		checkDoctorMCPToolProvenance(cfg),
 		checkDoctorFileSentry(cfg),
+		checkDoctorFlightRecorder(cfg),
 		checkDoctorLicense(cfg),
 		checkDoctorSentry(cfg),
 		checkDoctorDeploymentBoundary(cfg),
@@ -603,6 +604,37 @@ func checkDoctorFileSentry(cfg *config.Config) doctorReportCheck {
 	check.Reachable = true
 	check.Detail = "watch paths are readable, but wrapper/sidecar lifecycle still must be proven"
 	return check
+}
+
+func checkDoctorFlightRecorder(cfg *config.Config) doctorReportCheck {
+	if !cfg.FlightRecorder.Enabled {
+		return doctorReportCheck{
+			Name:    "flight_recorder",
+			Surface: doctorSurfaceConfig,
+			Status:  doctorStatusInfo,
+			Detail:  "disabled",
+			Next:    "enable flight_recorder to emit signed decision receipts",
+		}
+	}
+	if cfg.FlightRecorder.Dir == "" {
+		return doctorReportCheck{
+			Name:       "flight_recorder",
+			Surface:    doctorSurfaceConfig,
+			Status:     doctorStatusWarn,
+			Configured: true,
+			Detail:     "flight_recorder is enabled but dir is unset; no receipts will be written",
+			Next:       "set flight_recorder.dir to a writable directory so receipts are persisted",
+		}
+	}
+	return doctorReportCheck{
+		Name:       "flight_recorder",
+		Surface:    doctorSurfaceConfig,
+		Status:     doctorStatusOK,
+		Configured: true,
+		Reachable:  pathReadable(cfg.FlightRecorder.Dir),
+		Enforcing:  true,
+		Detail:     "flight_recorder is enabled with a configured directory",
+	}
 }
 
 func checkDoctorSentry(cfg *config.Config) doctorReportCheck {

--- a/internal/cli/selfupdate/cmd.go
+++ b/internal/cli/selfupdate/cmd.go
@@ -52,6 +52,9 @@ Examples:
   pipelock update --rollback           # restore the previous binary
   pipelock update --insecure-skip-signature`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if checkOnly && doRollOut {
+				return fmt.Errorf("use only one of --check / --rollback")
+			}
 			opts := &Options{
 				CurrentVersion:         cliutil.Version,
 				TargetVersion:          strings.TrimSpace(version),

--- a/internal/cli/selfupdate/cmd_test.go
+++ b/internal/cli/selfupdate/cmd_test.go
@@ -172,6 +172,21 @@ func TestRunCommand_ErrorJSONEmitsStatus(t *testing.T) {
 	}
 }
 
+func TestCmd_CheckAndRollbackMutuallyExclusive(t *testing.T) {
+	cmd := Cmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--check", "--rollback"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --check and --rollback are both set")
+	}
+	if !strings.Contains(err.Error(), "use only one of --check / --rollback") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // readFile is a tiny test helper.
 func readFile(path string) (string, error) {
 	b, err := os.ReadFile(path) // #nosec G304 -- test reads its own temp file

--- a/internal/cli/support/bundle.go
+++ b/internal/cli/support/bundle.go
@@ -55,7 +55,7 @@ Secret handling before inclusion:
   - License tokens, bearer tokens, API keys → <redacted>
   - Private key material (CA key, signing keys) → presence noted only
   - Environment variable values → names only, never values
-  - Webhook URLs → userinfo and token query params → <redacted>
+  - Webhook URLs → userinfo, path, fragment, and token query params → <redacted>
   - Audit-log lines with remaining secret-shaped content → <redacted>
 
 The archive contains:

--- a/internal/cli/support/bundle.go
+++ b/internal/cli/support/bundle.go
@@ -397,13 +397,17 @@ func writeArchive(path string, m manifest, entries []bundleEntry) error {
 		return fmt.Errorf("marshalling manifest: %w", err)
 	}
 	manifestBytes = append(manifestBytes, '\n')
-	if err := tarWrite(tw, "manifest.json", manifestBytes); err != nil {
+	// Use a single timestamp for all entries so mtimes are consistent
+	// and never in the future (avoids "time stamp in the future" warnings
+	// on extract). Truncate to seconds — tar headers have second resolution.
+	archiveTime := time.Now().UTC().Truncate(time.Second)
+	if err := tarWrite(tw, "manifest.json", manifestBytes, archiveTime); err != nil {
 		return err
 	}
 
 	// Write each collected entry.
 	for _, entry := range entries {
-		if err := tarWrite(tw, entry.name, entry.data); err != nil {
+		if err := tarWrite(tw, entry.name, entry.data, archiveTime); err != nil {
 			return err
 		}
 	}
@@ -414,13 +418,14 @@ func writeArchive(path string, m manifest, entries []bundleEntry) error {
 	return gw.Close()
 }
 
-// tarWrite adds a single file to the tar archive.
-func tarWrite(tw *tar.Writer, name string, data []byte) error {
+// tarWrite adds a single file to the tar archive. The mtime is set to the
+// provided timestamp so all entries share a consistent, non-future time.
+func tarWrite(tw *tar.Writer, name string, data []byte, mtime time.Time) error {
 	hdr := &tar.Header{
 		Name:    name,
 		Mode:    int64(bundleFileMode),
 		Size:    int64(len(data)),
-		ModTime: time.Now().UTC(),
+		ModTime: mtime,
 	}
 	if err := tw.WriteHeader(hdr); err != nil {
 		return fmt.Errorf("writing tar header for %s: %w", name, err)

--- a/internal/cli/support/bundle.go
+++ b/internal/cli/support/bundle.go
@@ -415,7 +415,10 @@ func writeArchive(path string, m manifest, entries []bundleEntry) error {
 	if err := tw.Close(); err != nil {
 		return fmt.Errorf("closing tar writer: %w", err)
 	}
-	return gw.Close()
+	if err := gw.Close(); err != nil {
+		return fmt.Errorf("closing gzip writer: %w", err)
+	}
+	return nil
 }
 
 // tarWrite adds a single file to the tar archive. The mtime is set to the

--- a/internal/cli/support/bundle_test.go
+++ b/internal/cli/support/bundle_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/cli/support"
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -664,6 +665,18 @@ func TestRedactURL(t *testing.T) {
 			wantSub: "region=us-east-1",
 			wantNot: []string{},
 		},
+		{
+			name:    "path secret stripped",
+			input:   "https://hooks.provider.example/services/T0123/B4567/pathsecretvalue",
+			wantSub: "hooks.provider.example",
+			wantNot: []string{"pathsecretvalue", "T0123", "B4567"},
+		},
+		{
+			name:    "fragment stripped",
+			input:   "https://hooks.provider.example/events#fragsecretvalue",
+			wantSub: "hooks.provider.example",
+			wantNot: []string{"fragsecretvalue"},
+		},
 	}
 
 	for _, tc := range cases {
@@ -733,6 +746,71 @@ func TestRedactHeaders(t *testing.T) {
 	// Non-secret header value SHOULD appear (used as a correlation ID in traces).
 	if !bytes.Contains(all, []byte("trace-123")) {
 		t.Errorf("non-secret X-Request-ID value 'trace-123' unexpectedly absent from bundle")
+	}
+}
+
+// TestBundle_NoFutureTimestamps verifies that all tar entry mtimes are at or
+// before the current time (no future timestamps that cause extract warnings).
+func TestBundle_NoFutureTimestamps(t *testing.T) {
+	t.Parallel()
+
+	archivePath := runBundleCmd(t, "")
+	now := time.Now().Add(time.Second) // 1s grace for test execution
+
+	f, err := os.Open(filepath.Clean(archivePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gr.Close() }()
+
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.ModTime.After(now) {
+			t.Errorf("entry %q has future mtime %v (now=%v)", hdr.Name, hdr.ModTime, now)
+		}
+	}
+}
+
+// TestBundle_NoSecretLeaks_WebhookURLPath verifies that webhook URL path
+// segments carrying provider secrets (e.g. /services/<T>/<B>/<SECRET>) are
+// redacted from config-summary.json and manifest.json in the bundle.
+func TestBundle_NoSecretLeaks_WebhookURLPath(t *testing.T) {
+	t.Parallel()
+
+	// Build a webhook URL with the secret in the path, not the query or userinfo.
+	pathSecret := "xoxb-" + "path-secret-value-1234"
+	webhookURL := "https://hooks.provider.example/services/T0123/B4567/" + pathSecret
+
+	tmp := t.TempDir()
+	yamlContent := "mode: balanced\ninternal: null\nemit:\n  webhook:\n    url: '" + webhookURL + "'\n"
+	cfgPath := filepath.Join(tmp, "pipelock.yaml")
+	if err := os.WriteFile(filepath.Clean(cfgPath), []byte(yamlContent), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	archivePath := runBundleCmd(t, cfgPath)
+	files := readArchive(t, archivePath)
+	all := archiveBytes(files)
+
+	if bytes.Contains(all, []byte(pathSecret)) {
+		t.Errorf("webhook URL path secret %q leaked into bundle", pathSecret)
+	}
+	// The host must still be visible for diagnostics.
+	if !bytes.Contains(all, []byte("hooks.provider.example")) {
+		t.Error("webhook URL host was unexpectedly stripped from bundle")
 	}
 }
 

--- a/internal/cli/support/redact.go
+++ b/internal/cli/support/redact.go
@@ -140,7 +140,21 @@ func redactURL(raw string) string {
 	}
 	// Strip userinfo (Basic auth credentials in URL).
 	if u.User != nil {
-		u.User = url.User("<redacted>")
+		u.User = url.User(redactedPlaceholder)
+	}
+	// Redact the path segment. Webhook providers encode their routing
+	// secret in the URL path (e.g. /services/<T>/<B>/<SECRET>), so
+	// shipping the path verbatim in a support bundle leaks the secret.
+	// Keep scheme+host for diagnostics; replace everything after.
+	if u.Path != "" && u.Path != "/" {
+		u.Path = "/" + redactedPlaceholder
+		u.RawPath = ""
+	}
+	// Strip the fragment — an operator could place routing or diagnostic
+	// metadata there, and the redactor's contract is to scrub the whole URL.
+	if u.Fragment != "" || u.RawFragment != "" {
+		u.Fragment = ""
+		u.RawFragment = ""
 	}
 	// Redact known secret query params, matching param NAMES case-insensitively
 	// (a key may be spelled Token or API_KEY just as easily as lowercase).

--- a/internal/cli/support/redact.go
+++ b/internal/cli/support/redact.go
@@ -126,9 +126,9 @@ func redactConfig(cfg *config.Config) map[string]any {
 	return out
 }
 
-// redactURL replaces userinfo (user:pass@) and known secret query params in
-// a URL with redactedPlaceholder, then returns the sanitised URL string.
-// Returns the original string unchanged if it cannot be parsed as a URL.
+// redactURL replaces userinfo (user:pass@), path, fragment, and known secret
+// query params in a URL with redactedPlaceholder, then returns the sanitised
+// URL string. Parse failures redact the whole value.
 func redactURL(raw string) string {
 	if raw == "" {
 		return ""

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -181,7 +181,10 @@ const (
 	// hard-blocked ordinary credential setup documentation ("provide your API
 	// key in config"). Imperative solicitations to the requester still block.
 	// Detection-relevant change.
-	goldenHashDefaults = "61c5bd3f1f3ef4b7c2adf22599528ca1efdd738b2ecbb49d1076bac1b92c6933"
+	// Re-bumped for removal of vestigial DeferConfig.ResolutionTriggers
+	// field. The field had zero runtime consumers (only validated/defaulted)
+	// and was dropped in v2.8 before any release shipped it.
+	goldenHashDefaults = "4d15bb5d19674cbf21f45b43b36035406d9d730e09ae71399042e72cdb310cbd"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -271,7 +274,7 @@ const (
 	// response-scanning pattern set, so the hash shifts in lockstep.
 	// Re-bumped for the defer section: held-action timeout and capacity
 	// bounds are policy semantics for action enforcement.
-	goldenHashRichConfig = "94d5487d33f8e748733e52f9f3354c5bdcd34b90c6bda428ce56ad225b5af64e"
+	goldenHashRichConfig = "26d7dbb0b32a79971a46119afcb2d51bb117a62832ff9d98a2e31530677ff595"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13476,3 +13476,35 @@ func TestEnvLicenseCRLMaxAgeDefaultParity(t *testing.T) {
 			cfg.LicenseCRLMaxAgeResolved, license.DefaultCRLMaxAge)
 	}
 }
+
+// TestLoad_StdinDash verifies that Load("-") reads config from stdin.
+func TestLoad_StdinDash(t *testing.T) {
+	yamlData := []byte("mode: balanced\ninternal: null\n")
+
+	// Create a pipe to simulate stdin.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Write the config data and close the write end.
+	if _, err := w.Write(yamlData); err != nil {
+		_ = r.Close()
+		_ = w.Close()
+		t.Fatal(err)
+	}
+	_ = w.Close()
+
+	// Replace os.Stdin for the duration of this call.
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	cfg, err := Load("-")
+	_ = r.Close()
+	if err != nil {
+		t.Fatalf("Load('-') error: %v", err)
+	}
+	if cfg.Mode != ModeBalanced {
+		t.Fatalf("Load('-') mode = %q, want %q", cfg.Mode, ModeBalanced)
+	}
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -363,7 +363,6 @@ func Defaults() *Config {
 			MaxPending:           64,
 			MaxPendingPerSession: 8,
 			MaxPendingBytes:      1024 * 1024,
-			ResolutionTriggers:   []string{"tool_inventory_updated", "policy_reload", "session_context_updated"},
 		},
 		GitProtection: GitProtection{
 			Enabled:         false,

--- a/internal/config/defer_test.go
+++ b/internal/config/defer_test.go
@@ -4,6 +4,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -79,11 +81,6 @@ func TestValidateDeferSettingsRejectInvalidValues(t *testing.T) {
 			name: "max pending bytes",
 			mut:  func(c *Config) { c.Defer.MaxPendingBytes = 0 },
 			want: "defer.max_pending_bytes must be positive",
-		},
-		{
-			name: "unknown resolution trigger",
-			mut:  func(c *Config) { c.Defer.ResolutionTriggers = []string{"unknown"} },
-			want: "invalid defer resolution_triggers value",
 		},
 	}
 	for _, tt := range tests {
@@ -251,6 +248,24 @@ func TestValidateDeferDisabledRejectsMCPToolPolicy(t *testing.T) {
 	_, err := cfg.ValidateWithWarnings()
 	if err == nil || !strings.Contains(err.Error(), "defer.enabled must be true") {
 		t.Fatalf("ValidateWithWarnings() error = %v, want defer.enabled error", err)
+	}
+}
+
+func TestDeferResolutionTriggersFieldRemoved(t *testing.T) {
+	// A config that sets defer.resolution_triggers must fail the strict
+	// unknown-field decode, proving the vestigial field has been removed.
+	yaml := []byte("mode: balanced\ndefer:\n  resolution_triggers:\n    - tool_inventory_updated\n")
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, yaml, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("Load() succeeded, want error for unknown field resolution_triggers")
+	}
+	if !strings.Contains(err.Error(), "resolution_triggers") {
+		t.Fatalf("Load() error = %v, want error mentioning resolution_triggers", err)
 	}
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -22,10 +22,20 @@ import (
 )
 
 // Load reads, parses, defaults, and validates a Pipelock config file.
+// If path is "-", the config is read from stdin.
 func Load(path string) (*Config, error) {
-	data, err := os.ReadFile(filepath.Clean(path))
-	if err != nil {
-		return nil, fmt.Errorf("reading config %s: %w", path, err)
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading config from stdin: %w", err)
+		}
+	} else {
+		data, err = os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			return nil, fmt.Errorf("reading config %s: %w", path, err)
+		}
 	}
 
 	cfg := &Config{}

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -295,9 +295,6 @@ func (c *Config) ApplyDefaults() {
 	if c.Defer.MaxPendingBytes <= 0 {
 		c.Defer.MaxPendingBytes = 1024 * 1024
 	}
-	if len(c.Defer.ResolutionTriggers) == 0 {
-		c.Defer.ResolutionTriggers = []string{"tool_inventory_updated", "policy_reload", "session_context_updated"}
-	}
 	if c.RequestPolicy.OnParseError == "" {
 		c.RequestPolicy.OnParseError = ActionBlock
 	}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -604,12 +604,11 @@ type MCPToolPolicy struct {
 // DeferConfig configures per-action held authorization for supported MCP
 // transports. Unsupported synchronous transports reject action=defer.
 type DeferConfig struct {
-	Enabled              bool     `yaml:"enabled"`
-	TimeoutSeconds       int      `yaml:"timeout_seconds"`
-	MaxPending           int      `yaml:"max_pending"`
-	MaxPendingPerSession int      `yaml:"max_pending_per_session"`
-	MaxPendingBytes      int      `yaml:"max_pending_bytes"`
-	ResolutionTriggers   []string `yaml:"resolution_triggers"`
+	Enabled              bool `yaml:"enabled"`
+	TimeoutSeconds       int  `yaml:"timeout_seconds"`
+	MaxPending           int  `yaml:"max_pending"`
+	MaxPendingPerSession int  `yaml:"max_pending_per_session"`
+	MaxPendingBytes      int  `yaml:"max_pending_bytes"`
 }
 
 // DeferResolutionPolicy defines which affirmative signals may turn a held

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -943,16 +943,6 @@ func (c *Config) validateDefer() error {
 	if c.Defer.MaxPendingBytes <= 0 {
 		return fmt.Errorf("defer.max_pending_bytes must be positive")
 	}
-	allowedTriggers := map[string]bool{
-		"tool_inventory_updated":  true,
-		"policy_reload":           true,
-		"session_context_updated": true,
-	}
-	for _, trigger := range c.Defer.ResolutionTriggers {
-		if !allowedTriggers[trigger] {
-			return fmt.Errorf("invalid defer resolution_triggers value %q", trigger)
-		}
-	}
 	return nil
 }
 

--- a/internal/signing/signing.go
+++ b/internal/signing/signing.go
@@ -6,10 +6,12 @@
 package signing
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -185,10 +187,21 @@ func EncodePrivateKey(key ed25519.PrivateKey) string {
 }
 
 // DecodePrivateKey deserializes a private key from the versioned format.
+// DecodePrivateKey accepts two formats:
+//  1. The 2-line versioned format: "pipelock-ed25519-private-v1\n<base64>"
+//  2. The JSON keyfile produced by "pipelock signing key generate":
+//     {"schema_version":1,"purpose":"...","private":"<hex>", ...}
+//
+// Detection is by content: a leading '{' (after whitespace trim) selects JSON.
 func DecodePrivateKey(encoded string) (ed25519.PrivateKey, error) {
-	lines := strings.SplitN(strings.TrimSpace(encoded), "\n", 2)
+	trimmed := strings.TrimSpace(encoded)
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		return decodePrivateKeyJSON([]byte(trimmed))
+	}
+
+	lines := strings.SplitN(trimmed, "\n", 2)
 	if len(lines) != 2 || lines[0] != privateKeyHeader {
-		return nil, fmt.Errorf("invalid private key format (expected %s header)", privateKeyHeader)
+		return nil, fmt.Errorf("invalid private key format (expected %s header or JSON keyfile)", privateKeyHeader)
 	}
 
 	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(lines[1]))
@@ -199,6 +212,53 @@ func DecodePrivateKey(encoded string) (ed25519.PrivateKey, error) {
 		return nil, fmt.Errorf("invalid private key length: got %d, want %d", len(raw), ed25519.PrivateKeySize)
 	}
 	return ed25519.PrivateKey(raw), nil
+}
+
+// decodePrivateKeyJSON extracts an ed25519 private key from the JSON keyfile
+// format produced by "pipelock signing key generate". The private key is
+// stored as a 128-char hex string.
+func decodePrivateKeyJSON(data []byte) (ed25519.PrivateKey, error) {
+	// Minimal struct matching the keyfile schema fields we need.
+	var kf struct {
+		SchemaVersion int    `json:"schema_version"`
+		Private       string `json:"private"`
+		Public        string `json:"public"`
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	if err := dec.Decode(&kf); err != nil {
+		return nil, fmt.Errorf("decoding JSON private key file: %w", err)
+	}
+	if kf.SchemaVersion != 1 {
+		return nil, fmt.Errorf("unsupported JSON key file schema_version %d (expected 1)", kf.SchemaVersion)
+	}
+	if kf.Private == "" {
+		return nil, fmt.Errorf("JSON key file missing private field")
+	}
+	privBytes, err := hex.DecodeString(kf.Private)
+	if err != nil {
+		return nil, fmt.Errorf("decoding JSON key file private hex: %w", err)
+	}
+	if len(privBytes) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("JSON key file private key has wrong size: got %d, want %d", len(privBytes), ed25519.PrivateKeySize)
+	}
+	priv := ed25519.PrivateKey(privBytes)
+	// Cross-check the public key if provided to detect tampered keyfiles.
+	// A present-but-malformed public field is itself a tamper signal, so we
+	// fail closed on it rather than silently skipping the check.
+	if kf.Public != "" {
+		pubBytes, pubErr := hex.DecodeString(kf.Public)
+		if pubErr != nil {
+			return nil, fmt.Errorf("decoding JSON key file public hex: %w", pubErr)
+		}
+		if len(pubBytes) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("JSON key file public key has wrong size: got %d, want %d", len(pubBytes), ed25519.PublicKeySize)
+		}
+		derivedPub, ok := priv.Public().(ed25519.PublicKey)
+		if !ok || !bytes.Equal(derivedPub, pubBytes) {
+			return nil, fmt.Errorf("JSON key file private key does not match public key")
+		}
+	}
+	return priv, nil
 }
 
 // atomicWrite writes data to path via a temporary file and rename.

--- a/internal/signing/signing.go
+++ b/internal/signing/signing.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -226,6 +227,12 @@ func decodePrivateKeyJSON(data []byte) (ed25519.PrivateKey, error) {
 	}
 	dec := json.NewDecoder(bytes.NewReader(data))
 	if err := dec.Decode(&kf); err != nil {
+		return nil, fmt.Errorf("decoding JSON private key file: %w", err)
+	}
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); err == nil {
+		return nil, fmt.Errorf("decoding JSON private key file: trailing data after key object")
+	} else if !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("decoding JSON private key file: %w", err)
 	}
 	if kf.SchemaVersion != 1 {

--- a/internal/signing/signing_test.go
+++ b/internal/signing/signing_test.go
@@ -323,6 +323,8 @@ func TestDecodePrivateKey_JSONKeyFileMalformed(t *testing.T) {
 		name  string
 		input string
 	}{
+		{"malformed JSON syntax", `{broken json`},
+		{"trailing JSON data", `{"schema_version":1,"private":"aa"} true`},
 		{"wrong schema version", `{"schema_version":99,"private":"aa","public":"bb"}`},
 		{"empty private field", `{"schema_version":1,"private":"","public":"bb"}`},
 		{"bad hex in private", `{"schema_version":1,"private":"not-hex","public":"bb"}`},

--- a/internal/signing/signing_test.go
+++ b/internal/signing/signing_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -286,6 +287,137 @@ func TestDecodePrivateKey_InvalidFormat(t *testing.T) {
 				t.Fatalf("expected error for input %q", tt.name)
 			}
 		})
+	}
+}
+
+// TestDecodePrivateKey_JSONKeyFile verifies that DecodePrivateKey accepts the
+// JSON keyfile format produced by "pipelock signing key generate".
+func TestDecodePrivateKey_JSONKeyFile(t *testing.T) {
+	_, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+
+	jsonKeyFile := fmt.Sprintf(`{
+  "schema_version": 1,
+  "purpose": "receipt-signing",
+  "key_id": "receipt-signing-test",
+  "public": %q,
+  "private": %q,
+  "created_at": "2026-01-01T00:00:00Z"
+}`, hex.EncodeToString(pub), hex.EncodeToString(priv))
+
+	loaded, err := DecodePrivateKey(jsonKeyFile)
+	if err != nil {
+		t.Fatalf("DecodePrivateKey(JSON keyfile) error: %v", err)
+	}
+	if !bytes.Equal(priv, loaded) {
+		t.Fatal("loaded key does not match original")
+	}
+}
+
+// TestDecodePrivateKey_JSONKeyFileMalformed verifies fail-closed for bad JSON keyfiles.
+func TestDecodePrivateKey_JSONKeyFileMalformed(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"wrong schema version", `{"schema_version":99,"private":"aa","public":"bb"}`},
+		{"empty private field", `{"schema_version":1,"private":"","public":"bb"}`},
+		{"bad hex in private", `{"schema_version":1,"private":"not-hex","public":"bb"}`},
+		{"wrong private length", `{"schema_version":1,"private":"aabb","public":"cc"}`},
+		{"public key mismatch", func() string {
+			// Generate a real key, then pair it with a different public key.
+			_, p, _ := GenerateKeyPair()
+			wrongPub := make([]byte, ed25519.PublicKeySize)
+			wrongPub[0] = 0xff // guaranteed to differ from derived pub
+			return fmt.Sprintf(`{"schema_version":1,"private":"%s","public":"%s"}`,
+				hex.EncodeToString(p), hex.EncodeToString(wrongPub))
+		}()},
+		{"bad hex in public", func() string {
+			// Valid private key but a present, non-hex public field: a tamper
+			// signal that must fail closed, not be silently skipped.
+			_, p, _ := GenerateKeyPair()
+			return fmt.Sprintf(`{"schema_version":1,"private":"%s","public":"not-hex"}`,
+				hex.EncodeToString(p))
+		}()},
+		{"wrong size public", func() string {
+			// Valid private key but a present public field of the wrong length.
+			_, p, _ := GenerateKeyPair()
+			return fmt.Sprintf(`{"schema_version":1,"private":"%s","public":"aabb"}`,
+				hex.EncodeToString(p))
+		}()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodePrivateKey(tt.input)
+			if err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+// TestLoadPrivateKeyFile_JSONKeyFile verifies that LoadPrivateKeyFile (the consumer
+// used by flight_recorder.signing_key_path) accepts the JSON keyfile format
+// produced by "pipelock signing key generate".
+func TestLoadPrivateKeyFile_JSONKeyFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission check uses Unix mode bits")
+	}
+	_, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+
+	jsonKeyFile := fmt.Sprintf(`{
+  "schema_version": 1,
+  "purpose": "receipt-signing",
+  "key_id": "receipt-signing-test",
+  "public": %q,
+  "private": %q,
+  "created_at": "2026-01-01T00:00:00Z"
+}`, hex.EncodeToString(pub), hex.EncodeToString(priv))
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "receipt-key.json")
+	if err := os.WriteFile(path, []byte(jsonKeyFile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadPrivateKeyFile(path)
+	if err != nil {
+		t.Fatalf("LoadPrivateKeyFile(JSON keyfile) error: %v", err)
+	}
+	if !bytes.Equal(priv, loaded) {
+		t.Fatal("loaded key does not match original")
+	}
+}
+
+// TestLoadPrivateKeyFile_TwoLineFormat confirms the existing 2-line format still works.
+func TestLoadPrivateKeyFile_TwoLineFormat(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission check uses Unix mode bits")
+	}
+	_, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "receipt.key")
+	if err := SavePrivateKey(priv, path); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadPrivateKeyFile(path)
+	if err != nil {
+		t.Fatalf("LoadPrivateKeyFile(2-line format) error: %v", err)
+	}
+	if !bytes.Equal(priv, loaded) {
+		t.Fatal("loaded key does not match original")
 	}
 }
 


### PR DESCRIPTION
## What changed

Five operability, UX, and security fixes surfaced by stress-testing the build. Independent of the scanner fail-open PR (different files, no conflict).

- Remove the dead `defer.resolution_triggers` config knob. It had zero runtime consumers (only validated, defaulted, backfilled), vestigial from an event-trigger design dropped before ship. The shipped model uses per-rule `resolution_policy` plus a timeout backstop. `defer` is unreleased, so removal has no backward-compat cost; strict decode now rejects the field.
- Redact the URL path and fragment in support bundles (security). `redactURL` stripped userinfo and secret query params but shipped the URL path verbatim in `config-summary.json` and `manifest.json`. Providers that encode their routing secret in the path (`/services/<T>/<B>/<SECRET>`) leaked it into a bundle meant to be attached to public bug reports. The path and fragment are now replaced with a placeholder; scheme and host are kept for diagnostics. Applies to every URL field the bundle emits (webhook, OTLP endpoint, syslog).
- Accept the JSON keyfile format in the trusted key load path. `signing key generate` writes a JSON keyfile, but `flight_recorder.signing_key_path` loaded only the 2-line versioned format, so the documented generator produced a key the recorder rejected. `DecodePrivateKey` and `LoadPrivateKeyFile` now accept both formats (detected by content). The file-permission gate is unchanged, and malformed or tampered keyfiles (bad schema, empty/bad-hex/wrong-size private, present-but-malformed or mismatched public) fail closed.
- Support `--config -` to read config from stdin for `check`, `doctor`, and `explain` (previously documented but unsupported).
- Surface operator-visibility advisories in `check`. Inert `suppress:` rules and an enabled-but-inert flight recorder (dir unset) were only reported by `doctor` or at startup; `check` now emits the same non-fatal advisories (exit code unchanged).
- Support-bundle housekeeping: archive entries get non-future mtimes (no future-timestamp extract warnings), and `update --check --rollback` now errors instead of silently picking one.

No new dependencies. Vendor-neutral throughout.

Do not merge yet. For review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `check` now emits non-fatal configuration advisories
  * Diagnostics now include `flight_recorder` status (info/warn/ok/fail)
  * Config loading supports `Load("-")` via stdin
  * Private key loading supports JSON keyfile format
* **Improvements**
  * Support bundle URL redaction now removes sensitive data from URL paths and fragments
  * Bundle archive timestamps are consistent (no future mtimes)
  * `defer.resolution_triggers` is no longer accepted in config
* **Bug Fixes**
  * Update/upgrade rejects using `--check` and `--rollback` together
<!-- end of auto-generated comment: release notes by coderabbit.ai -->