### PR TITLE
Harden dashboard raw evidence access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--auth-token-file` grants the redacted metadata view, while optional
   `--raw-token-file` unlocks raw destinations and signed payloads.
 - Enterprise Evidence dashboard access is audited on stderr with role, method,
-  path, session, and remote address for each authenticated request.
+  path, session, `session_sha256`, and remote address for each authenticated
+  request.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Enterprise Evidence dashboard now supports a two-tier token model:
+  `--auth-token-file` grants the redacted metadata view, while optional
+  `--raw-token-file` unlocks raw destinations and signed payloads.
+- Enterprise Evidence dashboard access is audited on stderr with role, method,
+  path, session, and remote address for each authenticated request.
+
 ### Changed
+
+- Enterprise Evidence dashboard redacts receipt destinations and signed payloads
+  by default before template rendering.
 
 ### Fixed
 

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -49,7 +49,8 @@ openssl rand -hex 32 > /etc/pipelock/dashboard.token
 | Flag | Default | Purpose |
 |---|---|---|
 | `--receipt-dir` | (required) | Flight-recorder evidence directory holding action receipts (the runtime's `flight_recorder.dir`). |
-| `--auth-token-file` | (required) | File containing the operator token required on every request. |
+| `--auth-token-file` | (required) | File containing the operator token required on every request. Grants the redacted metadata view. |
+| `--raw-token-file` | none | Optional second, higher-privilege token that unlocks raw destinations and signed payloads. Must differ from `--auth-token-file`. |
 | `--listen` | `127.0.0.1:8896` | Dashboard listener address. Non-loopback addresses require `--tls-cert`/`--tls-key`. |
 | `--trusted-signer` | none | Trusted receipt signing key: `(inline=HEX_OR_VERSIONED_PUBLIC_KEY\|file=/path)[,source=LABEL]`. Repeatable. `source` is shown in the UI as the reason the key is trusted. |
 | `--license-crl-file` | none | Signed license revocation list; falls back to `PIPELOCK_LICENSE_CRL_FILE`. |
@@ -82,9 +83,21 @@ the server is running stops serving.
 - **No trust-on-first-use.** Signer keys are trusted only via
   `--trusted-signer`. With no trusted keys configured the dashboard still
   serves, and the Authentic line honestly reports every signer as Unverified.
-- **Sensitive by design.** The evidence view includes destinations, block
-  reasons, signer fingerprints, and session IDs. Treat the listener like an
-  admin API: keep it loopback or behind TLS on a network only operators reach.
+- **Redacted by default (least privilege).** The metadata token sees the
+  scorecard, hashes, timeline verdicts/reasons/timestamps, and the offline
+  verify command — but receipt destinations and full signed payloads are
+  redacted, because a destination URL can carry a capability token and the raw
+  payload is the largest exfil surface. Raw detail is shown only to a request
+  that authenticates with `--raw-token-file`; with no raw token configured, raw
+  is redacted for everyone (fail closed). Redaction happens before templating,
+  so the raw bytes never reach a metadata-view response. The scorecard — the
+  actual proof — does not depend on the raw fields.
+- **Access is audited.** Every authenticated request is written to an access log
+  on stderr (role `metadata` or `raw`, method, path, session, remote address).
+  Viewing evidence is itself a recorded action.
+- **Sensitive by design.** Even the metadata view exposes reasons, signer
+  fingerprints, and session IDs. Treat the listener like an admin API: keep it
+  loopback or behind TLS on a network only operators reach.
 
 ### Verify it yourself
 

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -53,6 +53,7 @@ type dashboardServeOptions struct {
 	listen         string
 	receiptDir     string
 	authTokenFile  string
+	rawTokenFile   string
 	trustedSigners []string
 	licenseCRLFile string
 	tlsCert        string
@@ -69,6 +70,12 @@ directory. Every request must authenticate with the operator token from
 --auth-token-file, sent either as "Authorization: Bearer <token>" or as the
 password of an HTTP Basic prompt (any username). The license feature check is
 entitlement, not identity; the token is the authentication boundary.
+
+By default the view is redacted: receipt destinations and signed payloads are
+hidden, because a destination URL can carry a capability token and the payload
+is the largest exfil surface. Supply --raw-token-file to issue a second,
+higher-privilege token whose holders see the full raw detail. Every
+authenticated request is written to the access log on stderr.
 
 Without --tls-cert/--tls-key the listener refuses non-loopback addresses,
 because the operator token would transit in cleartext.`,
@@ -89,7 +96,9 @@ because the operator token would transit in cleartext.`,
 	cmd.Flags().StringVar(&opts.receiptDir, "receipt-dir", "",
 		"flight-recorder evidence directory holding action receipts (flight_recorder.dir)")
 	cmd.Flags().StringVar(&opts.authTokenFile, "auth-token-file", "",
-		"file containing the operator token required on every dashboard request")
+		"file containing the operator token required on every dashboard request (redacted metadata view)")
+	cmd.Flags().StringVar(&opts.rawTokenFile, "raw-token-file", "",
+		"optional file containing a higher-privilege token that unlocks raw destinations and signed payloads; must differ from --auth-token-file")
 	cmd.Flags().StringArrayVar(&opts.trustedSigners, "trusted-signer", nil,
 		"trusted receipt signing key as comma-separated kv pairs: "+
 			"'(inline=HEX_OR_VERSIONED_PUBLIC_KEY|file=/path)[,source=LABEL]'; repeatable")
@@ -103,9 +112,22 @@ because the operator token would transit in cleartext.`,
 }
 
 func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic license.License) error {
-	token, err := loadDashboardTokenFile(opts.authTokenFile)
+	token, err := loadDashboardTokenFile("--auth-token-file", opts.authTokenFile)
 	if err != nil {
 		return err
+	}
+	// Optional raw-access token: elevates a request from the redacted metadata
+	// view to full destinations + signed payloads. Must differ from the
+	// metadata token so the two roles are actually distinguishable.
+	var rawToken string
+	if strings.TrimSpace(opts.rawTokenFile) != "" {
+		rawToken, err = loadDashboardTokenFile("--raw-token-file", opts.rawTokenFile)
+		if err != nil {
+			return err
+		}
+		if subtle.ConstantTimeCompare([]byte(rawToken), []byte(token)) == 1 {
+			return errors.New("--raw-token-file must differ from --auth-token-file")
+		}
 	}
 	trusted, err := parseTrustedSigners(opts.trustedSigners)
 	if err != nil {
@@ -130,13 +152,29 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 			"pipelock: warning: no --trusted-signer configured; the Authentic line will render every signer as Unverified")
 	}
 
