### PR TITLE
fix: enforce required receipts in reverse proxy

### DIFF
--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -130,6 +130,9 @@ func TestStatsHandler(t *testing.T) {
 	if len(stats.Receipts.EmitFailures) != 0 {
 		t.Errorf("expected no receipt emit failures, got %v", stats.Receipts.EmitFailures)
 	}
+	if len(stats.Receipts.RequiredBlocks) != 0 {
+		t.Errorf("expected no required receipt blocks, got %v", stats.Receipts.RequiredBlocks)
+	}
 }
 
 func TestStatsHandler_BlockRate(t *testing.T) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -127,6 +127,9 @@ func TestStatsHandler(t *testing.T) {
 	if len(stats.TopScanners) != 1 {
 		t.Errorf("expected 1 top scanner, got %d", len(stats.TopScanners))
 	}
+	if len(stats.Receipts.EmitFailures) != 0 {
+		t.Errorf("expected no receipt emit failures, got %v", stats.Receipts.EmitFailures)
+	}
 }
 
 func TestStatsHandler_BlockRate(t *testing.T) {
@@ -163,6 +166,59 @@ func TestStatsHandler_Empty(t *testing.T) {
 	}
 	if stats.Requests.BlockRate != 0 {
 		t.Errorf("expected block_rate=0, got %f", stats.Requests.BlockRate)
+	}
+	if len(stats.Receipts.EmitFailures) != 0 {
+		t.Errorf("expected no receipt emit failures, got %v", stats.Receipts.EmitFailures)
+	}
+	if len(stats.Receipts.RequiredBlocks) != 0 {
+		t.Errorf("expected no required receipt blocks, got %v", stats.Receipts.RequiredBlocks)
+	}
+}
+
+func TestStatsHandler_IncludesReceiptFailureSummary(t *testing.T) {
+	m := New()
+	m.RecordEmitFailure("record")
+	m.RecordEmitFailure("record")
+	m.RecordEmitFailure("unavailable")
+	m.RecordEmitFailure("attacker-controlled detail")
+	m.RecordRequiredReceiptBlock("unavailable", "fetch")
+	m.RecordRequiredReceiptBlock("emit_error", "reverse")
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil)
+	w := httptest.NewRecorder()
+	m.StatsHandler().ServeHTTP(w, req)
+
+	var stats statsResponse
+	if err := json.NewDecoder(w.Body).Decode(&stats); err != nil {
+		t.Fatalf("failed to decode stats: %v", err)
+	}
+	got := make(map[string]int64, len(stats.Receipts.EmitFailures))
+	for _, reason := range stats.Receipts.EmitFailures {
+		got[reason.Name] = reason.Count
+	}
+	want := map[string]int64{
+		"record":      2,
+		"unavailable": 1,
+		"unknown":     1,
+	}
+	for reason, count := range want {
+		if got[reason] != count {
+			t.Errorf("receipt failure reason %q = %d, want %d", reason, got[reason], count)
+		}
+	}
+	if _, ok := got["attacker-controlled detail"]; ok {
+		t.Fatal("non-canonical receipt failure reason leaked into /stats")
+	}
+
+	blocked := make(map[string]int64, len(stats.Receipts.RequiredBlocks))
+	for _, block := range stats.Receipts.RequiredBlocks {
+		blocked[block.Reason+"/"+block.Transport] = block.Count
+	}
+	if blocked["unavailable/fetch"] != 1 {
+		t.Fatalf("required unavailable/fetch blocks = %d, want 1", blocked["unavailable/fetch"])
+	}
+	if blocked["emit_error/reverse"] != 1 {
+		t.Fatalf("required emit_error/reverse blocks = %d, want 1", blocked["emit_error/reverse"])
 	}
 }
 

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -167,6 +167,12 @@ func interceptRecordSignal(ic *InterceptContext, sig session.SignalType) {
 // the current emitter (including after key rotation on reload).
 func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) error {
 	if ic.Proxy == nil {
+		if ic.Config != nil && ic.Config.FlightRecorder.RequireReceipts {
+			if ic.Logger != nil {
+				ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), receiptEmissionError(opts, errReceiptEmitterUnavailable))
+			}
+			return errReceiptEmitterUnavailable
+		}
 		return nil
 	}
 	if ic.Config != nil {
@@ -179,9 +185,7 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) error {
 		return errReceiptEmitterUnavailable
 	}
 	if err := e.Emit(opts); err != nil {
-		if ic.Logger != nil {
-			ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
-		}
+		ic.Proxy.logReceiptEmissionFailure(opts, err)
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -201,11 +201,11 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) error {
 
 func interceptEmitReceiptOrBlock(ic *InterceptContext, w http.ResponseWriter, actx audit.LogContext, opts receipt.EmitOpts) bool {
 	if err := interceptEmitReceipt(ic, opts); err != nil && ic.Config != nil && ic.Config.FlightRecorder.RequireReceipts {
-		if errors.Is(err, errReceiptEmitterUnavailable) && ic.Proxy != nil {
-			ic.Proxy.metrics.RecordEmitFailure(receipt.FailReasonUnavailable)
-		}
-		if ic.Proxy != nil {
-			ic.Proxy.metrics.RecordRequiredReceiptBlock(requiredReceiptBlockMetricReason(err), opts.Transport)
+		if m := interceptReceiptMetrics(ic); m != nil {
+			if errors.Is(err, errReceiptEmitterUnavailable) {
+				m.RecordEmitFailure(receipt.FailReasonUnavailable)
+			}
+			m.RecordRequiredReceiptBlock(requiredReceiptBlockMetricReason(err), opts.Transport)
 		}
 		blockedErr := newReceiptEmissionBlockedRequest(err)
 		ic.Logger.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
@@ -215,6 +215,16 @@ func interceptEmitReceiptOrBlock(ic *InterceptContext, w http.ResponseWriter, ac
 		return true
 	}
 	return false
+}
+
+func interceptReceiptMetrics(ic *InterceptContext) *metrics.Metrics {
+	if ic == nil {
+		return nil
+	}
+	if ic.Proxy != nil && ic.Proxy.metrics != nil {
+		return ic.Proxy.metrics
+	}
+	return ic.Metrics
 }
 
 // interceptReadHeaderTimeout is the maximum time to read request headers on an

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -154,6 +154,39 @@ func TestInterceptEmitReceiptOrBlockUnavailableEmitterRecordsMetric(t *testing.T
 	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="intercept"} 1`)
 }
 
+func TestInterceptEmitReceiptOrBlockRequiresProxy(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.FlightRecorder.RequireReceipts = true
+	cfg.Internal = nil
+	cfg.ApplyDefaults()
+
+	ic := &InterceptContext{
+		Config:    cfg,
+		Logger:    audit.NewNop(),
+		RequestID: "req-intercept-no-proxy",
+		Agent:     "agent",
+	}
+	rr := httptest.NewRecorder()
+	blocked := interceptEmitReceiptOrBlock(ic, rr, audit.NewRequestLogContext(ic.RequestID), receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: "intercept",
+		Method:    http.MethodGet,
+		Target:    "https://example.test/",
+		RequestID: ic.RequestID,
+		Agent:     ic.Agent,
+	})
+	if !blocked {
+		t.Fatal("missing proxy did not fail closed when receipts are required")
+	}
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+	if got := rr.Header().Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.ReceiptEmissionFailed)
+	}
+}
+
 func testInterceptRedactProxy(t *testing.T, cfg *config.Config) *Proxy {
 	t.Helper()
 	return testInterceptRedactProxyWithScanner(t, cfg, nil)

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -160,9 +160,11 @@ func TestInterceptEmitReceiptOrBlockRequiresProxy(t *testing.T) {
 	cfg.Internal = nil
 	cfg.ApplyDefaults()
 
+	m := metrics.New()
 	ic := &InterceptContext{
 		Config:    cfg,
 		Logger:    audit.NewNop(),
+		Metrics:   m,
 		RequestID: "req-intercept-no-proxy",
 		Agent:     "agent",
 	}
@@ -185,6 +187,8 @@ func TestInterceptEmitReceiptOrBlockRequiresProxy(t *testing.T) {
 	if got := rr.Header().Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
 		t.Fatalf("block reason = %q, want %s", got, blockreason.ReceiptEmissionFailed)
 	}
+	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`)
+	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="intercept"} 1`)
 }
 
 func testInterceptRedactProxy(t *testing.T, cfg *config.Config) *Proxy {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -999,12 +999,12 @@ func (p *Proxy) emitRequiredReceipt(opts receipt.EmitOpts) error {
 	}
 	e := p.receiptEmitterPtr.Load()
 	if e == nil {
-		p.metrics.RecordEmitFailure(receipt.FailReasonUnavailable)
-		p.metrics.RecordRequiredReceiptBlock(receipt.FailReasonUnavailable, opts.Transport)
-		return errReceiptEmitterUnavailable
+		err := p.recordReceiptEmitterUnavailable(opts)
+		p.recordRequiredReceiptBlock(err, opts.Transport)
+		return err
 	}
 	if err := p.emitReceiptWithEmitter(opts, e); err != nil {
-		p.metrics.RecordRequiredReceiptBlock(requiredReceiptBlockMetricReason(err), opts.Transport)
+		p.recordRequiredReceiptBlock(err, opts.Transport)
 		return err
 	}
 	return nil
@@ -1015,10 +1015,7 @@ func (p *Proxy) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter
 		return nil
 	}
 	if err := e.Emit(opts); err != nil {
-		p.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
-			fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
-				opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
-				opts.Transport, opts.Method, opts.Target, opts.Agent, err))
+		p.logReceiptEmissionFailure(opts, err)
 		// v1 stays authoritative: skip v2 when v1 failed to record, so a
 		// proxy_decision never outlives its action_receipt sibling.
 		return err
@@ -1026,6 +1023,36 @@ func (p *Proxy) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter
 	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
 	p.emitV2Receipt(opts)
 	return nil
+}
+
+func (p *Proxy) recordReceiptEmitterUnavailable(opts receipt.EmitOpts) error {
+	if p != nil && p.metrics != nil {
+		p.metrics.RecordEmitFailure(receipt.FailReasonUnavailable)
+	}
+	if p != nil {
+		p.logReceiptEmissionFailure(opts, errReceiptEmitterUnavailable)
+	}
+	return errReceiptEmitterUnavailable
+}
+
+func (p *Proxy) recordRequiredReceiptBlock(err error, transport string) {
+	if p == nil || p.metrics == nil {
+		return
+	}
+	p.metrics.RecordRequiredReceiptBlock(requiredReceiptBlockMetricReason(err), transport)
+}
+
+func (p *Proxy) logReceiptEmissionFailure(opts receipt.EmitOpts, err error) {
+	if p == nil || p.logger == nil || err == nil {
+		return
+	}
+	p.logger.LogError(audit.NewRequestLogContext(opts.RequestID), receiptEmissionError(opts, err))
+}
+
+func receiptEmissionError(opts receipt.EmitOpts, err error) error {
+	return fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
+		opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
+		opts.Transport, opts.Method, opts.Target, opts.Agent, err)
 }
 
 // receiptEmitterStage is the staged result of a receipt-emitter reload.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1050,9 +1050,9 @@ func (p *Proxy) logReceiptEmissionFailure(opts receipt.EmitOpts, err error) {
 }
 
 func receiptEmissionError(opts receipt.EmitOpts, err error) error {
-	return fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
+	return fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s: %w",
 		opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
-		opts.Transport, opts.Method, opts.Target, opts.Agent, err)
+		opts.Transport, opts.Method, err)
 }
 
 // receiptEmitterStage is the staged result of a receipt-emitter reload.

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -326,6 +326,33 @@ func TestEmitRequiredReceipt_UnavailableEmitterRecordsMetric(t *testing.T) {
 	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="fetch"} 1`)
 }
 
