### PR TITLE
Fail closed on default MCP binary integrity

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2421,7 +2421,7 @@ Pre-spawn SHA-256 hash verification for MCP server subprocesses. Prevents tamper
 mcp_binary_integrity:
   enabled: true
   manifest_path: /etc/pipelock/binary-manifest.json
-  action: warn
+  action: block
   require_signature: false
 ```
 
@@ -2429,11 +2429,13 @@ mcp_binary_integrity:
 |-------|---------|-------------|
 | `enabled` | `false` | Enable binary hash verification before spawn |
 | `manifest_path` | (required if enabled) | Path to JSON hash manifest |
-| `action` | `warn` | Action on hash mismatch: `block` or `warn` |
+| `action` | `block` | Action on manifest load failure or hash mismatch: `block` or `warn` |
 | `require_signature` | `false` | Verify a detached manifest signature before using the manifest |
 | `signature_path` | `<manifest_path>.sig` | Detached signature path when signatures are required |
 | `trusted_signer` | (required when signatures are required) | Keystore identity used to verify the manifest signature |
 | `keystore` | `~/.pipelock` | Keystore used for the trusted signer lookup |
+
+Omitting `action` is fail-closed: a missing manifest, unreadable manifest, unknown binary, or hash mismatch blocks MCP subprocess spawn. Set `action: warn` only for a temporary rollout if you need the previous log-only behavior while completing the manifest.
 
 The manifest is a JSON file mapping binary paths to expected SHA-256 hashes. Pipelock resolves shebangs and versioned interpreters (e.g., `python3.11`) before hashing. Generate, preflight, and sign the manifest with `pipelock mcp integrity manifest`; see [MCP integrity manifest tooling](cli/mcp-integrity.md).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2429,13 +2429,14 @@ mcp_binary_integrity:
 |-------|---------|-------------|
 | `enabled` | `false` | Enable binary hash verification before spawn |
 | `manifest_path` | (required if enabled) | Path to JSON hash manifest |
-| `action` | `block` | Action on manifest load failure or hash mismatch: `block` or `warn` |
-| `require_signature` | `false` | Verify a detached manifest signature before using the manifest |
-| `signature_path` | `<manifest_path>.sig` | Detached signature path when signatures are required |
-| `trusted_signer` | (required when signatures are required) | Keystore identity used to verify the manifest signature |
+| `action` | `block` | Action on manifest load failure or hash mismatch: `block` or `warn`; signature trust failures still block when `require_signature: true` |
+| `require_signature` | `false` | Verify a detached manifest signature before using the manifest; verification failures always block |
+| `signature_path` | `<manifest_path>.sig` | Detached signature path when signatures are required; unreadable or invalid signatures block |
+| `trusted_signer` | (required when signatures are required) | Keystore identity used to verify the manifest signature; missing or untrusted signer state blocks |
 | `keystore` | `~/.pipelock` | Keystore used for the trusted signer lookup |
 
 Omitting `action` is fail-closed: a missing manifest, unreadable manifest, unknown binary, or hash mismatch blocks MCP subprocess spawn. Set `action: warn` only for a temporary rollout if you need the previous log-only behavior while completing the manifest.
+When `require_signature: true`, signer lookup and signature verification failures always block; `action: warn` only applies to non-signature manifest load and hash issues.
 
 The manifest is a JSON file mapping binary paths to expected SHA-256 hashes. Pipelock resolves shebangs and versioned interpreters (e.g., `python3.11`) before hashing. Generate, preflight, and sign the manifest with `pipelock mcp integrity manifest`; see [MCP integrity manifest tooling](cli/mcp-integrity.md).
 

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -216,6 +216,10 @@ const (
 	// Re-bumped for removing Slack/Discord/Telegram from generated default
 	// api_allowlist. Messaging platforms are common exfiltration channels and
 	// should be explicit operator choices, not out-of-box policy.
+	// Re-bumped for MCP binary-integrity fail-closed defaults:
+	// enabled mcp_binary_integrity with no explicit action now defaults to
+	// block, so missing manifests and hash failures stop MCP subprocess spawn
+	// unless an operator deliberately sets action: warn.
 	// Re-bumped for the dotted-token DLP false-positive fix: the "Discord Bot
 	// Token", "SendGrid API Key", and "JWT Token" default patterns now pin
 	// their structural prefix anchors case-sensitively ((?-i:[MN]), (?-i:SG.),
@@ -227,7 +231,7 @@ const (
 	// JSON-object encodings (`eyA`, `ew[o/k/0]`, `e30`, `e30=`), so compact
 	// JWTs with whitespace or empty claims are not dropped. See
 	// TestTextDLP_DottedTokenPatterns.
-	goldenHashDefaults = "202ed8105c8c7b9c415bb5890b359313f5cc8395550d5bd22cba88662fa1e2be"
+	goldenHashDefaults = "eccdfd0b83416de46dd9247c7a5986558834e2f9be5e21ae0fda9c280c6bc8bc"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10243,6 +10243,24 @@ func TestLoad_MCPBinaryIntegrityDefaults(t *testing.T) {
 		t.Fatalf("Load() error: %v", err)
 	}
 
+	if cfg.MCPBinaryIntegrity.Action != ActionBlock {
+		t.Errorf("Action = %q, want %q", cfg.MCPBinaryIntegrity.Action, ActionBlock)
+	}
+}
+
+func TestLoad_MCPBinaryIntegrityExplicitWarnPreserved(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "integrity.yaml")
+	content := "mode: balanced\nmcp_binary_integrity:\n  enabled: true\n  manifest_path: /tmp/manifest.json\n  action: warn\n"
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
 	if cfg.MCPBinaryIntegrity.Action != ActionWarn {
 		t.Errorf("Action = %q, want %q", cfg.MCPBinaryIntegrity.Action, ActionWarn)
 	}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -597,7 +597,7 @@ func Defaults() *Config {
 			MaxRawSize:                1 << 20, // 1MB encoded
 		},
 		MCPBinaryIntegrity: MCPBinaryIntegrity{
-			Action: ActionWarn, // default action when hash verification fails
+			Action: ActionBlock, // default action when hash verification fails
 		},
 		FlightRecorder: FlightRecorder{
 			// Enabled by default so receipts ("verify the boundary") are on out

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -700,7 +700,7 @@ func (c *Config) ApplyDefaults() {
 	// MCP binary integrity defaults
 	if c.MCPBinaryIntegrity.Enabled {
 		if c.MCPBinaryIntegrity.Action == "" {
-			c.MCPBinaryIntegrity.Action = ActionWarn
+			c.MCPBinaryIntegrity.Action = ActionBlock
 		}
 	}
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1486,7 +1486,7 @@ type TaintTrustOverride struct {
 type MCPBinaryIntegrity struct {
 	Enabled          bool   `yaml:"enabled"`
 	ManifestPath     string `yaml:"manifest_path"`     // path to hash manifest JSON
-	Action           string `yaml:"action"`            // "block" or "warn" (default "warn")
+	Action           string `yaml:"action"`            // "block" or "warn" (default "block")
 	RequireSignature bool   `yaml:"require_signature"` // verify detached manifest signature before use
 	SignaturePath    string `yaml:"signature_path"`    // optional; default manifest_path + .sig
 	TrustedSigner    string `yaml:"trusted_signer"`    // keystore identity used to verify manifest signature

--- a/internal/mcp/integrity/integrity.go
+++ b/internal/mcp/integrity/integrity.go
@@ -81,7 +81,7 @@ func isInterpreterName(baseName string) bool {
 type Config struct {
 	Enabled      bool              `yaml:"enabled"`
 	ManifestPath string            `yaml:"manifest_path"` // path to JSON manifest on disk
-	Action       string            `yaml:"action"`        // "block" or "warn" (default "warn")
+	Action       string            `yaml:"action"`        // "block" or "warn" (default "block")
 	Manifests    map[string]string `yaml:"-"`             // loaded: resolved_path -> expected SHA-256
 }
 

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1427,11 +1427,15 @@ func safeEnv() []string {
 	return env
 }
 
-// hash before subprocess spawn. Returns an error only when action is "block"
-// and verification fails; "warn" failures are logged to logW and return nil.
-// VerifyBinaryIntegrity checks the command binary against a hash manifest.
-// Returns nil when verification passes or action is warn (logged only).
-// Returns an error when action is block and verification fails.
+// VerifyBinaryIntegrity checks the command binary against a hash manifest
+// before subprocess spawn. Fail-closed: a verification failure returns an
+// error (blocking spawn) UNLESS action is explicitly "warn", in which case the
+// failure is logged to logW and nil is returned. An empty or unrecognized
+// action therefore blocks, matching the fail-closed config default. Config
+// load already constrains action to "warn" or "block" via Validate; treating
+// only an explicit "warn" as relaxing is defense-in-depth for any in-process
+// caller that constructs the config without validation.
+// Returns nil when verification passes.
 func VerifyBinaryIntegrity(command []string, icfg *config.MCPBinaryIntegrity, logW io.Writer, workDir ...string) error {
 	agentWorkDir := ""
 	if len(workDir) > 0 {
@@ -1449,12 +1453,12 @@ func VerifyBinaryIntegrity(command []string, icfg *config.MCPBinaryIntegrity, lo
 	// the file after verification would open a TOCTOU window where an
 	// attacker with write access to the manifest path could swap the
 	// file between sig-verify and parse. Fail-closed: load errors are
-	// fatal when action is "block", logged as warnings otherwise, EXCEPT
-	// when require_signature=true: trust-establishment failures always
-	// block regardless of action.
+	// fatal unless action is explicitly "warn", EXCEPT when
+	// require_signature=true: trust-establishment failures always block
+	// regardless of action.
 	manifest, loadErr := loadMCPIntegrityManifest(icfg)
 	if loadErr != nil {
-		if icfg.RequireSignature || icfg.Action == config.ActionBlock {
+		if icfg.RequireSignature || icfg.Action != config.ActionWarn {
 			return fmt.Errorf("binary integrity: loading manifest: %w", loadErr)
 		}
 		_, _ = fmt.Fprintf(logW, "pipelock: binary integrity warning: %v\n", loadErr)
@@ -1464,7 +1468,7 @@ func VerifyBinaryIntegrity(command []string, icfg *config.MCPBinaryIntegrity, lo
 
 	result, verifyErr := integrity.Verify(command, intCfg, agentWorkDir)
 	if verifyErr != nil {
-		if icfg.Action == config.ActionBlock {
+		if icfg.Action != config.ActionWarn {
 			return fmt.Errorf("binary integrity: %w", verifyErr)
 		}
 		_, _ = fmt.Fprintf(logW, "pipelock: binary integrity warning: %v\n", verifyErr)
@@ -1473,7 +1477,7 @@ func VerifyBinaryIntegrity(command []string, icfg *config.MCPBinaryIntegrity, lo
 
 	if !result.Verified {
 		reasons := strings.Join(result.Reasons, "; ")
-		if icfg.Action == config.ActionBlock {
+		if icfg.Action != config.ActionWarn {
 			return fmt.Errorf("binary integrity check failed: %s", reasons)
 		}
 		_, _ = fmt.Fprintf(logW, "pipelock: binary integrity warning: %s\n", reasons)

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -1189,6 +1189,7 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolving sh binary: %v", err)
 	}
+	spawnCommand := []string{"sh", "-c", `printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"spawned":true}}'`}
 
 	// Helper: write a manifest file and return its path.
 	writeManifest := func(t *testing.T, entries map[string]string) string {
@@ -1212,6 +1213,7 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 		wantErr     bool
 		wantLog     string // substring expected in log output
 		wantNoSpawn bool
+		wantOutput  string
 	}{
 		{
 			name: "disabled_skips_check",
@@ -1240,7 +1242,7 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				Enabled: true,
 				Action:  config.ActionBlock,
 			},
-			command:     []string{"sh", "-c", "printf spawned"},
+			command:     spawnCommand,
 			entries:     map[string]string{shPath: "deadbeef"},
 			wantErr:     true,
 			wantNoSpawn: true,
@@ -1251,9 +1253,11 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				Enabled: true,
 				Action:  config.ActionWarn,
 			},
