### PR TITLE
fix(mcp): enforce denial-of-wallet and chain detection on A2A methods

### DIFF
--- a/internal/mcp/a2a_enforcement_parity_test.go
+++ b/internal/mcp/a2a_enforcement_parity_test.go
@@ -201,6 +201,60 @@ func TestForwardScannedInput_A2ADoWBlock(t *testing.T) {
 	}
 }
 
+func TestForwardScannedInput_A2ADoWBlockLeavesNoChainTrace(t *testing.T) {
+	sc := testInputScanner(t)
+	opts := testOpts(sc)
+	opts.InputCfg = &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock}
+	opts.ChainMatcher = testA2AChainMatcher()
+	opts.DoWCheck = func(identity, _ string) (bool, string, string, string) {
+		if identity == a2aBaselineIdentity(testA2AMethod) {
+			return false, config.ActionBlock, testA2ADoWReason, testA2ADoWBudgetType
+		}
+		return true, "", "", ""
+	}
+
+	input := string(testA2ARequest(1, testA2AMethod)) + "\n" +
+		string(testA2ARequest(2, testA2ASecondMethod)) + "\n"
+	var serverIn bytes.Buffer
+	var logW bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 10)
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(input)),
+		transport.NewStdioWriter(&serverIn),
+		&logW,
+		config.ActionWarn,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		nil,
+		opts,
+	)
+
+	if strings.Contains(serverIn.String(), testA2AMethod) {
+		t.Fatalf("expected DoW-blocked A2A request not to forward, got: %s", serverIn.String())
+	}
+	if !strings.Contains(serverIn.String(), testA2ASecondMethod) {
+		t.Fatalf("DoW-blocked A2A request left a chain trace; second request did not forward: %s", serverIn.String())
+	}
+	var gotDoWBlock bool
+	for br := range blockedCh {
+		if strings.Contains(br.ErrorMessage, testA2ADoWReason) {
+			gotDoWBlock = true
+			continue
+		}
+		if strings.Contains(br.ErrorMessage, testA2AChainPattern) {
+			t.Fatalf("DoW-blocked A2A request left a chain trace; chain block: %+v", br)
+		}
+		t.Fatalf("unexpected block: %+v; log=%s", br, logW.String())
+	}
+	if !gotDoWBlock {
+		t.Fatalf("expected A2A DoW block; log=%s", logW.String())
+	}
+	if !strings.Contains(logW.String(), testA2ADoWReason) {
+		t.Fatalf("expected DoW reason in log, got: %s", logW.String())
+	}
+}
+
 func TestForwardScannedInput_A2ADoWAllowDoesNotFalseBlock(t *testing.T) {
 	sc := testInputScanner(t)
 	opts := testOpts(sc)

--- a/internal/mcp/a2a_enforcement_parity_test.go
+++ b/internal/mcp/a2a_enforcement_parity_test.go
@@ -1,0 +1,342 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/chains"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
+)
+
+const (
+	testA2AMethod         = "SendMessage"
+	testA2ASecondMethod   = "GetTask"
+	testA2ADoWReason      = "a2a budget exceeded"
+	testA2ADoWBudgetType  = "a2a_per_method"
+	testA2AChainPattern   = "a2a-send-burst"
+	testA2ARequestPayload = `{"message":{"parts":[{"kind":"text","text":"hello"}]}}`
+)
+
+func testA2ARequest(id int, method string) []byte {
+	return []byte(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"` + method + `","params":` + testA2ARequestPayload + `}`)
+}
+
+func testA2AChainMatcher() *chains.Matcher {
+	return chains.New(&config.ToolChainDetection{
+		Enabled:       true,
+		Action:        config.ActionBlock,
+		WindowSize:    20,
+		WindowSeconds: 300,
+		MaxGap:        intPtrInput(3),
+		ToolCategories: map[string][]string{
+			"network": {
+				a2aBaselineIdentity(testA2AMethod),
+				a2aBaselineIdentity(testA2ASecondMethod),
+			},
+		},
+		CustomPatterns: []config.ChainPattern{{
+			Name:     testA2AChainPattern,
+			Sequence: []string{"network", "network"},
+			Severity: config.SeverityHigh,
+			Action:   config.ActionBlock,
+		}},
+	})
+}
+
+func TestScanHTTPInput_A2ADoWBlock(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	var gotIdentity string
+	opts := MCPProxyOpts{
+		Scanner:  sc,
+		InputCfg: &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock},
+		DoWCheck: func(identity, argsJSON string) (bool, string, string, string) {
+			gotIdentity = identity
+			if identity == a2aBaselineIdentity(testA2AMethod) && strings.Contains(argsJSON, `"method":"`+testA2AMethod+`"`) {
+				return false, config.ActionBlock, testA2ADoWReason, testA2ADoWBudgetType
+			}
+			return true, "", "", ""
+		},
+	}
+
+	blocked := scanHTTPInput(testA2ARequest(1, testA2AMethod), io.Discard, "a2a-session", "a2a-session", opts)
+	if blocked == nil {
+		t.Fatal("expected A2A DoW block")
+	}
+	if gotIdentity != a2aBaselineIdentity(testA2AMethod) {
+		t.Fatalf("DoW identity = %q, want %q", gotIdentity, a2aBaselineIdentity(testA2AMethod))
+	}
+	if !strings.Contains(blocked.ErrorMessage, testA2ADoWReason) {
+		t.Fatalf("ErrorMessage = %q, want DoW reason", blocked.ErrorMessage)
+	}
+}
+
+func TestScanHTTPInput_A2ADoWAllowDoesNotFalseBlock(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	var gotIdentity string
+	opts := MCPProxyOpts{
+		Scanner:  sc,
+		InputCfg: &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock},
+		DoWCheck: func(identity, _ string) (bool, string, string, string) {
+			gotIdentity = identity
+			return true, "", "", ""
+		},
+	}
+
+	blocked := scanHTTPInput(testA2ARequest(1, testA2AMethod), io.Discard, "a2a-session", "a2a-session", opts)
+	if blocked != nil {
+		t.Fatalf("A2A DoW allow should not block: %+v", blocked)
+	}
+	if gotIdentity != a2aBaselineIdentity(testA2AMethod) {
+		t.Fatalf("DoW identity = %q, want %q", gotIdentity, a2aBaselineIdentity(testA2AMethod))
+	}
+}
+
+func TestScanHTTPInput_A2AChainBlock(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	var logBuf bytes.Buffer
+	opts := MCPProxyOpts{
+		Scanner:      sc,
+		InputCfg:     &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock},
+		ChainMatcher: testA2AChainMatcher(),
+	}
+
+	first := scanHTTPInput(testA2ARequest(1, testA2AMethod), &logBuf, "a2a-session", "a2a-session", opts)
+	if first != nil {
+		t.Fatalf("first A2A chain element should not block: %+v", first)
+	}
+	second := scanHTTPInput(testA2ARequest(2, testA2ASecondMethod), &logBuf, "a2a-session", "a2a-session", opts)
+	if second == nil {
+		t.Fatal("expected A2A chain block on second method")
+	}
+	if second.ErrorCode != -32004 {
+		t.Fatalf("ErrorCode = %d, want -32004", second.ErrorCode)
+	}
+	if !strings.Contains(logBuf.String(), testA2AChainPattern) {
+		t.Fatalf("expected chain pattern in log, got: %s", logBuf.String())
+	}
+}
+
+func TestScanHTTPInput_A2AChainNonMatchAllows(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	opts := MCPProxyOpts{
+		Scanner:      sc,
+		InputCfg:     &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock},
+		ChainMatcher: testA2AChainMatcher(),
+	}
+
+	blocked := scanHTTPInput(testA2ARequest(1, testA2AMethod), io.Discard, "a2a-session", "a2a-session", opts)
+	if blocked != nil {
+		t.Fatalf("single A2A chain element should not block: %+v", blocked)
+	}
+}
+
+func TestScanHTTPInput_A2ADoWBlockLeavesNoChainTrace(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	opts := MCPProxyOpts{
+		Scanner:      sc,
+		InputCfg:     &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock},
+		ChainMatcher: testA2AChainMatcher(),
+		DoWCheck: func(identity, _ string) (bool, string, string, string) {
+			if identity == a2aBaselineIdentity(testA2AMethod) {
+				return false, config.ActionBlock, testA2ADoWReason, testA2ADoWBudgetType
+			}
+			return true, "", "", ""
+		},
+	}
+
+	first := scanHTTPInput(testA2ARequest(1, testA2AMethod), io.Discard, "a2a-session", "a2a-session", opts)
+	if first == nil || !strings.Contains(first.ErrorMessage, testA2ADoWReason) {
+		t.Fatalf("first A2A request should DoW-block, got: %+v", first)
+	}
+	second := scanHTTPInput(testA2ARequest(2, testA2ASecondMethod), io.Discard, "a2a-session", "a2a-session", opts)
+	if second != nil {
+		t.Fatalf("DoW-blocked A2A request left a chain trace; second block: %+v", second)
+	}
+}
+
+func TestForwardScannedInput_A2ADoWBlock(t *testing.T) {
+	sc := testInputScanner(t)
+	opts := testOpts(sc)
+	opts.InputCfg = &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock}
+	opts.DoWCheck = func(identity, _ string) (bool, string, string, string) {
+		if identity == a2aBaselineIdentity(testA2AMethod) {
+			return false, config.ActionBlock, testA2ADoWReason, testA2ADoWBudgetType
+		}
+		return true, "", "", ""
+	}
+
+	var serverIn bytes.Buffer
+	var logW bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 10)
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(string(testA2ARequest(1, testA2AMethod))+"\n")),
+		transport.NewStdioWriter(&serverIn),
+		&logW,
+		config.ActionWarn,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		nil,
+		opts,
+	)
+
+	if strings.Contains(serverIn.String(), testA2AMethod) {
+		t.Fatal("expected A2A DoW-blocked request not to be forwarded")
+	}
+	var gotBlock bool
+	for br := range blockedCh {
+		if strings.Contains(br.ErrorMessage, testA2ADoWReason) {
+			gotBlock = true
+		}
+	}
+	if !gotBlock {
+		t.Fatalf("expected A2A DoW block; log=%s", logW.String())
+	}
+}
+
+func TestForwardScannedInput_A2ADoWAllowDoesNotFalseBlock(t *testing.T) {
+	sc := testInputScanner(t)
+	opts := testOpts(sc)
+	opts.InputCfg = &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock}
+	opts.DoWCheck = func(identity, _ string) (bool, string, string, string) {
+		if identity != a2aBaselineIdentity(testA2AMethod) {
+			t.Fatalf("DoW identity = %q, want %q", identity, a2aBaselineIdentity(testA2AMethod))
+		}
+		return true, "", "", ""
+	}
+
+	var serverIn bytes.Buffer
+	var logW bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 10)
+	req := string(testA2ARequest(1, testA2AMethod)) + "\n"
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(req)),
+		transport.NewStdioWriter(&serverIn),
+		&logW,
+		config.ActionWarn,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		nil,
+		opts,
+	)
+
+	for br := range blockedCh {
+		t.Fatalf("A2A DoW allow should not block: %+v; log=%s", br, logW.String())
+	}
+	if !strings.Contains(serverIn.String(), testA2AMethod) {
+		t.Fatalf("expected A2A request to forward, got: %s", serverIn.String())
+	}
+}
+
+func TestForwardScannedInput_A2AChainBlock(t *testing.T) {
+	sc := testInputScanner(t)
+	opts := testOpts(sc)
+	opts.InputCfg = &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock}
+	opts.ChainMatcher = testA2AChainMatcher()
+
+	input := string(testA2ARequest(1, testA2AMethod)) + "\n" +
+		string(testA2ARequest(2, testA2ASecondMethod)) + "\n"
+	var serverIn bytes.Buffer
+	var logW bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 10)
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(input)),
+		transport.NewStdioWriter(&serverIn),
+		&logW,
+		config.ActionWarn,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		nil,
+		opts,
+	)
+
+	var gotChainBlock bool
+	for br := range blockedCh {
+		if strings.Contains(br.ErrorMessage, testA2AChainPattern) {
+			gotChainBlock = true
+		}
+	}
+	if !gotChainBlock {
+		t.Fatalf("expected A2A chain block; log=%s", logW.String())
+	}
+}
+
+func TestForwardScannedInput_A2AChainNonMatchAllows(t *testing.T) {
+	sc := testInputScanner(t)
+	opts := testOpts(sc)
+	opts.InputCfg = &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock}
+	opts.ChainMatcher = testA2AChainMatcher()
+
+	var serverIn bytes.Buffer
+	var logW bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 10)
+	req := string(testA2ARequest(1, testA2AMethod)) + "\n"
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(req)),
+		transport.NewStdioWriter(&serverIn),
+		&logW,
+		config.ActionWarn,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		nil,
+		opts,
+	)
+
+	for br := range blockedCh {
+		t.Fatalf("single A2A chain element should not block: %+v; log=%s", br, logW.String())
+	}
+	if !strings.Contains(serverIn.String(), testA2AMethod) {
+		t.Fatalf("expected single A2A request to forward, got: %s", serverIn.String())
+	}
+}
+
+func TestForwardScannedInput_A2ABodyURLFieldBlocks(t *testing.T) {
+	sc := testInputScanner(t)
+	opts := testOpts(sc)
+	opts.InputCfg = &InputScanConfig{Enabled: true, Action: config.ActionWarn, OnParseError: config.ActionBlock}
+	a2aCfg := enabledA2ACfg()
+	a2aCfg.Action = config.ActionBlock
+	opts.A2ACfg = a2aCfg
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"` + testA2AMethod + `","params":{"message":{"parts":[{"kind":"file","url":"http://169.254.169.254/latest/meta-data/"}]}}}`
+	var serverIn bytes.Buffer
+	var logW bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 10)
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(body+"\n")),
+		transport.NewStdioWriter(&serverIn),
+		&logW,
+		config.ActionWarn,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		nil,
+		opts,
+	)
+
+	if serverIn.Len() != 0 {
+		t.Fatalf("expected stdio A2A body block before forward, got: %s", serverIn.String())
+	}
+	var gotA2ABlock bool
+	for br := range blockedCh {
+		if strings.Contains(br.ErrorMessage, "A2A input scanning") {
+			gotA2ABlock = true
+		}
+	}
+	if !gotA2ABlock {
+		t.Fatalf("expected stdio A2A body block; log=%s", logW.String())
+	}
+	if !strings.Contains(logW.String(), "a2a input blocked") {
+		t.Fatalf("expected A2A body gate log, got: %s", logW.String())
+	}
+}

