### PR TITLE
fix(selfupdate): require signed release manifest, never exec the download

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,7 @@ jobs:
         env:
           LICENSE_PUBLIC_KEY: ${{ secrets.LICENSE_PUBLIC_KEY }}
           RULES_KEYRING_HEX: ${{ secrets.RULES_KEYRING_HEX }}
+          RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
         run: |
           test -n "$LICENSE_PUBLIC_KEY" || {
             echo "::error::LICENSE_PUBLIC_KEY secret is required for release builds"
@@ -84,6 +85,10 @@ jobs:
           }
           test -n "$RULES_KEYRING_HEX" || {
             echo "::error::RULES_KEYRING_HEX secret is required for release builds"
+            exit 1
+          }
+          test -n "$RELEASE_KEYRING_HEX" || {
+            echo "::error::RELEASE_KEYRING_HEX secret is required for self-update release verification"
             exit 1
           }
           case "$LICENSE_PUBLIC_KEY" in
@@ -98,6 +103,10 @@ jobs:
           }
           if [[ ! "$RULES_KEYRING_HEX" =~ ^[0-9A-Fa-f]{64}(,[0-9A-Fa-f]{64})*$ ]]; then
             echo "::error::RULES_KEYRING_HEX must be one or more 64-hex Ed25519 public keys separated by commas"
+            exit 1
+          fi
+          if [[ ! "$RELEASE_KEYRING_HEX" =~ ^[0-9A-Fa-f]{64}(,[0-9A-Fa-f]{64})*$ ]]; then
+            echo "::error::RELEASE_KEYRING_HEX must be one or more 64-hex Ed25519 public keys separated by commas"
             exit 1
           fi
           license_public_key_normalized="${LICENSE_PUBLIC_KEY,,}"
@@ -116,6 +125,27 @@ jobs:
               exit 1
             }
           done
+          IFS=',' read -r -a release_keys <<< "$RELEASE_KEYRING_HEX"
+          for key in "${release_keys[@]}"; do
+            test -n "$key" || {
+              echo "::error::RELEASE_KEYRING_HEX contains an empty key entry"
+              exit 1
+            }
+            test "${#key}" -eq 64 || {
+              echo "::error::RELEASE_KEYRING_HEX entries must be 64 hex characters"
+              exit 1
+            }
+            test "${key,,}" != "$license_public_key_normalized" || {
+              echo "::error::LICENSE_PUBLIC_KEY must not appear in RELEASE_KEYRING_HEX"
+              exit 1
+            }
+            for rules_key in "${rules_keys[@]}"; do
+              test "${key,,}" != "${rules_key,,}" || {
+                echo "::error::RELEASE_KEYRING_HEX must not reuse a rules signing key"
+                exit 1
+              }
+            done
+          done
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
@@ -129,6 +159,18 @@ jobs:
           GOVERSION: ${{ env.GOVERSION }}
           LICENSE_PUBLIC_KEY: ${{ secrets.LICENSE_PUBLIC_KEY }}
           RULES_KEYRING_HEX: ${{ secrets.RULES_KEYRING_HEX }}
+          RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
+
+      - name: Generate and upload self-update release manifest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
+        run: |
+          go run ./cmd/pipelock-release-manifest \
+            -dist dist \
+            -tag "$GITHUB_REF_NAME" \
+            -commit "$GITHUB_SHA"
+          gh release upload "$GITHUB_REF_NAME" dist/release.json --clobber
 
       - name: Generate SBOM
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,7 @@ builds:
       - -X github.com/luckyPipewrench/pipelock/internal/proxy.Version={{.Version}}
       - -X github.com/luckyPipewrench/pipelock/internal/license.PublicKeyHex={{.Env.LICENSE_PUBLIC_KEY}}
       - -X github.com/luckyPipewrench/pipelock/internal/rules.KeyringHex={{.Env.RULES_KEYRING_HEX}}
+      - -X github.com/luckyPipewrench/pipelock/internal/release.PublicKeyringHex={{.Env.RELEASE_KEYRING_HEX}}
 
   # License service: cluster-only webhook handler for Polar subscription events.
   # Linux-only (runs in k8s), not distributed via Homebrew or public archives.

