### PR TITLE
ci: restrict PR review trigger to owner

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -15,6 +15,7 @@ jobs:
     # trigger needs a permission gate beyond the comment body check.
     if: >-
       github.event.comment.user.login == 'luckyPipewrench' &&
+      github.event.comment.author_association == 'OWNER' &&
       github.event.issue.pull_request &&
       (github.event.comment.body == '/review' ||
        github.event.comment.body == '/review deep' ||

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -10,14 +10,11 @@ permissions:
 
 jobs:
   review:
-    # Restrict to repo members. Some /review modes execute code from the
-    # PR's merge ref in this workflow's secret scope, so the trigger needs
-    # a permission gate beyond the comment body check (the body is
-    # user-controlled, author_association is not).
+    # Restrict to the repository owner account. Some /review modes execute
+    # code from the PR's merge ref in this workflow's secret scope, so the
+    # trigger needs a permission gate beyond the comment body check.
     if: >-
-      (github.event.comment.author_association == 'OWNER' ||
-       github.event.comment.author_association == 'MEMBER' ||
-       github.event.comment.author_association == 'COLLABORATOR') &&
+      github.event.comment.user.login == 'luckyPipewrench' &&
       github.event.issue.pull_request &&
       (github.event.comment.body == '/review' ||
        github.event.comment.body == '/review deep' ||
@@ -67,4 +64,6 @@ jobs:
           REVIEW_MODE: ${{ steps.mode.outputs.mode }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
+          PR_REVIEW_MODEL_FAST: gpt-5.4-mini
+          PR_REVIEW_MODEL_DEEP: gpt-5.5
         run: python scripts/pr-review.py

--- a/scripts/pr-review.py
+++ b/scripts/pr-review.py
@@ -20,7 +20,7 @@ LLM configuration (one of, not needed for /review stats):
 
 Model selection:
   PR_REVIEW_MODEL_FAST  - Model for default/tests/docs (default: gpt-5.4-mini)
-  PR_REVIEW_MODEL_DEEP  - Model for /review deep (default: gpt-5.4)
+  PR_REVIEW_MODEL_DEEP  - Model for /review deep (default: gpt-5.5)
 
 The PR_REVIEW_MODEL_FAST env var keeps its name for backwards compatibility
 with any existing repo-secrets overrides; the user-facing /review fast
@@ -39,7 +39,7 @@ import requests
 
 MAX_DIFF_CHARS = 100_000
 DEFAULT_MODEL_FAST = "gpt-5.4-mini"
-DEFAULT_MODEL_DEEP = "gpt-5.4"
+DEFAULT_MODEL_DEEP = "gpt-5.5"
 
 PROMPT_SECURITY = """You are reviewing a pull request for Pipelock, an AI agent firewall and security boundary product. Pipelock is a network proxy that sits between AI agents and the internet, scanning HTTP/WebSocket/MCP traffic for secret exfiltration, prompt injection, SSRF, and tool poisoning.
 


### PR DESCRIPTION
## Summary
- restrict `/review` workflow triggers to the repository owner account
- set `/review deep` to `gpt-5.5`
- keep default, tests, and docs review modes on `gpt-5.4-mini`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable model selection for fast and deep PR review modes via environment variables.

* **Bug Fixes**
  * Tightened PR review access control so only the intended account can trigger review mode actions.
  * Updated the default model used for deep PR review mode to the newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->