### PR TITLE
feat: verify Rekor anchor inclusion proofs

### DIFF
--- a/cmd/pipelock-verifier/independent.go
+++ b/cmd/pipelock-verifier/independent.go
@@ -17,13 +17,14 @@ import (
 )
 
 type independentOptions struct {
-	bundlePath string
-	signerKeys []string
-	logPath    string
-	logID      string
-	sessionID  string
-	asDir      bool
-	jsonOutput bool
+	bundlePath   string
+	signerKeys   []string
+	rekorLogKeys []string
+	logPath      string
+	logID        string
+	sessionID    string
+	asDir        bool
+	jsonOutput   bool
 }
 
 func newIndependentCmd() *cobra.Command {
@@ -36,8 +37,8 @@ material. The local backend is a deterministic test backend; it proves the
 checkpoint/proof mechanics but is not an operator-independent witness.
 
 Honest limit: anchoring does not prove real-time truth by whoever held the
-receipt signing key. Rekor bundles fail closed until trusted Rekor SET and
-inclusion-proof verification is implemented.`,
+receipt signing key. Rekor verification requires a pinned Rekor log public key
+and verifies the recorded SET, signed checkpoint, and inclusion proof offline.`,
 		Args:          exactOneArg,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -50,6 +51,7 @@ inclusion-proof verification is implemented.`,
 	cmd.Flags().StringArrayVar(&opts.signerKeys, "key", nil, "trusted signer public key (hex, public-key text, or file path); repeat for rotated chains")
 	cmd.Flags().StringVar(&opts.logPath, "local-log", "", "local fake-log JSONL path")
 	cmd.Flags().StringVar(&opts.logID, "log-id", anchor.DefaultLocalLogID, "local fake-log identifier")
+	cmd.Flags().StringArrayVar(&opts.rekorLogKeys, "rekor-log-key", nil, "trusted Rekor log public key (PEM, Pipelock Ed25519 key, raw hex, or file path); repeat for rotations")
 	cmd.Flags().StringVar(&opts.sessionID, "session", "proxy", "session ID inside the evidence directory when --dir is set")
 	cmd.Flags().BoolVar(&opts.asDir, "dir", false, "treat PATH as a session directory rather than a single evidence file")
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON verdict on stdout")
@@ -101,7 +103,11 @@ func independentBackend(bundle anchor.Bundle, opts independentOptions) (anchor.B
 			LogID: opts.logID,
 		}, cliutil.ExitOK, nil
 	case anchor.RekorBackend:
-		return anchor.RekorLog{}, cliutil.ExitOK, nil
+		keys, err := anchor.LoadRekorPublicKeys(opts.rekorLogKeys)
+		if err != nil {
+			return nil, cliutil.ExitConfig, fmt.Errorf("resolve --rekor-log-key: %w", err)
+		}
+		return anchor.RekorLog{TrustedLogKeys: keys}, cliutil.ExitOK, nil
 	default:
 		return nil, cliutil.ExitConfig, fmt.Errorf("unsupported anchor backend %q", bundle.Backend)
 	}

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -636,7 +636,7 @@ func TestIndependent_ValidLocalAnchor(t *testing.T) {
 	}
 }
 
-func TestIndependent_RekorAnchorFailsClosedUntilTrustedLogVerification(t *testing.T) {
+func TestIndependent_RekorAnchorRequiresTrustedLogKey(t *testing.T) {
 	fix := newFixture(t, 3)
 	evidence, bundle := writeIndependentRekorFixture(t, fix)
 
@@ -647,7 +647,7 @@ func TestIndependent_RekorAnchorFailsClosedUntilTrustedLogVerification(t *testin
 	if code != cliutil.ExitGeneral {
 		t.Fatalf("code=%d, want %d for Rekor fail-closed verification; stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
 	}
-	if !strings.Contains(stderr, "trusted Rekor SET") {
+	if !strings.Contains(stderr, "trusted Rekor log public key") {
 		t.Fatalf("stderr missing fail-closed Rekor verification error:\n%s", stderr)
 	}
 }
@@ -680,6 +680,34 @@ func TestIndependent_RejectsUnsupportedBundleBackendAsConfig(t *testing.T) {
 	}
 	if err == nil || !strings.Contains(err.Error(), "does not match proof backend") {
 		t.Fatalf("err = %v, want backend mismatch", err)
+	}
+}
+
+func TestIndependentBackend_RekorLoadsTrustedLogKey(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	bundle := anchorpkg.Bundle{
+		Backend: anchorpkg.RekorBackend,
+		Proof:   anchorpkg.Proof{Backend: anchorpkg.RekorBackend},
+	}
+
+	backend, code, err := independentBackend(bundle, independentOptions{
+		rekorLogKeys: []string{hex.EncodeToString(pub)},
+	})
+	if err != nil {
+		t.Fatalf("independentBackend: %v", err)
+	}
+	if code != cliutil.ExitOK {
+		t.Fatalf("code=%d, want %d", code, cliutil.ExitOK)
+	}
+	rekorBackend, ok := backend.(anchorpkg.RekorLog)
+	if !ok {
+		t.Fatalf("backend type = %T, want anchor.RekorLog", backend)
+	}
+	if len(rekorBackend.TrustedLogKeys) != 1 {
+		t.Fatalf("TrustedLogKeys len = %d, want 1", len(rekorBackend.TrustedLogKeys))
 	}
 }
 
@@ -873,7 +901,13 @@ func writeIndependentRekorFixture(t *testing.T, fix *fixture) (evidencePath, bun
 				"integratedTime": 1780000000,
 				"body":           body,
 				"verification": map[string]any{
-					"inclusionProof":       map[string]any{"rootHash": "fake-root"},
+					"inclusionProof": map[string]any{
+						"rootHash":   strings.Repeat("a", 64),
+						"logIndex":   4,
+						"treeSize":   5,
+						"hashes":     []string{},
+						"checkpoint": "checkpoint",
+					},
 					"signedEntryTimestamp": "fake-set",
 				},
 			},

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -709,6 +709,13 @@ func TestIndependentBackend_RekorLoadsTrustedLogKey(t *testing.T) {
 	if len(rekorBackend.TrustedLogKeys) != 1 {
 		t.Fatalf("TrustedLogKeys len = %d, want 1", len(rekorBackend.TrustedLogKeys))
 	}
+	loaded, ok := rekorBackend.TrustedLogKeys[0].(ed25519.PublicKey)
+	if !ok {
+		t.Fatalf("TrustedLogKeys[0] type = %T, want ed25519.PublicKey", rekorBackend.TrustedLogKeys[0])
+	}
+	if !bytes.Equal(loaded, pub) {
+		t.Fatal("TrustedLogKeys[0] does not match configured Rekor log key")
+	}
 }
 
 func TestIndependent_RejectsRewrittenBundleCheckpoint(t *testing.T) {

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -39,8 +39,9 @@ var DefaultLimits = []string{
 }
 
 var rekorLimits = []string{
-	"Rekor submission records a receipt-chain checkpoint for later transparency-log audit.",
-	"Independent Rekor verification requires trusted SET and inclusion-proof verification; this bundle does not make that claim.",
+	"Rekor verification proves the checkpoint entry has a valid SET and inclusion proof under a pinned Rekor log key.",
+	"Rekor anchoring does not prove the checkpoint was witnessed before every later action unless the anchored checkpoint covers the whole receipt chain being verified.",
+	"Rekor anchoring does not prove the log remained globally consistent after the recorded checkpoint without a later consistency audit.",
 	"Anchoring does not prove real-time truth by whoever held the receipt signing key.",
 }
 
@@ -69,13 +70,22 @@ type Proof struct {
 }
 
 type RekorProof struct {
-	URL                  string `json:"url,omitempty"`
-	UUID                 string `json:"uuid,omitempty"`
-	Body                 string `json:"body,omitempty"`
-	PublicKey            string `json:"public_key,omitempty"`
-	Signature            string `json:"signature,omitempty"`
-	IntegratedTime       int64  `json:"integrated_time,omitempty"`
-	SignedEntryTimestamp string `json:"signed_entry_timestamp,omitempty"`
+	URL                  string               `json:"url,omitempty"`
+	UUID                 string               `json:"uuid,omitempty"`
+	Body                 string               `json:"body,omitempty"`
+	PublicKey            string               `json:"public_key,omitempty"`
+	Signature            string               `json:"signature,omitempty"`
+	IntegratedTime       int64                `json:"integrated_time,omitempty"`
+	SignedEntryTimestamp string               `json:"signed_entry_timestamp,omitempty"`
+	InclusionProof       *RekorInclusionProof `json:"inclusion_proof,omitempty"`
+}
+
+type RekorInclusionProof struct {
+	RootHash   string   `json:"root_hash"`
+	LogIndex   uint64   `json:"log_index"`
+	TreeSize   uint64   `json:"tree_size"`
+	Hashes     []string `json:"hashes"`
+	Checkpoint string   `json:"checkpoint"`
 }
 
 type Bundle struct {

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -6,17 +6,26 @@ package anchor
 import (
 	"bytes"
 	"context"
+	"crypto"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -31,12 +40,13 @@ const (
 )
 
 // RekorLog submits receipt-chain checkpoints to Rekor and stores the returned
-// submission metadata. Verify fails closed until trusted Rekor SET and
-// inclusion-proof verification is implemented.
+// submission metadata. Verify requires a pinned Rekor log public key and checks
+// the SET, signed checkpoint, and inclusion proof offline.
 type RekorLog struct {
-	URL        string
-	HTTPClient *http.Client
-	Signer     ed25519.PrivateKey
+	URL            string
+	HTTPClient     *http.Client
+	Signer         ed25519.PrivateKey
+	TrustedLogKeys []crypto.PublicKey
 }
 
 type rekorSubmitRequest struct {
@@ -177,6 +187,13 @@ func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
 			Signature:            signature,
 			IntegratedTime:       entry.IntegratedTime,
 			SignedEntryTimestamp: entry.Verification.SignedEntryTimestamp,
+			InclusionProof: &RekorInclusionProof{
+				RootHash:   entry.Verification.InclusionProof.RootHash,
+				LogIndex:   entry.Verification.InclusionProof.LogIndex,
+				TreeSize:   entry.Verification.InclusionProof.TreeSize,
+				Hashes:     append([]string(nil), entry.Verification.InclusionProof.Hashes...),
+				Checkpoint: entry.Verification.InclusionProof.Checkpoint,
+			},
 		},
 	}
 	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
@@ -189,7 +206,19 @@ func (r RekorLog) Verify(proof Proof, checkpoint Checkpoint) error {
 	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
 		return err
 	}
-	return errors.New("rekor independent verification unavailable: trusted Rekor SET and inclusion-proof verification is required")
+	if len(r.TrustedLogKeys) == 0 {
+		return errors.New("trusted Rekor log public key required")
+	}
+	if err := verifyRekorSET(proof, r.TrustedLogKeys); err != nil {
+		return err
+	}
+	if err := verifyRekorCheckpoint(proof, r.TrustedLogKeys); err != nil {
+		return err
+	}
+	if err := verifyRekorInclusion(proof); err != nil {
+		return err
+	}
+	return nil
 }
 
 func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
@@ -217,6 +246,12 @@ func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
 	}
 	if proof.Rekor.IntegratedTime <= 0 {
 		return errors.New("rekor proof integrated_time required")
+	}
+	if proof.Rekor.InclusionProof == nil {
+		return errors.New("rekor proof inclusion_proof required")
+	}
+	if err := validateRekorInclusionProof(proof); err != nil {
+		return err
 	}
 	normalizedURL, err := normalizeRekorBaseURL(proof.Rekor.URL)
 	if err != nil {
@@ -261,6 +296,34 @@ func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
 	return nil
 }
 
+func validateRekorInclusionProof(proof Proof) error {
+	inc := proof.Rekor.InclusionProof
+	if strings.TrimSpace(inc.RootHash) == "" {
+		return errors.New("rekor proof inclusion_proof.root_hash required")
+	}
+	if inc.RootHash != proof.LogRootHash {
+		return errors.New("rekor proof inclusion_proof.root_hash does not match log_root_hash")
+	}
+	if inc.TreeSize == 0 {
+		return errors.New("rekor proof inclusion_proof.tree_size required")
+	}
+	if inc.LogIndex >= inc.TreeSize {
+		return fmt.Errorf("rekor proof inclusion_proof.log_index %d outside tree_size %d", inc.LogIndex, inc.TreeSize)
+	}
+	if strings.TrimSpace(inc.Checkpoint) == "" {
+		return errors.New("rekor proof inclusion_proof.checkpoint required")
+	}
+	if _, err := hex.DecodeString(inc.RootHash); err != nil {
+		return fmt.Errorf("decode rekor inclusion root_hash: %w", err)
+	}
+	for i, hash := range inc.Hashes {
+		if _, err := hex.DecodeString(hash); err != nil {
+			return fmt.Errorf("decode rekor inclusion proof hash %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
 // LoadRekorPrivateKey loads the Ed25519 key used to sign Rekor submission
 // bodies before they are posted.
 func LoadRekorPrivateKey(path string) (ed25519.PrivateKey, error) {
@@ -269,6 +332,76 @@ func LoadRekorPrivateKey(path string) (ed25519.PrivateKey, error) {
 		return nil, fmt.Errorf("load rekor signing key: %w", err)
 	}
 	return key, nil
+}
+
+func LoadRekorPublicKeys(inputs []string) ([]crypto.PublicKey, error) {
+	keys := make([]crypto.PublicKey, 0, len(inputs))
+	for _, input := range inputs {
+		key, err := LoadRekorPublicKey(input)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+func LoadRekorPublicKey(pathOrValue string) (crypto.PublicKey, error) {
+	input := strings.TrimSpace(pathOrValue)
+	if input == "" {
+		return nil, errors.New("rekor log public key is empty")
+	}
+	if strings.Contains(input, "\n") || strings.HasPrefix(input, "-----BEGIN ") {
+		return ParseRekorPublicKey(input)
+	}
+	cleanPath := filepath.Clean(input)
+	if _, err := os.Stat(cleanPath); err == nil {
+		data, readErr := os.ReadFile(cleanPath)
+		if readErr != nil {
+			return nil, fmt.Errorf("read rekor log public key: %w", readErr)
+		}
+		key, parseErr := ParseRekorPublicKey(string(data))
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse rekor log public key file: %w", parseErr)
+		}
+		return key, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("read rekor log public key: %w", err)
+	}
+	if strings.ContainsAny(input, "/\\") || strings.HasPrefix(input, ".") || filepath.Ext(input) != "" {
+		return nil, fmt.Errorf("read rekor log public key file %s: %w", cleanPath, os.ErrNotExist)
+	}
+	return ParseRekorPublicKey(input)
+}
+
+func ParseRekorPublicKey(encoded string) (crypto.PublicKey, error) {
+	trimmed := strings.TrimSpace(encoded)
+	if trimmed == "" {
+		return nil, errors.New("rekor log public key is empty")
+	}
+	if block, _ := pem.Decode([]byte(trimmed)); block != nil {
+		switch block.Type {
+		case "PUBLIC KEY":
+			key, err := x509.ParsePKIXPublicKey(block.Bytes)
+			if err != nil {
+				return nil, fmt.Errorf("parse PEM public key: %w", err)
+			}
+			return key, nil
+		case "CERTIFICATE":
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return nil, fmt.Errorf("parse PEM certificate: %w", err)
+			}
+			return cert.PublicKey, nil
+		default:
+			return nil, fmt.Errorf("unsupported PEM block type %q", block.Type)
+		}
+	}
+	key, err := domsigning.ParsePublicKey(trimmed)
+	if err == nil {
+		return key, nil
+	}
+	return nil, fmt.Errorf("parse rekor log public key: %w", err)
 }
 
 func checkpointBytes(checkpoint Checkpoint) ([]byte, error) {
@@ -326,6 +459,281 @@ func verifyRekorSignature(data []byte, publicKey, signature string) error {
 		return errors.New("rekor checkpoint signature invalid")
 	}
 	return nil
+}
+
+func verifyRekorSET(proof Proof, keys []crypto.PublicKey) error {
+	if proof.LogIndex > math.MaxInt64 {
+		return fmt.Errorf("rekor proof log_index %d overflows SET payload", proof.LogIndex)
+	}
+	sig, err := base64.StdEncoding.DecodeString(proof.Rekor.SignedEntryTimestamp)
+	if err != nil {
+		return fmt.Errorf("decode rekor signed_entry_timestamp: %w", err)
+	}
+	payload, err := canonicalRekorSETPayload(proof)
+	if err != nil {
+		return err
+	}
+	if verifyWithAnyKey(keys, payload, sig) {
+		return nil
+	}
+	return errors.New("rekor signed_entry_timestamp verification failed")
+}
+
+func canonicalRekorSETPayload(proof Proof) ([]byte, error) {
+	// Rekor signs the JCS form of exactly these four fields. For this shape,
+	// JCS is normal JSON string escaping plus lexicographic field order:
+	// body, integratedTime, logID, logIndex.
+	body, err := json.Marshal(proof.Rekor.Body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal rekor SET body: %w", err)
+	}
+	logID, err := json.Marshal(proof.LogID)
+	if err != nil {
+		return nil, fmt.Errorf("marshal rekor SET logID: %w", err)
+	}
+	var out bytes.Buffer
+	out.WriteString(`{"body":`)
+	out.Write(body)
+	out.WriteString(`,"integratedTime":`)
+	_, _ = fmt.Fprintf(&out, "%d", proof.Rekor.IntegratedTime)
+	out.WriteString(`,"logID":`)
+	out.Write(logID)
+	out.WriteString(`,"logIndex":`)
+	_, _ = fmt.Fprintf(&out, "%d", proof.LogIndex)
+	out.WriteByte('}')
+	return out.Bytes(), nil
+}
+
+func verifyRekorCheckpoint(proof Proof, keys []crypto.PublicKey) error {
+	checkpoint, err := parseSignedRekorCheckpoint(proof.Rekor.InclusionProof.Checkpoint)
+	if err != nil {
+		return err
+	}
+	root, err := hex.DecodeString(proof.Rekor.InclusionProof.RootHash)
+	if err != nil {
+		return fmt.Errorf("decode rekor inclusion root_hash: %w", err)
+	}
+	if !bytes.Equal(root, checkpoint.RootHash) {
+		return errors.New("rekor checkpoint root hash does not match inclusion proof")
+	}
+	if checkpoint.TreeSize != proof.Rekor.InclusionProof.TreeSize {
+		return errors.New("rekor checkpoint tree size does not match inclusion proof")
+	}
+	for _, key := range keys {
+		for _, sig := range checkpoint.Signatures {
+			if sig.KeyHash == publicKeyHash(key) && verifySignature(key, checkpoint.Note, sig.Signature) {
+				return nil
+			}
+		}
+	}
+	return errors.New("rekor checkpoint signature verification failed")
+}
+
+type signedRekorCheckpoint struct {
+	Note       []byte
+	TreeSize   uint64
+	RootHash   []byte
+	Signatures []rekorNoteSignature
+}
+
+type rekorNoteSignature struct {
+	Name      string
+	KeyHash   uint32
+	Signature []byte
+}
+
+func parseSignedRekorCheckpoint(raw string) (signedRekorCheckpoint, error) {
+	data := []byte(raw)
+	split := bytes.LastIndex(data, []byte("\n\n"))
+	if split < 0 {
+		return signedRekorCheckpoint{}, errors.New("rekor checkpoint malformed signed note")
+	}
+	note := data[:split+1]
+	signatureBlock := data[split+2:]
+	if len(signatureBlock) == 0 || signatureBlock[len(signatureBlock)-1] != '\n' {
+		return signedRekorCheckpoint{}, errors.New("rekor checkpoint malformed signature block")
+	}
+	lines := bytes.Split(note, []byte("\n"))
+	if len(lines) < 4 {
+		return signedRekorCheckpoint{}, errors.New("rekor checkpoint has too few lines")
+	}
+	if len(lines[0]) == 0 {
+		return signedRekorCheckpoint{}, errors.New("rekor checkpoint origin is empty")
+	}
+	treeSize, err := parseUintLine(lines[1], "tree size")
+	if err != nil {
+		return signedRekorCheckpoint{}, err
+	}
+	root, err := base64.StdEncoding.DecodeString(string(lines[2]))
+	if err != nil {
+		return signedRekorCheckpoint{}, fmt.Errorf("decode rekor checkpoint root hash: %w", err)
+	}
+	signatures, err := parseRekorNoteSignatures(signatureBlock)
+	if err != nil {
+		return signedRekorCheckpoint{}, err
+	}
+	return signedRekorCheckpoint{Note: note, TreeSize: treeSize, RootHash: root, Signatures: signatures}, nil
+}
+
+func parseUintLine(line []byte, name string) (uint64, error) {
+	var value uint64
+	if len(line) == 0 {
+		return 0, fmt.Errorf("rekor checkpoint %s is empty", name)
+	}
+	for _, b := range line {
+		if b < '0' || b > '9' {
+			return 0, fmt.Errorf("rekor checkpoint %s is not numeric", name)
+		}
+		if value > (math.MaxUint64-uint64(b-'0'))/10 {
+			return 0, fmt.Errorf("rekor checkpoint %s overflows uint64", name)
+		}
+		value = value*10 + uint64(b-'0')
+	}
+	return value, nil
+}
+
+func parseRekorNoteSignatures(data []byte) ([]rekorNoteSignature, error) {
+	lines := bytes.Split(data, []byte("\n"))
+	var signatures []rekorNoteSignature
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		rest, ok := strings.CutPrefix(string(line), "\u2014 ")
+		if !ok {
+			return nil, errors.New("rekor checkpoint signature line malformed")
+		}
+		name, encoded, ok := strings.Cut(rest, " ")
+		if !ok || name == "" || encoded == "" {
+			return nil, errors.New("rekor checkpoint signature line malformed")
+		}
+		raw, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("decode rekor checkpoint signature: %w", err)
+		}
+		if len(raw) < 5 {
+			return nil, errors.New("rekor checkpoint signature too small")
+		}
+		signatures = append(signatures, rekorNoteSignature{
+			Name:      name,
+			KeyHash:   binary.BigEndian.Uint32(raw[:4]),
+			Signature: raw[4:],
+		})
+	}
+	if len(signatures) == 0 {
+		return nil, errors.New("rekor checkpoint has no signatures")
+	}
+	return signatures, nil
+}
+
+func verifyRekorInclusion(proof Proof) error {
+	bodyBytes, err := base64.StdEncoding.DecodeString(proof.Rekor.Body)
+	if err != nil {
+		return fmt.Errorf("decode rekor body: %w", err)
+	}
+	root, err := hex.DecodeString(proof.Rekor.InclusionProof.RootHash)
+	if err != nil {
+		return fmt.Errorf("decode rekor inclusion root_hash: %w", err)
+	}
+	hashes := make([][]byte, 0, len(proof.Rekor.InclusionProof.Hashes))
+	for i, hash := range proof.Rekor.InclusionProof.Hashes {
+		decoded, err := hex.DecodeString(hash)
+		if err != nil {
+			return fmt.Errorf("decode rekor inclusion proof hash %d: %w", i, err)
+		}
+		hashes = append(hashes, decoded)
+	}
+	leaf := rfc6962LeafHash(bodyBytes)
+	if err := verifyRFC6962Inclusion(proof.Rekor.InclusionProof.LogIndex, proof.Rekor.InclusionProof.TreeSize, leaf, hashes, root); err != nil {
+		return fmt.Errorf("verify rekor inclusion proof: %w", err)
+	}
+	return nil
+}
+
+func verifyRFC6962Inclusion(index, size uint64, leafHash []byte, hashes [][]byte, root []byte) error {
+	if size == 0 {
+		return errors.New("tree size is zero")
+	}
+	if index >= size {
+		return fmt.Errorf("index %d outside tree size %d", index, size)
+	}
+	fn := index
+	sn := size - 1
+	computed := append([]byte(nil), leafHash...)
+	for _, hash := range hashes {
+		if sn == 0 {
+			return errors.New("too many proof hashes")
+		}
+		if fn%2 == 1 || fn == sn {
+			computed = rfc6962NodeHash(hash, computed)
+			for fn%2 == 0 && fn != 0 {
+				fn /= 2
+				sn /= 2
+			}
+		} else {
+			computed = rfc6962NodeHash(computed, hash)
+		}
+		fn /= 2
+		sn /= 2
+	}
+	if sn != 0 {
+		return errors.New("proof too short")
+	}
+	if !bytes.Equal(computed, root) {
+		return errors.New("computed root does not match proof root")
+	}
+	return nil
+}
+
+func rfc6962LeafHash(data []byte) []byte {
+	h := sha256.New()
+	h.Write([]byte{0x00})
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func rfc6962NodeHash(left, right []byte) []byte {
+	h := sha256.New()
+	h.Write([]byte{0x01})
+	h.Write(left)
+	h.Write(right)
+	return h.Sum(nil)
+}
+
+func verifyWithAnyKey(keys []crypto.PublicKey, message, signature []byte) bool {
+	for _, key := range keys {
+		if verifySignature(key, message, signature) {
+			return true
+		}
+	}
+	return false
+}
+
+func verifySignature(key crypto.PublicKey, message, signature []byte) bool {
+	switch pub := key.(type) {
+	case ed25519.PublicKey:
+		return ed25519.Verify(pub, message, signature)
+	case *ecdsa.PublicKey:
+		digest := sha256.Sum256(message)
+		return ecdsa.VerifyASN1(pub, digest[:], signature)
+	case *rsa.PublicKey:
+		digest := sha256.Sum256(message)
+		if rsa.VerifyPSS(pub, crypto.SHA256, digest[:], signature, nil) == nil {
+			return true
+		}
+		return rsa.VerifyPKCS1v15(pub, crypto.SHA256, digest[:], signature) == nil
+	default:
+		return false
+	}
+}
+
+func publicKeyHash(key crypto.PublicKey) uint32 {
+	der, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return 0
+	}
+	sum := sha256.Sum256(der)
+	return binary.BigEndian.Uint32(sum[:4])
 }
 
 func rekorBaseURL(raw string) string {

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -307,18 +307,29 @@ func validateRekorInclusionProof(proof Proof) error {
 	if inc.TreeSize == 0 {
 		return errors.New("rekor proof inclusion_proof.tree_size required")
 	}
+	if inc.LogIndex != proof.LogIndex {
+		return fmt.Errorf("rekor proof inclusion_proof.log_index %d does not match log_index %d", inc.LogIndex, proof.LogIndex)
+	}
 	if inc.LogIndex >= inc.TreeSize {
 		return fmt.Errorf("rekor proof inclusion_proof.log_index %d outside tree_size %d", inc.LogIndex, inc.TreeSize)
 	}
 	if strings.TrimSpace(inc.Checkpoint) == "" {
 		return errors.New("rekor proof inclusion_proof.checkpoint required")
 	}
-	if _, err := hex.DecodeString(inc.RootHash); err != nil {
+	root, err := hex.DecodeString(inc.RootHash)
+	if err != nil {
 		return fmt.Errorf("decode rekor inclusion root_hash: %w", err)
 	}
+	if len(root) != sha256.Size {
+		return fmt.Errorf("rekor proof inclusion_proof.root_hash length = %d, want %d", len(root), sha256.Size)
+	}
 	for i, hash := range inc.Hashes {
-		if _, err := hex.DecodeString(hash); err != nil {
+		decoded, err := hex.DecodeString(hash)
+		if err != nil {
 			return fmt.Errorf("decode rekor inclusion proof hash %d: %w", i, err)
+		}
+		if len(decoded) != sha256.Size {
+			return fmt.Errorf("rekor inclusion proof hash %d length = %d, want %d", i, len(decoded), sha256.Size)
 		}
 	}
 	return nil

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -18,6 +19,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -168,8 +170,19 @@ func TestRekorSubmissionRecordRequiresMetadata(t *testing.T) {
 		{name: "set whitespace", edit: func(p *Proof) { p.Rekor.SignedEntryTimestamp = " \t" }, want: "signed_entry_timestamp"},
 		{name: "inclusion proof", edit: func(p *Proof) { p.Rekor.InclusionProof = nil }, want: "inclusion_proof"},
 		{name: "inclusion root mismatch", edit: func(p *Proof) { p.Rekor.InclusionProof.RootHash = strings.Repeat("0", 64) }, want: "root_hash"},
+		{name: "inclusion log index mismatch", edit: func(p *Proof) {
+			p.Rekor.InclusionProof.TreeSize = 2
+			p.Rekor.InclusionProof.LogIndex = 1
+		}, want: "log_index"},
 		{name: "inclusion tree size", edit: func(p *Proof) { p.Rekor.InclusionProof.TreeSize = 0 }, want: "tree_size"},
 		{name: "inclusion checkpoint", edit: func(p *Proof) { p.Rekor.InclusionProof.Checkpoint = "" }, want: "checkpoint"},
+		{name: "inclusion root hash short", edit: func(p *Proof) {
+			p.LogRootHash = "aabb"
+			p.Rekor.InclusionProof.RootHash = "aabb"
+		}, want: "root_hash length"},
+		{name: "inclusion proof hash short", edit: func(p *Proof) {
+			p.Rekor.InclusionProof.Hashes = append(p.Rekor.InclusionProof.Hashes, "aabb")
+		}, want: "proof hash 0 length"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -274,6 +287,42 @@ func TestLoadRekorPublicKeyAcceptsPEMAndPipelockFormats(t *testing.T) {
 	if !pipelockKey.(ed25519.PublicKey).Equal(pub) {
 		t.Fatal("pipelock key mismatch")
 	}
+	keys, err := LoadRekorPublicKeys([]string{pemText, domsigning.EncodePublicKey(pub)})
+	if err != nil {
+		t.Fatalf("LoadRekorPublicKeys: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("LoadRekorPublicKeys len = %d, want 2", len(keys))
+	}
+}
+
+func TestLoadRekorPublicKeyRejectsMalformedInputs(t *testing.T) {
+	dir := t.TempDir()
+	badFile := filepath.Join(dir, "bad.pub")
+	if err := os.WriteFile(badFile, []byte("not-a-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: " \t", want: "empty"},
+		{name: "unsupported pem", input: "-----BEGIN TRUST ANCHOR-----\nAA==\n-----END TRUST ANCHOR-----", want: "unsupported PEM"},
+		{name: "missing file path", input: filepath.Join(dir, "missing.pub"), want: "file does not exist"},
+		{name: "bad file contents", input: badFile, want: "parse rekor log public key file"},
+		{name: "bad inline value", input: "not-a-key", want: "parse rekor log public key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := LoadRekorPublicKey(tc.input); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("LoadRekorPublicKey err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+	if _, err := LoadRekorPublicKeys([]string{domsigning.EncodePublicKey(mustEd25519PublicKey(t)), "not-a-key"}); err == nil || !strings.Contains(err.Error(), "parse rekor log public key") {
+		t.Fatalf("LoadRekorPublicKeys err = %v, want wrapped parse error", err)
+	}
 }
 
 func TestRekorLogVerifyRejectsForgedSelfConsistentProof(t *testing.T) {
@@ -297,6 +346,165 @@ func TestRekorLogVerifyRejectsForgedSelfConsistentProof(t *testing.T) {
 	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, RekorLog{TrustedLogKeys: []crypto.PublicKey{trustedLogPub}})
 	if report.Valid || !strings.Contains(report.Error, "signed_entry_timestamp") {
 		t.Fatalf("forged Rekor proof report = %+v, want SET verification failure", report)
+	}
+}
+
+func TestRekorLogVerifyRejectsMalformedVerificationArtifacts(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	logPub, logPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	proof := selfConsistentRekorProof(t, checkpoint, logPriv, logPriv)
+	root, err := hex.DecodeString(proof.Rekor.InclusionProof.RootHash)
+	if err != nil {
+		t.Fatalf("DecodeString root: %v", err)
+	}
+	cases := []struct {
+		name string
+		edit func(*Proof)
+		want string
+	}{
+		{name: "set base64", edit: func(p *Proof) {
+			p.Rekor.SignedEntryTimestamp = "not base64!"
+		}, want: "signed_entry_timestamp"},
+		{name: "checkpoint root mismatch", edit: func(p *Proof) {
+			p.Rekor.InclusionProof.Checkpoint = signedCheckpointForTest(t, 1, make([]byte, sha256.Size), logPriv)
+		}, want: "checkpoint root hash"},
+		{name: "checkpoint tree size mismatch", edit: func(p *Proof) {
+			p.Rekor.InclusionProof.Checkpoint = signedCheckpointForTest(t, 2, root, logPriv)
+		}, want: "checkpoint tree size"},
+		{name: "checkpoint wrong signer", edit: func(p *Proof) {
+			_, wrongPriv, genErr := ed25519.GenerateKey(rand.Reader)
+			if genErr != nil {
+				t.Fatalf("GenerateKey wrong: %v", genErr)
+			}
+			p.Rekor.InclusionProof.Checkpoint = signedCheckpointForTest(t, 1, root, wrongPriv)
+		}, want: "checkpoint signature"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := proof
+			candidate.Rekor = cloneRekorProof(proof.Rekor)
+			tc.edit(&candidate)
+			err := (RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}}).Verify(candidate, checkpoint)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Verify err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+	setOverflow := proof
+	setOverflow.Rekor = cloneRekorProof(proof.Rekor)
+	setOverflow.LogIndex = math.MaxUint64
+	if err := verifyRekorSET(setOverflow, []crypto.PublicKey{logPub}); err == nil || !strings.Contains(err.Error(), "overflows SET payload") {
+		t.Fatalf("verifyRekorSET overflow err = %v, want overflow", err)
+	}
+}
+
+func TestVerifyRekorInclusionRejectsMalformedInputs(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, logPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	proof := selfConsistentRekorProof(t, checkpoint, logPriv, logPriv)
+	cases := []struct {
+		name string
+		edit func(*Proof)
+		want string
+	}{
+		{name: "body base64", edit: func(p *Proof) {
+			p.Rekor.Body = "not base64!"
+		}, want: "decode rekor body"},
+		{name: "root hex", edit: func(p *Proof) {
+			p.Rekor.InclusionProof.RootHash = "not-hex"
+		}, want: "decode rekor inclusion root_hash"},
+		{name: "path hex", edit: func(p *Proof) {
+			p.Rekor.InclusionProof.Hashes = []string{"not-hex"}
+		}, want: "decode rekor inclusion proof hash 0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := proof
+			candidate.Rekor = cloneRekorProof(proof.Rekor)
+			tc.edit(&candidate)
+			if err := verifyRekorInclusion(candidate); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("verifyRekorInclusion err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseSignedRekorCheckpointRejectsMalformedNotes(t *testing.T) {
+	validRoot := base64.StdEncoding.EncodeToString([]byte("root"))
+	validSig := base64.StdEncoding.EncodeToString([]byte{0, 0, 0, 1, 's'})
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "no signature split", raw: "origin\n1\n" + validRoot + "\n", want: "malformed signed note"},
+		{name: "signature block no trailing newline", raw: "origin\n1\n" + validRoot + "\n\n— fake " + validSig, want: "malformed signature block"},
+		{name: "too few note lines", raw: "origin\n1\n\n— fake " + validSig + "\n", want: "too few lines"},
+		{name: "empty origin", raw: "\n1\n" + validRoot + "\n\n— fake " + validSig + "\n", want: "origin is empty"},
+		{name: "empty tree size", raw: "origin\n\n" + validRoot + "\n\n— fake " + validSig + "\n", want: "tree size is empty"},
+		{name: "nonnumeric tree size", raw: "origin\none\n" + validRoot + "\n\n— fake " + validSig + "\n", want: "tree size is not numeric"},
+		{name: "overflow tree size", raw: "origin\n18446744073709551616\n" + validRoot + "\n\n— fake " + validSig + "\n", want: "tree size overflows"},
+		{name: "bad root", raw: "origin\n1\nnot-base64!\n\n— fake " + validSig + "\n", want: "decode rekor checkpoint root hash"},
+		{name: "bad signature prefix", raw: "origin\n1\n" + validRoot + "\n\nbad\n", want: "signature line malformed"},
+		{name: "bad signature base64", raw: "origin\n1\n" + validRoot + "\n\n— fake not-base64!\n", want: "decode rekor checkpoint signature"},
+		{name: "small signature", raw: "origin\n1\n" + validRoot + "\n\n— fake AA==\n", want: "signature too small"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseSignedRekorCheckpoint(tc.raw); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("parseSignedRekorCheckpoint err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+	if _, err := parseRekorNoteSignatures([]byte("\n")); err == nil || !strings.Contains(err.Error(), "no signatures") {
+		t.Fatalf("parseRekorNoteSignatures err = %v, want no signatures", err)
+	}
+}
+
+func TestVerifySignature_RSAAndUnsupportedKeys(t *testing.T) {
+	t.Parallel()
+	msg := []byte("rekor checkpoint bytes")
+	digest := sha256.Sum256(msg)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa GenerateKey: %v", err)
+	}
+	pss, err := rsa.SignPSS(rand.Reader, key, crypto.SHA256, digest[:], nil)
+	if err != nil {
+		t.Fatalf("SignPSS: %v", err)
+	}
+	if !verifySignature(&key.PublicKey, msg, pss) {
+		t.Fatal("rsa pss: valid signature rejected")
+	}
+	pkcs1, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("SignPKCS1v15: %v", err)
+	}
+	if !verifySignature(&key.PublicKey, msg, pkcs1) {
+		t.Fatal("rsa pkcs1v15: valid signature rejected")
+	}
+	if verifySignature(&key.PublicKey, []byte("wrong message"), pss) {
+		t.Fatal("rsa: wrong-message signature accepted")
+	}
+	if verifySignature(struct{}{}, msg, pss) {
+		t.Fatal("unsupported key type accepted")
+	}
+	if publicKeyHash(struct{}{}) != 0 {
+		t.Fatal("unsupported key hash did not fail closed to zero")
 	}
 }
 
@@ -450,6 +658,15 @@ func cloneRekorProof(in *RekorProof) *RekorProof {
 		out.InclusionProof = &inc
 	}
 	return &out
+}
+
+func mustEd25519PublicKey(t *testing.T) ed25519.PublicKey {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub
 }
 
 func fakeRekorServer(t *testing.T) *httptest.Server {

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -5,13 +5,23 @@ package anchor
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,8 +31,6 @@ import (
 
 const (
 	fakeRekorIntegratedTime int64 = 1780000000
-	fakeRekorRootHash             = "fake-root"
-	fakeRekorSET                  = "fake-set"
 )
 
 func TestRekorLogSubmitRecordsSubmissionProof(t *testing.T) {
@@ -35,7 +43,7 @@ func TestRekorLogSubmitRecordsSubmissionProof(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
-	server := fakeRekorServer(t)
+	server, logPub := fakeTrustedRekorServer(t)
 	proof, err := (RekorLog{URL: server.URL, Signer: priv}).Submit(checkpoint)
 	if err != nil {
 		t.Fatalf("Submit: %v", err)
@@ -43,7 +51,7 @@ func TestRekorLogSubmitRecordsSubmissionProof(t *testing.T) {
 	if proof.Backend != RekorBackend || proof.Rekor == nil {
 		t.Fatalf("incomplete proof: %+v", proof)
 	}
-	if proof.LogID != "fake-rekor-log" || proof.LogIndex != 7 || proof.LogRootHash != fakeRekorRootHash || proof.EntryHash == "" {
+	if proof.LogID != "fake-rekor-log" || proof.LogIndex != 0 || proof.LogRootHash == "" || proof.EntryHash == "" {
 		t.Fatalf("unexpected Rekor log metadata: %+v", proof)
 	}
 	if proof.Rekor.URL != server.URL ||
@@ -52,15 +60,22 @@ func TestRekorLogSubmitRecordsSubmissionProof(t *testing.T) {
 		proof.Rekor.PublicKey == "" ||
 		proof.Rekor.Signature == "" ||
 		proof.Rekor.IntegratedTime != fakeRekorIntegratedTime ||
-		proof.Rekor.SignedEntryTimestamp != fakeRekorSET {
+		proof.Rekor.SignedEntryTimestamp == "" ||
+		proof.Rekor.InclusionProof == nil ||
+		proof.Rekor.InclusionProof.RootHash != proof.LogRootHash ||
+		proof.Rekor.InclusionProof.TreeSize != 1 {
 		t.Fatalf("unexpected Rekor proof metadata: %+v", proof.Rekor)
 	}
 	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
 		t.Fatalf("validateRekorSubmissionRecord: %v", err)
 	}
 	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, RekorLog{})
-	if report.Valid || !strings.Contains(report.Error, "trusted Rekor SET") {
-		t.Fatalf("VerifyBundle report = %+v, want fail-closed SET verification error", report)
+	if report.Valid || !strings.Contains(report.Error, "trusted Rekor log public key") {
+		t.Fatalf("VerifyBundle report = %+v, want missing Rekor key error", report)
+	}
+	report = VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}})
+	if !report.Valid {
+		t.Fatalf("VerifyBundle with trusted Rekor key invalid: %s", report.Error)
 	}
 }
 
@@ -151,6 +166,10 @@ func TestRekorSubmissionRecordRequiresMetadata(t *testing.T) {
 		{name: "integrated time", edit: func(p *Proof) { p.Rekor.IntegratedTime = 0 }, want: "integrated_time"},
 		{name: "set", edit: func(p *Proof) { p.Rekor.SignedEntryTimestamp = "" }, want: "signed_entry_timestamp"},
 		{name: "set whitespace", edit: func(p *Proof) { p.Rekor.SignedEntryTimestamp = " \t" }, want: "signed_entry_timestamp"},
+		{name: "inclusion proof", edit: func(p *Proof) { p.Rekor.InclusionProof = nil }, want: "inclusion_proof"},
+		{name: "inclusion root mismatch", edit: func(p *Proof) { p.Rekor.InclusionProof.RootHash = strings.Repeat("0", 64) }, want: "root_hash"},
+		{name: "inclusion tree size", edit: func(p *Proof) { p.Rekor.InclusionProof.TreeSize = 0 }, want: "tree_size"},
+		{name: "inclusion checkpoint", edit: func(p *Proof) { p.Rekor.InclusionProof.Checkpoint = "" }, want: "checkpoint"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -220,6 +239,43 @@ func TestLoadRekorPrivateKey(t *testing.T) {
 	}
 }
 
+func TestLoadRekorPublicKeyAcceptsPEMAndPipelockFormats(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	pemText := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+	inline, err := LoadRekorPublicKey(pemText)
+	if err != nil {
+		t.Fatalf("LoadRekorPublicKey inline PEM: %v", err)
+	}
+	if !inline.(ed25519.PublicKey).Equal(pub) {
+		t.Fatal("inline PEM key mismatch")
+	}
+	path := filepath.Join(t.TempDir(), "rekor.pub")
+	if err := os.WriteFile(path, []byte(pemText), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	fromFile, err := LoadRekorPublicKey(path)
+	if err != nil {
+		t.Fatalf("LoadRekorPublicKey file: %v", err)
+	}
+	if !fromFile.(ed25519.PublicKey).Equal(pub) {
+		t.Fatal("file PEM key mismatch")
+	}
+	pipelockKey, err := LoadRekorPublicKey(domsigning.EncodePublicKey(pub))
+	if err != nil {
+		t.Fatalf("LoadRekorPublicKey pipelock: %v", err)
+	}
+	if !pipelockKey.(ed25519.PublicKey).Equal(pub) {
+		t.Fatal("pipelock key mismatch")
+	}
+}
+
 func TestRekorLogVerifyRejectsForgedSelfConsistentProof(t *testing.T) {
 	receipts, keyHex := testReceiptChain(t, 1)
 	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
@@ -230,55 +286,17 @@ func TestRekorLogVerifyRejectsForgedSelfConsistentProof(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
-	checkpointBytes, err := checkpointBytes(checkpoint)
+	trustedLogPub, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		t.Fatalf("checkpointBytes: %v", err)
+		t.Fatalf("GenerateKey trusted: %v", err)
 	}
-	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, attackerPriv)
-	if err != nil {
-		t.Fatalf("signRekorCheckpoint: %v", err)
-	}
-	body := rekorSubmitRequest{
-		APIVersion: rekorHashedRekordAPIVersion,
-		Kind:       rekorHashedRekordKind,
-		Spec: rekorSubmitSpec{
-			Data: rekorData{Hash: rekorHash{
-				Algorithm: rekorSHA256Algorithm,
-				Value:     sha256Hex(checkpointBytes),
-			}},
-			Signature: rekorSignature{
-				Content:   signature,
-				PublicKey: rekorPublicKey{Content: publicKey},
-			},
-		},
-	}
-	bodyBytes, err := json.Marshal(body)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	encodedBody := base64.StdEncoding.EncodeToString(bodyBytes)
-	proof := Proof{
-		Backend:     RekorBackend,
-		LogID:       "TOTALLY-MADE-UP",
-		LogIndex:    999999,
-		EntryHash:   sha256Hex([]byte(encodedBody)),
-		LogRootHash: "fabricated-root",
-		Rekor: &RekorProof{
-			URL:                  "https://rekor.example.invalid",
-			UUID:                 "fake-uuid",
-			Body:                 encodedBody,
-			PublicKey:            publicKey,
-			Signature:            signature,
-			IntegratedTime:       fakeRekorIntegratedTime,
-			SignedEntryTimestamp: fakeRekorSET,
-		},
-	}
+	proof := selfConsistentRekorProof(t, checkpoint, attackerPriv, attackerPriv)
 	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
 		t.Fatalf("forged self-consistent submission record did not validate: %v", err)
 	}
-	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, RekorLog{})
-	if report.Valid || !strings.Contains(report.Error, "trusted Rekor SET") {
-		t.Fatalf("forged Rekor proof report = %+v, want fail-closed SET verification error", report)
+	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, RekorLog{TrustedLogKeys: []crypto.PublicKey{trustedLogPub}})
+	if report.Valid || !strings.Contains(report.Error, "signed_entry_timestamp") {
+		t.Fatalf("forged Rekor proof report = %+v, want SET verification failure", report)
 	}
 }
 
@@ -314,21 +332,21 @@ func TestRekorLogSubmitRejectsMalformedResponses(t *testing.T) {
 		{
 			name: "missing log id",
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				writeMappedRekorEntry(t, w, r, "", "body", fakeRekorRootHash, fakeRekorSET, fakeRekorIntegratedTime)
+				writeMappedRekorEntry(t, w, r, "", "body", "aabb", "set", fakeRekorIntegratedTime)
 			},
 			want: "logID required",
 		},
 		{
 			name: "missing body",
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				writeMappedRekorEntry(t, w, r, "fake-rekor-log", "", fakeRekorRootHash, fakeRekorSET, fakeRekorIntegratedTime)
+				writeMappedRekorEntry(t, w, r, "fake-rekor-log", "", "aabb", "set", fakeRekorIntegratedTime)
 			},
 			want: "body required",
 		},
 		{
 			name: "missing set",
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				writeMappedRekorEntry(t, w, r, "fake-rekor-log", "body", fakeRekorRootHash, "", fakeRekorIntegratedTime)
+				writeMappedRekorEntry(t, w, r, "fake-rekor-log", "body", "aabb", "", fakeRekorIntegratedTime)
 			},
 			want: "signed_entry_timestamp",
 		},
@@ -426,11 +444,26 @@ func cloneRekorProof(in *RekorProof) *RekorProof {
 		return nil
 	}
 	out := *in
+	if in.InclusionProof != nil {
+		inc := *in.InclusionProof
+		inc.Hashes = append([]string(nil), in.InclusionProof.Hashes...)
+		out.InclusionProof = &inc
+	}
 	return &out
 }
 
 func fakeRekorServer(t *testing.T) *httptest.Server {
 	t.Helper()
+	server, _ := fakeTrustedRekorServer(t)
+	return server
+}
+
+func fakeTrustedRekorServer(t *testing.T) (*httptest.Server, ed25519.PublicKey) {
+	t.Helper()
+	logPub, logPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey log: %v", err)
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/log/entries" {
 			http.Error(w, "not found", http.StatusNotFound)
@@ -447,22 +480,28 @@ func fakeRekorServer(t *testing.T) *httptest.Server {
 			return
 		}
 		encodedBody := base64.StdEncoding.EncodeToString(raw)
+		rootHashBytes := rfc6962LeafHash(raw)
+		rootHash := hex.EncodeToString(rootHashBytes)
+		set := signedEntryTimestampForTest(t, "fake-rekor-log", 0, encodedBody, logPriv)
 		entry := rekorEntry{
 			LogID:          "fake-rekor-log",
-			LogIndex:       7,
+			LogIndex:       0,
 			IntegratedTime: fakeRekorIntegratedTime,
 			Body:           encodedBody,
 			Verification: rekorVerification{
-				SignedEntryTimestamp: fakeRekorSET,
+				SignedEntryTimestamp: set,
 				InclusionProof: rekorInclusionProof{
-					RootHash: fakeRekorRootHash,
+					RootHash:   rootHash,
+					LogIndex:   0,
+					TreeSize:   1,
+					Checkpoint: signedCheckpointForTest(t, 1, rootHashBytes, logPriv),
 				},
 			},
 		}
 		_ = json.NewEncoder(w).Encode(map[string]rekorEntry{"fake-uuid": entry})
 	}))
 	t.Cleanup(server.Close)
-	return server
+	return server, logPub
 }
 
 func writeDirectRekorEntry(t *testing.T, w http.ResponseWriter, r *http.Request, logID, body string) {
@@ -476,8 +515,8 @@ func writeDirectRekorEntry(t *testing.T, w http.ResponseWriter, r *http.Request,
 		IntegratedTime: fakeRekorIntegratedTime,
 		Body:           body,
 		Verification: rekorVerification{
-			SignedEntryTimestamp: fakeRekorSET,
-			InclusionProof:       rekorInclusionProof{RootHash: fakeRekorRootHash},
+			SignedEntryTimestamp: "set",
+			InclusionProof:       rekorInclusionProof{RootHash: "aabb", TreeSize: 1, Checkpoint: "checkpoint"},
 		},
 	})
 }
@@ -494,7 +533,7 @@ func writeMappedRekorEntry(t *testing.T, w http.ResponseWriter, r *http.Request,
 		Body:           body,
 		Verification: rekorVerification{
 			SignedEntryTimestamp: set,
-			InclusionProof:       rekorInclusionProof{RootHash: rootHash},
+			InclusionProof:       rekorInclusionProof{RootHash: rootHash, TreeSize: 1, Checkpoint: "checkpoint"},
 		},
 	}})
 }
@@ -510,4 +549,237 @@ func encodedRekorRequestBody(t *testing.T, r *http.Request) string {
 		t.Fatalf("Marshal request: %v", err)
 	}
 	return base64.StdEncoding.EncodeToString(raw)
+}
+
+func selfConsistentRekorProof(t *testing.T, checkpoint Checkpoint, entrySigner, logSigner ed25519.PrivateKey) Proof {
+	t.Helper()
+	checkpointBytes, err := checkpointBytes(checkpoint)
+	if err != nil {
+		t.Fatalf("checkpointBytes: %v", err)
+	}
+	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, entrySigner)
+	if err != nil {
+		t.Fatalf("signRekorCheckpoint: %v", err)
+	}
+	body := rekorSubmitRequest{
+		APIVersion: rekorHashedRekordAPIVersion,
+		Kind:       rekorHashedRekordKind,
+		Spec: rekorSubmitSpec{
+			Data: rekorData{Hash: rekorHash{
+				Algorithm: rekorSHA256Algorithm,
+				Value:     sha256Hex(checkpointBytes),
+			}},
+			Signature: rekorSignature{
+				Content:   signature,
+				PublicKey: rekorPublicKey{Content: publicKey},
+			},
+		},
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	encodedBody := base64.StdEncoding.EncodeToString(bodyBytes)
+	rootHash := rfc6962LeafHash(bodyBytes)
+	proof := Proof{
+		Backend:     RekorBackend,
+		LogID:       "fake-rekor-log",
+		LogIndex:    0,
+		EntryHash:   sha256Hex([]byte(encodedBody)),
+		LogRootHash: hex.EncodeToString(rootHash),
+		Rekor: &RekorProof{
+			URL:                  "https://rekor.example.invalid",
+			UUID:                 "fake-uuid",
+			Body:                 encodedBody,
+			PublicKey:            publicKey,
+			Signature:            signature,
+			IntegratedTime:       fakeRekorIntegratedTime,
+			SignedEntryTimestamp: signedEntryTimestampForTest(t, "fake-rekor-log", 0, encodedBody, logSigner),
+			InclusionProof: &RekorInclusionProof{
+				RootHash:   hex.EncodeToString(rootHash),
+				LogIndex:   0,
+				TreeSize:   1,
+				Checkpoint: signedCheckpointForTest(t, 1, rootHash, logSigner),
+			},
+		},
+	}
+	return proof
+}
+
+func signedEntryTimestampForTest(t *testing.T, logID string, logIndex uint64, body string, priv ed25519.PrivateKey) string {
+	t.Helper()
+	proof := Proof{
+		LogID:    logID,
+		LogIndex: logIndex,
+		Rekor: &RekorProof{
+			Body:           body,
+			IntegratedTime: fakeRekorIntegratedTime,
+		},
+	}
+	payload, err := canonicalRekorSETPayload(proof)
+	if err != nil {
+		t.Fatalf("canonicalRekorSETPayload: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(priv, payload))
+}
+
+func signedCheckpointForTest(t *testing.T, treeSize uint64, root []byte, priv ed25519.PrivateKey) string {
+	t.Helper()
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		t.Fatal("private key public half is not Ed25519")
+	}
+	note := fmt.Sprintf("fake-rekor-log\n%d\n%s\n", treeSize, base64.StdEncoding.EncodeToString(root))
+	sig := ed25519.Sign(priv, []byte(note))
+	var prefix [4]byte
+	binary.BigEndian.PutUint32(prefix[:], publicKeyHash(pub))
+	encoded := base64.StdEncoding.EncodeToString(append(prefix[:], sig...))
+	return note + "\n\u2014 fake-rekor " + encoded + "\n"
+}
+
+// TestVerifyRFC6962Inclusion_MultiNodeTrees exercises the inclusion-proof loop
+// against multi-leaf Merkle trees, including unbalanced ones. The integration
+// tests only build TreeSize=1 trees (empty proof path), so without this the
+// fn/sn navigation loop \u2014 exactly where Merkle-proof off-by-ones live \u2014 has no
+// coverage. The expected root and audit path are computed independently here,
+// straight from the RFC 6962 recursive definitions, so a regression in the
+// verifier loop produces a mismatch rather than a self-consistent pass.
+func TestVerifyRFC6962Inclusion_MultiNodeTrees(t *testing.T) {
+	t.Parallel()
+	for _, size := range []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 16} {
+		hashed := make([][]byte, size)
+		for i := range hashed {
+			hashed[i] = rfc6962LeafHash([]byte(fmt.Sprintf("leaf-%d-of-%d", i, size)))
+		}
+		root := rfc6962TestMerkleRoot(hashed)
+		usize := uint64(len(hashed))
+		for idx := range hashed {
+			uidx := uint64(idx)
+			path := rfc6962TestAuditPath(idx, hashed)
+			if err := verifyRFC6962Inclusion(uidx, usize, hashed[idx], path, root); err != nil {
+				t.Fatalf("size=%d idx=%d: valid inclusion proof rejected: %v", size, idx, err)
+			}
+			// Tampered sibling must fail.
+			if len(path) > 0 {
+				bad := rfc6962TestClonePath(path)
+				bad[0][0] ^= 0xFF
+				if err := verifyRFC6962Inclusion(uidx, usize, hashed[idx], bad, root); err == nil {
+					t.Fatalf("size=%d idx=%d: tampered proof hash accepted", size, idx)
+				}
+			}
+			// Forged leaf must fail.
+			if err := verifyRFC6962Inclusion(uidx, usize, rfc6962LeafHash([]byte("forged")), path, root); err == nil {
+				t.Fatalf("size=%d idx=%d: forged leaf accepted", size, idx)
+			}
+			// Over-long proof (extra hash) must fail.
+			over := append(rfc6962TestClonePath(path), rfc6962LeafHash([]byte("extra")))
+			if err := verifyRFC6962Inclusion(uidx, usize, hashed[idx], over, root); err == nil {
+				t.Fatalf("size=%d idx=%d: over-long proof accepted", size, idx)
+			}
+			// Truncated proof (too short) must fail.
+			if len(path) > 0 {
+				short := rfc6962TestClonePath(path)[:len(path)-1]
+				if err := verifyRFC6962Inclusion(uidx, usize, hashed[idx], short, root); err == nil {
+					t.Fatalf("size=%d idx=%d: truncated proof accepted", size, idx)
+				}
+			}
+			// Wrong index against a valid path must fail.
+			if wrongIdx := (uidx + 1) % usize; wrongIdx != uidx {
+				if err := verifyRFC6962Inclusion(wrongIdx, usize, hashed[idx], path, root); err == nil {
+					t.Fatalf("size=%d idx=%d: proof accepted under wrong index %d", size, idx, wrongIdx)
+				}
+			}
+		}
+	}
+}
+
+// rfc6962TestMerkleRoot computes the RFC 6962 Merkle Tree Hash of pre-hashed
+// leaves, independently of the verifier under test.
+func rfc6962TestMerkleRoot(leaves [][]byte) []byte {
+	if len(leaves) == 1 {
+		return leaves[0]
+	}
+	k := rfc6962TestSplit(len(leaves))
+	return rfc6962NodeHash(rfc6962TestMerkleRoot(leaves[:k]), rfc6962TestMerkleRoot(leaves[k:]))
+}
+
+// rfc6962TestAuditPath builds the RFC 6962 inclusion path for leaf m, ordered
+// from the leaf level upward (the order the verifier consumes it).
+func rfc6962TestAuditPath(m int, leaves [][]byte) [][]byte {
+	if len(leaves) == 1 {
+		return nil
+	}
+	k := rfc6962TestSplit(len(leaves))
+	if m < k {
+		return append(rfc6962TestAuditPath(m, leaves[:k]), rfc6962TestMerkleRoot(leaves[k:]))
+	}
+	return append(rfc6962TestAuditPath(m-k, leaves[k:]), rfc6962TestMerkleRoot(leaves[:k]))
+}
+
+// rfc6962TestSplit returns the largest power of two strictly less than n.
+func rfc6962TestSplit(n int) int {
+	k := 1
+	for k<<1 < n {
+		k <<= 1
+	}
+	return k
+}
+
+func rfc6962TestClonePath(path [][]byte) [][]byte {
+	out := make([][]byte, len(path))
+	for i, h := range path {
+		out[i] = append([]byte(nil), h...)
+	}
+	return out
+}
+
+// TestVerifySignature_AcrossKeyTypes exercises the production signature path.
+// The public-good Rekor log signs SETs and checkpoints with ECDSA P-256, but
+// every other test in this package uses Ed25519, so the ecdsa branch of
+// verifySignature ships untested otherwise.
+func TestVerifySignature_AcrossKeyTypes(t *testing.T) {
+	t.Parallel()
+	msg := []byte("rekor set or checkpoint note bytes")
+	other := []byte("a different message")
+
+	edPub, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519 GenerateKey: %v", err)
+	}
+	if !verifySignature(edPub, msg, ed25519.Sign(edPriv, msg)) {
+		t.Fatal("ed25519: valid signature rejected")
+	}
+	if verifySignature(edPub, msg, ed25519.Sign(edPriv, other)) {
+		t.Fatal("ed25519: wrong-message signature accepted")
+	}
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa GenerateKey: %v", err)
+	}
+	digest := sha256.Sum256(msg)
+	ecSig, err := ecdsa.SignASN1(rand.Reader, ecKey, digest[:])
+	if err != nil {
+		t.Fatalf("ecdsa SignASN1: %v", err)
+	}
+	if !verifySignature(&ecKey.PublicKey, msg, ecSig) {
+		t.Fatal("ecdsa P-256: valid signature rejected")
+	}
+	otherDigest := sha256.Sum256(other)
+	otherSig, err := ecdsa.SignASN1(rand.Reader, ecKey, otherDigest[:])
+	if err != nil {
+		t.Fatalf("ecdsa SignASN1 (other): %v", err)
+	}
+	if verifySignature(&ecKey.PublicKey, msg, otherSig) {
+		t.Fatal("ecdsa P-256: wrong-message signature accepted")
+	}
+
+	// A different ECDSA key must not validate.
+	otherKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa GenerateKey (other): %v", err)
+	}
+	if verifySignature(&otherKey.PublicKey, msg, ecSig) {
+		t.Fatal("ecdsa P-256: signature accepted under wrong key")
+	}
 }

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -39,8 +39,8 @@ func Cmd() *cobra.Command {
 The local backend is a deterministic test backend. It exercises the same
 checkpoint and proof plumbing used by outside logs, but it is not an
 operator-independent witness. The Rekor backend records a transparency-log
-submission for later audit; independent Rekor verification requires trusted SET
-and inclusion-proof verification.`,
+submission for later audit; independent Rekor verification requires a pinned
+Rekor log public key.`,
 	}
 	cmd.AddCommand(receiptsCmd())
 	return cmd
@@ -56,9 +56,8 @@ an anchor backend, and emits an anchor bundle for verifier and audit tooling.
 
 Honest limit: anchoring does not prove real-time truth by whoever held the
 receipt signing key. The local backend is for deterministic tests and
-development. Rekor submission is recorded for later transparency-log audit, but
-this command does not claim independent Rekor verification without trusted SET
-and inclusion-proof checks.`,
+development. Rekor submission is recorded for later transparency-log audit;
+verify Rekor bundles with pipelock-verifier independent --rekor-log-key.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runReceipts(cmd.OutOrStdout(), args[0], opts)

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -135,7 +135,13 @@ func TestReceiptsCmdWritesRekorAnchorBundle(t *testing.T) {
 				"integratedTime": 1780000000,
 				"body":           encodedBody,
 				"verification": map[string]any{
-					"inclusionProof":       map[string]any{"rootHash": "fake-root"},
+					"inclusionProof": map[string]any{
+						"rootHash":   strings.Repeat("a", 64),
+						"logIndex":   3,
+						"treeSize":   4,
+						"hashes":     []string{},
+						"checkpoint": "checkpoint",
+					},
 					"signedEntryTimestamp": "fake-set",
 				},
 			},
@@ -165,7 +171,7 @@ func TestReceiptsCmdWritesRekorAnchorBundle(t *testing.T) {
 	if bundle.Backend != anchorpkg.RekorBackend || bundle.Proof.Backend != anchorpkg.RekorBackend || bundle.Proof.Rekor == nil {
 		t.Fatalf("unexpected Rekor bundle: %+v", bundle)
 	}
-	if bundle.Proof.LogID != "fake-rekor-log" || bundle.Proof.LogIndex != 3 || bundle.Proof.LogRootHash != "fake-root" || bundle.Proof.EntryHash == "" {
+	if bundle.Proof.LogID != "fake-rekor-log" || bundle.Proof.LogIndex != 3 || bundle.Proof.LogRootHash != strings.Repeat("a", 64) || bundle.Proof.EntryHash == "" {
 		t.Fatalf("unexpected Rekor log metadata: %+v", bundle.Proof)
 	}
 	if bundle.Proof.Rekor.UUID != "fake-uuid" ||
@@ -174,7 +180,9 @@ func TestReceiptsCmdWritesRekorAnchorBundle(t *testing.T) {
 		bundle.Proof.Rekor.PublicKey == "" ||
 		bundle.Proof.Rekor.Signature == "" ||
 		bundle.Proof.Rekor.IntegratedTime != 1780000000 ||
-		bundle.Proof.Rekor.SignedEntryTimestamp != "fake-set" {
+		bundle.Proof.Rekor.SignedEntryTimestamp != "fake-set" ||
+		bundle.Proof.Rekor.InclusionProof == nil ||
+		bundle.Proof.Rekor.InclusionProof.TreeSize != 4 {
 		t.Fatalf("unexpected Rekor proof metadata: %+v", bundle.Proof.Rekor)
 	}
 	if !strings.Contains(out.String(), "Backend:       rekor") {


### PR DESCRIPTION
## Summary

- persist Rekor inclusion proof material in anchor bundles
- verify Rekor bundles offline against pinned Rekor log public keys
- add `--rekor-log-key` to `pipelock-verifier independent`
- update Rekor anchor limits to distinguish recorded inclusion from later log consistency

## Why

Rekor anchor submission already recorded the transparency-log response but still failed closed for independent verification. This adds the missing verifier side: the recorded entry must have a valid signed entry timestamp, a signed checkpoint matching the proof root, and a valid RFC6962 inclusion path before the bundle verifies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for independent offline verification of Rekor records using a pinned set of Rekor log public keys, validating the recorded timestamp, checkpoint signature, and inclusion proof/root hash.
  * Added a new repeatable command-line option to provide one or more trusted Rekor log public keys.
* **Bug Fixes**
  * Improved fail-closed behavior: verification now errors when no trusted Rekor log key is configured or when verification artifacts don’t match the expected trusted key.
* **Documentation**
  * Updated command help text to clarify pinned trusted key requirements and what claims are (and aren’t) established.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->