### PR TITLE
fix(playground): harden live demo adversarial edges

### DIFF
--- a/cmd/pipelock-playground-live/main.go
+++ b/cmd/pipelock-playground-live/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -252,6 +253,38 @@ func validateServeSafety(f *serveFlags, modelBacked bool) error {
 	if modelBacked && !f.dev && f.dailyTurnBudget <= 0 {
 		return errors.New("model-backed public serve requires --daily-turn-budget > 0 (or --dev for local testing)")
 	}
+	if err := validateAllowOrigin(f.allowOrigin, f.dev); err != nil {
+		return fmt.Errorf("--allow-origin: %w", err)
+	}
+	return nil
+}
+
+func validateAllowOrigin(raw string, dev bool) error {
+	if raw == "" {
+		return nil
+	}
+	if strings.TrimSpace(raw) != raw {
+		return errors.New("must not contain surrounding whitespace")
+	}
+	if raw == "*" {
+		if dev {
+			return nil
+		}
+		return errors.New("wildcard is only allowed with --dev")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.New("must be an http(s) origin")
+	}
+	if u.Host == "" {
+		return errors.New("host is required")
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "" {
+		return errors.New("must be an origin only, like https://pipelab.org")
+	}
 	return nil
 }
 
@@ -284,6 +317,9 @@ func buildLLMAgentConfig(f *serveFlags) (*playground.LLMAgentConfig, error) {
 	if len(missing) > 0 {
 		return nil, fmt.Errorf("model-backed agent requires %s", strings.Join(missing, ", "))
 	}
+	if err := validateModelBaseURL(f.modelBaseURL); err != nil {
+		return nil, fmt.Errorf("--model-base-url: %w", err)
+	}
 	return &playground.LLMAgentConfig{
 		Bin:          f.llmAgentBin,
 		ModelBaseURL: f.modelBaseURL,
@@ -292,6 +328,26 @@ func buildLLMAgentConfig(f *serveFlags) (*playground.LLMAgentConfig, error) {
 		MaxSteps:     f.modelMaxSteps,
 		Timeout:      f.modelTimeout,
 	}, nil
+}
+
+func validateModelBaseURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.New("must use http or https")
+	}
+	if u.Host == "" {
+		return errors.New("host is required")
+	}
+	if u.User != nil {
+		return errors.New("must not include credentials")
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return errors.New("must not include query strings or fragments")
+	}
+	return nil
 }
 
 // resolveSecret picks the gate-signing secret. A --secret-file (base64 contents)

