### PR TITLE
Make contain install portable across Linux distros

### DIFF
--- a/internal/cli/contain/addtool.go
+++ b/internal/cli/contain/addtool.go
@@ -69,7 +69,7 @@ Exit codes:
 	}
 
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "print planned actions without mutating state")
-	cmd.Flags().StringVar(&opts.target, "target", "", "explicit path to the target tool (default: which <name> from pipelock-agent's PATH)")
+	cmd.Flags().StringVar(&opts.target, "target", "", "explicit path to the target tool (default: command -v <name> from pipelock-agent's PATH)")
 
 	return cmd
 }
@@ -91,11 +91,13 @@ func runAddTool(ctx context.Context, env *installEnv, name string, opts addToolO
 	existing, readErr := env.readFile(wrapperPath)
 	alreadyInInventory := wrapperInInventory(env, wrapperName)
 
-	// Target resolution. --target trumps. Otherwise we run `which` AS
-	// pipelock-agent so the lookup uses pipelock-agent's PATH, not root's.
+	// Target resolution. --target trumps. Otherwise we run `command -v` AS
+	// pipelock-agent so the lookup uses pipelock-agent's PATH, not root's,
+	// and does not depend on a separate which(1) package.
 	target := opts.target
 	if target == "" {
-		out, code, _ := env.runCmd(ctx, "sudo", "-n", "-u", env.agentUserName, "--", "which", name)
+		out, code, _ := env.runCmd(ctx, "sudo", "-n", "-u", env.agentUserName, "--",
+			"sh", "-c", `command -v -- "$1"`, "sh", name)
 		if code != 0 {
 			return cliutil.ExitCodeError(
 				cliutil.ExitConfig,

--- a/internal/cli/contain/addtool.go
+++ b/internal/cli/contain/addtool.go
@@ -96,8 +96,11 @@ func runAddTool(ctx context.Context, env *installEnv, name string, opts addToolO
 	// and does not depend on a separate which(1) package.
 	target := opts.target
 	if target == "" {
-		out, code, _ := env.runCmd(ctx, "sudo", "-n", "-u", env.agentUserName, "--",
-			"sh", "-c", `command -v -- "$1"`, "sh", name)
+		out, code, err := env.runCmd(ctx, "sudo", "-n", "-u", env.agentUserName, "--",
+			"env", "PATH="+agentExecPath(env.agentUserName), "sh", "-c", `command -v -- "$1"`, "sh", name)
+		if err != nil {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("resolve tool %q in pipelock-agent's PATH: %w", name, err))
+		}
 		if code != 0 {
 			return cliutil.ExitCodeError(
 				cliutil.ExitConfig,

--- a/internal/cli/contain/addtool_test.go
+++ b/internal/cli/contain/addtool_test.go
@@ -59,17 +59,16 @@ func TestRunAddTool_DryRunNonMutating(t *testing.T) {
 	}
 }
 
-func TestRunAddTool_UsesWhichToResolveTarget(t *testing.T) {
+func TestRunAddTool_UsesCommandVToResolveTarget(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	if err := os.WriteFile(filepath.Join(env.wrapperDir, "plk-launch"), []byte("#!/bin/bash\n"), 0o755); err != nil { //nolint:gosec // tmpdir
 		t.Fatalf("plant: %v", err)
 	}
-	whichTarget := filepath.Join(t.TempDir(), "discovered-tool")
-	if err := os.WriteFile(whichTarget, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
+	resolvedTarget := filepath.Join(t.TempDir(), "discovered-tool")
+	if err := os.WriteFile(resolvedTarget, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
 		t.Fatalf("plant: %v", err)
 	}
-	// Pre-bake the which response.
-	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "which", "discovered"), whichTarget+"\n", 0, nil)
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "sh", "-c", "command -v -- \"$1\"", "sh", "discovered"), resolvedTarget+"\n", 0, nil)
 	err := runAddTool(context.Background(), env, "discovered", addToolOpts{})
 	if err != nil {
 		t.Fatalf("addTool: %v", err)
@@ -79,9 +78,9 @@ func TestRunAddTool_UsesWhichToResolveTarget(t *testing.T) {
 	}
 }
 
-func TestRunAddTool_FailsWhenWhichNotInPath(t *testing.T) {
+func TestRunAddTool_FailsWhenCommandVFindsNoTarget(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
-	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "which", "nopath"), "", 1, nil)
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "sh", "-c", "command -v -- \"$1\"", "sh", "nopath"), "", 1, nil)
 	err := runAddTool(context.Background(), env, "nopath", addToolOpts{})
 	if err == nil {
 		t.Fatal("expected error")

--- a/internal/cli/contain/addtool_test.go
+++ b/internal/cli/contain/addtool_test.go
@@ -68,7 +68,7 @@ func TestRunAddTool_UsesCommandVToResolveTarget(t *testing.T) {
 	if err := os.WriteFile(resolvedTarget, []byte("x"), 0o755); err != nil { //nolint:gosec // tmpdir
 		t.Fatalf("plant: %v", err)
 	}
-	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "sh", "-c", "command -v -- \"$1\"", "sh", "discovered"), resolvedTarget+"\n", 0, nil)
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "env", "PATH="+agentExecPath("pipelock-agent"), "sh", "-c", "command -v -- \"$1\"", "sh", "discovered"), resolvedTarget+"\n", 0, nil)
 	err := runAddTool(context.Background(), env, "discovered", addToolOpts{})
 	if err != nil {
 		t.Fatalf("addTool: %v", err)
@@ -80,7 +80,7 @@ func TestRunAddTool_UsesCommandVToResolveTarget(t *testing.T) {
 
 func TestRunAddTool_FailsWhenCommandVFindsNoTarget(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
-	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "sh", "-c", "command -v -- \"$1\"", "sh", "nopath"), "", 1, nil)
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "env", "PATH="+agentExecPath("pipelock-agent"), "sh", "-c", "command -v -- \"$1\"", "sh", "nopath"), "", 1, nil)
 	err := runAddTool(context.Background(), env, "nopath", addToolOpts{})
 	if err == nil {
 		t.Fatal("expected error")
@@ -89,6 +89,21 @@ func TestRunAddTool_FailsWhenCommandVFindsNoTarget(t *testing.T) {
 		t.Errorf("exit: %d", cliutil.ExitCodeOf(err))
 	}
 	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("err: %v", err)
+	}
+}
+
+func TestRunAddTool_FailsWhenCommandVCannotStart(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "env", "PATH="+agentExecPath("pipelock-agent"), "sh", "-c", "command -v -- \"$1\"", "sh", "broken"), "", -1, errors.New("fork/exec sudo: permission denied"))
+	err := runAddTool(context.Background(), env, "broken", addToolOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cliutil.ExitCodeOf(err) != cliutil.ExitConfig {
+		t.Errorf("exit: %d", cliutil.ExitCodeOf(err))
+	}
+	if !strings.Contains(err.Error(), "resolve tool") {
 		t.Errorf("err: %v", err)
 	}
 }

--- a/internal/cli/contain/carefresh.go
+++ b/internal/cli/contain/carefresh.go
@@ -83,7 +83,7 @@ Exit codes:
 	cmd.Flags().BoolVar(&opts.regenerateOnSnapshotRestore, "regenerate-on-snapshot-restore", false, "force-generate a fresh contain-managed CA before rebuilding the bundle")
 	cmd.Flags().StringVar(&opts.caOutput, "ca-output", "", "destination for the Pipelock-only CA (default /etc/pipelock/ca.pem)")
 	cmd.Flags().StringVar(&opts.bundleOutput, "bundle-output", "", "destination for the combined bundle (default /etc/pipelock/combined-ca.pem)")
-	cmd.Flags().StringVar(&opts.systemBundle, "system-bundle", defaultSystemCABundle, "source system CA bundle to combine with")
+	cmd.Flags().StringVar(&opts.systemBundle, "system-bundle", "", "source system CA bundle to combine with (default: auto-detect for this Linux distro)")
 
 	return cmd
 }
@@ -96,7 +96,7 @@ func runCARefresh(ctx context.Context, env *installEnv, opts caRefreshOpts) erro
 	// this function directly with fakes.
 	systemBundle := opts.systemBundle
 	if systemBundle == "" {
-		systemBundle = defaultSystemCABundle
+		systemBundle = env.systemCABundlePath
 	}
 	systemBundle = filepath.Clean(systemBundle)
 	resolvedSystemBundle, err := resolveSystemBundlePath(env, systemBundle)

--- a/internal/cli/contain/contain_hardening_test.go
+++ b/internal/cli/contain/contain_hardening_test.go
@@ -39,7 +39,7 @@ func TestRunAddToolAutoResolvedTargetIsPinned(t *testing.T) {
 	if err != nil {
 		t.Fatalf("executable: %v", err)
 	}
-	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "which", "discovered"), target+"\n", 0, nil)
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "sh", "-c", "command -v -- \"$1\"", "sh", "discovered"), target+"\n", 0, nil)
 	if err := runAddTool(context.Background(), env, "discovered", addToolOpts{}); err != nil {
 		t.Fatalf("add tool: %v", err)
 	}

--- a/internal/cli/contain/contain_hardening_test.go
+++ b/internal/cli/contain/contain_hardening_test.go
@@ -39,7 +39,7 @@ func TestRunAddToolAutoResolvedTargetIsPinned(t *testing.T) {
 	if err != nil {
 		t.Fatalf("executable: %v", err)
 	}
-	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "sh", "-c", "command -v -- \"$1\"", "sh", "discovered"), target+"\n", 0, nil)
+	runner.on(argvFor(testSudoCmd, "-n", "-u", "pipelock-agent", "--", "env", "PATH="+agentExecPath("pipelock-agent"), "sh", "-c", "command -v -- \"$1\"", "sh", "discovered"), target+"\n", 0, nil)
 	if err := runAddTool(context.Background(), env, "discovered", addToolOpts{}); err != nil {
 		t.Fatalf("add tool: %v", err)
 	}