-			entries: map[string]string{truePath: "deadbeef"},
-			wantErr: false,
-			wantLog: "binary integrity warning",
+			command:    spawnCommand,
+			entries:    map[string]string{shPath: "deadbeef"},
+			wantErr:    false,
+			wantLog:    "binary integrity warning",
+			wantOutput: "spawned",
 		},
 		{
 			name: "unknown_binary_blocks",
@@ -1261,7 +1265,7 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				Enabled: true,
 				Action:  config.ActionBlock,
 			},
-			command:     []string{"sh", "-c", "printf spawned"},
+			command:     spawnCommand,
 			entries:     map[string]string{"/some/other/binary": "abc123"},
 			wantErr:     true,
 			wantNoSpawn: true,
@@ -1272,9 +1276,11 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				Enabled: true,
 				Action:  config.ActionWarn,
 			},
-			entries: map[string]string{"/some/other/binary": "abc123"},
-			wantErr: false,
-			wantLog: "binary integrity warning",
+			command:    spawnCommand,
+			entries:    map[string]string{"/some/other/binary": "abc123"},
+			wantErr:    false,
+			wantLog:    "binary integrity warning",
+			wantOutput: "spawned",
 		},
 		{
 			name: "missing_manifest_blocks",
@@ -1283,7 +1289,7 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				ManifestPath: "/nonexistent/manifest.json",
 				Action:       config.ActionBlock,
 			},
