### PR TITLE
chore: correct v3.0.0 CHANGELOG date to release day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## [3.0.0] - 2026-06-24
+## [3.0.0] - 2026-06-23
 
 ### Highlights
 


### PR DESCRIPTION
One-line CHANGELOG date fix: the [3.0.0] heading was dated 2026-06-24; correcting to the actual release day 2026-06-23 ahead of tagging. No code or content change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the release date for version 3.0.0 in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->