### PR TITLE
fix: block split DLP in A2A task updates

### DIFF
--- a/internal/mcp/a2a_scan.go
+++ b/internal/mcp/a2a_scan.go
@@ -39,8 +39,8 @@ type A2AScanResult struct {
 }
 
 // rollingTailSize is the number of bytes kept across SSE events for
-// cross-event scanning. A2A uses it for response injection detection;
-// generic SSE also uses it for DLP.
+// cross-event scanning. A2A and generic SSE use it for response injection and
+// DLP detection.
 const rollingTailSize = 4096
 
 // ScanA2ARequestBody runs field-aware scanning on an A2A request body.
@@ -595,7 +595,7 @@ func (ct *ContextTracker) touchOrderLocked(id string) {
 // --- SSE Stream Scanning ---
 
 // ScanA2AStream handles SSE streaming responses with per-event field-aware
-// scanning and a rolling tail for cross-event injection detection.
+// scanning and rolling tails for cross-event injection and DLP detection.
 //
 // Contract:
 // - Caller copies response headers to w BEFORE calling this function.
@@ -615,7 +615,8 @@ func ScanA2AStream(ctx context.Context, body io.Reader, w io.Writer, flusher htt
 	}
 
 	reader := transport.NewSSEReader(body)
-	var tail string
+	var injectionTail string
+	var dlpTail string
 
 	for {
 		select {
@@ -653,30 +654,34 @@ func ScanA2AStream(ctx context.Context, body io.Reader, w io.Writer, flusher htt
 				ErrA2AStreamFinding, sseDLPMatchNames(dlpResult.Matches))
 		}
 
-		// Rolling tail: concatenate tail + current text, scan for
-		// cross-event injection.
+		// Rolling tails: injection keeps word boundaries; DLP does not insert a
+		// separator so a credential split exactly at an event boundary is visible
+		// to the same detectors that caught per-event data.
 		currentText, currentTruncated := extractTextFromEvent(event)
 		if currentTruncated {
 			return fmt.Errorf("%w: input exceeds maximum inspectable nesting depth", ErrA2AStreamFinding)
 		}
-		if tail != "" && currentText != "" {
-			combined := tail + " " + currentText
+		if injectionTail != "" && currentText != "" {
+			combined := injectionTail + " " + currentText
 			tailResult := sc.ScanResponse(ctx, combined)
 			if !tailResult.Clean {
 				return fmt.Errorf("%w: cross-event injection detected", ErrA2AStreamFinding)
 			}
 		}
-
-		// Update rolling tail.
-		if currentText != "" {
-			if len(currentText) >= rollingTailSize {
-				tail = currentText[len(currentText)-rollingTailSize:]
-			} else if len(tail)+len(currentText) > rollingTailSize {
-				combined := tail + currentText
-				tail = combined[len(combined)-rollingTailSize:]
-			} else {
-				tail += currentText
+		if dlpTail != "" && currentText != "" {
+			combined := dlpTail + currentText
+			dlpResult := sc.ScanTextForDLP(ctx, combined)
+			if !dlpResult.Clean {
+				return fmt.Errorf("%w: cross-event dlp detected: %s",
+					ErrA2AStreamFinding, sseDLPMatchNames(dlpResult.Matches))
 			}
+		}
+
+		// Update rolling tails.
+		if currentText != "" {
+			current := []byte(currentText)
+			injectionTail = advanceSSERollingTail(injectionTail, current, false, " ")
+			dlpTail = advanceSSERollingTail(dlpTail, current, false, "")
 		}
 
 		// Forward clean event. Preserve id, event, and retry fields from the

--- a/internal/mcp/a2a_scan_test.go
+++ b/internal/mcp/a2a_scan_test.go
@@ -385,6 +385,35 @@ func TestScanA2AStream_InjectionTerminates(t *testing.T) {
 	}
 }
 
+func TestScanA2AStream_TaskUpdateSplitDLPTerminates(t *testing.T) {
+	key := "AKIA" + "IOSFODNN7EXAMPLE"
+	part1, part2 := key[:10], key[10:]
+	events := strings.Join([]string{
+		`event: task-update`,
+		`data: {"status":{"message":{"parts":[{"text":"` + part1 + `"}]}}}`,
+		``,
+		`event: task-update`,
+		`data: {"status":{"message":{"parts":[{"text":"` + part2 + `"}]}}}`,
+		``,
+		``,
+	}, "\n")
+	r := strings.NewReader(events)
+	var buf bytes.Buffer
+	err := ScanA2AStream(context.Background(), r, &buf, nil, testA2AScanner(t), enabledA2ACfg())
+	if !errors.Is(err, ErrA2AStreamFinding) {
+		t.Fatalf("expected ErrA2AStreamFinding for split task-update DLP, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "cross-event dlp") {
+		t.Fatalf("expected cross-event DLP reason, got %v", err)
+	}
+	if !strings.Contains(buf.String(), part1) {
+		t.Fatalf("first clean fragment should be forwarded, got %q", buf.String())
+	}
+	if strings.Contains(buf.String(), part2) {
+		t.Fatalf("completing fragment must not be forwarded, got %q", buf.String())
+	}
+}
+
 func TestScanA2AStream_Disabled(t *testing.T) {
 	cfg := enabledA2ACfg()
 	cfg.Enabled = false


### PR DESCRIPTION
## Summary

This blocks A2A SSE task-update streams when a DLP secret is split across consecutive events. A2A streaming already kept a rolling tail for cross-event prompt injection; this adds a separator-free DLP tail so boundary-split credentials are scanned before the completing event is forwarded.

The change also keeps the stream tail comments accurate now that A2A uses rolling tails for both injection and DLP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream scanning to detect injection and sensitive data split across SSE event boundaries.
  * Better handling of partial matches across events, reducing missed detections when content arrives in fragments.

* **Tests**
  * Added coverage for split sensitive-data patterns to verify scanning stops correctly and only previously safe output is forwarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->