### PR TITLE
feat(playground): require real live model, add per-session verify kits, fix model 400

### DIFF
--- a/cmd/pipelock-playground-live/main.go
+++ b/cmd/pipelock-playground-live/main.go
@@ -62,6 +62,7 @@ type serveFlags struct {
 	maxPerCode             int
 	concurrency            int
 	requireContainment     bool
+	requireModel           bool
 	selfManagedContainment bool
 	dev                    bool
 	orchestratorKey        string
@@ -89,6 +90,9 @@ type serveFlags struct {
 	perIPDailyBudget       int
 	perCodeDailyBudget     int
 	maxMessagesPerSession  int
+	verifierBinLinux       string
+	verifierBinMacOS       string
+	verifierBinWindows     string
 }
 
 // defaultMaxPerCode is the safe default lifetime session budget per invite code.
@@ -111,6 +115,7 @@ func newServeCmd() *cobra.Command {
 	fl.IntVar(&f.maxPerCode, "max-per-code", defaultMaxPerCode, "max sessions per invite code (0 = unlimited, opt-in)")
 	fl.IntVar(&f.concurrency, "concurrency", 3, "global cap on simultaneous live sessions")
 	fl.BoolVar(&f.requireContainment, "require-containment", true, "refuse sessions unless kernel containment is established")
+	fl.BoolVar(&f.requireModel, "require-model", false, "refuse to serve unless the real model-backed agent is fully configured (public demo guard)")
 	fl.BoolVar(&f.selfManagedContainment, "self-managed-containment", false, "the deployment sets the nft owner-match egress rule itself (e.g. a per-visitor microVM boot entrypoint) instead of `pipelock contain install`; the server proves the agent-uid egress/local escape drops empirically at start and via the signed witness, and does NOT require `pipelock contain verify`")
 	fl.BoolVar(&f.dev, "dev", false, "DEV ONLY: run uncontained (disables --require-containment); never use for public exposure")
 	fl.StringVar(&f.orchestratorKey, "orchestrator-key", "", "path to the published demo signing key (required outside --dev; empty = ephemeral per-run key in --dev)")
@@ -138,6 +143,9 @@ func newServeCmd() *cobra.Command {
 	fl.IntVar(&f.perIPDailyBudget, "per-ip-daily-budget", 0, "per client-IP ceiling on model round trips per UTC day so one client cannot drain the global budget (0 = no per-IP cap)")
 	fl.IntVar(&f.perCodeDailyBudget, "per-code-daily-budget", 0, "per invite-code ceiling on model round trips per UTC day so one code cannot drain the global budget (0 = no per-code cap)")
 	fl.IntVar(&f.maxMessagesPerSession, "max-messages-per-session", 0, "max messages one session may send (0 = default of 40)")
+	fl.StringVar(&f.verifierBinLinux, "verifier-bin-linux", "", "Linux pipelock-verifier binary path for live verify-kit downloads")
+	fl.StringVar(&f.verifierBinMacOS, "verifier-bin-macos", "", "macOS pipelock-verifier binary path for live verify-kit downloads")
+	fl.StringVar(&f.verifierBinWindows, "verifier-bin-windows", "", "Windows pipelock-verifier.exe binary path for live verify-kit downloads")
 	return cmd
 }
 
@@ -236,20 +244,25 @@ func buildServer(out io.Writer, f *serveFlags) (*livechat.Server, http.Handler, 
 	}
 
 	srv, err := livechat.NewServer(livechat.ServerConfig{
-		Gate:                  gate,
-		Limits:                livechat.Limits{MaxInputBytes: f.maxInputBytes, SessionTTL: f.sessionTTL},
-		IPRate:                livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
-		CodeRate:              livechat.RateConfig{RefillPerSec: f.codeRate, Burst: f.codeBurst},
-		MaxConcurrent:         f.concurrency,
-		RequireContainment:    requireContainment,
-		Containment:           verifier,
-		OrchestratorKeyPath:   f.orchestratorKey,
-		ToyAgentBin:           f.toyAgentBin,
-		WebToolBin:            f.webToolBin,
-		ProxyPort:             f.proxyPort,
-		TrustForwardedFor:     f.trustForwardedFor,
-		AllowOrigin:           f.allowOrigin,
-		LLMAgent:              llmAgent,
+		Gate:                gate,
+		Limits:              livechat.Limits{MaxInputBytes: f.maxInputBytes, SessionTTL: f.sessionTTL},
+		IPRate:              livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
+		CodeRate:            livechat.RateConfig{RefillPerSec: f.codeRate, Burst: f.codeBurst},
+		MaxConcurrent:       f.concurrency,
+		RequireContainment:  requireContainment,
+		Containment:         verifier,
+		OrchestratorKeyPath: f.orchestratorKey,
+		ToyAgentBin:         f.toyAgentBin,
+		WebToolBin:          f.webToolBin,
+		ProxyPort:           f.proxyPort,
+		TrustForwardedFor:   f.trustForwardedFor,
+		AllowOrigin:         f.allowOrigin,
+		LLMAgent:            llmAgent,
+		VerifierBinaries: playground.VerifyKitBinaries{
+			Linux:   f.verifierBinLinux,
+			MacOS:   f.verifierBinMacOS,
+			Windows: f.verifierBinWindows,
+		},
 		DailyTurnBudget:       f.dailyTurnBudget,
 		PerIPDailyBudget:      f.perIPDailyBudget,
 		PerCodeDailyBudget:    f.perCodeDailyBudget,
@@ -325,6 +338,9 @@ func validateServeSafety(f *serveFlags, modelBacked bool) error {
 	}
 	if !f.dev && strings.TrimSpace(f.orchestratorKey) == "" {
 		return errors.New("non-dev serve requires --orchestrator-key so bundles verify against the published demo key")
+	}
+	if f.requireModel && !modelBacked {
+		return errors.New("--require-model set but model-backed agent is not configured")
 	}
 	if modelBacked && !f.dev && f.dailyTurnBudget <= 0 {
 		return errors.New("model-backed public serve requires --daily-turn-budget > 0 (or --dev for local testing)")

--- a/cmd/pipelock-playground-live/main_test.go
+++ b/cmd/pipelock-playground-live/main_test.go
@@ -234,7 +234,7 @@ func TestNewRootCmd_HasSubcommands(t *testing.T) {
 func TestNewServeCmd_RegistersFlags(t *testing.T) {
 	t.Parallel()
 	cmd := newServeCmd()
-	for _, name := range []string{"listen", "code", "max-per-code", "dev", "require-containment", "secret", "secret-file", "static-dir", "session-ttl", "daily-turn-budget", "max-messages-per-session"} {
+	for _, name := range []string{"listen", "code", "max-per-code", "dev", "require-containment", "require-model", "secret", "secret-file", "static-dir", "session-ttl", "daily-turn-budget", "max-messages-per-session", "verifier-bin-linux", "verifier-bin-macos", "verifier-bin-windows"} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("serve missing --%s flag", name)
 		}
@@ -386,6 +386,21 @@ func TestBuildServer_PublicModelRequiresDailyBudget(t *testing.T) {
 		t.Fatal("nil server/handler")
 	}
 	defer srv.Close()
+}
+
+func TestBuildServer_RequireModelFailsClosedWithoutModelConfig(t *testing.T) {
+	t.Parallel()
+	f := devServeFlags()
+	f.dev = false
+	f.requireContainment = true
+	f.requireModel = true
+	f.codes = []string{"good"}
+	f.orchestratorKey = testOrchestratorKeyPath(t)
+
+	var out bytes.Buffer
+	if _, _, err := buildServer(&out, f); err == nil {
+		t.Fatal("--require-model without model config should fail closed")
+	}
 }
 
 func TestBuildServer_PublicModelValidatesRuntimeFiles(t *testing.T) {

--- a/deploy/fly-playground/Dockerfile
+++ b/deploy/fly-playground/Dockerfile
@@ -28,7 +28,10 @@ ENV CGO_ENABLED=0
 RUN go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-live      ./cmd/pipelock-playground-live \
  && go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-llm-agent ./cmd/pipelock-playground-llm-agent \
  && go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-toyagent  ./cmd/pipelock-playground-toyagent \
- && go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-webtool   ./cmd/pipelock-playground-webtool
+ && go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-webtool   ./cmd/pipelock-playground-webtool \
+ && GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o /out/pipelock-verifier-linux ./cmd/pipelock-verifier \
+ && GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o /out/pipelock-verifier-macos ./cmd/pipelock-verifier \
+ && GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o /out/pipelock-verifier-windows.exe ./cmd/pipelock-verifier
 
 FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716
 # nftables: load the owner-match egress rule. ca-certificates: TLS to the model
@@ -54,8 +57,11 @@ COPY --from=build /out/pipelock-playground-live      /usr/local/bin/pipelock-pla
 COPY --from=build /out/pipelock-playground-llm-agent /usr/local/bin/pipelock-playground-llm-agent
 COPY --from=build /out/pipelock-playground-toyagent  /usr/local/bin/pipelock-playground-toyagent
 COPY --from=build /out/pipelock-playground-webtool   /usr/local/bin/pipelock-playground-webtool
+COPY --from=build /out/pipelock-verifier-linux       /usr/local/bin/pipelock-verifier-linux
+COPY --from=build /out/pipelock-verifier-macos       /usr/local/bin/pipelock-verifier-macos
+COPY --from=build /out/pipelock-verifier-windows.exe /usr/local/bin/pipelock-verifier-windows.exe
 COPY deploy/fly-playground/entrypoint.sh /usr/local/bin/playground-entrypoint
-RUN chmod 0755 /usr/local/bin/playground-entrypoint /usr/local/bin/pipelock-playground-*
+RUN chmod 0755 /usr/local/bin/playground-entrypoint /usr/local/bin/pipelock-playground-* /usr/local/bin/pipelock-verifier-*
 ENV PLAYGROUND_AGENT_USER=pipelock-agent \
     PLAYGROUND_AGENT_UID=10001 \
     PLAYGROUND_PROXY_PORT=8888 \

--- a/deploy/fly-playground/Dockerfile
+++ b/deploy/fly-playground/Dockerfile
@@ -25,12 +25,18 @@ RUN go mod download
 COPY . .
 ARG VERSION=dev
 ENV CGO_ENABLED=0
+# makefat (Keith Randall, Go team) fat-combines the two macOS arches into one
+# universal2 binary so the verifier runs natively on Intel AND Apple Silicon
+# without Rosetta. Pinned, not @latest (build-time supply-chain hygiene).
+RUN go install github.com/randall77/makefat@v0.0.0-20260406194835-1b91746796b7
 RUN go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-live      ./cmd/pipelock-playground-live \
  && go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-llm-agent ./cmd/pipelock-playground-llm-agent \
  && go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-toyagent  ./cmd/pipelock-playground-toyagent \
  && go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-webtool   ./cmd/pipelock-playground-webtool \
  && GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o /out/pipelock-verifier-linux ./cmd/pipelock-verifier \
- && GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o /out/pipelock-verifier-macos ./cmd/pipelock-verifier \
+ && GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o /out/pipelock-verifier-macos-amd64 ./cmd/pipelock-verifier \
+ && GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "-s -w" -o /out/pipelock-verifier-macos-arm64 ./cmd/pipelock-verifier \
+ && makefat /out/pipelock-verifier-macos /out/pipelock-verifier-macos-amd64 /out/pipelock-verifier-macos-arm64 \
  && GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o /out/pipelock-verifier-windows.exe ./cmd/pipelock-verifier
 
 FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716

--- a/deploy/fly-playground/entrypoint.sh
+++ b/deploy/fly-playground/entrypoint.sh
@@ -24,6 +24,9 @@ BIN=/usr/local/bin/pipelock-playground-live
 TOYAGENT_BIN=/usr/local/bin/pipelock-playground-toyagent
 WEBTOOL_BIN=/usr/local/bin/pipelock-playground-webtool
 LLM_AGENT_BIN=/usr/local/bin/pipelock-playground-llm-agent
+VERIFIER_LINUX=/usr/local/bin/pipelock-verifier-linux
+VERIFIER_MACOS=/usr/local/bin/pipelock-verifier-macos
+VERIFIER_WINDOWS=/usr/local/bin/pipelock-verifier-windows.exe
 
 log() { printf '[entrypoint] %s\n' "$*" >&2; }
 
@@ -86,8 +89,9 @@ add_flag --daily-turn-budget "${PLAYGROUND_DAILY_TURN_BUDGET:-}"
 add_flag --session-ttl "${PLAYGROUND_SESSION_TTL:-}"
 add_flag --max-messages-per-session "${PLAYGROUND_MAX_MESSAGES:-}"
 # The model agent is all-or-nothing (serve rejects --llm-agent-bin without the
-# model flags). Only enable it when a model is configured, so a no-model
-# deployment runs the deterministic agent cleanly.
+# model flags). The public entrypoint also passes --require-model below, so a
+# no-model deployment fails honest instead of serving the deterministic agent as
+# "live".
 if [ -n "${PLAYGROUND_MODEL_BASE_URL:-}" ]; then
 	add_flag --llm-agent-bin "${LLM_AGENT_BIN}"
 fi
@@ -97,11 +101,15 @@ log "containment proven; starting server on ${LISTEN}"
 # shellcheck disable=SC2086  # word-splitting of ORCH_KEY_ARGS/MODEL_KEY_ARGS/EXTRA_ARGS is intended; secret paths are fixed under /run/playground (no spaces)
 exec "${BIN}" serve \
 	--self-managed-containment \
+	--require-model \
 	--listen "${LISTEN}" \
 	--proxy-port "${PROXY_PORT}" \
 	--concurrency 1 \
 	--toyagent-bin "${TOYAGENT_BIN}" \
 	--webtool-bin "${WEBTOOL_BIN}" \
+	--verifier-bin-linux "${VERIFIER_LINUX}" \
+	--verifier-bin-macos "${VERIFIER_MACOS}" \
+	--verifier-bin-windows "${VERIFIER_WINDOWS}" \
 	${ORCH_KEY_ARGS} \
 	${MODEL_KEY_ARGS} \
 	${EXTRA_ARGS} \

--- a/internal/playground/live_llm_internal_test.go
+++ b/internal/playground/live_llm_internal_test.go
@@ -504,6 +504,25 @@ func TestScanAgentReply_CleanPassthrough(t *testing.T) {
 	}
 }
 
+// TestScanAgentReply_PlantedSecretRedacted: when the agent echoes a planted
+// secret the exact-match redactor fires before the generic-DLP pass and replaces
+// the reply with the redaction notice. No proxy/scanner is needed: the
+// planted-secret branch returns before touching the live runner.
+func TestScanAgentReply_PlantedSecretRedacted(t *testing.T) {
+	t.Parallel()
+	// Built at runtime so the literal never looks like a real key (gosec G101).
+	accessKey := "AKIA" + "EXAMPLE0123456789AB"
+	sess := &LiveSession{plantedSecrets: []string{accessKey}}
+	ev, blocked := sess.scanAgentReply(context.Background(),
+		LiveEvent{Type: LiveEventChat, Role: liveRoleAgent, Text: "sure, the key is " + accessKey})
+	if !blocked {
+		t.Fatal("a reply echoing a planted secret must be blocked")
+	}
+	if ev.Text != redactedReplyNotice {
+		t.Fatalf("planted-secret reply = %q, want redaction notice", ev.Text)
+	}
+}
+
 // TestSendViaModel_NoReceipt_FailsClosed: the runner narrates a tool action that
 // got a (claimed) proxy response but never went through the proxy, so no receipt
 // backs it. The turn must fail closed with ErrReceiptInvariant.

--- a/internal/playground/live_session.go
+++ b/internal/playground/live_session.go
@@ -512,6 +512,9 @@ func (s *LiveSession) scanAgentReply(ctx context.Context, ev LiveEvent) (LiveEve
 	// reversed, base64/hex-encoded, or chunked, which the shape patterns miss.
 	// This is browser-safety, not a network-egress proof (the receipts are that).
 	if containsPlantedSecret(ev.Text, s.plantedSecrets) {
+		// Diagnostic: a planted-secret exact match is a TRUE catch (the agent
+		// echoed the canary/decoy, even encoded). Pattern name only, never the secret.
+		fmt.Fprintf(os.Stderr, "playground: agent reply redacted (trigger=planted-secret)\n")
 		ev.Text = redactedReplyNotice
 		return ev, true
 	}
@@ -519,6 +522,14 @@ func (s *LiveSession) scanAgentReply(ctx context.Context, ev LiveEvent) (LiveEve
 		return ev, false
 	}
 	if res := s.lr.sc.ScanTextForDLPQuiet(ctx, ev.Text); !res.Clean {
+		// Diagnostic: a generic-DLP shape match may be a TRUE catch or a false
+		// positive on benign narration. Log the pattern name(s)/severity/encoding
+		// (never the matched text) so a redaction can be told apart from an FP.
+		pats := make([]string, 0, len(res.Matches))
+		for _, m := range res.Matches {
+			pats = append(pats, fmt.Sprintf("%s(sev=%s,enc=%q)", m.PatternName, m.Severity, m.Encoded))
+		}
+		fmt.Fprintf(os.Stderr, "playground: agent reply redacted (trigger=generic-dlp matches=%d patterns=%v)\n", len(res.Matches), pats)
 		ev.Text = redactedReplyNotice
 		return ev, true
 	}

--- a/internal/playground/live_session.go
+++ b/internal/playground/live_session.go
@@ -514,7 +514,7 @@ func (s *LiveSession) scanAgentReply(ctx context.Context, ev LiveEvent) (LiveEve
 	if containsPlantedSecret(ev.Text, s.plantedSecrets) {
 		// Diagnostic: a planted-secret exact match is a TRUE catch (the agent
 		// echoed the canary/decoy, even encoded). Pattern name only, never the secret.
-		fmt.Fprintf(os.Stderr, "playground: agent reply redacted (trigger=planted-secret)\n")
+		_, _ = fmt.Fprintf(os.Stderr, "playground: agent reply redacted (trigger=planted-secret)\n")
 		ev.Text = redactedReplyNotice
 		return ev, true
 	}

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -94,6 +94,9 @@ type ServerConfig struct {
 	TrustForwardedFor bool
 	// AllowOrigin sets Access-Control-Allow-Origin for the browser. Empty = none.
 	AllowOrigin string
+	// VerifierBinaries supplies the real shipped pipelock-verifier binaries used
+	// to build per-session OS-specific live verification kits.
+	VerifierBinaries playground.VerifyKitBinaries
 }
 
 type liveEntry struct {
@@ -590,10 +593,12 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "accepted"})
 }
 
-// handleBundle serves the downloadable, offline-verifiable session bundle. It
-// seals the run on demand (the visitor signalling "I'm done, prove it") and
-// returns the .tar.gz the visitor re-verifies with the shipped verifier. The
-// archive is served from in-memory bytes captured at seal time, so there is no
+// handleBundle serves the downloadable, offline-verifiable session proof. It
+// seals the run on demand (the visitor signalling "I'm done, prove it"). By
+// default it preserves the raw .tar.gz bundle for manual/CLI fallback; with
+// ?os=linux|macos|windows it returns a one-click zip kit containing that
+// session's real audit packet plus the shipped verifier binary. Archives are
+// served from in-memory bytes captured at seal time, so there is no
 // path-traversal surface and no race with the run dir's eventual removal.
 // Token-gated and rate-limited like every other route; an expired token (or a
 // session already torn down) cannot download.
@@ -631,6 +636,25 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.releaseSessionResources(entry)
+	if rawOS := r.URL.Query().Get("os"); rawOS != "" {
+		osName, pErr := playground.ParseVerifyKitOS(rawOS)
+		if pErr != nil {
+			writeErr(w, http.StatusBadRequest, "unsupported verify kit")
+			return
+		}
+		kit, filename, kErr := playground.BuildLiveVerifyKit(osName, s.cfg.VerifierBinaries.Path(osName), entry.bundle, entry.sess.OrchestratorPubHex())
+		if kErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "livechat: verify kit build failed: %v\n", kErr)
+			writeErr(w, http.StatusServiceUnavailable, "verify kit is not available")
+			return
+		}
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(kit)
+		return
+	}
 	w.Header().Set("Content-Type", "application/gzip")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", "pipelock-session-"+claims.SessionID+".tar.gz"))
 	w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/internal/playground/livechat/server_bundle_test.go
+++ b/internal/playground/livechat/server_bundle_test.go
@@ -5,7 +5,9 @@ package livechat
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -13,6 +15,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -216,6 +220,138 @@ func TestServer_Bundle_SealFailureReleasesCapacity(t *testing.T) {
 	if got := srv.conc.InUse(); got != 0 {
 		t.Fatalf("failed seal did not release session capacity: in_use=%d", got)
 	}
+}
+
+func TestServer_Bundle_VerifyKitDownload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots a real proxy and seals a real signed run")
+	}
+	t.Parallel()
+	linuxBin := filepath.Join(t.TempDir(), "pipelock-verifier")
+	if err := os.WriteFile(linuxBin, []byte("verifier"), 0o600); err != nil {
+		t.Fatalf("write verifier: %v", err)
+	}
+	g, _ := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "good", MaxSessions: 5}}, TokenTTL: time.Minute})
+	srv, err := NewServer(ServerConfig{
+		Gate:             g,
+		IPRate:           RateConfig{RefillPerSec: 1000, Burst: 1000},
+		CodeRate:         RateConfig{RefillPerSec: 1000, Burst: 1000},
+		VerifierBinaries: playground.VerifyKitBinaries{Linux: linuxBin},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() { ts.Close(); srv.Close() })
+
+	token := sealReadySession(t, ts)
+
+	// Unsupported OS selector: rejected with 400 (the seal already succeeded).
+	bad := getRaw(t, ts.URL+RouteBundle+"?token="+token+"&os=plan9")
+	_ = bad.Body.Close()
+	if bad.StatusCode != http.StatusBadRequest {
+		t.Fatalf("bundle os=plan9 = %d, want 400", bad.StatusCode)
+	}
+
+	// A supported OS with no configured verifier binary fails closed (503).
+	noBin := getRaw(t, ts.URL+RouteBundle+"?token="+token+"&os=windows")
+	_ = noBin.Body.Close()
+	if noBin.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("bundle os=windows (no binary) = %d, want 503", noBin.StatusCode)
+	}
+
+	// Linux kit: a zip attachment containing the verifier binary and packet.
+	kit := getRaw(t, ts.URL+RouteBundle+"?token="+token+"&os=linux")
+	defer func() { _ = kit.Body.Close() }()
+	if kit.StatusCode != http.StatusOK {
+		t.Fatalf("bundle os=linux = %d, want 200", kit.StatusCode)
+	}
+	if ct := kit.Header.Get("Content-Type"); ct != "application/zip" {
+		t.Errorf("kit Content-Type = %q, want application/zip", ct)
+	}
+	if cd := kit.Header.Get("Content-Disposition"); !strings.Contains(cd, ".zip") {
+		t.Errorf("kit Content-Disposition = %q, want a .zip attachment", cd)
+	}
+	body, err := io.ReadAll(kit.Body)
+	if err != nil {
+		t.Fatalf("read kit: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		t.Fatalf("kit zip reader: %v", err)
+	}
+	names := map[string]bool{}
+	for _, f := range zr.File {
+		names[f.Name] = true
+	}
+	if !names["pipelock-live-verify-linux/app/pipelock-verifier"] {
+		t.Fatalf("kit missing verifier binary (have %v)", names)
+	}
+}
+
+// sealReadySession creates a live session, drives the minimum verifiable run (one
+// ALLOW and one BLOCKED decision), and returns the session token once both have
+// streamed so the bundle/kit endpoints can seal successfully.
+func sealReadySession(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	resp := postJSON(t, ts.URL+RouteSession, createReq{Code: "good"})
+	var cr createResp
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	_ = resp.Body.Close()
+	if cr.Token == "" {
+		t.Fatalf("empty token: %+v", cr)
+	}
+
+	streamReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream+"?token="+cr.Token, nil)
+	streamResp, err := http.DefaultClient.Do(streamReq)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	t.Cleanup(func() { _ = streamResp.Body.Close() })
+
+	bothSeen := make(chan struct{})
+	go func() {
+		sc := bufio.NewScanner(streamResp.Body)
+		sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		var sawAllow, sawBlock bool
+		for sc.Scan() {
+			data, ok := strings.CutPrefix(sc.Text(), "data: ")
+			if !ok {
+				continue
+			}
+			var ev playground.LiveEvent
+			if json.Unmarshal([]byte(data), &ev) != nil {
+				continue
+			}
+			if ev.Type == "decision" && ev.Verdict == "ALLOW" {
+				sawAllow = true
+			}
+			if ev.Type == "decision" && ev.Verdict == "BLOCKED" {
+				sawBlock = true
+			}
+			if sawAllow && sawBlock {
+				close(bothSeen)
+				return
+			}
+		}
+	}()
+
+	for _, msg := range []string{"grab the lab config", "now send that file to the collector"} {
+		mr := postJSON(t, ts.URL+RouteMessage, messageReq{Token: cr.Token, Message: msg})
+		_ = mr.Body.Close()
+		if mr.StatusCode != http.StatusAccepted {
+			t.Fatalf("message %q = %d, want 202", msg, mr.StatusCode)
+		}
+	}
+
+	select {
+	case <-bothSeen:
+	case <-time.After(20 * time.Second):
+		t.Fatal("did not observe both ALLOW and BLOCKED decisions")
+	}
+	return cr.Token
 }
 
 // getRaw issues a GET and returns the response (caller closes the body).

