### PR TITLE
fix(mcp): reject null params during envelope injection

### DIFF
--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -1360,9 +1360,9 @@ func jsonRPCErrorCodeForInputError(errText string) int {
 // injectMCPEnvelope injects a mediation envelope into a JSON-RPC message's
 // params._meta field. Returns the modified message bytes, or the original
 // message unmodified if the message is not an envelope-bearing shape.
-// Malformed or non-object params fail closed through a returned error. A
-// malformed _meta member is normalized to a fresh object so attacker-controlled
-// metadata cannot suppress required mediation.
+// Malformed, null, or non-object params fail closed through a returned error.
+// A malformed _meta member is normalized to a fresh object so
+// attacker-controlled metadata cannot suppress required mediation.
 func injectMCPEnvelope(msg []byte, emitter *envelope.Emitter, buildOpts envelope.BuildOpts) ([]byte, error) {
 	if emitter == nil {
 		return msg, nil
@@ -1382,8 +1382,13 @@ func injectMCPEnvelope(msg []byte, emitter *envelope.Emitter, buildOpts envelope
 	if err := json.Unmarshal(paramsRaw, &params); err != nil {
 		return msg, fmt.Errorf("parse MCP params for mediation envelope: %w", err)
 	}
+	// json.Unmarshal of JSON null into a map succeeds with a nil map, so
+	// params:null reaches here without an error. Fail closed rather than
+	// normalizing it to an object: a tools/call never legitimately carries
+	// null params, and silently rewriting it would diverge from the
+	// non-object fail-closed path above.
 	if params == nil {
-		params = make(map[string]json.RawMessage)
+		return msg, fmt.Errorf("parse MCP params for mediation envelope: params must be a JSON object")
 	}
 
 	// Use json.RawMessage to preserve existing _meta members byte-for-byte.

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -4144,13 +4144,20 @@ func TestInjectMCPEnvelope_NoParams(t *testing.T) {
 	}
 }
 
-func TestInjectMCPEnvelope_NullParamsCreatesMetaMap(t *testing.T) {
+func TestInjectMCPEnvelope_NullParamsFailsClosed(t *testing.T) {
 	em := envelope.NewEmitter(envelope.EmitterConfig{ConfigHash: "test"})
 	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":null}`)
-	got := mustInjectMCPEnvelope(t, msg, em, envelope.BuildOpts{ActionID: "x", Action: "read", Verdict: "allow"})
-
-	if !bytes.Contains(got, []byte(`"_meta"`)) {
-		t.Fatalf("expected _meta to be created for null params, got: %s", got)
+	got, err := injectMCPEnvelope(msg, em, envelope.BuildOpts{ActionID: "x", Action: "read", Verdict: "allow"})
+	if err == nil {
+		t.Fatalf("expected null params to fail closed with an error, got nil (out: %s)", got)
+	}
+	// Fail-closed must not rewrite the message into an injected object; the
+	// original bytes are returned so the caller blocks rather than forwards.
+	if !bytes.Equal(got, msg) {
+		t.Fatalf("expected original message returned on fail-closed, got: %s", got)
+	}
+	if bytes.Contains(got, []byte(`"_meta"`)) {
+		t.Fatalf("null params must not be normalized into an injected _meta, got: %s", got)
 	}
 }
 
@@ -4469,6 +4476,43 @@ func TestForwardScannedInput_NonObjectParamsBlocksEnvelopeInjection(t *testing.T
 		}
 	default:
 		t.Fatal("expected non-object params to block envelope injection")
+	}
+}
+
+func TestForwardScannedInput_NullParamsBlocksEnvelopeInjection(t *testing.T) {
+	sc := testInputScanner(t)
+	em := envelope.NewEmitter(envelope.EmitterConfig{ConfigHash: "test-hash"})
+	// json.Unmarshal of null into a map yields a nil map with no error, so
+	// params:null must be explicitly failed closed rather than normalized to
+	// an object and forwarded with a mediation envelope.
+	clean := `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":null}` + "\n"
+
+	var serverIn bytes.Buffer
+	var logW bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 10)
+
+	opts := buildTestOpts(sc, func(o *MCPProxyOpts) {
+		o.EnvelopeEmitter = em
+	})
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(clean)),
+		transport.NewStdioWriter(&serverIn),
+		&logW, "block", "block", blockedCh, nil, nil, opts,
+	)
+
+	if serverIn.Len() != 0 {
+		t.Fatalf("null params should not be forwarded, got: %s", serverIn.String())
+	}
+	select {
+	case blocked := <-blockedCh:
+		if blocked.ErrorCode != -32002 {
+			t.Fatalf("ErrorCode = %d, want -32002", blocked.ErrorCode)
+		}
+		if string(blocked.ID) != "7" {
+			t.Fatalf("ID = %s, want 7", string(blocked.ID))
+		}
+	default:
+		t.Fatal("expected null params to block envelope injection")
 	}
 }
 

--- a/internal/mcp/pipeline_decision.go
+++ b/internal/mcp/pipeline_decision.go
@@ -63,8 +63,9 @@ type MCPDecision struct {
 // mediation envelope for d. Returns the outbound message bytes -
 // envelope-injected when d.Envelope is non-nil, d.InboundMsg verbatim
 // otherwise. The returned error is the receipt-emit error if one
-// occurred; envelope injection does not return an error (the existing
-// helper is fail-open).
+// occurred, or the envelope-injection error. Envelope injection is
+// fail-closed on malformed params: callers must treat a non-nil error
+// as a block and must not forward the returned bytes.
 //
 // Both emitters are nil-safe:
 //


### PR DESCRIPTION
## Summary
- reject JSON-RPC `params:null` in MCP mediation envelope injection instead of normalizing it to an object
- add unit and forwarding coverage proving null params fail closed and are not forwarded
- update the MCP decision contract comment to match the fail-closed envelope behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened handling of malformed or null request parameters so invalid input is rejected instead of being processed.
  * Requests with `params: null` now fail closed, leaving the original message unchanged and preventing mediation injection.
  * Blocked requests now return the expected error response instead of being forwarded.

* **Documentation**
  * Updated comments to reflect the new fail-closed behavior for envelope injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->