+func TestReceiptEmissionError_OmitsRawTargetAndAgent(t *testing.T) {
+	t.Parallel()
+
+	err := receiptEmissionError(receipt.EmitOpts{
+		ActionID:  "act-123",
+		Verdict:   config.ActionAllow,
+		Layer:     "receipt_emission",
+		Pattern:   "required",
+		Transport: TransportReverse,
+		Method:    http.MethodGet,
+		Target:    "https://example.test/path?debug=raw-target-marker",
+		Agent:     "private-agent",
+	}, errors.New("disk full"))
+
+	msg := err.Error()
+	for _, forbidden := range []string{"https://example.test", "raw-target-marker", "private-agent"} {
+		if strings.Contains(msg, forbidden) {
+			t.Fatalf("receipt emission error leaked %q in %q", forbidden, msg)
+		}
+	}
+	for _, want := range []string{"act-123", string(config.ActionAllow), TransportReverse, http.MethodGet, "disk full"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("receipt emission error %q missing %q", msg, want)
+		}
+	}
+}
+
 func TestRequiredReceiptBlockMetricReason(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proxy/reload_scanner_lifecycle_test.go
+++ b/internal/proxy/reload_scanner_lifecycle_test.go
@@ -190,12 +190,16 @@ func TestReverseProxy_EmitReceipt_NilGuards(t *testing.T) {
 	rp := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, logger, metrics.New(), killswitch.New(cfg), nil, nil)
 
 	// Path 1: receiptEmitterPtr never set. Must be a no-op.
-	_ = rp.emitReceipt(receipt.EmitOpts{ActionID: receipt.NewActionID(), Verdict: config.ActionBlock})
+	if err := rp.emitReceipt(receipt.EmitOpts{ActionID: receipt.NewActionID(), Verdict: config.ActionBlock}); err != nil {
+		t.Fatalf("emitReceipt with unset emitter = %v, want nil", err)
+	}
 
 	// Path 2: receiptEmitterPtr set but storing nil. Must be a no-op.
 	var emPtr atomic.Pointer[receipt.Emitter]
 	rp.SetReceiptEmitter(&emPtr)
-	_ = rp.emitReceipt(receipt.EmitOpts{ActionID: receipt.NewActionID(), Verdict: config.ActionBlock})
+	if err := rp.emitReceipt(receipt.EmitOpts{ActionID: receipt.NewActionID(), Verdict: config.ActionBlock}); err != nil {
+		t.Fatalf("emitReceipt with nil stored emitter = %v, want nil", err)
+	}
 }
 
 // TestReverseProxy_SnapshotAndAcquire_RetryAndFallback covers the

