### PR TITLE
feat(dashboard): read-only Evidence view for Pro/Enterprise

### DIFF
--- a/enterprise/dashboard/evidence.tmpl.html
+++ b/enterprise/dashboard/evidence.tmpl.html
@@ -1,0 +1,334 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Pipelock Evidence</title>
+  <style>
+    :root {
+      --accent:#00e5a0;
+      --bg:#09090b;
+      --bg-elevated:#0e0e11;
+      --border:rgba(255,255,255,0.07);
+      --border-strong:rgba(255,255,255,0.13);
+      --text:#e2e8f0;
+      --text-muted:#94a3b8;
+      --text-dim:#64748b;
+      --warn:#f59e0b;
+      --danger:#ef4444;
+    }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      overflow: hidden;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.45 Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .topbar {
+      height: 56px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 24px;
+      border-bottom: 1px solid var(--border-strong);
+      background: #08080a;
+    }
+    .brand { font-weight: 650; }
+    .brand span { color: var(--text-muted); font-weight: 500; }
+    .mode { color: var(--text-dim); font-size: 13px; }
+    .shell {
+      display: grid;
+      grid-template-columns: 320px minmax(0, 1fr);
+      height: calc(100vh - 56px);
+      min-height: 0;
+    }
+    aside {
+      overflow-y: auto;
+      border-right: 1px solid var(--border);
+      background: #0b0b0e;
+      min-height: 0;
+    }
+    .aside-title {
+      padding: 18px 18px 10px;
+      color: var(--text-muted);
+      font-size: 12px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .session {
+      display: block;
+      color: inherit;
+      text-decoration: none;
+      padding: 14px 18px;
+      border-top: 1px solid var(--border);
+    }
+    .session[aria-current="page"], .session:hover { background: var(--bg-elevated); }
+    .session-name { display: flex; justify-content: space-between; gap: 12px; font-weight: 600; }
+    .session-meta { color: var(--text-dim); font-size: 12px; margin-top: 4px; }
+    .pips { display: inline-flex; gap: 5px; align-items: center; }
+    .pip {
+      width: 18px;
+      height: 18px;
+      display: inline-grid;
+      place-items: center;
+      border-radius: 50%;
+      color: #050507;
+      font-size: 10px;
+      font-weight: 800;
+    }
+    .verify { background: var(--accent); }
+    .warn, .limited { background: var(--warn); }
+    .fail { background: var(--danger); color: white; }
+    main {
+      height: calc(100vh - 56px);
+      overflow-y: auto;
+      min-width: 0;
+      min-height: 0;
+      padding: 24px;
+    }
+    .panel {
+      max-width: 1180px;
+      margin: 0 auto;
+    }
+    .heading {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 20px;
+      margin-bottom: 18px;
+    }
+    h1, h2, h3 { margin: 0; letter-spacing: 0; }
+    h1 { font-size: 24px; }
+    h2 { font-size: 16px; margin-bottom: 12px; }
+    .muted { color: var(--text-muted); }
+    .dim { color: var(--text-dim); }
+    .mono { font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .section {
+      border-top: 1px solid var(--border-strong);
+      padding-top: 18px;
+      margin-top: 18px;
+    }
+    .scorecard {
+      display: grid;
+      gap: 10px;
+    }
+    .score-row {
+      display: grid;
+      grid-template-columns: 150px 170px minmax(0, 1fr);
+      gap: 14px;
+      align-items: start;
+      padding: 14px;
+      border: 1px solid var(--border);
+      background: var(--bg-elevated);
+      border-radius: 8px;
+    }
+    .line-name { font-weight: 700; }
+    .chip {
+      display: inline-flex;
+      justify-content: center;
+      min-width: 128px;
+      padding: 4px 9px;
+      border-radius: 999px;
+      color: #050507;
+      font-size: 12px;
+      font-weight: 800;
+      white-space: nowrap;
+    }
+    .chip.fail { color: white; }
+    .detail { min-width: 0; }
+    .sub { color: var(--text-dim); margin-top: 4px; }
+    .score-footer {
+      color: var(--text-muted);
+      border-left: 3px solid var(--warn);
+      padding: 10px 0 10px 14px;
+    }
+    .callout {
+      border: 1px solid var(--border-strong);
+      background: #0b0f0e;
+      padding: 14px;
+      border-radius: 8px;
+    }
+    code, pre {
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+    code {
+      display: inline-block;
+      margin-top: 8px;
+      padding: 8px 10px;
+      background: #050507;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--accent);
+      max-width: 100%;
+      overflow-x: auto;
+    }
+    .absence {
+      border: 1px solid rgba(239,68,68,0.7);
+      background: rgba(239,68,68,0.12);
+      padding: 18px;
+      border-radius: 8px;
+    }
+    .absence h2 { color: #fecaca; font-size: 20px; }
+    .timeline {
+      display: grid;
+      gap: 10px;
+    }
+    .receipt {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg-elevated);
+      padding: 14px;
+    }
+    .receipt.unverifiable { opacity: 0.55; border-color: rgba(245,158,11,0.35); }
+    .receipt-grid {
+      display: grid;
+      grid-template-columns: 80px 180px 120px minmax(120px, 1fr) minmax(140px, 1fr) 145px;
+      gap: 12px;
+      align-items: start;
+    }
+    .label { color: var(--text-dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
+    .value { margin-top: 3px; overflow-wrap: anywhere; }
+    details { margin-top: 10px; }
+    summary { cursor: pointer; color: var(--text-muted); }
+    pre {
+      max-height: 360px;
+      overflow: auto;
+      padding: 12px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: #050507;
+      color: var(--text);
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+    .empty {
+      color: var(--text-muted);
+      padding: 26px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg-elevated);
+    }
+    @media (max-width: 900px) {
+      .shell { grid-template-columns: 1fr; }
+      aside { display: none; }
+      main { padding: 16px; }
+      .heading, .score-row, .receipt-grid { grid-template-columns: 1fr; }
+      .score-row { gap: 8px; }
+    }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">Pipelock <span>· Operator Console / Evidence</span></div>
+    <div class="mode">air-gapped · self-hosted</div>
+  </header>
+  <div class="shell">
+    <aside>
+      <div class="aside-title">Sessions</div>
+      {{range .Sessions}}
+        <a class="session" href="/session/{{.ID}}" {{if eq $.SelectedSession .ID}}aria-current="page"{{end}}>
+          <div class="session-name">
+            <span>{{.Agent}}</span>
+            <span class="pips">{{range .Pips}}<span class="pip {{.State}}" title="{{.Label}}">{{.Label}}</span>{{end}}</span>
+          </div>
+          <div class="session-meta">{{.ID}} · {{.ReceiptCount}}{{if .ReadLimited}}+{{end}} receipts</div>
+        </a>
+      {{else}}
+        <div class="empty">No recorder sessions found.</div>
+      {{end}}
+    </aside>
+    <main>
+      <div class="panel">
+        {{if .HasEvidence}}
+          <div class="heading">
+            <div>
+              <h1>Evidence · {{.Evidence.Agent}}</h1>
+              <div class="muted mono">{{.Evidence.ID}}</div>
+            </div>
+            <div class="dim mono">{{len .Evidence.Receipts}}{{if .Evidence.ReadLimited}}+{{end}} receipts</div>
+          </div>
+
+          {{if not .Evidence.ReceiptsEnabled}}
+            <section class="absence">
+              <h2>No receipts for this agent — you have NO independent evidence for its decisions</h2>
+              <p>ABSENT · ABSENT · ABSENT · ABSENT</p>
+            </section>
+          {{end}}
+
+          {{if .Evidence.ReadLimited}}
+            <section class="section callout">
+              <h2>Dashboard read limit reached</h2>
+              <div class="muted">This online view loaded only the first {{len .Evidence.Receipts}} receipts before the {{.Evidence.ReadLimit}}-entry ceiling. Use offline verification before relying on this session.</div>
+            </section>
+          {{end}}
+
+          <section class="section">
+            <h2>Scorecard</h2>
+            <div class="scorecard">
+              <div class="score-row">
+                <div class="line-name">Authentic</div>
+                <div><span class="chip {{.Evidence.Scorecard.Authentic.State}}">{{.Evidence.Scorecard.Authentic.Chip}}</span></div>
+                <div class="detail">{{.Evidence.Scorecard.Authentic.Detail}}<div class="sub">{{.Evidence.Scorecard.Authentic.Sub}}</div></div>
+              </div>
+              <div class="score-row">
+                <div class="line-name">Untampered</div>
+                <div><span class="chip {{.Evidence.Scorecard.Untampered.State}}">{{.Evidence.Scorecard.Untampered.Chip}}</span></div>
+                <div class="detail">{{.Evidence.Scorecard.Untampered.Detail}}<div class="sub">{{.Evidence.Scorecard.Untampered.Sub}}</div></div>
+              </div>
+              <div class="score-row">
+                <div class="line-name">Anchored</div>
+                <div><span class="chip {{.Evidence.Scorecard.Anchored.State}}">{{.Evidence.Scorecard.Anchored.Chip}}</span></div>
+                <div class="detail">{{.Evidence.Scorecard.Anchored.Detail}}<div class="sub">{{.Evidence.Scorecard.Anchored.Sub}}</div></div>
+              </div>
+              <div class="score-row">
+                <div class="line-name">Completeness</div>
+                <div><span class="chip {{.Evidence.Scorecard.Completeness.State}}">{{.Evidence.Scorecard.Completeness.Chip}}</span></div>
+                <div class="detail">{{.Evidence.Scorecard.Completeness.Detail}}<div class="sub">{{.Evidence.Scorecard.Completeness.Sub}}</div></div>
+              </div>
+            </div>
+            <p class="score-footer">Absence of evidence renders red or amber, never as success. No line summarises the others — read all four.</p>
+          </section>
+
+          <section class="section callout">
+            <h2>Don't trust this page — verify offline</h2>
+            <div class="muted">Use the signed bundle and configured trusted key fingerprint.</div>
+            <code>pipelock-verifier verify-run &lt;bundle&gt; --trusted-key {{.Evidence.TrustedKeyText}}</code>
+          </section>
+
+          <section class="section">
+            <h2>Receipt Timeline</h2>
+            {{if .Evidence.TimelineLimited}}
+              <p class="dim">Showing {{.Evidence.TimelineWindow}} {{len .Evidence.Timeline}} of {{len .Evidence.Receipts}}{{if .Evidence.ReadLimited}}+{{end}} loaded receipts.</p>
+            {{end}}
+            <div class="timeline">
+              {{range .Evidence.Timeline}}
+                <article class="receipt {{if .Unverifiable}}unverifiable{{end}}">
+                  <div class="receipt-grid">
+                    <div><div class="label">Seq</div><div class="value mono">{{.Seq}}</div></div>
+                    <div><div class="label">Time</div><div class="value mono">{{.Time}}</div></div>
+                    <div><div class="label">Decision</div><div class="value"><span class="chip limited">{{.Verdict}}</span></div></div>
+                    <div><div class="label">Reason</div><div class="value">{{.Reason}}</div></div>
+                    <div><div class="label">Destination</div><div class="value">{{.Destination}}</div></div>
+                    <div><div class="label">Prev → Hash</div><div class="value mono">{{.PrevShort}} → {{.HashShort}}</div></div>
+                  </div>
+                  {{if .Unverifiable}}<div class="sub">This receipt is at or after the break and is unverifiable.</div>{{end}}
+                  <details>
+                    <summary>Signed JSON payload</summary>
+                    <pre>{{.RawJSON}}</pre>
+                  </details>
+                </article>
+              {{else}}
+                <div class="empty">No receipt timeline is available for this session.</div>
+              {{end}}
+            </div>
+          </section>
+        {{else}}
+          <div class="empty">No evidence session selected.</div>
+        {{end}}
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -1,0 +1,131 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"embed"
+	"html/template"
+	"net/http"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+const (
+	contentSecurityPolicy = "default-src 'self'; style-src 'self' 'unsafe-inline'"
+	contentTypeHTML       = "text/html; charset=utf-8"
+	contentTypeText       = "text/plain; charset=utf-8"
+)
+
+//go:embed evidence.tmpl.html
+var templateFS embed.FS
+
+var evidenceTemplate = template.Must(template.ParseFS(templateFS, "evidence.tmpl.html"))
+
+type pageData struct {
+	Sessions        []SessionSummary
+	SelectedSession string
+	Evidence        SessionEvidence
+	HasEvidence     bool
+}
+
+// New returns a read-only HTTP handler for the Enterprise Evidence dashboard.
+func New(opts Options) http.Handler {
+	model := NewReadModel(opts)
+	mux := http.NewServeMux()
+	d := &dashboardHandler{
+		model:      model,
+		hasFeature: opts.HasFeature,
+	}
+	mux.Handle("/", d.gate(http.HandlerFunc(d.handleIndex)))
+	mux.Handle("/session/", d.gate(http.HandlerFunc(d.handleSession)))
+	return mux
+}
+
+type dashboardHandler struct {
+	model      *ReadModel
+	hasFeature func(string) bool
+}
+
+func (d *dashboardHandler) gate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		if d.hasFeature == nil || !d.hasFeature(license.FeatureAgents) {
+			w.Header().Set("Content-Type", contentTypeText)
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("Pipelock Enterprise agents feature required\n"))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (d *dashboardHandler) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	sessions, err := d.model.Sessions()
+	if err != nil {
+		http.Error(w, "could not read evidence sessions", http.StatusInternalServerError)
+		return
+	}
+
+	selected := r.URL.Query().Get("session")
+	if selected == "" && len(sessions) > 0 {
+		selected = sessions[0].ID
+	}
+	d.render(w, sessions, selected)
+}
+
+func (d *dashboardHandler) handleSession(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	selected := strings.TrimPrefix(r.URL.Path, "/session/")
+	if selected == "" || strings.Contains(selected, "/") {
+		http.NotFound(w, r)
+		return
+	}
+	sessions, err := d.model.Sessions()
+	if err != nil {
+		http.Error(w, "could not read evidence sessions", http.StatusInternalServerError)
+		return
+	}
+	d.render(w, sessions, selected)
+}
+
+func (d *dashboardHandler) render(w http.ResponseWriter, sessions []SessionSummary, selected string) {
+	data := pageData{
+		Sessions:        sessions,
+		SelectedSession: selected,
+	}
+	if selected != "" {
+		evidence, err := d.model.Session(selected)
+		if err != nil {
+			http.Error(w, "could not read selected evidence", http.StatusInternalServerError)
+			return
+		}
+		data.Evidence = evidence
+		data.HasEvidence = true
+	}
+
+	w.Header().Set("Content-Type", contentTypeHTML)
+	if err := evidenceTemplate.Execute(w, data); err != nil {
+		http.Error(w, "could not render evidence", http.StatusInternalServerError)
+	}
+}

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	contentSecurityPolicy = "default-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'"
+	contentSecurityPolicy = "default-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'; object-src 'none'"
 	contentTypeHTML       = "text/html; charset=utf-8"
 	contentTypeText       = "text/plain; charset=utf-8"
 )
@@ -33,12 +33,21 @@ type pageData struct {
 }
 
 // New returns a read-only HTTP handler for the Enterprise Evidence dashboard.
+//
+// SECURITY: this handler serves sensitive evidence (signed receipt payloads,
+// destinations, block reasons, signer fingerprints, session IDs). The
+// license-feature check is NOT authentication. Mount this handler ONLY on an
+// authenticated, admin-only listener, and never on the agent-reachable proxy
+// port. Set Options.Authorize to enforce an authenticated principal per
+// request; it fails closed when it returns an error. When Authorize is nil the
+// surrounding router MUST provide the authentication boundary.
 func New(opts Options) http.Handler {
 	model := NewReadModel(opts)
 	mux := http.NewServeMux()
 	d := &dashboardHandler{
 		model:      model,
 		hasFeature: opts.HasFeature,
+		authorize:  opts.Authorize,
 	}
 	mux.Handle("/", d.gate(http.HandlerFunc(d.handleIndex)))
 	mux.Handle("/session/", d.gate(http.HandlerFunc(d.handleSession)))
@@ -48,6 +57,7 @@ func New(opts Options) http.Handler {
 type dashboardHandler struct {
 	model      *ReadModel
 	hasFeature func(string) bool
+	authorize  func(*http.Request) error
 }
 
 func (d *dashboardHandler) gate(next http.Handler) http.Handler {
@@ -61,6 +71,16 @@ func (d *dashboardHandler) gate(next http.Handler) http.Handler {
 			w.WriteHeader(http.StatusForbidden)
 			_, _ = w.Write([]byte("Pipelock Enterprise agents feature required\n"))
 			return
+		}
+		// Authentication boundary. The license check above is entitlement, not
+		// identity; fail closed when a configured authorizer rejects the request.
+		if d.authorize != nil {
+			if err := d.authorize(r); err != nil {
+				w.Header().Set("Content-Type", contentTypeText)
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("forbidden\n"))
+				return
+			}
 		}
 		next.ServeHTTP(w, r)
 	})

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -5,6 +5,7 @@
 package dashboard
 
 import (
+	"bytes"
 	"embed"
 	"html/template"
 	"net/http"
@@ -14,7 +15,7 @@ import (
 )
 
 const (
-	contentSecurityPolicy = "default-src 'self'; style-src 'self' 'unsafe-inline'"
+	contentSecurityPolicy = "default-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'"
 	contentTypeHTML       = "text/html; charset=utf-8"
 	contentTypeText       = "text/plain; charset=utf-8"
 )
@@ -70,9 +71,7 @@ func (d *dashboardHandler) handleIndex(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", http.MethodGet)
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	if !requireGet(w, r) {
 		return
 	}
 
@@ -90,9 +89,7 @@ func (d *dashboardHandler) handleIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *dashboardHandler) handleSession(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", http.MethodGet)
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	if !requireGet(w, r) {
 		return
 	}
 
@@ -107,6 +104,15 @@ func (d *dashboardHandler) handleSession(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	d.render(w, sessions, selected)
+}
+
+func requireGet(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method == http.MethodGet {
+		return true
+	}
+	w.Header().Set("Allow", http.MethodGet)
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	return false
 }
 
 func (d *dashboardHandler) render(w http.ResponseWriter, sessions []SessionSummary, selected string) {
@@ -124,8 +130,11 @@ func (d *dashboardHandler) render(w http.ResponseWriter, sessions []SessionSumma
 		data.HasEvidence = true
 	}
 
-	w.Header().Set("Content-Type", contentTypeHTML)
-	if err := evidenceTemplate.Execute(w, data); err != nil {
+	var buf bytes.Buffer
+	if err := evidenceTemplate.Execute(&buf, data); err != nil {
 		http.Error(w, "could not render evidence", http.StatusInternalServerError)
+		return
 	}
+	w.Header().Set("Content-Type", contentTypeHTML)
+	_, _ = w.Write(buf.Bytes())
 }

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -132,6 +132,18 @@ func TestHandler_HostileEvidenceRenderEscapesReceiptFields(t *testing.T) {
 	if strings.Contains(body, hostileJSON) {
 		t.Fatal("response contains raw script-breaking JSON payload")
 	}
+	if strings.Contains(body, `href="javascript:`) {
+		t.Fatal("response contains javascript URL in href attribute")
+	}
+	for _, rawAttr := range []string{
+		`="` + hostileJSURL + `"`,
+		`='` + hostileJSURL + `'`,
+		`=` + hostileJSURL,
+	} {
+		if strings.Contains(body, rawAttr) {
+			t.Fatalf("response contains raw javascript URL in attribute context: %q", rawAttr)
+		}
+	}
 	if !strings.Contains(body, "&lt;script&gt;alert(1)&lt;/script&gt;") {
 		t.Fatal("response should contain HTML-escaped script text")
 	}
@@ -140,6 +152,42 @@ func TestHandler_HostileEvidenceRenderEscapesReceiptFields(t *testing.T) {
 	}
 	if !strings.Contains(body, "\\u003c/script\\u003e") {
 		t.Fatal("response should contain JSON-escaped closing script token in signed payload")
+	}
+	escapedRequestID := "&#34;request_id&#34;: &#34;" + hostileJSURL + "&#34;"
+	if !strings.Contains(body, escapedRequestID) {
+		t.Fatal("javascript URL field should render only as escaped text in the signed payload")
+	}
+}
+
+func TestHandler_MethodAndPathRejection(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	handler := New(Options{
+		ReceiptDir: dir,
+		HasFeature: allowAgentsFeature,
+	})
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   int
+	}{
+		{name: "post index", method: http.MethodPost, path: "/", want: http.StatusMethodNotAllowed},
+		{name: "nested session path", method: http.MethodGet, path: "/session/foo/bar", want: http.StatusNotFound},
+		{name: "unknown path", method: http.MethodGet, path: "/nope", want: http.StatusNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(context.Background(), tc.method, tc.path, nil)
+			handler.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("%s %s status = %d, want %d; body=%s", tc.method, tc.path, rec.Code, tc.want, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/hex"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -246,6 +247,40 @@ func TestHandler_AbsenceRender(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Fatalf("body missing %q: %s", want, body)
 		}
+	}
+}
+
+func TestHandler_AuthorizeFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+
+	// A rejecting authorizer must fail closed even when the feature is present.
+	denied := New(Options{
+		ReceiptDir: dir,
+		HasFeature: allowAgentsFeature,
+		Authorize:  func(*http.Request) error { return errors.New("no principal") },
+	})
+	rec := httptest.NewRecorder()
+	denied.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("rejecting Authorize status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+	if strings.Contains(rec.Body.String(), "Scorecard") {
+		t.Fatal("forbidden response must not contain evidence body")
+	}
+
+	// An accepting authorizer reaches the handler.
+	allowed := New(Options{
+		ReceiptDir: dir,
+		HasFeature: allowAgentsFeature,
+		Authorize:  func(*http.Request) error { return nil },
+	})
+	rec = httptest.NewRecorder()
+	allowed.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("accepting Authorize status = %d, want %d", rec.Code, http.StatusOK)
 	}
 }
 

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -1,0 +1,221 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+const (
+	hostileScript = "<script>alert(1)</script>"
+	hostileImage  = "\"><img src=x onerror=alert(1)>"
+	hostileJSURL  = "javascript:alert(1)"
+	hostileJSON   = `</script><script>alert("json")</script>`
+)
+
+func TestHandler_Gating(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	handler := New(Options{ReceiptDir: dir})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("nil HasFeature status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+	if strings.Contains(rec.Body.String(), "Scorecard") {
+		t.Fatal("forbidden response should not contain evidence body")
+	}
+
+	handler = New(Options{
+		ReceiptDir: dir,
+		HasFeature: func(string) bool {
+			return false
+		},
+	})
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("false HasFeature status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("false HasFeature /session status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestHandler_AllowedRendersScorecard(t *testing.T) {
+	t.Parallel()
+
+	dir, trusted := writeTrustedHandlerSession(t)
+	handler := New(Options{
+		ReceiptDir:  dir,
+		TrustedKeys: trusted,
+		HasFeature:  allowAgentsFeature,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Scorecard") {
+		t.Fatal("allowed response should render scorecard")
+	}
+	if got := rec.Header().Get("Content-Security-Policy"); got != contentSecurityPolicy {
+		t.Fatalf("CSP = %q, want %q", got, contentSecurityPolicy)
+	}
+	for header, want := range map[string]string{
+		"Cache-Control":          "no-store",
+		"Referrer-Policy":        "no-referrer",
+		"X-Content-Type-Options": "nosniff",
+	} {
+		if got := rec.Header().Get(header); got != want {
+			t.Fatalf("%s = %q, want %q", header, got, want)
+		}
+	}
+}
+
+func TestHandler_HostileEvidenceRenderEscapesReceiptFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	r := signDashboardReceipt(t, priv, 0, receipt.GenesisHash, time.Date(2026, 7, 3, 13, 0, 0, 0, time.UTC))
+	r.ActionRecord.Target = hostileScript
+	r.ActionRecord.Pattern = hostileImage
+	r.ActionRecord.Verdict = hostileScript
+	r.ActionRecord.Intent = hostileJSON
+	r.ActionRecord.RequestID = hostileJSURL
+	resigned, err := signAlteredReceipt(r, priv)
+	if err != nil {
+		t.Fatalf("signAlteredReceipt: %v", err)
+	}
+	writeReceiptsToDir(t, dir, []receipt.Receipt{resigned})
+
+	handler := New(Options{
+		ReceiptDir: dir,
+		TrustedKeys: map[string]TrustedKey{
+			keyHex: {Source: trustedKeySource},
+		},
+		HasFeature: allowAgentsFeature,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, hostileScript) {
+		t.Fatal("response contains raw script tag")
+	}
+	if strings.Contains(body, hostileImage) {
+		t.Fatal("response contains raw image injection")
+	}
+	if strings.Contains(body, hostileJSON) {
+		t.Fatal("response contains raw script-breaking JSON payload")
+	}
+	if !strings.Contains(body, "&lt;script&gt;alert(1)&lt;/script&gt;") {
+		t.Fatal("response should contain HTML-escaped script text")
+	}
+	if !strings.Contains(body, "&lt;img src=x onerror=alert(1)&gt;") {
+		t.Fatal("response should contain HTML-escaped image injection text")
+	}
+	if !strings.Contains(body, "\\u003c/script\\u003e") {
+		t.Fatal("response should contain JSON-escaped closing script token in signed payload")
+	}
+}
+
+func TestHandler_ReadLimitWarning(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	writeReceiptsToDir(t, dir, buildDashboardChain(t, priv, 4))
+
+	handler := New(Options{
+		ReceiptDir:       dir,
+		ReceiptReadLimit: 2,
+		TimelineLimit:    1,
+		TrustedKeys: map[string]TrustedKey{
+			keyHex: {Source: trustedKeySource},
+		},
+		HasFeature: allowAgentsFeature,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"Dashboard read limit reached",
+		"2+ receipts",
+		"Showing first 1 of 2+ loaded receipts.",
+		"Partial",
+		"Prefix only",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestHandler_AbsenceRender(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeZeroReceiptSessionFile(t, dir, zeroSessionID)
+	handler := New(Options{
+		ReceiptDir: dir,
+		HasFeature: allowAgentsFeature,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+zeroSessionID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"No receipts", "NO independent evidence", "ABSENT"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+}
+
+func allowAgentsFeature(feature string) bool {
+	return feature == license.FeatureAgents
+}
+
+func signAlteredReceipt(r receipt.Receipt, priv ed25519.PrivateKey) (receipt.Receipt, error) {
+	return receipt.Sign(r.ActionRecord, priv)
+}
+
+func writeTrustedHandlerSession(t *testing.T) (string, map[string]TrustedKey) {
+	t.Helper()
+	dir := t.TempDir()
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	writeReceiptsToDir(t, dir, buildDashboardChain(t, priv, 2))
+	return dir, map[string]TrustedKey{
+		keyHex: {Source: trustedKeySource},
+	}
+}

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -7,6 +7,7 @@ package dashboard
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
@@ -20,9 +21,14 @@ const (
 
 // Options configures the read-only Evidence dashboard.
 type Options struct {
-	ReceiptDir       string
-	TrustedKeys      map[string]TrustedKey
-	HasFeature       func(string) bool
+	ReceiptDir  string
+	TrustedKeys map[string]TrustedKey
+	HasFeature  func(string) bool
+	// Authorize, when non-nil, runs per request after the license-feature check
+	// and fails the request closed (403) on a non-nil error. It is the handler's
+	// authentication/authorization seam, distinct from the license entitlement
+	// check. Nil means the surrounding router must own authentication.
+	Authorize        func(*http.Request) error
 	ReceiptReadLimit int
 	TimelineLimit    int
 }

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -1,0 +1,287 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+const (
+	dashboardReceiptReadLimit = 5000
+	dashboardTimelineLimit    = 500
+)
+
+// Options configures the read-only Evidence dashboard.
+type Options struct {
+	ReceiptDir       string
+	TrustedKeys      map[string]TrustedKey
+	HasFeature       func(string) bool
+	ReceiptReadLimit int
+	TimelineLimit    int
+}
+
+// ReadModel builds dashboard views over recorder sessions and receipts.
+type ReadModel struct {
+	receiptDir       string
+	trustedKeys      map[string]TrustedKey
+	receiptReadLimit int
+	timelineLimit    int
+}
+
+// SessionSummary is the left-nav row for one recorder session.
+type SessionSummary struct {
+	ID              string
+	Agent           string
+	ReceiptCount    int
+	ReadLimited     bool
+	StartTime       time.Time
+	EndTime         time.Time
+	ReceiptsEnabled bool
+	Pips            []SummaryPip
+}
+
+// SummaryPip is a compact state indicator for one scorecard line.
+type SummaryPip struct {
+	State string
+	Label string
+}
+
+// SessionEvidence is the full Evidence view for one session.
+type SessionEvidence struct {
+	ID              string
+	Agent           string
+	ReceiptsEnabled bool
+	Receipts        []receipt.Receipt
+	ReadLimited     bool
+	ReadLimit       int
+	TimelineLimited bool
+	TimelineLimit   int
+	TimelineWindow  string
+	Chain           receipt.ChainResult
+	Scorecard       Scorecard
+	Timeline        []TimelineItem
+	TrustedKeyText  string
+}
+
+// TimelineItem is one rendered receipt row.
+type TimelineItem struct {
+	Seq          uint64
+	Time         time.Time
+	Verdict      string
+	Reason       string
+	Destination  string
+	PrevShort    string
+	HashShort    string
+	Unverifiable bool
+	RawJSON      string
+}
+
+// NewReadModel creates a dashboard read model from Options.
+func NewReadModel(opts Options) *ReadModel {
+	receiptReadLimit := opts.ReceiptReadLimit
+	if receiptReadLimit <= 0 {
+		receiptReadLimit = dashboardReceiptReadLimit
+	}
+	timelineLimit := opts.TimelineLimit
+	if timelineLimit <= 0 {
+		timelineLimit = dashboardTimelineLimit
+	}
+	return &ReadModel{
+		receiptDir:       opts.ReceiptDir,
+		trustedKeys:      cloneTrustedKeys(opts.TrustedKeys),
+		receiptReadLimit: receiptReadLimit,
+		timelineLimit:    timelineLimit,
+	}
+}
+
+// Sessions lists available recorder sessions and computes their compact state.
+func (m *ReadModel) Sessions() ([]SessionSummary, error) {
+	ids, err := recorder.ListSessions(m.receiptDir)
+	if err != nil {
+		return nil, fmt.Errorf("list sessions: %w", err)
+	}
+
+	summaries := make([]SessionSummary, 0, len(ids))
+	for _, id := range ids {
+		receipts, readLimited, err := receipt.ExtractReceiptsFromSessionDirBounded(m.receiptDir, id, m.receiptReadLimit)
+		if err != nil {
+			return nil, fmt.Errorf("read session %s receipts: %w", id, err)
+		}
+		summaries = append(summaries, sessionSummary(id, receipts, m.trustedKeys, readLimited, m.receiptReadLimit))
+	}
+	return summaries, nil
+}
+
+// Session reads one session's complete evidence.
+func (m *ReadModel) Session(id string) (SessionEvidence, error) {
+	receipts, readLimited, err := receipt.ExtractReceiptsFromSessionDirBounded(m.receiptDir, id, m.receiptReadLimit)
+	if err != nil {
+		return SessionEvidence{}, fmt.Errorf("read session %s receipts: %w", id, err)
+	}
+	return sessionEvidence(id, receipts, m.trustedKeys, readLimited, m.receiptReadLimit, m.timelineLimit), nil
+}
+
+func sessionSummary(id string, receipts []receipt.Receipt, trustedKeys map[string]TrustedKey, readLimited bool, readLimit int) SessionSummary {
+	if len(receipts) == 0 {
+		return SessionSummary{
+			ID:              id,
+			Agent:           id,
+			ReceiptsEnabled: false,
+			Pips:            scorecardPips(absentScorecard()),
+		}
+	}
+
+	result := computeScorecard(receipts, trustedKeys, id)
+	scorecard := result.Scorecard
+	if readLimited {
+		scorecard = readLimitedScorecard(len(receipts), readLimit)
+	}
+	return SessionSummary{
+		ID:              id,
+		Agent:           agentLabel(id, receipts),
+		ReceiptCount:    len(receipts),
+		ReadLimited:     readLimited,
+		StartTime:       receipts[0].ActionRecord.Timestamp,
+		EndTime:         receipts[len(receipts)-1].ActionRecord.Timestamp,
+		ReceiptsEnabled: true,
+		Pips:            scorecardPips(scorecard),
+	}
+}
+
+func sessionEvidence(id string, receipts []receipt.Receipt, trustedKeys map[string]TrustedKey, readLimited bool, readLimit, timelineLimit int) SessionEvidence {
+	if len(receipts) == 0 {
+		return SessionEvidence{
+			ID:              id,
+			Agent:           id,
+			ReceiptsEnabled: false,
+			Scorecard:       absentScorecard(),
+			TrustedKeyText:  "none",
+		}
+	}
+
+	result := computeScorecard(receipts, trustedKeys, id)
+	scorecard := result.Scorecard
+	if readLimited {
+		scorecard = readLimitedScorecard(len(receipts), readLimit)
+	}
+	timelineReceipts, timelineStartIndex, timelineLimited, timelineWindow := selectTimelineReceipts(receipts, readLimited, timelineLimit)
+	return SessionEvidence{
+		ID:              id,
+		Agent:           agentLabel(id, receipts),
+		ReceiptsEnabled: true,
+		Receipts:        append([]receipt.Receipt(nil), receipts...),
+		ReadLimited:     readLimited,
+		ReadLimit:       readLimit,
+		TimelineLimited: timelineLimited,
+		TimelineLimit:   timelineLimit,
+		TimelineWindow:  timelineWindow,
+		Chain:           result.Chain,
+		Scorecard:       scorecard,
+		Timeline:        buildTimeline(timelineReceipts, timelineStartIndex, result.Chain),
+		TrustedKeyText:  formatKeyList(trustedKeysForSession(signerKeys(receipts), trustedKeys)),
+	}
+}
+
+func scorecardPips(scorecard Scorecard) []SummaryPip {
+	return []SummaryPip{
+		{State: scorecard.Authentic.State, Label: "A"},
+		{State: scorecard.Untampered.State, Label: "U"},
+		{State: scorecard.Anchored.State, Label: "N"},
+		{State: scorecard.Completeness.State, Label: "C"},
+	}
+}
+
+func agentLabel(id string, receipts []receipt.Receipt) string {
+	if len(receipts) == 0 {
+		return id
+	}
+	first := receipts[0].ActionRecord
+	if first.Actor != "" {
+		return first.Actor
+	}
+	if first.SessionID != "" {
+		return first.SessionID
+	}
+	return id
+}
+
+func buildTimeline(receipts []receipt.Receipt, startIndex int, chain receipt.ChainResult) []TimelineItem {
+	items := make([]TimelineItem, 0, len(receipts))
+	for i, r := range receipts {
+		ar := r.ActionRecord
+		hash, err := receipt.ReceiptHash(r)
+		if err != nil {
+			hash = "hash-error"
+		}
+		raw, err := json.MarshalIndent(r, "", "  ")
+		if err != nil {
+			raw = []byte(`{"error":"receipt marshal failed"}`)
+		}
+		items = append(items, TimelineItem{
+			Seq:          ar.ChainSeq,
+			Time:         ar.Timestamp,
+			Verdict:      ar.Verdict,
+			Reason:       reasonLabel(ar.Layer, ar.Pattern, ar.ActionType),
+			Destination:  ar.Target,
+			PrevShort:    shortHash(ar.ChainPrevHash),
+			HashShort:    shortHash(hash),
+			Unverifiable: !chain.Valid && startIndex+i >= chain.BrokenAtIndex,
+			RawJSON:      string(raw),
+		})
+	}
+	return items
+}
+
+func selectTimelineReceipts(receipts []receipt.Receipt, readLimited bool, timelineLimit int) ([]receipt.Receipt, int, bool, string) {
+	if timelineLimit <= 0 {
+		timelineLimit = dashboardTimelineLimit
+	}
+	if len(receipts) <= timelineLimit {
+		return receipts, 0, false, "all"
+	}
+	if readLimited {
+		return receipts[:timelineLimit], 0, true, "first"
+	}
+	start := len(receipts) - timelineLimit
+	return receipts[start:], start, true, "latest"
+}
+
+func reasonLabel(layer, pattern string, actionType receipt.ActionType) string {
+	switch {
+	case layer != "" && pattern != "":
+		return layer + " / " + pattern
+	case layer != "":
+		return layer
+	case pattern != "":
+		return pattern
+	case actionType != "":
+		return string(actionType)
+	default:
+		return "policy decision"
+	}
+}
+
+func shortHash(hash string) string {
+	if len(hash) <= 12 {
+		return hash
+	}
+	return hash[:12]
+}
+
+func cloneTrustedKeys(in map[string]TrustedKey) map[string]TrustedKey {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]TrustedKey, len(in))
+	for key, trusted := range in {
+		out[key] = trusted
+	}
+	return out
+}

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -138,10 +138,11 @@ func sessionSummary(id string, receipts []receipt.Receipt, trustedKeys map[strin
 		}
 	}
 
-	result := computeScorecard(receipts, trustedKeys, id)
-	scorecard := result.Scorecard
+	var scorecard Scorecard
 	if readLimited {
 		scorecard = readLimitedScorecard(len(receipts), readLimit)
+	} else {
+		scorecard = computeScorecard(receipts, trustedKeys, id).Scorecard
 	}
 	return SessionSummary{
 		ID:              id,

--- a/enterprise/dashboard/readmodel_test.go
+++ b/enterprise/dashboard/readmodel_test.go
@@ -1,0 +1,182 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+const (
+	testReceiptEntryType = "action_receipt"
+	zeroSessionID        = "empty-agent"
+)
+
+func TestReadModel_IntegrationRealReadPathAndZeroReceiptSession(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	rec := newTestRecorder(t, dir, priv)
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: testPolicyHash,
+		Principal:  testPrincipal,
+		Actor:      testActor,
+	})
+	for i := 0; i < 2; i++ {
+		if err := emitter.Emit(receipt.EmitOpts{
+			ActionID:  receipt.NewActionID(),
+			Target:    testTarget,
+			Verdict:   config.ActionAllow,
+			Transport: testTransport,
+			Method:    http.MethodGet,
+			Layer:     "allowlist",
+			Pattern:   "example.com",
+			SessionID: testSessionID,
+			Agent:     testActor,
+		}); err != nil {
+			t.Fatalf("Emit(%d): %v", i, err)
+		}
+	}
+	_ = rec.Close()
+	writeZeroReceiptSessionFile(t, dir, zeroSessionID)
+
+	model := NewReadModel(Options{
+		ReceiptDir: dir,
+		TrustedKeys: map[string]TrustedKey{
+			keyHex: {Source: trustedKeySource},
+		},
+	})
+	sessions, err := model.Sessions()
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("len(Sessions) = %d, want 2", len(sessions))
+	}
+
+	evidence, err := model.Session("proxy")
+	if err != nil {
+		t.Fatalf("Session(proxy): %v", err)
+	}
+	if evidence.Scorecard.Authentic.State != StateVerify {
+		t.Fatalf("Authentic.State = %q, want %q", evidence.Scorecard.Authentic.State, StateVerify)
+	}
+	if !evidence.ReceiptsEnabled {
+		t.Fatal("proxy session should have receipts enabled")
+	}
+
+	zero, err := model.Session(zeroSessionID)
+	if err != nil {
+		t.Fatalf("Session(%s): %v", zeroSessionID, err)
+	}
+	if zero.ReceiptsEnabled {
+		t.Fatal("zero-receipt session should be marked receipts disabled")
+	}
+	if zero.Scorecard.Authentic.Chip != chipAbsent {
+		t.Fatalf("zero Authentic.Chip = %q, want %q", zero.Scorecard.Authentic.Chip, chipAbsent)
+	}
+}
+
+func TestReadModel_ReadLimitDowngradesEvidence(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	writeReceiptsToDir(t, dir, buildDashboardChain(t, priv, 4))
+
+	model := NewReadModel(Options{
+		ReceiptDir:       dir,
+		ReceiptReadLimit: 2,
+		TimelineLimit:    1,
+		TrustedKeys: map[string]TrustedKey{
+			keyHex: {Source: trustedKeySource},
+		},
+	})
+	sessions, err := model.Sessions()
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("len(Sessions) = %d, want 1", len(sessions))
+	}
+	if !sessions[0].ReadLimited {
+		t.Fatal("summary should report read-limited evidence")
+	}
+	if sessions[0].ReceiptCount != 2 {
+		t.Fatalf("ReceiptCount = %d, want 2", sessions[0].ReceiptCount)
+	}
+
+	evidence, err := model.Session(testSessionID)
+	if err != nil {
+		t.Fatalf("Session(%s): %v", testSessionID, err)
+	}
+	if !evidence.ReadLimited {
+		t.Fatal("evidence should report read-limited session")
+	}
+	if evidence.Scorecard.Authentic.State != StateLimited {
+		t.Fatalf("Authentic.State = %q, want %q", evidence.Scorecard.Authentic.State, StateLimited)
+	}
+	if evidence.Scorecard.Untampered.State != StateLimited {
+		t.Fatalf("Untampered.State = %q, want %q", evidence.Scorecard.Untampered.State, StateLimited)
+	}
+	if len(evidence.Timeline) != 1 {
+		t.Fatalf("len(Timeline) = %d, want 1", len(evidence.Timeline))
+	}
+	if evidence.TimelineWindow != "first" {
+		t.Fatalf("TimelineWindow = %q, want first", evidence.TimelineWindow)
+	}
+}
+
+func writeReceiptsToDir(t *testing.T, dir string, receipts []receipt.Receipt) {
+	t.Helper()
+	rec := newTestRecorder(t, dir, nil)
+	for i, r := range receipts {
+		if err := rec.Record(recorder.Entry{
+			SessionID: testSessionID,
+			Type:      testReceiptEntryType,
+			EventKind: string(r.ActionRecord.ActionType),
+			Transport: r.ActionRecord.Transport,
+			Summary:   "receipt",
+			Detail:    r,
+		}); err != nil {
+			t.Fatalf("Record(%d): %v", i, err)
+		}
+	}
+	_ = rec.Close()
+}
+
+func newTestRecorder(t *testing.T, dir string, priv ed25519.PrivateKey) *recorder.Recorder {
+	t.Helper()
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	return rec
+}
+
+func writeZeroReceiptSessionFile(t *testing.T, dir, sessionID string) {
+	t.Helper()
+	path := filepath.Join(dir, "evidence-"+sessionID+"-000000.jsonl")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}

--- a/enterprise/dashboard/scorecard.go
+++ b/enterprise/dashboard/scorecard.go
@@ -65,11 +65,13 @@ func computeScorecard(receipts []receipt.Receipt, trustedKeys map[string]Trusted
 	structural := receipt.VerifyChainTrusted(receipts, signers)
 	trustedSessionKeys := trustedKeysForSession(signers, trustedKeys)
 
-	authentic := authenticLine(signers, trustedSessionKeys, trustedKeys, structural)
 	chain := structural
+	var authentic Line
 	if len(trustedSessionKeys) > 0 {
 		chain = receipt.VerifyChainTrusted(receipts, trustedSessionKeys)
 		authentic = authenticLineFromTrustedResult(chain, trustedSessionKeys, trustedKeys, uint64(len(receipts)))
+	} else {
+		authentic = unverifiedAuthenticLine(signers, structural)
 	}
 
 	anchoredState, anchoredChip, anchoredDetail, anchoredSub := anchorState(sessionID)
@@ -113,11 +115,7 @@ func absentScorecard() Scorecard {
 	}
 }
 
-func authenticLine(signers, trustedSessionKeys []string, trustedKeys map[string]TrustedKey, chain receipt.ChainResult) Line {
-	if len(trustedSessionKeys) > 0 {
-		return authenticLineFromTrustedResult(chain, trustedSessionKeys, trustedKeys, chain.ReceiptCount)
-	}
-
+func unverifiedAuthenticLine(signers []string, chain receipt.ChainResult) Line {
 	detail := fmt.Sprintf(
 		"Signer key %s is not in the trusted-key set; signatures are well-formed but UNTRUSTED.",
 		formatKeyList(signers),
@@ -206,28 +204,12 @@ func untamperedLine(chain receipt.ChainResult, receiptCount int) Line {
 }
 
 func anchorState(_ string) (state, chip, detail, sub string) {
-	const (
-		externalAnchor = "external"
-		localAnchor    = "local"
-		noAnchor       = "none"
-	)
-	switch noAnchor {
-	case externalAnchor:
-		return StateVerify,
-			"Externally anchored",
-			"External inclusion proof recorded; ordering is backed by an external anchor.",
-			"External proof details were verified for this session."
-	case localAnchor:
-		return StateWarn,
-			"Local anchor",
-			"Local inclusion proof recorded, but no external anchor was available.",
-			"Ordering rests on local evidence and the hash chain."
-	default:
-		return StateWarn,
-			chipNotAnchored,
-			"no inclusion proof - local or external - was recorded; ordering rests on the hash chain alone.",
-			"Add an external inclusion proof before treating ordering as independently anchored."
-	}
+	// MVP always reports not-anchored. TODO: wire real external/local inclusion-proof detection and return
+	// the external/local states here; keep the chip derived from the state so it cannot misreport.
+	return StateWarn,
+		chipNotAnchored,
+		"no inclusion proof - local or external - was recorded; ordering rests on the hash chain alone.",
+		"Add an external inclusion proof before treating ordering as independently anchored."
 }
 
 func completenessLine(chain receipt.ChainResult, receipts []receipt.Receipt) Line {

--- a/enterprise/dashboard/scorecard.go
+++ b/enterprise/dashboard/scorecard.go
@@ -1,0 +1,376 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+const (
+	StateVerify  = "verify"
+	StateWarn    = "warn"
+	StateFail    = "fail"
+	StateLimited = "limited"
+
+	chipAbsent           = "ABSENT"
+	chipChainBroken      = "Chain broken"
+	chipChainIntact      = "Chain intact"
+	chipNotAnchored      = "Not anchored"
+	chipPartial          = "Partial"
+	chipSignaturesVerify = "Signatures verify"
+	chipUnverified       = "Unverified"
+)
+
+// TrustedKey describes why a signer key is trusted by the operator.
+type TrustedKey struct {
+	Source string
+}
+
+// Line is one independently evaluated scorecard fact. There is intentionally
+// no aggregate status: every line must be read on its own.
+type Line struct {
+	State  string
+	Chip   string
+	Detail string
+	Sub    string
+}
+
+// Scorecard reports the four honest evidence facts shown to operators.
+type Scorecard struct {
+	Authentic    Line
+	Untampered   Line
+	Anchored     Line
+	Completeness Line
+}
+
+type scorecardResult struct {
+	Scorecard Scorecard
+	Chain     receipt.ChainResult
+}
+
+func computeScorecard(receipts []receipt.Receipt, trustedKeys map[string]TrustedKey, sessionID string) scorecardResult {
+	if len(receipts) == 0 {
+		return scorecardResult{
+			Scorecard: absentScorecard(),
+			Chain:     receipt.ChainResult{Valid: false, Error: "no receipts"},
+		}
+	}
+
+	signers := signerKeys(receipts)
+	structural := receipt.VerifyChainTrusted(receipts, signers)
+	trustedSessionKeys := trustedKeysForSession(signers, trustedKeys)
+
+	authentic := authenticLine(signers, trustedSessionKeys, trustedKeys, structural)
+	chain := structural
+	if len(trustedSessionKeys) > 0 {
+		chain = receipt.VerifyChainTrusted(receipts, trustedSessionKeys)
+		authentic = authenticLineFromTrustedResult(chain, trustedSessionKeys, trustedKeys, uint64(len(receipts)))
+	}
+
+	anchoredState, anchoredChip, anchoredDetail, anchoredSub := anchorState(sessionID)
+	return scorecardResult{
+		Scorecard: Scorecard{
+			Authentic:    authentic,
+			Untampered:   untamperedLine(chain, len(receipts)),
+			Anchored:     Line{State: anchoredState, Chip: anchoredChip, Detail: anchoredDetail, Sub: anchoredSub},
+			Completeness: completenessLine(chain, receipts),
+		},
+		Chain: chain,
+	}
+}
+
+func absentScorecard() Scorecard {
+	return Scorecard{
+		Authentic: Line{
+			State:  StateFail,
+			Chip:   chipAbsent,
+			Detail: "No receipts were recorded, so there are no signatures to authenticate.",
+			Sub:    "Enable receipts before treating this agent's decisions as independently evidenced.",
+		},
+		Untampered: Line{
+			State:  StateFail,
+			Chip:   chipAbsent,
+			Detail: "No hash chain exists for this session.",
+			Sub:    "Absence is a red evidence state, not a successful verification.",
+		},
+		Anchored: Line{
+			State:  StateWarn,
+			Chip:   chipAbsent,
+			Detail: "No inclusion proof - local or external - was recorded.",
+			Sub:    "Ordering cannot be established without receipts.",
+		},
+		Completeness: Line{
+			State:  StateLimited,
+			Chip:   chipAbsent,
+			Detail: "0 receipts, 0 chain gaps. Covers no mediated egress decisions.",
+			Sub:    "Cannot prove that no unmediated action occurred outside the boundary.",
+		},
+	}
+}
+
+func authenticLine(signers, trustedSessionKeys []string, trustedKeys map[string]TrustedKey, chain receipt.ChainResult) Line {
+	if len(trustedSessionKeys) > 0 {
+		return authenticLineFromTrustedResult(chain, trustedSessionKeys, trustedKeys, chain.ReceiptCount)
+	}
+
+	detail := fmt.Sprintf(
+		"Signer key %s is not in the trusted-key set; signatures are well-formed but UNTRUSTED.",
+		formatKeyList(signers),
+	)
+	if !chain.Valid {
+		detail = fmt.Sprintf(
+			"Signer key %s is not in the trusted-key set, and the chain could not be structurally verified: %s.",
+			formatKeyList(signers),
+			chain.Error,
+		)
+	}
+	return Line{
+		State:  StateWarn,
+		Chip:   chipUnverified,
+		Detail: detail,
+		Sub:    "Import the signer key from an operator-controlled source to upgrade this line.",
+	}
+}
+
+func authenticLineFromTrustedResult(chain receipt.ChainResult, trustedSessionKeys []string, trustedKeys map[string]TrustedKey, receiptCount uint64) Line {
+	if chain.UntrustedSignerKey != "" {
+		return Line{
+			State: StateWarn,
+			Chip:  chipUnverified,
+			Detail: fmt.Sprintf(
+				"Signer key %s is not in the trusted-key set; signatures may be well-formed but are UNTRUSTED.",
+				fingerprint(chain.UntrustedSignerKey),
+			),
+			Sub: "Import the key only after confirming it came from an operator-controlled source.",
+		}
+	}
+	if !chain.Valid {
+		return Line{
+			State:  StateFail,
+			Chip:   "Signature check failed",
+			Detail: fmt.Sprintf("Trusted-key verification failed: %s.", chain.Error),
+			Sub:    "Treat this evidence as broken until the receipt chain is investigated.",
+		}
+	}
+
+	keyText := formatKeyList(trustedSessionKeys)
+	source := provenanceText(trustedSessionKeys, trustedKeys)
+	if chain.ReceiptCount > 0 {
+		receiptCount = chain.ReceiptCount
+	}
+	return Line{
+		State: StateVerify,
+		Chip:  chipSignaturesVerify,
+		Detail: fmt.Sprintf(
+			"%d/%d signatures verify against trusted key %s - source: %s.",
+			receiptCount,
+			receiptCount,
+			keyText,
+			source,
+		),
+		Sub: "Signer trust came from configured operator provenance, not trust-on-first-use.",
+	}
+}
+
+func untamperedLine(chain receipt.ChainResult, receiptCount int) Line {
+	if chain.Valid && chain.BrokenAtSeq == 0 {
+		finalSeq := chain.FinalSeq
+		if receiptCount == 0 {
+			finalSeq = 0
+		}
+		return Line{
+			State:  StateVerify,
+			Chip:   chipChainIntact,
+			Detail: fmt.Sprintf("hash chain intact; sequence contiguous 0-%d.", finalSeq),
+			Sub:    "Every receipt links to the previous receipt hash.",
+		}
+	}
+
+	return Line{
+		State: StateFail,
+		Chip:  chipChainBroken,
+		Detail: fmt.Sprintf(
+			"BROKEN at seq %d - this receipt and later receipts are unverifiable.",
+			chain.BrokenAtSeq,
+		),
+		Sub: emptyToDefault(
+			chain.Error,
+			"Hash or signature continuity failed.",
+		),
+	}
+}
+
+func anchorState(_ string) (state, chip, detail, sub string) {
+	const (
+		externalAnchor = "external"
+		localAnchor    = "local"
+		noAnchor       = "none"
+	)
+	switch noAnchor {
+	case externalAnchor:
+		return StateVerify,
+			"Externally anchored",
+			"External inclusion proof recorded; ordering is backed by an external anchor.",
+			"External proof details were verified for this session."
+	case localAnchor:
+		return StateWarn,
+			"Local anchor",
+			"Local inclusion proof recorded, but no external anchor was available.",
+			"Ordering rests on local evidence and the hash chain."
+	default:
+		return StateWarn,
+			chipNotAnchored,
+			"no inclusion proof - local or external - was recorded; ordering rests on the hash chain alone.",
+			"Add an external inclusion proof before treating ordering as independently anchored."
+	}
+}
+
+func completenessLine(chain receipt.ChainResult, receipts []receipt.Receipt) Line {
+	receiptCount := len(receipts)
+	gaps := 0
+	detail := fmt.Sprintf(
+		"%d receipts, %d chain gaps. Covers mediated egress inside the declared Pipelock boundary.",
+		receiptCount,
+		gaps,
+	)
+	if !chain.Valid || chain.BrokenAtSeq != 0 {
+		gaps = 1
+		lost := receiptsAtOrAfterBreak(receipts, chain.BrokenAtIndex)
+		verifiable := receiptCount - lost
+		detail = fmt.Sprintf(
+			"%d of %d receipts verifiable; %d lost to the break. %d receipts, %d chain gaps. Covers mediated egress inside the declared Pipelock boundary.",
+			verifiable,
+			receiptCount,
+			lost,
+			receiptCount,
+			gaps,
+		)
+	}
+	return Line{
+		State:  StateLimited,
+		Chip:   "Boundary-limited",
+		Detail: detail,
+		Sub:    "Cannot prove that no unmediated action occurred outside the boundary.",
+	}
+}
+
+func readLimitedScorecard(loadedReceipts, readLimit int) Scorecard {
+	limitDetail := fmt.Sprintf(
+		"Dashboard read ceiling reached after %d recorder entries; this page did not load the complete session.",
+		readLimit,
+	)
+	return Scorecard{
+		Authentic: Line{
+			State:  StateLimited,
+			Chip:   chipPartial,
+			Detail: fmt.Sprintf("Loaded %d receipts, but the dashboard did not authenticate the complete session. %s", loadedReceipts, limitDetail),
+			Sub:    "Run the offline verifier before relying on authenticity for this session.",
+		},
+		Untampered: Line{
+			State:  StateLimited,
+			Chip:   "Prefix only",
+			Detail: fmt.Sprintf("Loaded %d receipts before the dashboard ceiling. Later receipts may exist and were not chain-verified here.", loadedReceipts),
+			Sub:    "The online view is intentionally bounded to avoid unbounded memory and CPU use.",
+		},
+		Anchored: Line{
+			State:  StateWarn,
+			Chip:   chipNotAnchored,
+			Detail: "No complete-session inclusion proof was verified in this bounded dashboard view.",
+			Sub:    "Use a signed bundle and external proof for complete ordering evidence.",
+		},
+		Completeness: Line{
+			State:  StateLimited,
+			Chip:   "Boundary-limited",
+			Detail: fmt.Sprintf("%d receipts loaded before the dashboard read ceiling. Covers only the loaded prefix of mediated egress.", loadedReceipts),
+			Sub:    "Cannot prove that no unmediated action occurred outside the boundary, or that no later mediated receipt exists.",
+		},
+	}
+}
+
+func receiptsAtOrAfterBreak(receipts []receipt.Receipt, brokenAtIndex int) int {
+	if len(receipts) == 0 {
+		return 0
+	}
+	if brokenAtIndex < 0 || brokenAtIndex >= len(receipts) {
+		return len(receipts)
+	}
+	return len(receipts) - brokenAtIndex
+}
+
+func signerKeys(receipts []receipt.Receipt) []string {
+	keys := make([]string, 0, len(receipts))
+	seen := make(map[string]struct{}, len(receipts))
+	for _, r := range receipts {
+		key := strings.TrimSpace(r.SignerKey)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func trustedKeysForSession(signers []string, trustedKeys map[string]TrustedKey) []string {
+	if len(trustedKeys) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(signers))
+	for _, signer := range signers {
+		if _, ok := trustedKeys[signer]; ok {
+			keys = append(keys, signer)
+		}
+	}
+	return keys
+}
+
+func provenanceText(keys []string, trustedKeys map[string]TrustedKey) string {
+	sources := make([]string, 0, len(keys))
+	seen := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		source := trustedKeys[key].Source
+		if source == "" {
+			source = "configured trusted key"
+		}
+		if _, ok := seen[source]; ok {
+			continue
+		}
+		seen[source] = struct{}{}
+		sources = append(sources, source)
+	}
+	return strings.Join(sources, ", ")
+}
+
+func formatKeyList(keys []string) string {
+	if len(keys) == 0 {
+		return "none"
+	}
+	fps := make([]string, 0, len(keys))
+	for _, key := range keys {
+		fps = append(fps, fingerprint(key))
+	}
+	return strings.Join(fps, ", ")
+}
+
+func fingerprint(key string) string {
+	key = strings.TrimSpace(key)
+	if len(key) <= 12 {
+		return key
+	}
+	return key[:12]
+}
+
+func emptyToDefault(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/enterprise/dashboard/scorecard_test.go
+++ b/enterprise/dashboard/scorecard_test.go
@@ -181,6 +181,24 @@ func TestComputeScorecard_RotatedChainDoesNotTrustPresentKeysForAuthentic(t *tes
 	if partialTrust.Chain.UntrustedSignerKey != keyB {
 		t.Fatalf("UntrustedSignerKey = %q, want %q", partialTrust.Chain.UntrustedSignerKey, keyB)
 	}
+	if partialTrust.Chain.BrokenAtIndex != 2 {
+		t.Fatalf("BrokenAtIndex = %d, want 2", partialTrust.Chain.BrokenAtIndex)
+	}
+	if !strings.Contains(partialTrust.Scorecard.Completeness.Detail, "2 of 4 receipts verifiable; 2 lost") {
+		t.Fatalf("Completeness.Detail = %q, want trusted-key break to count receipts at/after broken index lost", partialTrust.Scorecard.Completeness.Detail)
+	}
+
+	evidence := sessionEvidence(testSessionID, chain, map[string]TrustedKey{
+		keyA: {Source: trustedKeySource},
+	}, false, dashboardReceiptReadLimit, dashboardTimelineLimit)
+	if evidence.Chain.UntrustedSignerKey != keyB {
+		t.Fatalf("evidence UntrustedSignerKey = %q, want %q", evidence.Chain.UntrustedSignerKey, keyB)
+	}
+	for i, item := range evidence.Timeline {
+		if got, want := item.Unverifiable, i >= evidence.Chain.BrokenAtIndex; got != want {
+			t.Fatalf("timeline index %d seq %d Unverifiable = %t, want %t", i, item.Seq, got, want)
+		}
+	}
 }
 
 func TestComputeScorecard_ReadLimitedDowngradesGreenProofLines(t *testing.T) {

--- a/enterprise/dashboard/scorecard_test.go
+++ b/enterprise/dashboard/scorecard_test.go
@@ -1,0 +1,341 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+const (
+	testActor        = "agent-alpha"
+	testPolicyHash   = "policy-hash-test"
+	testPrincipal    = "operator"
+	testSessionID    = "session-alpha"
+	testTarget       = "https://example.com/evidence"
+	testTransport    = "fetch"
+	trustedKeySource = "operator-imported"
+)
+
+func TestComputeScorecard_NoTOFU(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	chain := buildDashboardChain(t, priv, 1)
+
+	score := computeScorecard(chain, nil, testSessionID).Scorecard
+	assertNotVerify(t, score.Authentic.State, "empty trusted key set")
+	if score.Authentic.State != StateWarn {
+		t.Fatalf("Authentic.State = %q, want %q", score.Authentic.State, StateWarn)
+	}
+	if !strings.Contains(score.Authentic.Detail, "UNTRUSTED") {
+		t.Fatalf("Authentic.Detail = %q, want UNTRUSTED", score.Authentic.Detail)
+	}
+
+	_, forgedPriv := generateDashboardKey(t)
+	forged := buildDashboardChain(t, forgedPriv, 1)
+	forgedScore := computeScorecard(forged, map[string]TrustedKey{}, testSessionID).Scorecard
+	assertNotVerify(t, forgedScore.Authentic.State, "different forged key with empty trusted key set")
+
+	trustedScore := computeScorecard(chain, map[string]TrustedKey{
+		keyHex: {Source: trustedKeySource},
+	}, testSessionID).Scorecard
+	if trustedScore.Authentic.State != StateVerify {
+		t.Fatalf("Authentic.State = %q, want %q; detail=%s", trustedScore.Authentic.State, StateVerify, trustedScore.Authentic.Detail)
+	}
+}
+
+func TestComputeScorecard_UntamperedBrokenChain(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	chain := buildDashboardChain(t, priv, 4)
+	chain[1].ActionRecord.Target = "https://evil.example/tampered"
+
+	evidence := sessionEvidence(testSessionID, chain, map[string]TrustedKey{
+		keyHex: {Source: trustedKeySource},
+	}, false, dashboardReceiptReadLimit, dashboardTimelineLimit)
+	if evidence.Scorecard.Untampered.State != StateFail {
+		t.Fatalf("Untampered.State = %q, want %q", evidence.Scorecard.Untampered.State, StateFail)
+	}
+	if evidence.Chain.BrokenAtSeq != 1 {
+		t.Fatalf("BrokenAtSeq = %d, want 1", evidence.Chain.BrokenAtSeq)
+	}
+
+	for _, item := range evidence.Timeline {
+		if item.Seq >= evidence.Chain.BrokenAtSeq && !item.Unverifiable {
+			t.Fatalf("seq %d should be marked unverifiable at or after break", item.Seq)
+		}
+	}
+}
+
+func TestComputeScorecard_BrokenReceiptIsNotCountedVerifiable(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	chain := buildDashboardChain(t, priv, 4)
+	chain[1].ActionRecord.Target = "https://evil.example/tampered"
+
+	score := computeScorecard(chain, map[string]TrustedKey{
+		keyHex: {Source: trustedKeySource},
+	}, testSessionID).Scorecard
+	if !strings.Contains(score.Completeness.Detail, "1 of 4 receipts verifiable; 3 lost") {
+		t.Fatalf("Completeness.Detail = %q, want broken receipt counted lost", score.Completeness.Detail)
+	}
+	if !strings.Contains(score.Untampered.Detail, "this receipt and later receipts are unverifiable") {
+		t.Fatalf("Untampered.Detail = %q, want at-and-after wording", score.Untampered.Detail)
+	}
+}
+
+func TestComputeScorecard_TimelineWindowUsesGlobalReceiptPosition(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	chain := buildDashboardChain(t, priv, 4)
+	chain[1].ActionRecord.Target = "https://evil.example/tampered"
+
+	evidence := sessionEvidence(testSessionID, chain, map[string]TrustedKey{
+		keyHex: {Source: trustedKeySource},
+	}, false, dashboardReceiptReadLimit, 1)
+	if evidence.TimelineWindow != "latest" {
+		t.Fatalf("TimelineWindow = %q, want latest", evidence.TimelineWindow)
+	}
+	if len(evidence.Timeline) != 1 {
+		t.Fatalf("len(Timeline) = %d, want 1", len(evidence.Timeline))
+	}
+	if !evidence.Timeline[0].Unverifiable {
+		t.Fatal("latest displayed receipt should be marked unverifiable after an earlier break")
+	}
+}
+
+func TestComputeScorecard_RotatedBreakUsesReceiptPositionNotSeq(t *testing.T) {
+	t.Parallel()
+
+	pubA, privA := generateDashboardKey(t)
+	keyA := hex.EncodeToString(pubA)
+	pubB, privB := generateDashboardKey(t)
+	keyB := hex.EncodeToString(pubB)
+	chain := buildRotatedDashboardChain(t, privA, privB)
+	chain[3].ActionRecord.Target = "https://evil.example/tampered-after-rotation"
+
+	evidence := sessionEvidence(testSessionID, chain, map[string]TrustedKey{
+		keyA: {Source: trustedKeySource},
+		keyB: {Source: trustedKeySource},
+	}, false, dashboardReceiptReadLimit, dashboardTimelineLimit)
+	if evidence.Chain.Valid {
+		t.Fatal("rotated tampered chain should fail verification")
+	}
+	if evidence.Chain.BrokenAtSeq != 1 {
+		t.Fatalf("BrokenAtSeq = %d, want reused rotated seq 1", evidence.Chain.BrokenAtSeq)
+	}
+	if evidence.Chain.BrokenAtIndex != 3 {
+		t.Fatalf("BrokenAtIndex = %d, want 3", evidence.Chain.BrokenAtIndex)
+	}
+	if !strings.Contains(evidence.Scorecard.Completeness.Detail, "3 of 4 receipts verifiable; 1 lost") {
+		t.Fatalf("Completeness.Detail = %q, want only receipts at/after broken index lost", evidence.Scorecard.Completeness.Detail)
+	}
+	for i, item := range evidence.Timeline {
+		if got, want := item.Unverifiable, i >= evidence.Chain.BrokenAtIndex; got != want {
+			t.Fatalf("timeline index %d seq %d Unverifiable = %t, want %t", i, item.Seq, got, want)
+		}
+	}
+}
+
+func TestComputeScorecard_RotatedChainDoesNotTrustPresentKeysForAuthentic(t *testing.T) {
+	t.Parallel()
+
+	pubA, privA := generateDashboardKey(t)
+	keyA := hex.EncodeToString(pubA)
+	pubB, privB := generateDashboardKey(t)
+	keyB := hex.EncodeToString(pubB)
+	chain := buildRotatedDashboardChain(t, privA, privB)
+
+	untrusted := computeScorecard(chain, nil, testSessionID)
+	if untrusted.Chain.Valid != true {
+		t.Fatalf("structural rotated chain Valid = false, want true: %s", untrusted.Chain.Error)
+	}
+	if untrusted.Scorecard.Untampered.State != StateVerify {
+		t.Fatalf("Untampered.State = %q, want %q", untrusted.Scorecard.Untampered.State, StateVerify)
+	}
+	assertNotVerify(t, untrusted.Scorecard.Authentic.State, "rotated chain with only present keys")
+
+	partialTrust := computeScorecard(chain, map[string]TrustedKey{
+		keyA: {Source: trustedKeySource},
+	}, testSessionID)
+	if partialTrust.Scorecard.Authentic.State == StateVerify {
+		t.Fatal("Authentic returned verify when the rotated segment key was not trusted")
+	}
+	if partialTrust.Chain.UntrustedSignerKey != keyB {
+		t.Fatalf("UntrustedSignerKey = %q, want %q", partialTrust.Chain.UntrustedSignerKey, keyB)
+	}
+}
+
+func TestComputeScorecard_ReadLimitedDowngradesGreenProofLines(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	chain := buildDashboardChain(t, priv, 2)
+
+	evidence := sessionEvidence(testSessionID, chain, map[string]TrustedKey{
+		keyHex: {Source: trustedKeySource},
+	}, true, 1, dashboardTimelineLimit)
+	if !evidence.ReadLimited {
+		t.Fatal("evidence should be marked read-limited")
+	}
+	if evidence.Scorecard.Authentic.State != StateLimited {
+		t.Fatalf("Authentic.State = %q, want %q", evidence.Scorecard.Authentic.State, StateLimited)
+	}
+	if evidence.Scorecard.Untampered.State != StateLimited {
+		t.Fatalf("Untampered.State = %q, want %q", evidence.Scorecard.Untampered.State, StateLimited)
+	}
+	if strings.Contains(evidence.Scorecard.Authentic.Chip, chipSignaturesVerify) {
+		t.Fatalf("Authentic.Chip = %q, must not claim full signature verification", evidence.Scorecard.Authentic.Chip)
+	}
+}
+
+func TestComputeScorecard_CompletenessAndAnchoredNeverGreen(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	scenarios := map[string][]receipt.Receipt{
+		"trusted":   buildDashboardChain(t, priv, 2),
+		"untrusted": buildDashboardChain(t, priv, 1),
+		"absent":    nil,
+	}
+	for name, receipts := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			trusted := map[string]TrustedKey{}
+			if name == "trusted" {
+				trusted[keyHex] = TrustedKey{Source: trustedKeySource}
+			}
+			score := computeScorecard(receipts, trusted, testSessionID).Scorecard
+			if score.Completeness.State != StateLimited {
+				t.Fatalf("Completeness.State = %q, want %q", score.Completeness.State, StateLimited)
+			}
+			if score.Anchored.State == StateVerify {
+				t.Fatalf("Anchored.State = %q, MVP must never return green", score.Anchored.State)
+			}
+			if name != "absent" && score.Anchored.Chip != chipNotAnchored {
+				t.Fatalf("Anchored.Chip = %q, want %q", score.Anchored.Chip, chipNotAnchored)
+			}
+		})
+	}
+}
+
+func generateDashboardKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+func buildDashboardChain(t *testing.T, priv ed25519.PrivateKey, count int) []receipt.Receipt {
+	t.Helper()
+	chain := make([]receipt.Receipt, 0, count)
+	prevHash := receipt.GenesisHash
+	base := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+
+	for i := range count {
+		r := signDashboardReceipt(t, priv, uint64(i), prevHash, base.Add(time.Duration(i)*time.Second))
+		hash, err := receipt.ReceiptHash(r)
+		if err != nil {
+			t.Fatalf("ReceiptHash: %v", err)
+		}
+		chain = append(chain, r)
+		prevHash = hash
+	}
+	return chain
+}
+
+func buildRotatedDashboardChain(t *testing.T, privA, privB ed25519.PrivateKey) []receipt.Receipt {
+	t.Helper()
+	base := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	chain := buildDashboardChain(t, privA, 2)
+	priorTail := chain[len(chain)-1]
+	priorHash, err := receipt.ReceiptHash(priorTail)
+	if err != nil {
+		t.Fatalf("ReceiptHash prior tail: %v", err)
+	}
+
+	ar := validDashboardAction(0, priorHash, base.Add(2*time.Second))
+	ar.KeyTransition = &receipt.KeyTransition{
+		PriorSignerKey: priorTail.SignerKey,
+		PriorChainSeq:  priorTail.ActionRecord.ChainSeq,
+		PriorChainHash: priorHash,
+	}
+	rotatedGenesis, err := receipt.Sign(ar, privB)
+	if err != nil {
+		t.Fatalf("Sign rotated genesis: %v", err)
+	}
+	rotatedHash, err := receipt.ReceiptHash(rotatedGenesis)
+	if err != nil {
+		t.Fatalf("ReceiptHash rotated genesis: %v", err)
+	}
+	chain = append(chain, rotatedGenesis)
+	chain = append(chain, signDashboardReceipt(t, privB, 1, rotatedHash, base.Add(3*time.Second)))
+	return chain
+}
+
+func signDashboardReceipt(
+	t *testing.T,
+	priv ed25519.PrivateKey,
+	seq uint64,
+	prevHash string,
+	ts time.Time,
+) receipt.Receipt {
+	t.Helper()
+	ar := validDashboardAction(seq, prevHash, ts)
+	r, err := receipt.Sign(ar, priv)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	return r
+}
+
+func validDashboardAction(seq uint64, prevHash string, ts time.Time) receipt.ActionRecord {
+	return receipt.ActionRecord{
+		Version:         receipt.ActionRecordVersion,
+		ActionID:        receipt.NewActionID(),
+		ActionType:      receipt.ActionRead,
+		Timestamp:       ts,
+		Principal:       testPrincipal,
+		Actor:           testActor,
+		Target:          testTarget,
+		SideEffectClass: receipt.SideEffectExternalRead,
+		Reversibility:   receipt.ReversibilityFull,
+		PolicyHash:      testPolicyHash,
+		Verdict:         "allow",
+		SessionID:       testSessionID,
+		Transport:       testTransport,
+		Method:          http.MethodGet,
+		Layer:           "allowlist",
+		Pattern:         "example.com",
+		ChainPrevHash:   prevHash,
+		ChainSeq:        seq,
+	}
+}
+
+func assertNotVerify(t *testing.T, got, name string) {
+	t.Helper()
+	if got == StateVerify {
+		t.Fatalf("%s returned %q for an unknown signer", name, StateVerify)
+	}
+}

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -42,14 +42,15 @@ func ReceiptHash(r Receipt) (string, error) {
 
 // ChainResult describes the outcome of chain verification.
 type ChainResult struct {
-	Valid        bool
-	ReceiptCount uint64
-	FinalSeq     uint64
-	RootHash     string
-	StartTime    time.Time
-	EndTime      time.Time
-	Error        string // empty if valid
-	BrokenAtSeq  uint64 // set when chain breaks
+	Valid         bool
+	ReceiptCount  uint64
+	FinalSeq      uint64
+	RootHash      string
+	StartTime     time.Time
+	EndTime       time.Time
+	Error         string // empty if valid
+	BrokenAtSeq   uint64 // set when chain breaks
+	BrokenAtIndex int    // zero-based receipt index where chain verification failed
 
 	// SignerKeys is the ordered, de-duplicated set of signer public keys
 	// (hex) observed across the chain's segments, in segment order. A
@@ -139,9 +140,10 @@ func VerifyChainTrusted(receipts []Receipt, trustedKeys []string) ChainResult {
 	normalizedKeys, err := normalizeTrustedKeys(trustedKeys)
 	if err != nil {
 		return ChainResult{
-			Valid:       false,
-			BrokenAtSeq: receipts[0].ActionRecord.ChainSeq,
-			Error:       fmt.Sprintf("seq %d: trusted key set: %v", receipts[0].ActionRecord.ChainSeq, err),
+			Valid:         false,
+			BrokenAtSeq:   receipts[0].ActionRecord.ChainSeq,
+			BrokenAtIndex: 0,
+			Error:         fmt.Sprintf("seq %d: trusted key set: %v", receipts[0].ActionRecord.ChainSeq, err),
 		}
 	}
 
@@ -181,10 +183,12 @@ type chainVerifier struct {
 	signerKeys []string
 	segments   []ChainSegment
 	curSeg     *ChainSegment
+	index      int
 }
 
 func (v *chainVerifier) run(receipts []Receipt) ChainResult {
 	for i := range receipts {
+		v.index = i
 		r := receipts[i]
 		marker := r.ActionRecord.KeyTransition
 
@@ -379,10 +383,11 @@ func (v *chainVerifier) appendSignerKey(key string) {
 
 func (v *chainVerifier) brokenAt(r Receipt, msg string) ChainResult {
 	return ChainResult{
-		Valid:       false,
-		BrokenAtSeq: r.ActionRecord.ChainSeq,
-		Error:       fmt.Sprintf("seq %d: %s", r.ActionRecord.ChainSeq, msg),
-		SignerKeys:  v.signerKeys,
+		Valid:         false,
+		BrokenAtSeq:   r.ActionRecord.ChainSeq,
+		BrokenAtIndex: v.index,
+		Error:         fmt.Sprintf("seq %d: %s", r.ActionRecord.ChainSeq, msg),
+		SignerKeys:    v.signerKeys,
 	}
 }
 
@@ -454,13 +459,23 @@ func ExtractReceiptsWithSessionID(path string) ([]Receipt, string, error) {
 // ExtractReceiptsFromSessionDir reads all evidence files for a session from a
 // recorder directory and returns the action receipts in chain order.
 func ExtractReceiptsFromSessionDir(dir, sessionID string) ([]Receipt, error) {
+	receipts, _, err := ExtractReceiptsFromSessionDirBounded(dir, sessionID, 0)
+	return receipts, err
+}
+
+// ExtractReceiptsFromSessionDirBounded reads action receipts for a session with
+// an optional hard ceiling on parsed recorder entries. The returned boolean is
+// true when the ceiling was reached before the full session was loaded.
+func ExtractReceiptsFromSessionDirBounded(dir, sessionID string, maxEntriesRead int) ([]Receipt, bool, error) {
 	result, err := recorder.QuerySession(filepath.Clean(dir), sessionID, &recorder.QueryFilter{
-		Type: recorderEntryType,
+		Type:           recorderEntryType,
+		MaxEntriesRead: maxEntriesRead,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("querying session receipts: %w", err)
+		return nil, false, fmt.Errorf("querying session receipts: %w", err)
 	}
-	return extractReceiptsFromEntries(result.Entries)
+	receipts, err := extractReceiptsFromEntries(result.Entries)
+	return receipts, result.Truncated, err
 }
 
 func extractReceiptsFromEntries(entries []recorder.Entry) ([]Receipt, error) {

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -238,22 +238,32 @@ func VerifyCheckpoints(entries []Entry, pubKey ed25519.PublicKey) error {
 // ReadEntries reads and parses JSONL evidence entries from a file.
 // Accepts the versions in acceptedEntryVersions; rejects unknown versions.
 func ReadEntries(path string) ([]Entry, error) {
+	entries, _, err := readEntries(path, 0)
+	return entries, err
+}
+
+func readEntries(path string, maxEntries int) ([]Entry, bool, error) {
 	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
-		return nil, fmt.Errorf("opening evidence file: %w", err)
+		return nil, false, fmt.Errorf("opening evidence file: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
-	entries, err := ReadEntriesFromReader(f)
+	entries, truncated, err := readEntriesFromReader(f, maxEntries)
 	if err != nil {
-		return nil, fmt.Errorf("reading evidence file: %w", err)
+		return nil, false, fmt.Errorf("reading evidence file: %w", err)
 	}
-	return entries, nil
+	return entries, truncated, nil
 }
 
 // ReadEntriesFromReader reads and parses JSONL evidence entries from r.
 // It applies the same duplicate-key and version fences as ReadEntries.
 func ReadEntriesFromReader(r io.Reader) ([]Entry, error) {
+	entries, _, err := readEntriesFromReader(r, 0)
+	return entries, err
+}
+
+func readEntriesFromReader(r io.Reader, maxEntries int) ([]Entry, bool, error) {
 	var entries []Entry
 	sc := bufio.NewScanner(r)
 
@@ -263,6 +273,10 @@ func ReadEntriesFromReader(r io.Reader) ([]Entry, error) {
 
 	lineNum := 0
 	for sc.Scan() {
+		if maxEntries > 0 && len(entries) >= maxEntries {
+			return entries, true, nil
+		}
+
 		lineNum++
 		line := strings.TrimSpace(sc.Text())
 		if line == "" {
@@ -273,20 +287,20 @@ func ReadEntriesFromReader(r io.Reader) ([]Entry, error) {
 		// last-wins (a parser-differential smuggling vector); shared with the
 		// receipt verify path via internal/jsonscan.
 		if err := jsonscan.RejectDuplicateKeys([]byte(line)); err != nil {
-			return nil, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
+			return nil, false, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
 		}
 
 		var e Entry
 		if err := json.Unmarshal([]byte(line), &e); err != nil {
-			return nil, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
+			return nil, false, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
 		}
 		if !acceptedEntryVersions[e.Version] {
-			return nil, fmt.Errorf("line %d: unsupported entry version %d (accepted: 1, 2)", lineNum, e.Version)
+			return nil, false, fmt.Errorf("line %d: unsupported entry version %d (accepted: 1, 2)", lineNum, e.Version)
 		}
 		entries = append(entries, e)
 	}
 	if err := sc.Err(); err != nil {
-		return nil, fmt.Errorf("scanning evidence entries: %w", err)
+		return nil, false, fmt.Errorf("scanning evidence entries: %w", err)
 	}
-	return entries, nil
+	return entries, false, nil
 }

--- a/internal/recorder/query.go
+++ b/internal/recorder/query.go
@@ -136,32 +136,36 @@ func ListSessions(dir string) ([]string, error) {
 }
 
 func evidenceFileSessionID(name string) (string, bool) {
+	sessionID, _, ok := parseEvidenceFilename(name)
+	return sessionID, ok
+}
+
+func parseEvidenceFilename(name string) (sessionID string, seqStart int, ok bool) {
+	name = filepath.Base(name)
 	if !strings.HasPrefix(name, "evidence-") || !strings.HasSuffix(name, ".jsonl") {
-		return "", false
+		return "", 0, false
 	}
 	rest := strings.TrimPrefix(name, "evidence-")
 	rest = strings.TrimSuffix(rest, ".jsonl")
 	lastDash := strings.LastIndex(rest, "-")
 	if lastDash < 0 {
-		return "", false
+		return "", 0, false
 	}
-	return rest[:lastDash], true
+	n, err := strconv.Atoi(rest[lastDash+1:])
+	if err != nil {
+		n = 0
+	}
+	return rest[:lastDash], n, true
 }
 
 // extractSeqStart parses the numeric seqStart from an evidence filename.
 // Returns 0 if the filename cannot be parsed.
 func extractSeqStart(path string) int {
-	name := filepath.Base(path)
-	name = strings.TrimSuffix(name, ".jsonl")
-	lastDash := strings.LastIndex(name, "-")
-	if lastDash < 0 {
+	_, seqStart, ok := parseEvidenceFilename(path)
+	if !ok {
 		return 0
 	}
-	n, err := strconv.Atoi(name[lastDash+1:])
-	if err != nil {
-		return 0
-	}
-	return n
+	return seqStart
 }
 
 // matchesFilter checks if an entry matches the given filter criteria.

--- a/internal/recorder/query.go
+++ b/internal/recorder/query.go
@@ -23,13 +23,19 @@ type QueryFilter struct {
 	MinSeq    uint64
 	MaxSeq    uint64
 	HasMaxSeq bool // Distinguishes MaxSeq=0 from unset
+
+	// MaxEntriesRead is a hard ceiling on parsed recorder entries for callers
+	// that render evidence in an online UI. Zero means unbounded.
+	MaxEntriesRead int
 }
 
 // QueryResult holds the results of an evidence query.
 type QueryResult struct {
-	Entries    []Entry
-	TotalFiles int
-	FilesRead  int
+	Entries     []Entry
+	TotalFiles  int
+	FilesRead   int
+	EntriesRead int
+	Truncated   bool
 }
 
 // QuerySession reads evidence files for a session and applies filters.
@@ -40,14 +46,14 @@ func QuerySession(dir, sessionID string, filter *QueryFilter) (*QueryResult, err
 		return nil, fmt.Errorf("reading evidence directory: %w", err)
 	}
 
-	prefix := "evidence-" + sessionID + "-"
 	var files []string
 	for _, de := range dirEntries {
 		if de.IsDir() {
 			continue
 		}
 		name := de.Name()
-		if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, ".jsonl") {
+		fileSessionID, ok := evidenceFileSessionID(name)
+		if ok && fileSessionID == sessionID {
 			files = append(files, filepath.Join(dir, name))
 		}
 	}
@@ -61,16 +67,37 @@ func QuerySession(dir, sessionID string, filter *QueryFilter) (*QueryResult, err
 	}
 
 	for _, f := range files {
-		entries, err := ReadEntries(f)
+		maxEntries := 0
+		if filter != nil && filter.MaxEntriesRead > 0 {
+			remaining := filter.MaxEntriesRead - result.EntriesRead
+			if remaining <= 0 {
+				result.Truncated = true
+				break
+			}
+			maxEntries = remaining
+		}
+
+		entries, truncated, err := readEntries(f, maxEntries)
 		if err != nil {
 			return nil, fmt.Errorf("reading %s: %w", filepath.Base(f), err)
 		}
 		result.FilesRead++
+		result.EntriesRead += len(entries)
+		if truncated {
+			result.Truncated = true
+		}
 
 		for _, e := range entries {
+			if e.SessionID != sessionID {
+				return nil, fmt.Errorf("reading %s: entry seq %d session_id %q does not match requested session %q", filepath.Base(f), e.Sequence, e.SessionID, sessionID)
+			}
 			if matchesFilter(e, filter) {
 				result.Entries = append(result.Entries, e)
 			}
+		}
+
+		if result.Truncated {
+			break
 		}
 	}
 
@@ -91,18 +118,10 @@ func ListSessions(dir string) ([]string, error) {
 			continue
 		}
 		name := de.Name()
-		if !strings.HasPrefix(name, "evidence-") || !strings.HasSuffix(name, ".jsonl") {
+		sessionID, ok := evidenceFileSessionID(name)
+		if !ok {
 			continue
 		}
-		// Parse session ID: evidence-<session_id>-<seq>.jsonl
-		rest := strings.TrimPrefix(name, "evidence-")
-		rest = strings.TrimSuffix(rest, ".jsonl")
-		// Find the last dash to separate session ID from seq number
-		lastDash := strings.LastIndex(rest, "-")
-		if lastDash < 0 {
-			continue
-		}
-		sessionID := rest[:lastDash]
 		if sessionID != "" {
 			seen[sessionID] = struct{}{}
 		}
@@ -114,6 +133,19 @@ func ListSessions(dir string) ([]string, error) {
 	}
 	sort.Strings(sessions)
 	return sessions, nil
+}
+
+func evidenceFileSessionID(name string) (string, bool) {
+	if !strings.HasPrefix(name, "evidence-") || !strings.HasSuffix(name, ".jsonl") {
+		return "", false
+	}
+	rest := strings.TrimPrefix(name, "evidence-")
+	rest = strings.TrimSuffix(rest, ".jsonl")
+	lastDash := strings.LastIndex(rest, "-")
+	if lastDash < 0 {
+		return "", false
+	}
+	return rest[:lastDash], true
 }
 
 // extractSeqStart parses the numeric seqStart from an evidence filename.

--- a/internal/recorder/query_test.go
+++ b/internal/recorder/query_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,6 +66,27 @@ func TestQuerySession_NoFilter(t *testing.T) {
 	}
 	if result.FilesRead != 1 {
 		t.Errorf("FilesRead = %d, want 1", result.FilesRead)
+	}
+}
+
+func TestQuerySession_MaxEntriesReadTruncates(t *testing.T) {
+	dir := t.TempDir()
+	writeTestEntries(t, dir, "sess-1", 5)
+
+	result, err := recorder.QuerySession(dir, "sess-1", &recorder.QueryFilter{
+		MaxEntriesRead: 2,
+	})
+	if err != nil {
+		t.Fatalf("QuerySession: %v", err)
+	}
+	if !result.Truncated {
+		t.Fatal("QuerySession should report truncation")
+	}
+	if result.EntriesRead != 2 {
+		t.Fatalf("EntriesRead = %d, want 2", result.EntriesRead)
+	}
+	if len(result.Entries) != 2 {
+		t.Fatalf("len(Entries) = %d, want 2", len(result.Entries))
 	}
 }
 
@@ -368,6 +390,63 @@ func TestQuerySession_FilterBySessionID(t *testing.T) {
 	}
 	if len(result.Entries) != 0 {
 		t.Errorf("expected 0 entries for mismatched session, got %d", len(result.Entries))
+	}
+}
+
+func TestQuerySession_DoesNotPrefixMatchSessionIDs(t *testing.T) {
+	dir := t.TempDir()
+	writeTestEntries(t, dir, "sess", 1)
+	writeTestEntries(t, dir, "sess-evil", 3)
+
+	result, err := recorder.QuerySession(dir, "sess", nil)
+	if err != nil {
+		t.Fatalf("QuerySession: %v", err)
+	}
+	if result.TotalFiles != 1 {
+		t.Fatalf("TotalFiles = %d, want 1", result.TotalFiles)
+	}
+	for _, e := range result.Entries {
+		if e.SessionID != "sess" {
+			t.Fatalf("returned entry for session %q, want sess", e.SessionID)
+		}
+	}
+
+	result, err = recorder.QuerySession(dir, "sess", &recorder.QueryFilter{MaxEntriesRead: 2})
+	if err != nil {
+		t.Fatalf("QuerySession with read ceiling: %v", err)
+	}
+	if result.TotalFiles != 1 {
+		t.Fatalf("bounded TotalFiles = %d, want 1", result.TotalFiles)
+	}
+}
+
+func TestQuerySession_FailsOnFilenameSessionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	e := recorder.Entry{
+		Version:   recorder.EntryVersion,
+		Sequence:  0,
+		Timestamp: time.Now().UTC(),
+		SessionID: "other",
+		Type:      testType,
+		Transport: testTransport,
+		Summary:   "mismatched session",
+		PrevHash:  recorder.GenesisHash,
+	}
+	e.Hash = recorder.ComputeHash(e)
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFile(filepath.Join(dir, "evidence-victim-0.jsonl"), append(data, '\n')); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = recorder.QuerySession(dir, "victim", nil)
+	if err == nil {
+		t.Fatal("expected session mismatch error")
+	}
+	if !strings.Contains(err.Error(), `session_id "other" does not match requested session "victim"`) {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/internal/recorder/query_test.go
+++ b/internal/recorder/query_test.go
@@ -110,6 +110,54 @@ func TestQuerySession_FilterByType(t *testing.T) {
 	}
 }
 
+func TestQuerySession_TypeFilterWithMaxEntriesRead(t *testing.T) {
+	dir := t.TempDir()
+	cfg := recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		Redact:             false,
+		CheckpointInterval: 1000,
+	}
+	rec, err := recorder.New(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	for i, entryType := range []string{"request", "action_receipt", "request", "action_receipt"} {
+		if err := rec.Record(recorder.Entry{
+			SessionID: "sess-1",
+			Type:      entryType,
+			Transport: testTransport,
+			Summary:   fmt.Sprintf("entry %d", i),
+		}); err != nil {
+			t.Fatalf("Record(%d): %v", i, err)
+		}
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	result, err := recorder.QuerySession(dir, "sess-1", &recorder.QueryFilter{
+		Type:           "action_receipt",
+		MaxEntriesRead: 3,
+	})
+	if err != nil {
+		t.Fatalf("QuerySession: %v", err)
+	}
+	if !result.Truncated {
+		t.Fatal("QuerySession should report truncation when MaxEntriesRead caps total entries read before filtering")
+	}
+	if result.EntriesRead != 3 {
+		t.Fatalf("EntriesRead = %d, want 3", result.EntriesRead)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("len(Entries) = %d, want 1 filtered receipt entry", len(result.Entries))
+	}
+	if result.Entries[0].Type != "action_receipt" || result.Entries[0].Sequence != 1 {
+		t.Fatalf("filtered entry = type %q seq %d, want action_receipt seq 1", result.Entries[0].Type, result.Entries[0].Sequence)
+	}
+}
+
 func TestQuerySession_FilterByTransport(t *testing.T) {
 	dir := t.TempDir()
 	writeTestEntries(t, dir, "sess-1", 6)


### PR DESCRIPTION
## What changed

Adds the first slice of the Pro/Enterprise operator dashboard: a license-gated, read-only web Evidence view, behind `//go:build enterprise` in a new `enterprise/dashboard` package. It reads signed decision-receipt chains from the flight recorder, verifies them, and renders a deliberately honest four-line scorecard.

## Behavior

- Honest evidence with no aggregate "all clear": the scorecard shows four independent facts (Authentic, Untampered, Anchored, Completeness) with no roll-up verdict. Authentic reports success only when the signer key is in the operator-configured trusted set (never trust-on-first-use), and an unknown signer reads as Unverified. Completeness is always boundary-limited. Anchored is never green without an external inclusion proof. A broken chain marks the failing receipt and everything after it as unverifiable. A session with no receipts renders a loud "no independent evidence" state rather than a clean one.
- Verify it yourself: the page surfaces the offline verifier command and the trusted-key fingerprint, because the dashboard is a lens, not the root of trust.
- Bounded for large sessions: recorder reads take an optional hard ceiling (`QueryFilter.MaxEntriesRead`, default unbounded so existing callers are unchanged), a read-limited session is downgraded to a partial prefix-only state rather than presented as complete, and the timeline is capped with an honest showing-N-of-M window.
- Fail-closed gate: without the `agents` feature the handler returns 403 with no evidence body, and both routes sit behind the gate. Responses set a strict Content-Security-Policy plus no-store, no-referrer, and nosniff. Attacker-controlled receipt fields render through `html/template` auto-escaping.

## Scope

Exposes `New(Options) http.Handler`. It is not yet wired into the CLI or the enterprise edition and license surface: that integration (command, listener isolation, license plumbing) is a separate change and gets its own review before the view is exposed at runtime. All detection and enforcement remain free and unchanged, this is a paid coordination lens only.

Branch: `feat/dashboard-evidence-mvp`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Enterprise Evidence dashboard with a sessions sidebar, scorecard, and receipt timeline, including expandable per-receipt details.
* **Bug Fixes**
  * Strengthened access control with feature gating and fail-closed authorization, plus added security-focused response headers for the dashboard.
  * Improved evidence read-limits with explicit truncation/read-limit messaging and safer rendering for hostile content.
  * Enhanced verification reporting by identifying the precise verification failure point for “unverifiable” states.
* **Tests**
  * Expanded coverage for dashboard rendering, feature/authorization gating, truncation behavior, session matching, and scoring scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->