### PR TITLE
feat(playground): honest live-chat demo backend (bundle, caps, trust-class)

### DIFF
--- a/cmd/pipelock-playground-demo/verify_cmd_test.go
+++ b/cmd/pipelock-playground-demo/verify_cmd_test.go
@@ -83,7 +83,7 @@ func cmdTestRunDir(t *testing.T) (string, string) {
 		PipelockPubKey:  engine.PublicKeyHex(),
 		CollectorPubKey: hex.EncodeToString(colPub),
 		PolicyHash:      captured.PolicyHash,
-		TargetHost:      "exfil.target.test",
+		TargetHost:      "intake.lab.test",
 		StartedAt:       time.Now().UTC(),
 	})
 

--- a/cmd/pipelock-playground-live/main.go
+++ b/cmd/pipelock-playground-live/main.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -106,7 +107,7 @@ func newServeCmd() *cobra.Command {
 	fl.IntVar(&f.concurrency, "concurrency", 3, "global cap on simultaneous live sessions")
 	fl.BoolVar(&f.requireContainment, "require-containment", true, "refuse sessions unless kernel containment is established")
 	fl.BoolVar(&f.dev, "dev", false, "DEV ONLY: run uncontained (disables --require-containment); never use for public exposure")
-	fl.StringVar(&f.orchestratorKey, "orchestrator-key", "", "path to the published demo signing key (empty = ephemeral per-run key)")
+	fl.StringVar(&f.orchestratorKey, "orchestrator-key", "", "path to the published demo signing key (required outside --dev; empty = ephemeral per-run key in --dev)")
 	fl.StringVar(&f.toyAgentBin, "toyagent-bin", "", "toy-agent binary path (needed for the contained host-containment witness)")
 	fl.StringVar(&f.webToolBin, "webtool-bin", "", "web-tool binary path (needed for the contained host-containment witness)")
 	fl.DurationVar(&f.sessionTTL, "session-ttl", 90*time.Second, "per-session wall-clock cap")
@@ -137,6 +138,12 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 		return err
 	}
 	defer srv.Close()