--- a/cmd/pipelock-playground-live/main.go
+++ b/cmd/pipelock-playground-live/main.go
@@ -317,7 +317,7 @@ func buildLLMAgentConfig(f *serveFlags) (*playground.LLMAgentConfig, error) {
 	if len(missing) > 0 {
 		return nil, fmt.Errorf("model-backed agent requires %s", strings.Join(missing, ", "))
 	}
-	if err := validateModelBaseURL(f.modelBaseURL); err != nil {
+	if _, err := playground.ValidatePlainHTTPURL(f.modelBaseURL); err != nil {
 		return nil, fmt.Errorf("--model-base-url: %w", err)
 	}
 	return &playground.LLMAgentConfig{
@@ -328,26 +328,6 @@ func buildLLMAgentConfig(f *serveFlags) (*playground.LLMAgentConfig, error) {
 		MaxSteps:     f.modelMaxSteps,
 		Timeout:      f.modelTimeout,
 	}, nil
-}
-
-func validateModelBaseURL(raw string) error {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return fmt.Errorf("parse: %w", err)
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return errors.New("must use http or https")
-	}
-	if u.Host == "" {
-		return errors.New("host is required")
-	}
-	if u.User != nil {
-		return errors.New("must not include credentials")
-	}
-	if u.RawQuery != "" || u.Fragment != "" {
-		return errors.New("must not include query strings or fragments")
-	}
-	return nil
 }
 
 // resolveSecret picks the gate-signing secret. A --secret-file (base64 contents)

--- a/cmd/pipelock-playground-live/main_test.go
+++ b/cmd/pipelock-playground-live/main_test.go
@@ -59,6 +59,27 @@ func TestBuildLLMAgentConfig(t *testing.T) {
 	if cfg == nil || cfg.Model != "test-model" || cfg.Bin == "" || cfg.SecretFile == "" {
 		t.Fatalf("full flags: unexpected cfg %+v", cfg)
 	}
+
+	credentialModelURL := "http://user:" + strings.ToLower("PASS") + "@provider.example/v1"
+	queryModelURL := "http://provider.example/v1?api_key=" + strings.ToLower("SECRET")
+	fragmentModelURL := "http://provider.example/v1#" + strings.ToLower("SECRET")
+	for _, raw := range []string{
+		credentialModelURL,
+		queryModelURL,
+		fragmentModelURL,
+	} {
+		t.Run("bad_model_url_"+raw, func(t *testing.T) {
+			_, err := buildLLMAgentConfig(&serveFlags{
+				llmAgentBin:     "/usr/local/bin/pipelock-playground-llm-agent",
+				modelBaseURL:    raw,
+				model:           "test-model",
+				modelSecretFile: keyPath,
+			})
+			if err == nil {
+				t.Fatal("want error for unsafe model base URL")
+			}
+		})
+	}
 }
 
 func TestResolveSecret_Generated(t *testing.T) {
@@ -337,6 +358,33 @@ func TestValidateServeSafety_RejectsNegativeCaps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := validateServeSafety(&tc.f, false); err == nil {
 				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestValidateServeSafety_AllowOrigin(t *testing.T) {
+	t.Parallel()
+	if err := validateServeSafety(&serveFlags{allowOrigin: "https://pipelab.org", dev: true}, false); err != nil {
+		t.Fatalf("exact origin rejected: %v", err)
+	}
+	if err := validateServeSafety(&serveFlags{allowOrigin: "*", dev: true}, false); err != nil {
+		t.Fatalf("dev wildcard rejected: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		f    serveFlags
+	}{
+		{name: "wildcard_nondev", f: serveFlags{allowOrigin: "*", requireContainment: true}},
+		{name: "path", f: serveFlags{allowOrigin: "https://pipelab.org/app", dev: true}},
+		{name: "query", f: serveFlags{allowOrigin: "https://pipelab.org?x=1", dev: true}},
+		{name: "fragment", f: serveFlags{allowOrigin: "https://pipelab.org#x", dev: true}},
+		{name: "whitespace", f: serveFlags{allowOrigin: " https://pipelab.org", dev: true}},
+		{name: "non_http", f: serveFlags{allowOrigin: "file:///tmp/viewer", dev: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateServeSafety(&tc.f, false); err == nil {
+				t.Fatal("expected unsafe allow-origin to be rejected")
 			}
 		})
 	}

--- a/cmd/pipelock-playground-llm-agent/main.go
+++ b/cmd/pipelock-playground-llm-agent/main.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/playground"
 	"github.com/luckyPipewrench/pipelock/internal/playground/llmagent"
 	"github.com/luckyPipewrench/pipelock/internal/proxy"
 )
@@ -211,14 +212,11 @@ func buildAgent(cfg config, apiKey string, emit func(llmagent.Event)) (*llmagent
 }
 
 func hostnameFromHTTPURL(raw string) (string, error) {
-	u, err := url.Parse(raw)
+	u, err := playground.ValidatePlainHTTPURL(raw)
 	if err != nil {
-		return "", fmt.Errorf("parse model base url: %w", err)
+		return "", fmt.Errorf("model base url: %w", err)
 	}
 	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
-	if host == "" {
-		return "", fmt.Errorf("model base url host is required")
-	}
 	return host, nil
 }
 
@@ -280,21 +278,8 @@ func proxyOnlyDialContext(want string, base dialFunc) dialFunc {
 }
 
 func validateHTTPURL(name, raw string) error {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return fmt.Errorf("%s: parse: %w", name, err)
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("%s: must use http or https", name)
-	}
-	if u.Host == "" {
-		return fmt.Errorf("%s: host is required", name)
-	}
-	if u.User != nil {
-		return fmt.Errorf("%s: must not include credentials", name)
-	}
-	if u.RawQuery != "" || u.Fragment != "" {
-		return fmt.Errorf("%s: must not include query strings or fragments", name)
+	if _, err := playground.ValidatePlainHTTPURL(raw); err != nil {
+		return fmt.Errorf("%s: %w", name, err)
 	}
 	return nil
 }

--- a/cmd/pipelock-playground-llm-agent/main.go
+++ b/cmd/pipelock-playground-llm-agent/main.go
@@ -191,13 +191,13 @@ func buildAgent(cfg config, apiKey string, emit func(llmagent.Event)) (*llmagent
 	if err != nil {
 		return nil, err
 	}
-	modelAuthority, err := authorityFromHTTPURL(cfg.modelBaseURL)
+	modelHost, err := hostnameFromHTTPURL(cfg.modelBaseURL)
 	if err != nil {
 		return nil, err
 	}
 	tools := llmagent.LabToolsWithConfig(client, map[string]string{proxy.AgentHeader: cfg.actor}, llmagent.ToolRuntimeConfig{
 		Canary:       cfg.canary,
-		BlockedHosts: []string{modelAuthority},
+		BlockedHosts: []string{modelHost},
 	})
 	mc := llmagent.ModelConfig{
 		BaseURL:      cfg.modelBaseURL,
@@ -210,15 +210,16 @@ func buildAgent(cfg config, apiKey string, emit func(llmagent.Event)) (*llmagent
 	return llmagent.New(mc, client, tools, emit), nil
 }
 
-func authorityFromHTTPURL(raw string) (string, error) {
+func hostnameFromHTTPURL(raw string) (string, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return "", fmt.Errorf("parse model base url: %w", err)
 	}
-	if u.Host == "" {
+	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+	if host == "" {
 		return "", fmt.Errorf("model base url host is required")
 	}
-	return u.Host, nil
+	return host, nil
 }
 
 func buildClient(proxyURL string, timeout time.Duration) (*http.Client, error) {
@@ -243,7 +244,13 @@ func buildClient(proxyURL string, timeout time.Duration) (*http.Client, error) {
 		base := &net.Dialer{Timeout: timeout}
 		tr.DialContext = proxyOnlyDialContext(proxyDialAddr(u), base.DialContext)
 	}
-	return &http.Client{Transport: tr, Timeout: timeout}, nil
+	return &http.Client{
+		Transport: tr,
+		Timeout:   timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}, nil
 }
 
 type dialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
@@ -285,6 +292,9 @@ func validateHTTPURL(name, raw string) error {
 	}
 	if u.User != nil {
 		return fmt.Errorf("%s: must not include credentials", name)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("%s: must not include query strings or fragments", name)
 	}
 	return nil
 }

--- a/cmd/pipelock-playground-llm-agent/main_test.go
+++ b/cmd/pipelock-playground-llm-agent/main_test.go
@@ -52,8 +52,21 @@ func TestParseFlags(t *testing.T) {
 	if _, err := parseFlags([]string{"--model-base-url", "http://m", "--model", "m", "--proxy-url", "file:///tmp/proxy"}, noEnv); err == nil {
 		t.Fatal("want error on non-http proxy URL")
 	}
-	if _, err := parseFlags([]string{"--model-base-url", "http://user:pass@m", "--model", "m"}, noEnv); err == nil {
+	credentialModelURL := "http://user:" + strings.ToLower("PASS") + "@m"
+	queryModelURL := "http://m/v1?api_key=" + strings.ToLower("SECRET")
+	fragmentModelURL := "http://m/v1#" + strings.ToLower("SECRET")
+	proxyQueryURL := "http://proxy.local:8080/?token=" + strings.ToLower("SECRET")
+	if _, err := parseFlags([]string{"--model-base-url", credentialModelURL, "--model", "m"}, noEnv); err == nil {
 		t.Fatal("want error on model URL with credentials")
+	}
+	if _, err := parseFlags([]string{"--model-base-url", queryModelURL, "--model", "m"}, noEnv); err == nil {
+		t.Fatal("want error on model URL with query string")
+	}
+	if _, err := parseFlags([]string{"--model-base-url", fragmentModelURL, "--model", "m"}, noEnv); err == nil {
+		t.Fatal("want error on model URL with fragment")
+	}
+	if _, err := parseFlags([]string{"--model-base-url", "http://m", "--model", "m", "--proxy-url", proxyQueryURL}, noEnv); err == nil {
+		t.Fatal("want error on proxy URL with query string")
 	}
 	if _, err := parseFlags([]string{"--model-base-url", "http://m", "--model", "m", "--safe-url", "://bad"}, noEnv); err == nil {
 		t.Fatal("want error on invalid safe URL")
@@ -135,10 +148,55 @@ func TestBuildClient(t *testing.T) {
 	}
 }
 
+func TestBuildClient_DoesNotFollowRedirects(t *testing.T) {
+	var targetHits int
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		targetHits++
+	}))
+	t.Cleanup(target.Close)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	c, err := buildClient("", 0)
+	if err != nil {
+		t.Fatalf("buildClient: %v", err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, redirector.URL, nil)
+	if err != nil {
+		t.Fatalf("new redirect request: %v", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("GET redirector: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302 without following redirect", resp.StatusCode)
+	}
+	if targetHits != 0 {
+		t.Fatalf("redirect target was reached %d time(s)", targetHits)
+	}
+}
+
 func TestBuildAgent_BadProxy(t *testing.T) {
 	cfg := config{modelBaseURL: "http://m", model: "m", proxyURL: "://bad"}
 	if _, err := buildAgent(cfg, "k", func(llmagent.Event) {}); err == nil {
 		t.Fatal("want error when proxy url is invalid")
+	}
+}
+
+func TestHostnameFromHTTPURL(t *testing.T) {
+	got, err := hostnameFromHTTPURL("https://API.DeepSeek.com.:8443/v1")
+	if err != nil {
+		t.Fatalf("hostnameFromHTTPURL: %v", err)
+	}
+	if got != "api.deepseek.com" {
+		t.Fatalf("hostnameFromHTTPURL = %q, want normalized hostname", got)
+	}
+	if _, err := hostnameFromHTTPURL("http://"); err == nil {
+		t.Fatal("want error when URL has no hostname")
 	}
 }
 
@@ -292,8 +350,12 @@ func TestRunLoop_ToolCannotTargetModelHost(t *testing.T) {
 		modelCalls++
 		bodies = append(bodies, string(raw))
 		if modelCalls == 1 {
+			targetHost, _, err := net.SplitHostPort(r.Host)
+			if err != nil {
+				t.Fatalf("split model host: %v", err)
+			}
 			argURL, _ := json.Marshal(map[string]string{
-				"url":  "http://" + r.Host + "/steal",
+				"url":  "http://" + net.JoinHostPort(targetHost, "1") + "/steal",
 				"data": "payload=" + llmagent.CanaryPlaceholder,
 			})
 			_, _ = fmt.Fprintf(w, `{"choices":[{"message":{"role":"assistant","tool_calls":[`+

--- a/docs/guides/playground-live-chat.md
+++ b/docs/guides/playground-live-chat.md
@@ -27,7 +27,10 @@ pipelock-playground-live serve \
 
 Omitting the `--llm-agent-bin`/`--model-*` flags runs the deterministic
 (non-model) agent instead. The model API key is read from `--model-secret-file`
-(a path), never passed on the command line.
+(a path), never passed on the command line. `--model-base-url` must be a plain
+HTTP(S) API root such as `https://api.provider.example/v1`; query strings,
+fragments, and URL credentials are rejected so provider secrets cannot end up in
+request URLs, logs, or receipts.
 
 ## Safety and abuse controls
 
@@ -91,3 +94,6 @@ For the reverse proxy/CDN in front of the server:
   bearer token in the URL query.
 - Set `--trust-forwarded-for` only when the server is reachable exclusively
   through that trusted proxy/CDN.
+- If the browser is served from a different origin, set `--allow-origin` to that
+  exact origin, such as `https://pipelab.org`. Wildcard CORS is rejected outside
+  `--dev`.

--- a/internal/playground/live_llm_internal_test.go
+++ b/internal/playground/live_llm_internal_test.go
@@ -130,6 +130,9 @@ func TestTargetHostPort(t *testing.T) {
 }
 
 func TestModelHostname(t *testing.T) {
+	credentialURL := "https://user:" + strings.ToLower("PASS") + "@model.api.test/v1"
+	queryURL := "https://model.api.test/v1?api_key=" + strings.ToLower("SECRET")
+	fragmentURL := "https://model.api.test/v1#" + strings.ToLower("SECRET")
 	tests := []struct {
 		name    string
 		in      string
@@ -137,8 +140,12 @@ func TestModelHostname(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "valid_http_with_port", in: "http://model.api.test:9000/v1", want: "model.api.test"},
+		{name: "trailing_dot_normalized", in: "https://MODEL.API.TEST.:8443/v1", want: "model.api.test"},
 		{name: "non_http_scheme", in: "ftp://nope/", wantErr: true},
 		{name: "missing_host", in: "http:///v1", wantErr: true},
+		{name: "credentials_rejected", in: credentialURL, wantErr: true},
+		{name: "query_rejected", in: queryURL, wantErr: true},
+		{name: "fragment_rejected", in: fragmentURL, wantErr: true},
 		{name: "unparseable", in: "://bad\x00url", wantErr: true},
 	}
 	for _, tc := range tests {

--- a/internal/playground/livechat/gate.go
+++ b/internal/playground/livechat/gate.go
@@ -145,11 +145,19 @@ func NewGate(cfg GateConfig) (*Gate, error) {
 		sum := sha256.Sum256([]byte(c.Code))
 		id := c.ID
 		if id == "" {
-			id = "code-" + base64.RawURLEncoding.EncodeToString(sum[:6])
+			id = defaultCodeID(g.secret, c.Code)
 		}
 		g.codes[sum] = &codeState{id: id, maxIssued: c.MaxSessions}
 	}
 	return g, nil
+}
+
+func defaultCodeID(secret []byte, code string) string {
+	m := hmac.New(sha256.New, secret)
+	m.Write([]byte("pipelock-livechat-code-id\x00"))
+	m.Write([]byte(code))
+	sum := m.Sum(nil)
+	return "code-" + base64.RawURLEncoding.EncodeToString(sum[:9])
 }
 
 // Open reports whether the gate can currently mint any session (has at least

--- a/internal/playground/livechat/gate_test.go
+++ b/internal/playground/livechat/gate_test.go
@@ -4,6 +4,8 @@
 package livechat
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"strings"
 	"sync"
@@ -301,12 +303,28 @@ func flipFirstChar(s string) string {
 // sanity: ensure codes are not stored or surfaced in the clear anywhere obvious.
 func TestGate_CodeIDNotEqualToCode(t *testing.T) {
 	t.Parallel()
-	g, _ := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "super-secret-code"}}})
-	_, claims, err := g.Redeem("super-secret-code", "s1")
+	code := "super-secret-code"
+	g, _ := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: code}}})
+	_, claims, err := g.Redeem(code, "s1")
 	if err != nil {
 		t.Fatalf("Redeem: %v", err)
 	}
-	if strings.Contains(claims.CodeID, "super-secret-code") {
+	if strings.Contains(claims.CodeID, code) {
 		t.Errorf("CodeID %q leaks the raw code", claims.CodeID)
+	}
+
+	rawHash := sha256.Sum256([]byte(code))
+	oldPublicID := "code-" + base64.RawURLEncoding.EncodeToString(rawHash[:6])
+	if claims.CodeID == oldPublicID {
+		t.Fatalf("CodeID %q must not be a public truncated hash of the invite code", claims.CodeID)
+	}
+
+	g2, _ := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: code}}})
+	_, claims2, err := g2.Redeem(code, "s2")
+	if err != nil {
+		t.Fatalf("Redeem second gate: %v", err)
+	}
+	if claims.CodeID == claims2.CodeID {
+		t.Fatalf("default CodeID should be bound to the gate secret, got %q twice", claims.CodeID)
 	}
 }

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -342,6 +342,11 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "streaming unsupported")
 		return
 	}
