### PR TITLE
fix: attest full MCP tool definitions

### DIFF
--- a/internal/mcp/provenance/failclosed_test.go
+++ b/internal/mcp/provenance/failclosed_test.go
@@ -337,8 +337,12 @@ func TestVerifyToolsList_FullToolObjectSigned(t *testing.T) {
 
 		var meta map[string]json.RawMessage
 		readFirstToolMeta(t, embedded, &meta)
-		if _, ok := meta["openai/outputTemplate"]; !ok {
-			t.Fatal("expected existing _meta sibling key to be preserved")
+		var outputTemplate string
+		if err := json.Unmarshal(meta["openai/outputTemplate"], &outputTemplate); err != nil {
+			t.Fatalf("parse preserved _meta sibling: %v", err)
+		}
+		if outputTemplate != "ui://trusted/template.html" {
+			t.Fatalf("preserved _meta sibling=%q, want %q", outputTemplate, "ui://trusted/template.html")
 		}
 		if _, ok := meta[metaKey]; !ok {
 			t.Fatal("expected provenance _meta key to be injected")

--- a/internal/mcp/provenance/failclosed_test.go
+++ b/internal/mcp/provenance/failclosed_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"testing"
 )
 
@@ -237,4 +238,158 @@ func TestVerifyToolsList_FailClosed(t *testing.T) {
 			t.Fatal("expected error on unparseable response (caller fails closed)")
 		}
 	})
