### PR TITLE
feat(playground): live-demo spend controls + polish

### DIFF
--- a/cmd/pipelock-playground-live/main.go
+++ b/cmd/pipelock-playground-live/main.go
@@ -141,6 +141,9 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 		Addr:              f.listen,
 		Handler:           handler,
 		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    16 << 10,
 	}
 	return httpSrv.ListenAndServe()
 }
@@ -183,6 +186,9 @@ func buildServer(out io.Writer, f *serveFlags) (*livechat.Server, http.Handler, 
 
 	llmAgent, err := buildLLMAgentConfig(f)
 	if err != nil {
+		return nil, nil, err
+	}
+	if err := validateServeSafety(f, llmAgent != nil); err != nil {
 		return nil, nil, err
 	}
 
@@ -228,6 +234,25 @@ func buildServer(out io.Writer, f *serveFlags) (*livechat.Server, http.Handler, 
 		_, _ = fmt.Fprintf(out, "serving viewer from %s at /\n", f.staticDir)
 	}
 	return srv, handler, nil
+}
+
+func validateServeSafety(f *serveFlags, modelBacked bool) error {
+	if f.maxPerCode < 0 {
+		return errors.New("--max-per-code must be >= 0")
+	}
+	if f.dailyTurnBudget < 0 {
+		return errors.New("--daily-turn-budget must be >= 0")
+	}
+	if f.maxMessagesPerSession < 0 {
+		return errors.New("--max-messages-per-session must be >= 0")
+	}
+	if !f.dev && !f.requireContainment {
+		return errors.New("non-dev serve requires containment; use --dev for local uncontained testing")
+	}
+	if modelBacked && !f.dev && f.dailyTurnBudget <= 0 {
+		return errors.New("model-backed public serve requires --daily-turn-budget > 0 (or --dev for local testing)")
+	}
+	return nil
 }
 
 // buildLLMAgentConfig assembles the model-backed agent config from the model
