### PR TITLE
feat: add MCP taint trust by server name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -841,6 +841,8 @@ response_scanning:
 
 `reasoning` maps to `warn`; `untrusted` maps to `block`. Unknown trust values fail config validation, duplicate server entries fail validation, and entries are surfaced as warnings when `response_scanning.enabled` is false. The trust decision applies to MCP stdio, stdio-to-HTTP, reverse Streamable HTTP/SSE, and WebSocket surfaces because they share the MCP response scan gate. Block logs and JSON-RPC errors name the server, matched pattern, and trust class so operators can see whether a server needs an explicit trust-class review.
 
+Response trust does not make a server trusted for taint propagation. If a reasoning server is also an operator-trusted source whose clean responses should not contaminate the session, add the same `--server-name` value under `taint.trusted_mcp_servers`. Prompt-injection findings still raise hostile taint.
+
 Launch MCP proxies with a stable server identity so the entry can match: use `pipelock mcp proxy --server-name codex ...` for per-server wrappers, or `pipelock run --mcp-listen ... --mcp-upstream ... --mcp-server-name codex` for the long-lived MCP listener.
 
 For forward-proxy and TLS-intercepted traffic, an exempt host's response streams through untouched when `response_scanning.enabled` is true: no buffering, response scan-cap block, media metadata strip, Browser Shield rewrite, or injection scan is applied to that trusted response. Request-side DLP, redaction, SSRF, authority checks, and budget accounting still run. If a host needs full byte-preserving passthrough without MITM, prefer `tls_interception.passthrough_domains`.
@@ -2511,6 +2513,8 @@ taint:
     - "docs.anthropic.com"
     - "docs.github.com"
     - "developer.mozilla.org"
+  trusted_mcp_servers:                 # MCP --server-name values that do NOT raise session taint
+    - "docs-cache"
   protected_paths:                     # tainted sessions are blocked (or escalated) on these paths
     - "*/auth/*"
     - "*/security/*"
@@ -2542,6 +2546,7 @@ taint:
 | `policy` | string | `balanced` | `strict` is the most conservative taint policy, `balanced` is the security default, and `permissive` observes taint without changing enforcement. |
 | `recent_sources` | int | `10` | How many recent taint sources to keep per session for receipt reporting. |
 | `allowlisted_domains` | []string | 3 high-trust documentation domains | Responses from these domains do not raise taint. Supports `MatchDomain` wildcards. |
+| `trusted_mcp_servers` | []string | empty | MCP server names whose clean responses do not raise session taint. Entries match `pipelock mcp proxy --server-name`; URLs and slashes are rejected. This does not disable MCP response scanning, and prompt-injection hits can still raise hostile taint. |
 | `protected_paths` | []string | 7 patterns (see above) | Globs for file paths or tool args that are blocked for tainted sessions. |
 | `elevated_paths` | []string | `*/config/*`, `*/middleware*` | Globs that trigger warn/ask rather than block. |
 | `trust_overrides` | []object | empty | Narrow exemptions (see below). |
@@ -2569,7 +2574,7 @@ Task boundaries are surfaced on every emitted receipt as `session_task_id`, and 
 
 ### Classification details
 
-- **Taint level** is raised when a response arrives from a non-allowlisted domain, when an MCP tool returns content from an external source, or when prompt-injection signals fire on response content.
+- **Taint level** is raised when a response arrives from a non-allowlisted domain, when an MCP tool returns content from an external source, or when prompt-injection signals fire on response content. `taint.allowlisted_domains` applies to URL/HTTP response sources only; MCP response taint is keyed by the proxy's `--server-name` value through `taint.trusted_mcp_servers`.
 - **Action sensitivity** is derived from the target path (or tool-argument path) against `protected_paths` and `elevated_paths`.
 - **Authority kind** records which authority tier gated the action: `external`, `policy`, `user_broad`, `user_exact`, or `operator_override`.
 