--- a/cmd/pipelock-release-manifest/main.go
+++ b/cmd/pipelock-release-manifest/main.go
@@ -1,0 +1,257 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// pipelock-release-manifest generates release.json for "pipelock update" and
+// signs an existing manifest in offline mode. It is intentionally a small
+// stdlib-only release-engineering tool so self-update does not depend on cosign
+// or sigstore libraries at runtime.
+package main
+
+import (
+	"bufio"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	releasetrust "github.com/luckyPipewrench/pipelock/internal/release"
+)
+
+var pipelockArchiveRE = regexp.MustCompile(`^pipelock_([^_]+)_([^_]+)_([^_]+)\.(tar\.gz|zip)$`)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "pipelock-release-manifest: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("pipelock-release-manifest", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	dist := fs.String("dist", "dist", "GoReleaser dist directory")
+	tag := fs.String("tag", "", "release tag, e.g. v2.8.0")
+	commit := fs.String("commit", "", "release commit SHA")
+	keyHex := fs.String("private-key-hex", "", "hex Ed25519 private key or 32-byte seed; required only with --sign-only")
+	signerKeyID := fs.String("signer-key-id", firstReleaseKey(os.Getenv("RELEASE_KEYRING_HEX")), "hex Ed25519 public key expected to sign release.json")
+	signOnly := fs.Bool("sign-only", false, "sign an existing release.json without regenerating it")
+	manifestPath := fs.String("manifest", "", "release.json path for --sign-only; defaults to <dist>/release.json")
+	genKey := fs.Bool("gen-key", false, "generate a fresh Ed25519 release-signing keypair and print private_hex + public_hex (private -> offline key safe; public -> RELEASE_KEYRING_HEX)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *genKey {
+		privHex, pubHex, err := generateReleaseKeypair()
+		if err != nil {
+			return err
+		}
+		// Public half is safe to display; private half is the offline signer and
+		// must go ONLY to the operator's key safe, never into CI.
+		_, _ = fmt.Fprintf(stderr, "WARNING: private_hex is the offline release signer. Store it ONLY in the offline key safe; put public_hex into the RELEASE_KEYRING_HEX secret.\n")
+		if _, err := fmt.Fprintf(stdout, "private_hex=%s\npublic_hex=%s\n", privHex, pubHex); err != nil {
+			return fmt.Errorf("write generated release keypair: %w", err)
+		}
+		return nil
+	}
+	if *signOnly {
+		return runSignOnly(*dist, *manifestPath, *keyHex)
+	}
+	if strings.TrimSpace(*tag) == "" {
+		return errors.New("--tag is required")
+	}
+	if strings.TrimSpace(*commit) == "" {
+		return errors.New("--commit is required")
+	}
+	if strings.TrimSpace(*signerKeyID) == "" {
+		return errors.New("--signer-key-id or RELEASE_KEYRING_HEX is required")
+	}
+	if !isPublicKeyHex(*signerKeyID) {
+		return errors.New("--signer-key-id must be a 32-byte Ed25519 public key encoded as 64 hex characters")
+	}
+	checksumsPath := filepath.Join(*dist, "checksums.txt")
+	checksums, err := os.ReadFile(checksumsPath) // #nosec G304 -- release tool reads caller-supplied dist dir
+	if err != nil {
+		return fmt.Errorf("read checksums.txt: %w", err)
+	}
+	entries, err := parseChecksumFile(checksums)
+	if err != nil {
+		return err
+	}
+	assets, err := manifestAssets(*dist, entries)
+	if err != nil {
+		return err
+	}
+	manifest := releasetrust.Manifest{
+		Schema:             "pipelock-release-v1",
+		Repo:               "github.com/luckyPipewrench/pipelock",
+		Tag:                *tag,
+		Commit:             *commit,
+		CreatedUTC:         time.Now().UTC().Format(time.RFC3339),
+		ChecksumFileSHA256: sha256Hex(checksums),
+		Assets:             assets,
+		SignerKeyID:        strings.ToLower(strings.TrimSpace(*signerKeyID)),
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal release manifest: %w", err)
+	}
+	data = append(data, '\n')
+	if err := releasetrust.ValidateManifest(manifest); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(*dist, releasetrust.ManifestFile), data, 0o600); err != nil {
+		return fmt.Errorf("write release.json: %w", err)
+	}
+	return nil
+}
+
+func runSignOnly(dist, manifestPath, keyHex string) error {
+	priv, err := parsePrivateKey(keyHex)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(manifestPath) == "" {
+		manifestPath = filepath.Join(dist, releasetrust.ManifestFile)
+	}
+	data, err := os.ReadFile(filepath.Clean(manifestPath)) // #nosec G304 -- release owner supplies manifest path
+	if err != nil {
+		return fmt.Errorf("read release.json: %w", err)
+	}
+	var manifest releasetrust.Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("parse release.json: %w", err)
+	}
+	if err := releasetrust.ValidateManifest(manifest); err != nil {
+		return err
+	}
+	pub := publicKeyHex(priv.Public().(ed25519.PublicKey))
+	if !strings.EqualFold(manifest.SignerKeyID, pub) {
+		return fmt.Errorf("offline signing key %s does not match release.json signer_key_id %s", pub, manifest.SignerKeyID)
+	}
+	sig := releasetrust.SignManifest(data, priv)
+	if err := os.WriteFile(filepath.Join(filepath.Dir(manifestPath), releasetrust.ManifestSigFile), []byte(sig+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write release.json.sig: %w", err)
+	}
+	return nil
+}
+
+func parsePrivateKey(value string) (ed25519.PrivateKey, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, errors.New("--private-key-hex is required for --sign-only")
+	}
+	raw, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("release private key must be hex: %w", err)
+	}
+	switch len(raw) {
+	case ed25519.SeedSize:
+		return ed25519.NewKeyFromSeed(raw), nil
+	case ed25519.PrivateKeySize:
+		return ed25519.PrivateKey(raw), nil
+	default:
+		return nil, fmt.Errorf("release private key must be %d-byte seed or %d-byte private key", ed25519.SeedSize, ed25519.PrivateKeySize)
+	}
+}
+
+// generateReleaseKeypair creates a fresh Ed25519 release-signing keypair and
+// returns the private seed and public key as hex. The private seed feeds
+// --private-key-hex for offline -sign-only; the public hex is what goes into
+// the RELEASE_KEYRING_HEX build secret and becomes the manifest signer_key_id.
+func generateReleaseKeypair() (privHex, pubHex string, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", "", fmt.Errorf("generate release keypair: %w", err)
+	}
+	return hex.EncodeToString(priv.Seed()), publicKeyHex(pub), nil
+}
+
+func firstReleaseKey(keyring string) string {
+	keyring = strings.TrimSpace(keyring)
+	if keyring == "" {
+		return ""
+	}
+	parts := strings.Split(keyring, ",")
+	return strings.TrimSpace(parts[0])
+}
+
+func isPublicKeyHex(value string) bool {
+	raw, err := hex.DecodeString(strings.TrimSpace(value))
+	return err == nil && len(raw) == ed25519.PublicKeySize
+}
+
+func parseChecksumFile(data []byte) (map[string]string, error) {
+	entries := make(map[string]string)
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 {
+			continue
+		}
+		if _, err := hex.DecodeString(fields[0]); err != nil || len(fields[0]) != 64 {
+			return nil, fmt.Errorf("invalid checksum for %s", fields[1])
+		}
+		entries[fields[1]] = strings.ToLower(fields[0])
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan checksums.txt: %w", err)
+	}
+	return entries, nil
+}
+
+func manifestAssets(dist string, entries map[string]string) ([]releasetrust.Asset, error) {
+	assets := make([]releasetrust.Asset, 0, 6)
+	for name, checksum := range entries {
+		match := pipelockArchiveRE.FindStringSubmatch(name)
+		if match == nil {
+			continue
+		}
+		archivePath := filepath.Join(dist, name)
+		archive, err := os.ReadFile(archivePath) // #nosec G304 -- release tool reads caller-supplied dist dir
+		if err != nil {
+			return nil, fmt.Errorf("read archive %s: %w", name, err)
+		}
+		if got := sha256Hex(archive); got != checksum {
+			return nil, fmt.Errorf("archive %s checksum mismatch: got %s want %s", name, got, checksum)
+		}
+		goos := match[2]
+		asset := releasetrust.Asset{
+			Name:   name,
+			SHA256: checksum,
+			GOOS:   goos,
+			GOARCH: match[3],
+			Binary: archiveBinaryName(goos),
+		}
+		assets = append(assets, asset)
+	}
+	if len(assets) == 0 {
+		return nil, errors.New("no pipelock archives found in checksums.txt")
+	}
+	return assets, nil
+}
+
+func archiveBinaryName(goos string) string {
+	if goos == "windows" {
+		return "pipelock.exe"
+	}
+	return "pipelock"
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func publicKeyHex(pub ed25519.PublicKey) string {
+	return hex.EncodeToString(pub)
+}

--- a/cmd/pipelock-release-manifest/main_test.go
+++ b/cmd/pipelock-release-manifest/main_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -109,6 +110,141 @@ func TestRunGenKeyFailsWhenStdoutWriteFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "write generated release keypair") {
 		t.Fatalf("error = %v, want write generated release keypair", err)
+	}
+}
+
+func TestRunRejectsMissingInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing tag", args: nil, want: "--tag is required"},
+		{name: "missing commit", args: []string{"-tag", "v2.8.0"}, want: "--commit is required"},
+		{name: "missing signer", args: []string{"-tag", "v2.8.0", "-commit", strings.Repeat("a", 40)}, want: "--signer-key-id"},
+		{name: "bad signer", args: []string{"-tag", "v2.8.0", "-commit", strings.Repeat("a", 40), "-signer-key-id", "bad"}, want: "32-byte Ed25519 public key"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run(tc.args, ioDiscard{}, ioDiscard{})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("run error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunUsesReleaseKeyringEnvForSignerDefault(t *testing.T) {
+	dist := t.TempDir()
+	archiveName := "pipelock_2.8.0_windows_amd64.zip"
+	archive := []byte("fake windows archive")
+	if err := os.WriteFile(filepath.Join(dist, archiveName), archive, 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dist, "checksums.txt"), []byte(sha256Hex(archive)+"  "+archiveName+"\n"), 0o600); err != nil {
+		t.Fatalf("write checksums: %v", err)
+	}
+	pubHex := strings.Repeat("a", 64)
+	t.Setenv("RELEASE_KEYRING_HEX", " "+pubHex+" ,"+strings.Repeat("b", 64))
+
+	if err := run([]string{
+		"-dist", dist,
+		"-tag", "v2.8.0",
+		"-commit", strings.Repeat("c", 40),
+	}, ioDiscard{}, ioDiscard{}); err != nil {
+		t.Fatalf("run with RELEASE_KEYRING_HEX signer default: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dist, releasetrust.ManifestFile)) // #nosec G304 -- test reads its own temp dist dir
+	if err != nil {
+		t.Fatalf("read release.json: %v", err)
+	}
+	if !strings.Contains(string(data), `"signer_key_id": "`+pubHex+`"`) {
+		t.Fatalf("release.json did not use first keyring key: %s", data)
+	}
+}
+
+func TestRunSignOnlyRejectsKeyMismatch(t *testing.T) {
+	dist := t.TempDir()
+	priv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x44}, ed25519.SeedSize))
+	other := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x45}, ed25519.SeedSize))
+	manifest := releasetrust.Manifest{
+		Schema:             "pipelock-release-v1",
+		Repo:               "github.com/luckyPipewrench/pipelock",
+		Tag:                "v2.8.0",
+		Commit:             strings.Repeat("d", 40),
+		CreatedUTC:         "2026-06-19T12:00:00Z",
+		ChecksumFileSHA256: strings.Repeat("0", 64),
+		Assets: []releasetrust.Asset{{
+			Name:   "pipelock_2.8.0_linux_amd64.tar.gz",
+			SHA256: strings.Repeat("1", 64),
+			GOOS:   "linux",
+			GOARCH: "amd64",
+			Binary: "pipelock",
+		}},
+		SignerKeyID: publicKeyHex(other.Public().(ed25519.PublicKey)),
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	manifestPath := filepath.Join(dist, releasetrust.ManifestFile)
+	if err := os.WriteFile(manifestPath, data, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	err = run([]string{"-sign-only", "-manifest", manifestPath, "-private-key-hex", hex.EncodeToString(priv)}, ioDiscard{}, ioDiscard{})
+	if err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("run -sign-only mismatch error = %v, want mismatch", err)
+	}
+}
+
+func TestParsePrivateKeyForms(t *testing.T) {
+	seed := bytes.Repeat([]byte{0x55}, ed25519.SeedSize)
+	privFromSeed := ed25519.NewKeyFromSeed(seed)
+	got, err := parsePrivateKey(hex.EncodeToString(seed))
+	if err != nil {
+		t.Fatalf("parse seed: %v", err)
+	}
+	if !bytes.Equal(got, privFromSeed) {
+		t.Fatal("seed form did not derive expected private key")
+	}
+	got, err = parsePrivateKey(hex.EncodeToString(privFromSeed))
+	if err != nil {
+		t.Fatalf("parse private key: %v", err)
+	}
+	if !bytes.Equal(got, privFromSeed) {
+		t.Fatal("private-key form did not round-trip")
+	}
+	for _, value := range []string{"", "not-hex", "abcd"} {
+		if _, err := parsePrivateKey(value); err == nil {
+			t.Fatalf("parsePrivateKey(%q) succeeded, want error", value)
+		}
+	}
+}
+
+func TestParseChecksumFileAndManifestAssetsErrors(t *testing.T) {
+	if _, err := parseChecksumFile([]byte("nothex  file\n")); err == nil {
+		t.Fatal("parseChecksumFile accepted malformed checksum")
+	}
+	dist := t.TempDir()
+	if _, err := manifestAssets(dist, map[string]string{"README.txt": strings.Repeat("0", 64)}); err == nil {
+		t.Fatal("manifestAssets accepted no pipelock archives")
+	}
+	archiveName := "pipelock_2.8.0_linux_amd64.tar.gz"
+	if err := os.WriteFile(filepath.Join(dist, archiveName), []byte("archive"), 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	if _, err := manifestAssets(dist, map[string]string{archiveName: strings.Repeat("0", 64)}); err == nil {
+		t.Fatal("manifestAssets accepted checksum mismatch")
+	}
+}
+
+func TestArchiveBinaryName(t *testing.T) {
+	if got := archiveBinaryName("windows"); got != "pipelock.exe" {
+		t.Fatalf("windows binary = %q", got)
+	}
+	if got := archiveBinaryName("linux"); got != "pipelock" {
+		t.Fatalf("linux binary = %q", got)
 	}
 }
 

--- a/cmd/pipelock-release-manifest/main_test.go
+++ b/cmd/pipelock-release-manifest/main_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	releasetrust "github.com/luckyPipewrench/pipelock/internal/release"
+)
+
+func TestRunGenerateUnsignedThenOfflineSign(t *testing.T) {
+	dist := t.TempDir()
+	archiveName := "pipelock_2.8.0_linux_amd64.tar.gz"
+	archive := []byte("fake archive bytes")
+	if err := os.WriteFile(filepath.Join(dist, archiveName), archive, 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	checksums := []byte(sha256Hex(archive) + "  " + archiveName + "\n")
+	if err := os.WriteFile(filepath.Join(dist, "checksums.txt"), checksums, 0o600); err != nil {
+		t.Fatalf("write checksums: %v", err)
+	}
+
+	priv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x7a}, ed25519.SeedSize))
+	pubHex := hex.EncodeToString(priv.Public().(ed25519.PublicKey))
+
+	if err := run([]string{
+		"-dist", dist,
+		"-tag", "v2.8.0",
+		"-commit", "0123456789abcdef0123456789abcdef01234567",
+		"-signer-key-id", pubHex,
+	}, ioDiscard{}, ioDiscard{}); err != nil {
+		t.Fatalf("generate unsigned manifest: %v", err)
+	}
+	manifestPath := filepath.Join(dist, releasetrust.ManifestFile)
+	manifestData, err := os.ReadFile(manifestPath) // #nosec G304 -- test reads release.json from its own temp dist dir
+	if err != nil {
+		t.Fatalf("read release.json: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dist, releasetrust.ManifestSigFile)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("release.json.sig exists after CI generation, stat err=%v", err)
+	}
+	if _, err := releasetrust.VerifyManifest(manifestData, nil, pubHex); !errors.Is(err, releasetrust.ErrReleaseSignature) {
+		t.Fatalf("VerifyManifest without sig error = %v, want ErrReleaseSignature", err)
+	}
+
+	if err := run([]string{
+		"-sign-only",
+		"-manifest", manifestPath,
+		"-private-key-hex", hex.EncodeToString(priv.Seed()),
+	}, ioDiscard{}, ioDiscard{}); err != nil {
+		t.Fatalf("offline sign manifest: %v", err)
+	}
+	sigData, err := os.ReadFile(filepath.Join(dist, releasetrust.ManifestSigFile)) // #nosec G304 -- test reads release.json.sig from its own temp dist dir
+	if err != nil {
+		t.Fatalf("read release.json.sig: %v", err)
+	}
+	if _, err := releasetrust.VerifyManifest(manifestData, sigData, pubHex); err != nil {
+		t.Fatalf("VerifyManifest offline signature: %v", err)
+	}
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("write blocked")
+}
+
+func TestRunGenKeyWritesKeyMaterialOnlyToStdout(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := run([]string{"-gen-key"}, &stdout, &stderr); err != nil {
+		t.Fatalf("run -gen-key: %v", err)
+	}
+	if strings.Contains(stdout.String(), "WARNING") {
+		t.Fatalf("stdout contains warning text: %q", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "private_hex=") || strings.Contains(stderr.String(), "public_hex=") {
+		t.Fatalf("stderr contains generated key material: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "WARNING: private_hex is the offline release signer") {
+		t.Fatalf("stderr warning = %q", stderr.String())
+	}
+
+	seed, pubBytes := decodeGeneratedKeyOutput(t, stdout.String())
+	priv := ed25519.NewKeyFromSeed(seed)
+	if got := priv.Public().(ed25519.PublicKey); !bytes.Equal(got, pubBytes) {
+		t.Fatalf("public_hex not derived from private seed")
+	}
+}
+
+func TestRunGenKeyFailsWhenStdoutWriteFails(t *testing.T) {
+	err := run([]string{"-gen-key"}, failingWriter{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("run -gen-key with failing stdout succeeded")
+	}
+	if !strings.Contains(err.Error(), "write generated release keypair") {
+		t.Fatalf("error = %v, want write generated release keypair", err)
+	}
+}
+
+func TestGenerateReleaseKeypair(t *testing.T) {
+	privHex, pubHex, err := generateReleaseKeypair()
+	if err != nil {
+		t.Fatalf("generateReleaseKeypair: %v", err)
+	}
+	seed, err := hex.DecodeString(privHex)
+	if err != nil || len(seed) != ed25519.SeedSize {
+		t.Fatalf("private_hex not a %d-byte seed: err=%v len=%d", ed25519.SeedSize, err, len(seed))
+	}
+	pubBytes, err := hex.DecodeString(pubHex)
+	if err != nil || len(pubBytes) != ed25519.PublicKeySize {
+		t.Fatalf("public_hex not a %d-byte key: err=%v len=%d", ed25519.PublicKeySize, err, len(pubBytes))
+	}
+	// public_hex MUST be the public half derived from the private seed, or the
+	// operator would put a mismatched key in RELEASE_KEYRING_HEX and -sign-only
+	// would reject every manifest (main.go signer_key_id match check).
+	priv := ed25519.NewKeyFromSeed(seed)
+	if got := hex.EncodeToString(priv.Public().(ed25519.PublicKey)); got != pubHex {
+		t.Fatalf("public_hex %s not derived from private seed (want %s)", pubHex, got)
+	}
+	// The pair signs+verifies, so the real -sign-only ceremony will work.
+	msg := []byte("release manifest")
+	if !ed25519.Verify(priv.Public().(ed25519.PublicKey), msg, ed25519.Sign(priv, msg)) {
+		t.Fatal("generated keypair failed sign/verify round-trip")
+	}
+	// Distinct keys per call (real randomness, not a fixed/zero key).
+	p2, _, err := generateReleaseKeypair()
+	if err != nil {
+		t.Fatalf("second generateReleaseKeypair: %v", err)
+	}
+	if p2 == privHex {
+		t.Fatal("generateReleaseKeypair returned identical keys on two calls")
+	}
+}
+
+func decodeGeneratedKeyOutput(t *testing.T, output string) ([]byte, []byte) {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("-gen-key output lines = %d, want 2: %q", len(lines), output)
+	}
+	privHex, ok := strings.CutPrefix(lines[0], "private_hex=")
+	if !ok {
+		t.Fatalf("first output line = %q, want private_hex=", lines[0])
+	}
+	pubHex, ok := strings.CutPrefix(lines[1], "public_hex=")
+	if !ok {
+		t.Fatalf("second output line = %q, want public_hex=", lines[1])
+	}
+	seed, err := hex.DecodeString(privHex)
+	if err != nil || len(seed) != ed25519.SeedSize {
+		t.Fatalf("private_hex not a %d-byte seed: err=%v len=%d", ed25519.SeedSize, err, len(seed))
+	}
+	pubBytes, err := hex.DecodeString(pubHex)
+	if err != nil || len(pubBytes) != ed25519.PublicKeySize {
+		t.Fatalf("public_hex not a %d-byte key: err=%v len=%d", ed25519.PublicKeySize, err, len(pubBytes))
+	}
+	return seed, pubBytes
+}

--- a/docs/security/self-update-signing-custody.md
+++ b/docs/security/self-update-signing-custody.md
@@ -1,0 +1,50 @@
+# Self-Update Signing Key Custody
+
+Pipelock self-update verification requires a native signed `release.json`
+manifest before any downloaded binary is installed. That preserves offline
+Ed25519 verification on the client. The remaining release-risk decision is
+where the `release.json` private signing key lives.
+
+## Decision
+
+Option A is chosen and implemented for v2.8: CI builds artifacts and publishes
+an unsigned `release.json`; the release owner signs that exact manifest offline
+and uploads `release.json.sig` as a release asset.
+
+`RELEASE_KEYRING_HEX` remains in CI because it is the public Ed25519 verification
+keyring embedded into release binaries. The private manifest signing key is not
+referenced by the release workflow.
+
+## Offline Signing Runbook
+
+1. Download `release.json` from the draft GitHub release onto the offline signing
+   machine.
+
+2. Unlock the offline release signing key from USB `PIPELOCK-KEYS2`, using the
+   same custody handling as the license signer.
+
+3. Sign the manifest:
+
+```bash
+read -rsp 'release Ed25519 seed/private key hex: ' PIPELOCK_RELEASE_PRIVATE_KEY_HEX
+echo
+go run ./cmd/pipelock-release-manifest \
+  -sign-only \
+  -manifest ./release.json \
+  -private-key-hex "$PIPELOCK_RELEASE_PRIVATE_KEY_HEX"
+unset PIPELOCK_RELEASE_PRIVATE_KEY_HEX
+```
+
+4. Upload the generated `release.json.sig` to the same release assets as
+   `release.json`.
+
+5. Confirm the release contains both files:
+
+```bash
+gh release view v2.8.0 --json assets --jq '.assets[].name' | sort
+```
+
+The client verification path is unchanged: `pipelock update` downloads
+`release.json` and `release.json.sig`, verifies the Ed25519 signature against
+the embedded public keyring, then checks the archive hash pinned inside the
+signed manifest. A release without `release.json.sig` fails closed.

--- a/docs/security/self-update-signing-custody.md
+++ b/docs/security/self-update-signing-custody.md
@@ -17,8 +17,9 @@ referenced by the release workflow.
 
 ## Offline Signing Runbook
 
-1. Download `release.json` from the draft GitHub release onto the offline signing
-   machine.
+1. On a networked machine, download `release.json` from the draft GitHub release,
+   then transfer it to the offline signing machine on removable media. The signing
+   machine stays air-gapped and never connects to the network.
 
 2. Unlock the offline release signing key from USB `PIPELOCK-KEYS2`, using the
    same custody handling as the license signer.
@@ -35,7 +36,8 @@ go run ./cmd/pipelock-release-manifest \
 unset PIPELOCK_RELEASE_PRIVATE_KEY_HEX
 ```
 
-4. Upload the generated `release.json.sig` to the same release assets as
+4. Transfer the generated `release.json.sig` off the signing machine on removable
+   media, then from a networked machine upload it to the same release assets as
    `release.json`.
 
 5. Confirm the release contains both files:

--- a/internal/cli/selfupdate/cmd.go
+++ b/internal/cli/selfupdate/cmd.go
@@ -36,10 +36,11 @@ replacing the running binary in place.
 
 The update is FAIL-CLOSED: it aborts and leaves the installed binary untouched
 on any verification failure. Every release archive is verified against the
-published SHA256 checksums; when a cosign binary is on PATH the checksums file
-is also verified against its keyless publisher signature (GitHub Actions OIDC).
-If cosign is absent, the updater fails closed by default. Use
---insecure-skip-signature only for an explicit checksum-only recovery flow.
+published SHA256 checksums and a native Ed25519-signed release manifest using
+Pipelock's embedded release key. When a cosign binary is on PATH the checksums
+file is also verified against its keyless publisher signature (GitHub Actions
+OIDC) for ecosystem auditors. Cosign absence is allowed after native Ed25519
+verification succeeds; checksum-only updates are never allowed.
 
 The previous binary is saved to <binary>.bak so "pipelock update --rollback"
 can restore it. When downgrading to a release that predates the update command
@@ -51,8 +52,7 @@ Examples:
   pipelock update                      # interactive update to the latest release
   pipelock update --yes                # update without the confirmation prompt
   pipelock update --version v2.7.0     # install a specific release tag
-  pipelock update --rollback           # restore the previous binary
-  pipelock update --insecure-skip-signature`,
+  pipelock update --rollback           # restore the previous binary`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if checkOnly && doRollOut {
 				return fmt.Errorf("use only one of --check / --rollback")
@@ -76,7 +76,7 @@ Examples:
 	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "skip the interactive confirmation prompt")
 	cmd.Flags().BoolVar(&doRollOut, "rollback", false, "restore the previous binary from the backup saved by a prior update")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "emit machine-readable JSON status")
