### PR TITLE
Bound cumulative SSE event reads

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -865,7 +865,7 @@ response_scanning:
 |-------|---------|-------------|
 | `enabled` | `true` | Run per-event plus rolling cross-event DLP + injection scanning on non-A2A SSE responses. When `false`, SSE responses still stream with per-read flushing — they are NOT silently downgraded to the buffered path. |
 | `action` | `block` | `block` terminates the stream on detection. `warn` logs an anomaly and continues forwarding events. |
-| `max_event_bytes` | `65536` | Per-event data-payload ceiling. Measures only the bytes inside the SSE `data:` field(s) — `event:`, `id:`, and `retry:` metadata are not counted. Events exceeding this are treated as findings and fail closed. Set higher only for providers with genuinely large single events. |
+| `max_event_bytes` | `65536` | Per-event data-payload ceiling. Measures only the bytes inside the SSE `data:` field(s) — `event:`, `id:`, and `retry:` metadata are not counted. Events exceeding this are treated as findings and fail closed. Set higher only for providers with genuinely large single events. Independently, the SSE reader bounds any single event's cumulative `data:` payload at the 10 MB transport ceiling to prevent unbounded buffering, so values above 10 MB do not take effect. |
 
 **Behavior:**
 - Each event's canonical SSE text (`data:` plus `event:`, `id:`, and `retry:` metadata) is fed through the same DLP + injection patterns used for buffered response scanning.

--- a/docs/guides/sse-streaming.md
+++ b/docs/guides/sse-streaming.md
@@ -65,7 +65,7 @@ response_scanning:
 |-------|---------|-------------|
 | `enabled` | `true` | Enable generic SSE streaming scan. When disabled, `text/event-stream` responses stream through with flushing but are not body-scanned (CONNECT-level visibility preserved). |
 | `action` | `block` | `block` terminates the stream on a finding and emits a block receipt. `warn` logs the anomaly and forwards the event. |
-| `max_event_bytes` | `65536` | Per-event byte ceiling. Exceeding this is treated as a finding. LLM token events are typically small; 64 KiB is a conservative default for most streaming providers. Raise it if a provider emits larger single events (batched deltas, full response chunks). |
+| `max_event_bytes` | `65536` | Per-event byte ceiling. Exceeding this is treated as a finding. LLM token events are typically small; 64 KiB is a conservative default for most streaming providers. Raise it if a provider emits larger single events (batched deltas, full response chunks). The SSE reader also hard-bounds any single event's cumulative `data:` payload at the 10 MB transport ceiling, so values above 10 MB do not take effect. |
 
 ## Transport coverage
 

--- a/docs/guides/sse-streaming.md
+++ b/docs/guides/sse-streaming.md
@@ -65,7 +65,7 @@ response_scanning:
 |-------|---------|-------------|
 | `enabled` | `true` | Enable generic SSE streaming scan. When disabled, `text/event-stream` responses stream through with flushing but are not body-scanned (CONNECT-level visibility preserved). |
 | `action` | `block` | `block` terminates the stream on a finding and emits a block receipt. `warn` logs the anomaly and forwards the event. |