-			command:     []string{"sh", "-c", "printf spawned"},
+			command:     spawnCommand,
 			wantErr:     true,
 			wantNoSpawn: true,
 		},
@@ -1294,8 +1300,10 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				ManifestPath: "/nonexistent/manifest.json",
 				Action:       config.ActionWarn,
 			},
-			wantErr: false,
-			wantLog: "binary integrity warning",
+			command:    spawnCommand,
+			wantErr:    false,
+			wantLog:    "binary integrity warning",
+			wantOutput: "spawned",
 		},
 	}
 
@@ -1338,6 +1346,9 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 			}
 			if tt.wantNoSpawn && out.String() != "" {
 				t.Fatalf("subprocess spawned despite block action; output: %q", out.String())
+			}
+			if tt.wantOutput != "" && !strings.Contains(out.String(), tt.wantOutput) {
+				t.Fatalf("expected subprocess output to contain %q, got %q", tt.wantOutput, out.String())
 			}
 		})
 	}

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -1206,7 +1206,6 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 		entries map[string]string // nil = use missing manifest path
 		wantErr bool
 		wantLog string // substring expected in log output
-		noSpawn bool   // true if subprocess should NOT be spawned
 	}{
 		{
 			name: "disabled_skips_check",
@@ -1237,7 +1236,6 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 			},
 			entries: map[string]string{truePath: "deadbeef"},
 			wantErr: true,
-			noSpawn: true,
 		},
 		{
 			name: "wrong_hash_warns_and_spawns",
@@ -1257,7 +1255,6 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 			},
 			entries: map[string]string{"/some/other/binary": "abc123"},
 			wantErr: true,
