### PR TITLE
fix: reject required-mode reload downgrades

### DIFF
--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -446,6 +446,9 @@ func reloadDowngradeRejectReason(oldCfg *config.Config, warnings []config.Reload
 	if oldCfg.Mode == config.ModeStrict {
 		return "strict mode"
 	}
+	if !hasRejectableDowngradeWarning(warnings) {
+		return ""
+	}
 
 	var required []string
 	if oldCfg.FlightRecorder.RequireReceipts {
@@ -467,6 +470,36 @@ func reloadDowngradeRejectReason(oldCfg *config.Config, warnings []config.Reload
 		return ""
 	}
 	return "required security mode (" + strings.Join(required, ", ") + ")"
+}
+
+func hasRejectableDowngradeWarning(warnings []config.ReloadWarning) bool {
+	for _, w := range warnings {
+		if reloadWarningIsAdvisory(w) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func reloadWarningIsAdvisory(w config.ReloadWarning) bool {
+	msg := strings.ToLower(w.Message)
+	if strings.Contains(msg, "requires restart") ||
+		strings.Contains(msg, "require restart") ||
+		strings.Contains(msg, "ignored on reload") ||
+		strings.Contains(msg, "uses init-time") ||
+		strings.Contains(msg, "cannot change at runtime") {
+		return true
+	}
+
+	switch w.Field {
+	case "mediation_envelope.key_id":
+		return true
+	case "dlp.secrets_file":
+		return !strings.Contains(msg, "removed")
+	default:
+		return false
+	}
 }
 
 func hasNamedAgentProfiles(agents map[string]config.AgentProfile) bool {

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -334,9 +334,11 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		for _, w := range warnings {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: %s - %s\n", w.Field, w.Message)
 		}
-		// Block downgrades from strict mode (security-critical).
-		if oldCfg.Mode == config.ModeStrict && len(warnings) > 0 {
-			rejectErr := fmt.Errorf("rejected: security downgrade from strict mode")
+		// Block downgrades from strict mode and from explicit "required"
+		// security contracts. A required evidence/signature mode should not
+		// keep forwarding under a warning-only weakening reload.
+		if reason := reloadDowngradeRejectReason(oldCfg, warnings); reason != "" {
+			rejectErr := fmt.Errorf("rejected: security downgrade from %s", reason)
 			s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
 			return rejectErr
 		}
@@ -435,6 +437,36 @@ func implausibleReloadTeardownReasons(oldCfg, newCfg *config.Config) []string {
 	}
 
 	return reasons
+}
+
+func reloadDowngradeRejectReason(oldCfg *config.Config, warnings []config.ReloadWarning) string {
+	if oldCfg == nil || len(warnings) == 0 {
+		return ""
+	}
+	if oldCfg.Mode == config.ModeStrict {
+		return "strict mode"
+	}
+
+	var required []string
+	if oldCfg.FlightRecorder.RequireReceipts {
+		required = append(required, "flight_recorder.require_receipts")
+	}
+	if oldCfg.LicenseRequireIntermediateResolved {
+		required = append(required, "license_require_intermediate")
+	}
+	if oldCfg.A2AScanning.Enabled && oldCfg.A2AScanning.RequireSignedAgentCards {
+		required = append(required, "a2a_scanning.require_signed_agent_cards")
+	}
+	if oldCfg.MCPBinaryIntegrity.Enabled && oldCfg.MCPBinaryIntegrity.RequireSignature {
+		required = append(required, "mcp_binary_integrity.require_signature")
+	}
+	if oldCfg.MediationEnvelope.VerifyInbound.Enabled {
+		required = append(required, "mediation_envelope.verify_inbound.enabled")
+	}
+	if len(required) == 0 {
+		return ""
+	}
+	return "required security mode (" + strings.Join(required, ", ") + ")"
 }
 
 func hasNamedAgentProfiles(agents map[string]config.AgentProfile) bool {

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1042,6 +1042,27 @@ func TestServer_Reload_RequireReceiptsAllowsNonDowngradeReload(t *testing.T) {
 	}
 }
 
+func TestServer_Reload_RequireReceiptsAllowsRestartOnlyWarning(t *testing.T) {
+	s, buf := newTestServer(t, nil)
+	oldLive := s.proxy.CurrentConfig()
+	oldLive.Mode = config.ModeBalanced
+	oldLive.FlightRecorder.RequireReceipts = true
+
+	restartOnly := oldLive.Clone()
+	restartOnly.HealthWatchdog.IntervalSeconds = oldLive.HealthWatchdog.IntervalSeconds + 1
+
+	if err := s.Reload(restartOnly); err != nil {
+		t.Fatalf("require_receipts restart-only warning reload should not error, got: %v", err)
+	}
+	if !buf.contains("health_watchdog") {
+		t.Fatalf("stderr missing health_watchdog restart-only warning:\n%s", buf.String())
+	}
+	live := s.proxy.CurrentConfig()
+	if !live.FlightRecorder.RequireReceipts {
+		t.Fatal("require_receipts was not preserved")
+	}
+}
+
 func TestServer_Reload_MCPBinaryRequireSignatureRejectsDowngrade(t *testing.T) {
 	s, buf := newTestServer(t, nil)
 	oldLive := s.proxy.CurrentConfig()
@@ -1110,6 +1131,10 @@ func TestServer_Reload_MediationVerifyInboundRejectsDowngrade(t *testing.T) {
 
 func TestReloadDowngradeRejectReason(t *testing.T) {
 	downgrade := []config.ReloadWarning{{Field: "enforce", Message: "enforcement disabled"}}
+	restartOnly := []config.ReloadWarning{{
+		Field:   "health_watchdog",
+		Message: "health_watchdog config changes require restart — ignored on reload",
+	}}
 
 	for _, tt := range []struct {
 		name   string
@@ -1155,6 +1180,15 @@ func TestReloadDowngradeRejectReason(t *testing.T) {
 			wantIn: "flight_recorder.require_receipts",
 		},
 		{
+			name: "required receipts allows restart-only warning",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.FlightRecorder.RequireReceipts = true
+				return c
+			},
+			warns: restartOnly,
+		},
+		{
 			name: "license require-intermediate rejects",
 			cfg: func() *config.Config {
 				c := config.Defaults()
@@ -1185,6 +1219,16 @@ func TestReloadDowngradeRejectReason(t *testing.T) {
 			},
 			warns:  downgrade,
 			wantIn: "mcp_binary_integrity.require_signature",
+		},
+		{
+			name: "MCP binary signature allows restart-only warning",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.MCPBinaryIntegrity.Enabled = true
+				c.MCPBinaryIntegrity.RequireSignature = true
+				return c
+			},
+			warns: restartOnly,
 		},
 		{
 			name: "disabled MCP binary integrity stale require flag does not reject",

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -990,6 +990,238 @@ func TestServer_Reload_StrictAllowsApiTokenRotation(t *testing.T) {
 	}
 }
 
+func TestServer_Reload_RequireReceiptsRejectsSecurityDowngrade(t *testing.T) {
+	s, buf := newTestServer(t, nil)
+	oldLive := s.proxy.CurrentConfig()
+	oldLive.Mode = config.ModeBalanced
+	oldLive.FlightRecorder.RequireReceipts = true
+	oldLive.ResponseScanning.Enabled = true
+	oldLive.ResponseScanning.Action = config.ActionBlock
+
+	downgraded := oldLive.Clone()
+	downgraded.ResponseScanning.Action = config.ActionWarn
+
+	err := s.Reload(downgraded)
+	if err == nil {
+		t.Fatal("expected require_receipts mode to reject response action downgrade reload")
+	}
+	if !strings.Contains(err.Error(), "required security mode") ||
+		!strings.Contains(err.Error(), "flight_recorder.require_receipts") {
+		t.Fatalf("error = %q, want required receipt downgrade context", err.Error())
+	}
+	if !buf.contains("response_scanning.action") {
+		t.Fatalf("stderr missing downgrade warning:\n%s", buf.String())
+	}
+	live := s.proxy.CurrentConfig()
+	if live.ResponseScanning.Action != config.ActionBlock {
+		t.Fatalf("rejected reload changed response action to %q", live.ResponseScanning.Action)
+	}
+	if !live.FlightRecorder.RequireReceipts {
+		t.Fatal("rejected reload cleared require_receipts in live config")
+	}
+}
+
+func TestServer_Reload_RequireReceiptsAllowsNonDowngradeReload(t *testing.T) {
+	s, _ := newTestServer(t, nil)
+	oldLive := s.proxy.CurrentConfig()
+	oldLive.Mode = config.ModeBalanced
+	oldLive.FlightRecorder.RequireReceipts = true
+
+	rotated := oldLive.Clone()
+	rotated.KillSwitch.APIToken = "new-token"
+
+	if err := s.Reload(rotated); err != nil {
+		t.Fatalf("require_receipts non-downgrade reload should not error, got: %v", err)
+	}
+	live := s.proxy.CurrentConfig()
+	if live.KillSwitch.APIToken != "new-token" {
+		t.Fatalf("api token reload did not apply: got %q", live.KillSwitch.APIToken)
+	}
+	if !live.FlightRecorder.RequireReceipts {
+		t.Fatal("require_receipts was not preserved")
+	}
+}
+
+func TestServer_Reload_MCPBinaryRequireSignatureRejectsDowngrade(t *testing.T) {
+	s, buf := newTestServer(t, nil)
+	oldLive := s.proxy.CurrentConfig()
+	oldLive.Mode = config.ModeBalanced
+	oldLive.MCPBinaryIntegrity.Enabled = true
+	oldLive.MCPBinaryIntegrity.Action = config.ActionBlock
+	oldLive.MCPBinaryIntegrity.RequireSignature = true
+	oldLive.MCPBinaryIntegrity.ManifestPath = "/tmp/pipelock-test-manifest.json"
+	oldLive.MCPBinaryIntegrity.TrustedSigner = "release"
+
+	downgraded := oldLive.Clone()
+	downgraded.MCPBinaryIntegrity.RequireSignature = false
+
+	err := s.Reload(downgraded)
+	if err == nil {
+		t.Fatal("expected require_signature mode to reject MCP binary integrity downgrade reload")
+	}
+	if !strings.Contains(err.Error(), "required security mode") ||
+		!strings.Contains(err.Error(), "mcp_binary_integrity.require_signature") {
+		t.Fatalf("error = %q, want MCP binary required-signature downgrade context", err.Error())
+	}
+	if !buf.contains("mcp_binary_integrity.require_signature") {
+		t.Fatalf("stderr missing MCP binary signature downgrade warning:\n%s", buf.String())
+	}
+	live := s.proxy.CurrentConfig()
+	if !live.MCPBinaryIntegrity.RequireSignature {
+		t.Fatal("rejected reload cleared MCP binary signature requirement in live config")
+	}
+}
+
+func TestServer_Reload_MediationVerifyInboundRejectsDowngrade(t *testing.T) {
+	s, buf := newTestServer(t, nil)
+	pub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	oldLive := s.proxy.CurrentConfig()
+	oldLive.Mode = config.ModeBalanced
+	oldLive.MediationEnvelope.VerifyInbound.Enabled = true
+	oldLive.MediationEnvelope.VerifyInbound.TrustList = []config.MediationEnvelopeTrustedKey{{
+		KeyID:     "peer",
+		PublicKey: signing.EncodePublicKey(pub),
+	}}
+	oldLive.MediationEnvelope.VerifyInbound.ReplayCache.Window = "2m"
+	oldLive.MediationEnvelope.VerifyInbound.ReplayCache.MaxEntries = 16
+
+	downgraded := oldLive.Clone()
+	downgraded.MediationEnvelope.VerifyInbound.Enabled = false
+
+	err = s.Reload(downgraded)
+	if err == nil {
+		t.Fatal("expected inbound mediation verification mode to reject disable reload")
+	}
+	if !strings.Contains(err.Error(), "required security mode") ||
+		!strings.Contains(err.Error(), "mediation_envelope.verify_inbound.enabled") {
+		t.Fatalf("error = %q, want inbound mediation verification downgrade context", err.Error())
+	}
+	if !buf.contains("mediation_envelope.verify_inbound.enabled") {
+		t.Fatalf("stderr missing inbound mediation verification downgrade warning:\n%s", buf.String())
+	}
+	live := s.proxy.CurrentConfig()
+	if !live.MediationEnvelope.VerifyInbound.Enabled {
+		t.Fatal("rejected reload disabled inbound mediation verification in live config")
+	}
+}
+
+func TestReloadDowngradeRejectReason(t *testing.T) {
+	downgrade := []config.ReloadWarning{{Field: "enforce", Message: "enforcement disabled"}}
+
+	for _, tt := range []struct {
+		name   string
+		cfg    func() *config.Config
+		warns  []config.ReloadWarning
+		wantIn string
+	}{
+		{
+			name: "balanced without required contract allows warning-only reload",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.Mode = config.ModeBalanced
+				return c
+			},
+		},
+		{
+			name: "warnings are required",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.Mode = config.ModeStrict
+				return c
+			},
+			warns: nil,
+		},
+		{
+			name: "strict rejects",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.Mode = config.ModeStrict
+				return c
+			},
+			warns:  downgrade,
+			wantIn: "strict mode",
+		},
+		{
+			name: "required receipts reject",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.FlightRecorder.RequireReceipts = true
+				return c
+			},
+			warns:  downgrade,
+			wantIn: "flight_recorder.require_receipts",
+		},
+		{
+			name: "license require-intermediate rejects",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.LicenseRequireIntermediateResolved = true
+				return c
+			},
+			warns:  downgrade,
+			wantIn: "license_require_intermediate",
+		},
+		{
+			name: "A2A signed cards reject",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.A2AScanning.Enabled = true
+				c.A2AScanning.RequireSignedAgentCards = true
+				return c
+			},
+			warns:  downgrade,
+			wantIn: "a2a_scanning.require_signed_agent_cards",
+		},
+		{
+			name: "MCP binary signature rejects",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.MCPBinaryIntegrity.Enabled = true
+				c.MCPBinaryIntegrity.RequireSignature = true
+				return c
+			},
+			warns:  downgrade,
+			wantIn: "mcp_binary_integrity.require_signature",
+		},
+		{
+			name: "disabled MCP binary integrity stale require flag does not reject",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.MCPBinaryIntegrity.Enabled = false
+				c.MCPBinaryIntegrity.RequireSignature = true
+				return c
+			},
+			warns: downgrade,
+		},
+		{
+			name: "inbound mediation verification rejects",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.MediationEnvelope.VerifyInbound.Enabled = true
+				return c
+			},
+			warns:  downgrade,
+			wantIn: "mediation_envelope.verify_inbound.enabled",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reloadDowngradeRejectReason(tt.cfg(), tt.warns)
+			if tt.wantIn == "" {
+				if got != "" {
+					t.Fatalf("reject reason = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.wantIn) {
+				t.Fatalf("reject reason = %q, want substring %q", got, tt.wantIn)
+			}
+		})
+	}
+}
+
 func TestServer_Reload_RejectsRestartRequiredProxyModes(t *testing.T) {
 	s, _ := newTestServer(t, nil)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3791,6 +3791,14 @@ func TestValidateReload_ActionDowngradesWarnForEnforcementSurfaces(t *testing.T)
 	old.MCPToolPolicy.Rules = []ToolPolicyRule{{Name: "deny-shell", ToolPattern: "shell", Action: ActionBlock}}
 	updated.MCPToolPolicy.Action = ActionWarn
 	updated.MCPToolPolicy.Rules = []ToolPolicyRule{{Name: "deny-shell", ToolPattern: "shell", Action: ActionWarn}}
+	old.MCPBinaryIntegrity.Enabled = true
+	updated.MCPBinaryIntegrity.Enabled = true
+	old.MCPBinaryIntegrity.Action = ActionBlock
+	updated.MCPBinaryIntegrity.Action = ActionWarn
+	old.MCPToolProvenance.Enabled = true
+	updated.MCPToolProvenance.Enabled = true
+	old.MCPToolProvenance.Action = ActionBlock
+	updated.MCPToolProvenance.Action = ActionWarn
 	old.AddressProtection.Enabled = true
 	updated.AddressProtection.Enabled = true
 	old.AddressProtection.Action = ActionBlock
@@ -3832,6 +3840,8 @@ func TestValidateReload_ActionDowngradesWarnForEnforcementSurfaces(t *testing.T)
 		"mcp_tool_scanning.action",
 		"mcp_tool_policy.action",
 		"mcp_tool_policy.rules.deny-shell.action",
+		"mcp_binary_integrity.action",
+		"mcp_tool_provenance.action",
 		"address_protection.action",
 		"address_protection.unknown_action",
 		"a2a_scanning.action",
@@ -3840,6 +3850,27 @@ func TestValidateReload_ActionDowngradesWarnForEnforcementSurfaces(t *testing.T)
 		"mcp_session_binding.unknown_tool_action",
 		"mcp_session_binding.no_baseline_action",
 		"tool_chain_detection.action",
+	} {
+		if !hasReloadWarning(warnings, field) {
+			t.Fatalf("missing reload warning for %s; warnings=%+v", field, warnings)
+		}
+	}
+}
+
+func TestValidateReload_MCPIntegrityAndProvenanceDowngrades(t *testing.T) {
+	old := Defaults()
+	updated := old.Clone()
+	old.MCPBinaryIntegrity.Enabled = true
+	old.MCPBinaryIntegrity.RequireSignature = true
+	updated.MCPBinaryIntegrity.Enabled = false
+	old.MCPToolProvenance.Enabled = true
+	updated.MCPToolProvenance.Enabled = false
+
+	warnings := ValidateReload(old, updated)
+	for _, field := range []string{
+		"mcp_binary_integrity.enabled",
+		"mcp_binary_integrity.require_signature",
+		"mcp_tool_provenance.enabled",
 	} {
 		if !hasReloadWarning(warnings, field) {
 			t.Fatalf("missing reload warning for %s; warnings=%+v", field, warnings)

--- a/internal/config/mediation_envelope_test.go
+++ b/internal/config/mediation_envelope_test.go
@@ -399,6 +399,35 @@ func TestValidateReload_MediationEnvelopeDisabled(t *testing.T) {
 	}
 }
 
+func TestValidateReload_MediationEnvelopeVerifyInboundDisabled(t *testing.T) {
+	t.Parallel()
+
+	pub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	old := Defaults()
+	old.MediationEnvelope.VerifyInbound.Enabled = true
+	old.MediationEnvelope.VerifyInbound.TrustList = []MediationEnvelopeTrustedKey{{
+		KeyID:     "peer",
+		PublicKey: signing.EncodePublicKey(pub),
+	}}
+	if err := old.validateMediationEnvelope(); err != nil {
+		t.Fatalf("old validate: %v", err)
+	}
+
+	updated := old.Clone()
+	updated.MediationEnvelope.VerifyInbound.Enabled = false
+	if err := updated.validateMediationEnvelope(); err != nil {
+		t.Fatalf("updated validate: %v", err)
+	}
+
+	warnings := ValidateReload(old, updated)
+	if !reloadWarningHasField(warnings, "mediation_envelope.verify_inbound.enabled") {
+		t.Errorf("expected mediation_envelope.verify_inbound.enabled warning, got %v", warnings)
+	}
+}
+
 func TestValidateReload_MediationEnvelopeKeyIDChange(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -158,6 +158,29 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 		})
 	}
 