--- a/internal/proxy/reload_scanner_lifecycle_test.go
+++ b/internal/proxy/reload_scanner_lifecycle_test.go
@@ -190,12 +190,12 @@ func TestReverseProxy_EmitReceipt_NilGuards(t *testing.T) {
 	rp := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, logger, metrics.New(), killswitch.New(cfg), nil, nil)
 
 	// Path 1: receiptEmitterPtr never set. Must be a no-op.
-	rp.emitReceipt(receipt.EmitOpts{ActionID: receipt.NewActionID(), Verdict: config.ActionBlock})
+	_ = rp.emitReceipt(receipt.EmitOpts{ActionID: receipt.NewActionID(), Verdict: config.ActionBlock})
 
 	// Path 2: receiptEmitterPtr set but storing nil. Must be a no-op.
 	var emPtr atomic.Pointer[receipt.Emitter]
 	rp.SetReceiptEmitter(&emPtr)
-	rp.emitReceipt(receipt.EmitOpts{ActionID: receipt.NewActionID(), Verdict: config.ActionBlock})
+	_ = rp.emitReceipt(receipt.EmitOpts{ActionID: receipt.NewActionID(), Verdict: config.ActionBlock})
 }
 
 // TestReverseProxy_SnapshotAndAcquire_RetryAndFallback covers the

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -232,42 +232,102 @@ func (rp *ReverseProxyHandler) SetRequestPolicyPrepareFn(fn func(*http.Request, 
 }
 
 // emitReceipt records a signed action receipt for a reverse-proxy
-// decision. Mirrors Proxy.emitReceipt: nil emitter is a no-op, errors are
-// logged but never propagated so a recorder failure cannot poison the
-// hot path. Reverse-proxy receipts use Transport="reverse"; the caller
-// supplies Layer/Pattern/ActionID/RequestID/Agent/Method/Target.
+// decision. Mirrors Proxy.emitReceipt: nil emitter is a no-op; emitter errors
+// are logged and returned to the caller. Current reverse-proxy hot paths ignore
+// the return value, preserving optional-receipt behavior, while tests and future
+// require_receipts gates can assert the failure directly. Reverse-proxy receipts
+// use Transport="reverse"; the caller supplies Layer/Pattern/ActionID/RequestID/
+// Agent/Method/Target.
 //
 // On emit failure the wrapped error carries every receipt field so an
 // operator reconstructing an enforcement decision after a missing-receipt
 // incident can correlate the audit log entry to the action that was
 // supposed to be attested. Plain RequestID alone is too thin for that.
-func (rp *ReverseProxyHandler) emitReceipt(opts receipt.EmitOpts) {
+func (rp *ReverseProxyHandler) emitReceipt(opts receipt.EmitOpts) error {
 	if rp.cfgPtr != nil {
 		if cfg := rp.cfgPtr.Load(); cfg != nil {
 			opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 		}
 	}
 	if rp.receiptEmitterPtr == nil {
-		return
+		return nil
 	}
 	e := rp.receiptEmitterPtr.Load()
 	if e == nil {
-		return
+		return nil
 	}
 	if err := e.Emit(opts); err != nil {
-		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
-			fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s target=%s agent=%s: %w",
-				opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
-				opts.Transport, opts.Method, opts.Target, opts.Agent, err))
+		rp.logReceiptEmissionFailure(opts, err)
 		// v1 stays authoritative: skip v2 when v1 failed to record.
-		return
+		return err
 	}
 	// Dual-emit the v2 proxy_decision receipt.
 	emitV2(rp.v2EmitterPtr, opts, func(err error) {
+		if rp.logger == nil {
+			return
+		}
 		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
 			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s transport=%s: %w",
 				opts.ActionID, opts.Verdict, opts.Transport, err))
 	})