+	ip := s.clientIP(r)
+	if !s.ipRate.Allow("ip:" + ip) {
+		writeErr(w, http.StatusTooManyRequests, "rate limited")
+		return
+	}
 	claims, err := s.cfg.Gate.Validate(r.URL.Query().Get("token"))
 	if err != nil {
 		writeErr(w, http.StatusUnauthorized, "invalid or expired token")

--- a/internal/playground/livechat/server_more_test.go
+++ b/internal/playground/livechat/server_more_test.go
@@ -25,6 +25,31 @@ func TestServer_Message_MethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestServer_Stream_RateLimitedBeforeTokenValidation(t *testing.T) {
+	t.Parallel()
+	ts := newTestServer(t, ServerConfig{IPRate: RateConfig{RefillPerSec: 1, Burst: 1}})
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("first stream status = %d, want 401", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream, nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("second stream status = %d, want 429", resp.StatusCode)
+	}
+}
+
 func TestServer_Message_CodeRateLimited(t *testing.T) {
 	t.Parallel()
 	g, _ := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "good"}}, TokenTTL: time.Minute})

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -692,23 +691,11 @@ func (lr *LiveRun) Close() {
 // modelHostname extracts the hostname (no port) from a model API base URL, for
 // allowlisting and DNS-override keying. It requires an http(s) URL with a host.
 func modelHostname(raw string) (string, error) {
-	u, err := url.Parse(raw)
+	u, err := ValidatePlainHTTPURL(raw)
 	if err != nil {
-		return "", fmt.Errorf("parse: %w", err)
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return "", fmt.Errorf("must use http or https")
-	}
-	if u.User != nil {
-		return "", fmt.Errorf("must not include credentials")
-	}
-	if u.RawQuery != "" || u.Fragment != "" {
-		return "", fmt.Errorf("must not include query strings or fragments")
+		return "", err
 	}
 	host := u.Hostname()
-	if host == "" {
-		return "", fmt.Errorf("host is required")
-	}
 	return strings.TrimSuffix(strings.ToLower(host), "."), nil
 }
 

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -699,6 +699,12 @@ func modelHostname(raw string) (string, error) {
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return "", fmt.Errorf("must use http or https")
 	}
+	if u.User != nil {
+		return "", fmt.Errorf("must not include credentials")
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("must not include query strings or fragments")
+	}
 	host := u.Hostname()
 	if host == "" {
 		return "", fmt.Errorf("host is required")

--- a/internal/playground/llmagent/client_test.go
+++ b/internal/playground/llmagent/client_test.go
@@ -279,8 +279,8 @@ func TestLabToolsWithConfig_BlocksReservedHost(t *testing.T) {
 		t.Fatalf("result=%q ev=%+v, want local refusal", result, ev)
 	}
 
-	if toolTargetBlocked("http://127.0.0.1:2000/path", []string{"127.0.0.1:1000"}) {
-		t.Fatal("host:port reservation must not block a different port on the same host")
+	if !toolTargetBlocked("http://127.0.0.1:2000/path", []string{"127.0.0.1:1000"}) {
+		t.Fatal("host:port reservation must reserve the whole host")
 	}
 	if !toolTargetBlocked("https://api.deepseek.com:443/v1", []string{"api.deepseek.com"}) {
 		t.Fatal("hostname reservation must block the host regardless of port")
@@ -294,8 +294,8 @@ func TestLabToolsWithConfig_BlocksReservedHost(t *testing.T) {
 	if !toolTargetBlocked("http://api.deepseek.com/v1", []string{"api.deepseek.com:80"}) {
 		t.Fatal("default HTTP port must match an explicit host:80 reservation")
 	}
-	if toolTargetBlocked("https://api.deepseek.com:8443/v1", []string{"api.deepseek.com:443"}) {
-		t.Fatal("host:port reservation must not block a non-default different port")
+	if !toolTargetBlocked("https://api.deepseek.com:8443/v1", []string{"api.deepseek.com:443"}) {
+		t.Fatal("host:port reservation must block non-default ports on the same host")
 	}
 }
 

--- a/internal/playground/llmagent/tools.go
+++ b/internal/playground/llmagent/tools.go
@@ -45,9 +45,9 @@ type postArgs struct {
 type ToolRuntimeConfig struct {
 	// Canary is expanded only from CanaryPlaceholder inside post_data bodies.
 	Canary string
-	// BlockedHosts are hosts or host:port authorities the model may use for its own
-	// API calls but must not target with lab tools. This keeps an allowlisted HTTPS
-	// model API host from becoming an opaque CONNECT exfil sink.
+	// BlockedHosts are model API hosts the lab tools must not target. Host:port
+	// entries are accepted for caller convenience, but they still reserve the
+	// whole host because the playground model allowlist is host-scoped.
 	BlockedHosts []string
 }
 
@@ -122,9 +122,9 @@ func LabToolsWithConfig(client *http.Client, reqHeaders map[string]string, cfg T
 	}
 }
 
-// toolTargetBlocked reports whether rawURL targets a reserved model API host or
-// authority. It canonicalizes hostnames and default ports so spelling variants
-// like "host.", "https://host", and "https://host:443" cannot bypass the guard.
+// toolTargetBlocked reports whether rawURL targets a reserved model API host.
+// It canonicalizes hostname spellings so variants like "host.", "host:443",
+// and "[::1]" cannot bypass the host-wide guard.
 func toolTargetBlocked(rawURL string, blockedHosts []string) bool {
 	if len(blockedHosts) == 0 {
 		return false
@@ -137,14 +137,13 @@ func toolTargetBlocked(rawURL string, blockedHosts []string) bool {
 	if targetHost == "" {
 		return false
 	}
-	targetPort := effectivePort(u)
 	for _, blocked := range blockedHosts {
 		blocked = strings.TrimSpace(blocked)
 		if blocked == "" {
 			continue
 		}
-		if host, port, err := net.SplitHostPort(blocked); err == nil {
-			if normalizeHost(host) == targetHost && port == targetPort {
+		if host, _, err := net.SplitHostPort(blocked); err == nil {
+			if normalizeHost(host) == targetHost {
 				return true
 			}
 			continue
@@ -165,22 +164,6 @@ func normalizeHost(host string) string {
 		host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
 	}
 	return strings.ToLower(host)
-}
-
-// effectivePort returns the explicit URL port, or the scheme default when the
-// URL omits one.
-func effectivePort(u *url.URL) string {
-	if port := u.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(u.Scheme) {
-	case "http":
-		return "80"
-	case "https":
-		return "443"
-	default:
-		return ""
-	}
 }
 
 // doRequest issues one tool request through the proxy client and renders the

--- a/internal/playground/url_validation.go
+++ b/internal/playground/url_validation.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// ValidatePlainHTTPURL parses raw as an http(s) URL that carries no embedded
+// credentials, query string, or fragment. Playground configuration URLs use
+// separate secret-file flags and fixed path construction; allowing URL-carried
+// secrets here would risk exposing them in argv, logs, receipts, or error text.
+func ValidatePlainHTTPURL(raw string) (*url.URL, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, errors.New("must use http or https")
+	}
+	if u.Hostname() == "" {
+		return nil, errors.New("host is required")
+	}
+	if u.User != nil {
+		return nil, errors.New("must not include credentials")
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return nil, errors.New("must not include query strings or fragments")
+	}
+	return u, nil
+}

--- a/internal/playground/url_validation_test.go
+++ b/internal/playground/url_validation_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePlainHTTPURL(t *testing.T) {
+	credentialURL := "https://user:" + strings.ToLower("PASS") + "@model.api.test/v1"
+	queryURL := "https://model.api.test/v1?api_key=" + strings.ToLower("SECRET")
+	fragmentURL := "https://model.api.test/v1#" + strings.ToLower("SECRET")
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "http", raw: "http://model.api.test/v1"},
+		{name: "https_with_port", raw: "https://model.api.test:8443/v1"},
+		{name: "non_http_scheme", raw: "ftp://model.api.test/v1", wantErr: true},
+		{name: "missing_host", raw: "http:///v1", wantErr: true},
+		{name: "empty_hostname_with_port", raw: "http://:8080/v1", wantErr: true},
+		{name: "credentials", raw: credentialURL, wantErr: true},
+		{name: "query", raw: queryURL, wantErr: true},
+		{name: "fragment", raw: fragmentURL, wantErr: true},
+		{name: "unparseable", raw: "://bad\x00url", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := ValidatePlainHTTPURL(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidatePlainHTTPURL: %v", err)
+			}
+			if u.Hostname() == "" {
+				t.Fatalf("validated URL has empty hostname: %q", tc.raw)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- tighten live playground model URL, CORS, redirect, and model-host tool-target guards
- rate-limit SSE stream attempts before token validation
- derive default invite-code IDs with the gate secret instead of a public code hash

## Notes
This keeps the model-backed public playground fail-closed on several cheap bypass and abuse edges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Hardened `--allow-origin` with strict origin checks; wildcard CORS is blocked outside dev mode
  * Tightened model/proxy URL validation (no credentials, query strings, or fragments) and normalized model hostnames
  * Prevented HTTP redirects in proxied requests
  * Strengthened tool destination host blocking to reserve the entire hostname
  * Live-chat stream rate limiting now triggers before token validation
* **New Features**
  * Streaming endpoint now enforces IP-based rate limits
* **Documentation**
  * Updated operator guidance for safer `--model-base-url` and exact-origin `--allow-origin` usage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->