@@ -297,6 +322,9 @@ func resolveSecret(b64, file string) ([]byte, error) {
 func resolveCodes(out interface{ Write([]byte) (int, error) }, f *serveFlags) ([]livechat.CodeSpec, error) {
 	specs := make([]livechat.CodeSpec, 0, len(f.codes))
 	for _, c := range f.codes {
+		if strings.TrimSpace(c) == "" {
+			return nil, errors.New("invite code cannot be empty or whitespace")
+		}
 		specs = append(specs, livechat.CodeSpec{Code: c, MaxSessions: f.maxPerCode})
 	}
 	if len(specs) == 0 {

--- a/cmd/pipelock-playground-live/main.go
+++ b/cmd/pipelock-playground-live/main.go
@@ -54,32 +54,34 @@ func newRootCmd() *cobra.Command {
 }
 
 type serveFlags struct {
-	listen             string
-	codes              []string
-	maxPerCode         int
-	concurrency        int
-	requireContainment bool
-	dev                bool
-	orchestratorKey    string
-	toyAgentBin        string
-	webToolBin         string
-	sessionTTL         time.Duration
-	maxInputBytes      int
-	ipRate             float64
-	ipBurst            float64
-	codeRate           float64
-	codeBurst          float64
-	allowOrigin        string
-	trustForwardedFor  bool
-	secretB64          string
-	secretFile         string
-	staticDir          string
-	llmAgentBin        string
-	modelBaseURL       string
-	model              string
-	modelSecretFile    string
-	modelMaxSteps      int
-	modelTimeout       time.Duration
+	listen                string
+	codes                 []string
+	maxPerCode            int
+	concurrency           int
+	requireContainment    bool
+	dev                   bool
+	orchestratorKey       string
+	toyAgentBin           string
+	webToolBin            string
+	sessionTTL            time.Duration
+	maxInputBytes         int
+	ipRate                float64
+	ipBurst               float64
+	codeRate              float64
+	codeBurst             float64
+	allowOrigin           string
+	trustForwardedFor     bool
+	secretB64             string
+	secretFile            string
+	staticDir             string
+	llmAgentBin           string
+	modelBaseURL          string
+	model                 string
+	modelSecretFile       string
+	modelMaxSteps         int
+	modelTimeout          time.Duration
+	dailyTurnBudget       int
+	maxMessagesPerSession int
 }
 
 // defaultMaxPerCode is the safe default lifetime session budget per invite code.
@@ -123,6 +125,8 @@ func newServeCmd() *cobra.Command {
 	fl.StringVar(&f.modelSecretFile, "model-secret-file", "", "path to a file holding the model API key (kept out of argv); required to enable the model-backed agent")
 	fl.IntVar(&f.modelMaxSteps, "model-max-steps", 0, "max model/tool steps per turn (0 = default)")
 	fl.DurationVar(&f.modelTimeout, "model-timeout", 0, "per model/tool request timeout (0 = default)")
+	fl.IntVar(&f.dailyTurnBudget, "daily-turn-budget", 0, "hard global ceiling on total visitor turns (model calls) per UTC day, the spend kill switch (0 = unlimited; set a positive value for public exposure)")
+	fl.IntVar(&f.maxMessagesPerSession, "max-messages-per-session", 0, "max messages one session may send (0 = default of 40)")
 	return cmd
 }
 
@@ -183,19 +187,21 @@ func buildServer(out io.Writer, f *serveFlags) (*livechat.Server, http.Handler, 
 	}
 
 	srv, err := livechat.NewServer(livechat.ServerConfig{
-		Gate:                gate,
-		Limits:              livechat.Limits{MaxInputBytes: f.maxInputBytes, SessionTTL: f.sessionTTL},
-		IPRate:              livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
-		CodeRate:            livechat.RateConfig{RefillPerSec: f.codeRate, Burst: f.codeBurst},
-		MaxConcurrent:       f.concurrency,
-		RequireContainment:  requireContainment,
-		Containment:         verifier,
-		OrchestratorKeyPath: f.orchestratorKey,
-		ToyAgentBin:         f.toyAgentBin,
-		WebToolBin:          f.webToolBin,
-		TrustForwardedFor:   f.trustForwardedFor,
-		AllowOrigin:         f.allowOrigin,
-		LLMAgent:            llmAgent,
+		Gate:                  gate,
+		Limits:                livechat.Limits{MaxInputBytes: f.maxInputBytes, SessionTTL: f.sessionTTL},
+		IPRate:                livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
+		CodeRate:              livechat.RateConfig{RefillPerSec: f.codeRate, Burst: f.codeBurst},
+		MaxConcurrent:         f.concurrency,
+		RequireContainment:    requireContainment,
+		Containment:           verifier,
+		OrchestratorKeyPath:   f.orchestratorKey,
+		ToyAgentBin:           f.toyAgentBin,
+		WebToolBin:            f.webToolBin,
+		TrustForwardedFor:     f.trustForwardedFor,
+		AllowOrigin:           f.allowOrigin,
+		LLMAgent:              llmAgent,
+		DailyTurnBudget:       f.dailyTurnBudget,
+		MaxMessagesPerSession: f.maxMessagesPerSession,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/cmd/pipelock-playground-live/main_test.go
+++ b/cmd/pipelock-playground-live/main_test.go
@@ -144,6 +144,14 @@ func TestResolveCodes_NoCodesNotDev(t *testing.T) {
 	}
 }
 
+func TestResolveCodes_BlankCodeRejected(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	if _, err := resolveCodes(&out, &serveFlags{codes: []string{" \t"}, maxPerCode: defaultMaxPerCode}); err == nil {
+		t.Error("expected error: blank invite code")
+	}
+}
+
 func TestResolveCodes_DevGenerates(t *testing.T) {
 	t.Parallel()
 	var out bytes.Buffer
@@ -203,7 +211,7 @@ func TestNewRootCmd_HasSubcommands(t *testing.T) {
 func TestNewServeCmd_RegistersFlags(t *testing.T) {
 	t.Parallel()
 	cmd := newServeCmd()
-	for _, name := range []string{"listen", "code", "max-per-code", "dev", "require-containment", "secret", "secret-file", "static-dir", "session-ttl"} {
+	for _, name := range []string{"listen", "code", "max-per-code", "dev", "require-containment", "secret", "secret-file", "static-dir", "session-ttl", "daily-turn-budget", "max-messages-per-session"} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("serve missing --%s flag", name)
 		}
@@ -274,6 +282,63 @@ func TestBuildServer_StaticDirMux(t *testing.T) {
 	handler.ServeHTTP(rec2, httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/live/health", nil))
 	if rec2.Code != http.StatusOK {
 		t.Errorf("api/live/health under static mux: code=%d", rec2.Code)
+	}
+}
+
+func TestBuildServer_PublicModelRequiresDailyBudget(t *testing.T) {
+	t.Parallel()
+	f := devServeFlags()
+	f.dev = false
+	f.requireContainment = true
+	f.codes = []string{"good"}
+	f.llmAgentBin = "/usr/local/bin/pipelock-playground-llm-agent"
+	f.modelBaseURL = "http://provider.example/v1"
+	f.model = "test-model"
+	f.modelSecretFile = filepath.Join(t.TempDir(), "model.key")
+
+	var out bytes.Buffer
+	if _, _, err := buildServer(&out, f); err == nil {
+		t.Fatal("model-backed non-dev server without daily budget should fail closed")
+	}
+
+	f.dailyTurnBudget = 10
+	srv, handler, err := buildServer(&out, f)
+	if err != nil {
+		t.Fatalf("model-backed non-dev server with daily budget: %v", err)
+	}
+	if srv == nil || handler == nil {
+		t.Fatal("nil server/handler")
+	}
+	defer srv.Close()
+}
+
+func TestBuildServer_NonDevRequiresContainment(t *testing.T) {
+	t.Parallel()
+	f := devServeFlags()
+	f.dev = false
+	f.requireContainment = false
+	f.codes = []string{"good"}
+	var out bytes.Buffer
+	if _, _, err := buildServer(&out, f); err == nil {
+		t.Fatal("non-dev uncontained server should fail closed")
+	}
+}
+
+func TestValidateServeSafety_RejectsNegativeCaps(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		f    serveFlags
+	}{
+		{name: "max_per_code", f: serveFlags{maxPerCode: -1}},
+		{name: "daily_budget", f: serveFlags{dailyTurnBudget: -1}},
+		{name: "session_messages", f: serveFlags{maxMessagesPerSession: -1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateServeSafety(&tc.f, false); err == nil {
+				t.Fatal("expected error")
+			}
+		})
 	}
 }
 

--- a/docs/guides/playground-live-chat.md
+++ b/docs/guides/playground-live-chat.md
@@ -1,0 +1,78 @@
+# Playground live chat: operator controls
+
+The live-chat playground (`pipelock-playground-live serve`) lets a visitor talk to
+a real model-backed agent and watch Pipelock mediate the agent's actual requests
+in real time, streaming a signed decision for every action. Unlike the recorded
+replay demo, every visitor message drives a real model API call, so it costs money
+and is an attack surface. This page covers the controls an operator uses to run it
+safely.
+
+> The agent is provider-neutral: any OpenAI-compatible `/chat/completions` endpoint
+> (base URL, model name, bearer key). The agent only ever holds a synthetic,
+> per-run canary, never real credentials.
+
+## Running it
+
+```bash
+pipelock-playground-live serve \
+  --listen 0.0.0.0:8099 \
+  --code <invite-code> \
+  --llm-agent-bin /usr/local/bin/pipelock-playground-llm-agent \
+  --model-base-url https://api.provider.example/v1 \
+  --model <model-name> \
+  --model-secret-file /run/secrets/model.key \
+  --daily-turn-budget 2000 \
+  --max-messages-per-session 40
+```
+
+Omitting the `--llm-agent-bin`/`--model-*` flags runs the deterministic
+(non-model) agent instead. The model API key is read from `--model-secret-file`
+(a path), never passed on the command line.
+
+## Safety and abuse controls
+
+These are layered: the rate limiters bound how *fast* the demo can be driven, and
+the budgets bound the *total*. Public exposure should set all of them.
+
+| Control | Flag | What it bounds |
+|---|---|---|
+| Invite-code gate | `--code` (repeatable), `--max-per-code` | Who can start a session; lifetime sessions per code |
+| Global concurrency | `--concurrency` | Simultaneous live sessions |
+| Per-IP / per-code rate | `--ip-rate`/`--ip-burst`, `--code-rate`/`--code-burst` | Request rate per client / per code |
+| Session wall-clock | `--session-ttl` | How long one session lasts |
+| Input size | `--max-input-bytes` | Size of one message |
+| **Per-session message cap** | `--max-messages-per-session` | Messages (model calls) per session. Default 40. |
+| **Daily spend kill switch** | `--daily-turn-budget` | **Hard ceiling on total turns (model calls) per UTC day.** When spent, messages are refused until the next UTC day. |
+
+### Why the daily budget matters
+
+Rate limits alone are not a spend ceiling: a flood of distinct codes or IPs, each
+under its own per-client limit, still adds up to an unbounded model bill. The
+daily turn budget is the hard backstop. Once the day's budget is spent, the demo
+refuses further messages (HTTP 503, "paused until tomorrow") and resets at the UTC
+day boundary. A value of `0` means unlimited and must only be used for local/dev
+runs. `/api/live/health` reports `budget_remaining`.
+
+## Containment posture
+
+- `--require-containment` (default) refuses to start a session unless host kernel
+  containment is established and verified. Use this for any exposed deployment.
+- `--dev` runs **uncontained** and says so loudly. The detection and enforcement
+  controls (egress allowlist, DLP, signed receipts) still apply, but the host
+  kernel does not block an out-of-band egress path. Never use `--dev` for public
+  exposure.
+
+The model-backed agent runs as a separate, proxy-only subprocess: its transport
+may dial only the Pipelock proxy, so its model calls and tool calls are all
+mediated. This is a transport-level guarantee; where the host provides kernel
+containment, that no-bypass property is attested separately. Egress for a
+model-agent run is restricted to the lab targets and the model API host; any other
+destination is refused.
+
+## Deployment guidance
+
+Run the public instance on isolated cloud infrastructure (a separate account/org),
+not on shared or homelab hardware: the demo is a deliberately jailbreakable agent
+behind a public endpoint, so its blast radius should be disposable and account-
+isolated. The frontend is static and can be served separately. See the playground
+cost/hosting plan for the recommended topology.

--- a/docs/guides/playground-live-chat.md
+++ b/docs/guides/playground-live-chat.md
@@ -51,7 +51,13 @@ under its own per-client limit, still adds up to an unbounded model bill. The
 daily turn budget is the hard backstop. Once the day's budget is spent, the demo
 refuses further messages (HTTP 503, "paused until tomorrow") and resets at the UTC
 day boundary. A value of `0` means unlimited and must only be used for local/dev
-runs. `/api/live/health` reports `budget_remaining`.
+runs. The server refuses to enable the model-backed agent outside `--dev` unless
+`--daily-turn-budget` is positive. `/api/live/health` reports
+`budget_remaining`.
+
+The in-process budget protects one live server process. Public deployments should
+also set an account/provider spend cap, because a process restart or a multi-node
+deployment is outside that local counter.
 
 ## Containment posture
 
@@ -67,7 +73,9 @@ may dial only the Pipelock proxy, so its model calls and tool calls are all
 mediated. This is a transport-level guarantee; where the host provides kernel
 containment, that no-bypass property is attested separately. Egress for a
 model-agent run is restricted to the lab targets and the model API host; any other
-destination is refused.
+destination is refused. The model provider authorization header is allowed only to
+the configured `/chat/completions` endpoint; lab target requests remain scanned
+and blocked on credential-shaped payloads.
 
 ## Deployment guidance
 
@@ -76,3 +84,10 @@ not on shared or homelab hardware: the demo is a deliberately jailbreakable agen
 behind a public endpoint, so its blast radius should be disposable and account-
 isolated. The frontend is static and can be served separately. See the playground
 cost/hosting plan for the recommended topology.
+
+For the reverse proxy/CDN in front of the server:
+
+- Do not log query strings for `/api/live/stream`; the SSE token is a short-lived
+  bearer token in the URL query.
+- Set `--trust-forwarded-for` only when the server is reachable exclusively
+  through that trusted proxy/CDN.

--- a/internal/playground/live_llm_internal_test.go
+++ b/internal/playground/live_llm_internal_test.go
@@ -485,6 +485,18 @@ func TestModelRun_EgressAllowlistEnforced(t *testing.T) {
 	if st := doProxiedGet(t.Context(), client, modelRoot); st != http.StatusOK {
 		t.Errorf("GET allowlisted model host status = %d, want 200", st)
 	}
+	providerKey := "sk-" + "proj-" + strings.Repeat("a", 24)
+	modelHeaders := map[string]string{
+		"Authorization": "Bearer " + providerKey,
+		"Content-Type":  "application/json",
+	}
+	modelChatURL := strings.TrimRight(modelBase, "/") + "/chat/completions"
+	if st := doProxiedRequest(t.Context(), client, http.MethodPost, modelChatURL, []byte(`{"model":"test"}`), modelHeaders); st != http.StatusOK {
+		t.Errorf("POST model chat endpoint with provider auth status = %d, want 200", st)
+	}
+	if st := doProxiedRequest(t.Context(), client, http.MethodGet, lr.liveSafeURL(), nil, map[string]string{"Authorization": "Bearer " + providerKey}); st < http.StatusBadRequest {
+		t.Errorf("provider-shaped auth header to lab target status = %d, want a 4xx DLP block", st)
+	}
 
 	// Blocked: a host outside the allowlist is refused (pre-DNS), so a jailbroken
 	// model cannot egress to an arbitrary destination through the lab proxy.
@@ -878,27 +890,28 @@ func main() {
 // --- small request helpers ---
 
 func doProxiedGet(ctx context.Context, client *http.Client, rawURL string) int {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-	if err != nil {
-		return 0
-	}
-	req.Header.Set(proxy.AgentHeader, liveRunActor)
-	resp, err := client.Do(req)
-	if err != nil {
-		return 0
-	}
-	_, _ = io.Copy(io.Discard, resp.Body)
-	_ = resp.Body.Close()
-	return resp.StatusCode
+	return doProxiedRequest(ctx, client, http.MethodGet, rawURL, nil, nil)
 }
 
 func doProxiedPost(ctx context.Context, client *http.Client, rawURL string, body []byte) int {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	return doProxiedRequest(ctx, client, http.MethodPost, rawURL, body, map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	})
+}
+
+func doProxiedRequest(ctx context.Context, client *http.Client, method, rawURL string, body []byte, headers map[string]string) int {
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, rdr)
 	if err != nil {
 		return 0
 	}
 	req.Header.Set(proxy.AgentHeader, liveRunActor)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0

--- a/internal/playground/livechat/budget.go
+++ b/internal/playground/livechat/budget.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package livechat
+
+import (
+	"sync"
+	"time"
+)
+
+// DailyBudget is the global spend kill switch for the live playground. Every
+// visitor message drives a real model call that costs money, so per-code and
+// per-IP rate limits (which bound the RATE) are not enough on their own: a flood
+// of distinct codes/IPs, each under its own limit, still adds up. DailyBudget is
+// the hard ceiling on TOTAL turns per UTC day. Once the day's count reaches the
+// cap, Charge fails closed until the next UTC day, so a busy (or abusive) day
+// cannot run an unbounded model bill.
+//
+// A cap of 0 means unlimited (no global ceiling) — only for --dev / local runs.
+// Public exposure MUST set a positive cap.
+type DailyBudget struct {
+	mu    sync.Mutex
+	cap   int
+	day   string
+	count int
+	now   func() time.Time // injectable for tests
+}
+
+// NewDailyBudget returns a budget capping total charges per UTC day. limit <= 0
+// disables the ceiling (unlimited).
+func NewDailyBudget(limit int) *DailyBudget {
+	return &DailyBudget{cap: limit, now: time.Now}
+}
+
+// dayKey is the UTC calendar day a time falls in. The budget resets when this
+// changes, so the cap is a per-UTC-day ceiling.
+func dayKey(t time.Time) string {
+	return t.UTC().Format("2006-01-02")
+}
+
+// Charge records one unit against today's budget and reports whether it fit. It
+// resets the count at the UTC day boundary. With an unlimited cap (<= 0) it always
+// allows and records nothing. Fail-closed semantics: at the cap, it returns false
+// WITHOUT incrementing, so a rejected charge does not consume tomorrow's headroom.
+func (b *DailyBudget) Charge() bool {
+	if b == nil || b.cap <= 0 {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	today := dayKey(b.now())
+	if today != b.day {
+		b.day = today
+		b.count = 0
+	}
+	if b.count >= b.cap {
+		return false
+	}
+	b.count++
+	return true
+}
+
+// Remaining reports today's remaining budget, or -1 when unlimited.
+func (b *DailyBudget) Remaining() int {
+	if b == nil || b.cap <= 0 {
+		return -1
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if dayKey(b.now()) != b.day {
+		return b.cap
+	}
+	if b.count >= b.cap {
+		return 0
+	}
+	return b.cap - b.count
+}
+
+// Open reports whether the budget has headroom right now (without charging).
+func (b *DailyBudget) Open() bool {
+	if b == nil || b.cap <= 0 {
+		return true
+	}
+	return b.Remaining() > 0
+}

--- a/internal/playground/livechat/budget.go
+++ b/internal/playground/livechat/budget.go
@@ -16,7 +16,7 @@ import (
 // cap, Charge fails closed until the next UTC day, so a busy (or abusive) day
 // cannot run an unbounded model bill.
 //
-// A cap of 0 means unlimited (no global ceiling) — only for --dev / local runs.
+// A cap of 0 means unlimited (no global ceiling) - only for --dev / local runs.
 // Public exposure MUST set a positive cap.
 type DailyBudget struct {
 	mu    sync.Mutex
@@ -58,6 +58,22 @@ func (b *DailyBudget) Charge() bool {
 	}
 	b.count++
 	return true
+}
+
+// Refund returns one already-admitted charge to today's budget. It is used only
+// when the server reserved budget but the session was already sealed before the
+// turn could start. Refund never creates extra headroom: it only decrements a
+// positive count for the same UTC day.
+func (b *DailyBudget) Refund() {
+	if b == nil || b.cap <= 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if dayKey(b.now()) != b.day || b.count <= 0 {
+		return
+	}
+	b.count--
 }
 
 // Remaining reports today's remaining budget, or -1 when unlimited.

--- a/internal/playground/livechat/budget_test.go
+++ b/internal/playground/livechat/budget_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package livechat
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestDailyBudget_Unlimited(t *testing.T) {
+	t.Parallel()
+	b := NewDailyBudget(0)
+	for i := 0; i < 5; i++ {
+		if !b.Charge() {
+			t.Fatal("cap 0 must be unlimited")
+		}
+	}
+	if b.Remaining() != -1 {
+		t.Errorf("unlimited Remaining = %d, want -1", b.Remaining())
+	}
+	if !b.Open() {
+		t.Error("unlimited Open must be true")
+	}
+
+	// A nil budget also allows (a server without a budget configured).
+	var nb *DailyBudget
+	if !nb.Charge() || !nb.Open() || nb.Remaining() != -1 {
+		t.Error("nil budget must allow and report unlimited")
+	}
+}
+
+func TestDailyBudget_CapAndDailyReset(t *testing.T) {
+	t.Parallel()
+	day1 := time.Date(2026, 6, 17, 10, 0, 0, 0, time.UTC)
+	b := NewDailyBudget(2)
+	b.now = func() time.Time { return day1 }
+
+	if !b.Charge() {
+		t.Fatal("first charge must fit cap 2")
+	}
+	if !b.Charge() {
+		t.Fatal("second charge must fit cap 2")
+	}
+	if b.Charge() {
+		t.Error("third charge must fail at the cap")
+	}
+	if b.Remaining() != 0 {
+		t.Errorf("Remaining at cap = %d, want 0", b.Remaining())
+	}
+	if b.Open() {
+		t.Error("Open at cap must be false")
+	}
+
+	// Crossing into the next UTC day resets the count.
+	b.now = func() time.Time { return day1.Add(24 * time.Hour) }
+	if b.Remaining() != 2 {
+		t.Errorf("Remaining after daily reset = %d, want 2", b.Remaining())
+	}
+	if !b.Open() || !b.Charge() {
+		t.Error("budget must reopen on a new UTC day")
+	}
+}
+
+func TestLiveEntry_TryMessage(t *testing.T) {
+	t.Parallel()
+	e := &liveEntry{}
+	if !e.tryMessage(2) {
+		t.Fatal("first message must fit cap 2")
+	}
+	if !e.tryMessage(2) {
+		t.Fatal("second message must fit cap 2")
+	}
+	if e.tryMessage(2) {
+		t.Error("third message must be refused at the cap")
+	}
+	// cap 0 is unlimited.
+	u := &liveEntry{}
+	for i := 0; i < 10; i++ {
+		if !u.tryMessage(0) {
+			t.Fatal("cap 0 must be unlimited")
+		}
+	}
+}
+
+// --- HTTP integration: the caps refuse over budget without driving a turn ---
+
+func createLiveSession(t *testing.T, ts string, code string) string {
+	t.Helper()
+	resp := postJSON(t, ts+RouteSession, createReq{Code: code})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("session create status = %d, want 200", resp.StatusCode)
+	}
+	var cr createResp
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	return cr.Token
+}
+
+func sendLiveMessage(t *testing.T, ts, token, msg string) int {
+	t.Helper()
+	resp := postJSON(t, ts+RouteMessage, messageReq{Token: token, Message: msg})
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
+}
+
+func TestServer_DailyTurnBudget_KillSwitch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a real proxy per session")
+	}
+	ts := newTestServer(t, ServerConfig{DailyTurnBudget: 1})
+	token := createLiveSession(t, ts.URL, "good")
+
+	if st := sendLiveMessage(t, ts.URL, token, "hello"); st != http.StatusAccepted {
+		t.Fatalf("first message status = %d, want 202", st)
+	}
+	// The day's single-turn budget is spent: the next message is refused (paused).
+	if st := sendLiveMessage(t, ts.URL, token, "again"); st != http.StatusServiceUnavailable {
+		t.Errorf("over-budget message status = %d, want 503", st)
+	}
+}
+
+func TestServer_PerSessionMessageCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a real proxy per session")
+	}
+	ts := newTestServer(t, ServerConfig{MaxMessagesPerSession: 1})
+	token := createLiveSession(t, ts.URL, "good")
+
+	if st := sendLiveMessage(t, ts.URL, token, "hello"); st != http.StatusAccepted {
+		t.Fatalf("first message status = %d, want 202", st)
+	}
+	// This session has used its one-message budget.
+	if st := sendLiveMessage(t, ts.URL, token, "again"); st != http.StatusTooManyRequests {
+		t.Errorf("over-cap message status = %d, want 429", st)
+	}
+}

--- a/internal/playground/livechat/budget_test.go
+++ b/internal/playground/livechat/budget_test.go
@@ -64,6 +64,30 @@ func TestDailyBudget_CapAndDailyReset(t *testing.T) {
 	}
 }
 
+func TestDailyBudget_RefundSameDayOnly(t *testing.T) {
+	t.Parallel()
+	day1 := time.Date(2026, 6, 17, 10, 0, 0, 0, time.UTC)
+	b := NewDailyBudget(2)
+	b.now = func() time.Time { return day1 }
+
+	if !b.Charge() || b.Remaining() != 1 {
+		t.Fatalf("initial charge failed or remaining = %d, want 1", b.Remaining())
+	}
+	b.Refund()
+	if b.Remaining() != 2 {
+		t.Fatalf("refund remaining = %d, want 2", b.Remaining())
+	}
+
+	if !b.Charge() {
+		t.Fatal("second charge failed")
+	}
+	b.now = func() time.Time { return day1.Add(24 * time.Hour) }
+	b.Refund()
+	if b.Remaining() != 2 {
+		t.Fatalf("cross-day refund must not affect new day, remaining = %d", b.Remaining())
+	}
+}
+
 func TestLiveEntry_TryMessage(t *testing.T) {
 	t.Parallel()
 	e := &liveEntry{}
@@ -75,6 +99,10 @@ func TestLiveEntry_TryMessage(t *testing.T) {
 	}
 	if e.tryMessage(2) {
 		t.Error("third message must be refused at the cap")
+	}
+	e.refundMessage(2)
+	if !e.tryMessage(2) {
+		t.Error("refund should return one message slot")
 	}
 	// cap 0 is unlimited.
 	u := &liveEntry{}
@@ -121,6 +149,31 @@ func TestServer_DailyTurnBudget_KillSwitch(t *testing.T) {
 	// The day's single-turn budget is spent: the next message is refused (paused).
 	if st := sendLiveMessage(t, ts.URL, token, "again"); st != http.StatusServiceUnavailable {
 		t.Errorf("over-budget message status = %d, want 503", st)
+	}
+	resp := postJSON(t, ts.URL+RouteSession, createReq{Code: "good"})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("new session after spent budget status = %d, want 503", resp.StatusCode)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+RouteHealth, nil)
+	if err != nil {
+		t.Fatalf("new health request: %v", err)
+	}
+	healthResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	defer func() { _ = healthResp.Body.Close() }()
+	var health map[string]any
+	if err := json.NewDecoder(healthResp.Body).Decode(&health); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if ok, _ := health["ok"].(bool); ok {
+		t.Fatalf("health ok after spent budget = true, want false: %+v", health)
+	}
+	if rem, _ := health["budget_remaining"].(float64); rem != 0 {
+		t.Fatalf("budget_remaining = %v, want 0", health["budget_remaining"])
 	}
 }
 

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -45,6 +45,14 @@ type ServerConfig struct {
 	CodeRate RateConfig
 	// MaxConcurrent caps simultaneous live sessions (global). Never unlimited.
 	MaxConcurrent int
+	// DailyTurnBudget is the hard global ceiling on total visitor turns (model
+	// calls) per UTC day -- the spend kill switch. 0 = unlimited (dev/local only;
+	// public exposure MUST set a positive value). When the day's budget is spent,
+	// further messages are refused until the next UTC day.
+	DailyTurnBudget int
+	// MaxMessagesPerSession caps how many messages one session may send (each is a
+	// real model call). 0 = unlimited. Defaults applied in NewServer.
+	MaxMessagesPerSession int
 	// RequireContainment is passed to each session. Public exposure MUST be true.
 	RequireContainment bool
 	// Containment proves kernel containment per session. Required (non-nil) when
@@ -77,19 +85,45 @@ type liveEntry struct {
 
 	streamMu sync.Mutex
 	streamOn bool
+
+	msgMu    sync.Mutex
+	msgCount int
+}
+
+// tryMessage atomically admits one message against the per-session cap. cap <= 0
+// means unlimited. It returns false (without counting) once the session has used
+// its budget, so the check has no TOCTOU under concurrent messages.
+func (e *liveEntry) tryMessage(limit int) bool {
+	if limit <= 0 {
+		return true
+	}
+	e.msgMu.Lock()
+	defer e.msgMu.Unlock()
+	if e.msgCount >= limit {
+		return false
+	}
+	e.msgCount++
+	return true
 }
 
 // Server is the live-chat HTTP/SSE front door.
 type Server struct {
-	cfg      ServerConfig
-	limits   Limits
-	ipRate   *RateLimiter
-	codeRate *RateLimiter
-	conc     *ConcurrencyLimiter
+	cfg              ServerConfig
+	limits           Limits
+	ipRate           *RateLimiter
+	codeRate         *RateLimiter
+	conc             *ConcurrencyLimiter
+	budget           *DailyBudget
+	maxMsgPerSession int
 
 	mu       sync.Mutex
 	sessions map[string]*liveEntry
 }
+
+// defaultMaxMessagesPerSession bounds one session's model calls when the operator
+// does not set MaxMessagesPerSession. Matches the playground cost plan's 40-message
+// session cap.
+const defaultMaxMessagesPerSession = 40
 
 // NewServer builds the server. It returns an error (fail-closed at startup) when
 // the gate is missing, or containment is required but no verifier is supplied.
@@ -100,13 +134,19 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	if cfg.RequireContainment && cfg.Containment == nil {
 		return nil, errors.New("livechat: RequireContainment set but no ContainmentVerifier supplied")
 	}
+	maxMsg := cfg.MaxMessagesPerSession
+	if maxMsg == 0 {
+		maxMsg = defaultMaxMessagesPerSession
+	}
 	return &Server{
-		cfg:      cfg,
-		limits:   cfg.Limits.Clamp(),
-		ipRate:   NewRateLimiter(cfg.IPRate),
-		codeRate: NewRateLimiter(cfg.CodeRate),
-		conc:     NewConcurrencyLimiter(cfg.MaxConcurrent),
-		sessions: make(map[string]*liveEntry),
+		cfg:              cfg,
+		limits:           cfg.Limits.Clamp(),
+		ipRate:           NewRateLimiter(cfg.IPRate),
+		codeRate:         NewRateLimiter(cfg.CodeRate),
+		conc:             NewConcurrencyLimiter(cfg.MaxConcurrent),
+		budget:           NewDailyBudget(cfg.DailyTurnBudget),
+		maxMsgPerSession: maxMsg,
+		sessions:         make(map[string]*liveEntry),
 	}, nil
 }
 
@@ -122,10 +162,11 @@ func (s *Server) Handler() http.Handler {
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
-		"ok":        s.cfg.Gate.Open(),
-		"in_use":    s.conc.InUse(),
-		"capacity":  s.conc.Cap(),
-		"contained": s.cfg.RequireContainment,
+		"ok":               s.cfg.Gate.Open() && s.budget.Open(),
+		"in_use":           s.conc.InUse(),
+		"capacity":         s.conc.Cap(),
+		"contained":        s.cfg.RequireContainment,
+		"budget_remaining": s.budget.Remaining(),
 	})
 }
 
@@ -358,6 +399,16 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 	entry := s.lookup(claims.SessionID)
 	if entry == nil {
 		writeErr(w, http.StatusNotFound, "session not found")
+		return
+	}
+	// Per-session message cap: each message is a real model call.
+	if !entry.tryMessage(s.maxMsgPerSession) {
+		writeErr(w, http.StatusTooManyRequests, "session message limit reached")
+		return
+	}
+	// Global daily spend kill switch: hard ceiling on total turns per UTC day.
+	if !s.budget.Charge() {
+		writeErr(w, http.StatusServiceUnavailable, "daily limit reached, the demo is paused until tomorrow")
 		return
 	}
 	if err := entry.sess.Send(r.Context(), body.Message); err != nil {

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -51,7 +51,7 @@ type ServerConfig struct {
 	// further messages are refused until the next UTC day.
 	DailyTurnBudget int
 	// MaxMessagesPerSession caps how many messages one session may send (each is a
-	// real model call). 0 = unlimited. Defaults applied in NewServer.
+	// real model call). 0 = the conservative default applied in NewServer.
 	MaxMessagesPerSession int
 	// RequireContainment is passed to each session. Public exposure MUST be true.
 	RequireContainment bool
@@ -106,6 +106,19 @@ func (e *liveEntry) tryMessage(limit int) bool {
 	return true
 }
 
+// refundMessage returns one reserved message slot. It is intentionally narrow:
+// only call it when no turn could have started.
+func (e *liveEntry) refundMessage(limit int) {
+	if limit <= 0 {
+		return
+	}
+	e.msgMu.Lock()
+	defer e.msgMu.Unlock()
+	if e.msgCount > 0 {
+		e.msgCount--
+	}
+}
+
 // Server is the live-chat HTTP/SSE front door.
 type Server struct {
 	cfg              ServerConfig
@@ -134,6 +147,12 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	if cfg.RequireContainment && cfg.Containment == nil {
 		return nil, errors.New("livechat: RequireContainment set but no ContainmentVerifier supplied")
 	}
+	if cfg.DailyTurnBudget < 0 {
+		return nil, errors.New("livechat: DailyTurnBudget must be >= 0")
+	}
+	if cfg.MaxMessagesPerSession < 0 {
+		return nil, errors.New("livechat: MaxMessagesPerSession must be >= 0")
+	}
 	maxMsg := cfg.MaxMessagesPerSession
 	if maxMsg == 0 {
 		maxMsg = defaultMaxMessagesPerSession
@@ -160,7 +179,16 @@ func (s *Server) Handler() http.Handler {
 	return mux
 }
 
-func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	s.setCORS(w)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ok":               s.cfg.Gate.Open() && s.budget.Open(),
 		"in_use":           s.conc.InUse(),
@@ -204,6 +232,10 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.Code == "" {
 		writeErr(w, http.StatusUnauthorized, "invite code required")
+		return
+	}
+	if !s.budget.Open() {
+		writeErr(w, http.StatusServiceUnavailable, "daily limit reached, the demo is paused until tomorrow")
 		return
 	}
 
@@ -408,10 +440,15 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	// Global daily spend kill switch: hard ceiling on total turns per UTC day.
 	if !s.budget.Charge() {
+		entry.refundMessage(s.maxMsgPerSession)
 		writeErr(w, http.StatusServiceUnavailable, "daily limit reached, the demo is paused until tomorrow")
 		return
 	}
 	if err := entry.sess.Send(r.Context(), body.Message); err != nil {
+		if errors.Is(err, playground.ErrSessionClosed) {
+			entry.refundMessage(s.maxMsgPerSession)
+			s.budget.Refund()
+		}
 		writeErr(w, http.StatusInternalServerError, "send failed")
 		return
 	}

--- a/internal/playground/livechat/server_more_test.go
+++ b/internal/playground/livechat/server_more_test.go
@@ -80,20 +80,22 @@ func TestServer_CORSPreflight(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t, ServerConfig{AllowOrigin: "https://pipelab.org"})
 
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodOptions, ts.URL+RouteMessage, nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent {
-		t.Fatalf("preflight status = %d, want 204", resp.StatusCode)
-	}
-	if got := resp.Header.Get("Access-Control-Allow-Methods"); got != "GET, POST, OPTIONS" {
-		t.Errorf("methods = %q, want GET, POST, OPTIONS", got)
-	}
-	if got := resp.Header.Get("Access-Control-Allow-Headers"); got != "Content-Type" {
-		t.Errorf("headers = %q, want Content-Type", got)
+	for _, route := range []string{RouteMessage, RouteHealth} {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodOptions, ts.URL+route, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("%s preflight status = %d, want 204", route, resp.StatusCode)
+		}
+		if got := resp.Header.Get("Access-Control-Allow-Methods"); got != "GET, POST, OPTIONS" {
+			t.Errorf("%s methods = %q, want GET, POST, OPTIONS", route, got)
+		}
+		if got := resp.Header.Get("Access-Control-Allow-Headers"); got != "Content-Type" {
+			t.Errorf("%s headers = %q, want Content-Type", route, got)
+		}
 	}
 }
 

--- a/internal/playground/livechat/server_test.go
+++ b/internal/playground/livechat/server_test.go
@@ -75,6 +75,12 @@ func TestServer_NewServer_FailsClosed(t *testing.T) {
 	if _, err := NewServer(ServerConfig{Gate: g, RequireContainment: true}); err == nil {
 		t.Error("NewServer RequireContainment with nil verifier succeeded; want error (fail-closed)")
 	}
+	if _, err := NewServer(ServerConfig{Gate: g, DailyTurnBudget: -1}); err == nil {
+		t.Error("NewServer accepted negative DailyTurnBudget; want error")
+	}
+	if _, err := NewServer(ServerConfig{Gate: g, MaxMessagesPerSession: -1}); err == nil {
+		t.Error("NewServer accepted negative MaxMessagesPerSession; want error")
+	}
 }
 
 func TestServer_Session_MethodAndCodeChecks(t *testing.T) {

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -221,7 +221,6 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 
 	// --- Build pipelock config ---
 	cfg := config.Defaults()
-	cfg.Internal = nil // disable SSRF/DNS lookups
 	cfg.ForwardProxy.Enabled = true
 
 	// DNS host overrides: .test hosts -> loopback
@@ -255,6 +254,7 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 		}
 		cfg.Mode = config.ModeStrict
 		cfg.APIAllowlist = append(cfg.APIAllowlist, liveRunSafeHost, liveRunExfilHost, modelHost)
+		cfg.Suppress = append(cfg.Suppress, modelProviderAuthSuppressions(opts.ModelBaseURL)...)
 	}
 
 	cfg.ApplyDefaults()
@@ -703,7 +703,36 @@ func modelHostname(raw string) (string, error) {
 	if host == "" {
 		return "", fmt.Errorf("host is required")
 	}
-	return host, nil
+	return strings.TrimSuffix(strings.ToLower(host), "."), nil
+}
+
+var modelProviderAuthDLPPatterns = []string{
+	"Anthropic API Key",
+	"OpenAI API Key",
+	"OpenAI Service Key",
+	"Fireworks API Key",
+	"Google API Key",
+	"Hugging Face Token",
+	"Replicate API Token",
+	"Groq API Key",
+	"xAI API Key",
+}
+
+// modelProviderAuthSuppressions allows the playground's own model-provider
+// Authorization key to reach exactly the configured chat-completions endpoint.
+// Tool calls still cannot target the model host, and the lab collector/safe
+// targets remain fully scanned.
+func modelProviderAuthSuppressions(baseURL string) []config.SuppressEntry {
+	target := strings.TrimRight(baseURL, "/") + "/chat/completions"
+	out := make([]config.SuppressEntry, 0, len(modelProviderAuthDLPPatterns))
+	for _, rule := range modelProviderAuthDLPPatterns {
+		out = append(out, config.SuppressEntry{
+			Rule:   rule,
+			Path:   target,
+			Reason: "playground model provider authorization header",
+		})
+	}
+	return out
 }
 
 // portFromAddr extracts the port string from a net.Addr.

--- a/internal/playground/targets.go
+++ b/internal/playground/targets.go
@@ -387,8 +387,12 @@ func (c *Collector) SealAndSign(nonce string, colPriv ed25519.PrivateKey, drain 
 	return w, nil
 }
 
-// SafeTarget is a trivial HTTP target that returns a benign 200 response.
-// Used for the "allowed request" beat of the demo.
+// SafeTarget is a benign HTTP target for the "allowed request" beat of the demo.
+// It serves realistic-looking (but entirely synthetic) lab configuration so a
+// model-backed agent asked to "read the lab config" gets actual content to report
+// and finishes the turn, instead of probing path after path against a bare "ok"
+// and hitting the step limit. The body is DLP-clean by construction: no
+// credential-shaped values, so the read is allowed.
 type SafeTarget struct{}
 
 // NewSafeTarget creates a new SafeTarget.
@@ -396,10 +400,38 @@ func NewSafeTarget() *SafeTarget {
 	return &SafeTarget{}
 }
 
-// Handler returns the HTTP handler for the safe target.
+// safeTargetConfigJSON is the synthetic lab config the safe target serves. It
+// deliberately contains NO credential-shaped strings (the agent's only secret is
+// the planted canary, which lives elsewhere) so this read is always allowed.
+const safeTargetConfigJSON = `{
+  "service": "lab-config-service",
+  "environment": "sandbox",
+  "version": "1.4.2",
+  "region": "lab-local",
+  "features": {
+    "telemetry": false,
+    "debug_endpoints": true,
+    "experimental_ui": false
+  },
+  "limits": {
+    "max_requests_per_minute": 120,
+    "request_timeout_seconds": 30,
+    "max_payload_kb": 256
+  },
+  "logging": {
+    "level": "info",
+    "redact_pii": true
+  },
+  "note": "Synthetic lab configuration for the Pipelock playground. No real credentials are served here."
+}
+`
+
+// Handler returns the HTTP handler for the safe target. Every path serves the
+// synthetic config so the agent finds it on the first read regardless of the path
+// it guesses.
 func (s *SafeTarget) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		_, _ = fmt.Fprintf(w, "ok")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, safeTargetConfigJSON)
 	})
 }

--- a/internal/playground/targets_test.go
+++ b/internal/playground/targets_test.go
@@ -244,4 +244,12 @@ func TestSafeTarget_Returns200(t *testing.T) {
 	if len(body) == 0 {
 		t.Fatal("safe target body must not be empty")
 	}
+	// Serves realistic JSON config (not a bare "ok") so a model agent finds
+	// content on the first read instead of probing to the step limit.
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("safe target Content-Type = %q, want application/json", ct)
+	}
+	if len(body) < 50 {
+		t.Errorf("safe target should serve a config body, got %d bytes", len(body))
+	}
 }


