### PR TITLE
fix(mcp): opt-in stdio response timeout + self-update downgrade warning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -862,6 +862,7 @@ mcp_input_scanning:
   enabled: true
   action: warn
   on_parse_error: block         # block or forward
+  response_timeout_seconds: 0   # 0 = disabled (stdio MCP proxy only)
 ```
 
 | Field | Default | Description |
@@ -869,8 +870,9 @@ mcp_input_scanning:
 | `enabled` | `false` | Enable input scanning |
 | `action` | `"warn"` | warn or block |
 | `on_parse_error` | `"block"` | What to do with malformed JSON-RPC |
+| `response_timeout_seconds` | `0` | Per-read timeout (seconds) for upstream MCP server responses. `0` disables it (default). When set, a wrapped server that accepts a request but never replies no longer hangs the agent: the proxy fails closed, emitting a JSON-RPC `-32000` error for every pending request. The deadline is per complete response message (one JSON-RPC message, or one SSE data event on the bridge): it resets when each message arrives, so a steady stream of responses is never severed, but it does bound the wait for the *next* message — set it above your slowest legitimate tool's response latency. Applies to the **stdio subprocess proxy** (`-- COMMAND`, including sandboxed mode) and the **stdio-to-HTTP bridge** (`--upstream URL`). On the subprocess proxy a timeout **terminates the hung child** (a stuck subprocess cannot recover); on the HTTP bridge it **fails the affected request closed and the session keeps serving** (one slow response should not kill a shared HTTP upstream). The HTTP reverse-proxy listener (`--listen`) instead uses its own HTTP client/server timeouts. |
 
-Auto-enabled when running `pipelock mcp proxy`.
+Auto-enabled when running `pipelock mcp proxy`. `response_timeout_seconds` applies independently of `enabled`; it governs the response read path whenever the stdio-fronted proxy is running.
 
 If top-level `redaction.enabled` is also set, `tools/call` `params.arguments` are rewritten through the same matcher before input DLP runs. The behavior is identical across stdio, HTTP/SSE upstream mode, HTTP listener mode, and MCP-over-WebSocket.
 

--- a/enterprise/cli/conductor/degenerate_key_test.go
+++ b/enterprise/cli/conductor/degenerate_key_test.go
@@ -1,0 +1,41 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// TestLoadFleetReportSigningKey_RejectsDegenerate proves the conductor signing
+// key loader inherits the seed->stored-pub consistency check: a JSON keyfile
+// whose private AND public halves are both all-zero passes the loader's
+// stored-pub-vs-declared-pub agreement check (both zero), so only the
+// derivation check rejects it. This is a representative parallel path for the
+// other direct JSON signing-key loaders, which apply the same consistency check.
+func TestLoadFleetReportSigningKey_RejectsDegenerate(t *testing.T) {
+	dir := t.TempDir()
+
+	zero := ed25519.PrivateKey(make([]byte, ed25519.PrivateKeySize))
+	zeroPath := writeFleetReportKeyFile(t, dir, "zero.key", "zero-1", signing.PurposeFleetReportSigning, zero)
+	if _, _, err := loadFleetReportSigningKey(zeroPath); err == nil {
+		t.Fatal("loadFleetReportSigningKey accepted an all-zero degenerate key (fail-open)")
+	}
+
+	_, realKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	realPath := writeFleetReportKeyFile(t, dir, "real.key", "real-1", signing.PurposeFleetReportSigning, realKey)
+	id, got, err := loadFleetReportSigningKey(realPath)
+	if err != nil {
+		t.Fatalf("loadFleetReportSigningKey rejected a real key: %v", err)
+	}
+	if id != "real-1" || !got.Equal(realKey) {
+		t.Fatalf("unexpected load result: id=%q keyMatches=%v", id, got.Equal(realKey))
+	}
+}

--- a/enterprise/cli/conductor/degenerate_key_test.go
+++ b/enterprise/cli/conductor/degenerate_key_test.go
@@ -18,24 +18,56 @@ import (
 // derivation check rejects it. This is a representative parallel path for the
 // other direct JSON signing-key loaders, which apply the same consistency check.
 func TestLoadFleetReportSigningKey_RejectsDegenerate(t *testing.T) {
-	dir := t.TempDir()
-
-	zero := ed25519.PrivateKey(make([]byte, ed25519.PrivateKeySize))
-	zeroPath := writeFleetReportKeyFile(t, dir, "zero.key", "zero-1", signing.PurposeFleetReportSigning, zero)
-	if _, _, err := loadFleetReportSigningKey(zeroPath); err == nil {
-		t.Fatal("loadFleetReportSigningKey accepted an all-zero degenerate key (fail-open)")
+	tests := []struct {
+		name    string
+		file    string
+		keyID   string
+		wantErr bool
+		makeKey func(*testing.T) ed25519.PrivateKey
+	}{
+		{
+			name:    "rejects all-zero degenerate key",
+			file:    "zero.key",
+			keyID:   "zero-1",
+			wantErr: true,
+			makeKey: func(_ *testing.T) ed25519.PrivateKey {
+				return ed25519.PrivateKey(make([]byte, ed25519.PrivateKeySize))
+			},
+		},
+		{
+			name:  "accepts generated key",
+			file:  "real.key",
+			keyID: "real-1",
+			makeKey: func(t *testing.T) ed25519.PrivateKey {
+				_, realKey, err := ed25519.GenerateKey(nil)
+				if err != nil {
+					t.Fatalf("GenerateKey: %v", err)
+				}
+				return realKey
+			},
+		},
 	}
 
-	_, realKey, err := ed25519.GenerateKey(nil)
-	if err != nil {
-		t.Fatalf("GenerateKey: %v", err)
-	}
-	realPath := writeFleetReportKeyFile(t, dir, "real.key", "real-1", signing.PurposeFleetReportSigning, realKey)
-	id, got, err := loadFleetReportSigningKey(realPath)
-	if err != nil {
-		t.Fatalf("loadFleetReportSigningKey rejected a real key: %v", err)
-	}
-	if id != "real-1" || !got.Equal(realKey) {
-		t.Fatalf("unexpected load result: id=%q keyMatches=%v", id, got.Equal(realKey))
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			key := tc.makeKey(t)
+			path := writeFleetReportKeyFile(t, dir, tc.file, tc.keyID, signing.PurposeFleetReportSigning, key)
+
+			id, got, err := loadFleetReportSigningKey(path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("loadFleetReportSigningKey accepted an all-zero degenerate key (fail-open)")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("loadFleetReportSigningKey rejected a real key: %v", err)
+			}
+			if id != tc.keyID || !got.Equal(key) {
+				t.Fatalf("unexpected load result: id=%q keyMatches=%v", id, got.Equal(key))
+			}
+		})
 	}
 }

--- a/enterprise/cli/conductor/emergency_common.go
+++ b/enterprise/cli/conductor/emergency_common.go
@@ -141,6 +141,10 @@ func loadSigningKeyFile(path string, requiredPurpose signing.KeyPurpose) (loaded
 		return loadedSigningKey{}, fmt.Errorf("signing key %q has a malformed private key", clean)
 	}
 	priv := ed25519.PrivateKey(privBytes)
+	if err := signing.ValidatePrivateKeyConsistency(priv); err != nil {
+		zeroBytes(privBytes)
+		return loadedSigningKey{}, fmt.Errorf("signing key %q: %w", clean, err)
+	}
 	derived, ok := priv.Public().(ed25519.PublicKey)
 	if !ok || !bytes.Equal(derived, pubBytes) {
 		zeroBytes(privBytes)

--- a/enterprise/cli/conductor/fleet_report.go
+++ b/enterprise/cli/conductor/fleet_report.go
@@ -237,6 +237,9 @@ func loadFleetReportSigningKey(path string) (string, ed25519.PrivateKey, error) 
 		return "", nil, fmt.Errorf("--signing-key %q: malformed private key", cleanPath)
 	}
 	priv := ed25519.PrivateKey(privBytes)
+	if err := signing.ValidatePrivateKeyConsistency(priv); err != nil {
+		return "", nil, fmt.Errorf("--signing-key %q: %w", cleanPath, err)
+	}
 	derived, ok := priv.Public().(ed25519.PublicKey)
 	if !ok || !bytes.Equal(derived, pubBytes) {
 		return "", nil, fmt.Errorf("--signing-key %q: private key does not match its public key", cleanPath)

--- a/enterprise/cli/conductor/publish.go
+++ b/enterprise/cli/conductor/publish.go
@@ -525,6 +525,9 @@ func loadPolicySigningKey(path string) (string, ed25519.PrivateKey, error) {
 		return "", nil, fmt.Errorf("--signing-key %q: malformed private key", cleanPath)
 	}
 	priv := ed25519.PrivateKey(privBytes)
+	if err := signing.ValidatePrivateKeyConsistency(priv); err != nil {
+		return "", nil, fmt.Errorf("--signing-key %q: %w", cleanPath, err)
+	}
 	derived, ok := priv.Public().(ed25519.PublicKey)
 	if !ok || !bytes.Equal(derived, pubBytes) {
 		return "", nil, fmt.Errorf("--signing-key %q: private key does not match its public key", cleanPath)

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -666,9 +666,10 @@ Key-free evidence capture:
 			}
 
 			inputCfg := &mcp.InputScanConfig{
-				Enabled:      cfg.MCPInputScanning.Enabled,
-				Action:       cfg.MCPInputScanning.Action,
-				OnParseError: cfg.MCPInputScanning.OnParseError,
+				Enabled:                cfg.MCPInputScanning.Enabled,
+				Action:                 cfg.MCPInputScanning.Action,
+				OnParseError:           cfg.MCPInputScanning.OnParseError,
+				ResponseTimeoutSeconds: cfg.MCPInputScanning.ResponseTimeoutSeconds,
 			}
 
 			var mcpRedactMatcher *redact.Matcher

--- a/internal/cli/runtime/server_builders.go
+++ b/internal/cli/runtime/server_builders.go
@@ -25,9 +25,10 @@ func buildMCPInputCfg(cfg *config.Config) *mcp.InputScanConfig {
 		return nil
 	}
 	return &mcp.InputScanConfig{
-		Enabled:      cfg.MCPInputScanning.Enabled,
-		Action:       cfg.MCPInputScanning.Action,
-		OnParseError: cfg.MCPInputScanning.OnParseError,
+		Enabled:                cfg.MCPInputScanning.Enabled,
+		Action:                 cfg.MCPInputScanning.Action,
+		OnParseError:           cfg.MCPInputScanning.OnParseError,
+		ResponseTimeoutSeconds: cfg.MCPInputScanning.ResponseTimeoutSeconds,
 	}
 }
 

--- a/internal/cli/runtime/server_builders.go
+++ b/internal/cli/runtime/server_builders.go
@@ -21,7 +21,10 @@ func buildToolPolicyCfg(cfg *config.Config) *policy.Config {
 }
 
 func buildMCPInputCfg(cfg *config.Config) *mcp.InputScanConfig {
-	if cfg == nil || !cfg.MCPInputScanning.Enabled {
+	if cfg == nil {
+		return nil
+	}
+	if !cfg.MCPInputScanning.Enabled && cfg.MCPInputScanning.ResponseTimeoutSeconds <= 0 {
 		return nil
 	}
 	return &mcp.InputScanConfig{

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -481,6 +481,12 @@ func TestRuntimeMCPBuilders(t *testing.T) {
 		t.Fatal("nil config should not build MCP tool config")
 	}
 	cfg := config.Defaults()
+	cfg.MCPInputScanning.Enabled = false
+	cfg.MCPInputScanning.ResponseTimeoutSeconds = 7
+	timeoutOnlyCfg := buildMCPInputCfg(cfg)
+	if timeoutOnlyCfg == nil || timeoutOnlyCfg.Enabled || timeoutOnlyCfg.ResponseTimeoutSeconds != 7 {
+		t.Fatalf("timeout-only input cfg = %+v, want disabled scanner with timeout", timeoutOnlyCfg)
+	}
 	cfg.MCPInputScanning.Enabled = true
 	cfg.MCPInputScanning.Action = config.ActionBlock
 	cfg.MCPToolScanning.Enabled = true

--- a/internal/cli/selfupdate/cmd.go
+++ b/internal/cli/selfupdate/cmd.go
@@ -42,7 +42,9 @@ If cosign is absent, the updater fails closed by default. Use
 --insecure-skip-signature only for an explicit checksum-only recovery flow.
 
 The previous binary is saved to <binary>.bak so "pipelock update --rollback"
-can restore it.
+can restore it. When downgrading to a release that predates the update command
+(before v2.8.0), the updater warns that --rollback will not be available from
+the downgraded binary and prints the manual recovery command.
 
 Examples:
   pipelock update --check              # report current vs latest, change nothing

--- a/internal/cli/selfupdate/extra_test.go
+++ b/internal/cli/selfupdate/extra_test.go
@@ -160,6 +160,99 @@ func TestCmd_RunE_CheckEndToEnd(t *testing.T) {
 	}
 }
 
+func TestLacksUpdateCommand(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"v2.7.0", true},
+		{"v2.7.5", true},
+		{"v2.6.0", true},
+		{"v1.0.0", true},
+		{"v2.8.0", false},
+		{"v2.8.1", false},
+		{"v3.0.0", false},
+		{"v2.8.0-rc1", false}, // pre-release of v2.8.0 still parses as 2.8.0
+	}
+	for _, tc := range tests {
+		t.Run(tc.version, func(t *testing.T) {
+			got := lacksUpdateCommand(tc.version)
+			if got != tc.want {
+				t.Fatalf("lacksUpdateCommand(%q) = %v, want %v", tc.version, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRun_DowngradeWarnsAboutMissingRollback(t *testing.T) {
+	const downgradeTarget = "v2.7.0"
+	assets, _ := standardAssets(t, downgradeTarget, testGOOS)
+	rs := newReleaseServer(t, downgradeTarget, assets)
+	target := writeTargetBinary(t, "CURRENT")
+
+	stderr := &bytes.Buffer{}
+	opts := baseOptions(rs, target)
+	opts.CurrentVersion = "v2.8.0"
+	opts.TargetVersion = downgradeTarget
+	opts.Stderr = stderr
+
+	st, err := opts.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !st.Applied {
+		t.Fatal("expected update to be applied")
+	}
+
+	// Must warn about missing rollback command.
+	warn := stderr.String()
+	if !strings.Contains(warn, "predates the 'update' command") {
+		t.Fatalf("expected downgrade warning, got stderr: %q", warn)
+	}
+	if !strings.Contains(warn, "mv") {
+		t.Fatalf("expected manual recovery command in warning, got: %q", warn)
+	}
+	if !strings.Contains(warn, st.BackupPath) {
+		t.Fatalf("expected backup path in warning, got: %q", warn)
+	}
+}
+
+func TestRun_UpgradeDoesNotWarnAboutRollback(t *testing.T) {
+	// Upgrading to v2.8.0+ should NOT emit the downgrade warning.
+	assets, _ := standardAssets(t, testLatest, testGOOS)
+	rs := newReleaseServer(t, testLatest, assets)
+	target := writeTargetBinary(t, "OLD")
+
+	stderr := &bytes.Buffer{}
+	opts := baseOptions(rs, target)
+	opts.Stderr = stderr
+
+	st, err := opts.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !st.Applied {
+		t.Fatal("expected update to be applied")
+	}
+	if strings.Contains(stderr.String(), "predates") {
+		t.Fatalf("unexpected downgrade warning on upgrade: %q", stderr.String())
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"/usr/local/bin/pipelock", `'/usr/local/bin/pipelock'`},
+		{"/path with spaces/pipelock", `'/path with spaces/pipelock'`},
+		{"/odd/$(rm -rf ~)/pipelock", `'/odd/$(rm -rf ~)/pipelock'`},
+		{"/it's/here/pipelock", `'/it'\''s/here/pipelock'`},
+	}
+	for _, tt := range tests {
+		if got := shellQuote(tt.in); got != tt.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestStageAndVerifySignature_StageError(t *testing.T) {
 	// dir does not exist -> writeFileQuiet fails.
 	opts := &Options{CosignAvailable: func() bool { return false }, RunCommand: stubVersionRunner("")}

--- a/internal/cli/selfupdate/extra_test.go
+++ b/internal/cli/selfupdate/extra_test.go
@@ -247,9 +247,11 @@ func TestShellQuote(t *testing.T) {
 		{"/it's/here/pipelock", `'/it'\''s/here/pipelock'`},
 	}
 	for _, tt := range tests {
-		if got := shellQuote(tt.in); got != tt.want {
-			t.Errorf("shellQuote(%q) = %q, want %q", tt.in, got, tt.want)
-		}
+		t.Run(tt.in, func(t *testing.T) {
+			if got := shellQuote(tt.in); got != tt.want {
+				t.Fatalf("shellQuote(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/selfupdate/run.go
+++ b/internal/cli/selfupdate/run.go
@@ -12,6 +12,11 @@ import (
 	"strings"
 )
 
+// firstVersionWithUpdate is the earliest release that ships the "update"
+// subcommand. Any target version strictly older than this lacks the rollback
+// command, so the operator needs a manual recovery path printed.
+const firstVersionWithUpdate = "v2.8.0"
+
 // versionTag strips only a leading "v" and surrounding whitespace, PRESERVING
 // any pre-release/build suffix. Use this for asset-name resolution and the
 // extracted-binary version check, where "v2.8.0-rc1" must stay "2.8.0-rc1"
@@ -71,6 +76,13 @@ func isNewer(current, latest string) bool {
 	default:
 		return lPatch > cPatch
 	}
+}
+
+// lacksUpdateCommand reports whether the given release version predates the
+// "update" subcommand. When true, "pipelock update --rollback" will not be
+// available from the downgraded binary.
+func lacksUpdateCommand(version string) bool {
+	return isNewer(version, firstVersionWithUpdate)
 }
 
 // Check resolves the latest (or pinned) release and reports status WITHOUT
@@ -195,7 +207,27 @@ func (o *Options) Run(ctx context.Context) (*Status, error) {
 	}
 	st.BackupPath = backup
 	st.Applied = true
+
+	// Warn when the installed version predates the "update" command. The
+	// downgraded binary has no "pipelock update --rollback" so the operator
+	// needs the manual recovery path printed before they lose this binary.
+	if lacksUpdateCommand(rel.TagName) {
+		_, _ = fmt.Fprintf(o.Stderr,
+			"\nWARNING: %s predates the 'update' command.\n"+
+				"'pipelock update --rollback' will NOT be available from the downgraded binary.\n"+
+				"To restore manually, run:\n  mv %s %s\n",
+			rel.TagName, shellQuote(st.BackupPath), shellQuote(o.TargetPath))
+	}
+
 	return st, nil
+}
+
+// shellQuote single-quotes a path so the printed manual-recovery command is
+// safe to paste verbatim even when the path contains spaces or shell
+// metacharacters. Embedded single quotes are escaped by closing the quoted
+// string, adding an escaped quote, and reopening the quoted string.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // Rollback restores the previous binary from <target>.bak.

--- a/internal/cli/signing/key_generate.go
+++ b/internal/cli/signing/key_generate.go
@@ -252,6 +252,9 @@ func loadKeyFile(path string, expectedPurpose domsigning.KeyPurpose) (*keyFile, 
 		return nil, nil, nil, fmt.Errorf("private key has wrong size: got %d, want %d", len(privBytes), ed25519.PrivateKeySize)
 	}
 	priv := ed25519.PrivateKey(privBytes)
+	if err := domsigning.ValidatePrivateKeyConsistency(priv); err != nil {
+		return nil, nil, nil, err
+	}
 	derivedPub, ok := priv.Public().(ed25519.PublicKey)
 	if !ok || !bytes.Equal(derivedPub, pubBytes) {
 		return nil, nil, nil, fmt.Errorf("private key does not match public key")

--- a/internal/cli/signing/key_generate.go
+++ b/internal/cli/signing/key_generate.go
@@ -253,7 +253,7 @@ func loadKeyFile(path string, expectedPurpose domsigning.KeyPurpose) (*keyFile, 
 	}
 	priv := ed25519.PrivateKey(privBytes)
 	if err := domsigning.ValidatePrivateKeyConsistency(priv); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("validate private key consistency for %q: %w", cleanPath, err)
 	}
 	derivedPub, ok := priv.Public().(ed25519.PublicKey)
 	if !ok || !bytes.Equal(derivedPub, pubBytes) {

--- a/internal/cli/signing/key_generate_test.go
+++ b/internal/cli/signing/key_generate_test.go
@@ -282,6 +282,49 @@ func TestLoadKeyFile_DetectsPurposeMismatch(t *testing.T) {
 	}
 }
 
+func TestLoadKeyFile_RejectsDegeneratePrivateKeyWithContext(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.json")
+
+	gen := keyGenerateCmd()
+	gen.SetOut(&bytes.Buffer{})
+	gen.SetErr(&bytes.Buffer{})
+	gen.SetArgs([]string{"--purpose", string(domsigning.PurposeRosterRoot), "--out", path})
+	if err := gen.Execute(); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var kf keyFile
+	if err := json.Unmarshal(raw, &kf); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	kf.Private = hex.EncodeToString(make([]byte, ed25519.PrivateKeySize))
+	tampered, err := json.Marshal(kf)
+	if err != nil {
+		t.Fatalf("marshal tampered: %v", err)
+	}
+	if err := os.WriteFile(path, tampered, 0o600); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+
+	_, _, _, err = loadKeyFile(path, domsigning.PurposeRosterRoot)
+	if err == nil {
+		t.Fatalf("expected degenerate private-key error")
+	}
+	for _, want := range []string{
+		"validate private key consistency",
+		filepath.Clean(path),
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
 func TestLoadKeyFile_RejectsMismatchedPrivatePublic(t *testing.T) {
 	dir := t.TempDir()
 	rootPath := filepath.Join(dir, "root.json")

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -184,7 +184,10 @@ const (
 	// Re-bumped for removal of vestigial DeferConfig.ResolutionTriggers
 	// field. The field had zero runtime consumers (only validated/defaulted)
 	// and was dropped in v2.8 before any release shipped it.
-	goldenHashDefaults = "4d15bb5d19674cbf21f45b43b36035406d9d730e09ae71399042e72cdb310cbd"
+	// Re-bumped for mcp_input_scanning.response_timeout_seconds field
+	// (v2.8 stress-followup Finding 12). New policy-semantic field that
+	// changes upstream response timeout behavior. Zero default = disabled.
+	goldenHashDefaults = "0d8fb5014d616d5207afd946094b98561f564d6394aa1d6c99f739c01c572728"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -274,7 +277,9 @@ const (
 	// response-scanning pattern set, so the hash shifts in lockstep.
 	// Re-bumped for the defer section: held-action timeout and capacity
 	// bounds are policy semantics for action enforcement.
-	goldenHashRichConfig = "26d7dbb0b32a79971a46119afcb2d51bb117a62832ff9d98a2e31530677ff595"
+	// Re-bumped for mcp_input_scanning.response_timeout_seconds: see
+	// goldenHashDefaults note above.
+	goldenHashRichConfig = "a182adbf13fcf2add0e10480aeeba79586e64ae017b9ad45fb06bad9bc13bfee"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4162,6 +4162,30 @@ func TestApplyDefaults_MCPInputScanningOnParseErrorDefaulted(t *testing.T) {
 	}
 }
 
+func TestValidate_MCPInputScanningResponseTimeoutNegative(t *testing.T) {
+	cfg := Defaults()
+	cfg.MCPInputScanning.ResponseTimeoutSeconds = -1
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for negative response_timeout_seconds")
+	}
+}
+
+func TestValidate_MCPInputScanningResponseTimeoutZero(t *testing.T) {
+	cfg := Defaults()
+	cfg.MCPInputScanning.ResponseTimeoutSeconds = 0
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error for zero response_timeout_seconds: %v", err)
+	}
+}
+
+func TestValidate_MCPInputScanningResponseTimeoutPositive(t *testing.T) {
+	cfg := Defaults()
+	cfg.MCPInputScanning.ResponseTimeoutSeconds = 30
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected error for positive response_timeout_seconds: %v", err)
+	}
+}
+
 // --- Default DLP Pattern Tests ---
 
 func TestDefaults_ContainsNewDLPPatterns(t *testing.T) {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -558,6 +558,20 @@ type MCPInputScanning struct {
 	Enabled      bool   `yaml:"enabled"`
 	Action       string `yaml:"action"`         // warn, block
 	OnParseError string `yaml:"on_parse_error"` // block (default), forward
+	// ResponseTimeoutSeconds is an optional per-read timeout (in seconds) for
+	// the wrapped MCP server's response stream. When set to a positive value,
+	// the proxy emits a JSON-RPC error (-32000 "upstream response timeout")
+	// if no complete response message arrives from the upstream within this
+	// window, instead of the agent hanging. The deadline is per response
+	// message and resets as each arrives, so a steady stream is not severed;
+	// set it above the slowest legitimate tool latency. Applies to the stdio
+	// subprocess proxy (RunProxy, incl. sandbox) and the stdio-to-HTTP bridge
+	// (RunHTTPForward); the HTTP reverse-proxy listener uses its own HTTP
+	// timeouts. On the subprocess proxy a timeout terminates the hung child; on
+	// the bridge it fails the affected request closed and the session
+	// continues. Default 0 = disabled, preserving current behavior. Consumed
+	// independently of Enabled.
+	ResponseTimeoutSeconds int `yaml:"response_timeout_seconds"`
 }
 
 // MCPToolScanning configures scanning of MCP tool descriptions for poisoning

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -810,6 +810,9 @@ func (c *Config) validateMCPInputScanning() error {
 	default:
 		return fmt.Errorf("invalid mcp_input_scanning on_parse_error %q: must be block or forward", c.MCPInputScanning.OnParseError)
 	}
+	if c.MCPInputScanning.ResponseTimeoutSeconds < 0 {
+		return fmt.Errorf("invalid mcp_input_scanning response_timeout_seconds %d: must be non-negative", c.MCPInputScanning.ResponseTimeoutSeconds)
+	}
 	return nil
 }
 

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +20,25 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
 	session "github.com/luckyPipewrench/pipelock/internal/session"
 )
+
+func emitRequestScopedTimeout(
+	respReader transport.MessageReader,
+	writer transport.MessageWriter,
+	logW io.Writer,
+	tracker *RequestTracker,
+	id json.RawMessage,
+	logMessage string,
+) {
+	if c, ok := respReader.(io.Closer); ok {
+		_ = c.Close()
+	}
+	if len(id) != 0 && (tracker == nil || tracker.Validate(id)) {
+		if wErr := writer.WriteMessage(timeoutErrorResponse(id)); wErr != nil {
+			_, _ = fmt.Fprintf(logW, "pipelock: failed to send timeout response: %v\n", wErr)
+		}
+	}
+	_, _ = fmt.Fprintln(logW, logMessage)
+}
 
 // RunHTTPProxy bridges stdio (client) to an upstream HTTP MCP server with
 // bidirectional scanning. Reads JSON-RPC from clientIn, POSTs to upstreamURL,
@@ -93,10 +113,6 @@ func RunHTTPProxy(
 	fwdOpts.ToolCfg = fwdToolCfg
 	fwdOpts.ToolCfgFn = nil
 	fwdOpts.WarnContext = ctx
-	// The bridge calls ForwardScanned once per request, so a response timeout
-	// must fail only that request (this loop emits the -32000 for its id), not
-	// drain the shared tracker and falsely time out other in-flight requests.
-	fwdOpts.TimeoutScopeSingleResponse = true
 	resolverRuntime := newDeferResolverRuntime(ctx)
 	fwdOpts.DeferResolverRuntime = resolverRuntime
 	defer func() {
@@ -227,27 +243,14 @@ func RunHTTPProxy(
 						respReader = fwdOpts.withResponseTimeout(respReader)
 						_, scanErr := ForwardScanned(respReader, safeClientOut, safeLogW, tracker, fwdOpts)
 						if errors.Is(scanErr, transport.ErrResponseTimeout) {
-							// Hung upstream on a deferred request. Close the
-							// timed-out response so the wrapped reader's
-							// background read drains (no leak / late double-emit)
-							// and emit a -32000 for THIS request only. This runs
-							// in the async resolution callback, so we fail just
-							// this request closed rather than tearing down the
-							// bridge (the main loop may be blocked on a
-							// non-cancellable stdin read) or draining unrelated
-							// in-flight request ids.
-							if c, ok := respReader.(io.Closer); ok {
-								_ = c.Close()
-							}
-							// Emit only if still pending (Validate untracks and
-							// returns false if the upstream already answered),
-							// so an already-answered id is never double-emitted.
-							if !deferredReq.IsNotification && deferredReq.ID != nil && tracker.Validate(deferredReq.ID) {
-								if wErr := safeClientOut.WriteMessage(timeoutErrorResponse(deferredReq.ID)); wErr != nil {
-									_, _ = fmt.Fprintf(safeLogW, "pipelock: failed to send timeout response: %v\n", wErr)
-								}
-							}
-							_, _ = fmt.Fprintf(safeLogW, "pipelock: upstream response timeout on deferred request; failed request closed\n")
+							emitRequestScopedTimeout(
+								respReader,
+								safeClientOut,
+								safeLogW,
+								tracker,
+								deferredReq.ID,
+								"pipelock: upstream response timeout on deferred request; failed request closed",
+							)
 						} else if scanErr != nil {
 							_, _ = fmt.Fprintf(safeLogW, "pipelock: scan error: %v\n", scanErr)
 						}
@@ -348,28 +351,14 @@ func RunHTTPProxy(
 		respReader = fwdOpts.withResponseTimeout(respReader)
 		_, scanErr := ForwardScanned(respReader, safeClientOut, safeLogW, tracker, fwdOpts)
 		if errors.Is(scanErr, transport.ErrResponseTimeout) {
-			// Upstream accepted the request but never replied. Close the
-			// timed-out response so the wrapped reader's background read drains
-			// (no goroutine/body leak, no late double-emit), emit a -32000 for
-			// THIS request only (request-scoped, so other in-flight requests
-			// are untouched), then keep serving: one slow HTTP response must not
-			// tear down the whole MCP session. (The stdio subprocess proxy DOES
-			// terminate its child here, because a hung subprocess cannot
-			// recover; an HTTP upstream serving many requests can.)
-			if c, ok := respReader.(io.Closer); ok {
-				_ = c.Close()
-			}
-			// Emit the timeout error only if this id is still pending. Validate
-			// returns true and untracks it when pending; it returns false when
-			// the upstream already answered (e.g. an SSE POST that replied then
-			// held the stream open past the deadline), so we never double-emit
-			// for an already-answered id.
-			if rpcID := frame.ID; rpcID != nil && tracker.Validate(rpcID) {
-				if wErr := safeClientOut.WriteMessage(timeoutErrorResponse(rpcID)); wErr != nil {
-					_, _ = fmt.Fprintf(safeLogW, "pipelock: failed to send timeout response: %v\n", wErr)
-				}
-			}
-			_, _ = fmt.Fprintf(safeLogW, "pipelock: upstream response timeout; failed request closed, session continues\n")
+			emitRequestScopedTimeout(
+				respReader,
+				safeClientOut,
+				safeLogW,
+				tracker,
+				frame.ID,
+				"pipelock: upstream response timeout; failed request closed, session continues",
+			)
 			lastScanErr = scanErr
 			continue
 		}

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -93,6 +93,10 @@ func RunHTTPProxy(
 	fwdOpts.ToolCfg = fwdToolCfg
 	fwdOpts.ToolCfgFn = nil
 	fwdOpts.WarnContext = ctx
+	// The bridge calls ForwardScanned once per request, so a response timeout
+	// must fail only that request (this loop emits the -32000 for its id), not
+	// drain the shared tracker and falsely time out other in-flight requests.
+	fwdOpts.TimeoutScopeSingleResponse = true
 	resolverRuntime := newDeferResolverRuntime(ctx)
 	fwdOpts.DeferResolverRuntime = resolverRuntime
 	defer func() {
@@ -220,8 +224,31 @@ func RunHTTPProxy(
 							}
 							return
 						}
+						respReader = fwdOpts.withResponseTimeout(respReader)
 						_, scanErr := ForwardScanned(respReader, safeClientOut, safeLogW, tracker, fwdOpts)
-						if scanErr != nil {
+						if errors.Is(scanErr, transport.ErrResponseTimeout) {
+							// Hung upstream on a deferred request. Close the
+							// timed-out response so the wrapped reader's
+							// background read drains (no leak / late double-emit)
+							// and emit a -32000 for THIS request only. This runs
+							// in the async resolution callback, so we fail just
+							// this request closed rather than tearing down the
+							// bridge (the main loop may be blocked on a
+							// non-cancellable stdin read) or draining unrelated
+							// in-flight request ids.
+							if c, ok := respReader.(io.Closer); ok {
+								_ = c.Close()
+							}
+							// Emit only if still pending (Validate untracks and
+							// returns false if the upstream already answered),
+							// so an already-answered id is never double-emitted.
+							if !deferredReq.IsNotification && deferredReq.ID != nil && tracker.Validate(deferredReq.ID) {
+								if wErr := safeClientOut.WriteMessage(timeoutErrorResponse(deferredReq.ID)); wErr != nil {
+									_, _ = fmt.Fprintf(safeLogW, "pipelock: failed to send timeout response: %v\n", wErr)
+								}
+							}
+							_, _ = fmt.Fprintf(safeLogW, "pipelock: upstream response timeout on deferred request; failed request closed\n")
+						} else if scanErr != nil {
 							_, _ = fmt.Fprintf(safeLogW, "pipelock: scan error: %v\n", scanErr)
 						}
 					default:
@@ -316,8 +343,36 @@ func RunHTTPProxy(
 			continue
 		}
 
-		// Scan and forward response.
+		// Scan and forward response. Apply the optional per-read response
+		// timeout (no-op when disabled) so a hung HTTP upstream fails closed.
+		respReader = fwdOpts.withResponseTimeout(respReader)
 		_, scanErr := ForwardScanned(respReader, safeClientOut, safeLogW, tracker, fwdOpts)
+		if errors.Is(scanErr, transport.ErrResponseTimeout) {
+			// Upstream accepted the request but never replied. Close the
+			// timed-out response so the wrapped reader's background read drains
+			// (no goroutine/body leak, no late double-emit), emit a -32000 for
+			// THIS request only (request-scoped, so other in-flight requests
+			// are untouched), then keep serving: one slow HTTP response must not
+			// tear down the whole MCP session. (The stdio subprocess proxy DOES
+			// terminate its child here, because a hung subprocess cannot
+			// recover; an HTTP upstream serving many requests can.)
+			if c, ok := respReader.(io.Closer); ok {
+				_ = c.Close()
+			}
+			// Emit the timeout error only if this id is still pending. Validate
+			// returns true and untracks it when pending; it returns false when
+			// the upstream already answered (e.g. an SSE POST that replied then
+			// held the stream open past the deadline), so we never double-emit
+			// for an already-answered id.
+			if rpcID := frame.ID; rpcID != nil && tracker.Validate(rpcID) {
+				if wErr := safeClientOut.WriteMessage(timeoutErrorResponse(rpcID)); wErr != nil {
+					_, _ = fmt.Fprintf(safeLogW, "pipelock: failed to send timeout response: %v\n", wErr)
+				}
+			}
+			_, _ = fmt.Fprintf(safeLogW, "pipelock: upstream response timeout; failed request closed, session continues\n")
+			lastScanErr = scanErr
+			continue
+		}
 		if scanErr != nil {
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: scan error: %v\n", scanErr)
 			lastScanErr = scanErr

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -54,20 +54,28 @@ type MCPRedactionConfig struct {
 // Optional (nil-safe): all other fields - functions check before use.
 type MCPProxyOpts struct {
 	// Scanning
-	Scanner        *scanner.Scanner
-	ScannerFn      func() *scanner.Scanner
-	Approver       *hitl.Approver
-	InputCfg       *InputScanConfig
-	InputCfgFn     func() *InputScanConfig
-	RequestBodyCfg *config.RequestBodyScanning
-	RequestBodyFn  func() *config.RequestBodyScanning
-	ToolCfg        *tools.ToolScanConfig
-	ToolCfgFn      func() *tools.ToolScanConfig
-	PolicyCfg      *policy.Config
-	PolicyCfgFn    func() *policy.Config
-	KillSwitch     *killswitch.Controller
-	ChainMatcher   *chains.Matcher
-	ChainMatcherFn func() *chains.Matcher
+	Scanner    *scanner.Scanner
+	ScannerFn  func() *scanner.Scanner
+	Approver   *hitl.Approver
+	InputCfg   *InputScanConfig
+	InputCfgFn func() *InputScanConfig
+	// TimeoutScopeSingleResponse marks a ForwardScanned call as owning exactly
+	// one request's response (the HTTP bridge per-request path). When set, an
+	// upstream response timeout does NOT drain the shared request tracker (that
+	// would falsely time out other concurrently-pending requests); the caller
+	// emits the -32000 for its own request id instead. Subprocess/sandbox
+	// proxies leave this false: their timeout is a terminal teardown that fails
+	// every pending request closed.
+	TimeoutScopeSingleResponse bool
+	RequestBodyCfg             *config.RequestBodyScanning
+	RequestBodyFn              func() *config.RequestBodyScanning
+	ToolCfg                    *tools.ToolScanConfig
+	ToolCfgFn                  func() *tools.ToolScanConfig
+	PolicyCfg                  *policy.Config
+	PolicyCfgFn                func() *policy.Config
+	KillSwitch                 *killswitch.Controller
+	ChainMatcher               *chains.Matcher
+	ChainMatcherFn             func() *chains.Matcher
 
 	// Session and adaptive enforcement
 	Store         session.Store

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -54,28 +54,20 @@ type MCPRedactionConfig struct {
 // Optional (nil-safe): all other fields - functions check before use.
 type MCPProxyOpts struct {
 	// Scanning
-	Scanner    *scanner.Scanner
-	ScannerFn  func() *scanner.Scanner
-	Approver   *hitl.Approver
-	InputCfg   *InputScanConfig
-	InputCfgFn func() *InputScanConfig
-	// TimeoutScopeSingleResponse marks a ForwardScanned call as owning exactly
-	// one request's response (the HTTP bridge per-request path). When set, an
-	// upstream response timeout does NOT drain the shared request tracker (that
-	// would falsely time out other concurrently-pending requests); the caller
-	// emits the -32000 for its own request id instead. Subprocess/sandbox
-	// proxies leave this false: their timeout is a terminal teardown that fails
-	// every pending request closed.
-	TimeoutScopeSingleResponse bool
-	RequestBodyCfg             *config.RequestBodyScanning
-	RequestBodyFn              func() *config.RequestBodyScanning
-	ToolCfg                    *tools.ToolScanConfig
-	ToolCfgFn                  func() *tools.ToolScanConfig
-	PolicyCfg                  *policy.Config
-	PolicyCfgFn                func() *policy.Config
-	KillSwitch                 *killswitch.Controller
-	ChainMatcher               *chains.Matcher
-	ChainMatcherFn             func() *chains.Matcher
+	Scanner        *scanner.Scanner
+	ScannerFn      func() *scanner.Scanner
+	Approver       *hitl.Approver
+	InputCfg       *InputScanConfig
+	InputCfgFn     func() *InputScanConfig
+	RequestBodyCfg *config.RequestBodyScanning
+	RequestBodyFn  func() *config.RequestBodyScanning
+	ToolCfg        *tools.ToolScanConfig
+	ToolCfgFn      func() *tools.ToolScanConfig
+	PolicyCfg      *policy.Config
+	PolicyCfgFn    func() *policy.Config
+	KillSwitch     *killswitch.Controller
+	ChainMatcher   *chains.Matcher
+	ChainMatcherFn func() *chains.Matcher
 
 	// Session and adaptive enforcement
 	Store         session.Store

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -160,6 +161,30 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			// scan", not a fatal error. IsExpectedCloseErr covers io.EOF too.
 			if wsutil.IsExpectedCloseErr(err) {
 				break
+			}
+			// Upstream response timeout: emit a JSON-RPC error for every
+			// pending (unanswered) request so the agent does not hang, then
+			// return the sentinel so the owning transport tears down the hung
+			// upstream. Returning (not break) is load-bearing: a clean-EOF
+			// break would let RunProxy fall into cmd.Wait() on a still-alive
+			// child (blocking forever) and let the HTTP bridge loop keep
+			// accepting requests against a dead upstream.
+			if errors.Is(err, transport.ErrResponseTimeout) {
+				_, _ = fmt.Fprintf(logW, "pipelock: upstream response timeout\n")
+				// Terminal callers (stdio subprocess / sandbox) fail EVERY
+				// pending request closed here. Single-response callers (the HTTP
+				// bridge) own one request and emit the -32000 for that id
+				// themselves, so they suppress this broad drain to avoid timing
+				// out an unrelated concurrently-pending request.
+				if tracker != nil && !opts.TimeoutScopeSingleResponse {
+					for _, id := range tracker.DrainPending() {
+						resp := timeoutErrorResponse(id)
+						if wErr := writer.WriteMessage(resp); wErr != nil {
+							_, _ = fmt.Fprintf(logW, "pipelock: failed to send timeout response: %v\n", wErr)
+						}
+					}
+				}
+				return foundInjection, transport.ErrResponseTimeout
 			}
 			return foundInjection, fmt.Errorf("reading input: %w", err)
 		}
@@ -692,6 +717,37 @@ type rpcErrorDetail struct {
 	Data    json.RawMessage `json:"data,omitempty"`
 }
 
+// timeoutErrorResponse generates a JSON-RPC 2.0 error response for a request
+// whose upstream response timed out. Code -32000 is in the server-error range.
+func timeoutErrorResponse(id json.RawMessage) []byte {
+	resp := rpcError{
+		JSONRPC: jsonrpc.Version,
+		ID:      id,
+		Error: rpcErrorDetail{
+			Code:    -32000,
+			Message: "pipelock: upstream response timeout",
+		},
+	}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+// withResponseTimeout wraps an upstream response reader with a per-read
+// deadline when mcp_input_scanning.response_timeout_seconds is positive. A
+// wrapped MCP server that accepts a request but never replies then triggers a
+// fail-closed timeout instead of hanging the agent. Shared by the stdio
+// subprocess proxy (RunProxy) and the stdio-to-HTTP bridge (RunHTTPForward) so
+// the knob behaves identically on both stdio-fronted transports. The deadline
+// is per complete response message (it resets when each message arrives), so a
+// steady response stream is not severed; it bounds the wait for the next
+// message. Returns r unchanged when the timeout is disabled.
+func (o MCPProxyOpts) withResponseTimeout(r transport.MessageReader) transport.MessageReader {
+	if inputCfg := o.inputCfg(); inputCfg != nil && inputCfg.ResponseTimeoutSeconds > 0 {
+		return transport.NewTimeoutReader(r, time.Duration(inputCfg.ResponseTimeoutSeconds)*time.Second)
+	}
+	return r
+}
+
 // blockResponse generates a JSON-RPC 2.0 error response for a blocked message.
 // Code -32000 is in the implementation-defined error range.
 // Use this only when the block is genuinely driven by prompt-injection
@@ -891,6 +947,11 @@ type InputScanConfig struct {
 	Enabled      bool
 	Action       string // warn, block
 	OnParseError string // block, forward
+	// ResponseTimeoutSeconds is an optional per-read timeout (in seconds) for
+	// the upstream MCP server's response stream. When positive, the proxy
+	// emits a JSON-RPC error if no response data arrives within this window.
+	// Default 0 = disabled (no timeout).
+	ResponseTimeoutSeconds int
 }
 
 // RunProxy launches an MCP server subprocess and proxies stdio through
@@ -1169,12 +1230,29 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		}
 	}()
 
-	// Scan and forward server output to client.
-	serverReader := transport.NewStdioReader(serverOut)
+	// Scan and forward server output to client. Apply the optional per-read
+	// response timeout (no-op when disabled) so a dead upstream that accepts a
+	// request but never replies fails closed instead of hanging the agent.
+	serverReader := opts.withResponseTimeout(transport.NewStdioReader(serverOut))
+
 	fwdOpts := inputOpts
 	fwdOpts.ToolCfg = fwdToolCfg // session-specific baseline
 	fwdOpts.ToolCfgFn = nil
 	_, scanErr := ForwardScanned(serverReader, safeClientOut, safeLogW, tracker, fwdOpts)
+
+	// On an upstream response timeout the child is still alive (it accepted a
+	// request and never replied). The agent already received -32000 timeout
+	// errors; terminate the child now so cmd.Wait() below returns instead of
+	// blocking forever on the hung process. The pgid teardown after Wait()
+	// then reaps any descendants.
+	if errors.Is(scanErr, transport.ErrResponseTimeout) && cmd.Process != nil {
+		_, _ = fmt.Fprintf(safeLogW, "pipelock: terminating MCP subprocess after upstream response timeout\n")
+		if c, ok := clientIn.(io.Closer); ok {
+			_ = c.Close()
+		}
+		_ = serverIn.Close()
+		_ = cmd.Process.Kill()
+	}
 
 	// Wait for subprocess to exit.
 	waitErr := cmd.Wait()
@@ -1208,11 +1286,30 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// non-Linux builds - the stub is a no-op there.
 	killAdoptedDescendants()
 
-	// Wait for stdin goroutine to finish (server exit closes pipe, unblocking scanner).
-	wg.Wait()
+	if errors.Is(scanErr, transport.ErrResponseTimeout) {
+		// Closing a closable clientIn above wakes the usual CLI/pipe readers.
+		// If a custom Reader cannot be interrupted, do not let a request that
+		// already failed closed wedge shutdown forever.
+		drainCtx, drainCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer drainCancel()
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			wgBlocked.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-drainCtx.Done():
+			_, _ = fmt.Fprintf(safeLogW, "pipelock: timed out waiting for MCP input drain after upstream response timeout\n")
+		}
+	} else {
+		// Wait for stdin goroutine to finish (server exit closes pipe, unblocking scanner).
+		wg.Wait()
 
-	// Wait for blocked channel drain to complete.
-	wgBlocked.Wait()
+		// Wait for blocked channel drain to complete.
+		wgBlocked.Wait()
+	}
 
 	if scanErr != nil {
 		return fmt.Errorf("scanning: %w", scanErr)

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -73,6 +73,18 @@ func (sw *syncWriter) WriteMessage(msg []byte) error {
 	return nil
 }
 
+func emitPendingTimeoutResponses(writer transport.MessageWriter, logW io.Writer, tracker *RequestTracker) {
+	if tracker == nil {
+		return
+	}
+	for _, id := range tracker.DrainPending() {
+		resp := timeoutErrorResponse(id)
+		if wErr := writer.WriteMessage(resp); wErr != nil {
+			_, _ = fmt.Fprintf(logW, "pipelock: failed to send timeout response: %v\n", wErr)
+		}
+	}
+}
+
 // isResponse returns true if msg is a JSON-RPC response (has "result" or "error"
 // field). Messages with only a "method" field (server-initiated requests) return
 // false. A message with both "method" and "result" is treated as a response
@@ -162,28 +174,14 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			if wsutil.IsExpectedCloseErr(err) {
 				break
 			}
-			// Upstream response timeout: emit a JSON-RPC error for every
-			// pending (unanswered) request so the agent does not hang, then
-			// return the sentinel so the owning transport tears down the hung
-			// upstream. Returning (not break) is load-bearing: a clean-EOF
-			// break would let RunProxy fall into cmd.Wait() on a still-alive
-			// child (blocking forever) and let the HTTP bridge loop keep
-			// accepting requests against a dead upstream.
+			// Upstream response timeout: return the sentinel so the owning
+			// transport tears down the hung upstream and decides the failure
+			// scope. Returning (not break) is load-bearing: a clean-EOF break
+			// would let RunProxy fall into cmd.Wait() on a still-alive child
+			// (blocking forever) and let the HTTP bridge loop keep accepting
+			// requests against a dead upstream.
 			if errors.Is(err, transport.ErrResponseTimeout) {
 				_, _ = fmt.Fprintf(logW, "pipelock: upstream response timeout\n")
-				// Terminal callers (stdio subprocess / sandbox) fail EVERY
-				// pending request closed here. Single-response callers (the HTTP
-				// bridge) own one request and emit the -32000 for that id
-				// themselves, so they suppress this broad drain to avoid timing
-				// out an unrelated concurrently-pending request.
-				if tracker != nil && !opts.TimeoutScopeSingleResponse {
-					for _, id := range tracker.DrainPending() {
-						resp := timeoutErrorResponse(id)
-						if wErr := writer.WriteMessage(resp); wErr != nil {
-							_, _ = fmt.Fprintf(logW, "pipelock: failed to send timeout response: %v\n", wErr)
-						}
-					}
-				}
 				return foundInjection, transport.ErrResponseTimeout
 			}
 			return foundInjection, fmt.Errorf("reading input: %w", err)
@@ -1239,13 +1237,14 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	fwdOpts.ToolCfg = fwdToolCfg // session-specific baseline
 	fwdOpts.ToolCfgFn = nil
 	_, scanErr := ForwardScanned(serverReader, safeClientOut, safeLogW, tracker, fwdOpts)
+	timedOut := errors.Is(scanErr, transport.ErrResponseTimeout)
 
 	// On an upstream response timeout the child is still alive (it accepted a
-	// request and never replied). The agent already received -32000 timeout
-	// errors; terminate the child now so cmd.Wait() below returns instead of
-	// blocking forever on the hung process. The pgid teardown after Wait()
-	// then reaps any descendants.
-	if errors.Is(scanErr, transport.ErrResponseTimeout) && cmd.Process != nil {
+	// request and never replied). Stop request intake before emitting pending
+	// timeout responses below, then terminate the child so cmd.Wait() returns
+	// instead of blocking forever on the hung process. The pgid teardown after
+	// Wait() then reaps any descendants.
+	if timedOut && cmd.Process != nil {
 		_, _ = fmt.Fprintf(safeLogW, "pipelock: terminating MCP subprocess after upstream response timeout\n")
 		if c, ok := clientIn.(io.Closer); ok {
 			_ = c.Close()
@@ -1286,7 +1285,7 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// non-Linux builds - the stub is a no-op there.
 	killAdoptedDescendants()
 
-	if errors.Is(scanErr, transport.ErrResponseTimeout) {
+	if timedOut {
 		// Closing a closable clientIn above wakes the usual CLI/pipe readers.
 		// If a custom Reader cannot be interrupted, do not let a request that
 		// already failed closed wedge shutdown forever.
@@ -1303,6 +1302,7 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		case <-drainCtx.Done():
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: timed out waiting for MCP input drain after upstream response timeout\n")
 		}
+		emitPendingTimeoutResponses(safeClientOut, safeLogW, tracker)
 	} else {
 		// Wait for stdin goroutine to finish (server exit closes pipe, unblocking scanner).
 		wg.Wait()

--- a/internal/mcp/proxy_sandbox.go
+++ b/internal/mcp/proxy_sandbox.go
@@ -135,11 +135,25 @@ func RunProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, clientIn io.
 		}
 	}()
 
-	serverReader := transport.NewStdioReader(serverOut)
 	fwdOpts := inputOpts
 	fwdOpts.ToolCfg = fwdToolCfg // session-specific baseline
 	fwdOpts.ToolCfgFn = nil
+	// Apply the optional per-read response timeout (no-op when disabled) so a
+	// hung sandboxed upstream fails closed instead of hanging the agent.
+	serverReader := fwdOpts.withResponseTimeout(transport.NewStdioReader(serverOut))
 	_, scanErr := ForwardScanned(serverReader, safeClientOut, safeLogW, tracker, fwdOpts)
+
+	// On an upstream response timeout the sandboxed child is still alive; kill
+	// it before Wait() so Wait() returns instead of blocking forever, then fall
+	// through to the existing sandbox teardown below.
+	if errors.Is(scanErr, transport.ErrResponseTimeout) && sandboxCmd.Process != nil {
+		_, _ = fmt.Fprintf(safeLogW, "pipelock: terminating sandboxed MCP subprocess after upstream response timeout\n")
+		if c, ok := clientIn.(io.Closer); ok {
+			_ = c.Close()
+		}
+		_ = serverIn.Close()
+		_ = sandboxCmd.Process.Signal(os.Kill)
+	}
 
 	waitErr := sandboxCmd.Wait()
 

--- a/internal/mcp/proxy_sandbox.go
+++ b/internal/mcp/proxy_sandbox.go
@@ -142,11 +142,12 @@ func RunProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, clientIn io.
 	// hung sandboxed upstream fails closed instead of hanging the agent.
 	serverReader := fwdOpts.withResponseTimeout(transport.NewStdioReader(serverOut))
 	_, scanErr := ForwardScanned(serverReader, safeClientOut, safeLogW, tracker, fwdOpts)
+	timedOut := errors.Is(scanErr, transport.ErrResponseTimeout)
 
 	// On an upstream response timeout the sandboxed child is still alive; kill
 	// it before Wait() so Wait() returns instead of blocking forever, then fall
 	// through to the existing sandbox teardown below.
-	if errors.Is(scanErr, transport.ErrResponseTimeout) && sandboxCmd.Process != nil {
+	if timedOut && sandboxCmd.Process != nil {
 		_, _ = fmt.Fprintf(safeLogW, "pipelock: terminating sandboxed MCP subprocess after upstream response timeout\n")
 		if c, ok := clientIn.(io.Closer); ok {
 			_ = c.Close()
@@ -181,6 +182,9 @@ func RunProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, clientIn io.
 	select {
 	case <-done:
 	case <-drainCtx.Done():
+	}
+	if timedOut {
+		emitPendingTimeoutResponses(safeClientOut, safeLogW, tracker)
 	}
 
 	if scanErr != nil {

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -3706,9 +3706,10 @@ func (m *mockRecorderEscalateOnClean) RecordClean(decay float64) {
 	}
 }
 
-// TestForwardScanned_ResponseTimeout verifies that a dead upstream (sends
-// nothing) triggers a JSON-RPC timeout error for pending requests instead
-// of hanging the agent indefinitely.
+// TestForwardScanned_ResponseTimeoutReturnsSentinel verifies that a dead
+// upstream (sends nothing) returns the timeout sentinel instead of hanging the
+// agent indefinitely. The owning transport emits pending timeout responses
+// after it stops request intake.
 func TestForwardScanned_ResponseTimeout(t *testing.T) {
 	sc := testScannerWithAction(t, "warn")
 	tracker := NewRequestTracker()
@@ -3732,16 +3733,11 @@ func TestForwardScanned_ResponseTimeout(t *testing.T) {
 		t.Fatalf("expected ErrResponseTimeout, got: %v", err)
 	}
 
-	// Client output should contain a timeout error response for id 42.
-	outStr := out.String()
-	if !strings.Contains(outStr, `"code":-32000`) {
-		t.Fatalf("expected -32000 timeout code in output, got: %s", outStr)
+	if out.Len() != 0 {
+		t.Fatalf("ForwardScanned must not emit timeout responses directly; got: %s", out.String())
 	}
-	if !strings.Contains(outStr, `"id":42`) {
-		t.Fatalf("expected id 42 in timeout response, got: %s", outStr)
-	}
-	if !strings.Contains(outStr, "upstream response timeout") {
-		t.Fatalf("expected timeout message in output, got: %s", outStr)
+	if got := tracker.DrainPending(); len(got) != 1 || string(got[0]) != `42` {
+		t.Fatalf("ForwardScanned must leave pending ids for the owner to drain; got %q", got)
 	}
 	if !strings.Contains(logBuf.String(), "upstream response timeout") {
 		t.Fatalf("expected timeout log, got: %s", logBuf.String())
@@ -3751,37 +3747,73 @@ func TestForwardScanned_ResponseTimeout(t *testing.T) {
 	ch <- transport.ReadResult{Err: io.EOF}
 }
 
-// TestForwardScanned_ResponseTimeout_SingleScopeDoesNotDrain proves that with
-// TimeoutScopeSingleResponse set (the HTTP bridge per-request path), a timeout
-// does NOT emit or drain the shared tracker — so other concurrently-pending
-// request ids are not falsely timed out. The caller emits the -32000 for its
-// own id.
-func TestForwardScanned_ResponseTimeout_SingleScopeDoesNotDrain(t *testing.T) {
-	sc := testScannerWithAction(t, "warn")
+func TestEmitPendingTimeoutResponses_DrainsTracker(t *testing.T) {
 	tracker := NewRequestTracker()
 	tracker.Track(json.RawMessage(`1`))
 	tracker.Track(json.RawMessage(`2`))
 
-	ch := make(chan transport.ReadResult, 1)
-	br := &chanReader{ch: ch}
-	tr := transport.NewTimeoutReader(br, 50*time.Millisecond)
-
 	var out, logBuf bytes.Buffer
-	opts := buildTestOpts(sc)
-	opts.TimeoutScopeSingleResponse = true
-	_, err := ForwardScanned(tr, transport.NewStdioWriter(&out), &logBuf, tracker, opts)
-	if !errors.Is(err, transport.ErrResponseTimeout) {
-		t.Fatalf("want ErrResponseTimeout, got %v", err)
-	}
-	if out.Len() != 0 {
-		t.Fatalf("single-scope timeout must not emit a response; got: %s", out.String())
-	}
-	if got := tracker.DrainPending(); len(got) != 2 {
-		t.Fatalf("single-scope timeout must not drain the tracker; pending=%d want 2", len(got))
-	}
+	emitPendingTimeoutResponses(transport.NewStdioWriter(&out), &logBuf, tracker)
 
-	// Unblock the background goroutine so it does not leak.
-	ch <- transport.ReadResult{Err: io.EOF}
+	outStr := out.String()
+	for _, want := range []string{`"id":1`, `"id":2`, `"code":-32000`, "upstream response timeout"} {
+		if !strings.Contains(outStr, want) {
+			t.Fatalf("timeout output missing %q: %s", want, outStr)
+		}
+	}
+	if got := tracker.DrainPending(); len(got) != 0 {
+		t.Fatalf("tracker still has pending ids after drain: %q", got)
+	}
+}
+
+func TestEmitRequestScopedTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      json.RawMessage
+		trackID bool
+		wantOut string
+	}{
+		{name: "tracked request", id: json.RawMessage(`7`), trackID: true, wantOut: `"id":7`},
+		{name: "explicit null id", id: json.RawMessage(jsonrpc.Null), wantOut: `"id":null`},
+		{name: "notification without id", id: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := NewRequestTracker()
+			if tt.trackID {
+				tracker.Track(tt.id)
+			}
+			reader := &closeTrackingReader{}
+			var out, logBuf bytes.Buffer
+
+			emitRequestScopedTimeout(
+				reader,
+				transport.NewStdioWriter(&out),
+				&logBuf,
+				tracker,
+				tt.id,
+				"pipelock: upstream response timeout; failed request closed, session continues",
+			)
+
+			if !reader.closed {
+				t.Fatal("expected response reader to be closed")
+			}
+			if tt.wantOut == "" {
+				if out.Len() != 0 {
+					t.Fatalf("notification should not receive a response, got: %s", out.String())
+				}
+			} else {
+				for _, want := range []string{tt.wantOut, `"code":-32000`} {
+					if !strings.Contains(out.String(), want) {
+						t.Fatalf("timeout response missing %q: %s", want, out.String())
+					}
+				}
+			}
+			if !strings.Contains(logBuf.String(), "upstream response timeout") {
+				t.Fatalf("expected timeout log, got: %s", logBuf.String())
+			}
+		})
+	}
 }
 
 // chanReader is a MessageReader that returns results from a channel. Used
@@ -3793,6 +3825,19 @@ type chanReader struct {
 func (cr *chanReader) ReadMessage() ([]byte, error) {
 	r := <-cr.ch
 	return r.Msg, r.Err
+}
+
+type closeTrackingReader struct {
+	closed bool
+}
+
+func (*closeTrackingReader) ReadMessage() ([]byte, error) {
+	return nil, io.EOF
+}
+
+func (r *closeTrackingReader) Close() error {
+	r.closed = true
+	return nil
 }
 
 // TestWithResponseTimeout proves the shared helper used by BOTH stdio-fronted

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
@@ -3702,5 +3703,203 @@ func (m *mockRecorderEscalateOnClean) RecordClean(decay float64) {
 	m.cleans++
 	if m.cleans >= m.escalateAt {
 		m.level = 1
+	}
+}
+
+// TestForwardScanned_ResponseTimeout verifies that a dead upstream (sends
+// nothing) triggers a JSON-RPC timeout error for pending requests instead
+// of hanging the agent indefinitely.
+func TestForwardScanned_ResponseTimeout(t *testing.T) {
+	sc := testScannerWithAction(t, "warn")
+	tracker := NewRequestTracker()
+	// Simulate a pending request whose response we are waiting for.
+	tracker.Track(json.RawMessage(`42`))
+
+	// blockingReader never returns a message until we tell it to.
+	ch := make(chan transport.ReadResult, 1)
+	br := &chanReader{ch: ch}
+
+	// Wrap with a short timeout.
+	tr := transport.NewTimeoutReader(br, 50*time.Millisecond)
+
+	var out, logBuf bytes.Buffer
+	opts := buildTestOpts(sc)
+	_, err := ForwardScanned(tr, transport.NewStdioWriter(&out), &logBuf, tracker, opts)
+	// Timeout is terminal: ForwardScanned returns the sentinel so the owning
+	// transport tears down the hung upstream instead of treating it as a clean
+	// EOF (which would block RunProxy on cmd.Wait() / loop the HTTP bridge).
+	if !errors.Is(err, transport.ErrResponseTimeout) {
+		t.Fatalf("expected ErrResponseTimeout, got: %v", err)
+	}
+
+	// Client output should contain a timeout error response for id 42.
+	outStr := out.String()
+	if !strings.Contains(outStr, `"code":-32000`) {
+		t.Fatalf("expected -32000 timeout code in output, got: %s", outStr)
+	}
+	if !strings.Contains(outStr, `"id":42`) {
+		t.Fatalf("expected id 42 in timeout response, got: %s", outStr)
+	}
+	if !strings.Contains(outStr, "upstream response timeout") {
+		t.Fatalf("expected timeout message in output, got: %s", outStr)
+	}
+	if !strings.Contains(logBuf.String(), "upstream response timeout") {
+		t.Fatalf("expected timeout log, got: %s", logBuf.String())
+	}
+
+	// Push a late response to unblock the goroutine so it does not leak.
+	ch <- transport.ReadResult{Err: io.EOF}
+}
+
+// TestForwardScanned_ResponseTimeout_SingleScopeDoesNotDrain proves that with
+// TimeoutScopeSingleResponse set (the HTTP bridge per-request path), a timeout
+// does NOT emit or drain the shared tracker — so other concurrently-pending
+// request ids are not falsely timed out. The caller emits the -32000 for its
+// own id.
+func TestForwardScanned_ResponseTimeout_SingleScopeDoesNotDrain(t *testing.T) {
+	sc := testScannerWithAction(t, "warn")
+	tracker := NewRequestTracker()
+	tracker.Track(json.RawMessage(`1`))
+	tracker.Track(json.RawMessage(`2`))
+
+	ch := make(chan transport.ReadResult, 1)
+	br := &chanReader{ch: ch}
+	tr := transport.NewTimeoutReader(br, 50*time.Millisecond)
+
+	var out, logBuf bytes.Buffer
+	opts := buildTestOpts(sc)
+	opts.TimeoutScopeSingleResponse = true
+	_, err := ForwardScanned(tr, transport.NewStdioWriter(&out), &logBuf, tracker, opts)
+	if !errors.Is(err, transport.ErrResponseTimeout) {
+		t.Fatalf("want ErrResponseTimeout, got %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("single-scope timeout must not emit a response; got: %s", out.String())
+	}
+	if got := tracker.DrainPending(); len(got) != 2 {
+		t.Fatalf("single-scope timeout must not drain the tracker; pending=%d want 2", len(got))
+	}
+
+	// Unblock the background goroutine so it does not leak.
+	ch <- transport.ReadResult{Err: io.EOF}
+}
+
+// chanReader is a MessageReader that returns results from a channel. Used
+// to simulate a dead upstream that never sends data.
+type chanReader struct {
+	ch chan transport.ReadResult
+}
+
+func (cr *chanReader) ReadMessage() ([]byte, error) {
+	r := <-cr.ch
+	return r.Msg, r.Err
+}
+
+// TestWithResponseTimeout proves the shared helper used by BOTH stdio-fronted
+// transports (the subprocess proxy and the stdio-to-HTTP bridge) wraps the
+// upstream reader only when response_timeout_seconds is positive, reads through
+// the hot-reload-aware accessor, and is a no-op (identity) when disabled.
+func TestWithResponseTimeout(t *testing.T) {
+	base := &chanReader{ch: make(chan transport.ReadResult, 1)}
+
+	tests := []struct {
+		name     string
+		opts     MCPProxyOpts
+		wantWrap bool
+	}{
+		{"disabled (zero)", MCPProxyOpts{InputCfg: &InputScanConfig{ResponseTimeoutSeconds: 0}}, false},
+		{"nil input cfg", MCPProxyOpts{}, false},
+		{"enabled", MCPProxyOpts{InputCfg: &InputScanConfig{ResponseTimeoutSeconds: 5}}, true},
+		{"enabled via hot-reload fn", MCPProxyOpts{InputCfgFn: func() *InputScanConfig {
+			return &InputScanConfig{ResponseTimeoutSeconds: 5}
+		}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.opts.withResponseTimeout(base)
+			_, wrapped := got.(*transport.TimeoutReader)
+			if wrapped != tt.wantWrap {
+				t.Fatalf("withResponseTimeout wrapped=%v, want %v", wrapped, tt.wantWrap)
+			}
+			if !tt.wantWrap && got != transport.MessageReader(base) {
+				t.Fatal("disabled timeout must return the original reader unchanged")
+			}
+		})
+	}
+}
+
+// TestRunProxy_ResponseTimeoutTerminatesHungUpstream proves the timeout is a
+// TERMINAL fail-closed teardown, not a clean-EOF break: a subprocess that
+// accepts a request and never replies must not hang RunProxy on cmd.Wait().
+// Without the kill-before-Wait, RunProxy blocks for the full sleep and the
+// deadline below fires.
+func TestRunProxy_ResponseTimeoutTerminatesHungUpstream(t *testing.T) {
+	sc := testScannerWithAction(t, "warn")
+	opts := buildTestOpts(sc)
+	opts.InputCfg = &InputScanConfig{
+		Action:                 config.ActionWarn,
+		OnParseError:           config.ActionBlock,
+		ResponseTimeoutSeconds: 1,
+	}
+
+	var out, logBuf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		// "sleep" never reads stdin and never writes stdout: a dead upstream.
+		done <- RunProxy(context.Background(),
+			strings.NewReader(mcpToolCall(mcpAllowedTool, "")+"\n"),
+			&out, &logBuf, []string{"sleep", "30"}, opts)
+	}()
+
+	select {
+	case <-done:
+		// Returned: the hung child was killed before cmd.Wait(). Good.
+	case <-time.After(15 * time.Second):
+		t.Fatal("RunProxy hung after upstream response timeout (cmd.Wait blocked on a live child)")
+	}
+
+	if !strings.Contains(logBuf.String(), "upstream response timeout") {
+		t.Fatalf("expected upstream response timeout log, got: %s", logBuf.String())
+	}
+}
+
+// TestRunProxy_ResponseTimeoutReturnsWithOpenClientInput covers the real agent
+// posture: the client writes one request, then keeps stdin open while waiting
+// for a response. A timeout must fail closed and return; it must not hang while
+// waiting for the input-scanner goroutine to observe EOF.
+func TestRunProxy_ResponseTimeoutReturnsWithOpenClientInput(t *testing.T) {
+	sc := testScannerWithAction(t, "warn")
+	opts := buildTestOpts(sc)
+	opts.InputCfg = &InputScanConfig{
+		Action:                 config.ActionWarn,
+		OnParseError:           config.ActionBlock,
+		ResponseTimeoutSeconds: 1,
+	}
+
+	clientIn, clientWriter := io.Pipe()
+	t.Cleanup(func() { _ = clientWriter.Close() })
+
+	var out, logBuf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunProxy(context.Background(), clientIn, &out, &logBuf, []string{"sleep", "30"}, opts)
+	}()
+
+	_, _ = clientWriter.Write([]byte(mcpToolCall(mcpAllowedTool, "") + "\n"))
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, transport.ErrResponseTimeout) {
+			t.Fatalf("RunProxy error = %v, want ErrResponseTimeout", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("RunProxy hung after timeout while client input stayed open")
+	}
+
+	if !strings.Contains(out.String(), `"code":-32000`) {
+		t.Fatalf("expected timeout error response, got stdout: %s", out.String())
+	}
+	if !strings.Contains(logBuf.String(), "upstream response timeout") {
+		t.Fatalf("expected upstream response timeout log, got: %s", logBuf.String())
 	}
 }

--- a/internal/mcp/request_tracker.go
+++ b/internal/mcp/request_tracker.go
@@ -114,6 +114,24 @@ func (t *RequestTracker) Seeded() bool {
 	return t.seeded
 }
 
+// DrainPending returns and removes all pending request IDs. Used when a
+// response timeout fires and the proxy needs to emit error responses for
+// every unanswered request before shutting down.
+func (t *RequestTracker) DrainPending() []json.RawMessage {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	ids := make([]json.RawMessage, 0, len(t.order))
+	for _, key := range t.order {
+		ids = append(ids, json.RawMessage(key))
+	}
+	t.pending = make(map[string]struct{})
+	t.order = nil
+	return ids
+}
+
 // canonicalID normalizes a JSON-RPC ID to a canonical string for map
 // lookup. Returns "" for nil, empty, or "null" IDs (notifications).
 // The canonical form preserves the raw JSON representation so numeric

--- a/internal/mcp/request_tracker_test.go
+++ b/internal/mcp/request_tracker_test.go
@@ -169,6 +169,30 @@ func TestRequestTracker_NilTracker(t *testing.T) {
 	if !tr.Validate(json.RawMessage(`999`)) {
 		t.Error("expected nil tracker Validate to return true for any ID")
 	}
+	if got := tr.DrainPending(); got != nil {
+		t.Fatalf("nil tracker DrainPending = %q, want nil", got)
+	}
+}
+
+func TestRequestTracker_DrainPending(t *testing.T) {
+	tr := NewRequestTracker()
+	tr.Track(json.RawMessage(`1`))
+	tr.Track(json.RawMessage(`"two"`))
+	tr.Track(json.RawMessage(`null`))
+
+	got := tr.DrainPending()
+	if len(got) != 2 || string(got[0]) != `1` || string(got[1]) != `"two"` {
+		t.Fatalf("DrainPending = %q, want [1 \"two\"]", got)
+	}
+	if tr.Validate(json.RawMessage(`1`)) {
+		t.Fatal("drained id 1 should no longer validate")
+	}
+	if tr.Validate(json.RawMessage(`"two"`)) {
+		t.Fatal("drained id \"two\" should no longer validate")
+	}
+	if got := tr.DrainPending(); len(got) != 0 {
+		t.Fatalf("second DrainPending = %q, want empty", got)
+	}
 }
 
 func TestRequestTracker_TrackNilID(t *testing.T) {

--- a/internal/mcp/transport/httpclient.go
+++ b/internal/mcp/transport/httpclient.go
@@ -249,6 +249,13 @@ func (r *SingleMessageReader) ReadMessage() ([]byte, error) {
 	return data, nil
 }
 
+// Close releases the underlying body so a caller can abort a read blocked on a
+// slow or hung upstream (e.g. an MCP response timeout). Safe to call more than
+// once; a redundant close on an already-closed body is ignored.
+func (r *SingleMessageReader) Close() error {
+	return r.Body.Close()
+}
+
 // closingSSEReader wraps an SSEReader with the response body so that
 // the body is closed when the SSE stream returns EOF or any error.
 type closingSSEReader struct {
@@ -268,6 +275,13 @@ func (r *closingSSEReader) ReadMessage() ([]byte, error) {
 		return nil, err
 	}
 	return msg, nil
+}
+
+// Close releases the underlying body so a caller can abort a read blocked on a
+// slow or hung SSE upstream (e.g. an MCP response timeout). Safe to call more
+// than once; a redundant close is ignored.
+func (r *closingSSEReader) Close() error {
+	return r.body.Close()
 }
 
 // OpenGETStream opens a GET SSE connection for server-initiated messages.

--- a/internal/mcp/transport/httpclient_test.go
+++ b/internal/mcp/transport/httpclient_test.go
@@ -867,6 +867,51 @@ func (r *errReadCloser) Close() error {
 	return nil
 }
 
+type closeRecordingBody struct {
+	closed atomic.Int32
+}
+
+func (*closeRecordingBody) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (b *closeRecordingBody) Close() error {
+	b.closed.Add(1)
+	return nil
+}
+
+func TestHTTPClient_ResponseReadersCloseBody(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader func(*closeRecordingBody) io.Closer
+	}{
+		{
+			name: "single message reader",
+			reader: func(body *closeRecordingBody) io.Closer {
+				return &SingleMessageReader{Body: body}
+			},
+		},
+		{
+			name: "sse reader",
+			reader: func(body *closeRecordingBody) io.Closer {
+				return &closingSSEReader{sse: NewSSEReader(body), body: body}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := &closeRecordingBody{}
+			reader := tt.reader(body)
+			if err := reader.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			if body.closed.Load() != 1 {
+				t.Fatalf("body close count = %d, want 1", body.closed.Load())
+			}
+		})
+	}
+}
+
 func TestHTTPClient_ErrorStatusEmptyBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)

--- a/internal/mcp/transport/timeout.go
+++ b/internal/mcp/transport/timeout.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package transport
+
+import (
+	"errors"
+	"io"
+	"time"
+)
+
+// ErrResponseTimeout is returned when a TimeoutReader's per-read deadline
+// expires before the underlying reader delivers a message. Fail-closed:
+// the proxy emits a JSON-RPC error to the client rather than hanging.
+var ErrResponseTimeout = errors.New("upstream response timeout")
+
+// ReadResult holds the outcome of a single ReadMessage call. Exported so
+// test helpers in other packages can build channel-based message readers.
+type ReadResult struct {
+	Msg []byte
+	Err error
+}
+
+// TimeoutReader wraps a MessageReader with a per-read deadline. If the
+// underlying reader does not return within the configured timeout, the
+// read returns ErrResponseTimeout. A zero or negative timeout disables
+// the deadline (passthrough).
+//
+// Implementation: each ReadMessage call runs the delegate in a goroutine
+// when no prior read is outstanding. When a timeout fires, the goroutine
+// remains blocked on the inner reader; the next ReadMessage call reuses
+// the same channel, so the late result is consumed without spawning a
+// second concurrent read.
+type TimeoutReader struct {
+	inner   MessageReader
+	timeout time.Duration
+
+	// inflight is non-nil when a background read goroutine is still waiting
+	// on the inner reader from a previous timed-out call.
+	inflight chan ReadResult
+}
+
+// NewTimeoutReader creates a TimeoutReader. A zero timeout disables the
+// deadline (every call delegates directly without a goroutine).
+func NewTimeoutReader(inner MessageReader, timeout time.Duration) *TimeoutReader {
+	return &TimeoutReader{
+		inner:   inner,
+		timeout: timeout,
+	}
+}
+
+// ReadMessage reads the next message, returning ErrResponseTimeout if the
+// underlying reader does not respond within the configured deadline.
+func (tr *TimeoutReader) ReadMessage() ([]byte, error) {
+	if tr.timeout <= 0 {
+		return tr.inner.ReadMessage()
+	}
+
+	// Reuse the channel from a prior timed-out read if one is still in flight.
+	ch := tr.inflight
+	if ch == nil {
+		ch = make(chan ReadResult, 1)
+		go func() {
+			msg, err := tr.inner.ReadMessage()
+			ch <- ReadResult{Msg: msg, Err: err}
+		}()
+	}
+	tr.inflight = nil // consumed; will be re-set below if we time out again
+
+	timer := time.NewTimer(tr.timeout)
+	defer timer.Stop()
+
+	select {
+	case r := <-ch:
+		return r.Msg, r.Err
+	case <-timer.C:
+		// The goroutine is still blocked on inner.ReadMessage. Keep the
+		// channel so the next call drains its result, or so Close() can
+		// release the underlying reader to unblock it.
+		tr.inflight = ch
+		return nil, ErrResponseTimeout
+	}
+}
+
+// Close releases the wrapped reader when it implements io.Closer. Callers use
+// this after an ErrResponseTimeout to abort the in-flight read: closing the
+// underlying body makes the background ReadMessage goroutine's blocked read
+// return, so it drains instead of leaking. No-op when the inner reader is not
+// a Closer.
+func (tr *TimeoutReader) Close() error {
+	if c, ok := tr.inner.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}

--- a/internal/mcp/transport/timeout_test.go
+++ b/internal/mcp/transport/timeout_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package transport
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+// blockingReader never returns from ReadMessage until a response is pushed
+// into the responses channel.
+type blockingReader struct {
+	responses chan ReadResult
+}
+
+func (br *blockingReader) ReadMessage() ([]byte, error) {
+	r := <-br.responses
+	return r.Msg, r.Err
+}
+
+func TestTimeoutReader_PassthroughWhenDisabled(t *testing.T) {
+	br := &blockingReader{responses: make(chan ReadResult, 1)}
+	br.responses <- ReadResult{Msg: []byte(`{"ok":true}`), Err: nil}
+	tr := NewTimeoutReader(br, 0)
+	msg, err := tr.ReadMessage()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(msg) != `{"ok":true}` {
+		t.Fatalf("msg = %q", msg)
+	}
+}
+
+func TestTimeoutReader_ReturnsBeforeDeadline(t *testing.T) {
+	br := &blockingReader{responses: make(chan ReadResult, 1)}
+	br.responses <- ReadResult{Msg: []byte(`{"id":1}`), Err: nil}
+	tr := NewTimeoutReader(br, 5*time.Second)
+	msg, err := tr.ReadMessage()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(msg) != `{"id":1}` {
+		t.Fatalf("msg = %q", msg)
+	}
+}
+
+func TestTimeoutReader_TimesOut(t *testing.T) {
+	br := &blockingReader{responses: make(chan ReadResult, 1)}
+	// Do not push a response - the reader will block.
+	tr := NewTimeoutReader(br, 50*time.Millisecond)
+	_, err := tr.ReadMessage()
+	if !errors.Is(err, ErrResponseTimeout) {
+		t.Fatalf("expected ErrResponseTimeout, got %v", err)
+	}
+
+	// Push the late response so the goroutine can drain.
+	br.responses <- ReadResult{Msg: []byte(`{"id":1}`), Err: nil}
+
+	// The next read reuses the inflight channel and should return the
+	// buffered late response immediately (well within the 5s deadline).
+	tr.timeout = 5 * time.Second
+	msg, err := tr.ReadMessage()
+	if err != nil {
+		t.Fatalf("expected buffered response, got error: %v", err)
+	}
+	if string(msg) != `{"id":1}` {
+		t.Fatalf("msg = %q", msg)
+	}
+}
+
+func TestTimeoutReader_PropagatesEOF(t *testing.T) {
+	br := &blockingReader{responses: make(chan ReadResult, 1)}
+	br.responses <- ReadResult{Msg: nil, Err: io.EOF}
+	tr := NewTimeoutReader(br, 5*time.Second)
+	_, err := tr.ReadMessage()
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+}
+
+// blockingCloseReader blocks in ReadMessage until Close releases it, modeling a
+// hung upstream whose body read only returns once the connection is closed.
+type blockingCloseReader struct {
+	release chan struct{}
+}
+
+func (b *blockingCloseReader) ReadMessage() ([]byte, error) {
+	<-b.release
+	return nil, io.EOF
+}
+
+func (b *blockingCloseReader) Close() error {
+	close(b.release)
+	return nil
+}
+
+// TestTimeoutReader_CloseDrainsHungInner proves Close() aborts the in-flight
+// inner read after a timeout so the background goroutine drains instead of
+// leaking — the path the HTTP bridge uses to free a hung response on timeout.
+func TestTimeoutReader_CloseDrainsHungInner(t *testing.T) {
+	inner := &blockingCloseReader{release: make(chan struct{})}
+	tr := NewTimeoutReader(inner, 20*time.Millisecond)
+
+	if _, err := tr.ReadMessage(); !errors.Is(err, ErrResponseTimeout) {
+		t.Fatalf("first read: want ErrResponseTimeout, got %v", err)
+	}
+
+	// Close aborts the still-blocked inner read so its goroutine completes.
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := tr.ReadMessage()
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("drained read: want io.EOF, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReadMessage hung after Close; background goroutine did not drain")
+	}
+}

--- a/internal/mcp/transport/timeout_test.go
+++ b/internal/mcp/transport/timeout_test.go
@@ -21,63 +21,84 @@ func (br *blockingReader) ReadMessage() ([]byte, error) {
 	return r.Msg, r.Err
 }
 
-func TestTimeoutReader_PassthroughWhenDisabled(t *testing.T) {
-	br := &blockingReader{responses: make(chan ReadResult, 1)}
-	br.responses <- ReadResult{Msg: []byte(`{"ok":true}`), Err: nil}
-	tr := NewTimeoutReader(br, 0)
-	msg, err := tr.ReadMessage()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestTimeoutReader_ReadMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		timeout    time.Duration
+		initial    *ReadResult
+		wantMsg    string
+		wantErr    error
+		late       *ReadResult
+		lateMsg    string
+		lateErr    error
+		lateReadTO time.Duration
+	}{
+		{
+			name:    "passthrough when disabled",
+			timeout: 0,
+			initial: &ReadResult{Msg: []byte(`{"ok":true}`)},
+			wantMsg: `{"ok":true}`,
+		},
+		{
+			name:    "returns before deadline",
+			timeout: 5 * time.Second,
+			initial: &ReadResult{Msg: []byte(`{"id":1}`)},
+			wantMsg: `{"id":1}`,
+		},
+		{
+			name:       "times out then drains late response",
+			timeout:    50 * time.Millisecond,
+			wantErr:    ErrResponseTimeout,
+			late:       &ReadResult{Msg: []byte(`{"id":1}`)},
+			lateMsg:    `{"id":1}`,
+			lateReadTO: 5 * time.Second,
+		},
+		{
+			name:    "propagates eof",
+			timeout: 5 * time.Second,
+			initial: &ReadResult{Err: io.EOF},
+			wantErr: io.EOF,
+		},
 	}
-	if string(msg) != `{"ok":true}` {
-		t.Fatalf("msg = %q", msg)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			br := &blockingReader{responses: make(chan ReadResult, 1)}
+			if tt.initial != nil {
+				br.responses <- *tt.initial
+			}
+			tr := NewTimeoutReader(br, tt.timeout)
 
-func TestTimeoutReader_ReturnsBeforeDeadline(t *testing.T) {
-	br := &blockingReader{responses: make(chan ReadResult, 1)}
-	br.responses <- ReadResult{Msg: []byte(`{"id":1}`), Err: nil}
-	tr := NewTimeoutReader(br, 5*time.Second)
-	msg, err := tr.ReadMessage()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if string(msg) != `{"id":1}` {
-		t.Fatalf("msg = %q", msg)
-	}
-}
+			msg, err := tr.ReadMessage()
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("ReadMessage error = %v, want %v", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("ReadMessage unexpected error: %v", err)
+			}
+			if string(msg) != tt.wantMsg {
+				t.Fatalf("ReadMessage msg = %q, want %q", msg, tt.wantMsg)
+			}
+			if tt.late == nil {
+				return
+			}
 
-func TestTimeoutReader_TimesOut(t *testing.T) {
-	br := &blockingReader{responses: make(chan ReadResult, 1)}
-	// Do not push a response - the reader will block.
-	tr := NewTimeoutReader(br, 50*time.Millisecond)
-	_, err := tr.ReadMessage()
-	if !errors.Is(err, ErrResponseTimeout) {
-		t.Fatalf("expected ErrResponseTimeout, got %v", err)
-	}
-
-	// Push the late response so the goroutine can drain.
-	br.responses <- ReadResult{Msg: []byte(`{"id":1}`), Err: nil}
-
-	// The next read reuses the inflight channel and should return the
-	// buffered late response immediately (well within the 5s deadline).
-	tr.timeout = 5 * time.Second
-	msg, err := tr.ReadMessage()
-	if err != nil {
-		t.Fatalf("expected buffered response, got error: %v", err)
-	}
-	if string(msg) != `{"id":1}` {
-		t.Fatalf("msg = %q", msg)
-	}
-}
-
-func TestTimeoutReader_PropagatesEOF(t *testing.T) {
-	br := &blockingReader{responses: make(chan ReadResult, 1)}
-	br.responses <- ReadResult{Msg: nil, Err: io.EOF}
-	tr := NewTimeoutReader(br, 5*time.Second)
-	_, err := tr.ReadMessage()
-	if !errors.Is(err, io.EOF) {
-		t.Fatalf("expected io.EOF, got %v", err)
+			// Push the late response so the goroutine can drain. The next read
+			// reuses the inflight channel and should return the buffered result.
+			br.responses <- *tt.late
+			tr.timeout = tt.lateReadTO
+			msg, err = tr.ReadMessage()
+			if tt.lateErr != nil {
+				if !errors.Is(err, tt.lateErr) {
+					t.Fatalf("late ReadMessage error = %v, want %v", err, tt.lateErr)
+				}
+			} else if err != nil {
+				t.Fatalf("late ReadMessage unexpected error: %v", err)
+			}
+			if string(msg) != tt.lateMsg {
+				t.Fatalf("late ReadMessage msg = %q, want %q", msg, tt.lateMsg)
+			}
+		})
 	}
 }
 
@@ -125,5 +146,12 @@ func TestTimeoutReader_CloseDrainsHungInner(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("ReadMessage hung after Close; background goroutine did not drain")
+	}
+}
+
+func TestTimeoutReader_CloseNoopWhenInnerNotCloser(t *testing.T) {
+	tr := NewTimeoutReader(&blockingReader{responses: make(chan ReadResult, 1)}, time.Second)
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
 	}
 }

--- a/internal/playground/bundle_internal_test.go
+++ b/internal/playground/bundle_internal_test.go
@@ -401,6 +401,14 @@ func TestLoadOrchestratorSigningKey_Errors(t *testing.T) {
 		t.Fatal("wrong key size must error")
 	}
 
+	degenerate := filepath.Join(dir, "degenerate")
+	if err := os.WriteFile(degenerate, []byte(hex.EncodeToString(make([]byte, ed25519.PrivateKeySize))), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadOrchestratorSigningKey(degenerate); err == nil {
+		t.Fatal("degenerate orchestrator key must error")
+	}
+
 	loosePerms := filepath.Join(dir, "loose")
 	if err := os.WriteFile(loosePerms, []byte(hex.EncodeToString(make([]byte, ed25519.PrivateKeySize))), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/playground/orchestrator_key.go
+++ b/internal/playground/orchestrator_key.go
@@ -63,8 +63,8 @@ func DefaultOrchestratorKeyPath() string {
 }
 
 // LoadOrchestratorSigningKey reads a hex-encoded ed25519 private key from path.
-// It fails closed on a missing file, unsafe Unix permissions, malformed hex, or
-// wrong key length.
+// It fails closed on a missing file, unsafe Unix permissions, malformed hex,
+// wrong key length, or a seed/public-inconsistent private key.
 func LoadOrchestratorSigningKey(path string) (ed25519.PrivateKey, error) {
 	resolved, err := filepath.EvalSymlinks(filepath.Clean(path))
 	if err != nil {
@@ -88,7 +88,11 @@ func LoadOrchestratorSigningKey(path string) (ed25519.PrivateKey, error) {
 	if len(decoded) != ed25519.PrivateKeySize {
 		return nil, fmt.Errorf("orchestrator key wrong size: got %d bytes, want %d", len(decoded), ed25519.PrivateKeySize)
 	}
-	return ed25519.PrivateKey(decoded), nil
+	priv := ed25519.PrivateKey(decoded)
+	if err := signing.ValidatePrivateKeyConsistency(priv); err != nil {
+		return nil, fmt.Errorf("orchestrator key: %w", err)
+	}
+	return priv, nil
 }
 
 // OrchestratorKeyMatchesPublished reports whether priv derives the compiled

--- a/internal/signing/key_consistency_test.go
+++ b/internal/signing/key_consistency_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// allZeroPrivateKey is a length-valid but degenerate Ed25519 private key: its
+// 32-byte stored public half is all zeros, which does NOT match the public key
+// that the (all-zero) seed actually derives. Without a seed->stored-pub
+// consistency check it loads as "valid" and would sign receipts.
+func allZeroPrivateKey() ed25519.PrivateKey {
+	return ed25519.PrivateKey(make([]byte, ed25519.PrivateKeySize))
+}
+
+func realPrivateKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return priv
+}
+
+func TestValidatePrivateKeyConsistency(t *testing.T) {
+	realKey := realPrivateKey(t)
+
+	// A real key with its stored public half corrupted: the seed no longer
+	// derives the stored pub. Tamper a copy so the seed is untouched.
+	tampered := make(ed25519.PrivateKey, ed25519.PrivateKeySize)
+	copy(tampered, realKey)
+	tampered[ed25519.SeedSize] ^= 0xFF
+
+	tests := []struct {
+		name    string
+		key     ed25519.PrivateKey
+		wantErr bool
+	}{
+		{"real key from GenerateKey", realKey, false},
+		{"real key from NewKeyFromSeed", ed25519.NewKeyFromSeed(realKey.Seed()), false},
+		{"all-zero degenerate key", allZeroPrivateKey(), true},
+		{"seed/public mismatch (tampered pub half)", tampered, true},
+		{"wrong length (seed only)", ed25519.PrivateKey(make([]byte, ed25519.SeedSize)), true},
+		{"wrong length (empty)", ed25519.PrivateKey(nil), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePrivateKeyConsistency(tc.key)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil (degenerate/invalid key accepted)")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected nil, got %v (real key wrongly rejected)", err)
+			}
+		})
+	}
+}
+
+func TestDecodePrivateKey_RejectsDegenerate_TwoLine(t *testing.T) {
+	// 2-line versioned format with an all-zero 64-byte key.
+	encoded := EncodePrivateKey(allZeroPrivateKey())
+	if _, err := DecodePrivateKey(encoded); err == nil {
+		t.Fatal("DecodePrivateKey accepted an all-zero 2-line key (fail-open)")
+	}
+
+	// A real key round-trips fine.
+	realKey := realPrivateKey(t)
+	got, err := DecodePrivateKey(EncodePrivateKey(realKey))
+	if err != nil {
+		t.Fatalf("DecodePrivateKey rejected a real key: %v", err)
+	}
+	if !got.Equal(realKey) {
+		t.Fatal("round-tripped key does not equal original")
+	}
+}
+
+func TestDecodePrivateKey_RejectsDegenerate_JSON(t *testing.T) {
+	// JSON keyfile where BOTH the private and public fields are all zeros: the
+	// existing stored-pub-vs-declared-pub check passes (both zero), so only a
+	// seed->stored-pub derivation check catches it.
+	zeroPriv := strings.Repeat("00", ed25519.PrivateKeySize)
+	zeroPub := strings.Repeat("00", ed25519.PublicKeySize)
+	jsonKey := fmt.Sprintf(`{"schema_version":1,"private":"%s","public":"%s"}`, zeroPriv, zeroPub)
+	if _, err := DecodePrivateKey(jsonKey); err == nil {
+		t.Fatal("DecodePrivateKey accepted an all-zero JSON key with matching zero public field (fail-open)")
+	}
+
+	// JSON with no public field but degenerate private must also be rejected.
+	jsonNoPub := fmt.Sprintf(`{"schema_version":1,"private":"%s"}`, zeroPriv)
+	if _, err := DecodePrivateKey(jsonNoPub); err == nil {
+		t.Fatal("DecodePrivateKey accepted an all-zero JSON key with no public field (fail-open)")
+	}
+
+	// A real key serialized as JSON is accepted.
+	realKey := realPrivateKey(t)
+	realPrivHex := hex.EncodeToString(realKey)
+	realPubHex := hex.EncodeToString(realKey[ed25519.SeedSize:])
+	realJSON := fmt.Sprintf(`{"schema_version":1,"private":"%s","public":"%s"}`, realPrivHex, realPubHex)
+	if _, err := DecodePrivateKey(realJSON); err != nil {
+		t.Fatalf("DecodePrivateKey rejected a real JSON key: %v", err)
+	}
+}

--- a/internal/signing/signing.go
+++ b/internal/signing/signing.go
@@ -182,6 +182,26 @@ func ParsePublicKey(encoded string) (ed25519.PublicKey, error) {
 	return ed25519.PublicKey(raw), nil
 }
 
+// ValidatePrivateKeyConsistency verifies that an Ed25519 private key's seed
+// actually derives its stored public half. Go represents an ed25519.PrivateKey
+// as seed(32)||public(32), and priv.Public() returns the STORED public half
+// verbatim, so a length-valid but degenerate or tampered key (e.g. all-zero
+// bytes, or one whose public half was swapped) otherwise loads as "valid" and
+// would sign receipts under a key no verifier can validate. Re-deriving the
+// public key from the seed and comparing closes that gap: a key produced by
+// ed25519.GenerateKey or ed25519.NewKeyFromSeed always passes; an all-zero or
+// seed/public-inconsistent key is rejected. Fails closed.
+func ValidatePrivateKeyConsistency(priv ed25519.PrivateKey) error {
+	if len(priv) != ed25519.PrivateKeySize {
+		return fmt.Errorf("invalid private key length: got %d, want %d", len(priv), ed25519.PrivateKeySize)
+	}
+	derived := ed25519.NewKeyFromSeed(priv.Seed())
+	if !bytes.Equal(derived[ed25519.SeedSize:], priv[ed25519.SeedSize:]) {
+		return errors.New("private key seed does not derive its stored public half (corrupt or degenerate key)")
+	}
+	return nil
+}
+
 // EncodePrivateKey serializes a private key with a versioned header.
 func EncodePrivateKey(key ed25519.PrivateKey) string {
 	return privateKeyHeader + "\n" + base64.StdEncoding.EncodeToString(key) + "\n"
@@ -212,7 +232,11 @@ func DecodePrivateKey(encoded string) (ed25519.PrivateKey, error) {
 	if len(raw) != ed25519.PrivateKeySize {
 		return nil, fmt.Errorf("invalid private key length: got %d, want %d", len(raw), ed25519.PrivateKeySize)
 	}
-	return ed25519.PrivateKey(raw), nil
+	priv := ed25519.PrivateKey(raw)
+	if err := ValidatePrivateKeyConsistency(priv); err != nil {
+		return nil, err
+	}
+	return priv, nil
 }
 
 // decodePrivateKeyJSON extracts an ed25519 private key from the JSON keyfile
@@ -249,6 +273,13 @@ func decodePrivateKeyJSON(data []byte) (ed25519.PrivateKey, error) {
 		return nil, fmt.Errorf("JSON key file private key has wrong size: got %d, want %d", len(privBytes), ed25519.PrivateKeySize)
 	}
 	priv := ed25519.PrivateKey(privBytes)
+	// Reject a degenerate or seed/public-inconsistent key (e.g. all-zero bytes)
+	// before any optional declared-public cross-check: the declared check only
+	// proves the file's two halves agree with each other, not that the seed
+	// derives the stored public half.
+	if err := ValidatePrivateKeyConsistency(priv); err != nil {
+		return nil, err
+	}
 	// Cross-check the public key if provided to detect tampered keyfiles.
 	// A present-but-malformed public field is itself a tamper signal, so we
 	// fail closed on it rather than silently skipping the check.


### PR DESCRIPTION
## What changed

Two stress-test follow-ups found while breaking the v2.8 build before tag. Both fail closed.

Also rejects degenerate or seed/public-inconsistent Ed25519 private keys at load time across signing-key loaders, including the playground orchestrator key path, so corrupt length-valid keys fail closed before signing receipts or bundles.

**MCP response timeout (opt-in).** New `mcp_input_scanning.response_timeout_seconds` (default `0`, disabled, so behavior is unchanged unless you set it). A wrapped MCP server that accepts a request and then never replies used to hang the agent forever. With a positive timeout the proxy fails closed and emits a JSON-RPC `-32000` for the pending request instead of blocking.

The deadline is per complete response message and resets as each message arrives, so a steady response stream is never cut off. Set it above your slowest legitimate tool's latency. It reads through the hot-reload-aware input config and applies whether or not input scanning is enabled.

Teardown differs by transport, because the correct response differs:

- stdio subprocess proxy (including sandbox): terminal. The hung child is killed, and both client and server stdin are closed so the input-forwarding goroutine wakes and the proxy returns even when the agent holds its own input open. A bounded drain backstops a client reader that cannot be closed.
- stdio-to-HTTP bridge (`--upstream`): request-scoped. The timed-out response body is closed, a single `-32000` goes out for that one request only if it is still pending, and the session keeps serving. Other in-flight requests are untouched, and a request that was already answered is never sent a second error.
- HTTP reverse-proxy listener (`--listen`): unchanged, covered by its existing HTTP client and server timeouts.

**Self-update downgrade warning.** `pipelock update --version <older>` now warns before installing a release that predates the `update` command, and prints the exact `mv` command to restore the backup by hand, since the downgraded binary has no `update --rollback`. The printed paths are shell-quoted so they paste safely.

Docs for the new config knob land in this PR (`docs/configuration.md`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mcp_input_scanning.response_timeout_seconds` to cap upstream MCP response time per message and prevent proxy hangs (default `0` disables).

* **Documentation**
  * Configuration guide now explains the new timeout setting and how it behaves across MCP proxy modes.

* **Improvements**
  * Self-update now warns when downgrading to versions before rollback support, including a copy/paste recovery command.
  * Enhanced signing key validation rejects degenerate/tampered Ed25519 private keys.

* **Tests**
  * Expanded coverage for MCP timeout behavior, request-scoped timeout handling, and CLI warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
