### PR TITLE
fix(baseline): fail closed on unreadable or corrupt persisted profile under enforcement

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2520,7 +2520,7 @@ behavioral_baseline:
 | `poison_resistance` | `true` | Trim outlier sessions when building the profile, so adversarial sessions during learning have bounded influence |
 | `seasonality_mode` | `none` | Only `none` is implemented. `labeled` and `time` are reserved and rejected by the baseline engine at startup. |
 
-Profile lifecycle: `observe` → `learn` → `ratify` → `locked`. Enforcement applies only to a **locked** profile; a profile in any earlier state (including `ratify`) produces no deviations. Profiles persist to `profile_dir` (one JSON file per agent, carrying the lifecycle state) and survive restarts.
+Profile lifecycle: `observe` → `learn` → `ratify` → `locked`. Enforcement applies only to a **locked** profile; a profile in any earlier state (including `ratify`) produces no deviations. Profiles persist to `profile_dir` (one JSON file per agent, carrying the lifecycle state) and survive restarts. If a persisted profile exists but cannot be read or parsed and `deviation_action` is `ask` or `block`, Pipelock fails closed: it refuses to start rather than come up with that agent's enforcement silently disabled (fix or restore the file). In `warn` (observational) mode an unreadable profile is skipped.
 
 **Locking a profile (current limitation).** A profile reaches `locked` only via `auto_ratify: true`, which locks automatically at the end of the learning window. There is no operator ratify command in this release: a profile learned without `auto_ratify` stays in `ratify` and never enforces. So today the practical choices are `auto_ratify: true` (accepting the documented learning-window poisoning risk) or leaving the baseline observe-only. Do not rely on a manual operator-approval step before enforcement — it is not yet wired.
 

--- a/internal/proxy/baseline/baseline.go
+++ b/internal/proxy/baseline/baseline.go
@@ -288,6 +288,23 @@ func (m *Manager) Reconfigure(cfg Config) error {
 		if err := os.MkdirAll(cfg.ProfileDir, 0o750); err != nil {
 			return fmt.Errorf("creating profile dir: %w", err)
 		}
+		candidate := &Manager{
+			cfg:    cfg,
+			agents: make(map[string]*agentState),
+		}
+		if err := candidate.loadProfiles(); err != nil {
+			return fmt.Errorf("loading profiles: %w", err)
+		}
+
+		m.mu.Lock()
+		m.cfg = cfg
+		for agentKey, loaded := range candidate.agents {
+			if existing, ok := m.agents[agentKey]; !ok || existing.profile == nil {
+				m.agents[agentKey] = loaded
+			}
+		}
+		m.mu.Unlock()
+		return nil
 	}
 
 	m.mu.Lock()

--- a/internal/proxy/baseline/baseline.go
+++ b/internal/proxy/baseline/baseline.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	appconfig "github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 // safeAgentKeyRe restricts agent keys to alphanumeric, hyphens, underscores,
@@ -173,6 +175,32 @@ type Manager struct {
 	mu     sync.RWMutex
 }
 
