### PR TITLE
fix: reject duplicate playground artifact keys

### DIFF
--- a/internal/playground/bundle.go
+++ b/internal/playground/bundle.go
@@ -6,7 +6,6 @@
 package playground
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -188,7 +187,7 @@ func loadLaunchManifest(cleanDir string) (LaunchManifest, error) {
 		return LaunchManifest{}, fmt.Errorf("read launch manifest: %w", err)
 	}
 	var lm LaunchManifest
-	if err := json.Unmarshal(data, &lm); err != nil {
+	if err := unmarshalStrictArtifact(launchManifestFile, data, &lm); err != nil {
 		return LaunchManifest{}, fmt.Errorf("parse launch manifest: %w", err)
 	}
 	return lm, nil

--- a/internal/playground/containment_verify_test.go
+++ b/internal/playground/containment_verify_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/playground"
@@ -95,6 +96,32 @@ func TestVerify_Contained_MalformedWitness_FailsClosed(t *testing.T) {
 	rep, err := playground.VerifyRun(dir, orchPubHex)
 	if err == nil && rep.OK {
 		t.Fatal("malformed host-containment witness must fail closed")
+	}
+}
+
+func TestVerify_Contained_DuplicateKeyWitnessFailsClosed(t *testing.T) {
+	t.Parallel()
+	dir, orchPubHex, _ := buildRunDir(t, true)
+	path := filepath.Join(dir, hcwFile)
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read hcw: %v", err)
+	}
+	data = prependDuplicateJSONField(t, data, "run_nonce", "attacker-run")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write hcw: %v", err)
+	}
+
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err == nil && rep.OK {
+		t.Fatal("duplicate-key host-containment witness must fail closed")
+	}
+	check := findCheck(t, rep.Checks, "host-containment-witness-signature")
+	if check.OK {
+		t.Fatalf("host-containment witness signature check passed unexpectedly: %+v", check)
+	}
+	if !strings.Contains(check.Reason, "duplicate JSON key") {
+		t.Fatalf("Reason = %q, want duplicate JSON key", check.Reason)
 	}
 }
 

--- a/internal/playground/containment_verify_test.go
+++ b/internal/playground/containment_verify_test.go
@@ -113,7 +113,10 @@ func TestVerify_Contained_DuplicateKeyWitnessFailsClosed(t *testing.T) {
 	}
 
 	rep, err := playground.VerifyRun(dir, orchPubHex)
