### PR TITLE
fix(proxy): improve receipt failure visibility

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -135,7 +135,10 @@ type Metrics struct {
 	envelopeVerifyTotal *prometheus.CounterVec
 
 	// Signed action-receipt emission (receipt.go).
-	receiptEmitFailures *prometheus.CounterVec
+	receiptEmitFailures      *prometheus.CounterVec
+	requiredReceiptBlockings *prometheus.CounterVec
+	receiptEmitFailureCounts map[string]int64
+	requiredReceiptBlocks    map[string]int64
 
 	// Stats endpoint state (stats_handler.go).
 	mu                     sync.Mutex
@@ -176,12 +179,14 @@ func New() *Metrics {
 	reg := prometheus.NewRegistry()
 
 	m := &Metrics{
-		registry:          reg,
-		startTime:         time.Now(),
-		topBlockedDomains: make(map[string]int64),
-		topScannerHits:    make(map[string]int64),
-		topAnomalyTypes:   make(map[string]int64),
-		agentStats:        make(map[string]*agentCounters),
+		registry:                 reg,
+		startTime:                time.Now(),
+		topBlockedDomains:        make(map[string]int64),
+		topScannerHits:           make(map[string]int64),
+		topAnomalyTypes:          make(map[string]int64),
+		agentStats:               make(map[string]*agentCounters),
+		receiptEmitFailureCounts: make(map[string]int64),
+		requiredReceiptBlocks:    make(map[string]int64),
 	}
 
 	m.registerProxyMetrics(reg)

--- a/internal/metrics/receipt.go
+++ b/internal/metrics/receipt.go
@@ -3,18 +3,28 @@
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // receiptEmitFailureReasons is the closed label domain for
 // pipelock_receipt_emit_failures_total. Bounding the label set prevents
 // unbounded cardinality from arbitrary reason strings.
 var receiptEmitFailureReasons = map[string]bool{
-	"chain_init": true,
-	"sign":       true,
-	"hash":       true,
-	"marshal":    true,
-	"record":     true,
-	"sealed":     true,
+	"chain_init":  true,
+	"sign":        true,
+	"hash":        true,
+	"marshal":     true,
+	"record":      true,
+	"sealed":      true,
+	"unavailable": true,
+}
+
+var requiredReceiptBlockReasons = map[string]bool{
+	"emit_error":  true,
+	"unavailable": true,
 }
 
 func (m *Metrics) registerReceiptMetrics(reg *prometheus.Registry) {
@@ -23,8 +33,14 @@ func (m *Metrics) registerReceiptMetrics(reg *prometheus.Registry) {
 		Name:      "receipt_emit_failures_total",
 		Help:      "Total signed action-receipt emission failures, labeled by reason. A non-zero rate means receipts are not being recorded; investigate the flight-recorder signing key and chain state.",
 	}, []string{"reason"})
+	m.requiredReceiptBlockings = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "pipelock",
+		Name:      "required_receipt_blocks_total",
+		Help:      "Total requests blocked because require_receipts was enabled and a signed action receipt could not be emitted.",
+	}, []string{"reason", "transport"})
 
 	reg.MustRegister(m.receiptEmitFailures)
+	reg.MustRegister(m.requiredReceiptBlockings)
 }
 
 // RecordEmitFailure increments the receipt-emit-failure counter for a
@@ -38,5 +54,54 @@ func (m *Metrics) RecordEmitFailure(reason string) {
 	if !receiptEmitFailureReasons[reason] {
 		reason = "unknown"
 	}
-	m.receiptEmitFailures.WithLabelValues(reason).Inc()
+	m.mu.Lock()
+	if m.receiptEmitFailureCounts != nil {
+		m.receiptEmitFailureCounts[reason]++
+	}
+	m.mu.Unlock()
+	if m.receiptEmitFailures != nil {
+		m.receiptEmitFailures.WithLabelValues(reason).Inc()
+	}
+}
+
+// RecordRequiredReceiptBlock increments the traffic-impact counter for a
+// require_receipts fail-closed decision. The reason and transport label domains
+// are bounded because this path can be reached from client-controlled requests.
+func (m *Metrics) RecordRequiredReceiptBlock(reason, transport string) {
+	if m == nil {
+		return
+	}
+	if !requiredReceiptBlockReasons[reason] {
+		reason = "unknown"
+	}
+	transport = normalizeReceiptTransport(transport)
+	m.mu.Lock()
+	if m.requiredReceiptBlocks != nil {
+		m.requiredReceiptBlocks[requiredReceiptBlockKey(reason, transport)]++
+	}
+	m.mu.Unlock()
+	if m.requiredReceiptBlockings != nil {
+		m.requiredReceiptBlockings.WithLabelValues(reason, transport).Inc()
+	}
+}
+
+func normalizeReceiptTransport(transport string) string {
+	switch transport {
+	case "fetch", "forward", "connect", "websocket", "intercept", "reverse", "mcp":
+		return transport
+	default:
+		return "other"
+	}
+}
+
+func requiredReceiptBlockKey(reason, transport string) string {
+	return reason + "\x00" + transport
+}
+
+func splitRequiredReceiptBlockKey(key string) (reason, transport string) {
+	parts := strings.SplitN(key, "\x00", 2)
+	if len(parts) != 2 {
+		return "unknown", "other"
+	}
+	return parts[0], parts[1]
 }

--- a/internal/metrics/receipt_test.go
+++ b/internal/metrics/receipt_test.go
@@ -4,6 +4,11 @@
 package metrics
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -14,12 +19,16 @@ func TestRecordEmitFailure_CanonicalReasons(t *testing.T) {
 	m.RecordEmitFailure("chain_init")
 	m.RecordEmitFailure("chain_init")
 	m.RecordEmitFailure("record")
+	m.RecordEmitFailure("unavailable")
 
 	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("chain_init")); got != 2 {
 		t.Errorf("chain_init = %v, want 2", got)
 	}
 	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("record")); got != 1 {
 		t.Errorf("record = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("unavailable")); got != 1 {
+		t.Errorf("unavailable = %v, want 1", got)
 	}
 }
 