+	// MCP binary integrity disabled or signature requirement weakened.
+	if old.MCPBinaryIntegrity.Enabled && !updated.MCPBinaryIntegrity.Enabled {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "mcp_binary_integrity.enabled",
+			Message: "MCP binary integrity disabled",
+		})
+	}
+	if old.MCPBinaryIntegrity.Enabled && old.MCPBinaryIntegrity.RequireSignature &&
+		(!updated.MCPBinaryIntegrity.Enabled || !updated.MCPBinaryIntegrity.RequireSignature) {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "mcp_binary_integrity.require_signature",
+			Message: "MCP binary manifest signature requirement disabled",
+		})
+	}
+
+	// MCP tool provenance disabled.
+	if old.MCPToolProvenance.Enabled && !updated.MCPToolProvenance.Enabled {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "mcp_tool_provenance.enabled",
+			Message: "MCP tool provenance verification disabled",
+		})
+	}
+
 	// Forward proxy disabled
 	if old.ForwardProxy.Enabled && !updated.ForwardProxy.Enabled {
 		warnings = append(warnings, ReloadWarning{
@@ -668,6 +691,15 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 			Message: "mediation envelope disabled — outbound requests will no longer carry the Pipelock-Mediation header",
 		})
 	}
+	// Inbound verification is a fail-closed trust boundary for federated
+	// mediation. Disabling it means incoming mediation headers are no longer
+	// authenticated before being stripped/replaced.
+	if old.MediationEnvelope.VerifyInbound.Enabled && !updated.MediationEnvelope.VerifyInbound.Enabled {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "mediation_envelope.verify_inbound.enabled",
+			Message: "inbound mediation envelope verification disabled — incoming mediation headers will no longer require a trusted RFC 9421 signature",
+		})
+	}
 	// Key rotation is not a downgrade, but an operator rotating the
 	// key id without first publishing the new public key will silently
 	// start emitting signatures no verifier can check. Warn on change.
