### PR TITLE
Baseline/taint review follow-ups: startup cleanup + reload downgrade guard

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1094,7 +1094,7 @@ behavioral_baseline:
 | `deviation_action` | `"warn"` | Action for locked-profile deviations: `warn`, `ask`, or `block` |
 | `auto_ratify` | `false` | Automatically lock learned profiles. Dangerous for production because poisoned training traffic can approve itself. |
 | `sensitivity_sigma` | `2.0` | Standard-deviation multiplier for deviation detection |
-| `lock_dimensions` | `tool_calls`, `unique_tools`, `domains`, `duration`, `requests` | Optional subset of `tool_calls`, `unique_tools`, `domains`, `duration`, `requests`. `bytes` remains stored in profiles for compatibility but is not part of default enforcement until transport byte recording is wired into session state. |
+| `lock_dimensions` | `tool_calls`, `unique_tools`, `domains`, `duration`, `requests` | Optional subset of `tool_calls`, `unique_tools`, `domains`, `bytes`, `duration`, `requests`. `bytes` remains stored in profiles for compatibility but is not part of default enforcement until transport byte recording is wired into session state. |
 | `poison_resistance` | `true` | Trim high-sigma training outliers before building the profile |
 | `seasonality_mode` | `"none"` | Seasonality mode; only `none` is currently enforced |
 

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -451,8 +451,7 @@ func implausibleReloadTeardownReasons(oldCfg, newCfg *config.Config) []string {
 		reasons = append(reasons, "dlp.patterns emptied")
 	}
 	if oldCfg.BehavioralBaseline.Enabled && newCfg.BehavioralBaseline.Enabled &&
-		oldCfg.BehavioralBaseline.DeviationAction == config.ActionBlock &&
-		newCfg.BehavioralBaseline.DeviationAction != config.ActionBlock {
+		config.ActionDowngraded(oldCfg.BehavioralBaseline.DeviationAction, newCfg.BehavioralBaseline.DeviationAction) {
 		reasons = append(reasons, "behavioral_baseline.deviation_action downgraded")
 	}
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1574,6 +1574,16 @@ func TestImplausibleReloadTeardownReasons_BehavioralBaselineWeakening(t *testing
 		t.Fatalf("baseline downgrade reasons = %v, want behavioral_baseline.deviation_action downgraded", reasons)
 	}
 
+	// A non-block downgrade (ask -> warn) must also be rejected: the guard ranks
+	// enforcement strength (warn < ask < block) rather than special-casing block.
+	askOld := oldCfg.Clone()
+	askOld.BehavioralBaseline.DeviationAction = config.ActionAsk
+	askToWarn := askOld.Clone()
+	askToWarn.BehavioralBaseline.DeviationAction = config.ActionWarn
+	if reasons := implausibleReloadTeardownReasons(askOld, askToWarn); !containsString(reasons, "behavioral_baseline.deviation_action downgraded") {
+		t.Fatalf("ask->warn downgrade reasons = %v, want behavioral_baseline.deviation_action downgraded", reasons)
+	}
+
 	// A live profile_dir move orphans locked profiles on the next restart
 	// (Reconfigure does not reload the new dir), so it must be rejected as a
 	// teardown rather than hot-applied.

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -897,6 +897,14 @@ func actionDowngraded(oldAction, newAction string) bool {
 	return oldOK && newOK && newStrength < oldStrength
 }
 
+// ActionDowngraded reports whether newAction is a weaker terminal enforcement
+// outcome than oldAction (e.g. block->warn, ask->warn) using the same ranking
+// as reload-downgrade detection. Exported for reload teardown guards in other
+// packages that must reject any enforcement downgrade, not just block->non-block.
+func ActionDowngraded(oldAction, newAction string) bool {
+	return actionDowngraded(oldAction, newAction)
+}
+
 // reloadActionStrength ranks terminal enforcement outcomes for reload-downgrade
 // detection. Block is strongest because it denies the risky operation outright.
 // Defer and ask both stop automatic forwarding, but defer is stronger because it

--- a/internal/config/reloadwarn_coverage_test.go
+++ b/internal/config/reloadwarn_coverage_test.go
@@ -95,6 +95,30 @@ func TestReloadActionStrengthCoversAllOrderedActions(t *testing.T) {
 	}
 }
 