-			noSpawn: true,
 		},
 		{
 			name: "unknown_binary_warns",
@@ -1277,7 +1274,6 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				Action:       config.ActionBlock,
 			},
 			wantErr: true,
-			noSpawn: true,
 		},
 		{
 			name: "missing_manifest_warns",
@@ -1325,6 +1321,43 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				t.Errorf("expected log to contain %q, got: %s", tt.wantLog, logStr)
 			}
 		})
+	}
+}
+
+func TestRunProxy_BinaryIntegrityDefaultBlocksBeforeSpawn(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("subprocess test requires unix")
+	}
+
+	cfgPath := filepath.Join(t.TempDir(), "integrity.yaml")
+	content := "mode: balanced\nmcp_binary_integrity:\n  enabled: true\n  manifest_path: /nonexistent/manifest.json\n"
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.MCPBinaryIntegrity.Action != config.ActionBlock {
+		t.Fatalf("Action = %q, want %q", cfg.MCPBinaryIntegrity.Action, config.ActionBlock)
+	}
+
+	sc := testScannerWithAction(t, "warn")
+	var out bytes.Buffer
+	logBuf := &syncBuffer{}
+	opts := testOpts(sc)
+	opts.IntegrityCfg = &cfg.MCPBinaryIntegrity
+
+	err = RunProxy(context.Background(), strings.NewReader(""), &out, logBuf, []string{"sh", "-c", "printf spawned"}, opts)
+	if err == nil {
+		t.Fatal("expected missing manifest to block before spawn")
+	}
+	if !strings.Contains(err.Error(), "loading manifest") {
+		t.Errorf("error should mention manifest loading, got: %v", err)
+	}
+	if out.String() != "" {
+		t.Fatalf("subprocess spawned despite default block action; output: %q", out.String())
 	}
 }
 
