### PR TITLE
chore: CodeRabbit profile chill to assertive

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,7 +7,7 @@
 language: "en-US"
 
 reviews:
-  profile: "chill"                 # fewer nitpicks; flip to "assertive" if too quiet
+  profile: "assertive"             # broader coverage (Kilo reviewer removed); path_instructions below temper speculative nits
   request_changes_workflow: false  # advisory only — must NEVER block a merge
   high_level_summary: true         # one automated summary; maintainers own decisions
   poem: false


### PR DESCRIPTION
## What changed

Switch CodeRabbit's review profile from chill to assertive for broader automated coverage, now that the separate Kilo reviewer was removed from the repo.

The existing path_instructions already keep the bot advisory-only, tell it to skip speculative security nits, and disable the linters CI already runs (golangci-lint, gitleaks). So this adds review depth without blocking merges or duplicating CI. CodeRabbit profiles are only chill or assertive; this is the broader of the two, tempered by the instructions in the same file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review settings to make automated checks more thorough.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->