+func TestActionDowngradedExportedWrapper(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		oldAction string
+		newAction string
+		want      bool
+	}{
+		{name: "block_to_warn_downgrades", oldAction: ActionBlock, newAction: ActionWarn, want: true},
+		{name: "warn_to_block_not_downgrade", oldAction: ActionWarn, newAction: ActionBlock, want: false},
+		{name: "unknown_action_not_downgrade", oldAction: "bogus", newAction: ActionWarn, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ActionDowngraded(tc.oldAction, tc.newAction); got != tc.want {
+				t.Fatalf("ActionDowngraded(%q, %q) = %v, want %v", tc.oldAction, tc.newAction, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSuppressCoverageHelpersEdgeCases(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/reloadwarn_coverage_test.go
+++ b/internal/config/reloadwarn_coverage_test.go
@@ -107,6 +107,8 @@ func TestActionDowngradedExportedWrapper(t *testing.T) {
 		{name: "block_to_warn_downgrades", oldAction: ActionBlock, newAction: ActionWarn, want: true},
 		{name: "warn_to_block_not_downgrade", oldAction: ActionWarn, newAction: ActionBlock, want: false},
 		{name: "unknown_action_not_downgrade", oldAction: "bogus", newAction: ActionWarn, want: false},
+		{name: "unknown_new_action_not_downgrade", oldAction: ActionWarn, newAction: "bogus", want: false},
+		{name: "same_action_not_downgrade", oldAction: ActionWarn, newAction: ActionWarn, want: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -544,6 +544,10 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			// initialize must not be silently swallowed (that leaves enforcement
 			// off while the operator believes deviations are blocked).
 			if err := sm.EnableBaseline(&cfg.BehavioralBaseline); err != nil {
+				// Fail closed AND clean up: sm is not yet stored in
+				// sessionMgrPtr, so nothing else would ever close its
+				// background goroutines (mirrors the Reload staging path).
+				sm.Close()
 				return nil, fmt.Errorf("behavioral baseline init: %w", err)
 			}
 		}

--- a/internal/session/taint_classify.go
+++ b/internal/session/taint_classify.go
@@ -115,6 +115,17 @@ func ClassifyPathSensitivityWithConfidence(targetPath string, protectedPatterns,
 	return ActionClassification{Sensitivity: SensitivityNormal, Confident: confident}
 }
 
+// failSafeSensitivity elevates an otherwise-normal read/browse action to
+// Protected when fail-safe classification is enabled and the target could not be
+// confidently classified. Centralizes the fail-safe read-path downgrade so the
+// stdio/HTTP read branches do not repeat it.
+func failSafeSensitivity(opts ClassificationOptions, confident bool) ActionSensitivity {
+	if opts.FailSafe && !confident {
+		return SensitivityProtected
+	}
+	return SensitivityNormal
+}
+
 // ClassifyHTTPAction returns the taint policy action class for an HTTP request.
 func ClassifyHTTPAction(method, targetPath string, protectedPatterns, elevatedPatterns []string) (ActionClass, ActionSensitivity) {
 	classified := ClassifyHTTPActionWithOptions(method, targetPath, protectedPatterns, elevatedPatterns, ClassificationOptions{})
@@ -127,11 +138,7 @@ func ClassifyHTTPActionWithOptions(method, targetPath string, protectedPatterns,
 	pathClass := ClassifyPathSensitivityWithConfidence(targetPath, protectedPatterns, elevatedPatterns, opts)
 	switch strings.ToUpper(method) {
 	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
-		sensitivity := SensitivityNormal
-		if opts.FailSafe && !pathClass.Confident {
-			sensitivity = SensitivityProtected
-		}
-		return ActionClassification{Class: ActionClassRead, Sensitivity: sensitivity, Confident: pathClass.Confident}
+		return ActionClassification{Class: ActionClassRead, Sensitivity: failSafeSensitivity(opts, pathClass.Confident), Confident: pathClass.Confident}
 	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
 		return ActionClassification{Class: ActionClassPublish, Sensitivity: pathClass.Sensitivity, Confident: pathClass.Confident}
 	default:
@@ -187,11 +194,7 @@ func ClassifyMCPToolCallWithOptions(toolName, argsJSON string, protectedPatterns
 
 	if looksLikeReadTool(name) || category == "read" || category == "list" {
 		pathClass := ClassifyPathSensitivityWithConfidence(targetPath, protectedPatterns, elevatedPatterns, opts)
-		sensitivity := SensitivityNormal
-		if opts.FailSafe && !pathClass.Confident {
-			sensitivity = SensitivityProtected
-		}
-		return ActionClassification{Class: ActionClassRead, Sensitivity: sensitivity, ActionRef: targetPath, Confident: pathClass.Confident}
+		return ActionClassification{Class: ActionClassRead, Sensitivity: failSafeSensitivity(opts, pathClass.Confident), ActionRef: targetPath, Confident: pathClass.Confident}
 	}
 
 	if hasExecIntent(argsJSON) {

--- a/internal/session/taint_classify_internal_test.go
+++ b/internal/session/taint_classify_internal_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import "testing"
+
+func TestFailSafeSensitivity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		opts      ClassificationOptions
+		confident bool
+		want      ActionSensitivity
+	}{
+		{name: "failsafe_low_confidence_protects", opts: ClassificationOptions{FailSafe: true}, confident: false, want: SensitivityProtected},
+		{name: "failsafe_confident_stays_normal", opts: ClassificationOptions{FailSafe: true}, confident: true, want: SensitivityNormal},
+		{name: "disabled_low_confidence_stays_normal", opts: ClassificationOptions{}, confident: false, want: SensitivityNormal},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := failSafeSensitivity(tc.opts, tc.confident); got != tc.want {
+				t.Fatalf("failSafeSensitivity(%+v, %v) = %s, want %s", tc.opts, tc.confident, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

Follow-up to #876 addressing review findings.

- `proxy.New` closes the session manager when a configured behavioral baseline fails to initialize, instead of leaking its background goroutines on the fail-closed return.
- The reload teardown guard rejects any `behavioral_baseline.deviation_action` downgrade (reusing the shared action-strength ranking), so `ask -> warn` is caught, not only `block -> non-block`.
- The fail-safe read-path sensitivity elevation is extracted into one helper, removing duplication across the HTTP and MCP read branches.
- Docs list `bytes` as an accepted `lock_dimensions` value that is not part of default enforcement.

Base `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Behavioral baseline reloads now detect and reject additional enforcement downgrades, including non-blocking action transitions, with consistent messaging.
* **Bug Fixes**
  * Startup now reliably cleans up session-manager resources when behavioral baseline initialization fails.
  * Read/browse sensitivity now applies fail-safe behavior more consistently across supported HTTP request types and MCP tool calls.
* **Documentation**
  * Updated behavioral baseline configuration guidance to clarify `bytes` is selectable, but not part of default enforcement yet.
* **Tests**
  * Added coverage for downgrade detection and fail-safe sensitivity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->