### PR TITLE
fix: harden containment nft drift proof

### DIFF
--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1420,10 +1420,15 @@ func liveNFTContainmentMatches(out, chainName string, operatorUID, proxyUID, age
 	return chainHasSkuidAcceptForUID(out, chainName, operatorUID) &&
 		chainHasSkuidAcceptForUID(out, chainName, proxyUID) &&
 		chainHasAgentCatchAllDrop(out, chainName, agentUID) &&
-		chainHasAgentProxyLoopbackAllow(out, chainName, agentUID, proxyPort) &&
-		chainHasAgentDNSDrop(out, chainName, agentUID, "udp") &&
-		chainHasAgentDNSDrop(out, chainName, agentUID, "tcp") &&
-		!chainHasBroadLoopbackAccept(out, chainName, agentUID)
+		chainHasAgentProxyLoopbackAllowBeforeDrop(out, chainName, agentUID, proxyPort) &&
+		chainHasAgentDNSDropBeforeCatchAll(out, chainName, agentUID, "udp") &&
+		chainHasAgentDNSDropBeforeCatchAll(out, chainName, agentUID, "tcp") &&
+		!chainHasUnexpectedAcceptBeforeAgentDrop(out, chainName, containmentUIDs{
+			operatorUID:   operatorUID,
+			operatorKnown: true,
+			proxyUID:      proxyUID,
+			agentUID:      agentUID,
+		}, proxyPort)
 }
 
 func nftRulesIncludeLine(path string) string {

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1423,7 +1423,7 @@ func liveNFTContainmentMatches(out, chainName string, operatorUID, proxyUID, age
 		chainHasAgentProxyLoopbackAllowBeforeDrop(out, chainName, agentUID, proxyPort) &&
 		chainHasAgentDNSDropBeforeCatchAll(out, chainName, agentUID, "udp") &&
 		chainHasAgentDNSDropBeforeCatchAll(out, chainName, agentUID, "tcp") &&
-		!chainHasUnexpectedAcceptBeforeAgentDrop(out, chainName, containmentUIDs{
+		!chainHasUnsafeVerdictBeforeAgentDrop(out, chainName, containmentUIDs{
 			operatorUID:   operatorUID,
 			operatorKnown: true,
 			proxyUID:      proxyUID,

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -1400,6 +1400,83 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasUnexpectedAcceptBeforeDrop
 	}
 }
 
+func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasPreDropUnsafeVerdict(t *testing.T) {
+	tests := []struct {
+		name string
+		rule string
+	}{
+		{
+			name: "return",
+			rule: "meta skuid 987 return",
+		},
+		{
+			name: "jump",
+			rule: "meta skuid 987 jump allow_all",
+		},
+		{
+			name: "goto",
+			rule: "meta skuid 987 goto allow_all",
+		},
+		{
+			name: "queue",
+			rule: "meta skuid 987 queue",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, runner, _ := newFakeEnv(t)
+			operatorUID, proxyUID, agentUID := 1000, 988, 987
+			body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+			if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+				t.Fatalf("mkdir rules parent: %v", err)
+			}
+			if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+				t.Fatalf("write rules: %v", err)
+			}
+			writeNFTPersistUnitFixture(t, env)
+			failOpen := `table inet pipelock_containment {
+		chain allow_all {
+			accept
+		}
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			` + tc.rule + `
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+`
+			runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), failOpen, 0, nil)
+
+			s := stepInstallNFTRules()
+			applied, err := s.apply(context.Background(), env)
+			if err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			if !applied {
+				t.Fatalf("expected pre-drop %s to trigger rules reload", tc.name)
+			}
+
+			var sawDelete, sawLoad bool
+			for _, c := range runner.calls {
+				if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+					sawDelete = true
+				}
+				if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
+					sawLoad = true
+				}
+			}
+			if !sawDelete || !sawLoad {
+				t.Fatalf("expected delete+reload for pre-drop %s, got %v", tc.name, runner.calls)
+			}
+		})
+	}
+}
+
 func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasStaleAgentUID(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	operatorUID, proxyUID, agentUID := 1000, 988, 987

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -1352,6 +1352,54 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
 	}
 }
 