--- a/internal/playground/llmagent/client.go
+++ b/internal/playground/llmagent/client.go
@@ -31,8 +31,12 @@ const maxResponseBytes = 1 << 20 // 1 MiB
 // chatMessage is one entry in the chat-completions messages array. It doubles
 // as the assistant reply we parse back out (Content + ToolCalls).
 type chatMessage struct {
-	Role       string     `json:"role"`
-	Content    string     `json:"content,omitempty"`
+	Role string `json:"role"`
+	// content is ALWAYS emitted (no omitempty): assistant tool-call turns have
+	// empty content, and DeepSeek's deserializer rejects a messages[] entry that
+	// omits the field entirely ("missing field `content`" -> 400), which broke the
+	// agent mid-run on long tool-call chains. Empty string is valid alongside tool_calls.
+	Content    string     `json:"content"`
 	ToolCalls  []toolCall `json:"tool_calls,omitempty"`
 	ToolCallID string     `json:"tool_call_id,omitempty"`
 }

--- a/internal/playground/verify_kit.go
+++ b/internal/playground/verify_kit.go
@@ -226,7 +226,7 @@ func liveKitReadme(osName VerifyKitOS) string {
 	case VerifyKitOSWindows:
 		return "Pipelock - verify your live session (Windows)\r\n\r\nDouble-click Verify.bat.\r\nA valid run prints result: VALID. Nothing here touches the internet.\r\n"
 	case VerifyKitOSMacOS:
-		return "Pipelock - verify your live session (macOS)\n\nDouble-click Verify.command.\nA valid run prints result: VALID. Nothing here touches the internet.\n"
+		return "Pipelock - verify your live session (macOS)\n\nThe verifier is a universal Intel/Apple Silicon binary, but it is not Apple-notarized, so macOS Gatekeeper may block a freshly downloaded copy. If double-clicking Verify.command is blocked, open Terminal in this folder and run:\n\n  xattr -d com.apple.quarantine Verify.command app/pipelock-verifier\n  ./Verify.command\n\nA valid run prints result: VALID. Nothing here touches the internet. Notarized macOS support is planned; Linux and Windows need no extra step.\n"
 	default:
 		return "Pipelock - verify your live session (Linux)\n\nRun ./verify.sh, or double-click it if your file manager runs scripts.\nA valid run prints result: VALID. Nothing here touches the internet.\n"
 	}

