### PR TITLE
conductor: clearer follower operator UX (check advisories, error remediation, recovery docs)

### DIFF
--- a/docs/cli/conductor-recovery.md
+++ b/docs/cli/conductor-recovery.md
@@ -95,7 +95,7 @@ it re-fetches and verifies the authoritative bundle for its current audience.
 `follower reset-replay-state` is an offline follower-side recovery command for a
 wedged remote-kill replay state. Use it when the follower reports:
 
-> conductor remote kill replay state missing while follower context is present
+> conductor remote kill replay state missing while follower context is present; run: pipelock conductor follower reset-replay-state --state-dir <conductor.bundle_cache_dir> --confirm
 
 This happens when the follower's enrollment context exists but the corresponding
 replay-state file is missing or corrupt (e.g., after a partial disk recovery or

--- a/docs/cli/conductor-recovery.md
+++ b/docs/cli/conductor-recovery.md
@@ -90,6 +90,40 @@ pipelock conductor follower reset-bundle-state \
 After a confirmed reset, restart the follower if it is wedged. On the next poll
 it re-fetches and verifies the authoritative bundle for its current audience.
 
+## `follower reset-replay-state`
+
+`follower reset-replay-state` is an offline follower-side recovery command for a
+wedged remote-kill replay state. Use it when the follower reports:
+
+> conductor remote kill replay state missing while follower context is present
+
+This happens when the follower's enrollment context exists but the corresponding
+replay-state file is missing or corrupt (e.g., after a partial disk recovery or
+an interrupted enrollment).
+
+The command rewrites the follower's local remote-kill replay state to a clean
+baseline. On the next poll the follower re-syncs the authoritative kill state
+from the Conductor.
+
+Dry run (default):
+
+```sh
+pipelock conductor follower reset-replay-state \
+  --state-dir /var/lib/pipelock/bundles
+```
+
+Apply:
+
+```sh
+pipelock conductor follower reset-replay-state \
+  --state-dir /var/lib/pipelock/bundles \
+  --confirm
+```
+
+`--state-dir` is the same directory as `conductor.bundle_cache_dir` in the
+follower config. Without `--confirm`, the command prints what it would do and
+exits without modifying state (fail-closed dry run).
+
 ## `rollback clear`
 
 Clear a single active rollback authorization by its `authorization_id`. This is

--- a/docs/guides/conductor-production-runbook.md
+++ b/docs/guides/conductor-production-runbook.md
@@ -16,7 +16,9 @@ the Helm topology). Read those first for context; this guide is the operator
 
 Everything here is Enterprise-tier. Every server command verifies a license
 granting the `fleet` feature and **fails closed** before binding a listener or
-writing a file. See [`pipelock license`](../cli/license.md).
+writing a file. A follower running `pipelock run` with `conductor.enabled: true`
+also requires a license granting the `fleet` feature and fails closed before
+binding a listener. See [`pipelock license`](../cli/license.md).
 
 > **Build note.** Conductor exists only in an enterprise build (`-tags
 > enterprise`). The commands below assume a `pipelock` binary built with that
@@ -37,6 +39,7 @@ writing a file. See [`pipelock license`](../cli/license.md).
 | 8. Kill / resume the fleet | `pipelock conductor kill` / `resume` | **Shipped** |
 | 9. Roll back a bad bundle | `pipelock conductor rollback` | **Shipped** |
 | 10. Recover follower bundle state | `pipelock conductor follower reset-bundle-state` | **Shipped** |
+| 10b. Recover follower replay state | `pipelock conductor follower reset-replay-state` | **Shipped** |
 | 11. Mint enrollment tokens | `pipelock conductor enrollment-token mint` | **Shipped** |
 | 12. Fleet status / followers | `pipelock conductor fleet status` / `followers` | **Shipped** |
 | 13. Remove / decommission followers | `pipelock conductor follower remove` | **Shipped** |
@@ -337,8 +340,9 @@ conductor:
   client_key_path: /etc/pipelock/follower.key
   bundle_cache_dir: /var/lib/pipelock/bundles
   durable_audit_queue_dir: /var/lib/pipelock/audit-queue
-  audit_signing_key_id: edge-01-audit
-  recorder_key_id: edge-01-recorder
+  # audit_signing_key_id and recorder_key_id default to instance_id when omitted; override only if the audit sink expects a different key id
+  # audit_signing_key_id: edge-01-audit
+  # recorder_key_id: edge-01-recorder
   enrollment_token_path: /etc/pipelock/conductor/enrollment-token  # single-use; auto-enroll on startup
   poll_interval: 30s
   honor_remote_kill_switch: true
