### PR TITLE
Make crash reporting opt-in with a minimizing sanitizer

### DIFF
--- a/charts/pipelock/templates/configmap.yaml
+++ b/charts/pipelock/templates/configmap.yaml
@@ -20,6 +20,11 @@ data:
     {{- if and .Values.license.crlSecretRef.name .Values.license.crlSecretRef.key }}
     {{- $_ := set $cfg "license_crl_file" (printf "%s/%s" .Values.license.crlSecretRef.mountPath .Values.license.crlSecretRef.key) }}
     {{- end }}
+    {{- if .Values.sentry.enabled }}
+    {{- $sentry := deepCopy (default dict $cfg.sentry) }}
+    {{- $_ := set $sentry "enabled" true }}
+    {{- $_ := set $cfg "sentry" $sentry }}
+    {{- end }}
     {{- if .Values.conductorFollower.enabled }}
     {{- $conductor := merge (dict
       "enabled" true

--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -471,11 +471,10 @@ logging:
   include_allowed: true
   include_blocked: true
 
-# Defaults to pipelock maintainer Sentry for crash reporting.
-# Override via SENTRY_DSN env var or set dsn below.
+# Sentry crash reporting is opt-in. Set enabled: true and provide dsn or SENTRY_DSN.
 sentry:
-  enabled: true
-  dsn: "https://b1902c1ea2d87902780bfbf59c0fb343@o4511026551783424.ingest.us.sentry.io/4511026559254528"
+  enabled: false
+  dsn: ""
   environment: production
   sample_rate: 1.0
 

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -542,11 +542,10 @@ logging:
   include_allowed: true
   include_blocked: true
 
-# Defaults to pipelock maintainer Sentry for crash reporting.
-# Override via SENTRY_DSN env var or set dsn below.
+# Sentry crash reporting is opt-in. Set enabled: true and provide dsn or SENTRY_DSN.
 sentry:
-  enabled: true
-  dsn: "https://b1902c1ea2d87902780bfbf59c0fb343@o4511026551783424.ingest.us.sentry.io/4511026559254528"
+  enabled: false
+  dsn: ""
   environment: production
   sample_rate: 1.0
 

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -512,11 +512,10 @@ logging:
   include_allowed: true
   include_blocked: true
 
-# Defaults to pipelock maintainer Sentry for crash reporting.
-# Override via SENTRY_DSN env var or set dsn below.
+# Sentry crash reporting is opt-in. Set enabled: true and provide dsn or SENTRY_DSN.
 sentry:
-  enabled: true
-  dsn: "https://b1902c1ea2d87902780bfbf59c0fb343@o4511026551783424.ingest.us.sentry.io/4511026559254528"
+  enabled: false
+  dsn: ""
   environment: production
   sample_rate: 1.0
 

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -513,11 +513,10 @@ logging:
   include_allowed: true
   include_blocked: true
 
-# Defaults to pipelock maintainer Sentry for crash reporting.
-# Override via SENTRY_DSN env var or set dsn below.
+# Sentry crash reporting is opt-in. Set enabled: true and provide dsn or SENTRY_DSN.
 sentry:
-  enabled: true
-  dsn: "https://b1902c1ea2d87902780bfbf59c0fb343@o4511026551783424.ingest.us.sentry.io/4511026559254528"
+  enabled: false
+  dsn: ""
   environment: production
   sample_rate: 1.0
 

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -509,11 +509,10 @@ logging:
   include_allowed: true
   include_blocked: true
 
-# Defaults to pipelock maintainer Sentry for crash reporting.
-# Override via SENTRY_DSN env var or set dsn below.
+# Sentry crash reporting is opt-in. Set enabled: true and provide dsn or SENTRY_DSN.
 sentry:
-  enabled: true
-  dsn: "https://b1902c1ea2d87902780bfbf59c0fb343@o4511026551783424.ingest.us.sentry.io/4511026559254528"
+  enabled: false
+  dsn: ""
   environment: production
   sample_rate: 1.0
 

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -534,11 +534,10 @@ logging:
   include_allowed: true
   include_blocked: true
 
-# Defaults to pipelock maintainer Sentry for crash reporting.
-# Override via SENTRY_DSN env var or set dsn below.
+# Sentry crash reporting is opt-in. Set enabled: true and provide dsn or SENTRY_DSN.
 sentry:
-  enabled: true
-  dsn: "https://b1902c1ea2d87902780bfbf59c0fb343@o4511026551783424.ingest.us.sentry.io/4511026559254528"
+  enabled: false
+  dsn: ""
   environment: production
   sample_rate: 1.0
 

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -530,11 +530,10 @@ logging:
   include_allowed: true
   include_blocked: true
 
-# Defaults to pipelock maintainer Sentry for crash reporting.
-# Override via SENTRY_DSN env var or set dsn below.
+# Sentry crash reporting is opt-in. Set enabled: true and provide dsn or SENTRY_DSN.
 sentry:
-  enabled: true
-  dsn: "https://b1902c1ea2d87902780bfbf59c0fb343@o4511026551783424.ingest.us.sentry.io/4511026559254528"
+  enabled: false
+  dsn: ""
   environment: production
   sample_rate: 1.0
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ On reload, the scanner and session manager are atomically swapped. Kill switch s
 
 If a reload fails validation (invalid regex, security downgrade), the old config is retained and a warning is logged.
 
-**Reload exceptions:** the Sentry crash-report scrubber captures the DLP pattern list at startup and does **not** update on reload. If you add DLP patterns used to scrub Sentry events, restart pipelock to propagate them. A warning is logged on any reload that changes `dlp.patterns` while Sentry is enabled: `DLP patterns changed; Sentry scrubber uses init-time patterns until restart`.
+**Reload exceptions:** the Sentry crash-report sanitizer captures the DLP pattern list at startup and does **not** update on reload. If you add DLP patterns used to scrub Sentry events, restart pipelock to propagate them. A warning is logged on any reload that changes `dlp.patterns` while Sentry is enabled: `DLP patterns changed; Sentry scrubber uses init-time patterns until restart`.
 
 **Strict parsing:** Pipelock rejects unknown top-level and nested YAML fields at startup, and it only accepts a single YAML document per config file. Trailing `---` documents are a hard error. This prevents typos from silently disabling controls and blocks shadow-config bypasses.
 
@@ -40,6 +40,22 @@ explain_blocks: false         # true = include fix hints in block responses
 | `mode` | string | `"balanced"` | Operating mode (see [Modes](#modes)) |
 | `enforce` | bool | `true` | When false, all blocks become warnings |
 | `explain_blocks` | bool | `false` | Include actionable hints in block responses |
+
+### Sentry Crash Reporting
+
+Sentry crash reporting is disabled by default. It is enabled only when `sentry.enabled: true` is set and either `sentry.dsn` or the `SENTRY_DSN` environment variable is non-empty.
+
+```yaml
+sentry:
+  enabled: false
+  dsn: ""
+  environment: production
+  sample_rate: 1.0
+```
+
+When enabled, Pipelock prints a startup disclosure. Crash payloads are rebuilt through an allowlist sanitizer before leaving the process: request bodies, headers, user identity, hostnames, breadcrumbs, module inventory, local variables, absolute paths, and source context lines are dropped. Transactions, SDK logs, metrics, and check-ins are not sent by this integration.
+
+`sample_rate: 0.0` does **not** disable Sentry in the Go SDK; it is treated as `1.0`. To disable crash reporting, set `sentry.enabled: false` or leave the DSN empty. Pipelock rejects `sample_rate: 0.0` when Sentry is enabled.
 
 ### Block Hints (`explain_blocks`)
 

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -674,7 +674,7 @@ func checkDoctorSentry(cfg *config.Config) doctorReportCheck {
 			Surface: doctorSurfaceHost,
 			Status:  doctorStatusInfo,
 			Detail:  "disabled (default)",
-			Next:    "optional: set your own SENTRY_DSN to receive minimized crash reports, or use equivalent alerting",
+			Next:    "optional: set sentry.enabled: true and provide your own DSN via YAML or SENTRY_DSN to receive minimized crash reports, or use equivalent alerting",
 		}
 	}
 	if !dsnConfigured {

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -672,9 +672,9 @@ func checkDoctorSentry(cfg *config.Config) doctorReportCheck {
 		return doctorReportCheck{
 			Name:    "sentry",
 			Surface: doctorSurfaceHost,
-			Status:  doctorStatusWarn,
-			Detail:  "disabled",
-			Next:    "enable Sentry or equivalent alerting before production claims",
+			Status:  doctorStatusInfo,
+			Detail:  "disabled (default)",
+			Next:    "optional: set your own SENTRY_DSN to receive minimized crash reports, or use equivalent alerting",
 		}
 	}
 	if !dsnConfigured {

--- a/internal/cli/diag/doctor_test.go
+++ b/internal/cli/diag/doctor_test.go
@@ -494,8 +494,8 @@ func TestDoctorChecksCoverConfiguredBranches(t *testing.T) {
 		cfg := config.Defaults()
 		disabled := false
 		cfg.Sentry.Enabled = &disabled
-		if check := checkDoctorSentry(cfg); check.Status != doctorStatusWarn || check.Configured {
-			t.Fatalf("disabled sentry check = %+v, want unconfigured warning", check)
+		if check := checkDoctorSentry(cfg); check.Status != doctorStatusInfo || check.Configured {
+			t.Fatalf("disabled sentry check = %+v, want informational disabled-by-default", check)
 		}
 		enabled := true
 		cfg.Sentry.Enabled = &enabled

--- a/internal/cli/diag/doctor_test.go
+++ b/internal/cli/diag/doctor_test.go
@@ -496,6 +496,8 @@ func TestDoctorChecksCoverConfiguredBranches(t *testing.T) {
 		cfg.Sentry.Enabled = &disabled
 		if check := checkDoctorSentry(cfg); check.Status != doctorStatusInfo || check.Configured {
 			t.Fatalf("disabled sentry check = %+v, want informational disabled-by-default", check)
+		} else if !strings.Contains(check.Next, "sentry.enabled: true") || !strings.Contains(check.Next, "SENTRY_DSN") {
+			t.Fatalf("disabled sentry next = %q, want enabled flag and DSN guidance", check.Next)
 		}
 		enabled := true
 		cfg.Sentry.Enabled = &enabled

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11218,10 +11218,10 @@ func TestLoad_AddressProtectionChainDefaults(t *testing.T) {
 
 // --- Sentry tests ---
 
-func TestEnabled_NilDefaultsTrue(t *testing.T) {
+func TestEnabled_NilDefaultsFalse(t *testing.T) {
 	cfg := SentryConfig{}
-	if !cfg.IsEnabled() {
-		t.Error("expected Enabled() to return true when Enabled is nil")
+	if cfg.IsEnabled() {
+		t.Error("expected IsEnabled() to return false when Enabled is nil")
 	}
 }
 
@@ -11238,6 +11238,14 @@ func TestEnabled_ExplicitlyTrue(t *testing.T) {
 	cfg := SentryConfig{Enabled: &tr}
 	if !cfg.IsEnabled() {
 		t.Error("expected Enabled() to return true when Enabled is explicitly true")
+	}
+}
+
+func TestEnabled_ExplicitTrueWithDSN(t *testing.T) {
+	tr := true
+	cfg := SentryConfig{Enabled: &tr, DSN: "https://examplePublicKey@o0.ingest.sentry.io/0"}
+	if !cfg.IsEnabled() {
+		t.Error("expected IsEnabled() to return true when Enabled is explicitly true")
 	}
 }
 
@@ -11317,11 +11325,50 @@ func TestValidate_SampleRateValid(t *testing.T) {
 	}
 }
 
-func TestValidate_SampleRateZeroIsValid(t *testing.T) {
+func TestValidate_SampleRateZeroAllowedWhenDisabled(t *testing.T) {
 	cfg := Defaults()
 	cfg.Sentry.SampleRate = floatPtr(0.0)
 	if err := cfg.Validate(); err != nil {
-		t.Errorf("expected sample_rate 0.0 to be valid (disables sampling), got: %v", err)
+		t.Errorf("expected sample_rate 0.0 to be harmless when Sentry is disabled, got: %v", err)
+	}
+}
+
+func TestValidate_SampleRateZeroRejectedWhenEnabled(t *testing.T) {
+	enabled := true
+	cfg := Defaults()
+	cfg.Sentry.Enabled = &enabled
+	cfg.Sentry.SampleRate = floatPtr(0.0)
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "treats 0.0 as 1.0") {
+		t.Errorf("expected sample_rate 0.0 enabled rejection, got: %v", err)
+	}
+}
+
+func TestPresetSentryDefaultOffNoMaintainerDSN(t *testing.T) {
+	entries, err := os.ReadDir(filepath.Join("..", "..", "configs"))
+	if err != nil {
+		t.Fatalf("read configs dir: %v", err)
+	}
+
+	checked := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		checked++
+		path := filepath.Join("..", "..", "configs", entry.Name())
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load(%s): %v", path, err)
+		}
+		if cfg.Sentry.IsEnabled() {
+			t.Fatalf("%s has Sentry enabled by default", path)
+		}
+		if cfg.Sentry.DSN != "" {
+			t.Fatalf("%s has non-empty Sentry DSN", path)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no config presets checked")
 	}
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1289,13 +1289,14 @@ type MCPWSListener struct {
 	MaxConnections int      `yaml:"max_connections"` // max concurrent inbound WS connections (default 100)
 }
 
-// SentryConfig configures Sentry error reporting with secret redaction.
-// All error data is scrubbed through DLP patterns before leaving the process.
+// SentryConfig configures opt-in Sentry error reporting with event minimization.
+// Crash reporting is enabled only when enabled is explicitly true and a DSN is
+// configured here or through SENTRY_DSN.
 type SentryConfig struct {
-	Enabled     *bool    `yaml:"enabled"`     // nil = true (default enabled)
+	Enabled     *bool    `yaml:"enabled"`     // nil = false (default disabled)
 	DSN         string   `yaml:"dsn"`         // Sentry DSN; also reads SENTRY_DSN env
 	Environment string   `yaml:"environment"` // e.g. "production" (default)
-	SampleRate  *float64 `yaml:"sample_rate"` // nil = 1.0; 0.0-1.0
+	SampleRate  *float64 `yaml:"sample_rate"` // nil = 1.0; >0.0-1.0 when enabled
 	Debug       bool     `yaml:"debug"`       // SDK debug mode
 }
 

--- a/internal/config/schema_receiver_methods.go
+++ b/internal/config/schema_receiver_methods.go
@@ -270,12 +270,14 @@ func (c *Config) ExplainBlocksEnabled() bool {
 	return c.ExplainBlocks != nil && *c.ExplainBlocks
 }
 
-// IsEnabled returns true if Sentry is enabled (nil defaults to true).
+// IsEnabled returns true if Sentry is explicitly enabled.
 func (s *SentryConfig) IsEnabled() bool {
-	return s.Enabled == nil || *s.Enabled
+	return s.Enabled != nil && *s.Enabled
 }
 
 // EffectiveSampleRate returns the configured sample rate (nil defaults to 1.0).
+// A value of 0.0 does not disable events in sentry-go; Validate rejects it when
+// Sentry is enabled.
 func (s *SentryConfig) EffectiveSampleRate() float64 {
 	if s.SampleRate == nil {
 		return 1.0

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2516,6 +2516,9 @@ func (c *Config) validateSentry() error {
 	if sr < 0 || sr > 1 {
 		return fmt.Errorf("invalid sentry.sample_rate %f: must be between 0.0 and 1.0", sr)
 	}
+	if c.Sentry.IsEnabled() && c.Sentry.SampleRate != nil && sr == 0 {
+		return fmt.Errorf("invalid sentry.sample_rate 0.0: sentry-go treats 0.0 as 1.0; disable crash reporting with sentry.enabled: false or an empty DSN")
+	}
 	return nil
 }
 

--- a/internal/sentry/client.go
+++ b/internal/sentry/client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
-// Client wraps the Sentry SDK with secret scrubbing. When disabled (enabled=false),
+// Client wraps the Sentry SDK with event minimization. When disabled (enabled=false),
 // all methods are safe no-ops. Nil-safe: (*Client)(nil).CaptureError(err) is a no-op.
 //
 // Uses the global Sentry hub - only one Client should be active per process.
@@ -38,9 +38,12 @@ func initClient(cfg *config.Config, version string, transport sentry.Transport) 
 	if !cfg.Sentry.IsEnabled() {
 		return &Client{enabled: false}, nil
 	}
+	if cfg.Sentry.SampleRate != nil && *cfg.Sentry.SampleRate == 0 {
+		return nil, fmt.Errorf("invalid sentry.sample_rate 0.0: it does not disable Sentry in sentry-go; use sentry.enabled: false or an empty DSN")
+	}
 
 	// SENTRY_DSN env overrides config so users can redirect crash reports
-	// away from the maintainer DSN shipped in preset configs.
+	// without editing checked-in configs.
 	dsn := os.Getenv("SENTRY_DSN")
 	if dsn == "" {
 		dsn = cfg.Sentry.DSN
@@ -83,19 +86,35 @@ func initClient(cfg *config.Config, version string, transport sentry.Transport) 
 		Environment:      cfg.Sentry.Environment,
 		SampleRate:       cfg.Sentry.EffectiveSampleRate(),
 		Debug:            cfg.Sentry.Debug,
-		AttachStacktrace: true,
+		AttachStacktrace: false,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			if isUnsafeEventType(event) {
+				return nil
+			}
 			return scrubber.ScrubEvent(event, hint)
+		},
+		BeforeSendTransaction: func(_ *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+			return nil
+		},
+		BeforeSendLog: func(_ *sentry.Log) *sentry.Log {
+			return nil
+		},
+		BeforeSendMetric: func(_ *sentry.Metric) *sentry.Metric {
+			return nil
 		},
 	}
 	if transport != nil {
-		opts.Transport = transport
+		opts.Transport = dropUnsafeEventTransport{delegate: transport}
+	} else {
+		opts.Transport = dropUnsafeEventTransport{delegate: sentry.NewHTTPTransport()}
 	}
 
 	err := sentry.Init(opts)
 	if err != nil {
 		return nil, err
 	}
+
+	_, _ = fmt.Fprintln(os.Stderr, "pipelock: Sentry crash reporting enabled; crash reports go to the configured Sentry DSN and payloads are minimized without request bodies, headers, user, hostname, breadcrumbs, or local variables.")
 
 	return &Client{scrubber: scrubber, enabled: true}, nil
 }
@@ -165,6 +184,60 @@ func (c *Client) Close() {
 		return
 	}
 	sentry.Flush(2 * time.Second)
+}
+
+// dropUnsafeEventTransport blocks SDK event classes that do not flow through
+// the allowlist sanitizer. Check-ins intentionally skip BeforeSend in
+// sentry-go, so the transport is the last in-process choke point.
+type dropUnsafeEventTransport struct {
+	delegate sentry.Transport
+}
+
+func (t dropUnsafeEventTransport) Configure(options sentry.ClientOptions) {
+	if t.delegate != nil {
+		t.delegate.Configure(options)
+	}
+}
+
+func (t dropUnsafeEventTransport) SendEvent(event *sentry.Event) {
+	if event == nil || isUnsafeEventType(event) || t.delegate == nil {
+		return
+	}
+	t.delegate.SendEvent(event)
+}
+
+func (t dropUnsafeEventTransport) Flush(timeout time.Duration) bool {
+	if t.delegate == nil {
+		return true
+	}
+	return t.delegate.Flush(timeout)
+}
+
+func (t dropUnsafeEventTransport) FlushWithContext(ctx context.Context) bool {
+	if t.delegate == nil {
+		return true
+	}
+	if flusher, ok := t.delegate.(interface {
+		FlushWithContext(context.Context) bool
+	}); ok {
+		return flusher.FlushWithContext(ctx)
+	}
+	return t.delegate.Flush(0)
+}
+
+func (t dropUnsafeEventTransport) Close() {
+	if t.delegate != nil {
+		t.delegate.Close()
+	}
+}
+
+func isUnsafeEventType(event *sentry.Event) bool {
+	return event.Type == "check_in" ||
+		event.Type == "transaction" ||
+		event.CheckIn != nil ||
+		event.MonitorConfig != nil ||
+		len(event.Logs) > 0 ||
+		len(event.Metrics) > 0
 }
 
 // loadFileSecrets reads literal secret values from a file, one per line.

--- a/internal/sentry/client.go
+++ b/internal/sentry/client.go
@@ -114,6 +114,7 @@ func initClient(cfg *config.Config, version string, transport sentry.Transport) 
 
 	err := sentry.Init(opts)
 	if err != nil {
+		disableGlobalClient()
 		return nil, err
 	}
 

--- a/internal/sentry/client.go
+++ b/internal/sentry/client.go
@@ -36,6 +36,7 @@ func Init(cfg *config.Config, version string) (*Client, error) {
 // injected into the Sentry SDK options (used by tests to capture events).
 func initClient(cfg *config.Config, version string, transport sentry.Transport) (*Client, error) {
 	if !cfg.Sentry.IsEnabled() {
+		disableGlobalClient()
 		return &Client{enabled: false}, nil
 	}
 	if cfg.Sentry.SampleRate != nil && *cfg.Sentry.SampleRate == 0 {
@@ -49,6 +50,7 @@ func initClient(cfg *config.Config, version string, transport sentry.Transport) 
 		dsn = cfg.Sentry.DSN
 	}
 	if dsn == "" {
+		disableGlobalClient()
 		return &Client{enabled: false}, nil
 	}
 
@@ -117,6 +119,10 @@ func initClient(cfg *config.Config, version string, transport sentry.Transport) 
 	_, _ = fmt.Fprintln(os.Stderr, "pipelock: Sentry crash reporting enabled; crash reports go to the configured Sentry DSN and payloads are minimized without request bodies, headers, user, hostname, breadcrumbs, or local variables.")
 
 	return &Client{scrubber: scrubber, enabled: true}, nil
+}
+
+func disableGlobalClient() {
+	sentry.CurrentHub().BindClient(nil)
 }
 
 // CaptureError sends an error event to Sentry (scrubbed by BeforeSend and the

--- a/internal/sentry/client.go
+++ b/internal/sentry/client.go
@@ -40,6 +40,7 @@ func initClient(cfg *config.Config, version string, transport sentry.Transport) 
 		return &Client{enabled: false}, nil
 	}
 	if cfg.Sentry.SampleRate != nil && *cfg.Sentry.SampleRate == 0 {
+		disableGlobalClient()
 		return nil, fmt.Errorf("invalid sentry.sample_rate 0.0: it does not disable Sentry in sentry-go; use sentry.enabled: false or an empty DSN")
 	}
 

--- a/internal/sentry/client.go
+++ b/internal/sentry/client.go
@@ -104,9 +104,9 @@ func initClient(cfg *config.Config, version string, transport sentry.Transport) 
 		},
 	}
 	if transport != nil {
-		opts.Transport = dropUnsafeEventTransport{delegate: transport}
+		opts.Transport = dropUnsafeEventTransport{delegate: transport, scrubber: scrubber}
 	} else {
-		opts.Transport = dropUnsafeEventTransport{delegate: sentry.NewHTTPTransport()}
+		opts.Transport = dropUnsafeEventTransport{delegate: sentry.NewHTTPTransport(), scrubber: scrubber}
 	}
 
 	err := sentry.Init(opts)
@@ -119,7 +119,8 @@ func initClient(cfg *config.Config, version string, transport sentry.Transport) 
 	return &Client{scrubber: scrubber, enabled: true}, nil
 }
 
-// CaptureError sends an error event to Sentry (scrubbed by BeforeSend).
+// CaptureError sends an error event to Sentry (scrubbed by BeforeSend and the
+// transport guard).
 // context.Canceled is dropped because it signals normal shutdown propagation
 // (SIGINT, parent exit, session end), not a failure worth paging on.
 // Expected operational errors (e.g. a listener bind hitting EADDRINUSE on a
@@ -149,7 +150,8 @@ func isExpectedOperationalError(err error) bool {
 	return errors.Is(err, syscall.EADDRINUSE)
 }
 
-// CaptureMessage sends a message event to Sentry (scrubbed by BeforeSend).
+// CaptureMessage sends a message event to Sentry (scrubbed by BeforeSend and
+// the transport guard).
 func (c *Client) CaptureMessage(msg string) {
 	if c == nil || !c.enabled {
 		return
@@ -191,6 +193,7 @@ func (c *Client) Close() {
 // sentry-go, so the transport is the last in-process choke point.
 type dropUnsafeEventTransport struct {
 	delegate sentry.Transport
+	scrubber *Scrubber
 }
 
 func (t dropUnsafeEventTransport) Configure(options sentry.ClientOptions) {
@@ -203,7 +206,11 @@ func (t dropUnsafeEventTransport) SendEvent(event *sentry.Event) {
 	if event == nil || isUnsafeEventType(event) || t.delegate == nil {
 		return
 	}
-	t.delegate.SendEvent(event)
+	safe := t.scrubber.ScrubEvent(event, nil)
+	if safe == nil || isUnsafeEventType(safe) {
+		return
+	}
+	t.delegate.SendEvent(safe)
 }
 
 func (t dropUnsafeEventTransport) Flush(timeout time.Duration) bool {

--- a/internal/sentry/client.go
+++ b/internal/sentry/client.go
@@ -230,12 +230,7 @@ func (t dropUnsafeEventTransport) FlushWithContext(ctx context.Context) bool {
 	if t.delegate == nil {
 		return true
 	}
-	if flusher, ok := t.delegate.(interface {
-		FlushWithContext(context.Context) bool
-	}); ok {
-		return flusher.FlushWithContext(ctx)
-	}
-	return t.delegate.Flush(0)
+	return t.delegate.FlushWithContext(ctx)
 }
 
 func (t dropUnsafeEventTransport) Close() {

--- a/internal/sentry/client_test.go
+++ b/internal/sentry/client_test.go
@@ -21,18 +21,26 @@ const testDSN = "https://examplePublicKey@o0.ingest.sentry.io/0"
 
 // mockTransport captures events sent through the Sentry SDK.
 type mockTransport struct {
-	mu     sync.Mutex
-	events []*sentry.Event
+	mu                    sync.Mutex
+	events                []*sentry.Event
+	flushCalls            int
+	flushWithContextCalls int
 }
 
 func (t *mockTransport) Configure(_ sentry.ClientOptions) {}
 func (t *mockTransport) Close()                           {}
 
 func (t *mockTransport) Flush(_ time.Duration) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.flushCalls++
 	return true
 }
 
 func (t *mockTransport) FlushWithContext(_ context.Context) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.flushWithContextCalls++
 	return true
 }
 
@@ -48,6 +56,12 @@ func (t *mockTransport) Events() []*sentry.Event {
 	cp := make([]*sentry.Event, len(t.events))
 	copy(cp, t.events)
 	return cp
+}
+
+func (t *mockTransport) FlushCalls() (int, int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.flushCalls, t.flushWithContextCalls
 }
 
 // initTestClient creates an enabled client with a mock transport.
@@ -574,6 +588,23 @@ func TestTransportGuard_SanitizesNormalEvents(t *testing.T) {
 		if strings.Contains(raw, forbidden) {
 			t.Fatalf("transport guard leaked %q in %+v", forbidden, event)
 		}
+	}
+}
+
+func TestTransportGuard_FlushWithContextDelegates(t *testing.T) {
+	if !(dropUnsafeEventTransport{}).FlushWithContext(context.Background()) {
+		t.Fatal("nil delegate FlushWithContext should be a successful no-op")
+	}
+
+	transport := &mockTransport{}
+	guard := dropUnsafeEventTransport{delegate: transport}
+	if !guard.FlushWithContext(context.Background()) {
+		t.Fatal("expected delegated FlushWithContext to succeed")
+	}
+
+	flushCalls, flushWithContextCalls := transport.FlushCalls()
+	if flushCalls != 0 || flushWithContextCalls != 1 {
+		t.Fatalf("flush calls = %d, flush-with-context calls = %d; want 0 and 1", flushCalls, flushWithContextCalls)
 	}
 }
 

--- a/internal/sentry/client_test.go
+++ b/internal/sentry/client_test.go
@@ -54,6 +54,8 @@ func initTestClient(t *testing.T, dlpPatterns []config.DLPPattern) (*Client, *mo
 	t.Helper()
 	transport := &mockTransport{}
 	cfg := config.Defaults()
+	enabled := true
+	cfg.Sentry.Enabled = &enabled
 	cfg.Sentry.DSN = testDSN
 	cfg.DLP.Patterns = dlpPatterns
 	c, err := initClient(cfg, "test-version", transport)
@@ -80,7 +82,9 @@ func TestInit_DisabledReturnsNoOp(t *testing.T) {
 }
 
 func TestInit_EmptyDSNReturnsNoOp(t *testing.T) {
+	enabled := true
 	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
 	cfg.Sentry.DSN = ""
 	// Ensure SENTRY_DSN env is not set for this test.
 	t.Setenv("SENTRY_DSN", "")
@@ -94,7 +98,9 @@ func TestInit_EmptyDSNReturnsNoOp(t *testing.T) {
 }
 
 func TestInit_EnvDSNUsedWhenConfigEmpty(t *testing.T) {
+	enabled := true
 	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
 	cfg.Sentry.DSN = ""
 	// Set a valid-looking DSN via env. The Sentry SDK will accept it
 	// but won't actually connect in tests.
@@ -110,7 +116,9 @@ func TestInit_EnvDSNUsedWhenConfigEmpty(t *testing.T) {
 
 func TestInit_EnvDSNOverridesConfig(t *testing.T) {
 	envDSN := "https://envKey@o0.ingest.sentry.io/0"
+	enabled := true
 	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
 	cfg.Sentry.DSN = "https://configKey@o0.ingest.sentry.io/0"
 	t.Setenv("SENTRY_DSN", envDSN)
 
@@ -169,20 +177,15 @@ func TestAddBreadcrumbEnabledClient(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("events = %d, want 1", len(events))
 	}
-	if len(events[0].Breadcrumbs) != 1 {
-		t.Fatalf("breadcrumbs = %d, want 1", len(events[0].Breadcrumbs))
-	}
-	crumb := events[0].Breadcrumbs[0]
-	if crumb.Category != "license" || crumb.Message != "expiry warning" || crumb.Level != sentry.Level("warn") {
-		t.Fatalf("breadcrumb = %+v, want license warning", crumb)
-	}
-	if crumb.Data["threshold_days"] != "7" || crumb.Data["days_remaining"] != "6" {
-		t.Fatalf("breadcrumb data = %+v, want warning band data", crumb.Data)
+	if len(events[0].Breadcrumbs) != 0 {
+		t.Fatalf("breadcrumbs = %d, want 0", len(events[0].Breadcrumbs))
 	}
 }
 
 func TestInit_InvalidDSNReturnsError(t *testing.T) {
+	enabled := true
 	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
 	cfg.Sentry.DSN = "not-a-valid-dsn"
 	c, err := Init(cfg, "test")
 	if err == nil {
@@ -194,7 +197,9 @@ func TestInit_InvalidDSNReturnsError(t *testing.T) {
 }
 
 func TestInit_ScrubberPopulated(t *testing.T) {
+	enabled := true
 	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
 	cfg.Sentry.DSN = testDSN
 	cfg.DLP.Patterns = testDLPPatterns()
 	c, err := Init(cfg, "test")
@@ -211,7 +216,9 @@ func TestInit_ScrubberPopulated(t *testing.T) {
 }
 
 func TestInit_EnvSecretsCollected(t *testing.T) {
+	enabled := true
 	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
 	cfg.Sentry.DSN = testDSN
 	cfg.DLP.ScanEnv = true
 	t.Setenv("PIPELOCK_TEST_SECRET", "this-is-a-long-enough-secret")
@@ -225,7 +232,9 @@ func TestInit_EnvSecretsCollected(t *testing.T) {
 }
 
 func TestInit_EnvSecretsSkippedWhenScanEnvFalse(t *testing.T) {
+	enabled := true
 	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
 	cfg.Sentry.DSN = testDSN
 	cfg.DLP.ScanEnv = false
 	c, err := Init(cfg, "test")
@@ -349,7 +358,9 @@ func TestInit_FileSecretsLoaded(t *testing.T) {
 	}
 
 	transport := &mockTransport{}
+	enabled := true
 	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
 	cfg.Sentry.DSN = testDSN
 	cfg.DLP.ScanEnv = false
 	cfg.DLP.SecretsFile = secretsFile
@@ -387,7 +398,9 @@ func TestInit_FileSecretsLoaded(t *testing.T) {
 
 func TestInit_FileSecretsFileNotFound_WarnsAndContinues(t *testing.T) {
 	transport := &mockTransport{}
+	enabled := true
 	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
 	cfg.Sentry.DSN = testDSN
 	cfg.DLP.SecretsFile = "/nonexistent/secrets.txt"
 	c, err := initClient(cfg, "test", transport)
@@ -422,5 +435,72 @@ func TestBeforeSend_ScrubEventCalled(t *testing.T) {
 	}
 	if e.Request != nil {
 		t.Error("BeforeSend did not wipe Request")
+	}
+}
+
+func TestInit_DefaultOmittedDisabledEvenWithDSN(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Sentry.DSN = testDSN
+
+	c, err := Init(cfg, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.enabled {
+		t.Error("expected disabled client when sentry.enabled is omitted")
+	}
+}
+
+func TestInit_ExplicitTrueWithDSNEnabled(t *testing.T) {
+	enabled := true
+	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
+	cfg.Sentry.DSN = testDSN
+
+	transport := &mockTransport{}
+	c, err := initClient(cfg, "test", transport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !c.enabled {
+		t.Fatal("expected enabled client")
+	}
+}
+
+func TestInit_SampleRateZeroRejectedWhenEnabled(t *testing.T) {
+	enabled := true
+	zero := 0.0
+	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
+	cfg.Sentry.DSN = testDSN
+	cfg.Sentry.SampleRate = &zero
+
+	_, err := initClient(cfg, "test", &mockTransport{})
+	if err == nil || !strings.Contains(err.Error(), "sample_rate 0.0") {
+		t.Fatalf("expected sample_rate 0.0 rejection, got %v", err)
+	}
+}
+
+func TestEventTypes_DroppedBeforeTransport(t *testing.T) {
+	c, transport := initTestClient(t, nil)
+	defer c.Close()
+
+	sentry.CaptureEvent(&sentry.Event{
+		Type:        "transaction",
+		Transaction: "GET /private",
+		Spans:       []*sentry.Span{{Description: "https://api.vendor.example/private"}},
+	})
+	sentry.CaptureEvent(&sentry.Event{
+		Type: "log",
+		Logs: []sentry.Log{{Body: "log body that must not ship"}},
+	})
+	sentry.CaptureCheckIn(&sentry.CheckIn{
+		MonitorSlug: "private-monitor",
+		Status:      sentry.CheckInStatusOK,
+	}, nil)
+	_ = c.Flush(2 * time.Second)
+
+	if events := transport.Events(); len(events) != 0 {
+		t.Fatalf("expected transaction/log/check-in events to be dropped, got %d", len(events))
 	}
 }

--- a/internal/sentry/client_test.go
+++ b/internal/sentry/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -502,5 +503,57 @@ func TestEventTypes_DroppedBeforeTransport(t *testing.T) {
 
 	if events := transport.Events(); len(events) != 0 {
 		t.Fatalf("expected transaction/log/check-in events to be dropped, got %d", len(events))
+	}
+}
+
+func TestTransportGuard_SanitizesNormalEvents(t *testing.T) {
+	transport := &mockTransport{}
+	guard := dropUnsafeEventTransport{
+		delegate: transport,
+		scrubber: NewScrubber(testDLPPatterns(), []string{
+			testEnvSecret,
+		}),
+	}
+
+	guard.SendEvent(&sentry.Event{
+		Message:    "failed for " + fakeURLWithUserinfo("user", testEnvSecret, "internal-host.example", "/private"),
+		ServerName: "agent-prod-01.internal",
+		User:       sentry.User{ID: "agent-user"},
+		Request:    &sentry.Request{URL: "https://internal-host.example/private"},
+		Breadcrumbs: []*sentry.Breadcrumb{
+			{Message: "visited /private"},
+		},
+		Exception: []sentry.Exception{{
+			Type:  "PathError",
+			Value: "open /home/agent/private.yaml: " + testAWSKeyID,
+		}},
+	})
+
+	events := transport.Events()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1 sanitized event", len(events))
+	}
+	event := events[0]
+	if event.ServerName != "" || event.User.ID != "" || event.Request != nil || len(event.Breadcrumbs) != 0 {
+		t.Fatalf("unsafe fields survived transport guard: %+v", event)
+	}
+	raw := fmt.Sprintf("%+v", event)
+	for _, forbidden := range []string{"user", testEnvSecret, "internal-host.example", "/private", "/home/agent", testAWSKeyID} {
+		if strings.Contains(raw, forbidden) {
+			t.Fatalf("transport guard leaked %q in %+v", forbidden, event)
+		}
+	}
+}
+
+func TestTransportGuard_DropsSanitizerPanic(t *testing.T) {
+	transport := &mockTransport{}
+	guard := dropUnsafeEventTransport{
+		delegate: transport,
+		scrubber: &Scrubber{patterns: []*regexp.Regexp{nil}},
+	}
+
+	guard.SendEvent(&sentry.Event{Message: "panic path"})
+	if events := transport.Events(); len(events) != 0 {
+		t.Fatalf("expected sanitizer panic to drop event, got %d", len(events))
 	}
 }

--- a/internal/sentry/client_test.go
+++ b/internal/sentry/client_test.go
@@ -243,6 +243,34 @@ func TestInit_InvalidDSNReturnsError(t *testing.T) {
 	}
 }
 
+func TestInit_InvalidDSNClearsStaleGlobalClient(t *testing.T) {
+	t.Cleanup(func() {
+		sentry.CurrentHub().BindClient(nil)
+	})
+	t.Setenv("SENTRY_DSN", "")
+
+	staleTransport := &mockTransport{}
+	enabled := true
+	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
+	cfg.Sentry.DSN = testDSN
+	if _, err := initClient(cfg, "test", staleTransport); err != nil {
+		t.Fatalf("enable stale client: %v", err)
+	}
+
+	cfg.Sentry.DSN = "not-a-valid-dsn"
+	if c, err := Init(cfg, "test"); err == nil || c != nil {
+		t.Fatalf("invalid dsn init = (%+v, %v), want nil client and error", c, err)
+	}
+
+	if id := sentry.CaptureMessage("must not reach stale transport"); id != nil {
+		t.Fatalf("package-level capture returned event id after failed init: %s", *id)
+	}
+	if events := staleTransport.Events(); len(events) != 0 {
+		t.Fatalf("stale global client captured %d event(s) after failed init", len(events))
+	}
+}
+
 func TestInit_ScrubberPopulated(t *testing.T) {
 	enabled := true
 	cfg := config.Defaults()

--- a/internal/sentry/client_test.go
+++ b/internal/sentry/client_test.go
@@ -82,6 +82,38 @@ func TestInit_DisabledReturnsNoOp(t *testing.T) {
 	}
 }
 
+func TestInit_DisabledClearsStaleGlobalClient(t *testing.T) {
+	t.Cleanup(func() {
+		sentry.CurrentHub().BindClient(nil)
+	})
+
+	staleTransport := &mockTransport{}
+	enabled := true
+	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
+	cfg.Sentry.DSN = testDSN
+	if _, err := initClient(cfg, "test", staleTransport); err != nil {
+		t.Fatalf("enable stale client: %v", err)
+	}
+
+	disabled := false
+	cfg.Sentry.Enabled = &disabled
+	c, err := Init(cfg, "test")
+	if err != nil {
+		t.Fatalf("disabled init: %v", err)
+	}
+	if c.enabled {
+		t.Fatal("expected disabled client")
+	}
+
+	if id := sentry.CaptureMessage("must not reach stale transport"); id != nil {
+		t.Fatalf("package-level capture returned event id after disabled init: %s", *id)
+	}
+	if events := staleTransport.Events(); len(events) != 0 {
+		t.Fatalf("stale global client captured %d event(s) after disabled init", len(events))
+	}
+}
+
 func TestInit_EmptyDSNReturnsNoOp(t *testing.T) {
 	enabled := true
 	cfg := config.Defaults()

--- a/internal/sentry/client_test.go
+++ b/internal/sentry/client_test.go
@@ -528,6 +528,34 @@ func TestInit_SampleRateZeroRejectedWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestInit_SampleRateZeroClearsStaleGlobalClient(t *testing.T) {
+	t.Cleanup(func() {
+		sentry.CurrentHub().BindClient(nil)
+	})
+
+	staleTransport := &mockTransport{}
+	enabled := true
+	cfg := config.Defaults()
+	cfg.Sentry.Enabled = &enabled
+	cfg.Sentry.DSN = testDSN
+	if _, err := initClient(cfg, "test", staleTransport); err != nil {
+		t.Fatalf("enable stale client: %v", err)
+	}
+
+	zero := 0.0
+	cfg.Sentry.SampleRate = &zero
+	if _, err := initClient(cfg, "test", &mockTransport{}); err == nil || !strings.Contains(err.Error(), "sample_rate 0.0") {
+		t.Fatalf("expected sample_rate 0.0 rejection, got %v", err)
+	}
+
+	if id := sentry.CaptureMessage("must not reach stale transport"); id != nil {
+		t.Fatalf("package-level capture returned event id after rejected init: %s", *id)
+	}
+	if events := staleTransport.Events(); len(events) != 0 {
+		t.Fatalf("stale global client captured %d event(s) after rejected init", len(events))
+	}
+}
+
 func TestEventTypes_DroppedBeforeTransport(t *testing.T) {
 	c, transport := initTestClient(t, nil)
 	defer c.Close()

--- a/internal/sentry/scrub.go
+++ b/internal/sentry/scrub.go
@@ -3,7 +3,6 @@
 package plsentry
 
 import (
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -93,38 +92,11 @@ func (s *Scrubber) ScrubString(input string) string {
 		return input
 	}
 
-	result := input
-
-	// Drop locators before generic matching so composite forms like
-	// user:pass@host are removed as one unit instead of leaving the username
-	// behind after email/FQDN matching.
-	result = urlLikeRe.ReplaceAllString(result, "${1}://"+redacted)
-	result = protocolRelativeURLRe.ReplaceAllString(result, "${1}//"+redacted)
-	result = scrubDeploymentLocators(result)
-
-	// Shared matcher surface: typed secret classes from internal/redact.
+	var matchFn func(string) []redact.Match
 	if s.matcher != nil {
-		result = replaceMatchedSpans(result, s.matcher.Scan(result), func(redact.Match) string { return redacted })
+		matchFn = s.matcher.Scan
 	}
-
-	// Safety-net patterns stay separate: they intentionally cover cases not
-	// yet modelled in the redact class registry (Bearer headers, URL auth).
-	for _, re := range s.patterns {
-		result = re.ReplaceAllString(result, redacted)
-	}
-
-	// Redact known env secret values.
-	for _, secret := range s.secrets {
-		if secret != "" && strings.Contains(result, secret) {
-			result = strings.ReplaceAll(result, secret, redacted)
-		}
-	}
-
-	// Redact URL query parameter values.
-	result = urlParamValueRe.ReplaceAllString(result, "${1}="+redacted)
-	result = secretAssignmentValueRe.ReplaceAllString(result, "${1}"+redacted)
-
-	return result
+	return s.applyRedactionPipeline(input, matchFn)
 }
 
 func scrubDeploymentLocators(input string) string {
@@ -171,18 +143,40 @@ func (s *Scrubber) safeScrubCodeString(input string) string {
 	if s == nil {
 		return ""
 	}
-	result := urlLikeRe.ReplaceAllString(input, "${1}://"+redacted)
+	return s.applyRedactionPipeline(input, s.sensitiveCodeMatches)
+}
+
+func (s *Scrubber) applyRedactionPipeline(input string, matchFn func(string) []redact.Match) string {
+	result := input
+
+	// Drop locators before generic matching so composite forms like
+	// user:pass@host are removed as one unit instead of leaving the username
+	// behind after email/FQDN matching.
+	result = urlLikeRe.ReplaceAllString(result, "${1}://"+redacted)
 	result = protocolRelativeURLRe.ReplaceAllString(result, "${1}//"+redacted)
 	result = scrubDeploymentLocators(result)
-	result = replaceMatchedSpans(result, s.sensitiveCodeMatches(result), func(redact.Match) string { return redacted })
+
+	// Shared matcher surface: typed secret classes from internal/redact. The
+	// caller chooses the full string scanner or the narrower code-identifier
+	// scanner, but the rest of the redaction order stays shared.
+	if matchFn != nil {
+		result = replaceMatchedSpans(result, matchFn(result), func(redact.Match) string { return redacted })
+	}
+
+	// Safety-net patterns stay separate: they intentionally cover cases not
+	// yet modelled in the redact class registry (Bearer headers, URL auth).
 	for _, re := range s.patterns {
 		result = re.ReplaceAllString(result, redacted)
 	}
+
+	// Redact known env secret values.
 	for _, secret := range s.secrets {
 		if secret != "" && strings.Contains(result, secret) {
 			result = strings.ReplaceAll(result, secret, redacted)
 		}
 	}
+
+	// Redact URL query parameter values and key/value-style secret payloads.
 	result = urlParamValueRe.ReplaceAllString(result, "${1}="+redacted)
 	result = secretAssignmentValueRe.ReplaceAllString(result, "${1}"+redacted)
 	return result
@@ -209,7 +203,7 @@ func (s *Scrubber) safeScrubFilename(input string) string {
 	if s == nil {
 		return ""
 	}
-	result := codePathLeaf(filepath.Base(input))
+	result := codePathLeaf(input)
 	return s.safeScrubCodeString(result)
 }
 

--- a/internal/sentry/scrub.go
+++ b/internal/sentry/scrub.go
@@ -31,6 +31,10 @@ const redacted = "[REDACTED]"
 // urlParamValueRe matches query parameter values in URL-like strings.
 var urlParamValueRe = regexp.MustCompile(`([?&][^=&]+)=([^&\s]+)`)
 
+// secretAssignmentValueRe catches key/value payloads that can appear in
+// basename-like frame strings without URL delimiters.
+var secretAssignmentValueRe = regexp.MustCompile(`(?i)\b((?:[A-Za-z0-9_-]*-)?(?:api[_-]?key|token|secret|password|passwd|pwd|credential|session)[A-Za-z0-9_-]*=)[^\s"'<>/\\?&]+`)
+
 // urlLikeRe matches URL-bearing text. Sentry crash payloads do not need hosts,
 // userinfo, paths, or query values; keep only the coarse scheme.
 var urlLikeRe = regexp.MustCompile(`\b([a-zA-Z][a-zA-Z0-9+.-]*)://[^\s"'<>]+`)
@@ -118,6 +122,7 @@ func (s *Scrubber) ScrubString(input string) string {
 
 	// Redact URL query parameter values.
 	result = urlParamValueRe.ReplaceAllString(result, "${1}="+redacted)
+	result = secretAssignmentValueRe.ReplaceAllString(result, "${1}"+redacted)
 
 	return result
 }
@@ -178,6 +183,8 @@ func (s *Scrubber) safeScrubCodeString(input string) string {
 			result = strings.ReplaceAll(result, secret, redacted)
 		}
 	}
+	result = urlParamValueRe.ReplaceAllString(result, "${1}="+redacted)
+	result = secretAssignmentValueRe.ReplaceAllString(result, "${1}"+redacted)
 	return result
 }
 

--- a/internal/sentry/scrub.go
+++ b/internal/sentry/scrub.go
@@ -269,7 +269,7 @@ func (s *Scrubber) ScrubEvent(event *sentry.Event, _ *sentry.EventHint) (safe *s
 		Level:     event.Level,
 		Release:   s.safeScrubString(event.Release),
 		Message:   s.safeScrubString(event.Message),
-		Platform:  "go/" + runtime.GOOS + "/" + runtime.GOARCH,
+		Platform:  "go/" + runtime.GOOS,
 	}
 
 	if len(event.Exception) > 0 {

--- a/internal/sentry/scrub.go
+++ b/internal/sentry/scrub.go
@@ -1,5 +1,5 @@
-// Package plsentry provides Sentry error reporting with secret redaction.
-// All error data is scrubbed through DLP patterns before leaving the process.
+// Package plsentry provides opt-in Sentry error reporting with event minimization.
+// Events are structurally allowlisted and scrubbed before leaving the process.
 package plsentry
 
 import (
@@ -35,6 +35,10 @@ var urlParamValueRe = regexp.MustCompile(`([?&][^=&]+)=([^&\s]+)`)
 // userinfo, paths, or query values; keep only the coarse scheme.
 var urlLikeRe = regexp.MustCompile(`\b([a-zA-Z][a-zA-Z0-9+.-]*)://[^\s"'<>]+`)
 
+// protocolRelativeURLRe catches parse-error strings such as
+// "//host/private/path" that do not have a scheme for urlLikeRe to anchor on.
+var protocolRelativeURLRe = regexp.MustCompile(`(^|[^:])//[^\s"'<>]+`)
+
 // Filesystem paths and bare network identifiers commonly appear in Go error
 // strings. They are deployment/agent-local data, so surviving diagnostic
 // strings keep only coarse redaction markers.
@@ -42,10 +46,11 @@ var (
 	unixAbsPathRe      = regexp.MustCompile(`(^|[\s"'(=:])(/(?:[^/\s"'<>:]+/)+[^/\s"'<>:]*)`)
 	windowsAbsPathRe   = regexp.MustCompile(`(?i)\b[A-Z]:\\[^\s"'<>]+`)
 	uncPathRe          = regexp.MustCompile(`\\\\[^\s"'<>\\]+\\[^\s"'<>]+`)
-	userinfoEndpointRe = regexp.MustCompile(`[A-Za-z0-9._~-]+:[^\s"'<>/@]+@(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::\d{1,5})?`)
-	ipv4EndpointRe     = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?\b`)
-	ipv6EndpointRe     = regexp.MustCompile(`\[[0-9A-Fa-f:.]+\](?::\d{1,5})?`)
-	fqdnEndpointRe     = regexp.MustCompile(`(?i)\b((?:lookup|host|server|upstream|endpoint|address|addr|for|not|on|to|from|tcp|udp|connect(?:ing)?(?:\s+to)?|dial(?:ing)?(?:\s+tcp|\s+udp)?)\s+)(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}(?::\d{1,5})?\b`)
+	userinfoEndpointRe = regexp.MustCompile(`[A-Za-z0-9._~-]+:[^\s"'<>/@]+@(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::\d{1,5})?(?:/[^\s"'<>]*)?`)
+	ipv4EndpointRe     = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?(?:/[^\s"'<>]*)?\b`)
+	ipv6EndpointRe     = regexp.MustCompile(`\[[0-9A-Fa-f:.]+\](?::\d{1,5})?(?:/[^\s"'<>]*)?`)
+	bareFQDNPathRe     = regexp.MustCompile(`(?i)\b(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}(?::\d{1,5})?/[^/\s"'<>][^\s"'<>]*`)
+	fqdnEndpointRe     = regexp.MustCompile(`(?i)\b((?:lookup|host|server|upstream|endpoint|address|addr|for|not|on|to|from|tcp|udp|connect(?:ing)?(?:\s+to)?|dial(?:ing)?(?:\s+tcp|\s+udp)?)\s+)(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}(?::\d{1,5})?(?:/[^\s"'<>]*)?\b`)
 )
 
 // Scrubber redacts secrets from strings and Sentry events using
@@ -90,6 +95,7 @@ func (s *Scrubber) ScrubString(input string) string {
 	// user:pass@host are removed as one unit instead of leaving the username
 	// behind after email/FQDN matching.
 	result = urlLikeRe.ReplaceAllString(result, "${1}://"+redacted)
+	result = protocolRelativeURLRe.ReplaceAllString(result, "${1}//"+redacted)
 	result = scrubDeploymentLocators(result)
 
 	// Shared matcher surface: typed secret classes from internal/redact.
@@ -123,6 +129,7 @@ func scrubDeploymentLocators(input string) string {
 	result = userinfoEndpointRe.ReplaceAllString(result, redacted)
 	result = ipv6EndpointRe.ReplaceAllString(result, redacted)
 	result = ipv4EndpointRe.ReplaceAllString(result, redacted)
+	result = bareFQDNPathRe.ReplaceAllString(result, redacted)
 	result = fqdnEndpointRe.ReplaceAllString(result, "${1}"+redacted)
 	return result
 }
@@ -160,6 +167,7 @@ func (s *Scrubber) safeScrubCodeString(input string) string {
 		return ""
 	}
 	result := urlLikeRe.ReplaceAllString(input, "${1}://"+redacted)
+	result = protocolRelativeURLRe.ReplaceAllString(result, "${1}//"+redacted)
 	result = scrubDeploymentLocators(result)
 	result = replaceMatchedSpans(result, s.sensitiveCodeMatches(result), func(redact.Match) string { return redacted })
 	for _, re := range s.patterns {

--- a/internal/sentry/scrub.go
+++ b/internal/sentry/scrub.go
@@ -3,7 +3,9 @@
 package plsentry
 
 import (
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/getsentry/sentry-go"
@@ -28,6 +30,10 @@ const redacted = "[REDACTED]"
 
 // urlParamValueRe matches query parameter values in URL-like strings.
 var urlParamValueRe = regexp.MustCompile(`([?&][^=&]+)=([^&\s]+)`)
+
+// urlLikeRe matches URL-bearing text. Sentry crash payloads do not need hosts,
+// userinfo, paths, or query values; keep only the coarse scheme.
+var urlLikeRe = regexp.MustCompile(`\b([a-zA-Z][a-zA-Z0-9+.-]*)://[^\s"'<>]+`)
 
 // Scrubber redacts secrets from strings and Sentry events using
 // DLP patterns from config plus hardcoded safety-net patterns.
@@ -85,6 +91,10 @@ func (s *Scrubber) ScrubString(input string) string {
 		}
 	}
 
+	// Drop URL authority/path/query by construction. Query redaction below is
+	// retained as defense in depth for URL-ish fragments this regex misses.
+	result = urlLikeRe.ReplaceAllString(result, "${1}://"+redacted)
+
 	// Redact URL query parameter values.
 	result = urlParamValueRe.ReplaceAllString(result, "${1}="+redacted)
 
@@ -112,96 +122,104 @@ func replaceMatchedSpans(input string, matches []redact.Match, replacement func(
 	return b.String()
 }
 
-// scrubStacktrace redacts secrets in stacktrace frame variables.
-// Shared by exception and thread scrubbing paths.
-func (s *Scrubber) scrubStacktrace(st *sentry.Stacktrace) {
-	if st == nil {
-		return
+func (s *Scrubber) safeScrubString(input string) string {
+	if s == nil {
+		return ""
 	}
-	for i := range st.Frames {
-		for k, v := range st.Frames[i].Vars {
-			if sv, ok := v.(string); ok {
-				st.Frames[i].Vars[k] = s.ScrubString(sv)
-			} else {
-				// Fail-closed: delete non-string vars rather than
-				// risk leaking secrets in serialized form.
-				delete(st.Frames[i].Vars, k)
-			}
-		}
-	}
+	return s.ScrubString(input)
 }
 
-// ScrubEvent scrubs all string fields in a Sentry event before transmission.
+func (s *Scrubber) safeScrubFilename(input string) string {
+	if s == nil {
+		return ""
+	}
+	result := filepath.Base(input)
+	for _, re := range s.patterns {
+		result = re.ReplaceAllString(result, redacted)
+	}
+	for _, secret := range s.secrets {
+		if secret != "" && strings.Contains(result, secret) {
+			result = strings.ReplaceAll(result, secret, redacted)
+		}
+	}
+	return result
+}
+
+// scrubStacktrace returns a minimized copy of a stacktrace. It keeps only
+// package/function/file-basename/line and drops vars, abs_path, context lines,
+// addresses, package images, and frame-local data.
+func (s *Scrubber) scrubStacktrace(st *sentry.Stacktrace) *sentry.Stacktrace {
+	if st == nil {
+		return nil
+	}
+
+	frames := make([]sentry.Frame, 0, len(st.Frames))
+	for i := range st.Frames {
+		frame := st.Frames[i]
+		safeFrame := sentry.Frame{
+			Function: s.safeScrubString(frame.Function),
+			Module:   s.safeScrubString(frame.Module),
+			Filename: s.safeScrubFilename(frame.Filename),
+			Lineno:   frame.Lineno,
+		}
+		frames = append(frames, safeFrame)
+	}
+	return &sentry.Stacktrace{Frames: frames}
+}
+
+// ScrubEvent returns a minimized allowlisted Sentry event before transmission.
 // This is used as the BeforeSend hook in sentry.ClientOptions.
 //
-// Fail-closed: non-string interface{} values in Breadcrumbs.Data, Contexts,
-// and Stacktrace.Vars are deleted rather than passed through unscrubbed.
-func (s *Scrubber) ScrubEvent(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+// Fail-closed: any sanitizer panic drops the event rather than risking a raw
+// event. This is deliberately structural: request, user, server_name,
+// breadcrumbs, tags, contexts, modules, debug meta, attachments, spans, logs,
+// metrics, frame vars, abs_path, and source context lines are omitted by
+// construction.
+func (s *Scrubber) ScrubEvent(event *sentry.Event, _ *sentry.EventHint) (safe *sentry.Event) {
+	defer func() {
+		if recover() != nil {
+			safe = nil
+		}
+	}()
+
 	if event == nil {
 		return nil
 	}
 
-	// Scrub message.
-	event.Message = s.ScrubString(event.Message)
-
-	// Scrub transaction name (can contain URL paths with tokens).
-	event.Transaction = s.ScrubString(event.Transaction)
-
-	// Scrub fingerprint strings.
-	for i, fp := range event.Fingerprint {
-		event.Fingerprint[i] = s.ScrubString(fp)
+	safe = &sentry.Event{
+		EventID:   event.EventID,
+		Timestamp: event.Timestamp,
+		Level:     event.Level,
+		Release:   s.safeScrubString(event.Release),
+		Message:   s.safeScrubString(event.Message),
+		Platform:  "go/" + runtime.GOOS + "/" + runtime.GOARCH,
 	}
 
-	// Scrub exceptions - both Type and Value can contain secrets.
-	for i := range event.Exception {
-		event.Exception[i].Type = s.ScrubString(event.Exception[i].Type)
-		event.Exception[i].Value = s.ScrubString(event.Exception[i].Value)
-		s.scrubStacktrace(event.Exception[i].Stacktrace)
-	}
-
-	// Scrub threads - same Stacktrace structure as exceptions.
-	for i := range event.Threads {
-		s.scrubStacktrace(event.Threads[i].Stacktrace)
-	}
-
-	// Scrub breadcrumbs.
-	for i := range event.Breadcrumbs {
-		event.Breadcrumbs[i].Message = s.ScrubString(event.Breadcrumbs[i].Message)
-		for k, v := range event.Breadcrumbs[i].Data {
-			if sv, ok := v.(string); ok {
-				event.Breadcrumbs[i].Data[k] = s.ScrubString(sv)
-			} else {
-				delete(event.Breadcrumbs[i].Data, k)
-			}
+	if len(event.Exception) > 0 {
+		safe.Exception = make([]sentry.Exception, 0, len(event.Exception))
+		for i := range event.Exception {
+			exception := event.Exception[i]
+			safe.Exception = append(safe.Exception, sentry.Exception{
+				Type:       s.safeScrubString(exception.Type),
+				Value:      s.safeScrubString(exception.Value),
+				Stacktrace: s.scrubStacktrace(exception.Stacktrace),
+			})
 		}
 	}
 
-	// Scrub tags.
-	for k, v := range event.Tags {
-		event.Tags[k] = s.ScrubString(v)
-	}
-
-	// Scrub contexts - auto-populated with device/os/runtime info (ints,
-	// bools for OS/device/runtime) but custom contexts could contain secrets.
-	// Fail-closed: delete non-string values to prevent serialization leaks.
-	for ctxName, ctx := range event.Contexts {
-		for k, v := range ctx {
-			if sv, ok := v.(string); ok {
-				event.Contexts[ctxName][k] = s.ScrubString(sv)
-			} else {
-				delete(event.Contexts[ctxName], k)
+	if len(safe.Exception) == 0 && safe.Message == "" {
+		for i := range event.Threads {
+			if event.Threads[i].Stacktrace == nil {
+				continue
 			}
+			safe.Exception = append(safe.Exception, sentry.Exception{
+				Type:       "thread",
+				Value:      "stacktrace",
+				Stacktrace: s.scrubStacktrace(event.Threads[i].Stacktrace),
+			})
 		}
 	}
 
-	// Wipe request entirely - URLs, headers, body all dangerous.
-	event.Request = nil
-
-	// Wipe user - IP could identify targets.
-	event.User = sentry.User{}
-
-	// Wipe server name - reveals internal infrastructure hostname.
-	event.ServerName = ""
-
-	return event
+	safe.MakeSerializationSafe()
+	return safe
 }

--- a/internal/sentry/scrub.go
+++ b/internal/sentry/scrub.go
@@ -35,6 +35,19 @@ var urlParamValueRe = regexp.MustCompile(`([?&][^=&]+)=([^&\s]+)`)
 // userinfo, paths, or query values; keep only the coarse scheme.
 var urlLikeRe = regexp.MustCompile(`\b([a-zA-Z][a-zA-Z0-9+.-]*)://[^\s"'<>]+`)
 
+// Filesystem paths and bare network identifiers commonly appear in Go error
+// strings. They are deployment/agent-local data, so surviving diagnostic
+// strings keep only coarse redaction markers.
+var (
+	unixAbsPathRe      = regexp.MustCompile(`(^|[\s"'(=:])(/(?:[^/\s"'<>:]+/)+[^/\s"'<>:]*)`)
+	windowsAbsPathRe   = regexp.MustCompile(`(?i)\b[A-Z]:\\[^\s"'<>]+`)
+	uncPathRe          = regexp.MustCompile(`\\\\[^\s"'<>\\]+\\[^\s"'<>]+`)
+	userinfoEndpointRe = regexp.MustCompile(`[A-Za-z0-9._~-]+:[^\s"'<>/@]+@(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::\d{1,5})?`)
+	ipv4EndpointRe     = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?\b`)
+	ipv6EndpointRe     = regexp.MustCompile(`\[[0-9A-Fa-f:.]+\](?::\d{1,5})?`)
+	fqdnEndpointRe     = regexp.MustCompile(`(?i)\b((?:lookup|host|server|upstream|endpoint|address|addr|for|not|on|to|from|tcp|udp|connect(?:ing)?(?:\s+to)?|dial(?:ing)?(?:\s+tcp|\s+udp)?)\s+)(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}(?::\d{1,5})?\b`)
+)
+
 // Scrubber redacts secrets from strings and Sentry events using
 // DLP patterns from config plus hardcoded safety-net patterns.
 type Scrubber struct {
@@ -73,6 +86,12 @@ func (s *Scrubber) ScrubString(input string) string {
 
 	result := input
 
+	// Drop locators before generic matching so composite forms like
+	// user:pass@host are removed as one unit instead of leaving the username
+	// behind after email/FQDN matching.
+	result = urlLikeRe.ReplaceAllString(result, "${1}://"+redacted)
+	result = scrubDeploymentLocators(result)
+
 	// Shared matcher surface: typed secret classes from internal/redact.
 	if s.matcher != nil {
 		result = replaceMatchedSpans(result, s.matcher.Scan(result), func(redact.Match) string { return redacted })
@@ -91,13 +110,20 @@ func (s *Scrubber) ScrubString(input string) string {
 		}
 	}
 
-	// Drop URL authority/path/query by construction. Query redaction below is
-	// retained as defense in depth for URL-ish fragments this regex misses.
-	result = urlLikeRe.ReplaceAllString(result, "${1}://"+redacted)
-
 	// Redact URL query parameter values.
 	result = urlParamValueRe.ReplaceAllString(result, "${1}="+redacted)
 
+	return result
+}
+
+func scrubDeploymentLocators(input string) string {
+	result := unixAbsPathRe.ReplaceAllString(input, "${1}"+redacted)
+	result = windowsAbsPathRe.ReplaceAllString(result, redacted)
+	result = uncPathRe.ReplaceAllString(result, redacted)
+	result = userinfoEndpointRe.ReplaceAllString(result, redacted)
+	result = ipv6EndpointRe.ReplaceAllString(result, redacted)
+	result = ipv4EndpointRe.ReplaceAllString(result, redacted)
+	result = fqdnEndpointRe.ReplaceAllString(result, "${1}"+redacted)
 	return result
 }
 
@@ -129,11 +155,13 @@ func (s *Scrubber) safeScrubString(input string) string {
 	return s.ScrubString(input)
 }
 
-func (s *Scrubber) safeScrubFilename(input string) string {
+func (s *Scrubber) safeScrubCodeString(input string) string {
 	if s == nil {
 		return ""
 	}
-	result := filepath.Base(input)
+	result := urlLikeRe.ReplaceAllString(input, "${1}://"+redacted)
+	result = scrubDeploymentLocators(result)
+	result = replaceMatchedSpans(result, s.sensitiveCodeMatches(result), func(redact.Match) string { return redacted })
 	for _, re := range s.patterns {
 		result = re.ReplaceAllString(result, redacted)
 	}
@@ -141,6 +169,46 @@ func (s *Scrubber) safeScrubFilename(input string) string {
 		if secret != "" && strings.Contains(result, secret) {
 			result = strings.ReplaceAll(result, secret, redacted)
 		}
+	}
+	return result
+}
+
+func (s *Scrubber) sensitiveCodeMatches(input string) []redact.Match {
+	if s.matcher == nil {
+		return nil
+	}
+	matches := s.matcher.Scan(input)
+	filtered := matches[:0]
+	for _, match := range matches {
+		switch match.Class {
+		case redact.ClassIPv4, redact.ClassIPv6, redact.ClassCIDR, redact.ClassFQDN, redact.ClassEmail, redact.ClassMAC, redact.ClassADUser:
+			continue
+		default:
+			filtered = append(filtered, match)
+		}
+	}
+	return filtered
+}
+
+func (s *Scrubber) safeScrubFilename(input string) string {
+	if s == nil {
+		return ""
+	}
+	result := codePathLeaf(filepath.Base(input))
+	return s.safeScrubCodeString(result)
+}
+
+func (s *Scrubber) safeScrubCodePath(input string) string {
+	if s == nil {
+		return ""
+	}
+	return s.safeScrubCodeString(codePathLeaf(input))
+}
+
+func codePathLeaf(input string) string {
+	result := input
+	if idx := strings.LastIndexAny(result, `/\`); idx >= 0 && idx+1 < len(result) {
+		result = result[idx+1:]
 	}
 	return result
 }
@@ -157,8 +225,8 @@ func (s *Scrubber) scrubStacktrace(st *sentry.Stacktrace) *sentry.Stacktrace {
 	for i := range st.Frames {
 		frame := st.Frames[i]
 		safeFrame := sentry.Frame{
-			Function: s.safeScrubString(frame.Function),
-			Module:   s.safeScrubString(frame.Module),
+			Function: s.safeScrubCodePath(frame.Function),
+			Module:   s.safeScrubCodePath(frame.Module),
 			Filename: s.safeScrubFilename(frame.Filename),
 			Lineno:   frame.Lineno,
 		}

--- a/internal/sentry/scrub_test.go
+++ b/internal/sentry/scrub_test.go
@@ -184,6 +184,29 @@ func TestScrubString_DeploymentLocatorsDropped(t *testing.T) {
 	}
 }
 
+func TestRedactionPipeline_SharedStringAndCodeSurfaces(t *testing.T) {
+	s := NewScrubber(nil, []string{testEnvSecret})
+	input := "failed at " + fakeURLWithUserinfo("user", testEnvSecret, "internal-host.example", "/private") +
+		" api_key=novel-secret"
+
+	for name, scrub := range map[string]func(string) string{
+		"string": s.ScrubString,
+		"code":   s.safeScrubCodeString,
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := scrub(input)
+			for _, forbidden := range []string{"user", testEnvSecret, "internal-host.example", "/private", "novel-secret"} {
+				if strings.Contains(result, forbidden) {
+					t.Fatalf("%s surface leaked %q in %q", name, forbidden, result)
+				}
+			}
+			if !containsRedacted(result) {
+				t.Fatalf("%s surface result did not include redaction marker: %q", name, result)
+			}
+		})
+	}
+}
+
 func TestScrubEvent_AllowlistPayloadShape(t *testing.T) {
 	eventTime := time.Unix(1700000000, 0).UTC()
 	s := NewScrubber(testDLPPatterns(), nil)
@@ -323,6 +346,18 @@ func TestScrubEvent_FrameFilenameWindowsBasenameOnly(t *testing.T) {
 	frame := result.Exception[0].Stacktrace.Frames[0]
 	if frame.Filename != "private.go" {
 		t.Fatalf("filename = %q, want basename only", frame.Filename)
+	}
+}
+
+func TestSafeScrubFilename_UsesCrossPlatformLeaf(t *testing.T) {
+	s := NewScrubber(nil, nil)
+	key := "tok" + "en"
+	result := s.safeScrubFilename(`/home/agent/src/private.go?` + key + `=novel-secret`)
+	if strings.Contains(result, "/home/agent") || strings.Contains(result, "novel-secret") {
+		t.Fatalf("filename scrub leaked path or token payload in %q", result)
+	}
+	if !strings.Contains(result, "private.go?"+key+"="+redacted) {
+		t.Fatalf("filename scrub = %q, want basename with redacted token value", result)
 	}
 }
 

--- a/internal/sentry/scrub_test.go
+++ b/internal/sentry/scrub_test.go
@@ -158,8 +158,8 @@ func TestScrubEvent_AllowlistPayloadShape(t *testing.T) {
 						{
 							Function:    "runProxy",
 							Module:      "github.com/luckyPipewrench/pipelock/internal/cli/runtime",
-							Filename:    "/home/josh/dev/pipelock/internal/cli/runtime/mcp.go",
-							AbsPath:     "/home/josh/dev/pipelock/internal/cli/runtime/mcp.go",
+							Filename:    "/home/developer/project/internal/cli/runtime/mcp.go",
+							AbsPath:     "/home/developer/project/internal/cli/runtime/mcp.go",
 							Lineno:      1115,
 							ContextLine: "return upstreamURL.String()",
 							Vars:        map[string]interface{}{"upstream": fakeURLWithUserinfo("user", "secret", "host", "/p")},

--- a/internal/sentry/scrub_test.go
+++ b/internal/sentry/scrub_test.go
@@ -3,6 +3,7 @@ package plsentry
 import (
 	"encoding/json"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -255,6 +256,9 @@ func TestScrubEvent_AllowlistPayloadShape(t *testing.T) {
 	}
 	if result.EventID != event.EventID || !result.Timestamp.Equal(eventTime) || result.Level != sentry.LevelError || result.Release != "v1.2.3" {
 		t.Fatalf("safe scalar fields not preserved: %+v", result)
+	}
+	if result.Platform != "go/"+runtime.GOOS {
+		t.Fatalf("platform = %q, want coarse OS only", result.Platform)
 	}
 	if !containsRedacted(result.Message) || !containsRedacted(result.Exception[0].Type) || !containsRedacted(result.Exception[0].Value) {
 		t.Fatalf("expected surviving diagnostic strings to be scrubbed: %+v", result.Exception[0])

--- a/internal/sentry/scrub_test.go
+++ b/internal/sentry/scrub_test.go
@@ -128,6 +128,42 @@ func TestScrubString_URLAuthorityAndPathDropped(t *testing.T) {
 	}
 }
 
+func TestScrubString_DeploymentLocatorsDropped(t *testing.T) {
+	s := NewScrubber(nil, nil)
+	input := strings.Join([]string{
+		"open /home/agent/.config/pipelock/private.yaml: permission denied",
+		`open C:\Users\agent\AppData\Roaming\pipelock\private.yaml: access denied`,
+		`open \\fileserver\share\private.yaml: access denied`,
+		"dial tcp 10.0.0.12:8443: connect: connection refused",
+		"lookup internal-host.example on 10.0.0.2:53: no such host",
+		"x509: certificate is valid for private.service.internal, not public.vendor.example",
+		"dial tcp [fd00::10]:443: connect: network unreachable",
+		"proxy auth failed for deployer:novel-secret@private.service.internal:443",
+	}, "\n")
+
+	result := s.ScrubString(input)
+	for _, forbidden := range []string{
+		"/home/agent",
+		`C:\Users\agent`,
+		`\\fileserver\share`,
+		"10.0.0.12",
+		"10.0.0.2",
+		"internal-host.example",
+		"private.service.internal",
+		"public.vendor.example",
+		"fd00::10",
+		"deployer",
+		"novel-secret",
+	} {
+		if strings.Contains(result, forbidden) {
+			t.Fatalf("deployment locator %q leaked in %q", forbidden, result)
+		}
+	}
+	if !containsRedacted(result) {
+		t.Fatalf("expected redaction marker in %q", result)
+	}
+}
+
 func TestScrubEvent_AllowlistPayloadShape(t *testing.T) {
 	eventTime := time.Unix(1700000000, 0).UTC()
 	s := NewScrubber(testDLPPatterns(), nil)
@@ -156,7 +192,7 @@ func TestScrubEvent_AllowlistPayloadShape(t *testing.T) {
 				Stacktrace: &sentry.Stacktrace{
 					Frames: []sentry.Frame{
 						{
-							Function:    "runProxy",
+							Function:    "github.com/luckyPipewrench/pipelock/internal/cli/runtime.runProxy",
 							Module:      "github.com/luckyPipewrench/pipelock/internal/cli/runtime",
 							Filename:    "/home/developer/project/internal/cli/runtime/mcp.go",
 							AbsPath:     "/home/developer/project/internal/cli/runtime/mcp.go",
@@ -186,7 +222,7 @@ func TestScrubEvent_AllowlistPayloadShape(t *testing.T) {
 	}
 
 	frame := result.Exception[0].Stacktrace.Frames[0]
-	if frame.Filename != "mcp.go" || frame.Lineno != 1115 || frame.Function != "runProxy" {
+	if frame.Filename != "mcp.go" || frame.Lineno != 1115 || frame.Function != "runtime.runProxy" || frame.Module != "runtime" {
 		t.Fatalf("safe frame fields not preserved: %+v", frame)
 	}
 	if frame.AbsPath != "" || frame.ContextLine != "" || len(frame.PreContext) != 0 || len(frame.PostContext) != 0 || len(frame.Vars) != 0 {
@@ -228,6 +264,45 @@ func TestScrubEvent_UpstreamURLUserinfoHostPathDropped(t *testing.T) {
 		if strings.Contains(payload, forbidden) {
 			t.Fatalf("forbidden URL component %q survived in payload: %s", forbidden, payload)
 		}
+	}
+}
+
+func TestScrubEvent_ExceptionValueDropsPathsAndBareEndpoints(t *testing.T) {
+	s := NewScrubber(nil, nil)
+	event := &sentry.Event{
+		Exception: []sentry.Exception{{
+			Type:  "PathError",
+			Value: "open /home/agent/work/private.yaml: dial tcp 10.0.0.8:443: lookup private.internal.example on 10.0.0.2:53: no such host",
+		}},
+	}
+
+	result := s.ScrubEvent(event, nil)
+	raw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal sanitized event: %v", err)
+	}
+	payload := string(raw)
+	for _, forbidden := range []string{"/home/agent", "10.0.0.8", "private.internal.example", "10.0.0.2"} {
+		if strings.Contains(payload, forbidden) {
+			t.Fatalf("deployment locator %q survived in payload: %s", forbidden, payload)
+		}
+	}
+}
+
+func TestScrubEvent_FrameFilenameWindowsBasenameOnly(t *testing.T) {
+	s := NewScrubber(nil, nil)
+	event := &sentry.Event{
+		Exception: []sentry.Exception{{
+			Stacktrace: &sentry.Stacktrace{
+				Frames: []sentry.Frame{{Filename: `C:\Users\agent\src\private.go`}},
+			},
+		}},
+	}
+
+	result := s.ScrubEvent(event, nil)
+	frame := result.Exception[0].Stacktrace.Frames[0]
+	if frame.Filename != "private.go" {
+		t.Fatalf("filename = %q, want basename only", frame.Filename)
 	}
 }
 

--- a/internal/sentry/scrub_test.go
+++ b/internal/sentry/scrub_test.go
@@ -1,8 +1,11 @@
 package plsentry
 
 import (
+	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 
@@ -24,7 +27,6 @@ func testDLPPatterns() []config.DLPPattern {
 }
 
 func TestScrubString_DLPPatterns(t *testing.T) {
-	// Build fake credentials at runtime for gosec G101.
 	tests := []struct {
 		name  string
 		input string
@@ -52,14 +54,8 @@ func TestScrubString_DLPPatterns(t *testing.T) {
 }
 
 func TestScrubString_DLPPatterns_CaseInsensitive(t *testing.T) {
-	// DLP patterns are auto-prefixed with (?i) so mixed-case variants must
-	// still be scrubbed. This mirrors the scanner.New() behavior.
 	s := NewScrubber(testDLPPatterns(), nil)
 
-	// "ghp_" token with the prefix chars in different case won't match the
-	// original regex literally, but the real vector is an agent upper-casing
-	// secrets. Use a Slack token variant since xox is case-sensitive in the
-	// regex but agents can uppercase.
 	mixedCase := "webhook " + "XOXb-" + "123456789012345"
 	result := s.ScrubString(mixedCase)
 	if result == mixedCase {
@@ -73,7 +69,6 @@ func TestScrubString_DLPPatterns_CaseInsensitive(t *testing.T) {
 func TestScrubString_SafetyNet_CaseInsensitive(t *testing.T) {
 	s := NewScrubber(nil, nil)
 
-	// Lowercase "bearer" and "authorization" must still be caught.
 	lower := "header: bearer " + "eyJhbGciOiJIUzI1NiJ9.test"
 	result := s.ScrubString(lower)
 	if result == lower {
@@ -94,7 +89,6 @@ func TestScrubString_NonSecretPassesThrough(t *testing.T) {
 	s := NewScrubber(testDLPPatterns(), nil)
 	input := "normal error message without secrets"
 	result := s.ScrubString(input)
-	// URL param scrubbing won't affect this since there are no URL params.
 	if result != input {
 		t.Errorf("expected unchanged string, got %q", result)
 	}
@@ -108,9 +102,8 @@ func TestScrubString_EmptyString(t *testing.T) {
 }
 
 func TestScrubString_EnvSecrets(t *testing.T) {
-	secret := testEnvSecret
-	s := NewScrubber(nil, []string{secret})
-	input := "error: env value was " + secret + " in context"
+	s := NewScrubber(nil, []string{testEnvSecret})
+	input := "error: env value was " + testEnvSecret + " in context"
 	result := s.ScrubString(input)
 	if result == input {
 		t.Error("expected env secret to be scrubbed")
@@ -120,109 +113,129 @@ func TestScrubString_EnvSecrets(t *testing.T) {
 	}
 }
 
-func TestScrubString_URLQueryParams(t *testing.T) {
+func TestScrubString_URLAuthorityAndPathDropped(t *testing.T) {
 	s := NewScrubber(nil, nil)
-	input := "error fetching https://example.com/api?token=secretvalue&user=admin" // pipelock:ignore Credential in URL
+	input := "mcp upstream failed: " + fakeURLWithUserinfo("user", "novel-secret", "internal-host.example", "/p?q=secret")
 	result := s.ScrubString(input)
-	if result == input {
-		t.Error("expected URL query params to be scrubbed")
+
+	for _, forbidden := range []string{"user", "novel-secret", "internal-host.example", "/p", "q=secret"} {
+		if strings.Contains(result, forbidden) {
+			t.Fatalf("URL component %q leaked in %q", forbidden, result)
+		}
+	}
+	if !strings.Contains(result, "wss://"+redacted) {
+		t.Fatalf("expected coarse redacted URL, got %q", result)
 	}
 }
 
-func TestScrubEvent_Message(t *testing.T) {
-	awsKey := testAWSKeyID
+func TestScrubEvent_AllowlistPayloadShape(t *testing.T) {
+	eventTime := time.Unix(1700000000, 0).UTC()
 	s := NewScrubber(testDLPPatterns(), nil)
 	event := &sentry.Event{
-		Message: "error with key " + awsKey,
-	}
-	result := s.ScrubEvent(event, nil)
-	if result.Message == event.Message {
-		// ScrubEvent modifies in-place, so compare against original value
-		t.Log("message was scrubbed in-place, checking for redaction")
-	}
-	if !containsRedacted(result.Message) {
-		t.Errorf("expected [REDACTED] in message %q", result.Message)
-	}
-}
-
-func TestScrubEvent_Exception(t *testing.T) {
-	awsKey := testAWSKeyID
-	s := NewScrubber(testDLPPatterns(), nil)
-	event := &sentry.Event{
+		EventID:    "1234567890abcdef1234567890abcdef",
+		Timestamp:  eventTime,
+		Level:      sentry.LevelError,
+		Message:    "failed with " + testAWSKeyID,
+		Release:    "v1.2.3",
+		ServerName: "prod-secret-host-01.internal",
+		User:       sentry.User{ID: "user-123", IPAddress: "192.0.2.10"},
+		Request:    &sentry.Request{URL: "https://api.vendor.example/private", Method: "POST"},
+		Breadcrumbs: []*sentry.Breadcrumb{
+			{Message: "visited private path", Data: map[string]interface{}{"url": "https://api.vendor.example/private"}},
+		},
+		Tags:     map[string]string{"tenant": "acme-prod"},
+		Contexts: map[string]sentry.Context{"custom": {"hostname": "prod-secret-host-01.internal"}},
+		Modules:  map[string]string{"github.com/private/module": "v0.0.1"},
+		Attachments: []*sentry.Attachment{
+			{Filename: "secret.txt", Payload: []byte("secret")},
+		},
 		Exception: []sentry.Exception{
 			{
-				Value: "secret " + awsKey + " leaked",
+				Type:  "error at " + testAWSKeyID,
+				Value: "upstream failed with " + testAWSKeyID,
 				Stacktrace: &sentry.Stacktrace{
 					Frames: []sentry.Frame{
-						{Vars: map[string]interface{}{"key": awsKey}},
+						{
+							Function:    "runProxy",
+							Module:      "github.com/luckyPipewrench/pipelock/internal/cli/runtime",
+							Filename:    "/home/josh/dev/pipelock/internal/cli/runtime/mcp.go",
+							AbsPath:     "/home/josh/dev/pipelock/internal/cli/runtime/mcp.go",
+							Lineno:      1115,
+							ContextLine: "return upstreamURL.String()",
+							Vars:        map[string]interface{}{"upstream": fakeURLWithUserinfo("user", "secret", "host", "/p")},
+						},
 					},
 				},
 			},
 		},
 	}
+
 	result := s.ScrubEvent(event, nil)
-	if !containsRedacted(result.Exception[0].Value) {
-		t.Errorf("expected [REDACTED] in exception value %q", result.Exception[0].Value)
+	if result == nil {
+		t.Fatal("expected sanitized event")
 	}
-	if sv, ok := result.Exception[0].Stacktrace.Frames[0].Vars["key"].(string); !ok || !containsRedacted(sv) {
-		t.Errorf("expected [REDACTED] in frame vars")
+	if result.EventID != event.EventID || !result.Timestamp.Equal(eventTime) || result.Level != sentry.LevelError || result.Release != "v1.2.3" {
+		t.Fatalf("safe scalar fields not preserved: %+v", result)
+	}
+	if !containsRedacted(result.Message) || !containsRedacted(result.Exception[0].Type) || !containsRedacted(result.Exception[0].Value) {
+		t.Fatalf("expected surviving diagnostic strings to be scrubbed: %+v", result.Exception[0])
+	}
+	if result.Request != nil || result.ServerName != "" || result.User.ID != "" || len(result.Breadcrumbs) != 0 ||
+		len(result.Tags) != 0 || len(result.Contexts) != 0 || len(result.Modules) != 0 || len(result.Attachments) != 0 {
+		t.Fatalf("unsafe event fields survived: %+v", result)
+	}
+
+	frame := result.Exception[0].Stacktrace.Frames[0]
+	if frame.Filename != "mcp.go" || frame.Lineno != 1115 || frame.Function != "runProxy" {
+		t.Fatalf("safe frame fields not preserved: %+v", frame)
+	}
+	if frame.AbsPath != "" || frame.ContextLine != "" || len(frame.PreContext) != 0 || len(frame.PostContext) != 0 || len(frame.Vars) != 0 {
+		t.Fatalf("unsafe frame fields survived: %+v", frame)
+	}
+
+	if result.DebugMeta != nil || len(result.Spans) != 0 || len(result.Logs) != 0 || len(result.Metrics) != 0 {
+		t.Fatalf("unsafe event type fields survived: %+v", result)
+	}
+
+	raw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal sanitized event: %v", err)
+	}
+	payload := string(raw)
+	for _, forbidden := range []string{"request", "user", "server_name", "breadcrumbs", "tags", "contexts", "modules", "debug_meta", "attachments", "vars", "abs_path", "context_line"} {
+		if strings.Contains(payload, forbidden) {
+			t.Fatalf("forbidden field %q survived in payload: %s", forbidden, payload)
+		}
 	}
 }
 
-func TestScrubEvent_Breadcrumbs(t *testing.T) {
-	awsKey := testAWSKeyID
-	s := NewScrubber(testDLPPatterns(), nil)
-	event := &sentry.Event{
-		Breadcrumbs: []*sentry.Breadcrumb{
-			{
-				Message: "fetching with " + awsKey,
-				Data:    map[string]interface{}{"url": "https://api.example.com?key=" + awsKey},
-			},
-		},
-	}
-	result := s.ScrubEvent(event, nil)
-	if !containsRedacted(result.Breadcrumbs[0].Message) {
-		t.Errorf("expected [REDACTED] in breadcrumb message %q", result.Breadcrumbs[0].Message)
-	}
-}
-
-func TestScrubEvent_Tags(t *testing.T) {
-	awsKey := testAWSKeyID
-	s := NewScrubber(testDLPPatterns(), nil)
-	event := &sentry.Event{
-		Tags: map[string]string{"url": "https://api.example.com/" + awsKey},
-	}
-	result := s.ScrubEvent(event, nil)
-	if !containsRedacted(result.Tags["url"]) {
-		t.Errorf("expected [REDACTED] in tag %q", result.Tags["url"])
-	}
-}
-
-func TestScrubEvent_RequestWiped(t *testing.T) {
+func TestScrubEvent_UpstreamURLUserinfoHostPathDropped(t *testing.T) {
 	s := NewScrubber(nil, nil)
 	event := &sentry.Event{
-		Request: &sentry.Request{
-			URL:    "https://api.example.com/secret",
-			Method: "POST",
-		},
+		Exception: []sentry.Exception{{
+			Type:  "mcp upstream error",
+			Value: "connect failed for " + fakeURLWithUserinfo("urluser", "novel-secret", "internal-host.example", "/p"),
+		}},
 	}
+
 	result := s.ScrubEvent(event, nil)
-	if result.Request != nil {
-		t.Error("expected Request to be wiped")
+	raw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal sanitized event: %v", err)
+	}
+	payload := string(raw)
+	for _, forbidden := range []string{"urluser", "novel-secret", "internal-host.example", "/p"} {
+		if strings.Contains(payload, forbidden) {
+			t.Fatalf("forbidden URL component %q survived in payload: %s", forbidden, payload)
+		}
 	}
 }
 
-func TestScrubEvent_UserWiped(t *testing.T) {
-	s := NewScrubber(nil, nil)
-	event := &sentry.Event{
-		User: sentry.User{
-			ID:        "123",
-			IPAddress: "192.168.1.1",
-		},
-	}
-	result := s.ScrubEvent(event, nil)
-	if result.User.ID != "" || result.User.IPAddress != "" {
-		t.Error("expected User to be wiped")
+func TestScrubEvent_SanitizerPanicDropsEvent(t *testing.T) {
+	s := &Scrubber{patterns: []*regexp.Regexp{nil}}
+	result := s.ScrubEvent(&sentry.Event{Message: "panic path"}, nil)
+	if result != nil {
+		t.Fatalf("expected sanitizer panic to drop event, got %+v", result)
 	}
 }
 
@@ -240,14 +253,12 @@ func TestNewScrubber_InvalidPatternSkipped(t *testing.T) {
 		{Name: "Valid", Regex: `secret`, Severity: "high"},
 	}
 	s := NewScrubber(patterns, nil)
-	// Should not panic. Safety-net patterns + one valid = at least len(safetyNetPatterns)+1.
 	if len(s.patterns) < len(safetyNetPatterns)+1 {
 		t.Errorf("expected at least %d patterns, got %d", len(safetyNetPatterns)+1, len(s.patterns))
 	}
 }
 
 func TestScrubString_SafetyNetPatternsAlwaysApplied(t *testing.T) {
-	// Even with no config DLP patterns, safety-net patterns should work.
 	s := NewScrubber(nil, nil)
 	bearerInput := "header: Bearer " + "some-token-value-here"
 	result := s.ScrubString(bearerInput)
@@ -256,215 +267,10 @@ func TestScrubString_SafetyNetPatternsAlwaysApplied(t *testing.T) {
 	}
 }
 
-func TestScrubEvent_ServerNameWiped(t *testing.T) {
-	s := NewScrubber(nil, nil)
-	event := &sentry.Event{
-		ServerName: "prod-secret-host-01.internal.corp",
-	}
-	result := s.ScrubEvent(event, nil)
-	if result.ServerName != "" {
-		t.Errorf("expected ServerName to be wiped, got %q", result.ServerName)
-	}
-}
-
-func TestScrubEvent_ExceptionType(t *testing.T) {
-	awsKey := testAWSKeyID
-	s := NewScrubber(testDLPPatterns(), nil)
-	event := &sentry.Event{
-		Exception: []sentry.Exception{
-			{
-				Type:  "error at " + awsKey,
-				Value: "some value",
-			},
-		},
-	}
-	result := s.ScrubEvent(event, nil)
-	if !containsRedacted(result.Exception[0].Type) {
-		t.Errorf("expected [REDACTED] in exception type %q", result.Exception[0].Type)
-	}
-}
-
-func TestScrubEvent_Transaction(t *testing.T) {
-	awsKey := testAWSKeyID
-	s := NewScrubber(testDLPPatterns(), nil)
-	event := &sentry.Event{
-		Transaction: "/api/fetch?key=" + awsKey,
-	}
-	result := s.ScrubEvent(event, nil)
-	if !containsRedacted(result.Transaction) {
-		t.Errorf("expected [REDACTED] in transaction %q", result.Transaction)
-	}
-}
-
-func TestScrubEvent_Fingerprint(t *testing.T) {
-	awsKey := testAWSKeyID
-	s := NewScrubber(testDLPPatterns(), nil)
-	event := &sentry.Event{
-		Fingerprint: []string{"error-group", "key=" + awsKey},
-	}
-	result := s.ScrubEvent(event, nil)
-	if !containsRedacted(result.Fingerprint[1]) {
-		t.Errorf("expected [REDACTED] in fingerprint %q", result.Fingerprint[1])
-	}
-}
-
-func TestScrubEvent_BreadcrumbDataNonStringDeleted(t *testing.T) {
-	s := NewScrubber(nil, nil)
-	event := &sentry.Event{
-		Breadcrumbs: []*sentry.Breadcrumb{
-			{
-				Message: "test",
-				Data: map[string]interface{}{
-					"safe":      "value",
-					"dangerous": map[string]interface{}{"nested": "secret"},
-				},
-			},
-		},
-	}
-	result := s.ScrubEvent(event, nil)
-	if _, ok := result.Breadcrumbs[0].Data["dangerous"]; ok {
-		t.Error("expected non-string breadcrumb data to be deleted (fail-closed)")
-	}
-	if _, ok := result.Breadcrumbs[0].Data["safe"]; !ok {
-		t.Error("expected string breadcrumb data to be preserved")
-	}
-}
-
-func TestScrubEvent_ContextsStringScrubbed(t *testing.T) {
-	awsKey := testAWSKeyID
-	s := NewScrubber(testDLPPatterns(), nil)
-	event := &sentry.Event{
-		Contexts: map[string]sentry.Context{
-			"custom": {"url": "https://api.example.com/" + awsKey},
-		},
-	}
-	result := s.ScrubEvent(event, nil)
-	sv, ok := result.Contexts["custom"]["url"].(string)
-	if !ok {
-		t.Fatal("expected context value to remain string")
-	}
-	if !containsRedacted(sv) {
-		t.Errorf("expected [REDACTED] in context value %q", sv)
-	}
-}
-
-func TestScrubEvent_ContextsNonStringDeleted(t *testing.T) {
-	s := NewScrubber(nil, nil)
-	event := &sentry.Event{
-		Contexts: map[string]sentry.Context{
-			"custom": {
-				"safe":      "value",
-				"dangerous": []byte("secret bytes"),
-				"number":    42,
-			},
-		},
-	}
-	result := s.ScrubEvent(event, nil)
-	if _, ok := result.Contexts["custom"]["dangerous"]; ok {
-		t.Error("expected non-string Context value to be deleted (fail-closed)")
-	}
-	if _, ok := result.Contexts["custom"]["number"]; ok {
-		t.Error("expected non-string Context value to be deleted (fail-closed)")
-	}
-	if _, ok := result.Contexts["custom"]["safe"]; !ok {
-		t.Error("expected string Context value to be preserved")
-	}
-}
-
-func TestScrubEvent_VarsNonStringDeleted(t *testing.T) {
-	s := NewScrubber(nil, nil)
-	event := &sentry.Event{
-		Exception: []sentry.Exception{
-			{
-				Value: "error",
-				Stacktrace: &sentry.Stacktrace{
-					Frames: []sentry.Frame{
-						{Vars: map[string]interface{}{
-							"safe":      "value",
-							"dangerous": []string{"nested"},
-						}},
-					},
-				},
-			},
-		},
-	}
-	result := s.ScrubEvent(event, nil)
-	vars := result.Exception[0].Stacktrace.Frames[0].Vars
-	if _, ok := vars["dangerous"]; ok {
-		t.Error("expected non-string Vars value to be deleted (fail-closed)")
-	}
-	if _, ok := vars["safe"]; !ok {
-		t.Error("expected string Vars value to be preserved")
-	}
-}
-
-func TestScrubEvent_ThreadsVarsScrubbed(t *testing.T) {
-	awsKey := testAWSKeyID
-	s := NewScrubber(testDLPPatterns(), nil)
-	event := &sentry.Event{
-		Threads: []sentry.Thread{
-			{
-				ID:   "1",
-				Name: "main",
-				Stacktrace: &sentry.Stacktrace{
-					Frames: []sentry.Frame{
-						{Vars: map[string]interface{}{"key": awsKey, "safe": "hello"}},
-					},
-				},
-			},
-		},
-	}
-	result := s.ScrubEvent(event, nil)
-	sv, ok := result.Threads[0].Stacktrace.Frames[0].Vars["key"].(string)
-	if !ok || !containsRedacted(sv) {
-		t.Errorf("expected [REDACTED] in thread frame vars, got %v", result.Threads[0].Stacktrace.Frames[0].Vars["key"])
-	}
-	if _, ok := result.Threads[0].Stacktrace.Frames[0].Vars["safe"]; !ok {
-		t.Error("expected safe string var to be preserved in thread")
-	}
-}
-
-func TestScrubEvent_ThreadsVarsNonStringDeleted(t *testing.T) {
-	s := NewScrubber(nil, nil)
-	event := &sentry.Event{
-		Threads: []sentry.Thread{
-			{
-				ID: "1",
-				Stacktrace: &sentry.Stacktrace{
-					Frames: []sentry.Frame{
-						{Vars: map[string]interface{}{
-							"safe":      "value",
-							"dangerous": 42,
-						}},
-					},
-				},
-			},
-		},
-	}
-	result := s.ScrubEvent(event, nil)
-	vars := result.Threads[0].Stacktrace.Frames[0].Vars
-	if _, ok := vars["dangerous"]; ok {
-		t.Error("expected non-string thread var to be deleted (fail-closed)")
-	}
-	if _, ok := vars["safe"]; !ok {
-		t.Error("expected string thread var to be preserved")
-	}
-}
-
-func TestScrubEvent_ThreadsNilStacktrace(t *testing.T) {
-	s := NewScrubber(nil, nil)
-	event := &sentry.Event{
-		Threads: []sentry.Thread{
-			{ID: "1", Stacktrace: nil},
-		},
-	}
-	// Should not panic on nil stacktrace.
-	result := s.ScrubEvent(event, nil)
-	if len(result.Threads) != 1 {
-		t.Errorf("expected 1 thread, got %d", len(result.Threads))
-	}
-}
-
 func containsRedacted(s string) bool {
 	return strings.Contains(s, redacted)
+}
+
+func fakeURLWithUserinfo(user, pass, host, path string) string {
+	return "wss://" + user + ":" + pass + "@" + host + path
 }

--- a/internal/sentry/scrub_test.go
+++ b/internal/sentry/scrub_test.go
@@ -128,6 +128,21 @@ func TestScrubString_URLAuthorityAndPathDropped(t *testing.T) {
 	}
 }
 
+func TestScrubString_ProtocolRelativeURLPathDropped(t *testing.T) {
+	s := NewScrubber(nil, nil)
+	input := `parse "//internal-host.example/private-agent/token?key=secret": missing protocol scheme`
+	result := s.ScrubString(input)
+
+	for _, forbidden := range []string{"internal-host.example", "/private-agent", "token", "key=secret"} {
+		if strings.Contains(result, forbidden) {
+			t.Fatalf("protocol-relative URL component %q leaked in %q", forbidden, result)
+		}
+	}
+	if !strings.Contains(result, "//"+redacted) {
+		t.Fatalf("expected coarse protocol-relative URL redaction, got %q", result)
+	}
+}
+
 func TestScrubString_DeploymentLocatorsDropped(t *testing.T) {
 	s := NewScrubber(nil, nil)
 	input := strings.Join([]string{
@@ -135,10 +150,13 @@ func TestScrubString_DeploymentLocatorsDropped(t *testing.T) {
 		`open C:\Users\agent\AppData\Roaming\pipelock\private.yaml: access denied`,
 		`open \\fileserver\share\private.yaml: access denied`,
 		"dial tcp 10.0.0.12:8443: connect: connection refused",
+		"dial tcp 10.0.0.12:8443/private-token: connect: connection refused",
 		"lookup internal-host.example on 10.0.0.2:53: no such host",
 		"x509: certificate is valid for private.service.internal, not public.vendor.example",
+		"upstream private.service.internal/v1/secret refused",
 		"dial tcp [fd00::10]:443: connect: network unreachable",
-		"proxy auth failed for deployer:novel-secret@private.service.internal:443",
+		"dial tcp [fd00::10]:443/private-token: network unreachable",
+		"proxy auth failed for deployer:novel-secret@private.service.internal:443/private-token",
 	}, "\n")
 
 	result := s.ScrubString(input)
@@ -152,6 +170,8 @@ func TestScrubString_DeploymentLocatorsDropped(t *testing.T) {
 		"private.service.internal",
 		"public.vendor.example",
 		"fd00::10",
+		"private-token",
+		"/v1/secret",
 		"deployer",
 		"novel-secret",
 	} {

--- a/internal/sentry/scrub_test.go
+++ b/internal/sentry/scrub_test.go
@@ -326,6 +326,37 @@ func TestScrubEvent_FrameFilenameWindowsBasenameOnly(t *testing.T) {
 	}
 }
 
+func TestScrubEvent_FrameIdentifiersScrubQueryPayloads(t *testing.T) {
+	s := NewScrubber(nil, nil)
+	event := &sentry.Event{
+		Exception: []sentry.Exception{{
+			Stacktrace: &sentry.Stacktrace{
+				Frames: []sentry.Frame{{
+					Function: "handler?" + "token=novel-secret",
+					Module:   "runtime&" + "api_key=novel-secret",
+					Filename: "/tmp/private-token=novel-secret.go?session=novel-secret",
+				}},
+			},
+		}},
+	}
+
+	result := s.ScrubEvent(event, nil)
+	raw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal sanitized event: %v", err)
+	}
+	payload := string(raw)
+	if strings.Contains(payload, "novel-secret") {
+		t.Fatalf("frame identifier query payload leaked in %s", payload)
+	}
+	frame := result.Exception[0].Stacktrace.Frames[0]
+	for _, field := range []string{frame.Function, frame.Module, frame.Filename} {
+		if !containsRedacted(field) {
+			t.Fatalf("frame field %q did not include redaction marker", field)
+		}
+	}
+}
+
 func TestScrubEvent_SanitizerPanicDropsEvent(t *testing.T) {
 	s := &Scrubber{patterns: []*regexp.Regexp{nil}}
 	result := s.ScrubEvent(&sentry.Event{Message: "panic path"}, nil)


### PR DESCRIPTION
Crash reporting is now disabled by default and is enabled only with an explicit opt-in plus a configured DSN. The shipped configuration presets no longer carry a default DSN, so a fresh install sends nothing until an operator turns it on.

When enabled, reported payloads are rebuilt through a structural allowlist that keeps only a minimal, non-sensitive set of fields (event id, timestamp, level, version, coarse OS, exception type, a minimized message, and package, function, file basename, and line for stack frames). Request bodies, headers, user identity, hostnames, breadcrumbs, module inventory, local variables, and absolute paths are dropped by construction, and the surviving strings are additionally stripped of filesystem paths and network locators.

Sanitization fails closed (any failure drops the event rather than sending a raw one), non-error event classes are not transmitted, and a sample rate of 0.0 is rejected as a disable mechanism because the SDK treats it as fully on. A startup line discloses reporting when it is enabled.

The deployment chart now renders the enable flag into the runtime configuration so a self-hosted operator's own reporting continues to work after the default change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sentry crash reporting is now opt-in across shipped presets; enable it with `sentry.enabled: true` and a non-empty DSN.
* **Bug Fixes**
  * Crash reporting now minimizes outbound data, drops unsafe event types, and fails safely if sanitization encounters an error.
  * `pipelock doctor` reports default-disabled Sentry as informational, and disabling Sentry clears any previously initialized client.
  * When Sentry is enabled, `sample_rate: 0.0` is rejected (use a positive value).
* **Documentation**
  * Expanded Hot Reload and added a “Sentry Crash Reporting” section covering enablement, sanitization behavior, and `sample_rate` rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->