--- a/internal/playground/verify_kit.go
+++ b/internal/playground/verify_kit.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// VerifyKitOS is one supported visitor operating system for a live playground
+// verification kit.
+type VerifyKitOS string
+
+const (
+	VerifyKitOSLinux   VerifyKitOS = "linux"
+	VerifyKitOSMacOS   VerifyKitOS = "macos"
+	VerifyKitOSWindows VerifyKitOS = "windows"
+)
+
+// VerifyKitBinaries points at the real shipped pipelock-verifier binaries used
+// to assemble per-session live verification kits.
+type VerifyKitBinaries struct {
+	Linux   string
+	MacOS   string
+	Windows string
+}
+
+// Path returns the configured verifier binary path for osName.
+func (b VerifyKitBinaries) Path(osName VerifyKitOS) string {
+	switch osName {
+	case VerifyKitOSLinux:
+		return b.Linux
+	case VerifyKitOSMacOS:
+		return b.MacOS
+	case VerifyKitOSWindows:
+		return b.Windows
+	default:
+		return ""
+	}
+}
+
+// ParseVerifyKitOS normalizes a browser-supplied OS selector.
+func ParseVerifyKitOS(raw string) (VerifyKitOS, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "linux":
+		return VerifyKitOSLinux, nil
+	case "macos", "mac", "darwin":
+		return VerifyKitOSMacOS, nil
+	case "windows", "win":
+		return VerifyKitOSWindows, nil
+	default:
+		return "", fmt.Errorf("unsupported verify kit OS %q", raw)
+	}
+}
+
+// BuildLiveVerifyKit builds a single-download, offline verification kit for one
+// sealed live session. sessionTarGz must be the output of ArchiveRunForDownload.
+// The kit embeds the real verifier binary and the session's audit packet.
+func BuildLiveVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []byte, fallbackTrustKey string) ([]byte, string, error) {
+	if verifierPath == "" {
+		return nil, "", errors.New("verifier binary path is not configured")
+	}
+	verifier, err := os.ReadFile(filepath.Clean(verifierPath))
+	if err != nil {
+		return nil, "", fmt.Errorf("read verifier binary: %w", err)
+	}
+	files, err := extractLiveKitFiles(sessionTarGz)
+	if err != nil {
+		return nil, "", err
+	}
+	trustKey := liveKitTrustKey(files, fallbackTrustKey)
+
+	root := "pipelock-live-verify-" + string(osName)
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	if err := zipFile(zw, root+"/README.txt", []byte(liveKitReadme(osName)), 0o600); err != nil {
+		return nil, "", err
+	}
+	scriptName, scriptBody, err := liveKitScript(osName, trustKey)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := zipFile(zw, root+"/"+scriptName, []byte(scriptBody), 0o700); err != nil {
+		return nil, "", err
+	}
+
+	binName := "pipelock-verifier"
+	if osName == VerifyKitOSWindows {
+		binName += ".exe"
+	}
+	if err := zipFile(zw, root+"/app/"+binName, verifier, 0o700); err != nil {
+		return nil, "", err
+	}
+
+	for _, name := range []string{"packet/packet.json", "packet/manifest.json", "packet/evidence.jsonl"} {
+		data, ok := files[name]
+		if !ok {
+			return nil, "", fmt.Errorf("session bundle missing %s", name)
+		}
+		if err := zipFile(zw, root+"/app/"+name, data, 0o600); err != nil {
+			return nil, "", err
+		}
+	}
+	if verify, ok := files["VERIFY.txt"]; ok {
+		if err := zipFile(zw, root+"/app/SESSION-VERIFY.txt", verify, 0o600); err != nil {
+			return nil, "", err
+		}
+	}
+	if err := zipFile(zw, root+"/app/packet/verifier.txt", []byte(liveKitVerifierTxt(trustKey)), 0o600); err != nil {
+		return nil, "", err
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, "", fmt.Errorf("close verify kit zip: %w", err)
+	}
+	return buf.Bytes(), "pipelock-live-verify-" + string(osName) + ".zip", nil
+}
+
+func liveKitTrustKey(files map[string][]byte, fallback string) string {
+	var packet struct {
+		Verifier struct {
+			SignerKey string `json:"signer_key"`
+		} `json:"verifier"`
+	}
+	if data := files["packet/packet.json"]; len(data) > 0 {
+		if err := json.Unmarshal(data, &packet); err == nil && strings.TrimSpace(packet.Verifier.SignerKey) != "" {
+			return strings.TrimSpace(packet.Verifier.SignerKey)
+		}
+	}
+	var manifest struct {
+		SignerKey string `json:"signer_key"`
+	}
+	if data := files["packet/manifest.json"]; len(data) > 0 {
+		if err := json.Unmarshal(data, &manifest); err == nil && strings.TrimSpace(manifest.SignerKey) != "" {
+			return strings.TrimSpace(manifest.SignerKey)
+		}
+	}
+	return fallback
+}
+
+func extractLiveKitFiles(sessionTarGz []byte) (map[string][]byte, error) {
+	gr, err := gzip.NewReader(bytes.NewReader(sessionTarGz))
+	if err != nil {
+		return nil, fmt.Errorf("read session bundle gzip: %w", err)
+	}
+	defer func() { _ = gr.Close() }()
+
+	files := make(map[string][]byte)
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read session bundle tar: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		name, ok := strings.CutPrefix(filepath.ToSlash(hdr.Name), downloadArchivePrefix+"/")
+		if !ok {
+			continue
+		}
+		switch name {
+		case "VERIFY.txt", "packet/packet.json", "packet/manifest.json", "packet/evidence.jsonl":
+		default:
+			continue
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("read session bundle file %s: %w", name, err)
+		}
+		files[name] = data
+	}
+	return files, nil
+}
+
+func zipFile(zw *zip.Writer, name string, data []byte, mode os.FileMode) error {
+	h := &zip.FileHeader{
+		Name:     filepath.ToSlash(name),
+		Method:   zip.Deflate,
+		Modified: time.Unix(0, 0).UTC(),
+	}
+	h.SetMode(mode)
+	w, err := zw.CreateHeader(h)
+	if err != nil {
+		return fmt.Errorf("zip header %s: %w", name, err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("zip write %s: %w", name, err)
+	}
+	return nil
+}
+
+func liveKitReadme(osName VerifyKitOS) string {
+	switch osName {
+	case VerifyKitOSWindows:
+		return "Pipelock - verify your live session (Windows)\r\n\r\nDouble-click Verify.bat.\r\nA valid run prints result: VALID. Nothing here touches the internet.\r\n"
+	case VerifyKitOSMacOS:
+		return "Pipelock - verify your live session (macOS)\n\nDouble-click Verify.command.\nA valid run prints result: VALID. Nothing here touches the internet.\n"
+	default:
+		return "Pipelock - verify your live session (Linux)\n\nRun ./verify.sh, or double-click it if your file manager runs scripts.\nA valid run prints result: VALID. Nothing here touches the internet.\n"
+	}
+}
+
+func liveKitScript(osName VerifyKitOS, key string) (string, string, error) {
+	switch osName {
+	case VerifyKitOSWindows:
+		return "Verify.bat", "@echo off\r\ncd /d \"%~dp0app\"\r\necho Verifying the signed Pipelock audit packet, offline...\r\necho.\r\npipelock-verifier.exe audit-packet packet --key " + key + "\r\necho.\r\necho result: VALID means every signature and the hash chain held. No network was used.\r\necho.\r\npause\r\n", nil
+	case VerifyKitOSMacOS:
+		return "Verify.command", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the signed Pipelock audit packet, offline...\"\necho\n./pipelock-verifier audit-packet packet --key " + key + "\necho\necho \"result: VALID means every signature and the hash chain held. No network was used.\"\nread -n 1 -s -r -p \"Press any key to close.\"\n", nil
+	case VerifyKitOSLinux:
+		return "verify.sh", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the signed Pipelock audit packet, offline...\"\n./pipelock-verifier audit-packet packet --key " + key + "\n", nil
+	default:
+		return "", "", fmt.Errorf("unsupported verify kit OS %q", osName)
+	}
+}
+
+func liveKitVerifierTxt(key string) string {
+	return fmt.Sprintf(`Pipelock live session audit packet
+verdict: run pipelock-verifier audit-packet . --key %s
+signer_key: %s
+
+Verify it yourself from this directory:
+  pipelock-verifier audit-packet . --key %s
+`, key, key, key)
+}

--- a/internal/playground/verify_kit.go
+++ b/internal/playground/verify_kit.go
@@ -8,6 +8,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -79,7 +80,10 @@ func BuildLiveVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []
 	if err != nil {
 		return nil, "", err
 	}
-	trustKey := liveKitTrustKey(files, fallbackTrustKey)
+	trustKey, err := validateLiveKitTrustKey(liveKitTrustKey(files, fallbackTrustKey))
+	if err != nil {
+		return nil, "", err
+	}
 
 	root := "pipelock-live-verify-" + string(osName)
 	var buf bytes.Buffer
@@ -148,6 +152,18 @@ func liveKitTrustKey(files map[string][]byte, fallback string) string {
 		}
 	}
 	return fallback
