### PR TITLE
Behavioral-baseline runtime enforcement + fail-safe taint default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1080,7 +1080,6 @@ behavioral_baseline:
     - tool_calls
     - unique_tools
     - domains
-    - bytes
     - duration
     - requests
   poison_resistance: true
@@ -1095,7 +1094,7 @@ behavioral_baseline:
 | `deviation_action` | `"warn"` | Action for locked-profile deviations: `warn`, `ask`, or `block` |
 | `auto_ratify` | `false` | Automatically lock learned profiles. Dangerous for production because poisoned training traffic can approve itself. |
 | `sensitivity_sigma` | `2.0` | Standard-deviation multiplier for deviation detection |
-| `lock_dimensions` | all dimensions | Optional subset of `tool_calls`, `unique_tools`, `domains`, `bytes`, `duration`, `requests` |
+| `lock_dimensions` | `tool_calls`, `unique_tools`, `domains`, `duration`, `requests` | Optional subset of `tool_calls`, `unique_tools`, `domains`, `duration`, `requests`. `bytes` remains stored in profiles for compatibility but is not part of default enforcement until transport byte recording is wired into session state. |
 | `poison_resistance` | `true` | Trim high-sigma training outliers before building the profile |
 | `seasonality_mode` | `"none"` | Seasonality mode; only `none` is currently enforced |
 
@@ -2477,7 +2476,7 @@ The `action` knob applies only to unsigned tools. A tool whose attestation is pr
 
 ## Behavioral Baseline
 
