### PR TITLE
fix(playground): orphan-VM reaper blinded by Fly summary mode

### DIFF
--- a/internal/playground/broker/flymachines.go
+++ b/internal/playground/broker/flymachines.go
@@ -36,6 +36,12 @@ const defaultWaitTimeout = 60 * time.Second
 // misbehaving/huge response cannot exhaust broker memory.
 const flyMaxBodyBytes = 1 << 20 // 1 MiB
 
+// flyListPageSize caps the per-page machine count in ListManagedMachines. It is
+// kept well under the Fly API maximum so a full (non-summary) machine page stays
+// under flyMaxBodyBytes even during a large orphan event; the cursor loop handles
+// the extra pages. See ListManagedMachines for why summary mode is not used.
+const flyListPageSize = 50
+
 // flyRequestIDHeader is the Fly API response header that carries a per-request
 // trace identifier. Including it in error messages lets operators debug failures
 // with Fly support without exposing potentially secret response-body content.
@@ -253,7 +259,7 @@ func (f *FlyMachines) ListManagedMachines(ctx context.Context) ([]Machine, error
 	// orphan event, fail to parse, and stall cleanup exactly when it matters most.
 	// More pages of a bounded size is the safer trade; the cursor loop below
 	// handles pagination.
-	query := url.Values{"limit": []string{"50"}}
+	query := url.Values{"limit": []string{strconv.Itoa(flyListPageSize)}}
 	var raw []flyListMachine
 	for {
 		respBody, err := f.do(ctx, http.MethodGet, path, query, nil)

--- a/internal/playground/broker/flymachines.go
+++ b/internal/playground/broker/flymachines.go
@@ -238,7 +238,22 @@ func (f *FlyMachines) ListManagedMachines(ctx context.Context) ([]Machine, error
 		return nil, err
 	}
 	path := fmt.Sprintf("/apps/%s/machines", url.PathEscape(f.AppName))
-	query := url.Values{"summary": []string{"true"}, "limit": []string{"200"}}
+	// Do NOT set summary=true: Fly's summary list response strips config.metadata
+	// to null, and this reaper filters managed machines on the
+	// pipelock_role=playground-vm metadata tag. With summary=true the filter drops
+	// EVERY machine, ListManagedMachines returns empty, and the reaper silently
+	// reaps nothing while per-visitor VMs accumulate forever (observed live:
+	// 14 orphaned VMs after a week). The full list response carries both
+	// config.metadata and created_at, which the reaper's tag filter and grace
+	// check require.
+	//
+	// Page size is kept modest (not the API max): full machine objects are
+	// larger than summary rows, and the response body is capped at flyMaxBodyBytes
+	// (1 MiB) in do(). A too-large page could exceed that cap during a large
+	// orphan event, fail to parse, and stall cleanup exactly when it matters most.
+	// More pages of a bounded size is the safer trade; the cursor loop below
+	// handles pagination.
+	query := url.Values{"limit": []string{"50"}}
 	var raw []flyListMachine
 	for {
 		respBody, err := f.do(ctx, http.MethodGet, path, query, nil)

--- a/internal/playground/broker/flymachines_test.go
+++ b/internal/playground/broker/flymachines_test.go
@@ -376,11 +376,15 @@ func TestFlyListManagedMachinesPagedObjectResponse(t *testing.T) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		if got := r.URL.Query().Get("summary"); got != "true" {
-			t.Fatalf("summary query = %q, want true", got)
+		// REGRESSION GUARD: ListManagedMachines MUST NOT request summary=true.
+		// Fly's summary list response strips config.metadata to null, which makes
+		// the pipelock_role tag filter drop every machine and the reaper reap
+		// nothing (orphaned VMs pile up). See ListManagedMachines comment.
+		if got := r.URL.Query().Get("summary"); got != "" {
+			t.Fatalf("summary query = %q, want unset (summary strips metadata)", got)
 		}
-		if got := r.URL.Query().Get("limit"); got != "200" {
-			t.Fatalf("limit query = %q, want 200", got)
+		if got := r.URL.Query().Get("limit"); got != "50" {
+			t.Fatalf("limit query = %q, want 50", got)
 		}
 		cursor := r.URL.Query().Get("cursor")
 		cursors = append(cursors, cursor)
@@ -419,6 +423,35 @@ func TestFlyListManagedMachinesPagedObjectResponse(t *testing.T) {
 	}
 	if machines[0].ID != "m-page-1" || machines[1].ID != "m-page-2" {
 		t.Fatalf("machine IDs = %q, %q; want m-page-1, m-page-2", machines[0].ID, machines[1].ID)
+	}
+}
+
+// TestFlyListManagedMachinesFlySummaryStripsMetadata reproduces the live Fly
+// behavior that broke the orphan reaper: the summary list response returns
+// config.metadata as null. This mock mimics that — it strips metadata whenever
+// summary=true is requested. If ListManagedMachines ever requests summary mode
+// again, the tag filter drops every machine and this test fails with 0 machines,
+// which is exactly the production symptom (per-visitor VMs never reaped).
+func TestFlyListManagedMachinesFlySummaryStripsMetadata(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("summary") == "true" {
+			// Fly summary mode: metadata stripped to null.
+			_, _ = w.Write([]byte(`[{"id": "m-tagged", "state": "started", "created_at": "2026-06-25T10:00:00Z", "config": {"metadata": null}}]`))
+			return
+		}
+		// Full mode: metadata present.
+		_, _ = w.Write([]byte(`[{"id": "m-tagged", "state": "started", "created_at": "2026-06-25T10:00:00Z", "config": {"metadata": {"pipelock_role": "playground-vm"}}}]`))
+	}))
+	defer srv.Close()
+
+	fly := newTestFly(srv)
+	machines, err := fly.ListManagedMachines(context.Background())
+	if err != nil {
+		t.Fatalf("ListManagedMachines: %v", err)
+	}
+	if len(machines) != 1 || machines[0].ID != "m-tagged" {
+		t.Fatalf("got %d machines (%v), want 1 (m-tagged); a 0 result means summary=true stripped metadata", len(machines), machines)
 	}
 }
 

--- a/internal/playground/broker/flymachines_test.go
+++ b/internal/playground/broker/flymachines_test.go
@@ -383,8 +383,8 @@ func TestFlyListManagedMachinesPagedObjectResponse(t *testing.T) {
 		if got := r.URL.Query().Get("summary"); got != "" {
 			t.Fatalf("summary query = %q, want unset (summary strips metadata)", got)
 		}
-		if got := r.URL.Query().Get("limit"); got != "50" {
-			t.Fatalf("limit query = %q, want 50", got)
+		if want := strconv.Itoa(flyListPageSize); r.URL.Query().Get("limit") != want {
+			t.Fatalf("limit query = %q, want %q", r.URL.Query().Get("limit"), want)
 		}
 		cursor := r.URL.Query().Get("cursor")
 		cursors = append(cursors, cursor)

--- a/internal/playground/broker/pool.go
+++ b/internal/playground/broker/pool.go
@@ -187,6 +187,32 @@ func (p *Pool) FinishHandoff(machineID string) {
 	delete(p.handoff, machineID)
 }
 
+// AbortHandoff tears down a warm VM that was Acquire'd but could not be adopted
+// into an active lease (e.g. AdoptWarm failed). It destroys the VM through the
+// quarantine-on-failure path — NOT a fire-and-forget DestroyMachine — so that a
+// FAILED destroy keeps the VM tracked (in quarantine, still protected from the
+// reaper) and its concurrency slot HELD until a retry succeeds. A fire-and-forget
+// destroy that silently fails would release the slot while the VM is still alive
+// on the provider, letting warm+active drift above the operator cap (INVARIANT 1)
+// and spending on an untracked machine. FinishHandoff is called last so the
+// machine is never simultaneously absent from the handoff, quarantine, AND active
+// sets (no reaper TOCTOU). Idempotent-safe for a nil machine/release.
+func (p *Pool) AbortHandoff(ctx context.Context, machine *Machine, release func(), reason string) {
+	if machine == nil {
+		return
+	}
+	if release == nil {
+		release = func() {}
+	}
+	failed := p.destroyWarmEntries(ctx, []warmEntry{{
+		machine: machine,
+		release: release,
+		created: p.now(),
+	}}, reason)
+	p.quarantineFailed(failed)
+	p.FinishHandoff(machine.ID)
+}
+
 // WarmMachineIDs returns a snapshot of machine IDs the reaper must protect:
 // every VM currently in the warm pool PLUS every VM in an in-flight handoff
 // (popped by Acquire, not yet an active lease). Combined with
@@ -400,9 +426,12 @@ func (p *Pool) fill(ctx context.Context) {
 			return
 		}
 		if werr := p.provider.WaitReady(ctx, m.ID); werr != nil {
-			_ = p.provider.DestroyMachine(context.WithoutCancel(ctx), m.ID)
-			release()
 			_, _ = fmt.Fprintf(p.log, "pool: warm vm %s not ready: %v\n", m.ID, werr)
+			// Quarantine-on-failure rather than fire-and-forget: if DestroyMachine
+			// also fails, keep the VM tracked and its slot held until retry, so a
+			// still-alive VM cannot be forgotten while its slot is freed.
+			failed := p.destroyWarmEntries(ctx, []warmEntry{{machine: m, vmCode: vmCode, release: release, created: p.now()}}, "warm vm not ready")
+			p.quarantineFailed(failed)
 			return
 		}
 
@@ -414,8 +443,10 @@ func (p *Pool) fill(ctx context.Context) {
 		// stop. Destroy it and free the slot.
 		if p.closed || p.paused {
 			p.mu.Unlock()
-			_ = p.provider.DestroyMachine(context.WithoutCancel(ctx), m.ID)
-			release()
+			// Quarantine-on-failure: a destroy that fails here must not release the
+			// slot and forget a still-running VM (same invariant as the not-ready path).
+			failed := p.destroyWarmEntries(ctx, []warmEntry{{machine: m, vmCode: vmCode, release: release, created: p.now()}}, "discard stopped warm vm")
+			p.quarantineFailed(failed)
 			return
 		}
 		p.entries = append(p.entries, warmEntry{

--- a/internal/playground/broker/pool_test.go
+++ b/internal/playground/broker/pool_test.go
@@ -531,6 +531,80 @@ func TestPoolRecycleStaleDestroyFailureKeepsEntryAndSlot(t *testing.T) {
 	}
 }
 
+func TestPoolFillWaitReadyDestroyFailureQuarantinesVM(t *testing.T) {
+	// fill() creates a VM, WaitReady fails, and the follow-up destroy ALSO fails.
+	// The VM must be quarantined (still tracked + slot held), NOT forgotten with
+	// its slot released — otherwise a still-alive VM leaks and the freed slot lets
+	// warm+active drift above the cap (the cost-amplifier bug).
+	fp := &destroyErrProvider{
+		fakeProvider: &fakeProvider{waitErr: errors.New("not ready")},
+		destroyErr:   errors.New("destroy failed"),
+	}
+	limiter := livechat.NewConcurrencyLimiter(1)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+
+	pool.maintain(context.Background())
+
+	warmIDs := pool.WarmMachineIDs()
+	if len(warmIDs) != 1 {
+		t.Fatalf("WarmMachineIDs after not-ready+failed-destroy = %d, want 1 (quarantined)", len(warmIDs))
+	}
+	if _, _, _, ok := pool.Acquire(); ok {
+		t.Fatal("quarantined not-ready VM was handed out; must not be acquirable")
+	}
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse = %d, want 1 (slot held for the still-alive VM whose destroy failed)", limiter.InUse())
+	}
+	if created, _ := fp.counts(); created != 1 {
+		t.Fatalf("created = %d, want 1 (a freed slot would spawn a replacement = the leak/cost bug)", created)
+	}
+
+	// Recover: destroy + WaitReady now succeed; quarantine retry cleans up and refills.
+	fp.destroyErr = nil
+	fp.waitErr = nil
+	pool.maintain(context.Background())
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse after recovery = %d, want 1", limiter.InUse())
+	}
+}
+
+func TestPoolAbortHandoffDestroyFailureQuarantines(t *testing.T) {
+	// AbortHandoff on a warm VM whose destroy fails must keep it tracked (in
+	// quarantine, still reaper-protected) with its slot held, and clear the
+	// handoff marker — never release the slot and forget a still-alive VM.
+	fp := &destroyErrProvider{fakeProvider: &fakeProvider{}, destroyErr: errors.New("destroy failed")}
+	limiter := livechat.NewConcurrencyLimiter(1)
+	pool := newTestPool(t, fp, limiter, 1, 0, nil)
+	pool.maintain(context.Background())
+
+	m, _, release, ok := pool.Acquire()
+	if !ok {
+		t.Fatal("Acquire should return the warm VM")
+	}
+	if _, in := pool.WarmMachineIDs()[m.ID]; !in {
+		t.Fatal("acquired VM should be in the handoff-protected set")
+	}
+
+	pool.AbortHandoff(context.Background(), m, release, "adopt failed")
+
+	if _, in := pool.WarmMachineIDs()[m.ID]; !in {
+		t.Fatalf("AbortHandoff with failing destroy must keep the VM tracked (quarantine)")
+	}
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse = %d, want 1 (slot held until destroy succeeds)", limiter.InUse())
+	}
+	pool.mu.Lock()
+	_, stillHandoff := pool.handoff[m.ID]
+	_, inQuarantine := pool.quarantine[m.ID]
+	pool.mu.Unlock()
+	if stillHandoff {
+		t.Error("AbortHandoff should clear the handoff marker")
+	}
+	if !inQuarantine {
+		t.Error("AbortHandoff with failing destroy should quarantine the VM")
+	}
+}
+
 func TestPoolPauseDestroyFailureQuarantinesVM(t *testing.T) {
 	fp := &destroyErrProvider{fakeProvider: &fakeProvider{}, destroyErr: errors.New("destroy failed")}
 	limiter := livechat.NewConcurrencyLimiter(1)

--- a/internal/playground/broker/reaper.go
+++ b/internal/playground/broker/reaper.go
@@ -108,22 +108,40 @@ func (r *Reaper) ReconcileOnce(ctx context.Context) (int, error) {
 	active := r.activeIDs()
 	now := r.now()
 	destroyed := 0
+	skippedActive := 0
+	skippedYoung := 0
+	skippedUnknownAge := 0
+	destroyErrors := 0
 	for _, m := range machines {
 		if _, ok := active[m.ID]; ok {
+			skippedActive++
 			continue // actively leased
 		}
 		// SAFETY INVARIANT: a machine younger than grace is ALWAYS spared.
 		// A zero/unknown CreatedAt is treated as NOT-yet-past-grace.
-		if m.CreatedAt.IsZero() || now.Sub(m.CreatedAt) < r.grace {
+		if m.CreatedAt.IsZero() {
+			skippedUnknownAge++
+			continue
+		}
+		if now.Sub(m.CreatedAt) < r.grace {
+			skippedYoung++
 			continue
 		}
 		if dErr := r.provider.DestroyMachine(ctx, m.ID); dErr != nil {
+			destroyErrors++
 			_, _ = fmt.Fprintf(r.log, "reaper: destroy %s: %v\n", m.ID, dErr)
 			continue
 		}
 		_, _ = fmt.Fprintf(r.log, "reaper: destroyed orphan %s (age %s)\n", m.ID, now.Sub(m.CreatedAt).Truncate(time.Second))
 		destroyed++
 	}
+	// Per-reconcile heartbeat: ALWAYS log the tallies, even when nothing is
+	// destroyed. This is deliberate observability — the production orphan leak
+	// stayed invisible for a week precisely because a reconcile that found
+	// nothing logged nothing. "managed=0" recurring is now a visible signal that
+	// the provider list/filter has been blinded (e.g. an API-shape regression).
+	_, _ = fmt.Fprintf(r.log, "reaper: reconcile managed=%d active=%d destroyed=%d skipped_active=%d skipped_young=%d skipped_unknown_age=%d destroy_errors=%d\n",
+		len(machines), len(active), destroyed, skippedActive, skippedYoung, skippedUnknownAge, destroyErrors)
 	return destroyed, nil
 }
 

--- a/internal/playground/broker/reaper_test.go
+++ b/internal/playground/broker/reaper_test.go
@@ -110,6 +110,53 @@ func TestReaperReconcileOnce(t *testing.T) {
 	}
 }
 
+func TestReaperReconcileHeartbeatLog(t *testing.T) {
+	baseTime := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+
+	// A reconcile that finds nothing MUST still log a heartbeat. This is the
+	// observability that was missing when the production reaper was blinded by
+	// Fly summary mode and silently reaped nothing for a week.
+	t.Run("zero machines logs managed=0", func(t *testing.T) {
+		fp := &fakeProvider{}
+		var logBuf bytes.Buffer
+		reaper, err := NewReaper(ReaperConfig{
+			Provider:  fp,
+			ActiveIDs: func() map[string]struct{} { return nil },
+			Now:       func() time.Time { return baseTime },
+			Log:       &logBuf,
+		})
+		if err != nil {
+			t.Fatalf("NewReaper: %v", err)
+		}
+		if _, err := reaper.ReconcileOnce(context.Background()); err != nil {
+			t.Fatalf("ReconcileOnce: %v", err)
+		}
+		if !strings.Contains(logBuf.String(), "reaper: reconcile managed=0") {
+			t.Errorf("want managed=0 heartbeat, got: %q", logBuf.String())
+		}
+	})
+
+	t.Run("zero-CreatedAt tagged machine logs skipped_unknown_age", func(t *testing.T) {
+		fp := &fakeProvider{managedMachines: []Machine{{ID: "unknown", State: "started"}}}
+		var logBuf bytes.Buffer
+		reaper, err := NewReaper(ReaperConfig{
+			Provider:  fp,
+			ActiveIDs: func() map[string]struct{} { return nil },
+			Now:       func() time.Time { return baseTime },
+			Log:       &logBuf,
+		})
+		if err != nil {
+			t.Fatalf("NewReaper: %v", err)
+		}
+		if _, err := reaper.ReconcileOnce(context.Background()); err != nil {
+			t.Fatalf("ReconcileOnce: %v", err)
+		}
+		if !strings.Contains(logBuf.String(), "skipped_unknown_age=1") {
+			t.Errorf("want skipped_unknown_age=1 in heartbeat, got: %q", logBuf.String())
+		}
+	})
+}
+
 func TestReaperReconcileOnceListError(t *testing.T) {
 	fp := &fakeProvider{listErr: errors.New("provider down")}
 	reaper, err := NewReaper(ReaperConfig{

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -569,17 +569,19 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 			vmCode = wc
 			adopted, adoptErr := s.cfg.Leases.AdoptWarm(sessionKey, wm, wRelease)
 			if adoptErr != nil {
-				// Adoption failed (e.g. duplicate key race). Destroy the warm VM
-				// and release the slot so neither leaks.
-				_ = s.cfg.Leases.cfg.Provider.DestroyMachine(context.WithoutCancel(r.Context()), wm.ID)
-				wRelease()
+				// Adoption failed (e.g. duplicate key race). Tear down the warm VM
+				// through the quarantine-on-failure path so a FAILED destroy keeps
+				// the slot held and the VM tracked (still reaper-protected) rather
+				// than releasing the slot and forgetting a still-alive VM.
+				// AbortHandoff clears the in-flight handoff marker itself.
+				s.cfg.WarmPool.AbortHandoff(r.Context(), wm, wRelease, "adopt failed")
 			} else {
 				lease = adopted
+				// Machine is now an active lease (protected by ActiveMachineIDs);
+				// clear the in-flight handoff marker. Closes the reaper TOCTOU
+				// window opened by Acquire.
+				s.cfg.WarmPool.FinishHandoff(wm.ID)
 			}
-			// Clear the in-flight handoff marker now that the machine is either an
-			// active lease (protected by ActiveMachineIDs) or destroyed. Closes the
-			// reaper TOCTOU window opened by Acquire.
-			s.cfg.WarmPool.FinishHandoff(wm.ID)
 		}
 	}
 	if lease == nil {


### PR DESCRIPTION
## What changed

The playground broker's orphan-VM reaper listed Fly machines with `summary=true`, whose response strips `config.metadata` to null. The reaper filters managed VMs on the `pipelock_role` tag, so it matched zero machines and reaped nothing. Per-visitor microVMs accumulated indefinitely.

- **flymachines:** drop `summary=true`. The full response carries `config.metadata` and `created_at`, which the tag filter and grace check require. Page size is capped at 50 so a full-mode page cannot exceed the 1 MiB response body cap and stall cleanup.
- **reaper:** always emit a per-reconcile heartbeat (`managed`/`active`/`destroyed`/`skipped_*`), so a blinded reaper is observable instead of silently reaping nothing (the failure mode that hid this bug).
- **pool:** route warm-VM discard (not-ready, closed/paused) and warm adoption failure through the quarantine path (new `AbortHandoff`), so a failed destroy keeps the concurrency slot held and the VM tracked and retried instead of freeing the slot and forgetting a still-alive VM (which lets warm+active exceed the cap).

## Tests

- Regression: `ListManagedMachines` must not request summary mode. The mock strips metadata under summary, mirroring Fly's real response.
- Reaper heartbeat tallies (`managed=0`, `skipped_unknown_age`).
- Quarantine-on-destroy-failure for both `fill()` and `AbortHandoff`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warm machine handling so failed handoffs are quarantined and safely retried instead of being dropped.
  * Reduced the chance of losing track of machines during pool cleanup and recovery.
  * Reaper status reporting is now always emitted per cycle, including clearer counts when machine age is unknown.
  * Updated managed machine listing to avoid incomplete “summary” data and to use consistent paging for more reliable filtering.
* **Tests**
  * Added regression coverage for warm handoff failure quarantine and reaper heartbeat logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->