### PR TITLE
fix: eval mint matches net_amount (tax-invariant) + playground bundle signed receipts

### DIFF
--- a/enterprise/licenseservice/eval.go
+++ b/enterprise/licenseservice/eval.go
@@ -422,7 +422,12 @@ func (h *WebhookHandler) evalOrderDenialReason(order *PolarOrder) string {
 	if order.Currency != h.cfg.EvalCurrency {
 		return denyReasonCurrencyMismatch
 	}
-	if order.TotalAmount != h.cfg.EvalAmountCents {
+	// Compare the tax-EXCLUSIVE net amount, not the gross total. Polar is the
+	// merchant of record and adds sales tax/VAT on top of the price, so
+	// total_amount varies by buyer jurisdiction while net_amount equals the
+	// configured product price for every buyer. Comparing total_amount rejected
+	// any taxed purchase (e.g. $5000 + tax > 500000) and never minted a token.
+	if order.NetAmount != h.cfg.EvalAmountCents {
 		return denyReasonAmountMismatch
 	}
 	if classifyRefund(order) != refundStateNone {

--- a/enterprise/licenseservice/eval_test.go
+++ b/enterprise/licenseservice/eval_test.go
@@ -118,11 +118,12 @@ func defaultEvalOrderJSON(status string) string {
 		"paid": %s,
 		"billing_reason": "purchase",
 		"total_amount": %d,
+		"net_amount": %d,
 		"refunded_amount": %d,
 		"currency": "usd",
 		"customer": {"email": "%s", "metadata": {"org": "buyercorp"}},
 		"product": {"id": "%s", "name": "Enterprise Eval", "metadata": {"pipelock_tier": "enterprise_eval"}}
-	}`, testEvalOrderID, status, paid, testEvalAmount, refunded, testEvalEmail, testEvalProductID)
+	}`, testEvalOrderID, status, paid, testEvalAmount, testEvalAmount, refunded, testEvalEmail, testEvalProductID)
 }
 
 func evalPaidEvent() *PolarWebhookEvent {
@@ -197,7 +198,7 @@ func TestHandleOrderPaid_RejectsInvalidOrders(t *testing.T) {
 		body string
 	}{
 		{name: "unpaid", body: strings.ReplaceAll(defaultEvalOrderJSON(orderStatusPaid), `"paid": true`, `"paid": false`)},
-		{name: "wrong amount", body: strings.ReplaceAll(defaultEvalOrderJSON(orderStatusPaid), `"total_amount": 500000`, `"total_amount": 100`)},
+		{name: "wrong amount", body: strings.ReplaceAll(defaultEvalOrderJSON(orderStatusPaid), `"net_amount": 500000`, `"net_amount": 100`)},
 		{name: "wrong currency", body: strings.ReplaceAll(defaultEvalOrderJSON(orderStatusPaid), `"currency": "usd"`, `"currency": "eur"`)},
 		{name: "wrong product", body: strings.ReplaceAll(defaultEvalOrderJSON(orderStatusPaid), testEvalProductID, "prod_not_allowlisted")},
 		{name: "fully refunded", body: defaultEvalOrderJSON(orderStatusRefunded)},
@@ -350,5 +351,51 @@ func TestHandleOrderPaid_MintedTokenVerifies(t *testing.T) {
 	}
 	if lic.Tier != tierEnterpriseEval || !lic.HasFeature(license.FeatureFleet) {
 		t.Errorf("license = %+v, want eval tier + fleet feature", lic)
+	}
+}
+
+// TestEvalOrderDenialReason_NetAmountTaxInvariant proves the amount gate matches
+// on the tax-exclusive net_amount, not the gross total_amount. Polar is the
+// merchant of record and adds tax on top of the price, so total_amount varies by
+// buyer jurisdiction; comparing it rejected every taxed purchase. Regression for
+// that bug: a taxed order (net == price, gross > price) must mint; a wrong net
+// must be denied even if the gross happens to equal the configured price.
+func TestEvalOrderDenialReason_NetAmountTaxInvariant(t *testing.T) {
+	const pid = "prod_eval_net_test"
+	h := &WebhookHandler{cfg: &Config{
+		EvalAmountCents: 500000,
+		EvalCurrency:    "usd",
+		EvalProductIDs:  []string{pid},
+	}}
+	base := func() *PolarOrder {
+		o := &PolarOrder{
+			Paid:          true,
+			BillingReason: "purchase",
+			Currency:      "usd",
+			NetAmount:     500000,
+			TotalAmount:   500000,
+		}
+		o.Product.ID = pid
+		o.Product.Metadata = map[string]string{"pipelock_tier": tierEnterpriseEval}
+		return o
+	}
+	tests := []struct {
+		name   string
+		mutate func(*PolarOrder)
+		want   string
+	}{
+		{"taxed order mints (net==price, gross>price)", func(o *PolarOrder) { o.NetAmount = 500000; o.TotalAmount = 535000 }, ""},
+		{"no-tax order mints", func(o *PolarOrder) { o.NetAmount = 500000; o.TotalAmount = 500000 }, ""},
+		{"wrong net denied", func(o *PolarOrder) { o.NetAmount = 400000; o.TotalAmount = 428000 }, denyReasonAmountMismatch},
+		{"net wrong is denied even when gross equals price", func(o *PolarOrder) { o.NetAmount = 450000; o.TotalAmount = 500000 }, denyReasonAmountMismatch},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := base()
+			tt.mutate(o)
+			if got := h.evalOrderDenialReason(o); got != tt.want {
+				t.Fatalf("evalOrderDenialReason = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/enterprise/licenseservice/polar.go
+++ b/enterprise/licenseservice/polar.go
@@ -263,7 +263,8 @@ type PolarOrder struct {
 	// re-fetch from the Polar API (the webhook body is not authoritative).
 	Status         string `json:"status"`          // "paid", "refunded", "partially_refunded", …
 	Paid           bool   `json:"paid"`            // true once payment has settled
-	TotalAmount    int    `json:"total_amount"`    // order total in minor units (cents)
+	TotalAmount    int    `json:"total_amount"`    // gross total incl. tax in minor units (cents); used for refund accounting
+	NetAmount      int    `json:"net_amount"`      // amount excl. tax in minor units (cents); the configured product price, tax-invariant
 	RefundedAmount int    `json:"refunded_amount"` // refunded so far in minor units (cents)
 	Currency       string `json:"currency"`        // ISO 4217, lowercase (e.g. "usd")
 

--- a/enterprise/licenseservice/polar_test.go
+++ b/enterprise/licenseservice/polar_test.go
@@ -407,6 +407,7 @@ func TestPolarClient_GetOrder(t *testing.T) {
 		wantStatus   string
 		wantRefunded int
 		wantTotal    int
+		wantNet      int
 		wantCurrency string
 	}{
 		{
@@ -417,7 +418,8 @@ func TestPolarClient_GetOrder(t *testing.T) {
 				"status": "paid",
 				"paid": true,
 				"billing_reason": "purchase",
-				"total_amount": 500000,
+				"total_amount": 535000,
+				"net_amount": 500000,
 				"refunded_amount": 0,
 				"currency": "usd",
 				"customer": {"email": "buyer@example.com", "metadata": {}},
@@ -427,7 +429,8 @@ func TestPolarClient_GetOrder(t *testing.T) {
 			wantPaid:     true,
 			wantStatus:   "paid",
 			wantRefunded: 0,
-			wantTotal:    500000,
+			wantTotal:    535000,
+			wantNet:      500000,
 			wantCurrency: "usd",
 		},
 		{
@@ -438,7 +441,8 @@ func TestPolarClient_GetOrder(t *testing.T) {
 				"status": "partially_refunded",
 				"paid": true,
 				"billing_reason": "purchase",
-				"total_amount": 500000,
+				"total_amount": 535000,
+				"net_amount": 500000,
 				"refunded_amount": 100000,
 				"currency": "usd",
 				"customer": {"email": "buyer@example.com", "metadata": {}},
@@ -448,7 +452,8 @@ func TestPolarClient_GetOrder(t *testing.T) {
 			wantPaid:     true,
 			wantStatus:   "partially_refunded",
 			wantRefunded: 100000,
-			wantTotal:    500000,
+			wantTotal:    535000,
+			wantNet:      500000,
 			wantCurrency: "usd",
 		},
 		{
@@ -499,6 +504,9 @@ func TestPolarClient_GetOrder(t *testing.T) {
 			}
 			if order.TotalAmount != tt.wantTotal {
 				t.Errorf("TotalAmount = %d, want %d", order.TotalAmount, tt.wantTotal)
+			}
+			if order.NetAmount != tt.wantNet {
+				t.Errorf("NetAmount = %d, want %d", order.NetAmount, tt.wantNet)
 			}
 			if order.Currency != tt.wantCurrency {
 				t.Errorf("Currency = %q, want %q", order.Currency, tt.wantCurrency)

--- a/internal/playground/bundle_build.go
+++ b/internal/playground/bundle_build.go
@@ -93,6 +93,7 @@ func buildDecisions(narr scenarioNarrative, receipts []receipt.Receipt, rep Veri
 			Meta:             fmt.Sprintf("verdict=allow · transport=%s", ar.Transport),
 			Signer:           bundleSignerPipelock,
 			Key:              shortKey(allowR.SignerKey),
+			Envelope:         receiptEnvelopeLines(allowR),
 			DestinationClass: DestinationClassUntrusted,
 		})
 	}
@@ -131,9 +132,10 @@ func buildDecisions(narr scenarioNarrative, receipts []receipt.Receipt, rep Veri
 			Headline: narr.containDecision.headline,
 			Body: fmt.Sprintf("%d direct-egress routes and %d local escape surfaces blocked for the contained agent; the same control target stayed reachable for the operator.",
 				len(hcw.AgentProbes), len(hcw.LocalAgentProbes)),
-			Meta:   "owner-match drop · local hardening · enforced by the host kernel",
-			Signer: bundleSignerOrch,
-			Key:    shortKey(rep.OrchestratorKey),
+			Meta:     "owner-match drop · local hardening · enforced by the host kernel",
+			Signer:   bundleSignerOrch,
+			Key:      shortKey(rep.OrchestratorKey),
+			Envelope: witnessEnvelopeLines(*hcw),
 		})
 	}
 
@@ -147,6 +149,7 @@ func buildDecisions(narr scenarioNarrative, receipts []receipt.Receipt, rep Veri
 		Meta:     fmt.Sprintf("observations=%d · binds=%s", witness.ObservedCount, shortNonce(witness.RunNonce)),
 		Signer:   bundleSignerCollector,
 		Key:      shortKey(rep.CollectorKey),
+		Envelope: witnessEnvelopeLines(witness),
 	})
 
 	return decisions
@@ -157,6 +160,15 @@ func buildDecisions(narr scenarioNarrative, receipts []receipt.Receipt, rep Veri
 // signed artifact, not a sample — the same bytes a verifier checks.
 func receiptEnvelopeLines(r receipt.Receipt) []string {
 	b, _ := json.MarshalIndent(r, "", "  ")
+	return strings.Split(string(b), "\n")
+}
+
+// witnessEnvelopeLines renders a signed attestation (the collector witness or the
+// host-containment witness) as indented JSON lines, matching the viewer's
+// expandable-envelope format. Like receiptEnvelopeLines, this is the real signed
+// artifact — the witness carries its own ed25519 Signature — not a sample.
+func witnessEnvelopeLines(v any) []string {
+	b, _ := json.MarshalIndent(v, "", "  ")
 	return strings.Split(string(b), "\n")
 }
 

--- a/internal/playground/bundle_internal_test.go
+++ b/internal/playground/bundle_internal_test.go
@@ -168,6 +168,7 @@ func bundleTestHCW() HostContainmentWitness {
 		RunNonce:    "n",
 		AgentProbes: []ProbeResult{{Target: "169.254.169.254:80", Blocked: true}, {Target: "10.0.0.1:443", Blocked: true}},
 		ProbedAt:    time.Unix(testFixtureTS, 0).UTC(),
+		Signature:   "hcw-sig",
 	}
 }
 
@@ -178,7 +179,7 @@ func TestBuildDecisions(t *testing.T) {
 		OrchestratorKey: strings.Repeat("0", 64),
 		CollectorKey:    strings.Repeat("c", 64),
 	}
-	witness := Witness{RunNonce: "playground-demo-run", ObservedCount: 0}
+	witness := Witness{RunNonce: "playground-demo-run", ObservedCount: 0, Signature: "collector-sig"}
 
 	// Uncontained: allow, block, witness; no containment decision.
 	d := buildDecisions(liveDemoNarrative, rs, rep, witness, nil)
@@ -187,6 +188,9 @@ func TestBuildDecisions(t *testing.T) {
 	}
 	if d[0].Verdict != "ALLOW" || d[0].Class != string(ClassPipelockDecision) {
 		t.Fatalf("decision 0 = %+v", d[0])
+	}
+	if got := strings.Join(d[0].Envelope, "\n"); !strings.Contains(got, "ed25519:deadbeef") || !strings.Contains(got, "signer_key") {
+		t.Fatalf("allow decision must carry the real signed receipt envelope:\n%s", got)
 	}
 	if d[1].Verdict != "BLOCKED" || !d[1].Pop || len(d[1].Envelope) == 0 {
 		t.Fatalf("block decision missing pop/envelope: %+v", d[1])
@@ -197,6 +201,9 @@ func TestBuildDecisions(t *testing.T) {
 	if d[2].Class != string(ClassCollectorWitness) || !strings.Contains(d[2].Headline, "observed = 0") {
 		t.Fatalf("witness decision = %+v", d[2])
 	}
+	if got := strings.Join(d[2].Envelope, "\n"); !strings.Contains(got, "collector-sig") || !strings.Contains(got, "run_nonce") {
+		t.Fatalf("collector witness decision must carry the signed witness envelope:\n%s", got)
+	}
 
 	// Contained: a host-containment decision is inserted before the witness.
 	hcw := bundleTestHCW()
@@ -206,6 +213,9 @@ func TestBuildDecisions(t *testing.T) {
 	}
 	if dc[2].Class != string(ClassHostContainment) || dc[2].Signer != bundleSignerOrch {
 		t.Fatalf("containment decision = %+v", dc[2])
+	}
+	if got := strings.Join(dc[2].Envelope, "\n"); !strings.Contains(got, "hcw-sig") || !strings.Contains(got, "agent_probes") {
+		t.Fatalf("host-containment decision must carry the signed witness envelope:\n%s", got)
 	}
 	if !strings.Contains(dc[2].Body, "2 direct-egress routes and 0 local escape surfaces") {
 		t.Fatalf("containment body should reflect probe count: %q", dc[2].Body)


### PR DESCRIPTION
## What changed

Two small fixes in separate subsystems, bundled together.

### Enterprise Eval mint: match net_amount, not the gross total

The eval purchase gate compared the order's tax-inclusive total against the configured price. Polar is the merchant of record and adds tax on top, so the gross total varies by buyer jurisdiction and a fixed configured amount could never match it. Every taxed eval purchase was denied and no license token minted.

The gate now compares net_amount (the tax-exclusive price), which equals the configured product price for every buyer. The gross total is retained for refund accounting (classifyRefund). A regression test covers it: a taxed order mints, a wrong net is still denied.

### Playground bundle: attach real signed receipts

The bundle generator now attaches the real signed envelopes to the allow decision and both witnesses, so a downloaded bundle carries verifiable receipts, not just the block receipt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order validation so purchases with tax are evaluated using the pre-tax amount, reducing false rejections.
  * Ensured order details now reflect both gross and net amounts consistently in related views and checks.

* **New Features**
  * Expanded decision details in the playground to show fuller signed envelope content for applicable outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->