@@ -514,6 +518,26 @@ pipelock conductor follower reset-bundle-state \
 Restart the follower after a confirmed reset if it is wedged. On the next poll it
 re-fetches and verifies the authoritative bundle for its audience.
 
+### 10b. Recover follower replay state
+
+If a follower is wedged with "conductor remote kill replay state missing while
+follower context is present," reset only the remote-kill replay state on the
+follower host. This does not touch policy-bundle apply state.
+
+```bash
+# Dry run first.
+pipelock conductor follower reset-replay-state \
+  --state-dir /var/lib/pipelock/bundles
+
+# Apply after confirming the state dir is conductor.bundle_cache_dir.
+pipelock conductor follower reset-replay-state \
+  --state-dir /var/lib/pipelock/bundles \
+  --confirm
+```
+
+Restart the follower after a confirmed reset. On the next poll it re-syncs the
+authoritative kill state from the Conductor.
+
 ## 11. Mint enrollment tokens
 
 Enrollment is token-gated (see [step 5](#5-enroll-followers)).
@@ -557,6 +581,26 @@ pipelock conductor enroll \
   --tls-key /etc/pipelock/follower.key \
   --server-ca /etc/pipelock/conductor-ca.pem
 ```
+
+### Troubleshooting: re-enrolling after an aborted attempt
+
+If enrollment returns a 409 ("conductor follower instance already enrolled"),
+the follower identity is still registered on the Conductor. To re-enroll:
+
+1. Remove the existing enrollment on the server side:
+
+```bash
+pipelock conductor follower remove \
+  --server https://conductor.pipelock-control.svc.cluster.local:8895 \
+  --org-id <org> --fleet-id <fleet> --instance-id <instance> --environment <env> \
+  --token-file /etc/pipelock/conductor/tokens/admin/token \
+  --client-cert /etc/pipelock/operator.crt \
+  --client-key /etc/pipelock/operator.key \
+  --ca-file /etc/pipelock/conductor-ca.pem
+```
+
+2. Mint a new enrollment token (`enrollment-token mint`).
+3. Re-enroll the follower using the new token.
 
 ## 12. Fleet status and followers
 

--- a/enterprise/conductor/applycache/cache.go
+++ b/enterprise/conductor/applycache/cache.go
@@ -47,7 +47,7 @@ const (
 var (
 	ErrCacheRequired         = errors.New("conductor apply cache required")
 	ErrNoValidBundle         = errors.New("conductor apply cache has no valid bundle")
-	ErrRollbackRequired      = errors.New("conductor rollback authorization required")
+	ErrRollbackRequired      = errors.New("conductor rollback authorization required: the incoming bundle version is not a forward advance from the locally cached version; either authorize a rollback on the conductor (pipelock conductor rollback), or if the local cache is stale from an aborted attempt, reset it: pipelock conductor follower reset-bundle-state --state-dir <conductor.bundle_cache_dir> --confirm")
 	ErrInvalidActiveRecord   = errors.New("conductor apply cache active record invalid")
 	ErrUnsupportedMinVersion = errors.New("conductor policy bundle requires unsupported pipelock version")
 	// ErrEntitlementLost aborts an in-flight policy-bundle apply when the fleet

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -426,7 +426,7 @@ func readDurableRemoteKillStateLocked(canonical string) (remoteKillState, error)
 			return remoteKillState{}, contextErr
 		}
 		if contextFound {
-			return remoteKillState{}, fmt.Errorf("conductor remote kill replay state missing while follower context is present; run an explicit replay-state reset")
+			return remoteKillState{}, fmt.Errorf("conductor remote kill replay state missing while follower context is present; run: pipelock conductor follower reset-replay-state --state-dir <conductor.bundle_cache_dir> --confirm")
 		}
 		return remoteKillState{}, nil
 	}

--- a/enterprise/conductor/enrollmentclient/client.go
+++ b/enterprise/conductor/enrollmentclient/client.go
@@ -88,7 +88,11 @@ func (c *Client) Enroll(ctx context.Context, reqBody Request) (Response, error) 
 		return Response{}, fmt.Errorf("enrollmentclient: read enroll response: %w", err)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return Response{}, fmt.Errorf("enrollmentclient: enroll status=%d body=%s", resp.StatusCode, snippet(respBody, reqBody.Token))
+		msg := fmt.Sprintf("enrollmentclient: enroll status=%d body=%s", resp.StatusCode, snippet(respBody, reqBody.Token))
+		if resp.StatusCode == http.StatusConflict {
+			msg += "; to re-enroll, first remove the existing enrollment: pipelock conductor follower remove --org-id <org> --fleet-id <fleet> --instance-id <instance> --environment <env>, then mint a new enrollment token and re-enroll"
+		}
+		return Response{}, errors.New(msg)
 	}
 	var out Response
 	if err := json.Unmarshal(respBody, &out); err != nil {

--- a/enterprise/conductor/enrollmentclient/client_test.go
+++ b/enterprise/conductor/enrollmentclient/client_test.go
@@ -51,6 +51,54 @@ func TestNewRejectsBadBaseURL(t *testing.T) {
 	}
 }
 
+func TestEnrollConflictSurfacesReEnrollGuidance(t *testing.T) {
+	doer := &stubDoer{
+		status: http.StatusConflict,
+		body:   `{"error":"conductor follower instance already enrolled"}`,
+	}
+	c, err := New(Config{BaseURL: "https://conductor.example:8895", Client: doer})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = c.Enroll(context.Background(), Request{
+		Token:          "pl_" + "enroll_test",
+		AuditKeyID:     "audit-key-1",
+		AuditPublicKey: strings.Repeat("a", 64),
+	})
+	if err == nil {
+		t.Fatal("Enroll() error = nil, want 409 error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "status=409") {
+		t.Errorf("error missing status=409: %s", msg)
+	}
+	if !strings.Contains(msg, "pipelock conductor follower remove") {
+		t.Errorf("error missing re-enroll guidance: %s", msg)
+	}
+}
+
+func TestEnrollNon409DoesNotSurfaceReEnrollGuidance(t *testing.T) {
+	doer := &stubDoer{
+		status: http.StatusForbidden,
+		body:   `{"error":"forbidden"}`,
+	}
+	c, err := New(Config{BaseURL: "https://conductor.example:8895", Client: doer})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = c.Enroll(context.Background(), Request{
+		Token:          "pl_" + "enroll_test",
+		AuditKeyID:     "audit-key-1",
+		AuditPublicKey: strings.Repeat("a", 64),
+	})
+	if err == nil {
+		t.Fatal("Enroll() error = nil, want 403 error")
+	}
+	if strings.Contains(err.Error(), "pipelock conductor follower remove") {
+		t.Errorf("non-409 error should not contain re-enroll guidance: %s", err.Error())
+	}
+}
+
 func TestEnrollValidatesSuccessResponse(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/cli/diag/check.go
+++ b/internal/cli/diag/check.go
@@ -4,14 +4,20 @@
 package diag
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/rules"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 // ErrURLBlocked is returned when pipelock check --url detects a blocked URL.
@@ -110,5 +116,74 @@ func checkConfigAdvisories(cfg *config.Config) []string {
 		advisories = append(advisories, "flight_recorder is enabled but dir is unset; no receipts will be written")
 	}
 
+	if cfg.Conductor.Enabled {
+		_, err := license.VerifyFleetWithOptions(fleetVerifyInputsFromConfig(cfg))
+		if err != nil {
+			advisories = append(advisories,
+				"conductor.enabled is true but no license granting the \"fleet\" feature was found; "+
+					"the proxy will refuse to start (install an Enterprise license with fleet or set PIPELOCK_LICENSE_KEY)")
+		}
+	}
+
+	if cfg.Conductor.Enabled && cfg.FlightRecorder.SigningKeyPath != "" {
+		advisories = append(advisories, conductorSigningKeyAdvisories(cfg)...)
+	}
+
 	return advisories
+}
+
+func fleetVerifyInputsFromConfig(cfg *config.Config) license.FleetVerifyInputs {
+	return license.FleetVerifyInputs{
+		LicenseKey:       cfg.LicenseKey,
+		PublicKeyHex:     cfg.LicensePublicKey,
+		CRLFile:          cfg.LicenseCRLFile,
+		IntermediateFile: cfg.LicenseIntermediateFile,
+		IntermediateCert: cfg.LicenseIntermediateCert,
+		RequireSet:       true,
+		Require:          cfg.LicenseRequireIntermediateResolved,
+		MaxAge:           cfg.LicenseCRLMaxAgeResolved,
+	}
+}
+
+// conductorSigningKeyAdvisories checks for mismatched key IDs and missing key
+// files when conductor.enabled is true and flight_recorder.signing_key_path is
+// set. Returns zero or more advisory strings.
+func conductorSigningKeyAdvisories(cfg *config.Config) []string {
+	var out []string
+	keyPath := filepath.Clean(cfg.FlightRecorder.SigningKeyPath)
+	priv, err := signing.LoadPrivateKeyFile(keyPath)
+	if err != nil {
+		out = append(out, fmt.Sprintf(
+			"flight_recorder.signing_key_path %q cannot be loaded; the proxy will fail to start (required when conductor.enabled): %v",
+			cfg.FlightRecorder.SigningKeyPath, err))
+		return out
+	}
+	for i := range priv {
+		priv[i] = 0
+	}
+
+	data, err := os.ReadFile(keyPath) // #nosec G304 -- path comes from validated config
+	if err != nil {
+		out = append(out, fmt.Sprintf(
+			"flight_recorder.signing_key_path %q cannot be read for key-id advisory: %v",
+			cfg.FlightRecorder.SigningKeyPath, err))
+		return out
+	}
+
+	// If the key file is a JSON keypair with a key_id field, check whether
+	// conductor.recorder_key_id matches.
+	var kf struct {
+		KeyID string `json:"key_id"`
+	}
+	if json.Unmarshal(data, &kf) != nil || kf.KeyID == "" {
+		// Raw (non-JSON) key or JSON without key_id — skip silently.
+		return out
+	}
+	if cfg.Conductor.RecorderKeyID != "" && cfg.Conductor.RecorderKeyID != kf.KeyID {
+		out = append(out, fmt.Sprintf(
+			"conductor.recorder_key_id %q does not match the key_id %q in flight_recorder.signing_key_path; "+
+				"omit recorder_key_id to auto-derive from instance_id, or set it to match",
+			cfg.Conductor.RecorderKeyID, kf.KeyID))
+	}
+	return out
 }

--- a/internal/cli/diag/check.go
+++ b/internal/cli/diag/check.go
@@ -151,23 +151,26 @@ func fleetVerifyInputsFromConfig(cfg *config.Config) license.FleetVerifyInputs {
 func conductorSigningKeyAdvisories(cfg *config.Config) []string {
 	var out []string
 	keyPath := filepath.Clean(cfg.FlightRecorder.SigningKeyPath)
-	priv, err := signing.LoadPrivateKeyFile(keyPath)
+	// Read once: this read's failure is the missing/unreadable-file case, and the
+	// same bytes feed the key_id advisory below (no untestable second read).
+	data, err := os.ReadFile(keyPath) // #nosec G304 -- path comes from validated config
 	if err != nil {
 		out = append(out, fmt.Sprintf(
 			"flight_recorder.signing_key_path %q cannot be loaded; the proxy will fail to start (required when conductor.enabled): %v",
 			cfg.FlightRecorder.SigningKeyPath, err))
 		return out
 	}
-	for i := range priv {
-		priv[i] = 0
-	}
-
-	data, err := os.ReadFile(keyPath) // #nosec G304 -- path comes from validated config
+	// Validate the file loads the way the runtime loads it (catches malformed or
+	// too-permissive keys that would pass a shape check but fail at startup).
+	priv, err := signing.LoadPrivateKeyFile(keyPath)
 	if err != nil {
 		out = append(out, fmt.Sprintf(
-			"flight_recorder.signing_key_path %q cannot be read for key-id advisory: %v",
+			"flight_recorder.signing_key_path %q is not a usable signing key; the proxy will fail to start (required when conductor.enabled): %v",
 			cfg.FlightRecorder.SigningKeyPath, err))
 		return out
+	}
+	for i := range priv {
+		priv[i] = 0
 	}
 
 	// If the key file is a JSON keypair with a key_id field, check whether

--- a/internal/cli/diag/check_conductor_advisory_test.go
+++ b/internal/cli/diag/check_conductor_advisory_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+func TestCheckConductorAdvisories(t *testing.T) {
+	tests := []struct {
+		name             string
+		mutate           func(cfg *config.Config, dir string)
+		wantSubstr       string
+		wantNoAdvisories bool
+	}{
+		{
+			name: "conductor enabled without fleet license emits advisory",
+			mutate: func(cfg *config.Config, _ string) {
+				cfg.Conductor.Enabled = true
+				// No license key set -> fleet check fails.
+			},
+			wantSubstr: "conductor.enabled is true but no license granting the \"fleet\" feature was found",
+		},
+		{
+			name: "conductor disabled emits no fleet advisory",
+			mutate: func(cfg *config.Config, _ string) {
+				cfg.Conductor.Enabled = false
+				// Disable flight recorder to suppress the unrelated advisory.
+				cfg.FlightRecorder.Enabled = false
+			},
+			wantNoAdvisories: true,
+		},
+		{
+			name: "conductor enabled with missing signing key path emits advisory",
+			mutate: func(cfg *config.Config, dir string) {
+				cfg.Conductor.Enabled = true
+				cfg.FlightRecorder.SigningKeyPath = filepath.Join(dir, "nonexistent-key.json")
+			},
+			wantSubstr: "cannot be loaded; the proxy will fail to start (required when conductor.enabled)",
+		},
+		{
+			name: "conductor enabled with mismatched recorder key id emits advisory",
+			mutate: func(cfg *config.Config, dir string) {
+				cfg.Conductor.Enabled = true
+				// Write a JSON keypair with a key_id that differs from recorder_key_id.
+				kp := writeJSONSigningKey(t, dir, "file-key-id")
+				cfg.FlightRecorder.SigningKeyPath = kp
+				cfg.Conductor.RecorderKeyID = "different-key-id"
+			},
+			wantSubstr: "conductor.recorder_key_id \"different-key-id\" does not match the key_id \"file-key-id\"",
+		},
+		{
+			name: "matching recorder key id emits no mismatch advisory",
+			mutate: func(cfg *config.Config, dir string) {
+				cfg.Conductor.Enabled = true
+				kp := writeJSONSigningKey(t, dir, "same-id")
+				cfg.FlightRecorder.SigningKeyPath = kp
+				cfg.Conductor.RecorderKeyID = "same-id"
+			},
+			// The fleet-license advisory will still fire (no license), but no
+			// recorder-key-id mismatch advisory.
+			wantSubstr: "conductor.enabled is true but no license",
+		},
+		{
+			name: "raw key file emits no mismatch advisory",
+			mutate: func(cfg *config.Config, dir string) {
+				cfg.Conductor.Enabled = true
+				kp := filepath.Join(dir, "raw-key")
+				_, priv, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(kp, []byte(signingPrivateKey(priv)), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				cfg.FlightRecorder.SigningKeyPath = kp
+				cfg.Conductor.RecorderKeyID = "some-id"
+			},
+			// Only fleet-license advisory, no recorder mismatch.
+			wantSubstr: "conductor.enabled is true but no license",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.Internal = nil
+			dir := t.TempDir()
+			tt.mutate(cfg, dir)
+
+			advisories := checkConfigAdvisories(cfg)
+
+			if tt.wantNoAdvisories {
+				if len(advisories) > 0 {
+					t.Fatalf("expected no advisories, got %d: %v", len(advisories), advisories)
+				}
+				return
+			}
+
+			found := false
+			for _, a := range advisories {
+				if strings.Contains(a, tt.wantSubstr) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected advisory containing %q, got %v", tt.wantSubstr, advisories)
+			}
+		})
+	}
+}
+
+func TestCheckConductorAdvisoriesMirrorsRequireIntermediateFleetGate(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := license.Issue(license.License{
+		ID:        "lic_diag_require_intermediate",
+		Email:     "ops@example.test",
+		IssuedAt:  time.Now().Add(-time.Hour).Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		Features:  []string{license.FeatureFleet},
+	}, priv)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.Conductor.Enabled = true
+	cfg.FlightRecorder.Enabled = false
+	cfg.LicenseKey = token
+	cfg.LicensePublicKey = hex.EncodeToString(pub)
+	cfg.LicenseRequireIntermediateResolved = true
+	cfg.LicenseIntermediateCert = []byte("configured intermediate certificate unavailable")
+
+	advisories := checkConfigAdvisories(cfg)
+	for _, advisory := range advisories {
+		if strings.Contains(advisory, "conductor.enabled is true but no license granting the \"fleet\" feature was found") {
+			return
+		}
+	}
+	t.Fatalf("expected require-intermediate fleet-gate advisory, got %v", advisories)
+}
+
+func writeJSONSigningKey(t *testing.T, dir, keyID string) string {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kf := map[string]any{
+		"schema_version": 1,
+		"key_id":         keyID,
+		"public":         hex.EncodeToString(pub),
+		"private":        hex.EncodeToString(priv),
+		"created_at":     "2026-01-01T00:00:00Z",
+	}
+	data, err := json.Marshal(kf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kp := filepath.Join(dir, keyID+".json")
+	if err := os.WriteFile(kp, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return kp
+}
+
+func signingPrivateKey(priv ed25519.PrivateKey) string {
+	return "pipelock-ed25519-private-v1\n" + base64.StdEncoding.EncodeToString(priv) + "\n"
+}

--- a/internal/cli/diag/check_conductor_advisory_test.go
+++ b/internal/cli/diag/check_conductor_advisory_test.go
@@ -24,6 +24,7 @@ func TestCheckConductorAdvisories(t *testing.T) {
 		name             string
 		mutate           func(cfg *config.Config, dir string)
 		wantSubstr       string
+		forbidSubstr     string
 		wantNoAdvisories bool
 	}{
 		{
@@ -72,7 +73,8 @@ func TestCheckConductorAdvisories(t *testing.T) {
 			},
 			// The fleet-license advisory will still fire (no license), but no
 			// recorder-key-id mismatch advisory.
-			wantSubstr: "conductor.enabled is true but no license",
+			wantSubstr:   "conductor.enabled is true but no license",
+			forbidSubstr: "does not match the key_id",
 		},
 		{
 			name: "raw key file emits no mismatch advisory",
@@ -90,7 +92,8 @@ func TestCheckConductorAdvisories(t *testing.T) {
 				cfg.Conductor.RecorderKeyID = "some-id"
 			},
 			// Only fleet-license advisory, no recorder mismatch.
-			wantSubstr: "conductor.enabled is true but no license",
+			wantSubstr:   "conductor.enabled is true but no license",
+			forbidSubstr: "does not match the key_id",
 		},
 	}
 
@@ -119,6 +122,14 @@ func TestCheckConductorAdvisories(t *testing.T) {
 			}
 			if !found {
 				t.Errorf("expected advisory containing %q, got %v", tt.wantSubstr, advisories)
+			}
+			if tt.forbidSubstr != "" {
+				for _, a := range advisories {
+					if strings.Contains(a, tt.forbidSubstr) {
+						t.Errorf("did not expect advisory containing %q, got %v", tt.forbidSubstr, advisories)
+						break
+					}
+				}
 			}
 		})
 	}

--- a/internal/cli/diag/check_conductor_advisory_test.go
+++ b/internal/cli/diag/check_conductor_advisory_test.go
@@ -53,6 +53,18 @@ func TestCheckConductorAdvisories(t *testing.T) {
 			wantSubstr: "cannot be loaded; the proxy will fail to start (required when conductor.enabled)",
 		},
 		{
+			name: "conductor enabled with unusable signing key file emits advisory",
+			mutate: func(cfg *config.Config, dir string) {
+				cfg.Conductor.Enabled = true
+				kp := filepath.Join(dir, "garbage-key")
+				if err := os.WriteFile(kp, []byte("not a valid signing key"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				cfg.FlightRecorder.SigningKeyPath = kp
+			},
+			wantSubstr: "is not a usable signing key; the proxy will fail to start (required when conductor.enabled)",
+		},
+		{
 			name: "conductor enabled with mismatched recorder key id emits advisory",
 			mutate: func(cfg *config.Config, dir string) {
 				cfg.Conductor.Enabled = true


### PR DESCRIPTION
## Summary

Improves Conductor follower operator UX for startup checks, enrollment recovery, and follower recovery docs. No control-plane enforcement behavior changes. Messages, check-time advisories, and documentation only.

## Changes

- Surface `pipelock check` advisories when a Conductor follower would fail at startup because the node's license does not grant `fleet`, or the recorder signing key is missing / cannot be loaded / has a `key_id` that does not match `conductor.recorder_key_id`.
- Add clearer re-enrollment guidance on HTTP 409 enrollment conflicts (remove the existing enrollment, mint a new token, re-enroll).
- Add explicit remediation commands to the rollback-authorization and remote-kill replay-state recovery errors.
- Document follower bundle-state and replay-state recovery, re-enrollment after an aborted attempt, and that `recorder_key_id` / `audit_signing_key_id` default to `instance_id` when omitted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `pipelock conductor follower reset-replay-state` to reset only a wedged follower’s remote-kill replay state (dry-run by default; requires `--confirm` to apply).

* **Bug Fixes**
  * Expanded rollback-required and missing remote-kill replay-state guidance for clearer operator next steps.
  * Improved enrollment `409` Conflict errors to include re-enrollment instructions.

* **Documentation**
  * Strengthened license “fail closed” guidance and updated the production runbook with a new recovery stage.
  * Clarified follower configuration defaults for signing key IDs.

* **Tests**
  * Added coverage for enrollment error guidance and conductor diagnostic advisories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->