+	// metaAuthorized gates all access: the metadata token OR the raw token (a
+	// raw holder is also a valid operator). rawAuthorized gates only the
+	// sensitive raw view and matches the raw token alone.
+	metaAuthorized := func(r *http.Request) bool {
+		if dashboardTokenMatches(r, token) {
+			return true
+		}
+		return rawToken != "" && dashboardTokenMatches(r, rawToken)
+	}
+	rawAuthorized := func(r *http.Request) bool {
+		return rawToken != "" && dashboardTokenMatches(r, rawToken)
+	}
+
 	inner := dashboard.New(dashboard.Options{
-		ReceiptDir:  opts.receiptDir,
-		TrustedKeys: trusted,
-		HasFeature:  dashboardRuntimeHasFeature(lic),
-		Authorize:   dashboardAuthorizeFunc(token),
+		ReceiptDir:   opts.receiptDir,
+		TrustedKeys:  trusted,
+		HasFeature:   dashboardRuntimeHasFeature(lic),
+		Authorize:    dashboardAuthorizeFunc(metaAuthorized),
+		AuthorizeRaw: dashboardAuthorizeFunc(rawAuthorized),
+		// Viewing evidence is itself audited; the access log goes to stderr.
+		AuditWriter: cmd.ErrOrStderr(),
 	})
-	handler := dashboardAuthHandler(token, inner)
+	handler := dashboardAuthHandler(metaAuthorized, inner)
 
 	ctx := cmd.Context()
 	if ctx == nil {
@@ -223,12 +261,13 @@ func validateDashboardListen(opts dashboardServeOptions) error {
 		"every request carries the operator token, so add --tls-cert/--tls-key or keep --listen on 127.0.0.1", opts.listen)
 }
 
