### PR TITLE
test: guard MCP v2 receipt parity

### DIFF
--- a/internal/mcp/receipt_parity_static_test.go
+++ b/internal/mcp/receipt_parity_static_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestMCPReceiptCallsitesStayV2Paired guards the maintenance invariant behind
+// MCP receipt parity: production call sites that emit an authoritative v1 MCP
+// receipt must also pass the v2 proxy_decision emitter into the same emission
+// helper. Runtime tests cover representative stdio, HTTP listener, and A2A
+// paths; this catches future v1-only receipt emit sites before they ship.
+func TestMCPReceiptCallsitesStayV2Paired(t *testing.T) {
+	t.Parallel()
+
+	dir := mcpPackageDir(t)
+	fset, files := parseMCPProductionFiles(t, dir)
+	for _, file := range files {
+		ast.Inspect(file.file, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.CallExpr:
+				if callName(node.Fun) == "EmitMCPDecision" {
+					assertEmitMCPDecisionV2Paired(t, fset, node)
+				}
+			case *ast.CompositeLit:
+				if typeName(node.Type) == "mcpToolReceiptOpts" {
+					assertToolReceiptOptsV2Paired(t, fset, node)
+				}
+			}
+			return true
+		})
+	}
+}
+
+func TestMCPV1ReceiptEmissionStaysFunnelled(t *testing.T) {
+	t.Parallel()
+
+	dir := mcpPackageDir(t)
+	fset, files := parseMCPProductionFiles(t, dir)
+	for _, file := range files {
+		ast.Inspect(file.file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Emit" {
+				return true
+			}
+			if file.name != "pipeline_decision.go" {
+				t.Fatalf("%s: MCP emitter calls must stay funnelled through EmitMCPDecision", fset.Position(call.Pos()))
+			}
+			return true
+		})
+	}
+}
+
+type mcpProductionFile struct {
+	name string
+	file *ast.File
+}
+
+func parseMCPProductionFiles(t *testing.T, dir string) (*token.FileSet, []mcpProductionFile) {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", dir, err)
+	}
+	fset := token.NewFileSet()
+	var files []mcpProductionFile
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("ParseFile(%s): %v", path, err)
+		}
+		files = append(files, mcpProductionFile{
+			name: entry.Name(),
+			file: file,
+		})
+	}
+	return fset, files
+}
+
+func assertEmitMCPDecisionV2Paired(t *testing.T, fset *token.FileSet, call *ast.CallExpr) {
+	t.Helper()
+	if len(call.Args) < 2 {
+		t.Fatalf("%s: EmitMCPDecision call has %d args, want at least 2", fset.Position(call.Pos()), len(call.Args))
+	}
+	if exprIsNil(call.Args[0]) {
+		return
+	}
+	if exprIsNil(call.Args[1]) {
+		t.Fatalf("%s: EmitMCPDecision emits v1 receipt without paired v2 emitter", fset.Position(call.Pos()))
+	}
+}
+
+func assertToolReceiptOptsV2Paired(t *testing.T, fset *token.FileSet, lit *ast.CompositeLit) {
+	t.Helper()
+
+	hasV1Emitter := false
+	hasV2Emitter := false
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch key.Name {
+		case "Emitter":
+			hasV1Emitter = !exprIsNil(kv.Value)
+		case "V2Emitter":
+			hasV2Emitter = !exprIsNil(kv.Value)
+		}
+	}
+	if hasV1Emitter && !hasV2Emitter {
+		t.Fatalf("%s: mcpToolReceiptOpts sets Emitter without paired V2Emitter", fset.Position(lit.Pos()))
+	}
+}
+
+func mcpPackageDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(file)
+}
+
+func callName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return e.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func typeName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return e.Sel.Name
+	case *ast.StarExpr:
+		return typeName(e.X)
+	default:
+		return ""
+	}
+}
+
+func exprIsNil(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == "nil"
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -400,10 +400,10 @@ func WithReceiptEmitter(e *receipt.Emitter) Option {
 // proxy dual-emits a signed EvidenceReceipt v2 proxy_decision alongside every v1
 // action receipt the proxy emit path produces (fetch, forward, CONNECT,
 // intercept, WebSocket, reverse, and MCP-over-HTTP that transits the proxy).
-// The standalone MCP proxy emits v1 on a separate path (internal/mcp
-// EmitMCPDecision) that this does NOT cover; that surface is a follow-up. Pass
-// nil to disable (default). v2 emission is gated on the same receipt intent as
-// v1 (flight recorder + signing key); no separate config flag.
+// Standalone MCP transports use internal/mcp EmitMCPDecision with the same v2
+// emitter threaded through MCPProxyOpts. Pass nil to disable (default). v2
+// emission is gated on the same receipt intent as v1 (flight recorder + signing
+// key); no separate config flag.
 func WithV2ReceiptEmitter(e *proxydecision.Emitter) Option {
 	return func(p *Proxy) { p.v2EmitterPtr.Store(e) }
 }


### PR DESCRIPTION
## Summary
- update stale v2 receipt emitter comments now that standalone MCP uses the shared MCP decision emitter
- add production-callsite guards so MCP v1 receipt emission stays paired with v2 proxy_decision emission
- keep v1 receipt emission funnelled through the shared MCP decision helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in MCP receipt handling to prevent mismatched receipt output paths.
  * Tightened validation so receipt emission continues through the supported flow, reducing the risk of accidental misuse.

* **Documentation**
  * Clarified guidance for receipt emitter configuration, including how v2 receipt emission is controlled and where standalone transports are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->