-| `max_event_bytes` | `65536` | Per-event byte ceiling. Exceeding this is treated as a finding. LLM token events are typically small; 64 KiB is a conservative default for most streaming providers. Raise it if a provider emits larger single events (batched deltas, full response chunks). The SSE reader also hard-bounds any single event's cumulative `data:` payload at the 10 MB transport ceiling, so values above 10 MB do not take effect. |
+| `max_event_bytes` | `65536` | Per-event `data:`-payload ceiling. It measures only the bytes from joined `data:` lines; `event:`, `id:`, and `retry:` metadata are excluded. Exceeding this is treated as a finding. LLM token events are typically small; 64 KiB is a conservative default for most streaming providers. Raise it if a provider emits larger single events (batched deltas, full response chunks). The SSE reader also hard-bounds any single event's cumulative `data:` payload at the 10 MB transport ceiling, so values above 10 MB do not take effect. |
 
 ## Transport coverage
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -734,7 +734,7 @@ func MCPResponseActionForTrust(trust string) string {
 type GenericSSEScanning struct {
 	Enabled       bool   `yaml:"enabled"`
 	Action        string `yaml:"action"`          // warn, block (mirrors a2a_scanning.action)
-	MaxEventBytes int    `yaml:"max_event_bytes"` // per-event ceiling, default 65536
+	MaxEventBytes int    `yaml:"max_event_bytes"` // per-event ceiling, default 65536; also hard-bounded by the 10 MB SSE transport ceiling
 }
 
 // ResponseScanPattern is a named regex pattern for detecting prompt injection in responses.

--- a/internal/mcp/transport/sse.go
+++ b/internal/mcp/transport/sse.go
@@ -5,6 +5,7 @@ package transport
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"strings"
 )