@@ -36,4 +45,279 @@ func TestRecordEmitFailure_NonCanonicalMappedToUnknown(t *testing.T) {
 func TestRecordEmitFailure_NilSafe(t *testing.T) {
 	var m *Metrics
 	m.RecordEmitFailure("chain_init") // must not panic
+}
+
+func TestRecordEmitFailure_ZeroValueSafe(t *testing.T) {
+	var m Metrics
+	m.RecordEmitFailure("record") // must not panic
+}
+
+func TestRecordRequiredReceiptBlock_BoundedLabels(t *testing.T) {
+	m := New()
+	m.RecordRequiredReceiptBlock("unavailable", "fetch")
+	m.RecordRequiredReceiptBlock("emit_error", "websocket")
+	m.RecordRequiredReceiptBlock("attacker-controlled", "CONNECT /evil")
+
+	if got := testutil.ToFloat64(m.requiredReceiptBlockings.WithLabelValues("unavailable", "fetch")); got != 1 {
+		t.Errorf("unavailable/fetch = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.requiredReceiptBlockings.WithLabelValues("emit_error", "websocket")); got != 1 {
+		t.Errorf("emit_error/websocket = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.requiredReceiptBlockings.WithLabelValues("unknown", "other")); got != 1 {
+		t.Errorf("unknown/other = %v, want 1 (unbounded labels collapsed)", got)
+	}
+}
+
+func TestRecordRequiredReceiptBlock_NilSafe(t *testing.T) {
+	var m *Metrics
+	m.RecordRequiredReceiptBlock("unavailable", "fetch") // must not panic
+}
+
+func TestRecordRequiredReceiptBlock_ZeroValueSafe(t *testing.T) {
+	var m Metrics
+	m.RecordRequiredReceiptBlock("unavailable", "fetch") // must not panic
+}
+
+func TestNormalizeReceiptTransport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		transport string
+		want      string
+	}{
+		{"fetch", "fetch", "fetch"},
+		{"forward", "forward", "forward"},
+		{"connect", "connect", "connect"},
+		{"websocket", "websocket", "websocket"},
+		{"intercept", "intercept", "intercept"},
+		{"reverse", "reverse", "reverse"},
+		{"mcp", "mcp", "mcp"},
+		{"empty", "", "other"},
+		{"uppercase", "FETCH", "other"},
+		{"attacker string", "fetch,reason=record", "other"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeReceiptTransport(tt.transport); got != tt.want {
+				t.Fatalf("normalizeReceiptTransport(%q) = %q, want %q", tt.transport, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatsHandler_IncludesReceiptHealth(t *testing.T) {
+	m := New()
+	m.RecordEmitFailure("record")
+	m.RecordEmitFailure("record")
+	m.RecordEmitFailure("unavailable")
+	m.RecordRequiredReceiptBlock("emit_error", "fetch")
+	m.RecordRequiredReceiptBlock("unavailable", "websocket")
+
+	rec := httptest.NewRecorder()
+	m.StatsHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil))
+
+	var got struct {
+		Receipts struct {
+			EmitFailures   []rankedEntry                 `json:"emit_failures"`
+			RequiredBlocks []requiredReceiptBlockSummary `json:"required_blocks"`
+		} `json:"receipts"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal stats: %v", err)
+	}
+	if len(got.Receipts.EmitFailures) < 2 {
+		t.Fatalf("emit_failures = %+v, want record and unavailable", got.Receipts.EmitFailures)
+	}
+	if got.Receipts.EmitFailures[0] != (rankedEntry{Name: "record", Count: 2}) {
+		t.Fatalf("top emit failure = %+v, want record=2", got.Receipts.EmitFailures[0])
+	}
+	if got.Receipts.EmitFailures[1] != (rankedEntry{Name: "unavailable", Count: 1}) {
+		t.Fatalf("second emit failure = %+v, want unavailable=1", got.Receipts.EmitFailures[1])
+	}
+	wantBlocks := map[requiredReceiptBlockSummary]bool{
+		{Reason: "emit_error", Transport: "fetch", Count: 1}:      true,
+		{Reason: "unavailable", Transport: "websocket", Count: 1}: true,
+	}
+	for _, block := range got.Receipts.RequiredBlocks {
+		delete(wantBlocks, block)
+	}
+	if len(wantBlocks) != 0 {
+		t.Fatalf("required_blocks missing entries: %+v; got %+v", wantBlocks, got.Receipts.RequiredBlocks)
+	}
+}
+
+func TestStatsHandler_ReceiptHealthEmptyByDefault(t *testing.T) {
+	m := New()
+
+	rec := httptest.NewRecorder()
+	m.StatsHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil))
+
+	var got struct {
+		Receipts struct {
+			EmitFailures   []rankedEntry                 `json:"emit_failures"`
+			RequiredBlocks []requiredReceiptBlockSummary `json:"required_blocks"`
+		} `json:"receipts"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal stats: %v", err)
+	}
+	if len(got.Receipts.EmitFailures) != 0 {
+		t.Fatalf("default emit_failures = %+v, want empty", got.Receipts.EmitFailures)
+	}
+	if len(got.Receipts.RequiredBlocks) != 0 {
+		t.Fatalf("default required_blocks = %+v, want empty", got.Receipts.RequiredBlocks)
+	}
+}
+
+func TestStatsHandler_ReceiptHealthUsesBoundedLabels(t *testing.T) {
+	m := New()
+	m.RecordEmitFailure("client supplied reason")
+	m.RecordRequiredReceiptBlock("client supplied reason", "client supplied transport")
+
+	rec := httptest.NewRecorder()
+	m.StatsHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil))
+
+	var got struct {
+		Receipts struct {
+			EmitFailures   []rankedEntry                 `json:"emit_failures"`
+			RequiredBlocks []requiredReceiptBlockSummary `json:"required_blocks"`
+		} `json:"receipts"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal stats: %v", err)
+	}
+	if len(got.Receipts.EmitFailures) != 1 || got.Receipts.EmitFailures[0] != (rankedEntry{Name: "unknown", Count: 1}) {
+		t.Fatalf("emit_failures = %+v, want bounded unknown=1", got.Receipts.EmitFailures)
+	}
+	wantBlock := requiredReceiptBlockSummary{Reason: "unknown", Transport: "other", Count: 1}
+	if len(got.Receipts.RequiredBlocks) != 1 || got.Receipts.RequiredBlocks[0] != wantBlock {
+		t.Fatalf("required_blocks = %+v, want %+v", got.Receipts.RequiredBlocks, wantBlock)
+	}
+}
+
+func TestReceiptHealthMetricsConcurrent(t *testing.T) {
+	m := New()
+	var wg sync.WaitGroup
+	const workers = 8
+	const perWorker = 25
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for j := 0; j < perWorker; j++ {
+				if worker%2 == 0 {
+					m.RecordEmitFailure("record")
+					m.RecordRequiredReceiptBlock("emit_error", "fetch")
+				} else {
+					m.RecordEmitFailure("unavailable")
+					m.RecordRequiredReceiptBlock("unavailable", "websocket")
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	rec := httptest.NewRecorder()
+	m.StatsHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil))
+
+	var got struct {
+		Receipts struct {
+			EmitFailures   []rankedEntry                 `json:"emit_failures"`
+			RequiredBlocks []requiredReceiptBlockSummary `json:"required_blocks"`
+		} `json:"receipts"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal stats: %v", err)
+	}
+	wantEach := int64(workers / 2 * perWorker)
+	wantFailures := map[string]int64{
+		"record":      wantEach,
+		"unavailable": wantEach,
+	}
+	for _, entry := range got.Receipts.EmitFailures {
+		if want, ok := wantFailures[entry.Name]; ok {
+			if entry.Count != want {
+				t.Fatalf("emit failure %s = %d, want %d", entry.Name, entry.Count, want)
+			}
+			delete(wantFailures, entry.Name)
+		}
+	}
+	if len(wantFailures) != 0 {
+		t.Fatalf("missing emit failure counts: %+v; got %+v", wantFailures, got.Receipts.EmitFailures)
+	}
+
+	wantBlocks := map[requiredReceiptBlockSummary]bool{
+		{Reason: "emit_error", Transport: "fetch", Count: wantEach}:      true,
+		{Reason: "unavailable", Transport: "websocket", Count: wantEach}: true,
+	}
+	for _, block := range got.Receipts.RequiredBlocks {
+		delete(wantBlocks, block)
+	}
+	if len(wantBlocks) != 0 {
+		t.Fatalf("missing required block counts: %+v; got %+v", wantBlocks, got.Receipts.RequiredBlocks)
+	}
+}
+
+func TestTopRequiredReceiptBlocksSortsAndCaps(t *testing.T) {
+	counts := map[string]int64{
+		requiredReceiptBlockKey("emit_error", "fetch"):      7,
+		requiredReceiptBlockKey("emit_error", "websocket"):  7,
+		requiredReceiptBlockKey("unavailable", "connect"):   9,
+		requiredReceiptBlockKey("unavailable", "forward"):   3,
+		requiredReceiptBlockKey("unavailable", "websocket"): 9,
+		requiredReceiptBlockKey("malformed-key", "ignored"): 1,
+		"not-delimited": 2,
+	}
+	got := topRequiredReceiptBlocks(counts)
+	wantPrefix := []requiredReceiptBlockSummary{
+		{Reason: "unavailable", Transport: "connect", Count: 9},
+		{Reason: "unavailable", Transport: "websocket", Count: 9},
+		{Reason: "emit_error", Transport: "fetch", Count: 7},
+		{Reason: "emit_error", Transport: "websocket", Count: 7},
+		{Reason: "unavailable", Transport: "forward", Count: 3},
+		{Reason: "unknown", Transport: "other", Count: 2},
+	}
+	if len(got) != len(counts) {
+		t.Fatalf("entry count = %d, want %d: %+v", len(got), len(counts), got)
+	}
+	for i, want := range wantPrefix {
+		if got[i] != want {
+			t.Fatalf("entry %d = %+v, want %+v (all: %+v)", i, got[i], want, got)
+		}
+	}
+
+	large := make(map[string]int64, maxTopEntries+25)
+	for i := 0; i < maxTopEntries+25; i++ {
+		large[requiredReceiptBlockKey("emit_error", fmt.Sprintf("transport-%03d", i))] = int64(i)
+	}
+	capped := topRequiredReceiptBlocks(large)
+	if len(capped) != maxTopEntries {
+		t.Fatalf("capped length = %d, want %d", len(capped), maxTopEntries)
+	}
+	if capped[0].Count != int64(maxTopEntries+24) {
+		t.Fatalf("top count = %d, want %d", capped[0].Count, maxTopEntries+24)
+	}
+	if capped[len(capped)-1].Count != 25 {
+		t.Fatalf("last retained count = %d, want 25", capped[len(capped)-1].Count)
+	}
+}
+
+func TestRequiredReceiptBlockKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key := requiredReceiptBlockKey("emit_error", "websocket")
+	reason, transport := splitRequiredReceiptBlockKey(key)
+	if reason != "emit_error" || transport != "websocket" {
+		t.Fatalf("splitRequiredReceiptBlockKey(%q) = (%q, %q), want (emit_error, websocket)",
+			key, reason, transport)
+	}
+
+	reason, transport = splitRequiredReceiptBlockKey("malformed")
+	if reason != "unknown" || transport != "other" {
+		t.Fatalf("malformed key split = (%q, %q), want bounded fallback (unknown, other)",
+			reason, transport)
+	}
 }

--- a/internal/metrics/stats_handler.go
+++ b/internal/metrics/stats_handler.go
@@ -41,6 +41,10 @@ func (m *Metrics) StatsHandler() http.HandlerFunc {
 				Escalations:  m.sessionEscalationCount,
 				TopAnomalies: topN(m.topAnomalyTypes),
 			},
+			Receipts: receiptStats{
+				EmitFailures:   topN(m.receiptEmitFailureCounts),
+				RequiredBlocks: topRequiredReceiptBlocks(m.requiredReceiptBlocks),
+			},
 		}
 		ceeFunc := m.CEEStatsFunc
 		if total > 0 {
@@ -76,8 +80,20 @@ type statsResponse struct {
 	TopBlockedDomains []rankedEntry            `json:"top_blocked_domains"`
 	TopScanners       []rankedEntry            `json:"top_scanners"`
 	Sessions          sessionStats             `json:"sessions"`
+	Receipts          receiptStats             `json:"receipts"`
 	CEE               CEEStats                 `json:"cross_request_detection"`
 	Agents            map[string]agentStatsOut `json:"agents,omitempty"`
+}
+
+type receiptStats struct {
+	EmitFailures   []rankedEntry                 `json:"emit_failures"`
+	RequiredBlocks []requiredReceiptBlockSummary `json:"required_blocks"`
+}
+
+type requiredReceiptBlockSummary struct {
+	Reason    string `json:"reason"`
+	Transport string `json:"transport"`
+	Count     int64  `json:"count"`
 }
 
 type agentStatsOut struct {
@@ -113,5 +129,30 @@ func topN(m map[string]int64) []rankedEntry {
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Count > entries[j].Count
 	})
+	return entries
+}
+
+func topRequiredReceiptBlocks(m map[string]int64) []requiredReceiptBlockSummary {
+	entries := make([]requiredReceiptBlockSummary, 0, len(m))
+	for key, count := range m {
+		reason, transport := splitRequiredReceiptBlockKey(key)
+		entries = append(entries, requiredReceiptBlockSummary{
+			Reason:    reason,
+			Transport: transport,
+			Count:     count,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Count != entries[j].Count {
+			return entries[i].Count > entries[j].Count
+		}
+		if entries[i].Reason != entries[j].Reason {
+			return entries[i].Reason < entries[j].Reason
+		}
+		return entries[i].Transport < entries[j].Transport
+	})
+	if len(entries) > maxTopEntries {
+		entries = entries[:maxTopEntries]
+	}
 	return entries
 }

--- a/internal/proxy/fetch_require_receipts_test.go
+++ b/internal/proxy/fetch_require_receipts_test.go
@@ -34,7 +34,7 @@ func fetchRequireReceiptsProxy(t *testing.T, require bool) *Proxy {
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
-	rph := newReceiptProxyHelper(t)
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
 	if err := rph.rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}
@@ -95,6 +95,44 @@ func TestHandleFetch_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
 	if got := hits.Load(); got != 0 {
 		t.Fatalf("upstream hits = %d, want 0 (must block before egress)", got)
 	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="fetch"} 1`)
+}
+
+func TestHandleFetch_RequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	cfg := testScannerConfig()
+	cfg.Internal = nil
+	cfg.ResponseScanning.Enabled = false
+	cfg.FlightRecorder.RequireReceipts = true
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+upstream.URL, nil)
+	rec := httptest.NewRecorder()
+	p.handleFetch(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if got := rec.Header().Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
+		t.Fatalf("block reason header = %q, want %s", got, blockreason.ReceiptEmissionFailed)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (must block before egress)", got)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="fetch"} 1`)
 }
 
 // TestHandleFetch_ReceiptFailureWithoutRequireStillForwards pins the default:
@@ -120,6 +158,8 @@ func TestHandleFetch_ReceiptFailureWithoutRequireStillForwards(t *testing.T) {
 	if got := hits.Load(); got != 1 {
 		t.Fatalf("upstream hits = %d, want 1", got)
 	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsNotContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="fetch"} 1`)
 }
 
 func TestHandleFetch_RequireReceiptsResponseBlockReusesActionID(t *testing.T) {

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -555,7 +555,7 @@ func TestForwardProxy_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
 		cfg.ResponseScanning.Enabled = false
 	})
 	defer cleanup()
-	rph := newReceiptProxyHelper(t)
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
 	if err := rph.rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}
@@ -572,6 +572,37 @@ func TestForwardProxy_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
 	if got := hits.Load(); got != 0 {
 		t.Fatalf("upstream hits = %d, want 0", got)
 	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="forward"} 1`)
+}
+
+func TestForwardProxy_RequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+		cfg.ResponseScanning.Enabled = false
+	})
+	defer cleanup()
+
+	resp := doGet(t, forwardHTTPClient(t, proxyAddr), upstream.URL)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.ReceiptEmissionFailed)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0", got)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="forward"} 1`)
 }
 
 func TestConnect_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
@@ -581,7 +612,11 @@ func TestConnect_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("target listen: %v", err)
 	}