--- a/internal/cli/contain/doctor.go
+++ b/internal/cli/contain/doctor.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -49,6 +50,7 @@ type doctorEnv struct {
 	caBundlePath   string
 	undiciShimPath string
 	canaryURL      string
+	curlPath       string
 
 	runCmd   runCommand
 	dialCtx  dialFunc
@@ -62,6 +64,7 @@ type doctorEnv struct {
 var doctorEnvFactory = defaultDoctorEnv
 
 func defaultDoctorEnv() *doctorEnv {
+	platform := detectContainPlatform(os.ReadFile, os.Stat, exec.LookPath)
 	return &doctorEnv{
 		port:           defaultProxyPort,
 		agentUserName:  defaultAgentUser,
@@ -69,6 +72,7 @@ func defaultDoctorEnv() *doctorEnv {
 		caBundlePath:   defaultCABundlePath,
 		undiciShimPath: defaultUndiciShimPath,
 		canaryURL:      canaryURL,
+		curlPath:       platform.curlPath,
 		runCmd:         realRunCommand,
 		dialCtx:        realDial,
 		readFile:       os.ReadFile,
@@ -147,8 +151,12 @@ func classifyAgentRun(out string, err error, tool string) (doctorResult, bool) {
 // --proxy/--cacert (rather than relying on env) makes the check definitive:
 // success means the proxy + CA path itself works, independent of env plumbing.
 func (env *doctorEnv) curlProxyArgs(url string) []string {
+	curl := env.curlPath
+	if curl == "" {
+		curl = defaultCurlPath
+	}
 	return []string{
-		curlPath,
+		curl,
 		"--proxy", proxyURLFor(env.port),
 		"--cacert", env.caBundlePath,
 		"--connect-timeout", curlConnectTimeout,
@@ -351,8 +359,12 @@ func checkDNSFailure(ctx context.Context, env *doctorEnv) doctorResult {
 // ---------------------------------------------------------------------------
 
 func (env *doctorEnv) curlDirectArgs(url string) []string {
+	curl := env.curlPath
+	if curl == "" {
+		curl = defaultCurlPath
+	}
 	return []string{
-		curlPath,
+		curl,
 		"--connect-timeout", curlConnectTimeout,
 		"--max-time", curlMaxTime,
 		"--noproxy", "*",

--- a/internal/cli/contain/file_owner_test_unix.go
+++ b/internal/cli/contain/file_owner_test_unix.go
@@ -1,0 +1,12 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package contain
+
+import "syscall"
+
+func fakeFileSysWithUID(uid uint32) any {
+	return &syscall.Stat_t{Uid: uid}
+}

--- a/internal/cli/contain/file_owner_test_windows.go
+++ b/internal/cli/contain/file_owner_test_windows.go
@@ -1,0 +1,10 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package contain
+
+func fakeFileSysWithUID(_ uint32) any {
+	return nil
+}

--- a/internal/cli/contain/file_owner_unix.go
+++ b/internal/cli/contain/file_owner_unix.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package contain
+
+import (
+	"os"
+	"syscall"
+)
+
+func fileOwnerUID(info os.FileInfo) (uint32, bool) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return st.Uid, true
+}

--- a/internal/cli/contain/file_owner_windows.go
+++ b/internal/cli/contain/file_owner_windows.go
@@ -1,0 +1,12 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package contain
+
+import "os"
+
+func fileOwnerUID(_ os.FileInfo) (uint32, bool) {
+	return 0, false
+}

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -329,7 +329,7 @@ func stepWriteCredentialGuard() step {
 				body string
 				mode os.FileMode
 			}{
-				{env.guardScriptPath, renderCredentialGuardScript(env.agentUserName, home), modeWrapperExec},
+				{env.guardScriptPath, renderCredentialGuardScript(env.agentUserName, home, env.bashPath), modeWrapperExec},
 				{env.guardServiceUnit, renderCredentialGuardService(env.guardScriptPath), modeUnitFile},
 				{env.guardPathUnit, renderCredentialGuardPathUnit(home, filepath.Base(env.guardServiceUnit)), modeUnitFile},
 			}
@@ -384,14 +384,17 @@ func stepWriteCredentialGuard() step {
 	}
 }
 
-func renderCredentialGuardScript(agentUser, operatorHome string) string {
+func renderCredentialGuardScript(agentUser, operatorHome, bashPath string) string {
+	if bashPath == "" {
+		bashPath = "/usr/bin/env bash"
+	}
 	roots := []string{
 		filepath.Join(operatorHome, ".claude"),
 		filepath.Join(operatorHome, ".claude-cc2"),
 		filepath.Join(operatorHome, ".codex"),
 	}
 	var b strings.Builder
-	b.WriteString("#!/usr/bin/env bash\nset -euo pipefail\n\n")
+	b.WriteString("#!" + bashPath + "\nset -euo pipefail\n\n")
 	b.WriteString("AGENT_USER=" + shellQuote(agentUser) + "\n")
 	b.WriteString("lock_matches() {\n")
 	b.WriteString("  local root=\"$1\"\n")
@@ -680,12 +683,23 @@ func toolsListEntriesEqual(a, b []toolsListEntry) bool {
 func stepPreflight(_ installOpts) step {
 	return step{
 		name: "preflight",
-		desc: "preflight: required binaries present (useradd / systemctl / nft / visudo)",
-		apply: func(_ context.Context, _ *installEnv) (bool, error) {
-			for _, b := range []string{"useradd", "userdel", "systemctl", "nft", "visudo"} {
+		desc: "preflight: required binaries present (useradd / systemctl / visudo / sudo / setfacl)",
+		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			for _, b := range []string{"useradd", "userdel", "systemctl", "visudo", "sudo", "setfacl", "find", "chmod"} {
 				if err := expectExec(b); err != nil {
 					return false, err
 				}
+			}
+			for label, path := range map[string]string{
+				"bash":    env.bashPath,
+				"nologin": env.nologinPath,
+			} {
+				if err := expectExecutablePath(env.stat, label, path); err != nil {
+					return false, err
+				}
+			}
+			if err := expectPrivilegedExecutablePath(env.stat, "nft", env.nftPath); err != nil {
+				return false, err
 			}
 			return true, nil
 		},
@@ -705,9 +719,9 @@ func stepPreflight(_ installOpts) step {
 func stepCreateUser(proxyUser bool) step {
 	pick := func(env *installEnv) (name, shell, home string) {
 		if proxyUser {
-			return env.proxyUserName, "/usr/sbin/nologin", "/var/lib/" + env.proxyUserName
+			return env.proxyUserName, env.nologinPath, "/var/lib/" + env.proxyUserName
 		}
-		return env.agentUserName, "/bin/bash", "/home/" + env.agentUserName
+		return env.agentUserName, env.bashPath, "/home/" + env.agentUserName
 	}
 	return step{
 		name: func() string {
@@ -1224,9 +1238,9 @@ func stepWriteCombinedCABundle() step {
 		name: "write-combined-ca",
 		desc: "build /etc/pipelock/combined-ca.pem (system bundle + pipelock CA)",
 		apply: func(_ context.Context, env *installEnv) (bool, error) {
-			sys, err := env.readFile(defaultSystemCABundle)
+			sys, err := env.readFile(env.systemCABundlePath)
 			if err != nil {
-				return false, fmt.Errorf("read system CA bundle %s: %w", defaultSystemCABundle, err)
+				return false, fmt.Errorf("read system CA bundle %s: %w", env.systemCABundlePath, err)
 			}
 			pl, err := env.readFile(env.caExportPath)
 			if err != nil {
@@ -1259,7 +1273,7 @@ func stepWriteCombinedCABundle() step {
 func stepInstallNFTRules() step {
 	return step{
 		name: "install-nft-rules",
-		desc: "write + load /etc/nftables.d/50-pipelock-containment.nft + persist via nftables.service",
+		desc: "write + load /etc/nftables.d/50-pipelock-containment.nft + persist via pipelock-containment-nft.service",
 		apply: func(ctx context.Context, env *installEnv) (bool, error) {
 			// Check nft version before generating rules. The containment
 			// ruleset requires "meta skuid" (available since nftables 0.4)
@@ -1288,7 +1302,7 @@ func stepInstallNFTRules() step {
 			}
 			tableLoaded := false
 			liveRulesDrifted := false
-			if out, code, _ := env.runCmd(ctx, "nft", "list", "table", "inet", env.nftTableOrDefault()); code == 0 {
+			if out, code, _ := env.runCmd(ctx, nftExecutable(env), "list", "table", "inet", env.nftTableOrDefault()); code == 0 {
 				tableLoaded = true
 				liveRulesDrifted = !liveNFTContainmentMatches(out, env.nftChainOrDefault(), env.proxyPort)
 			}
@@ -1306,83 +1320,88 @@ func stepInstallNFTRules() step {
 				}
 				rulesChanged = true
 			}
-			mainChanged, err := ensureNFTMainIncludesRules(env)
+			unitChanged, err := ensureNFTPersistUnit(env)
 			if err != nil {
 				return false, err
 			}
-			if mainChanged {
-				_, _ = fmt.Fprintf(env.out, "WARN: added %s include to %s for nftables.service persistence\n", env.nftRulesPath, env.nftMainPath)
-			}
-			if !rulesChanged && !mainChanged && tableLoaded && !liveRulesDrifted {
+			if !rulesChanged && !unitChanged && tableLoaded && !liveRulesDrifted {
 				return false, nil
 			}
 			// Validate before loading.
-			if err := runOrErr(ctx, env, "nft", "-c", "-f", env.nftRulesPath); err != nil {
+			if err := runOrErr(ctx, env, nftExecutable(env), "-c", "-f", env.nftRulesPath); err != nil {
 				return false, fmt.Errorf("nft validation failed: %w", err)
-			}
-			if err := runOrErr(ctx, env, "nft", "-c", "-f", env.nftMainPath); err != nil {
-				return false, fmt.Errorf("nft persistence validation failed: %w", err)
-			}
-			if tableLoaded && (rulesChanged || liveRulesDrifted) {
-				captureNFTPreState(ctx, env)
-				// nft -f merges into an existing table. Drop our managed table
-				// first so stale rules from an older contain install cannot
-				// survive beside the new ruleset.
-				_, _, _ = env.runCmd(ctx, "nft", "delete", "table", "inet", env.nftTableOrDefault())
-				tableLoaded = false
 			}
 			if !tableLoaded || rulesChanged || liveRulesDrifted {
 				captureNFTPreState(ctx, env)
-				if err := runOrErr(ctx, env, "nft", "-f", env.nftRulesPath); err != nil {
+			}
+			if tableLoaded && (rulesChanged || liveRulesDrifted) {
+				// nft -f merges into an existing table. Drop our managed table
+				// first so stale rules from an older contain install cannot
+				// survive beside the new ruleset.
+				_, _, _ = env.runCmd(ctx, nftExecutable(env), "delete", "table", "inet", env.nftTableOrDefault())
+				tableLoaded = false
+			}
+			if !tableLoaded || rulesChanged || liveRulesDrifted {
+				if err := runOrErr(ctx, env, nftExecutable(env), "-f", env.nftRulesPath); err != nil {
 					return false, fmt.Errorf("nft load failed: %w", err)
 				}
 			}
 			captureNFTPreState(ctx, env)
-			if err := runOrErr(ctx, env, "systemctl", "enable", "nftables.service"); err != nil {
-				return false, fmt.Errorf("enable nftables.service: %w", err)
+			if err := runOrErr(ctx, env, "systemctl", "daemon-reload"); err != nil {
+				return false, fmt.Errorf("systemctl daemon-reload: %w", err)
+			}
+			if err := runOrErr(ctx, env, "systemctl", "enable", filepath.Base(env.nftPersistUnitPath)); err != nil {
+				return false, fmt.Errorf("enable %s: %w", filepath.Base(env.nftPersistUnitPath), err)
 			}
 			return true, nil
 		},
 		undo: func(ctx context.Context, env *installEnv) error {
 			// Drop the managed table best-effort, restore any previous live
 			// table captured during this install attempt, then restore files.
-			_, _, _ = env.runCmd(ctx, "nft", "delete", "table", "inet", env.nftTableOrDefault())
+			_, _, _ = env.runCmd(ctx, nftExecutable(env), "delete", "table", "inet", env.nftTableOrDefault())
 			if err := restorePreviousNFTState(ctx, env); err != nil {
 				return err
 			}
 			if err := restoreBackup(env, env.nftRulesPath); err != nil {
 				return err
 			}
-			if err := restoreOrRemoveNFTMainInclude(env); err != nil {
+			if err := restoreBackup(env, env.nftPersistUnitPath); err != nil {
 				return err
 			}
-			if env.prevNftablesStateKnown && !env.prevNftablesEnabled {
-				if err := runOrErr(ctx, env, "systemctl", "disable", "nftables.service"); err != nil {
-					return fmt.Errorf("restore nftables.service disabled state: %w", err)
+			if env.prevNFTPersistStateKnown && !env.prevNFTPersistEnabled {
+				if err := runOrErr(ctx, env, "systemctl", "disable", filepath.Base(env.nftPersistUnitPath)); err != nil {
+					return fmt.Errorf("restore %s disabled state: %w", filepath.Base(env.nftPersistUnitPath), err)
 				}
 			}
+			_, _, _ = env.runCmd(ctx, "systemctl", "daemon-reload")
 			return nil
 		},
 	}
 }
 
 func captureNFTPreState(ctx context.Context, env *installEnv) {
-	if env.prevNFTTableDump == "" {
-		out, code, err := env.runCmd(ctx, "nft", "list", "table", "inet", env.nftTableOrDefault())
-		if err == nil && code == 0 {
-			env.prevNFTTableDump = out
+	if !env.prevNFTTableStateKnown {
+		out, code, err := env.runCmd(ctx, nftExecutable(env), "list", "table", "inet", env.nftTableOrDefault())
+		if err == nil {
+			env.prevNFTTableStateKnown = true
+			if code == 0 {
+				env.prevNFTTableDump = out
+			}
 		}
 	}
-	if !env.prevNftablesStateKnown {
-		_, code, err := env.runCmd(ctx, "systemctl", "is-enabled", "nftables.service")
+	if !env.prevNFTPersistStateKnown {
+		_, code, err := env.runCmd(ctx, "systemctl", "is-enabled", filepath.Base(env.nftPersistUnitPath))
 		if err == nil {
-			env.prevNftablesEnabled = code == 0
-			env.prevNftablesStateKnown = true
+			env.prevNFTPersistEnabled = code == 0
+			env.prevNFTPersistStateKnown = true
 		}
 	}
 }
 
 func restorePreviousNFTState(ctx context.Context, env *installEnv) error {
+	if !env.prevNFTTableStateKnown {
+		return nil
+	}
 	if strings.TrimSpace(env.prevNFTTableDump) == "" {
 		return nil
 	}
@@ -1391,7 +1410,7 @@ func restorePreviousNFTState(ctx context.Context, env *installEnv) error {
 		return fmt.Errorf("write nft restore file %s: %w", restorePath, err)
 	}
 	defer func() { _ = env.removeFile(restorePath) }()
-	if err := runOrErr(ctx, env, "nft", "-f", restorePath); err != nil {
+	if err := runOrErr(ctx, env, nftExecutable(env), "-f", restorePath); err != nil {
 		return fmt.Errorf("restore previous nft table: %w", err)
 	}
 	return nil
@@ -1407,42 +1426,55 @@ func nftRulesIncludeLine(path string) string {
 	return fmt.Sprintf("include %q", path)
 }
 
-func ensureNFTMainIncludesRules(env *installEnv) (bool, error) {
-	if err := env.mkdirAll(filepath.Dir(env.nftMainPath), modeDirReadable); err != nil {
-		return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(env.nftMainPath), err)
+func ensureNFTPersistUnit(env *installEnv) (bool, error) {
+	if err := env.mkdirAll(filepath.Dir(env.nftPersistUnitPath), modeDirReadable); err != nil {
+		return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(env.nftPersistUnitPath), err)
 	}
-	if err := env.chmod(filepath.Dir(env.nftMainPath), modeDirReadable); err != nil {
-		return false, fmt.Errorf("chmod %s: %w", filepath.Dir(env.nftMainPath), err)
+	if err := env.chmod(filepath.Dir(env.nftPersistUnitPath), modeDirReadable); err != nil {
+		return false, fmt.Errorf("chmod %s: %w", filepath.Dir(env.nftPersistUnitPath), err)
 	}
-
-	includeLine := nftRulesIncludeLine(env.nftRulesPath)
-	data, err := env.readFile(env.nftMainPath)
-	if err == nil && nftMainHasInclude(string(data), includeLine) {
+	body := renderNFTPersistUnit(env)
+	if existing, err := env.readFile(env.nftPersistUnitPath); err == nil && string(existing) == body {
+		if err := env.chmod(env.nftPersistUnitPath, modeUnitFile); err != nil {
+			return false, fmt.Errorf("chmod %s: %w", env.nftPersistUnitPath, err)
+		}
 		return false, nil
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("read %s: %w", env.nftPersistUnitPath, err)
 	}
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return false, fmt.Errorf("read %s: %w", env.nftMainPath, err)
-	}
-
-	var body string
-	if errors.Is(err, os.ErrNotExist) || len(data) == 0 {
-		body = "# Pipelock containment persistence\n" + includeLine + "\n"
-	} else {
-		body = strings.TrimRight(string(data), "\n") + "\n\n# Pipelock containment persistence\n" + includeLine + "\n"
-	}
-	if err := backupAndWrite(env, env.nftMainPath, []byte(body), modeNFTMainConfig); err != nil {
-		return false, fmt.Errorf("write %s: %w", env.nftMainPath, err)
+	if err := backupAndWrite(env, env.nftPersistUnitPath, []byte(body), modeUnitFile); err != nil {
+		return false, err
 	}
 	return true, nil
 }
 
-func nftMainHasInclude(body, includeLine string) bool {
-	for _, line := range strings.Split(body, "\n") {
-		if strings.TrimSpace(line) == includeLine {
-			return true
-		}
+func renderNFTPersistUnit(env *installEnv) string {
+	return strings.Join([]string{
+		"[Unit]",
+		"Description=Pipelock containment nftables rules",
+		"Documentation=https://github.com/luckyPipewrench/pipelock",
+		"DefaultDependencies=no",
+		"After=local-fs.target",
+		"Before=network-pre.target",
+		"Wants=network-pre.target",
+		"ConditionPathExists=" + env.nftRulesPath,
+		"",
+		"[Service]",
+		"Type=oneshot",
+		"ExecStart=" + nftExecutable(env) + " -f " + env.nftRulesPath,
+		"RemainAfterExit=yes",
+		"",
+		"[Install]",
+		"WantedBy=multi-user.target",
+		"",
+	}, "\n")
+}
+
+func nftExecutable(env *installEnv) string {
+	if env != nil && env.nftPath != "" {
+		return env.nftPath
 	}
-	return false
+	return "nft"
 }
 
 func restoreOrRemoveNFTMainInclude(env *installEnv) error {
@@ -1650,7 +1682,7 @@ func stepWriteLaunchWrapper() step {
 // sudo, plk-launch already runs AS pipelock-agent, no nested sudo here.
 func renderLaunchWrapper(env *installEnv) string {
 	return strings.Join([]string{
-		"#!/bin/bash",
+		shebangBash(env),
 		"# Managed by `pipelock contain install`. Edits are clobbered on next install.",
 		"# Runs AS pipelock-agent. Validates the tool name against the install-time",
 		"# allow-list (root-mutated, pipelock-agent-readable at " + env.toolsListPath + ") before exec.",
@@ -1773,7 +1805,7 @@ func stepWriteMetaWrapper() step {
 
 func renderMetaWrapper(env *installEnv) string {
 	return strings.Join([]string{
-		"#!/bin/bash",
+		shebangBash(env),
 		"# Managed by `pipelock contain install`. Edits are clobbered on next install.",
 		"set -euo pipefail",
 		"",
@@ -1885,11 +1917,18 @@ func wrapperNamesForEntries(entries []toolsListEntry) []string {
 // install is NOPASSWD-scoped so the legitimate case never prompts.
 func renderToolWrapper(env *installEnv, tool string) string {
 	return strings.Join([]string{
-		"#!/bin/bash",
+		shebangBash(env),
 		"# Managed by `pipelock contain install`. Edits are clobbered on next install.",
 		"exec sudo -n -u " + env.agentUserName + " " + filepath.Join(env.wrapperDir, "plk-launch") + " " + tool + ` "$@"`,
 		"",
 	}, "\n")
+}
+
+func shebangBash(env *installEnv) string {
+	if env != nil && env.bashPath != "" {
+		return "#!" + env.bashPath
+	}
+	return "#!/usr/bin/env bash"
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -774,7 +774,7 @@ func TestActionRemoveNFTRules_DropsAndCleans(t *testing.T) {
 	}
 	var sawDelete bool
 	for _, c := range runner.calls {
-		if c.name == testNFT && containsArg(c.args, "delete") {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+env.nftTableOrDefault() {
 			sawDelete = true
 		}
 	}

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -504,6 +505,41 @@ func TestStepInstallNFTRules_UndoDropsTable(t *testing.T) {
 	}
 }
 
+func TestStepInstallNFTRules_UndoDoesNotRestoreNewlyCreatedTable(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "", 1, nil)
+	runner.on(argvFor(testNFT, "-c", "-f", env.nftRulesPath), "", 0, nil)
+	runner.on(argvFor(testNFT, "-f", env.nftRulesPath), "", 0, nil)
+	runner.on(argvFor(testSystemctl, "daemon-reload"), "", 0, nil)
+	runner.on(argvFor(testSystemctl, "enable", filepath.Base(env.nftPersistUnitPath)), "", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-enabled", filepath.Base(env.nftPersistUnitPath)), "disabled\n", 1, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected nft rules to apply")
+	}
+	if !env.prevNFTTableStateKnown {
+		t.Fatal("previous absent nft table state was not captured")
+	}
+	if env.prevNFTTableDump != "" {
+		t.Fatalf("expected no previous table dump, got %q", env.prevNFTTableDump)
+	}
+
+	if err := s.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	restorePath := env.nftRulesPath + ".restore"
+	for _, c := range runner.calls {
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == restorePath {
+			t.Fatalf("undo restored a table that did not exist before install: %v", runner.calls)
+		}
+	}
+}
+
 func TestStepInstallNFTRules_ValidationFailureSurfaces(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	// Force nft validate to fail.
@@ -753,8 +789,46 @@ func TestActionRemoveNFTRules_DropsAndCleans(t *testing.T) {
 	}
 }
 
+// TestActionRemoveNFTRules_CleansLegacyMainInclude proves the rollback
+// action actually reaches restoreOrRemoveNFTMainInclude when nftMainPath is
+// populated the way defaultInstallEnv now wires it. The pre-portability
+// install appended an `include` line to the distro nft config; if rollback
+// skips this cleanup, the dangling include breaks the host nftables.service
+// at the next boot once the rules file is gone. A direct unit test of the
+// cleanup helper (which sets nftMainPath itself) would mask a regression
+// where the production env stops wiring the path.
+func TestActionRemoveNFTRules_CleansLegacyMainInclude(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	// Mirror defaultInstallEnv wiring: rollback must know the legacy path.
+	if defaultInstallEnv(io.Discard).nftMainPath == "" {
+		t.Fatal("defaultInstallEnv no longer wires nftMainPath; rollback legacy cleanup is unreachable")
+	}
+	env.nftMainPath = filepath.Join(t.TempDir(), "nftables.conf")
+	if err := os.MkdirAll(filepath.Dir(env.nftMainPath), 0o750); err != nil {
+		t.Fatalf("mkdir main config parent: %v", err)
+	}
+	includeLine := nftRulesIncludeLine(env.nftRulesPath)
+	body := "flush ruleset\n\n# Pipelock containment persistence\n" + includeLine + "\n"
+	if err := os.WriteFile(env.nftMainPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write legacy main config: %v", err)
+	}
+
+	a := actionRemoveNFTRules()
+	if err := a.undo(context.Background(), env); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+
+	got, err := os.ReadFile(env.nftMainPath)
+	if err != nil {
+		t.Fatalf("read legacy main config: %v", err)
+	}
+	if strings.Contains(string(got), includeLine) {
+		t.Fatalf("rollback left dangling legacy include:\n%s", got)
+	}
+}
+
 func TestRenderCredentialGuardScriptLocksCredentialNames(t *testing.T) {
-	body := renderCredentialGuardScript("pipelock-agent", "/home/operator")
+	body := renderCredentialGuardScript("pipelock-agent", "/home/operator", "/bin/bash")
 	for _, want := range []string{
 		"AGENT_USER='pipelock-agent'",
 		"lock_home_root '/home/operator'",

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 
 type fakeFileInfo struct {
 	mode os.FileMode
+	sys  any
 }
 
 func (f fakeFileInfo) Name() string       { return "fake" }
@@ -31,7 +33,7 @@ func (f fakeFileInfo) Size() int64        { return 0 }
 func (f fakeFileInfo) Mode() os.FileMode  { return f.mode }
 func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
 func (f fakeFileInfo) IsDir() bool        { return f.mode.IsDir() }
-func (f fakeFileInfo) Sys() any           { return nil }
+func (f fakeFileInfo) Sys() any           { return f.sys }
 
 func TestDefaultInstallEnvWiresContainmentDefaults(t *testing.T) {
 	env := defaultInstallEnv(io.Discard)
@@ -43,6 +45,13 @@ func TestDefaultInstallEnvWiresContainmentDefaults(t *testing.T) {
 	}
 	if env.configDir != defaultConfigDir || env.nftRulesPath != defaultNFTRulesPath {
 		t.Fatalf("paths not wired to defaults: config=%q nft=%q", env.configDir, env.nftRulesPath)
+	}
+	// nftMainPath must be populated so rollback's legacy-include cleanup
+	// (gated on env.nftMainPath != "") is reachable for systems upgraded
+	// from a pre-portability build. A regression here silently orphans the
+	// `include` line in the distro nft config on rollback.
+	if env.nftMainPath != defaultNFTMainConfigPath {
+		t.Fatalf("nftMainPath: got %q, want %q (legacy rollback cleanup must stay wired)", env.nftMainPath, defaultNFTMainConfigPath)
 	}
 	if env.proxyPort != defaultProxyPort {
 		t.Fatalf("proxy port: got %d want %d", env.proxyPort, defaultProxyPort)
@@ -182,8 +191,10 @@ func newFakeEnv(t *testing.T) (*installEnv, *fakeRunner, *bytes.Buffer) {
 		systemUnitPath:     filepath.Join(root, "etc", "systemd", "system", "pipelock.service"),
 		nftRulesPath:       filepath.Join(root, "etc", "nftables.d", "50-pipelock-containment.nft"),
 		nftMainPath:        filepath.Join(root, "etc", "sysconfig", "nftables.conf"),
+		nftPersistUnitPath: filepath.Join(root, "etc", "systemd", "system", "pipelock-containment-nft.service"),
 		sudoersPath:        filepath.Join(root, "etc", "sudoers.d", "50-pipelock-agent"),
 		caBundlePath:       filepath.Join(root, "etc", "pipelock", "combined-ca.pem"),
+		systemCABundlePath: filepath.Join(root, "etc", "ssl", "certs", "ca-certificates.crt"),
 		caExportPath:       filepath.Join(root, "etc", "pipelock", "ca.pem"),
 		integrityDir:       filepath.Join(root, "etc", "pipelock", "integrity"),
 		integrityPin:       filepath.Join(root, "etc", "pipelock", "integrity", "binary-pin.sha256"),
@@ -198,6 +209,10 @@ func newFakeEnv(t *testing.T) (*installEnv, *fakeRunner, *bytes.Buffer) {
 		profileScriptPath:  filepath.Join(root, "etc", "profile.d", "pipelock-contain.sh"),
 		agentHome:          filepath.Join(root, "home", "pipelock-agent"),
 		pipelockTarget:     filepath.Join(root, "usr", "local", "bin", "pipelock"),
+		bashPath:           "/bin/bash",
+		nologinPath:        "/usr/sbin/nologin",
+		nftPath:            testNFT,
+		curlPath:           "/usr/bin/curl",
 		proxyPort:          8888,
 	}
 
@@ -221,7 +236,7 @@ func newFakeEnv(t *testing.T) (*installEnv, *fakeRunner, *bytes.Buffer) {
 		t.Fatalf("mkdir unit parent: %v", err)
 	}
 	// Plant a fake system CA bundle the install will read.
-	systemBundle := filepath.Join(root, "etc", "ssl", "certs", "ca-bundle.crt")
+	systemBundle := env.systemCABundlePath
 	if err := os.MkdirAll(filepath.Dir(systemBundle), 0o755); err != nil { //nolint:gosec // tmpdir
 		t.Fatalf("mkdir system bundle parent: %v", err)
 	}
@@ -233,16 +248,6 @@ func newFakeEnv(t *testing.T) (*installEnv, *fakeRunner, *bytes.Buffer) {
 	// subprocess writing through pipelock).
 	if err := os.MkdirAll(env.configDir, 0o750); err != nil {
 		t.Fatalf("mkdir configDir: %v", err)
-	}
-
-	// Patch defaultSystemCABundle indirection by overriding readFile so
-	// the canonical path resolves to our test path.
-	origReadFile := env.readFile
-	env.readFile = func(p string) ([]byte, error) {
-		if p == defaultSystemCABundle {
-			return os.ReadFile(systemBundle) //nolint:gosec // tmpdir-scoped test path
-		}
-		return origReadFile(p)
 	}
 
 	return env, runner, out
@@ -401,7 +406,8 @@ func TestRunInstall_DryRunPrintsPlan(t *testing.T) {
 
 func TestRunInstall_EndToEndWithExistingUsers(t *testing.T) {
 	env, runner, buf := newFakeEnv(t)
-	installContainCommandFixtures(t)
+	binDir := installContainCommandFixtures(t)
+	env.nftPath = filepath.Join(binDir, "nft")
 
 	// Let the default allow-list find one agent tool without depending on
 	// host-global /usr/local/bin contents.
@@ -409,6 +415,9 @@ func TestRunInstall_EndToEndWithExistingUsers(t *testing.T) {
 	env.stat = func(path string) (os.FileInfo, error) {
 		if path == "/usr/local/bin/claude" {
 			return origStat(env.pipelockBinary)
+		}
+		if path == env.nftPath {
+			return fakeFileInfo{mode: 0o700, sys: &syscall.Stat_t{Uid: 0}}, nil
 		}
 		return origStat(path)
 	}
@@ -441,7 +450,8 @@ func TestRunInstall_EndToEndWithExistingUsers(t *testing.T) {
 
 func TestRunInstall_UpgradeRotatesExistingBackups(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
-	installContainCommandFixtures(t)
+	binDir := installContainCommandFixtures(t)
+	env.nftPath = filepath.Join(binDir, "nft")
 
 	cfgDir := t.TempDir()
 	cfg1 := filepath.Join(cfgDir, "pipelock-1.yaml")
@@ -456,6 +466,9 @@ func TestRunInstall_UpgradeRotatesExistingBackups(t *testing.T) {
 	enabledTools := map[string]bool{"claude": true}
 	origStat := env.stat
 	env.stat = func(path string) (os.FileInfo, error) {
+		if path == env.nftPath {
+			return fakeFileInfo{mode: 0o700, sys: &syscall.Stat_t{Uid: 0}}, nil
+		}
 		for _, tool := range defaultToolNames() {
 			for _, dir := range filepath.SplitList(agentExecPath(env.agentUserName)) {
 				if path != filepath.Join(dir, tool) {
@@ -485,7 +498,7 @@ func TestRunInstall_UpgradeRotatesExistingBackups(t *testing.T) {
 	systemBundle := []byte("# system bundle v1\n")
 	origReadFile := env.readFile
 	env.readFile = func(path string) ([]byte, error) {
-		if path == defaultSystemCABundle {
+		if path == env.systemCABundlePath {
 			return append([]byte(nil), systemBundle...), nil
 		}
 		return origReadFile(path)
@@ -584,16 +597,27 @@ func legacyBody(path string, overrides map[string][]byte) []byte {
 	return []byte("legacy:" + filepath.Base(path) + "\n")
 }
 
-func installContainCommandFixtures(t *testing.T) {
+func installContainCommandFixtures(t *testing.T) string {
 	t.Helper()
 	binDir := t.TempDir()
-	for _, name := range []string{"useradd", "userdel", "systemctl", "nft", "visudo"} {
+	for _, name := range []string{"useradd", "userdel", "systemctl", "nft", "visudo", "sudo", "setfacl", "find", "chmod"} {
 		path := filepath.Join(binDir, name)
 		if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil { //nolint:gosec // executable fixture required for preflight PATH lookup.
 			t.Fatalf("write %s: %v", name, err)
 		}
 	}
 	t.Setenv("PATH", binDir)
+	return binDir
+}
+
+func writeNFTPersistUnitFixture(t *testing.T, env *installEnv) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(env.nftPersistUnitPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir persistence unit parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftPersistUnitPath, []byte(renderNFTPersistUnit(env)), 0o600); err != nil {
+		t.Fatalf("write persistence unit: %v", err)
+	}
 }
 
 func seedLegacyInstallFiles(t *testing.T, paths []string, overrides map[string][]byte) {
@@ -690,11 +714,19 @@ func TestStepPreflightChecksRequiredBinaries(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		binDir := t.TempDir()
-		for _, name := range []string{"useradd", "userdel", "systemctl", "nft", "visudo"} {
+		for _, name := range []string{"useradd", "userdel", "systemctl", "nft", "visudo", "sudo", "setfacl", "find", "chmod"} {
 			path := filepath.Join(binDir, name)
 			if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil { //nolint:gosec // executable fixture required for preflight PATH lookup.
 				t.Fatalf("write %s: %v", name, err)
 			}
+		}
+		env.nftPath = filepath.Join(binDir, "nft")
+		origStat := env.stat
+		env.stat = func(path string) (os.FileInfo, error) {
+			if path == env.nftPath {
+				return fakeFileInfo{mode: 0o700, sys: &syscall.Stat_t{Uid: 0}}, nil
+			}
+			return origStat(path)
 		}
 		t.Setenv("PATH", binDir)
 		applied, err := s.apply(context.Background(), env)
@@ -719,6 +751,60 @@ func TestStepPreflightChecksRequiredBinaries(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 	})
+}
+
+func TestStepPreflightRejectsUntrustedNFTPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		mode    os.FileMode
+		uid     uint32
+		wantErr string
+	}{
+		{
+			name:    "relative path",
+			path:    "nft",
+			mode:    0o700,
+			uid:     0,
+			wantErr: "absolute path",
+		},
+		{
+			name:    "operator owned",
+			path:    "/tmp/nft",
+			mode:    0o700,
+			uid:     1000,
+			wantErr: "root-owned",
+		},
+		{
+			name:    "world writable",
+			path:    "/tmp/nft",
+			mode:    0o722,
+			uid:     0,
+			wantErr: "group- or world-writable",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, _, _ := newFakeEnv(t)
+			binDir := installContainCommandFixtures(t)
+			env.nftPath = tc.path
+			env.stat = func(path string) (os.FileInfo, error) {
+				if path == filepath.Clean(tc.path) {
+					return fakeFileInfo{mode: tc.mode, sys: &syscall.Stat_t{Uid: tc.uid}}, nil
+				}
+				return os.Stat(path)
+			}
+			t.Setenv("PATH", binDir)
+
+			_, err := stepPreflight(installOpts{}).apply(context.Background(), env)
+			if err == nil {
+				t.Fatal("expected preflight error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error: got %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
 }
 
 func TestStepCreateUser_CallsUseradd(t *testing.T) {
@@ -1175,12 +1261,7 @@ func TestStepInstallNFTRules_SkipsWhenLoaded(t *testing.T) {
 	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
 		t.Fatalf("write rules: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(env.nftMainPath), 0o755); err != nil { //nolint:gosec // tmpdir
-		t.Fatalf("mkdir main config parent: %v", err)
-	}
-	if err := os.WriteFile(env.nftMainPath, []byte(nftRulesIncludeLine(env.nftRulesPath)+"\n"), 0o600); err != nil {
-		t.Fatalf("write main config: %v", err)
-	}
+	writeNFTPersistUnitFixture(t, env)
 	// Make `nft list table` succeed with a healthy live table.
 	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), body, 0, nil)
 
@@ -1204,12 +1285,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
 	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
 		t.Fatalf("write rules: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(env.nftMainPath), 0o755); err != nil { //nolint:gosec // tmpdir
-		t.Fatalf("mkdir main config parent: %v", err)
-	}
-	if err := os.WriteFile(env.nftMainPath, []byte(nftRulesIncludeLine(env.nftRulesPath)+"\n"), 0o600); err != nil {
-		t.Fatalf("write main config: %v", err)
-	}
+	writeNFTPersistUnitFixture(t, env)
 	drifted := `table inet pipelock_containment {
 		chain output_filter {
 			meta oif "lo" accept
@@ -1243,7 +1319,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
 	}
 }
 
-func TestStepInstallNFTRules_RepairsMissingPersistenceOnRerun(t *testing.T) {
+func TestStepInstallNFTRules_RepairsMissingPersistenceUnitOnRerun(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	operatorUID, proxyUID, agentUID := 1000, 988, 987
 	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
@@ -1261,14 +1337,14 @@ func TestStepInstallNFTRules_RepairsMissingPersistenceOnRerun(t *testing.T) {
 		t.Fatalf("apply: %v", err)
 	}
 	if !applied {
-		t.Fatal("expected rerun to repair missing persistence include")
+		t.Fatal("expected rerun to repair missing persistence unit")
 	}
-	mainBody, err := os.ReadFile(env.nftMainPath)
+	unitBody, err := os.ReadFile(env.nftPersistUnitPath)
 	if err != nil {
-		t.Fatalf("read main config: %v", err)
+		t.Fatalf("read persistence unit: %v", err)
 	}
-	if !strings.Contains(string(mainBody), nftRulesIncludeLine(env.nftRulesPath)) {
-		t.Fatalf("main config missing include:\n%s", mainBody)
+	if !strings.Contains(string(unitBody), env.nftRulesPath) {
+		t.Fatalf("persistence unit missing rules path:\n%s", unitBody)
 	}
 }
 
@@ -1342,14 +1418,14 @@ func TestStepInstallNFTRules_DropsLoadedTableBeforeChangedReload(t *testing.T) {
 	}
 }
 
-func TestStepInstallNFTRules_PersistsViaMainConfigAndRestores(t *testing.T) {
+func TestStepInstallNFTRules_PersistsViaOwnedSystemdUnitAndRestores(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
-	original := "flush ruleset\n"
-	if err := os.MkdirAll(filepath.Dir(env.nftMainPath), 0o755); err != nil { //nolint:gosec // tmpdir
-		t.Fatalf("mkdir main config parent: %v", err)
+	original := "[Unit]\nDescription=old unit\n"
+	if err := os.MkdirAll(filepath.Dir(env.nftPersistUnitPath), 0o755); err != nil { //nolint:gosec // tmpdir
+		t.Fatalf("mkdir unit parent: %v", err)
 	}
-	if err := os.WriteFile(env.nftMainPath, []byte(original), 0o600); err != nil {
-		t.Fatalf("write main config: %v", err)
+	if err := os.WriteFile(env.nftPersistUnitPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write unit: %v", err)
 	}
 	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "", 1, fmt.Errorf("not loaded"))
 
@@ -1362,33 +1438,23 @@ func TestStepInstallNFTRules_PersistsViaMainConfigAndRestores(t *testing.T) {
 		t.Fatal("expected apply=true")
 	}
 
-	mainBody, err := os.ReadFile(env.nftMainPath)
+	unitBody, err := os.ReadFile(env.nftPersistUnitPath)
 	if err != nil {
-		t.Fatalf("read main config: %v", err)
+		t.Fatalf("read persistence unit: %v", err)
 	}
-	if !strings.Contains(string(mainBody), nftRulesIncludeLine(env.nftRulesPath)) {
-		t.Fatalf("main config missing include:\n%s", mainBody)
-	}
-
-	var sawMainValidation bool
-	for _, c := range runner.calls {
-		if c.name == testNFT && len(c.args) == 3 && c.args[0] == "-c" && c.args[1] == "-f" && c.args[2] == env.nftMainPath {
-			sawMainValidation = true
-		}
-	}
-	if !sawMainValidation {
-		t.Fatalf("expected nft -c -f main config validation, got %v", runner.calls)
+	if !strings.Contains(string(unitBody), "ExecStart="+env.nftPath+" -f "+env.nftRulesPath) {
+		t.Fatalf("unit missing ExecStart:\n%s", unitBody)
 	}
 
 	if err := s.undo(context.Background(), env); err != nil {
 		t.Fatalf("undo: %v", err)
 	}
-	restored, err := os.ReadFile(env.nftMainPath)
+	restored, err := os.ReadFile(env.nftPersistUnitPath)
 	if err != nil {
-		t.Fatalf("read restored main config: %v", err)
+		t.Fatalf("read restored unit: %v", err)
 	}
 	if string(restored) != original {
-		t.Fatalf("main config not restored: got %q want %q", restored, original)
+		t.Fatalf("unit not restored: got %q want %q", restored, original)
 	}
 }
 
@@ -1402,7 +1468,7 @@ func TestStepInstallNFTRules_UndoRestoresPreviousLiveTableAndServiceState(t *tes
 }
 `
 	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), previousTable, 0, nil)
-	runner.on(argvFor(testSystemctl, "is-enabled", "nftables.service"), "disabled\n", 1, nil)
+	runner.on(argvFor(testSystemctl, "is-enabled", filepath.Base(env.nftPersistUnitPath)), "disabled\n", 1, nil)
 
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
@@ -1415,8 +1481,8 @@ func TestStepInstallNFTRules_UndoRestoresPreviousLiveTableAndServiceState(t *tes
 	if env.prevNFTTableDump != previousTable {
 		t.Fatalf("previous table not captured: %q", env.prevNFTTableDump)
 	}
-	if !env.prevNftablesStateKnown || env.prevNftablesEnabled {
-		t.Fatalf("previous nftables service state not captured as disabled")
+	if !env.prevNFTPersistStateKnown || env.prevNFTPersistEnabled {
+		t.Fatalf("previous nft persistence unit state not captured as disabled")
 	}
 
 	if err := s.undo(context.Background(), env); err != nil {
@@ -1431,7 +1497,7 @@ func TestStepInstallNFTRules_UndoRestoresPreviousLiveTableAndServiceState(t *tes
 		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == restorePath {
 			sawRestore = true
 		}
-		if c.name == testSystemctl && strings.Join(c.args, " ") == "disable nftables.service" {
+		if c.name == testSystemctl && strings.Join(c.args, " ") == "disable "+filepath.Base(env.nftPersistUnitPath) {
 			sawDisable = true
 		}
 	}
@@ -1439,12 +1505,13 @@ func TestStepInstallNFTRules_UndoRestoresPreviousLiveTableAndServiceState(t *tes
 		t.Fatalf("expected nft restore from captured table, got %v", runner.calls)
 	}
 	if !sawDisable {
-		t.Fatalf("expected nftables.service disabled-state restore, got %v", runner.calls)
+		t.Fatalf("expected persistence unit disabled-state restore, got %v", runner.calls)
 	}
 }
 
 func TestStepInstallNFTRules_UndoRemovesManagedIncludeWhenNoBackup(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
+	env.nftMainPath = filepath.Join(t.TempDir(), "nftables.conf")
 	if err := os.MkdirAll(filepath.Dir(env.nftMainPath), 0o755); err != nil { //nolint:gosec // tmpdir
 		t.Fatalf("mkdir main config parent: %v", err)
 	}

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 
@@ -417,7 +416,7 @@ func TestRunInstall_EndToEndWithExistingUsers(t *testing.T) {
 			return origStat(env.pipelockBinary)
 		}
 		if path == env.nftPath {
-			return fakeFileInfo{mode: 0o700, sys: &syscall.Stat_t{Uid: 0}}, nil
+			return fakeFileInfo{mode: 0o700, sys: fakeFileSysWithUID(0)}, nil
 		}
 		return origStat(path)
 	}
@@ -467,7 +466,7 @@ func TestRunInstall_UpgradeRotatesExistingBackups(t *testing.T) {
 	origStat := env.stat
 	env.stat = func(path string) (os.FileInfo, error) {
 		if path == env.nftPath {
-			return fakeFileInfo{mode: 0o700, sys: &syscall.Stat_t{Uid: 0}}, nil
+			return fakeFileInfo{mode: 0o700, sys: fakeFileSysWithUID(0)}, nil
 		}
 		for _, tool := range defaultToolNames() {
 			for _, dir := range filepath.SplitList(agentExecPath(env.agentUserName)) {
@@ -612,7 +611,7 @@ func installContainCommandFixtures(t *testing.T) string {
 
 func writeNFTPersistUnitFixture(t *testing.T, env *installEnv) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(env.nftPersistUnitPath), 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(filepath.Dir(env.nftPersistUnitPath), 0o750); err != nil {
 		t.Fatalf("mkdir persistence unit parent: %v", err)
 	}
 	if err := os.WriteFile(env.nftPersistUnitPath, []byte(renderNFTPersistUnit(env)), 0o600); err != nil {
@@ -724,7 +723,7 @@ func TestStepPreflightChecksRequiredBinaries(t *testing.T) {
 		origStat := env.stat
 		env.stat = func(path string) (os.FileInfo, error) {
 			if path == env.nftPath {
-				return fakeFileInfo{mode: 0o700, sys: &syscall.Stat_t{Uid: 0}}, nil
+				return fakeFileInfo{mode: 0o700, sys: fakeFileSysWithUID(0)}, nil
 			}
 			return origStat(path)
 		}
@@ -790,7 +789,7 @@ func TestStepPreflightRejectsUntrustedNFTPath(t *testing.T) {
 			env.nftPath = tc.path
 			env.stat = func(path string) (os.FileInfo, error) {
 				if path == filepath.Clean(tc.path) {
-					return fakeFileInfo{mode: tc.mode, sys: &syscall.Stat_t{Uid: tc.uid}}, nil
+					return fakeFileInfo{mode: tc.mode, sys: fakeFileSysWithUID(tc.uid)}, nil
 				}
 				return os.Stat(path)
 			}
@@ -1421,7 +1420,7 @@ func TestStepInstallNFTRules_DropsLoadedTableBeforeChangedReload(t *testing.T) {
 func TestStepInstallNFTRules_PersistsViaOwnedSystemdUnitAndRestores(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	original := "[Unit]\nDescription=old unit\n"
-	if err := os.MkdirAll(filepath.Dir(env.nftPersistUnitPath), 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(filepath.Dir(env.nftPersistUnitPath), 0o750); err != nil {
 		t.Fatalf("mkdir unit parent: %v", err)
 	}
 	if err := os.WriteFile(env.nftPersistUnitPath, []byte(original), 0o600); err != nil {

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -756,7 +756,7 @@ func expectPrivilegedExecutablePath(stat func(string) (os.FileInfo, error), labe
 	if info.Mode().Perm()&0o022 != 0 {
 		return fmt.Errorf("required %s executable %q must not be group- or world-writable", label, path)
 	}
-	if st, ok := info.Sys().(*syscall.Stat_t); ok && st.Uid != 0 {
+	if uid, ok := fileOwnerUID(info); ok && uid != 0 {
 		return fmt.Errorf("required %s executable %q must be root-owned", label, path)
 	}
 	return nil

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -75,9 +75,11 @@ type installEnv struct {
 	wrapperDir         string
 	systemUnitPath     string
 	nftRulesPath       string
-	nftMainPath        string
+	nftMainPath        string // legacy distro nft service config path; new installs never write it, but rollback cleans up a legacy include here.
+	nftPersistUnitPath string
 	sudoersPath        string
 	caBundlePath       string
+	systemCABundlePath string
 	caExportPath       string
 	integrityDir       string
 	integrityPin       string
@@ -93,12 +95,17 @@ type installEnv struct {
 	agentHome          string // contained agent home (per-tool config destination)
 	pipelockBinary     string // source binary path passed to --pipelock-binary
 	pipelockTarget     string // destination, default /usr/local/bin/pipelock
+	bashPath           string
+	nologinPath        string
+	nftPath            string
+	curlPath           string
 	proxyPort          int
 
-	prevNFTTableDump       string
-	prevNftablesEnabled    bool
-	prevNftablesStateKnown bool
-	archivedBackups        map[string][]string
+	prevNFTTableDump         string
+	prevNFTTableStateKnown   bool
+	prevNFTPersistEnabled    bool
+	prevNFTPersistStateKnown bool
+	archivedBackups          map[string][]string
 }
 
 // defaultInstallEnv wires installEnv to the real OS. Callers fill in
@@ -107,6 +114,7 @@ type installEnv struct {
 // - step1 (preflight) errors out cleanly if root invoked install without
 // sudo (where $SUDO_USER is empty) and -- no override flag was passed.
 func defaultInstallEnv(out io.Writer) *installEnv {
+	platform := detectContainPlatform(os.ReadFile, os.Stat, exec.LookPath)
 	return &installEnv{
 		runCmd:             realRunCommand,
 		stat:               os.Stat,
@@ -133,9 +141,13 @@ func defaultInstallEnv(out io.Writer) *installEnv {
 		wrapperDir:         defaultWrapperDir,
 		systemUnitPath:     defaultSystemUnitPath,
 		nftRulesPath:       defaultNFTRulesPath,
+		nftPersistUnitPath: defaultNFTPersistUnitPath,
+		// Populated so rollback can clean up a legacy `include` line a
+		// pre-portability build appended here. New installs never write it.
 		nftMainPath:        defaultNFTMainConfigPath,
 		sudoersPath:        defaultSudoersPath,
 		caBundlePath:       defaultCABundlePath,
+		systemCABundlePath: platform.systemCABundlePath,
 		caExportPath:       defaultCAExportPath,
 		integrityDir:       defaultIntegrityDir,
 		integrityPin:       defaultIntegrityPin,
@@ -150,6 +162,10 @@ func defaultInstallEnv(out io.Writer) *installEnv {
 		profileScriptPath:  defaultProfileScriptPath,
 		agentHome:          "/home/" + defaultAgentUser,
 		pipelockTarget:     defaultPipelockTarget,
+		bashPath:           platform.bashPath,
+		nologinPath:        platform.nologinPath,
+		nftPath:            platform.nftPath,
+		curlPath:           platform.curlPath,
 		proxyPort:          defaultProxyPort,
 	}
 }
@@ -162,6 +178,14 @@ const (
 	defaultDataDir            = "/var/lib/pipelock"
 	defaultSystemUnitPath     = "/etc/systemd/system/pipelock.service"
 	defaultNFTRulesPath       = "/etc/nftables.d/50-pipelock-containment.nft"
+	defaultNFTPersistUnitPath = "/etc/systemd/system/pipelock-containment-nft.service"
+	// defaultNFTMainConfigPath is the distro nft service config that
+	// pre-portability installs appended a managed `include` line to. New
+	// installs persist via defaultNFTPersistUnitPath and never touch this
+	// file, but rollback must still clean up a legacy include left by an
+	// older build (otherwise the dangling include breaks the distro
+	// nftables.service after the rules file is removed). See
+	// restoreOrRemoveNFTMainInclude.
 	defaultNFTMainConfigPath  = "/etc/sysconfig/nftables.conf"
 	defaultSudoersPath        = "/etc/sudoers.d/50-pipelock-agent"
 	defaultCAExportPath       = "/etc/pipelock/ca.pem"
@@ -175,7 +199,7 @@ const (
 	defaultGuardServiceUnit   = "/etc/systemd/system/pipelock-cred-guard.service" //nolint:gosec // G101: unit filename, not a credential value.
 	defaultGuardPathUnit      = "/etc/systemd/system/pipelock-cred-guard.path"    //nolint:gosec // G101: unit filename, not a credential value.
 	defaultPipelockTarget     = "/usr/local/bin/pipelock"
-	defaultSystemCABundle     = "/etc/ssl/certs/ca-bundle.crt"
+	defaultSystemCABundle     = "/etc/ssl/certs/ca-certificates.crt"
 
 	// File modes. The model is "pipelock-agent UID must be able to read every
 	// non-secret file the wrappers depend on at runtime, but cannot read
@@ -694,6 +718,46 @@ func pathExists(env *installEnv, path string) bool {
 func expectExec(name string) error {
 	if _, err := exec.LookPath(name); err != nil {
 		return fmt.Errorf("required executable %q not found in PATH: %w", name, err)
+	}
+	return nil
+}
+
+func expectExecutablePath(stat func(string) (os.FileInfo, error), label, path string) error {
+	if path == "" {
+		return fmt.Errorf("required %s path is empty", label)
+	}
+	if stat == nil {
+		stat = os.Stat
+	}
+	info, err := stat(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("required %s executable %q not found: %w", label, path, err)
+	}
+	if info.IsDir() || info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("required %s executable %q is not executable", label, path)
+	}
+	return nil
+}
+
+func expectPrivilegedExecutablePath(stat func(string) (os.FileInfo, error), label, path string) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("required %s executable %q must be an absolute path", label, path)
+	}
+	if stat == nil {
+		stat = os.Stat
+	}
+	info, err := stat(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("required %s executable %q not found: %w", label, path, err)
+	}
+	if info.IsDir() || info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("required %s executable %q is not executable", label, path)
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return fmt.Errorf("required %s executable %q must not be group- or world-writable", label, path)
+	}
+	if st, ok := info.Sys().(*syscall.Stat_t); ok && st.Uid != 0 {
+		return fmt.Errorf("required %s executable %q must be root-owned", label, path)
 	}
 	return nil
 }

--- a/internal/cli/contain/platform.go
+++ b/internal/cli/contain/platform.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type containPlatform struct {
+	id                 string
+	idLike             []string
+	family             string
+	systemCABundlePath string
+	bashPath           string
+	nologinPath        string
+	nftPath            string
+	curlPath           string
+}
+
+const (
+	platformFamilyDebian  = "debian"
+	platformFamilyRHEL    = "rhel"
+	platformFamilyArch    = "arch"
+	platformFamilySUSE    = "suse"
+	platformFamilyGeneric = "generic"
+)
+
+func detectContainPlatform(
+	readFile func(string) ([]byte, error),
+	stat func(string) (os.FileInfo, error),
+	lookPath func(string) (string, error),
+) containPlatform {
+	id, likes := readOSRelease(readFile)
+	family := platformFamilyFor(id, likes)
+	return containPlatform{
+		id:                 id,
+		idLike:             likes,
+		family:             family,
+		systemCABundlePath: firstExistingPath(stat, systemCABundleCandidates(family)),
+		bashPath:           resolveExecutablePath(stat, lookPath, "bash", []string{"/usr/bin/bash", "/bin/bash"}),
+		nologinPath:        resolveExecutablePath(stat, lookPath, "nologin", []string{"/usr/sbin/nologin", "/sbin/nologin", "/bin/false"}),
+		nftPath:            resolveExecutablePathCandidatesFirst(stat, lookPath, "nft", []string{"/usr/sbin/nft", "/sbin/nft", "/usr/bin/nft", "/bin/nft"}),
+		curlPath:           resolveExecutablePath(stat, lookPath, "curl", []string{"/usr/bin/curl", "/bin/curl", "/usr/local/bin/curl"}),
+	}
+}
+
+func readOSRelease(readFile func(string) ([]byte, error)) (string, []string) {
+	for _, path := range []string{"/etc/os-release", "/usr/lib/os-release"} {
+		data, err := readFile(path)
+		if err != nil {
+			continue
+		}
+		fields := parseOSRelease(data)
+		id := fields["ID"]
+		if id == "" {
+			id = "linux"
+		}
+		return id, strings.Fields(fields["ID_LIKE"])
+	}
+	return "linux", nil
+}
+
+func parseOSRelease(data []byte) map[string]string {
+	out := map[string]string{}
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if len(value) >= 2 {
+			quote := value[0]
+			if (quote == '"' || quote == '\'') && value[len(value)-1] == quote {
+				value = value[1 : len(value)-1]
+			}
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func platformFamilyFor(id string, likes []string) string {
+	for _, candidate := range append([]string{id}, likes...) {
+		switch candidate {
+		case "debian", "ubuntu":
+			return platformFamilyDebian
+		case "fedora", "rhel", "centos", "rocky", "almalinux", "ol", "amzn":
+			return platformFamilyRHEL
+		case "arch", "archlinux":
+			return platformFamilyArch
+		case "suse", "opensuse", "opensuse-tumbleweed", "opensuse-leap", "sles":
+			return platformFamilySUSE
+		}
+	}
+	return platformFamilyGeneric
+}
+
+func systemCABundleCandidates(family string) []string {
+	switch family {
+	case platformFamilyDebian:
+		return []string{
+			"/etc/ssl/certs/ca-certificates.crt",
+			"/etc/ssl/certs/ca-bundle.crt",
+		}
+	case platformFamilyRHEL:
+		return []string{
+			"/etc/pki/tls/certs/ca-bundle.crt",
+			"/etc/ssl/certs/ca-bundle.crt",
+			"/etc/ssl/certs/ca-certificates.crt",
+		}
+	case platformFamilyArch:
+		return []string{
+			"/etc/ssl/certs/ca-certificates.crt",
+			"/etc/ssl/certs/ca-bundle.crt",
+		}
+	case platformFamilySUSE:
+		return []string{
+			"/etc/ssl/ca-bundle.pem",
+			"/var/lib/ca-certificates/ca-bundle.pem",
+			"/etc/ssl/certs/ca-certificates.crt",
+			"/etc/ssl/certs/ca-bundle.crt",
+		}
+	default:
+		return []string{
+			"/etc/ssl/certs/ca-certificates.crt",
+			"/etc/ssl/certs/ca-bundle.crt",
+			"/etc/pki/tls/certs/ca-bundle.crt",
+			"/etc/ssl/ca-bundle.pem",
+			"/var/lib/ca-certificates/ca-bundle.pem",
+		}
+	}
+}
+
+func firstExistingPath(stat func(string) (os.FileInfo, error), paths []string) string {
+	for _, path := range paths {
+		clean := filepath.Clean(path)
+		info, err := stat(clean)
+		if err == nil && !info.IsDir() {
+			return clean
+		}
+	}
+	if len(paths) == 0 {
+		return defaultSystemCABundle
+	}
+	return filepath.Clean(paths[0])
+}
+
+func resolveExecutablePath(
+	stat func(string) (os.FileInfo, error),
+	lookPath func(string) (string, error),
+	name string,
+	candidates []string,
+) string {
+	if lookPath != nil {
+		if path, err := lookPath(name); err == nil && path != "" {
+			return filepath.Clean(path)
+		}
+	}
+	for _, path := range candidates {
+		clean := filepath.Clean(path)
+		info, err := stat(clean)
+		if err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0 {
+			return clean
+		}
+	}
+	if len(candidates) == 0 {
+		return name
+	}
+	return filepath.Clean(candidates[0])
+}
+
+func resolveExecutablePathCandidatesFirst(
+	stat func(string) (os.FileInfo, error),
+	lookPath func(string) (string, error),
+	name string,
+	candidates []string,
+) string {
+	for _, path := range candidates {
+		clean := filepath.Clean(path)
+		info, err := stat(clean)
+		if err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0 {
+			return clean
+		}
+	}
+	if lookPath != nil {
+		if path, err := lookPath(name); err == nil && path != "" {
+			return filepath.Clean(path)
+		}
+	}
+	if len(candidates) == 0 {
+		return name
+	}
+	return filepath.Clean(candidates[0])
+}

--- a/internal/cli/contain/platform_test.go
+++ b/internal/cli/contain/platform_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseOSRelease(t *testing.T) {
+	fields := parseOSRelease([]byte(`
+# comment
+ID="ubuntu"
+ID_LIKE='debian rhel'
+BROKEN
+ NAME = "ignored-key-with-space"
+`))
+	if fields["ID"] != "ubuntu" {
+		t.Fatalf("ID: got %q, want ubuntu", fields["ID"])
+	}
+	if fields["ID_LIKE"] != "debian rhel" {
+		t.Fatalf("ID_LIKE: got %q, want debian rhel", fields["ID_LIKE"])
+	}
+	if _, ok := fields["BROKEN"]; ok {
+		t.Fatalf("malformed line was parsed: %#v", fields)
+	}
+}
+
+func TestDetectContainPlatformUsesIDLikeAndDistroCABundle(t *testing.T) {
+	stat := fakeContainStat(map[string]os.FileMode{
+		"/etc/pki/tls/certs/ca-bundle.crt": 0o644,
+		"/usr/bin/bash":                    0o755,
+		"/usr/sbin/nologin":                0o755,
+		"/usr/sbin/nft":                    0o755,
+		"/usr/bin/curl":                    0o755,
+	})
+	readFile := func(path string) ([]byte, error) {
+		if path == "/etc/os-release" {
+			return []byte("ID=linux\nID_LIKE=\"rhel fedora\"\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+	lookPath := func(name string) (string, error) {
+		if name == "nft" {
+			return "/custom/sbin/nft", nil
+		}
+		return "", errors.New("not found")
+	}
+
+	got := detectContainPlatform(readFile, stat, lookPath)
+	if got.family != platformFamilyRHEL {
+		t.Fatalf("family: got %q, want %q", got.family, platformFamilyRHEL)
+	}
+	if got.systemCABundlePath != "/etc/pki/tls/certs/ca-bundle.crt" {
+		t.Fatalf("systemCABundlePath: got %q", got.systemCABundlePath)
+	}
+	if got.nftPath != "/usr/sbin/nft" {
+		t.Fatalf("nftPath: got %q, want vetted candidate", got.nftPath)
+	}
+}
+
+func TestDetectContainPlatformFallsBackToLookPathForNFT(t *testing.T) {
+	readFile := func(path string) ([]byte, error) {
+		if path == "/etc/os-release" {
+			return []byte("ID=unknown\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	got := detectContainPlatform(readFile, fakeContainStat(nil), fakeContainLookPath(map[string]string{
+		"nft": "/opt/nft/bin/nft",
+	}))
+	if got.nftPath != "/opt/nft/bin/nft" {
+		t.Fatalf("nftPath: got %q, want lookPath fallback", got.nftPath)
+	}
+}
+
+func TestDetectContainPlatformSUSECABundle(t *testing.T) {
+	stat := fakeContainStat(map[string]os.FileMode{
+		"/var/lib/ca-certificates/ca-bundle.pem": 0o644,
+	})
+	readFile := func(path string) ([]byte, error) {
+		if path == "/usr/lib/os-release" {
+			return []byte("ID=opensuse-tumbleweed\n"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	got := detectContainPlatform(readFile, stat, fakeContainLookPath(nil))
+	if got.family != platformFamilySUSE {
+		t.Fatalf("family: got %q, want %q", got.family, platformFamilySUSE)
+	}
+	if got.systemCABundlePath != "/var/lib/ca-certificates/ca-bundle.pem" {
+		t.Fatalf("systemCABundlePath: got %q", got.systemCABundlePath)
+	}
+}
+
+func TestDetectContainPlatformGenericFallbacks(t *testing.T) {
+	got := detectContainPlatform(
+		func(string) ([]byte, error) { return nil, os.ErrNotExist },
+		fakeContainStat(nil),
+		fakeContainLookPath(nil),
+	)
+	if got.family != platformFamilyGeneric {
+		t.Fatalf("family: got %q, want %q", got.family, platformFamilyGeneric)
+	}
+	if got.systemCABundlePath != defaultSystemCABundle {
+		t.Fatalf("systemCABundlePath: got %q, want %q", got.systemCABundlePath, defaultSystemCABundle)
+	}
+	if got.bashPath != "/usr/bin/bash" {
+		t.Fatalf("bashPath: got %q, want first candidate", got.bashPath)
+	}
+}
+
+func fakeContainLookPath(paths map[string]string) func(string) (string, error) {
+	return func(name string) (string, error) {
+		if paths != nil {
+			if path, ok := paths[name]; ok {
+				return path, nil
+			}
+		}
+		return "", errors.New("not found")
+	}
+}
+
+func fakeContainStat(paths map[string]os.FileMode) func(string) (os.FileInfo, error) {
+	return func(path string) (os.FileInfo, error) {
+		mode, ok := paths[filepath.Clean(path)]
+		if !ok {
+			return nil, os.ErrNotExist
+		}
+		return containFileInfo{name: filepath.Base(path), mode: mode}, nil
+	}
+}
+
+type containFileInfo struct {
+	name string
+	mode os.FileMode
+}
+
+func (i containFileInfo) Name() string       { return i.name }
+func (i containFileInfo) Size() int64        { return 1 }
+func (i containFileInfo) Mode() os.FileMode  { return i.mode }
+func (i containFileInfo) ModTime() time.Time { return time.Time{} }
+func (i containFileInfo) IsDir() bool        { return i.mode.IsDir() }
+func (i containFileInfo) Sys() any           { return nil }

--- a/internal/cli/contain/rollback.go
+++ b/internal/cli/contain/rollback.go
@@ -314,20 +314,30 @@ func actionDisablePipelockService() step {
 	}
 }
 
-// actionRemoveNFTRules deletes the table, removes the rules file, and
-// restores/removes the managed persistence include. We do NOT disable
-// nftables.service: the operator may have had it enabled before our install.
+// actionRemoveNFTRules deletes the table, removes the rules file, and removes
+// the Pipelock-owned boot-time unit. It never disables a distro nftables.service:
+// the operator may have had that enabled before our install.
 func actionRemoveNFTRules() step {
 	return step{
 		name: "remove-nft-rules",
-		desc: "drop pipelock_containment table and remove nftables persistence include",
+		desc: "drop pipelock_containment table and remove Pipelock nft persistence unit",
 		undo: func(ctx context.Context, env *installEnv) error {
-			_, _, _ = env.runCmd(ctx, "nft", "delete", "table", "inet", defaultNFTTable)
+			unit := filepath.Base(env.nftPersistUnitPath)
+			_, _, _ = env.runCmd(ctx, "systemctl", "disable", "--now", unit)
+			_, _, _ = env.runCmd(ctx, nftExecutable(env), "delete", "table", "inet", defaultNFTTable)
 			if err := env.removeFile(env.nftRulesPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf("remove %s: %w", env.nftRulesPath, err)
 			}
 			_ = env.removeFile(env.nftRulesPath + ".bak")
-			return restoreOrRemoveNFTMainInclude(env)
+			if err := env.removeFile(env.nftPersistUnitPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove %s: %w", env.nftPersistUnitPath, err)
+			}
+			_ = env.removeFile(env.nftPersistUnitPath + ".bak")
+			_, _, _ = env.runCmd(ctx, "systemctl", "daemon-reload")
+			if env.nftMainPath != "" {
+				return restoreOrRemoveNFTMainInclude(env)
+			}
+			return nil
 		},
 	}
 }

--- a/internal/cli/contain/rollback.go
+++ b/internal/cli/contain/rollback.go
@@ -324,7 +324,7 @@ func actionRemoveNFTRules() step {
 		undo: func(ctx context.Context, env *installEnv) error {
 			unit := filepath.Base(env.nftPersistUnitPath)
 			_, _, _ = env.runCmd(ctx, "systemctl", "disable", "--now", unit)
-			_, _, _ = env.runCmd(ctx, nftExecutable(env), "delete", "table", "inet", defaultNFTTable)
+			_, _, _ = env.runCmd(ctx, nftExecutable(env), "delete", "table", "inet", env.nftTableOrDefault())
 			if err := env.removeFile(env.nftRulesPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf("remove %s: %w", env.nftRulesPath, err)
 			}

--- a/internal/cli/contain/runtime_contract.go
+++ b/internal/cli/contain/runtime_contract.go
@@ -276,7 +276,7 @@ func renderUtilityWrapper(env *installEnv, tool string) string {
 		assigns = append(assigns, "    "+envAssign(v.name, v.value)+" \\")
 	}
 	header := []string{
-		"#!/bin/bash",
+		shebangBash(env),
 		"# Managed by `pipelock contain install`. Edits are clobbered on next install.",
 		"# Forces the Pipelock proxy + CA runtime contract, then execs " + tool + ".",
 		"set -euo pipefail",

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -48,7 +48,8 @@ const (
 	// max time so a slow handshake still returns within probe budget.
 	curlConnectTimeout = "3"
 	curlMaxTime        = "5"
-	curlPath           = "/usr/bin/curl"
+	defaultCurlPath    = "/usr/bin/curl"
+	curlPath           = defaultCurlPath
 	canaryURL          = "https://example.com/"
 
 	// Probe status values. Strings (not an enum type) so JSON
@@ -96,23 +97,26 @@ type lookupUserFunc func(name string) (*user.User, error)
 // addressable from outside the package so tests can populate it
 // directly without going through the cobra layer.
 type probeEnv struct {
-	port           int
-	operatorUser   string
-	proxyUserName  string
-	agentUserName  string
-	wrapperDir     string
-	toolWrappers   []string
-	caBundlePath   string
-	launchPath     string
-	nftTable       string
-	nftChain       string
-	nftRulesPath   string
-	nftMainPath    string
-	serviceName    string
-	pinPath        string
-	wrapperInvPath string
-	toolsListPath  string
-	workspacePaths []string
+	port               int
+	operatorUser       string
+	proxyUserName      string
+	agentUserName      string
+	wrapperDir         string
+	toolWrappers       []string
+	caBundlePath       string
+	launchPath         string
+	nftTable           string
+	nftChain           string
+	nftRulesPath       string
+	nftMainPath        string
+	nftPersistUnitPath string
+	nftPath            string
+	serviceName        string
+	curlPath           string
+	pinPath            string
+	wrapperInvPath     string
+	toolsListPath      string
+	workspacePaths     []string
 
 	runCmd     runCommand
 	dialCtx    dialFunc
@@ -128,30 +132,33 @@ type probeEnv struct {
 // present; otherwise probe 9 runs curl as the current process user
 // directly. See probe 9 implementation for the runtime branch.
 func defaultProbeEnv() *probeEnv {
+	platform := detectContainPlatform(os.ReadFile, os.Stat, exec.LookPath)
 	return &probeEnv{
-		port:           defaultProxyPort,
-		operatorUser:   os.Getenv("SUDO_USER"),
-		proxyUserName:  defaultProxyUser,
-		agentUserName:  defaultAgentUser,
-		wrapperDir:     defaultWrapperDir,
-		toolWrappers:   append([]string(nil), defaultToolWrappers...),
-		caBundlePath:   defaultCABundlePath,
-		launchPath:     defaultLaunchScript,
-		nftTable:       defaultNFTTable,
-		nftChain:       defaultNFTChain,
-		nftRulesPath:   defaultNFTRulesPath,
-		nftMainPath:    defaultNFTMainConfigPath,
-		serviceName:    defaultServiceName,
-		pinPath:        defaultIntegrityPin,
-		wrapperInvPath: defaultWrapperInvPath,
-		toolsListPath:  defaultToolsListPath,
-		runCmd:         realRunCommand,
-		dialCtx:        realDial,
-		lookupUser:     user.Lookup,
-		stat:           os.Stat,
-		readFile:       os.ReadFile,
-		selfPath:       os.Executable,
-		hashFile:       sha256HexOfFile,
+		port:               defaultProxyPort,
+		operatorUser:       os.Getenv("SUDO_USER"),
+		proxyUserName:      defaultProxyUser,
+		agentUserName:      defaultAgentUser,
+		wrapperDir:         defaultWrapperDir,
+		toolWrappers:       append([]string(nil), defaultToolWrappers...),
+		caBundlePath:       defaultCABundlePath,
+		launchPath:         defaultLaunchScript,
+		nftTable:           defaultNFTTable,
+		nftChain:           defaultNFTChain,
+		nftRulesPath:       defaultNFTRulesPath,
+		nftPersistUnitPath: defaultNFTPersistUnitPath,
+		nftPath:            platform.nftPath,
+		serviceName:        defaultServiceName,
+		curlPath:           platform.curlPath,
+		pinPath:            defaultIntegrityPin,
+		wrapperInvPath:     defaultWrapperInvPath,
+		toolsListPath:      defaultToolsListPath,
+		runCmd:             realRunCommand,
+		dialCtx:            realDial,
+		lookupUser:         user.Lookup,
+		stat:               os.Stat,
+		readFile:           os.ReadFile,
+		selfPath:           os.Executable,
+		hashFile:           sha256HexOfFile,
 	}
 }
 
@@ -718,7 +725,7 @@ func parseSystemdShow(out string) map[string]string {
 // ---------------------------------------------------------------------------
 
 func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
-	out, code, err := env.runCmd(ctx, "nft", "list", "table", "inet", env.nftTable)
+	out, code, err := env.runCmd(ctx, probeNFTExecutable(env), "list", "table", "inet", env.nftTable)
 	if err != nil {
 		return statusSkip, fmt.Sprintf("nft unavailable: %v", err)
 	}
@@ -747,25 +754,32 @@ func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 	if chainHasBroadLoopbackAccept(out, env.nftChain) {
 		return statusFail, "chain contains broad loopback accept before agent drop"
 	}
-	if env.nftMainPath != "" && env.nftRulesPath != "" {
+	if env.nftPersistUnitPath != "" && env.nftRulesPath != "" {
 		if err := verifyNFTPersistence(env); err != nil {
 			return statusFail, err.Error()
 		}
 	}
-	return statusPass, fmt.Sprintf("table inet %s has chain %s with skuid drop rule, proxy-only loopback allow, and persistence include",
+	return statusPass, fmt.Sprintf("table inet %s has chain %s with skuid drop rule, proxy-only loopback allow, and persistence unit",
 		env.nftTable, env.nftChain)
 }
 
 func verifyNFTPersistence(env *probeEnv) error {
-	data, err := env.readFile(env.nftMainPath)
+	data, err := env.readFile(env.nftPersistUnitPath)
 	if err != nil {
-		return fmt.Errorf("read nftables persistence config %s: %w", env.nftMainPath, err)
+		return fmt.Errorf("read nftables persistence unit %s: %w", env.nftPersistUnitPath, err)
 	}
-	includeLine := nftRulesIncludeLine(env.nftRulesPath)
-	if !nftMainHasInclude(string(data), includeLine) {
-		return fmt.Errorf("%s missing persistence include %q", env.nftMainPath, includeLine)
+	body := string(data)
+	if !strings.Contains(body, "ExecStart=") || !strings.Contains(body, env.nftRulesPath) {
+		return fmt.Errorf("%s missing ExecStart for %s", env.nftPersistUnitPath, env.nftRulesPath)
 	}
 	return nil
+}
+
+func probeNFTExecutable(env *probeEnv) string {
+	if env != nil && env.nftPath != "" {
+		return env.nftPath
+	}
+	return "nft"
 }
 
 func chainHasSkuidDrop(out, chainName string) bool {
@@ -1058,12 +1072,12 @@ func extractNoProxy(data []byte) string {
 // Probe 8: cc_agent_egress_denied
 // ---------------------------------------------------------------------------
 
-// curlNoProxyArgs is the argv tail shared by probes 8 and 9: try to
-// reach the canary URL, never proxy, return only the HTTP status code
-// or zero on failure.
-func curlNoProxyArgs() []string {
+func curlNoProxyArgsFor(curl string) []string {
+	if curl == "" {
+		curl = defaultCurlPath
+	}
 	return []string{
-		curlPath,
+		curl,
 		"--connect-timeout", curlConnectTimeout,
 		"--max-time", curlMaxTime,
 		"--noproxy", "*",
@@ -1075,7 +1089,7 @@ func curlNoProxyArgs() []string {
 }
 
 func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, string) {
-	args := append([]string{"-n", "-u", env.agentUserName, "--"}, curlNoProxyArgs()...)
+	args := append([]string{"-n", "-u", env.agentUserName, "--"}, curlNoProxyArgsFor(env.curlPath)...)
 	out, code, err := env.runCmd(ctx, "sudo", args...)
 	if err != nil {
 		return statusSkip, fmt.Sprintf("sudo/curl unavailable: %v", err)
@@ -1087,7 +1101,7 @@ func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, strin
 		return statusSkip, fmt.Sprintf("%s user not present; install containment model first", env.agentUserName)
 	}
 	if isSudoTargetCommandMissing(out) {
-		return statusSkip, "sudo could not execute /usr/bin/curl; install curl to enable canary"
+		return statusSkip, fmt.Sprintf("sudo could not execute %s; install curl to enable canary", env.curlPath)
 	}
 	if code == 0 {
 		return statusFail, fmt.Sprintf("unexpected curl success: HTTP %s from example.com", oneLine(out))
@@ -1105,9 +1119,10 @@ func probeOperatorEgress(ctx context.Context, env *probeEnv) (string, string) {
 	var err error
 
 	if env.operatorUser == "" {
-		out, code, err = env.runCmd(ctx, curlPath, curlNoProxyArgs()[1:]...)
+		curlArgs := curlNoProxyArgsFor(env.curlPath)
+		out, code, err = env.runCmd(ctx, curlArgs[0], curlArgs[1:]...)
 	} else {
-		args := append([]string{"-n", "-u", env.operatorUser, "--"}, curlNoProxyArgs()...)
+		args := append([]string{"-n", "-u", env.operatorUser, "--"}, curlNoProxyArgsFor(env.curlPath)...)
 		out, code, err = env.runCmd(ctx, "sudo", args...)
 	}
 

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -769,10 +769,20 @@ func verifyNFTPersistence(env *probeEnv) error {
 		return fmt.Errorf("read nftables persistence unit %s: %w", env.nftPersistUnitPath, err)
 	}
 	body := string(data)
-	if !strings.Contains(body, "ExecStart=") || !strings.Contains(body, env.nftRulesPath) {
+	if !execStartLineContains(body, env.nftRulesPath) {
 		return fmt.Errorf("%s missing ExecStart for %s", env.nftPersistUnitPath, env.nftRulesPath)
 	}
 	return nil
+}
+
+func execStartLineContains(body, needle string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "ExecStart=") && strings.Contains(line, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 func probeNFTExecutable(env *probeEnv) string {
@@ -1089,7 +1099,9 @@ func curlNoProxyArgsFor(curl string) []string {
 }
 
 func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, string) {
-	args := append([]string{"-n", "-u", env.agentUserName, "--"}, curlNoProxyArgsFor(env.curlPath)...)
+	curlArgs := curlNoProxyArgsFor(env.curlPath)
+	curlPath := curlArgs[0]
+	args := append([]string{"-n", "-u", env.agentUserName, "--"}, curlArgs...)
 	out, code, err := env.runCmd(ctx, "sudo", args...)
 	if err != nil {
 		return statusSkip, fmt.Sprintf("sudo/curl unavailable: %v", err)
@@ -1101,7 +1113,7 @@ func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, strin
 		return statusSkip, fmt.Sprintf("%s user not present; install containment model first", env.agentUserName)
 	}
 	if isSudoTargetCommandMissing(out) {
-		return statusSkip, fmt.Sprintf("sudo could not execute %s; install curl to enable canary", env.curlPath)
+		return statusSkip, fmt.Sprintf("sudo could not execute %s; install curl to enable canary", curlPath)
 	}
 	if code == 0 {
 		return statusFail, fmt.Sprintf("unexpected curl success: HTTP %s from example.com", oneLine(out))

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -124,6 +124,7 @@ func makeProbeEnv(t *testing.T, opts ...func(*probeEnv)) *probeEnv {
 		launchPath:    "", // populated below
 		nftTable:      testTable,
 		nftChain:      testChain,
+		nftPath:       testNFT,
 		serviceName:   testService,
 		pinPath:       filepath.Join(t.TempDir(), "binary-pin.sha256"),
 		toolsListPath: filepath.Join(t.TempDir(), "tools.list"),
@@ -436,16 +437,17 @@ func TestProbeNFTContainment(t *testing.T) {
 	}
 }
 
-func TestProbeNFTContainment_ChecksPersistenceInclude(t *testing.T) {
+func TestProbeNFTContainment_ChecksPersistenceUnit(t *testing.T) {
 	tmp := t.TempDir()
-	mainPath := filepath.Join(tmp, "nftables.conf")
+	unitPath := filepath.Join(tmp, "pipelock-containment-nft.service")
 	rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
-	if err := os.WriteFile(mainPath, []byte(nftRulesIncludeLine(rulesPath)+"\n"), 0o600); err != nil {
-		t.Fatalf("write main config: %v", err)
+	unitBody := "[Service]\nExecStart=/usr/sbin/nft -f " + rulesPath + "\n"
+	if err := os.WriteFile(unitPath, []byte(unitBody), 0o600); err != nil {
+		t.Fatalf("write persistence unit: %v", err)
 	}
 	env := makeProbeEnv(t, func(e *probeEnv) {
 		e.nftRulesPath = rulesPath
-		e.nftMainPath = mainPath
+		e.nftPersistUnitPath = unitPath
 		e.readFile = os.ReadFile
 		e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
 			return goodNFTContainmentOutput, 0, nil
@@ -455,21 +457,21 @@ func TestProbeNFTContainment_ChecksPersistenceInclude(t *testing.T) {
 	if gotStatus != statusPass {
 		t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
 	}
-	if !strings.Contains(gotDetail, "persistence include") {
-		t.Fatalf("detail: got %q, want persistence include", gotDetail)
+	if !strings.Contains(gotDetail, "persistence unit") {
+		t.Fatalf("detail: got %q, want persistence unit", gotDetail)
 	}
 }
 
-func TestProbeNFTContainment_FailsWhenPersistenceIncludeMissing(t *testing.T) {
+func TestProbeNFTContainment_FailsWhenPersistenceUnitMissingExecStart(t *testing.T) {
 	tmp := t.TempDir()
-	mainPath := filepath.Join(tmp, "nftables.conf")
+	unitPath := filepath.Join(tmp, "pipelock-containment-nft.service")
 	rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
-	if err := os.WriteFile(mainPath, []byte("flush ruleset\n"), 0o600); err != nil {
-		t.Fatalf("write main config: %v", err)
+	if err := os.WriteFile(unitPath, []byte("[Service]\nExecStart=/usr/sbin/nft -f /other/rules.nft\n"), 0o600); err != nil {
+		t.Fatalf("write persistence unit: %v", err)
 	}
 	env := makeProbeEnv(t, func(e *probeEnv) {
 		e.nftRulesPath = rulesPath
-		e.nftMainPath = mainPath
+		e.nftPersistUnitPath = unitPath
 		e.readFile = os.ReadFile
 		e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
 			return goodNFTContainmentOutput, 0, nil
@@ -479,8 +481,8 @@ func TestProbeNFTContainment_FailsWhenPersistenceIncludeMissing(t *testing.T) {
 	if gotStatus != statusFail {
 		t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
 	}
-	if !strings.Contains(gotDetail, "missing persistence include") {
-		t.Fatalf("detail: got %q, want missing persistence include", gotDetail)
+	if !strings.Contains(gotDetail, "missing ExecStart") {
+		t.Fatalf("detail: got %q, want missing ExecStart", gotDetail)
 	}
 }
 
@@ -1682,8 +1684,11 @@ func TestDefaultProbeEnv(t *testing.T) {
 	if env.nftRulesPath != defaultNFTRulesPath {
 		t.Errorf("nftRulesPath: got %q, want %q", env.nftRulesPath, defaultNFTRulesPath)
 	}
-	if env.nftMainPath != defaultNFTMainConfigPath {
-		t.Errorf("nftMainPath: got %q, want %q", env.nftMainPath, defaultNFTMainConfigPath)
+	if env.nftMainPath != "" {
+		t.Errorf("nftMainPath: got %q, want empty legacy path", env.nftMainPath)
+	}
+	if env.nftPersistUnitPath != defaultNFTPersistUnitPath {
+		t.Errorf("nftPersistUnitPath: got %q, want %q", env.nftPersistUnitPath, defaultNFTPersistUnitPath)
 	}
 	if env.runCmd == nil || env.dialCtx == nil || env.lookupUser == nil || env.readFile == nil {
 		t.Errorf("hooks: runCmd=%v dialCtx=%v lookupUser=%v readFile=%v",

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -438,51 +438,62 @@ func TestProbeNFTContainment(t *testing.T) {
 }
 
 func TestProbeNFTContainment_ChecksPersistenceUnit(t *testing.T) {
-	tmp := t.TempDir()
-	unitPath := filepath.Join(tmp, "pipelock-containment-nft.service")
-	rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
-	unitBody := "[Service]\nExecStart=/usr/sbin/nft -f " + rulesPath + "\n"
-	if err := os.WriteFile(unitPath, []byte(unitBody), 0o600); err != nil {
-		t.Fatalf("write persistence unit: %v", err)
+	tests := []struct {
+		name       string
+		unitBody   func(string) string
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name: "exec start points at managed rules",
+			unitBody: func(rulesPath string) string {
+				return "[Service]\nExecStart=/usr/sbin/nft -f " + rulesPath + "\n"
+			},
+			wantStatus: statusPass,
+			wantDetail: "persistence unit",
+		},
+		{
+			name: "exec start points elsewhere",
+			unitBody: func(_ string) string {
+				return "[Service]\nExecStart=/usr/sbin/nft -f /other/rules.nft\n"
+			},
+			wantStatus: statusFail,
+			wantDetail: "missing ExecStart",
+		},
+		{
+			name: "rules path outside exec start does not satisfy check",
+			unitBody: func(rulesPath string) string {
+				return "[Unit]\nConditionPathExists=" + rulesPath + "\n[Service]\nExecStart=/usr/sbin/nft -f /other/rules.nft\n"
+			},
+			wantStatus: statusFail,
+			wantDetail: "missing ExecStart",
+		},
 	}
-	env := makeProbeEnv(t, func(e *probeEnv) {
-		e.nftRulesPath = rulesPath
-		e.nftPersistUnitPath = unitPath
-		e.readFile = os.ReadFile
-		e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
-			return goodNFTContainmentOutput, 0, nil
-		}
-	})
-	gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
-	if gotStatus != statusPass {
-		t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
-	}
-	if !strings.Contains(gotDetail, "persistence unit") {
-		t.Fatalf("detail: got %q, want persistence unit", gotDetail)
-	}
-}
 
-func TestProbeNFTContainment_FailsWhenPersistenceUnitMissingExecStart(t *testing.T) {
-	tmp := t.TempDir()
-	unitPath := filepath.Join(tmp, "pipelock-containment-nft.service")
-	rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
-	if err := os.WriteFile(unitPath, []byte("[Service]\nExecStart=/usr/sbin/nft -f /other/rules.nft\n"), 0o600); err != nil {
-		t.Fatalf("write persistence unit: %v", err)
-	}
-	env := makeProbeEnv(t, func(e *probeEnv) {
-		e.nftRulesPath = rulesPath
-		e.nftPersistUnitPath = unitPath
-		e.readFile = os.ReadFile
-		e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
-			return goodNFTContainmentOutput, 0, nil
-		}
-	})
-	gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
-	if gotStatus != statusFail {
-		t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
-	}
-	if !strings.Contains(gotDetail, "missing ExecStart") {
-		t.Fatalf("detail: got %q, want missing ExecStart", gotDetail)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			unitPath := filepath.Join(tmp, "pipelock-containment-nft.service")
+			rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
+			if err := os.WriteFile(unitPath, []byte(tc.unitBody(rulesPath)), 0o600); err != nil {
+				t.Fatalf("write persistence unit: %v", err)
+			}
+			env := makeProbeEnv(t, func(e *probeEnv) {
+				e.nftRulesPath = rulesPath
+				e.nftPersistUnitPath = unitPath
+				e.readFile = os.ReadFile
+				e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+					return goodNFTContainmentOutput, 0, nil
+				}
+			})
+			gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
+			if gotStatus != tc.wantStatus {
+				t.Fatalf("status: got %q, want %q (detail=%q)", gotStatus, tc.wantStatus, gotDetail)
+			}
+			if !strings.Contains(gotDetail, tc.wantDetail) {
+				t.Fatalf("detail: got %q, want substring %q", gotDetail, tc.wantDetail)
+			}
+		})
 	}
 }
 
@@ -931,6 +942,7 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 		stdout     string
 		code       int
 		runErr     error
+		curlPath   string
 		wantStatus string
 		wantDetail string
 	}{
@@ -984,16 +996,26 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 		},
 		{
 			name:       "target curl missing",
+			stdout:     "sudo: /custom/bin/curl: command not found\n",
+			code:       1,
+			curlPath:   "/custom/bin/curl",
+			wantStatus: statusSkip,
+			wantDetail: "sudo could not execute /custom/bin/curl",
+		},
+		{
+			name:       "fallback curl missing",
 			stdout:     "sudo: /usr/bin/curl: command not found\n",
 			code:       1,
+			curlPath:   "",
 			wantStatus: statusSkip,
-			wantDetail: "install curl",
+			wantDetail: "sudo could not execute /usr/bin/curl",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			env := makeProbeEnv(t, func(e *probeEnv) {
+				e.curlPath = tc.curlPath
 				e.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
 					if name != testSudoCmd {
 						t.Fatalf("unexpected cmd %q", name)


### PR DESCRIPTION
## Summary

- add Linux distro/platform detection for containment install paths
- persist nft containment rules with a Pipelock-owned systemd unit instead of distro nft config includes
- resolve distro-specific CA bundle and tool paths for install, verify, doctor, and CA refresh
- harden the persisted nft executable path used by the root boot unit
- preserve rollback cleanup for legacy nft main-config includes
- fix failed-install rollback so newly created nft tables are not restored as prior state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added platform-aware Linux detection to resolve CA bundle and required executables automatically.
  * Switched containment rules persistence to a dedicated systemd unit.

* **Bug Fixes**
  * Improved auto-resolution of added tools by using `command -v` and failing fast when resolution can’t run.
  * Updated rollback/undo to fully clean up the persistence unit and related nft artifacts.

* **Improvements**
  * Refined curl/CA bundle handling and wrapper script shebangs based on detected system paths.
  * Expanded install preflight checks and tightened nft persistence verification to use the systemd unit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->