@@ -15,6 +16,7 @@ import (
 // per the SSE specification.
 type SSEReader struct {
 	scanner       *bufio.Scanner
+	maxEventBytes int
 	lastEventID   string
 	lastEventType string
 	lastRetry     string
@@ -25,7 +27,7 @@ type SSEReader struct {
 func NewSSEReader(r io.Reader) *SSEReader {
 	s := bufio.NewScanner(r)
 	s.Buffer(make([]byte, 0, 64*1024), MaxLineSize)
-	return &SSEReader{scanner: s}
+	return &SSEReader{scanner: s, maxEventBytes: MaxLineSize}
 }
 
 // LastEventID returns the most recently seen SSE id: field value.
@@ -53,7 +55,12 @@ func (sr *SSEReader) LastRetry() string {
 // Returns io.EOF when no more events are available.
 func (sr *SSEReader) ReadMessage() ([]byte, error) {
 	var data []string
+	eventBytes := 0
 	hasData := false
+	maxEventBytes := sr.maxEventBytes
+	if maxEventBytes <= 0 {
+		maxEventBytes = MaxLineSize
+	}
 
 	// Reset per-event fields so they only reflect the current event.
 	sr.lastEventType = ""
@@ -83,7 +90,15 @@ func (sr *SSEReader) ReadMessage() ([]byte, error) {
 
 		switch field {
 		case "data":
+			nextEventBytes := eventBytes + len(value)
+			if hasData {
+				nextEventBytes++ // newline inserted by strings.Join below
+			}
+			if nextEventBytes > maxEventBytes {
+				return nil, fmt.Errorf("sse event too large: %d bytes (max %d)", nextEventBytes, maxEventBytes)
+			}
 			data = append(data, value)
+			eventBytes = nextEventBytes
 			hasData = true
 		case "id":
 			// Per SSE spec: if the id field value contains U+0000 NULL, ignore it.

--- a/internal/mcp/transport/sse_test.go
+++ b/internal/mcp/transport/sse_test.go
@@ -100,6 +100,61 @@ func TestSSEReader_CumulativeDataTooLarge(t *testing.T) {
 	}
 }
 
+func TestSSEReader_CumulativeEmptyDataTooLarge(t *testing.T) {
+	newCappedReader := func(input string, maxEventBytes int) *SSEReader {
+		t.Helper()
+		s := bufio.NewScanner(strings.NewReader(input))
+		s.Buffer(make([]byte, 0, 64), MaxLineSize)
+		return &SSEReader{scanner: s, maxEventBytes: maxEventBytes}
+	}
+
+	allowed := newCappedReader("data:\ndata:\ndata:\n\n", len("\n\n"))
+	msg, err := allowed.ReadMessage()
+	if err != nil {
+		t.Fatalf("exact-limit empty-data event should pass: %v", err)
+	}
+	if string(msg) != "\n\n" {
+		t.Fatalf("msg = %q, want %q", string(msg), "\n\n")
+	}
+
+	blocked := newCappedReader("data:\ndata:\ndata:\n\n", len("\n\n")-1)
+	_, err = blocked.ReadMessage()
+	if err == nil {
+		t.Fatal("expected cumulative event-size error")
+	}
+	if !strings.Contains(err.Error(), "sse event too large") {
+		t.Fatalf("error = %v, want sse event too large", err)
+	}
+}
+
+func TestSSEReader_NonPositiveMaxEventBytesUsesTransportCeiling(t *testing.T) {
+	var b strings.Builder
+	chunk := strings.Repeat("x", 1024)
+	eventBytes := 0
+	for eventBytes <= MaxLineSize {
+		if eventBytes > 0 {
+			eventBytes++
+		}
+		eventBytes += len(chunk)
+		b.WriteString("data: ")
+		b.WriteString(chunk)
+		b.WriteByte('\n')
+	}
+	b.WriteByte('\n')
+
+	s := bufio.NewScanner(strings.NewReader(b.String()))
+	s.Buffer(make([]byte, 0, 64*1024), MaxLineSize)
+	r := &SSEReader{scanner: s, maxEventBytes: 0}
+
+	_, err := r.ReadMessage()
+	if err == nil {
+		t.Fatal("expected cumulative event-size error")
+	}
+	if !strings.Contains(err.Error(), "sse event too large") {
+		t.Fatalf("error = %v, want sse event too large", err)
+	}
+}
+
 func TestSSEReader_IgnoresNonDataFields(t *testing.T) {
 	// event:, id:, retry: fields should not appear in the data payload.
 	input := "event: message\nid: 42\nretry: 3000\ndata: hello\n\n"

--- a/internal/mcp/transport/sse_test.go
+++ b/internal/mcp/transport/sse_test.go
@@ -71,17 +71,17 @@ func TestSSEReader_MultiLineData(t *testing.T) {
 	}
 }
 
-func TestSSEReader_CumulativeDataTooLarge(t *testing.T) {
-	newCappedReader := func(input string, maxEventBytes int) *SSEReader {
-		t.Helper()
-		s := bufio.NewScanner(strings.NewReader(input))
-		s.Buffer(make([]byte, 0, 64), MaxLineSize)
-		return &SSEReader{scanner: s, maxEventBytes: maxEventBytes}
-	}
+func newCappedSSEReader(t *testing.T, input string, maxEventBytes int) *SSEReader {
+	t.Helper()
+	s := bufio.NewScanner(strings.NewReader(input))
+	s.Buffer(make([]byte, 0, 64), MaxLineSize)
+	return &SSEReader{scanner: s, maxEventBytes: maxEventBytes}
+}
 
+func TestSSEReader_CumulativeDataTooLarge(t *testing.T) {
 	// The joined payload is "hello\nworld" (11 bytes). This proves the
 	// cumulative event cap counts the newline inserted between data: fields.
-	allowed := newCappedReader("data: hello\ndata: world\n\n", len("hello\nworld"))
+	allowed := newCappedSSEReader(t, "data: hello\ndata: world\n\n", len("hello\nworld"))
 	msg, err := allowed.ReadMessage()
 	if err != nil {
 		t.Fatalf("exact-limit event should pass: %v", err)
@@ -90,7 +90,7 @@ func TestSSEReader_CumulativeDataTooLarge(t *testing.T) {
 		t.Fatalf("msg = %q, want %q", string(msg), "hello\nworld")
 	}
 
-	blocked := newCappedReader("data: hello\ndata: world\n\n", len("hello\nworld")-1)
+	blocked := newCappedSSEReader(t, "data: hello\ndata: world\n\n", len("hello\nworld")-1)
 	_, err = blocked.ReadMessage()
 	if err == nil {
 		t.Fatal("expected cumulative event-size error")
@@ -101,14 +101,7 @@ func TestSSEReader_CumulativeDataTooLarge(t *testing.T) {
 }
 
 func TestSSEReader_CumulativeEmptyDataTooLarge(t *testing.T) {
-	newCappedReader := func(input string, maxEventBytes int) *SSEReader {
-		t.Helper()
-		s := bufio.NewScanner(strings.NewReader(input))
-		s.Buffer(make([]byte, 0, 64), MaxLineSize)
-		return &SSEReader{scanner: s, maxEventBytes: maxEventBytes}
-	}
-
-	allowed := newCappedReader("data:\ndata:\ndata:\n\n", len("\n\n"))
+	allowed := newCappedSSEReader(t, "data:\ndata:\ndata:\n\n", len("\n\n"))
 	msg, err := allowed.ReadMessage()
 	if err != nil {
 		t.Fatalf("exact-limit empty-data event should pass: %v", err)
@@ -117,7 +110,7 @@ func TestSSEReader_CumulativeEmptyDataTooLarge(t *testing.T) {
 		t.Fatalf("msg = %q, want %q", string(msg), "\n\n")
 	}
 
-	blocked := newCappedReader("data:\ndata:\ndata:\n\n", len("\n\n")-1)
+	blocked := newCappedSSEReader(t, "data:\ndata:\ndata:\n\n", len("\n\n")-1)
 	_, err = blocked.ReadMessage()
 	if err == nil {
 		t.Fatal("expected cumulative event-size error")

--- a/internal/mcp/transport/sse_test.go
+++ b/internal/mcp/transport/sse_test.go
@@ -71,6 +71,35 @@ func TestSSEReader_MultiLineData(t *testing.T) {
 	}
 }
 
+func TestSSEReader_CumulativeDataTooLarge(t *testing.T) {
+	newCappedReader := func(input string, maxEventBytes int) *SSEReader {
+		t.Helper()
+		s := bufio.NewScanner(strings.NewReader(input))
+		s.Buffer(make([]byte, 0, 64), MaxLineSize)
+		return &SSEReader{scanner: s, maxEventBytes: maxEventBytes}
+	}
+
+	// The joined payload is "hello\nworld" (11 bytes). This proves the
+	// cumulative event cap counts the newline inserted between data: fields.
+	allowed := newCappedReader("data: hello\ndata: world\n\n", len("hello\nworld"))
+	msg, err := allowed.ReadMessage()
+	if err != nil {
+		t.Fatalf("exact-limit event should pass: %v", err)
+	}
+	if string(msg) != "hello\nworld" {
+		t.Fatalf("msg = %q, want %q", string(msg), "hello\nworld")
+	}
+
+	blocked := newCappedReader("data: hello\ndata: world\n\n", len("hello\nworld")-1)
+	_, err = blocked.ReadMessage()
+	if err == nil {
+		t.Fatal("expected cumulative event-size error")
+	}
+	if !strings.Contains(err.Error(), "sse event too large") {
+		t.Fatalf("error = %v, want sse event too large", err)
+	}
+}
+
 func TestSSEReader_IgnoresNonDataFields(t *testing.T) {
 	// event:, id:, retry: fields should not appear in the data payload.
 	input := "event: message\nid: 42\nretry: 3000\ndata: hello\n\n"


### PR DESCRIPTION
## Summary
- cap cumulative SSE `data:` payloads per event in `transport.SSEReader`, including newlines inserted between multi-line `data:` fields
- preserve fail-closed behavior when the reader limit is unset and add regression coverage for empty-data and non-positive-limit cases
- document that `response_scanning.sse_streaming.max_event_bytes` is still bounded by the 10 MB transport ceiling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a maximum cumulative byte size for each SSE event’s joined `data:` payload (including newline separators), rejecting oversized events.
  * Clarified that if the configured per-event cap is higher than the SSE transport’s 10MB single-event `data:` ceiling, it won’t take effect.

* **Documentation**
  * Updated configuration and SSE streaming docs to explain how `max_event_bytes` is measured and capped by the 10MB transport limit.

* **Tests**
  * Added coverage for exact-limit vs over-limit multi-line events, empty `data:` events, and fallback behavior when `max_event_bytes` is non-positive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->