### PR TITLE
feat: add local receipt anchor bundles

### DIFF
--- a/cmd/pipelock-verifier/independent.go
+++ b/cmd/pipelock-verifier/independent.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/anchor"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+type independentOptions struct {
+	bundlePath string
+	signerKeys []string
+	logPath    string
+	logID      string
+	sessionID  string
+	asDir      bool
+	jsonOutput bool
+}
+
+func newIndependentCmd() *cobra.Command {
+	var opts independentOptions
+	cmd := &cobra.Command{
+		Use:   "independent PATH",
+		Short: "Verify an externally anchored receipt-chain checkpoint",
+		Long: `Verifies a receipt chain against an anchor bundle and external inclusion
+proof. The local backend is a deterministic test backend; it proves the
+checkpoint/proof mechanics but is not an operator-independent witness.
+
+Honest limit: anchoring detects after-the-fact rewrite, delete, omit, and
+equivocation against the anchored checkpoint. It does not prove real-time truth
+by whoever held the receipt signing key.`,
+		Args:          exactOneArg,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runIndependent(cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], opts)
+		},
+	}
+	cmd.SetFlagErrorFunc(usageFlagError)
+	cmd.Flags().StringVar(&opts.bundlePath, "bundle", "", "anchor bundle JSON path")
+	cmd.Flags().StringArrayVar(&opts.signerKeys, "key", nil, "trusted signer public key (hex, public-key text, or file path); repeat for rotated chains")
+	cmd.Flags().StringVar(&opts.logPath, "local-log", "", "local fake-log JSONL path")
+	cmd.Flags().StringVar(&opts.logID, "log-id", anchor.DefaultLocalLogID, "local fake-log identifier")
+	cmd.Flags().StringVar(&opts.sessionID, "session", "proxy", "session ID inside the evidence directory when --dir is set")
+	cmd.Flags().BoolVar(&opts.asDir, "dir", false, "treat PATH as a session directory rather than a single evidence file")
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON verdict on stdout")
+	return cmd
+}
+
+func runIndependent(stdout, stderr io.Writer, target string, opts independentOptions) error {
+	if strings.TrimSpace(opts.bundlePath) == "" {
+		return cliutil.ExitCodeError(exitUsage, fmt.Errorf("--bundle is required"))
+	}
+	if len(opts.signerKeys) == 0 {
+		return cliutil.ExitCodeError(exitUsage, fmt.Errorf("at least one --key is required"))
+	}
+	if strings.TrimSpace(opts.logPath) == "" {
+		return cliutil.ExitCodeError(exitUsage, fmt.Errorf("--local-log is required for local anchor verification"))
+	}
+	keyHexes, err := resolveSignerKeys(opts.signerKeys)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("resolve signer key: %w", err))
+	}
+	receipts, err := independentReceipts(target, opts)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", err))
+	}
+	bundle, err := anchor.LoadBundle(opts.bundlePath)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+	}
+	report := anchor.VerifyBundle(bundle, receipts, keyHexes, anchor.LocalLog{
+		Path:  opts.logPath,
+		LogID: opts.logID,
+	})
+	emitIndependentReport(stdout, stderr, filepath.Clean(target), report, opts.jsonOutput)
+	if !report.Valid {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("independent verification failed: %s", report.Error))
+	}
+	return nil
+}
+
+func independentReceipts(target string, opts independentOptions) ([]receipt.Receipt, error) {
+	if opts.asDir {
+		return receipt.ExtractReceiptsFromSessionDir(target, opts.sessionID)
+	}
+	return receipt.ExtractReceipts(target)
+}
+
+func resolveSignerKeys(inputs []string) ([]string, error) {
+	out := make([]string, 0, len(inputs))
+	for _, input := range inputs {
+		keyHex, err := resolveSignerKey(input)
+		if err != nil {
+			return nil, err
+		}
+		if keyHex != "" {
+			out = append(out, keyHex)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("at least one non-empty --key is required")
+	}
+	return out, nil
+}
+
+func emitIndependentReport(stdout, stderr io.Writer, path string, report anchor.VerifyReport, jsonMode bool) {
+	if jsonMode {
+		writeJSON(stdout, report)
+		return
+	}
+	if report.Valid {
+		_, _ = fmt.Fprintf(stdout, "INDEPENDENT VERIFY OK: %s\n", path)
+		_, _ = fmt.Fprintf(stdout, "  Backend:       %s\n", report.Backend)
+		_, _ = fmt.Fprintf(stdout, "  Session:       %s\n", report.SessionID)
+		_, _ = fmt.Fprintf(stdout, "  Receipts:      %d\n", report.ReceiptCount)
+		_, _ = fmt.Fprintf(stdout, "  Final seq:     %d\n", report.FinalSeq)
+		_, _ = fmt.Fprintf(stdout, "  Root hash:     %s\n", report.RootHash)
+		_, _ = fmt.Fprintf(stdout, "  Log index:     %d\n", report.Proof.LogIndex)
+		for _, limit := range report.Limits {
+			_, _ = fmt.Fprintf(stdout, "  Limit:         %s\n", limit)
+		}
+		return
+	}
+	_, _ = fmt.Fprintf(stderr, "INDEPENDENT VERIFY FAILED: %s\n", path)
+	if report.Error != "" {
+		_, _ = fmt.Fprintf(stderr, "  error: %s\n", report.Error)
+	}
+}

--- a/cmd/pipelock-verifier/main.go
+++ b/cmd/pipelock-verifier/main.go
@@ -69,6 +69,7 @@ CI runner, an auditor's laptop, or an isolated environment.`,
 
 	root.AddCommand(newAuditPacketCmd())
 	root.AddCommand(newChainCmd())
+	root.AddCommand(newIndependentCmd())
 	root.AddCommand(newReceiptCmd())
 	root.AddCommand(newReplayCmd())
 	root.AddCommand(newAARPCmd())

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -676,6 +676,74 @@ func TestIndependent_ResolveSignerKeysAcceptsRepeatedKeys(t *testing.T) {
 	}
 }
 
