### PR TITLE
fix(mcp): fail closed without envelope leak on empty action id under require-receipts; harden A2A method match + drift doc

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -922,6 +922,15 @@ mcp_tool_scanning:
 | `action` | `"warn"` | warn or block |
 | `detect_drift` | `false` | Alert on tool description changes |
 
+When `detect_drift` is enabled, Pipelock hashes the canonical full tool object
+from `tools/list`, excluding only Pipelock's own provenance attestation in
+`_meta["com.pipelock/provenance"]`. Other `_meta` fields are part of the drift
+hash. If an MCP server publishes volatile values such as nonces, timestamps,
+request IDs, or per-list counters in the tool object, that tool will drift on
+every `tools/list`. Keep `tools/list` definitions stable: move changing values
+to tool call arguments, tool results, or an out-of-band capability endpoint, and
+leave `_meta` for stable metadata unless drift on that value is intentional.
+
 ## MCP Tool Policy
 
 Pre-execution rules that block or warn before tool calls reach the MCP server. Ships with 17 built-in rules covering destructive operations, credential access, network exfiltration, persistence mechanisms, and encoded command execution.

--- a/internal/mcp/a2a.go
+++ b/internal/mcp/a2a.go
@@ -301,9 +301,17 @@ var a2aMethods = map[string]bool{
 	"agent/getAuthenticatedExtendedCard":  true,
 }
 
+var normalizedA2AMethods = func() map[string]bool {
+	methods := make(map[string]bool, len(a2aMethods))
+	for method := range a2aMethods {
+		methods[strings.ToLower(method)] = true
+	}
+	return methods
+}()
+
 // IsA2AMethod returns true if the JSON-RPC method name is an A2A method.
 func IsA2AMethod(method string) bool {
-	return a2aMethods[method]
+	return a2aMethods[method] || normalizedA2AMethods[strings.ToLower(method)]
 }
 
 // a2aPathRe matches A2A REST endpoint paths after version prefix stripping.