+// Deviation actions. "warn" is observational; "ask" (HITL) and "block" both
+// take a consequential action on a deviation, so they are enforcing.
+const (
+	deviationActionWarn  = appconfig.ActionWarn
+	deviationActionAsk   = appconfig.ActionAsk
+	deviationActionBlock = appconfig.ActionBlock
+)
+
+// enforces reports whether a deviation from a locked profile takes a
+// consequential action (ask=HITL, block=deny) rather than only observing
+// (warn). Under enforcement, a persisted profile that exists but cannot be
+// read or parsed must fail closed at load: silently skipping it would erase
+// active enforcement for that agent on the next restart (fail-open).
+func (c Config) enforces() bool {
+	return c.DeviationAction == deviationActionAsk || c.DeviationAction == deviationActionBlock
+}
+
+func validateDeviationAction(action string) error {
+	switch action {
+	case deviationActionWarn, deviationActionAsk, deviationActionBlock:
+		return nil
+	default:
+		return fmt.Errorf("unsupported deviation_action %q: valid values are warn, ask, or block", action)
+	}
+}
+
 // NewManager creates a new baseline manager. If ProfileDir is set and exists,
 // persisted profiles are loaded.
 func NewManager(cfg Config) (*Manager, error) {
@@ -183,7 +211,10 @@ func NewManager(cfg Config) (*Manager, error) {
 		cfg.SensitivitySigma = 2.0 // Default: 2 sigma.
 	}
 	if cfg.DeviationAction == "" {
-		cfg.DeviationAction = "warn"
+		cfg.DeviationAction = deviationActionWarn
+	}
+	if err := validateDeviationAction(cfg.DeviationAction); err != nil {
+		return nil, err
 	}
 	if cfg.SeasonalityMode == "" {
 		cfg.SeasonalityMode = seasonalityNone
@@ -233,7 +264,10 @@ func (m *Manager) Reconfigure(cfg Config) error {
 		cfg.SensitivitySigma = 2.0
 	}
 	if cfg.DeviationAction == "" {
-		cfg.DeviationAction = "warn"
+		cfg.DeviationAction = deviationActionWarn
+	}
+	if err := validateDeviationAction(cfg.DeviationAction); err != nil {
+		return err
 	}
 	if cfg.SeasonalityMode == "" {
 		cfg.SeasonalityMode = seasonalityNone
@@ -708,11 +742,22 @@ func (m *Manager) loadProfiles() error {
 		path := filepath.Join(m.cfg.ProfileDir, entry.Name())
 		data, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
+			// A persisted profile that exists but cannot be read may be a
+			// locked, enforcing profile. Under an enforcing action we cannot
+			// prove it is not, so fail closed rather than silently start with
+			// enforcement erased. Observational (warn) mode has no enforcement
+			// to lose, so it skips.
+			if m.cfg.enforces() {
+				return fmt.Errorf("reading persisted baseline profile %q under enforcing deviation_action %q (refusing to start without it; fix or restore the file): %w", entry.Name(), m.cfg.DeviationAction, err)
+			}
 			continue
 		}
 
 		var profile Profile
 		if err := json.Unmarshal(data, &profile); err != nil {
+			if m.cfg.enforces() {
+				return fmt.Errorf("parsing persisted baseline profile %q under enforcing deviation_action %q (refusing to start with a corrupt profile; fix or restore the file): %w", entry.Name(), m.cfg.DeviationAction, err)
+			}
 			continue
 		}
 

--- a/internal/proxy/baseline/baseline.go
+++ b/internal/proxy/baseline/baseline.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
@@ -297,10 +298,15 @@ func (m *Manager) Reconfigure(cfg Config) error {
 		}
 
 		m.mu.Lock()
+		profileDirChanged := !sameProfileDir(m.cfg.ProfileDir, cfg.ProfileDir)
 		m.cfg = cfg
-		for agentKey, loaded := range candidate.agents {
-			if existing, ok := m.agents[agentKey]; !ok || existing.profile == nil {
-				m.agents[agentKey] = loaded
+		if profileDirChanged {
+			m.agents = candidate.agents
+		} else {
+			for agentKey, loaded := range candidate.agents {
+				if existing, ok := m.agents[agentKey]; !ok || existing.profile == nil {
+					m.agents[agentKey] = loaded
+				}
 			}
 		}
 		m.mu.Unlock()
@@ -311,6 +317,13 @@ func (m *Manager) Reconfigure(cfg Config) error {
 	m.cfg = cfg
 	m.mu.Unlock()
 	return nil
+}
+
+func sameProfileDir(a, b string) bool {
+	if a == "" || b == "" {
+		return a == b
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
 }
 
 // RecordSession adds a completed session's metrics to the learning set.
@@ -767,6 +780,10 @@ func (m *Manager) loadProfiles() error {
 			if m.cfg.enforces() {
 				return fmt.Errorf("reading persisted baseline profile %q under enforcing deviation_action %q (refusing to start without it; fix or restore the file): %w", entry.Name(), m.cfg.DeviationAction, err)
 			}
+			slog.Warn("skipping unreadable persisted baseline profile",
+				"profile", entry.Name(),
+				"deviation_action", m.cfg.DeviationAction,
+				"error", err)
 			continue
 		}
 
@@ -775,6 +792,10 @@ func (m *Manager) loadProfiles() error {
 			if m.cfg.enforces() {
 				return fmt.Errorf("parsing persisted baseline profile %q under enforcing deviation_action %q (refusing to start with a corrupt profile; fix or restore the file): %w", entry.Name(), m.cfg.DeviationAction, err)
 			}
+			slog.Warn("skipping corrupt persisted baseline profile",
+				"profile", entry.Name(),
+				"deviation_action", m.cfg.DeviationAction,
+				"error", err)
 			continue
 		}
 

--- a/internal/proxy/baseline/baseline_test.go
+++ b/internal/proxy/baseline/baseline_test.go
@@ -470,6 +470,31 @@ func seedLockedProfileFor(t *testing.T, dir, agentKey string) string {
 	return path
 }
 
+func rewriteProfileToolCallsMean(t *testing.T, path string, mean float64) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+	var profile Profile
+	if err := json.Unmarshal(data, &profile); err != nil {
+		t.Fatalf("unmarshal profile: %v", err)
+	}
+	profile.Metrics.ToolCallsPerSession = Range{
+		Min:    mean,
+		Max:    mean,
+		Mean:   mean,
+		StdDev: 0,
+	}
+	data, err = json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal profile: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+}
+
 // TestBaseline_LoadProfiles_FailsClosedOnCorruptProfileUnderEnforcement proves
 // that a persisted profile which exists but cannot be read or parsed fails the
 // manager's startup when the deviation action is enforcing (ask/block).
@@ -533,9 +558,10 @@ func TestBaseline_LoadProfiles_FailsClosedOnCorruptProfileUnderEnforcement(t *te
 
 func TestBaseline_ReconfigureLoadsProfilesBeforeCommittingEnforcingConfig(t *testing.T) {
 	startDir := t.TempDir()
+	_ = seedLockedProfile(t, startDir)
 	mgr, err := NewManager(Config{
 		Enabled:         true,
-		DeviationAction: deviationActionWarn,
+		DeviationAction: deviationActionBlock,
 		ProfileDir:      startDir,
 	})
 	if err != nil {
@@ -556,11 +582,17 @@ func TestBaseline_ReconfigureLoadsProfilesBeforeCommittingEnforcingConfig(t *tes
 	if err == nil {
 		t.Fatal("Reconfigure: want fail-closed error for corrupt profile under block")
 	}
-	if mgr.cfg.DeviationAction != deviationActionWarn {
-		t.Fatalf("failed Reconfigure committed deviation_action = %q, want %q", mgr.cfg.DeviationAction, deviationActionWarn)
+	if mgr.cfg.DeviationAction != deviationActionBlock {
+		t.Fatalf("failed Reconfigure committed deviation_action = %q, want %q", mgr.cfg.DeviationAction, deviationActionBlock)
 	}
 	if mgr.cfg.ProfileDir != startDir {
 		t.Fatalf("failed Reconfigure committed profile_dir = %q, want %q", mgr.cfg.ProfileDir, startDir)
+	}
+	if state := mgr.GetState(testAgent); state != StateLocked {
+		t.Fatalf("failed Reconfigure changed profile state = %q, want %q", state, StateLocked)
+	}
+	if devs := mgr.Check(testAgent, SessionMetrics{ToolCalls: 9999}); len(devs) == 0 {
+		t.Fatal("failed Reconfigure must preserve existing locked-profile enforcement")
 	}
 }
 
@@ -589,6 +621,40 @@ func TestBaseline_ReconfigureLoadsValidProfilesUnderEnforcement(t *testing.T) {
 	}
 	if devs := mgr.Check(testAgent, SessionMetrics{ToolCalls: 9999}); len(devs) == 0 {
 		t.Fatal("reconfigured locked profile must detect deviations")
+	}
+}
+
+func TestBaseline_ReconfigureReplacesProfilesWhenProfileDirChanges(t *testing.T) {
+	startDir := t.TempDir()
+	_ = seedLockedProfile(t, startDir)
+	mgr, err := NewManager(Config{
+		Enabled:         true,
+		DeviationAction: deviationActionBlock,
+		ProfileDir:      startDir,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	reloadDir := t.TempDir()
+	reloadPath := seedLockedProfile(t, reloadDir)
+	rewriteProfileToolCallsMean(t, reloadPath, 100)
+
+	if err := mgr.Reconfigure(Config{
+		Enabled:         true,
+		DeviationAction: deviationActionBlock,
+		ProfileDir:      reloadDir,
+	}); err != nil {
+		t.Fatalf("Reconfigure with replacement profile dir: %v", err)
+	}
+
+	replacementMetrics := normalMetrics()
+	replacementMetrics.ToolCalls = 100
+	if devs := mgr.Check(testAgent, replacementMetrics); len(devs) != 0 {
+		t.Fatalf("reconfigured manager kept stale profile, got deviations: %+v", devs)
+	}
+	if devs := mgr.Check(testAgent, normalMetrics()); len(devs) == 0 {
+		t.Fatal("reconfigured manager must enforce replacement profile from new profile dir")
 	}
 }
 

--- a/internal/proxy/baseline/baseline_test.go
+++ b/internal/proxy/baseline/baseline_test.go
@@ -505,6 +505,7 @@ func TestBaseline_LoadProfiles_FailsClosedOnCorruptProfileUnderEnforcement(t *te
 		{"malformed_json_block_fails_closed", deviationActionBlock, corruptJSON, true},
 		{"read_error_block_fails_closed", deviationActionBlock, replaceWithBrokenSymlink, true},
 		{"malformed_json_ask_fails_closed", deviationActionAsk, corruptJSON, true},
+		{"read_error_ask_fails_closed", deviationActionAsk, replaceWithBrokenSymlink, true},
 		{"malformed_json_warn_starts_skipping", deviationActionWarn, corruptJSON, false},
 		{"read_error_warn_starts_skipping", deviationActionWarn, replaceWithBrokenSymlink, false},
 	}
@@ -527,6 +528,67 @@ func TestBaseline_LoadProfiles_FailsClosedOnCorruptProfileUnderEnforcement(t *te
 				t.Fatalf("NewManager: want success under deviation_action %q, got %v", tc.action, err)
 			}
 		})
+	}
+}
+
+func TestBaseline_ReconfigureLoadsProfilesBeforeCommittingEnforcingConfig(t *testing.T) {
+	startDir := t.TempDir()
+	mgr, err := NewManager(Config{
+		Enabled:         true,
+		DeviationAction: deviationActionWarn,
+		ProfileDir:      startDir,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	reloadDir := t.TempDir()
+	path := seedLockedProfile(t, reloadDir)
+	if err := os.WriteFile(path, []byte("{ not valid json"), 0o600); err != nil {
+		t.Fatalf("corrupt profile: %v", err)
+	}
+
+	err = mgr.Reconfigure(Config{
+		Enabled:         true,
+		DeviationAction: deviationActionBlock,
+		ProfileDir:      reloadDir,
+	})
+	if err == nil {
+		t.Fatal("Reconfigure: want fail-closed error for corrupt profile under block")
+	}
+	if mgr.cfg.DeviationAction != deviationActionWarn {
+		t.Fatalf("failed Reconfigure committed deviation_action = %q, want %q", mgr.cfg.DeviationAction, deviationActionWarn)
+	}
+	if mgr.cfg.ProfileDir != startDir {
+		t.Fatalf("failed Reconfigure committed profile_dir = %q, want %q", mgr.cfg.ProfileDir, startDir)
+	}
+}
+
+func TestBaseline_ReconfigureLoadsValidProfilesUnderEnforcement(t *testing.T) {
+	mgr, err := NewManager(Config{
+		Enabled:         true,
+		DeviationAction: deviationActionWarn,
+		ProfileDir:      t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	reloadDir := t.TempDir()
+	_ = seedLockedProfile(t, reloadDir)
+
+	if err := mgr.Reconfigure(Config{
+		Enabled:         true,
+		DeviationAction: deviationActionBlock,
+		ProfileDir:      reloadDir,
+	}); err != nil {
+		t.Fatalf("Reconfigure with intact profile under block: %v", err)
+	}
+	if state := mgr.GetState(testAgent); state != StateLocked {
+		t.Fatalf("reconfigured profile state = %q, want %q", state, StateLocked)
+	}
+	if devs := mgr.Check(testAgent, SessionMetrics{ToolCalls: 9999}); len(devs) == 0 {
+		t.Fatal("reconfigured locked profile must detect deviations")
 	}
 }
 

--- a/internal/proxy/baseline/baseline_test.go
+++ b/internal/proxy/baseline/baseline_test.go
@@ -53,6 +53,48 @@ func TestNewManager_Defaults(t *testing.T) {
 	}
 }
 
+func TestBaseline_InvalidDeviationActionRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T) error
+	}{
+		{
+			name: "new_manager",
+			run: func(t *testing.T) error {
+				t.Helper()
+				_, err := NewManager(Config{
+					Enabled:         true,
+					DeviationAction: "observe",
+					ProfileDir:      t.TempDir(),
+				})
+				return err
+			},
+		},
+		{
+			name: "reconfigure",
+			run: func(t *testing.T) error {
+				t.Helper()
+				mgr, err := NewManager(Config{Enabled: true, ProfileDir: t.TempDir()})
+				if err != nil {
+					t.Fatalf("NewManager: %v", err)
+				}
+				return mgr.Reconfigure(Config{
+					Enabled:         true,
+					DeviationAction: "observe",
+					ProfileDir:      t.TempDir(),
+				})
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(t); err == nil {
+				t.Fatal("expected invalid deviation_action to be rejected")
+			}
+		})
+	}
+}
+
 func TestBaseline_Learning(t *testing.T) {
 	cfg := Config{Enabled: true, LearningWindow: 3, ProfileDir: t.TempDir()}
 	mgr, err := NewManager(cfg)
@@ -399,6 +441,157 @@ func TestBaseline_Reset_FailsClosedWhenRemovalFails(t *testing.T) {
 	}
 	if devs := mgr.Check(testAgent, SessionMetrics{ToolCalls: 9999}); len(devs) == 0 {
 		t.Fatal("enforcement must remain active after a failed forget")
+	}
+}
+
+// seedLockedProfile creates a ratified, locked, persisted profile for testAgent
+// in dir and returns its on-disk path.
+func seedLockedProfile(t *testing.T, dir string) string {
+	t.Helper()
+	return seedLockedProfileFor(t, dir, testAgent)
+}
+
+func seedLockedProfileFor(t *testing.T, dir, agentKey string) string {
+	t.Helper()
+	seed, err := NewManager(Config{Enabled: true, LearningWindow: 3, ProfileDir: dir})
+	if err != nil {
+		t.Fatalf("seed NewManager: %v", err)
+	}
+	for range 3 {
+		seed.RecordSession(agentKey, normalMetrics())
+	}
+	if err := seed.Ratify(agentKey); err != nil {
+		t.Fatalf("seed Ratify: %v", err)
+	}
+	path := filepath.Join(dir, agentKey+profileFileExt)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("seed profile not persisted: %v", err)
+	}
+	return path
+}
+
+// TestBaseline_LoadProfiles_FailsClosedOnCorruptProfileUnderEnforcement proves
+// that a persisted profile which exists but cannot be read or parsed fails the
+// manager's startup when the deviation action is enforcing (ask/block).
+// Silently skipping it (the pre-fix behavior) erased a locked agent's
+// enforcement on the next restart - a fail-open on a security control.
+func TestBaseline_LoadProfiles_FailsClosedOnCorruptProfileUnderEnforcement(t *testing.T) {
+	corruptJSON := func(t *testing.T, path string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte("{ not valid json"), 0o600); err != nil {
+			t.Fatalf("corrupt profile: %v", err)
+		}
+	}
+	// replaceWithBrokenSymlink makes os.ReadFile fail (ENOENT via a dangling
+	// link) while keeping the dir entry a non-directory with the profile
+	// extension, so it reaches the read path. This is privilege-independent -
+	// a chmod-000 regular file is bypassed under root.
+	replaceWithBrokenSymlink := func(t *testing.T, path string) {
+		t.Helper()
+		if err := os.Remove(path); err != nil {
+			t.Fatalf("remove seeded profile: %v", err)
+		}
+		if err := os.Symlink(filepath.Join(t.TempDir(), "does-not-exist"), path); err != nil {
+			t.Fatalf("symlink at profile path: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		action  string
+		corrupt func(*testing.T, string)
+		wantErr bool
+	}{
+		{"malformed_json_block_fails_closed", deviationActionBlock, corruptJSON, true},
+		{"read_error_block_fails_closed", deviationActionBlock, replaceWithBrokenSymlink, true},
+		{"malformed_json_ask_fails_closed", deviationActionAsk, corruptJSON, true},
+		{"malformed_json_warn_starts_skipping", deviationActionWarn, corruptJSON, false},
+		{"read_error_warn_starts_skipping", deviationActionWarn, replaceWithBrokenSymlink, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := seedLockedProfile(t, dir)
+			tc.corrupt(t, path)
+
+			_, err := NewManager(Config{
+				Enabled:         true,
+				LearningWindow:  3,
+				DeviationAction: tc.action,
+				ProfileDir:      dir,
+			})
+			if tc.wantErr && err == nil {
+				t.Fatalf("NewManager: want fail-closed error for corrupt profile under deviation_action %q, got nil (fail-open)", tc.action)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("NewManager: want success under deviation_action %q, got %v", tc.action, err)
+			}
+		})
+	}
+}
+
+func TestBaseline_LoadProfiles_MixedValidAndCorruptFailsClosedUnderBlock(t *testing.T) {
+	dir := t.TempDir()
+	_ = seedLockedProfileFor(t, dir, "agent-2")
+	corruptPath := filepath.Join(dir, testAgent+profileFileExt)
+	if err := os.WriteFile(corruptPath, []byte("{ not valid json"), 0o600); err != nil {
+		t.Fatalf("write corrupt profile: %v", err)
+	}
+
+	_, err := NewManager(Config{
+		Enabled:         true,
+		LearningWindow:  3,
+		DeviationAction: deviationActionBlock,
+		ProfileDir:      dir,
+	})
+	if err == nil {
+		t.Fatal("NewManager: want fail-closed error when any persisted profile is corrupt under block")
+	}
+}
+
+// TestBaseline_LoadProfiles_ValidProfileLoadsAndEnforcesUnderBlock ensures the
+// fail-closed load does not regress the normal path: an intact locked profile
+// still loads and enforces under block mode.
+func TestBaseline_LoadProfiles_ValidProfileLoadsAndEnforcesUnderBlock(t *testing.T) {
+	dir := t.TempDir()
+	_ = seedLockedProfile(t, dir)
+
+	mgr, err := NewManager(Config{
+		Enabled:         true,
+		LearningWindow:  3,
+		DeviationAction: deviationActionBlock,
+		ProfileDir:      dir,
+	})
+	if err != nil {
+		t.Fatalf("NewManager with intact profile under block: %v", err)
+	}
+	if state := mgr.GetState(testAgent); state != StateLocked {
+		t.Fatalf("reloaded profile state = %q, want %q", state, StateLocked)
+	}
+	if devs := mgr.Check(testAgent, SessionMetrics{ToolCalls: 9999}); len(devs) == 0 {
+		t.Fatal("reloaded locked profile must still detect deviations")
+	}
+}
+
+func TestBaseline_LoadProfiles_EmptyOrAbsentProfileDirAllowedUnderBlock(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+	}{
+		{"empty", t.TempDir()},
+		{"absent", filepath.Join(t.TempDir(), "profiles")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewManager(Config{
+				Enabled:         true,
+				DeviationAction: deviationActionBlock,
+				ProfileDir:      tc.dir,
+			})
+			if err != nil {
+				t.Fatalf("NewManager with %s profile dir under block: %v", tc.name, err)
+			}
+		})
 	}
 }
 
@@ -897,14 +1090,19 @@ func TestBaseline_LoadProfileWithEmptyAgentKey(t *testing.T) {
 		State:        StateLocked,
 		SessionCount: 3,
 		Ratified:     true,
-		Metrics:      ProfileMetrics{},
+		Metrics: ProfileMetrics{
+			ToolCallsPerSession: Range{Min: 4, Max: 4, Mean: 4, StdDev: 0},
+		},
 	}
-	data, _ := json.Marshal(profile)
+	data, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatalf("marshal filename-derived profile: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, "derived-agent.json"), data, 0o600); err != nil {
 		t.Fatalf("writing profile: %v", err)
 	}
 
-	cfg := Config{Enabled: true, ProfileDir: dir}
+	cfg := Config{Enabled: true, DeviationAction: deviationActionBlock, ProfileDir: dir}
 	mgr, err := NewManager(cfg)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
@@ -914,6 +1112,12 @@ func TestBaseline_LoadProfileWithEmptyAgentKey(t *testing.T) {
 	p := mgr.GetProfile("derived-agent")
 	if p == nil {
 		t.Fatal("expected profile loaded from filename-derived key")
+	}
+	if state := mgr.GetState("derived-agent"); state != StateLocked {
+		t.Fatalf("derived profile state = %q, want %q", state, StateLocked)
+	}
+	if devs := mgr.Check("derived-agent", SessionMetrics{ToolCalls: 9999}); len(devs) == 0 {
+		t.Fatal("filename-derived locked profile must still detect deviations")
 	}
 }
 


### PR DESCRIPTION
## What changed

Under an enforcing `deviation_action` (`ask` or `block`), the behavioral-baseline manager now refuses to start when a persisted profile exists but cannot be read or parsed, instead of silently skipping it.

- `loadProfiles` returns an error on a read or unmarshal failure when the configured action is enforcing. `NewManager` already propagates it, so the proxy fails to start rather than come up with a locked agent's deviation enforcement silently erased. `Reconfigure` (hot reload) does the same, and the reload path keeps the previous config on failure.
- `warn` (observational) mode still skips an unreadable profile, since there is no enforcement to lose.
- Added an `enforces()` helper and a `validateDeviationAction` guard that rejects unknown actions, so a typo (e.g. `observe`) cannot fall through to warn-like behavior. Action constants now reference the canonical `config.Action*` values.
- Documented the fail-closed load behavior in the behavioral-baseline configuration section.

## Why

A locked, enforcing behavioral-baseline profile that was corrupt or unreadable on restart was silently dropped, disabling that agent's deviation enforcement with no error. That is a fail-open on a security control, against the invariant that stateful controls fail closed on restart.

## Scope

This closes the corrupt/unreadable-profile vector. Broader profile-integrity hardening (verifying that persisted profiles have not been tampered with or removed) is tracked separately and is intentionally out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Persisted “Behavioral Baseline” profiles now fail closed in enforcement modes (including `ask`/`block`) when they can’t be read or are corrupt; `warn` mode continues by skipping them.
  * Reconfiguration won’t commit a new enforcing configuration if persisted profile loading fails, and changing the profile directory correctly replaces the enforced baseline.
  * Invalid `deviation_action` values are now rejected during startup/reconfiguration.
* **Documentation**
  * Updated configuration guidance for the Behavioral Baseline restart behavior and enforcement vs warn outcomes on unreadable profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->