-	defer targetLn.Close() //nolint:errcheck // test cleanup
+	t.Cleanup(func() {
+		if closeErr := targetLn.Close(); closeErr != nil {
+			t.Errorf("target listener close: %v", closeErr)
+		}
+	})
 	go func() {
 		for {
 			conn, err := targetLn.Accept()
@@ -597,21 +632,29 @@ func TestConnect_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
 		cfg.FlightRecorder.RequireReceipts = true
 	})
 	defer cleanup()
-	rph := newReceiptProxyHelper(t)
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
 	if err := rph.rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}
 	p.receiptEmitterPtr.Store(rph.emitter)
 
 	conn := dialProxy(t, proxyAddr)
-	defer conn.Close() //nolint:errcheck // test cleanup
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Errorf("proxy connection close: %v", closeErr)
+		}
+	}()
 	target := targetLn.Addr().String()
 	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
 	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
 	if err != nil {
 		t.Fatalf("read CONNECT response: %v", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck // test cleanup
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("CONNECT response body close: %v", closeErr)
+		}
+	}()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("CONNECT status = %d, want 403", resp.StatusCode)
 	}
@@ -621,6 +664,66 @@ func TestConnect_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
 	if got := hits.Load(); got != 0 {
 		t.Fatalf("target hits = %d, want 0", got)
 	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="connect"} 1`)
+}
+
+func TestConnect_RequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
+	var hits atomic.Int32
+	lc := net.ListenConfig{}
+	targetLn, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("target listen: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := targetLn.Close(); closeErr != nil {
+			t.Errorf("target listener close: %v", closeErr)
+		}
+	})
+	go func() {
+		for {
+			conn, acceptErr := targetLn.Accept()
+			if acceptErr != nil {
+				return
+			}
+			hits.Add(1)
+			_ = conn.Close()
+		}
+	}()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+	})
+	defer cleanup()
+
+	conn := dialProxy(t, proxyAddr)
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Errorf("proxy connection close: %v", closeErr)
+		}
+	}()
+	target := targetLn.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("CONNECT response body close: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("CONNECT status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.ReceiptEmissionFailed)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("target hits = %d, want 0", got)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="connect"} 1`)
 }
 
 func TestForwardProxy_ReceiptFailureWithoutRequireStillForwards(t *testing.T) {
@@ -636,7 +739,7 @@ func TestForwardProxy_ReceiptFailureWithoutRequireStillForwards(t *testing.T) {
 		cfg.ResponseScanning.Enabled = false
 	})
 	defer cleanup()