--- a/internal/mcp/a2a_test.go
+++ b/internal/mcp/a2a_test.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -283,7 +284,10 @@ func TestIsA2AMethod(t *testing.T) {
 		{"CreateTaskPushNotificationConfig", true},
 		{"GetExtendedAgentCard", true},
 		{"DeleteTaskPushNotificationConfig", true},
+		{"MESSAGE/SEND", true},
+		{"sendmessage", true},
 		{"tools/call", false},
+		{"TOOLS/CALL", false},
 		{"tools/list", false},
 		{"initialize", false},
 		{"", false},
@@ -294,6 +298,43 @@ func TestIsA2AMethod(t *testing.T) {
 				t.Errorf("IsA2AMethod(%q) = %v, want %v", tt.method, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsA2AMethod_KnownMethodsDetectAfterCaseFold(t *testing.T) {
+	normalized := make(map[string]string, len(a2aMethods))
+	for method := range a2aMethods {
+		folded := strings.ToLower(method)
+		if previous, ok := normalized[folded]; ok && previous != method {
+			t.Fatalf("A2A methods %q and %q collide after case fold", previous, method)
+		}
+		normalized[folded] = method
+		if got := IsA2AMethod(method); !got {
+			t.Fatalf("known method %q no longer detected", method)
+		}
+		if got := IsA2AMethod(strings.ToUpper(method)); !got {
+			t.Fatalf("case-folded known method %q not detected", method)
+		}
+	}
+	for _, method := range []string{
+		"tools/call",
+		"tools/list",
+		"initialize",
+		"notifications/message",
+		"xmessage/send",
+		"message/send/extra",
+		"message/send ",
+		" message/send",
+		"sendmessage2",
+		"send-message",
+		"tasks/pushNotificationConfigset",
+	} {
+		if got := IsA2AMethod(method); got {
+			t.Fatalf("non-A2A method %q detected as A2A", method)
+		}
+		if got := IsA2AMethod(strings.ToUpper(method)); got {
+			t.Fatalf("case-folded non-A2A method %q detected as A2A", method)
+		}
 	}
 }
 

--- a/internal/mcp/pipeline_decision.go
+++ b/internal/mcp/pipeline_decision.go
@@ -30,11 +30,10 @@ var ErrReceiptRequired = errors.New("receipt required but not emitted")
 // would force this file to evolve every time the receipt schema gains
 // a field; wrapping keeps MCPDecision as pure routing.
 type MCPDecision struct {
-	// Receipt is handed straight to receipt.Emitter.Emit when the
-	// decision should produce a receipt. A zero-value Receipt (in
-	// particular, empty ActionID) is the skip signal. The emission
-	// path already no-ops on empty ActionID but surfacing the skip
-	// explicitly here keeps the decision contract legible at callers.
+	// Receipt is handed straight to receipt.Emitter.Emit when the decision should
+	// produce a receipt. A zero-value Receipt (in particular, empty ActionID) is
+	// the skip signal unless RequireReceipt is set, in which case the decision
+	// fails closed.
 	Receipt receipt.EmitOpts
 
 	// Envelope, if non-nil, is injected into InboundMsg via the
@@ -69,19 +68,18 @@ type MCPDecision struct {
 //
 // Both emitters are nil-safe:
 //
-//   - nil receiptEmitter: receipt stage is skipped silently.
+//   - nil receiptEmitter: receipt stage is skipped silently unless
+//     RequireReceipt is set, in which case the decision fails closed.
 //   - nil envelopeEmitter or nil d.Envelope: envelope stage is
 //     skipped and the input message flows through unchanged.
-//   - empty d.Receipt.ActionID: receipt stage is skipped (the
-//     downstream emitter interprets this as "no receipt for this
-//     decision"; surfacing the check here avoids an unnecessary
-//     call and keeps the contract legible at gate sites).
+//   - empty d.Receipt.ActionID: receipt stage is skipped unless
+//     RequireReceipt is set, in which case the decision fails closed.
 //
-// Receipt and envelope emission are independent: a failed receipt
-// emit does not block envelope injection and a nil envelope does
-// not block receipt emission. This matches today's scatter-gather
-// callsites where the two are inlined in sequence with no
-// cross-dependency.
+// Receipt and envelope emission are independent unless RequireReceipt turns a
+// missing or failed receipt into a blocking error: best-effort receipt failures
+// do not block envelope injection, and a nil envelope does not block receipt
+// emission. Required receipt failures return before envelope injection so the
+// caller never receives rewritten bytes for a fail-closed decision.
 //
 // Callers that want fine-grained control (e.g., conditional
 // injection based on session taint state) assemble their Envelope
@@ -96,8 +94,10 @@ func EmitMCPDecision(
 	outbound = d.InboundMsg
 
 	v1Emitted := false
-	receiptRequired := d.RequireReceipt && d.Receipt.ActionID != ""
-	if receiptRequired && receiptEmitter == nil {
+	receiptRequired := d.RequireReceipt
+	if receiptRequired && d.Receipt.ActionID == "" {
+		err = fmt.Errorf("empty action id: %w", ErrReceiptRequired)
+	} else if receiptRequired && receiptEmitter == nil {
 		err = fmt.Errorf("%w: emitter unavailable", ErrReceiptRequired)
 	} else if receiptEmitter != nil && d.Receipt.ActionID != "" {
 		err = receiptEmitter.Emit(d.Receipt)
@@ -106,8 +106,11 @@ func EmitMCPDecision(
 		// error. The two stages are independent at today's callsites
 		// and coupling them here would break parity.
 	}
-	if receiptRequired && err != nil {
+	if receiptRequired && err != nil && !errors.Is(err, ErrReceiptRequired) {
 		err = fmt.Errorf("%w: %w", ErrReceiptRequired, err)
+	}
+	if receiptRequired && err != nil {
+		return outbound, err
 	}
 	if v1Emitted && v2Emitter != nil {
 		if v2Decision, ok := mcpV2DecisionFromReceipt(d.Receipt); ok {

--- a/internal/mcp/pipeline_decision_test.go
+++ b/internal/mcp/pipeline_decision_test.go
@@ -162,6 +162,58 @@ func TestEmitMCPDecision_EmptyActionIDSkipsReceipt(t *testing.T) {
 	}
 }
 
+func TestEmitMCPDecision_RequiredEmptyActionIDFailsClosed(t *testing.T) {
+	emitter, _, dir, _ := newReceiptTestHarness(t)
+
+	_, err := EmitMCPDecision(emitter, nil, nil, MCPDecision{
+		Receipt: receipt.EmitOpts{
+			Verdict: config.ActionAllow,
+			// ActionID intentionally empty: RequireReceipt must fail closed
+			// instead of treating the missing receipt as a silent skip.
+		},
+		RequireReceipt: true,
+	})
+	if !errors.Is(err, ErrReceiptRequired) {
+		t.Fatalf("err = %v, want ErrReceiptRequired", err)
+	}
+	var log bytes.Buffer
+	logReceiptEmitFailure(&log, err, true, config.ActionAllow)
+	if !strings.Contains(log.String(), "event=block_receipt_emit_failed") || !strings.Contains(log.String(), "audit_gap=true") {
+		t.Fatalf("missing audit-gap warning for required empty ActionID: %q", log.String())
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "evidence-proxy-0.jsonl")); !os.IsNotExist(statErr) {
+		t.Errorf("evidence file created despite empty ActionID; stat err = %v", statErr)
+	}
+}
+
+func TestEmitMCPDecision_RequiredEmptyActionIDDoesNotInjectEnvelope(t *testing.T) {
+	emitter, _, _, _ := newReceiptTestHarness(t)
+	envEmitter := envelope.NewEmitter(envelope.EmitterConfig{ConfigHash: "policy-h"})
+	inbound := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fetch","arguments":{}}}`)
+
+	out, err := EmitMCPDecision(emitter, nil, envEmitter, MCPDecision{
+		Receipt: receipt.EmitOpts{
+			Verdict: config.ActionAllow,
+		},
+		Envelope: &envelope.BuildOpts{
+			ActionID: "must-not-leak",
+			Action:   "tool_call",
+			Verdict:  config.ActionAllow,
+		},
+		InboundMsg:     inbound,
+		RequireReceipt: true,
+	})
+	if !errors.Is(err, ErrReceiptRequired) {
+		t.Fatalf("err = %v, want ErrReceiptRequired", err)
+	}
+	if !bytes.Equal(out, inbound) {
+		t.Fatalf("outbound was rewritten despite required receipt failure: %s", out)
+	}
+	if strings.Contains(string(out), "must-not-leak") || strings.Contains(string(out), "com.pipelock/mediation") {
+		t.Fatalf("outbound leaked mediation envelope after required receipt failure: %s", out)
+	}
+}
+
 func TestEmitMCPDecision_ReceiptOnly(t *testing.T) {
 	emitter, _, dir, _ := newReceiptTestHarness(t)
 

--- a/internal/mcp/receipt_attribution_test.go
+++ b/internal/mcp/receipt_attribution_test.go
@@ -323,6 +323,25 @@ func TestEmitMCPToolReceipt_RequiredEmptyActionIDFailsClosed(t *testing.T) {
 	}
 }
 
+func TestEmitMCPToolReceipt_RequiredEmptyActionIDLogsAuditGap(t *testing.T) {
+	var log bytes.Buffer
+	err := emitMCPToolReceipt(mcpToolReceiptOpts{
+		Log:             &log,
+		RequireReceipts: true,
+		RequireReceipt:  true,
+		Verdict:         config.ActionAllow,
+	})
+	if !errors.Is(err, ErrReceiptRequired) {
+		t.Fatalf("err = %v, want ErrReceiptRequired", err)
+	}
+	if !strings.Contains(log.String(), "receipt emission failed") {
+		t.Fatalf("missing receipt failure log: %q", log.String())
+	}
+	if !strings.Contains(log.String(), "event=block_receipt_emit_failed") || !strings.Contains(log.String(), "audit_gap=true") {
+		t.Fatalf("missing audit-gap warning for required empty ActionID: %q", log.String())
+	}
+}
+
 func TestEmitMCPToolReceipt_AuditGapGateNegativePaths(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -308,7 +308,9 @@ type mcpToolReceiptOpts struct {
 func emitMCPToolReceipt(opts mcpToolReceiptOpts) error {
 	if opts.ActionID == "" {
 		if opts.RequireReceipt {
-			return fmt.Errorf("empty action id: %w", ErrReceiptRequired)
+			err := fmt.Errorf("empty action id: %w", ErrReceiptRequired)
+			logReceiptEmitFailure(opts.Log, err, opts.RequireReceipts, opts.Verdict)
+			return err
 		}
 		return nil
 	}
@@ -372,7 +374,7 @@ func logReceiptEmitFailure(logW io.Writer, err error, requireReceipts bool, verd
 		return
 	}
 	_, _ = fmt.Fprintf(logW, "pipelock: receipt emission failed: %v\n", err)
-	if requireReceipts && verdict == config.ActionBlock {
+	if requireReceipts && (verdict == config.ActionBlock || errors.Is(err, ErrReceiptRequired)) {
 		logBlockReceiptAuditGap(logW, err)
 	}
 }


### PR DESCRIPTION
## What changed

When require-receipts is enabled and a decision carries an empty action id, the receipt-emit path previously skipped emission and could return an outbound envelope that leaked mediation metadata. It now fails closed: the action is blocked, the original inbound bytes are returned with no mediation or action metadata, and an audit-gap warning is emitted on both the decision path and the tool-receipt path.

This also hardens A2A method detection with a case-folded lookup over the known method set, so a case variant of a known method still receives the A2A identity and scanning without over-matching ordinary tool calls, and documents that full-object drift detection hashes non-provenance _meta, so a server that places a volatile value there will drift on every tools/list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP method detection now recognizes A2A methods regardless of letter case, improving compatibility with mixed-case requests.

* **Bug Fixes**
  * Required receipt failures now stop processing immediately, preventing unintended outbound message changes.
  * Receipt-related failures now produce clearer audit-gap logging when required information is missing.

* **Documentation**
  * Expanded guidance on tool-scanning drift detection and how to keep tool definitions stable to avoid repeated drift alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->