### PR TITLE
fix(scanner): robust documentation-example-credential exemption

### DIFF
--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -23,11 +23,36 @@ import (
 // is not treated as a hostname.
 var textURLTokenRe = regexp.MustCompile(`(?i)\b(?:https?|wss?|ftp)://[^\s"'<>\\]+`)
 
+// officialAWSExampleCredentialDocMarkers are documentation-context phrases that,
+// when present OUTSIDE the credential literal's own byte span, mark the AWS
+// example key/secret as documentation rather than a live secret. They are
+// deliberately DISTINCT phrases (each contains "credential" or an equally
+// specific doc cue) rather than bare common words: a bare "example" or "sample"
+// would match ordinary hostnames like api.vendor.example and non-doc prose,
+// exempting the example key in contexts that are not documentation.
+var officialAWSExampleCredentialDocMarkers = []string{
+	"example credential",
+	"example credentials",
+	"sample credential",
+	"dummy credential",
+	"placeholder credential",
+	"test credential",
+	"fake credential",
+	"not a real credential",
+	"official aws example",
+	"replace these with your actual credentials",
+}
+
 type textHostView struct {
 	host      string
 	start     int
 	end       int
 	viewLabel string
+}
+
+type textByteSpan struct {
+	start int
+	end   int
 }
 
 // extractHostsFromTextViews pulls de-duplicated hostnames out of URL tokens in
@@ -615,19 +640,138 @@ func redactOfficialAWSExampleCredentialsForDocs(text string) string {
 		return text
 	}
 
-	lower := strings.ToLower(text)
-	docContext := strings.Contains(lower, "example credential") ||
-		strings.Contains(lower, "example credentials") ||
-		strings.Contains(lower, "replace these with your actual credentials") ||
-		strings.Contains(lower, "official aws example")
-	if !docContext {
+	if !hasOfficialAWSExampleCredentialDocContext(text, key, secret) {
 		return text
 	}
 
-	return strings.NewReplacer(
-		key, "AWS_ACCESS_KEY_ID_EXAMPLE",
-		secret, "AWS_SECRET_ACCESS_KEY_EXAMPLE",
-	).Replace(text)
+	text = replaceWholeCredentialToken(text, key, "AWS_ACCESS_KEY_ID_EXAMPLE")
+	text = replaceWholeCredentialToken(text, secret, "AWS_SECRET_ACCESS_KEY_EXAMPLE")
+	return text
+}
+
+func hasOfficialAWSExampleCredentialDocContext(text, key, secret string) bool {
+	// Use a length-preserving ASCII lowercase, NOT strings.ToLower: some Unicode
+	// runes (e.g. U+212A KELVIN SIGN) change byte length when lowercased, which
+	// would shift marker offsets out of alignment with the credential byte spans
+	// computed from the original text below. A misaligned marker inside the key's
+	// own EXAMPLE suffix could then look like an out-of-span marker and
+	// self-exempt a bare key. All markers are ASCII, so ASCII-only folding is
+	// sufficient for matching and keeps every byte offset identical.
+	lower := asciiLowerPreserveLen(text)
+	credentialSpans := literalByteSpans(text, key, secret)
+
+	for _, marker := range officialAWSExampleCredentialDocMarkers {
+		searchFrom := 0
+		for {
+			idx := strings.Index(lower[searchFrom:], marker)
+			if idx < 0 {
+				break
+			}
+
+			start := searchFrom + idx
+			end := start + len(marker)
+			if !overlapsAnyTextByteSpan(start, end, credentialSpans) {
+				return true
+			}
+			searchFrom = start + 1
+		}
+	}
+
+	return false
+}
+
+func literalByteSpans(text string, literals ...string) []textByteSpan {
+	var spans []textByteSpan
+	for _, literal := range literals {
+		searchFrom := 0
+		for {
+			idx := strings.Index(text[searchFrom:], literal)
+			if idx < 0 {
+				break
+			}
+
+			start := searchFrom + idx
+			end := start + len(literal)
+			spans = append(spans, textByteSpan{start: start, end: end})
+			searchFrom = end
+		}
+	}
+	return spans
+}
+
+func overlapsAnyTextByteSpan(start, end int, spans []textByteSpan) bool {
+	for _, span := range spans {
+		if start < span.end && end > span.start {
+			return true
+		}
+	}
+	return false
+}
+
+func replaceWholeCredentialToken(text, literal, replacement string) string {
+	searchFrom := 0
+	copyFrom := 0
+	changed := false
+	var b strings.Builder
+
+	for {
+		idx := strings.Index(text[searchFrom:], literal)
+		if idx < 0 {
+			break
+		}
+
+		start := searchFrom + idx
+		end := start + len(literal)
+		if isWholeCredentialToken(text, start, end) {
+			if !changed {
+				b.Grow(len(text))
+				changed = true
+			}
+			b.WriteString(text[copyFrom:start])
+			b.WriteString(replacement)
+			copyFrom = end
+		}
+		searchFrom = end
+	}
+
+	if !changed {
+		return text
+	}
+	b.WriteString(text[copyFrom:])
+	return b.String()
+}
+
+func isWholeCredentialToken(text string, start, end int) bool {
+	return (start == 0 || !isCredentialTokenByte(text[start-1])) &&
+		(end == len(text) || !isCredentialTokenByte(text[end]))
+}
+
+func isCredentialTokenByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') ||
+		b == '/' ||
+		b == '+' ||
+		b == '='
+}
+
+// asciiLowerPreserveLen lowercases ASCII A-Z only, leaving every other byte
+// (including multi-byte UTF-8 sequences) unchanged. Unlike strings.ToLower it
+// never changes the byte length, so offsets into the result line up exactly with
+// offsets into the input.
+func asciiLowerPreserveLen(s string) string {
+	b := []byte(s)
+	changed := false
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+			changed = true
+		}
+	}
+	if !changed {
+		return s
+	}
+	return string(b)
 }
 
 func rot13ASCII(s string) string {

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -1164,15 +1164,40 @@ func TestScanTextForDLP_OfficialAWSExampleCredentialDocsWholeTokenOnly(t *testin
 
 func TestScanTextForDLP_UnicodePrefixedBareKeyStillBlocks(t *testing.T) {
 	// A rune that changes byte length when lowercased (U+212A KELVIN SIGN -> "k")
-	// must not shift the doc-marker offset logic into self-exempting a marker
-	// that overlaps the example key's own EXAMPLE suffix.
+	// must not shift doc-marker offsets away from credential byte spans.
 	s := New(testConfig())
 	defer s.Close()
 
 	key := "AKIA" + "IOSFODNN7" + "EXAMPLE"
-	input := strings.Repeat("K", 10) + key + " credential"
-	if s.ScanTextForDLP(context.Background(), input).Clean {
-		t.Fatal("self-overlapping example credential marker after a length-changing Unicode rune must still block")
+	prefix := strings.Repeat("K", 10)
+
+	tests := []struct {
+		name      string
+		input     string
+		wantClean bool
+	}{
+		{
+			name:      "legitimate_doc_marker_allows_whole_token_dummy",
+			input:     prefix + "example credential fixture\naws_access_key_id = " + key,
+			wantClean: true,
+		},
+		{
+			name:      "self_overlapping_marker_still_blocks",
+			input:     prefix + key + " credential",
+			wantClean: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), tt.input)
+			if result.Clean != tt.wantClean {
+				t.Fatalf("Clean=%v, want %v, matches=%+v", result.Clean, tt.wantClean, result.Matches)
+			}
+			if !tt.wantClean && !hasTextDLPMatch(result.Matches, "AWS Access ID", "") {
+				t.Fatalf("expected AWS Access ID match, got %+v", result.Matches)
+			}
+		})
 	}
 }
 

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -1110,6 +1110,72 @@ func TestScanTextForDLP_AllowsOfficialAWSExampleCredentialDocs(t *testing.T) {
 	}
 }
 
