### PR TITLE
feat(dashboard): read-only exemptions inventory with inert-exemption detection

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -5,14 +5,21 @@ SPDX-License-Identifier: Apache-2.0
 
 # `pipelock dashboard`
 
-Serve the read-only Evidence dashboard: a web view over the signed action
-receipts in a flight-recorder evidence directory. It renders each recorder
-session with a four-line scorecard — **Authentic**, **Untampered**,
+Serve the read-only operator dashboard. The Evidence view is a web view over
+the signed action receipts in a flight-recorder evidence directory. It renders
+each recorder session with a four-line scorecard — **Authentic**, **Untampered**,
 **Anchored**, **Completeness** — where every line is an independent fact.
 There is deliberately no aggregate "all clear": Completeness is always limited
 to mediated traffic, Anchored is never green without an external inclusion
 proof, and signers are only shown as trusted when the operator configured
 their keys (never trust-on-first-use).
+
+The Exemptions view is a read-only inventory over the loaded Pipelock config.
+It lists configured exemption-like knobs and flags only the inert or
+wrong-knob findings produced by the same config semantic analyzer used by
+`pipelock doctor`. It does not create, renew, apply, remove, or hot-reload
+exemptions, and it does not invent lifecycle telemetry: owner, expiry,
+last-matched, and suppressed-count columns are shown as `not tracked`.
 
 The command ships in official release builds (enterprise-tagged) and requires
 a license that grants the `agents` feature (Pro or Enterprise); without one it
@@ -24,6 +31,7 @@ mutates policy, receipts, or runtime state.
 ```bash
 pipelock dashboard serve \
   --receipt-dir /var/lib/pipelock/evidence \
+  --config /etc/pipelock/pipelock.yaml \
   --auth-token-file /etc/pipelock/dashboard.token \
   --trusted-signer 'file=/etc/pipelock/receipt-signing.pub,source=ops runbook'
 ```
