### PR TITLE
fix(conductor): reject empty-scope audit queries and enforce config-consumption gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,6 +207,9 @@ jobs:
       - name: Test stability policy
         run: bash scripts/check-test-stability.sh
 
+      - name: Config consumption policy
+        run: bash scripts/check-config-consumption.sh
+
   helm:
     needs: [security-scan]
     runs-on: ubuntu-latest

--- a/enterprise/cli/conductor/rollback_test.go
+++ b/enterprise/cli/conductor/rollback_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -205,6 +206,23 @@ func TestRunRollback_StaleCounterRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "conductor rejected request") {
 		t.Fatalf("error = %v, want stale-counter rejection", err)
+	}
+}
+
+func TestRunRollback_DefaultCounterFromClockIsObservable(t *testing.T) {
+	opts := newRollbackRig(t, 0)
+	opts.counter = 0
+	opts.authorizationID = ""
+	cmd, out := rollbackCobra(t)
+	if err := runRollback(cmd, opts); err != nil {
+		t.Fatalf("rollback error = %v", err)
+	}
+	wantCounter := strconv.FormatInt(opts.now().Unix(), 10)
+	if !strings.Contains(out.String(), "counter="+wantCounter) {
+		t.Fatalf("output %q missing clock-derived counter %s", out.String(), wantCounter)
+	}
+	if !strings.Contains(out.String(), "authorization_id=rollback-42-to-41-"+wantCounter) {
+		t.Fatalf("output %q missing counter-derived authorization id", out.String())
 	}
 }
 

