### PR TITLE
Fail closed on unverifiable git diffs and harden rules config loading

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -797,12 +797,12 @@ response_scanning:
   ask_timeout_seconds: 30       # HITL approval timeout
   include_defaults: true
   exempt_domains:               # skip injection scanning for these hosts
-    - "api.openai.com"
-    - "*.anthropic.com"
+    - "api.vendor.example"
+    - "*.vendor.example"
   size_exempt_domains:          # trusted large-download hosts; scan cap only
     - "downloads.example.com"
   mcp_servers:                  # MCP response trust classes; default is untrusted/block
-    - server: "codex"
+    - server: "analysis-server"
       trust: "reasoning"        # reasoning => warn; untrusted => block
   patterns:
     - name: "Custom Injection"
@@ -816,7 +816,7 @@ response_scanning:
 | `ask_timeout_seconds` | `30` | Timeout for human-in-the-loop approval |
 | `include_defaults` | `true` | Merge with 29 built-in patterns |
 | `exempt_domains` | `[]` | Hosts to skip injection scanning for (DLP still applies on outbound). Supports `*.example.com` wildcards (also matches the apex `example.com`). |
-| `size_exempt_domains` | `[]` | Trusted hosts whose oversized forward-proxy or TLS-intercepted responses may stream through instead of failing the scan ceiling. Request-side scanning and budget accounting still run. |
+| `size_exempt_domains` | `[]` | Trusted hosts whose oversized forward-proxy, TLS-intercepted, or reverse-proxy responses may stream through instead of failing the scan ceiling. Request-side scanning and budget accounting still run. |
 | `mcp_servers` | `[]` | Per-MCP-server response trust classes keyed by `pipelock mcp proxy --server-name`. Omitted, missing, malformed, or non-matching servers are treated as `untrusted` and block response-injection findings. `reasoning` is an explicit opt-in that logs/warns but forwards the response. |
 | `patterns` | 29 built-in | Injection and state/control poisoning patterns |
 
@@ -828,14 +828,16 @@ response_scanning:
 - **warn:** log the match, return content unchanged
 - **ask:** pause and prompt the operator for approval (requires TTY)
 
-**Exempt domains:** LLM provider APIs (OpenAI, Anthropic, etc.) return instruction-like text as part of normal operation, which can trigger false positives. Use `exempt_domains` to skip injection scanning for trusted providers. DLP scanning on the outbound request still runs — only the response injection scan is skipped. Applies to fetch proxy, forward proxy, CONNECT (TLS intercept), WebSocket, and reverse proxy. Does not affect MCP response scanning; MCP uses `response_scanning.mcp_servers` so a reasoning-model MCP server can warn while web-relay MCP servers keep blocking.
+**MCP required control:** `response_scanning.enabled: false` is currently ignored in `pipelock mcp proxy` and `pipelock mcp scan` modes because MCP response scanning is the required injection-control path. Pipelock runs with default response scanning and prints a warning naming the overridden field. This compatibility fallback will become a startup/reload error in a future release; remove the disable to silence the warning.
+
+**Exempt domains:** Trusted response APIs can return instruction-like text as part of normal operation, which can trigger false positives. Use `exempt_domains` to skip injection scanning for trusted providers. DLP scanning on the outbound request still runs — only the response injection scan is skipped. Applies to fetch proxy, forward proxy, CONNECT (TLS intercept), WebSocket, and reverse proxy. Does not affect MCP response scanning; MCP uses `response_scanning.mcp_servers` so a reasoning-model MCP server can warn while web-relay MCP servers keep blocking.
 
 **MCP response trust classes:** MCP response scanning defaults to `untrusted`, which blocks response-injection findings even if the generic `response_scanning.action` is `warn`. This protects web-relay servers such as fetch/search/scraping tools. To allow a reasoning-model MCP server to answer security-analysis questions that quote canonical jailbreak strings, opt in by server name:
 
 ```yaml
 response_scanning:
   mcp_servers:
-    - server: "codex"
+    - server: "analysis-server"
       trust: "reasoning"
 ```
 
@@ -843,13 +845,13 @@ response_scanning:
 
 Response trust does not make a server trusted for taint propagation. If a reasoning server is also an operator-trusted source whose clean responses should not contaminate the session, add the same `--server-name` value under `taint.trusted_mcp_servers`. Prompt-injection findings still raise hostile taint.
 
-Launch MCP proxies with a stable server identity so the entry can match: use `pipelock mcp proxy --server-name codex ...` for per-server wrappers, or `pipelock run --mcp-listen ... --mcp-upstream ... --mcp-server-name codex` for the long-lived MCP listener.
+Launch MCP proxies with a stable server identity so the entry can match: use `pipelock mcp proxy --server-name analysis-server ...` for per-server wrappers, or `pipelock run --mcp-listen ... --mcp-upstream ... --mcp-server-name analysis-server` for the long-lived MCP listener.
 
 For forward-proxy and TLS-intercepted traffic, an exempt host's response streams through untouched when `response_scanning.enabled` is true: no buffering, response scan-cap block, media metadata strip, Browser Shield rewrite, or injection scan is applied to that trusted response. Request-side DLP, redaction, SSRF, authority checks, and budget accounting still run. If a host needs full byte-preserving passthrough without MITM, prefer `tls_interception.passthrough_domains`.
 
 Non-exempt responses that must be buffered for response scanning, Browser Shield, or media policy block fail-closed if they exceed the configured scan cap (`fetch_proxy.max_response_mb` or `tls_interception.max_response_bytes`). The block uses reason code `response_size` and names the host, observed size, scan ceiling, and the knob to raise. Data-budget truncation is separate and remains an explicit budget policy.
 
-Use `size_exempt_domains` for trusted large-download hosts when the default fail-closed scan ceiling blocks legitimate artifacts such as package headers, signed binaries, or model weights. This exemption is narrower than `exempt_domains`: it only takes effect after the response exceeds the scan cap. Smaller responses from the same host still take the normal buffered scanning path. The exemption applies only to the forward proxy and TLS interception; reverse-proxy / MCP-HTTP responses and compressed (`Content-Encoding`) responses still fail closed when they cannot be fully scanned, regardless of this list.
+Use `size_exempt_domains` for trusted large-download hosts when the default fail-closed scan ceiling blocks legitimate artifacts such as package headers, signed binaries, or model weights. This exemption is narrower than `exempt_domains`: it only takes effect after the response exceeds the scan cap. Smaller responses from the same host still take the normal buffered scanning path. The exemption applies to forward proxy, TLS interception, and reverse proxy responses. MCP-HTTP responses and compressed (`Content-Encoding`) responses still fail closed when they cannot be fully scanned, regardless of this list.
 
 ### Generic SSE streaming (`response_scanning.sse_streaming`)
 
@@ -1459,7 +1461,7 @@ Git-aware scanning for pre-push secret detection and branch restrictions.
 git_protection:
   enabled: false
   allowed_branches: ["feature/*", "fix/*", "main"]