@@ -49,6 +57,7 @@ openssl rand -hex 32 > /etc/pipelock/dashboard.token
 | Flag | Default | Purpose |
 |---|---|---|
 | `--receipt-dir` | (required) | Flight-recorder evidence directory holding action receipts (the runtime's `flight_recorder.dir`). |
+| `--config` | none | Optional Pipelock config file for the read-only Exemptions inventory. When omitted, `/exemptions` renders an explicit "no config loaded" state and the Evidence view still works. |
 | `--auth-token-file` | (required) | File containing the operator token required on every request. Grants the redacted metadata view. |
 | `--raw-token-file` | none | Optional second, higher-privilege token that unlocks raw destinations and signed payloads. Must differ from `--auth-token-file`. |
 | `--listen` | `127.0.0.1:8896` | Dashboard listener address. Non-loopback addresses require `--tls-cert`/`--tls-key`. |
@@ -58,9 +67,15 @@ openssl rand -hex 32 > /etc/pipelock/dashboard.token
 
 ### License resolution
 
-`dashboard serve` takes no config file. Like the other server commands, it
-resolves the license token from `PIPELOCK_LICENSE_KEY` and verifies it against
-the build-embedded public key (or `PIPELOCK_LICENSE_PUBLIC_KEY` on unofficial
+`dashboard serve` loads `--config` only when the flag is provided, using the
+normal Pipelock config loader. The loaded config feeds the `/exemptions` view;
+it does not grant the dashboard authority to mutate policy or reload runtime
+state. If `--config` is omitted, the Exemptions view reports that no config was
+loaded.
+
+License resolution still follows the paid-surface gate: the command resolves
+the license token from `PIPELOCK_LICENSE_KEY` and verifies it against the
+build-embedded public key (or `PIPELOCK_LICENSE_PUBLIC_KEY` on unofficial
 builds). Verification fails closed before any listener binds, and the feature
 entitlement is re-checked on every request, so a license that expires while
 the server is running stops serving.
@@ -95,6 +110,9 @@ the server is running stops serving.
 - **Access is audited.** Every authenticated request is written to an access log
   on stderr (role `metadata` or `raw`, method, path, session, remote address).
   Viewing evidence is itself a recorded action.
+- **Exemptions is inventory only.** `/exemptions` is GET-only and reads the
+  already-loaded config snapshot. It has no POST route, no apply/remove/renew
+  controls, no config write path, and no hot-reload hook.
 - **Sensitive by design.** Even the metadata view exposes reasons, signer
   fingerprints, and session IDs. Treat the listener like an admin API: keep it
   loopback or behind TLS on a network only operators reach.

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -157,7 +157,7 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 	}
 	var loadedConfig *config.Config
 	if strings.TrimSpace(opts.configFile) != "" {
-		loadedConfig, err = config.Load(opts.configFile)
+		loadedConfig, err = config.LoadForInspection(opts.configFile)
 		if err != nil {
 			return fmt.Errorf("--config: %w", err)
 		}

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/dashboard"
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -52,6 +53,7 @@ func DashboardCmd() *cobra.Command {
 type dashboardServeOptions struct {
 	listen         string
 	receiptDir     string
+	configFile     string
 	authTokenFile  string
 	rawTokenFile   string
 	trustedSigners []string
@@ -95,6 +97,8 @@ because the operator token would transit in cleartext.`,
 		"address for the dashboard listener; non-loopback addresses require --tls-cert/--tls-key")
 	cmd.Flags().StringVar(&opts.receiptDir, "receipt-dir", "",
 		"flight-recorder evidence directory holding action receipts (flight_recorder.dir)")
+	cmd.Flags().StringVar(&opts.configFile, "config", "",
+		"optional Pipelock config file for the read-only exemptions inventory")
 	cmd.Flags().StringVar(&opts.authTokenFile, "auth-token-file", "",
 		"file containing the operator token required on every dashboard request (redacted metadata view)")
 	cmd.Flags().StringVar(&opts.rawTokenFile, "raw-token-file", "",
@@ -151,6 +155,13 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
 			"pipelock: warning: no --trusted-signer configured; the Authentic line will render every signer as Unverified")
 	}
+	var loadedConfig *config.Config
+	if strings.TrimSpace(opts.configFile) != "" {
+		loadedConfig, err = config.Load(opts.configFile)
+		if err != nil {
+			return fmt.Errorf("--config: %w", err)
+		}
+	}
 
 	// metaAuthorized gates all access: the metadata token OR the raw token (a
 	// raw holder is also a valid operator). rawAuthorized gates only the
@@ -168,6 +179,7 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 	inner := dashboard.New(dashboard.Options{
 		ReceiptDir:   opts.receiptDir,
 		TrustedKeys:  trusted,
+		Config:       loadedConfig,
 		HasFeature:   dashboardRuntimeHasFeature(lic),
 		Authorize:    dashboardAuthorizeFunc(metaAuthorized),
 		AuthorizeRaw: dashboardAuthorizeFunc(rawAuthorized),

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/dashboard"
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
@@ -358,7 +359,12 @@ func TestDashboardServe_RejectsMalformedConfig(t *testing.T) {
 	}
 }
 
-func TestDashboardServe_RejectsUnreadableConfigReferencedFile(t *testing.T) {
+func TestDashboardServe_InspectionConfigIgnoresUnreadableReferencedFile(t *testing.T) {
+	// A read-only inventory must not resolve unrelated runtime-side files it does
+	// not need. An unreadable license_file (a file the exemptions view never uses)
+	// must NOT prevent the config from loading for inspection. runDashboardServe
+	// loads the config via config.LoadForInspection, so proving that succeeds
+	// proves the serve path no longer fails to start on such files.
 	t.Setenv(license.EnvLicenseKey, "")
 	dir := t.TempDir()
 	licensePath := filepath.Join(dir, "license.token")
@@ -370,20 +376,35 @@ func TestDashboardServe_RejectsUnreadableConfigReferencedFile(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(licensePath, 0o600) })
 	configPath := filepath.Join(dir, "pipelock.yaml")
-	if err := os.WriteFile(configPath, []byte("mode: balanced\nlicense_file: license.token\n"), 0o600); err != nil {
+	body := "mode: balanced\nlicense_file: license.token\nbrowser_shield:\n  enabled: false\n  exempt_domains:\n    - my.internal.example\n"
+	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
 		t.Fatalf("WriteFile(config): %v", err)
 	}
-	cmd := dashboardServeCmd()
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
-	err := runDashboardServe(cmd, dashboardServeOptions{
-		listen:        "127.0.0.1:0",
-		receiptDir:    t.TempDir(),
-		authTokenFile: writeDashTokenFile(t),
-		configFile:    configPath,
-	}, license.License{Features: []string{license.FeatureAgents}})
-	if err == nil || !strings.Contains(err.Error(), "--config") {
-		t.Fatalf("unreadable referenced file: want --config error, got %v", err)
+
+	cfg, err := config.LoadForInspection(configPath)
+	if err != nil {
+		t.Fatalf("LoadForInspection with unreadable license_file: %v", err)
+	}
+	inv := dashboard.NewReadModel(dashboard.Options{Config: cfg}).Exemptions()
+	if !inv.ConfigLoaded {
+		t.Fatal("ConfigLoaded = false, want true")
+	}
+	// The operator-added exemption on the disabled feature must still be surfaced,
+	// so the inventory is genuinely usable without the unrelated file.
+	if inv.InertCount == 0 {
+		t.Fatalf("expected the operator-added disabled-feature exemption to be inert; inventory=%+v", inv)
+	}
+}
+
+func TestDashboardServe_InspectionConfigRejectsMalformedYAML(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(configPath, []byte("mode: balanced\n\tbroken: [::\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+	if _, err := config.LoadForInspection(configPath); err == nil {
+		t.Fatal("LoadForInspection(malformed yaml) = nil error, want parse failure (fail closed)")
 	}
 }
 
@@ -487,10 +508,16 @@ func TestDashboardServe_EndToEnd(t *testing.T) {
 			t.Fatalf("ReadAll: %v", err)
 		}
 		text := string(body)
-		for _, want := range []string{"Exemptions inventory", "api.vendor.example", "inert"} {
+		// The metadata operator token does not carry raw access, so configured
+		// values are redacted; the view still shows the inventory, states, and
+		// the redaction note.
+		for _, want := range []string{"Exemptions inventory", "raw access is required", "inert"} {
 			if !strings.Contains(text, want) {
 				t.Fatalf("body missing %q: %s", want, text)
 			}
+		}
+		if strings.Contains(text, "api.vendor.example") {
+			t.Fatalf("metadata view leaked a configured domain: %s", text)
 		}
 	})
 

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -361,13 +361,18 @@ func TestDashboardServe_RejectsMalformedConfig(t *testing.T) {
 
 func TestDashboardServe_InspectionConfigIgnoresUnreadableReferencedFile(t *testing.T) {
 	// A read-only inventory must not resolve unrelated runtime-side files it does
-	// not need. An unreadable license_file (a file the exemptions view never uses)
-	// must NOT prevent the config from loading for inspection. runDashboardServe
-	// loads the config via config.LoadForInspection, so proving that succeeds
-	// proves the serve path no longer fails to start on such files.
+	// not need. An unreadable license_file referenced by --config (a file the
+	// exemptions view never uses) must NOT prevent the dashboard from starting.
+	// This exercises the real serve path: runDashboardServe loads --config via
+	// config.LoadForInspection, so a regression back to config.Load (which reads
+	// license_file) would fail before the listening banner and fail this test.
+	// Empty env license so config.Load, if it were used, would resolve the
+	// config's license_file (env takes priority over license_file). The
+	// dashboard's own license is supplied via the lic argument, independent of
+	// --config, so config's unreadable license_file only bites the config load.
 	t.Setenv(license.EnvLicenseKey, "")
 	dir := t.TempDir()
-	licensePath := filepath.Join(dir, "license.token")
+	licensePath := filepath.Join(dir, "unrelated-license.token")
 	if err := os.WriteFile(licensePath, []byte("unused"), 0o600); err != nil {
 		t.Fatalf("WriteFile(license): %v", err)
 	}
@@ -376,23 +381,47 @@ func TestDashboardServe_InspectionConfigIgnoresUnreadableReferencedFile(t *testi
 	}
 	t.Cleanup(func() { _ = os.Chmod(licensePath, 0o600) })
 	configPath := filepath.Join(dir, "pipelock.yaml")
-	body := "mode: balanced\nlicense_file: license.token\nbrowser_shield:\n  enabled: false\n  exempt_domains:\n    - my.internal.example\n"
+	body := "mode: balanced\nlicense_file: unrelated-license.token\nbrowser_shield:\n  enabled: false\n  exempt_domains:\n    - my.internal.example\n"
 	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
 		t.Fatalf("WriteFile(config): %v", err)
 	}
 
-	cfg, err := config.LoadForInspection(configPath)
-	if err != nil {
-		t.Fatalf("LoadForInspection with unreadable license_file: %v", err)
-	}
-	inv := dashboard.NewReadModel(dashboard.Options{Config: cfg}).Exemptions()
-	if !inv.ConfigLoaded {
-		t.Fatal("ConfigLoaded = false, want true")
-	}
-	// The operator-added exemption on the disabled feature must still be surfaced,
-	// so the inventory is genuinely usable without the unrelated file.
-	if inv.InertCount == 0 {
-		t.Fatalf("expected the operator-added disabled-feature exemption to be inert; inventory=%+v", inv)
+	out := &dashSyncBuffer{}
+	errOut := &dashSyncBuffer{}
+	cmd := dashboardServeCmd()
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runDashboardServe(cmd, dashboardServeOptions{
+			listen:        "127.0.0.1:0",
+			receiptDir:    t.TempDir(),
+			authTokenFile: writeDashTokenFile(t),
+			configFile:    configPath,
+		}, license.License{Features: []string{license.FeatureAgents}})
+	}()
+
+	// LoadForInspection reaches the listening banner. A regression to config.Load
+	// returns the unreadable-license_file error before the banner and fails here.
+	testwait.For(t, 10*time.Second, func() bool {
+		select {
+		case err := <-done:
+			t.Fatalf("serve returned before the listening banner (config load read the unrelated license_file?): %v", err)
+			return false
+		default:
+			return out.contains("dashboard listening on")
+		}
+	}, "serve never printed the listening banner; stderr: %s", errOut.String())
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("serve did not shut down after context cancel")
 	}
 }
 

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -110,7 +111,7 @@ func TestDashboardCmd_Tree(t *testing.T) {
 	if err != nil || serve.Use != "serve" {
 		t.Fatalf("dashboard serve subcommand not found: %v", err)
 	}
-	for _, flag := range []string{"listen", "receipt-dir", "auth-token-file", "raw-token-file", "trusted-signer", "license-crl-file", "tls-cert", "tls-key"} {
+	for _, flag := range []string{"listen", "receipt-dir", "config", "auth-token-file", "raw-token-file", "trusted-signer", "license-crl-file", "tls-cert", "tls-key"} {
 		if serve.Flags().Lookup(flag) == nil {
 			t.Errorf("serve is missing --%s", flag)
 		}
@@ -125,6 +126,21 @@ func writeDashRawTokenFile(t *testing.T) (path, token string) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	return path, token
+}
+
+func writeDashConfigFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	body := []byte(`mode: balanced
+response_scanning:
+  enabled: false
+  exempt_domains:
+    - api.vendor.example
+`)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+	return path
 }
 
 func TestDashboardServe_RawTokenMustDifferFromAuthToken(t *testing.T) {
@@ -287,6 +303,90 @@ func TestDashboardServe_RejectsMissingReceiptDir(t *testing.T) {
 	}
 }
 
+func TestDashboardServe_RejectsBadConfigPath(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", writeDashTokenFile(t),
+		"--config", filepath.Join(t.TempDir(), "missing.yaml"),
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--config") {
+		t.Fatalf("missing config: want --config error, got %v", err)
+	}
+}
+
+func TestDashboardServe_RejectsConfigDirectory(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", writeDashTokenFile(t),
+		"--config", t.TempDir(),
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--config") {
+		t.Fatalf("config directory: want --config error, got %v", err)
+	}
+}
+
+func TestDashboardServe_RejectsMalformedConfig(t *testing.T) {
+	pub, priv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
+	configPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(configPath, []byte("mode: balanced\nresponse_scanning: ["), 0o600); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--auth-token-file", writeDashTokenFile(t),
+		"--config", configPath,
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--config") {
+		t.Fatalf("malformed config: want --config error, got %v", err)
+	}
+}
+
+func TestDashboardServe_RejectsUnreadableConfigReferencedFile(t *testing.T) {
+	t.Setenv(license.EnvLicenseKey, "")
+	dir := t.TempDir()
+	licensePath := filepath.Join(dir, "license.token")
+	if err := os.WriteFile(licensePath, []byte("unused"), 0o600); err != nil {
+		t.Fatalf("WriteFile(license): %v", err)
+	}
+	if err := os.Chmod(licensePath, 0); err != nil {
+		t.Fatalf("Chmod(license): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(licensePath, 0o600) })
+	configPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(configPath, []byte("mode: balanced\nlicense_file: license.token\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+	cmd := dashboardServeCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := runDashboardServe(cmd, dashboardServeOptions{
+		listen:        "127.0.0.1:0",
+		receiptDir:    t.TempDir(),
+		authTokenFile: writeDashTokenFile(t),
+		configFile:    configPath,
+	}, license.License{Features: []string{license.FeatureAgents}})
+	if err == nil || !strings.Contains(err.Error(), "--config") {
+		t.Fatalf("unreadable referenced file: want --config error, got %v", err)
+	}
+}
+
 func TestDashboardServe_EndToEnd(t *testing.T) {
 	pub, priv := newDashKeyPair(t)
 	setDashLicenseEnv(t, issueDashLicense(t, priv, []string{license.FeatureAgents}), hex.EncodeToString(pub))
@@ -297,6 +397,7 @@ func TestDashboardServe_EndToEnd(t *testing.T) {
 	cmd.SetArgs([]string{
 		"--receipt-dir", t.TempDir(),
 		"--auth-token-file", writeDashTokenFile(t),
+		"--config", writeDashConfigFile(t),
 		"--listen", "127.0.0.1:0",
 	})
 	cmd.SetOut(out)
@@ -364,6 +465,32 @@ func TestDashboardServe_EndToEnd(t *testing.T) {
 		}
 		if resp.Header.Get("Content-Security-Policy") == "" {
 			t.Errorf("missing Content-Security-Policy header")
+		}
+	})
+
+	t.Run("exemptions uses loaded config", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/exemptions", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+dashTestToken)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("GET /exemptions: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		text := string(body)
+		for _, want := range []string{"Exemptions inventory", "api.vendor.example", "inert"} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("body missing %q: %s", want, text)
+			}
 		}
 	})
 

--- a/enterprise/dashboard/evidence.tmpl.html
+++ b/enterprise/dashboard/evidence.tmpl.html
@@ -38,6 +38,8 @@
     .brand { font-weight: 650; }
     .brand span { color: var(--text-muted); font-weight: 500; }
     .mode { color: var(--text-dim); font-size: 13px; }
+    .mode a { color: var(--text-muted); text-decoration: none; margin-right: 14px; }
+    .mode a:hover { color: var(--text); }
     .shell {
       display: grid;
       grid-template-columns: 320px minmax(0, 1fr);
@@ -222,7 +224,7 @@
 <body>
   <header class="topbar">
     <div class="brand">Pipelock <span>· Operator Console / Evidence</span></div>
-    <div class="mode">air-gapped · self-hosted</div>
+    <div class="mode"><a href="/exemptions">Exemptions</a>air-gapped · self-hosted</div>
   </header>
   <div class="shell">
     <aside>

--- a/enterprise/dashboard/exemptions.go
+++ b/enterprise/dashboard/exemptions.go
@@ -31,6 +31,52 @@ type ExemptionInventory struct {
 	InertCount       int
 	MisdirectedCount int
 	TrackingNote     string
+	// RawRedacted is true when this view was rendered without raw access, so
+	// the sensitive configured values (destinations, IPs, addresses, paths,
+	// rules, reasons) have been stripped and the template shows a "raw access
+	// required" note. Knob names, states, and counts are preserved.
+	RawRedacted bool
+}
+
+// redactExemptions strips the raw-sensitive surface from an inventory view: the
+// configured Scope value, every Attribute value, and the remediation Detail/Next
+// text (which can embed a configured value). It keeps the non-sensitive
+// structure — knob names, State, and the counts — so a metadata-only operator
+// still sees which knobs have inert/misdirected exemptions and how many, without
+// a map of internal destinations and enforcement exceptions. Mirrors the
+// evidence view's redactRaw boundary. Operates on the freshly built value so raw
+// bytes never reach a metadata response.
+func redactExemptions(inv ExemptionInventory) ExemptionInventory {
+	inv.RawRedacted = true
+	inv.Entries = redactExemptionEntries(inv.Entries)
+	inv.Attention = redactExemptionEntries(inv.Attention)
+	return inv
+}
+
+func redactExemptionEntries(entries []ExemptionEntry) []ExemptionEntry {
+	if len(entries) == 0 {
+		return entries
+	}
+	out := make([]ExemptionEntry, len(entries))
+	for i, e := range entries {
+		e.Scope = redactedDestination
+		e.semanticSubject = ""
+		if e.Detail != "" {
+			e.Detail = redactedDestination
+		}
+		if e.Next != "" {
+			e.Next = redactedDestination
+		}
+		if len(e.Attributes) > 0 {
+			redactedAttrs := make([]ExemptionAttribute, len(e.Attributes))
+			for j, a := range e.Attributes {
+				redactedAttrs[j] = ExemptionAttribute{Name: a.Name, Value: redactedDestination}
+			}
+			e.Attributes = redactedAttrs
+		}
+		out[i] = e
+	}
+	return out
 }
 
 // ExemptionEntry is one configured exemption-like knob value.
@@ -104,7 +150,7 @@ func enumerateExemptionEntries(cfg *config.Config) []ExemptionEntry {
 	}
 
 	for _, entry := range cfg.Suppress {
-		entries = append(entries, newExemptionEntry("Proxy scanners", "suppress", entry.Path, strings.ToLower(entry.Rule),
+		entries = append(entries, newExemptionEntry("Proxy scanners", diag.ConfigScopeSuppress, entry.Path, strings.ToLower(entry.Rule),
 			attr("rule", entry.Rule),
 			attrIfSet("reason", entry.Reason),
 		))
@@ -120,7 +166,7 @@ func enumerateExemptionEntries(cfg *config.Config) []ExemptionEntry {
 			))
 		}
 	}
-	addDomainList("Response scanning", "response_scanning.exempt_domains", cfg.ResponseScanning.ExemptDomains)
+	addDomainList("Response scanning", diag.ConfigScopeResponseExemptDomains, cfg.ResponseScanning.ExemptDomains)
 	addDomainList("Response scanning size limit", "response_scanning.size_exempt_domains", cfg.ResponseScanning.SizeExemptDomains)
 	for _, entry := range cfg.ResponseScanning.UnscannablePassthrough {
 		entries = append(entries, newExemptionEntry("Response scanning passthrough", "response_scanning.unscannable_passthrough", entry.Host, entry.Host,
@@ -130,7 +176,7 @@ func enumerateExemptionEntries(cfg *config.Config) []ExemptionEntry {
 		))
 	}
 	for _, entry := range cfg.ResponseScanning.MCPServers {
-		entries = append(entries, newExemptionEntry("MCP response trust", "response_scanning.mcp_servers", entry.Server, entry.Server,
+		entries = append(entries, newExemptionEntry("MCP response trust", diag.ConfigScopeResponseMCPServers, entry.Server, entry.Server,
 			attr("trust", entry.Trust),
 		))
 	}
@@ -148,7 +194,7 @@ func enumerateExemptionEntries(cfg *config.Config) []ExemptionEntry {
 		))
 	}
 
-	addDomainList("TLS interception", "tls_interception.passthrough_domains", cfg.TLSInterception.PassthroughDomains)
+	addDomainList("TLS interception", diag.ConfigScopeTLSPassthroughDomains, cfg.TLSInterception.PassthroughDomains)
 	addDomainList("SSRF", "trusted_domains", cfg.TrustedDomains)
 	addDomainList("SSRF", "ssrf.ip_allowlist", cfg.SSRF.IPAllowlist)
 	for _, cidr := range cfg.KillSwitch.AllowlistIPs {
@@ -163,11 +209,11 @@ func enumerateExemptionEntries(cfg *config.Config) []ExemptionEntry {
 	addBooleanExemption("kill_switch.health_exempt", "health endpoints", cfg.KillSwitch.HealthExempt)
 	addBooleanExemption("kill_switch.metrics_exempt", "metrics endpoints", cfg.KillSwitch.MetricsExempt)
 	addBooleanExemption("kill_switch.api_exempt", "kill-switch API endpoints", cfg.KillSwitch.APIExempt)
-	addDomainList("Adaptive enforcement", "adaptive_enforcement.exempt_domains", cfg.AdaptiveEnforcement.ExemptDomains)
-	addDomainList("Cross-request entropy", "cross_request_detection.entropy_budget.exempt_domains", cfg.CrossRequestDetection.EntropyBudget.ExemptDomains)
-	addDomainList("Browser shield", "browser_shield.exempt_domains", cfg.BrowserShield.ExemptDomains)
+	addDomainList("Adaptive enforcement", diag.ConfigScopeAdaptiveExemptDomains, cfg.AdaptiveEnforcement.ExemptDomains)
+	addDomainList("Cross-request entropy", diag.ConfigScopeCrossRequestEntropyExempt, cfg.CrossRequestDetection.EntropyBudget.ExemptDomains)
+	addDomainList("Browser shield", diag.ConfigScopeBrowserShieldExemptDomains, cfg.BrowserShield.ExemptDomains)
 	for _, header := range cfg.RequestBodyScanning.IgnoreHeaders {
-		entries = append(entries, newExemptionEntry("Request header DLP", "request_body_scanning.ignore_headers", header, strings.ToLower(header)))
+		entries = append(entries, newExemptionEntry("Request header DLP", diag.ConfigScopeRequestBodyIgnoreHeaders, header, strings.ToLower(header)))
 	}
 	addDomainList("Taint trust", "taint.allowlisted_domains", cfg.Taint.AllowlistedDomains)
 	addDomainList("Taint trust", "taint.trusted_mcp_servers", cfg.Taint.TrustedMCPServers)
@@ -235,7 +281,7 @@ func newExemptionEntry(scanner, knob, scope, matchValue string, attributes ...Ex
 func normalizeExemptionSemanticSubject(knob, subject string) string {
 	subject = strings.TrimSpace(subject)
 	switch knob {
-	case "suppress", "request_body_scanning.ignore_headers":
+	case diag.ConfigScopeSuppress, diag.ConfigScopeRequestBodyIgnoreHeaders:
 		return strings.ToLower(subject)
 	default:
 		return subject

--- a/enterprise/dashboard/exemptions.go
+++ b/enterprise/dashboard/exemptions.go
@@ -1,0 +1,296 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/cli/diag"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	ExemptionStateActive      = "active"
+	ExemptionStateInert       = diag.ConfigSemanticKindInert
+	ExemptionStateMisdirected = diag.ConfigSemanticKindMisdirected
+
+	notTracked = "not tracked"
+)
+
+// ExemptionInventory is the read-only dashboard view over configured
+// exemptions in the loaded Pipelock config.
+type ExemptionInventory struct {
+	ConfigLoaded     bool
+	Entries          []ExemptionEntry
+	Attention        []ExemptionEntry
+	ConfiguredCount  int
+	InertCount       int
+	MisdirectedCount int
+	TrackingNote     string
+}
+
+// ExemptionEntry is one configured exemption-like knob value.
+type ExemptionEntry struct {
+	Scanner     string
+	Knob        string
+	Scope       string
+	Attributes  []ExemptionAttribute
+	State       string
+	Detail      string
+	Next        string
+	Owner       string
+	Expiry      string
+	LastMatched string
+	Suppressed  string
+
+	semanticSubject string
+}
+
+// ExemptionAttribute is a real config attribute attached to an exemption.
+type ExemptionAttribute struct {
+	Name  string
+	Value string
+}
+
+// Exemptions builds a unified read-only inventory of configured exemptions.
+func (m *ReadModel) Exemptions() ExemptionInventory {
+	if m == nil || m.cfg == nil {
+		return ExemptionInventory{
+			ConfigLoaded: false,
+			TrackingNote: "owner/expiry/last-matched/suppressed-count telemetry is not tracked",
+		}
+	}
+	entries := enumerateExemptionEntries(m.cfg)
+	joinSemanticFindings(entries, diag.AnalyzeConfigSemantics(m.cfg))
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Knob != entries[j].Knob {
+			return entries[i].Knob < entries[j].Knob
+		}
+		if entries[i].Scanner != entries[j].Scanner {
+			return entries[i].Scanner < entries[j].Scanner
+		}
+		return entries[i].Scope < entries[j].Scope
+	})
+
+	inventory := ExemptionInventory{
+		ConfigLoaded:    true,
+		Entries:         entries,
+		ConfiguredCount: len(entries),
+		TrackingNote:    "owner/expiry/last-matched/suppressed-count telemetry is not tracked",
+	}
+	for _, entry := range entries {
+		switch entry.State {
+		case ExemptionStateInert:
+			inventory.InertCount++
+			inventory.Attention = append(inventory.Attention, entry)
+		case ExemptionStateMisdirected:
+			inventory.MisdirectedCount++
+			inventory.Attention = append(inventory.Attention, entry)
+		}
+	}
+	return inventory
+}
+
+func enumerateExemptionEntries(cfg *config.Config) []ExemptionEntry {
+	var entries []ExemptionEntry
+	addDomainList := func(scanner, knob string, domains []string) {
+		for _, domain := range domains {
+			entries = append(entries, newExemptionEntry(scanner, knob, domain, domain))
+		}
+	}
+
+	for _, entry := range cfg.Suppress {
+		entries = append(entries, newExemptionEntry("Proxy scanners", "suppress", entry.Path, strings.ToLower(entry.Rule),
+			attr("rule", entry.Rule),
+			attrIfSet("reason", entry.Reason),
+		))
+	}
+	addDomainList("Strict-mode reachability", "api_allowlist", cfg.APIAllowlist)
+	for _, pattern := range cfg.FileSentry.IgnorePatterns {
+		entries = append(entries, newExemptionEntry("File sentry", "file_sentry.ignore_patterns", pattern, pattern))
+	}
+	for _, pattern := range cfg.DLP.Patterns {
+		for _, domain := range pattern.ExemptDomains {
+			entries = append(entries, newExemptionEntry("DLP", "dlp.patterns[].exempt_domains", domain, domain,
+				attr("pattern", pattern.Name),
+			))
+		}
+	}
+	addDomainList("Response scanning", "response_scanning.exempt_domains", cfg.ResponseScanning.ExemptDomains)
+	addDomainList("Response scanning size limit", "response_scanning.size_exempt_domains", cfg.ResponseScanning.SizeExemptDomains)
+	for _, entry := range cfg.ResponseScanning.UnscannablePassthrough {
+		entries = append(entries, newExemptionEntry("Response scanning passthrough", "response_scanning.unscannable_passthrough", entry.Host, entry.Host,
+			attrIfSet("paths", strings.Join(entry.Paths, ", ")),
+			attrIfSet("content_types", strings.Join(entry.ContentTypes, ", ")),
+			attrIfSet("reason", entry.Reason),
+		))
+	}
+	for _, entry := range cfg.ResponseScanning.MCPServers {
+		entries = append(entries, newExemptionEntry("MCP response trust", "response_scanning.mcp_servers", entry.Server, entry.Server,
+			attr("trust", entry.Trust),
+		))
+	}
+
+	addDomainList("Query entropy", "fetch_proxy.monitoring.query_entropy_exclusions", cfg.FetchProxy.Monitoring.QueryEntropyExclusions)
+	addDomainList("Subdomain entropy", "fetch_proxy.monitoring.subdomain_entropy_exclusions", cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions)
+	for _, entry := range cfg.FetchProxy.Monitoring.QueryEntropyParamExclusions {
+		tuple := queryEntropyParamScope(entry)
+		entries = append(entries, newExemptionEntry("Query entropy parameter", "fetch_proxy.monitoring.query_entropy_param_exclusions", tuple, tuple,
+			attr("host", entry.Host),
+			attr("path", entry.Path),
+			attr("param", entry.Param),
+			attrIfSet("scheme", entry.Scheme),
+			attrIfSet("reason", entry.Reason),
+		))
+	}
+
+	addDomainList("TLS interception", "tls_interception.passthrough_domains", cfg.TLSInterception.PassthroughDomains)
+	addDomainList("SSRF", "trusted_domains", cfg.TrustedDomains)
+	addDomainList("SSRF", "ssrf.ip_allowlist", cfg.SSRF.IPAllowlist)
+	for _, cidr := range cfg.KillSwitch.AllowlistIPs {
+		entries = append(entries, newExemptionEntry("Kill switch", "kill_switch.allowlist_ips", cidr, cidr))
+	}
+	addBooleanExemption := func(knob, scope string, enabled *bool) {
+		if enabled == nil || !*enabled {
+			return
+		}
+		entries = append(entries, newExemptionEntry("Kill switch", knob, scope, scope, attr("value", "true")))
+	}
+	addBooleanExemption("kill_switch.health_exempt", "health endpoints", cfg.KillSwitch.HealthExempt)
+	addBooleanExemption("kill_switch.metrics_exempt", "metrics endpoints", cfg.KillSwitch.MetricsExempt)
+	addBooleanExemption("kill_switch.api_exempt", "kill-switch API endpoints", cfg.KillSwitch.APIExempt)
+	addDomainList("Adaptive enforcement", "adaptive_enforcement.exempt_domains", cfg.AdaptiveEnforcement.ExemptDomains)
+	addDomainList("Cross-request entropy", "cross_request_detection.entropy_budget.exempt_domains", cfg.CrossRequestDetection.EntropyBudget.ExemptDomains)
+	addDomainList("Browser shield", "browser_shield.exempt_domains", cfg.BrowserShield.ExemptDomains)
+	for _, header := range cfg.RequestBodyScanning.IgnoreHeaders {
+		entries = append(entries, newExemptionEntry("Request header DLP", "request_body_scanning.ignore_headers", header, strings.ToLower(header)))
+	}
+	addDomainList("Taint trust", "taint.allowlisted_domains", cfg.Taint.AllowlistedDomains)
+	addDomainList("Taint trust", "taint.trusted_mcp_servers", cfg.Taint.TrustedMCPServers)
+	for _, override := range cfg.Taint.TrustOverrides {
+		scope := override.Scope
+		if scope == "" {
+			scope = override.SourceMatch
+		}
+		entries = append(entries, newExemptionEntry("Taint trust", "taint.trust_overrides", scope, scope,
+			attrIfSet("source_match", override.SourceMatch),
+			attrIfSet("action_match", override.ActionMatch),
+			attrIfSet("reason", override.Reason),
+		))
+	}
+
+	addDomainList("Address protection", "address_protection.allowed_addresses", cfg.AddressProtection.AllowedAddresses)
+	if cfg.ReverseProxy.TrustedUpstream.Host != "" || cfg.ReverseProxy.TrustedUpstream.Port != 0 {
+		upstream := cfg.ReverseProxy.TrustedUpstream
+		scope := upstream.Host
+		if upstream.Port != 0 {
+			scope = fmt.Sprintf("%s:%d", upstream.Host, upstream.Port)
+		}
+		entries = append(entries, newExemptionEntry("Reverse proxy", "reverse_proxy.trusted_upstream", scope, scope,
+			attrIfSet("reason", upstream.Reason),
+			attrIfSet("added", upstream.Added),
+		))
+	}
+
+	agentNames := make([]string, 0, len(cfg.Agents))
+	for name := range cfg.Agents {
+		agentNames = append(agentNames, name)
+	}
+	sort.Strings(agentNames)
+	for _, name := range agentNames {
+		profile := cfg.Agents[name]
+		for _, domain := range profile.TrustedDomains {
+			entries = append(entries, newExemptionEntry("Agent SSRF", "agents[].trusted_domains", domain, domain, attr("agent", name)))
+		}
+		for _, domain := range profile.APIAllowlist {
+			entries = append(entries, newExemptionEntry("Agent strict-mode reachability", "agents[].api_allowlist", domain, domain, attr("agent", name)))
+		}
+		for _, address := range profile.AllowedAddresses {
+			entries = append(entries, newExemptionEntry("Agent address protection", "agents[].allowed_addresses", address, address, attr("agent", name)))
+		}
+	}
+
+	return entries
+}
+
+func newExemptionEntry(scanner, knob, scope, matchValue string, attributes ...ExemptionAttribute) ExemptionEntry {
+	return ExemptionEntry{
+		Scanner:         scanner,
+		Knob:            knob,
+		Scope:           scope,
+		Attributes:      compactAttributes(attributes),
+		State:           ExemptionStateActive,
+		Owner:           notTracked,
+		Expiry:          notTracked,
+		LastMatched:     notTracked,
+		Suppressed:      notTracked,
+		semanticSubject: normalizeExemptionSemanticSubject(knob, matchValue),
+	}
+}
+
+func normalizeExemptionSemanticSubject(knob, subject string) string {
+	subject = strings.TrimSpace(subject)
+	switch knob {
+	case "suppress", "request_body_scanning.ignore_headers":
+		return strings.ToLower(subject)
+	default:
+		return subject
+	}
+}
+
+func compactAttributes(attributes []ExemptionAttribute) []ExemptionAttribute {
+	out := attributes[:0]
+	for _, attribute := range attributes {
+		if strings.TrimSpace(attribute.Value) == "" {
+			continue
+		}
+		out = append(out, attribute)
+	}
+	return out
+}
+
+func attr(name, value string) ExemptionAttribute {
+	return ExemptionAttribute{Name: name, Value: value}
+}
+
+func attrIfSet(name, value string) ExemptionAttribute {
+	return ExemptionAttribute{Name: name, Value: strings.TrimSpace(value)}
+}
+
+func queryEntropyParamScope(entry config.QueryEntropyParamExclusion) string {
+	scheme := entry.Scheme
+	if scheme == "" {
+		scheme = config.QueryEntropyParamDefaultScheme
+	}
+	return fmt.Sprintf("%s://%s%s?%s", scheme, entry.Host, entry.Path, entry.Param)
+}
+
+func joinSemanticFindings(entries []ExemptionEntry, findings []diag.ConfigSemanticFinding) {
+	for _, finding := range findings {
+		if finding.Kind != diag.ConfigSemanticKindInert && finding.Kind != diag.ConfigSemanticKindMisdirected {
+			continue
+		}
+		for i := range entries {
+			if !semanticFindingMatchesEntry(finding, entries[i]) {
+				continue
+			}
+			entries[i].State = finding.Kind
+			entries[i].Detail = finding.Detail
+			entries[i].Next = finding.Next
+		}
+	}
+}
+
+func semanticFindingMatchesEntry(finding diag.ConfigSemanticFinding, entry ExemptionEntry) bool {
+	if finding.Scope != entry.Knob {
+		return false
+	}
+	if finding.Subject == "" {
+		return true
+	}
+	return finding.Subject != "" && finding.Subject == entry.semanticSubject
+}

--- a/enterprise/dashboard/exemptions.tmpl.html
+++ b/enterprise/dashboard/exemptions.tmpl.html
@@ -1,0 +1,292 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Pipelock Exemptions</title>
+  <style>
+    :root {
+      --accent:#00e5a0;
+      --bg:#09090b;
+      --bg-elevated:#0e0e11;
+      --border:rgba(255,255,255,0.07);
+      --border-strong:rgba(255,255,255,0.13);
+      --text:#e2e8f0;
+      --text-muted:#94a3b8;
+      --text-dim:#64748b;
+      --warn:#f59e0b;
+      --danger:#ef4444;
+    }
+    * { box-sizing: border-box; }
+    html, body { min-height: 100%; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.45 Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .topbar {
+      height: 56px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 24px;
+      border-bottom: 1px solid var(--border-strong);
+      background: #08080a;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+    .brand { font-weight: 650; }
+    .brand span { color: var(--text-muted); font-weight: 500; }
+    .nav { display: flex; align-items: center; gap: 14px; color: var(--text-dim); font-size: 13px; }
+    .nav a { color: var(--text-muted); text-decoration: none; }
+    .nav a:hover { color: var(--text); }
+    main {
+      min-width: 0;
+      padding: 24px;
+    }
+    .panel {
+      max-width: 1280px;
+      margin: 0 auto;
+    }
+    .heading {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 20px;
+      margin-bottom: 18px;
+    }
+    h1, h2, h3 { margin: 0; letter-spacing: 0; }
+    h1 { font-size: 24px; }
+    h2 { font-size: 16px; margin-bottom: 12px; }
+    .muted { color: var(--text-muted); }
+    .dim { color: var(--text-dim); }
+    .mono { font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(150px, 1fr));
+      gap: 10px;
+      margin-bottom: 18px;
+    }
+    .metric {
+      border: 1px solid var(--border);
+      background: var(--bg-elevated);
+      border-radius: 8px;
+      padding: 14px;
+    }
+    .metric-value { font-size: 22px; font-weight: 750; }
+    .metric-label { color: var(--text-muted); margin-top: 2px; }
+    .section {
+      border-top: 1px solid var(--border-strong);
+      padding-top: 18px;
+      margin-top: 18px;
+    }
+    .callout {
+      border: 1px solid var(--border-strong);
+      background: #0b0f0e;
+      padding: 14px;
+      border-radius: 8px;
+    }
+    .absence {
+      border: 1px solid rgba(245,158,11,0.7);
+      background: rgba(245,158,11,0.10);
+      padding: 18px;
+      border-radius: 8px;
+    }
+    .absence h2 { color: #fde68a; font-size: 20px; }
+    .attention {
+      display: grid;
+      gap: 10px;
+    }
+    .finding {
+      border: 1px solid rgba(245,158,11,0.35);
+      background: var(--bg-elevated);
+      border-radius: 8px;
+      padding: 14px;
+    }
+    .finding-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: flex-start;
+      margin-bottom: 8px;
+    }
+    .chip {
+      display: inline-flex;
+      justify-content: center;
+      min-width: 96px;
+      padding: 4px 9px;
+      border-radius: 999px;
+      color: #050507;
+      font-size: 12px;
+      font-weight: 800;
+      white-space: nowrap;
+    }
+    .chip.active { background: var(--accent); }
+    .chip.inert { background: var(--danger); color: white; }
+    .chip.misdirected { background: var(--warn); }
+    .table-wrap {
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg-elevated);
+    }
+    table {
+      width: 100%;
+      min-width: 1120px;
+      border-collapse: collapse;
+    }
+    th, td {
+      padding: 11px 12px;
+      text-align: left;
+      vertical-align: top;
+      border-bottom: 1px solid var(--border);
+    }
+    th {
+      color: var(--text-muted);
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      background: #0b0b0e;
+    }
+    tr:last-child td { border-bottom: 0; }
+    .scope, .detail { overflow-wrap: anywhere; }
+    .attrs { display: grid; gap: 4px; }
+    .attr-name { color: var(--text-dim); }
+    .empty {
+      color: var(--text-muted);
+      padding: 26px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg-elevated);
+    }
+    @media (max-width: 900px) {
+      main { padding: 16px; }
+      .heading, .summary { grid-template-columns: 1fr; }
+      .summary { display: grid; }
+      .topbar { align-items: flex-start; height: auto; min-height: 56px; padding: 14px 16px; gap: 10px; flex-direction: column; }
+    }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">Pipelock <span>- Operator Console / Exemptions</span></div>
+    <div class="nav"><a href="/">Evidence</a><span class="mono">air-gapped - self-hosted</span></div>
+  </header>
+  <main>
+    <div class="panel">
+      <div class="heading">
+        <div>
+          <h1>Exemptions inventory</h1>
+          <div class="muted">{{.Inventory.TrackingNote}}</div>
+        </div>
+        {{if .Inventory.ConfigLoaded}}
+          <div class="dim mono">{{.Inventory.ConfiguredCount}} configured</div>
+        {{else}}
+          <div class="dim mono">no config loaded</div>
+        {{end}}
+      </div>
+
+      {{if not .Inventory.ConfigLoaded}}
+        <section class="absence">
+          <h2>No config loaded</h2>
+          <p class="muted">Start the dashboard with <span class="mono">--config</span> to show configured exemptions. The evidence view still works without a config.</p>
+        </section>
+      {{else}}
+        <section class="summary" aria-label="Exemption counts">
+          <div class="metric">
+            <div class="metric-value mono">{{.Inventory.ConfiguredCount}}</div>
+            <div class="metric-label">exemptions configured</div>
+          </div>
+          <div class="metric">
+            <div class="metric-value mono">{{.Inventory.InertCount}}</div>
+            <div class="metric-label">inert (does nothing)</div>
+          </div>
+          <div class="metric">
+            <div class="metric-value mono">{{.Inventory.MisdirectedCount}}</div>
+            <div class="metric-label">wrong knob</div>
+          </div>
+          <div class="metric">
+            <div class="metric-value mono">not tracked</div>
+            <div class="metric-label">owner / expiry / matches</div>
+          </div>
+        </section>
+
+        <section class="section">
+          <h2>Attention</h2>
+          {{if .Inventory.Attention}}
+            <div class="attention">
+              {{range .Inventory.Attention}}
+                <article class="finding">
+                  <div class="finding-head">
+                    <div>
+                      <strong>{{.Knob}}</strong>
+                      <div class="dim mono">{{.Scope}}</div>
+                    </div>
+                    <span class="chip {{.State}}">{{.State}}</span>
+                  </div>
+                  <div class="detail">{{.Detail}}</div>
+                  {{if .Next}}<div class="muted">Next: {{.Next}}</div>{{end}}
+                </article>
+              {{end}}
+            </div>
+          {{else}}
+            <div class="callout muted">No inert or wrong-knob findings from the config semantic analyzer.</div>
+          {{end}}
+        </section>
+
+        <section class="section">
+          <h2>Inventory</h2>
+          {{if .Inventory.Entries}}
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Scanner</th>
+                    <th>Knob</th>
+                    <th>Scope</th>
+                    <th>Attributes</th>
+                    <th>State</th>
+                    <th>Owner</th>
+                    <th>Expiry</th>
+                    <th>Last matched</th>
+                    <th>Suppressed</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {{range .Inventory.Entries}}
+                    <tr>
+                      <td>{{.Scanner}}</td>
+                      <td class="mono">{{.Knob}}</td>
+                      <td class="scope mono">{{.Scope}}</td>
+                      <td>
+                        {{if .Attributes}}
+                          <div class="attrs">
+                            {{range .Attributes}}
+                              <div><span class="attr-name">{{.Name}}:</span> <span class="mono">{{.Value}}</span></div>
+                            {{end}}
+                          </div>
+                        {{else}}
+                          <span class="dim">none</span>
+                        {{end}}
+                      </td>
+                      <td><span class="chip {{.State}}">{{.State}}</span></td>
+                      <td>{{.Owner}}</td>
+                      <td>{{.Expiry}}</td>
+                      <td>{{.LastMatched}}</td>
+                      <td>{{.Suppressed}}</td>
+                    </tr>
+                  {{end}}
+                </tbody>
+              </table>
+            </div>
+          {{else}}
+            <div class="empty">No exemption entries are configured in the loaded config.</div>
+          {{end}}
+        </section>
+      {{end}}
+    </div>
+  </main>
+</body>
+</html>

--- a/enterprise/dashboard/exemptions.tmpl.html
+++ b/enterprise/dashboard/exemptions.tmpl.html
@@ -188,6 +188,10 @@
         {{end}}
       </div>
 
+      {{if .Inventory.RawRedacted}}
+        <div class="callout muted" style="margin-bottom:18px;">Configured values (destinations, IP allowlists, addresses, paths, rules) are hidden. Knob names, states, and counts are shown; raw access is required to view the values.</div>
+      {{end}}
+
       {{if not .Inventory.ConfigLoaded}}
         <section class="absence">
           <h2>No config loaded</h2>

--- a/enterprise/dashboard/exemptions_test.go
+++ b/enterprise/dashboard/exemptions_test.go
@@ -451,11 +451,15 @@ func TestHandler_ExemptionsHostileConfigEscapes(t *testing.T) {
 		}},
 	}
 	handler := New(Options{
-		ReceiptDir:  t.TempDir(),
-		Config:      cfg,
-		HasFeature:  allowAgentsFeature,
-		Authorize:   func(*http.Request) error { return nil },
-		AuditWriter: &strings.Builder{},
+		ReceiptDir: t.TempDir(),
+		Config:     cfg,
+		HasFeature: allowAgentsFeature,
+		Authorize:  func(*http.Request) error { return nil },
+		// Raw access so the hostile config values are actually rendered (and
+		// therefore html/template-escaped); the metadata-only path redacts them
+		// instead and is covered by TestHandler_ExemptionsMetadataViewRedactsRawValues.
+		AuthorizeRaw: allowRawAccess,
+		AuditWriter:  &strings.Builder{},
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/exemptions", nil))
@@ -490,4 +494,64 @@ func assertEntryState(t *testing.T, inventory ExemptionInventory, knob, scope, s
 		}
 	}
 	t.Fatalf("missing entry knob=%q scope=%q; entries=%+v", knob, scope, inventory.Entries)
+}
+
+func TestHandler_ExemptionsMetadataViewRedactsRawValues(t *testing.T) {
+	t.Parallel()
+
+	const (
+		shieldDomain = "secret-shield.internal.example"
+		ssrfDomain   = "secret-ssrf.internal.example"
+		ssrfIP       = "10.9.8.7/32"
+		agentDomain  = "secret-agent.internal.example"
+	)
+	cfg := &config.Config{
+		BrowserShield:  config.BrowserShield{Enabled: false, ExemptDomains: []string{shieldDomain}},
+		TrustedDomains: []string{ssrfDomain},
+		SSRF:           config.SSRF{IPAllowlist: []string{ssrfIP}},
+		Agents:         map[string]config.AgentProfile{"agent-a": {TrustedDomains: []string{agentDomain}}},
+	}
+	sensitive := []string{shieldDomain, ssrfDomain, ssrfIP, agentDomain}
+
+	// Metadata-only view (no raw authorizer): raw infra values must be redacted.
+	metaBody := serveExemptionsBody(t, cfg, false)
+	for _, s := range sensitive {
+		if strings.Contains(metaBody, s) {
+			t.Fatalf("metadata view leaked raw value %q; body=%s", s, metaBody)
+		}
+	}
+	// The view stays useful: knob names, states, counts, and the redaction note.
+	for _, want := range []string{diag.ConfigScopeBrowserShieldExemptDomains, "raw access is required", "inert"} {
+		if !strings.Contains(metaBody, want) {
+			t.Fatalf("metadata view missing %q; body=%s", want, metaBody)
+		}
+	}
+
+	// Raw-authorized view shows the actual values.
+	rawBody := serveExemptionsBody(t, cfg, true)
+	for _, s := range sensitive {
+		if !strings.Contains(rawBody, s) {
+			t.Fatalf("raw view missing value %q", s)
+		}
+	}
+}
+
+func serveExemptionsBody(t *testing.T, cfg *config.Config, raw bool) string {
+	t.Helper()
+	opts := Options{
+		ReceiptDir: t.TempDir(),
+		Config:     cfg,
+		HasFeature: allowAgentsFeature,
+		Authorize:  func(*http.Request) error { return nil },
+	}
+	if raw {
+		opts.AuthorizeRaw = allowRawAccess
+	}
+	handler := New(opts)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/exemptions", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	return rec.Body.String()
 }

--- a/enterprise/dashboard/exemptions_test.go
+++ b/enterprise/dashboard/exemptions_test.go
@@ -1,0 +1,493 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cli/diag"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestExemptions_NoConfigLoaded(t *testing.T) {
+	t.Parallel()
+
+	model := NewReadModel(Options{})
+	inventory := model.Exemptions()
+	if inventory.ConfigLoaded {
+		t.Fatal("ConfigLoaded = true, want false")
+	}
+	if inventory.ConfiguredCount != 0 || len(inventory.Entries) != 0 {
+		t.Fatalf("empty inventory = %+v", inventory)
+	}
+	if !strings.Contains(inventory.TrackingNote, "not tracked") {
+		t.Fatalf("TrackingNote = %q, want not tracked", inventory.TrackingNote)
+	}
+
+	var nilModel *ReadModel
+	nilInventory := nilModel.Exemptions()
+	if nilInventory.ConfigLoaded || nilInventory.ConfiguredCount != 0 {
+		t.Fatalf("nil model inventory = %+v, want unloaded empty inventory", nilInventory)
+	}
+}
+
+func TestExemptions_ConfigLoadedNoEntries(t *testing.T) {
+	t.Parallel()
+
+	inventory := NewReadModel(Options{Config: &config.Config{}}).Exemptions()
+	if !inventory.ConfigLoaded {
+		t.Fatal("ConfigLoaded = false, want true")
+	}
+	if inventory.ConfiguredCount != 0 || len(inventory.Entries) != 0 || len(inventory.Attention) != 0 {
+		t.Fatalf("loaded empty inventory = %+v, want no entries or attention", inventory)
+	}
+}
+
+func TestExemptions_PristineDefaultsHaveNoAttentionFindings(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.ApplyDefaults()
+	inventory := NewReadModel(Options{Config: cfg}).Exemptions()
+	if !inventory.ConfigLoaded {
+		t.Fatal("ConfigLoaded = false, want true")
+	}
+	t.Logf("dashboard default inert count = %d, misdirected count = %d", inventory.InertCount, inventory.MisdirectedCount)
+	if inventory.InertCount != 0 || inventory.MisdirectedCount != 0 {
+		t.Fatalf("pristine default attention counts: inert=%d misdirected=%d, want 0/0; attention=%+v",
+			inventory.InertCount, inventory.MisdirectedCount, inventory.Attention)
+	}
+}
+
+func TestExemptions_EnumeratesConfiguredKnobFamiliesAndJoinsFindings(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	cfg := &config.Config{
+		APIAllowlist: []string{"public.vendor.example"},
+		Suppress: []config.SuppressEntry{{
+			Rule:   "Vendor Token",
+			Path:   "*api.vendor.example*",
+			Reason: "provider-bound credential",
+		}},
+		FileSentry: config.FileSentry{
+			IgnorePatterns: []string{"vendor-cache/**"},
+		},
+		DLP: config.DLP{
+			Patterns: []config.DLPPattern{{
+				Name:          "Vendor Token",
+				Regex:         "vendortok_[a-z0-9]{20}",
+				Severity:      config.SeverityHigh,
+				ExemptDomains: []string{"api.vendor.example"},
+			}},
+		},
+		ResponseScanning: config.ResponseScanning{
+			Enabled:       false,
+			ExemptDomains: []string{"responses.vendor.example"},
+			SizeExemptDomains: []string{
+				"downloads.vendor.example",
+			},
+			UnscannablePassthrough: []config.UnscannablePassthroughEntry{{
+				Host:         "media.vendor.example",
+				Paths:        []string{"/asset.bin"},
+				ContentTypes: []string{"application/octet-stream"},
+				Reason:       "opaque binary",
+			}},
+			MCPServers: []config.MCPResponseServerTrust{{
+				Server: "reasoning-cache",
+				Trust:  config.ResponseTrustReasoning,
+			}},
+		},
+		RequestBodyScanning: config.RequestBodyScanning{
+			Enabled:       true,
+			ScanHeaders:   false,
+			IgnoreHeaders: []string{"X-Provider-Trace"},
+		},
+		FetchProxy: config.FetchProxy{Monitoring: config.Monitoring{
+			EntropyThreshold:           4.5,
+			QueryEntropyExclusions:     []string{"query.vendor.example"},
+			SubdomainEntropyExclusions: []string{"*.cdn.vendor.example"},
+			QueryEntropyParamExclusions: []config.QueryEntropyParamExclusion{{
+				Host:   "api.vendor.example",
+				Path:   "/v1/search",
+				Param:  "query",
+				Reason: "structured query",
+			}},
+		}},
+		TLSInterception: config.TLSInterception{
+			PassthroughDomains: []string{"tls.vendor.example"},
+		},
+		TrustedDomains: []string{"internal.vendor.example"},
+		SSRF: config.SSRF{
+			IPAllowlist: []string{"10.0.0.0/24"},
+		},
+		KillSwitch: config.KillSwitch{
+			HealthExempt:  &enabled,
+			MetricsExempt: &enabled,
+			APIExempt:     &enabled,
+			AllowlistIPs:  []string{"192.0.2.10/32"},
+		},
+		AdaptiveEnforcement: config.AdaptiveEnforcement{
+			Enabled:       false,
+			ExemptDomains: []string{"adaptive.vendor.example"},
+		},
+		CrossRequestDetection: config.CrossRequestDetection{
+			EntropyBudget: config.CrossRequestEntropyBudget{
+				ExemptDomains: []string{"entropy.vendor.example"},
+			},
+		},
+		BrowserShield: config.BrowserShield{
+			ExemptDomains: []string{"browser.vendor.example"},
+		},
+		Taint: config.TaintConfig{
+			AllowlistedDomains: []string{"docs.vendor.example"},
+			TrustedMCPServers:  []string{"trusted-docs"},
+			TrustOverrides: []config.TaintTrustOverride{{
+				Scope:       "source",
+				SourceMatch: "docs.vendor.example",
+				ActionMatch: "read",
+				Reason:      "operator docs",
+			}},
+		},
+		AddressProtection: config.AddressProtection{
+			AllowedAddresses: []string{"0x1111111111111111111111111111111111111111"},
+		},
+		ReverseProxy: config.ReverseProxy{
+			TrustedUpstream: config.ReverseProxyTrustedUpstream{
+				Host:   "submit.vendor.example",
+				Port:   443,
+				Reason: "submit endpoint",
+				Added:  "2026-01-01",
+			},
+		},
+		Agents: map[string]config.AgentProfile{
+			"agent-a": {
+				APIAllowlist:     []string{"agent-api.vendor.example"},
+				TrustedDomains:   []string{"agent-internal.vendor.example"},
+				AllowedAddresses: []string{"0x2222222222222222222222222222222222222222"},
+			},
+		},
+	}
+
+	inventory := NewReadModel(Options{Config: cfg}).Exemptions()
+	if !inventory.ConfigLoaded {
+		t.Fatal("ConfigLoaded = false, want true")
+	}
+	if inventory.ConfiguredCount != 30 {
+		t.Fatalf("ConfiguredCount = %d, want 30; entries=%+v", inventory.ConfiguredCount, inventory.Entries)
+	}
+	if inventory.InertCount != 7 {
+		t.Fatalf("InertCount = %d, want 7", inventory.InertCount)
+	}
+	if inventory.MisdirectedCount != 0 {
+		t.Fatalf("MisdirectedCount = %d, want 0", inventory.MisdirectedCount)
+	}
+	assertEntryState(t, inventory, "response_scanning.exempt_domains", "responses.vendor.example", ExemptionStateInert)
+	assertEntryState(t, inventory, "adaptive_enforcement.exempt_domains", "adaptive.vendor.example", ExemptionStateInert)
+	assertEntryState(t, inventory, "cross_request_detection.entropy_budget.exempt_domains", "entropy.vendor.example", ExemptionStateInert)
+	assertEntryState(t, inventory, "browser_shield.exempt_domains", "browser.vendor.example", ExemptionStateInert)
+	assertEntryState(t, inventory, "tls_interception.passthrough_domains", "tls.vendor.example", ExemptionStateInert)
+	assertEntryState(t, inventory, "file_sentry.ignore_patterns", "vendor-cache/**", ExemptionStateActive)
+	assertEntryState(t, inventory, "kill_switch.allowlist_ips", "192.0.2.10/32", ExemptionStateActive)
+	assertEntryState(t, inventory, "kill_switch.health_exempt", "health endpoints", ExemptionStateActive)
+	assertEntryState(t, inventory, "kill_switch.metrics_exempt", "metrics endpoints", ExemptionStateActive)
+	assertEntryState(t, inventory, "kill_switch.api_exempt", "kill-switch API endpoints", ExemptionStateActive)
+	assertEntryState(t, inventory, "request_body_scanning.ignore_headers", "X-Provider-Trace", ExemptionStateInert)
+	assertEntryState(t, inventory, "response_scanning.mcp_servers", "reasoning-cache", ExemptionStateInert)
+	assertEntryState(t, inventory, "suppress", "*api.vendor.example*", ExemptionStateActive)
+	assertEntryState(t, inventory, "api_allowlist", "public.vendor.example", ExemptionStateActive)
+	assertEntryState(t, inventory, "agents[].api_allowlist", "agent-api.vendor.example", ExemptionStateActive)
+	assertEntryState(t, inventory, "fetch_proxy.monitoring.query_entropy_param_exclusions", "https://api.vendor.example/v1/search?query", ExemptionStateActive)
+}
+
+func TestExemptions_JoinDoesNotUseRenderedDetailSubstring(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	body := []byte(`version: 1
+mode: balanced
+response_scanning:
+  enabled: true
+  mcp_servers:
+    - server: "reasoning\"cache"
+      trust: reasoning
+`)
+	if err := os.WriteFile(configPath, body, 0o600); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load(config): %v", err)
+	}
+
+	inventory := NewReadModel(Options{Config: cfg}).Exemptions()
+	assertEntryState(t, inventory, "response_scanning.mcp_servers", `reasoning"cache`, ExemptionStateMisdirected)
+}
+
+func TestExemptions_JoinsMixedCaseHeaderFinding(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		RequestBodyScanning: config.RequestBodyScanning{
+			Enabled:       true,
+			ScanHeaders:   false,
+			IgnoreHeaders: []string{"X-Provider-Trace"},
+		},
+	}
+
+	inventory := NewReadModel(Options{Config: cfg}).Exemptions()
+	assertEntryState(t, inventory, "request_body_scanning.ignore_headers", "X-Provider-Trace", ExemptionStateInert)
+}
+
+func TestExemptions_HeaderDefaultStaysActiveButOperatorAddedInertWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	body := []byte(`mode: balanced
+request_body_scanning:
+  enabled: false
+  scan_headers: true
+  header_mode: all
+  ignore_headers:
+    - Accept
+    - X-Provider-Trace
+`)
+	if err := os.WriteFile(configPath, body, 0o600); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load(config): %v", err)
+	}
+
+	inventory := NewReadModel(Options{Config: cfg}).Exemptions()
+	// Accept is an auto-filled default header, not an operator-authored
+	// exemption, so it is never flagged even when the scanner is disabled.
+	assertEntryState(t, inventory, "request_body_scanning.ignore_headers", "Accept", ExemptionStateActive)
+	// X-Provider-Trace is operator-added and non-default, so it is inert while
+	// the ignore-list is not consumed.
+	assertEntryState(t, inventory, "request_body_scanning.ignore_headers", "X-Provider-Trace", ExemptionStateInert)
+}
+
+func TestExemptions_DefaultBaselinesDoNotBecomeAttentionWhenFeatureDisabled(t *testing.T) {
+	t.Parallel()
+
+	defaults := config.Defaults()
+	defaults.ApplyDefaults()
+	cfg := &config.Config{
+		BrowserShield: config.BrowserShield{
+			Enabled:       false,
+			ExemptDomains: append([]string(nil), defaults.BrowserShield.ExemptDomains...),
+		},
+		TLSInterception: config.TLSInterception{
+			Enabled:            false,
+			PassthroughDomains: append([]string(nil), defaults.TLSInterception.PassthroughDomains...),
+		},
+		RequestBodyScanning: config.RequestBodyScanning{
+			Enabled:       false,
+			ScanHeaders:   true,
+			HeaderMode:    config.HeaderModeAll,
+			IgnoreHeaders: append([]string(nil), defaults.RequestBodyScanning.IgnoreHeaders...),
+		},
+	}
+
+	inventory := NewReadModel(Options{Config: cfg}).Exemptions()
+	for _, domain := range defaults.BrowserShield.ExemptDomains {
+		assertEntryState(t, inventory, "browser_shield.exempt_domains", domain, ExemptionStateActive)
+	}
+	for _, domain := range defaults.TLSInterception.PassthroughDomains {
+		assertEntryState(t, inventory, "tls_interception.passthrough_domains", domain, ExemptionStateActive)
+	}
+	for _, header := range defaults.RequestBodyScanning.IgnoreHeaders {
+		assertEntryState(t, inventory, "request_body_scanning.ignore_headers", header, ExemptionStateActive)
+	}
+	if inventory.InertCount != 0 {
+		t.Fatalf("InertCount = %d, want 0; inventory=%+v", inventory.InertCount, inventory)
+	}
+
+	handler := New(Options{
+		ReceiptDir:   t.TempDir(),
+		Config:       cfg,
+		HasFeature:   allowAgentsFeature,
+		Authorize:    func(*http.Request) error { return nil },
+		AuthorizeRaw: allowRawAccess,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/exemptions", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, `chip inert">inert</span>`) {
+		t.Fatalf("default baselines should not render an inert chip: %s", body)
+	}
+}
+
+func TestExemptions_ResponseSizeAndUnscannableRemainActiveWhenResponseScanningDisabled(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	body := []byte(`mode: balanced
+response_scanning:
+  enabled: false
+  size_exempt_domains:
+    - downloads.vendor.example
+  unscannable_passthrough:
+    - host: downloads.vendor.example
+      paths:
+        - /archive.bin
+      content_types:
+        - application/octet-stream
+      reason: trusted binary mirror
+      expires: 2099-01-01
+`)
+	if err := os.WriteFile(configPath, body, 0o600); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load(config): %v", err)
+	}
+
+	inventory := NewReadModel(Options{Config: cfg}).Exemptions()
+	assertEntryState(t, inventory, "response_scanning.size_exempt_domains", "downloads.vendor.example", ExemptionStateActive)
+	assertEntryState(t, inventory, "response_scanning.unscannable_passthrough", "downloads.vendor.example", ExemptionStateActive)
+}
+
+func TestExemptions_CountsMisdirectedAttention(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		ResponseScanning: config.ResponseScanning{
+			Enabled: true,
+			MCPServers: []config.MCPResponseServerTrust{{
+				Server: "reasoning-cache",
+				Trust:  config.ResponseTrustReasoning,
+			}},
+		},
+	}
+
+	inventory := NewReadModel(Options{Config: cfg}).Exemptions()
+	if inventory.MisdirectedCount != 1 {
+		t.Fatalf("MisdirectedCount = %d, want 1; inventory=%+v", inventory.MisdirectedCount, inventory)
+	}
+	if len(inventory.Attention) != 1 || inventory.Attention[0].State != ExemptionStateMisdirected {
+		t.Fatalf("Attention = %+v, want one misdirected entry", inventory.Attention)
+	}
+	assertEntryState(t, inventory, "response_scanning.mcp_servers", "reasoning-cache", ExemptionStateMisdirected)
+}
+
+func TestSemanticFindingMatchesEntryBranches(t *testing.T) {
+	t.Parallel()
+
+	entry := newExemptionEntry("Request header DLP", "request_body_scanning.ignore_headers", "X-Provider-Trace", "X-Provider-Trace")
+	tests := []struct {
+		name    string
+		finding diag.ConfigSemanticFinding
+		want    bool
+	}{
+		{
+			name: "scope mismatch",
+			finding: diag.ConfigSemanticFinding{
+				Scope:   "suppress",
+				Subject: "x-provider-trace",
+			},
+			want: false,
+		},
+		{
+			name: "family wide fallback",
+			finding: diag.ConfigSemanticFinding{
+				Scope: "request_body_scanning.ignore_headers",
+			},
+			want: true,
+		},
+		{
+			name: "normalized subject match",
+			finding: diag.ConfigSemanticFinding{
+				Scope:   "request_body_scanning.ignore_headers",
+				Subject: "x-provider-trace",
+			},
+			want: true,
+		},
+		{
+			name: "subject mismatch",
+			finding: diag.ConfigSemanticFinding{
+				Scope:   "request_body_scanning.ignore_headers",
+				Subject: "x-other",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := semanticFindingMatchesEntry(tt.finding, entry); got != tt.want {
+				t.Fatalf("semanticFindingMatchesEntry() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandler_ExemptionsHostileConfigEscapes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		ResponseScanning: config.ResponseScanning{
+			Enabled:       true,
+			ExemptDomains: []string{hostileScript},
+		},
+		Suppress: []config.SuppressEntry{{
+			Rule:   hostileImage,
+			Path:   hostileJSURL,
+			Reason: hostileJSON,
+		}},
+	}
+	handler := New(Options{
+		ReceiptDir:  t.TempDir(),
+		Config:      cfg,
+		HasFeature:  allowAgentsFeature,
+		Authorize:   func(*http.Request) error { return nil },
+		AuditWriter: &strings.Builder{},
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/exemptions", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, raw := range []string{hostileScript, hostileImage, hostileJSON} {
+		if strings.Contains(body, raw) {
+			t.Fatalf("response contains unescaped hostile config value %q", raw)
+		}
+	}
+	if strings.Contains(body, `href="javascript:`) {
+		t.Fatal("response contains javascript URL in href context")
+	}
+	if !strings.Contains(body, "&lt;script&gt;alert(1)&lt;/script&gt;") {
+		t.Fatal("response should contain escaped script text")
+	}
+	if !strings.Contains(body, "not tracked") {
+		t.Fatal("response should state lifecycle telemetry is not tracked")
+	}
+}
+
+func assertEntryState(t *testing.T, inventory ExemptionInventory, knob, scope, state string) {
+	t.Helper()
+	for _, entry := range inventory.Entries {
+		if entry.Knob == knob && entry.Scope == scope {
+			if entry.State != state {
+				t.Fatalf("%s %s state = %q, want %q; entry=%+v", knob, scope, entry.State, state, entry)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing entry knob=%q scope=%q; entries=%+v", knob, scope, inventory.Entries)
+}

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -223,7 +223,16 @@ func (d *dashboardHandler) handleExemptions(w http.ResponseWriter, r *http.Reque
 	if !requireGet(w, r) {
 		return
 	}
-	data := exemptionsPageData{Inventory: d.model.Exemptions()}
+	inventory := d.model.Exemptions()
+	// Exemption scopes/attributes are a map of internal destinations, IP
+	// allowlists, addresses, and enforcement exceptions — as sensitive as the
+	// evidence view's raw destinations. Fail closed: strip them in Go unless
+	// this request is authorized for raw, so raw values never reach a
+	// metadata-only response.
+	if !rawAllowedFromContext(r) {
+		inventory = redactExemptions(inventory)
+	}
+	data := exemptionsPageData{Inventory: inventory}
 	var buf bytes.Buffer
 	if err := exemptionsTemplate.Execute(&buf, data); err != nil {
 		http.Error(w, "could not render exemptions", http.StatusInternalServerError)

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -28,10 +28,13 @@ const (
 	auditSessionMaxBytes  = 128
 )
 
-//go:embed evidence.tmpl.html
+//go:embed evidence.tmpl.html exemptions.tmpl.html
 var templateFS embed.FS
 
-var evidenceTemplate = template.Must(template.ParseFS(templateFS, "evidence.tmpl.html"))
+var (
+	evidenceTemplate   = template.Must(template.ParseFS(templateFS, "evidence.tmpl.html"))
+	exemptionsTemplate = template.Must(template.ParseFS(templateFS, "exemptions.tmpl.html"))
+)
 
 type pageData struct {
 	Sessions        []SessionSummary
@@ -39,6 +42,10 @@ type pageData struct {
 	Evidence        SessionEvidence
 	HasEvidence     bool
 	RawAllowed      bool
+}
+
+type exemptionsPageData struct {
+	Inventory ExemptionInventory
 }
 
 // New returns a read-only HTTP handler for the Enterprise Evidence dashboard.
@@ -61,6 +68,7 @@ func New(opts Options) http.Handler {
 		auditWriter:  opts.AuditWriter,
 	}
 	mux.Handle("/", d.gate(http.HandlerFunc(d.handleIndex)))
+	mux.Handle("/exemptions", d.gate(http.HandlerFunc(d.handleExemptions)))
 	mux.Handle("/session/", d.gate(http.HandlerFunc(d.handleSession)))
 	return mux
 }
@@ -205,6 +213,24 @@ func (d *dashboardHandler) handleSession(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	d.render(w, sessions, selected, rawAllowedFromContext(r))
+}
+
+func (d *dashboardHandler) handleExemptions(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/exemptions" {
+		http.NotFound(w, r)
+		return
+	}
+	if !requireGet(w, r) {
+		return
+	}
+	data := exemptionsPageData{Inventory: d.model.Exemptions()}
+	var buf bytes.Buffer
+	if err := exemptionsTemplate.Execute(&buf, data); err != nil {
+		http.Error(w, "could not render exemptions", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", contentTypeHTML)
+	_, _ = w.Write(buf.Bytes())
 }
 
 func requireGet(w http.ResponseWriter, r *http.Request) bool {

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
@@ -59,6 +60,12 @@ func TestHandler_Gating(t *testing.T) {
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("false HasFeature /session status = %d, want %d", rec.Code, http.StatusForbidden)
 	}
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/exemptions", nil))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("false HasFeature /exemptions status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
 }
 
 func TestHandler_AllowedRendersScorecard(t *testing.T) {
@@ -90,6 +97,43 @@ func TestHandler_AllowedRendersScorecard(t *testing.T) {
 		if got := rec.Header().Get(header); got != want {
 			t.Fatalf("%s = %q, want %q", header, got, want)
 		}
+	}
+}
+
+func TestHandler_ExemptionsAllowedRendersInventory(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		ResponseScanning: config.ResponseScanning{
+			Enabled:       false,
+			ExemptDomains: []string{"api.vendor.example"},
+		},
+	}
+	var audit strings.Builder
+	handler := New(Options{
+		ReceiptDir:   t.TempDir(),
+		Config:       cfg,
+		HasFeature:   allowAgentsFeature,
+		Authorize:    func(*http.Request) error { return nil },
+		AuditWriter:  &audit,
+		AuthorizeRaw: allowRawAccess,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/exemptions", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Exemptions inventory", "api.vendor.example", "inert", "not tracked"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+	if got := rec.Header().Get("Content-Security-Policy"); got != contentSecurityPolicy {
+		t.Fatalf("CSP = %q, want %q", got, contentSecurityPolicy)
+	}
+	if !strings.Contains(audit.String(), "path=\"/exemptions\"") {
+		t.Fatalf("audit should record exemptions path; got %q", audit.String())
 	}
 }
 
@@ -180,7 +224,9 @@ func TestHandler_MethodAndPathRejection(t *testing.T) {
 		want   int
 	}{
 		{name: "post index", method: http.MethodPost, path: "/", want: http.StatusMethodNotAllowed},
+		{name: "post exemptions", method: http.MethodPost, path: "/exemptions", want: http.StatusMethodNotAllowed},
 		{name: "nested session path", method: http.MethodGet, path: "/session/foo/bar", want: http.StatusNotFound},
+		{name: "nested exemptions path", method: http.MethodGet, path: "/exemptions/extra", want: http.StatusNotFound},
 		{name: "unknown path", method: http.MethodGet, path: "/nope", want: http.StatusNotFound},
 	}
 
@@ -285,6 +331,12 @@ func TestHandler_AuthorizeFailsClosed(t *testing.T) {
 	allowed.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("accepting Authorize status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	rec = httptest.NewRecorder()
+	denied.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/exemptions", nil))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("rejecting Authorize /exemptions status = %d, want %d", rec.Code, http.StatusForbidden)
 	}
 }
 

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
@@ -29,6 +30,7 @@ const (
 type Options struct {
 	ReceiptDir  string
 	TrustedKeys map[string]TrustedKey
+	Config      *config.Config
 	HasFeature  func(string) bool
 	// Authorize, when non-nil, runs per request after the license-feature check
 	// and fails the request closed (403) on a non-nil error. It is the handler's
@@ -54,6 +56,7 @@ type Options struct {
 type ReadModel struct {
 	receiptDir       string
 	trustedKeys      map[string]TrustedKey
+	cfg              *config.Config
 	receiptReadLimit int
 	timelineLimit    int
 }
@@ -123,6 +126,7 @@ func NewReadModel(opts Options) *ReadModel {
 	return &ReadModel{
 		receiptDir:       opts.ReceiptDir,
 		trustedKeys:      cloneTrustedKeys(opts.TrustedKeys),
+		cfg:              opts.Config,
 		receiptReadLimit: receiptReadLimit,
 		timelineLimit:    timelineLimit,
 	}

--- a/internal/cli/diag/check_conductor_advisory_test.go
+++ b/internal/cli/diag/check_conductor_advisory_test.go
@@ -42,7 +42,7 @@ func TestCheckConductorAdvisories(t *testing.T) {
 				// Disable flight recorder to suppress the unrelated advisory.
 				cfg.FlightRecorder.Enabled = false
 			},
-			wantNoAdvisories: true,
+			forbidSubstr: "conductor.enabled is true but no license",
 		},
 		{
 			name: "conductor enabled with missing signing key path emits advisory",
@@ -125,15 +125,17 @@ func TestCheckConductorAdvisories(t *testing.T) {
 				return
 			}
 
-			found := false
-			for _, a := range advisories {
-				if strings.Contains(a, tt.wantSubstr) {
-					found = true
-					break
+			if tt.wantSubstr != "" {
+				found := false
+				for _, a := range advisories {
+					if strings.Contains(a, tt.wantSubstr) {
+						found = true
+						break
+					}
 				}
-			}
-			if !found {
-				t.Errorf("expected advisory containing %q, got %v", tt.wantSubstr, advisories)
+				if !found {
+					t.Errorf("expected advisory containing %q, got %v", tt.wantSubstr, advisories)
+				}
 			}
 			if tt.forbidSubstr != "" {
 				for _, a := range advisories {

--- a/internal/cli/diag/config_scopes.go
+++ b/internal/cli/diag/config_scopes.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+// Config scope identifiers shared with consumers (for example the dashboard
+// exemptions inventory). A semantic finding's Scope and a consumer's knob name
+// are joined by string equality, so both the finding-producing side (this
+// package) and the finding-joining side reference these constants. A scope
+// rename then becomes a compile error instead of a silent join break that would
+// mis-report an inert exemption as active.
+//
+// These live in a dedicated file so the string literals appear exactly once,
+// here, and every other reference is the constant.
+const (
+	ConfigScopeSuppress                   = "suppress"
+	ConfigScopeResponseExemptDomains      = "response_scanning.exempt_domains"
+	ConfigScopeResponseMCPServers         = "response_scanning.mcp_servers"
+	ConfigScopeAdaptiveExemptDomains      = "adaptive_enforcement.exempt_domains"
+	ConfigScopeCrossRequestEntropyExempt  = "cross_request_detection.entropy_budget.exempt_domains"
+	ConfigScopeBrowserShieldExemptDomains = "browser_shield.exempt_domains"
+	ConfigScopeTLSPassthroughDomains      = "tls_interception.passthrough_domains"
+	ConfigScopeRequestBodyIgnoreHeaders   = "request_body_scanning.ignore_headers"
+)

--- a/internal/cli/diag/doctor_config_semantics.go
+++ b/internal/cli/diag/doctor_config_semantics.go
@@ -5,6 +5,7 @@ package diag
 
 import (
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 	"time"
@@ -41,19 +42,47 @@ const (
 	doctorCheckSuppressSemantics  = "config_suppress_semantics"
 	doctorCheckExemptionSemantics = "config_exemption_semantics"
 
+	ConfigSemanticKindInert       = "inert"
+	ConfigSemanticKindMisdirected = "misdirected"
+	ConfigSemanticKindAdvisory    = "advisory"
+
+	ConfigSemanticSeverityWarn = "warn"
+
 	// nextSuppressURLDLP is the correct knob for a URL-query DLP false
 	// positive (suppress does not reach URL DLP).
 	nextSuppressURLDLP = "to exempt a URL-query match, set dlp.patterns[].exempt_domains for this pattern; suppress: only reaches body/header DLP, generic SSE DLP, response scanning, and the audit/git scanners"
 )
+
+// ConfigSemanticFinding is a reusable semantic finding for syntactically valid
+// config that does not do what an operator is likely to expect.
+type ConfigSemanticFinding struct {
+	Kind     string
+	Scope    string
+	Subject  string
+	Detail   string
+	Next     string
+	Severity string
+}
+
+// AnalyzeConfigSemantics returns semantic findings for the loaded config.
+// It is deliberately conservative: findings are emitted only when the config
+// model proves a knob is inert, misdirected, or missing advisory metadata.
+func AnalyzeConfigSemantics(cfg *config.Config) []ConfigSemanticFinding {
+	if cfg == nil {
+		return nil
+	}
+	var findings []ConfigSemanticFinding
+	findings = append(findings, analyzeDoctorSuppressEntries(cfg)...)
+	findings = append(findings, analyzeDoctorInertExemptions(cfg)...)
+	return findings
+}
 
 // checkDoctorConfigSemantics runs the semantic config-validation checks and
 // returns one doctorReportCheck per finding. When the config has no semantic
 // problems it returns a single ok check so the surface is always represented
 // in the report.
 func checkDoctorConfigSemantics(cfg *config.Config) []doctorReportCheck {
-	var checks []doctorReportCheck
-	checks = append(checks, checkDoctorSuppressEntries(cfg)...)
-	checks = append(checks, checkDoctorInertExemptions(cfg)...)
+	checks := semanticFindingsToDoctorChecks(AnalyzeConfigSemantics(cfg))
 	if len(checks) == 0 {
 		return []doctorReportCheck{{
 			Name:    doctorCheckSuppressSemantics,
@@ -98,16 +127,60 @@ func suppressConsumingDLPScannerEnabled(cfg *config.Config) bool {
 		cfg.ResponseScanning.SSEStreaming.Enabled
 }
 
-// checkDoctorSuppressEntries classifies each suppress entry against the active
-// pattern namespaces and enabled scanners.
-func checkDoctorSuppressEntries(cfg *config.Config) []doctorReportCheck {
+func newConfigSemanticFinding(kind, scope, subject, detail, next string) ConfigSemanticFinding {
+	return ConfigSemanticFinding{
+		Kind:     kind,
+		Scope:    scope,
+		Subject:  normalizeConfigSemanticSubject(scope, subject),
+		Detail:   detail,
+		Next:     next,
+		Severity: ConfigSemanticSeverityWarn,
+	}
+}
+
+func normalizeConfigSemanticSubject(scope, subject string) string {
+	subject = strings.TrimSpace(subject)
+	switch scope {
+	case "suppress", "request_body_scanning.ignore_headers":
+		return strings.ToLower(subject)
+	default:
+		return subject
+	}
+}
+
+func semanticFindingsToDoctorChecks(findings []ConfigSemanticFinding) []doctorReportCheck {
+	checks := make([]doctorReportCheck, 0, len(findings))
+	for _, finding := range findings {
+		name := doctorCheckExemptionSemantics
+		if finding.Scope == "suppress" {
+			name = doctorCheckSuppressSemantics
+		}
+		status := doctorStatusWarn
+		if finding.Severity != "" {
+			status = finding.Severity
+		}
+		checks = append(checks, doctorReportCheck{
+			Name:       name,
+			Surface:    doctorSurfaceConfig,
+			Status:     status,
+			Configured: true,
+			Detail:     finding.Detail,
+			Next:       finding.Next,
+		})
+	}
+	return checks
+}
+
+// analyzeDoctorSuppressEntries classifies each suppress entry against the
+// active pattern namespaces and enabled scanners.
+func analyzeDoctorSuppressEntries(cfg *config.Config) []ConfigSemanticFinding {
 	if len(cfg.Suppress) == 0 {
 		return nil
 	}
 	dlpNames := dlpPatternNames(cfg)
 	respNames := responsePatternNames(cfg)
 
-	var checks []doctorReportCheck
+	var findings []ConfigSemanticFinding
 	// Collapse duplicate rule names so an operator with the same rule on many
 	// paths gets one finding per distinct rule, not one per path. Preserve
 	// first-seen order for deterministic output, then sort the emitted checks.
@@ -131,30 +204,28 @@ func checkDoctorSuppressEntries(cfg *config.Config) []doctorReportCheck {
 			// DLP or response-scan pattern, so no proxy scanner can honor this
 			// suppress. Audit/git project scanners have additional finding
 			// names, so keep the warning explicitly scoped.
-			checks = append(checks, doctorReportCheck{
-				Name:       doctorCheckSuppressSemantics,
-				Surface:    doctorSurfaceConfig,
-				Status:     doctorStatusWarn,
-				Configured: true,
-				Detail: fmt.Sprintf(
+			findings = append(findings, newConfigSemanticFinding(
+				ConfigSemanticKindInert,
+				"suppress",
+				ruleKey,
+				fmt.Sprintf(
 					"suppress entry names pattern %q, which matches no active DLP or response-scanning pattern; this exemption is inert for the proxy enforcement path",
 					entry.Rule),
-				Next: "fix the rule name to match a pattern in dlp.patterns or response_scanning.patterns, move audit/git-only suppressions to the config used for those commands, or remove the entry; run `pipelock doctor` again to confirm",
-			})
+				"fix the rule name to match a pattern in dlp.patterns or response_scanning.patterns, move audit/git-only suppressions to the config used for those commands, or remove the entry; run `pipelock doctor` again to confirm",
+			))
 		case isResp && !isDLP && !cfg.ResponseScanning.Enabled:
 			// Response-only pattern, response scanning off. The only scanners
 			// that match this name (response scanning and its SSE injection
 			// path) are disabled, so the suppress is inert.
-			checks = append(checks, doctorReportCheck{
-				Name:       doctorCheckSuppressSemantics,
-				Surface:    doctorSurfaceConfig,
-				Status:     doctorStatusWarn,
-				Configured: true,
-				Detail: fmt.Sprintf(
+			findings = append(findings, newConfigSemanticFinding(
+				ConfigSemanticKindInert,
+				"suppress",
+				ruleKey,
+				fmt.Sprintf(
 					"suppress entry names response-scanning pattern %q, but response_scanning.enabled=false; no enabled scanner matches this pattern, so the suppress is inert",
 					entry.Rule),
-				Next: "enable response_scanning to make this suppress effective, or remove the entry",
-			})
+				"enable response_scanning to make this suppress effective, or remove the entry",
+			))
 		case isDLP && !isResp && !suppressConsumingDLPScannerEnabled(cfg):
 			// DLP pattern, but no live proxy scanner that consults suppress is
 			// enabled. URL DLP would still match this pattern, but it ignores
@@ -162,149 +233,300 @@ func checkDoctorSuppressEntries(cfg *config.Config) []doctorReportCheck {
 			// Note: the audit/git project scanners still consult suppress, so
 			// the entry is not universally dead -- this warning is scoped to
 			// the proxy enforcement path the doctor reports on.
-			checks = append(checks, doctorReportCheck{
-				Name:       doctorCheckSuppressSemantics,
-				Surface:    doctorSurfaceConfig,
-				Status:     doctorStatusWarn,
-				Configured: true,
-				Detail: fmt.Sprintf(
+			findings = append(findings, newConfigSemanticFinding(
+				ConfigSemanticKindMisdirected,
+				"suppress",
+				ruleKey,
+				fmt.Sprintf(
 					"suppress entry names DLP pattern %q, but no suppress-consulting DLP proxy scanner is enabled (request_body_scanning=false, sse_streaming=false; response_scanning uses a separate pattern namespace); URL-query DLP would match this pattern but does not consult suppress, so the suppress has no effect on the proxy path",
 					entry.Rule),
-				Next: nextSuppressURLDLP,
-			})
+				nextSuppressURLDLP,
+			))
 		case isDLP && isResp && !cfg.ResponseScanning.Enabled && !suppressConsumingDLPScannerEnabled(cfg):
 			// Same rule name exists in both namespaces, but every proxy scanner
 			// that could honor either namespace is off.
-			checks = append(checks, doctorReportCheck{
-				Name:       doctorCheckSuppressSemantics,
-				Surface:    doctorSurfaceConfig,
-				Status:     doctorStatusWarn,
-				Configured: true,
-				Detail: fmt.Sprintf(
+			findings = append(findings, newConfigSemanticFinding(
+				ConfigSemanticKindMisdirected,
+				"suppress",
+				ruleKey,
+				fmt.Sprintf(
 					"suppress entry names pattern %q in both DLP and response-scanning namespaces, but response_scanning=false and no suppress-consulting DLP proxy scanner is enabled; URL-query DLP would match this pattern but does not consult suppress, so the suppress has no effect on the proxy path",
 					entry.Rule),
-				Next: "enable the scanner path this suppress is meant to affect, or use dlp.patterns[].exempt_domains for URL-query DLP false positives",
-			})
+				"enable the scanner path this suppress is meant to affect, or use dlp.patterns[].exempt_domains for URL-query DLP false positives",
+			))
 		}
 	}
-	sortDoctorChecks(checks)
-	return checks
+	sortConfigSemanticFindings(findings)
+	return findings
 }
 
-// checkDoctorInertExemptions flags exempt_domains lists configured on scanners
-// that are disabled, so the exemption cannot affect anything.
-func checkDoctorInertExemptions(cfg *config.Config) []doctorReportCheck {
-	var checks []doctorReportCheck
+// checkDoctorSuppressEntries classifies each suppress entry against the active
+// pattern namespaces and enabled scanners.
+func checkDoctorSuppressEntries(cfg *config.Config) []doctorReportCheck {
+	return semanticFindingsToDoctorChecks(analyzeDoctorSuppressEntries(cfg))
+}
 
-	if len(cfg.ResponseScanning.ExemptDomains) > 0 && !cfg.ResponseScanning.Enabled {
-		checks = append(checks, doctorReportCheck{
-			Name:       doctorCheckExemptionSemantics,
-			Surface:    doctorSurfaceConfig,
-			Status:     doctorStatusWarn,
-			Configured: true,
-			Detail:     "response_scanning.exempt_domains is set but response_scanning.enabled=false; this exemption is inert",
-			Next:       "enable response_scanning to make the exemption effective, or remove the exempt_domains list",
-		})
+// analyzeDoctorInertExemptions flags exempt_domains lists configured on
+// scanners that are disabled, so the exemption cannot affect anything.
+func analyzeDoctorInertExemptions(cfg *config.Config) []ConfigSemanticFinding {
+	var findings []ConfigSemanticFinding
+
+	if !cfg.ResponseScanning.Enabled {
+		for _, domain := range cfg.ResponseScanning.ExemptDomains {
+			findings = append(findings, newConfigSemanticFinding(
+				ConfigSemanticKindInert,
+				"response_scanning.exempt_domains",
+				domain,
+				"response_scanning.exempt_domains is set but response_scanning.enabled=false; this exemption is inert",
+				"enable response_scanning to make the exemption effective, or remove the exempt_domains list",
+			))
+		}
+		for _, entry := range cfg.ResponseScanning.MCPServers {
+			findings = append(findings, newConfigSemanticFinding(
+				ConfigSemanticKindInert,
+				"response_scanning.mcp_servers",
+				entry.Server,
+				fmt.Sprintf("response_scanning.mcp_servers marks %q but response_scanning.enabled=false; this MCP response trust exemption is inert", entry.Server),
+				"enable response_scanning to make the MCP response trust effective, or remove the mcp_servers entry",
+			))
+		}
 	}
 
-	if len(cfg.AdaptiveEnforcement.ExemptDomains) > 0 && !cfg.AdaptiveEnforcement.Enabled {
-		checks = append(checks, doctorReportCheck{
-			Name:       doctorCheckExemptionSemantics,
-			Surface:    doctorSurfaceConfig,
-			Status:     doctorStatusWarn,
-			Configured: true,
-			Detail:     "adaptive_enforcement.exempt_domains is set but adaptive_enforcement.enabled=false; the escalation exemption is inert",
-			Next:       "enable adaptive_enforcement to make the exemption effective, or remove the exempt_domains list",
-		})
+	if !cfg.AdaptiveEnforcement.Enabled {
+		for _, domain := range cfg.AdaptiveEnforcement.ExemptDomains {
+			findings = append(findings, newConfigSemanticFinding(
+				ConfigSemanticKindInert,
+				"adaptive_enforcement.exempt_domains",
+				domain,
+				"adaptive_enforcement.exempt_domains is set but adaptive_enforcement.enabled=false; the escalation exemption is inert",
+				"enable adaptive_enforcement to make the exemption effective, or remove the exempt_domains list",
+			))
+		}
 	}
 
-	checks = append(checks, checkDoctorQueryEntropyParamExclusions(cfg)...)
+	if !cfg.CrossRequestDetection.Enabled || !cfg.CrossRequestDetection.EntropyBudget.Enabled {
+		for _, domain := range cfg.CrossRequestDetection.EntropyBudget.ExemptDomains {
+			detail := "cross_request_detection.entropy_budget.exempt_domains is set but cross_request_detection.enabled=false; this entropy-budget exemption is inert"
+			next := "enable cross_request_detection and cross_request_detection.entropy_budget to make the exemption effective, or remove the exempt_domains list"
+			if cfg.CrossRequestDetection.Enabled {
+				detail = "cross_request_detection.entropy_budget.exempt_domains is set but cross_request_detection.entropy_budget.enabled=false; this entropy-budget exemption is inert"
+			}
+			findings = append(findings, newConfigSemanticFinding(
+				ConfigSemanticKindInert,
+				"cross_request_detection.entropy_budget.exempt_domains",
+				domain,
+				detail,
+				next,
+			))
+		}
+	}
+
+	browserShieldDefaultExemptDomains := config.Defaults().BrowserShield.ExemptDomains
+	for _, domain := range operatorAddedStrings(cfg.BrowserShield.ExemptDomains, browserShieldDefaultExemptDomains) {
+		if cfg.BrowserShield.Enabled {
+			continue
+		}
+		findings = append(findings, newConfigSemanticFinding(
+			ConfigSemanticKindInert,
+			"browser_shield.exempt_domains",
+			domain,
+			"browser_shield.exempt_domains is set but browser_shield.enabled=false; this shield exemption is inert",
+			"enable browser_shield to make the exemption effective, or remove the exempt_domains entry",
+		))
+	}
+
+	tlsInterceptionDefaultPassthroughDomains := config.Defaults().TLSInterception.PassthroughDomains
+	for _, domain := range operatorAddedStrings(cfg.TLSInterception.PassthroughDomains, tlsInterceptionDefaultPassthroughDomains) {
+		if cfg.TLSInterception.Enabled {
+			continue
+		}
+		findings = append(findings, newConfigSemanticFinding(
+			ConfigSemanticKindInert,
+			"tls_interception.passthrough_domains",
+			domain,
+			"tls_interception.passthrough_domains is set but tls_interception.enabled=false; this CONNECT passthrough exemption is inert",
+			"enable tls_interception to make the passthrough effective, or remove the passthrough_domains entry",
+		))
+	}
+
+	if !requestHeaderIgnoreListConsumed(cfg.RequestBodyScanning) {
+		// Auto-filled default headers are not an operator-authored exemption, so
+		// they are never flagged; only operator-added (non-default) headers on an
+		// unconsumed ignore-list are inert. This matches the browser_shield and
+		// tls_interception disabled-feature handling. Distinguishing a
+		// deliberately re-typed default from an auto-fill needs config-origin
+		// metadata (not yet available).
+		for _, header := range operatorAddedHeaderNames(cfg.RequestBodyScanning.IgnoreHeaders, defaultRequestBodyIgnoreHeaders()) {
+			findings = append(findings, newConfigSemanticFinding(
+				ConfigSemanticKindInert,
+				"request_body_scanning.ignore_headers",
+				header,
+				requestHeaderIgnoreListInertDetail(cfg.RequestBodyScanning),
+				"enable request_body_scanning with scan_headers=true and header_mode=all to make ignore_headers effective, or remove the unused header exemption",
+			))
+		}
+	}
+
+	findings = append(findings, analyzeDoctorQueryEntropyParamExclusions(cfg)...)
 
 	for _, entry := range cfg.ResponseScanning.MCPServers {
+		if !cfg.ResponseScanning.Enabled {
+			continue
+		}
 		if entry.Trust != config.ResponseTrustReasoning || cfg.TaintTrustsMCPServer(entry.Server) {
 			continue
 		}
-		checks = append(checks, doctorReportCheck{
-			Name:       doctorCheckExemptionSemantics,
-			Surface:    doctorSurfaceConfig,
-			Status:     doctorStatusWarn,
-			Configured: true,
-			Detail: fmt.Sprintf(
+		findings = append(findings, newConfigSemanticFinding(
+			ConfigSemanticKindMisdirected,
+			"response_scanning.mcp_servers",
+			entry.Server,
+			fmt.Sprintf(
 				"response_scanning.mcp_servers marks %q as reasoning-trusted, but taint.allowlisted_domains does not apply to MCP response taint and taint.trusted_mcp_servers does not include this server",
 				entry.Server),
-			Next: "if this MCP server is an operator-trusted source, add its --server-name value to taint.trusted_mcp_servers; otherwise leave it untrusted for taint",
-		})
+			"if this MCP server is an operator-trusted source, add its --server-name value to taint.trusted_mcp_servers; otherwise leave it untrusted for taint",
+		))
 	}
 
-	return checks
+	return findings
 }
 
-func checkDoctorQueryEntropyParamExclusions(cfg *config.Config) []doctorReportCheck {
+func requestHeaderIgnoreListConsumed(cfg config.RequestBodyScanning) bool {
+	return cfg.Enabled && cfg.ScanHeaders && cfg.HeaderMode == config.HeaderModeAll
+}
+
+func requestHeaderIgnoreListInertDetail(cfg config.RequestBodyScanning) string {
+	switch {
+	case !cfg.Enabled:
+		return "request_body_scanning.ignore_headers is set but request_body_scanning.enabled=false; this header exemption is inert"
+	case !cfg.ScanHeaders:
+		return "request_body_scanning.ignore_headers is set but request_body_scanning.scan_headers=false; this header exemption is inert"
+	case cfg.HeaderMode != config.HeaderModeAll:
+		return "request_body_scanning.ignore_headers is set but request_body_scanning.header_mode is not all; this header exemption is inert"
+	default:
+		return "request_body_scanning.ignore_headers is set but header ignore-list scanning is disabled; this header exemption is inert"
+	}
+}
+
+func operatorAddedStrings(entries, defaults []string) []string {
+	return operatorAddedValues(entries, defaults, strings.TrimSpace)
+}
+
+func operatorAddedHeaderNames(entries, defaults []string) []string {
+	return operatorAddedValues(entries, defaults, func(entry string) string {
+		return http.CanonicalHeaderKey(strings.TrimSpace(entry))
+	})
+}
+
+func operatorAddedValues(entries, defaults []string, normalize func(string) string) []string {
+	type normalizedValue struct {
+		raw        string
+		normalized string
+	}
+	values := make([]normalizedValue, 0, len(entries))
+	for _, entry := range entries {
+		normalized := normalize(entry)
+		if normalized == "" {
+			continue
+		}
+		values = append(values, normalizedValue{raw: entry, normalized: normalized})
+	}
+	if len(values) == 0 {
+		return nil
+	}
+
+	defaultSet := make(map[string]struct{}, len(defaults))
+	for _, entry := range defaults {
+		normalized := normalize(entry)
+		if normalized != "" {
+			defaultSet[normalized] = struct{}{}
+		}
+	}
+
+	var out []string
+	for _, value := range values {
+		if _, isDefault := defaultSet[value.normalized]; isDefault {
+			continue
+		}
+		out = append(out, value.raw)
+	}
+	return out
+}
+
+func defaultRequestBodyIgnoreHeaders() []string {
+	defaults := config.Defaults()
+	defaults.ApplyDefaults()
+	return defaults.RequestBodyScanning.IgnoreHeaders
+}
+
+func analyzeDoctorQueryEntropyParamExclusions(cfg *config.Config) []ConfigSemanticFinding {
 	entries := cfg.FetchProxy.Monitoring.QueryEntropyParamExclusions
 	if len(entries) == 0 {
 		return nil
 	}
-	var checks []doctorReportCheck
+	var findings []ConfigSemanticFinding
 	for _, entry := range entries {
 		tuple := queryEntropyParamAdvisoryTuple(entry)
 		if cfg.FetchProxy.Monitoring.EntropyThreshold <= 0 {
-			checks = append(checks, newQueryEntropyParamWarn(
+			findings = append(findings, newQueryEntropyParamFinding(
+				ConfigSemanticKindInert,
+				tuple,
 				fmt.Sprintf("query_entropy_param_exclusions entry %s is configured but fetch_proxy.monitoring.entropy_threshold<=0; this exemption is inert", tuple),
 				"remove the endpoint-parameter exemption while entropy is disabled, or re-enable entropy before relying on the narrow exemption",
 			))
 		}
 		if queryEntropyParamCoveredByHostWide(entry, cfg.FetchProxy.Monitoring.QueryEntropyExclusions) {
-			checks = append(checks, newQueryEntropyParamWarn(
+			findings = append(findings, newQueryEntropyParamFinding(
+				ConfigSemanticKindMisdirected,
+				tuple,
 				fmt.Sprintf("query_entropy_param_exclusions entry %s is redundant because query_entropy_exclusions already covers host %s", tuple, entry.Host),
 				"prefer the endpoint-parameter exemption and remove the broader host-wide query_entropy_exclusions entry if the broad bypass is not needed",
 			))
 		}
 		if strings.TrimSpace(entry.Reason) == "" {
-			checks = append(checks, queryEntropyParamLifecycleCheck(tuple, "reason", "add a short reason so future operators know why this narrow entropy exemption exists"))
+			findings = append(findings, queryEntropyParamLifecycleCheck(tuple, "reason", "add a short reason so future operators know why this narrow entropy exemption exists"))
 		}
 		if strings.TrimSpace(entry.Owner) == "" {
-			checks = append(checks, queryEntropyParamLifecycleCheck(tuple, "owner", "add an owner so future operators know who can revalidate this exemption"))
+			findings = append(findings, queryEntropyParamLifecycleCheck(tuple, "owner", "add an owner so future operators know who can revalidate this exemption"))
 		}
 		expires := strings.TrimSpace(entry.Expires)
 		if expires == "" {
-			checks = append(checks, queryEntropyParamLifecycleCheck(tuple, "expires", "add an expires date in YYYY-MM-DD format so this exemption gets periodically reviewed"))
+			findings = append(findings, queryEntropyParamLifecycleCheck(tuple, "expires", "add an expires date in YYYY-MM-DD format so this exemption gets periodically reviewed"))
 			continue
 		}
 		parsed, err := time.Parse("2006-01-02", expires)
 		if err != nil {
-			checks = append(checks, newQueryEntropyParamWarn(
+			findings = append(findings, newQueryEntropyParamFinding(
+				ConfigSemanticKindAdvisory,
+				tuple,
 				fmt.Sprintf("query_entropy_param_exclusions entry %s has invalid expires %q; expected YYYY-MM-DD", tuple, expires),
 				"set expires to a valid YYYY-MM-DD date, or remove the exemption if it is no longer needed",
 			))
 			continue
 		}
 		if parsed.Before(todayUTC()) {
-			checks = append(checks, newQueryEntropyParamWarn(
+			findings = append(findings, newQueryEntropyParamFinding(
+				ConfigSemanticKindAdvisory,
+				tuple,
 				fmt.Sprintf("query_entropy_param_exclusions entry %s expired on %s", tuple, expires),
 				"review whether the endpoint still needs the exemption; remove it or renew expires with a future YYYY-MM-DD date",
 			))
 		}
 	}
-	sortDoctorChecks(checks)
-	return checks
+	sortConfigSemanticFindings(findings)
+	return findings
 }
 
-func queryEntropyParamLifecycleCheck(tuple, field, next string) doctorReportCheck {
-	return newQueryEntropyParamWarn(
+func queryEntropyParamLifecycleCheck(tuple, field, next string) ConfigSemanticFinding {
+	return newQueryEntropyParamFinding(
+		ConfigSemanticKindAdvisory,
+		tuple,
 		fmt.Sprintf("query_entropy_param_exclusions entry %s is missing advisory %s", tuple, field),
 		next,
 	)
 }
 
-func newQueryEntropyParamWarn(detail, next string) doctorReportCheck {
-	return doctorReportCheck{
-		Name:       doctorCheckExemptionSemantics,
-		Surface:    doctorSurfaceConfig,
-		Status:     doctorStatusWarn,
-		Configured: true,
-		Detail:     detail,
-		Next:       next,
-	}
+func newQueryEntropyParamFinding(kind, subject, detail, next string) ConfigSemanticFinding {
+	return newConfigSemanticFinding(kind, "fetch_proxy.monitoring.query_entropy_param_exclusions", subject, detail, next)
 }
 
 func queryEntropyParamCoveredByHostWide(entry config.QueryEntropyParamExclusion, hostWide []string) bool {
@@ -329,13 +551,11 @@ func todayUTC() time.Time {
 	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
 }
 
-// sortDoctorChecks orders checks by name then detail for deterministic output.
-// Map-iteration order over pattern-name sets must not leak into the report.
-func sortDoctorChecks(checks []doctorReportCheck) {
-	sort.SliceStable(checks, func(i, j int) bool {
-		if checks[i].Name != checks[j].Name {
-			return checks[i].Name < checks[j].Name
+func sortConfigSemanticFindings(findings []ConfigSemanticFinding) {
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Scope != findings[j].Scope {
+			return findings[i].Scope < findings[j].Scope
 		}
-		return checks[i].Detail < checks[j].Detail
+		return findings[i].Detail < findings[j].Detail
 	})
 }

--- a/internal/cli/diag/doctor_config_semantics.go
+++ b/internal/cli/diag/doctor_config_semantics.go
@@ -8,11 +8,31 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
+
+var (
+	cachedConfigDefaultsOnce sync.Once
+	cachedConfigDefaults     *config.Config
+)
+
+// configDefaults returns a lazily-computed, shared, defaults-applied Config.
+// Defaults do not change at runtime, so this avoids rebuilding every default
+// pattern literal on each AnalyzeConfigSemantics call, which runs on every
+// dashboard GET /exemptions request. Callers must treat the returned config
+// and its slices as read-only.
+func configDefaults() *config.Config {
+	cachedConfigDefaultsOnce.Do(func() {
+		cfg := config.Defaults()
+		cfg.ApplyDefaults()
+		cachedConfigDefaults = cfg
+	})
+	return cachedConfigDefaults
+}
 
 // Semantic config-validation checks for the doctor command.
 //
@@ -141,7 +161,7 @@ func newConfigSemanticFinding(kind, scope, subject, detail, next string) ConfigS
 func normalizeConfigSemanticSubject(scope, subject string) string {
 	subject = strings.TrimSpace(subject)
 	switch scope {
-	case "suppress", "request_body_scanning.ignore_headers":
+	case ConfigScopeSuppress, ConfigScopeRequestBodyIgnoreHeaders:
 		return strings.ToLower(subject)
 	default:
 		return subject
@@ -152,7 +172,7 @@ func semanticFindingsToDoctorChecks(findings []ConfigSemanticFinding) []doctorRe
 	checks := make([]doctorReportCheck, 0, len(findings))
 	for _, finding := range findings {
 		name := doctorCheckExemptionSemantics
-		if finding.Scope == "suppress" {
+		if finding.Scope == ConfigScopeSuppress {
 			name = doctorCheckSuppressSemantics
 		}
 		status := doctorStatusWarn
@@ -206,7 +226,7 @@ func analyzeDoctorSuppressEntries(cfg *config.Config) []ConfigSemanticFinding {
 			// names, so keep the warning explicitly scoped.
 			findings = append(findings, newConfigSemanticFinding(
 				ConfigSemanticKindInert,
-				"suppress",
+				ConfigScopeSuppress,
 				ruleKey,
 				fmt.Sprintf(
 					"suppress entry names pattern %q, which matches no active DLP or response-scanning pattern; this exemption is inert for the proxy enforcement path",
@@ -219,7 +239,7 @@ func analyzeDoctorSuppressEntries(cfg *config.Config) []ConfigSemanticFinding {
 			// path) are disabled, so the suppress is inert.
 			findings = append(findings, newConfigSemanticFinding(
 				ConfigSemanticKindInert,
-				"suppress",
+				ConfigScopeSuppress,
 				ruleKey,
 				fmt.Sprintf(
 					"suppress entry names response-scanning pattern %q, but response_scanning.enabled=false; no enabled scanner matches this pattern, so the suppress is inert",
@@ -235,7 +255,7 @@ func analyzeDoctorSuppressEntries(cfg *config.Config) []ConfigSemanticFinding {
 			// the proxy enforcement path the doctor reports on.
 			findings = append(findings, newConfigSemanticFinding(
 				ConfigSemanticKindMisdirected,
-				"suppress",
+				ConfigScopeSuppress,
 				ruleKey,
 				fmt.Sprintf(
 					"suppress entry names DLP pattern %q, but no suppress-consulting DLP proxy scanner is enabled (request_body_scanning=false, sse_streaming=false; response_scanning uses a separate pattern namespace); URL-query DLP would match this pattern but does not consult suppress, so the suppress has no effect on the proxy path",
@@ -247,7 +267,7 @@ func analyzeDoctorSuppressEntries(cfg *config.Config) []ConfigSemanticFinding {
 			// that could honor either namespace is off.
 			findings = append(findings, newConfigSemanticFinding(
 				ConfigSemanticKindMisdirected,
-				"suppress",
+				ConfigScopeSuppress,
 				ruleKey,
 				fmt.Sprintf(
 					"suppress entry names pattern %q in both DLP and response-scanning namespaces, but response_scanning=false and no suppress-consulting DLP proxy scanner is enabled; URL-query DLP would match this pattern but does not consult suppress, so the suppress has no effect on the proxy path",
@@ -275,7 +295,7 @@ func analyzeDoctorInertExemptions(cfg *config.Config) []ConfigSemanticFinding {
 		for _, domain := range cfg.ResponseScanning.ExemptDomains {
 			findings = append(findings, newConfigSemanticFinding(
 				ConfigSemanticKindInert,
-				"response_scanning.exempt_domains",
+				ConfigScopeResponseExemptDomains,
 				domain,
 				"response_scanning.exempt_domains is set but response_scanning.enabled=false; this exemption is inert",
 				"enable response_scanning to make the exemption effective, or remove the exempt_domains list",
@@ -284,7 +304,7 @@ func analyzeDoctorInertExemptions(cfg *config.Config) []ConfigSemanticFinding {
 		for _, entry := range cfg.ResponseScanning.MCPServers {
 			findings = append(findings, newConfigSemanticFinding(
 				ConfigSemanticKindInert,
-				"response_scanning.mcp_servers",
+				ConfigScopeResponseMCPServers,
 				entry.Server,
 				fmt.Sprintf("response_scanning.mcp_servers marks %q but response_scanning.enabled=false; this MCP response trust exemption is inert", entry.Server),
 				"enable response_scanning to make the MCP response trust effective, or remove the mcp_servers entry",
@@ -296,7 +316,7 @@ func analyzeDoctorInertExemptions(cfg *config.Config) []ConfigSemanticFinding {
 		for _, domain := range cfg.AdaptiveEnforcement.ExemptDomains {
 			findings = append(findings, newConfigSemanticFinding(
 				ConfigSemanticKindInert,
-				"adaptive_enforcement.exempt_domains",
+				ConfigScopeAdaptiveExemptDomains,
 				domain,
 				"adaptive_enforcement.exempt_domains is set but adaptive_enforcement.enabled=false; the escalation exemption is inert",
 				"enable adaptive_enforcement to make the exemption effective, or remove the exempt_domains list",
@@ -313,7 +333,7 @@ func analyzeDoctorInertExemptions(cfg *config.Config) []ConfigSemanticFinding {
 			}
 			findings = append(findings, newConfigSemanticFinding(
 				ConfigSemanticKindInert,
-				"cross_request_detection.entropy_budget.exempt_domains",
+				ConfigScopeCrossRequestEntropyExempt,
 				domain,
 				detail,
 				next,
@@ -321,28 +341,28 @@ func analyzeDoctorInertExemptions(cfg *config.Config) []ConfigSemanticFinding {
 		}
 	}
 
-	browserShieldDefaultExemptDomains := config.Defaults().BrowserShield.ExemptDomains
+	browserShieldDefaultExemptDomains := configDefaults().BrowserShield.ExemptDomains
 	for _, domain := range operatorAddedStrings(cfg.BrowserShield.ExemptDomains, browserShieldDefaultExemptDomains) {
 		if cfg.BrowserShield.Enabled {
 			continue
 		}
 		findings = append(findings, newConfigSemanticFinding(
 			ConfigSemanticKindInert,
-			"browser_shield.exempt_domains",
+			ConfigScopeBrowserShieldExemptDomains,
 			domain,
 			"browser_shield.exempt_domains is set but browser_shield.enabled=false; this shield exemption is inert",
 			"enable browser_shield to make the exemption effective, or remove the exempt_domains entry",
 		))
 	}
 
-	tlsInterceptionDefaultPassthroughDomains := config.Defaults().TLSInterception.PassthroughDomains
+	tlsInterceptionDefaultPassthroughDomains := configDefaults().TLSInterception.PassthroughDomains
 	for _, domain := range operatorAddedStrings(cfg.TLSInterception.PassthroughDomains, tlsInterceptionDefaultPassthroughDomains) {
 		if cfg.TLSInterception.Enabled {
 			continue
 		}
 		findings = append(findings, newConfigSemanticFinding(
 			ConfigSemanticKindInert,
-			"tls_interception.passthrough_domains",
+			ConfigScopeTLSPassthroughDomains,
 			domain,
 			"tls_interception.passthrough_domains is set but tls_interception.enabled=false; this CONNECT passthrough exemption is inert",
 			"enable tls_interception to make the passthrough effective, or remove the passthrough_domains entry",
@@ -359,7 +379,7 @@ func analyzeDoctorInertExemptions(cfg *config.Config) []ConfigSemanticFinding {
 		for _, header := range operatorAddedHeaderNames(cfg.RequestBodyScanning.IgnoreHeaders, defaultRequestBodyIgnoreHeaders()) {
 			findings = append(findings, newConfigSemanticFinding(
 				ConfigSemanticKindInert,
-				"request_body_scanning.ignore_headers",
+				ConfigScopeRequestBodyIgnoreHeaders,
 				header,
 				requestHeaderIgnoreListInertDetail(cfg.RequestBodyScanning),
 				"enable request_body_scanning with scan_headers=true and header_mode=all to make ignore_headers effective, or remove the unused header exemption",
@@ -378,7 +398,7 @@ func analyzeDoctorInertExemptions(cfg *config.Config) []ConfigSemanticFinding {
 		}
 		findings = append(findings, newConfigSemanticFinding(
 			ConfigSemanticKindMisdirected,
-			"response_scanning.mcp_servers",
+			ConfigScopeResponseMCPServers,
 			entry.Server,
 			fmt.Sprintf(
 				"response_scanning.mcp_servers marks %q as reasoning-trusted, but taint.allowlisted_domains does not apply to MCP response taint and taint.trusted_mcp_servers does not include this server",
@@ -453,9 +473,7 @@ func operatorAddedValues(entries, defaults []string, normalize func(string) stri
 }
 
 func defaultRequestBodyIgnoreHeaders() []string {
-	defaults := config.Defaults()
-	defaults.ApplyDefaults()
-	return defaults.RequestBodyScanning.IgnoreHeaders
+	return configDefaults().RequestBodyScanning.IgnoreHeaders
 }
 
 func analyzeDoctorQueryEntropyParamExclusions(cfg *config.Config) []ConfigSemanticFinding {

--- a/internal/cli/diag/doctor_config_semantics_test.go
+++ b/internal/cli/diag/doctor_config_semantics_test.go
@@ -41,7 +41,14 @@ func baseSemanticsConfig() *config.Config {
 	cfg.AdaptiveEnforcement.Enabled = false
 	cfg.Suppress = nil
 	cfg.ResponseScanning.ExemptDomains = nil
+	cfg.ResponseScanning.MCPServers = nil
 	cfg.AdaptiveEnforcement.ExemptDomains = nil
+	cfg.CrossRequestDetection.Enabled = false
+	cfg.CrossRequestDetection.EntropyBudget.Enabled = false
+	cfg.CrossRequestDetection.EntropyBudget.ExemptDomains = nil
+	cfg.BrowserShield.ExemptDomains = nil
+	cfg.TLSInterception.PassthroughDomains = nil
+	cfg.RequestBodyScanning.IgnoreHeaders = nil
 	return cfg
 }
 
@@ -203,8 +210,22 @@ func TestDoctorConfigSemantics(t *testing.T) {
 			wantWarn: 0,
 		},
 		{
+			name: "response MCP trust inert when response scanning disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.ResponseScanning.Enabled = false
+				cfg.ResponseScanning.MCPServers = []config.MCPResponseServerTrust{{
+					Server: "docs-cache",
+					Trust:  config.ResponseTrustReasoning,
+				}}
+			},
+			wantWarn:         1,
+			wantDetailSubstr: "response_scanning.mcp_servers marks \"docs-cache\" but response_scanning.enabled=false",
+			wantNextSubstr:   "enable response_scanning",
+		},
+		{
 			name: "MCP response reasoning trust is not taint trust",
 			mutate: func(cfg *config.Config) {
+				cfg.ResponseScanning.Enabled = true
 				cfg.ResponseScanning.MCPServers = []config.MCPResponseServerTrust{{
 					Server: "docs-cache",
 					Trust:  config.ResponseTrustReasoning,
@@ -217,6 +238,7 @@ func TestDoctorConfigSemantics(t *testing.T) {
 		{
 			name: "MCP response reasoning trust with taint trust is NOT flagged",
 			mutate: func(cfg *config.Config) {
+				cfg.ResponseScanning.Enabled = true
 				cfg.ResponseScanning.MCPServers = []config.MCPResponseServerTrust{{
 					Server: "docs-cache",
 					Trust:  config.ResponseTrustReasoning,
@@ -246,6 +268,182 @@ func TestDoctorConfigSemantics(t *testing.T) {
 					// lowercased name must still match the active DLP pattern.
 					{Rule: strings.ToLower(testDLPPatternName), Path: "*" + testExemptHost + "*"},
 				}
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "cross request entropy exemption inert when parent disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.CrossRequestDetection.Enabled = false
+				cfg.CrossRequestDetection.EntropyBudget.Enabled = true
+				cfg.CrossRequestDetection.EntropyBudget.ExemptDomains = []string{testExemptHost}
+			},
+			wantWarn:         1,
+			wantDetailSubstr: "cross_request_detection.enabled=false",
+			wantNextSubstr:   "enable cross_request_detection",
+		},
+		{
+			name: "cross request entropy exemption inert when entropy budget disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.CrossRequestDetection.Enabled = true
+				cfg.CrossRequestDetection.FragmentReassembly.Enabled = true
+				cfg.CrossRequestDetection.EntropyBudget.Enabled = false
+				cfg.CrossRequestDetection.EntropyBudget.ExemptDomains = []string{testExemptHost}
+			},
+			wantWarn:         1,
+			wantDetailSubstr: "cross_request_detection.entropy_budget.enabled=false",
+			wantNextSubstr:   "enable cross_request_detection",
+		},
+		{
+			name: "cross request entropy exemption NOT flagged when entropy budget enabled",
+			mutate: func(cfg *config.Config) {
+				cfg.CrossRequestDetection.Enabled = true
+				cfg.CrossRequestDetection.EntropyBudget.Enabled = true
+				cfg.CrossRequestDetection.EntropyBudget.ExemptDomains = []string{testExemptHost}
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "browser shield exemption inert when shield disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.BrowserShield.Enabled = false
+				cfg.BrowserShield.ExemptDomains = []string{"browser.vendor.example"}
+			},
+			wantWarn:         1,
+			wantDetailSubstr: "browser_shield.exempt_domains is set but browser_shield.enabled=false",
+			wantNextSubstr:   "enable browser_shield",
+		},
+		{
+			name: "browser shield pristine default baseline NOT flagged when shield disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.BrowserShield.Enabled = false
+				cfg.BrowserShield.ExemptDomains = append([]string(nil), config.Defaults().BrowserShield.ExemptDomains...)
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "browser shield exemption NOT flagged when shield enabled",
+			mutate: func(cfg *config.Config) {
+				cfg.BrowserShield.Enabled = true
+				cfg.BrowserShield.ExemptDomains = []string{"browser.vendor.example"}
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "browser shield pristine default baseline NOT flagged when shield enabled",
+			mutate: func(cfg *config.Config) {
+				cfg.BrowserShield.Enabled = true
+				cfg.BrowserShield.ExemptDomains = append([]string(nil), config.Defaults().BrowserShield.ExemptDomains...)
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "TLS passthrough exemption inert when TLS interception disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.TLSInterception.Enabled = false
+				cfg.TLSInterception.PassthroughDomains = []string{"tls.vendor.example"}
+			},
+			wantWarn:         1,
+			wantDetailSubstr: "tls_interception.passthrough_domains is set but tls_interception.enabled=false",
+			wantNextSubstr:   "enable tls_interception",
+		},
+		{
+			name: "TLS pristine default passthrough baseline NOT flagged when TLS interception disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.TLSInterception.Enabled = false
+				cfg.TLSInterception.PassthroughDomains = append([]string(nil), config.Defaults().TLSInterception.PassthroughDomains...)
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "TLS passthrough exemption NOT flagged when TLS interception enabled",
+			mutate: func(cfg *config.Config) {
+				cfg.TLSInterception.Enabled = true
+				cfg.TLSInterception.PassthroughDomains = []string{"tls.vendor.example"}
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "TLS pristine default passthrough baseline NOT flagged when TLS interception enabled",
+			mutate: func(cfg *config.Config) {
+				cfg.TLSInterception.Enabled = true
+				cfg.TLSInterception.PassthroughDomains = append([]string(nil), config.Defaults().TLSInterception.PassthroughDomains...)
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "request header ignore entry inert when request scanning disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.RequestBodyScanning.Enabled = false
+				cfg.RequestBodyScanning.ScanHeaders = true
+				cfg.RequestBodyScanning.HeaderMode = config.HeaderModeAll
+				cfg.RequestBodyScanning.IgnoreHeaders = []string{"X-Provider-Trace"}
+			},
+			wantWarn:         1,
+			wantDetailSubstr: "request_body_scanning.enabled=false",
+			wantNextSubstr:   "header_mode=all",
+		},
+		{
+			name: "request header ignore entry inert when header scanning disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.RequestBodyScanning.Enabled = true
+				cfg.RequestBodyScanning.ScanHeaders = false
+				cfg.RequestBodyScanning.HeaderMode = config.HeaderModeAll
+				cfg.RequestBodyScanning.IgnoreHeaders = []string{"X-Provider-Trace"}
+			},
+			wantWarn:         1,
+			wantDetailSubstr: "request_body_scanning.scan_headers=false",
+			wantNextSubstr:   "header_mode=all",
+		},
+		{
+			name: "request header ignore entry inert outside all header mode",
+			mutate: func(cfg *config.Config) {
+				cfg.RequestBodyScanning.Enabled = true
+				cfg.RequestBodyScanning.ScanHeaders = true
+				cfg.RequestBodyScanning.HeaderMode = config.HeaderModeSensitive
+				cfg.RequestBodyScanning.IgnoreHeaders = []string{"X-Provider-Trace"}
+			},
+			wantWarn:         1,
+			wantDetailSubstr: "request_body_scanning.header_mode is not all",
+			wantNextSubstr:   "header_mode=all",
+		},
+		{
+			name: "request header complete default ignore baseline NOT flagged when request scanning disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.RequestBodyScanning.Enabled = false
+				cfg.RequestBodyScanning.ScanHeaders = true
+				cfg.RequestBodyScanning.HeaderMode = config.HeaderModeAll
+				cfg.RequestBodyScanning.IgnoreHeaders = append([]string(nil), defaultRequestBodyIgnoreHeaders()...)
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "request header default ignore baseline is not warned outside all header mode",
+			mutate: func(cfg *config.Config) {
+				cfg.RequestBodyScanning.Enabled = true
+				cfg.RequestBodyScanning.ScanHeaders = true
+				cfg.RequestBodyScanning.HeaderMode = config.HeaderModeSensitive
+				cfg.RequestBodyScanning.IgnoreHeaders = append([]string(nil), defaultRequestBodyIgnoreHeaders()...)
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "request header pristine default ignore baseline NOT flagged when all-header scanning enabled",
+			mutate: func(cfg *config.Config) {
+				cfg.RequestBodyScanning.Enabled = true
+				cfg.RequestBodyScanning.ScanHeaders = true
+				cfg.RequestBodyScanning.HeaderMode = config.HeaderModeAll
+				cfg.RequestBodyScanning.IgnoreHeaders = append([]string(nil), defaultRequestBodyIgnoreHeaders()...)
+			},
+			wantWarn: 0,
+		},
+		{
+			name: "request header ignore entry NOT flagged in all header mode",
+			mutate: func(cfg *config.Config) {
+				cfg.RequestBodyScanning.Enabled = true
+				cfg.RequestBodyScanning.ScanHeaders = true
+				cfg.RequestBodyScanning.HeaderMode = config.HeaderModeAll
+				cfg.RequestBodyScanning.IgnoreHeaders = []string{"X-Provider-Trace"}
 			},
 			wantWarn: 0,
 		},
@@ -486,6 +684,96 @@ func TestDoctorConfigSemanticsCleanReturnsOK(t *testing.T) {
 	}
 }
 
+func TestAnalyzeConfigSemanticsNilConfig(t *testing.T) {
+	if findings := AnalyzeConfigSemantics(nil); findings != nil {
+		t.Fatalf("AnalyzeConfigSemantics(nil) = %+v, want nil", findings)
+	}
+}
+
+func TestAnalyzeConfigSemanticsPristineDefaultsHaveNoFindings(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.ApplyDefaults()
+
+	findings := AnalyzeConfigSemantics(cfg)
+	t.Logf("findings count = %d", len(findings))
+	if len(findings) != 0 {
+		t.Fatalf("AnalyzeConfigSemantics(defaults) findings count = %d, want 0: %+v", len(findings), findings)
+	}
+}
+
+func TestDoctorConfigSemanticsPristineDefaultsReturnOK(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.ApplyDefaults()
+
+	checks := checkDoctorConfigSemantics(cfg)
+	if len(checks) != 1 {
+		t.Fatalf("checkDoctorConfigSemantics(defaults) checks = %d, want 1 OK placeholder: %+v", len(checks), checks)
+	}
+	if checks[0].Status != doctorStatusOK {
+		t.Fatalf("checkDoctorConfigSemantics(defaults) status = %q, want %q: %+v", checks[0].Status, doctorStatusOK, checks)
+	}
+}
+
+func TestConfigSemanticHelperBranches(t *testing.T) {
+	if got := normalizeConfigSemanticSubject("request_body_scanning.ignore_headers", " X-Provider-Trace "); got != "x-provider-trace" {
+		t.Fatalf("normalized header subject = %q, want x-provider-trace", got)
+	}
+	if got := normalizeConfigSemanticSubject("response_scanning.mcp_servers", " docs-cache "); got != "docs-cache" {
+		t.Fatalf("normalized MCP subject = %q, want docs-cache", got)
+	}
+
+	added := operatorAddedStrings([]string{"", "  *.googlevideo.com  ", "tls.vendor.example"}, config.Defaults().TLSInterception.PassthroughDomains)
+	if len(added) != 1 || added[0] != "tls.vendor.example" {
+		t.Fatalf("operatorAddedStrings = %v, want [tls.vendor.example]", added)
+	}
+
+	headers := operatorAddedHeaderNames([]string{"", "accept", "X-Provider-Trace"}, defaultRequestBodyIgnoreHeaders())
+	if len(headers) != 1 || headers[0] != "X-Provider-Trace" {
+		t.Fatalf("operatorAddedHeaderNames = %v, want [X-Provider-Trace]", headers)
+	}
+	headers = operatorAddedHeaderNames(defaultRequestBodyIgnoreHeaders(), defaultRequestBodyIgnoreHeaders())
+	if len(headers) != 0 {
+		t.Fatalf("operatorAddedHeaderNames(defaults) = %v, want none", headers)
+	}
+
+	if !requestHeaderIgnoreListConsumed(config.RequestBodyScanning{
+		Enabled:     true,
+		ScanHeaders: true,
+		HeaderMode:  config.HeaderModeAll,
+	}) {
+		t.Fatal("requestHeaderIgnoreListConsumed() = false, want true")
+	}
+	detail := requestHeaderIgnoreListInertDetail(config.RequestBodyScanning{
+		Enabled:     true,
+		ScanHeaders: true,
+		HeaderMode:  config.HeaderModeAll,
+	})
+	if !strings.Contains(detail, "header ignore-list scanning is disabled") {
+		t.Fatalf("fallback inert detail = %q", detail)
+	}
+
+	findings := []ConfigSemanticFinding{
+		{Scope: "z", Detail: "b"},
+		{Scope: "a", Detail: "c"},
+		{Scope: "a", Detail: "b"},
+	}
+	sortConfigSemanticFindings(findings)
+	if findings[0].Scope != "a" || findings[0].Detail != "b" ||
+		findings[1].Scope != "a" || findings[1].Detail != "c" ||
+		findings[2].Scope != "z" {
+		t.Fatalf("sortConfigSemanticFindings = %+v", findings)
+	}
+
+	tuple := queryEntropyParamAdvisoryTuple(config.QueryEntropyParamExclusion{
+		Host:  "api.vendor.example",
+		Path:  "/v1/search",
+		Param: "query",
+	})
+	if tuple != "https://api.vendor.example/v1/search?query" {
+		t.Fatalf("default scheme tuple = %q", tuple)
+	}
+}
+
 // TestDoctorSemanticsCountedInSummary proves the new checks flow through the
 // full report build and into the JSON summary tallies and exit code.
 func TestDoctorSemanticsCountedInSummary(t *testing.T) {
@@ -538,5 +826,148 @@ response_scanning:
 	}
 	if report.Summary.Warnings < 2 {
 		t.Errorf("summary warnings = %d, want >= 2 (semantic checks must be tallied)", report.Summary.Warnings)
+	}
+}
+
+func TestAnalyzeConfigSemanticsPublicKinds(t *testing.T) {
+	cfg := baseSemanticsConfig()
+	cfg.RequestBodyScanning.Enabled = false
+	cfg.ResponseScanning.Enabled = false
+	cfg.ResponseScanning.SSEStreaming.Enabled = false
+	cfg.Suppress = []config.SuppressEntry{
+		{Rule: testDLPPatternName, Path: "*" + testExemptHost + "*", Reason: "url token FP"},
+	}
+	cfg.ResponseScanning.MCPServers = []config.MCPResponseServerTrust{{
+		Server: "reasoning-cache",
+		Trust:  config.ResponseTrustReasoning,
+	}}
+
+	findings := AnalyzeConfigSemantics(cfg)
+	var sawMisdirectedSuppress, sawInertTrust bool
+	for _, finding := range findings {
+		if finding.Scope == "suppress" && finding.Kind == ConfigSemanticKindMisdirected {
+			sawMisdirectedSuppress = true
+		}
+		if finding.Scope == "response_scanning.mcp_servers" && finding.Kind == ConfigSemanticKindInert {
+			sawInertTrust = true
+		}
+		if finding.Severity != ConfigSemanticSeverityWarn {
+			t.Fatalf("Severity = %q, want %q", finding.Severity, ConfigSemanticSeverityWarn)
+		}
+	}
+	if !sawMisdirectedSuppress {
+		t.Fatalf("AnalyzeConfigSemantics() missing misdirected suppress finding: %+v", findings)
+	}
+	if !sawInertTrust {
+		t.Fatalf("AnalyzeConfigSemantics() missing inert MCP trust finding: %+v", findings)
+	}
+}
+
+func TestDoctorConfigSemanticsSuppressesDefaultHeaderSubsetWhenInert(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := dir + "/pipelock.yaml"
+	const body = `mode: balanced
+request_body_scanning:
+  enabled: false
+  scan_headers: true
+  header_mode: all
+  ignore_headers:
+    - Accept
+`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(config): %v", err)
+	}
+
+	findings := AnalyzeConfigSemantics(cfg)
+	for _, finding := range findings {
+		if finding.Scope == "request_body_scanning.ignore_headers" &&
+			finding.Subject == "accept" &&
+			finding.Kind == ConfigSemanticKindInert {
+			t.Fatalf("default header was flagged inert: %+v", finding)
+		}
+	}
+}
+
+func TestDoctorConfigSemanticsSuppressesDefaultDomainSubsetWhenInert(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := dir + "/pipelock.yaml"
+	const body = `mode: balanced
+browser_shield:
+  enabled: false
+  exempt_domains:
+    - docs.github.com
+`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(config): %v", err)
+	}
+
+	findings := AnalyzeConfigSemantics(cfg)
+	for _, finding := range findings {
+		if finding.Scope == "browser_shield.exempt_domains" &&
+			finding.Subject == "docs.github.com" &&
+			finding.Kind == ConfigSemanticKindInert {
+			t.Fatalf("default browser shield domain was flagged inert: %+v", finding)
+		}
+	}
+}
+
+func TestDoctorConfigSemanticsAnalyzerRefactorGolden(t *testing.T) {
+	cfg := baseSemanticsConfig()
+	cfg.RequestBodyScanning.Enabled = false
+	cfg.ResponseScanning.Enabled = false
+	cfg.ResponseScanning.SSEStreaming.Enabled = false
+	cfg.Suppress = []config.SuppressEntry{
+		{Rule: "Totally Made Up Pattern", Path: "*provider.example*"},
+		{Rule: testDLPPatternName, Path: "*" + testExemptHost + "*"},
+	}
+	cfg.ResponseScanning.ExemptDomains = []string{testExemptHost}
+
+	checks := semanticFindingsToDoctorChecks(AnalyzeConfigSemantics(cfg))
+	got, err := json.MarshalIndent(checks, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	want := strings.ReplaceAll(strings.TrimSpace(`[
+  {
+    "name": "config_suppress_semantics",
+    "surface": "config",
+    "status": "warn",
+    "configured": true,
+    "reachable": false,
+    "enforcing": false,
+    "detail": "suppress entry names DLP pattern \"Vendor Token\", but no suppress-consulting DLP proxy scanner is enabled (request_body_scanning=false, sse_streaming=false; response_scanning uses a separate pattern namespace); URL-query DLP would match this pattern but does not consult suppress, so the suppress has no effect on the proxy path",
+    "next": "to exempt a URL-query match, set dlp.patterns[].exempt_domains for this pattern; suppress: only reaches body/header DLP, generic SSE DLP, response scanning, and the audit/git scanners"
+  },
+  {
+    "name": "config_suppress_semantics",
+    "surface": "config",
+    "status": "warn",
+    "configured": true,
+    "reachable": false,
+    "enforcing": false,
+    "detail": "suppress entry names pattern \"Totally Made Up Pattern\", which matches no active DLP or response-scanning pattern; this exemption is inert for the proxy enforcement path",
+    "next": "fix the rule name to match a pattern in dlp.patterns or response_scanning.patterns, move audit/git-only suppressions to the config used for those commands, or remove the entry; run PIPELOCK_DOCTOR again to confirm"
+  },
+  {
+    "name": "config_exemption_semantics",
+    "surface": "config",
+    "status": "warn",
+    "configured": true,
+    "reachable": false,
+    "enforcing": false,
+    "detail": "response_scanning.exempt_domains is set but response_scanning.enabled=false; this exemption is inert",
+    "next": "enable response_scanning to make the exemption effective, or remove the exempt_domains list"
+  }
+]`), "PIPELOCK_DOCTOR", "`pipelock doctor`")
+	if string(got) != want {
+		t.Fatalf("semantic doctor checks changed:\n got:\n%s\nwant:\n%s", got, want)
 	}
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -23,6 +23,7 @@ import (
 
 type loadOptions struct {
 	resolveLicense bool
+	skipValidate   bool
 }
 
 // Load reads, parses, defaults, and validates a Pipelock config file.
@@ -38,6 +39,18 @@ func Load(path string) (*Config, error) {
 // is service-owned.
 func LoadForRules(path string) (*Config, error) {
 	return load(path, loadOptions{resolveLicense: false})
+}
+
+// LoadForInspection reads config for read-only inspection surfaces (e.g. the
+// dashboard's exemptions inventory). It keeps strict YAML parsing and defaults
+// so the parsed config model is accurate, but intentionally does NOT resolve
+// runtime-side external files (license/key/cert/token) and does NOT run full
+// validation. A read-only inventory must not depend on, read, or fail to start
+// because of unrelated referenced files it does not need — that would expand the
+// inspection surface's privilege and operational dependencies. Malformed YAML
+// still fails closed at the strict parse step.
+func LoadForInspection(path string) (*Config, error) {
+	return load(path, loadOptions{resolveLicense: false, skipValidate: true})
 }
 
 func load(path string, opts loadOptions) (*Config, error) {
@@ -159,13 +172,15 @@ func load(path string, opts loadOptions) (*Config, error) {
 		}
 	}
 
-	if opts.resolveLicense {
-		if err := cfg.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid config: %w", err)
-		}
-	} else {
-		if err := cfg.validateForRules(); err != nil {
-			return nil, fmt.Errorf("invalid rules config: %w", err)
+	if !opts.skipValidate {
+		if opts.resolveLicense {
+			if err := cfg.Validate(); err != nil {
+				return nil, fmt.Errorf("invalid config: %w", err)
+			}
+		} else {
+			if err := cfg.validateForRules(); err != nil {
+				return nil, fmt.Errorf("invalid rules config: %w", err)
+			}
 		}
 	}
 	cfg.canonicalHashCache = &canonicalHashCacheHolder{}


### PR DESCRIPTION
## What changed

The enterprise dashboard gains a read-only Exemptions page. It lists every exemption configured in the loaded config and flags the ones that are inert (configured against a knob the blocking scanner never consults, or on a disabled scanner) or misdirected (aimed at the wrong knob), so an operator can see which exemptions silently do nothing instead of trusting that a false positive is fixed.

The config doctor semantic analysis is extracted into a shared analyzer, so the config doctor CLI and the dashboard use one source of truth for inert and wrong-knob detection rather than drifting. The detector covers the full disabled-feature class: response scanning, adaptive enforcement, cross-request entropy budget, browser shield, TLS passthrough, and the request-header ignore list.

`dashboard serve` gains a `--config` flag that loads the config whose exemptions are shown. When it is omitted the page renders an explicit "no config loaded" state, and the evidence view still works without a config.

## Read-only and honest by construction

The page is a lens, not an authority surface: no create, apply, remove, or renew controls, no mutation routes, and it is gated behind the same license, authentication, CSP, and audit seams as the evidence view. Owner, expiry, and last-matched render as "not tracked" because there is no exemption-lifecycle store yet, so nothing is fabricated.

A pristine default config produces zero findings, held by an invariant test at both the analyzer and dashboard layers. Inert detection fires only for operator-added exemptions on a disabled feature, never for auto-filled default baselines.

## Not included (deferred)

Owner, expiry, and last-matched lifecycle tracking, a create-and-verify flow, and distinguishing operator-set values from auto-filled defaults all require backend that does not exist yet and are intentionally out of scope. The page shows only what the loaded config actually contains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only **Exemptions** inventory view to the dashboard, alongside **Evidence**.
  * `pipelock dashboard serve` now supports an optional `--config` flag to populate the Exemptions view.
* **Bug Fixes**
  * Improved fail-closed handling for missing/invalid/malformed configs while keeping the server start reachable during inspection.
  * Strengthened security: hostile config HTML escaping and correct raw-value redaction behavior.
* **Documentation**
  * Updated the CLI dashboard docs, including the `/exemptions` GET-only security model and “not tracked” lifecycle columns.
* **Tests**
  * Added end-to-end, handler, and exemptions coverage for `--config` and view authorization/redaction behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->