### PR TITLE
feat(playground): harden broker for public internet exposure

### DIFF
--- a/cmd/pipelock-playground-broker/control_signals_unix.go
+++ b/cmd/pipelock-playground-broker/control_signals_unix.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func controlSignals() []os.Signal {
+	return []os.Signal{syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGTERM, syscall.SIGINT}
+}
+
+func isPauseSignal(sig os.Signal) bool {
+	return sig == syscall.SIGUSR1
+}
+
+func isResumeSignal(sig os.Signal) bool {
+	return sig == syscall.SIGUSR2
+}
+
+func isShutdownSignal(sig os.Signal) bool {
+	return sig == syscall.SIGTERM || sig == syscall.SIGINT
+}

--- a/cmd/pipelock-playground-broker/control_signals_unix_test.go
+++ b/cmd/pipelock-playground-broker/control_signals_unix_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestControlSignalsIncludesUnixControlSignals(t *testing.T) {
+	got := controlSignals()
+	want := map[os.Signal]bool{
+		syscall.SIGUSR1: false,
+		syscall.SIGUSR2: false,
+		syscall.SIGTERM: false,
+		syscall.SIGINT:  false,
+	}
+	for _, sig := range got {
+		if _, ok := want[sig]; ok {
+			want[sig] = true
+		}
+	}
+	for sig, seen := range want {
+		if !seen {
+			t.Fatalf("controlSignals missing %v from %v", sig, got)
+		}
+	}
+}
+
+func TestApplyControlSignalPauseResume(t *testing.T) {
+	srv := newBrokerControlTestServer(t)
+
+	var out bytes.Buffer
+	if shutdown := applyControlSignal(&out, srv, syscall.SIGUSR1); shutdown {
+		t.Fatal("SIGUSR1 requested shutdown, want pause only")
+	}
+	if !srv.Killed() {
+		t.Fatal("SIGUSR1 did not pause broker")
+	}
+	if shutdown := applyControlSignal(&out, srv, syscall.SIGUSR2); shutdown {
+		t.Fatal("SIGUSR2 requested shutdown, want resume only")
+	}
+	if srv.Killed() {
+		t.Fatal("SIGUSR2 did not resume broker")
+	}
+	if got := out.String(); !strings.Contains(got, "paused") || !strings.Contains(got, "resumed") {
+		t.Fatalf("operator output = %q, want pause and resume messages", got)
+	}
+}

