### PR TITLE
Embed validated config paths in installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ For false positive tuning: **[docs/false-positive-tuning.md](docs/false-positive
 - **[LangGraph](docs/guides/langgraph.md):** `MultiServerMCPClient`, `StateGraph`
 - **[Hermes](docs/guides/hermes.md):** full-plugin coverage (default, plugin-visible tool surfaces) or lighter MCP-only wrapping for Nous Research's agent, with auth-header sidecar preservation
 - **[JetBrains/Junie](docs/guides/jetbrains.md):** MCP proxy wrapping for IntelliJ, PyCharm, GoLand ([walkthrough](https://pipelab.org/learn/jetbrains-integration/))
-- **Cursor:** `pipelock cursor install` registers Pipelock as a Cursor hook for shell execution, MCP tool calls, and file reads; or use `configs/cursor.yaml` with the same MCP proxy pattern as [Claude Code](docs/guides/claude-code.md) ([walkthrough](https://pipelab.org/learn/cursor-integration/))
+- **Cursor:** `pipelock cursor install` registers Pipelock as a Cursor hook for shell execution, MCP tool calls, and file reads; use `--config` to embed a validated policy path and `pipelock cursor remove` to remove only Pipelock-managed hooks. You can also use `configs/cursor.yaml` with the same MCP proxy pattern as [Claude Code](docs/guides/claude-code.md) ([walkthrough](https://pipelab.org/learn/cursor-integration/))
 - **VS Code:** `pipelock vscode install` rewrites `.vscode/mcp.json` to route every MCP server through the MCP proxy (stdio commands wrapped, HTTP/SSE servers bridged via `--upstream`); `--global` targets the user-level `mcp.json`
 - **[OpenClaw](docs/guides/openclaw.md):** Gateway sidecar, init container, config wrapping
 

--- a/docs/guides/claude-code.md
+++ b/docs/guides/claude-code.md
@@ -175,6 +175,9 @@ execution. The `pipelock claude setup` command installs hooks automatically:
 # Install hooks (writes to ~/.claude/settings.json)
 pipelock claude setup
 
+# Install hooks with an explicit policy file
+pipelock claude setup --config ~/.config/pipelock/pipelock.yaml
+
 # Or install to a project-local settings file
 pipelock claude setup --project
 
@@ -184,6 +187,11 @@ pipelock claude setup --dry-run
 # Remove hooks
 pipelock claude remove
 ```
+
+At install time, Pipelock validates the config path, embeds the resolved
+absolute path into the generated hook command, and prints the config source. If
+no standard config is available, the hook is installed with built-in defaults
+and the setup output says so.
 
 This registers pipelock as a `PreToolUse` hook for security-relevant tools:
 

--- a/docs/guides/codex.md
+++ b/docs/guides/codex.md
@@ -44,6 +44,13 @@ pipelock assess finalize assessment-*/
 
 `pipelock codex install` discovers Codex's MCP server entries in `~/.codex/config.toml`, rewrites each one to launch through `pipelock mcp proxy`, and is idempotent — re-running it on an already-installed setup is a no-op. Add or remove an MCP server via `codex mcp add/remove` as usual, then re-run `pipelock codex install` to wrap any new entries.
 
+The installer validates and embeds an absolute Pipelock config path when you pass
+`--config`, or when a secure config is discovered through `PIPELOCK_CONFIG`,
+`$XDG_CONFIG_HOME/pipelock/pipelock.yaml`, `~/.config/pipelock/pipelock.yaml`,
+or `/etc/pipelock/pipelock.yaml`. It prints the selected config source during
+install so the wrapped MCP servers do not depend on Codex's later working
+directory.
+
 For manual / per-server control, the original pattern still works:
 
 ```bash

--- a/docs/guides/jetbrains.md
+++ b/docs/guides/jetbrains.md
@@ -48,6 +48,10 @@ pipelock jetbrains install --dry-run
 pipelock jetbrains install --config ~/.config/pipelock/pipelock.yaml
 ```
 
+During install, Pipelock validates the selected config and writes the resolved
+absolute path into each wrapped MCP server. Without `--config`, it uses the
+standard config discovery order and prints the source it embedded.
+
 ## Remove
 
 ```bash

--- a/internal/cli/git/git.go
+++ b/internal/cli/git/git.go
@@ -180,6 +180,7 @@ func installHooksCmd() *cobra.Command {
 	var configFile string
 	var binary string
 	var force bool
+	var quiet bool
 
 	cmd := &cobra.Command{
 		Use:   "install-hooks",
@@ -191,7 +192,7 @@ If .git/hooks/pre-push already exists, use --force to overwrite it.
 
 Examples:
   pipelock git install-hooks
-  pipelock git install-hooks --config /etc/pipelock.yaml
+  pipelock git install-hooks --config /etc/pipelock/pipelock.yaml
   pipelock git install-hooks --force`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			gitDir, err := findGitDir()
@@ -211,7 +212,13 @@ Examples:
 				binary = binaryName
 			}
 
-			hookContent := gitprotect.GeneratePrePushHook(binary, configFile)
+			resolvedConfig, err := cliutil.ResolveConfigForInstall(configFile)
+			if err != nil {
+				return err
+			}
+			cliutil.WriteInstallConfigProvenance(cmd.ErrOrStderr(), "git install-hooks", resolvedConfig, quiet)
+
+			hookContent := gitprotect.GeneratePrePushHook(binary, resolvedConfig.Path)
 
 			hooksDir := filepath.Join(gitDir, "hooks")
 			if err := os.MkdirAll(hooksDir, 0o750); err != nil {
@@ -230,6 +237,7 @@ Examples:
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "config file path for the hook to use")
 	cmd.Flags().StringVar(&binary, "binary", "", "path to pipelock binary (default: "+binaryName+" in PATH)")
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing hook")
+	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress config provenance output")
 	return cmd
 }
 

--- a/internal/cli/git/git_test.go
+++ b/internal/cli/git/git_test.go
@@ -46,6 +46,15 @@ func fakeKey() string {
 	return "AK" + "IA" + "IOSFODNN7" + "EXAMPLE"
 }
 
+func writeInstallTestConfig(t *testing.T) string {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return cfgPath
+}
+
 func runScanDiffCmd(t *testing.T, diff string) (string, error) {
 	t.Helper()
 	stdin, err := os.CreateTemp(t.TempDir(), "scan-diff-stdin-*")
@@ -743,13 +752,14 @@ func TestInstallHooksCmd_WithConfig(t *testing.T) {
 	if err := os.MkdirAll(gitDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
+	cfgPath := writeInstallTestConfig(t)
 
 	oldDir, _ := os.Getwd()
 	_ = os.Chdir(dir)
 	defer func() { _ = os.Chdir(oldDir) }()
 
 	cmd := testRootCmd()
-	cmd.SetArgs([]string{"git", "install-hooks", "--config", "/etc/pipelock.yaml"})
+	cmd.SetArgs([]string{"git", "install-hooks", "--config", cfgPath})
 
 	buf := &strings.Builder{}
 	cmd.SetOut(buf)
@@ -761,7 +771,7 @@ func TestInstallHooksCmd_WithConfig(t *testing.T) {
 
 	hookPath := filepath.Join(gitDir, "hooks", "pre-push")
 	data, _ := os.ReadFile(filepath.Clean(hookPath))
-	if !strings.Contains(string(data), "/etc/pipelock.yaml") {
+	if !strings.Contains(string(data), cfgPath) {
 		t.Error("hook should contain the config path")
 	}
 }

--- a/internal/cli/git/git_test.go
+++ b/internal/cli/git/git_test.go
@@ -386,9 +386,18 @@ func TestInstallHooksCmd_CreatesHook(t *testing.T) {
 	}
 
 	// Change to the fake repo dir
-	oldDir, _ := os.Getwd()
-	_ = os.Chdir(dir)
-	defer func() { _ = os.Chdir(oldDir) }()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
 
 	cmd := testRootCmd()
 	cmd.SetArgs([]string{"git", "install-hooks"})

--- a/internal/cli/setup/claude.go
+++ b/internal/cli/setup/claude.go
@@ -381,17 +381,19 @@ func parseClaudeSettings(data []byte) (*claudeSettings, error) {
 }
 
 // isClaudePipelockHook returns true if a hook entry was installed by pipelock.
-// The command always ends with "claude hook" because mergeClaudeHooks
-// constructs it as `<binary> claude hook`. Mirrors cursor.go's HasSuffix
-// detection pattern.
+// mergeClaudeHooks only ever produces "<binary> claude hook" (bare) or
+// "<binary> claude hook --config <path>". Match exactly those two forms so an
+// unrelated user hook that merely contains "claude hook" mid-command is never
+// clobbered. Mirrors cursor.go's isPipelockHook detection pattern.
 func isClaudePipelockHook(h claudeHookEntry) bool {
-	return strings.HasSuffix(strings.TrimSpace(h.Command), "claude hook")
+	command := strings.TrimSpace(h.Command)
+	return strings.HasSuffix(command, "claude hook") || strings.Contains(command, " claude hook --config ")
 }
 
 // mergeClaudeHooks removes existing pipelock hooks from PreToolUse and adds
 // fresh ones. Non-pipelock hooks are preserved even if they share a matcher
 // group with a pipelock hook. All other events are copied unchanged.
-func mergeClaudeHooks(settings *claudeSettings, exe string) *claudeSettings {
+func mergeClaudeHooks(settings *claudeSettings, exe, configFile string) *claudeSettings {
 	result := &claudeSettings{
 		Hooks: make(map[string][]claudeMatcherGroup),
 	}
@@ -423,6 +425,9 @@ func mergeClaudeHooks(settings *claudeSettings, exe string) *claudeSettings {
 	// every tool; dispatch in claudePayloadToAction decides what to scan.
 	quoted := shellQuote(exe)
 	hookCommand := quoted + " claude hook"
+	if configFile != "" {
+		hookCommand += " --config " + shellQuote(configFile)
+	}
 
 	result.Hooks[claudeHookEventPreToolUse] = append(
 		result.Hooks[claudeHookEventPreToolUse],
@@ -472,9 +477,11 @@ func removeClaudeHooks(settings *claudeSettings) *claudeSettings {
 
 func claudeSetupCmd() *cobra.Command {
 	var (
-		global  bool
-		project bool
-		dryRun  bool
+		global     bool
+		project    bool
+		dryRun     bool
+		configFile string
+		quiet      bool
 	)
 
 	cmd := &cobra.Command{
@@ -493,21 +500,29 @@ modification. Runs are idempotent: running twice produces the same result.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runClaudeSetup(cmd, global, project, dryRun)
+			return runClaudeSetup(cmd, global, project, dryRun, configFile, quiet)
 		},
 	}
 
 	cmd.Flags().BoolVar(&global, "global", false, "install to ~/.claude/settings.json (default)")
 	cmd.Flags().BoolVar(&project, "project", false, "install to .claude/settings.json in current directory")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be written without modifying files")
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "path to pipelock config file for installed hooks")
+	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress config provenance output")
 
 	return cmd
 }
 
-func runClaudeSetup(cmd *cobra.Command, global, project, dryRun bool) error {
+func runClaudeSetup(cmd *cobra.Command, global, project, dryRun bool, configFile string, quiet bool) error {
 	if global && project {
 		return fmt.Errorf("--global and --project are mutually exclusive")
 	}
+
+	resolvedConfig, err := cliutil.ResolveConfigForInstall(configFile)
+	if err != nil {
+		return err
+	}
+	cliutil.WriteInstallConfigProvenance(cmd.ErrOrStderr(), "claude setup", resolvedConfig, quiet)
 
 	// Determine target path.
 	targetDir, err := claudeSettingsDir(project)
@@ -543,7 +558,7 @@ func runClaudeSetup(cmd *cobra.Command, global, project, dryRun bool) error {
 	}
 
 	// Merge pipelock hooks.
-	merged := mergeClaudeHooks(settings, exe)
+	merged := mergeClaudeHooks(settings, exe, resolvedConfig.Path)
 
 	// Serialize with raw field preservation.
 	output, err := marshalClaudeSettings(merged, rawMap)

--- a/internal/cli/setup/claude.go
+++ b/internal/cli/setup/claude.go
@@ -386,8 +386,7 @@ func parseClaudeSettings(data []byte) (*claudeSettings, error) {
 // unrelated user hook that merely contains "claude hook" mid-command is never
 // clobbered. Mirrors cursor.go's isPipelockHook detection pattern.
 func isClaudePipelockHook(h claudeHookEntry) bool {
-	command := strings.TrimSpace(h.Command)
-	return strings.HasSuffix(command, "claude hook") || strings.Contains(command, " claude hook --config ")
+	return isGeneratedPipelockHookCommand(h.Command, "claude")
 }
 
 // mergeClaudeHooks removes existing pipelock hooks from PreToolUse and adds

--- a/internal/cli/setup/claude_test.go
+++ b/internal/cli/setup/claude_test.go
@@ -526,6 +526,7 @@ func TestIsClaudePipelockHook_Detection(t *testing.T) {
 		{"user hook containing the phrase", "/opt/tool claude hook helper --verbose", false},
 		{"other binary exact hook words", "/opt/tool claude hook", false},
 		{"user hook with unrelated flag after phrase", "/opt/tool claude hook --helper", false},
+		{"flag-like config operand", "/usr/bin/pipelock claude hook --config --helper", false},
 		{"trailing args after config", "/usr/bin/pipelock claude hook --config /etc/pipelock/pipelock.yaml --helper", false},
 	}
 	for _, tc := range cases {

--- a/internal/cli/setup/claude_test.go
+++ b/internal/cli/setup/claude_test.go
@@ -524,7 +524,9 @@ func TestIsClaudePipelockHook_Detection(t *testing.T) {
 		// Regression: a user hook that merely contains "claude hook" mid-command
 		// (not a pipelock-generated form) must not be clobbered.
 		{"user hook containing the phrase", "/opt/tool claude hook helper --verbose", false},
+		{"other binary exact hook words", "/opt/tool claude hook", false},
 		{"user hook with unrelated flag after phrase", "/opt/tool claude hook --helper", false},
+		{"trailing args after config", "/usr/bin/pipelock claude hook --config /etc/pipelock/pipelock.yaml --helper", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/setup/claude_test.go
+++ b/internal/cli/setup/claude_test.go
@@ -391,7 +391,7 @@ func TestParseClaudeSettings_Malformed(t *testing.T) {
 
 func TestMergeClaudeHooks_Fresh(t *testing.T) {
 	settings := &claudeSettings{Hooks: make(map[string][]claudeMatcherGroup)}
-	merged := mergeClaudeHooks(settings, "/usr/local/bin/pipelock")
+	merged := mergeClaudeHooks(settings, "/usr/local/bin/pipelock", "")
 
 	groups := merged.Hooks["PreToolUse"]
 	if len(groups) != 1 {
@@ -399,6 +399,23 @@ func TestMergeClaudeHooks_Fresh(t *testing.T) {
 	}
 	if groups[0].Matcher != claudeToolMatcher {
 		t.Errorf("matcher = %q, want %q", groups[0].Matcher, claudeToolMatcher)
+	}
+}
+
+func TestMergeClaudeHooks_WithConfig(t *testing.T) {
+	settings := &claudeSettings{Hooks: make(map[string][]claudeMatcherGroup)}
+	merged := mergeClaudeHooks(settings, "/usr/local/bin/pipelock", "/tmp/pipelock config.yaml")
+
+	groups := merged.Hooks["PreToolUse"]
+	if len(groups) != 1 || len(groups[0].Hooks) != 1 {
+		t.Fatalf("expected one installed hook, got %#v", groups)
+	}
+	command := groups[0].Hooks[0].Command
+	if !strings.Contains(command, "claude hook --config") {
+		t.Fatalf("expected config flag in command, got %q", command)
+	}
+	if !strings.Contains(command, "'/tmp/pipelock config.yaml'") {
+		t.Fatalf("expected shell-quoted config path, got %q", command)
 	}
 }
 
@@ -413,7 +430,7 @@ func TestMergeClaudeHooks_PreservesOtherHooks(t *testing.T) {
 			},
 		},
 	}
-	merged := mergeClaudeHooks(settings, "/usr/local/bin/pipelock")
+	merged := mergeClaudeHooks(settings, "/usr/local/bin/pipelock", "")
 
 	// SessionStart untouched.
 	if len(merged.Hooks["SessionStart"]) != 1 {
@@ -437,8 +454,8 @@ func TestMergeClaudeHooks_PreservesOtherHooks(t *testing.T) {
 
 func TestMergeClaudeHooks_Idempotent(t *testing.T) {
 	settings := &claudeSettings{Hooks: make(map[string][]claudeMatcherGroup)}
-	first := mergeClaudeHooks(settings, "/usr/local/bin/pipelock")
-	second := mergeClaudeHooks(first, "/usr/local/bin/pipelock")
+	first := mergeClaudeHooks(settings, "/usr/local/bin/pipelock", "")
+	second := mergeClaudeHooks(first, "/usr/local/bin/pipelock", "")
 
 	// Count pipelock groups (should be same after second merge).
 	count := 0
@@ -457,7 +474,7 @@ func TestMergeClaudeHooks_Idempotent(t *testing.T) {
 
 func TestRemoveClaudeHooks(t *testing.T) {
 	settings := &claudeSettings{Hooks: make(map[string][]claudeMatcherGroup)}
-	installed := mergeClaudeHooks(settings, "/usr/local/bin/pipelock")
+	installed := mergeClaudeHooks(settings, "/usr/local/bin/pipelock", "")
 	removed := removeClaudeHooks(installed)
 
 	if len(removed.Hooks["PreToolUse"]) != 0 {
@@ -476,7 +493,7 @@ func TestMergeClaudeHooks_PreservesSharedGroupHooks(t *testing.T) {
 			},
 		},
 	}
-	merged := mergeClaudeHooks(settings, "/usr/local/bin/pipelock")
+	merged := mergeClaudeHooks(settings, "/usr/local/bin/pipelock", "")
 
 	found := false
 	for _, g := range merged.Hooks["PreToolUse"] {
@@ -498,11 +515,16 @@ func TestIsClaudePipelockHook_Detection(t *testing.T) {
 		want    bool
 	}{
 		{"actual pipelock hook", "/usr/bin/pipelock claude hook", true},
+		{"hook with config", "/usr/bin/pipelock claude hook --config /etc/pipelock/pipelock.yaml", true},
 		{"quoted path", "'/usr/local/bin/pipelock' claude hook", true},
 		{"trailing whitespace", "/usr/bin/pipelock claude hook ", true},
 		{"unrelated command", "echo hello", false},
 		{"partial match", "pipelock claude", false},
 		{"empty command", "", false},
+		// Regression: a user hook that merely contains "claude hook" mid-command
+		// (not a pipelock-generated form) must not be clobbered.
+		{"user hook containing the phrase", "/opt/tool claude hook helper --verbose", false},
+		{"user hook with unrelated flag after phrase", "/opt/tool claude hook --helper", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/setup/codex.go
+++ b/internal/cli/setup/codex.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/spf13/cobra"
 )
 
@@ -100,6 +101,7 @@ func codexInstallCmd() *cobra.Command {
 		dryRun     bool
 		configFile string
 		codexPath  string
+		quiet      bool
 	)
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -114,12 +116,13 @@ Use --codex-path to override the codex binary location (default: PATH lookup).`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runCodexInstall(cmd, dryRun, configFile, codexPath)
+			return runCodexInstall(cmd, dryRun, configFile, codexPath, quiet)
 		},
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without modifying Codex config")
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "pipelock config path passed through to 'pipelock mcp proxy'")
 	cmd.Flags().StringVar(&codexPath, "codex-path", "", "path to the codex binary (default: PATH lookup)")
+	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress config provenance output")
 	return cmd
 }
 
@@ -507,7 +510,7 @@ func copyStringMap(in map[string]string) map[string]string {
 }
 
 // runCodexInstall is the top-level handler for `pipelock codex install`.
-func runCodexInstall(cmd *cobra.Command, dryRun bool, configFile, codexPathOverride string) error {
+func runCodexInstall(cmd *cobra.Command, dryRun bool, configFile, codexPathOverride string, quiet bool) error {
 	codexBin, err := resolveCodexBinary(codexPathOverride)
 	if err != nil {
 		return err
@@ -516,12 +519,17 @@ func runCodexInstall(cmd *cobra.Command, dryRun bool, configFile, codexPathOverr
 	if err != nil {
 		return err
 	}
+	resolvedConfig, err := cliutil.ResolveConfigForInstall(configFile)
+	if err != nil {
+		return err
+	}
+	cliutil.WriteInstallConfigProvenance(cmd.ErrOrStderr(), "codex install", resolvedConfig, quiet)
 
 	servers, err := codexMCPList(cmd.Context(), codexBin)
 	if err != nil {
 		return err
 	}
-	plans := planCodexInstall(servers, pipelockBin, configFile)
+	plans := planCodexInstall(servers, pipelockBin, resolvedConfig.Path)
 
 	wrapped, skipped := 0, 0
 	for _, p := range plans {

--- a/internal/cli/setup/codex_test.go
+++ b/internal/cli/setup/codex_test.go
@@ -882,9 +882,13 @@ func TestRunCodexInstall_RealInstall(t *testing.T) {
 		}
 	}]`
 	codexBin, invokeLog := fakeCodex(t, listJSON)
+	installCfgPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(installCfgPath, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	root := newCodexTestRoot()
-	root.SetArgs([]string{"codex", "install", "--codex-path", codexBin, "--config", cfgPath})
+	root.SetArgs([]string{"codex", "install", "--codex-path", codexBin, "--config", installCfgPath})
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
@@ -911,8 +915,8 @@ func TestRunCodexInstall_RealInstall(t *testing.T) {
 	if !strings.Contains(logStr, "--env PORT=3000") {
 		t.Errorf("expected env to be passed to codex mcp add, got: %s", logStr)
 	}
-	if !strings.Contains(logStr, cfgPath) {
-		t.Errorf("expected --config %s passthrough in log, got: %s", cfgPath, logStr)
+	if !strings.Contains(logStr, installCfgPath) {
+		t.Errorf("expected --config %s passthrough in log, got: %s", installCfgPath, logStr)
 	}
 }
 

--- a/internal/cli/setup/codex_test.go
+++ b/internal/cli/setup/codex_test.go
@@ -915,7 +915,7 @@ func TestRunCodexInstall_RealInstall(t *testing.T) {
 	if !strings.Contains(logStr, "--env PORT=3000") {
 		t.Errorf("expected env to be passed to codex mcp add, got: %s", logStr)
 	}
-	if !strings.Contains(logStr, installCfgPath) {
+	if !strings.Contains(logStr, "--config "+installCfgPath) {
 		t.Errorf("expected --config %s passthrough in log, got: %s", installCfgPath, logStr)
 	}
 }

--- a/internal/cli/setup/cursor.go
+++ b/internal/cli/setup/cursor.go
@@ -619,8 +619,7 @@ func mergeHooks(existing *hooksJSON, newEntries map[string][]hookEntry) *hooksJS
 // unrelated user hook that merely contains "cursor hook" mid-command is never
 // clobbered on install or remove.
 func isPipelockHook(h hookEntry) bool {
-	command := strings.TrimSpace(h.Command)
-	return strings.HasSuffix(command, "cursor hook") || strings.Contains(command, " cursor hook --config ")
+	return isGeneratedPipelockHookCommand(h.Command, "cursor")
 }
 
 func cursorHooksDir(project bool) (string, error) {

--- a/internal/cli/setup/cursor.go
+++ b/internal/cli/setup/cursor.go
@@ -508,6 +508,10 @@ func runCursorRemove(cmd *cobra.Command, global, project, dryRun bool) error {
 			result.Hooks[event] = append(result.Hooks[event], h)
 		}
 	}
+	if removed == 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No pipelock hooks found in %s\n", targetPath)
+		return nil
+	}
 
 	output, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {

--- a/internal/cli/setup/cursor.go
+++ b/internal/cli/setup/cursor.go
@@ -132,6 +132,7 @@ The install subcommand writes hooks.json to register pipelock with Cursor.`,
 	cmd.AddCommand(
 		cursorHookCmd(),
 		cursorInstallCmd(),
+		cursorRemoveCmd(),
 	)
 
 	return cmd
@@ -333,9 +334,11 @@ func writeResponse(w io.Writer, resp cursorResponse) {
 
 func cursorInstallCmd() *cobra.Command {
 	var (
-		global  bool
-		project bool
-		dryRun  bool
+		global     bool
+		project    bool
+		dryRun     bool
+		configFile string
+		quiet      bool
 	)
 
 	cmd := &cobra.Command{
@@ -353,34 +356,35 @@ Runs are idempotent: running twice produces the same result.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runCursorInstall(cmd, global, project, dryRun)
+			return runCursorInstall(cmd, global, project, dryRun, configFile, quiet)
 		},
 	}
 
 	cmd.Flags().BoolVar(&global, "global", false, "install to ~/.cursor/hooks.json (default when no scope flag given)")
 	cmd.Flags().BoolVar(&project, "project", false, "install to .cursor/hooks.json in current directory")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be written without modifying files")
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "path to pipelock config file for installed hooks")
+	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress config provenance output")
 
 	return cmd
 }
 
-func runCursorInstall(cmd *cobra.Command, global, project, dryRun bool) error {
+func runCursorInstall(cmd *cobra.Command, global, project, dryRun bool, configFile string, quiet bool) error {
 	if global && project {
 		return fmt.Errorf("--global and --project are mutually exclusive")
 	}
 
-	// Determine target path. When neither flag is set, defaults to global.
-	var targetDir string
-	if project {
-		targetDir = filepath.Join(".", ".cursor")
-	} else {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("finding home directory: %w", err)
-		}
-		targetDir = filepath.Join(home, ".cursor")
+	resolvedConfig, err := cliutil.ResolveConfigForInstall(configFile)
+	if err != nil {
+		return err
 	}
+	cliutil.WriteInstallConfigProvenance(cmd.ErrOrStderr(), "cursor install", resolvedConfig, quiet)
 
+	// Determine target path. When neither flag is set, defaults to global.
+	targetDir, err := cursorHooksDir(project)
+	if err != nil {
+		return err
+	}
 	targetPath := filepath.Join(targetDir, "hooks.json")
 
 	// Find pipelock binary path.
@@ -394,7 +398,7 @@ func runCursorInstall(cmd *cobra.Command, global, project, dryRun bool) error {
 	}
 
 	// Build the hook entries.
-	newEntries := buildHookEntries(exe)
+	newEntries := buildHookEntries(exe, resolvedConfig.Path)
 
 	// Load existing hooks.json if present.
 	existing := &hooksJSON{Version: 1, Hooks: make(map[string][]hookEntry)}
@@ -426,11 +430,6 @@ func runCursorInstall(cmd *cobra.Command, global, project, dryRun bool) error {
 		return nil
 	}
 
-	// Create directory if needed.
-	if err := os.MkdirAll(targetDir, 0o750); err != nil {
-		return fmt.Errorf("creating directory %s: %w", targetDir, err)
-	}
-
 	// Backup existing file.
 	if readErr == nil {
 		backupPath := targetPath + ".bak"
@@ -438,35 +437,97 @@ func runCursorInstall(cmd *cobra.Command, global, project, dryRun bool) error {
 			return fmt.Errorf("creating backup %s: %w", backupPath, err)
 		}
 	}
-
-	// Atomic write: temp file + rename.
-	tmpFile, err := os.CreateTemp(targetDir, "hooks-*.json.tmp")
-	if err != nil {
-		return fmt.Errorf("creating temp file: %w", err)
-	}
-	tmpPath := tmpFile.Name()
-
-	if _, err := tmpFile.Write(output); err != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("writing temp file: %w", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("closing temp file: %w", err)
-	}
-
-	if err := os.Chmod(tmpPath, 0o600); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("setting permissions: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, targetPath); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("renaming temp file to %s: %w", targetPath, err)
+	if err := writeCursorHooksFile(targetDir, targetPath, output); err != nil {
+		return err
 	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Installed pipelock hooks to %s\n", targetPath)
+	return nil
+}
+
+func cursorRemoveCmd() *cobra.Command {
+	var (
+		global  bool
+		project bool
+		dryRun  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove pipelock hooks from Cursor",
+		Long: `Removes pipelock-managed hooks from Cursor hooks.json.
+Non-pipelock hooks are preserved. A .bak backup is created before modification.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCursorRemove(cmd, global, project, dryRun)
+		},
+	}
+
+	cmd.Flags().BoolVar(&global, "global", false, "remove from ~/.cursor/hooks.json (default when no scope flag given)")
+	cmd.Flags().BoolVar(&project, "project", false, "remove from .cursor/hooks.json in current directory")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be written without modifying files")
+	return cmd
+}
+
+func runCursorRemove(cmd *cobra.Command, global, project, dryRun bool) error {
+	if global && project {
+		return fmt.Errorf("--global and --project are mutually exclusive")
+	}
+
+	targetDir, err := cursorHooksDir(project)
+	if err != nil {
+		return err
+	}
+	targetPath := filepath.Join(targetDir, "hooks.json")
+
+	existingData, readErr := os.ReadFile(filepath.Clean(targetPath))
+	if readErr != nil {
+		if errors.Is(readErr, os.ErrNotExist) {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no hooks.json found, nothing to remove")
+			return nil
+		}
+		return fmt.Errorf("reading existing %s: %w", targetPath, readErr)
+	}
+	existing, err := parseHooksJSON(existingData)
+	if err != nil {
+		return fmt.Errorf("parsing existing %s: %w", targetPath, err)
+	}
+
+	removed := 0
+	result := &hooksJSON{Version: existing.Version, Hooks: make(map[string][]hookEntry)}
+	if result.Version < 1 {
+		result.Version = 1
+	}
+	for event, entries := range existing.Hooks {
+		for _, h := range entries {
+			if isPipelockHook(h) {
+				removed++
+				continue
+			}
+			result.Hooks[event] = append(result.Hooks[event], h)
+		}
+	}
+
+	output, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling hooks.json: %w", err)
+	}
+	output = append(output, '\n')
+
+	if dryRun {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Would write to %s (%d removed):\n%s", targetPath, removed, output)
+		return nil
+	}
+
+	backupPath := targetPath + ".bak"
+	if err := os.WriteFile(backupPath, existingData, 0o600); err != nil {
+		return fmt.Errorf("creating backup %s: %w", backupPath, err)
+	}
+	if err := writeCursorHooksFile(targetDir, targetPath, output); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Removed %d pipelock hook(s) from %s\n", removed, targetPath)
 	return nil
 }
 
@@ -474,7 +535,7 @@ func runCursorInstall(cmd *cobra.Command, global, project, dryRun bool) error {
 const cursorHookTimeout = 10
 
 // buildHookEntries creates the 3 hook entries for pipelock, keyed by event name.
-func buildHookEntries(exe string) map[string][]hookEntry {
+func buildHookEntries(exe, configFile string) map[string][]hookEntry {
 	events := []string{
 		"beforeShellExecution",
 		"beforeMCPExecution",
@@ -484,8 +545,12 @@ func buildHookEntries(exe string) map[string][]hookEntry {
 	quoted := shellQuote(exe)
 	result := make(map[string][]hookEntry, len(events))
 	for _, event := range events {
+		command := quoted + " cursor hook"
+		if configFile != "" {
+			command += " --config " + shellQuote(configFile)
+		}
 		result[event] = []hookEntry{{
-			Command: quoted + " cursor hook",
+			Command: command,
 			Timeout: cursorHookTimeout,
 		}}
 	}
@@ -549,8 +614,51 @@ func mergeHooks(existing *hooksJSON, newEntries map[string][]hookEntry) *hooksJS
 }
 
 // isPipelockHook returns true if a hook entry is a pipelock cursor hook.
-// The command always ends with "cursor hook" because buildHookEntries
-// constructs it as `<binary> cursor hook`.
+// buildHookEntries only ever produces two forms: "<binary> cursor hook" (bare)
+// or "<binary> cursor hook --config <path>". Match exactly those so an
+// unrelated user hook that merely contains "cursor hook" mid-command is never
+// clobbered on install or remove.
 func isPipelockHook(h hookEntry) bool {
-	return strings.HasSuffix(strings.TrimSpace(h.Command), "cursor hook")
+	command := strings.TrimSpace(h.Command)
+	return strings.HasSuffix(command, "cursor hook") || strings.Contains(command, " cursor hook --config ")
+}
+
+func cursorHooksDir(project bool) (string, error) {
+	if project {
+		return filepath.Join(".", ".cursor"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, ".cursor"), nil
+}
+
+func writeCursorHooksFile(targetDir, targetPath string, output []byte) error {
+	if err := os.MkdirAll(targetDir, 0o750); err != nil {
+		return fmt.Errorf("creating directory %s: %w", targetDir, err)
+	}
+	tmpFile, err := os.CreateTemp(targetDir, "hooks-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	if _, err := tmpFile.Write(output); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("setting permissions: %w", err)
+	}
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("renaming temp file to %s: %w", targetPath, err)
+	}
+	return nil
 }

--- a/internal/cli/setup/cursor_test.go
+++ b/internal/cli/setup/cursor_test.go
@@ -737,6 +737,43 @@ func TestCursorRemoveCmd_RemovesPipelockHooksOnly(t *testing.T) {
 	}
 }
 
+func TestCursorRemoveCmd_DryRunDoesNotWriteBackup(t *testing.T) {
+	dir := t.TempDir()
+	cursorDir := filepath.Join(dir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"version":1,"hooks":{"beforeShellExecution":[{"command":"lint","timeout":5},{"command":"/usr/bin/pipelock cursor hook","timeout":10}]}}`
+	hooksPath := filepath.Join(cursorDir, "hooks.json")
+	if err := os.WriteFile(hooksPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, dir)
+
+	cmd := CursorCmd()
+	cmd.SetArgs([]string{"remove", "--project", "--dry-run"})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Would write to") || !strings.Contains(output, "(1 removed)") {
+		t.Fatalf("expected dry-run removal output, got %q", output)
+	}
+	data, err := os.ReadFile(filepath.Clean(hooksPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != existing {
+		t.Fatalf("dry-run remove changed hooks.json: got %q want %q", string(data), existing)
+	}
+	if _, err := os.Stat(hooksPath + ".bak"); !os.IsNotExist(err) {
+		t.Fatalf("dry-run remove should not create backup, stat err: %v", err)
+	}
+}
+
 func TestCursorRemoveCmd_NoPipelockHooksNoops(t *testing.T) {
 	dir := t.TempDir()
 	cursorDir := filepath.Join(dir, ".cursor")
@@ -773,6 +810,69 @@ func TestCursorRemoveCmd_NoPipelockHooksNoops(t *testing.T) {
 	}
 }
 
+func TestCursorRemoveCmd_NoHooksJSONNoops(t *testing.T) {
+	dir := t.TempDir()
+	chdirTemp(t, dir)
+
+	cmd := CursorCmd()
+	cmd.SetArgs([]string{"remove", "--project"})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "no hooks.json found") {
+		t.Fatalf("expected missing-file no-op message, got %q", buf.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".cursor", "hooks.json")); !os.IsNotExist(err) {
+		t.Fatalf("remove should not create hooks.json when it is absent, stat err: %v", err)
+	}
+}
+
+func TestCursorRemoveCmd_MalformedExisting(t *testing.T) {
+	dir := t.TempDir()
+	cursorDir := filepath.Join(dir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	hooksPath := filepath.Join(cursorDir, "hooks.json")
+	if err := os.WriteFile(hooksPath, []byte("{bad json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, dir)
+
+	cmd := CursorCmd()
+	cmd.SetArgs([]string{"remove", "--project"})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for malformed existing hooks.json")
+	}
+	if !strings.Contains(err.Error(), "parsing existing") {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+}
+
+func TestCursorRemoveCmd_InvalidFlags(t *testing.T) {
+	cmd := CursorCmd()
+	cmd.SetArgs([]string{"remove", "--global", "--project"})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when both --global and --project are set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}
+
 func TestIsPipelockHook_Detection(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -792,6 +892,9 @@ func TestIsPipelockHook_Detection(t *testing.T) {
 		{"user hook with unrelated flag after phrase", "/opt/tool cursor hook --helper", false},
 		{"flag-like config operand", "/usr/bin/pipelock cursor hook --config --helper", false},
 		{"trailing args after config", "/usr/bin/pipelock cursor hook --config /etc/pipelock/pipelock.yaml --helper", false},
+		{"escaped space in config", `/usr/bin/pipelock cursor hook --config /tmp/has\ space.yaml`, true},
+		{"escaped single quote in config", `/usr/bin/pipelock cursor hook --config '/tmp/it'\''s.yaml'`, true},
+		{"unmatched quote", `/usr/bin/pipelock cursor hook --config '/tmp/bad.yaml`, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/setup/cursor_test.go
+++ b/internal/cli/setup/cursor_test.go
@@ -648,6 +648,120 @@ func TestCursorInstallCmd_GlobalActual(t *testing.T) {
 	}
 }
 
+func TestCursorInstallCmd_EmbedsExplicitConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, dir)
+
+	cmd := CursorCmd()
+	cmd.SetArgs([]string{"install", "--project", "--config", cfgPath})
+	var out, errOut strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errOut.String(), cfgPath) {
+		t.Fatalf("expected config provenance on stderr, got %q", errOut.String())
+	}
+
+	hooksPath := filepath.Join(dir, ".cursor", "hooks.json")
+	data, err := os.ReadFile(filepath.Clean(hooksPath))
+	if err != nil {
+		t.Fatalf("hooks.json not created: %v", err)
+	}
+	var hooks hooksJSON
+	if err := json.Unmarshal(data, &hooks); err != nil {
+		t.Fatalf("invalid hooks.json: %v", err)
+	}
+	for event, entries := range hooks.Hooks {
+		if len(entries) != 1 {
+			t.Fatalf("%s entries = %d, want 1", event, len(entries))
+		}
+		command := entries[0].Command
+		if !strings.Contains(command, "cursor hook --config") {
+			t.Fatalf("%s command missing --config: %q", event, command)
+		}
+		if !strings.Contains(command, shellQuote(cfgPath)) {
+			t.Fatalf("%s command missing shell-quoted config path: %q", event, command)
+		}
+	}
+}
+
+func TestCursorRemoveCmd_RemovesPipelockHooksOnly(t *testing.T) {
+	dir := t.TempDir()
+	cursorDir := filepath.Join(dir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"version":1,"hooks":{"beforeShellExecution":[{"command":"lint","timeout":5},{"command":"/usr/bin/pipelock cursor hook --config /etc/pipelock/pipelock.yaml","timeout":10}],"beforeReadFile":[{"command":"/old/pipelock cursor hook","timeout":10}]}}`
+	hooksPath := filepath.Join(cursorDir, "hooks.json")
+	if err := os.WriteFile(hooksPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, dir)
+
+	cmd := CursorCmd()
+	cmd.SetArgs([]string{"remove", "--project"})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Removed 2") {
+		t.Fatalf("expected removal count in output, got %q", buf.String())
+	}
+
+	data, err := os.ReadFile(filepath.Clean(hooksPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hooks hooksJSON
+	if err := json.Unmarshal(data, &hooks); err != nil {
+		t.Fatalf("invalid hooks.json: %v", err)
+	}
+	if got := hooks.Hooks["beforeShellExecution"]; len(got) != 1 || got[0].Command != "lint" {
+		t.Fatalf("non-pipelock hook not preserved exactly: %#v", got)
+	}
+	if len(hooks.Hooks["beforeReadFile"]) != 0 {
+		t.Fatalf("pipelock read-file hook was not removed: %#v", hooks.Hooks["beforeReadFile"])
+	}
+	if _, err := os.Stat(hooksPath + ".bak"); err != nil {
+		t.Fatalf("backup not created: %v", err)
+	}
+}
+
+func TestIsPipelockHook_Detection(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{"bare pipelock hook", "/usr/bin/pipelock cursor hook", true},
+		{"hook with config", "/usr/bin/pipelock cursor hook --config /etc/pipelock/pipelock.yaml", true},
+		{"quoted path", "'/usr/local/bin/pipelock' cursor hook", true},
+		{"trailing whitespace", "/usr/bin/pipelock cursor hook ", true},
+		{"unrelated command", "lint", false},
+		{"empty command", "", false},
+		// Regression: a user hook that merely contains "cursor hook" mid-command
+		// (not a pipelock-generated form) must not be clobbered.
+		{"user hook containing the phrase", "/opt/tool cursor hook helper --verbose", false},
+		{"user hook with unrelated flag after phrase", "/opt/tool cursor hook --helper", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPipelockHook(hookEntry{Command: tc.command}); got != tc.want {
+				t.Errorf("isPipelockHook(%q) = %v, want %v", tc.command, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCursorHookCmd_StdinReadError(t *testing.T) {
 	cmd := CursorCmd()
 	cmd.SetArgs([]string{"hook"})

--- a/internal/cli/setup/cursor_test.go
+++ b/internal/cli/setup/cursor_test.go
@@ -751,7 +751,9 @@ func TestIsPipelockHook_Detection(t *testing.T) {
 		// Regression: a user hook that merely contains "cursor hook" mid-command
 		// (not a pipelock-generated form) must not be clobbered.
 		{"user hook containing the phrase", "/opt/tool cursor hook helper --verbose", false},
+		{"other binary exact hook words", "/opt/tool cursor hook", false},
 		{"user hook with unrelated flag after phrase", "/opt/tool cursor hook --helper", false},
+		{"trailing args after config", "/usr/bin/pipelock cursor hook --config /etc/pipelock/pipelock.yaml --helper", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/setup/cursor_test.go
+++ b/internal/cli/setup/cursor_test.go
@@ -650,14 +650,15 @@ func TestCursorInstallCmd_GlobalActual(t *testing.T) {
 
 func TestCursorInstallCmd_EmbedsExplicitConfig(t *testing.T) {
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "pipelock config.yaml")
+	cfgName := "pipelock config.yaml"
+	cfgPath := filepath.Join(dir, cfgName)
 	if err := os.WriteFile(cfgPath, []byte("mode: balanced\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	chdirTemp(t, dir)
 
 	cmd := CursorCmd()
-	cmd.SetArgs([]string{"install", "--project", "--config", cfgPath})
+	cmd.SetArgs([]string{"install", "--project", "--config", cfgName})
 	var out, errOut strings.Builder
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
@@ -736,6 +737,42 @@ func TestCursorRemoveCmd_RemovesPipelockHooksOnly(t *testing.T) {
 	}
 }
 
+func TestCursorRemoveCmd_NoPipelockHooksNoops(t *testing.T) {
+	dir := t.TempDir()
+	cursorDir := filepath.Join(dir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"version":1,"hooks":{"beforeShellExecution":[{"command":"lint","timeout":5}]}}`
+	hooksPath := filepath.Join(cursorDir, "hooks.json")
+	if err := os.WriteFile(hooksPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, dir)
+
+	cmd := CursorCmd()
+	cmd.SetArgs([]string{"remove", "--project"})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No pipelock hooks found") {
+		t.Fatalf("expected no-op message, got %q", buf.String())
+	}
+	data, err := os.ReadFile(filepath.Clean(hooksPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != existing {
+		t.Fatalf("hooks.json changed on no-op remove: got %q want %q", string(data), existing)
+	}
+	if _, err := os.Stat(hooksPath + ".bak"); !os.IsNotExist(err) {
+		t.Fatalf("no-op remove should not create backup, stat err: %v", err)
+	}
+}
+
 func TestIsPipelockHook_Detection(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -753,6 +790,7 @@ func TestIsPipelockHook_Detection(t *testing.T) {
 		{"user hook containing the phrase", "/opt/tool cursor hook helper --verbose", false},
 		{"other binary exact hook words", "/opt/tool cursor hook", false},
 		{"user hook with unrelated flag after phrase", "/opt/tool cursor hook --helper", false},
+		{"flag-like config operand", "/usr/bin/pipelock cursor hook --config --helper", false},
 		{"trailing args after config", "/usr/bin/pipelock cursor hook --config /etc/pipelock/pipelock.yaml --helper", false},
 	}
 	for _, tc := range cases {

--- a/internal/cli/setup/hook_command.go
+++ b/internal/cli/setup/hook_command.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func isGeneratedPipelockHookCommand(command, tool string) bool {
+	fields, ok := splitHookCommandFields(command)
+	if !ok || len(fields) != 3 && len(fields) != 5 {
+		return false
+	}
+	if !isPipelockHookBinary(fields[0]) || fields[1] != tool || fields[2] != "hook" {
+		return false
+	}
+	if len(fields) == 3 {
+		return true
+	}
+	return fields[3] == "--config" && fields[4] != ""
+}
+
+func isPipelockHookBinary(binary string) bool {
+	base := filepath.Base(binary)
+	if base == "pipelock" || base == "pipelock.exe" {
+		return true
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return base == filepath.Base(exe)
+}
+
+func splitHookCommandFields(command string) ([]string, bool) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil, true
+	}
+
+	var fields []string
+	var b strings.Builder
+	inSingle := false
+	inField := false
+	for i := 0; i < len(command); i++ {
+		c := command[i]
+		switch {
+		case inSingle && c == '\'':
+			inSingle = false
+		case !inSingle && c == '\'':
+			inSingle = true
+			inField = true
+		case !inSingle && c == '\\' && i+1 < len(command):
+			i++
+			b.WriteByte(command[i])
+			inField = true
+		case !inSingle && (c == ' ' || c == '\t' || c == '\n' || c == '\r'):
+			if inField {
+				fields = append(fields, b.String())
+				b.Reset()
+				inField = false
+			}
+		default:
+			b.WriteByte(c)
+			inField = true
+		}
+	}
+	if inSingle {
+		return nil, false
+	}
+	if inField {
+		fields = append(fields, b.String())
+	}
+	return fields, true
+}

--- a/internal/cli/setup/hook_command.go
+++ b/internal/cli/setup/hook_command.go
@@ -20,7 +20,7 @@ func isGeneratedPipelockHookCommand(command, tool string) bool {
 	if len(fields) == 3 {
 		return true
 	}
-	return fields[3] == "--config" && fields[4] != ""
+	return fields[3] == "--config" && fields[4] != "" && !strings.HasPrefix(fields[4], "-")
 }
 
 func isPipelockHookBinary(binary string) bool {

--- a/internal/cli/setup/install_config_test.go
+++ b/internal/cli/setup/install_config_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "pipelock-setup-test-config-*")
+	if err != nil {
+		panic(err)
+	}
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: balanced\n"), 0o600); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("PIPELOCK_CONFIG", cfgPath); err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/cli/setup/jetbrains.go
+++ b/internal/cli/setup/jetbrains.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/spf13/cobra"
 )
 
@@ -44,6 +45,7 @@ func jetbrainsInstallCmd() *cobra.Command {
 		configFile string
 		sandbox    bool
 		workspace  string
+		quiet      bool
 	)
 
 	cmd := &cobra.Command{
@@ -63,7 +65,7 @@ servers are skipped (idempotent). A .bak backup is created before modification.`
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runJetbrainsInstall(cmd, global, project, dryRun, configFile, sandbox, workspace)
+			return runJetbrainsInstall(cmd, global, project, dryRun, configFile, sandbox, workspace, quiet)
 		},
 	}
 
@@ -73,6 +75,7 @@ servers are skipped (idempotent). A .bak backup is created before modification.`
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "path to pipelock config file for --config passthrough")
 	cmd.Flags().BoolVar(&sandbox, "sandbox", false, "enable sandbox mode for wrapped MCP servers")
 	cmd.Flags().StringVar(&workspace, "workspace", "", "workspace path for sandbox mode")
+	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress config provenance output")
 
 	return cmd
 }
@@ -119,10 +122,15 @@ func junieConfigPath(global bool) (string, error) {
 	return filepath.Join(".", ".junie", "mcp", "mcp.json"), nil
 }
 
-func runJetbrainsInstall(cmd *cobra.Command, global, project, dryRun bool, configFile string, sandbox bool, workspace string) error {
+func runJetbrainsInstall(cmd *cobra.Command, global, project, dryRun bool, configFile string, sandbox bool, workspace string, quiet bool) error {
 	if global && project {
 		return fmt.Errorf("--global and --project are mutually exclusive")
 	}
+	resolvedConfig, err := cliutil.ResolveConfigForInstall(configFile)
+	if err != nil {
+		return err
+	}
+	cliutil.WriteInstallConfigProvenance(cmd.ErrOrStderr(), "jetbrains install", resolvedConfig, quiet)
 
 	// Default to global (user-level) when neither flag is set.
 	// This ensures the default install target is visible to pipelock discover.
@@ -154,7 +162,7 @@ func runJetbrainsInstall(cmd *cobra.Command, global, project, dryRun bool, confi
 			continue
 		}
 
-		newServer, meta, err := wrapMCPServer(server, exe, configFile, sandbox, workspace)
+		newServer, meta, err := wrapMCPServer(server, exe, resolvedConfig.Path, sandbox, workspace)
 		if err != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping server %q: %v\n", name, err)
 			continue

--- a/internal/cliutil/config.go
+++ b/internal/cliutil/config.go
@@ -79,7 +79,7 @@ func WriteInstallConfigProvenance(w io.Writer, surface string, resolved InstallC
 		return
 	}
 	_, _ = fmt.Fprintf(w, "pipelock %s: config: built-in defaults; no PIPELOCK_CONFIG, user config, or system config was found\n", surface)
-	_, _ = fmt.Fprintln(w, "pipelock: installed hooks will use built-in defaults until reinstalled with --config or a standard config path exists")
+	_, _ = fmt.Fprintln(w, "pipelock: the installed integration will use built-in defaults until reinstalled with --config or a standard config path exists")
 }
 
 // ConfigPathIsSecure verifies that a discovered config file is safe to trust.

--- a/internal/cliutil/config.go
+++ b/internal/cliutil/config.go
@@ -5,11 +5,14 @@ package cliutil
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
+
+var defaultSystemConfigPath = "/etc/pipelock/pipelock.yaml"
 
 // LoadConfigOrDefault loads a config file if path is non-empty, otherwise
 // returns the built-in defaults.
@@ -22,6 +25,61 @@ func LoadConfigOrDefault(path string) (*config.Config, error) {
 		return cfg, nil
 	}
 	return config.Defaults(), nil
+}
+
+// InstallConfigResolution records the config path embedded into an installed
+// hook/wrapper and the source used to choose it.
+type InstallConfigResolution struct {
+	Path     string
+	Source   string
+	Explicit bool
+}
+
+// ResolveConfigForInstall resolves the config an installer should embed into
+// generated hook or wrapper commands. It intentionally never checks cwd-local
+// pipelock.yaml files; install-time config must be stable and operator-owned,
+// not dependent on the directory the agent later runs from.
+func ResolveConfigForInstall(path string) (InstallConfigResolution, error) {
+	if path != "" {
+		clean, err := filepath.Abs(filepath.Clean(path))
+		if err != nil {
+			return InstallConfigResolution{}, fmt.Errorf("resolving config path %q: %w", path, err)
+		}
+		if err := ConfigPathIsSecure(clean); err != nil {
+			return InstallConfigResolution{}, err
+		}
+		if _, err := config.Load(clean); err != nil {
+			return InstallConfigResolution{}, fmt.Errorf("loading config %q: %w", clean, err)
+		}
+		return InstallConfigResolution{Path: clean, Source: "explicit --config", Explicit: true}, nil
+	}
+
+	discovered, err := DiscoverConfigPathStrict()
+	if err != nil {
+		return InstallConfigResolution{}, err
+	}
+	if discovered == "" {
+		return InstallConfigResolution{Source: "built-in defaults"}, nil
+	}
+	if _, err := config.Load(discovered); err != nil {
+		return InstallConfigResolution{}, fmt.Errorf("loading discovered config %q: %w", discovered, err)
+	}
+	return InstallConfigResolution{Path: discovered, Source: "auto-discovered"}, nil
+}
+
+// WriteInstallConfigProvenance reports the config an installer embedded. Keep
+// this operator-facing; generated hooks may later run from arbitrary working
+// directories, so the install output must make the trust boundary explicit.
+func WriteInstallConfigProvenance(w io.Writer, surface string, resolved InstallConfigResolution, quiet bool) {
+	if quiet || w == nil {
+		return
+	}
+	if resolved.Path != "" {
+		_, _ = fmt.Fprintf(w, "pipelock %s: config: %s (%s)\n", surface, resolved.Path, resolved.Source)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "pipelock %s: config: built-in defaults; no PIPELOCK_CONFIG, user config, or system config was found\n", surface)
+	_, _ = fmt.Fprintln(w, "pipelock: installed hooks will use built-in defaults until reinstalled with --config or a standard config path exists")
 }
 
 // ConfigPathIsSecure verifies that a discovered config file is safe to trust.
@@ -69,7 +127,7 @@ func configOwnershipSecure(ownerUID, euid int) bool {
 // wrapped argv so the spawned subprocess loads the same config as the
 // operator's main pipelock service.
 func DiscoverConfigPath() string {
-	return discoverConfigPath("/etc/pipelock/pipelock.yaml")
+	return discoverConfigPath(defaultSystemConfigPath)
 }
 
 // DiscoverConfigPathStrict returns the first secure config file pipelock would
@@ -78,7 +136,7 @@ func DiscoverConfigPath() string {
 // being silently skipped. Use this for security-sensitive commands where
 // falling back to defaults would hide an unsafe operator config.
 func DiscoverConfigPathStrict() (string, error) {
-	return discoverConfigPathStrict("/etc/pipelock/pipelock.yaml")
+	return discoverConfigPathStrict(defaultSystemConfigPath)
 }
 
 func configPathCandidates(systemPath string) []string {

--- a/internal/cliutil/config_test.go
+++ b/internal/cliutil/config_test.go
@@ -485,7 +485,7 @@ func TestConfigPathIsSecure_MissingRejected(t *testing.T) {
 
 func TestConfigPathIsSecure_NonRegularRejected(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "pipelock.yaml")
-	if err := os.Mkdir(dir, 0o700); err != nil {
+	if err := os.Mkdir(dir, 0o750); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/cliutil/config_test.go
+++ b/internal/cliutil/config_test.go
@@ -151,6 +151,17 @@ func TestResolveConfigForInstall_ExplicitSecureConfig(t *testing.T) {
 	}
 }
 
+func TestResolveConfigForInstall_RejectsMalformedExplicitConfig(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: [\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ResolveConfigForInstall(cfg); err == nil {
+		t.Fatal("expected malformed explicit config to be rejected")
+	}
+}
+
 func TestResolveConfigForInstall_RejectsUnsafeExplicitConfig(t *testing.T) {
 	cfg := filepath.Join(t.TempDir(), "pipelock.yaml")
 	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
@@ -163,6 +174,43 @@ func TestResolveConfigForInstall_RejectsUnsafeExplicitConfig(t *testing.T) {
 
 	if _, err := ResolveConfigForInstall(cfg); err == nil {
 		t.Fatal("expected unsafe explicit config to be rejected")
+	}
+}
+
+func TestResolveConfigForInstall_AutoDiscoversEnvConfig(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", cfg)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	resolved, err := ResolveConfigForInstall("")
+	if err != nil {
+		t.Fatalf("ResolveConfigForInstall: %v", err)
+	}
+	if resolved.Path != cfg {
+		t.Fatalf("Path = %q, want %q", resolved.Path, cfg)
+	}
+	if resolved.Source != "auto-discovered" || resolved.Explicit {
+		t.Fatalf("unexpected resolution metadata: %#v", resolved)
+	}
+}
+
+func TestResolveConfigForInstall_RejectsMalformedDiscoveredConfig(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: [\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", cfg)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	if _, err := ResolveConfigForInstall(""); err == nil {
+		t.Fatal("expected malformed discovered config to be rejected")
 	}
 }
 
@@ -202,16 +250,49 @@ func TestResolveConfigForInstall_IgnoresCWDConfig(t *testing.T) {
 }
 
 func TestWriteInstallConfigProvenance(t *testing.T) {
-	var out bytes.Buffer
-	WriteInstallConfigProvenance(&out, "cursor install", InstallConfigResolution{
-		Path:   "/secure/pipelock.yaml",
-		Source: "auto-discovered",
-	}, false)
+	t.Run("path", func(t *testing.T) {
+		var out bytes.Buffer
+		WriteInstallConfigProvenance(&out, "cursor install", InstallConfigResolution{
+			Path:   "/secure/pipelock.yaml",
+			Source: "auto-discovered",
+		}, false)
 
-	got := out.String()
-	if !strings.Contains(got, "cursor install") || !strings.Contains(got, "/secure/pipelock.yaml") {
-		t.Fatalf("provenance output missing install surface/path: %q", got)
-	}
+		got := out.String()
+		if !strings.Contains(got, "cursor install") || !strings.Contains(got, "/secure/pipelock.yaml") {
+			t.Fatalf("provenance output missing install surface/path: %q", got)
+		}
+	})
+
+	t.Run("built in defaults", func(t *testing.T) {
+		var out bytes.Buffer
+		WriteInstallConfigProvenance(&out, "git install-hooks", InstallConfigResolution{
+			Source: "built-in defaults",
+		}, false)
+
+		got := out.String()
+		if !strings.Contains(got, "git install-hooks") || !strings.Contains(got, "built-in defaults") {
+			t.Fatalf("provenance output missing built-in defaults warning: %q", got)
+		}
+		if !strings.Contains(got, "reinstalled with --config") {
+			t.Fatalf("provenance output missing reinstall guidance: %q", got)
+		}
+	})
+
+	t.Run("quiet", func(t *testing.T) {
+		var out bytes.Buffer
+		WriteInstallConfigProvenance(&out, "cursor install", InstallConfigResolution{
+			Path:   "/secure/pipelock.yaml",
+			Source: "explicit --config",
+		}, true)
+		WriteInstallConfigProvenance(nil, "cursor install", InstallConfigResolution{
+			Path:   "/secure/pipelock.yaml",
+			Source: "explicit --config",
+		}, false)
+
+		if out.Len() != 0 {
+			t.Fatalf("quiet provenance wrote output: %q", out.String())
+		}
+	})
 }
 
 // TestDiscoverConfigPath_HomeFallback exercises the legacy ~/.config branch.
@@ -399,6 +480,17 @@ func TestConfigPathIsSecure_GroupOrWorldWritableRejected(t *testing.T) {
 func TestConfigPathIsSecure_MissingRejected(t *testing.T) {
 	if err := ConfigPathIsSecure(filepath.Join(t.TempDir(), "missing.yaml")); err == nil {
 		t.Fatal("missing config should be rejected")
+	}
+}
+
+func TestConfigPathIsSecure_NonRegularRejected(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ConfigPathIsSecure(dir); err == nil {
+		t.Fatal("directory config path should be rejected")
 	}
 }
 

--- a/internal/cliutil/config_test.go
+++ b/internal/cliutil/config_test.go
@@ -4,10 +4,12 @@
 package cliutil
 
 import (
+	"bytes"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -127,6 +129,88 @@ func TestDiscoverConfigPathStrict_ExportedWrapper(t *testing.T) {
 	}
 	if got != cfg {
 		t.Fatalf("DiscoverConfigPathStrict() = %q, want %q", got, cfg)
+	}
+}
+
+func TestResolveConfigForInstall_ExplicitSecureConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := ResolveConfigForInstall(cfg)
+	if err != nil {
+		t.Fatalf("ResolveConfigForInstall: %v", err)
+	}
+	if resolved.Path != cfg {
+		t.Fatalf("Path = %q, want %q", resolved.Path, cfg)
+	}
+	if resolved.Source != "explicit --config" || !resolved.Explicit {
+		t.Fatalf("unexpected resolution metadata: %#v", resolved)
+	}
+}
+
+func TestResolveConfigForInstall_RejectsUnsafeExplicitConfig(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unsafeMode := os.FileMode(0o600 | 0o020)
+	if err := os.Chmod(cfg, unsafeMode); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ResolveConfigForInstall(cfg); err == nil {
+		t.Fatal("expected unsafe explicit config to be rejected")
+	}
+}
+
+func TestResolveConfigForInstall_IgnoresCWDConfig(t *testing.T) {
+	oldSystem := defaultSystemConfigPath
+	defaultSystemConfigPath = filepath.Join(t.TempDir(), "missing-system.yaml")
+	t.Cleanup(func() { defaultSystemConfigPath = oldSystem })
+
+	dir := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("pipelock.yaml", []byte("mode: strict\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PIPELOCK_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	resolved, err := ResolveConfigForInstall("")
+	if err != nil {
+		t.Fatalf("ResolveConfigForInstall: %v", err)
+	}
+	if resolved.Path != "" || resolved.Source != "built-in defaults" {
+		t.Fatalf("cwd-local config must not be discovered for installs: %#v", resolved)
+	}
+}
+
+func TestWriteInstallConfigProvenance(t *testing.T) {
+	var out bytes.Buffer
+	WriteInstallConfigProvenance(&out, "cursor install", InstallConfigResolution{
+		Path:   "/secure/pipelock.yaml",
+		Source: "auto-discovered",
+	}, false)
+
+	got := out.String()
+	if !strings.Contains(got, "cursor install") || !strings.Contains(got, "/secure/pipelock.yaml") {
+		t.Fatalf("provenance output missing install surface/path: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve and validate installer config paths before writing generated hooks or MCP wrappers
- embed the resolved absolute config path for Claude, Cursor, Codex, JetBrains, and git hooks
- add Cursor hook removal and document installer config provenance behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cursor **install** and **remove** for managing `hooks.json`, with config-aware `cursor hook --config ...` commands.
  * Added **--quiet** support for git hook installation and for Cursor, Claude Code, Codex, and JetBrains to suppress config provenance output.
* **Bug Fixes**
  * Improved pipelock-managed hook detection so config-aware hooks are identified precisely, avoiding clobbering unrelated commands.
  * Install now embeds the **resolved absolute** config path when `--config` is provided.
* **Documentation**
  * Updated integration guides (including Cursor) to describe `--config` behavior, provenance output, and the config embedding walkthrough.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->