### PR TITLE
feat(deferred): cascade-depth limit + pending-ancestor linkage for held MCP actions

### DIFF
--- a/cmd/pipelock-verifier/cascade_lint.go
+++ b/cmd/pipelock-verifier/cascade_lint.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/luckyPipewrench/pipelock/internal/deferred"
+	actionreceipt "github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+type cascadeAdmission struct {
+	index  int
+	policy deferred.ReceiptPolicy
+}
+
+func lintDeferredCascadeReceipts(receipts []actionreceipt.Receipt) error {
+	admissions := make(map[string]cascadeAdmission)
+	resolutionDepths := make(map[string]int)
+	for i, rcpt := range receipts {
+		ar := rcpt.ActionRecord
+		if ar.DeferID == "" {
+			continue
+		}
+		if ar.DecisionPhase == actionreceipt.DecisionPhaseDefer {
+			admissions[ar.DeferID] = cascadeAdmission{index: i, policy: parseReceiptPolicy(ar.ResolutionPolicy)}
+			continue
+		}
+		if ar.DecisionPhase != actionreceipt.DecisionPhaseResolution {
+			continue
+		}
+		policy, ok := parseReceiptPolicyCascade(ar.ResolutionPolicy)
+		if !ok {
+			continue
+		}
+		cascade := policy.Cascade
+		admission, found := admissions[ar.DeferID]
+		if !found {
+			return fmt.Errorf("defer cascade lint: resolution %q has cascade metadata but no earlier admission receipt", ar.DeferID)
+		}
+		if cascade.ParentDeferID != "" {
+			parentAdmission, parentFound := admissions[cascade.ParentDeferID]
+			if !parentFound || parentAdmission.index >= i {
+				return fmt.Errorf("defer cascade lint: resolution %q references missing earlier parent admission %q", ar.DeferID, cascade.ParentDeferID)
+			}
+			if parentDepth, parentResolved := resolutionDepths[cascade.ParentDeferID]; parentResolved && cascade.CascadeDepth != parentDepth+1 {
+				return fmt.Errorf("defer cascade lint: resolution %q depth %d does not equal parent %q depth %d + 1", ar.DeferID, cascade.CascadeDepth, cascade.ParentDeferID, parentDepth)
+			}
+		}
+		if admission.policy.Bounds.MaxCascadeDepth > 0 && cascade.CascadeDepth > admission.policy.Bounds.MaxCascadeDepth {
+			return fmt.Errorf("defer cascade lint: resolution %q depth %d exceeds admission max_cascade_depth %d", ar.DeferID, cascade.CascadeDepth, admission.policy.Bounds.MaxCascadeDepth)
+		}
+		resolutionDepths[ar.DeferID] = cascade.CascadeDepth
+	}
+	return nil
+}
+
+func parseReceiptPolicyCascade(raw string) (deferred.ReceiptPolicy, bool) {
+	policy := parseReceiptPolicy(raw)
+	return policy, policy.Cascade != nil
+}
+
+func parseReceiptPolicy(raw string) deferred.ReceiptPolicy {
+	var policy deferred.ReceiptPolicy
+	if raw == "" {
+		return policy
+	}
+	if err := json.Unmarshal([]byte(raw), &policy); err != nil {
+		return deferred.ReceiptPolicy{}
+	}
+	return policy
+}

--- a/cmd/pipelock-verifier/cascade_lint.go
+++ b/cmd/pipelock-verifier/cascade_lint.go
@@ -31,13 +31,20 @@ func lintDeferredCascadeReceipts(receipts []actionreceipt.Receipt) error {
 			continue
 		}
 		if ar.DecisionPhase == actionreceipt.DecisionPhaseDefer {
-			admissions[ar.DeferID] = cascadeAdmission{index: i, policy: parseReceiptPolicy(ar.ResolutionPolicy)}
+			policy, err := parseReceiptPolicy(ar.ResolutionPolicy)
+			if err != nil {
+				return fmt.Errorf("defer cascade lint: admission %q has malformed resolution policy: %w", ar.DeferID, err)
+			}
+			admissions[ar.DeferID] = cascadeAdmission{index: i, policy: policy}
 			continue
 		}
 		if ar.DecisionPhase != actionreceipt.DecisionPhaseResolution {
 			continue
 		}
-		policy, ok := parseReceiptPolicyCascade(ar.ResolutionPolicy)
+		policy, ok, err := parseReceiptPolicyCascade(ar.ResolutionPolicy)
+		if err != nil {
+			return fmt.Errorf("defer cascade lint: resolution %q has malformed resolution policy: %w", ar.DeferID, err)
+		}
 		if !ok {
 			continue
 		}
@@ -88,18 +95,23 @@ func lintDeferredCascadeReceipts(receipts []actionreceipt.Receipt) error {
 	return nil
 }
 