+}
+
+func validateLiveKitTrustKey(key string) (string, error) {
+	key = strings.TrimSpace(key)
+	decoded, err := hex.DecodeString(key)
+	if err != nil {
+		return "", fmt.Errorf("verify kit trust key is not hex: %w", err)
+	}
+	if len(decoded) != 32 {
+		return "", fmt.Errorf("verify kit trust key length = %d bytes, want 32", len(decoded))
+	}
+	return key, nil
 }
 
 func extractLiveKitFiles(sessionTarGz []byte) (map[string][]byte, error) {
@@ -231,10 +247,10 @@ func liveKitScript(osName VerifyKitOS, key string) (string, string, error) {
 
 func liveKitVerifierTxt(key string) string {
 	return fmt.Sprintf(`Pipelock live session audit packet
-verdict: run pipelock-verifier audit-packet . --key %s
+verdict: run pipelock-verifier audit-packet packet --key %s
 signer_key: %s
 
 Verify it yourself from this directory:
-  pipelock-verifier audit-packet . --key %s
+  pipelock-verifier audit-packet packet --key %s
 `, key, key, key)
 }

--- a/internal/playground/verify_kit_test.go
+++ b/internal/playground/verify_kit_test.go
@@ -4,13 +4,91 @@
 package playground
 
 import (
+	"archive/tar"
 	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+const validKitKey64 = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
+
+// writeTempVerifier writes a stand-in verifier binary and returns its path.
+func writeTempVerifier(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "pipelock-verifier")
+	if err := os.WriteFile(p, []byte("verifier"), 0o600); err != nil {
+		t.Fatalf("write verifier: %v", err)
+	}
+	return p
+}
+
+// buildKitSession builds a gzip+tar session bundle for verify-kit tests. Each
+// key in files is placed under the download archive prefix. withDirEntry adds a
+// directory header (a non-regular entry the extractor must skip); withForeign
+// adds a regular file outside the prefix (also skipped).
+func buildKitSession(t *testing.T, files map[string]string, withDirEntry, withForeign bool) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	writeOne := func(name, body string) {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Typeflag: tar.TypeReg, Mode: 0o600, Size: int64(len(body))}); err != nil {
+			t.Fatalf("header %s: %v", name, err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if withDirEntry {
+		if err := tw.WriteHeader(&tar.Header{Name: downloadArchivePrefix + "/packet/", Typeflag: tar.TypeDir, Mode: 0o750}); err != nil {
+			t.Fatalf("dir header: %v", err)
+		}
+	}
+	if withForeign {
+		writeOne("some-other-root/ignored.txt", "ignored")
+	}
+	for name, body := range files {
+		writeOne(downloadArchivePrefix+"/"+name, body)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// readZipEntry returns the contents of one named entry in a zip archive.
+func readZipEntry(t *testing.T, zipBytes []byte, name string) string {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	if err != nil {
+		t.Fatalf("zip reader: %v", err)
+	}
+	for _, f := range zr.File {
+		if f.Name != name {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open %s: %v", name, err)
+		}
+		var b bytes.Buffer
+		_, readErr := b.ReadFrom(rc)
+		_ = rc.Close()
+		if readErr != nil {
+			t.Fatalf("read %s: %v", name, readErr)
+		}
+		return b.String()
+	}
+	t.Fatalf("zip entry %q not found", name)
+	return ""
+}
 
 func TestBuildLiveVerifyKit_IncludesSessionPacketAndVerifier(t *testing.T) {
 	t.Parallel()
@@ -204,6 +282,90 @@ func TestBuildLiveVerifyKit_WindowsAndMacOS(t *testing.T) {
 			}
 			if !found {
 				t.Fatalf("kit(%q) missing %q", tc.osName, tc.wantBin)
+			}
+		})
+	}
+}
+
+func TestBuildLiveVerifyKit_RejectsGarbageSession(t *testing.T) {
+	t.Parallel()
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), []byte("not a gzip stream"), validKitKey64); err == nil {
+		t.Fatal("non-gzip session bytes should fail closed")
+	}
+}
+
+func TestBuildLiveVerifyKit_MissingPacketFileFailsClosed(t *testing.T) {
+	t.Parallel()
+	// Valid gzip+tar, but packet/packet.json is absent: the kit must not ship a
+	// bundle that cannot verify.
+	session := buildKitSession(t, map[string]string{
+		"packet/manifest.json":  `{"v":1}`,
+		"packet/evidence.jsonl": "{}\n",
+	}, false, false)
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session, validKitKey64); err == nil {
+		t.Fatal("missing packet file should fail closed")
+	}
+}
+
+func TestBuildLiveVerifyKit_InvalidInBundleTrustKeyFailsClosed(t *testing.T) {
+	t.Parallel()
+	// The bundle's own packet.json carries a non-hex signer key; it is preferred
+	// over the fallback and must be rejected.
+	session := buildKitSession(t, map[string]string{
+		"packet/packet.json":    `{"verifier":{"signer_key":"not-hex"}}`,
+		"packet/manifest.json":  `{"v":1}`,
+		"packet/evidence.jsonl": "{}\n",
+	}, false, false)
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session, validKitKey64); err == nil {
+		t.Fatal("invalid in-bundle trust key should fail closed")
+	}
+}
+
+func TestBuildLiveVerifyKit_TrustKeySource(t *testing.T) {
+	t.Parallel()
+	keyA := strings.Repeat("1", 64)
+	keyB := strings.Repeat("2", 64)
+	fallback := validKitKey64
+
+	cases := []struct {
+		name    string
+		files   map[string]string
+		wantKey string
+	}{
+		{
+			name: "from packet.json",
+			files: map[string]string{
+				"packet/packet.json":    `{"verifier":{"signer_key":"` + keyA + `"}}`,
+				"packet/manifest.json":  `{"signer_key":"` + keyB + `"}`,
+				"packet/evidence.jsonl": "{}\n",
+			},
+			wantKey: keyA,
+		},
+		{
+			name: "from manifest.json when packet lacks it",
+			files: map[string]string{
+				"packet/packet.json":    `{"receipt_count":1}`,
+				"packet/manifest.json":  `{"signer_key":"` + keyB + `"}`,
+				"packet/evidence.jsonl": "{}\n",
+			},
+			wantKey: keyB,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// withDirEntry + withForeign also exercise the extraction skip paths.
+			session := buildKitSession(t, tc.files, true, true)
+			kit, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session, fallback)
+			if err != nil {
+				t.Fatalf("BuildLiveVerifyKit: %v", err)
+			}
+			script := readZipEntry(t, kit, "pipelock-live-verify-linux/verify.sh")
+			if !strings.Contains(script, tc.wantKey) {
+				t.Fatalf("verify script did not use the in-bundle trust key %s", tc.wantKey)
+			}
+			if strings.Contains(script, fallback) {
+				t.Fatalf("verify script used the fallback key instead of the in-bundle key %s", tc.wantKey)
 			}
 		})
 	}