### PR DESCRIPTION
## What changed

Follow-up to the live model-backed playground agent (#804). Adds the spend and abuse controls a public live demo needs, plus demo-quality polish and operator docs. Every visitor message drives a real model API call, so without a hard ceiling a flood of distinct codes or IPs (each under its own per-client rate limit) still adds up to an unbounded bill.

- **Daily spend kill switch** (`internal/playground/livechat/budget.go`): a hard global ceiling on total turns per UTC day. Once spent, messages are refused (HTTP 503, paused until tomorrow) and session creation is refused too, so a spent budget cannot be used to burn invite or concurrency capacity. Resets at the UTC day boundary. A value of 0 is unlimited and is rejected for non-dev model-backed serving.
- **Per-session message cap** (default 40), enforced atomically with no TOCTOU; refused with 429 over the cap.
- **Fail-closed serve validation**: non-dev serving requires containment, non-dev model-backed serving requires a positive daily budget, and negative caps are rejected at construction and on the CLI.
- **Safe target serves realistic synthetic config** instead of a bare "ok", so a model agent asked to read the lab config finds content on the first read and the benign turn resolves cleanly instead of probing to the step limit. The config is DLP-clean by construction (no credential-shaped values), so the read stays allowed.
- **Operator docs** (`docs/guides/playground-live-chat.md`): the controls, the containment posture, and the deploy guidance (run the public instance on isolated cloud, not shared hardware).

New `serve` flags: `--daily-turn-budget`, `--max-messages-per-session`. The budget is surfaced on `/api/live/health` as `budget_remaining`.

## Security notes

The model provider authorization header is allowed only to the configured `/chat/completions` endpoint via a destination-scoped suppress; the same provider-shaped key to any lab target is still DLP-blocked (regression-tested both ways). The egress allowlist for a model-agent run does not bypass content scanning: a credential-shaped body to an allowlisted host is still blocked.

The daily budget is process-local: it resets on restart and does not span replicas. A public deployment must also set a provider/account spend cap (or a shared durable budget store) as the real hard ceiling; this is called out in the docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Daily turn budget kill switch for the live-chat playground—limits model interactions per UTC day.
  * Per-session message caps to prevent abuse within individual conversations.
  * New CLI flags (`--daily-turn-budget`, `--max-messages-per-session`) for operators to control safety parameters.

* **Documentation**
  * Added comprehensive guide for running and safely operating the live-chat playground, covering containment options, abuse-prevention controls, and deployment best practices.

* **Improvements**
  * Enhanced HTTP server configuration with timeout and header size limits.
  * Improved model provider authorization handling.
  * Lab safe target now returns JSON configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->