-	rph := newReceiptProxyHelper(t)
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
 	if err := rph.rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}
@@ -650,6 +753,8 @@ func TestForwardProxy_ReceiptFailureWithoutRequireStillForwards(t *testing.T) {
 	if got := hits.Load(); got != 1 {
 		t.Fatalf("upstream hits = %d, want 1", got)
 	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsNotContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="forward"} 1`)
 }
 
 func TestForwardProxy_RequireReceiptsSuccessEmitsSingleAllow(t *testing.T) {

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -176,7 +176,7 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) error {
 	e := ic.Proxy.receiptEmitterPtr.Load()
 	ic.Proxy.reloadMu.RUnlock()
 	if e == nil {
-		return fmt.Errorf("receipt emitter unavailable")
+		return errReceiptEmitterUnavailable
 	}
 	if err := e.Emit(opts); err != nil {
 		if ic.Logger != nil {
@@ -197,6 +197,12 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) error {
 
 func interceptEmitReceiptOrBlock(ic *InterceptContext, w http.ResponseWriter, actx audit.LogContext, opts receipt.EmitOpts) bool {
 	if err := interceptEmitReceipt(ic, opts); err != nil && ic.Config != nil && ic.Config.FlightRecorder.RequireReceipts {
+		if errors.Is(err, errReceiptEmitterUnavailable) && ic.Proxy != nil {
+			ic.Proxy.metrics.RecordEmitFailure(receipt.FailReasonUnavailable)
+		}
+		if ic.Proxy != nil {
+			ic.Proxy.metrics.RecordRequiredReceiptBlock(requiredReceiptBlockMetricReason(err), opts.Transport)
+		}
 		blockedErr := newReceiptEmissionBlockedRequest(err)
 		ic.Logger.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
 		writeBlockedError(w,

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -70,11 +70,14 @@ func TestInterceptEmitReceiptOrBlockRequiresReceipt(t *testing.T) {
 	cfg.Internal = nil
 	cfg.ApplyDefaults()
 
-	p, err := New(cfg, audit.NewNop(), scanner.New(cfg), metrics.New())
+	m := metrics.New()
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, audit.NewNop(), sc, m)
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
-	rph := newReceiptProxyHelper(t)
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
 	if err := rph.rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}
@@ -106,6 +109,49 @@ func TestInterceptEmitReceiptOrBlockRequiresReceipt(t *testing.T) {
 	if got := rr.Header().Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
 		t.Fatalf("block reason = %q, want %s", got, blockreason.ReceiptEmissionFailed)
 	}
+	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="intercept"} 1`)
+}
+
+func TestInterceptEmitReceiptOrBlockUnavailableEmitterRecordsMetric(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.FlightRecorder.RequireReceipts = true
+	cfg.Internal = nil
+	cfg.ApplyDefaults()
+
+	m := metrics.New()
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, audit.NewNop(), sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	ic := &InterceptContext{
+		Proxy:     p,
+		Config:    cfg,
+		Logger:    audit.NewNop(),
+		RequestID: "req-intercept-unavailable",
+		Agent:     "agent",
+	}
+	rr := httptest.NewRecorder()
+	blocked := interceptEmitReceiptOrBlock(ic, rr, audit.NewRequestLogContext(ic.RequestID), receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: "intercept",
+		Method:    http.MethodGet,
+		Target:    "https://example.test/",
+		RequestID: ic.RequestID,
+		Agent:     ic.Agent,
+	})
+	if !blocked {
+		t.Fatal("unavailable required receipt emitter did not fail closed")
+	}
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`)
+	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="intercept"} 1`)
 }
 
 func testInterceptRedactProxy(t *testing.T, cfg *config.Config) *Proxy {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -984,15 +984,30 @@ func (p *Proxy) emitReceipt(opts receipt.EmitOpts) error {
 	return p.emitReceiptWithEmitter(opts, p.receiptEmitterPtr.Load())
 }
 
+var errReceiptEmitterUnavailable = errors.New("receipt emitter unavailable")
+
+func requiredReceiptBlockMetricReason(err error) string {
+	if errors.Is(err, errReceiptEmitterUnavailable) {
+		return receipt.FailReasonUnavailable
+	}
+	return "emit_error"
+}
+
 func (p *Proxy) emitRequiredReceipt(opts receipt.EmitOpts) error {
 	if cfg := p.cfgPtr.Load(); cfg != nil {
 		opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 	}
 	e := p.receiptEmitterPtr.Load()
 	if e == nil {
-		return fmt.Errorf("receipt emitter unavailable")
+		p.metrics.RecordEmitFailure(receipt.FailReasonUnavailable)
+		p.metrics.RecordRequiredReceiptBlock(receipt.FailReasonUnavailable, opts.Transport)
+		return errReceiptEmitterUnavailable
 	}
-	return p.emitReceiptWithEmitter(opts, e)
+	if err := p.emitReceiptWithEmitter(opts, e); err != nil {
+		p.metrics.RecordRequiredReceiptBlock(requiredReceiptBlockMetricReason(err), opts.Transport)
+		return err
+	}
+	return nil
 }
 
 func (p *Proxy) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter) error {

--- a/internal/proxy/receipt_coverage_test.go
+++ b/internal/proxy/receipt_coverage_test.go
@@ -976,6 +976,11 @@ type receiptProxyHelper struct {
 
 func newReceiptProxyHelper(t *testing.T) *receiptProxyHelper {
 	t.Helper()
+	return newReceiptProxyHelperWithMetrics(t, nil)
+}
+
+func newReceiptProxyHelperWithMetrics(t *testing.T, m *metrics.Metrics) *receiptProxyHelper {
+	t.Helper()
 	dir := t.TempDir()
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -998,6 +1003,7 @@ func newReceiptProxyHelper(t *testing.T) *receiptProxyHelper {
 		ConfigHash: coverageTestConfigHash,
 		Principal:  coverageTestPrincipal,
 		Actor:      coverageTestActor,
+		Metrics:    m,
 	})
 
 	return &receiptProxyHelper{

--- a/internal/proxy/receipt_reliability_test.go
+++ b/internal/proxy/receipt_reliability_test.go
@@ -16,16 +16,23 @@ func assertMetricsContain(t *testing.T, m *metrics.Metrics, want string) {
 	t.Helper()
 	rec := httptest.NewRecorder()
 	m.PrometheusHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
-	if body := rec.Body.String(); !strings.Contains(body, want) {
-		t.Fatalf("missing metric line %q:\n%s", want, body)
+	body := rec.Body.String()
+	for _, line := range strings.Split(body, "\n") {
+		if line == want {
+			return
+		}
 	}
+	t.Fatalf("missing metric line %q:\n%s", want, body)
 }
 
 func assertMetricsNotContain(t *testing.T, m *metrics.Metrics, unwanted string) {
 	t.Helper()
 	rec := httptest.NewRecorder()
 	m.PrometheusHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
-	if body := rec.Body.String(); strings.Contains(body, unwanted) {
-		t.Fatalf("unexpected metric line %q:\n%s", unwanted, body)
+	body := rec.Body.String()
+	for _, line := range strings.Split(body, "\n") {
+		if line == unwanted {
+			t.Fatalf("unexpected metric line %q:\n%s", unwanted, body)
+		}
 	}
 }

--- a/internal/proxy/receipt_reliability_test.go
+++ b/internal/proxy/receipt_reliability_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+)
+
+func assertMetricsContain(t *testing.T, m *metrics.Metrics, want string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	m.PrometheusHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
+	if body := rec.Body.String(); !strings.Contains(body, want) {
+		t.Fatalf("missing metric line %q:\n%s", want, body)
+	}
+}
+
+func assertMetricsNotContain(t *testing.T, m *metrics.Metrics, unwanted string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	m.PrometheusHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
+	if body := rec.Body.String(); strings.Contains(body, unwanted) {
+		t.Fatalf("unexpected metric line %q:\n%s", unwanted, body)
+	}
+}

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -293,6 +294,74 @@ func TestProxy_NilEmitter_NoReceipt(t *testing.T) {
 		if e.Type == receiptEntryType {
 			t.Fatal("unexpected action_receipt entry when emitter is nil")
 		}
+	}
+}
+
+func TestEmitRequiredReceipt_UnavailableEmitterRecordsMetric(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	m := metrics.New()
+	p, err := New(cfg, audit.NewNop(), sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	err = p.emitRequiredReceipt(receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: TransportFetch,
+		Method:    http.MethodGet,
+		Target:    "https://example.test/required",
+		RequestID: "req-required-unavailable",
+		Agent:     "agent",
+	})
+	if !errors.Is(err, errReceiptEmitterUnavailable) {
+		t.Fatalf("error = %v, want errReceiptEmitterUnavailable", err)
+	}
+	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`)
+	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="fetch"} 1`)
+}
+
+func TestRequiredReceiptBlockMetricReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "unavailable",
+			err:  errReceiptEmitterUnavailable,
+			want: receipt.FailReasonUnavailable,
+		},
+		{
+			name: "wrapped unavailable",
+			err:  fmt.Errorf("context: %w", errReceiptEmitterUnavailable),
+			want: receipt.FailReasonUnavailable,
+		},
+		{
+			name: "record failure",
+			err:  fmt.Errorf("recording receipt: disk full"),
+			want: "emit_error",
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: "emit_error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := requiredReceiptBlockMetricReason(tt.err); got != tt.want {
+				t.Fatalf("requiredReceiptBlockMetricReason(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -247,17 +247,20 @@ func (rp *ReverseProxyHandler) emitReceipt(opts receipt.EmitOpts) {
 			opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 		}
 	}
-	if rp.receiptEmitterPtr != nil {
-		if e := rp.receiptEmitterPtr.Load(); e != nil {
-			if err := e.Emit(opts); err != nil {
-				rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
-					fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
-						opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
-						opts.Transport, opts.Method, opts.Target, opts.Agent, err))
-				// v1 stays authoritative: skip v2 when v1 failed to record.
-				return
-			}
-		}
+	if rp.receiptEmitterPtr == nil {
+		return
+	}
+	e := rp.receiptEmitterPtr.Load()
+	if e == nil {
+		return
+	}
+	if err := e.Emit(opts); err != nil {
+		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
+			fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
+				opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
+				opts.Transport, opts.Method, opts.Target, opts.Agent, err))
+		// v1 stays authoritative: skip v2 when v1 failed to record.
+		return
 	}
 	// Dual-emit the v2 proxy_decision receipt.
 	emitV2(rp.v2EmitterPtr, opts, func(err error) {

--- a/internal/proxy/reverse_receipt_parity_test.go
+++ b/internal/proxy/reverse_receipt_parity_test.go
@@ -7,6 +7,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,9 +21,12 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/shield"
 )
@@ -74,6 +80,229 @@ func reverseReceiptParitySetupWithShield(t *testing.T, cfg *config.Config, upstr
 		if err := rec.Close(); err != nil {
 			t.Fatalf("recorder close: %v", err)
 		}
+	}
+}
+
+func TestReverseEmitReceipt_NoV1EmitterSkipsV2(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	signer := proxydecision.NewKeyedSigner(priv)
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder:  rec,
+		Signer:    signer,
+		Principal: "local",
+		Actor:     "pipelock",
+	})
+	if v2 == nil {
+		t.Fatal("v2 emitter construction returned nil")
+	}
+	var v2Ptr atomic.Pointer[proxydecision.Emitter]
+	v2Ptr.Store(v2)
+
+	rp := &ReverseProxyHandler{
+		logger:       audit.NewNop(),
+		v2EmitterPtr: &v2Ptr,
+	}
+	rp.emitReceipt(receipt.EmitOpts{
+		ActionID:  "reverse-no-v1",
+		Verdict:   config.ActionBlock,
+		Layer:     LayerReverseResponseBlocked,
+		Pattern:   "response_scan",
+		Transport: TransportReverse,
+		Method:    http.MethodGet,
+		Target:    "https://example.test/reverse",
+		RequestID: "req-reverse-no-v1",
+		Agent:     "agent",
+	})
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	for _, e := range readRecorderEntries(t, dir) {
+		if e.Type == "action_receipt" {
+			t.Fatalf("unexpected v1 action_receipt without a v1 emitter: %+v", e)
+		}
+		if e.Type == "evidence_receipt" && e.EventKind == string(contractreceipt.PayloadProxyDecision) {
+			t.Fatalf("unexpected v2 proxy_decision without a v1 action_receipt sibling: %+v", e)
+		}
+	}
+}
+
+func TestReverseEmitReceipt_V1FailureSkipsV2(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	v1 := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: "test-hash",
+		Principal:  "local",
+		Actor:      "pipelock",
+	})
+	if v1 == nil {
+		t.Fatal("v1 emitter construction returned nil")
+	}
+	if err := v1.Emit(receipt.EmitOpts{
+		ActionID:  "seed",
+		Verdict:   config.ActionAllow,
+		Transport: TransportReverse,
+		Method:    http.MethodGet,
+		Target:    "https://example.test/seed",
+	}); err != nil {
+		t.Fatalf("seed Emit: %v", err)
+	}
+	if err := v1.EmitTranscriptRoot("proxy"); err != nil {
+		t.Fatalf("EmitTranscriptRoot: %v", err)
+	}
+
+	signer := proxydecision.NewKeyedSigner(priv)
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder:  rec,
+		Signer:    signer,
+		Principal: "local",
+		Actor:     "pipelock",
+	})
+	if v2 == nil {
+		t.Fatal("v2 emitter construction returned nil")
+	}
+	var v1Ptr atomic.Pointer[receipt.Emitter]
+	v1Ptr.Store(v1)
+	var v2Ptr atomic.Pointer[proxydecision.Emitter]
+	v2Ptr.Store(v2)
+
+	rp := &ReverseProxyHandler{
+		logger:            audit.NewNop(),
+		receiptEmitterPtr: &v1Ptr,
+		v2EmitterPtr:      &v2Ptr,
+	}
+	rp.emitReceipt(receipt.EmitOpts{
+		ActionID:  "reverse-v1-fail",
+		Verdict:   config.ActionBlock,
+		Layer:     LayerReverseResponseBlocked,
+		Pattern:   "response_scan",
+		Transport: TransportReverse,
+		Method:    http.MethodGet,
+		Target:    "https://example.test/reverse",
+		RequestID: "req-reverse-v1-fail",
+		Agent:     "agent",
+	})
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	for _, e := range readRecorderEntries(t, dir) {
+		if e.Type == "evidence_receipt" && e.EventKind == string(contractreceipt.PayloadProxyDecision) {
+			t.Fatalf("unexpected v2 proxy_decision after v1 receipt failure: %+v", e)
+		}
+	}
+}
+
+func TestReverseEmitReceipt_V1SuccessEmitsV2Sibling(t *testing.T) {
+	dir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	v1 := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: "test-hash",
+		Principal:  "local",
+		Actor:      "pipelock",
+	})
+	if v1 == nil {
+		t.Fatal("v1 emitter construction returned nil")
+	}
+	signer := proxydecision.NewKeyedSigner(priv)
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder:  rec,
+		Signer:    signer,
+		Principal: "local",
+		Actor:     "pipelock",
+	})
+	if v2 == nil {
+		t.Fatal("v2 emitter construction returned nil")
+	}
+	var v1Ptr atomic.Pointer[receipt.Emitter]
+	v1Ptr.Store(v1)
+	var v2Ptr atomic.Pointer[proxydecision.Emitter]
+	v2Ptr.Store(v2)
+
+	rp := &ReverseProxyHandler{
+		logger:            audit.NewNop(),
+		receiptEmitterPtr: &v1Ptr,
+		v2EmitterPtr:      &v2Ptr,
+	}
+	wantPolicyHash := strings.Repeat("a", 64)
+	rp.emitReceipt(receipt.EmitOpts{
+		ActionID:   "reverse-v1-ok",
+		Verdict:    config.ActionBlock,
+		Layer:      LayerReverseResponseBlocked,
+		Pattern:    "response_scan",
+		Transport:  TransportReverse,
+		Method:     http.MethodGet,
+		Target:     "https://example.test/reverse",
+		RequestID:  "req-reverse-v1-ok",
+		Agent:      "agent",
+		PolicyHash: wantPolicyHash,
+	})
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	var v1Count, v2Count int
+	for _, e := range readRecorderEntries(t, dir) {
+		switch {
+		case e.Type == "action_receipt":
+			v1Count++
+		case e.Type == "evidence_receipt" && e.EventKind == string(contractreceipt.PayloadProxyDecision):
+			v2Count++
+			var rcpt contractreceipt.EvidenceReceipt
+			if err := json.Unmarshal(e.Detail, &rcpt); err != nil {
+				t.Fatalf("unmarshal v2 receipt: %v", err)
+			}
+			if err := contractreceipt.VerifyWithKey(rcpt, pub, signer.KeyID()); err != nil {
+				t.Fatalf("v2 receipt verify: %v", err)
+			}
+			if rcpt.PolicyHash != contractreceipt.NormalizePolicyHash(wantPolicyHash) {
+				t.Fatalf("v2 policy_hash = %q, want %q", rcpt.PolicyHash, contractreceipt.NormalizePolicyHash(wantPolicyHash))
+			}
+		}
+	}
+	if v1Count != 1 {
+		t.Fatalf("v1 action_receipt count = %d, want 1", v1Count)
+	}
+	if v2Count != 1 {
+		t.Fatalf("v2 proxy_decision count = %d, want 1", v2Count)
 	}
 }
 

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/addressprotect"
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
@@ -608,6 +610,109 @@ func TestWSProxyRequireReceipts_RedactedSuccessEmitsCloseSummary(t *testing.T) {
 	if redactionCloseCount != 1 {
 		t.Fatalf("redaction close receipt count = %d, want one signed close summary", redactionCloseCount)
 	}
+}
+
+func TestWSProxyRequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
+	var upstreamHits atomic.Int32
+	lc := net.ListenConfig{}
+	backendLn, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen backend: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := backendLn.Close(); closeErr != nil {
+			t.Errorf("backend listener close: %v", closeErr)
+		}
+	})
+	go func() {
+		for {
+			conn, acceptErr := backendLn.Accept()
+			if acceptErr != nil {
+				return
+			}
+			upstreamHits.Add(1)
+			_ = conn.Close()
+		}
+	}()
+
+	proxyAddr, p, proxyCleanup := setupWSProxyDefaultWithProxy(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+	})
+	defer proxyCleanup()
+
+	conn := dialWS(t, proxyAddr, backendLn.Addr().String())
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Errorf("websocket connection close: %v", closeErr)
+		}
+	}()
+	_, _, err = wsutil.ReadServerData(conn)
+	if err == nil {
+		t.Fatal("expected websocket close error for required receipt failure")
+	}
+	if errText := err.Error(); errText != "EOF" &&
+		(!strings.Contains(errText, "1008") || !strings.Contains(errText, string(blockreason.ReceiptEmissionFailed))) {
+		t.Fatalf("close error = %q, want EOF or policy violation receipt emission failure", errText)
+	}
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0", got)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="websocket"} 1`)
+}
+
+func TestWSProxyRequireReceiptsEmissionFailureBlocksAndRecordsMetrics(t *testing.T) {
+	var upstreamHits atomic.Int32
+	lc := net.ListenConfig{}
+	backendLn, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen backend: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := backendLn.Close(); closeErr != nil {
+			t.Errorf("backend listener close: %v", closeErr)
+		}
+	})
+	go func() {
+		for {
+			conn, acceptErr := backendLn.Accept()
+			if acceptErr != nil {
+				return
+			}
+			upstreamHits.Add(1)
+			_ = conn.Close()
+		}
+	}()
+
+	proxyAddr, p, proxyCleanup := setupWSProxyDefaultWithProxy(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+	})
+	defer proxyCleanup()
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	if err := rph.rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	conn := dialWS(t, proxyAddr, backendLn.Addr().String())
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Errorf("websocket connection close: %v", closeErr)
+		}
+	}()
+	_, _, err = wsutil.ReadServerData(conn)
+	if err == nil {
+		t.Fatal("expected websocket close error for required receipt failure")
+	}
+	if errText := err.Error(); errText != "EOF" &&
+		(!strings.Contains(errText, "1008") || !strings.Contains(errText, string(blockreason.ReceiptEmissionFailed))) {
+		t.Fatalf("close error = %q, want EOF or policy violation receipt emission failure", errText)
+	}
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0", got)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="websocket"} 1`)
 }
 
 func TestWSProxyRedaction_BinaryNonJSONBlocked(t *testing.T) {

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -55,6 +55,11 @@ const (
 	FailReasonRecord = "record"
 	// FailReasonSealed is an emit attempt after the transcript root was emitted.
 	FailReasonSealed = "sealed"
+	// FailReasonUnavailable is a required-receipt emission attempt when no
+	// receipt emitter is configured. Best-effort receipt paths intentionally
+	// remain silent when receipts are disabled; this reason is for fail-closed
+	// require_receipts decisions only.
+	FailReasonUnavailable = "unavailable"
 )
 
 // Emitter produces signed action receipts and writes them to the flight recorder.


### PR DESCRIPTION
## Summary
- add bounded Prometheus and JSON stats visibility for required receipt blocks and missing receipt emitters
- distinguish unavailable emitters from emit errors across fetch, forward, CONNECT, WebSocket, and intercept required-receipt paths
- keep reverse proxy v2 proxy_decision receipts from being emitted without a successful v1 action_receipt sibling
- expand proxy and metrics tests across required-receipt failure modes and reverse v1/v2 receipt parity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added receipt-related health data to the stats output, including ranked summaries of receipt emission failures and blocked required receipts (with reason and transport breakdowns).
  * Extended Prometheus metrics for required-receipt blocking and receipt emission failures, including an “unavailable” failure reason.
* **Bug Fixes**
  * Improved fail-closed handling when required receipts can’t be produced, with consistent metrics recording across proxy paths.
  * Added safeguards to keep metric labels bounded and normalize reason/transport values to prevent malformed inputs from skewing reporting.
* **Tests**
  * Expanded coverage for metrics, stats output, concurrency, and edge cases (including nil/zero-value safety).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->