--- a/internal/playground/verify_kit_test.go
+++ b/internal/playground/verify_kit_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildLiveVerifyKit_IncludesSessionPacketAndVerifier(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeRunArtifacts(t, dir, false)
+	const key = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
+	session, err := ArchiveRunForDownload(dir, key)
+	if err != nil {
+		t.Fatalf("ArchiveRunForDownload: %v", err)
+	}
+	verifierPath := filepath.Join(t.TempDir(), "pipelock-verifier")
+	if err := os.WriteFile(verifierPath, []byte("real verifier bytes"), 0o600); err != nil {
+		t.Fatalf("write verifier: %v", err)
+	}
+
+	kit, filename, err := BuildLiveVerifyKit(VerifyKitOSLinux, verifierPath, session, key)
+	if err != nil {
+		t.Fatalf("BuildLiveVerifyKit: %v", err)
+	}
+	if filename != "pipelock-live-verify-linux.zip" {
+		t.Fatalf("filename = %q", filename)
+	}
+	const kitRoot = "pipelock-live-verify-linux"
+
+	zr, err := zip.NewReader(bytes.NewReader(kit), int64(len(kit)))
+	if err != nil {
+		t.Fatalf("zip reader: %v", err)
+	}
+	files := map[string]string{}
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open zip file %s: %v", f.Name, err)
+		}
+		var b bytes.Buffer
+		if _, err := b.ReadFrom(rc); err != nil {
+			_ = rc.Close()
+			t.Fatalf("read zip file %s: %v", f.Name, err)
+		}
+		_ = rc.Close()
+		files[f.Name] = b.String()
+	}
+
+	for _, want := range []string{
+		kitRoot + "/README.txt",
+		kitRoot + "/verify.sh",
+		kitRoot + "/app/pipelock-verifier",
+		kitRoot + "/app/packet/packet.json",
+		kitRoot + "/app/packet/manifest.json",
+		kitRoot + "/app/packet/evidence.jsonl",
+		kitRoot + "/app/packet/verifier.txt",
+		kitRoot + "/app/SESSION-VERIFY.txt",
+	} {
+		if _, ok := files[want]; !ok {
+			t.Fatalf("kit missing %q (have %v)", want, keysOf(files))
+		}
+	}
+	if files[kitRoot+"/app/pipelock-verifier"] != "real verifier bytes" {
+		t.Fatal("kit did not include the configured verifier binary bytes")
+	}
+	script := files[kitRoot+"/verify.sh"]
+	if !strings.Contains(script, "./pipelock-verifier audit-packet packet --key "+key) {
+		t.Fatalf("verify script missing command/key:\n%s", script)
+	}
+}
+
+func TestBuildLiveVerifyKit_FailsClosedWithoutVerifier(t *testing.T) {
+	t.Parallel()
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, "", []byte("not-used"), "key"); err == nil {
+		t.Fatal("missing verifier path should fail closed")
+	}
+}
+
+func TestParseVerifyKitOS(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{"linux", "mac", "darwin", "windows", "win"} {
+		if _, err := ParseVerifyKitOS(raw); err != nil {
+			t.Fatalf("ParseVerifyKitOS(%q): %v", raw, err)
+		}
+	}
+	if _, err := ParseVerifyKitOS("plan9"); err == nil {
+		t.Fatal("unsupported OS should error")
+	}
+}