-	cmd.Flags().BoolVar(&insecure, "insecure-skip-signature", false, "allow checksum-only update if cosign is unavailable (publisher identity is not verified)")
+	cmd.Flags().BoolVar(&insecure, "insecure-skip-signature", false, "deprecated compatibility no-op; native Ed25519 release verification is always required")
 
 	return cmd
 }

--- a/internal/cli/selfupdate/cmd_test.go
+++ b/internal/cli/selfupdate/cmd_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	releasetrust "github.com/luckyPipewrench/pipelock/internal/release"
 )
 
 func TestCmd_Construction(t *testing.T) {
@@ -151,7 +153,11 @@ func TestRunCommand_RollbackFlag(t *testing.T) {
 
 func TestRunCommand_ErrorJSONEmitsStatus(t *testing.T) {
 	assets, archiveName := standardAssets(t, testLatest, testGOOS)
-	assets[checksumsFile] = []byte("deadbeef  " + archiveName + "\n")
+	checks := []byte("deadbeef  " + archiveName + "\n")
+	assets[checksumsFile] = checks
+	manifest, sig := signedReleaseManifest(t, testLatest, testGOOS, archiveName, assets[archiveName], checks)
+	assets[releasetrust.ManifestFile] = manifest
+	assets[releasetrust.ManifestSigFile] = sig
 	rs := newReleaseServer(t, testLatest, assets)
 	target := writeTargetBinary(t, "ORIGINAL")
 	opts := baseOptions(rs, target)

--- a/internal/cli/selfupdate/errorpath_test.go
+++ b/internal/cli/selfupdate/errorpath_test.go
@@ -186,14 +186,6 @@ func TestInstallBinary_RestoreOnRenameFailure(t *testing.T) {
 	}
 }
 
-func TestVerifyBinaryVersion_RunError(t *testing.T) {
-	opts := &Options{RunCommand: stubVersionRunner("boom")}
-	err := opts.verifyBinaryVersion(context.Background(), "/x", "2.8.0")
-	if !errors.Is(err, ErrVersionMismatch) {
-		t.Fatalf("expected ErrVersionMismatch, got %v", err)
-	}
-}
-
 func TestRun_NoArchiveAssetOnPinned(t *testing.T) {
 	// Release exists with checksums but NO archive for our os/arch.
 	assets, _ := standardAssets(t, testLatest, testGOOS)

--- a/internal/cli/selfupdate/extra_test.go
+++ b/internal/cli/selfupdate/extra_test.go
@@ -257,9 +257,8 @@ func TestShellQuote(t *testing.T) {
 
 func TestStageAndVerifySignature_StageError(t *testing.T) {
 	// dir does not exist -> writeFileQuiet fails.
-	opts := &Options{CosignAvailable: func() bool { return false }, RunCommand: stubVersionRunner("")}
-	_, err := opts.stageAndVerifySignature(context.Background(), &release{}, filepath.Join(t.TempDir(), "nope"), []byte("x"))
-	if err == nil {
+	opts := &Options{CosignAvailable: func() bool { return true }, RunCommand: stubVersionRunner("")}
+	if err := opts.stageAndVerifySignature(context.Background(), &release{}, filepath.Join(t.TempDir(), "nope"), []byte("x")); err == nil {
 		t.Fatal("expected staging error")
 	}
 }

--- a/internal/cli/selfupdate/run.go
+++ b/internal/cli/selfupdate/run.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	releasetrust "github.com/luckyPipewrench/pipelock/internal/release"
 )
 
 // firstVersionWithUpdate is the earliest release that ships the "update"
@@ -104,10 +106,11 @@ func (o *Options) Check(ctx context.Context) (*Status, error) {
 	return st, nil
 }
 
-// Run performs the full verified update: resolve release -> verify publisher
-// signature (best-effort) -> download archive -> checksum match -> extract ->
-// verify version -> back up -> atomic replace. FAIL-CLOSED at every step: any
-// error aborts and leaves the installed binary untouched.
+// Run performs the full verified update: resolve release -> verify the native
+// Ed25519 release manifest -> optionally verify legacy cosign material ->
+// download archive -> checksum match -> extract -> back up -> atomic replace.
+// FAIL-CLOSED at every step: any error aborts and leaves the installed binary
+// untouched.
 //
 // The cobra layer is responsible for any interactive confirmation before
 // calling Run; Run itself always proceeds (it is the "yes" path).
@@ -151,29 +154,57 @@ func (o *Options) Run(ctx context.Context) (*Status, error) {
 	if err != nil {
 		return st, fmt.Errorf("resolving checksums asset: %w", err)
 	}
+	manifestURL, err := assetURL(rel, releasetrust.ManifestFile)
+	if err != nil {
+		return st, fmt.Errorf("%w: resolving release manifest: %w", ErrSignatureVerify, err)
+	}
+	manifestSigURL, err := assetURL(rel, releasetrust.ManifestSigFile)
+	if err != nil {
+		return st, fmt.Errorf("%w: resolving release manifest signature: %w", ErrSignatureVerify, err)
+	}
 
 	// Stage checksums + signature material in the target directory's tempdir so
 	// cosign can read them by path and the extracted binary lands on the same FS.
 	dir := filepath.Dir(o.TargetPath)
 
-	// --- 1. checksums.txt + cosign authenticity (fail-closed unless --insecure-skip-signature) ---
+	// --- 1. release.json native Ed25519 authenticity (mandatory fail-closed) ---
+	manifestData, err := o.httpGet(ctx, manifestURL)
+	if err != nil {
+		return st, fmt.Errorf("%w: downloading %s: %w", ErrSignatureVerify, releasetrust.ManifestFile, err)
+	}
+	manifestSig, err := o.httpGet(ctx, manifestSigURL)
+	if err != nil {
+		return st, fmt.Errorf("%w: downloading %s: %w", ErrSignatureVerify, releasetrust.ManifestSigFile, err)
+	}
+	verification, err := releasetrust.VerifyManifest(manifestData, manifestSig, o.ReleaseKeyringHex)
+	if err != nil {
+		return st, fmt.Errorf("%w: native release manifest: %w", ErrSignatureVerify, err)
+	}
+	if verification.Manifest.Tag != rel.TagName {
+		return st, fmt.Errorf("%w: release metadata tag %q does not match manifest tag %q", ErrSignatureVerify, rel.TagName, verification.Manifest.Tag)
+	}
+	assetMeta, err := releasetrust.FindAsset(verification.Manifest, asset, o.GOOS, o.GOARCH, archiveBinaryName(o.GOOS))
+	if err != nil {
+		return st, fmt.Errorf("%w: %w", ErrSignatureVerify, err)
+	}
+
+	// --- 2. checksums.txt integrity, anchored by the signed manifest ---
 	sums, err := o.httpGet(ctx, sumsURL)
 	if err != nil {
 		return st, fmt.Errorf("downloading %s: %w", checksumsFile, err)
 	}
-	skipped, err := o.stageAndVerifySignature(ctx, rel, dir, sums)
-	if err != nil {
-		return st, err // ErrSignatureVerify -> fail-closed, no changes
-	}
-	st.SignatureSkipped = skipped
-	st.SignatureVerified = !skipped
-	if skipped {
-		_, _ = fmt.Fprintln(o.Stderr,
-			"WARNING: --insecure-skip-signature is set and cosign was not found on PATH. "+
-				"Publisher identity was NOT verified; proceeding with checksum integrity only.")
+	if got := sha256Hex(sums); got != verification.Manifest.ChecksumFileSHA256 {
+		return st, fmt.Errorf("%w: %s got %s want %s", ErrSignatureVerify, checksumsFile, got, verification.Manifest.ChecksumFileSHA256)
 	}
 
-	// --- 2. download archive + exact checksum match ---
+	// --- 3. optional cosign verification for external auditors ---
+	if err := o.stageAndVerifySignature(ctx, rel, dir, sums); err != nil {
+		return st, err // ErrSignatureVerify -> fail-closed, no changes
+	}
+	st.SignatureSkipped = false
+	st.SignatureVerified = true
+
+	// --- 4. download archive + exact checksum match ---
 	archive, err := o.httpGet(ctx, archiveURL)
 	if err != nil {
 		return st, fmt.Errorf("downloading %s: %w", asset, err)
@@ -182,24 +213,22 @@ func (o *Options) Run(ctx context.Context) (*Status, error) {
 	if !ok {
 		return st, fmt.Errorf("%w: %s has no entry in %s", ErrChecksumMismatch, asset, checksumsFile)
 	}
-	if got := sha256Hex(archive); got != wantSum {
-		return st, fmt.Errorf("%w: %s got %s want %s", ErrChecksumMismatch, asset, got, wantSum)
+	gotArchiveSum := sha256Hex(archive)
+	if gotArchiveSum != wantSum {
+		return st, fmt.Errorf("%w: %s got %s want %s", ErrChecksumMismatch, asset, gotArchiveSum, wantSum)
+	}
+	if gotArchiveSum != assetMeta.SHA256 {
+		return st, fmt.Errorf("%w: %s got %s want manifest %s", ErrChecksumMismatch, asset, gotArchiveSum, assetMeta.SHA256)
 	}
 
-	// --- 3. extract the pipelock binary into the target dir (atomic-rename ready) ---
+	// --- 5. extract the pipelock binary into the target dir (atomic-rename ready) ---
 	tmpPath, err := extractBinary(archive, isZip, dir, archiveBinaryName(o.GOOS))
 	if err != nil {
 		return st, err
 	}
 	// From here, any failure must delete tmpPath and leave target untouched.
 
-	// --- 4. verify the extracted binary self-reports the expected version ---
-	if err := o.verifyBinaryVersion(ctx, tmpPath, assetVer); err != nil {
-		_ = removeQuiet(tmpPath)
-		return st, err
-	}
-
-	// --- 5. back up current + atomic replace ---
+	// --- 6. back up current + atomic replace ---
 	backup, err := installBinary(o.TargetPath, tmpPath)
 	if err != nil {
 		_ = removeQuiet(tmpPath)
@@ -252,18 +281,21 @@ func (o *Options) Rollback(_ context.Context) (*Status, error) {
 }
 
 // stageAndVerifySignature writes checksums.txt (+ .sig + .pem if present) into
-// a private temp dir under dir, then runs cosign verification. Returns
-// skipped=true when cosign is absent (integrity-only), or an error when cosign
-// is present and rejects the signature.
-func (o *Options) stageAndVerifySignature(ctx context.Context, rel *release, dir string, sums []byte) (skipped bool, err error) {
+// a private temp dir under dir, then runs cosign verification when cosign is
+// available. Native release.json verification is mandatory and happens before
+// this helper, so cosign absence is no longer a checksum-only bypass.
+func (o *Options) stageAndVerifySignature(ctx context.Context, rel *release, dir string, sums []byte) error {
+	if !o.CosignAvailable() {
+		return nil
+	}
 	stageDir, err := os.MkdirTemp(dir, ".pipelock-verify-*")
 	if err != nil {
-		return false, fmt.Errorf("creating verification temp dir: %w", err)
+		return fmt.Errorf("creating verification temp dir: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(stageDir) }()
 
 	if err := writeFileQuiet(filepath.Join(stageDir, checksumsFile), sums); err != nil {
-		return false, fmt.Errorf("staging %s: %w", checksumsFile, err)
+		return fmt.Errorf("staging %s: %w", checksumsFile, err)
 	}
 
 	// Best-effort fetch of signature + certificate. If they're missing from the
@@ -279,5 +311,8 @@ func (o *Options) stageAndVerifySignature(ctx context.Context, rel *release, dir
 		}
 	}
 
-	return o.verifyPublisherSignature(ctx, stageDir, rel.TagName)
+	if err := o.verifyPublisherSignature(ctx, stageDir, rel.TagName); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/cli/selfupdate/update.go
+++ b/internal/cli/selfupdate/update.go
@@ -3,8 +3,9 @@
 
 // Package selfupdate implements the "pipelock update" command: a fail-closed
 // self-updater that fetches a release archive from GitHub, verifies it against
-// the published checksums (and, when a cosign binary is available, against the
-// keyless publisher signature), then atomically replaces the running binary.
+// the published checksums and the native Ed25519 release manifest, optionally
+// verifies the legacy cosign keyless signature when cosign is available, then
+// atomically replaces the running binary.
 //
 // Every failure in the verification chain aborts and leaves the installed
 // binary untouched. The temp download/extract happens in the SAME directory as
@@ -25,6 +26,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	releasetrust "github.com/luckyPipewrench/pipelock/internal/release"
 )
 
 // GitHub repository coordinates. The host is ours, so naming it is fine.
@@ -77,14 +80,18 @@ var (
 	// ErrChecksumMismatch is returned when a downloaded archive's SHA256 does
 	// not match the published checksum. Fail-closed: no changes applied.
 	ErrChecksumMismatch = errors.New("archive checksum does not match published checksums.txt")
-	// ErrVersionMismatch is returned when the freshly extracted binary does not
-	// report the expected target version. Fail-closed: temp deleted, no changes.
+	// ErrVersionMismatch is retained for callers compiled against older versions.
+	// The updater no longer executes a downloaded candidate to ask its version;
+	// release.json is the signed version/asset binding.
 	ErrVersionMismatch = errors.New("downloaded binary reports an unexpected version")
-	// ErrSignatureVerify is returned when cosign is present and rejects the
-	// publisher signature on checksums.txt. Fail-closed: no changes applied.
+	// ErrSignatureVerify is returned when native release-manifest verification
+	// fails, or when optional cosign verification is attempted and fails.
+	// Fail-closed: no changes applied.
 	ErrSignatureVerify = errors.New("publisher signature verification failed")
-	// ErrSignatureUnavailable is returned when cosign is unavailable and the
-	// caller did not explicitly opt into checksum-only update mode.
+	// ErrSignatureUnavailable is retained for callers compiled against older
+	// versions. Missing native release signing material now returns
+	// ErrSignatureVerify instead; cosign absence is not fatal after native
+	// Ed25519 verification succeeds.
 	ErrSignatureUnavailable = errors.New("publisher signature verification unavailable")
 	// ErrUnsupportedPlatform is returned for an OS/arch with no published asset.
 	ErrUnsupportedPlatform = errors.New("no release asset for this OS/architecture")
@@ -136,10 +143,14 @@ type Options struct {
 	AssumeYes bool
 	// JSON requests machine-readable output (handled by the cobra layer).
 	JSON bool
-	// AllowUnsignedChecksums permits checksum-only updates when cosign is absent.
-	// This is intentionally opt-in because checksums downloaded from the same
-	// release page prove integrity, not publisher authenticity.
+	// AllowUnsignedChecksums is a legacy cobra flag field retained for CLI
+	// compatibility. It never bypasses native Ed25519 release-manifest
+	// verification; checksum-only updates are not allowed.
 	AllowUnsignedChecksums bool
+
+	// ReleaseKeyringHex is the comma-separated Ed25519 public-key keyring used
+	// to verify release.json. Default: internal/release.PublicKeyringHex.
+	ReleaseKeyringHex string
 
 	// CosignAvailable reports whether a cosign binary is usable. Default: PATH lookup.
 	CosignAvailable func() bool
@@ -174,6 +185,9 @@ func (o *Options) fillDefaults() error {
 	}
 	if o.RunCommand == nil {
 		o.RunCommand = defaultCommandRunner
+	}
+	if o.ReleaseKeyringHex == "" {
+		o.ReleaseKeyringHex = releasetrust.PublicKeyringHex
 	}
 	if o.Stdout == nil {
 		o.Stdout = os.Stdout

--- a/internal/cli/selfupdate/update_test.go
+++ b/internal/cli/selfupdate/update_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -18,8 +19,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
+
+	releasetrust "github.com/luckyPipewrench/pipelock/internal/release"
 )
 
 const (
@@ -27,6 +32,11 @@ const (
 	testCurrent = "v2.7.0"
 	testGOOS    = "linux"
 	testGOARCH  = "amd64"
+)
+
+var (
+	testReleasePriv   = ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x42}, ed25519.SeedSize))
+	testReleasePubHex = hex.EncodeToString(testReleasePriv.Public().(ed25519.PublicKey))
 )
 
 // fakeBinaryScript is the payload we pack into the fake archive. The test
@@ -141,7 +151,9 @@ func newReleaseServer(t *testing.T, tag string, assets map[string][]byte) *relea
 	return rs
 }
 
-// standardAssets builds a coherent release: archive + matching checksums.txt.
+// standardAssets builds a coherent release: archive + matching checksums.txt +
+// native Ed25519-signed release.json. The manifest is the in-process publisher
+// identity check; checksums.txt is only integrity data.
 func standardAssets(t *testing.T, version, goos string) (assets map[string][]byte, archiveName string) {
 	t.Helper()
 	bare := strings.TrimPrefix(version, "v")
@@ -155,12 +167,40 @@ func standardAssets(t *testing.T, version, goos string) (assets map[string][]byt
 	}
 	archiveName = assetName(bare, goos, testGOARCH)
 	checks := fmt.Sprintf("%s  %s\n", sum(archive), archiveName)
+	manifest, sig := signedReleaseManifest(t, version, goos, archiveName, archive, []byte(checks))
 	return map[string][]byte{
-		archiveName:   archive,
-		checksumsFile: []byte(checks),
-		checksumsSig:  []byte("fake-signature"),
-		checksumsPEM:  []byte("fake-certificate"),
+		archiveName:                  archive,
+		checksumsFile:                []byte(checks),
+		checksumsSig:                 []byte("fake-signature"),
+		checksumsPEM:                 []byte("fake-certificate"),
+		releasetrust.ManifestFile:    manifest,
+		releasetrust.ManifestSigFile: sig,
 	}, archiveName
+}
+
+func signedReleaseManifest(t *testing.T, version, goos, archiveName string, archive, checksums []byte) ([]byte, []byte) {
+	t.Helper()
+	manifest := releasetrust.Manifest{
+		Schema:             "pipelock-release-v1",
+		Repo:               "github.com/luckyPipewrench/pipelock",
+		Tag:                version,
+		Commit:             strings.Repeat("a", 40),
+		CreatedUTC:         time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		ChecksumFileSHA256: sum(checksums),
+		Assets: []releasetrust.Asset{{
+			Name:   archiveName,
+			SHA256: sum(archive),
+			GOOS:   goos,
+			GOARCH: testGOARCH,
+			Binary: archiveBinaryName(goos),
+		}},
+		SignerKeyID: "test-release-key",
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal release manifest: %v", err)
+	}
+	return data, []byte(releasetrust.SignManifest(data, testReleasePriv))
 }
 
 // writeTargetBinary creates a stand-in installed binary in a temp dir and
@@ -179,16 +219,17 @@ func writeTargetBinary(t *testing.T, contents string) string {
 // present by default so success paths exercise publisher verification.
 func baseOptions(rs *releaseServer, target string) *Options {
 	return &Options{
-		APIBase:         rs.srv.URL,
-		HTTPClient:      rs.srv.Client(),
-		TargetPath:      target,
-		CurrentVersion:  testCurrent,
-		GOOS:            testGOOS,
-		GOARCH:          testGOARCH,
-		CosignAvailable: func() bool { return true },
-		RunCommand:      stubVersionRunner(""),
-		Stdout:          &bytes.Buffer{},
-		Stderr:          &bytes.Buffer{},
+		APIBase:           rs.srv.URL,
+		HTTPClient:        rs.srv.Client(),
+		TargetPath:        target,
+		CurrentVersion:    testCurrent,
+		GOOS:              testGOOS,
+		GOARCH:            testGOARCH,
+		ReleaseKeyringHex: testReleasePubHex,
+		CosignAvailable:   func() bool { return true },
+		RunCommand:        stubVersionRunner(""),
+		Stdout:            &bytes.Buffer{},
+		Stderr:            &bytes.Buffer{},
 	}
 }
 
@@ -296,10 +337,45 @@ func TestRun_PinnedVersion(t *testing.T) {
 	}
 }
 
+func TestRun_DoesNotExecuteDownloadedBinaryBeforeInstall(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("shell-script execution PoC is linux-only")
+	}
+	marker := filepath.Join(t.TempDir(), "candidate-executed")
+	payload := []byte("#!/bin/sh\nprintf executed > " + shellQuote(marker) + "\necho pipelock version 2.8.0\n")
+	archive := makeTarGz(t, map[string][]byte{binaryName: payload})
+	archiveName := assetName(strings.TrimPrefix(testLatest, "v"), testGOOS, testGOARCH)
+	checks := fmt.Sprintf("%s  %s\n", sum(archive), archiveName)
+	manifest, sig := signedReleaseManifest(t, testLatest, testGOOS, archiveName, archive, []byte(checks))
+	assets := map[string][]byte{
+		archiveName:                  archive,
+		checksumsFile:                []byte(checks),
+		releasetrust.ManifestFile:    manifest,
+		releasetrust.ManifestSigFile: sig,
+	}
+	rs := newReleaseServer(t, testLatest, assets)
+	target := writeTargetBinary(t, "ORIGINAL")
+	opts := baseOptions(rs, target)
+	opts.CosignAvailable = func() bool { return false }
+	opts.AllowUnsignedChecksums = true
+	opts.RunCommand = defaultCommandRunner
+
+	if _, err := opts.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("downloaded candidate executed before install; marker stat err=%v contents=%q", err, readT(marker))
+	}
+}
+
 func TestRun_ChecksumMismatchAborts(t *testing.T) {
 	assets, archiveName := standardAssets(t, testLatest, testGOOS)
 	// Corrupt the checksums entry so it no longer matches the archive.
-	assets[checksumsFile] = []byte("deadbeef  " + archiveName + "\n")
+	checks := []byte("deadbeef  " + archiveName + "\n")
+	assets[checksumsFile] = checks
+	manifest, sig := signedReleaseManifest(t, testLatest, testGOOS, archiveName, assets[archiveName], checks)
+	assets[releasetrust.ManifestFile] = manifest
+	assets[releasetrust.ManifestSigFile] = sig
 	rs := newReleaseServer(t, testLatest, assets)
 	target := writeTargetBinary(t, "ORIGINAL")
 	opts := baseOptions(rs, target)
@@ -334,23 +410,24 @@ func TestRun_NetworkErrorFailsClosed(t *testing.T) {
 	}
 }
 
-func TestRun_ExtractedVersionMismatchAborts(t *testing.T) {
-	// Archive binary reports the WRONG version.
-	bin := fakeBinaryBytes("9.9.9")
-	archive := makeTarGz(t, map[string][]byte{binaryName: bin})
+func TestRun_ManifestTagMismatchAborts(t *testing.T) {
+	assets, _ := standardAssets(t, testLatest, testGOOS)
 	archiveName := assetName(strings.TrimPrefix(testLatest, "v"), testGOOS, testGOARCH)
-	checks := fmt.Sprintf("%s  %s\n", sum(archive), archiveName)
-	assets := map[string][]byte{archiveName: archive, checksumsFile: []byte(checks)}
+	archive := assets[archiveName]
+	checks := assets[checksumsFile]
+	manifest, sig := signedReleaseManifest(t, "v9.9.9", testGOOS, archiveName, archive, checks)
+	assets[releasetrust.ManifestFile] = manifest
+	assets[releasetrust.ManifestSigFile] = sig
 	rs := newReleaseServer(t, testLatest, assets)
 	target := writeTargetBinary(t, "ORIGINAL")
 	opts := baseOptions(rs, target)
 
 	_, err := opts.Run(context.Background())
-	if !errors.Is(err, ErrVersionMismatch) {
-		t.Fatalf("expected ErrVersionMismatch, got %v", err)
+	if !errors.Is(err, ErrSignatureVerify) {
+		t.Fatalf("expected ErrSignatureVerify, got %v", err)
 	}
 	if string(readT(target)) != "ORIGINAL" {
-		t.Fatalf("target mutated on version mismatch: %q", readT(target))
+		t.Fatalf("target mutated on manifest mismatch: %q", readT(target))
 	}
 	// Temp file should be cleaned up (no leftover .pipelock-update-* in dir).
 	assertNoTempLeftovers(t, filepath.Dir(target))

--- a/internal/cli/selfupdate/verify.go
+++ b/internal/cli/selfupdate/verify.go
@@ -36,22 +36,10 @@ func parseChecksums(data []byte) map[string]string {
 }
 
 // verifyPublisherSignature checks checksums.txt against its keyless cosign
-// signature. Behavior:
-//   - cosign NOT on PATH: returns ErrSignatureUnavailable unless the caller
-//     explicitly enabled checksum-only mode.
-//   - cosign present and verification FAILS: returns (false, ErrSignatureVerify)
-//     — fail-closed, caller aborts with no changes.
-//   - cosign present and verification PASSES: returns (false-skipped, nil).
-//
-// It is a single helper with injected availability + runner so tests cover
-// all three paths without a real cosign binary.
-func (o *Options) verifyPublisherSignature(ctx context.Context, dir, tagName string) (skipped bool, err error) {
-	if !o.CosignAvailable() {
-		if !o.AllowUnsignedChecksums {
-			return false, ErrSignatureUnavailable
-		}
-		return true, nil
-	}
+// signature. This is an optional secondary ecosystem check; native release.json
+// verification is the mandatory publisher-authentication path. If cosign is
+// present and rejects the signature, the updater still fails closed.
+func (o *Options) verifyPublisherSignature(ctx context.Context, dir, tagName string) error {
 	// #nosec G204 -- all args are fixed consts or paths we constructed in our temp dir.
 	out, runErr := o.RunCommand(ctx, cosignBinary,
 		"verify-blob",
@@ -62,9 +50,9 @@ func (o *Options) verifyPublisherSignature(ctx context.Context, dir, tagName str
 		filepath.Join(dir, checksumsFile),
 	)
 	if runErr != nil {
-		return false, fmt.Errorf("%w: cosign verify-blob: %s: %s", ErrSignatureVerify, runErr.Error(), strings.TrimSpace(string(out)))
+		return fmt.Errorf("%w: cosign verify-blob: %s: %s", ErrSignatureVerify, runErr.Error(), strings.TrimSpace(string(out)))
 	}
-	return false, nil
+	return nil
 }
 
 // sha256Hex returns the lowercase hex SHA256 of data.
@@ -201,34 +189,6 @@ func extractZip(archive []byte, w io.Writer, expectedBinary string) error {
 		return nil
 	}
 	return fmt.Errorf("%w: %s not found in archive", ErrAssetNotFound, expectedBinary)
-}
-
-// verifyBinaryVersion runs "<path> --version" and confirms the output mentions
-// the expected bare version. Fail-closed: any error or a missing version match
-// returns ErrVersionMismatch.
-func (o *Options) verifyBinaryVersion(ctx context.Context, path, wantVersion string) error {
-	// #nosec G204 -- path is a temp file we just extracted into our own dir.
-	out, err := o.RunCommand(ctx, path, "--version")
-	if err != nil {
-		return fmt.Errorf("%w: running --version: %s", ErrVersionMismatch, err.Error())
-	}
-	got := string(out)
-	if !versionOutputMatches(got, wantVersion) {
-		return fmt.Errorf("%w: expected %q in %q", ErrVersionMismatch, wantVersion, strings.TrimSpace(got))
-	}
-	return nil
-}
-
-func versionOutputMatches(output, wantVersion string) bool {
-	// Exact match including any pre-release suffix: a "2.8.0" binary must NOT
-	// satisfy a "2.8.0-rc1" pin. Strip only the leading "v".
-	want := versionTag(wantVersion)
-	for _, field := range strings.Fields(output) {
-		if field == want || field == "v"+want {
-			return true
-		}
-	}
-	return false
 }
 
 func copyBounded(w io.Writer, r io.Reader) error {

--- a/internal/cli/selfupdate/verify_test.go
+++ b/internal/cli/selfupdate/verify_test.go
@@ -15,46 +15,47 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	releasetrust "github.com/luckyPipewrench/pipelock/internal/release"
 )
 
-func TestRun_CosignAbsentFailsClosedByDefault(t *testing.T) {
-	assets, _ := standardAssets(t, testLatest, testGOOS)
-	rs := newReleaseServer(t, testLatest, assets)
-	target := writeTargetBinary(t, "ORIGINAL")
-	opts := baseOptions(rs, target)
-	opts.CosignAvailable = func() bool { return false }
-
-	_, err := opts.Run(context.Background())
-	if !errors.Is(err, ErrSignatureUnavailable) {
-		t.Fatalf("expected ErrSignatureUnavailable, got %v", err)
-	}
-	if string(readT(target)) != "ORIGINAL" {
-		t.Fatalf("target mutated when cosign unavailable: %q", readT(target))
-	}
-	if _, err := os.Stat(target + backupSuffix); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("backup should not exist after signature-unavailable abort")
-	}
-}
-
-func TestRun_InsecureSkipSignatureAllowsChecksumOnly(t *testing.T) {
+func TestRun_CosignAbsentStillVerifiesNativeManifest(t *testing.T) {
 	assets, _ := standardAssets(t, testLatest, testGOOS)
 	rs := newReleaseServer(t, testLatest, assets)
 	target := writeTargetBinary(t, "OLD")
+	opts := baseOptions(rs, target)
+	opts.CosignAvailable = func() bool { return false }
+
+	st, err := opts.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !st.Applied || st.SignatureSkipped || !st.SignatureVerified {
+		t.Fatalf("expected native-signature verified update, got %+v", st)
+	}
+}
+
+func TestRun_InsecureSkipSignatureDoesNotBypassNativeManifest(t *testing.T) {
+	assets, _ := standardAssets(t, testLatest, testGOOS)
+	delete(assets, releasetrust.ManifestFile)
+	delete(assets, releasetrust.ManifestSigFile)
+	rs := newReleaseServer(t, testLatest, assets)
+	target := writeTargetBinary(t, "ORIGINAL")
 	opts := baseOptions(rs, target)
 	stderr := &bytes.Buffer{}
 	opts.Stderr = stderr
 	opts.CosignAvailable = func() bool { return false }
 	opts.AllowUnsignedChecksums = true
 
-	st, err := opts.Run(context.Background())
-	if err != nil {
-		t.Fatalf("Run: %v", err)
+	_, err := opts.Run(context.Background())
+	if !errors.Is(err, ErrSignatureVerify) {
+		t.Fatalf("expected ErrSignatureVerify, got %v", err)
 	}
-	if !st.Applied || !st.SignatureSkipped || st.SignatureVerified {
-		t.Fatalf("expected applied + skipped, got %+v", st)
+	if string(readT(target)) != "ORIGINAL" {
+		t.Fatalf("target mutated without native release signature: %q", readT(target))
 	}
-	if !strings.Contains(stderr.String(), "--insecure-skip-signature") {
-		t.Fatalf("expected insecure warning, got %q", stderr.String())
+	if stderr.String() != "" {
+		t.Fatalf("unexpected insecure warning: %q", stderr.String())
 	}
 }
 
@@ -65,13 +66,14 @@ func TestRun_CosignPresentAndPasses(t *testing.T) {
 	opts := baseOptions(rs, target)
 	opts.CosignAvailable = func() bool { return true }
 	var cosignArgs []string
-	// Runner: cosign verify-blob succeeds; --version echoes the binary file.
+	// Runner: cosign verify-blob succeeds. The updater must not execute the
+	// downloaded candidate for a version probe.
 	opts.RunCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		if name == cosignBinary {
 			cosignArgs = append([]string(nil), args...)
 			return []byte("Verified OK"), nil
 		}
-		return stubVersionRunner("")(ctx, name, args...)
+		return nil, fmt.Errorf("unexpected command execution: %s %v", name, args)
 	}
 
 	st, err := opts.Run(context.Background())
@@ -206,31 +208,9 @@ func TestCopyBounded_RejectsOversize(t *testing.T) {
 	}
 }
 
-func TestVersionOutputMatchesWholeTokenOnly(t *testing.T) {
-	if !versionOutputMatches("pipelock version 2.8.0\n", "2.8.0") {
-		t.Fatal("expected exact bare version token to match")
-	}
-	if !versionOutputMatches("pipelock version v2.8.0\n", "2.8.0") {
-		t.Fatal("expected exact v-prefixed version token to match")
-	}
-	if versionOutputMatches("pipelock version 12.8.0\n", "2.8.0") {
-		t.Fatal("substring version match should fail")
-	}
-	// Pre-release pins must match EXACTLY, not collapse to the core version.
-	if !versionOutputMatches("pipelock version 2.8.0-rc1\n", "v2.8.0-rc1") {
-		t.Fatal("expected exact pre-release token to match")
-	}
-	if versionOutputMatches("pipelock version 2.8.0\n", "2.8.0-rc1") {
-		t.Fatal("a stable binary must NOT satisfy a pre-release pin")
-	}
-	if versionOutputMatches("pipelock version 2.8.0-rc2\n", "2.8.0-rc1") {
-		t.Fatal("rc2 binary must NOT satisfy an rc1 pin")
-	}
-}
-
 // TestVersionTagPreservesPrerelease guards the bareVersion-vs-versionTag split:
-// asset names and version checks must keep the pre-release suffix so a pinned
-// "v2.8.0-rc1" resolves the rc archive, not the stable one.
+// asset names must keep the pre-release suffix so a pinned "v2.8.0-rc1"
+// resolves the rc archive, not the stable one.
 func TestVersionTagPreservesPrerelease(t *testing.T) {
 	if got := versionTag("v2.8.0-rc1"); got != "2.8.0-rc1" {
 		t.Fatalf("versionTag should keep pre-release: got %q", got)

--- a/internal/release/verify.go
+++ b/internal/release/verify.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package release verifies Pipelock release manifests with the embedded
+// Ed25519 release keyring.
+package release
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+)
+
+const (
+	ManifestFile    = "release.json"
+	ManifestSigFile = "release.json.sig"
+
+	manifestSignaturePrefix = "ed25519:"
+	signingDomain           = "Pipelock release manifest signature v1\n"
+)
+
+// PublicKeyringHex is set at build time via ldflags. Official releases embed
+// one or more comma-separated raw Ed25519 public keys encoded as 64 hex chars.
+var PublicKeyringHex string
+
+var (
+	ErrNoReleaseKey      = errors.New("release verification keyring is empty")
+	ErrReleaseSignature  = errors.New("release manifest signature verification failed")
+	ErrReleaseManifest   = errors.New("release manifest invalid")
+	ErrReleaseAsset      = errors.New("release manifest asset invalid")
+	ErrReleaseTrustInput = errors.New("release trust input invalid")
+)
+
+type Manifest struct {
+	Schema             string  `json:"schema"`
+	Repo               string  `json:"repo"`
+	Tag                string  `json:"tag"`
+	Commit             string  `json:"commit"`
+	CreatedUTC         string  `json:"created_utc"`
+	ChecksumFileSHA256 string  `json:"checksum_file_sha256"`
+	Assets             []Asset `json:"assets"`
+	SignerKeyID        string  `json:"signer_key_id"`
+}
+
+type Asset struct {
+	Name   string `json:"name"`
+	SHA256 string `json:"sha256"`
+	GOOS   string `json:"goos"`
+	GOARCH string `json:"goarch"`
+	Binary string `json:"binary"`
+}
+
+type Verification struct {
+	Manifest       Manifest
+	SignerKeyHex   string
+	SignerKeyIndex int
+}
+
+func VerifyManifest(data, sig []byte, keyringHex string) (Verification, error) {
+	keys, err := parseKeyring(keyringHex)
+	if err != nil {
+		return Verification{}, err
+	}
+	rawSig, err := parseSignature(sig)
+	if err != nil {
+		return Verification{}, err
+	}
+	preimage := append([]byte(signingDomain), data...)
+	for i, key := range keys {
+		if ed25519.Verify(key, preimage, rawSig) {
+			var manifest Manifest
+			if err := decodeManifest(data, &manifest); err != nil {
+				return Verification{}, err
+			}
+			return Verification{
+				Manifest:       manifest,
+				SignerKeyHex:   hex.EncodeToString(key),
+				SignerKeyIndex: i,
+			}, nil
+		}
+	}
+	return Verification{}, ErrReleaseSignature
+}
+
+func SignManifest(data []byte, priv ed25519.PrivateKey) string {
+	preimage := append([]byte(signingDomain), data...)
+	return manifestSignaturePrefix + hex.EncodeToString(ed25519.Sign(priv, preimage))
+}
+
+func FindAsset(m Manifest, name, goos, goarch, binary string) (Asset, error) {
+	for _, asset := range m.Assets {
+		if asset.Name == name {
+			if asset.GOOS != goos || asset.GOARCH != goarch || asset.Binary != binary {
+				return Asset{}, fmt.Errorf("%w: %s metadata mismatch", ErrReleaseAsset, name)
+			}
+			if !isSHA256Hex(asset.SHA256) {
+				return Asset{}, fmt.Errorf("%w: %s has invalid sha256", ErrReleaseAsset, name)
+			}
+			return asset, nil
+		}
+	}
+	return Asset{}, fmt.Errorf("%w: missing %s", ErrReleaseAsset, name)
+}
+
+func ValidateManifest(m Manifest) error {
+	if m.Schema != "pipelock-release-v1" {
+		return fmt.Errorf("%w: unsupported schema %q", ErrReleaseManifest, m.Schema)
+	}
+	if m.Repo != "github.com/luckyPipewrench/pipelock" {
+		return fmt.Errorf("%w: repo %q", ErrReleaseManifest, m.Repo)
+	}
+	if strings.TrimSpace(m.Tag) == "" {
+		return fmt.Errorf("%w: tag is required", ErrReleaseManifest)
+	}
+	if strings.TrimSpace(m.Commit) == "" {
+		return fmt.Errorf("%w: commit is required", ErrReleaseManifest)
+	}
+	if strings.TrimSpace(m.SignerKeyID) == "" {
+		return fmt.Errorf("%w: signer_key_id is required", ErrReleaseManifest)
+	}
+	if !isSHA256Hex(m.ChecksumFileSHA256) {
+		return fmt.Errorf("%w: checksum_file_sha256 is invalid", ErrReleaseManifest)
+	}
+	if _, err := time.Parse(time.RFC3339, m.CreatedUTC); err != nil {
+		return fmt.Errorf("%w: created_utc: %w", ErrReleaseManifest, err)
+	}
+	if len(m.Assets) == 0 {
+		return fmt.Errorf("%w: no assets", ErrReleaseManifest)
+	}
+	seen := make(map[string]struct{}, len(m.Assets))
+	for _, asset := range m.Assets {
+		if strings.TrimSpace(asset.Name) == "" {
+			return fmt.Errorf("%w: asset name is required", ErrReleaseManifest)
+		}
+		if _, ok := seen[asset.Name]; ok {
+			return fmt.Errorf("%w: duplicate asset %q", ErrReleaseManifest, asset.Name)
+		}
+		seen[asset.Name] = struct{}{}
+		if !isSHA256Hex(asset.SHA256) {
+			return fmt.Errorf("%w: asset %q sha256 is invalid", ErrReleaseManifest, asset.Name)
+		}
+		if strings.TrimSpace(asset.GOOS) == "" || strings.TrimSpace(asset.GOARCH) == "" || strings.TrimSpace(asset.Binary) == "" {
+			return fmt.Errorf("%w: asset %q platform metadata is incomplete", ErrReleaseManifest, asset.Name)
+		}
+	}
+	return nil
+}
+
+func decodeManifest(data []byte, manifest *Manifest) error {
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		return fmt.Errorf("%w: %w", ErrReleaseManifest, err)
+	}
+	if err := json.Unmarshal(data, manifest); err != nil {
+		return fmt.Errorf("%w: %w", ErrReleaseManifest, err)
+	}
+	if err := ValidateManifest(*manifest); err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseKeyring(keyringHex string) ([]ed25519.PublicKey, error) {
+	keyringHex = strings.TrimSpace(keyringHex)
+	if keyringHex == "" {
+		return nil, ErrNoReleaseKey
+	}
+	parts := strings.Split(keyringHex, ",")
+	keys := make([]ed25519.PublicKey, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		raw, err := hex.DecodeString(part)
+		if err != nil || len(raw) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("%w: malformed release public key", ErrReleaseTrustInput)
+		}
+		keys = append(keys, ed25519.PublicKey(raw))
+	}
+	return keys, nil
+}
+
+func parseSignature(sig []byte) ([]byte, error) {
+	text := strings.TrimSpace(string(sig))
+	if !strings.HasPrefix(text, manifestSignaturePrefix) {
+		return nil, fmt.Errorf("%w: missing %s prefix", ErrReleaseSignature, manifestSignaturePrefix)
+	}
+	raw, err := hex.DecodeString(strings.TrimPrefix(text, manifestSignaturePrefix))
+	if err != nil || len(raw) != ed25519.SignatureSize {
+		return nil, fmt.Errorf("%w: malformed signature", ErrReleaseSignature)
+	}
+	return raw, nil
+}
+
+func isSHA256Hex(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}

--- a/internal/release/verify_test.go
+++ b/internal/release/verify_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package release
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	testPrivA = ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x11}, ed25519.SeedSize))
+	testPubA  = testPrivA.Public().(ed25519.PublicKey)
+	testPrivB = ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x22}, ed25519.SeedSize))
+	testPubB  = testPrivB.Public().(ed25519.PublicKey)
+)
+
+func testManifest() Manifest {
+	return Manifest{
+		Schema:             "pipelock-release-v1",
+		Repo:               "github.com/luckyPipewrench/pipelock",
+		Tag:                "v2.8.0",
+		Commit:             strings.Repeat("a", 40),
+		CreatedUTC:         time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		ChecksumFileSHA256: strings.Repeat("0", 64),
+		Assets: []Asset{{
+			Name:   "pipelock_2.8.0_linux_amd64.tar.gz",
+			SHA256: strings.Repeat("1", 64),
+			GOOS:   "linux",
+			GOARCH: "amd64",
+			Binary: "pipelock",
+		}},
+		SignerKeyID: "release-key-a",
+	}
+}
+
+func mustManifestJSON(t *testing.T, manifest Manifest) []byte {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	return data
+}
+
+func TestVerifyManifestAcceptsAnyTrustedKey(t *testing.T) {
+	data := mustManifestJSON(t, testManifest())
+	sig := []byte(SignManifest(data, testPrivB))
+	keyring := hex.EncodeToString(testPubA) + ", " + hex.EncodeToString(testPubB)
+
+	got, err := VerifyManifest(data, sig, keyring)
+	if err != nil {
+		t.Fatalf("VerifyManifest: %v", err)
+	}
+	if got.SignerKeyIndex != 1 {
+		t.Fatalf("SignerKeyIndex = %d, want 1", got.SignerKeyIndex)
+	}
+	if got.SignerKeyHex != hex.EncodeToString(testPubB) {
+		t.Fatalf("SignerKeyHex = %q, want second key", got.SignerKeyHex)
+	}
+	if got.Manifest.Tag != "v2.8.0" {
+		t.Fatalf("manifest tag = %q", got.Manifest.Tag)
+	}
+}
+
+func TestVerifyManifestRejectsTrustAndSignatureFailures(t *testing.T) {
+	data := mustManifestJSON(t, testManifest())
+	goodSig := []byte(SignManifest(data, testPrivA))
+	goodKeyring := hex.EncodeToString(testPubA)
+
+	tests := []struct {
+		name    string
+		data    []byte
+		sig     []byte
+		keyring string
+		want    error
+	}{
+		{
+			name:    "empty keyring",
+			data:    data,
+			sig:     goodSig,
+			keyring: "",
+			want:    ErrNoReleaseKey,
+		},
+		{
+			name:    "malformed keyring",
+			data:    data,
+			sig:     goodSig,
+			keyring: "not-hex",
+			want:    ErrReleaseTrustInput,
+		},
+		{
+			name:    "missing signature prefix",
+			data:    data,
+			sig:     []byte(hex.EncodeToString(ed25519.Sign(testPrivA, append([]byte(signingDomain), data...)))),
+			keyring: goodKeyring,
+			want:    ErrReleaseSignature,
+		},
+		{
+			name:    "malformed signature hex",
+			data:    data,
+			sig:     []byte(manifestSignaturePrefix + "zz"),
+			keyring: goodKeyring,
+			want:    ErrReleaseSignature,
+		},
+		{
+			name:    "tampered manifest",
+			data:    append([]byte{}, append(data, ' ')...),
+			sig:     goodSig,
+			keyring: goodKeyring,
+			want:    ErrReleaseSignature,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := VerifyManifest(tc.data, tc.sig, tc.keyring); !errors.Is(err, tc.want) {
+				t.Fatalf("VerifyManifest error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerifyManifestRejectsDuplicateKeysAfterSignaturePasses(t *testing.T) {
+	data := []byte(`{"schema":"pipelock-release-v1","schema":"pipelock-release-v1"}`)
+	sig := []byte(SignManifest(data, testPrivA))
+	if _, err := VerifyManifest(data, sig, hex.EncodeToString(testPubA)); !errors.Is(err, ErrReleaseManifest) {
+		t.Fatalf("VerifyManifest duplicate key error = %v, want ErrReleaseManifest", err)
+	}
+}
+
+func TestValidateManifestRejectsInvalidFields(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*Manifest)
+	}{
+		{name: "schema", edit: func(m *Manifest) { m.Schema = "v0" }},
+		{name: "repo", edit: func(m *Manifest) { m.Repo = "github.com/evil/fork" }},
+		{name: "tag", edit: func(m *Manifest) { m.Tag = " " }},
+		{name: "commit", edit: func(m *Manifest) { m.Commit = "" }},
+		{name: "signer", edit: func(m *Manifest) { m.SignerKeyID = "" }},
+		{name: "checksums", edit: func(m *Manifest) { m.ChecksumFileSHA256 = "short" }},
+		{name: "created", edit: func(m *Manifest) { m.CreatedUTC = "not-time" }},
+		{name: "no assets", edit: func(m *Manifest) { m.Assets = nil }},
+		{name: "asset name", edit: func(m *Manifest) { m.Assets[0].Name = "" }},
+		{name: "asset duplicate", edit: func(m *Manifest) { m.Assets = append(m.Assets, m.Assets[0]) }},
+		{name: "asset sha", edit: func(m *Manifest) { m.Assets[0].SHA256 = "bad" }},
+		{name: "asset metadata", edit: func(m *Manifest) { m.Assets[0].GOARCH = "" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := testManifest()
+			tc.edit(&manifest)
+			if err := ValidateManifest(manifest); !errors.Is(err, ErrReleaseManifest) {
+				t.Fatalf("ValidateManifest error = %v, want ErrReleaseManifest", err)
+			}
+		})
+	}
+}
+
+func TestFindAssetBindsPlatformAndDigest(t *testing.T) {
+	manifest := testManifest()
+	if _, err := FindAsset(manifest, manifest.Assets[0].Name, "linux", "arm64", "pipelock"); !errors.Is(err, ErrReleaseAsset) {
+		t.Fatalf("FindAsset platform mismatch error = %v, want ErrReleaseAsset", err)
+	}
+	if _, err := FindAsset(manifest, "missing.tar.gz", "linux", "amd64", "pipelock"); !errors.Is(err, ErrReleaseAsset) {
+		t.Fatalf("FindAsset missing error = %v, want ErrReleaseAsset", err)
+	}
+	manifest.Assets[0].SHA256 = "not-a-sha"
+	if _, err := FindAsset(manifest, manifest.Assets[0].Name, "linux", "amd64", "pipelock"); !errors.Is(err, ErrReleaseAsset) {
+		t.Fatalf("FindAsset invalid digest error = %v, want ErrReleaseAsset", err)
+	}
+}


### PR DESCRIPTION
Self-update executed the downloaded binary (`--version`) before install: a pre-install RCE from a compromised or MITM'd release.

Native Ed25519-signed `release.json` verification is now mandatory. The manifest is verified against the embedded release keyring before any asset is processed, and the downloaded candidate binary is never executed (the version is derived from the signed manifest). Release-manifest signing moves out of CI to an offline key: `pipelock-release-manifest -sign-only` signs an existing manifest, and `-gen-key` generates the release-signing keypair (private to an offline key safe, public to the `RELEASE_KEYRING_HEX` build secret). `--insecure-skip-signature` can no longer bypass native verification; cosign remains an optional secondary check.

## What changed
- `internal/release`: native Ed25519 release-manifest verification.
- `internal/cli/selfupdate`: mandatory manifest verify; candidate binary is no longer executed.
- `cmd/pipelock-release-manifest`: `-sign-only` (offline) and `-gen-key`.
- Release workflow + goreleaser: emit unsigned `release.json`, embed `RELEASE_KEYRING_HEX`, drop in-CI signing.
- `docs/security/self-update-signing-custody.md`: signing-key custody options and the chosen offline model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Self-update now uses a native Ed25519-signed `release.json` manifest (`release.json.sig`) and verifies it (plus pinned checksums) before installing updates.

* **Bug Fixes**
  * Update verification is fail-closed: checksum-only updates are blocked, and “insecure skip signature” no longer relaxes native manifest/signature verification.
  * The updater no longer runs the downloaded binary to check its version prior to installation.

* **Documentation**
  * Added/updated a self-update signing custody runbook and clarified command help behavior.

* **Chores**
  * Release pipeline now generates/uploads self-update manifest metadata for signed verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->