-// dashboardAuthorizeFunc is the Options.Authorize seam: defense in depth
-// behind the outer dashboardAuthHandler boundary, so the dashboard handler
-// itself fails closed (403) if it is ever mounted without that boundary.
-func dashboardAuthorizeFunc(token string) func(*http.Request) error {
+// dashboardAuthorizeFunc adapts a boolean request predicate to the
+// Options.Authorize / Options.AuthorizeRaw seam: defense in depth behind the
+// outer dashboardAuthHandler boundary, so the dashboard handler itself fails
+// closed (403) if it is ever mounted without that boundary.
+func dashboardAuthorizeFunc(authorized func(*http.Request) bool) func(*http.Request) error {
 	return func(r *http.Request) error {
-		if !dashboardRequestAuthorized(r, token) {
+		if !authorized(r) {
 			return errors.New("dashboard request not authenticated")
 		}
 		return nil
@@ -237,11 +276,11 @@ func dashboardAuthorizeFunc(token string) func(*http.Request) error {
 
 // dashboardAuthHandler is the outer authentication boundary. It answers 401
 // with a WWW-Authenticate challenge so browsers prompt for credentials; the
-// inner dashboard handler re-checks the same token via Options.Authorize as
+// inner dashboard handler re-checks the same predicate via Options.Authorize as
 // defense in depth.
-func dashboardAuthHandler(token string, next http.Handler) http.Handler {
+func dashboardAuthHandler(authorized func(*http.Request) bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !dashboardRequestAuthorized(r, token) {
+		if !authorized(r) {
 			w.Header().Set("WWW-Authenticate", `Basic realm="pipelock dashboard", charset="UTF-8"`)
 			http.Error(w, "authentication required", http.StatusUnauthorized)
 			return
@@ -250,10 +289,10 @@ func dashboardAuthHandler(token string, next http.Handler) http.Handler {
 	})
 }
 
-// dashboardRequestAuthorized accepts the operator token as either a Bearer
-// token (automation) or the password of an HTTP Basic credential (browsers;
-// the username is ignored). Comparisons are constant-time.
-func dashboardRequestAuthorized(r *http.Request, token string) bool {
+// dashboardTokenMatches accepts the operator token as either a Bearer token
+// (automation) or the password of an HTTP Basic credential (browsers; the
+// username is ignored). Comparisons are constant-time.
+func dashboardTokenMatches(r *http.Request, token string) bool {
 	if token == "" {
 		return false // fail closed: no configured token means no access
 	}
@@ -373,10 +412,9 @@ func parseTrustedSignerSpec(raw string) (keyHex, source string, err error) {
 	return hex.EncodeToString(pub), source, nil
 }
 
-// loadDashboardTokenFile reads and validates the required operator token file.
+// loadDashboardTokenFile reads and validates a required operator token file.
 // Mirrors the conductor loadTokenFile semantics: trimmed and non-empty.
-func loadDashboardTokenFile(path string) (string, error) {
-	const flag = "--auth-token-file"
+func loadDashboardTokenFile(flag, path string) (string, error) {
 	if strings.TrimSpace(path) == "" {
 		return "", fmt.Errorf("%s is required", flag)
 	}

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -147,6 +147,23 @@ func TestDashboardServe_RawTokenMustDifferFromAuthToken(t *testing.T) {
 	}
 }
 
+func TestDashboardServe_RejectsUnreadableRawTokenFile(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", writeDashTokenFile(t),
+		"--raw-token-file", filepath.Join(t.TempDir(), "missing.raw-token"),
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--raw-token-file") {
+		t.Fatalf("missing raw token file: want --raw-token-file error, got %v", err)
+	}
+}
+
 func TestDashboardServe_RawTokenElevatesAndAudits(t *testing.T) {
 	pub, priv := newDashKeyPair(t)
 	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -110,10 +110,105 @@ func TestDashboardCmd_Tree(t *testing.T) {
 	if err != nil || serve.Use != "serve" {
 		t.Fatalf("dashboard serve subcommand not found: %v", err)
 	}
-	for _, flag := range []string{"listen", "receipt-dir", "auth-token-file", "trusted-signer", "license-crl-file", "tls-cert", "tls-key"} {
+	for _, flag := range []string{"listen", "receipt-dir", "auth-token-file", "raw-token-file", "trusted-signer", "license-crl-file", "tls-cert", "tls-key"} {
 		if serve.Flags().Lookup(flag) == nil {
 			t.Errorf("serve is missing --%s", flag)
 		}
+	}
+}
+
+func writeDashRawTokenFile(t *testing.T) (path, token string) {
+	t.Helper()
+	token = "dash-raw-" + "elevated-token"
+	path = filepath.Join(t.TempDir(), "dashboard-raw.token")
+	if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path, token
+}
+
+func TestDashboardServe_RawTokenMustDifferFromAuthToken(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	// Point --raw-token-file at the SAME file as --auth-token-file: identical
+	// tokens make the two roles indistinguishable and must be rejected.
+	tokenFile := writeDashTokenFile(t)
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", tokenFile,
+		"--raw-token-file", tokenFile,
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "must differ") {
+		t.Fatalf("identical raw+auth token: want must-differ error, got %v", err)
+	}
+}
+
+func TestDashboardServe_RawTokenElevatesAndAudits(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	rawTokenFile, rawToken := writeDashRawTokenFile(t)
+
+	out := &dashSyncBuffer{}
+	errOut := &dashSyncBuffer{}
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", writeDashTokenFile(t),
+		"--raw-token-file", rawTokenFile,
+		"--listen", "127.0.0.1:0",
+	})
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- cmd.ExecuteContext(ctx) }()
+
+	testwait.For(t, 10*time.Second, func() bool { return out.contains("dashboard listening on") },
+		"serve never printed the listening banner; stderr: %s", errOut.String())
+	m := regexp.MustCompile(`listening on http://(127\.0\.0\.1:\d+)`).FindStringSubmatch(out.String())
+	if m == nil {
+		t.Fatalf("could not parse listen address from %q", out.String())
+	}
+	base := "http://" + m[1]
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	do := func(tok string) int {
+		t.Helper()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	// The raw token is a valid operator token (metadata-level access too).
+	if code := do(rawToken); code != http.StatusOK {
+		t.Fatalf("raw token access = %d, want 200", code)
+	}
+	// Its access is audited on stderr with the raw role.
+	testwait.For(t, 5*time.Second, func() bool { return errOut.contains("role=raw") },
+		"raw access was not audited; stderr: %s", errOut.String())
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("serve shutdown error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("serve did not shut down")
 	}
 }
 
@@ -362,7 +457,9 @@ func TestDashboardServe_InvalidTLSMaterialFailsServe(t *testing.T) {
 }
 
 func TestDashboardAuthorizeFunc(t *testing.T) {
-	authorize := dashboardAuthorizeFunc(dashTestToken)
+	authorize := dashboardAuthorizeFunc(func(r *http.Request) bool {
+		return dashboardTokenMatches(r, dashTestToken)
+	})
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/", nil)
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
@@ -517,7 +614,7 @@ func TestDashboardServe_TLSEndToEnd(t *testing.T) {
 	}
 }
 
-func TestDashboardRequestAuthorized(t *testing.T) {
+func TestDashboardTokenMatches(t *testing.T) {
 	tests := []struct {
 		name  string
 		token string
@@ -554,8 +651,8 @@ func TestDashboardRequestAuthorized(t *testing.T) {
 				t.Fatalf("NewRequest: %v", err)
 			}
 			tc.setup(req)
-			if got := dashboardRequestAuthorized(req, tc.token); got != tc.want {
-				t.Errorf("dashboardRequestAuthorized = %v, want %v", got, tc.want)
+			if got := dashboardTokenMatches(req, tc.token); got != tc.want {
+				t.Errorf("dashboardTokenMatches = %v, want %v", got, tc.want)
 			}
 		})
 	}
@@ -698,19 +795,19 @@ func TestDashboardRuntimeHasFeature(t *testing.T) {
 
 func TestLoadDashboardTokenFile(t *testing.T) {
 	t.Run("valid token trimmed", func(t *testing.T) {
-		got, err := loadDashboardTokenFile(writeDashTokenFile(t))
+		got, err := loadDashboardTokenFile("--auth-token-file", writeDashTokenFile(t))
 		if err != nil || got != dashTestToken {
 			t.Fatalf("got (%q, %v), want (%q, nil)", got, err, dashTestToken)
 		}
 	})
 	t.Run("empty path", func(t *testing.T) {
-		if _, err := loadDashboardTokenFile("  "); err == nil ||
+		if _, err := loadDashboardTokenFile("--auth-token-file", "  "); err == nil ||
 			!strings.Contains(err.Error(), "required") {
 			t.Fatalf("want required error, got %v", err)
 		}
 	})
 	t.Run("missing file", func(t *testing.T) {
-		if _, err := loadDashboardTokenFile(filepath.Join(t.TempDir(), "nope")); err == nil ||
+		if _, err := loadDashboardTokenFile("--auth-token-file", filepath.Join(t.TempDir(), "nope")); err == nil ||
 			!strings.Contains(err.Error(), "read --auth-token-file") {
 			t.Fatalf("want read error, got %v", err)
 		}
@@ -720,7 +817,7 @@ func TestLoadDashboardTokenFile(t *testing.T) {
 		if err := os.WriteFile(path, []byte(" \n"), 0o600); err != nil {
 			t.Fatalf("WriteFile: %v", err)
 		}
-		if _, err := loadDashboardTokenFile(path); err == nil ||
+		if _, err := loadDashboardTokenFile("--auth-token-file", path); err == nil ||
 			!strings.Contains(err.Error(), "is empty") {
 			t.Fatalf("want empty error, got %v", err)
 		}

--- a/enterprise/dashboard/evidence.tmpl.html
+++ b/enterprise/dashboard/evidence.tmpl.html
@@ -257,6 +257,13 @@
             </section>
           {{end}}
 
+          {{if not .RawAllowed}}
+            <section class="section callout">
+              <h2>Metadata view</h2>
+              <div class="muted">Receipt destinations and signed payloads are redacted. Raw access requires the raw operator token; the scorecard, hashes, and offline verifier below do not depend on the raw fields.</div>
+            </section>
+          {{end}}
+
           {{if .Evidence.ReadLimited}}
             <section class="section callout">
               <h2>Dashboard read limit reached</h2>
@@ -314,10 +321,14 @@
                     <div><div class="label">Prev → Hash</div><div class="value mono">{{.PrevShort}} → {{.HashShort}}</div></div>
                   </div>
                   {{if .Unverifiable}}<div class="sub">This receipt is at or after the break and is unverifiable.</div>{{end}}
+                  {{if .RawJSON}}
                   <details>
                     <summary>Signed JSON payload</summary>
                     <pre>{{.RawJSON}}</pre>
                   </details>
+                  {{else}}
+                  <div class="sub">Signed payload and destination hidden — raw access required.</div>
+                  {{end}}
                 </article>
               {{else}}
                 <div class="empty">No receipt timeline is available for this session.</div>

--- a/enterprise/dashboard/evidence.tmpl.html
+++ b/enterprise/dashboard/evidence.tmpl.html
@@ -247,7 +247,7 @@
               <h1>Evidence · {{.Evidence.Agent}}</h1>
               <div class="muted mono">{{.Evidence.ID}}</div>
             </div>
-            <div class="dim mono">{{len .Evidence.Receipts}}{{if .Evidence.ReadLimited}}+{{end}} receipts</div>
+            <div class="dim mono">{{.Evidence.ReceiptCount}}{{if .Evidence.ReadLimited}}+{{end}} receipts</div>
           </div>
 
           {{if not .Evidence.ReceiptsEnabled}}
@@ -267,7 +267,7 @@
           {{if .Evidence.ReadLimited}}
             <section class="section callout">
               <h2>Dashboard read limit reached</h2>
-              <div class="muted">This online view loaded only the first {{len .Evidence.Receipts}} receipts before the {{.Evidence.ReadLimit}}-entry ceiling. Use offline verification before relying on this session.</div>
+              <div class="muted">This online view loaded only the first {{.Evidence.ReceiptCount}} receipts before the {{.Evidence.ReadLimit}}-entry ceiling. Use offline verification before relying on this session.</div>
             </section>
           {{end}}
 
@@ -307,7 +307,7 @@
           <section class="section">
             <h2>Receipt Timeline</h2>
             {{if .Evidence.TimelineLimited}}
-              <p class="dim">Showing {{.Evidence.TimelineWindow}} {{len .Evidence.Timeline}} of {{len .Evidence.Receipts}}{{if .Evidence.ReadLimited}}+{{end}} loaded receipts.</p>
+              <p class="dim">Showing {{.Evidence.TimelineWindow}} {{len .Evidence.Timeline}} of {{.Evidence.ReceiptCount}}{{if .Evidence.ReadLimited}}+{{end}} loaded receipts.</p>
             {{end}}
             <div class="timeline">
               {{range .Evidence.Timeline}}

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/license"
@@ -66,6 +67,7 @@ type dashboardHandler struct {
 	authorize    func(*http.Request) error
 	authorizeRaw func(*http.Request) error
 	auditWriter  io.Writer
+	auditMu      sync.Mutex
 }
 
 // rawAllowed reports whether this request may see the raw view (destinations
@@ -92,6 +94,8 @@ func (d *dashboardHandler) recordAudit(r *http.Request, raw bool) {
 	if session == "" {
 		session = "-"
 	}
+	d.auditMu.Lock()
+	defer d.auditMu.Unlock()
 	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s method=%s path=%q session=%q remote=%s\n",
 		time.Now().UTC().Format(time.RFC3339), role, r.Method, r.URL.Path, session, r.RemoteAddr)
 }

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -6,7 +6,10 @@ package dashboard
 
 import (
 	"bytes"
+	"context"
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"fmt"
 	"html/template"
 	"io"
@@ -22,6 +25,7 @@ const (
 	contentSecurityPolicy = "default-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'; object-src 'none'"
 	contentTypeHTML       = "text/html; charset=utf-8"
 	contentTypeText       = "text/plain; charset=utf-8"
+	auditSessionMaxBytes  = 128
 )
 
 //go:embed evidence.tmpl.html
@@ -70,11 +74,18 @@ type dashboardHandler struct {
 	auditMu      sync.Mutex
 }
 
+type rawAllowedContextKey struct{}
+
 // rawAllowed reports whether this request may see the raw view (destinations
 // and full signed payloads). Fail closed: raw is shown only when an authorizer
 // is configured and accepts the request.
 func (d *dashboardHandler) rawAllowed(r *http.Request) bool {
 	return d.authorizeRaw != nil && d.authorizeRaw(r) == nil
+}
+
+func rawAllowedFromContext(r *http.Request) bool {
+	raw, _ := r.Context().Value(rawAllowedContextKey{}).(bool)
+	return raw
 }
 
 // recordAudit writes one access-log line for an authenticated request. Viewing
@@ -94,10 +105,38 @@ func (d *dashboardHandler) recordAudit(r *http.Request, raw bool) {
 	if session == "" {
 		session = "-"
 	}
+	sessionDisplay, sessionHash := auditSessionField(session)
 	d.auditMu.Lock()
 	defer d.auditMu.Unlock()
-	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s method=%s path=%q session=%q remote=%s\n",
-		time.Now().UTC().Format(time.RFC3339), role, r.Method, r.URL.Path, session, r.RemoteAddr)
+	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s method=%s path=%q session=%q session_sha256=%s remote=%s\n",
+		time.Now().UTC().Format(time.RFC3339), role, r.Method, r.URL.Path, sessionDisplay, sessionHash, r.RemoteAddr)
+}
+
+func auditSessionField(session string) (display, hash string) {
+	sum := sha256.Sum256([]byte(session))
+	hash = hex.EncodeToString(sum[:])
+
+	var b strings.Builder
+	truncated := false
+	for _, r := range session {
+		if b.Len() >= auditSessionMaxBytes {
+			truncated = true
+			break
+		}
+		if r >= 0x20 && r <= 0x7e {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('?')
+	}
+	display = b.String()
+	if truncated && len(display) > 3 {
+		display = display[:auditSessionMaxBytes-3] + "..."
+	}
+	if display == "" {
+		display = "-"
+	}
+	return display, hash
 }
 
 func (d *dashboardHandler) gate(next http.Handler) http.Handler {
@@ -122,8 +161,9 @@ func (d *dashboardHandler) gate(next http.Handler) http.Handler {
 				return
 			}
 		}
-		d.recordAudit(r, d.rawAllowed(r))
-		next.ServeHTTP(w, r)
+		raw := d.rawAllowed(r)
+		d.recordAudit(r, raw)
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), rawAllowedContextKey{}, raw)))
 	})
 }
 
@@ -146,7 +186,7 @@ func (d *dashboardHandler) handleIndex(w http.ResponseWriter, r *http.Request) {
 	if selected == "" && len(sessions) > 0 {
 		selected = sessions[0].ID
 	}
-	d.render(w, sessions, selected, d.rawAllowed(r))
+	d.render(w, sessions, selected, rawAllowedFromContext(r))
 }
 
 func (d *dashboardHandler) handleSession(w http.ResponseWriter, r *http.Request) {
@@ -164,7 +204,7 @@ func (d *dashboardHandler) handleSession(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "could not read evidence sessions", http.StatusInternalServerError)
 		return
 	}
-	d.render(w, sessions, selected, d.rawAllowed(r))
+	d.render(w, sessions, selected, rawAllowedFromContext(r))
 }
 
 func requireGet(w http.ResponseWriter, r *http.Request) bool {

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -7,9 +7,12 @@ package dashboard
 import (
 	"bytes"
 	"embed"
+	"fmt"
 	"html/template"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/license"
 )
@@ -30,6 +33,7 @@ type pageData struct {
 	SelectedSession string
 	Evidence        SessionEvidence
 	HasEvidence     bool
+	RawAllowed      bool
 }
 
 // New returns a read-only HTTP handler for the Enterprise Evidence dashboard.
@@ -45,9 +49,11 @@ func New(opts Options) http.Handler {
 	model := NewReadModel(opts)
 	mux := http.NewServeMux()
 	d := &dashboardHandler{
-		model:      model,
-		hasFeature: opts.HasFeature,
-		authorize:  opts.Authorize,
+		model:        model,
+		hasFeature:   opts.HasFeature,
+		authorize:    opts.Authorize,
+		authorizeRaw: opts.AuthorizeRaw,
+		auditWriter:  opts.AuditWriter,
 	}
 	mux.Handle("/", d.gate(http.HandlerFunc(d.handleIndex)))
 	mux.Handle("/session/", d.gate(http.HandlerFunc(d.handleSession)))
@@ -55,9 +61,39 @@ func New(opts Options) http.Handler {
 }
 
 type dashboardHandler struct {
-	model      *ReadModel
-	hasFeature func(string) bool
-	authorize  func(*http.Request) error
+	model        *ReadModel
+	hasFeature   func(string) bool
+	authorize    func(*http.Request) error
+	authorizeRaw func(*http.Request) error
+	auditWriter  io.Writer
+}
+
+// rawAllowed reports whether this request may see the raw view (destinations
+// and full signed payloads). Fail closed: raw is shown only when an authorizer
+// is configured and accepts the request.
+func (d *dashboardHandler) rawAllowed(r *http.Request) bool {
+	return d.authorizeRaw != nil && d.authorizeRaw(r) == nil
+}
+
+// recordAudit writes one access-log line for an authenticated request. Viewing
+// evidence is itself an audited action. No-op when no writer is configured.
+func (d *dashboardHandler) recordAudit(r *http.Request, raw bool) {
+	if d.auditWriter == nil {
+		return
+	}
+	role := "metadata"
+	if raw {
+		role = "raw"
+	}
+	session := r.URL.Query().Get("session")
+	if session == "" {
+		session = strings.TrimPrefix(r.URL.Path, "/session/")
+	}
+	if session == "" {
+		session = "-"
+	}
+	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s method=%s path=%q session=%q remote=%s\n",
+		time.Now().UTC().Format(time.RFC3339), role, r.Method, r.URL.Path, session, r.RemoteAddr)
 }
 
 func (d *dashboardHandler) gate(next http.Handler) http.Handler {
@@ -82,6 +118,7 @@ func (d *dashboardHandler) gate(next http.Handler) http.Handler {
 				return
 			}
 		}
+		d.recordAudit(r, d.rawAllowed(r))
 		next.ServeHTTP(w, r)
 	})
 }
@@ -105,7 +142,7 @@ func (d *dashboardHandler) handleIndex(w http.ResponseWriter, r *http.Request) {
 	if selected == "" && len(sessions) > 0 {
 		selected = sessions[0].ID
 	}
-	d.render(w, sessions, selected)
+	d.render(w, sessions, selected, d.rawAllowed(r))
 }
 
 func (d *dashboardHandler) handleSession(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +160,7 @@ func (d *dashboardHandler) handleSession(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "could not read evidence sessions", http.StatusInternalServerError)
 		return
 	}
-	d.render(w, sessions, selected)
+	d.render(w, sessions, selected, d.rawAllowed(r))
 }
 
 func requireGet(w http.ResponseWriter, r *http.Request) bool {
@@ -135,16 +172,23 @@ func requireGet(w http.ResponseWriter, r *http.Request) bool {
 	return false
 }
 
-func (d *dashboardHandler) render(w http.ResponseWriter, sessions []SessionSummary, selected string) {
+func (d *dashboardHandler) render(w http.ResponseWriter, sessions []SessionSummary, selected string, raw bool) {
 	data := pageData{
 		Sessions:        sessions,
 		SelectedSession: selected,
+		RawAllowed:      raw,
 	}
 	if selected != "" {
 		evidence, err := d.model.Session(selected)
 		if err != nil {
 			http.Error(w, "could not read selected evidence", http.StatusInternalServerError)
 			return
+		}
+		// Fail closed: strip destinations and signed payloads in Go before
+		// templating unless this request is authorized for raw, so the raw
+		// bytes never reach the response.
+		if !raw {
+			evidence = redactRaw(evidence)
 		}
 		data.Evidence = evidence
 		data.HasEvidence = true

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -116,6 +116,9 @@ func TestHandler_HostileEvidenceRenderEscapesReceiptFields(t *testing.T) {
 			keyHex: {Source: trustedKeySource},
 		},
 		HasFeature: allowAgentsFeature,
+		// Grant raw so the signed payload + destination render and their
+		// auto-escaping is exercised; escaping must hold in the raw view.
+		AuthorizeRaw: allowRawAccess,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
@@ -286,6 +289,147 @@ func TestHandler_AuthorizeFailsClosed(t *testing.T) {
 
 func allowAgentsFeature(feature string) bool {
 	return feature == license.FeatureAgents
+}
+
+// allowRawAccess is an AuthorizeRaw that grants every request the raw view.
+func allowRawAccess(*http.Request) error { return nil }
+
+func TestHandler_RedactsRawByDefault(t *testing.T) {
+	t.Parallel()
+	dir, trusted := writeTrustedHandlerSession(t)
+
+	// No AuthorizeRaw configured => raw is redacted for everyone (fail closed).
+	handler := New(Options{
+		ReceiptDir:  dir,
+		TrustedKeys: trusted,
+		HasFeature:  allowAgentsFeature,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, testTarget) {
+		t.Errorf("metadata view leaked the raw destination %q", testTarget)
+	}
+	if !strings.Contains(body, redactedDestination) {
+		t.Errorf("metadata view should show the redaction placeholder")
+	}
+	if strings.Contains(body, `"action_id"`) || strings.Contains(body, "Signed JSON payload") {
+		t.Errorf("metadata view leaked the raw signed payload")
+	}
+	if !strings.Contains(body, "Metadata view") {
+		t.Errorf("metadata view should show the redaction banner")
+	}
+	// The scorecard (the actual proof) must still render without the raw fields.
+	if !strings.Contains(body, "Scorecard") {
+		t.Errorf("scorecard must render in the metadata view")
+	}
+}
+
+func TestHandler_RawAccessShowsDetail(t *testing.T) {
+	t.Parallel()
+	dir, trusted := writeTrustedHandlerSession(t)
+
+	handler := New(Options{
+		ReceiptDir:   dir,
+		TrustedKeys:  trusted,
+		HasFeature:   allowAgentsFeature,
+		AuthorizeRaw: allowRawAccess,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, testTarget) {
+		t.Errorf("raw view should show the destination %q", testTarget)
+	}
+	if !strings.Contains(body, "Signed JSON payload") {
+		t.Errorf("raw view should show the signed payload")
+	}
+	if strings.Contains(body, redactedDestination) {
+		t.Errorf("raw view should not show the redaction placeholder")
+	}
+	if strings.Contains(body, "Metadata view") {
+		t.Errorf("raw view should not show the metadata redaction banner")
+	}
+}
+
+func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
+	t.Parallel()
+	dir, trusted := writeTrustedHandlerSession(t)
+
+	var meta strings.Builder
+	metaHandler := New(Options{
+		ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+		AuditWriter: &meta,
+	})
+	metaHandler.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+	if !strings.Contains(meta.String(), "role=metadata") {
+		t.Errorf("audit log should record metadata role; got %q", meta.String())
+	}
+	if !strings.Contains(meta.String(), "session=\""+testSessionID+"\"") {
+		t.Errorf("audit log should record the session; got %q", meta.String())
+	}
+
+	// Session carried as a query param (index route) is recorded too.
+	var q strings.Builder
+	qHandler := New(Options{
+		ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+		AuditWriter: &q,
+	})
+	qHandler.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?session="+testSessionID, nil))
+	if !strings.Contains(q.String(), "session=\""+testSessionID+"\"") {
+		t.Errorf("audit log should record the query-param session; got %q", q.String())
+	}
+
+	// No identifiable session (bare /session/) records the "-" placeholder.
+	var none strings.Builder
+	noneHandler := New(Options{
+		ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+		AuditWriter: &none,
+	})
+	noneHandler.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/", nil))
+	if !strings.Contains(none.String(), "session=\"-\"") {
+		t.Errorf("audit log should record '-' for an empty session; got %q", none.String())
+	}
+
+	var raw strings.Builder
+	rawHandler := New(Options{
+		ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+		AuthorizeRaw: allowRawAccess, AuditWriter: &raw,
+	})
+	rawHandler.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+	if !strings.Contains(raw.String(), "role=raw") {
+		t.Errorf("audit log should record raw role; got %q", raw.String())
+	}
+}
+
+func TestHandler_AuditNotWrittenForUnauthorized(t *testing.T) {
+	t.Parallel()
+	dir, trusted := writeTrustedHandlerSession(t)
+
+	var buf strings.Builder
+	handler := New(Options{
+		ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+		Authorize:   func(*http.Request) error { return errors.New("denied") },
+		AuditWriter: &buf,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("denied request must not be audited as access; got %q", buf.String())
+	}
 }
 
 func signAlteredReceipt(r receipt.Receipt, priv ed25519.PrivateKey) (receipt.Receipt, error) {

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -480,7 +480,7 @@ func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 
 func TestAuditSessionFieldNormalizesAndBoundsDisplay(t *testing.T) {
 	t.Parallel()
-	weird := strings.Repeat("a", auditSessionMaxBytes+20) + "\n\u202ereversed"
+	weird := "session\n\u202ereversed" + strings.Repeat("a", auditSessionMaxBytes+20)
 
 	display, hash := auditSessionField(weird)
 	if len(display) > auditSessionMaxBytes {
@@ -494,6 +494,14 @@ func TestAuditSessionFieldNormalizesAndBoundsDisplay(t *testing.T) {
 	}
 	if len(hash) != 64 {
 		t.Fatalf("hash length = %d, want 64", len(hash))
+	}
+
+	display, hash = auditSessionField("")
+	if display != "-" {
+		t.Fatalf("empty display = %q, want '-'", display)
+	}
+	if len(hash) != 64 {
+		t.Fatalf("empty hash length = %d, want 64", len(hash))
 	}
 }
 

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -380,6 +380,41 @@ func TestHandler_RawAccessShowsDetail(t *testing.T) {
 	}
 }
 
+func TestHandler_RawAccessDecisionIsCachedPerRequest(t *testing.T) {
+	t.Parallel()
+	dir, trusted := writeTrustedHandlerSession(t)
+
+	var calls int
+	var audit strings.Builder
+	handler := New(Options{
+		ReceiptDir:  dir,
+		TrustedKeys: trusted,
+		HasFeature:  allowAgentsFeature,
+		AuthorizeRaw: func(*http.Request) error {
+			calls++
+			if calls == 1 {
+				return nil
+			}
+			return errors.New("raw authorizer called more than once")
+		},
+		AuditWriter: &audit,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("AuthorizeRaw calls = %d, want 1", calls)
+	}
+	if !strings.Contains(rec.Body.String(), "Signed JSON payload") {
+		t.Fatalf("cached raw decision should drive render; body=%s", rec.Body.String())
+	}
+	if !strings.Contains(audit.String(), "role=raw") {
+		t.Fatalf("cached raw decision should drive audit role; audit=%q", audit.String())
+	}
+}
+
 func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 	t.Parallel()
 	dir, trusted := writeTrustedHandlerSession(t)
@@ -396,6 +431,9 @@ func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 	}
 	if !strings.Contains(meta.String(), "session=\""+testSessionID+"\"") {
 		t.Errorf("audit log should record the session; got %q", meta.String())
+	}
+	if !strings.Contains(meta.String(), "session_sha256=") {
+		t.Errorf("audit log should record the session hash; got %q", meta.String())
 	}
 
 	// Session carried as a query param (index route) is recorded too.
@@ -431,6 +469,25 @@ func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
 	if !strings.Contains(raw.String(), "role=raw") {
 		t.Errorf("audit log should record raw role; got %q", raw.String())
+	}
+}
+
+func TestAuditSessionFieldNormalizesAndBoundsDisplay(t *testing.T) {
+	t.Parallel()
+	weird := strings.Repeat("a", auditSessionMaxBytes+20) + "\n\u202ereversed"
+
+	display, hash := auditSessionField(weird)
+	if len(display) > auditSessionMaxBytes {
+		t.Fatalf("display length = %d, want <= %d", len(display), auditSessionMaxBytes)
+	}
+	if strings.ContainsAny(display, "\n\r\t") || strings.Contains(display, "\u202e") {
+		t.Fatalf("display should not carry control or confusing Unicode: %q", display)
+	}
+	if !strings.HasSuffix(display, "...") {
+		t.Fatalf("long display should be visibly truncated: %q", display)
+	}
+	if len(hash) != 64 {
+		t.Fatalf("hash length = %d, want 64", len(hash))
 	}
 }
 

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -328,6 +329,27 @@ func TestHandler_RedactsRawByDefault(t *testing.T) {
 	}
 }
 
+func TestRedactRawRemovesTemplateReceiptPayload(t *testing.T) {
+	t.Parallel()
+	_, priv := generateDashboardKey(t)
+	rec := signDashboardReceipt(t, priv, 0, receipt.GenesisHash, time.Date(2026, 7, 3, 13, 0, 0, 0, time.UTC))
+	ev := sessionEvidence(testSessionID, []receipt.Receipt{rec}, nil, false, dashboardReceiptReadLimit, dashboardTimelineLimit)
+
+	redacted := redactRaw(ev)
+	if redacted.ReceiptCount != 1 {
+		t.Fatalf("ReceiptCount = %d, want 1", redacted.ReceiptCount)
+	}
+	if redacted.Receipts != nil {
+		t.Fatalf("metadata view must not carry raw receipts into template data")
+	}
+	if redacted.Timeline[0].Destination != redactedDestination {
+		t.Fatalf("Destination = %q, want redacted placeholder", redacted.Timeline[0].Destination)
+	}
+	if redacted.Timeline[0].RawJSON != "" {
+		t.Fatalf("RawJSON should be stripped, got %q", redacted.Timeline[0].RawJSON)
+	}
+}
+
 func TestHandler_RawAccessShowsDetail(t *testing.T) {
 	t.Parallel()
 	dir, trusted := writeTrustedHandlerSession(t)
@@ -409,6 +431,40 @@ func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
 	if !strings.Contains(raw.String(), "role=raw") {
 		t.Errorf("audit log should record raw role; got %q", raw.String())
+	}
+}
+
+func TestHandler_AuditWriterSerializesConcurrentRequests(t *testing.T) {
+	t.Parallel()
+	dir, trusted := writeTrustedHandlerSession(t)
+
+	var audit strings.Builder
+	handler := New(Options{
+		ReceiptDir:   dir,
+		TrustedKeys:  trusted,
+		HasFeature:   allowAgentsFeature,
+		AuditWriter:  &audit,
+		AuthorizeRaw: allowRawAccess,
+	})
+
+	const requests = 25
+	var wg sync.WaitGroup
+	wg.Add(requests)
+	for i := 0; i < requests; i++ {
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec,
+				httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+			if rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200", rec.Code)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := strings.Count(audit.String(), "pipelock-dashboard access"); got != requests {
+		t.Fatalf("audit lines = %d, want %d; log=%q", got, requests, audit.String())
 	}
 }
 

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -419,57 +419,63 @@ func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 	t.Parallel()
 	dir, trusted := writeTrustedHandlerSession(t)
 
-	var meta strings.Builder
-	metaHandler := New(Options{
-		ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
-		AuditWriter: &meta,
+	t.Run("metadata_role_and_path_session", func(t *testing.T) {
+		var meta strings.Builder
+		metaHandler := New(Options{
+			ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+			AuditWriter: &meta,
+		})
+		metaHandler.ServeHTTP(httptest.NewRecorder(),
+			httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+		if !strings.Contains(meta.String(), "role=metadata") {
+			t.Errorf("audit log should record metadata role; got %q", meta.String())
+		}
+		if !strings.Contains(meta.String(), "session=\""+testSessionID+"\"") {
+			t.Errorf("audit log should record the session; got %q", meta.String())
+		}
+		if !strings.Contains(meta.String(), "session_sha256=") {
+			t.Errorf("audit log should record the session hash; got %q", meta.String())
+		}
 	})
-	metaHandler.ServeHTTP(httptest.NewRecorder(),
-		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
-	if !strings.Contains(meta.String(), "role=metadata") {
-		t.Errorf("audit log should record metadata role; got %q", meta.String())
-	}
-	if !strings.Contains(meta.String(), "session=\""+testSessionID+"\"") {
-		t.Errorf("audit log should record the session; got %q", meta.String())
-	}
-	if !strings.Contains(meta.String(), "session_sha256=") {
-		t.Errorf("audit log should record the session hash; got %q", meta.String())
-	}
 
-	// Session carried as a query param (index route) is recorded too.
-	var q strings.Builder
-	qHandler := New(Options{
-		ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
-		AuditWriter: &q,
+	t.Run("query_param_session", func(t *testing.T) {
+		var q strings.Builder
+		qHandler := New(Options{
+			ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+			AuditWriter: &q,
+		})
+		qHandler.ServeHTTP(httptest.NewRecorder(),
+			httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?session="+testSessionID, nil))
+		if !strings.Contains(q.String(), "session=\""+testSessionID+"\"") {
+			t.Errorf("audit log should record the query-param session; got %q", q.String())
+		}
 	})
-	qHandler.ServeHTTP(httptest.NewRecorder(),
-		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?session="+testSessionID, nil))
-	if !strings.Contains(q.String(), "session=\""+testSessionID+"\"") {
-		t.Errorf("audit log should record the query-param session; got %q", q.String())
-	}
 
-	// No identifiable session (bare /session/) records the "-" placeholder.
-	var none strings.Builder
-	noneHandler := New(Options{
-		ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
-		AuditWriter: &none,
+	t.Run("empty_session", func(t *testing.T) {
+		var none strings.Builder
+		noneHandler := New(Options{
+			ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+			AuditWriter: &none,
+		})
+		noneHandler.ServeHTTP(httptest.NewRecorder(),
+			httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/", nil))
+		if !strings.Contains(none.String(), "session=\"-\"") {
+			t.Errorf("audit log should record '-' for an empty session; got %q", none.String())
+		}
 	})
-	noneHandler.ServeHTTP(httptest.NewRecorder(),
-		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/", nil))
-	if !strings.Contains(none.String(), "session=\"-\"") {
-		t.Errorf("audit log should record '-' for an empty session; got %q", none.String())
-	}
 
-	var raw strings.Builder
-	rawHandler := New(Options{
-		ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
-		AuthorizeRaw: allowRawAccess, AuditWriter: &raw,
+	t.Run("raw_role", func(t *testing.T) {
+		var raw strings.Builder
+		rawHandler := New(Options{
+			ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+			AuthorizeRaw: allowRawAccess, AuditWriter: &raw,
+		})
+		rawHandler.ServeHTTP(httptest.NewRecorder(),
+			httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+		if !strings.Contains(raw.String(), "role=raw") {
+			t.Errorf("audit log should record raw role; got %q", raw.String())
+		}
 	})
-	rawHandler.ServeHTTP(httptest.NewRecorder(),
-		httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
-	if !strings.Contains(raw.String(), "role=raw") {
-		t.Errorf("audit log should record raw role; got %q", raw.String())
-	}
 }
 
 func TestAuditSessionFieldNormalizesAndBoundsDisplay(t *testing.T) {

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -81,6 +81,7 @@ type SessionEvidence struct {
 	ID              string
 	Agent           string
 	ReceiptsEnabled bool
+	ReceiptCount    int
 	Receipts        []receipt.Receipt
 	ReadLimited     bool
 	ReadLimit       int
@@ -133,6 +134,7 @@ func NewReadModel(opts Options) *ReadModel {
 // bytes never reach the response. Idempotent and safe on a zero value.
 func redactRaw(ev SessionEvidence) SessionEvidence {
 	ev.RawRedacted = true
+	ev.Receipts = nil
 	for i := range ev.Timeline {
 		ev.Timeline[i].Destination = redactedDestination
 		ev.Timeline[i].RawJSON = ""
@@ -216,6 +218,7 @@ func sessionEvidence(id string, receipts []receipt.Receipt, trustedKeys map[stri
 		ID:              id,
 		Agent:           agentLabel(id, receipts),
 		ReceiptsEnabled: true,
+		ReceiptCount:    len(receipts),
 		Receipts:        append([]receipt.Receipt(nil), receipts...),
 		ReadLimited:     readLimited,
 		ReadLimit:       readLimit,

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -7,12 +7,18 @@ package dashboard
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
+
+// redactedDestination replaces a receipt Destination in the metadata view. A
+// destination URL can carry a capability token or secret in its query string,
+// so it is only shown to a request that authenticated with raw access.
+const redactedDestination = "[redacted — raw access required]"
 
 const (
 	dashboardReceiptReadLimit = 5000
@@ -28,7 +34,18 @@ type Options struct {
 	// and fails the request closed (403) on a non-nil error. It is the handler's
 	// authentication/authorization seam, distinct from the license entitlement
 	// check. Nil means the surrounding router must own authentication.
-	Authorize        func(*http.Request) error
+	Authorize func(*http.Request) error
+	// AuthorizeRaw gates the sensitive raw view (receipt destinations and full
+	// signed payloads). A request is shown raw detail only when AuthorizeRaw is
+	// non-nil AND returns nil for it; every other authenticated request gets the
+	// redacted metadata view. Nil means raw detail is redacted for everyone
+	// (fail closed): a destination URL can carry a capability token, and the raw
+	// payload is the largest exfil surface, so raw is least-privilege by default.
+	AuthorizeRaw func(*http.Request) error
+	// AuditWriter, when non-nil, receives one line per authenticated dashboard
+	// request (role, method, path, session, remote address). Viewing evidence is
+	// itself an audited action. Nil disables the access log.
+	AuditWriter      io.Writer
 	ReceiptReadLimit int
 	TimelineLimit    int
 }
@@ -74,6 +91,9 @@ type SessionEvidence struct {
 	Scorecard       Scorecard
 	Timeline        []TimelineItem
 	TrustedKeyText  string
+	// RawRedacted is true when this view was rendered without raw access, so the
+	// template shows a "raw access required" note instead of the signed payload.
+	RawRedacted bool
 }
 
 // TimelineItem is one rendered receipt row.
@@ -105,6 +125,19 @@ func NewReadModel(opts Options) *ReadModel {
 		receiptReadLimit: receiptReadLimit,
 		timelineLimit:    timelineLimit,
 	}
+}
+
+// redactRaw strips the raw exfil surface from an evidence view: every receipt's
+// destination and full signed payload. It operates on the freshly built value
+// from Session, so callers hand the redacted copy to the template and the raw
+// bytes never reach the response. Idempotent and safe on a zero value.
+func redactRaw(ev SessionEvidence) SessionEvidence {
+	ev.RawRedacted = true
+	for i := range ev.Timeline {
+		ev.Timeline[i].Destination = redactedDestination
+		ev.Timeline[i].RawJSON = ""
+	}
+	return ev
 }
 
 // Sessions lists available recorder sessions and computes their compact state.


### PR DESCRIPTION
## Summary
- Adds a redacted-by-default metadata view for the Enterprise Evidence dashboard.
- Adds an optional raw-access token for receipt destinations and signed payloads.
- Audits authenticated dashboard access by role, method, path, session, and remote address.
- Hardens metadata rendering so raw receipt payloads are stripped before template rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added higher-privilege “raw” mode for `pipelock dashboard serve` via `--raw-token-file`, while the default view remains redacted.
  * Added per-request access auditing to indicate whether access was “metadata” vs “raw”.
* **Documentation**
  * Updated CLI docs and changelog to clarify the two-tier token model and redaction behavior.
* **Bug Fixes**
  * Prevents use of identical token files for `--auth-token-file` and `--raw-token-file`.
  * Ensures raw destination and signed payload details are omitted when raw access isn’t authorized.
* **Tests**
  * Expanded coverage for raw-token validation, rendering differences, and audit logging (including concurrency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->