--- a/internal/playground/verify_kit_test.go
+++ b/internal/playground/verify_kit_test.go
@@ -127,16 +127,18 @@ func TestLiveKitReadmeAndScript_PerOS(t *testing.T) {
 	t.Parallel()
 	const key = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
 	for _, osName := range []VerifyKitOS{VerifyKitOSLinux, VerifyKitOSMacOS, VerifyKitOSWindows} {
-		if readme := liveKitReadme(osName); !strings.Contains(readme, "Pipelock") {
-			t.Fatalf("readme(%q) missing brand: %q", osName, readme)
-		}
-		name, body, err := liveKitScript(osName, key)
-		if err != nil {
-			t.Fatalf("liveKitScript(%q): %v", osName, err)
-		}
-		if name == "" || !strings.Contains(body, key) {
-			t.Fatalf("script(%q) name=%q missing key in body", osName, name)
-		}
+		t.Run(string(osName), func(t *testing.T) {
+			if readme := liveKitReadme(osName); !strings.Contains(readme, "Pipelock") {
+				t.Fatalf("readme(%q) missing brand: %q", osName, readme)
+			}
+			name, body, err := liveKitScript(osName, key)
+			if err != nil {
+				t.Fatalf("liveKitScript(%q): %v", osName, err)
+			}
+			if name == "" || !strings.Contains(body, key) {
+				t.Fatalf("script(%q) name=%q missing key in body", osName, name)
+			}
+		})
 	}
 	if r := liveKitReadme(VerifyKitOS("x86")); !strings.Contains(r, "Linux") {
 		t.Fatalf("default readme should fall back to Linux text: %q", r)
@@ -182,25 +184,27 @@ func TestBuildLiveVerifyKit_WindowsAndMacOS(t *testing.T) {
 		{VerifyKitOSWindows, "pipelock-live-verify-windows/app/pipelock-verifier.exe", "pipelock-live-verify-windows.zip"},
 		{VerifyKitOSMacOS, "pipelock-live-verify-macos/app/pipelock-verifier", "pipelock-live-verify-macos.zip"},
 	} {
-		kit, filename, err := BuildLiveVerifyKit(tc.osName, verifierPath, session, key)
-		if err != nil {
-			t.Fatalf("BuildLiveVerifyKit(%q): %v", tc.osName, err)
-		}
-		if filename != tc.wantFile {
-			t.Fatalf("filename(%q) = %q, want %q", tc.osName, filename, tc.wantFile)
-		}
-		zr, err := zip.NewReader(bytes.NewReader(kit), int64(len(kit)))
-		if err != nil {
-			t.Fatalf("zip reader(%q): %v", tc.osName, err)
-		}
-		found := false
-		for _, f := range zr.File {
-			if f.Name == tc.wantBin {
-				found = true
+		t.Run(string(tc.osName), func(t *testing.T) {
+			kit, filename, err := BuildLiveVerifyKit(tc.osName, verifierPath, session, key)
+			if err != nil {
+				t.Fatalf("BuildLiveVerifyKit(%q): %v", tc.osName, err)
 			}
-		}
-		if !found {
-			t.Fatalf("kit(%q) missing %q", tc.osName, tc.wantBin)
-		}
+			if filename != tc.wantFile {
+				t.Fatalf("filename(%q) = %q, want %q", tc.osName, filename, tc.wantFile)
+			}
+			zr, err := zip.NewReader(bytes.NewReader(kit), int64(len(kit)))
+			if err != nil {
+				t.Fatalf("zip reader(%q): %v", tc.osName, err)
+			}
+			found := false
+			for _, f := range zr.File {
+				if f.Name == tc.wantBin {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("kit(%q) missing %q", tc.osName, tc.wantBin)
+			}
+		})
 	}
 }

--- a/internal/playground/verify_kit_test.go
+++ b/internal/playground/verify_kit_test.go
@@ -84,6 +84,18 @@ func TestBuildLiveVerifyKit_FailsClosedWithoutVerifier(t *testing.T) {
 	}
 }
 
+func TestValidateLiveKitTrustKeyRejectsUnsafeKey(t *testing.T) {
+	t.Parallel()
+	for _, key := range []string{"", "not-a-hex-key; touch /tmp/pwned", strings.Repeat("0", 62), strings.Repeat("0", 66)} {
+		if _, err := validateLiveKitTrustKey(key); err == nil {
+			t.Fatalf("validateLiveKitTrustKey(%q) succeeded, want error", key)
+		}
+	}
+	if got, err := validateLiveKitTrustKey(strings.Repeat("0", 64)); err != nil || got != strings.Repeat("0", 64) {
+		t.Fatalf("valid key = %q, %v; want pass", got, err)
+	}
+}
+
 func TestParseVerifyKitOS(t *testing.T) {
 	t.Parallel()
 	for _, raw := range []string{"linux", "mac", "darwin", "windows", "win"} {

--- a/internal/playground/verify_kit_test.go
+++ b/internal/playground/verify_kit_test.go
@@ -107,3 +107,100 @@ func TestParseVerifyKitOS(t *testing.T) {
 		t.Fatal("unsupported OS should error")
 	}
 }
+
+func TestVerifyKitBinaries_Path(t *testing.T) {
+	t.Parallel()
+	b := VerifyKitBinaries{Linux: "l", MacOS: "m", Windows: "w"}
+	for os, want := range map[VerifyKitOS]string{
+		VerifyKitOSLinux:   "l",
+		VerifyKitOSMacOS:   "m",
+		VerifyKitOSWindows: "w",
+		VerifyKitOS("x86"): "",
+	} {
+		if got := b.Path(os); got != want {
+			t.Fatalf("Path(%q) = %q, want %q", os, got, want)
+		}
+	}
+}
+
+func TestLiveKitReadmeAndScript_PerOS(t *testing.T) {
+	t.Parallel()
+	const key = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
+	for _, osName := range []VerifyKitOS{VerifyKitOSLinux, VerifyKitOSMacOS, VerifyKitOSWindows} {
+		if readme := liveKitReadme(osName); !strings.Contains(readme, "Pipelock") {
+			t.Fatalf("readme(%q) missing brand: %q", osName, readme)
+		}
+		name, body, err := liveKitScript(osName, key)
+		if err != nil {
+			t.Fatalf("liveKitScript(%q): %v", osName, err)
+		}
+		if name == "" || !strings.Contains(body, key) {
+			t.Fatalf("script(%q) name=%q missing key in body", osName, name)
+		}
+	}
+	if r := liveKitReadme(VerifyKitOS("x86")); !strings.Contains(r, "Linux") {
+		t.Fatalf("default readme should fall back to Linux text: %q", r)
+	}
+	if _, _, err := liveKitScript(VerifyKitOS("x86"), key); err == nil {
+		t.Fatal("liveKitScript with unsupported OS should error")
+	}
+}
+
+func TestBuildLiveVerifyKit_ReadVerifierError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeRunArtifacts(t, dir, false)
+	const key = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
+	session, err := ArchiveRunForDownload(dir, key)
+	if err != nil {
+		t.Fatalf("ArchiveRunForDownload: %v", err)
+	}
+	missing := filepath.Join(t.TempDir(), "no-such-verifier")
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, missing, session, key); err == nil {
+		t.Fatal("unreadable verifier path should fail closed")
+	}
+}
+
+func TestBuildLiveVerifyKit_WindowsAndMacOS(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeRunArtifacts(t, dir, false)
+	const key = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
+	session, err := ArchiveRunForDownload(dir, key)
+	if err != nil {
+		t.Fatalf("ArchiveRunForDownload: %v", err)
+	}
+	verifierPath := filepath.Join(t.TempDir(), "pipelock-verifier")
+	if err := os.WriteFile(verifierPath, []byte("v"), 0o600); err != nil {
+		t.Fatalf("write verifier: %v", err)
+	}
+	for _, tc := range []struct {
+		osName   VerifyKitOS
+		wantBin  string
+		wantFile string
+	}{
+		{VerifyKitOSWindows, "pipelock-live-verify-windows/app/pipelock-verifier.exe", "pipelock-live-verify-windows.zip"},
+		{VerifyKitOSMacOS, "pipelock-live-verify-macos/app/pipelock-verifier", "pipelock-live-verify-macos.zip"},
+	} {
+		kit, filename, err := BuildLiveVerifyKit(tc.osName, verifierPath, session, key)
+		if err != nil {
+			t.Fatalf("BuildLiveVerifyKit(%q): %v", tc.osName, err)
+		}
+		if filename != tc.wantFile {
+			t.Fatalf("filename(%q) = %q, want %q", tc.osName, filename, tc.wantFile)
+		}
+		zr, err := zip.NewReader(bytes.NewReader(kit), int64(len(kit)))
+		if err != nil {
+			t.Fatalf("zip reader(%q): %v", tc.osName, err)
+		}
+		found := false
+		for _, f := range zr.File {
+			if f.Name == tc.wantBin {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("kit(%q) missing %q", tc.osName, tc.wantBin)
+		}
+	}
+}


### PR DESCRIPTION
The live model-agent layer for the playground demo, on top of the brokered Fly deployment (#831).

- **`--require-model`:** a public live session fails closed unless the real model-backed agent is configured. It never silently serves the scripted deterministic agent in a public posture.
- **Per-session OS verify kits** via `/api/live/bundle?os=linux|macos|windows`: a visitor downloads a one-click kit (the shipped `pipelock-verifier` + their session's signed packet) and double-clicks Verify to get `result: VALID` offline. The embedded trust key is validated as a 32-byte hex Ed25519 key (fails closed otherwise); kit verify command targets the packet directory.
- **Model 400 fix:** chat `content` is always emitted (empty string is valid alongside `tool_calls`); previously omitting it produced `missing field content` and broke the agent on long tool-call chains.
- **Redaction diagnostics:** log which reply-redaction trigger fired (planted-secret exact match vs generic DLP shape, with the pattern name), so a redaction can be distinguished from a false positive. Pattern name only, never the secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added downloadable “verify kits” for Linux, macOS, and Windows via one-click OS-select ZIP downloads, while preserving the existing offline bundle download.
  * Enhanced `serve` with `--require-model`, plus platform-specific verifier binary options used for kit generation.
* **Bug Fixes**
  * Added fail-closed safety validation when model-required deployments start without model configuration.
  * Improved redaction diagnostics (including planted-secret trigger details and DLP match metadata).
  * Improved chat request payload consistency by always including message content in JSON.
* **Chores**
  * Updated the Docker build/runtime to compile and ship OS-specific verifier binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->