### PR TITLE
fix(conductor): prevent follower restart-wedge and add replay-state recovery command

### DIFF
--- a/enterprise/cli/conductor/cmd.go
+++ b/enterprise/cli/conductor/cmd.go
@@ -101,6 +101,7 @@ func Cmd() *cobra.Command {
 	cmd.AddCommand(enrollCmd())
 	cmd.AddCommand(enrollmentTokenCmd())
 	cmd.AddCommand(storeCmd())
+	cmd.AddCommand(followerCmd())
 	return cmd
 }
 

--- a/enterprise/cli/conductor/follower.go
+++ b/enterprise/cli/conductor/follower.go
@@ -56,6 +56,9 @@ Safety posture (mirrors 'conductor store repair'):
     follower, never on a healthy one.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := validateFollowerResetReplayStateOptions(opts); err != nil {
+				return err
+			}
 			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.licenseCRLFile}); err != nil {
 				return err
 			}
@@ -69,10 +72,10 @@ Safety posture (mirrors 'conductor store repair'):
 }
 
 func runFollowerResetReplayState(cmd *cobra.Command, opts followerResetReplayOptions) error {
-	if opts.stateDir == "" {
-		return fmt.Errorf("--state-dir is required")
+	if err := validateFollowerResetReplayStateOptions(opts); err != nil {
+		return err
 	}
-	statePath := filepath.Join(filepath.Clean(opts.stateDir), emergency.RemoteKillStateFileName)
+	statePath := filepath.Join(opts.stateDir, emergency.RemoteKillStateFileName)
 	out := cmd.OutOrStdout()
 	if !opts.confirm {
 		_, _ = fmt.Fprintf(out, "DRY RUN: would reset remote-kill replay state at %s to a clean baseline (counter 0, no decision).\n", statePath)
@@ -83,5 +86,12 @@ func runFollowerResetReplayState(cmd *cobra.Command, opts followerResetReplayOpt
 		return fmt.Errorf("reset remote-kill replay state: %w", err)
 	}
 	_, _ = fmt.Fprintf(out, "reset remote-kill replay state at %s to a clean baseline; restart the follower if it is wedged.\n", statePath)
+	return nil
+}
+
+func validateFollowerResetReplayStateOptions(opts followerResetReplayOptions) error {
+	if opts.stateDir == "" {
+		return fmt.Errorf("--state-dir is required")
+	}
 	return nil
 }

--- a/enterprise/cli/conductor/follower.go
+++ b/enterprise/cli/conductor/follower.go
@@ -1,0 +1,87 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/emergency"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+// followerCmd groups local, follower-side Conductor recovery commands. These run
+// on the follower host (against its on-disk conductor state), not over the mTLS
+// control-plane API.
+func followerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "follower",
+		Short: "Local follower-side Conductor recovery commands",
+	}
+	cmd.AddCommand(followerResetReplayStateCmd())
+	return cmd
+}
+
+type followerResetReplayOptions struct {
+	stateDir       string
+	confirm        bool
+	licenseCRLFile string
+}
+
+func followerResetReplayStateCmd() *cobra.Command {
+	opts := followerResetReplayOptions{}
+	cmd := &cobra.Command{
+		Use:   "reset-replay-state",
+		Short: "Reset a follower's local remote-kill replay state to a clean baseline (offline recovery)",
+		Long: `reset-replay-state rewrites the follower's local remote-kill replay state
+under --state-dir to a clean, no-decision baseline so a wedged follower can start.
+
+A follower that enrolled but has no valid replay state fails closed at startup
+with "conductor remote kill replay state missing while follower context is
+present". This is the explicit reset that error refers to. It writes a baseline
+with counter 0 and no kill decision; the follower then boots and re-fetches the
+authoritative kill state from the Conductor on its next poll, so a genuinely
+active fleet kill is restored (its counter exceeds 0).
+
+Safety posture (mirrors 'conductor store repair'):
+  - Without --confirm the command is a DRY RUN: it reports what it would write
+    and changes nothing.
+  - With --confirm it overwrites the local replay state. This deliberately resets
+    local replay protection to 0; only run it as an operator recovering a wedged
+    follower, never on a healthy one.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.licenseCRLFile}); err != nil {
+				return err
+			}
+			return runFollowerResetReplayState(cmd, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.stateDir, "state-dir", "", "follower conductor bundle cache dir (conductor.bundle_cache_dir); the replay state lives here (required)")
+	cmd.Flags().BoolVar(&opts.confirm, "confirm", false, "actually overwrite the replay state; without this the command is a dry run")
+	cmd.Flags().StringVar(&opts.licenseCRLFile, "license-crl-file", "", "signed license revocation list file; falls back to PIPELOCK_LICENSE_CRL_FILE")
+	return cmd
+}
+
+func runFollowerResetReplayState(cmd *cobra.Command, opts followerResetReplayOptions) error {
+	if opts.stateDir == "" {
+		return fmt.Errorf("--state-dir is required")
+	}
+	statePath := filepath.Join(filepath.Clean(opts.stateDir), emergency.RemoteKillStateFileName)
+	out := cmd.OutOrStdout()
+	if !opts.confirm {
+		_, _ = fmt.Fprintf(out, "DRY RUN: would reset remote-kill replay state at %s to a clean baseline (counter 0, no decision).\n", statePath)
+		_, _ = fmt.Fprintln(out, "Re-run with --confirm to apply. The follower will re-sync the authoritative kill state from the Conductor on its next poll.")
+		return nil
+	}
+	if err := emergency.ResetReplayStateToBaseline(statePath, time.Now().UTC()); err != nil {
+		return fmt.Errorf("reset remote-kill replay state: %w", err)
+	}
+	_, _ = fmt.Fprintf(out, "reset remote-kill replay state at %s to a clean baseline; restart the follower if it is wedged.\n", statePath)
+	return nil
+}

--- a/enterprise/cli/conductor/follower_test.go
+++ b/enterprise/cli/conductor/follower_test.go
@@ -25,21 +25,36 @@ func TestFollowerResetReplayState_RequiresStateDir(t *testing.T) {
 	}
 }
 
-func TestFollowerResetReplayState_RequiresStateDirBeforeLicense(t *testing.T) {
-	t.Setenv(license.EnvLicenseKey, "")
-	t.Setenv(license.EnvLicensePublicKey, "")
-	t.Setenv(license.EnvLicenseCRLFile, "")
+func TestFollowerResetReplayState_ErrorPaths(t *testing.T) {
+	t.Run("requires state dir before license", func(t *testing.T) {
+		t.Setenv(license.EnvLicenseKey, "")
+		t.Setenv(license.EnvLicensePublicKey, "")
+		t.Setenv(license.EnvLicenseCRLFile, "")
 
-	cmd := followerResetReplayStateCmd()
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "--state-dir is required") {
-		t.Fatalf("missing --state-dir command error = %v, want required", err)
-	}
-	if errors.Is(err, license.ErrFleetLicenseRequired) {
-		t.Fatalf("missing --state-dir checked license first: %v", err)
-	}
+		cmd := followerResetReplayStateCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--state-dir is required") {
+			t.Fatalf("missing --state-dir command error = %v, want required", err)
+		}
+		if errors.Is(err, license.ErrFleetLicenseRequired) {
+			t.Fatalf("missing --state-dir checked license first: %v", err)
+		}
+	})
+
+	t.Run("confirm surfaces reset error", func(t *testing.T) {
+		dir := t.TempDir()
+		blocker := filepath.Join(dir, "not-a-dir")
+		if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write blocker: %v", err)
+		}
+		cmd := &cobra.Command{}
+		err := runFollowerResetReplayState(cmd, followerResetReplayOptions{stateDir: blocker, confirm: true})
+		if err == nil || !strings.Contains(err.Error(), "reset remote-kill replay state") {
+			t.Fatalf("confirm reset error = %v, want wrapped reset context", err)
+		}
+	})
 }
 
 func TestFollowerResetReplayState_DryRunWritesNothing(t *testing.T) {
@@ -71,18 +86,5 @@ func TestFollowerResetReplayState_ConfirmWritesBaseline(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "reset remote-kill replay state") {
 		t.Fatalf("confirm output = %q, want reset confirmation", out.String())
-	}
-}
-
-func TestFollowerResetReplayState_ConfirmSurfacesResetError(t *testing.T) {
-	dir := t.TempDir()
-	blocker := filepath.Join(dir, "not-a-dir")
-	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
-		t.Fatalf("write blocker: %v", err)
-	}
-	cmd := &cobra.Command{}
-	err := runFollowerResetReplayState(cmd, followerResetReplayOptions{stateDir: blocker, confirm: true})
-	if err == nil || !strings.Contains(err.Error(), "reset remote-kill replay state") {
-		t.Fatalf("confirm reset error = %v, want wrapped reset context", err)
 	}
 }

--- a/enterprise/cli/conductor/follower_test.go
+++ b/enterprise/cli/conductor/follower_test.go
@@ -6,6 +6,7 @@ package conductor
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,12 +15,30 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/emergency"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
 func TestFollowerResetReplayState_RequiresStateDir(t *testing.T) {
 	if err := runFollowerResetReplayState(&cobra.Command{}, followerResetReplayOptions{}); err == nil ||
 		!strings.Contains(err.Error(), "--state-dir is required") {
 		t.Fatalf("missing --state-dir error = %v, want required", err)
+	}
+}
+
+func TestFollowerResetReplayState_RequiresStateDirBeforeLicense(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	t.Setenv(license.EnvLicensePublicKey, "")
+	t.Setenv(license.EnvLicenseCRLFile, "")
+
+	cmd := followerResetReplayStateCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--state-dir is required") {
+		t.Fatalf("missing --state-dir command error = %v, want required", err)
+	}
+	if errors.Is(err, license.ErrFleetLicenseRequired) {
+		t.Fatalf("missing --state-dir checked license first: %v", err)
 	}
 }
 
@@ -52,5 +71,18 @@ func TestFollowerResetReplayState_ConfirmWritesBaseline(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "reset remote-kill replay state") {
 		t.Fatalf("confirm output = %q, want reset confirmation", out.String())
+	}
+}
+
+func TestFollowerResetReplayState_ConfirmSurfacesResetError(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	cmd := &cobra.Command{}
+	err := runFollowerResetReplayState(cmd, followerResetReplayOptions{stateDir: blocker, confirm: true})
+	if err == nil || !strings.Contains(err.Error(), "reset remote-kill replay state") {
+		t.Fatalf("confirm reset error = %v, want wrapped reset context", err)
 	}
 }

--- a/enterprise/cli/conductor/follower_test.go
+++ b/enterprise/cli/conductor/follower_test.go
@@ -1,0 +1,56 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/emergency"
+)
+
+func TestFollowerResetReplayState_RequiresStateDir(t *testing.T) {
+	if err := runFollowerResetReplayState(&cobra.Command{}, followerResetReplayOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "--state-dir is required") {
+		t.Fatalf("missing --state-dir error = %v, want required", err)
+	}
+}
+
+func TestFollowerResetReplayState_DryRunWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runFollowerResetReplayState(cmd, followerResetReplayOptions{stateDir: dir, confirm: false}); err != nil {
+		t.Fatalf("dry run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "DRY RUN") {
+		t.Fatalf("dry-run output = %q, want DRY RUN notice", out.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, emergency.RemoteKillStateFileName)); !os.IsNotExist(err) {
+		t.Fatalf("dry run wrote a state file (stat err=%v), want none", err)
+	}
+}
+
+func TestFollowerResetReplayState_ConfirmWritesBaseline(t *testing.T) {
+	dir := t.TempDir()
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runFollowerResetReplayState(cmd, followerResetReplayOptions{stateDir: dir, confirm: true}); err != nil {
+		t.Fatalf("confirm error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, emergency.RemoteKillStateFileName)); err != nil {
+		t.Fatalf("confirm did not write the baseline state file: %v", err)
+	}
+	if !strings.Contains(out.String(), "reset remote-kill replay state") {
+		t.Fatalf("confirm output = %q, want reset confirmation", out.String())
+	}
+}

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -164,16 +164,6 @@ func (a *RemoteKillApplier) RestorePersistedState() error {
 	if state.LastMessageHash == "" {
 		return nil
 	}
-	// Applying a persisted decision here is BLIND: unlike Apply (which re-verifies a
-	// signed Conductor message before reconciling), RestorePersistedState trusts the
-	// on-disk decision as-is. So the decision MUST be cryptographically bound to this
-	// state path (non-empty context+digest, already validated for match on read by
-	// readOptionalRemoteKillState). An unbound decision could be a forged or copied
-	// state planted to flip or pin a follower's kill switch; refuse it and fail closed.
-	// Recover an over-tight follower with `pipelock conductor follower reset-replay-state`.
-	if state.Context == "" || state.Digest == "" {
-		return fmt.Errorf("conductor remote kill persisted decision is not bound to this follower; refusing to apply unverified state (run an explicit replay-state reset to recover)")
-	}
 	return a.applyPersistedDecisionLocked(state)
 }
 

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -470,3 +470,53 @@ func ResetRemoteKillReplayState(path string, counter uint64, state conductor.Kil
 		AppliedAt:       now.UTC(),
 	})
 }
+
+// InitializeReplayBaseline writes an initial, no-decision remote-kill replay
+// baseline for a freshly enrolled follower that has never received a kill.
+//
+// Why this exists: an enrolled follower is treated as "follower context
+// present" (the enrollment marker sits next to the replay state). On restart,
+// readDurableRemoteKillState refuses to start when that context is present but
+// no replay state exists — a deliberate anti-replay guard against someone
+// deleting the state file to reset the kill counter. A follower that enrolled
+// cleanly but was never killed has no replay state yet, so without this
+// baseline it would wedge (fail closed) on its first restart with no shipped
+// recovery path. Writing the baseline at enrollment closes that gap.
+//
+// The baseline carries counter 0 and an empty LastMessageHash, so
+// RestorePersistedState treats it as "no decision to apply" (boots clean, kill
+// switch untouched) while the first real remote-kill (counter > 0) still
+// advances the replay counter normally.
+//
+// It is replay-safe: if ANY replay state already exists (primary file, anchor,
+// or context) the call is a no-op, so it can never overwrite a real kill
+// decision and reset the counter. A corrupt/unreadable existing state fails
+// loud rather than being silently overwritten.
+func InitializeReplayBaseline(path string, now time.Time) error {
+	canonical := filepath.Clean(path)
+	if _, found, err := readOptionalRemoteKillState(canonical, canonical); err != nil {
+		return err
+	} else if found {
+		return nil
+	}
+	if _, found, err := readOptionalRemoteKillState(remoteKillStateAnchorPath(canonical), canonical); err != nil {
+		return err
+	} else if found {
+		return nil
+	}
+	if found, err := readRemoteKillStateContext(canonical); err != nil {
+		return err
+	} else if found {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return writeRemoteKillState(canonical, remoteKillState{
+		LastCounter:     0,
+		LastMessageHash: "",
+		State:           conductor.KillSwitchInactive,
+		Reason:          "",
+		AppliedAt:       now.UTC(),
+	})
+}

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -164,6 +164,16 @@ func (a *RemoteKillApplier) RestorePersistedState() error {
 	if state.LastMessageHash == "" {
 		return nil
 	}
+	// Applying a persisted decision here is BLIND: unlike Apply (which re-verifies a
+	// signed Conductor message before reconciling), RestorePersistedState trusts the
+	// on-disk decision as-is. So the decision MUST be cryptographically bound to this
+	// state path (non-empty context+digest, already validated for match on read by
+	// readOptionalRemoteKillState). An unbound decision could be a forged or copied
+	// state planted to flip or pin a follower's kill switch; refuse it and fail closed.
+	// Recover an over-tight follower with `pipelock conductor follower reset-replay-state`.
+	if state.Context == "" || state.Digest == "" {
+		return fmt.Errorf("conductor remote kill persisted decision is not bound to this follower; refusing to apply unverified state (run an explicit replay-state reset to recover)")
+	}
 	return a.applyPersistedDecisionLocked(state)
 }
 

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -555,6 +555,12 @@ func writeRemoteKillStateContext(path string) error {
 	return nil
 }
 
+// ResetRemoteKillReplayState writes an unsigned monotonic replay floor.
+//
+// This is not a boot-recovery path for a persisted kill decision: after signed
+// restore hardening, non-empty decisions without SignedMessage intentionally fail
+// RestorePersistedState. Use ResetReplayStateToBaseline for the shipped operator
+// recovery command that lets a wedged follower boot and re-sync from Conductor.
 func ResetRemoteKillReplayState(path string, counter uint64, state conductor.KillSwitchState, reason string, now time.Time) error {
 	switch state {
 	case conductor.KillSwitchActive, conductor.KillSwitchInactive:

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -509,6 +509,30 @@ func InitializeReplayBaseline(path string, now time.Time) error {
 	} else if found {
 		return nil
 	}
+	return writeReplayBaseline(canonical, now)
+}
+
+// ResetReplayStateToBaseline force-writes a clean, no-decision replay baseline,
+// OVERWRITING any existing remote-kill replay state. It is the explicit operator
+// recovery for a follower that cannot start because it is enrolled but its replay
+// state is missing or partial ("replay state missing while follower context is
+// present") and there is otherwise no shipped way out.
+//
+// Unlike InitializeReplayBaseline this is intentionally NOT replay-safe on its own:
+// it resets the local replay counter to 0. That is acceptable ONLY as a deliberate,
+// operator-invoked action because the Conductor remains the source of truth — on the
+// next poll the follower re-fetches and re-applies the authoritative kill state
+// (whose counter exceeds 0), so a genuinely-active fleet kill is restored. Callers
+// MUST gate this behind an explicit operator command, never an automatic path.
+func ResetReplayStateToBaseline(path string, now time.Time) error {
+	return writeReplayBaseline(filepath.Clean(path), now)
+}
+
+// writeReplayBaseline writes the canonical no-decision baseline (counter 0, empty
+// message hash, inactive) bound to path. RestorePersistedState treats the empty
+// hash as "no decision to apply" so the follower boots clean, and the first real
+// remote-kill (counter > 0) still advances normally.
+func writeReplayBaseline(canonical string, now time.Time) error {
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -6,6 +6,7 @@
 package emergency
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -47,8 +48,14 @@ type remoteKillState struct {
 	State           conductor.KillSwitchState `json:"state"`
 	Reason          string                    `json:"reason"`
 	AppliedAt       time.Time                 `json:"applied_at"`
-	Context         string                    `json:"context,omitempty"`
-	Digest          string                    `json:"digest,omitempty"`
+	// SignedMessage is the canonical JSON of the signed Conductor
+	// RemoteKillMessage that authorized this decision. It is re-verified against
+	// the trust roster on restore, so a persisted decision cannot be forged by an
+	// attacker who can write the (non-secret) replay-state binding. Empty only for
+	// the no-decision baseline (LastMessageHash == "").
+	SignedMessage json.RawMessage `json:"signed_message,omitempty"`
+	Context       string          `json:"context,omitempty"`
+	Digest        string          `json:"digest,omitempty"`
 }
 
 type remoteKillStateContext struct {
@@ -84,10 +91,7 @@ func (a *RemoteKillApplier) Apply(msg conductor.RemoteKillMessage) error {
 	if a.StatePath == "" {
 		return ErrRemoteKillStateRequired
 	}
-	now := time.Now().UTC()
-	if a.Now != nil {
-		now = a.Now().UTC()
-	}
+	now := a.nowUTC()
 	if a.DisableRemoteKill {
 		a.logReject("disabled", ErrRemoteKillDisabled)
 		return ErrRemoteKillDisabled
@@ -108,6 +112,12 @@ func (a *RemoteKillApplier) Apply(msg conductor.RemoteKillMessage) error {
 	if err != nil {
 		return err
 	}
+	// Persist the just-verified signed message so the decision can be
+	// re-verified against the trust roster on restart (anti-forgery).
+	signedJSON, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal verified conductor remote kill message: %w", err)
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	state, err := readDurableRemoteKillState(a.StatePath)
@@ -115,25 +125,23 @@ func (a *RemoteKillApplier) Apply(msg conductor.RemoteKillMessage) error {
 		return err
 	}
 	if hash == state.LastMessageHash {
-		switch state.State {
-		case conductor.KillSwitchActive, conductor.KillSwitchInactive:
-			return a.applyPersistedDecisionLocked(state)
-		default:
-			a.KillSwitch.SetConductorRemote(msg.State == conductor.KillSwitchActive, msg.Reason)
-			return writeRemoteKillState(a.StatePath, remoteKillState{
-				LastCounter:     msg.Counter,
-				LastMessageHash: hash,
-				State:           msg.State,
-				Reason:          msg.Reason,
-				AppliedAt:       now,
-			})
-		}
+		// Idempotent re-apply (also backfills legacy/loose persisted state): the
+		// incoming message was just signature-verified above, so re-apply it and
+		// persist the signed message so a later restart re-verifies it.
+		return a.applyAndPersistLocked(msg, hash, signedJSON, now)
 	}
 	if msg.Counter <= state.LastCounter {
 		err := fmt.Errorf("%w: counter=%d last=%d", ErrRemoteKillSuperseded, msg.Counter, state.LastCounter)
 		a.logReject("stale_counter", err)
 		return err
 	}
+	return a.applyAndPersistLocked(msg, hash, signedJSON, now)
+}
+
+// applyAndPersistLocked applies a freshly signature-verified message to the kill
+// switch and persists the decision together with its signed message. Callers MUST
+// hold a.mu and MUST have verified msg before calling.
+func (a *RemoteKillApplier) applyAndPersistLocked(msg conductor.RemoteKillMessage, hash string, signedJSON json.RawMessage, now time.Time) error {
 	a.KillSwitch.SetConductorRemote(msg.State == conductor.KillSwitchActive, msg.Reason)
 	return writeRemoteKillState(a.StatePath, remoteKillState{
 		LastCounter:     msg.Counter,
@@ -141,7 +149,15 @@ func (a *RemoteKillApplier) Apply(msg conductor.RemoteKillMessage) error {
 		State:           msg.State,
 		Reason:          msg.Reason,
 		AppliedAt:       now,
+		SignedMessage:   signedJSON,
 	})
+}
+
+func (a *RemoteKillApplier) nowUTC() time.Time {
+	if a.Now != nil {
+		return a.Now().UTC()
+	}
+	return time.Now().UTC()
 }
 
 func (a *RemoteKillApplier) RestorePersistedState() error {
@@ -178,7 +194,51 @@ func (a *RemoteKillApplier) applyPersistedDecisionLocked(state remoteKillState) 
 	if len(state.Reason) > conductor.MaxReasonBytes {
 		return fmt.Errorf("invalid conductor remote kill persisted reason: %d bytes > cap %d", len(state.Reason), conductor.MaxReasonBytes)
 	}
-	a.KillSwitch.SetConductorRemote(state.State == conductor.KillSwitchActive, state.Reason)
+	// A persisted decision MUST be backed by a re-verifiable signed Conductor
+	// message. The replay-state Context/Digest binding is deterministic and
+	// non-secret, so without re-verification an attacker who can write the
+	// follower replay-state dir could forge a decision and flip (or pin) the kill
+	// switch on restart. Re-verify the signature against the trust roster and fail
+	// CLOSED on any mismatch; the operator recovers with
+	// `conductor follower reset-replay-state`.
+	//
+	// Residual (documented, not closed here): an attacker with replay-state write
+	// access who also possesses a genuine OLDER signed resume (inactive) message
+	// could roll the persisted state back to it; it re-verifies. This is bounded —
+	// the live poller re-fetches the authoritative higher-counter state and
+	// re-asserts within one poll interval — and write access to pipelock's own
+	// state store already implies host compromise. The signature requirement
+	// closes the trivial, total, no-message-needed forgery.
+	if len(state.SignedMessage) == 0 {
+		return errors.New("conductor remote kill persisted decision is not backed by a signed message; refusing to apply unauthenticated kill state (run conductor follower reset-replay-state)")
+	}
+	if a.Resolver == nil {
+		return errors.New("conductor remote kill applier resolver required to verify persisted decision")
+	}
+	var msg conductor.RemoteKillMessage
+	if err := json.Unmarshal(state.SignedMessage, &msg); err != nil {
+		return fmt.Errorf("decode persisted conductor remote kill message: %w", err)
+	}
+	now := a.nowUTC()
+	if err := msg.VerifySignaturesAt(now, a.Resolver); err != nil {
+		a.logReject("persisted_signature", err)
+		return fmt.Errorf("verify persisted conductor remote kill signature: %w", err)
+	}
+	if err := msg.ValidateForFollower(a.OrgID, a.FleetID, a.InstanceID, a.Labels); err != nil {
+		a.logReject("persisted_audience", err)
+		return fmt.Errorf("verify persisted conductor remote kill audience: %w", err)
+	}
+	hash, err := msg.CanonicalHash()
+	if err != nil {
+		return err
+	}
+	// The signed message must match the persisted decision it claims to authorize;
+	// otherwise an attacker could pair a valid signed message with a different
+	// on-disk State/Counter/Reason.
+	if hash != state.LastMessageHash || msg.State != state.State || msg.Counter != state.LastCounter || msg.Reason != state.Reason {
+		return errors.New("persisted conductor remote kill decision does not match its signed message")
+	}
+	a.KillSwitch.SetConductorRemote(msg.State == conductor.KillSwitchActive, msg.Reason)
 	return nil
 }
 
@@ -254,14 +314,32 @@ func remoteKillContextID(path string) string {
 }
 
 func remoteKillDigest(path string, state remoteKillState) string {
-	sum := sha256.Sum256([]byte(fmt.Sprintf("remote-kill-replay-v1\n%s\n%d\n%s\n%s\n%s\n%s",
+	sum := sha256.Sum256([]byte(fmt.Sprintf("remote-kill-replay-v1\n%s\n%d\n%s\n%s\n%s\n%s\n%s",
 		remoteKillContextID(path),
 		state.LastCounter,
 		state.LastMessageHash,
 		state.State,
 		state.Reason,
 		state.AppliedAt.UTC().Format(time.RFC3339Nano),
+		signedMessageDigest(state.SignedMessage),
 	)))
+	return hex.EncodeToString(sum[:])
+}
+
+// signedMessageDigest hashes the signed message in a whitespace-invariant way.
+// json.MarshalIndent re-indents an embedded json.RawMessage when writing the
+// state file, so the bytes differ from the compact form passed in; compacting
+// first keeps the digest stable across the write/read round-trip.
+func signedMessageDigest(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, b); err != nil {
+		sum := sha256.Sum256(b)
+		return hex.EncodeToString(sum[:])
+	}
+	sum := sha256.Sum256(buf.Bytes())
 	return hex.EncodeToString(sum[:])
 }
 
@@ -348,7 +426,8 @@ func remoteKillStatesEqual(a, b remoteKillState) bool {
 		a.LastMessageHash == b.LastMessageHash &&
 		a.State == b.State &&
 		a.Reason == b.Reason &&
-		a.AppliedAt.Equal(b.AppliedAt)
+		a.AppliedAt.Equal(b.AppliedAt) &&
+		bytes.Equal(a.SignedMessage, b.SignedMessage)
 }
 
 func withRemoteKillStateLock(path string, fn func(canonical string) error) error {

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -266,12 +266,22 @@ func remoteKillDigest(path string, state remoteKillState) string {
 }
 
 func readDurableRemoteKillState(path string) (remoteKillState, error) {
-	canonical := filepath.Clean(path)
+	var state remoteKillState
+	err := withRemoteKillStateLock(path, func(canonical string) error {
+		var err error
+		state, err = readDurableRemoteKillStateLocked(canonical)
+		return err
+	})
+	return state, err
+}
+
+func readDurableRemoteKillStateLocked(canonical string) (remoteKillState, error) {
 	primary, primaryFound, err := readOptionalRemoteKillState(canonical, canonical)
 	if err != nil {
 		return remoteKillState{}, err
 	}
-	anchor, anchorFound, err := readOptionalRemoteKillState(remoteKillStateAnchorPath(path), canonical)
+	anchorPath := remoteKillStateAnchorPath(canonical)
+	anchor, anchorFound, err := readOptionalRemoteKillState(anchorPath, canonical)
 	if err != nil {
 		return remoteKillState{}, err
 	}
@@ -282,10 +292,10 @@ func readDurableRemoteKillState(path string) (remoteKillState, error) {
 		}
 		return primary, nil
 	case primaryFound:
-		if err := writeRemoteKillStateFileForContext(remoteKillStateAnchorPath(path), canonical, primary); err != nil {
+		if err := writeRemoteKillStateFileForContext(anchorPath, canonical, primary); err != nil {
 			return remoteKillState{}, fmt.Errorf("backfill conductor remote kill state anchor: %w", err)
 		}
-		if err := writeRemoteKillStateContext(path); err != nil {
+		if err := writeRemoteKillStateContext(canonical); err != nil {
 			return remoteKillState{}, fmt.Errorf("backfill conductor remote kill state context: %w", err)
 		}
 		return primary, nil
@@ -293,12 +303,12 @@ func readDurableRemoteKillState(path string) (remoteKillState, error) {
 		if err := writeRemoteKillStateFileForContext(canonical, canonical, anchor); err != nil {
 			return remoteKillState{}, fmt.Errorf("restore conductor remote kill state primary: %w", err)
 		}
-		if err := writeRemoteKillStateContext(path); err != nil {
+		if err := writeRemoteKillStateContext(canonical); err != nil {
 			return remoteKillState{}, fmt.Errorf("backfill conductor remote kill state context: %w", err)
 		}
 		return anchor, nil
 	default:
-		contextFound, contextErr := remoteKillReplayContextPresent(path)
+		contextFound, contextErr := remoteKillReplayContextPresent(canonical)
 		if contextErr != nil {
 			return remoteKillState{}, contextErr
 		}

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -120,30 +120,33 @@ func (a *RemoteKillApplier) Apply(msg conductor.RemoteKillMessage) error {
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	state, err := readDurableRemoteKillState(a.StatePath)
-	if err != nil {
-		return err
-	}
-	if hash == state.LastMessageHash {
-		// Idempotent re-apply (also backfills legacy/loose persisted state): the
-		// incoming message was just signature-verified above, so re-apply it and
-		// persist the signed message so a later restart re-verifies it.
-		return a.applyAndPersistLocked(msg, hash, signedJSON, now)
-	}
-	if msg.Counter <= state.LastCounter {
-		err := fmt.Errorf("%w: counter=%d last=%d", ErrRemoteKillSuperseded, msg.Counter, state.LastCounter)
-		a.logReject("stale_counter", err)
-		return err
-	}
-	return a.applyAndPersistLocked(msg, hash, signedJSON, now)
+	return withRemoteKillStateLock(a.StatePath, func(canonical string) error {
+		state, err := readDurableRemoteKillStateLocked(canonical)
+		if err != nil {
+			return err
+		}
+		if hash == state.LastMessageHash {
+			// Idempotent re-apply (also backfills legacy/loose persisted state): the
+			// incoming message was just signature-verified above, so re-apply it and
+			// persist the signed message so a later restart re-verifies it.
+			return a.applyAndPersistLocked(canonical, msg, hash, signedJSON, now)
+		}
+		if msg.Counter <= state.LastCounter {
+			err := fmt.Errorf("%w: counter=%d last=%d", ErrRemoteKillSuperseded, msg.Counter, state.LastCounter)
+			a.logReject("stale_counter", err)
+			return err
+		}
+		return a.applyAndPersistLocked(canonical, msg, hash, signedJSON, now)
+	})
 }
 
 // applyAndPersistLocked applies a freshly signature-verified message to the kill
-// switch and persists the decision together with its signed message. Callers MUST
-// hold a.mu and MUST have verified msg before calling.
-func (a *RemoteKillApplier) applyAndPersistLocked(msg conductor.RemoteKillMessage, hash string, signedJSON json.RawMessage, now time.Time) error {
+// switch and persists the decision together with its signed message. Callers
+// MUST hold a.mu and the per-path remote-kill state lock, and MUST have verified
+// msg before calling.
+func (a *RemoteKillApplier) applyAndPersistLocked(canonical string, msg conductor.RemoteKillMessage, hash string, signedJSON json.RawMessage, now time.Time) error {
 	a.KillSwitch.SetConductorRemote(msg.State == conductor.KillSwitchActive, msg.Reason)
-	return writeRemoteKillState(a.StatePath, remoteKillState{
+	return writeRemoteKillStateLocked(canonical, remoteKillState{
 		LastCounter:     msg.Counter,
 		LastMessageHash: hash,
 		State:           msg.State,
@@ -175,14 +178,16 @@ func (a *RemoteKillApplier) RestorePersistedState() error {
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	state, err := readDurableRemoteKillState(a.StatePath)
-	if err != nil {
-		return err
-	}
-	if state.LastMessageHash == "" {
-		return nil
-	}
-	return a.applyPersistedDecisionLocked(state)
+	return withRemoteKillStateLock(a.StatePath, func(canonical string) error {
+		state, err := readDurableRemoteKillStateLocked(canonical)
+		if err != nil {
+			return err
+		}
+		if state.LastMessageHash == "" {
+			return nil
+		}
+		return a.applyPersistedDecisionLocked(state)
+	})
 }
 
 func (a *RemoteKillApplier) applyPersistedDecisionLocked(state remoteKillState) error {

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -26,6 +26,8 @@ var (
 	ErrRemoteKillSuperseded    = errors.New("conductor remote kill message superseded")
 	ErrRemoteKillStateRequired = errors.New("conductor remote kill replay state path required")
 	ErrRemoteKillStateMismatch = errors.New("conductor remote kill replay state mismatch")
+
+	remoteKillStateLocks sync.Map
 )
 
 const (
@@ -339,15 +341,29 @@ func remoteKillStatesEqual(a, b remoteKillState) bool {
 		a.AppliedAt.Equal(b.AppliedAt)
 }
 
-func writeRemoteKillState(path string, state remoteKillState) error {
+func withRemoteKillStateLock(path string, fn func(canonical string) error) error {
 	canonical := filepath.Clean(path)
+	value, _ := remoteKillStateLocks.LoadOrStore(canonical, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
+	return fn(canonical)
+}
+
+func writeRemoteKillState(path string, state remoteKillState) error {
+	return withRemoteKillStateLock(path, func(canonical string) error {
+		return writeRemoteKillStateLocked(canonical, state)
+	})
+}
+
+func writeRemoteKillStateLocked(canonical string, state remoteKillState) error {
 	if err := writeRemoteKillStateFileForContext(canonical, canonical, state); err != nil {
 		return err
 	}
-	if err := writeRemoteKillStateFileForContext(remoteKillStateAnchorPath(path), canonical, state); err != nil {
+	if err := writeRemoteKillStateFileForContext(remoteKillStateAnchorPath(canonical), canonical, state); err != nil {
 		return err
 	}
-	if err := writeRemoteKillStateContext(path); err != nil {
+	if err := writeRemoteKillStateContext(canonical); err != nil {
 		return err
 	}
 	return nil
@@ -493,23 +509,24 @@ func ResetRemoteKillReplayState(path string, counter uint64, state conductor.Kil
 // decision and reset the counter. A corrupt/unreadable existing state fails
 // loud rather than being silently overwritten.
 func InitializeReplayBaseline(path string, now time.Time) error {
-	canonical := filepath.Clean(path)
-	if _, found, err := readOptionalRemoteKillState(canonical, canonical); err != nil {
-		return err
-	} else if found {
-		return nil
-	}
-	if _, found, err := readOptionalRemoteKillState(remoteKillStateAnchorPath(canonical), canonical); err != nil {
-		return err
-	} else if found {
-		return nil
-	}
-	if found, err := readRemoteKillStateContext(canonical); err != nil {
-		return err
-	} else if found {
-		return nil
-	}
-	return writeReplayBaseline(canonical, now)
+	return withRemoteKillStateLock(path, func(canonical string) error {
+		if _, found, err := readOptionalRemoteKillState(canonical, canonical); err != nil {
+			return err
+		} else if found {
+			return nil
+		}
+		if _, found, err := readOptionalRemoteKillState(remoteKillStateAnchorPath(canonical), canonical); err != nil {
+			return err
+		} else if found {
+			return nil
+		}
+		if found, err := readRemoteKillStateContext(canonical); err != nil {
+			return err
+		} else if found {
+			return nil
+		}
+		return writeReplayBaselineLocked(canonical, now)
+	})
 }
 
 // ResetReplayStateToBaseline force-writes a clean, no-decision replay baseline,
@@ -533,10 +550,16 @@ func ResetReplayStateToBaseline(path string, now time.Time) error {
 // hash as "no decision to apply" so the follower boots clean, and the first real
 // remote-kill (counter > 0) still advances normally.
 func writeReplayBaseline(canonical string, now time.Time) error {
+	return withRemoteKillStateLock(canonical, func(canonical string) error {
+		return writeReplayBaselineLocked(canonical, now)
+	})
+}
+
+func writeReplayBaselineLocked(canonical string, now time.Time) error {
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
-	return writeRemoteKillState(canonical, remoteKillState{
+	return writeRemoteKillStateLocked(canonical, remoteKillState{
 		LastCounter:     0,
 		LastMessageHash: "",
 		State:           conductor.KillSwitchInactive,

--- a/enterprise/conductor/emergency/remote_kill_baseline_test.go
+++ b/enterprise/conductor/emergency/remote_kill_baseline_test.go
@@ -1,0 +1,131 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package emergency
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+)
+
+// writeEnrolledMarker drops a minimal enrollment marker next to the replay
+// state path, reproducing the on-disk shape of a follower that has enrolled.
+func writeEnrolledMarker(t *testing.T, statePath string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(filepath.Dir(statePath), "enrolled.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write enrolled.json: %v", err)
+	}
+}
+
+// TestEnrolledFollowerWithoutBaselineWedges documents the bug: a follower that
+// has enrolled (marker present) but never received a kill (no replay state)
+// fails closed on restart with no recovery path. This is the failure the
+// InitializeReplayBaseline fix prevents.
+func TestEnrolledFollowerWithoutBaselineWedges(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
+	writeEnrolledMarker(t, statePath)
+
+	applier := &RemoteKillApplier{KillSwitch: &captureKillSwitch{}, StatePath: statePath}
+	err := applier.RestorePersistedState()
+	if err == nil || !strings.Contains(err.Error(), "replay state missing while follower context is present") {
+		t.Fatalf("RestorePersistedState() error = %v, want enrolled-without-baseline wedge", err)
+	}
+}
+
+// TestInitializeReplayBaselinePreventsRestartWedge proves the fix: after the
+// baseline is written at enrollment, an enrolled follower restarts cleanly and
+// the kill switch stays inactive (no spurious kill from the baseline).
+func TestInitializeReplayBaselinePreventsRestartWedge(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
+	writeEnrolledMarker(t, statePath)
+
+	if err := InitializeReplayBaseline(statePath, testNow); err != nil {
+		t.Fatalf("InitializeReplayBaseline: %v", err)
+	}
+
+	ks := &captureKillSwitch{}
+	applier := &RemoteKillApplier{KillSwitch: ks, StatePath: statePath}
+	if err := applier.RestorePersistedState(); err != nil {
+		t.Fatalf("RestorePersistedState() after baseline error = %v, want nil", err)
+	}
+	if ks.active {
+		t.Fatalf("kill switch active after baseline restore, want inactive")
+	}
+
+	// The baseline is counter 0 / no decision, so the first real remote-kill
+	// (counter > 0) still advances normally — equivalent to a never-enrolled
+	// fresh follower, which the existing Apply tests already cover.
+	st, err := readRemoteKillStateFile(statePath)
+	if err != nil {
+		t.Fatalf("readRemoteKillStateFile: %v", err)
+	}
+	if st.LastCounter != 0 || st.LastMessageHash != "" || st.State != conductor.KillSwitchInactive {
+		t.Fatalf("baseline = counter=%d hash=%q state=%q, want 0/empty/inactive", st.LastCounter, st.LastMessageHash, st.State)
+	}
+}
+
+// TestInitializeReplayBaselineDoesNotClobberExistingState is the replay-safety
+// guard: if a real kill decision already exists, the baseline call must be a
+// no-op. Overwriting it would reset the replay counter — a kill-switch replay
+// hole.
+func TestInitializeReplayBaselineDoesNotClobberExistingState(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
+	if err := writeRemoteKillState(statePath, remoteKillState{
+		LastCounter:     9,
+		LastMessageHash: strings.Repeat("b", 64),
+		State:           conductor.KillSwitchActive,
+		Reason:          "real kill",
+		AppliedAt:       testNow,
+	}); err != nil {
+		t.Fatalf("writeRemoteKillState: %v", err)
+	}
+
+	if err := InitializeReplayBaseline(statePath, testNow.Add(time.Hour)); err != nil {
+		t.Fatalf("InitializeReplayBaseline: %v", err)
+	}
+
+	st, err := readRemoteKillStateFile(statePath)
+	if err != nil {
+		t.Fatalf("readRemoteKillStateFile: %v", err)
+	}
+	if st.LastCounter != 9 || st.State != conductor.KillSwitchActive || st.Reason != "real kill" {
+		t.Fatalf("existing kill state clobbered: counter=%d state=%q reason=%q", st.LastCounter, st.State, st.Reason)
+	}
+
+	ks := &captureKillSwitch{}
+	applier := &RemoteKillApplier{KillSwitch: ks, StatePath: statePath}
+	if err := applier.RestorePersistedState(); err != nil {
+		t.Fatalf("RestorePersistedState: %v", err)
+	}
+	if !ks.active || ks.message != "real kill" {
+		t.Fatalf("restored kill switch = active=%v message=%q, want preserved active kill", ks.active, ks.message)
+	}
+}
+
+// TestInitializeReplayBaselineIdempotent: a second call is a no-op and never
+// errors, so repeated enrollment attempts cannot reset the counter.
+func TestInitializeReplayBaselineIdempotent(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
+	writeEnrolledMarker(t, statePath)
+
+	if err := InitializeReplayBaseline(statePath, testNow); err != nil {
+		t.Fatalf("InitializeReplayBaseline (first): %v", err)
+	}
+	if err := InitializeReplayBaseline(statePath, testNow.Add(time.Hour)); err != nil {
+		t.Fatalf("InitializeReplayBaseline (second): %v", err)
+	}
+
+	st, err := readRemoteKillStateFile(statePath)
+	if err != nil {
+		t.Fatalf("readRemoteKillStateFile: %v", err)
+	}
+	if st.LastCounter != 0 || st.LastMessageHash != "" || st.State != conductor.KillSwitchInactive {
+		t.Fatalf("baseline drifted after second call: counter=%d hash=%q state=%q", st.LastCounter, st.LastMessageHash, st.State)
+	}
+}

--- a/enterprise/conductor/emergency/remote_kill_baseline_test.go
+++ b/enterprise/conductor/emergency/remote_kill_baseline_test.go
@@ -76,15 +76,19 @@ func TestInitializeReplayBaselinePreventsRestartWedge(t *testing.T) {
 // no-op. Overwriting it would reset the replay counter — a kill-switch replay
 // hole.
 func TestInitializeReplayBaselineDoesNotClobberExistingState(t *testing.T) {
+	msg, resolver := signedRemoteKill(t, 9, conductor.KillSwitchActive)
 	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
-	if err := writeRemoteKillState(statePath, remoteKillState{
-		LastCounter:     9,
-		LastMessageHash: strings.Repeat("b", 64),
-		State:           conductor.KillSwitchActive,
-		Reason:          "real kill",
-		AppliedAt:       testNow,
-	}); err != nil {
-		t.Fatalf("writeRemoteKillState: %v", err)
+	// A real, signature-verified kill decision already exists.
+	if err := (&RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   resolver,
+		KillSwitch: &captureKillSwitch{},
+		StatePath:  statePath,
+		Now:        func() time.Time { return testNow },
+	}).Apply(msg); err != nil {
+		t.Fatalf("Apply(existing kill): %v", err)
 	}
 
 	if err := InitializeReplayBaseline(statePath, testNow.Add(time.Hour)); err != nil {
@@ -95,16 +99,24 @@ func TestInitializeReplayBaselineDoesNotClobberExistingState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("readRemoteKillStateFile: %v", err)
 	}
-	if st.LastCounter != 9 || st.State != conductor.KillSwitchActive || st.Reason != "real kill" {
+	if st.LastCounter != 9 || st.State != conductor.KillSwitchActive || st.Reason != msg.Reason {
 		t.Fatalf("existing kill state clobbered: counter=%d state=%q reason=%q", st.LastCounter, st.State, st.Reason)
 	}
 
 	ks := &captureKillSwitch{}
-	applier := &RemoteKillApplier{KillSwitch: ks, StatePath: statePath}
+	applier := &RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   resolver,
+		KillSwitch: ks,
+		StatePath:  statePath,
+		Now:        func() time.Time { return testNow },
+	}
 	if err := applier.RestorePersistedState(); err != nil {
 		t.Fatalf("RestorePersistedState: %v", err)
 	}
-	if !ks.active || ks.message != "real kill" {
+	if !ks.active || ks.message != msg.Reason {
 		t.Fatalf("restored kill switch = active=%v message=%q, want preserved active kill", ks.active, ks.message)
 	}
 }

--- a/enterprise/conductor/emergency/remote_kill_baseline_test.go
+++ b/enterprise/conductor/emergency/remote_kill_baseline_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -166,5 +167,54 @@ func TestInitializeReplayBaselineIdempotent(t *testing.T) {
 	}
 	if st.LastCounter != 0 || st.LastMessageHash != "" || st.State != conductor.KillSwitchInactive {
 		t.Fatalf("baseline drifted after second call: counter=%d hash=%q state=%q", st.LastCounter, st.LastMessageHash, st.State)
+	}
+}
+
+func TestInitializeReplayBaselineConcurrentApplyPreservesKillState(t *testing.T) {
+	msg, resolver := signedRemoteKill(t, 17, conductor.KillSwitchActive)
+	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
+	writeEnrolledMarker(t, statePath)
+
+	start := make(chan struct{})
+	errs := make(chan error, 17)
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- InitializeReplayBaseline(statePath, testNow)
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		applier := &RemoteKillApplier{
+			OrgID:      "org-main",
+			FleetID:    "prod",
+			InstanceID: "pl-prod-1",
+			Resolver:   resolver,
+			KillSwitch: &captureKillSwitch{},
+			StatePath:  statePath,
+			Now:        func() time.Time { return testNow },
+		}
+		errs <- applier.Apply(msg)
+	}()
+
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent baseline/apply error = %v", err)
+		}
+	}
+	st, err := readDurableRemoteKillState(statePath)
+	if err != nil {
+		t.Fatalf("readDurableRemoteKillState: %v", err)
+	}
+	if st.LastCounter != msg.Counter || st.State != conductor.KillSwitchActive || st.Reason != msg.Reason {
+		t.Fatalf("state after concurrent baseline/apply = counter=%d state=%q reason=%q, want applied kill", st.LastCounter, st.State, st.Reason)
 	}
 }

--- a/enterprise/conductor/emergency/remote_kill_baseline_test.go
+++ b/enterprise/conductor/emergency/remote_kill_baseline_test.go
@@ -108,6 +108,45 @@ func TestInitializeReplayBaselineDoesNotClobberExistingState(t *testing.T) {
 	}
 }
 
+// TestResetReplayStateToBaseline is the operator recovery: force-overwrite an
+// existing (even active-kill) replay state with a clean baseline so a wedged
+// follower can boot. The Conductor re-syncs the authoritative state on next poll.
+func TestResetReplayStateToBaseline(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
+	// Pre-existing active kill state (the thing the operator is deliberately resetting).
+	if err := writeRemoteKillState(statePath, remoteKillState{
+		LastCounter:     5,
+		LastMessageHash: strings.Repeat("c", 64),
+		State:           conductor.KillSwitchActive,
+		Reason:          "stuck kill",
+		AppliedAt:       testNow,
+	}); err != nil {
+		t.Fatalf("writeRemoteKillState: %v", err)
+	}
+
+	if err := ResetReplayStateToBaseline(statePath, testNow.Add(time.Hour)); err != nil {
+		t.Fatalf("ResetReplayStateToBaseline: %v", err)
+	}
+
+	st, err := readRemoteKillStateFile(statePath)
+	if err != nil {
+		t.Fatalf("readRemoteKillStateFile: %v", err)
+	}
+	if st.LastCounter != 0 || st.LastMessageHash != "" || st.State != conductor.KillSwitchInactive {
+		t.Fatalf("reset baseline = counter=%d hash=%q state=%q, want 0/empty/inactive", st.LastCounter, st.LastMessageHash, st.State)
+	}
+
+	// The follower now boots clean (no wedge, kill switch not spuriously active).
+	ks := &captureKillSwitch{}
+	applier := &RemoteKillApplier{KillSwitch: ks, StatePath: statePath}
+	if err := applier.RestorePersistedState(); err != nil {
+		t.Fatalf("RestorePersistedState() after reset error = %v, want nil", err)
+	}
+	if ks.active {
+		t.Fatal("kill switch active after reset-to-baseline, want inactive (re-sync from Conductor restores a live kill)")
+	}
+}
+
 // TestInitializeReplayBaselineIdempotent: a second call is a no-op and never
 // errors, so repeated enrollment attempts cannot reset the counter.
 func TestInitializeReplayBaselineIdempotent(t *testing.T) {

--- a/enterprise/conductor/emergency/remote_kill_baseline_test.go
+++ b/enterprise/conductor/emergency/remote_kill_baseline_test.go
@@ -5,6 +5,7 @@
 package emergency
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,6 +106,38 @@ func TestInitializeReplayBaselineDoesNotClobberExistingState(t *testing.T) {
 	}
 	if !ks.active || ks.message != "real kill" {
 		t.Fatalf("restored kill switch = active=%v message=%q, want preserved active kill", ks.active, ks.message)
+	}
+}
+
+// TestRestorePersistedStateRefusesUnboundDecision (G6): RestorePersistedState
+// applies a persisted decision BLINDLY (no signed message to re-verify against),
+// so it must refuse an UNBOUND decision (empty context/digest). Otherwise a forged
+// or copied state planted on the follower's disk could flip its kill switch. The
+// Apply path's legacy reconciliation against a verified message is unaffected.
+func TestRestorePersistedStateRefusesUnboundDecision(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
+	// Hand-crafted unbound state carrying a decision (un-kill): no context, no digest.
+	unbound, err := json.Marshal(map[string]any{
+		"last_counter":      7,
+		"last_message_hash": strings.Repeat("d", 64),
+		"state":             string(conductor.KillSwitchInactive),
+		"applied_at":        testNow,
+	})
+	if err != nil {
+		t.Fatalf("marshal unbound state: %v", err)
+	}
+	if err := os.WriteFile(statePath, unbound, 0o600); err != nil {
+		t.Fatalf("write unbound state: %v", err)
+	}
+
+	ks := &captureKillSwitch{}
+	applier := &RemoteKillApplier{KillSwitch: ks, StatePath: statePath}
+	err = applier.RestorePersistedState()
+	if err == nil || !strings.Contains(err.Error(), "not bound to this follower") {
+		t.Fatalf("RestorePersistedState(unbound decision) error = %v, want refuse-unbound", err)
+	}
+	if ks.active {
+		t.Fatal("kill switch was flipped by an unbound (unverified) decision — replay/forgery hole")
 	}
 }
 

--- a/enterprise/conductor/emergency/remote_kill_baseline_test.go
+++ b/enterprise/conductor/emergency/remote_kill_baseline_test.go
@@ -217,3 +217,62 @@ func TestInitializeReplayBaselineConcurrentApplyPreservesKillState(t *testing.T)
 		t.Fatalf("state after concurrent baseline/apply = counter=%d state=%q reason=%q, want applied kill", st.LastCounter, st.State, st.Reason)
 	}
 }
+
+func TestReadDurableRemoteKillStateConcurrentBackfillAndApply(t *testing.T) {
+	msg, resolver := signedRemoteKill(t, 17, conductor.KillSwitchActive)
+	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
+
+	if err := writeRemoteKillStateFileForContext(statePath, filepath.Clean(statePath), remoteKillState{
+		LastCounter:     11,
+		LastMessageHash: strings.Repeat("d", 64),
+		State:           conductor.KillSwitchInactive,
+		Reason:          "primary only",
+		AppliedAt:       testNow.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("write primary-only remote kill state: %v", err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 17)
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := readDurableRemoteKillState(statePath)
+			errs <- err
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		applier := &RemoteKillApplier{
+			OrgID:      "org-main",
+			FleetID:    "prod",
+			InstanceID: "pl-prod-1",
+			Resolver:   resolver,
+			KillSwitch: &captureKillSwitch{},
+			StatePath:  statePath,
+			Now:        func() time.Time { return testNow },
+		}
+		errs <- applier.Apply(msg)
+	}()
+
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent backfill/apply error = %v", err)
+		}
+	}
+	st, err := readDurableRemoteKillState(statePath)
+	if err != nil {
+		t.Fatalf("readDurableRemoteKillState: %v", err)
+	}
+	if st.LastCounter != msg.Counter || st.State != conductor.KillSwitchActive || st.Reason != msg.Reason {
+		t.Fatalf("state after concurrent backfill/apply = counter=%d state=%q reason=%q, want applied kill", st.LastCounter, st.State, st.Reason)
+	}
+}

--- a/enterprise/conductor/emergency/remote_kill_baseline_test.go
+++ b/enterprise/conductor/emergency/remote_kill_baseline_test.go
@@ -5,7 +5,6 @@
 package emergency
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,38 +105,6 @@ func TestInitializeReplayBaselineDoesNotClobberExistingState(t *testing.T) {
 	}
 	if !ks.active || ks.message != "real kill" {
 		t.Fatalf("restored kill switch = active=%v message=%q, want preserved active kill", ks.active, ks.message)
-	}
-}
-
-// TestRestorePersistedStateRefusesUnboundDecision (G6): RestorePersistedState
-// applies a persisted decision BLINDLY (no signed message to re-verify against),
-// so it must refuse an UNBOUND decision (empty context/digest). Otherwise a forged
-// or copied state planted on the follower's disk could flip its kill switch. The
-// Apply path's legacy reconciliation against a verified message is unaffected.
-func TestRestorePersistedStateRefusesUnboundDecision(t *testing.T) {
-	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
-	// Hand-crafted unbound state carrying a decision (un-kill): no context, no digest.
-	unbound, err := json.Marshal(map[string]any{
-		"last_counter":      7,
-		"last_message_hash": strings.Repeat("d", 64),
-		"state":             string(conductor.KillSwitchInactive),
-		"applied_at":        testNow,
-	})
-	if err != nil {
-		t.Fatalf("marshal unbound state: %v", err)
-	}
-	if err := os.WriteFile(statePath, unbound, 0o600); err != nil {
-		t.Fatalf("write unbound state: %v", err)
-	}
-
-	ks := &captureKillSwitch{}
-	applier := &RemoteKillApplier{KillSwitch: ks, StatePath: statePath}
-	err = applier.RestorePersistedState()
-	if err == nil || !strings.Contains(err.Error(), "not bound to this follower") {
-		t.Fatalf("RestorePersistedState(unbound decision) error = %v, want refuse-unbound", err)
-	}
-	if ks.active {
-		t.Fatal("kill switch was flipped by an unbound (unverified) decision — replay/forgery hole")
 	}
 }
 

--- a/enterprise/conductor/emergency/remote_kill_baseline_test.go
+++ b/enterprise/conductor/emergency/remote_kill_baseline_test.go
@@ -173,7 +173,6 @@ func TestInitializeReplayBaselineIdempotent(t *testing.T) {
 func TestInitializeReplayBaselineConcurrentApplyPreservesKillState(t *testing.T) {
 	msg, resolver := signedRemoteKill(t, 17, conductor.KillSwitchActive)
 	statePath := filepath.Join(t.TempDir(), RemoteKillStateFileName)
-	writeEnrolledMarker(t, statePath)
 
 	start := make(chan struct{})
 	errs := make(chan error, 17)

--- a/enterprise/conductor/emergency/remote_kill_test.go
+++ b/enterprise/conductor/emergency/remote_kill_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,6 +32,17 @@ type captureKillSwitch struct {
 func (c *captureKillSwitch) SetConductorRemote(active bool, message string) {
 	c.active = active
 	c.message = message
+}
+
+type blockingKillSwitch struct {
+	reached chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingKillSwitch) SetConductorRemote(bool, string) {
+	b.once.Do(func() { close(b.reached) })
+	<-b.release
 }
 
 func TestRemoteKillApplier(t *testing.T) {
@@ -380,6 +392,82 @@ func TestRemoteKillApplierRejectsStaleCounter(t *testing.T) {
 	}
 	if err := applier.Apply(msg); !errors.Is(err, ErrRemoteKillSuperseded) {
 		t.Fatalf("Apply(stale counter) error = %v, want ErrRemoteKillSuperseded", err)
+	}
+}
+
+func TestRemoteKillApplierSerializesCounterCheckAcrossInstances(t *testing.T) {
+	lowMsg, lowResolver := signedRemoteKill(t, 11, conductor.KillSwitchActive)
+	highMsg, highResolver := signedRemoteKill(t, 12, conductor.KillSwitchInactive)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	if err := ResetRemoteKillReplayState(statePath, 10, conductor.KillSwitchActive, "operator floor", testNow); err != nil {
+		t.Fatalf("ResetRemoteKillReplayState: %v", err)
+	}
+
+	blockingKS := &blockingKillSwitch{
+		reached: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	lowApplier := &RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   lowResolver,
+		KillSwitch: blockingKS,
+		StatePath:  statePath,
+		Now:        func() time.Time { return testNow },
+	}
+	highApplier := &RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   highResolver,
+		KillSwitch: &captureKillSwitch{},
+		StatePath:  statePath,
+		Now:        func() time.Time { return testNow.Add(time.Second) },
+	}
+
+	lowErr := make(chan error, 1)
+	go func() {
+		lowErr <- lowApplier.Apply(lowMsg)
+	}()
+	select {
+	case <-blockingKS.reached:
+	case <-time.After(time.Second):
+		t.Fatal("lower-counter Apply did not reach kill switch")
+	}
+
+	highErr := make(chan error, 1)
+	go func() {
+		highErr <- highApplier.Apply(highMsg)
+	}()
+	select {
+	case err := <-highErr:
+		close(blockingKS.release)
+		if lowApplyErr := <-lowErr; lowApplyErr != nil {
+			t.Fatalf("lower-counter Apply error after early higher-counter completion = %v", lowApplyErr)
+		}
+		if err != nil {
+			t.Fatalf("higher-counter Apply returned early with error: %v", err)
+		}
+		t.Fatal("higher-counter Apply completed while lower-counter Apply held the replay-state critical section")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(blockingKS.release)
+	if err := <-lowErr; err != nil {
+		t.Fatalf("lower-counter Apply error = %v", err)
+	}
+	if err := <-highErr; err != nil {
+		t.Fatalf("higher-counter Apply error = %v", err)
+	}
+
+	state, err := readDurableRemoteKillState(statePath)
+	if err != nil {
+		t.Fatalf("readDurableRemoteKillState: %v", err)
+	}
+	if state.LastCounter != highMsg.Counter || state.State != highMsg.State || state.Reason != highMsg.Reason {
+		t.Fatalf("state after concurrent appliers = counter=%d state=%q reason=%q, want counter=%d state=%q reason=%q",
+			state.LastCounter, state.State, state.Reason, highMsg.Counter, highMsg.State, highMsg.Reason)
 	}
 }
 

--- a/enterprise/conductor/emergency/remote_kill_test.go
+++ b/enterprise/conductor/emergency/remote_kill_test.go
@@ -511,6 +511,17 @@ func TestResetRemoteKillReplayState(t *testing.T) {
 	if state.LastCounter != 21 || state.State != conductor.KillSwitchInactive || state.Reason != "operator reset after restore" {
 		t.Fatalf("state = %+v, want reset counter/state/reason", state)
 	}
+	err = (&RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		KillSwitch: &captureKillSwitch{},
+		StatePath:  statePath,
+		Now:        func() time.Time { return testNow },
+	}).RestorePersistedState()
+	if err == nil || !strings.Contains(err.Error(), "not backed by a signed message") {
+		t.Fatalf("RestorePersistedState(unsigned reset) error = %v, want signed-message rejection", err)
+	}
 	if err := ResetRemoteKillReplayState(filepath.Join(t.TempDir(), "bad.json"), 0, conductor.KillSwitchInactive, "", testNow); err == nil {
 		t.Fatal("counter 0 reset must fail")
 	}

--- a/enterprise/conductor/emergency/remote_kill_test.go
+++ b/enterprise/conductor/emergency/remote_kill_test.go
@@ -248,25 +248,36 @@ func TestRemoteKillApplierInactiveClearsSource(t *testing.T) {
 }
 
 func TestRemoteKillApplierRestoresPersistedState(t *testing.T) {
+	msg, resolver := signedRemoteKill(t, 12, conductor.KillSwitchActive)
 	statePath := filepath.Join(t.TempDir(), "state.json")
-	if err := writeRemoteKillState(statePath, remoteKillState{
-		LastCounter:     12,
-		LastMessageHash: strings.Repeat("a", 64),
-		State:           conductor.KillSwitchActive,
-		Reason:          "persisted emergency stop",
-		AppliedAt:       testNow.Add(-time.Minute),
-	}); err != nil {
-		t.Fatalf("writeRemoteKillState: %v", err)
+	// Apply persists the signed message alongside the decision.
+	if err := (&RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   resolver,
+		KillSwitch: &captureKillSwitch{},
+		StatePath:  statePath,
+		Now:        func() time.Time { return testNow },
+	}).Apply(msg); err != nil {
+		t.Fatalf("Apply: %v", err)
 	}
+	// A fresh applier (simulating restart) must re-verify the persisted decision
+	// against the trust roster, not blindly trust the on-disk state.
 	ks := &captureKillSwitch{}
 	applier := &RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   resolver,
 		KillSwitch: ks,
 		StatePath:  statePath,
+		Now:        func() time.Time { return testNow },
 	}
 	if err := applier.RestorePersistedState(); err != nil {
 		t.Fatalf("RestorePersistedState() error = %v", err)
 	}
-	if !ks.active || ks.message != "persisted emergency stop" {
+	if !ks.active || ks.message != msg.Reason {
 		t.Fatalf("kill switch = active=%v message=%q, want restored active", ks.active, ks.message)
 	}
 }
@@ -453,25 +464,37 @@ func TestRemoteKillApplierRejectsReplayAfterPrimaryAndSecondaryDeletion(t *testi
 }
 
 func TestRemoteKillRestoreUsesAnchorAfterPrimaryStateDeletion(t *testing.T) {
+	msg, resolver := signedRemoteKill(t, 12, conductor.KillSwitchActive)
 	statePath := filepath.Join(t.TempDir(), "state.json")
-	if err := writeRemoteKillState(statePath, remoteKillState{
-		LastCounter:     12,
-		LastMessageHash: strings.Repeat("a", 64),
-		State:           conductor.KillSwitchActive,
-		Reason:          "persisted emergency stop",
-		AppliedAt:       testNow.Add(-time.Minute),
-	}); err != nil {
-		t.Fatalf("writeRemoteKillState: %v", err)
+	if err := (&RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   resolver,
+		KillSwitch: &captureKillSwitch{},
+		StatePath:  statePath,
+		Now:        func() time.Time { return testNow },
+	}).Apply(msg); err != nil {
+		t.Fatalf("Apply: %v", err)
 	}
 	if err := os.Remove(statePath); err != nil {
 		t.Fatalf("Remove(primary state): %v", err)
 	}
 	ks := &captureKillSwitch{}
-	applier := &RemoteKillApplier{KillSwitch: ks, StatePath: statePath}
+	applier := &RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   resolver,
+		KillSwitch: ks,
+		StatePath:  statePath,
+		Now:        func() time.Time { return testNow },
+	}
+	// Anchor recovery must still re-verify the signed message, not blindly trust it.
 	if err := applier.RestorePersistedState(); err != nil {
 		t.Fatalf("RestorePersistedState(anchor only) error = %v", err)
 	}
-	if !ks.active || ks.message != "persisted emergency stop" {
+	if !ks.active || ks.message != msg.Reason {
 		t.Fatalf("kill switch = active=%v message=%q, want restored active", ks.active, ks.message)
 	}
 }
@@ -537,6 +560,138 @@ func TestRemoteKillApplierBackfillsLegacyStateOnDuplicateHash(t *testing.T) {
 	if state.State != msg.State || state.Reason != msg.Reason || state.LastMessageHash != hash {
 		t.Fatalf("backfilled state = %+v, want state/reason/hash from verified message", state)
 	}
+}
+
+// TestRemoteKillApplier_RejectsForgedPersistedStateOnRestore is the G6 red-team
+// regression. An attacker with write access to the follower replay-state dir can
+// craft a persisted decision (the Context/Digest binding is non-secret and
+// deterministic) that lifts an operator kill or pins one for DoS. On restart the
+// follower must NOT honor a persisted decision that is not backed by a
+// re-verifiable signed Conductor message; it must fail closed and require an
+// explicit operator reset-replay-state.
+func TestRemoteKillApplier_RejectsForgedPersistedStateOnRestore(t *testing.T) {
+	_, resolver := signedRemoteKill(t, 9, conductor.KillSwitchActive)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	// Attacker forges an "inactive" decision (kill lifted) with a valid binding
+	// but no signed message. writeRemoteKillState computes the (non-secret)
+	// Context/Digest exactly as a PVC-write attacker could.
+	if err := writeRemoteKillState(statePath, remoteKillState{
+		LastCounter:     12,
+		LastMessageHash: "forged-by-attacker",
+		State:           conductor.KillSwitchInactive,
+		Reason:          "attacker lifted the kill",
+		AppliedAt:       testNow,
+	}); err != nil {
+		t.Fatalf("writeRemoteKillState(forged): %v", err)
+	}
+	ks := &captureKillSwitch{active: true, message: "real operator kill"}
+	applier := &RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   resolver,
+		KillSwitch: ks,
+		StatePath:  statePath,
+		Now:        func() time.Time { return testNow },
+	}
+	err := applier.RestorePersistedState()
+	if err == nil {
+		t.Fatal("RestorePersistedState() accepted a forged (unsigned) persisted decision; want fail-closed rejection")
+	}
+	if ks.message == "attacker lifted the kill" {
+		t.Fatalf("forged decision was applied to the kill switch: active=%v message=%q", ks.active, ks.message)
+	}
+}
+
+// TestRemoteKillApplier_RejectsTamperedPersistedDecisionOnRestore covers the
+// harder G6 variants: a persisted decision whose on-disk fields were tampered
+// away from the signed message, a signed kill bound to a different follower, and
+// a signed message with a broken signature. All must fail closed on restore.
+func TestRemoteKillApplier_RejectsTamperedPersistedDecisionOnRestore(t *testing.T) {
+	seed := func(t *testing.T) (string, conductor.SignatureKeyResolver) {
+		t.Helper()
+		msg, resolver := signedRemoteKill(t, 9, conductor.KillSwitchActive)
+		statePath := filepath.Join(t.TempDir(), "state.json")
+		if err := (&RemoteKillApplier{
+			OrgID: "org-main", FleetID: "prod", InstanceID: "pl-prod-1",
+			Resolver: resolver, KillSwitch: &captureKillSwitch{}, StatePath: statePath,
+			Now: func() time.Time { return testNow },
+		}).Apply(msg); err != nil {
+			t.Fatalf("seed Apply: %v", err)
+		}
+		return statePath, resolver
+	}
+	rewrite := func(t *testing.T, statePath string, mutate func(*remoteKillState)) {
+		t.Helper()
+		st, err := readDurableRemoteKillState(statePath)
+		if err != nil {
+			t.Fatalf("read seed state: %v", err)
+		}
+		mutate(&st)
+		if err := writeRemoteKillState(statePath, st); err != nil {
+			t.Fatalf("rewrite state: %v", err)
+		}
+	}
+	applier := func(statePath, instanceID string, resolver conductor.SignatureKeyResolver, ks *captureKillSwitch) *RemoteKillApplier {
+		return &RemoteKillApplier{
+			OrgID: "org-main", FleetID: "prod", InstanceID: instanceID,
+			Resolver: resolver, KillSwitch: ks, StatePath: statePath,
+			Now: func() time.Time { return testNow },
+		}
+	}
+
+	t.Run("state flipped to inactive without re-signing", func(t *testing.T) {
+		statePath, resolver := seed(t)
+		rewrite(t, statePath, func(s *remoteKillState) {
+			s.State = conductor.KillSwitchInactive
+			s.Reason = "attacker lifted the kill"
+		})
+		ks := &captureKillSwitch{active: true, message: "real operator kill"}
+		if err := applier(statePath, "pl-prod-1", resolver, ks).RestorePersistedState(); err == nil {
+			t.Fatal("accepted a decision that does not match its signed message")
+		}
+		if ks.message == "attacker lifted the kill" {
+			t.Fatalf("forged decision applied: active=%v message=%q", ks.active, ks.message)
+		}
+	})
+
+	t.Run("signed kill bound to a different follower", func(t *testing.T) {
+		statePath, resolver := seed(t)
+		ks := &captureKillSwitch{}
+		if err := applier(statePath, "pl-prod-OTHER", resolver, ks).RestorePersistedState(); err == nil {
+			t.Fatal("accepted a kill bound to a different follower's audience")
+		}
+	})
+
+	t.Run("broken signature on the persisted message", func(t *testing.T) {
+		statePath, resolver := seed(t)
+		rewrite(t, statePath, func(s *remoteKillState) {
+			var msg conductor.RemoteKillMessage
+			if err := json.Unmarshal(s.SignedMessage, &msg); err != nil {
+				t.Fatalf("unmarshal signed message: %v", err)
+			}
+			for i := range msg.Signatures {
+				msg.Signatures[i].Signature = conductor.SignaturePrefixEd25519 + strings.Repeat("00", ed25519.SignatureSize)
+			}
+			b, err := json.Marshal(msg)
+			if err != nil {
+				t.Fatalf("remarshal tampered message: %v", err)
+			}
+			s.SignedMessage = b
+		})
+		ks := &captureKillSwitch{active: true}
+		if err := applier(statePath, "pl-prod-1", resolver, ks).RestorePersistedState(); err == nil {
+			t.Fatal("accepted a persisted message with an invalid signature")
+		}
+	})
+
+	t.Run("resolver missing cannot apply a persisted decision", func(t *testing.T) {
+		statePath, _ := seed(t)
+		ks := &captureKillSwitch{}
+		if err := applier(statePath, "pl-prod-1", nil, ks).RestorePersistedState(); err == nil {
+			t.Fatal("applied a persisted decision with no resolver to verify it")
+		}
+	})
 }
 
 func signedRemoteKill(t *testing.T, counter uint64, state conductor.KillSwitchState) (conductor.RemoteKillMessage, conductor.SignatureKeyResolver) {

--- a/internal/cli/runtime/conductor_enrollment.go
+++ b/internal/cli/runtime/conductor_enrollment.go
@@ -66,6 +66,9 @@ func runConductorAutoEnroll(ctx context.Context, cfg *config.Config, recPrivKey 
 		return false, err
 	}
 	if marked {
+		if err := initializeConductorReplayBaseline(cfg.Conductor); err != nil {
+			return false, err
+		}
 		return false, nil
 	}
 	token, err := readConductorEnrollmentToken(cfg.Conductor.EnrollmentTokenPath)
@@ -97,19 +100,25 @@ func runConductorAutoEnroll(ctx context.Context, cfg *config.Config, recPrivKey 
 	if err != nil {
 		return false, err
 	}
+	if err := initializeConductorReplayBaseline(cfg.Conductor); err != nil {
+		return false, err
+	}
 	if err := writeConductorEnrollmentMarker(markerPath, resp); err != nil {
 		return false, err
 	}
-	// Write an initial remote-kill replay baseline alongside the enrollment
-	// marker. Without it, this freshly enrolled follower would wedge on its
-	// first restart: the marker counts as "follower context present" but no
-	// replay state exists yet (it is only written on the first remote-kill),
-	// so startup fails closed with no shipped recovery path.
-	baselinePath := filepath.Join(cfg.Conductor.BundleCacheDir, emergency.RemoteKillStateFileName)
-	if err := emergency.InitializeReplayBaseline(baselinePath, time.Now().UTC()); err != nil {
-		return false, fmt.Errorf("initialize conductor remote kill replay baseline: %w", err)
-	}
 	return true, nil
+}
+
+func initializeConductorReplayBaseline(cfg config.Conductor) error {
+	// Write an initial remote-kill replay baseline alongside the enrollment
+	// marker. Without it, a freshly enrolled follower would wedge on restart:
+	// the marker counts as "follower context present", but replay state is only
+	// written on the first remote kill.
+	baselinePath := filepath.Join(cfg.BundleCacheDir, emergency.RemoteKillStateFileName)
+	if err := emergency.InitializeReplayBaseline(baselinePath, time.Now().UTC()); err != nil {
+		return fmt.Errorf("initialize conductor remote kill replay baseline: %w", err)
+	}
+	return nil
 }
 
 func conductorEnrollmentRequired(cfg *config.Config) bool {

--- a/internal/cli/runtime/conductor_enrollment.go
+++ b/internal/cli/runtime/conductor_enrollment.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/emergency"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/enrollmentclient"
 	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -98,6 +99,15 @@ func runConductorAutoEnroll(ctx context.Context, cfg *config.Config, recPrivKey 
 	}
 	if err := writeConductorEnrollmentMarker(markerPath, resp); err != nil {
 		return false, err
+	}
+	// Write an initial remote-kill replay baseline alongside the enrollment
+	// marker. Without it, this freshly enrolled follower would wedge on its
+	// first restart: the marker counts as "follower context present" but no
+	// replay state exists yet (it is only written on the first remote-kill),
+	// so startup fails closed with no shipped recovery path.
+	baselinePath := filepath.Join(cfg.Conductor.BundleCacheDir, emergency.RemoteKillStateFileName)
+	if err := emergency.InitializeReplayBaseline(baselinePath, time.Now().UTC()); err != nil {
+		return false, fmt.Errorf("initialize conductor remote kill replay baseline: %w", err)
 	}
 	return true, nil
 }

--- a/internal/cli/runtime/conductor_enrollment_test.go
+++ b/internal/cli/runtime/conductor_enrollment_test.go
@@ -173,6 +173,15 @@ func TestRunConductorAutoEnrollExistingMarkerSkipsPost(t *testing.T) {
 	if client.count() != 0 {
 		t.Fatalf("request count = %d, want 0", client.count())
 	}
+	baselinePath := filepath.Join(cfg.Conductor.BundleCacheDir, emergency.RemoteKillStateFileName)
+	ks := &stubKillSwitch{}
+	applier := &emergency.RemoteKillApplier{KillSwitch: ks, StatePath: baselinePath}
+	if err := applier.RestorePersistedState(); err != nil {
+		t.Fatalf("RestorePersistedState() after marked baseline retry error = %v, want nil", err)
+	}
+	if ks.active {
+		t.Fatal("kill switch active after marked baseline retry, want inactive")
+	}
 }
 
 func TestRunConductorAutoEnrollStaleMarkerDoesNotSkipPost(t *testing.T) {

--- a/internal/cli/runtime/conductor_enrollment_test.go
+++ b/internal/cli/runtime/conductor_enrollment_test.go
@@ -16,10 +16,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/emergency"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/enrollmentclient"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+// stubKillSwitch satisfies emergency.KillSwitchSetter for restore tests.
+type stubKillSwitch struct {
+	active  bool
+	message string
+}
+
+func (s *stubKillSwitch) SetConductorRemote(active bool, message string) {
+	s.active = active
+	s.message = message
+}
 
 type conductorEnrollmentStubClient struct {
 	mu     sync.Mutex
@@ -375,4 +387,46 @@ func conductorEnrollmentTestConfig(t *testing.T) *config.Config {
 		AuditSigningKeyID:   "audit-key-1",
 		PollInterval:        time.Second.String(),
 	}}
+}
+
+// TestRunConductorAutoEnrollWritesReplayBaseline proves the restart-wedge fix
+// end to end at the runtime layer: a successful auto-enroll writes the initial
+// remote-kill replay baseline next to the enrollment marker, so an enrolled
+// follower that has never received a kill restores cleanly on restart instead
+// of failing closed.
+func TestRunConductorAutoEnrollWritesReplayBaseline(t *testing.T) {
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	cfg := conductorEnrollmentTestConfig(t)
+	client := &conductorEnrollmentStubClient{}
+	enrolled, err := runConductorAutoEnroll(t.Context(), cfg, priv, client)
+	if err != nil {
+		t.Fatalf("runConductorAutoEnroll error = %v", err)
+	}
+	if !enrolled {
+		t.Fatal("runConductorAutoEnroll enrolled=false, want true")
+	}
+
+	baselinePath := filepath.Join(cfg.Conductor.BundleCacheDir, emergency.RemoteKillStateFileName)
+	info, err := os.Stat(baselinePath)
+	if err != nil {
+		t.Fatalf("stat replay baseline: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("replay baseline mode = %v, want 0600", got)
+	}
+
+	// Simulate the next pod start: an enrolled follower with the baseline must
+	// restore cleanly (no wedge) and must NOT spuriously activate the kill
+	// switch (the baseline is a no-decision counter-0 state).
+	ks := &stubKillSwitch{}
+	applier := &emergency.RemoteKillApplier{KillSwitch: ks, StatePath: baselinePath}
+	if err := applier.RestorePersistedState(); err != nil {
+		t.Fatalf("RestorePersistedState() after enroll baseline error = %v, want nil", err)
+	}
+	if ks.active {
+		t.Fatal("kill switch active after baseline restore, want inactive")
+	}
 }

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/applycache"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/emergency"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
@@ -506,12 +507,7 @@ func TestBuildConductorRemoteKillPollerRejectsInvalidConfig(t *testing.T) {
 
 func TestBuildConductorRemoteKillPollerRestoresPersistedState(t *testing.T) {
 	dir := t.TempDir()
-	remotePub, _, err := ed25519.GenerateKey(nil)
-	if err != nil {
-		t.Fatalf("GenerateKey: %v", err)
-	}
 	trustPath := filepath.Join(dir, "trust-roster.json")
-	rootFingerprint := writeRuntimeTrustRoster(t, trustPath, remotePub, "remote-kill-1", signing.PurposeRemoteKillSigning)
 	clientPEM, clientKeyPEM := testTLSClientCert(t)
 	caPath := filepath.Join(dir, "boss-ca.pem")
 	clientCertPath := filepath.Join(dir, "client.crt")
@@ -524,13 +520,10 @@ func TestBuildConductorRemoteKillPollerRestoresPersistedState(t *testing.T) {
 	if err := os.MkdirAll(bundleCacheDir, 0o750); err != nil {
 		t.Fatalf("MkdirAll(bundle cache): %v", err)
 	}
-	writePrivateTestFile(t, statePath, []byte(`{
-  "last_counter": 7,
-  "last_message_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  "state": "active",
-  "reason": "persisted emergency stop",
-  "applied_at": "2026-05-23T12:00:00Z"
-}`))
+	// Seed a properly signed, re-verifiable persisted kill (threshold = 2 signers
+	// in the roster the poller will build). A persisted decision is honored on
+	// restore only if its signed message re-verifies against the trust roster.
+	rootFingerprint, reason := seedSignedRemoteKillState(t, trustPath, statePath)
 	ks := &testRuntimeKillSwitch{}
 	poller, err := buildConductorRemoteKillPoller(&config.Config{
 		Conductor: config.Conductor{
@@ -555,9 +548,104 @@ func TestBuildConductorRemoteKillPollerRestoresPersistedState(t *testing.T) {
 	if poller == nil {
 		t.Fatal("poller = nil")
 	}
-	if !ks.active || ks.message != "persisted emergency stop" {
+	if !ks.active || ks.message != reason {
 		t.Fatalf("kill switch = active=%v message=%q, want restored active", ks.active, ks.message)
 	}
+}
+
+// seedSignedRemoteKillState writes a 2-signer remote-kill trust roster to
+// trustPath and seeds a properly signed, re-verifiable persisted kill decision
+// at statePath (via the real Apply path, so the on-disk binding is correct). It
+// returns the roster root fingerprint and the kill reason. This mirrors what a
+// follower's on-disk state looks like after the Conductor signed and the
+// follower applied a real kill.
+func seedSignedRemoteKillState(t *testing.T, trustPath, statePath string) (rootFingerprint, reason string) {
+	t.Helper()
+	rootPub, rootPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey(root): %v", err)
+	}
+	pub1, priv1, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey(signer 1): %v", err)
+	}
+	pub2, priv2, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey(signer 2): %v", err)
+	}
+	rootFingerprint, err = signing.Fingerprint(rootPub)
+	if err != nil {
+		t.Fatalf("Fingerprint(root): %v", err)
+	}
+	body := contract.KeyRoster{
+		SchemaVersion:  1,
+		RosterSignedBy: "roster-root-1",
+		DataClassRoot:  string(contract.DataClassInternal),
+		Keys: []contract.KeyInfo{
+			{KeyID: "roster-root-1", KeyPurpose: signing.PurposeRosterRoot.String(), PublicKeyHex: hex.EncodeToString(rootPub), ValidFrom: "2026-01-01T00:00:00Z", Status: contract.KeyStatusRoot},
+			{KeyID: "remote-kill-1", KeyPurpose: signing.PurposeRemoteKillSigning.String(), PublicKeyHex: hex.EncodeToString(pub1), ValidFrom: "2026-01-01T00:00:00Z", Status: contract.KeyStatusActive},
+			{KeyID: "remote-kill-2", KeyPurpose: signing.PurposeRemoteKillSigning.String(), PublicKeyHex: hex.EncodeToString(pub2), ValidFrom: "2026-01-01T00:00:00Z", Status: contract.KeyStatusActive},
+		},
+	}
+	rosterPreimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage(roster): %v", err)
+	}
+	envelope := contract.RosterEnvelope{
+		Body:      body,
+		Signature: "ed25519:" + hex.EncodeToString(ed25519.Sign(rootPriv, rosterPreimage)),
+	}
+	rosterData, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("Marshal(roster): %v", err)
+	}
+	writePrivateTestFile(t, trustPath, rosterData)
+
+	reason = "persisted emergency stop"
+	seedNow := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	msg := conductor.RemoteKillMessage{
+		SchemaVersion: conductor.SchemaVersion,
+		MessageID:     "kill-runtime-1",
+		OrgID:         "org-main",
+		FleetID:       "prod",
+		Audience:      conductor.Audience{InstanceIDs: []string{"pl-prod-1"}},
+		State:         conductor.KillSwitchActive,
+		Counter:       7,
+		Reason:        reason,
+		CreatedAt:     seedNow,
+		NotBefore:     seedNow.Add(-time.Minute),
+		ExpiresAt:     seedNow.Add(time.Hour),
+	}
+	msgPreimage, err := msg.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage(kill): %v", err)
+	}
+	msg.Signatures = []conductor.SignatureProof{
+		{SignerKeyID: "remote-kill-1", KeyPurpose: signing.PurposeRemoteKillSigning, Algorithm: conductor.SignatureAlgorithmEd25519, Signature: conductor.SignaturePrefixEd25519 + hex.EncodeToString(ed25519.Sign(priv1, msgPreimage))},
+		{SignerKeyID: "remote-kill-2", KeyPurpose: signing.PurposeRemoteKillSigning, Algorithm: conductor.SignatureAlgorithmEd25519, Signature: conductor.SignaturePrefixEd25519 + hex.EncodeToString(ed25519.Sign(priv2, msgPreimage))},
+	}
+	resolver := func(keyID string) (conductor.SignatureKey, error) {
+		switch keyID {
+		case "remote-kill-1":
+			return conductor.SignatureKey{PublicKey: pub1, KeyPurpose: signing.PurposeRemoteKillSigning}, nil
+		case "remote-kill-2":
+			return conductor.SignatureKey{PublicKey: pub2, KeyPurpose: signing.PurposeRemoteKillSigning}, nil
+		default:
+			return conductor.SignatureKey{}, conductor.ErrSignatureVerification
+		}
+	}
+	if err := (&emergency.RemoteKillApplier{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "pl-prod-1",
+		Resolver:   resolver,
+		KillSwitch: &testRuntimeKillSwitch{},
+		StatePath:  statePath,
+		Now:        func() time.Time { return seedNow },
+	}).Apply(msg); err != nil {
+		t.Fatalf("seed Apply: %v", err)
+	}
+	return rootFingerprint, reason
 }
 
 func TestConductorRuntimeChanged(t *testing.T) {

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -536,6 +536,35 @@ func waitForPortOrCommandExitResult(addr string, cmdErr <-chan error, stderr fmt
 	}
 }
 
+func doMCPPostWithStartupRetry(t *testing.T, addr string, body string, cmdErr <-chan error, stderr fmt.Stringer) *http.Response {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://"+addr+"/", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("new mcp request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			return resp
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			t.Fatalf("mcp listener POST: %v\nstderr:\n%s", lastErr, stderr.String())
+		}
+
+		select {
+		case err := <-cmdErr:
+			t.Fatalf("RunCmd exited before MCP listener accepted POST: %v\nlast POST error: %v\nstderr:\n%s", err, lastErr, stderr.String())
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
 // doGet issues a context-aware GET and fails the test on error.
 func doGet(t *testing.T, client *http.Client, url string) *http.Response {
 	t.Helper()
@@ -785,16 +814,9 @@ logging:
 			t.Fatalf("reverse proxy status = %d, want 200", reverseResp.StatusCode)
 		}
 
-		mcpReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://"+mcpAddr+"/",
-			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"prompt":"use `+secret+` to deploy"}}}`))
-		if err != nil {
-			t.Fatalf("new mcp request: %v", err)
-		}
-		mcpReq.Header.Set("Content-Type", "application/json")
-		mcpResp, err := http.DefaultClient.Do(mcpReq)
-		if err != nil {
-			t.Fatalf("mcp listener POST: %v", err)
-		}
+		mcpResp := doMCPPostWithStartupRetry(t, mcpAddr,
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"prompt":"use `+secret+` to deploy"}}}`,
+			cmdErr, &stderr)
 		_ = mcpResp.Body.Close()
 		if mcpResp.StatusCode != http.StatusOK {
 			t.Fatalf("mcp listener status = %d, want 200", mcpResp.StatusCode)
@@ -891,16 +913,9 @@ logging:
 			return err
 		}
 
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://"+mcpAddr+"/",
-			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`))
-		if err != nil {
-			t.Fatalf("new mcp request: %v", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("mcp listener POST: %v", err)
-		}
+		resp := doMCPPostWithStartupRetry(t, mcpAddr,
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}`,
+			cmdErr, &stderr)
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
 				t.Errorf("close mcp response body: %v", err)

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -539,10 +539,12 @@ func waitForPortOrCommandExitResult(addr string, cmdErr <-chan error, stderr fmt
 func doMCPPostWithStartupRetry(t *testing.T, addr string, body string, cmdErr <-chan error, stderr fmt.Stringer) *http.Response {
 	t.Helper()
 
-	deadline := time.Now().Add(2 * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	var lastErr error
 	for {
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://"+addr+"/", strings.NewReader(body))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+addr+"/", strings.NewReader(body))
 		if err != nil {
 			t.Fatalf("new mcp request: %v", err)
 		}
@@ -553,11 +555,10 @@ func doMCPPostWithStartupRetry(t *testing.T, addr string, body string, cmdErr <-
 			return resp
 		}
 		lastErr = err
-		if time.Now().After(deadline) {
-			t.Fatalf("mcp listener POST: %v\nstderr:\n%s", lastErr, stderr.String())
-		}
 
 		select {
+		case <-ctx.Done():
+			t.Fatalf("mcp listener POST: %v\nstderr:\n%s", lastErr, stderr.String())
 		case err := <-cmdErr:
 			t.Fatalf("RunCmd exited before MCP listener accepted POST: %v\nlast POST error: %v\nstderr:\n%s", err, lastErr, stderr.String())
 		case <-time.After(20 * time.Millisecond):


### PR DESCRIPTION
Conductor follower lifecycle hardening: two fixes for the remote-kill replay state. FIX 1 (restart-wedge ship-blocker): a follower that enrolled cleanly but never received a remote-kill failed closed on its first restart (enrollment marker present, no replay state, so readDurableRemoteKillState aborted with 'replay state missing while follower context is present'); InitializeReplayBaseline now writes an initial no-decision baseline (counter 0, empty hash, inactive) at enrollment so it boots clean, while the first real kill (counter>0) still advances; replay-safe (no-op if any state exists). FIX 2 (recovery): adds the offline, fleet-license-gated 'conductor follower reset-replay-state' command (the explicit reset the wedge error references) with dry-run default and --confirm. Tests: reproduction+fix+replay-safety+idempotency+CLI; race-clean, lint-clean, full enterprise suite green. Proven live: old build CrashLooped on first restart, fixed build survived two restarts (no kill); reset command recovered a wedged state dir. TRACKED FOLLOW-UPS (not in this PR): (a) persisted-kill-state authenticity: RestorePersistedState applies a persisted decision without re-verifying a signature and the context/digest binding is deterministic/non-secret, so an attacker with write access to the follower state PVC could forge a bound decision (pre-existing; requires compromising pipelock's own state store, which already defeats the kill switch; correct fix is to persist the signed Conductor message and re-verify it against the trust roster on restore); (b) follower deregister/re-enroll-replace for clean recovery of a lost identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added an enterprise `conductor follower` subcommand (`reset-replay-state`) with dry-run preview and `--confirm` to reset replay state to an emergency baseline (including fleet license verification).

- **Bug Fixes**
  - Improved remote-kill replay-state durability and correctness under concurrent operations.
  - Hardened restore to fail closed unless persisted decisions are properly signed and unmodified.
  - Conductor auto-enrollment now initializes the emergency replay baseline and stops enrollment if initialization fails.

- **Tests**
  - Expanded emergency and CLI test coverage for idempotency, restart recovery, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->