+}
+
+func TestVerifyToolsList_FullToolObjectSigned(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	keyID := "k1"
+	cfg := VerifyConfig{
+		TrustedKeys: map[string]ed25519.PublicKey{keyID: pub},
+		Mode:        ModePipelock,
+	}
+
+	signAndEmbed := func(t *testing.T, raw []byte, tool ToolDef) []byte {
+		t.Helper()
+		att := signOne(t, tool, priv, keyID)
+		embedded, err := EmbedInToolsList(raw, []Attestation{att})
+		if err != nil {
+			t.Fatalf("EmbedInToolsList: %v", err)
+		}
+		return embedded
+	}
+	statusFor := func(t *testing.T, response []byte) string {
+		t.Helper()
+		results, err := VerifyToolsList(response, cfg)
+		if err != nil {
+			t.Fatalf("VerifyToolsList: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("results=%+v, want one result", results)
+		}
+		return results[0].Status
+	}
+
+	t.Run("top level extension mutation fails", func(t *testing.T) {
+		raw := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"exec","description":"run","inputSchema":{"type":"object"}}]}}`)
+		embedded := signAndEmbed(t, raw, ToolDef{Name: "exec", Description: "run", InputSchema: []byte(`{"type":"object"}`)})
+		tampered := mutateFirstTool(t, embedded, func(tool map[string]json.RawMessage) {
+			tool["annotations"] = json.RawMessage(`{"destructiveHint":false,"title":"safe wrapper"}`)
+		})
+
+		if got := statusFor(t, tampered); got != StatusFailed {
+			t.Fatalf("status=%q, want failed for unsigned extension mutation", got)
+		}
+	})
+
+	t.Run("sibling meta mutation fails", func(t *testing.T) {
+		raw := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"ui","description":"show ui","inputSchema":{"type":"object"}}]}}`)
+		embedded := signAndEmbed(t, raw, ToolDef{Name: "ui", Description: "show ui", InputSchema: []byte(`{"type":"object"}`)})
+		tampered := mutateFirstTool(t, embedded, func(tool map[string]json.RawMessage) {
+			var meta map[string]json.RawMessage
+			if err := json.Unmarshal(tool["_meta"], &meta); err != nil {
+				t.Fatalf("parse _meta: %v", err)
+			}
+			meta["openai/outputTemplate"] = json.RawMessage(`"ui://attacker/template.html"`)
+			out, err := json.Marshal(meta)
+			if err != nil {
+				t.Fatalf("marshal _meta: %v", err)
+			}
+			tool["_meta"] = out
+		})
+
+		if got := statusFor(t, tampered); got != StatusFailed {
+			t.Fatalf("status=%q, want failed for unsigned _meta sibling mutation", got)
+		}
+	})
+
+	t.Run("signed extension verifies", func(t *testing.T) {
+		raw := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"lookup","description":"lookup records","inputSchema":{"type":"object"},"annotations":{"readOnlyHint":true}}]}}`)
+		tool := ToolDef{
+			Name:        "lookup",
+			Description: "lookup records",
+			InputSchema: []byte(`{"type":"object"}`),
+			ExtraFields: map[string]json.RawMessage{
+				"annotations": []byte(`{"readOnlyHint":true}`),
+			},
+		}
+		embedded := signAndEmbed(t, raw, tool)
+
+		if got := statusFor(t, embedded); got != StatusVerified {
+			t.Fatalf("status=%q, want verified for signed extension", got)
+		}
+	})
+
+	t.Run("signed sibling meta verifies and is preserved", func(t *testing.T) {
+		raw := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"ui","description":"show ui","inputSchema":{"type":"object"},"_meta":{"openai/outputTemplate":"ui://trusted/template.html"}}]}}`)
+		tool := ToolDef{
+			Name:        "ui",
+			Description: "show ui",
+			InputSchema: []byte(`{"type":"object"}`),
+			ExtraFields: map[string]json.RawMessage{
+				"_meta": []byte(`{"openai/outputTemplate":"ui://trusted/template.html"}`),
+			},
+		}
+		embedded := signAndEmbed(t, raw, tool)
+
+		if got := statusFor(t, embedded); got != StatusVerified {
+			t.Fatalf("status=%q, want verified for signed _meta sibling", got)
+		}
+
+		var meta map[string]json.RawMessage
+		readFirstToolMeta(t, embedded, &meta)
+		if _, ok := meta["openai/outputTemplate"]; !ok {
+			t.Fatal("expected existing _meta sibling key to be preserved")
+		}
+		if _, ok := meta[metaKey]; !ok {
+			t.Fatal("expected provenance _meta key to be injected")
+		}
+	})
+}
+
+func mutateFirstTool(t *testing.T, response []byte, mutate func(map[string]json.RawMessage)) []byte {
+	t.Helper()
+	var rpc map[string]json.RawMessage
+	if err := json.Unmarshal(response, &rpc); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	var result struct {
+		Tools []map[string]json.RawMessage `json:"tools"`
+	}
+	if err := json.Unmarshal(rpc["result"], &result); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	if len(result.Tools) != 1 {
+		t.Fatalf("tools=%d, want 1", len(result.Tools))
+	}
+	mutate(result.Tools[0])
+	newResult, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	rpc["result"] = newResult
+	out, err := json.Marshal(rpc)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	return out
+}
+
+func readFirstToolMeta(t *testing.T, response []byte, dst *map[string]json.RawMessage) {
+	t.Helper()
+	var rpc struct {
+		Result struct {
+			Tools []struct {
+				Meta json.RawMessage `json:"_meta"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(response, &rpc); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if len(rpc.Result.Tools) != 1 {
+		t.Fatalf("tools=%d, want 1", len(rpc.Result.Tools))
+	}
+	if err := json.Unmarshal(rpc.Result.Tools[0].Meta, dst); err != nil {
+		t.Fatalf("parse _meta: %v", err)
+	}
 }

--- a/internal/mcp/provenance/provenance.go
+++ b/internal/mcp/provenance/provenance.go
@@ -132,8 +132,8 @@ func VerifyTool(tool ToolDef, att Attestation, cfg VerifyConfig) VerificationRes
 		return result
 	}
 
-	// Recompute digest from the tool definition.
-	expectedDigest := ToolDigest(tool.Name, tool.Description, tool.InputSchema)
+	// Recompute digest from the full tool definition.
+	expectedDigest := toolDigest(tool)
 	if expectedDigest != att.Digest.SHA256 {
 		result.Status = StatusFailed
 		result.Detail = fmt.Sprintf("digest mismatch: computed %s, attestation has %s", expectedDigest, att.Digest.SHA256)
@@ -298,15 +298,33 @@ func VerifyToolsList(response []byte, cfg VerifyConfig) ([]VerificationResult, e
 			continue
 		}
 
-		td := ToolDef{
-			Name:        tool.Name,
-			Description: tool.Description,
-			InputSchema: tool.InputSchema,
-		}
+		td := toolDefFromRaw(raw, tool)
 		results = append(results, VerifyTool(td, att, cfg))
 	}
 
 	return results, nil
+}
+
+func toolDefFromRaw(raw json.RawMessage, tool toolWithMeta) ToolDef {
+	td := ToolDef{
+		Name:        tool.Name,
+		Description: tool.Description,
+		InputSchema: tool.InputSchema,
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return td
+	}
+
+	delete(fields, "name")
+	delete(fields, "description")
+	delete(fields, "inputSchema")
+	if len(fields) == 0 {
+		return td
+	}
+	td.ExtraFields = fields
+	return td
 }
 
 // ErrFailedVerification is returned when an attestation is present but invalid.

--- a/internal/mcp/provenance/sign.go
+++ b/internal/mcp/provenance/sign.go
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package provenance provides cryptographic attestation generation and
-// verification for MCP tool definitions. It supports two signing modes:
-// "pipelock" (offline Ed25519) and "sigstore" (keyless OIDC, future).
+// verification for MCP tool definitions. It signs the canonical tool object
+// with the embedded Pipelock provenance _meta member removed, so extension
+// fields and non-provenance _meta members are covered by the attestation. It
+// supports two signing modes: "pipelock" (offline Ed25519) and "sigstore"
+// (keyless OIDC, future).
 package provenance
 
 import (
@@ -47,35 +50,67 @@ type ToolDef struct {
 	Name        string
 	Description string
 	InputSchema json.RawMessage
+	// ExtraFields carries additional MCP tool-definition fields that should be
+	// covered by the attestation, such as annotations, title, outputSchema, or
+	// non-provenance _meta members.
+	ExtraFields map[string]json.RawMessage
 }
 
-// canonicalTool is the sorted-key struct used for deterministic hashing.
-// Field order is alphabetical: description, inputSchema, name.
-type canonicalTool struct {
-	Description string          `json:"description"`
-	InputSchema json.RawMessage `json:"inputSchema"`
-	Name        string          `json:"name"`
-}
-
-// ToolDigest computes a canonical SHA-256 of a tool definition.
+// ToolDigest computes a canonical SHA-256 of a core tool definition.
 // The canonical form is JSON with sorted keys and no extraneous whitespace,
 // making the digest format-independent. InputSchema is re-serialized through
-// a round-trip to normalize whitespace and key ordering.
+// a round-trip to normalize whitespace and key ordering. Use ToolDef.ExtraFields
+// with SignPipelock to include additional MCP tool-definition fields.
 func ToolDigest(name, description string, inputSchema json.RawMessage) string {
-	normalized := normalizeSchema(inputSchema)
-
-	ct := canonicalTool{
-		Description: description,
-		InputSchema: normalized,
+	return toolDigest(ToolDef{
 		Name:        name,
+		Description: description,
+		InputSchema: inputSchema,
+	})
+}
+
+func toolDigest(tool ToolDef) string {
+	fields := make(map[string]json.RawMessage, len(tool.ExtraFields)+3)
+	fields["name"] = mustMarshal(tool.Name)
+	fields["description"] = mustMarshal(tool.Description)
+	fields["inputSchema"] = normalizeSchema(tool.InputSchema)
+	for key, value := range tool.ExtraFields {
+		if key == "name" || key == "description" || key == "inputSchema" {
+			continue
+		}
+		fields[key] = value
+	}
+	return digestToolFields(fields)
+}
+
+func toolDigestRaw(raw json.RawMessage) string {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return ""
+	}
+	return digestToolFields(fields)
+}
+
+func digestToolFields(fields map[string]json.RawMessage) string {
+	canonical := make(map[string]json.RawMessage, len(fields))
+	for key, raw := range fields {
+		if key == "_meta" {
+			stripped, keep := stripProvenanceMeta(raw)
+			if !keep {
+				continue
+			}
+			raw = stripped
+		}
+
+		normalized := normalizeJSON(raw)
+		if !json.Valid(normalized) {
+			return ""
+		}
+		canonical[key] = normalized
 	}
 
-	// json.Marshal produces sorted keys for structs (field order = declaration order,
-	// which is alphabetical here). No indent = no extraneous whitespace.
-	data, err := json.Marshal(ct)
+	data, err := json.Marshal(canonical)
 	if err != nil {
-		// Should never happen with string/RawMessage fields.
-		// Return empty digest so verification always fails rather than panicking.
 		return ""
 	}
 
@@ -89,11 +124,12 @@ func normalizeSchema(raw json.RawMessage) json.RawMessage {
 	if len(raw) == 0 || string(raw) == "null" {
 		return json.RawMessage("null")
 	}
+	return normalizeJSON(raw)
+}
 
+func normalizeJSON(raw json.RawMessage) json.RawMessage {
 	var parsed interface{}
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		// If the schema is invalid JSON, use it as-is.
-		// Verification will catch mismatches.
 		return raw
 	}
 
@@ -103,6 +139,22 @@ func normalizeSchema(raw json.RawMessage) json.RawMessage {
 		return raw
 	}
 	return out
+}
+
+func stripProvenanceMeta(raw json.RawMessage) (json.RawMessage, bool) {
+	var meta map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return raw, true
+	}
+	delete(meta, metaKey)
+	if len(meta) == 0 {
+		return nil, false
+	}
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return raw, true
+	}
+	return out, true
 }
 
 // sortAndMarshal recursively sorts map keys for deterministic JSON output.
@@ -149,7 +201,7 @@ func SignPipelock(tools []ToolDef, privKey ed25519.PrivateKey, keyID string) ([]
 
 	attestations := make([]Attestation, 0, len(tools))
 	for _, tool := range tools {
-		digest := ToolDigest(tool.Name, tool.Description, tool.InputSchema)
+		digest := toolDigest(tool)
 		if digest == "" {
 			return nil, fmt.Errorf("failed to compute digest for tool %q", tool.Name)
 		}
@@ -244,19 +296,7 @@ func EmbedInToolsList(response []byte, attestations []Attestation) ([]byte, erro
 
 	modified := make([]json.RawMessage, 0, len(rpc.Result.Tools))
 	for _, raw := range rpc.Result.Tools {
-		// Parse tool to compute digest and find matching attestation.
-		var td struct {
-			Name        string          `json:"name"`
-			Description string          `json:"description"`
-			InputSchema json.RawMessage `json:"inputSchema"`
-		}
-		if err := json.Unmarshal(raw, &td); err != nil {
-			// Unparseable tool entry: keep as-is.
-			modified = append(modified, raw)
-			continue
-		}
-
-		digest := ToolDigest(td.Name, td.Description, td.InputSchema)
+		digest := toolDigestRaw(raw)
 		att, found := byDigest[digest]
 		if !found {
 			modified = append(modified, raw)
@@ -270,7 +310,7 @@ func EmbedInToolsList(response []byte, attestations []Attestation) ([]byte, erro
 			continue
 		}
 
-		toolMap["_meta"] = InjectMeta(att)
+		toolMap["_meta"] = injectMeta(toolMap["_meta"], att)
 
 		out, err := json.Marshal(toolMap)
 		if err != nil {
@@ -298,6 +338,23 @@ func EmbedInToolsList(response []byte, attestations []Attestation) ([]byte, erro
 func mustMarshal(v interface{}) json.RawMessage {
 	data, _ := json.Marshal(v)
 	return data
+}
+
+func injectMeta(existing json.RawMessage, att Attestation) json.RawMessage {
+	meta := make(map[string]json.RawMessage)
+	if len(existing) > 0 && string(existing) != "null" {
+		_ = json.Unmarshal(existing, &meta)
+	}
+	attRaw, err := json.Marshal(att)
+	if err != nil {
+		return existing
+	}
+	meta[metaKey] = attRaw
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return existing
+	}
+	return out
 }
 
 // SortAttestations sorts attestations by digest for deterministic output.

--- a/internal/mcp/provenance/sign.go
+++ b/internal/mcp/provenance/sign.go
@@ -344,7 +344,9 @@ func mustMarshal(v interface{}) json.RawMessage {
 func injectMeta(existing json.RawMessage, att Attestation) json.RawMessage {
 	meta := make(map[string]json.RawMessage)
 	if len(existing) > 0 && string(existing) != "null" {
-		_ = json.Unmarshal(existing, &meta)
+		if err := json.Unmarshal(existing, &meta); err != nil {
+			return existing
+		}
 	}
 	attRaw, err := json.Marshal(att)
 	if err != nil {

--- a/internal/mcp/provenance/sign.go
+++ b/internal/mcp/provenance/sign.go
@@ -70,10 +70,11 @@ func ToolDigest(name, description string, inputSchema json.RawMessage) string {
 }
 
 func toolDigest(tool ToolDef) string {
-	fields := make(map[string]json.RawMessage, len(tool.ExtraFields)+3)
-	fields["name"] = mustMarshal(tool.Name)
-	fields["description"] = mustMarshal(tool.Description)
-	fields["inputSchema"] = normalizeSchema(tool.InputSchema)
+	fields := map[string]json.RawMessage{
+		"name":        mustMarshal(tool.Name),
+		"description": mustMarshal(tool.Description),
+		"inputSchema": normalizeSchema(tool.InputSchema),
+	}
 	for key, value := range tool.ExtraFields {
 		if key == "name" || key == "description" || key == "inputSchema" {
 			continue

--- a/internal/mcp/provenance/sign_test.go
+++ b/internal/mcp/provenance/sign_test.go
@@ -301,6 +301,22 @@ func TestInjectMeta(t *testing.T) {
 	}
 }
 
+func TestInjectMeta_InvalidExistingMetaPreserved(t *testing.T) {
+	att := Attestation{
+		PredicateType: predicateType,
+		Digest:        Digest{SHA256: "abc123"},
+		Mode:          ModePipelock,
+		Bundle:        "sig-data",
+		SignerID:      "key-1",
+	}
+	existing := json.RawMessage(`"not-an-object"`)
+
+	got := injectMeta(existing, att)
+	if string(got) != string(existing) {
+		t.Fatalf("injectMeta()=%s, want preserved existing _meta %s", got, existing)
+	}
+}
+
 func TestSortAttestations(t *testing.T) {
 	atts := []Attestation{
 		{Digest: Digest{SHA256: "zzz"}},


### PR DESCRIPTION
## Summary
- include MCP tool extension fields in provenance digests instead of only the core name/description/inputSchema fields
- strip only Pipelock's embedded provenance `_meta` entry before hashing so sibling `_meta` fields remain covered
- preserve existing `_meta` sibling keys when embedding provenance attestations

## Security
A signed `tools/list` entry now fails verification if an attacker mutates top-level extension fields or non-provenance `_meta` fields after signing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool provenance signing and verification now covers complete tool entries, including additional non-core fields beyond name, description, and input schema.
  * When embedding provenance, any existing `_meta` content is merged (provenance is injected without overwriting unrelated `_meta` data).
* **Bug Fixes**
  * Fail-closed verification more reliably rejects tampering of unsigned extension fields and unsigned `_meta` siblings.
  * Verification now recomputes expected digests from the full signed tool content.
* **Tests**
  * Added scenarios for signed full tool-object verification and `_meta` mutation/tampering, including preservation of invalid existing `_meta`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->