### PR TITLE
fix(proxy): fail closed on undecodable multipart transfer encoding

### DIFF
--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -844,8 +844,8 @@ func extractMultipart(body []byte, boundary string, maxBytes int) ([]string, str
 		// Decode Content-Transfer-Encoding before scanning. Go's
 		// multipart.Reader does NOT decode CTE, so base64/QP content
 		// reaches the scanner as raw encoded text. Decode it so DLP
-		// patterns match the actual secret. If decoding fails, scan raw
-		// (fail-closed: don't skip, raw scan still catches plaintext).
+		// patterns match the actual secret. If decoding fails, block:
+		// raw encoded bytes are not a complete inspection of the content.
 		cte := strings.ToLower(part.Header.Get("Content-Transfer-Encoding"))
 		rawBody := string(partBody)
 		switch cte {
@@ -859,24 +859,26 @@ func extractMultipart(body []byte, boundary string, maxBytes int) ([]string, str
 				return r
 			}, rawBody)
 			decoded, err := base64.StdEncoding.DecodeString(cleaned)
-			if err == nil {
-				// Scan BOTH decoded (catches actual secrets) and raw
-				// (catches patterns visible in encoded form).
-				result = append(result, string(decoded))
+			if err != nil {
+				return nil, fmt.Sprintf("error decoding multipart part content-transfer-encoding %q: %v", cte, err)
 			}
-			// Always scan raw form too - fail-closed on decode failure,
-			// and catches patterns visible in encoded form.
+			// Scan BOTH decoded (catches actual secrets) and raw
+			// (catches patterns visible in encoded form).
+			result = append(result, string(decoded))
 			result = append(result, rawBody)
 		case "quoted-printable":
 			decoded, err := io.ReadAll(quotedprintable.NewReader(bytes.NewReader(partBody)))
-			if err == nil {
-				result = append(result, string(decoded))
+			if err != nil {
+				return nil, fmt.Sprintf("error decoding multipart part content-transfer-encoding %q: %v", cte, err)
 			}
+			result = append(result, string(decoded))
 			result = append(result, rawBody)
-		default:
+		case "", "7bit", "8bit", "binary":
 			if len(partBody) > 0 {
 				result = append(result, rawBody)
 			}
+		default:
+			return nil, fmt.Sprintf("unsupported multipart part content-transfer-encoding %q", cte)
 		}
 
 		// Include field name and filename in extracted text (can carry exfil data).

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -771,7 +771,7 @@ func extractFormURLEncoded(body []byte) ([]string, string) {
 // Returns extracted strings and an error message if any limit is exceeded.
 // On limit violation: fail-closed (returns error, caller blocks).
 func extractMultipart(body []byte, boundary string, maxBytes int) ([]string, string) {
-	reader := multipart.NewReader(strings.NewReader(string(body)), boundary)
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
 
 	var result []string
 	partCount := 0
@@ -781,7 +781,7 @@ func extractMultipart(body []byte, boundary string, maxBytes int) ([]string, str
 			return nil, fmt.Sprintf("multipart body exceeds %d parts limit", maxMultipartParts)
 		}
 
-		part, err := reader.NextPart()
+		part, err := reader.NextRawPart()
 		if err == io.EOF {
 			break
 		}
@@ -841,11 +841,9 @@ func extractMultipart(body []byte, boundary string, maxBytes int) ([]string, str
 			return nil, fmt.Sprintf("multipart part exceeds max_body_bytes (%d)", maxBytes)
 		}
 
-		// Decode Content-Transfer-Encoding before scanning. Go's
-		// multipart.Reader does NOT decode CTE, so base64/QP content
-		// reaches the scanner as raw encoded text. Decode it so DLP
-		// patterns match the actual secret. If decoding fails, block:
-		// raw encoded bytes are not a complete inspection of the content.
+		// Decode Content-Transfer-Encoding before scanning. NextRawPart
+		// keeps CTE visible instead of transparently decoding quoted-printable,
+		// so Pipelock can fail closed when encoded content is uninspectable.
 		cte := strings.ToLower(part.Header.Get("Content-Transfer-Encoding"))
 		rawBody := string(partBody)
 		switch cte {
@@ -867,6 +865,9 @@ func extractMultipart(body []byte, boundary string, maxBytes int) ([]string, str
 			result = append(result, string(decoded))
 			result = append(result, rawBody)
 		case "quoted-printable":
+			if err := validateQuotedPrintable(partBody); err != nil {
+				return nil, fmt.Sprintf("error decoding multipart part content-transfer-encoding %q: %v", cte, err)
+			}
 			decoded, err := io.ReadAll(quotedprintable.NewReader(bytes.NewReader(partBody)))
 			if err != nil {
 				return nil, fmt.Sprintf("error decoding multipart part content-transfer-encoding %q: %v", cte, err)
@@ -891,6 +892,37 @@ func extractMultipart(body []byte, boundary string, maxBytes int) ([]string, str
 	}
 
 	return result, ""
+}
+
+func validateQuotedPrintable(body []byte) error {
+	for i := 0; i < len(body); i++ {
+		if body[i] != '=' {
+			continue
+		}
+		if i+1 >= len(body) {
+			return fmt.Errorf("invalid quoted-printable escape at byte %d", i)
+		}
+		if body[i+1] == '\n' {
+			i++
+			continue
+		}
+		if body[i+1] == '\r' {
+			if i+2 >= len(body) || body[i+2] != '\n' {
+				return fmt.Errorf("invalid quoted-printable escape at byte %d", i)
+			}
+			i += 2
+			continue
+		}
+		if i+2 >= len(body) || !isHexDigit(body[i+1]) || !isHexDigit(body[i+2]) {
+			return fmt.Errorf("invalid quoted-printable escape at byte %d", i)
+		}
+		i += 2
+	}
+	return nil
+}
+
+func isHexDigit(b byte) bool {
+	return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F')
 }
 
 // isBinaryContentType returns true for content types that are clearly binary

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -2167,6 +2167,53 @@ func TestExtractMultipart_Base64TransferEncoding(t *testing.T) {
 	}
 }
 
+func TestExtractMultipart_TransferEncodingDecodeFailureBlocks(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	boundary := testMultipartBoundary
+	encodedSecret := base64.StdEncoding.EncodeToString([]byte(fakeAPIKey()))
+	tests := []struct {
+		name string
+		cte  string
+		body string
+	}{
+		{
+			name: "malformed_base64",
+			cte:  "base64",
+			body: encodedSecret + "!",
+		},
+		{
+			name: "unsupported_encoding",
+			cte:  "x-secret-wrapper",
+			body: encodedSecret,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := "--" + boundary + "\r\n" +
+				"Content-Disposition: form-data; name=\"data\"\r\n" +
+				"Content-Transfer-Encoding: " + tc.cte + "\r\n\r\n" +
+				tc.body + "\r\n" +
+				"--" + boundary + "--\r\n"
+
+			_, result := scanRequestBody(context.Background(), BodyScanRequest{
+				Body:        strings.NewReader(body),
+				ContentType: "multipart/form-data; boundary=" + boundary,
+				MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+				Scanner:     sc,
+			})
+			if result.Clean {
+				t.Fatal("expected fail-closed block for uninspectable multipart transfer encoding")
+			}
+			if result.Action != config.ActionBlock {
+				t.Fatalf("action = %q, want %q", result.Action, config.ActionBlock)
+			}
+		})
+	}
+}
+
 // base64Encode76 encodes data as base64 with RFC 2045 line wrapping
 // (76-character lines separated by CRLF), mimicking real MIME encoding.
 func base64Encode76(data string) string {

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -2224,6 +2224,35 @@ func TestExtractMultipart_TransferEncodingDecodeFailureBlocks(t *testing.T) {
 	}
 }
 
+func TestValidateQuotedPrintable(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    []byte
+		wantErr bool
+	}{
+		{name: "plain", body: []byte("clean text")},
+		{name: "hex_upper", body: []byte("sk=2Dant")},
+		{name: "hex_lower", body: []byte("sk=2dant")},
+		{name: "soft_lf", body: []byte("wrapped=\nline")},
+		{name: "soft_crlf", body: []byte("wrapped=\r\nline")},
+		{name: "trailing_equals", body: []byte("bad="), wantErr: true},
+		{name: "short_hex_escape", body: []byte("bad=2"), wantErr: true},
+		{name: "invalid_hex_escape", body: []byte("bad=ZZ"), wantErr: true},
+		{name: "cr_without_lf", body: []byte("bad=\rline"), wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateQuotedPrintable(tc.body)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected invalid quoted-printable escape")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected valid quoted-printable, got %v", err)
+			}
+		})
+	}
+}
+
 // base64Encode76 encodes data as base64 with RFC 2045 line wrapping
 // (76-character lines separated by CRLF), mimicking real MIME encoding.
 func base64Encode76(data string) string {

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -2185,6 +2185,11 @@ func TestExtractMultipart_TransferEncodingDecodeFailureBlocks(t *testing.T) {
 			body: encodedSecret + "!",
 		},
 		{
+			name: "malformed_quoted_printable",
+			cte:  "quoted-printable",
+			body: "clean=ZZ",
+		},
+		{
 			name: "unsupported_encoding",
 			cte:  "x-secret-wrapper",
 			body: encodedSecret,

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -2190,6 +2190,11 @@ func TestExtractMultipart_TransferEncodingDecodeFailureBlocks(t *testing.T) {
 			body: "clean=ZZ",
 		},
 		{
+			name: "invalid_quoted_printable_byte",
+			cte:  "quoted-printable",
+			body: "clean\x01data",
+		},
+		{
 			name: "unsupported_encoding",
 			cte:  "x-secret-wrapper",
 			body: encodedSecret,


### PR DESCRIPTION
Go's multipart.Reader doesn't decode Content-Transfer-Encoding, so the scanner decoded base64/quoted-printable before DLP. On a decode failure (or an unknown CTE) the old path scanned the raw encoded bytes and continued — a fail-open, since a secret hidden by the encoding wouldn't match.

Now an undecodable or unsupported transfer encoding blocks fail-closed (identity encodings still scan raw). Adds an end-to-end regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multipart uploads now fail closed when a part’s `Content-Transfer-Encoding` is malformed or unsupported, preventing inconsistent scanning of encoded payloads.
  * When decoding succeeds, scanning covers both the decoded content and the original encoded payload.
* **Tests**
  * Added regression coverage for malformed `base64`, malformed `quoted-printable`, invalid escape sequences, and unsupported encodings to confirm requests are blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->