### PR TITLE
feat(mcp): tool-policy type/range/length/value arg validators

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -943,6 +943,12 @@ mcp_tool_policy:
       arg_pattern: '/etc/shadow'
       arg_key: '^(file_?path|target)$'
       action: block
+    - name: "Block large transfers"
+      tool_pattern: "^transfer$"
+      arg_key: "^amount$"
+      arg_type: number
+      arg_number_gt: 1000000000
+      action: block
 ```
 
 | Field | Default | Description |
@@ -955,12 +961,20 @@ mcp_tool_policy:
 - `name:` rule identifier
 - `tool_pattern:` regex matching tool name
 - `arg_pattern:` regex matching argument values (optional; omit for tool-name-only rules)
-- `arg_key:` regex scoping `arg_pattern` to specific top-level argument keys (optional; requires `arg_pattern`). Without `arg_key`, `arg_pattern` checks values from all argument keys. Values under matching keys are extracted recursively.
+- `arg_key:` regex scoping `arg_pattern` or structural validators to specific top-level argument keys (optional for `arg_pattern`, required for structural validators). Without `arg_key`, `arg_pattern` checks values from all argument keys. Values under matching keys are extracted recursively for regex matching.
+- `arg_type:` required JSON type guard for the value at `arg_key`: `string`, `number`, `integer`, `boolean`, `array`, or `object`. Type mismatch is dangerous and matches fail-closed. When used alone, `arg_type` means "match if this value is not this type." If combined with numeric bounds, it must be `number` or `integer`; if combined with length bounds, it must be `string` or `array`.
+- `arg_number_gt:` match when the numeric value at `arg_key` is strictly greater than this threshold.
+- `arg_number_lt:` match when the numeric value at `arg_key` is strictly less than this threshold.
+- `arg_len_gt:` match when the string rune count or array element count at `arg_key` is strictly greater than this non-negative threshold.
+- `arg_len_lt:` match when the string rune count or array element count at `arg_key` is strictly less than this non-negative threshold.
+- `arg_value_in:` list of dangerous canonical values; matches when the canonical value at `arg_key` is in the set.
 - `action:` per-rule override (warn, block, redirect, or defer)
 - `redirect_profile:` reference to a named redirect profile (required when `action: redirect`)
 - `resolution_policy:` affirmative-clearing policy (required when `action: defer`; see below)
 
-Shell obfuscation detection is built-in: backslash escapes, `$IFS` substitution, brace expansion, and octal/hex escapes are decoded before matching. See [Redirect Action (v2.0)](#redirect-action-v20) for redirect profile configuration.
+Tool policy is a default-allow denylist: a rule describes the dangerous condition, and a matched rule applies its action. `arg_pattern` and all configured structural validators AND together within one rule. Numeric validators parse JSON numbers losslessly, so `1e9` and `1000000000` compare as equal. If a bound/type/length validator cannot evaluate a present or required value, the rule matches fail-closed; the exception is an `arg_value_in`-only rule with an absent key, which does not match because the dangerous value was not sent.
+
+Shell obfuscation detection is built-in for `arg_pattern`: backslash escapes, `$IFS` substitution, brace expansion, and octal/hex escapes are decoded before matching. See [Redirect Action (v2.0)](#redirect-action-v20) for redirect profile configuration.
 
 ### Defer Action
 

--- a/docs/policy-spec-v0.1.md
+++ b/docs/policy-spec-v0.1.md
@@ -207,8 +207,16 @@ mcp:
 | `name` | string | yes | Rule identifier |
 | `tool_pattern` | string | yes | Regex matching tool name |
 | `arg_pattern` | string | no | Regex matching argument values |
-| `arg_key` | string | no | Regex scoping `arg_pattern` to top-level argument keys. Requires `arg_pattern`; specifying `arg_key` without `arg_pattern` is a validation error. |
+| `arg_key` | string | no | Regex scoping `arg_pattern` or structural validators to top-level argument keys. Required when any structural validator is set. |
+| `arg_type` | string | no | Required JSON type guard (`string`, `number`, `integer`, `boolean`, `array`, `object`). Type mismatch is dangerous and matches fail-closed. Standalone `arg_type` matches when the value is not that type. With numeric bounds, it must be `number` or `integer`; with length bounds, it must be `string` or `array`. |
+| `arg_number_gt` | number | no | Dangerous numeric condition: match when the parsed JSON number is strictly greater than this threshold. |
+| `arg_number_lt` | number | no | Dangerous numeric condition: match when the parsed JSON number is strictly less than this threshold. |
+| `arg_len_gt` | integer | no | Dangerous length condition: match when a string rune count or array element count is strictly greater than this non-negative threshold. |
+| `arg_len_lt` | integer | no | Dangerous length condition: match when a string rune count or array element count is strictly less than this non-negative threshold. |
+| `arg_value_in` | string array | no | Dangerous value set: match when the canonical value at `arg_key` is in this set. |
 | `action` | string | no | `block` or `warn` |
+
+Structural validators describe dangerous conditions in the default-allow denylist model. Within one rule, `tool_pattern`, optional `arg_pattern`, and every configured structural validator AND together. Numeric checks compare parsed JSON numbers losslessly. Bound, type, and length validators fail closed when the value is absent or unevaluable; `arg_value_in` alone does not match an absent key.
 
 ## Audit Event Format
 

--- a/docs/policy-spec-v0.1.md
+++ b/docs/policy-spec-v0.1.md
@@ -214,7 +214,7 @@ mcp:
 | `arg_len_gt` | integer | no | Dangerous length condition: match when a string rune count or array element count is strictly greater than this non-negative threshold. |
 | `arg_len_lt` | integer | no | Dangerous length condition: match when a string rune count or array element count is strictly less than this non-negative threshold. |
 | `arg_value_in` | string array | no | Dangerous value set: match when the canonical value at `arg_key` is in this set. |
-| `action` | string | no | `block` or `warn` |
+| `action` | string | no | `block`, `warn`, `redirect`, or `defer` |
 
 Structural validators describe dangerous conditions in the default-allow denylist model. Within one rule, `tool_pattern`, optional `arg_pattern`, and every configured structural validator AND together. Numeric checks compare parsed JSON numbers losslessly. Bound, type, and length validators fail closed when the value is absent or unevaluable; `arg_value_in` alone does not match an absent key.
 

--- a/internal/config/bounded_number_test.go
+++ b/internal/config/bounded_number_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestParseBoundedJSONNumber_ExponentBound is a regression guard against a
+// CPU/memory amplification vector: an attacker-supplied tool-call value like
+// 1e1000001 is only a few bytes but, if fed to big.Rat.SetString, eagerly
+// expands into a multi-megabyte integer (10^1000000 builds in ~17ms). The
+// parser must bound the exponent BEFORE any big-number construction and reject
+// it. If a future change reintroduces the eager SetString shortcut, an
+// over-bound exponent would parse as valid and this test fails.
+func TestParseBoundedJSONNumber_ExponentBound(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"small integer", "1000", true},
+		{"scientific within bound", "1e9", true},
+		{"negative", "-42.5", true},
+		{"exponent at bound", "1e10000", true},
+		{"exponent just over bound", "1e10001", false},
+		{"amplification exponent", "1e1000001", false},
+		{"negative exponent over bound", "1e-10001", false},
+		{"garbage", "not-a-number", false},
+		{"empty", "", false},
+		{"lone e", "1e", false},
+		{"over-long", strings.Repeat("9", 5000), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := ParseBoundedJSONNumber(json.Number(tt.in))
+			if ok != tt.want {
+				t.Fatalf("ParseBoundedJSONNumber(%q) ok=%v, want %v", tt.in, ok, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseBoundedJSONNumber_Fidelity proves scientific and plain forms compare
+// exactly equal (no float collapse), backing the numeric-range invariant.
+func TestParseBoundedJSONNumber_Fidelity(t *testing.T) {
+	sci, ok := ParseBoundedJSONNumber(json.Number("1e9"))
+	if !ok {
+		t.Fatal("expected 1e9 to parse")
+	}
+	plain, ok := ParseBoundedJSONNumber(json.Number("1000000000"))
+	if !ok {
+		t.Fatal("expected 1000000000 to parse")
+	}
+	if sci.Cmp(plain) != 0 {
+		t.Fatalf("1e9 != 1000000000 exactly: %s vs %s", sci.String(), plain.String())
+	}
+}

--- a/internal/config/bounded_number_test.go
+++ b/internal/config/bounded_number_test.go
@@ -23,7 +23,9 @@ func TestParseBoundedJSONNumber_ExponentBound(t *testing.T) {
 		want bool
 	}{
 		{"small integer", "1000", true},
+		{"zero", "0", true},
 		{"scientific within bound", "1e9", true},
+		{"negative exponent within bound", "1e-9", true},
 		{"negative", "-42.5", true},
 		{"exponent at bound", "1e10000", true},
 		{"exponent just over bound", "1e10001", false},

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -339,7 +339,10 @@ const (
 	// header/payload edge-case polish: see goldenHashDefaults note above. The
 	// rich fixture inherits the default DLP pattern set (include_defaults: true),
 	// so the hash shifts in lockstep.
-	goldenHashRichConfig = "06714a1deedfcd869f0a249d2b0fb8c46e38847f99d2e8c13c1e331f2414805f"
+	// Re-bumped for MCP tool-policy structural argument validators. New
+	// ToolPolicyRule fields are policy-semantic even when zero-valued because
+	// non-zero values change tool-call decisions.
+	goldenHashRichConfig = "9bea5ad49aacea8ab8e7e2ec68fdfb567f39526ffa5485f682f3b77749dc6b2a"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5137,6 +5137,35 @@ func TestValidate_MCPToolPolicyStructuralValidators(t *testing.T) {
 			wantErr: `arg_type "string" with numeric bounds`,
 		},
 		{
+			name: "numeric bound with integer type is valid",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^amount$",
+				ArgType:     "integer",
+				ArgNumberGT: testJSONNumberPtr("10"),
+				ArgNumberLT: testJSONNumberPtr("100"),
+			},
+		},
+		{
+			name: "arg_value_in with arg_key is valid",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^currency$",
+				ArgValueIn:  []string{"BTC", "ETH"},
+			},
+		},
+		{
+			name: "arg_value_in without arg_key is invalid",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgValueIn:  []string{"BTC"},
+			},
+			wantErr: "structural argument validators but no arg_key",
+		},
+		{
 			name: "negative arg_len_lt",
 			rule: ToolPolicyRule{
 				Name:        "structural",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5060,7 +5060,7 @@ func TestValidate_MCPToolPolicyRuleInvalidPerRuleAction(t *testing.T) {
 	}
 }
 
-func TestValidate_MCPToolPolicyStructuralValidators(t *testing.T) {
+func TestValidate_StructuralValidators(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		rule    ToolPolicyRule

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5060,6 +5060,167 @@ func TestValidate_MCPToolPolicyRuleInvalidPerRuleAction(t *testing.T) {
 	}
 }
 
+func TestValidate_MCPToolPolicyStructuralValidators(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		rule    ToolPolicyRule
+		wantErr string
+	}{
+		{
+			name: "arg_key structural without arg_pattern is valid",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^amount$",
+				ArgNumberGT: testJSONNumberPtr("10000"),
+			},
+		},
+		{
+			name: "structural without arg_key is invalid",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgNumberGT: testJSONNumberPtr("10000"),
+			},
+			wantErr: "structural argument validators but no arg_key",
+		},
+		{
+			name: "invalid arg_type",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^amount$",
+				ArgType:     "float",
+			},
+			wantErr: `invalid arg_type "float"`,
+		},
+		{
+			name: "invalid arg_number_gt",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^amount$",
+				ArgNumberGT: testJSONNumberPtr("not-a-number"),
+			},
+			wantErr: `invalid arg_number_gt "not-a-number"`,
+		},
+		{
+			name: "invalid arg_number_lt",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^amount$",
+				ArgNumberLT: testJSONNumberPtr("1e10001"),
+			},
+			wantErr: `invalid arg_number_lt "1e10001"`,
+		},
+		{
+			name: "unsatisfiable numeric range",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^amount$",
+				ArgNumberGT: testJSONNumberPtr("10"),
+				ArgNumberLT: testJSONNumberPtr("10"),
+			},
+			wantErr: "unsatisfiable numeric range",
+		},
+		{
+			name: "numeric bound with string type",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^amount$",
+				ArgType:     "string",
+				ArgNumberGT: testJSONNumberPtr("10"),
+			},
+			wantErr: `arg_type "string" with numeric bounds`,
+		},
+		{
+			name: "negative arg_len_lt",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^path$",
+				ArgLenLT:    testIntPtr(-1),
+			},
+			wantErr: "invalid arg_len_lt -1",
+		},
+		{
+			name: "unsatisfiable length range",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^path$",
+				ArgLenGT:    testIntPtr(5),
+				ArgLenLT:    testIntPtr(5),
+			},
+			wantErr: "unsatisfiable length range",
+		},
+		{
+			name: "length bound with number type",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^path$",
+				ArgType:     "number",
+				ArgLenGT:    testIntPtr(3),
+			},
+			wantErr: `arg_type "number" with length bounds`,
+		},
+		{
+			name: "length bound with array type is valid",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^items$",
+				ArgType:     "array",
+				ArgLenGT:    testIntPtr(3),
+			},
+		},
+		{
+			name: "negative length bound",
+			rule: ToolPolicyRule{
+				Name:        "structural",
+				ToolPattern: "^transfer$",
+				ArgKey:      "^path$",
+				ArgLenGT:    testIntPtr(-1),
+			},
+			wantErr: "invalid arg_len_gt -1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.MCPToolPolicy.Enabled = true
+			cfg.MCPToolPolicy.Action = ActionBlock
+			cfg.MCPToolPolicy.Rules = []ToolPolicyRule{tc.rule}
+
+			err := cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() err = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() err = nil, want substring %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate() err = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func testJSONNumberPtr(value string) *json.Number {
+	n := json.Number(value)
+	return &n
+}
+
+func testIntPtr(value int) *int {
+	return &value
+}
+
 func TestValidateReload_MCPToolPolicyDisabled(t *testing.T) {
 	old := Defaults()
 	old.MCPToolPolicy.Enabled = true

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
 	"time"
@@ -679,6 +680,12 @@ type ToolPolicyRule struct {
 	ToolPattern      string                 `yaml:"tool_pattern"`     // regex matching tool name
 	ArgPattern       string                 `yaml:"arg_pattern"`      // regex matching argument values (optional)
 	ArgKey           string                 `yaml:"arg_key"`          // regex scoping arg_pattern to specific argument keys (optional)
+	ArgType          string                 `yaml:"arg_type"`         // required JSON type guard for arg_key value (optional)
+	ArgNumberGT      *json.Number           `yaml:"arg_number_gt"`    // match when arg_key numeric value is greater than this (optional)
+	ArgNumberLT      *json.Number           `yaml:"arg_number_lt"`    // match when arg_key numeric value is less than this (optional)
+	ArgLenGT         *int                   `yaml:"arg_len_gt"`       // match when arg_key string/array length is greater than this (optional)
+	ArgLenLT         *int                   `yaml:"arg_len_lt"`       // match when arg_key string/array length is less than this (optional)
+	ArgValueIn       []string               `yaml:"arg_value_in"`     // dangerous canonical values for arg_key value (optional)
 	Action           string                 `yaml:"action"`           // per-rule override: warn, block, redirect, defer (optional)
 	RedirectProfile  string                 `yaml:"redirect_profile"` // key in redirect_profiles (required when action=redirect)
 	ResolutionPolicy *DeferResolutionPolicy `yaml:"resolution_policy,omitempty" json:"resolution_policy,omitempty"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1032,22 +1032,21 @@ func validateToolPolicyStructuralArgs(r ToolPolicyRule) error {
 	if err := validateToolPolicyStructuralTypeCompatibility(r); err != nil {
 		return err
 	}
+	var gt, lt *big.Rat
 	if r.ArgNumberGT != nil {
-		if _, ok := ParseBoundedJSONNumber(*r.ArgNumberGT); !ok {
+		var ok bool
+		if gt, ok = ParseBoundedJSONNumber(*r.ArgNumberGT); !ok {
 			return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_number_gt %q", r.Name, r.ArgNumberGT.String())
 		}
 	}
 	if r.ArgNumberLT != nil {
-		if _, ok := ParseBoundedJSONNumber(*r.ArgNumberLT); !ok {
+		var ok bool
+		if lt, ok = ParseBoundedJSONNumber(*r.ArgNumberLT); !ok {
 			return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_number_lt %q", r.Name, r.ArgNumberLT.String())
 		}
 	}
-	if r.ArgNumberGT != nil && r.ArgNumberLT != nil {
-		gt, _ := ParseBoundedJSONNumber(*r.ArgNumberGT)
-		lt, _ := ParseBoundedJSONNumber(*r.ArgNumberLT)
-		if gt.Cmp(lt) >= 0 {
-			return fmt.Errorf("mcp_tool_policy rule %q has unsatisfiable numeric range: arg_number_gt must be less than arg_number_lt", r.Name)
-		}
+	if gt != nil && lt != nil && gt.Cmp(lt) >= 0 {
+		return fmt.Errorf("mcp_tool_policy rule %q has unsatisfiable numeric range: arg_number_gt must be less than arg_number_lt", r.Name)
 	}
 	if r.ArgLenGT != nil && *r.ArgLenGT < 0 {
 		return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_len_gt %d: must be non-negative", r.Name, *r.ArgLenGT)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -6,9 +6,11 @@ package config
 import (
 	"crypto/ed25519"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -950,13 +952,19 @@ func (c *Config) validateMCPToolPolicy() error {
 				return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_pattern: %w", r.Name, err)
 			}
 		}
+		hasStructuralValidators := r.hasStructuralArgValidators()
 		if r.ArgKey != "" {
-			if r.ArgPattern == "" {
+			if r.ArgPattern == "" && !hasStructuralValidators {
 				return fmt.Errorf("mcp_tool_policy rule %q has arg_key without arg_pattern", r.Name)
 			}
 			if _, err := regexp.Compile(r.ArgKey); err != nil {
 				return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_key: %w", r.Name, err)
 			}
+		} else if hasStructuralValidators {
+			return fmt.Errorf("mcp_tool_policy rule %q has structural argument validators but no arg_key", r.Name)
+		}
+		if err := validateToolPolicyStructuralArgs(r); err != nil {
+			return err
 		}
 		if r.Action != "" {
 			switch r.Action {
@@ -1003,6 +1011,131 @@ func (c *Config) validateMCPToolPolicy() error {
 		}
 	}
 	return nil
+}
+
+func (r ToolPolicyRule) hasStructuralArgValidators() bool {
+	return r.ArgType != "" ||
+		r.ArgNumberGT != nil ||
+		r.ArgNumberLT != nil ||
+		r.ArgLenGT != nil ||
+		r.ArgLenLT != nil ||
+		len(r.ArgValueIn) > 0
+}
+
+func validateToolPolicyStructuralArgs(r ToolPolicyRule) error {
+	switch r.ArgType {
+	case "", "string", "number", "integer", "boolean", "array", "object":
+		// valid
+	default:
+		return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_type %q: must be string, number, integer, boolean, array, or object", r.Name, r.ArgType)
+	}
+	if err := validateToolPolicyStructuralTypeCompatibility(r); err != nil {
+		return err
+	}
+	if r.ArgNumberGT != nil {
+		if _, ok := ParseBoundedJSONNumber(*r.ArgNumberGT); !ok {
+			return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_number_gt %q", r.Name, r.ArgNumberGT.String())
+		}
+	}
+	if r.ArgNumberLT != nil {
+		if _, ok := ParseBoundedJSONNumber(*r.ArgNumberLT); !ok {
+			return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_number_lt %q", r.Name, r.ArgNumberLT.String())
+		}
+	}
+	if r.ArgNumberGT != nil && r.ArgNumberLT != nil {
+		gt, _ := ParseBoundedJSONNumber(*r.ArgNumberGT)
+		lt, _ := ParseBoundedJSONNumber(*r.ArgNumberLT)
+		if gt.Cmp(lt) >= 0 {
+			return fmt.Errorf("mcp_tool_policy rule %q has unsatisfiable numeric range: arg_number_gt must be less than arg_number_lt", r.Name)
+		}
+	}
+	if r.ArgLenGT != nil && *r.ArgLenGT < 0 {
+		return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_len_gt %d: must be non-negative", r.Name, *r.ArgLenGT)
+	}
+	if r.ArgLenLT != nil && *r.ArgLenLT < 0 {
+		return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_len_lt %d: must be non-negative", r.Name, *r.ArgLenLT)
+	}
+	if r.ArgLenGT != nil && r.ArgLenLT != nil && *r.ArgLenGT >= *r.ArgLenLT {
+		return fmt.Errorf("mcp_tool_policy rule %q has unsatisfiable length range: arg_len_gt must be less than arg_len_lt", r.Name)
+	}
+	return nil
+}
+
+func validateToolPolicyStructuralTypeCompatibility(r ToolPolicyRule) error {
+	if r.ArgType == "" {
+		return nil
+	}
+	hasNumberBound := r.ArgNumberGT != nil || r.ArgNumberLT != nil
+	if hasNumberBound && r.ArgType != "number" && r.ArgType != "integer" {
+		return fmt.Errorf("mcp_tool_policy rule %q has arg_type %q with numeric bounds: arg_type must be number or integer", r.Name, r.ArgType)
+	}
+	hasLengthBound := r.ArgLenGT != nil || r.ArgLenLT != nil
+	if hasLengthBound && r.ArgType != "string" && r.ArgType != "array" {
+		return fmt.Errorf("mcp_tool_policy rule %q has arg_type %q with length bounds: arg_type must be string or array", r.Name, r.ArgType)
+	}
+	return nil
+}
+
+const (
+	toolPolicyMaxNumberChars  = 4096
+	toolPolicyMaxNumberExpAbs = 10000
+)
+
+var toolPolicyJSONNumberPattern = regexp.MustCompile(`^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$`)
+
+// ParseBoundedJSONNumber parses a JSON number into an exact big.Rat, rejecting
+// values that are empty, over-long, malformed, or whose exponent magnitude
+// exceeds a safe bound. The exponent is bounded BEFORE any big-number
+// construction, so an attacker-supplied value like 1e1000000 (a few bytes) is
+// rejected in microseconds rather than forcing a multi-megabyte allocation. It
+// deliberately never calls big.Rat.SetString on the raw string, because
+// SetString eagerly expands a large exponent (10^1000000 → ~17ms) before any
+// bound can apply. Shared by config validation and the MCP tool-policy engine
+// so the parse+bounds logic has a single source of truth.
+func ParseBoundedJSONNumber(n json.Number) (*big.Rat, bool) {
+	s := n.String()
+	if len(s) == 0 || len(s) > toolPolicyMaxNumberChars || !toolPolicyJSONNumberPattern.MatchString(s) {
+		return nil, false
+	}
+
+	base, expPart, hasExp := strings.Cut(strings.ToLower(s), "e")
+	exp := 0
+	if hasExp {
+		parsed, err := strconv.Atoi(expPart)
+		if err != nil || parsed > toolPolicyMaxNumberExpAbs || parsed < -toolPolicyMaxNumberExpAbs {
+			return nil, false
+		}
+		exp = parsed
+	}
+
+	negative := strings.HasPrefix(base, "-")
+	base = strings.TrimPrefix(base, "-")
+	intPart, fracPart, hasFrac := strings.Cut(base, ".")
+	digits := intPart
+	scale := 0
+	if hasFrac {
+		digits += fracPart
+		scale = len(fracPart)
+	}
+	digits = strings.TrimLeft(digits, "0")
+	if digits == "" {
+		digits = "0"
+	}
+
+	num := new(big.Int)
+	if _, ok := num.SetString(digits, 10); !ok {
+		return nil, false
+	}
+	if negative {
+		num.Neg(num)
+	}
+	den := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
+	if exp >= 0 {
+		num.Mul(num, new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(exp)), nil))
+	} else {
+		den.Mul(den, new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(-exp)), nil))
+	}
+	return new(big.Rat).SetFrac(num, den), true
 }
 
 func (c *Config) validateDefer() error {

--- a/internal/mcp/policy/policy.go
+++ b/internal/mcp/policy/policy.go
@@ -277,44 +277,19 @@ func (pc *Config) CheckToolCallWithArgs(toolName string, argStrings []string, ra
 
 		// Key-scoped rules: extract only values under matching top-level keys,
 		// then normalize and match those instead of all values. If raw
-		// arguments are unavailable, skip the rule rather than falling
-		// back to unscoped matching (safety net for future callers).
+		// arguments are unavailable, skip best-effort pattern-only rules rather
+		// than falling back to unscoped matching; structural validators need raw
+		// JSON, so they fail closed instead.
 		ruleTokens, ruleJoined := tokens, joined
 		ruleAltTokens, ruleAltJoined := altTokens, altJoined
 		ruleBaseTokens, ruleBaseJoined := baseTokens, baseJoined
-		if rule.ArgKey != nil && rule.ArgPattern != nil {
-			if len(rawArgs) == 0 {
-				argPatternMatched := matchArgPattern(rule.ArgPattern, ruleTokens, ruleJoined) ||
-					matchArgPattern(rule.ArgPattern, ruleAltTokens, ruleAltJoined) ||
-					matchArgPattern(rule.ArgPattern, ruleBaseTokens, ruleBaseJoined)
-				if !argPatternMatched {
-					continue
-				}
-				if !rule.hasStructuralValidators() {
-					continue // cannot scope without raw JSON - skip non-structural rule
-				}
-				structuralMatched, uninspectable := rule.matchStructuralValidators(rawArgs)
-				if uninspectable {
-					return uninspectableJSONDepthVerdict()
-				}
-				if !structuralMatched {
-					continue
-				}
-				matchedRules = append(matchedRules, rule.Name)
-				action := rule.Action
-				if action == "" {
-					action = pc.Action
-				}
-				prev := strictest
-				strictest = StricterAction(strictest, action)
-				if strictest != prev && action == config.ActionRedirect {
-					redirectProfile = rule.RedirectProfile
-				}
-				if strictest != prev && action == config.ActionDefer {
-					resolutionPolicy = rule.ResolutionPolicy
-				}
-				continue
+		if rule.ArgKey != nil && len(rawArgs) == 0 {
+			if rule.hasStructuralValidators() {
+				return uninspectableStructuralArgsVerdict(rule.Name)
 			}
+			continue
+		}
+		if rule.ArgKey != nil && rule.ArgPattern != nil {
 			scoped := jsonrpc.ExtractStringsForKeysResult(rawArgs, rule.ArgKey)
 			if scoped.Truncated {
 				return uninspectableJSONDepthVerdict()
@@ -730,6 +705,18 @@ func uninspectableJSONDepthVerdict() Verdict {
 		Matched: true,
 		Action:  config.ActionBlock,
 		Rules:   []string{uninspectableJSONDepthRule},
+	}
+}
+
+func uninspectableStructuralArgsVerdict(ruleName string) Verdict {
+	rules := []string{uninspectableJSONDepthRule}
+	if ruleName != "" {
+		rules = []string{ruleName, uninspectableJSONDepthRule}
+	}
+	return Verdict{
+		Matched: true,
+		Action:  config.ActionBlock,
+		Rules:   rules,
 	}
 }
 

--- a/internal/mcp/policy/policy.go
+++ b/internal/mcp/policy/policy.go
@@ -284,6 +284,12 @@ func (pc *Config) CheckToolCallWithArgs(toolName string, argStrings []string, ra
 		ruleBaseTokens, ruleBaseJoined := baseTokens, baseJoined
 		if rule.ArgKey != nil && rule.ArgPattern != nil {
 			if len(rawArgs) == 0 {
+				argPatternMatched := matchArgPattern(rule.ArgPattern, ruleTokens, ruleJoined) ||
+					matchArgPattern(rule.ArgPattern, ruleAltTokens, ruleAltJoined) ||
+					matchArgPattern(rule.ArgPattern, ruleBaseTokens, ruleBaseJoined)
+				if !argPatternMatched {
+					continue
+				}
 				if !rule.hasStructuralValidators() {
 					continue // cannot scope without raw JSON - skip non-structural rule
 				}
@@ -477,6 +483,10 @@ func structuralValuesForArgKey(rawArgs json.RawMessage, keyPattern *regexp.Regex
 	if len(rawArgs) == 0 || string(rawArgs) == jsonrpc.Null {
 		return nil, false, true
 	}
+	truncated, valid := structuralJSONDepthTruncated(rawArgs)
+	if truncated || !valid {
+		return nil, truncated, valid
+	}
 	dec := json.NewDecoder(bytes.NewReader(rawArgs))
 	dec.UseNumber()
 	var parsed interface{}
@@ -485,9 +495,6 @@ func structuralValuesForArgKey(rawArgs json.RawMessage, keyPattern *regexp.Regex
 	}
 	if err := dec.Decode(&struct{}{}); err != io.EOF {
 		return nil, false, false
-	}
-	if structuralValueDepthTruncated(parsed, 0) {
-		return nil, true, true
 	}
 	args, ok := parsed.(map[string]interface{})
 	if !ok || keyPattern == nil {
@@ -503,25 +510,33 @@ func structuralValuesForArgKey(rawArgs json.RawMessage, keyPattern *regexp.Regex
 	return values, false, true
 }
 
-func structuralValueDepthTruncated(value interface{}, depth int) bool {
-	if depth > structuralMaxArgDepth {
-		return true
-	}
-	switch typed := value.(type) {
-	case []interface{}:
-		for _, item := range typed {
-			if structuralValueDepthTruncated(item, depth+1) {
-				return true
-			}
+func structuralJSONDepthTruncated(rawArgs json.RawMessage) (bool, bool) {
+	dec := json.NewDecoder(bytes.NewReader(rawArgs))
+	depth := 0
+	sawToken := false
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			return false, sawToken && depth == 0
 		}
-	case map[string]interface{}:
-		for _, item := range typed {
-			if structuralValueDepthTruncated(item, depth+1) {
-				return true
+		if err != nil {
+			return false, false
+		}
+		sawToken = true
+		delim, ok := tok.(json.Delim)
+		if !ok {
+			continue
+		}
+		switch delim {
+		case '{', '[':
+			depth++
+			if depth > structuralMaxArgDepth+1 {
+				return true, true
 			}
+		case '}', ']':
+			depth--
 		}
 	}
-	return false
 }
 
 func (rule *CompiledRule) matchStructuralValue(value interface{}) bool {

--- a/internal/mcp/policy/policy.go
+++ b/internal/mcp/policy/policy.go
@@ -8,9 +8,12 @@ package policy
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"math/big"
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/jsonrpc"
@@ -139,8 +142,14 @@ type CompiledRule struct {
 	ToolPattern      *regexp.Regexp
 	ArgPattern       *regexp.Regexp // nil = match on tool name alone
 	ArgKey           *regexp.Regexp // nil = match all arg values; non-nil = scope to matching keys
-	Action           string         // per-rule override, empty = use Config.Action
-	RedirectProfile  string         // key in redirect_profiles (when action=redirect)
+	ArgType          string
+	ArgNumberGT      *json.Number
+	ArgNumberLT      *json.Number
+	ArgLenGT         *int
+	ArgLenLT         *int
+	ArgValueIn       map[string]struct{}
+	Action           string // per-rule override, empty = use Config.Action
+	RedirectProfile  string // key in redirect_profiles (when action=redirect)
 	ResolutionPolicy config.DeferResolutionPolicy
 }
 
@@ -169,6 +178,11 @@ func New(cfg config.MCPToolPolicy) *Config {
 		compiled := &CompiledRule{
 			Name:            r.Name,
 			ToolPattern:     regexp.MustCompile(r.ToolPattern),
+			ArgType:         r.ArgType,
+			ArgNumberGT:     r.ArgNumberGT,
+			ArgNumberLT:     r.ArgNumberLT,
+			ArgLenGT:        r.ArgLenGT,
+			ArgLenLT:        r.ArgLenLT,
 			Action:          r.Action,
 			RedirectProfile: r.RedirectProfile,
 		}
@@ -180,6 +194,12 @@ func New(cfg config.MCPToolPolicy) *Config {
 		}
 		if r.ArgKey != "" {
 			compiled.ArgKey = regexp.MustCompile(r.ArgKey)
+		}
+		if len(r.ArgValueIn) > 0 {
+			compiled.ArgValueIn = make(map[string]struct{}, len(r.ArgValueIn))
+			for _, value := range r.ArgValueIn {
+				compiled.ArgValueIn[value] = struct{}{}
+			}
 		}
 		pc.Rules = append(pc.Rules, compiled)
 	}
@@ -196,8 +216,9 @@ func (pc *Config) CheckToolCall(toolName string, argStrings []string) Verdict {
 
 // CheckToolCallWithArgs evaluates a tool call against policy rules.
 // argStrings contains all argument values (for rules without arg_key).
-// rawArgs is the raw JSON arguments (for rules with arg_key that need
-// key-scoped extraction). rawArgs may be nil if no rules use arg_key.
+// rawArgs is the raw JSON arguments (for rules with arg_key or structural
+// validators that need parsed argument values). rawArgs may be nil when callers
+// cannot provide the original JSON.
 //
 // Three matching strategies handle different evasion techniques:
 //  1. Joined string - catches array-split evasion (["rm","-rf","/"])
@@ -254,24 +275,6 @@ func (pc *Config) CheckToolCallWithArgs(toolName string, argStrings []string, ra
 			continue
 		}
 
-		// No arg pattern - tool name match alone triggers the rule.
-		if rule.ArgPattern == nil {
-			matchedRules = append(matchedRules, rule.Name)
-			action := rule.Action
-			if action == "" {
-				action = pc.Action
-			}
-			prev := strictest
-			strictest = StricterAction(strictest, action)
-			if strictest != prev && action == config.ActionRedirect {
-				redirectProfile = rule.RedirectProfile
-			}
-			if strictest != prev && action == config.ActionDefer {
-				resolutionPolicy = rule.ResolutionPolicy
-			}
-			continue
-		}
-
 		// Key-scoped rules: extract only values under matching top-level keys,
 		// then normalize and match those instead of all values. If raw
 		// arguments are unavailable, skip the rule rather than falling
@@ -279,9 +282,32 @@ func (pc *Config) CheckToolCallWithArgs(toolName string, argStrings []string, ra
 		ruleTokens, ruleJoined := tokens, joined
 		ruleAltTokens, ruleAltJoined := altTokens, altJoined
 		ruleBaseTokens, ruleBaseJoined := baseTokens, baseJoined
-		if rule.ArgKey != nil {
+		if rule.ArgKey != nil && rule.ArgPattern != nil {
 			if len(rawArgs) == 0 {
-				continue // cannot scope without raw JSON - skip rule
+				if !rule.hasStructuralValidators() {
+					continue // cannot scope without raw JSON - skip non-structural rule
+				}
+				structuralMatched, uninspectable := rule.matchStructuralValidators(rawArgs)
+				if uninspectable {
+					return uninspectableJSONDepthVerdict()
+				}
+				if !structuralMatched {
+					continue
+				}
+				matchedRules = append(matchedRules, rule.Name)
+				action := rule.Action
+				if action == "" {
+					action = pc.Action
+				}
+				prev := strictest
+				strictest = StricterAction(strictest, action)
+				if strictest != prev && action == config.ActionRedirect {
+					redirectProfile = rule.RedirectProfile
+				}
+				if strictest != prev && action == config.ActionDefer {
+					resolutionPolicy = rule.ResolutionPolicy
+				}
+				continue
 			}
 			scoped := jsonrpc.ExtractStringsForKeysResult(rawArgs, rule.ArgKey)
 			if scoped.Truncated {
@@ -293,22 +319,34 @@ func (pc *Config) CheckToolCallWithArgs(toolName string, argStrings []string, ra
 			ruleBaseTokens, ruleBaseJoined = normalizeArgTokens(scopedStrings, normalize.ForMatching, nil)
 		}
 
-		if matchArgPattern(rule.ArgPattern, ruleTokens, ruleJoined) ||
+		argPatternMatched := rule.ArgPattern == nil ||
+			matchArgPattern(rule.ArgPattern, ruleTokens, ruleJoined) ||
 			matchArgPattern(rule.ArgPattern, ruleAltTokens, ruleAltJoined) ||
-			matchArgPattern(rule.ArgPattern, ruleBaseTokens, ruleBaseJoined) {
-			matchedRules = append(matchedRules, rule.Name)
-			action := rule.Action
-			if action == "" {
-				action = pc.Action
-			}
-			prev := strictest
-			strictest = StricterAction(strictest, action)
-			if strictest != prev && action == config.ActionRedirect {
-				redirectProfile = rule.RedirectProfile
-			}
-			if strictest != prev && action == config.ActionDefer {
-				resolutionPolicy = rule.ResolutionPolicy
-			}
+			matchArgPattern(rule.ArgPattern, ruleBaseTokens, ruleBaseJoined)
+		if !argPatternMatched {
+			continue
+		}
+
+		structuralMatched, uninspectable := rule.matchStructuralValidators(rawArgs)
+		if uninspectable {
+			return uninspectableJSONDepthVerdict()
+		}
+		if !structuralMatched {
+			continue
+		}
+
+		matchedRules = append(matchedRules, rule.Name)
+		action := rule.Action
+		if action == "" {
+			action = pc.Action
+		}
+		prev := strictest
+		strictest = StricterAction(strictest, action)
+		if strictest != prev && action == config.ActionRedirect {
+			redirectProfile = rule.RedirectProfile
+		}
+		if strictest != prev && action == config.ActionDefer {
+			resolutionPolicy = rule.ResolutionPolicy
 		}
 	}
 
@@ -396,6 +434,226 @@ func matchArgPattern(pat *regexp.Regexp, tokens []string, joined string) bool {
 	return false
 }
 
+const structuralMaxArgDepth = 64
+
+func (rule *CompiledRule) hasStructuralValidators() bool {
+	return rule.ArgType != "" ||
+		rule.ArgNumberGT != nil ||
+		rule.ArgNumberLT != nil ||
+		rule.ArgLenGT != nil ||
+		rule.ArgLenLT != nil ||
+		len(rule.ArgValueIn) > 0
+}
+
+func (rule *CompiledRule) hasAbsentFailClosedValidator() bool {
+	return rule.ArgType != "" ||
+		rule.ArgNumberGT != nil ||
+		rule.ArgNumberLT != nil ||
+		rule.ArgLenGT != nil ||
+		rule.ArgLenLT != nil
+}
+
+func (rule *CompiledRule) matchStructuralValidators(rawArgs json.RawMessage) (matched bool, uninspectable bool) {
+	if !rule.hasStructuralValidators() {
+		return true, false
+	}
+
+	values, truncated, ok := structuralValuesForArgKey(rawArgs, rule.ArgKey)
+	if truncated || !ok {
+		return false, true
+	}
+	if len(values) == 0 {
+		return rule.hasAbsentFailClosedValidator(), false
+	}
+	for _, value := range values {
+		if rule.matchStructuralValue(value) {
+			return true, false
+		}
+	}
+	return false, false
+}
+
+func structuralValuesForArgKey(rawArgs json.RawMessage, keyPattern *regexp.Regexp) ([]interface{}, bool, bool) {
+	if len(rawArgs) == 0 || string(rawArgs) == jsonrpc.Null {
+		return nil, false, true
+	}
+	dec := json.NewDecoder(bytes.NewReader(rawArgs))
+	dec.UseNumber()
+	var parsed interface{}
+	if err := dec.Decode(&parsed); err != nil {
+		return nil, false, false
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return nil, false, false
+	}
+	if structuralValueDepthTruncated(parsed, 0) {
+		return nil, true, true
+	}
+	args, ok := parsed.(map[string]interface{})
+	if !ok || keyPattern == nil {
+		return nil, false, true
+	}
+
+	var values []interface{}
+	for _, key := range jsonrpc.SortedKeys(args) {
+		if keyPattern.MatchString(key) {
+			values = append(values, args[key])
+		}
+	}
+	return values, false, true
+}
+
+func structuralValueDepthTruncated(value interface{}, depth int) bool {
+	if depth > structuralMaxArgDepth {
+		return true
+	}
+	switch typed := value.(type) {
+	case []interface{}:
+		for _, item := range typed {
+			if structuralValueDepthTruncated(item, depth+1) {
+				return true
+			}
+		}
+	case map[string]interface{}:
+		for _, item := range typed {
+			if structuralValueDepthTruncated(item, depth+1) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (rule *CompiledRule) matchStructuralValue(value interface{}) bool {
+	hasNonTypeValidator := rule.ArgNumberGT != nil ||
+		rule.ArgNumberLT != nil ||
+		rule.ArgLenGT != nil ||
+		rule.ArgLenLT != nil ||
+		len(rule.ArgValueIn) > 0
+
+	if rule.ArgType != "" {
+		if !structuralValueHasType(value, rule.ArgType) {
+			return true
+		}
+		if !hasNonTypeValidator {
+			return false
+		}
+	}
+
+	if rule.ArgNumberGT != nil || rule.ArgNumberLT != nil {
+		valueNumber, ok := value.(json.Number)
+		if !ok {
+			return true
+		}
+		valueRat, ok := config.ParseBoundedJSONNumber(valueNumber)
+		if !ok {
+			return true
+		}
+		if rule.ArgNumberGT != nil {
+			threshold, ok := config.ParseBoundedJSONNumber(*rule.ArgNumberGT)
+			if !ok {
+				return true // unevaluable compiled threshold: fail closed (match)
+			}
+			if valueRat.Cmp(threshold) <= 0 {
+				return false
+			}
+		}
+		if rule.ArgNumberLT != nil {
+			threshold, ok := config.ParseBoundedJSONNumber(*rule.ArgNumberLT)
+			if !ok {
+				return true // unevaluable compiled threshold: fail closed (match)
+			}
+			if valueRat.Cmp(threshold) >= 0 {
+				return false
+			}
+		}
+	}
+
+	if rule.ArgLenGT != nil || rule.ArgLenLT != nil {
+		length, ok := structuralValueLength(value)
+		if !ok {
+			return true
+		}
+		if rule.ArgLenGT != nil && length <= *rule.ArgLenGT {
+			return false
+		}
+		if rule.ArgLenLT != nil && length >= *rule.ArgLenLT {
+			return false
+		}
+	}
+
+	if len(rule.ArgValueIn) > 0 {
+		canonical, ok := canonicalStructuralValue(value)
+		if !ok {
+			return true
+		}
+		if _, ok := rule.ArgValueIn[canonical]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func structuralValueHasType(value interface{}, argType string) bool {
+	switch argType {
+	case "string":
+		_, ok := value.(string)
+		return ok
+	case "number":
+		_, ok := value.(json.Number)
+		return ok
+	case "integer":
+		number, ok := value.(json.Number)
+		if !ok {
+			return false
+		}
+		rat, ok := config.ParseBoundedJSONNumber(number)
+		return ok && rat.Denom().Cmp(big.NewInt(1)) == 0
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "array":
+		_, ok := value.([]interface{})
+		return ok
+	case "object":
+		_, ok := value.(map[string]interface{})
+		return ok
+	default:
+		return false
+	}
+}
+
+func structuralValueLength(value interface{}) (int, bool) {
+	switch typed := value.(type) {
+	case string:
+		return utf8.RuneCountInString(typed), true
+	case []interface{}:
+		return len(typed), true
+	default:
+		return 0, false
+	}
+}
+
+func canonicalStructuralValue(value interface{}) (string, bool) {
+	switch typed := value.(type) {
+	case nil:
+		return "null", true
+	case string:
+		return typed, true
+	case json.Number:
+		return typed.String(), true
+	case bool:
+		return strconv.FormatBool(typed), true
+	default:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return "", false
+		}
+		return string(encoded), true
+	}
+}
+
 // CheckRequest evaluates a JSON-RPC request (single or batch) against policy.
 // Returns a clean verdict for non-tools/call methods and unparseable messages.
 func (pc *Config) CheckRequest(line []byte) Verdict {
@@ -435,12 +693,12 @@ func (pc *Config) checkSingle(line []byte) Verdict {
 		argStrings = extracted.Strings
 	}
 
-	// If any rule uses ArgKey, we need per-rule key-scoped extraction.
-	// Pass raw arguments so CheckToolCallWithArgs can extract per-key.
+	// If any rule uses ArgKey or structural validators, pass raw arguments so
+	// CheckToolCallWithArgs can extract per-key and inspect parsed JSON values.
 	var rawArgs json.RawMessage
 	if hasArgs {
 		for _, rule := range pc.Rules {
-			if rule.ArgKey != nil {
+			if rule.ArgKey != nil || rule.hasStructuralValidators() {
 				rawArgs = tc.Arguments
 				break
 			}

--- a/internal/mcp/policy/policy_test.go
+++ b/internal/mcp/policy/policy_test.go
@@ -3723,6 +3723,26 @@ func TestValidate_StructuralValidators(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid arg_number_gt",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgNumberGT: jsonNumberPtr("not-a-number"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid arg_number_lt",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgNumberLT: jsonNumberPtr("1e10001"),
+			},
+			wantErr: true,
+		},
+		{
 			name: "unsatisfiable numeric range",
 			rule: config.ToolPolicyRule{
 				Name:        structuralRuleName,

--- a/internal/mcp/policy/policy_test.go
+++ b/internal/mcp/policy/policy_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -3366,9 +3367,12 @@ func TestStructuralValidators_RawArgsMissingWithArgPatternFailsClosed(t *testing
 	if !v.Matched {
 		t.Fatal("structural bound rule should fail closed instead of skipping when raw args are unavailable")
 	}
+	if !slices.Equal(v.Rules, []string{structuralRuleName, uninspectableJSONDepthRule}) {
+		t.Fatalf("Rules = %v, want [%q %q]", v.Rules, structuralRuleName, uninspectableJSONDepthRule)
+	}
 
-	if v := pc.CheckToolCall(structuralTool, []string{"safe"}); v.Matched {
-		t.Fatalf("non-matching arg_pattern should not trigger structural fail-closed without raw args, got %+v", v)
+	if v := pc.CheckToolCall(structuralTool, []string{"safe"}); !v.Matched {
+		t.Fatal("key-scoped structural rule should fail closed before using unscoped arg strings")
 	}
 
 	valuePolicy := structuralPolicy(t, config.ToolPolicyRule{
@@ -3378,8 +3382,8 @@ func TestStructuralValidators_RawArgsMissingWithArgPatternFailsClosed(t *testing
 		ArgKey:      "^mode$",
 		ArgValueIn:  []string{"admin"},
 	})
-	if v := valuePolicy.CheckToolCall(structuralTool, []string{"anything"}); v.Matched {
-		t.Fatalf("value-in-only structural rule should not fail closed on absent raw args, got %+v", v)
+	if v := valuePolicy.CheckToolCall(structuralTool, []string{"anything"}); !v.Matched {
+		t.Fatal("value-in structural rule should fail closed on absent raw args")
 	}
 }
 

--- a/internal/mcp/policy/policy_test.go
+++ b/internal/mcp/policy/policy_test.go
@@ -3366,6 +3366,96 @@ func TestStructuralValidators_RawArgsMissingWithArgPatternFailsClosed(t *testing
 	if !v.Matched {
 		t.Fatal("structural bound rule should fail closed instead of skipping when raw args are unavailable")
 	}
+
+	if v := pc.CheckToolCall(structuralTool, []string{"safe"}); v.Matched {
+		t.Fatalf("non-matching arg_pattern should not trigger structural fail-closed without raw args, got %+v", v)
+	}
+
+	valuePolicy := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        "value-only",
+		ToolPattern: structuralToolPattern,
+		ArgPattern:  "anything",
+		ArgKey:      "^mode$",
+		ArgValueIn:  []string{"admin"},
+	})
+	if v := valuePolicy.CheckToolCall(structuralTool, []string{"anything"}); v.Matched {
+		t.Fatalf("value-in-only structural rule should not fail closed on absent raw args, got %+v", v)
+	}
+}
+
+func TestStructuralValidators_DepthPrescanRejectsDeepJSON(t *testing.T) {
+	if truncated, valid := structuralJSONDepthTruncated(json.RawMessage(`{"amount":1}`)); truncated || !valid {
+		t.Fatalf("shallow JSON truncated=%v valid=%v, want false/true", truncated, valid)
+	}
+	if truncated, valid := structuralJSONDepthTruncated(json.RawMessage(`{"amount":`)); truncated || valid {
+		t.Fatalf("malformed JSON truncated=%v valid=%v, want false/false", truncated, valid)
+	}
+	if truncated, valid := structuralJSONDepthTruncated(json.RawMessage(fmt.Sprintf(`{"amount":%s}`, deepPolicyJSONObject("leaf", 100)))); !truncated || !valid {
+		t.Fatalf("deep JSON truncated=%v valid=%v, want true/true", truncated, valid)
+	}
+}
+
+func TestStructuralValuesForArgKeyEdgeCases(t *testing.T) {
+	keyPattern := regexp.MustCompile("^amount$")
+
+	if _, truncated, ok := structuralValuesForArgKey(json.RawMessage(`{} {}`), keyPattern); truncated || ok {
+		t.Fatalf("multiple JSON values truncated=%v ok=%v, want false/false", truncated, ok)
+	}
+	if _, truncated, ok := structuralValuesForArgKey(json.RawMessage(`[]`), keyPattern); truncated || !ok {
+		t.Fatalf("non-object JSON truncated=%v ok=%v, want false/true", truncated, ok)
+	}
+	if _, truncated, ok := structuralValuesForArgKey(json.RawMessage(`{"amount":1}`), nil); truncated || !ok {
+		t.Fatalf("nil key pattern truncated=%v ok=%v, want false/true", truncated, ok)
+	}
+}
+
+func TestStructuralValueBranchCoverage(t *testing.T) {
+	if (&CompiledRule{ArgType: "string"}).matchStructuralValue("safe") {
+		t.Fatal("type-only rule should not match when the value has the required type")
+	}
+	if !(&CompiledRule{ArgType: "integer"}).matchStructuralValue("not-a-number") {
+		t.Fatal("integer type guard should fail closed on non-number values")
+	}
+	if (&CompiledRule{ArgType: "integer"}).matchStructuralValue(json.Number("1")) {
+		t.Fatal("integer type guard should not match integer JSON numbers")
+	}
+	if !(&CompiledRule{ArgType: "integer"}).matchStructuralValue(json.Number("1.5")) {
+		t.Fatal("integer type guard should fail closed on non-integer JSON numbers")
+	}
+	if !(&CompiledRule{ArgType: "boolean"}).matchStructuralValue("true") {
+		t.Fatal("boolean type guard should fail closed on non-boolean values")
+	}
+	if !(&CompiledRule{ArgType: "array"}).matchStructuralValue("not-array") {
+		t.Fatal("array type guard should fail closed on non-array values")
+	}
+	if !(&CompiledRule{ArgType: "object"}).matchStructuralValue("not-object") {
+		t.Fatal("object type guard should fail closed on non-object values")
+	}
+	if !(&CompiledRule{ArgType: "unknown"}).matchStructuralValue("value") {
+		t.Fatal("unknown compiled type should fail closed")
+	}
+
+	if !(&CompiledRule{ArgNumberGT: jsonNumberPtr("not-a-number")}).matchStructuralValue(json.Number("1")) {
+		t.Fatal("invalid compiled gt threshold should fail closed")
+	}
+	if (&CompiledRule{ArgNumberLT: jsonNumberPtr("10")}).matchStructuralValue(json.Number("10")) {
+		t.Fatal("value equal to lt threshold should not match")
+	}
+	if !(&CompiledRule{ArgNumberLT: jsonNumberPtr("not-a-number")}).matchStructuralValue(json.Number("1")) {
+		t.Fatal("invalid compiled lt threshold should fail closed")
+	}
+
+	lenGT := 3
+	lenLT := 3
+	if (&CompiledRule{ArgLenGT: &lenGT}).matchStructuralValue("abc") {
+		t.Fatal("length equal to gt threshold should not match")
+	}
+	if (&CompiledRule{ArgLenLT: &lenLT}).matchStructuralValue("abc") {
+		t.Fatal("length equal to lt threshold should not match")
+	}
+	if (&CompiledRule{ArgValueIn: map[string]struct{}{"admin": {}}}).matchStructuralValue("user") {
+		t.Fatal("value outside arg_value_in should not match")
+	}
 }
 
 func TestStructuralValidators_TypeGuardComposition(t *testing.T) {

--- a/internal/mcp/policy/policy_test.go
+++ b/internal/mcp/policy/policy_test.go
@@ -3141,6 +3141,622 @@ func TestValidate_InvalidArgKey(t *testing.T) {
 	}
 }
 
+// --- Structural argument validators ---
+
+const (
+	structuralTool        = "transfer"
+	structuralToolPattern = "^transfer$"
+	structuralArgKey      = "^amount$"
+	structuralRuleName    = "structural-rule"
+)
+
+func TestStructuralValidators_DangerousValuesMatch(t *testing.T) {
+	lenGT := 3
+	for _, tc := range []struct {
+		name string
+		rule config.ToolPolicyRule
+		args string
+	}{
+		{
+			name: "number over gt",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgNumberGT: jsonNumberPtr("10000"),
+			},
+			args: `{"amount":10001}`,
+		},
+		{
+			name: "length over gt",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^path$",
+				ArgLenGT:    &lenGT,
+			},
+			args: `{"path":"abcd"}`,
+		},
+		{
+			name: "dangerous value in set",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^mode$",
+				ArgValueIn:  []string{"rw", "admin"},
+			},
+			args: `{"mode":"admin"}`,
+		},
+		{
+			name: "wrong required type",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^payload$",
+				ArgType:     "string",
+			},
+			args: `{"payload":{"nested":true}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pc := structuralPolicy(t, tc.rule)
+			v := pc.CheckRequest(structuralRequest(tc.args))
+			if !v.Matched || v.Action != config.ActionBlock {
+				t.Fatalf("verdict = %+v, want block match", v)
+			}
+		})
+	}
+}
+
+func TestStructuralValidators_SafeValuesDoNotMatch(t *testing.T) {
+	pc := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        structuralRuleName,
+		ToolPattern: structuralToolPattern,
+		ArgKey:      structuralArgKey,
+		ArgNumberGT: jsonNumberPtr("10000"),
+	})
+
+	over := pc.CheckRequest(structuralRequest(`{"amount":10001}`))
+	if !over.Matched {
+		t.Fatal("over-threshold value should match")
+	}
+	under := pc.CheckRequest(structuralRequest(`{"amount":10000}`))
+	if under.Matched {
+		t.Fatalf("in-range value should not match, got %+v", under)
+	}
+}
+
+func TestStructuralValidators_WrongTypeNumericComparatorFailsClosed(t *testing.T) {
+	pc := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        structuralRuleName,
+		ToolPattern: structuralToolPattern,
+		ArgKey:      structuralArgKey,
+		ArgNumberGT: jsonNumberPtr("10000"),
+	})
+
+	v := pc.CheckRequest(structuralRequest(`{"amount":"99999"}`))
+	if !v.Matched || v.Action != config.ActionBlock {
+		t.Fatalf("wrong-type numeric value should fail closed, got %+v", v)
+	}
+}
+
+func TestStructuralValidators_AbsentKeyBoundFailsClosedValueInDoesNot(t *testing.T) {
+	boundPolicy := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        "missing-bound",
+		ToolPattern: structuralToolPattern,
+		ArgKey:      structuralArgKey,
+		ArgNumberGT: jsonNumberPtr("10000"),
+	})
+	if v := boundPolicy.CheckRequest(structuralRequest(`{"other":1}`)); !v.Matched {
+		t.Fatalf("absent bound arg_key should fail closed, got %+v", v)
+	}
+
+	valuePolicy := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        "missing-value",
+		ToolPattern: structuralToolPattern,
+		ArgKey:      "^mode$",
+		ArgValueIn:  []string{"admin"},
+	})
+	if v := valuePolicy.CheckRequest(structuralRequest(`{"other":"admin"}`)); v.Matched {
+		t.Fatalf("absent arg_value_in-only arg_key should not match, got %+v", v)
+	}
+}
+
+func TestStructuralValidators_NumericFidelity(t *testing.T) {
+	pc := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        structuralRuleName,
+		ToolPattern: structuralToolPattern,
+		ArgKey:      structuralArgKey,
+		ArgNumberGT: jsonNumberPtr("1000000000"),
+	})
+
+	for _, tc := range []struct {
+		name    string
+		value   string
+		matched bool
+	}{
+		{name: "scientific equal is not greater", value: "1e9", matched: false},
+		{name: "integer below threshold", value: "999999999", matched: false},
+		{name: "integer above threshold", value: "1000000001", matched: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := pc.CheckRequest(structuralRequest(fmt.Sprintf(`{"amount":%s}`, tc.value)))
+			if v.Matched != tc.matched {
+				t.Fatalf("matched = %v, want %v; verdict = %+v", v.Matched, tc.matched, v)
+			}
+		})
+	}
+}
+
+func TestStructuralValidators_AdversarialArgsFailClosedNoPanic(t *testing.T) {
+	pc := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        structuralRuleName,
+		ToolPattern: structuralToolPattern,
+		ArgKey:      structuralArgKey,
+		ArgNumberGT: jsonNumberPtr("10000"),
+	})
+
+	for _, tc := range []struct {
+		name string
+		run  func() Verdict
+	}{
+		{
+			name: "deeply nested",
+			run: func() Verdict {
+				return pc.CheckRequest(structuralRequest(fmt.Sprintf(`{"amount":%s}`, deepPolicyJSONObject("leaf", 100))))
+			},
+		},
+		{
+			name: "huge number",
+			run: func() Verdict {
+				return pc.CheckRequest(structuralRequest(`{"amount":1e1000001}`))
+			},
+		},
+		{
+			name: "non numeric",
+			run: func() Verdict {
+				return pc.CheckRequest(structuralRequest(`{"amount":{}}`))
+			},
+		},
+		{
+			name: "malformed raw json",
+			run: func() Verdict {
+				return pc.CheckToolCallWithArgs(structuralTool, nil, json.RawMessage(`{"amount":`))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panic: %v", r)
+				}
+			}()
+			v := tc.run()
+			if !v.Matched || v.Action != config.ActionBlock {
+				t.Fatalf("adversarial input should fail closed, got %+v", v)
+			}
+		})
+	}
+}
+
+func TestStructuralValidators_ReachabilityWithoutArgPattern(t *testing.T) {
+	pc := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        "reachable-structural",
+		ToolPattern: structuralToolPattern,
+		ArgKey:      structuralArgKey,
+		ArgNumberGT: jsonNumberPtr("10000"),
+	})
+
+	v := pc.CheckRequest(structuralRequest(`{"amount":10001}`))
+	if !v.Matched {
+		t.Fatal("structural-validator rule without arg_pattern should receive raw args and match")
+	}
+}
+
+func TestStructuralValidators_RawArgsMissingWithArgPatternFailsClosed(t *testing.T) {
+	pc := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        structuralRuleName,
+		ToolPattern: structuralToolPattern,
+		ArgPattern:  "anything",
+		ArgKey:      structuralArgKey,
+		ArgNumberGT: jsonNumberPtr("10000"),
+	})
+
+	v := pc.CheckToolCall(structuralTool, []string{"anything"})
+	if !v.Matched {
+		t.Fatal("structural bound rule should fail closed instead of skipping when raw args are unavailable")
+	}
+}
+
+func TestStructuralValidators_TypeGuardComposition(t *testing.T) {
+	pc := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        structuralRuleName,
+		ToolPattern: structuralToolPattern,
+		ArgKey:      structuralArgKey,
+		ArgType:     "number",
+		ArgNumberGT: jsonNumberPtr("10000"),
+	})
+
+	if v := pc.CheckRequest(structuralRequest(`{"amount":10001}`)); !v.Matched {
+		t.Fatalf("matching type with dangerous range should match, got %+v", v)
+	}
+	if v := pc.CheckRequest(structuralRequest(`{"amount":9999}`)); v.Matched {
+		t.Fatalf("matching type with safe range should not match, got %+v", v)
+	}
+	if v := pc.CheckRequest(structuralRequest(`{"amount":"10001"}`)); !v.Matched {
+		t.Fatalf("type mismatch should fail closed, got %+v", v)
+	}
+}
+
+func TestStructuralValidators_BatchRequestOverRangeMatches(t *testing.T) {
+	pc := structuralPolicy(t, config.ToolPolicyRule{
+		Name:        "batch-over-range",
+		ToolPattern: structuralToolPattern,
+		ArgKey:      structuralArgKey,
+		ArgNumberGT: jsonNumberPtr("10000"),
+	})
+
+	batch := fmt.Sprintf(`[
+		{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"safe","arguments":{"amount":10001}}},
+		{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":%q,"arguments":{"amount":10001}}}
+	]`, structuralTool)
+	v := pc.CheckRequest([]byte(batch))
+	if !v.Matched || v.Action != config.ActionBlock {
+		t.Fatalf("batch structural validator should match over-range tools/call, got %+v", v)
+	}
+}
+
+func TestStructuralValidators_FailClosedMatrix(t *testing.T) {
+	lenGT := 3
+	lenLT := 3
+	tests := []struct {
+		name    string
+		rule    config.ToolPolicyRule
+		args    string
+		matched bool
+	}{
+		{
+			name: "type and bound safe number",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgType:     "number",
+				ArgNumberGT: jsonNumberPtr("10.5"),
+			},
+			args:    `{"amount":10}`,
+			matched: false,
+		},
+		{
+			name: "fractional threshold less than integer",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgNumberGT: jsonNumberPtr("10.5"),
+			},
+			args:    `{"amount":11}`,
+			matched: true,
+		},
+		{
+			name: "negative number below lt",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgNumberLT: jsonNumberPtr("-1"),
+			},
+			args:    `{"amount":-2}`,
+			matched: true,
+		},
+		{
+			name: "type and value in require both dangerous",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^mode$",
+				ArgType:     "string",
+				ArgValueIn:  []string{"admin"},
+			},
+			args:    `{"mode":"user"}`,
+			matched: false,
+		},
+		{
+			name: "type mismatch with value in fails closed",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^mode$",
+				ArgType:     "string",
+				ArgValueIn:  []string{"admin"},
+			},
+			args:    `{"mode":false}`,
+			matched: true,
+		},
+		{
+			name: "bound and value in require both dangerous",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgNumberGT: jsonNumberPtr("10"),
+				ArgValueIn:  []string{"11"},
+			},
+			args:    `{"amount":12}`,
+			matched: false,
+		},
+		{
+			name: "bound and value in both dangerous",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgNumberGT: jsonNumberPtr("10"),
+				ArgValueIn:  []string{"11"},
+			},
+			args:    `{"amount":11}`,
+			matched: true,
+		},
+		{
+			name: "matching key regex ORs over values",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^amount",
+				ArgNumberGT: jsonNumberPtr("10"),
+			},
+			args:    `{"amount_safe":1,"amount_danger":11}`,
+			matched: true,
+		},
+		{
+			name: "present null type guard fails closed",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^payload$",
+				ArgType:     "object",
+			},
+			args:    `{"payload":null}`,
+			matched: true,
+		},
+		{
+			name: "value in null matches present null",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^payload$",
+				ArgValueIn:  []string{"null"},
+			},
+			args:    `{"payload":null}`,
+			matched: true,
+		},
+		{
+			name: "empty string below len lt",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^payload$",
+				ArgLenLT:    &lenLT,
+			},
+			args:    `{"payload":""}`,
+			matched: true,
+		},
+		{
+			name: "empty array below len lt",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^payload$",
+				ArgLenLT:    &lenLT,
+			},
+			args:    `{"payload":[]}`,
+			matched: true,
+		},
+		{
+			name: "array over len gt",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^payload$",
+				ArgLenGT:    &lenGT,
+			},
+			args:    `{"payload":[1,2,3,4]}`,
+			matched: true,
+		},
+		{
+			name: "boolean where number expected fails closed",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgNumberGT: jsonNumberPtr("10"),
+			},
+			args:    `{"amount":true}`,
+			matched: true,
+		},
+		{
+			name: "object where length expected fails closed",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^payload$",
+				ArgLenGT:    &lenGT,
+			},
+			args:    `{"payload":{}}`,
+			matched: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pc := structuralPolicy(t, tc.rule)
+			v := pc.CheckRequest(structuralRequest(tc.args))
+			if v.Matched != tc.matched {
+				t.Fatalf("matched = %v, want %v; verdict = %+v", v.Matched, tc.matched, v)
+			}
+		})
+	}
+}
+
+func TestValidate_StructuralValidators(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		rule    config.ToolPolicyRule
+		wantErr bool
+	}{
+		{
+			name: "arg_key structural without arg_pattern is valid",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgNumberGT: jsonNumberPtr("10000"),
+			},
+		},
+		{
+			name: "structural without arg_key is invalid",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgNumberGT: jsonNumberPtr("10000"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid arg_type",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgType:     "float",
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsatisfiable numeric range",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgNumberGT: jsonNumberPtr("10"),
+				ArgNumberLT: jsonNumberPtr("10"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsatisfiable length range",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^path$",
+				ArgLenGT:    intPtr(5),
+				ArgLenLT:    intPtr(5),
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative arg_len_gt",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^path$",
+				ArgLenGT:    intPtr(-1),
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative arg_len_lt",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^path$",
+				ArgLenLT:    intPtr(-1),
+			},
+			wantErr: true,
+		},
+		{
+			name: "numeric bound with string type",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgType:     "string",
+				ArgNumberGT: jsonNumberPtr("10"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "numeric bound with integer type is valid",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      structuralArgKey,
+				ArgType:     "integer",
+				ArgNumberGT: jsonNumberPtr("10"),
+			},
+		},
+		{
+			name: "length bound with number type",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^path$",
+				ArgType:     "number",
+				ArgLenGT:    intPtr(3),
+			},
+			wantErr: true,
+		},
+		{
+			name: "length bound with array type is valid",
+			rule: config.ToolPolicyRule{
+				Name:        structuralRuleName,
+				ToolPattern: structuralToolPattern,
+				ArgKey:      "^items$",
+				ArgType:     "array",
+				ArgLenGT:    intPtr(3),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.MCPToolPolicy.Enabled = true
+			cfg.MCPToolPolicy.Action = config.ActionBlock
+			cfg.MCPToolPolicy.Rules = []config.ToolPolicyRule{tc.rule}
+			err := cfg.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Validate() err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func structuralPolicy(t *testing.T, rule config.ToolPolicyRule) *Config {
+	t.Helper()
+	cfg := config.MCPToolPolicy{
+		Enabled: true,
+		Action:  config.ActionBlock,
+		Rules:   []config.ToolPolicyRule{rule},
+	}
+	pc := New(cfg)
+	if pc == nil {
+		t.Fatal("New returned nil")
+	}
+	return pc
+}
+
+func structuralRequest(args string) []byte {
+	return []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":%q,"arguments":%s}}`, structuralTool, args))
+}
+
+func jsonNumberPtr(value string) *json.Number {
+	n := json.Number(value)
+	return &n
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
 // --- Gauntlet regression tests ---
 
 func TestCheckToolCall_GauntletBraceExpansionTrailingEmpty(t *testing.T) {


### PR DESCRIPTION
## What changed

MCP tool-policy rules gain optional structural argument validators, evaluated on the parsed JSON value at a named `arg_key`:

- `arg_type`: required JSON type (`string`/`number`/`integer`/`boolean`/`array`/`object`)
- `arg_number_gt` / `arg_number_lt`: numeric bounds
- `arg_len_gt` / `arg_len_lt`: string rune-count or array element-count bounds
- `arg_value_in`: membership in a set of dangerous values

Previously rules could only regex-match string views of arguments. These let a rule express conditions like "amount over 10000", "path longer than N", "mode in a dangerous set", or a required type.

## Semantics

Consistent with the existing default-allow denylist: a validator describes the dangerous condition, and a matched rule applies its action. Within one rule, `tool_pattern`, optional `arg_pattern`, and every configured validator AND-compose. Structural validators require `arg_key`.

- Unevaluable values (wrong type, malformed, or absent) on a bound/type/length validator fail closed. An `arg_value_in`-only rule does not match an absent key.
- Numeric comparison is exact (`json.Number` / `big.Rat`), so `1e9` and `1000000000` compare equal. Number parsing bounds the exponent before any big-number construction, so a small input cannot force a large allocation.

Backward compatible: unset validators are no-ops; existing regex and tool-name rules are unchanged. Config validation rejects unsatisfiable ranges, negative lengths, invalid types, and explicit type/bound mismatches.

Docs updated in `docs/configuration.md` and `docs/policy-spec-v0.1.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structural MCP tool-policy argument validators: argument type guards, bounded numeric comparisons, length bounds, and allowed-value matching (with per-key scoping).
* **Bug Fixes**
  * Strengthened fail-closed behavior for key-scoped structural checks when tool arguments can’t be safely inspected, preventing fallback to unscoped matching.
* **Documentation**
  * Expanded tool-policy rule field semantics and examples (including a new “Block large transfers” rule).
* **Tests**
  * Added regression coverage for bounded numeric parsing and extensive structural-validator matching/validation; updated canonical policy fixture expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->