@@ -753,6 +785,12 @@ func appendActionDowngradeWarnings(warnings *[]ReloadWarning, old, updated *Conf
 	if old.MCPToolPolicy.Enabled && updated.MCPToolPolicy.Enabled {
 		appendActionDowngradeWarning(warnings, "mcp_tool_policy.action", old.MCPToolPolicy.Action, updated.MCPToolPolicy.Action)
 		appendToolPolicyRuleActionDowngrades(warnings, old.MCPToolPolicy, updated.MCPToolPolicy)
+	}
+	if old.MCPBinaryIntegrity.Enabled && updated.MCPBinaryIntegrity.Enabled {
+		appendActionDowngradeWarning(warnings, "mcp_binary_integrity.action", old.MCPBinaryIntegrity.Action, updated.MCPBinaryIntegrity.Action)
+	}
+	if old.MCPToolProvenance.Enabled && updated.MCPToolProvenance.Enabled {
+		appendActionDowngradeWarning(warnings, "mcp_tool_provenance.action", old.MCPToolProvenance.Action, updated.MCPToolProvenance.Action)
 	}
 	if old.AddressProtection.Enabled && updated.AddressProtection.Enabled {
 		appendActionDowngradeWarning(warnings, "address_protection.action", old.AddressProtection.Action, updated.AddressProtection.Action)


### PR DESCRIPTION
## Summary
- Reject warning-level security downgrades during hot reload when strict mode or explicit required security contracts are active.
- Add reload warnings for MCP binary integrity, MCP tool provenance, and inbound mediation verification downgrades.
- Cover required receipts, MCP binary required signatures, and inbound mediation verification with negative reload regression tests, while preserving safe non-downgrade reload behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hot reloads now block or warn on additional security downgrades, including MCP binary integrity/provenance settings and inbound mediation envelope verification.
  * Reload rejections now provide clearer “required security mode” context, including which security gates were affected.
  * For allowed reloads, previously required security enforcement settings are preserved to prevent accidental weakening.

* **Tests**
  * Expanded regression and validation coverage for reload warning generation and required-settings downgrade rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->