-  allowed_push_repos: ["github.com/acme/private-*", "gitlab.com/*"]
+  allowed_push_repos: ["git.vendor.example/team/private-*", "forge.vendor.example/*"]
   pre_push_scan: true
 ```
 
@@ -1467,8 +1469,12 @@ git_protection:
 |-------|---------|-------------|
 | `enabled` | `false` | Enable git protection |
 | `allowed_branches` | `["feature/*", "fix/*", "main", "master"]` | Reserved, not yet enforced (push gating today uses `allowed_push_repos`, `blocked_commands`, `pre_push_scan`) |
-| `allowed_push_repos` | `[]` | Optional proxy-enforced allowlist for visible Git smart-HTTP pushes (`git-receive-pack`). Supported patterns include exact repos (`host/owner/repo`), owner globs (`github.com/acme/*`), and host-wide allowlists (`gitlab.com/*`). Bare `owner/repo` entries are rejected. Matching is case-insensitive. When `git_protection.enabled` is true and the allowlist is empty, visible pushes are blocked (fail-closed). Non-intercepted HTTPS CONNECT exposes only the host; enable TLS interception for repo-path enforcement. SSH pushes are opaque to the proxy and are not gated. |
+| `allowed_push_repos` | `[]` | Optional proxy-enforced allowlist for visible Git smart-HTTP pushes (`git-receive-pack`). Supported patterns include exact repos (`host/owner/repo`), owner globs (`git.vendor.example/team/*`), and host-wide allowlists (`forge.vendor.example/*`). Bare `owner/repo` entries are rejected. Matching is case-insensitive. When `git_protection.enabled` is true and the allowlist is empty, visible pushes are blocked (fail-closed). Non-intercepted HTTPS CONNECT exposes only the host; enable TLS interception for repo-path enforcement. SSH pushes are opaque to the proxy and are not gated. |
 | `pre_push_scan` | `true` | Scan diffs before push |
+
+`pipelock git scan-diff` is a fail-closed gate. Empty input and valid metadata-only diffs (mode-only changes, rename-only changes, and `--no-prefix` diffs with no added secret content) pass. Non-empty input that is not recognizable unified diff output exits non-zero as unverifiable. Added `+` lines that cannot be attributed to a valid file header and hunk are still scanned as orphan added-content candidates, so partial or malformed diffs cannot hide a secret before or between valid file sections. Unsupported binary patches fail closed because the line scanner cannot inspect their payload. Generated pre-push hooks invoke `git diff --no-ext-diff --no-textconv` before `pipelock git scan-diff` so repository-local diff drivers and textconv filters cannot substitute untrusted patch text.
+
+The gate scans added text lines, not unchanged context lines. That avoids re-blocking every push because of a pre-existing secret already present in the repository. Future hardening should scan changed blob contents by object ID and add per-hunk window scanning for split-token cases.
 
 ## Logging
 

--- a/internal/cli/git/git.go
+++ b/internal/cli/git/git.go
@@ -89,13 +89,12 @@ Examples:
 				return err
 			}
 
-			const maxDiffSize = 100 * 1024 * 1024 // 100 MB
-			diffData, err := io.ReadAll(io.LimitReader(os.Stdin, maxDiffSize+1))
+			diffData, err := io.ReadAll(io.LimitReader(os.Stdin, gitprotect.MaxDiffBytes+1))
 			if err != nil {
 				return fmt.Errorf("reading diff from stdin: %w", err)
 			}
-			if len(diffData) > maxDiffSize {
-				return fmt.Errorf("diff exceeds maximum size of %d bytes", maxDiffSize)
+			if len(diffData) > gitprotect.MaxDiffBytes {
+				return fmt.Errorf("diff exceeds maximum size of %d bytes", gitprotect.MaxDiffBytes)
 			}
 
 			if len(diffData) == 0 {
@@ -113,7 +112,8 @@ Examples:
 			patterns := gitprotect.CompileDLPPatterns(cfg.DLP.Patterns)
 			result, scanErr := gitprotect.ScanDiff(string(diffData), patterns)
 			if scanErr != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %v\n", scanErr)
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "ERROR: %v\n", scanErr)
+				return scanErr
 			}
 
 			// ScanDiff handles inline pipelock:ignore from the diff content

--- a/internal/cli/git/git.go
+++ b/internal/cli/git/git.go
@@ -94,7 +94,7 @@ Examples:
 				return fmt.Errorf("reading diff from stdin: %w", err)
 			}
 			if len(diffData) > gitprotect.MaxDiffBytes {
-				return fmt.Errorf("diff exceeds maximum size of %d bytes", gitprotect.MaxDiffBytes)
+				return fmt.Errorf("%w of %d bytes", gitprotect.ErrDiffTooLarge, gitprotect.MaxDiffBytes)
 			}
 
 			if len(diffData) == 0 {

--- a/internal/cli/git/git_test.go
+++ b/internal/cli/git/git_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,6 +44,35 @@ func testRootCmd() *cobra.Command {
 // fakeKey builds a test credential at runtime to avoid gitleaks false positives.
 func fakeKey() string {
 	return "AK" + "IA" + "IOSFODNN7" + "EXAMPLE"
+}
+
+func runScanDiffCmd(t *testing.T, diff string, args ...string) (string, error) {
+	t.Helper()
+	stdin, err := os.CreateTemp(t.TempDir(), "scan-diff-stdin-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stdin.WriteString(diff); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stdin.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = stdin.Close() })
+
+	oldStdin := os.Stdin
+	os.Stdin = stdin
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	cmd := testRootCmd()
+	cmd.SetArgs(append([]string{"git", "scan-diff"}, args...))
+
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	err = cmd.Execute()
+	return buf.String(), err
 }
 
 func TestGitCmd_Help(t *testing.T) {
@@ -136,6 +166,143 @@ func TestScanDiffCmd_FindsSecret(t *testing.T) {
 	}
 	if !errors.Is(err, ErrSecretsFound) {
 		t.Fatalf("expected ErrSecretsFound, got: %v", err)
+	}
+}
+
+func TestScanDiffCmd_FailClosedMalformedInputs(t *testing.T) {
+	key := fakeKey()
+	tests := []struct {
+		name    string
+		diff    string
+		wantErr error
+	}{
+		{
+			name:    "bare added secret no headers",
+			diff:    "+AWS_ACCESS_KEY_ID=" + key + "\n",
+			wantErr: ErrSecretsFound,
+		},
+		{
+			name:    "bogus empty new-file header",
+			diff:    "+++ \n+AWS_ACCESS_KEY_ID=" + key + "\n",
+			wantErr: ErrSecretsFound,
+		},
+		{
+			name:    "dev null new-file header",
+			diff:    "+++ /dev/null\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+			wantErr: ErrSecretsFound,
+		},
+		{
+			name: "partial parse secret before valid section",
+			diff: "+AWS_ACCESS_KEY_ID=" + key + "\n" +
+				"diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -0,0 +1 @@\n+safe=true\n",
+			wantErr: ErrSecretsFound,
+		},
+		{
+			name: "secret in later malformed section",
+			diff: "diff --git a/safe b/safe\n--- a/safe\n+++ b/safe\n@@ -0,0 +1 @@\n+safe=true\n" +
+				"diff --git a/bad b/bad\n--- a/bad\n+++ \n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+			wantErr: ErrSecretsFound,
+		},
+		{
+			name: "multi-file some headers missing",
+			diff: "diff --git a/safe b/safe\n--- a/safe\n+++ b/safe\n@@ -0,0 +1 @@\n+safe=true\n" +
+				"diff --git a/noheader b/noheader\n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+			wantErr: ErrSecretsFound,
+		},
+		{
+			name:    "crlf line endings",
+			diff:    "diff --git a/x b/x\r\n--- a/x\r\n+++ b/x\r\n@@ -0,0 +1 @@\r\n+AWS_ACCESS_KEY_ID=" + key + "\r\n",
+			wantErr: ErrSecretsFound,
+		},
+		{
+			name:    "clean non-diff garbage",
+			diff:    "not a diff\nstill not a diff\n",
+			wantErr: gitprotect.ErrNoDiffHeaders,
+		},
+		{
+			name:    "binary patch",
+			diff:    "diff --git a/blob.bin b/blob.bin\nindex 1111111..2222222 100644\nGIT binary patch\nliteral 1\nA\n",
+			wantErr: gitprotect.ErrUnsupportedBinaryPatch,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := runScanDiffCmd(t, tc.diff)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected %v, got %v\noutput:\n%s", tc.wantErr, err, output)
+			}
+		})
+	}
+}
+
+func TestScanDiffCmd_CleanMetadataOnlyDiffs(t *testing.T) {
+	tests := []struct {
+		name string
+		diff string
+	}{
+		{
+			name: "mode only",
+			diff: "diff --git a/tool.sh b/tool.sh\nold mode 100644\nnew mode 100755\n",
+		},
+		{
+			name: "rename only",
+			diff: "diff --git a/old.txt b/new.txt\nsimilarity index 100%\nrename from old.txt\nrename to new.txt\n",
+		},
+		{
+			name: "no prefix",
+			diff: "diff --git main.go main.go\n--- main.go\n+++ main.go\n@@ -1,2 +1,3 @@\n package main\n+import \"fmt\"\n",
+		},
+		{
+			name: "clean text with binary summary",
+			diff: "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n@@ -1 +1,2 @@\n package main\n+const ok = true\n" +
+				"diff --git a/x.png b/x.png\nBinary files a/x.png and b/x.png differ\n",
+		},
+		{
+			name: "long clean line",
+			diff: "diff --git a/min.js b/min.js\n--- a/min.js\n+++ b/min.js\n@@ -0,0 +1 @@\n+" + strings.Repeat("A", 1100*1024) + "\n",
+		},
+		{
+			name: "empty",
+			diff: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := runScanDiffCmd(t, tc.diff)
+			if err != nil {
+				t.Fatalf("expected clean diff to exit 0, got %v\noutput:\n%s", err, output)
+			}
+		})
+	}
+}
+
+func TestScanDiffCmd_LongAndBinarySummarySecretsStillBlock(t *testing.T) {
+	key := fakeKey()
+	tests := []struct {
+		name string
+		diff string
+	}{
+		{
+			name: "secret in long line",
+			diff: "diff --git a/min.js b/min.js\n--- a/min.js\n+++ b/min.js\n@@ -0,0 +1 @@\n+" +
+				strings.Repeat("A", 1100*1024) + "AWS_ACCESS_KEY_ID=" + key + "\n",
+		},
+		{
+			name: "secret with binary summary",
+			diff: "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n" +
+				"diff --git a/x.png b/x.png\nBinary files a/x.png and b/x.png differ\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := runScanDiffCmd(t, tc.diff)
+			if !errors.Is(err, ErrSecretsFound) {
+				t.Fatalf("expected %v, got %v\noutput:\n%s", ErrSecretsFound, err, output)
+			}
+		})
 	}
 }
 
@@ -270,7 +437,7 @@ func TestInstallHooksCmd_ForceOverwrite(t *testing.T) {
 }
 
 func TestInstallHooksCmd_NoGitDir(t *testing.T) {
-	dir := t.TempDir() // no .git directory
+	dir := t.TempDir()
 
 	oldDir, _ := os.Getwd()
 	_ = os.Chdir(dir)
@@ -286,9 +453,6 @@ func TestInstallHooksCmd_NoGitDir(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error when not in git repo")
-	}
-	if !strings.Contains(err.Error(), "not a git repository") {
-		t.Errorf("expected 'not a git repository' error, got: %v", err)
 	}
 }
 

--- a/internal/cli/git/git_test.go
+++ b/internal/cli/git/git_test.go
@@ -46,7 +46,7 @@ func fakeKey() string {
 	return "AK" + "IA" + "IOSFODNN7" + "EXAMPLE"
 }
 
-func runScanDiffCmd(t *testing.T, diff string, args ...string) (string, error) {
+func runScanDiffCmd(t *testing.T, diff string) (string, error) {
 	t.Helper()
 	stdin, err := os.CreateTemp(t.TempDir(), "scan-diff-stdin-*")
 	if err != nil {
@@ -65,7 +65,7 @@ func runScanDiffCmd(t *testing.T, diff string, args ...string) (string, error) {
 	t.Cleanup(func() { os.Stdin = oldStdin })
 
 	cmd := testRootCmd()
-	cmd.SetArgs(append([]string{"git", "scan-diff"}, args...))
+	cmd.SetArgs([]string{"git", "scan-diff"})
 
 	buf := &strings.Builder{}
 	cmd.SetOut(buf)
@@ -178,40 +178,74 @@ func TestScanDiffCmd_FailClosedMalformedInputs(t *testing.T) {
 	}{
 		{
 			name:    "bare added secret no headers",
-			diff:    "+AWS_ACCESS_KEY_ID=" + key + "\n",
+			diff:    "+provider_token=" + key + "\n",
 			wantErr: ErrSecretsFound,
 		},
 		{
 			name:    "bogus empty new-file header",
-			diff:    "+++ \n+AWS_ACCESS_KEY_ID=" + key + "\n",
+			diff:    "+++ \n+provider_token=" + key + "\n",
 			wantErr: ErrSecretsFound,
 		},
 		{
 			name:    "dev null new-file header",
-			diff:    "+++ /dev/null\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+			diff:    "+++ /dev/null\n+provider_token=" + key + "\n",
 			wantErr: ErrSecretsFound,
 		},
 		{
 			name: "partial parse secret before valid section",
-			diff: "+AWS_ACCESS_KEY_ID=" + key + "\n" +
+			diff: "+provider_token=" + key + "\n" +
 				"diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -0,0 +1 @@\n+safe=true\n",
 			wantErr: ErrSecretsFound,
 		},
 		{
+			name: "bare secret before valid section",
+			diff: "provider_token=" + key + "\n" +
+				"diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -0,0 +1 @@\n+safe=true\n",
+			wantErr: ErrSecretsFound,
+		},
+		{
+			name: "suppressed orphan secret still unverifiable",
+			diff: "+provider_token=" + key + " // pipelock:ignore\n" +
+				"diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -0,0 +1 @@\n+safe=true\n",
+			wantErr: gitprotect.ErrUnattributedAddedLines,
+		},
+		{
+			name:    "suppressed bare secret no headers",
+			diff:    "+provider_token=" + key + " // pipelock:ignore\n",
+			wantErr: gitprotect.ErrNoDiffHeaders,
+		},
+		{
+			name: "clean orphan line before valid section",
+			diff: "+not_a_secret=true\n" +
+				"diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -0,0 +1 @@\n+safe=true\n",
+			wantErr: gitprotect.ErrUnattributedAddedLines,
+		},
+		{
+			name: "clean garbage before valid section",
+			diff: "not a diff\n" +
+				"diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -0,0 +1 @@\n+safe=true\n",
+			wantErr: gitprotect.ErrUnattributedAddedLines,
+		},
+		{
+			name:    "whitespace",
+			diff:    " \n\t\n",
+			wantErr: gitprotect.ErrNoDiffHeaders,
+		},
+		{
 			name: "secret in later malformed section",
 			diff: "diff --git a/safe b/safe\n--- a/safe\n+++ b/safe\n@@ -0,0 +1 @@\n+safe=true\n" +
-				"diff --git a/bad b/bad\n--- a/bad\n+++ \n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+				"diff --git a/bad b/bad\n--- a/bad\n+++ \n@@ -0,0 +1 @@\n+provider_token=" + key + "\n",
 			wantErr: ErrSecretsFound,
 		},
 		{
 			name: "multi-file some headers missing",
 			diff: "diff --git a/safe b/safe\n--- a/safe\n+++ b/safe\n@@ -0,0 +1 @@\n+safe=true\n" +
-				"diff --git a/noheader b/noheader\n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+				"diff --git a/noheader b/noheader\n@@ -0,0 +1 @@\n+provider_token=" + key + "\n",
 			wantErr: ErrSecretsFound,
 		},
 		{
 			name:    "crlf line endings",
-			diff:    "diff --git a/x b/x\r\n--- a/x\r\n+++ b/x\r\n@@ -0,0 +1 @@\r\n+AWS_ACCESS_KEY_ID=" + key + "\r\n",
+			diff:    "diff --git a/x b/x\r\n--- a/x\r\n+++ b/x\r\n@@ -0,0 +1 @@\r\n+provider_token=" + key + "\r\n",
 			wantErr: ErrSecretsFound,
 		},
 		{
@@ -233,6 +267,15 @@ func TestScanDiffCmd_FailClosedMalformedInputs(t *testing.T) {
 				t.Fatalf("expected %v, got %v\noutput:\n%s", tc.wantErr, err, output)
 			}
 		})
+	}
+}
+
+func TestScanDiffCmd_FailClosedOversizedInput(t *testing.T) {
+	diff := strings.Repeat("A", gitprotect.MaxDiffBytes+1)
+
+	output, err := runScanDiffCmd(t, diff)
+	if !errors.Is(err, gitprotect.ErrDiffTooLarge) {
+		t.Fatalf("expected %v, got %v\noutput:\n%s", gitprotect.ErrDiffTooLarge, err, output)
 	}
 }
 
@@ -262,10 +305,6 @@ func TestScanDiffCmd_CleanMetadataOnlyDiffs(t *testing.T) {
 			name: "long clean line",
 			diff: "diff --git a/min.js b/min.js\n--- a/min.js\n+++ b/min.js\n@@ -0,0 +1 @@\n+" + strings.Repeat("A", 1100*1024) + "\n",
 		},
-		{
-			name: "empty",
-			diff: "",
-		},
 	}
 
 	for _, tc := range tests {
@@ -287,11 +326,11 @@ func TestScanDiffCmd_LongAndBinarySummarySecretsStillBlock(t *testing.T) {
 		{
 			name: "secret in long line",
 			diff: "diff --git a/min.js b/min.js\n--- a/min.js\n+++ b/min.js\n@@ -0,0 +1 @@\n+" +
-				strings.Repeat("A", 1100*1024) + "AWS_ACCESS_KEY_ID=" + key + "\n",
+				strings.Repeat("A", 1100*1024) + "provider_token=" + key + "\n",
 		},
 		{
 			name: "secret with binary summary",
-			diff: "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n" +
+			diff: "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n@@ -0,0 +1 @@\n+provider_token=" + key + "\n" +
 				"diff --git a/x.png b/x.png\nBinary files a/x.png and b/x.png differ\n",
 		},
 	}
@@ -321,9 +360,11 @@ func TestScanDiffCmd_EmptyStdin(t *testing.T) {
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
 
-	err := cmd.Execute()
-	if err != nil {
-		t.Fatalf("expected no error for empty stdin, got: %v", err)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("empty stdin should be a no-op, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No diff content on stdin.") {
+		t.Fatalf("expected empty-stdin notice, got: %q", buf.String())
 	}
 }
 
@@ -814,12 +855,10 @@ func TestScanDiffCmd_JSON_EmptyStdin(t *testing.T) {
 	cmd.SetErr(buf)
 
 	if err := cmd.Execute(); err != nil {
-		t.Fatalf("expected no error, got: %v", err)
+		t.Fatalf("empty JSON stdin should be a no-op, got: %v", err)
 	}
-
-	output := strings.TrimSpace(buf.String())
-	if output != "[]" {
-		t.Errorf("expected [] for empty stdin, got %q", output)
+	if strings.TrimSpace(buf.String()) != "[]" {
+		t.Fatalf("expected empty JSON array, got: %q", buf.String())
 	}
 }
 
@@ -1125,12 +1164,10 @@ func TestScanDiffCmd_SARIF_EmptyStdin(t *testing.T) {
 	cmd.SetErr(buf)
 
 	if err := cmd.Execute(); err != nil {
-		t.Fatalf("expected no error, got: %v", err)
+		t.Fatalf("empty SARIF stdin should be a no-op, got: %v", err)
 	}
-
-	var parsed map[string]interface{}
-	if err := json.Unmarshal([]byte(buf.String()), &parsed); err != nil {
-		t.Fatalf("SARIF output is not valid JSON: %v", err)
+	if !strings.Contains(buf.String(), `"version"`) {
+		t.Fatalf("expected SARIF output for empty stdin, got: %q", buf.String())
 	}
 }
 

--- a/internal/cli/hermes/hook.go
+++ b/internal/cli/hermes/hook.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/extract"
@@ -150,7 +151,7 @@ func runHook(ctx context.Context, cmd *cobra.Command, configFile string) error {
 		return emitDecision(stdout, blockDecision(fmt.Sprintf("pipelock hermes hook: config load failed: %v", err)))
 	}
 
-	cfg, _ = cfg.ResolveRuntime(config.RuntimeResolveOpts{
+	cfg, _ = runtimeconfig.ResolveAndReportConfig(cfg, config.RuntimeResolveOpts{
 		Mode: config.RuntimeMCPScan,
 		MergeBundles: func(c *config.Config) {
 			// Bundle merge errors are surfaced via stderr only; an empty
@@ -162,7 +163,7 @@ func runHook(ctx context.Context, cmd *cobra.Command, configFile string) error {
 				_, _ = fmt.Fprintf(stderr, "pipelock hermes hook: warning: bundle %s: %s\n", e.Name, e.Reason)
 			}
 		},
-	})
+	}, stderr, "hermes hook")
 
 	sc := scanner.New(cfg)
 	defer sc.Close()

--- a/internal/cli/hermes/hook_test.go
+++ b/internal/cli/hermes/hook_test.go
@@ -9,10 +9,14 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 )
 
 // runHookCLI feeds stdin to a fresh hook subcommand and returns the parsed
@@ -228,6 +232,31 @@ func TestHook_FailsClosedOnConfigLoadFailure(t *testing.T) {
 	}
 	if !strings.Contains(decision.Reason, "config load failed") {
 		t.Fatalf("reason missing config-load marker: %q", decision.Reason)
+	}
+}
+
+func TestHook_ResponseScanningFallbackEmitsNotice(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	cfg := "version: 1\nresponse_scanning:\n  enabled: false\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := hookCmd()
+	cmd.SetIn(strings.NewReader(`{"hook_event_name":"on_session_start"}`))
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--config", cfgPath})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("ExecuteContext: %v", err)
+	}
+	if !strings.Contains(stderr.String(), runtimeconfig.ResponseScanningMCPDisabledWarning) {
+		t.Fatalf("stderr missing response-scanning fallback notice:\n%s", stderr.String())
 	}
 }
 

--- a/internal/cli/rules/coverage_boost_test.go
+++ b/internal/cli/rules/coverage_boost_test.go
@@ -100,6 +100,9 @@ func TestLoadRulesConfig_NoFlag_NilConfig(t *testing.T) {
 	t.Setenv("PIPELOCK_CONFIG", "")
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
 
 	cfg, err := loadRulesConfig("")
 	if err != nil {

--- a/internal/cli/rules/coverage_boost_test.go
+++ b/internal/cli/rules/coverage_boost_test.go
@@ -96,15 +96,18 @@ func TestLoadRulesConfig_EnvVar_Valid(t *testing.T) {
 }
 
 func TestLoadRulesConfig_NoFlag_NilConfig(t *testing.T) {
-	// Clear env and ensure no pipelock.yaml in cwd.
+	// Clear env and isolate standard discovery locations.
 	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", t.TempDir())
 
 	cfg, err := loadRulesConfig("")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// May return nil or a config from cwd pipelock.yaml; either is acceptable.
-	_ = cfg
+	if cfg != nil {
+		t.Fatal("expected nil config when no discovered config exists")
+	}
 }
 
 // ---------- decodeSignatureBytes (additional cases) ----------

--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -724,17 +724,17 @@ type installRemoteOptions struct {
 func installRemote(opts installRemoteOptions) error {
 	ctx := context.Background()
 
-	bundleData, sigData, err := fetchRemoteBundle(ctx, opts.bundleURL)
-	if err != nil {
-		return err
-	}
-
 	// Load trusted keys from config (explicit flag, env, or user/system discovery).
 	var trustedKeys []config.TrustedKey
 	if cfg, cfgErr := loadRulesConfig(opts.configFile, opts.stderr); cfgErr != nil {
 		return cfgErr
 	} else if cfg != nil {
 		trustedKeys = cfg.Rules.TrustedKeys
+	}
+
+	bundleData, sigData, err := fetchRemoteBundle(ctx, opts.bundleURL)
+	if err != nil {
+		return err
 	}
 
 	result, err := verifyRemoteSignature(bundleData, sigData, trustedKeys)

--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -31,29 +31,59 @@ import (
 // from the pipelab.org Hugo site via Cloudflare Pages.
 const officialRegistryURL = "https://pipelab.org/rules"
 
+var discoverRulesConfigPath = cliutil.DiscoverConfigPathStrict
+
 // loadRulesConfig loads the pipelock config for trusted key resolution.
-// When configFile is explicitly set (--config flag), load failures are fatal
-// (returned as error). Auto-discovery (PIPELOCK_CONFIG env, cwd pipelock.yaml)
-// is best-effort: failures return nil config, not an error.
-func loadRulesConfig(configFile string) (*config.Config, error) {
+// Resolution is explicit --config, then PIPELOCK_CONFIG, then the shared
+// user/system discovery path. CWD-local pipelock.yaml is intentionally ignored:
+// rules_dir and trusted_keys are security decisions and must not be discovered
+// from a hostile repository working directory.
+func loadRulesConfig(configFile string, stderr ...io.Writer) (*config.Config, error) {
+	provenance := io.Discard
+	if len(stderr) > 0 && stderr[0] != nil {
+		provenance = stderr[0]
+	}
+
 	// Explicit flag: hard error on failure.
 	if configFile != "" {
-		cfg, err := config.Load(configFile)
+		cfg, err := config.LoadForRules(configFile)
 		if err != nil {
 			return nil, fmt.Errorf("loading config %q: %w", configFile, err)
 		}
+		_, _ = fmt.Fprintf(provenance, "pipelock rules: using config %s\n", configFile)
 		return cfg, nil
 	}
-	// Try PIPELOCK_CONFIG env var (best-effort).
+
 	if envPath := os.Getenv("PIPELOCK_CONFIG"); envPath != "" {
-		if cfg, err := config.Load(envPath); err == nil {
-			return cfg, nil
+		clean, err := filepath.Abs(filepath.Clean(envPath))
+		if err != nil {
+			return nil, fmt.Errorf("resolving PIPELOCK_CONFIG %q: %w", envPath, err)
 		}
-	}
-	// Try pipelock.yaml in current directory (best-effort).
-	if cfg, err := config.Load("pipelock.yaml"); err == nil {
+		if err := cliutil.ConfigPathIsSecure(clean); err != nil {
+			return nil, fmt.Errorf("rejecting PIPELOCK_CONFIG %q: %w", clean, err)
+		}
+		cfg, err := config.LoadForRules(clean)
+		if err != nil {
+			return nil, fmt.Errorf("loading PIPELOCK_CONFIG %q: %w", clean, err)
+		}
+		_, _ = fmt.Fprintf(provenance, "pipelock rules: using config %s\n", clean)
 		return cfg, nil
 	}
+
+	discovered, discoverErr := discoverRulesConfigPath()
+	if discoverErr != nil {
+		return nil, fmt.Errorf("discovering config: %w", discoverErr)
+	}
+	if discovered != "" {
+		cfg, err := config.LoadForRules(discovered)
+		if err != nil {
+			return nil, fmt.Errorf("loading discovered config %q: %w", discovered, err)
+		}
+		_, _ = fmt.Fprintf(provenance, "pipelock rules: using config %s\n", discovered)
+		return cfg, nil
+	}
+
+	_, _ = fmt.Fprintln(provenance, "pipelock rules: using built-in defaults (no config found)")
 	return nil, nil
 }
 
@@ -105,7 +135,7 @@ Uses the same config resolution as runtime for accurate reporting.`,
 
 			// Load full config to respect rules_dir, include_defaults,
 			// min_confidence, disabled, and trusted_keys.
-			cfg, err := loadRulesConfig(configFile)
+			cfg, err := loadRulesConfig(configFile, cmd.ErrOrStderr())
 			if err != nil {
 				return err
 			}
@@ -592,11 +622,24 @@ Examples:
 			case localPath != "":
 				return installLocal(out, dir, localPath, allowUnsign)
 			case sourceURL != "":
-				return installRemote(out, dir, sourceURL, configFile, "")
+				return installRemote(installRemoteOptions{
+					out:        out,
+					stderr:     cmd.ErrOrStderr(),
+					rulesDir:   dir,
+					bundleURL:  sourceURL,
+					configFile: configFile,
+				})
 			case len(args) == 1:
 				name := args[0]
 				url := officialRegistryURL + "/" + name + "/bundle.yaml"
-				return installRemote(out, dir, url, configFile, name)
+				return installRemote(installRemoteOptions{
+					out:          out,
+					stderr:       cmd.ErrOrStderr(),
+					rulesDir:     dir,
+					bundleURL:    url,
+					configFile:   configFile,
+					expectedName: name,
+				})
 			default:
 				return fmt.Errorf("specify a bundle name, --source URL, or --path DIR")
 			}
@@ -668,18 +711,27 @@ func installLocal(out io.Writer, rulesDir, localPath string, allowUnsigned bool)
 	return nil
 }
 
+type installRemoteOptions struct {
+	out          io.Writer
+	stderr       io.Writer
+	rulesDir     string
+	bundleURL    string
+	configFile   string
+	expectedName string
+}
+
 // installRemote installs a bundle from a remote URL.
-func installRemote(out io.Writer, rulesDir, bundleURL, configFile, expectedName string) error {
+func installRemote(opts installRemoteOptions) error {
 	ctx := context.Background()
 
-	bundleData, sigData, err := fetchRemoteBundle(ctx, bundleURL)
+	bundleData, sigData, err := fetchRemoteBundle(ctx, opts.bundleURL)
 	if err != nil {
 		return err
 	}
 
-	// Load trusted keys from config (explicit flag, env, or cwd).
+	// Load trusted keys from config (explicit flag, env, or user/system discovery).
 	var trustedKeys []config.TrustedKey
-	if cfg, cfgErr := loadRulesConfig(configFile); cfgErr != nil {
+	if cfg, cfgErr := loadRulesConfig(opts.configFile, opts.stderr); cfgErr != nil {
 		return cfgErr
 	} else if cfg != nil {
 		trustedKeys = cfg.Rules.TrustedKeys
@@ -696,8 +748,8 @@ func installRemote(out io.Writer, rulesDir, bundleURL, configFile, expectedName 
 	}
 
 	// If an expected name was given (official install), verify it matches.
-	if expectedName != "" && bundle.Name != expectedName {
-		return fmt.Errorf("bundle name %q does not match expected %q", bundle.Name, expectedName)
+	if opts.expectedName != "" && bundle.Name != opts.expectedName {
+		return fmt.Errorf("bundle name %q does not match expected %q", bundle.Name, opts.expectedName)
 	}
 
 	// Enforce pipelock-* prefix reservation: only official keys allowed.
@@ -710,7 +762,7 @@ func installRemote(out io.Writer, rulesDir, bundleURL, configFile, expectedName 
 	}
 
 	digest := sha256Hex(bundleData)
-	destDir := filepath.Join(rulesDir, bundle.Name)
+	destDir := filepath.Join(opts.rulesDir, bundle.Name)
 
 	if err := checkExistingInstall(destDir, bundle.Version, digest); err != nil {
 		return err
@@ -721,20 +773,20 @@ func installRemote(out io.Writer, rulesDir, bundleURL, configFile, expectedName 
 	lf := &domrules.LockFile{
 		InstalledVersion:  bundle.Version,
 		InstalledAt:       now,
-		Source:            bundleURL,
+		Source:            opts.bundleURL,
 		LastCheck:         now,
 		BundleSHA256:      digest,
 		SignerFingerprint: result.SignerFingerprint,
 	}
-	if err := stageBundle(rulesDir, bundle.Name, bundleData, sigData, lf); err != nil {
+	if err := stageBundle(opts.rulesDir, bundle.Name, bundleData, sigData, lf); err != nil {
 		return err
 	}
-	if err := resetFreshnessStateAfterBundleChange(rulesDir); err != nil {
+	if err := resetFreshnessStateAfterBundleChange(opts.rulesDir); err != nil {
 		return err
 	}
 
-	_, _ = fmt.Fprintf(out, "Installed %s v%s (%s)\n", bundle.Name, bundle.Version, result.Tier)
-	_, _ = fmt.Fprintf(out, "  %d rules, signer: %s\n", len(bundle.Rules), result.SignerFingerprint[:16]+"...")
+	_, _ = fmt.Fprintf(opts.out, "Installed %s v%s (%s)\n", bundle.Name, bundle.Version, result.Tier)
+	_, _ = fmt.Fprintf(opts.out, "  %d rules, signer: %s\n", len(bundle.Rules), result.SignerFingerprint[:16]+"...")
 	return nil
 }
 
@@ -864,7 +916,7 @@ Local (unsigned) bundles are skipped during update.`,
 			defer unlock()
 
 			var trustedKeys []config.TrustedKey
-			if cfg, cfgErr := loadRulesConfig(configFile); cfgErr != nil {
+			if cfg, cfgErr := loadRulesConfig(configFile, cmd.ErrOrStderr()); cfgErr != nil {
 				return cfgErr
 			} else if cfg != nil {
 				trustedKeys = cfg.Rules.TrustedKeys
@@ -1066,7 +1118,7 @@ func rulesVerifyCmd() *cobra.Command {
 			dir := domrules.ResolveRulesDir(rulesDir)
 
 			var trustedKeys []config.TrustedKey
-			if cfg, cfgErr := loadRulesConfig(configFile); cfgErr != nil {
+			if cfg, cfgErr := loadRulesConfig(configFile, cmd.ErrOrStderr()); cfgErr != nil {
 				return cfgErr
 			} else if cfg != nil {
 				trustedKeys = cfg.Rules.TrustedKeys

--- a/internal/cli/rules/rules_test.go
+++ b/internal/cli/rules/rules_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
@@ -30,6 +32,31 @@ const (
 	testBundleName    = "test-bundle"
 	testBundleVersion = "2026.03.1"
 )
+
+func TestMain(m *testing.M) {
+	discoverRulesConfigPath = func() (string, error) {
+		return "", nil
+	}
+	dir, err := os.MkdirTemp("", "pipelock-rules-test-home-*")
+	if err != nil {
+		panic(err)
+	}
+	_ = os.Setenv("PIPELOCK_CONFIG", "")
+	_ = os.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	_ = os.Setenv("HOME", filepath.Join(dir, "home"))
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+func withRulesConfigDiscovery(t *testing.T, fn func() (string, error)) {
+	t.Helper()
+	old := discoverRulesConfigPath
+	discoverRulesConfigPath = fn
+	t.Cleanup(func() {
+		discoverRulesConfigPath = old
+	})
+}
 
 // validBundleYAML is minimal valid bundle YAML for testing.
 const validBundleYAML = `format_version: 1
@@ -1030,15 +1057,203 @@ func TestLoadRulesConfig_ExplicitPathError(t *testing.T) {
 }
 
 func TestLoadRulesConfig_EmptyFallback(t *testing.T) {
-	// Empty configFile + no env + no cwd config -> nil, nil (not an error).
+	// Empty configFile + no env + no discovered config -> nil, nil (not an error).
 	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", t.TempDir())
 	t.Chdir(t.TempDir())
-	cfg, err := loadRulesConfig("")
+	var stderr strings.Builder
+	cfg, err := loadRulesConfig("", &stderr)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if cfg != nil {
-		t.Fatal("expected nil config when no explicit, env, or cwd config is present")
+		t.Fatal("expected nil config when no explicit, env, or discovered config is present")
+	}
+	if !strings.Contains(stderr.String(), "using built-in defaults") {
+		t.Fatalf("expected defaults provenance, got %q", stderr.String())
+	}
+}
+
+func TestLoadRulesConfig_HostileCWDConfigIgnored(t *testing.T) {
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "pipelock.yaml"), []byte("mode: balanced\nrules_dir: /hostile\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr strings.Builder
+	cfg, err := loadRulesConfig("", &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatal("cwd pipelock.yaml must be ignored")
+	}
+	if !strings.Contains(stderr.String(), "using built-in defaults") {
+		t.Fatalf("expected defaults provenance, got %q", stderr.String())
+	}
+}
+
+func TestLoadRulesConfig_EnvVarHonoredWithProvenance(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "env-pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	var stderr strings.Builder
+	cfg, err := loadRulesConfig("", &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected env config")
+	}
+	if !strings.Contains(stderr.String(), cfgPath) {
+		t.Fatalf("expected config provenance to include env path, got %q", stderr.String())
+	}
+}
+
+func TestLoadRulesConfig_IgnoresRuntimeLicenseFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: balanced\nlicense_file: missing-license.token\n"), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	var stderr strings.Builder
+	cfg, err := loadRulesConfig(cfgPath, &stderr)
+	if err != nil {
+		t.Fatalf("rules config load should not require runtime license_file: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected config")
+	}
+	if cfg.LicenseFile != "" || cfg.LicenseKey != "" {
+		t.Fatalf("rules config loader should scrub runtime license fields, got license_file=%q license_key=%q", cfg.LicenseFile, cfg.LicenseKey)
+	}
+}
+
+func TestLoadRulesConfig_IgnoresRuntimeOnlyFiles(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	cfgYAML := `mode: balanced
+dlp:
+  secrets_file: /root/not-readable/pipelock-secrets.env
+tls_interception:
+  enabled: true
+  ca_cert: /root/not-readable/ca.pem
+  ca_key: /root/not-readable/ca-key.pem
+`
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	cfg, err := loadRulesConfig(cfgPath, io.Discard)
+	if err != nil {
+		t.Fatalf("rules config load should not require runtime-only files: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected config")
+	}
+}
+
+func TestLoadRulesConfig_InvalidRulesFacingConfigFatal(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	cfgYAML := `mode: balanced
+dlp:
+  patterns:
+    - name: bad-regex
+      regex: "["
+`
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	cfg, err := loadRulesConfig(cfgPath, io.Discard)
+	if err == nil {
+		t.Fatal("expected invalid rules-facing DLP pattern to be fatal")
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config on invalid rules-facing config, got %+v", cfg)
+	}
+	if !strings.Contains(err.Error(), "invalid rules config") || !strings.Contains(err.Error(), "bad-regex") {
+		t.Fatalf("expected invalid DLP pattern error, got %v", err)
+	}
+}
+
+func TestLoadRulesConfig_MalformedDiscoveredConfigFatal(t *testing.T) {
+	xdg := t.TempDir()
+	cfgDir := filepath.Join(xdg, "pipelock")
+	if err := os.MkdirAll(cfgDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cfgDir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: [broken\n"), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+	withRulesConfigDiscovery(t, cliutil.DiscoverConfigPathStrict)
+
+	var stderr strings.Builder
+	cfg, err := loadRulesConfig("", &stderr)
+	if err == nil {
+		t.Fatal("expected malformed discovered config to be fatal")
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config on malformed discovered config, got %+v", cfg)
+	}
+	if !strings.Contains(err.Error(), "loading discovered config") {
+		t.Fatalf("expected discovered config load error, got %v", err)
+	}
+}
+
+func TestLoadRulesConfig_UnsafeDiscoveredConfigFatal(t *testing.T) {
+	xdg := t.TempDir()
+	cfgDir := filepath.Join(xdg, "pipelock")
+	if err := os.MkdirAll(cfgDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cfgDir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	unsafeMode := os.FileMode(0o600 | 0o020)
+	if err := os.Chmod(cfgPath, unsafeMode); err != nil {
+		t.Fatalf("chmod config: %v", err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+	withRulesConfigDiscovery(t, cliutil.DiscoverConfigPathStrict)
+
+	var stderr strings.Builder
+	cfg, err := loadRulesConfig("", &stderr)
+	if err == nil {
+		t.Fatal("expected unsafe discovered config to be fatal")
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config on unsafe discovered config, got %+v", cfg)
+	}
+	if !strings.Contains(err.Error(), "discovering config") || !strings.Contains(err.Error(), "writable by group or other") {
+		t.Fatalf("expected unsafe discovery error, got %v", err)
+	}
+	if strings.Contains(stderr.String(), "using built-in defaults") {
+		t.Fatalf("unsafe discovered config must not fall back to defaults; stderr=%q", stderr.String())
 	}
 }
 
@@ -1609,7 +1824,13 @@ func TestRulesInstall_RemoteNameMismatch(t *testing.T) {
 	buf := &strings.Builder{}
 
 	// Call installRemote directly with an expectedName that doesn't match the bundle.
-	err = installRemote(buf, rulesDir, ts.URL+testBundlePath, "", "wrong-name")
+	err = installRemote(installRemoteOptions{
+		out:          buf,
+		stderr:       io.Discard,
+		rulesDir:     rulesDir,
+		bundleURL:    ts.URL + testBundlePath,
+		expectedName: "wrong-name",
+	})
 	if err == nil {
 		t.Fatal("expected error for name mismatch")
 	}
@@ -2182,7 +2403,13 @@ func TestInstallRemote_PipelockPrefixNonOfficial(t *testing.T) {
 
 	_ = trustedKeys // used through config file
 	buf := &strings.Builder{}
-	err = installRemote(buf, rulesDir, ts.URL+"/pipelock-evil/bundle.yaml", cfgPath, "")
+	err = installRemote(installRemoteOptions{
+		out:        buf,
+		stderr:     io.Discard,
+		rulesDir:   rulesDir,
+		bundleURL:  ts.URL + "/pipelock-evil/bundle.yaml",
+		configFile: cfgPath,
+	})
 	if err == nil {
 		t.Fatal("expected error for pipelock- prefix with non-official signer")
 	}
@@ -2407,10 +2634,19 @@ func TestRulesInstall_RemoteSignatureFailure(t *testing.T) {
 
 // ---------- rules status ----------
 
+type statusCmdOutput struct {
+	stdout string
+	stderr string
+}
+
 // runStatusCmd sets up a cobra root with the rules command, writes cfgYAML to
 // a temp config file, and executes "rules status" with the given extra args.
-func runStatusCmd(t *testing.T, cfgYAML string, extraArgs ...string) string {
+func runStatusCmd(t *testing.T, cfgYAML string, extraArgs ...string) statusCmdOutput {
 	t.Helper()
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
 	root := &cobra.Command{Use: "pipelock"}
 	root.AddCommand(Cmd())
 
@@ -2422,34 +2658,40 @@ func runStatusCmd(t *testing.T, cfgYAML string, extraArgs ...string) string {
 		t.Fatal(err)
 	}
 
-	var buf strings.Builder
-	root.SetOut(&buf)
-	root.SetErr(&buf)
+	var stdout strings.Builder
+	var stderr strings.Builder
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
 	args := append([]string{"rules", "status", "--config", cfgFile}, extraArgs...)
 	root.SetArgs(args)
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("rules status failed: %v", err)
 	}
-	return buf.String()
+	return statusCmdOutput{stdout: stdout.String(), stderr: stderr.String()}
 }
 
 func TestRulesStatus_DefaultConfig(t *testing.T) {
-	out := runStatusCmd(t, "")
+	output := runStatusCmd(t, "")
+	out := output.stdout
 	if !strings.Contains(out, "Core:") {
 		t.Error("expected Core: line in status output")
 	}
 	if !strings.Contains(out, "compiled fallback") {
 		t.Error("expected 'compiled fallback' when no standard bundle installed")
 	}
+	if !strings.Contains(output.stderr, "pipelock rules: using config ") {
+		t.Fatalf("expected config provenance on stderr, got %q", output.stderr)
+	}
 }
 
 func TestRulesStatus_JSON(t *testing.T) {
-	out := runStatusCmd(t, "", "--json")
+	output := runStatusCmd(t, "", "--json")
+	out := output.stdout
 
 	var status statusReport
 	if err := json.Unmarshal([]byte(out), &status); err != nil {
-		t.Fatalf("invalid JSON output: %v", err)
+		t.Fatalf("invalid JSON output: %v\nstdout=%q\nstderr=%q", err, out, output.stderr)
 	}
 	if status.Core.DLP != scanner.CoreDLPCount() {
 		t.Errorf("expected %d core DLP, got %d", scanner.CoreDLPCount(), status.Core.DLP)
@@ -2460,10 +2702,14 @@ func TestRulesStatus_JSON(t *testing.T) {
 	if status.StandardDLPSource != "compiled" {
 		t.Errorf("expected standard DLP source 'compiled', got %q", status.StandardDLPSource)
 	}
+	if !strings.Contains(output.stderr, "pipelock rules: using config ") {
+		t.Fatalf("expected config provenance on stderr, got %q", output.stderr)
+	}
 }
 
 func TestRulesStatus_IncludeDefaultsFalse(t *testing.T) {
-	out := runStatusCmd(t, "dlp:\n  include_defaults: false\nresponse_scanning:\n  include_defaults: false\n")
+	output := runStatusCmd(t, "dlp:\n  include_defaults: false\nresponse_scanning:\n  include_defaults: false\n")
+	out := output.stdout
 	if !strings.Contains(out, "disabled") {
 		t.Error("expected 'disabled' when include_defaults: false")
 	}

--- a/internal/cli/rules/rules_test.go
+++ b/internal/cli/rules/rules_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -1836,6 +1837,35 @@ func TestRulesInstall_RemoteNameMismatch(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "does not match") {
 		t.Errorf("error should mention name mismatch, got: %v", err)
+	}
+}
+
+func TestInstallRemote_LoadsConfigBeforeFetch(t *testing.T) {
+	var requests atomic.Int32
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte(validBundleYAML))
+	}))
+	defer ts.Close()
+
+	origClient := httpsOnlyClient
+	testClient := ts.Client()
+	testClient.CheckRedirect = httpsOnlyClient.CheckRedirect
+	httpsOnlyClient = testClient
+	t.Cleanup(func() { httpsOnlyClient = origClient })
+
+	err := installRemote(installRemoteOptions{
+		out:        io.Discard,
+		stderr:     io.Discard,
+		rulesDir:   t.TempDir(),
+		bundleURL:  ts.URL + testBundlePath,
+		configFile: filepath.Join(t.TempDir(), "missing-pipelock.yaml"),
+	})
+	if err == nil {
+		t.Fatal("expected config load error")
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("remote bundle was fetched before config validation; requests=%d", requests.Load())
 	}
 }
 

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
+	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
@@ -435,13 +436,12 @@ Examples:
 			// wraps an upstream server; RuntimeMCPProxy mode supplies the
 			// response-scanning fallback behavior the command needs.
 			var bundleResult *rules.LoadResult
-			var resolveInfo config.ResolveRuntimeInfo
-			cfg, resolveInfo = cfg.ResolveRuntime(config.RuntimeResolveOpts{
+			cfg, _ = runtimeconfig.ResolveAndReportConfig(cfg, config.RuntimeResolveOpts{
 				Mode: config.RuntimeMCPScan,
 				MergeBundles: func(c *config.Config) {
 					bundleResult = rules.MergeIntoConfig(c, cliutil.Version)
 				},
-			})
+			}, cmd.ErrOrStderr(), "scan")
 			for _, e := range bundleResult.Errors {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: warning: bundle %s: %s\n", e.Name, e.Reason)
 			}
@@ -451,7 +451,6 @@ Examples:
 			if bundleResult.Degraded {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: DEGRADED — standard pack failed, running core patterns only\n")
 			}
-			emitResolveInfoLogs(cmd.ErrOrStderr(), resolveInfo, "scan")
 			sc := scanner.New(cfg)
 			defer sc.Close()
 
@@ -657,14 +656,13 @@ Key-free evidence capture:
 			// reflects the effective policy every downstream emitter,
 			// scanner, and receipt stamp consumes.
 			var bundleResult *rules.LoadResult
-			var resolveInfo config.ResolveRuntimeInfo
-			cfg, resolveInfo = cfg.ResolveRuntime(config.RuntimeResolveOpts{
+			cfg, _ = runtimeconfig.ResolveAndReportConfig(cfg, config.RuntimeResolveOpts{
 				Mode: config.RuntimeMCPProxy,
 				MergeBundles: func(c *config.Config) {
 					bundleResult = rules.MergeIntoConfig(c, cliutil.Version)
 				},
 				DefaultToolPolicyRules: policy.DefaultToolPolicyRules,
-			})
+			}, cmd.ErrOrStderr(), "proxy")
 			for _, e := range bundleResult.Errors {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: warning: bundle %s: %s\n", e.Name, e.Reason)
 			}
@@ -674,7 +672,6 @@ Key-free evidence capture:
 			if bundleResult.Degraded {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: DEGRADED — standard pack failed, running core patterns only\n")
 			}
-			emitResolveInfoLogs(cmd.ErrOrStderr(), resolveInfo, "proxy")
 			extraPoison := rules.ConvertToolPoison(bundleResult.ToolPoison)
 
 			// Rebuild scanner with the (possibly modified) resolved config.

--- a/internal/cli/runtime/resolve_enforcement_test.go
+++ b/internal/cli/runtime/resolve_enforcement_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"testing"
+)
+
+func TestProductionCallersUseResolveAndReportConfig(t *testing.T) {
+	_, thisFile, _, ok := goruntime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "../../.."))
+	checkedDirs := []string{
+		filepath.Join(repoRoot, "internal", "cli", "runtime"),
+		filepath.Join(repoRoot, "internal", "cli", "hermes"),
+	}
+
+	for _, dir := range checkedDirs {
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				return err
+			}
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "ResolveRuntime" {
+					return true
+				}
+				pos := fset.Position(sel.Sel.Pos())
+				t.Errorf("%s calls ResolveRuntime directly; use runtimeconfig.ResolveAndReportConfig", pos)
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", dir, err)
+		}
+	}
+}

--- a/internal/cli/runtime/resolve_enforcement_test.go
+++ b/internal/cli/runtime/resolve_enforcement_test.go
@@ -21,8 +21,7 @@ func TestProductionCallersUseResolveAndReportConfig(t *testing.T) {
 	}
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "../../.."))
 	checkedDirs := []string{
-		filepath.Join(repoRoot, "internal", "cli", "runtime"),
-		filepath.Join(repoRoot, "internal", "cli", "hermes"),
+		filepath.Join(repoRoot, "internal", "cli"),
 	}
 
 	for _, dir := range checkedDirs {
@@ -33,29 +32,62 @@ func TestProductionCallersUseResolveAndReportConfig(t *testing.T) {
 			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 				return nil
 			}
+			rel, err := filepath.Rel(repoRoot, path)
+			if err != nil {
+				return err
+			}
+			if strings.HasPrefix(rel, filepath.Join("internal", "cli", "runtimeconfig")+string(filepath.Separator)) {
+				return nil
+			}
 
 			fset := token.NewFileSet()
 			file, err := parser.ParseFile(fset, path, nil, 0)
 			if err != nil {
 				return err
 			}
-			ast.Inspect(file, func(n ast.Node) bool {
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel.Name != "ResolveRuntime" {
-					return true
-				}
-				pos := fset.Position(sel.Sel.Pos())
+			for _, pos := range resolveRuntimeSelectorPositions(fset, file) {
 				t.Errorf("%s calls ResolveRuntime directly; use runtimeconfig.ResolveAndReportConfig", pos)
-				return true
-			})
+			}
 			return nil
 		})
 		if err != nil {
 			t.Fatalf("walk %s: %v", dir, err)
 		}
 	}
+}
+
+func TestResolveRuntimeSelectorDetectorCatchesMethodValueBypass(t *testing.T) {
+	src := `package runtime
+
+func direct(cfg interface{ ResolveRuntime(any) (any, any) }, opts any) {
+	_, _ = cfg.ResolveRuntime(opts)
+}
+
+func methodValue(cfg interface{ ResolveRuntime(any) (any, any) }, opts any) {
+	resolve := cfg.ResolveRuntime
+	_, _ = resolve(opts)
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "bypass.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	positions := resolveRuntimeSelectorPositions(fset, file)
+	if len(positions) != 2 {
+		t.Fatalf("selector detector found %d ResolveRuntime selectors, want 2", len(positions))
+	}
+}
+
+func resolveRuntimeSelectorPositions(fset *token.FileSet, file *ast.File) []token.Position {
+	var positions []token.Position
+	ast.Inspect(file, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "ResolveRuntime" {
+			return true
+		}
+		positions = append(positions, fset.Position(sel.Sel.Pos()))
+		return true
+	})
+	return positions
 }

--- a/internal/cli/runtime/resolve_logs.go
+++ b/internal/cli/runtime/resolve_logs.go
@@ -4,9 +4,9 @@
 package runtime
 
 import (
-	"fmt"
 	"io"
 
+	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
@@ -20,16 +20,5 @@ import (
 // truth for these messages and so the branches are trivially
 // unit-testable without spinning up a full proxy process.
 func emitResolveInfoLogs(w io.Writer, info config.ResolveRuntimeInfo, modeLabel string) {
-	if info.ResponseScanningFallback {
-		_, _ = fmt.Fprintln(w, "warning: response scanning was disabled in config, enabling with defaults")
-	}
-	if info.MCPInputScanningAutoEnabled {
-		_, _ = fmt.Fprintf(w, "pipelock: auto-enabling MCP input scanning for %s mode\n", modeLabel)
-	}
-	if info.MCPToolScanningAutoEnabled {
-		_, _ = fmt.Fprintf(w, "pipelock: auto-enabling MCP tool scanning for %s mode\n", modeLabel)
-	}
-	if info.MCPToolPolicyAutoEnabled {
-		_, _ = fmt.Fprintf(w, "pipelock: auto-enabling MCP tool call policy for %s mode\n", modeLabel)
-	}
+	runtimeconfig.EmitResolveInfoLogs(w, info, modeLabel)
 }

--- a/internal/cli/runtime/resolve_logs_test.go
+++ b/internal/cli/runtime/resolve_logs_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
@@ -22,7 +23,7 @@ func TestEmitResolveInfoLogs(t *testing.T) {
 		}, "proxy")
 
 		want := []string{
-			"warning: response scanning was disabled in config, enabling with defaults",
+			runtimeconfig.ResponseScanningMCPDisabledWarning,
 			"pipelock: auto-enabling MCP input scanning for proxy mode",
 			"pipelock: auto-enabling MCP tool scanning for proxy mode",
 			"pipelock: auto-enabling MCP tool call policy for proxy mode",
@@ -59,7 +60,7 @@ func TestEmitResolveInfoLogs(t *testing.T) {
 			ResponseScanningFallback: true,
 		}, "proxy")
 		out := buf.String()
-		if !strings.Contains(out, "warning: response scanning was disabled") {
+		if !strings.Contains(out, runtimeconfig.ResponseScanningMCPDisabledWarning) {
 			t.Errorf("expected response-fallback line, got:\n%s", out)
 		}
 		if strings.Contains(out, "auto-enabling MCP") {

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
+	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
@@ -316,14 +317,13 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	s.runtimeMode = runtimeMode
 
 	var bundleResult *rules.LoadResult
-	var resolveInfo config.ResolveRuntimeInfo
-	cfg, resolveInfo = cfg.ResolveRuntime(config.RuntimeResolveOpts{
+	cfg, _ = runtimeconfig.ResolveAndReportConfig(cfg, config.RuntimeResolveOpts{
 		Mode: runtimeMode,
 		MergeBundles: func(c *config.Config) {
 			bundleResult = rules.MergeIntoConfig(c, cliutil.Version)
 		},
 		DefaultToolPolicyRules: policy.DefaultToolPolicyRules,
-	})
+	}, opts.Stderr, "listener")
 	for _, e := range bundleResult.Errors {
 		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: warning: bundle %s: %s\n", e.Name, e.Reason)
 	}
@@ -333,7 +333,6 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	if bundleResult.Degraded {
 		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: DEGRADED — standard pack failed, running core patterns only\n")
 	}
-	emitResolveInfoLogs(opts.Stderr, resolveInfo, "listener")
 	if hasMCPListen {
 		if err := validateMCPDeferSurface(deferred.SurfaceMCPHTTPListener, cfg); err != nil {
 			return nil, err

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/license"
@@ -304,13 +305,13 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 	// the startup flags: reload cannot toggle MCP listener or forward
 	// proxy enablement (both gated above).
 	var reloadBundleResult *rules.LoadResult
-	newCfg, _ = newCfg.ResolveRuntime(config.RuntimeResolveOpts{
+	newCfg, _ = runtimeconfig.ResolveAndReportConfig(newCfg, config.RuntimeResolveOpts{
 		Mode: s.runtimeMode,
 		MergeBundles: func(c *config.Config) {
 			reloadBundleResult = rules.MergeIntoConfig(c, cliutil.Version)
 		},
 		DefaultToolPolicyRules: policy.DefaultToolPolicyRules,
-	})
+	}, s.opts.Stderr, "reload")
 	for _, e := range reloadBundleResult.Errors {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: bundle %s: %s\n", e.Name, e.Reason)
 	}

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -311,7 +311,7 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			reloadBundleResult = rules.MergeIntoConfig(c, cliutil.Version)
 		},
 		DefaultToolPolicyRules: policy.DefaultToolPolicyRules,
-	}, s.opts.Stderr, "reload")
+	}, s.opts.Stderr, reloadRuntimeModeLabel(s.runtimeMode))
 	for _, e := range reloadBundleResult.Errors {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: bundle %s: %s\n", e.Name, e.Reason)
 	}
@@ -381,6 +381,19 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 	s.logger.LogConfigReload("success", fmt.Sprintf("mode=%s", newCfg.Mode), reloadHash)
 	s.recordReloadSuccess(reloadHash)
 	return nil
+}
+
+func reloadRuntimeModeLabel(mode config.RuntimeMode) string {
+	switch mode {
+	case config.RuntimeForwardWithMCPListener:
+		return "listener"
+	case config.RuntimeMCPProxy:
+		return "proxy"
+	case config.RuntimeMCPScan:
+		return "scan"
+	default:
+		return "forward"
+	}
 }
 
 func implausibleReloadTeardownReasons(oldCfg, newCfg *config.Config) []string {

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	mcptools "github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
@@ -659,6 +660,22 @@ func TestServer_Reload_StrictRejectsDowngrade(t *testing.T) {
 	live := s.proxy.CurrentConfig()
 	if live.Mode != config.ModeStrict {
 		t.Errorf("live config mode after rejected reload: want %q, got %q", config.ModeStrict, live.Mode)
+	}
+}
+
+func TestServer_Reload_MCPResponseScanningFallbackEmitsNotice(t *testing.T) {
+	s, buf := newTestServer(t, nil)
+	s.runtimeMode = config.RuntimeMCPProxy
+
+	newCfg := s.proxy.CurrentConfig().Clone()
+	newCfg.ResponseScanning.Enabled = false
+	buf.reset()
+
+	if err := s.Reload(newCfg); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if !strings.Contains(buf.String(), runtimeconfig.ResponseScanningMCPDisabledWarning) {
+		t.Fatalf("reload stderr missing response-scanning fallback notice:\n%s", buf.String())
 	}
 }
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -669,13 +669,26 @@ func TestServer_Reload_MCPResponseScanningFallbackEmitsNotice(t *testing.T) {
 
 	newCfg := s.proxy.CurrentConfig().Clone()
 	newCfg.ResponseScanning.Enabled = false
+	newCfg.MCPInputScanning.Enabled = false
 	buf.reset()
 
 	if err := s.Reload(newCfg); err != nil {
 		t.Fatalf("Reload: %v", err)
 	}
+	if !s.proxy.CurrentConfig().ResponseScanning.Enabled {
+		t.Fatal("reload left response scanning disabled in MCP mode")
+	}
+	if !s.proxy.CurrentConfig().MCPInputScanning.Enabled {
+		t.Fatal("reload left MCP input scanning disabled in MCP mode")
+	}
 	if !strings.Contains(buf.String(), runtimeconfig.ResponseScanningMCPDisabledWarning) {
 		t.Fatalf("reload stderr missing response-scanning fallback notice:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "auto-enabling MCP input scanning for proxy mode") {
+		t.Fatalf("reload stderr missing actual runtime mode label:\n%s", buf.String())
+	}
+	if strings.Contains(buf.String(), "for reload mode") {
+		t.Fatalf("reload stderr used reload as a runtime mode label:\n%s", buf.String())
 	}
 }
 

--- a/internal/cli/runtimeconfig/resolve.go
+++ b/internal/cli/runtimeconfig/resolve.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtimeconfig
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// ResponseScanningMCPDisabledWarning is the single operator-facing notice for
+// the temporary MCP-mode fail-safe that overrides response_scanning.enabled=false.
+const ResponseScanningMCPDisabledWarning = "warning: response_scanning.enabled=false is ignored in MCP mode (this control is required); running with default response scanning. This will become a startup error in a future release - remove the disable to silence."
+
+// ResolveAndReportConfig applies runtime-mode config resolution and immediately
+// emits any operator-facing notices for fallbacks or auto-enabled MCP controls.
+func ResolveAndReportConfig(cfg *config.Config, opts config.RuntimeResolveOpts, w io.Writer, modeLabel string) (*config.Config, config.ResolveRuntimeInfo) {
+	resolved, info := cfg.ResolveRuntime(opts)
+	EmitResolveInfoLogs(w, info, modeLabel)
+	return resolved, info
+}
+
+// EmitResolveInfoLogs writes the operator-facing notices that correspond to the
+// auto-enable and fallback branches a config.ResolveRuntime call reported as
+// having fired.
+func EmitResolveInfoLogs(w io.Writer, info config.ResolveRuntimeInfo, modeLabel string) {
+	if w == nil {
+		return
+	}
+	if info.ResponseScanningFallback {
+		_, _ = fmt.Fprintln(w, ResponseScanningMCPDisabledWarning)
+	}
+	if info.MCPInputScanningAutoEnabled {
+		_, _ = fmt.Fprintf(w, "pipelock: auto-enabling MCP input scanning for %s mode\n", modeLabel)
+	}
+	if info.MCPToolScanningAutoEnabled {
+		_, _ = fmt.Fprintf(w, "pipelock: auto-enabling MCP tool scanning for %s mode\n", modeLabel)
+	}
+	if info.MCPToolPolicyAutoEnabled {
+		_, _ = fmt.Fprintf(w, "pipelock: auto-enabling MCP tool call policy for %s mode\n", modeLabel)
+	}
+}

--- a/internal/cli/runtimeconfig/resolve_test.go
+++ b/internal/cli/runtimeconfig/resolve_test.go
@@ -72,3 +72,32 @@ func TestResolveAndReportConfig_ResponseScanningReloadStates(t *testing.T) {
 		t.Fatalf("reload without config change should still warn when fallback fires:\n%s", stderr.String())
 	}
 }
+
+func TestEmitResolveInfoLogs_AllBranches(t *testing.T) {
+	EmitResolveInfoLogs(nil, config.ResolveRuntimeInfo{
+		ResponseScanningFallback:    true,
+		MCPInputScanningAutoEnabled: true,
+		MCPToolScanningAutoEnabled:  true,
+		MCPToolPolicyAutoEnabled:    true,
+	}, "proxy")
+
+	var stderr bytes.Buffer
+	EmitResolveInfoLogs(&stderr, config.ResolveRuntimeInfo{
+		ResponseScanningFallback:    true,
+		MCPInputScanningAutoEnabled: true,
+		MCPToolScanningAutoEnabled:  true,
+		MCPToolPolicyAutoEnabled:    true,
+	}, "proxy")
+
+	out := stderr.String()
+	for _, want := range []string{
+		ResponseScanningMCPDisabledWarning,
+		"auto-enabling MCP input scanning for proxy mode",
+		"auto-enabling MCP tool scanning for proxy mode",
+		"auto-enabling MCP tool call policy for proxy mode",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in stderr:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/runtimeconfig/resolve_test.go
+++ b/internal/cli/runtimeconfig/resolve_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtimeconfig
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func loadConfigYAML(t *testing.T, yaml string) *config.Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	return cfg
+}
+
+func TestResolveAndReportConfig_ResponseScanningBooleanStates(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		wantWarning bool
+	}{
+		{name: "omitted", yaml: "version: 1\n", wantWarning: false},
+		{name: "null", yaml: "version: 1\nresponse_scanning:\n  enabled: null\n", wantWarning: false},
+		{name: "false", yaml: "version: 1\nresponse_scanning:\n  enabled: false\n", wantWarning: true},
+		{name: "true", yaml: "version: 1\nresponse_scanning:\n  enabled: true\n", wantWarning: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			ResolveAndReportConfig(loadConfigYAML(t, tc.yaml), config.RuntimeResolveOpts{Mode: config.RuntimeMCPScan}, &stderr, "scan")
+			gotWarning := strings.Contains(stderr.String(), ResponseScanningMCPDisabledWarning)
+			if gotWarning != tc.wantWarning {
+				t.Fatalf("warning = %v, want %v; stderr:\n%s", gotWarning, tc.wantWarning, stderr.String())
+			}
+		})
+	}
+}
+
+func TestResolveAndReportConfig_ResponseScanningReloadStates(t *testing.T) {
+	trueCfg := loadConfigYAML(t, "version: 1\nresponse_scanning:\n  enabled: true\n")
+	falseCfg := loadConfigYAML(t, "version: 1\nresponse_scanning:\n  enabled: false\n")
+
+	var stderr bytes.Buffer
+	ResolveAndReportConfig(trueCfg, config.RuntimeResolveOpts{Mode: config.RuntimeMCPScan}, &stderr, "reload")
+	if strings.Contains(stderr.String(), ResponseScanningMCPDisabledWarning) {
+		t.Fatalf("reload without disable should not warn:\n%s", stderr.String())
+	}
+
+	stderr.Reset()
+	ResolveAndReportConfig(falseCfg, config.RuntimeResolveOpts{Mode: config.RuntimeMCPScan}, &stderr, "reload")
+	if !strings.Contains(stderr.String(), ResponseScanningMCPDisabledWarning) {
+		t.Fatalf("reload with disable should warn:\n%s", stderr.String())
+	}
+
+	stderr.Reset()
+	ResolveAndReportConfig(falseCfg, config.RuntimeResolveOpts{Mode: config.RuntimeMCPScan}, &stderr, "reload")
+	if !strings.Contains(stderr.String(), ResponseScanningMCPDisabledWarning) {
+		t.Fatalf("reload without config change should still warn when fallback fires:\n%s", stderr.String())
+	}
+}

--- a/internal/cliutil/config.go
+++ b/internal/cliutil/config.go
@@ -24,6 +24,36 @@ func LoadConfigOrDefault(path string) (*config.Config, error) {
 	return config.Defaults(), nil
 }
 
+// ConfigPathIsSecure verifies that a discovered config file is safe to trust.
+// It rejects group/other-writable files and files not owned by root, the
+// invoking user, or Pipelock's dedicated service account. The contain-managed
+// /etc/pipelock path is service-owned on installed systems, while the contained
+// agent remains a separate UID and must not be able to mutate it.
+func ConfigPathIsSecure(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat config %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("config %q is not a regular file", path)
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return fmt.Errorf("config %q is writable by group or other", path)
+	}
+	ownerUID, ok := configPathOwnerUID(info)
+	if !ok {
+		return nil
+	}
+	if !configOwnershipSecure(ownerUID, currentEUID()) {
+		return fmt.Errorf("config %q is owned by uid %d, not root or the invoking user", path, ownerUID)
+	}
+	return nil
+}
+
+func configOwnershipSecure(ownerUID, euid int) bool {
+	return ownerUID == 0 || ownerUID == euid || configPathOwnerTrusted(ownerUID)
+}
+
 // DiscoverConfigPath returns the first config file pipelock would naturally
 // look at, or empty string if none of the candidates exist. Search order
 // mirrors the systemd unit and CLI convention:
@@ -42,7 +72,16 @@ func DiscoverConfigPath() string {
 	return discoverConfigPath("/etc/pipelock/pipelock.yaml")
 }
 
-func discoverConfigPath(systemPath string) string {
+// DiscoverConfigPathStrict returns the first secure config file pipelock would
+// naturally look at. Unlike DiscoverConfigPath, candidate files that exist but
+// are non-regular, unreadable, or unsafe are returned as errors instead of
+// being silently skipped. Use this for security-sensitive commands where
+// falling back to defaults would hide an unsafe operator config.
+func DiscoverConfigPathStrict() (string, error) {
+	return discoverConfigPathStrict("/etc/pipelock/pipelock.yaml")
+}
+
+func configPathCandidates(systemPath string) []string {
 	candidates := []string{}
 
 	if env := os.Getenv("PIPELOCK_CONFIG"); env != "" {
@@ -57,16 +96,43 @@ func discoverConfigPath(systemPath string) string {
 	if systemPath != "" {
 		candidates = append(candidates, systemPath)
 	}
+	return candidates
+}
 
-	for _, c := range candidates {
+func discoverConfigPath(systemPath string) string {
+	for _, c := range configPathCandidates(systemPath) {
 		clean, err := filepath.Abs(filepath.Clean(c))
 		if err != nil {
 			continue
 		}
 		info, err := os.Stat(clean)
-		if err == nil && info.Mode().IsRegular() {
+		if err == nil && info.Mode().IsRegular() && ConfigPathIsSecure(clean) == nil {
 			return clean
 		}
 	}
 	return ""
+}
+
+func discoverConfigPathStrict(systemPath string) (string, error) {
+	for _, c := range configPathCandidates(systemPath) {
+		clean, err := filepath.Abs(filepath.Clean(c))
+		if err != nil {
+			return "", fmt.Errorf("resolving config path %q: %w", c, err)
+		}
+		info, err := os.Stat(clean)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", fmt.Errorf("stat config %q: %w", clean, err)
+		}
+		if !info.Mode().IsRegular() {
+			return "", fmt.Errorf("config %q is not a regular file", clean)
+		}
+		if err := ConfigPathIsSecure(clean); err != nil {
+			return "", err
+		}
+		return clean, nil
+	}
+	return "", nil
 }

--- a/internal/cliutil/config_security_other.go
+++ b/internal/cliutil/config_security_other.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !unix
+
+package cliutil
+
+import "os"
+
+func configPathOwnerUID(_ os.FileInfo) (int, bool) {
+	return 0, false
+}
+
+func currentEUID() int {
+	return 0
+}
+
+func configPathOwnerTrusted(_ int) bool {
+	return false
+}

--- a/internal/cliutil/config_security_unix.go
+++ b/internal/cliutil/config_security_unix.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package cliutil
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+func configPathOwnerUID(info os.FileInfo) (int, bool) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return int(st.Uid), true
+}
+
+func currentEUID() int {
+	return os.Geteuid()
+}
+
+func configPathOwnerTrusted(ownerUID int) bool {
+	u, err := user.LookupId(strconv.Itoa(ownerUID))
+	if err != nil {
+		return false
+	}
+	return u.Username == "pipelock-proxy"
+}

--- a/internal/cliutil/config_test.go
+++ b/internal/cliutil/config_test.go
@@ -86,6 +86,50 @@ func TestDiscoverConfigPath_XDGFallback(t *testing.T) {
 	}
 }
 
+func TestDiscoverConfigPath_ExportedWrapper(t *testing.T) {
+	xdg := t.TempDir()
+	dir := filepath.Join(xdg, "pipelock")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+
+	if got := DiscoverConfigPath(); got != cfg {
+		t.Fatalf("DiscoverConfigPath() = %q, want %q", got, cfg)
+	}
+}
+
+func TestDiscoverConfigPathStrict_ExportedWrapper(t *testing.T) {
+	xdg := t.TempDir()
+	dir := filepath.Join(xdg, "pipelock")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+
+	got, err := DiscoverConfigPathStrict()
+	if err != nil {
+		t.Fatalf("DiscoverConfigPathStrict: %v", err)
+	}
+	if got != cfg {
+		t.Fatalf("DiscoverConfigPathStrict() = %q, want %q", got, cfg)
+	}
+}
+
 // TestDiscoverConfigPath_HomeFallback exercises the legacy ~/.config branch.
 func TestDiscoverConfigPath_HomeFallback(t *testing.T) {
 	home := t.TempDir()

--- a/internal/cliutil/config_test.go
+++ b/internal/cliutil/config_test.go
@@ -252,6 +252,39 @@ func TestDiscoverConfigPathStrict_UnsafeCandidateErrors(t *testing.T) {
 	}
 }
 
+func TestDiscoverConfigPathStrict_NonRegularCandidateErrors(t *testing.T) {
+	xdg := t.TempDir()
+	xdgDir := filepath.Join(xdg, "pipelock")
+	if err := os.MkdirAll(xdgDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(xdgDir, "pipelock.yaml"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	home := t.TempDir()
+	homeDir := filepath.Join(home, ".config", "pipelock")
+	if err := os.MkdirAll(homeDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	homeCfg := filepath.Join(homeDir, "pipelock.yaml")
+	if err := os.WriteFile(homeCfg, []byte("mode: permissive\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", home)
+
+	got, err := discoverConfigPathStrict(filepath.Join(t.TempDir(), "system.yaml"))
+	if err == nil {
+		t.Fatal("expected non-regular higher-priority candidate to error")
+	}
+	if got != "" {
+		t.Fatalf("strict discovery should not fall through after non-regular candidate, got %q", got)
+	}
+}
+
 func TestConfigPathIsSecure_OwnUserAccepted(t *testing.T) {
 	cfg := filepath.Join(t.TempDir(), "pipelock.yaml")
 	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {

--- a/internal/cliutil/config_test.go
+++ b/internal/cliutil/config_test.go
@@ -5,7 +5,9 @@ package cliutil
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -140,5 +142,142 @@ func TestDiscoverConfigPath_NonRegularRejected(t *testing.T) {
 	got := discoverConfigPath(filepath.Join(t.TempDir(), "system.yaml"))
 	if got != "" {
 		t.Errorf("non-regular candidate must not be returned, got %q", got)
+	}
+}
+
+func TestDiscoverConfigPath_GroupOrWorldWritableRejected(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "pipelock")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	groupWritable := os.FileMode(0o620)
+	if err := os.Chmod(cfg, groupWritable); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", home)
+
+	got := discoverConfigPath(filepath.Join(t.TempDir(), "system.yaml"))
+	if got != "" {
+		t.Errorf("group-writable candidate must not be returned, got %q", got)
+	}
+}
+
+func TestDiscoverConfigPathStrict_UnsafeCandidateErrors(t *testing.T) {
+	xdg := t.TempDir()
+	xdgDir := filepath.Join(xdg, "pipelock")
+	if err := os.MkdirAll(xdgDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	unsafeCfg := filepath.Join(xdgDir, "pipelock.yaml")
+	if err := os.WriteFile(unsafeCfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unsafeMode := os.FileMode(0o600 | 0o020)
+	if err := os.Chmod(unsafeCfg, unsafeMode); err != nil {
+		t.Fatal(err)
+	}
+
+	home := t.TempDir()
+	homeDir := filepath.Join(home, ".config", "pipelock")
+	if err := os.MkdirAll(homeDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	homeCfg := filepath.Join(homeDir, "pipelock.yaml")
+	if err := os.WriteFile(homeCfg, []byte("mode: permissive\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", home)
+
+	got, err := discoverConfigPathStrict(filepath.Join(t.TempDir(), "system.yaml"))
+	if err == nil {
+		t.Fatal("expected unsafe higher-priority candidate to error")
+	}
+	if got != "" {
+		t.Fatalf("strict discovery should not fall through after unsafe candidate, got %q", got)
+	}
+}
+
+func TestConfigPathIsSecure_OwnUserAccepted(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ConfigPathIsSecure(cfg); err != nil {
+		t.Fatalf("own-user 0600 config should be secure: %v", err)
+	}
+}
+
+func TestConfigPathIsSecure_GroupOrWorldWritableRejected(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, mode := range []os.FileMode{0o620, 0o602} {
+		if err := os.Chmod(cfg, mode); err != nil {
+			t.Fatal(err)
+		}
+		if err := ConfigPathIsSecure(cfg); err == nil {
+			t.Fatalf("mode %04o config should be rejected", mode)
+		}
+	}
+}
+
+func TestConfigPathIsSecure_MissingRejected(t *testing.T) {
+	if err := ConfigPathIsSecure(filepath.Join(t.TempDir(), "missing.yaml")); err == nil {
+		t.Fatal("missing config should be rejected")
+	}
+}
+
+func TestConfigOwnershipSecure(t *testing.T) {
+	euid := currentEUID()
+	otherUID := euid + 1
+	if otherUID == 0 {
+		otherUID = 12345
+	}
+
+	tests := []struct {
+		name     string
+		ownerUID int
+		want     bool
+	}{
+		{name: "root owner accepted", ownerUID: 0, want: true},
+		{name: "effective user owner accepted", ownerUID: euid, want: true},
+		{name: "other user owner rejected", ownerUID: otherUID, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := configOwnershipSecure(tc.ownerUID, euid)
+			if got != tc.want {
+				t.Fatalf("configOwnershipSecure(%d, %d) = %v, want %v", tc.ownerUID, euid, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConfigOwnershipSecure_PipelockProxyAcceptedWhenPresent(t *testing.T) {
+	u, err := user.Lookup("pipelock-proxy")
+	if err != nil {
+		t.Skip("pipelock-proxy user is not present")
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		t.Fatalf("parse pipelock-proxy uid %q: %v", u.Uid, err)
+	}
+	if !configOwnershipSecure(uid, currentEUID()) {
+		t.Fatalf("pipelock-proxy-owned config should be trusted")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5142,6 +5142,19 @@ func TestValidate_SecretsFileNotFound(t *testing.T) {
 	}
 }
 
+func TestValidate_SecretsFileNonRegularRejected(t *testing.T) {
+	cfg := Defaults()
+	cfg.DLP.SecretsFile = t.TempDir()
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for non-regular secrets file")
+	}
+	if !strings.Contains(err.Error(), "must be a regular file") {
+		t.Errorf("error should mention regular file requirement, got: %v", err)
+	}
+}
+
 func TestValidate_SecretsFileWorldReadable(t *testing.T) {
 	dir := t.TempDir()
 	secretsPath := filepath.Join(dir, "secrets.txt")

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -21,9 +21,26 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type loadOptions struct {
+	resolveLicense bool
+}
+
 // Load reads, parses, defaults, and validates a Pipelock config file.
 // If path is "-", the config is read from stdin.
 func Load(path string) (*Config, error) {
+	return load(path, loadOptions{resolveLicense: true})
+}
+
+// LoadForRules reads config for rules subcommands. It preserves strict YAML
+// parsing, defaults, path resolution, and validation, but intentionally skips
+// license_file resolution because rules operations only need rules/trusted-key
+// policy and may run as an unprivileged operator while runtime license material
+// is service-owned.
+func LoadForRules(path string) (*Config, error) {
+	return load(path, loadOptions{resolveLicense: false})
+}
+
+func load(path string, opts loadOptions) (*Config, error) {
 	var data []byte
 	var err error
 	if path == "-" {
@@ -69,19 +86,35 @@ func Load(path string) (*Config, error) {
 
 	cfg.ApplyDefaults()
 
-	// Resolve license key from multiple sources. Priority:
-	// - PIPELOCK_LICENSE_KEY env var (containers, CI)
-	// - license_file config field (file path, read at startup)
-	// - license_key config field (inline YAML, lowest priority)
-	if err := cfg.resolveLicenseKey(filepath.Dir(path)); err != nil {
-		return nil, fmt.Errorf("license key: %w", err)
-	}
-	cfg.resolveLicenseIntermediate(filepath.Dir(path))
-	cfg.resolveLicenseRuntimeVerification()
+	if opts.resolveLicense {
+		// Resolve license key from multiple sources. Priority:
+		// - PIPELOCK_LICENSE_KEY env var (containers, CI)
+		// - license_file config field (file path, read at startup)
+		// - license_key config field (inline YAML, lowest priority)
+		if err := cfg.resolveLicenseKey(filepath.Dir(path)); err != nil {
+			return nil, fmt.Errorf("license key: %w", err)
+		}
+		cfg.resolveLicenseIntermediate(filepath.Dir(path))
+		cfg.resolveLicenseRuntimeVerification()
 
-	// Soft-gate premium features: disable agents section if no license key.
-	if EnforceLicenseGateFunc != nil {
-		EnforceLicenseGateFunc(cfg)
+		// Soft-gate premium features: disable agents section if no license key.
+		if EnforceLicenseGateFunc != nil {
+			EnforceLicenseGateFunc(cfg)
+		}
+	} else {
+		cfg.LicenseKey = ""
+		cfg.LicenseFile = ""
+		cfg.LicenseCRLFile = ""
+		cfg.LicenseIntermediateFile = ""
+		cfg.LicenseIntermediateCert = nil
+		cfg.LicenseIntermediateLoadError = ""
+		cfg.LicenseRequireIntermediate = nil
+		cfg.LicenseRequireIntermediateResolved = false
+		cfg.LicenseRequireIntermediateEnvError = ""
+		cfg.LicenseCRLMaxAge = ""
+		cfg.LicenseCRLMaxAgeResolved = license.DefaultCRLMaxAge
+		cfg.LicenseCRLMaxAgeError = ""
+		cfg.LicensePublicKey = ""
 	}
 
 	// Resolve relative secrets_file path relative to config file directory.
@@ -126,8 +159,14 @@ func Load(path string) (*Config, error) {
 		}
 	}
 
-	if err := cfg.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid config: %w", err)
+	if opts.resolveLicense {
+		if err := cfg.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid config: %w", err)
+		}
+	} else {
+		if err := cfg.validateForRules(); err != nil {
+			return nil, fmt.Errorf("invalid rules config: %w", err)
+		}
 	}
 	cfg.canonicalHashCache = &canonicalHashCacheHolder{}
 	cfg.canonicalRedactionKeyCache = &canonicalHashCacheHolder{}
@@ -143,6 +182,23 @@ func Load(path string) (*Config, error) {
 	_ = cfg.CanonicalPolicyHash()
 
 	return cfg, nil
+}
+
+func (c *Config) validateForRules() error {
+	if err := c.validateMode(); err != nil {
+		return err
+	}
+	if err := c.validateDLPPatternConfig(); err != nil {
+		return err
+	}
+	var warnings []Warning
+	if err := c.validateResponseScanning(&warnings); err != nil {
+		return err
+	}
+	if err := c.validateRules(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func readStableRegularFile(path string) ([]byte, error) {

--- a/internal/config/load_rules_test.go
+++ b/internal/config/load_rules_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadForRules_SkipsRuntimeOnlyFiles(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	cfgYAML := `version: 1
+mode: balanced
+license_file: missing-license.token
+dlp:
+  secrets_file: /root/not-readable/pipelock-secrets.env
+tls_interception:
+  enabled: true
+  ca_cert: /root/not-readable/ca.pem
+  ca_key: /root/not-readable/ca-key.pem
+`
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRules(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadForRules should skip runtime-only files: %v", err)
+	}
+	if cfg.LicenseFile != "" || cfg.LicenseKey != "" {
+		t.Fatalf("LoadForRules should scrub license fields, got license_file=%q license_key=%q", cfg.LicenseFile, cfg.LicenseKey)
+	}
+}
+
+func TestLoadForRules_ValidatesRulesFacingConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "rules",
+			yaml: `version: 1
+mode: balanced
+rules:
+  min_confidence: impossible
+`,
+			wantErr: "min_confidence",
+		},
+		{
+			name: "dlp",
+			yaml: `version: 1
+mode: balanced
+dlp:
+  patterns:
+    - name: bad
+      regex: "["
+`,
+			wantErr: "DLP pattern",
+		},
+		{
+			name: "response scanning",
+			yaml: `version: 1
+mode: balanced
+response_scanning:
+  exempt_domains:
+    - "*.com"
+`,
+			wantErr: "wildcard must target a concrete domain",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+			if err := os.WriteFile(cfgPath, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := LoadForRules(cfgPath)
+			if err == nil {
+				t.Fatal("expected invalid rules-facing config to fail")
+			}
+			if !strings.Contains(err.Error(), "invalid rules config") || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected %q validation error, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/config/reload_unix_test.go
+++ b/internal/config/reload_unix_test.go
@@ -7,6 +7,8 @@ package config
 
 import (
 	"context"
+	"os"
+	"os/signal"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -39,6 +41,13 @@ func signalUntilReload(t *testing.T, r *Reloader, mode string) *Config {
 }
 
 func TestReloader_SIGHUPReload(t *testing.T) {
+	// Keep SIGHUP caught for the whole test. The test sends a real process
+	// signal; if delivery races with reloader signal cleanup, the default
+	// SIGHUP action can terminate the test binary instead of failing the test.
+	guard := make(chan os.Signal, 1)
+	signal.Notify(guard, syscall.SIGHUP)
+	defer signal.Stop(guard)
+
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "pipelock.yaml")
 	writeTestConfig(t, cfgPath, "balanced")

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -662,6 +662,9 @@ func (c *Config) validateDLP() error {
 		if err != nil {
 			return fmt.Errorf("secrets_file %q: %w", c.DLP.SecretsFile, err)
 		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("secrets_file %q must be a regular file", c.DLP.SecretsFile)
+		}
 		// Reject group-write/execute and all other access. Group-read
 		// allowed for k8s Secret volume compatibility.
 		if secperm.TooPermissive(info.Mode().Perm(), 0o037) {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -652,6 +652,26 @@ func (c *Config) validateLogging() error {
 }
 
 func (c *Config) validateDLP() error {
+	if err := c.validateDLPPatternConfig(); err != nil {
+		return err
+	}
+
+	// Validate secrets_file if configured
+	if c.DLP.SecretsFile != "" {
+		info, err := os.Stat(c.DLP.SecretsFile)
+		if err != nil {
+			return fmt.Errorf("secrets_file %q: %w", c.DLP.SecretsFile, err)
+		}
+		// Reject group-write/execute and all other access. Group-read
+		// allowed for k8s Secret volume compatibility.
+		if secperm.TooPermissive(info.Mode().Perm(), 0o037) {
+			return fmt.Errorf("secrets_file %q has unsafe permissions (mode %04o): restrict to 0600 or 0640", c.DLP.SecretsFile, info.Mode().Perm())
+		}
+	}
+	return nil
+}
+
+func (c *Config) validateDLPPatternConfig() error {
 	// Reject unsupported DLP action fields. Request-side DLP redaction (strip)
 	// is not implemented - DLP matches follow the transport-level action
 	// (request_body_scanning.action, mcp_input_scanning.action, or enforce mode).
@@ -694,19 +714,6 @@ func (c *Config) validateDLP() error {
 
 	if err := validateCanaryTokens(c); err != nil {
 		return fmt.Errorf("canary_tokens: %w", err)
-	}
-
-	// Validate secrets_file if configured
-	if c.DLP.SecretsFile != "" {
-		info, err := os.Stat(c.DLP.SecretsFile)
-		if err != nil {
-			return fmt.Errorf("secrets_file %q: %w", c.DLP.SecretsFile, err)
-		}
-		// Reject group-write/execute and all other access. Group-read
-		// allowed for k8s Secret volume compatibility.
-		if secperm.TooPermissive(info.Mode().Perm(), 0o037) {
-			return fmt.Errorf("secrets_file %q has unsafe permissions (mode %04o): restrict to 0600 or 0640", c.DLP.SecretsFile, info.Mode().Perm())
-		}
 	}
 	return nil
 }

--- a/internal/gitprotect/diffscan.go
+++ b/internal/gitprotect/diffscan.go
@@ -110,7 +110,12 @@ func parseDiffStructured(diffText string) diffParseResult {
 
 		if strings.HasPrefix(line, "old mode ") ||
 			strings.HasPrefix(line, "new mode ") ||
+			strings.HasPrefix(line, "new file mode ") ||
+			strings.HasPrefix(line, "deleted file mode ") ||
 			strings.HasPrefix(line, "similarity index ") ||
+			strings.HasPrefix(line, "dissimilarity index ") ||
+			strings.HasPrefix(line, "copy from ") ||
+			strings.HasPrefix(line, "copy to ") ||
 			strings.HasPrefix(line, "rename from ") ||
 			strings.HasPrefix(line, "rename to ") ||
 			strings.HasPrefix(line, "index ") ||
@@ -156,6 +161,11 @@ func parseDiffStructured(diffText string) diffParseResult {
 			lineNum, inHunk = parseHunkNewStartOK(line)
 			if inHunk {
 				result.hasRecognizableStructure = true
+			} else {
+				result.orphans = append(result.orphans, addedLine{
+					lineNum: inputLineNum,
+					content: line,
+				})
 			}
 			continue
 		}
@@ -178,9 +188,17 @@ func parseDiffStructured(diffText string) diffParseResult {
 		} else if strings.HasPrefix(line, "-") {
 			// Removed lines don't increment the new-file line counter
 			continue
-		} else if inHunk {
+		} else if strings.HasPrefix(line, `\ `) {
+			// "\ No newline at end of file" is diff metadata, not content.
+			continue
+		} else if inHunk && (line == "" || strings.HasPrefix(line, " ")) {
 			// Context lines increment the counter
 			lineNum = nextDiffLineNumber(lineNum)
+		} else if strings.TrimSpace(line) != "" {
+			result.orphans = append(result.orphans, addedLine{
+				lineNum: inputLineNum,
+				content: strings.TrimPrefix(line, "+"),
+			})
 		}
 	}
 
@@ -317,6 +335,9 @@ var (
 	ErrUnsupportedBinaryPatch = fmt.Errorf("unsupported binary patch in diff")
 	// ErrDiffTooLarge is returned when input exceeds the bounded scan size.
 	ErrDiffTooLarge = fmt.Errorf("diff exceeds maximum size")
+	// ErrUnattributedAddedLines is returned when input contains content that
+	// cannot be attributed to a valid unified diff hunk.
+	ErrUnattributedAddedLines = fmt.Errorf("unverifiable input: content outside unified diff hunks")
 )
 
 // ScanDiffResult holds findings and suppressed findings from a diff scan.
@@ -339,26 +360,36 @@ func ScanDiff(diffText string, patterns []CompiledDLPPattern) (ScanDiffResult, e
 	if len(diffText) > MaxDiffBytes {
 		return ScanDiffResult{}, fmt.Errorf("%w of %d bytes", ErrDiffTooLarge, MaxDiffBytes)
 	}
+	if strings.TrimSpace(diffText) == "" {
+		return ScanDiffResult{}, ErrNoDiffHeaders
+	}
 
 	parsed := parseDiffStructured(diffText)
 	if parsed.hasBinaryPatch {
 		return ScanDiffResult{}, ErrUnsupportedBinaryPatch
 	}
 
-	if !parsed.hasRecognizableStructure && strings.TrimSpace(diffText) != "" {
+	if !parsed.hasRecognizableStructure {
 		if len(patterns) == 0 {
 			return ScanDiffResult{}, ErrNoDiffHeaders
 		}
 		result := scanAddedLines(map[string][]addedLine{
 			orphanDiffFile: rawInputLines(diffText),
 		}, patterns)
-		if len(result.Findings) > 0 || len(result.Suppressed) > 0 {
+		if len(result.Findings) > 0 {
 			return result, nil
 		}
 		return ScanDiffResult{}, ErrNoDiffHeaders
 	}
 
-	if (len(parsed.attributed) == 0 && len(parsed.orphans) == 0) || len(patterns) == 0 {
+	if len(parsed.orphans) > 0 && len(patterns) == 0 {
+		return ScanDiffResult{}, ErrUnattributedAddedLines
+	}
+
+	if len(parsed.attributed) == 0 && len(parsed.orphans) == 0 {
+		return ScanDiffResult{}, nil
+	}
+	if len(patterns) == 0 {
 		return ScanDiffResult{}, nil
 	}
 
@@ -369,7 +400,14 @@ func ScanDiff(diffText string, patterns []CompiledDLPPattern) (ScanDiffResult, e
 	if len(parsed.orphans) > 0 {
 		scanInput[orphanDiffFile] = parsed.orphans
 	}
-	return scanAddedLines(scanInput, patterns), nil
+	result := scanAddedLines(scanInput, patterns)
+	if len(parsed.orphans) > 0 {
+		if len(result.Findings) > 0 {
+			return result, nil
+		}
+		return result, ErrUnattributedAddedLines
+	}
+	return result, nil
 }
 
 func rawInputLines(diffText string) []addedLine {

--- a/internal/gitprotect/diffscan.go
+++ b/internal/gitprotect/diffscan.go
@@ -26,6 +26,14 @@ var (
 	maxDiffLineNumber = int(^uint(0)>>1) - 1
 )
 
+// Diff input limits keep git gates from truncating and silently passing
+// unverifiable input.
+const (
+	MaxDiffBytes = 100 * 1024 * 1024
+
+	orphanDiffFile = "(unattributed diff input)"
+)
+
 // Finding represents a secret detected in a git diff.
 type Finding struct {
 	File     string `json:"file"`
@@ -41,55 +49,128 @@ type addedLine struct {
 	content string
 }
 
-// parseDiff extracts added lines from unified diff output.
+type diffParseResult struct {
+	attributed               map[string][]addedLine
+	orphans                  []addedLine
+	hasRecognizableStructure bool
+	hasBinaryPatch           bool
+}
+
+// parseDiff extracts attributed added lines from unified diff output.
+//
+// Use parseDiffStructured for security decisions: this compatibility wrapper is
+// kept for existing unit tests and fuzz coverage that only care about normal
+// attributed lines.
+func parseDiff(diffText string) map[string][]addedLine {
+	return parseDiffStructured(diffText).attributed
+}
+
+// parseDiffStructured extracts added lines from unified diff output.
 // It tracks the current file from "+++ b/filename" or "+++ filename" lines
 // (supporting both standard and --no-prefix diffs) and line numbers from
-// "@@ -X,Y +Z,W @@" hunk headers. Only lines starting with "+" (but not
-// "+++") are captured. CRLF line endings are normalized before parsing.
-func parseDiff(diffText string) map[string][]addedLine {
+// "@@ -X,Y +Z,W @@" hunk headers.
+//
+// Only added content lines are scanned by callers. If a +line cannot be
+// attributed to a valid file header and active hunk, it is preserved as an
+// orphan candidate so malformed partial diffs fail closed on secrets without
+// scanning unchanged context.
+func parseDiffStructured(diffText string) diffParseResult {
 	// Normalize \r\n to \n to handle Windows-style line endings.
 	diffText = strings.ReplaceAll(diffText, "\r\n", "\n")
 
-	result := make(map[string][]addedLine)
+	result := diffParseResult{attributed: make(map[string][]addedLine)}
 	lines := strings.Split(diffText, "\n")
 
 	var currentFile string
 	var lineNum int
+	var inHunk bool
 
-	for _, line := range lines {
+	for i, line := range lines {
+		inputLineNum := i + 1
+
+		if line == "GIT binary patch" {
+			result.hasRecognizableStructure = true
+			result.hasBinaryPatch = true
+			inHunk = false
+			continue
+		}
+
+		if strings.HasPrefix(line, "Binary files ") {
+			result.hasRecognizableStructure = true
+			inHunk = false
+			continue
+		}
+
+		if strings.HasPrefix(line, "diff --git ") {
+			result.hasRecognizableStructure = true
+			currentFile = ""
+			inHunk = false
+			continue
+		}
+
+		if strings.HasPrefix(line, "old mode ") ||
+			strings.HasPrefix(line, "new mode ") ||
+			strings.HasPrefix(line, "similarity index ") ||
+			strings.HasPrefix(line, "rename from ") ||
+			strings.HasPrefix(line, "rename to ") ||
+			strings.HasPrefix(line, "index ") ||
+			strings.HasPrefix(line, "--- ") {
+			result.hasRecognizableStructure = true
+			inHunk = false
+			continue
+		}
+
 		// Track current file from "+++ b/filename" header (standard prefix)
 		if strings.HasPrefix(line, "+++ b/") {
 			currentFile = line[6:] // strip "+++ b/"
+			result.hasRecognizableStructure = true
+			inHunk = false
 			continue
 		}
 
 		// Also handle --no-prefix diffs: "+++ filename" (no b/ prefix).
 		// Must come after the "+++ b/" check to avoid stripping "b/" from paths.
-		if strings.HasPrefix(line, "+++ ") && !strings.HasPrefix(line, "+++ /dev/null") {
-			currentFile = line[4:] // strip "+++ "
+		if strings.HasPrefix(line, "+++ ") {
+			header := strings.TrimSpace(line[4:])
+			if header == "" || header == "/dev/null" {
+				currentFile = ""
+				inHunk = false
+				continue
+			}
+			currentFile = header
+			result.hasRecognizableStructure = true
+			inHunk = false
 			continue
 		}
 
 		// Skip other diff headers
-		if strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "diff ") ||
-			strings.HasPrefix(line, "index ") {
+		if strings.HasPrefix(line, "diff ") {
+			result.hasRecognizableStructure = true
+			currentFile = ""
+			inHunk = false
 			continue
 		}
 
 		// Parse hunk header for line numbers: @@ -X,Y +Z,W @@
 		if strings.HasPrefix(line, "@@") {
-			lineNum = parseHunkNewStart(line)
-			continue
-		}
-
-		if currentFile == "" {
+			lineNum, inHunk = parseHunkNewStartOK(line)
+			if inHunk {
+				result.hasRecognizableStructure = true
+			}
 			continue
 		}
 
 		// Added lines start with "+" (but not "+++")
 		if strings.HasPrefix(line, "+") {
 			content := line[1:] // strip leading "+"
-			result[currentFile] = append(result[currentFile], addedLine{
+			if currentFile == "" || !inHunk {
+				result.orphans = append(result.orphans, addedLine{
+					lineNum: inputLineNum,
+					content: content,
+				})
+				continue
+			}
+			result.attributed[currentFile] = append(result.attributed[currentFile], addedLine{
 				lineNum: lineNum,
 				content: content,
 			})
@@ -97,7 +178,7 @@ func parseDiff(diffText string) map[string][]addedLine {
 		} else if strings.HasPrefix(line, "-") {
 			// Removed lines don't increment the new-file line counter
 			continue
-		} else {
+		} else if inHunk {
 			// Context lines increment the counter
 			lineNum = nextDiffLineNumber(lineNum)
 		}
@@ -116,10 +197,18 @@ func nextDiffLineNumber(n int) int {
 // parseHunkNewStart extracts the starting line number of the new file
 // from a hunk header like "@@ -10,5 +20,8 @@" (returns 20).
 func parseHunkNewStart(hunkLine string) int {
+	n, ok := parseHunkNewStartOK(hunkLine)
+	if !ok {
+		return 1
+	}
+	return n
+}
+
+func parseHunkNewStartOK(hunkLine string) (int, bool) {
 	// Format: @@ -old_start[,old_count] +new_start[,new_count] @@
 	idx := strings.Index(hunkLine, "+")
 	if idx < 0 {
-		return 1
+		return 1, false
 	}
 
 	rest := hunkLine[idx+1:]
@@ -131,9 +220,9 @@ func parseHunkNewStart(hunkLine string) int {
 
 	n, err := strconv.Atoi(rest[:end])
 	if err != nil || n < 1 || n > maxDiffLineNumber {
-		return 1
+		return 1, false
 	}
-	return n
+	return n, true
 }
 
 // CompiledDLPPattern is a pre-compiled DLP regex for scanning diffs.
@@ -221,8 +310,14 @@ func (cp *CompiledDLPPattern) regexMatches(text string) bool {
 	return false
 }
 
-// ErrNoDiffHeaders is returned when input contains no unified diff file headers.
-var ErrNoDiffHeaders = fmt.Errorf("no unified diff file headers found (expected '+++ b/filename' or '+++ filename')")
+var (
+	// ErrNoDiffHeaders is returned when input contains no recognizable unified diff structure.
+	ErrNoDiffHeaders = fmt.Errorf("unverifiable input: no recognizable unified diff structure")
+	// ErrUnsupportedBinaryPatch is returned when input contains a binary patch the line scanner cannot inspect.
+	ErrUnsupportedBinaryPatch = fmt.Errorf("unsupported binary patch in diff")
+	// ErrDiffTooLarge is returned when input exceeds the bounded scan size.
+	ErrDiffTooLarge = fmt.Errorf("diff exceeds maximum size")
+)
 
 // ScanDiffResult holds findings and suppressed findings from a diff scan.
 type ScanDiffResult struct {
@@ -239,20 +334,61 @@ type ScanDiffResult struct {
 // Returns ErrNoDiffHeaders if the input contains no valid diff file headers,
 // indicating the caller may have passed non-diff content.
 func ScanDiff(diffText string, patterns []CompiledDLPPattern) (ScanDiffResult, error) {
-	addedLines := parseDiff(diffText)
-
-	// Check if input had content but no diff headers - likely not a diff.
-	if len(addedLines) == 0 && len(strings.TrimSpace(diffText)) > 0 && len(patterns) > 0 {
-		// Only error if the input has content - empty input is fine.
-		if !strings.Contains(diffText, "+++ ") {
-			return ScanDiffResult{}, ErrNoDiffHeaders
-		}
+	// TODO: scan changed blob contents by object ID and add per-hunk window
+	// scanning so split-token additions cannot evade line-local matching.
+	if len(diffText) > MaxDiffBytes {
+		return ScanDiffResult{}, fmt.Errorf("%w of %d bytes", ErrDiffTooLarge, MaxDiffBytes)
 	}
 
-	if len(addedLines) == 0 || len(patterns) == 0 {
+	parsed := parseDiffStructured(diffText)
+	if parsed.hasBinaryPatch {
+		return ScanDiffResult{}, ErrUnsupportedBinaryPatch
+	}
+
+	if !parsed.hasRecognizableStructure && strings.TrimSpace(diffText) != "" {
+		if len(patterns) == 0 {
+			return ScanDiffResult{}, ErrNoDiffHeaders
+		}
+		result := scanAddedLines(map[string][]addedLine{
+			orphanDiffFile: rawInputLines(diffText),
+		}, patterns)
+		if len(result.Findings) > 0 || len(result.Suppressed) > 0 {
+			return result, nil
+		}
+		return ScanDiffResult{}, ErrNoDiffHeaders
+	}
+
+	if (len(parsed.attributed) == 0 && len(parsed.orphans) == 0) || len(patterns) == 0 {
 		return ScanDiffResult{}, nil
 	}
 
+	scanInput := make(map[string][]addedLine, len(parsed.attributed)+1)
+	for file, lines := range parsed.attributed {
+		scanInput[file] = lines
+	}
+	if len(parsed.orphans) > 0 {
+		scanInput[orphanDiffFile] = parsed.orphans
+	}
+	return scanAddedLines(scanInput, patterns), nil
+}
+
+func rawInputLines(diffText string) []addedLine {
+	diffText = strings.ReplaceAll(diffText, "\r\n", "\n")
+	lines := strings.Split(diffText, "\n")
+	result := make([]addedLine, 0, len(lines))
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		result = append(result, addedLine{
+			lineNum: i + 1,
+			content: strings.TrimPrefix(line, "+"),
+		})
+	}
+	return result
+}
+
+func scanAddedLines(addedLines map[string][]addedLine, patterns []CompiledDLPPattern) ScanDiffResult {
 	var findings []Finding
 	var suppressed []Finding
 	var matcher *redact.Matcher
@@ -319,7 +455,7 @@ func ScanDiff(diffText string, patterns []CompiledDLPPattern) (ScanDiffResult, e
 	sortFindings(findings)
 	sortFindings(suppressed)
 
-	return ScanDiffResult{Findings: findings, Suppressed: suppressed}, nil
+	return ScanDiffResult{Findings: findings, Suppressed: suppressed}
 }
 
 func replaceGitProtectMatches(input string, matches []redact.Match) string {

--- a/internal/gitprotect/diffscan_test.go
+++ b/internal/gitprotect/diffscan_test.go
@@ -336,10 +336,9 @@ func TestScanDiff_NoFindings(t *testing.T) {
 }
 
 func TestScanDiff_EmptyDiff(t *testing.T) {
-	result, _ := ScanDiff("", testPatterns())
-	findings := result.Findings
-	if findings != nil {
-		t.Fatalf("expected nil findings, got %d", len(findings))
+	_, err := ScanDiff("", testPatterns())
+	if !errors.Is(err, ErrNoDiffHeaders) {
+		t.Fatalf("expected %v, got %v", ErrNoDiffHeaders, err)
 	}
 }
 
@@ -350,6 +349,28 @@ func TestScanDiff_EmptyPatterns(t *testing.T) {
 	findings := result.Findings
 	if findings != nil {
 		t.Fatalf("expected nil findings, got %d", len(findings))
+	}
+}
+
+func TestScanDiff_FailsClosedOnUnattributedCleanInput(t *testing.T) {
+	diff := "+not_a_secret=true\n" +
+		"diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -0,0 +1 @@\n+package x\n"
+	_, err := ScanDiff(diff, testPatterns())
+	if !errors.Is(err, ErrUnattributedAddedLines) {
+		t.Fatalf("expected %v, got %v", ErrUnattributedAddedLines, err)
+	}
+}
+
+func TestScanDiff_FailsClosedWhenInlineSuppressionMasksUnattributedSecret(t *testing.T) {
+	key := fakeKey("EXAMPLE")
+	diff := "+provider_token=" + key + " // pipelock:ignore\n" +
+		"diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -0,0 +1 @@\n+package x\n"
+	result, err := ScanDiff(diff, testPatterns())
+	if !errors.Is(err, ErrUnattributedAddedLines) {
+		t.Fatalf("expected %v, got %v", ErrUnattributedAddedLines, err)
+	}
+	if len(result.Suppressed) != 1 {
+		t.Fatalf("expected suppressed finding to be retained, got %+v", result.Suppressed)
 	}
 }
 
@@ -533,39 +554,43 @@ func TestScanDiff_FailClosedMalformedAddedContent(t *testing.T) {
 	}{
 		{
 			name: "bare added secret no headers",
-			diff: "+AWS_ACCESS_KEY_ID=" + key + "\n",
+			diff: "+provider_token=" + key + "\n",
 		},
 		{
 			name: "bogus empty new-file header",
-			diff: "+++ \n+AWS_ACCESS_KEY_ID=" + key + "\n",
+			diff: "+++ \n+provider_token=" + key + "\n",
 		},
 		{
 			name: "dev null new-file header",
-			diff: "+++ /dev/null\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+			diff: "+++ /dev/null\n+provider_token=" + key + "\n",
 		},
 		{
 			name: "partial parse secret before valid section",
-			diff: "+AWS_ACCESS_KEY_ID=" + key + "\n" +
+			diff: "+provider_token=" + key + "\n" +
 				"diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -0,0 +1 @@\n+safe=true\n",
 		},
 		{
 			name: "secret in later malformed section",
 			diff: "diff --git a/safe b/safe\n--- a/safe\n+++ b/safe\n@@ -0,0 +1 @@\n+safe=true\n" +
-				"diff --git a/bad b/bad\n--- a/bad\n+++ \n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+				"diff --git a/bad b/bad\n--- a/bad\n+++ \n@@ -0,0 +1 @@\n+provider_token=" + key + "\n",
 		},
 		{
 			name: "multi file with missing header",
 			diff: "diff --git a/safe b/safe\n--- a/safe\n+++ b/safe\n@@ -0,0 +1 @@\n+safe=true\n" +
-				"diff --git a/noheader b/noheader\n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+				"diff --git a/noheader b/noheader\n@@ -0,0 +1 @@\n+provider_token=" + key + "\n",
+		},
+		{
+			name: "secret in malformed hunk line without diff marker",
+			diff: "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -0,0 +1 @@\nprovider_token=" + key + "\n",
 		},
 		{
 			name: "crlf orphan",
 			diff: "diff --git a/safe b/safe\r\n--- a/safe\r\n+++ b/safe\r\n@@ -0,0 +1 @@\r\n+safe=true\r\n" +
-				"+AWS_ACCESS_KEY_ID=" + key + "\r\n",
+				"+provider_token=" + key + "\r\n",
 		},
 		{
 			name: "non diff raw secret without plus",
-			diff: "AWS_ACCESS_KEY_ID=" + key + "\n",
+			diff: "provider_token=" + key + "\n",
 		},
 	}
 
@@ -632,11 +657,11 @@ func TestScanDiff_SecretsWithLongLinesAndBinarySummaries(t *testing.T) {
 		{
 			name: "secret in long line",
 			diff: "diff --git a/min.js b/min.js\n--- a/min.js\n+++ b/min.js\n@@ -0,0 +1 @@\n+" +
-				strings.Repeat("A", 1100*1024) + "AWS_ACCESS_KEY_ID=" + key + "\n",
+				strings.Repeat("A", 1100*1024) + "provider_token=" + key + "\n",
 		},
 		{
 			name: "secret with binary summary",
-			diff: "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n" +
+			diff: "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n@@ -0,0 +1 @@\n+provider_token=" + key + "\n" +
 				"diff --git a/x.png b/x.png\nBinary files a/x.png and b/x.png differ\n",
 		},
 	}

--- a/internal/gitprotect/diffscan_test.go
+++ b/internal/gitprotect/diffscan_test.go
@@ -525,6 +525,146 @@ func TestScanDiff_ErrNoDiffHeaders(t *testing.T) {
 	}
 }
 
+func TestScanDiff_FailClosedMalformedAddedContent(t *testing.T) {
+	key := fakeKey("EXAMPLE")
+	tests := []struct {
+		name string
+		diff string
+	}{
+		{
+			name: "bare added secret no headers",
+			diff: "+AWS_ACCESS_KEY_ID=" + key + "\n",
+		},
+		{
+			name: "bogus empty new-file header",
+			diff: "+++ \n+AWS_ACCESS_KEY_ID=" + key + "\n",
+		},
+		{
+			name: "dev null new-file header",
+			diff: "+++ /dev/null\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+		},
+		{
+			name: "partial parse secret before valid section",
+			diff: "+AWS_ACCESS_KEY_ID=" + key + "\n" +
+				"diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -0,0 +1 @@\n+safe=true\n",
+		},
+		{
+			name: "secret in later malformed section",
+			diff: "diff --git a/safe b/safe\n--- a/safe\n+++ b/safe\n@@ -0,0 +1 @@\n+safe=true\n" +
+				"diff --git a/bad b/bad\n--- a/bad\n+++ \n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+		},
+		{
+			name: "multi file with missing header",
+			diff: "diff --git a/safe b/safe\n--- a/safe\n+++ b/safe\n@@ -0,0 +1 @@\n+safe=true\n" +
+				"diff --git a/noheader b/noheader\n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n",
+		},
+		{
+			name: "crlf orphan",
+			diff: "diff --git a/safe b/safe\r\n--- a/safe\r\n+++ b/safe\r\n@@ -0,0 +1 @@\r\n+safe=true\r\n" +
+				"+AWS_ACCESS_KEY_ID=" + key + "\r\n",
+		},
+		{
+			name: "non diff raw secret without plus",
+			diff: "AWS_ACCESS_KEY_ID=" + key + "\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ScanDiff(tc.diff, testPatterns())
+			if err != nil {
+				t.Fatalf("ScanDiff returned error instead of findings: %v", err)
+			}
+			if len(result.Findings) == 0 {
+				t.Fatal("expected secret finding")
+			}
+		})
+	}
+}
+
+func TestScanDiff_CleanMetadataOnlyDiffs(t *testing.T) {
+	tests := []struct {
+		name string
+		diff string
+	}{
+		{
+			name: "mode only",
+			diff: "diff --git a/tool.sh b/tool.sh\nold mode 100644\nnew mode 100755\n",
+		},
+		{
+			name: "rename only",
+			diff: "diff --git a/old.txt b/new.txt\nsimilarity index 100%\nrename from old.txt\nrename to new.txt\n",
+		},
+		{
+			name: "no prefix clean",
+			diff: "diff --git main.go main.go\n--- main.go\n+++ main.go\n@@ -1,2 +1,3 @@\n package main\n+import \"fmt\"\n",
+		},
+		{
+			name: "clean text with binary summary",
+			diff: "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n@@ -1 +1,2 @@\n package main\n+const ok = true\n" +
+				"diff --git a/x.png b/x.png\nBinary files a/x.png and b/x.png differ\n",
+		},
+		{
+			name: "long clean line",
+			diff: "diff --git a/min.js b/min.js\n--- a/min.js\n+++ b/min.js\n@@ -0,0 +1 @@\n+" + strings.Repeat("A", 1100*1024) + "\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ScanDiff(tc.diff, testPatterns())
+			if err != nil {
+				t.Fatalf("ScanDiff returned error for clean metadata/text diff: %v", err)
+			}
+			if len(result.Findings) != 0 {
+				t.Fatalf("expected no findings, got %+v", result.Findings)
+			}
+		})
+	}
+}
+
+func TestScanDiff_SecretsWithLongLinesAndBinarySummaries(t *testing.T) {
+	key := fakeKey("EXAMPLE")
+	tests := []struct {
+		name string
+		diff string
+	}{
+		{
+			name: "secret in long line",
+			diff: "diff --git a/min.js b/min.js\n--- a/min.js\n+++ b/min.js\n@@ -0,0 +1 @@\n+" +
+				strings.Repeat("A", 1100*1024) + "AWS_ACCESS_KEY_ID=" + key + "\n",
+		},
+		{
+			name: "secret with binary summary",
+			diff: "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n@@ -0,0 +1 @@\n+AWS_ACCESS_KEY_ID=" + key + "\n" +
+				"diff --git a/x.png b/x.png\nBinary files a/x.png and b/x.png differ\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ScanDiff(tc.diff, testPatterns())
+			if err != nil {
+				t.Fatalf("ScanDiff returned error instead of findings: %v", err)
+			}
+			if len(result.Findings) == 0 {
+				t.Fatal("expected secret finding")
+			}
+		})
+	}
+}
+
+func TestScanDiff_FailClosedUnsupportedBinaryPatch(t *testing.T) {
+	diff := "diff --git a/blob.bin b/blob.bin\nindex 1111111..2222222 100644\nGIT binary patch\nliteral 1\nA\n"
+	result, err := ScanDiff(diff, testPatterns())
+	if !errors.Is(err, ErrUnsupportedBinaryPatch) {
+		t.Fatalf("expected ErrUnsupportedBinaryPatch, got %v", err)
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("expected no findings on unsupported error, got %+v", result.Findings)
+	}
+}
+
 func TestParseDiff_DevNullSkipped(t *testing.T) {
 	// +++ /dev/null should not be treated as a filename.
 	diff := `diff --git a/deleted.go b/deleted.go

--- a/internal/gitprotect/hooks.go
+++ b/internal/gitprotect/hooks.go
@@ -72,8 +72,8 @@ while read local_ref local_sha remote_ref remote_sha; do
 
     if ! %s git scan-diff%s < "$tmp_diff"; then
         echo ""
-        echo "Push blocked: secrets detected in diff."
-        echo "Fix the issues above, then try again."
+        echo "Push blocked: Pipelock could not verify the diff or found secrets."
+        echo "Fix the issue above, then try again."
         exit 1
     fi
     : > "$tmp_diff"

--- a/internal/gitprotect/hooks.go
+++ b/internal/gitprotect/hooks.go
@@ -46,6 +46,11 @@ url="$2"
 
 z40=0000000000000000000000000000000000000000
 empty_tree=$(git hash-object -t tree /dev/null)
+tmp_diff=$(mktemp "${TMPDIR:-/tmp}/pipelock-diff.XXXXXX") || {
+    echo "ERROR: could not create temporary diff file; blocking push."
+    exit 1
+}
+trap 'rm -f "$tmp_diff"' EXIT HUP INT TERM
 
 while read local_ref local_sha remote_ref remote_sha; do
     if [ "$local_sha" = "$z40" ]; then
@@ -55,17 +60,23 @@ while read local_ref local_sha remote_ref remote_sha; do
 
     if [ "$remote_sha" = "$z40" ]; then
         # New branch, diff against empty tree
-        range="$empty_tree..$local_sha"
+        base="$empty_tree"
     else
-        range="$remote_sha..$local_sha"
+        base="$remote_sha"
     fi
 
-    if ! git diff "$range" | %s git scan-diff%s; then
+    if ! git diff --no-ext-diff --no-textconv "$base" "$local_sha" > "$tmp_diff"; then
+        echo "ERROR: git diff failed; blocking push."
+        exit 1
+    fi
+
+    if ! %s git scan-diff%s < "$tmp_diff"; then
         echo ""
         echo "Push blocked: secrets detected in diff."
         echo "Fix the issues above, then try again."
         exit 1
     fi
+    : > "$tmp_diff"
 done
 
 exit 0

--- a/internal/gitprotect/hooks_test.go
+++ b/internal/gitprotect/hooks_test.go
@@ -66,6 +66,16 @@ func TestGeneratePrePushHook_FailClosed(t *testing.T) {
 	}
 }
 
+func TestGeneratePrePushHook_GenericScanFailureMessage(t *testing.T) {
+	hook := GeneratePrePushHook("pipelock", "")
+	if !strings.Contains(hook, "could not verify the diff or found secrets") {
+		t.Error("hook should describe scan-diff failures generically")
+	}
+	if strings.Contains(hook, "secrets detected in diff") {
+		t.Error("hook should not imply every scan-diff failure is a secret finding")
+	}
+}
+
 func TestGeneratePrePushHook_SkipsBranchDeletion(t *testing.T) {
 	hook := GeneratePrePushHook("pipelock", "")
 	if !strings.Contains(hook, "Deleting a branch") {

--- a/internal/gitprotect/hooks_test.go
+++ b/internal/gitprotect/hooks_test.go
@@ -78,15 +78,34 @@ func TestGeneratePrePushHook_HandlesNewBranch(t *testing.T) {
 	if !strings.Contains(hook, "empty_tree") {
 		t.Error("hook should handle new branches by diffing against empty tree")
 	}
+	if strings.Contains(hook, "$empty_tree..$local_sha") {
+		t.Error("hook must not use empty-tree revision ranges; git diff rejects tree..commit on initial pushes")
+	}
+	if !strings.Contains(hook, `git diff --no-ext-diff --no-textconv "$base" "$local_sha"`) {
+		t.Error("hook should diff base and local sha as separate arguments")
+	}
 }
 
 func TestGeneratePrePushHook_ExplicitErrorHandling(t *testing.T) {
 	hook := GeneratePrePushHook("pipelock", "")
 	// Should use if ! cmd pattern instead of set -e + $?
-	if !strings.Contains(hook, "if ! git diff") {
-		t.Error("hook should use 'if ! cmd' pattern for error handling")
+	if !strings.Contains(hook, "if ! git diff --no-ext-diff --no-textconv") {
+		t.Error("hook should check git diff with explicit error handling")
+	}
+	if !strings.Contains(hook, "if ! 'pipelock' git scan-diff < \"$tmp_diff\"") {
+		t.Error("hook should scan a verified diff file instead of a pipeline")
 	}
 	if strings.Contains(hook, "$? -ne 0") {
 		t.Error("hook should not use $? check (incompatible with set -e)")
+	}
+	if strings.Contains(hook, "| 'pipelock' git scan-diff") {
+		t.Error("hook must not pipe git diff into scan-diff because POSIX sh masks left-side failures")
+	}
+}
+
+func TestGeneratePrePushHook_DisablesExternalDiffAndTextconv(t *testing.T) {
+	hook := GeneratePrePushHook("pipelock", "")
+	if !strings.Contains(hook, "git diff --no-ext-diff --no-textconv") {
+		t.Error("hook should disable external diff and textconv before scan-diff")
 	}
 }


### PR DESCRIPTION
## Summary

- reject malformed, unsupported, and unattributed diff content in `pipelock git scan-diff`
- harden generated Git and Hermes hooks so diff failures, external diff drivers, and textconv cannot mask scan input
- make rules commands use secure config discovery with provenance while ignoring CWD-local configs
- load rules config without requiring access to runtime-only license, TLS, or secrets files
- update response size-exemption docs for forward, TLS, and reverse proxy behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation / Operator Notices**
  * Updated response-scanning configuration docs (including reverse-proxy) and clarified MCP scan/proxy behavior when `response_scanning.enabled: false`.
  * Extended Git protection documentation with `allowed_push_repos` and improved `pipelock git scan-diff` gate semantics.

* **Bug Fixes**
  * Improved `git scan-diff` fail-closed behavior for oversized, malformed, binary-patch, and un-attributable diffs; tightened output/error handling for failures.
  * Made the pre-push hook generate diffs into a temporary file before scanning.

* **Security**
  * Hardened configuration discovery and rules loading: secure-only config paths, stricter failures for unsafe/invalid configs, and safer rules-facing validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->