### PR TITLE
fix: verify containment nft rules against current uids

### DIFF
--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1304,7 +1304,7 @@ func stepInstallNFTRules() step {
 			liveRulesDrifted := false
 			if out, code, _ := env.runCmd(ctx, nftExecutable(env), "list", "table", "inet", env.nftTableOrDefault()); code == 0 {
 				tableLoaded = true
-				liveRulesDrifted = !liveNFTContainmentMatches(out, env.nftChainOrDefault(), env.proxyPort)
+				liveRulesDrifted = !liveNFTContainmentMatches(out, env.nftChainOrDefault(), operatorUID, proxyUID, agentUID, env.proxyPort)
 			}
 
 			rulesChanged := false
@@ -1416,10 +1416,14 @@ func restorePreviousNFTState(ctx context.Context, env *installEnv) error {
 	return nil
 }
 
-func liveNFTContainmentMatches(out, chainName string, proxyPort int) bool {
-	return chainHasSkuidDrop(out, chainName) &&
-		chainHasAgentProxyLoopbackAllow(out, chainName, proxyPort) &&
-		!chainHasBroadLoopbackAccept(out, chainName)
+func liveNFTContainmentMatches(out, chainName string, operatorUID, proxyUID, agentUID, proxyPort int) bool {
+	return chainHasSkuidAcceptForUID(out, chainName, operatorUID) &&
+		chainHasSkuidAcceptForUID(out, chainName, proxyUID) &&
+		chainHasAgentCatchAllDrop(out, chainName, agentUID) &&
+		chainHasAgentProxyLoopbackAllow(out, chainName, agentUID, proxyPort) &&
+		chainHasAgentDNSDrop(out, chainName, agentUID, "udp") &&
+		chainHasAgentDNSDrop(out, chainName, agentUID, "tcp") &&
+		!chainHasBroadLoopbackAccept(out, chainName, agentUID)
 }
 
 func nftRulesIncludeLine(path string) string {

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -1254,7 +1254,7 @@ func TestStepInstallNFTRules_SkipsWhenLoaded(t *testing.T) {
 	// Pre-write the file so the body matches.
 	operatorUID, proxyUID, agentUID := 1000, 988, 987
 	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
-	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
@@ -1274,11 +1274,45 @@ func TestStepInstallNFTRules_SkipsWhenLoaded(t *testing.T) {
 	}
 }
 
+func TestStepInstallNFTRules_SkipsWhenLoadedForRootOperator(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	env.lookupUser = func(name string) (*user.User, error) {
+		switch name {
+		case "pipelock-proxy":
+			return &user.User{Uid: "988", Gid: "988", Username: name, HomeDir: "/var/lib/pipelock-proxy"}, nil
+		case "pipelock-agent":
+			return &user.User{Uid: "987", Gid: "987", Username: name, HomeDir: "/home/pipelock-agent"}, nil
+		case containInstallOperatorUser:
+			return &user.User{Uid: "0", Gid: "0", Username: name, HomeDir: "/root"}, nil
+		default:
+			return nil, user.UnknownUserError(name)
+		}
+	}
+	body := renderNFTRules(0, 988, 987, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	writeNFTPersistUnitFixture(t, env)
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), body, 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied {
+		t.Errorf("expected skip when root-operator rules file matches and table is loaded")
+	}
+}
+
 func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	operatorUID, proxyUID, agentUID := 1000, 988, 987
 	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
-	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o755); err != nil { //nolint:gosec // tmpdir
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
 		t.Fatalf("mkdir rules parent: %v", err)
 	}
 	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
@@ -1315,6 +1349,43 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
 	}
 	if !sawDelete || !sawLoad {
 		t.Fatalf("expected delete+reload for live drift, got %v", runner.calls)
+	}
+}
+
+func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasStaleAgentUID(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	writeNFTPersistUnitFixture(t, env)
+	stale := renderNFTRules(operatorUID, proxyUID, 986, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), stale, 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected stale live agent uid to trigger rules reload")
+	}
+
+	var sawDelete, sawLoad bool
+	for _, c := range runner.calls {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+			sawDelete = true
+		}
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
+			sawLoad = true
+		}
+	}
+	if !sawDelete || !sawLoad {
+		t.Fatalf("expected delete+reload for stale uid, got %v", runner.calls)
 	}
 }
 

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -965,7 +965,7 @@ func chainHasSkuidAcceptForUID(out, chainName string, uid int) bool {
 func chainHasAgentProxyLoopbackAllow(out, chainName string, agentUID, port int) bool {
 	return chainHasLine(out, chainName, func(line string) bool {
 		return lineHasSkuid(line, agentUID) &&
-			strings.Contains(line, "ip daddr 127.0.0.1") &&
+			lineHasIPDAddr(line, "127.0.0.1") &&
 			lineHasToken(line, "tcp") &&
 			lineHasDPort(line, port) &&
 			lineHasToken(line, "accept")
@@ -974,10 +974,7 @@ func chainHasAgentProxyLoopbackAllow(out, chainName string, agentUID, port int) 
 
 func chainHasAgentDNSDrop(out, chainName string, agentUID int, protocol string) bool {
 	return chainHasLine(out, chainName, func(line string) bool {
-		return lineHasSkuid(line, agentUID) &&
-			lineHasToken(line, protocol) &&
-			lineHasDPort(line, 53) &&
-			lineHasToken(line, "drop")
+		return lineHasSkuidProtocolDPortVerdict(line, agentUID, protocol, 53, "drop")
 	})
 }
 
@@ -1004,28 +1001,54 @@ func lineHasSkuid(line string, uid int) bool {
 func lineHasTerminalSkuidVerdict(line string, uid int, verdict string) bool {
 	fields := strings.Fields(line)
 	uidText := strconv.Itoa(uid)
-	skuidAt := -1
-	for i := 0; i+1 < len(fields); i++ {
-		if fields[i] == "skuid" && fields[i+1] == uidText {
-			skuidAt = i + 1
-			break
-		}
-	}
+	skuidAt := indexSkuidUID(fields, uidText)
 	if skuidAt == -1 {
 		return false
 	}
-	verdictAt := -1
-	for i := skuidAt + 1; i < len(fields); i++ {
-		if fields[i] == verdict {
-			verdictAt = i
-			break
-		}
-	}
+	verdictAt := indexTokenAfter(fields, verdict, skuidAt+1)
 	if verdictAt == -1 {
 		return false
 	}
+	return fieldsAreNFTBookkeeping(fields[skuidAt+1 : verdictAt])
+}
+
+func lineHasSkuidProtocolDPortVerdict(line string, uid int, protocol string, port int, verdict string) bool {
+	fields := strings.Fields(line)
+	skuidAt := indexSkuidUID(fields, strconv.Itoa(uid))
+	if skuidAt == -1 || skuidAt+3 >= len(fields) {
+		return false
+	}
+	if fields[skuidAt+1] != protocol || fields[skuidAt+2] != "dport" || fields[skuidAt+3] != strconv.Itoa(port) {
+		return false
+	}
+	verdictAt := indexTokenAfter(fields, verdict, skuidAt+4)
+	if verdictAt == -1 {
+		return false
+	}
+	return fieldsAreNFTBookkeeping(fields[skuidAt+4 : verdictAt])
+}
+
+func indexSkuidUID(fields []string, uidText string) int {
+	for i := 0; i+1 < len(fields); i++ {
+		if fields[i] == "skuid" && fields[i+1] == uidText {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func indexTokenAfter(fields []string, want string, start int) int {
+	for i := start; i < len(fields); i++ {
+		if fields[i] == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func fieldsAreNFTBookkeeping(fields []string) bool {
 	inPrefix := false
-	for _, field := range fields[skuidAt+1 : verdictAt] {
+	for _, field := range fields {
 		if inPrefix {
 			if strings.HasSuffix(field, `"`) {
 				inPrefix = false
@@ -1042,6 +1065,16 @@ func lineHasTerminalSkuidVerdict(line string, uid int, verdict string) bool {
 		}
 	}
 	return !inPrefix
+}
+
+func lineHasIPDAddr(line, addr string) bool {
+	fields := strings.Fields(line)
+	for i := 0; i+2 < len(fields); i++ {
+		if fields[i] == "ip" && fields[i+1] == "daddr" && fields[i+2] == addr {
+			return true
+		}
+	}
+	return false
 }
 
 func lineHasDPort(line string, port int) bool {

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -836,6 +836,9 @@ func containmentUIDsFromProbeEnv(env *probeEnv) (containmentUIDs, error) {
 	}
 
 	current := containmentUIDs{proxyUID: proxyUID, agentUID: agentUID}
+	if proxyUID == agentUID {
+		return containmentUIDs{}, fmt.Errorf("%s and %s both resolve to uid %d; containment users must be distinct", env.proxyUserName, env.agentUserName, agentUID)
+	}
 	if env.nftRulesPath == "" {
 		return current, nil
 	}
@@ -858,6 +861,9 @@ func containmentUIDsFromProbeEnv(env *probeEnv) (containmentUIDs, error) {
 	}
 	if header.agentUID != agentUID {
 		return containmentUIDs{}, fmt.Errorf("nftables rules file agent uid %d does not match current %s uid %d", header.agentUID, env.agentUserName, agentUID)
+	}
+	if header.operatorUID == agentUID {
+		return containmentUIDs{}, fmt.Errorf("nftables rules file operator uid %d matches current %s uid; contained agent must not be allow-listed", header.operatorUID, env.agentUserName)
 	}
 	current.operatorUID = header.operatorUID
 	current.operatorKnown = true
@@ -946,33 +952,32 @@ func probeNFTExecutable(env *probeEnv) string {
 
 func chainHasAgentCatchAllDrop(out, chainName string, uid int) bool {
 	return chainHasLine(out, chainName, func(line string) bool {
-		return lineHasSkuid(line, uid) &&
-			strings.Contains(line, "drop") &&
-			!strings.Contains(line, " dport ")
+		return lineHasTerminalSkuidVerdict(line, uid, "drop")
 	})
 }
 
 func chainHasSkuidAcceptForUID(out, chainName string, uid int) bool {
 	return chainHasLine(out, chainName, func(line string) bool {
-		return lineHasSkuid(line, uid) && strings.Contains(line, "accept")
+		return lineHasTerminalSkuidVerdict(line, uid, "accept")
 	})
 }
 
 func chainHasAgentProxyLoopbackAllow(out, chainName string, agentUID, port int) bool {
-	portText := strconv.Itoa(port)
 	return chainHasLine(out, chainName, func(line string) bool {
 		return lineHasSkuid(line, agentUID) &&
 			strings.Contains(line, "ip daddr 127.0.0.1") &&
-			strings.Contains(line, "tcp dport "+portText) &&
-			strings.Contains(line, "accept")
+			lineHasToken(line, "tcp") &&
+			lineHasDPort(line, port) &&
+			lineHasToken(line, "accept")
 	})
 }
 
 func chainHasAgentDNSDrop(out, chainName string, agentUID int, protocol string) bool {
 	return chainHasLine(out, chainName, func(line string) bool {
 		return lineHasSkuid(line, agentUID) &&
-			strings.Contains(line, protocol+" dport 53") &&
-			strings.Contains(line, "drop")
+			lineHasToken(line, protocol) &&
+			lineHasDPort(line, 53) &&
+			lineHasToken(line, "drop")
 	})
 }
 
@@ -996,6 +1001,69 @@ func lineHasSkuid(line string, uid int) bool {
 	return false
 }
 
+func lineHasTerminalSkuidVerdict(line string, uid int, verdict string) bool {
+	fields := strings.Fields(line)
+	uidText := strconv.Itoa(uid)
+	skuidAt := -1
+	for i := 0; i+1 < len(fields); i++ {
+		if fields[i] == "skuid" && fields[i+1] == uidText {
+			skuidAt = i + 1
+			break
+		}
+	}
+	if skuidAt == -1 {
+		return false
+	}
+	verdictAt := -1
+	for i := skuidAt + 1; i < len(fields); i++ {
+		if fields[i] == verdict {
+			verdictAt = i
+			break
+		}
+	}
+	if verdictAt == -1 {
+		return false
+	}
+	inPrefix := false
+	for _, field := range fields[skuidAt+1 : verdictAt] {
+		if inPrefix {
+			if strings.HasSuffix(field, `"`) {
+				inPrefix = false
+			}
+			continue
+		}
+		switch field {
+		case "counter", "log":
+			continue
+		case "prefix":
+			inPrefix = true
+		default:
+			return false
+		}
+	}
+	return !inPrefix
+}
+
+func lineHasDPort(line string, port int) bool {
+	want := strconv.Itoa(port)
+	fields := strings.Fields(line)
+	for i, field := range fields {
+		if field == "dport" && i+1 < len(fields) && fields[i+1] == want {
+			return true
+		}
+	}
+	return false
+}
+
+func lineHasToken(line, want string) bool {
+	for _, field := range strings.Fields(line) {
+		if field == want {
+			return true
+		}
+	}
+	return false
+}
+
 func chainHasLineBeforeAgentDrop(out, chainName string, agentUID int, match func(string) bool) bool {
 	inChain := false
 	depth := 0
@@ -1013,7 +1081,7 @@ func chainHasLineBeforeAgentDrop(out, chainName string, agentUID int, match func
 		if strings.Contains(line, "{") {
 			depth += strings.Count(line, "{")
 		}
-		if lineHasSkuid(line, agentUID) && strings.Contains(line, "drop") && !strings.Contains(line, " dport ") {
+		if lineHasTerminalSkuidVerdict(line, agentUID, "drop") {
 			return false
 		}
 		if match(line) {

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -777,15 +777,30 @@ func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 	if !strings.Contains(out, "chain "+env.nftChain) {
 		return statusFail, fmt.Sprintf("chain %s missing from table", env.nftChain)
 	}
-	// The containment rule signature: a drop tied to an skuid match.
-	// We don't pin the exact UID since it varies per machine.
-	if !chainHasSkuidDrop(out, env.nftChain) {
-		return statusFail, "chain present but skuid-drop rule missing"
+
+	current, err := containmentUIDsFromProbeEnv(env)
+	if err != nil {
+		return statusFail, err.Error()
 	}
-	if !chainHasAgentProxyLoopbackAllow(out, env.nftChain, env.port) {
-		return statusFail, fmt.Sprintf("chain present but pipelock-agent loopback allow is not limited to 127.0.0.1:%d", env.port)
+	if current.operatorKnown && !chainHasSkuidAcceptForUID(out, env.nftChain, current.operatorUID) {
+		return statusFail, fmt.Sprintf("chain present but operator uid %d accept rule missing", current.operatorUID)
 	}
-	if chainHasBroadLoopbackAccept(out, env.nftChain) {
+	if !chainHasSkuidAcceptForUID(out, env.nftChain, current.proxyUID) {
+		return statusFail, fmt.Sprintf("chain present but proxy uid %d accept rule missing", current.proxyUID)
+	}
+	if !chainHasAgentCatchAllDrop(out, env.nftChain, current.agentUID) {
+		return statusFail, fmt.Sprintf("chain present but current agent uid %d catch-all skuid-drop rule missing", current.agentUID)
+	}
+	if !chainHasAgentProxyLoopbackAllow(out, env.nftChain, current.agentUID, env.port) {
+		return statusFail, fmt.Sprintf("chain present but current agent uid %d loopback allow is not limited to 127.0.0.1:%d", current.agentUID, env.port)
+	}
+	if !chainHasAgentDNSDrop(out, env.nftChain, current.agentUID, "udp") {
+		return statusFail, fmt.Sprintf("chain present but current agent uid %d udp/53 DNS drop rule missing", current.agentUID)
+	}
+	if !chainHasAgentDNSDrop(out, env.nftChain, current.agentUID, "tcp") {
+		return statusFail, fmt.Sprintf("chain present but current agent uid %d tcp/53 DNS drop rule missing", current.agentUID)
+	}
+	if chainHasBroadLoopbackAccept(out, env.nftChain, current.agentUID) {
 		return statusFail, "chain contains broad loopback accept before agent drop"
 	}
 	if env.nftPersistUnitPath != "" && env.nftRulesPath != "" {
@@ -793,8 +808,111 @@ func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 			return statusFail, err.Error()
 		}
 	}
-	return statusPass, fmt.Sprintf("table inet %s has chain %s with skuid drop rule, proxy-only loopback allow, and persistence unit",
-		env.nftTable, env.nftChain)
+	return statusPass, fmt.Sprintf("table inet %s has chain %s with current agent uid %d skuid drop rule, proxy-only loopback allow, direct-DNS drops, and persistence unit",
+		env.nftTable, env.nftChain, current.agentUID)
+}
+
+type containmentUIDs struct {
+	operatorUID   int
+	operatorKnown bool
+	proxyUID      int
+	agentUID      int
+}
+
+func containmentUIDsFromProbeEnv(env *probeEnv) (containmentUIDs, error) {
+	proxyUID, err := lookupUID(env.lookupUser, env.proxyUserName)
+	if err != nil {
+		return containmentUIDs{}, fmt.Errorf("lookup proxy uid %s: %w", env.proxyUserName, err)
+	}
+	if proxyUID == 0 {
+		return containmentUIDs{}, fmt.Errorf("%s resolves to uid 0; containment proxy user must be non-root", env.proxyUserName)
+	}
+	agentUID, err := lookupUID(env.lookupUser, env.agentUserName)
+	if err != nil {
+		return containmentUIDs{}, fmt.Errorf("lookup agent uid %s: %w", env.agentUserName, err)
+	}
+	if agentUID == 0 {
+		return containmentUIDs{}, fmt.Errorf("%s resolves to uid 0; contained agent user must be non-root", env.agentUserName)
+	}
+
+	current := containmentUIDs{proxyUID: proxyUID, agentUID: agentUID}
+	if env.nftRulesPath == "" {
+		return current, nil
+	}
+	data, err := env.readFile(env.nftRulesPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return current, nil
+		}
+		return containmentUIDs{}, fmt.Errorf("read nftables rules file %s: %w", env.nftRulesPath, err)
+	}
+	header, ok, err := parseNFTRulesHeaderUIDs(data)
+	if err != nil {
+		return containmentUIDs{}, fmt.Errorf("parse nftables rules file %s: %w", env.nftRulesPath, err)
+	}
+	if !ok {
+		return current, nil
+	}
+	if header.proxyUID != proxyUID {
+		return containmentUIDs{}, fmt.Errorf("nftables rules file proxy uid %d does not match current %s uid %d", header.proxyUID, env.proxyUserName, proxyUID)
+	}
+	if header.agentUID != agentUID {
+		return containmentUIDs{}, fmt.Errorf("nftables rules file agent uid %d does not match current %s uid %d", header.agentUID, env.agentUserName, agentUID)
+	}
+	current.operatorUID = header.operatorUID
+	current.operatorKnown = true
+	return current, nil
+}
+
+func lookupUID(lookup lookupUserFunc, name string) (int, error) {
+	u, err := lookup(name)
+	if err != nil {
+		return 0, err
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return 0, fmt.Errorf("parse uid: %w", err)
+	}
+	return uid, nil
+}
+
+type nftRulesHeaderUIDs struct {
+	operatorUID int
+	proxyUID    int
+	agentUID    int
+}
+
+func parseNFTRulesHeaderUIDs(data []byte) (nftRulesHeaderUIDs, bool, error) {
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if !strings.HasPrefix(line, "#") || !strings.Contains(line, "operator=") {
+			continue
+		}
+		fields := strings.Fields(strings.TrimSpace(strings.TrimPrefix(line, "#")))
+		values := map[string]int{}
+		for _, field := range fields {
+			key, value, ok := strings.Cut(field, "=")
+			if !ok {
+				continue
+			}
+			switch key {
+			case "operator", "pipelock-proxy", "pipelock-agent":
+				uid, err := strconv.Atoi(value)
+				if err != nil {
+					return nftRulesHeaderUIDs{}, true, fmt.Errorf("%s uid %q: %w", key, value, err)
+				}
+				values[key] = uid
+			}
+		}
+		operatorUID, hasOperator := values["operator"]
+		proxyUID, hasProxy := values["pipelock-proxy"]
+		agentUID, hasAgent := values["pipelock-agent"]
+		if !hasOperator || !hasProxy || !hasAgent {
+			return nftRulesHeaderUIDs{}, true, errors.New("managed uid header missing operator, pipelock-proxy, or pipelock-agent uid")
+		}
+		return nftRulesHeaderUIDs{operatorUID: operatorUID, proxyUID: proxyUID, agentUID: agentUID}, true, nil
+	}
+	return nftRulesHeaderUIDs{}, false, nil
 }
 
 func verifyNFTPersistence(env *probeEnv) error {
@@ -826,30 +944,59 @@ func probeNFTExecutable(env *probeEnv) string {
 	return "nft"
 }
 
-func chainHasSkuidDrop(out, chainName string) bool {
+func chainHasAgentCatchAllDrop(out, chainName string, uid int) bool {
 	return chainHasLine(out, chainName, func(line string) bool {
-		return strings.Contains(line, "skuid") && strings.Contains(line, "drop")
+		return lineHasSkuid(line, uid) &&
+			strings.Contains(line, "drop") &&
+			!strings.Contains(line, " dport ")
 	})
 }
 
-func chainHasAgentProxyLoopbackAllow(out, chainName string, port int) bool {
+func chainHasSkuidAcceptForUID(out, chainName string, uid int) bool {
+	return chainHasLine(out, chainName, func(line string) bool {
+		return lineHasSkuid(line, uid) && strings.Contains(line, "accept")
+	})
+}
+
+func chainHasAgentProxyLoopbackAllow(out, chainName string, agentUID, port int) bool {
 	portText := strconv.Itoa(port)
 	return chainHasLine(out, chainName, func(line string) bool {
-		return strings.Contains(line, "skuid") &&
+		return lineHasSkuid(line, agentUID) &&
 			strings.Contains(line, "ip daddr 127.0.0.1") &&
 			strings.Contains(line, "tcp dport "+portText) &&
 			strings.Contains(line, "accept")
 	})
 }
 
-func chainHasBroadLoopbackAccept(out, chainName string) bool {
-	return chainHasLineBeforeSkuidDrop(out, chainName, func(line string) bool {
-		return strings.Contains(line, "accept") &&
-			(strings.Contains(line, `meta oif "lo"`) || strings.Contains(line, "ip daddr 127.0.0.0/8"))
+func chainHasAgentDNSDrop(out, chainName string, agentUID int, protocol string) bool {
+	return chainHasLine(out, chainName, func(line string) bool {
+		return lineHasSkuid(line, agentUID) &&
+			strings.Contains(line, protocol+" dport 53") &&
+			strings.Contains(line, "drop")
 	})
 }
 
-func chainHasLineBeforeSkuidDrop(out, chainName string, match func(string) bool) bool {
+func chainHasBroadLoopbackAccept(out, chainName string, agentUID int) bool {
+	return chainHasLineBeforeAgentDrop(out, chainName, agentUID, func(line string) bool {
+		return strings.Contains(line, "accept") &&
+			(strings.Contains(line, `meta oif "lo"`) ||
+				strings.Contains(line, "ip daddr 127.0.0.0/8") ||
+				(strings.Contains(line, "ip daddr 127.0.0.1") && !strings.Contains(line, " dport ")))
+	})
+}
+
+func lineHasSkuid(line string, uid int) bool {
+	want := strconv.Itoa(uid)
+	fields := strings.Fields(line)
+	for i, field := range fields {
+		if field == "skuid" && i+1 < len(fields) && fields[i+1] == want {
+			return true
+		}
+	}
+	return false
+}
+
+func chainHasLineBeforeAgentDrop(out, chainName string, agentUID int, match func(string) bool) bool {
 	inChain := false
 	depth := 0
 	for _, raw := range strings.Split(out, "\n") {
@@ -866,7 +1013,7 @@ func chainHasLineBeforeSkuidDrop(out, chainName string, match func(string) bool)
 		if strings.Contains(line, "{") {
 			depth += strings.Count(line, "{")
 		}
-		if strings.Contains(line, "skuid") && strings.Contains(line, "drop") {
+		if lineHasSkuid(line, agentUID) && strings.Contains(line, "drop") && !strings.Contains(line, " dport ") {
 			return false
 		}
 		if match(line) {

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -404,6 +404,23 @@ func TestProbeNFTContainment(t *testing.T) {
 			wantDetail: "skuid-drop rule missing",
 		},
 		{
+			name: "constrained agent drop is not catch all",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 ip daddr 10.0.0.0/8 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "skuid-drop rule missing",
+		},
+		{
 			name: "broad loopback accept",
 			stdout: `table inet pipelock_containment {
 		chain output_filter {
@@ -440,11 +457,47 @@ func TestProbeNFTContainment(t *testing.T) {
 			wantDetail: "broad loopback accept",
 		},
 		{
+			name: "constrained agent drop does not hide broad loopback accept",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 10.0.0.0/8 drop
+			ip daddr 127.0.0.1 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "broad loopback accept",
+		},
+		{
 			name: "missing proxy port allow",
 			stdout: `table inet pipelock_containment {
 		chain output_filter {
 			meta skuid 1000 accept
 			meta skuid 988 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "loopback allow",
+		},
+		{
+			name: "proxy port prefix is not proxy port",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 88880 accept
 			meta skuid 987 udp dport 53 drop
 			meta skuid 987 tcp dport 53 drop
 			meta skuid 987 drop
@@ -486,6 +539,40 @@ func TestProbeNFTContainment(t *testing.T) {
 			code:       0,
 			wantStatus: statusFail,
 			wantDetail: "DNS drop rule missing",
+		},
+		{
+			name: "dns port prefix is not dns port",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 530 drop
+			meta skuid 987 tcp dport 530 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "DNS drop rule missing",
+		},
+		{
+			name: "constrained proxy accept is not terminal accept",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 ip daddr 127.0.0.1 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "proxy uid 988 accept rule missing",
 		},
 		{
 			name: "skuid and drop outside target chain",
@@ -619,6 +706,27 @@ func TestProbeNFTContainment_UsesInstalledOperatorUIDFromRulesFile(t *testing.T)
 	if gotStatus != statusPass {
 		t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
 	}
+
+	liveWithoutOperator1000 := `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`
+	env.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+		return liveWithoutOperator1000, 0, nil
+	}
+	gotStatus, gotDetail = probeNFTContainment(context.Background(), env)
+	if gotStatus != statusFail {
+		t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+	}
+	if !strings.Contains(gotDetail, "operator uid 1000") {
+		t.Fatalf("detail: got %q, want operator uid 1000 failure", gotDetail)
+	}
 }
 
 func TestProbeNFTContainment_SkuidUIDBoundaryIsExact(t *testing.T) {
@@ -679,6 +787,56 @@ func TestProbeNFTContainment_StaleAgentUIDPrefixDoesNotSatisfyDrop(t *testing.T)
 	if !strings.Contains(gotDetail, "current agent uid 98") {
 		t.Fatalf("detail: got %q, want current agent uid 98 failure", gotDetail)
 	}
+}
+
+func TestProbeNFTContainment_RejectsContainmentUIDCollisions(t *testing.T) {
+	t.Run("proxy equals agent", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.lookupUser = func(name string) (*user.User, error) {
+				switch name {
+				case testProxyUser, testAgentUser:
+					return &user.User{Uid: "987", Gid: "987", Username: name, HomeDir: "/home/" + name}, nil
+				default:
+					return nil, user.UnknownUserError(name)
+				}
+			}
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				return goodNFTContainmentOutput, 0, nil
+			}
+		})
+
+		gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "containment users must be distinct") {
+			t.Fatalf("detail: got %q, want distinct-user failure", gotDetail)
+		}
+	})
+
+	t.Run("operator equals agent", func(t *testing.T) {
+		tmp := t.TempDir()
+		rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
+		if err := os.WriteFile(rulesPath, []byte(renderNFTRules(987, 988, 987, 8888, testTable, testChain)), 0o600); err != nil {
+			t.Fatalf("write rules: %v", err)
+		}
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.lookupUser = containTestLookup
+			e.nftRulesPath = rulesPath
+			e.readFile = os.ReadFile
+			e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+				return goodNFTContainmentOutput, 0, nil
+			}
+		})
+
+		gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
+		if gotStatus != statusFail {
+			t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+		}
+		if !strings.Contains(gotDetail, "operator uid 987 matches current pipelock-agent uid") {
+			t.Fatalf("detail: got %q, want operator-agent collision failure", gotDetail)
+		}
+	})
 }
 
 func containTestLookup(name string) (*user.User, error) {

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -49,7 +49,11 @@ const (
 
 const goodNFTContainmentOutput = `table inet pipelock_containment {
 	chain output_filter {
+		meta skuid 1000 accept
+		meta skuid 988 accept
 		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+		meta skuid 987 udp dport 53 counter log prefix "pipelock-contain class=direct_dns_blocked " drop
+		meta skuid 987 tcp dport 53 counter log prefix "pipelock-contain class=direct_dns_blocked " drop
 		meta skuid 987 drop
 	}
 }
@@ -387,7 +391,11 @@ func TestProbeNFTContainment(t *testing.T) {
 			name: "no skuid drop rule",
 			stdout: `table inet pipelock_containment {
 		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
 			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
 		}
 	}
 	`,
@@ -399,8 +407,30 @@ func TestProbeNFTContainment(t *testing.T) {
 			name: "broad loopback accept",
 			stdout: `table inet pipelock_containment {
 		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
 			meta oif "lo" accept
 			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "broad loopback accept",
+		},
+		{
+			name: "bare loopback host accept",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			ip daddr 127.0.0.1 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
 			meta skuid 987 drop
 		}
 	}
@@ -413,6 +443,10 @@ func TestProbeNFTContainment(t *testing.T) {
 			name: "missing proxy port allow",
 			stdout: `table inet pipelock_containment {
 		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
 			meta skuid 987 drop
 		}
 	}
@@ -422,10 +456,46 @@ func TestProbeNFTContainment(t *testing.T) {
 			wantDetail: "loopback allow",
 		},
 		{
+			name: "stale agent uid",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 986 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 986 udp dport 53 drop
+			meta skuid 986 tcp dport 53 drop
+			meta skuid 986 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "current agent uid 987",
+		},
+		{
+			name: "missing direct dns drop",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "DNS drop rule missing",
+		},
+		{
 			name: "skuid and drop outside target chain",
 			stdout: `table inet pipelock_containment {
 		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
 			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
 		}
 		chain decoy {
 			meta skuid 987 drop
@@ -441,6 +511,8 @@ func TestProbeNFTContainment(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			env := makeProbeEnv(t, func(e *probeEnv) {
+				e.operatorUser = testOperatorUser
+				e.lookupUser = containTestLookup
 				e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
 					return tc.stdout, tc.code, tc.runErr
 				}
@@ -498,6 +570,8 @@ func TestProbeNFTContainment_ChecksPersistenceUnit(t *testing.T) {
 				t.Fatalf("write persistence unit: %v", err)
 			}
 			env := makeProbeEnv(t, func(e *probeEnv) {
+				e.operatorUser = testOperatorUser
+				e.lookupUser = containTestLookup
 				e.nftRulesPath = rulesPath
 				e.nftPersistUnitPath = unitPath
 				e.readFile = os.ReadFile
@@ -513,6 +587,110 @@ func TestProbeNFTContainment_ChecksPersistenceUnit(t *testing.T) {
 				t.Fatalf("detail: got %q, want substring %q", gotDetail, tc.wantDetail)
 			}
 		})
+	}
+}
+
+func TestProbeNFTContainment_UsesInstalledOperatorUIDFromRulesFile(t *testing.T) {
+	tmp := t.TempDir()
+	rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
+	if err := os.WriteFile(rulesPath, []byte(renderNFTRules(1000, 988, 987, 8888, testTable, testChain)), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	env := makeProbeEnv(t, func(e *probeEnv) {
+		e.operatorUser = ""
+		e.lookupUser = func(name string) (*user.User, error) {
+			switch name {
+			case testProxyUser:
+				return &user.User{Uid: "988", Gid: "988", Username: name, HomeDir: "/home/" + name}, nil
+			case testAgentUser:
+				return &user.User{Uid: "987", Gid: "987", Username: name, HomeDir: "/home/" + name}, nil
+			default:
+				return nil, fmt.Errorf("unexpected lookup %q", name)
+			}
+		}
+		e.nftRulesPath = rulesPath
+		e.readFile = os.ReadFile
+		e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+			return goodNFTContainmentOutput, 0, nil
+		}
+	})
+
+	gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
+	if gotStatus != statusPass {
+		t.Fatalf("status: got %q, want pass (detail=%q)", gotStatus, gotDetail)
+	}
+}
+
+func TestProbeNFTContainment_SkuidUIDBoundaryIsExact(t *testing.T) {
+	tmp := t.TempDir()
+	rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
+	if err := os.WriteFile(rulesPath, []byte(renderNFTRules(98, 988, 987, 8888, testTable, testChain)), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	liveWithoutOperator98 := `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`
+	env := makeProbeEnv(t, func(e *probeEnv) {
+		e.lookupUser = containTestLookup
+		e.nftRulesPath = rulesPath
+		e.readFile = os.ReadFile
+		e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+			return liveWithoutOperator98, 0, nil
+		}
+	})
+
+	gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
+	if gotStatus != statusFail {
+		t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+	}
+	if !strings.Contains(gotDetail, "operator uid 98") {
+		t.Fatalf("detail: got %q, want operator uid 98 failure", gotDetail)
+	}
+}
+
+func TestProbeNFTContainment_StaleAgentUIDPrefixDoesNotSatisfyDrop(t *testing.T) {
+	env := makeProbeEnv(t, func(e *probeEnv) {
+		e.lookupUser = func(name string) (*user.User, error) {
+			switch name {
+			case testProxyUser:
+				return &user.User{Uid: "988", Gid: "988", Username: name, HomeDir: "/home/" + name}, nil
+			case testAgentUser:
+				return &user.User{Uid: "98", Gid: "98", Username: name, HomeDir: "/home/" + name}, nil
+			default:
+				return nil, user.UnknownUserError(name)
+			}
+		}
+		e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+			return goodNFTContainmentOutput, 0, nil
+		}
+	})
+
+	gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
+	if gotStatus != statusFail {
+		t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+	}
+	if !strings.Contains(gotDetail, "current agent uid 98") {
+		t.Fatalf("detail: got %q, want current agent uid 98 failure", gotDetail)
+	}
+}
+
+func containTestLookup(name string) (*user.User, error) {
+	switch name {
+	case testOperatorUser:
+		return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: "/home/" + name}, nil
+	case testProxyUser:
+		return &user.User{Uid: "988", Gid: "988", Username: name, HomeDir: "/home/" + name}, nil
+	case testAgentUser:
+		return &user.User{Uid: "987", Gid: "987", Username: name, HomeDir: "/home/" + name}, nil
+	default:
+		return nil, user.UnknownUserError(name)
 	}
 }
 
@@ -1588,6 +1766,8 @@ func allPassEnv(t *testing.T) *probeEnv {
 	// Probe 1: both users present.
 	env.lookupUser = func(name string) (*user.User, error) {
 		switch name {
+		case testOperatorUser:
+			return &user.User{Uid: "1000", Gid: "1000", Username: testOperatorUser, HomeDir: "/home/" + testOperatorUser}, nil
 		case testProxyUser:
 			return &user.User{Uid: "988", Gid: "988", Username: testProxyUser, HomeDir: "/home/" + testProxyUser}, nil
 		case testAgentUser:

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -509,6 +509,23 @@ func TestProbeNFTContainment(t *testing.T) {
 			wantDetail: "loopback allow",
 		},
 		{
+			name: "loopback address prefix is not proxy address",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.10 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "loopback allow",
+		},
+		{
 			name: "stale agent uid",
 			stdout: `table inet pipelock_containment {
 		chain output_filter {
@@ -541,13 +558,30 @@ func TestProbeNFTContainment(t *testing.T) {
 			wantDetail: "DNS drop rule missing",
 		},
 		{
-			name: "dns port prefix is not dns port",
+			name: "udp dns port prefix is not dns port",
 			stdout: `table inet pipelock_containment {
 		chain output_filter {
 			meta skuid 1000 accept
 			meta skuid 988 accept
 			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
 			meta skuid 987 udp dport 530 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "udp/53 DNS drop rule missing",
+		},
+		{
+			name: "tcp dns port prefix is not dns port",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
 			meta skuid 987 tcp dport 530 drop
 			meta skuid 987 drop
 		}
@@ -555,7 +589,41 @@ func TestProbeNFTContainment(t *testing.T) {
 	`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "DNS drop rule missing",
+			wantDetail: "tcp/53 DNS drop rule missing",
+		},
+		{
+			name: "constrained udp dns drop is not catch all dns drop",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 ip daddr 8.8.8.8 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "udp/53 DNS drop rule missing",
+		},
+		{
+			name: "constrained tcp dns drop is not catch all dns drop",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 ip daddr 8.8.8.8 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "tcp/53 DNS drop rule missing",
 		},
 		{
 			name: "constrained proxy accept is not terminal accept",


### PR DESCRIPTION
## Summary

Tighten containment verification so the live nftables rules must match the installed/current containment identities, not just the rough shape of the ruleset.

This closes stale-UID cases where `pipelock-agent` or `pipelock-proxy` can be recreated with a new UID while old nftables rules still appear structurally valid. The verifier now checks the current proxy and agent UIDs, uses the managed rules file header for the install-time operator UID, and matches `skuid` tokens exactly so UID prefixes cannot satisfy another user's rule.

The install idempotency check uses the same UID-aware rule comparison, so rerunning `pipelock contain install` repairs stale live rules instead of treating them as healthy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nftables containment drift detection by validating the live ruleset against fully rendered, UID-specific expectations (operator, proxy, agent), including stricter DNS (UDP/TCP/53) and safer loopback ordering checks.
  * Enhanced install-time repair so stale or mismatched UID values in live rules more reliably trigger delete-and-reload to restore containment integrity.
* **Tests**
  * Expanded and tightened nftables installation and verification tests for UID derivation, exact `skuid` boundary matching, and rejection/repair for stale or conflicting UID patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->