+	return nil
+}
+
+func (rp *ReverseProxyHandler) emitRequiredReceipt(opts receipt.EmitOpts) error {
+	if rp.cfgPtr != nil {
+		if cfg := rp.cfgPtr.Load(); cfg != nil {
+			opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
+		}
+	}
+	if rp.receiptEmitterPtr == nil {
+		err := rp.recordReceiptEmitterUnavailable(opts)
+		rp.recordRequiredReceiptBlock(err, opts.Transport)
+		return err
+	}
+	e := rp.receiptEmitterPtr.Load()
+	if e == nil {
+		err := rp.recordReceiptEmitterUnavailable(opts)
+		rp.recordRequiredReceiptBlock(err, opts.Transport)
+		return err
+	}
+	if err := e.Emit(opts); err != nil {
+		rp.logReceiptEmissionFailure(opts, err)
+		rp.recordRequiredReceiptBlock(err, opts.Transport)
+		return err
+	}
+	emitV2(rp.v2EmitterPtr, opts, func(err error) {
+		if rp.logger == nil {
+			return
+		}
+		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
+			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s transport=%s: %w",
+				opts.ActionID, opts.Verdict, opts.Transport, err))
+	})
+	return nil
+}
+
+func (rp *ReverseProxyHandler) recordReceiptEmitterUnavailable(opts receipt.EmitOpts) error {
+	if rp != nil && rp.metrics != nil {
+		rp.metrics.RecordEmitFailure(receipt.FailReasonUnavailable)
+	}
+	if rp != nil {
+		rp.logReceiptEmissionFailure(opts, errReceiptEmitterUnavailable)
+	}
+	return errReceiptEmitterUnavailable
+}
+
+func (rp *ReverseProxyHandler) recordRequiredReceiptBlock(err error, transport string) {
+	if rp == nil || rp.metrics == nil {
+		return
+	}
+	rp.metrics.RecordRequiredReceiptBlock(requiredReceiptBlockMetricReason(err), transport)
+}
+
+func (rp *ReverseProxyHandler) logReceiptEmissionFailure(opts receipt.EmitOpts, err error) {
+	if rp == nil || rp.logger == nil || err == nil {
+		return
+	}
+	rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID), receiptEmissionError(opts, err))
 }
 
 func reverseTargetURL(upstream *url.URL, r *http.Request) string {
@@ -385,7 +445,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		if snap.cfg != nil {
 			opts = withReceiptPolicyHash(opts, snap.cfg.CanonicalPolicyHash())
 		}
-		rp.emitReceipt(opts)
+		_ = rp.emitReceipt(opts)
 	}
 	if !scOK {
 		// Reload thrash or no live scanner. Fail closed at the request
@@ -788,6 +848,35 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	reverseAllowReceipt := withReverseContractReceipt(receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: TransportReverse,
+		Method:    r.Method,
+		Target:    targetURL,
+		RequestID: requestID,
+		Agent:     agent,
+	})
+	if cfg.FlightRecorder.RequireReceipts {
+		// Pin the v2 proxy_decision policy hash to the admission snapshot
+		// (cfg == snap.cfg), not a possibly-reloaded rp.cfgPtr. The v2
+		// receipt consumes opts.PolicyHash; withReceiptPolicyHash is
+		// first-write-wins, so emitRequiredReceipt's internal load becomes a
+		// no-op. Mirrors the forward/fetch/websocket required-allow call
+		// sites, which pre-apply the snapshot hash so a hot reload between
+		// admission and emit cannot bind the allow to a successor policy.
+		if err := rp.emitRequiredReceipt(withReceiptPolicyHash(reverseAllowReceipt, cfg.CanonicalPolicyHash())); err != nil {
+			blockedErr := newReceiptEmissionBlockedRequest(err)
+			rp.logger.LogBlocked(newHTTPAuditContext(rp.logger, r.Method, targetURL, clientIP, requestID, agent), blockedErr.layer, blockedErr.detail)
+			rp.metrics.RecordReverseProxyRequest(r.Method, "403")
+			rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, blockedErr.layer)
+			writeReverseProxyBlock(w, http.StatusForbidden,
+				blockInfoFor(blockreason.ReceiptEmissionFailed, blockedErr.layer),
+				blockedErr.reason)
+			return
+		}
+	}
+
 	// Stash envelope build metadata on the request context so the
 	// signing RoundTripper (installed on rp.proxy.Transport) can
 	// attach a Pipelock-Mediation header and an RFC 9421 signature