-func parseReceiptPolicyCascade(raw string) (deferred.ReceiptPolicy, bool) {
-	policy := parseReceiptPolicy(raw)
-	return policy, policy.Cascade != nil
+func parseReceiptPolicyCascade(raw string) (deferred.ReceiptPolicy, bool, error) {
+	policy, err := parseReceiptPolicy(raw)
+	if err != nil {
+		return deferred.ReceiptPolicy{}, false, err
+	}
+	return policy, policy.Cascade != nil, nil
 }
 
-func parseReceiptPolicy(raw string) deferred.ReceiptPolicy {
+// parseReceiptPolicy fails closed: a malformed policy string is a lint error,
+// never an empty policy, so bad receipts cannot bypass the cascade checks.
+func parseReceiptPolicy(raw string) (deferred.ReceiptPolicy, error) {
 	var policy deferred.ReceiptPolicy
 	if raw == "" {
-		return policy
+		return policy, nil
 	}
 	if err := json.Unmarshal([]byte(raw), &policy); err != nil {
-		return deferred.ReceiptPolicy{}
+		return deferred.ReceiptPolicy{}, err
 	}
-	return policy
+	return policy, nil
 }

--- a/cmd/pipelock-verifier/cascade_lint.go
+++ b/cmd/pipelock-verifier/cascade_lint.go
@@ -16,9 +16,15 @@ type cascadeAdmission struct {
 	policy deferred.ReceiptPolicy
 }
 
+type cascadeResolution struct {
+	index  int
+	depth  int
+	parent string
+}
+
 func lintDeferredCascadeReceipts(receipts []actionreceipt.Receipt) error {
 	admissions := make(map[string]cascadeAdmission)
-	resolutionDepths := make(map[string]int)
+	resolutions := make(map[string]cascadeResolution)
 	for i, rcpt := range receipts {
 		ar := rcpt.ActionRecord
 		if ar.DeferID == "" {
@@ -45,14 +51,39 @@ func lintDeferredCascadeReceipts(receipts []actionreceipt.Receipt) error {
 			if !parentFound || parentAdmission.index >= i {
 				return fmt.Errorf("defer cascade lint: resolution %q references missing earlier parent admission %q", ar.DeferID, cascade.ParentDeferID)
 			}
-			if parentDepth, parentResolved := resolutionDepths[cascade.ParentDeferID]; parentResolved && cascade.CascadeDepth != parentDepth+1 {
-				return fmt.Errorf("defer cascade lint: resolution %q depth %d does not equal parent %q depth %d + 1", ar.DeferID, cascade.CascadeDepth, cascade.ParentDeferID, parentDepth)
-			}
+		}
+		if cascade.CascadeDepth <= 0 {
+			return fmt.Errorf("defer cascade lint: resolution %q has invalid cascade depth %d", ar.DeferID, cascade.CascadeDepth)
+		}
+		if cascade.ParentDeferID == "" && cascade.CascadeDepth != 1 {
+			return fmt.Errorf("defer cascade lint: resolution %q root depth %d does not equal 1", ar.DeferID, cascade.CascadeDepth)
+		}
+		if cascade.Linkage != "" && cascade.Linkage != deferred.LinkageSessionPendingAncestor {
+			return fmt.Errorf("defer cascade lint: resolution %q has unsupported cascade linkage %q", ar.DeferID, cascade.Linkage)
 		}
 		if admission.policy.Bounds.MaxCascadeDepth > 0 && cascade.CascadeDepth > admission.policy.Bounds.MaxCascadeDepth {
 			return fmt.Errorf("defer cascade lint: resolution %q depth %d exceeds admission max_cascade_depth %d", ar.DeferID, cascade.CascadeDepth, admission.policy.Bounds.MaxCascadeDepth)
 		}
-		resolutionDepths[ar.DeferID] = cascade.CascadeDepth
+		if prior, exists := resolutions[ar.DeferID]; exists {
+			return fmt.Errorf("defer cascade lint: resolution %q has duplicate cascade resolution at receipts %d and %d", ar.DeferID, prior.index, i)
+		}
+		resolutions[ar.DeferID] = cascadeResolution{
+			index:  i,
+			depth:  cascade.CascadeDepth,
+			parent: cascade.ParentDeferID,
+		}
+	}
+	for deferID, resolution := range resolutions {
+		if resolution.parent == "" {
+			continue
+		}
+		parent, found := resolutions[resolution.parent]
+		if !found {
+			return fmt.Errorf("defer cascade lint: resolution %q references parent %q without a cascade resolution", deferID, resolution.parent)
+		}
+		if resolution.depth != parent.depth+1 {
+			return fmt.Errorf("defer cascade lint: resolution %q depth %d does not equal parent %q depth %d + 1", deferID, resolution.depth, resolution.parent, parent.depth)
+		}
 	}
 	return nil
 }

--- a/cmd/pipelock-verifier/cascade_lint_test.go
+++ b/cmd/pipelock-verifier/cascade_lint_test.go
@@ -129,6 +129,30 @@ func TestLintDeferredCascadeReceipts(t *testing.T) {
 			},
 			want: "no earlier admission receipt",
 		},
+		{
+			name: "malformed admission policy fails closed",
+			receipts: []receipt.Receipt{
+				{ActionRecord: receipt.ActionRecord{
+					DeferID:          "child",
+					DecisionPhase:    receipt.DecisionPhaseDefer,
+					ResolutionPolicy: "{not json",
+				}},
+				resolve("child", "", 1),
+			},
+			want: "malformed resolution policy",
+		},
+		{
+			name: "malformed resolution policy fails closed",
+			receipts: []receipt.Receipt{
+				admit("child"),
+				{ActionRecord: receipt.ActionRecord{
+					DeferID:          "child",
+					DecisionPhase:    receipt.DecisionPhaseResolution,
+					ResolutionPolicy: "{not json",
+				}},
+			},
+			want: "malformed resolution policy",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/pipelock-verifier/cascade_lint_test.go
+++ b/cmd/pipelock-verifier/cascade_lint_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/deferred"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+func TestLintDeferredCascadeReceipts(t *testing.T) {
+	bounds := deferred.ResolutionPolicy{
+		Timeout:              2 * time.Second,
+		MaxPending:           64,
+		MaxPendingPerSession: 8,
+		MaxPendingBytes:      1024 * 1024,
+		MaxCascadeDepth:      8,
+	}
+	admit := func(deferID string) receipt.Receipt {
+		return receipt.Receipt{ActionRecord: receipt.ActionRecord{
+			DeferID:          deferID,
+			DecisionPhase:    receipt.DecisionPhaseDefer,
+			ResolutionPolicy: deferred.ReceiptPolicyString(bounds, config.DeferResolutionPolicy{}),
+		}}
+	}
+	resolve := func(deferID, parentID string, depth int) receipt.Receipt {
+		return receipt.Receipt{ActionRecord: receipt.ActionRecord{
+			DeferID:       deferID,
+			DecisionPhase: receipt.DecisionPhaseResolution,
+			ResolutionPolicy: deferred.ReceiptPolicyStringFor(deferred.ReceiptPolicyOptions{
+				Bounds: bounds,
+				Cascade: &deferred.ReceiptCascade{
+					ParentDeferID: parentID,
+					CascadeDepth:  depth,
+					Linkage:       deferred.LinkageSessionPendingAncestor,
+				},
+			}),
+		}}
+	}
+
+	tests := []struct {
+		name     string
+		receipts []receipt.Receipt
+		want     string
+	}{
+		{
+			name:     "well formed cascade",
+			receipts: []receipt.Receipt{admit("parent"), admit("child"), resolve("parent", "", 1), resolve("child", "parent", 2)},
+		},
+		{
+			name:     "skip absent cascade",
+			receipts: []receipt.Receipt{{ActionRecord: receipt.ActionRecord{DeferID: "legacy", DecisionPhase: receipt.DecisionPhaseResolution}}},
+		},
+		{
+			name:     "missing parent admission",
+			receipts: []receipt.Receipt{admit("child"), resolve("child", "parent", 2)},
+			want:     "missing earlier parent admission",
+		},
+		{
+			name:     "depth mismatch",
+			receipts: []receipt.Receipt{admit("parent"), admit("child"), resolve("parent", "", 1), resolve("child", "parent", 3)},
+			want:     "does not equal parent",
+		},
+		{
+			name: "depth exceeds bound",
+			receipts: []receipt.Receipt{
+				{ActionRecord: receipt.ActionRecord{
+					DeferID:       "child",
+					DecisionPhase: receipt.DecisionPhaseDefer,
+					ResolutionPolicy: deferred.ReceiptPolicyString(deferred.ResolutionPolicy{
+						MaxCascadeDepth: 1,
+					}, config.DeferResolutionPolicy{}),
+				}},
+				resolve("child", "", 2),
+			},
+			want: "exceeds admission max_cascade_depth",
+		},
+		{
+			name: "missing own admission",
+			receipts: []receipt.Receipt{
+				resolve("child", "", 1),
+			},
+			want: "no earlier admission receipt",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := lintDeferredCascadeReceipts(tt.receipts)
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("lintDeferredCascadeReceipts() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("lintDeferredCascadeReceipts() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/pipelock-verifier/cascade_lint_test.go
+++ b/cmd/pipelock-verifier/cascade_lint_test.go
@@ -67,8 +67,49 @@ func TestLintDeferredCascadeReceipts(t *testing.T) {
 			want:     "does not equal parent",
 		},
 		{
+			name:     "child before parent depth mismatch",
+			receipts: []receipt.Receipt{admit("parent"), admit("child"), resolve("child", "parent", 3), resolve("parent", "", 1)},
+			want:     "does not equal parent",
+		},
+		{
+			name:     "missing parent resolution",
+			receipts: []receipt.Receipt{admit("parent"), admit("child"), resolve("child", "parent", 2)},
+			want:     "without a cascade resolution",
+		},
+		{
+			name:     "invalid zero depth",
+			receipts: []receipt.Receipt{admit("child"), resolve("child", "", 0)},
+			want:     "invalid cascade depth",
+		},
+		{
+			name:     "invalid root depth",
+			receipts: []receipt.Receipt{admit("child"), resolve("child", "", 2)},
+			want:     "root depth",
+		},
+		{
+			name: "unsupported linkage",
+			receipts: []receipt.Receipt{admit("child"), {ActionRecord: receipt.ActionRecord{
+				DeferID:       "child",
+				DecisionPhase: receipt.DecisionPhaseResolution,
+				ResolutionPolicy: deferred.ReceiptPolicyStringFor(deferred.ReceiptPolicyOptions{
+					Bounds: bounds,
+					Cascade: &deferred.ReceiptCascade{
+						CascadeDepth: 1,
+						Linkage:      "unknown_linkage",
+					},
+				}),
+			}}},
+			want: "unsupported cascade linkage",
+		},
+		{
+			name:     "duplicate cascade resolution",
+			receipts: []receipt.Receipt{admit("child"), resolve("child", "", 1), resolve("child", "", 1)},
+			want:     "duplicate cascade resolution",
+		},
+		{
 			name: "depth exceeds bound",
 			receipts: []receipt.Receipt{
+				admit("parent"),
 				{ActionRecord: receipt.ActionRecord{
 					DeferID:       "child",
 					DecisionPhase: receipt.DecisionPhaseDefer,
@@ -76,7 +117,8 @@ func TestLintDeferredCascadeReceipts(t *testing.T) {
 						MaxCascadeDepth: 1,
 					}, config.DeferResolutionPolicy{}),
 				}},
-				resolve("child", "", 2),
+				resolve("parent", "", 1),
+				resolve("child", "parent", 2),
 			},
 			want: "exceeds admission max_cascade_depth",
 		},

--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -150,6 +150,14 @@ func verifyActionChain(stdout, stderr io.Writer, label string, receipts []action
 		report.Error = unpinnedReceiptBanner
 		report.Valid = opts.allowUnpinned
 	}
+	if res.Valid {
+		if lintErr := lintDeferredCascadeReceipts(receipts); lintErr != nil {
+			report.Valid = false
+			report.Error = lintErr.Error()
+			emitChainReport(stdout, stderr, report, opts.jsonOutput)
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, lintErr)
+		}
+	}
 	emitChainReport(stdout, stderr, report, opts.jsonOutput)
 	if !res.Valid {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("chain rejected at seq %d: %s", res.BrokenAtSeq, res.Error))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -991,6 +991,7 @@ defer:                            # top-level section
   max_pending: 64                 # total concurrent holds (overflow denies the new action)
   max_pending_per_session: 8      # per-session concurrent holds
   max_pending_bytes: 1048576      # total held-payload budget
+  max_cascade_depth: 8            # max same-session pending-ancestor chain depth
 
 mcp_tool_policy:
   enabled: true
@@ -1008,6 +1009,10 @@ mcp_tool_policy:
           approval: true                   # allow only when the resolver returns an affirmative result
           tool_inventory_baseline: false   # or: re-confirm against the pinned tool inventory baseline
 ```
+
+When a new held action is admitted while another action from the same session is still pending, Pipelock records a derived linkage kind of `session_pending_ancestor`: the new action's parent is the newest still-held action in that session, and its cascade depth is the parent depth plus one. This is a temporal fact observed by the proxy, not a claim that the child consumed the parent's data.
+
+`max_cascade_depth` bounds that continuous same-session defer pressure. If the next hold would exceed the limit, Pipelock denies it before creating held state and emits a resolution receipt with `resolution_source: "cascade_limit"`. If a parent later resolves to anything other than allow, still-held descendants block immediately with `resolution_source: "cascade"`. A parent allow does not allow descendants; each descendant still needs its own affirmative resolution signal.
 
 `resolution_policy.allow_on.policy_permits` is rejected on the supported defer transports because they do not own a live config-reload callback. Each held action emits a hash-chained defer receipt and a resolution receipt bound to the original call; `pipelock verify-receipt --clean-report` derives a minimal offline-verifiable report that fails closed on any incomplete, duplicate, identity-changed, or non-terminal defer pair. Defer is free-tier.
 

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -16,6 +16,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -270,34 +271,48 @@ func buildDeferManager(cfg *config.Config) *deferred.Manager {
 	if cfg == nil || !cfg.Defer.Enabled {
 		return nil
 	}
-	journalPath := ""
-	if cfg.FlightRecorder.Dir != "" {
-		journalPath = filepath.Join(cfg.FlightRecorder.Dir, "deferred-actions.jsonl")
-	}
 	return deferred.NewManager(deferred.Config{
 		Enabled:              cfg.Defer.Enabled,
 		Timeout:              time.Duration(cfg.Defer.TimeoutSeconds) * time.Second,
 		MaxPending:           cfg.Defer.MaxPending,
 		MaxPendingPerSession: cfg.Defer.MaxPendingPerSession,
 		MaxPendingBytes:      cfg.Defer.MaxPendingBytes,
-		JournalPath:          journalPath,
+		MaxCascadeDepth:      cfg.Defer.MaxCascadeDepth,
+		JournalPath:          deferJournalPath(cfg),
 	})
+}
+
+func deferJournalPath(cfg *config.Config) string {
+	if cfg == nil || cfg.FlightRecorder.Dir == "" {
+		return ""
+	}
+	return filepath.Join(cfg.FlightRecorder.Dir, "deferred-actions.jsonl")
 }
 
 func recoverDeferredActions(
 	manager *deferred.Manager,
+	journalPath string,
 	receiptEmitter *receipt.Emitter,
 	v2ReceiptEmitter *proxydecision.Emitter,
 	policyHash string,
 	logW io.Writer,
 ) error {
-	if manager == nil || manager.JournalPath() == "" {
+	if journalPath == "" && manager != nil {
+		journalPath = manager.JournalPath()
+	}
+	if journalPath == "" {
 		return nil
 	}
-	pending, err := deferred.PendingJournal(manager.JournalPath())
+	pending, err := deferred.PendingJournal(journalPath)
 	if err != nil {
 		return fmt.Errorf("reading deferred action journal: %w", err)
 	}
+	sort.Slice(pending, func(i, j int) bool {
+		if pending[i].CascadeDepth != pending[j].CascadeDepth {
+			return pending[i].CascadeDepth < pending[j].CascadeDepth
+		}
+		return pending[i].DeferID < pending[j].DeferID
+	})
 	for _, held := range pending {
 		opts := mcp.MCPProxyOpts{
 			ReceiptEmitter:   receiptEmitter,
@@ -312,13 +327,22 @@ func recoverDeferredActions(
 			FinalDecision:    config.ActionBlock,
 			ResolutionSource: deferred.SourceRestartRecovery,
 			Authority:        held.Authority,
+			ParentDeferID:    held.ParentDeferID,
+			CascadeDepth:     held.CascadeDepth,
+			Linkage:          held.Linkage,
+			Policy:           held.Policy,
 			Target:           held.Target,
 			Method:           held.Method,
 			Reason:           held.Reason,
 		}); err != nil {
 			return fmt.Errorf("emitting deferred restart recovery receipt %q: %w", held.DeferID, err)
 		}
-		if err := manager.RecordRestartRecovery(held); err != nil {
+		if manager != nil {
+			err = manager.RecordRestartRecovery(held)
+		} else {
+			err = deferred.RecordRestartRecoveryJournal(journalPath, held)
+		}
+		if err != nil {
 			return fmt.Errorf("recording deferred restart recovery %q: %w", held.DeferID, err)
 		}
 	}
@@ -974,7 +998,7 @@ Key-free evidence capture:
 				policyAction = policyCfg.Action
 			}
 			deferManager := buildDeferManager(cfg)
-			if err := recoverDeferredActions(deferManager, receiptEmitter, v2ReceiptEmitter, captureConfigHash, cmd.ErrOrStderr()); err != nil {
+			if err := recoverDeferredActions(deferManager, deferJournalPath(cfg), receiptEmitter, v2ReceiptEmitter, captureConfigHash, cmd.ErrOrStderr()); err != nil {
 				return err
 			}
 			if hasUpstream {

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -109,6 +109,7 @@ func TestBuildDeferManagerAndSurfaceValidation(t *testing.T) {
 	cfg.Defer.MaxPending = 5
 	cfg.Defer.MaxPendingPerSession = 3
 	cfg.Defer.MaxPendingBytes = 2048
+	cfg.Defer.MaxCascadeDepth = 6
 	cfg.FlightRecorder.Dir = t.TempDir()
 	manager := buildDeferManager(cfg)
 	if manager == nil {
@@ -118,7 +119,7 @@ func TestBuildDeferManagerAndSurfaceValidation(t *testing.T) {
 		t.Fatalf("JournalPath = %q, want %q", got, want)
 	}
 	policy := manager.Policy()
-	if policy.Timeout != 7*time.Second || policy.MaxPending != 5 || policy.MaxPendingPerSession != 3 || policy.MaxPendingBytes != 2048 {
+	if policy.Timeout != 7*time.Second || policy.MaxPending != 5 || policy.MaxPendingPerSession != 3 || policy.MaxPendingBytes != 2048 || policy.MaxCascadeDepth != 6 {
 		t.Fatalf("manager policy = %+v", policy)
 	}
 
@@ -200,7 +201,7 @@ func TestRecoverDeferredActionsBlocksPendingJournal(t *testing.T) {
 	}
 
 	var log bytes.Buffer
-	if err := recoverDeferredActions(manager, emitter, nil, "policy-hash", &log); err != nil {
+	if err := recoverDeferredActions(manager, manager.JournalPath(), emitter, nil, "policy-hash", &log); err != nil {
 		t.Fatalf("recoverDeferredActions: %v", err)
 	}
 	pending, err = deferred.PendingJournal(manager.JournalPath())
@@ -213,6 +214,131 @@ func TestRecoverDeferredActionsBlocksPendingJournal(t *testing.T) {
 	if log.String() != "" {
 		t.Fatalf("recovery log = %q, want empty", log.String())
 	}
+}
+
+func TestRecoverDeferredActionsRunsWithoutLiveManager(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Defaults()
+	cfg.Defer.Enabled = true
+	cfg.FlightRecorder.Dir = dir
+	manager := buildDeferManager(cfg)
+	if manager == nil {
+		t.Fatal("buildDeferManager returned nil")
+	}
+	for _, id := range []string{"a", "b"} {
+		if err := manager.Hold(deferred.HeldAction{
+			DeferID:   id,
+			ActionID:  id,
+			Target:    "neutral_tool",
+			Surface:   deferred.SurfaceMCPStdio,
+			Method:    "tools/call",
+			Reason:    "policy",
+			SizeBytes: 1,
+			Authority: deferred.AuthoritySnapshot{
+				SessionID:         "sess",
+				SessionIDOriginal: "sess",
+			},
+			Resolve: func(deferred.Resolution) {},
+		}); err != nil {
+			t.Fatalf("Hold(%s): %v", id, err)
+		}
+	}
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                filepath.Join(dir, "receipts-disabled"),
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: "config-hash",
+		Principal:  "local",
+		Actor:      "pipelock",
+	})
+	if emitter == nil {
+		t.Fatal("receipt.NewEmitter returned nil")
+	}
+
+	var log bytes.Buffer
+	if err := recoverDeferredActions(nil, manager.JournalPath(), emitter, nil, "policy-hash", &log); err != nil {
+		t.Fatalf("recoverDeferredActions without manager: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
+	pending, err := deferred.PendingJournal(manager.JournalPath())
+	if err != nil {
+		t.Fatalf("PendingJournal after journal-only recovery: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending after journal-only recovery = %d, want 0", len(pending))
+	}
+	records := readRuntimeActionRecords(t, filepath.Join(dir, "receipts-disabled"))
+	if len(records) != 2 {
+		t.Fatalf("recovery receipt count = %d, want 2", len(records))
+	}
+	if records[0].DeferID != "a" || records[1].DeferID != "b" {
+		t.Fatalf("recovery order = %q,%q; want a,b", records[0].DeferID, records[1].DeferID)
+	}
+	for _, record := range records {
+		if record.ResolutionSource != deferred.SourceRestartRecovery {
+			t.Fatalf("resolution_source = %q, want restart_recovery", record.ResolutionSource)
+		}
+	}
+	var childPolicy deferred.ReceiptPolicy
+	if err := json.Unmarshal([]byte(records[1].ResolutionPolicy), &childPolicy); err != nil {
+		t.Fatalf("child recovery resolution_policy JSON: %v", err)
+	}
+	if childPolicy.Cascade == nil {
+		t.Fatal("child recovery resolution_policy.cascade missing")
+	}
+	if childPolicy.Cascade.ParentDeferID != "a" ||
+		childPolicy.Cascade.CascadeDepth != 2 ||
+		childPolicy.Cascade.Linkage != deferred.LinkageSessionPendingAncestor ||
+		childPolicy.Bounds.MaxCascadeDepth != cfg.Defer.MaxCascadeDepth {
+		t.Fatalf("child recovery resolution_policy = %+v, want parent/depth/linkage plus max_cascade_depth %d", childPolicy, cfg.Defer.MaxCascadeDepth)
+	}
+	manager.ResolveAll(config.ActionBlock, deferred.SourceCancel)
+}
+
+func readRuntimeActionRecords(t *testing.T, dir string) []receipt.ActionRecord {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", dir, err)
+	}
+	var records []receipt.ActionRecord
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		batch, err := recorder.ReadEntries(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			t.Fatalf("ReadEntries(%s): %v", entry.Name(), err)
+		}
+		for _, recEntry := range batch {
+			if recEntry.Type != "action_receipt" {
+				continue
+			}
+			data, err := json.Marshal(recEntry.Detail)
+			if err != nil {
+				t.Fatalf("marshal detail: %v", err)
+			}
+			var rcpt receipt.Receipt
+			if err := json.Unmarshal(data, &rcpt); err != nil {
+				t.Fatalf("unmarshal receipt: %v", err)
+			}
+			records = append(records, rcpt.ActionRecord)
+		}
+	}
+	return records
 }
 
 func TestBuildRedirectRT_WithFetchListen(t *testing.T) {

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -181,6 +181,8 @@ const (
 	// hard-blocked ordinary credential setup documentation ("provide your API
 	// key in config"). Imperative solicitations to the requester still block.
 	// Detection-relevant change.
+	// Re-bumped for defer.max_cascade_depth. The bound changes held-action
+	// admission decisions, so it participates in the signed policy hash.
 	// Re-bumped for removal of vestigial DeferConfig.ResolutionTriggers
 	// field. The field had zero runtime consumers (only validated/defaulted)
 	// and was dropped in v2.8 before any release shipped it.
@@ -231,7 +233,7 @@ const (
 	// JSON-object encodings (`eyA`, `ew[o/k/0]`, `e30`, `e30=`), so compact
 	// JWTs with whitespace or empty claims are not dropped. See
 	// TestTextDLP_DottedTokenPatterns.
-	goldenHashDefaults = "eccdfd0b83416de46dd9247c7a5986558834e2f9be5e21ae0fda9c280c6bc8bc"
+	goldenHashDefaults = "0c8208c1e050a6bf3f2d578ad353a101fcf905b3c27255c047a3f236433bac69"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -342,7 +344,8 @@ const (
 	// Re-bumped for MCP tool-policy structural argument validators. New
 	// ToolPolicyRule fields are policy-semantic even when zero-valued because
 	// non-zero values change tool-call decisions.
-	goldenHashRichConfig = "9bea5ad49aacea8ab8e7e2ec68fdfb567f39526ffa5485f682f3b77749dc6b2a"
+	// Re-bumped for defer.max_cascade_depth: see goldenHashDefaults note above.
+	goldenHashRichConfig = "873f7742304ad83946f53a32e69b15b0cd58dc5cbbd7d05534b836155b8fe633"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -430,6 +430,7 @@ func Defaults() *Config {
 			MaxPending:           64,
 			MaxPendingPerSession: 8,
 			MaxPendingBytes:      1024 * 1024,
+			MaxCascadeDepth:      8,
 		},
 		GitProtection: GitProtection{
 			Enabled:         false,

--- a/internal/config/defer_test.go
+++ b/internal/config/defer_test.go
@@ -82,6 +82,11 @@ func TestValidateDeferSettingsRejectInvalidValues(t *testing.T) {
 			mut:  func(c *Config) { c.Defer.MaxPendingBytes = 0 },
 			want: "defer.max_pending_bytes must be positive",
 		},
+		{
+			name: "max cascade depth",
+			mut:  func(c *Config) { c.Defer.MaxCascadeDepth = -1 },
+			want: "defer.max_cascade_depth must be >= 0",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -93,6 +98,116 @@ func TestValidateDeferSettingsRejectInvalidValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeferMaxCascadeDepthDefaultsAndReloadStates(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want int
+	}{
+		{
+			name: "omitted",
+			yaml: "mode: balanced\n",
+			want: 8,
+		},
+		{
+			name: "yaml null blank",
+			yaml: "mode: balanced\ndefer:\n  max_cascade_depth:\n",
+			want: 8,
+		},
+		{
+			name: "explicit zero",
+			yaml: "mode: balanced\ndefer:\n  max_cascade_depth: 0\n",
+			want: 8,
+		},
+		{
+			name: "explicit value",
+			yaml: "mode: balanced\ndefer:\n  max_cascade_depth: 5\n",
+			want: 5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := loadDeferYAML(t, tt.yaml)
+			if cfg.Defer.MaxCascadeDepth != tt.want {
+				t.Fatalf("MaxCascadeDepth = %d, want %d", cfg.Defer.MaxCascadeDepth, tt.want)
+			}
+		})
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipelock.yaml")
+	writeConfigYAML(t, path, "mode: balanced\ndefer:\n  max_cascade_depth: 4\n")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load initial: %v", err)
+	}
+	if cfg.Defer.MaxCascadeDepth != 4 {
+		t.Fatalf("initial MaxCascadeDepth = %d, want 4", cfg.Defer.MaxCascadeDepth)
+	}
+	writeConfigYAML(t, path, "mode: balanced\ndefer:\n  max_cascade_depth: 6\n")
+	cfg, err = Load(path)
+	if err != nil {
+		t.Fatalf("Load changed: %v", err)
+	}
+	if cfg.Defer.MaxCascadeDepth != 6 {
+		t.Fatalf("changed MaxCascadeDepth = %d, want 6", cfg.Defer.MaxCascadeDepth)
+	}
+	cfg, err = Load(path)
+	if err != nil {
+		t.Fatalf("Load unchanged: %v", err)
+	}
+	if cfg.Defer.MaxCascadeDepth != 6 {
+		t.Fatalf("unchanged MaxCascadeDepth = %d, want 6", cfg.Defer.MaxCascadeDepth)
+	}
+}
+
+func TestValidateDeferMaxCascadeDepthWarnsWhenDisabled(t *testing.T) {
+	cfg := loadDeferYAML(t, "mode: balanced\ndefer:\n  enabled: false\n  max_cascade_depth: 4\n")
+	warnings, err := cfg.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() error = %v", err)
+	}
+	if !hasDeferWarning(warnings, "defer.max_cascade_depth") {
+		t.Fatalf("warnings = %+v, want defer.max_cascade_depth warning", warnings)
+	}
+
+	cfg = loadDeferYAML(t, "mode: balanced\ndefer:\n  enabled: false\n")
+	warnings, err = cfg.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() without explicit value error = %v", err)
+	}
+	if hasDeferWarning(warnings, "defer.max_cascade_depth") {
+		t.Fatalf("warnings = %+v, want no max_cascade_depth warning", warnings)
+	}
+}
+
+func loadDeferYAML(t *testing.T, src string) *Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	writeConfigYAML(t, path, src)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(%q): %v", src, err)
+	}
+	return cfg
+}
+
+func writeConfigYAML(t *testing.T, path, src string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func hasDeferWarning(warnings []Warning, field string) bool {
+	for _, warning := range warnings {
+		if warning.Field == field {
+			return true
+		}
+	}
+	return false
 }
 
 func TestValidateDeferMCPToolPolicyRejectsInvalidResolverProfiles(t *testing.T) {

--- a/internal/config/defer_test.go
+++ b/internal/config/defer_test.go
@@ -183,6 +183,20 @@ func TestValidateDeferMaxCascadeDepthWarnsWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestValidateDeferNoCascadeDepthWarningFromDefaults(t *testing.T) {
+	// Programmatic configs have no raw YAML; the resolved default depth must
+	// not be mistaken for an operator-set value.
+	cfg := Defaults()
+	cfg.Defer.Enabled = false
+	warnings, err := cfg.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() error = %v", err)
+	}
+	if hasDeferWarning(warnings, "defer.max_cascade_depth") {
+		t.Fatalf("warnings = %+v, want no max_cascade_depth warning from Defaults()", warnings)
+	}
+}
+
 func loadDeferYAML(t *testing.T, src string) *Config {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "pipelock.yaml")

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -303,6 +303,9 @@ func (c *Config) ApplyDefaults() {
 	if c.Defer.MaxPendingBytes <= 0 {
 		c.Defer.MaxPendingBytes = 1024 * 1024
 	}
+	if c.Defer.MaxCascadeDepth == 0 {
+		c.Defer.MaxCascadeDepth = 8
+	}
 	if c.RequestPolicy.OnParseError == "" {
 		c.RequestPolicy.OnParseError = ActionBlock
 	}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -640,6 +640,7 @@ type DeferConfig struct {
 	MaxPending           int  `yaml:"max_pending"`
 	MaxPendingPerSession int  `yaml:"max_pending_per_session"`
 	MaxPendingBytes      int  `yaml:"max_pending_bytes"`
+	MaxCascadeDepth      int  `yaml:"max_cascade_depth"`
 }
 
 // DeferResolutionPolicy defines which affirmative signals may turn a held

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -23,6 +23,8 @@ import (
 	"time"
 	"unicode"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/secperm"
@@ -111,7 +113,7 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateMCPToolPolicy(); err != nil {
 		return warnings, err
 	}
-	if err := c.validateDefer(); err != nil {
+	if err := c.validateDefer(&warnings); err != nil {
 		return warnings, err
 	}
 	if err := c.validateGitProtection(); err != nil {
@@ -1137,7 +1139,7 @@ func ParseBoundedJSONNumber(n json.Number) (*big.Rat, bool) {
 	return new(big.Rat).SetFrac(num, den), true
 }
 
-func (c *Config) validateDefer() error {
+func (c *Config) validateDefer(warnings *[]Warning) error {
 	if c.Defer.TimeoutSeconds <= 0 {
 		return fmt.Errorf("defer.timeout_seconds must be positive")
 	}
@@ -1149,6 +1151,49 @@ func (c *Config) validateDefer() error {
 	}
 	if c.Defer.MaxPendingBytes <= 0 {
 		return fmt.Errorf("defer.max_pending_bytes must be positive")
+	}
+	if c.Defer.MaxCascadeDepth < 0 {
+		return fmt.Errorf("defer.max_cascade_depth must be >= 0")
+	}
+	if warnings != nil && !c.Defer.Enabled && c.deferFieldExplicit("max_cascade_depth") {
+		*warnings = append(*warnings, Warning{
+			Field:   "defer.max_cascade_depth",
+			Message: "is set while defer.enabled is false; the cascade-depth bound is inert until defer is enabled",
+		})
+	}
+	return nil
+}
+
+func (c *Config) deferFieldExplicit(field string) bool {
+	if len(c.rawBytes) == 0 {
+		return c.Defer.MaxCascadeDepth != 0
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(c.rawBytes, &root); err != nil {
+		return false
+	}
+	if len(root.Content) == 0 {
+		return false
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return false
+	}
+	deferNode := mappingValue(doc, "defer")
+	if deferNode == nil || deferNode.Kind != yaml.MappingNode {
+		return false
+	}
+	return mappingValue(deferNode, field) != nil
+}
+
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
 	}
 	return nil
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1165,8 +1165,11 @@ func (c *Config) validateDefer(warnings *[]Warning) error {
 }
 
 func (c *Config) deferFieldExplicit(field string) bool {
+	// No raw YAML means the config was built programmatically (Defaults(),
+	// tests, SDK callers); nothing was explicitly set by an operator, so the
+	// inert-field warning would be spurious noise.
 	if len(c.rawBytes) == 0 {
-		return c.Defer.MaxCascadeDepth != 0
+		return false
 	}
 	var root yaml.Node
 	if err := yaml.Unmarshal(c.rawBytes, &root); err != nil {

--- a/internal/deferred/manager.go
+++ b/internal/deferred/manager.go
@@ -564,8 +564,8 @@ type journalEntry struct {
 	Method        string                       `json:"method,omitempty"`
 	Reason        string                       `json:"reason,omitempty"`
 	Authority     AuthoritySnapshot            `json:"authority"`
-	Policy        ResolutionPolicy             `json:"policy,omitempty"`
-	RulePolicy    config.DeferResolutionPolicy `json:"rule_policy,omitempty"`
+	Policy        ResolutionPolicy             `json:"policy"`
+	RulePolicy    config.DeferResolutionPolicy `json:"rule_policy"`
 	ParentDeferID string                       `json:"parent_defer_id,omitempty"`
 	CascadeDepth  int                          `json:"cascade_depth,omitempty"`
 	Linkage       string                       `json:"linkage,omitempty"`

--- a/internal/deferred/manager.go
+++ b/internal/deferred/manager.go
@@ -17,24 +17,28 @@ import (
 )
 
 const (
-	StateHeld                = "deferred_held"
-	StateResolving           = "resolving"
-	StateResolvedAllow       = "resolved_allow"
-	StateResolvedBlock       = "resolved_block"
-	StateResolvedStepUp      = "resolved_step_up"
-	SourceContext            = "context"
-	SourceTimeout            = "timeout"
-	SourceCancel             = "cancel"
-	SourceRestartRecovery    = "restart_recovery"
-	SourceKillSwitch         = "kill_switch"
-	SourceCapacity           = "capacity"
-	SourcePolicyReload       = "policy_reload"
-	SourceApproval           = "approval"
-	SourceToolInventory      = "tool_inventory"
-	DefaultTimeoutSeconds    = 2
-	DefaultMaxPending        = 64
-	DefaultMaxPendingSession = 8
-	DefaultMaxPendingBytes   = 1024 * 1024
+	StateHeld                     = "deferred_held"
+	StateResolving                = "resolving"
+	StateResolvedAllow            = "resolved_allow"
+	StateResolvedBlock            = "resolved_block"
+	StateResolvedStepUp           = "resolved_step_up"
+	SourceContext                 = "context"
+	SourceTimeout                 = "timeout"
+	SourceCancel                  = "cancel"
+	SourceRestartRecovery         = "restart_recovery"
+	SourceKillSwitch              = "kill_switch"
+	SourceCapacity                = "capacity"
+	SourceCascade                 = "cascade"
+	SourceCascadeLimit            = "cascade_limit"
+	SourcePolicyReload            = "policy_reload"
+	SourceApproval                = "approval"
+	SourceToolInventory           = "tool_inventory"
+	LinkageSessionPendingAncestor = "session_pending_ancestor"
+	DefaultTimeoutSeconds         = 2
+	DefaultMaxPending             = 64
+	DefaultMaxPendingSession      = 8
+	DefaultMaxPendingBytes        = 1024 * 1024
+	DefaultMaxCascadeDepth        = DefaultMaxPendingSession
 )
 
 // Config controls held-action bounds and timers.
@@ -44,6 +48,7 @@ type Config struct {
 	MaxPending           int
 	MaxPendingPerSession int
 	MaxPendingBytes      int
+	MaxCascadeDepth      int
 	JournalPath          string
 }
 
@@ -53,6 +58,7 @@ type ResolutionPolicy struct {
 	MaxPending           int           `json:"max_pending"`
 	MaxPendingPerSession int           `json:"max_pending_per_session"`
 	MaxPendingBytes      int           `json:"max_pending_bytes"`
+	MaxCascadeDepth      int           `json:"max_cascade_depth"`
 }
 
 func (p ResolutionPolicy) String() string {
@@ -63,17 +69,35 @@ func (p ResolutionPolicy) String() string {
 	return string(data)
 }
 
+type ReceiptCascade struct {
+	ParentDeferID string `json:"parent_defer_id,omitempty"`
+	CascadeDepth  int    `json:"cascade_depth"`
+	Linkage       string `json:"linkage,omitempty"`
+}
+
 type ReceiptPolicy struct {
 	Bounds   ResolutionPolicy     `json:"bounds"`
 	AllowOn  config.DeferAllowOn  `json:"allow_on,omitempty"`
 	StepUpOn config.DeferStepUpOn `json:"step_up_on,omitempty"`
+	Cascade  *ReceiptCascade      `json:"cascade,omitempty"`
+}
+
+type ReceiptPolicyOptions struct {
+	Bounds  ResolutionPolicy
+	Rule    config.DeferResolutionPolicy
+	Cascade *ReceiptCascade
 }
 
 func ReceiptPolicyString(bounds ResolutionPolicy, rule config.DeferResolutionPolicy) string {
+	return ReceiptPolicyStringFor(ReceiptPolicyOptions{Bounds: bounds, Rule: rule})
+}
+
+func ReceiptPolicyStringFor(opts ReceiptPolicyOptions) string {
 	data, err := json.Marshal(ReceiptPolicy{
-		Bounds:   bounds,
-		AllowOn:  rule.AllowOn,
-		StepUpOn: rule.StepUpOn,
+		Bounds:   opts.Bounds,
+		AllowOn:  opts.Rule.AllowOn,
+		StepUpOn: opts.Rule.StepUpOn,
+		Cascade:  opts.Cascade,
 	})
 	if err != nil {
 		return ""
@@ -91,23 +115,26 @@ type AuthoritySnapshot struct {
 
 // HeldAction is the immutable action payload stored while awaiting resolution.
 type HeldAction struct {
-	DeferID    string
-	ActionID   string
-	Target     string
-	Reason     string
-	Surface    string
-	Method     string
-	SizeBytes  int
-	Policy     ResolutionPolicy
-	RulePolicy config.DeferResolutionPolicy
-	Authority  AuthoritySnapshot
-	Deadline   time.Time
-	Payload    []byte
-	ArgDigest  string
-	Resolve    func(Resolution)
-	timer      *time.Timer
-	state      string
-	createdAt  time.Time
+	DeferID       string
+	ActionID      string
+	Target        string
+	Reason        string
+	Surface       string
+	Method        string
+	SizeBytes     int
+	Policy        ResolutionPolicy
+	RulePolicy    config.DeferResolutionPolicy
+	Authority     AuthoritySnapshot
+	ParentDeferID string
+	CascadeDepth  int
+	Linkage       string
+	Deadline      time.Time
+	Payload       []byte
+	ArgDigest     string
+	Resolve       func(Resolution)
+	timer         *time.Timer
+	state         string
+	createdAt     time.Time
 }
 
 // Resolution is delivered exactly once for a held action.
@@ -117,6 +144,10 @@ type Resolution struct {
 	FinalDecision    string
 	ResolutionSource string
 	Authority        AuthoritySnapshot
+	ParentDeferID    string
+	CascadeDepth     int
+	Linkage          string
+	Policy           ResolutionPolicy
 	Target           string
 	Method           string
 	Reason           string
@@ -127,16 +158,38 @@ type Manager struct {
 	mu             sync.Mutex
 	cfg            Config
 	holds          map[string]*HeldAction
-	bySession      map[string]int
+	sessionHolds   map[string][]string
 	totalBytes     int
 	pendingJournal map[string]journalEntry
 }
 
 var (
-	ErrDisabled = errors.New("defer manager disabled")
-	ErrCapacity = errors.New("defer capacity exceeded")
-	ErrNotFound = errors.New("defer hold not found")
+	ErrDisabled     = errors.New("defer manager disabled")
+	ErrCapacity     = errors.New("defer capacity exceeded")
+	ErrNotFound     = errors.New("defer hold not found")
+	ErrCascadeLimit = errors.New("defer cascade depth exceeded")
 )
+
+type CascadeLimitError struct {
+	Depth         int
+	Limit         int
+	ParentDeferID string
+}
+
+func (e *CascadeLimitError) Error() string {
+	return fmt.Sprintf("%s: depth %d exceeds limit %d", ErrCascadeLimit, e.Depth, e.Limit)
+}
+
+func (e *CascadeLimitError) Unwrap() error {
+	return ErrCascadeLimit
+}
+
+func HoldFailureSource(err error) string {
+	if errors.Is(err, ErrCascadeLimit) {
+		return SourceCascadeLimit
+	}
+	return SourceCapacity
+}
 
 // NewManager constructs a bounded held-action manager.
 func NewManager(cfg Config) *Manager {
@@ -152,10 +205,13 @@ func NewManager(cfg Config) *Manager {
 	if cfg.MaxPendingBytes <= 0 {
 		cfg.MaxPendingBytes = DefaultMaxPendingBytes
 	}
+	if cfg.MaxCascadeDepth <= 0 {
+		cfg.MaxCascadeDepth = DefaultMaxCascadeDepth
+	}
 	return &Manager{
 		cfg:            cfg,
 		holds:          make(map[string]*HeldAction),
-		bySession:      make(map[string]int),
+		sessionHolds:   make(map[string][]string),
 		pendingJournal: make(map[string]journalEntry),
 	}
 }
@@ -173,6 +229,7 @@ func (m *Manager) Policy() ResolutionPolicy {
 		MaxPending:           m.cfg.MaxPending,
 		MaxPendingPerSession: m.cfg.MaxPendingPerSession,
 		MaxPendingBytes:      m.cfg.MaxPendingBytes,
+		MaxCascadeDepth:      m.cfg.MaxCascadeDepth,
 	}
 }
 
@@ -210,17 +267,32 @@ func (m *Manager) Hold(action HeldAction) error {
 		return fmt.Errorf("defer hold %q already exists", action.DeferID)
 	}
 	if len(m.holds) >= m.cfg.MaxPending ||
-		m.bySession[action.Authority.SessionID] >= m.cfg.MaxPendingPerSession ||
+		len(m.sessionHolds[action.Authority.SessionID]) >= m.cfg.MaxPendingPerSession ||
 		action.SizeBytes > m.cfg.MaxPendingBytes ||
 		m.totalBytes > m.cfg.MaxPendingBytes-action.SizeBytes {
 		m.mu.Unlock()
 		return ErrCapacity
 	}
+	action.Linkage = LinkageSessionPendingAncestor
+	action.CascadeDepth = 1
+	if ids := m.sessionHolds[action.Authority.SessionID]; len(ids) > 0 {
+		parent := m.holds[ids[len(ids)-1]]
+		action.ParentDeferID = parent.DeferID
+		action.CascadeDepth = parent.CascadeDepth + 1
+	}
+	if action.CascadeDepth > m.cfg.MaxCascadeDepth {
+		m.mu.Unlock()
+		return &CascadeLimitError{
+			Depth:         action.CascadeDepth,
+			Limit:         m.cfg.MaxCascadeDepth,
+			ParentDeferID: action.ParentDeferID,
+		}
+	}
 	journalAction := action
 	stored := action
 	held := &stored
 	m.holds[action.DeferID] = held
-	m.bySession[action.Authority.SessionID]++
+	m.sessionHolds[action.Authority.SessionID] = append(m.sessionHolds[action.Authority.SessionID], action.DeferID)
 	m.totalBytes += action.SizeBytes
 	m.mu.Unlock()
 
@@ -258,10 +330,7 @@ func (m *Manager) Resolve(deferID, finalDecision, source string) error {
 	}
 	held.state = StateResolving
 	delete(m.holds, deferID)
-	m.bySession[held.Authority.SessionID]--
-	if m.bySession[held.Authority.SessionID] <= 0 {
-		delete(m.bySession, held.Authority.SessionID)
-	}
+	m.removeSessionHoldLocked(held.Authority.SessionID, deferID)
 	m.totalBytes -= held.SizeBytes
 	if held.timer != nil {
 		held.timer.Stop()
@@ -275,12 +344,19 @@ func (m *Manager) Resolve(deferID, finalDecision, source string) error {
 		state = resolvedState(finalDecision)
 		_ = m.appendJournal(journalEntryFromHeld(*held, state, source))
 	}
+	if finalDecision != config.ActionAllow && source != SourceCascade {
+		m.cascadeBlockDescendants([]string{held.DeferID})
+	}
 	held.Resolve(Resolution{
 		DeferID:          held.DeferID,
 		ParentActionID:   held.ActionID,
 		FinalDecision:    finalDecision,
 		ResolutionSource: source,
 		Authority:        held.Authority,
+		ParentDeferID:    held.ParentDeferID,
+		CascadeDepth:     held.CascadeDepth,
+		Linkage:          held.Linkage,
+		Policy:           held.Policy,
 		Target:           held.Target,
 		Method:           held.Method,
 		Reason:           held.Reason,
@@ -308,6 +384,14 @@ func (m *Manager) RecordRestartRecovery(held HeldAction) error {
 	if m == nil {
 		return ErrDisabled
 	}
+	return m.appendJournal(journalEntryFromHeld(held, StateResolvedBlock, SourceRestartRecovery))
+}
+
+func RecordRestartRecoveryJournal(path string, held HeldAction) error {
+	if path == "" {
+		return nil
+	}
+	m := &Manager{cfg: Config{JournalPath: path}}
 	return m.appendJournal(journalEntryFromHeld(held, StateResolvedBlock, SourceRestartRecovery))
 }
 
@@ -420,6 +504,45 @@ func (m *Manager) snapshotOne(deferID string) (HeldAction, error) {
 	return cp, nil
 }
 
+func (m *Manager) removeSessionHoldLocked(sessionID, deferID string) {
+	ids := m.sessionHolds[sessionID]
+	for i, id := range ids {
+		if id == deferID {
+			ids = append(ids[:i], ids[i+1:]...)
+			break
+		}
+	}
+	if len(ids) == 0 {
+		delete(m.sessionHolds, sessionID)
+		return
+	}
+	m.sessionHolds[sessionID] = ids
+}
+
+func (m *Manager) cascadeBlockDescendants(parentIDs []string) {
+	frontier := append([]string(nil), parentIDs...)
+	for len(frontier) > 0 {
+		m.mu.Lock()
+		children := make([]string, 0)
+		for id, held := range m.holds {
+			for _, parentID := range frontier {
+				if held.ParentDeferID == parentID {
+					children = append(children, id)
+					break
+				}
+			}
+		}
+		m.mu.Unlock()
+		if len(children) == 0 {
+			return
+		}
+		for _, id := range children {
+			_ = m.Resolve(id, config.ActionBlock, SourceCascade)
+		}
+		frontier = children
+	}
+}
+
 func resolvedState(finalDecision string) string {
 	switch finalDecision {
 	case "allow":
@@ -432,36 +555,44 @@ func resolvedState(finalDecision string) string {
 }
 
 type journalEntry struct {
-	DeferID    string                       `json:"defer_id"`
-	ActionID   string                       `json:"action_id"`
-	State      string                       `json:"state"`
-	Source     string                       `json:"source,omitempty"`
-	Target     string                       `json:"target,omitempty"`
-	Surface    string                       `json:"surface,omitempty"`
-	Method     string                       `json:"method,omitempty"`
-	Reason     string                       `json:"reason,omitempty"`
-	Authority  AuthoritySnapshot            `json:"authority"`
-	RulePolicy config.DeferResolutionPolicy `json:"rule_policy,omitempty"`
-	Deadline   time.Time                    `json:"deadline,omitempty"`
-	Timestamp  time.Time                    `json:"timestamp"`
-	SizeBytes  int                          `json:"size_bytes,omitempty"`
+	DeferID       string                       `json:"defer_id"`
+	ActionID      string                       `json:"action_id"`
+	State         string                       `json:"state"`
+	Source        string                       `json:"source,omitempty"`
+	Target        string                       `json:"target,omitempty"`
+	Surface       string                       `json:"surface,omitempty"`
+	Method        string                       `json:"method,omitempty"`
+	Reason        string                       `json:"reason,omitempty"`
+	Authority     AuthoritySnapshot            `json:"authority"`
+	Policy        ResolutionPolicy             `json:"policy,omitempty"`
+	RulePolicy    config.DeferResolutionPolicy `json:"rule_policy,omitempty"`
+	ParentDeferID string                       `json:"parent_defer_id,omitempty"`
+	CascadeDepth  int                          `json:"cascade_depth,omitempty"`
+	Linkage       string                       `json:"linkage,omitempty"`
+	Deadline      time.Time                    `json:"deadline,omitempty"`
+	Timestamp     time.Time                    `json:"timestamp"`
+	SizeBytes     int                          `json:"size_bytes,omitempty"`
 }
 
 func journalEntryFromHeld(held HeldAction, state, source string) journalEntry {
 	return journalEntry{
-		DeferID:    held.DeferID,
-		ActionID:   held.ActionID,
-		State:      state,
-		Source:     source,
-		Target:     held.Target,
-		Surface:    held.Surface,
-		Method:     held.Method,
-		Reason:     held.Reason,
-		Authority:  held.Authority,
-		RulePolicy: held.RulePolicy,
-		Deadline:   held.Deadline,
-		Timestamp:  time.Now().UTC(),
-		SizeBytes:  held.SizeBytes,
+		DeferID:       held.DeferID,
+		ActionID:      held.ActionID,
+		State:         state,
+		Source:        source,
+		Target:        held.Target,
+		Surface:       held.Surface,
+		Method:        held.Method,
+		Reason:        held.Reason,
+		Authority:     held.Authority,
+		Policy:        held.Policy,
+		RulePolicy:    held.RulePolicy,
+		ParentDeferID: held.ParentDeferID,
+		CascadeDepth:  held.CascadeDepth,
+		Linkage:       held.Linkage,
+		Deadline:      held.Deadline,
+		Timestamp:     time.Now().UTC(),
+		SizeBytes:     held.SizeBytes,
 	}
 }
 
@@ -523,16 +654,20 @@ func PendingJournal(path string) ([]HeldAction, error) {
 	out := make([]HeldAction, 0, len(pending))
 	for _, entry := range pending {
 		out = append(out, HeldAction{
-			DeferID:    entry.DeferID,
-			ActionID:   entry.ActionID,
-			Target:     entry.Target,
-			Reason:     entry.Reason,
-			Surface:    entry.Surface,
-			Method:     entry.Method,
-			SizeBytes:  entry.SizeBytes,
-			RulePolicy: entry.RulePolicy,
-			Authority:  entry.Authority,
-			Deadline:   entry.Deadline,
+			DeferID:       entry.DeferID,
+			ActionID:      entry.ActionID,
+			Target:        entry.Target,
+			Reason:        entry.Reason,
+			Surface:       entry.Surface,
+			Method:        entry.Method,
+			SizeBytes:     entry.SizeBytes,
+			Policy:        entry.Policy,
+			RulePolicy:    entry.RulePolicy,
+			Authority:     entry.Authority,
+			ParentDeferID: entry.ParentDeferID,
+			CascadeDepth:  entry.CascadeDepth,
+			Linkage:       entry.Linkage,
+			Deadline:      entry.Deadline,
 		})
 	}
 	return out, nil

--- a/internal/deferred/manager_test.go
+++ b/internal/deferred/manager_test.go
@@ -4,6 +4,7 @@
 package deferred
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -143,9 +144,10 @@ func TestPolicyStringHelpers(t *testing.T) {
 		MaxPending:           3,
 		MaxPendingPerSession: 2,
 		MaxPendingBytes:      512,
+		MaxCascadeDepth:      4,
 	}
 	got := policy.String()
-	for _, want := range []string{`"max_pending":3`, `"max_pending_per_session":2`, `"max_pending_bytes":512`} {
+	for _, want := range []string{`"max_pending":3`, `"max_pending_per_session":2`, `"max_pending_bytes":512`, `"max_cascade_depth":4`} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("ResolutionPolicy.String() = %q, want %s", got, want)
 		}
@@ -159,6 +161,21 @@ func TestPolicyStringHelpers(t *testing.T) {
 			t.Fatalf("ReceiptPolicyString() = %q, want %s", receiptPolicy, want)
 		}
 	}
+	withCascade := ReceiptPolicyStringFor(ReceiptPolicyOptions{
+		Bounds: policy,
+		Cascade: &ReceiptCascade{
+			ParentDeferID: "parent",
+			CascadeDepth:  2,
+			Linkage:       LinkageSessionPendingAncestor,
+		},
+	})
+	var parsed ReceiptPolicy
+	if err := json.Unmarshal([]byte(withCascade), &parsed); err != nil {
+		t.Fatalf("ReceiptPolicyStringFor cascade JSON: %v", err)
+	}
+	if parsed.Cascade == nil || parsed.Cascade.ParentDeferID != "parent" || parsed.Cascade.CascadeDepth != 2 || parsed.Cascade.Linkage != LinkageSessionPendingAncestor {
+		t.Fatalf("parsed cascade policy = %+v", parsed.Cascade)
+	}
 }
 
 func TestManagerDefaultsNilHelpersAndValidation(t *testing.T) {
@@ -167,7 +184,8 @@ func TestManagerDefaultsNilHelpersAndValidation(t *testing.T) {
 	if policy.Timeout != DefaultTimeoutSeconds*time.Second ||
 		policy.MaxPending != DefaultMaxPending ||
 		policy.MaxPendingPerSession != DefaultMaxPendingSession ||
-		policy.MaxPendingBytes != DefaultMaxPendingBytes {
+		policy.MaxPendingBytes != DefaultMaxPendingBytes ||
+		policy.MaxCascadeDepth != DefaultMaxCascadeDepth {
 		t.Fatalf("default policy = %+v", policy)
 	}
 	if m.Enabled() {
@@ -325,14 +343,14 @@ func TestResolvePolicyReloadAllowBlockAndStillHeld(t *testing.T) {
 			ActionID:  "block",
 			Target:    "tool",
 			SizeBytes: 1,
-			Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "orig"},
+			Authority: AuthoritySnapshot{SessionID: "s2", SessionIDOriginal: "orig"},
 		},
 		{
 			DeferID:   "still-held",
 			ActionID:  "still-held",
 			Target:    "tool",
 			SizeBytes: 1,
-			Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "orig"},
+			Authority: AuthoritySnapshot{SessionID: "s3", SessionIDOriginal: "orig"},
 			RulePolicy: config.DeferResolutionPolicy{
 				AllowOn: config.DeferAllowOn{PolicyPermits: true},
 			},
@@ -393,6 +411,476 @@ func TestResolvePolicyReloadErrorBlocks(t *testing.T) {
 	got := <-ch
 	if got.FinalDecision != config.ActionBlock || got.ResolutionSource != SourcePolicyReload {
 		t.Fatalf("reload error resolved %+v, want block policy_reload", got)
+	}
+}
+
+func TestManagerDerivesSessionPendingAncestorLinkage(t *testing.T) {
+	tests := []struct {
+		name    string
+		session string
+	}{
+		{name: "named session", session: "s1"},
+		{name: "empty session group", session: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 8, MaxPendingPerSession: 8, MaxCascadeDepth: 8})
+			for i, id := range []string{"a", "b", "c"} {
+				if err := m.Hold(HeldAction{
+					DeferID:   id,
+					ActionID:  id,
+					Target:    "tool",
+					SizeBytes: 1,
+					Authority: AuthoritySnapshot{SessionID: tt.session, SessionIDOriginal: tt.session},
+					Resolve:   func(Resolution) {},
+				}); err != nil {
+					t.Fatalf("Hold(%s): %v", id, err)
+				}
+				held, ok := m.Held(id)
+				if !ok {
+					t.Fatalf("Held(%s) missing", id)
+				}
+				if held.CascadeDepth != i+1 || held.Linkage != LinkageSessionPendingAncestor {
+					t.Fatalf("Held(%s) depth/linkage = %d/%q", id, held.CascadeDepth, held.Linkage)
+				}
+			}
+			b, _ := m.Held("b")
+			c, _ := m.Held("c")
+			if b.ParentDeferID != "a" || c.ParentDeferID != "b" {
+				t.Fatalf("parents b=%q c=%q, want a/b", b.ParentDeferID, c.ParentDeferID)
+			}
+		})
+	}
+}
+
+func TestManagerLinkageResetAndCrossSessionIsolation(t *testing.T) {
+	m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 8, MaxPendingPerSession: 8, MaxCascadeDepth: 8})
+	resolved := make(chan Resolution, 4)
+	hold := func(id, session string) {
+		t.Helper()
+		if err := m.Hold(HeldAction{
+			DeferID:   id,
+			ActionID:  id,
+			Target:    "tool",
+			SizeBytes: 1,
+			Authority: AuthoritySnapshot{SessionID: session, SessionIDOriginal: session},
+			Resolve:   func(res Resolution) { resolved <- res },
+		}); err != nil {
+			t.Fatalf("Hold(%s): %v", id, err)
+		}
+	}
+	hold("a", "s1")
+	hold("b", "s2")
+	b, _ := m.Held("b")
+	if b.ParentDeferID != "" || b.CascadeDepth != 1 {
+		t.Fatalf("cross-session hold linked: %+v", b)
+	}
+	if err := m.Resolve("a", config.ActionAllow, SourceApproval); err != nil {
+		t.Fatalf("Resolve(a): %v", err)
+	}
+	<-resolved
+	hold("c", "s1")
+	c, _ := m.Held("c")
+	if c.ParentDeferID != "" || c.CascadeDepth != 1 {
+		t.Fatalf("reset hold = %+v, want root depth 1", c)
+	}
+}
+
+func TestManagerCascadeLimitDeniesBeforeStateAndJournal(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deferred-actions.jsonl")
+	m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 8, MaxPendingPerSession: 8, MaxCascadeDepth: 2, JournalPath: path})
+	for _, id := range []string{"a", "b"} {
+		if err := m.Hold(HeldAction{
+			DeferID:   id,
+			ActionID:  id,
+			Target:    "tool",
+			SizeBytes: 1,
+			Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+			Resolve:   func(Resolution) {},
+		}); err != nil {
+			t.Fatalf("Hold(%s): %v", id, err)
+		}
+	}
+	err := m.Hold(HeldAction{
+		DeferID:   "c",
+		ActionID:  "c",
+		Target:    "tool",
+		SizeBytes: 1,
+		Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+		Resolve:   func(Resolution) {},
+	})
+	var limitErr *CascadeLimitError
+	if !errors.Is(err, ErrCascadeLimit) || !errors.As(err, &limitErr) {
+		t.Fatalf("Hold(c) error = %v, want CascadeLimitError", err)
+	}
+	if limitErr.Depth != 3 || limitErr.Limit != 2 || limitErr.ParentDeferID != "b" {
+		t.Fatalf("limit error = %+v", limitErr)
+	}
+	if HoldFailureSource(err) != SourceCascadeLimit {
+		t.Fatalf("HoldFailureSource = %q, want cascade_limit", HoldFailureSource(err))
+	}
+	if _, ok := m.Held("c"); ok {
+		t.Fatal("limit-denied action was held")
+	}
+	pending, journalErr := PendingJournal(path)
+	if journalErr != nil {
+		t.Fatalf("PendingJournal: %v", journalErr)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("pending journal count = %d, want 2", len(pending))
+	}
+}
+
+func TestManagerSequentialRatchetBoundedByCascadeDepth(t *testing.T) {
+	m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 8, MaxPendingPerSession: 2, MaxCascadeDepth: 3})
+	resolved := make(chan Resolution, 3)
+	hold := func(id string) error {
+		return m.Hold(HeldAction{
+			DeferID:   id,
+			ActionID:  id,
+			Target:    "tool",
+			SizeBytes: 1,
+			Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+			Resolve:   func(res Resolution) { resolved <- res },
+		})
+	}
+	for _, id := range []string{"a", "b"} {
+		if err := hold(id); err != nil {
+			t.Fatalf("Hold(%s): %v", id, err)
+		}
+	}
+	if err := m.Resolve("a", config.ActionAllow, SourceApproval); err != nil {
+		t.Fatalf("Resolve(a): %v", err)
+	}
+	<-resolved
+	if err := hold("c"); err != nil {
+		t.Fatalf("Hold(c): %v", err)
+	}
+	if err := m.Resolve("b", config.ActionAllow, SourceApproval); err != nil {
+		t.Fatalf("Resolve(b): %v", err)
+	}
+	<-resolved
+	err := hold("d")
+	if !errors.Is(err, ErrCascadeLimit) {
+		t.Fatalf("Hold(d) error = %v, want ErrCascadeLimit", err)
+	}
+	if got := len(m.Snapshot()); got != 1 {
+		t.Fatalf("pending count = %d, want 1", got)
+	}
+}
+
+func TestManagerDefaultBurstCompatUsesSessionCapacityBeforeCascadeLimit(t *testing.T) {
+	m := NewManager(Config{Enabled: true, Timeout: time.Hour})
+	for i := 0; i < DefaultMaxPendingSession; i++ {
+		id := fmt.Sprintf("d%d", i)
+		if err := m.Hold(HeldAction{
+			DeferID:   id,
+			ActionID:  id,
+			Target:    "tool",
+			SizeBytes: 1,
+			Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+			Resolve:   func(Resolution) {},
+		}); err != nil {
+			t.Fatalf("Hold(%s): %v", id, err)
+		}
+	}
+	err := m.Hold(HeldAction{
+		DeferID:   "overflow",
+		ActionID:  "overflow",
+		Target:    "tool",
+		SizeBytes: 1,
+		Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+		Resolve:   func(Resolution) {},
+	})
+	if !errors.Is(err, ErrCapacity) || errors.Is(err, ErrCascadeLimit) {
+		t.Fatalf("overflow error = %v, want capacity only", err)
+	}
+	if HoldFailureSource(err) != SourceCapacity {
+		t.Fatalf("HoldFailureSource = %q, want capacity", HoldFailureSource(err))
+	}
+}
+
+func TestManagerCascadeBlockDescendantsAndAllowDoesNotPropagate(t *testing.T) {
+	t.Run("block cascades descendants", func(t *testing.T) {
+		m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 8, MaxPendingPerSession: 8, MaxCascadeDepth: 8})
+		resolved := make(chan Resolution, 3)
+		for _, id := range []string{"a", "b", "c"} {
+			if err := m.Hold(HeldAction{
+				DeferID:   id,
+				ActionID:  id,
+				Target:    "tool",
+				SizeBytes: 1,
+				Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+				Resolve:   func(res Resolution) { resolved <- res },
+			}); err != nil {
+				t.Fatalf("Hold(%s): %v", id, err)
+			}
+		}
+		if err := m.Resolve("a", config.ActionBlock, SourceApproval); err != nil {
+			t.Fatalf("Resolve(a): %v", err)
+		}
+		got := map[string]Resolution{}
+		for i := 0; i < 3; i++ {
+			res := <-resolved
+			got[res.DeferID] = res
+		}
+		if got["a"].ResolutionSource != SourceApproval {
+			t.Fatalf("parent source = %q, want approval", got["a"].ResolutionSource)
+		}
+		for _, id := range []string{"b", "c"} {
+			if got[id].FinalDecision != config.ActionBlock || got[id].ResolutionSource != SourceCascade {
+				t.Fatalf("%s resolution = %+v, want block cascade", id, got[id])
+			}
+			if got[id].CascadeDepth == 0 || got[id].Linkage != LinkageSessionPendingAncestor {
+				t.Fatalf("%s linkage fields missing: %+v", id, got[id])
+			}
+		}
+	})
+
+	t.Run("allow leaves child held", func(t *testing.T) {
+		m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 4, MaxPendingPerSession: 4, MaxCascadeDepth: 4})
+		resolved := make(chan Resolution, 2)
+		for _, id := range []string{"a", "b"} {
+			if err := m.Hold(HeldAction{
+				DeferID:   id,
+				ActionID:  id,
+				Target:    "tool",
+				SizeBytes: 1,
+				Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+				Resolve:   func(res Resolution) { resolved <- res },
+			}); err != nil {
+				t.Fatalf("Hold(%s): %v", id, err)
+			}
+		}
+		if err := m.Resolve("a", config.ActionAllow, SourceApproval); err != nil {
+			t.Fatalf("Resolve(a): %v", err)
+		}
+		if got := <-resolved; got.DeferID != "a" || got.FinalDecision != config.ActionAllow {
+			t.Fatalf("parent resolution = %+v", got)
+		}
+		if _, ok := m.Held("b"); !ok {
+			t.Fatal("child was resolved by parent allow")
+		}
+		if err := m.Resolve("b", config.ActionAllow, SourceApproval); err != nil {
+			t.Fatalf("Resolve(b): %v", err)
+		}
+		if got := <-resolved; got.DeferID != "b" || got.FinalDecision != config.ActionAllow || got.ResolutionSource != SourceApproval {
+			t.Fatalf("child resolution = %+v", got)
+		}
+	})
+}
+
+func TestManagerParentBlockCallbackCannotAllowChildBeforeCascade(t *testing.T) {
+	m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 4, MaxPendingPerSession: 4, MaxCascadeDepth: 4})
+	resolved := make(chan Resolution, 2)
+	if err := m.Hold(HeldAction{
+		DeferID:   "a",
+		ActionID:  "a",
+		Target:    "tool",
+		SizeBytes: 1,
+		Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+		Resolve: func(res Resolution) {
+			if err := m.Resolve("b", config.ActionAllow, SourceApproval); err != nil && !errors.Is(err, ErrNotFound) {
+				t.Errorf("Resolve(b allow) from parent callback: %v", err)
+			}
+			resolved <- res
+		},
+	}); err != nil {
+		t.Fatalf("Hold(a): %v", err)
+	}
+	if err := m.Hold(HeldAction{
+		DeferID:   "b",
+		ActionID:  "b",
+		Target:    "tool",
+		SizeBytes: 1,
+		Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+		Resolve:   func(res Resolution) { resolved <- res },
+	}); err != nil {
+		t.Fatalf("Hold(b): %v", err)
+	}
+	if err := m.Resolve("a", config.ActionBlock, SourceApproval); err != nil {
+		t.Fatalf("Resolve(a): %v", err)
+	}
+	got := map[string]Resolution{}
+	for i := 0; i < 2; i++ {
+		res := waitResolution(t, resolved)
+		got[res.DeferID] = res
+	}
+	if got["b"].FinalDecision != config.ActionBlock || got["b"].ResolutionSource != SourceCascade {
+		t.Fatalf("child resolution = %+v, want fail-closed cascade block", got["b"])
+	}
+}
+
+func TestManagerTimeoutAndStepUpCascadeBlockChildren(t *testing.T) {
+	t.Run("timeout", func(t *testing.T) {
+		resolved := make(chan Resolution, 2)
+		m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 4, MaxPendingPerSession: 4, MaxCascadeDepth: 4})
+		for _, id := range []string{"a", "b"} {
+			if err := m.Hold(HeldAction{
+				DeferID:   id,
+				ActionID:  id,
+				Target:    "tool",
+				SizeBytes: 1,
+				Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+				Resolve:   func(res Resolution) { resolved <- res },
+			}); err != nil {
+				t.Fatalf("Hold(%s): %v", id, err)
+			}
+		}
+		if err := m.Resolve("a", config.ActionBlock, SourceTimeout); err != nil {
+			t.Fatalf("Resolve(a timeout): %v", err)
+		}
+		got := map[string]Resolution{}
+		for i := 0; i < 2; i++ {
+			res := waitResolution(t, resolved)
+			got[res.DeferID] = res
+		}
+		if got["a"].ResolutionSource != SourceTimeout || got["b"].ResolutionSource != SourceCascade {
+			t.Fatalf("timeout cascade resolutions = %+v", got)
+		}
+	})
+
+	t.Run("step up", func(t *testing.T) {
+		resolved := make(chan Resolution, 2)
+		m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 4, MaxPendingPerSession: 4, MaxCascadeDepth: 4})
+		for _, action := range []HeldAction{
+			{
+				DeferID:   "a",
+				ActionID:  "a",
+				Target:    "tool",
+				SizeBytes: 1,
+				Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+				RulePolicy: config.DeferResolutionPolicy{
+					StepUpOn: config.DeferStepUpOn{ApprovalRequestsHuman: true},
+				},
+			},
+			{
+				DeferID:   "b",
+				ActionID:  "b",
+				Target:    "tool",
+				SizeBytes: 1,
+				Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+			},
+		} {
+			action := action
+			action.Resolve = func(res Resolution) { resolved <- res }
+			if err := m.Hold(action); err != nil {
+				t.Fatalf("Hold(%s): %v", action.DeferID, err)
+			}
+		}
+		if err := m.ResolveApproval("a", config.ActionAsk); err != nil {
+			t.Fatalf("ResolveApproval(a): %v", err)
+		}
+		got := map[string]Resolution{}
+		for i := 0; i < 2; i++ {
+			res := <-resolved
+			got[res.DeferID] = res
+		}
+		if got["a"].FinalDecision != config.ActionAsk || got["b"].ResolutionSource != SourceCascade {
+			t.Fatalf("step-up cascade resolutions = %+v", got)
+		}
+	})
+}
+
+func TestManagerCascadeFixpointCatchesAttachDuringCascade(t *testing.T) {
+	m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 8, MaxPendingPerSession: 8, MaxCascadeDepth: 8})
+	resolved := make(chan Resolution, 4)
+	for _, id := range []string{"a", "b", "c"} {
+		id := id
+		if err := m.Hold(HeldAction{
+			DeferID:   id,
+			ActionID:  id,
+			Target:    "tool",
+			SizeBytes: 1,
+			Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+			Resolve: func(res Resolution) {
+				if res.DeferID == "b" && res.ResolutionSource == SourceCascade {
+					if err := m.Hold(HeldAction{
+						DeferID:   "d",
+						ActionID:  "d",
+						Target:    "tool",
+						SizeBytes: 1,
+						Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+						Resolve:   func(res Resolution) { resolved <- res },
+					}); err != nil {
+						t.Errorf("Hold(d) during cascade: %v", err)
+					}
+				}
+				resolved <- res
+			},
+		}); err != nil {
+			t.Fatalf("Hold(%s): %v", id, err)
+		}
+	}
+	if err := m.Resolve("a", config.ActionBlock, SourceApproval); err != nil {
+		t.Fatalf("Resolve(a): %v", err)
+	}
+	got := map[string]Resolution{}
+	for i := 0; i < 4; i++ {
+		res := waitResolution(t, resolved)
+		got[res.DeferID] = res
+	}
+	for _, id := range []string{"b", "c", "d"} {
+		if got[id].FinalDecision != config.ActionBlock || got[id].ResolutionSource != SourceCascade {
+			t.Fatalf("%s resolution = %+v, want cascade block", id, got[id])
+		}
+	}
+	if got["d"].ParentDeferID != "c" || got["d"].CascadeDepth != 4 {
+		t.Fatalf("attach-during-cascade child linkage = %+v, want parent c depth 4", got["d"])
+	}
+	if pending := m.Snapshot(); len(pending) != 0 {
+		t.Fatalf("pending after cascade fixpoint = %+v, want none", pending)
+	}
+}
+
+func TestManagerConcurrentResolveAllAndCascadeResolveExactlyOnce(t *testing.T) {
+	for iter := 0; iter < 25; iter++ {
+		m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 16, MaxPendingPerSession: 16, MaxCascadeDepth: 16})
+		resolved := make(chan Resolution, 8)
+		for i := 0; i < 8; i++ {
+			id := fmt.Sprintf("d%d", i)
+			if err := m.Hold(HeldAction{
+				DeferID:   id,
+				ActionID:  id,
+				Target:    "tool",
+				SizeBytes: 1,
+				Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+				Resolve:   func(res Resolution) { resolved <- res },
+			}); err != nil {
+				t.Fatalf("iter %d Hold(%s): %v", iter, id, err)
+			}
+		}
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = m.Resolve("d0", config.ActionBlock, SourceApproval)
+		}()
+		go func() {
+			defer wg.Done()
+			m.ResolveAll(config.ActionBlock, SourceKillSwitch)
+		}()
+		wg.Wait()
+
+		seen := map[string]Resolution{}
+		for i := 0; i < 8; i++ {
+			res := waitResolution(t, resolved)
+			if _, exists := seen[res.DeferID]; exists {
+				t.Fatalf("iter %d duplicate resolution for %s", iter, res.DeferID)
+			}
+			if res.FinalDecision != config.ActionBlock {
+				t.Fatalf("iter %d resolution = %+v, want block", iter, res)
+			}
+			seen[res.DeferID] = res
+		}
+		select {
+		case extra := <-resolved:
+			t.Fatalf("iter %d extra resolution: %+v", iter, extra)
+		default:
+		}
+		if pending := m.Snapshot(); len(pending) != 0 {
+			t.Fatalf("iter %d pending after concurrent resolve = %+v, want none", iter, pending)
+		}
 	}
 }
 
@@ -464,8 +952,11 @@ func TestResolveAllKillSwitchBlocksHeldActions(t *testing.T) {
 	m.ResolveAll(config.ActionBlock, SourceKillSwitch)
 	for i := 0; i < 2; i++ {
 		got := <-ch
-		if got.FinalDecision != config.ActionBlock || got.ResolutionSource != SourceKillSwitch {
-			t.Fatalf("kill switch resolution = %+v, want block kill_switch", got)
+		if got.FinalDecision != config.ActionBlock {
+			t.Fatalf("kill switch resolution = %+v, want block", got)
+		}
+		if got.ResolutionSource != SourceKillSwitch && got.ResolutionSource != SourceCascade {
+			t.Fatalf("kill switch resolution = %+v, want kill_switch or cascade", got)
 		}
 	}
 }
@@ -503,6 +994,52 @@ func TestRecordRestartRecoveryClearsPendingJournal(t *testing.T) {
 		t.Fatalf("pending count after recovery = %d, want 0", len(pending))
 	}
 	_ = m.Resolve("d1", config.ActionBlock, SourceCancel)
+}
+
+func TestPendingJournalRoundTripsCascadeFieldsAndPreUpgradeEntries(t *testing.T) {
+	t.Run("roundtrip cascade fields", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "deferred-actions.jsonl")
+		m := NewManager(Config{Enabled: true, Timeout: time.Hour, MaxPending: 4, MaxPendingPerSession: 4, MaxCascadeDepth: 4, JournalPath: path})
+		for _, id := range []string{"a", "b"} {
+			if err := m.Hold(HeldAction{
+				DeferID:   id,
+				ActionID:  id,
+				Target:    "tool",
+				Surface:   SurfaceMCPStdio,
+				SizeBytes: 1,
+				Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+				Resolve:   func(Resolution) {},
+			}); err != nil {
+				t.Fatalf("Hold(%s): %v", id, err)
+			}
+		}
+		pending, err := PendingJournal(path)
+		if err != nil {
+			t.Fatalf("PendingJournal: %v", err)
+		}
+		byID := map[string]HeldAction{}
+		for _, held := range pending {
+			byID[held.DeferID] = held
+		}
+		if byID["b"].ParentDeferID != "a" || byID["b"].CascadeDepth != 2 || byID["b"].Linkage != LinkageSessionPendingAncestor {
+			t.Fatalf("roundtripped child = %+v", byID["b"])
+		}
+	})
+
+	t.Run("pre-upgrade entry", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "deferred-actions.jsonl")
+		line := `{"defer_id":"legacy","action_id":"legacy-action","state":"deferred_held","authority":{"SessionID":"s1","SessionIDOriginal":"s1"},"timestamp":"2026-07-03T00:00:00Z"}` + "\n"
+		if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		pending, err := PendingJournal(path)
+		if err != nil {
+			t.Fatalf("PendingJournal: %v", err)
+		}
+		if len(pending) != 1 || pending[0].CascadeDepth != 0 || pending[0].ParentDeferID != "" || pending[0].Linkage != "" {
+			t.Fatalf("pre-upgrade pending = %+v", pending)
+		}
+	})
 }
 
 func TestPendingJournalEmptyMissingMalformedAndLongLine(t *testing.T) {
@@ -553,6 +1090,7 @@ func TestManagerTimerRace(t *testing.T) {
 		Timeout:              time.Nanosecond,
 		MaxPending:           512,
 		MaxPendingPerSession: 512,
+		MaxCascadeDepth:      512,
 		MaxPendingBytes:      1024 * 1024,
 	})
 	var wg sync.WaitGroup
@@ -584,4 +1122,15 @@ func TestManagerTimerRace(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timer resolutions did not complete")
 	}
+}
+
+func waitResolution(t *testing.T, ch <-chan Resolution) Resolution {
+	t.Helper()
+	select {
+	case res := <-ch:
+		return res
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for deferred resolution")
+	}
+	return Resolution{}
 }

--- a/internal/deferred/surfaces.go
+++ b/internal/deferred/surfaces.go
@@ -46,31 +46,31 @@ var surfaceSupport = []SurfaceSupport{
 		Surface:          SurfaceMCPHTTPListener,
 		Status:           StatusNotYetSupported,
 		RejectReason:     "reverse HTTP/SSE clients do not have a portable deferred-response and later-notification resume contract",
-		UnblockCondition: "add a cooperative pending-response protocol with tested later delivery semantics",
+		UnblockCondition: "add a cooperative pending-response protocol with tested later delivery semantics and stable per-session IDs for cascade linkage",
 	},
 	{
 		Surface:          SurfaceMCPWS,
 		Status:           StatusNotYetSupported,
 		RejectReason:     "ordered bidirectional streams need in-order buffering and backpressure before a held frame can resume without reordering",
-		UnblockCondition: "add ordered hold queues with bounded backpressure and no-reorder parity tests",
+		UnblockCondition: "add ordered hold queues with bounded backpressure, no-reorder parity tests, and stable per-session IDs for cascade linkage",
 	},
 	{
 		Surface:          SurfaceForwardProxy,
 		Status:           StatusNotYetSupported,
 		RejectReason:     "the client is blocked on one synchronous response and Pipelock has no later resume path",
-		UnblockCondition: "use a cooperative asynchronous action protocol instead of a synchronous proxy response",
+		UnblockCondition: "use a cooperative asynchronous action protocol instead of a synchronous proxy response, with stable per-session IDs for cascade linkage",
 	},
 	{
 		Surface:          SurfaceCONNECT,
 		Status:           StatusNotYetSupported,
 		RejectReason:     "the client is blocked on one synchronous tunnel decision and Pipelock has no later resume path",
-		UnblockCondition: "use a cooperative asynchronous action protocol instead of a synchronous proxy response",
+		UnblockCondition: "use a cooperative asynchronous action protocol instead of a synchronous proxy response, with stable per-session IDs for cascade linkage",
 	},
 	{
 		Surface:          SurfaceFetch,
 		Status:           StatusNotYetSupported,
 		RejectReason:     "the caller is blocked on one fetch response and Pipelock has no later resume path",
-		UnblockCondition: "use a cooperative asynchronous action protocol instead of a synchronous fetch response",
+		UnblockCondition: "use a cooperative asynchronous action protocol instead of a synchronous fetch response, with stable per-session IDs for cascade linkage",
 	},
 }
 
@@ -86,7 +86,7 @@ func LookupSurface(surface string) SurfaceSupport {
 		Surface:          surface,
 		Status:           StatusNotYetSupported,
 		RejectReason:     "surface is not registered for held-action resume",
-		UnblockCondition: "register the surface with a tested withhold and resume path",
+		UnblockCondition: "register the surface with a tested withhold and resume path plus stable per-session IDs for cascade linkage",
 	}
 }
 

--- a/internal/mcp/defer_resolution.go
+++ b/internal/mcp/defer_resolution.go
@@ -26,6 +26,18 @@ func EmitDeferredResolutionReceipt(opts MCPProxyOpts, logW io.Writer, res deferr
 	if final == "step_up" {
 		final = config.ActionAsk
 	}
+	var cascade *deferred.ReceiptCascade
+	if res.CascadeDepth > 0 || res.ParentDeferID != "" || res.Linkage != "" {
+		cascade = &deferred.ReceiptCascade{
+			ParentDeferID: res.ParentDeferID,
+			CascadeDepth:  res.CascadeDepth,
+			Linkage:       res.Linkage,
+		}
+	}
+	resolutionPolicy := ""
+	if cascade != nil {
+		resolutionPolicy = deferred.ReceiptPolicyStringFor(deferred.ReceiptPolicyOptions{Bounds: res.Policy, Cascade: cascade})
+	}
 	return emitMCPToolReceipt(mcpToolReceiptOpts{
 		Emitter:           opts.receiptEmitter(),
 		V2Emitter:         opts.v2ReceiptEmitter(),
@@ -44,6 +56,7 @@ func EmitDeferredResolutionReceipt(opts MCPProxyOpts, logW io.Writer, res deferr
 		RequireReceipt:    true,
 		DecisionPhase:     receipt.DecisionPhaseResolution,
 		DeferID:           res.DeferID,
+		ResolutionPolicy:  resolutionPolicy,
 		ResolutionSource:  res.ResolutionSource,
 		SessionID:         res.Authority.SessionID,
 		SessionIDOriginal: res.Authority.SessionIDOriginal,

--- a/internal/mcp/defer_resolution.go
+++ b/internal/mcp/defer_resolution.go
@@ -4,6 +4,7 @@
 package mcp
 
 import (
+	"errors"
 	"io"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -34,10 +35,9 @@ func EmitDeferredResolutionReceipt(opts MCPProxyOpts, logW io.Writer, res deferr
 			Linkage:       res.Linkage,
 		}
 	}
-	resolutionPolicy := ""
-	if cascade != nil {
-		resolutionPolicy = deferred.ReceiptPolicyStringFor(deferred.ReceiptPolicyOptions{Bounds: res.Policy, Cascade: cascade})
-	}
+	// Unconditional so capacity denials (no cascade context) still record the
+	// policy bounds; Cascade stays nil and marshals away via omitempty.
+	resolutionPolicy := deferred.ReceiptPolicyStringFor(deferred.ReceiptPolicyOptions{Bounds: res.Policy, Cascade: cascade})
 	return emitMCPToolReceipt(mcpToolReceiptOpts{
 		Emitter:           opts.receiptEmitter(),
 		V2Emitter:         opts.v2ReceiptEmitter(),
@@ -65,4 +65,49 @@ func EmitDeferredResolutionReceipt(opts MCPProxyOpts, logW io.Writer, res deferr
 
 func emitDeferredResolutionReceipt(opts MCPProxyOpts, logW io.Writer, res deferred.Resolution) error {
 	return EmitDeferredResolutionReceipt(opts, logW, res)
+}
+
+// holdFailureResolution carries the surface-specific fields for a failed
+// Manager.Hold so both defer transports emit identical denial receipts.
+type holdFailureResolution struct {
+	DeferID   string
+	Authority deferred.AuthoritySnapshot
+	Policy    deferred.ResolutionPolicy
+	Target    string
+	Method    string
+	Reason    string
+}
+
+// emitHoldFailureResolution classifies a failed Hold (capacity vs cascade
+// limit), emits the blocking resolution receipt, and returns the client-facing
+// error message. Shared by the stdio and HTTP-forward defer paths.
+func emitHoldFailureResolution(opts MCPProxyOpts, logW io.Writer, holdErr error, hf holdFailureResolution) string {
+	source := deferred.HoldFailureSource(holdErr)
+	cascadeDepth := 0
+	parentDeferID := ""
+	linkage := ""
+	var limitErr *deferred.CascadeLimitError
+	if errors.As(holdErr, &limitErr) {
+		cascadeDepth = limitErr.Depth
+		parentDeferID = limitErr.ParentDeferID
+		linkage = deferred.LinkageSessionPendingAncestor
+	}
+	_ = emitDeferredResolutionReceipt(opts, logW, deferred.Resolution{
+		DeferID:          hf.DeferID,
+		ParentActionID:   hf.DeferID,
+		FinalDecision:    config.ActionBlock,
+		ResolutionSource: source,
+		Authority:        hf.Authority,
+		ParentDeferID:    parentDeferID,
+		CascadeDepth:     cascadeDepth,
+		Linkage:          linkage,
+		Policy:           hf.Policy,
+		Target:           hf.Target,
+		Method:           hf.Method,
+		Reason:           hf.Reason,
+	})
+	if source == deferred.SourceCascadeLimit {
+		return "pipelock: defer cascade depth exceeded"
+	}
+	return "pipelock: defer capacity exceeded"
 }

--- a/internal/mcp/defer_resolution_test.go
+++ b/internal/mcp/defer_resolution_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/deferred"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+func TestEmitDeferredResolutionReceiptCarriesCascadePolicy(t *testing.T) {
+	emitter, rec, dir := newTestReceiptEmitter(t)
+	t.Cleanup(func() { _ = rec.Close() })
+
+	opts := MCPProxyOpts{
+		ReceiptEmitter:  emitter,
+		PolicyHash:      "policy-hash",
+		RequireReceipts: true,
+		Transport:       deferred.SurfaceMCPStdio,
+	}
+	var log bytes.Buffer
+	err := EmitDeferredResolutionReceipt(opts, &log, deferred.Resolution{
+		DeferID:          "child-defer",
+		ParentActionID:   "child-action",
+		FinalDecision:    config.ActionBlock,
+		ResolutionSource: deferred.SourceCascade,
+		Authority: deferred.AuthoritySnapshot{
+			SessionID:         "session-a",
+			SessionIDOriginal: "session-a",
+		},
+		ParentDeferID: "parent-defer",
+		CascadeDepth:  2,
+		Linkage:       deferred.LinkageSessionPendingAncestor,
+		Policy: deferred.ResolutionPolicy{
+			Timeout:              2 * time.Second,
+			MaxPending:           64,
+			MaxPendingPerSession: 8,
+			MaxPendingBytes:      1024 * 1024,
+			MaxCascadeDepth:      8,
+		},
+		Target: "neutral_tool",
+		Method: "tools/call",
+		Reason: "policy",
+	})
+	if err != nil {
+		t.Fatalf("EmitDeferredResolutionReceipt: %v log=%q", err, log.String())
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
+	recorded := findActionReceiptHTTP(t, readReceiptEntriesHTTP(t, dir)).ActionRecord
+	if recorded.ResolutionSource != deferred.SourceCascade {
+		t.Fatalf("resolution_source = %q, want cascade", recorded.ResolutionSource)
+	}
+	if recorded.DecisionPhase != receipt.DecisionPhaseResolution {
+		t.Fatalf("decision_phase = %q, want resolution", recorded.DecisionPhase)
+	}
+	var policy deferred.ReceiptPolicy
+	if err := json.Unmarshal([]byte(recorded.ResolutionPolicy), &policy); err != nil {
+		t.Fatalf("resolution_policy JSON: %v", err)
+	}
+	if policy.Cascade == nil {
+		t.Fatal("resolution_policy.cascade missing")
+	}
+	if policy.Cascade.ParentDeferID != "parent-defer" ||
+		policy.Cascade.CascadeDepth != 2 ||
+		policy.Cascade.Linkage != deferred.LinkageSessionPendingAncestor ||
+		policy.Bounds.MaxCascadeDepth != 8 {
+		t.Fatalf("resolution_policy = %+v", policy)
+	}
+}

--- a/internal/mcp/defer_resolution_test.go
+++ b/internal/mcp/defer_resolution_test.go
@@ -75,3 +75,60 @@ func TestEmitDeferredResolutionReceiptCarriesCascadePolicy(t *testing.T) {
 		t.Fatalf("resolution_policy = %+v", policy)
 	}
 }
+
+func TestEmitDeferredResolutionReceiptNonCascadeCarriesBounds(t *testing.T) {
+	emitter, rec, dir := newTestReceiptEmitter(t)
+	t.Cleanup(func() { _ = rec.Close() })
+
+	opts := MCPProxyOpts{
+		ReceiptEmitter:  emitter,
+		PolicyHash:      "policy-hash",
+		RequireReceipts: true,
+		Transport:       deferred.SurfaceMCPStdio,
+	}
+	var log bytes.Buffer
+	// Mirrors a plain capacity-exceeded Hold() failure: no cascade metadata.
+	err := EmitDeferredResolutionReceipt(opts, &log, deferred.Resolution{
+		DeferID:          "capacity-defer",
+		ParentActionID:   "capacity-defer",
+		FinalDecision:    config.ActionBlock,
+		ResolutionSource: deferred.SourceCapacity,
+		Authority: deferred.AuthoritySnapshot{
+			SessionID:         "session-a",
+			SessionIDOriginal: "session-a",
+		},
+		Policy: deferred.ResolutionPolicy{
+			Timeout:              2 * time.Second,
+			MaxPending:           64,
+			MaxPendingPerSession: 8,
+			MaxPendingBytes:      1024 * 1024,
+			MaxCascadeDepth:      8,
+		},
+		Target: "neutral_tool",
+		Method: "tools/call",
+		Reason: "capacity",
+	})
+	if err != nil {
+		t.Fatalf("EmitDeferredResolutionReceipt: %v log=%q", err, log.String())
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
+	recorded := findActionReceiptHTTP(t, readReceiptEntriesHTTP(t, dir)).ActionRecord
+	if recorded.ResolutionSource != deferred.SourceCapacity {
+		t.Fatalf("resolution_source = %q, want capacity", recorded.ResolutionSource)
+	}
+	if recorded.ResolutionPolicy == "" {
+		t.Fatal("resolution_policy missing on non-cascade denial")
+	}
+	var policy deferred.ReceiptPolicy
+	if err := json.Unmarshal([]byte(recorded.ResolutionPolicy), &policy); err != nil {
+		t.Fatalf("resolution_policy JSON: %v", err)
+	}
+	if policy.Cascade != nil {
+		t.Fatalf("resolution_policy.cascade = %+v, want nil", policy.Cascade)
+	}
+	if policy.Bounds.MaxCascadeDepth != 8 || policy.Bounds.MaxPending != 64 {
+		t.Fatalf("resolution_policy bounds = %+v", policy.Bounds)
+	}
+}

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -1119,38 +1119,18 @@ func ForwardScannedInput(
 				},
 			})
 			if holdErr != nil {
-				source := deferred.HoldFailureSource(holdErr)
-				cascadeDepth := 0
-				parentDeferID := ""
-				linkage := ""
-				var limitErr *deferred.CascadeLimitError
-				if errors.As(holdErr, &limitErr) {
-					cascadeDepth = limitErr.Depth
-					parentDeferID = limitErr.ParentDeferID
-					linkage = deferred.LinkageSessionPendingAncestor
-				}
-				_ = emitDeferredResolutionReceipt(opts, logW, deferred.Resolution{
-					DeferID:          actionID,
-					ParentActionID:   actionID,
-					FinalDecision:    config.ActionBlock,
-					ResolutionSource: source,
+				errorMessage := emitHoldFailureResolution(opts, logW, holdErr, holdFailureResolution{
+					DeferID: actionID,
 					Authority: deferred.AuthoritySnapshot{
 						SessionID:         receiptSessionID,
 						SessionIDOriginal: receiptSessionIDOriginal,
 					},
-					ParentDeferID: parentDeferID,
-					CascadeDepth:  cascadeDepth,
-					Linkage:       linkage,
-					Policy:        manager.Policy(),
-					Target:        toolCallName,
-					Method:        verdict.Method,
-					Reason:        reasonStr,
+					Policy: manager.Policy(),
+					Target: toolCallName,
+					Method: verdict.Method,
+					Reason: reasonStr,
 				})
 				if !isNotification {
-					errorMessage := "pipelock: defer capacity exceeded"
-					if source == deferred.SourceCascadeLimit {
-						errorMessage = "pipelock: defer cascade depth exceeded"
-					}
 					blockedCh <- BlockedRequest{
 						ID:           verdict.ID,
 						ErrorCode:    -32002,

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -1119,24 +1119,42 @@ func ForwardScannedInput(
 				},
 			})
 			if holdErr != nil {
+				source := deferred.HoldFailureSource(holdErr)
+				cascadeDepth := 0
+				parentDeferID := ""
+				linkage := ""
+				var limitErr *deferred.CascadeLimitError
+				if errors.As(holdErr, &limitErr) {
+					cascadeDepth = limitErr.Depth
+					parentDeferID = limitErr.ParentDeferID
+					linkage = deferred.LinkageSessionPendingAncestor
+				}
 				_ = emitDeferredResolutionReceipt(opts, logW, deferred.Resolution{
 					DeferID:          actionID,
 					ParentActionID:   actionID,
 					FinalDecision:    config.ActionBlock,
-					ResolutionSource: deferred.SourceCapacity,
+					ResolutionSource: source,
 					Authority: deferred.AuthoritySnapshot{
 						SessionID:         receiptSessionID,
 						SessionIDOriginal: receiptSessionIDOriginal,
 					},
-					Target: toolCallName,
-					Method: verdict.Method,
-					Reason: reasonStr,
+					ParentDeferID: parentDeferID,
+					CascadeDepth:  cascadeDepth,
+					Linkage:       linkage,
+					Policy:        manager.Policy(),
+					Target:        toolCallName,
+					Method:        verdict.Method,
+					Reason:        reasonStr,
 				})
 				if !isNotification {
+					errorMessage := "pipelock: defer capacity exceeded"
+					if source == deferred.SourceCascadeLimit {
+						errorMessage = "pipelock: defer cascade depth exceeded"
+					}
 					blockedCh <- BlockedRequest{
 						ID:           verdict.ID,
 						ErrorCode:    -32002,
-						ErrorMessage: "pipelock: defer capacity exceeded",
+						ErrorMessage: errorMessage,
 					}
 				}
 				effectiveAction = config.ActionBlock

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -269,38 +269,18 @@ func RunHTTPProxy(
 				},
 			})
 			if holdErr != nil {
-				source := deferred.HoldFailureSource(holdErr)
-				cascadeDepth := 0
-				parentDeferID := ""
-				linkage := ""
-				var limitErr *deferred.CascadeLimitError
-				if errors.As(holdErr, &limitErr) {
-					cascadeDepth = limitErr.Depth
-					parentDeferID = limitErr.ParentDeferID
-					linkage = deferred.LinkageSessionPendingAncestor
-				}
-				_ = emitDeferredResolutionReceipt(fwdOpts, safeLogW, deferred.Resolution{
-					DeferID:          deferredReq.DeferID,
-					ParentActionID:   deferredReq.DeferID,
-					FinalDecision:    config.ActionBlock,
-					ResolutionSource: source,
+				errorMessage := emitHoldFailureResolution(fwdOpts, safeLogW, holdErr, holdFailureResolution{
+					DeferID: deferredReq.DeferID,
 					Authority: deferred.AuthoritySnapshot{
 						SessionID:         deferredReq.SessionID,
 						SessionIDOriginal: deferredReq.SessionIDOriginal,
 					},
-					ParentDeferID: parentDeferID,
-					CascadeDepth:  cascadeDepth,
-					Linkage:       linkage,
-					Policy:        manager.Policy(),
-					Target:        deferredReq.ToolName,
-					Method:        deferredReq.Method,
-					Reason:        deferredReq.Reason,
+					Policy: manager.Policy(),
+					Target: deferredReq.ToolName,
+					Method: deferredReq.Method,
+					Reason: deferredReq.Reason,
 				})
 				if !deferredReq.IsNotification {
-					errorMessage := "pipelock: defer capacity exceeded"
-					if source == deferred.SourceCascadeLimit {
-						errorMessage = "pipelock: defer cascade depth exceeded"
-					}
 					_ = safeClientOut.WriteMessage(blockRequestResponse(BlockedRequest{
 						ID:           deferredReq.ID,
 						ErrorCode:    -32002,

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -269,24 +269,42 @@ func RunHTTPProxy(
 				},
 			})
 			if holdErr != nil {
+				source := deferred.HoldFailureSource(holdErr)
+				cascadeDepth := 0
+				parentDeferID := ""
+				linkage := ""
+				var limitErr *deferred.CascadeLimitError
+				if errors.As(holdErr, &limitErr) {
+					cascadeDepth = limitErr.Depth
+					parentDeferID = limitErr.ParentDeferID
+					linkage = deferred.LinkageSessionPendingAncestor
+				}
 				_ = emitDeferredResolutionReceipt(fwdOpts, safeLogW, deferred.Resolution{
 					DeferID:          deferredReq.DeferID,
 					ParentActionID:   deferredReq.DeferID,
 					FinalDecision:    config.ActionBlock,
-					ResolutionSource: deferred.SourceCapacity,
+					ResolutionSource: source,
 					Authority: deferred.AuthoritySnapshot{
 						SessionID:         deferredReq.SessionID,
 						SessionIDOriginal: deferredReq.SessionIDOriginal,
 					},
-					Target: deferredReq.ToolName,
-					Method: deferredReq.Method,
-					Reason: deferredReq.Reason,
+					ParentDeferID: parentDeferID,
+					CascadeDepth:  cascadeDepth,
+					Linkage:       linkage,
+					Policy:        manager.Policy(),
+					Target:        deferredReq.ToolName,
+					Method:        deferredReq.Method,
+					Reason:        deferredReq.Reason,
 				})
 				if !deferredReq.IsNotification {
+					errorMessage := "pipelock: defer capacity exceeded"
+					if source == deferred.SourceCascadeLimit {
+						errorMessage = "pipelock: defer cascade depth exceeded"
+					}
 					_ = safeClientOut.WriteMessage(blockRequestResponse(BlockedRequest{
 						ID:           deferredReq.ID,
 						ErrorCode:    -32002,
-						ErrorMessage: "pipelock: defer capacity exceeded",
+						ErrorMessage: errorMessage,
 					}))
 				}
 			} else if held, ok := manager.Held(deferredReq.DeferID); ok && deferredReq.ResolverProfileName != "" {


### PR DESCRIPTION
## What changed

Held (deferred) MCP actions had no relationship to one another, which left two gaps: an agent could form an unbounded chain of same-session holds while earlier ones were still pending, and a parent's non-allow resolution left dependent held actions to sit until their own timeout.

This adds:

- Pending-ancestor linkage. At admission, a new hold's parent is the newest still-held action in the same session; its cascade depth is the parent's depth plus one, resetting to 1 when nothing in the session is pending. It records a temporal fact the proxy observed, not a claim that the child consumed the parent's data.
- `defer.max_cascade_depth` (default 8, equal to `max_pending_per_session` so no burst that is legal today is newly denied). Exceeding it denies the new action at admission, before any held state, timer, or journal entry exists, with `resolution_source: "cascade_limit"`.
- Cascade block. When a parent resolves to anything other than allow (block, timeout, step-up, kill switch, cancel, policy-reload block), every still-held descendant is blocked with `resolution_source: "cascade"` via a fixpoint sweep that runs before the parent's own resolution callback, so no descendant can slip through. A parent allow propagates nothing: each descendant still resolves only on its own affirmative signals. Fail-closed throughout; restart recovery blocks all pending in depth order and recovers even when defer is disabled at the next start.
- No receipt schema or version change. Linkage rides in the already-signed `resolution_source` and `resolution_policy` fields, so every shipped verifier verifies cascade-bearing chains unchanged. An additive Go verifier chain lint validates cascade metadata after signature verification: order-independent, rejecting tampered depth or linkage, duplicate resolutions, and truncated (non-terminal) parents, and skipping pre-upgrade receipts.

No new dependencies. The config field, defaults, validation (rejects negative; warns when set while defer is disabled), canonical config-hash goldens, and docs land together. Agent-declared linkage and a per-parent child cap are intentionally out of scope; they need a call-site-supplied dependency signal that does not exist yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cascade depth limits for deferred actions, including tracking parent/child cascade relationships and emitting richer cascade resolution details.
  * Introduced `defer.max_cascade_depth` configuration to control the maximum allowed cascade depth.
* **Bug Fixes**
  * Verification now performs additional cascade-specific checks and rejects invalid cascade-linked action chains.
  * Improved deferred recovery and MCP proxy behavior for deterministic ordering and correct cascade metadata.
* **Documentation**
  * Updated defer action documentation with cascade behavior and the new `defer.max_cascade_depth` setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->