+func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasUnexpectedAcceptBeforeDrop(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	writeNFTPersistUnitFixture(t, env)
+	failOpen := `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			ip daddr 10.0.0.10 tcp dport 443 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+`
+	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), failOpen, 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected fail-open live accept to trigger rules reload")
+	}
+
+	var sawDelete, sawLoad bool
+	for _, c := range runner.calls {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+			sawDelete = true
+		}
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
+			sawLoad = true
+		}
+	}
+	if !sawDelete || !sawLoad {
+		t.Fatalf("expected delete+reload for unexpected accept, got %v", runner.calls)
+	}
+}
+
 func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasStaleAgentUID(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	operatorUID, proxyUID, agentUID := 1000, 988, 987

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -792,13 +792,13 @@ func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 		return statusFail, fmt.Sprintf("chain present but current agent uid %d catch-all skuid-drop rule missing", current.agentUID)
 	}
 	if !chainHasAgentProxyLoopbackAllowBeforeDrop(out, env.nftChain, current.agentUID, env.port) {
-		return statusFail, fmt.Sprintf("chain present but current agent uid %d loopback allow is not limited to 127.0.0.1:%d", current.agentUID, env.port)
+		return statusFail, fmt.Sprintf("chain present but current agent uid %d loopback allow for 127.0.0.1:%d is missing or appears after the agent catch-all drop", current.agentUID, env.port)
 	}
 	if !chainHasAgentDNSDropBeforeCatchAll(out, env.nftChain, current.agentUID, "udp") {
-		return statusFail, fmt.Sprintf("chain present but current agent uid %d udp/53 DNS drop rule missing", current.agentUID)
+		return statusFail, fmt.Sprintf("chain present but current agent uid %d udp/53 DNS drop rule missing or appears after the agent catch-all drop", current.agentUID)
 	}
 	if !chainHasAgentDNSDropBeforeCatchAll(out, env.nftChain, current.agentUID, "tcp") {
-		return statusFail, fmt.Sprintf("chain present but current agent uid %d tcp/53 DNS drop rule missing", current.agentUID)
+		return statusFail, fmt.Sprintf("chain present but current agent uid %d tcp/53 DNS drop rule missing or appears after the agent catch-all drop", current.agentUID)
 	}
 	if chainHasUnexpectedAcceptBeforeAgentDrop(out, env.nftChain, current, env.port) {
 		return statusFail, "chain contains unexpected accept before agent drop"

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -800,8 +800,8 @@ func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 	if !chainHasAgentDNSDropBeforeCatchAll(out, env.nftChain, current.agentUID, "tcp") {
 		return statusFail, fmt.Sprintf("chain present but current agent uid %d tcp/53 DNS drop rule missing or appears after the agent catch-all drop", current.agentUID)
 	}
-	if chainHasUnexpectedAcceptBeforeAgentDrop(out, env.nftChain, current, env.port) {
-		return statusFail, "chain contains unexpected accept before agent drop"
+	if chainHasUnsafeVerdictBeforeAgentDrop(out, env.nftChain, current, env.port) {
+		return statusFail, "chain contains unexpected verdict before agent drop"
 	}
 	if env.nftPersistUnitPath != "" && env.nftRulesPath != "" {
 		if err := verifyNFTPersistence(env); err != nil {
@@ -982,9 +982,13 @@ func chainHasAgentDNSDropBeforeCatchAll(out, chainName string, agentUID int, pro
 	})
 }
 
-func chainHasUnexpectedAcceptBeforeAgentDrop(out, chainName string, uids containmentUIDs, proxyPort int) bool {
+func chainHasUnsafeVerdictBeforeAgentDrop(out, chainName string, uids containmentUIDs, proxyPort int) bool {
 	return chainHasLineBeforeAgentDrop(out, chainName, uids.agentUID, func(line string) bool {
-		if !lineHasToken(line, "accept") {
+		// Before the agent catch-all drop, only the managed operator/proxy
+		// accepts, the agent's proxy loopback allow, and DNS drops are safe.
+		// Any other terminal/control-flow verdict can bypass containment under
+		// the base-chain "policy accept" default.
+		if !lineHasAnyToken(line, "accept", "return", "jump", "goto", "queue") {
 			return false
 		}
 		if uids.operatorKnown && lineHasTerminalSkuidVerdict(line, uids.operatorUID, "accept") {
@@ -994,6 +998,10 @@ func chainHasUnexpectedAcceptBeforeAgentDrop(out, chainName string, uids contain
 			return false
 		}
 		if lineHasAgentProxyLoopbackAllow(line, uids.agentUID, proxyPort) {
+			return false
+		}
+		if lineHasSkuidProtocolDPortVerdict(line, uids.agentUID, "udp", 53, "drop") ||
+			lineHasSkuidProtocolDPortVerdict(line, uids.agentUID, "tcp", 53, "drop") {
 			return false
 		}
 		if uid, ok := terminalSkuidUIDVerdict(line, "accept"); ok && uid != uids.agentUID {
@@ -1082,6 +1090,8 @@ func indexTokenAfter(fields []string, want string, start int) int {
 
 func fieldsAreNFTBookkeeping(fields []string) bool {
 	inPrefix := false
+	seenCounter := false
+	expectCount := false
 	for _, field := range fields {
 		if inPrefix {
 			if strings.HasSuffix(field, `"`) {
@@ -1089,16 +1099,33 @@ func fieldsAreNFTBookkeeping(fields []string) bool {
 			}
 			continue
 		}
+		if expectCount {
+			// `nft list` renders an inline counter as
+			// "counter packets <n> bytes <n>"; consume the numeric
+			// argument that follows the packets/bytes keyword.
+			expectCount = false
+			if _, err := strconv.Atoi(field); err == nil {
+				continue
+			}
+			return false
+		}
 		switch field {
-		case "counter", "log":
+		case "counter":
+			seenCounter = true
+		case "log":
 			continue
+		case "packets", "bytes":
+			if !seenCounter {
+				return false
+			}
+			expectCount = true
 		case "prefix":
 			inPrefix = true
 		default:
 			return false
 		}
 	}
-	return !inPrefix
+	return !inPrefix && !expectCount
 }
 
 func lineHasIPDAddr(line, addr string) bool {
@@ -1126,6 +1153,17 @@ func lineHasToken(line, want string) bool {
 	for _, field := range strings.Fields(line) {
 		if field == want {
 			return true
+		}
+	}
+	return false
+}
+
+func lineHasAnyToken(line string, wants ...string) bool {
+	for _, field := range strings.Fields(line) {
+		for _, want := range wants {
+			if field == want {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -791,17 +791,17 @@ func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 	if !chainHasAgentCatchAllDrop(out, env.nftChain, current.agentUID) {
 		return statusFail, fmt.Sprintf("chain present but current agent uid %d catch-all skuid-drop rule missing", current.agentUID)
 	}
-	if !chainHasAgentProxyLoopbackAllow(out, env.nftChain, current.agentUID, env.port) {
+	if !chainHasAgentProxyLoopbackAllowBeforeDrop(out, env.nftChain, current.agentUID, env.port) {
 		return statusFail, fmt.Sprintf("chain present but current agent uid %d loopback allow is not limited to 127.0.0.1:%d", current.agentUID, env.port)
 	}
-	if !chainHasAgentDNSDrop(out, env.nftChain, current.agentUID, "udp") {
+	if !chainHasAgentDNSDropBeforeCatchAll(out, env.nftChain, current.agentUID, "udp") {
 		return statusFail, fmt.Sprintf("chain present but current agent uid %d udp/53 DNS drop rule missing", current.agentUID)
 	}
-	if !chainHasAgentDNSDrop(out, env.nftChain, current.agentUID, "tcp") {
+	if !chainHasAgentDNSDropBeforeCatchAll(out, env.nftChain, current.agentUID, "tcp") {
 		return statusFail, fmt.Sprintf("chain present but current agent uid %d tcp/53 DNS drop rule missing", current.agentUID)
 	}
-	if chainHasBroadLoopbackAccept(out, env.nftChain, current.agentUID) {
-		return statusFail, "chain contains broad loopback accept before agent drop"
+	if chainHasUnexpectedAcceptBeforeAgentDrop(out, env.nftChain, current, env.port) {
+		return statusFail, "chain contains unexpected accept before agent drop"
 	}
 	if env.nftPersistUnitPath != "" && env.nftRulesPath != "" {
 		if err := verifyNFTPersistence(env); err != nil {
@@ -962,29 +962,63 @@ func chainHasSkuidAcceptForUID(out, chainName string, uid int) bool {
 	})
 }
 
-func chainHasAgentProxyLoopbackAllow(out, chainName string, agentUID, port int) bool {
-	return chainHasLine(out, chainName, func(line string) bool {
-		return lineHasSkuid(line, agentUID) &&
-			lineHasIPDAddr(line, "127.0.0.1") &&
-			lineHasToken(line, "tcp") &&
-			lineHasDPort(line, port) &&
-			lineHasToken(line, "accept")
+func chainHasAgentProxyLoopbackAllowBeforeDrop(out, chainName string, agentUID, port int) bool {
+	return chainHasLineBeforeAgentDrop(out, chainName, agentUID, func(line string) bool {
+		return lineHasAgentProxyLoopbackAllow(line, agentUID, port)
 	})
 }
 
-func chainHasAgentDNSDrop(out, chainName string, agentUID int, protocol string) bool {
-	return chainHasLine(out, chainName, func(line string) bool {
+func lineHasAgentProxyLoopbackAllow(line string, agentUID, port int) bool {
+	return lineHasSkuid(line, agentUID) &&
+		lineHasIPDAddr(line, "127.0.0.1") &&
+		lineHasToken(line, "tcp") &&
+		lineHasDPort(line, port) &&
+		lineHasToken(line, "accept")
+}
+
+func chainHasAgentDNSDropBeforeCatchAll(out, chainName string, agentUID int, protocol string) bool {
+	return chainHasLineBeforeAgentDrop(out, chainName, agentUID, func(line string) bool {
 		return lineHasSkuidProtocolDPortVerdict(line, agentUID, protocol, 53, "drop")
 	})
 }
 
-func chainHasBroadLoopbackAccept(out, chainName string, agentUID int) bool {
-	return chainHasLineBeforeAgentDrop(out, chainName, agentUID, func(line string) bool {
-		return strings.Contains(line, "accept") &&
-			(strings.Contains(line, `meta oif "lo"`) ||
-				strings.Contains(line, "ip daddr 127.0.0.0/8") ||
-				(strings.Contains(line, "ip daddr 127.0.0.1") && !strings.Contains(line, " dport ")))
+func chainHasUnexpectedAcceptBeforeAgentDrop(out, chainName string, uids containmentUIDs, proxyPort int) bool {
+	return chainHasLineBeforeAgentDrop(out, chainName, uids.agentUID, func(line string) bool {
+		if !lineHasToken(line, "accept") {
+			return false
+		}
+		if uids.operatorKnown && lineHasTerminalSkuidVerdict(line, uids.operatorUID, "accept") {
+			return false
+		}
+		if lineHasTerminalSkuidVerdict(line, uids.proxyUID, "accept") {
+			return false
+		}
+		if lineHasAgentProxyLoopbackAllow(line, uids.agentUID, proxyPort) {
+			return false
+		}
+		if uid, ok := terminalSkuidUIDVerdict(line, "accept"); ok && uid != uids.agentUID {
+			return false
+		}
+		return true
 	})
+}
+
+func terminalSkuidUIDVerdict(line, verdict string) (int, bool) {
+	fields := strings.Fields(line)
+	for i := 0; i+1 < len(fields); i++ {
+		if fields[i] != "skuid" {
+			continue
+		}
+		uid, err := strconv.Atoi(fields[i+1])
+		if err != nil {
+			continue
+		}
+		verdictAt := indexTokenAfter(fields, verdict, i+2)
+		if verdictAt != -1 && fieldsAreNFTBookkeeping(fields[i+2:verdictAt]) {
+			return uid, true
+		}
+	}
+	return 0, false
 }
 
 func lineHasSkuid(line string, uid int) bool {

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -59,6 +59,25 @@ const goodNFTContainmentOutput = `table inet pipelock_containment {
 }
 `
 
+// goodNFTContainmentOutputRealListing mirrors what `nft list table inet` actually
+// emits for the canonical ruleset: inline counters are expanded to
+// "counter packets N bytes N" and the agent catch-all carries counter+log+prefix
+// bookkeeping (renderNFTRules writes it). The simplified fixtures above never
+// exercise this shape; the parser must accept the real listing form or verify
+// fails on every correctly-installed system.
+const goodNFTContainmentOutputRealListing = `table inet pipelock_containment {
+	chain output_filter {
+		type filter hook output priority filter; policy accept;
+		meta skuid 1000 accept
+		meta skuid 988 accept
+		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+		meta skuid 987 udp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked" drop
+		meta skuid 987 tcp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked" drop
+		meta skuid 987 counter packets 12 bytes 840 log prefix "pipelock-contain class=not_routing_through_pipelock" drop
+	}
+}
+`
+
 // fakeRunResult is a canned subprocess response keyed by the leading
 // argv element (the command name). Tests pre-populate the map with
 // the expected calls; unexpected calls return an error.
@@ -354,6 +373,12 @@ func TestProbeNFTContainment(t *testing.T) {
 		wantDetail string
 	}{
 		{
+			name:       "happy path with real nft list expanded counters",
+			stdout:     goodNFTContainmentOutputRealListing,
+			code:       0,
+			wantStatus: statusPass,
+		},
+		{
 			name:       "happy path",
 			stdout:     goodNFTContainmentOutput,
 			code:       0,
@@ -436,7 +461,7 @@ func TestProbeNFTContainment(t *testing.T) {
 			`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "unexpected accept",
+			wantDetail: "unexpected verdict",
 		},
 		{
 			name: "bare loopback host accept",
@@ -454,7 +479,7 @@ func TestProbeNFTContainment(t *testing.T) {
 			`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "unexpected accept",
+			wantDetail: "unexpected verdict",
 		},
 		{
 			name: "constrained agent drop does not hide broad loopback accept",
@@ -473,7 +498,7 @@ func TestProbeNFTContainment(t *testing.T) {
 			`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "unexpected accept",
+			wantDetail: "unexpected verdict",
 		},
 		{
 			name: "missing proxy port allow",
@@ -541,7 +566,7 @@ func TestProbeNFTContainment(t *testing.T) {
 			`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "unexpected accept",
+			wantDetail: "unexpected verdict",
 		},
 		{
 			name: "agent alternate destination accept before drop is fail open",
@@ -559,7 +584,7 @@ func TestProbeNFTContainment(t *testing.T) {
 			`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "unexpected accept",
+			wantDetail: "unexpected verdict",
 		},
 		{
 			name: "unscoped external accept before drop is fail open",
@@ -577,7 +602,7 @@ func TestProbeNFTContainment(t *testing.T) {
 	`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "unexpected accept",
+			wantDetail: "unexpected verdict",
 		},
 		{
 			name: "agent skuid set accept before drop is fail open",
@@ -595,7 +620,85 @@ func TestProbeNFTContainment(t *testing.T) {
 	`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "unexpected accept",
+			wantDetail: "unexpected verdict",
+		},
+		{
+			name: "pre-drop return is fail open under accept policy",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 return
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "unexpected verdict",
+		},
+		{
+			name: "pre-drop jump is fail open",
+			stdout: `table inet pipelock_containment {
+		chain allow_all {
+			accept
+		}
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 jump allow_all
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "unexpected verdict",
+		},
+		{
+			name: "pre-drop goto is fail open",
+			stdout: `table inet pipelock_containment {
+		chain allow_all {
+			accept
+		}
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 goto allow_all
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "unexpected verdict",
+		},
+		{
+			name: "pre-drop queue is fail open",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 queue
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "unexpected verdict",
 		},
 		{
 			name: "loopback address prefix is not proxy address",

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -71,9 +71,9 @@ const goodNFTContainmentOutputRealListing = `table inet pipelock_containment {
 		meta skuid 1000 accept
 		meta skuid 988 accept
 		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
-		meta skuid 987 udp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked" drop
-		meta skuid 987 tcp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked" drop
-		meta skuid 987 counter packets 12 bytes 840 log prefix "pipelock-contain class=not_routing_through_pipelock" drop
+		meta skuid 987 udp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked " drop
+		meta skuid 987 tcp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked " drop
+		meta skuid 987 counter packets 12 bytes 840 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
 	}
 }
 `
@@ -887,6 +887,59 @@ func TestProbeNFTContainment(t *testing.T) {
 			}
 			if !strings.Contains(gotDetail, tc.wantDetail) {
 				t.Fatalf("detail: got %q, want substring %q", gotDetail, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestFieldsAreNFTBookkeeping(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields []string
+		want   bool
+	}{
+		{
+			name:   "empty",
+			fields: nil,
+			want:   true,
+		},
+		{
+			name:   "inline counter log prefix",
+			fields: strings.Fields(`counter log prefix "pipelock-contain class=direct_dns_blocked "`),
+			want:   true,
+		},
+		{
+			name:   "expanded counter log prefix",
+			fields: strings.Fields(`counter packets 12 bytes 840 log prefix "pipelock-contain class=not_routing_through_pipelock "`),
+			want:   true,
+		},
+		{
+			name:   "packets without counter rejected",
+			fields: strings.Fields(`packets 12 bytes 840`),
+			want:   false,
+		},
+		{
+			name:   "non numeric packets rejected",
+			fields: strings.Fields(`counter packets nope bytes 840`),
+			want:   false,
+		},
+		{
+			name:   "unterminated prefix rejected",
+			fields: strings.Fields(`counter log prefix "unterminated`),
+			want:   false,
+		},
+		{
+			name:   "unexpected token rejected",
+			fields: strings.Fields(`counter meta`),
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fieldsAreNFTBookkeeping(tc.fields); got != tc.want {
+				t.Fatalf("fieldsAreNFTBookkeeping(%q) = %v, want %v", tc.fields, got, tc.want)
 			}
 		})
 	}

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -433,10 +433,10 @@ func TestProbeNFTContainment(t *testing.T) {
 			meta skuid 987 drop
 		}
 	}
-	`,
+			`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "broad loopback accept",
+			wantDetail: "unexpected accept",
 		},
 		{
 			name: "bare loopback host accept",
@@ -451,10 +451,10 @@ func TestProbeNFTContainment(t *testing.T) {
 			meta skuid 987 drop
 		}
 	}
-	`,
+			`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "broad loopback accept",
+			wantDetail: "unexpected accept",
 		},
 		{
 			name: "constrained agent drop does not hide broad loopback accept",
@@ -470,10 +470,10 @@ func TestProbeNFTContainment(t *testing.T) {
 			meta skuid 987 drop
 		}
 	}
-	`,
+			`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "broad loopback accept",
+			wantDetail: "unexpected accept",
 		},
 		{
 			name: "missing proxy port allow",
@@ -507,6 +507,95 @@ func TestProbeNFTContainment(t *testing.T) {
 			code:       0,
 			wantStatus: statusFail,
 			wantDetail: "loopback allow",
+		},
+		{
+			name: "proxy loopback allow after agent drop is unreachable",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "loopback allow",
+		},
+		{
+			name: "agent broad accept before drop is fail open",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+			`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "unexpected accept",
+		},
+		{
+			name: "agent alternate destination accept before drop is fail open",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 ip daddr 10.0.0.10 tcp dport 443 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+			`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "unexpected accept",
+		},
+		{
+			name: "unscoped external accept before drop is fail open",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			ip daddr 10.0.0.10 tcp dport 443 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "unexpected accept",
+		},
+		{
+			name: "agent skuid set accept before drop is fail open",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid { 987, 1001 } ip daddr 10.0.0.10 tcp dport 443 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "unexpected accept",
 		},
 		{
 			name: "loopback address prefix is not proxy address",
@@ -550,6 +639,23 @@ func TestProbeNFTContainment(t *testing.T) {
 			meta skuid 988 accept
 			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
 			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "DNS drop rule missing",
+		},
+		{
+			name: "dns drops after catch all drop are unreachable",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 drop
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
 		}
 	}
 	`,


### PR DESCRIPTION
## Summary
- make containment nft verification order-aware for agent proxy and DNS rules before the catch-all drop
- reject unexpected accept rules before the agent drop so drifted live nft tables cannot silently fail open
- reload drifted live nft tables when install detects an unsafe accept before the drop


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened nftables containment validation to require correct ordering of agent proxy loopback allow and DNS (UDP/TCP 53) drop rules ahead of the agent catch-all drop.
  * Improved drift detection by flagging unexpected unsafe verdicts appearing before agent drop (including fail-open accept behavior).
  * Enhanced nftables output parsing to better recognize counter/log/prefix bookkeeping in validation.
  * Added live-repair during nftables install when unexpected accept verdicts appear before drop logic.
* **Tests**
  * Expanded verification coverage with real-style nft listings, refined expected failure classifications, and new fail-open/reachability scenarios.
  * Added unit tests for nftables bookkeeping token parsing/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->