### PR TITLE
feat(dashboard): pipelock dashboard serve command for the Evidence view

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -18,4 +18,5 @@ the full command tree and `pipelock <command> --help` for any command's flags.
 | [`pipelock mcp integrity manifest`](mcp-integrity.md) | Generate and verify MCP server binary-integrity manifests. |
 | [`pipelock init sidecar`](init-sidecar.md) | Generate an enforced Pipelock companion proxy for a Kubernetes workload. |
 | [`pipelock license`](license.md) | Install, inspect, and check the license that unlocks paid features. |
+| [`pipelock dashboard serve`](dashboard.md) | Serve the read-only Evidence dashboard over a flight-recorder directory (Pro/Enterprise). |
 | [`pipelock update`](update.md) | Check for, verify, and install a newer Pipelock release; roll back to the previous binary. |

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -28,7 +28,8 @@ pipelock dashboard serve \
   --trusted-signer 'file=/etc/pipelock/receipt-signing.pub,source=ops runbook'
 ```
 
-Then open `http://127.0.0.1:8896/` in a browser. The browser prompts for
+Then open `http://127.0.0.1:8896/` in a browser (`https://` when
+`--tls-cert`/`--tls-key` are set). The browser prompts for
 credentials: enter any username and the token file's contents as the password.
 Automation can send the same token as a bearer header:
 

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -1,0 +1,94 @@
+<!--
+Copyright 2026 Josh Waldrep
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# `pipelock dashboard`
+
+Serve the read-only Evidence dashboard: a web view over the signed action
+receipts in a flight-recorder evidence directory. It renders each recorder
+session with a four-line scorecard — **Authentic**, **Untampered**,
+**Anchored**, **Completeness** — where every line is an independent fact.
+There is deliberately no aggregate "all clear": Completeness is always limited
+to mediated traffic, Anchored is never green without an external inclusion
+proof, and signers are only shown as trusted when the operator configured
+their keys (never trust-on-first-use).
+
+The command ships in official release builds (enterprise-tagged) and requires
+a license that grants the `agents` feature (Pro or Enterprise); without one it
+refuses to start. The dashboard is read-only: it renders evidence and never
+mutates policy, receipts, or runtime state.
+
+## `pipelock dashboard serve`
+
+```bash
+pipelock dashboard serve \
+  --receipt-dir /var/lib/pipelock/evidence \
+  --auth-token-file /etc/pipelock/dashboard.token \
+  --trusted-signer 'file=/etc/pipelock/receipt-signing.pub,source=ops runbook'
+```
+
+Then open `http://127.0.0.1:8896/` in a browser. The browser prompts for
+credentials: enter any username and the token file's contents as the password.
+Automation can send the same token as a bearer header:
+
+```bash
+curl -H "Authorization: Bearer $(cat /etc/pipelock/dashboard.token)" http://127.0.0.1:8896/
+```
+
+Create the token file once, readable only by the operator:
+
+```bash
+umask 077
+openssl rand -hex 32 > /etc/pipelock/dashboard.token
+```
+
+### Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--receipt-dir` | (required) | Flight-recorder evidence directory holding action receipts (the runtime's `flight_recorder.dir`). |
+| `--auth-token-file` | (required) | File containing the operator token required on every request. |
+| `--listen` | `127.0.0.1:8896` | Dashboard listener address. Non-loopback addresses require `--tls-cert`/`--tls-key`. |
+| `--trusted-signer` | none | Trusted receipt signing key: `(inline=HEX_OR_VERSIONED_PUBLIC_KEY\|file=/path)[,source=LABEL]`. Repeatable. `source` is shown in the UI as the reason the key is trusted. |
+| `--license-crl-file` | none | Signed license revocation list; falls back to `PIPELOCK_LICENSE_CRL_FILE`. |
+| `--tls-cert`, `--tls-key` | none | TLS server certificate and key. Both or neither. |
+
+### License resolution
+
+`dashboard serve` takes no config file. Like the other server commands, it
+resolves the license token from `PIPELOCK_LICENSE_KEY` and verifies it against
+the build-embedded public key (or `PIPELOCK_LICENSE_PUBLIC_KEY` on unofficial
+builds). Verification fails closed before any listener binds, and the feature
+entitlement is re-checked on every request, so a license that expires while
+the server is running stops serving.
+
+### Security model
+
+- **Dedicated listener, never the proxy port.** The dashboard binds its own
+  address, following the same port-isolation principle as
+  `kill_switch.api_listen`: an agent routed through the proxy has no path to
+  its own evidence view. Isolation from an agent running on the same host as
+  a different user is deployment guidance (containment/network policy), not a
+  property this command can enforce by itself — which is why the token is
+  required even on loopback.
+- **The license check is entitlement, not identity.** Every request must also
+  carry the operator token (constant-time comparison), as a `Bearer` header or
+  as the Basic-auth password. Requests without it get `401` and no evidence.
+- **Cleartext refusal.** Without TLS the listener only accepts loopback
+  addresses; serving a non-loopback address over plain HTTP is refused at
+  startup because the operator token would transit in cleartext.
+- **No trust-on-first-use.** Signer keys are trusted only via
+  `--trusted-signer`. With no trusted keys configured the dashboard still
+  serves, and the Authentic line honestly reports every signer as Unverified.
+- **Sensitive by design.** The evidence view includes destinations, block
+  reasons, signer fingerprints, and session IDs. Treat the listener like an
+  admin API: keep it loopback or behind TLS on a network only operators reach.
+
+### Verify it yourself
+
+The dashboard is a lens, not the proof. Every session view includes the exact
+offline `pipelock-verifier verify-run` command that re-verifies the same
+receipts against the trusted key, so anything the dashboard claims can be
+independently re-checked against the signed evidence — without trusting this
+server.

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -1,0 +1,392 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package entcli
+
+import (
+	"context"
+	"crypto/subtle"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/dashboard"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	// dashboardDefaultListen is loopback-only by design: the dashboard is an
+	// authenticated admin surface on its own dedicated listener, never the
+	// agent-reachable proxy port (same port-isolation principle as
+	// kill_switch.api_listen).
+	dashboardDefaultListen  = "127.0.0.1:8896"
+	dashboardShutdownPeriod = 5 * time.Second
+	// trustedSignerDefaultSource labels a trusted key whose --trusted-signer
+	// value did not carry an explicit source= reason.
+	trustedSignerDefaultSource = "--trusted-signer flag"
+)
+
+// DashboardCmd returns the `pipelock dashboard` command tree (Pro/Enterprise).
+func DashboardCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dashboard",
+		Short: "Web dashboard over Pipelock evidence (Pro/Enterprise)",
+	}
+	cmd.AddCommand(dashboardServeCmd())
+	return cmd
+}
+
+type dashboardServeOptions struct {
+	listen         string
+	receiptDir     string
+	authTokenFile  string
+	trustedSigners []string
+	licenseCRLFile string
+	tlsCert        string
+	tlsKey         string
+}
+
+func dashboardServeCmd() *cobra.Command {
+	opts := dashboardServeOptions{listen: dashboardDefaultListen}
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Serve the read-only Evidence dashboard on a dedicated listener",
+		Long: `Serve the read-only Evidence dashboard over a flight-recorder evidence
+directory. Every request must authenticate with the operator token from
+--auth-token-file, sent either as "Authorization: Bearer <token>" or as the
+password of an HTTP Basic prompt (any username). The license feature check is
+entitlement, not identity; the token is the authentication boundary.
+
+Without --tls-cert/--tls-key the listener refuses non-loopback addresses,
+because the operator token would transit in cleartext.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// License gate: the dashboard is a paid surface. Fail closed before
+			// any listener bind or file IO so an unlicensed invocation produces
+			// a clear entitlement error instead of a half-started server.
+			lic, err := license.VerifyAgentsWithOptions(license.FleetVerifyInputs{CRLFile: opts.licenseCRLFile})
+			if err != nil {
+				return err
+			}
+			return runDashboardServe(cmd, opts, lic)
+		},
+	}
+	cmd.Flags().StringVar(&opts.listen, "listen", opts.listen,
+		"address for the dashboard listener; non-loopback addresses require --tls-cert/--tls-key")
+	cmd.Flags().StringVar(&opts.receiptDir, "receipt-dir", "",
+		"flight-recorder evidence directory holding action receipts (flight_recorder.dir)")
+	cmd.Flags().StringVar(&opts.authTokenFile, "auth-token-file", "",
+		"file containing the operator token required on every dashboard request")
+	cmd.Flags().StringArrayVar(&opts.trustedSigners, "trusted-signer", nil,
+		"trusted receipt signing key as comma-separated kv pairs: "+
+			"'(inline=HEX_OR_VERSIONED_PUBLIC_KEY|file=/path)[,source=LABEL]'; repeatable")
+	cmd.Flags().StringVar(&opts.licenseCRLFile, "license-crl-file", "",
+		"signed license revocation list file; falls back to PIPELOCK_LICENSE_CRL_FILE")
+	cmd.Flags().StringVar(&opts.tlsCert, "tls-cert", "", "TLS server certificate file")
+	cmd.Flags().StringVar(&opts.tlsKey, "tls-key", "", "TLS server private key file")
+	_ = cmd.MarkFlagRequired("receipt-dir")
+	_ = cmd.MarkFlagRequired("auth-token-file")
+	return cmd
+}
+
+func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic license.License) error {
+	token, err := loadDashboardTokenFile(opts.authTokenFile)
+	if err != nil {
+		return err
+	}
+	trusted, err := parseTrustedSigners(opts.trustedSigners)
+	if err != nil {
+		return err
+	}
+	if err := validateDashboardListen(opts); err != nil {
+		return err
+	}
+	tlsConfig, err := dashboardTLSConfig(opts)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(filepath.Clean(opts.receiptDir))
+	if err != nil {
+		return fmt.Errorf("--receipt-dir: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("--receipt-dir %q is not a directory", opts.receiptDir)
+	}
+	if len(trusted) == 0 {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+			"pipelock: warning: no --trusted-signer configured; the Authentic line will render every signer as Unverified")
+	}
+
+	inner := dashboard.New(dashboard.Options{
+		ReceiptDir:  opts.receiptDir,
+		TrustedKeys: trusted,
+		HasFeature:  dashboardRuntimeHasFeature(lic),
+		Authorize:   dashboardAuthorizeFunc(token),
+	})
+	handler := dashboardAuthHandler(token, inner)
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	baseCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	runCtx, stop := signal.NotifyContext(baseCtx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	server := &http.Server{
+		Addr:              opts.listen,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    64 * 1024,
+		TLSConfig:         tlsConfig,
+	}
+	ln, err := (&net.ListenConfig{}).Listen(runCtx, "tcp", opts.listen)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		<-runCtx.Done()
+		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), dashboardShutdownPeriod)
+		defer cancelShutdown()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	useTLS := opts.tlsCert != ""
+	scheme := "http"
+	if useTLS {
+		scheme = "https"
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "pipelock: dashboard listening on %s://%s\n", scheme, ln.Addr())
+
+	if useTLS {
+		err = server.ServeTLS(ln, "", "")
+	} else {
+		err = server.Serve(ln)
+	}
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+func dashboardTLSConfig(opts dashboardServeOptions) (*tls.Config, error) {
+	if opts.tlsCert == "" {
+		return nil, nil
+	}
+	cert, err := tls.LoadX509KeyPair(filepath.Clean(opts.tlsCert), filepath.Clean(opts.tlsKey))
+	if err != nil {
+		return nil, fmt.Errorf("load dashboard TLS certificate: %w", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}
+
+// validateDashboardListen refuses configurations that would put the operator
+// token on the wire in cleartext: without TLS, only loopback addresses are
+// allowed. TLS flags must come as a pair.
+func validateDashboardListen(opts dashboardServeOptions) error {
+	if (opts.tlsCert == "") != (opts.tlsKey == "") {
+		return errors.New("--tls-cert and --tls-key must be set together")
+	}
+	if opts.tlsCert != "" {
+		return nil
+	}
+	host, _, err := net.SplitHostPort(opts.listen)
+	if err != nil {
+		return fmt.Errorf("--listen %q: %w", opts.listen, err)
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf("refusing to serve the dashboard over cleartext HTTP on non-loopback address %q; "+
+		"every request carries the operator token, so add --tls-cert/--tls-key or keep --listen on 127.0.0.1", opts.listen)
+}
+
+// dashboardAuthorizeFunc is the Options.Authorize seam: defense in depth
+// behind the outer dashboardAuthHandler boundary, so the dashboard handler
+// itself fails closed (403) if it is ever mounted without that boundary.
+func dashboardAuthorizeFunc(token string) func(*http.Request) error {
+	return func(r *http.Request) error {
+		if !dashboardRequestAuthorized(r, token) {
+			return errors.New("dashboard request not authenticated")
+		}
+		return nil
+	}
+}
+
+// dashboardAuthHandler is the outer authentication boundary. It answers 401
+// with a WWW-Authenticate challenge so browsers prompt for credentials; the
+// inner dashboard handler re-checks the same token via Options.Authorize as
+// defense in depth.
+func dashboardAuthHandler(token string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !dashboardRequestAuthorized(r, token) {
+			w.Header().Set("WWW-Authenticate", `Basic realm="pipelock dashboard", charset="UTF-8"`)
+			http.Error(w, "authentication required", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// dashboardRequestAuthorized accepts the operator token as either a Bearer
+// token (automation) or the password of an HTTP Basic credential (browsers;
+// the username is ignored). Comparisons are constant-time.
+func dashboardRequestAuthorized(r *http.Request, token string) bool {
+	if token == "" {
+		return false // fail closed: no configured token means no access
+	}
+	const bearerPrefix = "bearer "
+	auth := r.Header.Get("Authorization")
+	if len(auth) > len(bearerPrefix) && strings.EqualFold(auth[:len(bearerPrefix)], bearerPrefix) {
+		got := strings.TrimSpace(auth[len(bearerPrefix):])
+		return subtle.ConstantTimeCompare([]byte(got), []byte(token)) == 1
+	}
+	if _, pass, ok := r.BasicAuth(); ok {
+		return subtle.ConstantTimeCompare([]byte(pass), []byte(token)) == 1
+	}
+	return false
+}
+
+// dashboardRuntimeHasFeature wraps the boot-time-verified license's feature
+// check with a runtime expiry re-check so a license that expires while the
+// server is running stops serving. Mirrors the AgentRegistry.Lookup expiry
+// rule; the startup Verify only proves validity at boot.
+func dashboardRuntimeHasFeature(lic license.License) func(string) bool {
+	return func(feature string) bool {
+		if lic.ExpiresAt > 0 && time.Now().Unix() > lic.ExpiresAt {
+			return false
+		}
+		return lic.HasFeature(feature)
+	}
+}
+
+// parseTrustedSigners parses repeated --trusted-signer values into the
+// operator trusted-key set. An empty flag list returns nil: the dashboard then
+// honestly renders every signer as Unverified (never trust-on-first-use).
+func parseTrustedSigners(values []string) (map[string]dashboard.TrustedKey, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]dashboard.TrustedKey, len(values))
+	for _, raw := range values {
+		keyHex, source, err := parseTrustedSignerSpec(raw)
+		if err != nil {
+			return nil, fmt.Errorf("--trusted-signer %q: %w", raw, err)
+		}
+		if _, dup := out[keyHex]; dup {
+			return nil, fmt.Errorf("--trusted-signer %q: duplicate key %s", raw, keyHex)
+		}
+		out[keyHex] = dashboard.TrustedKey{Source: source}
+	}
+	return out, nil
+}
+
+// parseTrustedSignerSpec parses one --trusted-signer value: comma-separated
+// kv pairs with exactly one key source, '(inline=<hex-or-versioned>|file=/path)',
+// plus an optional 'source=LABEL' shown in the UI as the reason the key is
+// trusted.
+func parseTrustedSignerSpec(raw string) (keyHex, source string, err error) {
+	var inline, file string
+	var hasInline, hasFile, hasSource bool
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(part, "=")
+		if !ok {
+			return "", "", fmt.Errorf("expected key=value, got %q", part)
+		}
+		v = strings.TrimSpace(v)
+		switch strings.TrimSpace(k) {
+		case "inline":
+			if hasInline {
+				return "", "", errors.New("inline= may appear only once")
+			}
+			if v == "" {
+				return "", "", errors.New("inline= value is empty")
+			}
+			hasInline = true
+			inline = v
+		case "file":
+			if hasFile {
+				return "", "", errors.New("file= may appear only once")
+			}
+			if v == "" {
+				return "", "", errors.New("file= value is empty")
+			}
+			hasFile = true
+			file = v
+		case "source":
+			if hasSource {
+				return "", "", errors.New("source= may appear only once")
+			}
+			hasSource = true
+			source = v
+		default:
+			return "", "", fmt.Errorf("unknown key %q", k)
+		}
+	}
+	switch {
+	case inline != "" && file != "":
+		return "", "", errors.New("inline= and file= are mutually exclusive")
+	case inline == "" && file == "":
+		return "", "", errors.New("one of inline= or file= is required")
+	case file != "":
+		data, readErr := os.ReadFile(filepath.Clean(file))
+		if readErr != nil {
+			return "", "", fmt.Errorf("read key file: %w", readErr)
+		}
+		inline = strings.TrimSpace(string(data))
+	}
+	// signing.ParsePublicKey enforces the Ed25519 key size on both the
+	// versioned and raw-hex paths, so a parsed key is always well-formed.
+	pub, err := signing.ParsePublicKey(inline)
+	if err != nil {
+		return "", "", fmt.Errorf("parse public key: %w", err)
+	}
+	if source == "" {
+		source = trustedSignerDefaultSource
+	}
+	return hex.EncodeToString(pub), source, nil
+}
+
+// loadDashboardTokenFile reads and validates the required operator token file.
+// Mirrors the conductor loadTokenFile semantics: trimmed and non-empty.
+func loadDashboardTokenFile(path string) (string, error) {
+	const flag = "--auth-token-file"
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("%s is required", flag)
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", flag, err)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", fmt.Errorf("%s is empty", flag)
+	}
+	return token, nil
+}

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -1,0 +1,728 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package entcli
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/dashboard"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
+)
+
+// dashTestToken is built by concatenation so credential linters do not flag a
+// literal secret; it is a test-only value.
+var dashTestToken = "dash-test-" + "operator-token"
+
+type dashSyncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *dashSyncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *dashSyncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *dashSyncBuffer) contains(s string) bool {
+	return strings.Contains(b.String(), s)
+}
+
+func newDashKeyPair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+func issueDashLicense(t *testing.T, priv ed25519.PrivateKey, features []string) string {
+	t.Helper()
+	tok, err := license.Issue(license.License{
+		ID:        "lic_dash_test",
+		Email:     "test@example.com",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		Features:  features,
+	}, priv)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	return tok
+}
+
+// setDashLicenseEnv pins every license-relevant env variable so tests are
+// hermetic regardless of the host environment.
+func setDashLicenseEnv(t *testing.T, tok, pubHex string) {
+	t.Helper()
+	t.Setenv(license.EnvLicenseKey, tok)
+	t.Setenv(license.EnvLicensePublicKey, pubHex)
+	t.Setenv(license.EnvLicenseCRLFile, "")
+	t.Setenv(license.EnvLicenseIntermediateFile, "")
+}
+
+func writeDashTokenFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "dashboard.token")
+	if err := os.WriteFile(path, []byte(dashTestToken+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func TestDashboardCmd_Tree(t *testing.T) {
+	cmd := DashboardCmd()
+	if cmd.Use != "dashboard" {
+		t.Fatalf("Use = %q, want dashboard", cmd.Use)
+	}
+	serve, _, err := cmd.Find([]string{"serve"})
+	if err != nil || serve.Use != "serve" {
+		t.Fatalf("dashboard serve subcommand not found: %v", err)
+	}
+	for _, flag := range []string{"listen", "receipt-dir", "auth-token-file", "trusted-signer", "license-crl-file", "tls-cert", "tls-key"} {
+		if serve.Flags().Lookup(flag) == nil {
+			t.Errorf("serve is missing --%s", flag)
+		}
+	}
+}
+
+func TestDashboardServe_FailsClosedWithoutLicense(t *testing.T) {
+	setDashLicenseEnv(t, "", "")
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{"--receipt-dir", t.TempDir(), "--auth-token-file", writeDashTokenFile(t)})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if !errors.Is(err, license.ErrAgentsLicenseRequired) {
+		t.Fatalf("serve without license: want ErrAgentsLicenseRequired, got %v", err)
+	}
+}
+
+func TestDashboardServe_FailsClosedWithoutAgentsFeature(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAssess}), hex.EncodeToString(pub))
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{"--receipt-dir", t.TempDir(), "--auth-token-file", writeDashTokenFile(t)})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if !errors.Is(err, license.ErrAgentsLicenseRequired) {
+		t.Fatalf("serve without agents feature: want ErrAgentsLicenseRequired, got %v", err)
+	}
+}
+
+func TestDashboardServe_RefusesNonLoopbackWithoutTLS(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", writeDashTokenFile(t),
+		"--listen", "0.0.0.0:0",
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "refusing to serve") {
+		t.Fatalf("non-loopback cleartext listen: want refusal, got %v", err)
+	}
+}
+
+func TestDashboardServe_RejectsMissingReceiptDir(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", filepath.Join(t.TempDir(), "does-not-exist"),
+		"--auth-token-file", writeDashTokenFile(t),
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--receipt-dir") {
+		t.Fatalf("missing receipt dir: want --receipt-dir error, got %v", err)
+	}
+}
+
+func TestDashboardServe_EndToEnd(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+
+	out := &dashSyncBuffer{}
+	errOut := &dashSyncBuffer{}
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", writeDashTokenFile(t),
+		"--listen", "127.0.0.1:0",
+	})
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- cmd.ExecuteContext(ctx) }()
+
+	testwait.For(t, 10*time.Second, func() bool { return out.contains("dashboard listening on") },
+		"serve never printed the listening banner; stderr: %s", errOut.String())
+
+	addrRe := regexp.MustCompile(`listening on http://(127\.0\.0\.1:\d+)`)
+	m := addrRe.FindStringSubmatch(out.String())
+	if m == nil {
+		t.Fatalf("could not parse listen address from output %q", out.String())
+	}
+	base := "http://" + m[1]
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	get := func(auth string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("GET /: %v", err)
+		}
+		return resp
+	}
+
+	t.Run("no auth is 401 with challenge", func(t *testing.T) {
+		resp := get("")
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+		if !strings.Contains(resp.Header.Get("WWW-Authenticate"), "Basic") {
+			t.Errorf("missing WWW-Authenticate Basic challenge")
+		}
+	})
+
+	t.Run("wrong bearer is 401", func(t *testing.T) {
+		resp := get("Bearer wrong-value")
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("bearer token is 200 html", func(t *testing.T) {
+		resp := get("Bearer " + dashTestToken)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/html") {
+			t.Errorf("Content-Type = %q, want text/html", ct)
+		}
+		if resp.Header.Get("Content-Security-Policy") == "" {
+			t.Errorf("missing Content-Security-Policy header")
+		}
+	})
+
+	t.Run("basic auth password is 200", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.SetBasicAuth("operator", dashTestToken)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("GET /: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	})
+
+	t.Run("authenticated POST is rejected", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+dashTestToken)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("POST /: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusMethodNotAllowed {
+			t.Fatalf("status = %d, want 405", resp.StatusCode)
+		}
+	})
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("serve returned error on shutdown: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("serve did not shut down after context cancel")
+	}
+}
+
+func TestDashboardServe_RejectsBadTokenFile(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", filepath.Join(t.TempDir(), "missing.token"),
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "read --auth-token-file") {
+		t.Fatalf("missing token file: want read error, got %v", err)
+	}
+}
+
+func TestDashboardServe_RejectsBadTrustedSigner(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", writeDashTokenFile(t),
+		"--trusted-signer", "inline=not-a-key",
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "parse public key") {
+		t.Fatalf("bad trusted signer: want parse error, got %v", err)
+	}
+}
+
+func TestDashboardServe_InvalidTLSMaterialFailsServe(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	dir := t.TempDir()
+	badCert := filepath.Join(dir, "cert.pem")
+	badKey := filepath.Join(dir, "key.pem")
+	for _, p := range []string{badCert, badKey} {
+		if err := os.WriteFile(p, []byte("not pem"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", writeDashTokenFile(t),
+		"--listen", "127.0.0.1:0",
+		"--tls-cert", badCert,
+		"--tls-key", badKey,
+	})
+	out := &dashSyncBuffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(&dashSyncBuffer{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("invalid TLS material: want serve error, got nil")
+	}
+	if out.contains("dashboard listening on") {
+		t.Fatalf("invalid TLS material printed listening banner before refusing startup: %q", out.String())
+	}
+}
+
+func TestDashboardAuthorizeFunc(t *testing.T) {
+	authorize := dashboardAuthorizeFunc(dashTestToken)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if err := authorize(req); err == nil {
+		t.Fatal("unauthenticated request: want error, got nil")
+	}
+	req.Header.Set("Authorization", "Bearer "+dashTestToken)
+	if err := authorize(req); err != nil {
+		t.Fatalf("authenticated request: want nil, got %v", err)
+	}
+}
+
+func TestDashboardServe_RejectsReceiptDirThatIsAFile(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	file := filepath.Join(t.TempDir(), "receipts.log")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{"--receipt-dir", file, "--auth-token-file", writeDashTokenFile(t)})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "is not a directory") {
+		t.Fatalf("file as receipt dir: want not-a-directory error, got %v", err)
+	}
+}
+
+// TestRunDashboardServe_BindFailure calls runDashboardServe directly (nil
+// command context) with a port that is already bound, covering the
+// context-fallback and listener-error paths.
+func TestRunDashboardServe_BindFailure(t *testing.T) {
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	opts := dashboardServeOptions{
+		listen:        ln.Addr().String(),
+		receiptDir:    t.TempDir(),
+		authTokenFile: writeDashTokenFile(t),
+	}
+	err = runDashboardServe(cmd, opts, license.License{Features: []string{license.FeatureAgents}})
+	if err == nil {
+		t.Fatal("bind to an in-use port: want error, got nil")
+	}
+}
+
+// writeDashTLSCert writes a self-signed server certificate for 127.0.0.1 and
+// returns the cert/key file paths plus a pool that trusts the certificate.
+func writeDashTLSCert(t *testing.T) (certFile, keyFile string, pool *x509.CertPool) {
+	t.Helper()
+	pub, priv := newDashKeyPair(t)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "pipelock-dashboard-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certFile, certPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile(cert): %v", err)
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile(key): %v", err)
+	}
+	pool = x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(certPEM) {
+		t.Fatal("AppendCertsFromPEM failed")
+	}
+	return certFile, keyFile, pool
+}
+
+func TestDashboardServe_TLSEndToEnd(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	certFile, keyFile, pool := writeDashTLSCert(t)
+
+	out := &dashSyncBuffer{}
+	errOut := &dashSyncBuffer{}
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", writeDashTokenFile(t),
+		"--listen", "127.0.0.1:0",
+		"--tls-cert", certFile,
+		"--tls-key", keyFile,
+	})
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- cmd.ExecuteContext(ctx) }()
+
+	testwait.For(t, 10*time.Second, func() bool { return out.contains("dashboard listening on https://") },
+		"serve never printed the TLS listening banner; stderr: %s", errOut.String())
+
+	addrRe := regexp.MustCompile(`listening on https://(127\.0\.0\.1:\d+)`)
+	m := addrRe.FindStringSubmatch(out.String())
+	if m == nil {
+		t.Fatalf("could not parse listen address from output %q", out.String())
+	}
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+m[1]+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+dashTestToken)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET over TLS: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("serve returned error on shutdown: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("serve did not shut down after context cancel")
+	}
+}
+
+func TestDashboardRequestAuthorized(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		setup func(*http.Request)
+		want  bool
+	}{
+		{"empty configured token fails closed", "", func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer ")
+		}, false},
+		{"no header", dashTestToken, func(*http.Request) {}, false},
+		{"bearer match", dashTestToken, func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer "+dashTestToken)
+		}, true},
+		{"bearer prefix case-insensitive", dashTestToken, func(r *http.Request) {
+			r.Header.Set("Authorization", "BEARER "+dashTestToken)
+		}, true},
+		{"bearer mismatch", dashTestToken, func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer nope")
+		}, false},
+		{"basic password match, any username", dashTestToken, func(r *http.Request) {
+			r.SetBasicAuth("whoever", dashTestToken)
+		}, true},
+		{"basic password mismatch", dashTestToken, func(r *http.Request) {
+			r.SetBasicAuth("whoever", "nope")
+		}, false},
+		{"token as basic username does not count", dashTestToken, func(r *http.Request) {
+			r.SetBasicAuth(dashTestToken, "")
+		}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/", nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			tc.setup(req)
+			if got := dashboardRequestAuthorized(req, tc.token); got != tc.want {
+				t.Errorf("dashboardRequestAuthorized = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateDashboardListen(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    dashboardServeOptions
+		wantErr string
+	}{
+		{"loopback v4 ok", dashboardServeOptions{listen: "127.0.0.1:8896"}, ""},
+		{"loopback v6 ok", dashboardServeOptions{listen: "[::1]:8896"}, ""},
+		{"localhost hostname refused", dashboardServeOptions{listen: "localhost:8896"}, "refusing"},
+		{"all interfaces refused", dashboardServeOptions{listen: "0.0.0.0:8896"}, "refusing"},
+		{"private address refused", dashboardServeOptions{listen: "10.0.0.5:8896"}, "refusing"},
+		{"hostname refused", dashboardServeOptions{listen: "dash.internal:8896"}, "refusing"},
+		{"empty host refused", dashboardServeOptions{listen: ":8896"}, "refusing"},
+		{"malformed listen", dashboardServeOptions{listen: "not-an-addr"}, "--listen"},
+		{"tls pair allows non-loopback", dashboardServeOptions{listen: "0.0.0.0:8896", tlsCert: "c.pem", tlsKey: "k.pem"}, ""},
+		{"cert without key refused", dashboardServeOptions{listen: "127.0.0.1:8896", tlsCert: "c.pem"}, "must be set together"},
+		{"key without cert refused", dashboardServeOptions{listen: "127.0.0.1:8896", tlsKey: "k.pem"}, "must be set together"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDashboardListen(tc.opts)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want nil, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestParseTrustedSigners(t *testing.T) {
+	pub, _ := newDashKeyPair(t)
+	keyHex := hex.EncodeToString(pub)
+	keyFile := filepath.Join(t.TempDir(), "signer.pub")
+	if err := os.WriteFile(keyFile, []byte(keyHex+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	t.Run("empty returns nil", func(t *testing.T) {
+		got, err := parseTrustedSigners(nil)
+		if err != nil || got != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", got, err)
+		}
+	})
+
+	t.Run("inline hex with source", func(t *testing.T) {
+		got, err := parseTrustedSigners([]string{"inline=" + keyHex + ",source=ops runbook"})
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if got[keyHex] != (dashboard.TrustedKey{Source: "ops runbook"}) {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("empty parts from trailing comma are skipped", func(t *testing.T) {
+		got, err := parseTrustedSigners([]string{"inline=" + keyHex + ","})
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if _, ok := got[keyHex]; !ok {
+			t.Fatalf("got %+v, want key present", got)
+		}
+	})
+
+	t.Run("file key with default source", func(t *testing.T) {
+		got, err := parseTrustedSigners([]string{"file=" + keyFile})
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if got[keyHex] != (dashboard.TrustedKey{Source: trustedSignerDefaultSource}) {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	errCases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"inline and file exclusive", "inline=" + keyHex + ",file=" + keyFile, "mutually exclusive"},
+		{"neither inline nor file", "source=x", "one of inline= or file= is required"},
+		{"unknown kv key", "inline=" + keyHex + ",color=green", "unknown key"},
+		{"missing equals", "justakey", "expected key=value"},
+		{"duplicate inline rejected", "inline=" + keyHex + ",inline=" + keyHex, "inline= may appear only once"},
+		{"duplicate file rejected", "file=" + keyFile + ",file=" + keyFile, "file= may appear only once"},
+		{"duplicate source rejected", "inline=" + keyHex + ",source=one,source=two", "source= may appear only once"},
+		{"empty inline rejected", "inline= ", "inline= value is empty"},
+		{"empty file rejected", "file= ", "file= value is empty"},
+		{"garbage key rejected", "inline=zz-not-a-key", "parse public key"},
+		{"unreadable file", "file=" + filepath.Join(t.TempDir(), "nope.pub"), "read key file"},
+	}
+	for _, tc := range errCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseTrustedSigners([]string{tc.in})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+
+	t.Run("duplicate key rejected", func(t *testing.T) {
+		_, err := parseTrustedSigners([]string{"inline=" + keyHex, "file=" + keyFile})
+		if err == nil || !strings.Contains(err.Error(), "duplicate key") {
+			t.Fatalf("want duplicate-key error, got %v", err)
+		}
+	})
+}
+
+func TestDashboardRuntimeHasFeature(t *testing.T) {
+	now := time.Now().Unix()
+	tests := []struct {
+		name    string
+		lic     license.License
+		feature string
+		want    bool
+	}{
+		{"valid with feature", license.License{Features: []string{license.FeatureAgents}, ExpiresAt: now + 3600}, license.FeatureAgents, true},
+		{"perpetual with feature", license.License{Features: []string{license.FeatureAgents}}, license.FeatureAgents, true},
+		{"expired at runtime", license.License{Features: []string{license.FeatureAgents}, ExpiresAt: now - 1}, license.FeatureAgents, false},
+		{"missing feature", license.License{Features: []string{license.FeatureAssess}, ExpiresAt: now + 3600}, license.FeatureAgents, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dashboardRuntimeHasFeature(tc.lic)(tc.feature); got != tc.want {
+				t.Errorf("hasFeature(%q) = %v, want %v", tc.feature, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadDashboardTokenFile(t *testing.T) {
+	t.Run("valid token trimmed", func(t *testing.T) {
+		got, err := loadDashboardTokenFile(writeDashTokenFile(t))
+		if err != nil || got != dashTestToken {
+			t.Fatalf("got (%q, %v), want (%q, nil)", got, err, dashTestToken)
+		}
+	})
+	t.Run("empty path", func(t *testing.T) {
+		if _, err := loadDashboardTokenFile("  "); err == nil ||
+			!strings.Contains(err.Error(), "required") {
+			t.Fatalf("want required error, got %v", err)
+		}
+	})
+	t.Run("missing file", func(t *testing.T) {
+		if _, err := loadDashboardTokenFile(filepath.Join(t.TempDir(), "nope")); err == nil ||
+			!strings.Contains(err.Error(), "read --auth-token-file") {
+			t.Fatalf("want read error, got %v", err)
+		}
+	})
+	t.Run("empty file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.token")
+		if err := os.WriteFile(path, []byte(" \n"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if _, err := loadDashboardTokenFile(path); err == nil ||
+			!strings.Contains(err.Error(), "is empty") {
+			t.Fatalf("want empty error, got %v", err)
+		}
+	})
+}

--- a/enterprise/cli/register.go
+++ b/enterprise/cli/register.go
@@ -2,7 +2,8 @@
 
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
-// Package entcli provides enterprise CLI commands (license, conductor, fleet).
+// Package entcli provides enterprise CLI commands (license, conductor, fleet,
+// dashboard).
 // The init function registers these commands with the core CLI via the
 // RegisterCommand hook so the Apache-only core remains free of enterprise
 // imports.
@@ -18,4 +19,5 @@ func init() {
 	cli.RegisterCommand(LicenseCmd())
 	cli.RegisterCommand(conductorcli.Cmd())
 	cli.RegisterCommand(fleetcli.SinkCmd())
+	cli.RegisterCommand(DashboardCmd())
 }

--- a/internal/license/agents_gate_test.go
+++ b/internal/license/agents_gate_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import (
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestVerifyAgentsWithOptions_AgentsFeatureAccepted(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, "lic_agents", []string{FeatureAgents}) // Pro tier
+	lic, err := VerifyAgentsWithOptions(FleetVerifyInputs{
+		LicenseKey:   tok,
+		PublicKeyHex: hex.EncodeToString(pub),
+	})
+	if err != nil {
+		t.Fatalf("VerifyAgentsWithOptions with Pro license: want nil, got %v", err)
+	}
+	if lic.ID != "lic_agents" {
+		t.Errorf("license ID = %q, want lic_agents", lic.ID)
+	}
+}
+
+func TestVerifyAgentsWithOptions_MissingFeatureRejected(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	tok := mustIssue(t, priv, "lic_assess", []string{FeatureAssess}) // no agents
+	_, err := VerifyAgentsWithOptions(FleetVerifyInputs{
+		LicenseKey:   tok,
+		PublicKeyHex: hex.EncodeToString(pub),
+	})
+	if !errors.Is(err, ErrAgentsLicenseRequired) {
+		t.Fatalf("assess-only license: want ErrAgentsLicenseRequired, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "does not include the agents feature") {
+		t.Errorf("error should explain missing feature; got %v", err)
+	}
+}
+
+func TestVerifyAgentsWithOptions_NoTokenRejected(t *testing.T) {
+	t.Setenv(EnvLicenseKey, "")
+	_, err := VerifyAgentsWithOptions(FleetVerifyInputs{})
+	if !errors.Is(err, ErrAgentsLicenseRequired) {
+		t.Fatalf("no license token: want ErrAgentsLicenseRequired, got %v", err)
+	}
+}
+
+func TestVerifyAgentsWithOptions_WrongKeyRejected(t *testing.T) {
+	_, priv := newKeyPair(t)
+	otherPub, _ := newKeyPair(t)
+	tok := mustIssue(t, priv, "lic_wrong_key", []string{FeatureAgents})
+	_, err := VerifyAgentsWithOptions(FleetVerifyInputs{
+		LicenseKey:   tok,
+		PublicKeyHex: hex.EncodeToString(otherPub),
+	})
+	if !errors.Is(err, ErrAgentsLicenseRequired) {
+		t.Fatalf("wrong verifier key: want ErrAgentsLicenseRequired, got %v", err)
+	}
+}

--- a/internal/license/fleet_gate.go
+++ b/internal/license/fleet_gate.go
@@ -48,6 +48,17 @@ var ErrFleetLicenseRequired = errors.New(
 		"administrator",
 )
 
+// ErrAgentsLicenseRequired is returned by VerifyAgentsWithOptions when the
+// supplied license does not carry the agents feature (or no license is
+// present). Callers should refuse to start and surface this error verbatim so
+// the operator sees the missing-entitlement message.
+var ErrAgentsLicenseRequired = errors.New(
+	"this command requires a Pro or Enterprise license " +
+		"that grants the \"agents\" feature; set PIPELOCK_LICENSE_KEY (and " +
+		"PIPELOCK_LICENSE_PUBLIC_KEY on unofficial builds) or contact your " +
+		"administrator",
+)
+
 // RequireFleet verifies the supplied license and returns nil only when it
 // carries the FeatureFleet entitlement. Pass licenseKey="" and publicKeyHex=""
 // to use the environment variables + the build-embedded public key.
@@ -180,14 +191,32 @@ func VerifyFleetWithIntermediate(licenseKey, publicKeyHex, crlFile, intermediate
 // ErrIntermediateRequired. This is the entry point the env-only conductor / fleet
 // CLI commands use so require mode is honoured there, not just in the runtime.
 func VerifyFleetWithOptions(in FleetVerifyInputs) (License, error) {
+	return verifyFeatureWithOptions(FeatureFleet, ErrFleetLicenseRequired, in)
+}
+
+// VerifyAgentsWithOptions verifies a license honouring require-intermediate
+// mode (and any other VerifyOptions knob) resolved from in. It returns the
+// decoded license only when it carries FeatureAgents, failing closed (wrapped
+// in ErrAgentsLicenseRequired) on any verification failure. This is the entry
+// point for env-only Pro/Enterprise server commands (such as
+// `pipelock dashboard serve`) that do not take a config file.
+func VerifyAgentsWithOptions(in FleetVerifyInputs) (License, error) {
+	return verifyFeatureWithOptions(FeatureAgents, ErrAgentsLicenseRequired, in)
+}
+
+// verifyFeatureWithOptions is the shared fail-closed feature gate: any
+// verification failure, and a verified license that lacks the required
+// feature, both return an error wrapping requiredErr so call sites keep a
+// uniform error path without branching on individual failure reasons.
+func verifyFeatureWithOptions(feature string, requiredErr error, in FleetVerifyInputs) (License, error) {
 	lic, err := verifyLicenseInputsOpts(in)
 	if err != nil {
-		return License{}, fmt.Errorf("%w: %w", ErrFleetLicenseRequired, err)
+		return License{}, fmt.Errorf("%w: %w", requiredErr, err)
 	}
-	if !lic.HasFeature(FeatureFleet) {
-		return License{}, fmt.Errorf("%w: license %s does not include the fleet feature "+
+	if !lic.HasFeature(feature) {
+		return License{}, fmt.Errorf("%w: license %s does not include the %s feature "+
 			"(present features: %v)",
-			ErrFleetLicenseRequired, lic.ID, lic.Features)
+			requiredErr, lic.ID, feature, lic.Features)
 	}
 	return lic, nil
 }


### PR DESCRIPTION
## What changed

Adds `pipelock dashboard serve`, an enterprise-gated command that serves the read-only Evidence dashboard (added in #885) over a flight-recorder evidence directory, so an operator can actually run the signed-receipt view.

- **Dedicated listener, never the proxy port.** Defaults to `127.0.0.1:8896`. Without `--tls-cert`/`--tls-key` it refuses non-loopback addresses, so the operator token never transits in cleartext. TLS material is loaded before the listener binds, so bad cert/key fails closed at startup.
- **Fail-closed license gate.** Verifies the `agents` feature before any bind or file IO, and re-checks the entitlement per request so a mid-run expiry stops serving. Generalizes the existing fleet gate into a shared feature-verify helper and adds an agents-feature entry point.
- **Authentication is separate from entitlement.** Every request must carry the operator token from `--auth-token-file`, as an `Authorization: Bearer` header or an HTTP Basic password (constant-time compare); missing or wrong token returns 401. The license check is entitlement, not identity.
- **No trust-on-first-use.** Receipt signers are trusted only via `--trusted-signer`; with none configured the dashboard still serves and honestly renders every signer as Unverified.
- Read-only: GET only, no mutation of policy, receipts, or runtime state.
- Docs: `docs/cli/dashboard.md` and the CLI index entry.

The free build compiles and runs unchanged; all new code is behind `//go:build enterprise`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pipelock dashboard serve` to launch a read-only Evidence dashboard (Pro/Enterprise).
  * Dashboard requests now require an operator token (Bearer or Basic), with optional trusted signer configuration and receipt-directory sourcing.
  * HTTPS support via TLS certificate/key; cleartext is restricted to loopback.

* **Bug Fixes**
  * Dashboard now fails closed when required entitlements are missing.
  * Serving stops once the license entitlement expires during runtime.

* **Documentation**
  * Added detailed CLI documentation for `pipelock dashboard` and `serve`, including examples and security guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->