### PR TITLE
fix(proxy): measure idle across both tunnel directions (CONNECT + WebSocket)

### DIFF
--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -1748,68 +1748,49 @@ func TestConnectDialFailure(t *testing.T) {
 	}
 }
 
-func TestCopyWithIdleTimeoutRespectsDeadline(t *testing.T) {
-	// Verify that copyWithIdleTimeout caps per-read deadlines at the absolute
-	// deadline. A 10s idle timeout should be capped by a near-immediate deadline.
+func TestBidirectionalCopyRespectsAbsoluteDeadline(t *testing.T) {
+	// The absolute deadline caps total tunnel lifetime even when the idle
+	// timeout is far longer. Neither side sends, so only the deadline (via the
+	// watchdog) can end the relay; it must not wait out the 10s idle timeout.
 	server, client := net.Pipe()
 	defer func() { _ = server.Close() }()
 	defer func() { _ = client.Close() }()
 
-	// Set deadline to 50ms from now, idle timeout much longer (10s)
-	deadline := time.Now().Add(50 * time.Millisecond)
-	var dst strings.Builder
-	dstConn := &writerConn{Writer: &dst, Conn: client}
-
+	deadline := time.Now().Add(100 * time.Millisecond)
 	start := time.Now()
-	// Server never sends data, so copyWithIdleTimeout blocks on Read.
-	// With deadline capping, it should return after ~50ms (the deadline),
-	// not after 10s (the idle timeout).
-	_ = copyWithIdleTimeout(dstConn, server, 10*time.Second, deadline, nil)
+	_ = bidirectionalCopy(client, server, 10*time.Second, deadline, nil)
 	elapsed := time.Since(start)
 
 	if elapsed > 2*time.Second {
-		t.Errorf("copyWithIdleTimeout took %v; expected it to respect the ~50ms deadline", elapsed)
+		t.Errorf("bidirectionalCopy took %v; expected it to honor the ~100ms absolute deadline, not the 10s idle timeout", elapsed)
 	}
 }
 
-func TestCopyWithIdleTimeout_KillSwitchTerminatesTunnel(t *testing.T) {
+func TestBidirectionalCopy_KillSwitchTerminatesTunnel(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.Internal = nil
 	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
 	ks := killswitch.New(cfg)
 
-	// Create a TCP pipe. Server side will block on read forever.
 	client, server := net.Pipe()
 	defer func() { _ = client.Close() }()
 	defer func() { _ = server.Close() }()
 
-	// Activate kill switch before starting copy.
+	// Activate the kill switch before starting the relay.
 	ks.SetAPI(true)
 
-	deadline := time.Now().Add(5 * time.Second)
 	start := time.Now()
-	total := copyWithIdleTimeout(server, client, time.Second, deadline, ks)
+	total := bidirectionalCopy(client, server, time.Second, time.Now().Add(5*time.Second), ks)
 	elapsed := time.Since(start)
 
-	// With kill switch active, copyWithIdleTimeout should return immediately
-	// (first loop iteration checks ks.IsActive() before reading).
+	// With the kill switch active, both copy directions return on their first
+	// iteration (ks checked before any read), so the relay ends immediately.
 	if elapsed > time.Second {
-		t.Errorf("copyWithIdleTimeout with kill switch took %v; expected immediate return", elapsed)
+		t.Errorf("bidirectionalCopy with kill switch took %v; expected immediate return", elapsed)
 	}
 	if total != 0 {
 		t.Errorf("expected 0 bytes transferred, got %d", total)
 	}
-}
-
-// writerConn wraps an io.Writer into a net.Conn for testing copyWithIdleTimeout's
-// write path. Only Write is used; all net.Conn methods delegate to the embedded Conn.
-type writerConn struct {
-	io.Writer
-	net.Conn
-}
-
-func (w *writerConn) Write(p []byte) (int, error) {
-	return w.Writer.Write(p)
 }
 
 func TestConnectDefaultPort(t *testing.T) {

--- a/internal/proxy/relay.go
+++ b/internal/proxy/relay.go
@@ -200,6 +200,13 @@ func (tr *tunnelRelay) copyDir(dst, src net.Conn) int64 {
 			}
 			written, wErr := dst.Write(buf[:n])
 			total += int64(written)
+			// A conforming io.Writer never returns written < n without an
+			// error, but treat a short write as a teardown anyway (matching
+			// io.Copy's ErrShortWrite) so a misbehaving conn cannot silently
+			// drop the unwritten bytes when the next read overwrites buf.
+			if wErr == nil && written < n {
+				wErr = io.ErrShortWrite
+			}
 			if wErr != nil {
 				tr.closeBoth()
 				return total

--- a/internal/proxy/relay.go
+++ b/internal/proxy/relay.go
@@ -4,9 +4,13 @@
 package proxy
 
 import (
+	"errors"
+	"io"
 	"net"
 	"net/http"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
@@ -49,78 +53,169 @@ func removeHopByHopHeaders(h http.Header) {
 	}
 }
 
-// bidirectionalCopy relays data between two connections with idle timeout.
-// When deadline is non-zero, per-read deadlines are capped at that absolute
-// time; a zero deadline means the tunnel is governed by idle timeout only.
-// When ks is non-nil, the kill switch is checked after each read so activation
-// mid-stream terminates already-open tunnels immediately.
-// Returns the total bytes transferred in both directions.
-func bidirectionalCopy(client, target net.Conn, idleTimeout time.Duration, deadline time.Time, ks *killswitch.Controller) int64 {
-	if !deadline.IsZero() {
-		_ = client.SetDeadline(deadline)
-		_ = target.SetDeadline(deadline)
-	}
-
-	var clientToTarget, targetToClient int64
-	done := make(chan struct{})
-
-	go func() {
-		clientToTarget = copyWithIdleTimeout(target, client, idleTimeout, deadline, ks)
-		// Half-close: signal target that no more data is coming
-		if tc, ok := target.(*net.TCPConn); ok {
-			_ = tc.CloseWrite()
-		}
-		close(done)
-	}()
-
-	targetToClient = copyWithIdleTimeout(client, target, idleTimeout, deadline, ks)
-	// Half-close: signal client that no more data is coming
-	if tc, ok := client.(*net.TCPConn); ok {
-		_ = tc.CloseWrite()
-	}
-
-	<-done
-	return clientToTarget + targetToClient
-}
-
 // tunnelBufSize is the buffer size for tunnel relay reads.
 const tunnelBufSize = 32 * 1024
 
-// copyWithIdleTimeout copies from src to dst, resetting the read deadline on
-// src after each successful read. When deadline is non-zero, the per-read
-// deadline is capped at that absolute time; otherwise active tunnels are
-// governed by idle timeout only.
-// When ks is non-nil, the kill switch is checked after each successful read
-// so activation mid-tunnel terminates the connection immediately.
-// Returns total bytes copied.
-func copyWithIdleTimeout(dst, src net.Conn, idleTimeout time.Duration, deadline time.Time, ks *killswitch.Controller) int64 {
+// watchdogPollInterval is how often the tunnel watchdog re-checks the shared
+// idle clock, the absolute deadline, and the kill switch. It is capped at the
+// idle timeout so very short idle timeouts still reap promptly.
+const watchdogPollInterval = 250 * time.Millisecond
+
+// bidirectionalCopy relays data between two connections until the tunnel goes
+// idle, an absolute deadline passes, the kill switch activates, or a side
+// closes.
+//
+// Idle is measured across the WHOLE tunnel via a single shared activity clock:
+// bytes flowing in EITHER direction keep the tunnel alive. This is the
+// liveness contract long-lived streaming responses depend on (an LLM token
+// stream keeps the upstream->client direction busy while client->upstream is
+// legitimately silent for the whole response). Measuring idle per-direction
+// would reap the silent direction at idle_timeout and half-close the upstream,
+// killing the active stream.
+//
+// A single watchdog owns liveness: it force-closes both connections when the
+// shared clock expires (or the deadline/kill switch fires), which wakes any
+// blocked read. A genuine EOF on one direction still half-closes the peer so
+// bidirectional teardown is preserved; only a spurious idle reap is avoided.
+//
+// When deadline is non-zero it caps total tunnel lifetime. When ks is non-nil
+// the kill switch terminates the tunnel mid-stream. Returns the total bytes
+// transferred in both directions.
+func bidirectionalCopy(client, target net.Conn, idleTimeout time.Duration, deadline time.Time, ks *killswitch.Controller) int64 {
+	now := time.Now()
+	tr := &tunnelRelay{
+		client:      client,
+		target:      target,
+		idleTimeout: idleTimeout,
+		deadline:    deadline,
+		ks:          ks,
+		clockStart:  now,
+	}
+	return tr.run()
+}
+
+// tunnelRelay carries the shared state for one bidirectional relay: the two
+// connections, the liveness bounds, and the shared activity clock that both
+// copy directions update and the watchdog reads.
+type tunnelRelay struct {
+	client, target net.Conn
+	idleTimeout    time.Duration
+	deadline       time.Time
+	ks             *killswitch.Controller
+
+	clockStart   time.Time
+	lastActivity atomic.Int64 // monotonic nanoseconds since clockStart of the last byte seen in either direction
+	closeOnce    sync.Once
+}
+
+// touch records activity on the shared clock. Called on every successful read
+// in either direction so the watchdog treats the tunnel as alive while bytes
+// move on either side.
+func (tr *tunnelRelay) touch() {
+	tr.lastActivity.Store(time.Since(tr.clockStart).Nanoseconds())
+}
+
+// closeBoth tears the tunnel down exactly once, closing both connections. This
+// is what wakes a read blocked on the silent direction.
+func (tr *tunnelRelay) closeBoth() {
+	tr.closeOnce.Do(func() {
+		_ = tr.client.Close()
+		_ = tr.target.Close()
+	})
+}
+
+func (tr *tunnelRelay) run() int64 {
+	done := make(chan struct{})
+	go tr.watchdog(done)
+
+	var clientToTarget, targetToClient int64
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		clientToTarget = tr.copyDir(tr.target, tr.client)
+	}()
+	targetToClient = tr.copyDir(tr.client, tr.target)
+
+	wg.Wait()
+	close(done)    // stop the watchdog
+	tr.closeBoth() // ensure both ends are closed (idempotent)
+	return clientToTarget + targetToClient
+}
+
+// watchdog owns tunnel liveness. It force-closes both connections when the
+// shared idle clock expires, the absolute deadline passes, or the kill switch
+// activates, and exits when both copy directions have finished.
+func (tr *tunnelRelay) watchdog(done <-chan struct{}) {
+	interval := watchdogPollInterval
+	if tr.idleTimeout > 0 && tr.idleTimeout < interval {
+		interval = tr.idleTimeout
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			if tr.ks != nil && tr.ks.IsActive() {
+				tr.closeBoth()
+				return
+			}
+			if !tr.deadline.IsZero() && time.Now().After(tr.deadline) {
+				tr.closeBoth()
+				return
+			}
+			if tr.idleTimeout > 0 {
+				idleFor := time.Since(tr.clockStart) - time.Duration(tr.lastActivity.Load())
+				if idleFor >= tr.idleTimeout {
+					tr.closeBoth()
+					return
+				}
+			}
+		}
+	}
+}
+
+// copyDir copies src->dst until EOF, error, or the watchdog closes the
+// connections. It updates the shared activity clock on every read and checks
+// the kill switch before and after each read so a chunk read while the switch
+// is flipping is not forwarded. A genuine EOF half-closes the peer (preserving
+// bidirectional teardown); any other read/write error tears the tunnel down.
+func (tr *tunnelRelay) copyDir(dst, src net.Conn) int64 {
 	buf := make([]byte, tunnelBufSize)
 	var total int64
 	for {
-		// Kill switch: terminate tunnel immediately when activated mid-stream.
-		if ks != nil && ks.IsActive() {
+		if tr.ks != nil && tr.ks.IsActive() {
+			tr.closeBoth()
 			return total
 		}
-
-		rd := time.Now().Add(idleTimeout)
-		if !deadline.IsZero() && rd.After(deadline) {
-			rd = deadline
-		}
-		_ = src.SetReadDeadline(rd)
 		n, err := src.Read(buf)
 		if n > 0 {
-			// Re-check kill switch after Read returns. Without this, one
-			// chunk read while the switch was flipping gets forwarded.
-			if ks != nil && ks.IsActive() {
+			tr.touch()
+			if tr.ks != nil && tr.ks.IsActive() {
+				tr.closeBoth()
 				return total
 			}
 			written, wErr := dst.Write(buf[:n])
 			total += int64(written)
 			if wErr != nil {
+				tr.closeBoth()
 				return total
 			}
 		}
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				// Genuine end of this direction: signal the peer that no more
+				// data is coming, but leave the other direction free to drain.
+				if tc, ok := dst.(*net.TCPConn); ok {
+					_ = tc.CloseWrite()
+				}
+			} else {
+				// Read error (watchdog/airlock close, reset, timeout): tear down.
+				tr.closeBoth()
+			}
 			return total
 		}
 	}

--- a/internal/proxy/relay_stream_test.go
+++ b/internal/proxy/relay_stream_test.go
@@ -1,0 +1,415 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+)
+
+// streamChunk is the per-tick payload a modeled streaming backend writes.
+const streamChunk = "data: token\n\n"
+
+// streamAbortBackend models a real streaming server (SSE / long reasoning
+// response): it writes a chunk every gap until it has sent nChunks, and it
+// ABORTS early if it observes the client half-close its write direction (the
+// relay's CloseWrite on a reaped direction arrives here as a read EOF). This
+// is the real-world trigger that turns the per-direction idle reap into a
+// stream kill. Returns the listener; the caller closes it.
+func streamAbortBackend(t *testing.T, gap time.Duration, nChunks int) net.Listener {
+	t.Helper()
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		// A real server stops producing when the client goes away. The relay's
+		// half-close on a reaped direction surfaces here as a read EOF.
+		stop := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(io.Discard, conn)
+			close(stop)
+		}()
+
+		ticker := time.NewTicker(gap)
+		defer ticker.Stop()
+		for i := 0; i < nChunks; i++ {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if _, err := conn.Write([]byte(streamChunk)); err != nil {
+					return
+				}
+			}
+		}
+	}()
+	return ln
+}
+
+// disableSNIVerify turns off forward-proxy SNI verification for a test. SNI
+// verification reads a TLS ClientHello from the client; a plaintext relay test
+// sends no ClientHello, so leaving it on would fail the tunnel on the SNI read
+// timeout instead of exercising the relay idle path. SNI verification is
+// orthogonal to tunnel liveness, and the relay code under test is identical
+// whether or not it ran.
+func disableSNIVerify(cfg *config.Config) {
+	off := false
+	cfg.ForwardProxy.SNIVerification = &off
+}
+
+// TestConnectStreamSurvivesSilentClientDirection is the red repro for the
+// long-lived-stream kill. A server streams a response (chunks every gap, well
+// inside idle_timeout) while the client->server tunnel direction is
+// legitimately silent (the request was already sent). The tunnel must stay
+// alive while bytes flow in EITHER direction.
+//
+// Pre-fix: the silent client->server copy loop reaps itself at idle_timeout
+// and half-closes the upstream; the modeled server treats that as a hangup and
+// aborts, so the client receives only the chunks sent before idle_timeout.
+func TestConnectStreamSurvivesSilentClientDirection(t *testing.T) {
+	const (
+		idleSeconds = 1
+		gap         = 300 * time.Millisecond
+		nChunks     = 8
+	)
+
+	ln := streamAbortBackend(t, gap, nChunks)
+	defer func() { _ = ln.Close() }()
+
+	proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
+		cfg.ForwardProxy.IdleTimeoutSeconds = idleSeconds
+		cfg.ForwardProxy.MaxTunnelSeconds = 30
+		disableSNIVerify(cfg)
+	})
+	defer cleanup()
+
+	conn := dialProxy(t, proxyAddr)
+	defer func() { _ = conn.Close() }()
+
+	target := ln.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Client never writes again on the client->server direction; it only reads
+	// the streamed response, which runs well past idle_timeout.
+	want := nChunks * len(streamChunk)
+	got := 0
+	buf := make([]byte, 256)
+	for got < want {
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		n, rErr := br.Read(buf)
+		got += n
+		if rErr != nil {
+			break
+		}
+	}
+
+	if got < want {
+		t.Fatalf("stream killed early: received %d/%d bytes; the silent client->server direction reaped the tunnel at idle_timeout", got, want)
+	}
+}
+
+// TestConnectIdleReapBothSilent confirms the shared idle clock still reaps a
+// genuinely idle tunnel: a backend that accepts but never sends, with a silent
+// client, must be torn down near idle_timeout (not held open).
+func TestConnectIdleReapBothSilent(t *testing.T) {
+	ln := listenHold(t) // accepts, discards, never sends
+	defer func() { _ = ln.Close() }()
+
+	proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
+		cfg.ForwardProxy.IdleTimeoutSeconds = 1
+		disableSNIVerify(cfg)
+	})
+	defer cleanup()
+
+	conn := dialProxy(t, proxyAddr)
+	defer func() { _ = conn.Close() }()
+
+	target := ln.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// Both directions silent: the watchdog must reap near idle_timeout. The
+	// generous 5s client deadline only guards against a hang; a working reap
+	// returns the error well before it.
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	start := time.Now()
+	_, rErr := br.Read(make([]byte, 1))
+	elapsed := time.Since(start)
+
+	if rErr == nil {
+		t.Fatal("expected idle tunnel to be reaped, got no error")
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("idle tunnel closed too early after %v; expected the shared idle timeout to drive teardown", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("idle reap took %v; expected near idle_timeout (1s)", elapsed)
+	}
+}
+
+// streamThenCloseBackend streams nChunks (one every gap) then closes the
+// connection: a normal completed streaming response that ends with a genuine
+// EOF rather than an idle reap.
+func streamThenCloseBackend(t *testing.T, gap time.Duration, nChunks int) net.Listener {
+	t.Helper()
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for i := 0; i < nChunks; i++ {
+			time.Sleep(gap)
+			if _, err := conn.Write([]byte(streamChunk)); err != nil {
+				return
+			}
+		}
+	}()
+	return ln
+}
+
+// TestConnectStreamCompletesOnServerClose verifies a completed streaming
+// response delivers every byte and then propagates EOF, even though the
+// client->server direction is silent the whole time. Genuine EOF must
+// half-close the peer (no data lost), distinct from an idle reap.
+func TestConnectStreamCompletesOnServerClose(t *testing.T) {
+	const (
+		idleSeconds = 3 // longer than the whole stream so completion is via EOF, not idle
+		gap         = 200 * time.Millisecond
+		nChunks     = 5
+	)
+
+	ln := streamThenCloseBackend(t, gap, nChunks)
+	defer func() { _ = ln.Close() }()
+
+	proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
+		cfg.ForwardProxy.IdleTimeoutSeconds = idleSeconds
+		disableSNIVerify(cfg)
+	})
+	defer cleanup()
+
+	conn := dialProxy(t, proxyAddr)
+	defer func() { _ = conn.Close() }()
+
+	target := ln.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	want := nChunks * len(streamChunk)
+	got := 0
+	buf := make([]byte, 256)
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		n, rErr := br.Read(buf)
+		got += n
+		if rErr != nil {
+			break // expect EOF once the server closes after the last chunk
+		}
+	}
+
+	if got != want {
+		t.Fatalf("completed stream lost data: received %d/%d bytes", got, want)
+	}
+}
+
+// scriptConn is a controllable net.Conn for exercising relay error and
+// teardown branches deterministically. Read and Write delegate to the provided
+// funcs; Close unblocks any read parked on the done channel. Only Read, Write,
+// and Close are invoked by the relay, so the embedded nil net.Conn is never
+// dereferenced.
+type scriptConn struct {
+	net.Conn
+	readFn  func([]byte) (int, error)
+	writeFn func([]byte) (int, error)
+	done    chan struct{}
+	once    sync.Once
+}
+
+func newScriptConn(readFn, writeFn func([]byte) (int, error)) *scriptConn {
+	return &scriptConn{readFn: readFn, writeFn: writeFn, done: make(chan struct{})}
+}
+
+func (s *scriptConn) Read(b []byte) (int, error)  { return s.readFn(b) }
+func (s *scriptConn) Write(b []byte) (int, error) { return s.writeFn(b) }
+
+func (s *scriptConn) Close() error {
+	s.once.Do(func() { close(s.done) })
+	return nil
+}
+
+// blockUntilClosed parks until the conn is closed, then reports closure as a
+// read error (mirroring a real conn whose blocked read is woken by Close).
+func (s *scriptConn) blockUntilClosed() (int, error) {
+	<-s.done
+	return 0, errors.New("scriptConn closed")
+}
+
+// TestCopyDirWriteErrorTearsDownTunnel covers the copyDir write-error path: a
+// read succeeds but the write to the peer fails, which must tear the whole
+// tunnel down (closeBoth), not leak the other direction.
+func TestCopyDirWriteErrorTearsDownTunnel(t *testing.T) {
+	sentOnce := make(chan struct{})
+	var clientReadOnce sync.Once
+
+	target := newScriptConn(
+		func(_ []byte) (int, error) { return 0, errors.New("blocked read") }, // never feeds the reverse direction
+		func(_ []byte) (int, error) { return 0, errors.New("write failed") }, // forces the write-error branch
+	)
+	client := newScriptConn(
+		func(b []byte) (int, error) {
+			sent := false
+			clientReadOnce.Do(func() {
+				b[0] = 'x'
+				sent = true
+				close(sentOnce)
+			})
+			if sent {
+				return 1, nil
+			}
+			return 0, errors.New("blocked read")
+		},
+		func(_ []byte) (int, error) { return 0, errors.New("no write") },
+	)
+	// Wire blocked reads to wake on Close so both directions terminate.
+	target.readFn = func(_ []byte) (int, error) { return target.blockUntilClosed() }
+	client.writeFn = func(_ []byte) (int, error) { return client.blockUntilClosed() }
+
+	done := make(chan int64, 1)
+	go func() { done <- bidirectionalCopy(client, target, 10*time.Second, time.Time{}, nil) }()
+
+	select {
+	case <-done:
+		// client->target read returned 'x', target.Write failed, tunnel torn down.
+	case <-time.After(3 * time.Second):
+		t.Fatal("bidirectionalCopy did not return after a write error")
+	}
+	<-sentOnce
+}
+
+// TestCopyDirPostReadKillSwitch covers the post-read kill-switch check: the
+// switch flips active during a read, so the freshly read chunk must NOT be
+// forwarded.
+func TestCopyDirPostReadKillSwitch(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	ks := killswitch.New(cfg)
+
+	var forwarded bool
+	var readOnce sync.Once
+
+	target := newScriptConn(nil, func(_ []byte) (int, error) {
+		forwarded = true // a forwarded chunk would call target.Write
+		return 0, errors.New("write")
+	})
+	client := newScriptConn(func(b []byte) (int, error) {
+		var done bool
+		readOnce.Do(func() {
+			ks.SetAPI(true) // activate between the pre-read and post-read checks
+			b[0] = 'x'
+			done = true
+		})
+		if done {
+			return 1, nil
+		}
+		return 0, errors.New("blocked read")
+	}, nil)
+	target.readFn = func(_ []byte) (int, error) { return target.blockUntilClosed() }
+	client.writeFn = func(_ []byte) (int, error) { return client.blockUntilClosed() }
+
+	doneCh := make(chan struct{})
+	go func() { _ = bidirectionalCopy(client, target, 10*time.Second, time.Time{}, ks); close(doneCh) }()
+
+	select {
+	case <-doneCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("bidirectionalCopy did not return after kill switch activated")
+	}
+	if forwarded {
+		t.Error("chunk was forwarded after the kill switch activated mid-read")
+	}
+}
+
+// TestWatchdogKillSwitchOnIdleTunnel covers the watchdog kill-switch path: a
+// tunnel that is idle (both directions blocked in Read) must be terminated by
+// the watchdog when the kill switch activates, without waiting out the long
+// idle timeout. This is the kill-switch responsiveness the watchdog adds.
+func TestWatchdogKillSwitchOnIdleTunnel(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	ks := killswitch.New(cfg)
+
+	client := newScriptConn(nil, nil)
+	target := newScriptConn(nil, nil)
+	client.readFn = func(_ []byte) (int, error) { return client.blockUntilClosed() }
+	client.writeFn = func(_ []byte) (int, error) { return client.blockUntilClosed() }
+	target.readFn = func(_ []byte) (int, error) { return target.blockUntilClosed() }
+	target.writeFn = func(_ []byte) (int, error) { return target.blockUntilClosed() }
+
+	// Activate the kill switch after the relay is parked on idle reads.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		ks.SetAPI(true)
+	}()
+
+	doneCh := make(chan struct{})
+	start := time.Now()
+	// Long idle timeout: only the watchdog kill-switch path can end this.
+	go func() { _ = bidirectionalCopy(client, target, 1*time.Hour, time.Time{}, ks); close(doneCh) }()
+
+	select {
+	case <-doneCh:
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Fatalf("watchdog took %v to honor the kill switch on an idle tunnel", elapsed)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("watchdog did not terminate the idle tunnel after the kill switch activated")
+	}
+}