+func TestScanTextForDLP_OfficialAWSExampleCredentialDocsWholeTokenOnly(t *testing.T) {
+	s := New(testConfig())
+	key := "AKIA" + "IOSFODNN7" + "EXAMPLE"
+	realKey := "AKIA" + strings.Repeat("Q", 16)
+
+	tests := []struct {
+		name      string
+		text      string
+		wantClean bool
+	}{
+		{
+			name:      "superstring_key_in_doc_context_blocks",
+			text:      "example credential fixture\naws_access_key_id = " + key + strings.Repeat("0", 10),
+			wantClean: false,
+		},
+		{
+			name:      "broadened_sample_marker_allows_whole_token_dummy",
+			text:      "// sample credential\naws_access_key_id = " + key,
+			wantClean: true,
+		},
+		{
+			name:      "bare_key_without_marker_blocks",
+			text:      "exfil key " + key,
+			wantClean: false,
+		},
+		{
+			name:      "adjacent_real_key_still_blocks",
+			text:      "example credentials:\naws_access_key_id = " + key + " " + realKey,
+			wantClean: false,
+		},
+		{
+			// "example" in a hostname (api.vendor.example) is NOT a documentation
+			// marker: the example key in a live URL must still block.
+			name:      "example_in_hostname_is_not_a_doc_marker_blocks",
+			text:      "https://api.vendor.example/v1/keys#" + key,
+			wantClean: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), tt.text)
+			if result.Clean != tt.wantClean {
+				t.Fatalf("Clean=%v, want %v, matches=%+v", result.Clean, tt.wantClean, result.Matches)
+			}
+			if !tt.wantClean && !hasTextDLPMatch(result.Matches, "AWS Access ID", "") {
+				t.Fatalf("expected AWS Access ID match, got %+v", result.Matches)
+			}
+		})
+	}
+}
+
+func TestScanTextForDLP_UnicodePrefixedBareKeyStillBlocks(t *testing.T) {
+	// A rune that changes byte length when lowercased (U+212A KELVIN SIGN -> "k")
+	// must not shift the doc-marker offset logic into self-exempting a bare
+	// example key. Bare key with no legitimate doc marker MUST still block.
+	s := New(testConfig())
+	defer s.Close()
+
+	key := "AKIA" + "IOSFODNN7" + "EXAMPLE"
+	input := strings.Repeat("K", 10) + key
+	if s.ScanTextForDLP(context.Background(), input).Clean {
+		t.Fatal("bare example key preceded by a length-changing Unicode rune must still block")
+	}
+}
+
 // TestEnvVarSecret_WhitespaceViewMechanism locks the exact path that fired in
 // production. A wrapped tool RESULT and a wrapped first-party MCP tool's
 // security-review input both blocked on "Environment Variable Secret" because

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -1164,15 +1164,15 @@ func TestScanTextForDLP_OfficialAWSExampleCredentialDocsWholeTokenOnly(t *testin
 
 func TestScanTextForDLP_UnicodePrefixedBareKeyStillBlocks(t *testing.T) {
 	// A rune that changes byte length when lowercased (U+212A KELVIN SIGN -> "k")
-	// must not shift the doc-marker offset logic into self-exempting a bare
-	// example key. Bare key with no legitimate doc marker MUST still block.
+	// must not shift the doc-marker offset logic into self-exempting a marker
+	// that overlaps the example key's own EXAMPLE suffix.
 	s := New(testConfig())
 	defer s.Close()
 
 	key := "AKIA" + "IOSFODNN7" + "EXAMPLE"
-	input := strings.Repeat("K", 10) + key
+	input := strings.Repeat("K", 10) + key + " credential"
 	if s.ScanTextForDLP(context.Background(), input).Clean {
-		t.Fatal("bare example key preceded by a length-changing Unicode rune must still block")
+		t.Fatal("self-overlapping example credential marker after a length-changing Unicode rune must still block")
 	}
 }
 


### PR DESCRIPTION
## What changed

Pipelock exempts the well-known AWS documentation example credentials (`AKIAIOSFODNN7EXAMPLE` and the canonical example secret) from DLP when they appear in a documentation context, so writing docs or fixtures does not trip a block. A bare example key with no documentation context still blocks, by design, with no detection loss. This hardens that exemption, which had three weaknesses.

Only whole-token occurrences are neutralized now, bounded by non-credential bytes on both sides. The prior substring replace stripped the example literal even when it was the prefix of a longer token, so a real key that extends the literal could slip through. A superstring real key now reaches the scanner and blocks.

The documentation markers are distinct `credential`-qualified phrases, required to appear outside the credential literal's own byte span. The key ends in `EXAMPLE`, so otherwise it could self-exempt as its own marker, and a bare word like `example` would match ordinary hostnames such as `api.vendor.example` and non-doc prose, exempting the key outside real documentation.

Marker matching uses a length-preserving ASCII lowercase. `strings.ToLower` changes byte length for some Unicode runes (for example U+212A), which shifted marker offsets out of alignment with the credential spans and let a Unicode-prefixed bare key self-exempt.

## Tests

A superstring real key in documentation context still blocks; a documentation-marker fixture is clean; a bare key with no marker blocks; an adjacent real key still blocks; a Unicode-prefixed bare key blocks; `example` in a hostname does not exempt. The existing example-credential-docs test is unchanged and still passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of AWS “official example credential” documentation context so exemptions apply only when the marker appears outside credential token spans, using exact whole-token matching.
  * Prevented partial/embedded credential-like text and neighboring characters from incorrectly bypassing detection, including cases where “example” appears in URLs/hostnames.
  * Fixed casing and byte-offset behavior so Unicode-prefixed inputs can’t shift offsets to create false exemptions.
* **Tests**
  * Replaced prior coverage with stricter whole-token doc-marker regression tests and added Unicode byte-offset edge-case assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->