-Profile-then-lock behavioral analysis per agent. Pipelock observes an agent's sessions, builds a statistical profile of its normal behavior (tool calls, unique tools, domains, bytes, duration, requests), and once the profile is ratified and locked, flags or blocks sessions that deviate beyond `sensitivity_sigma` standard deviations from the learned mean.
+Profile-then-lock behavioral analysis per agent. Pipelock observes an agent's sessions, builds a statistical profile of its normal behavior (tool calls, unique tools, domains, duration, requests, with bytes retained for profile compatibility), and once the profile is ratified and locked, flags or blocks sessions that deviate beyond `sensitivity_sigma` standard deviations from the learned mean.
 
 ```yaml
 session_profiling:
@@ -2498,7 +2497,7 @@ behavioral_baseline:
 | `profile_dir` | (required if enabled) | Directory where learned profiles persist as JSON |
 | `auto_ratify` | `false` | Lock learned profiles without operator approval. **Dangerous:** an attacker active during the learning window gets their behavior baselined as normal. |
 | `sensitivity_sigma` | `2.0` | Standard deviations from the learned mean before a metric counts as deviant |
-| `lock_dimensions` | all | Metrics to enforce: `tool_calls`, `unique_tools`, `domains`, `bytes`, `duration`, `requests` |
+| `lock_dimensions` | `tool_calls`, `unique_tools`, `domains`, `duration`, `requests` | Metrics to enforce. `bytes` is accepted for existing profiles/configs but is not part of default enforcement until session byte recording is wired on production transports. |
 | `poison_resistance` | `true` | Trim outlier sessions when building the profile, so adversarial sessions during learning have bounded influence |
 | `seasonality_mode` | `none` | Only `none` is implemented. `labeled` and `time` are reserved and rejected by the baseline engine at startup. |
 
@@ -2515,6 +2514,7 @@ taint:
   enabled: true                        # default: true
   policy: balanced                     # strict, balanced, permissive (default: balanced)
   recent_sources: 10                   # bounded history of recent taint-raising events (default: 10)
+  fail_safe_classification: false      # unknown read/tool classifications become protected when true
   allowlisted_domains:                 # fetches from these domains do NOT raise session taint
     - "docs.anthropic.com"
     - "docs.github.com"
@@ -2551,6 +2551,7 @@ taint:
 | `enabled` | bool | `true` | Master switch. Omit to get the security default (enabled). |
 | `policy` | string | `balanced` | `strict` is the most conservative taint policy, `balanced` is the security default, and `permissive` observes taint without changing enforcement. |
 | `recent_sources` | int | `10` | How many recent taint sources to keep per session for receipt reporting. |
+| `fail_safe_classification` | bool | `false` | When true, unknown or low-confidence read/tool classifications are treated as protected instead of passing the read-only shortcut. |
 | `allowlisted_domains` | []string | 3 high-trust documentation domains | Responses from these domains do not raise taint. Supports `MatchDomain` wildcards. |
 | `trusted_mcp_servers` | []string | empty | MCP server names whose clean responses do not raise session taint. Entries match `pipelock mcp proxy --server-name`; URLs and slashes are rejected. This does not disable MCP response scanning, and prompt-injection hits can still raise hostile taint. |
 | `protected_paths` | []string | 7 patterns (see above) | Globs for file paths or tool args that are blocked for tainted sessions. |

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -754,6 +754,7 @@ Key-free evidence capture:
 			// profiling config as the HTTP proxy. store and adaptiveCfg are nil-safe
 			// downstream when session profiling is disabled.
 			var store session.Store
+			var baselineChecker session.BaselineChecker
 			var adaptiveCfg *config.AdaptiveEnforcement
 			var mcpMetrics *metrics.Metrics
 			if cfg.AdaptiveEnforcement.Enabled {
@@ -769,6 +770,7 @@ Key-free evidence capture:
 				}
 				defer sm.Close()
 				store = sm.AsStore()
+				baselineChecker = sm
 			}
 
 			// Denial-of-wallet tracker: _default budget is free tier (always
@@ -1027,7 +1029,7 @@ Key-free evidence capture:
 						InputCfg: inputCfg, RequestBodyCfg: &cfg.RequestBodyScanning,
 						ToolCfg: toolCfg, PolicyCfg: policyCfg,
 						KillSwitch: ks, ChainMatcher: chainMatcher,
-						CEE: cee, Store: store, AdaptiveCfgFn: adaptiveFn, Metrics: mcpMetrics,
+						CEE: cee, Store: store, Baseline: baselineChecker, AdaptiveCfgFn: adaptiveFn, Metrics: mcpMetrics,
 						ConfigHash: captureConfigHash, Profile: captureProfile,
 						AddressProtectionAgent: captureProfile,
 						RedirectRT:             buildRedirectRT(cfg),
@@ -1066,7 +1068,7 @@ Key-free evidence capture:
 						Scanner: sc, Approver: approver,
 						InputCfg: inputCfg, ToolCfg: toolCfg, PolicyCfg: policyCfg,
 						KillSwitch: ks, ChainMatcher: chainMatcher,
-						CEE: cee, Store: store,
+						CEE: cee, Store: store, Baseline: baselineChecker,
 						AdaptiveCfg:            adaptiveCfg,
 						ConfigHash:             captureConfigHash,
 						Profile:                captureProfile,
@@ -1106,7 +1108,7 @@ Key-free evidence capture:
 					Scanner: sc, Approver: approver,
 					InputCfg: inputCfg, ToolCfg: toolCfg, PolicyCfg: policyCfg,
 					KillSwitch: ks, ChainMatcher: chainMatcher,
-					CEE: cee, Store: store,
+					CEE: cee, Store: store, Baseline: baselineChecker,
 					AdaptiveCfg: adaptiveCfg, Metrics: mcpMetrics,
 					ConfigHash: captureConfigHash, Profile: captureProfile,
 					AddressProtectionAgent: captureProfile,
@@ -1271,7 +1273,7 @@ Key-free evidence capture:
 					Scanner: sc, Approver: approver,
 					InputCfg: inputCfg, ToolCfg: toolCfg, PolicyCfg: policyCfg,
 					KillSwitch: ks, ChainMatcher: chainMatcher,
-					CEE: cee, Store: store,
+					CEE: cee, Store: store, Baseline: baselineChecker,
 					AdaptiveCfg: adaptiveCfg, Metrics: mcpMetrics,
 					ConfigHash: captureConfigHash, Profile: captureProfile,
 					AddressProtectionAgent: captureProfile,
@@ -1389,7 +1391,7 @@ Key-free evidence capture:
 				Scanner: sc, Approver: approver,
 				InputCfg: inputCfg, ToolCfg: toolCfg, PolicyCfg: policyCfg,
 				KillSwitch: ks, ChainMatcher: chainMatcher,
-				CEE: cee, Store: store,
+				CEE: cee, Store: store, Baseline: baselineChecker,
 				AdaptiveCfg: adaptiveCfg, Metrics: mcpMetrics,
 				ConfigHash: captureConfigHash, Profile: captureProfile,
 				AddressProtectionAgent: captureProfile,

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -741,6 +741,7 @@ func (s *Server) Start(ctx context.Context) error {
 				AuditLogger:              s.logger,
 				CEEFn:                    s.currentMCPCEE,
 				Store:                    mcpStore,
+				BaselineFn:               s.proxy.SessionBaselineChecker,
 				AdaptiveCfgFn:            mcpAdaptiveFn,
 				Metrics:                  s.metrics,
 				RedirectRTFn:             mcpRedirectRTFn,

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -456,6 +456,15 @@ func implausibleReloadTeardownReasons(oldCfg, newCfg *config.Config) []string {
 		reasons = append(reasons, "behavioral_baseline.deviation_action downgraded")
 	}
 
+	// A live profile_dir change is a posture teardown: Reconfigure swaps the
+	// dir in memory without loading profiles from it, so locked profiles are
+	// silently orphaned on the next restart (fail-open). Require a full restart
+	// to move the profile store instead of a hot reload.
+	if oldCfg.BehavioralBaseline.Enabled && newCfg.BehavioralBaseline.Enabled &&
+		oldCfg.BehavioralBaseline.ProfileDir != newCfg.BehavioralBaseline.ProfileDir {
+		reasons = append(reasons, "behavioral_baseline.profile_dir changed")
+	}
+
 	return reasons
 }
 

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -435,6 +435,7 @@ func implausibleReloadTeardownReasons(oldCfg, newCfg *config.Config) []string {
 	appendDisabled("mcp_tool_policy.enabled", oldCfg.MCPToolPolicy.Enabled, newCfg.MCPToolPolicy.Enabled)
 	appendDisabled("session_profiling.enabled", oldCfg.SessionProfiling.Enabled, newCfg.SessionProfiling.Enabled)
 	appendDisabled("adaptive_enforcement.enabled", oldCfg.AdaptiveEnforcement.Enabled, newCfg.AdaptiveEnforcement.Enabled)
+	appendDisabled("behavioral_baseline.enabled", oldCfg.BehavioralBaseline.Enabled, newCfg.BehavioralBaseline.Enabled)
 	appendDisabled("mcp_session_binding.enabled", oldCfg.MCPSessionBinding.Enabled, newCfg.MCPSessionBinding.Enabled)
 	appendDisabled("a2a_scanning.enabled", oldCfg.A2AScanning.Enabled, newCfg.A2AScanning.Enabled)
 	appendDisabled("tool_chain_detection.enabled", oldCfg.ToolChainDetection.Enabled, newCfg.ToolChainDetection.Enabled)
@@ -448,6 +449,11 @@ func implausibleReloadTeardownReasons(oldCfg, newCfg *config.Config) []string {
 	// only WARNS on this, which strict rejects but balanced does not.
 	if len(oldCfg.DLP.Patterns) > 0 && len(newCfg.DLP.Patterns) == 0 {
 		reasons = append(reasons, "dlp.patterns emptied")
+	}
+	if oldCfg.BehavioralBaseline.Enabled && newCfg.BehavioralBaseline.Enabled &&
+		oldCfg.BehavioralBaseline.DeviationAction == config.ActionBlock &&
+		newCfg.BehavioralBaseline.DeviationAction != config.ActionBlock {
+		reasons = append(reasons, "behavioral_baseline.deviation_action downgraded")
 	}
 
 	return reasons

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1553,6 +1553,37 @@ func TestServer_Reload_ProxyFailureStaysFailSafe(t *testing.T) {
 	}
 }
 
+func TestImplausibleReloadTeardownReasons_BehavioralBaselineWeakening(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := config.Defaults()
+	oldCfg.SessionProfiling.Enabled = true
+	oldCfg.BehavioralBaseline.Enabled = true
+	oldCfg.BehavioralBaseline.DeviationAction = config.ActionBlock
+	oldCfg.BehavioralBaseline.ProfileDir = t.TempDir()
+
+	disabled := oldCfg.Clone()
+	disabled.BehavioralBaseline.Enabled = false
+	if reasons := implausibleReloadTeardownReasons(oldCfg, disabled); !containsString(reasons, "behavioral_baseline.enabled disabled") {
+		t.Fatalf("baseline disable reasons = %v, want behavioral_baseline.enabled disabled", reasons)
+	}
+
+	downgraded := oldCfg.Clone()
+	downgraded.BehavioralBaseline.DeviationAction = config.ActionWarn
+	if reasons := implausibleReloadTeardownReasons(oldCfg, downgraded); !containsString(reasons, "behavioral_baseline.deviation_action downgraded") {
+		t.Fatalf("baseline downgrade reasons = %v, want behavioral_baseline.deviation_action downgraded", reasons)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 // TestServer_MCPListener_ResponseScanningFallback verifies the
 // ResolveRuntime interaction for --mcp-listen: listener mode does NOT
 // trigger the response-scanning fallback (that is only for RuntimeMCPProxy

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1573,6 +1573,15 @@ func TestImplausibleReloadTeardownReasons_BehavioralBaselineWeakening(t *testing
 	if reasons := implausibleReloadTeardownReasons(oldCfg, downgraded); !containsString(reasons, "behavioral_baseline.deviation_action downgraded") {
 		t.Fatalf("baseline downgrade reasons = %v, want behavioral_baseline.deviation_action downgraded", reasons)
 	}
+
+	// A live profile_dir move orphans locked profiles on the next restart
+	// (Reconfigure does not reload the new dir), so it must be rejected as a
+	// teardown rather than hot-applied.
+	movedDir := oldCfg.Clone()
+	movedDir.BehavioralBaseline.ProfileDir = t.TempDir()
+	if reasons := implausibleReloadTeardownReasons(oldCfg, movedDir); !containsString(reasons, "behavioral_baseline.profile_dir changed") {
+		t.Fatalf("baseline profile_dir change reasons = %v, want behavioral_baseline.profile_dir changed", reasons)
+	}
 }
 
 func containsString(values []string, want string) bool {

--- a/internal/config/fail_safe_classification_test.go
+++ b/internal/config/fail_safe_classification_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTaint_FailSafeClassification_ConfigStates exercises the six config states
+// required for a security-sensitive boolean: omitted, YAML null/blank, explicit
+// false, explicit true, reload-with-change, and reload-without-change. The
+// default MUST be false (fail-safe classification is opt-in), omission must not
+// silently enable it, and toggling it on reload must apply cleanly without being
+// treated as a posture teardown.
+func TestTaint_FailSafeClassification_ConfigStates(t *testing.T) {
+	const base = "taint:\n  enabled: true\n"
+
+	load := func(t *testing.T, extra string) *Config {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "pipelock.yaml")
+		if err := os.WriteFile(path, []byte(base+extra), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load(): %v", err)
+		}
+		return cfg
+	}
+
+	valueStates := []struct {
+		name  string
+		extra string
+		want  bool
+	}{
+		{"omitted", "", false},
+		{"yaml_null_blank", "  fail_safe_classification:\n", false},
+		{"explicit_false", "  fail_safe_classification: false\n", false},
+		{"explicit_true", "  fail_safe_classification: true\n", true},
+	}
+	for _, s := range valueStates {
+		t.Run(s.name, func(t *testing.T) {
+			if got := load(t, s.extra).Taint.FailSafeClassification; got != s.want {
+				t.Fatalf("fail_safe_classification = %v, want %v", got, s.want)
+			}
+		})
+	}
+
+	// Reload WITH change (off -> on): the new value is applied and the toggle is
+	// not flagged as a reload teardown (it is a hot-reloadable classification knob).
+	t.Run("reload_with_change", func(t *testing.T) {
+		old := load(t, "  fail_safe_classification: false\n")
+		updated := load(t, "  fail_safe_classification: true\n")
+		if old.Taint.FailSafeClassification {
+			t.Fatal("old config should have fail-safe off")
+		}
+		if !updated.Taint.FailSafeClassification {
+			t.Fatal("reloaded config lost the enabled toggle")
+		}
+		for _, w := range ValidateReload(old, updated) {
+			if strings.Contains(w.Field, "fail_safe_classification") {
+				t.Fatalf("hot-reloadable toggle wrongly flagged on reload: %+v", w)
+			}
+		}
+	})
+
+	// Reload WITHOUT change: value is stable and not flagged.
+	t.Run("reload_without_change", func(t *testing.T) {
+		old := load(t, "  fail_safe_classification: true\n")
+		same := load(t, "  fail_safe_classification: true\n")
+		if !same.Taint.FailSafeClassification {
+			t.Fatal("value not stable across an unchanged reload")
+		}
+		for _, w := range ValidateReload(old, same) {
+			if strings.Contains(w.Field, "fail_safe_classification") {
+				t.Fatalf("unchanged toggle flagged on reload: %+v", w)
+			}
+		}
+	})
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1463,14 +1463,15 @@ type MediationEnvelopeReplayCache struct {
 // TaintConfig configures exposure-based policy escalation for sessions that
 // recently observed untrusted content.
 type TaintConfig struct {
-	Enabled            bool                 `yaml:"enabled"`
-	AllowlistedDomains []string             `yaml:"allowlisted_domains"`
-	TrustedMCPServers  []string             `yaml:"trusted_mcp_servers" json:"trusted_mcp_servers,omitempty"`
-	ProtectedPaths     []string             `yaml:"protected_paths"`
-	ElevatedPaths      []string             `yaml:"elevated_paths"`
-	TrustOverrides     []TaintTrustOverride `yaml:"trust_overrides"`
-	Policy             string               `yaml:"policy"`         // strict, balanced, permissive
-	RecentSources      int                  `yaml:"recent_sources"` // bounded recent source history
+	Enabled                bool                 `yaml:"enabled"`
+	AllowlistedDomains     []string             `yaml:"allowlisted_domains"`
+	TrustedMCPServers      []string             `yaml:"trusted_mcp_servers" json:"trusted_mcp_servers,omitempty"`
+	ProtectedPaths         []string             `yaml:"protected_paths"`
+	ElevatedPaths          []string             `yaml:"elevated_paths"`
+	TrustOverrides         []TaintTrustOverride `yaml:"trust_overrides"`
+	Policy                 string               `yaml:"policy"`         // strict, balanced, permissive
+	RecentSources          int                  `yaml:"recent_sources"` // bounded recent source history
+	FailSafeClassification bool                 `yaml:"fail_safe_classification" json:"fail_safe_classification,omitempty"`
 }
 
 // TaintTrustsMCPServer reports whether MCP responses from serverName should be

--- a/internal/mcp/baseline.go
+++ b/internal/mcp/baseline.go
@@ -46,6 +46,21 @@ func recordMCPToolCallAndCheckBaseline(opts MCPProxyOpts, rec session.Recorder, 
 	return decision
 }
 
+func recordMCPBaselineSample(opts MCPProxyOpts, rec session.Recorder) {
+	if rec == nil {
+		return
+	}
+	checker := opts.baselineChecker()
+	if checker == nil {
+		return
+	}
+	agentKey := mcpBaselineAgentKey(opts)
+	if agentKey == "" {
+		return
+	}
+	checker.RecordBaselineForRecorder(agentKey, rec)
+}
+
 func mcpBaselineAgentKey(opts MCPProxyOpts) string {
 	if agent := strings.TrimSpace(opts.addressProtectionAgent()); agent != "" {
 		return agent

--- a/internal/mcp/baseline.go
+++ b/internal/mcp/baseline.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	session "github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+type toolCallRecorder interface {
+	RecordToolCall(toolName string)
+}
+
+func recordMCPToolCallAndCheckBaseline(opts MCPProxyOpts, rec session.Recorder, toolName string) session.BaselineDecision {
+	if rec == nil || strings.TrimSpace(toolName) == "" {
+		return session.BaselineDecision{}
+	}
+	if recorder, ok := rec.(toolCallRecorder); ok {
+		recorder.RecordToolCall(toolName)
+	}
+	checker := opts.baselineChecker()
+	if checker == nil {
+		return session.BaselineDecision{}
+	}
+	agentKey := mcpBaselineAgentKey(opts)
+	if agentKey == "" {
+		return session.BaselineDecision{}
+	}
+	decision := checker.CheckBaselineForRecorder(agentKey, rec)
+	if decision.Action == "" {
+		if decision.Blocked {
+			decision.Action = config.ActionBlock
+		} else {
+			return session.BaselineDecision{}
+		}
+	}
+	if decision.Detail == "" {
+		decision.Detail = "baseline deviation"
+	}
+	if decision.Action == config.ActionAsk {
+		decision.Blocked = true
+	}
+	return decision
+}
+
+func mcpBaselineAgentKey(opts MCPProxyOpts) string {
+	if agent := strings.TrimSpace(opts.addressProtectionAgent()); agent != "" {
+		return agent
+	}
+	return strings.TrimSpace(opts.captureProfile())
+}

--- a/internal/mcp/baseline_coverage_test.go
+++ b/internal/mcp/baseline_coverage_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import "testing"
+
+// TestMCPBaselineAgentKeyResolution covers the identity-key resolution branches:
+// address-protection agent wins, else the capture profile, else empty.
+func TestMCPBaselineAgentKeyResolution(t *testing.T) {
+	if got := mcpBaselineAgentKey(MCPProxyOpts{AddressProtectionAgent: "ident", Profile: "cap-p"}); got != "ident" {
+		t.Fatalf("agent key = %q, want ident", got)
+	}
+	if got := mcpBaselineAgentKey(MCPProxyOpts{AddressProtectionAgent: "  ", Profile: "cap-p"}); got != "cap-p" {
+		t.Fatalf("agent key = %q, want cap-p (profile fallback)", got)
+	}
+	if got := mcpBaselineAgentKey(MCPProxyOpts{}); got != "" {
+		t.Fatalf("agent key = %q, want empty", got)
+	}
+}
+
+// TestRecordMCPBaselineSampleGuards covers the fail-safe no-op guards: a nil
+// recorder and no baseline checker configured must both be safe no-ops.
+func TestRecordMCPBaselineSampleGuards(t *testing.T) {
+	recordMCPBaselineSample(MCPProxyOpts{}, nil)                     // nil recorder -> no-op
+	recordMCPBaselineSample(MCPProxyOpts{}, &baselineTestRecorder{}) // no checker -> no-op
+}

--- a/internal/mcp/baseline_integration_test.go
+++ b/internal/mcp/baseline_integration_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+	"github.com/luckyPipewrench/pipelock/internal/proxy/baseline"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+func TestMCPBehavioralBaselineRealStdioProxyLearnsAndBlocksUnderIdentityKey(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	sm := proxy.NewSessionManager(&cfg.SessionProfiling, nil, metrics.New())
+	t.Cleanup(sm.Close)
+	baselineCfg := &config.BehavioralBaseline{
+		Enabled:          true,
+		LearningWindow:   2,
+		DeviationAction:  config.ActionBlock,
+		ProfileDir:       t.TempDir(),
+		AutoRatify:       false,
+		SensitivitySigma: 2.0,
+		LockDimensions:   []string{"tool_calls", "unique_tools"},
+		SeasonalityMode:  config.SeasonalityModeNone,
+	}
+	if err := sm.EnableBaseline(baselineCfg); err != nil {
+		t.Fatalf("EnableBaseline: %v", err)
+	}
+
+	const identityKey = "identity-k"
+	for i := 0; i < baselineCfg.LearningWindow; i++ {
+		stdout, stderr := runMCPStdioBaselineInvocation(t, sc, sm, identityKey, "steady_tool")
+		if strings.Contains(stdout, `"error"`) || strings.Contains(stderr, "baseline deviation") {
+			t.Fatalf("learning invocation %d unexpectedly blocked\nstdout=%s\nstderr=%s", i, stdout, stderr)
+		}
+	}
+
+	mgr := sm.BaselineManager()
+	if state := mgr.GetState(identityKey); state != baseline.StateRatify {
+		t.Fatalf("identity-key profile state = %q, want %q", state, baseline.StateRatify)
+	}
+	assertNoInvocationBaselineAgents(t, mgr)
+	assertBaselineAgents(t, mgr, identityKey)
+
+	if err := mgr.Ratify(identityKey); err != nil {
+		t.Fatalf("Ratify(%q): %v", identityKey, err)
+	}
+	if state := mgr.GetState(identityKey); state != baseline.StateLocked {
+		t.Fatalf("identity-key profile state after ratify = %q, want %q", state, baseline.StateLocked)
+	}
+
+	stdout, stderr := runMCPStdioBaselineInvocation(t, sc, sm, identityKey, "steady_tool", "deviant_tool")
+	if !strings.Contains(stdout, `"error"`) {
+		t.Fatalf("deviating invocation under locked identity was allowed\nstdout=%s\nstderr=%s", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "baseline deviation") {
+		t.Fatalf("deviating invocation did not log baseline block\nstdout=%s\nstderr=%s", stdout, stderr)
+	}
+
+	const otherIdentityKey = "identity-other"
+	otherStdout, otherStderr := runMCPStdioBaselineInvocation(t, sc, sm, otherIdentityKey, "steady_tool", "deviant_tool")
+	if strings.Contains(otherStdout, `"error"`) || strings.Contains(otherStderr, "baseline deviation") {
+		t.Fatalf("still-learning identity unexpectedly blocked\nstdout=%s\nstderr=%s", otherStdout, otherStderr)
+	}
+	assertNoInvocationBaselineAgents(t, mgr)
+}
+
+func runMCPStdioBaselineInvocation(t *testing.T, sc *scanner.Scanner, sm *proxy.SessionManager, identityKey string, toolNames ...string) (string, string) {
+	t.Helper()
+
+	var stdin strings.Builder
+	for i, toolName := range toolNames {
+		_, _ = fmt.Fprintf(&stdin, `{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":%q,"arguments":{}}}`+"\n", i+1, toolName)
+	}
+
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := mcp.RunProxy(ctx, strings.NewReader(stdin.String()), &stdout, &stderr, []string{os.Args[0], "-test.run=TestMCPBaselineHelperProcess", "--"}, mcp.MCPProxyOpts{
+		Scanner:                sc,
+		Store:                  sm.AsStore(),
+		Baseline:               sm,
+		AddressProtectionAgent: identityKey,
+		Transport:              "mcp_stdio",
+	}, "PIPELOCK_MCP_BASELINE_HELPER=1")
+	if err != nil {
+		t.Fatalf("RunProxy: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	return stdout.String(), stderr.String()
+}
+
+func TestMCPBaselineHelperProcess(t *testing.T) {
+	if os.Getenv("PIPELOCK_MCP_BASELINE_HELPER") != "1" {
+		return
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		var req struct {
+			ID json.RawMessage `json:"id"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil || len(req.ID) == 0 {
+			req.ID = json.RawMessage("null")
+		}
+		_, _ = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"content":[{"type":"text","text":"ok"}]}}`+"\n", req.ID)
+	}
+	os.Exit(0)
+}
+
+func assertBaselineAgents(t *testing.T, mgr *baseline.Manager, want ...string) {
+	t.Helper()
+	got := strings.Join(mgr.ListAgents(), ",")
+	wantJoined := strings.Join(want, ",")
+	if got != wantJoined {
+		t.Fatalf("baseline agents = %q, want %q", got, wantJoined)
+	}
+}
+
+func assertNoInvocationBaselineAgents(t *testing.T, mgr *baseline.Manager) {
+	t.Helper()
+	for _, agent := range mgr.ListAgents() {
+		if strings.HasPrefix(agent, "mcp-stdio-") || strings.HasPrefix(agent, "mcp-http-") || strings.HasPrefix(agent, "mcp-ws-") {
+			t.Fatalf("baseline learned under invocation key %q; want identity key only", agent)
+		}
+	}
+}

--- a/internal/mcp/baseline_test.go
+++ b/internal/mcp/baseline_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"io"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	session "github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+type baselineTestRecorder struct {
+	toolCalls int
+}
+
+func (r *baselineTestRecorder) RecordToolCall(string) {
+	r.toolCalls++
+}
+
+func (r *baselineTestRecorder) RecordSignal(session.SignalType, float64) (bool, string, string) {
+	return false, "", ""
+}
+
+func (r *baselineTestRecorder) RecordClean(float64) {}
+
+func (r *baselineTestRecorder) EscalationLevel() int { return 0 }
+
+func (r *baselineTestRecorder) ThreatScore() float64 { return 0 }
+
+type identityBaselineChecker struct {
+	t               *testing.T
+	wantAgentKey    string
+	blockedAgentKey string
+}
+
+func (c *identityBaselineChecker) CheckBaselineForRecorder(agentKey string, rec session.Recorder) session.BaselineDecision {
+	if agentKey != c.wantAgentKey {
+		c.t.Fatalf("baseline checked agent key %q, want identity key %q", agentKey, c.wantAgentKey)
+	}
+	r, ok := rec.(*baselineTestRecorder)
+	if !ok {
+		c.t.Fatalf("baseline checked with recorder %T, want *baselineTestRecorder", rec)
+	}
+	if r.toolCalls != 1 {
+		c.t.Fatalf("baseline checked before recording tool call: tool_calls=%d", r.toolCalls)
+	}
+	if agentKey == c.blockedAgentKey {
+		return session.BaselineDecision{Blocked: true, Action: config.ActionBlock, Detail: "baseline deviation: tool_calls"}
+	}
+	return session.BaselineDecision{}
+}
+
+func TestMCPBehavioralBaselineUsesIdentityKeyNotInvocationKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	rec := &baselineTestRecorder{}
+	checker := &identityBaselineChecker{
+		t:               t,
+		wantAgentKey:    "identity-k",
+		blockedAgentKey: "identity-k",
+	}
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"README.md"}}}`)
+	blocked := scanHTTPInput(msg, io.Discard, "mcp-http-42", "mcp-http-42", MCPProxyOpts{
+		Scanner:                sc,
+		Rec:                    rec,
+		Baseline:               checker,
+		AddressProtectionAgent: "identity-k",
+		Transport:              "mcp_http_listener",
+	})
+
+	if blocked == nil {
+		t.Fatal("MCP baseline deviation was allowed; want JSON-RPC block")
+	}
+}

--- a/internal/mcp/baseline_test.go
+++ b/internal/mcp/baseline_test.go
@@ -53,6 +53,8 @@ func (c *identityBaselineChecker) CheckBaselineForRecorder(agentKey string, rec 
 	return session.BaselineDecision{}
 }
 
+func (c *identityBaselineChecker) RecordBaselineForRecorder(string, session.Recorder) {}
+
 func TestMCPBehavioralBaselineUsesIdentityKeyNotInvocationKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -661,6 +661,32 @@ func ForwardScannedInput(
 
 		// All clean - forward (with block_all and CEE checks).
 		if verdict.Clean && !policyVerdict.Matched && bindingAction == "" && chainAction == "" {
+			if toolCallName != "" {
+				baselineDecision := recordMCPToolCallAndCheckBaseline(opts, rec, toolCallName)
+				switch baselineDecision.Action {
+				case config.ActionBlock, config.ActionAsk:
+					_, _ = fmt.Fprintf(logW, "pipelock: input line %d: blocked %s request (%s)\n",
+						lineNum, methodToolsCall, baselineDecision.Detail)
+					recordAdaptiveSignal(session.SignalBlock)
+					errMsg := ""
+					if baselineDecision.Action == config.ActionAsk {
+						errMsg = "pipelock: MCP request blocked by behavioral baseline"
+					}
+					blockedCh <- BlockedRequest{
+						ID:             verdict.ID,
+						IsNotification: isRPCNotification(verdict.ID),
+						LogMessage:     fmt.Sprintf("pipelock: input line %d: blocked (baseline deviation)", lineNum),
+						ErrorCode:      -32001,
+						ErrorMessage:   errMsg,
+					}
+					_ = emitToolReceipt(config.ActionBlock)
+					continue
+				case config.ActionWarn:
+					_, _ = fmt.Fprintf(logW, "pipelock: input line %d: warning — %s request contains flagged content (%s)\n",
+						lineNum, methodToolsCall, baselineDecision.Detail)
+					recordAdaptiveSignal(session.SignalNearMiss)
+				}
+			}
 			// block_all enforcement: deny ALL traffic (including clean) when the
 			// session is at an escalation level with block_all=true.
 			if rec != nil && decide.UpgradeAction("", rec.EscalationLevel(), adaptiveCfg) == config.ActionBlock {
@@ -836,6 +862,18 @@ func ForwardScannedInput(
 			_, _ = fmt.Fprintf(logW, "pipelock: adaptive upgrade %s -> %s (level %s)\n", originalAction, effectiveAction, session.EscalationLabel(rec.EscalationLevel()))
 			if m != nil {
 				m.RecordAdaptiveUpgrade(originalAction, effectiveAction, session.EscalationLabel(rec.EscalationLevel()))
+			}
+		}
+
+		if toolCallName != "" {
+			baselineDecision := recordMCPToolCallAndCheckBaseline(opts, rec, toolCallName)
+			if baselineDecision.Action != "" {
+				reasons = append(reasons, baselineDecision.Detail)
+				effectiveAction = mergeAction(effectiveAction, baselineDecision.Action)
+				if baselineDecision.Action == config.ActionAsk {
+					errCode = -32001
+					errMsg = "pipelock: MCP request blocked by behavioral baseline"
+				}
 			}
 		}
 

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -83,6 +83,7 @@ func RunHTTPProxy(
 	if opts.Store != nil {
 		rec = opts.Store.GetOrCreate(invocationKey)
 	}
+	defer recordMCPBaselineSample(opts, rec)
 
 	safeClientOut := &syncWriter{w: clientOut}
 	safeLogW := &syncWriter{w: logW}

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -504,6 +504,30 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 
 	// All clean - proceed (with block_all and CEE checks).
 	if verdict.Clean && !policyVerdict.Matched && bindingAction == "" && chainAction == "" {
+		if toolName != "" {
+			baselineDecision := recordMCPToolCallAndCheckBaseline(opts, rec, toolName)
+			switch baselineDecision.Action {
+			case config.ActionBlock, config.ActionAsk:
+				_, _ = fmt.Fprintf(logW, "pipelock: input: blocked (%s)\n", baselineDecision.Detail)
+				recordAdaptiveSignal(session.SignalBlock)
+				receiptVerdict = config.ActionBlock
+				errMsg := ""
+				if baselineDecision.Action == config.ActionAsk {
+					errMsg = "pipelock: MCP request blocked by behavioral baseline"
+				}
+				result.Blocked = &BlockedRequest{
+					ID:             verdict.ID,
+					IsNotification: isRPCNotification(verdict.ID),
+					LogMessage:     "blocked (baseline deviation)",
+					ErrorCode:      -32001,
+					ErrorMessage:   errMsg,
+				}
+				return result
+			case config.ActionWarn:
+				_, _ = fmt.Fprintf(logW, "pipelock: input: warning (%s)\n", baselineDecision.Detail)
+				recordAdaptiveSignal(session.SignalNearMiss)
+			}
+		}
 		// block_all enforcement: deny ALL traffic (including clean) when the
 		// session is at an escalation level with block_all=true.
 		if rec != nil && decide.UpgradeAction("", rec.EscalationLevel(), adaptiveCfg) == config.ActionBlock {
@@ -655,6 +679,18 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		if m != nil {
 			m.RecordAdaptiveUpgrade(originalAction, effectiveAction, levelLabel)
+		}
+	}
+
+	if toolName != "" {
+		baselineDecision := recordMCPToolCallAndCheckBaseline(opts, rec, toolName)
+		if baselineDecision.Action != "" {
+			reasons = append(reasons, baselineDecision.Detail)
+			effectiveAction = mergeAction(effectiveAction, baselineDecision.Action)
+			if baselineDecision.Action == config.ActionAsk {
+				errCode = -32001
+				errMsg = "pipelock: MCP request blocked by behavioral baseline"
+			}
 		}
 	}
 

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -132,6 +132,9 @@ func RunHTTPListenerProxy(
 		KillSwitch:               opts.KillSwitch,
 		ChainMatcher:             opts.chainMatcher(),
 		ChainMatcherFn:           opts.ChainMatcherFn,
+		Store:                    opts.Store,
+		Baseline:                 opts.Baseline,
+		BaselineFn:               opts.BaselineFn,
 		AuditLogger:              opts.AuditLogger,
 		CEE:                      opts.cee(),
 		CEEFn:                    opts.CEEFn,
@@ -341,6 +344,7 @@ func RunHTTPListenerProxy(
 			}
 			reqRec = opts.Store.GetOrCreate(adaptiveHost)
 		}
+		defer recordMCPBaselineSample(baseOpts, reqRec)
 
 		warnCtx := scanner.DLPWarnContextFromCtx(r.Context())
 		if warnCtx.Transport == "" {

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -72,6 +72,8 @@ type MCPProxyOpts struct {
 	// Session and adaptive enforcement
 	Store         session.Store
 	Rec           session.Recorder // set by RunProxy after Store.GetOrCreate
+	Baseline      session.BaselineChecker
+	BaselineFn    func() session.BaselineChecker
 	AdaptiveCfg   *config.AdaptiveEnforcement
 	AdaptiveCfgFn AdaptiveConfigFunc // hot-reload aware; used by listener proxy. Nil = use static AdaptiveCfg.
 	TaintCfg      *config.TaintConfig
@@ -379,6 +381,13 @@ func (o MCPProxyOpts) adaptiveCfg() *config.AdaptiveEnforcement {
 		return o.AdaptiveCfgFn()
 	}
 	return o.AdaptiveCfg
+}
+
+func (o MCPProxyOpts) baselineChecker() session.BaselineChecker {
+	if o.BaselineFn != nil {
+		return o.BaselineFn()
+	}
+	return o.Baseline
 }
 
 func (o MCPProxyOpts) taintCfg() *config.TaintConfig {

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1007,6 +1007,7 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	if opts.Store != nil {
 		rec = opts.Store.GetOrCreate(session.NextInvocationKey("mcp-stdio"))
 	}
+	defer recordMCPBaselineSample(opts, rec)
 
 	// Wrap shared writers in mutex adapters. Multiple goroutines write to
 	// clientOut (blocked request drainer + response scanner) and logW

--- a/internal/mcp/proxy_sandbox.go
+++ b/internal/mcp/proxy_sandbox.go
@@ -46,6 +46,7 @@ func RunProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, clientIn io.
 	if opts.Store != nil {
 		rec = opts.Store.GetOrCreate(session.NextInvocationKey("mcp-stdio"))
 	}
+	defer recordMCPBaselineSample(opts, rec)
 
 	safeClientOut := &syncWriter{w: clientOut}
 	safeLogW := &syncWriter{w: logW}

--- a/internal/mcp/proxy_ws.go
+++ b/internal/mcp/proxy_ws.go
@@ -51,6 +51,7 @@ func RunWSProxy(
 	if opts.Store != nil {
 		rec = opts.Store.GetOrCreate(session.NextInvocationKey("mcp-ws"))
 	}
+	defer recordMCPBaselineSample(opts, rec)
 
 	safeClientOut := &syncWriter{w: clientOut}
 	safeLogW := &syncWriter{w: logW}

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -96,12 +96,16 @@ func evaluateMCPTaint(opts MCPProxyOpts, toolName, argsJSON string) taintDecisio
 	if rs, ok := opts.Rec.(session.RiskState); ok {
 		decision.Risk = rs.RiskSnapshot()
 	}
-	decision.ActionClass, decision.Sensitivity, decision.ActionRef = session.ClassifyMCPToolCall(
+	classified := session.ClassifyMCPToolCallWithOptions(
 		toolName,
 		argsJSON,
 		taintCfg.ProtectedPaths,
 		taintCfg.ElevatedPaths,
+		session.ClassificationOptions{FailSafe: taintCfg.FailSafeClassification},
 	)
+	decision.ActionClass = classified.Class
+	decision.Sensitivity = classified.Sensitivity
+	decision.ActionRef = classified.ActionRef
 	decision.ActionRef = mcpActionRef(toolName, decision.ActionRef)
 	if tp, ok := opts.Rec.(session.TaskContextProvider); ok {
 		decision.Task = tp.TaskSnapshot()
@@ -114,11 +118,15 @@ func evaluateMCPTaint(opts MCPProxyOpts, toolName, argsJSON string) taintDecisio
 			return decision
 		}
 	}
-	decision.Result = session.PolicyMatrix{Profile: taintCfg.Policy}.Evaluate(
+	decision.Result = session.PolicyMatrix{Profile: taintCfg.Policy}.EvaluateWithOptions(
 		decision.Risk.Level,
 		decision.ActionClass,
 		decision.Sensitivity,
 		decision.Authority,
+		session.PolicyEvaluateOptions{
+			FailSafeClassification:  taintCfg.FailSafeClassification,
+			ClassificationConfident: classified.Confident,
+		},
 	)
 	if taintTrustOverrideApplies(taintCfg.TrustOverrides, decision.Risk, decision.ActionRef) {
 		decision.Result = session.PolicyDecisionResult{

--- a/internal/proxy/baseline/baseline.go
+++ b/internal/proxy/baseline/baseline.go
@@ -38,6 +38,12 @@ func validateAgentKey(key string) error {
 	return nil
 }
 
+// ValidateAgentKey reports whether key is safe for identity-keyed baseline
+// storage and lookup.
+func ValidateAgentKey(key string) error {
+	return validateAgentKey(key)
+}
+
 // ProfileState is the explicit state machine for baseline lifecycle.
 // Transitions: Observe->Learn (auto), Learn->Ratify (auto),
 // Ratify->Locked (operator only), Locked->Observe (operator only).

--- a/internal/proxy/baseline/baseline.go
+++ b/internal/proxy/baseline/baseline.go
@@ -141,9 +141,16 @@ type Config struct {
 // seasonalityNone is the only supported seasonality mode.
 const seasonalityNone = "none"
 
-// allDimensions is the complete list of enforceable metrics.
-var allDimensions = []string{
+// supportedDimensions is the complete list of accepted metric names.
+var supportedDimensions = []string{
 	"tool_calls", "unique_tools", "domains", "bytes", "duration", "requests",
+}
+
+// defaultDimensions are enforced when lock_dimensions is omitted. Bytes are
+// accepted for existing profiles/configs but excluded from the PR1 default
+// because production traffic does not yet record bytes into SessionState.
+var defaultDimensions = []string{
+	"tool_calls", "unique_tools", "domains", "duration", "requests",
 }
 
 // agentState holds the in-memory state for a single agent.
@@ -183,13 +190,13 @@ func NewManager(cfg Config) (*Manager, error) {
 	}
 
 	// Validate LockDimensions against known metric names.
-	validDims := make(map[string]bool, len(allDimensions))
-	for _, d := range allDimensions {
+	validDims := make(map[string]bool, len(supportedDimensions))
+	for _, d := range supportedDimensions {
 		validDims[d] = true
 	}
 	for _, d := range cfg.LockDimensions {
 		if !validDims[d] {
-			return nil, fmt.Errorf("unsupported lock_dimension %q: valid values are %v", d, allDimensions)
+			return nil, fmt.Errorf("unsupported lock_dimension %q: valid values are %v", d, supportedDimensions)
 		}
 	}
 
@@ -209,6 +216,44 @@ func NewManager(cfg Config) (*Manager, error) {
 	}
 
 	return m, nil
+}
+
+// Reconfigure updates tunables without clearing learned or locked profiles.
+func (m *Manager) Reconfigure(cfg Config) error {
+	if cfg.LearningWindow <= 0 {
+		cfg.LearningWindow = 10
+	}
+	if cfg.SensitivitySigma <= 0 {
+		cfg.SensitivitySigma = 2.0
+	}
+	if cfg.DeviationAction == "" {
+		cfg.DeviationAction = "warn"
+	}
+	if cfg.SeasonalityMode == "" {
+		cfg.SeasonalityMode = seasonalityNone
+	}
+	if cfg.SeasonalityMode != seasonalityNone {
+		return fmt.Errorf("unsupported seasonality_mode %q: only \"none\" is supported", cfg.SeasonalityMode)
+	}
+	validDims := make(map[string]bool, len(supportedDimensions))
+	for _, d := range supportedDimensions {
+		validDims[d] = true
+	}
+	for _, d := range cfg.LockDimensions {
+		if !validDims[d] {
+			return fmt.Errorf("unsupported lock_dimension %q: valid values are %v", d, supportedDimensions)
+		}
+	}
+	if cfg.ProfileDir != "" {
+		if err := os.MkdirAll(cfg.ProfileDir, 0o750); err != nil {
+			return fmt.Errorf("creating profile dir: %w", err)
+		}
+	}
+
+	m.mu.Lock()
+	m.cfg = cfg
+	m.mu.Unlock()
+	return nil
 }
 
 // RecordSession adds a completed session's metrics to the learning set.
@@ -305,6 +350,15 @@ func (m *Manager) Check(agentKey string, current SessionMetrics) []Deviation {
 	}
 
 	return deviations
+}
+
+// CheckErr evaluates current session metrics against the locked profile and
+// returns validation errors separately so enforcement callers can fail closed.
+func (m *Manager) CheckErr(agentKey string, current SessionMetrics) ([]Deviation, error) {
+	if err := validateAgentKey(agentKey); err != nil {
+		return nil, err
+	}
+	return m.Check(agentKey, current), nil
 }
 
 // GetProfile returns the current profile for an agent. Returns nil if
@@ -603,7 +657,7 @@ func (m *Manager) activeDimensions() []string {
 	if len(m.cfg.LockDimensions) > 0 {
 		return m.cfg.LockDimensions
 	}
-	return allDimensions
+	return defaultDimensions
 }
 
 // persistProfile saves a profile to disk as JSON.

--- a/internal/proxy/baseline/restart_durability_test.go
+++ b/internal/proxy/baseline/restart_durability_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package baseline
+
+import "testing"
+
+// TestBaseline_RestartDurability_LockedProfileReloadsAndEnforces proves that a
+// ratified/locked profile survives a process restart: a brand-new Manager over
+// the same ProfileDir must reload the persisted locked profile and keep
+// enforcing deviations. A restart that silently dropped enforcement would be a
+// fail-open across the exact boundary (process restart) the design flagged.
+func TestBaseline_RestartDurability_LockedProfileReloadsAndEnforces(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Enabled:          true,
+		LearningWindow:   3,
+		DeviationAction:  "block",
+		ProfileDir:       dir,
+		SensitivitySigma: 2.0,
+	}
+
+	mgr, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	for range 3 {
+		mgr.RecordSession(testAgent, normalMetrics())
+	}
+	if err := mgr.Ratify(testAgent); err != nil {
+		t.Fatalf("Ratify: %v", err)
+	}
+	if state := mgr.GetState(testAgent); state != StateLocked {
+		t.Fatalf("pre-restart state = %q, want %q", state, StateLocked)
+	}
+
+	// Simulate a process restart: a fresh Manager over the SAME ProfileDir.
+	restarted, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager (restart): %v", err)
+	}
+	if state := restarted.GetState(testAgent); state != StateLocked {
+		t.Fatalf("post-restart state = %q, want %q (durability lost)", state, StateLocked)
+	}
+
+	// The reloaded locked profile must still enforce.
+	if devs := restarted.Check(testAgent, SessionMetrics{ToolCalls: 999}); len(devs) == 0 {
+		t.Fatal("restarted locked profile did not flag a deviation (fail-open across restart)")
+	}
+	// ...and must not flag a normal session (no spurious block after reload).
+	if devs := restarted.Check(testAgent, normalMetrics()); len(devs) != 0 {
+		t.Fatalf("restarted profile flagged a normal session: %d deviations", len(devs))
+	}
+}

--- a/internal/proxy/baseline_enforcement_test.go
+++ b/internal/proxy/baseline_enforcement_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+func testBaselineBlockConfig(t *testing.T) *config.BehavioralBaseline {
+	t.Helper()
+	return &config.BehavioralBaseline{
+		Enabled:          true,
+		LearningWindow:   1,
+		DeviationAction:  config.ActionBlock,
+		ProfileDir:       t.TempDir(),
+		AutoRatify:       true,
+		SensitivitySigma: 2.0,
+		LockDimensions:   []string{"domains", "requests"},
+		SeasonalityMode:  config.SeasonalityModeNone,
+	}
+}
+
+func lockHTTPBaseline(t *testing.T, sm *SessionManager, agent string) {
+	t.Helper()
+	cfg := testSessionConfig()
+	learned := sm.GetOrCreate(agent + "|10.0.0.1")
+	learned.RecordRequest("steady.example", cfg)
+	sm.recordSessionBaseline(learned)
+	if state := sm.BaselineManager().GetState(agent); state != "locked" {
+		t.Fatalf("baseline state = %q, want locked", state)
+	}
+}
+
+func TestRecordSessionActivity_BaselineBlockAfterLock(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.SessionProfiling.Enabled = true
+	cfg.SessionProfiling.AnomalyAction = config.ActionWarn
+	cfg.BehavioralBaseline = *testBaselineBlockConfig(t)
+
+	sm := NewSessionManager(&cfg.SessionProfiling, nil, metrics.New())
+	t.Cleanup(sm.Close)
+	if err := sm.EnableBaseline(&cfg.BehavioralBaseline); err != nil {
+		t.Fatalf("EnableBaseline: %v", err)
+	}
+	lockHTTPBaseline(t, sm, "agent-a")
+
+	p := &Proxy{metrics: metrics.New()}
+	p.sessionMgrPtr.Store(sm)
+	log := audit.NewNop()
+	clean := scanner.Result{Allowed: true}
+
+	first := p.recordSessionActivityWithUserAgent(sessionActivityOptions{
+		ClientIP: "10.0.0.99", Agent: "agent-a", Hostname: "steady.example",
+		RequestID: "req-1", Result: clean, Config: cfg, Logger: log,
+	})
+	if first.Blocked {
+		t.Fatalf("first request blocked before deviation: %+v", first)
+	}
+
+	second := p.recordSessionActivityWithUserAgent(sessionActivityOptions{
+		ClientIP: "10.0.0.99", Agent: "agent-a", Hostname: "deviant.example",
+		RequestID: "req-2", Result: clean, Config: cfg, Logger: log,
+	})
+	if !second.Blocked {
+		t.Fatalf("deviating locked profile allowed: %+v", second)
+	}
+}
+
+func TestSessionManager_CheckBaselineInvalidAgentKeyFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	cfg := testSessionConfig()
+	sm := NewSessionManager(cfg, nil, nil)
+	t.Cleanup(sm.Close)
+	if err := sm.EnableBaseline(testBaselineBlockConfig(t)); err != nil {
+		t.Fatalf("EnableBaseline: %v", err)
+	}
+	sess := sm.GetOrCreate("agent-bad|10.0.0.1")
+	sess.RecordRequest("steady.example", cfg)
+
+	result := sm.CheckBaselineFailClosed("../agent-bad", sess)
+	if result == nil || !result.Blocked || result.Action != config.ActionBlock || result.Err == nil {
+		t.Fatalf("expected invalid agent key to fail closed, got %#v", result)
+	}
+}
+
+func TestSessionManager_ReconfigureBaselinePreservesLockedProfile(t *testing.T) {
+	t.Parallel()
+
+	cfg := testSessionConfig()
+	sm := NewSessionManager(cfg, nil, nil)
+	t.Cleanup(sm.Close)
+	bb := testBaselineBlockConfig(t)
+	if err := sm.EnableBaseline(bb); err != nil {
+		t.Fatalf("EnableBaseline: %v", err)
+	}
+	lockHTTPBaseline(t, sm, "agent-b")
+
+	reloaded := *bb
+	reloaded.DeviationAction = config.ActionWarn
+	if err := sm.ReconfigureBaseline(&reloaded); err != nil {
+		t.Fatalf("ReconfigureBaseline: %v", err)
+	}
+
+	deviant := sm.GetOrCreate("agent-b|10.0.0.99")
+	deviant.RecordRequest("one.example", cfg)
+	deviant.RecordRequest("two.example", cfg)
+	result := sm.CheckBaseline("agent-b", deviant)
+	if result == nil {
+		t.Fatal("locked profile did not survive reload")
+	}
+	if result.Action != config.ActionWarn || result.Blocked {
+		t.Fatalf("baseline result after reload = %+v, want warn non-blocking", result)
+	}
+}
+
+func TestSessionManager_CheckBaselineRaceWithReconfigure(t *testing.T) {
+	t.Parallel()
+
+	cfg := testSessionConfig()
+	sm := NewSessionManager(cfg, nil, nil)
+	t.Cleanup(sm.Close)
+	bb := testBaselineBlockConfig(t)
+	if err := sm.EnableBaseline(bb); err != nil {
+		t.Fatalf("EnableBaseline: %v", err)
+	}
+	lockHTTPBaseline(t, sm, "agent-race")
+	deviant := sm.GetOrCreate("agent-race|10.0.0.99")
+	deviant.RecordRequest("one.example", cfg)
+	deviant.RecordRequest("two.example", cfg)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = sm.CheckBaselineFailClosed("agent-race", deviant)
+			}
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				next := *bb
+				if (i+j)%2 == 0 {
+					next.DeviationAction = config.ActionWarn
+				}
+				next.SensitivitySigma = float64((i+j)%3) + 1
+				if err := sm.ReconfigureBaseline(&next); err != nil {
+					t.Errorf("ReconfigureBaseline: %v", err)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if result := sm.CheckBaselineFailClosed("agent-race", deviant); result == nil {
+		t.Fatal("locked profile missing after concurrent reconfigure/check")
+	}
+}

--- a/internal/proxy/baseline_enforcement_test.go
+++ b/internal/proxy/baseline_enforcement_test.go
@@ -93,6 +93,51 @@ func TestSessionManager_CheckBaselineInvalidAgentKeyFailsClosed(t *testing.T) {
 	}
 }
 
+func TestSessionManager_RecordBaselineForAgentInvalidKeyAndLockedNoOp(t *testing.T) {
+	t.Parallel()
+
+	cfg := testSessionConfig()
+	sm := NewSessionManager(cfg, nil, nil)
+	t.Cleanup(sm.Close)
+	bb := testBaselineBlockConfig(t)
+	bb.AutoRatify = false
+	bb.LockDimensions = []string{"tool_calls"}
+	if err := sm.EnableBaseline(bb); err != nil {
+		t.Fatalf("EnableBaseline: %v", err)
+	}
+
+	invalid := sm.GetOrCreate("mcp-http-invalid")
+	invalid.RecordToolCall("steady_tool")
+	sm.RecordBaselineForAgent("../agent-bad", invalid)
+	if agents := sm.BaselineManager().ListAgents(); len(agents) != 0 {
+		t.Fatalf("invalid identity key created baseline agents: %v", agents)
+	}
+
+	const agent = "agent-locked"
+	learned := sm.GetOrCreate("mcp-http-learn")
+	learned.RecordToolCall("steady_tool")
+	sm.RecordBaselineForAgent(agent, learned)
+	if state := sm.BaselineManager().GetState(agent); state != "ratify" {
+		t.Fatalf("baseline state = %q, want ratify", state)
+	}
+	if err := sm.BaselineManager().Ratify(agent); err != nil {
+		t.Fatalf("Ratify: %v", err)
+	}
+
+	deviant := sm.GetOrCreate("mcp-http-deviant")
+	deviant.RecordToolCall("steady_tool")
+	deviant.RecordToolCall("second_tool")
+	sm.RecordBaselineForAgent(agent, deviant)
+
+	profile := sm.BaselineManager().GetProfile(agent)
+	if profile == nil {
+		t.Fatal("locked profile missing")
+	}
+	if profile.Metrics.ToolCallsPerSession.Mean != 1 {
+		t.Fatalf("locked profile mutated after record: tool_calls mean = %.2f, want 1.00", profile.Metrics.ToolCallsPerSession.Mean)
+	}
+}
+
 func TestSessionManager_ReconfigureBaselinePreservesLockedProfile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proxy/baseline_startup_failclosed_test.go
+++ b/internal/proxy/baseline_startup_failclosed_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// TestNew_FailsClosedWhenBaselineInitFails proves the proxy refuses to start
+// when a configured-enabled behavioral baseline cannot initialize, instead of
+// silently running with enforcement off. seasonality_mode "labeled" is accepted
+// by config validation (forward-compat) but the baseline manager only
+// implements "none", so EnableBaseline fails; New must surface that error.
+func TestNew_FailsClosedWhenBaselineInitFails(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SessionProfiling.Enabled = true
+	cfg.BehavioralBaseline.Enabled = true
+	cfg.BehavioralBaseline.ProfileDir = t.TempDir()
+	cfg.BehavioralBaseline.DeviationAction = config.ActionBlock
+	cfg.BehavioralBaseline.SeasonalityMode = config.SeasonalityModeLabeled
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+	m := metrics.New()
+
+	if _, err := New(cfg, logger, sc, m); err == nil {
+		t.Fatal("proxy.New did not fail closed on behavioral-baseline init failure")
+	}
+}

--- a/internal/proxy/baseline_wiring_coverage_test.go
+++ b/internal/proxy/baseline_wiring_coverage_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+// nonSessionRecorder is a session.Recorder that is NOT a *SessionState, to
+// exercise the type-assertion guard in RecordBaselineForRecorder.
+type nonSessionRecorder struct{}
+
+func (nonSessionRecorder) RecordSignal(session.SignalType, float64) (bool, string, string) {
+	return false, "", ""
+}
+func (nonSessionRecorder) RecordClean(float64)  {}
+func (nonSessionRecorder) EscalationLevel() int { return 0 }
+func (nonSessionRecorder) ThreatScore() float64 { return 0 }
+
+// TestBaselineWiringGuards exercises the fail-safe guard and lifecycle branches
+// of the MCP baseline wiring: safe no-ops when disabled / invalid key / wrong
+// recorder type, and the reconfigure disable + re-enable paths.
+func TestBaselineWiringGuards(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	sm := NewSessionManager(&cfg.SessionProfiling, nil, metrics.New())
+	t.Cleanup(sm.Close)
+
+	sess := sm.GetOrCreate("baseline-guard-session")
+
+	// Baseline disabled: record + check are safe no-ops (nil snapshot).
+	sm.RecordBaselineForAgent("agent-x", sess)
+	if r := sm.CheckBaseline("agent-x", sess); r != nil {
+		t.Fatalf("disabled baseline CheckBaseline = %+v, want nil", r)
+	}
+
+	bcfg := &config.BehavioralBaseline{
+		Enabled: true, LearningWindow: 2, DeviationAction: config.ActionBlock,
+		ProfileDir: t.TempDir(), SensitivitySigma: 2.0, SeasonalityMode: config.SeasonalityModeNone,
+	}
+	if err := sm.EnableBaseline(bcfg); err != nil {
+		t.Fatalf("EnableBaseline: %v", err)
+	}
+
+	// Invalid / empty identity key and nil session are no-ops (never panic, never record).
+	sm.RecordBaselineForAgent("bad/../key", sess)
+	sm.RecordBaselineForAgent("", sess)
+	sm.RecordBaselineForAgent("agent-x", nil)
+	if agents := sm.BaselineManager().ListAgents(); len(agents) != 0 {
+		t.Fatalf("guarded records created agent(s): %v", agents)
+	}
+
+	// A recorder that is not a *SessionState is ignored.
+	sm.RecordBaselineForRecorder("agent-x", nonSessionRecorder{})
+	if agents := sm.BaselineManager().ListAgents(); len(agents) != 0 {
+		t.Fatalf("non-SessionState recorder created agent(s): %v", agents)
+	}
+
+	// Reconfigure disable drops the manager.
+	if err := sm.ReconfigureBaseline(&config.BehavioralBaseline{Enabled: false}); err != nil {
+		t.Fatalf("ReconfigureBaseline disable: %v", err)
+	}
+	if sm.BaselineManager() != nil {
+		t.Fatal("disable reconfigure should drop the baseline manager")
+	}
+
+	// Reconfigure from no-manager state re-enables (EnableBaseline fallback), warn action.
+	if err := sm.ReconfigureBaseline(&config.BehavioralBaseline{
+		Enabled: true, LearningWindow: 2, DeviationAction: config.ActionWarn,
+		ProfileDir: t.TempDir(), SensitivitySigma: 2.0, SeasonalityMode: config.SeasonalityModeNone,
+	}); err != nil {
+		t.Fatalf("ReconfigureBaseline re-enable: %v", err)
+	}
+	if sm.BaselineManager() == nil {
+		t.Fatal("re-enable reconfigure should create the baseline manager")
+	}
+
+	// In-place reconfigure (manager present) with ask action: snapshot swap + baselineActionOrDefault(ask).
+	if err := sm.ReconfigureBaseline(&config.BehavioralBaseline{
+		Enabled: true, LearningWindow: 3, DeviationAction: config.ActionAsk,
+		ProfileDir: t.TempDir(), SensitivitySigma: 2.0, SeasonalityMode: config.SeasonalityModeNone,
+	}); err != nil {
+		t.Fatalf("ReconfigureBaseline in-place: %v", err)
+	}
+
+	// Empty deviation action exercises baselineActionOrDefault's default branch.
+	if err := sm.ReconfigureBaseline(&config.BehavioralBaseline{
+		Enabled: true, LearningWindow: 3, DeviationAction: "",
+		ProfileDir: t.TempDir(), SensitivitySigma: 2.0, SeasonalityMode: config.SeasonalityModeNone,
+	}); err != nil {
+		t.Fatalf("ReconfigureBaseline empty-action: %v", err)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1393,6 +1393,8 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 	p.reloadMu.Lock()
 	defer p.reloadMu.Unlock()
 
+	oldCfg := p.cfgPtr.Load()
+
 	// Build new edition BEFORE swapping config/scanner.
 	// If this fails, keep all existing state unchanged (fail-safe).
 	oldSnap := p.editionPtr.Load()
@@ -1483,6 +1485,49 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		return false
 	}
 
+	var adaptiveCfg *config.AdaptiveEnforcement
+	if cfg.AdaptiveEnforcement.Enabled {
+		adaptiveCfg = &cfg.AdaptiveEnforcement
+	}
+	var airlockCfg *config.Airlock
+	if cfg.Airlock.Enabled {
+		airlockCfg = &cfg.Airlock
+	}
+	var stagedSessionMgr *SessionManager
+	if oldCfg != nil {
+		wasSessionProfilingEnabled := oldCfg.SessionProfiling.Enabled
+		isSessionProfilingEnabled := cfg.SessionProfiling.Enabled
+		switch {
+		case !wasSessionProfilingEnabled && isSessionProfilingEnabled:
+			smOpts := SessionManagerOptions{Logger: p.logger, AirlockCfg: airlockCfg}
+			stagedSessionMgr = NewSessionManager(&cfg.SessionProfiling, adaptiveCfg, p.metrics, smOpts)
+			if cfg.BehavioralBaseline.Enabled {
+				if err := stagedSessionMgr.EnableBaseline(&cfg.BehavioralBaseline); err != nil {
+					p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
+						fmt.Errorf("baseline reload failed, keeping old config: %w", err))
+					stagedSessionMgr.Close()
+					sc.Close()
+					if newEd != nil {
+						newEd.Close()
+					}
+					return false
+				}
+			}
+		case wasSessionProfilingEnabled && isSessionProfilingEnabled:
+			if sm := p.sessionMgrPtr.Load(); sm != nil {
+				if err := sm.ReconfigureBaseline(&cfg.BehavioralBaseline); err != nil {
+					p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
+						fmt.Errorf("baseline reload failed, keeping old config: %w", err))
+					sc.Close()
+					if newEd != nil {
+						newEd.Close()
+					}
+					return false
+				}
+			}
+		}
+	}
+
 	// Publish both emitters now that staging has fully succeeded. The
 	// atomic.Pointer swaps are individually atomic; between them, a
 	// request can observe "new envelope + old receipt" for a few
@@ -1509,7 +1554,6 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		p.receiptKeyPath = receiptStage.keyPath
 	}
 
-	oldCfg := p.cfgPtr.Load()
 	// When redaction is being disabled, publish the config before clearing the
 	// legacy matcher mirror. Enabling keeps the opposite order: runtime first,
 	// then cfg, so a cfg that requires redaction never appears before its
@@ -1572,23 +1616,10 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 	}
 
 	// Toggle session manager lifecycle on config change.
-	var adaptiveCfg *config.AdaptiveEnforcement
-	if cfg.AdaptiveEnforcement.Enabled {
-		adaptiveCfg = &cfg.AdaptiveEnforcement
-	}
-	var airlockCfg *config.Airlock
-	if cfg.Airlock.Enabled {
-		airlockCfg = &cfg.Airlock
-	}
 	wasEnabled := oldCfg.SessionProfiling.Enabled
 	isEnabled := cfg.SessionProfiling.Enabled
 	if !wasEnabled && isEnabled {
-		smOpts := SessionManagerOptions{Logger: p.logger, AirlockCfg: airlockCfg}
-		sm := NewSessionManager(&cfg.SessionProfiling, adaptiveCfg, p.metrics, smOpts)
-		if cfg.BehavioralBaseline.Enabled {
-			_ = sm.EnableBaseline(&cfg.BehavioralBaseline)
-		}
-		p.sessionMgrPtr.Store(sm)
+		p.sessionMgrPtr.Store(stagedSessionMgr)
 	} else if wasEnabled && !isEnabled {
 		if old := p.sessionMgrPtr.Swap(nil); old != nil {
 			old.Close()
@@ -1887,6 +1918,15 @@ func (p *Proxy) scannerProbe(ctx context.Context) error {
 func (p *Proxy) SessionStore() session.Store {
 	if sm := p.sessionMgrPtr.Load(); sm != nil {
 		return sm.AsStore()
+	}
+	return nil
+}
+
+// SessionBaselineChecker returns the proxy's behavioral-baseline checker for
+// sharing with MCP transports. Returns nil when session profiling is disabled.
+func (p *Proxy) SessionBaselineChecker() session.BaselineChecker {
+	if sm := p.sessionMgrPtr.Load(); sm != nil {
+		return sm
 	}
 	return nil
 }
@@ -2244,6 +2284,34 @@ func (p *Proxy) recordSessionActivityWithUserAgent(opts sessionActivityOptions) 
 	ipAnomalies := sm.RecordIPDomain(clientIP, hostname, &cfg.SessionProfiling)
 	anomalies = append(anomalies, ipAnomalies...)
 
+	if baselineResult := sm.CheckBaselineFailClosed(baselineAgentKeyForSessionKey(key), sess); baselineResult != nil {
+		detail := baselineDecisionDetail(baselineResult)
+		if log != nil {
+			log.LogSessionAnomaly(key, "baseline_deviation", detail, clientIP, requestID, 3.0)
+		}
+		if p.metrics != nil {
+			p.metrics.RecordSessionAnomaly("baseline_deviation")
+		}
+		sess.RecordEvent(SessionEvent{
+			Kind:     "anomaly",
+			Type:     "baseline_deviation",
+			Target:   hostname,
+			Detail:   detail,
+			Severity: "warn",
+			Score:    3.0,
+		})
+		switch baselineResult.Action {
+		case config.ActionWarn:
+			// Observe and allow.
+		case config.ActionAsk:
+			return SessionResult{Blocked: true, Detail: detail, Level: sess.EffectiveEscalationLevel(scope)}
+		case config.ActionBlock:
+			return SessionResult{Blocked: true, Detail: detail, Level: sess.EffectiveEscalationLevel(scope)}
+		default:
+			return SessionResult{Blocked: true, Detail: detail, Level: sess.EffectiveEscalationLevel(scope)}
+		}
+	}
+
 	// Record adaptive signals (only when adaptive enforcement is enabled).
 	// escalated tracks whether the current request actually crossed an
 	// adaptive escalation threshold. Downstream airlock triggering is
@@ -2387,6 +2455,14 @@ func (p *Proxy) recordSessionActivityWithUserAgent(opts sessionActivityOptions) 
 	}
 
 	return SessionResult{Level: level}
+}
+
+func baselineAgentKeyForSessionKey(key string) string {
+	kind, agent, _ := classifySessionKey(key)
+	if kind == sessionKindIdentity && agent != "" {
+		return agent
+	}
+	return key
 }
 
 func recordScopedAdaptiveSignal(sess *SessionState, scope string, sig session.SignalType, ep decide.EscalationParams) bool {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -540,7 +540,12 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 		}
 		sm := NewSessionManager(&cfg.SessionProfiling, adaptiveCfg, m, smOpts)
 		if cfg.BehavioralBaseline.Enabled {
-			_ = sm.EnableBaseline(&cfg.BehavioralBaseline) // validated at Load time
+			// Fail closed: a configured-enabled behavioral baseline that cannot
+			// initialize must not be silently swallowed (that leaves enforcement
+			// off while the operator believes deviations are blocked).
+			if err := sm.EnableBaseline(&cfg.BehavioralBaseline); err != nil {
+				return nil, fmt.Errorf("behavioral baseline init: %w", err)
+			}
 		}
 		p.sessionMgrPtr.Store(sm)
 	}

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -1154,6 +1154,16 @@ func (sm *SessionManager) CheckBaselineForRecorder(agentKey string, rec session.
 	}
 }
 
+// RecordBaselineForRecorder records an invocation recorder under an explicit
+// identity key for MCP transports.
+func (sm *SessionManager) RecordBaselineForRecorder(agentKey string, rec session.Recorder) {
+	sess, ok := rec.(*SessionState)
+	if !ok || sess == nil {
+		return
+	}
+	sm.RecordBaselineForAgent(agentKey, sess)
+}
+
 func baselineDecisionDetail(result *BaselineResult) string {
 	if result == nil {
 		return ""
@@ -1169,6 +1179,22 @@ func baselineDecisionDetail(result *BaselineResult) string {
 		parts = append(parts, fmt.Sprintf("%s observed=%.2f baseline_mean=%.2f severity=%s", d.Metric, d.Observed, d.Baseline.Mean, d.Severity))
 	}
 	return "baseline deviation: " + strings.Join(parts, "; ")
+}
+
+// RecordBaselineForAgent records sess metrics into the behavioral baseline
+// manager under an explicit identity key. MCP invocation sessions carry their
+// identity out of band, so they intentionally bypass the identity-session key
+// gate used by HTTP eviction.
+func (sm *SessionManager) RecordBaselineForAgent(identityKey string, sess *SessionState) {
+	snap := sm.baselinePtr.Load()
+	if snap == nil || snap.mgr == nil || identityKey == "" || sess == nil {
+		return
+	}
+	if err := baseline.ValidateAgentKey(identityKey); err != nil {
+		return
+	}
+	bm := sess.BaselineMetrics()
+	snap.mgr.RecordSession(identityKey, bm)
 }
 
 // recordSessionBaseline records the session's accumulated metrics into the
@@ -1194,8 +1220,7 @@ func (sm *SessionManager) recordSessionBaseline(sess *SessionState) {
 		// Fall back to full key when no "|" separator exists.
 		agent = key
 	}
-	bm := sess.BaselineMetrics()
-	snap.mgr.RecordSession(agent, bm)
+	sm.RecordBaselineForAgent(agent, sess)
 }
 
 // GetOrCreate returns the session for a key, creating if needed.

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -954,6 +954,12 @@ type BaselineResult struct {
 	Blocked    bool                 // true when DeviationAction is "block" and deviations found
 	Deviations []baseline.Deviation // specific metrics that deviated
 	Action     string               // the configured action: "warn", "ask", or "block"
+	Err        error                // non-nil when the check failed and enforcement must fail closed
+}
+
+type baselineSnapshot struct {
+	mgr    *baseline.Manager
+	action string
 }
 
 // SessionManager manages per-client sessions with eviction and cleanup.
@@ -977,8 +983,7 @@ type SessionManager struct {
 
 	// Behavioral baseline: profile-then-lock analysis.
 	// nil when behavioral_baseline.enabled is false.
-	baselineMgr    *baseline.Manager
-	baselineAction string // "warn", "ask", or "block" - cached from config
+	baselinePtr atomic.Pointer[baselineSnapshot]
 }
 
 // SessionManagerOptions configures optional SessionManager behavior.
@@ -1020,6 +1025,15 @@ func (sm *SessionManager) EnableBaseline(cfg *config.BehavioralBaseline) error {
 	if cfg == nil || !cfg.Enabled {
 		return nil
 	}
+	snap, err := newBaselineSnapshot(cfg)
+	if err != nil {
+		return err
+	}
+	sm.baselinePtr.Store(snap)
+	return nil
+}
+
+func newBaselineSnapshot(cfg *config.BehavioralBaseline) (*baselineSnapshot, error) {
 	mgr, err := baseline.NewManager(baseline.Config{
 		Enabled:          cfg.Enabled,
 		LearningWindow:   cfg.LearningWindow,
@@ -1032,41 +1046,136 @@ func (sm *SessionManager) EnableBaseline(cfg *config.BehavioralBaseline) error {
 		SeasonalityMode:  cfg.SeasonalityMode,
 	})
 	if err != nil {
-		return fmt.Errorf("baseline init: %w", err)
+		return nil, fmt.Errorf("baseline init: %w", err)
 	}
-	sm.baselineMgr = mgr
-	sm.baselineAction = cfg.DeviationAction
-	return nil
+	return &baselineSnapshot{mgr: mgr, action: baselineActionOrDefault(cfg.DeviationAction)}, nil
+}
+
+func baselineActionOrDefault(action string) string {
+	if action == "" {
+		return config.ActionWarn
+	}
+	return action
+}
+
+// ReconfigureBaseline applies behavioral_baseline hot-reload changes without
+// resetting learned or locked profiles.
+func (sm *SessionManager) ReconfigureBaseline(cfg *config.BehavioralBaseline) error {
+	if cfg == nil || !cfg.Enabled {
+		sm.baselinePtr.Store(nil)
+		return nil
+	}
+	if snap := sm.baselinePtr.Load(); snap != nil && snap.mgr != nil {
+		if err := snap.mgr.Reconfigure(baseline.Config{
+			Enabled:          cfg.Enabled,
+			LearningWindow:   cfg.LearningWindow,
+			DeviationAction:  cfg.DeviationAction,
+			ProfileDir:       cfg.ProfileDir,
+			AutoRatify:       cfg.AutoRatify,
+			SensitivitySigma: cfg.SensitivitySigma,
+			LockDimensions:   cfg.LockDimensions,
+			PoisonResistance: cfg.PoisonResistance,
+			SeasonalityMode:  cfg.SeasonalityMode,
+		}); err != nil {
+			return fmt.Errorf("baseline reconfigure: %w", err)
+		}
+		sm.baselinePtr.Store(&baselineSnapshot{mgr: snap.mgr, action: baselineActionOrDefault(cfg.DeviationAction)})
+		return nil
+	}
+	return sm.EnableBaseline(cfg)
 }
 
 // BaselineManager returns the baseline manager, or nil if not enabled.
 func (sm *SessionManager) BaselineManager() *baseline.Manager {
-	return sm.baselineMgr
+	snap := sm.baselinePtr.Load()
+	if snap == nil {
+		return nil
+	}
+	return snap.mgr
 }
 
 // CheckBaseline evaluates the current session metrics against the agent's
 // locked behavioral profile. Returns nil result when baseline is disabled
 // or the agent has no locked profile yet (still learning).
 func (sm *SessionManager) CheckBaseline(agentKey string, sess *SessionState) *BaselineResult {
-	if sm.baselineMgr == nil {
+	snap := sm.baselinePtr.Load()
+	if snap == nil || snap.mgr == nil {
 		return nil
 	}
 	metrics := sess.BaselineMetrics()
-	deviations := sm.baselineMgr.Check(agentKey, metrics)
+	deviations, err := snap.mgr.CheckErr(agentKey, metrics)
+	if err != nil {
+		return &BaselineResult{
+			Blocked: true,
+			Action:  config.ActionBlock,
+			Err:     fmt.Errorf("baseline check failed: %w", err),
+		}
+	}
 	if len(deviations) == 0 {
 		return nil
 	}
 	return &BaselineResult{
-		Blocked:    sm.baselineAction == config.ActionBlock,
+		Blocked:    snap.action == config.ActionBlock,
 		Deviations: deviations,
-		Action:     sm.baselineAction,
+		Action:     snap.action,
 	}
+}
+
+// CheckBaselineFailClosed wraps CheckBaseline with fail-closed panic handling
+// for enforcement paths.
+func (sm *SessionManager) CheckBaselineFailClosed(agentKey string, sess *SessionState) (res *BaselineResult) {
+	defer func() {
+		if r := recover(); r != nil {
+			res = &BaselineResult{
+				Blocked: true,
+				Action:  config.ActionBlock,
+				Err:     fmt.Errorf("baseline check failed: %v", r),
+			}
+		}
+	}()
+	return sm.CheckBaseline(agentKey, sess)
+}
+
+// CheckBaselineForRecorder adapts the proxy baseline checker to the shared
+// session.BaselineChecker interface used by MCP transports.
+func (sm *SessionManager) CheckBaselineForRecorder(agentKey string, rec session.Recorder) session.BaselineDecision {
+	sess, ok := rec.(*SessionState)
+	if !ok || sess == nil || agentKey == "" {
+		return session.BaselineDecision{}
+	}
+	result := sm.CheckBaselineFailClosed(agentKey, sess)
+	if result == nil {
+		return session.BaselineDecision{}
+	}
+	return session.BaselineDecision{
+		Blocked: result.Blocked,
+		Action:  result.Action,
+		Detail:  baselineDecisionDetail(result),
+	}
+}
+
+func baselineDecisionDetail(result *BaselineResult) string {
+	if result == nil {
+		return ""
+	}
+	if result.Err != nil {
+		return result.Err.Error()
+	}
+	if len(result.Deviations) == 0 {
+		return "baseline deviation"
+	}
+	parts := make([]string, 0, len(result.Deviations))
+	for _, d := range result.Deviations {
+		parts = append(parts, fmt.Sprintf("%s observed=%.2f baseline_mean=%.2f severity=%s", d.Metric, d.Observed, d.Baseline.Mean, d.Severity))
+	}
+	return "baseline deviation: " + strings.Join(parts, "; ")
 }
 
 // recordSessionBaseline records the session's accumulated metrics into the
 // baseline manager for learning. Called during session eviction/cleanup.
 func (sm *SessionManager) recordSessionBaseline(sess *SessionState) {
-	if sm.baselineMgr == nil {
+	snap := sm.baselinePtr.Load()
+	if snap == nil || snap.mgr == nil {
 		return
 	}
 	// Extract agent key from session key. Only identity sessions produce
@@ -1086,7 +1195,7 @@ func (sm *SessionManager) recordSessionBaseline(sess *SessionState) {
 		agent = key
 	}
 	bm := sess.BaselineMetrics()
-	sm.baselineMgr.RecordSession(agent, bm)
+	snap.mgr.RecordSession(agent, bm)
 }
 
 // GetOrCreate returns the session for a key, creating if needed.

--- a/internal/proxy/taint.go
+++ b/internal/proxy/taint.go
@@ -56,7 +56,11 @@ func evaluateHTTPTaint(cfg *config.Config, rec session.Recorder, method string, 
 	if rs, ok := rec.(session.RiskState); ok {
 		decision.Risk = rs.RiskSnapshot()
 	}
-	decision.ActionClass, decision.Sensitivity = session.ClassifyHTTPAction(method, parsedURL.Path, cfg.Taint.ProtectedPaths, cfg.Taint.ElevatedPaths)
+	classified := session.ClassifyHTTPActionWithOptions(method, parsedURL.Path, cfg.Taint.ProtectedPaths, cfg.Taint.ElevatedPaths, session.ClassificationOptions{
+		FailSafe: cfg.Taint.FailSafeClassification,
+	})
+	decision.ActionClass = classified.Class
+	decision.Sensitivity = classified.Sensitivity
 	decision.ActionRef = httpActionRef(decision.ActionClass, method, parsedURL)
 	if tp, ok := rec.(session.TaskContextProvider); ok {
 		decision.Task = tp.TaskSnapshot()
@@ -66,11 +70,15 @@ func evaluateHTTPTaint(cfg *config.Config, rec session.Recorder, method string, 
 			return decision
 		}
 	}
-	decision.Result = session.PolicyMatrix{Profile: cfg.Taint.Policy}.Evaluate(
+	decision.Result = session.PolicyMatrix{Profile: cfg.Taint.Policy}.EvaluateWithOptions(
 		decision.Risk.Level,
 		decision.ActionClass,
 		decision.Sensitivity,
 		decision.Authority,
+		session.PolicyEvaluateOptions{
+			FailSafeClassification:  cfg.Taint.FailSafeClassification,
+			ClassificationConfident: classified.Confident,
+		},
 	)
 	if trustOverrideApplies(cfg.Taint.TrustOverrides, decision.Risk, decision.ActionRef) {
 		decision.Result = session.PolicyDecisionResult{Decision: session.PolicyAllow, Reason: "taint_trust_override"}

--- a/internal/session/classify_options_coverage_test.go
+++ b/internal/session/classify_options_coverage_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session_test
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+// TestClassifyWithOptions_BranchCoverage exercises the WithOptions classifier
+// and policy-evaluation branches under both fail-safe settings, so the fail-safe
+// and per-class paths added for AARM-1 are covered.
+func TestClassifyWithOptions_BranchCoverage(t *testing.T) {
+	t.Parallel()
+
+	protected := []string{"*/auth/*", "*/.env*"}
+	elevated := []string{"*/config/*", "*/middleware*"}
+
+	mcp := []struct {
+		name string
+		tool string
+		args string
+		want session.ActionClass
+	}{
+		{"write", "write_file", `{"path":"/repo/auth/middleware.go","content":"x"}`, session.ActionClassWrite},
+		{"exec", "shell", `{"command":"git push origin main"}`, session.ActionClassExec},
+		{"secret", "read_file", `{"path":"/home/u/.ssh/id_rsa"}`, session.ActionClassSecret},
+		{"browse", "browse_url", `{"url":"https://example.com/docs"}`, session.ActionClassBrowse},
+		{"unknown_read", "mystery_tool", `{}`, session.ActionClassRead},
+	}
+	for _, tc := range mcp {
+		for _, fs := range []bool{false, true} {
+			got := session.ClassifyMCPToolCallWithOptions(tc.tool, tc.args, protected, elevated, session.ClassificationOptions{FailSafe: fs})
+			if got.Class != tc.want {
+				t.Fatalf("mcp %s (failsafe=%v): class=%v want %v", tc.name, fs, got.Class, tc.want)
+			}
+		}
+	}
+
+	httpCases := []struct {
+		name   string
+		method string
+		path   string
+		want   session.ActionClass
+	}{
+		{"get_read", "GET", "/repo/readme.md", session.ActionClassRead},
+		{"post_publish", "POST", "/repo/config/app.yaml", session.ActionClassPublish},
+		{"delete_publish", "DELETE", "/repo/auth/token", session.ActionClassPublish},
+		{"unknown_method_network", "PROPFIND", "/x", session.ActionClassNetwork},
+	}
+	for _, tc := range httpCases {
+		for _, fs := range []bool{false, true} {
+			got := session.ClassifyHTTPActionWithOptions(tc.method, tc.path, protected, elevated, session.ClassificationOptions{FailSafe: fs})
+			if got.Class != tc.want {
+				t.Fatalf("http %s (failsafe=%v): class=%v want %v", tc.name, fs, got.Class, tc.want)
+			}
+		}
+	}
+
+	// Exercise the untrusted policy switch branches (write/exec/secret/network)
+	// plus the trusted early-return, under strict profile.
+	pm := session.PolicyMatrix{Profile: "strict"}
+	combos := []struct {
+		taint session.TaintLevel
+		act   session.ActionClass
+		sens  session.ActionSensitivity
+		auth  session.AuthorityKind
+	}{
+		{session.TaintExternalUntrusted, session.ActionClassWrite, session.SensitivityProtected, session.AuthorityUserBroad},
+		{session.TaintExternalUntrusted, session.ActionClassExec, session.SensitivityElevated, session.AuthorityUserBroad},
+		{session.TaintExternalUntrusted, session.ActionClassSecret, session.SensitivityProtected, session.AuthorityUserBroad},
+		{session.TaintExternalUntrusted, session.ActionClassNetwork, session.SensitivityElevated, session.AuthorityUserBroad},
+		{session.TaintTrusted, session.ActionClassWrite, session.SensitivityProtected, session.AuthorityUserBroad},
+	}
+	for _, c := range combos {
+		_ = pm.EvaluateWithOptions(c.taint, c.act, c.sens, c.auth, session.PolicyEvaluateOptions{ClassificationConfident: true})
+	}
+}

--- a/internal/session/failsafe_untrusted_read_test.go
+++ b/internal/session/failsafe_untrusted_read_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session_test
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+// TestPolicyMatrixEvaluateWithOptions_FailSafeUntrustedRead covers the
+// non-hostile untrusted path: a read/browse/summarize that only reached
+// SensitivityProtected because it could not be confidently classified must be
+// escalated to HITL under fail-safe, not allowed. The untrusted switch has no
+// read-class branch, so before the fix a low-confidence read fell through to
+// PolicyAllow even with the toggle on (inert fail-safe).
+func TestPolicyMatrixEvaluateWithOptions_FailSafeUntrustedRead(t *testing.T) {
+	t.Parallel()
+
+	pm := session.PolicyMatrix{Profile: "balanced"}
+	decideRead := func(opts session.PolicyEvaluateOptions) session.PolicyDecision {
+		return pm.EvaluateWithOptions(
+			session.TaintExternalUntrusted,
+			session.ActionClassRead,
+			session.SensitivityProtected,
+			session.AuthorityUserBroad,
+			opts,
+		).Decision
+	}
+
+	// Toggle OFF: the always-allow read shortcut applies (unchanged behavior).
+	if got := decideRead(session.PolicyEvaluateOptions{ClassificationConfident: false}); got != session.PolicyAllow {
+		t.Fatalf("fail-safe off: decision = %s, want allow", got)
+	}
+
+	// Toggle ON + low-confidence: escalate to HITL (the fixed gap).
+	if got := decideRead(session.PolicyEvaluateOptions{FailSafeClassification: true, ClassificationConfident: false}); got != session.PolicyAsk {
+		t.Fatalf("fail-safe on, low-confidence: decision = %s, want ask", got)
+	}
+
+	// Toggle ON but CONFIDENT: no escalation; confident reads are unaffected
+	// (regression guard against over-blocking normal reads).
+	if got := decideRead(session.PolicyEvaluateOptions{FailSafeClassification: true, ClassificationConfident: true}); got != session.PolicyAllow {
+		t.Fatalf("fail-safe on, confident: decision = %s, want allow", got)
+	}
+}

--- a/internal/session/risk.go
+++ b/internal/session/risk.go
@@ -315,6 +315,18 @@ func (pm PolicyMatrix) EvaluateWithOptions(
 		return PolicyDecisionResult{Decision: PolicyBlock, Reason: "sensitive_action_after_hostile_external_exposure"}
 	}
 
+	// Fail-safe classification (opt-in): a read/browse/summarize that only
+	// reached SensitivityProtected because it could NOT be confidently
+	// classified must not fall through to allow under untrusted exposure.
+	// Skipping the always-allow shortcut above is not enough — the untrusted
+	// switch has no read-class branch — so escalate to HITL here. Fires only
+	// when the toggle is on AND the classification was low-confidence, so
+	// confidently-normal reads are unaffected (regression-safe when off).
+	if opts.FailSafeClassification && !opts.ClassificationConfident &&
+		sensitivity >= SensitivityProtected && isAlwaysAllowedAction(action) {
+		return PolicyDecisionResult{Decision: PolicyAsk, Reason: "fail_safe_low_confidence_read_after_untrusted_exposure"}
+	}
+
 	switch action {
 	case ActionClassWrite:
 		if sensitivity >= SensitivityProtected && authority < AuthorityUserExact {

--- a/internal/session/risk.go
+++ b/internal/session/risk.go
@@ -178,6 +178,12 @@ type PolicyDecisionResult struct {
 	Reason   string
 }
 
+// PolicyEvaluateOptions carries optional fail-safe classification state.
+type PolicyEvaluateOptions struct {
+	FailSafeClassification  bool
+	ClassificationConfident bool
+}
+
 // RiskState is implemented by session recorders that track taint state.
 type RiskState interface {
 	RiskSnapshot() SessionRisk
@@ -285,7 +291,19 @@ func (pm PolicyMatrix) Evaluate(
 	sensitivity ActionSensitivity,
 	authority AuthorityKind,
 ) PolicyDecisionResult {
-	if isAlwaysAllowedAction(action) {
+	return pm.EvaluateWithOptions(taint, action, sensitivity, authority, PolicyEvaluateOptions{ClassificationConfident: true})
+}
+
+// EvaluateWithOptions applies the taint policy matrix with classifier
+// confidence metadata.
+func (pm PolicyMatrix) EvaluateWithOptions(
+	taint TaintLevel,
+	action ActionClass,
+	sensitivity ActionSensitivity,
+	authority AuthorityKind,
+	opts PolicyEvaluateOptions,
+) PolicyDecisionResult {
+	if isAlwaysAllowedAction(action) && (!opts.FailSafeClassification || opts.ClassificationConfident) {
 		return PolicyDecisionResult{Decision: PolicyAllow, Reason: "taint_safe_read_only_action"}
 	}
 

--- a/internal/session/risk_test.go
+++ b/internal/session/risk_test.go
@@ -181,3 +181,30 @@ func TestPolicyMatrixEvaluate(t *testing.T) {
 		})
 	}
 }
+
+func TestPolicyMatrixEvaluateWithOptions_FailSafeLowConfidenceRead(t *testing.T) {
+	t.Parallel()
+
+	pm := session.PolicyMatrix{Profile: "balanced"}
+	withoutFailSafe := pm.EvaluateWithOptions(
+		session.TaintExternalHostile,
+		session.ActionClassRead,
+		session.SensitivityProtected,
+		session.AuthorityUserBroad,
+		session.PolicyEvaluateOptions{ClassificationConfident: false},
+	)
+	if withoutFailSafe.Decision != session.PolicyAllow {
+		t.Fatalf("without fail-safe decision = %s, want allow", withoutFailSafe.Decision)
+	}
+
+	withFailSafe := pm.EvaluateWithOptions(
+		session.TaintExternalHostile,
+		session.ActionClassRead,
+		session.SensitivityProtected,
+		session.AuthorityUserBroad,
+		session.PolicyEvaluateOptions{FailSafeClassification: true, ClassificationConfident: false},
+	)
+	if withFailSafe.Decision != session.PolicyBlock {
+		t.Fatalf("with fail-safe decision = %s, want block", withFailSafe.Decision)
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -76,6 +76,19 @@ type Store interface {
 	GetOrCreate(key string) Recorder
 }
 
+// BaselineDecision is the transport-neutral behavioral baseline result.
+type BaselineDecision struct {
+	Blocked bool
+	Action  string
+	Detail  string
+}
+
+// BaselineChecker evaluates a live recorder against an identity-keyed
+// behavioral baseline without coupling MCP callers to proxy internals.
+type BaselineChecker interface {
+	CheckBaselineForRecorder(agentKey string, rec Recorder) BaselineDecision
+}
+
 // TaskContext describes the current task boundary attached to a live session.
 type TaskContext struct {
 	CurrentTaskID    string

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -87,6 +87,7 @@ type BaselineDecision struct {
 // behavioral baseline without coupling MCP callers to proxy internals.
 type BaselineChecker interface {
 	CheckBaselineForRecorder(agentKey string, rec Recorder) BaselineDecision
+	RecordBaselineForRecorder(agentKey string, rec Recorder)
 }
 
 // TaskContext describes the current task boundary attached to a live session.

--- a/internal/session/taint_classify.go
+++ b/internal/session/taint_classify.go
@@ -6,6 +6,7 @@ package session
 import (
 	"encoding/json"
 	"net"
+	"net/http"
 	"net/url"
 	"path"
 	"strings"
@@ -13,6 +14,21 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/mcp/chains"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
+
+// ClassificationOptions controls fail-safe action classification.
+type ClassificationOptions struct {
+	FailSafe bool
+}
+
+// ActionClassification carries an action class plus whether classification
+// came from a concrete method/tool/path signal instead of a low-confidence
+// fallback.
+type ActionClassification struct {
+	Class       ActionClass
+	Sensitivity ActionSensitivity
+	ActionRef   string
+	Confident   bool
+}
 
 // ClassifyURLSource maps a URL to a taint level using host-based trust rules.
 func ClassifyURLSource(rawURL string, allowlistedDomains []string) TaintLevel {
@@ -75,83 +91,122 @@ func IsMediaContentType(contentType string) bool {
 
 // ClassifyPathSensitivity returns the configured sensitivity for a path.
 func ClassifyPathSensitivity(targetPath string, protectedPatterns, elevatedPatterns []string) ActionSensitivity {
+	return ClassifyPathSensitivityWithConfidence(targetPath, protectedPatterns, elevatedPatterns, ClassificationOptions{}).Sensitivity
+}
+
+// ClassifyPathSensitivityWithConfidence returns path sensitivity plus whether
+// the target path was concrete enough to classify.
+func ClassifyPathSensitivityWithConfidence(targetPath string, protectedPatterns, elevatedPatterns []string, opts ClassificationOptions) ActionClassification {
 	normalized := toSlash(targetPath)
+	confident := strings.TrimSpace(normalized) != ""
 	for _, pattern := range protectedPatterns {
 		if matchPathPattern(normalized, pattern) {
-			return SensitivityProtected
+			return ActionClassification{Sensitivity: SensitivityProtected, Confident: true}
 		}
 	}
 	for _, pattern := range elevatedPatterns {
 		if matchPathPattern(normalized, pattern) {
-			return SensitivityElevated
+			return ActionClassification{Sensitivity: SensitivityElevated, Confident: true}
 		}
 	}
-	return SensitivityNormal
+	if opts.FailSafe && !confident {
+		return ActionClassification{Sensitivity: SensitivityProtected, Confident: false}
+	}
+	return ActionClassification{Sensitivity: SensitivityNormal, Confident: confident}
 }
 
 // ClassifyHTTPAction returns the taint policy action class for an HTTP request.
 func ClassifyHTTPAction(method, targetPath string, protectedPatterns, elevatedPatterns []string) (ActionClass, ActionSensitivity) {
+	classified := ClassifyHTTPActionWithOptions(method, targetPath, protectedPatterns, elevatedPatterns, ClassificationOptions{})
+	return classified.Class, classified.Sensitivity
+}
+
+// ClassifyHTTPActionWithOptions returns the taint policy action class for an
+// HTTP request plus a confidence flag.
+func ClassifyHTTPActionWithOptions(method, targetPath string, protectedPatterns, elevatedPatterns []string, opts ClassificationOptions) ActionClassification {
+	pathClass := ClassifyPathSensitivityWithConfidence(targetPath, protectedPatterns, elevatedPatterns, opts)
 	switch strings.ToUpper(method) {
-	case "GET", "HEAD", "OPTIONS", "TRACE":
-		return ActionClassRead, SensitivityNormal
-	case "POST", "PUT", "PATCH", "DELETE":
-		return ActionClassPublish, ClassifyPathSensitivity(targetPath, protectedPatterns, elevatedPatterns)
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		sensitivity := SensitivityNormal
+		if opts.FailSafe && !pathClass.Confident {
+			sensitivity = SensitivityProtected
+		}
+		return ActionClassification{Class: ActionClassRead, Sensitivity: sensitivity, Confident: pathClass.Confident}
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return ActionClassification{Class: ActionClassPublish, Sensitivity: pathClass.Sensitivity, Confident: pathClass.Confident}
 	default:
-		return ActionClassNetwork, ClassifyPathSensitivity(targetPath, protectedPatterns, elevatedPatterns)
+		return ActionClassification{Class: ActionClassNetwork, Sensitivity: pathClass.Sensitivity, Confident: false}
 	}
 }
 
 // ClassifyMCPToolCall returns the taint policy action class for an MCP tools/call request.
 func ClassifyMCPToolCall(toolName, argsJSON string, protectedPatterns, elevatedPatterns []string) (ActionClass, ActionSensitivity, string) {
+	classified := ClassifyMCPToolCallWithOptions(toolName, argsJSON, protectedPatterns, elevatedPatterns, ClassificationOptions{})
+	return classified.Class, classified.Sensitivity, classified.ActionRef
+}
+
+// ClassifyMCPToolCallWithOptions returns the taint policy action class for an
+// MCP tools/call request plus a confidence flag.
+func ClassifyMCPToolCallWithOptions(toolName, argsJSON string, protectedPatterns, elevatedPatterns []string, opts ClassificationOptions) ActionClassification {
 	name := strings.ToLower(toolName)
 	args := flattenJSONStrings(argsJSON)
 	targetPath := firstPathLikeValue(args)
 	category := chains.ClassifyTool(toolName, argsJSON, nil)
 
 	if secretPath := firstSecretPath(args); secretPath != "" {
-		return ActionClassSecret, SensitivityProtected, secretPath
+		return ActionClassification{Class: ActionClassSecret, Sensitivity: SensitivityProtected, ActionRef: secretPath, Confident: true}
 	}
 
 	if looksLikeShellTool(name) || category == "exec" {
 		command := strings.Join(args, " ")
 		if isMutatingShellCommand(command) {
-			return ActionClassExec, classifyShellSensitivity(command, targetPath, protectedPatterns, elevatedPatterns), targetPath
+			return ActionClassification{Class: ActionClassExec, Sensitivity: classifyShellSensitivity(command, targetPath, protectedPatterns, elevatedPatterns), ActionRef: targetPath, Confident: true}
 		}
-		return ActionClassExec, SensitivityProtected, targetPath
+		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, Confident: true}
 	}
 
 	if category == "persist" {
-		return ActionClassExec, SensitivityProtected, targetPath
+		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, Confident: true}
 	}
 
 	if looksLikeWriteTool(name) || category == "write" || hasWriteIntent(argsJSON) {
-		return ActionClassWrite, ClassifyPathSensitivity(targetPath, protectedPatterns, elevatedPatterns), targetPath
+		pathClass := ClassifyPathSensitivityWithConfidence(targetPath, protectedPatterns, elevatedPatterns, opts)
+		return ActionClassification{Class: ActionClassWrite, Sensitivity: pathClass.Sensitivity, ActionRef: targetPath, Confident: pathClass.Confident}
 	}
 
 	if looksLikePublishTool(name, argsJSON) || hasMutatingNetworkIntent(argsJSON) {
-		return ActionClassPublish, SensitivityElevated, firstURLLikeValue(args)
+		return ActionClassification{Class: ActionClassPublish, Sensitivity: SensitivityElevated, ActionRef: firstURLLikeValue(args), Confident: true}
 	}
 
 	if looksLikeBrowseTool(name) || category == "network" {
 		if hasMutatingNetworkIntent(argsJSON) {
-			return ActionClassPublish, SensitivityElevated, firstURLLikeValue(args)
+			return ActionClassification{Class: ActionClassPublish, Sensitivity: SensitivityElevated, ActionRef: firstURLLikeValue(args), Confident: true}
 		}
-		return ActionClassBrowse, SensitivityNormal, firstURLLikeValue(args)
+		return ActionClassification{Class: ActionClassBrowse, Sensitivity: SensitivityNormal, ActionRef: firstURLLikeValue(args), Confident: true}
 	}
 
 	if looksLikeReadTool(name) || category == "read" || category == "list" {
-		return ActionClassRead, SensitivityNormal, targetPath
+		pathClass := ClassifyPathSensitivityWithConfidence(targetPath, protectedPatterns, elevatedPatterns, opts)
+		sensitivity := SensitivityNormal
+		if opts.FailSafe && !pathClass.Confident {
+			sensitivity = SensitivityProtected
+		}
+		return ActionClassification{Class: ActionClassRead, Sensitivity: sensitivity, ActionRef: targetPath, Confident: pathClass.Confident}
 	}
 
 	if hasExecIntent(argsJSON) {
 		command := strings.Join(args, " ")
 		if isMutatingShellCommand(command) {
-			return ActionClassExec, classifyShellSensitivity(command, targetPath, protectedPatterns, elevatedPatterns), targetPath
+			return ActionClassification{Class: ActionClassExec, Sensitivity: classifyShellSensitivity(command, targetPath, protectedPatterns, elevatedPatterns), ActionRef: targetPath, Confident: true}
 		}
-		return ActionClassExec, SensitivityProtected, targetPath
+		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, Confident: true}
 	}
 
-	return ActionClassRead, SensitivityNormal, targetPath
+	sensitivity := SensitivityNormal
+	if opts.FailSafe {
+		sensitivity = SensitivityProtected
+	}
+	return ActionClassification{Class: ActionClassRead, Sensitivity: sensitivity, ActionRef: targetPath, Confident: false}
 }
 
 func classifyShellSensitivity(command, targetPath string, protectedPatterns, elevatedPatterns []string) ActionSensitivity {

--- a/internal/session/taint_classify_test.go
+++ b/internal/session/taint_classify_test.go
@@ -145,6 +145,34 @@ func TestClassifyPathSensitivity_RootRelativePatterns(t *testing.T) {
 	}
 }
 
+func TestClassifyHTTPActionWithOptions_FailSafeReadNeedsConfidence(t *testing.T) {
+	t.Parallel()
+
+	off := session.ClassifyHTTPActionWithOptions("GET", "", nil, nil, session.ClassificationOptions{})
+	if off.Class != session.ActionClassRead || off.Sensitivity != session.SensitivityNormal || off.Confident {
+		t.Fatalf("fail-safe off classification = %+v, want read normal low-confidence", off)
+	}
+
+	on := session.ClassifyHTTPActionWithOptions("GET", "", nil, nil, session.ClassificationOptions{FailSafe: true})
+	if on.Class != session.ActionClassRead || on.Sensitivity != session.SensitivityProtected || on.Confident {
+		t.Fatalf("fail-safe on classification = %+v, want read protected low-confidence", on)
+	}
+}
+
+func TestClassifyMCPToolCallWithOptions_FailSafeUnknownTool(t *testing.T) {
+	t.Parallel()
+
+	off := session.ClassifyMCPToolCallWithOptions("mystery_tool", `{}`, nil, nil, session.ClassificationOptions{})
+	if off.Class != session.ActionClassRead || off.Sensitivity != session.SensitivityNormal || off.Confident {
+		t.Fatalf("fail-safe off classification = %+v, want read normal low-confidence", off)
+	}
+
+	on := session.ClassifyMCPToolCallWithOptions("mystery_tool", `{}`, nil, nil, session.ClassificationOptions{FailSafe: true})
+	if on.Class != session.ActionClassRead || on.Sensitivity != session.SensitivityProtected || on.Confident {
+		t.Fatalf("fail-safe on classification = %+v, want read protected low-confidence", on)
+	}
+}
+
 func TestClassifyMCPToolCall_MutatingNetworkIntentWithSpacedJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

Wires the profile-then-lock behavioral baseline into runtime enforcement and adds an opt-in fail-safe taint classification default.

**Behavioral baseline enforcement (`behavioral_baseline`)**

- Evaluates each session against its locked profile on the HTTP and MCP request paths and applies the configured deviation action (block / warn / ask), failing closed on error, timeout, or non-terminal input.
- Enforcement and learning are keyed to the agent identity across all MCP transports (stdio, sandbox stdio, WebSocket, HTTP forward, HTTP listener), so a profile learned for an identity is enforced on that identity's calls.
- Hot reload reconfigures the baseline while preserving learned and locked profiles. A reload that would disable enforcement, downgrade the action, or move the profile store is rejected.
- Startup fails closed if a configured baseline cannot initialize. The reload swap is race-safe.

**Fail-safe taint classification (`taint.fail_safe_classification`, default off)**

- When enabled, an action that cannot be confidently classified is treated as protected rather than taking the read-only allow shortcut, and is escalated to human review under untrusted exposure. Confidently-classified actions are unaffected.

Docs: `docs/configuration.md`. Base `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new fail-safe classification option for taint handling, allowing low-confidence reads and tool calls to be treated more conservatively.
  * Behavioral baseline support now applies consistently across proxy modes and can record/compare baseline activity for sessions.

* **Bug Fixes**
  * Hot reloads now reject changes that would weaken behavioral baseline protections.
  * Startup now fails closed when baseline initialization cannot complete.
  * Baseline decisions are now enforced more consistently during request handling and proxy forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->