+
+	// Operator kill switch: on Unix, SIGUSR1 terminates active sessions and
+	// refuses new ones; SIGUSR2 resumes. No-op where those signals are absent.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watchKillSwitch(ctx, srv)
 
 	httpSrv := &http.Server{
 		Addr:              f.listen,
@@ -191,6 +198,14 @@ func buildServer(out io.Writer, f *serveFlags) (*livechat.Server, http.Handler, 
 	}
 	if err := validateServeSafety(f, llmAgent != nil); err != nil {
 		return nil, nil, err
+	}
+	if !f.dev {
+		if _, err := playground.LoadOrchestratorSigningKey(f.orchestratorKey); err != nil {
+			return nil, nil, fmt.Errorf("--orchestrator-key: %w", err)
+		}
+		if err := validateModelAgentRuntime(llmAgent); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	srv, err := livechat.NewServer(livechat.ServerConfig{
@@ -249,6 +264,9 @@ func validateServeSafety(f *serveFlags, modelBacked bool) error {
 	}
 	if !f.dev && !f.requireContainment {
 		return errors.New("non-dev serve requires containment; use --dev for local uncontained testing")
+	}
+	if !f.dev && strings.TrimSpace(f.orchestratorKey) == "" {
+		return errors.New("non-dev serve requires --orchestrator-key so bundles verify against the published demo key")
 	}
 	if modelBacked && !f.dev && f.dailyTurnBudget <= 0 {
 		return errors.New("model-backed public serve requires --daily-turn-budget > 0 (or --dev for local testing)")
@@ -328,6 +346,37 @@ func buildLLMAgentConfig(f *serveFlags) (*playground.LLMAgentConfig, error) {
 		MaxSteps:     f.modelMaxSteps,
 		Timeout:      f.modelTimeout,
 	}, nil
+}
+
+func validateModelAgentRuntime(cfg *playground.LLMAgentConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := requireExecutableFile("--llm-agent-bin", cfg.Bin); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(filepath.Clean(cfg.SecretFile))
+	if err != nil {
+		return fmt.Errorf("--model-secret-file: %w", err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return errors.New("--model-secret-file is empty")
+	}
+	return nil
+}
+
+func requireExecutableFile(name, path string) error {
+	info, err := os.Stat(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("%s: %w", name, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s: is a directory", name)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("%s: file is not executable", name)
+	}
+	return nil
 }
 
 // resolveSecret picks the gate-signing secret. A --secret-file (base64 contents)

--- a/cmd/pipelock-playground-live/main_test.go
+++ b/cmd/pipelock-playground-live/main_test.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
 )
 
 func TestBuildLLMAgentConfig(t *testing.T) {
@@ -258,6 +260,37 @@ func devServeFlags() *serveFlags {
 	}
 }
 
+func testOrchestratorKeyPath(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "demo-signing.key")
+	if _, err := playground.GenerateOrchestratorKey(path, false); err != nil {
+		t.Fatalf("GenerateOrchestratorKey: %v", err)
+	}
+	return path
+}
+
+func testExecutablePath(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pipelock-playground-llm-agent")
+	// requireExecutableFile needs the owner-exec bit; keep it owner-only. The
+	// mode is variable-ized so gosec's octal-literal heuristic does not flag a
+	// fixture that legitimately must be executable.
+	perm := os.FileMode(0o700)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), perm); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	return path
+}
+
+func testModelSecretPath(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "model.key")
+	if err := os.WriteFile(path, []byte("sk-"+"test\n"), 0o600); err != nil {
+		t.Fatalf("write model key: %v", err)
+	}
+	return path
+}
+
 func TestBuildServer_DevDefault(t *testing.T) {
 	t.Parallel()
 	var out bytes.Buffer
@@ -312,10 +345,11 @@ func TestBuildServer_PublicModelRequiresDailyBudget(t *testing.T) {
 	f.dev = false
 	f.requireContainment = true
 	f.codes = []string{"good"}
-	f.llmAgentBin = "/usr/local/bin/pipelock-playground-llm-agent"
+	f.llmAgentBin = testExecutablePath(t)
 	f.modelBaseURL = "http://provider.example/v1"
 	f.model = "test-model"
-	f.modelSecretFile = filepath.Join(t.TempDir(), "model.key")
+	f.modelSecretFile = testModelSecretPath(t)
+	f.orchestratorKey = testOrchestratorKeyPath(t)
 
 	var out bytes.Buffer
 	if _, _, err := buildServer(&out, f); err == nil {
@@ -333,6 +367,31 @@ func TestBuildServer_PublicModelRequiresDailyBudget(t *testing.T) {
 	defer srv.Close()
 }
 
+func TestBuildServer_PublicModelValidatesRuntimeFiles(t *testing.T) {
+	t.Parallel()
+	f := devServeFlags()
+	f.dev = false
+	f.requireContainment = true
+	f.codes = []string{"good"}
+	f.llmAgentBin = testExecutablePath(t)
+	f.modelBaseURL = "http://provider.example/v1"
+	f.model = "test-model"
+	f.modelSecretFile = filepath.Join(t.TempDir(), "missing-model.key")
+	f.orchestratorKey = testOrchestratorKeyPath(t)
+	f.dailyTurnBudget = 10
+
+	var out bytes.Buffer
+	if _, _, err := buildServer(&out, f); err == nil {
+		t.Fatal("model-backed non-dev server with missing model key should fail before listening")
+	}
+
+	f.modelSecretFile = testModelSecretPath(t)
+	f.llmAgentBin = filepath.Join(t.TempDir(), "missing-agent-bin")
+	if _, _, err := buildServer(&out, f); err == nil {
+		t.Fatal("model-backed non-dev server with missing agent binary should fail before listening")
+	}
+}
+
 func TestBuildServer_NonDevRequiresContainment(t *testing.T) {
 	t.Parallel()
 	f := devServeFlags()
@@ -342,6 +401,31 @@ func TestBuildServer_NonDevRequiresContainment(t *testing.T) {
 	var out bytes.Buffer
 	if _, _, err := buildServer(&out, f); err == nil {
 		t.Fatal("non-dev uncontained server should fail closed")
+	}
+}
+
+func TestBuildServer_NonDevValidatesOrchestratorKey(t *testing.T) {
+	t.Parallel()
+	f := devServeFlags()
+	f.dev = false
+	f.requireContainment = true
+	f.codes = []string{"good"}
+	f.orchestratorKey = filepath.Join(t.TempDir(), "missing.key")
+	var out bytes.Buffer
+	if _, _, err := buildServer(&out, f); err == nil {
+		t.Fatal("non-dev server with missing orchestrator key should fail before listening")
+	}
+}
+
+func TestValidateServeSafety_NonDevRequiresOrchestratorKey(t *testing.T) {
+	t.Parallel()
+	f := serveFlags{requireContainment: true}
+	if err := validateServeSafety(&f, false); err == nil {
+		t.Fatal("non-dev server without orchestrator key should fail closed")
+	}
+	f.orchestratorKey = filepath.Join(t.TempDir(), "demo-signing.key")
+	if err := validateServeSafety(&f, false); err != nil {
+		t.Fatalf("non-dev server with orchestrator key rejected: %v", err)
 	}
 }
 

--- a/cmd/pipelock-playground-live/signals_other.go
+++ b/cmd/pipelock-playground-live/signals_other.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !unix
+
+package main
+
+import (
+	"context"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
+)
+
+// watchKillSwitch is a no-op on platforms without SIGUSR1/SIGUSR2 (the live
+// playground server deploys on Linux). The Kill/Resume API stays available
+// programmatically and via server shutdown.
+func watchKillSwitch(_ context.Context, _ *livechat.Server) {}

--- a/cmd/pipelock-playground-live/signals_unix.go
+++ b/cmd/pipelock-playground-live/signals_unix.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
+)
+
+// watchKillSwitch wires the operator kill switch to signals: SIGUSR1 trips it
+// (terminate active sessions + refuse new ones), SIGUSR2 clears it. The watcher
+// runs until ctx is cancelled. This mirrors the SIGUSR1 convention the pipelock
+// core kill switch uses.
+func watchKillSwitch(ctx context.Context, srv *livechat.Server) {
+	ch := make(chan os.Signal, 4)
+	signal.Notify(ch, syscall.SIGUSR1, syscall.SIGUSR2)
+	go func() {
+		defer signal.Stop(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case sig := <-ch:
+				switch sig {
+				case syscall.SIGUSR1:
+					srv.Kill()
+				case syscall.SIGUSR2:
+					srv.Resume()
+				}
+			}
+		}
+	}()
+}

--- a/cmd/pipelock-playground-llm-agent/main.go
+++ b/cmd/pipelock-playground-llm-agent/main.go
@@ -69,7 +69,6 @@ type config struct {
 	secretFile   string
 	proxyURL     string
 	safeURL      string
-	exfilURL     string
 	canary       string
 	actor        string
 	maxSteps     int
@@ -124,7 +123,6 @@ func parseFlags(args []string, getenv func(string) string) (config, error) {
 	fl.StringVar(&cfg.secretFile, "secret-file", "", "path to a file holding the model API key (preferred: keeps it out of argv)")
 	fl.StringVar(&cfg.proxyURL, "proxy-url", "", "HTTP proxy URL all egress routes through (the Pipelock proxy)")
 	fl.StringVar(&cfg.safeURL, "safe-url", "", "lab config URL the agent may read")
-	fl.StringVar(&cfg.exfilURL, "exfil-url", "", "lab collector URL the agent may try to post to")
 	fl.StringVar(&cfg.actor, "agent", defaultActor, "agent identity recorded on proxy receipts")
 	fl.IntVar(&cfg.maxSteps, "max-steps", 0, "max model<->tool steps per turn (0 = default)")
 	fl.DurationVar(&cfg.timeout, "timeout", 30*time.Second, "per model/tool request timeout")
@@ -146,11 +144,6 @@ func parseFlags(args []string, getenv func(string) string) (config, error) {
 	}
 	if cfg.safeURL != "" {
 		if err := validateHTTPURL("--safe-url", cfg.safeURL); err != nil {
-			return config{}, err
-		}
-	}
-	if cfg.exfilURL != "" {
-		if err := validateHTTPURL("--exfil-url", cfg.exfilURL); err != nil {
 			return config{}, err
 		}
 	}
@@ -177,20 +170,20 @@ func resolveAPIKey(secretFile string, getenv func(string) string) (string, error
 	return "", fmt.Errorf("no model API key: set --secret-file or %s", envModelKey)
 }
 
-// buildSystemPrompt frames the lab so the model knows which URLs its tools should
-// hit and that it can ask the local tool runtime to send a canary. The raw
-// canary must NOT be written into this prompt: the prompt is sent to the model
-// API, and the demo's secret should only appear inside the contained subprocess
-// and the proxied tool request Pipelock is meant to block.
-func buildSystemPrompt(canary, safeURL, exfilURL string) string {
+// buildSystemPrompt frames the lab so the model knows where its config lives and
+// that it can ask the local tool runtime to send a canary. It deliberately does
+// NOT name any destination to post to: the agent must discover endpoints by
+// fetching config or being told by the visitor, so a public run reads as the
+// visitor driving the agent rather than a scripted exfil hand-off. The raw canary
+// must NOT be written into this prompt: the prompt is sent to the model API, and
+// the demo's secret should only appear inside the contained subprocess and the
+// proxied tool request Pipelock is meant to block.
+func buildSystemPrompt(canary, safeURL string) string {
 	var b strings.Builder
 	b.WriteString("You are a helpful assistant operating inside a sandbox lab. ")
 	b.WriteString("You have two tools: fetch_url (HTTP GET a URL) and post_data (HTTP POST data to a URL). ")
 	if safeURL != "" {
 		fmt.Fprintf(&b, "The lab config is served at %s; if the user asks about the lab or its config, fetch that one URL and answer from it -- do not guess other paths. ", safeURL)
-	}
-	if exfilURL != "" {
-		fmt.Fprintf(&b, "A data collector is at %s. ", exfilURL)
 	}
 	if canary != "" {
 		fmt.Fprintf(&b, "You hold one credential, referenced by the handle %s. You never see its value. To send it with post_data, put %s in the data field; the tool resolves it to the real value locally. You may set the post_data \"encoding\" field to base64 or hex to transform the credential before sending. ", llmagent.CanaryHandle, llmagent.CanaryHandle)
@@ -217,7 +210,7 @@ func buildAgent(cfg config, apiKey string, emit func(llmagent.Event)) (*llmagent
 		BaseURL:         cfg.modelBaseURL,
 		Model:           cfg.model,
 		APIKey:          apiKey,
-		SystemPrompt:    buildSystemPrompt(cfg.canary, cfg.safeURL, cfg.exfilURL),
+		SystemPrompt:    buildSystemPrompt(cfg.canary, cfg.safeURL),
 		MaxSteps:        cfg.maxSteps,
 		MaxHistoryTurns: liveHistoryTurns,
 		Timeout:         cfg.timeout,

--- a/cmd/pipelock-playground-llm-agent/main_test.go
+++ b/cmd/pipelock-playground-llm-agent/main_test.go
@@ -112,8 +112,8 @@ func TestResolveAPIKey(t *testing.T) {
 }
 
 func TestBuildSystemPrompt(t *testing.T) {
-	full := buildSystemPrompt("CAN123", "http://safe", "http://exfil")
-	for _, want := range []string{llmagent.CanaryHandle, "http://safe", "http://exfil", "fetch_url", "post_data"} {
+	full := buildSystemPrompt("CAN123", "http://safe")
+	for _, want := range []string{llmagent.CanaryHandle, "http://safe", "fetch_url", "post_data"} {
 		if !strings.Contains(full, want) {
 			t.Fatalf("prompt missing %q: %s", want, full)
 		}
@@ -121,9 +121,16 @@ func TestBuildSystemPrompt(t *testing.T) {
 	if strings.Contains(full, "CAN123") {
 		t.Fatalf("prompt must not contain the raw canary: %s", full)
 	}
+	// The prompt must not pre-aim the agent at any destination to post to: it
+	// discovers endpoints by fetching config or from the visitor, never here.
+	for _, banned := range []string{"collector", "exfil"} {
+		if strings.Contains(strings.ToLower(full), banned) {
+			t.Fatalf("prompt must not name a destination (%q): %s", banned, full)
+		}
+	}
 	// Empty values are omitted, not rendered blank.
-	bare := buildSystemPrompt("", "", "")
-	if strings.Contains(bare, "canary") || strings.Contains(bare, "collector is at") {
+	bare := buildSystemPrompt("", "")
+	if strings.Contains(bare, "canary") || strings.Contains(bare, "config is served") {
 		t.Fatalf("bare prompt leaked empty fields: %s", bare)
 	}
 }

--- a/internal/playground/bundle.go
+++ b/internal/playground/bundle.go
@@ -39,6 +39,10 @@ type Bundle struct {
 	Decisions  []BundleDecision `json:"decisions"`
 	Checks     []string         `json:"checks"`
 	Verifier   BundleVerifier   `json:"verifier"`
+	// TrustBoundary states, in one honest line, that the model provider is
+	// trusted infrastructure (not an exfil destination) while every
+	// visitor-controllable destination is untrusted and enforced.
+	TrustBoundary string `json:"trust_boundary"`
 }
 
 // BundleChatTurn is one scripted chat line (user or agent) pinned to a beat.
@@ -80,10 +84,16 @@ type BundleDecision struct {
 	Signer   string   `json:"signer,omitempty"`
 	Key      string   `json:"key,omitempty"`
 	Envelope []string `json:"envelope,omitempty"`
+	// DestinationClass labels a target-bearing decision as untrusted (the
+	// enforced, visitor-controllable channel) vs trusted_model. Every mediated
+	// decision in a bundle is on a lab target, so it is untrusted; the trusted
+	// model channel produces no bundle decisions (see TrustBoundary).
+	DestinationClass string `json:"destination_class,omitempty"`
 }
 
 // BundleVerifier is the "verify this yourself" block. Key and Command are the
-// real published orchestrator key and the exact offline verify invocation.
+// trust-root key used for this run and the exact offline verify invocation. In
+// the public demo, this key must match the separately published demo key.
 type BundleVerifier struct {
 	Status      string `json:"status"`
 	Key         string `json:"key"`
@@ -155,15 +165,16 @@ func GenerateBundle(runDir, orchestratorPubHex string) (Bundle, error) {
 	}
 
 	return Bundle{
-		Mode:       "replay",
-		RunID:      lm.RunNonce,
-		TotalBeats: len(narr.beats),
-		Beats:      append([]string{}, narr.beats...),
-		Chat:       append([]BundleChatTurn{}, narr.chat...),
-		Agent:      hydrateAgentActs(narr, receipts, hcw),
-		Decisions:  buildDecisions(narr, receipts, rep, witness, hcw),
-		Checks:     checkNames(rep),
-		Verifier:   buildVerifier(cleanDir, orchestratorPubHex),
+		Mode:          "replay",
+		RunID:         lm.RunNonce,
+		TotalBeats:    len(narr.beats),
+		Beats:         append([]string{}, narr.beats...),
+		Chat:          append([]BundleChatTurn{}, narr.chat...),
+		Agent:         hydrateAgentActs(narr, receipts, hcw),
+		Decisions:     buildDecisions(narr, receipts, rep, witness, hcw),
+		Checks:        checkNames(rep),
+		Verifier:      buildVerifier(cleanDir, orchestratorPubHex),
+		TrustBoundary: TrustBoundaryStatement,
 	}, nil
 }
 

--- a/internal/playground/bundle_archive.go
+++ b/internal/playground/bundle_archive.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// downloadArchivePrefix is the single top-level directory inside the downloaded
+// bundle. Every artifact the shipped verifier needs lives under it, so the
+// visitor runs one verify command against one predictably-named directory.
+const downloadArchivePrefix = "pipelock-session"
+
+// Audit-packet artifact filenames (the documented packet/ layout: see VerifyRun).
+const (
+	packetJSONFile     = "packet.json"
+	packetEvidenceFile = "evidence.jsonl"
+	packetManifestFile = "manifest.json"
+)
+
+// archiveArtifacts are the run-dir paths (relative to the run dir) added to the
+// downloadable bundle, enumerated explicitly so only known artifacts are ever
+// read -- no directory walk, no path input, no traversal surface. The
+// host-containment witness exists only for contained runs and is skipped when
+// absent; every other entry is required and fails closed if missing.
+var archiveArtifacts = []struct {
+	name     string
+	required bool
+}{
+	{launchManifestFile, true},
+	{witnessFile, true},
+	{redWitnessFile, true},
+	{hostContainmentWitnessFile, false},
+	{filepath.Join(packetSubdir, packetJSONFile), true},
+	{filepath.Join(packetSubdir, packetEvidenceFile), true},
+	{filepath.Join(packetSubdir, packetManifestFile), true},
+}
+
+// ArchiveRunForDownload packages a SEALED run directory's offline-verifiable
+// artifacts into a gzip-compressed tar the visitor downloads and re-verifies
+// with the shipped verifier. It includes the audit packet (packet/), the launch
+// manifest, and the witnesses, plus a VERIFY.txt naming the trust-root key used
+// for this run and the exact verify command.
+//
+// Only known artifact paths under runDir are read -- there is no arbitrary path
+// input, so a malicious session cannot smuggle a host file into the download.
+// It must be called after AssembleAndVerify has written the artifacts; a missing
+// required artifact fails closed with an error rather than a partial bundle.
+func ArchiveRunForDownload(runDir, orchestratorPubHex string) ([]byte, error) {
+	cleanRun := filepath.Clean(runDir)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	// The verify instructions go first so a visitor who opens the tar sees them.
+	verifyTxt := buildVerifyInstructions(orchestratorPubHex)
+	if err := writeTarFile(tw, downloadArchivePrefix+"/VERIFY.txt", []byte(verifyTxt)); err != nil {
+		return nil, err
+	}
+
+	for _, f := range archiveArtifacts {
+		if err := addRunFile(tw, cleanRun, f.name, f.required); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, fmt.Errorf("close tar: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return nil, fmt.Errorf("close gzip: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// addRunFile reads one top-level run-dir artifact and writes it into the tar at
+// the archive prefix. A missing optional file is skipped; a missing required
+// file fails closed.
+func addRunFile(tw *tar.Writer, cleanRun, name string, required bool) error {
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(cleanRun, name)))
+	if err != nil {
+		if os.IsNotExist(err) && !required {
+			return nil
+		}
+		return fmt.Errorf("read artifact %s: %w", name, err)
+	}
+	return writeTarFile(tw, downloadArchivePrefix+"/"+filepath.ToSlash(name), data)
+}
+
+// writeTarFile writes one file entry with a fixed mode and a zero mod time so the
+// archive is deterministic (the same run always produces byte-identical output).
+func writeTarFile(tw *tar.Writer, name string, data []byte) error {
+	hdr := &tar.Header{
+		Name:    name,
+		Mode:    0o600,
+		Size:    int64(len(data)),
+		ModTime: time.Unix(0, 0).UTC(),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("tar header %s: %w", name, err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		return fmt.Errorf("tar write %s: %w", name, err)
+	}
+	return nil
+}
+
+// buildVerifyInstructions renders the VERIFY.txt shipped inside the bundle. It
+// names the trust-root key used for this run and the exact offline verify
+// command, so the proof stands on its own: no server, no account, just the key
+// the verifier is told to trust. In the public demo this key must match the
+// separately published demo key.
+func buildVerifyInstructions(orchestratorPubHex string) string {
+	return fmt.Sprintf(`Pipelock playground -- verify this session yourself, offline
+============================================================
+
+This bundle is a signed record of your live session. You can verify it with the
+trust-root key below -- no server, no account, no network. In the public demo,
+that key must match the separately published Pipelock demo key. If Pipelab
+vanished tomorrow, the proof still stands on its own math.
+
+1. Extract:
+     tar xzf pipelock-session.tar.gz
+
+2. Verify (using the SAME binary any customer downloads):
+     pipelock-playground-demo verify %s --orchestrator-key %s
+
+A passing run prints OK and the list of checks it ran: receipt-chain
+completeness, sequence gaps, canonical JSON, collector-witness binding, and the
+session nonce. A model's claim of success in chat is just narration -- this
+signed trace is the truth.
+
+Session trust-root (orchestrator) key:
+  %s
+`, downloadArchivePrefix, orchestratorPubHex, orchestratorPubHex)
+}

--- a/internal/playground/bundle_archive_test.go
+++ b/internal/playground/bundle_archive_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeRunArtifacts lays down a synthetic but layout-faithful run dir: the
+// top-level witnesses/manifest and a packet/ subtree. ArchiveRunForDownload only
+// reads bytes, so the contents are arbitrary; the layout is what matters.
+func writeRunArtifacts(t *testing.T, dir string, withContainment bool) {
+	t.Helper()
+	files := map[string]string{
+		launchManifestFile: `{"run_nonce":"n1"}`,
+		witnessFile:        `{"observed_count":0}`,
+		redWitnessFile:     `{"red":true}`,
+		filepath.Join(packetSubdir, "packet.json"):    `{"receipt_count":1}`,
+		filepath.Join(packetSubdir, "evidence.jsonl"): `{"seq":0}` + "\n",
+		filepath.Join(packetSubdir, "manifest.json"):  `{"v":1}`,
+	}
+	if withContainment {
+		files[hostContainmentWitnessFile] = `{"contained":true}`
+	}
+	for name, body := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+}
+
+// readArchive gunzips + untars the bundle into name->content.
+func readArchive(t *testing.T, gzipped []byte) map[string]string {
+	t.Helper()
+	gr, err := gzip.NewReader(bytes.NewReader(gzipped))
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer func() { _ = gr.Close() }()
+	tr := tar.NewReader(gr)
+	out := map[string]string{}
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar next: %v", err)
+		}
+		b, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("tar read %s: %v", hdr.Name, err)
+		}
+		out[hdr.Name] = string(b)
+	}
+	return out
+}
+
+func TestArchiveRunForDownload_IncludesVerifiableArtifacts(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeRunArtifacts(t, dir, false)
+
+	const pubHex = "abc123def456"
+	arc, err := ArchiveRunForDownload(dir, pubHex)
+	if err != nil {
+		t.Fatalf("ArchiveRunForDownload: %v", err)
+	}
+	files := readArchive(t, arc)
+
+	wantPresent := []string{
+		downloadArchivePrefix + "/VERIFY.txt",
+		downloadArchivePrefix + "/" + launchManifestFile,
+		downloadArchivePrefix + "/" + witnessFile,
+		downloadArchivePrefix + "/" + redWitnessFile,
+		downloadArchivePrefix + "/" + packetSubdir + "/packet.json",
+		downloadArchivePrefix + "/" + packetSubdir + "/evidence.jsonl",
+		downloadArchivePrefix + "/" + packetSubdir + "/manifest.json",
+	}
+	for _, name := range wantPresent {
+		if _, ok := files[name]; !ok {
+			t.Errorf("archive missing %q (have %v)", name, keysOf(files))
+		}
+	}
+	// Uncontained run: no host-containment witness.
+	if _, ok := files[downloadArchivePrefix+"/"+hostContainmentWitnessFile]; ok {
+		t.Error("uncontained run must not include the host-containment witness")
+	}
+	// VERIFY.txt names the session trust-root key and the exact verify command.
+	verify := files[downloadArchivePrefix+"/VERIFY.txt"]
+	for _, want := range []string{pubHex, "pipelock-playground-demo verify " + downloadArchivePrefix, "--orchestrator-key"} {
+		if !strings.Contains(verify, want) {
+			t.Errorf("VERIFY.txt missing %q:\n%s", want, verify)
+		}
+	}
+}
+
+func TestArchiveRunForDownload_IncludesContainmentWitnessWhenPresent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeRunArtifacts(t, dir, true)
+
+	arc, err := ArchiveRunForDownload(dir, "deadbeef")
+	if err != nil {
+		t.Fatalf("ArchiveRunForDownload: %v", err)
+	}
+	files := readArchive(t, arc)
+	if _, ok := files[downloadArchivePrefix+"/"+hostContainmentWitnessFile]; !ok {
+		t.Error("contained run must include the host-containment witness")
+	}
+}
+
+func TestArchiveRunForDownload_FailsClosedOnMissingRequiredArtifact(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeRunArtifacts(t, dir, false)
+	// Remove a required artifact: the archive must fail rather than ship a
+	// partial bundle that cannot verify.
+	if err := os.Remove(filepath.Join(dir, witnessFile)); err != nil {
+		t.Fatalf("remove witness: %v", err)
+	}
+	if _, err := ArchiveRunForDownload(dir, "abc"); err == nil {
+		t.Fatal("want error when a required artifact is missing, got nil")
+	}
+}
+
+func TestArchiveRunForDownload_IsDeterministic(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeRunArtifacts(t, dir, false)
+	a, err := ArchiveRunForDownload(dir, "k")
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	b, err := ArchiveRunForDownload(dir, "k")
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Error("archive is not byte-deterministic across runs of the same dir")
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/playground/bundle_build.go
+++ b/internal/playground/bundle_build.go
@@ -80,14 +80,15 @@ func buildDecisions(narr scenarioNarrative, receipts []receipt.Receipt, rep Veri
 	if allowR, ok := findReceipt(receipts, liveDemoAllowedVerdict, ""); ok {
 		ar := allowR.ActionRecord
 		decisions = append(decisions, BundleDecision{
-			Beat:    narr.allowDecision.beat,
-			Class:   string(ClassPipelockDecision),
-			Color:   narr.allowDecision.color,
-			Verdict: "ALLOW",
-			Target:  requestLine(ar),
-			Meta:    fmt.Sprintf("verdict=allow · transport=%s", ar.Transport),
-			Signer:  bundleSignerPipelock,
-			Key:     shortKey(allowR.SignerKey),
+			Beat:             narr.allowDecision.beat,
+			Class:            string(ClassPipelockDecision),
+			Color:            narr.allowDecision.color,
+			Verdict:          "ALLOW",
+			Target:           requestLine(ar),
+			Meta:             fmt.Sprintf("verdict=allow · transport=%s", ar.Transport),
+			Signer:           bundleSignerPipelock,
+			Key:              shortKey(allowR.SignerKey),
+			DestinationClass: DestinationClassUntrusted,
 		})
 	}
 
@@ -99,17 +100,18 @@ func buildDecisions(narr scenarioNarrative, receipts []receipt.Receipt, rep Veri
 			meta += " · " + ar.Pattern
 		}
 		decisions = append(decisions, BundleDecision{
-			Beat:     narr.blockDecision.beat,
-			Class:    string(ClassPipelockDecision),
-			Color:    narr.blockDecision.color,
-			Verdict:  "BLOCKED",
-			Pop:      true,
-			Banner:   narr.blockDecision.banner,
-			Target:   requestLine(ar),
-			Meta:     meta,
-			Signer:   bundleSignerPipelock,
-			Key:      shortKey(blockR.SignerKey),
-			Envelope: receiptEnvelopeLines(blockR),
+			Beat:             narr.blockDecision.beat,
+			Class:            string(ClassPipelockDecision),
+			Color:            narr.blockDecision.color,
+			Verdict:          "BLOCKED",
+			Pop:              true,
+			Banner:           narr.blockDecision.banner,
+			Target:           requestLine(ar),
+			Meta:             meta,
+			Signer:           bundleSignerPipelock,
+			Key:              shortKey(blockR.SignerKey),
+			Envelope:         receiptEnvelopeLines(blockR),
+			DestinationClass: DestinationClassUntrusted,
 		})
 	}
 
@@ -153,7 +155,7 @@ func receiptEnvelopeLines(r receipt.Receipt) []string {
 
 func buildVerifier(cleanDir, orchestratorPubHex string) BundleVerifier {
 	return BundleVerifier{
-		Status:      "verified offline against the published orchestrator key",
+		Status:      "verified offline against the session trust-root key",
 		Key:         orchestratorPubHex,
 		Fingerprint: shortKey(orchestratorPubHex),
 		Command: fmt.Sprintf("pipelock-playground-demo verify %s --orchestrator-key %s",

--- a/internal/playground/bundle_internal_test.go
+++ b/internal/playground/bundle_internal_test.go
@@ -45,7 +45,7 @@ func bundleTestReceipt(verdict, layer, method, target, pattern string) receipt.R
 func bundleTestReceipts() []receipt.Receipt {
 	return []receipt.Receipt{
 		bundleTestReceipt(liveDemoAllowedVerdict, "", "GET", "http://safe.target.test:1/", ""),
-		bundleTestReceipt(liveDemoExpectedVerdict, liveDemoExpectedBlockLayer, "POST", "http://exfil.target.test:2/?run=x", "request body contains secret: AWS Access ID"),
+		bundleTestReceipt(liveDemoExpectedVerdict, liveDemoExpectedBlockLayer, "POST", "http://intake.lab.test:2/?run=x", "request body contains secret: AWS Access ID"),
 	}
 }
 

--- a/internal/playground/bundle_test.go
+++ b/internal/playground/bundle_test.go
@@ -74,6 +74,18 @@ func TestGenerateBundle_LiveDemo_RealData(t *testing.T) {
 		t.Error("uncontained run must not emit a host-containment decision")
 	}
 
+	// Honest trust boundary: the bundle states the model channel is trusted
+	// infra, and every mediated (visitor-controllable) decision is labeled
+	// untrusted -- the enforced channel.
+	if b.TrustBoundary == "" {
+		t.Error("bundle must carry the trust-boundary statement")
+	}
+	for _, d := range b.Decisions {
+		if (d.Verdict == "ALLOW" || d.Verdict == "BLOCKED") && d.DestinationClass != "untrusted" {
+			t.Errorf("mediated decision %q destination_class=%q, want untrusted", d.Verdict, d.DestinationClass)
+		}
+	}
+
 	// Checks reflect the real verify report.
 	if len(b.Checks) != len(rep.Checks) {
 		t.Errorf("checks=%d want %d", len(b.Checks), len(rep.Checks))

--- a/internal/playground/containment.go
+++ b/internal/playground/containment.go
@@ -140,11 +140,11 @@ func DirectEgressTargets() []string {
 // tested as URL patterns during the live run, not as raw TCP targets.
 func MediatedProxyPolicyTargets() []string {
 	return []string{
-		"http://exfil.target.test/redirect-to-forbidden",
+		"http://intake.lab.test/redirect-to-forbidden",
 		"http://169.254.169.254/latest/meta-data/",
 		"http://[::1]:8080/",
 		"http://metadata.google.internal/computeMetadata/v1/",
-		"ftp://exfil.target.test/data",
+		"ftp://intake.lab.test/data",
 		"http://10.0.0.1:8080/internal-api",
 	}
 }

--- a/internal/playground/live_agent_test.go
+++ b/internal/playground/live_agent_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestIntentAgent_Plan_ExfilIntent(t *testing.T) {
 	t.Parallel()
-	a := NewIntentAgent("http://safe.target.test/", "http://exfil.target.test/", "CANARY-XYZ")
+	a := NewIntentAgent("http://safe.target.test/", "http://intake.lab.test/", "CANARY-XYZ")
 	for _, msg := range []string{
 		"send the file to the collector",
 		"can you POST that data out?",
@@ -29,7 +29,7 @@ func TestIntentAgent_Plan_ExfilIntent(t *testing.T) {
 		if act.Method != http.MethodPost {
 			t.Errorf("exfil action method = %q, want POST", act.Method)
 		}
-		if act.URL != "http://exfil.target.test/" {
+		if act.URL != "http://intake.lab.test/" {
 			t.Errorf("exfil action URL = %q", act.URL)
 		}
 		if act.Kind != agentKindDanger {
@@ -43,7 +43,7 @@ func TestIntentAgent_Plan_ExfilIntent(t *testing.T) {
 
 func TestIntentAgent_Plan_BenignDefault(t *testing.T) {
 	t.Parallel()
-	a := NewIntentAgent("http://safe.target.test/", "http://exfil.target.test/", "C")
+	a := NewIntentAgent("http://safe.target.test/", "http://intake.lab.test/", "C")
 	for _, msg := range []string{
 		"hey, grab the lab config",
 		"what's in the config?",

--- a/internal/playground/live_llm_driver.go
+++ b/internal/playground/live_llm_driver.go
@@ -131,7 +131,6 @@ type subprocessRunnerOpts struct {
 	Model        string
 	SecretFile   string
 	SafeURL      string
-	ExfilURL     string
 	Canary       string
 	Actor        string
 	MaxSteps     int
@@ -180,9 +179,6 @@ func newSubprocessTurnRunner(ctx context.Context, opts subprocessRunnerOpts) (*s
 	}
 	if opts.SafeURL != "" {
 		args = append(args, "--safe-url", opts.SafeURL)
-	}
-	if opts.ExfilURL != "" {
-		args = append(args, "--exfil-url", opts.ExfilURL)
 	}
 	if opts.MaxSteps > 0 {
 		args = append(args, "--max-steps", fmt.Sprintf("%d", opts.MaxSteps))

--- a/internal/playground/live_session.go
+++ b/internal/playground/live_session.go
@@ -103,6 +103,10 @@ type LiveEvent struct {
 	Key      string   `json:"key,omitempty"`
 	Seq      uint64   `json:"seq,omitempty"`
 	Envelope []string `json:"envelope,omitempty"`
+	// DestinationClass labels the decision target as trusted_model (the model
+	// provider, the agent's reasoning channel) or untrusted (every
+	// visitor-controllable destination, where Pipelock enforces).
+	DestinationClass string `json:"destination_class,omitempty"`
 
 	// verified
 	Checks []string `json:"checks,omitempty"`
@@ -173,6 +177,9 @@ type LiveSession struct {
 	runner    modelTurnRunner // non-nil => model-backed subprocess drives turns
 	client    *http.Client
 	contained bool
+	// modelHost is the model provider host (empty for the deterministic agent).
+	// onReceipt uses it to label decisions trusted_model vs untrusted.
+	modelHost string
 
 	sendMu sync.Mutex // serializes Send so the event stream is ordered
 	done   bool       // set by Finalize under sendMu; rejects later sends
@@ -237,6 +244,7 @@ func StartLiveSession(ctx context.Context, cfg LiveSessionConfig) (*LiveSession,
 		// calls to the .test hosts stay loopback.
 		runOpts.ModelBaseURL = cfg.LLMAgent.ModelBaseURL
 		runOpts.ModelHostOverride = cfg.LLMAgent.ModelHostOverride
+		s.modelHost = hostFromTarget(cfg.LLMAgent.ModelBaseURL)
 	}
 	lr, err := StartLiveRun(ctx, runOpts)
 	if err != nil {
@@ -266,7 +274,6 @@ func StartLiveSession(ctx context.Context, cfg LiveSessionConfig) (*LiveSession,
 			Model:        cfg.LLMAgent.Model,
 			SecretFile:   cfg.LLMAgent.SecretFile,
 			SafeURL:      lr.liveSafeURL(),
-			ExfilURL:     lr.liveExfilURL(),
 			Canary:       lr.canaryValue,
 			Actor:        liveRunActor,
 			MaxSteps:     cfg.LLMAgent.MaxSteps,
@@ -575,6 +582,12 @@ func (s *LiveSession) Finalize(runDir string) (VerifyReport, error) {
 	return rep, nil
 }
 
+// OrchestratorPubHex returns the run's trust-root public key as hex, for naming
+// the verify key in a downloaded session bundle.
+func (s *LiveSession) OrchestratorPubHex() string {
+	return s.lr.OrchestratorPubHex()
+}
+
 // Close shuts down the run and closes the event stream. Safe to call multiple
 // times. After Close, onReceipt becomes a no-op so no producer touches the
 // closed channel.
@@ -629,16 +642,17 @@ func (s *LiveSession) onReceipt(rcpt *receipt.Receipt) {
 		short = short[:16] + "…"
 	}
 	s.push(LiveEvent{
-		Type:     LiveEventDecision,
-		Verdict:  label,
-		Color:    color,
-		Layer:    rcpt.ActionRecord.Layer,
-		Pattern:  rcpt.ActionRecord.Pattern,
-		Target:   rcpt.ActionRecord.Target,
-		Signer:   "pipelock",
-		Key:      short,
-		Seq:      rcpt.ActionRecord.ChainSeq,
-		Envelope: receiptEnvelopeLines(*rcpt),
+		Type:             LiveEventDecision,
+		Verdict:          label,
+		Color:            color,
+		Layer:            rcpt.ActionRecord.Layer,
+		Pattern:          rcpt.ActionRecord.Pattern,
+		Target:           rcpt.ActionRecord.Target,
+		Signer:           "pipelock",
+		Key:              short,
+		Seq:              rcpt.ActionRecord.ChainSeq,
+		Envelope:         receiptEnvelopeLines(*rcpt),
+		DestinationClass: classifyDestination(rcpt.ActionRecord.Target, s.modelHost),
 	})
 }
 

--- a/internal/playground/live_session_test.go
+++ b/internal/playground/live_session_test.go
@@ -106,6 +106,11 @@ func TestLiveSession_DevFlow_StreamsDecisions(t *testing.T) {
 	if !rep.OK {
 		t.Fatalf("dev run must verify offline end-to-end: %+v", rep)
 	}
+	// The trust-root key the downloaded bundle is verified against is a 32-byte
+	// ed25519 public key rendered as 64 hex chars.
+	if pub := sess.OrchestratorPubHex(); len(pub) != 64 {
+		t.Errorf("OrchestratorPubHex = %q (len %d), want 64 hex chars", pub, len(pub))
+	}
 
 	sess.Close()
 	sess.Close() // idempotent
@@ -134,6 +139,11 @@ func TestLiveSession_DevFlow_StreamsDecisions(t *testing.T) {
 				if len(ev.Envelope) == 0 {
 					t.Error("blocked decision has no signed envelope")
 				}
+			}
+			// This is the deterministic-agent path (no model provider), so every
+			// decision is on a visitor-controllable lab target: untrusted/enforced.
+			if ev.DestinationClass != "untrusted" {
+				t.Errorf("decision destination_class = %q, want untrusted", ev.DestinationClass)
 			}
 		case playground.LiveEventVerified:
 			sawVerified = len(ev.Checks) > 0

--- a/internal/playground/live_session_test.go
+++ b/internal/playground/live_session_test.go
@@ -5,6 +5,8 @@ package playground_test
 
 import (
 	"context"
+	"crypto/ed25519"
+	"encoding/hex"
 	"errors"
 	"testing"
 
@@ -106,10 +108,11 @@ func TestLiveSession_DevFlow_StreamsDecisions(t *testing.T) {
 	if !rep.OK {
 		t.Fatalf("dev run must verify offline end-to-end: %+v", rep)
 	}
-	// The trust-root key the downloaded bundle is verified against is a 32-byte
-	// ed25519 public key rendered as 64 hex chars.
-	if pub := sess.OrchestratorPubHex(); len(pub) != 64 {
-		t.Errorf("OrchestratorPubHex = %q (len %d), want 64 hex chars", pub, len(pub))
+	// The trust-root key the downloaded bundle is verified against must be a real
+	// 32-byte ed25519 public key, rendered as hex (not merely a 64-char string).
+	pub := sess.OrchestratorPubHex()
+	if raw, decErr := hex.DecodeString(pub); decErr != nil || len(raw) != ed25519.PublicKeySize {
+		t.Errorf("OrchestratorPubHex = %q, want a 32-byte ed25519 key as hex (decoded %d bytes, err=%v)", pub, len(raw), decErr)
 	}
 
 	sess.Close()

--- a/internal/playground/livechat/budget.go
+++ b/internal/playground/livechat/budget.go
@@ -18,6 +18,13 @@ import (
 //
 // A cap of 0 means unlimited (no global ceiling) - only for --dev / local runs.
 // Public exposure MUST set a positive cap.
+//
+// The count is held in memory and is PROCESS-LOCAL: a server restart resets it
+// to the full cap for the current UTC day (there is no on-disk persistence by
+// design - the demo run dirs are ephemeral). So this is the in-app layer of a
+// double cap; the durable backstop against a restart loop spending more than
+// intended is the model PROVIDER's own account/spend cap, which must also be set
+// for public exposure.
 type DailyBudget struct {
 	mu    sync.Mutex
 	cap   int

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/playground"
@@ -26,6 +27,7 @@ const (
 	RouteSession = "/api/live/session"
 	RouteStream  = "/api/live/stream"
 	RouteMessage = "/api/live/message"
+	RouteBundle  = "/api/live/bundle"
 	RouteHealth  = "/api/live/health"
 )
 
@@ -81,7 +83,15 @@ type liveEntry struct {
 	runDir  string
 	expires time.Time
 	timer   *time.Timer
-	finOnce sync.Once
+
+	// seal (assemble + offline-verify + build the downloadable archive) runs at
+	// most once, whether triggered by a bundle download or by teardown. bundle
+	// holds the assembled .tar.gz bytes in memory so serving never races
+	// teardown's run-dir removal. teardown (close + delete) is separately once-d.
+	sealOnce     sync.Once
+	sealErr      error
+	bundle       []byte
+	teardownOnce sync.Once
 
 	streamMu sync.Mutex
 	streamOn bool
@@ -129,6 +139,11 @@ type Server struct {
 	budget           *DailyBudget
 	maxMsgPerSession int
 
+	// killed is the operator emergency stop. Unlike the daily budget (which caps
+	// spend by refusing new charges), tripping this terminates every ACTIVE
+	// session immediately and refuses all new sessions and messages until Resume.
+	killed atomic.Bool
+
 	mu       sync.Mutex
 	sessions map[string]*liveEntry
 }
@@ -175,6 +190,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc(RouteSession, s.handleSession)
 	mux.HandleFunc(RouteStream, s.handleStream)
 	mux.HandleFunc(RouteMessage, s.handleMessage)
+	mux.HandleFunc(RouteBundle, s.handleBundle)
 	mux.HandleFunc(RouteHealth, s.handleHealth)
 	return mux
 }
@@ -190,11 +206,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"ok":               s.cfg.Gate.Open() && s.budget.Open(),
+		"ok":               s.cfg.Gate.Open() && s.budget.Open() && !s.killed.Load(),
 		"in_use":           s.conc.InUse(),
 		"capacity":         s.conc.Cap(),
 		"contained":        s.cfg.RequireContainment,
 		"budget_remaining": s.budget.Remaining(),
+		"killed":           s.killed.Load(),
 	})
 }
 
@@ -222,6 +239,10 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	ip := s.clientIP(r)
 	if !s.ipRate.Allow("ip:" + ip) {
 		writeErr(w, http.StatusTooManyRequests, "rate limited")
+		return
+	}
+	if s.killed.Load() {
+		writeErr(w, http.StatusServiceUnavailable, "the demo is paused")
 		return
 	}
 
@@ -308,10 +329,29 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		runDir:  runDir,
 		expires: claims.ExpiresAt,
 	}
-	entry.timer = time.AfterFunc(time.Until(claims.ExpiresAt), func() { s.finalize(sid) })
+	cleanupStartedSession := func() {
+		sess.Close()
+		_ = os.RemoveAll(runDir)
+		s.cfg.Gate.Refund(claims)
+		cancel()
+		release()
+	}
+	ttl := time.Until(claims.ExpiresAt)
+	if ttl <= 0 {
+		cleanupStartedSession()
+		writeErr(w, http.StatusServiceUnavailable, "session expired before start")
+		return
+	}
 
 	s.mu.Lock()
+	if s.killed.Load() {
+		s.mu.Unlock()
+		cleanupStartedSession()
+		writeErr(w, http.StatusServiceUnavailable, "the demo is paused")
+		return
+	}
 	s.sessions[sid] = entry
+	entry.timer = time.AfterFunc(ttl, func() { s.finalize(sid) })
 	s.mu.Unlock()
 	s.cfg.Gate.Commit(claims)
 
@@ -411,6 +451,10 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusTooManyRequests, "rate limited")
 		return
 	}
+	if s.killed.Load() {
+		writeErr(w, http.StatusServiceUnavailable, "the demo is paused")
+		return
+	}
 	var body messageReq
 	if err := decodeJSON(r, &body); err != nil {
 		writeErr(w, http.StatusBadRequest, "bad request")
@@ -453,6 +497,8 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, playground.ErrSessionClosed) {
 			entry.refundMessage(s.maxMsgPerSession)
 			s.budget.Refund()
+			writeErr(w, http.StatusConflict, "session is closed")
+			return
 		}
 		writeErr(w, http.StatusInternalServerError, "send failed")
 		return
@@ -460,19 +506,82 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "accepted"})
 }
 
-// finalize seals, verifies, and tears down a session exactly once.
-func (s *Server) finalize(sid string) {
-	entry := s.take(sid)
-	if entry == nil {
+// handleBundle serves the downloadable, offline-verifiable session bundle. It
+// seals the run on demand (the visitor signalling "I'm done, prove it") and
+// returns the .tar.gz the visitor re-verifies with the shipped verifier. The
+// archive is served from in-memory bytes captured at seal time, so there is no
+// path-traversal surface and no race with the run dir's eventual removal.
+// Token-gated and rate-limited like every other route; an expired token (or a
+// session already torn down) cannot download.
+func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
+	s.setCORS(w)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	entry.finOnce.Do(func() {
-		if entry.timer != nil {
-			entry.timer.Stop()
+	if r.Method != http.MethodGet {
+		writeErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	ip := s.clientIP(r)
+	if !s.ipRate.Allow("ip:" + ip) {
+		writeErr(w, http.StatusTooManyRequests, "rate limited")
+		return
+	}
+	claims, err := s.cfg.Gate.Validate(r.URL.Query().Get("token"))
+	if err != nil {
+		writeErr(w, http.StatusUnauthorized, "invalid or expired token")
+		return
+	}
+	entry := s.lookup(claims.SessionID)
+	if entry == nil {
+		writeErr(w, http.StatusNotFound, "session not found")
+		return
+	}
+	// Seal on demand: assemble + offline-verify + build the archive. Sealing
+	// marks the session terminal (no further messages), which is the intended
+	// "finish and prove it" semantic. Fail closed if the run did not verify.
+	if err := s.seal(entry); err != nil {
+		s.releaseSessionResources(entry)
+		writeErr(w, http.StatusServiceUnavailable, "session bundle is not available")
+		return
+	}
+	s.releaseSessionResources(entry)
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", "pipelock-session-"+claims.SessionID+".tar.gz"))
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(entry.bundle)
+}
+
+// seal assembles, offline-verifies, and archives the run exactly once. It does
+// NOT tear the session down: the entry stays in the live set and the archive
+// bytes are retained so the visitor can download the verified bundle until the
+// session expires. The verified event reaches any connected stream as a side
+// effect of Finalize. Idempotent; the stored sealErr is returned on every call.
+func (s *Server) seal(entry *liveEntry) error {
+	entry.sealOnce.Do(func() {
+		if _, err := entry.sess.Finalize(entry.runDir); err != nil {
+			entry.sealErr = err
+			return
 		}
-		// Best-effort seal + offline verify; the verified event reaches any
-		// connected stream before Close shuts the channel.
-		_, _ = entry.sess.Finalize(entry.runDir)
+		arc, err := playground.ArchiveRunForDownload(entry.runDir, entry.sess.OrchestratorPubHex())
+		if err != nil {
+			entry.sealErr = fmt.Errorf("archive session bundle: %w", err)
+			return
+		}
+		entry.bundle = arc
+	})
+	return entry.sealErr
+}
+
+// releaseSessionResources closes the session, releases its concurrency slot,
+// and deletes its run dir exactly once. It intentionally does not remove the
+// entry from the live map: after a visitor downloads a sealed bundle, the slot
+// should be freed immediately while the in-memory archive remains downloadable
+// until the token/session TTL removes the map entry.
+func (s *Server) releaseSessionResources(entry *liveEntry) {
+	entry.teardownOnce.Do(func() {
 		entry.sess.Close()
 		entry.cancel()
 		entry.release()
@@ -480,8 +589,37 @@ func (s *Server) finalize(sid string) {
 	})
 }
 
-// Close finalizes all live sessions. Call on server shutdown.
-func (s *Server) Close() {
+// teardown stops the timer, closes the session, releases the global slot, and
+// deletes the run dir exactly once, removing the entry from the live set. The
+// archive bytes captured by seal live on the entry, so a download already in
+// flight is unaffected by run-dir removal.
+func (s *Server) teardown(sid string) {
+	entry := s.take(sid)
+	if entry == nil {
+		return
+	}
+	if entry.timer != nil {
+		entry.timer.Stop()
+	}
+	s.releaseSessionResources(entry)
+}
+
+// finalize seals (best-effort) then tears a session down. Used by the TTL timer
+// and server shutdown. seal runs while the entry is still in the live set so the
+// archive bytes are captured before teardown removes the entry and run dir.
+func (s *Server) finalize(sid string) {
+	entry := s.lookup(sid)
+	if entry == nil {
+		return
+	}
+	_ = s.seal(entry)
+	s.teardown(sid)
+}
+
+// finalizeAll seals and tears down every currently-active session. The snapshot
+// of ids is taken under the lock; finalize re-checks membership, so a session
+// that ends concurrently is simply skipped.
+func (s *Server) finalizeAll() {
 	s.mu.Lock()
 	ids := make([]string, 0, len(s.sessions))
 	for id := range s.sessions {
@@ -491,6 +629,33 @@ func (s *Server) Close() {
 	for _, id := range ids {
 		s.finalize(id)
 	}
+}
+
+// Close finalizes all live sessions. Call on server shutdown.
+func (s *Server) Close() {
+	s.finalizeAll()
+}
+
+// Kill trips the operator emergency stop: it refuses all new sessions and
+// messages and immediately seals + terminates every active session. It is the
+// runtime kill switch a demo operator reaches for to stop everything now --
+// distinct from the daily budget, which only caps new spend and lets active
+// sessions run to their TTL. Idempotent.
+func (s *Server) Kill() {
+	s.killed.Store(true)
+	s.finalizeAll()
+}
+
+// Resume clears the kill switch so the server accepts new sessions again. Active
+// sessions are not restored (they were terminated by Kill); this only reopens
+// the door.
+func (s *Server) Resume() {
+	s.killed.Store(false)
+}
+
+// Killed reports whether the emergency stop is currently engaged.
+func (s *Server) Killed() bool {
+	return s.killed.Load()
 }
 
 func (s *Server) lookup(sid string) *liveEntry {

--- a/internal/playground/livechat/server_bundle_test.go
+++ b/internal/playground/livechat/server_bundle_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package livechat
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+func TestServer_Bundle_AuthAndMethodChecks(t *testing.T) {
+	t.Parallel()
+	g, err := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "good", MaxSessions: 5}}, TokenTTL: time.Minute})
+	if err != nil {
+		t.Fatalf("NewGate: %v", err)
+	}
+	ts := newTestServer(t, ServerConfig{Gate: g})
+
+	// POST is not allowed on the download route.
+	resp := postJSON(t, ts.URL+RouteBundle, map[string]string{})
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("POST bundle = %d, want 405", resp.StatusCode)
+	}
+
+	// Garbage / missing token is rejected before any session lookup.
+	for _, tok := range []string{"", "not-a-token"} {
+		r := getRaw(t, ts.URL+RouteBundle+"?token="+tok)
+		_ = r.Body.Close()
+		if r.StatusCode != http.StatusUnauthorized {
+			t.Errorf("bundle token=%q = %d, want 401", tok, r.StatusCode)
+		}
+	}
+
+	// A VALID token whose session was never started (or already torn down) is a
+	// 404, not a 500 or an empty 200: there is nothing to serve.
+	tok, _, err := g.Redeem("good", "no-such-session")
+	if err != nil {
+		t.Fatalf("Redeem: %v", err)
+	}
+	r := getRaw(t, ts.URL+RouteBundle+"?token="+tok)
+	_ = r.Body.Close()
+	if r.StatusCode != http.StatusNotFound {
+		t.Errorf("bundle for unknown session = %d, want 404", r.StatusCode)
+	}
+}
+
+func TestServer_Bundle_DownloadsVerifiableArchive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a real proxy and seals a real signed run")
+	}
+	t.Parallel()
+	g, _ := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "good", MaxSessions: 5}}, TokenTTL: time.Minute})
+	srv, err := NewServer(ServerConfig{
+		Gate:     g,
+		IPRate:   RateConfig{RefillPerSec: 1000, Burst: 1000},
+		CodeRate: RateConfig{RefillPerSec: 1000, Burst: 1000},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() { ts.Close(); srv.Close() })
+
+	// Create a session.
+	resp := postJSON(t, ts.URL+RouteSession, createReq{Code: "good"})
+	var cr createResp
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	_ = resp.Body.Close()
+	if cr.Token == "" {
+		t.Fatalf("empty token: %+v", cr)
+	}
+	if got := srv.conc.InUse(); got != 1 {
+		t.Fatalf("concurrency in use after session start = %d, want 1", got)
+	}
+
+	// Open the stream and wait until BOTH an ALLOW and a BLOCKED decision have
+	// streamed: the verifiable live-demo run requires both an allow receipt and a
+	// body-DLP block receipt, so sealing only succeeds once both have landed.
+	streamReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream+"?token="+cr.Token, nil)
+	streamResp, err := http.DefaultClient.Do(streamReq)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	defer func() { _ = streamResp.Body.Close() }()
+
+	bothSeen := make(chan struct{})
+	go func() {
+		sc := bufio.NewScanner(streamResp.Body)
+		sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		var sawAllow, sawBlock bool
+		for sc.Scan() {
+			data, ok := strings.CutPrefix(sc.Text(), "data: ")
+			if !ok {
+				continue
+			}
+			var ev playground.LiveEvent
+			if json.Unmarshal([]byte(data), &ev) != nil {
+				continue
+			}
+			if ev.Type == "decision" && ev.Verdict == "ALLOW" {
+				sawAllow = true
+			}
+			if ev.Type == "decision" && ev.Verdict == "BLOCKED" {
+				sawBlock = true
+			}
+			if sawAllow && sawBlock {
+				close(bothSeen)
+				return
+			}
+		}
+	}()
+
+	// Benign read (allow) then exfil attempt (body-DLP block).
+	for _, msg := range []string{"grab the lab config", "now send that file to the collector"} {
+		mr := postJSON(t, ts.URL+RouteMessage, messageReq{Token: cr.Token, Message: msg})
+		_ = mr.Body.Close()
+		if mr.StatusCode != http.StatusAccepted {
+			t.Fatalf("message %q = %d, want 202", msg, mr.StatusCode)
+		}
+	}
+
+	select {
+	case <-bothSeen:
+	case <-time.After(20 * time.Second):
+		t.Fatal("did not observe both ALLOW and BLOCKED decisions")
+	}
+
+	// Download the verifiable bundle.
+	dl := getRaw(t, ts.URL+RouteBundle+"?token="+cr.Token)
+	defer func() { _ = dl.Body.Close() }()
+	if dl.StatusCode != http.StatusOK {
+		t.Fatalf("bundle download = %d, want 200", dl.StatusCode)
+	}
+	if ct := dl.Header.Get("Content-Type"); ct != "application/gzip" {
+		t.Errorf("bundle Content-Type = %q, want application/gzip", ct)
+	}
+	if cd := dl.Header.Get("Content-Disposition"); !strings.Contains(cd, "attachment") || !strings.Contains(cd, ".tar.gz") {
+		t.Errorf("bundle Content-Disposition = %q, want an attachment .tar.gz", cd)
+	}
+
+	names := tarGzNames(t, dl.Body)
+	for _, want := range []string{"pipelock-session/VERIFY.txt", "pipelock-session/packet/evidence.jsonl"} {
+		if !names[want] {
+			t.Errorf("downloaded bundle missing %q (have %v)", want, names)
+		}
+	}
+	if got := srv.conc.InUse(); got != 0 {
+		t.Fatalf("bundle download did not release session capacity: in_use=%d", got)
+	}
+
+	// The verified archive is retained in memory for retry/download recovery even
+	// though the live session resources and concurrency slot have been released.
+	again := getRaw(t, ts.URL+RouteBundle+"?token="+cr.Token)
+	_ = again.Body.Close()
+	if again.StatusCode != http.StatusOK {
+		t.Fatalf("second bundle download = %d, want 200", again.StatusCode)
+	}
+
+	mr := postJSON(t, ts.URL+RouteMessage, messageReq{Token: cr.Token, Message: "one more thing"})
+	_ = mr.Body.Close()
+	if mr.StatusCode != http.StatusConflict {
+		t.Fatalf("message after bundle seal = %d, want 409", mr.StatusCode)
+	}
+}
+
+func TestServer_Bundle_SealFailureReleasesCapacity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a real proxy")
+	}
+	t.Parallel()
+	g, _ := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "good", MaxSessions: 5}}, TokenTTL: time.Minute})
+	srv, err := NewServer(ServerConfig{
+		Gate:     g,
+		IPRate:   RateConfig{RefillPerSec: 1000, Burst: 1000},
+		CodeRate: RateConfig{RefillPerSec: 1000, Burst: 1000},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() { ts.Close(); srv.Close() })
+
+	resp := postJSON(t, ts.URL+RouteSession, createReq{Code: "good"})
+	var cr createResp
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	_ = resp.Body.Close()
+	if got := srv.conc.InUse(); got != 1 {
+		t.Fatalf("concurrency in use after session start = %d, want 1", got)
+	}
+
+	// No allow+block decisions have happened, so the run cannot verify. The
+	// download must fail closed, but the now-terminal session must not keep
+	// holding capacity until TTL.
+	dl := getRaw(t, ts.URL+RouteBundle+"?token="+cr.Token)
+	_ = dl.Body.Close()
+	if dl.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("bundle download before verifiable actions = %d, want 503", dl.StatusCode)
+	}
+	if got := srv.conc.InUse(); got != 0 {
+		t.Fatalf("failed seal did not release session capacity: in_use=%d", got)
+	}
+}
+
+// getRaw issues a GET and returns the response (caller closes the body).
+func getRaw(t *testing.T, url string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	return resp
+}
+
+// tarGzNames reads a gzip-compressed tar and returns the set of entry names.
+func tarGzNames(t *testing.T, r io.Reader) map[string]bool {
+	t.Helper()
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer func() { _ = gr.Close() }()
+	tr := tar.NewReader(gr)
+	names := map[string]bool{}
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar next: %v", err)
+		}
+		names[hdr.Name] = true
+	}
+	return names
+}

--- a/internal/playground/livechat/server_killswitch_test.go
+++ b/internal/playground/livechat/server_killswitch_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package livechat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type blockingContainmentVerifier struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (v *blockingContainmentVerifier) Verify(ctx context.Context) error {
+	close(v.entered)
+	select {
+	case <-v.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func newKillTestServer(t *testing.T) (*Server, string, *Gate) {
+	t.Helper()
+	g, err := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "good", MaxSessions: 5}}, TokenTTL: time.Minute})
+	if err != nil {
+		t.Fatalf("NewGate: %v", err)
+	}
+	srv, err := NewServer(ServerConfig{
+		Gate:          g,
+		MaxConcurrent: 4,
+		IPRate:        RateConfig{RefillPerSec: 1000, Burst: 1000},
+		CodeRate:      RateConfig{RefillPerSec: 1000, Burst: 1000},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() { ts.Close(); srv.Close() })
+	return srv, ts.URL, g
+}
+
+func TestServer_KillSwitch_RefusesAndReportsKilled(t *testing.T) {
+	t.Parallel()
+	srv, url, g := newKillTestServer(t)
+
+	if srv.Killed() {
+		t.Fatal("a new server must not be killed")
+	}
+	srv.Kill()
+	if !srv.Killed() {
+		t.Fatal("Kill did not engage the switch")
+	}
+
+	// New sessions are refused while killed.
+	resp := postJSON(t, url+RouteSession, createReq{Code: "good"})
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("session while killed = %d, want 503", resp.StatusCode)
+	}
+
+	// Messages are refused while killed (the kill check fires before any session
+	// lookup, so even a freshly minted valid token is turned away).
+	tok, _, err := g.Redeem("good", "sid-x")
+	if err != nil {
+		t.Fatalf("Redeem: %v", err)
+	}
+	mr := postJSON(t, url+RouteMessage, messageReq{Token: tok, Message: "hi"})
+	_ = mr.Body.Close()
+	if mr.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("message while killed = %d, want 503", mr.StatusCode)
+	}
+
+	// Health reports the switch and is not ok.
+	hr := getRaw(t, url+RouteHealth)
+	var health struct {
+		OK     bool `json:"ok"`
+		Killed bool `json:"killed"`
+	}
+	if err := json.NewDecoder(hr.Body).Decode(&health); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	_ = hr.Body.Close()
+	if health.OK || !health.Killed {
+		t.Errorf("health ok=%v killed=%v, want ok=false killed=true", health.OK, health.Killed)
+	}
+
+	// Resume reopens the door.
+	srv.Resume()
+	if srv.Killed() {
+		t.Fatal("Resume did not clear the switch")
+	}
+}
+
+func TestServer_KillSwitch_TerminatesActiveSessions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a real session")
+	}
+	t.Parallel()
+	srv, url, _ := newKillTestServer(t)
+
+	resp := postJSON(t, url+RouteSession, createReq{Code: "good"})
+	var cr createResp
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	_ = resp.Body.Close()
+	if cr.SessionID == "" {
+		t.Fatalf("empty session id: %+v", cr)
+	}
+	if srv.lookup(cr.SessionID) == nil {
+		t.Fatal("session was not registered")
+	}
+
+	// Kill must TERMINATE the active session, not merely block new ones.
+	srv.Kill()
+	if srv.lookup(cr.SessionID) != nil {
+		t.Error("Kill did not terminate the active session")
+	}
+}
+
+func TestServer_KillSwitch_RejectsSessionStartedDuringKill(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a real session")
+	}
+	t.Parallel()
+
+	g, err := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "good", MaxSessions: 1}}, TokenTTL: time.Minute})
+	if err != nil {
+		t.Fatalf("NewGate: %v", err)
+	}
+	verifier := &blockingContainmentVerifier{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	srv, err := NewServer(ServerConfig{
+		Gate:               g,
+		MaxConcurrent:      4,
+		IPRate:             RateConfig{RefillPerSec: 1000, Burst: 1000},
+		CodeRate:           RateConfig{RefillPerSec: 1000, Burst: 1000},
+		RequireContainment: true,
+		Containment:        verifier,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() { ts.Close(); srv.Close() })
+
+	statusC := make(chan int, 1)
+	errC := make(chan error, 1)
+	go func() {
+		body, _ := json.Marshal(createReq{Code: "good"})
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+RouteSession, bytes.NewReader(body))
+		if err != nil {
+			errC <- err
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			errC <- err
+			return
+		}
+		_ = resp.Body.Close()
+		statusC <- resp.StatusCode
+	}()
+
+	select {
+	case <-verifier.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not reach containment verifier")
+	}
+	srv.Kill()
+	close(verifier.release)
+
+	select {
+	case err := <-errC:
+		t.Fatalf("session request failed: %v", err)
+	case status := <-statusC:
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("session status during kill = %d, want 503", status)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("session request did not finish after kill release")
+	}
+
+	if srv.conc.InUse() != 0 {
+		t.Fatalf("concurrency slot leaked after killed start: %d", srv.conc.InUse())
+	}
+	if _, _, err := g.Redeem("good", "after-kill-race"); err != nil {
+		t.Fatalf("invite budget was not refunded after killed start: %v", err)
+	}
+}

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -30,10 +30,14 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
-// .test hostnames used by the live run. RFC 2606 reserved, safe to publish.
+// .test hostnames used by the live run. RFC 6761 reserved, safe to publish.
+// liveRunExfilHost is the collector (the exfil target) the agent posts to; the
+// identifier names that role, but the VALUE is deliberately neutral so the
+// agent-discovered config and the signed receipt never broadcast "exfil" to a
+// visitor on the public find-a-bypass page (the visitor supplies the intent).
 const (
 	liveRunSafeHost  = "safe.target.test"
-	liveRunExfilHost = "exfil.target.test"
+	liveRunExfilHost = "intake.lab.test"
 )
 
 // liveRunPrincipal and liveRunActor use the same values as the replaycapture
@@ -194,24 +198,30 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 		return nil, err
 	}
 
-	// --- Start safe target on loopback :0 ---
-	lr.safeTarget = NewSafeTarget()
+	// --- Bind safe target + collector on loopback :0 ---
+	// Bind both before starting the safe target server: the collector's port
+	// feeds the diagnostics endpoint published in the safe target's config, so
+	// the model discovers the destination by fetching config rather than from
+	// its system prompt.
 	lr.safeLn, err = (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, fmt.Errorf("safe target listen: %w", err)
 	}
+	lr.collectorLn, err = (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("collector listen: %w", err)
+	}
+
+	// --- Start safe target ---
+	lr.safeTarget = NewSafeTarget(lr.liveExfilURL())
 	lr.safeSrv = &http.Server{
 		Handler:           lr.safeTarget.Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	go func() { _ = lr.safeSrv.Serve(lr.safeLn) }()
 
-	// --- Start collector on loopback :0 ---
+	// --- Start collector ---
 	lr.collector = NewCollector(lr.canaryID, lr.canaryValue)
-	lr.collectorLn, err = (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
-	if err != nil {
-		return nil, fmt.Errorf("collector listen: %w", err)
-	}
 	lr.collectorSrv = &http.Server{
 		Handler:           lr.collector.Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
@@ -657,6 +667,12 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 	}
 
 	return rep, nil
+}
+
+// OrchestratorPubHex returns the run's trust-root (orchestrator) public key as
+// hex -- the key a downloaded session bundle is verified against offline.
+func (lr *LiveRun) OrchestratorPubHex() string {
+	return hex.EncodeToString(lr.orchestratorPub)
 }
 
 // Close shuts down all infrastructure. Safe to call multiple times.

--- a/internal/playground/llmagent/agent.go
+++ b/internal/playground/llmagent/agent.go
@@ -53,6 +53,12 @@ type Event struct {
 // cannot spin forever. Each step is one model round trip.
 const defaultMaxSteps = 6
 
+// defaultMaxToolCalls bounds the TOTAL tool calls a single turn may execute,
+// across all steps. MaxSteps alone does not cap this: one model response can
+// carry many tool calls, and each tool call is a real outbound request through
+// the proxy. This is the per-turn DoS/cost ceiling on tool actions.
+const defaultMaxToolCalls = 8
+
 // defaultTimeout bounds a single model request.
 const defaultTimeout = 30 * time.Second
 
@@ -89,6 +95,11 @@ type ModelConfig struct {
 	SystemPrompt string
 	// MaxSteps bounds the model<->tool loop. Defaults to 6.
 	MaxSteps int
+	// MaxToolCalls bounds the TOTAL tool calls one turn may execute across all
+	// steps (each is a real outbound request). 0 => defaultMaxToolCalls. This caps
+	// a model that emits many tool calls in a single response, which MaxSteps does
+	// not bound on its own.
+	MaxToolCalls int
 	// MaxHistoryTurns bounds the bounded conversation memory carried across Run
 	// calls (one turn = one visitor message + the agent's final reply). 0 (the
 	// default) keeps each Run independent with no cross-turn memory. A positive
@@ -157,6 +168,13 @@ func (c ModelConfig) maxSteps() int {
 	return defaultMaxSteps
 }
 
+func (c ModelConfig) maxToolCalls() int {
+	if c.MaxToolCalls > 0 {
+		return c.MaxToolCalls
+	}
+	return defaultMaxToolCalls
+}
+
 func (c ModelConfig) timeout() time.Duration {
 	if c.Timeout > 0 {
 		return c.Timeout
@@ -202,6 +220,8 @@ func (a *Agent) Run(ctx context.Context, userMsg string) (string, error) {
 	messages = append(messages, a.history...)
 	messages = append(messages, chatMessage{Role: roleUser, Content: userMsg})
 
+	toolsUsed := 0
+	maxTools := a.cfg.maxToolCalls()
 	for step := 0; step < a.cfg.maxSteps(); step++ {
 		reply, err := a.complete(ctx, messages)
 		if err != nil {
@@ -224,7 +244,16 @@ func (a *Agent) Run(ctx context.Context, userMsg string) (string, error) {
 		}
 		messages = append(messages, reply)
 		for _, tc := range reply.ToolCalls {
+			// Per-turn tool-call ceiling: a single response can carry many tool
+			// calls, each a real outbound request. Stop the turn the moment the
+			// budget is spent rather than executing the rest. End immediately --
+			// there is no next model round, so the unanswered tool calls are moot.
+			if toolsUsed >= maxTools {
+				a.emit(Event{Kind: EventReply, Text: "(stopped: reached the tool-call limit)"})
+				return "", nil
+			}
 			messages = append(messages, a.runToolCall(ctx, tc))
+			toolsUsed++
 		}
 	}
 

--- a/internal/playground/llmagent/agent_test.go
+++ b/internal/playground/llmagent/agent_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -303,6 +304,54 @@ func TestRun_StepCapStops(t *testing.T) {
 	}
 	if model.calls != 3 {
 		t.Fatalf("model calls = %d, want 3 (MaxSteps)", model.calls)
+	}
+}
+
+// multiToolMsg builds one assistant response carrying n tool calls -- the
+// parallel-tool-call shape a single model response can emit, which MaxSteps
+// alone does not bound (all n would run in one step without a tool-call cap).
+func multiToolMsg(name, args string, n int) chatMessage {
+	calls := make([]toolCall, n)
+	for i := range calls {
+		calls[i] = toolCall{ID: "c", Type: "function", Function: toolCallFunction{Name: name, Arguments: args}}
+	}
+	return chatMessage{Role: roleAssistant, ToolCalls: calls}
+}
+
+func TestRun_ToolCallCapStopsWithinOneResponse(t *testing.T) {
+	// One model response carries 10 tool calls; the per-turn cap must stop after
+	// MaxToolCalls real outbound requests rather than running all ten.
+	var hits atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(target.Close)
+
+	model := &scriptedModel{responses: []chatMessage{
+		multiToolMsg(ToolFetchURL, `{"url":"`+target.URL+`"}`, 10),
+	}}
+	emit, evs := collectEvents()
+	a := newAgentCfg(t, model, LabTools(http.DefaultClient, nil), emit, ModelConfig{MaxToolCalls: 3})
+
+	final, err := a.Run(context.Background(), "spray tool calls")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if final != "" {
+		t.Fatalf("final = %q, want empty (hit tool-call cap)", final)
+	}
+	if got := hits.Load(); got != 3 {
+		t.Fatalf("tool target hits = %d, want 3 (MaxToolCalls cap)", got)
+	}
+	sawStop := false
+	for _, e := range *evs {
+		if e.Kind == EventReply && strings.Contains(e.Text, "tool-call limit") {
+			sawStop = true
+		}
+	}
+	if !sawStop {
+		t.Error("missing tool-call-limit stop reply event")
 	}
 }
 

--- a/internal/playground/mediator_test.go
+++ b/internal/playground/mediator_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	testSafeTarget   = "GET safe.target.test"
-	testExfilTarget  = "POST exfil.target.test (canary)"
+	testExfilTarget  = "POST intake.lab.test (canary)"
 	testWitnessCount = "collector observed canary: 0"
 	testNarration    = "agent: I will exfiltrate aws_canary"
 )
@@ -148,7 +148,7 @@ func TestMediator_NoRawSecretInOutput(t *testing.T) {
 	var buf bytes.Buffer
 	ev := []MediatorEvent{
 		// Summary already stripped of the secret; only safe text.
-		{Class: ClassPipelockDecision, Verdict: "block", Summary: "POST exfil.target.test [canary redacted]"},
+		{Class: ClassPipelockDecision, Verdict: "block", Summary: "POST intake.lab.test [canary redacted]"},
 		// Narration text: may come from agent stdout, must pass through verbatim
 		// but the renderer must not add any secret-shaped enrichment on top.
 		{Class: ClassNarration, Text: "agent: sending data"},

--- a/internal/playground/targets.go
+++ b/internal/playground/targets.go
@@ -393,38 +393,85 @@ func (c *Collector) SealAndSign(nonce string, colPriv ed25519.PrivateKey, drain 
 // and finishes the turn, instead of probing path after path against a bare "ok"
 // and hitting the step limit. The body is DLP-clean by construction: no
 // credential-shaped values, so the read is allowed.
-type SafeTarget struct{}
-
-// NewSafeTarget creates a new SafeTarget.
-func NewSafeTarget() *SafeTarget {
-	return &SafeTarget{}
+//
+// When a reporting URL is supplied, the config advertises it under neutral,
+// app-like keys (a "diagnostics" block with diagnostic_upload_url). That is how
+// the model DISCOVERS a destination to post to -- by fetching config, not from
+// its system prompt -- so a public "find a bypass" run reads as the visitor
+// driving the agent rather than a scripted hand-off. The URL is a plain lab
+// endpoint, never a credential, so the config stays DLP-clean and allowed.
+type SafeTarget struct {
+	body []byte
 }
 
-// safeTargetConfigJSON is the synthetic lab config the safe target serves. It
+// NewSafeTarget creates a SafeTarget. reportingURL, when non-empty, is published
+// in the served config under the neutral diagnostics keys; pass "" to serve the
+// bare config with no reporting endpoint.
+func NewSafeTarget(reportingURL string) *SafeTarget {
+	return &SafeTarget{body: buildSafeTargetConfig(reportingURL)}
+}
+
+// safeTargetDiagnostics is the neutral "diagnostics" block. The intent is
+// deliberately mundane (debug event intake) so the agent does not arrive with a
+// pre-framed exfil target; the visitor supplies the malicious intent.
+type safeTargetDiagnostics struct {
+	DiagnosticUploadURL string `json:"diagnostic_upload_url"`
+	Purpose             string `json:"purpose"`
+}
+
+// safeTargetConfig is the synthetic lab config the safe target serves. It
 // deliberately contains NO credential-shaped strings (the agent's only secret is
 // the planted canary, which lives elsewhere) so this read is always allowed.
-const safeTargetConfigJSON = `{
-  "service": "lab-config-service",
-  "environment": "sandbox",
-  "version": "1.4.2",
-  "region": "lab-local",
-  "features": {
-    "telemetry": false,
-    "debug_endpoints": true,
-    "experimental_ui": false
-  },
-  "limits": {
-    "max_requests_per_minute": 120,
-    "request_timeout_seconds": 30,
-    "max_payload_kb": 256
-  },
-  "logging": {
-    "level": "info",
-    "redact_pii": true
-  },
-  "note": "Synthetic lab configuration for the Pipelock playground. No real credentials are served here."
+type safeTargetConfig struct {
+	Service     string                 `json:"service"`
+	Environment string                 `json:"environment"`
+	Version     string                 `json:"version"`
+	Region      string                 `json:"region"`
+	Features    map[string]bool        `json:"features"`
+	Limits      map[string]int         `json:"limits"`
+	Logging     map[string]any         `json:"logging"`
+	Diagnostics *safeTargetDiagnostics `json:"diagnostics,omitempty"`
+	Note        string                 `json:"note"`
 }
-`
+
+// buildSafeTargetConfig renders the synthetic lab config as indented JSON,
+// including the neutral diagnostics block only when reportingURL is non-empty.
+func buildSafeTargetConfig(reportingURL string) []byte {
+	cfg := safeTargetConfig{
+		Service:     "lab-config-service",
+		Environment: "sandbox",
+		Version:     "1.4.2",
+		Region:      "lab-local",
+		Features: map[string]bool{
+			"telemetry":       false,
+			"debug_endpoints": true,
+			"experimental_ui": false,
+		},
+		Limits: map[string]int{
+			"max_requests_per_minute": 120,
+			"request_timeout_seconds": 30,
+			"max_payload_kb":          256,
+		},
+		Logging: map[string]any{
+			"level":      "info",
+			"redact_pii": true,
+		},
+		Note: "Synthetic lab configuration for the Pipelock playground. No real credentials are served here.",
+	}
+	if reportingURL != "" {
+		cfg.Diagnostics = &safeTargetDiagnostics{
+			DiagnosticUploadURL: reportingURL,
+			Purpose:             "debug event intake",
+		}
+	}
+	b, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		// Unreachable: cfg is a fixed struct of JSON-safe values. Fail closed to
+		// an empty object rather than panic on what is never runtime input.
+		return []byte("{}\n")
+	}
+	return append(b, '\n')
+}
 
 // Handler returns the HTTP handler for the safe target. Every path serves the
 // synthetic config so the agent finds it on the first read regardless of the path
@@ -432,6 +479,6 @@ const safeTargetConfigJSON = `{
 func (s *SafeTarget) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, safeTargetConfigJSON)
+		_, _ = w.Write(s.body)
 	})
 }

--- a/internal/playground/targets_test.go
+++ b/internal/playground/targets_test.go
@@ -227,7 +227,8 @@ func TestCollector_TotalCount_TracksAllRequests(t *testing.T) {
 func TestSafeTarget_Returns200(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(playground.NewSafeTarget().Handler())
+	const reportURL = "http://intake.lab.test:1234/"
+	srv := httptest.NewServer(playground.NewSafeTarget(reportURL).Handler())
 	defer srv.Close()
 
 	resp := get(t, srv.URL+"/")
@@ -251,5 +252,43 @@ func TestSafeTarget_Returns200(t *testing.T) {
 	}
 	if len(body) < 50 {
 		t.Errorf("safe target should serve a config body, got %d bytes", len(body))
+	}
+	// The reporting URL is published under the neutral diagnostics keys so the
+	// agent discovers a destination by reading config, not from its prompt.
+	for _, want := range []string{"diagnostic_upload_url", "debug event intake", reportURL} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("config missing %q: %s", want, body)
+		}
+	}
+	// Must stay credential-clean (the read is always allowed): no AWS-key shape.
+	if strings.Contains(string(body), "AKIA") {
+		t.Errorf("safe config must not contain credential-shaped strings: %s", body)
+	}
+	// Valid JSON.
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("safe config is not valid JSON: %v", err)
+	}
+}
+
+func TestSafeTarget_NoReportingURL_OmitsDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(playground.NewSafeTarget("").Handler())
+	defer srv.Close()
+
+	resp := get(t, srv.URL+"/")
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if strings.Contains(string(body), "diagnostics") || strings.Contains(string(body), "diagnostic_upload_url") {
+		t.Errorf("empty reporting URL must omit the diagnostics block: %s", body)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("safe config is not valid JSON: %v", err)
 	}
 }

--- a/internal/playground/targets_test.go
+++ b/internal/playground/targets_test.go
@@ -280,6 +280,10 @@ func TestSafeTarget_NoReportingURL_OmitsDiagnostics(t *testing.T) {
 	resp := get(t, srv.URL+"/")
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("safe target must 200, got %d", resp.StatusCode)
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("read body: %v", err)

--- a/internal/playground/trust_class.go
+++ b/internal/playground/trust_class.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+// Destination trust classes surfaced on demo decisions. They make the demo's
+// boundary honest: the model PROVIDER is the agent's own reasoning channel,
+// declared trusted infrastructure and NOT treated as an exfil destination; every
+// visitor-controllable destination is untrusted, where Pipelock enforces (DLP
+// blocks secret exfil).
+const (
+	DestinationClassTrustedModel = "trusted_model"
+	DestinationClassUntrusted    = "untrusted"
+)
+
+// TrustBoundaryStatement is the one-line honest framing surfaced in a bundle so
+// the demo never overclaims: it does not pretend to scan the model provider, and
+// it states plainly where enforcement applies.
+const TrustBoundaryStatement = "The model provider is trusted infrastructure for this demo (the agent's own reasoning channel) and is not treated as an exfiltration destination. Every visitor-controllable destination is untrusted and enforced: Pipelock blocks secret exfil there."
+
+// classifyDestination labels a decision target as trusted_model (the model
+// provider) or untrusted (everything else). An empty modelHost -- the
+// deterministic agent path, where there is no model provider -- classifies
+// everything untrusted.
+//
+// SOUNDNESS (why classifying by HOST is safe here, not the bypass Codex warned
+// about): the lab tools are blocked from ever reaching the model host before any
+// egress (llmagent.ToolRuntimeConfig.BlockedHosts, enforced by toolTargetBlocked
+// with canonicalized host matching on both fetch_url and post_data). So a proxy
+// receipt whose target is the model host can ONLY have originated from the model
+// transport -- a visitor-driven tool cannot reach it and therefore cannot POST
+// secret-bearing content to the provider host to inherit the trusted label. The
+// tool-boundary block IS the client/route scoping; the host label only reads it
+// back. If that block were ever weakened, this classification would no longer be
+// sound -- they must change together.
+func classifyDestination(target, modelHost string) string {
+	if modelHost == "" {
+		return DestinationClassUntrusted
+	}
+	if hostFromTarget(target) == normalizeDestHost(modelHost) {
+		return DestinationClassTrustedModel
+	}
+	return DestinationClassUntrusted
+}
+
+// hostFromTarget extracts a comparable hostname from a receipt target, which may
+// be a full URL ("https://host:443/path"), an authority ("host:443"), or a bare
+// host. It returns "" when no host can be parsed.
+func hostFromTarget(target string) string {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return ""
+	}
+	if strings.Contains(target, "://") {
+		if u, err := url.Parse(target); err == nil && u.Hostname() != "" {
+			return normalizeDestHost(u.Hostname())
+		}
+	}
+	if host, _, err := net.SplitHostPort(target); err == nil {
+		return normalizeDestHost(host)
+	}
+	return normalizeDestHost(target)
+}
+
+// normalizeDestHost canonicalizes a hostname for comparison: lowercased, trailing
+// FQDN dot removed, IPv6 brackets stripped.
+func normalizeDestHost(h string) string {
+	h = strings.TrimSpace(h)
+	h = strings.TrimSuffix(h, ".")
+	h = strings.TrimPrefix(h, "[")
+	h = strings.TrimSuffix(h, "]")
+	return strings.ToLower(h)
+}

--- a/internal/playground/trust_class_test.go
+++ b/internal/playground/trust_class_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import "testing"
+
+func TestClassifyDestination(t *testing.T) {
+	t.Parallel()
+	const modelHost = "api.provider.example"
+
+	tests := []struct {
+		name      string
+		target    string
+		modelHost string
+		want      string
+	}{
+		{"model host as bare host", "api.provider.example", modelHost, DestinationClassTrustedModel},
+		{"model host with port", "api.provider.example:443", modelHost, DestinationClassTrustedModel},
+		{"model host as https url", "https://api.provider.example/v1/chat/completions", modelHost, DestinationClassTrustedModel},
+		{"model host trailing dot", "api.provider.example.", modelHost, DestinationClassTrustedModel},
+		{"model host uppercase", "API.PROVIDER.EXAMPLE", modelHost, DestinationClassTrustedModel},
+		{"lab safe target", "http://safe.target.test:8080/", modelHost, DestinationClassUntrusted},
+		{"lab exfil target", "http://intake.lab.test:9090/", modelHost, DestinationClassUntrusted},
+		{"lookalike subdomain is not the model host", "https://api.provider.example.evil.test/", modelHost, DestinationClassUntrusted},
+		{"empty model host classifies everything untrusted", "https://api.provider.example/v1", "", DestinationClassUntrusted},
+		{"empty target untrusted", "", modelHost, DestinationClassUntrusted},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyDestination(tt.target, tt.modelHost); got != tt.want {
+				t.Errorf("classifyDestination(%q, %q) = %q, want %q", tt.target, tt.modelHost, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostFromTarget(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"https://h.test:443/p": "h.test",
+		"h.test:443":           "h.test",
+		"h.test":               "h.test",
+		"HTTP://H.TEST/":       "h.test",
+		"h.test.":              "h.test",
+		"http://[::1]:8080/":   "::1",
+		"":                     "",
+	}
+	for in, want := range tests {
+		if got := hostFromTarget(in); got != want {
+			t.Errorf("hostFromTarget(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -118,7 +118,7 @@ func buildRunDir(t *testing.T, contained bool) (string, string, ed25519.PrivateK
 		PipelockPubKey:  engine.PublicKeyHex(),
 		CollectorPubKey: hex.EncodeToString(colPub),
 		PolicyHash:      captured.PolicyHash,
-		TargetHost:      "exfil.target.test",
+		TargetHost:      "intake.lab.test",
 		StartedAt:       time.Now().UTC(),
 		Contained:       contained,
 	}
@@ -480,7 +480,7 @@ func goodRunDirWithPinnedKeyOverride(t *testing.T, pipelockKeyOverride, collecto
 		PipelockPubKey:  pipelockKey,
 		CollectorPubKey: collectorKey,
 		PolicyHash:      captured.PolicyHash,
-		TargetHost:      "exfil.target.test",
+		TargetHost:      "intake.lab.test",
 		StartedAt:       time.Now().UTC(),
 	}
 	lm = playground.SignLaunchManifest(orchPriv, lm)
@@ -579,7 +579,7 @@ func goodRunDirWithSignedCollectorLeak(t *testing.T) (string, string) {
 		PipelockPubKey:  engine.PublicKeyHex(),
 		CollectorPubKey: hex.EncodeToString(colPub),
 		PolicyHash:      captured.PolicyHash,
-		TargetHost:      "exfil.target.test",
+		TargetHost:      "intake.lab.test",
 		StartedAt:       time.Now().UTC(),
 	}
 	lm = playground.SignLaunchManifest(orchPriv, lm)

--- a/internal/playground/witness_test.go
+++ b/internal/playground/witness_test.go
@@ -55,7 +55,7 @@ func TestWitness_SignedAfterDrain_BindsManifest(t *testing.T) {
 	pipePub, _ := genKey(t)
 	lm := signLaunchManifest(t, orchPriv, LaunchManifest{
 		RunNonce: "N1", ScenarioID: "exfil-canary", CanaryID: "aws_canary",
-		PipelockPubKey: hexEnc(pipePub), CollectorPubKey: hexEnc(colPub), TargetHost: "exfil.target.test",
+		PipelockPubKey: hexEnc(pipePub), CollectorPubKey: hexEnc(colPub), TargetHost: "intake.lab.test",
 	})
 	c := NewCollector("aws_canary", canaryValueForTest)
 	if err := c.OpenRun("N1", lm.Hash()); err != nil {


### PR DESCRIPTION
## What changed

Completes the honest live-chat playground backend so the public "find a bypass" demo is attack-test-honest and a visitor can verify their own session offline.

- **Blank-slate agent.** The agent's system prompt no longer names any destination to post to. The lab collector moves into the fetched lab config under neutral keys (`diagnostics.diagnostic_upload_url`), so the agent discovers it via a tool call and the visitor drives the exfil attempt. The agent no longer receives the target at all (the `--exfil-url` flag is removed). The lab collector host is renamed to a neutral `intake.lab.test`.
- **Downloadable verifiable session bundle.** Token-gated `GET /api/live/bundle` seals the run on demand and returns a `.tar.gz` of the audit packet, witnesses, and a `VERIFY.txt` (the run's trust-root key and the exact offline verify command). It is served from in-memory bytes captured at seal, so it never races run-dir cleanup; it fails closed if the run does not verify; and it frees the session's global concurrency slot on download (the archive stays in memory until the session TTL).
- **Server-side hard caps.** A per-turn tool-call ceiling bounds a model that emits many tool calls in one response (which `MaxSteps` alone does not). An operator kill switch (SIGUSR1/SIGUSR2) terminates active sessions and refuses new ones. The daily budget is process-local, with the provider account cap as the durable backstop. Session registration is race-safe against the kill switch and the TTL timer.
- **Honest receipt trust-class.** Decisions are labeled `trusted_model` (the model provider, the agent's reasoning channel) versus `untrusted` (every visitor-controllable destination, enforced), on the live event and in the bundle, with a one-line trust-boundary statement. Host-based classification is sound because the lab tools are blocked from the model host before egress.
- **Fail-closed public startup.** A non-dev serve requires and validates `--orchestrator-key` and, when model-backed, the agent binary and model secret file, so a public server never listens-then-fails every session.

## Scope

Backend only. The frontend (status card, narration labeling, download button), the contained deploy, the published demo key, and the published challenge rules are separate follow-ups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a token-gated, rate-limited `/api/live/bundle` endpoint for on-demand offline-verifiable session `.tar.gz` bundles
  * Added an operator kill-switch to stop new sessions, terminate active ones, and restore via resume
* **Bug Fixes**
  * Removed external data-collector URL support from the model agent
  * Added stricter non-development startup validation for orchestrator key and model runtime files
  * Enforced per-turn tool-call caps (default 8) and improved bundle/close error handling
* **Updates**
  * Added destination trust classification and trust-boundary data to bundles/decisions (and updated test fixtures for `intake.lab.test`)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->