--- a/internal/cli/diag/doctor_config_semantics.go
+++ b/internal/cli/diag/doctor_config_semantics.go
@@ -216,6 +216,22 @@ func checkDoctorInertExemptions(cfg *config.Config) []doctorReportCheck {
 		})
 	}
 
+	for _, entry := range cfg.ResponseScanning.MCPServers {
+		if entry.Trust != config.ResponseTrustReasoning || cfg.TaintTrustsMCPServer(entry.Server) {
+			continue
+		}
+		checks = append(checks, doctorReportCheck{
+			Name:       doctorCheckExemptionSemantics,
+			Surface:    doctorSurfaceConfig,
+			Status:     doctorStatusWarn,
+			Configured: true,
+			Detail: fmt.Sprintf(
+				"response_scanning.mcp_servers marks %q as reasoning-trusted, but taint.allowlisted_domains does not apply to MCP response taint and taint.trusted_mcp_servers does not include this server",
+				entry.Server),
+			Next: "if this MCP server is an operator-trusted source, add its --server-name value to taint.trusted_mcp_servers; otherwise leave it untrusted for taint",
+		})
+	}
+
 	return checks
 }
 

--- a/internal/cli/diag/doctor_config_semantics_test.go
+++ b/internal/cli/diag/doctor_config_semantics_test.go
@@ -202,6 +202,29 @@ func TestDoctorConfigSemantics(t *testing.T) {
 			wantWarn: 0,
 		},
 		{
+			name: "MCP response reasoning trust is not taint trust",
+			mutate: func(cfg *config.Config) {
+				cfg.ResponseScanning.MCPServers = []config.MCPResponseServerTrust{{
+					Server: "docs-cache",
+					Trust:  config.ResponseTrustReasoning,
+				}}
+			},
+			wantWarn:         1,
+			wantDetailSubstr: "taint.allowlisted_domains does not apply to MCP response taint",
+			wantNextSubstr:   "taint.trusted_mcp_servers",
+		},
+		{
+			name: "MCP response reasoning trust with taint trust is NOT flagged",
+			mutate: func(cfg *config.Config) {
+				cfg.ResponseScanning.MCPServers = []config.MCPResponseServerTrust{{
+					Server: "docs-cache",
+					Trust:  config.ResponseTrustReasoning,
+				}}
+				cfg.Taint.TrustedMCPServers = []string{"docs-cache"}
+			},
+			wantWarn: 0,
+		},
+		{
 			name: "duplicate suppress rule names collapse to one finding",
 			mutate: func(cfg *config.Config) {
 				cfg.Suppress = []config.SuppressEntry{

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -222,14 +222,17 @@ func handleProxyError(err error, logW io.Writer, sentryClient *plsentry.Client) 
 func applyMCPResponseSuppressOpts(opts *mcp.MCPProxyOpts, cfg *config.Config, serverName string) {
 	opts.ServerName = serverName
 	trust := config.ResponseTrustUntrusted
+	taintTrusted := false
 	if cfg != nil {
 		opts.Suppress = cfg.Suppress
 		if configuredTrust, ok := cfg.MCPResponseTrustForServer(serverName); ok {
 			trust = configuredTrust
 		}
+		taintTrusted = cfg.TaintTrustsMCPServer(serverName)
 	}
 	opts.ResponseTrustClass = trust
 	opts.ResponseActionOverride = config.MCPResponseActionForTrust(trust)
+	opts.TaintTrustedSource = taintTrusted
 }
 
 func mcpResponseLogFields(opts mcp.MCPProxyOpts) (action, trust, server string) {

--- a/internal/cli/runtime/mcp_response_suppress_test.go
+++ b/internal/cli/runtime/mcp_response_suppress_test.go
@@ -41,6 +41,9 @@ func TestApplyMCPResponseSuppressOpts(t *testing.T) {
 	if opts.ResponseTrustClass != config.ResponseTrustUntrusted || opts.ResponseActionOverride != config.ActionBlock {
 		t.Fatalf("default trust/action = %q/%q, want untrusted/block", opts.ResponseTrustClass, opts.ResponseActionOverride)
 	}
+	if opts.TaintTrustedSource {
+		t.Fatal("default MCP server must not be taint-trusted")
+	}
 }
 
 func TestApplyMCPResponseSuppressOpts_ReasoningTrustWarnsMatchingServer(t *testing.T) {
@@ -58,6 +61,18 @@ func TestApplyMCPResponseSuppressOpts_ReasoningTrustWarnsMatchingServer(t *testi
 	}
 	if opts.ResponseActionOverride != config.ActionWarn {
 		t.Fatalf("ResponseActionOverride = %q, want %q", opts.ResponseActionOverride, config.ActionWarn)
+	}
+}
+
+func TestApplyMCPResponseSuppressOpts_TaintTrustedMatchingServer(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Taint.TrustedMCPServers = []string{testMCPServerName}
+	opts := mcp.MCPProxyOpts{}
+
+	applyMCPResponseSuppressOpts(&opts, cfg, testMCPServerName)
+
+	if !opts.TaintTrustedSource {
+		t.Fatal("expected matching server to be taint-trusted")
 	}
 }
 

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -713,6 +713,10 @@ func (s *Server) Start(ctx context.Context) error {
 		mcpResponseActionFn := func() string {
 			return config.MCPResponseActionForTrust(mcpResponseTrustFn())
 		}
+		mcpTaintTrustedFn := func() bool {
+			c := s.proxy.CurrentConfig()
+			return c != nil && c.TaintTrustsMCPServer(s.opts.MCPServerName)
+		}
 
 		mcpErr = make(chan error, 1)
 		lifecycleWG.Add(1)
@@ -752,6 +756,7 @@ func (s *Server) Start(ctx context.Context) error {
 				EnvelopeEmitterFn:        s.liveEnvelopeEmitter,
 				RedactionCfgFn:           mcpRedactionCfgFn,
 				TaintCfgFn:               mcpTaintCfgFn,
+				TaintTrustedSourceFn:     mcpTaintTrustedFn,
 				A2ACfgFn:                 mcpA2ACfgFn,
 				MediaPolicyFn:            mcpMediaPolicyFn,
 				ServerName:               s.opts.MCPServerName,

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -212,6 +212,7 @@ func (c *Config) policySemanticView() Config {
 	view.APIAllowlist = sortedCopy(view.APIAllowlist)
 	view.Internal = sortedCopy(view.Internal)
 	view.TrustedDomains = sortedCopy(view.TrustedDomains)
+	view.Taint.TrustedMCPServers = sortedCopy(view.Taint.TrustedMCPServers)
 	view.A2AScanning.TrustedAgentCardKeys = canonicalA2ATrustedCardKeys(view.A2AScanning.TrustedAgentCardKeys)
 	view.ResponseScanning.SizeExemptDomains = sortedCopy(view.ResponseScanning.SizeExemptDomains)
 	view.ResponseScanning.MCPServers = canonicalMCPResponseServers(view.ResponseScanning.MCPServers)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3982,6 +3982,7 @@ const (
 	reloadFieldTaintAllowlisted    = "taint.allowlisted_domains"
 	reloadFieldTaintElevatedPaths  = "taint.elevated_paths"
 	reloadFieldTaintProtectedPaths = "taint.protected_paths"
+	reloadFieldTaintTrustedMCP     = "taint.trusted_mcp_servers"
 	reloadFieldTaintTrustOverrides = "taint.trust_overrides"
 )
 
@@ -4124,6 +4125,54 @@ func TestValidateReload_TaintAllowlistedDomainsReduced_NoWarning(t *testing.T) {
 		if w.Field == reloadFieldTaintAllowlisted {
 			t.Errorf("pure taint allowlist reduction should not produce warning, got: %s", w.Message)
 		}
+	}
+}
+
+func TestValidateReload_TaintTrustedMCPServersExpanded(t *testing.T) {
+	old := Defaults()
+	old.Taint.Enabled = true
+	old.Taint.TrustedMCPServers = []string{"docs-cache"}
+	updated := Defaults()
+	updated.Taint.Enabled = true
+	updated.Taint.TrustedMCPServers = []string{"docs-cache", "code-search"}
+
+	warnings := ValidateReload(old, updated)
+	found := false
+	for _, w := range warnings {
+		if w.Field == reloadFieldTaintTrustedMCP {
+			found = true
+			if !strings.Contains(w.Message, "code-search") {
+				t.Errorf("warning should name the added MCP server, got: %s", w.Message)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected taint trusted MCP server expansion warning")
+	}
+}
+
+func TestValidateReload_TaintTrustedMCPServersCaseChangeWarns(t *testing.T) {
+	old := Defaults()
+	old.Taint.Enabled = true
+	old.Taint.TrustedMCPServers = []string{"DocsCache"}
+	updated := Defaults()
+	updated.Taint.Enabled = true
+	updated.Taint.TrustedMCPServers = []string{"docscache"}
+
+	warnings := ValidateReload(old, updated)
+	found := false
+	for _, w := range warnings {
+		if w.Field == reloadFieldTaintTrustedMCP {
+			found = true
+			if !strings.Contains(w.Message, "docscache") {
+				t.Errorf("warning should name the case-changed MCP server, got: %s", w.Message)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected taint trusted MCP server case-change warning")
 	}
 }
 

--- a/internal/config/mcp_response_trust_test.go
+++ b/internal/config/mcp_response_trust_test.go
@@ -91,6 +91,12 @@ func TestMCPResponseTrustValidationRejectsUnknownAndInertConfigWarns(t *testing.
 	}
 
 	cfg = Defaults()
+	cfg.ResponseScanning.MCPServers = []MCPResponseServerTrust{{Server: "docs cache", Trust: ResponseTrustReasoning}}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "whitespace/control characters") {
+		t.Fatalf("Validate err = %v, want whitespace rejection", err)
+	}
+
+	cfg = Defaults()
 	cfg.ResponseScanning.Enabled = false
 	cfg.ResponseScanning.MCPServers = []MCPResponseServerTrust{{Server: "codex", Trust: ResponseTrustReasoning}}
 	warnings, err := cfg.ValidateWithWarnings()

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -255,6 +255,9 @@ func (c *Config) ApplyDefaults() {
 		c.ResponseScanning.MCPServers[i].Server = strings.TrimSpace(c.ResponseScanning.MCPServers[i].Server)
 		c.ResponseScanning.MCPServers[i].Trust = strings.ToLower(strings.TrimSpace(c.ResponseScanning.MCPServers[i].Trust))
 	}
+	for i := range c.Taint.TrustedMCPServers {
+		c.Taint.TrustedMCPServers[i] = strings.TrimSpace(c.Taint.TrustedMCPServers[i])
+	}
 	// Merge default response scanning patterns with user patterns.
 	// include_defaults (nil/true): defaults load first, user patterns override by name.
 	// include_defaults (false): only user patterns are used (full override).

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -238,6 +238,12 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 				Message: fmt.Sprintf("taint allowlisted domains added: %s — these sources now downgrade from untrusted to allowlisted", strings.Join(added, ", ")),
 			})
 		}
+		if added := exactStringsAdded(old.Taint.TrustedMCPServers, updated.Taint.TrustedMCPServers); len(added) > 0 {
+			warnings = append(warnings, ReloadWarning{
+				Field:   "taint.trusted_mcp_servers",
+				Message: fmt.Sprintf("taint-trusted MCP servers added: %s — clean responses from these servers no longer contaminate the session", strings.Join(added, ", ")),
+			})
+		}
 		if removed := removedPatterns(old.Taint.ProtectedPaths, updated.Taint.ProtectedPaths); len(removed) > 0 {
 			warnings = append(warnings, ReloadWarning{
 				Field:   "taint.protected_paths",
@@ -1139,6 +1145,22 @@ func passthroughDomainsAdded(old, updated []string) []string {
 	for _, d := range updated {
 		if _, exists := oldSet[strings.ToLower(d)]; !exists {
 			added = append(added, d)
+		}
+	}
+	return added
+}
+
+// exactStringsAdded returns values present in updated but not in old, preserving
+// case-sensitive identity for non-domain config surfaces such as MCP server names.
+func exactStringsAdded(old, updated []string) []string {
+	oldSet := make(map[string]struct{}, len(old))
+	for _, v := range old {
+		oldSet[v] = struct{}{}
+	}
+	var added []string
+	for _, v := range updated {
+		if _, exists := oldSet[v]; !exists {
+			added = append(added, v)
 		}
 	}
 	return added

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -220,6 +220,9 @@ func (c *Config) Clone() *Config {
 	if c.ResponseScanning.ExemptDomains != nil {
 		clone.ResponseScanning.ExemptDomains = append([]string(nil), c.ResponseScanning.ExemptDomains...)
 	}
+	if c.Taint.TrustedMCPServers != nil {
+		clone.Taint.TrustedMCPServers = append([]string(nil), c.Taint.TrustedMCPServers...)
+	}
 	clone.MCPToolPolicy.Rules = cloneToolPolicyRules(c.MCPToolPolicy.Rules)
 	// Deep-copy the follower audience-labels map so a runtime caller that
 	// mutates clone.Conductor.Labels never aliases back into the loaded config,

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1465,11 +1465,27 @@ type MediationEnvelopeReplayCache struct {
 type TaintConfig struct {
 	Enabled            bool                 `yaml:"enabled"`
 	AllowlistedDomains []string             `yaml:"allowlisted_domains"`
+	TrustedMCPServers  []string             `yaml:"trusted_mcp_servers" json:"trusted_mcp_servers,omitempty"`
 	ProtectedPaths     []string             `yaml:"protected_paths"`
 	ElevatedPaths      []string             `yaml:"elevated_paths"`
 	TrustOverrides     []TaintTrustOverride `yaml:"trust_overrides"`
 	Policy             string               `yaml:"policy"`         // strict, balanced, permissive
 	RecentSources      int                  `yaml:"recent_sources"` // bounded recent source history
+}
+
+// TaintTrustsMCPServer reports whether MCP responses from serverName should be
+// treated as operator-trusted source material for taint classification.
+func (c *Config) TaintTrustsMCPServer(serverName string) bool {
+	serverName = strings.TrimSpace(serverName)
+	if c == nil || serverName == "" {
+		return false
+	}
+	for _, trusted := range c.Taint.TrustedMCPServers {
+		if strings.TrimSpace(trusted) == serverName {
+			return true
+		}
+	}
+	return false
 }
 
 // TaintTrustOverride grants a narrow, expiring trust exemption.

--- a/internal/config/taint_test.go
+++ b/internal/config/taint_test.go
@@ -130,6 +130,13 @@ func TestValidateTaint(t *testing.T) {
 			wantErr: "taint.trusted_mcp_servers",
 		},
 		{
+			name: "trusted MCP server control character rejected",
+			mutate: func(cfg *Config) {
+				cfg.Taint.TrustedMCPServers = []string{"docs\fcache"}
+			},
+			wantErr: "whitespace/control characters",
+		},
+		{
 			name: "duplicate trusted MCP server rejected",
 			mutate: func(cfg *Config) {
 				cfg.Taint.TrustedMCPServers = []string{"docs-cache", "docs-cache"}

--- a/internal/config/taint_test.go
+++ b/internal/config/taint_test.go
@@ -30,6 +30,9 @@ func TestDefaults_Taint(t *testing.T) {
 	if len(cfg.Taint.ElevatedPaths) == 0 {
 		t.Fatal("expected elevated path defaults")
 	}
+	if len(cfg.Taint.TrustedMCPServers) != 0 {
+		t.Fatalf("trusted_mcp_servers = %#v, want empty default", cfg.Taint.TrustedMCPServers)
+	}
 }
 
 func TestApplyDefaults_TaintPreservesExplicitEmptySlices(t *testing.T) {
@@ -120,6 +123,26 @@ func TestValidateTaint(t *testing.T) {
 			wantErr: "source_match is required",
 		},
 		{
+			name: "trusted MCP server URL rejected",
+			mutate: func(cfg *Config) {
+				cfg.Taint.TrustedMCPServers = []string{"https://mcp.example.com"}
+			},
+			wantErr: "taint.trusted_mcp_servers",
+		},
+		{
+			name: "duplicate trusted MCP server rejected",
+			mutate: func(cfg *Config) {
+				cfg.Taint.TrustedMCPServers = []string{"docs-cache", "docs-cache"}
+			},
+			wantErr: "duplicates",
+		},
+		{
+			name: "valid trusted MCP server",
+			mutate: func(cfg *Config) {
+				cfg.Taint.TrustedMCPServers = []string{"docs-cache"}
+			},
+		},
+		{
 			name: "valid trust override",
 			mutate: func(cfg *Config) {
 				cfg.Taint.TrustOverrides = []TaintTrustOverride{{
@@ -151,5 +174,24 @@ func TestValidateTaint(t *testing.T) {
 				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestTaintTrustedMCPServersTrimLookupAndHash(t *testing.T) {
+	cfg := loadMCPResponseTrustConfig(t, "version: 1\ntaint:\n  trusted_mcp_servers:\n    - \" docs-cache \"\n    - code-search\n")
+
+	if !cfg.TaintTrustsMCPServer("docs-cache") {
+		t.Fatal("expected trimmed trusted MCP server lookup to match")
+	}
+	if cfg.TaintTrustsMCPServer("unknown") {
+		t.Fatal("unexpected trust for unknown MCP server")
+	}
+
+	a := Defaults()
+	a.Taint.TrustedMCPServers = []string{"docs-cache", "code-search"}
+	b := Defaults()
+	b.Taint.TrustedMCPServers = []string{"code-search", "docs-cache"}
+	if gotA, gotB := a.CanonicalPolicyHash(), b.CanonicalPolicyHash(); gotA != gotB {
+		t.Fatalf("CanonicalPolicyHash reordered trusted_mcp_servers mismatch:\nA=%s\nB=%s", gotA, gotB)
 	}
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -816,11 +816,8 @@ func (c *Config) validateResponseScanning(warnings *[]Warning) error {
 	seenMCPServers := make(map[string]struct{}, len(c.ResponseScanning.MCPServers))
 	for i, entry := range c.ResponseScanning.MCPServers {
 		field := fmt.Sprintf("response_scanning.mcp_servers[%d]", i)
-		if entry.Server == "" {
-			return fmt.Errorf("%s.server is empty", field)
-		}
-		if strings.Contains(entry.Server, "://") || strings.ContainsAny(entry.Server, "/\\\r\n\t") {
-			return fmt.Errorf("%s.server %q: use the MCP --server-name value without URL syntax or slashes", field, entry.Server)
+		if err := validateMCPServerName(entry.Server, field+".server"); err != nil {
+			return err
 		}
 		if _, ok := seenMCPServers[entry.Server]; ok {
 			return fmt.Errorf("%s.server %q duplicates an earlier MCP response trust entry", field, entry.Server)
@@ -2843,6 +2840,9 @@ func (c *Config) validateTaint() error {
 	if err := ValidateTrustedDomains(c.Taint.AllowlistedDomains, "taint.allowlisted_domains"); err != nil {
 		return err
 	}
+	if err := validateMCPServerNameList(c.Taint.TrustedMCPServers, "taint.trusted_mcp_servers"); err != nil {
+		return err
+	}
 	if err := validatePathGlobs(c.Taint.ProtectedPaths, "taint.protected_paths"); err != nil {
 		return err
 	}
@@ -2868,6 +2868,31 @@ func (c *Config) validateTaint() error {
 		if override.ExpiresAt.IsZero() {
 			return fmt.Errorf("taint.trust_overrides[%d].expires_at is required", i)
 		}
+	}
+	return nil
+}
+
+func validateMCPServerNameList(serverNames []string, label string) error {
+	seen := make(map[string]struct{}, len(serverNames))
+	for i, serverName := range serverNames {
+		field := fmt.Sprintf("%s[%d]", label, i)
+		if err := validateMCPServerName(serverName, field); err != nil {
+			return err
+		}
+		if _, ok := seen[serverName]; ok {
+			return fmt.Errorf("%s %q duplicates an earlier MCP server entry", field, serverName)
+		}
+		seen[serverName] = struct{}{}
+	}
+	return nil
+}
+
+func validateMCPServerName(serverName, field string) error {
+	if serverName == "" {
+		return fmt.Errorf("%s is empty", field)
+	}
+	if strings.Contains(serverName, "://") || strings.ContainsAny(serverName, "/\\\r\n\t") {
+		return fmt.Errorf("%s %q: use the MCP --server-name value without URL syntax or slashes", field, serverName)
 	}
 	return nil
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/license"
@@ -2891,8 +2892,13 @@ func validateMCPServerName(serverName, field string) error {
 	if serverName == "" {
 		return fmt.Errorf("%s is empty", field)
 	}
-	if strings.Contains(serverName, "://") || strings.ContainsAny(serverName, "/\\\r\n\t") {
+	if strings.Contains(serverName, "://") || strings.ContainsAny(serverName, "/\\") {
 		return fmt.Errorf("%s %q: use the MCP --server-name value without URL syntax or slashes", field, serverName)
+	}
+	for _, r := range serverName {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return fmt.Errorf("%s %q: use the MCP --server-name value without URL syntax or whitespace/control characters", field, serverName)
+		}
 	}
 	return nil
 }

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -180,6 +180,8 @@ func RunHTTPListenerProxy(
 		TaintCfg:                 opts.taintCfg(),
 		TaintCfgFn:               opts.TaintCfgFn,
 		TaintExternalSource:      true,
+		TaintTrustedSource:       opts.TaintTrustedSource,
+		TaintTrustedSourceFn:     opts.TaintTrustedSourceFn,
 		EnvelopeEmitter:          opts.envelopeEmitter(),
 		EnvelopeEmitterFn:        opts.EnvelopeEmitterFn,
 	}

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -79,6 +79,13 @@ type MCPProxyOpts struct {
 	// TaintExternalSource marks responses from this MCP transport as external
 	// content by default (HTTP/SSE and WebSocket upstreams).
 	TaintExternalSource bool
+	// TaintTrustedSource marks this MCP server's responses as operator-trusted
+	// for taint classification. Prompt-injection hits can still raise hostile
+	// taint; this only changes clean response-source classification.
+	TaintTrustedSource bool
+	// TaintTrustedSourceFn returns the current MCP taint trust decision for
+	// hot-reload-aware proxy surfaces. Nil falls back to TaintTrustedSource.
+	TaintTrustedSourceFn func() bool
 
 	// Cross-request exfiltration detection
 	CEE   *CEEDeps
@@ -379,6 +386,14 @@ func (o MCPProxyOpts) taintCfg() *config.TaintConfig {
 		return o.TaintCfgFn()
 	}
 	return o.TaintCfg
+}
+
+func (o MCPProxyOpts) mcpResponseTaintExternal() bool {
+	trusted := o.TaintTrustedSource
+	if o.TaintTrustedSourceFn != nil {
+		trusted = o.TaintTrustedSourceFn()
+	}
+	return o.TaintExternalSource && !trusted
 }
 
 func (o MCPProxyOpts) cee() *CEEDeps {

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -77,7 +77,7 @@ func observeMCPResponseTaint(opts MCPProxyOpts, promptHit bool) {
 	if !ok {
 		return
 	}
-	observation := session.ClassifyMCPResponseObservation(mcpTaintSourceKind, opts.TaintExternalSource, promptHit)
+	observation := session.ClassifyMCPResponseObservation(mcpTaintSourceKind, opts.mcpResponseTaintExternal(), promptHit)
 	observation.MaxSources = taintCfg.RecentSources
 	rs.ObserveRisk(observation)
 }

--- a/internal/mcp/taint_test.go
+++ b/internal/mcp/taint_test.go
@@ -91,6 +91,42 @@ func TestForwardScanned_ExternalResponseContaminatesSession(t *testing.T) {
 	}
 }
 
+func TestForwardScanned_TrustedMCPResponseDoesNotContaminateSession(t *testing.T) {
+	t.Parallel()
+
+	sc := testScannerWithAction(t, config.ActionWarn)
+	rec := &taintRecorder{}
+	cfg := config.Defaults()
+
+	var out bytes.Buffer
+	found, err := ForwardScanned(
+		transport.NewStdioReader(bytes.NewBufferString(cleanResponse+"\n")),
+		transport.NewStdioWriter(&out),
+		&bytes.Buffer{},
+		nil,
+		MCPProxyOpts{
+			Scanner:             sc,
+			Rec:                 rec,
+			TaintCfg:            &cfg.Taint,
+			TaintExternalSource: true,
+			TaintTrustedSource:  true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned() error = %v", err)
+	}
+	if found {
+		t.Fatal("expected clean response to remain clean")
+	}
+	risk := rec.RiskSnapshot()
+	if risk.Contaminated {
+		t.Fatal("trusted clean MCP response should not contaminate the session")
+	}
+	if risk.Level != session.TaintInternalGenerated {
+		t.Fatalf("taint level = %v, want internal_generated", risk.Level)
+	}
+}
+
 func TestForwardScanned_PromptHitMarksSessionHostile(t *testing.T) {
 	t.Parallel()
 
@@ -122,6 +158,42 @@ func TestForwardScanned_PromptHitMarksSessionHostile(t *testing.T) {
 	}
 	if !rec.RiskSnapshot().PromptHit {
 		t.Fatal("expected prompt_hit to be sticky")
+	}
+}
+
+func TestForwardScanned_TrustedMCPPromptHitStillMarksSessionHostile(t *testing.T) {
+	t.Parallel()
+
+	sc := testScannerWithAction(t, config.ActionWarn)
+	rec := &taintRecorder{}
+	cfg := config.Defaults()
+
+	var out bytes.Buffer
+	found, err := ForwardScanned(
+		transport.NewStdioReader(bytes.NewBufferString(injectionResponse+"\n")),
+		transport.NewStdioWriter(&out),
+		&bytes.Buffer{},
+		nil,
+		MCPProxyOpts{
+			Scanner:             sc,
+			Rec:                 rec,
+			TaintCfg:            &cfg.Taint,
+			TaintExternalSource: true,
+			TaintTrustedSource:  true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned() error = %v", err)
+	}
+	if !found {
+		t.Fatal("expected injection response to be detected")
+	}
+	risk := rec.RiskSnapshot()
+	if risk.Level != session.TaintExternalHostile {
+		t.Fatalf("taint level = %v, want external_hostile", risk.Level)
+	}
+	if !risk.Contaminated || !risk.PromptHit {
+		t.Fatalf("trusted prompt hit should still contaminate as hostile: %+v", risk)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `taint.trusted_mcp_servers` for MCP server-name based taint trust
- thread MCP taint trust through HTTP, listener, and WebSocket proxy paths
- warn when MCP response trust is configured without matching taint trust

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `taint.trusted_mcp_servers` to treat selected MCP server responses as operator-trusted for taint classification.
  * Clean responses from trusted MCP servers no longer contaminate session taint, while prompt-injection findings still mark the session hostile.
* **Bug Fixes**
  * Improved MCP trust/taint semantics and diagnostics, including guided recommendations to update `taint.trusted_mcp_servers`.
  * Enhanced config reload warnings and ensured consistent matching by normalizing and order-independent hashing.
  * Strengthened validation for MCP server names (rejects URLs, slashes, whitespace, and control characters).
* **Documentation**
  * Updated configuration docs with the new taint trusted-server behavior and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->