-	if err == nil && rep.OK {
+	if err != nil {
+		t.Fatalf("VerifyRun returned unexpected error: %v", err)
+	}
+	if rep.OK {
 		t.Fatal("duplicate-key host-containment witness must fail closed")
 	}
 	check := findCheck(t, rep.Checks, "host-containment-witness-signature")

--- a/internal/playground/strict_json.go
+++ b/internal/playground/strict_json.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+)
+
+func unmarshalStrictArtifact(name string, data []byte, dst any) error {
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		if errors.Is(err, jsonscan.ErrDuplicateKey) {
+			return fmt.Errorf("%s contains duplicate JSON key: %w", name, err)
+		}
+		return fmt.Errorf("%s is invalid JSON: %w", name, err)
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -10,7 +10,6 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -320,7 +319,7 @@ func VerifyRunArtifacts(artifacts RunArtifacts, orchestratorPubHex string) (Veri
 		return finalize(rep, required), nil
 	}
 	var lm LaunchManifest
-	if err := json.Unmarshal(artifacts.LaunchManifest, &lm); err != nil {
+	if err := unmarshalStrictArtifact(launchManifestFile, artifacts.LaunchManifest, &lm); err != nil {
 		rep.Checks = append(rep.Checks, Check{
 			Name:   checkManifestSig,
 			OK:     false,
@@ -346,7 +345,7 @@ func VerifyRunArtifacts(artifacts RunArtifacts, orchestratorPubHex string) (Veri
 		return finalize(rep, required), nil
 	}
 	var witness Witness
-	if err := json.Unmarshal(artifacts.Witness, &witness); err != nil {
+	if err := unmarshalStrictArtifact(witnessFile, artifacts.Witness, &witness); err != nil {
 		rep.Checks = append(rep.Checks, Check{
 			Name:   checkWitnessSig,
 			OK:     false,
@@ -543,7 +542,7 @@ func verifyHostContainmentBytes(data []byte, lm LaunchManifest, orchestratorPubH
 
 func verifyHostContainmentData(data []byte, lm LaunchManifest, orchestratorPubHex string, rep *VerifyReport) {
 	var hcw HostContainmentWitness
-	if err := json.Unmarshal(data, &hcw); err != nil {
+	if err := unmarshalStrictArtifact(hostContainmentWitnessFile, data, &hcw); err != nil {
 		rep.Checks = append(rep.Checks, Check{
 			Name:   checkHostContainSig,
 			OK:     false,
@@ -606,7 +605,7 @@ func verifyRedWitnessArtifactBytes(data []byte, lm LaunchManifest, rc *RedCaseRe
 
 func verifyRedWitnessArtifactData(data []byte, lm LaunchManifest, rc *RedCaseResult, reasons []string) (Witness, []string) {
 	var red Witness
-	if err := json.Unmarshal(data, &red); err != nil {
+	if err := unmarshalStrictArtifact(redWitnessFile, data, &red); err != nil {
 		return Witness{}, []string{fmt.Sprintf("malformed %s: %v", redWitnessFile, err)}
 	}
 	if !VerifyWitness(lm.CollectorPubKey, red) {
@@ -633,7 +632,7 @@ func verifyLiveDemoSemanticsBytes(manifestJSON, evidenceJSONL []byte, lm LaunchM
 		return fmt.Errorf("missing packet manifest")
 	}
 	var replayManifest replaycapture.Manifest
-	if err := json.Unmarshal(manifestJSON, &replayManifest); err != nil {
+	if err := unmarshalStrictArtifact(packetManifestFile, manifestJSON, &replayManifest); err != nil {
 		return fmt.Errorf("malformed packet manifest: %w", err)
 	}
 	if err := verifyLiveDemoManifest(replayManifest, lm); err != nil {

--- a/internal/playground/verify_memory_test.go
+++ b/internal/playground/verify_memory_test.go
@@ -99,6 +99,75 @@ func TestVerifyRunArtifacts_InMemory(t *testing.T) {
 	}
 }
 
+func TestVerifyRunArtifacts_RejectsDuplicateJSONKeys(t *testing.T) {
+	t.Parallel()
+	fixture := newVerifyMemoryFixture(t)
+
+	tests := []struct {
+		name       string
+		mutate     func(*testing.T, playground.RunArtifacts) playground.RunArtifacts
+		wantCheck  string
+		wantReason string
+	}{
+		{
+			name: "launch manifest duplicate signed field",
+			mutate: func(t *testing.T, artifacts playground.RunArtifacts) playground.RunArtifacts {
+				artifacts.LaunchManifest = prependDuplicateJSONField(t, artifacts.LaunchManifest, "run_nonce", "attacker-run")
+				return artifacts
+			},
+			wantCheck:  "launch-manifest-signature",
+			wantReason: "duplicate JSON key",
+		},
+		{
+			name: "witness duplicate signed field",
+			mutate: func(t *testing.T, artifacts playground.RunArtifacts) playground.RunArtifacts {
+				artifacts.Witness = prependDuplicateJSONField(t, artifacts.Witness, "observed_count", 99)
+				return artifacts
+			},
+			wantCheck:  "collector-witness-signature",
+			wantReason: "duplicate JSON key",
+		},
+		{
+			name: "red witness duplicate signed field",
+			mutate: func(t *testing.T, artifacts playground.RunArtifacts) playground.RunArtifacts {
+				artifacts.RedWitness = prependDuplicateJSONField(t, artifacts.RedWitness, "observed_count", 0)
+				return artifacts
+			},
+			wantCheck:  "red-case-calibration",
+			wantReason: "duplicate JSON key",
+		},
+		{
+			name: "packet manifest duplicate semantic field",
+			mutate: func(t *testing.T, artifacts playground.RunArtifacts) playground.RunArtifacts {
+				artifacts.PacketManifestJSON = prependDuplicateJSONField(t, artifacts.PacketManifestJSON, "scenario_id", "wrong-scenario")
+				return artifacts
+			},
+			wantCheck:  "live-demo-semantics",
+			wantReason: "duplicate JSON key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rep, err := playground.VerifyRunArtifacts(tc.mutate(t, fixture.artifacts), fixture.orchestratorPubHex)
+			if err != nil {
+				t.Fatalf("VerifyRunArtifacts returned unexpected error: %v", err)
+			}
+			if rep.OK {
+				t.Fatalf("duplicate-key artifact verified: %+v", rep.Checks)
+			}
+			check := findCheck(t, rep.Checks, tc.wantCheck)
+			if check.OK {
+				t.Fatalf("%s check passed unexpectedly: %+v", tc.wantCheck, check)
+			}
+			if !strings.Contains(check.Reason, tc.wantReason) {
+				t.Fatalf("%s reason = %q, want %q", tc.wantCheck, check.Reason, tc.wantReason)
+			}
+		})
+	}
+}
+
 func TestExtractRunArtifactsFromBundle_InMemory(t *testing.T) {
 	t.Parallel()
 	fixture := newVerifyMemoryFixture(t)
@@ -562,6 +631,34 @@ func corruptWitnessByte(artifacts playground.RunArtifacts) playground.RunArtifac
 		out.Witness[len(out.Witness)/2] ^= 0x01
 	}
 	return out
+}
+
+func prependDuplicateJSONField(t *testing.T, raw []byte, key string, value any) []byte {
+	t.Helper()
+	valueJSON, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal duplicate value: %v", err)
+	}
+	prefix := append([]byte(`{"`+key+`":`), valueJSON...)
+	prefix = append(prefix, ',')
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		t.Fatalf("fixture is not a JSON object: %q", raw)
+	}
+	out := append([]byte(nil), prefix...)
+	out = append(out, trimmed[1:]...)
+	return out
+}
+
+func findCheck(t *testing.T, checks []playground.Check, name string) playground.Check {
+	t.Helper()
+	for _, check := range checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	t.Fatalf("missing check %q in %+v", name, checks)
+	return playground.Check{}
 }
 
 func writeRunArtifactsFromMemory(t *testing.T, artifacts playground.RunArtifacts) string {


### PR DESCRIPTION
## Summary
- reject duplicate JSON keys before playground verification decodes signed launch, witness, host-containment, and packet manifest artifacts
- share a strict artifact unmarshal helper between verifier and bundle parsing paths
- cover last-wins duplicate-key artifacts that previously could still verify

## Security
This closes parser-differential cases where signed proof artifacts could carry contradictory first values while Go verified the last decoded value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened verification JSON parsing to reject inputs containing duplicate keys, ensuring consistent fail-closed behavior.
  * Improved reporting when launch manifests and witness/packet artifacts contain invalid or malformed JSON.
* **Tests**
  * Added new test coverage to confirm duplicate-key JSON payloads are detected and do not pass verification checks, including containment-related failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->