--- a/internal/mcp/cross_agent_test.go
+++ b/internal/mcp/cross_agent_test.go
@@ -171,6 +171,34 @@ func TestEvaluateMCPInputGates_CrossAgentA2ARequest(t *testing.T) {
 	}
 }
 
+func TestEvaluateMCPInputGates_CrossAgentA2ARecordedWhenDoWBlocksWithoutA2AScanning(t *testing.T) {
+	t.Parallel()
+	sc := testScannerWithAction(t, config.ActionWarn)
+	cfg := config.Defaults()
+	rec := &taintRecorder{}
+	contaminateRecorder(rec, true)
+	dow := func(_, _ string) (bool, string, string, string) {
+		return false, config.ActionBlock, "dow: a2a budget exceeded", "calls"
+	}
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"parts":[{"text":"hello peer"}]}}}`)
+	frame := ParseMCPFrame(msg)
+	eval := EvaluateMCPInputGates(context.Background(), frame, msg, "sess-1",
+		MCPProxyOpts{Scanner: sc, Rec: rec, TaintCfg: &cfg.Taint, DoWCheck: dow},
+		config.ActionWarn, config.ActionWarn, true)
+
+	if eval.BlockingGate != blockingGateDoW {
+		t.Fatalf("expected DoW block, got %q", eval.BlockingGate)
+	}
+	srcs := crossAgentSources(rec)
+	if len(srcs) != 1 || srcs[0].MatchReason != "cross_agent_a2a_request" {
+		t.Fatalf("A2A DoW block without A2A scanning must still record cross-agent source, got %+v", srcs)
+	}
+	if !eval.CrossAgentEscalate {
+		t.Fatal("hostile A2A propagation must request escalation before DoW short-circuits")
+	}
+}
+
 // stdio parity: the stdio gate records cross-agent taint on a tool call.
 func TestEvaluateMCPInputGatesStdio_CrossAgentToolCall(t *testing.T) {
 	t.Parallel()
@@ -188,6 +216,34 @@ func TestEvaluateMCPInputGatesStdio_CrossAgentToolCall(t *testing.T) {
 	srcs := crossAgentSources(rec)
 	if len(srcs) != 1 || srcs[0].MatchReason != "cross_agent_mcp_tool_call" {
 		t.Fatalf("stdio cross-agent source = %+v", srcs)
+	}
+}
+
+func TestEvaluateMCPInputGatesStdio_CrossAgentA2ARecordedWhenDoWBlocksWithoutA2AScanning(t *testing.T) {
+	t.Parallel()
+	sc := testScannerWithAction(t, config.ActionWarn)
+	cfg := config.Defaults()
+	rec := &taintRecorder{}
+	contaminateRecorder(rec, true)
+	dow := func(_, _ string) (bool, string, string, string) {
+		return false, config.ActionBlock, "dow: a2a budget exceeded", "calls"
+	}
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"parts":[{"text":"hello peer"}]}}}`)
+	frame := ParseMCPFrame(msg)
+	eval := EvaluateMCPInputGatesStdio(context.Background(), frame, msg, msg, nil,
+		MCPProxyOpts{Scanner: sc, Rec: rec, TaintCfg: &cfg.Taint, DoWCheck: dow},
+		config.ActionWarn, config.ActionBlock)
+
+	if eval.BlockingGate != blockingGateDoW {
+		t.Fatalf("expected DoW block, got %q", eval.BlockingGate)
+	}
+	srcs := crossAgentSources(rec)
+	if len(srcs) != 1 || srcs[0].MatchReason != "cross_agent_a2a_request" {
+		t.Fatalf("stdio A2A DoW block without A2A scanning must still record cross-agent source, got %+v", srcs)
+	}
+	if !eval.CrossAgentEscalate {
+		t.Fatal("hostile stdio A2A propagation must request escalation before DoW short-circuits")
 	}
 }
 

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -413,6 +413,14 @@ func ForwardScannedInput(
 		if verdict.Method == methodToolsCall {
 			toolCallName = frame.ToolCallName
 		}
+		enforcementTarget := toolCallName
+		if enforcementTarget == "" {
+			enforcementTarget = eval.EnforcementIdentity
+		}
+		enforcementKind := "tools/call"
+		if toolCallName == "" && enforcementTarget != "" {
+			enforcementKind = "mcp method"
+		}
 		baselineIdentity := mcpFrameBaselineIdentity(frame)
 		captureActionClass := captureMCPFrameActionClass(toolCallName, verdict.Method, string(frame.Args))
 
@@ -465,7 +473,7 @@ func ForwardScannedInput(
 			_, _ = fmt.Fprintf(logW, "pipelock: chain detected: %s (severity=%s, action=%s)\n",
 				eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction)
 			if auditLogger != nil {
-				auditLogger.LogChainDetection(eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction, toolCallName, "default")
+				auditLogger.LogChainDetection(eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction, enforcementTarget, "default")
 			}
 			obs.ObserveToolPolicyVerdict(context.Background(), &capture.ToolPolicyRecord{
 				Subsurface:        "chain_detection",
@@ -476,8 +484,8 @@ func ForwardScannedInput(
 				Profile:           opts.captureProfile(),
 				ActionClass:       captureActionClass,
 				Request: capture.CaptureRequest{
-					ToolName:  toolCallName,
-					MCPMethod: methodToolsCall,
+					ToolName:  enforcementTarget,
+					MCPMethod: verdict.Method,
 					RPCID:     captureRPCID(verdict.ID),
 				},
 				RawFindings: []capture.Finding{{
@@ -584,8 +592,8 @@ func ForwardScannedInput(
 		// reuse it verbatim as the BlockedRequest.LogMessage.
 		var dowLogMsg string
 		if !eval.DoWAllowed && eval.DoWAction != "" {
-			dowLogMsg = fmt.Sprintf("pipelock: input line %d: tools/call %q DoW %s: %s (%s)",
-				lineNum, toolCallName, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
+			dowLogMsg = fmt.Sprintf("pipelock: input line %d: %s %q DoW %s: %s (%s)",
+				lineNum, enforcementKind, enforcementTarget, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
 			_, _ = fmt.Fprintln(logW, dowLogMsg)
 		}
 
@@ -594,9 +602,27 @@ func ForwardScannedInput(
 		// The response shape (JSON-RPC error code, LogMessage) stays
 		// here because it is transport-specific.
 		switch eval.BlockingGate {
+		case blockingGateA2ABody:
+			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: a2a input blocked (%s)\n", lineNum, eval.A2AResult.Reason)
+			switch {
+			case eval.A2AResult.IsAdaptiveNeutral():
+			case eval.A2AResult.IsConfigMismatch():
+				recordAdaptiveSignal(session.SignalNearMiss)
+			default:
+				recordAdaptiveSignal(session.SignalBlock)
+			}
+			blockedCh <- BlockedRequest{
+				ID:             verdict.ID,
+				IsNotification: isRPCNotification(verdict.ID),
+				LogMessage:     fmt.Sprintf("pipelock: input line %d: blocked (a2a input scanning)", lineNum),
+				ErrorCode:      -32001,
+				ErrorMessage:   "pipelock: request blocked by A2A input scanning",
+			}
+			_ = emitToolReceipt(config.ActionBlock)
+			continue
 		case blockingGateDoW:
 			if auditLogger != nil {
-				auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", toolCallName), "denial_of_wallet", eval.DoWReason)
+				auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), "denial_of_wallet", eval.DoWReason)
 			}
 			if m != nil {
 				m.RecordBlocked("mcp", "denial_of_wallet", 0, "")
@@ -665,13 +691,20 @@ func ForwardScannedInput(
 		}
 
 		// Non-blocking warn-level side effects from gates that did not
-		// short-circuit. DoW warn: audit anomaly + near-miss signal
-		// (the diagnostic log already ran above). Taint approved:
-		// audit the pre-approval decision so the operator sees the
-		// approval happened.
+		// short-circuit. A2A warn logs and records a near-miss unless the
+		// finding is adaptive-neutral. DoW warn: audit anomaly + near-miss
+		// signal (the diagnostic log already ran above). Taint approved:
+		// audit the pre-approval decision so the operator sees the approval
+		// happened.
+		if !eval.A2AResult.Clean && eval.A2AEffectiveAction != "" && eval.A2AEffectiveAction != config.ActionBlock {
+			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: a2a input warning (%s)\n", lineNum, eval.A2AResult.Reason)
+			if !eval.A2AResult.IsAdaptiveNeutral() {
+				recordAdaptiveSignal(session.SignalNearMiss)
+			}
+		}
 		if !eval.DoWAllowed && eval.DoWAction != "" {
 			if auditLogger != nil {
-				auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", toolCallName), "denial_of_wallet", eval.DoWReason, 0)
+				auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), "denial_of_wallet", eval.DoWReason, 0)
 			}
 			recordAdaptiveSignal(session.SignalNearMiss)
 		}

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -330,6 +330,14 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		toolName = frame.ToolCallName
 	}
+	enforcementTarget := toolName
+	if enforcementTarget == "" {
+		enforcementTarget = eval.EnforcementIdentity
+	}
+	enforcementKind := "tools/call"
+	if toolName == "" && enforcementTarget != "" {
+		enforcementKind = "mcp method"
+	}
 	captureActionClass := captureMCPFrameActionClass(toolName, verdict.Method, string(frame.Args))
 	logTaintDecision := func() {
 		if auditLogger == nil {
@@ -382,10 +390,10 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		return result
 	case blockingGateDoW:
-		_, _ = fmt.Fprintf(logW, "pipelock: tools/call %q DoW %s: %s (%s)\n",
-			toolName, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
+		_, _ = fmt.Fprintf(logW, "pipelock: %s %q DoW %s: %s (%s)\n",
+			enforcementKind, enforcementTarget, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
 		if auditLogger != nil {
-			auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", toolName), "denial_of_wallet", eval.DoWReason)
+			auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), "denial_of_wallet", eval.DoWReason)
 		}
 		if m != nil {
 			m.RecordBlocked("mcp", "denial_of_wallet", 0, "")
@@ -398,7 +406,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		_, _ = fmt.Fprintf(logW, "pipelock: chain detected: %s (severity=%s, action=%s)\n",
 			eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction)
 		if auditLogger != nil {
-			auditLogger.LogChainDetection(eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction, toolName, auditSessionKey)
+			auditLogger.LogChainDetection(eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction, enforcementTarget, auditSessionKey)
 		}
 		recordAdaptiveSignal(session.SignalBlock)
 		receiptVerdict = config.ActionBlock
@@ -448,10 +456,10 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 	}
 	if eval.DoWAction != "" && !eval.DoWAllowed && eval.DoWAction != config.ActionBlock {
-		_, _ = fmt.Fprintf(logW, "pipelock: tools/call %q DoW %s: %s (%s)\n",
-			toolName, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
+		_, _ = fmt.Fprintf(logW, "pipelock: %s %q DoW %s: %s (%s)\n",
+			enforcementKind, enforcementTarget, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
 		if auditLogger != nil {
-			auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", toolName), "denial_of_wallet", eval.DoWReason, 0)
+			auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), "denial_of_wallet", eval.DoWReason, 0)
 		}
 		recordAdaptiveSignal(session.SignalNearMiss)
 	}
@@ -461,7 +469,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		_, _ = fmt.Fprintf(logW, "pipelock: chain detected: %s (severity=%s, action=%s)\n",
 			eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction)
 		if auditLogger != nil {
-			auditLogger.LogChainDetection(eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction, toolName, auditSessionKey)
+			auditLogger.LogChainDetection(eval.ChainPatternName, eval.ChainSeverity, eval.ChainAction, enforcementTarget, auditSessionKey)
 		}
 	}
 

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -25,7 +25,8 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/session"
 )
 
-// DoWCheckFunc checks a tool call against denial-of-wallet budgets.
+// DoWCheckFunc checks an MCP action identity against denial-of-wallet budgets.
+// The identity is a raw tool name for tools/call and "a2a:<Method>" for A2A.
 // Returns (allowed, action, reason, budgetType). Action is "block" or "warn".
 // When action is "warn", the caller logs but does not block the request.
 type DoWCheckFunc func(toolName, argsJSON string) (allowed bool, action, reason, budgetType string)

--- a/internal/mcp/pipeline_gates.go
+++ b/internal/mcp/pipeline_gates.go
@@ -92,8 +92,14 @@ type MCPInputEvaluation struct {
 	// blocked.
 	A2AEffectiveAction string
 
+	// EnforcementIdentity is the per-action key used by DoW and
+	// chain detection: raw tool name for tools/call, or the
+	// namespaced A2A method identity for A2A methods.
+	EnforcementIdentity string
+
 	// DoW fields are populated when DoWCheck is non-nil and the
-	// message is a tools/call with a non-empty ToolCallName.
+	// message is a tools/call with a non-empty ToolCallName or an
+	// A2A method with a baseline identity.
 	DoWAllowed    bool
 	DoWAction     string
 	DoWReason     string
@@ -103,7 +109,8 @@ type MCPInputEvaluation struct {
 	PolicyVerdict policy.Verdict
 
 	// Chain fields are populated when chainMatcher is non-nil and
-	// the message is a tools/call with a non-empty ToolCallName.
+	// the message is a tools/call with a non-empty ToolCallName or
+	// an A2A method with a baseline identity.
 	// Note that chainMatcher.Record mutates session chain state on
 	// every call; the gate ordering after DoW preserves the
 	// pre-refactor contract that DoW-block messages do not leave a
@@ -158,10 +165,27 @@ type MCPInputEvaluation struct {
 	CrossAgentEscalate bool
 }
 
+func mcpFrameEnforcementIdentity(frame MCPFrame, method string) string {
+	if frame.IsToolsCall() {
+		return strings.TrimSpace(frame.ToolCallName)
+	}
+	if method == "" {
+		method = frame.Method
+	}
+	return a2aBaselineIdentity(method)
+}
+
+func mcpFrameDoWArgs(frame MCPFrame, msg []byte) string {
+	if frame.IsToolsCall() {
+		return string(frame.Args)
+	}
+	return string(msg)
+}
+
 // EvaluateMCPInputGates runs the configured inbound gates for one
 // MCP request and returns their aggregated verdict. Each gate is
 // nil-safe: the helper skips gates whose config is nil or whose
-// preconditions are not met (e.g., DoW is tools/call-only).
+// preconditions are not met.
 //
 // Gate execution order (semantic, not cosmetic). Sequence is fixed by
 // the code below; see per-gate comments for placement rationale:
@@ -170,12 +194,13 @@ type MCPInputEvaluation struct {
 //     ContentVerdict.ID / Method used by later short-circuit paths.
 //   - A2A body scan when a2aCfg is enabled and the method matches
 //     IsA2AMethod. A block verdict short-circuits the remaining
-//     tools/call-scoped gates.
-//   - denial-of-wallet check for tools/call with a non-empty tool name.
+//     enforcement gates.
+//   - denial-of-wallet check for tools/call with a non-empty tool name
+//     or A2A method with a baseline identity.
 //   - policy check against the full message bytes.
-//   - chain detection for tools/call. Mutates chain-matcher session
-//     state; running after DoW preserves the contract that DoW-block
-//     messages do not leave a chain trace.
+//   - chain detection for tools/call and A2A method identities.
+//     Mutates chain-matcher session state; running after DoW preserves
+//     the contract that DoW-block messages do not leave a chain trace.
 //   - parse-error short-circuit from ContentVerdict.Error. Runs after
 //     the stateful gates above so every configured gate contributes
 //     its audit signals before the block verdict is emitted.
@@ -226,22 +251,23 @@ func EvaluateMCPInputGates(
 		eval.ContentVerdict.Error = frame.ParseErr.Error()
 	}
 
-	// A2A body scan. Runs before the tools/call-scoped
-	// gates so an A2A body block short-circuits them.
-	if a2aCfg != nil && a2aCfg.Enabled {
-		method := eval.ContentVerdict.Method
-		if method == "" {
-			method = frame.Method
-			if eval.ContentVerdict.ID == nil {
-				eval.ContentVerdict.ID = frame.ID
-			}
+	method := eval.ContentVerdict.Method
+	if method == "" {
+		method = frame.Method
+		if eval.ContentVerdict.ID == nil {
+			eval.ContentVerdict.ID = frame.ID
 		}
-		if IsA2AMethod(method) {
-			// Cross-agent contamination: a contaminated session emitting an
-			// A2A request to a peer agent propagates taint across the boundary.
-			// Recorded before the A2A content scan so the evidence is captured
-			// regardless of the content verdict (the emit happened either way).
-			observeCrossAgentEmit(&eval, opts, session.CrossAgentBoundaryA2ARequest)
+	}
+	if IsA2AMethod(method) {
+		// Cross-agent contamination: a contaminated session emitting an
+		// A2A request to a peer agent propagates taint across the boundary.
+		// Recorded before the A2A content scan and enforcement gates so the
+		// evidence is captured regardless of which later gate short-circuits.
+		observeCrossAgentEmit(&eval, opts, session.CrossAgentBoundaryA2ARequest)
+
+		// A2A body scan. Runs before the enforcement gates so an
+		// A2A body block short-circuits them.
+		if a2aCfg != nil && a2aCfg.Enabled {
 			eval.A2AResult = ScanA2ARequestBody(ctx, msg, sc, a2aCfg)
 			if !eval.A2AResult.Clean {
 				action := eval.A2AResult.Action
@@ -267,9 +293,13 @@ func EvaluateMCPInputGates(
 		observeCrossAgentEmit(&eval, opts, session.CrossAgentBoundaryMCPToolCall)
 	}
 
-	// DoW. Only for tools/call with a tool name.
-	if opts.DoWCheck != nil && frame.IsToolsCall() && frame.ToolCallName != "" {
-		allowed, action, reason, budgetType := opts.DoWCheck(frame.ToolCallName, string(frame.Args))
+	enforcementIdentity := mcpFrameEnforcementIdentity(frame, eval.ContentVerdict.Method)
+	eval.EnforcementIdentity = enforcementIdentity
+
+	// DoW. Applies to tools/call by tool name and to A2A methods by the
+	// namespaced method identity.
+	if opts.DoWCheck != nil && enforcementIdentity != "" {
+		allowed, action, reason, budgetType := opts.DoWCheck(enforcementIdentity, mcpFrameDoWArgs(frame, msg))
 		eval.DoWAllowed = allowed
 		eval.DoWAction = action
 		eval.DoWReason = reason
@@ -305,8 +335,8 @@ func EvaluateMCPInputGates(
 	// chain. Mutates chain-matcher session state; ordering
 	// after DoW preserves the pre-refactor contract that DoW-block
 	// messages do not leave a chain trace.
-	if chainMatcher != nil && frame.IsToolsCall() && frame.ToolCallName != "" {
-		cv := chainMatcher.Record(sessionKey, frame.ToolCallName, string(msg))
+	if chainMatcher != nil && enforcementIdentity != "" {
+		cv := chainMatcher.Record(sessionKey, enforcementIdentity, string(msg))
 		if cv.Matched {
 			eval.ChainMatched = true
 			eval.ChainPatternName = cv.PatternName
@@ -371,8 +401,8 @@ func EvaluateMCPInputGates(
 //
 //   - policy runs before DoW. HTTP runs policy after DoW; stdio's
 //     pre-refactor order placed the policy check ahead of the
-//     tools/call-scoped gates, so the policy verdict is materialized
-//     before any tools/call-scoped gate can short-circuit.
+//     enforcement gates, so the policy verdict is materialized
+//     before DoW or chain can short-circuit.
 //   - session binding is two-phase, wrapping DoW. The batch pre-check
 //     fires before DoW; the tool-name check fires after. Batches are
 //     rejected earlier in the caller, so the pre-check is
@@ -382,15 +412,13 @@ func EvaluateMCPInputGates(
 //     has no frozen-tool gate; it lives only on the stdio transport
 //     to enforce airlock-hard-tier tool snapshots.
 //
-// Unlike HTTP, stdio does not have an A2A body gate; A2A methods flow
-// through a separate path. The helper omits the a2a_body gate
-// entirely.
-//
 // Gate execution order (semantic, not cosmetic). Sequence is fixed
 // by the code below; see per-gate comments for placement rationale:
 //
 //   - content scan via ScanRequest. Always runs. Establishes
 //     ContentVerdict.ID / Method used by later short-circuit paths.
+//   - A2A body scan when a2aCfg is enabled and the method matches
+//     IsA2AMethod. A block verdict short-circuits the remaining gates.
 //   - policy check. Populates PolicyVerdict without short-circuit;
 //     the caller folds matched policy into the effective action.
 //   - session binding batch pre-check. Populates BindingAction /
@@ -398,8 +426,9 @@ func EvaluateMCPInputGates(
 //     active. No short-circuit -- batches are rejected earlier in
 //     the caller path.
 //   - tool name extraction from the frame for the tools/call gates.
-//   - denial-of-wallet check for tools/call with a non-empty tool
-//     name. Blocks short-circuit; warns populate DoWAction.
+//   - denial-of-wallet check for tools/call with a non-empty tool name
+//     or A2A method with a baseline identity. Blocks short-circuit;
+//     warns populate DoWAction.
 //   - session binding tool check for tools/call. Overrides the
 //     batch pre-check when it fires (missing tool name, no baseline,
 //     unknown tool). No short-circuit -- the caller folds
@@ -407,9 +436,9 @@ func EvaluateMCPInputGates(
 //   - frozen tool enforcement. Short-circuits on a block verdict
 //     when the session has a frozen snapshot and the tool is either
 //     unparseable or not in the snapshot.
-//   - chain detection for tools/call. Mutates chain-matcher session
-//     state; the 1:1 stdio architecture uses the literal "default"
-//     session key. Matched patterns populate chain fields;
+//   - chain detection for tools/call and A2A method identities. Mutates
+//     chain-matcher session state; the 1:1 stdio architecture uses the
+//     literal "default" session key. Matched patterns populate chain fields;
 //     Block-action matches short-circuit.
 //   - parse-error short-circuit from ContentVerdict.Error. Runs
 //     after the stateful gates so audit signals are recorded before
@@ -442,6 +471,7 @@ func EvaluateMCPInputGatesStdio(
 	sc := opts.scanner()
 	policyCfg := opts.policyCfg()
 	chainMatcher := opts.chainMatcher()
+	a2aCfg := opts.a2aCfg()
 
 	// content scan. Always runs on stdio (inputCfg is not
 	// consulted at this layer -- the caller gates enablement via
@@ -452,6 +482,32 @@ func EvaluateMCPInputGatesStdio(
 		eval.ContentVerdict.Method = frame.Method
 		eval.ContentVerdict.Clean = false
 		eval.ContentVerdict.Error = frame.ParseErr.Error()
+	}
+
+	method := eval.ContentVerdict.Method
+	if method == "" {
+		method = frame.Method
+		if eval.ContentVerdict.ID == nil {
+			eval.ContentVerdict.ID = frame.ID
+		}
+	}
+	if IsA2AMethod(method) {
+		observeCrossAgentEmit(&eval, opts, session.CrossAgentBoundaryA2ARequest)
+
+		if a2aCfg != nil && a2aCfg.Enabled {
+			eval.A2AResult = ScanA2ARequestBody(ctx, msg, sc, a2aCfg)
+			if !eval.A2AResult.Clean {
+				action := eval.A2AResult.Action
+				if action == "" {
+					action = a2aCfg.Action
+				}
+				eval.A2AEffectiveAction = action
+				if action == config.ActionBlock {
+					eval.BlockingGate = blockingGateA2ABody
+					return eval
+				}
+			}
+		}
 	}
 
 	// policy. No short-circuit; policy participates in the
@@ -474,6 +530,8 @@ func EvaluateMCPInputGatesStdio(
 	if eval.ContentVerdict.Method == methodToolsCall {
 		toolCallName = frame.ToolCallName
 	}
+	enforcementIdentity := mcpFrameEnforcementIdentity(frame, eval.ContentVerdict.Method)
+	eval.EnforcementIdentity = enforcementIdentity
 
 	// Cross-agent contamination for tools/call. Recorded BEFORE the
 	// short-circuiting DoW/binding/frozen/chain/taint gates so the cross_agent
@@ -483,9 +541,10 @@ func EvaluateMCPInputGatesStdio(
 		observeCrossAgentEmit(&eval, opts, session.CrossAgentBoundaryMCPToolCall)
 	}
 
-	// DoW. Only for tools/call with a tool name.
-	if opts.DoWCheck != nil && eval.ContentVerdict.Method == methodToolsCall && toolCallName != "" {
-		allowed, action, reason, budgetType := opts.DoWCheck(toolCallName, string(frame.Args))
+	// DoW. Applies to tools/call by tool name and to A2A methods by the
+	// namespaced method identity.
+	if opts.DoWCheck != nil && enforcementIdentity != "" {
+		allowed, action, reason, budgetType := opts.DoWCheck(enforcementIdentity, mcpFrameDoWArgs(frame, msg))
 		eval.DoWAllowed = allowed
 		eval.DoWAction = action
 		eval.DoWReason = reason
@@ -530,8 +589,8 @@ func EvaluateMCPInputGatesStdio(
 
 	// chain detection. Stdio is 1:1 session-per-process;
 	// the literal "default" session key is correct.
-	if chainMatcher != nil && toolCallName != "" {
-		cv := chainMatcher.Record("default", toolCallName, string(msg))
+	if chainMatcher != nil && enforcementIdentity != "" {
+		cv := chainMatcher.Record("default", enforcementIdentity, string(msg))
 		if cv.Matched {
 			eval.ChainMatched = true
 			eval.ChainPatternName = cv.PatternName


### PR DESCRIPTION
## What changed

A2A methods (such as SendMessage and tasks/send) were exempt from denial-of-wallet cost control and tool-chain sequence detection, because those gates keyed only on tools/call tool names. An agent could drive unbounded A2A calls, or run a malicious A2A call sequence that the equivalent tool calls would have blocked.

This introduces a shared enforcement identity (the raw tool name for tools/call, a namespaced `a2a:<method>` identity for A2A methods) and applies denial-of-wallet and tool-chain detection to both on the HTTP and stdio evaluation paths, preserving the existing ordering contract that a denied call leaves no chain trace.

It also adds A2A request-body scanning on stdio for parity with HTTP, and records the cross-agent contamination signal before the short-circuiting gates even when A2A body scanning is disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded input enforcement to cover A2A actions alongside standard tool calls.
  * Added support for blocking and warning on A2A body metadata URL scans.
  * Improved audit and log attribution so enforcement events are reported with clearer action identity.

* **Bug Fixes**
  * Fixed false negatives in chain and wallet-budget enforcement for A2A traffic.
  * Preserved cross-agent escalation records even when later checks block a request.
  * Prevented blocked A2A requests from being forwarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->