### PR TITLE
chore: enable osvVulnerabilityAlerts for OSV-database CVE fast-tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
   "lockFileMaintenance": {
     "enabled": false
   },
+  "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "labels": ["security", "fast-track"],
     "minimumReleaseAge": "0 days",


### PR DESCRIPTION
Adds osvVulnerabilityAlerts so OSV-database vulnerabilities also bypass the weekly schedule and cooldown, matching the GitHub vulnerability-alert fast-track already configured. Surfaced by an adversarial review of the cross-repo Renovate standardization. One-line config change, no code impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled OSV-based vulnerability alerts in Renovate to improve security visibility for dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->