@@ -886,7 +975,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 		if cfg != nil {
 			opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 		}
-		rp.emitReceipt(opts)
+		_ = rp.emitReceipt(opts)
 	}
 
 	// Skip binary content types - no secrets to scan in images/video.
@@ -1079,7 +1168,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		if cfg != nil {
 			opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 		}
-		rp.emitReceipt(opts)
+		_ = rp.emitReceipt(opts)
 	}
 	clientIP, _ := resp.Request.Context().Value(ctxKeyClientIP).(string)
 	requestID, _ := resp.Request.Context().Value(ctxKeyRequestID).(string)

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -244,55 +244,46 @@ func (rp *ReverseProxyHandler) SetRequestPolicyPrepareFn(fn func(*http.Request, 
 // incident can correlate the audit log entry to the action that was
 // supposed to be attested. Plain RequestID alone is too thin for that.
 func (rp *ReverseProxyHandler) emitReceipt(opts receipt.EmitOpts) error {
+	e := rp.receiptEmitter()
+	if e == nil {
+		return nil
+	}
+	return rp.emitReceiptWithEmitter(opts, e)
+}
+
+func (rp *ReverseProxyHandler) emitRequiredReceipt(opts receipt.EmitOpts) error {
+	e := rp.receiptEmitter()
+	if e == nil {
+		err := rp.recordReceiptEmitterUnavailable(opts)
+		rp.recordRequiredReceiptBlock(err, opts.Transport)
+		return err
+	}
+	if err := rp.emitReceiptWithEmitter(opts, e); err != nil {
+		rp.recordRequiredReceiptBlock(err, opts.Transport)
+		return err
+	}
+	return nil
+}
+
+func (rp *ReverseProxyHandler) receiptEmitter() *receipt.Emitter {
+	if rp == nil || rp.receiptEmitterPtr == nil {
+		return nil
+	}
+	return rp.receiptEmitterPtr.Load()
+}
+
+func (rp *ReverseProxyHandler) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter) error {
+	if e == nil {
+		return nil
+	}
 	if rp.cfgPtr != nil {
 		if cfg := rp.cfgPtr.Load(); cfg != nil {
 			opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 		}
-	}
-	if rp.receiptEmitterPtr == nil {
-		return nil
-	}
-	e := rp.receiptEmitterPtr.Load()
-	if e == nil {
-		return nil
 	}
 	if err := e.Emit(opts); err != nil {
 		rp.logReceiptEmissionFailure(opts, err)
 		// v1 stays authoritative: skip v2 when v1 failed to record.
-		return err
-	}
-	// Dual-emit the v2 proxy_decision receipt.
-	emitV2(rp.v2EmitterPtr, opts, func(err error) {
-		if rp.logger == nil {
-			return
-		}
-		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
-			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s transport=%s: %w",
-				opts.ActionID, opts.Verdict, opts.Transport, err))
-	})
-	return nil
-}
-
-func (rp *ReverseProxyHandler) emitRequiredReceipt(opts receipt.EmitOpts) error {
-	if rp.cfgPtr != nil {
-		if cfg := rp.cfgPtr.Load(); cfg != nil {
-			opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
-		}
-	}
-	if rp.receiptEmitterPtr == nil {
-		err := rp.recordReceiptEmitterUnavailable(opts)
-		rp.recordRequiredReceiptBlock(err, opts.Transport)
-		return err
-	}
-	e := rp.receiptEmitterPtr.Load()
-	if e == nil {
-		err := rp.recordReceiptEmitterUnavailable(opts)
-		rp.recordRequiredReceiptBlock(err, opts.Transport)
-		return err
-	}
-	if err := e.Emit(opts); err != nil {
-		rp.logReceiptEmissionFailure(opts, err)
-		rp.recordRequiredReceiptBlock(err, opts.Transport)
 		return err
 	}
 	emitV2(rp.v2EmitterPtr, opts, func(err error) {

--- a/internal/proxy/reverse_receipt_parity_test.go
+++ b/internal/proxy/reverse_receipt_parity_test.go
@@ -115,7 +115,7 @@ func TestReverseEmitReceipt_NoV1EmitterSkipsV2(t *testing.T) {
 		logger:       audit.NewNop(),
 		v2EmitterPtr: &v2Ptr,
 	}
-	_ = rp.emitReceipt(receipt.EmitOpts{
+	if err := rp.emitReceipt(receipt.EmitOpts{
 		ActionID:  "reverse-no-v1",
 		Verdict:   config.ActionBlock,
 		Layer:     LayerReverseResponseBlocked,
@@ -125,7 +125,9 @@ func TestReverseEmitReceipt_NoV1EmitterSkipsV2(t *testing.T) {
 		Target:    "https://example.test/reverse",
 		RequestID: "req-reverse-no-v1",
 		Agent:     "agent",
-	})
+	}); err != nil {
+		t.Fatalf("emitReceipt without v1 emitter = %v, want nil", err)
+	}
 	if err := rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}
@@ -197,7 +199,7 @@ func TestReverseEmitReceipt_V1FailureSkipsV2(t *testing.T) {
 		receiptEmitterPtr: &v1Ptr,
 		v2EmitterPtr:      &v2Ptr,
 	}
-	_ = rp.emitReceipt(receipt.EmitOpts{
+	if err := rp.emitReceipt(receipt.EmitOpts{
 		ActionID:  "reverse-v1-fail",
 		Verdict:   config.ActionBlock,
 		Layer:     LayerReverseResponseBlocked,
@@ -207,7 +209,9 @@ func TestReverseEmitReceipt_V1FailureSkipsV2(t *testing.T) {
 		Target:    "https://example.test/reverse",
 		RequestID: "req-reverse-v1-fail",
 		Agent:     "agent",
-	})
+	}); err == nil {
+		t.Fatal("emitReceipt after sealed v1 chain returned nil, want error")
+	}
 	if err := rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}
@@ -264,7 +268,7 @@ func TestReverseEmitReceipt_V1SuccessEmitsV2Sibling(t *testing.T) {
 		v2EmitterPtr:      &v2Ptr,
 	}
 	wantPolicyHash := strings.Repeat("a", 64)
-	_ = rp.emitReceipt(receipt.EmitOpts{
+	if err := rp.emitReceipt(receipt.EmitOpts{
 		ActionID:   "reverse-v1-ok",
 		Verdict:    config.ActionBlock,
 		Layer:      LayerReverseResponseBlocked,
@@ -275,7 +279,9 @@ func TestReverseEmitReceipt_V1SuccessEmitsV2Sibling(t *testing.T) {
 		RequestID:  "req-reverse-v1-ok",
 		Agent:      "agent",
 		PolicyHash: wantPolicyHash,
-	})
+	}); err != nil {
+		t.Fatalf("emitReceipt success path = %v, want nil", err)
+	}
 	if err := rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}

--- a/internal/proxy/reverse_receipt_parity_test.go
+++ b/internal/proxy/reverse_receipt_parity_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
@@ -114,7 +115,7 @@ func TestReverseEmitReceipt_NoV1EmitterSkipsV2(t *testing.T) {
 		logger:       audit.NewNop(),
 		v2EmitterPtr: &v2Ptr,
 	}
-	rp.emitReceipt(receipt.EmitOpts{
+	_ = rp.emitReceipt(receipt.EmitOpts{
 		ActionID:  "reverse-no-v1",
 		Verdict:   config.ActionBlock,
 		Layer:     LayerReverseResponseBlocked,
@@ -196,7 +197,7 @@ func TestReverseEmitReceipt_V1FailureSkipsV2(t *testing.T) {
 		receiptEmitterPtr: &v1Ptr,
 		v2EmitterPtr:      &v2Ptr,
 	}
-	rp.emitReceipt(receipt.EmitOpts{
+	_ = rp.emitReceipt(receipt.EmitOpts{
 		ActionID:  "reverse-v1-fail",
 		Verdict:   config.ActionBlock,
 		Layer:     LayerReverseResponseBlocked,
@@ -263,7 +264,7 @@ func TestReverseEmitReceipt_V1SuccessEmitsV2Sibling(t *testing.T) {
 		v2EmitterPtr:      &v2Ptr,
 	}
 	wantPolicyHash := strings.Repeat("a", 64)
-	rp.emitReceipt(receipt.EmitOpts{
+	_ = rp.emitReceipt(receipt.EmitOpts{
 		ActionID:   "reverse-v1-ok",
 		Verdict:    config.ActionBlock,
 		Layer:      LayerReverseResponseBlocked,
@@ -377,6 +378,106 @@ func TestReceiptCoverage_ReverseShieldReceiptScrubsTargetAndLinksParent(t *testi
 	}
 	if !strings.Contains(r.ActionRecord.Target, "__redacted") {
 		t.Fatalf("reverse shield receipt target did not include path redaction marker: %q", r.ActionRecord.Target)
+	}
+}
+
+func TestReverseProxy_RequireReceiptsBlocksMissingEmitterBeforeEgress(t *testing.T) {
+	var hits atomic.Int32
+	cfg := reverseTestConfig()
+	cfg.ResponseScanning.Enabled = false
+	cfg.FlightRecorder.RequireReceipts = true
+
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, audit.NewNop(), metrics.New(), killswitch.New(cfg), nil, nil)
+	proxySrv := newIPv4Server(t, handler)
+	t.Cleanup(proxySrv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/clean", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET reverse proxy: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("response body close: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.ReceiptEmissionFailed)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (missing receipt emitter must block before reverse egress)", got)
+	}
+}
+
+func TestReverseProxy_RequireReceiptsSuccessEmitsSingleAllow(t *testing.T) {
+	var hits atomic.Int32
+	cfg := reverseTestConfig()
+	cfg.ResponseScanning.Enabled = false
+	cfg.FlightRecorder.RequireReceipts = true
+
+	proxySrv, dir, closeRec := reverseReceiptParitySetup(t, cfg, func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/clean", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET reverse proxy: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("response body close: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream hits = %d, want 1", got)
+	}
+
+	waitForReceiptOrTimeout(t, dir)
+	closeRec()
+	receipts := extractReceiptsFromDir(t, dir)
+	var allowCount int
+	for _, rcpt := range receipts {
+		if rcpt.ActionRecord.Verdict == config.ActionAllow &&
+			rcpt.ActionRecord.Transport == TransportReverse &&
+			rcpt.ActionRecord.Layer == "" {
+			allowCount++
+		}
+	}
+	if allowCount != 1 {
+		t.Fatalf("reverse allow receipt count = %d, want 1 (receipts: %d)", allowCount, len(receipts))
 	}
 }
 


### PR DESCRIPTION
## Summary
- fail closed in reverse proxy when `require_receipts` is enabled and no receipt emitter is available before upstream egress
- pin reverse required-allow v2 policy hashes to the admission snapshot, matching fetch, forward, and websocket
- reuse shared receipt emission failure logging and metrics for required receipt paths
- add regression coverage for reverse required receipts and the intercept no-proxy required receipt edge case

## Why
`require_receipts` means an allow decision must be signed before egress. Reverse proxy allow traffic still had a best-effort receipt path, unlike the other proxy transports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for requiring receipt emission during proxy requests; when a required receipt can’t be produced, requests are blocked (403) with the appropriate reason header.
  * Expanded `/stats` output to include receipt emit-failure summaries and required receipt block summaries.

* **Bug Fixes**
  * Made receipt emission failure handling more consistent, including clearer behavior when the receipt emitter is missing and improved metrics/logging coverage.

* **Tests**
  * Expanded coverage for required-receipt and `/stats` reporting, and added validation that receipt emission errors don’t leak raw target/agent data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->