### PR TITLE
docs: align accuracy claims with live stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,11 +53,13 @@ Agent (has secrets, no network) → Pipelock Proxy (no agent secrets, has networ
 2. CRLF injection detection (encoded CR/LF in URLs)
 3. Path traversal detection (encoded dot-dot sequences)
 4. Domain blocklist (deny/allow per mode)
-5. DLP (48 regex patterns for API keys/tokens + checksum validators + env var leak detection)
-6. SSRF (private IPs, link-local, metadata endpoints, DNS rebinding)
-7. Rate limiting (per-domain sliding window)
-8. URL length (configurable max)
-9. Data budget (per-domain byte limits)
+5. DLP (65 built-in credential patterns + checksum validators + env var leak detection)
+6. Path entropy analysis
+7. Subdomain entropy analysis
+8. SSRF (private IPs, link-local, metadata endpoints, DNS rebinding)
+9. Rate limiting (per-domain sliding window)
+10. URL length (configurable max)
+11. Data budget (per-domain byte limits)
 
 **MCP proxy scans three directions:**
 - Server responses → prompt injection
@@ -83,7 +85,7 @@ These are Pipelock's three pillars. Weight findings in these areas highest.
 ## Code Conventions
 
 - **Go 1.25+**, module: `github.com/luckyPipewrench/pipelock`
-- **20 direct dependencies.** Don't suggest adding deps without strong justification.
+- **Dependency count is live, not fixed in prose.** Run `make stats` before citing the current direct-dependency count. Don't suggest adding deps without strong justification.
 - **golangci-lint v2** with 19 linters + gofumpt formatter (see `.golangci.yml`)
 - **`cmd.OutOrStdout()`** for output, never raw `fmt.Print`
 - **`0o600`** not `0600` for file permissions (gosec)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -269,7 +269,7 @@ Scans request bodies and headers for secret exfiltration and prompt injection be
 
 ```yaml
 request_body_scanning:
-  enabled: false
+  enabled: true
   action: warn              # warn or block (no strip for bodies)
   max_body_bytes: 5242880   # 5MB; fail-closed above this
   scan_headers: true        # scan request headers for DLP
@@ -285,7 +285,7 @@ request_body_scanning:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `enabled` | `false` | Enable request body/header DLP scanning and request body prompt-injection scanning |
+| `enabled` | `true` | Enable request body/header DLP scanning and request body prompt-injection scanning |
 | `action` | `warn` | `warn` logs ordinary findings, `block` rejects ordinary findings (requires enforce mode). Critical DLP and prompt-injection hard-blocks still reject non-provider destinations in enforce mode. |
 | `max_body_bytes` | `5242880` | Max body size to buffer; bodies exceeding this are always blocked (fail-closed) |
 | `scan_headers` | `true` | Scan request headers for DLP patterns |
@@ -310,7 +310,7 @@ request_body_scanning:
 
 **Security hard-blocks:** In enforce mode, critical-severity DLP findings in request bodies hard-block with `X-Pipelock-Block-Reason: dlp_match` even when `request_body_scanning.action: warn`. Request-body prompt-injection findings hard-block non-provider destinations with `X-Pipelock-Block-Reason: prompt_injection`. Operators that need audit-only rollout for selected critical patterns can set those individual patterns to `action: warn` or run the deployment with `enforce: false`.
 
-**Note on `scan_headers`:** The config default is `true`, but omitting the field from your YAML file gives `false` (Go's zero value overrides the default). Always set `scan_headers: true` explicitly in your config if you want header scanning enabled.
+**Note on security defaults:** Omitting `request_body_scanning.enabled` or `request_body_scanning.scan_headers` defaults both to `true`. Set either field to `false` explicitly only when you intend to disable that protection.
 
 ## Redaction
 

--- a/docs/guides/block-reason-header.md
+++ b/docs/guides/block-reason-header.md
@@ -13,7 +13,7 @@ The schema is locked at v1. Additive changes (new reason codes, new optional hea
 | `X-Pipelock-Block-Reason-Severity` | Always | `critical` |
 | `X-Pipelock-Block-Reason-Retry` | Always | `none` |
 | `X-Pipelock-Block-Reason-Layer` | Optional | `body_dlp` |
-| `X-Pipelock-Block-Reason-Receipt` | Optional | `01J0GNYZ7XSQRTQ8FPYM5BHX2K` |
+| `X-Pipelock-Block-Reason-Receipt` | Optional | `0190a3c4-1234-7abc-89ab-0123456789ab` |
 
 The version header lets a future v2 schema break compatibility cleanly. Receivers should parse the version header first and reject unknown majors.
 
@@ -101,7 +101,7 @@ Agents should switch on the retry hint, not on the reason code, when deciding wh
 
 `X-Pipelock-Block-Reason-Layer` carries the scanner label that fired (e.g. `subdomain_entropy`, `body_dlp`, `tool_policy`). Useful for telemetry attribution. Bounded to 32 characters; longer labels are dropped, not silently truncated.
 
-`X-Pipelock-Block-Reason-Receipt` is reserved for a 26-character Crockford-base32 ULID identifying an action receipt. The header schema and validator (`WithReceipt`) ship in v2.4, but v2.4 production block paths leave it unset — the header surface is reserved for follow-up wiring that supplies a receipt ID at the block emit site. When a block path does populate it, an auditor can pull the receipt by ID from the receipt store. Receipts are signed; see [`receipt-transports.md`](receipt-transports.md).
+`X-Pipelock-Block-Reason-Receipt` carries an opaque receipt identifier when the block path has one available. The validator accepts either a 26-character Crockford-base32 ULID or a canonical 36-character hyphenated UUIDv7; live receipt `action_id` values use the UUIDv7 form. When populated, an auditor can pull the matching receipt by ID from the receipt store. Receipts are signed; see [`receipt-transports.md`](receipt-transports.md).
 
 ## Privacy: what the headers do NOT carry
 

--- a/docs/specs/block-reason-header.md
+++ b/docs/specs/block-reason-header.md
@@ -4,7 +4,7 @@ When pipelock blocks an outbound request, the response carries a small set of HT
 
 This document is the canonical schema. Once an agent in production reads `dlp_match`, the vocabulary is locked. Renaming a code in v2 breaks every consumer.
 
-> **Status:** the schema and emit package land first (this PR). The transport refactor that wires every block path to call `Info.SetHeaders` lands in a follow-up PR. Until that PR merges, the vocabulary below is the *target* — it is not currently emitted on production blocks. The split is intentional: locking the operator-facing vocabulary before any block site commits to it.
+> **Status:** the v1 schema, validators, and production emit sites are shipped. The production-path matrix test (`internal/blockreason/production_path_matrix_test.go`) fails the build if a reason code has no production emit site or documented non-HTTP exemption.
 
 ## Header set
 
@@ -164,7 +164,7 @@ Agents should treat unknown reason codes as a generic block at the declared seve
 
 ## Transport coverage
 
-The follow-up transport PR wires the header onto every pipelock block path. There is no transport split — the schema is the same on every surface; only the framing differs (HTTP headers vs WebSocket close-frame JSON).
+HTTP-capable block paths emit the same v1 schema; only the framing differs (HTTP headers vs WebSocket close-frame JSON). MCP JSON-RPC-only blocks preserve the same reason vocabulary in error metadata where there is no HTTP response surface.
 
 | Transport | Mechanism |
 |---|---|

--- a/docs/specs/receipt-prior-art-mapping.md
+++ b/docs/specs/receipt-prior-art-mapping.md
@@ -83,7 +83,7 @@ and responses so intermediaries can verify origin and integrity.
 | Signed components | `target`, `method`, `transport` on the action record | Receipts capture the action semantically, not the byte-for-byte request. |
 | `keyid` parameter | `signer_key` | RFC 9421 `keyid` is an application-defined key identifier; receipts use raw hex today. A JWK or JWK-thumbprint (RFC 7638) profile would make the identifier resolver-friendly. |
 | Signature algorithm | `ed25519` | RFC 9421 supports ed25519. |
-| Integration point | `X-Pipelock-Block-Reason-Receipt` response header (opaque ULID receipt ID) | Block responses already carry a receipt ID per the [block-reason header spec](./block-reason-header.md); relying parties can fetch the matching receipt through the transports documented at [`docs/guides/receipt-transports.md`](../guides/receipt-transports.md). Embedding a full receipt inline in an HTTP header is a possible future profile, not shipped today. |
+| Integration point | `X-Pipelock-Block-Reason-Receipt` response header (opaque receipt ID) | Block responses may carry a receipt ID per the [block-reason header spec](./block-reason-header.md) when that block path has a receipt action ID available; relying parties can fetch the matching receipt through the transports documented at [`docs/guides/receipt-transports.md`](../guides/receipt-transports.md). Embedding a full receipt inline in an HTTP header is a possible future profile, not shipped today. |
 
 **Relationship:** Different problem. RFC 9421 proves "this HTTP message has not been
 modified." Receipts prove "an authorized agent caused this semantic action." Both can

--- a/internal/config/docs_accuracy_test.go
+++ b/internal/config/docs_accuracy_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDocsDeclareLiveStatsAndDefaults(t *testing.T) {
+	t.Parallel()
+
+	root := repoRootForDocsAccuracy(t)
+
+	configDoc := readDocAccuracyFile(t, root, "docs/configuration.md")
+	mustContain(t, configDoc, "request_body_scanning:\n  enabled: true")
+	mustContain(t, configDoc, "| `enabled` | `true` | Enable request body/header DLP scanning")
+	mustContain(t, configDoc, "Omitting `request_body_scanning.enabled` or `request_body_scanning.scan_headers` defaults both to `true`")
+	mustNotContain(t, configDoc, "omitting the field from your YAML file gives `false`")
+
+	agentDoc := readDocAccuracyFile(t, root, "AGENTS.md")
+	// Derive the DLP count from the live canonical source (same as make stats /
+	// TestCanonicalStats) so the doc must agree with reality, not a frozen
+	// literal. Hardcoding "65" here would let the doc rot when patterns are
+	// added (the count ratchets up) and would fail a *correct* doc update.
+	dlpCount := len(Defaults().DLP.Patterns)
+	mustContain(t, agentDoc, fmt.Sprintf("DLP (%d built-in credential patterns", dlpCount))
+	mustContain(t, agentDoc, "Path entropy analysis")
+	mustContain(t, agentDoc, "Subdomain entropy analysis")
+	mustContain(t, agentDoc, "Run `make stats` before citing the current direct-dependency count")
+	mustNotContain(t, agentDoc, "48 regex patterns")
+	mustNotContain(t, agentDoc, "20 direct dependencies")
+
+	blockReasonGuide := readDocAccuracyFile(t, root, "docs/guides/block-reason-header.md")
+	mustContain(t, blockReasonGuide, "canonical 36-character hyphenated UUIDv7")
+	mustContain(t, blockReasonGuide, "live receipt `action_id` values use the UUIDv7 form")
+	mustNotContain(t, blockReasonGuide, "reserved for a 26-character Crockford-base32 ULID")
+
+	blockReasonSpec := readDocAccuracyFile(t, root, "docs/specs/block-reason-header.md")
+	mustContain(t, blockReasonSpec, "production emit sites are shipped")
+	mustContain(t, blockReasonSpec, "production-path matrix test")
+	mustNotContain(t, blockReasonSpec, "it is not currently emitted on production blocks")
+	mustNotContain(t, blockReasonSpec, "The follow-up transport PR wires the header")
+
+	priorArt := readDocAccuracyFile(t, root, "docs/specs/receipt-prior-art-mapping.md")
+	mustContain(t, priorArt, "response header (opaque receipt ID)")
+	mustContain(t, priorArt, "may carry a receipt ID")
+	mustNotContain(t, priorArt, "response header (opaque ULID receipt ID)")
+}
+
+func repoRootForDocsAccuracy(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve docs accuracy test source path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+}
+
+func readDocAccuracyFile(t *testing.T, root, rel string) string {
+	t.Helper()
+	path := filepath.Clean(filepath.Join(root, rel))
+	withinRoot, err := filepath.Rel(root, path)
+	if err != nil {
+		t.Fatalf("resolve %s under repo root: %v", rel, err)
+	}
+	if withinRoot == ".." || strings.HasPrefix(withinRoot, ".."+string(filepath.Separator)) {
+		t.Fatalf("doc path %s escapes repo root", rel)
+	}
+	b, err := os.ReadFile(path) // #nosec G304 -- fixed repository docs checked above stay under repo root.
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(b)
+}
+
+func mustContain(t *testing.T, doc, want string) {
+	t.Helper()
+	if !strings.Contains(doc, want) {
+		t.Fatalf("doc missing %q", want)
+	}
+}
+
+func mustNotContain(t *testing.T, doc, stale string) {
+	t.Helper()
+	if strings.Contains(doc, stale) {
+		t.Fatalf("doc contains stale text %q", stale)
+	}
+}

--- a/internal/config/docs_accuracy_test.go
+++ b/internal/config/docs_accuracy_test.go
@@ -14,40 +14,50 @@ func TestDocsDeclareLiveStatsAndDefaults(t *testing.T) {
 
 	root := repoRootForDocsAccuracy(t)
 
-	configDoc := readDocAccuracyFile(t, root, "docs/configuration.md")
-	mustContain(t, configDoc, "request_body_scanning:\n  enabled: true")
-	mustContain(t, configDoc, "| `enabled` | `true` | Enable request body/header DLP scanning")
-	mustContain(t, configDoc, "Omitting `request_body_scanning.enabled` or `request_body_scanning.scan_headers` defaults both to `true`")
-	mustNotContain(t, configDoc, "omitting the field from your YAML file gives `false`")
+	t.Run("configuration.md", func(t *testing.T) {
+		configDoc := readDocAccuracyFile(t, root, "docs/configuration.md")
+		mustContain(t, configDoc, "request_body_scanning:\n  enabled: true")
+		mustContain(t, configDoc, "| `enabled` | `true` | Enable request body/header DLP scanning")
+		mustContain(t, configDoc, "Omitting `request_body_scanning.enabled` or `request_body_scanning.scan_headers` defaults both to `true`")
+		mustNotContain(t, configDoc, "omitting the field from your YAML file gives `false`")
+	})
 
-	agentDoc := readDocAccuracyFile(t, root, "AGENTS.md")
-	// Derive the DLP count from the live canonical source (same as make stats /
-	// TestCanonicalStats) so the doc must agree with reality, not a frozen
-	// literal. Hardcoding "65" here would let the doc rot when patterns are
-	// added (the count ratchets up) and would fail a *correct* doc update.
-	dlpCount := len(Defaults().DLP.Patterns)
-	mustContain(t, agentDoc, fmt.Sprintf("DLP (%d built-in credential patterns", dlpCount))
-	mustContain(t, agentDoc, "Path entropy analysis")
-	mustContain(t, agentDoc, "Subdomain entropy analysis")
-	mustContain(t, agentDoc, "Run `make stats` before citing the current direct-dependency count")
-	mustNotContain(t, agentDoc, "48 regex patterns")
-	mustNotContain(t, agentDoc, "20 direct dependencies")
+	t.Run("AGENTS.md", func(t *testing.T) {
+		agentDoc := readDocAccuracyFile(t, root, "AGENTS.md")
+		// Derive the DLP count from the live canonical source (same as make stats /
+		// TestCanonicalStats) so the doc must agree with reality, not a frozen
+		// literal. Hardcoding "65" here would let the doc rot when patterns are
+		// added (the count ratchets up) and would fail a *correct* doc update.
+		dlpCount := len(Defaults().DLP.Patterns)
+		mustContain(t, agentDoc, fmt.Sprintf("DLP (%d built-in credential patterns", dlpCount))
+		mustContain(t, agentDoc, "Path entropy analysis")
+		mustContain(t, agentDoc, "Subdomain entropy analysis")
+		mustContain(t, agentDoc, "Run `make stats` before citing the current direct-dependency count")
+		mustNotContain(t, agentDoc, "48 regex patterns")
+		mustNotContain(t, agentDoc, "20 direct dependencies")
+	})
 
-	blockReasonGuide := readDocAccuracyFile(t, root, "docs/guides/block-reason-header.md")
-	mustContain(t, blockReasonGuide, "canonical 36-character hyphenated UUIDv7")
-	mustContain(t, blockReasonGuide, "live receipt `action_id` values use the UUIDv7 form")
-	mustNotContain(t, blockReasonGuide, "reserved for a 26-character Crockford-base32 ULID")
+	t.Run("docs/guides/block-reason-header.md", func(t *testing.T) {
+		blockReasonGuide := readDocAccuracyFile(t, root, "docs/guides/block-reason-header.md")
+		mustContain(t, blockReasonGuide, "canonical 36-character hyphenated UUIDv7")
+		mustContain(t, blockReasonGuide, "live receipt `action_id` values use the UUIDv7 form")
+		mustNotContain(t, blockReasonGuide, "reserved for a 26-character Crockford-base32 ULID")
+	})
 
-	blockReasonSpec := readDocAccuracyFile(t, root, "docs/specs/block-reason-header.md")
-	mustContain(t, blockReasonSpec, "production emit sites are shipped")
-	mustContain(t, blockReasonSpec, "production-path matrix test")
-	mustNotContain(t, blockReasonSpec, "it is not currently emitted on production blocks")
-	mustNotContain(t, blockReasonSpec, "The follow-up transport PR wires the header")
+	t.Run("docs/specs/block-reason-header.md", func(t *testing.T) {
+		blockReasonSpec := readDocAccuracyFile(t, root, "docs/specs/block-reason-header.md")
+		mustContain(t, blockReasonSpec, "production emit sites are shipped")
+		mustContain(t, blockReasonSpec, "production-path matrix test")
+		mustNotContain(t, blockReasonSpec, "it is not currently emitted on production blocks")
+		mustNotContain(t, blockReasonSpec, "The follow-up transport PR wires the header")
+	})
 
-	priorArt := readDocAccuracyFile(t, root, "docs/specs/receipt-prior-art-mapping.md")
-	mustContain(t, priorArt, "response header (opaque receipt ID)")
-	mustContain(t, priorArt, "may carry a receipt ID")
-	mustNotContain(t, priorArt, "response header (opaque ULID receipt ID)")
+	t.Run("docs/specs/receipt-prior-art-mapping.md", func(t *testing.T) {
+		priorArt := readDocAccuracyFile(t, root, "docs/specs/receipt-prior-art-mapping.md")
+		mustContain(t, priorArt, "response header (opaque receipt ID)")
+		mustContain(t, priorArt, "may carry a receipt ID")
+		mustNotContain(t, priorArt, "response header (opaque ULID receipt ID)")
+	})
 }
 
 func repoRootForDocsAccuracy(t *testing.T) string {


### PR DESCRIPTION
## Summary
- correct request-body scanning defaults and block-reason receipt identifier wording
- align scanner pipeline and dependency-count guidance with live stats
- add a docs accuracy guard that derives live DLP count and rejects stale overclaims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated request body scanning defaults (including `enabled` and `scan_headers`) and clarified the security defaults note.
  * Refreshed block-reason receipt header guidance, including accepted receipt ID formats and “live” receipt `action_id` behavior.
  * Updated block-reason spec coverage/status and refined prior-art mapping wording for receipt identifiers.
  * Revised the documented AI scanner pipeline steps and credential-pattern references.
* **Tests**
  * Added a documentation accuracy test to ensure docs match current defaults/specs and avoid stale text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->