### PR TITLE
feat: add Rekor anchor submission backend

### DIFF
--- a/cmd/pipelock-verifier/independent.go
+++ b/cmd/pipelock-verifier/independent.go
@@ -30,14 +30,14 @@ func newIndependentCmd() *cobra.Command {
 	var opts independentOptions
 	cmd := &cobra.Command{
 		Use:   "independent PATH",
-		Short: "Verify an externally anchored receipt-chain checkpoint",
-		Long: `Verifies a receipt chain against an anchor bundle and external inclusion
-proof. The local backend is a deterministic test backend; it proves the
+		Short: "Verify an anchored receipt-chain checkpoint",
+		Long: `Verifies a receipt chain against an anchor bundle and backend proof
+material. The local backend is a deterministic test backend; it proves the
 checkpoint/proof mechanics but is not an operator-independent witness.
 
-Honest limit: anchoring detects after-the-fact rewrite, delete, omit, and
-equivocation against the anchored checkpoint. It does not prove real-time truth
-by whoever held the receipt signing key.`,
+Honest limit: anchoring does not prove real-time truth by whoever held the
+receipt signing key. Rekor bundles fail closed until trusted Rekor SET and
+inclusion-proof verification is implemented.`,
 		Args:          exactOneArg,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -63,9 +63,6 @@ func runIndependent(stdout, stderr io.Writer, target string, opts independentOpt
 	if len(opts.signerKeys) == 0 {
 		return cliutil.ExitCodeError(exitUsage, fmt.Errorf("at least one --key is required"))
 	}
-	if strings.TrimSpace(opts.logPath) == "" {
-		return cliutil.ExitCodeError(exitUsage, fmt.Errorf("--local-log is required for local anchor verification"))
-	}
 	keyHexes, err := resolveSignerKeys(opts.signerKeys)
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("resolve signer key: %w", err))
@@ -78,15 +75,33 @@ func runIndependent(stdout, stderr io.Writer, target string, opts independentOpt
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 	}
-	report := anchor.VerifyBundle(bundle, receipts, keyHexes, anchor.LocalLog{
-		Path:  opts.logPath,
-		LogID: opts.logID,
-	})
+	backend, err := independentBackend(bundle, opts)
+	if err != nil {
+		return cliutil.ExitCodeError(exitUsage, err)
+	}
+	report := anchor.VerifyBundle(bundle, receipts, keyHexes, backend)
 	emitIndependentReport(stdout, stderr, filepath.Clean(target), report, opts.jsonOutput)
 	if !report.Valid {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("independent verification failed: %s", report.Error))
 	}
 	return nil
+}
+
+func independentBackend(bundle anchor.Bundle, opts independentOptions) (anchor.Backend, error) {
+	switch bundle.Backend {
+	case anchor.LocalBackend:
+		if strings.TrimSpace(opts.logPath) == "" {
+			return nil, fmt.Errorf("--local-log is required for local anchor verification")
+		}
+		return anchor.LocalLog{
+			Path:  opts.logPath,
+			LogID: opts.logID,
+		}, nil
+	case anchor.RekorBackend:
+		return anchor.RekorLog{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported anchor backend %q", bundle.Backend)
+	}
 }
 
 func independentReceipts(target string, opts independentOptions) ([]receipt.Receipt, error) {

--- a/cmd/pipelock-verifier/independent.go
+++ b/cmd/pipelock-verifier/independent.go
@@ -75,9 +75,9 @@ func runIndependent(stdout, stderr io.Writer, target string, opts independentOpt
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 	}
-	backend, err := independentBackend(bundle, opts)
+	backend, exitCode, err := independentBackend(bundle, opts)
 	if err != nil {
-		return cliutil.ExitCodeError(exitUsage, err)
+		return cliutil.ExitCodeError(exitCode, err)
 	}
 	report := anchor.VerifyBundle(bundle, receipts, keyHexes, backend)
 	emitIndependentReport(stdout, stderr, filepath.Clean(target), report, opts.jsonOutput)
@@ -87,20 +87,20 @@ func runIndependent(stdout, stderr io.Writer, target string, opts independentOpt
 	return nil
 }
 
-func independentBackend(bundle anchor.Bundle, opts independentOptions) (anchor.Backend, error) {
+func independentBackend(bundle anchor.Bundle, opts independentOptions) (anchor.Backend, int, error) {
 	switch bundle.Backend {
 	case anchor.LocalBackend:
 		if strings.TrimSpace(opts.logPath) == "" {
-			return nil, fmt.Errorf("--local-log is required for local anchor verification")
+			return nil, exitUsage, fmt.Errorf("--local-log is required for local anchor verification")
 		}
 		return anchor.LocalLog{
 			Path:  opts.logPath,
 			LogID: opts.logID,
-		}, nil
+		}, cliutil.ExitOK, nil
 	case anchor.RekorBackend:
-		return anchor.RekorLog{}, nil
+		return anchor.RekorLog{}, cliutil.ExitOK, nil
 	default:
-		return nil, fmt.Errorf("unsupported anchor backend %q", bundle.Backend)
+		return nil, cliutil.ExitConfig, fmt.Errorf("unsupported anchor backend %q", bundle.Backend)
 	}
 }
 

--- a/cmd/pipelock-verifier/independent.go
+++ b/cmd/pipelock-verifier/independent.go
@@ -88,6 +88,9 @@ func runIndependent(stdout, stderr io.Writer, target string, opts independentOpt
 }
 
 func independentBackend(bundle anchor.Bundle, opts independentOptions) (anchor.Backend, int, error) {
+	if bundle.Backend != bundle.Proof.Backend {
+		return nil, cliutil.ExitConfig, fmt.Errorf("anchor bundle backend %q does not match proof backend %q", bundle.Backend, bundle.Proof.Backend)
+	}
 	switch bundle.Backend {
 	case anchor.LocalBackend:
 		if strings.TrimSpace(opts.logPath) == "" {

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -644,11 +644,32 @@ func TestIndependent_RekorAnchorFailsClosedUntilTrustedLogVerification(t *testin
 		"--bundle", bundle,
 		"--key", fix.keyHex,
 	)
-	if code == cliutil.ExitOK {
-		t.Fatalf("Rekor independent verification succeeded without trusted log verification, stdout=%q stderr=%q", stdout, stderr)
+	if code != cliutil.ExitGeneral {
+		t.Fatalf("code=%d, want %d for Rekor fail-closed verification; stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
 	}
 	if !strings.Contains(stderr, "trusted Rekor SET") {
 		t.Fatalf("stderr missing fail-closed Rekor verification error:\n%s", stderr)
+	}
+}
+
+func TestIndependent_RejectsUnsupportedBundleBackendAsConfig(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T14:00:00Z")
+	fix := newFixture(t, 1)
+	_, bundlePath, logPath := writeIndependentFixture(t, fix)
+	_ = logPath
+	bundle, err := anchorpkg.LoadBundle(bundlePath)
+	if err != nil {
+		t.Fatalf("LoadBundle: %v", err)
+	}
+	bundle.Backend = "future"
+	bundle.Proof.Backend = "future"
+
+	_, code, err := independentBackend(bundle, independentOptions{})
+	if code != cliutil.ExitConfig {
+		t.Fatalf("code=%d, want %d for unsupported bundle backend", code, cliutil.ExitConfig)
+	}
+	if err == nil || !strings.Contains(err.Error(), `unsupported anchor backend "future"`) {
+		t.Fatalf("err = %v, want unsupported backend", err)
 	}
 }
 
@@ -837,11 +858,13 @@ func writeIndependentRekorFixture(t *testing.T, fix *fixture) (evidencePath, bun
 		body := base64.StdEncoding.EncodeToString(raw)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"fake-uuid": map[string]any{
-				"logID":    "fake-rekor-log",
-				"logIndex": 4,
-				"body":     body,
+				"logID":          "fake-rekor-log",
+				"logIndex":       4,
+				"integratedTime": 1780000000,
+				"body":           body,
 				"verification": map[string]any{
-					"inclusionProof": map[string]any{"rootHash": "fake-root"},
+					"inclusionProof":       map[string]any{"rootHash": "fake-root"},
+					"signedEntryTimestamp": "fake-set",
 				},
 			},
 		})

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -7,10 +7,14 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -632,6 +636,22 @@ func TestIndependent_ValidLocalAnchor(t *testing.T) {
 	}
 }
 
+func TestIndependent_RekorAnchorFailsClosedUntilTrustedLogVerification(t *testing.T) {
+	fix := newFixture(t, 3)
+	evidence, bundle := writeIndependentRekorFixture(t, fix)
+
+	stdout, stderr, code := runRoot(t, "independent", evidence,
+		"--bundle", bundle,
+		"--key", fix.keyHex,
+	)
+	if code == cliutil.ExitOK {
+		t.Fatalf("Rekor independent verification succeeded without trusted log verification, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "trusted Rekor SET") {
+		t.Fatalf("stderr missing fail-closed Rekor verification error:\n%s", stderr)
+	}
+}
+
 func TestIndependent_RejectsRewrittenBundleCheckpoint(t *testing.T) {
 	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T14:00:00Z")
 	fix := newFixture(t, 2)
@@ -789,6 +809,54 @@ func writeIndependentFixture(t *testing.T, fix *fixture) (evidencePath, bundlePa
 		t.Fatalf("WriteBundle: %v", err)
 	}
 	return evidencePath, bundlePath, logPath
+}
+
+func writeIndependentRekorFixture(t *testing.T, fix *fixture) (evidencePath, bundlePath string) {
+	t.Helper()
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	evidencePath = filepath.Join(dir, "evidence.jsonl")
+	checkpoint, err := anchorpkg.BuildCheckpoint("proxy", fix.receipts, []string{fix.keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, rekorPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/log/entries" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		body := base64.StdEncoding.EncodeToString(raw)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"fake-uuid": map[string]any{
+				"logID":    "fake-rekor-log",
+				"logIndex": 4,
+				"body":     body,
+				"verification": map[string]any{
+					"inclusionProof": map[string]any{"rootHash": "fake-root"},
+				},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	proof, err := (anchorpkg.RekorLog{URL: server.URL, Signer: rekorPriv}).Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	bundlePath = filepath.Join(dir, "rekor-anchor-bundle.json")
+	if err := anchorpkg.WriteBundle(bundlePath, anchorpkg.NewBundle(checkpoint, proof)); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	return evidencePath, bundlePath
 }
 
 func moveIndependentEvidenceToSessionFile(t *testing.T, evidencePath string) string {

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -671,6 +671,16 @@ func TestIndependent_RejectsUnsupportedBundleBackendAsConfig(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), `unsupported anchor backend "future"`) {
 		t.Fatalf("err = %v, want unsupported backend", err)
 	}
+
+	bundle.Backend = anchorpkg.LocalBackend
+	bundle.Proof.Backend = anchorpkg.RekorBackend
+	_, code, err = independentBackend(bundle, independentOptions{logPath: logPath})
+	if code != cliutil.ExitConfig {
+		t.Fatalf("code=%d, want %d for backend mismatch", code, cliutil.ExitConfig)
+	}
+	if err == nil || !strings.Contains(err.Error(), "does not match proof backend") {
+		t.Fatalf("err = %v, want backend mismatch", err)
+	}
 }
 
 func TestIndependent_RejectsRewrittenBundleCheckpoint(t *testing.T) {

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -23,7 +23,9 @@ import (
 const (
 	BundleVersion     = 1
 	LocalBackend      = "local"
+	RekorBackend      = "rekor"
 	DefaultLocalLogID = "local-fake-log"
+	DefaultRekorURL   = "https://rekor.sigstore.dev"
 	GenesisHash       = "genesis"
 
 	dirPermissions  = 0o750
@@ -31,9 +33,15 @@ const (
 )
 
 var DefaultLimits = []string{
-	"External anchoring detects after-the-fact rewrite, delete, omit, and equivocation against the anchored checkpoint.",
-	"External anchoring does not prove real-time truth by whoever held the receipt signing key.",
+	"Anchor bundles bind a verified receipt-chain checkpoint to backend proof material.",
 	"The local backend is a deterministic test backend, not an operator-independent witness.",
+	"Anchoring does not prove real-time truth by whoever held the receipt signing key.",
+}
+
+var rekorLimits = []string{
+	"Rekor submission records a receipt-chain checkpoint for later transparency-log audit.",
+	"Independent Rekor verification requires trusted SET and inclusion-proof verification; this bundle does not make that claim.",
+	"Anchoring does not prove real-time truth by whoever held the receipt signing key.",
 }
 
 type Backend interface {
@@ -52,11 +60,22 @@ type Checkpoint struct {
 }
 
 type Proof struct {
-	Backend     string `json:"backend"`
-	LogID       string `json:"log_id"`
-	LogIndex    uint64 `json:"log_index"`
-	EntryHash   string `json:"entry_hash"`
-	LogRootHash string `json:"log_root_hash"`
+	Backend     string      `json:"backend"`
+	LogID       string      `json:"log_id"`
+	LogIndex    uint64      `json:"log_index"`
+	EntryHash   string      `json:"entry_hash"`
+	LogRootHash string      `json:"log_root_hash"`
+	Rekor       *RekorProof `json:"rekor,omitempty"`
+}
+
+type RekorProof struct {
+	URL                  string `json:"url,omitempty"`
+	UUID                 string `json:"uuid,omitempty"`
+	Body                 string `json:"body,omitempty"`
+	PublicKey            string `json:"public_key,omitempty"`
+	Signature            string `json:"signature,omitempty"`
+	IntegratedTime       int64  `json:"integrated_time,omitempty"`
+	SignedEntryTimestamp string `json:"signed_entry_timestamp,omitempty"`
 }
 
 type Bundle struct {
@@ -114,7 +133,7 @@ func NewBundle(checkpoint Checkpoint, proof Proof) Bundle {
 		CreatedAt:  time.Now().UTC(),
 		Checkpoint: checkpoint,
 		Proof:      proof,
-		Limits:     append([]string(nil), DefaultLimits...),
+		Limits:     limitsForBackend(proof.Backend),
 	}
 }
 
@@ -122,7 +141,7 @@ func VerifyBundle(b Bundle, receipts []receipt.Receipt, trustedKeys []string, ba
 	report := VerifyReport{
 		Valid:      false,
 		Proof:      b.Proof,
-		Limits:     append([]string(nil), DefaultLimits...),
+		Limits:     limitsForBackend(b.Proof.Backend),
 		Checkpoint: b.Checkpoint,
 	}
 	if b.Version != BundleVersion {
@@ -157,6 +176,15 @@ func VerifyBundle(b Bundle, receipts []receipt.Receipt, trustedKeys []string, ba
 	report.FinalSeq = computed.FinalSeq
 	report.RootHash = computed.RootHash
 	return report
+}
+
+func limitsForBackend(backend string) []string {
+	switch backend {
+	case RekorBackend:
+		return append([]string(nil), rekorLimits...)
+	default:
+		return append([]string(nil), DefaultLimits...)
+	}
 }
 
 func LoadBundle(path string) (Bundle, error) {

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -29,6 +29,9 @@ const (
 	rekorSHA256Algorithm        = "sha256"
 )
 
+// RekorLog submits receipt-chain checkpoints to Rekor and stores the returned
+// submission metadata. Verify fails closed until trusted Rekor SET and
+// inclusion-proof verification is implemented.
 type RekorLog struct {
 	URL        string
 	HTTPClient *http.Client
@@ -191,8 +194,29 @@ func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
 	if proof.Rekor == nil {
 		return errors.New("rekor proof required")
 	}
+	if strings.TrimSpace(proof.Rekor.URL) == "" {
+		return errors.New("rekor proof URL required")
+	}
+	if proof.Rekor.UUID == "" {
+		return errors.New("rekor proof UUID required")
+	}
+	if proof.LogID == "" {
+		return errors.New("rekor proof log_id required")
+	}
 	if proof.Rekor.Body == "" {
 		return errors.New("rekor proof body required")
+	}
+	if proof.EntryHash == "" {
+		return errors.New("rekor proof entry_hash required")
+	}
+	if proof.LogRootHash == "" {
+		return errors.New("rekor proof log_root_hash required")
+	}
+	if proof.Rekor.IntegratedTime <= 0 {
+		return errors.New("rekor proof integrated_time required")
+	}
+	if proof.Rekor.SignedEntryTimestamp == "" {
+		return errors.New("rekor proof signed_entry_timestamp required")
 	}
 	checkpointBytes, err := checkpointBytes(checkpoint)
 	if err != nil {
@@ -205,7 +229,7 @@ func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
 	if err != nil {
 		return fmt.Errorf("decode rekor body: %w", err)
 	}
-	if proof.EntryHash != "" && proof.EntryHash != sha256Hex([]byte(proof.Rekor.Body)) {
+	if proof.EntryHash != sha256Hex([]byte(proof.Rekor.Body)) {
 		return errors.New("rekor proof entry_hash does not match encoded body")
 	}
 	var body rekorSubmitRequest
@@ -230,6 +254,8 @@ func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
 	return nil
 }
 
+// LoadRekorPrivateKey loads the Ed25519 key used to sign Rekor submission
+// bodies before they are posted.
 func LoadRekorPrivateKey(path string) (ed25519.PrivateKey, error) {
 	key, err := domsigning.LoadPrivateKeyFile(path)
 	if err != nil {

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -121,11 +121,11 @@ func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
 	}
 	baseURL, err := normalizeRekorBaseURL(r.URL)
 	if err != nil {
-		return Proof{}, err
+		return Proof{}, fmt.Errorf("normalize rekor URL: %w", err)
 	}
 	endpoint, err := rekorEntriesURL(baseURL)
 	if err != nil {
-		return Proof{}, err
+		return Proof{}, fmt.Errorf("build rekor entries URL: %w", err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -194,29 +194,24 @@ func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
 	if proof.Rekor == nil {
 		return errors.New("rekor proof required")
 	}
-	if strings.TrimSpace(proof.Rekor.URL) == "" {
-		return errors.New("rekor proof URL required")
-	}
-	if proof.Rekor.UUID == "" {
-		return errors.New("rekor proof UUID required")
-	}
-	if proof.LogID == "" {
-		return errors.New("rekor proof log_id required")
-	}
-	if proof.Rekor.Body == "" {
-		return errors.New("rekor proof body required")
-	}
-	if proof.EntryHash == "" {
-		return errors.New("rekor proof entry_hash required")
-	}
-	if proof.LogRootHash == "" {
-		return errors.New("rekor proof log_root_hash required")
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "URL", value: proof.Rekor.URL},
+		{name: "UUID", value: proof.Rekor.UUID},
+		{name: "log_id", value: proof.LogID},
+		{name: "body", value: proof.Rekor.Body},
+		{name: "entry_hash", value: proof.EntryHash},
+		{name: "log_root_hash", value: proof.LogRootHash},
+		{name: "signed_entry_timestamp", value: proof.Rekor.SignedEntryTimestamp},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("rekor proof %s required", field.name)
+		}
 	}
 	if proof.Rekor.IntegratedTime <= 0 {
 		return errors.New("rekor proof integrated_time required")
-	}
-	if proof.Rekor.SignedEntryTimestamp == "" {
-		return errors.New("rekor proof signed_entry_timestamp required")
 	}
 	checkpointBytes, err := checkpointBytes(checkpoint)
 	if err != nil {

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -118,7 +119,11 @@ func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
 	if err != nil {
 		return Proof{}, fmt.Errorf("marshal rekor entry: %w", err)
 	}
-	endpoint, err := rekorEntriesURL(r.URL)
+	baseURL, err := normalizeRekorBaseURL(r.URL)
+	if err != nil {
+		return Proof{}, err
+	}
+	endpoint, err := rekorEntriesURL(baseURL)
 	if err != nil {
 		return Proof{}, err
 	}
@@ -165,7 +170,7 @@ func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
 		EntryHash:   sha256Hex([]byte(entry.Body)),
 		LogRootHash: entry.Verification.InclusionProof.RootHash,
 		Rekor: &RekorProof{
-			URL:                  strings.TrimRight(rekorBaseURL(r.URL), "/"),
+			URL:                  baseURL,
 			UUID:                 uuid,
 			Body:                 entry.Body,
 			PublicKey:            publicKey,
@@ -212,6 +217,13 @@ func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
 	}
 	if proof.Rekor.IntegratedTime <= 0 {
 		return errors.New("rekor proof integrated_time required")
+	}
+	normalizedURL, err := normalizeRekorBaseURL(proof.Rekor.URL)
+	if err != nil {
+		return fmt.Errorf("rekor proof URL invalid: %w", err)
+	}
+	if proof.Rekor.URL != normalizedURL {
+		return errors.New("rekor proof URL is not canonical")
 	}
 	checkpointBytes, err := checkpointBytes(checkpoint)
 	if err != nil {
@@ -323,8 +335,52 @@ func rekorBaseURL(raw string) string {
 	return strings.TrimSpace(raw)
 }
 
-func rekorEntriesURL(raw string) (string, error) {
+func normalizeRekorBaseURL(raw string) (string, error) {
 	base, err := url.Parse(rekorBaseURL(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse rekor URL: %w", err)
+	}
+	if base.Scheme == "" {
+		return "", errors.New("rekor URL scheme required")
+	}
+	base.Scheme = strings.ToLower(base.Scheme)
+	if base.Host == "" {
+		return "", errors.New("rekor URL host required")
+	}
+	if base.User != nil {
+		return "", errors.New("rekor URL userinfo is not allowed")
+	}
+	if base.RawQuery != "" {
+		return "", errors.New("rekor URL query is not allowed")
+	}
+	if base.Fragment != "" {
+		return "", errors.New("rekor URL fragment is not allowed")
+	}
+	if base.Scheme != "https" {
+		if base.Scheme != "http" || !isLocalRekorHost(base.Hostname()) {
+			return "", errors.New("rekor URL must use https unless host is a local test endpoint")
+		}
+	}
+	base.Host = strings.ToLower(base.Host)
+	base.Path = strings.TrimRight(base.Path, "/")
+	base.RawPath = ""
+	return base.String(), nil
+}
+
+func isLocalRekorHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func rekorEntriesURL(raw string) (string, error) {
+	baseURL, err := normalizeRekorBaseURL(raw)
+	if err != nil {
+		return "", err
+	}
+	base, err := url.Parse(baseURL)
 	if err != nil {
 		return "", fmt.Errorf("parse rekor URL: %w", err)
 	}
@@ -338,12 +394,23 @@ func decodeRekorEntry(data []byte) (rekorEntry, string, error) {
 	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
 		return rekorEntry{}, "", err
 	}
-	var byUUID map[string]rekorEntry
-	if err := json.Unmarshal(data, &byUUID); err == nil && len(byUUID) > 0 {
-		if len(byUUID) != 1 {
-			return rekorEntry{}, "", fmt.Errorf("rekor response contained %d entries, want exactly 1", len(byUUID))
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err == nil && len(raw) > 0 {
+		if isDirectRekorEntryObject(raw) {
+			var entry rekorEntry
+			if err := json.Unmarshal(data, &entry); err != nil {
+				return rekorEntry{}, "", fmt.Errorf("parse rekor response: %w", err)
+			}
+			return entry, "", nil
 		}
-		for uuid, entry := range byUUID {
+		if len(raw) != 1 {
+			return rekorEntry{}, "", fmt.Errorf("rekor response contained %d entries, want exactly 1", len(raw))
+		}
+		for uuid, entryData := range raw {
+			var entry rekorEntry
+			if err := json.Unmarshal(entryData, &entry); err != nil {
+				return rekorEntry{}, "", fmt.Errorf("parse rekor entry %q: %w", uuid, err)
+			}
 			return entry, uuid, nil
 		}
 	}
@@ -352,4 +419,13 @@ func decodeRekorEntry(data []byte) (rekorEntry, string, error) {
 		return rekorEntry{}, "", fmt.Errorf("parse rekor response: %w", err)
 	}
 	return entry, "", nil
+}
+
+func isDirectRekorEntryObject(raw map[string]json.RawMessage) bool {
+	for _, key := range []string{"logID", "logIndex", "integratedTime", "body", "verification"} {
+		if _, ok := raw[key]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -1,0 +1,334 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package anchor
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	rekorHashedRekordKind       = "hashedrekord"
+	rekorHashedRekordAPIVersion = "0.0.1"
+	rekorSHA256Algorithm        = "sha256"
+)
+
+type RekorLog struct {
+	URL        string
+	HTTPClient *http.Client
+	Signer     ed25519.PrivateKey
+}
+
+type rekorSubmitRequest struct {
+	APIVersion string          `json:"apiVersion"`
+	Kind       string          `json:"kind"`
+	Spec       rekorSubmitSpec `json:"spec"`
+}
+
+type rekorSubmitSpec struct {
+	Data      rekorData      `json:"data"`
+	Signature rekorSignature `json:"signature"`
+}
+
+type rekorData struct {
+	Hash rekorHash `json:"hash"`
+}
+
+type rekorHash struct {
+	Algorithm string `json:"algorithm"`
+	Value     string `json:"value"`
+}
+
+type rekorSignature struct {
+	Content   string         `json:"content"`
+	PublicKey rekorPublicKey `json:"publicKey"`
+}
+
+type rekorPublicKey struct {
+	Content string `json:"content"`
+}
+
+type rekorEntry struct {
+	LogID          string            `json:"logID"`
+	LogIndex       uint64            `json:"logIndex"`
+	IntegratedTime int64             `json:"integratedTime"`
+	Body           string            `json:"body"`
+	Verification   rekorVerification `json:"verification"`
+}
+
+type rekorVerification struct {
+	SignedEntryTimestamp string              `json:"signedEntryTimestamp"`
+	InclusionProof       rekorInclusionProof `json:"inclusionProof"`
+}
+
+type rekorInclusionProof struct {
+	RootHash   string   `json:"rootHash"`
+	LogIndex   uint64   `json:"logIndex"`
+	TreeSize   uint64   `json:"treeSize"`
+	Hashes     []string `json:"hashes"`
+	Checkpoint string   `json:"checkpoint"`
+}
+
+func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
+	if len(r.Signer) == 0 {
+		return Proof{}, errors.New("rekor signing key required")
+	}
+	checkpointBytes, err := checkpointBytes(checkpoint)
+	if err != nil {
+		return Proof{}, err
+	}
+	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, r.Signer)
+	if err != nil {
+		return Proof{}, err
+	}
+	body := rekorSubmitRequest{
+		APIVersion: rekorHashedRekordAPIVersion,
+		Kind:       rekorHashedRekordKind,
+		Spec: rekorSubmitSpec{
+			Data: rekorData{Hash: rekorHash{
+				Algorithm: rekorSHA256Algorithm,
+				Value:     sha256Hex(checkpointBytes),
+			}},
+			Signature: rekorSignature{
+				Content:   signature,
+				PublicKey: rekorPublicKey{Content: publicKey},
+			},
+		},
+	}
+	requestBody, err := json.Marshal(body)
+	if err != nil {
+		return Proof{}, fmt.Errorf("marshal rekor entry: %w", err)
+	}
+	endpoint, err := rekorEntriesURL(r.URL)
+	if err != nil {
+		return Proof{}, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(requestBody))
+	if err != nil {
+		return Proof{}, fmt.Errorf("build rekor request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := r.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return Proof{}, fmt.Errorf("submit rekor entry: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return Proof{}, fmt.Errorf("read rekor response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return Proof{}, fmt.Errorf("rekor submit status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	entry, uuid, err := decodeRekorEntry(respBody)
+	if err != nil {
+		return Proof{}, err
+	}
+	if uuid == "" {
+		return Proof{}, errors.New("rekor response UUID required")
+	}
+	if entry.LogID == "" {
+		return Proof{}, errors.New("rekor response logID required")
+	}
+	if entry.Body == "" {
+		return Proof{}, errors.New("rekor response body required")
+	}
+	proof := Proof{
+		Backend:     RekorBackend,
+		LogID:       entry.LogID,
+		LogIndex:    entry.LogIndex,
+		EntryHash:   sha256Hex([]byte(entry.Body)),
+		LogRootHash: entry.Verification.InclusionProof.RootHash,
+		Rekor: &RekorProof{
+			URL:                  strings.TrimRight(rekorBaseURL(r.URL), "/"),
+			UUID:                 uuid,
+			Body:                 entry.Body,
+			PublicKey:            publicKey,
+			Signature:            signature,
+			IntegratedTime:       entry.IntegratedTime,
+			SignedEntryTimestamp: entry.Verification.SignedEntryTimestamp,
+		},
+	}
+	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
+		return Proof{}, fmt.Errorf("validate submitted rekor proof: %w", err)
+	}
+	return proof, nil
+}
+
+func (r RekorLog) Verify(proof Proof, checkpoint Checkpoint) error {
+	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
+		return err
+	}
+	return errors.New("rekor independent verification unavailable: trusted Rekor SET and inclusion-proof verification is required")
+}
+
+func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
+	if proof.Backend != RekorBackend {
+		return fmt.Errorf("anchor proof backend %q is not %q", proof.Backend, RekorBackend)
+	}
+	if proof.Rekor == nil {
+		return errors.New("rekor proof required")
+	}
+	if proof.Rekor.Body == "" {
+		return errors.New("rekor proof body required")
+	}
+	checkpointBytes, err := checkpointBytes(checkpoint)
+	if err != nil {
+		return err
+	}
+	if err := verifyRekorSignature(checkpointBytes, proof.Rekor.PublicKey, proof.Rekor.Signature); err != nil {
+		return err
+	}
+	bodyBytes, err := base64.StdEncoding.DecodeString(proof.Rekor.Body)
+	if err != nil {
+		return fmt.Errorf("decode rekor body: %w", err)
+	}
+	if proof.EntryHash != "" && proof.EntryHash != sha256Hex([]byte(proof.Rekor.Body)) {
+		return errors.New("rekor proof entry_hash does not match encoded body")
+	}
+	var body rekorSubmitRequest
+	if err := decodeStrict(bodyBytes, &body); err != nil {
+		return fmt.Errorf("parse rekor body: %w", err)
+	}
+	if body.APIVersion != rekorHashedRekordAPIVersion || body.Kind != rekorHashedRekordKind {
+		return fmt.Errorf("unsupported rekor body %s/%s", body.Kind, body.APIVersion)
+	}
+	if body.Spec.Data.Hash.Algorithm != rekorSHA256Algorithm {
+		return fmt.Errorf("unsupported rekor hash algorithm %q", body.Spec.Data.Hash.Algorithm)
+	}
+	if body.Spec.Data.Hash.Value != sha256Hex(checkpointBytes) {
+		return errors.New("rekor body checkpoint digest does not match bundle checkpoint")
+	}
+	if body.Spec.Signature.Content != proof.Rekor.Signature {
+		return errors.New("rekor body signature does not match proof signature")
+	}
+	if body.Spec.Signature.PublicKey.Content != proof.Rekor.PublicKey {
+		return errors.New("rekor body public key does not match proof public key")
+	}
+	return nil
+}
+
+func LoadRekorPrivateKey(path string) (ed25519.PrivateKey, error) {
+	key, err := domsigning.LoadPrivateKeyFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("load rekor signing key: %w", err)
+	}
+	return key, nil
+}
+
+func checkpointBytes(checkpoint Checkpoint) ([]byte, error) {
+	data, err := json.Marshal(checkpoint)
+	if err != nil {
+		return nil, fmt.Errorf("marshal checkpoint: %w", err)
+	}
+	return data, nil
+}
+
+func signRekorCheckpoint(data []byte, priv ed25519.PrivateKey) (publicKey string, signature string, err error) {
+	if err := domsigning.ValidatePrivateKeyConsistency(priv); err != nil {
+		return "", "", fmt.Errorf("validate rekor signing key: %w", err)
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return "", "", errors.New("rekor signing key public key is not ed25519")
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", "", fmt.Errorf("marshal rekor public key: %w", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	if len(pemBytes) == 0 {
+		return "", "", errors.New("encode rekor public key")
+	}
+	return base64.StdEncoding.EncodeToString(pemBytes), base64.StdEncoding.EncodeToString(ed25519.Sign(priv, data)), nil
+}
+
+func verifyRekorSignature(data []byte, publicKey, signature string) error {
+	if publicKey == "" || signature == "" {
+		return errors.New("rekor proof public key and signature required")
+	}
+	pemBytes, err := base64.StdEncoding.DecodeString(publicKey)
+	if err != nil {
+		return fmt.Errorf("decode rekor public key: %w", err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return errors.New("parse rekor public key PEM")
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse rekor public key: %w", err)
+	}
+	pub, ok := parsed.(ed25519.PublicKey)
+	if !ok {
+		return errors.New("rekor public key is not ed25519")
+	}
+	sig, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return fmt.Errorf("decode rekor signature: %w", err)
+	}
+	if !ed25519.Verify(pub, data, sig) {
+		return errors.New("rekor checkpoint signature invalid")
+	}
+	return nil
+}
+
+func rekorBaseURL(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return DefaultRekorURL
+	}
+	return strings.TrimSpace(raw)
+}
+
+func rekorEntriesURL(raw string) (string, error) {
+	base, err := url.Parse(rekorBaseURL(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse rekor URL: %w", err)
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + "/api/v1/log/entries"
+	base.RawQuery = ""
+	base.Fragment = ""
+	return base.String(), nil
+}
+
+func decodeRekorEntry(data []byte) (rekorEntry, string, error) {
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		return rekorEntry{}, "", err
+	}
+	var byUUID map[string]rekorEntry
+	if err := json.Unmarshal(data, &byUUID); err == nil && len(byUUID) > 0 {
+		if len(byUUID) != 1 {
+			return rekorEntry{}, "", fmt.Errorf("rekor response contained %d entries, want exactly 1", len(byUUID))
+		}
+		for uuid, entry := range byUUID {
+			return entry, uuid, nil
+		}
+	}
+	var entry rekorEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return rekorEntry{}, "", fmt.Errorf("parse rekor response: %w", err)
+	}
+	return entry, "", nil
+}

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package anchor
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRekorLogSubmitRecordsSubmissionProof(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := fakeRekorServer(t)
+	proof, err := (RekorLog{URL: server.URL, Signer: priv}).Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if proof.Backend != RekorBackend || proof.Rekor == nil || proof.Rekor.Body == "" || proof.Rekor.Signature == "" {
+		t.Fatalf("incomplete proof: %+v", proof)
+	}
+	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
+		t.Fatalf("validateRekorSubmissionRecord: %v", err)
+	}
+	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, RekorLog{})
+	if report.Valid || !strings.Contains(report.Error, "trusted Rekor SET") {
+		t.Fatalf("VerifyBundle report = %+v, want fail-closed SET verification error", report)
+	}
+}
+
+func TestRekorSubmissionRecordRejectsTampering(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	proof, err := (RekorLog{URL: fakeRekorServer(t).URL, Signer: priv}).Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	if proof.Rekor == nil {
+		t.Fatal("proof.Rekor nil")
+	}
+	bodyBytes, err := base64.StdEncoding.DecodeString(proof.Rekor.Body)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	var body rekorSubmitRequest
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	body.Spec.Data.Hash.Value = strings.Repeat("0", 64)
+	tamperedBody, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	tampered := proof
+	tampered.Rekor = cloneRekorProof(proof.Rekor)
+	tampered.Rekor.Body = base64.StdEncoding.EncodeToString(tamperedBody)
+	tampered.EntryHash = sha256Hex([]byte(tampered.Rekor.Body))
+	if err := validateRekorSubmissionRecord(tampered, checkpoint); err == nil || !strings.Contains(err.Error(), "digest") {
+		t.Fatalf("validateRekorSubmissionRecord err = %v, want digest mismatch", err)
+	}
+
+	tamperedSig := proof
+	tamperedSig.Rekor = cloneRekorProof(proof.Rekor)
+	tamperedSig.Rekor.Signature = base64.StdEncoding.EncodeToString([]byte("not-a-valid-ed25519-signature"))
+	if err := validateRekorSubmissionRecord(tamperedSig, checkpoint); err == nil || !strings.Contains(err.Error(), "signature") {
+		t.Fatalf("validateRekorSubmissionRecord err = %v, want signature mismatch", err)
+	}
+}
+
+func TestRekorLogVerifyRejectsForgedSelfConsistentProof(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, attackerPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	checkpointBytes, err := checkpointBytes(checkpoint)
+	if err != nil {
+		t.Fatalf("checkpointBytes: %v", err)
+	}
+	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, attackerPriv)
+	if err != nil {
+		t.Fatalf("signRekorCheckpoint: %v", err)
+	}
+	body := rekorSubmitRequest{
+		APIVersion: rekorHashedRekordAPIVersion,
+		Kind:       rekorHashedRekordKind,
+		Spec: rekorSubmitSpec{
+			Data: rekorData{Hash: rekorHash{
+				Algorithm: rekorSHA256Algorithm,
+				Value:     sha256Hex(checkpointBytes),
+			}},
+			Signature: rekorSignature{
+				Content:   signature,
+				PublicKey: rekorPublicKey{Content: publicKey},
+			},
+		},
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	encodedBody := base64.StdEncoding.EncodeToString(bodyBytes)
+	proof := Proof{
+		Backend:     RekorBackend,
+		LogID:       "TOTALLY-MADE-UP",
+		LogIndex:    999999,
+		EntryHash:   sha256Hex([]byte(encodedBody)),
+		LogRootHash: "fabricated",
+		Rekor: &RekorProof{
+			URL:       "https://rekor.example.invalid",
+			UUID:      "fake-uuid",
+			Body:      encodedBody,
+			PublicKey: publicKey,
+			Signature: signature,
+		},
+	}
+	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
+		t.Fatalf("forged self-consistent submission record did not validate: %v", err)
+	}
+	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, RekorLog{})
+	if report.Valid || !strings.Contains(report.Error, "trusted Rekor SET") {
+		t.Fatalf("forged Rekor proof report = %+v, want fail-closed SET verification error", report)
+	}
+}
+
+func TestDecodeRekorEntryAcceptsRealisticUnknownFields(t *testing.T) {
+	body := base64.StdEncoding.EncodeToString([]byte(`{"kind":"hashedrekord"}`))
+	data := []byte(`{
+		"fake-uuid": {
+			"logID": "fake-rekor-log",
+			"logIndex": 7,
+			"integratedTime": 1780000000,
+			"body": "` + body + `",
+			"attestation": {"data": "ignored"},
+			"verification": {
+				"signedEntryTimestamp": "set-bytes",
+				"inclusionProof": {
+					"logIndex": 7,
+					"treeSize": 8,
+					"rootHash": "fake-root",
+					"hashes": ["a", "b"],
+					"checkpoint": "signed checkpoint"
+				}
+			}
+		}
+	}`)
+	entry, uuid, err := decodeRekorEntry(data)
+	if err != nil {
+		t.Fatalf("decodeRekorEntry: %v", err)
+	}
+	if uuid != "fake-uuid" || entry.Body != body || entry.Verification.SignedEntryTimestamp != "set-bytes" {
+		t.Fatalf("entry = %+v uuid=%q", entry, uuid)
+	}
+}
+
+func cloneRekorProof(in *RekorProof) *RekorProof {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func fakeRekorServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/log/entries" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var body rekorSubmitRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		raw, err := json.Marshal(body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		encodedBody := base64.StdEncoding.EncodeToString(raw)
+		entry := rekorEntry{
+			LogID:    "fake-rekor-log",
+			LogIndex: 7,
+			Body:     encodedBody,
+			Verification: rekorVerification{InclusionProof: rekorInclusionProof{
+				RootHash: sha256Hex([]byte(encodedBody)),
+			}},
+		}
+		_ = json.NewEncoder(w).Encode(map[string]rekorEntry{"fake-uuid": entry})
+	}))
+}

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -133,6 +133,11 @@ func TestRekorSubmissionRecordRequiresMetadata(t *testing.T) {
 	}{
 		{name: "url", edit: func(p *Proof) { p.Rekor.URL = "" }, want: "URL"},
 		{name: "url whitespace", edit: func(p *Proof) { p.Rekor.URL = " \t" }, want: "URL"},
+		{name: "url http remote", edit: func(p *Proof) { p.Rekor.URL = "http://rekor.example.invalid" }, want: "https"},
+		{name: "url query", edit: func(p *Proof) { p.Rekor.URL = "https://rekor.example.invalid?debug=true" }, want: "query"},
+		{name: "url fragment", edit: func(p *Proof) { p.Rekor.URL = "https://rekor.example.invalid#anchor" }, want: "fragment"},
+		{name: "url userinfo", edit: func(p *Proof) { p.Rekor.URL = "https://user@rekor.example.invalid" }, want: "userinfo"},
+		{name: "url noncanonical", edit: func(p *Proof) { p.Rekor.URL = "https://rekor.example.invalid/" }, want: "canonical"},
 		{name: "uuid", edit: func(p *Proof) { p.Rekor.UUID = "" }, want: "UUID"},
 		{name: "uuid whitespace", edit: func(p *Proof) { p.Rekor.UUID = " \t" }, want: "UUID"},
 		{name: "log id", edit: func(p *Proof) { p.LogID = "" }, want: "log_id"},
@@ -154,6 +159,41 @@ func TestRekorSubmissionRecordRequiresMetadata(t *testing.T) {
 			tc.edit(&candidate)
 			if err := validateRekorSubmissionRecord(candidate, checkpoint); err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("validateRekorSubmissionRecord err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeRekorBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+		err  string
+	}{
+		{name: "default", raw: "", want: DefaultRekorURL},
+		{name: "trim and canonicalize", raw: " HTTPS://Rekor.Example.Invalid/path/ ", want: "https://rekor.example.invalid/path"},
+		{name: "local http allowed", raw: "http://127.0.0.1:3000/", want: "http://127.0.0.1:3000"},
+		{name: "localhost http allowed", raw: "http://localhost:3000/", want: "http://localhost:3000"},
+		{name: "remote http", raw: "http://rekor.example.invalid", err: "https"},
+		{name: "query", raw: "https://rekor.example.invalid?debug=true", err: "query"},
+		{name: "fragment", raw: "https://rekor.example.invalid#frag", err: "fragment"},
+		{name: "userinfo", raw: "https://user@rekor.example.invalid", err: "userinfo"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeRekorBaseURL(tc.raw)
+			if tc.err != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.err) {
+					t.Fatalf("normalizeRekorBaseURL err = %v, want %q", err, tc.err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeRekorBaseURL: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeRekorBaseURL = %q, want %q", got, tc.want)
 			}
 		})
 	}
@@ -366,9 +406,12 @@ func TestDecodeRekorEntryAcceptsRealisticUnknownFields(t *testing.T) {
 
 func TestDecodeRekorEntryRejectsMalformedResponses(t *testing.T) {
 	for name, data := range map[string]string{
-		"duplicate": `{"fake-uuid":{"logID":"a"},"fake-uuid":{"logID":"b"}}`,
-		"multiple":  `{"uuid-a":{"logID":"a"},"uuid-b":{"logID":"b"}}`,
-		"invalid":   `{not json`,
+		"duplicate":        `{"fake-uuid":{"logID":"a"},"fake-uuid":{"logID":"b"}}`,
+		"nested duplicate": `{"fake-uuid":{"logID":"a","verification":{"inclusionProof":{"rootHash":"a","rootHash":"b"}}}}`,
+		"multiple":         `{"uuid-a":{"logID":"a"},"uuid-b":{"logID":"b"}}`,
+		"mapped type":      `{"fake-uuid":{"logID":123}}`,
+		"direct type":      `{"logID":123}`,
+		"invalid":          `{not json`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, _, err := decodeRekorEntry([]byte(data)); err == nil {

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -4,14 +4,25 @@
 package anchor
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	fakeRekorIntegratedTime int64 = 1780000000
+	fakeRekorRootHash             = "fake-root"
+	fakeRekorSET                  = "fake-set"
 )
 
 func TestRekorLogSubmitRecordsSubmissionProof(t *testing.T) {
@@ -29,8 +40,20 @@ func TestRekorLogSubmitRecordsSubmissionProof(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
-	if proof.Backend != RekorBackend || proof.Rekor == nil || proof.Rekor.Body == "" || proof.Rekor.Signature == "" {
+	if proof.Backend != RekorBackend || proof.Rekor == nil {
 		t.Fatalf("incomplete proof: %+v", proof)
+	}
+	if proof.LogID != "fake-rekor-log" || proof.LogIndex != 7 || proof.LogRootHash != fakeRekorRootHash || proof.EntryHash == "" {
+		t.Fatalf("unexpected Rekor log metadata: %+v", proof)
+	}
+	if proof.Rekor.URL != server.URL ||
+		proof.Rekor.UUID != "fake-uuid" ||
+		proof.Rekor.Body == "" ||
+		proof.Rekor.PublicKey == "" ||
+		proof.Rekor.Signature == "" ||
+		proof.Rekor.IntegratedTime != fakeRekorIntegratedTime ||
+		proof.Rekor.SignedEntryTimestamp != fakeRekorSET {
+		t.Fatalf("unexpected Rekor proof metadata: %+v", proof.Rekor)
 	}
 	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
 		t.Fatalf("validateRekorSubmissionRecord: %v", err)
@@ -88,6 +111,67 @@ func TestRekorSubmissionRecordRejectsTampering(t *testing.T) {
 	}
 }
 
+func TestRekorSubmissionRecordRequiresMetadata(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	proof, err := (RekorLog{URL: fakeRekorServer(t).URL, Signer: priv}).Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		edit func(*Proof)
+		want string
+	}{
+		{name: "url", edit: func(p *Proof) { p.Rekor.URL = "" }, want: "URL"},
+		{name: "uuid", edit: func(p *Proof) { p.Rekor.UUID = "" }, want: "UUID"},
+		{name: "log id", edit: func(p *Proof) { p.LogID = "" }, want: "log_id"},
+		{name: "entry hash", edit: func(p *Proof) { p.EntryHash = "" }, want: "entry_hash"},
+		{name: "root hash", edit: func(p *Proof) { p.LogRootHash = "" }, want: "log_root_hash"},
+		{name: "integrated time", edit: func(p *Proof) { p.Rekor.IntegratedTime = 0 }, want: "integrated_time"},
+		{name: "set", edit: func(p *Proof) { p.Rekor.SignedEntryTimestamp = "" }, want: "signed_entry_timestamp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := proof
+			candidate.Rekor = cloneRekorProof(proof.Rekor)
+			tc.edit(&candidate)
+			if err := validateRekorSubmissionRecord(candidate, checkpoint); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validateRekorSubmissionRecord err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadRekorPrivateKey(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "rekor.key")
+	if err := domsigning.SavePrivateKey(priv, path); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	loaded, err := LoadRekorPrivateKey(path)
+	if err != nil {
+		t.Fatalf("LoadRekorPrivateKey: %v", err)
+	}
+	if !loaded.Equal(priv) {
+		t.Fatal("loaded Rekor key does not match saved key")
+	}
+	if _, err := LoadRekorPrivateKey(filepath.Join(t.TempDir(), "missing.key")); err == nil || !strings.Contains(err.Error(), "load rekor signing key") {
+		t.Fatalf("LoadRekorPrivateKey missing err = %v, want wrapped load error", err)
+	}
+}
+
 func TestRekorLogVerifyRejectsForgedSelfConsistentProof(t *testing.T) {
 	receipts, keyHex := testReceiptChain(t, 1)
 	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
@@ -130,13 +214,15 @@ func TestRekorLogVerifyRejectsForgedSelfConsistentProof(t *testing.T) {
 		LogID:       "TOTALLY-MADE-UP",
 		LogIndex:    999999,
 		EntryHash:   sha256Hex([]byte(encodedBody)),
-		LogRootHash: "fabricated",
+		LogRootHash: "fabricated-root",
 		Rekor: &RekorProof{
-			URL:       "https://rekor.example.invalid",
-			UUID:      "fake-uuid",
-			Body:      encodedBody,
-			PublicKey: publicKey,
-			Signature: signature,
+			URL:                  "https://rekor.example.invalid",
+			UUID:                 "fake-uuid",
+			Body:                 encodedBody,
+			PublicKey:            publicKey,
+			Signature:            signature,
+			IntegratedTime:       fakeRekorIntegratedTime,
+			SignedEntryTimestamp: fakeRekorSET,
 		},
 	}
 	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
@@ -145,6 +231,98 @@ func TestRekorLogVerifyRejectsForgedSelfConsistentProof(t *testing.T) {
 	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, RekorLog{})
 	if report.Valid || !strings.Contains(report.Error, "trusted Rekor SET") {
 		t.Fatalf("forged Rekor proof report = %+v, want fail-closed SET verification error", report)
+	}
+}
+
+func TestRekorLogSubmitRejectsMalformedResponses(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    string
+	}{
+		{
+			name: "status",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "nope", http.StatusBadGateway)
+			},
+			want: "status 502",
+		},
+		{
+			name: "missing uuid",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				writeDirectRekorEntry(t, w, r, "fake-rekor-log", "body")
+			},
+			want: "UUID required",
+		},
+		{
+			name: "missing log id",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				writeMappedRekorEntry(t, w, r, "", "body", fakeRekorRootHash, fakeRekorSET, fakeRekorIntegratedTime)
+			},
+			want: "logID required",
+		},
+		{
+			name: "missing body",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				writeMappedRekorEntry(t, w, r, "fake-rekor-log", "", fakeRekorRootHash, fakeRekorSET, fakeRekorIntegratedTime)
+			},
+			want: "body required",
+		},
+		{
+			name: "missing set",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				writeMappedRekorEntry(t, w, r, "fake-rekor-log", "body", fakeRekorRootHash, "", fakeRekorIntegratedTime)
+			},
+			want: "signed_entry_timestamp",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			t.Cleanup(server.Close)
+			_, err := (RekorLog{URL: server.URL, Signer: priv}).Submit(checkpoint)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Submit err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRekorLogSubmitRejectsRequestFailures(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if _, err := (RekorLog{URL: "://bad-url", Signer: priv}).Submit(checkpoint); err == nil || !strings.Contains(err.Error(), "parse rekor URL") {
+		t.Fatalf("Submit bad URL err = %v, want parse error", err)
+	}
+	listener, err := new(net.ListenConfig).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	url := "http://" + listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := (RekorLog{URL: url, Signer: priv}).Submit(checkpoint); err == nil || !strings.Contains(err.Error(), "submit rekor entry") {
+		t.Fatalf("Submit connection err = %v, want submit error", err)
+	}
+	if _, err := (RekorLog{URL: fakeRekorServer(t).URL}).Submit(checkpoint); err == nil || !strings.Contains(err.Error(), "signing key required") {
+		t.Fatalf("Submit missing signer err = %v, want signing key error", err)
 	}
 }
 
@@ -178,6 +356,20 @@ func TestDecodeRekorEntryAcceptsRealisticUnknownFields(t *testing.T) {
 	}
 }
 
+func TestDecodeRekorEntryRejectsMalformedResponses(t *testing.T) {
+	for name, data := range map[string]string{
+		"duplicate": `{"fake-uuid":{"logID":"a"},"fake-uuid":{"logID":"b"}}`,
+		"multiple":  `{"uuid-a":{"logID":"a"},"uuid-b":{"logID":"b"}}`,
+		"invalid":   `{not json`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := decodeRekorEntry([]byte(data)); err == nil {
+				t.Fatal("decodeRekorEntry err = nil, want failure")
+			}
+		})
+	}
+}
+
 func cloneRekorProof(in *RekorProof) *RekorProof {
 	if in == nil {
 		return nil
@@ -188,7 +380,7 @@ func cloneRekorProof(in *RekorProof) *RekorProof {
 
 func fakeRekorServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/log/entries" {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
@@ -205,13 +397,66 @@ func fakeRekorServer(t *testing.T) *httptest.Server {
 		}
 		encodedBody := base64.StdEncoding.EncodeToString(raw)
 		entry := rekorEntry{
-			LogID:    "fake-rekor-log",
-			LogIndex: 7,
-			Body:     encodedBody,
-			Verification: rekorVerification{InclusionProof: rekorInclusionProof{
-				RootHash: sha256Hex([]byte(encodedBody)),
-			}},
+			LogID:          "fake-rekor-log",
+			LogIndex:       7,
+			IntegratedTime: fakeRekorIntegratedTime,
+			Body:           encodedBody,
+			Verification: rekorVerification{
+				SignedEntryTimestamp: fakeRekorSET,
+				InclusionProof: rekorInclusionProof{
+					RootHash: fakeRekorRootHash,
+				},
+			},
 		}
 		_ = json.NewEncoder(w).Encode(map[string]rekorEntry{"fake-uuid": entry})
 	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func writeDirectRekorEntry(t *testing.T, w http.ResponseWriter, r *http.Request, logID, body string) {
+	t.Helper()
+	if body == "body" {
+		body = encodedRekorRequestBody(t, r)
+	}
+	_ = json.NewEncoder(w).Encode(rekorEntry{
+		LogID:          logID,
+		LogIndex:       7,
+		IntegratedTime: fakeRekorIntegratedTime,
+		Body:           body,
+		Verification: rekorVerification{
+			SignedEntryTimestamp: fakeRekorSET,
+			InclusionProof:       rekorInclusionProof{RootHash: fakeRekorRootHash},
+		},
+	})
+}
+
+func writeMappedRekorEntry(t *testing.T, w http.ResponseWriter, r *http.Request, logID, body, rootHash, set string, integratedTime int64) {
+	t.Helper()
+	if body == "body" {
+		body = encodedRekorRequestBody(t, r)
+	}
+	_ = json.NewEncoder(w).Encode(map[string]rekorEntry{"fake-uuid": {
+		LogID:          logID,
+		LogIndex:       7,
+		IntegratedTime: integratedTime,
+		Body:           body,
+		Verification: rekorVerification{
+			SignedEntryTimestamp: set,
+			InclusionProof:       rekorInclusionProof{RootHash: rootHash},
+		},
+	}})
+}
+
+func encodedRekorRequestBody(t *testing.T, r *http.Request) string {
+	t.Helper()
+	var body rekorSubmitRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode request: %v", err)
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Marshal request: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
 }

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -137,6 +137,7 @@ func TestRekorSubmissionRecordRequiresMetadata(t *testing.T) {
 		{name: "uuid whitespace", edit: func(p *Proof) { p.Rekor.UUID = " \t" }, want: "UUID"},
 		{name: "log id", edit: func(p *Proof) { p.LogID = "" }, want: "log_id"},
 		{name: "log id whitespace", edit: func(p *Proof) { p.LogID = " \t" }, want: "log_id"},
+		{name: "body", edit: func(p *Proof) { p.Rekor.Body = "" }, want: "body"},
 		{name: "body whitespace", edit: func(p *Proof) { p.Rekor.Body = " \t" }, want: "body"},
 		{name: "entry hash", edit: func(p *Proof) { p.EntryHash = "" }, want: "entry_hash"},
 		{name: "entry hash whitespace", edit: func(p *Proof) { p.EntryHash = " \t" }, want: "entry_hash"},

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -132,12 +132,19 @@ func TestRekorSubmissionRecordRequiresMetadata(t *testing.T) {
 		want string
 	}{
 		{name: "url", edit: func(p *Proof) { p.Rekor.URL = "" }, want: "URL"},
+		{name: "url whitespace", edit: func(p *Proof) { p.Rekor.URL = " \t" }, want: "URL"},
 		{name: "uuid", edit: func(p *Proof) { p.Rekor.UUID = "" }, want: "UUID"},
+		{name: "uuid whitespace", edit: func(p *Proof) { p.Rekor.UUID = " \t" }, want: "UUID"},
 		{name: "log id", edit: func(p *Proof) { p.LogID = "" }, want: "log_id"},
+		{name: "log id whitespace", edit: func(p *Proof) { p.LogID = " \t" }, want: "log_id"},
+		{name: "body whitespace", edit: func(p *Proof) { p.Rekor.Body = " \t" }, want: "body"},
 		{name: "entry hash", edit: func(p *Proof) { p.EntryHash = "" }, want: "entry_hash"},
+		{name: "entry hash whitespace", edit: func(p *Proof) { p.EntryHash = " \t" }, want: "entry_hash"},
 		{name: "root hash", edit: func(p *Proof) { p.LogRootHash = "" }, want: "log_root_hash"},
+		{name: "root hash whitespace", edit: func(p *Proof) { p.LogRootHash = " \t" }, want: "log_root_hash"},
 		{name: "integrated time", edit: func(p *Proof) { p.Rekor.IntegratedTime = 0 }, want: "integrated_time"},
 		{name: "set", edit: func(p *Proof) { p.Rekor.SignedEntryTimestamp = "" }, want: "signed_entry_timestamp"},
+		{name: "set whitespace", edit: func(p *Proof) { p.Rekor.SignedEntryTimestamp = " \t" }, want: "signed_entry_timestamp"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -21,8 +21,11 @@ type receiptsOptions struct {
 	keys      []string
 	sessionID string
 	asDir     bool
+	backend   string
 	logPath   string
 	logID     string
+	rekorURL  string
+	rekorKey  string
 	output    string
 }
 
@@ -30,11 +33,13 @@ func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "anchor",
 		Short: "Anchor receipt-chain checkpoints",
-		Long: `Anchors verified receipt-chain checkpoints to an append-only backend.
+		Long: `Anchors verified receipt-chain checkpoints to backend proof material.
 
 The local backend is a deterministic test backend. It exercises the same
-checkpoint and proof plumbing used by real external logs, but it is not an
-operator-independent witness.`,
+checkpoint and proof plumbing used by outside logs, but it is not an
+operator-independent witness. The Rekor backend records a transparency-log
+submission for later audit; independent Rekor verification requires trusted SET
+and inclusion-proof verification.`,
 	}
 	cmd.AddCommand(receiptsCmd())
 	return cmd
@@ -46,13 +51,13 @@ func receiptsCmd() *cobra.Command {
 		Use:   "receipts PATH",
 		Short: "Anchor a verified receipt chain checkpoint",
 		Long: `Verifies a receipt chain with pinned signer keys, writes its chain head to
-an anchor backend, and emits an anchor bundle for independent verification.
+an anchor backend, and emits an anchor bundle for verifier and audit tooling.
 
-Honest limit: anchoring detects after-the-fact rewrite, delete, omit, and
-equivocation against the anchored checkpoint. It does not prove real-time truth
-by whoever held the receipt signing key. The local backend is for deterministic
-tests and development; a real outside witness backend must replace it before
-claiming operator-independent evidence.`,
+Honest limit: anchoring does not prove real-time truth by whoever held the
+receipt signing key. The local backend is for deterministic tests and
+development. Rekor submission is recorded for later transparency-log audit, but
+this command does not claim independent Rekor verification without trusted SET
+and inclusion-proof checks.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runReceipts(cmd.OutOrStdout(), args[0], opts)
@@ -61,8 +66,11 @@ claiming operator-independent evidence.`,
 	cmd.Flags().StringArrayVar(&opts.keys, "key", nil, "trusted signer public key (hex or file path); repeat for rotated chains")
 	cmd.Flags().StringVar(&opts.sessionID, "session", "proxy", "session ID inside the evidence directory when --dir is set")
 	cmd.Flags().BoolVar(&opts.asDir, "dir", false, "treat PATH as a session directory rather than a single evidence file")
-	cmd.Flags().StringVar(&opts.logPath, "local-log", "", "local fake-log JSONL path (required for this backend)")
+	cmd.Flags().StringVar(&opts.backend, "backend", anchorpkg.LocalBackend, "anchor backend: local or rekor")
+	cmd.Flags().StringVar(&opts.logPath, "local-log", "", "local fake-log JSONL path (required for local backend)")
 	cmd.Flags().StringVar(&opts.logID, "log-id", anchorpkg.DefaultLocalLogID, "local fake-log identifier")
+	cmd.Flags().StringVar(&opts.rekorURL, "rekor-url", anchorpkg.DefaultRekorURL, "Rekor base URL")
+	cmd.Flags().StringVar(&opts.rekorKey, "rekor-key", "", "Ed25519 private key file used to sign the Rekor checkpoint entry")
 	cmd.Flags().StringVar(&opts.output, "out", "", "anchor bundle output path")
 	return cmd
 }
@@ -74,9 +82,6 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 	}
 	if len(trustedKeys) == 0 {
 		return fmt.Errorf("at least one --key is required to anchor a receipt chain")
-	}
-	if opts.logPath == "" {
-		return fmt.Errorf("--local-log is required for the local anchor backend")
 	}
 	if opts.output == "" {
 		return fmt.Errorf("--out is required")
@@ -90,7 +95,11 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 	if err != nil {
 		return err
 	}
-	proof, err := (anchorpkg.LocalLog{Path: opts.logPath, LogID: opts.logID}).Submit(checkpoint)
+	backend, err := resolveBackend(opts)
+	if err != nil {
+		return err
+	}
+	proof, err := backend.Submit(checkpoint)
 	if err != nil {
 		return err
 	}
@@ -106,8 +115,31 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 	_, _ = fmt.Fprintf(out, "  Receipts:      %d\n", checkpoint.ReceiptCount)
 	_, _ = fmt.Fprintf(out, "  Final seq:     %d\n", checkpoint.FinalSeq)
 	_, _ = fmt.Fprintf(out, "  Root hash:     %s\n", checkpoint.RootHash)
-	_, _ = fmt.Fprintln(out, "  Limit:         local backend is not an operator-independent witness")
+	for _, limit := range bundle.Limits {
+		_, _ = fmt.Fprintf(out, "  Limit:         %s\n", limit)
+	}
 	return nil
+}
+
+func resolveBackend(opts receiptsOptions) (anchorpkg.Backend, error) {
+	switch strings.TrimSpace(opts.backend) {
+	case "", anchorpkg.LocalBackend:
+		if opts.logPath == "" {
+			return nil, fmt.Errorf("--local-log is required for the local anchor backend")
+		}
+		return anchorpkg.LocalLog{Path: opts.logPath, LogID: opts.logID}, nil
+	case anchorpkg.RekorBackend:
+		if strings.TrimSpace(opts.rekorKey) == "" {
+			return nil, fmt.Errorf("--rekor-key is required for the rekor anchor backend")
+		}
+		key, err := anchorpkg.LoadRekorPrivateKey(opts.rekorKey)
+		if err != nil {
+			return nil, err
+		}
+		return anchorpkg.RekorLog{URL: opts.rekorURL, Signer: key}, nil
+	default:
+		return nil, fmt.Errorf("unsupported anchor backend %q", opts.backend)
+	}
 }
 
 func extractReceipts(target string, opts receiptsOptions) ([]receipt.Receipt, string, error) {

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -26,6 +26,7 @@ type receiptsOptions struct {
 	logID     string
 	rekorURL  string
 	rekorKey  string
+	rekorYes  bool
 	output    string
 }
 
@@ -71,6 +72,7 @@ and inclusion-proof checks.`,
 	cmd.Flags().StringVar(&opts.logID, "log-id", anchorpkg.DefaultLocalLogID, "local fake-log identifier")
 	cmd.Flags().StringVar(&opts.rekorURL, "rekor-url", anchorpkg.DefaultRekorURL, "Rekor base URL")
 	cmd.Flags().StringVar(&opts.rekorKey, "rekor-key", "", "Ed25519 private key file used to sign the Rekor checkpoint entry")
+	cmd.Flags().BoolVar(&opts.rekorYes, "yes-send-to-remote-log", false, "acknowledge Rekor anchoring sends checkpoint material to the configured remote log")
 	cmd.Flags().StringVar(&opts.output, "out", "", "anchor bundle output path")
 	return cmd
 }
@@ -110,6 +112,9 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 
 	_, _ = fmt.Fprintf(out, "ANCHOR BUNDLE WRITTEN: %s\n", filepath.Clean(opts.output))
 	_, _ = fmt.Fprintf(out, "  Backend:       %s\n", proof.Backend)
+	if proof.Rekor != nil {
+		_, _ = fmt.Fprintf(out, "  Rekor URL:     %s\n", proof.Rekor.URL)
+	}
 	_, _ = fmt.Fprintf(out, "  Log index:     %d\n", proof.LogIndex)
 	_, _ = fmt.Fprintf(out, "  Session:       %s\n", checkpoint.SessionID)
 	_, _ = fmt.Fprintf(out, "  Receipts:      %d\n", checkpoint.ReceiptCount)
@@ -131,6 +136,9 @@ func resolveBackend(opts receiptsOptions) (anchorpkg.Backend, error) {
 	case anchorpkg.RekorBackend:
 		if strings.TrimSpace(opts.rekorKey) == "" {
 			return nil, fmt.Errorf("--rekor-key is required for the rekor anchor backend")
+		}
+		if !opts.rekorYes {
+			return nil, fmt.Errorf("--yes-send-to-remote-log is required for the rekor anchor backend")
 		}
 		key, err := anchorpkg.LoadRekorPrivateKey(opts.rekorKey)
 		if err != nil {

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -130,11 +130,13 @@ func TestReceiptsCmdWritesRekorAnchorBundle(t *testing.T) {
 		encodedBody := base64.StdEncoding.EncodeToString(raw)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"fake-uuid": map[string]any{
-				"logID":    "fake-rekor-log",
-				"logIndex": 3,
-				"body":     encodedBody,
+				"logID":          "fake-rekor-log",
+				"logIndex":       3,
+				"integratedTime": 1780000000,
+				"body":           encodedBody,
 				"verification": map[string]any{
-					"inclusionProof": map[string]any{"rootHash": "fake-root"},
+					"inclusionProof":       map[string]any{"rootHash": "fake-root"},
+					"signedEntryTimestamp": "fake-set",
 				},
 			},
 		})
@@ -159,8 +161,20 @@ func TestReceiptsCmdWritesRekorAnchorBundle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadBundle: %v", err)
 	}
-	if bundle.Backend != anchorpkg.RekorBackend || bundle.Proof.Rekor == nil || bundle.Proof.Rekor.Body == "" {
+	if bundle.Backend != anchorpkg.RekorBackend || bundle.Proof.Backend != anchorpkg.RekorBackend || bundle.Proof.Rekor == nil {
 		t.Fatalf("unexpected Rekor bundle: %+v", bundle)
+	}
+	if bundle.Proof.LogID != "fake-rekor-log" || bundle.Proof.LogIndex != 3 || bundle.Proof.LogRootHash != "fake-root" || bundle.Proof.EntryHash == "" {
+		t.Fatalf("unexpected Rekor log metadata: %+v", bundle.Proof)
+	}
+	if bundle.Proof.Rekor.UUID != "fake-uuid" ||
+		bundle.Proof.Rekor.URL != server.URL ||
+		bundle.Proof.Rekor.Body == "" ||
+		bundle.Proof.Rekor.PublicKey == "" ||
+		bundle.Proof.Rekor.Signature == "" ||
+		bundle.Proof.Rekor.IntegratedTime != 1780000000 ||
+		bundle.Proof.Rekor.SignedEntryTimestamp != "fake-set" {
+		t.Fatalf("unexpected Rekor proof metadata: %+v", bundle.Proof.Rekor)
 	}
 	if !strings.Contains(out.String(), "Backend:       rekor") {
 		t.Fatalf("output missing Rekor backend:\n%s", out.String())

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -7,7 +7,11 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +21,7 @@ import (
 	anchorpkg "github.com/luckyPipewrench/pipelock/internal/anchor"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 func cliReceiptJSONL(t *testing.T) (path string, keyHex string) {
@@ -102,6 +107,66 @@ func TestReceiptsCmdWritesLocalAnchorBundle(t *testing.T) {
 	}
 }
 
+func TestReceiptsCmdWritesRekorAnchorBundle(t *testing.T) {
+	receiptsPath, keyHex := cliReceiptJSONL(t)
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "bundle.json")
+	rekorKey := writeRekorKey(t, dir)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/log/entries" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		raw, err := json.Marshal(body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		encodedBody := base64.StdEncoding.EncodeToString(raw)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"fake-uuid": map[string]any{
+				"logID":    "fake-rekor-log",
+				"logIndex": 3,
+				"body":     encodedBody,
+				"verification": map[string]any{
+					"inclusionProof": map[string]any{"rootHash": "fake-root"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	cmd := receiptsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{
+		receiptsPath,
+		"--key", keyHex,
+		"--backend", anchorpkg.RekorBackend,
+		"--rekor-url", server.URL,
+		"--rekor-key", rekorKey,
+		"--out", bundlePath,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	bundle, err := anchorpkg.LoadBundle(bundlePath)
+	if err != nil {
+		t.Fatalf("LoadBundle: %v", err)
+	}
+	if bundle.Backend != anchorpkg.RekorBackend || bundle.Proof.Rekor == nil || bundle.Proof.Rekor.Body == "" {
+		t.Fatalf("unexpected Rekor bundle: %+v", bundle)
+	}
+	if !strings.Contains(out.String(), "Backend:       rekor") {
+		t.Fatalf("output missing Rekor backend:\n%s", out.String())
+	}
+}
+
 func TestCmdRegistersReceiptsSubcommand(t *testing.T) {
 	cmd := Cmd()
 	if cmd.Use != "anchor" {
@@ -139,6 +204,21 @@ func TestReceiptsCmdRequiresLocalLogAndOutput(t *testing.T) {
 				t.Fatalf("Execute err = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestReceiptsCmdRequiresRekorKey(t *testing.T) {
+	receiptsPath, keyHex := cliReceiptJSONL(t)
+	cmd := receiptsCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		receiptsPath,
+		"--key", keyHex,
+		"--backend", anchorpkg.RekorBackend,
+		"--out", filepath.Join(t.TempDir(), "bundle.json"),
+	})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--rekor-key is required") {
+		t.Fatalf("Execute err = %v, want Rekor key error", err)
 	}
 }
 
@@ -194,4 +274,17 @@ func TestReceiptsCmdReturnsFallbackExtractionError(t *testing.T) {
 	if !strings.Contains(err.Error(), "reading raw receipts") {
 		t.Fatalf("Execute err = %v, want fallback raw-receipt error", err)
 	}
+}
+
+func writeRekorKey(t *testing.T, dir string) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	path := filepath.Join(dir, "rekor.key")
+	if err := domsigning.SavePrivateKey(priv, path); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	return path
 }

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -152,6 +152,7 @@ func TestReceiptsCmdWritesRekorAnchorBundle(t *testing.T) {
 		"--backend", anchorpkg.RekorBackend,
 		"--rekor-url", server.URL,
 		"--rekor-key", rekorKey,
+		"--yes-send-to-remote-log",
 		"--out", bundlePath,
 	})
 	if err := cmd.Execute(); err != nil {
@@ -178,6 +179,9 @@ func TestReceiptsCmdWritesRekorAnchorBundle(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Backend:       rekor") {
 		t.Fatalf("output missing Rekor backend:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Rekor URL:     "+server.URL) {
+		t.Fatalf("output missing Rekor URL:\n%s", out.String())
 	}
 }
 
@@ -233,6 +237,23 @@ func TestReceiptsCmdRequiresRekorKey(t *testing.T) {
 	})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--rekor-key is required") {
 		t.Fatalf("Execute err = %v, want Rekor key error", err)
+	}
+}
+
+func TestReceiptsCmdRequiresRekorRemoteAcknowledgement(t *testing.T) {
+	receiptsPath, keyHex := cliReceiptJSONL(t)
+	dir := t.TempDir()
+	cmd := receiptsCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		receiptsPath,
+		"--key", keyHex,
+		"--backend", anchorpkg.RekorBackend,
+		"--rekor-key", writeRekorKey(t, dir),
+		"--out", filepath.Join(dir, "bundle.json"),
+	})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--yes-send-to-remote-log is required") {
+		t.Fatalf("Execute err = %v, want Rekor acknowledgement error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a Rekor submission backend for receipt-chain checkpoint anchor bundles
- record Rekor response body, log metadata, submitter signature, and SET metadata in anchor proofs
- fail closed for Rekor independent verification until trusted SET and inclusion-proof verification is implemented

## Notes
- local fake-log remains the deterministic test backend
- Rekor bundles are submission records in this slice; pipelock-verifier does not report them as independently verified without trusted Rekor log attestation verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rekor-backed anchoring with bundle support for Rekor proof/metadata and backend-specific “limits”, plus independent verification coverage for Rekor-backed flows.
  * Extended anchoring/receipt CLI commands with backend selection and Rekor URL/key options.
* **Bug Fixes**
  * Independent verification now validates anchor/proof backend compatibility, selects the appropriate anchor backend dynamically, and fails closed when trusted Rekor verification can’t be satisfied.
* **Tests**
  * Added end-to-end Rekor submit/verify, CLI Rekor bundle, and negative/tamper and failure-mode coverage.
* **Documentation**
  * Refined CLI help text to clarify “anchored” independent verification behavior and backend requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->