--- a/internal/proxy/relay_stream_test.go
+++ b/internal/proxy/relay_stream_test.go
@@ -198,8 +198,10 @@ func streamThenCloseBackend(t *testing.T, gap time.Duration, nChunks int) net.Li
 			return
 		}
 		defer func() { _ = conn.Close() }()
+		ticker := time.NewTicker(gap)
+		defer ticker.Stop()
 		for i := 0; i < nChunks; i++ {
-			time.Sleep(gap)
+			<-ticker.C
 			if _, err := conn.Write([]byte(streamChunk)); err != nil {
 				return
 			}
@@ -334,6 +336,42 @@ func TestCopyDirWriteErrorTearsDownTunnel(t *testing.T) {
 	<-sentOnce
 }
 
+// TestCopyDirShortWriteTearsDownTunnel covers the short-write guard: a writer
+// that returns written < n without an error must still tear the tunnel down
+// rather than silently drop the unwritten bytes on the next read.
+func TestCopyDirShortWriteTearsDownTunnel(t *testing.T) {
+	var clientReadOnce sync.Once
+	sent := make(chan struct{})
+
+	target := newScriptConn(nil, func(p []byte) (int, error) {
+		return len(p) - 1, nil // short write, no error (contract-violating)
+	})
+	client := newScriptConn(func(b []byte) (int, error) {
+		first := false
+		clientReadOnce.Do(func() {
+			b[0], b[1] = 'x', 'y'
+			first = true
+			close(sent)
+		})
+		if first {
+			return 2, nil
+		}
+		return 0, errors.New("blocked read")
+	}, nil)
+	target.readFn = func(_ []byte) (int, error) { return target.blockUntilClosed() }
+	client.writeFn = func(_ []byte) (int, error) { return client.blockUntilClosed() }
+
+	doneCh := make(chan struct{})
+	go func() { _ = bidirectionalCopy(client, target, 10*time.Second, time.Time{}, nil); close(doneCh) }()
+
+	select {
+	case <-doneCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("bidirectionalCopy did not return after a short write")
+	}
+	<-sent
+}
+
 // TestCopyDirPostReadKillSwitch covers the post-read kill-switch check: the
 // switch flips active during a read, so the freshly read chunk must NOT be
 // forwarded.
@@ -386,23 +424,34 @@ func TestWatchdogKillSwitchOnIdleTunnel(t *testing.T) {
 	cfg.Internal = nil
 	ks := killswitch.New(cfg)
 
+	// Signal when each direction has entered Read so the kill switch is flipped
+	// only after both copy loops are parked (so the watchdog, not a copyDir
+	// pre-read check, is what terminates the tunnel). Deterministic, no sleep.
+	clientReading := make(chan struct{})
+	targetReading := make(chan struct{})
+	var cOnce, tOnce sync.Once
 	client := newScriptConn(nil, nil)
 	target := newScriptConn(nil, nil)
-	client.readFn = func(_ []byte) (int, error) { return client.blockUntilClosed() }
+	client.readFn = func(_ []byte) (int, error) {
+		cOnce.Do(func() { close(clientReading) })
+		return client.blockUntilClosed()
+	}
 	client.writeFn = func(_ []byte) (int, error) { return client.blockUntilClosed() }
-	target.readFn = func(_ []byte) (int, error) { return target.blockUntilClosed() }
+	target.readFn = func(_ []byte) (int, error) {
+		tOnce.Do(func() { close(targetReading) })
+		return target.blockUntilClosed()
+	}
 	target.writeFn = func(_ []byte) (int, error) { return target.blockUntilClosed() }
-
-	// Activate the kill switch after the relay is parked on idle reads.
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		ks.SetAPI(true)
-	}()
 
 	doneCh := make(chan struct{})
 	start := time.Now()
 	// Long idle timeout: only the watchdog kill-switch path can end this.
 	go func() { _ = bidirectionalCopy(client, target, 1*time.Hour, time.Time{}, ks); close(doneCh) }()
+
+	// Once both directions are parked in Read, activate the kill switch.
+	<-clientReading
+	<-targetReading
+	ks.SetAPI(true)
 
 	select {
 	case <-doneCh:

--- a/internal/proxy/relay_ws_stream_test.go
+++ b/internal/proxy/relay_ws_stream_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// wsPushServer upgrades the connection and then pushes nChunks server frames
+// (one every gap) WITHOUT waiting for any client frame. It models a
+// server-push stream (the WebSocket analogue of an SSE/token stream) where the
+// client->upstream direction is silent for the whole response.
+func wsPushServer(t *testing.T, gap time.Duration, nChunks int) (string, func()) {
+	t.Helper()
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			conn, _, _, upErr := ws.UpgradeHTTP(r, w)
+			if upErr != nil {
+				return
+			}
+			defer func() { _ = conn.Close() }()
+			for i := 0; i < nChunks; i++ {
+				time.Sleep(gap)
+				if wErr := wsutil.WriteServerMessage(conn, ws.OpText, []byte("token")); wErr != nil {
+					return
+				}
+			}
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	return ln.Addr().String(), func() { _ = srv.Close() }
+}
+
+// TestWSServerPushSurvivesSilentClient is the WebSocket parity proof for the
+// shared idle clock. The upstream pushes frames well inside idle_timeout while
+// the client stays silent. Pre-fix, the silent client->upstream direction
+// reaped itself at idle_timeout and canceled the relay, killing an actively
+// streaming socket. With the shared clock, server frames keep the whole
+// connection alive.
+func TestWSServerPushSurvivesSilentClient(t *testing.T) {
+	const (
+		idleSeconds = 1
+		gap         = 300 * time.Millisecond
+		nChunks     = 8
+	)
+
+	backendAddr, stopBackend := wsPushServer(t, gap, nChunks)
+	defer stopBackend()
+
+	proxyAddr, stopProxy := setupWSProxy(t, func(cfg *config.Config) {
+		cfg.WebSocketProxy.IdleTimeoutSeconds = idleSeconds
+		cfg.WebSocketProxy.MaxConnectionSeconds = 30
+	})
+	defer stopProxy()
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	defer func() { _ = conn.Close() }()
+
+	// Client never sends a frame; it only reads the server push, which runs
+	// well past idle_timeout.
+	got := 0
+	for got < nChunks {
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, op, rErr := wsutil.ReadServerData(conn)
+		if rErr != nil {
+			break
+		}
+		if op == ws.OpText {
+			got++
+		}
+	}
+
+	if got < nChunks {
+		t.Fatalf("ws stream killed early: received %d/%d frames; the silent client->upstream direction reaped the connection at idle_timeout", got, nChunks)
+	}
+}
+
+// wsHoldServer upgrades the connection then blocks without ever sending a
+// frame, modeling a fully idle WebSocket (no traffic in either direction).
+func wsHoldServer(t *testing.T) (string, func()) {
+	t.Helper()
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			conn, _, _, upErr := ws.UpgradeHTTP(r, w)
+			if upErr != nil {
+				return
+			}
+			defer func() { _ = conn.Close() }()
+			_, _, _ = wsutil.ReadClientData(conn) // block; never send
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	return ln.Addr().String(), func() { _ = srv.Close() }
+}
+
+// TestWSIdleReapBothSilent confirms the shared idle clock still reaps a fully
+// idle WebSocket: neither side sends a frame, so the connection must be torn
+// down near idle_timeout rather than held open.
+func TestWSIdleReapBothSilent(t *testing.T) {
+	backendAddr, stopBackend := wsHoldServer(t)
+	defer stopBackend()
+
+	proxyAddr, stopProxy := setupWSProxy(t, func(cfg *config.Config) {
+		cfg.WebSocketProxy.IdleTimeoutSeconds = 1
+		cfg.WebSocketProxy.MaxConnectionSeconds = 30
+	})
+	defer stopProxy()
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	defer func() { _ = conn.Close() }()
+
+	// Both directions silent: the connection must be reaped near idle_timeout.
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	start := time.Now()
+	_, _, rErr := wsutil.ReadServerData(conn)
+	elapsed := time.Since(start)
+
+	if rErr == nil {
+		t.Fatal("expected idle WS connection to be reaped, got no error")
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("WS connection closed too early after %v; expected the shared idle timeout to drive teardown", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("WS idle reap took %v; expected near idle_timeout (1s)", elapsed)
+	}
+}

--- a/internal/proxy/relay_ws_stream_test.go
+++ b/internal/proxy/relay_ws_stream_test.go
@@ -34,8 +34,10 @@ func wsPushServer(t *testing.T, gap time.Duration, nChunks int) (string, func())
 				return
 			}
 			defer func() { _ = conn.Close() }()
+			ticker := time.NewTicker(gap)
+			defer ticker.Stop()
 			for i := 0; i < nChunks; i++ {
-				time.Sleep(gap)
+				<-ticker.C
 				if wErr := wsutil.WriteServerMessage(conn, ws.OpText, []byte("token")); wErr != nil {
 					return
 				}

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -76,6 +77,36 @@ type wsRelay struct {
 	redactionLog     *redact.Report
 	rec              session.Recorder // live escalation level for UpgradeAction; nil when profiling disabled
 	terminalOnce     sync.Once        // ensures only one terminal receipt (kill_switch/session_deny) is emitted across concurrent relay goroutines
+
+	// lastActivity is the shared idle clock, updated by BOTH relay directions
+	// on every frame read as monotonic nanoseconds since clockStart. Idle is
+	// measured across the whole connection, not per-direction: a server
+	// pushing frames while the client is silent (or vice versa) keeps the
+	// connection alive. Measuring idle per-direction would reap the silent side
+	// at idle_timeout and tear down an actively streaming socket.
+	clockStart   time.Time
+	lastActivity atomic.Int64
+}
+
+// touch records frame activity on the shared idle clock. Called by both relay
+// directions so either side's traffic (including ping/pong keepalives) keeps
+// the connection alive.
+func (r *wsRelay) touch() {
+	r.lastActivity.Store(time.Since(r.clockStart).Nanoseconds())
+}
+
+// idleDeadline returns the next read deadline based on the shared activity
+// clock. A read that wakes at this deadline re-checks idleExpired before
+// tearing down, so activity on the OTHER direction (which advanced
+// lastActivity) re-arms instead of reaping.
+func (r *wsRelay) idleDeadline(idleTimeout time.Duration) time.Time {
+	return r.clockStart.Add(time.Duration(r.lastActivity.Load()) + idleTimeout)
+}
+
+// idleExpired reports whether the whole connection has been idle (no frame in
+// either direction) for at least idleTimeout.
+func (r *wsRelay) idleExpired(idleTimeout time.Duration) bool {
+	return time.Since(r.clockStart)-time.Duration(r.lastActivity.Load()) >= idleTimeout
 }
 
 // escalationLevel returns the live escalation level from the session recorder.
@@ -946,6 +977,8 @@ func (p *Proxy) wsDialUpstream(ctx context.Context, targetURL string, fwdHeaders
 // run starts bidirectional frame relay. Returns stats when both directions complete.
 func (r *wsRelay) run(ctx context.Context) wsRelayStats {
 	idleTimeout := time.Duration(r.cfg.WebSocketProxy.IdleTimeoutSeconds) * time.Second
+	r.clockStart = time.Now()
+	r.lastActivity.Store(0)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -1680,15 +1713,24 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 			return
 		}
 
-		_ = r.clientConn.SetReadDeadline(time.Now().Add(idleTimeout))
+		_ = r.clientConn.SetReadDeadline(r.idleDeadline(idleTimeout))
 
 		hdr, err := ws.ReadHeader(r.clientConn)
 		if err != nil {
+			// A read-deadline wake is only a real idle timeout when the WHOLE
+			// connection has been idle. If the upstream->client direction was
+			// active (it advanced the shared clock), re-arm instead of tearing
+			// down an actively streaming socket.
+			var nerr net.Error
+			if errors.As(err, &nerr) && nerr.Timeout() && !r.idleExpired(idleTimeout) {
+				continue
+			}
 			if !plwsutil.IsExpectedCloseErr(err) {
 				plwsutil.WriteClientCloseFrame(r.upstreamConn, ws.StatusGoingAway, "client disconnected")
 			}
 			return
 		}
+		r.touch()
 
 		// Guard against OOM: reject frames exceeding limits before allocating.
 		if hdr.OpCode.IsControl() && hdr.Length > plwsutil.MaxControlPayload {
@@ -2038,15 +2080,24 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 			return
 		}
 
-		_ = r.upstreamConn.SetReadDeadline(time.Now().Add(idleTimeout))
+		_ = r.upstreamConn.SetReadDeadline(r.idleDeadline(idleTimeout))
 
 		hdr, err := ws.ReadHeader(r.upstreamConn)
 		if err != nil {
+			// A read-deadline wake is only a real idle timeout when the WHOLE
+			// connection has been idle. If the client->upstream direction was
+			// active (it advanced the shared clock), re-arm instead of tearing
+			// down an actively streaming socket.
+			var nerr net.Error
+			if errors.As(err, &nerr) && nerr.Timeout() && !r.idleExpired(idleTimeout) {
+				continue
+			}
 			if !plwsutil.IsExpectedCloseErr(err) {
 				plwsutil.WriteCloseFrame(r.clientConn, ws.StatusGoingAway, "upstream disconnected")
 			}
 			return
 		}
+		r.touch()
 
 		// Guard against OOM: reject frames exceeding limits before allocating.
 		if hdr.OpCode.IsControl() && hdr.Length > plwsutil.MaxControlPayload {


### PR DESCRIPTION
## What was broken

A long-lived streaming response over a forward-proxy CONNECT tunnel (an SSE or token stream, anything that streams for longer than `idle_timeout_seconds`) was killed mid-stream at exactly the idle timeout, even while data flowed the whole time.

The relay measured idle per direction. On a streaming response the client-to-upstream direction is silent for the whole response (the request was already sent), so that direction hit the idle timeout, closed its half of the tunnel, and the upstream treated the half-close as a hangup and aborted the stream. The active token direction was never idle; the silent return path reaped the whole tunnel.

The WebSocket relay had the same per-direction idle measurement (a server-push stream with a silent client), masked in practice by ping/pong keepalives.

## The fix

Measure idle across the whole tunnel with one shared activity clock. A read in either direction keeps the tunnel alive; it is reaped only when both directions are idle for `idle_timeout_seconds`. The clock is monotonic, so an NTP or wall-clock adjustment cannot distort idle reaping.

A genuine end of stream still half-closes the peer, so bidirectional teardown is unchanged. Kill-switch termination and idle reaping of genuinely idle tunnels are preserved.

`max_tunnel_seconds` (CONNECT) and `max_connection_seconds` (WebSocket) bound the outbound dial, not the established tunnel. Bounding total tunnel lifetime is a separate concern and would be a future opt-in setting; it is not changed here.

## Tests

Regression tests on both transports: a streaming response with a silent reverse direction survives past the idle timeout and completes, a genuinely idle tunnel is still reaped near the timeout, a completed stream propagates EOF without data loss, and kill-switch termination still fires mid-stream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel idle-timeout detection to use shared activity across both directions, preventing premature reaping while traffic is flowing.
  * Updated relay teardown so streams complete/propagate closure correctly, and tunnels terminate promptly when the kill switch is activated or when an absolute deadline is reached.
* **Tests**
  * Added integration and unit coverage for CONNECT streaming/teardown, idle reaping behavior, kill-switch handling, deadline respect, and short/write-error termination.
  * Added WebSocket-specific idle-timeout validation for both active and fully-idle scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->