### PR TITLE
feat(playground): broker hardening for public exposure

### DIFF
--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -432,7 +432,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 	if strings.TrimSpace(f.staticDir) != "" {
 		mux := http.NewServeMux()
 		mux.Handle(livechat.RouteAPIPrefix, srv.Handler())
-		mux.Handle("/", http.FileServer(http.Dir(f.staticDir)))
+		mux.Handle("/", noCacheStatic(http.FileServer(http.Dir(f.staticDir))))
 		handler = mux
 		_, _ = fmt.Fprintf(out, "serving static UI from %s at /\n", f.staticDir)
 	}
@@ -906,6 +906,19 @@ func normalizePublicHost(raw string) (string, error) {
 // than the deadline) before the response is written. Those long-lived routes
 // are bounded instead by the session TTL and the upstream/edge connection
 // timeouts, not by this deadline.
+// noCacheStatic sets Cache-Control: no-cache on static viewer assets so the
+// browser revalidates them (via ETag/Last-Modified) on every load instead of
+// serving a stale copy from disk cache. The demo updates the viewer (HTML/JS/CSS)
+// in place behind the same paths, so without revalidation a redeploy leaves
+// visitors on a stale viewer — e.g. old example prompts after the assets change.
+// no-cache (revalidate), not no-store, keeps 304s cheap when nothing changed.
+func noCacheStatic(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-cache")
+		next.ServeHTTP(w, r)
+	})
+}
+
 func writeDeadlineMiddleware(next http.Handler, defaultTimeout time.Duration, overrides map[string]time.Duration) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rc := http.NewResponseController(w)

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -201,11 +201,17 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	srv, handler, err := buildServer(ctx, cmd.OutOrStdout(), f)
+	srv, handler, startReaper, err := buildServer(ctx, cmd.OutOrStdout(), f)
 	if err != nil {
 		return err
 	}
 	defer srv.Close()
+
+	// Start the orphan-VM reaper under a context that cancels when the serve
+	// function returns (server close / shutdown / signal).
+	reaperCtx, reaperCancel := context.WithCancel(ctx)
+	defer reaperCancel()
+	go startReaper(reaperCtx)
 
 	httpSrv := &http.Server{
 		Handler:           handler,
@@ -234,17 +240,17 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 	return nil
 }
 
-func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Server, http.Handler, error) {
+func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Server, http.Handler, func(context.Context), error) {
 	if err := validateFlags(f); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	secret, err := resolveGateSecret(f.gateSecretFile, f.gateSecretEnv)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	codes, err := resolveCodes(f.codes, f.maxPerCode)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	gate, err := livechat.NewGate(livechat.GateConfig{
 		Secret:   secret,
@@ -252,23 +258,23 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		TokenTTL: f.sessionTTL,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	token, err := resolveFlyToken(f)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	provider, err := newMachineProvider(ctx, f, token)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	sessionEnv, err := resolveSessionEnv(f)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	humanVerifier, err := resolveTurnstileVerifier(f)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	lm, err := broker.NewLeaseManager(broker.LeaseConfig{
 		Provider:     provider,
@@ -281,7 +287,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		BaseEnv:      buildVMBaseEnv(f),
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	srv, err := broker.NewServer(broker.ServerConfig{
 		Leases:             lm,
@@ -299,8 +305,18 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		AllowOrigin:        f.allowOrigin,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
+
+	reaper, err := broker.NewReaper(broker.ReaperConfig{
+		Provider:  provider,
+		ActiveIDs: lm.ActiveMachineIDs,
+		Log:       out,
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	_, _ = fmt.Fprintf(out, "broker configured: %d code(s), capacity %d, image %s\n", len(codes), f.concurrency, f.image)
 
 	// The broker API lives under /api/live/*. When a static UI directory is
@@ -317,12 +333,20 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		_, _ = fmt.Fprintf(out, "serving static UI from %s at /\n", f.staticDir)
 	}
 	// Stream writes indefinitely; the message route is held open for the whole
-	// model turn. Both are exempt from the write deadline (see the middleware).
-	handler = writeDeadlineMiddleware(handler, nonStreamWriteTimeout, livechat.RouteStream, livechat.RouteMessage)
+	// model turn; session-create synchronously boots and proves a fresh
+	// per-visitor microVM, which on a cold start (image pull + boot + containment
+	// proof) legitimately exceeds this deadline. All three are exempt from the
+	// write deadline (see the middleware) and bounded instead by their own
+	// budgets — the SSE/turn lifecycle for stream/message, and the broker's
+	// vmReadyTimeout (createVMSession's readyCtx) for session-create. A 30s write
+	// deadline on session-create made cold starts fail closed mid-response
+	// (Fly PU02 / client 502) even though the VM came up healthy within the 60s
+	// VM-ready budget.
+	handler = writeDeadlineMiddleware(handler, nonStreamWriteTimeout, livechat.RouteStream, livechat.RouteMessage, livechat.RouteSession)
 
 	hosts, err := brokerPublicHosts(f)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if len(hosts) > 0 {
 		handler = hostGuard(handler, hosts)
@@ -330,13 +354,13 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 	}
 	cfAccess, err := newCFAccessVerifier(f)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if cfAccess != nil {
 		handler = cfAccessGuard(handler, cfAccess)
 		_, _ = fmt.Fprintf(out, "broker Cloudflare Access JWT guard enabled for %s\n", cfAccess.issuer)
 	}
-	return srv, handler, nil
+	return srv, handler, reaper.Run, nil
 }
 
 func defaultMachineProvider(_ context.Context, f *serveFlags, flyToken string) (broker.MachineProvider, error) {

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -46,18 +46,20 @@ const (
 	defaultCodeRate       = 0.5
 	defaultCodeBurst      = 10
 	nonStreamWriteTimeout = 30 * time.Second
-	// sessionWriteTimeout bounds the session-create response write. It must
-	// exceed the WHOLE cold-path budget, not just one stage: on a warm-pool MISS
-	// the handler runs Lease() (CreateMachine + WaitReady, bounded by the Fly
-	// adapter's ~60s wait timeout, which includes image pull) AND THEN
-	// createVMSession (bounded by the broker's ~60s vmReadyTimeout) before it
-	// writes the response — worst case ~120s. Allow margin so a legitimate cold
-	// start never fails closed mid-response (the 30s default caused exactly that:
-	// Fly PU02 / client 502), while still CAPPING a slow/non-reading client so the
-	// goroutine cannot be pinned indefinitely (a full exemption would leave that
-	// hole open). The warm-pool common path is ~2-3s; this ceiling only bites on a
-	// cold miss.
-	sessionWriteTimeout      = 180 * time.Second
+	// sessionWriteTimeout bounds the session-create response write. It must exceed
+	// the WHOLE cold-path budget, summed across every stage, or a legitimate cold
+	// start fails closed mid-response (the 30s default did exactly that: Fly PU02
+	// / client 502). On a warm-pool MISS the handler runs, in sequence, three
+	// independently-bounded Fly/broker calls before it writes the response:
+	//   - CreateMachine  — Fly adapter HTTP client timeout ~65s (waitTimeout+5s)
+	//   - WaitReady      — Fly adapter HTTP client timeout ~65s (incl. image pull)
+	//   - createVMSession — broker vmReadyTimeout ~60s
+	// i.e. a code-level worst case of ~190s. The ceiling is set above that with
+	// margin so a cold miss completes, while still CAPPING a slow/non-reading
+	// client (a full exemption would leave that goroutine-pin hole open; the
+	// concurrency cap bounds how many such pins can exist). The warm-pool common
+	// path is ~2-3s; this ceiling only bites on a cold miss.
+	sessionWriteTimeout      = 300 * time.Second
 	cfAccessJWTHeader        = "Cf-Access-Jwt-Assertion"
 	cfAccessKeysTTL          = 5 * time.Minute
 	cfAccessNegativeCacheTTL = 30 * time.Second

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -198,8 +198,8 @@ func newServeCmd() *cobra.Command {
 	fl.StringVar(&f.turnstileSecretFile, "turnstile-secret-file", "", "path to the Cloudflare Turnstile secret; enables human verification for session creation")
 	fl.StringVar(&f.turnstileSecretEnv, "turnstile-secret-env", "", "environment variable holding the Cloudflare Turnstile secret; enables human verification for session creation")
 	fl.StringVar(&f.turnstileVerifyURL, "turnstile-verify-url", "", "Cloudflare Turnstile Siteverify URL override (tests/dev only; empty uses Cloudflare)")
-	fl.StringVar(&f.turnstileExpectedHostname, "turnstile-expected-hostname", "", "expected hostname in the Turnstile Siteverify response; public deploys SHOULD set this")
-	fl.StringVar(&f.turnstileExpectedAction, "turnstile-action", "", "expected action label in the Turnstile Siteverify response; public deploys SHOULD set this")
+	fl.StringVar(&f.turnstileExpectedHostname, "turnstile-expected-hostname", "", "expected hostname in the Turnstile Siteverify response; required when Turnstile runs against Cloudflare")
+	fl.StringVar(&f.turnstileExpectedAction, "turnstile-action", "", "expected action label in the Turnstile Siteverify response; required when Turnstile runs against Cloudflare")
 	fl.DurationVar(&f.turnstileMaxAge, "turnstile-max-age", broker.DefaultTurnstileMaxAge, "max age for a Turnstile challenge_ts before it is rejected (0 disables)")
 	fl.StringVar(&f.turnstileSitekey, "turnstile-sitekey", "", "public Cloudflare Turnstile site key; reported via /health so the viewer renders the widget (the secret is set separately via --turnstile-secret-*)")
 	fl.DurationVar(&f.sessionTTL, "session-ttl", defaultSessionTTL, "VM session token TTL")
@@ -634,6 +634,16 @@ func validateTurnstileFlags(f *serveFlags) error {
 	configured := strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != ""
 	if !configured && strings.TrimSpace(f.turnstileVerifyURL) != "" {
 		return errors.New("--turnstile-verify-url requires --turnstile-secret-file or --turnstile-secret-env")
+	}
+	// In production (Turnstile configured against the real Cloudflare endpoint,
+	// i.e. no --turnstile-verify-url override) the hostname and action bindings
+	// are mandatory, not advisory: without them a token solved for another page
+	// or action could be replayed against this broker. Dev/test (which sets
+	// --turnstile-verify-url to a local stub) is exempt.
+	if configured && strings.TrimSpace(f.turnstileVerifyURL) == "" {
+		if strings.TrimSpace(f.turnstileExpectedHostname) == "" || strings.TrimSpace(f.turnstileExpectedAction) == "" {
+			return errors.New("--turnstile-expected-hostname and --turnstile-action are required when Turnstile is enabled against Cloudflare (use --turnstile-verify-url for dev/test only)")
+		}
 	}
 	if strings.TrimSpace(f.turnstileVerifyURL) == "" {
 		return nil
@@ -1306,8 +1316,9 @@ func resolveTurnstileVerifier(f *serveFlags) (broker.HumanVerifier, error) {
 		MaxAge:           f.turnstileMaxAge,
 	}
 	return &broker.ReplayGuardVerifier{
-		Inner: inner,
-		Seen:  broker.NewSeenTokens(0, nil),
+		Inner:  inner,
+		Seen:   broker.NewSeenTokens(0, nil),
+		Failed: broker.NewSeenTokens(broker.DefaultFailedTokenTTL, nil),
 	}, nil
 }
 

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -47,11 +47,17 @@ const (
 	defaultCodeBurst      = 10
 	nonStreamWriteTimeout = 30 * time.Second
 	// sessionWriteTimeout bounds the session-create response write. It must
-	// exceed the broker's VM-ready budget (defaultVMReadyTimeout = 60s) so a
-	// legitimate cold VM boot+proof completes, while still capping a slow/
-	// non-reading client so the goroutine cannot be pinned indefinitely. A full
-	// exemption (no deadline) would leave that slow-reader hole open.
-	sessionWriteTimeout      = 90 * time.Second
+	// exceed the WHOLE cold-path budget, not just one stage: on a warm-pool MISS
+	// the handler runs Lease() (CreateMachine + WaitReady, bounded by the Fly
+	// adapter's ~60s wait timeout, which includes image pull) AND THEN
+	// createVMSession (bounded by the broker's ~60s vmReadyTimeout) before it
+	// writes the response — worst case ~120s. Allow margin so a legitimate cold
+	// start never fails closed mid-response (the 30s default caused exactly that:
+	// Fly PU02 / client 502), while still CAPPING a slow/non-reading client so the
+	// goroutine cannot be pinned indefinitely (a full exemption would leave that
+	// hole open). The warm-pool common path is ~2-3s; this ceiling only bites on a
+	// cold miss.
+	sessionWriteTimeout      = 180 * time.Second
 	cfAccessJWTHeader        = "Cf-Access-Jwt-Assertion"
 	cfAccessKeysTTL          = 5 * time.Minute
 	cfAccessNegativeCacheTTL = 30 * time.Second
@@ -367,14 +373,28 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		return nil, nil, nil, nil, err
 	}
 
-	// The reaper's protected-ID set is (active leases UNION warm-pool machines).
-	// INVARIANT 2: reaper MUST NOT destroy warm VMs.
+	// The reaper's protected-ID set is (warm pool + in-flight handoffs) UNION
+	// (active leases). INVARIANT 2: the reaper MUST NOT destroy warm or
+	// handing-off VMs.
+	//
+	// HAND-OVER-HAND ORDERING (do NOT reorder these two reads): a machine's
+	// protection moves from the pool's handoff set to the lease's active set, and
+	// the pool clears the handoff marker only AFTER AdoptWarm has registered the
+	// active lease (handleSession calls FinishHandoff after AdoptWarm). The two
+	// sets are independently locked, so this snapshot is non-atomic. We therefore
+	// read the SOURCE (warm + handoff) FIRST and the DESTINATION (active leases)
+	// SECOND: if a machine has already left handoff between the reads, it is
+	// guaranteed to be in active by the time we read active (and stays there until
+	// the session ends). Reading active first would let a machine that adopts +
+	// finishes between the two reads fall out of BOTH snapshots, and the reaper
+	// could destroy a live VM (TOCTOU).
 	activeIDsFn := func() map[string]struct{} {
-		ids := lm.ActiveMachineIDs()
-		if warmPool != nil {
-			for id := range warmPool.WarmMachineIDs() {
-				ids[id] = struct{}{}
-			}
+		if warmPool == nil {
+			return lm.ActiveMachineIDs()
+		}
+		ids := warmPool.WarmMachineIDs()        // source: warm + in-flight handoff, FIRST
+		for id := range lm.ActiveMachineIDs() { // destination: active leases, SECOND
+			ids[id] = struct{}{}
 		}
 		return ids
 	}

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -73,53 +73,56 @@ const (
 )
 
 type serveFlags struct {
-	listen                  string
-	adminListen             string
-	adminTokenFile          string
-	adminTokenEnv           string
-	unsafeAdminListenPublic bool
-	staticDir               string
-	provider                string
-	flyApp                  string
-	flyTokenFile            string
-	flyTokenEnv             string
-	image                   string
-	region                  string
-	memoryMB                int
-	cpus                    int
-	internalPort            int
-	concurrency             int
-	codes                   []string
-	maxPerCode              int
-	gateSecretFile          string
-	gateSecretEnv           string
-	ipRate                  float64
-	ipBurst                 float64
-	codeRate                float64
-	codeBurst               float64
-	perIPDailyBudget        int
-	perCodeDailyBudget      int
-	globalDailyBudget       int
-	unsafeUnlimited         bool
-	unsafeNoHumanGate       bool
-	turnstileSecretFile     string
-	turnstileSecretEnv      string
-	turnstileVerifyURL      string
-	sessionTTL              time.Duration
-	deadlineGrace           time.Duration
-	allowOrigin             string
-	publicHosts             []string
-	cfAccessTeamDomain      string
-	cfAccessAUD             string
-	cfAccessCertsURL        string
-	cfAccessDefaultCode     string
-	trustForwardedFor       bool
-	modelKeyFile            string
-	modelKeyEnv             string
-	orchestratorKeyFile     string
-	orchestratorKeyEnv      string
-	requireSessionSecrets   bool
-	warmPoolSize            int
+	listen                    string
+	adminListen               string
+	adminTokenFile            string
+	adminTokenEnv             string
+	unsafeAdminListenPublic   bool
+	staticDir                 string
+	provider                  string
+	flyApp                    string
+	flyTokenFile              string
+	flyTokenEnv               string
+	image                     string
+	region                    string
+	memoryMB                  int
+	cpus                      int
+	internalPort              int
+	concurrency               int
+	codes                     []string
+	maxPerCode                int
+	gateSecretFile            string
+	gateSecretEnv             string
+	ipRate                    float64
+	ipBurst                   float64
+	codeRate                  float64
+	codeBurst                 float64
+	perIPDailyBudget          int
+	perCodeDailyBudget        int
+	globalDailyBudget         int
+	unsafeUnlimited           bool
+	unsafeNoHumanGate         bool
+	turnstileSecretFile       string
+	turnstileSecretEnv        string
+	turnstileVerifyURL        string
+	turnstileExpectedHostname string
+	turnstileExpectedAction   string
+	turnstileMaxAge           time.Duration
+	sessionTTL                time.Duration
+	deadlineGrace             time.Duration
+	allowOrigin               string
+	publicHosts               []string
+	cfAccessTeamDomain        string
+	cfAccessAUD               string
+	cfAccessCertsURL          string
+	cfAccessDefaultCode       string
+	trustForwardedFor         bool
+	modelKeyFile              string
+	modelKeyEnv               string
+	orchestratorKeyFile       string
+	orchestratorKeyEnv        string
+	requireSessionSecrets     bool
+	warmPoolSize              int
 	// VM model/session config, passed into each per-visitor VM via PLAYGROUND_*
 	// env (consumed by deploy/fly-playground/entrypoint.sh).
 	vmModelBaseURL    string
@@ -194,6 +197,9 @@ func newServeCmd() *cobra.Command {
 	fl.StringVar(&f.turnstileSecretFile, "turnstile-secret-file", "", "path to the Cloudflare Turnstile secret; enables human verification for session creation")
 	fl.StringVar(&f.turnstileSecretEnv, "turnstile-secret-env", "", "environment variable holding the Cloudflare Turnstile secret; enables human verification for session creation")
 	fl.StringVar(&f.turnstileVerifyURL, "turnstile-verify-url", "", "Cloudflare Turnstile Siteverify URL override (tests/dev only; empty uses Cloudflare)")
+	fl.StringVar(&f.turnstileExpectedHostname, "turnstile-expected-hostname", "", "expected hostname in the Turnstile Siteverify response; public deploys SHOULD set this")
+	fl.StringVar(&f.turnstileExpectedAction, "turnstile-action", "", "expected action label in the Turnstile Siteverify response; public deploys SHOULD set this")
+	fl.DurationVar(&f.turnstileMaxAge, "turnstile-max-age", broker.DefaultTurnstileMaxAge, "max age for a Turnstile challenge_ts before it is rejected (0 disables)")
 	fl.DurationVar(&f.sessionTTL, "session-ttl", defaultSessionTTL, "VM session token TTL")
 	fl.DurationVar(&f.deadlineGrace, "deadline-grace", defaultGrace, "lease teardown grace after VM session expiry")
 	fl.StringVar(&f.allowOrigin, "allow-origin", "", "Access-Control-Allow-Origin for the browser")
@@ -1270,9 +1276,12 @@ func resolveTurnstileVerifier(f *serveFlags) (broker.HumanVerifier, error) {
 		return nil, err
 	}
 	inner := broker.TurnstileVerifier{
-		Secret:    secretValue,
-		VerifyURL: strings.TrimSpace(f.turnstileVerifyURL),
-		Client:    &http.Client{Timeout: 5 * time.Second},
+		Secret:           secretValue,
+		VerifyURL:        strings.TrimSpace(f.turnstileVerifyURL),
+		Client:           &http.Client{Timeout: 5 * time.Second},
+		ExpectedHostname: strings.TrimSpace(f.turnstileExpectedHostname),
+		ExpectedAction:   strings.TrimSpace(f.turnstileExpectedAction),
+		MaxAge:           f.turnstileMaxAge,
 	}
 	return &broker.ReplayGuardVerifier{
 		Inner: inner,

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -52,6 +52,10 @@ const (
 
 	envModelKey        = "PLAYGROUND_MODEL_" + "KEY"
 	envOrchestratorKey = "PLAYGROUND_ORCHESTRATOR_" + "KEY"
+
+	// warmPoolVMCodeBytes mirrors broker.vmInviteCodeBytes for warm-pool VM
+	// code generation. Kept in sync with the broker constant.
+	warmPoolVMCodeBytes = 18
 )
 
 type serveFlags struct {
@@ -100,6 +104,7 @@ type serveFlags struct {
 	orchestratorKeyFile     string
 	orchestratorKeyEnv      string
 	requireSessionSecrets   bool
+	warmPoolSize            int
 	// VM model/session config, passed into each per-visitor VM via PLAYGROUND_*
 	// env (consumed by deploy/fly-playground/entrypoint.sh).
 	vmModelBaseURL    string
@@ -193,6 +198,7 @@ func newServeCmd() *cobra.Command {
 	fl.IntVar(&f.vmDailyTurnBudget, "vm-daily-turn-budget", 0, "per-VM model round-trip ceiling per UTC day (the in-VM spend kill switch; required by the VM when a model is set)")
 	fl.DurationVar(&f.vmSessionTTL, "vm-session-ttl", 0, "per-VM session wall-clock cap (0 = VM default)")
 	fl.IntVar(&f.vmMaxMessages, "vm-max-messages-per-session", 0, "per-VM max messages per session (0 = VM default)")
+	fl.IntVar(&f.warmPoolSize, "warm-pool-size", 0, "number of pre-created warm VMs to maintain (0 = disabled)")
 	return cmd
 }
 
@@ -201,7 +207,7 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	srv, handler, startReaper, err := buildServer(ctx, cmd.OutOrStdout(), f)
+	srv, handler, startReaper, pool, err := buildServer(ctx, cmd.OutOrStdout(), f)
 	if err != nil {
 		return err
 	}
@@ -212,6 +218,17 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 	reaperCtx, reaperCancel := context.WithCancel(ctx)
 	defer reaperCancel()
 	go startReaper(reaperCtx)
+
+	// Start the warm pool maintainer if enabled; drain on shutdown.
+	// INVARIANT 4: warm VMs are drained on graceful shutdown.
+	if pool != nil {
+		poolCtx, poolCancel := context.WithCancel(ctx)
+		defer func() {
+			poolCancel()
+			pool.Drain(context.Background())
+		}()
+		go pool.Run(poolCtx)
+	}
 
 	httpSrv := &http.Server{
 		Handler:           handler,
@@ -240,17 +257,17 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 	return nil
 }
 
-func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Server, http.Handler, func(context.Context), error) {
+func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Server, http.Handler, func(context.Context), *broker.Pool, error) {
 	if err := validateFlags(f); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	secret, err := resolveGateSecret(f.gateSecretFile, f.gateSecretEnv)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	codes, err := resolveCodes(f.codes, f.maxPerCode)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	gate, err := livechat.NewGate(livechat.GateConfig{
 		Secret:   secret,
@@ -258,39 +275,75 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		TokenTTL: f.sessionTTL,
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	token, err := resolveFlyToken(f)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	provider, err := newMachineProvider(ctx, f, token)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	sessionEnv, err := resolveSessionEnv(f)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	humanVerifier, err := resolveTurnstileVerifier(f)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
+	// The concurrency limiter is shared between the LeaseManager and the
+	// optional warm pool so warm + active machines never exceed the cap.
+	concLimiter := livechat.NewConcurrencyLimiter(f.concurrency)
+
+	baseEnv := buildVMBaseEnv(f)
 	lm, err := broker.NewLeaseManager(broker.LeaseConfig{
 		Provider:     provider,
-		Concurrency:  livechat.NewConcurrencyLimiter(f.concurrency),
+		Concurrency:  concLimiter,
 		Image:        f.image,
 		Region:       f.region,
 		MemoryMB:     f.memoryMB,
 		CPUs:         f.cpus,
 		InternalPort: f.internalPort,
-		BaseEnv:      buildVMBaseEnv(f),
+		BaseEnv:      baseEnv,
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
+
+	// Build the optional warm pool when --warm-pool-size > 0.
+	var warmPool *broker.Pool
+	if f.warmPoolSize > 0 {
+		pool, poolErr := broker.NewPool(broker.PoolConfig{
+			Provider:    provider,
+			Concurrency: concLimiter,
+			NewVMCode: func() (string, error) {
+				return livechat.NewRandomCode(warmPoolVMCodeBytes)
+			},
+			BuildSpec: func(vmCode string) broker.MachineSpec {
+				return broker.MachineSpec{
+					Image:        f.image,
+					Env:          mergeSessionAndBaseEnv(sessionEnv, baseEnv, vmCode),
+					Region:       f.region,
+					MemoryMB:     f.memoryMB,
+					CPUs:         f.cpus,
+					InternalPort: f.internalPort,
+				}
+			},
+			Size: f.warmPoolSize,
+			Log:  out,
+		})
+		if poolErr != nil {
+			return nil, nil, nil, nil, poolErr
+		}
+		warmPool = pool
+		_, _ = fmt.Fprintf(out, "warm pool enabled: size %d\n", f.warmPoolSize)
+	}
+
 	srv, err := broker.NewServer(broker.ServerConfig{
 		Leases:             lm,
+		WarmPool:           warmPool,
 		Gate:               gate,
 		HumanVerifier:      humanVerifier,
 		IPRate:             livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
@@ -305,16 +358,27 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		AllowOrigin:        f.allowOrigin,
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
+	// The reaper's protected-ID set is (active leases UNION warm-pool machines).
+	// INVARIANT 2: reaper MUST NOT destroy warm VMs.
+	activeIDsFn := func() map[string]struct{} {
+		ids := lm.ActiveMachineIDs()
+		if warmPool != nil {
+			for id := range warmPool.WarmMachineIDs() {
+				ids[id] = struct{}{}
+			}
+		}
+		return ids
+	}
 	reaper, err := broker.NewReaper(broker.ReaperConfig{
 		Provider:  provider,
-		ActiveIDs: lm.ActiveMachineIDs,
+		ActiveIDs: activeIDsFn,
 		Log:       out,
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	_, _ = fmt.Fprintf(out, "broker configured: %d code(s), capacity %d, image %s\n", len(codes), f.concurrency, f.image)
@@ -346,7 +410,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 
 	hosts, err := brokerPublicHosts(f)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	if len(hosts) > 0 {
 		handler = hostGuard(handler, hosts)
@@ -354,13 +418,13 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 	}
 	cfAccess, err := newCFAccessVerifier(f)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	if cfAccess != nil {
 		handler = cfAccessGuard(handler, cfAccess)
 		_, _ = fmt.Fprintf(out, "broker Cloudflare Access JWT guard enabled for %s\n", cfAccess.issuer)
 	}
-	return srv, handler, reaper.Run, nil
+	return srv, handler, reaper.Run, warmPool, nil
 }
 
 func defaultMachineProvider(_ context.Context, f *serveFlags, flyToken string) (broker.MachineProvider, error) {
@@ -1115,6 +1179,21 @@ func buildVMBaseEnv(f *serveFlags) map[string]string {
 		env["PLAYGROUND_MAX_MESSAGES"] = strconv.Itoa(f.vmMaxMessages)
 	}
 	return env
+}
+
+// mergeSessionAndBaseEnv builds the full VM environment for a warm-pool VM:
+// baseEnv (shared config) + sessionEnv (per-session secrets) + the per-VM
+// invite code. Mirrors the layering that handleSession does for cold-path VMs.
+func mergeSessionAndBaseEnv(sessionEnv, baseEnv map[string]string, vmCode string) map[string]string {
+	out := make(map[string]string, len(baseEnv)+len(sessionEnv)+1)
+	for k, v := range baseEnv {
+		out[k] = v
+	}
+	for k, v := range sessionEnv {
+		out[k] = v
+	}
+	out["PLAYGROUND_CODE"] = vmCode
+	return out
 }
 
 func resolveTurnstileVerifier(f *serveFlags) (broker.HumanVerifier, error) {

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -896,6 +896,11 @@ func brokerPublicHosts(f *serveFlags) ([]string, error) {
 			return nil, fmt.Errorf("--allow-origin host: %w", err)
 		}
 	}
+	if len(hosts) == 0 && f.turnstileExpectedHostname != "" {
+		if err := add(f.turnstileExpectedHostname); err != nil {
+			return nil, fmt.Errorf("--turnstile-expected-hostname: %w", err)
+		}
+	}
 	return hosts, nil
 }
 

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -686,7 +686,7 @@ func validateTurnstileFlags(f *serveFlags) error {
 	// broker. Only a non-Cloudflare override (a local dev/test stub) is exempt.
 	cloudflareEndpoint := strings.TrimSpace(f.turnstileVerifyURL) == ""
 	if v := strings.TrimSpace(f.turnstileVerifyURL); v != "" {
-		if u, err := url.Parse(v); err == nil && strings.EqualFold(u.Hostname(), "challenges.cloudflare.com") {
+		if u, err := url.Parse(v); err == nil && strings.EqualFold(strings.TrimSuffix(u.Hostname(), "."), "challenges.cloudflare.com") {
 			cloudflareEndpoint = true
 		}
 	}

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -673,6 +673,9 @@ func validateHumanGateFlags(f *serveFlags) error {
 
 func validateTurnstileFlags(f *serveFlags) error {
 	configured := strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != ""
+	if f.turnstileMaxAge < 0 {
+		return errors.New("--turnstile-max-age must be >= 0")
+	}
 	if !configured && strings.TrimSpace(f.turnstileVerifyURL) != "" {
 		return errors.New("--turnstile-verify-url requires --turnstile-secret-file or --turnstile-secret-env")
 	}
@@ -683,7 +686,7 @@ func validateTurnstileFlags(f *serveFlags) error {
 	// broker. Only a non-Cloudflare override (a local dev/test stub) is exempt.
 	cloudflareEndpoint := strings.TrimSpace(f.turnstileVerifyURL) == ""
 	if v := strings.TrimSpace(f.turnstileVerifyURL); v != "" {
-		if u, err := url.Parse(v); err == nil && strings.EqualFold(u.Host, "challenges.cloudflare.com") {
+		if u, err := url.Parse(v); err == nil && strings.EqualFold(u.Hostname(), "challenges.cloudflare.com") {
 			cloudflareEndpoint = true
 		}
 	}

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -117,6 +117,7 @@ type serveFlags struct {
 	cfAccessAUD               string
 	cfAccessCertsURL          string
 	cfAccessDefaultCode       string
+	defaultCode               string
 	trustForwardedFor         bool
 	modelKeyFile              string
 	modelKeyEnv               string
@@ -210,6 +211,7 @@ func newServeCmd() *cobra.Command {
 	fl.StringVar(&f.cfAccessAUD, "cf-access-aud", "", "Cloudflare Access application AUD tag expected in Cf-Access-Jwt-Assertion")
 	fl.StringVar(&f.cfAccessCertsURL, "cf-access-certs-url", "", "override Cloudflare Access JWKS URL (tests/dev only; defaults to <team-domain>/cdn-cgi/access/certs)")
 	fl.StringVar(&f.cfAccessDefaultCode, "cf-access-default-code", "", "invite code used when an Access-gated request sends none, so allowlisted users skip the code prompt; REQUIRES --cf-access-team-domain/--cf-access-aud and must be one of the --code values")
+	fl.StringVar(&f.defaultCode, "default-code", "", "invite code auto-applied when a session request sends none, so public visitors skip the code prompt; REQUIRES a human gate (--turnstile-secret-* or Cloudflare Access) and must be one of the --code values. Use this for a public Turnstile-gated demo (no email allowlist)")
 	fl.BoolVar(&f.trustForwardedFor, "trust-forwarded-for", false, "read client IP from X-Forwarded-For behind a trusted proxy")
 	fl.StringVar(&f.modelKeyFile, "model-key-file", "", "path to the model key file passed to the VM env")
 	fl.StringVar(&f.modelKeyEnv, "model-key-env", "", "environment variable holding the model key passed to the VM env")
@@ -369,7 +371,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		Leases:             lm,
 		WarmPool:           warmPool,
 		Gate:               gate,
-		DefaultCode:        f.cfAccessDefaultCode,
+		DefaultCode:        effectiveDefaultCode(f),
 		TurnstileSitekey:   f.turnstileSitekey,
 		HumanVerifier:      humanVerifier,
 		IPRate:             livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
@@ -548,7 +550,46 @@ func validateFlags(f *serveFlags) error {
 	if err := validateCFAccessFlags(f); err != nil {
 		return err
 	}
+	if err := validateDefaultCode(f); err != nil {
+		return err
+	}
 	return nil
+}
+
+// effectiveDefaultCode is the server-side invite code auto-applied when a
+// session request sends none. The general --default-code wins; --cf-access-default-code
+// remains as the Access-only alias. Empty means "client must send a code".
+func effectiveDefaultCode(f *serveFlags) string {
+	if dc := strings.TrimSpace(f.defaultCode); dc != "" {
+		return dc
+	}
+	return strings.TrimSpace(f.cfAccessDefaultCode)
+}
+
+// validateDefaultCode fails closed on --default-code: like --cf-access-default-code
+// it lets visitors skip the invite-code prompt, so it is only safe behind a human
+// gate (Turnstile OR Cloudflare Access) — never with no gate / --unsafe-no-human-gate
+// alone, which would let ANYONE create sessions code-free. It must also name a real
+// --code. (--cf-access-default-code keeps its own Access-only check in validateCFAccessFlags.)
+func validateDefaultCode(f *serveFlags) error {
+	dc := strings.TrimSpace(f.defaultCode)
+	if dc == "" {
+		return nil
+	}
+	if cfdc := strings.TrimSpace(f.cfAccessDefaultCode); cfdc != "" && cfdc != dc {
+		return errors.New("set only one of --default-code or --cf-access-default-code")
+	}
+	hasTurnstile := strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != ""
+	hasCFAccess := strings.TrimSpace(f.cfAccessTeamDomain) != "" || strings.TrimSpace(f.cfAccessAUD) != ""
+	if !hasTurnstile && !hasCFAccess {
+		return errors.New("--default-code requires a human gate (--turnstile-secret-file/--turnstile-secret-env or Cloudflare Access); a default code with no human gate would open the broker")
+	}
+	for _, c := range f.codes {
+		if strings.TrimSpace(c) == dc {
+			return nil
+		}
+	}
+	return errors.New("--default-code must be one of the --code values")
 }
 
 func validateAdminFlags(f *serveFlags) error {

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -36,16 +36,22 @@ import (
 )
 
 const (
-	defaultListen            = "127.0.0.1:8100"
-	defaultConcurrency       = 3
-	defaultMaxPerCode        = 25
-	defaultSessionTTL        = 10 * time.Minute
-	defaultGrace             = 30 * time.Second
-	defaultIPRate            = 0.5
-	defaultIPBurst           = 5
-	defaultCodeRate          = 0.5
-	defaultCodeBurst         = 10
-	nonStreamWriteTimeout    = 30 * time.Second
+	defaultListen         = "127.0.0.1:8100"
+	defaultConcurrency    = 3
+	defaultMaxPerCode     = 25
+	defaultSessionTTL     = 10 * time.Minute
+	defaultGrace          = 30 * time.Second
+	defaultIPRate         = 0.5
+	defaultIPBurst        = 5
+	defaultCodeRate       = 0.5
+	defaultCodeBurst      = 10
+	nonStreamWriteTimeout = 30 * time.Second
+	// sessionWriteTimeout bounds the session-create response write. It must
+	// exceed the broker's VM-ready budget (defaultVMReadyTimeout = 60s) so a
+	// legitimate cold VM boot+proof completes, while still capping a slow/
+	// non-reading client so the goroutine cannot be pinned indefinitely. A full
+	// exemption (no deadline) would leave that slow-reader hole open.
+	sessionWriteTimeout      = 90 * time.Second
 	cfAccessJWTHeader        = "Cf-Access-Jwt-Assertion"
 	cfAccessKeysTTL          = 5 * time.Minute
 	cfAccessNegativeCacheTTL = 30 * time.Second
@@ -396,17 +402,19 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		handler = mux
 		_, _ = fmt.Fprintf(out, "serving static UI from %s at /\n", f.staticDir)
 	}
-	// Stream writes indefinitely; the message route is held open for the whole
-	// model turn; session-create synchronously boots and proves a fresh
-	// per-visitor microVM, which on a cold start (image pull + boot + containment
-	// proof) legitimately exceeds this deadline. All three are exempt from the
-	// write deadline (see the middleware) and bounded instead by their own
-	// budgets — the SSE/turn lifecycle for stream/message, and the broker's
-	// vmReadyTimeout (createVMSession's readyCtx) for session-create. A 30s write
-	// deadline on session-create made cold starts fail closed mid-response
-	// (Fly PU02 / client 502) even though the VM came up healthy within the 60s
-	// VM-ready budget.
-	handler = writeDeadlineMiddleware(handler, nonStreamWriteTimeout, livechat.RouteStream, livechat.RouteMessage, livechat.RouteSession)
+	// Per-route write deadlines. Stream writes indefinitely and the message route
+	// is held open for the whole model turn, so both are exempt (deadline 0).
+	// Session-create synchronously boots and proves a fresh per-visitor microVM;
+	// on a cold start that legitimately exceeds the default 30s (a 30s deadline
+	// made cold starts fail closed mid-response: Fly PU02 / client 502), so it
+	// gets a longer BOUNDED deadline (sessionWriteTimeout > the 60s vmReadyTimeout)
+	// rather than a full exemption — capping a slow reader without cutting off a
+	// healthy boot. Everything else gets the default fast deadline.
+	handler = writeDeadlineMiddleware(handler, nonStreamWriteTimeout, map[string]time.Duration{
+		livechat.RouteStream:  0,
+		livechat.RouteMessage: 0,
+		livechat.RouteSession: sessionWriteTimeout,
+	})
 
 	hosts, err := brokerPublicHosts(f)
 	if err != nil {
@@ -864,18 +872,20 @@ func normalizePublicHost(raw string) (string, error) {
 // than the deadline) before the response is written. Those long-lived routes
 // are bounded instead by the session TTL and the upstream/edge connection
 // timeouts, not by this deadline.
-func writeDeadlineMiddleware(next http.Handler, timeout time.Duration, exemptPaths ...string) http.Handler {
-	exempt := make(map[string]struct{}, len(exemptPaths))
-	for _, p := range exemptPaths {
-		exempt[p] = struct{}{}
-	}
+func writeDeadlineMiddleware(next http.Handler, defaultTimeout time.Duration, overrides map[string]time.Duration) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rc := http.NewResponseController(w)
-		if _, ok := exempt[r.URL.Path]; ok {
-			// Long-lived route: clear any inherited deadline.
+		d, ok := overrides[r.URL.Path]
+		switch {
+		case ok && d <= 0:
+			// Exempt long-lived route: clear any inherited deadline.
 			_ = rc.SetWriteDeadline(time.Time{})
-		} else {
-			_ = rc.SetWriteDeadline(time.Now().Add(timeout))
+		case ok:
+			// Route-specific bounded deadline (e.g. session-create's long
+			// cold-start budget). Still bounded so a slow reader can't pin us.
+			_ = rc.SetWriteDeadline(time.Now().Add(d))
+		default:
+			_ = rc.SetWriteDeadline(time.Now().Add(defaultTimeout))
 		}
 		next.ServeHTTP(w, r)
 	})

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -112,6 +112,7 @@ type serveFlags struct {
 	cfAccessTeamDomain      string
 	cfAccessAUD             string
 	cfAccessCertsURL        string
+	cfAccessDefaultCode     string
 	trustForwardedFor       bool
 	modelKeyFile            string
 	modelKeyEnv             string
@@ -200,6 +201,7 @@ func newServeCmd() *cobra.Command {
 	fl.StringVar(&f.cfAccessTeamDomain, "cf-access-team-domain", "", "Cloudflare Access team domain, e.g. https://team.cloudflareaccess.com; enables origin-side Access JWT validation when set with --cf-access-aud")
 	fl.StringVar(&f.cfAccessAUD, "cf-access-aud", "", "Cloudflare Access application AUD tag expected in Cf-Access-Jwt-Assertion")
 	fl.StringVar(&f.cfAccessCertsURL, "cf-access-certs-url", "", "override Cloudflare Access JWKS URL (tests/dev only; defaults to <team-domain>/cdn-cgi/access/certs)")
+	fl.StringVar(&f.cfAccessDefaultCode, "cf-access-default-code", "", "invite code used when an Access-gated request sends none, so allowlisted users skip the code prompt; REQUIRES --cf-access-team-domain/--cf-access-aud and must be one of the --code values")
 	fl.BoolVar(&f.trustForwardedFor, "trust-forwarded-for", false, "read client IP from X-Forwarded-For behind a trusted proxy")
 	fl.StringVar(&f.modelKeyFile, "model-key-file", "", "path to the model key file passed to the VM env")
 	fl.StringVar(&f.modelKeyEnv, "model-key-env", "", "environment variable holding the model key passed to the VM env")
@@ -359,6 +361,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		Leases:             lm,
 		WarmPool:           warmPool,
 		Gate:               gate,
+		DefaultCode:        f.cfAccessDefaultCode,
 		HumanVerifier:      humanVerifier,
 		IPRate:             livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
 		CodeRate:           livechat.RateConfig{RefillPerSec: f.codeRate, Burst: f.codeBurst},
@@ -950,6 +953,25 @@ type cfAccessVerifier struct {
 func validateCFAccessFlags(f *serveFlags) error {
 	team := strings.TrimSpace(f.cfAccessTeamDomain)
 	aud := strings.TrimSpace(f.cfAccessAUD)
+	// --cf-access-default-code lets Access-gated users skip the invite code.
+	// Fail closed: it is only safe behind the Access JWT gate (without it, a
+	// default code would let ANYONE create sessions code-free), and it must name
+	// a real configured code so the gate can redeem it.
+	if dc := strings.TrimSpace(f.cfAccessDefaultCode); dc != "" {
+		if team == "" || aud == "" {
+			return errors.New("--cf-access-default-code requires --cf-access-team-domain and --cf-access-aud (a default code without a human gate would open the broker)")
+		}
+		found := false
+		for _, c := range f.codes {
+			if strings.TrimSpace(c) == dc {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return errors.New("--cf-access-default-code must be one of the --code values")
+		}
+	}
 	if team == "" && aud == "" {
 		if strings.TrimSpace(f.cfAccessCertsURL) != "" {
 			return errors.New("--cf-access-certs-url requires --cf-access-team-domain and --cf-access-aud")

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -108,6 +108,7 @@ type serveFlags struct {
 	turnstileExpectedHostname string
 	turnstileExpectedAction   string
 	turnstileMaxAge           time.Duration
+	turnstileSitekey          string
 	sessionTTL                time.Duration
 	deadlineGrace             time.Duration
 	allowOrigin               string
@@ -200,6 +201,7 @@ func newServeCmd() *cobra.Command {
 	fl.StringVar(&f.turnstileExpectedHostname, "turnstile-expected-hostname", "", "expected hostname in the Turnstile Siteverify response; public deploys SHOULD set this")
 	fl.StringVar(&f.turnstileExpectedAction, "turnstile-action", "", "expected action label in the Turnstile Siteverify response; public deploys SHOULD set this")
 	fl.DurationVar(&f.turnstileMaxAge, "turnstile-max-age", broker.DefaultTurnstileMaxAge, "max age for a Turnstile challenge_ts before it is rejected (0 disables)")
+	fl.StringVar(&f.turnstileSitekey, "turnstile-sitekey", "", "public Cloudflare Turnstile site key; reported via /health so the viewer renders the widget (the secret is set separately via --turnstile-secret-*)")
 	fl.DurationVar(&f.sessionTTL, "session-ttl", defaultSessionTTL, "VM session token TTL")
 	fl.DurationVar(&f.deadlineGrace, "deadline-grace", defaultGrace, "lease teardown grace after VM session expiry")
 	fl.StringVar(&f.allowOrigin, "allow-origin", "", "Access-Control-Allow-Origin for the browser")
@@ -368,6 +370,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		WarmPool:           warmPool,
 		Gate:               gate,
 		DefaultCode:        f.cfAccessDefaultCode,
+		TurnstileSitekey:   f.turnstileSitekey,
 		HumanVerifier:      humanVerifier,
 		IPRate:             livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
 		CodeRate:           livechat.RateConfig{RefillPerSec: f.codeRate, Burst: f.codeBurst},

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -448,6 +448,12 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		livechat.RouteStream:  0,
 		livechat.RouteMessage: 0,
 		livechat.RouteSession: sessionWriteTimeout,
+		// The signed bundle / verify kit can be large (one receipt per action — a
+		// long session is hundreds of KB) and the VM generates it on demand, so a
+		// 30s write deadline truncates the proxied download mid-body (Fly "could
+		// not finish reading HTTP body from instance"). Give it the same long
+		// bounded budget as session-create.
+		livechat.RouteBundle: sessionWriteTimeout,
 	})
 
 	hosts, err := brokerPublicHosts(f)

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -635,14 +635,20 @@ func validateTurnstileFlags(f *serveFlags) error {
 	if !configured && strings.TrimSpace(f.turnstileVerifyURL) != "" {
 		return errors.New("--turnstile-verify-url requires --turnstile-secret-file or --turnstile-secret-env")
 	}
-	// In production (Turnstile configured against the real Cloudflare endpoint,
-	// i.e. no --turnstile-verify-url override) the hostname and action bindings
-	// are mandatory, not advisory: without them a token solved for another page
-	// or action could be replayed against this broker. Dev/test (which sets
-	// --turnstile-verify-url to a local stub) is exempt.
-	if configured && strings.TrimSpace(f.turnstileVerifyURL) == "" {
+	// The endpoint is Cloudflare's production Siteverify when no override is set
+	// OR the override explicitly points at challenges.cloudflare.com. In that
+	// case the hostname + action bindings are mandatory, not advisory: without
+	// them a token solved for another page/action could be replayed against this
+	// broker. Only a non-Cloudflare override (a local dev/test stub) is exempt.
+	cloudflareEndpoint := strings.TrimSpace(f.turnstileVerifyURL) == ""
+	if v := strings.TrimSpace(f.turnstileVerifyURL); v != "" {
+		if u, err := url.Parse(v); err == nil && strings.EqualFold(u.Host, "challenges.cloudflare.com") {
+			cloudflareEndpoint = true
+		}
+	}
+	if configured && cloudflareEndpoint {
 		if strings.TrimSpace(f.turnstileExpectedHostname) == "" || strings.TrimSpace(f.turnstileExpectedAction) == "" {
-			return errors.New("--turnstile-expected-hostname and --turnstile-action are required when Turnstile is enabled against Cloudflare (use --turnstile-verify-url for dev/test only)")
+			return errors.New("--turnstile-expected-hostname and --turnstile-action are required when Turnstile is enabled against Cloudflare (use a non-Cloudflare --turnstile-verify-url for dev/test only)")
 		}
 	}
 	if strings.TrimSpace(f.turnstileVerifyURL) == "" {

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -1291,28 +1291,36 @@ var _ writeDeadliner = (*deadlineRecorder)(nil)
 func TestWriteDeadlineMiddleware(t *testing.T) {
 	t.Parallel()
 	const (
-		timeout      = 30 * time.Second
-		routeHealth  = "/api/live/health"
-		routeSession = "/api/live/session"
-		routeStream  = "/api/live/stream"
-		routeMessage = "/api/live/message"
+		defaultTimeout = 30 * time.Second
+		longTimeout    = 90 * time.Second
+		routeHealth    = "/api/live/health"
+		routeSession   = "/api/live/session"
+		routeStream    = "/api/live/stream"
+		routeMessage   = "/api/live/message"
 	)
-	exempt := []string{routeStream, routeMessage, routeSession}
+	overrides := map[string]time.Duration{
+		routeStream:  0,           // exempt: SSE writes indefinitely
+		routeMessage: 0,           // exempt: held open for the whole model turn
+		routeSession: longTimeout, // bounded long: cold VM boot+proof
+	}
 
+	const (
+		kindExempt  = "exempt"  // no deadline
+		kindDefault = "default" // ~defaultTimeout
+		kindLong    = "long"    // ~longTimeout (bounded, but > default)
+	)
 	tests := []struct {
 		name string
 		path string
-		// exempt routes get NO deadline (cleared to zero); bounded routes get a
-		// future deadline so a slow reader cannot pin the goroutine.
-		wantExempt bool
+		kind string
 	}{
-		{name: "health_bounded", path: routeHealth, wantExempt: false},
-		// session-create synchronously boots+proves a cold microVM (can exceed
-		// the 30s deadline); it must be exempt and bounded by vmReadyTimeout
-		// instead, else cold starts fail closed mid-response (PU02 / 502).
-		{name: "session_exempt_cold_start_boot", path: routeSession, wantExempt: true},
-		{name: "stream_exempt", path: routeStream, wantExempt: true},
-		{name: "message_exempt_held_open_for_turn", path: routeMessage, wantExempt: true},
+		{name: "health_default", path: routeHealth, kind: kindDefault},
+		// session-create boots+proves a cold microVM (can exceed 30s): a longer
+		// but still BOUNDED deadline, not a full exemption (a slow reader must
+		// not pin the goroutine). 30s here made cold starts fail closed (PU02/502).
+		{name: "session_long_bounded", path: routeSession, kind: kindLong},
+		{name: "stream_exempt", path: routeStream, kind: kindExempt},
+		{name: "message_exempt_held_open_for_turn", path: routeMessage, kind: kindExempt},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1322,7 +1330,7 @@ func TestWriteDeadlineMiddleware(t *testing.T) {
 				ran = true
 				w.WriteHeader(http.StatusOK)
 			})
-			mw := writeDeadlineMiddleware(inner, timeout, exempt...)
+			mw := writeDeadlineMiddleware(inner, defaultTimeout, overrides)
 			rec := &deadlineRecorder{ResponseWriter: httptest.NewRecorder()}
 			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
 			before := time.Now()
@@ -1334,13 +1342,24 @@ func TestWriteDeadlineMiddleware(t *testing.T) {
 			if !rec.set {
 				t.Fatal("middleware never called SetWriteDeadline")
 			}
-			if tc.wantExempt {
+			switch tc.kind {
+			case kindExempt:
 				if !rec.deadline.IsZero() {
 					t.Fatalf("exempt path %s: deadline = %v, want zero (cleared)", tc.path, rec.deadline)
 				}
-			} else {
-				if !rec.deadline.After(before) {
-					t.Fatalf("bounded path %s: deadline = %v, want a future deadline", tc.path, rec.deadline)
+			case kindDefault:
+				// ~defaultTimeout out, and clearly shorter than the long budget.
+				if !rec.deadline.After(before) || rec.deadline.After(before.Add(defaultTimeout+5*time.Second)) {
+					t.Fatalf("default path %s: deadline = %v, want ~%s out", tc.path, rec.deadline, defaultTimeout)
+				}
+			case kindLong:
+				// Bounded (not zero) AND longer than the default deadline, so a
+				// cold VM boot completes but a slow reader is still capped.
+				if rec.deadline.IsZero() {
+					t.Fatalf("long path %s: deadline = zero, want a bounded future deadline", tc.path)
+				}
+				if !rec.deadline.After(before.Add(defaultTimeout)) {
+					t.Fatalf("long path %s: deadline = %v, want > default (%s) out", tc.path, rec.deadline, defaultTimeout)
 				}
 			}
 		})

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -505,6 +505,64 @@ func TestBuildServerValidation(t *testing.T) {
 	}
 }
 
+func TestValidateDefaultCode(t *testing.T) {
+	t.Parallel()
+	const pub = "pub-code"
+	mk := func(mut func(*serveFlags)) *serveFlags {
+		f := &serveFlags{codes: []string{pub, "other"}}
+		mut(f)
+		return f
+	}
+	cases := []struct {
+		name    string
+		f       *serveFlags
+		wantErr bool
+	}{
+		{"empty_is_noop", mk(func(f *serveFlags) {}), false},
+		{"turnstile_gate_ok", mk(func(f *serveFlags) { f.defaultCode = pub; f.turnstileSecretEnv = "TS_SECRET" }), false},
+		{"cfaccess_gate_ok", mk(func(f *serveFlags) {
+			f.defaultCode = pub
+			f.cfAccessTeamDomain = "https://x.cloudflareaccess.com"
+			f.cfAccessAUD = "aud-tag"
+		}), false},
+		// The security guardrail: a default code with NO human gate would let
+		// anyone create sessions code-free. Must fail closed.
+		{"no_gate_rejected", mk(func(f *serveFlags) { f.defaultCode = pub }), true},
+		{"unsafe_no_human_gate_rejected", mk(func(f *serveFlags) { f.defaultCode = pub; f.unsafeNoHumanGate = true }), true},
+		{"unknown_code_rejected", mk(func(f *serveFlags) { f.defaultCode = "ghost"; f.turnstileSecretEnv = "TS_SECRET" }), true},
+		{"conflicting_flags_rejected", mk(func(f *serveFlags) {
+			f.defaultCode = pub
+			f.cfAccessDefaultCode = "other"
+			f.turnstileSecretEnv = "TS_SECRET"
+		}), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateDefaultCode(tc.f)
+			if tc.wantErr && err == nil {
+				t.Fatal("validateDefaultCode succeeded, want error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateDefaultCode failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestEffectiveDefaultCode(t *testing.T) {
+	t.Parallel()
+	if got := effectiveDefaultCode(&serveFlags{defaultCode: "general"}); got != "general" {
+		t.Fatalf("general wins: got %q", got)
+	}
+	if got := effectiveDefaultCode(&serveFlags{cfAccessDefaultCode: "cf"}); got != "cf" {
+		t.Fatalf("cf fallback: got %q", got)
+	}
+	if got := effectiveDefaultCode(&serveFlags{}); got != "" {
+		t.Fatalf("empty: got %q", got)
+	}
+}
+
 func TestRunServeListenErrorAfterBuild(t *testing.T) {
 	dir := t.TempDir()
 	flyTokenFile := writeTestFile(t, dir, "fly.token", "fly-file-token\n")

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -916,6 +916,12 @@ func TestValidateFlagsBranches(t *testing.T) {
 			// hostname + action; omitting them is rejected.
 			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
 		}},
+		{name: "turnstile_explicit_cloudflare_url_missing_bindings", mutate: func(f *serveFlags) {
+			// Explicitly pointing at the real Cloudflare Siteverify URL must NOT
+			// escape the hostname/action binding requirement.
+			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
+			f.turnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+		}},
 		{name: "bad_cf_combo", mutate: func(f *serveFlags) { f.cfAccessCertsURL = "https://keys.example/certs" }},
 		{name: "bad_cf_aud", mutate: func(f *serveFlags) {
 			f.cfAccessTeamDomain = "team.cloudflareaccess.com"

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -969,6 +969,11 @@ func TestValidateFlagsBranches(t *testing.T) {
 			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
 			f.turnstileVerifyURL = "file:///tmp/siteverify"
 		}},
+		{name: "bad_turnstile_max_age", mutate: func(f *serveFlags) {
+			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
+			f.turnstileVerifyURL = "https://turnstile.example/verify"
+			f.turnstileMaxAge = -1
+		}},
 		{name: "turnstile_production_missing_hostname_action", mutate: func(f *serveFlags) {
 			// Turnstile against Cloudflare (no --turnstile-verify-url) must bind
 			// hostname + action; omitting them is rejected.
@@ -979,6 +984,12 @@ func TestValidateFlagsBranches(t *testing.T) {
 			// escape the hostname/action binding requirement.
 			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
 			f.turnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+		}},
+		{name: "turnstile_explicit_cloudflare_url_with_port_missing_bindings", mutate: func(f *serveFlags) {
+			// A port on the real Cloudflare host is still the production
+			// Siteverify endpoint, so hostname/action binding remains required.
+			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
+			f.turnstileVerifyURL = "https://challenges.cloudflare.com:443/turnstile/v0/siteverify"
 		}},
 		{name: "bad_cf_combo", mutate: func(f *serveFlags) { f.cfAccessCertsURL = "https://keys.example/certs" }},
 		{name: "bad_cf_aud", mutate: func(f *serveFlags) {

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -875,6 +875,8 @@ func TestValidateFlagsBranches(t *testing.T) {
 	}
 	turnstileGate := noHumanGate
 	turnstileGate.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
+	turnstileGate.turnstileExpectedHostname = "playground.example"
+	turnstileGate.turnstileExpectedAction = "playground-session"
 	if err := validateFlags(&turnstileGate); err != nil {
 		t.Fatalf("turnstile gate should validate: %v", err)
 	}
@@ -908,6 +910,11 @@ func TestValidateFlagsBranches(t *testing.T) {
 		{name: "bad_turnstile_verify_url", mutate: func(f *serveFlags) {
 			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
 			f.turnstileVerifyURL = "file:///tmp/siteverify"
+		}},
+		{name: "turnstile_production_missing_hostname_action", mutate: func(f *serveFlags) {
+			// Turnstile against Cloudflare (no --turnstile-verify-url) must bind
+			// hostname + action; omitting them is rejected.
+			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
 		}},
 		{name: "bad_cf_combo", mutate: func(f *serveFlags) { f.cfAccessCertsURL = "https://keys.example/certs" }},
 		{name: "bad_cf_aud", mutate: func(f *serveFlags) {

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -962,6 +962,13 @@ func TestBrokerPublicHosts(t *testing.T) {
 	if len(hosts) != 1 || hosts[0] != "playground.pipelab.org" {
 		t.Fatalf("hosts from origin = %#v", hosts)
 	}
+	hosts, err = brokerPublicHosts(&serveFlags{turnstileExpectedHostname: "Playground.Pipelab.Org."})
+	if err != nil {
+		t.Fatalf("brokerPublicHosts turnstile hostname: %v", err)
+	}
+	if len(hosts) != 1 || hosts[0] != "playground.pipelab.org" {
+		t.Fatalf("hosts from turnstile hostname = %#v", hosts)
+	}
 	if _, err := brokerPublicHosts(&serveFlags{publicHosts: []string{"https://bad.example"}}); err == nil {
 		t.Fatal("URL-shaped public host should error")
 	}

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -991,6 +991,12 @@ func TestValidateFlagsBranches(t *testing.T) {
 			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
 			f.turnstileVerifyURL = "https://challenges.cloudflare.com:443/turnstile/v0/siteverify"
 		}},
+		{name: "turnstile_explicit_cloudflare_url_trailing_dot_missing_bindings", mutate: func(f *serveFlags) {
+			// A DNS-root trailing dot is still the real Cloudflare host, so it
+			// must not bypass hostname/action binding.
+			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
+			f.turnstileVerifyURL = "https://challenges.cloudflare.com./turnstile/v0/siteverify"
+		}},
 		{name: "bad_cf_combo", mutate: func(f *serveFlags) { f.cfAccessCertsURL = "https://keys.example/certs" }},
 		{name: "bad_cf_aud", mutate: func(f *serveFlags) {
 			f.cfAccessTeamDomain = "team.cloudflareaccess.com"

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -1288,6 +1288,24 @@ type writeDeadliner interface{ SetWriteDeadline(time.Time) error }
 
 var _ writeDeadliner = (*deadlineRecorder)(nil)
 
+func TestNoCacheStatic(t *testing.T) {
+	t.Parallel()
+	var served bool
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		served = true
+		w.WriteHeader(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/viewer-live.js", nil)
+	noCacheStatic(inner).ServeHTTP(rec, req)
+	if !served {
+		t.Fatal("inner static handler was not called")
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("Cache-Control = %q, want no-cache (so the viewer revalidates after a redeploy)", got)
+	}
+}
+
 func TestWriteDeadlineMiddleware(t *testing.T) {
 	t.Parallel()
 	const (

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -95,7 +95,7 @@ func TestBuildServerWithInjectedProvider(t *testing.T) {
 	t.Cleanup(func() { newMachineProvider = oldFactory })
 
 	var out bytes.Buffer
-	srv, handler, _, err := buildServer(context.Background(), &out, &serveFlags{
+	srv, handler, _, _, err := buildServer(context.Background(), &out, &serveFlags{
 		listen:                defaultListen,
 		provider:              "fake",
 		flyApp:                "playground-test",
@@ -168,7 +168,7 @@ func TestBuildServerStaticDir(t *testing.T) {
 	}
 
 	// With --static-dir: / serves the UI AND the API still routes on the same origin.
-	srv, handler, _, err := buildServer(context.Background(), &bytes.Buffer{}, flags(uiDir))
+	srv, handler, _, _, err := buildServer(context.Background(), &bytes.Buffer{}, flags(uiDir))
 	if err != nil {
 		t.Fatalf("buildServer(static): %v", err)
 	}
@@ -183,7 +183,7 @@ func TestBuildServerStaticDir(t *testing.T) {
 	}
 
 	// Without --static-dir: / is 404 (broker is API-only).
-	srv2, handler2, _, err := buildServer(context.Background(), &bytes.Buffer{}, flags(""))
+	srv2, handler2, _, _, err := buildServer(context.Background(), &bytes.Buffer{}, flags(""))
 	if err != nil {
 		t.Fatalf("buildServer(no static): %v", err)
 	}
@@ -212,7 +212,7 @@ func TestBuildServerHostGuardFromAllowOrigin(t *testing.T) {
 	}
 	t.Cleanup(func() { newMachineProvider = oldFactory })
 
-	srv, handler, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
+	srv, handler, _, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
 		listen: defaultListen, provider: "fake", flyApp: "playground-test",
 		flyTokenFile: flyTokenFile, image: "registry.example/playground:test",
 		staticDir: uiDir, internalPort: 8080, concurrency: 2,
@@ -284,7 +284,7 @@ func TestBuildServerCFAccessGuard(t *testing.T) {
 	}
 	t.Cleanup(func() { newMachineProvider = oldFactory })
 
-	srv, handler, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
+	srv, handler, _, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
 		listen: defaultListen, provider: "fake", flyApp: "playground-test",
 		flyTokenFile: flyTokenFile, image: "registry.example/playground:test",
 		staticDir: uiDir, internalPort: 8080, concurrency: 2,
@@ -347,7 +347,7 @@ func TestBuildServerTurnstileRejectsMissingToken(t *testing.T) {
 	}
 	t.Cleanup(func() { newMachineProvider = oldFactory })
 
-	srv, handler, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
+	srv, handler, _, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
 		listen:                defaultListen,
 		provider:              "fake",
 		flyApp:                "playground-test",

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -42,6 +42,10 @@ func (fakeProvider) DestroyMachine(_ context.Context, _ string) error {
 	return nil
 }
 
+func (fakeProvider) ListManagedMachines(_ context.Context) ([]broker.Machine, error) {
+	return nil, nil
+}
+
 type lockedBuffer struct {
 	mu sync.Mutex
 	b  bytes.Buffer
@@ -91,7 +95,7 @@ func TestBuildServerWithInjectedProvider(t *testing.T) {
 	t.Cleanup(func() { newMachineProvider = oldFactory })
 
 	var out bytes.Buffer
-	srv, handler, err := buildServer(context.Background(), &out, &serveFlags{
+	srv, handler, _, err := buildServer(context.Background(), &out, &serveFlags{
 		listen:                defaultListen,
 		provider:              "fake",
 		flyApp:                "playground-test",
@@ -164,7 +168,7 @@ func TestBuildServerStaticDir(t *testing.T) {
 	}
 
 	// With --static-dir: / serves the UI AND the API still routes on the same origin.
-	srv, handler, err := buildServer(context.Background(), &bytes.Buffer{}, flags(uiDir))
+	srv, handler, _, err := buildServer(context.Background(), &bytes.Buffer{}, flags(uiDir))
 	if err != nil {
 		t.Fatalf("buildServer(static): %v", err)
 	}
@@ -179,7 +183,7 @@ func TestBuildServerStaticDir(t *testing.T) {
 	}
 
 	// Without --static-dir: / is 404 (broker is API-only).
-	srv2, handler2, err := buildServer(context.Background(), &bytes.Buffer{}, flags(""))
+	srv2, handler2, _, err := buildServer(context.Background(), &bytes.Buffer{}, flags(""))
 	if err != nil {
 		t.Fatalf("buildServer(no static): %v", err)
 	}
@@ -208,7 +212,7 @@ func TestBuildServerHostGuardFromAllowOrigin(t *testing.T) {
 	}
 	t.Cleanup(func() { newMachineProvider = oldFactory })
 
-	srv, handler, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
+	srv, handler, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
 		listen: defaultListen, provider: "fake", flyApp: "playground-test",
 		flyTokenFile: flyTokenFile, image: "registry.example/playground:test",
 		staticDir: uiDir, internalPort: 8080, concurrency: 2,
@@ -280,7 +284,7 @@ func TestBuildServerCFAccessGuard(t *testing.T) {
 	}
 	t.Cleanup(func() { newMachineProvider = oldFactory })
 
-	srv, handler, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
+	srv, handler, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
 		listen: defaultListen, provider: "fake", flyApp: "playground-test",
 		flyTokenFile: flyTokenFile, image: "registry.example/playground:test",
 		staticDir: uiDir, internalPort: 8080, concurrency: 2,
@@ -343,7 +347,7 @@ func TestBuildServerTurnstileRejectsMissingToken(t *testing.T) {
 	}
 	t.Cleanup(func() { newMachineProvider = oldFactory })
 
-	srv, handler, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
+	srv, handler, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
 		listen:                defaultListen,
 		provider:              "fake",
 		flyApp:                "playground-test",
@@ -1293,7 +1297,7 @@ func TestWriteDeadlineMiddleware(t *testing.T) {
 		routeStream  = "/api/live/stream"
 		routeMessage = "/api/live/message"
 	)
-	exempt := []string{routeStream, routeMessage}
+	exempt := []string{routeStream, routeMessage, routeSession}
 
 	tests := []struct {
 		name string
@@ -1303,7 +1307,10 @@ func TestWriteDeadlineMiddleware(t *testing.T) {
 		wantExempt bool
 	}{
 		{name: "health_bounded", path: routeHealth, wantExempt: false},
-		{name: "session_bounded", path: routeSession, wantExempt: false},
+		// session-create synchronously boots+proves a cold microVM (can exceed
+		// the 30s deadline); it must be exempt and bounded by vmReadyTimeout
+		// instead, else cold starts fail closed mid-response (PU02 / 502).
+		{name: "session_exempt_cold_start_boot", path: routeSession, wantExempt: true},
 		{name: "stream_exempt", path: routeStream, wantExempt: true},
 		{name: "message_exempt_held_open_for_turn", path: routeMessage, wantExempt: true},
 	}

--- a/cmd/pipelock-playground-llm-agent/main.go
+++ b/cmd/pipelock-playground-llm-agent/main.go
@@ -71,13 +71,17 @@ const defaultActor = "lab-agent"
 // demo is a multi-step chat, so the agent must remember what it already explored
 // to handle "and then..." / "continue" without re-discovering from scratch; the
 // budget keeps that rich memory bounded in cost and context size. The oldest
-// whole turns are dropped when it overflows.
-const liveHistoryTokens = 16000
+// whole turns are dropped when it overflows. Sized well under the model's context
+// window (deepseek-chat is 64k) but large enough that a normal multi-prompt demo
+// session with verbose tool dumps (filesystem searches, config bodies, base64
+// blobs) does NOT drop earlier turns mid-conversation and "forget" what the
+// visitor asked. 16k was too small: a few exfil-technique turns overflowed it.
+const liveHistoryTokens = 40000
 
 // liveHistoryTurns is a secondary safety cap on the number of turns retained, a
 // backstop against a long run of tiny turns. The token budget is the real
 // limiter for normal tool-laden turns.
-const liveHistoryTurns = 12
+const liveHistoryTurns = 24
 
 type config struct {
 	modelBaseURL   string

--- a/cmd/pipelock-playground-llm-agent/main.go
+++ b/cmd/pipelock-playground-llm-agent/main.go
@@ -65,23 +65,24 @@ const maxInputLine = 16 << 10 // 16 KiB
 // to, so the proxy records this subprocess's requests as the lab agent.
 const defaultActor = "lab-agent"
 
-// liveHistoryTokens is the PRIMARY bound on the live chat agent's persistent
-// working conversation: an approximate token budget for the full carried context
-// (visitor messages + the agent's tool calls and tool results + replies). The
-// demo is a multi-step chat, so the agent must remember what it already explored
-// to handle "and then..." / "continue" without re-discovering from scratch; the
-// budget keeps that rich memory bounded in cost and context size. The oldest
-// whole turns are dropped when it overflows. Sized well under the model's context
-// window (deepseek-chat is 64k) but large enough that a normal multi-prompt demo
-// session with verbose tool dumps (filesystem searches, config bodies, base64
-// blobs) does NOT drop earlier turns mid-conversation and "forget" what the
-// visitor asked. 16k was too small: a few exfil-technique turns overflowed it.
+// liveHistoryTokens is the high-water retained-history budget for known
+// 64k-context demo models. Smaller or unknown models get lower caps from
+// liveHistoryCaps so persisted history leaves room for the system prompt, current
+// turn, tool transcripts, and response headroom.
 const liveHistoryTokens = 40000
 
 // liveHistoryTurns is a secondary safety cap on the number of turns retained, a
 // backstop against a long run of tiny turns. The token budget is the real
 // limiter for normal tool-laden turns.
 const liveHistoryTurns = 24
+
+const (
+	minLiveHistoryTokens          = 4000
+	defaultModelContextTokens     = 16384
+	liveHistoryReservedHeadroom   = 8192
+	deepSeekChatContextTokens     = 64000
+	deepSeekReasonerContextTokens = 64000
+)
 
 type config struct {
 	modelBaseURL   string
@@ -279,6 +280,7 @@ func buildAgent(cfg config, apiKey string, emit func(llmagent.Event)) (*llmagent
 		SecretValues:   cfg.secretValues,
 		BlockedHosts:   []string{modelHost},
 	})
+	historyTokens, historyTurns := liveHistoryCaps(cfg.model)
 	mc := llmagent.ModelConfig{
 		BaseURL: cfg.modelBaseURL,
 		Model:   cfg.model,
@@ -296,11 +298,41 @@ func buildAgent(cfg config, apiKey string, emit func(llmagent.Event)) (*llmagent
 		// still told nothing about secrets, collectors, or guardrails.
 		SystemPrompt:     buildSystemPrompt(cfg.safeURL),
 		MaxSteps:         cfg.maxSteps,
-		MaxHistoryTurns:  liveHistoryTurns,
-		MaxHistoryTokens: liveHistoryTokens,
+		MaxHistoryTurns:  historyTurns,
+		MaxHistoryTokens: historyTokens,
 		Timeout:          cfg.timeout,
 	}
 	return llmagent.New(mc, client, tools, emit), nil
+}
+
+func liveHistoryCaps(model string) (tokens int, turns int) {
+	contextTokens := modelContextTokens(model)
+	tokens = contextTokens - liveHistoryReservedHeadroom
+	if tokens < minLiveHistoryTokens {
+		tokens = minLiveHistoryTokens
+	}
+	if tokens > liveHistoryTokens {
+		tokens = liveHistoryTokens
+	}
+	turns = liveHistoryTurns
+	if tokens < liveHistoryTokens {
+		turns = liveHistoryTurns / 2
+	}
+	if turns < 1 {
+		turns = 1
+	}
+	return tokens, turns
+}
+
+func modelContextTokens(model string) int {
+	switch strings.ToLower(strings.TrimSpace(model)) {
+	case "deepseek-chat":
+		return deepSeekChatContextTokens
+	case "deepseek-reasoner":
+		return deepSeekReasonerContextTokens
+	default:
+		return defaultModelContextTokens
+	}
 }
 
 // buildSystemPrompt returns the default agent framing, plus a hint that the lab

--- a/cmd/pipelock-playground-llm-agent/main_test.go
+++ b/cmd/pipelock-playground-llm-agent/main_test.go
@@ -231,6 +231,30 @@ func TestBuildAgent_NoExecOmitsRunCommand(t *testing.T) {
 	}
 }
 
+func TestLiveHistoryCapsAreModelAware(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		model      string
+		wantTokens int
+		wantTurns  int
+	}{
+		{name: "deepseek_chat", model: "deepseek-chat", wantTokens: liveHistoryTokens, wantTurns: liveHistoryTurns},
+		{name: "deepseek_reasoner_case_trimmed", model: " DeepSeek-Reasoner ", wantTokens: liveHistoryTokens, wantTurns: liveHistoryTurns},
+		{name: "unknown_model_uses_default_context", model: "small-model", wantTokens: 8192, wantTurns: liveHistoryTurns / 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotTokens, gotTurns := liveHistoryCaps(tt.model)
+			if gotTokens != tt.wantTokens || gotTurns != tt.wantTurns {
+				t.Fatalf("liveHistoryCaps(%q) = (%d, %d), want (%d, %d)", tt.model, gotTokens, gotTurns, tt.wantTokens, tt.wantTurns)
+			}
+		})
+	}
+}
+
 func TestBuildClient(t *testing.T) {
 	c, err := buildClient("http://127.0.0.1:8888", 0, "")
 	if err != nil {

--- a/cmd/pipelock-playground-toyagent/main.go
+++ b/cmd/pipelock-playground-toyagent/main.go
@@ -218,7 +218,20 @@ func runLocalProbe(ctx context.Context, out, errOut io.Writer, targetsCSV string
 
 	_, _ = fmt.Fprintf(errOut, "[agent] probing %d local escape target(s) from this uid\n", len(targets))
 
-	results := probeConcurrent(ctx, targets, playground.ProbeLocalEscape)
+	// Local escape probes run SEQUENTIALLY, NOT via probeConcurrent. Unlike the
+	// direct-egress dials (pure, independent), at least one local probe
+	// (cap:userns-mount) is order-dependent: it can permanently mutate the
+	// probing OS thread's namespace/mount state, so it is designed to run last
+	// and in isolation. Running local probes concurrently would let that
+	// mutation change the execution environment while other local probes are
+	// still in flight, corrupting the proof. The local suite is also fast (most
+	// targets fail closed immediately: missing socket / denied), so it was never
+	// the slow part — the ~12s was the egress DROP-timeout waits, which
+	// runProbe parallelizes safely.
+	results := make([]playground.ProbeResult, 0, len(targets))
+	for _, t := range targets {
+		results = append(results, playground.ProbeLocalEscape(ctx, t))
+	}
 
 	enc := json.NewEncoder(out)
 	if err := enc.Encode(results); err != nil {

--- a/cmd/pipelock-playground-toyagent/main.go
+++ b/cmd/pipelock-playground-toyagent/main.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -165,16 +166,40 @@ func runProbe(ctx context.Context, out, errOut io.Writer, targetsCSV string) err
 
 	_, _ = fmt.Fprintf(errOut, "[agent] probing %d direct-egress target(s) from this network position\n", len(targets))
 
-	results := make([]playground.ProbeResult, 0, len(targets))
-	for _, t := range targets {
-		results = append(results, playground.ProbeDirectEgress(ctx, t))
-	}
+	results := probeConcurrent(ctx, targets, playground.ProbeDirectEgress)
 
 	enc := json.NewEncoder(out)
 	if err := enc.Encode(results); err != nil {
 		return fmt.Errorf("encode probe results: %w", err)
 	}
 	return nil
+}
+
+// probeConcurrent runs probe(ctx, target) for every target concurrently and
+// returns the results in the SAME ORDER as targets. Order matters: the
+// orchestrator's decodeProbeResults validates each result against the target at
+// the same index, and the differential containment proof relies on positional
+// alignment (control target first, then the suite). Each goroutine writes only
+// its own results[i], so there is no shared-state race.
+//
+// The probes are independent pure TCP/unix dials, each bounded by the same short
+// per-target timeout. Running them concurrently changes ONLY wall-clock: a suite
+// of DROP'd targets that each wait the full dial timeout completes in ~one
+// timeout instead of len(targets)*timeout sequentially. This is what keeps the
+// fail-closed containment proof off the critical path of session start; it does
+// not change which targets are probed or the pass/fail decision over them.
+func probeConcurrent(ctx context.Context, targets []string, probe func(context.Context, string) playground.ProbeResult) []playground.ProbeResult {
+	results := make([]playground.ProbeResult, len(targets))
+	var wg sync.WaitGroup
+	wg.Add(len(targets))
+	for i, t := range targets {
+		go func(i int, t string) {
+			defer wg.Done()
+			results[i] = probe(ctx, t)
+		}(i, t)
+	}
+	wg.Wait()
+	return results
 }
 
 // runLocalProbe performs local non-network escape probes and writes a JSON array
@@ -193,10 +218,7 @@ func runLocalProbe(ctx context.Context, out, errOut io.Writer, targetsCSV string
 
 	_, _ = fmt.Fprintf(errOut, "[agent] probing %d local escape target(s) from this uid\n", len(targets))
 
-	results := make([]playground.ProbeResult, 0, len(targets))
-	for _, t := range targets {
-		results = append(results, playground.ProbeLocalEscape(ctx, t))
-	}
+	results := probeConcurrent(ctx, targets, playground.ProbeLocalEscape)
 
 	enc := json.NewEncoder(out)
 	if err := enc.Encode(results); err != nil {

--- a/cmd/pipelock-playground-toyagent/probe_test.go
+++ b/cmd/pipelock-playground-toyagent/probe_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net"
 	"strings"
@@ -12,6 +13,42 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/playground"
 )
+
+// TestProbeConcurrent_PreservesOrderUnderOutOfOrderCompletion proves the
+// containment proof's parallelization keeps results positionally aligned with
+// targets even when probes COMPLETE out of order. Order is load-bearing:
+// decodeProbeResults validates result[i] against target[i], and the differential
+// proof relies on the control target being first. The probe for target 0 is
+// gated to finish only after the last target has started, so completion order is
+// the reverse of index order; the test fails if probeConcurrent returned results
+// in completion order instead of target order. Runs under -race to catch any
+// shared-state bug in the per-index writes.
+func TestProbeConcurrent_PreservesOrderUnderOutOfOrderCompletion(t *testing.T) {
+	t.Parallel()
+	targets := []string{"t0", "t1", "t2", "t3", "t4"}
+	gate := make(chan struct{})
+	probe := func(_ context.Context, target string) playground.ProbeResult {
+		switch target {
+		case "t4":
+			close(gate) // release t0 only once the last target has started
+		case "t0":
+			<-gate // forced to complete after t4
+		}
+		return playground.ProbeResult{Target: target, Open: target == "t2"}
+	}
+	results := probeConcurrent(context.Background(), targets, probe)
+	if len(results) != len(targets) {
+		t.Fatalf("got %d results, want %d", len(results), len(targets))
+	}
+	for i, tg := range targets {
+		if results[i].Target != tg {
+			t.Fatalf("results[%d].Target = %q, want %q (order not preserved across out-of-order completion)", i, results[i].Target, tg)
+		}
+	}
+	if !results[2].Open {
+		t.Fatalf("results[2] (t2) Open = false, want true (result content misaligned with index)")
+	}
+}
 
 func TestRunProbe_OpenAndRefused(t *testing.T) {
 	t.Parallel()

--- a/cmd/pipelock-verifier/main.go
+++ b/cmd/pipelock-verifier/main.go
@@ -20,6 +20,10 @@
 //	                    or a session directory).
 //	evidence PATH       Alias for chain.
 //	receipt PATH        Verify a single v1 or v2 receipt JSON file.
+//	verify-run RUNDIR   Verify a playground demo run directory against the
+//	                    full offline trust chain (launch manifest, audit
+//	                    packet, witnesses, red-case calibration, and
+//	                    host-containment).
 //
 // All subcommands accept --key (raw hex, public-key text, or file path) for
 // trusted verification, and --json for machine-readable output. Exit codes:
@@ -68,6 +72,7 @@ CI runner, an auditor's laptop, or an isolated environment.`,
 	root.AddCommand(newReceiptCmd())
 	root.AddCommand(newReplayCmd())
 	root.AddCommand(newAARPCmd())
+	root.AddCommand(newVerifyRunCmd())
 
 	return root
 }

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -852,6 +852,24 @@ func TestReceipt_V1WithoutKeyIsNotProvenance(t *testing.T) {
 	}
 }
 
+func TestVerifyRunJSONFailureExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, code := runRoot(t, "verify-run", "--json", t.TempDir())
+	if code == cliutil.ExitOK {
+		t.Fatalf("verify-run --json on malformed run dir exited 0, stdout=%q", stdout)
+	}
+	var rpt struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &rpt); err != nil {
+		t.Fatalf("verify-run --json output is not parseable JSON: %v\nstdout=%s", err, stdout)
+	}
+	if rpt.OK {
+		t.Fatalf("verify-run report ok=true for malformed run dir: %s", stdout)
+	}
+}
+
 func TestReceipt_V1AllowUnpinned(t *testing.T) {
 	t.Parallel()
 	fix := newFixture(t, 1)

--- a/cmd/pipelock-verifier/verifyrun.go
+++ b/cmd/pipelock-verifier/verifyrun.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+func newVerifyRunCmd() *cobra.Command {
+	var (
+		orchKey  string
+		jsonMode bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "verify-run RUNDIR",
+		Short: "Verify a playground demo run directory (full offline trust chain)",
+		Long: `Performs all-or-nothing offline verification of a playground demo run
+directory. The trust root is the single --orchestrator-key (defaults to the
+published Pipelock Playground key); all other keys (pipelock, collector) are
+taken from the verified manifest, NOT trusted blindly.
+
+The full chain checks:
+  1. Launch manifest signature under the orchestrator key.
+  2. Audit Packet (receipt chain + totals) under the manifest's pipelock key.
+  3. Collector witness signature under the manifest's collector key.
+  4. Witness binds the run (nonce + manifest hash).
+  5. Red-case calibration is present and genuine.
+  6. Live demo semantic receipts are present.
+  7. Host-containment witness (contained runs only).
+
+Exit code 0 = every check passed. Non-zero = at least one check failed.`,
+		Args: exactOneArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rep, err := playground.VerifyRun(args[0], orchKey)
+			if err != nil {
+				return err
+			}
+
+			w := cmd.OutOrStdout()
+
+			if jsonMode {
+				enc := json.NewEncoder(w)
+				enc.SetIndent("", "  ")
+				return enc.Encode(rep)
+			}
+
+			for _, c := range rep.Checks {
+				label := "PASS"
+				if !c.OK {
+					label = "FAIL"
+				}
+				_, _ = fmt.Fprintf(w, "[%s] %s", label, c.Name)
+				if c.Reason != "" {
+					_, _ = fmt.Fprintf(w, " -- %s", c.Reason)
+				}
+				_, _ = fmt.Fprintln(w)
+			}
+			_, _ = fmt.Fprintln(w)
+			if rep.OK {
+				_, _ = fmt.Fprintf(w, "result: VALID  run_nonce=%s observed=%d\n", rep.RunNonce, rep.ObservedCount)
+				return nil
+			}
+			return cliutil.ExitCodeError(1, fmt.Errorf("VERIFY FAILED: one or more checks did not pass"))
+		},
+	}
+	cmd.Flags().StringVar(&orchKey, "orchestrator-key", playground.PublishedOrchestratorPubKeyHex, "hex-encoded orchestrator Ed25519 public key (trust root)")
+	cmd.Flags().BoolVar(&jsonMode, "json", false, "emit machine-readable JSON output")
+	return cmd
+}

--- a/cmd/pipelock-verifier/verifyrun.go
+++ b/cmd/pipelock-verifier/verifyrun.go
@@ -50,7 +50,7 @@ Exit code 0 = every check passed. Non-zero = at least one check failed.`,
 				enc := json.NewEncoder(w)
 				enc.SetIndent("", "  ")
 				if err := enc.Encode(rep); err != nil {
-					return err
+					return fmt.Errorf("encode verify-run JSON report: %w", err)
 				}
 				if !rep.OK {
 					return cliutil.ExitCodeError(1, fmt.Errorf("VERIFY FAILED: one or more checks did not pass"))

--- a/cmd/pipelock-verifier/verifyrun.go
+++ b/cmd/pipelock-verifier/verifyrun.go
@@ -49,7 +49,13 @@ Exit code 0 = every check passed. Non-zero = at least one check failed.`,
 			if jsonMode {
 				enc := json.NewEncoder(w)
 				enc.SetIndent("", "  ")
-				return enc.Encode(rep)
+				if err := enc.Encode(rep); err != nil {
+					return err
+				}
+				if !rep.OK {
+					return cliutil.ExitCodeError(1, fmt.Errorf("VERIFY FAILED: one or more checks did not pass"))
+				}
+				return nil
 			}
 
 			for _, c := range rep.Checks {

--- a/deploy/fly-playground/Dockerfile.broker
+++ b/deploy/fly-playground/Dockerfile.broker
@@ -9,8 +9,15 @@
 # holds the Fly token + gate secret (delivered as Fly secrets/env), never an
 # agent secret beyond passing a per-session model key through to a leased VM.
 #
-# Build from the REPO ROOT:
-#   docker build -f deploy/fly-playground/Dockerfile.broker -t pipelock-playground-broker .
+# The broker serves the static playground viewer at / (via --static-dir /srv/ui).
+# That viewer lives in the public site repo, not here, so it is supplied as a
+# BuildKit named build context ("ui") instead of being vendored into this repo —
+# keeping the image build reproducible without copying the site into pipelock.
+#
+# Build from the REPO ROOT (see deploy/fly-playground/build-images.sh):
+#   docker build -f deploy/fly-playground/Dockerfile.broker \
+#     --build-context ui=<site-repo>/static/playground/demo \
+#     -t pipelock-playground-broker .
 
 ARG GO_VERSION=1.26
 
@@ -25,6 +32,10 @@ RUN go build -trimpath -ldflags "-s -w" -o /out/pipelock-playground-broker ./cmd
 
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
 COPY --from=build /out/pipelock-playground-broker /usr/local/bin/pipelock-playground-broker
+# Bundle the static playground viewer at /srv/ui (served at / via --static-dir).
+# Supplied by the "ui" named build context (see header). Without this the broker
+# serves an empty UI; bundling it here is the single source of the served viewer.
+COPY --from=ui . /srv/ui
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/pipelock-playground-broker"]
 CMD ["serve"]

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -39,6 +39,20 @@ cd "${REPO_ROOT}"
 echo "[build-images] building VM image ${VM_TAG}"
 docker build -f deploy/fly-playground/Dockerfile -t "${VM_TAG}" .
 
+# The viewer's inline "Verify in your browser" button loads a WASM build of the
+# shipped verifier from the served dir. Build it straight into PLAYGROUND_UI_DIR
+# so the broker bundles it into /srv/ui. The .wasm is gitignored in the site repo
+# (built here at image time, never committed). Requires deploy/wasm-verify/build.sh
+# + cmd/pipelock-verifier-wasm (the WASM-verifier change); if absent, the broker
+# still builds, just without the inline-verify button (the download-kit path is
+# unaffected). go (with the js/wasm target) must be on PATH.
+if [ -x deploy/wasm-verify/build.sh ]; then
+	echo "[build-images] building browser-verifier WASM into ${PLAYGROUND_UI_DIR}"
+	deploy/wasm-verify/build.sh "${PLAYGROUND_UI_DIR}"
+else
+	echo "[build-images] WARNING: deploy/wasm-verify/build.sh absent; broker will ship without the inline browser-verify button (download-kit path still works)" >&2
+fi
+
 echo "[build-images] building broker image ${BROKER_TAG} (viewer from ${PLAYGROUND_UI_DIR})"
 docker build -f deploy/fly-playground/Dockerfile.broker \
 	--build-context "ui=${PLAYGROUND_UI_DIR}" \

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -43,14 +43,19 @@ docker build -f deploy/fly-playground/Dockerfile -t "${VM_TAG}" .
 # shipped verifier from the served dir. Build it straight into PLAYGROUND_UI_DIR
 # so the broker bundles it into /srv/ui. The .wasm is gitignored in the site repo
 # (built here at image time, never committed). Requires deploy/wasm-verify/build.sh
-# + cmd/pipelock-verifier-wasm (the WASM-verifier change); if absent, the broker
-# still builds, just without the inline-verify button (the download-kit path is
-# unaffected). go (with the js/wasm target) must be on PATH.
-if [ -x deploy/wasm-verify/build.sh ]; then
-	echo "[build-images] building browser-verifier WASM into ${PLAYGROUND_UI_DIR}"
-	deploy/wasm-verify/build.sh "${PLAYGROUND_UI_DIR}"
-else
-	echo "[build-images] WARNING: deploy/wasm-verify/build.sh absent; broker will ship without the inline browser-verify button (download-kit path still works)" >&2
+# + cmd/pipelock-verifier-wasm (the WASM-verifier change). Fail closed if that
+# build path is absent or produces no .wasm, so the image cannot silently ship a
+# viewer whose inline-verify button points at missing browser-verifier assets.
+# go (with the js/wasm target) must be on PATH.
+if [ ! -x deploy/wasm-verify/build.sh ]; then
+	echo "[build-images] ERROR: deploy/wasm-verify/build.sh absent; refusing to build a broker with potentially stale inline browser-verify UI" >&2
+	exit 1
+fi
+echo "[build-images] building browser-verifier WASM into ${PLAYGROUND_UI_DIR}"
+deploy/wasm-verify/build.sh "${PLAYGROUND_UI_DIR}"
+if ! find "${PLAYGROUND_UI_DIR}" -type f -name '*.wasm' -print -quit | grep -q .; then
+	echo "[build-images] ERROR: browser-verifier build produced no .wasm under PLAYGROUND_UI_DIR=${PLAYGROUND_UI_DIR}; refusing to ship unwired inline verify UI" >&2
+	exit 1
 fi
 
 echo "[build-images] building broker image ${BROKER_TAG} (viewer from ${PLAYGROUND_UI_DIR})"

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -52,8 +52,10 @@ if [ ! -x deploy/wasm-verify/build.sh ]; then
 	exit 1
 fi
 echo "[build-images] building browser-verifier WASM into ${PLAYGROUND_UI_DIR}"
+wasm_stamp="$(mktemp)"
+trap 'rm -f "${wasm_stamp}"' EXIT
 deploy/wasm-verify/build.sh "${PLAYGROUND_UI_DIR}"
-if ! find "${PLAYGROUND_UI_DIR}" -type f -name '*.wasm' -print -quit | grep -q .; then
+if ! find "${PLAYGROUND_UI_DIR}" -type f -name '*.wasm' -newer "${wasm_stamp}" -print -quit | grep -q .; then
 	echo "[build-images] ERROR: browser-verifier build produced no .wasm under PLAYGROUND_UI_DIR=${PLAYGROUND_UI_DIR}; refusing to ship unwired inline verify UI" >&2
 	exit 1
 fi

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright 2026 Josh Waldrep
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build (and optionally push) the playground VM + broker images.
+#
+# The broker bundles the static playground viewer at /srv/ui via a BuildKit
+# named build context, so the viewer lives in the site repo (not vendored here)
+# while the build stays reproducible. This script is the single source of the
+# image build recipe — keep deploys going through it rather than ad-hoc
+# `docker build` invocations whose flags then drift out of version control.
+#
+# Required env:
+#   PLAYGROUND_REGISTRY  registry/app prefix, e.g. registry.fly.io/<fly-app>
+#   PLAYGROUND_UI_DIR    path to the site's static/playground/demo directory
+# Optional env:
+#   PLAYGROUND_PUSH=1    also `docker push` both images after building
+#
+# Example:
+#   PLAYGROUND_REGISTRY=registry.fly.io/<app> \
+#   PLAYGROUND_UI_DIR=/path/to/site/static/playground/demo \
+#   PLAYGROUND_PUSH=1 deploy/fly-playground/build-images.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+: "${PLAYGROUND_REGISTRY:?set PLAYGROUND_REGISTRY, e.g. registry.fly.io/<fly-app>}"
+: "${PLAYGROUND_UI_DIR:?set PLAYGROUND_UI_DIR to the site static/playground/demo dir}"
+
+if [ ! -f "${PLAYGROUND_UI_DIR}/index.html" ]; then
+	echo "PLAYGROUND_UI_DIR=${PLAYGROUND_UI_DIR} has no index.html; refusing to build a broker with an empty viewer" >&2
+	exit 1
+fi
+
+VM_TAG="${PLAYGROUND_REGISTRY}:vm"
+BROKER_TAG="${PLAYGROUND_REGISTRY}:broker"
+
+cd "${REPO_ROOT}"
+
+echo "[build-images] building VM image ${VM_TAG}"
+docker build -f deploy/fly-playground/Dockerfile -t "${VM_TAG}" .
+
+echo "[build-images] building broker image ${BROKER_TAG} (viewer from ${PLAYGROUND_UI_DIR})"
+docker build -f deploy/fly-playground/Dockerfile.broker \
+	--build-context "ui=${PLAYGROUND_UI_DIR}" \
+	-t "${BROKER_TAG}" .
+
+if [ "${PLAYGROUND_PUSH:-}" = "1" ]; then
+	echo "[build-images] pushing ${VM_TAG}"
+	docker push "${VM_TAG}"
+	echo "[build-images] pushing ${BROKER_TAG}"
+	docker push "${BROKER_TAG}"
+fi
+
+echo "[build-images] done"

--- a/internal/playground/broker/flymachines.go
+++ b/internal/playground/broker/flymachines.go
@@ -21,6 +21,14 @@ import (
 // in tests (httptest server).
 const defaultFlyBaseURL = "https://api.machines.dev/v1"
 
+// playgroundRoleKey and playgroundRoleVal are the metadata tag set on every
+// per-visitor VM so the orphan reaper can distinguish them from the broker's own
+// machine and unrelated infra. ListManagedMachines filters on this tag.
+const (
+	playgroundRoleKey = "pipelock_role"
+	playgroundRoleVal = "playground-vm"
+)
+
 // defaultWaitTimeout bounds a single WaitReady call's server-side wait.
 const defaultWaitTimeout = 60 * time.Second
 
@@ -68,6 +76,7 @@ type flyMachineConfig struct {
 	Guest       flyGuest          `json:"guest"`
 	AutoDestroy bool              `json:"auto_destroy"`
 	Restart     flyRestart        `json:"restart"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 type flyCreateRequest struct {
@@ -132,6 +141,9 @@ func (f *FlyMachines) CreateMachine(ctx context.Context, spec MachineSpec) (*Mac
 			// never restart it. The broker also force-destroys explicitly.
 			AutoDestroy: true,
 			Restart:     flyRestart{Policy: "no"},
+			// Tag the VM so the orphan reaper can distinguish per-visitor VMs
+			// from the broker's own machine and unrelated infra.
+			Metadata: map[string]string{playgroundRoleKey: playgroundRoleVal},
 		},
 		Region: spec.Region,
 	}
@@ -191,6 +203,49 @@ func (f *FlyMachines) DestroyMachine(ctx context.Context, id string) error {
 		return err
 	}
 	return nil
+}
+
+// flyListMachine mirrors the Fly Machines API list-machines response fields that
+// the broker reads. Only the fields needed for orphan reaping are modeled.
+type flyListMachine struct {
+	ID        string `json:"id"`
+	State     string `json:"state"`
+	CreatedAt string `json:"created_at"`
+	Config    struct {
+		Metadata map[string]string `json:"metadata"`
+	} `json:"config"`
+}
+
+// ListManagedMachines returns only per-visitor VMs (those tagged with
+// pipelock_role == playground-vm). The broker's own machine and unrelated infra
+// are excluded. A machine whose created_at is missing or unparseable gets a zero
+// CreatedAt (the reaper treats zero as "unknown age, spare it").
+func (f *FlyMachines) ListManagedMachines(ctx context.Context) ([]Machine, error) {
+	if err := f.validate(); err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/apps/%s/machines", url.PathEscape(f.AppName))
+	respBody, err := f.do(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var raw []flyListMachine
+	if uerr := json.Unmarshal(respBody, &raw); uerr != nil {
+		return nil, fmt.Errorf("fly: parse list machines response: %w", uerr)
+	}
+	var managed []Machine
+	for _, m := range raw {
+		if m.Config.Metadata[playgroundRoleKey] != playgroundRoleVal {
+			continue
+		}
+		created, _ := time.Parse(time.RFC3339, m.CreatedAt)
+		managed = append(managed, Machine{
+			ID:        m.ID,
+			State:     m.State,
+			CreatedAt: created,
+		})
+	}
+	return managed, nil
 }
 
 func (f *FlyMachines) validate() error {

--- a/internal/playground/broker/flymachines.go
+++ b/internal/playground/broker/flymachines.go
@@ -36,6 +36,11 @@ const defaultWaitTimeout = 60 * time.Second
 // misbehaving/huge response cannot exhaust broker memory.
 const flyMaxBodyBytes = 1 << 20 // 1 MiB
 
+// flyRequestIDHeader is the Fly API response header that carries a per-request
+// trace identifier. Including it in error messages lets operators debug failures
+// with Fly support without exposing potentially secret response-body content.
+const flyRequestIDHeader = "Fly-Request-Id"
+
 // FlyMachines is the Fly Machines API adapter for MachineProvider. It leases one
 // ephemeral, internal-only Firecracker microVM per visitor: the machine has no
 // public service (the broker reaches it over the app's private 6PN network on
@@ -259,16 +264,22 @@ func (f *FlyMachines) validate() error {
 }
 
 // apiError carries a non-2xx Fly API response for typed handling (e.g. 404 on
-// destroy). The body is truncated and must never be assumed secret-free in logs.
+// destroy is status-based). The response body is deliberately excluded: Fly
+// error responses can echo back parts of the submitted request, which may
+// contain VM environment secrets (model API keys, invite codes, etc.). Only
+// non-sensitive diagnostics (status, method, path, request ID) are surfaced.
 type apiError struct {
-	status int
-	method string
-	path   string
-	body   string
+	status    int
+	method    string
+	path      string
+	requestID string // Fly-Request-Id header for operator debugging
 }
 
 func (e *apiError) Error() string {
-	return fmt.Sprintf("fly: %s %s: HTTP %d: %s", e.method, e.path, e.status, e.body)
+	if e.requestID != "" {
+		return fmt.Sprintf("fly: %s %s: HTTP %d (request-id: %s)", e.method, e.path, e.status, e.requestID)
+	}
+	return fmt.Sprintf("fly: %s %s: HTTP %d", e.method, e.path, e.status)
 }
 
 // do performs a Fly API request and returns the response body for 2xx, or an
@@ -309,7 +320,12 @@ func (f *FlyMachines) do(ctx context.Context, method, path string, query url.Val
 		return nil, fmt.Errorf("fly: read %s %s response: %w", method, path, err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &apiError{status: resp.StatusCode, method: method, path: path, body: strings.TrimSpace(string(respBody))}
+		return nil, &apiError{
+			status:    resp.StatusCode,
+			method:    method,
+			path:      path,
+			requestID: resp.Header.Get(flyRequestIDHeader),
+		}
 	}
 	return respBody, nil
 }

--- a/internal/playground/broker/flymachines.go
+++ b/internal/playground/broker/flymachines.go
@@ -221,6 +221,14 @@ type flyListMachine struct {
 	} `json:"config"`
 }
 
+type flyListMachinesPage struct {
+	Machines         []flyListMachine `json:"machines"`
+	NextCursor       string           `json:"next_cursor"`
+	ResponseMetadata struct {
+		NextCursor string `json:"next_cursor"`
+	} `json:"response_metadata"`
+}
+
 // ListManagedMachines returns only per-visitor VMs (those tagged with
 // pipelock_role == playground-vm). The broker's own machine and unrelated infra
 // are excluded. A machine whose created_at is missing or unparseable gets a zero
@@ -230,13 +238,22 @@ func (f *FlyMachines) ListManagedMachines(ctx context.Context) ([]Machine, error
 		return nil, err
 	}
 	path := fmt.Sprintf("/apps/%s/machines", url.PathEscape(f.AppName))
-	respBody, err := f.do(ctx, http.MethodGet, path, nil, nil)
-	if err != nil {
-		return nil, err
-	}
+	query := url.Values{"summary": []string{"true"}, "limit": []string{"200"}}
 	var raw []flyListMachine
-	if uerr := json.Unmarshal(respBody, &raw); uerr != nil {
-		return nil, fmt.Errorf("fly: parse list machines response: %w", uerr)
+	for {
+		respBody, err := f.do(ctx, http.MethodGet, path, query, nil)
+		if err != nil {
+			return nil, err
+		}
+		page, next, err := parseFlyListMachines(respBody)
+		if err != nil {
+			return nil, err
+		}
+		raw = append(raw, page...)
+		if next == "" {
+			break
+		}
+		query.Set("cursor", next)
 	}
 	var managed []Machine
 	for _, m := range raw {
@@ -251,6 +268,22 @@ func (f *FlyMachines) ListManagedMachines(ctx context.Context) ([]Machine, error
 		})
 	}
 	return managed, nil
+}
+
+func parseFlyListMachines(respBody []byte) ([]flyListMachine, string, error) {
+	var raw []flyListMachine
+	if err := json.Unmarshal(respBody, &raw); err == nil {
+		return raw, "", nil
+	}
+	var page flyListMachinesPage
+	if err := json.Unmarshal(respBody, &page); err != nil {
+		return nil, "", fmt.Errorf("fly: parse list machines response: %w", err)
+	}
+	next := strings.TrimSpace(page.NextCursor)
+	if next == "" {
+		next = strings.TrimSpace(page.ResponseMetadata.NextCursor)
+	}
+	return page.Machines, next, nil
 }
 
 func (f *FlyMachines) validate() error {

--- a/internal/playground/broker/flymachines_test.go
+++ b/internal/playground/broker/flymachines_test.go
@@ -194,7 +194,9 @@ func TestFlyDestroyMachineIdempotentOn404(t *testing.T) {
 }
 
 func TestFlyNon2xxIsAPIError(t *testing.T) {
+	const fakeRequestID = "req-abc123"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(flyRequestIDHeader, fakeRequestID)
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		_, _ = w.Write([]byte(`{"error":"bad config"}`))
 	}))
@@ -212,8 +214,99 @@ func TestFlyNon2xxIsAPIError(t *testing.T) {
 	if apiErr.status != http.StatusUnprocessableEntity {
 		t.Errorf("status = %d", apiErr.status)
 	}
-	if !strings.Contains(err.Error(), "bad config") {
-		t.Errorf("error should carry body: %v", err)
+	errStr := err.Error()
+	// Error must include status code and path (non-sensitive diagnostics).
+	if !strings.Contains(errStr, "422") {
+		t.Errorf("error should contain HTTP status code: %s", errStr)
+	}
+	if !strings.Contains(errStr, "/apps/playground-pool/machines") {
+		t.Errorf("error should contain request path: %s", errStr)
+	}
+	// Error must include the Fly request ID for operator debugging.
+	if !strings.Contains(errStr, fakeRequestID) {
+		t.Errorf("error should contain Fly-Request-Id: %s", errStr)
+	}
+	// Error must NOT include the response body (may contain echoed secrets).
+	if strings.Contains(errStr, "bad config") {
+		t.Errorf("error must NOT contain response body: %s", errStr)
+	}
+}
+
+func TestFlyAPIErrorOmitsResponseBody(t *testing.T) {
+	// Fly error responses can echo back parts of the submitted request, which
+	// includes VM environment secrets (model API keys, invite codes). Verify
+	// the error string never surfaces the response body. Build the fake
+	// credential at runtime (gosec G101).
+	fakeSecret := "AKIA" + "IOSFODNN7EXAMPLE"
+	const wantRequestID = "req-trace-deadbeef"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(flyRequestIDHeader, wantRequestID)
+		w.WriteHeader(http.StatusBadRequest)
+		// Simulate Fly echoing back env secrets in the error response.
+		_, _ = w.Write([]byte(`{"error":"invalid config","env":{"MODEL_KEY":"` + fakeSecret + `"}}`))
+	}))
+	defer srv.Close()
+
+	fly := newTestFly(srv)
+	_, err := fly.CreateMachine(context.Background(), MachineSpec{Image: "img"})
+	if err == nil {
+		t.Fatal("want error on 400")
+	}
+
+	errStr := err.Error()
+
+	// Must NOT contain the fake secret (response body content).
+	if strings.Contains(errStr, fakeSecret) {
+		t.Fatalf("error string contains response-body secret: %s", errStr)
+	}
+	if strings.Contains(errStr, "invalid config") {
+		t.Fatalf("error string contains response-body text: %s", errStr)
+	}
+
+	// Must contain non-sensitive diagnostics: status, method, path, request-id.
+	if !strings.Contains(errStr, "400") {
+		t.Errorf("error missing HTTP status code: %s", errStr)
+	}
+	if !strings.Contains(errStr, http.MethodPost) {
+		t.Errorf("error missing HTTP method: %s", errStr)
+	}
+	if !strings.Contains(errStr, "/apps/playground-pool/machines") {
+		t.Errorf("error missing request path: %s", errStr)
+	}
+	if !strings.Contains(errStr, wantRequestID) {
+		t.Errorf("error missing Fly-Request-Id: %s", errStr)
+	}
+}
+
+func TestFlyAPIErrorWithoutRequestID(t *testing.T) {
+	// When the Fly API does not return a request ID header, the error should
+	// still be well-formed and contain status/method/path.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`internal error`))
+	}))
+	defer srv.Close()
+
+	fly := newTestFly(srv)
+	err := fly.WaitReady(context.Background(), "some-id")
+	if err == nil {
+		t.Fatal("want error on 500")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, "500") {
+		t.Errorf("error missing status code: %s", errStr)
+	}
+	if !strings.Contains(errStr, "/wait") {
+		t.Errorf("error missing path: %s", errStr)
+	}
+	// Must not contain the response body.
+	if strings.Contains(errStr, "internal error") {
+		t.Errorf("error must not contain response body: %s", errStr)
+	}
+	// Must not contain "request-id" when header is absent.
+	if strings.Contains(errStr, "request-id") {
+		t.Errorf("error should omit request-id field when header is absent: %s", errStr)
 	}
 }
 

--- a/internal/playground/broker/flymachines_test.go
+++ b/internal/playground/broker/flymachines_test.go
@@ -81,6 +81,13 @@ func TestFlyCreateMachine(t *testing.T) {
 	if gotBody.Region != "ord" {
 		t.Errorf("region = %q", gotBody.Region)
 	}
+	// Verify the playground role metadata tag is set.
+	if gotBody.Config.Metadata == nil {
+		t.Fatal("metadata is nil; want playground role tag")
+	}
+	if gotBody.Config.Metadata[playgroundRoleKey] != playgroundRoleVal {
+		t.Errorf("metadata[%s] = %q, want %q", playgroundRoleKey, gotBody.Config.Metadata[playgroundRoleKey], playgroundRoleVal)
+	}
 }
 
 func TestFlyCreateMachineDefaultsGuest(t *testing.T) {
@@ -207,6 +214,85 @@ func TestFlyNon2xxIsAPIError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bad config") {
 		t.Errorf("error should carry body: %v", err)
+	}
+}
+
+func TestFlyListManagedMachines(t *testing.T) {
+	// Return a mix of machines: one tagged, one untagged, one with foreign
+	// metadata. Only the tagged one should appear.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		body := `[
+			{
+				"id": "m-tagged",
+				"state": "started",
+				"created_at": "2026-06-25T10:00:00Z",
+				"config": {"metadata": {"pipelock_role": "playground-vm"}}
+			},
+			{
+				"id": "m-untagged",
+				"state": "started",
+				"created_at": "2026-06-25T10:00:00Z",
+				"config": {}
+			},
+			{
+				"id": "m-foreign",
+				"state": "started",
+				"created_at": "2026-06-25T10:00:00Z",
+				"config": {"metadata": {"pipelock_role": "something-else"}}
+			},
+			{
+				"id": "m-no-metadata",
+				"state": "started",
+				"created_at": "",
+				"config": {"metadata": null}
+			}
+		]`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	fly := newTestFly(srv)
+	machines, err := fly.ListManagedMachines(context.Background())
+	if err != nil {
+		t.Fatalf("ListManagedMachines: %v", err)
+	}
+	if len(machines) != 1 {
+		t.Fatalf("got %d machines, want 1 (only the tagged one)", len(machines))
+	}
+	if machines[0].ID != "m-tagged" {
+		t.Errorf("machine ID = %q, want m-tagged", machines[0].ID)
+	}
+	if machines[0].State != "started" {
+		t.Errorf("state = %q, want started", machines[0].State)
+	}
+	wantCreated := time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC)
+	if !machines[0].CreatedAt.Equal(wantCreated) {
+		t.Errorf("CreatedAt = %v, want %v", machines[0].CreatedAt, wantCreated)
+	}
+}
+
+func TestFlyListManagedMachinesUnparseableCreatedAt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body := `[{"id": "m1", "state": "started", "created_at": "not-a-date", "config": {"metadata": {"pipelock_role": "playground-vm"}}}]`
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	fly := newTestFly(srv)
+	machines, err := fly.ListManagedMachines(context.Background())
+	if err != nil {
+		t.Fatalf("ListManagedMachines: %v", err)
+	}
+	if len(machines) != 1 {
+		t.Fatalf("got %d machines, want 1", len(machines))
+	}
+	if !machines[0].CreatedAt.IsZero() {
+		t.Errorf("CreatedAt should be zero for unparseable date, got %v", machines[0].CreatedAt)
 	}
 }
 

--- a/internal/playground/broker/flymachines_test.go
+++ b/internal/playground/broker/flymachines_test.go
@@ -369,6 +369,59 @@ func TestFlyListManagedMachines(t *testing.T) {
 	}
 }
 
+func TestFlyListManagedMachinesPagedObjectResponse(t *testing.T) {
+	var cursors []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if got := r.URL.Query().Get("summary"); got != "true" {
+			t.Fatalf("summary query = %q, want true", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "200" {
+			t.Fatalf("limit query = %q, want 200", got)
+		}
+		cursor := r.URL.Query().Get("cursor")
+		cursors = append(cursors, cursor)
+		w.Header().Set("Content-Type", "application/json")
+		switch cursor {
+		case "":
+			_, _ = w.Write([]byte(`{
+				"machines": [
+					{"id": "m-page-1", "state": "started", "created_at": "2026-06-25T10:00:00Z", "config": {"metadata": {"pipelock_role": "playground-vm"}}}
+				],
+				"response_metadata": {"next_cursor": "next-page"}
+			}`))
+		case "next-page":
+			_, _ = w.Write([]byte(`{
+				"machines": [
+					{"id": "m-foreign", "state": "started", "created_at": "2026-06-25T10:00:00Z", "config": {"metadata": {"pipelock_role": "other"}}},
+					{"id": "m-page-2", "state": "started", "created_at": "2026-06-25T10:01:00Z", "config": {"metadata": {"pipelock_role": "playground-vm"}}}
+				]
+			}`))
+		default:
+			t.Fatalf("unexpected cursor %q", cursor)
+		}
+	}))
+	defer srv.Close()
+
+	fly := newTestFly(srv)
+	machines, err := fly.ListManagedMachines(context.Background())
+	if err != nil {
+		t.Fatalf("ListManagedMachines: %v", err)
+	}
+	if len(cursors) != 2 || cursors[0] != "" || cursors[1] != "next-page" {
+		t.Fatalf("cursors = %#v, want initial request then next-page", cursors)
+	}
+	if len(machines) != 2 {
+		t.Fatalf("got %d managed machines, want 2", len(machines))
+	}
+	if machines[0].ID != "m-page-1" || machines[1].ID != "m-page-2" {
+		t.Fatalf("machine IDs = %q, %q; want m-page-1, m-page-2", machines[0].ID, machines[1].ID)
+	}
+}
+
 func TestFlyListManagedMachinesUnparseableCreatedAt(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		body := `[{"id": "m1", "state": "started", "created_at": "not-a-date", "config": {"metadata": {"pipelock_role": "playground-vm"}}}]`

--- a/internal/playground/broker/lease.go
+++ b/internal/playground/broker/lease.go
@@ -169,6 +169,28 @@ func (lm *LeaseManager) ActiveLeases() int {
 	return len(lm.leases)
 }
 
+// AdoptWarm registers an already-created warm-pool VM as an active lease for
+// sessionKey, without creating a new machine or acquiring a concurrency slot
+// (the pool already holds the slot and transfers it via release). This is the
+// handout path that skips the cold-start cost.
+func (lm *LeaseManager) AdoptWarm(sessionKey string, machine *Machine, release func()) (*Lease, error) {
+	if sessionKey == "" {
+		return nil, errors.New("broker: empty session key")
+	}
+	if machine == nil {
+		return nil, errors.New("broker: nil machine for AdoptWarm")
+	}
+	lease := &Lease{SessionKey: sessionKey, Machine: machine, release: release}
+	lm.mu.Lock()
+	if _, exists := lm.leases[sessionKey]; exists {
+		lm.mu.Unlock()
+		return nil, ErrDuplicateLease
+	}
+	lm.leases[sessionKey] = lease
+	lm.mu.Unlock()
+	return lease, nil
+}
+
 // ActiveMachineIDs returns a snapshot of machine IDs currently held in active
 // leases. The reaper uses this to distinguish machines that are in use from
 // orphans.

--- a/internal/playground/broker/lease.go
+++ b/internal/playground/broker/lease.go
@@ -169,6 +169,21 @@ func (lm *LeaseManager) ActiveLeases() int {
 	return len(lm.leases)
 }
 
+// ActiveMachineIDs returns a snapshot of machine IDs currently held in active
+// leases. The reaper uses this to distinguish machines that are in use from
+// orphans.
+func (lm *LeaseManager) ActiveMachineIDs() map[string]struct{} {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	ids := make(map[string]struct{}, len(lm.leases))
+	for _, lease := range lm.leases {
+		if lease.Machine != nil {
+			ids[lease.Machine.ID] = struct{}{}
+		}
+	}
+	return ids
+}
+
 // mergeEnv returns base overlaid with over (over wins). Neither input is
 // mutated. A nil result is fine for the provider (no env).
 func mergeEnv(base, over map[string]string) map[string]string {

--- a/internal/playground/broker/lease_test.go
+++ b/internal/playground/broker/lease_test.go
@@ -9,11 +9,13 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
 )
 
-// fakeProvider is an in-memory MachineProvider for testing the lease lifecycle.
+// fakeProvider is an in-memory MachineProvider for testing the lease lifecycle
+// and the orphan reaper.
 type fakeProvider struct {
 	mu         sync.Mutex
 	created    []MachineSpec
@@ -22,6 +24,12 @@ type fakeProvider struct {
 	createErr  error
 	waitErr    error
 	nextID     int
+
+	// managedMachines is the set returned by ListManagedMachines. Tests
+	// populate it directly; CreateMachine also appends here with the
+	// playground role tag so the fake behaves like the real Fly adapter.
+	managedMachines []Machine
+	listErr         error
 }
 
 func (f *fakeProvider) CreateMachine(_ context.Context, spec MachineSpec) (*Machine, error) {
@@ -34,7 +42,9 @@ func (f *fakeProvider) CreateMachine(_ context.Context, spec MachineSpec) (*Mach
 	id := fmt.Sprintf("m%d", f.nextID)
 	f.created = append(f.created, spec)
 	f.createdIDs = append(f.createdIDs, id)
-	return &Machine{ID: id, State: "created", PrivateIP: "fdaa::" + id}, nil
+	m := &Machine{ID: id, State: "created", PrivateIP: "fdaa::" + id, CreatedAt: time.Now()}
+	f.managedMachines = append(f.managedMachines, *m)
+	return m, nil
 }
 
 func (f *fakeProvider) WaitReady(_ context.Context, _ string) error {
@@ -48,6 +58,17 @@ func (f *fakeProvider) DestroyMachine(_ context.Context, id string) error {
 	defer f.mu.Unlock()
 	f.destroyed = append(f.destroyed, id)
 	return nil
+}
+
+func (f *fakeProvider) ListManagedMachines(_ context.Context) ([]Machine, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]Machine, len(f.managedMachines))
+	copy(out, f.managedMachines)
+	return out, nil
 }
 
 func (f *fakeProvider) counts() (created, destroyed int) {
@@ -200,6 +221,48 @@ func TestLeaseDuplicateKey(t *testing.T) {
 	}
 	if created, _ := fp.counts(); created != 1 {
 		t.Errorf("duplicate key created %d machines, want 1", created)
+	}
+}
+
+func TestActiveMachineIDs(t *testing.T) {
+	fp := &fakeProvider{}
+	lm := newManager(t, fp, 3)
+
+	// Empty initially.
+	ids := lm.ActiveMachineIDs()
+	if len(ids) != 0 {
+		t.Fatalf("ActiveMachineIDs on empty manager = %d, want 0", len(ids))
+	}
+
+	// Lease two machines.
+	l1, err := lm.Lease(context.Background(), "s1", nil)
+	if err != nil {
+		t.Fatalf("Lease s1: %v", err)
+	}
+	l2, err := lm.Lease(context.Background(), "s2", nil)
+	if err != nil {
+		t.Fatalf("Lease s2: %v", err)
+	}
+
+	ids = lm.ActiveMachineIDs()
+	if len(ids) != 2 {
+		t.Fatalf("ActiveMachineIDs = %d, want 2", len(ids))
+	}
+	if _, ok := ids[l1.Machine.ID]; !ok {
+		t.Errorf("machine %s not in active set", l1.Machine.ID)
+	}
+	if _, ok := ids[l2.Machine.ID]; !ok {
+		t.Errorf("machine %s not in active set", l2.Machine.ID)
+	}
+
+	// Release one.
+	lm.Release(context.Background(), "s1")
+	ids = lm.ActiveMachineIDs()
+	if len(ids) != 1 {
+		t.Fatalf("ActiveMachineIDs after release = %d, want 1", len(ids))
+	}
+	if _, ok := ids[l2.Machine.ID]; !ok {
+		t.Errorf("machine %s not in active set after releasing s1", l2.Machine.ID)
 	}
 }
 

--- a/internal/playground/broker/pool.go
+++ b/internal/playground/broker/pool.go
@@ -85,6 +85,12 @@ type Pool struct {
 
 	mu      sync.Mutex
 	entries []warmEntry
+	// handoff holds machine IDs popped by Acquire but not yet adopted into an
+	// active lease. They are NO LONGER in entries but NOT YET in
+	// LeaseManager.ActiveMachineIDs, so without tracking them here the reaper
+	// could see them as unowned and destroy them mid-handoff (TOCTOU). They stay
+	// in the reaper's protected set (via WarmMachineIDs) until FinishHandoff.
+	handoff map[string]struct{}
 	closed  bool
 }
 
@@ -128,6 +134,7 @@ func NewPool(cfg PoolConfig) (*Pool, error) {
 		maxWarmAge: maxWarmAge,
 		now:        now,
 		log:        log,
+		handoff:    make(map[string]struct{}),
 	}, nil
 }
 
@@ -148,22 +155,44 @@ func (p *Pool) Acquire() (machine *Machine, vmCode string, release func(), ok bo
 	e := p.entries[0]
 	p.entries[0] = warmEntry{} // clear reference
 	p.entries = p.entries[1:]
+	// Mark the machine as in-flight handoff: it has left entries but is not yet
+	// an active lease. Keep it in the reaper's protected set until FinishHandoff
+	// (called by the caller once AdoptWarm succeeds OR the VM is destroyed on
+	// failure). Closes the reaper TOCTOU window.
+	if e.machine != nil {
+		p.handoff[e.machine.ID] = struct{}{}
+	}
 	return e.machine, e.vmCode, e.release, true
 }
 
-// WarmMachineIDs returns a snapshot of machine IDs currently in the warm pool.
-// Combined with LeaseManager.ActiveMachineIDs, this protects warm VMs from the
-// reaper.
+// FinishHandoff clears an in-flight handoff marker for machineID. The caller
+// invokes it after Acquire once the machine is either adopted into an active
+// lease (now protected by ActiveMachineIDs) or destroyed on adopt failure (no
+// longer exists). Idempotent.
+func (p *Pool) FinishHandoff(machineID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.handoff, machineID)
+}
+
+// WarmMachineIDs returns a snapshot of machine IDs the reaper must protect:
+// every VM currently in the warm pool PLUS every VM in an in-flight handoff
+// (popped by Acquire, not yet an active lease). Combined with
+// LeaseManager.ActiveMachineIDs, this guarantees no broker-owned VM is ever
+// unprotected — including during the Acquire->AdoptWarm window.
 //
-// INVARIANT 2: the reaper MUST NOT destroy warm VMs.
+// INVARIANT 2: the reaper MUST NOT destroy warm or handing-off VMs.
 func (p *Pool) WarmMachineIDs() map[string]struct{} {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	ids := make(map[string]struct{}, len(p.entries))
+	ids := make(map[string]struct{}, len(p.entries)+len(p.handoff))
 	for _, e := range p.entries {
 		if e.machine != nil {
 			ids[e.machine.ID] = struct{}{}
 		}
+	}
+	for id := range p.handoff {
+		ids[id] = struct{}{}
 	}
 	return ids
 }

--- a/internal/playground/broker/pool.go
+++ b/internal/playground/broker/pool.go
@@ -92,6 +92,9 @@ type Pool struct {
 	// in the reaper's protected set (via WarmMachineIDs) until FinishHandoff.
 	handoff map[string]struct{}
 	closed  bool
+	// paused stops the maintainer from creating warm VMs (kill switch). Unlike
+	// closed (permanent, shutdown), paused is reversible via Resume.
+	paused bool
 }
 
 // NewPool validates cfg and returns a Pool. Call Run() to start the background
@@ -235,6 +238,34 @@ func (p *Pool) Drain(ctx context.Context) {
 	}
 }
 
+// Pause stops the maintainer from creating new warm VMs and destroys the ones
+// currently warm, releasing their concurrency slots. It is the kill-switch
+// counterpart to Drain: reversible via Resume. Without this, a paused/killed
+// broker would keep a warm VM running and replenishing it under the serve
+// context, so the kill switch would not actually stop standing compute/spend.
+func (p *Pool) Pause(ctx context.Context) {
+	p.mu.Lock()
+	p.paused = true
+	draining := make([]warmEntry, len(p.entries))
+	copy(draining, p.entries)
+	p.entries = nil
+	p.mu.Unlock()
+
+	for _, e := range draining {
+		_ = p.provider.DestroyMachine(ctx, e.machine.ID)
+		e.release()
+		_, _ = fmt.Fprintf(p.log, "pool: paused, destroyed warm vm %s\n", e.machine.ID)
+	}
+}
+
+// Resume re-enables warm-VM creation. The maintainer refills the pool on its
+// next tick.
+func (p *Pool) Resume() {
+	p.mu.Lock()
+	p.paused = false
+	p.mu.Unlock()
+}
+
 // maintain recycles stale entries and fills the pool up to Size.
 func (p *Pool) maintain(ctx context.Context) {
 	p.recycleStale(ctx)
@@ -274,8 +305,9 @@ func (p *Pool) fill(ctx context.Context) {
 		p.mu.Lock()
 		need := p.size - len(p.entries)
 		isClosed := p.closed
+		isPaused := p.paused
 		p.mu.Unlock()
-		if need <= 0 || isClosed {
+		if need <= 0 || isClosed || isPaused {
 			return
 		}
 

--- a/internal/playground/broker/pool.go
+++ b/internal/playground/broker/pool.go
@@ -322,7 +322,8 @@ func (p *Pool) fill(ctx context.Context) {
 			release: release,
 			created: p.now(),
 		})
-		_, _ = fmt.Fprintf(p.log, "pool: warm vm %s ready (code %s)\n", m.ID, vmCode)
+		// Do NOT log vmCode: it is the per-VM broker->VM session credential.
+		_, _ = fmt.Fprintf(p.log, "pool: warm vm %s ready\n", m.ID)
 		p.mu.Unlock()
 	}
 }

--- a/internal/playground/broker/pool.go
+++ b/internal/playground/broker/pool.go
@@ -342,7 +342,12 @@ func (p *Pool) fill(ctx context.Context) {
 		}
 
 		p.mu.Lock()
-		if p.closed {
+		// Re-check closed AND paused under the lock: a Drain (closed) or Kill
+		// (paused) can land while this VM was being created/booted, and the top
+		// of the loop checked before CreateMachine. Without this, a kill mid-
+		// create would leave a warm VM running after the pool was supposed to
+		// stop. Destroy it and free the slot.
+		if p.closed || p.paused {
 			p.mu.Unlock()
 			_ = p.provider.DestroyMachine(context.WithoutCancel(ctx), m.ID)
 			release()

--- a/internal/playground/broker/pool.go
+++ b/internal/playground/broker/pool.go
@@ -1,0 +1,299 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+const (
+	// defaultMaxWarmAge is how long a warm VM may sit unused before it is
+	// recycled. This MUST be less than the VM session TTL so a handed-out VM
+	// is always fresh.
+	defaultMaxWarmAge = 10 * time.Minute
+
+	// defaultPoolSize is the number of pre-created VMs the pool tries to keep
+	// warm when no explicit --warm-pool-size is given.
+	defaultPoolSize = 1
+
+	// poolMaintainInterval is how often the background maintainer ticks.
+	poolMaintainInterval = 2 * time.Second
+)
+
+// warmEntry is one ready-to-hand-out VM in the warm pool.
+type warmEntry struct {
+	machine *Machine
+	vmCode  string
+	release func() // concurrency-slot release (transferred on handout)
+	created time.Time
+}
+
+// PoolConfig configures the warm VM pool.
+type PoolConfig struct {
+	// Provider creates and destroys VMs. Required.
+	Provider MachineProvider
+	// Concurrency is the shared limiter that caps warm + active machines.
+	// Required. The Pool acquires a slot when pre-creating a warm VM and
+	// transfers ownership of that slot when the VM is handed out. The same
+	// limiter MUST be shared with the LeaseManager so warm + active never
+	// exceeds the operator cap.
+	//
+	// INVARIANT 1: warm + active slots never exceed Cap().
+	Concurrency ConcurrencyAcquirer
+	// NewVMCode generates a unique invite code for each warm VM. Required.
+	NewVMCode func() (string, error)
+	// BuildSpec returns the MachineSpec for a warm VM given its vmCode env.
+	// Required.
+	BuildSpec func(vmCode string) MachineSpec
+	// Size is the target number of warm VMs to maintain. Zero or negative
+	// uses defaultPoolSize.
+	Size int
+	// MaxWarmAge is the maximum age of a warm VM before it is recycled.
+	// Zero uses defaultMaxWarmAge.
+	//
+	// INVARIANT 5: stale warm VMs older than MaxWarmAge are destroyed and
+	// replaced.
+	MaxWarmAge time.Duration
+	// Now returns the current time. Injectable for tests; nil uses time.Now.
+	Now func() time.Time
+	// Log receives one-line audit messages. Nil discards.
+	Log io.Writer
+}
+
+// ConcurrencyAcquirer is the interface the pool needs from the shared
+// concurrency limiter.
+type ConcurrencyAcquirer interface {
+	Acquire() (release func(), ok bool)
+}
+
+// Pool maintains a small set of pre-created, ready VMs so a visitor
+// session-create can skip the cold-start cost. It is safe for concurrent use.
+type Pool struct {
+	provider   MachineProvider
+	conc       ConcurrencyAcquirer
+	newVMCode  func() (string, error)
+	buildSpec  func(vmCode string) MachineSpec
+	size       int
+	maxWarmAge time.Duration
+	now        func() time.Time
+	log        io.Writer
+
+	mu      sync.Mutex
+	entries []warmEntry
+	closed  bool
+}
+
+// NewPool validates cfg and returns a Pool. Call Run() to start the background
+// maintainer.
+func NewPool(cfg PoolConfig) (*Pool, error) {
+	if cfg.Provider == nil {
+		return nil, fmt.Errorf("pool: Provider is required")
+	}
+	if cfg.Concurrency == nil {
+		return nil, fmt.Errorf("pool: Concurrency is required")
+	}
+	if cfg.NewVMCode == nil {
+		return nil, fmt.Errorf("pool: NewVMCode is required")
+	}
+	if cfg.BuildSpec == nil {
+		return nil, fmt.Errorf("pool: BuildSpec is required")
+	}
+	size := cfg.Size
+	if size <= 0 {
+		size = defaultPoolSize
+	}
+	maxWarmAge := cfg.MaxWarmAge
+	if maxWarmAge <= 0 {
+		maxWarmAge = defaultMaxWarmAge
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	log := cfg.Log
+	if log == nil {
+		log = io.Discard
+	}
+	return &Pool{
+		provider:   cfg.Provider,
+		conc:       cfg.Concurrency,
+		newVMCode:  cfg.NewVMCode,
+		buildSpec:  cfg.BuildSpec,
+		size:       size,
+		maxWarmAge: maxWarmAge,
+		now:        now,
+		log:        log,
+	}, nil
+}
+
+// Acquire pops a ready warm VM from the pool. ok=false when the pool is empty;
+// the caller MUST fall back to the synchronous create path.
+//
+// INVARIANT 3: a visitor NEVER fails because the pool is empty.
+//
+// On success the concurrency slot is transferred to the caller (the slot was
+// acquired when the warm VM was pre-created). The caller owns release().
+func (p *Pool) Acquire() (machine *Machine, vmCode string, release func(), ok bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.entries) == 0 {
+		return nil, "", nil, false
+	}
+	// Pop the oldest entry (FIFO: freshest are appended at the back).
+	e := p.entries[0]
+	p.entries[0] = warmEntry{} // clear reference
+	p.entries = p.entries[1:]
+	return e.machine, e.vmCode, e.release, true
+}
+
+// WarmMachineIDs returns a snapshot of machine IDs currently in the warm pool.
+// Combined with LeaseManager.ActiveMachineIDs, this protects warm VMs from the
+// reaper.
+//
+// INVARIANT 2: the reaper MUST NOT destroy warm VMs.
+func (p *Pool) WarmMachineIDs() map[string]struct{} {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ids := make(map[string]struct{}, len(p.entries))
+	for _, e := range p.entries {
+		if e.machine != nil {
+			ids[e.machine.ID] = struct{}{}
+		}
+	}
+	return ids
+}
+
+// Run starts the background maintainer that keeps the pool at Size warm VMs.
+// It exits when ctx is done. Call Drain() after ctx cancels to tear down any
+// remaining warm VMs.
+func (p *Pool) Run(ctx context.Context) {
+	// Initial fill on startup.
+	p.maintain(ctx)
+
+	ticker := time.NewTicker(poolMaintainInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.maintain(ctx)
+		}
+	}
+}
+
+// Drain destroys all warm VMs currently in the pool and releases their
+// concurrency slots.
+//
+// INVARIANT 4: warm VMs are cleaned up on graceful shutdown.
+func (p *Pool) Drain(ctx context.Context) {
+	p.mu.Lock()
+	p.closed = true
+	draining := make([]warmEntry, len(p.entries))
+	copy(draining, p.entries)
+	p.entries = nil
+	p.mu.Unlock()
+
+	for _, e := range draining {
+		_ = p.provider.DestroyMachine(ctx, e.machine.ID)
+		e.release()
+		_, _ = fmt.Fprintf(p.log, "pool: drain destroyed warm vm %s\n", e.machine.ID)
+	}
+}
+
+// maintain recycles stale entries and fills the pool up to Size.
+func (p *Pool) maintain(ctx context.Context) {
+	p.recycleStale(ctx)
+	p.fill(ctx)
+}
+
+// recycleStale destroys warm VMs older than MaxWarmAge.
+func (p *Pool) recycleStale(ctx context.Context) {
+	now := p.now()
+	p.mu.Lock()
+	var stale []warmEntry
+	kept := make([]warmEntry, 0, len(p.entries))
+	for _, e := range p.entries {
+		if now.Sub(e.created) >= p.maxWarmAge {
+			stale = append(stale, e)
+		} else {
+			kept = append(kept, e)
+		}
+	}
+	p.entries = kept
+	p.mu.Unlock()
+
+	for _, e := range stale {
+		_ = p.provider.DestroyMachine(ctx, e.machine.ID)
+		e.release()
+		_, _ = fmt.Fprintf(p.log, "pool: recycled stale warm vm %s (age %s)\n",
+			e.machine.ID, now.Sub(e.created).Truncate(time.Second))
+	}
+}
+
+// fill creates warm VMs up to Size, respecting the shared concurrency cap.
+func (p *Pool) fill(ctx context.Context) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		p.mu.Lock()
+		need := p.size - len(p.entries)
+		isClosed := p.closed
+		p.mu.Unlock()
+		if need <= 0 || isClosed {
+			return
+		}
+
+		// INVARIANT 1: acquire a concurrency slot BEFORE creating the VM.
+		// This slot counts toward the global cap, ensuring warm + active
+		// never exceeds the configured concurrency.
+		release, ok := p.conc.Acquire()
+		if !ok {
+			// At capacity: don't create more warm VMs. The pool will try
+			// again on the next maintain tick.
+			return
+		}
+
+		vmCode, err := p.newVMCode()
+		if err != nil {
+			release()
+			_, _ = fmt.Fprintf(p.log, "pool: generate vm code: %v\n", err)
+			return
+		}
+		spec := p.buildSpec(vmCode)
+		m, err := p.provider.CreateMachine(ctx, spec)
+		if err != nil {
+			release()
+			_, _ = fmt.Fprintf(p.log, "pool: create warm vm: %v\n", err)
+			return
+		}
+		if werr := p.provider.WaitReady(ctx, m.ID); werr != nil {
+			_ = p.provider.DestroyMachine(context.WithoutCancel(ctx), m.ID)
+			release()
+			_, _ = fmt.Fprintf(p.log, "pool: warm vm %s not ready: %v\n", m.ID, werr)
+			return
+		}
+
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			_ = p.provider.DestroyMachine(context.WithoutCancel(ctx), m.ID)
+			release()
+			return
+		}
+		p.entries = append(p.entries, warmEntry{
+			machine: m,
+			vmCode:  vmCode,
+			release: release,
+			created: p.now(),
+		})
+		_, _ = fmt.Fprintf(p.log, "pool: warm vm %s ready (code %s)\n", m.ID, vmCode)
+		p.mu.Unlock()
+	}
+}

--- a/internal/playground/broker/pool.go
+++ b/internal/playground/broker/pool.go
@@ -89,6 +89,10 @@ type Pool struct {
 
 	mu      sync.Mutex
 	entries []warmEntry
+	// quarantine holds VMs whose destroy call failed. They remain protected
+	// from the reaper and keep their limiter slot, but Acquire must never hand
+	// them to a visitor after cleanup already tried to remove them.
+	quarantine map[string]warmEntry
 	// handoff holds machine IDs popped by Acquire but not yet adopted into an
 	// active lease. They are NO LONGER in entries but NOT YET in
 	// LeaseManager.ActiveMachineIDs, so without tracking them here the reaper
@@ -141,6 +145,7 @@ func NewPool(cfg PoolConfig) (*Pool, error) {
 		maxWarmAge: maxWarmAge,
 		now:        now,
 		log:        log,
+		quarantine: make(map[string]warmEntry),
 		handoff:    make(map[string]struct{}),
 	}, nil
 }
@@ -192,11 +197,14 @@ func (p *Pool) FinishHandoff(machineID string) {
 func (p *Pool) WarmMachineIDs() map[string]struct{} {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	ids := make(map[string]struct{}, len(p.entries)+len(p.handoff))
+	ids := make(map[string]struct{}, len(p.entries)+len(p.quarantine)+len(p.handoff))
 	for _, e := range p.entries {
 		if e.machine != nil {
 			ids[e.machine.ID] = struct{}{}
 		}
+	}
+	for id := range p.quarantine {
+		ids[id] = struct{}{}
 	}
 	for id := range p.handoff {
 		ids[id] = struct{}{}
@@ -233,14 +241,14 @@ func (p *Pool) Drain(ctx context.Context) {
 	draining := make([]warmEntry, len(p.entries))
 	copy(draining, p.entries)
 	p.entries = nil
+	for id, e := range p.quarantine {
+		draining = append(draining, e)
+		delete(p.quarantine, id)
+	}
 	p.mu.Unlock()
 
 	failed := p.destroyWarmEntries(ctx, draining, "drain")
-	if len(failed) > 0 {
-		p.mu.Lock()
-		p.entries = append(failed, p.entries...)
-		p.mu.Unlock()
-	}
+	p.quarantineFailed(failed)
 }
 
 // Pause stops the maintainer from creating new warm VMs and destroys the ones
@@ -254,14 +262,14 @@ func (p *Pool) Pause(ctx context.Context) {
 	draining := make([]warmEntry, len(p.entries))
 	copy(draining, p.entries)
 	p.entries = nil
+	for id, e := range p.quarantine {
+		draining = append(draining, e)
+		delete(p.quarantine, id)
+	}
 	p.mu.Unlock()
 
 	failed := p.destroyWarmEntries(ctx, draining, "pause")
-	if len(failed) > 0 {
-		p.mu.Lock()
-		p.entries = append(failed, p.entries...)
-		p.mu.Unlock()
-	}
+	p.quarantineFailed(failed)
 }
 
 // Resume re-enables warm-VM creation. The maintainer refills the pool on its
@@ -274,6 +282,7 @@ func (p *Pool) Resume() {
 
 // maintain recycles stale entries and fills the pool up to Size.
 func (p *Pool) maintain(ctx context.Context) {
+	p.retryQuarantine(ctx)
 	p.recycleStale(ctx)
 	p.fill(ctx)
 }
@@ -295,10 +304,40 @@ func (p *Pool) recycleStale(ctx context.Context) {
 	p.mu.Unlock()
 
 	failed := p.destroyWarmEntries(ctx, stale, "recycle stale")
-	if len(failed) > 0 {
-		p.mu.Lock()
-		p.entries = append(failed, p.entries...)
+	p.quarantineFailed(failed)
+}
+
+func (p *Pool) retryQuarantine(ctx context.Context) {
+	p.mu.Lock()
+	if len(p.quarantine) == 0 {
 		p.mu.Unlock()
+		return
+	}
+	retry := make([]warmEntry, 0, len(p.quarantine))
+	for id, e := range p.quarantine {
+		retry = append(retry, e)
+		delete(p.quarantine, id)
+	}
+	p.mu.Unlock()
+
+	failed := p.destroyWarmEntries(ctx, retry, "retry quarantined")
+	p.quarantineFailed(failed)
+}
+
+func (p *Pool) quarantineFailed(entries []warmEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.quarantine == nil {
+		p.quarantine = make(map[string]warmEntry)
+	}
+	for _, e := range entries {
+		if e.machine == nil {
+			continue
+		}
+		p.quarantine[e.machine.ID] = e
 	}
 }
 

--- a/internal/playground/broker/pool.go
+++ b/internal/playground/broker/pool.go
@@ -23,6 +23,10 @@ const (
 
 	// poolMaintainInterval is how often the background maintainer ticks.
 	poolMaintainInterval = 2 * time.Second
+
+	// poolDestroyTimeout bounds cleanup calls made with a non-cancelled context.
+	// Destroy failure keeps the VM tracked and its limiter slot held.
+	poolDestroyTimeout = 30 * time.Second
 )
 
 // warmEntry is one ready-to-hand-out VM in the warm pool.
@@ -231,10 +235,11 @@ func (p *Pool) Drain(ctx context.Context) {
 	p.entries = nil
 	p.mu.Unlock()
 
-	for _, e := range draining {
-		_ = p.provider.DestroyMachine(ctx, e.machine.ID)
-		e.release()
-		_, _ = fmt.Fprintf(p.log, "pool: drain destroyed warm vm %s\n", e.machine.ID)
+	failed := p.destroyWarmEntries(ctx, draining, "drain")
+	if len(failed) > 0 {
+		p.mu.Lock()
+		p.entries = append(failed, p.entries...)
+		p.mu.Unlock()
 	}
 }
 
@@ -251,10 +256,11 @@ func (p *Pool) Pause(ctx context.Context) {
 	p.entries = nil
 	p.mu.Unlock()
 
-	for _, e := range draining {
-		_ = p.provider.DestroyMachine(ctx, e.machine.ID)
-		e.release()
-		_, _ = fmt.Fprintf(p.log, "pool: paused, destroyed warm vm %s\n", e.machine.ID)
+	failed := p.destroyWarmEntries(ctx, draining, "pause")
+	if len(failed) > 0 {
+		p.mu.Lock()
+		p.entries = append(failed, p.entries...)
+		p.mu.Unlock()
 	}
 }
 
@@ -288,12 +294,32 @@ func (p *Pool) recycleStale(ctx context.Context) {
 	p.entries = kept
 	p.mu.Unlock()
 
-	for _, e := range stale {
-		_ = p.provider.DestroyMachine(ctx, e.machine.ID)
-		e.release()
-		_, _ = fmt.Fprintf(p.log, "pool: recycled stale warm vm %s (age %s)\n",
-			e.machine.ID, now.Sub(e.created).Truncate(time.Second))
+	failed := p.destroyWarmEntries(ctx, stale, "recycle stale")
+	if len(failed) > 0 {
+		p.mu.Lock()
+		p.entries = append(failed, p.entries...)
+		p.mu.Unlock()
 	}
+}
+
+func (p *Pool) destroyWarmEntries(ctx context.Context, entries []warmEntry, reason string) []warmEntry {
+	failed := make([]warmEntry, 0)
+	for _, e := range entries {
+		if e.machine == nil {
+			continue
+		}
+		destroyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), poolDestroyTimeout)
+		err := p.provider.DestroyMachine(destroyCtx, e.machine.ID)
+		cancel()
+		if err != nil {
+			failed = append(failed, e)
+			_, _ = fmt.Fprintf(p.log, "pool: %s destroy warm vm %s failed: %v\n", reason, e.machine.ID, err)
+			continue
+		}
+		e.release()
+		_, _ = fmt.Fprintf(p.log, "pool: %s destroyed warm vm %s\n", reason, e.machine.ID)
+	}
+	return failed
 }
 
 // fill creates warm VMs up to Size, respecting the shared concurrency cap.

--- a/internal/playground/broker/pool_test.go
+++ b/internal/playground/broker/pool_test.go
@@ -5,6 +5,7 @@ package broker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -375,12 +376,12 @@ func TestPoolDrainDestroysAll(t *testing.T) {
 	// Fill: 2 warm VMs.
 	pool.maintain(context.Background())
 	pool.maintain(context.Background()) // second call may be needed if fill creates one at a time
-	if limiter.InUse() < 1 {
-		t.Fatalf("InUse after fill = %d, want >= 1", limiter.InUse())
+	if limiter.InUse() != 2 {
+		t.Fatalf("InUse after fill = %d, want 2", limiter.InUse())
 	}
 	warmBefore := len(pool.WarmMachineIDs())
-	if warmBefore < 1 {
-		t.Fatalf("warm VMs after fill = %d, want >= 1", warmBefore)
+	if warmBefore != 2 {
+		t.Fatalf("warm VMs after fill = %d, want 2", warmBefore)
 	}
 
 	pool.Drain(context.Background())
@@ -459,6 +460,51 @@ func TestPoolRecycleStale(t *testing.T) {
 	// Slot count: still 1 (recycled = destroyed old + created new).
 	if limiter.InUse() != 1 {
 		t.Errorf("InUse after recycle = %d, want 1", limiter.InUse())
+	}
+}
+
+func TestPoolRecycleStaleDestroyFailureKeepsEntryAndSlot(t *testing.T) {
+	fp := &destroyErrProvider{fakeProvider: &fakeProvider{}, destroyErr: errors.New("destroy failed")}
+	limiter := livechat.NewConcurrencyLimiter(1)
+
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	currentTime := now
+	var timeMu sync.Mutex
+	clockFn := func() time.Time {
+		timeMu.Lock()
+		defer timeMu.Unlock()
+		return currentTime
+	}
+
+	pool := newTestPool(t, fp, limiter, 1, 5*time.Minute, clockFn)
+	pool.maintain(context.Background())
+	warmIDs := pool.WarmMachineIDs()
+	if len(warmIDs) != 1 {
+		t.Fatalf("warm VMs after fill = %d, want 1", len(warmIDs))
+	}
+	var oldID string
+	for id := range warmIDs {
+		oldID = id
+	}
+
+	timeMu.Lock()
+	currentTime = now.Add(6 * time.Minute)
+	timeMu.Unlock()
+
+	pool.maintain(context.Background())
+	newIDs := pool.WarmMachineIDs()
+	if len(newIDs) != 1 {
+		t.Fatalf("warm VMs after failed recycle = %d, want 1", len(newIDs))
+	}
+	if _, ok := newIDs[oldID]; !ok {
+		t.Fatalf("stale VM %s should stay tracked when destroy fails", oldID)
+	}
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse after failed recycle = %d, want 1", limiter.InUse())
+	}
+	created, _ := fp.counts()
+	if created != 1 {
+		t.Fatalf("created after failed recycle = %d, want 1; failed destroy must not free slot for replacement", created)
 	}
 }
 
@@ -589,6 +635,10 @@ func TestPoolAdoptWarmSessionPath(t *testing.T) {
 	if lease.Machine.ID != m.ID {
 		t.Errorf("adopted lease machine ID = %s, want %s", lease.Machine.ID, m.ID)
 	}
+	pool.FinishHandoff(m.ID)
+	if _, protected := pool.WarmMachineIDs()[m.ID]; protected {
+		t.Fatalf("machine %s still reaper-protected after FinishHandoff", m.ID)
+	}
 
 	// The vmCode from the pool is what the session-create will use.
 	if code == "" {
@@ -630,9 +680,8 @@ func TestPoolConcurrentAcquireSafe(t *testing.T) {
 	for range acquired {
 		count++
 	}
-	// At most 5 should have succeeded (pool size 5).
-	if count > 5 {
-		t.Errorf("acquired %d from pool of 5", count)
+	if count != 5 {
+		t.Errorf("acquired %d from pool of 5, want exactly 5", count)
 	}
 }
 

--- a/internal/playground/broker/pool_test.go
+++ b/internal/playground/broker/pool_test.go
@@ -332,6 +332,41 @@ func TestPoolFallbackOnEmpty(t *testing.T) {
 // releases their concurrency slots.
 //
 // INVARIANT 4: warm VMs are drained on graceful shutdown.
+// TestPoolPauseDrainsAndStopsRefill proves the kill-switch behavior: Pause
+// destroys the warm VMs (freeing their concurrency slots) AND stops the
+// maintainer from refilling, until Resume. Without this a killed/paused broker
+// would keep standing warm compute and keep replenishing it.
+func TestPoolPauseDrainsAndStopsRefill(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+	pool.maintain(context.Background())
+	if got := len(pool.WarmMachineIDs()); got != 1 {
+		t.Fatalf("warm before pause = %d, want 1", got)
+	}
+
+	pool.Pause(context.Background())
+	if got := len(pool.WarmMachineIDs()); got != 0 {
+		t.Fatalf("warm after pause = %d, want 0 (drained)", got)
+	}
+	if got := limiter.InUse(); got != 0 {
+		t.Fatalf("slots in use after pause = %d, want 0 (released)", got)
+	}
+
+	// Paused: the maintainer must NOT refill.
+	pool.maintain(context.Background())
+	if got := len(pool.WarmMachineIDs()); got != 0 {
+		t.Fatalf("paused pool refilled: %d warm, want 0", got)
+	}
+
+	// Resume: the maintainer refills again.
+	pool.Resume()
+	pool.maintain(context.Background())
+	if got := len(pool.WarmMachineIDs()); got != 1 {
+		t.Fatalf("warm after resume = %d, want 1", got)
+	}
+}
+
 func TestPoolDrainDestroysAll(t *testing.T) {
 	fp := &fakeProvider{}
 	limiter := livechat.NewConcurrencyLimiter(5)

--- a/internal/playground/broker/pool_test.go
+++ b/internal/playground/broker/pool_test.go
@@ -92,6 +92,45 @@ func TestPoolAcquireReturnsWarmVM(t *testing.T) {
 	release()
 }
 
+// TestPoolHandoffStaysReaperProtected proves the warm-handoff TOCTOU is closed.
+// Acquire pops a VM out of the warm entries BEFORE the caller adopts it into an
+// active lease; in that window the VM is owned by neither the pool's entries nor
+// LeaseManager.ActiveMachineIDs. If WarmMachineIDs did not also cover in-flight
+// handoffs, a reaper sweep in that window could destroy a live, about-to-be-used
+// VM (it can outlive the 5m grace, since warm VMs live up to maxWarmAge). The VM
+// must stay reaper-protected until FinishHandoff.
+func TestPoolHandoffStaysReaperProtected(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+	pool.maintain(context.Background())
+
+	m, _, release, ok := pool.Acquire()
+	if !ok {
+		t.Fatal("Acquire should succeed after maintain fills the pool")
+	}
+
+	// Popped from entries...
+	pool.mu.Lock()
+	nEntries := len(pool.entries)
+	pool.mu.Unlock()
+	if nEntries != 0 {
+		t.Fatalf("entries = %d after Acquire, want 0 (machine popped)", nEntries)
+	}
+	// ...but STILL in the reaper-protected set (in-flight handoff).
+	if _, prot := pool.WarmMachineIDs()[m.ID]; !prot {
+		t.Fatalf("machine %s not protected during handoff; reaper could destroy a live VM", m.ID)
+	}
+
+	// FinishHandoff clears protection (caller has adopted it into a lease or
+	// destroyed it on adopt failure).
+	pool.FinishHandoff(m.ID)
+	if _, prot := pool.WarmMachineIDs()[m.ID]; prot {
+		t.Fatalf("machine %s still protected after FinishHandoff", m.ID)
+	}
+	release()
+}
+
 // TestPoolCapInvariant verifies that warm + active machines never exceed the
 // configured concurrency cap.
 //

--- a/internal/playground/broker/pool_test.go
+++ b/internal/playground/broker/pool_test.go
@@ -1,0 +1,647 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
+)
+
+const testImage = "registry.fly.io/playground:test"
+
+// testVMCode returns a deterministic code generator for tests.
+func testVMCode() func() (string, error) {
+	var n atomic.Int64
+	return func() (string, error) {
+		return fmt.Sprintf("code-%d", n.Add(1)), nil
+	}
+}
+
+func testBuildSpec(vmCode string) MachineSpec {
+	return MachineSpec{
+		Image: testImage,
+		Env:   map[string]string{"PLAYGROUND_CODE": vmCode},
+	}
+}
+
+// newTestPool constructs a Pool wired to a fake provider and a shared limiter.
+func newTestPool(t *testing.T, provider MachineProvider, limiter *livechat.ConcurrencyLimiter, size int, maxWarmAge time.Duration, now func() time.Time) *Pool {
+	t.Helper()
+	if maxWarmAge <= 0 {
+		maxWarmAge = 10 * time.Minute
+	}
+	if now == nil {
+		now = time.Now
+	}
+	log := &safeBuffer{}
+	p, err := NewPool(PoolConfig{
+		Provider:    provider,
+		Concurrency: limiter,
+		NewVMCode:   testVMCode(),
+		BuildSpec:   testBuildSpec,
+		Size:        size,
+		MaxWarmAge:  maxWarmAge,
+		Now:         now,
+		Log:         log,
+	})
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	return p
+}
+
+// TestPoolAcquireReturnsWarmVM verifies Acquire returns a warm VM when one is
+// ready, and ok=false when the pool is empty.
+func TestPoolAcquireReturnsWarmVM(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+
+	// Pool is empty initially: Acquire must return ok=false.
+	_, _, _, ok := pool.Acquire()
+	if ok {
+		t.Fatal("Acquire on empty pool should return ok=false")
+	}
+
+	// Run one maintain cycle to fill the pool.
+	ctx := context.Background()
+	pool.maintain(ctx)
+
+	// Now Acquire should succeed.
+	m, code, release, ok := pool.Acquire()
+	if !ok {
+		t.Fatal("Acquire should succeed after maintain fills the pool")
+	}
+	if m == nil || m.ID == "" {
+		t.Fatal("acquired machine is nil or has no ID")
+	}
+	if code == "" {
+		t.Fatal("acquired vmCode is empty")
+	}
+	if release == nil {
+		t.Fatal("acquired release func is nil")
+	}
+	// The release function is transferred to the caller.
+	release()
+}
+
+// TestPoolCapInvariant verifies that warm + active machines never exceed the
+// configured concurrency cap.
+//
+// INVARIANT 1: warm + active slots never exceed Cap().
+func TestPoolCapInvariant(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(2)
+	// Build a lease manager with the shared limiter (not via newManager,
+	// which creates its own limiter).
+	lm, err := NewLeaseManager(LeaseConfig{
+		Provider:    fp,
+		Concurrency: limiter,
+		Image:       testImage,
+	})
+	if err != nil {
+		t.Fatalf("NewLeaseManager: %v", err)
+	}
+
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+
+	// Fill the pool: 1 warm VM, consuming 1 of 2 slots.
+	pool.maintain(context.Background())
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse after pool fill = %d, want 1", limiter.InUse())
+	}
+
+	// Lease one active VM: should succeed (2 of 2 slots used: 1 warm + 1 active).
+	lease, leaseErr := lm.Lease(context.Background(), "sess-1", nil)
+	if leaseErr != nil {
+		t.Fatalf("Lease: %v", leaseErr)
+	}
+	if limiter.InUse() != 2 {
+		t.Fatalf("InUse after lease = %d, want 2", limiter.InUse())
+	}
+
+	// Another pool fill should NOT create a VM (at cap).
+	pool.maintain(context.Background())
+	if limiter.InUse() != 2 {
+		t.Fatalf("InUse after second maintain = %d, want 2 (cap)", limiter.InUse())
+	}
+
+	// Verify total machines created: 1 warm + 1 active = 2.
+	created, _ := fp.counts()
+	if created != 2 {
+		t.Errorf("total machines created = %d, want 2", created)
+	}
+
+	// Hand out the warm VM: slot count stays at 2 (transferred, not released).
+	m, code, warmRelease, ok := pool.Acquire()
+	if !ok {
+		t.Fatal("Acquire should succeed")
+	}
+	_ = code
+	// Adopt the warm VM as a lease. Slot is transferred: no new slot consumed.
+	adoptedLease, adoptErr := lm.AdoptWarm("sess-warm", m, warmRelease)
+	if adoptErr != nil {
+		t.Fatalf("AdoptWarm: %v", adoptErr)
+	}
+	if limiter.InUse() != 2 {
+		t.Fatalf("InUse after handout = %d, want 2 (no change on handout)", limiter.InUse())
+	}
+
+	// Release both leases: slots freed.
+	lm.Release(context.Background(), "sess-1")
+	_ = lease
+	lm.Release(context.Background(), "sess-warm")
+	_ = adoptedLease
+	// The warm VM's slot was released via lm.Release -> lease.release().
+	// Plus the active VM's slot.
+	if limiter.InUse() != 0 {
+		t.Fatalf("InUse after releasing both = %d, want 0", limiter.InUse())
+	}
+}
+
+// TestPoolHandoutDoesNotLeakOrDoubleCountSlot verifies that handing out a warm
+// VM transfers exactly one slot (no leak, no double-count).
+func TestPoolHandoutDoesNotLeakOrDoubleCountSlot(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+
+	// Fill: 1 warm VM, 1 slot used.
+	pool.maintain(context.Background())
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse after fill = %d, want 1", limiter.InUse())
+	}
+
+	// Acquire: slot stays at 1 (popped from pool, not released).
+	_, _, release, ok := pool.Acquire()
+	if !ok {
+		t.Fatal("Acquire should succeed")
+	}
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse after Acquire = %d, want 1", limiter.InUse())
+	}
+
+	// Release the slot (caller's responsibility after session ends).
+	release()
+	if limiter.InUse() != 0 {
+		t.Fatalf("InUse after release = %d, want 0", limiter.InUse())
+	}
+
+	// Pool replenish: maintain creates a new warm VM.
+	pool.maintain(context.Background())
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse after replenish = %d, want 1", limiter.InUse())
+	}
+}
+
+// TestReaperSparesWarmVMs proves a warm VM (tagged, not in active leases) is
+// NOT destroyed because WarmMachineIDs is in the protected set.
+//
+// INVARIANT 2: reaper MUST NOT destroy warm VMs.
+func TestReaperSparesWarmVMs(t *testing.T) {
+	baseTime := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	pool := newTestPool(t, fp, limiter, 1, 0, func() time.Time { return baseTime })
+	pool.maintain(context.Background())
+
+	// The warm VM is in managedMachines (fakeProvider appends on create).
+	// Give it an old CreatedAt so it would normally be reaped.
+	fp.mu.Lock()
+	for i := range fp.managedMachines {
+		fp.managedMachines[i].CreatedAt = baseTime.Add(-10 * time.Minute)
+	}
+	fp.mu.Unlock()
+
+	warmIDs := pool.WarmMachineIDs()
+	if len(warmIDs) != 1 {
+		t.Fatalf("WarmMachineIDs = %d, want 1", len(warmIDs))
+	}
+
+	// Build the reaper with the combined protected set (active leases UNION warm pool).
+	activeIDsFn := func() map[string]struct{} {
+		// No active leases in this test.
+		ids := make(map[string]struct{})
+		for id := range pool.WarmMachineIDs() {
+			ids[id] = struct{}{}
+		}
+		return ids
+	}
+
+	reaper, err := NewReaper(ReaperConfig{
+		Provider:  fp,
+		ActiveIDs: activeIDsFn,
+		Now:       func() time.Time { return baseTime },
+		Grace:     5 * time.Minute,
+		Log:       &safeBuffer{},
+	})
+	if err != nil {
+		t.Fatalf("NewReaper: %v", err)
+	}
+
+	destroyed, recErr := reaper.ReconcileOnce(context.Background())
+	if recErr != nil {
+		t.Fatalf("ReconcileOnce: %v", recErr)
+	}
+	if destroyed != 0 {
+		t.Errorf("reaper destroyed %d warm VMs, want 0 (warm VMs must be spared)", destroyed)
+	}
+}
+
+// TestPoolFallbackOnEmpty verifies that when the pool is empty, Acquire returns
+// ok=false and the caller can fall back to the synchronous create path.
+//
+// INVARIANT 3: a visitor NEVER fails because the pool is empty.
+func TestPoolFallbackOnEmpty(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+
+	// Don't run maintain: pool stays empty.
+	_, _, _, ok := pool.Acquire()
+	if ok {
+		t.Fatal("Acquire on empty pool should return ok=false")
+	}
+
+	// Cold path still works: lease directly.
+	lm, err := NewLeaseManager(LeaseConfig{
+		Provider:    fp,
+		Concurrency: limiter,
+		Image:       testImage,
+	})
+	if err != nil {
+		t.Fatalf("NewLeaseManager: %v", err)
+	}
+	lease, leaseErr := lm.Lease(context.Background(), "cold-path", nil)
+	if leaseErr != nil {
+		t.Fatalf("cold-path Lease: %v", leaseErr)
+	}
+	if lease.Machine.ID == "" {
+		t.Fatal("cold-path lease has no machine")
+	}
+}
+
+// TestPoolDrainDestroysAll verifies that Drain destroys all warm VMs and
+// releases their concurrency slots.
+//
+// INVARIANT 4: warm VMs are drained on graceful shutdown.
+func TestPoolDrainDestroysAll(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(5)
+	pool := newTestPool(t, fp, limiter, 2, 0, nil)
+
+	// Fill: 2 warm VMs.
+	pool.maintain(context.Background())
+	pool.maintain(context.Background()) // second call may be needed if fill creates one at a time
+	if limiter.InUse() < 1 {
+		t.Fatalf("InUse after fill = %d, want >= 1", limiter.InUse())
+	}
+	warmBefore := len(pool.WarmMachineIDs())
+	if warmBefore < 1 {
+		t.Fatalf("warm VMs after fill = %d, want >= 1", warmBefore)
+	}
+
+	pool.Drain(context.Background())
+
+	if len(pool.WarmMachineIDs()) != 0 {
+		t.Errorf("warm VMs after drain = %d, want 0", len(pool.WarmMachineIDs()))
+	}
+	if limiter.InUse() != 0 {
+		t.Errorf("InUse after drain = %d, want 0 (all slots freed)", limiter.InUse())
+	}
+
+	// Drain is idempotent.
+	pool.Drain(context.Background())
+}
+
+// TestPoolRecycleStale verifies that warm entries older than MaxWarmAge are
+// destroyed and replaced.
+//
+// INVARIANT 5: stale-warm recycling.
+func TestPoolRecycleStale(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	currentTime := now
+	var timeMu sync.Mutex
+	clockFn := func() time.Time {
+		timeMu.Lock()
+		defer timeMu.Unlock()
+		return currentTime
+	}
+
+	pool := newTestPool(t, fp, limiter, 1, 5*time.Minute, clockFn)
+
+	// Fill at t=0.
+	pool.maintain(context.Background())
+	warmIDs := pool.WarmMachineIDs()
+	if len(warmIDs) != 1 {
+		t.Fatalf("warm VMs after fill = %d, want 1", len(warmIDs))
+	}
+	var oldID string
+	for id := range warmIDs {
+		oldID = id
+	}
+
+	// Advance clock past MaxWarmAge.
+	timeMu.Lock()
+	currentTime = now.Add(6 * time.Minute)
+	timeMu.Unlock()
+
+	// Maintain: the stale entry should be destroyed and a fresh one created.
+	pool.maintain(context.Background())
+	newIDs := pool.WarmMachineIDs()
+	if len(newIDs) != 1 {
+		t.Fatalf("warm VMs after recycle = %d, want 1", len(newIDs))
+	}
+	for id := range newIDs {
+		if id == oldID {
+			t.Errorf("old warm VM %s should have been recycled", oldID)
+		}
+	}
+
+	// The old VM should have been destroyed.
+	fp.mu.Lock()
+	found := false
+	for _, d := range fp.destroyed {
+		if d == oldID {
+			found = true
+		}
+	}
+	fp.mu.Unlock()
+	if !found {
+		t.Errorf("old warm VM %s not found in destroyed list", oldID)
+	}
+
+	// Slot count: still 1 (recycled = destroyed old + created new).
+	if limiter.InUse() != 1 {
+		t.Errorf("InUse after recycle = %d, want 1", limiter.InUse())
+	}
+}
+
+// TestPoolMaintainerExitsOnCancel verifies the Run goroutine exits promptly
+// when its context is cancelled.
+func TestPoolMaintainerExitsOnCancel(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		pool.Run(ctx)
+		close(done)
+	}()
+
+	// Let the maintainer run at least one cycle.
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	for len(pool.WarmMachineIDs()) == 0 {
+		select {
+		case <-deadline.C:
+			t.Fatal("pool did not fill within deadline")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not exit after cancel")
+	}
+}
+
+// TestPoolCreateFailDoesNotLeak verifies that a failed VM create during pool
+// fill does not leak a concurrency slot.
+func TestPoolCreateFailDoesNotLeak(t *testing.T) {
+	fp := &fakeProvider{createErr: fmt.Errorf("provider down")}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+
+	pool.maintain(context.Background())
+
+	if limiter.InUse() != 0 {
+		t.Errorf("InUse after failed fill = %d, want 0 (slot not leaked)", limiter.InUse())
+	}
+	if len(pool.WarmMachineIDs()) != 0 {
+		t.Errorf("warm VMs after failed fill = %d, want 0", len(pool.WarmMachineIDs()))
+	}
+}
+
+// TestPoolWaitReadyFailDoesNotLeak verifies that a failed WaitReady during pool
+// fill tears down the machine and frees the slot.
+func TestPoolWaitReadyFailDoesNotLeak(t *testing.T) {
+	fp := &fakeProvider{waitErr: fmt.Errorf("never started")}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+
+	pool.maintain(context.Background())
+
+	if limiter.InUse() != 0 {
+		t.Errorf("InUse after wait fail = %d, want 0", limiter.InUse())
+	}
+	// Machine was created and then destroyed on wait failure.
+	created, destroyed := fp.counts()
+	if created != 1 || destroyed != 1 {
+		t.Errorf("created=%d destroyed=%d, want 1 and 1", created, destroyed)
+	}
+}
+
+// TestNewPoolValidation checks that NewPool rejects missing required fields.
+func TestNewPoolValidation(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(1)
+	vmCode := testVMCode()
+
+	tests := []struct {
+		name string
+		cfg  PoolConfig
+	}{
+		{"no provider", PoolConfig{Concurrency: limiter, NewVMCode: vmCode, BuildSpec: testBuildSpec}},
+		{"no concurrency", PoolConfig{Provider: fp, NewVMCode: vmCode, BuildSpec: testBuildSpec}},
+		{"no vm code", PoolConfig{Provider: fp, Concurrency: limiter, BuildSpec: testBuildSpec}},
+		{"no build spec", PoolConfig{Provider: fp, Concurrency: limiter, NewVMCode: vmCode}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewPool(tt.cfg); err == nil {
+				t.Error("want validation error")
+			}
+		})
+	}
+}
+
+// TestPoolAdoptWarmSessionPath verifies the full warm-handout path: pool
+// creates a warm VM, it's acquired, adopted as a lease, and the session-create
+// uses the warm VM's code.
+func TestPoolAdoptWarmSessionPath(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+
+	// Fill the pool.
+	pool.maintain(context.Background())
+
+	// Acquire the warm VM.
+	m, code, release, ok := pool.Acquire()
+	if !ok {
+		t.Fatal("Acquire should succeed after fill")
+	}
+
+	// Adopt as a lease.
+	lm, err := NewLeaseManager(LeaseConfig{
+		Provider:    fp,
+		Concurrency: limiter,
+		Image:       testImage,
+	})
+	if err != nil {
+		t.Fatalf("NewLeaseManager: %v", err)
+	}
+
+	lease, adoptErr := lm.AdoptWarm("warm-session", m, release)
+	if adoptErr != nil {
+		t.Fatalf("AdoptWarm: %v", adoptErr)
+	}
+	if lease.Machine.ID != m.ID {
+		t.Errorf("adopted lease machine ID = %s, want %s", lease.Machine.ID, m.ID)
+	}
+
+	// The vmCode from the pool is what the session-create will use.
+	if code == "" {
+		t.Error("warm vmCode is empty")
+	}
+
+	// Release the lease (destroy + free slot).
+	lm.Release(context.Background(), "warm-session")
+	if limiter.InUse() != 0 {
+		t.Errorf("InUse after release = %d, want 0", limiter.InUse())
+	}
+}
+
+// TestPoolConcurrentAcquireSafe verifies that concurrent Acquire calls are
+// safe under the race detector.
+func TestPoolConcurrentAcquireSafe(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(10)
+	pool := newTestPool(t, fp, limiter, 5, 0, nil)
+
+	// Fill the pool.
+	pool.maintain(context.Background())
+
+	var wg sync.WaitGroup
+	acquired := make(chan struct{}, 10)
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, _, release, ok := pool.Acquire(); ok {
+				acquired <- struct{}{}
+				release()
+			}
+		}()
+	}
+	wg.Wait()
+	close(acquired)
+	count := 0
+	for range acquired {
+		count++
+	}
+	// At most 5 should have succeeded (pool size 5).
+	if count > 5 {
+		t.Errorf("acquired %d from pool of 5", count)
+	}
+}
+
+// TestAdoptWarmValidation verifies AdoptWarm rejects empty session keys and
+// nil machines.
+func TestAdoptWarmValidation(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	lm, err := NewLeaseManager(LeaseConfig{
+		Provider:    fp,
+		Concurrency: limiter,
+		Image:       testImage,
+	})
+	if err != nil {
+		t.Fatalf("NewLeaseManager: %v", err)
+	}
+
+	t.Run("empty session key", func(t *testing.T) {
+		_, err := lm.AdoptWarm("", &Machine{ID: "m1"}, func() {})
+		if err == nil {
+			t.Error("want error for empty session key")
+		}
+	})
+
+	t.Run("nil machine", func(t *testing.T) {
+		_, err := lm.AdoptWarm("s1", nil, func() {})
+		if err == nil {
+			t.Error("want error for nil machine")
+		}
+	})
+
+	t.Run("duplicate session key", func(t *testing.T) {
+		_, err := lm.AdoptWarm("dup", &Machine{ID: "m1", PrivateIP: "fdaa::1"}, func() {})
+		if err != nil {
+			t.Fatalf("first AdoptWarm: %v", err)
+		}
+		_, err = lm.AdoptWarm("dup", &Machine{ID: "m2", PrivateIP: "fdaa::2"}, func() {})
+		if err == nil {
+			t.Error("want ErrDuplicateLease for duplicate session key")
+		}
+	})
+}
+
+// TestPoolFillVMCodeError verifies that a vmCode generation error during fill
+// does not leak a slot.
+func TestPoolFillVMCodeError(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(3)
+	log := &safeBuffer{}
+	p, err := NewPool(PoolConfig{
+		Provider:    fp,
+		Concurrency: limiter,
+		NewVMCode:   func() (string, error) { return "", fmt.Errorf("code gen failed") },
+		BuildSpec:   testBuildSpec,
+		Size:        1,
+		Log:         log,
+	})
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	p.maintain(context.Background())
+	if limiter.InUse() != 0 {
+		t.Errorf("InUse after vmCode error = %d, want 0", limiter.InUse())
+	}
+}
+
+// TestPoolDrainPreventsNewEntries verifies that after Drain, the maintainer
+// does not create new warm VMs.
+func TestPoolDrainPreventsNewEntries(t *testing.T) {
+	fp := &fakeProvider{}
+	limiter := livechat.NewConcurrencyLimiter(5)
+	pool := newTestPool(t, fp, limiter, 2, 0, nil)
+
+	pool.maintain(context.Background())
+	if len(pool.WarmMachineIDs()) == 0 {
+		t.Fatal("pool should have warm VMs after maintain")
+	}
+
+	pool.Drain(context.Background())
+
+	// Maintain after drain should not create new VMs.
+	pool.maintain(context.Background())
+	if len(pool.WarmMachineIDs()) != 0 {
+		t.Errorf("warm VMs after drain+maintain = %d, want 0", len(pool.WarmMachineIDs()))
+	}
+}

--- a/internal/playground/broker/pool_test.go
+++ b/internal/playground/broker/pool_test.go
@@ -499,12 +499,74 @@ func TestPoolRecycleStaleDestroyFailureKeepsEntryAndSlot(t *testing.T) {
 	if _, ok := newIDs[oldID]; !ok {
 		t.Fatalf("stale VM %s should stay tracked when destroy fails", oldID)
 	}
+	if _, _, _, ok := pool.Acquire(); ok {
+		t.Fatal("failed-destroy stale VM was handed out; want quarantined")
+	}
 	if limiter.InUse() != 1 {
 		t.Fatalf("InUse after failed recycle = %d, want 1", limiter.InUse())
 	}
 	created, _ := fp.counts()
 	if created != 1 {
 		t.Fatalf("created after failed recycle = %d, want 1; failed destroy must not free slot for replacement", created)
+	}
+
+	fp.destroyErr = nil
+	pool.maintain(context.Background())
+	recoveredIDs := pool.WarmMachineIDs()
+	if len(recoveredIDs) != 1 {
+		t.Fatalf("warm VMs after quarantine retry = %d, want replacement", len(recoveredIDs))
+	}
+	if _, ok := recoveredIDs[oldID]; ok {
+		t.Fatalf("old VM %s stayed tracked after successful quarantine retry", oldID)
+	}
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse after quarantine retry/refill = %d, want 1", limiter.InUse())
+	}
+	created, _ = fp.counts()
+	if created != 2 {
+		t.Fatalf("created after quarantine retry/refill = %d, want 2", created)
+	}
+	if fp.destroyCalls != 2 {
+		t.Fatalf("destroy attempts after quarantine retry = %d, want 2", fp.destroyCalls)
+	}
+}
+
+func TestPoolPauseDestroyFailureQuarantinesVM(t *testing.T) {
+	fp := &destroyErrProvider{fakeProvider: &fakeProvider{}, destroyErr: errors.New("destroy failed")}
+	limiter := livechat.NewConcurrencyLimiter(1)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+	pool.maintain(context.Background())
+	warmIDs := pool.WarmMachineIDs()
+	if len(warmIDs) != 1 {
+		t.Fatalf("warm VMs after fill = %d, want 1", len(warmIDs))
+	}
+	var oldID string
+	for id := range warmIDs {
+		oldID = id
+	}
+
+	pool.Pause(context.Background())
+	quarantinedIDs := pool.WarmMachineIDs()
+	if len(quarantinedIDs) != 1 {
+		t.Fatalf("warm VMs after failed pause destroy = %d, want quarantined VM", len(quarantinedIDs))
+	}
+	if _, ok := quarantinedIDs[oldID]; !ok {
+		t.Fatalf("failed pause destroy VM %s should stay protected", oldID)
+	}
+	if _, _, _, ok := pool.Acquire(); ok {
+		t.Fatal("failed-destroy paused VM was handed out; want quarantined")
+	}
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse after failed pause destroy = %d, want 1", limiter.InUse())
+	}
+
+	fp.destroyErr = nil
+	pool.maintain(context.Background())
+	if got := len(pool.WarmMachineIDs()); got != 0 {
+		t.Fatalf("warm VMs after paused quarantine retry = %d, want 0", got)
+	}
+	if limiter.InUse() != 0 {
+		t.Fatalf("InUse after paused quarantine retry = %d, want 0", limiter.InUse())
 	}
 }
 

--- a/internal/playground/broker/provider.go
+++ b/internal/playground/broker/provider.go
@@ -14,7 +14,10 @@
 // passing a per-session credential into the leased VM's environment.
 package broker
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Machine is the broker's view of one leased per-visitor microVM. Fields are the
 // subset the broker needs to route to and tear down the VM; provider-specific
@@ -29,6 +32,10 @@ type Machine struct {
 	// the provider's private network (Fly 6PN is an IPv6 address). Empty until
 	// the machine has been assigned one.
 	PrivateIP string
+	// CreatedAt is the provider-reported creation time. Zero if unknown or
+	// unparseable — callers that care about age must treat zero as "unknown,
+	// do not assume old."
+	CreatedAt time.Time
 }
 
 // MachineSpec describes the per-visitor VM to create. The broker fills it per
@@ -66,4 +73,9 @@ type MachineProvider interface {
 	// machine already gone is not an error, so teardown on a half-failed lease
 	// never wedges.
 	DestroyMachine(ctx context.Context, id string) error
+	// ListManagedMachines returns ONLY broker-tagged per-visitor VMs (those
+	// with metadata pipelock_role == playground-vm). The broker's own machine
+	// and unrelated infra are never returned. Used by the orphan reaper to
+	// reconcile actual provider state against live leases.
+	ListManagedMachines(ctx context.Context) ([]Machine, error)
 }

--- a/internal/playground/broker/reaper.go
+++ b/internal/playground/broker/reaper.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+)
+
+const (
+	// defaultReaperGrace is the minimum time a provider machine must have
+	// existed before the reaper considers it orphaned. It MUST exceed the
+	// maximum CreateMachine+WaitReady->lease-registration window: a machine
+	// exists at the provider during WaitReady BEFORE the LeaseManager
+	// registers it, so a too-short grace would destroy a VM mid-setup.
+	//
+	// SAFETY INVARIANT: a machine younger than grace is ALWAYS spared, even
+	// if it is not in the active lease set. The create path is bounded well
+	// under 60s; 5 minutes provides ample headroom.
+	defaultReaperGrace = 5 * time.Minute
+
+	// defaultReaperInterval is how often the background reconciliation loop
+	// ticks.
+	defaultReaperInterval = 2 * time.Minute
+)
+
+// ReaperConfig configures the orphan-VM reaper.
+type ReaperConfig struct {
+	// Provider lists managed machines and destroys orphans.
+	Provider MachineProvider
+	// ActiveIDs returns the set of machine IDs currently held in active
+	// leases (LeaseManager.ActiveMachineIDs).
+	ActiveIDs func() map[string]struct{}
+	// Now returns the current time. Injectable for tests; nil uses time.Now.
+	Now func() time.Time
+	// Grace is the minimum machine age before the reaper considers it
+	// orphaned. Zero uses defaultReaperGrace.
+	Grace time.Duration
+	// Interval is how often the background loop ticks. Zero uses
+	// defaultReaperInterval.
+	Interval time.Duration
+	// Log receives one-line audit messages (machine id + outcome). Nil
+	// discards. Never receives secrets.
+	Log io.Writer
+}
+
+// Reaper reconciles actual provider machines against live leases and destroys
+// strays. It is safe for concurrent use.
+type Reaper struct {
+	provider  MachineProvider
+	activeIDs func() map[string]struct{}
+	now       func() time.Time
+	grace     time.Duration
+	interval  time.Duration
+	log       io.Writer
+}
+
+// NewReaper validates cfg and returns a Reaper.
+func NewReaper(cfg ReaperConfig) (*Reaper, error) {
+	if cfg.Provider == nil {
+		return nil, fmt.Errorf("reaper: Provider is required")
+	}
+	if cfg.ActiveIDs == nil {
+		return nil, fmt.Errorf("reaper: ActiveIDs is required")
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	grace := cfg.Grace
+	if grace <= 0 {
+		grace = defaultReaperGrace
+	}
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = defaultReaperInterval
+	}
+	log := cfg.Log
+	if log == nil {
+		log = io.Discard
+	}
+	return &Reaper{
+		provider:  cfg.Provider,
+		activeIDs: cfg.ActiveIDs,
+		now:       now,
+		grace:     grace,
+		interval:  interval,
+		log:       log,
+	}, nil
+}
+
+// ReconcileOnce lists managed machines, compares against active leases, and
+// destroys orphans that are older than the grace period. A machine with a zero
+// CreatedAt (unknown age) is treated as NOT-yet-past-grace and spared
+// (fail-safe: do not destroy what we cannot age-check).
+//
+// Returns the count of machines destroyed. Returns a non-nil error only when
+// the list call itself fails; individual destroy errors are logged and
+// skipped.
+func (r *Reaper) ReconcileOnce(ctx context.Context) (int, error) {
+	machines, err := r.provider.ListManagedMachines(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("reaper: list managed machines: %w", err)
+	}
+	active := r.activeIDs()
+	now := r.now()
+	destroyed := 0
+	for _, m := range machines {
+		if _, ok := active[m.ID]; ok {
+			continue // actively leased
+		}
+		// SAFETY INVARIANT: a machine younger than grace is ALWAYS spared.
+		// A zero/unknown CreatedAt is treated as NOT-yet-past-grace.
+		if m.CreatedAt.IsZero() || now.Sub(m.CreatedAt) < r.grace {
+			continue
+		}
+		if dErr := r.provider.DestroyMachine(ctx, m.ID); dErr != nil {
+			_, _ = fmt.Fprintf(r.log, "reaper: destroy %s: %v\n", m.ID, dErr)
+			continue
+		}
+		_, _ = fmt.Fprintf(r.log, "reaper: destroyed orphan %s (age %s)\n", m.ID, now.Sub(m.CreatedAt).Truncate(time.Second))
+		destroyed++
+	}
+	return destroyed, nil
+}
+
+// Run calls ReconcileOnce immediately (startup reconciliation), then ticks
+// every interval until ctx is done. It exits promptly on context cancellation.
+func (r *Reaper) Run(ctx context.Context) {
+	// Startup reconciliation: destroy orphans left by a prior broker instance.
+	if _, err := r.ReconcileOnce(ctx); err != nil {
+		_, _ = fmt.Fprintf(r.log, "reaper: startup reconcile: %v\n", err)
+	}
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := r.ReconcileOnce(ctx); err != nil {
+				_, _ = fmt.Fprintf(r.log, "reaper: reconcile: %v\n", err)
+			}
+		}
+	}
+}

--- a/internal/playground/broker/reaper.go
+++ b/internal/playground/broker/reaper.go
@@ -31,8 +31,8 @@ const (
 type ReaperConfig struct {
 	// Provider lists managed machines and destroys orphans.
 	Provider MachineProvider
-	// ActiveIDs returns the set of machine IDs currently held in active
-	// leases (LeaseManager.ActiveMachineIDs).
+	// ActiveIDs returns provider machine IDs protected from orphan cleanup:
+	// active leases plus any warm-pool machines or in-flight warm handoffs.
 	ActiveIDs func() map[string]struct{}
 	// Now returns the current time. Injectable for tests; nil uses time.Now.
 	Now func() time.Time

--- a/internal/playground/broker/reaper_test.go
+++ b/internal/playground/broker/reaper_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestReaperReconcileOnce(t *testing.T) {
+	const graceWindow = 5 * time.Minute
+
+	baseTime := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		machines     []Machine
+		activeIDs    map[string]struct{}
+		wantDestroy  int
+		wantSpareIDs []string
+	}{
+		{
+			name: "destroy stray older than grace",
+			machines: []Machine{
+				{ID: "orphan-old", State: "started", CreatedAt: baseTime.Add(-10 * time.Minute)},
+			},
+			activeIDs:   map[string]struct{}{},
+			wantDestroy: 1,
+		},
+		{
+			name: "spare active machine even if old",
+			machines: []Machine{
+				{ID: "active-old", State: "started", CreatedAt: baseTime.Add(-10 * time.Minute)},
+			},
+			activeIDs:    map[string]struct{}{"active-old": {}},
+			wantDestroy:  0,
+			wantSpareIDs: []string{"active-old"},
+		},
+		{
+			name: "spare too-young machine not in active set (mid-setup race guard)",
+			machines: []Machine{
+				{ID: "young-orphan", State: "created", CreatedAt: baseTime.Add(-30 * time.Second)},
+			},
+			activeIDs:    map[string]struct{}{},
+			wantDestroy:  0,
+			wantSpareIDs: []string{"young-orphan"},
+		},
+		{
+			name: "spare machine with zero CreatedAt (unknown age)",
+			machines: []Machine{
+				{ID: "unknown-age", State: "started"},
+			},
+			activeIDs:    map[string]struct{}{},
+			wantDestroy:  0,
+			wantSpareIDs: []string{"unknown-age"},
+		},
+		{
+			name: "mixed: destroy old orphan, spare active and young",
+			machines: []Machine{
+				{ID: "orphan-old", State: "started", CreatedAt: baseTime.Add(-10 * time.Minute)},
+				{ID: "active-old", State: "started", CreatedAt: baseTime.Add(-10 * time.Minute)},
+				{ID: "young", State: "created", CreatedAt: baseTime.Add(-10 * time.Second)},
+				{ID: "unknown", State: "started"},
+			},
+			activeIDs:    map[string]struct{}{"active-old": {}},
+			wantDestroy:  1,
+			wantSpareIDs: []string{"active-old", "young", "unknown"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fp := &fakeProvider{managedMachines: tt.machines}
+			var logBuf bytes.Buffer
+			reaper, err := NewReaper(ReaperConfig{
+				Provider:  fp,
+				ActiveIDs: func() map[string]struct{} { return tt.activeIDs },
+				Now:       func() time.Time { return baseTime },
+				Grace:     graceWindow,
+				Interval:  time.Hour, // irrelevant for ReconcileOnce
+				Log:       &logBuf,
+			})
+			if err != nil {
+				t.Fatalf("NewReaper: %v", err)
+			}
+			destroyed, err := reaper.ReconcileOnce(context.Background())
+			if err != nil {
+				t.Fatalf("ReconcileOnce: %v", err)
+			}
+			if destroyed != tt.wantDestroy {
+				t.Errorf("destroyed = %d, want %d", destroyed, tt.wantDestroy)
+			}
+			fp.mu.Lock()
+			destroyedSet := make(map[string]struct{}, len(fp.destroyed))
+			for _, id := range fp.destroyed {
+				destroyedSet[id] = struct{}{}
+			}
+			fp.mu.Unlock()
+			for _, id := range tt.wantSpareIDs {
+				if _, ok := destroyedSet[id]; ok {
+					t.Errorf("machine %s should have been spared but was destroyed", id)
+				}
+			}
+		})
+	}
+}
+
+func TestReaperReconcileOnceListError(t *testing.T) {
+	fp := &fakeProvider{listErr: errors.New("provider down")}
+	reaper, err := NewReaper(ReaperConfig{
+		Provider:  fp,
+		ActiveIDs: func() map[string]struct{} { return nil },
+		Log:       &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatalf("NewReaper: %v", err)
+	}
+	_, recErr := reaper.ReconcileOnce(context.Background())
+	if recErr == nil {
+		t.Fatal("ReconcileOnce should fail when list fails")
+	}
+	if !strings.Contains(recErr.Error(), "provider down") {
+		t.Errorf("error should wrap list error: %v", recErr)
+	}
+}
+
+func TestReaperReconcileOnceDestroyError(t *testing.T) {
+	// A destroy error should be logged and skipped, not fail the whole reconcile.
+	baseTime := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	fp := &fakeProvider{
+		managedMachines: []Machine{
+			{ID: "orphan-a", State: "started", CreatedAt: baseTime.Add(-10 * time.Minute)},
+			{ID: "orphan-b", State: "started", CreatedAt: baseTime.Add(-10 * time.Minute)},
+		},
+	}
+	// Make DestroyMachine fail for all calls by replacing the fake's
+	// DestroyMachine behavior: use a destroyErr-capable fake wrapper.
+	destroyCallCount := 0
+	original := fp
+	wrapper := &destroyErrProvider{fakeProvider: original, destroyErr: errors.New("nope")}
+
+	var logBuf bytes.Buffer
+	reaper, err := NewReaper(ReaperConfig{
+		Provider:  wrapper,
+		ActiveIDs: func() map[string]struct{} { return map[string]struct{}{} },
+		Now:       func() time.Time { return baseTime },
+		Grace:     5 * time.Minute,
+		Log:       &logBuf,
+	})
+	if err != nil {
+		t.Fatalf("NewReaper: %v", err)
+	}
+	destroyed, recErr := reaper.ReconcileOnce(context.Background())
+	if recErr != nil {
+		t.Fatalf("ReconcileOnce should not fail for destroy errors: %v", recErr)
+	}
+	if destroyed != 0 {
+		t.Errorf("destroyed = %d, want 0 (all destroys failed)", destroyed)
+	}
+	_ = destroyCallCount
+	if !strings.Contains(logBuf.String(), "nope") {
+		t.Errorf("destroy error should be logged: %s", logBuf.String())
+	}
+}
+
+// destroyErrProvider wraps fakeProvider but makes DestroyMachine always fail.
+type destroyErrProvider struct {
+	*fakeProvider
+	destroyErr error
+}
+
+func (d *destroyErrProvider) DestroyMachine(_ context.Context, _ string) error {
+	return d.destroyErr
+}
+
+func TestReaperRunStartupReconcileAndCancel(t *testing.T) {
+	baseTime := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	fp := &fakeProvider{
+		managedMachines: []Machine{
+			{ID: "startup-orphan", State: "started", CreatedAt: baseTime.Add(-10 * time.Minute)},
+		},
+	}
+	var logBuf bytes.Buffer
+	reaper, err := NewReaper(ReaperConfig{
+		Provider:  fp,
+		ActiveIDs: func() map[string]struct{} { return map[string]struct{}{} },
+		Now:       func() time.Time { return baseTime },
+		Grace:     5 * time.Minute,
+		Interval:  50 * time.Millisecond, // short for test
+		Log:       &logBuf,
+	})
+	if err != nil {
+		t.Fatalf("NewReaper: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		reaper.Run(ctx)
+		close(done)
+	}()
+
+	// Wait for the startup reconcile to have destroyed the orphan.
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	for {
+		fp.mu.Lock()
+		n := len(fp.destroyed)
+		fp.mu.Unlock()
+		if n >= 1 {
+			break
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("startup reconcile did not destroy orphan within deadline")
+		default:
+		}
+		// Yield to the reaper goroutine.
+		select {
+		case <-time.After(10 * time.Millisecond):
+		case <-deadline.C:
+			t.Fatal("startup reconcile did not destroy orphan within deadline")
+		}
+	}
+
+	fp.mu.Lock()
+	if len(fp.destroyed) < 1 {
+		t.Error("startup reconcile did not destroy the orphan")
+	}
+	found := false
+	for _, id := range fp.destroyed {
+		if id == "startup-orphan" {
+			found = true
+		}
+	}
+	fp.mu.Unlock()
+	if !found {
+		t.Error("startup-orphan was not destroyed")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not exit after cancel")
+	}
+}
+
+func TestNewReaperValidation(t *testing.T) {
+	fp := &fakeProvider{}
+	tests := []struct {
+		name string
+		cfg  ReaperConfig
+	}{
+		{"no provider", ReaperConfig{ActiveIDs: func() map[string]struct{} { return nil }}},
+		{"no active ids", ReaperConfig{Provider: fp}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewReaper(tt.cfg); err == nil {
+				t.Error("want validation error")
+			}
+		})
+	}
+}
+
+// safeBuffer is a thread-safe bytes.Buffer for tests that read while a
+// goroutine writes.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestReaperRunLogsStartupAndTickErrors(t *testing.T) {
+	fp := &fakeProvider{listErr: errors.New("boom")}
+	logBuf := &safeBuffer{}
+	reaper, err := NewReaper(ReaperConfig{
+		Provider:  fp,
+		ActiveIDs: func() map[string]struct{} { return nil },
+		Interval:  50 * time.Millisecond,
+		Log:       logBuf,
+	})
+	if err != nil {
+		t.Fatalf("NewReaper: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		reaper.Run(ctx)
+		close(done)
+	}()
+
+	// Wait long enough for at least the startup reconcile + one tick to fire
+	// and log the list errors.
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	for strings.Count(logBuf.String(), "boom") < 2 {
+		select {
+		case <-deadline.C:
+			t.Fatalf("expected at least 2 error logs, got: %s", logBuf.String())
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not exit after cancel")
+	}
+}
+
+func TestReaperDefaults(t *testing.T) {
+	reaper, err := NewReaper(ReaperConfig{
+		Provider:  &fakeProvider{},
+		ActiveIDs: func() map[string]struct{} { return nil },
+	})
+	if err != nil {
+		t.Fatalf("NewReaper: %v", err)
+	}
+	if reaper.grace != defaultReaperGrace {
+		t.Errorf("grace = %v, want %v", reaper.grace, defaultReaperGrace)
+	}
+	if reaper.interval != defaultReaperInterval {
+		t.Errorf("interval = %v, want %v", reaper.interval, defaultReaperInterval)
+	}
+}

--- a/internal/playground/broker/reaper_test.go
+++ b/internal/playground/broker/reaper_test.go
@@ -138,9 +138,6 @@ func TestReaperReconcileOnceDestroyError(t *testing.T) {
 			{ID: "orphan-b", State: "started", CreatedAt: baseTime.Add(-10 * time.Minute)},
 		},
 	}
-	// Make DestroyMachine fail for all calls by replacing the fake's
-	// DestroyMachine behavior: use a destroyErr-capable fake wrapper.
-	destroyCallCount := 0
 	original := fp
 	wrapper := &destroyErrProvider{fakeProvider: original, destroyErr: errors.New("nope")}
 
@@ -162,7 +159,9 @@ func TestReaperReconcileOnceDestroyError(t *testing.T) {
 	if destroyed != 0 {
 		t.Errorf("destroyed = %d, want 0 (all destroys failed)", destroyed)
 	}
-	_ = destroyCallCount
+	if wrapper.destroyCalls != 2 {
+		t.Errorf("DestroyMachine calls = %d, want 2", wrapper.destroyCalls)
+	}
 	if !strings.Contains(logBuf.String(), "nope") {
 		t.Errorf("destroy error should be logged: %s", logBuf.String())
 	}
@@ -171,10 +170,12 @@ func TestReaperReconcileOnceDestroyError(t *testing.T) {
 // destroyErrProvider wraps fakeProvider but makes DestroyMachine always fail.
 type destroyErrProvider struct {
 	*fakeProvider
-	destroyErr error
+	destroyErr   error
+	destroyCalls int
 }
 
 func (d *destroyErrProvider) DestroyMachine(_ context.Context, _ string) error {
+	d.destroyCalls++
 	return d.destroyErr
 }
 

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -65,6 +65,11 @@ type ServerConfig struct {
 	// the broker — the caller (main) enforces that. Empty means a code is always
 	// required. It is never sent to clients.
 	DefaultCode string
+	// TurnstileSitekey is the PUBLIC Cloudflare Turnstile site key, reported via
+	// /health so the viewer can render the widget. Empty means no Turnstile
+	// widget (Access-gated or unsafe-no-gate deploy). The secret is held by
+	// HumanVerifier, never here.
+	TurnstileSitekey string
 	// HumanVerifier validates a browser proof before invite-code redemption and
 	// VM lease. Nil disables this gate for private/Access-gated deployments.
 	HumanVerifier HumanVerifier
@@ -283,6 +288,9 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		// (Access-gated deploys): the viewer then auto-starts instead of
 		// prompting for an invite code.
 		"code_required": s.cfg.DefaultCode == "",
+		// turnstile_sitekey is the public site key (empty if no Turnstile gate);
+		// the viewer renders the widget and sends turnstile_token when present.
+		"turnstile_sitekey": s.cfg.TurnstileSitekey,
 	})
 }
 

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -34,6 +34,14 @@ const (
 
 	envVMInviteCode = "PLAYGROUND_CODE"
 
+	// maxArtifactBytes caps the per-artifact size the broker will cache. The
+	// sealed bundle is signed JSON/tar.gz; 16 MiB is generous headroom.
+	maxArtifactBytes = 16 << 20 // 16 MiB
+
+	// maxArtifactCacheEntries bounds the total number of cached artifacts to
+	// prevent unbounded memory growth from many concurrent sessions.
+	maxArtifactCacheEntries = 128
+
 	// defaultVMReadyTimeout bounds the broker's whole VM session-create retry
 	// window. A freshly leased VM reports "started" (Firecracker booted) before it
 	// serves, and crosses TWO fail-closed containment proofs (six 2s egress probes
@@ -122,6 +130,10 @@ type Server struct {
 
 	killed atomic.Bool
 
+	// bundleCache holds sealed artifacts so re-downloads and kit-then-raw
+	// flows survive VM teardown. Keyed by (token, os).
+	bundleCache *artifactCache
+
 	mu       sync.Mutex
 	tokens   map[string]*tokenLease
 	bySess   map[string]string
@@ -135,6 +147,90 @@ type tokenLease struct {
 	sessionKey string
 	lease      *Lease
 	deadline   time.Time
+}
+
+// artifactCacheKey identifies a cached artifact by session token and OS
+// variant (empty string = the raw .tar.gz bundle).
+type artifactCacheKey struct {
+	token string
+	os    string
+}
+
+// artifactCacheEntry holds a single sealed artifact served to visitors.
+type artifactCacheEntry struct {
+	body               []byte
+	contentType        string
+	contentDisposition string
+	insertedAt         time.Time
+}
+
+// artifactCache is a bounded in-memory cache for sealed session artifacts,
+// keyed by (token, os). It survives VM teardown so re-downloads and kit-then-
+// raw flows work after the VM is destroyed.
+type artifactCache struct {
+	mu      sync.Mutex
+	entries map[artifactCacheKey]*artifactCacheEntry
+	ttl     time.Duration
+}
+
+func newArtifactCache(ttl time.Duration) *artifactCache {
+	return &artifactCache{
+		entries: make(map[artifactCacheKey]*artifactCacheEntry),
+		ttl:     ttl,
+	}
+}
+
+// get returns the cached artifact for the key, or nil if absent/expired.
+func (c *artifactCache) get(key artifactCacheKey) *artifactCacheEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return nil
+	}
+	if time.Since(e.insertedAt) > c.ttl {
+		delete(c.entries, key)
+		return nil
+	}
+	return e
+}
+
+// put stores an artifact. If the cache is at capacity, expired entries are
+// evicted first; if still at capacity, the oldest entry is evicted.
+func (c *artifactCache) put(key artifactCacheKey, e *artifactCacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Evict expired entries first.
+	now := time.Now()
+	for k, v := range c.entries {
+		if now.Sub(v.insertedAt) > c.ttl {
+			delete(c.entries, k)
+		}
+	}
+	// If still at capacity, evict the oldest.
+	if len(c.entries) >= maxArtifactCacheEntries {
+		var oldestKey artifactCacheKey
+		var oldestTime time.Time
+		first := true
+		for k, v := range c.entries {
+			if first || v.insertedAt.Before(oldestTime) {
+				oldestKey = k
+				oldestTime = v.insertedAt
+				first = false
+			}
+		}
+		if !first {
+			delete(c.entries, oldestKey)
+		}
+	}
+	c.entries[key] = e
+}
+
+// len returns the number of entries (for testing).
+func (c *artifactCache) len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
 }
 
 type sessionRequest struct {
@@ -192,6 +288,10 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	if vmReadyTimeout <= 0 {
 		vmReadyTimeout = defaultVMReadyTimeout
 	}
+	// The artifact cache TTL covers the session TTL plus generous grace for
+	// re-downloads. 10 minutes is safe: cached bytes are the visitor-facing
+	// signed artifact (offline-verifiable), not secrets.
+	const artifactCacheTTL = 10 * time.Minute
 	s := &Server{
 		cfg:            cfg,
 		ipRate:         livechat.NewRateLimiter(cfg.IPRate),
@@ -201,6 +301,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		global:         livechat.NewDailyBudget(cfg.GlobalDailyBudget),
 		client:         client,
 		vmReadyTimeout: vmReadyTimeout,
+		bundleCache:    newArtifactCache(artifactCacheTTL),
 		tokens:         make(map[string]*tokenLease),
 		bySess:         make(map[string]string),
 		reapDone:       make(chan struct{}),
@@ -544,17 +645,127 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 		writeBrokerErr(w, http.StatusTooManyRequests, "rate limited")
 		return
 	}
-	token := r.URL.Query().Get("token")
-	binding := s.lookupToken(token)
+	queryToken := r.URL.Query().Get("token")
+	osParam := r.URL.Query().Get("os")
+
+	// Cache HIT: serve the cached artifact without touching the VM. This
+	// makes re-downloads and kit-then-raw flows work after VM teardown.
+	cacheKey := artifactCacheKey{token: queryToken, os: osParam}
+	if cached := s.bundleCache.get(cacheKey); cached != nil {
+		w.Header().Set("Content-Type", cached.contentType)
+		w.Header().Set("Content-Disposition", cached.contentDisposition)
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(cached.body)
+		return
+	}
+
+	// Cache MISS: the VM must still be alive to fetch the artifact.
+	binding := s.lookupToken(queryToken)
 	if binding == nil {
 		writeBrokerErr(w, http.StatusNotFound, "session not found")
 		return
 	}
-	rec := &statusRecorder{ResponseWriter: w}
-	s.proxy(rec, r, binding, false)
-	if rec.status == http.StatusOK {
-		s.releaseToken(context.WithoutCancel(r.Context()), token)
+
+	// Fetch the requested artifact variant from the VM.
+	fetched, fetchErr := s.fetchVMArtifact(r.Context(), binding.lease, queryToken, osParam)
+	if fetchErr != nil {
+		// Propagate the error without releasing the VM so the client can
+		// retry while the session is still alive.
+		writeBrokerErr(w, http.StatusBadGateway, "session proxy unavailable")
+		return
 	}
+	if fetched.status != http.StatusOK {
+		// Non-200 from the VM (e.g. 503 seal failure): propagate and do NOT
+		// release. The visitor can retry while the VM still lives.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(fetched.status)
+		_, _ = w.Write(fetched.body)
+		return
+	}
+
+	// Store the successfully fetched artifact in the cache.
+	s.bundleCache.put(cacheKey, &artifactCacheEntry{
+		body:               fetched.body,
+		contentType:        fetched.contentType,
+		contentDisposition: fetched.contentDisposition,
+		insertedAt:         time.Now(),
+	})
+
+	// Also prefetch the raw bundle (os="") into the cache so a later
+	// raw-bundle download succeeds even after the VM is gone.
+	if osParam != "" {
+		rawKey := artifactCacheKey{token: queryToken, os: ""}
+		if s.bundleCache.get(rawKey) == nil {
+			if raw, rawErr := s.fetchVMArtifact(r.Context(), binding.lease, queryToken, ""); rawErr == nil && raw.status == http.StatusOK {
+				s.bundleCache.put(rawKey, &artifactCacheEntry{
+					body:               raw.body,
+					contentType:        raw.contentType,
+					contentDisposition: raw.contentDisposition,
+					insertedAt:         time.Now(),
+				})
+			}
+		}
+	}
+
+	// The artifact is durably cached. NOW release the VM.
+	s.releaseToken(context.WithoutCancel(r.Context()), queryToken)
+
+	// Serve the fetched artifact to the client.
+	w.Header().Set("Content-Type", fetched.contentType)
+	w.Header().Set("Content-Disposition", fetched.contentDisposition)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(fetched.body)
+}
+
+// vmArtifact holds the result of a direct bounded GET to the VM's bundle route.
+type vmArtifact struct {
+	status             int
+	body               []byte
+	contentType        string
+	contentDisposition string
+}
+
+// fetchVMArtifact makes a bounded HTTP GET to the VM's bundle endpoint and
+// reads the full response body into memory. It does NOT use the streaming
+// reverse proxy because the broker needs the complete body to cache it.
+func (s *Server) fetchVMArtifact(ctx context.Context, lease *Lease, vmToken, osParam string) (vmArtifact, error) {
+	target, err := s.targetURL(lease, livechat.RouteBundle)
+	if err != nil {
+		return vmArtifact{}, err
+	}
+	q := target.Query()
+	q.Set("token", vmToken)
+	if osParam != "" {
+		q.Set("os", osParam)
+	}
+	target.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
+	if err != nil {
+		return vmArtifact{}, fmt.Errorf("broker: build bundle request: %w", err)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return vmArtifact{}, fmt.Errorf("broker: fetch bundle: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxArtifactBytes+1))
+	if err != nil {
+		return vmArtifact{}, fmt.Errorf("broker: read bundle body: %w", err)
+	}
+	if len(body) > maxArtifactBytes {
+		return vmArtifact{}, fmt.Errorf("broker: bundle body exceeds %d bytes", maxArtifactBytes)
+	}
+
+	return vmArtifact{
+		status:             resp.StatusCode,
+		body:               body,
+		contentType:        resp.Header.Get("Content-Type"),
+		contentDisposition: resp.Header.Get("Content-Disposition"),
+	}, nil
 }
 
 func (s *Server) createVMSession(ctx context.Context, lease *Lease, code string) (vmSessionResponse, time.Time, error) {

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -34,13 +34,23 @@ const (
 
 	envVMInviteCode = "PLAYGROUND_CODE"
 
-	// maxArtifactBytes caps the per-artifact size the broker will cache. The
-	// sealed bundle is signed JSON/tar.gz; 16 MiB is generous headroom.
+	// maxArtifactBytes caps the per-artifact size of the raw sealed bundle the
+	// broker will cache. The bundle is signed JSON/tar.gz; 16 MiB is generous.
 	maxArtifactBytes = 16 << 20 // 16 MiB
 
+	// maxKitBytes caps the per-artifact size of a verify kit (os != ""), which
+	// bundles a platform verifier binary alongside the signed run and is much
+	// larger than the raw bundle. Kept separate so a future notarized/universal
+	// build cannot silently exceed the bundle cap and fail on one platform only.
+	maxKitBytes = 64 << 20 // 64 MiB
+
 	// maxArtifactCacheEntries bounds the total number of cached artifacts to
-	// prevent unbounded memory growth from many concurrent sessions.
-	maxArtifactCacheEntries = 128
+	// prevent unbounded memory growth. A single session can hold up to four
+	// entries (the raw bundle plus a per-OS verify kit each), so this is sized
+	// well above the global daily session budget to keep a traffic spike from
+	// evicting one visitor's artifact before they re-download within the cache
+	// TTL. Each entry is capped at maxArtifactBytes, bounding worst-case memory.
+	maxArtifactCacheEntries = 256
 
 	// defaultVMReadyTimeout bounds the broker's whole VM session-create retry
 	// window. A freshly leased VM reports "started" (Firecracker booted) before it
@@ -140,6 +150,15 @@ type Server struct {
 	starts   []time.Time
 	closed   bool
 	reapDone chan struct{}
+
+	// bundleInflight counts in-flight bundle-download requests per token, and
+	// bundleSealed records tokens whose artifact is durably cached. Together
+	// they hold the VM until every concurrent download for a token finishes, so
+	// a fast variant (raw bundle, a double-click, a second tab) cannot
+	// release/destroy the VM while another variant is still being fetched. Both
+	// are guarded by mu.
+	bundleInflight map[string]int
+	bundleSealed   map[string]bool
 }
 
 type tokenLease struct {
@@ -431,7 +450,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		code = s.cfg.DefaultCode
 	}
 	if code == "" {
-		writeBrokerErr(w, http.StatusForbidden, "invite code rejected")
+		writeBrokerErr(w, http.StatusUnauthorized, "invite code rejected")
 		return
 	}
 	if s.cfg.HumanVerifier != nil {
@@ -667,37 +686,54 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Mark this request in-flight for the token so a concurrent download of a
+	// different variant (raw bundle + OS kit, a double-click, two tabs, browser
+	// prefetch/retry) cannot release/destroy the VM while another fetch is still
+	// running. The VM is released only when the LAST in-flight request for the
+	// token finishes AND an artifact has been durably sealed into the cache.
+	s.bundleEnter(queryToken)
+	defer func() {
+		if s.bundleLeave(queryToken) {
+			s.releaseToken(context.WithoutCancel(r.Context()), queryToken)
+		}
+	}()
+
+	// Detach the fetch from request cancellation so a client disconnect mid-
+	// fetch cannot abort populating the durable cache.
+	fetchCtx := context.WithoutCancel(r.Context())
+
 	// Fetch the requested artifact variant from the VM.
-	fetched, fetchErr := s.fetchVMArtifact(r.Context(), binding.lease, queryToken, osParam)
+	fetched, fetchErr := s.fetchVMArtifact(fetchCtx, binding.lease, queryToken, osParam)
 	if fetchErr != nil {
-		// Propagate the error without releasing the VM so the client can
-		// retry while the session is still alive.
+		// Propagate without sealing so the VM is retained for retry.
 		writeBrokerErr(w, http.StatusBadGateway, "session proxy unavailable")
 		return
 	}
 	if fetched.status != http.StatusOK {
 		// Non-200 from the VM (e.g. 503 seal failure): propagate and do NOT
-		// release. The visitor can retry while the VM still lives.
+		// seal. The visitor can retry while the VM still lives.
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(fetched.status)
 		_, _ = w.Write(fetched.body)
 		return
 	}
 
-	// Store the successfully fetched artifact in the cache.
+	// Store the successfully fetched artifact in the cache and mark the token
+	// sealed so the VM may be released once all in-flight requests finish.
 	s.bundleCache.put(cacheKey, &artifactCacheEntry{
 		body:               fetched.body,
 		contentType:        fetched.contentType,
 		contentDisposition: fetched.contentDisposition,
 		insertedAt:         time.Now(),
 	})
+	s.bundleSeal(queryToken)
 
 	// Also prefetch the raw bundle (os="") into the cache so a later
 	// raw-bundle download succeeds even after the VM is gone.
 	if osParam != "" {
 		rawKey := artifactCacheKey{token: queryToken, os: ""}
 		if s.bundleCache.get(rawKey) == nil {
-			if raw, rawErr := s.fetchVMArtifact(r.Context(), binding.lease, queryToken, ""); rawErr == nil && raw.status == http.StatusOK {
+			if raw, rawErr := s.fetchVMArtifact(fetchCtx, binding.lease, queryToken, ""); rawErr == nil && raw.status == http.StatusOK {
 				s.bundleCache.put(rawKey, &artifactCacheEntry{
 					body:               raw.body,
 					contentType:        raw.contentType,
@@ -708,15 +744,53 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// The artifact is durably cached. NOW release the VM.
-	s.releaseToken(context.WithoutCancel(r.Context()), queryToken)
-
-	// Serve the fetched artifact to the client.
+	// Serve the fetched artifact to the client. VM release happens in the
+	// deferred bundleLeave once the last in-flight request for the token ends.
 	w.Header().Set("Content-Type", fetched.contentType)
 	w.Header().Set("Content-Disposition", fetched.contentDisposition)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(fetched.body)
+}
+
+// bundleEnter records a handleBundle request as in-flight for the token so the
+// VM is not released while a concurrent artifact fetch for the same token is
+// still running.
+func (s *Server) bundleEnter(token string) {
+	s.mu.Lock()
+	if s.bundleInflight == nil {
+		s.bundleInflight = make(map[string]int)
+	}
+	s.bundleInflight[token]++
+	s.mu.Unlock()
+}
+
+// bundleSeal records that an artifact for the token has been durably cached, so
+// the VM may be released once all in-flight requests finish.
+func (s *Server) bundleSeal(token string) {
+	s.mu.Lock()
+	if s.bundleSealed == nil {
+		s.bundleSealed = make(map[string]bool)
+	}
+	s.bundleSealed[token] = true
+	s.mu.Unlock()
+}
+
+// bundleLeave decrements the in-flight count for the token. It returns true if
+// this was the last in-flight request AND an artifact was sealed, meaning the
+// caller should release the VM now. If no artifact was sealed (every fetch
+// failed), the VM is retained for retry and the reaper reclaims it at TTL.
+func (s *Server) bundleLeave(token string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.bundleInflight[token]--
+	if s.bundleInflight[token] > 0 {
+		return false
+	}
+	delete(s.bundleInflight, token)
+	sealed := s.bundleSealed[token]
+	delete(s.bundleSealed, token)
+	return sealed
 }
 
 // vmArtifact holds the result of a direct bounded GET to the VM's bundle route.
@@ -752,12 +826,18 @@ func (s *Server) fetchVMArtifact(ctx context.Context, lease *Lease, vmToken, osP
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxArtifactBytes+1))
+	// Verify kits (os != "") bundle a platform verifier binary and are far
+	// larger than the raw bundle, so they get a separate, higher cap.
+	sizeCap := int64(maxArtifactBytes)
+	if osParam != "" {
+		sizeCap = int64(maxKitBytes)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, sizeCap+1))
 	if err != nil {
 		return vmArtifact{}, fmt.Errorf("broker: read bundle body: %w", err)
 	}
-	if len(body) > maxArtifactBytes {
-		return vmArtifact{}, fmt.Errorf("broker: bundle body exceeds %d bytes", maxArtifactBytes)
+	if int64(len(body)) > sizeCap {
+		return vmArtifact{}, fmt.Errorf("broker: bundle body exceeds %d bytes", sizeCap)
 	}
 
 	return vmArtifact{
@@ -1107,7 +1187,11 @@ func gateStatus(err error) int {
 	if errors.Is(err, livechat.ErrGateClosed) {
 		return http.StatusServiceUnavailable
 	}
-	return http.StatusForbidden
+	// An invite-code redemption failure is an authentication problem (a bad or
+	// spent code), distinct from the human-verification gate (403). Returning
+	// 401 lets the viewer tell the visitor to fix their code rather than retry
+	// the human check.
+	return http.StatusUnauthorized
 }
 
 func codeKey(code string) string {

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -169,6 +169,7 @@ type Server struct {
 	// are guarded by mu.
 	bundleInflight map[string]int
 	bundleSealed   map[string]bool
+	bundleFailed   map[string]bool
 	// fetchMu serializes concurrent identical (token, os) cache misses so only
 	// one request reads a full artifact from the VM into memory. Guarded by mu.
 	fetchMu map[artifactCacheKey]*sync.Mutex
@@ -772,12 +773,14 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 	fetched, fetchErr := s.fetchVMArtifact(fetchCtx, binding.lease, queryToken, osParam)
 	if fetchErr != nil {
 		// Propagate without sealing so the VM is retained for retry.
+		s.bundleMarkFailed(queryToken)
 		writeBrokerErr(w, http.StatusBadGateway, "session proxy unavailable")
 		return
 	}
 	if fetched.status != http.StatusOK {
 		// Non-200 from the VM (e.g. 503 seal failure): propagate and do NOT
 		// seal. The visitor can retry while the VM still lives.
+		s.bundleMarkFailed(queryToken)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(fetched.status)
 		_, _ = w.Write(fetched.body)
@@ -858,10 +861,22 @@ func (s *Server) bundleSeal(token string) {
 	s.mu.Unlock()
 }
 
+func (s *Server) bundleMarkFailed(token string) {
+	s.mu.Lock()
+	if s.bundleFailed == nil {
+		s.bundleFailed = make(map[string]bool)
+	}
+	s.bundleFailed[token] = true
+	s.mu.Unlock()
+}
+
 // bundleLeave decrements the in-flight count for the token. It returns true if
-// this was the last in-flight request AND an artifact was sealed, meaning the
-// caller should release the VM now. If no artifact was sealed (every fetch
-// failed), the VM is retained for retry and the reaper reclaims it at TTL.
+// this was the last in-flight request, an artifact was sealed, and no concurrent
+// artifact fetch failed, meaning the caller should release the VM now. If any
+// fetch in the wave failed, the VM is retained for retry and the reaper reclaims
+// it at TTL. This preserves the "try another variant / retry the failed
+// download" path instead of letting one successful variant tear down the VM
+// behind a concurrent failed one.
 func (s *Server) bundleLeave(token string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -871,6 +886,11 @@ func (s *Server) bundleLeave(token string) bool {
 	}
 	delete(s.bundleInflight, token)
 	sealed := s.bundleSealed[token]
+	failed := s.bundleFailed[token]
+	delete(s.bundleFailed, token)
+	if failed {
+		return false
+	}
 	delete(s.bundleSealed, token)
 	return sealed
 }

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -52,6 +52,15 @@ const (
 	// TTL. Each entry is capped at maxArtifactBytes, bounding worst-case memory.
 	maxArtifactCacheEntries = 256
 
+	// maxArtifactCacheBytes bounds the total resident size of all cached
+	// artifacts independent of the entry count, so many concurrent large verify
+	// kits cannot exhaust memory. The oldest entries are evicted to stay under it.
+	maxArtifactCacheBytes = 512 << 20 // 512 MiB
+
+	// artifactFetchTimeout bounds a single detached artifact fetch so a stalled
+	// VM cannot pin a goroutine, memory, or the per-token in-flight counter.
+	artifactFetchTimeout = 90 * time.Second
+
 	// defaultVMReadyTimeout bounds the broker's whole VM session-create retry
 	// window. A freshly leased VM reports "started" (Firecracker booted) before it
 	// serves, and crosses TWO fail-closed containment proofs (six 2s egress probes
@@ -159,6 +168,9 @@ type Server struct {
 	// are guarded by mu.
 	bundleInflight map[string]int
 	bundleSealed   map[string]bool
+	// fetchMu serializes concurrent identical (token, os) cache misses so only
+	// one request reads a full artifact from the VM into memory. Guarded by mu.
+	fetchMu map[artifactCacheKey]*sync.Mutex
 }
 
 type tokenLease struct {
@@ -187,15 +199,25 @@ type artifactCacheEntry struct {
 // keyed by (token, os). It survives VM teardown so re-downloads and kit-then-
 // raw flows work after the VM is destroyed.
 type artifactCache struct {
-	mu      sync.Mutex
-	entries map[artifactCacheKey]*artifactCacheEntry
-	ttl     time.Duration
+	mu       sync.Mutex
+	entries  map[artifactCacheKey]*artifactCacheEntry
+	ttl      time.Duration
+	curBytes int64
 }
 
 func newArtifactCache(ttl time.Duration) *artifactCache {
 	return &artifactCache{
 		entries: make(map[artifactCacheKey]*artifactCacheEntry),
 		ttl:     ttl,
+	}
+}
+
+// evictLocked removes an entry and decrements the byte total. Caller holds mu.
+// It is safe to call inside a range over c.entries (Go permits delete-on-range).
+func (c *artifactCache) evictLocked(key artifactCacheKey) {
+	if e, ok := c.entries[key]; ok {
+		c.curBytes -= int64(len(e.body))
+		delete(c.entries, key)
 	}
 }
 
@@ -208,41 +230,47 @@ func (c *artifactCache) get(key artifactCacheKey) *artifactCacheEntry {
 		return nil
 	}
 	if time.Since(e.insertedAt) > c.ttl {
-		delete(c.entries, key)
+		c.evictLocked(key)
 		return nil
 	}
 	return e
 }
 
-// put stores an artifact. If the cache is at capacity, expired entries are
-// evicted first; if still at capacity, the oldest entry is evicted.
+// put stores an artifact, evicting expired entries first and then the oldest
+// entries until both the entry-count cap AND the total-byte budget are
+// satisfied. The byte budget bounds worst-case memory regardless of how many
+// large verify kits are cached at once.
 func (c *artifactCache) put(key artifactCacheKey, e *artifactCacheEntry) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	// Evict expired entries first.
+	// Replace any existing entry for this key (adjust the byte total).
+	c.evictLocked(key)
+	// Evict expired entries.
 	now := time.Now()
 	for k, v := range c.entries {
 		if now.Sub(v.insertedAt) > c.ttl {
-			delete(c.entries, k)
+			c.evictLocked(k)
 		}
 	}
-	// If still at capacity, evict the oldest.
-	if len(c.entries) >= maxArtifactCacheEntries {
+	// Evict the oldest entries until within both the entry and byte budgets.
+	newBytes := int64(len(e.body))
+	for len(c.entries) >= maxArtifactCacheEntries ||
+		(len(c.entries) > 0 && c.curBytes+newBytes > maxArtifactCacheBytes) {
 		var oldestKey artifactCacheKey
 		var oldestTime time.Time
 		first := true
 		for k, v := range c.entries {
 			if first || v.insertedAt.Before(oldestTime) {
-				oldestKey = k
-				oldestTime = v.insertedAt
-				first = false
+				oldestKey, oldestTime, first = k, v.insertedAt, false
 			}
 		}
-		if !first {
-			delete(c.entries, oldestKey)
+		if first {
+			break
 		}
+		c.evictLocked(oldestKey)
 	}
 	c.entries[key] = e
+	c.curBytes += newBytes
 }
 
 // len returns the number of entries (for testing).
@@ -250,6 +278,13 @@ func (c *artifactCache) len() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.entries)
+}
+
+// bytesLen returns the tracked total cached bytes (for testing).
+func (c *artifactCache) bytesLen() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.curBytes
 }
 
 type sessionRequest struct {
@@ -698,9 +733,26 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	// Detach the fetch from request cancellation so a client disconnect mid-
-	// fetch cannot abort populating the durable cache.
-	fetchCtx := context.WithoutCancel(r.Context())
+	// Coalesce concurrent identical (token, os) misses so only ONE request reads
+	// a full artifact from the VM into memory; the others serialize on this
+	// per-variant lock and then read the cache the leader populated.
+	fm := s.bundleFetchMutex(cacheKey)
+	fm.Lock()
+	defer fm.Unlock()
+	if cached := s.bundleCache.get(cacheKey); cached != nil {
+		w.Header().Set("Content-Type", cached.contentType)
+		w.Header().Set("Content-Disposition", cached.contentDisposition)
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(cached.body)
+		return
+	}
+
+	// Detach the fetch from request cancellation so a client disconnect mid-fetch
+	// cannot abort populating the durable cache, but bound it with a hard timeout
+	// so a stalled VM cannot pin a goroutine or the in-flight counter forever.
+	fetchCtx, cancelFetch := context.WithTimeout(context.WithoutCancel(r.Context()), artifactFetchTimeout)
+	defer cancelFetch()
 
 	// Fetch the requested artifact variant from the VM.
 	fetched, fetchErr := s.fetchVMArtifact(fetchCtx, binding.lease, queryToken, osParam)
@@ -763,6 +815,22 @@ func (s *Server) bundleEnter(token string) {
 	}
 	s.bundleInflight[token]++
 	s.mu.Unlock()
+}
+
+// bundleFetchMutex returns the per-(token, os) mutex used to coalesce concurrent
+// identical cache misses so only one request fetches the artifact from the VM.
+func (s *Server) bundleFetchMutex(key artifactCacheKey) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fetchMu == nil {
+		s.fetchMu = make(map[artifactCacheKey]*sync.Mutex)
+	}
+	m := s.fetchMu[key]
+	if m == nil {
+		m = &sync.Mutex{}
+		s.fetchMu[key] = m
+	}
+	return m
 }
 
 // bundleSeal records that an artifact for the token has been durably cached, so

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -89,9 +89,9 @@ type ServerConfig struct {
 	Gate *livechat.Gate
 	// DefaultCode, when non-empty, is the invite code used when a session request
 	// arrives with no code. It MUST be one of the Gate's configured codes, and is
-	// only safe to set when an out-of-band human gate (Cloudflare Access) fronts
-	// the broker — the caller (main) enforces that. Empty means a code is always
-	// required. It is never sent to clients.
+	// only safe to set when a human gate (Turnstile or Cloudflare Access) protects
+	// session creation — the caller (main) enforces that. Empty means a code is
+	// always required. It is never sent to clients.
 	DefaultCode string
 	// TurnstileSitekey is the PUBLIC Cloudflare Turnstile site key, reported via
 	// /health so the viewer can render the widget. Empty means no Turnstile
@@ -475,12 +475,12 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		writeBrokerErr(w, http.StatusBadRequest, "bad request")
 		return
 	}
-	// An empty client code falls back to the configured DefaultCode. DefaultCode
-	// is only ever set when an out-of-band human gate (Cloudflare Access) fronts
-	// the broker, so the email allowlist — not the invite code — is the
-	// authorization, and allowlisted users need not paste a code. The default
-	// code is server-side only (never embedded in client JS). When no DefaultCode
-	// is configured (public/Turnstile path), an empty code is still rejected.
+	// An empty client code falls back to the configured DefaultCode. DefaultCode is
+	// only ever set when a human gate (Turnstile or Cloudflare Access) protects
+	// session creation, so the human proof — not the invite-code prompt — is the
+	// public authorization step. The default code is server-side only (never
+	// embedded in client JS). When no DefaultCode is configured, an empty code is
+	// still rejected.
 	code := body.Code
 	if code == "" {
 		code = s.cfg.DefaultCode
@@ -501,12 +501,6 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	codeLimiterKey := "code:" + codeKey(code)
-	if !s.codeRate.Allow(codeLimiterKey) {
-		writeBrokerErr(w, http.StatusTooManyRequests, "rate limited")
-		return
-	}
-
 	sessionKey, err := newBrokerSessionKey()
 	if err != nil {
 		writeBrokerErr(w, http.StatusInternalServerError, "internal error")
@@ -525,6 +519,13 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	rollback = append(rollback, func() { s.cfg.Gate.Refund(claims) })
+
+	codeLimiterKey := "code:" + claims.CodeID
+	if !s.codeRate.Allow(codeLimiterKey) {
+		undo()
+		writeBrokerErr(w, http.StatusTooManyRequests, "rate limited")
+		return
+	}
 
 	ipBudgetKey := "ip:" + ip
 	codeBudgetKey := "code:" + claims.CodeID

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -237,15 +237,24 @@ func (s *Server) Close() {
 	}
 }
 
-// Kill refuses new sessions/messages and releases every active lease.
+// Kill refuses new sessions/messages, releases every active lease, and drains
+// the warm pool (so a killed broker holds no standing compute/spend and does not
+// keep replenishing warm VMs).
 func (s *Server) Kill() {
 	s.killed.Store(true)
 	s.releaseAll()
+	if s.cfg.WarmPool != nil {
+		s.cfg.WarmPool.Pause(context.Background())
+	}
 }
 
-// Resume clears the kill switch for future sessions.
+// Resume clears the kill switch for future sessions and re-enables warm-pool
+// refill.
 func (s *Server) Resume() {
 	s.killed.Store(false)
+	if s.cfg.WarmPool != nil {
+		s.cfg.WarmPool.Resume()
+	}
 }
 
 // Killed reports whether the broker emergency stop is active.

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -59,6 +59,12 @@ type ServerConfig struct {
 	WarmPool *Pool
 	// Gate validates public invite codes before a VM is leased. Required.
 	Gate *livechat.Gate
+	// DefaultCode, when non-empty, is the invite code used when a session request
+	// arrives with no code. It MUST be one of the Gate's configured codes, and is
+	// only safe to set when an out-of-band human gate (Cloudflare Access) fronts
+	// the broker — the caller (main) enforces that. Empty means a code is always
+	// required. It is never sent to clients.
+	DefaultCode string
 	// HumanVerifier validates a browser proof before invite-code redemption and
 	// VM lease. Nil disables this gate for private/Access-gated deployments.
 	HumanVerifier HumanVerifier
@@ -264,6 +270,10 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		"budget_remaining":           s.global.Remaining(),
 		"killed":                     s.killed.Load(),
 		"session_starts_last_minute": s.sessionStartsSince(time.Now(), time.Minute),
+		// code_required is false when a server-side DefaultCode is configured
+		// (Access-gated deploys): the viewer then auto-starts instead of
+		// prompting for an invite code.
+		"code_required": s.cfg.DefaultCode == "",
 	})
 }
 
@@ -292,7 +302,17 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		writeBrokerErr(w, http.StatusBadRequest, "bad request")
 		return
 	}
-	if body.Code == "" {
+	// An empty client code falls back to the configured DefaultCode. DefaultCode
+	// is only ever set when an out-of-band human gate (Cloudflare Access) fronts
+	// the broker, so the email allowlist — not the invite code — is the
+	// authorization, and allowlisted users need not paste a code. The default
+	// code is server-side only (never embedded in client JS). When no DefaultCode
+	// is configured (public/Turnstile path), an empty code is still rejected.
+	code := body.Code
+	if code == "" {
+		code = s.cfg.DefaultCode
+	}
+	if code == "" {
 		writeBrokerErr(w, http.StatusForbidden, "invite code rejected")
 		return
 	}
@@ -304,7 +324,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	codeLimiterKey := "code:" + codeKey(body.Code)
+	codeLimiterKey := "code:" + codeKey(code)
 	if !s.codeRate.Allow(codeLimiterKey) {
 		writeBrokerErr(w, http.StatusTooManyRequests, "rate limited")
 		return
@@ -315,7 +335,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		writeBrokerErr(w, http.StatusInternalServerError, "internal error")
 		return
 	}
-	_, claims, err := s.cfg.Gate.Redeem(body.Code, sessionKey)
+	_, claims, err := s.cfg.Gate.Redeem(code, sessionKey)
 	if err != nil {
 		writeBrokerErr(w, gateStatus(err), "invite code rejected")
 		return

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -370,6 +370,10 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 			} else {
 				lease = adopted
 			}
+			// Clear the in-flight handoff marker now that the machine is either an
+			// active lease (protected by ActiveMachineIDs) or destroyed. Closes the
+			// reaper TOCTOU window opened by Acquire.
+			s.cfg.WarmPool.FinishHandoff(wm.ID)
 		}
 	}
 	if lease == nil {

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -171,8 +171,10 @@ type Server struct {
 	bundleSealed   map[string]bool
 	bundleFailed   map[string]bool
 	// fetchMu serializes concurrent identical (token, os) cache misses so only
-	// one request reads a full artifact from the VM into memory. Guarded by mu.
-	fetchMu map[artifactCacheKey]*sync.Mutex
+	// one request reads a full artifact from the VM into memory. Entries are
+	// removed after the last waiter leaves so long-running brokers cannot grow
+	// one lock per historical session. Guarded by mu.
+	fetchMu map[artifactCacheKey]*artifactFetchLock
 }
 
 type tokenLease struct {
@@ -187,6 +189,11 @@ type tokenLease struct {
 type artifactCacheKey struct {
 	token string
 	os    string
+}
+
+type artifactFetchLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 // artifactCacheEntry holds a single sealed artifact served to visitors.
@@ -751,9 +758,8 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 	// Coalesce concurrent identical (token, os) misses so only ONE request reads
 	// a full artifact from the VM into memory; the others serialize on this
 	// per-variant lock and then read the cache the leader populated.
-	fm := s.bundleFetchMutex(cacheKey)
-	fm.Lock()
-	defer fm.Unlock()
+	fm := s.bundleFetchLock(cacheKey)
+	defer s.bundleFetchUnlock(cacheKey, fm)
 	if cached := s.bundleCache.get(cacheKey); cached != nil {
 		w.Header().Set("Content-Type", cached.contentType)
 		w.Header().Set("Content-Disposition", cached.contentDisposition)
@@ -795,10 +801,10 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 		contentDisposition: fetched.contentDisposition,
 		insertedAt:         time.Now(),
 	})
-	s.bundleSeal(queryToken)
 
 	// Also prefetch the raw bundle (os="") into the cache so a later
 	// raw-bundle download succeeds even after the VM is gone.
+	sealToken := true
 	if osParam != "" {
 		rawKey := artifactCacheKey{token: queryToken, os: ""}
 		if s.bundleCache.get(rawKey) == nil {
@@ -809,8 +815,14 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 					contentDisposition: raw.contentDisposition,
 					insertedAt:         time.Now(),
 				})
+			} else {
+				sealToken = false
+				s.bundleMarkFailed(queryToken)
 			}
 		}
+	}
+	if sealToken {
+		s.bundleSeal(queryToken)
 	}
 
 	// Serve the fetched artifact to the client. VM release happens in the
@@ -834,20 +846,33 @@ func (s *Server) bundleEnter(token string) {
 	s.mu.Unlock()
 }
 
-// bundleFetchMutex returns the per-(token, os) mutex used to coalesce concurrent
+// bundleFetchLock locks the per-(token, os) mutex used to coalesce concurrent
 // identical cache misses so only one request fetches the artifact from the VM.
-func (s *Server) bundleFetchMutex(key artifactCacheKey) *sync.Mutex {
+// The returned lock must be released with bundleFetchUnlock.
+func (s *Server) bundleFetchLock(key artifactCacheKey) *artifactFetchLock {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.fetchMu == nil {
-		s.fetchMu = make(map[artifactCacheKey]*sync.Mutex)
+		s.fetchMu = make(map[artifactCacheKey]*artifactFetchLock)
 	}
 	m := s.fetchMu[key]
 	if m == nil {
-		m = &sync.Mutex{}
+		m = &artifactFetchLock{}
 		s.fetchMu[key] = m
 	}
+	m.refs++
+	s.mu.Unlock()
+	m.mu.Lock()
 	return m
+}
+
+func (s *Server) bundleFetchUnlock(key artifactCacheKey, m *artifactFetchLock) {
+	m.mu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m.refs--
+	if m.refs == 0 && s.fetchMu[key] == m {
+		delete(s.fetchMu, key)
+	}
 }
 
 // bundleSeal records that an artifact for the token has been durably cached, so

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -53,6 +53,10 @@ const (
 type ServerConfig struct {
 	// Leases owns VM lifecycle and the global machine concurrency cap. Required.
 	Leases *LeaseManager
+	// WarmPool is the optional pre-created VM pool. When set, handleSession
+	// tries to acquire a warm VM before falling back to the synchronous
+	// Lease() create path. Nil disables warm-pool handout.
+	WarmPool *Pool
 	// Gate validates public invite codes before a VM is leased. Required.
 	Gate *livechat.Gate
 	// HumanVerifier validates a browser proof before invite-code redemption and
@@ -348,22 +352,47 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	}
 	rollback = append(rollback, func() { s.global.Refund(1) })
 
-	vmCode, err := livechat.NewRandomCode(vmInviteCodeBytes)
-	if err != nil {
-		undo()
-		writeBrokerErr(w, http.StatusInternalServerError, "internal error")
-		return
+	// Try the warm pool first for instant handout; fall through to the
+	// synchronous create path if the pool is empty or disabled.
+	//
+	// INVARIANT 3: a visitor NEVER fails because the pool is empty.
+	var lease *Lease
+	var vmCode string
+	if s.cfg.WarmPool != nil {
+		if wm, wc, wRelease, ok := s.cfg.WarmPool.Acquire(); ok {
+			vmCode = wc
+			adopted, adoptErr := s.cfg.Leases.AdoptWarm(sessionKey, wm, wRelease)
+			if adoptErr != nil {
+				// Adoption failed (e.g. duplicate key race). Destroy the warm VM
+				// and release the slot so neither leaks.
+				_ = s.cfg.Leases.cfg.Provider.DestroyMachine(context.WithoutCancel(r.Context()), wm.ID)
+				wRelease()
+			} else {
+				lease = adopted
+			}
+		}
 	}
-	sessionEnv := mergeEnv(s.cfg.SessionEnv, map[string]string{envVMInviteCode: vmCode})
-	lease, err := s.cfg.Leases.Lease(r.Context(), sessionKey, sessionEnv)
-	if err != nil {
-		undo()
-		if errors.Is(err, ErrAtCapacity) {
-			writeBrokerErr(w, http.StatusServiceUnavailable, "at capacity, try again")
+	if lease == nil {
+		// Cold path: mint a fresh vmCode, create a VM synchronously.
+		var codeErr error
+		vmCode, codeErr = livechat.NewRandomCode(vmInviteCodeBytes)
+		if codeErr != nil {
+			undo()
+			writeBrokerErr(w, http.StatusInternalServerError, "internal error")
 			return
 		}
-		writeBrokerErr(w, http.StatusServiceUnavailable, "session could not be started")
-		return
+		sessionEnv := mergeEnv(s.cfg.SessionEnv, map[string]string{envVMInviteCode: vmCode})
+		var leaseErr error
+		lease, leaseErr = s.cfg.Leases.Lease(r.Context(), sessionKey, sessionEnv)
+		if leaseErr != nil {
+			undo()
+			if errors.Is(leaseErr, ErrAtCapacity) {
+				writeBrokerErr(w, http.StatusServiceUnavailable, "at capacity, try again")
+				return
+			}
+			writeBrokerErr(w, http.StatusServiceUnavailable, "session could not be started")
+			return
+		}
 	}
 
 	resp, expiresAt, err := s.createVMSession(r.Context(), lease, vmCode)

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/playground"
 	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
 )
 
@@ -488,6 +489,10 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		writeBrokerErr(w, http.StatusUnauthorized, "invite code rejected")
 		return
 	}
+	if !s.global.Open() {
+		writeBrokerErr(w, http.StatusServiceUnavailable, "daily limit reached, the demo is paused until tomorrow")
+		return
+	}
 	if s.cfg.HumanVerifier != nil {
 		// Turnstile remoteip must be the exact client address, not the /64
 		// abuse bucket, so token-to-IP binding stays correct.
@@ -701,6 +706,14 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 	}
 	queryToken := r.URL.Query().Get("token")
 	osParam := r.URL.Query().Get("os")
+	if osParam != "" {
+		normalized, err := playground.ParseVerifyKitOS(osParam)
+		if err != nil {
+			writeBrokerErr(w, http.StatusBadRequest, "unsupported verify kit")
+			return
+		}
+		osParam = string(normalized)
+	}
 
 	// Cache HIT: serve the cached artifact without touching the VM. This
 	// makes re-downloads and kit-then-raw flows work after VM teardown.

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -1352,6 +1352,41 @@ func TestServer_HumanVerifierRejectsBeforeLease(t *testing.T) {
 	}
 }
 
+func TestServer_GlobalBudgetClosedBeforeHumanVerifier(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "global-before-human-a")
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+	verifier := &serverFakeHumanVerifier{}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{
+		HumanVerifier:     verifier,
+		GlobalDailyBudget: 1,
+	})
+
+	status, _ := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("first status = %d, want 200", status)
+	}
+	if got := verifier.calls(); got != 1 {
+		t.Fatalf("human verifier calls after first session = %d, want 1", got)
+	}
+
+	resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{
+		Code:           brokerTestCode,
+		TurnstileToken: "second-token",
+	})
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("second status = %d, want 503", resp.StatusCode)
+	}
+	if got := verifier.calls(); got != 1 {
+		t.Fatalf("human verifier calls after exhausted global budget = %d, want 1", got)
+	}
+	if got := provider.createdCount(); got != 1 {
+		t.Fatalf("created machines = %d, want 1", got)
+	}
+}
+
 func TestServer_RegisterTokenRefusedAfterKill(t *testing.T) {
 	t.Parallel()
 	provider := &serverFakeProvider{}
@@ -1595,6 +1630,39 @@ func TestServer_BundleKitThenRawBothSucceed(t *testing.T) {
 	// the raw prefetch.
 	if got := vm.bundleHits.Load(); got != 2 {
 		t.Fatalf("VM bundle hits = %d, want 2 (kit + raw prefetch)", got)
+	}
+}
+
+func TestServer_BundleRejectsInvalidOSBeforeVMFetch(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "bad-os-token")
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+	srv, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	status, session := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+
+	badURL := ts.URL + livechat.RouteBundle + "?token=" + url.QueryEscape(session.Token) + "&os=plan9"
+	resp := getBroker(t, badURL)
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("bad os bundle status = %d, want 400", resp.StatusCode)
+	}
+	if got := vm.bundleHits.Load(); got != 0 {
+		t.Fatalf("VM bundle hits after bad os = %d, want 0", got)
+	}
+
+	srv.mu.Lock()
+	fetchMuLen := len(srv.fetchMu)
+	srv.mu.Unlock()
+	if fetchMuLen != 0 {
+		t.Fatalf("fetch mutex entries after bad os = %d, want 0", fetchMuLen)
+	}
+	if got := srv.cfg.Leases.ActiveLeases(); got != 1 {
+		t.Fatalf("active leases after bad os = %d, want 1", got)
 	}
 }
 

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -61,6 +61,12 @@ func (v *serverFakeHumanVerifier) calls() int {
 	return len(v.tokens)
 }
 
+func (v *serverFakeHumanVerifier) setErr(err error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.err = err
+}
+
 func (p *serverFakeProvider) CreateMachine(_ context.Context, spec MachineSpec) (*Machine, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -525,11 +531,11 @@ func getBrokerHealth(t *testing.T, ts *httptest.Server) map[string]any {
 	return body
 }
 
-// TestServer_DefaultCodeFallback proves the Access-gated code-optional path:
+// TestServer_DefaultCodeFallback proves the human-gated code-optional path:
 // with a DefaultCode configured, a session request carrying NO invite code falls
 // back to the default and succeeds (the human gate is the authorization), and
 // health advertises code_required=false. Without a DefaultCode an empty code is
-// still rejected (the public/Turnstile path is unchanged).
+// still rejected.
 func TestServer_DefaultCodeFallback(t *testing.T) {
 	t.Run("empty code uses default when configured", func(t *testing.T) {
 		vm := newFakeVM(t, "vm-default-token")
@@ -555,6 +561,43 @@ func TestServer_DefaultCodeFallback(t *testing.T) {
 		}
 		if health := getBrokerHealth(t, ts); health["code_required"] != true {
 			t.Fatalf("code_required = %v, want true", health["code_required"])
+		}
+	})
+	t.Run("default code still requires human verifier before lease", func(t *testing.T) {
+		vm := newFakeVM(t, "vm-default-human-token")
+		provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+		verifier := &serverFakeHumanVerifier{err: errors.New("missing human proof")}
+		_, ts := newBrokerTestServer(t, provider, ServerConfig{
+			DefaultCode:       brokerTestCode,
+			HumanVerifier:     verifier,
+			GlobalDailyBudget: 1,
+		})
+
+		resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{Code: ""})
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("empty code without human proof = %d, want 403", resp.StatusCode)
+		}
+		if got := verifier.calls(); got != 1 {
+			t.Fatalf("verifier calls = %d, want 1", got)
+		}
+		if got := provider.createdCount(); got != 0 {
+			t.Fatalf("created machines = %d, want 0 before human proof", got)
+		}
+
+		verifier.setErr(nil)
+		resp = postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{
+			Code:           "",
+			TurnstileToken: "human-token",
+		})
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("empty code with human proof after failed attempt = %d, want 200", resp.StatusCode)
+		}
+		if got := provider.createdCount(); got != 1 {
+			t.Fatalf("created machines = %d, want 1 after human proof", got)
 		}
 	})
 }
@@ -1037,6 +1080,30 @@ func TestServer_AbuseControlsReject(t *testing.T) {
 		status, _ := postBrokerSession(t, ts)
 		if status != http.StatusOK {
 			t.Fatalf("valid code after empty-code rejection = %d, want 200", status)
+		}
+	})
+
+	t.Run("unknown_code_spray_does_not_fill_code_rate_keys", func(t *testing.T) {
+		vm := newFakeVM(t, "unknown-code-rate")
+		provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+		_, ts := newBrokerTestServer(t, provider, ServerConfig{
+			DefaultCode: brokerTestCode,
+			CodeRate:    livechat.RateConfig{RefillPerSec: 1000, Burst: 1000, MaxKeys: 1},
+		})
+		resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{Code: "attacker-random-code"})
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("unknown-code status = %d, want 401", resp.StatusCode)
+		}
+		resp = postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{Code: ""})
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("default code after unknown-code spray = %d, want 200", resp.StatusCode)
+		}
+		if got := provider.createdCount(); got != 1 {
+			t.Fatalf("created machines = %d, want only the default-code session", got)
 		}
 	})
 

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -1682,6 +1682,91 @@ func TestServer_BundleConcurrentVariantsHoldVMUntilAllDone(t *testing.T) {
 	}
 }
 
+// TestServer_BundleConcurrentIdenticalCoalesced proves the per-(token, os) fetch
+// lock: two concurrent identical kit downloads result in exactly ONE VM fetch of
+// that variant (the follower reads the cache the leader populated), so N
+// concurrent identical downloads cannot each pull a full kit into memory.
+func TestServer_BundleConcurrentIdenticalCoalesced(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "coalesce-token")
+	vm.bundleHoldOS = "linux"
+	vm.bundleHold = make(chan struct{})
+	vm.bundleHeld = make(chan struct{}, 1)
+	var releaseOnce sync.Once
+	releaseHold := func() { releaseOnce.Do(func() { close(vm.bundleHold) }) }
+	t.Cleanup(releaseHold)
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	status, session := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+	kitURL := ts.URL + livechat.RouteBundle + "?token=" + url.QueryEscape(session.Token) + "&os=linux"
+
+	type res struct {
+		status int
+		body   string
+	}
+	run := func() res {
+		resp := getBroker(t, kitURL)
+		b, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return res{resp.StatusCode, string(b)}
+	}
+	r1 := make(chan res, 1)
+	r2 := make(chan res, 1)
+	go func() { r1 <- run() }() // leader: blocks at the VM, holding the fetch lock
+	select {
+	case <-vm.bundleHeld:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first kit fetch never reached the VM")
+	}
+	go func() { r2 <- run() }() // follower: blocks on the per-variant fetch lock
+	releaseHold()
+	for _, rr := range []res{<-r1, <-r2} {
+		if rr.status != http.StatusOK {
+			t.Fatalf("kit status = %d, want 200", rr.status)
+		}
+		if !strings.HasPrefix(rr.body, "kit-linux-") {
+			t.Fatalf("kit body = %q, want kit-linux-* prefix", rr.body)
+		}
+	}
+	// The kit was fetched from the VM exactly once; the extra hit is the raw
+	// prefetch. Pre-fix (no coalescing) the follower would fetch a second kit.
+	if got := vm.bundleHits.Load(); got != 2 {
+		t.Fatalf("VM bundle hits = %d, want 2 (1 kit + 1 raw prefetch; coalesced)", got)
+	}
+}
+
+// TestArtifactCache_ByteAccounting proves the cache tracks total bytes across
+// put/overwrite/expire so the byte budget can bound worst-case memory.
+func TestArtifactCache_ByteAccounting(t *testing.T) {
+	t.Parallel()
+	c := newArtifactCache(time.Minute)
+	k1 := artifactCacheKey{token: "t", os: "linux"}
+	k2 := artifactCacheKey{token: "t", os: ""}
+	c.put(k1, &artifactCacheEntry{body: make([]byte, 100), insertedAt: time.Now()})
+	c.put(k2, &artifactCacheEntry{body: make([]byte, 50), insertedAt: time.Now()})
+	if got := c.bytesLen(); got != 150 {
+		t.Fatalf("curBytes = %d, want 150", got)
+	}
+	// Overwriting a key adjusts the byte total, not double-counts.
+	c.put(k1, &artifactCacheEntry{body: make([]byte, 300), insertedAt: time.Now()})
+	if got := c.bytesLen(); got != 350 {
+		t.Fatalf("curBytes after overwrite = %d, want 350", got)
+	}
+	// Evicting an expired entry on get decrements the total.
+	exp := newArtifactCache(time.Nanosecond)
+	exp.put(k1, &artifactCacheEntry{body: make([]byte, 200), insertedAt: time.Now().Add(-time.Hour)})
+	if exp.get(k1) != nil {
+		t.Fatal("expired entry should be evicted on get")
+	}
+	if got := exp.bytesLen(); got != 0 {
+		t.Fatalf("curBytes after expired-get = %d, want 0", got)
+	}
+}
+
 // TestServer_BundleVM503DoesNotReleaseVM proves that a 503 from the VM (seal
 // failure) is propagated to the client and the VM is NOT released, so the
 // client can retry while the VM still lives.

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -97,6 +97,10 @@ func (p *serverFakeProvider) DestroyMachine(_ context.Context, id string) error 
 	return nil
 }
 
+func (p *serverFakeProvider) ListManagedMachines(_ context.Context) ([]Machine, error) {
+	return nil, nil
+}
+
 func (p *serverFakeProvider) createdCount() int {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -1817,6 +1817,30 @@ func TestServer_BundleConcurrentVariantsHoldVMUntilAllDone(t *testing.T) {
 	}
 }
 
+func TestServer_BundleFailedConcurrentWaveRetainsVMForRetry(t *testing.T) {
+	t.Parallel()
+	srv := &Server{}
+	const token = "retry-token"
+
+	srv.bundleEnter(token)
+	srv.bundleEnter(token)
+	srv.bundleSeal(token)
+	srv.bundleMarkFailed(token)
+
+	if srv.bundleLeave(token) {
+		t.Fatal("first leave released VM while another artifact fetch was in-flight")
+	}
+	if srv.bundleLeave(token) {
+		t.Fatal("failed concurrent artifact wave released VM; want retained for retry")
+	}
+
+	srv.bundleEnter(token)
+	srv.bundleSeal(token)
+	if !srv.bundleLeave(token) {
+		t.Fatal("successful retry after failed wave did not release VM")
+	}
+}
+
 // TestServer_BundleConcurrentIdenticalCoalesced proves the per-(token, os) fetch
 // lock: two concurrent identical kit downloads result in exactly ONE VM fetch of
 // that variant (the follower reads the cache the leader populated), so N

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -498,6 +498,40 @@ func getBrokerHealth(t *testing.T, ts *httptest.Server) map[string]any {
 	return body
 }
 
+// TestServer_DefaultCodeFallback proves the Access-gated code-optional path:
+// with a DefaultCode configured, a session request carrying NO invite code falls
+// back to the default and succeeds (the human gate is the authorization), and
+// health advertises code_required=false. Without a DefaultCode an empty code is
+// still rejected (the public/Turnstile path is unchanged).
+func TestServer_DefaultCodeFallback(t *testing.T) {
+	t.Run("empty code uses default when configured", func(t *testing.T) {
+		vm := newFakeVM(t, "vm-default-token")
+		provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+		_, ts := newBrokerTestServer(t, provider, ServerConfig{DefaultCode: brokerTestCode})
+
+		resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{Code: ""})
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("empty code with DefaultCode = %d, want 200", resp.StatusCode)
+		}
+		if health := getBrokerHealth(t, ts); health["code_required"] != false {
+			t.Fatalf("code_required = %v, want false when DefaultCode set", health["code_required"])
+		}
+	})
+	t.Run("empty code rejected without default", func(t *testing.T) {
+		provider := &serverFakeProvider{}
+		_, ts := newBrokerTestServer(t, provider, ServerConfig{})
+		resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{Code: ""})
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("empty code without DefaultCode = %d, want 403", resp.StatusCode)
+		}
+		if health := getBrokerHealth(t, ts); health["code_required"] != true {
+			t.Fatalf("code_required = %v, want true", health["code_required"])
+		}
+	})
+}
+
 func TestServer_EndToEndProxyAndRelease(t *testing.T) {
 	vm := newFakeVM(t, "vm-token-a")
 	destroyed := make(chan string, 4)

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -130,7 +130,14 @@ type fakeVM struct {
 	streamRelease chan struct{}
 	bundleStatus  int
 	bundleHits    atomic.Int32
-	server        *httptest.Server
+	// bundleHold, when non-nil, blocks a bundle response whose os matches
+	// bundleHoldOS until the channel is closed; bundleHeld signals (once) that
+	// such a request has reached the block. Used to drive concurrent-download
+	// race tests deterministically.
+	bundleHoldOS string
+	bundleHold   chan struct{}
+	bundleHeld   chan struct{}
+	server       *httptest.Server
 }
 
 func newFakeVM(t *testing.T, token string) *fakeVM {
@@ -218,6 +225,15 @@ func (vm *fakeVM) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		vm.bundleHits.Add(1)
 		osParam := r.URL.Query().Get("os")
+		if vm.bundleHold != nil && osParam == vm.bundleHoldOS {
+			if vm.bundleHeld != nil {
+				select {
+				case vm.bundleHeld <- struct{}{}:
+				default:
+				}
+			}
+			<-vm.bundleHold
+		}
 		if osParam != "" {
 			w.Header().Set("Content-Type", "application/zip")
 			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", "kit-"+osParam+".zip"))
@@ -534,8 +550,8 @@ func TestServer_DefaultCodeFallback(t *testing.T) {
 		_, ts := newBrokerTestServer(t, provider, ServerConfig{})
 		resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{Code: ""})
 		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != http.StatusForbidden {
-			t.Fatalf("empty code without DefaultCode = %d, want 403", resp.StatusCode)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("empty code without DefaultCode = %d, want 401", resp.StatusCode)
 		}
 		if health := getBrokerHealth(t, ts); health["code_required"] != true {
 			t.Fatalf("code_required = %v, want true", health["code_required"])
@@ -1015,8 +1031,8 @@ func TestServer_AbuseControlsReject(t *testing.T) {
 		resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{Code: ""})
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
-		if resp.StatusCode != http.StatusForbidden {
-			t.Fatalf("empty-code status = %d, want 403", resp.StatusCode)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("empty-code status = %d, want 401", resp.StatusCode)
 		}
 		status, _ := postBrokerSession(t, ts)
 		if status != http.StatusOK {
@@ -1104,7 +1120,7 @@ func TestServerDirectHelpers(t *testing.T) {
 	if got := gateStatus(livechat.ErrGateClosed); got != http.StatusServiceUnavailable {
 		t.Fatalf("gateStatus closed = %d", got)
 	}
-	if got := gateStatus(errors.New("bad code")); got != http.StatusForbidden {
+	if got := gateStatus(errors.New("bad code")); got != http.StatusUnauthorized {
 		t.Fatalf("gateStatus other = %d", got)
 	}
 	if got := codeKey("same"); got != codeKey("same") || got == codeKey("different") {
@@ -1582,6 +1598,90 @@ func TestServer_BundleKitThenRawBothSucceed(t *testing.T) {
 	}
 }
 
+// TestServer_BundleConcurrentVariantsHoldVMUntilAllDone proves the per-token
+// in-flight refcount: a fast variant (the raw bundle) completing while a slow
+// variant (an OS kit) is still being fetched must NOT release/destroy the VM.
+// Pre-fix, the fast download's eager releaseToken destroyed the VM mid-fetch of
+// the kit, reproducing the intermittent "download failed" bug under
+// double-clicks, two tabs, or raw+kit clicked together.
+func TestServer_BundleConcurrentVariantsHoldVMUntilAllDone(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "concurrent-token")
+	vm.bundleHoldOS = "linux"
+	vm.bundleHold = make(chan struct{})
+	vm.bundleHeld = make(chan struct{}, 1)
+	var releaseOnce sync.Once
+	releaseHold := func() { releaseOnce.Do(func() { close(vm.bundleHold) }) }
+	// Always release the held VM handler, even if the test fails early, so
+	// httptest.Server.Close() (which waits for outstanding requests) cannot hang.
+	t.Cleanup(releaseHold)
+	destroyed := make(chan string, 4)
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}, destroyedCh: destroyed}
+	srv, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	status, session := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+
+	kitURL := ts.URL + livechat.RouteBundle + "?token=" + url.QueryEscape(session.Token) + "&os=linux"
+	rawURL := ts.URL + livechat.RouteBundle + "?token=" + url.QueryEscape(session.Token)
+
+	// Start the slow kit download; it blocks inside the VM fetch. Read+close the
+	// body inside the goroutine so the response is consumed (and bodyclose-clean).
+	type kitResult struct {
+		status int
+		body   string
+	}
+	kitDone := make(chan kitResult, 1)
+	go func() {
+		resp := getBroker(t, kitURL)
+		b, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		kitDone <- kitResult{status: resp.StatusCode, body: string(b)}
+	}()
+
+	// Wait until the kit fetch has actually reached the VM (in-flight).
+	select {
+	case <-vm.bundleHeld:
+	case <-time.After(2 * time.Second):
+		t.Fatal("kit fetch never reached the VM")
+	}
+
+	// While the kit is still in-flight, the fast raw download completes.
+	rawResp := getBroker(t, rawURL)
+	rawBody, _ := io.ReadAll(rawResp.Body)
+	_ = rawResp.Body.Close()
+	if rawResp.StatusCode != http.StatusOK {
+		t.Fatalf("raw status = %d, want 200", rawResp.StatusCode)
+	}
+	if string(rawBody) != "bundle-"+vm.token {
+		t.Fatalf("raw body = %q, want %q", rawBody, "bundle-"+vm.token)
+	}
+
+	// The VM must STILL be leased: the kit download is in-flight, so the fast
+	// raw download must not have released it.
+	if got := srv.cfg.Leases.ActiveLeases(); got != 1 {
+		t.Fatalf("active leases while kit in-flight = %d, want 1 (VM must be held)", got)
+	}
+
+	// Release the kit fetch; as the last in-flight request it releases the VM.
+	releaseHold()
+	kit := <-kitDone
+	if kit.status != http.StatusOK {
+		t.Fatalf("kit status = %d, want 200", kit.status)
+	}
+	if !strings.HasPrefix(kit.body, "kit-linux-") {
+		t.Fatalf("kit body = %q, want kit-linux-* prefix", kit.body)
+	}
+
+	// Now the VM is released exactly once, after both downloads finished.
+	expectDestroyed(t, destroyed)
+	if got := srv.cfg.Leases.ActiveLeases(); got != 0 {
+		t.Fatalf("active leases after both downloads = %d, want 0", got)
+	}
+}
+
 // TestServer_BundleVM503DoesNotReleaseVM proves that a 503 from the VM (seal
 // failure) is propagated to the client and the VM is NOT released, so the
 // client can retry while the VM still lives.
@@ -1646,7 +1746,7 @@ func TestServer_BundleOversizedDoesNotCache(t *testing.T) {
 		t.Fatalf("session status = %d, want 200", status)
 	}
 
-	resp := getBroker(t, ts.URL+livechat.RouteBundle+"?token=oversize-tok")
+	resp := getBroker(t, ts.URL+livechat.RouteBundle+"?token="+url.QueryEscape("oversize-tok"))
 	_, _ = io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -126,16 +126,17 @@ func (p *serverFakeProvider) createdEnv(index int) map[string]string {
 }
 
 type fakeVM struct {
-	t             *testing.T
-	token         string
-	sessionID     string
-	expiresAt     time.Time
-	sessionCodes  chan string
-	messages      chan string
-	streamStarted chan struct{}
-	streamRelease chan struct{}
-	bundleStatus  int
-	bundleHits    atomic.Int32
+	t               *testing.T
+	token           string
+	sessionID       string
+	expiresAt       time.Time
+	sessionCodes    chan string
+	messages        chan string
+	streamStarted   chan struct{}
+	streamRelease   chan struct{}
+	bundleStatus    int
+	rawBundleStatus int
+	bundleHits      atomic.Int32
 	// bundleHold, when non-nil, blocks a bundle response whose os matches
 	// bundleHoldOS until the channel is closed; bundleHeld signals (once) that
 	// such a request has reached the block. Used to drive concurrent-download
@@ -240,15 +241,19 @@ func (vm *fakeVM) handle(w http.ResponseWriter, r *http.Request) {
 			}
 			<-vm.bundleHold
 		}
+		status := vm.bundleStatus
+		if osParam == "" && vm.rawBundleStatus != 0 {
+			status = vm.rawBundleStatus
+		}
 		if osParam != "" {
 			w.Header().Set("Content-Type", "application/zip")
 			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", "kit-"+osParam+".zip"))
-			w.WriteHeader(vm.bundleStatus)
+			w.WriteHeader(status)
 			_, _ = w.Write([]byte("kit-" + osParam + "-" + vm.token))
 		} else {
 			w.Header().Set("Content-Type", "application/gzip")
 			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", "bundle.tar.gz"))
-			w.WriteHeader(vm.bundleStatus)
+			w.WriteHeader(status)
 			_, _ = w.Write([]byte("bundle-" + vm.token))
 		}
 	default:
@@ -1653,7 +1658,7 @@ func TestServer_BundleKitThenRawBothSucceed(t *testing.T) {
 	vm := newFakeVM(t, "kit-raw-token")
 	destroyed := make(chan string, 4)
 	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}, destroyedCh: destroyed}
-	_, ts := newBrokerTestServer(t, provider, ServerConfig{})
+	srv, ts := newBrokerTestServer(t, provider, ServerConfig{})
 
 	status, session := postBrokerSession(t, ts)
 	if status != http.StatusOK {
@@ -1698,6 +1703,55 @@ func TestServer_BundleKitThenRawBothSucceed(t *testing.T) {
 	if got := vm.bundleHits.Load(); got != 2 {
 		t.Fatalf("VM bundle hits = %d, want 2 (kit + raw prefetch)", got)
 	}
+
+	srv.mu.Lock()
+	fetchMuLen := len(srv.fetchMu)
+	srv.mu.Unlock()
+	if fetchMuLen != 0 {
+		t.Fatalf("fetch mutex entries after bundle downloads = %d, want 0", fetchMuLen)
+	}
+}
+
+func TestServer_BundleKitRawPrefetchFailureRetainsVM(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "raw-prefetch-fail-token")
+	vm.rawBundleStatus = http.StatusServiceUnavailable
+	destroyed := make(chan string, 4)
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}, destroyedCh: destroyed}
+	srv, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	status, session := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+
+	kitURL := ts.URL + livechat.RouteBundle + "?token=" + url.QueryEscape(session.Token) + "&os=linux"
+	kitResp := getBroker(t, kitURL)
+	_, _ = io.ReadAll(kitResp.Body)
+	_ = kitResp.Body.Close()
+	if kitResp.StatusCode != http.StatusOK {
+		t.Fatalf("kit status = %d, want 200", kitResp.StatusCode)
+	}
+
+	select {
+	case id := <-destroyed:
+		t.Fatalf("VM %s was destroyed even though raw prefetch failed", id)
+	default:
+	}
+	if got := srv.cfg.Leases.ActiveLeases(); got != 1 {
+		t.Fatalf("active leases after raw prefetch failure = %d, want 1", got)
+	}
+
+	// Once the raw bundle can be fetched, the token seals and the VM releases.
+	vm.rawBundleStatus = 0
+	rawURL := ts.URL + livechat.RouteBundle + "?token=" + url.QueryEscape(session.Token)
+	rawResp := getBroker(t, rawURL)
+	_, _ = io.ReadAll(rawResp.Body)
+	_ = rawResp.Body.Close()
+	if rawResp.StatusCode != http.StatusOK {
+		t.Fatalf("raw bundle status after retry = %d, want 200", rawResp.StatusCode)
+	}
+	expectDestroyed(t, destroyed)
 }
 
 func TestServer_BundleRejectsInvalidOSBeforeVMFetch(t *testing.T) {

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -129,6 +129,7 @@ type fakeVM struct {
 	streamStarted chan struct{}
 	streamRelease chan struct{}
 	bundleStatus  int
+	bundleHits    atomic.Int32
 	server        *httptest.Server
 }
 
@@ -215,9 +216,19 @@ func (vm *fakeVM) handle(w http.ResponseWriter, r *http.Request) {
 			writeBrokerErr(w, http.StatusForbidden, "wrong VM")
 			return
 		}
-		w.Header().Set("Content-Type", "application/gzip")
-		w.WriteHeader(vm.bundleStatus)
-		_, _ = w.Write([]byte("bundle-" + vm.token))
+		vm.bundleHits.Add(1)
+		osParam := r.URL.Query().Get("os")
+		if osParam != "" {
+			w.Header().Set("Content-Type", "application/zip")
+			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", "kit-"+osParam+".zip"))
+			w.WriteHeader(vm.bundleStatus)
+			_, _ = w.Write([]byte("kit-" + osParam + "-" + vm.token))
+		} else {
+			w.Header().Set("Content-Type", "application/gzip")
+			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", "bundle.tar.gz"))
+			w.WriteHeader(vm.bundleStatus)
+			_, _ = w.Write([]byte("bundle-" + vm.token))
+		}
 	default:
 		writeBrokerErr(w, http.StatusNotFound, "not found")
 	}
@@ -1395,5 +1406,258 @@ func TestServer_HealthDoesNotOverclaimContainment(t *testing.T) {
 	}
 	if _, present := body["contained"]; present {
 		t.Fatal("health must not report a constant 'contained' field the broker cannot prove")
+	}
+}
+
+// --- Artifact cache tests ---
+
+func TestArtifactCache_GetPutEvictTTL(t *testing.T) {
+	t.Parallel()
+	c := newArtifactCache(50 * time.Millisecond)
+
+	key := artifactCacheKey{token: "t1", os: ""}
+	if got := c.get(key); got != nil {
+		t.Fatal("get on empty cache should return nil")
+	}
+
+	entry := &artifactCacheEntry{
+		body:               []byte("hello"),
+		contentType:        "application/gzip",
+		contentDisposition: "attachment",
+		insertedAt:         time.Now(),
+	}
+	c.put(key, entry)
+	if got := c.get(key); got == nil || string(got.body) != "hello" {
+		t.Fatalf("get after put = %v, want hello", got)
+	}
+
+	// Wait for TTL to expire, then verify eviction on read.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.get(key) == nil {
+			return // evicted as expected
+		}
+	}
+	t.Fatal("entry did not expire after TTL")
+}
+
+func TestArtifactCache_CapEvictsOldest(t *testing.T) {
+	t.Parallel()
+	c := newArtifactCache(time.Minute)
+
+	// Fill to capacity.
+	for i := range maxArtifactCacheEntries {
+		k := artifactCacheKey{token: fmt.Sprintf("t%d", i), os: ""}
+		c.put(k, &artifactCacheEntry{
+			body:       []byte(fmt.Sprintf("body%d", i)),
+			insertedAt: time.Now(),
+		})
+	}
+	if c.len() != maxArtifactCacheEntries {
+		t.Fatalf("cache len = %d, want %d", c.len(), maxArtifactCacheEntries)
+	}
+
+	// One more should evict the oldest (t0).
+	c.put(artifactCacheKey{token: "overflow", os: ""}, &artifactCacheEntry{
+		body:       []byte("new"),
+		insertedAt: time.Now(),
+	})
+	if c.len() != maxArtifactCacheEntries {
+		t.Fatalf("cache len after overflow = %d, want %d", c.len(), maxArtifactCacheEntries)
+	}
+	// The oldest entry should be gone.
+	if got := c.get(artifactCacheKey{token: "t0", os: ""}); got != nil {
+		t.Fatal("oldest entry should have been evicted")
+	}
+}
+
+// TestServer_BundleRedownloadAfterVMTeardown proves the core durability fix:
+// after the first successful bundle download releases the VM, a second download
+// (browser retry, double-click) succeeds from the broker's artifact cache.
+func TestServer_BundleRedownloadAfterVMTeardown(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "redownload-token")
+	destroyed := make(chan string, 4)
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}, destroyedCh: destroyed}
+	srv, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	status, session := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+
+	// First download: fetches from VM, caches, releases VM.
+	bundleURL := ts.URL + livechat.RouteBundle + "?token=" + url.QueryEscape(session.Token)
+	resp1 := getBroker(t, bundleURL)
+	body1, err := io.ReadAll(resp1.Body)
+	_ = resp1.Body.Close()
+	if err != nil {
+		t.Fatalf("read first bundle: %v", err)
+	}
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first bundle status = %d, want 200", resp1.StatusCode)
+	}
+	if string(body1) != "bundle-"+vm.token {
+		t.Fatalf("first bundle body = %q, want %q", body1, "bundle-"+vm.token)
+	}
+
+	// VM should be destroyed after first download.
+	expectDestroyed(t, destroyed)
+	if got := srv.cfg.Leases.ActiveLeases(); got != 0 {
+		t.Fatalf("active leases after first download = %d, want 0", got)
+	}
+
+	// Second download: VM is gone, but the cache serves it.
+	resp2 := getBroker(t, bundleURL)
+	body2, err := io.ReadAll(resp2.Body)
+	_ = resp2.Body.Close()
+	if err != nil {
+		t.Fatalf("read second bundle: %v", err)
+	}
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second bundle status = %d, want 200 (cache hit after VM teardown)", resp2.StatusCode)
+	}
+	if string(body2) != string(body1) {
+		t.Fatalf("second bundle body differs from first: %q vs %q", body2, body1)
+	}
+
+	// The VM should have been hit exactly once (not on the second download).
+	if got := vm.bundleHits.Load(); got != 1 {
+		t.Fatalf("VM bundle hits = %d, want 1 (second download should be a cache hit)", got)
+	}
+}
+
+// TestServer_BundleKitThenRawBothSucceed proves the prefetch-raw behavior:
+// downloading a verify-kit (os=linux) also prefetches the raw bundle into the
+// cache, so a subsequent raw download succeeds even after VM teardown.
+func TestServer_BundleKitThenRawBothSucceed(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "kit-raw-token")
+	destroyed := make(chan string, 4)
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}, destroyedCh: destroyed}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	status, session := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+
+	// Download the verify kit (os=linux).
+	kitURL := ts.URL + livechat.RouteBundle + "?token=" + url.QueryEscape(session.Token) + "&os=linux"
+	kitResp := getBroker(t, kitURL)
+	kitBody, err := io.ReadAll(kitResp.Body)
+	_ = kitResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read kit: %v", err)
+	}
+	if kitResp.StatusCode != http.StatusOK {
+		t.Fatalf("kit status = %d, want 200", kitResp.StatusCode)
+	}
+	if !strings.HasPrefix(string(kitBody), "kit-linux-") {
+		t.Fatalf("kit body = %q, want kit-linux-* prefix", kitBody)
+	}
+
+	// VM should be destroyed.
+	expectDestroyed(t, destroyed)
+
+	// Now download the raw bundle. VM is gone, but prefetch should have cached it.
+	rawURL := ts.URL + livechat.RouteBundle + "?token=" + url.QueryEscape(session.Token)
+	rawResp := getBroker(t, rawURL)
+	rawBody, err := io.ReadAll(rawResp.Body)
+	_ = rawResp.Body.Close()
+	if err != nil {
+		t.Fatalf("read raw: %v", err)
+	}
+	if rawResp.StatusCode != http.StatusOK {
+		t.Fatalf("raw bundle status = %d, want 200 (prefetched into cache)", rawResp.StatusCode)
+	}
+	if string(rawBody) != "bundle-"+vm.token {
+		t.Fatalf("raw bundle body = %q, want %q", rawBody, "bundle-"+vm.token)
+	}
+
+	// The VM should have been hit exactly twice: once for the kit, once for
+	// the raw prefetch.
+	if got := vm.bundleHits.Load(); got != 2 {
+		t.Fatalf("VM bundle hits = %d, want 2 (kit + raw prefetch)", got)
+	}
+}
+
+// TestServer_BundleVM503DoesNotReleaseVM proves that a 503 from the VM (seal
+// failure) is propagated to the client and the VM is NOT released, so the
+// client can retry while the VM still lives.
+func TestServer_BundleVM503DoesNotReleaseVM(t *testing.T) {
+	t.Parallel()
+	vm := newFakeVM(t, "vm-503-token")
+	vm.bundleStatus = http.StatusServiceUnavailable
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+	srv, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	status, session := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+
+	bundleURL := ts.URL + livechat.RouteBundle + "?token=" + url.QueryEscape(session.Token)
+	resp := getBroker(t, bundleURL)
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	// The non-200 should be propagated and the lease should be retained.
+	if got := srv.cfg.Leases.ActiveLeases(); got != 1 {
+		t.Fatalf("active leases after VM 503 = %d, want 1 (VM not released)", got)
+	}
+	if got := srv.bundleCache.len(); got != 0 {
+		t.Fatalf("cache len after VM 503 = %d, want 0 (failed fetch must not cache)", got)
+	}
+}
+
+// TestServer_BundleOversizedDoesNotCache proves that an oversized artifact
+// body does not poison the cache and does not release the VM.
+func TestServer_BundleOversizedDoesNotCache(t *testing.T) {
+	t.Parallel()
+	// Create a VM that returns a body exceeding maxArtifactBytes.
+	oversizeBody := strings.Repeat("x", maxArtifactBytes+1)
+	vmsrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case livechat.RouteSession:
+			writeBrokerJSON(w, http.StatusOK, vmSessionResponse{
+				Token:     "oversize-tok",
+				SessionID: "sid-oversize",
+				ExpiresAt: time.Now().Add(time.Minute).UTC().Format(time.RFC3339),
+			})
+		case livechat.RouteBundle:
+			w.Header().Set("Content-Type", "application/gzip")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, oversizeBody)
+		default:
+			writeBrokerErr(w, http.StatusNotFound, "not found")
+		}
+	}))
+	t.Cleanup(vmsrv.Close)
+	u, err := url.Parse(vmsrv.URL)
+	if err != nil {
+		t.Fatalf("parse vm url: %v", err)
+	}
+	provider := &serverFakeProvider{targets: []string{u.Host}}
+	srv, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	status, _ := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+
+	resp := getBroker(t, ts.URL+livechat.RouteBundle+"?token=oversize-tok")
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	// The oversize body should result in a 502 error (fetch failure).
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("oversize bundle status = %d, want 502", resp.StatusCode)
+	}
+	if got := srv.bundleCache.len(); got != 0 {
+		t.Fatalf("cache len after oversize = %d, want 0", got)
+	}
+	if got := srv.cfg.Leases.ActiveLeases(); got != 1 {
+		t.Fatalf("active leases after oversize = %d, want 1 (VM not released on fetch error)", got)
 	}
 }

--- a/internal/playground/broker/turnstile.go
+++ b/internal/playground/broker/turnstile.go
@@ -24,6 +24,11 @@ const (
 	// DefaultTurnstileMaxAge is the default maximum age for a Turnstile
 	// challenge_ts before the verifier rejects it.
 	DefaultTurnstileMaxAge = 5 * time.Minute
+	// DefaultFailedTokenTTL bounds how long a just-failed token is fast-rejected
+	// to dampen Siteverify retry amplification during provider trouble. It is
+	// short so a genuinely valid token blocked by a transient upstream error can
+	// be retried soon after.
+	DefaultFailedTokenTTL = 30 * time.Second
 )
 
 // HumanVerifier validates a browser proof before the broker leases a VM.
@@ -136,6 +141,12 @@ func (s *SeenTokens) CheckAndMark(token string) bool {
 type ReplayGuardVerifier struct {
 	Inner HumanVerifier
 	Seen  *SeenTokens
+	// Failed, when non-nil, is a short-TTL negative cache of tokens whose
+	// upstream verification just failed. It dampens Siteverify retry
+	// amplification (a client resubmitting the same bad token during provider
+	// trouble) without permanently poisoning the token: after the short TTL a
+	// genuinely valid token can be retried.
+	Failed *SeenTokens
 
 	mu       sync.Mutex
 	inflight map[string]chan struct{} // token → done channel
@@ -158,6 +169,12 @@ func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string
 		return ErrTokenAlreadyUsed
 	}
 
+	// Fast-reject a token that just failed upstream, so a client resubmitting a
+	// bad token during provider trouble does not amplify Siteverify calls.
+	if v.Failed != nil && v.Failed.IsSeen(trimmed) {
+		return errTurnstileRejected
+	}
+
 	// Serialize concurrent identical tokens so only one reaches the network.
 	// The second concurrent caller waits for the first to finish, then checks
 	// the seen cache: if the first succeeded the token is consumed and the
@@ -178,7 +195,12 @@ func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string
 		if v.Seen.IsSeen(trimmed) {
 			return ErrTokenAlreadyUsed
 		}
-		// First caller failed — fall through and let this caller try.
+		// If the first caller failed, the negative cache short-circuits this
+		// waiter instead of re-hitting Siteverify with the same bad token.
+		if v.Failed != nil && v.Failed.IsSeen(trimmed) {
+			return errTurnstileRejected
+		}
+		// Otherwise fall through and let this caller try.
 	} else {
 		ch = make(chan struct{})
 		v.inflight[trimmed] = ch
@@ -193,8 +215,12 @@ func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string
 
 	err := v.Inner.Verify(ctx, trimmed, remoteIP)
 	if err != nil {
-		// Failed verification: do NOT record in the seen cache so the token
-		// value is not poisoned for a potentially valid future use.
+		// Failed verification: do NOT record in the (permanent) seen cache so the
+		// token is not poisoned for a potentially valid future use. Record it in
+		// the short-TTL negative cache to dampen immediate retry amplification.
+		if v.Failed != nil {
+			v.Failed.MarkSeen(trimmed)
+		}
 		return err
 	}
 

--- a/internal/playground/broker/turnstile.go
+++ b/internal/playground/broker/turnstile.go
@@ -100,6 +100,9 @@ func (s *SeenTokens) MarkSeen(token string) bool {
 	if len(s.m) >= s.max {
 		return false
 	}
+	if exp, exists := s.m[token]; exists && now.Before(exp) {
+		return false
+	}
 	s.m[token] = now.Add(s.ttl)
 	return true
 }
@@ -164,45 +167,40 @@ func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string
 		return errors.New("turnstile token is too long")
 	}
 
-	// Reject already-verified (consumed) tokens.
-	if v.Seen.IsSeen(trimmed) {
-		return ErrTokenAlreadyUsed
-	}
-
-	// Fast-reject a token that just failed upstream, so a client resubmitting a
-	// bad token during provider trouble does not amplify Siteverify calls.
-	if v.Failed != nil && v.Failed.IsSeen(trimmed) {
-		return errTurnstileRejected
-	}
-
 	// Serialize concurrent identical tokens so only one reaches the network.
 	// The second concurrent caller waits for the first to finish, then checks
 	// the seen cache: if the first succeeded the token is consumed and the
 	// second is rejected, preserving the one-use invariant.
-	v.mu.Lock()
-	if v.inflight == nil {
-		v.inflight = make(map[string]chan struct{})
-	}
-	if ch, ok := v.inflight[trimmed]; ok {
-		v.mu.Unlock()
-		// Another goroutine is verifying this token — wait for it.
-		select {
-		case <-ch:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-		// Re-check: if the first caller succeeded, the token is now consumed.
+	for {
+		// Reject already-verified (consumed) tokens.
 		if v.Seen.IsSeen(trimmed) {
 			return ErrTokenAlreadyUsed
 		}
-		// If the first caller failed, the negative cache short-circuits this
-		// waiter instead of re-hitting Siteverify with the same bad token.
+
+		// Fast-reject a token that just failed upstream, so a client resubmitting a
+		// bad token during provider trouble does not amplify Siteverify calls.
 		if v.Failed != nil && v.Failed.IsSeen(trimmed) {
 			return errTurnstileRejected
 		}
-		// Otherwise fall through and let this caller try.
-	} else {
-		ch = make(chan struct{})
+
+		v.mu.Lock()
+		if v.inflight == nil {
+			v.inflight = make(map[string]chan struct{})
+		}
+		if ch, ok := v.inflight[trimmed]; ok {
+			v.mu.Unlock()
+			// Another goroutine is verifying this token. Wait, then loop back
+			// through the replay/negative-cache/inflight gates. If the leader
+			// failed without populating Failed, exactly one waiter may become the
+			// next leader; the rest keep waiting instead of all hitting upstream.
+			select {
+			case <-ch:
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		ch := make(chan struct{})
 		v.inflight[trimmed] = ch
 		v.mu.Unlock()
 		defer func() {
@@ -211,6 +209,7 @@ func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string
 			close(ch)
 			v.mu.Unlock()
 		}()
+		break
 	}
 
 	err := v.Inner.Verify(ctx, trimmed, remoteIP)

--- a/internal/playground/broker/turnstile.go
+++ b/internal/playground/broker/turnstile.go
@@ -153,6 +153,7 @@ type ReplayGuardVerifier struct {
 
 	mu       sync.Mutex
 	inflight map[string]chan struct{} // token → done channel
+	waitHook func()                   // test hook called when a waiter observes an in-flight token
 }
 
 // Verify rejects already-seen tokens, deduplicates in-flight concurrent
@@ -188,7 +189,11 @@ func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string
 			v.inflight = make(map[string]chan struct{})
 		}
 		if ch, ok := v.inflight[trimmed]; ok {
+			waitHook := v.waitHook
 			v.mu.Unlock()
+			if waitHook != nil {
+				waitHook()
+			}
 			// Another goroutine is verifying this token. Wait, then loop back
 			// through the replay/negative-cache/inflight gates. If the leader
 			// failed without populating Failed, exactly one waiter may become the

--- a/internal/playground/broker/turnstile.go
+++ b/internal/playground/broker/turnstile.go
@@ -21,6 +21,9 @@ const (
 	maxTurnstileTokenBytes    = 2048
 	defaultSeenTokenTTL       = 5 * time.Minute
 	defaultSeenTokenMax       = 10000
+	// DefaultTurnstileMaxAge is the default maximum age for a Turnstile
+	// challenge_ts before the verifier rejects it.
+	DefaultTurnstileMaxAge = 5 * time.Minute
 )
 
 // HumanVerifier validates a browser proof before the broker leases a VM.
@@ -33,10 +36,14 @@ type HumanVerifier interface {
 // use the same human-solve proof to lease two VMs.
 var ErrTokenAlreadyUsed = errors.New("turnstile token already used")
 
-// SeenTokens is a mutex-guarded set of recently submitted Turnstile tokens.
+// SeenTokens is a mutex-guarded set of recently verified Turnstile tokens.
 // It prevents replay-race attacks where two concurrent requests submit the
 // same token before the upstream Siteverify endpoint detects the duplicate.
 // Expired entries are lazily evicted on insert, capping growth.
+//
+// Tokens are recorded ONLY after a successful upstream verification. A failed
+// token does not poison the cache and cannot cause self-DoS by filling it with
+// junk entries.
 type SeenTokens struct {
 	mu  sync.Mutex
 	m   map[string]time.Time // token → expiry
@@ -62,9 +69,42 @@ func NewSeenTokens(ttl time.Duration, now func() time.Time) *SeenTokens {
 	}
 }
 
+// IsSeen returns true if the token is in the cache and not expired.
+func (s *SeenTokens) IsSeen(token string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	exp, exists := s.m[token]
+	return exists && now.Before(exp)
+}
+
+// MarkSeen records a token as consumed after a successful verification.
+// Returns false if the cache is full (fail-closed).
+func (s *SeenTokens) MarkSeen(token string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+
+	// Lazy eviction of expired entries to cap growth.
+	for k, exp := range s.m {
+		if !now.Before(exp) {
+			delete(s.m, k)
+		}
+	}
+
+	if len(s.m) >= s.max {
+		return false
+	}
+	s.m[token] = now.Add(s.ttl)
+	return true
+}
+
 // CheckAndMark atomically checks whether a token has been seen. If not, it
 // marks it and returns true (proceed). If already present and not expired, it
 // returns false (reject). Expired entries for other tokens are lazily evicted.
+//
+// Deprecated: use IsSeen + MarkSeen for the post-verify record pattern.
+// Retained for backward compatibility with tests that exercise the old API.
 func (s *SeenTokens) CheckAndMark(token string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -88,14 +128,22 @@ func (s *SeenTokens) CheckAndMark(token string) bool {
 }
 
 // ReplayGuardVerifier wraps a HumanVerifier with broker-side token replay
-// prevention. The seen-token check runs BEFORE the upstream Siteverify call,
-// so a replayed token never reaches the network.
+// prevention. A token is recorded as consumed ONLY after a successful
+// upstream verification, so an attacker spraying invalid tokens cannot
+// poison the cache and self-DoS legitimate users. Concurrent identical
+// tokens are serialized by singleflight to prevent double-lease during the
+// upstream network call.
 type ReplayGuardVerifier struct {
 	Inner HumanVerifier
 	Seen  *SeenTokens
+
+	mu       sync.Mutex
+	inflight map[string]chan struct{} // token → done channel
 }
 
-// Verify rejects already-seen tokens before delegating to the inner verifier.
+// Verify rejects already-seen tokens, deduplicates in-flight concurrent
+// identical tokens, delegates to the inner verifier, and records successful
+// tokens in the seen cache.
 func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string) error {
 	trimmed := strings.TrimSpace(token)
 	if trimmed == "" {
@@ -104,10 +152,58 @@ func (v *ReplayGuardVerifier) Verify(ctx context.Context, token, remoteIP string
 	if len(trimmed) > maxTurnstileTokenBytes {
 		return errors.New("turnstile token is too long")
 	}
-	if !v.Seen.CheckAndMark(trimmed) {
+
+	// Reject already-verified (consumed) tokens.
+	if v.Seen.IsSeen(trimmed) {
 		return ErrTokenAlreadyUsed
 	}
-	return v.Inner.Verify(ctx, trimmed, remoteIP)
+
+	// Serialize concurrent identical tokens so only one reaches the network.
+	// The second concurrent caller waits for the first to finish, then checks
+	// the seen cache: if the first succeeded the token is consumed and the
+	// second is rejected, preserving the one-use invariant.
+	v.mu.Lock()
+	if v.inflight == nil {
+		v.inflight = make(map[string]chan struct{})
+	}
+	if ch, ok := v.inflight[trimmed]; ok {
+		v.mu.Unlock()
+		// Another goroutine is verifying this token — wait for it.
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		// Re-check: if the first caller succeeded, the token is now consumed.
+		if v.Seen.IsSeen(trimmed) {
+			return ErrTokenAlreadyUsed
+		}
+		// First caller failed — fall through and let this caller try.
+	} else {
+		ch = make(chan struct{})
+		v.inflight[trimmed] = ch
+		v.mu.Unlock()
+		defer func() {
+			v.mu.Lock()
+			delete(v.inflight, trimmed)
+			close(ch)
+			v.mu.Unlock()
+		}()
+	}
+
+	err := v.Inner.Verify(ctx, trimmed, remoteIP)
+	if err != nil {
+		// Failed verification: do NOT record in the seen cache so the token
+		// value is not poisoned for a potentially valid future use.
+		return err
+	}
+
+	// Successful: record as consumed so replays are rejected.
+	if !v.Seen.MarkSeen(trimmed) {
+		// Cache full — fail closed to prevent replay.
+		return ErrTokenAlreadyUsed
+	}
+	return nil
 }
 
 // TurnstileVerifier validates Cloudflare Turnstile tokens via Siteverify.
@@ -115,16 +211,42 @@ type TurnstileVerifier struct {
 	Secret    string
 	VerifyURL string
 	Client    *http.Client
+
+	// ExpectedHostname validates the Siteverify response hostname field.
+	// When non-empty, the challenge must have been solved on this hostname.
+	// Public deployments SHOULD set this to prevent cross-site token reuse.
+	ExpectedHostname string
+
+	// ExpectedAction validates the Siteverify response action field.
+	// When non-empty, the challenge must carry this action label.
+	// Public deployments SHOULD set this to prevent cross-form token reuse.
+	ExpectedAction string
+
+	// MaxAge rejects challenges solved more than this duration ago.
+	// Zero disables freshness checking. Default: 5 minutes (set via flag).
+	// When set, a missing or unparseable challenge_ts fails closed.
+	MaxAge time.Duration
+
+	// Now is an injectable clock for deterministic tests. Nil uses time.Now.
+	Now func() time.Time
 }
 
 type turnstileResponse struct {
-	Success    bool     `json:"success"`
-	ErrorCodes []string `json:"error-codes"`
+	Success     bool     `json:"success"`
+	ErrorCodes  []string `json:"error-codes"`
+	Hostname    string   `json:"hostname"`
+	Action      string   `json:"action"`
+	ChallengeTS string   `json:"challenge_ts"`
 }
 
+// errTurnstileRejected is the generic client-facing error for any post-success
+// validation failure. The specific check that failed is intentionally NOT
+// disclosed to prevent an attacker from iterating on hostname/action/timing.
+var errTurnstileRejected = errors.New("turnstile rejected token")
+
 func (v TurnstileVerifier) Verify(ctx context.Context, token, remoteIP string) error {
-	secret := strings.TrimSpace(v.Secret)
-	if secret == "" {
+	trimmedSecret := strings.TrimSpace(v.Secret)
+	if trimmedSecret == "" {
 		return errors.New("turnstile secret is empty")
 	}
 	trimmedToken := strings.TrimSpace(token)
@@ -143,7 +265,7 @@ func (v TurnstileVerifier) Verify(ctx context.Context, token, remoteIP string) e
 		client = &http.Client{Timeout: 5 * time.Second}
 	}
 	form := url.Values{
-		"secret":   {secret},
+		"secret":   {trimmedSecret},
 		"response": {trimmedToken},
 	}
 	if strings.TrimSpace(remoteIP) != "" {
@@ -171,7 +293,35 @@ func (v TurnstileVerifier) Verify(ctx context.Context, token, remoteIP string) e
 		if len(out.ErrorCodes) > 0 {
 			return fmt.Errorf("turnstile rejected token: %s", strings.Join(out.ErrorCodes, ","))
 		}
-		return errors.New("turnstile rejected token")
+		return errTurnstileRejected
 	}
+
+	// Post-success response validation: hostname, action, and freshness.
+	// Fail closed with a generic error — never disclose which check failed.
+	if v.ExpectedHostname != "" && !strings.EqualFold(out.Hostname, v.ExpectedHostname) {
+		return errTurnstileRejected
+	}
+	if v.ExpectedAction != "" && out.Action != v.ExpectedAction {
+		return errTurnstileRejected
+	}
+	if v.MaxAge > 0 {
+		if out.ChallengeTS == "" {
+			// Missing timestamp with freshness enforcement — fail closed.
+			return errTurnstileRejected
+		}
+		ts, parseErr := time.Parse(time.RFC3339, out.ChallengeTS)
+		if parseErr != nil {
+			// Unparseable timestamp — fail closed.
+			return errTurnstileRejected
+		}
+		now := v.Now
+		if now == nil {
+			now = time.Now
+		}
+		if now().Sub(ts) > v.MaxAge {
+			return errTurnstileRejected
+		}
+	}
+
 	return nil
 }

--- a/internal/playground/broker/turnstile_test.go
+++ b/internal/playground/broker/turnstile_test.go
@@ -481,17 +481,25 @@ func TestReplayGuardVerifier_WaitersRecheckFailedLeader(t *testing.T) {
 		Seen:   NewSeenTokens(time.Minute, nil),
 		Failed: NewSeenTokens(time.Minute, nil),
 	}
+	waitersReady := make(chan struct{})
+	var waiters atomic.Int32
+	guard.waitHook = func() {
+		if waiters.Add(1) == 2 {
+			close(waitersReady)
+		}
+	}
 
 	errs := make(chan error, 3)
-	start := make(chan struct{})
-	for range 3 {
+	go func() {
+		errs <- guard.Verify(context.Background(), "same-token", testRemoteIP)
+	}()
+	<-inner.first
+	for range 2 {
 		go func() {
-			<-start
 			errs <- guard.Verify(context.Background(), "same-token", testRemoteIP)
 		}()
 	}
-	close(start)
-	<-inner.first
+	<-waitersReady
 	close(inner.allow)
 
 	for range 3 {

--- a/internal/playground/broker/turnstile_test.go
+++ b/internal/playground/broker/turnstile_test.go
@@ -504,6 +504,46 @@ func TestReplayGuardVerifier_FailedTokenDoesNotPoisonCache(t *testing.T) {
 	}
 }
 
+func TestReplayGuardVerifier_NegativeCacheDampsRetry(t *testing.T) {
+	t.Parallel()
+	// With a negative cache, a token that just failed upstream is fast-rejected
+	// on immediate retry WITHOUT a second Siteverify call, damping the retry
+	// amplification an attacker (or a provider outage) could otherwise cause.
+	var callCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success":     false,
+			"error-codes": []string{"invalid-input-response"},
+		})
+	}))
+	t.Cleanup(ts.Close)
+
+	inner := TurnstileVerifier{Secret: testSecretVal, VerifyURL: ts.URL, Client: ts.Client()}
+	guard := &ReplayGuardVerifier{
+		Inner:  inner,
+		Seen:   NewSeenTokens(time.Minute, nil),
+		Failed: NewSeenTokens(time.Minute, nil),
+	}
+
+	// First attempt reaches upstream and fails.
+	if err := guard.Verify(context.Background(), "bad-token", testRemoteIP); err == nil {
+		t.Fatal("first Verify should fail")
+	}
+	if got := callCount.Load(); got != 1 {
+		t.Fatalf("Siteverify calls after first attempt = %d, want 1", got)
+	}
+
+	// Immediate retry of the same bad token is short-circuited by the negative
+	// cache: no additional Siteverify call.
+	if err := guard.Verify(context.Background(), "bad-token", testRemoteIP); err == nil {
+		t.Fatal("retry of a just-failed token should be rejected")
+	}
+	if got := callCount.Load(); got != 1 {
+		t.Fatalf("Siteverify calls after retry = %d, want 1 (negative cache must short-circuit)", got)
+	}
+}
+
 func TestReplayGuardVerifier_InvalidTokenDoesNotPopulateSeenCache(t *testing.T) {
 	t.Parallel()
 	var siteverifyCalls atomic.Int32

--- a/internal/playground/broker/turnstile_test.go
+++ b/internal/playground/broker/turnstile_test.go
@@ -407,6 +407,9 @@ func TestSeenTokens_IsSeenAndMarkSeen(t *testing.T) {
 	if !seen.MarkSeen("tok-x") {
 		t.Fatal("MarkSeen should succeed")
 	}
+	if seen.MarkSeen("tok-x") {
+		t.Fatal("duplicate MarkSeen before expiry should reject")
+	}
 	if !seen.IsSeen("tok-x") {
 		t.Fatal("marked token should be seen")
 	}
@@ -447,6 +450,57 @@ func TestReplayGuardVerifier_BlocksReplayAfterSuccess(t *testing.T) {
 	}
 	if siteverifyCalls.Load() != 1 {
 		t.Fatalf("siteverify calls after replay = %d, want still 1 (no network call)", siteverifyCalls.Load())
+	}
+}
+
+type sequenceVerifier struct {
+	calls atomic.Int32
+	first chan struct{}
+	allow chan struct{}
+}
+
+func (v *sequenceVerifier) Verify(ctx context.Context, _, _ string) error {
+	n := v.calls.Add(1)
+	if n == 1 {
+		close(v.first)
+		select {
+		case <-v.allow:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		return errTurnstileRejected
+	}
+	return nil
+}
+
+func TestReplayGuardVerifier_WaitersRecheckFailedLeader(t *testing.T) {
+	t.Parallel()
+	inner := &sequenceVerifier{first: make(chan struct{}), allow: make(chan struct{})}
+	guard := &ReplayGuardVerifier{
+		Inner:  inner,
+		Seen:   NewSeenTokens(time.Minute, nil),
+		Failed: NewSeenTokens(time.Minute, nil),
+	}
+
+	errs := make(chan error, 3)
+	start := make(chan struct{})
+	for range 3 {
+		go func() {
+			<-start
+			errs <- guard.Verify(context.Background(), "same-token", testRemoteIP)
+		}()
+	}
+	close(start)
+	<-inner.first
+	close(inner.allow)
+
+	for range 3 {
+		if err := <-errs; err == nil {
+			t.Fatal("Verify succeeded, want failed leader and waiters to fail closed")
+		}
+	}
+	if got := inner.calls.Load(); got != 1 {
+		t.Fatalf("inner verifier calls = %d, want 1; waiters must recheck failed-token cache", got)
 	}
 }
 

--- a/internal/playground/broker/turnstile_test.go
+++ b/internal/playground/broker/turnstile_test.go
@@ -11,9 +11,33 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+const (
+	testSecretVal = "secret-val"
+	testRemoteIP  = "198.51.100.7"
+)
+
+// turnstileSuccessHandler returns a handler that responds with configurable
+// Siteverify fields. Missing fields use Cloudflare-realistic defaults.
+func turnstileSuccessHandler(t *testing.T, overrides map[string]any) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]any{
+			"success":      true,
+			"hostname":     "playground.pipelab.org",
+			"action":       "session-create",
+			"challenge_ts": time.Now().UTC().Format(time.RFC3339),
+		}
+		for k, v := range overrides {
+			resp[k] = v
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
 
 func TestTurnstileVerifier_Verify(t *testing.T) {
 	t.Parallel()
@@ -33,11 +57,11 @@ func TestTurnstileVerifier_Verify(t *testing.T) {
 	}))
 	t.Cleanup(ts.Close)
 
-	verifier := TurnstileVerifier{Secret: "secret", VerifyURL: ts.URL, Client: ts.Client()}
-	if err := verifier.Verify(context.Background(), "token", "198.51.100.7"); err != nil {
+	verifier := TurnstileVerifier{Secret: testSecretVal, VerifyURL: ts.URL, Client: ts.Client()}
+	if err := verifier.Verify(context.Background(), "tok-value", testRemoteIP); err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
-	if got.Get("secret") != "secret" || got.Get("response") != "token" || got.Get("remoteip") != "198.51.100.7" {
+	if got.Get("secret") != testSecretVal || got.Get("response") != "tok-value" || got.Get("remoteip") != testRemoteIP {
 		t.Fatalf("siteverify form = %v", got)
 	}
 }
@@ -106,8 +130,8 @@ func TestTurnstileVerifier_FailsClosed(t *testing.T) {
 			t.Parallel()
 			ts := httptest.NewServer(tc.handler)
 			t.Cleanup(ts.Close)
-			verifier := TurnstileVerifier{Secret: "secret", VerifyURL: ts.URL, Client: ts.Client()}
-			if err := verifier.Verify(context.Background(), tc.token, "198.51.100.7"); err == nil {
+			verifier := TurnstileVerifier{Secret: testSecretVal, VerifyURL: ts.URL, Client: ts.Client()}
+			if err := verifier.Verify(context.Background(), tc.token, testRemoteIP); err == nil {
 				t.Fatal("Verify succeeded, want fail closed")
 			}
 		})
@@ -116,11 +140,11 @@ func TestTurnstileVerifier_FailsClosed(t *testing.T) {
 
 func TestTurnstileVerifier_RequestBuildAndNetworkErrorsFailClosed(t *testing.T) {
 	t.Parallel()
-	if err := (TurnstileVerifier{Secret: "secret", VerifyURL: "://bad"}).Verify(context.Background(), "token", ""); err == nil {
+	if err := (TurnstileVerifier{Secret: testSecretVal, VerifyURL: "://bad"}).Verify(context.Background(), "token", ""); err == nil {
 		t.Fatal("invalid verify URL should fail closed")
 	}
 	verifier := TurnstileVerifier{
-		Secret:    "secret",
+		Secret:    testSecretVal,
 		VerifyURL: "https://turnstile.example/verify",
 		Client:    &http.Client{Transport: errRoundTripper{}},
 	}
@@ -131,10 +155,153 @@ func TestTurnstileVerifier_RequestBuildAndNetworkErrorsFailClosed(t *testing.T) 
 
 func TestTurnstileVerifier_EmptySecretFailsClosed(t *testing.T) {
 	t.Parallel()
-	if err := (TurnstileVerifier{}).Verify(context.Background(), "token", "198.51.100.7"); err == nil {
+	if err := (TurnstileVerifier{}).Verify(context.Background(), "token", testRemoteIP); err == nil {
 		t.Fatal("Verify with empty secret succeeded, want fail closed")
 	}
 }
+
+// --- Post-success response validation (Issue A) ---
+
+func TestTurnstileVerifier_HostnameActionFreshness(t *testing.T) {
+	t.Parallel()
+
+	freshTS := time.Now().UTC().Format(time.RFC3339)
+	staleTS := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	fixedNow := time.Now().UTC()
+	clock := func() time.Time { return fixedNow }
+
+	tests := []struct {
+		name      string
+		verifier  TurnstileVerifier
+		overrides map[string]any
+		wantErr   bool
+	}{
+		{
+			name: "success_matching_hostname_action_fresh",
+			verifier: TurnstileVerifier{
+				ExpectedHostname: "playground.pipelab.org",
+				ExpectedAction:   "session-create",
+				MaxAge:           5 * time.Minute,
+				Now:              clock,
+			},
+			overrides: map[string]any{
+				"hostname":     "playground.pipelab.org",
+				"action":       "session-create",
+				"challenge_ts": freshTS,
+			},
+			wantErr: false,
+		},
+		{
+			name: "wrong_hostname_rejected",
+			verifier: TurnstileVerifier{
+				ExpectedHostname: "playground.pipelab.org",
+			},
+			overrides: map[string]any{
+				"hostname": "evil.attacker.com",
+			},
+			wantErr: true,
+		},
+		{
+			name: "wrong_action_rejected",
+			verifier: TurnstileVerifier{
+				ExpectedAction: "session-create",
+			},
+			overrides: map[string]any{
+				"action": "wrong-action",
+			},
+			wantErr: true,
+		},
+		{
+			name: "stale_challenge_ts_rejected",
+			verifier: TurnstileVerifier{
+				MaxAge: 5 * time.Minute,
+				Now:    clock,
+			},
+			overrides: map[string]any{
+				"challenge_ts": staleTS,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing_challenge_ts_with_max_age_fails_closed",
+			verifier: TurnstileVerifier{
+				MaxAge: 5 * time.Minute,
+				Now:    clock,
+			},
+			overrides: map[string]any{
+				"challenge_ts": "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "unparseable_challenge_ts_with_max_age_fails_closed",
+			verifier: TurnstileVerifier{
+				MaxAge: 5 * time.Minute,
+				Now:    clock,
+			},
+			overrides: map[string]any{
+				"challenge_ts": "not-a-timestamp",
+			},
+			wantErr: true,
+		},
+		{
+			name: "hostname_case_insensitive",
+			verifier: TurnstileVerifier{
+				ExpectedHostname: "Playground.Pipelab.Org",
+			},
+			overrides: map[string]any{
+				"hostname": "playground.pipelab.org",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "no_validation_fields_set_allows_on_success",
+			verifier: TurnstileVerifier{},
+			overrides: map[string]any{
+				"hostname": "anything.example",
+				"action":   "whatever",
+			},
+			wantErr: false,
+		},
+		{
+			name: "max_age_zero_skips_freshness",
+			verifier: TurnstileVerifier{
+				MaxAge: 0,
+			},
+			overrides: map[string]any{
+				"challenge_ts": staleTS,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := httptest.NewServer(turnstileSuccessHandler(t, tc.overrides))
+			t.Cleanup(ts.Close)
+
+			v := tc.verifier
+			v.Secret = testSecretVal
+			v.VerifyURL = ts.URL
+			v.Client = ts.Client()
+
+			err := v.Verify(context.Background(), "test-token", testRemoteIP)
+			if tc.wantErr && err == nil {
+				t.Fatal("Verify succeeded, want fail closed")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("Verify failed: %v", err)
+			}
+			// Verify that error messages don't leak which check failed.
+			if tc.wantErr && err != nil && !errors.Is(err, errTurnstileRejected) {
+				t.Fatalf("error should be generic errTurnstileRejected, got: %v", err)
+			}
+		})
+	}
+}
+
+// --- SeenTokens unit tests ---
 
 func TestSeenTokens_Defaults(t *testing.T) {
 	t.Parallel()
@@ -206,14 +373,14 @@ func TestSeenTokens_CapFailsClosedUntilExpiry(t *testing.T) {
 func TestSeenTokens_ConcurrentRace(t *testing.T) {
 	t.Parallel()
 	seen := NewSeenTokens(time.Minute, nil)
-	const token = "race-token"
+	const tok = "race-token"
 	const goroutines = 50
 	accepted := make(chan bool, goroutines)
 	start := make(chan struct{})
 	for range goroutines {
 		go func() {
 			<-start
-			accepted <- seen.CheckAndMark(token)
+			accepted <- seen.CheckAndMark(tok)
 		}()
 	}
 	close(start)
@@ -228,60 +395,138 @@ func TestSeenTokens_ConcurrentRace(t *testing.T) {
 	}
 }
 
-func TestReplayGuardVerifier_BlocksReplayBeforeNetwork(t *testing.T) {
+func TestSeenTokens_IsSeenAndMarkSeen(t *testing.T) {
 	t.Parallel()
-	var siteverifyCalls int
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	seen := NewSeenTokens(2*time.Minute, clock)
+
+	if seen.IsSeen("tok-x") {
+		t.Fatal("unseen token should not be seen")
+	}
+	if !seen.MarkSeen("tok-x") {
+		t.Fatal("MarkSeen should succeed")
+	}
+	if !seen.IsSeen("tok-x") {
+		t.Fatal("marked token should be seen")
+	}
+	// After expiry, not seen.
+	now = now.Add(3 * time.Minute)
+	if seen.IsSeen("tok-x") {
+		t.Fatal("expired token should not be seen")
+	}
+}
+
+// --- ReplayGuardVerifier (Issue B: post-verify record pattern) ---
+
+func TestReplayGuardVerifier_BlocksReplayAfterSuccess(t *testing.T) {
+	t.Parallel()
+	var siteverifyCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		siteverifyCalls++
+		siteverifyCalls.Add(1)
 		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
 	}))
 	t.Cleanup(ts.Close)
 
-	inner := TurnstileVerifier{Secret: "secret", VerifyURL: ts.URL, Client: ts.Client()}
+	inner := TurnstileVerifier{Secret: testSecretVal, VerifyURL: ts.URL, Client: ts.Client()}
 	guard := &ReplayGuardVerifier{
 		Inner: inner,
 		Seen:  NewSeenTokens(time.Minute, nil),
 	}
 
 	// First call succeeds and reaches Siteverify.
-	if err := guard.Verify(context.Background(), "replay-tok", "198.51.100.7"); err != nil {
+	if err := guard.Verify(context.Background(), "replay-tok", testRemoteIP); err != nil {
 		t.Fatalf("first Verify: %v", err)
 	}
-	if siteverifyCalls != 1 {
-		t.Fatalf("siteverify calls = %d, want 1", siteverifyCalls)
+	if siteverifyCalls.Load() != 1 {
+		t.Fatalf("siteverify calls = %d, want 1", siteverifyCalls.Load())
 	}
 	// Second call with same token is rejected WITHOUT a Siteverify call.
-	if err := guard.Verify(context.Background(), "replay-tok", "198.51.100.7"); err == nil {
+	if err := guard.Verify(context.Background(), "replay-tok", testRemoteIP); err == nil {
 		t.Fatal("replayed token should be rejected")
 	}
-	if siteverifyCalls != 1 {
-		t.Fatalf("siteverify calls after replay = %d, want still 1 (no network call)", siteverifyCalls)
+	if siteverifyCalls.Load() != 1 {
+		t.Fatalf("siteverify calls after replay = %d, want still 1 (no network call)", siteverifyCalls.Load())
 	}
 }
 
-func TestReplayGuardVerifier_InvalidTokenDoesNotPopulateSeenCache(t *testing.T) {
+func TestReplayGuardVerifier_FailedTokenDoesNotPoisonCache(t *testing.T) {
 	t.Parallel()
-	var siteverifyCalls int
+	// Issue B: an attacker spraying invalid tokens must not fill the cache.
+	// A failed Siteverify must NOT record the token, so the same token value
+	// can succeed on a subsequent attempt.
+	var callCount atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		siteverifyCalls++
+		n := callCount.Add(1)
+		if n == 1 {
+			// First call: upstream rejects.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success":     false,
+				"error-codes": []string{"timeout-or-duplicate"},
+			})
+			return
+		}
+		// Second call: upstream accepts.
 		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
 	}))
 	t.Cleanup(ts.Close)
 
 	seen := NewSeenTokens(time.Minute, nil)
-	inner := TurnstileVerifier{Secret: "secret", VerifyURL: ts.URL, Client: ts.Client()}
+	inner := TurnstileVerifier{Secret: testSecretVal, VerifyURL: ts.URL, Client: ts.Client()}
 	guard := &ReplayGuardVerifier{
 		Inner: inner,
 		Seen:  seen,
 	}
 
-	for _, token := range []string{"", strings.Repeat("x", maxTurnstileTokenBytes+1)} {
-		if err := guard.Verify(context.Background(), token, "198.51.100.7"); err == nil {
+	// First attempt: upstream rejects.
+	if err := guard.Verify(context.Background(), "the-token", testRemoteIP); err == nil {
+		t.Fatal("first Verify should have failed")
+	}
+
+	// Token must NOT be in the seen cache.
+	if seen.IsSeen("the-token") {
+		t.Fatal("failed verification should not poison seen cache")
+	}
+
+	// Second attempt with same token: upstream accepts this time.
+	if err := guard.Verify(context.Background(), "the-token", testRemoteIP); err != nil {
+		t.Fatalf("second Verify should succeed: %v", err)
+	}
+
+	// NOW the token should be in the seen cache.
+	if !seen.IsSeen("the-token") {
+		t.Fatal("token should be recorded as seen after successful verification")
+	}
+
+	// Third attempt: replay rejected.
+	if err := guard.Verify(context.Background(), "the-token", testRemoteIP); err == nil {
+		t.Fatal("third Verify should reject replay")
+	}
+}
+
+func TestReplayGuardVerifier_InvalidTokenDoesNotPopulateSeenCache(t *testing.T) {
+	t.Parallel()
+	var siteverifyCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		siteverifyCalls.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}))
+	t.Cleanup(ts.Close)
+
+	seen := NewSeenTokens(time.Minute, nil)
+	inner := TurnstileVerifier{Secret: testSecretVal, VerifyURL: ts.URL, Client: ts.Client()}
+	guard := &ReplayGuardVerifier{
+		Inner: inner,
+		Seen:  seen,
+	}
+
+	for _, tok := range []string{"", strings.Repeat("x", maxTurnstileTokenBytes+1)} {
+		if err := guard.Verify(context.Background(), tok, testRemoteIP); err == nil {
 			t.Fatal("invalid token Verify succeeded, want fail closed")
 		}
 	}
-	if siteverifyCalls != 0 {
-		t.Fatalf("siteverify calls = %d, want 0 for invalid tokens", siteverifyCalls)
+	if siteverifyCalls.Load() != 0 {
+		t.Fatalf("siteverify calls = %d, want 0 for invalid tokens", siteverifyCalls.Load())
 	}
 	seen.mu.Lock()
 	defer seen.mu.Unlock()

--- a/internal/playground/coverage_more_test.go
+++ b/internal/playground/coverage_more_test.go
@@ -354,7 +354,7 @@ func TestBuildHostContainmentWitnessSignsProbeEvidence(t *testing.T) {
 		return results, nil
 	}
 
-	w, err := lr.buildHostContainmentWitness()
+	w, err := lr.buildHostContainmentWitness(t.Context())
 	if err != nil {
 		t.Fatalf("buildHostContainmentWitness: %v", err)
 	}
@@ -391,7 +391,7 @@ func TestBuildHostContainmentWitnessFailsClosedOnProbeError(t *testing.T) {
 		return nil, errors.New("agent probe should not run")
 	}
 
-	_, err = lr.buildHostContainmentWitness()
+	_, err = lr.buildHostContainmentWitness(t.Context())
 	if err == nil || !strings.Contains(err.Error(), "operator control probe") {
 		t.Fatalf("buildHostContainmentWitness error = %v, want operator probe failure", err)
 	}
@@ -432,7 +432,7 @@ func TestBuildHostContainmentWitnessFailsClosedOnNilProxyListener(t *testing.T) 
 		return []ProbeResult{{Target: targets[0], Open: true, Blocked: false, Detail: "connected"}}, nil
 	}
 
-	_, err = lr.buildHostContainmentWitness()
+	_, err = lr.buildHostContainmentWitness(t.Context())
 	if err == nil || !strings.Contains(err.Error(), "proxy listener not initialized") {
 		t.Fatalf("buildHostContainmentWitness error = %v, want proxy listener not initialized", err)
 	}

--- a/internal/playground/livechat/client_ip.go
+++ b/internal/playground/livechat/client_ip.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"os"
 	"strings"
 )
 
@@ -83,10 +84,8 @@ func ClientIPExact(r *http.Request, trustForwardedFor bool) string {
 	// visitor would otherwise collapse into one rate/budget bucket. Fly sets
 	// Fly-Client-IP to whoever connected to its edge; when that is a Cloudflare
 	// proxy IP, Cloudflare is the immediate upstream and CF-Connecting-IP is
-	// trustworthy. Fly always sets Fly-Client-IP itself (the app is reachable
-	// only through Fly's proxy), so a direct .fly.dev client cannot forge this:
-	// their Fly-Client-IP is their own non-Cloudflare address and the
-	// CF-Connecting-IP is ignored.
+	// trustworthy. This path is gated on Fly runtime indicators so a non-Fly
+	// reverse proxy that forwards client-supplied headers cannot forge identity.
 	if ip := cloudflareBehindEdgeIP(r, peer); ip != "" {
 		return ip
 	}
@@ -103,6 +102,9 @@ func ClientIPExact(r *http.Request, trustForwardedFor bool) string {
 // proxy address. Returns "" when the edge header is absent or is not Cloudflare,
 // or when CF-Connecting-IP is missing or unparseable.
 func cloudflareBehindEdgeIP(r *http.Request, peer string) string {
+	if !runningOnFly() {
+		return ""
+	}
 	// Only honor Fly-Client-IP when the DIRECT peer is a private/loopback address
 	// — i.e. the request actually arrived through a co-located front proxy (Fly's
 	// internal proxy connects from a private ULA address). A directly-exposed
@@ -115,15 +117,11 @@ func cloudflareBehindEdgeIP(r *http.Request, peer string) string {
 	if edge == "" || !isCloudflareProxy(edge) {
 		return ""
 	}
-	raw := strings.TrimSpace(r.Header.Get(cfConnectingIPHeader))
-	if raw == "" {
-		return ""
-	}
-	addr, err := netip.ParseAddr(raw)
-	if err != nil {
-		return ""
-	}
-	return addr.String()
+	return parseCFConnectingIP(r)
+}
+
+func runningOnFly() bool {
+	return os.Getenv("FLY_APP_NAME") != "" || os.Getenv("FLY_MACHINE_ID") != ""
 }
 
 // abuseBucket collapses an IPv6 address to its /64 network so rotating within a
@@ -146,6 +144,10 @@ func cloudflareConnectingIP(r *http.Request, peer string) string {
 	if !isCloudflareProxy(peer) {
 		return ""
 	}
+	return parseCFConnectingIP(r)
+}
+
+func parseCFConnectingIP(r *http.Request) string {
 	raw := strings.TrimSpace(r.Header.Get(cfConnectingIPHeader))
 	if raw == "" {
 		return ""

--- a/internal/playground/livechat/client_ip.go
+++ b/internal/playground/livechat/client_ip.go
@@ -87,7 +87,7 @@ func ClientIPExact(r *http.Request, trustForwardedFor bool) string {
 	// only through Fly's proxy), so a direct .fly.dev client cannot forge this:
 	// their Fly-Client-IP is their own non-Cloudflare address and the
 	// CF-Connecting-IP is ignored.
-	if ip := cloudflareBehindEdgeIP(r); ip != "" {
+	if ip := cloudflareBehindEdgeIP(r, peer); ip != "" {
 		return ip
 	}
 	if trustForwardedFor {
@@ -102,7 +102,15 @@ func ClientIPExact(r *http.Request, trustForwardedFor bool) string {
 // through a front edge (Fly) whose own client-IP header reports a Cloudflare
 // proxy address. Returns "" when the edge header is absent or is not Cloudflare,
 // or when CF-Connecting-IP is missing or unparseable.
-func cloudflareBehindEdgeIP(r *http.Request) string {
+func cloudflareBehindEdgeIP(r *http.Request, peer string) string {
+	// Only honor Fly-Client-IP when the DIRECT peer is a private/loopback address
+	// — i.e. the request actually arrived through a co-located front proxy (Fly's
+	// internal proxy connects from a private ULA address). A directly-exposed
+	// deployment sees the real client as the peer (a public address), so a forged
+	// Fly-Client-IP from such a client is ignored and cannot mint a fake identity.
+	if a, err := netip.ParseAddr(peer); err != nil || (!a.IsPrivate() && !a.IsLoopback()) {
+		return ""
+	}
 	edge := strings.TrimSpace(r.Header.Get(flyClientIPHeader))
 	if edge == "" || !isCloudflareProxy(edge) {
 		return ""

--- a/internal/playground/livechat/client_ip.go
+++ b/internal/playground/livechat/client_ip.go
@@ -12,6 +12,12 @@ import (
 
 const cfConnectingIPHeader = "CF-Connecting-IP"
 
+// flyClientIPHeader is set by Fly.io's proxy to the address that connected to
+// Fly's edge. The app is reachable only through that proxy, which overwrites any
+// client-supplied value, so this header is trustworthy for identifying the
+// immediate upstream (e.g. Cloudflare) in front of Fly.
+const flyClientIPHeader = "Fly-Client-IP"
+
 // cloudflareProxyPrefixes is a snapshot of Cloudflare's published proxy IP
 // ranges used to validate CF-Connecting-IP headers. These are NOT fetched at
 // runtime (avoids a network dependency at startup).
@@ -72,12 +78,44 @@ func ClientIPExact(r *http.Request, trustForwardedFor bool) string {
 	if ip := cloudflareConnectingIP(r, peer); ip != "" {
 		return ip
 	}
+	// Cloudflare-behind-Fly path: on Fly.io the direct peer is Fly's internal
+	// proxy, not Cloudflare, so the direct-peer check above fails and every
+	// visitor would otherwise collapse into one rate/budget bucket. Fly sets
+	// Fly-Client-IP to whoever connected to its edge; when that is a Cloudflare
+	// proxy IP, Cloudflare is the immediate upstream and CF-Connecting-IP is
+	// trustworthy. Fly always sets Fly-Client-IP itself (the app is reachable
+	// only through Fly's proxy), so a direct .fly.dev client cannot forge this:
+	// their Fly-Client-IP is their own non-Cloudflare address and the
+	// CF-Connecting-IP is ignored.
+	if ip := cloudflareBehindEdgeIP(r); ip != "" {
+		return ip
+	}
 	if trustForwardedFor {
 		if ip := firstForwardedFor(r.Header.Get("X-Forwarded-For")); ip != "" {
 			return ip
 		}
 	}
 	return peer
+}
+
+// cloudflareBehindEdgeIP trusts CF-Connecting-IP when the request reached us
+// through a front edge (Fly) whose own client-IP header reports a Cloudflare
+// proxy address. Returns "" when the edge header is absent or is not Cloudflare,
+// or when CF-Connecting-IP is missing or unparseable.
+func cloudflareBehindEdgeIP(r *http.Request) string {
+	edge := strings.TrimSpace(r.Header.Get(flyClientIPHeader))
+	if edge == "" || !isCloudflareProxy(edge) {
+		return ""
+	}
+	raw := strings.TrimSpace(r.Header.Get(cfConnectingIPHeader))
+	if raw == "" {
+		return ""
+	}
+	addr, err := netip.ParseAddr(raw)
+	if err != nil {
+		return ""
+	}
+	return addr.String()
 }
 
 // abuseBucket collapses an IPv6 address to its /64 network so rotating within a

--- a/internal/playground/livechat/client_ip_test.go
+++ b/internal/playground/livechat/client_ip_test.go
@@ -71,7 +71,8 @@ func TestClientIP_PublicPeerIgnoresForgedFlyClientIP(t *testing.T) {
 }
 
 func TestClientIP_NonFlyPrivatePeerIgnoresForgedFlyClientIP(t *testing.T) {
-	t.Parallel()
+	t.Setenv("FLY_APP_NAME", "")
+	t.Setenv("FLY_MACHINE_ID", "")
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	req.RemoteAddr = "172.19.0.5:443"
 	req.Header.Set(flyClientIPHeader, "162.158.0.1")

--- a/internal/playground/livechat/client_ip_test.go
+++ b/internal/playground/livechat/client_ip_test.go
@@ -24,7 +24,7 @@ func TestClientIP_CloudflareConnectingIP(t *testing.T) {
 }
 
 func TestClientIP_CloudflareBehindFlyEdge(t *testing.T) {
-	t.Parallel()
+	t.Setenv("FLY_APP_NAME", "pipelock-playground")
 	// On Fly the direct peer is Fly's internal proxy, not Cloudflare, so the
 	// real visitor must be resolved via Fly-Client-IP (Cloudflare's edge) plus
 	// CF-Connecting-IP (the visitor). Without this, every visitor collapses into
@@ -40,7 +40,7 @@ func TestClientIP_CloudflareBehindFlyEdge(t *testing.T) {
 }
 
 func TestClientIP_FlyEdgeNotCloudflareIgnoresForgedCFHeader(t *testing.T) {
-	t.Parallel()
+	t.Setenv("FLY_APP_NAME", "pipelock-playground")
 	// A client hitting .fly.dev directly cannot forge identity: Fly overwrites
 	// Fly-Client-IP with the client's own (non-Cloudflare) address, so the
 	// CF-Connecting-IP header is ignored and the identity falls back to the peer.
@@ -55,7 +55,7 @@ func TestClientIP_FlyEdgeNotCloudflareIgnoresForgedCFHeader(t *testing.T) {
 }
 
 func TestClientIP_PublicPeerIgnoresForgedFlyClientIP(t *testing.T) {
-	t.Parallel()
+	t.Setenv("FLY_APP_NAME", "pipelock-playground")
 	// A directly-exposed (non-Fly) deployment sees a PUBLIC peer. A client that
 	// sets both Fly-Client-IP (to a Cloudflare range) and CF-Connecting-IP must
 	// NOT forge identity: the Fly-behind-edge path is gated on a private/Fly
@@ -67,6 +67,18 @@ func TestClientIP_PublicPeerIgnoresForgedFlyClientIP(t *testing.T) {
 
 	if got := ClientIP(req, false); got != "203.0.113.50" {
 		t.Fatalf("ClientIP = %q, want public peer (forged Fly-Client-IP ignored)", got)
+	}
+}
+
+func TestClientIP_NonFlyPrivatePeerIgnoresForgedFlyClientIP(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "172.19.0.5:443"
+	req.Header.Set(flyClientIPHeader, "162.158.0.1")
+	req.Header.Set(cfConnectingIPHeader, "198.51.100.7")
+
+	if got := ClientIP(req, false); got != "172.19.0.5" {
+		t.Fatalf("ClientIP = %q, want private peer when not running on Fly", got)
 	}
 }
 

--- a/internal/playground/livechat/client_ip_test.go
+++ b/internal/playground/livechat/client_ip_test.go
@@ -54,6 +54,22 @@ func TestClientIP_FlyEdgeNotCloudflareIgnoresForgedCFHeader(t *testing.T) {
 	}
 }
 
+func TestClientIP_PublicPeerIgnoresForgedFlyClientIP(t *testing.T) {
+	t.Parallel()
+	// A directly-exposed (non-Fly) deployment sees a PUBLIC peer. A client that
+	// sets both Fly-Client-IP (to a Cloudflare range) and CF-Connecting-IP must
+	// NOT forge identity: the Fly-behind-edge path is gated on a private/Fly
+	// internal peer, so a public peer skips it and falls back to the real peer.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.50:443"              // public peer (directly exposed)
+	req.Header.Set(flyClientIPHeader, "162.158.0.1") // forged Cloudflare-range edge
+	req.Header.Set(cfConnectingIPHeader, "198.51.100.7")
+
+	if got := ClientIP(req, false); got != "203.0.113.50" {
+		t.Fatalf("ClientIP = %q, want public peer (forged Fly-Client-IP ignored)", got)
+	}
+}
+
 func TestClientIP_CloudflareConnectingIPv6BucketsToSlash64(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)

--- a/internal/playground/livechat/client_ip_test.go
+++ b/internal/playground/livechat/client_ip_test.go
@@ -23,6 +23,37 @@ func TestClientIP_CloudflareConnectingIP(t *testing.T) {
 	}
 }
 
+func TestClientIP_CloudflareBehindFlyEdge(t *testing.T) {
+	t.Parallel()
+	// On Fly the direct peer is Fly's internal proxy, not Cloudflare, so the
+	// real visitor must be resolved via Fly-Client-IP (Cloudflare's edge) plus
+	// CF-Connecting-IP (the visitor). Without this, every visitor collapses into
+	// one shared rate/budget bucket on the Fly proxy address.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "172.19.0.5:443"                // Fly internal proxy, not a Cloudflare range
+	req.Header.Set(flyClientIPHeader, "162.158.0.1") // a Cloudflare proxy IP
+	req.Header.Set(cfConnectingIPHeader, "198.51.100.7")
+
+	if got := ClientIP(req, false); got != "198.51.100.7" {
+		t.Fatalf("ClientIP = %q, want real visitor IP via the CF-behind-Fly chain", got)
+	}
+}
+
+func TestClientIP_FlyEdgeNotCloudflareIgnoresForgedCFHeader(t *testing.T) {
+	t.Parallel()
+	// A client hitting .fly.dev directly cannot forge identity: Fly overwrites
+	// Fly-Client-IP with the client's own (non-Cloudflare) address, so the
+	// CF-Connecting-IP header is ignored and the identity falls back to the peer.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "172.19.0.5:443"                 // Fly internal proxy
+	req.Header.Set(flyClientIPHeader, "203.0.113.10") // attacker's own IP, NOT Cloudflare
+	req.Header.Set(cfConnectingIPHeader, "198.51.100.7")
+
+	if got := ClientIP(req, false); got != "172.19.0.5" {
+		t.Fatalf("ClientIP = %q, want fallback to peer (forged CF header ignored)", got)
+	}
+}
+
 func TestClientIP_CloudflareConnectingIPv6BucketsToSlash64(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -627,6 +627,16 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusNotFound, "session not found")
 		return
 	}
+	rawOS := r.URL.Query().Get("os")
+	var osName playground.VerifyKitOS
+	if rawOS != "" {
+		var pErr error
+		osName, pErr = playground.ParseVerifyKitOS(rawOS)
+		if pErr != nil {
+			writeErr(w, http.StatusBadRequest, "unsupported verify kit")
+			return
+		}
+	}
 	// Seal on demand: assemble + offline-verify + build the archive. Sealing
 	// marks the session terminal (no further messages), which is the intended
 	// "finish and prove it" semantic. Fail closed if the run did not verify.
@@ -636,12 +646,7 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.releaseSessionResources(entry)
-	if rawOS := r.URL.Query().Get("os"); rawOS != "" {
-		osName, pErr := playground.ParseVerifyKitOS(rawOS)
-		if pErr != nil {
-			writeErr(w, http.StatusBadRequest, "unsupported verify kit")
-			return
-		}
+	if rawOS != "" {
 		kit, filename, kErr := playground.BuildLiveVerifyKit(osName, s.cfg.VerifierBinaries.Path(osName), entry.bundle)
 		if kErr != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "livechat: verify kit build failed: %v\n", kErr)

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -642,7 +642,7 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 			writeErr(w, http.StatusBadRequest, "unsupported verify kit")
 			return
 		}
-		kit, filename, kErr := playground.BuildLiveVerifyKit(osName, s.cfg.VerifierBinaries.Path(osName), entry.bundle, entry.sess.OrchestratorPubHex())
+		kit, filename, kErr := playground.BuildLiveVerifyKit(osName, s.cfg.VerifierBinaries.Path(osName), entry.bundle)
 		if kErr != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "livechat: verify kit build failed: %v\n", kErr)
 			writeErr(w, http.StatusServiceUnavailable, "verify kit is not available")

--- a/internal/playground/livechat/server_bundle_test.go
+++ b/internal/playground/livechat/server_bundle_test.go
@@ -246,11 +246,15 @@ func TestServer_Bundle_VerifyKitDownload(t *testing.T) {
 
 	token := sealReadySession(t, ts)
 
-	// Unsupported OS selector: rejected with 400 (the seal already succeeded).
+	// Unsupported OS selector: rejected with 400 before sealing or releasing the
+	// session slot.
 	bad := getRaw(t, ts.URL+RouteBundle+"?token="+token+"&os=plan9")
 	_ = bad.Body.Close()
 	if bad.StatusCode != http.StatusBadRequest {
 		t.Fatalf("bundle os=plan9 = %d, want 400", bad.StatusCode)
+	}
+	if got := srv.conc.InUse(); got != 1 {
+		t.Fatalf("capacity after bad os = %d, want 1", got)
 	}
 
 	// A supported OS with no configured verifier binary fails closed (503).

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -592,7 +592,10 @@ func decodeProbeResults(stdout []byte, expectedTargets []string) ([]ProbeResult,
 // contained position (all must be blocked), and probes local non-network escape
 // surfaces (platform sockets, device nodes, namespace/mount capabilities). The
 // witness is signed by the orchestrator key, the run's trust root.
-func (lr *LiveRun) buildHostContainmentWitness() (HostContainmentWitness, error) {
+//
+// ctx should survive session cancellation (e.g. via context.WithoutCancel) so
+// the witness can be built at TTL expiry when the session context is canceled.
+func (lr *LiveRun) buildHostContainmentWitness(ctx context.Context) (HostContainmentWitness, error) {
 	runProbe := lr.runEgressProbe
 	if lr.egressProbe != nil {
 		runProbe = lr.egressProbe
@@ -602,7 +605,7 @@ func (lr *LiveRun) buildHostContainmentWitness() (HostContainmentWitness, error)
 		runLocalProbe = lr.localEscapeProbe
 	}
 
-	ctrlLn, err := (&net.ListenConfig{}).Listen(lr.ctx, "tcp", "127.0.0.1:0")
+	ctrlLn, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		return HostContainmentWitness{}, fmt.Errorf("control listener: %w", err)
 	}
@@ -708,8 +711,15 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 		lr.rec = nil
 	}
 
+	// The seal must complete even when the session context is canceled (TTL
+	// expiry or client disconnect). WithoutCancel drops the parent's
+	// cancellation while preserving values; the 30s timeout bounds the seal
+	// so a genuinely stuck probe does not hang forever.
+	sealCtx, sealCancel := context.WithTimeout(context.WithoutCancel(lr.ctx), 30*time.Second)
+	defer sealCancel()
+
 	// --- Red-case calibration ---
-	rcResult, redWitness, err := RunRedCaseCalibrationWithWitness(lr.ctx, lr.collectorPriv, lr.canaryID, lr.canaryValue)
+	rcResult, redWitness, err := RunRedCaseCalibrationWithWitness(sealCtx, lr.collectorPriv, lr.canaryID, lr.canaryValue)
 	if err != nil {
 		return VerifyReport{}, fmt.Errorf("red-case calibration: %w", err)
 	}
@@ -794,7 +804,7 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 	// separate witness proves the kernel owner-match drop from the contained
 	// network position. Each property is attested where it is actually enforced.
 	if lr.opts.Contained {
-		hcw, hcwErr := lr.buildHostContainmentWitness()
+		hcw, hcwErr := lr.buildHostContainmentWitness(sealCtx)
 		if hcwErr != nil {
 			return VerifyReport{}, fmt.Errorf("host-containment witness: %w", hcwErr)
 		}

--- a/internal/playground/verify_kit.go
+++ b/internal/playground/verify_kit.go
@@ -229,7 +229,7 @@ func liveKitReadme(osName VerifyKitOS) string {
 	case VerifyKitOSMacOS:
 		return "Pipelock - verify your live session (macOS)\n\nThe verifier is a universal Intel/Apple Silicon binary, but it is not Apple-notarized, so macOS Gatekeeper may block a freshly downloaded copy. If double-clicking Verify.command is blocked, open Terminal in this folder and run:\n\n  xattr -d com.apple.quarantine Verify.command app/pipelock-verifier\n  ./Verify.command\n\nA valid run prints result: VALID. Nothing here touches the internet. Notarized macOS support is planned; Linux and Windows need no extra step.\n"
 	default:
-		return "Pipelock - verify your live session (Linux)\n\nRun ./verify.sh, or double-click it if your file manager runs scripts.\nA valid run prints result: VALID. Nothing here touches the internet.\n"
+		return "Pipelock - verify your live session (Linux)\n\nOpen a terminal in this folder and run:\n\n  ./verify.sh\n\nDouble-clicking usually opens it in a text editor instead of running it - that is normal on Linux; use the terminal.\nA valid run prints result: VALID. Nothing here touches the internet.\n"
 	}
 }
 
@@ -240,7 +240,7 @@ func liveKitScript(osName VerifyKitOS, orchKey string) (string, string, error) {
 	case VerifyKitOSMacOS:
 		return "Verify.command", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the full Pipelock playground trust chain, offline...\"\necho\n./pipelock-verifier verify-run run --orchestrator-key " + orchKey + "\necho\necho \"result: VALID means every signature, the receipt chain, witnesses, and run binding held.\"\necho \"No network was used.\"\nread -n 1 -s -r -p \"Press any key to close.\"\n", nil
 	case VerifyKitOSLinux:
-		return "verify.sh", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the full Pipelock playground trust chain, offline...\"\n./pipelock-verifier verify-run run --orchestrator-key " + orchKey + "\n", nil
+		return "verify.sh", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the full Pipelock playground trust chain, offline...\"\necho\n./pipelock-verifier verify-run run --orchestrator-key " + orchKey + "\necho\necho \"result: VALID means every signature, the receipt chain, witnesses, and run binding held.\"\necho \"No network was used.\"\n", nil
 	default:
 		return "", "", fmt.Errorf("unsupported verify kit OS %q", osName)
 	}

--- a/internal/playground/verify_kit.go
+++ b/internal/playground/verify_kit.go
@@ -8,8 +8,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -65,10 +63,35 @@ func ParseVerifyKitOS(raw string) (VerifyKitOS, error) {
 	}
 }
 
+// verifyKitRunFiles lists every run-directory file the kit must include for the
+// full VerifyRun trust chain. Missing files are tolerated only for optional
+// artifacts (the host-containment witness is required only for contained runs
+// and is extracted on a best-effort basis).
+var verifyKitRequiredFiles = []string{
+	"packet/packet.json",
+	"packet/manifest.json",
+	"packet/evidence.jsonl",
+	launchManifestFile,
+	witnessFile,
+	redWitnessFile,
+}
+
+// verifyKitOptionalFiles are extracted when present but their absence does not
+// fail the kit build.
+var verifyKitOptionalFiles = []string{
+	hostContainmentWitnessFile,
+	"VERIFY.txt",
+}
+
 // BuildLiveVerifyKit builds a single-download, offline verification kit for one
 // sealed live session. sessionTarGz must be the output of ArchiveRunForDownload.
-// The kit embeds the real verifier binary and the session's audit packet.
-func BuildLiveVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []byte, fallbackTrustKey string) ([]byte, string, error) {
+// The kit embeds the real verifier binary and ALL run artifacts needed for the
+// full VerifyRun trust chain (launch manifest, witnesses, receipt chain, etc.).
+//
+// The trust key is ALWAYS the compiled-in PublishedOrchestratorPubKeyHex. The
+// kit never derives, extracts, or falls back to a key from the bundle -- a
+// tampered bundle cannot ship its own key.
+func BuildLiveVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []byte) ([]byte, string, error) {
 	if verifierPath == "" {
 		return nil, "", errors.New("verifier binary path is not configured")
 	}
@@ -80,10 +103,8 @@ func BuildLiveVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []
 	if err != nil {
 		return nil, "", err
 	}
-	trustKey, err := validateLiveKitTrustKey(liveKitTrustKey(files, fallbackTrustKey))
-	if err != nil {
-		return nil, "", err
-	}
+
+	trustKey := PublishedOrchestratorPubKeyHex
 
 	root := "pipelock-live-verify-" + string(osName)
 	var buf bytes.Buffer
@@ -108,21 +129,28 @@ func BuildLiveVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []
 		return nil, "", err
 	}
 
-	for _, name := range []string{"packet/packet.json", "packet/manifest.json", "packet/evidence.jsonl"} {
+	// Pack required run-directory files -- all must be present.
+	for _, name := range verifyKitRequiredFiles {
 		data, ok := files[name]
 		if !ok {
 			return nil, "", fmt.Errorf("session bundle missing %s", name)
 		}
-		if err := zipFile(zw, root+"/app/"+name, data, 0o600); err != nil {
+		if err := zipFile(zw, root+"/app/run/"+name, data, 0o600); err != nil {
 			return nil, "", err
 		}
 	}
-	if verify, ok := files["VERIFY.txt"]; ok {
-		if err := zipFile(zw, root+"/app/SESSION-VERIFY.txt", verify, 0o600); err != nil {
+	// Pack optional files when present.
+	for _, name := range verifyKitOptionalFiles {
+		data, ok := files[name]
+		if !ok {
+			continue
+		}
+		if err := zipFile(zw, root+"/app/run/"+name, data, 0o600); err != nil {
 			return nil, "", err
 		}
 	}
-	if err := zipFile(zw, root+"/app/packet/verifier.txt", []byte(liveKitVerifierTxt(trustKey)), 0o600); err != nil {
+
+	if err := zipFile(zw, root+"/app/run/verifier.txt", []byte(liveKitVerifierTxt(trustKey)), 0o600); err != nil {
 		return nil, "", err
 	}
 
@@ -132,46 +160,21 @@ func BuildLiveVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []
 	return buf.Bytes(), "pipelock-live-verify-" + string(osName) + ".zip", nil
 }
 
-func liveKitTrustKey(files map[string][]byte, fallback string) string {
-	var packet struct {
-		Verifier struct {
-			SignerKey string `json:"signer_key"`
-		} `json:"verifier"`
-	}
-	if data := files["packet/packet.json"]; len(data) > 0 {
-		if err := json.Unmarshal(data, &packet); err == nil && strings.TrimSpace(packet.Verifier.SignerKey) != "" {
-			return strings.TrimSpace(packet.Verifier.SignerKey)
-		}
-	}
-	var manifest struct {
-		SignerKey string `json:"signer_key"`
-	}
-	if data := files["packet/manifest.json"]; len(data) > 0 {
-		if err := json.Unmarshal(data, &manifest); err == nil && strings.TrimSpace(manifest.SignerKey) != "" {
-			return strings.TrimSpace(manifest.SignerKey)
-		}
-	}
-	return fallback
-}
-
-func validateLiveKitTrustKey(key string) (string, error) {
-	key = strings.TrimSpace(key)
-	decoded, err := hex.DecodeString(key)
-	if err != nil {
-		return "", fmt.Errorf("verify kit trust key is not hex: %w", err)
-	}
-	if len(decoded) != 32 {
-		return "", fmt.Errorf("verify kit trust key length = %d bytes, want 32", len(decoded))
-	}
-	return key, nil
-}
-
 func extractLiveKitFiles(sessionTarGz []byte) (map[string][]byte, error) {
 	gr, err := gzip.NewReader(bytes.NewReader(sessionTarGz))
 	if err != nil {
 		return nil, fmt.Errorf("read session bundle gzip: %w", err)
 	}
 	defer func() { _ = gr.Close() }()
+
+	// Build the set of files to extract.
+	want := make(map[string]bool)
+	for _, f := range verifyKitRequiredFiles {
+		want[f] = true
+	}
+	for _, f := range verifyKitOptionalFiles {
+		want[f] = true
+	}
 
 	files := make(map[string][]byte)
 	tr := tar.NewReader(gr)
@@ -190,9 +193,7 @@ func extractLiveKitFiles(sessionTarGz []byte) (map[string][]byte, error) {
 		if !ok {
 			continue
 		}
-		switch name {
-		case "VERIFY.txt", "packet/packet.json", "packet/manifest.json", "packet/evidence.jsonl":
-		default:
+		if !want[name] {
 			continue
 		}
 		data, err := io.ReadAll(tr)
@@ -232,25 +233,32 @@ func liveKitReadme(osName VerifyKitOS) string {
 	}
 }
 
-func liveKitScript(osName VerifyKitOS, key string) (string, string, error) {
+func liveKitScript(osName VerifyKitOS, orchKey string) (string, string, error) {
 	switch osName {
 	case VerifyKitOSWindows:
-		return "Verify.bat", "@echo off\r\ncd /d \"%~dp0app\"\r\necho Verifying the signed Pipelock audit packet, offline...\r\necho.\r\npipelock-verifier.exe audit-packet packet --key " + key + "\r\necho.\r\necho result: VALID means every signature and the hash chain held. No network was used.\r\necho.\r\npause\r\n", nil
+		return "Verify.bat", "@echo off\r\ncd /d \"%~dp0app\"\r\necho Verifying the full Pipelock playground trust chain, offline...\r\necho.\r\npipelock-verifier.exe verify-run run --orchestrator-key " + orchKey + "\r\necho.\r\necho result: VALID means every signature, the receipt chain, witnesses, and run binding held.\r\necho No network was used.\r\necho.\r\npause\r\n", nil
 	case VerifyKitOSMacOS:
-		return "Verify.command", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the signed Pipelock audit packet, offline...\"\necho\n./pipelock-verifier audit-packet packet --key " + key + "\necho\necho \"result: VALID means every signature and the hash chain held. No network was used.\"\nread -n 1 -s -r -p \"Press any key to close.\"\n", nil
+		return "Verify.command", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the full Pipelock playground trust chain, offline...\"\necho\n./pipelock-verifier verify-run run --orchestrator-key " + orchKey + "\necho\necho \"result: VALID means every signature, the receipt chain, witnesses, and run binding held.\"\necho \"No network was used.\"\nread -n 1 -s -r -p \"Press any key to close.\"\n", nil
 	case VerifyKitOSLinux:
-		return "verify.sh", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the signed Pipelock audit packet, offline...\"\n./pipelock-verifier audit-packet packet --key " + key + "\n", nil
+		return "verify.sh", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the full Pipelock playground trust chain, offline...\"\n./pipelock-verifier verify-run run --orchestrator-key " + orchKey + "\n", nil
 	default:
 		return "", "", fmt.Errorf("unsupported verify kit OS %q", osName)
 	}
 }
 
-func liveKitVerifierTxt(key string) string {
-	return fmt.Sprintf(`Pipelock live session audit packet
-verdict: run pipelock-verifier audit-packet packet --key %s
-signer_key: %s
+func liveKitVerifierTxt(orchKey string) string {
+	return fmt.Sprintf(`Pipelock live session - full trust chain verification
+trust_root: %s (published Pipelock Playground orchestrator key)
+verdict: run pipelock-verifier verify-run run --orchestrator-key %s
 
 Verify it yourself from this directory:
-  pipelock-verifier audit-packet packet --key %s
-`, key, key, key)
+  pipelock-verifier verify-run run --orchestrator-key %s
+
+This performs the full verification chain:
+  - Launch manifest signature (orchestrator key)
+  - Audit packet receipt chain (manifest-pinned pipelock key)
+  - Collector witness signature and run binding
+  - Red-case calibration
+  - Host-containment witness (if contained)
+`, orchKey, orchKey, orchKey)
 }

--- a/internal/playground/verify_kit_test.go
+++ b/internal/playground/verify_kit_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 )
 
-const validKitKey64 = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
-
 // writeTempVerifier writes a stand-in verifier binary and returns its path.
 func writeTempVerifier(t *testing.T) string {
 	t.Helper()
@@ -90,12 +88,25 @@ func readZipEntry(t *testing.T, zipBytes []byte, name string) string {
 	return ""
 }
 
-func TestBuildLiveVerifyKit_IncludesSessionPacketAndVerifier(t *testing.T) {
+// fullKitSessionFiles returns the minimal set of files for a valid kit session
+// that includes all required run artifacts.
+func fullKitSessionFiles() map[string]string {
+	return map[string]string{
+		"packet/packet.json":       `{"receipt_count":1}`,
+		"packet/manifest.json":     `{"v":1}`,
+		"packet/evidence.jsonl":    "{}\n",
+		launchManifestFile:         `{"run_nonce":"n1"}`,
+		witnessFile:                `{"observed_count":0}`,
+		redWitnessFile:             `{"red":true}`,
+		hostContainmentWitnessFile: `{"contained":true}`,
+	}
+}
+
+func TestBuildLiveVerifyKit_IncludesAllRunArtifactsAndVerifier(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	writeRunArtifacts(t, dir, false)
-	const key = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
-	session, err := ArchiveRunForDownload(dir, key)
+	writeRunArtifacts(t, dir, true) // with containment witness
+	session, err := ArchiveRunForDownload(dir, PublishedOrchestratorPubKeyHex)
 	if err != nil {
 		t.Fatalf("ArchiveRunForDownload: %v", err)
 	}
@@ -104,7 +115,7 @@ func TestBuildLiveVerifyKit_IncludesSessionPacketAndVerifier(t *testing.T) {
 		t.Fatalf("write verifier: %v", err)
 	}
 
-	kit, filename, err := BuildLiveVerifyKit(VerifyKitOSLinux, verifierPath, session, key)
+	kit, filename, err := BuildLiveVerifyKit(VerifyKitOSLinux, verifierPath, session)
 	if err != nil {
 		t.Fatalf("BuildLiveVerifyKit: %v", err)
 	}
@@ -132,15 +143,19 @@ func TestBuildLiveVerifyKit_IncludesSessionPacketAndVerifier(t *testing.T) {
 		files[f.Name] = b.String()
 	}
 
+	// Must include ALL run artifacts, not just the packet subset.
 	for _, want := range []string{
 		kitRoot + "/README.txt",
 		kitRoot + "/verify.sh",
 		kitRoot + "/app/pipelock-verifier",
-		kitRoot + "/app/packet/packet.json",
-		kitRoot + "/app/packet/manifest.json",
-		kitRoot + "/app/packet/evidence.jsonl",
-		kitRoot + "/app/packet/verifier.txt",
-		kitRoot + "/app/SESSION-VERIFY.txt",
+		kitRoot + "/app/run/packet/packet.json",
+		kitRoot + "/app/run/packet/manifest.json",
+		kitRoot + "/app/run/packet/evidence.jsonl",
+		kitRoot + "/app/run/" + launchManifestFile,
+		kitRoot + "/app/run/" + witnessFile,
+		kitRoot + "/app/run/" + redWitnessFile,
+		kitRoot + "/app/run/" + hostContainmentWitnessFile,
+		kitRoot + "/app/run/verifier.txt",
 	} {
 		if _, ok := files[want]; !ok {
 			t.Fatalf("kit missing %q (have %v)", want, keysOf(files))
@@ -149,28 +164,52 @@ func TestBuildLiveVerifyKit_IncludesSessionPacketAndVerifier(t *testing.T) {
 	if files[kitRoot+"/app/pipelock-verifier"] != "real verifier bytes" {
 		t.Fatal("kit did not include the configured verifier binary bytes")
 	}
+	// The script must use the PUBLISHED key and the full verify-run command.
 	script := files[kitRoot+"/verify.sh"]
-	if !strings.Contains(script, "./pipelock-verifier audit-packet packet --key "+key) {
-		t.Fatalf("verify script missing command/key:\n%s", script)
+	if !strings.Contains(script, "verify-run run --orchestrator-key "+PublishedOrchestratorPubKeyHex) {
+		t.Fatalf("verify script missing full verify-run command with published key:\n%s", script)
+	}
+}
+
+func TestBuildLiveVerifyKit_AlwaysUsesPublishedKey(t *testing.T) {
+	t.Parallel()
+	// Even when the bundle carries a different key, the kit must use the
+	// published key. There is no fallback or extraction path.
+	session := buildKitSession(t, fullKitSessionFiles(), false, false)
+
+	kit, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session)
+	if err != nil {
+		t.Fatalf("BuildLiveVerifyKit: %v", err)
+	}
+	script := readZipEntry(t, kit, "pipelock-live-verify-linux/verify.sh")
+	if !strings.Contains(script, PublishedOrchestratorPubKeyHex) {
+		t.Fatalf("verify script does not contain the published key:\n%s", script)
+	}
+	verifierTxt := readZipEntry(t, kit, "pipelock-live-verify-linux/app/run/verifier.txt")
+	if !strings.Contains(verifierTxt, PublishedOrchestratorPubKeyHex) {
+		t.Fatalf("verifier.txt does not contain the published key:\n%s", verifierTxt)
 	}
 }
 
 func TestBuildLiveVerifyKit_FailsClosedWithoutVerifier(t *testing.T) {
 	t.Parallel()
-	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, "", []byte("not-used"), "key"); err == nil {
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, "", []byte("not-used")); err == nil {
 		t.Fatal("missing verifier path should fail closed")
 	}
 }
 
-func TestValidateLiveKitTrustKeyRejectsUnsafeKey(t *testing.T) {
+func TestPublishedKeyIsValid32ByteHex(t *testing.T) {
 	t.Parallel()
-	for _, key := range []string{"", "not-a-hex-key; touch /tmp/pwned", strings.Repeat("0", 62), strings.Repeat("0", 66)} {
-		if _, err := validateLiveKitTrustKey(key); err == nil {
-			t.Fatalf("validateLiveKitTrustKey(%q) succeeded, want error", key)
-		}
+	// Verify the published key constant is a valid 32-byte hex string.
+	if len(PublishedOrchestratorPubKeyHex) != 64 {
+		t.Fatalf("PublishedOrchestratorPubKeyHex length = %d, want 64", len(PublishedOrchestratorPubKeyHex))
 	}
-	if got, err := validateLiveKitTrustKey(strings.Repeat("0", 64)); err != nil || got != strings.Repeat("0", 64) {
-		t.Fatalf("valid key = %q, %v; want pass", got, err)
+	for _, c := range PublishedOrchestratorPubKeyHex {
+		isDigit := c >= '0' && c <= '9'
+		isHexLower := c >= 'a' && c <= 'f'
+		if !isDigit && !isHexLower {
+			t.Fatalf("PublishedOrchestratorPubKeyHex contains non-hex char %q", c)
+		}
 	}
 }
 
@@ -203,25 +242,28 @@ func TestVerifyKitBinaries_Path(t *testing.T) {
 
 func TestLiveKitReadmeAndScript_PerOS(t *testing.T) {
 	t.Parallel()
-	const key = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
+	orchKey := PublishedOrchestratorPubKeyHex
 	for _, osName := range []VerifyKitOS{VerifyKitOSLinux, VerifyKitOSMacOS, VerifyKitOSWindows} {
 		t.Run(string(osName), func(t *testing.T) {
 			if readme := liveKitReadme(osName); !strings.Contains(readme, "Pipelock") {
 				t.Fatalf("readme(%q) missing brand: %q", osName, readme)
 			}
-			name, body, err := liveKitScript(osName, key)
+			name, body, err := liveKitScript(osName, orchKey)
 			if err != nil {
 				t.Fatalf("liveKitScript(%q): %v", osName, err)
 			}
-			if name == "" || !strings.Contains(body, key) {
+			if name == "" || !strings.Contains(body, orchKey) {
 				t.Fatalf("script(%q) name=%q missing key in body", osName, name)
+			}
+			if !strings.Contains(body, "verify-run") {
+				t.Fatalf("script(%q) missing verify-run command: %s", osName, body)
 			}
 		})
 	}
 	if r := liveKitReadme(VerifyKitOS("x86")); !strings.Contains(r, "Linux") {
 		t.Fatalf("default readme should fall back to Linux text: %q", r)
 	}
-	if _, _, err := liveKitScript(VerifyKitOS("x86"), key); err == nil {
+	if _, _, err := liveKitScript(VerifyKitOS("x86"), orchKey); err == nil {
 		t.Fatal("liveKitScript with unsupported OS should error")
 	}
 }
@@ -230,13 +272,12 @@ func TestBuildLiveVerifyKit_ReadVerifierError(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	writeRunArtifacts(t, dir, false)
-	const key = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
-	session, err := ArchiveRunForDownload(dir, key)
+	session, err := ArchiveRunForDownload(dir, PublishedOrchestratorPubKeyHex)
 	if err != nil {
 		t.Fatalf("ArchiveRunForDownload: %v", err)
 	}
 	missing := filepath.Join(t.TempDir(), "no-such-verifier")
-	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, missing, session, key); err == nil {
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, missing, session); err == nil {
 		t.Fatal("unreadable verifier path should fail closed")
 	}
 }
@@ -245,8 +286,7 @@ func TestBuildLiveVerifyKit_WindowsAndMacOS(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	writeRunArtifacts(t, dir, false)
-	const key = "65c1e83850fe24c986f44bdd3a95360602d2f4f198f1c95e2d500d2b9495aaaf"
-	session, err := ArchiveRunForDownload(dir, key)
+	session, err := ArchiveRunForDownload(dir, PublishedOrchestratorPubKeyHex)
 	if err != nil {
 		t.Fatalf("ArchiveRunForDownload: %v", err)
 	}
@@ -263,7 +303,7 @@ func TestBuildLiveVerifyKit_WindowsAndMacOS(t *testing.T) {
 		{VerifyKitOSMacOS, "pipelock-live-verify-macos/app/pipelock-verifier", "pipelock-live-verify-macos.zip"},
 	} {
 		t.Run(string(tc.osName), func(t *testing.T) {
-			kit, filename, err := BuildLiveVerifyKit(tc.osName, verifierPath, session, key)
+			kit, filename, err := BuildLiveVerifyKit(tc.osName, verifierPath, session)
 			if err != nil {
 				t.Fatalf("BuildLiveVerifyKit(%q): %v", tc.osName, err)
 			}
@@ -289,84 +329,83 @@ func TestBuildLiveVerifyKit_WindowsAndMacOS(t *testing.T) {
 
 func TestBuildLiveVerifyKit_RejectsGarbageSession(t *testing.T) {
 	t.Parallel()
-	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), []byte("not a gzip stream"), validKitKey64); err == nil {
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), []byte("not a gzip stream")); err == nil {
 		t.Fatal("non-gzip session bytes should fail closed")
+	}
+}
+
+func TestBuildLiveVerifyKit_MissingRequiredFileFailsClosed(t *testing.T) {
+	t.Parallel()
+	// Missing launch-manifest.json: the kit must not ship a bundle that cannot
+	// verify the full trust chain.
+	incomplete := map[string]string{
+		"packet/packet.json":    `{"receipt_count":1}`,
+		"packet/manifest.json":  `{"v":1}`,
+		"packet/evidence.jsonl": "{}\n",
+		witnessFile:             `{"observed_count":0}`,
+		redWitnessFile:          `{"red":true}`,
+		// launchManifestFile is deliberately missing.
+	}
+	session := buildKitSession(t, incomplete, false, false)
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session); err == nil {
+		t.Fatal("missing launch-manifest.json should fail closed")
 	}
 }
 
 func TestBuildLiveVerifyKit_MissingPacketFileFailsClosed(t *testing.T) {
 	t.Parallel()
-	// Valid gzip+tar, but packet/packet.json is absent: the kit must not ship a
-	// bundle that cannot verify.
-	session := buildKitSession(t, map[string]string{
-		"packet/manifest.json":  `{"v":1}`,
-		"packet/evidence.jsonl": "{}\n",
-	}, false, false)
-	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session, validKitKey64); err == nil {
+	// Missing packet/packet.json.
+	incomplete := fullKitSessionFiles()
+	delete(incomplete, "packet/packet.json")
+	session := buildKitSession(t, incomplete, false, false)
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session); err == nil {
 		t.Fatal("missing packet file should fail closed")
 	}
 }
 
-func TestBuildLiveVerifyKit_InvalidInBundleTrustKeyFailsClosed(t *testing.T) {
+func TestBuildLiveVerifyKit_MissingWitnessFailsClosed(t *testing.T) {
 	t.Parallel()
-	// The bundle's own packet.json carries a non-hex signer key; it is preferred
-	// over the fallback and must be rejected.
-	session := buildKitSession(t, map[string]string{
-		"packet/packet.json":    `{"verifier":{"signer_key":"not-hex"}}`,
-		"packet/manifest.json":  `{"v":1}`,
-		"packet/evidence.jsonl": "{}\n",
-	}, false, false)
-	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session, validKitKey64); err == nil {
-		t.Fatal("invalid in-bundle trust key should fail closed")
+	incomplete := fullKitSessionFiles()
+	delete(incomplete, witnessFile)
+	session := buildKitSession(t, incomplete, false, false)
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session); err == nil {
+		t.Fatal("missing witness.json should fail closed")
 	}
 }
 
-func TestBuildLiveVerifyKit_TrustKeySource(t *testing.T) {
+func TestBuildLiveVerifyKit_MissingRedWitnessFailsClosed(t *testing.T) {
 	t.Parallel()
-	keyA := strings.Repeat("1", 64)
-	keyB := strings.Repeat("2", 64)
-	fallback := validKitKey64
-
-	cases := []struct {
-		name    string
-		files   map[string]string
-		wantKey string
-	}{
-		{
-			name: "from packet.json",
-			files: map[string]string{
-				"packet/packet.json":    `{"verifier":{"signer_key":"` + keyA + `"}}`,
-				"packet/manifest.json":  `{"signer_key":"` + keyB + `"}`,
-				"packet/evidence.jsonl": "{}\n",
-			},
-			wantKey: keyA,
-		},
-		{
-			name: "from manifest.json when packet lacks it",
-			files: map[string]string{
-				"packet/packet.json":    `{"receipt_count":1}`,
-				"packet/manifest.json":  `{"signer_key":"` + keyB + `"}`,
-				"packet/evidence.jsonl": "{}\n",
-			},
-			wantKey: keyB,
-		},
+	incomplete := fullKitSessionFiles()
+	delete(incomplete, redWitnessFile)
+	session := buildKitSession(t, incomplete, false, false)
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session); err == nil {
+		t.Fatal("missing red-witness.json should fail closed")
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			// withDirEntry + withForeign also exercise the extraction skip paths.
-			session := buildKitSession(t, tc.files, true, true)
-			kit, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session, fallback)
-			if err != nil {
-				t.Fatalf("BuildLiveVerifyKit: %v", err)
-			}
-			script := readZipEntry(t, kit, "pipelock-live-verify-linux/verify.sh")
-			if !strings.Contains(script, tc.wantKey) {
-				t.Fatalf("verify script did not use the in-bundle trust key %s", tc.wantKey)
-			}
-			if strings.Contains(script, fallback) {
-				t.Fatalf("verify script used the fallback key instead of the in-bundle key %s", tc.wantKey)
-			}
-		})
+}
+
+func TestBuildLiveVerifyKit_OptionalContainmentWitnessOK(t *testing.T) {
+	t.Parallel()
+	files := fullKitSessionFiles()
+	delete(files, hostContainmentWitnessFile)
+	session := buildKitSession(t, files, false, false)
+	// Should succeed -- containment witness is optional.
+	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session); err != nil {
+		t.Fatalf("missing optional containment witness should not fail: %v", err)
+	}
+}
+
+func TestBuildLiveVerifyKit_ScriptRunsVerifyRunNotAuditPacket(t *testing.T) {
+	t.Parallel()
+	session := buildKitSession(t, fullKitSessionFiles(), true, true)
+	kit, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session)
+	if err != nil {
+		t.Fatalf("BuildLiveVerifyKit: %v", err)
+	}
+	script := readZipEntry(t, kit, "pipelock-live-verify-linux/verify.sh")
+	if strings.Contains(script, "audit-packet") {
+		t.Fatalf("verify script should NOT use audit-packet (partial check):\n%s", script)
+	}
+	if !strings.Contains(script, "verify-run") {
+		t.Fatalf("verify script should use verify-run (full chain):\n%s", script)
 	}
 }


### PR DESCRIPTION
## What changed
- Hardening across the playground broker: download and warm-pool race fixes, human-verification replay/binding, abuse and spend caps, clean degradation, and a host-header guard.
- Validate input and check limits before any expensive work; retain a session for retry when a download fails.
- An optional server-side default invite code, accepted only behind a human-verification gate, so visitors don't have to paste a code.
- The image build bundles the browser verifier and fails closed without it.

## Why
Prepares the broker to run safely under public traffic.

Depends on #837 (provides the browser-verifier build the image step bundles).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional warm VM preloading with safer handoff/protected cleanup.
  * Added `verify-run` command for offline demo run verification (JSON or readable PASS/FAIL output).
  * Model-aware retained chat history limits for the LLM agent.
* **Bug Fixes**
  * Improved bundle download reliability with TTL-based redownload after VM teardown and safer concurrent variant fetching.
  * Better static caching behavior (`no-cache`) and more precise per-route write deadlines.
* **Security**
  * Fail-closed invite default code handling with human-gate/Access/Turnstile enforcement.
  * Stronger Turnstile replay protection and stricter hostname/action validation.
* **Tests / Chores**
  * Expanded validation and concurrency test coverage; improved Docker build reproducibility and image build script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->