+func TestIndependent_DirModeUsesSessionReceipts(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T14:00:00Z")
+	fix := newFixture(t, 3)
+	evidence, bundle, logPath := writeIndependentFixture(t, fix)
+	dir := filepath.Dir(evidence)
+	moveIndependentEvidenceToSessionFile(t, evidence)
+
+	stdout, stderr, code := runRoot(t, "independent", dir,
+		"--dir",
+		"--session", "proxy",
+		"--bundle", bundle,
+		"--key", fix.keyHex,
+		"--local-log", logPath,
+		"--log-id", "verifier-test-log",
+	)
+	if code != cliutil.ExitOK {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "INDEPENDENT VERIFY OK") {
+		t.Fatalf("stdout missing success marker:\n%s", stdout)
+	}
+}
+
+func TestIndependent_DirModeRejectsUnknownSession(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T14:00:00Z")
+	fix := newFixture(t, 3)
+	evidence, bundle, logPath := writeIndependentFixture(t, fix)
+	dir := filepath.Dir(evidence)
+	moveIndependentEvidenceToSessionFile(t, evidence)
+
+	_, stderr, code := runRoot(t, "independent", dir,
+		"--dir",
+		"--session", "missing",
+		"--bundle", bundle,
+		"--key", fix.keyHex,
+		"--local-log", logPath,
+		"--log-id", "verifier-test-log",
+	)
+	if code == cliutil.ExitOK {
+		t.Fatalf("expected failure, stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "empty receipt chain") {
+		t.Fatalf("stderr = %q, want empty-chain failure", stderr)
+	}
+}
+
+func TestIndependent_DirModeRejectsMalformedSessionFile(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T14:00:00Z")
+	fix := newFixture(t, 3)
+	evidence, bundle, logPath := writeIndependentFixture(t, fix)
+	sessionPath := moveIndependentEvidenceToSessionFile(t, evidence)
+	if err := os.WriteFile(sessionPath, []byte("{not json\n"), 0o600); err != nil {
+		t.Fatalf("write malformed evidence: %v", err)
+	}
+
+	_, stderr, code := runRoot(t, "independent", filepath.Dir(sessionPath),
+		"--dir",
+		"--session", "proxy",
+		"--bundle", bundle,
+		"--key", fix.keyHex,
+		"--local-log", logPath,
+		"--log-id", "verifier-test-log",
+	)
+	if code == cliutil.ExitOK {
+		t.Fatalf("expected failure, stderr=%q", stderr)
+	}
+}
+
 func TestChain_ActionWithoutKeyFailsUnpinned(t *testing.T) {
 	t.Parallel()
 	fix := newFixture(t, 2)
@@ -715,6 +783,15 @@ func writeIndependentFixture(t *testing.T, fix *fixture) (evidencePath, bundlePa
 		t.Fatalf("WriteBundle: %v", err)
 	}
 	return evidencePath, bundlePath, logPath
+}
+
+func moveIndependentEvidenceToSessionFile(t *testing.T, evidencePath string) string {
+	t.Helper()
+	sessionPath := filepath.Join(filepath.Dir(evidencePath), "evidence-proxy-0.jsonl")
+	if err := os.Rename(evidencePath, sessionPath); err != nil {
+		t.Fatalf("rename evidence: %v", err)
+	}
+	return sessionPath
 }
 
 func TestChain_ActionAllowUnpinned(t *testing.T) {

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	anchorpkg "github.com/luckyPipewrench/pipelock/internal/anchor"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
@@ -609,6 +610,72 @@ func TestChain_Valid(t *testing.T) {
 	}
 }
 
+func TestIndependent_ValidLocalAnchor(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T14:00:00Z")
+	fix := newFixture(t, 3)
+	evidence, bundle, logPath := writeIndependentFixture(t, fix)
+
+	stdout, stderr, code := runRoot(t, "independent", evidence,
+		"--bundle", bundle,
+		"--key", fix.keyHex,
+		"--local-log", logPath,
+		"--log-id", "verifier-test-log",
+	)
+	if code != cliutil.ExitOK {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "INDEPENDENT VERIFY OK") {
+		t.Fatalf("stdout missing success marker:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "does not prove real-time truth") {
+		t.Fatalf("stdout missing honest limit:\n%s", stdout)
+	}
+}
+
+func TestIndependent_RejectsRewrittenBundleCheckpoint(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T14:00:00Z")
+	fix := newFixture(t, 2)
+	evidence, bundlePath, logPath := writeIndependentFixture(t, fix)
+	bundle, err := anchorpkg.LoadBundle(bundlePath)
+	if err != nil {
+		t.Fatalf("LoadBundle: %v", err)
+	}
+	bundle.Checkpoint.RootHash = strings.Repeat("0", 64)
+	if err := anchorpkg.WriteBundle(bundlePath, bundle); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+
+	_, stderr, code := runRoot(t, "independent", evidence,
+		"--bundle", bundlePath,
+		"--key", fix.keyHex,
+		"--local-log", logPath,
+		"--log-id", "verifier-test-log",
+	)
+	if code == cliutil.ExitOK {
+		t.Fatalf("rewritten bundle checkpoint passed, stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "checkpoint does not match") {
+		t.Fatalf("stderr = %q, want checkpoint mismatch", stderr)
+	}
+}
+
+func TestIndependent_ResolveSignerKeysAcceptsRepeatedKeys(t *testing.T) {
+	t.Parallel()
+
+	keyA := strings.Repeat("a", 64)
+	keyB := strings.Repeat("b", 64)
+	keys, err := resolveSignerKeys([]string{keyA, keyB})
+	if err != nil {
+		t.Fatalf("resolveSignerKeys: %v", err)
+	}
+	if len(keys) != 2 || keys[0] != keyA || keys[1] != keyB {
+		t.Fatalf("keys = %#v, want [%s %s]", keys, keyA, keyB)
+	}
+	if _, err := resolveSignerKeys([]string{"  "}); err == nil {
+		t.Fatal("blank repeated key set should fail")
+	}
+}
+
 func TestChain_ActionWithoutKeyFailsUnpinned(t *testing.T) {
 	t.Parallel()
 	fix := newFixture(t, 2)
@@ -626,6 +693,28 @@ func TestChain_ActionWithoutKeyFailsUnpinned(t *testing.T) {
 	if !strings.Contains(stderr, unpinnedReceiptBanner) {
 		t.Fatalf("stderr = %q, want unpinned warning", stderr)
 	}
+}
+
+func writeIndependentFixture(t *testing.T, fix *fixture) (evidencePath, bundlePath, logPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	evidencePath = filepath.Join(dir, "evidence.jsonl")
+	checkpoint, err := anchorpkg.BuildCheckpoint("proxy", fix.receipts, []string{fix.keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	logPath = filepath.Join(dir, "anchor.jsonl")
+	log := anchorpkg.LocalLog{Path: logPath, LogID: "verifier-test-log"}
+	proof, err := log.Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	bundlePath = filepath.Join(dir, "anchor-bundle.json")
+	if err := anchorpkg.WriteBundle(bundlePath, anchorpkg.NewBundle(checkpoint, proof)); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	return evidencePath, bundlePath, logPath
 }
 
 func TestChain_ActionAllowUnpinned(t *testing.T) {

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -731,16 +731,22 @@ func TestIndependent_DirModeRejectsMalformedSessionFile(t *testing.T) {
 		t.Fatalf("write malformed evidence: %v", err)
 	}
 
-	_, stderr, code := runRoot(t, "independent", filepath.Dir(sessionPath),
-		"--dir",
-		"--session", "proxy",
-		"--bundle", bundle,
-		"--key", fix.keyHex,
-		"--local-log", logPath,
-		"--log-id", "verifier-test-log",
-	)
-	if code == cliutil.ExitOK {
-		t.Fatalf("expected failure, stderr=%q", stderr)
+	var stdout, stderr bytes.Buffer
+	err := runIndependent(&stdout, &stderr, filepath.Dir(sessionPath), independentOptions{
+		bundlePath: bundle,
+		signerKeys: []string{
+			fix.keyHex,
+		},
+		logPath:   logPath,
+		logID:     "verifier-test-log",
+		sessionID: "proxy",
+		asDir:     true,
+	})
+	if err == nil {
+		t.Fatalf("expected failure, stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(err.Error(), "invalid character") {
+		t.Fatalf("err = %v, want JSON decode failure", err)
 	}
 }
 

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -1,0 +1,225 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package anchor records and verifies external receipt-chain checkpoints.
+package anchor
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+const (
+	BundleVersion     = 1
+	LocalBackend      = "local"
+	DefaultLocalLogID = "local-fake-log"
+	GenesisHash       = "genesis"
+
+	dirPermissions  = 0o750
+	filePermissions = 0o600
+)
+
+var DefaultLimits = []string{
+	"External anchoring detects after-the-fact rewrite, delete, omit, and equivocation against the anchored checkpoint.",
+	"External anchoring does not prove real-time truth by whoever held the receipt signing key.",
+	"The local backend is a deterministic test backend, not an operator-independent witness.",
+}
+
+type Backend interface {
+	Submit(Checkpoint) (Proof, error)
+	Verify(Proof, Checkpoint) error
+}
+
+type Checkpoint struct {
+	SessionID    string    `json:"session_id"`
+	FinalSeq     uint64    `json:"final_seq"`
+	RootHash     string    `json:"root_hash"`
+	ReceiptCount uint64    `json:"receipt_count"`
+	StartTime    time.Time `json:"start_time"`
+	EndTime      time.Time `json:"end_time"`
+	SignerKeys   []string  `json:"signer_keys"`
+}
+
+type Proof struct {
+	Backend     string `json:"backend"`
+	LogID       string `json:"log_id"`
+	LogIndex    uint64 `json:"log_index"`
+	EntryHash   string `json:"entry_hash"`
+	LogRootHash string `json:"log_root_hash"`
+}
+
+type Bundle struct {
+	Version    int        `json:"version"`
+	Backend    string     `json:"backend"`
+	CreatedAt  time.Time  `json:"created_at"`
+	Checkpoint Checkpoint `json:"checkpoint"`
+	Proof      Proof      `json:"proof"`
+	Limits     []string   `json:"limits"`
+}
+
+type VerifyReport struct {
+	Valid        bool       `json:"valid"`
+	Backend      string     `json:"backend,omitempty"`
+	SessionID    string     `json:"session_id,omitempty"`
+	ReceiptCount uint64     `json:"receipt_count,omitempty"`
+	FinalSeq     uint64     `json:"final_seq,omitempty"`
+	RootHash     string     `json:"root_hash,omitempty"`
+	Proof        Proof      `json:"proof,omitempty"`
+	Limits       []string   `json:"limits,omitempty"`
+	Error        string     `json:"error,omitempty"`
+	Checkpoint   Checkpoint `json:"checkpoint,omitempty"`
+}
+
+func BuildCheckpoint(sessionID string, receipts []receipt.Receipt, trustedKeys []string) (Checkpoint, error) {
+	if len(receipts) == 0 {
+		return Checkpoint{}, errors.New("empty receipt chain")
+	}
+	result := receipt.VerifyChainTrusted(receipts, trustedKeys)
+	if !result.Valid {
+		return Checkpoint{}, fmt.Errorf("invalid receipt chain: %s", result.Error)
+	}
+	if len(trustedKeys) == 0 {
+		return Checkpoint{}, errors.New("trust anchor required: pass at least one trusted signer key")
+	}
+	root, err := receipt.ComputeTranscriptRootTrusted(sessionID, receipts, trustedKeys)
+	if err != nil {
+		return Checkpoint{}, err
+	}
+	return Checkpoint{
+		SessionID:    root.SessionID,
+		FinalSeq:     root.FinalSeq,
+		RootHash:     root.RootHash,
+		ReceiptCount: root.ReceiptCount,
+		StartTime:    root.StartTime,
+		EndTime:      root.EndTime,
+		SignerKeys:   append([]string(nil), result.SignerKeys...),
+	}, nil
+}
+
+func NewBundle(checkpoint Checkpoint, proof Proof) Bundle {
+	return Bundle{
+		Version:    BundleVersion,
+		Backend:    proof.Backend,
+		CreatedAt:  time.Now().UTC(),
+		Checkpoint: checkpoint,
+		Proof:      proof,
+		Limits:     append([]string(nil), DefaultLimits...),
+	}
+}
+
+func VerifyBundle(b Bundle, receipts []receipt.Receipt, trustedKeys []string, backend Backend) VerifyReport {
+	report := VerifyReport{
+		Valid:      false,
+		Backend:    b.Backend,
+		Proof:      b.Proof,
+		Limits:     append([]string(nil), b.Limits...),
+		Checkpoint: b.Checkpoint,
+	}
+	if b.Version != BundleVersion {
+		report.Error = fmt.Sprintf("unsupported anchor bundle version %d", b.Version)
+		return report
+	}
+	if backend == nil {
+		report.Error = "anchor backend required"
+		return report
+	}
+	computed, err := BuildCheckpoint(b.Checkpoint.SessionID, receipts, trustedKeys)
+	if err != nil {
+		report.Error = err.Error()
+		return report
+	}
+	if !checkpointsEqual(computed, b.Checkpoint) {
+		report.Error = "receipt chain checkpoint does not match anchor bundle"
+		return report
+	}
+	if err := backend.Verify(b.Proof, b.Checkpoint); err != nil {
+		report.Error = err.Error()
+		return report
+	}
+	report.Valid = true
+	report.SessionID = computed.SessionID
+	report.ReceiptCount = computed.ReceiptCount
+	report.FinalSeq = computed.FinalSeq
+	report.RootHash = computed.RootHash
+	return report
+}
+
+func LoadBundle(path string) (Bundle, error) {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return Bundle{}, fmt.Errorf("read anchor bundle: %w", err)
+	}
+	var b Bundle
+	if err := decodeStrict(data, &b); err != nil {
+		return Bundle{}, fmt.Errorf("parse anchor bundle: %w", err)
+	}
+	return b, nil
+}
+
+func WriteBundle(path string, b Bundle) error {
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal anchor bundle: %w", err)
+	}
+	clean := filepath.Clean(path)
+	if err := os.MkdirAll(filepath.Dir(clean), dirPermissions); err != nil {
+		return fmt.Errorf("create anchor bundle directory: %w", err)
+	}
+	if err := os.WriteFile(clean, append(data, '\n'), filePermissions); err != nil {
+		return fmt.Errorf("write anchor bundle: %w", err)
+	}
+	return nil
+}
+
+func checkpointsEqual(a, b Checkpoint) bool {
+	if a.SessionID != b.SessionID ||
+		a.FinalSeq != b.FinalSeq ||
+		a.RootHash != b.RootHash ||
+		a.ReceiptCount != b.ReceiptCount ||
+		!a.StartTime.Equal(b.StartTime) ||
+		!a.EndTime.Equal(b.EndTime) ||
+		len(a.SignerKeys) != len(b.SignerKeys) {
+		return false
+	}
+	for i := range a.SignerKeys {
+		if a.SignerKeys[i] != b.SignerKeys[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func decodeStrict(data []byte, dst any) error {
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		return err
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	var extra any
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("unexpected trailing JSON")
+		}
+		return errors.New("unexpected trailing JSON")
+	}
+	return nil
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -94,7 +94,7 @@ func BuildCheckpoint(sessionID string, receipts []receipt.Receipt, trustedKeys [
 	}
 	root, err := receipt.ComputeTranscriptRootTrusted(sessionID, receipts, trustedKeys)
 	if err != nil {
-		return Checkpoint{}, err
+		return Checkpoint{}, fmt.Errorf("compute transcript root: %w", err)
 	}
 	return Checkpoint{
 		SessionID:    root.SessionID,
@@ -121,13 +121,16 @@ func NewBundle(checkpoint Checkpoint, proof Proof) Bundle {
 func VerifyBundle(b Bundle, receipts []receipt.Receipt, trustedKeys []string, backend Backend) VerifyReport {
 	report := VerifyReport{
 		Valid:      false,
-		Backend:    b.Backend,
 		Proof:      b.Proof,
-		Limits:     append([]string(nil), b.Limits...),
+		Limits:     append([]string(nil), DefaultLimits...),
 		Checkpoint: b.Checkpoint,
 	}
 	if b.Version != BundleVersion {
 		report.Error = fmt.Sprintf("unsupported anchor bundle version %d", b.Version)
+		return report
+	}
+	if b.Backend != b.Proof.Backend {
+		report.Error = fmt.Sprintf("anchor bundle backend %q does not match proof backend %q", b.Backend, b.Proof.Backend)
 		return report
 	}
 	if backend == nil {
@@ -148,6 +151,7 @@ func VerifyBundle(b Bundle, receipts []receipt.Receipt, trustedKeys []string, ba
 		return report
 	}
 	report.Valid = true
+	report.Backend = b.Proof.Backend
 	report.SessionID = computed.SessionID
 	report.ReceiptCount = computed.ReceiptCount
 	report.FinalSeq = computed.FinalSeq
@@ -211,9 +215,6 @@ func decodeStrict(data []byte, dst any) error {
 	}
 	var extra any
 	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
-		if err == nil {
-			return errors.New("unexpected trailing JSON")
-		}
 		return errors.New("unexpected trailing JSON")
 	}
 	return nil

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -95,6 +96,65 @@ func TestVerifyBundleDetectsReceiptRewrite(t *testing.T) {
 	}
 }
 
+func TestVerifyBundleRejectsBackendMismatch(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+	proof, err := log.Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	bundle := NewBundle(checkpoint, proof)
+	bundle.Backend = "rekor-prod-transparency-log"
+
+	report := VerifyBundle(bundle, receipts, []string{keyHex}, log)
+	if report.Valid {
+		t.Fatalf("forged backend label produced a valid report: %+v", report)
+	}
+	if report.Backend != "" {
+		t.Fatalf("report.Backend = %q, want empty unverified backend", report.Backend)
+	}
+	if !strings.Contains(report.Error, "does not match proof backend") {
+		t.Fatalf("report.Error = %q, want backend mismatch", report.Error)
+	}
+}
+
+func TestVerifyBundleReportLimitsAreCanonical(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+	proof, err := log.Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	bundle := NewBundle(checkpoint, proof)
+	bundle.Limits = []string{"operator-independent witness PROVEN"}
+
+	report := VerifyBundle(bundle, receipts, []string{keyHex}, log)
+	if !report.Valid {
+		t.Fatalf("VerifyBundle invalid: %s", report.Error)
+	}
+	if report.Backend != LocalBackend {
+		t.Fatalf("report.Backend = %q, want %q", report.Backend, LocalBackend)
+	}
+	if len(report.Limits) != len(DefaultLimits) {
+		t.Fatalf("report.Limits = %v, want DefaultLimits", report.Limits)
+	}
+	for i := range DefaultLimits {
+		if report.Limits[i] != DefaultLimits[i] {
+			t.Fatalf("report.Limits[%d] = %q, want %q", i, report.Limits[i], DefaultLimits[i])
+		}
+	}
+}
+
 func TestVerifyBundleDetectsLocalLogRewrite(t *testing.T) {
 	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
 	receipts, keyHex := testReceiptChain(t, 1)
@@ -122,5 +182,89 @@ func TestVerifyBundleDetectsLocalLogRewrite(t *testing.T) {
 	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, log)
 	if report.Valid || !strings.Contains(report.Error, "hash mismatch") {
 		t.Fatalf("rewritten log report = %+v, want hash mismatch", report)
+	}
+}
+
+func TestLocalLogSubmitRejectsMixedExistingLogID(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+	for range 2 {
+		if _, err := log.Submit(checkpoint); err != nil {
+			t.Fatalf("Submit: %v", err)
+		}
+	}
+	entries, err := ReadLocalLog(log.Path)
+	if err != nil {
+		t.Fatalf("ReadLocalLog: %v", err)
+	}
+	entries[1].LogID = "other-log"
+	entries[1].Hash = localEntryHash(entries[1])
+	writeLocalLogEntries(t, log.Path, entries)
+
+	_, err = log.Submit(checkpoint)
+	if err == nil || !strings.Contains(err.Error(), "log_id mismatch at index 1") {
+		t.Fatalf("Submit err = %v, want mixed log_id rejection", err)
+	}
+}
+
+func TestLocalLogSubmitSerializesConcurrentAppends(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 3)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+
+	const submits = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, submits)
+	for range submits {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := log.Submit(checkpoint)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Submit: %v", err)
+		}
+	}
+	entries, err := ReadLocalLog(log.Path)
+	if err != nil {
+		t.Fatalf("ReadLocalLog: %v", err)
+	}
+	if len(entries) != submits {
+		t.Fatalf("len(entries) = %d, want %d", len(entries), submits)
+	}
+	for i, entry := range entries {
+		if entry.Index != uint64(i) {
+			t.Fatalf("entries[%d].Index = %d", i, entry.Index)
+		}
+	}
+}
+
+func writeLocalLogEntries(t *testing.T, path string, entries []LocalLogEntry) {
+	t.Helper()
+	var lines []byte
+	for _, entry := range entries {
+		data, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		lines = append(lines, data...)
+		lines = append(lines, '\n')
+	}
+	if err := os.WriteFile(path, lines, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 }

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -113,6 +113,23 @@ func TestBundleFileRoundTrip(t *testing.T) {
 	if loaded.Backend != LocalBackend || !checkpointsEqual(loaded.Checkpoint, checkpoint) {
 		t.Fatalf("loaded bundle = %+v", loaded)
 	}
+	if loaded.Version != bundle.Version {
+		t.Fatalf("loaded.Version = %d, want %d", loaded.Version, bundle.Version)
+	}
+	if loaded.Proof != bundle.Proof {
+		t.Fatalf("loaded.Proof = %+v, want %+v", loaded.Proof, bundle.Proof)
+	}
+	if !loaded.CreatedAt.Equal(bundle.CreatedAt) {
+		t.Fatalf("loaded.CreatedAt = %s, want %s", loaded.CreatedAt, bundle.CreatedAt)
+	}
+	if len(loaded.Limits) != len(bundle.Limits) {
+		t.Fatalf("loaded.Limits = %v, want %v", loaded.Limits, bundle.Limits)
+	}
+	for i := range bundle.Limits {
+		if loaded.Limits[i] != bundle.Limits[i] {
+			t.Fatalf("loaded.Limits[%d] = %q, want %q", i, loaded.Limits[i], bundle.Limits[i])
+		}
+	}
 }
 
 func TestLoadBundleRejectsStrictJSONViolations(t *testing.T) {

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package anchor
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+func testReceiptChain(t *testing.T, n int) ([]receipt.Receipt, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	prev := receipt.GenesisHash
+	base := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	receipts := make([]receipt.Receipt, 0, n)
+	for i := range n {
+		ar := receipt.ActionRecord{
+			Version:       receipt.ActionRecordVersion,
+			ActionID:      receipt.NewActionID(),
+			ActionType:    receipt.ActionRead,
+			Timestamp:     base.Add(time.Duration(i) * time.Second),
+			Target:        "https://example.test/resource",
+			Verdict:       config.ActionAllow,
+			Transport:     "fetch",
+			ChainPrevHash: prev,
+			ChainSeq:      uint64(i),
+			PolicyHash:    "policy-test",
+		}
+		r, err := receipt.Sign(ar, priv)
+		if err != nil {
+			t.Fatalf("Sign[%d]: %v", i, err)
+		}
+		h, err := receipt.ReceiptHash(r)
+		if err != nil {
+			t.Fatalf("ReceiptHash[%d]: %v", i, err)
+		}
+		prev = h
+		receipts = append(receipts, r)
+	}
+	return receipts, hex.EncodeToString(pub)
+}
+
+func TestLocalLogBundleVerify(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+	proof, err := log.Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, log)
+	if !report.Valid {
+		t.Fatalf("VerifyBundle invalid: %s", report.Error)
+	}
+	if report.RootHash != checkpoint.RootHash || report.Proof.EntryHash == "" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestVerifyBundleDetectsReceiptRewrite(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+	proof, err := log.Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	tampered := append([]receipt.Receipt(nil), receipts...)
+	tampered[1].ActionRecord.Target = "https://example.test/rewritten"
+	report := VerifyBundle(NewBundle(checkpoint, proof), tampered, []string{keyHex}, log)
+	if report.Valid || !strings.Contains(report.Error, "invalid receipt chain") {
+		t.Fatalf("tampered receipt report = %+v, want invalid chain", report)
+	}
+}
+
+func TestVerifyBundleDetectsLocalLogRewrite(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+	proof, err := log.Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	entries, err := ReadLocalLog(log.Path)
+	if err != nil {
+		t.Fatalf("ReadLocalLog: %v", err)
+	}
+	entries[0].Checkpoint.RootHash = strings.Repeat("0", 64)
+	data, err := json.Marshal(entries[0])
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(log.Path, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, log)
+	if report.Valid || !strings.Contains(report.Error, "hash mismatch") {
+		t.Fatalf("rewritten log report = %+v, want hash mismatch", report)
+	}
+}

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +19,18 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
+
+var errBackendVerify = errors.New("backend verification failed")
+
+type failingBackend struct{}
+
+func (failingBackend) Submit(Checkpoint) (Proof, error) {
+	return Proof{}, errBackendVerify
+}
+
+func (failingBackend) Verify(Proof, Checkpoint) error {
+	return errBackendVerify
+}
 
 func testReceiptChain(t *testing.T, n int) ([]receipt.Receipt, string) {
 	t.Helper()
@@ -73,6 +86,60 @@ func TestLocalLogBundleVerify(t *testing.T) {
 	}
 	if report.RootHash != checkpoint.RootHash || report.Proof.EntryHash == "" {
 		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestBundleFileRoundTrip(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+	proof, err := log.Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "nested", "bundle.json")
+	bundle := NewBundle(checkpoint, proof)
+	if err := WriteBundle(path, bundle); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	loaded, err := LoadBundle(path)
+	if err != nil {
+		t.Fatalf("LoadBundle: %v", err)
+	}
+	if loaded.Backend != LocalBackend || !checkpointsEqual(loaded.Checkpoint, checkpoint) {
+		t.Fatalf("loaded bundle = %+v", loaded)
+	}
+}
+
+func TestLoadBundleRejectsStrictJSONViolations(t *testing.T) {
+	for name, data := range map[string]string{
+		"duplicate": `{"version":1,"version":1}`,
+		"unknown":   `{"version":1,"backend":"local","created_at":"2026-06-28T12:00:00Z","checkpoint":{},"proof":{},"limits":[],"extra":true}`,
+		"trailing":  `{"version":1} {"version":1}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "bundle.json")
+			if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if _, err := LoadBundle(path); err == nil {
+				t.Fatal("LoadBundle err = nil, want strict JSON failure")
+			}
+		})
+	}
+}
+
+func TestBuildCheckpointRejectsTrustErrors(t *testing.T) {
+	if _, err := BuildCheckpoint("proxy", nil, []string{"key"}); err == nil || !strings.Contains(err.Error(), "empty receipt chain") {
+		t.Fatalf("empty BuildCheckpoint err = %v", err)
+	}
+	receipts, _ := testReceiptChain(t, 1)
+	if _, err := BuildCheckpoint("proxy", receipts, nil); err == nil || !strings.Contains(err.Error(), "trust anchor required") {
+		t.Fatalf("missing trust BuildCheckpoint err = %v", err)
 	}
 }
 
@@ -155,6 +222,38 @@ func TestVerifyBundleReportLimitsAreCanonical(t *testing.T) {
 	}
 }
 
+func TestVerifyBundleRejectsInvalidBundleAndBackendStates(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+	proof, err := log.Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	bundle := NewBundle(checkpoint, proof)
+
+	badVersion := bundle
+	badVersion.Version = 99
+	if report := VerifyBundle(badVersion, receipts, []string{keyHex}, log); report.Valid || !strings.Contains(report.Error, "unsupported") {
+		t.Fatalf("bad version report = %+v", report)
+	}
+	if report := VerifyBundle(bundle, receipts, []string{keyHex}, nil); report.Valid || !strings.Contains(report.Error, "backend required") {
+		t.Fatalf("nil backend report = %+v", report)
+	}
+	rewrittenCheckpoint := bundle
+	rewrittenCheckpoint.Checkpoint.RootHash = strings.Repeat("0", 64)
+	if report := VerifyBundle(rewrittenCheckpoint, receipts, []string{keyHex}, log); report.Valid || !strings.Contains(report.Error, "checkpoint does not match") {
+		t.Fatalf("checkpoint report = %+v", report)
+	}
+	if report := VerifyBundle(bundle, receipts, []string{keyHex}, failingBackend{}); report.Valid || !strings.Contains(report.Error, errBackendVerify.Error()) {
+		t.Fatalf("backend report = %+v", report)
+	}
+}
+
 func TestVerifyBundleDetectsLocalLogRewrite(t *testing.T) {
 	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
 	receipts, keyHex := testReceiptChain(t, 1)
@@ -185,6 +284,45 @@ func TestVerifyBundleDetectsLocalLogRewrite(t *testing.T) {
 	}
 }
 
+func TestLocalLogVerifyRejectsBadProofs(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+	proof, err := log.Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		proof Proof
+		want  string
+	}{
+		{name: "backend", proof: Proof{Backend: "rekor"}, want: "not"},
+		{name: "log id", proof: Proof{Backend: LocalBackend, LogID: "other"}, want: "log_id"},
+		{name: "index", proof: Proof{Backend: LocalBackend, LogID: "test-log", LogIndex: 99}, want: "outside local log length"},
+		{name: "entry hash", proof: Proof{Backend: LocalBackend, LogID: "test-log", EntryHash: "bad", LogRootHash: proof.LogRootHash}, want: "entry_hash"},
+		{name: "root hash", proof: Proof{Backend: LocalBackend, LogID: "test-log", EntryHash: proof.EntryHash, LogRootHash: "bad"}, want: "log_root_hash"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := log.Verify(tc.proof, checkpoint); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Verify err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	changed := checkpoint
+	changed.RootHash = strings.Repeat("f", 64)
+	if err := log.Verify(proof, changed); err == nil || !strings.Contains(err.Error(), "checkpoint does not match") {
+		t.Fatalf("Verify err = %v, want checkpoint mismatch", err)
+	}
+}
+
 func TestLocalLogSubmitRejectsMixedExistingLogID(t *testing.T) {
 	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
 	receipts, keyHex := testReceiptChain(t, 2)
@@ -209,6 +347,41 @@ func TestLocalLogSubmitRejectsMixedExistingLogID(t *testing.T) {
 	_, err = log.Submit(checkpoint)
 	if err == nil || !strings.Contains(err.Error(), "log_id mismatch at index 1") {
 		t.Fatalf("Submit err = %v, want mixed log_id rejection", err)
+	}
+}
+
+func TestReadLocalLogRejectsCorruptEntries(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T12:00:00Z")
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	log := LocalLog{Path: filepath.Join(t.TempDir(), "anchor.jsonl"), LogID: "test-log"}
+	if _, err := log.Submit(checkpoint); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	entries, err := ReadLocalLog(log.Path)
+	if err != nil {
+		t.Fatalf("ReadLocalLog: %v", err)
+	}
+
+	tests := map[string]func([]LocalLogEntry){
+		"version": func(in []LocalLogEntry) { in[0].Version = 99 },
+		"index":   func(in []LocalLogEntry) { in[0].Index = 3 },
+		"prev":    func(in []LocalLogEntry) { in[0].PrevHash = "bad" },
+		"hash":    func(in []LocalLogEntry) { in[0].Hash = "bad" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			copyEntries := append([]LocalLogEntry(nil), entries...)
+			mutate(copyEntries)
+			path := filepath.Join(t.TempDir(), "anchor.jsonl")
+			writeLocalLogEntries(t, path, copyEntries)
+			if _, err := ReadLocalLog(path); err == nil {
+				t.Fatal("ReadLocalLog err = nil, want corrupt entry failure")
+			}
+		})
 	}
 }
 
@@ -250,6 +423,16 @@ func TestLocalLogSubmitSerializesConcurrentAppends(t *testing.T) {
 		if entry.Index != uint64(i) {
 			t.Fatalf("entries[%d].Index = %d", i, entry.Index)
 		}
+	}
+}
+
+func TestLocalLogDefaults(t *testing.T) {
+	if got := (LocalLog{}).logID(); got != DefaultLocalLogID {
+		t.Fatalf("logID = %q, want %q", got, DefaultLocalLogID)
+	}
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "")
+	if got := nowString(); got == "" {
+		t.Fatal("nowString returned empty timestamp")
 	}
 }
 

--- a/internal/anchor/local.go
+++ b/internal/anchor/local.go
@@ -41,13 +41,21 @@ func (l LocalLog) Submit(checkpoint Checkpoint) (Proof, error) {
 	if l.Path == "" {
 		return Proof{}, errors.New("local anchor log path required")
 	}
+	unlock, err := acquireLocalLogLock(l.Path)
+	if err != nil {
+		return Proof{}, err
+	}
+	defer unlock()
+
 	logID := l.logID()
 	entries, err := ReadLocalLog(l.Path)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return Proof{}, err
 	}
-	if len(entries) > 0 && entries[0].LogID != logID {
-		return Proof{}, fmt.Errorf("local anchor log_id mismatch: got %q, want %q", entries[0].LogID, logID)
+	for _, entry := range entries {
+		if entry.LogID != logID {
+			return Proof{}, fmt.Errorf("local anchor log_id mismatch at index %d: got %q, want %q", entry.Index, entry.LogID, logID)
+		}
 	}
 	prevHash := GenesisHash
 	if len(entries) > 0 {

--- a/internal/anchor/local.go
+++ b/internal/anchor/local.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package anchor
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type LocalLog struct {
+	Path  string
+	LogID string
+}
+
+type LocalLogEntry struct {
+	Version    int        `json:"version"`
+	LogID      string     `json:"log_id"`
+	Index      uint64     `json:"index"`
+	Timestamp  string     `json:"timestamp"`
+	Checkpoint Checkpoint `json:"checkpoint"`
+	PrevHash   string     `json:"prev_hash"`
+	Hash       string     `json:"hash"`
+}
+
+type localLogEntryHashInput struct {
+	Version    int        `json:"version"`
+	LogID      string     `json:"log_id"`
+	Index      uint64     `json:"index"`
+	Timestamp  string     `json:"timestamp"`
+	Checkpoint Checkpoint `json:"checkpoint"`
+	PrevHash   string     `json:"prev_hash"`
+}
+
+func (l LocalLog) Submit(checkpoint Checkpoint) (Proof, error) {
+	if l.Path == "" {
+		return Proof{}, errors.New("local anchor log path required")
+	}
+	logID := l.logID()
+	entries, err := ReadLocalLog(l.Path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return Proof{}, err
+	}
+	if len(entries) > 0 && entries[0].LogID != logID {
+		return Proof{}, fmt.Errorf("local anchor log_id mismatch: got %q, want %q", entries[0].LogID, logID)
+	}
+	prevHash := GenesisHash
+	if len(entries) > 0 {
+		prevHash = entries[len(entries)-1].Hash
+	}
+	entry := LocalLogEntry{
+		Version:    BundleVersion,
+		LogID:      logID,
+		Index:      uint64(len(entries)),
+		Timestamp:  nowString(),
+		Checkpoint: checkpoint,
+		PrevHash:   prevHash,
+	}
+	entry.Hash = localEntryHash(entry)
+
+	clean := filepath.Clean(l.Path)
+	if err := os.MkdirAll(filepath.Dir(clean), dirPermissions); err != nil {
+		return Proof{}, fmt.Errorf("create local anchor log directory: %w", err)
+	}
+	f, err := os.OpenFile(clean, os.O_CREATE|os.O_WRONLY|os.O_APPEND, filePermissions)
+	if err != nil {
+		return Proof{}, fmt.Errorf("open local anchor log: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return Proof{}, fmt.Errorf("marshal local anchor entry: %w", err)
+	}
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return Proof{}, fmt.Errorf("write local anchor entry: %w", err)
+	}
+	return Proof{
+		Backend:     LocalBackend,
+		LogID:       logID,
+		LogIndex:    entry.Index,
+		EntryHash:   entry.Hash,
+		LogRootHash: entry.Hash,
+	}, nil
+}
+
+func (l LocalLog) Verify(proof Proof, checkpoint Checkpoint) error {
+	if proof.Backend != LocalBackend {
+		return fmt.Errorf("anchor proof backend %q is not %q", proof.Backend, LocalBackend)
+	}
+	if l.Path == "" {
+		return errors.New("local anchor log path required")
+	}
+	logID := l.logID()
+	if proof.LogID != logID {
+		return fmt.Errorf("anchor proof log_id %q does not match verifier log_id %q", proof.LogID, logID)
+	}
+	entries, err := ReadLocalLog(l.Path)
+	if err != nil {
+		return err
+	}
+	if proof.LogIndex >= uint64(len(entries)) {
+		return fmt.Errorf("anchor proof log_index %d outside local log length %d", proof.LogIndex, len(entries))
+	}
+	entry := entries[proof.LogIndex]
+	if entry.LogID != logID {
+		return fmt.Errorf("anchor log entry log_id %q does not match %q", entry.LogID, logID)
+	}
+	if entry.Hash != proof.EntryHash {
+		return fmt.Errorf("anchor proof entry_hash does not match local log entry")
+	}
+	if entry.Hash != proof.LogRootHash {
+		return fmt.Errorf("anchor proof log_root_hash does not match local log entry")
+	}
+	if !checkpointsEqual(entry.Checkpoint, checkpoint) {
+		return fmt.Errorf("anchor log checkpoint does not match bundle checkpoint")
+	}
+	return nil
+}
+
+func ReadLocalLog(path string) ([]LocalLogEntry, error) {
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64<<10), 10<<20)
+	var entries []LocalLogEntry
+	for sc.Scan() {
+		raw := sc.Bytes()
+		if len(raw) == 0 {
+			continue
+		}
+		var entry LocalLogEntry
+		if err := decodeStrict(raw, &entry); err != nil {
+			return nil, fmt.Errorf("parse local anchor log line %d: %w", len(entries)+1, err)
+		}
+		if err := verifyLocalEntry(entry, entries); err != nil {
+			return nil, fmt.Errorf("local anchor log line %d: %w", len(entries)+1, err)
+		}
+		entries = append(entries, entry)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("scan local anchor log: %w", err)
+	}
+	return entries, nil
+}
+
+func verifyLocalEntry(entry LocalLogEntry, prior []LocalLogEntry) error {
+	if entry.Version != BundleVersion {
+		return fmt.Errorf("unsupported version %d", entry.Version)
+	}
+	if entry.Index != uint64(len(prior)) {
+		return fmt.Errorf("index mismatch: got %d, want %d", entry.Index, len(prior))
+	}
+	wantPrev := GenesisHash
+	if len(prior) > 0 {
+		wantPrev = prior[len(prior)-1].Hash
+	}
+	if entry.PrevHash != wantPrev {
+		return fmt.Errorf("prev_hash mismatch")
+	}
+	if got := localEntryHash(entry); got != entry.Hash {
+		return fmt.Errorf("hash mismatch: computed %s, stored %s", got, entry.Hash)
+	}
+	return nil
+}
+
+func localEntryHash(entry LocalLogEntry) string {
+	data, err := json.Marshal(localLogEntryHashInput{
+		Version:    entry.Version,
+		LogID:      entry.LogID,
+		Index:      entry.Index,
+		Timestamp:  entry.Timestamp,
+		Checkpoint: entry.Checkpoint,
+		PrevHash:   entry.PrevHash,
+	})
+	if err != nil {
+		return ""
+	}
+	return sha256Hex(data)
+}
+
+func (l LocalLog) logID() string {
+	if l.LogID != "" {
+		return l.LogID
+	}
+	return DefaultLocalLogID
+}
+
+func nowString() string {
+	if fixed := os.Getenv("PIPELOCK_ANCHOR_TEST_NOW"); fixed != "" {
+		return fixed
+	}
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}

--- a/internal/anchor/local.go
+++ b/internal/anchor/local.go
@@ -43,7 +43,7 @@ func (l LocalLog) Submit(checkpoint Checkpoint) (Proof, error) {
 	}
 	unlock, err := acquireLocalLogLock(l.Path)
 	if err != nil {
-		return Proof{}, err
+		return Proof{}, fmt.Errorf("acquire local anchor log lock: %w", err)
 	}
 	defer unlock()
 

--- a/internal/anchor/local_lock_unix.go
+++ b/internal/anchor/local_lock_unix.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows && !js
+
+package anchor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func acquireLocalLogLock(logPath string) (func(), error) {
+	lockPath := filepath.Clean(logPath) + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), dirPermissions); err != nil {
+		return nil, fmt.Errorf("create local anchor log lock directory: %w", err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, filePermissions) // #nosec G304 -- lock path derives from operator-configured local anchor log path
+	if err != nil {
+		return nil, fmt.Errorf("open local anchor log lock: %w", err)
+	}
+	fd := int(f.Fd()) // #nosec G115 -- file descriptors fit in int
+	if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("acquire local anchor log lock: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(fd, syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/anchor/local_lock_windows.go
+++ b/internal/anchor/local_lock_windows.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package anchor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+const (
+	localLogErrSharingViolation = syscall.Errno(32)
+	localLogErrLockViolation    = syscall.Errno(33)
+
+	localLogLockTimeout = 2 * time.Second
+	localLogLockPoll    = 20 * time.Millisecond
+)
+
+func acquireLocalLogLock(logPath string) (func(), error) {
+	lockPath := filepath.Clean(logPath) + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), dirPermissions); err != nil {
+		return nil, fmt.Errorf("create local anchor log lock directory: %w", err)
+	}
+	pathp, err := syscall.UTF16PtrFromString(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("encode local anchor log lock path: %w", err)
+	}
+	deadline := time.Now().Add(localLogLockTimeout)
+	for {
+		handle, createErr := syscall.CreateFile(
+			pathp,
+			syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+			0,
+			nil,
+			syscall.OPEN_ALWAYS,
+			syscall.FILE_ATTRIBUTE_NORMAL,
+			0,
+		)
+		if createErr == nil {
+			f := os.NewFile(uintptr(handle), lockPath)
+			if f == nil {
+				_ = syscall.CloseHandle(handle)
+				return nil, fmt.Errorf("create local anchor log lock handle: %s", lockPath)
+			}
+			return func() { _ = f.Close() }, nil
+		}
+		if !errors.Is(createErr, localLogErrSharingViolation) &&
+			!errors.Is(createErr, localLogErrLockViolation) {
+			return nil, fmt.Errorf("open local anchor log lock: %w", createErr)
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("local anchor log locked by another process: %s", lockPath)
+		}
+		time.Sleep(localLogLockPoll)
+	}
+}

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -124,7 +124,7 @@ func extractReceipts(target string, opts receiptsOptions) ([]receipt.Receipt, st
 	}
 	receipts, extractErr := receipt.ExtractReceipts(target)
 	if extractErr != nil {
-		return nil, "", err
+		return nil, "", extractErr
 	}
 	return receipts, "file", nil
 }
@@ -134,7 +134,7 @@ func resolveTrustedKeys(keys []string) ([]string, error) {
 	for _, key := range keys {
 		key = strings.TrimSpace(key)
 		if key == "" {
-			continue
+			return nil, fmt.Errorf("resolve --key: public key is empty")
 		}
 		pub, err := sigutil.LoadPublicKey(key)
 		if err != nil {

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package anchor
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	anchorpkg "github.com/luckyPipewrench/pipelock/internal/anchor"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	sigutil "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+type receiptsOptions struct {
+	keys      []string
+	sessionID string
+	asDir     bool
+	logPath   string
+	logID     string
+	output    string
+}
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "anchor",
+		Short: "Anchor receipt-chain checkpoints",
+		Long: `Anchors verified receipt-chain checkpoints to an append-only backend.
+
+The local backend is a deterministic test backend. It exercises the same
+checkpoint and proof plumbing used by real external logs, but it is not an
+operator-independent witness.`,
+	}
+	cmd.AddCommand(receiptsCmd())
+	return cmd
+}
+
+func receiptsCmd() *cobra.Command {
+	var opts receiptsOptions
+	cmd := &cobra.Command{
+		Use:   "receipts PATH",
+		Short: "Anchor a verified receipt chain checkpoint",
+		Long: `Verifies a receipt chain with pinned signer keys, writes its chain head to
+an anchor backend, and emits an anchor bundle for independent verification.
+
+Honest limit: anchoring detects after-the-fact rewrite, delete, omit, and
+equivocation against the anchored checkpoint. It does not prove real-time truth
+by whoever held the receipt signing key. The local backend is for deterministic
+tests and development; a real outside witness backend must replace it before
+claiming operator-independent evidence.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReceipts(cmd.OutOrStdout(), args[0], opts)
+		},
+	}
+	cmd.Flags().StringArrayVar(&opts.keys, "key", nil, "trusted signer public key (hex or file path); repeat for rotated chains")
+	cmd.Flags().StringVar(&opts.sessionID, "session", "proxy", "session ID inside the evidence directory when --dir is set")
+	cmd.Flags().BoolVar(&opts.asDir, "dir", false, "treat PATH as a session directory rather than a single evidence file")
+	cmd.Flags().StringVar(&opts.logPath, "local-log", "", "local fake-log JSONL path (required for this backend)")
+	cmd.Flags().StringVar(&opts.logID, "log-id", anchorpkg.DefaultLocalLogID, "local fake-log identifier")
+	cmd.Flags().StringVar(&opts.output, "out", "", "anchor bundle output path")
+	return cmd
+}
+
+func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
+	trustedKeys, err := resolveTrustedKeys(opts.keys)
+	if err != nil {
+		return err
+	}
+	if len(trustedKeys) == 0 {
+		return fmt.Errorf("at least one --key is required to anchor a receipt chain")
+	}
+	if opts.logPath == "" {
+		return fmt.Errorf("--local-log is required for the local anchor backend")
+	}
+	if opts.output == "" {
+		return fmt.Errorf("--out is required")
+	}
+
+	receipts, sessionID, err := extractReceipts(target, opts)
+	if err != nil {
+		return err
+	}
+	checkpoint, err := anchorpkg.BuildCheckpoint(sessionID, receipts, trustedKeys)
+	if err != nil {
+		return err
+	}
+	proof, err := (anchorpkg.LocalLog{Path: opts.logPath, LogID: opts.logID}).Submit(checkpoint)
+	if err != nil {
+		return err
+	}
+	bundle := anchorpkg.NewBundle(checkpoint, proof)
+	if err := anchorpkg.WriteBundle(opts.output, bundle); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(out, "ANCHOR BUNDLE WRITTEN: %s\n", filepath.Clean(opts.output))
+	_, _ = fmt.Fprintf(out, "  Backend:       %s\n", proof.Backend)
+	_, _ = fmt.Fprintf(out, "  Log index:     %d\n", proof.LogIndex)
+	_, _ = fmt.Fprintf(out, "  Session:       %s\n", checkpoint.SessionID)
+	_, _ = fmt.Fprintf(out, "  Receipts:      %d\n", checkpoint.ReceiptCount)
+	_, _ = fmt.Fprintf(out, "  Final seq:     %d\n", checkpoint.FinalSeq)
+	_, _ = fmt.Fprintf(out, "  Root hash:     %s\n", checkpoint.RootHash)
+	_, _ = fmt.Fprintln(out, "  Limit:         local backend is not an operator-independent witness")
+	return nil
+}
+
+func extractReceipts(target string, opts receiptsOptions) ([]receipt.Receipt, string, error) {
+	if opts.asDir {
+		receipts, err := receipt.ExtractReceiptsFromSessionDir(target, opts.sessionID)
+		return receipts, opts.sessionID, err
+	}
+	receipts, sessionID, err := receipt.ExtractReceiptsWithSessionID(target)
+	if err == nil {
+		if sessionID == "" {
+			sessionID = "file"
+		}
+		return receipts, sessionID, nil
+	}
+	receipts, extractErr := receipt.ExtractReceipts(target)
+	if extractErr != nil {
+		return nil, "", err
+	}
+	return receipts, "file", nil
+}
+
+func resolveTrustedKeys(keys []string) ([]string, error) {
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		pub, err := sigutil.LoadPublicKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("resolve --key %q: %w", key, err)
+		}
+		out = append(out, hex.EncodeToString(pub))
+	}
+	return out, nil
+}

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -115,3 +115,23 @@ func TestReceiptsCmdRequiresPinnedKey(t *testing.T) {
 		t.Fatalf("Execute err = %v, want pinned-key error", err)
 	}
 }
+
+func TestReceiptsCmdRejectsBlankPinnedKey(t *testing.T) {
+	for _, key := range []string{"", "  "} {
+		t.Run("blank_"+strings.ReplaceAll(key, " ", "space"), func(t *testing.T) {
+			receiptsPath, keyHex := cliReceiptJSONL(t)
+			cmd := receiptsCmd()
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetArgs([]string{
+				receiptsPath,
+				"--key", key,
+				"--key", keyHex,
+				"--local-log", filepath.Join(t.TempDir(), "anchor.jsonl"),
+				"--out", filepath.Join(t.TempDir(), "bundle.json"),
+			})
+			if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "public key is empty") {
+				t.Fatalf("Execute err = %v, want blank-key error", err)
+			}
+		})
+	}
+}

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -102,6 +102,46 @@ func TestReceiptsCmdWritesLocalAnchorBundle(t *testing.T) {
 	}
 }
 
+func TestCmdRegistersReceiptsSubcommand(t *testing.T) {
+	cmd := Cmd()
+	if cmd.Use != "anchor" {
+		t.Fatalf("Use = %q, want anchor", cmd.Use)
+	}
+	if _, _, err := cmd.Find([]string{"receipts"}); err != nil {
+		t.Fatalf("Find receipts: %v", err)
+	}
+}
+
+func TestReceiptsCmdRequiresLocalLogAndOutput(t *testing.T) {
+	receiptsPath, keyHex := cliReceiptJSONL(t)
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "local log",
+			args: []string{receiptsPath, "--key", keyHex, "--out", filepath.Join(t.TempDir(), "bundle.json")},
+			want: "--local-log is required",
+		},
+		{
+			name: "output",
+			args: []string{receiptsPath, "--key", keyHex, "--local-log", filepath.Join(t.TempDir(), "anchor.jsonl")},
+			want: "--out is required",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := receiptsCmd()
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetArgs(tc.args)
+			if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Execute err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestReceiptsCmdRequiresPinnedKey(t *testing.T) {
 	receiptsPath, _ := cliReceiptJSONL(t)
 	cmd := receiptsCmd()

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package anchor
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	anchorpkg "github.com/luckyPipewrench/pipelock/internal/anchor"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+func cliReceiptJSONL(t *testing.T) (path string, keyHex string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	prev := receipt.GenesisHash
+	base := time.Date(2026, 6, 28, 13, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	for i := range 2 {
+		ar := receipt.ActionRecord{
+			Version:       receipt.ActionRecordVersion,
+			ActionID:      receipt.NewActionID(),
+			ActionType:    receipt.ActionRead,
+			Timestamp:     base.Add(time.Duration(i) * time.Second),
+			Target:        "https://example.test/resource",
+			Verdict:       config.ActionAllow,
+			Transport:     "fetch",
+			ChainPrevHash: prev,
+			ChainSeq:      uint64(i),
+			PolicyHash:    "policy-test",
+		}
+		r, err := receipt.Sign(ar, priv)
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		line, err := receipt.Marshal(r)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		_, _ = buf.Write(line)
+		_ = buf.WriteByte('\n')
+		prev, err = receipt.ReceiptHash(r)
+		if err != nil {
+			t.Fatalf("ReceiptHash: %v", err)
+		}
+	}
+	path = filepath.Join(t.TempDir(), "receipts.jsonl")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path, hex.EncodeToString(pub)
+}
+
+func TestReceiptsCmdWritesLocalAnchorBundle(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T13:00:00Z")
+	receiptsPath, keyHex := cliReceiptJSONL(t)
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "anchor.jsonl")
+	bundlePath := filepath.Join(dir, "bundle.json")
+
+	cmd := receiptsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{
+		receiptsPath,
+		"--key", keyHex,
+		"--local-log", logPath,
+		"--log-id", "cli-test-log",
+		"--out", bundlePath,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "ANCHOR BUNDLE WRITTEN") {
+		t.Fatalf("output missing success:\n%s", out.String())
+	}
+	bundle, err := anchorpkg.LoadBundle(bundlePath)
+	if err != nil {
+		t.Fatalf("LoadBundle: %v", err)
+	}
+	if bundle.Proof.Backend != anchorpkg.LocalBackend || bundle.Proof.LogIndex != 0 {
+		t.Fatalf("unexpected bundle proof: %+v", bundle.Proof)
+	}
+	entries, err := anchorpkg.ReadLocalLog(logPath)
+	if err != nil {
+		t.Fatalf("ReadLocalLog: %v", err)
+	}
+	if len(entries) != 1 || entries[0].LogID != "cli-test-log" {
+		t.Fatalf("unexpected log entries: %+v", entries)
+	}
+}
+
+func TestReceiptsCmdRequiresPinnedKey(t *testing.T) {
+	receiptsPath, _ := cliReceiptJSONL(t)
+	cmd := receiptsCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		receiptsPath,
+		"--local-log", filepath.Join(t.TempDir(), "anchor.jsonl"),
+		"--out", filepath.Join(t.TempDir(), "bundle.json"),
+	})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "at least one --key") {
+		t.Fatalf("Execute err = %v, want pinned-key error", err)
+	}
+}

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -135,3 +135,23 @@ func TestReceiptsCmdRejectsBlankPinnedKey(t *testing.T) {
 		})
 	}
 }
