### PR TITLE
fix: scan MCP resource HTTP URIs

### DIFF
--- a/internal/capture/types.go
+++ b/internal/capture/types.go
@@ -76,6 +76,7 @@ const (
 // Finding kind constants identify which detection rule produced a finding.
 const (
 	KindDLP               = "dlp"
+	KindURL               = "url"
 	KindAddressProtection = "address_protection"
 	KindInjection         = "injection"
 	KindCEE               = "cee"

--- a/internal/mcp/capture_helpers.go
+++ b/internal/mcp/capture_helpers.go
@@ -105,6 +105,23 @@ func responseMatchesToFindings(matches []scanner.ResponseMatch, action string) [
 	return findings
 }
 
+// urlFindingsToCapture converts scanner.Result URL findings to capture findings.
+func urlFindingsToCapture(findings []scanner.Result) []capture.Finding {
+	if len(findings) == 0 {
+		return nil
+	}
+	out := make([]capture.Finding, len(findings))
+	for i, f := range findings {
+		out[i] = capture.Finding{
+			Kind:        capture.KindURL,
+			PatternName: f.Scanner,
+			MatchText:   f.Reason,
+			Action:      config.ActionBlock,
+		}
+	}
+	return out
+}
+
 // addressFindingsToCapture converts addressprotect.Finding slice to capture findings.
 func addressFindingsToCapture(findings []addressprotect.Finding) []capture.Finding {
 	if len(findings) == 0 {

--- a/internal/mcp/contractgate.go
+++ b/internal/mcp/contractgate.go
@@ -19,6 +19,7 @@ import (
 	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/policy"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
 const (
@@ -312,10 +313,39 @@ func mcpScannerBlockReason(verdict InputVerdict, policyVerdict policy.Verdict, c
 		return blockreason.DLPMatch
 	case len(verdict.Inject) > 0:
 		return blockreason.PromptInjection
+	case len(verdict.URLFindings) > 0:
+		return mcpURLBlockReason(verdict.URLFindings[0].Scanner)
 	case policyVerdict.Matched:
 		return blockreason.ToolPolicyDeny
 	case chainMatched:
 		return blockreason.ToolChainBlocked
+	default:
+		return blockreason.ParseError
+	}
+}
+
+func mcpURLBlockReason(scannerLabel string) blockreason.Reason {
+	switch scannerLabel {
+	case scanner.ScannerScheme:
+		return blockreason.SchemeBlocked
+	case scanner.ScannerBlocklist:
+		return blockreason.DomainBlocklist
+	case scanner.ScannerSSRFMetadata:
+		return blockreason.SSRFMetadata
+	case scanner.ScannerSSRF, scanner.ScannerCoreSSRF:
+		return blockreason.SSRFPrivateIP
+	case scanner.ScannerEntropy:
+		return blockreason.PathEntropy
+	case scanner.ScannerSubdomainEntropy:
+		return blockreason.SubdomainEntropy
+	case scanner.ScannerLength:
+		return blockreason.URLLength
+	case scanner.ScannerRateLimit:
+		return blockreason.RateLimit
+	case scanner.ScannerDataBudget:
+		return blockreason.DataBudget
+	case scanner.ScannerDLP, scanner.ScannerCoreDLP:
+		return blockreason.DLPMatch
 	default:
 		return blockreason.ParseError
 	}

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -777,19 +777,7 @@ func ForwardScannedInput(
 		}
 
 		// Build combined reasons from content scan, policy, and binding.
-		var reasons []string
-		for _, m := range verdict.Matches {
-			reasons = append(reasons, m.PatternName)
-		}
-		for _, m := range verdict.Inject {
-			reasons = append(reasons, m.PatternName)
-		}
-		for _, f := range verdict.URLFindings {
-			reasons = append(reasons, "url:"+f.Scanner+":"+f.Reason)
-		}
-		for _, f := range verdict.AddressFindings {
-			reasons = append(reasons, "address:"+f.Explanation)
-		}
+		reasons := inputVerdictReasons(verdict)
 		for _, r := range policyVerdict.Rules {
 			reasons = append(reasons, "policy:"+r)
 		}
@@ -857,12 +845,17 @@ func ForwardScannedInput(
 		case config.ActionBlock:
 			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: blocked %s request (%s)\n",
 				lineNum, method, reasonStr)
+			blockReason := mcpScannerBlockReason(verdict, policyVerdict, chainAction != "")
+			if bindingReason != "" && bindingAction == config.ActionBlock {
+				blockReason = blockreason.SessionBinding
+			}
 			blockedCh <- BlockedRequest{
 				ID:             verdict.ID,
 				IsNotification: isNotification,
 				LogMessage:     fmt.Sprintf("pipelock: input line %d: blocked", lineNum),
 				ErrorCode:      errCode,
 				ErrorMessage:   errMsg,
+				ErrorData:      mcpBlockReasonData(blockReason),
 			}
 		case config.ActionRedirect:
 			// Batch requests cannot be redirected element-by-element.
@@ -1339,7 +1332,7 @@ func joinStrings(ss []string) string {
 	return strings.Join(ss, "\n")
 }
 
-func joinInputVerdictReasons(verdict InputVerdict) string {
+func inputVerdictReasons(verdict InputVerdict) []string {
 	reasons := make([]string, 0, len(verdict.Matches)+len(verdict.Inject)+len(verdict.URLFindings)+len(verdict.AddressFindings)+1)
 	for _, m := range verdict.Matches {
 		reasons = append(reasons, m.PatternName)
@@ -1356,6 +1349,11 @@ func joinInputVerdictReasons(verdict InputVerdict) string {
 	if verdict.Error != "" {
 		reasons = append(reasons, verdict.Error)
 	}
+	return reasons
+}
+
+func joinInputVerdictReasons(verdict InputVerdict) string {
+	reasons := inputVerdictReasons(verdict)
 	if len(reasons) == 0 {
 		return "input scanning"
 	}

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -72,6 +72,9 @@ func tryRecoverSession(rec session.Recorder, adaptiveCfg *config.AdaptiveEnforce
 // methodToolsCall is the JSON-RPC method for MCP tool invocations.
 const methodToolsCall = "tools/call"
 
+// methodResourcesRead is the JSON-RPC method for MCP resource reads.
+const methodResourcesRead = "resources/read"
+
 // errPolicyBlocked is the error message returned when a tool call is denied by policy.
 const errPolicyBlocked = "pipelock: request blocked by tool call policy"
 
@@ -90,6 +93,7 @@ type InputVerdict struct {
 	Action          string                   `json:"action,omitempty"`
 	Matches         []scanner.TextDLPMatch   `json:"dlp_matches,omitempty"`
 	Inject          []scanner.ResponseMatch  `json:"injection_matches,omitempty"`
+	URLFindings     []scanner.Result         `json:"url_findings,omitempty"`
 	AddressFindings []addressprotect.Finding `json:"address_findings,omitempty"`
 	Error           string                   `json:"error,omitempty"`
 }
@@ -302,7 +306,7 @@ func ForwardScannedInput(
 		stdioInputCtx := scanner.WithDLPWarnContext(opts.warnContext(), warnCtx)
 		if redactionCfg.Matcher != nil {
 			originalVerdict := scanRequestForAgent(stdioInputCtx, line, sc, action, onParseError, opts.addressProtectionAgent())
-			if !originalVerdict.Clean && inputVerdictEffectiveAction(originalVerdict, action) == config.ActionBlock {
+			if !originalVerdict.Clean && originalVerdict.Error == "" && inputVerdictEffectiveAction(originalVerdict, action) == config.ActionBlock {
 				_, _ = fmt.Fprintf(logW, "pipelock: input line %d: blocked (%s)\n", lineNum, joinInputVerdictReasons(originalVerdict))
 				recordAdaptiveSignal(session.SignalBlock)
 				if pendingActionID != "" && receiptEmitter != nil {
@@ -780,6 +784,9 @@ func ForwardScannedInput(
 		for _, m := range verdict.Inject {
 			reasons = append(reasons, m.PatternName)
 		}
+		for _, f := range verdict.URLFindings {
+			reasons = append(reasons, "url:"+f.Scanner+":"+f.Reason)
+		}
 		for _, f := range verdict.AddressFindings {
 			reasons = append(reasons, "address:"+f.Explanation)
 		}
@@ -1248,6 +1255,7 @@ func ForwardScannedInput(
 			var rawFindings []capture.Finding
 			rawFindings = append(rawFindings, dlpMatchesToFindings(verdict.Matches)...)
 			rawFindings = append(rawFindings, responseMatchesToFindings(verdict.Inject, effectiveAction)...)
+			rawFindings = append(rawFindings, urlFindingsToCapture(verdict.URLFindings)...)
 			rawFindings = append(rawFindings, addressFindingsToCapture(verdict.AddressFindings)...)
 			obs.ObserveDLPVerdict(context.Background(), &capture.DLPVerdictRecord{
 				Subsurface:        "dlp_mcp_input",
@@ -1332,12 +1340,18 @@ func joinStrings(ss []string) string {
 }
 
 func joinInputVerdictReasons(verdict InputVerdict) string {
-	reasons := make([]string, 0, len(verdict.Matches)+len(verdict.Inject)+1)
+	reasons := make([]string, 0, len(verdict.Matches)+len(verdict.Inject)+len(verdict.URLFindings)+len(verdict.AddressFindings)+1)
 	for _, m := range verdict.Matches {
 		reasons = append(reasons, m.PatternName)
 	}
 	for _, m := range verdict.Inject {
 		reasons = append(reasons, m.PatternName)
+	}
+	for _, f := range verdict.URLFindings {
+		reasons = append(reasons, "url:"+f.Scanner+":"+f.Reason)
+	}
+	for _, f := range verdict.AddressFindings {
+		reasons = append(reasons, "address:"+f.Explanation)
 	}
 	if verdict.Error != "" {
 		reasons = append(reasons, verdict.Error)

--- a/internal/mcp/input_scan.go
+++ b/internal/mcp/input_scan.go
@@ -87,6 +87,12 @@ func mcpInputVerdictAction(action string, dlpMatches []scanner.TextDLPMatch, inj
 }
 
 func inputVerdictEffectiveAction(verdict InputVerdict, configuredAction string) string {
+	if verdict.Error != "" {
+		return config.ActionBlock
+	}
+	if len(verdict.URLFindings) > 0 {
+		return config.ActionBlock
+	}
 	if verdict.Action != "" {
 		return verdict.Action
 	}
@@ -108,6 +114,34 @@ func inputVerdictEffectiveAction(verdict InputVerdict, configuredAction string) 
 		return addrAction
 	}
 	return configuredAction
+}
+
+func scanMCPResourceURI(ctx context.Context, method string, params json.RawMessage, sc *scanner.Scanner) []scanner.Result {
+	if sc == nil || method != methodResourcesRead {
+		return nil
+	}
+	if err := redact.NoDuplicateJSONKeys(bytes.TrimSpace(params)); err != nil && isDuplicateKeyBlock(err) {
+		return []scanner.Result{{
+			Allowed: false,
+			Reason:  fmt.Sprintf("duplicate resource URI key: %v", err),
+			Scanner: scanner.ScannerParser,
+		}}
+	}
+	var req struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(params, &req); err != nil {
+		return nil
+	}
+	uri := strings.TrimSpace(req.URI)
+	lower := strings.ToLower(uri)
+	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
+		return nil
+	}
+	if result := sc.Scan(ctx, uri); !result.Allowed {
+		return []scanner.Result{result}
+	}
+	return nil
 }
 
 // ScanRequest parses a JSON-RPC 2.0 request and scans its params for
@@ -338,8 +372,9 @@ func scanRequestForAgent(ctx context.Context, line []byte, sc *scanner.Scanner, 
 			addrFindings = addrResult.Findings
 		}
 	}
+	urlFindings := scanMCPResourceURI(ctx, rpc.Method, rpc.Params, sc)
 
-	if len(dlpMatches) == 0 && len(injMatches) == 0 && len(addrFindings) == 0 {
+	if len(dlpMatches) == 0 && len(injMatches) == 0 && len(addrFindings) == 0 && len(urlFindings) == 0 {
 		return InputVerdict{ID: rpc.ID, Method: rpc.Method, Clean: true}
 	}
 
@@ -352,6 +387,9 @@ func scanRequestForAgent(ctx context.Context, line []byte, sc *scanner.Scanner, 
 			verdictAction = addrAction
 		}
 	}
+	if len(urlFindings) > 0 {
+		verdictAction = config.ActionBlock
+	}
 
 	return InputVerdict{
 		ID:              rpc.ID,
@@ -360,6 +398,7 @@ func scanRequestForAgent(ctx context.Context, line []byte, sc *scanner.Scanner, 
 		Action:          verdictAction,
 		Matches:         dlpMatches,
 		Inject:          injMatches,
+		URLFindings:     urlFindings,
 		AddressFindings: addrFindings,
 	}
 }
@@ -466,6 +505,7 @@ func scanRequestBatch(ctx context.Context, line []byte, sc *scanner.Scanner, act
 
 	var allDLP []scanner.TextDLPMatch
 	var allInj []scanner.ResponseMatch
+	var allURL []scanner.Result
 	var allAddr []addressprotect.Finding
 	var firstID json.RawMessage
 	var hasError bool
@@ -493,11 +533,12 @@ func scanRequestBatch(ctx context.Context, line []byte, sc *scanner.Scanner, act
 		if !v.Clean && v.Error == "" {
 			allDLP = append(allDLP, v.Matches...)
 			allInj = append(allInj, v.Inject...)
+			allURL = append(allURL, v.URLFindings...)
 			allAddr = append(allAddr, v.AddressFindings...)
 		}
 	}
 
-	if len(allDLP) == 0 && len(allInj) == 0 && len(allAddr) == 0 {
+	if len(allDLP) == 0 && len(allInj) == 0 && len(allURL) == 0 && len(allAddr) == 0 {
 		if hasError {
 			errText := "one or more batch elements failed to parse"
 			if firstError == uninspectableJSONDepthReason {
@@ -512,7 +553,7 @@ func scanRequestBatch(ctx context.Context, line []byte, sc *scanner.Scanner, act
 	}
 	v := InputVerdict{
 		ID: firstID, Clean: false, Action: batchAction,
-		Matches: allDLP, Inject: allInj, AddressFindings: allAddr,
+		Matches: allDLP, Inject: allInj, URLFindings: allURL, AddressFindings: allAddr,
 	}
 	if hasError {
 		v.Error = "one or more batch elements also failed to parse"

--- a/internal/mcp/input_scan.go
+++ b/internal/mcp/input_scan.go
@@ -120,7 +120,11 @@ func scanMCPResourceURI(ctx context.Context, method string, params json.RawMessa
 	if sc == nil || method != methodResourcesRead {
 		return nil
 	}
-	if err := redact.NoDuplicateJSONKeys(bytes.TrimSpace(params)); err != nil && isDuplicateKeyBlock(err) {
+	trimmed := bytes.TrimSpace(params)
+	if len(trimmed) == 0 || string(trimmed) == jsonrpc.Null {
+		return mcpResourceURIParserFinding("missing resources/read params")
+	}
+	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && isDuplicateKeyBlock(err) {
 		return []scanner.Result{{
 			Allowed: false,
 			Reason:  fmt.Sprintf("duplicate resource URI key: %v", err),
@@ -130,10 +134,13 @@ func scanMCPResourceURI(ctx context.Context, method string, params json.RawMessa
 	var req struct {
 		URI string `json:"uri"`
 	}
-	if err := json.Unmarshal(params, &req); err != nil {
-		return nil
+	if err := json.Unmarshal(trimmed, &req); err != nil {
+		return mcpResourceURIParserFinding(fmt.Sprintf("invalid resources/read params: %v", err))
 	}
 	uri := strings.TrimSpace(req.URI)
+	if uri == "" {
+		return mcpResourceURIParserFinding("missing resources/read uri")
+	}
 	lower := strings.ToLower(uri)
 	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
 		return nil
@@ -142,6 +149,14 @@ func scanMCPResourceURI(ctx context.Context, method string, params json.RawMessa
 		return []scanner.Result{result}
 	}
 	return nil
+}
+
+func mcpResourceURIParserFinding(reason string) []scanner.Result {
+	return []scanner.Result{{
+		Allowed: false,
+		Reason:  reason,
+		Scanner: scanner.ScannerParser,
+	}}
 }
 
 // ScanRequest parses a JSON-RPC 2.0 request and scans its params for
@@ -266,8 +281,9 @@ func scanRequestForAgent(ctx context.Context, line []byte, sc *scanner.Scanner, 
 				addrFindings = addrResult.Findings
 			}
 		}
+		urlFindings := scanMCPResourceURI(ctx, rpc.Method, rpc.Params, sc)
 
-		if dlpResult.Clean && injResult.Clean && len(addrFindings) == 0 {
+		if dlpResult.Clean && injResult.Clean && len(addrFindings) == 0 && len(urlFindings) == 0 {
 			return InputVerdict{ID: rpc.ID, Method: rpc.Method, Clean: true}
 		}
 		var dlpMatches []scanner.TextDLPMatch
@@ -287,6 +303,9 @@ func scanRequestForAgent(ctx context.Context, line []byte, sc *scanner.Scanner, 
 				verdictAction = addrAction
 			}
 		}
+		if len(urlFindings) > 0 {
+			verdictAction = config.ActionBlock
+		}
 
 		return InputVerdict{
 			ID:              rpc.ID,
@@ -295,6 +314,7 @@ func scanRequestForAgent(ctx context.Context, line []byte, sc *scanner.Scanner, 
 			Action:          verdictAction,
 			Matches:         dlpMatches,
 			Inject:          injMatches,
+			URLFindings:     urlFindings,
 			AddressFindings: addrFindings,
 		}
 	}

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -2757,6 +2757,10 @@ func TestScanRequest_ResourcesReadMalformedParamsFailClosed(t *testing.T) {
 			line: `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{}}`,
 		},
 		{
+			name: "null uri",
+			line: `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":null}}`,
+		},
+		{
 			name: "empty uri",
 			line: `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"   "}}`,
 		},

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -2627,22 +2627,34 @@ func TestScanRequest_HexInURLPath_NoFalsePositives(t *testing.T) {
 
 func TestScanRequest_ResourcesReadHTTPURIUsesURLPolicy(t *testing.T) {
 	sc := testInputScanner(t)
-	line := makeRequest(1, "resources/read", map[string]string{
-		"uri": "http://169.254.169.254/latest/meta-data/",
-	})
+	tests := []struct {
+		name string
+		uri  string
+	}{
+		{"http", "http://169.254.169.254/latest/meta-data/"},
+		{"https", "https://169.254.169.254/latest/meta-data/"},
+	}
 
-	verdict := ScanRequest(context.Background(), []byte(line), sc, config.ActionWarn, config.ActionBlock)
-	if verdict.Clean {
-		t.Fatal("resources/read HTTP URI to metadata endpoint should be blocked by URL policy")
-	}
-	if len(verdict.URLFindings) != 1 {
-		t.Fatalf("URLFindings len = %d, want 1: %+v", len(verdict.URLFindings), verdict)
-	}
-	if got := verdict.URLFindings[0].Scanner; got != scanner.ScannerCoreSSRF {
-		t.Fatalf("URL finding scanner = %q, want %q", got, scanner.ScannerCoreSSRF)
-	}
-	if got := inputVerdictEffectiveAction(verdict, config.ActionWarn); got != config.ActionBlock {
-		t.Fatalf("effective action = %q, want %q", got, config.ActionBlock)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line := makeRequest(1, "resources/read", map[string]string{
+				"uri": tt.uri,
+			})
+
+			verdict := ScanRequest(context.Background(), []byte(line), sc, config.ActionWarn, config.ActionBlock)
+			if verdict.Clean {
+				t.Fatal("resources/read HTTP(S) URI to metadata endpoint should be blocked by URL policy")
+			}
+			if len(verdict.URLFindings) != 1 {
+				t.Fatalf("URLFindings len = %d, want 1: %+v", len(verdict.URLFindings), verdict)
+			}
+			if got := verdict.URLFindings[0].Scanner; got != scanner.ScannerCoreSSRF {
+				t.Fatalf("URL finding scanner = %q, want %q", got, scanner.ScannerCoreSSRF)
+			}
+			if got := inputVerdictEffectiveAction(verdict, config.ActionWarn); got != config.ActionBlock {
+				t.Fatalf("effective action = %q, want %q", got, config.ActionBlock)
+			}
+		})
 	}
 }
 
@@ -2664,22 +2676,37 @@ func TestScanRequest_ResourcesReadNonHTTPURIsSkipURLPolicy(t *testing.T) {
 
 func TestScanRequest_BatchResourcesReadHTTPURIUsesURLPolicy(t *testing.T) {
 	sc := testInputScanner(t)
-	batch := "[" +
-		makeRequest(1, "tools/list", nil) + "," +
-		makeRequest(2, "resources/read", map[string]string{
-			"uri": "http://169.254.169.254/latest/meta-data/",
-		}) +
-		"]"
+	tests := []struct {
+		name string
+		uri  string
+	}{
+		{"http", "http://169.254.169.254/latest/meta-data/"},
+		{"https", "https://169.254.169.254/latest/meta-data/"},
+	}
 
-	verdict := ScanRequest(context.Background(), []byte(batch), sc, config.ActionWarn, config.ActionBlock)
-	if verdict.Clean {
-		t.Fatal("batch resources/read HTTP URI to metadata endpoint should be blocked by URL policy")
-	}
-	if len(verdict.URLFindings) != 1 {
-		t.Fatalf("batch URLFindings len = %d, want 1: %+v", len(verdict.URLFindings), verdict)
-	}
-	if got := inputVerdictEffectiveAction(verdict, config.ActionWarn); got != config.ActionBlock {
-		t.Fatalf("batch effective action = %q, want %q", got, config.ActionBlock)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			batch := "[" +
+				makeRequest(1, "tools/list", nil) + "," +
+				makeRequest(2, "resources/read", map[string]string{
+					"uri": tt.uri,
+				}) +
+				"]"
+
+			verdict := ScanRequest(context.Background(), []byte(batch), sc, config.ActionWarn, config.ActionBlock)
+			if verdict.Clean {
+				t.Fatal("batch resources/read HTTP(S) URI to metadata endpoint should be blocked by URL policy")
+			}
+			if len(verdict.URLFindings) != 1 {
+				t.Fatalf("batch URLFindings len = %d, want 1: %+v", len(verdict.URLFindings), verdict)
+			}
+			if got := verdict.URLFindings[0].Scanner; got != scanner.ScannerCoreSSRF {
+				t.Fatalf("batch URL finding scanner = %q, want %q", got, scanner.ScannerCoreSSRF)
+			}
+			if got := inputVerdictEffectiveAction(verdict, config.ActionWarn); got != config.ActionBlock {
+				t.Fatalf("batch effective action = %q, want %q", got, config.ActionBlock)
+			}
+		})
 	}
 }
 
@@ -2696,6 +2723,86 @@ func TestScanRequest_ResourcesReadDuplicateURIBlocks(t *testing.T) {
 	}
 	if got := inputVerdictEffectiveAction(verdict, config.ActionWarn); got != config.ActionBlock {
 		t.Fatalf("effective action = %q, want %q", got, config.ActionBlock)
+	}
+}
+
+func TestScanRequest_ResourcesReadMalformedParamsFailClosed(t *testing.T) {
+	sc := testInputScanner(t)
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "omitted params",
+			line: `{"jsonrpc":"2.0","id":1,"method":"resources/read"}`,
+		},
+		{
+			name: "null params",
+			line: `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":null}`,
+		},
+		{
+			name: "string params",
+			line: `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":"http://169.254.169.254/latest/meta-data/"}`,
+		},
+		{
+			name: "array params",
+			line: `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":["http://169.254.169.254/latest/meta-data/"]}`,
+		},
+		{
+			name: "non-string uri",
+			line: `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":123}}`,
+		},
+		{
+			name: "missing uri",
+			line: `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{}}`,
+		},
+		{
+			name: "empty uri",
+			line: `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"   "}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verdict := ScanRequest(context.Background(), []byte(tt.line), sc, config.ActionWarn, config.ActionBlock)
+			if verdict.Clean {
+				t.Fatal("malformed resources/read params should fail closed")
+			}
+			if len(verdict.URLFindings) != 1 {
+				t.Fatalf("URLFindings len = %d, want 1: %+v", len(verdict.URLFindings), verdict)
+			}
+			if got := verdict.URLFindings[0].Scanner; got != scanner.ScannerParser {
+				t.Fatalf("URL finding scanner = %q, want %q", got, scanner.ScannerParser)
+			}
+			if got := inputVerdictEffectiveAction(verdict, config.ActionWarn); got != config.ActionBlock {
+				t.Fatalf("effective action = %q, want %q", got, config.ActionBlock)
+			}
+		})
+	}
+}
+
+func TestForwardScannedInput_ResourcesReadURLBlockIncludesReasonData(t *testing.T) {
+	sc := testInputScanner(t)
+	msg := makeRequest(9, "resources/read", map[string]string{
+		"uri": "https://169.254.169.254/latest/meta-data/",
+	}) + "\n"
+
+	var serverBuf, logBuf bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 1)
+	fwdScannedInput(strings.NewReader(msg), &serverBuf, &logBuf, sc, config.ActionWarn, config.ActionBlock, blockedCh)
+
+	if serverBuf.Len() != 0 {
+		t.Fatalf("expected resources/read URL-policy block not to be forwarded: %s", serverBuf.String())
+	}
+	blocked, ok := <-blockedCh
+	if !ok {
+		t.Fatal("expected blocked resources/read request")
+	}
+	if string(blocked.ID) != "9" {
+		t.Fatalf("blocked ID = %s, want 9", blocked.ID)
+	}
+	if !strings.Contains(string(blocked.ErrorData), string(blockreason.SSRFPrivateIP)) {
+		t.Fatalf("error data = %s, want %s", blocked.ErrorData, blockreason.SSRFPrivateIP)
 	}
 }
 

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -103,6 +103,13 @@ func TestInputVerdictEffectiveAction_AddressFindings(t *testing.T) {
 	}
 }
 
+func TestInputVerdictEffectiveAction_ErrorFailsClosed(t *testing.T) {
+	verdict := InputVerdict{Clean: false, Error: "invalid JSON"}
+	if got := inputVerdictEffectiveAction(verdict, config.ActionWarn); got != config.ActionBlock {
+		t.Fatalf("inputVerdictEffectiveAction(error) = %q, want %q", got, config.ActionBlock)
+	}
+}
+
 func mcpSyntheticAWSAccessKey() string {
 	return "AKIA" + strings.Repeat("F", 16)
 }
@@ -2615,6 +2622,80 @@ func TestScanRequest_HexInURLPath_NoFalsePositives(t *testing.T) {
 				t.Errorf("false positive on clean URL: %s", tt.url)
 			}
 		})
+	}
+}
+
+func TestScanRequest_ResourcesReadHTTPURIUsesURLPolicy(t *testing.T) {
+	sc := testInputScanner(t)
+	line := makeRequest(1, "resources/read", map[string]string{
+		"uri": "http://169.254.169.254/latest/meta-data/",
+	})
+
+	verdict := ScanRequest(context.Background(), []byte(line), sc, config.ActionWarn, config.ActionBlock)
+	if verdict.Clean {
+		t.Fatal("resources/read HTTP URI to metadata endpoint should be blocked by URL policy")
+	}
+	if len(verdict.URLFindings) != 1 {
+		t.Fatalf("URLFindings len = %d, want 1: %+v", len(verdict.URLFindings), verdict)
+	}
+	if got := verdict.URLFindings[0].Scanner; got != scanner.ScannerCoreSSRF {
+		t.Fatalf("URL finding scanner = %q, want %q", got, scanner.ScannerCoreSSRF)
+	}
+	if got := inputVerdictEffectiveAction(verdict, config.ActionWarn); got != config.ActionBlock {
+		t.Fatalf("effective action = %q, want %q", got, config.ActionBlock)
+	}
+}
+
+func TestScanRequest_ResourcesReadNonHTTPURIsSkipURLPolicy(t *testing.T) {
+	sc := testInputScanner(t)
+	for _, uri := range []string{
+		"ui://trusted/template.html",
+		"file:///etc/hosts",
+	} {
+		t.Run(uri, func(t *testing.T) {
+			line := makeRequest(1, "resources/read", map[string]string{"uri": uri})
+			verdict := ScanRequest(context.Background(), []byte(line), sc, config.ActionBlock, config.ActionBlock)
+			if !verdict.Clean {
+				t.Fatalf("non-HTTP resource URI should not be URL-policy scanned: %+v", verdict)
+			}
+		})
+	}
+}
+
+func TestScanRequest_BatchResourcesReadHTTPURIUsesURLPolicy(t *testing.T) {
+	sc := testInputScanner(t)
+	batch := "[" +
+		makeRequest(1, "tools/list", nil) + "," +
+		makeRequest(2, "resources/read", map[string]string{
+			"uri": "http://169.254.169.254/latest/meta-data/",
+		}) +
+		"]"
+
+	verdict := ScanRequest(context.Background(), []byte(batch), sc, config.ActionWarn, config.ActionBlock)
+	if verdict.Clean {
+		t.Fatal("batch resources/read HTTP URI to metadata endpoint should be blocked by URL policy")
+	}
+	if len(verdict.URLFindings) != 1 {
+		t.Fatalf("batch URLFindings len = %d, want 1: %+v", len(verdict.URLFindings), verdict)
+	}
+	if got := inputVerdictEffectiveAction(verdict, config.ActionWarn); got != config.ActionBlock {
+		t.Fatalf("batch effective action = %q, want %q", got, config.ActionBlock)
+	}
+}
+
+func TestScanRequest_ResourcesReadDuplicateURIBlocks(t *testing.T) {
+	sc := testInputScanner(t)
+	line := []byte(`{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"ui://trusted/template.html","uri":"http://169.254.169.254/latest/meta-data/"}}`)
+
+	verdict := ScanRequest(context.Background(), line, sc, config.ActionWarn, config.ActionBlock)
+	if verdict.Clean {
+		t.Fatal("resources/read with duplicate uri keys should fail closed")
+	}
+	if !strings.Contains(verdict.Error, "duplicate JSON object key") {
+		t.Fatalf("Error = %q, want duplicate JSON object key", verdict.Error)
+	}
+	if got := inputVerdictEffectiveAction(verdict, config.ActionWarn); got != config.ActionBlock {
+		t.Fatalf("effective action = %q, want %q", got, config.ActionBlock)
 	}
 }
 

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -594,19 +594,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	}
 
 	// Build reasons.
-	var reasons []string
-	for _, m := range verdict.Matches {
-		reasons = append(reasons, m.PatternName)
-	}
-	for _, m := range verdict.Inject {
-		reasons = append(reasons, m.PatternName)
-	}
-	for _, f := range verdict.URLFindings {
-		reasons = append(reasons, "url:"+f.Scanner+":"+f.Reason)
-	}
-	for _, f := range verdict.AddressFindings {
-		reasons = append(reasons, "address:"+f.Explanation)
-	}
+	reasons := inputVerdictReasons(verdict)
 	for _, r := range policyVerdict.Rules {
 		reasons = append(reasons, "policy:"+r)
 	}

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -262,7 +262,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	}
 	if scanEnabled && redactionCfg.Matcher != nil {
 		originalVerdict := scanRequestForAgent(inputScanCtx, msg, sc, action, onParseError, opts.addressProtectionAgent())
-		if !originalVerdict.Clean && inputVerdictEffectiveAction(originalVerdict, action) == config.ActionBlock {
+		if !originalVerdict.Clean && originalVerdict.Error == "" && inputVerdictEffectiveAction(originalVerdict, action) == config.ActionBlock {
 			receiptLayer, receiptPattern, receiptSeverity = contentScanAttribution(originalVerdict)
 			_, _ = fmt.Fprintf(logW, "pipelock: input: blocked (%s)\n", joinInputVerdictReasons(originalVerdict))
 			recordAdaptiveSignal(session.SignalBlock)
@@ -601,6 +601,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	for _, m := range verdict.Inject {
 		reasons = append(reasons, m.PatternName)
 	}
+	for _, f := range verdict.URLFindings {
+		reasons = append(reasons, "url:"+f.Scanner+":"+f.Reason)
+	}
 	for _, f := range verdict.AddressFindings {
 		reasons = append(reasons, "address:"+f.Explanation)
 	}
@@ -673,6 +676,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		var rawFindings []capture.Finding
 		rawFindings = append(rawFindings, dlpMatchesToFindings(verdict.Matches)...)
 		rawFindings = append(rawFindings, responseMatchesToFindings(verdict.Inject, effectiveAction)...)
+		rawFindings = append(rawFindings, urlFindingsToCapture(verdict.URLFindings)...)
 		rawFindings = append(rawFindings, addressFindingsToCapture(verdict.AddressFindings)...)
 		obs.ObserveDLPVerdict(context.Background(), &capture.DLPVerdictRecord{
 			Subsurface:        "dlp_mcp_input",

--- a/internal/mcp/mcp_livelock_test.go
+++ b/internal/mcp/mcp_livelock_test.go
@@ -254,6 +254,9 @@ func TestMCPContractBlockReasonHelpers(t *testing.T) {
 	if got := mcpScannerBlockReason(InputVerdict{Inject: []scanner.ResponseMatch{{PatternName: "prompt"}}}, policy.Verdict{}, false); got != blockreason.PromptInjection {
 		t.Fatalf("injection scanner reason = %s", got)
 	}
+	if got := mcpScannerBlockReason(InputVerdict{URLFindings: []scanner.Result{{Scanner: scanner.ScannerCoreSSRF}}}, policy.Verdict{}, false); got != blockreason.SSRFPrivateIP {
+		t.Fatalf("url scanner reason = %s", got)
+	}
 	if got := mcpScannerBlockReason(InputVerdict{}, policy.Verdict{Matched: true}, false); got != blockreason.ToolPolicyDeny {
 		t.Fatalf("policy scanner reason = %s", got)
 	}

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -411,6 +411,9 @@ func contentScanAttribution(verdict InputVerdict) (layer, pattern, severity stri
 	if len(verdict.Inject) > 0 {
 		return mcpReceiptLayerInput, verdict.Inject[0].PatternName, config.SeverityHigh
 	}
+	if len(verdict.URLFindings) > 0 {
+		return mcpReceiptLayerInput, "url:" + verdict.URLFindings[0].Scanner, config.SeverityHigh
+	}
 	if len(verdict.AddressFindings) > 0 {
 		return mcpReceiptLayerInput, "address:" + verdict.AddressFindings[0].Explanation, config.SeverityHigh
 	}


### PR DESCRIPTION
## Summary
- run URL policy scanning for HTTP(S) MCP resources/read URIs
- keep non-HTTP MCP resource schemes outside URL-policy enforcement
- carry URL findings through MCP input action, capture, receipt attribution, and JSON-RPC block reasons

## Security
This blocks SSRF/private-network MCP resource reads, including metadata endpoint URIs, that were previously scanned only as ordinary text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added URL-policy scanning for MCP `resources/read` parameters, including surfacing URL findings, deriving block reasons from the finding type, and reflecting URL findings in input attribution.

* **Bug Fixes**
  * Improved fail-closed handling for malformed/disallowed `resources/read` inputs (including batches) so they resolve to block.
  * Detects duplicate JSON keys in `resources/read` parameters to prevent ambiguous interpretation.

* **Tests**
  * Expanded coverage for HTTP/HTTPS URL blocking, non-HTTP scheme skipping, malformed parameters fail-closed behavior, duplicate key rejection, and correct blocked-request reason data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->