### PR TITLE
playground: pin Fly Dockerfile base images by digest

### DIFF
--- a/deploy/fly-playground/Dockerfile
+++ b/deploy/fly-playground/Dockerfile
@@ -18,7 +18,7 @@
 
 ARG GO_VERSION=1.26
 
-FROM golang:${GO_VERSION}-bookworm AS build
+FROM golang:${GO_VERSION}-bookworm@sha256:5f68ec6805843bd3981a951ffada82a26a0bd2631045c8f7dba483fa868f5ec5 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -30,7 +30,7 @@ RUN go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-live      ./
  && go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-toyagent  ./cmd/pipelock-playground-toyagent \
  && go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-webtool   ./cmd/pipelock-playground-webtool
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716
 # nftables: load the owner-match egress rule. ca-certificates: TLS to the model
 # API through the proxy. tini: clean PID 1 signal handling. iproute2: diagnostics.
 #

--- a/deploy/fly-playground/Dockerfile.broker
+++ b/deploy/fly-playground/Dockerfile.broker
@@ -14,7 +14,7 @@
 
 ARG GO_VERSION=1.26
 
-FROM golang:${GO_VERSION}-bookworm AS build
+FROM golang:${GO_VERSION}-bookworm@sha256:5f68ec6805843bd3981a951ffada82a26a0bd2631045c8f7dba483fa868f5ec5 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -23,7 +23,7 @@ ARG VERSION=dev
 ENV CGO_ENABLED=0
 RUN go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-broker ./cmd/pipelock-playground-broker
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
 COPY --from=build /out/pipelock-playground-broker /usr/local/bin/pipelock-playground-broker
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/pipelock-playground-broker"]


### PR DESCRIPTION
## Summary

Pin the playground Fly Dockerfile base images by sha256 digest. Clears the four Scorecard Pinned-Dependencies (Medium) code-scanning alerts on `deploy/fly-playground/Dockerfile` and `Dockerfile.broker`, and makes the builds reproducible (not subject to mutable-tag drift).

## Changes

- `deploy/fly-playground/Dockerfile`: pin `golang:${GO_VERSION}-bookworm` and `debian:bookworm-slim` by digest.
- `deploy/fly-playground/Dockerfile.broker`: pin `golang:${GO_VERSION}-bookworm` and `gcr.io/distroless/static-debian12:nonroot` by digest.

Digests resolved against the current tags (`golang:1.26-bookworm`, `debian:bookworm-slim`, `gcr.io/distroless/static-debian12:nonroot`). No behavior change. The tag is retained alongside the digest for readability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned container base images in deployment configurations to specific digests for enhanced build consistency and reproducibility across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->