+
+func TestReceiptsCmdReturnsFallbackExtractionError(t *testing.T) {
+	_, keyHex := cliReceiptJSONL(t)
+	missingPath := filepath.Join(t.TempDir(), "missing.jsonl")
+	cmd := receiptsCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		missingPath,
+		"--key", keyHex,
+		"--local-log", filepath.Join(t.TempDir(), "anchor.jsonl"),
+		"--out", filepath.Join(t.TempDir(), "bundle.json"),
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute err = nil, want missing evidence error")
+	}
+	if !strings.Contains(err.Error(), "reading raw receipts") {
+		t.Fatalf("Execute err = %v, want fallback raw-receipt error", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,6 +9,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/cli/anchor"
 	"github.com/luckyPipewrench/pipelock/internal/cli/assess"
 	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
 	"github.com/luckyPipewrench/pipelock/internal/cli/canary"
@@ -74,6 +75,8 @@ Quick start:
 		"pipelock home directory (default ~/.pipelock, or set PIPELOCK_HOME)")
 
 	cmd.AddCommand(
+		// External receipt anchoring
+		anchor.Cmd(),
 		// Assess
 		assess.Cmd(),
 		// Policy capture/replay

--- a/internal/emit/syslog.go
+++ b/internal/emit/syslog.go
@@ -275,9 +275,9 @@ func (s *SyslogSink) Emit(_ context.Context, event Event) error {
 		s.closeMu.Unlock()
 		return errors.New(errSyslogClosed)
 	}
+	degraded := s.degraded.Load()
 	select {
 	case s.queue <- msg:
-		degraded := s.degraded.Load()
 		s.closeMu.Unlock()
 		if degraded {
 			return ErrSyslogDegraded


### PR DESCRIPTION
## Summary
- add a receipt anchoring package with a backend interface, anchor bundles, and a deterministic local fake-log backend
- add `pipelock anchor receipts` to checkpoint a pinned receipt chain into a local anchor log and write an anchor bundle
- add `pipelock-verifier independent` to verify receipt evidence against an anchor bundle and local inclusion proof

## Why
External anchoring is the next receipt-evidence foundation, but the verifier and artifact format need a deterministic local backend before wiring a real transparency log. This slice keeps the local backend explicit as a test/development backend and states that it does not prove real-time truth or operator-independent witnessing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **anchor receipts** command to generate and write receipt-based anchor bundles using a local anchor-log backend.
  * Added an **independent** command to verify anchored receipt-chain checkpoints with human-readable or JSON output, including session-directory evidence mode.
* **Bug Fixes**
  * Strengthened validation and verification reporting (blank/invalid keys, malformed session evidence, rewritten checkpoint roots, tampered receipts, corrupted local-log entries, and backend/proof consistency), plus canonical limit handling.
  * Improved syslog “degraded” status evaluation timing.
* **Tests**
  * Added deterministic end-to-end and edge-case coverage for anchoring, independent verification, strict bundle loading, and local-log submit/verify (including concurrency and log-ID consistency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->