--- a/enterprise/conductor/controlplane/audit_evidence.go
+++ b/enterprise/conductor/controlplane/audit_evidence.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
@@ -39,7 +38,8 @@ func (s *SQLiteAuditStore) ListAuditBatchEvidence(ctx context.Context, q AuditEv
 	if ctx == nil {
 		return nil, fmt.Errorf("%w: context", ErrAuditSinkRequired)
 	}
-	if strings.TrimSpace(q.OrgID) == "" || strings.TrimSpace(q.FleetID) == "" {
+	q.OrgID, q.FleetID = normalizeAuditScope(q.OrgID, q.FleetID)
+	if q.OrgID == "" || q.FleetID == "" {
 		return nil, fmt.Errorf("%w: org_id and fleet_id required", ErrInvalidStoreRecord)
 	}
 	if q.ReceivedFrom.IsZero() || q.ReceivedTo.IsZero() || !q.ReceivedTo.After(q.ReceivedFrom) {

--- a/enterprise/conductor/controlplane/audit_evidence.go
+++ b/enterprise/conductor/controlplane/audit_evidence.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
@@ -38,7 +39,7 @@ func (s *SQLiteAuditStore) ListAuditBatchEvidence(ctx context.Context, q AuditEv
 	if ctx == nil {
 		return nil, fmt.Errorf("%w: context", ErrAuditSinkRequired)
 	}
-	if q.OrgID == "" || q.FleetID == "" {
+	if strings.TrimSpace(q.OrgID) == "" || strings.TrimSpace(q.FleetID) == "" {
 		return nil, fmt.Errorf("%w: org_id and fleet_id required", ErrInvalidStoreRecord)
 	}
 	if q.ReceivedFrom.IsZero() || q.ReceivedTo.IsZero() || !q.ReceivedTo.After(q.ReceivedFrom) {

--- a/enterprise/conductor/controlplane/audit_store.go
+++ b/enterprise/conductor/controlplane/audit_store.go
@@ -66,6 +66,10 @@ type AuditPruneResult struct {
 	Before  time.Time
 }
 
+func normalizeAuditScope(orgID, fleetID string) (string, string) {
+	return strings.TrimSpace(orgID), strings.TrimSpace(fleetID)
+}
+
 func OpenSQLiteAuditStore(ctx context.Context, path string) (*SQLiteAuditStore, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, errors.New("conductor audit store path is required")
@@ -357,7 +361,8 @@ func (s *SQLiteAuditStore) ListAuditBatches(ctx context.Context, q AuditBatchQue
 	if ctx == nil {
 		return nil, fmt.Errorf("%w: context", ErrAuditSinkRequired)
 	}
-	if strings.TrimSpace(q.OrgID) == "" {
+	q.OrgID, q.FleetID = normalizeAuditScope(q.OrgID, q.FleetID)
+	if q.OrgID == "" {
 		return nil, fmt.Errorf("%w: org_id required", ErrInvalidStoreRecord)
 	}
 	limit := normalizeAuditLimit(q.Limit)

--- a/enterprise/conductor/controlplane/audit_store.go
+++ b/enterprise/conductor/controlplane/audit_store.go
@@ -357,6 +357,9 @@ func (s *SQLiteAuditStore) ListAuditBatches(ctx context.Context, q AuditBatchQue
 	if ctx == nil {
 		return nil, fmt.Errorf("%w: context", ErrAuditSinkRequired)
 	}
+	if strings.TrimSpace(q.OrgID) == "" {
+		return nil, fmt.Errorf("%w: org_id required", ErrInvalidStoreRecord)
+	}
 	limit := normalizeAuditLimit(q.Limit)
 	query := `
 		SELECT batch_id, org_id, fleet_id, instance_id, audit_schema_version,

--- a/enterprise/conductor/controlplane/audit_store_test.go
+++ b/enterprise/conductor/controlplane/audit_store_test.go
@@ -126,6 +126,30 @@ func TestSQLiteAuditStoreListsLocalAuditEvidence(t *testing.T) {
 	}
 }
 
+func TestSQLiteAuditStoreListEvidenceTrimsScopeForQuery(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+
+	batch := signedAcceptedAuditBatch(t, defaultFollowerIdentity(), testAuditBatchID, 10, 10, []byte(testAuditPayload), testNow)
+	if _, err := store.put(context.Background(), batch); err != nil {
+		t.Fatalf("put() error = %v", err)
+	}
+
+	got, err := store.ListAuditBatchEvidence(context.Background(), AuditEvidenceQuery{
+		OrgID:        " \t" + batch.Identity.OrgID + "\n",
+		FleetID:      "\n" + batch.Identity.FleetID + " ",
+		ReceivedFrom: testNow.Add(-time.Minute),
+		ReceivedTo:   testNow.Add(time.Minute),
+		Limit:        10,
+	})
+	if err != nil {
+		t.Fatalf("ListAuditBatchEvidence(padded scope) error = %v", err)
+	}
+	if len(got) != 1 || got[0].Summary.BatchID != batch.Envelope.BatchID {
+		t.Fatalf("ListAuditBatchEvidence(padded scope) = %+v, want batch %q", got, batch.Envelope.BatchID)
+	}
+}
+
 func TestSQLiteAuditStoreEvidenceFailsClosedOnTruncation(t *testing.T) {
 	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
 	defer func() { _ = store.Close() }()
@@ -433,6 +457,29 @@ func TestSQLiteAuditStoreListOrdersAndLimits(t *testing.T) {
 	}
 	if len(clipped) != 2 {
 		t.Fatalf("clipped len = %d, want 2", len(clipped))
+	}
+}
+
+func TestSQLiteAuditStoreListTrimsScopeForQuery(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+
+	identity := defaultFollowerIdentity()
+	batch := signedAcceptedAuditBatch(t, identity, testAuditBatchID, 10, 10, []byte(testAuditPayload), testNow)
+	if _, err := store.put(context.Background(), batch); err != nil {
+		t.Fatalf("put() error = %v", err)
+	}
+
+	got, err := store.ListAuditBatches(context.Background(), AuditBatchQuery{
+		OrgID:   " \t" + identity.OrgID + "\n",
+		FleetID: "\n" + identity.FleetID + " ",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("ListAuditBatches(padded scope) error = %v", err)
+	}
+	if len(got) != 1 || got[0].BatchID != batch.Envelope.BatchID {
+		t.Fatalf("ListAuditBatches(padded scope) = %+v, want batch %q", got, batch.Envelope.BatchID)
 	}
 }
 

--- a/enterprise/conductor/controlplane/audit_store_test.go
+++ b/enterprise/conductor/controlplane/audit_store_test.go
@@ -195,6 +195,30 @@ func TestSQLiteAuditStoreEvidenceQueryValidation(t *testing.T) {
 	}
 }
 
+func TestSQLiteAuditStoreEvidenceRejectsWhitespaceScopeBeforeQuery(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	query := AuditEvidenceQuery{
+		OrgID:        " \t\n",
+		FleetID:      defaultFollowerIdentity().FleetID,
+		ReceivedFrom: testNow.Add(-time.Minute),
+		ReceivedTo:   testNow.Add(time.Minute),
+	}
+	if _, err := store.ListAuditBatchEvidence(context.Background(), query); !errors.Is(err, ErrInvalidStoreRecord) {
+		t.Fatalf("ListAuditBatchEvidence(whitespace org after close) error = %v, want ErrInvalidStoreRecord", err)
+	}
+
+	query.OrgID = defaultFollowerIdentity().OrgID
+	query.FleetID = "\n\t "
+	if _, err := store.ListAuditBatchEvidence(context.Background(), query); !errors.Is(err, ErrInvalidStoreRecord) {
+		t.Fatalf("ListAuditBatchEvidence(whitespace fleet after close) error = %v, want ErrInvalidStoreRecord", err)
+	}
+}
+
 func TestScanAuditEvidenceRejectsCorruptRows(t *testing.T) {
 	valid := auditEvidenceRowFromBatch(t,
 		signedAcceptedAuditBatch(t, defaultFollowerIdentity(), testAuditBatchID, 10, 10, []byte(testAuditPayload), testNow))
@@ -409,6 +433,35 @@ func TestSQLiteAuditStoreListOrdersAndLimits(t *testing.T) {
 	}
 	if len(clipped) != 2 {
 		t.Fatalf("clipped len = %d, want 2", len(clipped))
+	}
+}
+
+func TestSQLiteAuditStoreListRejectsEmptyOrgBeforeQuery(t *testing.T) {
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = store.Close() }()
+
+	identity := defaultFollowerIdentity()
+	batch := signedAcceptedAuditBatch(t, identity, testAuditBatchID, 10, 10, []byte(testAuditPayload), testNow)
+	if _, err := store.put(context.Background(), batch); err != nil {
+		t.Fatalf("put() error = %v", err)
+	}
+
+	got, err := store.ListAuditBatches(context.Background(), AuditBatchQuery{Limit: 10})
+	if !errors.Is(err, ErrInvalidStoreRecord) {
+		t.Fatalf("ListAuditBatches(empty org) error = %v, want ErrInvalidStoreRecord", err)
+	}
+	if got != nil {
+		t.Fatalf("ListAuditBatches(empty org) rows = %+v, want nil", got)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	got, err = store.ListAuditBatches(context.Background(), AuditBatchQuery{OrgID: " \t\n", Limit: 10})
+	if !errors.Is(err, ErrInvalidStoreRecord) {
+		t.Fatalf("ListAuditBatches(whitespace org after close) error = %v, want ErrInvalidStoreRecord", err)
+	}
+	if got != nil {
+		t.Fatalf("ListAuditBatches(whitespace org after close) rows = %+v, want nil", got)
 	}
 }
 

--- a/enterprise/conductor/controlplane/enrollment_test.go
+++ b/enterprise/conductor/controlplane/enrollment_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -152,6 +153,112 @@ func TestFileEnrollmentStoreRejectsDuplicateActiveInstance(t *testing.T) {
 	consume.Token = second.Token
 	if _, err := store.ConsumeEnrollmentToken(context.Background(), consume); !errors.Is(err, ErrEnrollmentActiveInstance) {
 		t.Fatalf("ConsumeEnrollmentToken(second) error = %v, want ErrEnrollmentActiveInstance", err)
+	}
+}
+
+func TestFileEnrollmentStoreRejectsEnrollmentTokenReuse(t *testing.T) {
+	store, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	issued, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "token-one-use",
+		Identity: defaultFollowerIdentity(),
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken() error = %v", err)
+	}
+	pub, _ := testAuditSigner(t)
+	consume := ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-1",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), consume); err != nil {
+		t.Fatalf("ConsumeEnrollmentToken(first) error = %v", err)
+	}
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), consume); !errors.Is(err, ErrEnrollmentTokenConsumed) {
+		t.Fatalf("ConsumeEnrollmentToken(reuse) error = %v, want ErrEnrollmentTokenConsumed", err)
+	}
+}
+
+func TestFileEnrollmentStoreConcurrentTokenConsumeAllowsOneWinner(t *testing.T) {
+	store, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	issued, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "token-race",
+		Identity: defaultFollowerIdentity(),
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken() error = %v", err)
+	}
+	pub, _ := testAuditSigner(t)
+	consume := ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-1",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}
+
+	const workers = 16
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := store.ConsumeEnrollmentToken(context.Background(), consume)
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	successes := 0
+	consumed := 0
+	for err := range errs {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, ErrEnrollmentTokenConsumed):
+			consumed++
+		default:
+			t.Fatalf("ConsumeEnrollmentToken(concurrent) unexpected error = %v", err)
+		}
+	}
+	if successes != 1 || consumed != workers-1 {
+		t.Fatalf("concurrent consume successes=%d consumed=%d, want 1/%d", successes, consumed, workers-1)
+	}
+
+	tokens, err := store.ListEnrollmentTokens(context.Background(), EnrollmentTokenListQuery{TokenID: "token-race", Now: testNow})
+	if err != nil {
+		t.Fatalf("ListEnrollmentTokens() error = %v", err)
+	}
+	if len(tokens) != 1 || tokens[0].State != EnrollmentTokenStateConsumed {
+		t.Fatalf("token state after concurrent consume = %+v, want one consumed token", tokens)
+	}
+	followers, err := store.ListEnrolledFollowers(context.Background(), FollowerListQuery{OrgID: defaultFollowerIdentity().OrgID})
+	if err != nil {
+		t.Fatalf("ListEnrolledFollowers() error = %v", err)
+	}
+	if len(followers) != 1 || followers[0].InstanceID != defaultFollowerIdentity().InstanceID {
+		t.Fatalf("followers after concurrent consume = %+v, want one enrolled follower", followers)
 	}
 }
 

--- a/scripts/config-consumption-allowlist.txt
+++ b/scripts/config-consumption-allowlist.txt
@@ -25,7 +25,7 @@ AllowedImageTypes  # (A) MediaPolicy.EffectiveAllowedImageTypes() -> IsImageType
 MaxImageBytes  # (A) MediaPolicy.EffectiveMaxImageBytes() schema_receiver_methods.go:240 -> mcp/media_policy.go:304
 SaltSource  # (A) Learn normalizer (normalize.go:16) resolves it; contract/privacy/salt.go:58 + cli/contain/config_migrate.go consume the resolved value
 MinimumSignatures  # (A) LearnLock.EffectiveMinimumSignatures() schema.go:1806 -> mcp/contractgate.go:58, proxy/contractgate.go:151
-TrustedMCPServers  # (A) Config.TaintTrustsMCPServer() schema.go:1487 -> runtime/server_lifecycle.go:718, runtime/mcp.go:233, diag/doctor_config_semantics.go:220
+TrustedMCPServers  # (A) Config.TaintTrustsMCPServer() schema.go:1501 -> runtime/server_lifecycle.go:718, runtime/mcp.go:233, diag/doctor_config_semantics.go:220
 
 # --- (B) validation-only by design ---
 MatchAbsPath  # (B) enforces absolute-path constraint on RedirectProfile.Exec[0] at validate.go:816; nothing to read after validation passes

--- a/scripts/config-consumption-allowlist.txt
+++ b/scripts/config-consumption-allowlist.txt
@@ -25,6 +25,7 @@ AllowedImageTypes  # (A) MediaPolicy.EffectiveAllowedImageTypes() -> IsImageType
 MaxImageBytes  # (A) MediaPolicy.EffectiveMaxImageBytes() schema_receiver_methods.go:240 -> mcp/media_policy.go:304
 SaltSource  # (A) Learn normalizer (normalize.go:16) resolves it; contract/privacy/salt.go:58 + cli/contain/config_migrate.go consume the resolved value
 MinimumSignatures  # (A) LearnLock.EffectiveMinimumSignatures() schema.go:1806 -> mcp/contractgate.go:58, proxy/contractgate.go:151
+TrustedMCPServers  # (A) Config.TaintTrustsMCPServer() schema.go:1487 -> runtime/server_lifecycle.go:718, runtime/mcp.go:233, diag/doctor_config_semantics.go:220
 
 # --- (B) validation-only by design ---
 MatchAbsPath  # (B) enforces absolute-path constraint on RedirectProfile.Exec[0] at validate.go:816; nothing to read after validation passes


### PR DESCRIPTION
## What changed

Conductor audit query paths accepted an empty or whitespace-only org scope and would run the query unscoped. Both the audit-batch list and the audit-evidence list now reject an empty or whitespace org before touching the store. This also adds a CI gate that runs the config-consumption check so a config field with no runtime consumer fails the build, and records the taint-trust MCP-server knob as consumed by its runtime callers.

Includes regression coverage proving enrollment tokens are single-use under concurrent double-consume, and that rollback rejects a stale counter and exposes an observable counter value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit scope validation by trimming whitespace and rejecting empty/whitespace-only values before audit queries run.
  * Strengthened enrollment token handling so consumed tokens can’t be reused, including under concurrent consumption attempts.
  * Rollback output now reliably exposes the automatically derived counter value and related authorization details.
* **Chores**
  * Added an additional CI policy check for config consumption.
* **Tests**
  * Expanded automated coverage for audit scope trimming/rejection, enrollment token reuse/concurrency, and rollback output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->