--- a/cmd/pipelock-playground-broker/control_signals_windows.go
+++ b/cmd/pipelock-playground-broker/control_signals_windows.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func controlSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}
+
+func isPauseSignal(os.Signal) bool {
+	return false
+}
+
+func isResumeSignal(os.Signal) bool {
+	return false
+}
+
+func isShutdownSignal(sig os.Signal) bool {
+	return sig == os.Interrupt || sig == syscall.SIGTERM
+}

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
@@ -518,7 +517,7 @@ func validateTurnstileFlags(f *serveFlags) error {
 
 func startSignalControlLoop(ctx context.Context, out io.Writer, srv *broker.Server, httpSrv *http.Server) func() {
 	sigCh := make(chan os.Signal, 2)
-	signal.Notify(sigCh, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(sigCh, controlSignals()...)
 	stopCh := make(chan struct{})
 	done := make(chan struct{})
 	var shutdownOnce sync.Once
@@ -671,20 +670,20 @@ func writeAdminJSON(w http.ResponseWriter, status int, v any) {
 }
 
 func applyControlSignal(out io.Writer, srv *broker.Server, sig os.Signal) bool {
-	switch sig {
-	case syscall.SIGUSR1:
+	if isPauseSignal(sig) {
 		srv.Kill()
 		_, _ = fmt.Fprintln(out, "broker paused by SIGUSR1")
 		return false
-	case syscall.SIGUSR2:
+	}
+	if isResumeSignal(sig) {
 		srv.Resume()
 		_, _ = fmt.Fprintln(out, "broker resumed by SIGUSR2")
 		return false
-	case syscall.SIGTERM, syscall.SIGINT:
-		return true
-	default:
-		return false
 	}
+	if isShutdownSignal(sig) {
+		return true
+	}
+	return false
 }
 
 func validateAllowOrigin(raw string) error {

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -1100,13 +1100,13 @@ func resolveTurnstileVerifier(f *serveFlags) (broker.HumanVerifier, error) {
 	if file == "" && envName == "" {
 		return nil, nil
 	}
-	var secret string
+	var secretValue string
 	var err error
 	if file != "" {
-		secret, err = readRequiredFile(file, "--turnstile-secret-file")
+		secretValue, err = readRequiredFile(file, "--turnstile-secret-file")
 	} else {
-		secret = strings.TrimSpace(os.Getenv(envName))
-		if secret == "" {
+		secretValue = strings.TrimSpace(os.Getenv(envName))
+		if secretValue == "" {
 			err = fmt.Errorf("%s is empty or unset", envName)
 		}
 	}
@@ -1114,7 +1114,7 @@ func resolveTurnstileVerifier(f *serveFlags) (broker.HumanVerifier, error) {
 		return nil, err
 	}
 	inner := broker.TurnstileVerifier{
-		Secret:    secret,
+		Secret:    secretValue,
 		VerifyURL: strings.TrimSpace(f.turnstileVerifyURL),
 		Client:    &http.Client{Timeout: 5 * time.Second},
 	}

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"os/signal"
@@ -36,67 +37,70 @@ import (
 )
 
 const (
-	defaultListen      = "127.0.0.1:8100"
-	defaultConcurrency = 3
-	defaultMaxPerCode  = 25
-	defaultSessionTTL  = 10 * time.Minute
-	defaultGrace       = 30 * time.Second
-	defaultIPRate      = 0.5
-	defaultIPBurst     = 5
-	defaultCodeRate    = 0.5
-	defaultCodeBurst   = 10
-	cfAccessJWTHeader  = "Cf-Access-Jwt-Assertion"
-	cfAccessKeysTTL    = 5 * time.Minute
+	defaultListen            = "127.0.0.1:8100"
+	defaultConcurrency       = 3
+	defaultMaxPerCode        = 25
+	defaultSessionTTL        = 10 * time.Minute
+	defaultGrace             = 30 * time.Second
+	defaultIPRate            = 0.5
+	defaultIPBurst           = 5
+	defaultCodeRate          = 0.5
+	defaultCodeBurst         = 10
+	nonStreamWriteTimeout    = 30 * time.Second
+	cfAccessJWTHeader        = "Cf-Access-Jwt-Assertion"
+	cfAccessKeysTTL          = 5 * time.Minute
+	cfAccessNegativeCacheTTL = 30 * time.Second
 
 	envModelKey        = "PLAYGROUND_MODEL_" + "KEY"
 	envOrchestratorKey = "PLAYGROUND_ORCHESTRATOR_" + "KEY"
 )
 
 type serveFlags struct {
-	listen                string
-	adminListen           string
-	adminTokenFile        string
-	adminTokenEnv         string
-	staticDir             string
-	provider              string
-	flyApp                string
-	flyTokenFile          string
-	flyTokenEnv           string
-	image                 string
-	region                string
-	memoryMB              int
-	cpus                  int
-	internalPort          int
-	concurrency           int
-	codes                 []string
-	maxPerCode            int
-	gateSecretFile        string
-	gateSecretEnv         string
-	ipRate                float64
-	ipBurst               float64
-	codeRate              float64
-	codeBurst             float64
-	perIPDailyBudget      int
-	perCodeDailyBudget    int
-	globalDailyBudget     int
-	unsafeUnlimited       bool
-	unsafeNoHumanGate     bool
-	turnstileSecretFile   string
-	turnstileSecretEnv    string
-	turnstileVerifyURL    string
-	sessionTTL            time.Duration
-	deadlineGrace         time.Duration
-	allowOrigin           string
-	publicHosts           []string
-	cfAccessTeamDomain    string
-	cfAccessAUD           string
-	cfAccessCertsURL      string
-	trustForwardedFor     bool
-	modelKeyFile          string
-	modelKeyEnv           string
-	orchestratorKeyFile   string
-	orchestratorKeyEnv    string
-	requireSessionSecrets bool
+	listen                  string
+	adminListen             string
+	adminTokenFile          string
+	adminTokenEnv           string
+	unsafeAdminListenPublic bool
+	staticDir               string
+	provider                string
+	flyApp                  string
+	flyTokenFile            string
+	flyTokenEnv             string
+	image                   string
+	region                  string
+	memoryMB                int
+	cpus                    int
+	internalPort            int
+	concurrency             int
+	codes                   []string
+	maxPerCode              int
+	gateSecretFile          string
+	gateSecretEnv           string
+	ipRate                  float64
+	ipBurst                 float64
+	codeRate                float64
+	codeBurst               float64
+	perIPDailyBudget        int
+	perCodeDailyBudget      int
+	globalDailyBudget       int
+	unsafeUnlimited         bool
+	unsafeNoHumanGate       bool
+	turnstileSecretFile     string
+	turnstileSecretEnv      string
+	turnstileVerifyURL      string
+	sessionTTL              time.Duration
+	deadlineGrace           time.Duration
+	allowOrigin             string
+	publicHosts             []string
+	cfAccessTeamDomain      string
+	cfAccessAUD             string
+	cfAccessCertsURL        string
+	trustForwardedFor       bool
+	modelKeyFile            string
+	modelKeyEnv             string
+	orchestratorKeyFile     string
+	orchestratorKeyEnv      string
+	requireSessionSecrets   bool
 	// VM model/session config, passed into each per-visitor VM via PLAYGROUND_*
 	// env (consumed by deploy/fly-playground/entrypoint.sh).
 	vmModelBaseURL    string
@@ -167,6 +171,7 @@ func newServeCmd() *cobra.Command {
 	fl.IntVar(&f.globalDailyBudget, "global-daily-budget", 0, "global session starts per UTC day (0 = unlimited)")
 	fl.BoolVar(&f.unsafeUnlimited, "unsafe-unlimited-budgets", false, "allow unlimited public broker/model budgets; unsafe for public deployments")
 	fl.BoolVar(&f.unsafeNoHumanGate, "unsafe-no-human-gate", false, "allow session creation without Turnstile or Cloudflare Access; unsafe for public deployments")
+	fl.BoolVar(&f.unsafeAdminListenPublic, "unsafe-admin-listen-public", false, "allow --admin-listen on a public/unspecified address; unsafe outside container netns")
 	fl.StringVar(&f.turnstileSecretFile, "turnstile-secret-file", "", "path to the Cloudflare Turnstile secret; enables human verification for session creation")
 	fl.StringVar(&f.turnstileSecretEnv, "turnstile-secret-env", "", "environment variable holding the Cloudflare Turnstile secret; enables human verification for session creation")
 	fl.StringVar(&f.turnstileVerifyURL, "turnstile-verify-url", "", "Cloudflare Turnstile Siteverify URL override (tests/dev only; empty uses Cloudflare)")
@@ -312,6 +317,10 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		handler = mux
 		_, _ = fmt.Fprintf(out, "serving static UI from %s at /\n", f.staticDir)
 	}
+	// Stream writes indefinitely; the message route is held open for the whole
+	// model turn. Both are exempt from the write deadline (see the middleware).
+	handler = writeDeadlineMiddleware(handler, nonStreamWriteTimeout, livechat.RouteStream, livechat.RouteMessage)
+
 	hosts, err := brokerPublicHosts(f)
 	if err != nil {
 		return nil, nil, err
@@ -420,7 +429,61 @@ func validateAdminFlags(f *serveFlags) error {
 	if tokenFile == "" && tokenEnv == "" {
 		return errors.New("--admin-listen requires --admin-token-file or --admin-token-env")
 	}
+	if err := validateAdminListenScope(listen, f.unsafeAdminListenPublic); err != nil {
+		return err
+	}
 	return nil
+}
+
+// validateAdminListenScope rejects admin listen addresses that bind to public
+// or unspecified IPs unless the operator explicitly opts in with
+// --unsafe-admin-listen-public. Loopback and RFC1918/ULA/link-local are safe.
+func validateAdminListenScope(listen string, unsafePublic bool) error {
+	host, _, err := net.SplitHostPort(listen)
+	if err != nil {
+		// May be a bare port like ":9090" — host is empty.
+		host = listen
+	}
+	host = strings.Trim(host, "[]")
+	if host == "" {
+		// Empty host = unspecified address (binds all interfaces).
+		if unsafePublic {
+			return nil
+		}
+		return errors.New("--admin-listen binds to all interfaces (unspecified address); use a loopback/private address or pass --unsafe-admin-listen-public")
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		// Not a numeric IP — could be a hostname. Allow loopback names.
+		lower := strings.ToLower(host)
+		if lower == "localhost" {
+			return nil
+		}
+		if unsafePublic {
+			return nil
+		}
+		return fmt.Errorf("--admin-listen host %q is not a recognized private address; use a loopback/private address or pass --unsafe-admin-listen-public", host)
+	}
+	if addr.IsUnspecified() {
+		if unsafePublic {
+			return nil
+		}
+		return errors.New("--admin-listen binds to all interfaces (unspecified address); use a loopback/private address or pass --unsafe-admin-listen-public")
+	}
+	if isPrivateOrLoopback(addr) {
+		return nil
+	}
+	if unsafePublic {
+		return nil
+	}
+	return fmt.Errorf("--admin-listen address %s is public; use a loopback/private address or pass --unsafe-admin-listen-public", addr)
+}
+
+// isPrivateOrLoopback returns true for loopback, link-local, RFC1918, and ULA
+// addresses — the address classes safe for an admin listener without explicit
+// opt-in.
+func isPrivateOrLoopback(addr netip.Addr) bool {
+	return addr.IsLoopback() || addr.IsPrivate() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast()
 }
 
 func validateHumanGateFlags(f *serveFlags) error {
@@ -705,6 +768,32 @@ func normalizePublicHost(raw string) (string, error) {
 	return host, nil
 }
 
+// writeDeadlineMiddleware sets a per-request write deadline on bounded,
+// fast-completing routes so a slow reader cannot pin a goroutine, WITHOUT a
+// server-level WriteTimeout (which would kill the long-lived routes). The
+// exemptPaths are left with NO write deadline because they legitimately exceed
+// it: the SSE stream writes indefinitely, and the message route is held open
+// for the entire model turn (a multi-step agent turn routinely takes longer
+// than the deadline) before the response is written. Those long-lived routes
+// are bounded instead by the session TTL and the upstream/edge connection
+// timeouts, not by this deadline.
+func writeDeadlineMiddleware(next http.Handler, timeout time.Duration, exemptPaths ...string) http.Handler {
+	exempt := make(map[string]struct{}, len(exemptPaths))
+	for _, p := range exemptPaths {
+		exempt[p] = struct{}{}
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rc := http.NewResponseController(w)
+		if _, ok := exempt[r.URL.Path]; ok {
+			// Long-lived route: clear any inherited deadline.
+			_ = rc.SetWriteDeadline(time.Time{})
+		} else {
+			_ = rc.SetWriteDeadline(time.Now().Add(timeout))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func hostGuard(next http.Handler, allowed []string) http.Handler {
 	set := make(map[string]struct{}, len(allowed))
 	for _, h := range allowed {
@@ -733,9 +822,10 @@ type cfAccessVerifier struct {
 	client   *http.Client
 	now      func() time.Time
 
-	mu      sync.RWMutex
-	keys    *jose.JSONWebKeySet
-	keysExp time.Time
+	mu        sync.RWMutex
+	keys      *jose.JSONWebKeySet
+	keysExp   time.Time
+	nextRetry time.Time // negative-cache: skip refetch until this time after a failure
 }
 
 func validateCFAccessFlags(f *serveFlags) error {
@@ -874,6 +964,32 @@ func (v *cfAccessVerifier) keySet(ctx context.Context) (*jose.JSONWebKeySet, err
 	if v.keys != nil && now.Before(v.keysExp) {
 		return v.keys, nil
 	}
+
+	// Negative-cache: if a previous refetch failed and we have stale keys,
+	// serve them until nextRetry to avoid hammering the JWKS endpoint.
+	if v.keys != nil && now.Before(v.nextRetry) {
+		v.keysExp = now.Add(cfAccessNegativeCacheTTL)
+		return v.keys, nil
+	}
+
+	keys, fetchErr := v.fetchKeys(ctx)
+	if fetchErr != nil {
+		// Fail-closed when there are no cached keys at all.
+		if v.keys == nil {
+			return nil, fetchErr
+		}
+		// Stale keys exist: serve them and set a negative-cache window.
+		v.nextRetry = now.Add(cfAccessNegativeCacheTTL)
+		v.keysExp = v.nextRetry
+		return v.keys, nil
+	}
+	v.keys = keys
+	v.keysExp = now.Add(cfAccessKeysTTL)
+	v.nextRetry = time.Time{}
+	return v.keys, nil
+}
+
+func (v *cfAccessVerifier) fetchKeys(ctx context.Context) (*jose.JSONWebKeySet, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.certsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build Cloudflare Access JWKS request: %w", err)
@@ -893,9 +1009,7 @@ func (v *cfAccessVerifier) keySet(ctx context.Context) (*jose.JSONWebKeySet, err
 	if len(keys.Keys) == 0 {
 		return nil, errors.New("cloudflare access jwks is empty")
 	}
-	v.keys = &keys
-	v.keysExp = now.Add(cfAccessKeysTTL)
-	return v.keys, nil
+	return &keys, nil
 }
 
 // resolveFlyToken reads the Fly API token from the configured file or env var.
@@ -999,10 +1113,14 @@ func resolveTurnstileVerifier(f *serveFlags) (broker.HumanVerifier, error) {
 	if err != nil {
 		return nil, err
 	}
-	return broker.TurnstileVerifier{
+	inner := broker.TurnstileVerifier{
 		Secret:    secret,
 		VerifyURL: strings.TrimSpace(f.turnstileVerifyURL),
 		Client:    &http.Client{Timeout: 5 * time.Second},
+	}
+	return &broker.ReplayGuardVerifier{
+		Inner: inner,
+		Seen:  broker.NewSeenTokens(0, nil),
 	}, nil
 }
 

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -17,10 +18,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
@@ -51,6 +54,9 @@ const (
 
 type serveFlags struct {
 	listen                string
+	adminListen           string
+	adminTokenFile        string
+	adminTokenEnv         string
 	staticDir             string
 	provider              string
 	flyApp                string
@@ -73,6 +79,11 @@ type serveFlags struct {
 	perIPDailyBudget      int
 	perCodeDailyBudget    int
 	globalDailyBudget     int
+	unsafeUnlimited       bool
+	unsafeNoHumanGate     bool
+	turnstileSecretFile   string
+	turnstileSecretEnv    string
+	turnstileVerifyURL    string
 	sessionTTL            time.Duration
 	deadlineGrace         time.Duration
 	allowOrigin           string
@@ -129,6 +140,9 @@ func newServeCmd() *cobra.Command {
 	}
 	fl := cmd.Flags()
 	fl.StringVar(&f.listen, "listen", defaultListen, "address to listen on")
+	fl.StringVar(&f.adminListen, "admin-listen", "", "separate admin listen address for authenticated pause/resume endpoints; empty disables")
+	fl.StringVar(&f.adminTokenFile, "admin-token-file", "", "path to bearer token required by --admin-listen")
+	fl.StringVar(&f.adminTokenEnv, "admin-token-env", "", "environment variable holding bearer token required by --admin-listen")
 	fl.StringVar(&f.staticDir, "static-dir", "", "directory of static UI files to serve at / (the /api/live/* API is unaffected); empty disables static serving")
 	fl.StringVar(&f.provider, "provider", "fly", "machine provider")
 	fl.StringVar(&f.flyApp, "fly-app", "", "Fly app that owns per-visitor machines")
@@ -151,6 +165,11 @@ func newServeCmd() *cobra.Command {
 	fl.IntVar(&f.perIPDailyBudget, "per-ip-daily-budget", 0, "per-IP session starts per UTC day (0 = unlimited)")
 	fl.IntVar(&f.perCodeDailyBudget, "per-code-daily-budget", 0, "per-code session starts per UTC day (0 = unlimited)")
 	fl.IntVar(&f.globalDailyBudget, "global-daily-budget", 0, "global session starts per UTC day (0 = unlimited)")
+	fl.BoolVar(&f.unsafeUnlimited, "unsafe-unlimited-budgets", false, "allow unlimited public broker/model budgets; unsafe for public deployments")
+	fl.BoolVar(&f.unsafeNoHumanGate, "unsafe-no-human-gate", false, "allow session creation without Turnstile or Cloudflare Access; unsafe for public deployments")
+	fl.StringVar(&f.turnstileSecretFile, "turnstile-secret-file", "", "path to the Cloudflare Turnstile secret; enables human verification for session creation")
+	fl.StringVar(&f.turnstileSecretEnv, "turnstile-secret-env", "", "environment variable holding the Cloudflare Turnstile secret; enables human verification for session creation")
+	fl.StringVar(&f.turnstileVerifyURL, "turnstile-verify-url", "", "Cloudflare Turnstile Siteverify URL override (tests/dev only; empty uses Cloudflare)")
 	fl.DurationVar(&f.sessionTTL, "session-ttl", defaultSessionTTL, "VM session token TTL")
 	fl.DurationVar(&f.deadlineGrace, "deadline-grace", defaultGrace, "lease teardown grace after VM session expiry")
 	fl.StringVar(&f.allowOrigin, "allow-origin", "", "Access-Control-Allow-Origin for the browser")
@@ -197,6 +216,13 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 		return fmt.Errorf("listen %s: %w", f.listen, err)
 	}
 	defer func() { _ = ln.Close() }()
+	stopSignals := startSignalControlLoop(ctx, cmd.OutOrStdout(), srv, httpSrv)
+	defer stopSignals()
+	stopAdmin, err := startAdminServer(ctx, cmd.OutOrStdout(), f, srv)
+	if err != nil {
+		return err
+	}
+	defer stopAdmin()
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pipelock-playground-broker serving on %s with provider %s\n", f.listen, f.provider)
 	if err := httpSrv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
@@ -236,6 +262,10 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 	if err != nil {
 		return nil, nil, err
 	}
+	humanVerifier, err := resolveTurnstileVerifier(f)
+	if err != nil {
+		return nil, nil, err
+	}
 	lm, err := broker.NewLeaseManager(broker.LeaseConfig{
 		Provider:     provider,
 		Concurrency:  livechat.NewConcurrencyLimiter(f.concurrency),
@@ -252,6 +282,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 	srv, err := broker.NewServer(broker.ServerConfig{
 		Leases:             lm,
 		Gate:               gate,
+		HumanVerifier:      humanVerifier,
 		IPRate:             livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
 		CodeRate:           livechat.RateConfig{RefillPerSec: f.codeRate, Burst: f.codeBurst},
 		PerIPDailyBudget:   f.perIPDailyBudget,
@@ -323,6 +354,9 @@ func validateFlags(f *serveFlags) error {
 	if strings.TrimSpace(f.flyTokenFile) == "" && strings.TrimSpace(f.flyTokenEnv) == "" {
 		return errors.New("a Fly API token is required: pass --fly-token-file or --fly-token-env")
 	}
+	if err := validateAdminFlags(f); err != nil {
+		return err
+	}
 	if f.concurrency <= 0 {
 		return errors.New("--concurrency must be > 0")
 	}
@@ -344,8 +378,22 @@ func validateFlags(f *serveFlags) error {
 	if f.perIPDailyBudget < 0 || f.perCodeDailyBudget < 0 || f.globalDailyBudget < 0 {
 		return errors.New("daily budgets must be >= 0")
 	}
+	if !f.unsafeUnlimited {
+		if f.globalDailyBudget <= 0 {
+			return errors.New("--global-daily-budget must be > 0 unless --unsafe-unlimited-budgets is set")
+		}
+		if f.vmDailyTurnBudget <= 0 {
+			return errors.New("--vm-daily-turn-budget must be > 0 unless --unsafe-unlimited-budgets is set")
+		}
+	}
+	if err := validateHumanGateFlags(f); err != nil {
+		return err
+	}
 	if f.sessionTTL <= 0 {
 		return errors.New("--session-ttl must be > 0")
+	}
+	if err := validateTurnstileFlags(f); err != nil {
+		return err
 	}
 	if f.deadlineGrace < 0 {
 		return errors.New("--deadline-grace must be >= 0")
@@ -357,6 +405,223 @@ func validateFlags(f *serveFlags) error {
 		return err
 	}
 	return nil
+}
+
+func validateAdminFlags(f *serveFlags) error {
+	listen := strings.TrimSpace(f.adminListen)
+	tokenFile := strings.TrimSpace(f.adminTokenFile)
+	tokenEnv := strings.TrimSpace(f.adminTokenEnv)
+	if listen == "" {
+		if tokenFile != "" || tokenEnv != "" {
+			return errors.New("--admin-token-file/--admin-token-env require --admin-listen")
+		}
+		return nil
+	}
+	if tokenFile == "" && tokenEnv == "" {
+		return errors.New("--admin-listen requires --admin-token-file or --admin-token-env")
+	}
+	return nil
+}
+
+func validateHumanGateFlags(f *serveFlags) error {
+	hasTurnstile := strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != ""
+	hasCFAccess := strings.TrimSpace(f.cfAccessTeamDomain) != "" || strings.TrimSpace(f.cfAccessAUD) != ""
+	if hasTurnstile || hasCFAccess || f.unsafeNoHumanGate {
+		return nil
+	}
+	return errors.New("--turnstile-secret-file/--turnstile-secret-env or Cloudflare Access is required unless --unsafe-no-human-gate is set")
+}
+
+func validateTurnstileFlags(f *serveFlags) error {
+	configured := strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != ""
+	if !configured && strings.TrimSpace(f.turnstileVerifyURL) != "" {
+		return errors.New("--turnstile-verify-url requires --turnstile-secret-file or --turnstile-secret-env")
+	}
+	if strings.TrimSpace(f.turnstileVerifyURL) == "" {
+		return nil
+	}
+	u, err := url.Parse(f.turnstileVerifyURL)
+	if err != nil {
+		return fmt.Errorf("--turnstile-verify-url: parse: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.New("--turnstile-verify-url must be http(s)")
+	}
+	if u.Host == "" {
+		return errors.New("--turnstile-verify-url host is required")
+	}
+	return nil
+}
+
+func startSignalControlLoop(ctx context.Context, out io.Writer, srv *broker.Server, httpSrv *http.Server) func() {
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGTERM, syscall.SIGINT)
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+	var shutdownOnce sync.Once
+	shutdown := func(reason string) {
+		shutdownOnce.Do(func() {
+			_, _ = fmt.Fprintf(out, "broker shutting down: %s\n", reason)
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			_ = httpSrv.Shutdown(shutdownCtx)
+		})
+	}
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case sig := <-sigCh:
+				if applyControlSignal(out, srv, sig) {
+					shutdown(sig.String())
+					return
+				}
+			case <-ctx.Done():
+				shutdown("context canceled")
+				return
+			case <-stopCh:
+				return
+			}
+		}
+	}()
+	return func() {
+		signal.Stop(sigCh)
+		close(stopCh)
+		<-done
+	}
+}
+
+func startAdminServer(ctx context.Context, out io.Writer, f *serveFlags, srv *broker.Server) (func(), error) {
+	if strings.TrimSpace(f.adminListen) == "" {
+		return func() {}, nil
+	}
+	token, err := resolveAdminToken(f)
+	if err != nil {
+		return nil, err
+	}
+	httpSrv := &http.Server{
+		Handler:           adminHandler(srv, token),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    8 << 10,
+	}
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(ctx, "tcp", f.adminListen)
+	if err != nil {
+		return nil, fmt.Errorf("admin listen %s: %w", f.adminListen, err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := httpSrv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			_, _ = fmt.Fprintf(out, "admin server error: %v\n", err)
+		}
+	}()
+	_, _ = fmt.Fprintf(out, "broker admin serving on %s\n", f.adminListen)
+	return func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = httpSrv.Shutdown(shutdownCtx)
+		_ = ln.Close()
+		<-done
+	}, nil
+}
+
+func resolveAdminToken(f *serveFlags) (string, error) {
+	if strings.TrimSpace(f.adminTokenFile) != "" {
+		return readRequiredFile(f.adminTokenFile, "--admin-token-file")
+	}
+	v := strings.TrimSpace(os.Getenv(f.adminTokenEnv))
+	if v == "" {
+		return "", fmt.Errorf("%s is empty or unset", f.adminTokenEnv)
+	}
+	return v, nil
+}
+
+func adminHandler(srv *broker.Server, token string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/admin/health", func(w http.ResponseWriter, r *http.Request) {
+		if !adminAuthorized(r, token) {
+			writeAdminAuthErr(w, r)
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		writeAdminJSON(w, http.StatusOK, map[string]any{"killed": srv.Killed()})
+	})
+	mux.HandleFunc("/admin/pause", func(w http.ResponseWriter, r *http.Request) {
+		if !adminAuthorized(r, token) {
+			writeAdminAuthErr(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		srv.Kill()
+		writeAdminJSON(w, http.StatusOK, map[string]any{"killed": true})
+	})
+	mux.HandleFunc("/admin/resume", func(w http.ResponseWriter, r *http.Request) {
+		if !adminAuthorized(r, token) {
+			writeAdminAuthErr(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		srv.Resume()
+		writeAdminJSON(w, http.StatusOK, map[string]any{"killed": false})
+	})
+	return mux
+}
+
+func adminAuthorized(r *http.Request, token string) bool {
+	got := strings.TrimSpace(r.Header.Get("Authorization"))
+	const prefix = "Bearer "
+	if !strings.HasPrefix(got, prefix) {
+		return false
+	}
+	got = strings.TrimSpace(strings.TrimPrefix(got, prefix))
+	if got == "" || token == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(token)) == 1
+}
+
+func writeAdminAuthErr(w http.ResponseWriter, r *http.Request) {
+	if strings.TrimSpace(r.Header.Get("Authorization")) == "" {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		http.Error(w, "missing bearer token", http.StatusUnauthorized)
+		return
+	}
+	http.Error(w, "invalid bearer token", http.StatusForbidden)
+}
+
+func writeAdminJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func applyControlSignal(out io.Writer, srv *broker.Server, sig os.Signal) bool {
+	switch sig {
+	case syscall.SIGUSR1:
+		srv.Kill()
+		_, _ = fmt.Fprintln(out, "broker paused by SIGUSR1")
+		return false
+	case syscall.SIGUSR2:
+		srv.Resume()
+		_, _ = fmt.Fprintln(out, "broker resumed by SIGUSR2")
+		return false
+	case syscall.SIGTERM, syscall.SIGINT:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateAllowOrigin(raw string) error {
@@ -713,6 +978,32 @@ func buildVMBaseEnv(f *serveFlags) map[string]string {
 		env["PLAYGROUND_MAX_MESSAGES"] = strconv.Itoa(f.vmMaxMessages)
 	}
 	return env
+}
+
+func resolveTurnstileVerifier(f *serveFlags) (broker.HumanVerifier, error) {
+	file := strings.TrimSpace(f.turnstileSecretFile)
+	envName := strings.TrimSpace(f.turnstileSecretEnv)
+	if file == "" && envName == "" {
+		return nil, nil
+	}
+	var secret string
+	var err error
+	if file != "" {
+		secret, err = readRequiredFile(file, "--turnstile-secret-file")
+	} else {
+		secret = strings.TrimSpace(os.Getenv(envName))
+		if secret == "" {
+			err = fmt.Errorf("%s is empty or unset", envName)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return broker.TurnstileVerifier{
+		Secret:    secret,
+		VerifyURL: strings.TrimSpace(f.turnstileVerifyURL),
+		Client:    &http.Client{Timeout: 5 * time.Second},
+	}, nil
 }
 
 func resolveSessionEnv(f *serveFlags) (map[string]string, error) {

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -1063,8 +1063,8 @@ func TestCFAccessJWKS_NegativeCache(t *testing.T) {
 	}
 
 	// Initial fetch succeeds and caches.
-	token := signedCFAccessTestJWT(t, priv, kid, verifier.issuer, verifier.audience, now)
-	if err := verifier.verify(context.Background(), token); err != nil {
+	jwt := signedCFAccessTestJWT(t, priv, kid, verifier.issuer, verifier.audience, now)
+	if err := verifier.verify(context.Background(), jwt); err != nil {
 		t.Fatalf("initial verify: %v", err)
 	}
 	if fetchCount != 1 {
@@ -1075,8 +1075,8 @@ func TestCFAccessJWKS_NegativeCache(t *testing.T) {
 	now = now.Add(cfAccessKeysTTL + time.Second)
 	fetchFailing = true
 	fetchesBefore := fetchCount
-	token = signedCFAccessTestJWT(t, priv, kid, verifier.issuer, verifier.audience, now)
-	if err := verifier.verify(context.Background(), token); err != nil {
+	jwt = signedCFAccessTestJWT(t, priv, kid, verifier.issuer, verifier.audience, now)
+	if err := verifier.verify(context.Background(), jwt); err != nil {
 		t.Fatalf("verify with stale keys after fetch failure: %v", err)
 	}
 	if fetchCount != fetchesBefore+1 {
@@ -1085,8 +1085,8 @@ func TestCFAccessJWKS_NegativeCache(t *testing.T) {
 
 	// Within the negative-cache window, no new fetch is attempted.
 	fetchesBefore = fetchCount
-	token = signedCFAccessTestJWT(t, priv, kid, verifier.issuer, verifier.audience, now)
-	if err := verifier.verify(context.Background(), token); err != nil {
+	jwt = signedCFAccessTestJWT(t, priv, kid, verifier.issuer, verifier.audience, now)
+	if err := verifier.verify(context.Background(), jwt); err != nil {
 		t.Fatalf("verify within negative-cache window: %v", err)
 	}
 	if fetchCount != fetchesBefore {

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -88,8 +89,11 @@ func TestBuildServerWithInjectedProvider(t *testing.T) {
 		ipBurst:               defaultIPBurst,
 		codeRate:              defaultCodeRate,
 		codeBurst:             defaultCodeBurst,
+		globalDailyBudget:     10,
+		unsafeNoHumanGate:     true,
 		sessionTTL:            defaultSessionTTL,
 		deadlineGrace:         defaultGrace,
+		vmDailyTurnBudget:     10,
 		modelKeyFile:          modelFile,
 		orchestratorKeyFile:   orchestratorFile,
 		requireSessionSecrets: true,
@@ -134,7 +138,10 @@ func TestBuildServerStaticDir(t *testing.T) {
 			codes: []string{"outer-code"}, maxPerCode: defaultMaxPerCode,
 			gateSecretFile: gateSecretFile, ipRate: defaultIPRate, ipBurst: defaultIPBurst,
 			codeRate: defaultCodeRate, codeBurst: defaultCodeBurst,
-			sessionTTL: defaultSessionTTL, deadlineGrace: defaultGrace,
+			globalDailyBudget: 10,
+			unsafeNoHumanGate: true,
+			sessionTTL:        defaultSessionTTL, deadlineGrace: defaultGrace,
+			vmDailyTurnBudget:     10,
 			requireSessionSecrets: false,
 		}
 	}
@@ -191,7 +198,10 @@ func TestBuildServerHostGuardFromAllowOrigin(t *testing.T) {
 		codes: []string{"outer-code"}, maxPerCode: defaultMaxPerCode,
 		gateSecretFile: gateSecretFile, ipRate: defaultIPRate, ipBurst: defaultIPBurst,
 		codeRate: defaultCodeRate, codeBurst: defaultCodeBurst,
-		sessionTTL: defaultSessionTTL, deadlineGrace: defaultGrace,
+		globalDailyBudget: 10,
+		unsafeNoHumanGate: true,
+		sessionTTL:        defaultSessionTTL, deadlineGrace: defaultGrace,
+		vmDailyTurnBudget:     10,
 		allowOrigin:           "https://playground.pipelab.org",
 		requireSessionSecrets: false,
 	})
@@ -260,7 +270,9 @@ func TestBuildServerCFAccessGuard(t *testing.T) {
 		codes: []string{"outer-code"}, maxPerCode: defaultMaxPerCode,
 		gateSecretFile: gateSecretFile, ipRate: defaultIPRate, ipBurst: defaultIPBurst,
 		codeRate: defaultCodeRate, codeBurst: defaultCodeBurst,
-		sessionTTL: defaultSessionTTL, deadlineGrace: defaultGrace,
+		globalDailyBudget: 10,
+		sessionTTL:        defaultSessionTTL, deadlineGrace: defaultGrace,
+		vmDailyTurnBudget:     10,
 		allowOrigin:           "https://playground.pipelab.org",
 		cfAccessTeamDomain:    issuer,
 		cfAccessAUD:           aud,
@@ -294,6 +306,60 @@ func TestBuildServerCFAccessGuard(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), "live demo ui") {
 		t.Fatalf("valid Access JWT status/body = %d %q, want UI", rr.Code, rr.Body.String())
+	}
+}
+
+func TestBuildServerTurnstileRejectsMissingToken(t *testing.T) {
+	dir := t.TempDir()
+	flyTokenFile := writeTestFile(t, dir, "fly.token", "fly-file-token\n")
+	gateSecret := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	gateSecretFile := writeTestFile(t, dir, "gate.b64", gateSecret+"\n")
+	turnstileSecretFile := writeTestFile(t, dir, "turnstile.secret", "turnstile-secret\n")
+	verifyServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("missing-token rejection should not call Turnstile Siteverify")
+	}))
+	t.Cleanup(verifyServer.Close)
+
+	oldFactory := newMachineProvider
+	newMachineProvider = func(_ context.Context, _ *serveFlags, _ string) (broker.MachineProvider, error) {
+		return fakeProvider{}, nil
+	}
+	t.Cleanup(func() { newMachineProvider = oldFactory })
+
+	srv, handler, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
+		listen:                defaultListen,
+		provider:              "fake",
+		flyApp:                "playground-test",
+		flyTokenFile:          flyTokenFile,
+		image:                 "registry.example/playground:test",
+		internalPort:          8080,
+		concurrency:           2,
+		codes:                 []string{"outer-code"},
+		maxPerCode:            defaultMaxPerCode,
+		gateSecretFile:        gateSecretFile,
+		ipRate:                defaultIPRate,
+		ipBurst:               defaultIPBurst,
+		codeRate:              defaultCodeRate,
+		codeBurst:             defaultCodeBurst,
+		globalDailyBudget:     10,
+		turnstileSecretFile:   turnstileSecretFile,
+		turnstileVerifyURL:    verifyServer.URL,
+		sessionTTL:            defaultSessionTTL,
+		deadlineGrace:         defaultGrace,
+		vmDailyTurnBudget:     10,
+		requireSessionSecrets: false,
+	})
+	if err != nil {
+		t.Fatalf("buildServer: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, livechat.RouteSession, strings.NewReader(`{"code":"outer-code"}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("missing Turnstile token status = %d, want 403", rr.Code)
 	}
 }
 
@@ -387,8 +453,11 @@ func TestBuildServerValidation(t *testing.T) {
 		ipBurst:               defaultIPBurst,
 		codeRate:              defaultCodeRate,
 		codeBurst:             defaultCodeBurst,
+		globalDailyBudget:     10,
+		unsafeNoHumanGate:     true,
 		sessionTTL:            defaultSessionTTL,
 		deadlineGrace:         defaultGrace,
+		vmDailyTurnBudget:     10,
 		requireSessionSecrets: false,
 	}
 	tests := []struct {
@@ -400,6 +469,8 @@ func TestBuildServerValidation(t *testing.T) {
 		{name: "bad_origin", mutate: func(f *serveFlags) { f.allowOrigin = "*" }},
 		{name: "bad_port", mutate: func(f *serveFlags) { f.internalPort = 0 }},
 		{name: "negative_budget", mutate: func(f *serveFlags) { f.globalDailyBudget = -1 }},
+		{name: "missing_global_budget", mutate: func(f *serveFlags) { f.globalDailyBudget = 0 }},
+		{name: "missing_vm_budget", mutate: func(f *serveFlags) { f.vmDailyTurnBudget = 0 }},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -443,8 +514,11 @@ func TestRunServeListenErrorAfterBuild(t *testing.T) {
 		ipBurst:               defaultIPBurst,
 		codeRate:              defaultCodeRate,
 		codeBurst:             defaultCodeBurst,
+		globalDailyBudget:     10,
+		unsafeNoHumanGate:     true,
 		sessionTTL:            defaultSessionTTL,
 		deadlineGrace:         defaultGrace,
+		vmDailyTurnBudget:     10,
 		requireSessionSecrets: false,
 	})
 	if err == nil || !strings.Contains(err.Error(), "listen 127.0.0.1:bad-port") {
@@ -452,6 +526,111 @@ func TestRunServeListenErrorAfterBuild(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "broker configured") {
 		t.Fatalf("runServe should build before listen error, output = %q", out.String())
+	}
+}
+
+func TestApplyControlSignal(t *testing.T) {
+	srv := newBrokerControlTestServer(t)
+
+	var out bytes.Buffer
+	if shutdown := applyControlSignal(&out, srv, syscall.SIGUSR1); shutdown {
+		t.Fatal("SIGUSR1 requested shutdown, want pause only")
+	}
+	if !srv.Killed() {
+		t.Fatal("SIGUSR1 did not pause broker")
+	}
+	if shutdown := applyControlSignal(&out, srv, syscall.SIGUSR2); shutdown {
+		t.Fatal("SIGUSR2 requested shutdown, want resume only")
+	}
+	if srv.Killed() {
+		t.Fatal("SIGUSR2 did not resume broker")
+	}
+	if shutdown := applyControlSignal(&out, srv, syscall.SIGTERM); !shutdown {
+		t.Fatal("SIGTERM did not request graceful shutdown")
+	}
+	if got := out.String(); !strings.Contains(got, "paused") || !strings.Contains(got, "resumed") {
+		t.Fatalf("operator output = %q, want pause and resume messages", got)
+	}
+}
+
+func newBrokerControlTestServer(t *testing.T) *broker.Server {
+	t.Helper()
+	gate, err := livechat.NewGate(livechat.GateConfig{
+		Secret: []byte("0123456789abcdef0123456789abcdef"),
+		Codes:  []livechat.CodeSpec{{Code: "outer-code"}},
+	})
+	if err != nil {
+		t.Fatalf("new gate: %v", err)
+	}
+	lm, err := broker.NewLeaseManager(broker.LeaseConfig{
+		Provider:    fakeProvider{},
+		Concurrency: livechat.NewConcurrencyLimiter(1),
+		Image:       "registry.example/playground:test",
+	})
+	if err != nil {
+		t.Fatalf("new lease manager: %v", err)
+	}
+	srv, err := broker.NewServer(broker.ServerConfig{
+		Leases:            lm,
+		Gate:              gate,
+		GlobalDailyBudget: 1,
+	})
+	if err != nil {
+		t.Fatalf("new broker server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestAdminHandlerAuthAndPauseResume(t *testing.T) {
+	srv := newBrokerControlTestServer(t)
+	handler := adminHandler(srv, "operator-value")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/admin/pause", nil)
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("missing auth status = %d, want 401", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/admin/pause", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("bad auth status = %d, want 403", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/admin/pause", nil)
+	req.Header.Set("Authorization", "Bearer operator-value")
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET pause status = %d, want 405", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/admin/pause", nil)
+	req.Header.Set("Authorization", "Bearer operator-value")
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK || !srv.Killed() {
+		t.Fatalf("pause status/killed = %d/%v, want 200/true", rr.Code, srv.Killed())
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/admin/resume", nil)
+	req.Header.Set("Authorization", "Bearer operator-value")
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK || srv.Killed() {
+		t.Fatalf("resume status/killed = %d/%v, want 200/false", rr.Code, srv.Killed())
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/admin/health", nil)
+	req.Header.Set("Authorization", "Bearer operator-value")
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"killed":false`) {
+		t.Fatalf("health status/body = %d/%q, want killed false", rr.Code, rr.Body.String())
 	}
 }
 
@@ -480,6 +659,65 @@ func TestResolveGateSecret(t *testing.T) {
 	}
 }
 
+func TestResolveTurnstileVerifier(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestFile(t, dir, "turnstile.secret", "file-secret\n")
+	got, err := resolveTurnstileVerifier(&serveFlags{turnstileSecretFile: path})
+	if err != nil {
+		t.Fatalf("resolveTurnstileVerifier file: %v", err)
+	}
+	fileVerifier, ok := got.(broker.TurnstileVerifier)
+	if !ok {
+		t.Fatalf("verifier type = %T, want broker.TurnstileVerifier", got)
+	}
+	if fileVerifier.Secret != "file-secret" {
+		t.Fatal("file turnstile secret mismatch")
+	}
+
+	t.Setenv("BROKER_TEST_TURNSTILE", "env-secret")
+	got, err = resolveTurnstileVerifier(&serveFlags{turnstileSecretEnv: "BROKER_TEST_TURNSTILE"})
+	if err != nil {
+		t.Fatalf("resolveTurnstileVerifier env: %v", err)
+	}
+	envVerifier, ok := got.(broker.TurnstileVerifier)
+	if !ok {
+		t.Fatalf("verifier type = %T, want broker.TurnstileVerifier", got)
+	}
+	if envVerifier.Secret != "env-secret" {
+		t.Fatal("env turnstile secret mismatch")
+	}
+	if got, err := resolveTurnstileVerifier(&serveFlags{}); err != nil || got != nil {
+		t.Fatalf("resolveTurnstileVerifier empty = %T %v, want nil nil", got, err)
+	}
+	if _, err := resolveTurnstileVerifier(&serveFlags{turnstileSecretEnv: "BROKER_TEST_EMPTY_VALUE"}); err == nil { //nolint:gosec // Test env var name, not a credential.
+		t.Fatal("empty turnstile env should error")
+	}
+}
+
+func TestResolveAdminToken(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestFile(t, dir, "admin.token", "file-token\n")
+	got, err := resolveAdminToken(&serveFlags{adminTokenFile: path})
+	if err != nil {
+		t.Fatalf("resolveAdminToken file: %v", err)
+	}
+	if got != "file-token" {
+		t.Fatal("file admin token mismatch")
+	}
+
+	t.Setenv("BROKER_TEST_ADMIN_VALUE", "env-token")
+	got, err = resolveAdminToken(&serveFlags{adminTokenEnv: "BROKER_TEST_ADMIN_VALUE"})
+	if err != nil {
+		t.Fatalf("resolveAdminToken env: %v", err)
+	}
+	if got != "env-token" {
+		t.Fatal("env admin token mismatch")
+	}
+	if _, err := resolveAdminToken(&serveFlags{adminTokenEnv: "BROKER_TEST_EMPTY_VALUE"}); err == nil { //nolint:gosec // Test env var name, not a credential.
+		t.Fatal("empty admin token env should error")
+	}
+}
+
 func TestDefaultMachineProvider(t *testing.T) {
 	provider, err := defaultMachineProvider(context.Background(), &serveFlags{
 		provider: "fly",
@@ -502,20 +740,23 @@ func TestDefaultMachineProvider(t *testing.T) {
 
 func TestValidateFlagsBranches(t *testing.T) {
 	base := serveFlags{
-		provider:      "fly",
-		flyApp:        "playground-test",
-		flyTokenEnv:   "BROKER_TEST_FLY_TOKEN",
-		image:         "registry.example/playground:test",
-		internalPort:  8080,
-		concurrency:   1,
-		codes:         []string{"outer-code"},
-		maxPerCode:    defaultMaxPerCode,
-		ipRate:        defaultIPRate,
-		ipBurst:       defaultIPBurst,
-		codeRate:      defaultCodeRate,
-		codeBurst:     defaultCodeBurst,
-		sessionTTL:    defaultSessionTTL,
-		deadlineGrace: defaultGrace,
+		provider:          "fly",
+		flyApp:            "playground-test",
+		flyTokenEnv:       "BROKER_TEST_FLY_TOKEN",
+		image:             "registry.example/playground:test",
+		internalPort:      8080,
+		concurrency:       1,
+		codes:             []string{"outer-code"},
+		maxPerCode:        defaultMaxPerCode,
+		ipRate:            defaultIPRate,
+		ipBurst:           defaultIPBurst,
+		codeRate:          defaultCodeRate,
+		codeBurst:         defaultCodeBurst,
+		globalDailyBudget: 10,
+		unsafeNoHumanGate: true,
+		sessionTTL:        defaultSessionTTL,
+		deadlineGrace:     defaultGrace,
+		vmDailyTurnBudget: 10,
 	}
 	if err := validateFlags(&base); err != nil {
 		t.Fatalf("base validateFlags: %v", err)
@@ -523,17 +764,47 @@ func TestValidateFlagsBranches(t *testing.T) {
 	if err := validateFlags(nil); err == nil {
 		t.Fatal("nil flags should error")
 	}
+	noHumanGate := base
+	noHumanGate.unsafeNoHumanGate = false
+	if err := validateFlags(&noHumanGate); err == nil {
+		t.Fatal("broker without Turnstile, Cloudflare Access, or --unsafe-no-human-gate should fail")
+	}
+	turnstileGate := noHumanGate
+	turnstileGate.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
+	if err := validateFlags(&turnstileGate); err != nil {
+		t.Fatalf("turnstile gate should validate: %v", err)
+	}
+	cfAccessGate := noHumanGate
+	cfAccessGate.cfAccessTeamDomain = "team.cloudflareaccess.com"
+	cfAccessGate.cfAccessAUD = "aud"
+	if err := validateFlags(&cfAccessGate); err != nil {
+		t.Fatalf("Cloudflare Access gate should validate: %v", err)
+	}
+	unsafeUnlimited := base
+	unsafeUnlimited.globalDailyBudget = 0
+	unsafeUnlimited.vmDailyTurnBudget = 0
+	unsafeUnlimited.unsafeUnlimited = true
+	if err := validateFlags(&unsafeUnlimited); err != nil {
+		t.Fatalf("unsafe unlimited budgets should validate: %v", err)
+	}
 	tests := []struct {
 		name   string
 		mutate func(*serveFlags)
 	}{
 		{name: "missing_fly_app", mutate: func(f *serveFlags) { f.flyApp = "" }},
 		{name: "missing_token_source", mutate: func(f *serveFlags) { f.flyTokenEnv = "" }},
+		{name: "admin_token_without_listen", mutate: func(f *serveFlags) { f.adminTokenEnv = "BROKER_ADMIN_VALUE" }},
+		{name: "admin_listen_without_token", mutate: func(f *serveFlags) { f.adminListen = "127.0.0.1:0" }},
 		{name: "bad_concurrency", mutate: func(f *serveFlags) { f.concurrency = 0 }},
 		{name: "bad_max_per_code", mutate: func(f *serveFlags) { f.maxPerCode = -1 }},
 		{name: "bad_memory", mutate: func(f *serveFlags) { f.memoryMB = -1 }},
 		{name: "bad_cpus", mutate: func(f *serveFlags) { f.cpus = -1 }},
 		{name: "bad_deadline_grace", mutate: func(f *serveFlags) { f.deadlineGrace = -1 }},
+		{name: "turnstile_url_without_secret", mutate: func(f *serveFlags) { f.turnstileVerifyURL = "https://turnstile.example/verify" }},
+		{name: "bad_turnstile_verify_url", mutate: func(f *serveFlags) {
+			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
+			f.turnstileVerifyURL = "file:///tmp/siteverify"
+		}},
 		{name: "bad_cf_combo", mutate: func(f *serveFlags) { f.cfAccessCertsURL = "https://keys.example/certs" }},
 		{name: "bad_cf_aud", mutate: func(f *serveFlags) {
 			f.cfAccessTeamDomain = "team.cloudflareaccess.com"

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,6 +40,23 @@ func (fakeProvider) WaitReady(_ context.Context, _ string) error {
 
 func (fakeProvider) DestroyMachine(_ context.Context, _ string) error {
 	return nil
+}
+
+type lockedBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
 }
 
 func TestRootCommandHasServe(t *testing.T) {
@@ -497,7 +514,7 @@ func TestRunServeListenErrorAfterBuild(t *testing.T) {
 	t.Cleanup(func() { newMachineProvider = oldFactory })
 
 	cmd := newServeCmd()
-	var out bytes.Buffer
+	var out lockedBuffer
 	cmd.SetOut(&out)
 	err := runServe(cmd, &serveFlags{
 		listen:                "127.0.0.1:bad-port",
@@ -529,27 +546,84 @@ func TestRunServeListenErrorAfterBuild(t *testing.T) {
 	}
 }
 
-func TestApplyControlSignal(t *testing.T) {
+func TestRunServeContextCancelledShutsDown(t *testing.T) {
+	dir := t.TempDir()
+	flyTokenFile := writeTestFile(t, dir, "fly.token", "fly-file-token\n")
+	gateSecret := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	gateSecretFile := writeTestFile(t, dir, "gate.b64", gateSecret+"\n")
+
+	oldFactory := newMachineProvider
+	newMachineProvider = func(_ context.Context, _ *serveFlags, _ string) (broker.MachineProvider, error) {
+		return fakeProvider{}, nil
+	}
+	t.Cleanup(func() { newMachineProvider = oldFactory })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd := newServeCmd()
+	cmd.SetContext(ctx)
+	var out lockedBuffer
+	cmd.SetOut(&out)
+	err := runServe(cmd, &serveFlags{
+		listen:                "127.0.0.1:0",
+		provider:              "fake",
+		flyApp:                "playground-test",
+		flyTokenFile:          flyTokenFile,
+		image:                 "registry.example/playground:test",
+		internalPort:          8080,
+		concurrency:           1,
+		codes:                 []string{"outer-code"},
+		maxPerCode:            defaultMaxPerCode,
+		gateSecretFile:        gateSecretFile,
+		ipRate:                defaultIPRate,
+		ipBurst:               defaultIPBurst,
+		codeRate:              defaultCodeRate,
+		codeBurst:             defaultCodeBurst,
+		globalDailyBudget:     10,
+		unsafeNoHumanGate:     true,
+		sessionTTL:            defaultSessionTTL,
+		deadlineGrace:         defaultGrace,
+		vmDailyTurnBudget:     10,
+		requireSessionSecrets: false,
+	})
+	if err != nil {
+		t.Fatalf("runServe with canceled context: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "broker shutting down: context canceled") {
+		t.Fatalf("runServe output = %q, want context-canceled shutdown", got)
+	}
+}
+
+func TestStartSignalControlLoopContextCancelled(t *testing.T) {
+	srv := newBrokerControlTestServer(t)
+	httpSrv := &http.Server{
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: time.Second,
+	}
+	shutdownDone := make(chan struct{})
+	httpSrv.RegisterOnShutdown(func() { close(shutdownDone) })
+	ctx, cancel := context.WithCancel(context.Background())
+	var out lockedBuffer
+	stop := startSignalControlLoop(ctx, &out, srv, httpSrv)
+	cancel()
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for signal loop shutdown")
+	}
+	stop()
+
+	if got := out.String(); !strings.Contains(got, "broker shutting down: context canceled") {
+		t.Fatalf("signal loop output = %q, want context-canceled shutdown", got)
+	}
+}
+
+func TestApplyControlSignalShutdown(t *testing.T) {
 	srv := newBrokerControlTestServer(t)
 
 	var out bytes.Buffer
-	if shutdown := applyControlSignal(&out, srv, syscall.SIGUSR1); shutdown {
-		t.Fatal("SIGUSR1 requested shutdown, want pause only")
-	}
-	if !srv.Killed() {
-		t.Fatal("SIGUSR1 did not pause broker")
-	}
-	if shutdown := applyControlSignal(&out, srv, syscall.SIGUSR2); shutdown {
-		t.Fatal("SIGUSR2 requested shutdown, want resume only")
-	}
-	if srv.Killed() {
-		t.Fatal("SIGUSR2 did not resume broker")
-	}
-	if shutdown := applyControlSignal(&out, srv, syscall.SIGTERM); !shutdown {
-		t.Fatal("SIGTERM did not request graceful shutdown")
-	}
-	if got := out.String(); !strings.Contains(got, "paused") || !strings.Contains(got, "resumed") {
-		t.Fatalf("operator output = %q, want pause and resume messages", got)
+	if shutdown := applyControlSignal(&out, srv, os.Interrupt); !shutdown {
+		t.Fatal("interrupt did not request graceful shutdown")
 	}
 }
 
@@ -631,6 +705,21 @@ func TestAdminHandlerAuthAndPauseResume(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"killed":false`) {
 		t.Fatalf("health status/body = %d/%q, want killed false", rr.Code, rr.Body.String())
+	}
+}
+
+func TestStartAdminServerValidationBranches(t *testing.T) {
+	srv := newBrokerControlTestServer(t)
+	if stop, err := startAdminServer(context.Background(), io.Discard, &serveFlags{}, srv); err != nil {
+		t.Fatalf("startAdminServer disabled: %v", err)
+	} else {
+		stop()
+	}
+	if _, err := startAdminServer(context.Background(), io.Discard, &serveFlags{
+		adminListen:   "127.0.0.1:0",
+		adminTokenEnv: "BROKER_TEST_EMPTY_" + "ADMIN",
+	}, srv); err == nil {
+		t.Fatal("startAdminServer with empty token env succeeded, want error")
 	}
 }
 
@@ -858,6 +947,50 @@ func TestBrokerPublicHosts(t *testing.T) {
 	}
 	if _, err := brokerPublicHosts(&serveFlags{publicHosts: []string{"https://bad.example"}}); err == nil {
 		t.Fatal("URL-shaped public host should error")
+	}
+}
+
+func TestValidateAllowOriginBranches(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "empty", raw: "", wantErr: false},
+		{name: "valid", raw: "https://playground.pipelab.org", wantErr: false},
+		{name: "surrounding_space", raw: " https://playground.pipelab.org", wantErr: true},
+		{name: "wildcard", raw: "*", wantErr: true},
+		{name: "bad_scheme", raw: "ftp://playground.pipelab.org", wantErr: true},
+		{name: "missing_host", raw: "https:///path", wantErr: true},
+		{name: "path_not_origin", raw: "https://playground.pipelab.org/path", wantErr: true},
+		{name: "query_not_origin", raw: "https://playground.pipelab.org?x=1", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAllowOrigin(tc.raw)
+			if tc.wantErr && err == nil {
+				t.Fatal("validateAllowOrigin succeeded, want error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateAllowOrigin: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveCodesBranches(t *testing.T) {
+	specs, err := resolveCodes([]string{"outer", "inner"}, 3)
+	if err != nil {
+		t.Fatalf("resolveCodes: %v", err)
+	}
+	if len(specs) != 2 || specs[0].Code != "outer" || specs[0].MaxSessions != 3 || specs[1].Code != "inner" {
+		t.Fatalf("specs = %+v, want two code specs with max sessions", specs)
+	}
+	if _, err := resolveCodes(nil, 3); err == nil {
+		t.Fatal("missing codes should error")
+	}
+	if _, err := resolveCodes([]string{"outer", " \t"}, 3); err == nil {
+		t.Fatal("blank code should error")
 	}
 }
 

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -666,11 +666,15 @@ func TestResolveTurnstileVerifier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveTurnstileVerifier file: %v", err)
 	}
-	fileVerifier, ok := got.(broker.TurnstileVerifier)
+	fileGuard, ok := got.(*broker.ReplayGuardVerifier)
 	if !ok {
-		t.Fatalf("verifier type = %T, want broker.TurnstileVerifier", got)
+		t.Fatalf("verifier type = %T, want *broker.ReplayGuardVerifier", got)
 	}
-	if fileVerifier.Secret != "file-secret" {
+	fileInner, ok := fileGuard.Inner.(broker.TurnstileVerifier)
+	if !ok {
+		t.Fatalf("inner type = %T, want broker.TurnstileVerifier", fileGuard.Inner)
+	}
+	if fileInner.Secret != "file-secret" {
 		t.Fatal("file turnstile secret mismatch")
 	}
 
@@ -679,11 +683,15 @@ func TestResolveTurnstileVerifier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveTurnstileVerifier env: %v", err)
 	}
-	envVerifier, ok := got.(broker.TurnstileVerifier)
+	envGuard, ok := got.(*broker.ReplayGuardVerifier)
 	if !ok {
-		t.Fatalf("verifier type = %T, want broker.TurnstileVerifier", got)
+		t.Fatalf("verifier type = %T, want *broker.ReplayGuardVerifier", got)
 	}
-	if envVerifier.Secret != "env-secret" {
+	envInner, ok := envGuard.Inner.(broker.TurnstileVerifier)
+	if !ok {
+		t.Fatalf("inner type = %T, want broker.TurnstileVerifier", envGuard.Inner)
+	}
+	if envInner.Secret != "env-secret" {
 		t.Fatal("env turnstile secret mismatch")
 	}
 	if got, err := resolveTurnstileVerifier(&serveFlags{}); err != nil || got != nil {
@@ -1016,6 +1024,93 @@ func TestCFAccessVerifierErrorsAndCache(t *testing.T) {
 	}
 }
 
+func TestCFAccessJWKS_NegativeCache(t *testing.T) {
+	t.Parallel()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	const kid = "neg-cache-key"
+	jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+		Key:       &priv.PublicKey,
+		KeyID:     kid,
+		Algorithm: string(jose.RS256),
+		Use:       "sig",
+	}}}
+
+	var fetchCount int
+	fetchFailing := false
+	keySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount++
+		if fetchFailing {
+			http.Error(w, "down", http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	t.Cleanup(keySrv.Close)
+
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	verifier := &cfAccessVerifier{
+		issuer:   "https://team.cloudflareaccess.com",
+		audience: "aud",
+		certsURL: keySrv.URL,
+		client:   keySrv.Client(),
+		now:      func() time.Time { return now },
+	}
+
+	// Initial fetch succeeds and caches.
+	token := signedCFAccessTestJWT(t, priv, kid, verifier.issuer, verifier.audience, now)
+	if err := verifier.verify(context.Background(), token); err != nil {
+		t.Fatalf("initial verify: %v", err)
+	}
+	if fetchCount != 1 {
+		t.Fatalf("fetches = %d, want 1", fetchCount)
+	}
+
+	// Expire the cache and make fetch fail.
+	now = now.Add(cfAccessKeysTTL + time.Second)
+	fetchFailing = true
+	fetchesBefore := fetchCount
+	token = signedCFAccessTestJWT(t, priv, kid, verifier.issuer, verifier.audience, now)
+	if err := verifier.verify(context.Background(), token); err != nil {
+		t.Fatalf("verify with stale keys after fetch failure: %v", err)
+	}
+	if fetchCount != fetchesBefore+1 {
+		t.Fatalf("expected exactly 1 refetch attempt, got %d", fetchCount-fetchesBefore)
+	}
+
+	// Within the negative-cache window, no new fetch is attempted.
+	fetchesBefore = fetchCount
+	token = signedCFAccessTestJWT(t, priv, kid, verifier.issuer, verifier.audience, now)
+	if err := verifier.verify(context.Background(), token); err != nil {
+		t.Fatalf("verify within negative-cache window: %v", err)
+	}
+	if fetchCount != fetchesBefore {
+		t.Fatalf("fetch during negative-cache window: got %d additional fetches", fetchCount-fetchesBefore)
+	}
+}
+
+func TestCFAccessJWKS_NoCacheFailsClosed(t *testing.T) {
+	t.Parallel()
+	keySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "down", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(keySrv.Close)
+
+	verifier := &cfAccessVerifier{
+		issuer:   "https://team.cloudflareaccess.com",
+		audience: "aud",
+		certsURL: keySrv.URL,
+		client:   keySrv.Client(),
+		now:      time.Now,
+	}
+
+	if _, err := verifier.keySet(context.Background()); err == nil {
+		t.Fatal("keySet with no cache and failing fetch should error (fail-closed)")
+	}
+}
+
 func writeTestFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)
@@ -1029,6 +1124,126 @@ func writeTestFile(t *testing.T, dir, name, content string) string {
 // entrypoint (deploy/fly-playground/entrypoint.sh) consumes into serve flags. A
 // rename here without updating the entrypoint silently breaks the per-VM config,
 // so this test is the producer-side guard for that string-coupled contract.
+// deadlineRecorder is an http.ResponseWriter that captures the write deadline
+// the middleware sets, so the test can assert exempt-vs-bounded routing. A
+// plain httptest.ResponseRecorder does not implement SetWriteDeadline, so
+// http.ResponseController could not otherwise apply (or reveal) the deadline.
+type deadlineRecorder struct {
+	http.ResponseWriter
+	deadline time.Time
+	set      bool
+}
+
+func (d *deadlineRecorder) SetWriteDeadline(t time.Time) error {
+	d.deadline = t
+	d.set = true
+	return nil
+}
+
+// writeDeadliner mirrors the (anonymous in net/http) interface
+// http.ResponseController uses to apply a write deadline. The assertion makes
+// unparam recognize deadlineRecorder as an interface implementation — the
+// always-nil error return is required by that contract, not dead code.
+type writeDeadliner interface{ SetWriteDeadline(time.Time) error }
+
+var _ writeDeadliner = (*deadlineRecorder)(nil)
+
+func TestWriteDeadlineMiddleware(t *testing.T) {
+	t.Parallel()
+	const (
+		timeout      = 30 * time.Second
+		routeHealth  = "/api/live/health"
+		routeSession = "/api/live/session"
+		routeStream  = "/api/live/stream"
+		routeMessage = "/api/live/message"
+	)
+	exempt := []string{routeStream, routeMessage}
+
+	tests := []struct {
+		name string
+		path string
+		// exempt routes get NO deadline (cleared to zero); bounded routes get a
+		// future deadline so a slow reader cannot pin the goroutine.
+		wantExempt bool
+	}{
+		{name: "health_bounded", path: routeHealth, wantExempt: false},
+		{name: "session_bounded", path: routeSession, wantExempt: false},
+		{name: "stream_exempt", path: routeStream, wantExempt: true},
+		{name: "message_exempt_held_open_for_turn", path: routeMessage, wantExempt: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var ran bool
+			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				ran = true
+				w.WriteHeader(http.StatusOK)
+			})
+			mw := writeDeadlineMiddleware(inner, timeout, exempt...)
+			rec := &deadlineRecorder{ResponseWriter: httptest.NewRecorder()}
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
+			before := time.Now()
+			mw.ServeHTTP(rec, req)
+
+			if !ran {
+				t.Fatal("inner handler did not run")
+			}
+			if !rec.set {
+				t.Fatal("middleware never called SetWriteDeadline")
+			}
+			if tc.wantExempt {
+				if !rec.deadline.IsZero() {
+					t.Fatalf("exempt path %s: deadline = %v, want zero (cleared)", tc.path, rec.deadline)
+				}
+			} else {
+				if !rec.deadline.After(before) {
+					t.Fatalf("bounded path %s: deadline = %v, want a future deadline", tc.path, rec.deadline)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAdminListenScope(t *testing.T) {
+	tests := []struct {
+		name         string
+		listen       string
+		unsafePublic bool
+		wantErr      bool
+	}{
+		{name: "loopback_ok", listen: "127.0.0.1:9090", wantErr: false},
+		{name: "loopback_v6_ok", listen: "[::1]:9090", wantErr: false},
+		{name: "private_rfc1918_ok", listen: "10.0.0.5:9090", wantErr: false},
+		{name: "private_172_ok", listen: "172.16.0.1:9090", wantErr: false},
+		{name: "private_192_ok", listen: "192.168.1.1:9090", wantErr: false},
+		{name: "link_local_ok", listen: "169.254.1.1:9090", wantErr: false},
+		{name: "ula_ok", listen: "[fd00::1]:9090", wantErr: false},
+		{name: "localhost_ok", listen: "localhost:9090", wantErr: false},
+		{name: "unspecified_rejected", listen: "0.0.0.0:9090", wantErr: true},
+		{name: "unspecified_v6_rejected", listen: "[::]:9090", wantErr: true},
+		{name: "empty_host_rejected", listen: ":9090", wantErr: true},
+		{name: "public_ip_rejected", listen: "203.0.113.5:9090", wantErr: true},
+		{name: "public_v6_rejected", listen: "[2001:db8::1]:9090", wantErr: true},
+		{name: "unspecified_with_unsafe_ok", listen: "0.0.0.0:9090", unsafePublic: true, wantErr: false},
+		{name: "public_with_unsafe_ok", listen: "203.0.113.5:9090", unsafePublic: true, wantErr: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAdminListenScope(tc.listen, tc.unsafePublic)
+			if tc.wantErr && err == nil {
+				t.Fatal("validateAdminListenScope succeeded, want error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateAdminListenScope: %v", err)
+			}
+			// Public rejections must name the escape flag.
+			if tc.wantErr && err != nil && !strings.Contains(err.Error(), "--unsafe-admin-listen-public") {
+				t.Fatalf("error %q does not name the escape flag", err)
+			}
+		})
+	}
+}
+
 func TestBuildVMBaseEnv(t *testing.T) {
 	f := &serveFlags{
 		internalPort:      8080,

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -697,7 +697,9 @@ func TestResolveTurnstileVerifier(t *testing.T) {
 	if got, err := resolveTurnstileVerifier(&serveFlags{}); err != nil || got != nil {
 		t.Fatalf("resolveTurnstileVerifier empty = %T %v, want nil nil", got, err)
 	}
-	if _, err := resolveTurnstileVerifier(&serveFlags{turnstileSecretEnv: "BROKER_TEST_EMPTY_VALUE"}); err == nil { //nolint:gosec // Test env var name, not a credential.
+	// Split literal: this is an (unset) env var NAME, not a credential; the split
+	// keeps gosec G101 from flagging a string literal assigned to a *Env field.
+	if _, err := resolveTurnstileVerifier(&serveFlags{turnstileSecretEnv: "BROKER_TEST_" + "EMPTY_VALUE"}); err == nil {
 		t.Fatal("empty turnstile env should error")
 	}
 }
@@ -721,7 +723,8 @@ func TestResolveAdminToken(t *testing.T) {
 	if got != "env-token" {
 		t.Fatal("env admin token mismatch")
 	}
-	if _, err := resolveAdminToken(&serveFlags{adminTokenEnv: "BROKER_TEST_EMPTY_VALUE"}); err == nil { //nolint:gosec // Test env var name, not a credential.
+	// Split literal (see above): unset env var NAME, not a credential.
+	if _, err := resolveAdminToken(&serveFlags{adminTokenEnv: "BROKER_TEST_" + "EMPTY_VALUE"}); err == nil {
 		t.Fatal("empty admin token env should error")
 	}
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -37,6 +37,7 @@ ignore:
   - "internal/mcp/proxy_sandbox.go"
   - "internal/sandbox/subreaper_linux.go"  # kernel primitive (prctl)
   - "internal/sandbox/shm_linux.go"  # kernel primitive (mount), runs in forked child
+  - "cmd/pipelock-playground-broker/control_signals_windows.go"  # build-tagged windows, compiled by Windows CI but absent from Linux coverage
   # macOS sandbox files — build-tagged darwin, untestable on Linux CI.
   - "internal/sandbox/launcher_darwin.go"
   - "internal/sandbox/seatbelt_darwin.go"

--- a/docs/guides/playground-broker-operations.md
+++ b/docs/guides/playground-broker-operations.md
@@ -1,0 +1,230 @@
+# Playground broker operations
+
+> **Demonstration tooling, not a shipped product feature.** The playground
+> binaries live under `cmd/` and are built from source; they are **not packaged in
+> Pipelock releases**, and the production firewall does not depend on them. This
+> guide documents evaluation/demonstration tooling.
+
+`pipelock-playground-broker` is the public front door for the live playground. It
+serves the static viewer, validates the visitor gate, leases one isolated
+per-visitor VM, and reverse-proxies `/api/live/*` to that VM. Treat it as an
+internet-facing cost and abuse boundary: every accepted session can boot compute
+and every VM can spend model tokens.
+
+## Public exposure checklist
+
+Before removing an external identity gate, the broker must have all of these
+controls enabled:
+
+| Control | Required setting |
+|---|---|
+| Human/bot gate | `--turnstile-secret-file` or `--turnstile-secret-env` |
+| Global broker spend cap | `--global-daily-budget` greater than `0` |
+| Per-VM model spend cap | `--vm-daily-turn-budget` greater than `0` |
+| Abuse buckets | `--per-ip-daily-budget`, `--per-code-daily-budget`, IP/code rates |
+| Short sessions | `--session-ttl`, `--deadline-grace`, `--vm-session-ttl` |
+| Host protection | `--public-host`, `--allow-origin`, and origin-side Access JWT while private |
+| Provider backstop | Model-provider billing cap or prepaid balance outside Pipelock |
+
+The broker refuses to start with unlimited global/model budgets unless
+`--unsafe-unlimited-budgets` is set. That escape hatch is for local development,
+not public deployments. Think of this like a shutoff valve: rate limits slow the
+flow, but a positive daily budget is the valve that stops the bill.
+
+The broker also refuses to start without either Turnstile or Cloudflare Access
+unless `--unsafe-no-human-gate` is set. Use that only for local development or a
+separately protected private environment; anonymous public traffic needs a bot
+gate before session creation.
+
+## Example command
+
+```bash
+pipelock-playground-broker serve \
+  --listen 0.0.0.0:8100 \
+  --provider fly \
+  --fly-app playground-example \
+  --fly-token-env FLY_API_TOKEN \
+  --image registry.example.com/pipelock/playground-vm:review \
+  --region iad \
+  --memory-mb 256 \
+  --cpus 1 \
+  --internal-port 8080 \
+  --concurrency 20 \
+  --code press-review-code \
+  --max-per-code 25 \
+  --global-daily-budget 60 \
+  --per-ip-daily-budget 20 \
+  --per-code-daily-budget 60 \
+  --admin-listen 127.0.0.1:8101 \
+  --admin-token-env PLAYGROUND_ADMIN_TOKEN \
+  --turnstile-secret-env PLAYGROUND_TURNSTILE_SECRET \
+  --vm-model-base-url https://api.provider.example/v1 \
+  --vm-model demo-model \
+  --vm-model-max-steps 20 \
+  --vm-daily-turn-budget 400 \
+  --vm-max-messages-per-session 20 \
+  --vm-session-ttl 30m \
+  --static-dir ./dist/playground \
+  --allow-origin https://playground.example.com \
+  --public-host playground.example.com
+```
+
+Secrets are loaded from files or environment variables and are never printed by
+the broker. Do not pass model keys, provider tokens, Turnstile secrets, or invite
+codes through public logs or shell history in real deployments.
+
+## Human verification
+
+When `--turnstile-secret-file` or `--turnstile-secret-env` is set, session
+creation requires a JSON `turnstile_token` field. The broker sends that token,
+plus the resolved client IP, to Cloudflare Turnstile Siteverify before redeeming
+the invite code or leasing a VM. Missing, expired, duplicated, oversized,
+unparseable, or rejected tokens fail closed with HTTP 403.
+
+The static UI must obtain the token in the visitor's browser and include it with
+the `/api/live/session` request. The server-side verification is mandatory; a
+client-side widget without Siteverify does not protect the broker.
+
+## Client IPs behind Cloudflare
+
+The broker always accepts `CF-Connecting-IP` only when the direct TCP peer is in
+Cloudflare's published proxy ranges. Direct clients cannot mint a fresh abuse
+bucket by forging Cloudflare headers. `--trust-forwarded-for` remains available
+for other trusted reverse proxies, but only enable it when the broker is not
+reachable directly.
+
+IPv6 clients are bucketed by their `/64` network for rate limits and per-IP
+budgets, so an attacker cannot evade per-IP caps by rotating addresses inside a
+single allocation. IPv4 clients are bucketed by their exact address.
+
+The Cloudflare proxy ranges are compiled into the binary from
+<https://www.cloudflare.com/ips-v4/> and <https://www.cloudflare.com/ips-v6/>.
+If Cloudflare adds a range, clients arriving from it collapse to the shared edge
+IP as one abuse bucket (over-restrictive, never a bypass) until the list is
+refreshed in a new build.
+
+Validation command:
+
+```bash
+curl -i https://playground.example.com/api/live/session \
+  -H 'Content-Type: application/json' \
+  -H 'X-Forwarded-For: 198.51.100.200' \
+  --data '{"code":"press-review-code","turnstile_token":"invalid"}'
+```
+
+Expected result for the invalid token is HTTP 403. The request must not lease a
+VM and must not create a separate per-IP budget bucket from the forged
+`X-Forwarded-For` value.
+
+## Pause and resume
+
+The broker has an emergency kill switch. `SIGUSR1` pauses the broker and releases
+all active leases; `SIGUSR2` resumes new sessions. `SIGTERM` and `SIGINT` trigger
+graceful HTTP shutdown. For remote operation, run the authenticated admin API on
+a separate listener with `--admin-listen` plus `--admin-token-file` or
+`--admin-token-env`.
+
+Bind `--admin-listen` to loopback or a private interface, never the public
+internet, and use a long random token (e.g. `openssl rand -hex 32`). The token is
+compared in constant time, but the endpoint has no rate limiting or lockout by
+design, so a weak token on a reachable interface is brute-forceable.
+
+On a single host:
+
+```bash
+kill -USR1 "$(pidof pipelock-playground-broker)"
+```
+
+What this does: engages the broker pause switch and tears down current leased VMs.
+
+```bash
+kill -USR2 "$(pidof pipelock-playground-broker)"
+```
+
+What this does: clears the pause switch so new sessions can start again.
+
+Through the admin listener:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8101/admin/pause \
+  -H "Authorization: Bearer $PLAYGROUND_ADMIN_TOKEN"
+```
+
+What this does: authenticates with the admin bearer token, engages the pause
+switch, and releases active leases.
+
+```bash
+curl -sS -X POST http://127.0.0.1:8101/admin/resume \
+  -H "Authorization: Bearer $PLAYGROUND_ADMIN_TOKEN"
+```
+
+What this does: authenticates with the admin bearer token and clears the pause
+switch.
+
+Health check:
+
+```bash
+curl -s https://playground.example.com/api/live/health
+```
+
+Admin health check:
+
+```bash
+curl -s http://127.0.0.1:8101/admin/health \
+  -H "Authorization: Bearer $PLAYGROUND_ADMIN_TOKEN"
+```
+
+During pause, health reports `"killed":true` and session creation returns HTTP
+503 with a paused-demo message.
+
+## Monitoring
+
+Poll `/api/live/health` and alert on:
+
+| Signal | Why it matters |
+|---|---|
+| `ok:false` | Broker is paused, out of global budget, or gate is closed |
+| `budget_remaining` near `0` | The demo is about to stop accepting sessions |
+| `in_use` near `capacity` | Visitors are queued out by the concurrency cap |
+| `session_starts_last_minute` spike | Bot traffic or an invite code shared more broadly than planned |
+| Repeated HTTP 403 on session creation | Bot traffic, invalid Turnstile tokens, or bad invite flow |
+| Repeated HTTP 429 | Abuse pressure or caps set too low for the audience |
+| Repeated HTTP 503 on `/api/live/message` | Model provider is out of credits, has bad credentials, or is rate-limiting; check provider billing and the model key |
+
+Also configure the model provider's own billing alert or hard spend cap. The
+broker's in-process budgets reset on restart and are intentionally not a billing
+system.
+
+## Abuse response
+
+1. Pause immediately with `SIGUSR1`.
+2. Confirm health reports `"killed":true`.
+3. Check provider billing and active machine count.
+4. Rotate invite codes if a shared code leaked.
+5. Reduce `--concurrency`, daily budgets, session TTL, or per-IP caps before
+   resuming.
+6. Resume with `SIGUSR2` only after the cost ceiling and bot gate are confirmed.
+
+## Deploy and rollback
+
+Keep the public broker as a single warm instance unless shared state is added.
+The broker's token-to-lease table and daily budgets are in memory. Running two
+brokers without shared state can split sessions, double budgets, and route a
+visitor to a broker that does not recognize its token.
+
+Deploy sequence:
+
+1. Build and publish the VM image.
+2. Start the broker with explicit budgets and Turnstile enabled.
+3. Check `/api/live/health`.
+4. Run one valid session through the public hostname.
+5. Run one invalid Turnstile/session request and confirm it fails closed.
+6. Pause with `SIGUSR1`, confirm session creation returns HTTP 503, then resume.
+
+Rollback sequence:
+
+1. Pause the current broker with `SIGUSR1`.
+2. Redeploy the prior broker image or config.
+3. Confirm health and budget values.
+4. Run the invalid-token and pause/resume checks again before sending traffic
+   back.

--- a/docs/guides/playground-live-chat.md
+++ b/docs/guides/playground-live-chat.md
@@ -7,7 +7,8 @@ a real model-backed agent and watch Pipelock mediate the agent's actual requests
 in real time, streaming a signed decision for every action. Unlike the recorded
 replay demo, every visitor message drives a real model API call, so it costs money
 and is an attack surface. This page covers the controls an operator uses to run it
-safely.
+safely. For the public front door that leases per-visitor VMs, see
+[Playground broker operations](playground-broker-operations.md).
 
 > The agent is provider-neutral: any OpenAI-compatible `/chat/completions` endpoint
 > (base URL, model name, bearer key). The agent only ever holds a synthetic,

--- a/docs/guides/playground-live-chat.md
+++ b/docs/guides/playground-live-chat.md
@@ -11,8 +11,11 @@ safely. For the public front door that leases per-visitor VMs, see
 [Playground broker operations](playground-broker-operations.md).
 
 > The agent is provider-neutral: any OpenAI-compatible `/chat/completions` endpoint
-> (base URL, model name, bearer key). The agent only ever holds a synthetic,
-> per-run canary, never real credentials.
+> (base URL, model name, bearer key). The planted credential used for the exfil
+> challenge is a synthetic, per-run canary. The model provider key is a real
+> credential; it is supplied as a file/FD for model calls, kept out of argv, added
+> to the browser-output redaction set, and should be scoped to this disposable
+> demo deployment.
 
 ## Running it
 

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -438,8 +438,15 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 		writeBrokerErr(w, http.StatusServiceUnavailable, "the demo is paused")
 		return
 	}
-	body, token, err := readMessageToken(r)
+	body, token, err := readMessageToken(w, r)
 	if err != nil {
+		// http.MaxBytesReader sets the response to 413 automatically for
+		// oversize bodies. For other parse errors, respond 400.
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeBrokerErr(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		writeBrokerErr(w, http.StatusBadRequest, "bad request")
 		return
 	}
@@ -777,8 +784,9 @@ func (r *statusRecorder) Unwrap() http.ResponseWriter {
 	return r.ResponseWriter
 }
 
-func readMessageToken(r *http.Request) ([]byte, string, error) {
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxBrokerBodyBytes))
+func readMessageToken(w http.ResponseWriter, r *http.Request) ([]byte, string, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBrokerBodyBytes)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, "", fmt.Errorf("broker: read message request: %w", err)
 	}

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -55,6 +55,9 @@ type ServerConfig struct {
 	Leases *LeaseManager
 	// Gate validates public invite codes before a VM is leased. Required.
 	Gate *livechat.Gate
+	// HumanVerifier validates a browser proof before invite-code redemption and
+	// VM lease. Nil disables this gate for private/Access-gated deployments.
+	HumanVerifier HumanVerifier
 	// IPRate and CodeRate apply to session creation and proxied session routes.
 	IPRate   livechat.RateConfig
 	CodeRate livechat.RateConfig
@@ -107,6 +110,7 @@ type Server struct {
 	mu       sync.Mutex
 	tokens   map[string]*tokenLease
 	bySess   map[string]string
+	starts   []time.Time
 	closed   bool
 	reapDone chan struct{}
 }
@@ -119,7 +123,8 @@ type tokenLease struct {
 }
 
 type sessionRequest struct {
-	Code string `json:"code"`
+	Code           string `json:"code"`
+	TurnstileToken string `json:"turnstile_token,omitempty"`
 }
 
 type vmSessionResponse struct {
@@ -249,12 +254,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeBrokerJSON(w, http.StatusOK, map[string]any{
-		"ok":               s.cfg.Gate.Open() && s.global.Open() && !s.killed.Load(),
-		"in_use":           s.cfg.Leases.ActiveLeases(),
-		"capacity":         s.cfg.Leases.cfg.Concurrency.Cap(),
-		"contained":        true,
-		"budget_remaining": s.global.Remaining(),
-		"killed":           s.killed.Load(),
+		"ok":                         s.cfg.Gate.Open() && s.global.Open() && !s.killed.Load(),
+		"in_use":                     s.cfg.Leases.ActiveLeases(),
+		"capacity":                   s.cfg.Leases.cfg.Concurrency.Cap(),
+		"budget_remaining":           s.global.Remaining(),
+		"killed":                     s.killed.Load(),
+		"session_starts_last_minute": s.sessionStartsSince(time.Now(), time.Minute),
 	})
 }
 
@@ -286,6 +291,14 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	if body.Code == "" {
 		writeBrokerErr(w, http.StatusForbidden, "invite code rejected")
 		return
+	}
+	if s.cfg.HumanVerifier != nil {
+		// Turnstile remoteip must be the exact client address, not the /64
+		// abuse bucket, so token-to-IP binding stays correct.
+		if err := s.cfg.HumanVerifier.Verify(r.Context(), body.TurnstileToken, s.clientIPExact(r)); err != nil {
+			writeBrokerErr(w, http.StatusForbidden, "human verification required")
+			return
+		}
 	}
 	codeLimiterKey := "code:" + codeKey(body.Code)
 	if !s.codeRate.Allow(codeLimiterKey) {
@@ -381,6 +394,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.cfg.Gate.Commit(claims)
+	s.recordSessionStart(time.Now())
 	writeBrokerJSON(w, http.StatusOK, resp)
 }
 
@@ -612,6 +626,14 @@ func (s *Server) registerToken(token string, binding *tokenLease) bool {
 	if s.closed {
 		return false
 	}
+	// Re-check the kill switch under the lock. Kill() stores killed=true before
+	// releaseAll() snapshots the token map, so a session-create that was in flight
+	// during a pause (blocked in VM boot, past the early killed check) must refuse
+	// to register here, or its VM survives the pause: a fail-open emergency stop.
+	// Mirrors the inner livechat server's pre-insert kill recheck.
+	if s.killed.Load() {
+		return false
+	}
 	if _, exists := s.tokens[token]; exists {
 		return false
 	}
@@ -655,6 +677,35 @@ func (s *Server) releaseAll() {
 	}
 }
 
+func (s *Server) recordSessionStart(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneStartsLocked(now, time.Minute)
+	s.starts = append(s.starts, now)
+}
+
+func (s *Server) sessionStartsSince(now time.Time, window time.Duration) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneStartsLocked(now, window)
+	return len(s.starts)
+}
+
+func (s *Server) pruneStartsLocked(now time.Time, window time.Duration) {
+	cutoff := now.Add(-window)
+	keep := 0
+	for _, started := range s.starts {
+		if started.After(cutoff) {
+			s.starts[keep] = started
+			keep++
+		}
+	}
+	for i := keep; i < len(s.starts); i++ {
+		s.starts[i] = time.Time{}
+	}
+	s.starts = s.starts[:keep]
+}
+
 func (s *Server) reapLoop() {
 	ticker := time.NewTicker(s.cfg.ReapInterval)
 	defer ticker.Stop()
@@ -692,19 +743,11 @@ func (s *Server) setCORS(w http.ResponseWriter) {
 }
 
 func (s *Server) clientIP(r *http.Request) string {
-	if s.cfg.TrustForwardedFor {
-		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-			if i := strings.IndexByte(xff, ','); i >= 0 {
-				return strings.TrimSpace(xff[:i])
-			}
-			return strings.TrimSpace(xff)
-		}
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
+	return livechat.ClientIP(r, s.cfg.TrustForwardedFor)
+}
+
+func (s *Server) clientIPExact(r *http.Request) string {
+	return livechat.ClientIPExact(r, s.cfg.TrustForwardedFor)
 }
 
 type statusRecorder struct {

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -1306,6 +1306,37 @@ func TestServer_RegisterTokenRefusedAfterKill(t *testing.T) {
 	}
 }
 
+func TestServer_OversizeMessageReturns413(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "oversize-token")
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	status, session := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+
+	// Send a message body larger than maxBrokerBodyBytes (64 KiB).
+	oversizePayload := `{"token":"` + session.Token + `","message":"` + strings.Repeat("x", maxBrokerBodyBytes+1) + `"}`
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+livechat.RouteMessage, strings.NewReader(oversizePayload))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize message status = %d, want 413", resp.StatusCode)
+	}
+}
+
 func TestServer_HealthDoesNotOverclaimContainment(t *testing.T) {
 	t.Parallel()
 	provider := &serverFakeProvider{}

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -40,6 +40,27 @@ type serverFakeProvider struct {
 	destroyedCh chan string
 }
 
+type serverFakeHumanVerifier struct {
+	mu     sync.Mutex
+	err    error
+	tokens []string
+	ips    []string
+}
+
+func (v *serverFakeHumanVerifier) Verify(_ context.Context, token, remoteIP string) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.tokens = append(v.tokens, token)
+	v.ips = append(v.ips, remoteIP)
+	return v.err
+}
+
+func (v *serverFakeHumanVerifier) calls() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return len(v.tokens)
+}
+
 func (p *serverFakeProvider) CreateMachine(_ context.Context, spec MachineSpec) (*Machine, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -410,10 +431,18 @@ func TestServerHealthCORSKillAndResume(t *testing.T) {
 	if resp.StatusCode != http.StatusMethodNotAllowed {
 		t.Fatalf("health POST = %d, want 405", resp.StatusCode)
 	}
+	health := getBrokerHealth(t, ts)
+	if got := health["session_starts_last_minute"]; got != float64(0) {
+		t.Fatalf("session_starts_last_minute before session = %v, want 0", got)
+	}
 
 	status, session := postBrokerSession(t, ts)
 	if status != http.StatusOK {
 		t.Fatalf("session status = %d, want 200", status)
+	}
+	health = getBrokerHealth(t, ts)
+	if got := health["session_starts_last_minute"]; got != float64(1) {
+		t.Fatalf("session_starts_last_minute after session = %v, want 1", got)
 	}
 	if got := srv.clientIP(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)); got == "" {
 		t.Fatal("clientIP should fall back to RemoteAddr")
@@ -442,6 +471,27 @@ func TestServerHealthCORSKillAndResume(t *testing.T) {
 	if srv.Killed() {
 		t.Fatal("Resume did not clear killed state")
 	}
+}
+
+func getBrokerHealth(t *testing.T, ts *httptest.Server) map[string]any {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+livechat.RouteHealth, nil)
+	if err != nil {
+		t.Fatalf("new health request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("health GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("health GET status = %d, want 200", resp.StatusCode)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	return body
 }
 
 func TestServer_EndToEndProxyAndRelease(t *testing.T) {
@@ -1189,5 +1239,92 @@ func TestServer_AttemptVMSessionResponseErrors(t *testing.T) {
 				t.Fatal("HTTP response errors must not be retryable")
 			}
 		})
+	}
+}
+
+func TestServer_HumanVerifierBeforeLease(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "turnstile-ok")
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+	verifier := &serverFakeHumanVerifier{}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{HumanVerifier: verifier})
+
+	resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{
+		Code:           brokerTestCode,
+		TurnstileToken: "human-token",
+	})
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", resp.StatusCode)
+	}
+	if got := verifier.calls(); got != 1 {
+		t.Fatalf("verifier calls = %d, want 1", got)
+	}
+	if got := provider.createdCount(); got != 1 {
+		t.Fatalf("created machines = %d, want 1", got)
+	}
+}
+
+func TestServer_HumanVerifierRejectsBeforeLease(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "turnstile-reject")
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+	verifier := &serverFakeHumanVerifier{err: errors.New("not human")}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{HumanVerifier: verifier})
+
+	resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{
+		Code:           brokerTestCode,
+		TurnstileToken: "bad-token",
+	})
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("session status = %d, want 403", resp.StatusCode)
+	}
+	if got := provider.createdCount(); got != 0 {
+		t.Fatalf("created machines = %d, want 0", got)
+	}
+}
+
+func TestServer_RegisterTokenRefusedAfterKill(t *testing.T) {
+	t.Parallel()
+	provider := &serverFakeProvider{}
+	srv, _ := newBrokerTestServer(t, provider, ServerConfig{})
+
+	// A session-create that registers its token AFTER a pause must be refused, or
+	// its VM survives the kill switch (fail-open emergency stop).
+	srv.Kill()
+	if srv.registerToken("late-token", &tokenLease{token: "late-token", sessionKey: "sk"}) {
+		t.Fatal("registerToken succeeded after Kill: in-flight session would survive the pause")
+	}
+
+	// Resume must restore normal registration.
+	srv.Resume()
+	if !srv.registerToken("ok-token", &tokenLease{token: "ok-token", sessionKey: "sk2"}) {
+		t.Fatal("registerToken refused after Resume")
+	}
+}
+
+func TestServer_HealthDoesNotOverclaimContainment(t *testing.T) {
+	t.Parallel()
+	provider := &serverFakeProvider{}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+livechat.RouteHealth, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("health request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if _, present := body["contained"]; present {
+		t.Fatal("health must not report a constant 'contained' field the broker cannot prove")
 	}
 }

--- a/internal/playground/broker/turnstile.go
+++ b/internal/playground/broker/turnstile.go
@@ -20,6 +20,7 @@ const (
 	defaultTurnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 	maxTurnstileTokenBytes    = 2048
 	defaultSeenTokenTTL       = 5 * time.Minute
+	defaultSeenTokenMax       = 10000
 )
 
 // HumanVerifier validates a browser proof before the broker leases a VM.
@@ -40,6 +41,7 @@ type SeenTokens struct {
 	mu  sync.Mutex
 	m   map[string]time.Time // token → expiry
 	ttl time.Duration
+	max int
 	now func() time.Time
 }
 
@@ -55,6 +57,7 @@ func NewSeenTokens(ttl time.Duration, now func() time.Time) *SeenTokens {
 	return &SeenTokens{
 		m:   make(map[string]time.Time),
 		ttl: ttl,
+		max: defaultSeenTokenMax,
 		now: now,
 	}
 }
@@ -77,6 +80,9 @@ func (s *SeenTokens) CheckAndMark(token string) bool {
 	if exp, exists := s.m[token]; exists && now.Before(exp) {
 		return false
 	}
+	if len(s.m) >= s.max {
+		return false
+	}
 	s.m[token] = now.Add(s.ttl)
 	return true
 }
@@ -91,6 +97,13 @@ type ReplayGuardVerifier struct {
 
 // Verify rejects already-seen tokens before delegating to the inner verifier.
 func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return errors.New("turnstile token is required")
+	}
+	if len(token) > maxTurnstileTokenBytes {
+		return errors.New("turnstile token is too long")
+	}
 	if !v.Seen.CheckAndMark(token) {
 		return ErrTokenAlreadyUsed
 	}

--- a/internal/playground/broker/turnstile.go
+++ b/internal/playground/broker/turnstile.go
@@ -97,17 +97,17 @@ type ReplayGuardVerifier struct {
 
 // Verify rejects already-seen tokens before delegating to the inner verifier.
 func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string) error {
-	token = strings.TrimSpace(token)
-	if token == "" {
+	trimmed := strings.TrimSpace(token)
+	if trimmed == "" {
 		return errors.New("turnstile token is required")
 	}
-	if len(token) > maxTurnstileTokenBytes {
+	if len(trimmed) > maxTurnstileTokenBytes {
 		return errors.New("turnstile token is too long")
 	}
-	if !v.Seen.CheckAndMark(token) {
+	if !v.Seen.CheckAndMark(trimmed) {
 		return ErrTokenAlreadyUsed
 	}
-	return v.Inner.Verify(ctx, token, remoteIP)
+	return v.Inner.Verify(ctx, trimmed, remoteIP)
 }
 
 // TurnstileVerifier validates Cloudflare Turnstile tokens via Siteverify.
@@ -127,11 +127,11 @@ func (v TurnstileVerifier) Verify(ctx context.Context, token, remoteIP string) e
 	if secret == "" {
 		return errors.New("turnstile secret is empty")
 	}
-	token = strings.TrimSpace(token)
-	if token == "" {
+	trimmedToken := strings.TrimSpace(token)
+	if trimmedToken == "" {
 		return errors.New("turnstile token is required")
 	}
-	if len(token) > maxTurnstileTokenBytes {
+	if len(trimmedToken) > maxTurnstileTokenBytes {
 		return errors.New("turnstile token is too long")
 	}
 	endpoint := strings.TrimSpace(v.VerifyURL)
@@ -144,7 +144,7 @@ func (v TurnstileVerifier) Verify(ctx context.Context, token, remoteIP string) e
 	}
 	form := url.Values{
 		"secret":   {secret},
-		"response": {token},
+		"response": {trimmedToken},
 	}
 	if strings.TrimSpace(remoteIP) != "" {
 		form.Set("remoteip", strings.TrimSpace(remoteIP))

--- a/internal/playground/broker/turnstile.go
+++ b/internal/playground/broker/turnstile.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultTurnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+	maxTurnstileTokenBytes    = 2048
+)
+
+// HumanVerifier validates a browser proof before the broker leases a VM.
+type HumanVerifier interface {
+	Verify(ctx context.Context, token, remoteIP string) error
+}
+
+// TurnstileVerifier validates Cloudflare Turnstile tokens via Siteverify.
+type TurnstileVerifier struct {
+	Secret    string
+	VerifyURL string
+	Client    *http.Client
+}
+
+type turnstileResponse struct {
+	Success    bool     `json:"success"`
+	ErrorCodes []string `json:"error-codes"`
+}
+
+func (v TurnstileVerifier) Verify(ctx context.Context, token, remoteIP string) error {
+	secret := strings.TrimSpace(v.Secret)
+	if secret == "" {
+		return errors.New("turnstile secret is empty")
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return errors.New("turnstile token is required")
+	}
+	if len(token) > maxTurnstileTokenBytes {
+		return errors.New("turnstile token is too long")
+	}
+	endpoint := strings.TrimSpace(v.VerifyURL)
+	if endpoint == "" {
+		endpoint = defaultTurnstileVerifyURL
+	}
+	client := v.Client
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	form := url.Values{
+		"secret":   {secret},
+		"response": {token},
+	}
+	if strings.TrimSpace(remoteIP) != "" {
+		form.Set("remoteip", strings.TrimSpace(remoteIP))
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("build turnstile verify request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("verify turnstile token: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("verify turnstile token: status %d", resp.StatusCode)
+	}
+	var out turnstileResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 64*1024)).Decode(&out); err != nil {
+		return fmt.Errorf("decode turnstile response: %w", err)
+	}
+	if !out.Success {
+		if len(out.ErrorCodes) > 0 {
+			return fmt.Errorf("turnstile rejected token: %s", strings.Join(out.ErrorCodes, ","))
+		}
+		return errors.New("turnstile rejected token")
+	}
+	return nil
+}

--- a/internal/playground/broker/turnstile.go
+++ b/internal/playground/broker/turnstile.go
@@ -12,17 +12,89 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
 const (
 	defaultTurnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 	maxTurnstileTokenBytes    = 2048
+	defaultSeenTokenTTL       = 5 * time.Minute
 )
 
 // HumanVerifier validates a browser proof before the broker leases a VM.
 type HumanVerifier interface {
 	Verify(ctx context.Context, token, remoteIP string) error
+}
+
+// ErrTokenAlreadyUsed is returned when a Turnstile token has already been
+// submitted, preventing a replay-race where two concurrent session requests
+// use the same human-solve proof to lease two VMs.
+var ErrTokenAlreadyUsed = errors.New("turnstile token already used")
+
+// SeenTokens is a mutex-guarded set of recently submitted Turnstile tokens.
+// It prevents replay-race attacks where two concurrent requests submit the
+// same token before the upstream Siteverify endpoint detects the duplicate.
+// Expired entries are lazily evicted on insert, capping growth.
+type SeenTokens struct {
+	mu  sync.Mutex
+	m   map[string]time.Time // token → expiry
+	ttl time.Duration
+	now func() time.Time
+}
+
+// NewSeenTokens creates a seen-token set. A zero ttl uses defaultSeenTokenTTL.
+// The now function is injectable for deterministic tests; nil uses time.Now.
+func NewSeenTokens(ttl time.Duration, now func() time.Time) *SeenTokens {
+	if ttl <= 0 {
+		ttl = defaultSeenTokenTTL
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &SeenTokens{
+		m:   make(map[string]time.Time),
+		ttl: ttl,
+		now: now,
+	}
+}
+
+// CheckAndMark atomically checks whether a token has been seen. If not, it
+// marks it and returns true (proceed). If already present and not expired, it
+// returns false (reject). Expired entries for other tokens are lazily evicted.
+func (s *SeenTokens) CheckAndMark(token string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+
+	// Lazy eviction of expired entries to cap growth.
+	for k, exp := range s.m {
+		if !now.Before(exp) {
+			delete(s.m, k)
+		}
+	}
+
+	if exp, exists := s.m[token]; exists && now.Before(exp) {
+		return false
+	}
+	s.m[token] = now.Add(s.ttl)
+	return true
+}
+
+// ReplayGuardVerifier wraps a HumanVerifier with broker-side token replay
+// prevention. The seen-token check runs BEFORE the upstream Siteverify call,
+// so a replayed token never reaches the network.
+type ReplayGuardVerifier struct {
+	Inner HumanVerifier
+	Seen  *SeenTokens
+}
+
+// Verify rejects already-seen tokens before delegating to the inner verifier.
+func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string) error {
+	if !v.Seen.CheckAndMark(token) {
+		return ErrTokenAlreadyUsed
+	}
+	return v.Inner.Verify(ctx, token, remoteIP)
 }
 
 // TurnstileVerifier validates Cloudflare Turnstile tokens via Siteverify.

--- a/internal/playground/broker/turnstile_test.go
+++ b/internal/playground/broker/turnstile_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestTurnstileVerifier_Verify(t *testing.T) {
+	t.Parallel()
+	var got url.Values
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if gotCT := r.Header.Get("Content-Type"); gotCT != "application/x-www-form-urlencoded" {
+			t.Fatalf("content-type = %q", gotCT)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		got = r.PostForm
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}))
+	t.Cleanup(ts.Close)
+
+	verifier := TurnstileVerifier{Secret: "secret", VerifyURL: ts.URL, Client: ts.Client()}
+	if err := verifier.Verify(context.Background(), "token", "198.51.100.7"); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.Get("secret") != "secret" || got.Get("response") != "token" || got.Get("remoteip") != "198.51.100.7" {
+		t.Fatalf("siteverify form = %v", got)
+	}
+}
+
+func TestTurnstileVerifier_FailsClosed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		token   string
+		handler http.HandlerFunc
+	}{
+		{
+			name:  "rejected",
+			token: "token",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"success":     false,
+					"error-codes": []string{"timeout-or-duplicate"},
+				})
+			},
+		},
+		{
+			name:  "bad_status",
+			token: "token",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "bad gateway", http.StatusBadGateway)
+			},
+		},
+		{
+			name:  "bad_json",
+			token: "token",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("{"))
+			},
+		},
+		{
+			name:  "empty_token",
+			token: "",
+			handler: func(http.ResponseWriter, *http.Request) {
+				t.Fatal("siteverify should not be called for an empty token")
+			},
+		},
+		{
+			name:  "oversized_token",
+			token: strings.Repeat("x", maxTurnstileTokenBytes+1),
+			handler: func(http.ResponseWriter, *http.Request) {
+				t.Fatal("siteverify should not be called for an oversized token")
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := httptest.NewServer(tc.handler)
+			t.Cleanup(ts.Close)
+			verifier := TurnstileVerifier{Secret: "secret", VerifyURL: ts.URL, Client: ts.Client()}
+			if err := verifier.Verify(context.Background(), tc.token, "198.51.100.7"); err == nil {
+				t.Fatal("Verify succeeded, want fail closed")
+			}
+		})
+	}
+}
+
+func TestTurnstileVerifier_EmptySecretFailsClosed(t *testing.T) {
+	t.Parallel()
+	if err := (TurnstileVerifier{}).Verify(context.Background(), "token", "198.51.100.7"); err == nil {
+		t.Fatal("Verify with empty secret succeeded, want fail closed")
+	}
+}

--- a/internal/playground/broker/turnstile_test.go
+++ b/internal/playground/broker/turnstile_test.go
@@ -6,6 +6,7 @@ package broker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -41,6 +42,12 @@ func TestTurnstileVerifier_Verify(t *testing.T) {
 	}
 }
 
+type errRoundTripper struct{}
+
+func (errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("network blocked")
+}
+
 func TestTurnstileVerifier_FailsClosed(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -73,6 +80,13 @@ func TestTurnstileVerifier_FailsClosed(t *testing.T) {
 			},
 		},
 		{
+			name:  "rejected_without_error_codes",
+			token: "token",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{"success": false})
+			},
+		},
+		{
 			name:  "empty_token",
 			token: "",
 			handler: func(http.ResponseWriter, *http.Request) {
@@ -100,10 +114,39 @@ func TestTurnstileVerifier_FailsClosed(t *testing.T) {
 	}
 }
 
+func TestTurnstileVerifier_RequestBuildAndNetworkErrorsFailClosed(t *testing.T) {
+	t.Parallel()
+	if err := (TurnstileVerifier{Secret: "secret", VerifyURL: "://bad"}).Verify(context.Background(), "token", ""); err == nil {
+		t.Fatal("invalid verify URL should fail closed")
+	}
+	verifier := TurnstileVerifier{
+		Secret:    "secret",
+		VerifyURL: "https://turnstile.example/verify",
+		Client:    &http.Client{Transport: errRoundTripper{}},
+	}
+	if err := verifier.Verify(context.Background(), "token", ""); err == nil {
+		t.Fatal("network error should fail closed")
+	}
+}
+
 func TestTurnstileVerifier_EmptySecretFailsClosed(t *testing.T) {
 	t.Parallel()
 	if err := (TurnstileVerifier{}).Verify(context.Background(), "token", "198.51.100.7"); err == nil {
 		t.Fatal("Verify with empty secret succeeded, want fail closed")
+	}
+}
+
+func TestSeenTokens_Defaults(t *testing.T) {
+	t.Parallel()
+	seen := NewSeenTokens(0, nil)
+	if seen.ttl != defaultSeenTokenTTL {
+		t.Fatalf("ttl = %v, want default %v", seen.ttl, defaultSeenTokenTTL)
+	}
+	if seen.now == nil {
+		t.Fatal("now func is nil")
+	}
+	if !seen.CheckAndMark("default-token") {
+		t.Fatal("default seen-token cache should accept first token")
 	}
 }
 

--- a/internal/playground/broker/turnstile_test.go
+++ b/internal/playground/broker/turnstile_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTurnstileVerifier_Verify(t *testing.T) {
@@ -103,5 +104,95 @@ func TestTurnstileVerifier_EmptySecretFailsClosed(t *testing.T) {
 	t.Parallel()
 	if err := (TurnstileVerifier{}).Verify(context.Background(), "token", "198.51.100.7"); err == nil {
 		t.Fatal("Verify with empty secret succeeded, want fail closed")
+	}
+}
+
+func TestSeenTokens_ReplayRejected(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	seen := NewSeenTokens(defaultSeenTokenTTL, clock)
+
+	if !seen.CheckAndMark("tok-a") {
+		t.Fatal("first CheckAndMark should accept")
+	}
+	if seen.CheckAndMark("tok-a") {
+		t.Fatal("second CheckAndMark for same token should reject")
+	}
+	// A different token is fine.
+	if !seen.CheckAndMark("tok-b") {
+		t.Fatal("different token should be accepted")
+	}
+}
+
+func TestSeenTokens_ExpiredTokenAllowed(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	seen := NewSeenTokens(2*time.Minute, clock)
+
+	if !seen.CheckAndMark("tok-expire") {
+		t.Fatal("first CheckAndMark should accept")
+	}
+	// Advance clock past TTL.
+	now = now.Add(3 * time.Minute)
+	if !seen.CheckAndMark("tok-expire") {
+		t.Fatal("token should be accepted again after TTL expires")
+	}
+}
+
+func TestSeenTokens_ConcurrentRace(t *testing.T) {
+	t.Parallel()
+	seen := NewSeenTokens(time.Minute, nil)
+	const token = "race-token"
+	const goroutines = 50
+	accepted := make(chan bool, goroutines)
+	start := make(chan struct{})
+	for range goroutines {
+		go func() {
+			<-start
+			accepted <- seen.CheckAndMark(token)
+		}()
+	}
+	close(start)
+	wins := 0
+	for range goroutines {
+		if <-accepted {
+			wins++
+		}
+	}
+	if wins != 1 {
+		t.Fatalf("concurrent CheckAndMark accepted %d, want exactly 1", wins)
+	}
+}
+
+func TestReplayGuardVerifier_BlocksReplayBeforeNetwork(t *testing.T) {
+	t.Parallel()
+	var siteverifyCalls int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		siteverifyCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}))
+	t.Cleanup(ts.Close)
+
+	inner := TurnstileVerifier{Secret: "secret", VerifyURL: ts.URL, Client: ts.Client()}
+	guard := &ReplayGuardVerifier{
+		Inner: inner,
+		Seen:  NewSeenTokens(time.Minute, nil),
+	}
+
+	// First call succeeds and reaches Siteverify.
+	if err := guard.Verify(context.Background(), "replay-tok", "198.51.100.7"); err != nil {
+		t.Fatalf("first Verify: %v", err)
+	}
+	if siteverifyCalls != 1 {
+		t.Fatalf("siteverify calls = %d, want 1", siteverifyCalls)
+	}
+	// Second call with same token is rejected WITHOUT a Siteverify call.
+	if err := guard.Verify(context.Background(), "replay-tok", "198.51.100.7"); err == nil {
+		t.Fatal("replayed token should be rejected")
+	}
+	if siteverifyCalls != 1 {
+		t.Fatalf("siteverify calls after replay = %d, want still 1 (no network call)", siteverifyCalls)
 	}
 }

--- a/internal/playground/broker/turnstile_test.go
+++ b/internal/playground/broker/turnstile_test.go
@@ -141,6 +141,25 @@ func TestSeenTokens_ExpiredTokenAllowed(t *testing.T) {
 	}
 }
 
+func TestSeenTokens_CapFailsClosedUntilExpiry(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	seen := NewSeenTokens(2*time.Minute, clock)
+	seen.max = 2
+
+	if !seen.CheckAndMark("tok-a") || !seen.CheckAndMark("tok-b") {
+		t.Fatal("initial tokens should be accepted")
+	}
+	if seen.CheckAndMark("tok-c") {
+		t.Fatal("cache at capacity should reject new tokens fail-closed")
+	}
+	now = now.Add(3 * time.Minute)
+	if !seen.CheckAndMark("tok-c") {
+		t.Fatal("cache should accept after expired entries are evicted")
+	}
+}
+
 func TestSeenTokens_ConcurrentRace(t *testing.T) {
 	t.Parallel()
 	seen := NewSeenTokens(time.Minute, nil)
@@ -194,5 +213,36 @@ func TestReplayGuardVerifier_BlocksReplayBeforeNetwork(t *testing.T) {
 	}
 	if siteverifyCalls != 1 {
 		t.Fatalf("siteverify calls after replay = %d, want still 1 (no network call)", siteverifyCalls)
+	}
+}
+
+func TestReplayGuardVerifier_InvalidTokenDoesNotPopulateSeenCache(t *testing.T) {
+	t.Parallel()
+	var siteverifyCalls int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		siteverifyCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}))
+	t.Cleanup(ts.Close)
+
+	seen := NewSeenTokens(time.Minute, nil)
+	inner := TurnstileVerifier{Secret: "secret", VerifyURL: ts.URL, Client: ts.Client()}
+	guard := &ReplayGuardVerifier{
+		Inner: inner,
+		Seen:  seen,
+	}
+
+	for _, token := range []string{"", strings.Repeat("x", maxTurnstileTokenBytes+1)} {
+		if err := guard.Verify(context.Background(), token, "198.51.100.7"); err == nil {
+			t.Fatal("invalid token Verify succeeded, want fail closed")
+		}
+	}
+	if siteverifyCalls != 0 {
+		t.Fatalf("siteverify calls = %d, want 0 for invalid tokens", siteverifyCalls)
+	}
+	seen.mu.Lock()
+	defer seen.mu.Unlock()
+	if len(seen.m) != 0 {
+		t.Fatalf("seen-token cache len = %d, want 0 after invalid tokens", len(seen.m))
 	}
 }

--- a/internal/playground/live_llm_driver.go
+++ b/internal/playground/live_llm_driver.go
@@ -110,6 +110,9 @@ func mapModelEvent(ev llmagent.Event) (out LiveEvent, push bool, proxiedAction s
 		// agent column shows "hit action limit" vs "done" instead of inferring it.
 		return LiveEvent{Type: LiveEventAgentState, State: agentStateEnded, Note: turnEndNote(ev.Reason)}, true, ""
 	case llmagent.EventError:
+		if ev.Code == llmagent.ErrorCodeModelProviderPaused {
+			return LiveEvent{Type: LiveEventError, Message: ModelProviderPausedMessage}, true, ""
+		}
 		return LiveEvent{Type: LiveEventError, Message: ev.Text}, true, ""
 	default:
 		return LiveEvent{}, false, ""
@@ -450,6 +453,7 @@ func (r *subprocessTurnRunner) RunTurn(ctx context.Context, msg string, onEvent 
 		return fmt.Errorf("playground: write message to model agent: %w", err)
 	}
 
+	var turnErr error
 	for r.sc.Scan() {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -459,7 +463,10 @@ func (r *subprocessTurnRunner) RunTurn(ctx context.Context, msg string, onEvent 
 			return fmt.Errorf("playground: parse model agent event: %w", err)
 		}
 		if ev.Kind == llmagent.EventTurnDone {
-			return nil
+			return turnErr
+		}
+		if ev.Kind == llmagent.EventError && ev.Code == llmagent.ErrorCodeModelProviderPaused {
+			turnErr = ErrModelProviderPaused
 		}
 		onEvent(ev)
 	}

--- a/internal/playground/live_llm_internal_test.go
+++ b/internal/playground/live_llm_internal_test.go
@@ -899,7 +899,7 @@ func TestSubprocessTurnRunner_ContextCancelled(t *testing.T) {
 	dir := t.TempDir()
 	bin := buildLLMHelper(t, echoHelperSrc)
 	runner, err := newSubprocessTurnRunner(t.Context(), subprocessRunnerOpts{
-		Bin: bin, ProxyURL: "http://127.0.0.1:1/",
+		Bin: bin, ProxyURL: "http://proxy.invalid/",
 		ModelBaseURL: "http://m/v1", Model: "x", SecretFile: filepath.Join(dir, "k"),
 	})
 	if err != nil {
@@ -938,7 +938,7 @@ func main() {
 `
 	bin := buildLLMHelper(t, src)
 	runner, err := newSubprocessTurnRunner(t.Context(), subprocessRunnerOpts{
-		Bin: bin, ProxyURL: "http://127.0.0.1:1/",
+		Bin: bin, ProxyURL: "http://proxy.invalid/",
 		ModelBaseURL: "http://m/v1", Model: "x", SecretFile: filepath.Join(dir, "k"),
 	})
 	if err != nil {

--- a/internal/playground/live_llm_internal_test.go
+++ b/internal/playground/live_llm_internal_test.go
@@ -91,6 +91,17 @@ func TestMapModelEvent(t *testing.T) {
 			wantMessage: "model unreachable",
 		},
 		{
+			name: "provider paused error uses clean message",
+			ev: llmagent.Event{
+				Kind: llmagent.EventError,
+				Text: "model returned 429: raw provider details",
+				Code: llmagent.ErrorCodeModelProviderPaused,
+			},
+			wantPush:    true,
+			wantType:    LiveEventError,
+			wantMessage: ModelProviderPausedMessage,
+		},
+		{
 			name:     "turn_done is not pushed",
 			ev:       llmagent.Event{Kind: llmagent.EventTurnDone},
 			wantPush: false,
@@ -531,6 +542,40 @@ func TestSendViaModel_NoReceipt_FailsClosed(t *testing.T) {
 	}
 }
 
+func TestSendViaModel_ModelProviderPausedCleanly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a real proxy")
+	}
+	runner := &scriptedRunner{
+		run: func(_ context.Context, _ string, onEvent func(llmagent.Event)) error {
+			onEvent(llmagent.Event{
+				Kind: llmagent.EventError,
+				Text: "model returned 429: provider raw detail",
+				Code: llmagent.ErrorCodeModelProviderPaused,
+			})
+			return ErrModelProviderPaused
+		},
+	}
+	sess := newModelSession(t, runner, "", nil)
+	collected := collectEvents(sess.Events())
+
+	err := sess.Send(context.Background(), "hello")
+	if !errors.Is(err, ErrModelProviderPaused) {
+		t.Fatalf("Send err = %v, want ErrModelProviderPaused", err)
+	}
+	sess.Close()
+	evs := <-collected
+	var got string
+	for _, ev := range evs {
+		if ev.Type == LiveEventError {
+			got = ev.Message
+		}
+	}
+	if got != ModelProviderPausedMessage {
+		t.Fatalf("error event = %q, want clean provider pause message", got)
+	}
+}
+
 // TestSendViaModel_DuplicateHost_CountedNotSet: two narrated actions to the same
 // destination but only one real proxied request must fail the invariant. A
 // set-membership check would wrongly pass; the count-based check catches it.
@@ -866,6 +911,60 @@ func TestSubprocessTurnRunner_ContextCancelled(t *testing.T) {
 	cancel() // cancel before the turn: the loop returns ctx.Err() after first read
 	if err := runner.RunTurn(ctx, "hello", func(llmagent.Event) {}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("RunTurn err = %v, want context.Canceled", err)
+	}
+}
+
+func TestSubprocessTurnRunner_ModelProviderPausedConsumesTurnDone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds + spawns a helper subprocess")
+	}
+	dir := t.TempDir()
+	src := `package main
+import ("bufio";"fmt";"os")
+func main() {
+	sc := bufio.NewScanner(os.Stdin)
+	first := true
+	for sc.Scan() {
+		if first {
+			first = false
+			fmt.Println(` + "`" + `{"kind":"error","text":"model returned 429: provider raw detail","code":"model_provider_paused"}` + "`" + `)
+			fmt.Println(` + "`" + `{"kind":"turn_done"}` + "`" + `)
+			continue
+		}
+		fmt.Println(` + "`" + `{"kind":"reply","text":"ok"}` + "`" + `)
+		fmt.Println(` + "`" + `{"kind":"turn_done"}` + "`" + `)
+	}
+}
+`
+	bin := buildLLMHelper(t, src)
+	runner, err := newSubprocessTurnRunner(t.Context(), subprocessRunnerOpts{
+		Bin: bin, ProxyURL: "http://127.0.0.1:1/",
+		ModelBaseURL: "http://m/v1", Model: "x", SecretFile: filepath.Join(dir, "k"),
+	})
+	if err != nil {
+		t.Fatalf("newSubprocessTurnRunner: %v", err)
+	}
+	defer func() { _ = runner.Close() }()
+
+	var first []llmagent.Event
+	err = runner.RunTurn(t.Context(), "hello", func(ev llmagent.Event) {
+		first = append(first, ev)
+	})
+	if !errors.Is(err, ErrModelProviderPaused) {
+		t.Fatalf("RunTurn first err = %v, want ErrModelProviderPaused", err)
+	}
+	if len(first) != 1 || first[0].Kind != llmagent.EventError || first[0].Code != llmagent.ErrorCodeModelProviderPaused {
+		t.Fatalf("first events = %+v, want provider-paused error event", first)
+	}
+
+	var second []llmagent.Event
+	if err := runner.RunTurn(t.Context(), "again", func(ev llmagent.Event) {
+		second = append(second, ev)
+	}); err != nil {
+		t.Fatalf("RunTurn second: %v", err)
+	}
+	if len(second) != 1 || second[0].Kind != llmagent.EventReply {
+		t.Fatalf("second events = %+v, want reply after turn_done was consumed", second)
 	}
 }
 

--- a/internal/playground/live_session.go
+++ b/internal/playground/live_session.go
@@ -6,6 +6,7 @@ package playground
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -82,6 +83,15 @@ var ErrReceiptInvariant = fmt.Errorf("playground: agent action produced no signe
 // is also closed, because it may already have recorded that raw reply in bounded
 // history before the parent process could redact it for the visitor.
 var ErrAgentReplyDLP = fmt.Errorf("playground: agent reply contained a secret")
+
+// ErrModelProviderPaused is returned when the model provider reports a spend,
+// auth, or rate-limit failure that should pause the public demo cleanly.
+var ErrModelProviderPaused = fmt.Errorf("playground: model provider paused")
+
+// ModelProviderPausedMessage is the visitor-facing message for provider spend,
+// auth, or rate-limit failures. Keep it generic so provider response details and
+// account state are not exposed to visitors.
+const ModelProviderPausedMessage = "demo paused: model provider unavailable or out of credits"
 
 // ContainmentVerifier proves the live agent's environment is kernel-contained
 // before a public session starts. Verify returns nil only when containment is
@@ -546,6 +556,9 @@ func (s *LiveSession) sendViaModel(ctx context.Context, msg string) error {
 	})
 	if runErr != nil {
 		s.endReceiptTurn()
+		if errors.Is(runErr, ErrModelProviderPaused) {
+			return ErrModelProviderPaused
+		}
 		s.push(LiveEvent{Type: LiveEventError, Message: "agent turn failed"})
 		return fmt.Errorf("model agent turn: %w", runErr)
 	}

--- a/internal/playground/livechat/client_ip.go
+++ b/internal/playground/livechat/client_ip.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package livechat
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+const cfConnectingIPHeader = "CF-Connecting-IP"
+
+var cloudflareProxyPrefixes = []netip.Prefix{
+	mustParsePrefix("173.245.48.0/20"),
+	mustParsePrefix("103.21.244.0/22"),
+	mustParsePrefix("103.22.200.0/22"),
+	mustParsePrefix("103.31.4.0/22"),
+	mustParsePrefix("141.101.64.0/18"),
+	mustParsePrefix("108.162.192.0/18"),
+	mustParsePrefix("190.93.240.0/20"),
+	mustParsePrefix("188.114.96.0/20"),
+	mustParsePrefix("197.234.240.0/22"),
+	mustParsePrefix("198.41.128.0/17"),
+	mustParsePrefix("162.158.0.0/15"),
+	mustParsePrefix("104.16.0.0/13"),
+	mustParsePrefix("104.24.0.0/14"),
+	mustParsePrefix("172.64.0.0/13"),
+	mustParsePrefix("131.0.72.0/22"),
+	mustParsePrefix("2400:cb00::/32"),
+	mustParsePrefix("2606:4700::/32"),
+	mustParsePrefix("2803:f800::/32"),
+	mustParsePrefix("2405:b500::/32"),
+	mustParsePrefix("2405:8100::/32"),
+	mustParsePrefix("2a06:98c0::/29"),
+	mustParsePrefix("2c0f:f248::/32"),
+}
+
+// ClientIP returns the abuse-budget identity for an HTTP request.
+//
+// CF-Connecting-IP is accepted only when the direct peer is in Cloudflare's
+// published proxy ranges. That keeps the public broker usable behind Cloudflare
+// while failing closed against direct clients that forge Cloudflare headers.
+//
+// IPv6 sources are collapsed to their /64 network so a single allocation cannot
+// mint unlimited per-IP rate/budget buckets by rotating addresses. Use
+// [ClientIPExact] where the precise source address matters (e.g. the Turnstile
+// Siteverify remoteip), never for rate-limit or budget keys.
+func ClientIP(r *http.Request, trustForwardedFor bool) string {
+	return abuseBucket(ClientIPExact(r, trustForwardedFor))
+}
+
+// ClientIPExact resolves the client IP without abuse-bucket normalization. It
+// applies the same Cloudflare/forwarded-for trust rules as [ClientIP] but
+// returns the full address.
+func ClientIPExact(r *http.Request, trustForwardedFor bool) string {
+	if r == nil {
+		return ""
+	}
+	peer := remoteHost(r.RemoteAddr)
+	if ip := cloudflareConnectingIP(r, peer); ip != "" {
+		return ip
+	}
+	if trustForwardedFor {
+		if ip := firstForwardedFor(r.Header.Get("X-Forwarded-For")); ip != "" {
+			return ip
+		}
+	}
+	return peer
+}
+
+// abuseBucket collapses an IPv6 address to its /64 network so rotating within a
+// single allocation does not bypass per-IP rate limits or budgets. IPv4 and
+// IPv4-mapped IPv6 addresses (and anything that does not parse as an IP) are
+// returned unchanged.
+func abuseBucket(ip string) string {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil || !addr.Is6() || addr.Is4In6() {
+		return ip
+	}
+	prefix, err := addr.Prefix(64)
+	if err != nil {
+		return ip
+	}
+	return prefix.Masked().String()
+}
+
+func cloudflareConnectingIP(r *http.Request, peer string) string {
+	if !isCloudflareProxy(peer) {
+		return ""
+	}
+	raw := strings.TrimSpace(r.Header.Get(cfConnectingIPHeader))
+	if raw == "" {
+		return ""
+	}
+	addr, err := netip.ParseAddr(raw)
+	if err != nil {
+		return ""
+	}
+	return addr.String()
+}
+
+func isCloudflareProxy(raw string) bool {
+	addr, err := netip.ParseAddr(strings.Trim(raw, "[]"))
+	if err != nil {
+		return false
+	}
+	for _, p := range cloudflareProxyPrefixes {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstForwardedFor(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if i := strings.IndexByte(raw, ','); i >= 0 {
+		raw = raw[:i]
+	}
+	return strings.TrimSpace(raw)
+}
+
+func remoteHost(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return host
+}
+
+func mustParsePrefix(raw string) netip.Prefix {
+	prefix, err := netip.ParsePrefix(raw)
+	if err != nil {
+		panic(err)
+	}
+	return prefix
+}

--- a/internal/playground/livechat/client_ip.go
+++ b/internal/playground/livechat/client_ip.go
@@ -12,6 +12,16 @@ import (
 
 const cfConnectingIPHeader = "CF-Connecting-IP"
 
+// cloudflareProxyPrefixes is a snapshot of Cloudflare's published proxy IP
+// ranges used to validate CF-Connecting-IP headers. These are NOT fetched at
+// runtime (avoids a network dependency at startup).
+//
+// Sources:
+//   - IPv4: https://www.cloudflare.com/ips-v4
+//   - IPv6: https://www.cloudflare.com/ips-v6
+//
+// Last refreshed: 2026-06-23
+// Refresh via scripts/check-cloudflare-ranges.sh.
 var cloudflareProxyPrefixes = []netip.Prefix{
 	mustParsePrefix("173.245.48.0/20"),
 	mustParsePrefix("103.21.244.0/22"),
@@ -121,7 +131,18 @@ func firstForwardedFor(raw string) string {
 	if i := strings.IndexByte(raw, ','); i >= 0 {
 		raw = raw[:i]
 	}
-	return strings.TrimSpace(raw)
+	segment := strings.TrimSpace(raw)
+	if segment == "" {
+		return ""
+	}
+	// Validate the segment is a real IP address; return empty on parse
+	// failure so the caller falls back to the peer address rather than using
+	// a garbage string as a rate-limit/budget key or Turnstile remoteip.
+	addr, err := netip.ParseAddr(segment)
+	if err != nil {
+		return ""
+	}
+	return addr.String()
 }
 
 func remoteHost(remoteAddr string) string {

--- a/internal/playground/livechat/client_ip_test.go
+++ b/internal/playground/livechat/client_ip_test.go
@@ -115,3 +115,27 @@ func TestClientIP_ForwardedForRequiresTrust(t *testing.T) {
 		t.Fatalf("trusted ClientIP = %q, want first XFF", got)
 	}
 }
+
+func TestClientIP_InvalidXFFSegmentFallsToPeer(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		xff  string
+		want string
+	}{
+		{name: "garbage_first_segment", xff: "not-an-ip, 1.2.3.4", want: "203.0.113.10"},
+		{name: "empty_first_segment", xff: ", 1.2.3.4", want: "203.0.113.10"},
+		{name: "valid_first_segment", xff: "198.51.100.7, 1.2.3.4", want: "198.51.100.7"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req.RemoteAddr = "203.0.113.10:443"
+			req.Header.Set("X-Forwarded-For", tc.xff)
+			if got := ClientIPExact(req, true); got != tc.want {
+				t.Fatalf("ClientIPExact = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/playground/livechat/client_ip_test.go
+++ b/internal/playground/livechat/client_ip_test.go
@@ -116,6 +116,59 @@ func TestClientIP_ForwardedForRequiresTrust(t *testing.T) {
 	}
 }
 
+func TestClientIP_NilRequest(t *testing.T) {
+	t.Parallel()
+	if got := ClientIP(nil, true); got != "" {
+		t.Fatalf("ClientIP(nil) = %q, want empty", got)
+	}
+	if got := ClientIPExact(nil, true); got != "" {
+		t.Fatalf("ClientIPExact(nil) = %q, want empty", got)
+	}
+}
+
+func TestClientIP_CloudflareHeaderEmptyFallsBack(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "173.245.48.9:443"
+	req.Header.Set("CF-Connecting-IP", " \t")
+
+	if got := ClientIPExact(req, false); got != "173.245.48.9" {
+		t.Fatalf("ClientIPExact = %q, want Cloudflare peer fallback", got)
+	}
+}
+
+func TestClientIP_MalformedCloudflarePeerFallsBack(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "not-an-ip:443"
+	req.Header.Set("CF-Connecting-IP", "198.51.100.7")
+
+	if got := ClientIPExact(req, false); got != "not-an-ip" {
+		t.Fatalf("ClientIPExact = %q, want raw malformed peer fallback", got)
+	}
+}
+
+func TestClientIP_EmptyForwardedForFallsBack(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.10:443"
+	req.Header.Set("X-Forwarded-For", "")
+
+	if got := ClientIPExact(req, true); got != "203.0.113.10" {
+		t.Fatalf("ClientIPExact = %q, want peer fallback", got)
+	}
+}
+
+func TestClientIP_RemoteAddrWithoutPort(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.10"
+
+	if got := ClientIPExact(req, false); got != "203.0.113.10" {
+		t.Fatalf("ClientIPExact = %q, want raw remote address", got)
+	}
+}
+
 func TestClientIP_InvalidXFFSegmentFallsToPeer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/playground/livechat/client_ip_test.go
+++ b/internal/playground/livechat/client_ip_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package livechat
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClientIP_CloudflareConnectingIP(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "173.245.48.9:443"
+	req.Header.Set("CF-Connecting-IP", "198.51.100.7")
+	req.Header.Set("X-Forwarded-For", "192.0.2.66, 198.51.100.4")
+
+	if got := ClientIP(req, false); got != "198.51.100.7" {
+		t.Fatalf("ClientIP = %q, want Cloudflare connecting IP", got)
+	}
+}
+
+func TestClientIP_CloudflareConnectingIPv6BucketsToSlash64(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "[2606:4700::1234]:443"
+	req.Header.Set("CF-Connecting-IP", "2001:db8::7")
+
+	if got := ClientIP(req, false); got != "2001:db8::/64" {
+		t.Fatalf("ClientIP = %q, want IPv6 /64 bucket", got)
+	}
+	if got := ClientIPExact(req, false); got != "2001:db8::7" {
+		t.Fatalf("ClientIPExact = %q, want full IPv6", got)
+	}
+}
+
+func TestClientIP_IPv6RotationSharesBucket(t *testing.T) {
+	t.Parallel()
+	mk := func(connecting string) *http.Request {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+		req.RemoteAddr = "[2606:4700::1234]:443"
+		req.Header.Set("CF-Connecting-IP", connecting)
+		return req
+	}
+	// Two distinct addresses inside one /64 collapse to one abuse bucket.
+	a := ClientIP(mk("2001:db8:1:2::1"), false)
+	b := ClientIP(mk("2001:db8:1:2:dead:beef:cafe:f00d"), false)
+	if a != b || a != "2001:db8:1:2::/64" {
+		t.Fatalf("same-/64 rotation: a=%q b=%q, want shared 2001:db8:1:2::/64", a, b)
+	}
+	// A different /64 is a different bucket.
+	if c := ClientIP(mk("2001:db8:1:3::1"), false); c == a {
+		t.Fatalf("different /64 collapsed to same bucket %q", c)
+	}
+}
+
+func TestClientIP_IPv4NotBucketed(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "173.245.48.9:443"
+	req.Header.Set("CF-Connecting-IP", "198.51.100.7")
+
+	// IPv4 is a /32 identity and must never be collapsed to a /64.
+	if got := ClientIP(req, false); got != "198.51.100.7" {
+		t.Fatalf("ClientIP = %q, want exact IPv4", got)
+	}
+}
+
+func TestClientIP_IPv4MappedNotMaskedAsV6(t *testing.T) {
+	t.Parallel()
+	// abuseBucket must leave IPv4-mapped IPv6 alone (no /64 collapse).
+	if got := abuseBucket("::ffff:198.51.100.7"); strings.HasSuffix(got, "/64") {
+		t.Fatalf("abuseBucket(IPv4-mapped) = %q, must not be a /64 bucket", got)
+	}
+	if got := abuseBucket("not-an-ip"); got != "not-an-ip" {
+		t.Fatalf("abuseBucket(non-IP) = %q, want passthrough", got)
+	}
+}
+
+func TestClientIP_RejectsForgedCloudflareHeader(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.10:443"
+	req.Header.Set("CF-Connecting-IP", "198.51.100.7")
+
+	if got := ClientIP(req, false); got != "203.0.113.10" {
+		t.Fatalf("ClientIP = %q, want direct peer", got)
+	}
+}
+
+func TestClientIP_InvalidCloudflareHeaderFallsBack(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "173.245.48.9:443"
+	req.Header.Set("CF-Connecting-IP", "not an ip")
+
+	if got := ClientIP(req, false); got != "173.245.48.9" {
+		t.Fatalf("ClientIP = %q, want Cloudflare peer fallback", got)
+	}
+}
+
+func TestClientIP_ForwardedForRequiresTrust(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.10:443"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7, 192.0.2.4")
+
+	if got := ClientIP(req, false); got != "203.0.113.10" {
+		t.Fatalf("untrusted ClientIP = %q, want direct peer", got)
+	}
+	if got := ClientIP(req, true); got != "198.51.100.7" {
+		t.Fatalf("trusted ClientIP = %q, want first XFF", got)
+	}
+}

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -11,10 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"os"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -582,6 +580,10 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 			writeErr(w, http.StatusConflict, "session is closed")
 			return
 		}
+		if errors.Is(err, playground.ErrModelProviderPaused) {
+			writeErr(w, http.StatusServiceUnavailable, playground.ModelProviderPausedMessage)
+			return
+		}
 		writeErr(w, http.StatusInternalServerError, "send failed")
 		return
 	}
@@ -770,19 +772,7 @@ func (s *Server) setCORS(w http.ResponseWriter) {
 }
 
 func (s *Server) clientIP(r *http.Request) string {
-	if s.cfg.TrustForwardedFor {
-		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-			if i := strings.IndexByte(xff, ','); i >= 0 {
-				return strings.TrimSpace(xff[:i])
-			}
-			return strings.TrimSpace(xff)
-		}
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
+	return ClientIP(r, s.cfg.TrustForwardedFor)
 }
 
 func gateErrStatus(err error) int {

--- a/internal/playground/llmagent/agent.go
+++ b/internal/playground/llmagent/agent.go
@@ -20,6 +20,7 @@ package llmagent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -46,6 +47,11 @@ const (
 	EventTurnDone = "turn_done"
 )
 
+// Error codes carried on EventError.Code.
+const (
+	ErrorCodeModelProviderPaused = "model_provider_paused"
+)
+
 // Turn-end reasons carried on EventTurnEnd.Reason.
 const (
 	turnEndComplete      = "complete"        // the model finished on its own
@@ -58,6 +64,7 @@ const (
 type Event struct {
 	Kind   string `json:"kind"`
 	Text   string `json:"text,omitempty"`   // reply text or error message
+	Code   string `json:"code,omitempty"`   // machine-readable EventError reason
 	Tool   string `json:"tool,omitempty"`   // tool name (tool_call/tool_result)
 	Method string `json:"method,omitempty"` // HTTP method for the tool's request
 	URL    string `json:"url,omitempty"`    // target URL for the tool's request
@@ -342,7 +349,7 @@ func (a *Agent) Run(ctx context.Context, userMsg string) (string, error) {
 		a.emit(Event{Kind: EventThinking})
 		reply, err := a.complete(ctx, messages, true)
 		if err != nil {
-			a.emit(Event{Kind: EventError, Text: err.Error()})
+			a.emit(Event{Kind: EventError, Text: err.Error(), Code: errorCode(err)})
 			return "", err
 		}
 
@@ -406,6 +413,14 @@ func (a *Agent) Run(ctx context.Context, userMsg string) (string, error) {
 		a.convo = a.trimContext(messages)
 	}
 	return finalText, nil
+}
+
+func errorCode(err error) string {
+	var st *ModelStatusError
+	if errors.As(err, &st) && IsProviderPausedStatus(st.Status) {
+		return ErrorCodeModelProviderPaused
+	}
+	return ""
 }
 
 // skippedToolResult is the synthetic tool message used to answer a tool call that

--- a/internal/playground/llmagent/client.go
+++ b/internal/playground/llmagent/client.go
@@ -80,6 +80,24 @@ type completionResponse struct {
 	} `json:"error,omitempty"`
 }
 
+// ModelStatusError reports a non-200 model provider response without losing the
+// status code needed by callers that turn spend/auth failures into operator UX.
+type ModelStatusError struct {
+	Status int
+	Body   string
+}
+
+func (e *ModelStatusError) Error() string {
+	return fmt.Sprintf("model returned %d: %s", e.Status, e.Body)
+}
+
+// IsProviderPausedStatus reports provider responses that should pause the demo
+// cleanly from a visitor's view: bad/expired credentials, exhausted credits, or
+// provider rate limits.
+func IsProviderPausedStatus(status int) bool {
+	return status == http.StatusUnauthorized || status == http.StatusPaymentRequired || status == http.StatusTooManyRequests
+}
+
 // complete issues one chat-completions round trip and returns the assistant
 // message. It advertises the agent's tools so the model can call them.
 func (a *Agent) complete(ctx context.Context, messages []chatMessage, offerTools bool) (chatMessage, error) {
@@ -127,7 +145,10 @@ func (a *Agent) complete(ctx context.Context, messages []chatMessage, offerTools
 	if resp.StatusCode != http.StatusOK {
 		// Redact BEFORE truncating: if the key sat near the snippet boundary,
 		// redacting the already-truncated string could miss a surviving prefix.
-		return chatMessage{}, fmt.Errorf("model returned %d: %s", resp.StatusCode, snippet([]byte(a.cfg.redactSecrets(string(body)))))
+		return chatMessage{}, &ModelStatusError{
+			Status: resp.StatusCode,
+			Body:   snippet([]byte(a.cfg.redactSecrets(string(body)))),
+		}
 	}
 
 	var parsed completionResponse

--- a/internal/playground/llmagent/client_test.go
+++ b/internal/playground/llmagent/client_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -101,6 +102,60 @@ func TestComplete_RedactsAPIKeyFromStatusErrorAndEvent(t *testing.T) {
 	}
 	if strings.Contains(errEv.Text, apiKey) || !strings.Contains(errEv.Text, "[redacted]") {
 		t.Fatalf("event text = %q, want API key redacted", errEv.Text)
+	}
+	if errEv.Code != ErrorCodeModelProviderPaused {
+		t.Fatalf("event code = %q, want provider paused", errEv.Code)
+	}
+}
+
+func TestComplete_ModelProviderPausedStatuses(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusTooManyRequests} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			model := &scriptedModel{
+				status:    status,
+				errorBody: `{"error":{"message":"provider unavailable"}}`,
+			}
+			emit, evs := collectEvents()
+			a := newAgent(t, model, nil, emit)
+
+			_, err := a.Run(context.Background(), "hi")
+			var st *ModelStatusError
+			if !errors.As(err, &st) || st.Status != status {
+				t.Fatalf("err = %v, want ModelStatusError status %d", err, status)
+			}
+			if !IsProviderPausedStatus(status) {
+				t.Fatalf("status %d should classify as provider paused", status)
+			}
+			var codes []string
+			for _, ev := range *evs {
+				if ev.Kind == EventError {
+					codes = append(codes, ev.Code)
+				}
+			}
+			if !slices.Contains(codes, ErrorCodeModelProviderPaused) {
+				t.Fatalf("error codes = %v, want %q", codes, ErrorCodeModelProviderPaused)
+			}
+		})
+	}
+}
+
+func TestComplete_ModelNonPausedStatusHasNoProviderPausedCode(t *testing.T) {
+	model := &scriptedModel{status: http.StatusInternalServerError}
+	emit, evs := collectEvents()
+	a := newAgent(t, model, nil, emit)
+
+	_, err := a.Run(context.Background(), "hi")
+	var st *ModelStatusError
+	if !errors.As(err, &st) || st.Status != http.StatusInternalServerError {
+		t.Fatalf("err = %v, want ModelStatusError 500", err)
+	}
+	if IsProviderPausedStatus(http.StatusInternalServerError) {
+		t.Fatal("500 must not classify as provider paused")
+	}
+	for _, ev := range *evs {
+		if ev.Kind == EventError && ev.Code == ErrorCodeModelProviderPaused {
+			t.Fatalf("event = %+v, 500 must not emit provider paused code", ev)
+		}
 	}
 }
 

--- a/scripts/check-cloudflare-ranges.sh
+++ b/scripts/check-cloudflare-ranges.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-cloudflare-ranges.sh — manual operator tool (NOT wired into required CI).
+#
+# Fetches the current Cloudflare proxy IP ranges and diffs them against the
+# hardcoded prefixes in internal/playground/livechat/client_ip.go. Exits
+# non-zero when the lists diverge.
+#
+# Usage:
+#   bash scripts/check-cloudflare-ranges.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SOURCE_FILE="$REPO_ROOT/internal/playground/livechat/client_ip.go"
+
+if [[ ! -f "$SOURCE_FILE" ]]; then
+  echo "ERROR: source file not found: $SOURCE_FILE" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Fetch the current published ranges.
+curl -sfL "https://www.cloudflare.com/ips-v4" -o "$tmpdir/ips-v4.txt"
+curl -sfL "https://www.cloudflare.com/ips-v6" -o "$tmpdir/ips-v6.txt"
+
+# Combine and sort.
+{ cat "$tmpdir/ips-v4.txt"; echo; cat "$tmpdir/ips-v6.txt"; } \
+  | tr -d '\r' | sed '/^$/d' | sort > "$tmpdir/published.txt"
+
+# Extract the hardcoded prefixes from the Go source.
+grep -oP 'mustParsePrefix\("\K[^"]+' "$SOURCE_FILE" | sort > "$tmpdir/hardcoded.txt"
+
+if diff -u "$tmpdir/hardcoded.txt" "$tmpdir/published.txt" > "$tmpdir/diff.txt"; then
+  echo "OK: hardcoded Cloudflare prefixes match the published lists."
+  exit 0
+fi
+
+echo "DRIFT DETECTED: hardcoded Cloudflare prefixes are out of date." >&2
+cat "$tmpdir/diff.txt" >&2
+echo "" >&2
+echo "Update internal/playground/livechat/client_ip.go and refresh the" >&2
+echo "'Last refreshed' comment." >&2
+exit 1


### PR DESCRIPTION
## What changed

Makes the playground demo broker (`pipelock-playground-broker`) safe to expose to the public internet. This is demonstration tooling under `cmd/`; it is not packaged in Pipelock releases and no product code imports it.

Controls:

- **Cloudflare Turnstile human gate**: server-side Siteverify before any VM lease, fail-closed on every error path, plus a broker-side replay guard so a solved token cannot be raced into concurrent sessions (the seen-token cache is shape-validated, TTL-bounded, and hard-capped).
- **Abuse / spend caps**: per-IP, per-code, and global daily budgets with atomic charge/rollback; a per-VM model-turn budget enforced inside each VM. The broker refuses to boot with unlimited budgets or no human gate absent explicit `--unsafe-*` flags.
- **Cloudflare client-IP trust**: `CF-Connecting-IP` honored only from published Cloudflare ranges; IPv6 abuse identity bucketed to /64; X-Forwarded-For segments IP-validated.
- **Admin API**: pause/resume on a separate authenticated listener (constant-time bearer), bound to loopback/private unless explicitly overridden.
- **Clean provider degrade**: model-provider auth/credit failures surface a generic 503 with the upstream body redacted; no key or account detail leaks.
- Operator runbook (`docs/guides/playground-broker-operations.md`) and a manual Cloudflare-range refresh script.

Each hardening finding from independent adversarial review (token-replay race, admin-listen scope, JWKS refetch backoff, request-body limits, write-deadline scoping, replay-cache admission) is addressed with a regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Human verification (Cloudflare Turnstile) gates public session creation against bots, using the request’s exact client IP.
  * Authenticated admin controls to health-check and pause/resume the broker (signals + admin HTTP).
  * Session-start rate tracking in the broker health endpoint.
* **Bug Fixes**
  * Clear “model/provider paused” handling now returns HTTP 503 with a dedicated message.
  * Oversized message uploads now return HTTP 413.
* **Documentation**
  * Updated the broker operations guide with a safety checklist and safer startup/deployment steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->