@@ -3169,6 +3202,105 @@ func TestVerifyBinaryIntegrity_BlockOnLoadError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "loading manifest") {
 		t.Errorf("error should mention manifest loading, got: %v", err)
+	}
+}
+
+// TestVerifyBinaryIntegrity_EmptyActionFailsClosed proves each enforcement
+// branch is fail-closed: an unset/unrecognized action (which config Validate
+// would reject, but a direct in-process caller could construct) blocks rather
+// than silently warning. Only an explicit "warn" relaxes enforcement.
+func TestVerifyBinaryIntegrity_EmptyActionFailsClosed(t *testing.T) {
+	actions := []string{"", "blok", "allow"}
+	testName := func(action string) string {
+		if action == "" {
+			return "empty"
+		}
+		return action
+	}
+
+	for _, action := range actions {
+		t.Run("load_error/"+testName(action), func(t *testing.T) {
+			icfg := &config.MCPBinaryIntegrity{
+				Enabled:      true,
+				ManifestPath: "/nonexistent/path/manifest.json",
+				Action:       action,
+			}
+
+			var logBuf bytes.Buffer
+			err := VerifyBinaryIntegrity([]string{"/bin/true"}, icfg, &logBuf)
+			if err == nil {
+				t.Fatalf("action %q should fail closed on manifest load failure", action)
+			}
+			if !strings.Contains(err.Error(), "loading manifest") {
+				t.Errorf("error should mention manifest loading, got: %v", err)
+			}
+		})
+	}
+
+	m := &integrity.Manifest{
+		Version: integrity.ManifestVersion,
+		Entries: map[string]string{
+			"/some/binary": "deadbeef",
+		},
+	}
+	mpath := filepath.Join(t.TempDir(), "manifest.json")
+	if err := integrity.SaveManifest(mpath, m); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+	missingBinary := filepath.Join(t.TempDir(), "missing-binary")
+	for _, action := range actions {
+		t.Run("verify_error/"+testName(action), func(t *testing.T) {
+			icfg := &config.MCPBinaryIntegrity{
+				Enabled:      true,
+				ManifestPath: mpath,
+				Action:       action,
+			}
+
+			var logBuf bytes.Buffer
+			err := VerifyBinaryIntegrity([]string{missingBinary}, icfg, &logBuf)
+			if err == nil {
+				t.Fatalf("action %q should fail closed on binary verify error", action)
+			}
+			if !strings.Contains(err.Error(), "binary integrity") {
+				t.Errorf("error should mention binary integrity, got: %v", err)
+			}
+		})
+	}
+
+	if runtime.GOOS == osWindows {
+		return
+	}
+	truePath, _, err := integrity.ResolveAndHash("true")
+	if err != nil {
+		t.Fatalf("resolving true binary: %v", err)
+	}
+	mismatch := &integrity.Manifest{
+		Version: integrity.ManifestVersion,
+		Entries: map[string]string{
+			truePath: "0000000000000000000000000000000000000000000000000000000000000000",
+		},
+	}
+	mismatchPath := filepath.Join(t.TempDir(), "mismatch-manifest.json")
+	if err := integrity.SaveManifest(mismatchPath, mismatch); err != nil {
+		t.Fatalf("writing mismatch manifest: %v", err)
+	}
+	for _, action := range actions {
+		t.Run("hash_mismatch/"+testName(action), func(t *testing.T) {
+			icfg := &config.MCPBinaryIntegrity{
+				Enabled:      true,
+				ManifestPath: mismatchPath,
+				Action:       action,
+			}
+
+			var logBuf bytes.Buffer
+			err := VerifyBinaryIntegrity([]string{"true"}, icfg, &logBuf)
+			if err == nil {
+				t.Fatalf("action %q should fail closed on hash mismatch", action)
+			}
+			if !strings.Contains(err.Error(), "integrity check failed") {
+				t.Errorf("error should mention integrity check, got: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -1185,6 +1185,10 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolving true binary: %v", err)
 	}
+	shPath, _, err := integrity.ResolveAndHash("sh")
+	if err != nil {
+		t.Fatalf("resolving sh binary: %v", err)
+	}
 
 	// Helper: write a manifest file and return its path.
 	writeManifest := func(t *testing.T, entries map[string]string) string {
@@ -1201,11 +1205,13 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		cfg     *config.MCPBinaryIntegrity
-		entries map[string]string // nil = use missing manifest path
-		wantErr bool
-		wantLog string // substring expected in log output
+		name        string
+		cfg         *config.MCPBinaryIntegrity
+		command     []string
+		entries     map[string]string // nil = use missing manifest path
+		wantErr     bool
+		wantLog     string // substring expected in log output
+		wantNoSpawn bool
 	}{
 		{
 			name: "disabled_skips_check",
@@ -1234,8 +1240,10 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				Enabled: true,
 				Action:  config.ActionBlock,
 			},
-			entries: map[string]string{truePath: "deadbeef"},
-			wantErr: true,
+			command:     []string{"sh", "-c", "printf spawned"},
+			entries:     map[string]string{shPath: "deadbeef"},
+			wantErr:     true,
+			wantNoSpawn: true,
 		},
 		{
 			name: "wrong_hash_warns_and_spawns",
@@ -1253,8 +1261,10 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				Enabled: true,
 				Action:  config.ActionBlock,
 			},
-			entries: map[string]string{"/some/other/binary": "abc123"},
-			wantErr: true,
+			command:     []string{"sh", "-c", "printf spawned"},
+			entries:     map[string]string{"/some/other/binary": "abc123"},
+			wantErr:     true,
+			wantNoSpawn: true,
 		},
 		{
 			name: "unknown_binary_warns",
@@ -1273,7 +1283,9 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 				ManifestPath: "/nonexistent/manifest.json",
 				Action:       config.ActionBlock,
 			},
-			wantErr: true,
+			command:     []string{"sh", "-c", "printf spawned"},
+			wantErr:     true,
+			wantNoSpawn: true,
 		},
 		{
 			name: "missing_manifest_warns",
@@ -1307,7 +1319,11 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 			opts := testOpts(sc)
 			opts.IntegrityCfg = icfg
 
-			err := RunProxy(context.Background(), strings.NewReader(""), &out, logBuf, []string{"true"}, opts)
+			command := tt.command
+			if command == nil {
+				command = []string{"true"}
+			}
+			err := RunProxy(context.Background(), strings.NewReader(""), &out, logBuf, command, opts)
 
 			if tt.wantErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -1319,6 +1335,9 @@ func TestRunProxy_BinaryIntegrity(t *testing.T) {
 			logStr := logBuf.String()
 			if tt.wantLog != "" && !strings.Contains(logStr, tt.wantLog) {
 				t.Errorf("expected log to contain %q, got: %s", tt.wantLog, logStr)
+			}
+			if tt.wantNoSpawn && out.String() != "" {
+				t.Fatalf("subprocess spawned despite block action; output: %q", out.String())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- default enabled MCP binary integrity with omitted `action` to `block`
- make binary-integrity enforcement fail closed unless `action: warn` is explicit
- document the upgrade impact and add regression coverage for default block and explicit warn behavior

## Upgrade Note
Operators with `mcp_binary_integrity.enabled: true` and no explicit `action` now block MCP subprocess spawn when the manifest is missing, unreadable, incomplete, or mismatched. Set `action: warn` temporarily to keep the previous log-only rollout behavior while completing the manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MCP binary integrity configuration docs to default to fail-closed (`action: block`), including clearer guidance for signature-related settings (`require_signature`, `signature_path`, `trusted_signer`, `keystore`) and how `action: warn` behaves.
* **Bug Fixes**
  * Binary integrity failures now block by default (including manifest load and hash mismatches), and verification treats empty/unknown actions as fail-closed.
* **Tests**
  * Added/updated coverage to confirm default blocking before subprocess execution, preserve explicit `action: warn`, and fail-closed behavior for invalid/empty action values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->