### PR TITLE
feat: durable receipt-evidence lifecycle and honest completeness verifier

### DIFF
--- a/cmd/pipelock-verifier/completeness.go
+++ b/cmd/pipelock-verifier/completeness.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/evidence/completeness"
+	actionreceipt "github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+type completenessOptions struct {
+	signerKey     string
+	sessionID     string
+	jsonOutput    bool
+	allowUnpinned bool
+}
+
+func newCompletenessCmd() *cobra.Command {
+	var opts completenessOptions
+	cmd := &cobra.Command{
+		Use:   "completeness RUNDIR|FILE",
+		Short: "Analyze bounded run-completeness evidence",
+		Long: `Analyzes signed session lifecycle evidence in an action-receipt chain.
+The best possible completeness result is LIMITED, never COMPLETE/PASS/OK:
+Pipelock can bound mediated egress it observed, but cannot prove the agent had
+no egress path outside that boundary.
+
+Exit-code contract:
+  0  analysis ran and the chain was not classified BROKEN; LIMITED and
+     UNVERIFIED are successful analyses
+  1  BROKEN chain/completeness evidence, unpinned non-empty chain without
+     --allow-unpinned, or another verifier failure
+  2  tool, IO, extraction, or key-resolution error
+ 64  command-line usage error`,
+		Args:          exactOneArg,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCompleteness(cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], opts)
+		},
+	}
+	cmd.SetFlagErrorFunc(usageFlagError)
+	cmd.Flags().StringVar(&opts.signerKey, "key", "", "expected signer public key (hex, public-key text, or file path)")
+	cmd.Flags().StringVar(&opts.sessionID, "session", "proxy", "session ID inside an evidence directory")
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON report on stdout")
+	cmd.Flags().BoolVar(&opts.allowUnpinned, "allow-unpinned", false, "allow structural-only verification without a trusted signer key")
+	return cmd
+}
+
+func runCompleteness(stdout, stderr io.Writer, target string, opts completenessOptions) error {
+	keyHex, err := resolveSignerKey(strings.TrimSpace(opts.signerKey))
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("resolve signer key: %w", err))
+	}
+	clean := filepath.Clean(target)
+	receipts, label, err := extractCompletenessReceipts(clean, opts.sessionID)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+	}
+	chainResult := actionreceipt.VerifyChain(receipts, keyHex)
+	report := completeness.Analyze(receipts, chainResult)
+	report.Path = label
+	report.SignaturesVerified = chainResult.IntegrityVerified && keyHex != ""
+	report.Unpinned = len(receipts) > 0 && chainResult.IntegrityVerified && keyHex == ""
+	if report.Unpinned && !opts.allowUnpinned {
+		report.Error = unpinnedReceiptBanner
+	}
+
+	emitCompletenessReport(stdout, stderr, report, opts.jsonOutput)
+	if report.Status == completeness.StatusBroken {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("completeness broken: %s", report.Error))
+	}
+	if report.Unpinned && !opts.allowUnpinned {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("completeness verification unpinned"))
+	}
+	return nil
+}
+
+func extractCompletenessReceipts(clean, sessionID string) ([]actionreceipt.Receipt, string, error) {
+	info, err := os.Stat(clean)
+	if err != nil {
+		return nil, "", fmt.Errorf("stat %q: %w", clean, err)
+	}
+	if info.IsDir() {
+		receipts, extractErr := actionreceipt.ExtractReceiptsFromSessionDir(clean, sessionID)
+		if extractErr != nil {
+			return nil, "", fmt.Errorf("extract receipts: %w", extractErr)
+		}
+		return receipts, fmt.Sprintf("%s (session %s)", clean, sessionID), nil
+	}
+	receipts, err := actionreceipt.ExtractReceipts(clean)
+	if err != nil {
+		return nil, "", fmt.Errorf("extract receipts: %w", err)
+	}
+	return receipts, clean, nil
+}
+
+func emitCompletenessReport(stdout, stderr io.Writer, report completeness.Report, jsonMode bool) {
+	if jsonMode {
+		writeJSON(stdout, report)
+		return
+	}
+	if report.Unpinned {
+		_, _ = fmt.Fprintf(stderr, "WARN: %s\n", unpinnedReceiptBanner)
+	}
+	_, _ = fmt.Fprintf(stdout, "completeness: %s (%s)\n", report.Status, report.Reason)
+	_, _ = fmt.Fprintf(stdout, "path: %s\n", report.Path)
+	_, _ = fmt.Fprintf(stdout, "receipts: %d\n", report.ReceiptCount)
+	if report.FinalSeq != 0 || report.RootHash != "" {
+		_, _ = fmt.Fprintf(stdout, "final_seq: %d\n", report.FinalSeq)
+	}
+	if report.RootHash != "" {
+		_, _ = fmt.Fprintf(stdout, "root_hash: %s\n", report.RootHash)
+	}
+	if report.Error != "" {
+		_, _ = fmt.Fprintf(stdout, "detail: %s\n", report.Error)
+	}
+	for _, run := range report.Runs {
+		emitCompletenessRun(stdout, run)
+	}
+}
+
+func emitCompletenessRun(stdout io.Writer, run completeness.RunReport) {
+	_, _ = fmt.Fprintf(stdout, "\nrun_nonce: %s\n", run.RunNonce)
+	_, _ = fmt.Fprintf(stdout, "  status: %s\n", run.Status)
+	_, _ = fmt.Fprintf(stdout, "  reason: %s\n", run.Reason)
+	_, _ = fmt.Fprintf(stdout, "  intents: %d\n", run.Intents)
+	_, _ = fmt.Fprintf(stdout, "  outcomes: %d\n", run.Outcomes)
+	_, _ = fmt.Fprintf(stdout, "  matched_pairs: %d\n", run.MatchedPairs)
+	_, _ = fmt.Fprintf(stdout, "  unmatched_intents: %d\n", run.UnmatchedIntents)
+	_, _ = fmt.Fprintf(stdout, "  heartbeats: %d\n", run.Heartbeats)
+	_, _ = fmt.Fprintf(stdout, "  closed: %t\n", run.Closed)
+	_, _ = fmt.Fprintf(stdout, "  durability_monotonic: %t\n", run.DurabilityMonotonic)
+	_, _ = fmt.Fprintf(stdout, "  fsync_errors_gated: %d\n", run.FsyncErrorsGated)
+	_, _ = fmt.Fprintf(stdout, "  durability_blocks: %d\n", run.DurabilityBlocks)
+	if run.LastHeartbeat != nil {
+		_, _ = fmt.Fprintf(stdout, "  last_heartbeat_fsync_errors_gated: %d\n", run.LastHeartbeat.FsyncErrorsGated)
+		_, _ = fmt.Fprintf(stdout, "  last_heartbeat_durability_blocks: %d\n", run.LastHeartbeat.DurabilityBlocks)
+	}
+	if run.Close != nil {
+		_, _ = fmt.Fprintf(stdout, "  close_fsync_errors_gated: %d\n", run.Close.FsyncErrorsGated)
+		_, _ = fmt.Fprintf(stdout, "  close_durability_blocks: %d\n", run.Close.DurabilityBlocks)
+	}
+	if run.StructuralViolation != "" {
+		_, _ = fmt.Fprintf(stdout, "  structural_violation: %s\n", run.StructuralViolation)
+	}
+}

--- a/cmd/pipelock-verifier/completeness.go
+++ b/cmd/pipelock-verifier/completeness.go
@@ -72,7 +72,15 @@ func runCompleteness(stdout, stderr io.Writer, target string, opts completenessO
 	report.SignaturesVerified = chainResult.IntegrityVerified && keyHex != ""
 	report.Unpinned = len(receipts) > 0 && chainResult.IntegrityVerified && keyHex == ""
 	if report.Unpinned && !opts.allowUnpinned {
-		report.Error = unpinnedReceiptBanner
+		// Append rather than overwrite: a report can be both Unpinned and
+		// StatusBroken (integrity-valid chain with a completeness structural
+		// violation), and the broken reason must survive so the exit-1 detail
+		// below reports the real cause, not just the unpinned banner.
+		if report.Error == "" {
+			report.Error = unpinnedReceiptBanner
+		} else {
+			report.Error = report.Error + "; " + unpinnedReceiptBanner
+		}
 	}
 
 	emitCompletenessReport(stdout, stderr, report, opts.jsonOutput)

--- a/cmd/pipelock-verifier/completeness_test.go
+++ b/cmd/pipelock-verifier/completeness_test.go
@@ -242,7 +242,7 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 		}
 	})
 
-	t.Run("unverified_no_open_exits_zero", func(t *testing.T) {
+	t.Run("lifecycle_no_open_exits_nonzero", func(t *testing.T) {
 		t.Parallel()
 		f := newCompletenessFixture(t)
 		path := writeCompletenessJSONL(t, []receipt.Receipt{
@@ -250,15 +250,15 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 			f.close(runNonce, openNonce),
 		})
 		stdout, stderr, code := runRoot(t, "completeness", "--json", "--key", f.keyHex, path)
-		if code != cliutil.ExitOK {
-			t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout, stderr)
+		if code != cliutil.ExitGeneral {
+			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
 		}
 		report := parseCompletenessReport(t, stdout)
-		if report.Status != completeness.StatusUnverified || report.Reason != completeness.ReasonNoOpen {
-			t.Fatalf("report=%s/%s, want UNVERIFIED/no_open", report.Status, report.Reason)
+		if report.Status != completeness.StatusBroken || report.Reason != completeness.ReasonChainBroken {
+			t.Fatalf("report=%s/%s, want BROKEN/chain_broken", report.Status, report.Reason)
 		}
 		if !report.SignaturesVerified {
-			t.Fatalf("signatures_verified=false, want true for integrity-valid no-open: %#v", report)
+			t.Fatalf("signatures_verified=false, want true for signed malformed lifecycle: %#v", report)
 		}
 	})
 
@@ -284,7 +284,7 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 		}
 	})
 
-	t.Run("unverified_no_open_without_key_requires_unpinned_flag", func(t *testing.T) {
+	t.Run("broken_no_open_without_key_stays_nonzero_with_unpinned_flag", func(t *testing.T) {
 		t.Parallel()
 		f := newCompletenessFixture(t)
 		path := writeCompletenessJSONL(t, []receipt.Receipt{
@@ -301,12 +301,12 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 		}
 
 		stdout, stderr, code = runRoot(t, "completeness", "--json", "--allow-unpinned", path)
-		if code != cliutil.ExitOK {
-			t.Fatalf("allow-unpinned code=%d stdout=%q stderr=%q", code, stdout, stderr)
+		if code != cliutil.ExitGeneral {
+			t.Fatalf("allow-unpinned code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
 		}
 		report = parseCompletenessReport(t, stdout)
-		if report.Status != completeness.StatusUnverified || report.Reason != completeness.ReasonNoOpen || !report.Unpinned {
-			t.Fatalf("allow-unpinned report=%s/%s unpinned=%t, want UNVERIFIED/no_open unpinned", report.Status, report.Reason, report.Unpinned)
+		if report.Status != completeness.StatusBroken || report.Reason != completeness.ReasonChainBroken || !report.Unpinned {
+			t.Fatalf("allow-unpinned report=%s/%s unpinned=%t, want BROKEN/chain_broken unpinned", report.Status, report.Reason, report.Unpinned)
 		}
 	})
 

--- a/cmd/pipelock-verifier/completeness_test.go
+++ b/cmd/pipelock-verifier/completeness_test.go
@@ -1,0 +1,412 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/evidence/completeness"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+type completenessFixture struct {
+	t      *testing.T
+	priv   ed25519.PrivateKey
+	keyHex string
+	prev   string
+	seq    uint64
+	base   time.Time
+	offset time.Duration
+}
+
+func newCompletenessFixture(t *testing.T) *completenessFixture {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+	return &completenessFixture{
+		t:      t,
+		priv:   priv,
+		keyHex: hex.EncodeToString(pub),
+		prev:   receipt.GenesisHash,
+		base:   time.Date(2026, 7, 6, 13, 0, 0, 0, time.UTC),
+	}
+}
+
+func (f *completenessFixture) sign(ar receipt.ActionRecord) receipt.Receipt {
+	f.t.Helper()
+	if ar.Version == 0 {
+		ar.Version = receipt.ActionRecordVersion
+	}
+	if ar.ActionID == "" {
+		ar.ActionID = receipt.NewActionID()
+	}
+	if ar.ActionType == "" {
+		ar.ActionType = receipt.ActionRead
+	}
+	if ar.Timestamp.IsZero() {
+		ar.Timestamp = f.base.Add(f.offset)
+	}
+	if ar.Target == "" {
+		ar.Target = "https://api.vendor.example/completeness-cli"
+	}
+	if ar.Verdict == "" {
+		ar.Verdict = verdictAllowed
+	}
+	if ar.Transport == "" {
+		ar.Transport = "fetch"
+	}
+	if ar.PolicyHash == "" {
+		ar.PolicyHash = "policy-completeness-cli"
+	}
+	ar.ChainPrevHash = f.prev
+	ar.ChainSeq = f.seq
+	r, err := receipt.Sign(ar, f.priv)
+	if err != nil {
+		f.t.Fatalf("Sign: %v", err)
+	}
+	hash, err := receipt.ReceiptHash(r)
+	if err != nil {
+		f.t.Fatalf("ReceiptHash: %v", err)
+	}
+	f.prev = hash
+	f.seq++
+	f.offset += time.Second
+	return r
+}
+
+func (f *completenessFixture) open(runNonce, openNonce string) receipt.Receipt {
+	f.t.Helper()
+	open := receipt.SessionOpen{
+		RunNonce:         runNonce,
+		OpenNonce:        openNonce,
+		RecorderSession:  "proxy",
+		PolicyHash:       "policy-completeness-cli",
+		SignerKeyEpoch:   "epoch-cli",
+		HeartbeatSeconds: 10,
+		ChainOpenSeq:     f.seq,
+	}
+	genesis := receipt.ComputeSessionOpenGenesis(open)
+	open.GenesisHash = genesis
+	f.prev = genesis
+	return f.sign(receipt.ActionRecord{
+		ActionType: receipt.ActionUnclassified,
+		Target:     "pipelock://session/open",
+		Transport:  "session_control",
+		RunNonce:   runNonce,
+		SessionControl: &receipt.SessionControl{
+			Kind: receipt.SessionControlOpen,
+			Open: &open,
+		},
+	})
+}
+
+func (f *completenessFixture) heartbeat(runNonce, openNonce string) receipt.Receipt {
+	f.t.Helper()
+	const beat = 1
+	return f.sign(receipt.ActionRecord{
+		ActionType: receipt.ActionUnclassified,
+		Target:     "pipelock://session/heartbeat",
+		Transport:  "session_control",
+		RunNonce:   runNonce,
+		SessionControl: &receipt.SessionControl{
+			Kind: receipt.SessionControlHeartbeat,
+			Heartbeat: &receipt.SessionHeartbeat{
+				RunNonce:         runNonce,
+				OpenNonce:        openNonce,
+				Beat:             beat,
+				ChainHead:        f.prev,
+				ChainSeqHead:     f.seq,
+				HeartbeatTime:    f.base.Add(f.offset).Format(time.RFC3339Nano),
+				DurabilityBlocks: beat,
+			},
+		},
+	})
+}
+
+func (f *completenessFixture) close(runNonce, openNonce string) receipt.Receipt {
+	f.t.Helper()
+	finalSeq := uint64(0)
+	if f.seq > 0 {
+		finalSeq = f.seq - 1
+	}
+	return f.sign(receipt.ActionRecord{
+		ActionType: receipt.ActionUnclassified,
+		Target:     "pipelock://session/close",
+		Transport:  "session_control",
+		RunNonce:   runNonce,
+		SessionControl: &receipt.SessionControl{
+			Kind: receipt.SessionControlClose,
+			Close: &receipt.SessionClose{
+				RunNonce:         runNonce,
+				OpenNonce:        openNonce,
+				FinalSeq:         finalSeq,
+				RootHash:         f.prev,
+				ReceiptCount:     f.seq,
+				CloseReason:      "normal",
+				DurabilityBlocks: 1,
+			},
+		},
+	})
+}
+
+func (f *completenessFixture) intent(runNonce, actionID string) receipt.Receipt {
+	f.t.Helper()
+	return f.sign(receipt.ActionRecord{
+		ActionID:      actionID,
+		ActionType:    receipt.ActionRead,
+		Target:        "https://api.vendor.example/completeness-cli/action",
+		Transport:     "fetch",
+		RunNonce:      runNonce,
+		DecisionPhase: receipt.DecisionPhaseIntent,
+	})
+}
+
+func (f *completenessFixture) outcome(runNonce, actionID string) receipt.Receipt {
+	f.t.Helper()
+	return f.sign(receipt.ActionRecord{
+		ActionID:      actionID,
+		ActionType:    receipt.ActionRead,
+		Target:        "https://api.vendor.example/completeness-cli/action",
+		Transport:     "fetch",
+		RunNonce:      runNonce,
+		DecisionPhase: receipt.DecisionPhaseOutcome,
+	})
+}
+
+func writeCompletenessJSONL(t *testing.T, receipts []receipt.Receipt) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "evidence.jsonl")
+	var buf bytes.Buffer
+	for _, r := range receipts {
+		line, err := receipt.Marshal(r)
+		if err != nil {
+			t.Fatalf("receipt.Marshal: %v", err)
+		}
+		_, _ = buf.Write(line)
+		_ = buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write evidence: %v", err)
+	}
+	return path
+}
+
+func parseCompletenessReport(t *testing.T, stdout string) completeness.Report {
+	t.Helper()
+	var report completeness.Report
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("unmarshal report: %v\nstdout=%s", err, stdout)
+	}
+	return report
+}
+
+func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
+	t.Parallel()
+	const (
+		runNonce  = "run-completeness-cli"
+		openNonce = "open-completeness-cli"
+	)
+
+	t.Run("limited_bounded_closed_exits_zero", func(t *testing.T) {
+		t.Parallel()
+		f := newCompletenessFixture(t)
+		actionID := "action-cli-limited"
+		path := writeCompletenessJSONL(t, []receipt.Receipt{
+			f.open(runNonce, openNonce),
+			f.intent(runNonce, actionID),
+			f.outcome(runNonce, actionID),
+			f.heartbeat(runNonce, openNonce),
+			f.close(runNonce, openNonce),
+		})
+		stdout, stderr, code := runRoot(t, "completeness", "--json", "--key", f.keyHex, path)
+		if code != cliutil.ExitOK {
+			t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout, stderr)
+		}
+		report := parseCompletenessReport(t, stdout)
+		if report.Status != completeness.StatusLimited || report.Reason != completeness.ReasonBoundedClosed {
+			t.Fatalf("report=%s/%s, want LIMITED/bounded_closed", report.Status, report.Reason)
+		}
+	})
+
+	t.Run("unverified_no_open_exits_zero", func(t *testing.T) {
+		t.Parallel()
+		f := newCompletenessFixture(t)
+		path := writeCompletenessJSONL(t, []receipt.Receipt{
+			f.heartbeat(runNonce, openNonce),
+			f.close(runNonce, openNonce),
+		})
+		stdout, stderr, code := runRoot(t, "completeness", "--json", "--key", f.keyHex, path)
+		if code != cliutil.ExitOK {
+			t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout, stderr)
+		}
+		report := parseCompletenessReport(t, stdout)
+		if report.Status != completeness.StatusUnverified || report.Reason != completeness.ReasonNoOpen {
+			t.Fatalf("report=%s/%s, want UNVERIFIED/no_open", report.Status, report.Reason)
+		}
+		if !report.SignaturesVerified {
+			t.Fatalf("signatures_verified=false, want true for integrity-valid no-open: %#v", report)
+		}
+	})
+
+	t.Run("forged_no_open_exits_nonzero", func(t *testing.T) {
+		t.Parallel()
+		f := newCompletenessFixture(t)
+		receipts := []receipt.Receipt{
+			f.heartbeat(runNonce, openNonce),
+			f.close(runNonce, openNonce),
+		}
+		receipts[0].ActionRecord.Target = "https://api.vendor.example/forged-no-open-cli"
+		path := writeCompletenessJSONL(t, receipts)
+		stdout, stderr, code := runRoot(t, "completeness", "--json", "--key", f.keyHex, path)
+		if code != cliutil.ExitGeneral {
+			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
+		}
+		report := parseCompletenessReport(t, stdout)
+		if report.Status != completeness.StatusBroken || report.Reason != completeness.ReasonChainBroken {
+			t.Fatalf("report=%s/%s, want BROKEN/chain_broken", report.Status, report.Reason)
+		}
+		if report.SignaturesVerified {
+			t.Fatalf("signatures_verified=true for forged chain: %#v", report)
+		}
+	})
+
+	t.Run("unverified_no_open_without_key_requires_unpinned_flag", func(t *testing.T) {
+		t.Parallel()
+		f := newCompletenessFixture(t)
+		path := writeCompletenessJSONL(t, []receipt.Receipt{
+			f.heartbeat(runNonce, openNonce),
+			f.close(runNonce, openNonce),
+		})
+		stdout, stderr, code := runRoot(t, "completeness", "--json", path)
+		if code != cliutil.ExitGeneral {
+			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
+		}
+		report := parseCompletenessReport(t, stdout)
+		if !report.Unpinned {
+			t.Fatalf("unpinned=false, want true: %#v", report)
+		}
+
+		stdout, stderr, code = runRoot(t, "completeness", "--json", "--allow-unpinned", path)
+		if code != cliutil.ExitOK {
+			t.Fatalf("allow-unpinned code=%d stdout=%q stderr=%q", code, stdout, stderr)
+		}
+		report = parseCompletenessReport(t, stdout)
+		if report.Status != completeness.StatusUnverified || report.Reason != completeness.ReasonNoOpen || !report.Unpinned {
+			t.Fatalf("allow-unpinned report=%s/%s unpinned=%t, want UNVERIFIED/no_open unpinned", report.Status, report.Reason, report.Unpinned)
+		}
+	})
+
+	t.Run("broken_chain_exits_nonzero", func(t *testing.T) {
+		t.Parallel()
+		f := newCompletenessFixture(t)
+		actionID := "action-cli-broken"
+		receipts := []receipt.Receipt{
+			f.open(runNonce, openNonce),
+			f.intent(runNonce, actionID),
+			f.outcome(runNonce, actionID),
+		}
+		receipts[1].ActionRecord.Target = "https://api.vendor.example/tampered"
+		path := writeCompletenessJSONL(t, receipts)
+		stdout, stderr, code := runRoot(t, "completeness", "--json", "--key", f.keyHex, path)
+		if code != cliutil.ExitGeneral {
+			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
+		}
+		report := parseCompletenessReport(t, stdout)
+		if report.Status != completeness.StatusBroken || report.Reason != completeness.ReasonChainBroken {
+			t.Fatalf("report=%s/%s, want BROKEN/chain_broken", report.Status, report.Reason)
+		}
+	})
+}
+
+func TestCompletenessCLINeverPrintsGreenTopline(t *testing.T) {
+	t.Parallel()
+	const (
+		runNonce  = "run-completeness-human"
+		openNonce = "open-completeness-human"
+	)
+	f := newCompletenessFixture(t)
+	actionID := "action-cli-human"
+	path := writeCompletenessJSONL(t, []receipt.Receipt{
+		f.open(runNonce, openNonce),
+		f.intent(runNonce, actionID),
+		f.outcome(runNonce, actionID),
+		f.heartbeat(runNonce, openNonce),
+		f.close(runNonce, openNonce),
+	})
+	stdout, stderr, code := runRoot(t, "completeness", "--key", f.keyHex, path)
+	if code != cliutil.ExitOK {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "completeness: LIMITED (bounded_closed)") {
+		t.Fatalf("stdout missing LIMITED topline: %s", stdout)
+	}
+	for _, forbidden := range []string{"COMPLETE", "PASS", "OK"} {
+		if strings.Contains(stdout, forbidden) {
+			t.Fatalf("stdout contains forbidden green term %q: %s", forbidden, stdout)
+		}
+	}
+}
+
+func TestCompletenessCLITranscriptRootAfterCloseDoesNotTripPostCloseGuard(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:           true,
+		Dir:               dir,
+		MaxEntriesPerFile: 100,
+		FileMode:          0o600,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	e := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: "policy-completeness-cli",
+		Principal:  "user",
+		Actor:      "agent",
+	})
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := e.EmitSessionClose("normal"); err != nil {
+		t.Fatalf("EmitSessionClose: %v", err)
+	}
+	if err := e.EmitTranscriptRoot("proxy"); err != nil {
+		t.Fatalf("EmitTranscriptRoot: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
+
+	stdout, stderr, code := runRoot(t, "completeness", "--json", "--key", hex.EncodeToString(pub), dir)
+	if code != cliutil.ExitOK {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	report := parseCompletenessReport(t, stdout)
+	if report.Status != completeness.StatusLimited || report.Reason != completeness.ReasonBoundedClosed {
+		t.Fatalf("report=%s/%s, want LIMITED/bounded_closed: %#v", report.Status, report.Reason, report)
+	}
+	if report.ReceiptCount != 2 {
+		t.Fatalf("receipt_count=%d, want 2 action receipts with transcript_root ignored: %#v", report.ReceiptCount, report)
+	}
+}

--- a/cmd/pipelock-verifier/main.go
+++ b/cmd/pipelock-verifier/main.go
@@ -69,6 +69,7 @@ CI runner, an auditor's laptop, or an isolated environment.`,
 
 	root.AddCommand(newAuditPacketCmd())
 	root.AddCommand(newChainCmd())
+	root.AddCommand(newCompletenessCmd())
 	root.AddCommand(newIndependentCmd())
 	root.AddCommand(newReceiptCmd())
 	root.AddCommand(newReplayCmd())

--- a/enterprise/dashboard/readmodel_test.go
+++ b/enterprise/dashboard/readmodel_test.go
@@ -36,6 +36,9 @@ func TestReadModel_IntegrationRealReadPathAndZeroReceiptSession(t *testing.T) {
 		Principal:  testPrincipal,
 		Actor:      testActor,
 	})
+	if err := emitter.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
 	for i := 0; i < 2; i++ {
 		if err := emitter.Emit(receipt.EmitOpts{
 			ActionID:  receipt.NewActionID(),

--- a/enterprise/dashboard/scorecard_test.go
+++ b/enterprise/dashboard/scorecard_test.go
@@ -256,6 +256,30 @@ func TestComputeScorecard_CompletenessAndAnchoredNeverGreen(t *testing.T) {
 	}
 }
 
+func TestComputeScorecard_BoundSessionOpenGenesis(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	chain := buildBoundDashboardChain(t, priv, keyHex)
+
+	evidence := sessionEvidence(testSessionID, chain, map[string]TrustedKey{
+		keyHex: {Source: trustedKeySource},
+	}, false, dashboardReceiptReadLimit, dashboardTimelineLimit)
+	if !evidence.Chain.Valid {
+		t.Fatalf("bound g1 session_open chain should verify in dashboard scorecard: %s", evidence.Chain.Error)
+	}
+	if evidence.Scorecard.Authentic.State != StateVerify {
+		t.Fatalf("Authentic.State = %q, want %q", evidence.Scorecard.Authentic.State, StateVerify)
+	}
+	if evidence.Scorecard.Untampered.State != StateVerify {
+		t.Fatalf("Untampered.State = %q, want %q", evidence.Scorecard.Untampered.State, StateVerify)
+	}
+	if evidence.Timeline[0].Seq != 0 || evidence.Timeline[0].Unverifiable {
+		t.Fatalf("first bound-g1 timeline item = %+v, want verifiable seq 0", evidence.Timeline[0])
+	}
+}
+
 func generateDashboardKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
 	t.Helper()
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
@@ -281,6 +305,45 @@ func buildDashboardChain(t *testing.T, priv ed25519.PrivateKey, count int) []rec
 		prevHash = hash
 	}
 	return chain
+}
+
+func buildBoundDashboardChain(t *testing.T, priv ed25519.PrivateKey, signerKey string) []receipt.Receipt {
+	t.Helper()
+	base := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	open := receipt.SessionOpen{
+		RunNonce:        "dashboard-run",
+		OpenNonce:       "dashboard-open",
+		RecorderSession: "proxy",
+		PolicyHash:      testPolicyHash,
+		SignerKeyEpoch:  signerKey,
+		ChainOpenSeq:    0,
+	}
+	genesis := receipt.ComputeSessionOpenGenesis(open)
+	open.GenesisHash = genesis
+
+	ar := validDashboardAction(0, genesis, base)
+	ar.RunNonce = open.RunNonce
+	ar.Transport = "receipt_session"
+	ar.Target = "pipelock://session/open"
+	ar.SessionControl = &receipt.SessionControl{
+		Kind: receipt.SessionControlOpen,
+		Open: &open,
+	}
+	first, err := receipt.Sign(ar, priv)
+	if err != nil {
+		t.Fatalf("Sign bound session_open: %v", err)
+	}
+	firstHash, err := receipt.ReceiptHash(first)
+	if err != nil {
+		t.Fatalf("ReceiptHash bound session_open: %v", err)
+	}
+	second := signDashboardReceipt(t, priv, 1, firstHash, base.Add(time.Second))
+	second.ActionRecord.RunNonce = open.RunNonce
+	second, err = receipt.Sign(second.ActionRecord, priv)
+	if err != nil {
+		t.Fatalf("Sign bound follow-up: %v", err)
+	}
+	return []receipt.Receipt{first, second}
 }
 
 func buildRotatedDashboardChain(t *testing.T, privA, privB ed25519.PrivateKey) []receipt.Receipt {

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1022,16 +1022,41 @@ Key-free evidence capture:
 			if cfg.FlightRecorder.RequireReceipts && !receiptEmitterReady(receiptEmitter) {
 				return fmt.Errorf("flight_recorder.require_receipts is enabled but no healthy signed receipt emitter is active: set flight_recorder.enabled, flight_recorder.dir, and flight_recorder.signing_key_path (run 'pipelock init'), fix any receipt-chain resume error, or disable require_receipts")
 			}
+			heartbeatCtx, heartbeatCancel := context.WithCancel(cmd.Context())
+			defer heartbeatCancel()
+			var heartbeatErrMu sync.Mutex
+			var heartbeatErr error
+			setRequiredHeartbeatErr := func(err error) {
+				if err == nil {
+					return
+				}
+				heartbeatErrMu.Lock()
+				if heartbeatErr == nil {
+					heartbeatErr = err
+				}
+				heartbeatErrMu.Unlock()
+				heartbeatCancel()
+			}
+			requiredHeartbeatErr := func() error {
+				heartbeatErrMu.Lock()
+				defer heartbeatErrMu.Unlock()
+				if heartbeatErr == nil {
+					return nil
+				}
+				return fmt.Errorf("flight_recorder.require_receipts is enabled but receipt heartbeat emission failed: %w", heartbeatErr)
+			}
 			// Standalone MCP does not have the proxy server's drain-then-seal
 			// WaitGroup. Tie heartbeat to the command lifetime instead: the
 			// deferred stop cancels and joins heartbeats before writing
 			// session_close + transcript_root, so no heartbeat appends after
 			// the close even though each transport has its own run loop.
 			stopReceiptLifecycle := startStandaloneReceiptLifecycle(
-				cmd.Context(),
+				heartbeatCtx,
 				cfg.FlightRecorder.HeartbeatIntervalDuration(),
 				receiptEmitter,
 				cmd.ErrOrStderr(),
+				cfg.FlightRecorder.RequireReceipts,
+				setRequiredHeartbeatErr,
 			)
 			defer stopReceiptLifecycle()
 			sc.SetDLPWarnHook(func(ctx context.Context, patternName, severity string) {
@@ -1123,7 +1148,7 @@ Key-free evidence capture:
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: --header is only honored in stdio-to-HTTP --upstream mode; ignored for --listen and ws/wss upstreams")
 				}
 
-				ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+				ctx, cancel := signal.NotifyContext(heartbeatCtx, syscall.SIGINT, syscall.SIGTERM)
 				defer cancel()
 
 				// HTTP reverse proxy mode: --listen + --upstream.
@@ -1178,10 +1203,16 @@ Key-free evidence capture:
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: MCP reverse proxy %s -> %s (response=%s, trust=%s, server=%s, input=%s, tools=%s, policy=%s)\n",
 						listenAddr, upstreamURL, respAction, respTrust, respServer, inputCfg.Action, toolAction, policyAction)
 					if err := mcp.RunHTTPListenerProxy(ctx, mcpLn, upstreamURL, cmd.ErrOrStderr(), listenerOpts); err != nil {
+						if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
+							return heartbeatErr
+						}
 						if sentryClient != nil {
 							sentryClient.CaptureError(err)
 						}
 						return err
+					}
+					if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
+						return heartbeatErr
 					}
 					return nil
 				}
@@ -1219,10 +1250,16 @@ Key-free evidence capture:
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: proxying WS upstream %s (response=%s, trust=%s, server=%s, input=%s, tools=%s, policy=%s)\n",
 						upstreamURL, respAction, respTrust, respServer, inputCfg.Action, toolAction, policyAction)
 					if err := mcp.RunWSProxy(ctx, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), upstreamURL, wsOpts); err != nil {
+						if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
+							return heartbeatErr
+						}
 						if sentryClient != nil {
 							sentryClient.CaptureError(err)
 						}
 						return err
+					}
+					if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
+						return heartbeatErr
 					}
 					return nil
 				}
@@ -1265,10 +1302,16 @@ Key-free evidence capture:
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: proxying upstream %s (response=%s, trust=%s, server=%s, input=%s, tools=%s, policy=%s)\n",
 					upstreamURL, respAction, respTrust, respServer, inputCfg.Action, toolAction, policyAction)
 				if err := mcp.RunHTTPProxy(ctx, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), upstreamURL, extraHeaders, httpOpts); err != nil {
+					if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
+						return heartbeatErr
+					}
 					if sentryClient != nil {
 						sentryClient.CaptureError(err)
 					}
 					return err
+				}
+				if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
+					return heartbeatErr
 				}
 				return nil
 			}
@@ -1338,7 +1381,7 @@ Key-free evidence capture:
 				}
 				workspace, _ = filepath.Abs(workspace)
 
-				ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+				ctx, cancel := signal.NotifyContext(heartbeatCtx, syscall.SIGINT, syscall.SIGTERM)
 				defer cancel()
 
 				stopDeferAPI, deferAPIErr := startDeferredOperatorAPIOrReport(ctx, cfg, deferManager, auditLogger, cmd.ErrOrStderr(), sentryClient)
@@ -1437,7 +1480,13 @@ Key-free evidence capture:
 					"pipelock: proxying MCP server %v [SANDBOXED] (response=%s, trust=%s, server=%s, input=%s, tools=%s, policy=%s, workspace=%s)\n",
 					serverCmd, respAction, respTrust, respServer, inputCfg.Action, toolAction, policyAction, workspace)
 				if err := mcp.RunProxyWithSandbox(ctx, sandboxCmd, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), proxyOpts, mcpStrict); err != nil {
+					if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
+						return heartbeatErr
+					}
 					return handleProxyError(err, cmd.ErrOrStderr(), sentryClient)
+				}
+				if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
+					return heartbeatErr
 				}
 				return nil
 			}
@@ -1446,7 +1495,7 @@ Key-free evidence capture:
 			if err := validateMCPDeferSurface(deferred.SurfaceMCPStdio, cfg); err != nil {
 				return err
 			}
-			ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+			ctx, cancel := signal.NotifyContext(heartbeatCtx, syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
 
 			stopDeferAPI, deferAPIErr := startDeferredOperatorAPIOrReport(ctx, cfg, deferManager, auditLogger, cmd.ErrOrStderr(), sentryClient)
@@ -1561,7 +1610,13 @@ Key-free evidence capture:
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: proxying MCP server %v (response=%s, trust=%s, server=%s, input=%s, tools=%s, policy=%s)\n",
 				serverCmd, respAction, respTrust, respServer, inputCfg.Action, toolAction, policyAction)
 			if err := mcp.RunProxy(ctx, cmd.InOrStdin(), cmd.OutOrStdout(), logW, serverCmd, proxyOpts, extraEnv...); err != nil {
+				if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
+					return heartbeatErr
+				}
 				return handleProxyError(err, logW, sentryClient)
+			}
+			if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
+				return heartbeatErr
 			}
 			return nil
 		},

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -987,6 +987,13 @@ Key-free evidence capture:
 						"            Receipt emission is DISABLED until resolved. Inspect the evidence\n"+
 						"            directory and flight_recorder.signing_key_path.\n", initErr)
 				} else if len(recPrivKey) > 0 {
+					if openErr := emitStartupSessionOpen(receiptEmitter); openErr != nil {
+						if cfg.FlightRecorder.RequireReceipts {
+							return fmt.Errorf("flight_recorder.require_receipts is enabled but session_open receipt could not be emitted: %w", openErr)
+						}
+						cmd.PrintErrf("  Receipts: ERROR - session_open could not be emitted: %v\n"+
+							"            Receipt emission for this run is UNVERIFIED until resolved.\n", openErr)
+					}
 					cmd.PrintErrf("  Receipts: enabled (action receipts signed)\n")
 					v2ReceiptEmitter = proxydecision.NewEmitter(proxydecision.EmitterConfig{
 						Recorder:  rec,

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1022,6 +1022,18 @@ Key-free evidence capture:
 			if cfg.FlightRecorder.RequireReceipts && !receiptEmitterReady(receiptEmitter) {
 				return fmt.Errorf("flight_recorder.require_receipts is enabled but no healthy signed receipt emitter is active: set flight_recorder.enabled, flight_recorder.dir, and flight_recorder.signing_key_path (run 'pipelock init'), fix any receipt-chain resume error, or disable require_receipts")
 			}
+			// Standalone MCP does not have the proxy server's drain-then-seal
+			// WaitGroup. Tie heartbeat to the command lifetime instead: the
+			// deferred stop cancels and joins heartbeats before writing
+			// session_close + transcript_root, so no heartbeat appends after
+			// the close even though each transport has its own run loop.
+			stopReceiptLifecycle := startStandaloneReceiptLifecycle(
+				cmd.Context(),
+				cfg.FlightRecorder.HeartbeatIntervalDuration(),
+				receiptEmitter,
+				cmd.ErrOrStderr(),
+			)
+			defer stopReceiptLifecycle()
 			sc.SetDLPWarnHook(func(ctx context.Context, patternName, severity string) {
 				emitDLPWarn(auditLogger, nil, receiptEmitter, ctx, patternName, severity)
 			})

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -591,16 +591,29 @@ func TestMcpProxyCmd_EmitsSignedReceipts_StdioSubprocess(t *testing.T) {
 	if len(receipts) == 0 {
 		t.Fatalf("expected at least one action receipt in %s", evidenceDir)
 	}
+	if receipts[0].ActionRecord.SessionControl == nil ||
+		receipts[0].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
+		t.Fatalf("first receipt session_control = %+v, want session_open before MCP stdio egress", receipts[0].ActionRecord.SessionControl)
+	}
 
 	var blockFound bool
-	for _, rcpt := range receipts {
+	for i, rcpt := range receipts {
 		if err := receipt.VerifyWithKey(rcpt, pubHex); err != nil {
 			t.Fatalf("VerifyWithKey(receipt): %v", err)
+		}
+		if rcpt.ActionRecord.SessionControl != nil {
+			if rcpt.ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
+				t.Fatalf("session control kind = %q, want session_open", rcpt.ActionRecord.SessionControl.Kind)
+			}
+			continue
 		}
 		if rcpt.ActionRecord.Transport != "mcp_stdio" {
 			t.Fatalf("transport = %q, want mcp_stdio", rcpt.ActionRecord.Transport)
 		}
 		if rcpt.ActionRecord.Verdict == config.ActionBlock {
+			if i == 0 {
+				t.Fatal("block receipt appeared before session_open")
+			}
 			blockFound = true
 		}
 	}
@@ -727,16 +740,29 @@ func TestMcpProxyCmd_EmitsSignedReceipts_HTTPUpstream(t *testing.T) {
 	if len(receipts) == 0 {
 		t.Fatalf("expected at least one action receipt in %s", evidenceDir)
 	}
+	if receipts[0].ActionRecord.SessionControl == nil ||
+		receipts[0].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
+		t.Fatalf("first receipt session_control = %+v, want session_open before MCP HTTP egress", receipts[0].ActionRecord.SessionControl)
+	}
 
 	var blockFound bool
-	for _, rcpt := range receipts {
+	for i, rcpt := range receipts {
 		if err := receipt.VerifyWithKey(rcpt, pubHex); err != nil {
 			t.Fatalf("VerifyWithKey(receipt): %v", err)
+		}
+		if rcpt.ActionRecord.SessionControl != nil {
+			if rcpt.ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
+				t.Fatalf("session control kind = %q, want session_open", rcpt.ActionRecord.SessionControl.Kind)
+			}
+			continue
 		}
 		if rcpt.ActionRecord.Transport != "mcp_http_upstream" {
 			t.Fatalf("transport = %q, want mcp_http_upstream", rcpt.ActionRecord.Transport)
 		}
 		if rcpt.ActionRecord.Verdict == config.ActionBlock {
+			if i == 0 {
+				t.Fatal("block receipt appeared before session_open")
+			}
 			blockFound = true
 		}
 	}

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -602,9 +602,6 @@ func TestMcpProxyCmd_EmitsSignedReceipts_StdioSubprocess(t *testing.T) {
 			t.Fatalf("VerifyWithKey(receipt): %v", err)
 		}
 		if rcpt.ActionRecord.SessionControl != nil {
-			if rcpt.ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
-				t.Fatalf("session control kind = %q, want session_open", rcpt.ActionRecord.SessionControl.Kind)
-			}
 			continue
 		}
 		if rcpt.ActionRecord.Transport != "mcp_stdio" {
@@ -751,9 +748,6 @@ func TestMcpProxyCmd_EmitsSignedReceipts_HTTPUpstream(t *testing.T) {
 			t.Fatalf("VerifyWithKey(receipt): %v", err)
 		}
 		if rcpt.ActionRecord.SessionControl != nil {
-			if rcpt.ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
-				t.Fatalf("session control kind = %q, want session_open", rcpt.ActionRecord.SessionControl.Kind)
-			}
 			continue
 		}
 		if rcpt.ActionRecord.Transport != "mcp_http_upstream" {

--- a/internal/cli/runtime/receipt_heartbeat.go
+++ b/internal/cli/runtime/receipt_heartbeat.go
@@ -24,6 +24,8 @@ func startReceiptHeartbeat(
 	interval time.Duration,
 	emitterFn receiptHeartbeatEmitter,
 	logW io.Writer,
+	requireReceipts bool,
+	onRequiredFailure func(error),
 ) {
 	if wg == nil || emitterFn == nil {
 		return
@@ -47,6 +49,13 @@ func startReceiptHeartbeat(
 					if logW != nil {
 						_, _ = fmt.Fprintf(logW, "pipelock: receipt heartbeat emit failed: %v\n", err)
 					}
+					if requireReceipts {
+						e.MarkUnhealthy(err)
+						if onRequiredFailure != nil {
+							onRequiredFailure(err)
+						}
+						return
+					}
 				}
 			case <-ctx.Done():
 				return
@@ -60,13 +69,15 @@ func startStandaloneReceiptLifecycle(
 	interval time.Duration,
 	e *receipt.Emitter,
 	logW io.Writer,
+	requireReceipts bool,
+	onRequiredFailure func(error),
 ) func() {
 	if !receiptEmitterReady(e) {
 		return func() {}
 	}
 	ctx, cancel := context.WithCancel(parent)
 	var wg sync.WaitGroup
-	startReceiptHeartbeat(ctx, &wg, interval, func() *receipt.Emitter { return e }, logW)
+	startReceiptHeartbeat(ctx, &wg, interval, func() *receipt.Emitter { return e }, logW, requireReceipts, onRequiredFailure)
 	return func() {
 		cancel()
 		wg.Wait()

--- a/internal/cli/runtime/receipt_heartbeat.go
+++ b/internal/cli/runtime/receipt_heartbeat.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+const sessionCloseReasonGracefulShutdown = "graceful_shutdown"
+
+type receiptHeartbeatEmitter func() *receipt.Emitter
+
+func startReceiptHeartbeat(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	interval time.Duration,
+	emitterFn receiptHeartbeatEmitter,
+	logW io.Writer,
+) {
+	if wg == nil || emitterFn == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				e := emitterFn()
+				if e == nil {
+					continue
+				}
+				if err := e.EmitHeartbeat(); err != nil && !errors.Is(err, receipt.ErrChainSealed) {
+					if logW != nil {
+						_, _ = fmt.Fprintf(logW, "pipelock: receipt heartbeat emit failed: %v\n", err)
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func startStandaloneReceiptLifecycle(
+	parent context.Context,
+	interval time.Duration,
+	e *receipt.Emitter,
+	logW io.Writer,
+) func() {
+	if !receiptEmitterReady(e) {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(parent)
+	var wg sync.WaitGroup
+	startReceiptHeartbeat(ctx, &wg, interval, func() *receipt.Emitter { return e }, logW)
+	return func() {
+		cancel()
+		wg.Wait()
+		if err := emitSessionCloseAndTranscriptRoot(e, transcriptRootSessionID, sessionCloseReasonGracefulShutdown); err != nil && logW != nil {
+			_, _ = fmt.Fprintf(logW, "pipelock: receipt shutdown seal failed: %v\n", err)
+		}
+	}
+}
+
+func emitSessionCloseAndTranscriptRoot(e *receipt.Emitter, sessionID, closeReason string) error {
+	if e == nil {
+		return nil
+	}
+	if err := e.EmitSessionClose(closeReason); err != nil && !errors.Is(err, receipt.ErrChainSealed) {
+		return err
+	}
+	return e.EmitTranscriptRoot(sessionID)
+}

--- a/internal/cli/runtime/receipt_heartbeat_test.go
+++ b/internal/cli/runtime/receipt_heartbeat_test.go
@@ -19,6 +19,28 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
+type heartbeatFailureLog struct {
+	mu      sync.Mutex
+	entries []string
+	seen    chan string
+}
+
+func newHeartbeatFailureLog() *heartbeatFailureLog {
+	return &heartbeatFailureLog{seen: make(chan string, 4)}
+}
+
+func (l *heartbeatFailureLog) Write(p []byte) (int, error) {
+	msg := string(p)
+	l.mu.Lock()
+	l.entries = append(l.entries, msg)
+	l.mu.Unlock()
+	select {
+	case l.seen <- msg:
+	default:
+	}
+	return len(p), nil
+}
+
 func TestReceiptHeartbeatTickerStopsBeforeSeal(t *testing.T) {
 	dir := t.TempDir()
 	pub, priv, err := signing.GenerateKeyPair()
@@ -142,6 +164,59 @@ func TestRequiredReceiptHeartbeatFailureMarksEmitterUnhealthy(t *testing.T) {
 	}
 }
 
+func TestOptionalReceiptHeartbeatFailureKeepsEmitterHealthy(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+
+	e := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder: rec,
+		PrivKey:  priv,
+	})
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	log := newHeartbeatFailureLog()
+	requiredFailure := make(chan error, 1)
+	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return e }, log, false, func(err error) {
+		requiredFailure <- err
+	})
+	defer wg.Wait()
+	defer cancel()
+
+	first := waitForHeartbeatFailureLog(t, log.seen)
+	second := waitForHeartbeatFailureLog(t, log.seen)
+	cancel()
+
+	if !strings.Contains(first, "receipt heartbeat emit failed") || !strings.Contains(second, "receipt heartbeat emit failed") {
+		t.Fatalf("heartbeat logs = %q, %q; want repeated failure logs", first, second)
+	}
+	if err := e.HealthError(); err != nil {
+		t.Fatalf("HealthError() = %v, want nil for optional heartbeat failure", err)
+	}
+	select {
+	case err := <-requiredFailure:
+		t.Fatalf("required failure callback called for optional heartbeat failure: %v", err)
+	default:
+	}
+}
+
 func waitForHeartbeatReceipt(t *testing.T, seen <-chan receipt.Receipt) {
 	t.Helper()
 	for {
@@ -154,6 +229,17 @@ func waitForHeartbeatReceipt(t *testing.T, seen <-chan receipt.Receipt) {
 		case <-time.After(5 * time.Second):
 			t.Fatal("timed out waiting for heartbeat receipt")
 		}
+	}
+}
+
+func waitForHeartbeatFailureLog(t *testing.T, seen <-chan string) string {
+	t.Helper()
+	select {
+	case msg := <-seen:
+		return msg
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for heartbeat failure log")
+		return ""
 	}
 }
 

--- a/internal/cli/runtime/receipt_heartbeat_test.go
+++ b/internal/cli/runtime/receipt_heartbeat_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestReceiptHeartbeatTickerStopsBeforeSeal(t *testing.T) {
+	dir := t.TempDir()
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+
+	seen := make(chan receipt.Receipt, 8)
+	e := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder: rec,
+		PrivKey:  priv,
+		OnReceipt: func(rcpt *receipt.Receipt) {
+			select {
+			case seen <- *rcpt:
+			default:
+			}
+		},
+	})
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	var log bytes.Buffer
+	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return e }, &log)
+	waitForHeartbeatReceipt(t, seen)
+	cancel()
+	wg.Wait()
+
+	if err := emitSessionCloseAndTranscriptRoot(e, transcriptRootSessionID, sessionCloseReasonGracefulShutdown); err != nil {
+		t.Fatalf("emitSessionCloseAndTranscriptRoot: %v", err)
+	}
+	if log.Len() != 0 {
+		t.Fatalf("heartbeat logged unexpected error: %s", log.String())
+	}
+
+	receipts := readRuntimeReceipts(t, dir, hex.EncodeToString(pub))
+	if len(receipts) < 3 {
+		t.Fatalf("receipts = %d, want open heartbeat close", len(receipts))
+	}
+	last := receipts[len(receipts)-1].ActionRecord.SessionControl
+	if last == nil || last.Close == nil {
+		t.Fatalf("last receipt before root is not session_close: %#v", last)
+	}
+	root := readRuntimeTranscriptRoot(t, dir)
+	closeHash, err := receipt.ReceiptHash(receipts[len(receipts)-1])
+	if err != nil {
+		t.Fatalf("ReceiptHash(close): %v", err)
+	}
+	if root.RootHash != closeHash {
+		t.Fatalf("root hash = %s, want close hash %s", root.RootHash, closeHash)
+	}
+}
+
+func waitForHeartbeatReceipt(t *testing.T, seen <-chan receipt.Receipt) {
+	t.Helper()
+	for {
+		select {
+		case r := <-seen:
+			sc := r.ActionRecord.SessionControl
+			if sc != nil && sc.Heartbeat != nil {
+				return
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for heartbeat receipt")
+		}
+	}
+}
+
+func readRuntimeReceipts(t *testing.T, dir, expectedKey string) []receipt.Receipt {
+	t.Helper()
+	entries, err := recorder.ReadEntries(filepath.Join(dir, "evidence-proxy-0.jsonl"))
+	if err != nil {
+		t.Fatalf("ReadEntries: %v", err)
+	}
+	var out []receipt.Receipt
+	for _, entry := range entries {
+		if entry.Type != "action_receipt" {
+			continue
+		}
+		raw, err := json.Marshal(entry.Detail)
+		if err != nil {
+			t.Fatalf("json.Marshal(receipt): %v", err)
+		}
+		r, err := receipt.Unmarshal(raw)
+		if err != nil {
+			t.Fatalf("receipt.Unmarshal: %v", err)
+		}
+		if err := receipt.VerifyWithKey(r, expectedKey); err != nil {
+			t.Fatalf("VerifyWithKey: %v", err)
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func readRuntimeTranscriptRoot(t *testing.T, dir string) receipt.TranscriptRoot {
+	t.Helper()
+	entries, err := recorder.ReadEntries(filepath.Join(dir, "evidence-proxy-0.jsonl"))
+	if err != nil {
+		t.Fatalf("ReadEntries: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Type != "transcript_root" {
+			continue
+		}
+		raw, err := json.Marshal(entry.Detail)
+		if err != nil {
+			t.Fatalf("json.Marshal(root): %v", err)
+		}
+		var root receipt.TranscriptRoot
+		if err := json.Unmarshal(raw, &root); err != nil {
+			t.Fatalf("json.Unmarshal(root): %v", err)
+		}
+		return root
+	}
+	t.Fatal("transcript root not found")
+	return receipt.TranscriptRoot{}
+}

--- a/internal/cli/runtime/receipt_heartbeat_test.go
+++ b/internal/cli/runtime/receipt_heartbeat_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -52,7 +53,7 @@ func TestReceiptHeartbeatTickerStopsBeforeSeal(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	var log bytes.Buffer
-	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return e }, &log)
+	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return e }, &log, false, nil)
 	waitForHeartbeatReceipt(t, seen)
 	cancel()
 	wg.Wait()
@@ -79,6 +80,65 @@ func TestReceiptHeartbeatTickerStopsBeforeSeal(t *testing.T) {
 	}
 	if root.RootHash != closeHash {
 		t.Fatalf("root hash = %s, want close hash %s", root.RootHash, closeHash)
+	}
+}
+
+func TestRequiredReceiptHeartbeatFailureMarksEmitterUnhealthy(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+
+	e := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder: rec,
+		PrivKey:  priv,
+	})
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	var log bytes.Buffer
+	requiredFailure := make(chan error, 1)
+	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return e }, &log, true, func(err error) {
+		requiredFailure <- err
+		cancel()
+	})
+	defer wg.Wait()
+
+	select {
+	case err := <-requiredFailure:
+		if err == nil {
+			t.Fatal("required heartbeat failure callback received nil error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for required heartbeat failure")
+	}
+	if e.HealthError() == nil {
+		t.Fatal("emitter health error was not marked after required heartbeat failure")
+	}
+	err = e.Emit(receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   "allow",
+		Transport: "fetch",
+		Target:    "https://api.vendor.example/after-heartbeat-failure",
+	})
+	if err == nil || !strings.Contains(err.Error(), "receipt emitter unhealthy") {
+		t.Fatalf("Emit after required heartbeat failure error = %v, want unhealthy", err)
 	}
 }
 

--- a/internal/cli/runtime/receipt_session_open.go
+++ b/internal/cli/runtime/receipt_session_open.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import "github.com/luckyPipewrench/pipelock/internal/receipt"
+
+var beforeStartupSessionOpenForTest func(*receipt.Emitter) error
+
+func emitStartupSessionOpen(e *receipt.Emitter) error {
+	if beforeStartupSessionOpenForTest != nil {
+		if err := beforeStartupSessionOpenForTest(e); err != nil {
+			return err
+		}
+	}
+	return e.EmitSessionOpen()
+}

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -494,10 +494,6 @@ func NewServer(opts ServerOpts) (*Server, error) {
 			Metrics:    m,
 		})
 		if s.receiptEmitter != nil {
-			proxyOpts = append(proxyOpts, proxy.WithReceiptEmitter(s.receiptEmitter))
-			if cfg.FlightRecorder.SigningKeyPath != "" {
-				proxyOpts = append(proxyOpts, proxy.WithReceiptKeyPath(cfg.FlightRecorder.SigningKeyPath))
-			}
 			// Loud, one-time startup signal when the chain could not be
 			// resumed. Without this an init failure was only an error log on
 			// each Emit (to a formerly root-only file), silent to operators.
@@ -512,6 +508,20 @@ func NewServer(opts ServerOpts) (*Server, error) {
 						"            directory and the configured signing_key_path.\n",
 					initErr)
 			} else {
+				if openErr := emitStartupSessionOpen(s.receiptEmitter); openErr != nil {
+					if cfg.FlightRecorder.RequireReceipts {
+						s.cleanup()
+						return nil, fmt.Errorf("flight_recorder.require_receipts is enabled but session_open receipt could not be emitted: %w", openErr)
+					}
+					_, _ = fmt.Fprintf(opts.Stderr,
+						"  Receipts: ERROR - session_open could not be emitted: %v\n"+
+							"            Receipt emission for this run is UNVERIFIED until resolved.\n",
+						openErr)
+				}
+				proxyOpts = append(proxyOpts, proxy.WithReceiptEmitter(s.receiptEmitter))
+				if cfg.FlightRecorder.SigningKeyPath != "" {
+					proxyOpts = append(proxyOpts, proxy.WithReceiptKeyPath(cfg.FlightRecorder.SigningKeyPath))
+				}
 				_, _ = fmt.Fprintf(opts.Stderr, "  Receipts: enabled (action receipts signed)\n")
 			}
 

--- a/internal/cli/runtime/server_emitters.go
+++ b/internal/cli/runtime/server_emitters.go
@@ -51,11 +51,12 @@ func (s *Server) liveReceiptEmitterReady() bool {
 	return receiptEmitterReady(s.liveReceiptEmitter())
 }
 
-// sealTranscriptRoot writes the transcript root for the live receipt chain at
-// graceful shutdown, anchoring the receipts emitted this run so a chain truncated
-// by a CLEAN exit becomes detectable: verify can see the sealed root instead of
-// reporting a silently-shortened chain as VALID. EmitTranscriptRoot has no other
-// production caller, so without this the completeness anchor never fires.
+// sealTranscriptRoot writes the signed session_close and compat transcript root
+// for the live receipt chain at graceful shutdown, anchoring the receipts
+// emitted this run so a chain truncated by a CLEAN exit becomes detectable:
+// verify can see the sealed root instead of reporting a silently-shortened
+// chain as VALID. EmitTranscriptRoot has no other production caller, so without
+// this the completeness anchor never fires.
 //
 // Drain-then-seal contract: call this ONLY after every receipt-emitting listener
 // has drained. Once the root is written the chain is sealed and a racing Emit
@@ -73,7 +74,7 @@ func (s *Server) sealTranscriptRoot() {
 	if e == nil {
 		return
 	}
-	if err := e.EmitTranscriptRoot(transcriptRootSessionID); err != nil {
+	if err := emitSessionCloseAndTranscriptRoot(e, transcriptRootSessionID, sessionCloseReasonGracefulShutdown); err != nil {
 		if s.logger != nil {
 			s.logger.LogError(audit.NewResourceLogContext("SHUTDOWN", "transcript_root"), err)
 		}

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -328,10 +328,29 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	cfg := s.currentConfig()
+	var requiredHeartbeatErrMu sync.Mutex
+	var requiredHeartbeatErr error
+	setRequiredHeartbeatErr := func(err error) {
+		if err == nil {
+			return
+		}
+		requiredHeartbeatErrMu.Lock()
+		if requiredHeartbeatErr == nil {
+			requiredHeartbeatErr = err
+		}
+		requiredHeartbeatErrMu.Unlock()
+		cancel()
+	}
+	getRequiredHeartbeatErr := func() error {
+		requiredHeartbeatErrMu.Lock()
+		defer requiredHeartbeatErrMu.Unlock()
+		if requiredHeartbeatErr == nil {
+			return nil
+		}
+		return fmt.Errorf("flight_recorder.require_receipts is enabled but receipt heartbeat emission failed: %w", requiredHeartbeatErr)
+	}
 	if receiptEmitterReady(s.liveReceiptEmitter()) {
-		startReceiptHeartbeat(ctx, &lifecycleWG, cfg.FlightRecorder.HeartbeatIntervalDuration(), s.liveReceiptEmitter, s.opts.Stderr, cfg.FlightRecorder.RequireReceipts, func(error) {
-			cancel()
-		})
+		startReceiptHeartbeat(ctx, &lifecycleWG, cfg.FlightRecorder.HeartbeatIntervalDuration(), s.liveReceiptEmitter, s.opts.Stderr, cfg.FlightRecorder.RequireReceipts, setRequiredHeartbeatErr)
 	}
 	stopFileSentry, fsErr := s.startFileSentry(ctx, cfg, cancel)
 	if fsErr != nil {
@@ -1060,6 +1079,9 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Start the fetch proxy (blocks until context cancelled or error).
 	if err := s.proxy.Start(ctx); err != nil {
+		if heartbeatErr := getRequiredHeartbeatErr(); heartbeatErr != nil {
+			return heartbeatErr
+		}
 		err = wrapBindError("fetch_proxy.listen", cfg.FetchProxy.Listen, err)
 		if s.sentry != nil {
 			s.sentry.CaptureError(err)
@@ -1101,6 +1123,10 @@ func (s *Server) Start(ctx context.Context) error {
 		if rpErr := <-reverseProxyErr; rpErr != nil {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: reverse proxy listener error: %v\n", rpErr)
 		}
+	}
+
+	if heartbeatErr := getRequiredHeartbeatErr(); heartbeatErr != nil {
+		return heartbeatErr
 	}
 
 	s.logger.LogShutdown("signal received")

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -329,7 +329,9 @@ func (s *Server) Start(ctx context.Context) error {
 
 	cfg := s.currentConfig()
 	if receiptEmitterReady(s.liveReceiptEmitter()) {
-		startReceiptHeartbeat(ctx, &lifecycleWG, cfg.FlightRecorder.HeartbeatIntervalDuration(), s.liveReceiptEmitter, s.opts.Stderr)
+		startReceiptHeartbeat(ctx, &lifecycleWG, cfg.FlightRecorder.HeartbeatIntervalDuration(), s.liveReceiptEmitter, s.opts.Stderr, cfg.FlightRecorder.RequireReceipts, func(error) {
+			cancel()
+		})
 	}
 	stopFileSentry, fsErr := s.startFileSentry(ctx, cfg, cancel)
 	if fsErr != nil {

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -328,6 +328,9 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	cfg := s.currentConfig()
+	if receiptEmitterReady(s.liveReceiptEmitter()) {
+		startReceiptHeartbeat(ctx, &lifecycleWG, cfg.FlightRecorder.HeartbeatIntervalDuration(), s.liveReceiptEmitter, s.opts.Stderr)
+	}
 	stopFileSentry, fsErr := s.startFileSentry(ctx, cfg, cancel)
 	if fsErr != nil {
 		return fsErr

--- a/internal/cli/runtime/server_require_receipts_test.go
+++ b/internal/cli/runtime/server_require_receipts_test.go
@@ -4,6 +4,7 @@
 package runtime
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/json"
 	"errors"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
@@ -172,6 +174,60 @@ func TestNewServer_RequireReceiptsSessionOpenEmitFailureFailsClosed(t *testing.T
 		!strings.Contains(err.Error(), "session_open") ||
 		!errors.Is(err, forcedErr) {
 		t.Fatalf("error = %q, want require_receipts session_open context wrapping forced error", err)
+	}
+}
+
+func TestServer_StartReturnsRequiredReceiptHeartbeatFailure(t *testing.T) {
+	recorderDir := t.TempDir()
+	keyPath := filepath.Join(t.TempDir(), "flight-recorder.key")
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate signing key: %v", err)
+	}
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("save signing key: %v", err)
+	}
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"flight_recorder:",
+		"  enabled: true",
+		"  require_receipts: true",
+		"  dir: " + strconv.Quote(recorderDir),
+		"  signing_key_path: " + strconv.Quote(keyPath),
+		"  completeness:",
+		"    heartbeat_interval: 1ms",
+		"",
+	}, "\n"))
+
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+	if err := s.recorder.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Start(ctx)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("Start returned nil, want required heartbeat failure")
+		}
+		if !strings.Contains(err.Error(), "require_receipts") ||
+			!strings.Contains(err.Error(), "receipt heartbeat emission failed") ||
+			!strings.Contains(err.Error(), "recorder is closed") {
+			t.Fatalf("Start error = %q, want required heartbeat recorder-closed failure", err)
+		}
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("timed out waiting for Start to return required heartbeat failure")
 	}
 }
 

--- a/internal/cli/runtime/server_require_receipts_test.go
+++ b/internal/cli/runtime/server_require_receipts_test.go
@@ -6,6 +6,7 @@ package runtime
 import (
 	"crypto/ed25519"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -131,6 +132,46 @@ func TestNewServer_RequireReceiptsWithBrickedEmitterFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "require_receipts") || !strings.Contains(err.Error(), "resume") {
 		t.Fatalf("error = %q, want require_receipts and resume context", err)
+	}
+}
+
+func TestNewServer_RequireReceiptsSessionOpenEmitFailureFailsClosed(t *testing.T) {
+	recorderDir := t.TempDir()
+	keyPath := filepath.Join(t.TempDir(), "flight-recorder.key")
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate signing key: %v", err)
+	}
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("save signing key: %v", err)
+	}
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"flight_recorder:",
+		"  enabled: true",
+		"  require_receipts: true",
+		"  dir: " + strconv.Quote(recorderDir),
+		"  signing_key_path: " + strconv.Quote(keyPath),
+		"",
+	}, "\n"))
+
+	forcedErr := errors.New("forced session_open emit failure")
+	beforeStartupSessionOpenForTest = func(*receipt.Emitter) error {
+		return forcedErr
+	}
+	t.Cleanup(func() {
+		beforeStartupSessionOpenForTest = nil
+	})
+
+	s, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}})
+	if err == nil {
+		s.cleanup()
+		t.Fatal("expected NewServer to fail when required session_open emission fails")
+	}
+	if !strings.Contains(err.Error(), "require_receipts") ||
+		!strings.Contains(err.Error(), "session_open") ||
+		!errors.Is(err, forcedErr) {
+		t.Fatalf("error = %q, want require_receipts session_open context wrapping forced error", err)
 	}
 }
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1307,6 +1307,26 @@ func TestServer_Reload_RequireReceiptsAllowsRestartOnlyWarning(t *testing.T) {
 	}
 }
 
+func TestServer_Reload_IgnoresFlightRecorderHeartbeatIntervalChange(t *testing.T) {
+	s, buf := newTestServer(t, nil)
+	oldLive := s.proxy.CurrentConfig()
+	oldLive.FlightRecorder.Completeness.HeartbeatInterval = "60s"
+
+	updated := oldLive.Clone()
+	updated.FlightRecorder.Completeness.HeartbeatInterval = "5s"
+
+	if err := s.Reload(updated); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	live := s.proxy.CurrentConfig()
+	if got := live.FlightRecorder.Completeness.HeartbeatInterval; got != "60s" {
+		t.Fatalf("heartbeat_interval = %q, want startup value 60s", got)
+	}
+	if !buf.contains("flight_recorder settings changed") {
+		t.Fatalf("stderr missing flight_recorder restart-only warning:\n%s", buf.String())
+	}
+}
+
 func TestServer_Reload_MCPBinaryRequireSignatureRejectsDowngrade(t *testing.T) {
 	s, buf := newTestServer(t, nil)
 	oldLive := s.proxy.CurrentConfig()

--- a/internal/cli/signing/receipt_rotation_test.go
+++ b/internal/cli/signing/receipt_rotation_test.go
@@ -57,6 +57,9 @@ func emitInto(t *testing.T, dir string, priv ed25519.PrivateKey, count, startIdx
 	if err := emitter.InitError(); err != nil {
 		t.Fatalf("emitter init error: %v", err)
 	}
+	if err := emitter.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
 	for i := range count {
 		if err := emitter.Emit(receipt.EmitOpts{
 			ActionID:  receipt.NewActionID(),
@@ -161,8 +164,8 @@ func TestTranscriptRootCmd_RotatedChainNeedsBothKeys(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("transcript root over rotated chain must succeed with both keys: %v\n%s", err, buf.String())
 	}
-	if !strings.Contains(buf.String(), "Receipt count: 5") {
-		t.Errorf("expected 5 receipts in transcript root, got: %s", buf.String())
+	if !strings.Contains(buf.String(), "Receipt count: 7") {
+		t.Errorf("expected 7 receipts in transcript root, got: %s", buf.String())
 	}
 
 	// Only key A: must fail (rotation key untrusted).

--- a/internal/cli/signing/receipt_test.go
+++ b/internal/cli/signing/receipt_test.go
@@ -560,6 +560,9 @@ func buildChainJSONL(t *testing.T, count int) (string, ed25519.PublicKey) {
 		Principal:  "test",
 		Actor:      "test",
 	})
+	if err := emitter.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
 
 	for i := range count {
 		err := emitter.Emit(receipt.EmitOpts{
@@ -617,6 +620,9 @@ func buildDeferredCleanChainJSONL(t *testing.T) (string, ed25519.PublicKey) {
 		Principal:  "operator",
 		Actor:      "agent",
 	})
+	if err := emitter.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
 
 	deferID := receipt.NewActionID()
 	if err := emitter.Emit(receipt.EmitOpts{
@@ -699,6 +705,9 @@ func buildRestartChainDir(t *testing.T, counts ...int) (string, ed25519.PublicKe
 			Principal:  "test",
 			Actor:      "test",
 		})
+		if err := emitter.EmitSessionOpen(); err != nil {
+			t.Fatalf("EmitSessionOpen[%d]: %v", i, err)
+		}
 
 		for j := range count {
 			err := emitter.Emit(receipt.EmitOpts{
@@ -740,8 +749,8 @@ func TestVerifyReceiptCmd_ChainValid(t *testing.T) {
 	if !strings.Contains(output, unpinnedReceiptBanner) {
 		t.Errorf("expected unpinned banner, got: %s", output)
 	}
-	if !strings.Contains(output, "Receipts:  5") {
-		t.Errorf("expected 5 receipts, got: %s", output)
+	if !strings.Contains(output, "Receipts:  6") {
+		t.Errorf("expected 6 receipts, got: %s", output)
 	}
 }
 
@@ -762,8 +771,8 @@ func TestVerifyReceiptCmd_ChainAllowUnpinned(t *testing.T) {
 	if !strings.Contains(output, "CHAIN UNPINNED") {
 		t.Errorf("expected CHAIN UNPINNED, got: %s", output)
 	}
-	if !strings.Contains(output, "Receipts:  5") {
-		t.Errorf("expected 5 receipts, got: %s", output)
+	if !strings.Contains(output, "Receipts:  6") {
+		t.Errorf("expected 6 receipts, got: %s", output)
 	}
 }
 
@@ -809,14 +818,14 @@ func TestVerifyReceiptCmd_CleanReportJSONLWithDeferPair(t *testing.T) {
 	if err := json.Unmarshal(raw, &report); err != nil {
 		t.Fatalf("Unmarshal(report): %v", err)
 	}
-	if report.Chain.ReceiptCount != 3 || report.Chain.FinalSeq != 2 {
-		t.Fatalf("chain summary = %+v, want 3 receipts seq 2", report.Chain)
+	if report.Chain.ReceiptCount != 4 || report.Chain.FinalSeq != 3 {
+		t.Fatalf("chain summary = %+v, want 4 receipts seq 3", report.Chain)
 	}
-	if len(report.Actions) != 3 {
-		t.Fatalf("actions = %d, want 3", len(report.Actions))
+	if len(report.Actions) != 4 {
+		t.Fatalf("actions = %d, want 4", len(report.Actions))
 	}
-	if report.Actions[0].DecisionPhase != receipt.DecisionPhaseDefer || report.Actions[1].DecisionPhase != receipt.DecisionPhaseResolution {
-		t.Fatalf("defer pair phases = (%q,%q)", report.Actions[0].DecisionPhase, report.Actions[1].DecisionPhase)
+	if report.Actions[1].DecisionPhase != receipt.DecisionPhaseDefer || report.Actions[2].DecisionPhase != receipt.DecisionPhaseResolution {
+		t.Fatalf("defer pair phases = (%q,%q)", report.Actions[1].DecisionPhase, report.Actions[2].DecisionPhase)
 	}
 }
 
@@ -1042,8 +1051,8 @@ func TestVerifyReceiptCmd_ChainDirAcrossRestart(t *testing.T) {
 	if !strings.Contains(output, "CHAIN VALID") {
 		t.Errorf("expected CHAIN VALID, got: %s", output)
 	}
-	if !strings.Contains(output, "Receipts:  4") {
-		t.Errorf("expected 4 receipts, got: %s", output)
+	if !strings.Contains(output, "Receipts:  6") {
+		t.Errorf("expected 6 receipts, got: %s", output)
 	}
 }
 
@@ -1105,8 +1114,8 @@ func TestTranscriptRootCmd_Valid(t *testing.T) {
 	if !strings.Contains(output, "Transcript Root") {
 		t.Errorf("expected Transcript Root header, got: %s", output)
 	}
-	if !strings.Contains(output, "Receipt count: 4") {
-		t.Errorf("expected 4 receipts, got: %s", output)
+	if !strings.Contains(output, "Receipt count: 5") {
+		t.Errorf("expected 5 receipts, got: %s", output)
 	}
 	if !strings.Contains(output, "Root hash:") {
 		t.Errorf("expected root hash, got: %s", output)
@@ -1130,8 +1139,8 @@ func TestTranscriptRootCmd_ChainDirAcrossRestart(t *testing.T) {
 	if !strings.Contains(output, "Transcript Root") {
 		t.Errorf("expected Transcript Root header, got: %s", output)
 	}
-	if !strings.Contains(output, "Receipt count: 3") {
-		t.Errorf("expected 3 receipts, got: %s", output)
+	if !strings.Contains(output, "Receipt count: 5") {
+		t.Errorf("expected 5 receipts, got: %s", output)
 	}
 }
 
@@ -1195,8 +1204,8 @@ func TestVerifyChainFromFile_ValidChain(t *testing.T) {
 	if !strings.Contains(buf.String(), "CHAIN VALID") {
 		t.Errorf("expected CHAIN VALID, got: %s", buf.String())
 	}
-	if !strings.Contains(buf.String(), "Receipts:  3") {
-		t.Errorf("expected 3 receipts, got: %s", buf.String())
+	if !strings.Contains(buf.String(), "Receipts:  4") {
+		t.Errorf("expected 4 receipts, got: %s", buf.String())
 	}
 }
 
@@ -1258,8 +1267,8 @@ func TestVerifyChain_ValidReceiptsNoKey(t *testing.T) {
 	if !strings.Contains(buf.String(), "CHAIN UNPINNED") {
 		t.Errorf("expected CHAIN UNPINNED, got: %s", buf.String())
 	}
-	if !strings.Contains(buf.String(), "Receipts:  4") {
-		t.Errorf("expected 4 receipts, got: %s", buf.String())
+	if !strings.Contains(buf.String(), "Receipts:  5") {
+		t.Errorf("expected 5 receipts, got: %s", buf.String())
 	}
 
 	buf.Reset()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10646,6 +10646,9 @@ func TestLoad_FlightRecorderDefaults(t *testing.T) {
 	if cfg.FlightRecorder.MaxEntriesPerFile != 10000 {
 		t.Errorf("MaxEntriesPerFile = %d, want 10000", cfg.FlightRecorder.MaxEntriesPerFile)
 	}
+	if got := cfg.FlightRecorder.HeartbeatIntervalDuration(); got != DefaultFlightRecorderHeartbeatInterval {
+		t.Errorf("HeartbeatIntervalDuration = %s, want %s", got, DefaultFlightRecorderHeartbeatInterval)
+	}
 	if !cfg.FlightRecorder.Redact {
 		t.Error("Redact = false, want true (secrets would leak into forensic evidence)")
 	}
@@ -14009,6 +14012,39 @@ func TestValidate_FlightRecorder(t *testing.T) {
 				return c
 			},
 			wantErr: "max_entries_per_file must be non-negative",
+		},
+		{
+			name: "negative_heartbeat_interval",
+			cfg: func() *Config {
+				c := Defaults()
+				c.FlightRecorder.Enabled = true
+				c.FlightRecorder.Dir = testRecorderDir
+				c.FlightRecorder.Completeness.HeartbeatInterval = "-1s"
+				return c
+			},
+			wantErr: "heartbeat_interval must be non-negative",
+		},
+		{
+			name: "absurd_heartbeat_interval",
+			cfg: func() *Config {
+				c := Defaults()
+				c.FlightRecorder.Enabled = true
+				c.FlightRecorder.Dir = testRecorderDir
+				c.FlightRecorder.Completeness.HeartbeatInterval = "25h"
+				return c
+			},
+			wantErr: "heartbeat_interval must be <= 24h",
+		},
+		{
+			name: "malformed_heartbeat_interval",
+			cfg: func() *Config {
+				c := Defaults()
+				c.FlightRecorder.Enabled = true
+				c.FlightRecorder.Dir = testRecorderDir
+				c.FlightRecorder.Completeness.HeartbeatInterval = "soon"
+				return c
+			},
+			wantErr: "heartbeat_interval must parse as a duration",
 		},
 		{
 			name: "raw_escrow_without_key",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14022,7 +14022,18 @@ func TestValidate_FlightRecorder(t *testing.T) {
 				c.FlightRecorder.Completeness.HeartbeatInterval = "-1s"
 				return c
 			},
-			wantErr: "heartbeat_interval must be non-negative",
+			wantErr: "heartbeat_interval must be positive",
+		},
+		{
+			name: "zero_heartbeat_interval_rejected",
+			cfg: func() *Config {
+				c := Defaults()
+				c.FlightRecorder.Enabled = true
+				c.FlightRecorder.Dir = testRecorderDir
+				c.FlightRecorder.Completeness.HeartbeatInterval = "0s"
+				return c
+			},
+			wantErr: "heartbeat_interval must be positive",
 		},
 		{
 			name: "absurd_heartbeat_interval",

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -394,6 +394,9 @@ func Defaults() *Config {
 			Redact:             true,  // DLP-scrub evidence before commit
 			SignCheckpoints:    true,  // Ed25519 sign checkpoints
 			MaxEntriesPerFile:  10000, // rotate files at this count
+			Completeness: FlightRecorderCompleteness{
+				HeartbeatInterval: "60s",
+			},
 		},
 		MCPToolProvenance: MCPToolProvenance{
 			Action:      ActionWarn,

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -727,6 +727,9 @@ func (c *Config) ApplyDefaults() {
 	if c.FlightRecorder.MaxEntriesPerFile <= 0 {
 		c.FlightRecorder.MaxEntriesPerFile = 10000 // rotate files at this count
 	}
+	if c.FlightRecorder.Completeness.HeartbeatInterval == "" {
+		c.FlightRecorder.Completeness.HeartbeatInterval = "60s"
+	}
 
 	// MCP tool provenance defaults
 	if c.MCPToolProvenance.Enabled {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1416,18 +1416,37 @@ type BudgetConfig struct {
 
 // FlightRecorder configures the tamper-evident evidence recording system.
 type FlightRecorder struct {
-	Enabled            bool        `yaml:"enabled"`
-	Dir                string      `yaml:"dir"`
-	CheckpointInterval int         `yaml:"checkpoint_interval"`  // entries between signed checkpoints (default 1000)
-	RetentionDays      int         `yaml:"retention_days"`       // auto-expire after N days (0=forever)
-	Redact             bool        `yaml:"redact"`               // DLP on evidence before commit (default true)
-	SignCheckpoints    bool        `yaml:"sign_checkpoints"`     // Ed25519 sign checkpoints (default true)
-	MaxEntriesPerFile  int         `yaml:"max_entries_per_file"` // rotate files (default 10000)
-	FileMode           os.FileMode `yaml:"file_mode" json:"-"`   // evidence file permissions: 0600, 0640, or 0660 (default 0600)
-	RawEscrow          bool        `yaml:"raw_escrow"`           // encrypted raw detail sidecar (default false)
-	EscrowPublicKey    string      `yaml:"escrow_public_key"`    // X25519 public key for raw escrow encryption
-	SigningKeyPath     string      `yaml:"signing_key_path"`     // Ed25519 private key for checkpoint signing and action receipts
-	RequireReceipts    bool        `yaml:"require_receipts"`     // fail closed when a required receipt cannot be emitted (default false)
+	Enabled            bool                       `yaml:"enabled"`
+	Dir                string                     `yaml:"dir"`
+	CheckpointInterval int                        `yaml:"checkpoint_interval"`   // entries between signed checkpoints (default 1000)
+	RetentionDays      int                        `yaml:"retention_days"`        // auto-expire after N days (0=forever)
+	Redact             bool                       `yaml:"redact"`                // DLP on evidence before commit (default true)
+	SignCheckpoints    bool                       `yaml:"sign_checkpoints"`      // Ed25519 sign checkpoints (default true)
+	MaxEntriesPerFile  int                        `yaml:"max_entries_per_file"`  // rotate files (default 10000)
+	FileMode           os.FileMode                `yaml:"file_mode" json:"-"`    // evidence file permissions: 0600, 0640, or 0660 (default 0600)
+	RawEscrow          bool                       `yaml:"raw_escrow"`            // encrypted raw detail sidecar (default false)
+	EscrowPublicKey    string                     `yaml:"escrow_public_key"`     // X25519 public key for raw escrow encryption
+	SigningKeyPath     string                     `yaml:"signing_key_path"`      // Ed25519 private key for checkpoint signing and action receipts
+	RequireReceipts    bool                       `yaml:"require_receipts"`      // fail closed when a required receipt cannot be emitted (default false)
+	Completeness       FlightRecorderCompleteness `yaml:"completeness" json:"-"` // restart-only evidence completeness knobs
+}
+
+type FlightRecorderCompleteness struct {
+	HeartbeatInterval string `yaml:"heartbeat_interval"` // time.ParseDuration string, default 60s; startup-only
+}
+
+const DefaultFlightRecorderHeartbeatInterval = 60 * time.Second
+
+func (f FlightRecorder) HeartbeatIntervalDuration() time.Duration {
+	raw := strings.TrimSpace(f.Completeness.HeartbeatInterval)
+	if raw == "" {
+		return DefaultFlightRecorderHeartbeatInterval
+	}
+	interval, err := time.ParseDuration(raw)
+	if err != nil || interval <= 0 {
+		return DefaultFlightRecorderHeartbeatInterval
+	}
+	return interval
 }
 
 // MediationEnvelope configures sideband metadata on proxied requests.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2999,8 +2999,8 @@ func (c *Config) validateFlightRecorder() error {
 		if err != nil {
 			return fmt.Errorf("flight_recorder.completeness.heartbeat_interval must parse as a duration: %w", err)
 		}
-		if interval < 0 {
-			return fmt.Errorf("flight_recorder.completeness.heartbeat_interval must be non-negative")
+		if interval <= 0 {
+			return fmt.Errorf("flight_recorder.completeness.heartbeat_interval must be positive; omit the field to use the 60s default")
 		}
 		if interval > 24*time.Hour {
 			return fmt.Errorf("flight_recorder.completeness.heartbeat_interval must be <= 24h")

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2994,6 +2994,18 @@ func (c *Config) validateFlightRecorder() error {
 	if c.FlightRecorder.MaxEntriesPerFile < 0 {
 		return fmt.Errorf("flight_recorder.max_entries_per_file must be non-negative")
 	}
+	if c.FlightRecorder.Completeness.HeartbeatInterval != "" {
+		interval, err := time.ParseDuration(c.FlightRecorder.Completeness.HeartbeatInterval)
+		if err != nil {
+			return fmt.Errorf("flight_recorder.completeness.heartbeat_interval must parse as a duration: %w", err)
+		}
+		if interval < 0 {
+			return fmt.Errorf("flight_recorder.completeness.heartbeat_interval must be non-negative")
+		}
+		if interval > 24*time.Hour {
+			return fmt.Errorf("flight_recorder.completeness.heartbeat_interval must be <= 24h")
+		}
+	}
 	switch c.FlightRecorder.FileMode {
 	case 0, 0o600, 0o640, 0o660:
 	default:

--- a/internal/evidence/completeness/completeness.go
+++ b/internal/evidence/completeness/completeness.go
@@ -1,0 +1,504 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package completeness analyzes signed receipt chains for bounded lifecycle
+// evidence. Its best result is LIMITED: mediated evidence can bound what
+// Pipelock saw, but it cannot prove the agent had no other egress path.
+package completeness
+
+import "github.com/luckyPipewrench/pipelock/internal/receipt"
+
+// Status is the top-level completeness status vocabulary.
+type Status string
+
+const (
+	StatusLimited    Status = "LIMITED"
+	StatusBroken     Status = "BROKEN"
+	StatusUnverified Status = "UNVERIFIED"
+)
+
+// Reason is the structured explanation for a report or per-run status.
+type Reason string
+
+const (
+	ReasonBoundedClosed    Reason = "bounded_closed"
+	ReasonAbnormalEnd      Reason = "abnormal_end"
+	ReasonOpenAction       Reason = "open_action"
+	ReasonHeartbeatGap     Reason = "heartbeat_gap"
+	ReasonNoOpen           Reason = "no_open"
+	ReasonNoLifecycle      Reason = "no_lifecycle"
+	ReasonRecorderDisabled Reason = "recorder_disabled"
+	ReasonNoReceipts       Reason = "no_receipts"
+	ReasonChainBroken      Reason = "chain_broken"
+)
+
+// Report is the completeness analysis result for one extracted chain.
+type Report struct {
+	Path               string      `json:"path,omitempty"`
+	Status             Status      `json:"status"`
+	Reason             Reason      `json:"reason"`
+	ReceiptCount       uint64      `json:"receipt_count"`
+	FinalSeq           uint64      `json:"final_seq,omitempty"`
+	RootHash           string      `json:"root_hash,omitempty"`
+	SignaturesVerified bool        `json:"signatures_verified,omitempty"`
+	Unpinned           bool        `json:"unpinned,omitempty"`
+	Error              string      `json:"error,omitempty"`
+	BrokenAtSeq        uint64      `json:"broken_at_seq,omitempty"`
+	BrokenAtIndex      int         `json:"broken_at_index,omitempty"`
+	Runs               []RunReport `json:"runs,omitempty"`
+}
+
+// RunReport describes completeness evidence for one run_nonce.
+type RunReport struct {
+	RunNonce              string              `json:"run_nonce"`
+	Status                Status              `json:"status"`
+	Reason                Reason              `json:"reason"`
+	Intents               int                 `json:"intents"`
+	Outcomes              int                 `json:"outcomes"`
+	MatchedPairs          int                 `json:"matched_pairs"`
+	UnmatchedIntents      int                 `json:"unmatched_intents"`
+	Heartbeats            int                 `json:"heartbeats"`
+	Closed                bool                `json:"closed"`
+	FsyncErrorsGated      uint64              `json:"fsync_errors_gated"`
+	DurabilityBlocks      uint64              `json:"durability_blocks"`
+	DurabilityMonotonic   bool                `json:"durability_monotonic"`
+	LastHeartbeat         *DurabilitySnapshot `json:"last_heartbeat,omitempty"`
+	Close                 *DurabilitySnapshot `json:"close,omitempty"`
+	OpenNonce             string              `json:"open_nonce,omitempty"`
+	ChainOpenSeq          uint64              `json:"chain_open_seq,omitempty"`
+	CloseFinalSeq         uint64              `json:"close_final_seq,omitempty"`
+	CloseRootHash         string              `json:"close_root_hash,omitempty"`
+	CloseReceiptCount     uint64              `json:"close_receipt_count,omitempty"`
+	HeartbeatGapDetected  bool                `json:"heartbeat_gap_detected,omitempty"`
+	StructuralViolation   string              `json:"structural_violation,omitempty"`
+	OutcomeWithoutIntent  int                 `json:"outcome_without_intent,omitempty"`
+	DuplicateSessionOpen  bool                `json:"duplicate_session_open,omitempty"`
+	ContradictOpenNonce   bool                `json:"contradict_open_nonce,omitempty"`
+	DurabilityCounterDrop bool                `json:"durability_counter_drop,omitempty"`
+}
+
+// DurabilitySnapshot carries the cumulative durability counters surfaced by a
+// heartbeat or session_close receipt.
+type DurabilitySnapshot struct {
+	FsyncErrorsGated uint64 `json:"fsync_errors_gated"`
+	DurabilityBlocks uint64 `json:"durability_blocks"`
+}
+
+type runState struct {
+	report RunReport
+
+	hasOpen  bool
+	intents  map[string]int
+	outcomes map[string]int
+
+	lastBeat uint64
+	sawBeat  bool
+
+	lastDurability *DurabilitySnapshot
+}
+
+type recordContext struct {
+	prefixCount      uint64
+	hasPreCloseTail  bool
+	preCloseFinalSeq uint64
+	preCloseRootHash string
+}
+
+// Analyze inspects a receipt chain and its integrity result, returning a
+// bounded completeness report. A cryptographically or structurally broken chain
+// is BROKEN. A chain with no lifecycle evidence is UNVERIFIED. A clean lifecycle
+// window is still LIMITED, never green.
+func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
+	report := Report{
+		ReceiptCount: uint64(len(chain)),
+		FinalSeq:     chainResult.FinalSeq,
+		RootHash:     chainResult.RootHash,
+	}
+	if len(chain) == 0 {
+		report.Status = StatusUnverified
+		report.Reason = ReasonNoReceipts
+		return report
+	}
+
+	if !chainResult.Valid && !isLifecycleOnlyChainFailure(chainResult) {
+		return brokenReport(report, chainResult)
+	}
+
+	if !hasSessionControl(chain) {
+		report.Status = StatusUnverified
+		report.Reason = ReasonNoLifecycle
+		report.Error = chainResult.Error
+		return report
+	}
+
+	states := make(map[string]*runState)
+	var order []string
+	getRun := func(runNonce string) *runState {
+		if runNonce == "" {
+			runNonce = "(missing)"
+		}
+		if st, ok := states[runNonce]; ok {
+			return st
+		}
+		st := &runState{
+			report: RunReport{
+				RunNonce:            runNonce,
+				Status:              StatusLimited,
+				Reason:              ReasonBoundedClosed,
+				DurabilityMonotonic: true,
+			},
+			intents:  make(map[string]int),
+			outcomes: make(map[string]int),
+		}
+		states[runNonce] = st
+		order = append(order, runNonce)
+		return st
+	}
+
+	var previous receipt.ActionRecord
+	hasPrevious := false
+	var segmentPrefixCount uint64
+	for i := range chain {
+		ar := chain[i].ActionRecord
+		// session_close carries the emitter's SEGMENT-LOCAL FinalSeq/ReceiptCount:
+		// a key rotation reopens a segment at chain_seq 0, so the observed prefix
+		// used to verify a close's claims must reset at each KeyTransition boundary.
+		// Counting from the whole file would falsely BROKEN a legitimate rotated
+		// chain's (correct, segment-local) close.
+		if ar.KeyTransition != nil {
+			segmentPrefixCount = 0
+		}
+		ctx := recordContext{
+			prefixCount:      segmentPrefixCount,
+			preCloseRootHash: ar.ChainPrevHash,
+		}
+		if hasPrevious && segmentPrefixCount > 0 {
+			ctx.hasPreCloseTail = true
+			ctx.preCloseFinalSeq = previous.ChainSeq
+		}
+		previous = ar
+		hasPrevious = true
+
+		runNonce := effectiveRunNonce(ar)
+		if runNonce != "" || ar.DecisionPhase != "" || ar.SessionControl != nil {
+			st := getRun(runNonce)
+			if violation := applyRecord(st, ar, ctx); violation != "" {
+				if st.report.StructuralViolation == "" {
+					st.report.StructuralViolation = violation
+				}
+				st.report.Status = StatusBroken
+				st.report.Reason = ReasonChainBroken
+			}
+		}
+		segmentPrefixCount++
+	}
+
+	for _, runNonce := range order {
+		st := states[runNonce]
+		finalizeRun(st)
+		report.Runs = append(report.Runs, st.report)
+		report.Status, report.Reason = worse(report.Status, report.Reason, st.report.Status, st.report.Reason)
+	}
+	if report.Status == "" {
+		report.Status = StatusUnverified
+		report.Reason = ReasonNoLifecycle
+	}
+	if report.Status == StatusBroken {
+		report.Error = firstBrokenRunError(report.Runs, chainResult.Error)
+		if report.BrokenAtSeq == 0 {
+			report.BrokenAtSeq = chainResult.BrokenAtSeq
+		}
+		report.BrokenAtIndex = chainResult.BrokenAtIndex
+		return report
+	}
+	if !chainResult.Valid {
+		report.Error = chainResult.Error
+	}
+	return report
+}
+
+func hasSessionControl(chain []receipt.Receipt) bool {
+	for i := range chain {
+		if chain[i].ActionRecord.SessionControl != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func isLifecycleOnlyChainFailure(res receipt.ChainResult) bool {
+	return res.FailureKind == receipt.ChainFailureLifecycleOpen && res.IntegrityVerified
+}
+
+func brokenReport(report Report, chainResult receipt.ChainResult) Report {
+	report.Status = StatusBroken
+	report.Reason = ReasonChainBroken
+	report.Error = chainResult.Error
+	report.BrokenAtSeq = chainResult.BrokenAtSeq
+	report.BrokenAtIndex = chainResult.BrokenAtIndex
+	return report
+}
+
+func effectiveRunNonce(ar receipt.ActionRecord) string {
+	if ar.RunNonce != "" {
+		return ar.RunNonce
+	}
+	if ar.SessionControl == nil {
+		return ""
+	}
+	switch ar.SessionControl.Kind {
+	case receipt.SessionControlOpen:
+		if ar.SessionControl.Open != nil {
+			return ar.SessionControl.Open.RunNonce
+		}
+	case receipt.SessionControlHeartbeat:
+		if ar.SessionControl.Heartbeat != nil {
+			return ar.SessionControl.Heartbeat.RunNonce
+		}
+	case receipt.SessionControlClose:
+		if ar.SessionControl.Close != nil {
+			return ar.SessionControl.Close.RunNonce
+		}
+	}
+	return ""
+}
+
+func applyRecord(st *runState, ar receipt.ActionRecord, ctx recordContext) string {
+	if st.report.Closed {
+		return "record observed after session_close"
+	}
+
+	switch ar.DecisionPhase {
+	case receipt.DecisionPhaseIntent:
+		st.report.Intents++
+		st.intents[ar.ActionID]++
+	case receipt.DecisionPhaseOutcome:
+		st.report.Outcomes++
+		st.outcomes[ar.ActionID]++
+	}
+
+	ctrl := ar.SessionControl
+	if ctrl == nil {
+		return ""
+	}
+	payloads := 0
+	if ctrl.Open != nil {
+		payloads++
+	}
+	if ctrl.Heartbeat != nil {
+		payloads++
+	}
+	if ctrl.Close != nil {
+		payloads++
+	}
+	if payloads != 1 {
+		return "session_control must carry exactly one payload"
+	}
+
+	switch ctrl.Kind {
+	case receipt.SessionControlOpen:
+		return applyOpen(st, ar, ctrl.Open)
+	case receipt.SessionControlHeartbeat:
+		return applyHeartbeat(st, ar, ctrl.Heartbeat)
+	case receipt.SessionControlClose:
+		return applyClose(st, ar, ctrl.Close, ctx)
+	default:
+		return "unknown session_control kind"
+	}
+}
+
+func applyOpen(st *runState, ar receipt.ActionRecord, open *receipt.SessionOpen) string {
+	if open == nil {
+		return "session_open kind missing open payload"
+	}
+	if ar.RunNonce == "" || open.RunNonce != ar.RunNonce {
+		return "session_open run_nonce does not match receipt run_nonce"
+	}
+	if open.OpenNonce == "" {
+		return "session_open open_nonce is empty"
+	}
+	if st.hasOpen {
+		st.report.DuplicateSessionOpen = true
+		return "duplicate session_open for run_nonce"
+	}
+	st.hasOpen = true
+	st.report.OpenNonce = open.OpenNonce
+	st.report.ChainOpenSeq = open.ChainOpenSeq
+	return ""
+}
+
+func applyHeartbeat(st *runState, ar receipt.ActionRecord, heartbeat *receipt.SessionHeartbeat) string {
+	if heartbeat == nil {
+		return "heartbeat kind missing heartbeat payload"
+	}
+	if ar.RunNonce == "" || heartbeat.RunNonce != ar.RunNonce {
+		return "heartbeat run_nonce does not match receipt run_nonce"
+	}
+	if st.hasOpen && heartbeat.OpenNonce != st.report.OpenNonce {
+		st.report.ContradictOpenNonce = true
+		return "heartbeat open_nonce does not match session_open"
+	}
+	st.report.Heartbeats++
+	if st.sawBeat {
+		if heartbeat.Beat != st.lastBeat+1 {
+			st.report.HeartbeatGapDetected = true
+		}
+	} else if heartbeat.Beat != 1 {
+		st.report.HeartbeatGapDetected = true
+	}
+	st.sawBeat = true
+	st.lastBeat = heartbeat.Beat
+
+	snapshot := DurabilitySnapshot{
+		FsyncErrorsGated: heartbeat.FsyncErrorsGated,
+		DurabilityBlocks: heartbeat.DurabilityBlocks,
+	}
+	st.report.LastHeartbeat = &snapshot
+	return applyDurability(st, snapshot)
+}
+
+func applyClose(st *runState, ar receipt.ActionRecord, closeRecord *receipt.SessionClose, ctx recordContext) string {
+	if closeRecord == nil {
+		return "session_close kind missing close payload"
+	}
+	if ar.RunNonce == "" || closeRecord.RunNonce != ar.RunNonce {
+		return "session_close run_nonce does not match receipt run_nonce"
+	}
+	if st.hasOpen && closeRecord.OpenNonce != st.report.OpenNonce {
+		st.report.ContradictOpenNonce = true
+		return "session_close open_nonce does not match session_open"
+	}
+	st.report.Closed = true
+	st.report.CloseFinalSeq = closeRecord.FinalSeq
+	st.report.CloseRootHash = closeRecord.RootHash
+	st.report.CloseReceiptCount = closeRecord.ReceiptCount
+	if closeRecord.RootHash != ctx.preCloseRootHash {
+		return "session_close root_hash does not match sealed pre-close tail hash"
+	}
+	if closeRecord.ReceiptCount != ctx.prefixCount {
+		return "session_close receipt_count does not match observed pre-close receipt count"
+	}
+	if ctx.hasPreCloseTail && closeRecord.FinalSeq != ctx.preCloseFinalSeq {
+		return "session_close final_seq does not match observed pre-close tail seq"
+	}
+	snapshot := DurabilitySnapshot{
+		FsyncErrorsGated: closeRecord.FsyncErrorsGated,
+		DurabilityBlocks: closeRecord.DurabilityBlocks,
+	}
+	st.report.Close = &snapshot
+	return applyDurability(st, snapshot)
+}
+
+func applyDurability(st *runState, snapshot DurabilitySnapshot) string {
+	if st.lastDurability != nil {
+		if snapshot.FsyncErrorsGated < st.lastDurability.FsyncErrorsGated ||
+			snapshot.DurabilityBlocks < st.lastDurability.DurabilityBlocks {
+			st.report.DurabilityCounterDrop = true
+			st.report.DurabilityMonotonic = false
+			return "durability counters decreased"
+		}
+	}
+	st.lastDurability = &snapshot
+	st.report.FsyncErrorsGated = snapshot.FsyncErrorsGated
+	st.report.DurabilityBlocks = snapshot.DurabilityBlocks
+	return ""
+}
+
+func finalizeRun(st *runState) {
+	if st.report.Status == StatusBroken {
+		return
+	}
+	for actionID, n := range st.intents {
+		outcomes := st.outcomes[actionID]
+		if outcomes >= n {
+			st.report.MatchedPairs += n
+			continue
+		}
+		st.report.MatchedPairs += outcomes
+		st.report.UnmatchedIntents += n - outcomes
+	}
+	for actionID, outcomes := range st.outcomes {
+		if st.intents[actionID] == 0 {
+			st.report.OutcomeWithoutIntent += outcomes
+		}
+	}
+	if st.report.OutcomeWithoutIntent > 0 {
+		st.report.Status = StatusBroken
+		st.report.Reason = ReasonChainBroken
+		st.report.StructuralViolation = "outcome without matching intent"
+		return
+	}
+	switch {
+	case !st.hasOpen:
+		st.report.Status = StatusUnverified
+		st.report.Reason = ReasonNoOpen
+	case st.report.UnmatchedIntents > 0:
+		st.report.Status = StatusLimited
+		st.report.Reason = ReasonOpenAction
+	case st.report.HeartbeatGapDetected:
+		st.report.Status = StatusLimited
+		st.report.Reason = ReasonHeartbeatGap
+	case !st.report.Closed:
+		st.report.Status = StatusLimited
+		st.report.Reason = ReasonAbnormalEnd
+	default:
+		st.report.Status = StatusLimited
+		st.report.Reason = ReasonBoundedClosed
+	}
+}
+
+func worse(curStatus Status, curReason Reason, nextStatus Status, nextReason Reason) (Status, Reason) {
+	if severity(nextStatus) > severity(curStatus) {
+		return nextStatus, nextReason
+	}
+	if severity(nextStatus) == severity(curStatus) && reasonSeverity(nextReason) > reasonSeverity(curReason) {
+		return nextStatus, nextReason
+	}
+	if curStatus == "" {
+		return nextStatus, nextReason
+	}
+	return curStatus, curReason
+}
+
+func severity(status Status) int {
+	switch status {
+	case StatusBroken:
+		return 3
+	case StatusUnverified:
+		return 2
+	case StatusLimited:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func reasonSeverity(reason Reason) int {
+	switch reason {
+	case ReasonChainBroken:
+		return 100
+	case ReasonNoOpen:
+		return 80
+	case ReasonNoLifecycle, ReasonRecorderDisabled, ReasonNoReceipts:
+		return 70
+	case ReasonOpenAction:
+		return 50
+	case ReasonHeartbeatGap:
+		return 40
+	case ReasonAbnormalEnd:
+		return 30
+	case ReasonBoundedClosed:
+		return 10
+	default:
+		return 0
+	}
+}
+
+func firstBrokenRunError(runs []RunReport, fallback string) string {
+	for _, run := range runs {
+		if run.Status == StatusBroken && run.StructuralViolation != "" {
+			return run.StructuralViolation
+		}
+	}
+	return fallback
+}

--- a/internal/evidence/completeness/completeness.go
+++ b/internal/evidence/completeness/completeness.go
@@ -197,7 +197,7 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 				continue
 			}
 		}
-		if runNonce != "" || ar.DecisionPhase != "" || ar.SessionControl != nil {
+		if runNonce != "" || ar.SessionControl != nil {
 			st := getRun(runNonce)
 			if violation := applyRecord(st, ar, ctx); violation != "" {
 				markStructuralViolation(st, violation)

--- a/internal/evidence/completeness/completeness.go
+++ b/internal/evidence/completeness/completeness.go
@@ -399,7 +399,7 @@ func applyHeartbeat(st *runState, ar receipt.ActionRecord, heartbeat *receipt.Se
 	if !st.hasOpen {
 		return "heartbeat observed before session_open"
 	}
-	if st.hasOpen && heartbeat.OpenNonce != st.report.OpenNonce {
+	if heartbeat.OpenNonce != st.report.OpenNonce {
 		st.report.ContradictOpenNonce = true
 		return "heartbeat open_nonce does not match session_open"
 	}
@@ -438,7 +438,7 @@ func applyClose(st *runState, ar receipt.ActionRecord, closeRecord *receipt.Sess
 	if !st.hasOpen {
 		return "session_close observed before session_open"
 	}
-	if st.hasOpen && closeRecord.OpenNonce != st.report.OpenNonce {
+	if closeRecord.OpenNonce != st.report.OpenNonce {
 		st.report.ContradictOpenNonce = true
 		return "session_close open_nonce does not match session_open"
 	}

--- a/internal/evidence/completeness/completeness.go
+++ b/internal/evidence/completeness/completeness.go
@@ -104,6 +104,11 @@ type recordContext struct {
 	preCloseRootHash string
 }
 
+type lifecycleState struct {
+	opened map[string]bool
+	closed map[string]bool
+}
+
 // Analyze inspects a receipt chain and its integrity result, returning a
 // bounded completeness report. A cryptographically or structurally broken chain
 // is BROKEN. A chain with no lifecycle evidence is UNVERIFIED. A clean lifecycle
@@ -132,6 +137,10 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 	}
 
 	states := make(map[string]*runState)
+	lifecycle := lifecycleState{
+		opened: make(map[string]bool),
+		closed: make(map[string]bool),
+	}
 	var order []string
 	getRun := func(runNonce string) *runState {
 		if runNonce == "" {
@@ -180,17 +189,29 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 		hasPrevious = true
 
 		runNonce := effectiveRunNonce(ar)
+		if ar.SessionControl == nil {
+			if violation := validateLifecycleAction(lifecycle, ar); violation != "" {
+				st := getRun(runNonce)
+				markStructuralViolation(st, violation)
+				segmentPrefixCount++
+				continue
+			}
+		}
 		if runNonce != "" || ar.DecisionPhase != "" || ar.SessionControl != nil {
 			st := getRun(runNonce)
 			if violation := applyRecord(st, ar, ctx); violation != "" {
-				if st.report.StructuralViolation == "" {
-					st.report.StructuralViolation = violation
-				}
-				st.report.Status = StatusBroken
-				st.report.Reason = ReasonChainBroken
+				markStructuralViolation(st, violation)
 			}
+			updateLifecycleState(lifecycle, ar)
 		}
 		segmentPrefixCount++
+	}
+
+	for _, runNonce := range order {
+		if runNonce == "(missing)" || lifecycle.opened[runNonce] {
+			continue
+		}
+		markStructuralViolation(states[runNonce], "receipt run_nonce has no matching session_open")
 	}
 
 	for _, runNonce := range order {
@@ -263,6 +284,44 @@ func effectiveRunNonce(ar receipt.ActionRecord) string {
 	return ""
 }
 
+func validateLifecycleAction(lifecycle lifecycleState, ar receipt.ActionRecord) string {
+	if ar.RunNonce == "" {
+		return "action receipt missing run_nonce in lifecycle chain"
+	}
+	if !lifecycle.opened[ar.RunNonce] {
+		return "action observed before matching session_open"
+	}
+	if lifecycle.closed[ar.RunNonce] {
+		return "action observed after session_close"
+	}
+	return ""
+}
+
+func updateLifecycleState(lifecycle lifecycleState, ar receipt.ActionRecord) {
+	if ar.SessionControl == nil {
+		return
+	}
+	runNonce := effectiveRunNonce(ar)
+	if runNonce == "" {
+		return
+	}
+	switch ar.SessionControl.Kind {
+	case receipt.SessionControlOpen:
+		lifecycle.opened[runNonce] = true
+		lifecycle.closed[runNonce] = false
+	case receipt.SessionControlClose:
+		lifecycle.closed[runNonce] = true
+	}
+}
+
+func markStructuralViolation(st *runState, violation string) {
+	if st.report.StructuralViolation == "" {
+		st.report.StructuralViolation = violation
+	}
+	st.report.Status = StatusBroken
+	st.report.Reason = ReasonChainBroken
+}
+
 func applyRecord(st *runState, ar receipt.ActionRecord, ctx recordContext) string {
 	if st.report.Closed {
 		return "record observed after session_close"
@@ -317,6 +376,9 @@ func applyOpen(st *runState, ar receipt.ActionRecord, open *receipt.SessionOpen)
 	if open.OpenNonce == "" {
 		return "session_open open_nonce is empty"
 	}
+	if open.ChainOpenSeq != ar.ChainSeq {
+		return "session_open chain_open_seq does not match receipt chain_seq"
+	}
 	if st.hasOpen {
 		st.report.DuplicateSessionOpen = true
 		return "duplicate session_open for run_nonce"
@@ -334,9 +396,18 @@ func applyHeartbeat(st *runState, ar receipt.ActionRecord, heartbeat *receipt.Se
 	if ar.RunNonce == "" || heartbeat.RunNonce != ar.RunNonce {
 		return "heartbeat run_nonce does not match receipt run_nonce"
 	}
+	if !st.hasOpen {
+		return "heartbeat observed before session_open"
+	}
 	if st.hasOpen && heartbeat.OpenNonce != st.report.OpenNonce {
 		st.report.ContradictOpenNonce = true
 		return "heartbeat open_nonce does not match session_open"
+	}
+	if heartbeat.ChainHead != ar.ChainPrevHash {
+		return "heartbeat chain_head does not match observed pre-heartbeat chain hash"
+	}
+	if heartbeat.ChainSeqHead != ar.ChainSeq {
+		return "heartbeat chain_seq_head does not match observed pre-heartbeat chain seq"
 	}
 	st.report.Heartbeats++
 	if st.sawBeat {
@@ -363,6 +434,9 @@ func applyClose(st *runState, ar receipt.ActionRecord, closeRecord *receipt.Sess
 	}
 	if ar.RunNonce == "" || closeRecord.RunNonce != ar.RunNonce {
 		return "session_close run_nonce does not match receipt run_nonce"
+	}
+	if !st.hasOpen {
+		return "session_close observed before session_open"
 	}
 	if st.hasOpen && closeRecord.OpenNonce != st.report.OpenNonce {
 		st.report.ContradictOpenNonce = true

--- a/internal/evidence/completeness/completeness_test.go
+++ b/internal/evidence/completeness/completeness_test.go
@@ -184,23 +184,32 @@ func (b *chainBuilder) heartbeat(beat, fsync, blocks uint64) receipt.Receipt {
 
 func (b *chainBuilder) heartbeatFor(runNonce, openNonce string, beat, fsync, blocks uint64) receipt.Receipt {
 	b.t.Helper()
+	return b.heartbeatForWithMutation(runNonce, openNonce, beat, fsync, blocks, nil)
+}
+
+func (b *chainBuilder) heartbeatForWithMutation(runNonce, openNonce string, beat, fsync, blocks uint64, mutate func(*receipt.SessionHeartbeat)) receipt.Receipt {
+	b.t.Helper()
+	heartbeat := &receipt.SessionHeartbeat{
+		RunNonce:         runNonce,
+		OpenNonce:        openNonce,
+		Beat:             beat,
+		ChainHead:        b.prev,
+		ChainSeqHead:     b.seq,
+		HeartbeatTime:    b.base.Add(b.offset).Format(time.RFC3339Nano),
+		FsyncErrorsGated: fsync,
+		DurabilityBlocks: blocks,
+	}
+	if mutate != nil {
+		mutate(heartbeat)
+	}
 	return b.sign(receipt.ActionRecord{
 		ActionType: receipt.ActionUnclassified,
 		Target:     "pipelock://session/heartbeat",
 		Transport:  "session_control",
 		RunNonce:   runNonce,
 		SessionControl: &receipt.SessionControl{
-			Kind: receipt.SessionControlHeartbeat,
-			Heartbeat: &receipt.SessionHeartbeat{
-				RunNonce:         runNonce,
-				OpenNonce:        openNonce,
-				Beat:             beat,
-				ChainHead:        b.prev,
-				ChainSeqHead:     b.seq,
-				HeartbeatTime:    b.base.Add(b.offset).Format(time.RFC3339Nano),
-				FsyncErrorsGated: fsync,
-				DurabilityBlocks: blocks,
-			},
+			Kind:      receipt.SessionControlHeartbeat,
+			Heartbeat: heartbeat,
 		},
 	})
 }
@@ -421,9 +430,9 @@ func TestAnalyzeNoOpenIsUnverified(t *testing.T) {
 		t.Fatal("fixture should trigger the existing chain verifier no-open rejection")
 	}
 	report := Analyze(chain, res)
-	run := requireOneRun(t, report, StatusUnverified, ReasonNoOpen)
-	if run.Closed != true {
-		t.Fatalf("close evidence should still be surfaced: %#v", run)
+	run := requireOneRun(t, report, StatusBroken, ReasonChainBroken)
+	if run.StructuralViolation != "heartbeat observed before session_open" {
+		t.Fatalf("structural_violation = %q, want heartbeat before open: %#v", run.StructuralViolation, run)
 	}
 }
 
@@ -553,8 +562,8 @@ func TestAnalyzeRecordAfterCloseIsBroken(t *testing.T) {
 
 	report := analyzeBuilt(chain, b.keyHex)
 	run := requireOneRun(t, report, StatusBroken, ReasonChainBroken)
-	if run.StructuralViolation != "record observed after session_close" {
-		t.Fatalf("structural_violation = %q, want record observed after session_close: %#v", run.StructuralViolation, run)
+	if run.StructuralViolation != "action observed after session_close" {
+		t.Fatalf("structural_violation = %q, want action observed after session_close: %#v", run.StructuralViolation, run)
 	}
 }
 
@@ -611,6 +620,95 @@ func TestAnalyzePostCloseGuardIsScopedToRun(t *testing.T) {
 			t.Fatalf("structural_violation = %q, want post-close guard: %#v", run.StructuralViolation, run)
 		}
 	})
+}
+
+func TestAnalyzeLifecycleChainRejectsActionsOutsideOpenedRun(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build         func(*chainBuilder) []receipt.Receipt
+		wantRun       string
+		wantViolation string
+	}{
+		"pre_open_action": {
+			build: func(b *chainBuilder) []receipt.Receipt {
+				actionID := "action-pre-open"
+				return []receipt.Receipt{
+					b.intent(actionID),
+					b.open(),
+					b.outcome(actionID),
+					b.close(0, 1),
+				}
+			},
+			wantRun:       testRunNonce,
+			wantViolation: "action observed before matching session_open",
+		},
+		"post_close_action_missing_run_nonce": {
+			build: func(b *chainBuilder) []receipt.Receipt {
+				return []receipt.Receipt{
+					b.open(),
+					b.close(0, 1),
+					b.legacyAction(),
+				}
+			},
+			wantRun:       "(missing)",
+			wantViolation: "action receipt missing run_nonce in lifecycle chain",
+		},
+		"post_close_action_unopened_run_nonce": {
+			build: func(b *chainBuilder) []receipt.Receipt {
+				return []receipt.Receipt{
+					b.open(),
+					b.close(0, 1),
+					b.actionFor("run-unopened", "action-unopened", receipt.DecisionPhaseIntent),
+				}
+			},
+			wantRun:       "run-unopened",
+			wantViolation: "action observed before matching session_open",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			b := newChainBuilder(t)
+			report := analyzeBuilt(tc.build(b), b.keyHex)
+			run := requireRun(t, report, tc.wantRun, StatusBroken, ReasonChainBroken)
+			if run.StructuralViolation != tc.wantViolation {
+				t.Fatalf("structural_violation = %q, want %q: %#v", run.StructuralViolation, tc.wantViolation, run)
+			}
+		})
+	}
+}
+
+func TestAnalyzeHeartbeatClaimsMustMatchObservedPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(*receipt.SessionHeartbeat){
+		"chain_head": func(heartbeat *receipt.SessionHeartbeat) {
+			heartbeat.ChainHead = "forged-heartbeat-chain-head"
+		},
+		"chain_seq_head": func(heartbeat *receipt.SessionHeartbeat) {
+			heartbeat.ChainSeqHead++
+		},
+	}
+
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			b := newChainBuilder(t)
+			chain := []receipt.Receipt{
+				b.open(),
+				b.heartbeatForWithMutation(testRunNonce, testOpenNonce, 1, 0, 1, mutate),
+				b.close(0, 2),
+			}
+
+			report := analyzeBuilt(chain, b.keyHex)
+			run := requireOneRun(t, report, StatusBroken, ReasonChainBroken)
+			if run.StructuralViolation == "" {
+				t.Fatalf("heartbeat prefix mutation did not surface a structural violation for %s: %#v", name, run)
+			}
+		})
+	}
 }
 
 func TestAnalyzeDurabilityCountersArePerRun(t *testing.T) {
@@ -767,8 +865,8 @@ func TestAnalyzeOnlyMissingOpenIntegrityFailureDowngrades(t *testing.T) {
 		},
 		"missing_open_with_integrity": {
 			chainResult: receipt.ChainResult{FailureKind: receipt.ChainFailureLifecycleOpen, IntegrityVerified: true, Error: "missing open"},
-			wantStatus:  StatusUnverified,
-			wantReason:  ReasonNoOpen,
+			wantStatus:  StatusBroken,
+			wantReason:  ReasonChainBroken,
 		},
 	}
 

--- a/internal/evidence/completeness/completeness_test.go
+++ b/internal/evidence/completeness/completeness_test.go
@@ -418,7 +418,7 @@ func TestAnalyzeReasons(t *testing.T) {
 	}
 }
 
-func TestAnalyzeNoOpenIsUnverified(t *testing.T) {
+func TestAnalyzeNoOpenIsBroken(t *testing.T) {
 	t.Parallel()
 	b := newChainBuilder(t)
 	chain := []receipt.Receipt{

--- a/internal/evidence/completeness/completeness_test.go
+++ b/internal/evidence/completeness/completeness_test.go
@@ -1,0 +1,1013 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package completeness
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+const (
+	testRunNonce  = "run-completeness-a"
+	testOpenNonce = "open-completeness-a"
+)
+
+type chainBuilder struct {
+	t      *testing.T
+	priv   ed25519.PrivateKey
+	keyHex string
+	prev   string
+	seq    uint64
+	base   time.Time
+	offset time.Duration
+}
+
+type rotationKey struct {
+	priv   ed25519.PrivateKey
+	keyHex string
+}
+
+func newChainBuilder(t *testing.T) *chainBuilder {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+	return &chainBuilder{
+		t:      t,
+		priv:   priv,
+		keyHex: hex.EncodeToString(pub),
+		prev:   receipt.GenesisHash,
+		base:   time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func newRotationKey(t *testing.T) rotationKey {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+	return rotationKey{
+		priv:   priv,
+		keyHex: hex.EncodeToString(pub),
+	}
+}
+
+func (b *chainBuilder) sign(ar receipt.ActionRecord) receipt.Receipt {
+	b.t.Helper()
+	if ar.Version == 0 {
+		ar.Version = receipt.ActionRecordVersion
+	}
+	if ar.ActionID == "" {
+		ar.ActionID = receipt.NewActionID()
+	}
+	if ar.ActionType == "" {
+		ar.ActionType = receipt.ActionRead
+	}
+	if ar.Timestamp.IsZero() {
+		ar.Timestamp = b.base.Add(b.offset)
+	}
+	if ar.Target == "" {
+		ar.Target = "https://api.vendor.example/completeness"
+	}
+	if ar.Verdict == "" {
+		ar.Verdict = "allow"
+	}
+	if ar.Transport == "" {
+		ar.Transport = "fetch"
+	}
+	if ar.PolicyHash == "" {
+		ar.PolicyHash = "policy-completeness"
+	}
+	ar.ChainPrevHash = b.prev
+	ar.ChainSeq = b.seq
+	r, err := receipt.Sign(ar, b.priv)
+	if err != nil {
+		b.t.Fatalf("Sign: %v", err)
+	}
+	hash, err := receipt.ReceiptHash(r)
+	if err != nil {
+		b.t.Fatalf("ReceiptHash: %v", err)
+	}
+	b.prev = hash
+	b.seq++
+	b.offset += time.Second
+	return r
+}
+
+func (b *chainBuilder) open() receipt.Receipt {
+	b.t.Helper()
+	return b.openFor(testRunNonce, testOpenNonce)
+}
+
+func (b *chainBuilder) openFor(runNonce, openNonce string) receipt.Receipt {
+	b.t.Helper()
+	open := receipt.SessionOpen{
+		RunNonce:         runNonce,
+		OpenNonce:        openNonce,
+		RecorderSession:  "proxy",
+		PolicyHash:       "policy-completeness",
+		SignerKeyEpoch:   "epoch-a",
+		HeartbeatSeconds: 10,
+		ChainOpenSeq:     b.seq,
+	}
+	if b.seq == 0 {
+		genesis := receipt.ComputeSessionOpenGenesis(open)
+		open.GenesisHash = genesis
+		b.prev = genesis
+	} else {
+		open.PriorChainHead = b.prev
+		open.PriorChainSeq = b.seq - 1
+	}
+	return b.sign(receipt.ActionRecord{
+		ActionType: receipt.ActionUnclassified,
+		Target:     "pipelock://session/open",
+		Transport:  "session_control",
+		RunNonce:   runNonce,
+		SessionControl: &receipt.SessionControl{
+			Kind: receipt.SessionControlOpen,
+			Open: &open,
+		},
+	})
+}
+
+func (b *chainBuilder) rotateOpenFor(next rotationKey, runNonce, openNonce string) receipt.Receipt {
+	b.t.Helper()
+	if b.seq == 0 {
+		b.t.Fatal("rotateOpenFor requires a prior segment tail")
+	}
+	priorKey := b.keyHex
+	priorHead := b.prev
+	priorSeq := b.seq - 1
+	b.priv = next.priv
+	b.keyHex = next.keyHex
+	b.seq = 0
+	open := receipt.SessionOpen{
+		RunNonce:         runNonce,
+		OpenNonce:        openNonce,
+		RecorderSession:  "proxy",
+		PolicyHash:       "policy-completeness",
+		SignerKeyEpoch:   "epoch-b",
+		HeartbeatSeconds: 10,
+		ChainOpenSeq:     0,
+		PriorChainHead:   priorHead,
+		PriorChainSeq:    priorSeq,
+	}
+	return b.sign(receipt.ActionRecord{
+		ActionType: receipt.ActionUnclassified,
+		Target:     "pipelock://session/open",
+		Transport:  "session_control",
+		RunNonce:   runNonce,
+		KeyTransition: &receipt.KeyTransition{
+			PriorSignerKey: priorKey,
+			PriorChainSeq:  priorSeq,
+			PriorChainHash: priorHead,
+		},
+		SessionControl: &receipt.SessionControl{
+			Kind: receipt.SessionControlOpen,
+			Open: &open,
+		},
+	})
+}
+
+func (b *chainBuilder) heartbeat(beat, fsync, blocks uint64) receipt.Receipt {
+	b.t.Helper()
+	return b.heartbeatFor(testRunNonce, testOpenNonce, beat, fsync, blocks)
+}
+
+func (b *chainBuilder) heartbeatFor(runNonce, openNonce string, beat, fsync, blocks uint64) receipt.Receipt {
+	b.t.Helper()
+	return b.sign(receipt.ActionRecord{
+		ActionType: receipt.ActionUnclassified,
+		Target:     "pipelock://session/heartbeat",
+		Transport:  "session_control",
+		RunNonce:   runNonce,
+		SessionControl: &receipt.SessionControl{
+			Kind: receipt.SessionControlHeartbeat,
+			Heartbeat: &receipt.SessionHeartbeat{
+				RunNonce:         runNonce,
+				OpenNonce:        openNonce,
+				Beat:             beat,
+				ChainHead:        b.prev,
+				ChainSeqHead:     b.seq,
+				HeartbeatTime:    b.base.Add(b.offset).Format(time.RFC3339Nano),
+				FsyncErrorsGated: fsync,
+				DurabilityBlocks: blocks,
+			},
+		},
+	})
+}
+
+func (b *chainBuilder) close(fsync, blocks uint64) receipt.Receipt {
+	b.t.Helper()
+	return b.closeFor(testRunNonce, testOpenNonce, fsync, blocks)
+}
+
+func (b *chainBuilder) closeFor(runNonce, openNonce string, fsync, blocks uint64) receipt.Receipt {
+	b.t.Helper()
+	finalSeq := uint64(0)
+	if b.seq > 0 {
+		finalSeq = b.seq - 1
+	}
+	closeRecord := &receipt.SessionClose{
+		RunNonce:         runNonce,
+		OpenNonce:        openNonce,
+		FinalSeq:         finalSeq,
+		RootHash:         b.prev,
+		ReceiptCount:     b.seq,
+		CloseReason:      "normal",
+		FsyncErrorsGated: fsync,
+		DurabilityBlocks: blocks,
+	}
+	return b.closeWithRecord(runNonce, closeRecord)
+}
+
+func (b *chainBuilder) closeForWithMutation(runNonce, openNonce string, fsync, blocks uint64, mutate func(*receipt.SessionClose)) receipt.Receipt {
+	b.t.Helper()
+	finalSeq := uint64(0)
+	if b.seq > 0 {
+		finalSeq = b.seq - 1
+	}
+	closeRecord := &receipt.SessionClose{
+		RunNonce:         runNonce,
+		OpenNonce:        openNonce,
+		FinalSeq:         finalSeq,
+		RootHash:         b.prev,
+		ReceiptCount:     b.seq,
+		CloseReason:      "normal",
+		FsyncErrorsGated: fsync,
+		DurabilityBlocks: blocks,
+	}
+	mutate(closeRecord)
+	return b.closeWithRecord(runNonce, closeRecord)
+}
+
+func (b *chainBuilder) closeWithRecord(runNonce string, closeRecord *receipt.SessionClose) receipt.Receipt {
+	b.t.Helper()
+	return b.sign(receipt.ActionRecord{
+		ActionType: receipt.ActionUnclassified,
+		Target:     "pipelock://session/close",
+		Transport:  "session_control",
+		RunNonce:   runNonce,
+		SessionControl: &receipt.SessionControl{
+			Kind:  receipt.SessionControlClose,
+			Close: closeRecord,
+		},
+	})
+}
+
+func (b *chainBuilder) intent(actionID string) receipt.Receipt {
+	b.t.Helper()
+	return b.action(actionID, receipt.DecisionPhaseIntent)
+}
+
+func (b *chainBuilder) outcome(actionID string) receipt.Receipt {
+	b.t.Helper()
+	return b.action(actionID, receipt.DecisionPhaseOutcome)
+}
+
+func (b *chainBuilder) action(actionID, phase string) receipt.Receipt {
+	b.t.Helper()
+	return b.actionFor(testRunNonce, actionID, phase)
+}
+
+func (b *chainBuilder) actionFor(runNonce, actionID, phase string) receipt.Receipt {
+	b.t.Helper()
+	return b.sign(receipt.ActionRecord{
+		ActionID:      actionID,
+		ActionType:    receipt.ActionRead,
+		Target:        "https://api.vendor.example/completeness/action",
+		Transport:     "fetch",
+		RunNonce:      runNonce,
+		DecisionPhase: phase,
+	})
+}
+
+func (b *chainBuilder) legacyAction() receipt.Receipt {
+	b.t.Helper()
+	return b.sign(receipt.ActionRecord{
+		ActionType: receipt.ActionRead,
+		Target:     "https://api.vendor.example/legacy",
+		Transport:  "fetch",
+	})
+}
+
+func analyzeBuilt(chain []receipt.Receipt, keyHex string) Report {
+	return Analyze(chain, receipt.VerifyChain(chain, keyHex))
+}
+
+func requireOneRun(t *testing.T, report Report, status Status, reason Reason) RunReport {
+	t.Helper()
+	if report.Status != status || report.Reason != reason {
+		t.Fatalf("report = %s/%s, want %s/%s: %#v", report.Status, report.Reason, status, reason, report)
+	}
+	if len(report.Runs) != 1 {
+		t.Fatalf("runs = %d, want 1: %#v", len(report.Runs), report)
+	}
+	run := report.Runs[0]
+	if run.Status != status || run.Reason != reason {
+		t.Fatalf("run = %s/%s, want %s/%s: %#v", run.Status, run.Reason, status, reason, run)
+	}
+	return run
+}
+
+func requireRun(t *testing.T, report Report, runNonce string, status Status, reason Reason) RunReport {
+	t.Helper()
+	for _, run := range report.Runs {
+		if run.RunNonce != runNonce {
+			continue
+		}
+		if run.Status != status || run.Reason != reason {
+			t.Fatalf("run %s = %s/%s, want %s/%s: %#v", runNonce, run.Status, run.Reason, status, reason, run)
+		}
+		return run
+	}
+	t.Fatalf("run %s not found in report: %#v", runNonce, report)
+	return RunReport{}
+}
+
+func TestAnalyzeReasons(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build func(t *testing.T) ([]receipt.Receipt, string)
+		want  Reason
+	}{
+		"bounded_closed": {
+			build: func(t *testing.T) ([]receipt.Receipt, string) {
+				b := newChainBuilder(t)
+				actionID := "action-bounded"
+				chain := []receipt.Receipt{
+					b.open(),
+					b.intent(actionID),
+					b.outcome(actionID),
+					b.heartbeat(1, 1, 2),
+					b.close(1, 3),
+				}
+				return chain, b.keyHex
+			},
+			want: ReasonBoundedClosed,
+		},
+		"abnormal_end": {
+			build: func(t *testing.T) ([]receipt.Receipt, string) {
+				b := newChainBuilder(t)
+				actionID := "action-abnormal"
+				chain := []receipt.Receipt{
+					b.open(),
+					b.intent(actionID),
+					b.outcome(actionID),
+				}
+				return chain, b.keyHex
+			},
+			want: ReasonAbnormalEnd,
+		},
+		"open_action": {
+			build: func(t *testing.T) ([]receipt.Receipt, string) {
+				b := newChainBuilder(t)
+				chain := []receipt.Receipt{
+					b.open(),
+					b.intent("action-open"),
+					b.close(0, 0),
+				}
+				return chain, b.keyHex
+			},
+			want: ReasonOpenAction,
+		},
+		"heartbeat_gap": {
+			build: func(t *testing.T) ([]receipt.Receipt, string) {
+				b := newChainBuilder(t)
+				chain := []receipt.Receipt{
+					b.open(),
+					b.heartbeat(1, 0, 1),
+					b.heartbeat(3, 0, 2),
+					b.close(0, 2),
+				}
+				return chain, b.keyHex
+			},
+			want: ReasonHeartbeatGap,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			chain, keyHex := tc.build(t)
+			run := requireOneRun(t, analyzeBuilt(chain, keyHex), StatusLimited, tc.want)
+			if tc.want == ReasonBoundedClosed {
+				if run.MatchedPairs != 1 || run.UnmatchedIntents != 0 || !run.Closed || !run.DurabilityMonotonic {
+					t.Fatalf("bounded run counters wrong: %#v", run)
+				}
+			}
+		})
+	}
+}
+
+func TestAnalyzeNoOpenIsUnverified(t *testing.T) {
+	t.Parallel()
+	b := newChainBuilder(t)
+	chain := []receipt.Receipt{
+		b.heartbeat(1, 0, 1),
+		b.close(0, 1),
+	}
+	res := receipt.VerifyChain(chain, b.keyHex)
+	if res.Valid {
+		t.Fatal("fixture should trigger the existing chain verifier no-open rejection")
+	}
+	report := Analyze(chain, res)
+	run := requireOneRun(t, report, StatusUnverified, ReasonNoOpen)
+	if run.Closed != true {
+		t.Fatalf("close evidence should still be surfaced: %#v", run)
+	}
+}
+
+func TestAnalyzeCloseClaimsMustMatchObservedPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(*receipt.SessionClose){
+		"receipt_count": func(closeRecord *receipt.SessionClose) {
+			closeRecord.ReceiptCount++
+		},
+		"root_hash": func(closeRecord *receipt.SessionClose) {
+			closeRecord.RootHash = "contradictory-root-hash"
+		},
+		"final_seq": func(closeRecord *receipt.SessionClose) {
+			closeRecord.FinalSeq++
+		},
+	}
+
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			b := newChainBuilder(t)
+			chain := []receipt.Receipt{
+				b.open(),
+				b.closeForWithMutation(testRunNonce, testOpenNonce, 0, 1, func(closeRecord *receipt.SessionClose) {
+					mutate(closeRecord)
+				}),
+			}
+
+			report := analyzeBuilt(chain, b.keyHex)
+			run := requireOneRun(t, report, StatusBroken, ReasonChainBroken)
+			if run.StructuralViolation == "" {
+				t.Fatalf("structural violation not surfaced for %s: %#v", name, run)
+			}
+		})
+	}
+}
+
+func TestAnalyzeCloseClaimsUseCurrentSegmentPrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same_key_restart_uses_chain_prefix_not_run_prefix", func(t *testing.T) {
+		t.Parallel()
+		b := newChainBuilder(t)
+		chain := []receipt.Receipt{
+			b.openFor("run-a", "open-a"),
+			b.closeFor("run-a", "open-a", 0, 1),
+			b.openFor("run-b", "open-b"),
+			b.closeFor("run-b", "open-b", 0, 2),
+		}
+
+		report := analyzeBuilt(chain, b.keyHex)
+		if report.Status != StatusLimited || report.Reason != ReasonBoundedClosed {
+			t.Fatalf("same-key restart report = %s/%s, want LIMITED/bounded_closed: %#v", report.Status, report.Reason, report)
+		}
+		runB := requireRun(t, report, "run-b", StatusLimited, ReasonBoundedClosed)
+		if runB.CloseReceiptCount != 3 || runB.CloseFinalSeq != 2 {
+			t.Fatalf("restart close claims = count %d seq %d, want whole-segment prefix count 3 seq 2: %#v",
+				runB.CloseReceiptCount, runB.CloseFinalSeq, runB)
+		}
+	})
+
+	t.Run("rotated_restart_uses_rotated_segment_prefix", func(t *testing.T) {
+		t.Parallel()
+		b := newChainBuilder(t)
+		keyA := b.keyHex
+		keyB := newRotationKey(t)
+		chain := []receipt.Receipt{
+			b.openFor("run-a", "open-a"),
+			b.closeFor("run-a", "open-a", 0, 1),
+			b.rotateOpenFor(keyB, "run-b", "open-b"),
+			b.closeFor("run-b", "open-b", 0, 2),
+		}
+
+		res := receipt.VerifyChainTrusted(chain, []string{keyA, keyB.keyHex})
+		if !res.Valid {
+			t.Fatalf("rotated fixture must verify before completeness analysis: %s", res.Error)
+		}
+		report := Analyze(chain, res)
+		if report.Status != StatusLimited || report.Reason != ReasonBoundedClosed {
+			t.Fatalf("rotated restart report = %s/%s, want LIMITED/bounded_closed: %#v", report.Status, report.Reason, report)
+		}
+		runB := requireRun(t, report, "run-b", StatusLimited, ReasonBoundedClosed)
+		if runB.CloseReceiptCount != 1 || runB.CloseFinalSeq != 0 {
+			t.Fatalf("rotated close claims = count %d seq %d, want segment prefix count 1 seq 0: %#v",
+				runB.CloseReceiptCount, runB.CloseFinalSeq, runB)
+		}
+	})
+
+	t.Run("rotated_restart_wrong_close_claim_is_broken", func(t *testing.T) {
+		t.Parallel()
+		b := newChainBuilder(t)
+		keyA := b.keyHex
+		keyB := newRotationKey(t)
+		chain := []receipt.Receipt{
+			b.openFor("run-a", "open-a"),
+			b.closeFor("run-a", "open-a", 0, 1),
+			b.rotateOpenFor(keyB, "run-b", "open-b"),
+			b.closeForWithMutation("run-b", "open-b", 0, 2, func(closeRecord *receipt.SessionClose) {
+				closeRecord.ReceiptCount++
+			}),
+		}
+
+		res := receipt.VerifyChainTrusted(chain, []string{keyA, keyB.keyHex})
+		if !res.Valid {
+			t.Fatalf("rotated fixture must verify before completeness analysis: %s", res.Error)
+		}
+		report := Analyze(chain, res)
+		runB := requireRun(t, report, "run-b", StatusBroken, ReasonChainBroken)
+		if runB.StructuralViolation == "" {
+			t.Fatalf("wrong rotated close claim did not surface a structural violation: %#v", runB)
+		}
+	})
+}
+
+func TestAnalyzeRecordAfterCloseIsBroken(t *testing.T) {
+	t.Parallel()
+
+	b := newChainBuilder(t)
+	actionID := "action-after-close"
+	chain := []receipt.Receipt{
+		b.open(),
+		b.close(0, 1),
+		b.intent(actionID),
+		b.outcome(actionID),
+	}
+
+	report := analyzeBuilt(chain, b.keyHex)
+	run := requireOneRun(t, report, StatusBroken, ReasonChainBroken)
+	if run.StructuralViolation != "record observed after session_close" {
+		t.Fatalf("structural_violation = %q, want record observed after session_close: %#v", run.StructuralViolation, run)
+	}
+}
+
+func TestAnalyzePostCloseGuardIsScopedToRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("new_run_after_prior_close_is_allowed", func(t *testing.T) {
+		t.Parallel()
+		b := newChainBuilder(t)
+		chain := []receipt.Receipt{
+			b.openFor("run-a", "open-a"),
+			b.closeFor("run-a", "open-a", 0, 1),
+			b.openFor("run-b", "open-b"),
+			b.heartbeatFor("run-b", "open-b", 1, 0, 2),
+			b.closeFor("run-b", "open-b", 0, 3),
+		}
+
+		report := analyzeBuilt(chain, b.keyHex)
+		if report.Status != StatusLimited || report.Reason != ReasonBoundedClosed {
+			t.Fatalf("second run after close = %s/%s, want LIMITED/bounded_closed: %#v", report.Status, report.Reason, report)
+		}
+		requireRun(t, report, "run-a", StatusLimited, ReasonBoundedClosed)
+		requireRun(t, report, "run-b", StatusLimited, ReasonBoundedClosed)
+	})
+
+	t.Run("same_run_heartbeat_after_close_is_broken", func(t *testing.T) {
+		t.Parallel()
+		b := newChainBuilder(t)
+		chain := []receipt.Receipt{
+			b.open(),
+			b.close(0, 1),
+			b.heartbeat(1, 0, 2),
+		}
+
+		report := analyzeBuilt(chain, b.keyHex)
+		run := requireOneRun(t, report, StatusBroken, ReasonChainBroken)
+		if run.StructuralViolation != "record observed after session_close" {
+			t.Fatalf("structural_violation = %q, want post-close guard: %#v", run.StructuralViolation, run)
+		}
+	})
+
+	t.Run("same_run_second_close_is_broken", func(t *testing.T) {
+		t.Parallel()
+		b := newChainBuilder(t)
+		chain := []receipt.Receipt{
+			b.open(),
+			b.close(0, 1),
+			b.close(0, 2),
+		}
+
+		report := analyzeBuilt(chain, b.keyHex)
+		run := requireOneRun(t, report, StatusBroken, ReasonChainBroken)
+		if run.StructuralViolation != "record observed after session_close" {
+			t.Fatalf("structural_violation = %q, want post-close guard: %#v", run.StructuralViolation, run)
+		}
+	})
+}
+
+func TestAnalyzeDurabilityCountersArePerRun(t *testing.T) {
+	t.Parallel()
+
+	b := newChainBuilder(t)
+	chain := []receipt.Receipt{
+		b.openFor("run-a", "open-a"),
+		b.heartbeatFor("run-a", "open-a", 1, 5, 9),
+		b.closeFor("run-a", "open-a", 5, 9),
+		b.openFor("run-b", "open-b"),
+		b.heartbeatFor("run-b", "open-b", 1, 0, 0),
+		b.closeFor("run-b", "open-b", 0, 1),
+	}
+
+	report := analyzeBuilt(chain, b.keyHex)
+	if report.Status != StatusLimited || report.Reason != ReasonBoundedClosed {
+		t.Fatalf("durability counter reset across run = %s/%s, want LIMITED/bounded_closed: %#v",
+			report.Status, report.Reason, report)
+	}
+	runB := requireRun(t, report, "run-b", StatusLimited, ReasonBoundedClosed)
+	if runB.DurabilityCounterDrop || !runB.DurabilityMonotonic {
+		t.Fatalf("run-b durability should be evaluated independently: %#v", runB)
+	}
+}
+
+func TestAnalyzeForgedNoOpenIsBroken(t *testing.T) {
+	t.Parallel()
+	b := newChainBuilder(t)
+	chain := []receipt.Receipt{
+		b.heartbeat(1, 0, 1),
+		b.close(0, 1),
+	}
+	chain[0].ActionRecord.Target = "https://api.vendor.example/forged-no-open"
+
+	res := receipt.VerifyChain(chain, b.keyHex)
+	if res.Valid {
+		t.Fatal("fixture should be rejected")
+	}
+	report := Analyze(chain, res)
+	if report.Status != StatusBroken || report.Reason != ReasonChainBroken {
+		t.Fatalf("forged no-open = %s/%s, want BROKEN/chain_broken: %#v", report.Status, report.Reason, report)
+	}
+	if report.SignaturesVerified {
+		t.Fatalf("analysis report should not claim signatures verified: %#v", report)
+	}
+}
+
+func TestAnalyzeDoesNotDowngradeIntegrityTrustOrLifecycleFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(t *testing.T) ([]receipt.Receipt, string){
+		"forged_first_receipt": func(t *testing.T) ([]receipt.Receipt, string) {
+			t.Helper()
+			b := newChainBuilder(t)
+			chain := []receipt.Receipt{b.open()}
+			chain[0].ActionRecord.Target = "https://api.vendor.example/forged-first"
+			return chain, b.keyHex
+		},
+		"forged_mid_chain_receipt": func(t *testing.T) ([]receipt.Receipt, string) {
+			t.Helper()
+			b := newChainBuilder(t)
+			chain := []receipt.Receipt{
+				b.open(),
+				b.intent("action-forged-mid"),
+				b.close(0, 1),
+			}
+			chain[1].ActionRecord.Target = "https://api.vendor.example/forged-mid"
+			return chain, b.keyHex
+		},
+		"forged_heartbeat": func(t *testing.T) ([]receipt.Receipt, string) {
+			t.Helper()
+			b := newChainBuilder(t)
+			chain := []receipt.Receipt{
+				b.open(),
+				b.heartbeat(1, 0, 1),
+				b.close(0, 1),
+			}
+			chain[1].ActionRecord.Target = "https://api.vendor.example/forged-heartbeat"
+			return chain, b.keyHex
+		},
+		"forged_close": func(t *testing.T) ([]receipt.Receipt, string) {
+			t.Helper()
+			b := newChainBuilder(t)
+			chain := []receipt.Receipt{
+				b.open(),
+				b.close(0, 1),
+			}
+			chain[1].ActionRecord.Target = "https://api.vendor.example/forged-close"
+			return chain, b.keyHex
+		},
+		"duplicate_open_lifecycle": func(t *testing.T) ([]receipt.Receipt, string) {
+			t.Helper()
+			b := newChainBuilder(t)
+			return []receipt.Receipt{
+				b.open(),
+				b.open(),
+			}, b.keyHex
+		},
+		"wrong_open_nonce_lifecycle": func(t *testing.T) ([]receipt.Receipt, string) {
+			t.Helper()
+			b := newChainBuilder(t)
+			return []receipt.Receipt{
+				b.open(),
+				b.heartbeatFor(testRunNonce, "wrong-open", 1, 0, 1),
+			}, b.keyHex
+		},
+	}
+
+	for name, build := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			chain, keyHex := build(t)
+			report := Analyze(chain, receipt.VerifyChain(chain, keyHex))
+			if report.Status != StatusBroken || report.Reason != ReasonChainBroken {
+				t.Fatalf("%s = %s/%s, want BROKEN/chain_broken: %#v", name, report.Status, report.Reason, report)
+			}
+		})
+	}
+}
+
+func TestAnalyzeOnlyMissingOpenIntegrityFailureDowngrades(t *testing.T) {
+	t.Parallel()
+
+	b := newChainBuilder(t)
+	chain := []receipt.Receipt{
+		b.heartbeat(1, 0, 1),
+	}
+
+	tests := map[string]struct {
+		chainResult receipt.ChainResult
+		wantStatus  Status
+		wantReason  Reason
+	}{
+		"integrity": {
+			chainResult: receipt.ChainResult{FailureKind: receipt.ChainFailureIntegrity, Error: "integrity failure"},
+			wantStatus:  StatusBroken,
+			wantReason:  ReasonChainBroken,
+		},
+		"trust": {
+			chainResult: receipt.ChainResult{FailureKind: receipt.ChainFailureTrust, Error: "trust failure"},
+			wantStatus:  StatusBroken,
+			wantReason:  ReasonChainBroken,
+		},
+		"lifecycle_not_missing_open": {
+			chainResult: receipt.ChainResult{FailureKind: receipt.ChainFailureLifecycle, IntegrityVerified: true, Error: "lifecycle failure"},
+			wantStatus:  StatusBroken,
+			wantReason:  ReasonChainBroken,
+		},
+		"missing_open_without_integrity": {
+			chainResult: receipt.ChainResult{FailureKind: receipt.ChainFailureLifecycleOpen, Error: "missing open without integrity"},
+			wantStatus:  StatusBroken,
+			wantReason:  ReasonChainBroken,
+		},
+		"missing_open_with_integrity": {
+			chainResult: receipt.ChainResult{FailureKind: receipt.ChainFailureLifecycleOpen, IntegrityVerified: true, Error: "missing open"},
+			wantStatus:  StatusUnverified,
+			wantReason:  ReasonNoOpen,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			report := Analyze(chain, tc.chainResult)
+			if report.Status != tc.wantStatus || report.Reason != tc.wantReason {
+				t.Fatalf("%s = %s/%s, want %s/%s: %#v", name, report.Status, report.Reason, tc.wantStatus, tc.wantReason, report)
+			}
+		})
+	}
+}
+
+func TestAnalyzeOutcomeWithoutIntentIsBroken(t *testing.T) {
+	t.Parallel()
+	b := newChainBuilder(t)
+	chain := []receipt.Receipt{
+		b.open(),
+		b.outcome("action-orphan-outcome"),
+		b.close(0, 1),
+	}
+	report := analyzeBuilt(chain, b.keyHex)
+	run := requireOneRun(t, report, StatusBroken, ReasonChainBroken)
+	if run.OutcomeWithoutIntent != 1 {
+		t.Fatalf("outcome_without_intent = %d, want 1: %#v", run.OutcomeWithoutIntent, run)
+	}
+	if run.StructuralViolation != "outcome without matching intent" {
+		t.Fatalf("structural_violation = %q", run.StructuralViolation)
+	}
+}
+
+func TestAnalyzeNoLifecycleAndNoReceiptsAreUnverified(t *testing.T) {
+	t.Parallel()
+	empty := Analyze(nil, receipt.VerifyChain(nil, ""))
+	if empty.Status != StatusUnverified || empty.Reason != ReasonNoReceipts {
+		t.Fatalf("empty = %s/%s, want UNVERIFIED/no_receipts", empty.Status, empty.Reason)
+	}
+
+	b := newChainBuilder(t)
+	chain := []receipt.Receipt{b.legacyAction()}
+	report := analyzeBuilt(chain, b.keyHex)
+	if report.Status != StatusUnverified || report.Reason != ReasonNoLifecycle {
+		t.Fatalf("legacy = %s/%s, want UNVERIFIED/no_lifecycle", report.Status, report.Reason)
+	}
+}
+
+func TestAnalyzeBrokenChainAndDurabilityDrop(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tampered_chain", func(t *testing.T) {
+		t.Parallel()
+		b := newChainBuilder(t)
+		chain := []receipt.Receipt{
+			b.open(),
+			b.intent("action-tampered"),
+			b.outcome("action-tampered"),
+		}
+		chain[1].ActionRecord.Target = "https://api.vendor.example/tampered"
+		report := Analyze(chain, receipt.VerifyChain(chain, b.keyHex))
+		if report.Status != StatusBroken || report.Reason != ReasonChainBroken {
+			t.Fatalf("tampered = %s/%s, want BROKEN/chain_broken: %#v", report.Status, report.Reason, report)
+		}
+	})
+
+	t.Run("durability_decrease", func(t *testing.T) {
+		t.Parallel()
+		b := newChainBuilder(t)
+		chain := []receipt.Receipt{
+			b.open(),
+			b.heartbeat(1, 2, 2),
+			b.close(1, 2),
+		}
+		report := analyzeBuilt(chain, b.keyHex)
+		run := requireOneRun(t, report, StatusBroken, ReasonChainBroken)
+		if !run.DurabilityCounterDrop || run.DurabilityMonotonic {
+			t.Fatalf("durability drop not surfaced: %#v", run)
+		}
+	})
+}
+
+func TestAnalyzeStatusDomainIsNeverGreen(t *testing.T) {
+	t.Parallel()
+	allowed := map[Status]bool{
+		StatusLimited:    true,
+		StatusBroken:     true,
+		StatusUnverified: true,
+	}
+	for _, status := range []Status{StatusLimited, StatusBroken, StatusUnverified} {
+		if !allowedStatus(status, allowed) {
+			t.Fatalf("unexpected status domain member %q", status)
+		}
+		for _, forbidden := range []Status{"COMPLETE", "PASS", "OK"} {
+			if status == forbidden {
+				t.Fatalf("green status constant %q is forbidden", status)
+			}
+		}
+	}
+
+	tests := map[string]func(t *testing.T) Report{
+		"empty": func(t *testing.T) Report {
+			t.Helper()
+			return Analyze(nil, receipt.VerifyChain(nil, ""))
+		},
+		"single_receipt_no_lifecycle": func(t *testing.T) Report {
+			t.Helper()
+			b := newChainBuilder(t)
+			return analyzeBuilt([]receipt.Receipt{b.legacyAction()}, b.keyHex)
+		},
+		"clean_closed": func(t *testing.T) Report {
+			t.Helper()
+			b := newChainBuilder(t)
+			actionID := "action-never-green"
+			return analyzeBuilt([]receipt.Receipt{
+				b.open(),
+				b.intent(actionID),
+				b.outcome(actionID),
+				b.heartbeat(1, 0, 1),
+				b.close(0, 1),
+			}, b.keyHex)
+		},
+		"multi_run_rollup": func(t *testing.T) Report {
+			t.Helper()
+			b := newChainBuilder(t)
+			return analyzeBuilt([]receipt.Receipt{
+				b.openFor("run-a", "open-a"),
+				b.actionFor("run-a", "action-a", receipt.DecisionPhaseIntent),
+				b.actionFor("run-a", "action-a", receipt.DecisionPhaseOutcome),
+				b.closeFor("run-a", "open-a", 0, 1),
+				b.openFor("run-b", "open-b"),
+				b.actionFor("run-b", "action-b", receipt.DecisionPhaseIntent),
+				b.closeFor("run-b", "open-b", 0, 2),
+			}, b.keyHex)
+		},
+		"duplicate_open": func(t *testing.T) Report {
+			t.Helper()
+			b := newChainBuilder(t)
+			chain := []receipt.Receipt{
+				b.open(),
+				b.open(),
+			}
+			return Analyze(chain, receipt.VerifyChain(chain, b.keyHex))
+		},
+		"contradictory_open_nonce": func(t *testing.T) Report {
+			t.Helper()
+			b := newChainBuilder(t)
+			return analyzeBuilt([]receipt.Receipt{
+				b.open(),
+				b.heartbeatFor(testRunNonce, "other-open", 1, 0, 1),
+			}, b.keyHex)
+		},
+		"decreasing_durability_counter": func(t *testing.T) Report {
+			t.Helper()
+			b := newChainBuilder(t)
+			return analyzeBuilt([]receipt.Receipt{
+				b.open(),
+				b.heartbeat(1, 3, 3),
+				b.close(2, 2),
+			}, b.keyHex)
+		},
+		"only_outcomes": func(t *testing.T) Report {
+			t.Helper()
+			b := newChainBuilder(t)
+			return analyzeBuilt([]receipt.Receipt{
+				b.open(),
+				b.outcome("action-only-outcome"),
+				b.close(0, 1),
+			}, b.keyHex)
+		},
+		"only_heartbeats": func(t *testing.T) Report {
+			t.Helper()
+			b := newChainBuilder(t)
+			chain := []receipt.Receipt{
+				b.heartbeat(1, 0, 1),
+			}
+			return Analyze(chain, receipt.VerifyChain(chain, b.keyHex))
+		},
+		"missing_run_nonce_bucket": func(t *testing.T) Report {
+			t.Helper()
+			b := newChainBuilder(t)
+			chain := []receipt.Receipt{
+				b.sign(receipt.ActionRecord{
+					ActionType: receipt.ActionUnclassified,
+					Target:     "pipelock://session/heartbeat",
+					Transport:  "session_control",
+					SessionControl: &receipt.SessionControl{
+						Kind: receipt.SessionControlHeartbeat,
+						Heartbeat: &receipt.SessionHeartbeat{
+							RunNonce:         testRunNonce,
+							OpenNonce:        testOpenNonce,
+							Beat:             1,
+							HeartbeatTime:    b.base.Format(time.RFC3339Nano),
+							DurabilityBlocks: 1,
+						},
+					},
+				}),
+			}
+			return analyzeBuilt(chain, b.keyHex)
+		},
+		"huge_chain": func(t *testing.T) Report {
+			t.Helper()
+			b := newChainBuilder(t)
+			chain := []receipt.Receipt{b.open()}
+			for i := 0; i < 256; i++ {
+				actionID := receipt.NewActionID()
+				chain = append(chain, b.intent(actionID), b.outcome(actionID))
+			}
+			chain = append(chain, b.heartbeat(1, 0, 1), b.close(0, 2))
+			return analyzeBuilt(chain, b.keyHex)
+		},
+	}
+
+	for name, build := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			report := build(t)
+			assertReportStatusDomain(t, report, allowed)
+			if report.Status == "COMPLETE" || report.Status == "PASS" || report.Status == "OK" {
+				t.Fatalf("green top-line status escaped: %#v", report)
+			}
+			if name == "clean_closed" && (report.Status != StatusLimited || report.Reason != ReasonBoundedClosed) {
+				t.Fatalf("clean run = %s/%s, want LIMITED/bounded_closed", report.Status, report.Reason)
+			}
+		})
+	}
+}
+
+func allowedStatus(status Status, allowed map[Status]bool) bool {
+	return allowed[status]
+}
+
+func assertReportStatusDomain(t *testing.T, report Report, allowed map[Status]bool) {
+	t.Helper()
+	if !allowedStatus(report.Status, allowed) {
+		t.Fatalf("report status %q outside allowed domain: %#v", report.Status, report)
+	}
+	for _, run := range report.Runs {
+		if !allowedStatus(run.Status, allowed) {
+			t.Fatalf("run status %q outside allowed domain: %#v", run.Status, run)
+		}
+	}
+}

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -844,7 +844,30 @@ func ForwardScannedInput(
 			// Track request ID immediately before forwarding so response-side
 			// can validate without leaving stale state when a required
 			// receipt fails before the request is written.
-			tracker.Track(verdict.ID)
+			if opts.requireReceipts() && actionID != "" {
+				outcomeReceipt := opts.withReceiptPolicyHash(receipt.EmitOpts{
+					ActionID:            actionID,
+					Verdict:             config.ActionAllow,
+					Transport:           opts.Transport,
+					Target:              receiptTarget,
+					MCPMethod:           verdict.Method,
+					ToolName:            toolCallName,
+					SessionTaintLevel:   taintDecision.Risk.Level.String(),
+					SessionContaminated: taintDecision.Risk.Contaminated,
+					RecentTaintSources:  taintDecision.Risk.Sources,
+					SessionTaskID:       taintDecision.Task.CurrentTaskID,
+					SessionTaskLabel:    taintDecision.Task.CurrentTaskLabel,
+					AuthorityKind:       taintDecision.Authority.String(),
+					TaintDecision:       taintDecision.Result.Decision.String(),
+					TaintDecisionReason: taintDecision.Result.Reason,
+					TaskOverrideApplied: taintDecision.TaskOverrideApplied,
+					PolicyHash:          policyHash,
+				})
+				outcomeReceipt = mcpWithContractReceipt(outcomeReceipt, contractGate)
+				tracker.TrackOutcome(verdict.ID, TrackedRequestOutcome{Receipt: outcomeReceipt})
+			} else {
+				tracker.Track(verdict.ID)
+			}
 			if err := forwardMessage(fwdLine); err != nil {
 				_, _ = fmt.Fprintf(logW, "pipelock: input forward error: %v\n", err)
 				return

--- a/internal/mcp/input_require_receipts_test.go
+++ b/internal/mcp/input_require_receipts_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
 
 // runStdioToolCall drives ForwardScannedInput for a single clean tools/call
@@ -152,6 +153,168 @@ func TestForwardScannedInput_A2ARequireReceiptsEmitsAllowReceipt(t *testing.T) {
 	}
 	if record.Target != "SendMessage" {
 		t.Fatalf("A2A allow receipt target = %q, want SendMessage", record.Target)
+	}
+}
+
+func TestForwardScanned_MCPRequireReceiptsEmitsIntentOutcomePair(t *testing.T) {
+	emitter, rec, dir, _ := newReceiptTestHarness(t)
+	intent := receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: transportMCPStdio,
+		Target:    "read_file",
+		MCPMethod: methodToolsCall,
+		ToolName:  "read_file",
+	}
+	if _, err := EmitMCPDecision(emitter, nil, nil, MCPDecision{
+		Receipt:        intent,
+		RequireReceipt: true,
+	}); err != nil {
+		t.Fatalf("EmitMCPDecision intent: %v", err)
+	}
+	tracker := NewRequestTracker()
+	tracker.TrackOutcome([]byte(`1`), TrackedRequestOutcome{Receipt: intent})
+	response := `{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}` + "\n"
+	var out, logBuf bytes.Buffer
+	found, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(response)),
+		transport.NewStdioWriter(&out),
+		&logBuf,
+		tracker,
+		MCPProxyOpts{
+			Scanner:        testInputScanner(t),
+			Transport:      transportMCPStdio,
+			ReceiptEmitter: emitter,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if found {
+		t.Fatal("ForwardScanned found injection on clean response")
+	}
+	if !strings.Contains(out.String(), `"result"`) {
+		t.Fatalf("forwarded response = %q, want result", out.String())
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	receipts := readActionReceipts(t, dir)
+	if len(receipts) != 2 {
+		t.Fatalf("receipt count = %d, want intent/outcome pair", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("intent phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+	if receipts[1].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
+		t.Fatalf("outcome phase = %q, want %q", receipts[1].ActionRecord.DecisionPhase, receipt.DecisionPhaseOutcome)
+	}
+	if receipts[1].ActionRecord.ActionID != receipts[0].ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %s, want %s", receipts[1].ActionRecord.ActionID, receipts[0].ActionRecord.ActionID)
+	}
+	if !strings.Contains(receipts[1].ActionRecord.Pattern, "status=result") {
+		t.Fatalf("outcome pattern = %q, want status=result", receipts[1].ActionRecord.Pattern)
+	}
+}
+
+func TestEmitPendingTimeoutResponses_MCPRequireReceiptsEmitsOutcome(t *testing.T) {
+	emitter, rec, dir, _ := newReceiptTestHarness(t)
+	intent := receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: transportMCPStdio,
+		Target:    "read_file",
+		MCPMethod: methodToolsCall,
+		ToolName:  "read_file",
+	}
+	if _, err := EmitMCPDecision(emitter, nil, nil, MCPDecision{
+		Receipt:        intent,
+		RequireReceipt: true,
+	}); err != nil {
+		t.Fatalf("EmitMCPDecision intent: %v", err)
+	}
+	tracker := NewRequestTracker()
+	tracker.TrackOutcome([]byte(`1`), TrackedRequestOutcome{Receipt: intent})
+	var out, logBuf bytes.Buffer
+	emitPendingTimeoutResponses(transport.NewStdioWriter(&out), &logBuf, tracker, MCPProxyOpts{
+		ReceiptEmitter: emitter,
+		Transport:      transportMCPStdio,
+	})
+	if !strings.Contains(out.String(), `"code":-32000`) {
+		t.Fatalf("timeout response = %q, want JSON-RPC timeout error", out.String())
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	receipts := readActionReceipts(t, dir)
+	if len(receipts) != 2 {
+		t.Fatalf("receipt count = %d, want intent/outcome pair", len(receipts))
+	}
+	if receipts[1].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
+		t.Fatalf("outcome phase = %q, want %q", receipts[1].ActionRecord.DecisionPhase, receipt.DecisionPhaseOutcome)
+	}
+	if receipts[1].ActionRecord.ActionID != receipts[0].ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %s, want %s", receipts[1].ActionRecord.ActionID, receipts[0].ActionRecord.ActionID)
+	}
+	for _, want := range []string{"status=error", "reason=response_timeout"} {
+		if !strings.Contains(receipts[1].ActionRecord.Pattern, want) {
+			t.Fatalf("outcome pattern = %q, want %s", receipts[1].ActionRecord.Pattern, want)
+		}
+	}
+}
+
+func TestForwardScanned_MCPRequireReceiptsOutcomeEmitFailureDoesNotFailResponse(t *testing.T) {
+	emitter, rec, dir, _ := newReceiptTestHarness(t)
+	intent := receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: transportMCPStdio,
+		Target:    "read_file",
+		MCPMethod: methodToolsCall,
+		ToolName:  "read_file",
+	}
+	if _, err := EmitMCPDecision(emitter, nil, nil, MCPDecision{
+		Receipt:        intent,
+		RequireReceipt: true,
+	}); err != nil {
+		t.Fatalf("EmitMCPDecision intent: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	tracker := NewRequestTracker()
+	tracker.TrackOutcome([]byte(`1`), TrackedRequestOutcome{Receipt: intent})
+	response := `{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}` + "\n"
+	var out, logBuf bytes.Buffer
+	found, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(response)),
+		transport.NewStdioWriter(&out),
+		&logBuf,
+		tracker,
+		MCPProxyOpts{
+			Scanner:        testInputScanner(t),
+			Transport:      transportMCPStdio,
+			ReceiptEmitter: emitter,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if found {
+		t.Fatal("ForwardScanned found injection on clean response")
+	}
+	if !strings.Contains(out.String(), `"result"`) {
+		t.Fatalf("forwarded response = %q, want result", out.String())
+	}
+	receipts := readActionReceipts(t, dir)
+	if len(receipts) != 1 {
+		t.Fatalf("receipt count after outcome failure = %d, want durable intent only", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("receipt phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+	if !strings.Contains(logBuf.String(), "receipt emission failed") {
+		t.Fatalf("log = %q, want outcome emit failure", logBuf.String())
 	}
 }
 

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -28,16 +28,45 @@ func emitRequestScopedTimeout(
 	tracker *RequestTracker,
 	id json.RawMessage,
 	logMessage string,
+	opts MCPProxyOpts,
 ) {
 	if c, ok := respReader.(io.Closer); ok {
 		_ = c.Close()
 	}
-	if len(id) != 0 && (tracker == nil || tracker.Validate(id)) {
-		if wErr := writer.WriteMessage(timeoutErrorResponse(id)); wErr != nil {
-			_, _ = fmt.Fprintf(logW, "pipelock: failed to send timeout response: %v\n", wErr)
+	if len(id) != 0 {
+		outcome, ok := consumeTrackedRequestOutcome(tracker, id)
+		if ok {
+			resp := timeoutErrorResponse(id)
+			if wErr := writer.WriteMessage(resp); wErr != nil {
+				_, _ = fmt.Fprintf(logW, "pipelock: failed to send timeout response: %v\n", wErr)
+			}
+			emitMCPOutcomeReceipt(opts.receiptEmitter(), opts.v2ReceiptEmitter(), logW, outcome.Receipt, "error", int64(len(resp)), "response_timeout")
 		}
 	}
 	_, _ = fmt.Fprintln(logW, logMessage)
+}
+
+func emitTrackedTerminalOutcome(logW io.Writer, tracker *RequestTracker, id json.RawMessage, resp []byte, reason string, opts MCPProxyOpts) {
+	outcome, ok := consumeTrackedRequestOutcome(tracker, id)
+	if !ok {
+		return
+	}
+	emitMCPOutcomeReceipt(opts.receiptEmitter(), opts.v2ReceiptEmitter(), logW, outcome.Receipt, mcpResponseStatus(resp), int64(len(resp)), reason)
+}
+
+func emitTrackedIncompleteOutcome(logW io.Writer, tracker *RequestTracker, id json.RawMessage, reason string, opts MCPProxyOpts) {
+	outcome, ok := consumeTrackedRequestOutcome(tracker, id)
+	if !ok {
+		return
+	}
+	emitMCPOutcomeReceipt(opts.receiptEmitter(), opts.v2ReceiptEmitter(), logW, outcome.Receipt, "incomplete", -1, reason)
+}
+
+func consumeTrackedRequestOutcome(tracker *RequestTracker, id json.RawMessage) (TrackedRequestOutcome, bool) {
+	if tracker == nil {
+		return TrackedRequestOutcome{}, true
+	}
+	return tracker.Consume(id)
 }
 
 // RunHTTPProxy bridges stdio (client) to an upstream HTTP MCP server with
@@ -251,6 +280,7 @@ func RunHTTPProxy(
 								tracker,
 								deferredReq.ID,
 								"pipelock: upstream response timeout on deferred request; failed request closed",
+								fwdOpts,
 							)
 						} else if scanErr != nil {
 							_, _ = fmt.Fprintf(safeLogW, "pipelock: scan error: %v\n", scanErr)
@@ -301,7 +331,11 @@ func RunHTTPProxy(
 		// Only track requests (have "method"), not client responses to
 		// server-initiated calls, to prevent tracker pollution.
 		if isRequest(msg) {
-			tracker.Track(frame.ID)
+			if decision.Outcome.Receipt.ActionID != "" {
+				tracker.TrackOutcome(frame.ID, decision.Outcome)
+			} else {
+				tracker.Track(frame.ID)
+			}
 		}
 
 		if gate, gateErr := evaluateMCPUpstreamGate(ctx, upstreamURL, opts); gateErr != nil {
@@ -315,6 +349,7 @@ func RunHTTPProxy(
 			if wErr := safeClientOut.WriteMessage(errResp); wErr != nil {
 				_, _ = fmt.Fprintf(safeLogW, "pipelock: failed to send contract response: %v\n", wErr)
 			}
+			emitTrackedTerminalOutcome(safeLogW, tracker, frame.ID, errResp, "upstream_contract", fwdOpts)
 			continue
 		} else if gate.Verdict == config.ActionBlock {
 			if gate.WinningSource == contractruntime.WinningSourceScanner {
@@ -329,6 +364,7 @@ func RunHTTPProxy(
 			if wErr := safeClientOut.WriteMessage(errResp); wErr != nil {
 				_, _ = fmt.Fprintf(safeLogW, "pipelock: failed to send contract response: %v\n", wErr)
 			}
+			emitTrackedTerminalOutcome(safeLogW, tracker, frame.ID, errResp, "upstream_contract", fwdOpts)
 			continue
 		}
 
@@ -348,6 +384,7 @@ func RunHTTPProxy(
 			if wErr := safeClientOut.WriteMessage(errResp); wErr != nil {
 				_, _ = fmt.Fprintf(safeLogW, "pipelock: failed to send error response: %v\n", wErr)
 			}
+			emitTrackedTerminalOutcome(safeLogW, tracker, frame.ID, errResp, "upstream_error", fwdOpts)
 			continue
 		}
 
@@ -363,12 +400,14 @@ func RunHTTPProxy(
 				tracker,
 				frame.ID,
 				"pipelock: upstream response timeout; failed request closed, session continues",
+				fwdOpts,
 			)
 			lastScanErr = scanErr
 			continue
 		}
 		if scanErr != nil {
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: scan error: %v\n", scanErr)
+			emitTrackedIncompleteOutcome(safeLogW, tracker, frame.ID, "scan_error", fwdOpts)
 			lastScanErr = scanErr
 		} else if !foundInjection {
 			commitMCPToolCall(baselineMetricsRecorder(fwdOpts, rec), mcpFrameBaselineIdentity(frame))
@@ -393,6 +432,7 @@ func RunHTTPProxy(
 	// Stop GET stream and wait for it to finish.
 	cancel()
 	wg.Wait()
+	emitPendingIncompleteOutcomes(safeLogW, tracker, fwdOpts, "upstream_closed")
 
 	return lastScanErr
 }

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -28,6 +28,7 @@ type httpInputDecision struct {
 	Blocked        *BlockedRequest
 	Deferred       *DeferredRequest
 	ForwardMessage []byte
+	Outcome        TrackedRequestOutcome
 }
 
 const redirectResultRedirected = "redirected"
@@ -189,6 +190,36 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 				ErrorMessage:   "pipelock: receipt emission failed",
 				ErrorData:      mcpBlockReasonData(blockreason.ReceiptEmissionFailed),
 			}
+			return
+		}
+		if requiredReceipt && result.Blocked == nil && receipt.NormalizeVerdict(emitVerdict) == config.ActionAllow {
+			outcomeReceipt := opts.withReceiptPolicyHash(receipt.EmitOpts{
+				ActionID:            emitActionID,
+				Verdict:             emitVerdict,
+				Layer:               receiptLayer,
+				Pattern:             receiptPattern,
+				Severity:            receiptSeverity,
+				RedactionProfile:    redactionCfg.Profile,
+				RedactionReport:     redactionReport,
+				Transport:           opts.Transport,
+				Target:              emitTarget,
+				MCPMethod:           mcpMethod,
+				ToolName:            emitTarget,
+				SessionTaintLevel:   taintEval.Risk.Level.String(),
+				SessionContaminated: taintEval.Risk.Contaminated,
+				RecentTaintSources:  taintEval.Risk.Sources,
+				SessionTaskID:       taintEval.Task.CurrentTaskID,
+				SessionTaskLabel:    taintEval.Task.CurrentTaskLabel,
+				AuthorityKind:       taintEval.Authority.String(),
+				TaintDecision:       taintEval.Result.Decision.String(),
+				TaintDecisionReason: taintEval.Result.Reason,
+				TaskOverrideApplied: taintEval.TaskOverrideApplied,
+				PolicyHash:          opts.receiptPolicyHash(),
+			})
+			if receiptContractGate != nil {
+				outcomeReceipt = mcpWithContractReceipt(outcomeReceipt, *receiptContractGate)
+			}
+			result.Outcome = TrackedRequestOutcome{Receipt: outcomeReceipt}
 		}
 	}()
 

--- a/internal/mcp/pipeline_decision.go
+++ b/internal/mcp/pipeline_decision.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
@@ -136,6 +137,37 @@ func EmitMCPDecision(
 	}
 
 	return outbound, err
+}
+
+func emitMCPOutcomeReceipt(
+	receiptEmitter *receipt.Emitter,
+	v2Emitter *proxydecision.Emitter,
+	logW io.Writer,
+	opts receipt.EmitOpts,
+	status string,
+	bytesTransferred int64,
+	reason string,
+) {
+	if receiptEmitter == nil || opts.ActionID == "" {
+		return
+	}
+	if status == "" {
+		status = "unknown"
+	}
+	if reason == "" {
+		reason = "complete"
+	}
+	bytesValue := "unknown"
+	if bytesTransferred >= 0 {
+		bytesValue = fmt.Sprintf("%d", bytesTransferred)
+	}
+	opts.DecisionPhase = receipt.DecisionPhaseOutcome
+	opts.Verdict = config.ActionAllow
+	opts.Layer = "outcome"
+	opts.Pattern = fmt.Sprintf("status=%s bytes=%s reason=%s", status, bytesValue, reason)
+	if _, err := EmitMCPDecision(receiptEmitter, v2Emitter, nil, MCPDecision{Receipt: opts}); err != nil {
+		logReceiptEmitFailure(logW, err, false, config.ActionAllow)
+	}
 }
 
 // mcpV2DecisionFromReceipt derives the v2 proxy_decision input from the v1

--- a/internal/mcp/pipeline_decision.go
+++ b/internal/mcp/pipeline_decision.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
@@ -95,16 +96,22 @@ func EmitMCPDecision(
 
 	v1Emitted := false
 	receiptRequired := d.RequireReceipt
+	durableIntent := receiptRequired && receipt.NormalizeVerdict(d.Receipt.Verdict) == config.ActionAllow
 	if receiptRequired && d.Receipt.ActionID == "" {
 		err = fmt.Errorf("empty action id: %w", ErrReceiptRequired)
 	} else if receiptRequired && receiptEmitter == nil {
 		err = fmt.Errorf("%w: emitter unavailable", ErrReceiptRequired)
 	} else if receiptEmitter != nil && d.Receipt.ActionID != "" {
-		err = receiptEmitter.Emit(d.Receipt)
+		if durableIntent {
+			d.Receipt.DecisionPhase = receipt.DecisionPhaseIntent
+			err = receiptEmitter.EmitDurable(d.Receipt)
+		} else {
+			err = receiptEmitter.Emit(d.Receipt)
+		}
 		v1Emitted = err == nil
-		// Intentional: continue to envelope injection even on receipt
-		// error. The two stages are independent at today's callsites
-		// and coupling them here would break parity.
+		// Optional receipt errors continue to envelope injection; the
+		// RequireReceipt gate below upgrades errors to fail-closed before
+		// envelope mutation.
 	}
 	if receiptRequired && err != nil && !errors.Is(err, ErrReceiptRequired) {
 		err = fmt.Errorf("%w: %w", ErrReceiptRequired, err)

--- a/internal/mcp/pipeline_decision_test.go
+++ b/internal/mcp/pipeline_decision_test.go
@@ -333,6 +333,88 @@ func TestEmitMCPDecision_ReceiptAndEnvelope(t *testing.T) {
 	}
 }
 
+func TestEmitMCPDecision_RequiredAllowEmitsDurableIntentBeforeEnvelope(t *testing.T) {
+	recEmitter, _, dir, _ := newReceiptTestHarness(t)
+	envEmitter := envelope.NewEmitter(envelope.EmitterConfig{ConfigHash: "policy-h"})
+
+	inbound := []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"fetch","arguments":{}}}`)
+	out, err := EmitMCPDecision(recEmitter, nil, envEmitter, MCPDecision{
+		Receipt: receipt.EmitOpts{
+			ActionID:  "required-allow-1",
+			Verdict:   config.ActionAllow,
+			Transport: transportMCPStdio,
+			Target:    "fetch",
+			MCPMethod: methodToolsCall,
+			ToolName:  "fetch",
+		},
+		Envelope: &envelope.BuildOpts{
+			ActionID: "required-allow-1",
+			Action:   "tool_call",
+			Verdict:  config.ActionAllow,
+		},
+		InboundMsg:     inbound,
+		RequireReceipt: true,
+	})
+	if err != nil {
+		t.Fatalf("EmitMCPDecision: %v", err)
+	}
+	if bytes.Equal(out, inbound) {
+		t.Fatal("envelope injection did not rewrite the message")
+	}
+
+	receipts := decisionReceiptLogFor(t, dir)
+	if len(receipts) != 1 {
+		t.Fatalf("expected 1 receipt, got %d", len(receipts))
+	}
+	record := receipts[0].ActionRecord
+	if record.ActionID != "required-allow-1" {
+		t.Fatalf("action_id = %q, want required-allow-1", record.ActionID)
+	}
+	if record.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("decision_phase = %q, want %q", record.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+}
+
+func TestEmitMCPDecision_RequiredAllowSyncFailureBlocksBeforeEnvelope(t *testing.T) {
+	recEmitter, rec, _, _ := newReceiptTestHarness(t)
+	envEmitter := envelope.NewEmitter(envelope.EmitterConfig{ConfigHash: "policy-h"})
+	syncErr := errors.New("injected durable sync failure")
+	rec.SetSyncForTest(func(*os.File) error {
+		return syncErr
+	})
+
+	inbound := []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"fetch","arguments":{}}}`)
+	out, err := EmitMCPDecision(recEmitter, nil, envEmitter, MCPDecision{
+		Receipt: receipt.EmitOpts{
+			ActionID:  "required-allow-sync-fail",
+			Verdict:   config.ActionAllow,
+			Transport: transportMCPStdio,
+			Target:    "fetch",
+			MCPMethod: methodToolsCall,
+			ToolName:  "fetch",
+		},
+		Envelope: &envelope.BuildOpts{
+			ActionID: "required-allow-sync-fail",
+			Action:   "tool_call",
+			Verdict:  config.ActionAllow,
+		},
+		InboundMsg:     inbound,
+		RequireReceipt: true,
+	})
+	if !errors.Is(err, ErrReceiptRequired) {
+		t.Fatalf("err = %v, want ErrReceiptRequired", err)
+	}
+	if !errors.Is(err, recorder.ErrDurability) {
+		t.Fatalf("err = %v, want recorder.ErrDurability", err)
+	}
+	if !bytes.Equal(out, inbound) {
+		t.Fatalf("outbound was rewritten despite durable intent failure: %s", out)
+	}
+	if strings.Contains(string(out), "com.pipelock/mediation") {
+		t.Fatalf("outbound leaked mediation envelope after durable intent failure: %s", out)
+	}
+}
+
 func TestEmitMCPDecision_ReceiptErrorDoesNotBlockEnvelope(t *testing.T) {
 	// A nil receipt emitter is the closest to a "fails/skips" signal
 	// we can induce without a bespoke error-injecting fake. The helper

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -73,15 +73,25 @@ func (sw *syncWriter) WriteMessage(msg []byte) error {
 	return nil
 }
 
-func emitPendingTimeoutResponses(writer transport.MessageWriter, logW io.Writer, tracker *RequestTracker) {
+func emitPendingTimeoutResponses(writer transport.MessageWriter, logW io.Writer, tracker *RequestTracker, opts MCPProxyOpts) {
 	if tracker == nil {
 		return
 	}
-	for _, id := range tracker.DrainPending() {
-		resp := timeoutErrorResponse(id)
+	for _, pending := range tracker.DrainPendingOutcomes() {
+		resp := timeoutErrorResponse(pending.ID)
 		if wErr := writer.WriteMessage(resp); wErr != nil {
 			_, _ = fmt.Fprintf(logW, "pipelock: failed to send timeout response: %v\n", wErr)
 		}
+		emitMCPOutcomeReceipt(opts.receiptEmitter(), opts.v2ReceiptEmitter(), logW, pending.Outcome.Receipt, "error", int64(len(resp)), "response_timeout")
+	}
+}
+
+func emitPendingIncompleteOutcomes(logW io.Writer, tracker *RequestTracker, opts MCPProxyOpts, reason string) {
+	if tracker == nil {
+		return
+	}
+	for _, pending := range tracker.DrainPendingOutcomes() {
+		emitMCPOutcomeReceipt(opts.receiptEmitter(), opts.v2ReceiptEmitter(), logW, pending.Outcome.Receipt, "incomplete", -1, reason)
 	}
 }
 
@@ -274,17 +284,31 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 		// arrives before ForwardScannedInput tracks the outbound request ID
 		// (concurrent goroutines). The window is not exploitable: before any
 		// client request, no valid request ID exists to hijack.
+		var trackedOutcome TrackedRequestOutcome
+		var hasTrackedOutcome bool
 		if tracker != nil && tracker.Seeded() && isResponse(line) {
 			rpcID := frame.ID
-			if rpcID != nil && !tracker.Validate(rpcID) {
-				_, _ = fmt.Fprintf(logW, "pipelock: line %d: confused deputy: unsolicited response ID %s\n",
-					lineNum, string(rpcID))
-				resp := blockResponseReason(rpcID, "unsolicited response ID (confused deputy)")
-				if err := writer.WriteMessage(resp); err != nil {
-					return foundInjection, fmt.Errorf("writing confused deputy block: %w", err)
+			if rpcID != nil {
+				var valid bool
+				trackedOutcome, valid = tracker.Consume(rpcID)
+				if !valid {
+					_, _ = fmt.Fprintf(logW, "pipelock: line %d: confused deputy: unsolicited response ID %s\n",
+						lineNum, string(rpcID))
+					resp := blockResponseReason(rpcID, "unsolicited response ID (confused deputy)")
+					if err := writer.WriteMessage(resp); err != nil {
+						return foundInjection, fmt.Errorf("writing confused deputy block: %w", err)
+					}
+					continue
 				}
-				continue
+				hasTrackedOutcome = trackedOutcome.Receipt.ActionID != ""
 			}
+		}
+
+		emitTrackedOutcome := func(status, reason string, outbound []byte) {
+			if !hasTrackedOutcome {
+				return
+			}
+			emitMCPOutcomeReceipt(receiptEmitter, v2ReceiptEmitter, logW, trackedOutcome.Receipt, status, int64(len(outbound)), reason)
 		}
 
 		mediaResult := applyMCPResponseMediaPolicy(line, mediaPolicy, opts.Transport)
@@ -341,6 +365,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			if err := writer.WriteMessage(resp); err != nil {
 				return foundInjection, fmt.Errorf("writing media policy block: %w", err)
 			}
+			emitTrackedOutcome("error", "media_policy", resp)
 			continue
 		}
 		line = mediaResult.Line
@@ -378,6 +403,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 					if err := writer.WriteMessage(resp); err != nil {
 						return foundInjection, fmt.Errorf("writing provenance block: %w", err)
 					}
+					emitTrackedOutcome("error", "provenance", resp)
 					continue
 				}
 				if pv.Error != "" {
@@ -477,6 +503,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 					if err := writer.WriteMessage(resp); err != nil {
 						return foundInjection, fmt.Errorf("writing tool block: %w", err)
 					}
+					emitTrackedOutcome("error", "tool_poisoning", resp)
 					continue
 				}
 				// warn: logged above, record near-miss and fall through to general handling.
@@ -510,6 +537,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			if err := writer.WriteMessage(line); err != nil {
 				return foundInjection, fmt.Errorf("writing line: %w", err)
 			}
+			emitTrackedOutcome(mcpResponseStatus(line), "complete", line)
 			observeMCPResponseTaint(taintOpts, toolPoisonDetected)
 			continue
 		}
@@ -531,6 +559,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			if err := writer.WriteMessage(resp); err != nil {
 				return foundInjection, fmt.Errorf("writing block response: %w", err)
 			}
+			emitTrackedOutcome("error", "parse_error", resp)
 			continue
 		}
 
@@ -657,6 +686,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 		if err := writer.WriteMessage(outbound); err != nil {
 			return foundInjection, fmt.Errorf("%s: %w", writeContext, err)
 		}
+		emitTrackedOutcome(mcpResponseStatus(outbound), "mcp_response_scan", outbound)
 
 		// Signal recording: record after action is taken.
 		if adaptiveCfg != nil && adaptiveCfg.Enabled {
@@ -775,6 +805,23 @@ func firstNonEmptyPattern(names []string) string {
 		}
 	}
 	return "unknown"
+}
+
+func mcpResponseStatus(line []byte) string {
+	var response struct {
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(line, &response); err != nil {
+		return "response"
+	}
+	if len(response.Error) > 0 {
+		return "error"
+	}
+	if len(response.Result) > 0 {
+		return "result"
+	}
+	return "response"
 }
 
 // blockResponseReason is like blockResponse but lets the caller supply a
@@ -1324,13 +1371,14 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		case <-drainCtx.Done():
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: timed out waiting for MCP input drain after upstream response timeout\n")
 		}
-		emitPendingTimeoutResponses(safeClientOut, safeLogW, tracker)
+		emitPendingTimeoutResponses(safeClientOut, safeLogW, tracker, fwdOpts)
 	} else {
 		// Wait for stdin goroutine to finish (server exit closes pipe, unblocking scanner).
 		wg.Wait()
 
 		// Wait for blocked channel drain to complete.
 		wgBlocked.Wait()
+		emitPendingIncompleteOutcomes(safeLogW, tracker, fwdOpts, "upstream_closed")
 	}
 
 	if scanErr != nil {

--- a/internal/mcp/proxy_sandbox.go
+++ b/internal/mcp/proxy_sandbox.go
@@ -185,7 +185,9 @@ func RunProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, clientIn io.
 	case <-drainCtx.Done():
 	}
 	if timedOut {
-		emitPendingTimeoutResponses(safeClientOut, safeLogW, tracker)
+		emitPendingTimeoutResponses(safeClientOut, safeLogW, tracker, fwdOpts)
+	} else {
+		emitPendingIncompleteOutcomes(safeLogW, tracker, fwdOpts, "upstream_closed")
 	}
 
 	if scanErr != nil {

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -3949,7 +3949,7 @@ func TestEmitPendingTimeoutResponses_DrainsTracker(t *testing.T) {
 	tracker.Track(json.RawMessage(`2`))
 
 	var out, logBuf bytes.Buffer
-	emitPendingTimeoutResponses(transport.NewStdioWriter(&out), &logBuf, tracker)
+	emitPendingTimeoutResponses(transport.NewStdioWriter(&out), &logBuf, tracker, MCPProxyOpts{})
 
 	outStr := out.String()
 	for _, want := range []string{`"id":1`, `"id":2`, `"code":-32000`, "upstream response timeout"} {
@@ -3989,6 +3989,7 @@ func TestEmitRequestScopedTimeout(t *testing.T) {
 				tracker,
 				tt.id,
 				"pipelock: upstream response timeout; failed request closed, session continues",
+				MCPProxyOpts{},
 			)
 
 			if !reader.closed {

--- a/internal/mcp/request_tracker.go
+++ b/internal/mcp/request_tracker.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/luckyPipewrench/pipelock/internal/mcp/jsonrpc"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
 
 // maxTrackedRequests caps the number of pending request IDs to prevent
@@ -23,7 +24,7 @@ const maxTrackedRequests = 10000
 // A nil tracker passes all IDs through (feature disabled).
 type RequestTracker struct {
 	mu      sync.Mutex
-	pending map[string]struct{}
+	pending map[string]TrackedRequestOutcome
 	// order preserves insertion order for FIFO eviction when cap is reached.
 	order []string
 	// seeded is true once at least one request ID has been tracked.
@@ -33,10 +34,23 @@ type RequestTracker struct {
 	seeded bool
 }
 
+// TrackedRequestOutcome carries the receipt metadata needed to emit a
+// post-response outcome for a previously admitted MCP request.
+type TrackedRequestOutcome struct {
+	Receipt receipt.EmitOpts
+}
+
+// PendingRequestOutcome is a drained pending JSON-RPC request ID plus its
+// outcome receipt metadata.
+type PendingRequestOutcome struct {
+	ID      json.RawMessage
+	Outcome TrackedRequestOutcome
+}
+
 // NewRequestTracker creates a tracker with an empty pending set.
 func NewRequestTracker() *RequestTracker {
 	return &RequestTracker{
-		pending: make(map[string]struct{}),
+		pending: make(map[string]TrackedRequestOutcome),
 	}
 }
 
@@ -44,6 +58,14 @@ func NewRequestTracker() *RequestTracker {
 // (notifications don't expect responses). If the pending set exceeds
 // maxTrackedRequests, the oldest entry is evicted.
 func (t *RequestTracker) Track(id json.RawMessage) {
+	t.TrackOutcome(id, TrackedRequestOutcome{})
+}
+
+// TrackOutcome records a request ID as pending and associates it with outcome
+// receipt metadata. Nil/null IDs are ignored (notifications don't expect
+// responses). If the pending set exceeds maxTrackedRequests, the oldest entry
+// is evicted.
+func (t *RequestTracker) TrackOutcome(id json.RawMessage, outcome TrackedRequestOutcome) {
 	if t == nil {
 		return
 	}
@@ -66,7 +88,7 @@ func (t *RequestTracker) Track(id json.RawMessage) {
 		t.order = t.order[1:]
 	}
 
-	t.pending[key] = struct{}{}
+	t.pending[key] = outcome
 	t.order = append(t.order, key)
 	t.seeded = true
 }
@@ -75,20 +97,28 @@ func (t *RequestTracker) Track(id json.RawMessage) {
 // match (one-shot). Returns true if the ID is valid (was tracked or is
 // nil/null). A nil tracker always returns true (feature disabled).
 func (t *RequestTracker) Validate(id json.RawMessage) bool {
+	_, ok := t.Consume(id)
+	return ok
+}
+
+// Consume checks whether id was previously tracked and returns the associated
+// outcome metadata. It consumes matching IDs exactly once.
+func (t *RequestTracker) Consume(id json.RawMessage) (TrackedRequestOutcome, bool) {
 	if t == nil {
-		return true
+		return TrackedRequestOutcome{}, true
 	}
 	key := canonicalID(id)
 	if key == "" {
 		// Nil/null IDs: notifications and server-initiated requests.
-		return true
+		return TrackedRequestOutcome{}, true
 	}
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if _, ok := t.pending[key]; !ok {
-		return false
+	outcome, ok := t.pending[key]
+	if !ok {
+		return TrackedRequestOutcome{}, false
 	}
 	delete(t.pending, key)
 	// Remove from order slice. Linear scan is acceptable because n
@@ -99,7 +129,7 @@ func (t *RequestTracker) Validate(id json.RawMessage) bool {
 			break
 		}
 	}
-	return true
+	return outcome, true
 }
 
 // Seeded reports whether at least one request ID has been tracked.
@@ -118,18 +148,35 @@ func (t *RequestTracker) Seeded() bool {
 // response timeout fires and the proxy needs to emit error responses for
 // every unanswered request before shutting down.
 func (t *RequestTracker) DrainPending() []json.RawMessage {
+	pending := t.DrainPendingOutcomes()
+	if pending == nil {
+		return nil
+	}
+	ids := make([]json.RawMessage, 0, len(pending))
+	for _, item := range pending {
+		ids = append(ids, item.ID)
+	}
+	return ids
+}
+
+// DrainPendingOutcomes returns and removes all pending request IDs with their
+// associated outcome metadata.
+func (t *RequestTracker) DrainPendingOutcomes() []PendingRequestOutcome {
 	if t == nil {
 		return nil
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	ids := make([]json.RawMessage, 0, len(t.order))
+	pending := make([]PendingRequestOutcome, 0, len(t.order))
 	for _, key := range t.order {
-		ids = append(ids, json.RawMessage(key))
+		pending = append(pending, PendingRequestOutcome{
+			ID:      json.RawMessage(key),
+			Outcome: t.pending[key],
+		})
 	}
-	t.pending = make(map[string]struct{})
+	t.pending = make(map[string]TrackedRequestOutcome)
 	t.order = nil
-	return ids
+	return pending
 }
 
 // canonicalID normalizes a JSON-RPC ID to a canonical string for map

--- a/internal/metrics/receipt.go
+++ b/internal/metrics/receipt.go
@@ -18,11 +18,13 @@ var receiptEmitFailureReasons = map[string]bool{
 	"hash":        true,
 	"marshal":     true,
 	"record":      true,
+	"sync":        true,
 	"sealed":      true,
 	"unavailable": true,
 }
 
 var requiredReceiptBlockReasons = map[string]bool{
+	"durability":  true,
 	"emit_error":  true,
 	"unavailable": true,
 }

--- a/internal/metrics/receipt_test.go
+++ b/internal/metrics/receipt_test.go
@@ -19,6 +19,7 @@ func TestRecordEmitFailure_CanonicalReasons(t *testing.T) {
 	m.RecordEmitFailure("chain_init")
 	m.RecordEmitFailure("chain_init")
 	m.RecordEmitFailure("record")
+	m.RecordEmitFailure("sync")
 	m.RecordEmitFailure("unavailable")
 
 	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("chain_init")); got != 2 {
@@ -26,6 +27,9 @@ func TestRecordEmitFailure_CanonicalReasons(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("record")); got != 1 {
 		t.Errorf("record = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("sync")); got != 1 {
+		t.Errorf("sync = %v, want 1", got)
 	}
 	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("unavailable")); got != 1 {
 		t.Errorf("unavailable = %v, want 1", got)
@@ -56,6 +60,7 @@ func TestRecordRequiredReceiptBlock_BoundedLabels(t *testing.T) {
 	m := New()
 	m.RecordRequiredReceiptBlock("unavailable", "fetch")
 	m.RecordRequiredReceiptBlock("emit_error", "websocket")
+	m.RecordRequiredReceiptBlock("durability", "connect")
 	m.RecordRequiredReceiptBlock("attacker-controlled", "CONNECT /evil")
 
 	if got := testutil.ToFloat64(m.requiredReceiptBlockings.WithLabelValues("unavailable", "fetch")); got != 1 {
@@ -63,6 +68,9 @@ func TestRecordRequiredReceiptBlock_BoundedLabels(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(m.requiredReceiptBlockings.WithLabelValues("emit_error", "websocket")); got != 1 {
 		t.Errorf("emit_error/websocket = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.requiredReceiptBlockings.WithLabelValues("durability", "connect")); got != 1 {
+		t.Errorf("durability/connect = %v, want 1", got)
 	}
 	if got := testutil.ToFloat64(m.requiredReceiptBlockings.WithLabelValues("unknown", "other")); got != 1 {
 		t.Errorf("unknown/other = %v, want 1 (unbounded labels collapsed)", got)

--- a/internal/playground/live_session.go
+++ b/internal/playground/live_session.go
@@ -774,6 +774,9 @@ func (s *LiveSession) onReceipt(rcpt *receipt.Receipt) {
 	if rcpt == nil {
 		return
 	}
+	if rcpt.ActionRecord.SessionControl != nil {
+		return
+	}
 	// Record the method+target key for the model-driver receipt invariant, if a
 	// turn is open, and signal any settle-wait that the tally advanced.
 	s.recMu.Lock()

--- a/internal/playground/live_session_test.go
+++ b/internal/playground/live_session_test.go
@@ -186,6 +186,9 @@ func TestLiveSession_SendAfterFinalizeRefused(t *testing.T) {
 	if err := sess.Send(ctx, "grab the lab config"); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
+	if err := sess.Send(ctx, "now send that file to the collector"); err != nil {
+		t.Fatalf("Send exfil attempt: %v", err)
+	}
 	if _, err := sess.Finalize(t.TempDir()); err != nil {
 		t.Fatalf("Finalize: %v", err)
 	}

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -394,7 +394,7 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 		err = fmt.Errorf("emitter construction failed")
 		return nil, err
 	}
-	if err := emitter.EmitSessionOpen(); err != nil {
+	if err = emitter.EmitSessionOpen(); err != nil {
 		return nil, fmt.Errorf("session_open receipt: %w", err)
 	}
 

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -394,6 +394,9 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 		err = fmt.Errorf("emitter construction failed")
 		return nil, err
 	}
+	if err := emitter.EmitSessionOpen(); err != nil {
+		return nil, fmt.Errorf("session_open receipt: %w", err)
+	}
 
 	// --- Proxy ---
 	lr.proxyObj, err = proxy.New(cfg, audit.NewNop(), lr.sc, metrics.New(),
@@ -824,6 +827,9 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 	rep, err := VerifyRun(runDir, hex.EncodeToString(lr.orchestratorPub))
 	if err != nil {
 		return VerifyReport{}, fmt.Errorf("verify run: %w", err)
+	}
+	if !rep.OK {
+		return rep, fmt.Errorf("verify run: failed checks")
 	}
 
 	return rep, nil

--- a/internal/playground/mediator.go
+++ b/internal/playground/mediator.go
@@ -109,7 +109,9 @@ func renderNarration(w io.Writer, ev MediatorEvent) {
 const verdictBlock = "block"
 
 // MediatorEventsFromEvidence reads a flight-recorder JSONL evidence file,
-// extracts all receipts, and maps each to a ClassPipelockDecision MediatorEvent.
+// extracts decision receipts, and maps each to a ClassPipelockDecision
+// MediatorEvent. Session-control receipts prove coverage windows; they are not
+// agent allow/deny decisions and must not be rendered as one.
 //
 // The summary for each event is built from the normalized verdict and the
 // transport layer field — raw target values are NOT included because they may
@@ -124,6 +126,9 @@ func MediatorEventsFromEvidence(evidenceFile string) ([]MediatorEvent, error) {
 	events := make([]MediatorEvent, 0, len(receipts))
 	for _, r := range receipts {
 		ar := r.ActionRecord
+		if ar.SessionControl != nil {
+			continue
+		}
 		verdict := receipt.NormalizeVerdict(ar.Verdict)
 
 		// Build a secret-free summary. We include:

--- a/internal/playground/mediator_test.go
+++ b/internal/playground/mediator_test.go
@@ -5,9 +5,17 @@ package playground
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
 )
 
@@ -229,4 +237,119 @@ func TestMediator_FromEvidenceFile(t *testing.T) {
 	if !strings.Contains(out, "pipelock_decision") {
 		t.Fatalf("rendered output from evidence must contain pipelock_decision label; output:\n%s", out)
 	}
+}
+
+func TestMediator_FromEvidenceFileSkipsSessionControlReceipts(t *testing.T) {
+	evidenceFile := writeMediatorReceiptEvidence(t)
+
+	events, err := MediatorEventsFromEvidence(evidenceFile)
+	if err != nil {
+		t.Fatalf("MediatorEventsFromEvidence: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want only the decision receipt", len(events))
+	}
+	if events[0].Class != ClassPipelockDecision {
+		t.Fatalf("event class = %q, want pipelock_decision", events[0].Class)
+	}
+	if strings.Contains(events[0].Summary, "receipt_session") {
+		t.Fatalf("session-control receipt rendered as decision summary: %q", events[0].Summary)
+	}
+
+	var buf bytes.Buffer
+	RenderMediator(&buf, events, false)
+	out := buf.String()
+	if strings.Contains(out, "receipt_session") || strings.Contains(out, "session_open") {
+		t.Fatalf("session control receipt leaked into mediator decision output:\n%s", out)
+	}
+	if !strings.Contains(out, "pipelock_decision") || !strings.Contains(out, "transport=fetch") {
+		t.Fatalf("decision receipt missing from mediator output:\n%s", out)
+	}
+}
+
+func writeMediatorReceiptEvidence(t *testing.T) string {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	runNonce := "0123456789abcdef0123456789abcdef"
+	policyHash := "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	open := receipt.SessionOpen{
+		RunNonce:        runNonce,
+		OpenNonce:       "11111111111111111111111111111111",
+		RecorderSession: "proxy",
+		PolicyHash:      policyHash,
+		SignerKeyEpoch:  "test-epoch",
+		ChainOpenSeq:    0,
+	}
+	genesis := receipt.ComputeSessionOpenGenesis(open)
+	open.GenesisHash = genesis
+	openReceipt := signMediatorReceipt(t, priv, receipt.ActionRecord{
+		Version:       receipt.ActionRecordVersion,
+		ActionID:      receipt.NewActionID(),
+		ActionType:    receipt.ActionUnclassified,
+		Timestamp:     base,
+		Target:        "pipelock://session/open",
+		PolicyHash:    policyHash,
+		Verdict:       config.ActionAllow,
+		Transport:     "receipt_session",
+		ChainPrevHash: genesis,
+		ChainSeq:      0,
+		RunNonce:      runNonce,
+		SessionControl: &receipt.SessionControl{
+			Kind: receipt.SessionControlOpen,
+			Open: &open,
+		},
+	})
+	openHash, err := receipt.ReceiptHash(openReceipt)
+	if err != nil {
+		t.Fatalf("ReceiptHash(open): %v", err)
+	}
+	decision := signMediatorReceipt(t, priv, receipt.ActionRecord{
+		Version:       receipt.ActionRecordVersion,
+		ActionID:      receipt.NewActionID(),
+		ActionType:    receipt.ActionRead,
+		Timestamp:     base.Add(time.Second),
+		Target:        "https://api.vendor.example/data",
+		PolicyHash:    policyHash,
+		Verdict:       config.ActionAllow,
+		Transport:     "fetch",
+		Method:        http.MethodGet,
+		Layer:         "scanner",
+		ChainPrevHash: openHash,
+		ChainSeq:      1,
+		RunNonce:      runNonce,
+	})
+
+	path := filepath.Join(t.TempDir(), "evidence.jsonl")
+	if err := os.WriteFile(path, marshalMediatorReceipts(t, openReceipt, decision), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func signMediatorReceipt(t *testing.T, priv ed25519.PrivateKey, ar receipt.ActionRecord) receipt.Receipt {
+	t.Helper()
+	rec, err := receipt.Sign(ar, priv)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	return rec
+}
+
+func marshalMediatorReceipts(t *testing.T, receipts ...receipt.Receipt) []byte {
+	t.Helper()
+	var out []byte
+	for _, rec := range receipts {
+		data, err := receipt.Marshal(rec)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		out = append(out, data...)
+		out = append(out, '\n')
+	}
+	return out
 }

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -657,6 +657,7 @@ func verifyLiveDemoManifest(replayManifest replaycapture.Manifest, lm LaunchMani
 }
 
 func verifyLiveDemoReceipts(receipts []receipt.Receipt, lm LaunchManifest, witness Witness) error {
+	decisionReceipts := liveDemoDecisionReceipts(receipts)
 	// A real model-backed run does not reproduce the scripted safe-GET + body_dlp
 	// beats, so it verifies under the honest model-mode predicate instead of the
 	// strict deterministic one. AgentKind is covered by the manifest signature, so
@@ -665,17 +666,28 @@ func verifyLiveDemoReceipts(receipts []receipt.Receipt, lm LaunchManifest, witne
 		if lm.ScenarioID != LiveDemoScenarioID {
 			return fmt.Errorf("unsupported model-mode scenario %q", lm.ScenarioID)
 		}
-		return verifyModelLiveContained(receipts, witness)
+		return verifyModelLiveContained(decisionReceipts, witness)
 	}
 
 	switch lm.ScenarioID {
 	case LiveDemoScenarioID:
-		return verifyBodyExfilLiveDemo(receipts, witness)
+		return verifyBodyExfilLiveDemo(decisionReceipts, witness)
 	case "secret-exfil-url-blocked":
-		return verifyURLExfilReplayCompatible(receipts, witness)
+		return verifyURLExfilReplayCompatible(decisionReceipts, witness)
 	default:
 		return fmt.Errorf("unsupported playground verify scenario %q", lm.ScenarioID)
 	}
+}
+
+func liveDemoDecisionReceipts(receipts []receipt.Receipt) []receipt.Receipt {
+	out := make([]receipt.Receipt, 0, len(receipts))
+	for _, r := range receipts {
+		if r.ActionRecord.SessionControl != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 // verifyModelLiveContained is the honest predicate for a real model-backed run.

--- a/internal/playground/verify_memory_test.go
+++ b/internal/playground/verify_memory_test.go
@@ -321,10 +321,11 @@ func realBundleForMemoryVerify(t *testing.T) ([]byte, string) {
 	const (
 		runNonce   = "0123456789abcdef0123456789abcdef"
 		canaryID   = "aws_canary"
-		policyHash = "policy-real-bundle-hash"
+		policyHash = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 		scenarioID = "secret-exfil-url-blocked"
 	)
 	now := time.Unix(1_700_000_123, 0).UTC()
+	openRec := signMemorySessionOpen(t, pipePriv, pipePub, runNonce, "11111111111111111111111111111111", policyHash, now)
 	rec := signReceipt(t, pipePriv, receipt.ActionRecord{
 		Version:         receipt.ActionRecordVersion,
 		ActionID:        "act-real-bundle-core-dlp",
@@ -341,8 +342,8 @@ func realBundleForMemoryVerify(t *testing.T) ([]byte, string) {
 		Method:          "POST",
 		Layer:           "core_dlp",
 		Pattern:         "request body contains secret",
-		ChainPrevHash:   receipt.GenesisHash,
-		ChainSeq:        0,
+		ChainPrevHash:   receiptHashForMemoryTest(t, openRec),
+		ChainSeq:        1,
 		RunNonce:        runNonce,
 	})
 
@@ -351,7 +352,7 @@ func realBundleForMemoryVerify(t *testing.T) ([]byte, string) {
 		t.Fatalf("mkdir evidence dir: %v", err)
 	}
 	evidenceFile := filepath.Join(evidenceDir, "evidence.jsonl")
-	if err := os.WriteFile(evidenceFile, mustMarshalReceiptLine(t, rec), 0o600); err != nil {
+	if err := os.WriteFile(evidenceFile, mustMarshalReceiptLines(t, openRec, rec), 0o600); err != nil {
 		t.Fatalf("write evidence: %v", err)
 	}
 
@@ -463,12 +464,13 @@ func newVerifyMemoryFixture(t *testing.T) verifyMemoryFixture {
 	colPub, colPriv := testKeyPair(t)
 
 	const (
-		runNonce   = "verify-memory-run"
+		runNonce   = "22222222222222222222222222222222"
 		canaryID   = "aws_canary"
-		policyHash = "policy-test-hash"
+		policyHash = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
 		scenarioID = "secret-exfil-url-blocked"
 	)
 	now := time.Unix(1_700_000_000, 0).UTC()
+	openRec := signMemorySessionOpen(t, pipePriv, pipePub, runNonce, "33333333333333333333333333333333", policyHash, now)
 	rec := signReceipt(t, pipePriv, receipt.ActionRecord{
 		Version:         receipt.ActionRecordVersion,
 		ActionID:        "act-block-core-dlp",
@@ -483,15 +485,15 @@ func newVerifyMemoryFixture(t *testing.T) verifyMemoryFixture {
 		Method:          "POST",
 		Layer:           "core_dlp",
 		Pattern:         "request body contains secret",
-		ChainPrevHash:   receipt.GenesisHash,
-		ChainSeq:        0,
+		ChainPrevHash:   receiptHashForMemoryTest(t, openRec),
+		ChainSeq:        1,
 		RunNonce:        runNonce,
 	})
-	chain := receipt.VerifyChain([]receipt.Receipt{rec}, hex.EncodeToString(pipePub))
+	chain := receipt.VerifyChain([]receipt.Receipt{openRec, rec}, hex.EncodeToString(pipePub))
 	if !chain.Valid {
 		t.Fatalf("test receipt chain invalid: %s", chain.Error)
 	}
-	evidenceJSONL := mustMarshalReceiptLine(t, rec)
+	evidenceJSONL := mustMarshalReceiptLines(t, openRec, rec)
 	packetJSON := mustJSON(t, auditpacket.Packet{
 		SchemaVersion: auditpacket.SchemaVersion,
 		PacketID:      "ap-verify-memory",
@@ -504,18 +506,18 @@ func newVerifyMemoryFixture(t *testing.T) verifyMemoryFixture {
 		},
 		Policy: auditpacket.Policy{PolicyHashes: []string{policyHash}},
 		Summary: auditpacket.Summary{
-			ReceiptCount:   1,
-			Totals:         auditpacket.Totals{Block: 1},
-			Transports:     map[string]int{"http": 1},
+			ReceiptCount:   2,
+			Totals:         auditpacket.Totals{Allow: 1, Block: 1},
+			Transports:     map[string]int{"receipt_session": 1, "http": 1},
 			Layers:         map[string]int{"core_dlp": 1},
 			DomainsTouched: []string{"intake.lab.test"},
 		},
 		Verifier: auditpacket.Verifier{
 			Verdict:      auditpacket.VerdictValid,
 			Trusted:      true,
-			ReceiptCount: 1,
+			ReceiptCount: 2,
 			RootHash:     chain.RootHash,
-			FinalSeq:     0,
+			FinalSeq:     1,
 			SignerKey:    hex.EncodeToString(pipePub),
 			OutputFile:   "verifier.txt",
 		},
@@ -543,8 +545,8 @@ func newVerifyMemoryFixture(t *testing.T) verifyMemoryFixture {
 		Packet: replaycapture.PacketBinding{
 			Path:         "packet.json",
 			RootHash:     chain.RootHash,
-			ReceiptCount: 1,
-			FinalSeq:     0,
+			ReceiptCount: 2,
+			FinalSeq:     1,
 		},
 	})
 
@@ -702,6 +704,56 @@ func signReceipt(t *testing.T, priv ed25519.PrivateKey, ar receipt.ActionRecord)
 	return rec
 }
 
+func signMemorySessionOpen(
+	t *testing.T,
+	priv ed25519.PrivateKey,
+	pub ed25519.PublicKey,
+	runNonce string,
+	openNonce string,
+	policyHash string,
+	ts time.Time,
+) receipt.Receipt {
+	t.Helper()
+	open := receipt.SessionOpen{
+		RunNonce:        runNonce,
+		OpenNonce:       openNonce,
+		RecorderSession: "proxy",
+		PolicyHash:      policyHash,
+		SignerKeyEpoch:  hex.EncodeToString(pub),
+		ChainOpenSeq:    0,
+	}
+	genesis := receipt.ComputeSessionOpenGenesis(open)
+	open.GenesisHash = genesis
+	return signReceipt(t, priv, receipt.ActionRecord{
+		Version:       receipt.ActionRecordVersion,
+		ActionID:      "act-session-open",
+		ActionType:    receipt.ActionUnclassified,
+		Timestamp:     ts,
+		Principal:     "pipelock-lab",
+		Actor:         "lab-agent",
+		Target:        "pipelock://session/open",
+		PolicyHash:    policyHash,
+		Verdict:       "allow",
+		Transport:     "receipt_session",
+		ChainPrevHash: genesis,
+		ChainSeq:      0,
+		RunNonce:      runNonce,
+		SessionControl: &receipt.SessionControl{
+			Kind: receipt.SessionControlOpen,
+			Open: &open,
+		},
+	})
+}
+
+func receiptHashForMemoryTest(t *testing.T, rec receipt.Receipt) string {
+	t.Helper()
+	h, err := receipt.ReceiptHash(rec)
+	if err != nil {
+		t.Fatalf("ReceiptHash: %v", err)
+	}
+	return h
+}
+
 func signWitness(t *testing.T, priv ed25519.PrivateKey, w playground.Witness) playground.Witness {
 	t.Helper()
 	w.Signature = hex.EncodeToString(ed25519.Sign(priv, w.SignedBytes()))
@@ -715,6 +767,15 @@ func mustMarshalReceiptLine(t *testing.T, rec receipt.Receipt) []byte {
 		t.Fatalf("receipt.Marshal: %v", err)
 	}
 	return append(data, '\n')
+}
+
+func mustMarshalReceiptLines(t *testing.T, receipts ...receipt.Receipt) []byte {
+	t.Helper()
+	var out []byte
+	for _, rec := range receipts {
+		out = append(out, mustMarshalReceiptLine(t, rec)...)
+	}
+	return out
 }
 
 func mustJSON(t *testing.T, v any) []byte {

--- a/internal/proxy/fetch_require_receipts_test.go
+++ b/internal/proxy/fetch_require_receipts_test.go
@@ -5,8 +5,10 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync/atomic"
 	"testing"
 
@@ -57,7 +59,7 @@ func fetchRequireReceiptsLiveProxy(t *testing.T, cfgMod func(*config.Config)) (*
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
-	rph := newReceiptProxyHelper(t)
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
 	p.receiptEmitterPtr.Store(rph.emitter)
 	return p, rph
 }
@@ -97,6 +99,36 @@ func TestHandleFetch_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
 	}
 	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="fetch"} 1`)
+}
+
+func TestHandleFetch_RequireReceiptsSyncFailureBlocksBeforeEgress(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	p, rph := fetchRequireReceiptsLiveProxy(t, func(cfg *config.Config) {
+		cfg.ResponseScanning.Enabled = false
+	})
+	syncErr := errors.New("injected durable sync failure")
+	rph.rec.SetSyncForTest(func(*os.File) error {
+		return syncErr
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+upstream.URL, nil)
+	rec := httptest.NewRecorder()
+	p.handleFetch(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (durable intent sync failure must block before egress)", got)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="sync"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="durability",transport="fetch"} 1`)
 }
 
 func TestHandleFetch_RequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
@@ -206,6 +238,9 @@ func TestHandleFetch_RequireReceiptsResponseBlockReusesActionID(t *testing.T) {
 	}
 	if actionReceipts[0].ActionRecord.Verdict != config.ActionAllow {
 		t.Fatalf("first verdict = %q, want allow", actionReceipts[0].ActionRecord.Verdict)
+	}
+	if actionReceipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("allow decision_phase = %q, want %q", actionReceipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
 	}
 	if actionReceipts[1].ActionRecord.Verdict != config.ActionBlock {
 		t.Fatalf("second verdict = %q, want block", actionReceipts[1].ActionRecord.Verdict)

--- a/internal/proxy/fetch_require_receipts_test.go
+++ b/internal/proxy/fetch_require_receipts_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -131,6 +132,75 @@ func TestHandleFetch_RequireReceiptsSyncFailureBlocksBeforeEgress(t *testing.T) 
 	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="durability",transport="fetch"} 1`)
 }
 
+func TestHandleFetch_RequireReceiptsSuccessEmitsIntentOutcomePair(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	p, rph := fetchRequireReceiptsLiveProxy(t, func(cfg *config.Config) {
+		cfg.ResponseScanning.Enabled = false
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+upstream.URL, nil)
+	p.handleFetch(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fetch status = %d, want 200", rec.Code)
+	}
+
+	receipts := rph.findReceipts(t)
+	if len(receipts) != 2 {
+		t.Fatalf("receipt count = %d, want intent/outcome pair", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("intent phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+	if receipts[1].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
+		t.Fatalf("outcome phase = %q, want %q", receipts[1].ActionRecord.DecisionPhase, receipt.DecisionPhaseOutcome)
+	}
+	if receipts[1].ActionRecord.ActionID != receipts[0].ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %s, want %s", receipts[1].ActionRecord.ActionID, receipts[0].ActionRecord.ActionID)
+	}
+	if !strings.Contains(receipts[1].ActionRecord.Pattern, "status=202") {
+		t.Fatalf("outcome pattern = %q, want status=202", receipts[1].ActionRecord.Pattern)
+	}
+}
+
+func TestHandleFetch_RequireReceiptsOutcomeEmitFailureDoesNotFailRequest(t *testing.T) {
+	var rph *receiptProxyHelper
+	var closed atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if closed.CompareAndSwap(false, true) {
+			if err := rph.rec.Close(); err != nil {
+				t.Errorf("recorder.Close: %v", err)
+			}
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	var p *Proxy
+	p, rph = fetchRequireReceiptsLiveProxy(t, func(cfg *config.Config) {
+		cfg.ResponseScanning.Enabled = false
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+upstream.URL, nil)
+	p.handleFetch(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fetch status = %d, want 200", rec.Code)
+	}
+	receipts := extractReceiptsFromDir(t, rph.dir)
+	if len(receipts) != 1 {
+		t.Fatalf("receipt count after outcome failure = %d, want durable intent only", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("receipt phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+}
+
 func TestHandleFetch_RequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
 	var hits atomic.Int32
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -233,8 +303,8 @@ func TestHandleFetch_RequireReceiptsResponseBlockReusesActionID(t *testing.T) {
 		}
 		actionReceipts = append(actionReceipts, rcpt)
 	}
-	if len(actionReceipts) != 2 {
-		t.Fatalf("action receipt count = %d, want 2", len(actionReceipts))
+	if len(actionReceipts) != 3 {
+		t.Fatalf("action receipt count = %d, want 3", len(actionReceipts))
 	}
 	if actionReceipts[0].ActionRecord.Verdict != config.ActionAllow {
 		t.Fatalf("first verdict = %q, want allow", actionReceipts[0].ActionRecord.Verdict)
@@ -245,8 +315,16 @@ func TestHandleFetch_RequireReceiptsResponseBlockReusesActionID(t *testing.T) {
 	if actionReceipts[1].ActionRecord.Verdict != config.ActionBlock {
 		t.Fatalf("second verdict = %q, want block", actionReceipts[1].ActionRecord.Verdict)
 	}
-	if actionReceipts[0].ActionRecord.ActionID != actionReceipts[1].ActionRecord.ActionID {
-		t.Fatalf("action IDs differ: allow=%s block=%s",
-			actionReceipts[0].ActionRecord.ActionID, actionReceipts[1].ActionRecord.ActionID)
+	if actionReceipts[2].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
+		t.Fatalf("outcome decision_phase = %q, want %q", actionReceipts[2].ActionRecord.DecisionPhase, receipt.DecisionPhaseOutcome)
+	}
+	if !strings.Contains(actionReceipts[2].ActionRecord.Pattern, "status=403") {
+		t.Fatalf("outcome pattern = %q, want status=403", actionReceipts[2].ActionRecord.Pattern)
+	}
+	for i, rcpt := range actionReceipts[1:] {
+		if actionReceipts[0].ActionRecord.ActionID != rcpt.ActionRecord.ActionID {
+			t.Fatalf("action receipt %d action_id = %s, want %s",
+				i+1, rcpt.ActionRecord.ActionID, actionReceipts[0].ActionRecord.ActionID)
+		}
 	}
 }

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -550,6 +551,12 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	outcomeStatus := "unknown"
+	outcomeBytes := int64(-1)
+	outcomeReason := "incomplete"
+	defer func() {
+		p.emitOutcomeReceipt(cfg, allowReceipt, outcomeStatus, outcomeBytes, outcomeReason)
+	}()
 
 	// Bound the outbound dial, then let the established tunnel live until it
 	// goes idle. Long-poll, SSE, and WebSocket control-plane streams must not
@@ -562,6 +569,8 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		p.logger.LogError(targetCtx, err)
 		http.Error(w, "tunnel dial failed", http.StatusBadGateway)
+		outcomeStatus = strconv.Itoa(http.StatusBadGateway)
+		outcomeReason = "dial_failed"
 		return
 	}
 	defer func() {
@@ -576,12 +585,16 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		p.logger.LogError(targetCtx,
 			fmt.Errorf("response writer does not support hijacking"))
 		http.Error(w, "hijack not supported", http.StatusInternalServerError)
+		outcomeStatus = strconv.Itoa(http.StatusInternalServerError)
+		outcomeReason = "hijack_unsupported"
 		return
 	}
 
 	clientConn, buf, err := hijacker.Hijack()
 	if err != nil {
 		p.logger.LogError(targetCtx, err)
+		outcomeStatus = strconv.Itoa(http.StatusInternalServerError)
+		outcomeReason = "hijack_failed"
 		return
 	}
 	defer safeClose(clientConn, "clientConn", p.logger)
@@ -600,6 +613,9 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		p.metrics.RecordSNI(category, agentLabel)
 		if sniErr != nil {
 			p.logger.LogSNIMismatch(host, sniHost, clientIP, requestID, agent, category)
+			outcomeStatus = strconv.Itoa(http.StatusOK)
+			outcomeBytes = 0
+			outcomeReason = "sni_mismatch"
 			return // close both connections via deferred Close()
 		}
 	}
@@ -616,6 +632,9 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 			// Connection is already hijacked, so close both sides (deferred).
 			p.logger.LogError(targetCtx, fmt.Errorf("TLS interception enabled but cert cache unavailable"))
 			p.metrics.RecordTLSIntercept("failed")
+			outcomeStatus = strconv.Itoa(http.StatusOK)
+			outcomeBytes = 0
+			outcomeReason = "tls_intercept_cert_cache_unavailable"
 			return
 		}
 		// Close the pre-established upstream TCP connection since interceptTunnel
@@ -666,7 +685,11 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 			KillSwitch:         p.ks,
 		}); err != nil {
 			p.logger.LogError(targetCtx, err)
+			outcomeReason = "intercept_error"
+		} else {
+			outcomeReason = "intercept_complete"
 		}
+		outcomeStatus = strconv.Itoa(http.StatusOK)
 		return
 	}
 
@@ -692,6 +715,9 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// Bidirectional relay with idle timeout
 	idleTimeout := time.Duration(cfg.ForwardProxy.IdleTimeoutSeconds) * time.Second
 	totalBytes := bidirectionalCopy(clientConn, targetConn, idleTimeout, time.Time{}, p.ks)
+	outcomeStatus = strconv.Itoa(http.StatusOK)
+	outcomeBytes = totalBytes
+	outcomeReason = "complete"
 
 	p.metrics.DecrActiveTunnels()
 	duration := time.Since(start)
@@ -1660,6 +1686,12 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	outcomeStatus := "unknown"
+	outcomeBytes := int64(-1)
+	outcomeReason := "incomplete"
+	defer func() {
+		p.emitOutcomeReceipt(cfg, forwardAllowReceipt, outcomeStatus, outcomeBytes, outcomeReason)
+	}()
 	emitForwardAllowReceipt := func() {
 		if !cfg.FlightRecorder.RequireReceipts {
 			emitForwardReceipt(forwardAllowReceipt)
@@ -1701,10 +1733,14 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			writeBlockedError(w,
 				redirectBlockedInfo(blockedErr),
 				"blocked: "+blockedErr.reason, http.StatusForbidden)
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeReason = blockedErr.layer
 			return
 		}
 		p.logger.LogError(actx, err)
 		http.Error(w, "forward proxy fetch failed", http.StatusBadGateway)
+		outcomeStatus = strconv.Itoa(http.StatusBadGateway)
+		outcomeReason = "fetch_failed"
 		return
 	}
 	defer safeClose(resp.Body, "resp.Body", p.logger)
@@ -1809,6 +1845,8 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			writeBlockedError(w,
 				blockInfoFor(blockreason.CompressedResponse, sseLayer),
 				"blocked: "+msg, http.StatusForbidden)
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeReason = "compressed_sse"
 			return
 		}
 		copyResponseHeaders(w.Header(), resp.Header)
@@ -1830,6 +1868,8 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			// GenericSSEScanOptions.OnFinding and return nil.
 			if IsSSEStreamFinding(err) && sseAction == config.ActionWarn {
 				p.logger.LogAnomaly(actx, sseLayer, err.Error(), 0)
+				outcomeStatus = strconv.Itoa(resp.StatusCode)
+				outcomeReason = sseLayer
 			} else {
 				p.logger.LogBlocked(actx, sseLayer, err.Error())
 				p.metrics.RecordBlocked(r.URL.Hostname(), sseLayer, time.Since(start), agentLabel)
@@ -1853,12 +1893,17 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 					TaintDecisionReason: forwardTaint.Result.Reason,
 					TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
 				}))
+				outcomeStatus = strconv.Itoa(resp.StatusCode)
+				outcomeReason = sseLayer
 			}
 		} else {
 			duration := time.Since(start)
 			p.metrics.RecordAllowed(duration, agentLabel)
 			emitForwardAllowReceipt()
 			p.logger.LogForwardHTTP(actx, resp.StatusCode, 0, duration)
+			outcomeStatus = strconv.Itoa(resp.StatusCode)
+			outcomeBytes = 0
+			outcomeReason = "complete"
 			if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 				recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
 			}
@@ -1916,6 +1961,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			emitForwardReceipt(forwardAllowReceipt)
 		}
 		p.logger.LogForwardHTTP(actx, resp.StatusCode, int(written), duration)
+		outcomeStatus = strconv.Itoa(resp.StatusCode)
+		outcomeBytes = written
+		outcomeReason = "complete"
 		if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 			recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
 		}
@@ -1949,6 +1997,8 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			writeBlockedError(w,
 				blockInfoFor(blockreason.CompressedResponse, "response_scan"),
 				"blocked: compressed response cannot be scanned", http.StatusForbidden)
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeReason = "compressed_response"
 			return
 		}
 
@@ -1964,6 +2014,8 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			writeBlockedError(w,
 				blockInfoFor(blockreason.ParseError, "response_scan"),
 				"blocked: response read error", http.StatusForbidden)
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeReason = "response_read_error"
 			return
 		}
 		if int64(len(respBody)) > maxBytes {
@@ -2007,16 +2059,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 							TaintDecisionReason: forwardTaint.Result.Reason,
 							TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
 						})
-						if cfg.FlightRecorder.RequireReceipts {
-							if err := p.emitRequiredReceipt(withReceiptPolicyHash(passthroughReceipt, cfg.CanonicalPolicyHash())); err != nil {
-								blockedErr := newReceiptEmissionBlockedRequest(err)
-								p.logger.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
-								writeBlockedError(w,
-									blockInfoFor(blockreason.ReceiptEmissionFailed, blockedErr.layer),
-									receiptEmissionBlockReason, http.StatusForbidden)
-								return
-							}
-						} else {
+						if !cfg.FlightRecorder.RequireReceipts {
 							emitForwardReceipt(passthroughReceipt)
 						}
 						copyResponseHeaders(w.Header(), resp.Header)
@@ -2042,6 +2085,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 						})
 						p.metrics.RecordAllowed(duration, agentLabel)
 						p.logger.LogForwardHTTP(actx, resp.StatusCode, int(written), duration)
+						outcomeStatus = strconv.Itoa(resp.StatusCode)
+						outcomeBytes = written
+						outcomeReason = "unscannable_passthrough"
 						if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 							recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
 						}
@@ -2071,6 +2117,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 							info = blockInfoFor(blockreason.ParseError, "response_scan")
 						}
 						writeBlockedError(w, info, "blocked: "+scanFailure.Reason, http.StatusForbidden)
+						outcomeStatus = strconv.Itoa(http.StatusForbidden)
+						outcomeBytes = int64(len(respBody))
+						outcomeReason = string(scanFailure.Kind)
 						return
 					}
 					defer releaseSizeExemptScan()
@@ -2091,6 +2140,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 					writeBlockedError(w,
 						blockInfoFor(blockreason.ResponseSize, "response_scan"),
 						"blocked: "+reason, http.StatusForbidden)
+					outcomeStatus = strconv.Itoa(http.StatusForbidden)
+					outcomeBytes = int64(len(respBody))
+					outcomeReason = "oversized"
 					return
 				}
 			}
@@ -2106,6 +2158,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			writeBlockedError(w,
 				blockInfoFor(blockreason.BrowserShieldOversize, "shield_oversize"),
 				"blocked: response body exceeds browser shield size limit", http.StatusForbidden)
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeBytes = int64(len(respBody))
+			outcomeReason = "shield_oversize"
 			return
 		}
 		if shieldSummary != nil {
@@ -2127,6 +2182,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			writeBlockedError(w,
 				blockInfoFor(blockreason.MediaPolicy, "media_policy"),
 				"blocked: "+mediaVerdict.BlockReason, http.StatusForbidden)
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeBytes = int64(len(respBody))
+			outcomeReason = "media_policy"
 			return
 		}
 		if mediaVerdict.StripResult != nil && mediaVerdict.StripResult.Changed() {
@@ -2218,6 +2276,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 					writeBlockedError(w,
 						blockInfoFor(blockreason.PromptInjection, "a2a_response"),
 						"blocked: "+a2aReason, http.StatusForbidden)
+					outcomeStatus = strconv.Itoa(http.StatusForbidden)
+					outcomeBytes = int64(len(respBody))
+					outcomeReason = "a2a_response"
 					return
 				}
 			}
@@ -2304,6 +2365,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 					writeBlockedError(w,
 						blockInfoFor(blockreason.PromptInjection, "response_scan"),
 						"blocked: response contains injection", http.StatusForbidden)
+					outcomeStatus = strconv.Itoa(http.StatusForbidden)
+					outcomeBytes = int64(len(respBody))
+					outcomeReason = "response_scan"
 					return
 				case config.ActionStrip:
 					// Record SignalStrip for adaptive enforcement scoring.
@@ -2345,6 +2409,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 						writeBlockedError(w,
 							blockInfoFor(blockreason.PromptInjection, "response_scan"),
 							"blocked: response contains injection", http.StatusForbidden)
+						outcomeStatus = strconv.Itoa(http.StatusForbidden)
+						outcomeBytes = int64(len(respBody))
+						outcomeReason = "response_scan"
 						return
 					}
 					p.logger.LogResponseScan(actx, config.ActionStrip, len(scanResult.Matches), patternNames, bundleRules)
@@ -2366,6 +2433,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		if budgetRemaining >= 0 && written >= budgetRemaining {
 			reason := fmt.Sprintf("response truncated at byte budget: %d bytes written", written)
 			p.logger.LogAnomaly(actx, "budget_truncated", reason, 0)
+			outcomeStatus = strconv.Itoa(resp.StatusCode)
+			outcomeBytes = written
+			outcomeReason = "budget_truncated"
 			return
 		}
 
@@ -2373,6 +2443,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		p.metrics.RecordAllowed(duration, agentLabel)
 		emitForwardAllowReceipt()
 		p.logger.LogForwardHTTP(actx, resp.StatusCode, int(written), duration)
+		outcomeStatus = strconv.Itoa(resp.StatusCode)
+		outcomeBytes = written
+		outcomeReason = "complete"
 		if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 			recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
 		}
@@ -2400,6 +2473,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	if budgetRemaining >= 0 && written >= budgetRemaining {
 		reason := fmt.Sprintf("response truncated at byte budget: %d bytes written", written)
 		p.logger.LogAnomaly(actx, "budget_truncated", reason, 0)
+		outcomeStatus = strconv.Itoa(resp.StatusCode)
+		outcomeBytes = written
+		outcomeReason = "budget_truncated"
 		return
 	}
 
@@ -2407,6 +2483,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	p.metrics.RecordAllowed(duration, agentLabel)
 	emitForwardAllowReceipt()
 	p.logger.LogForwardHTTP(actx, resp.StatusCode, int(written), duration)
+	outcomeStatus = strconv.Itoa(resp.StatusCode)
+	outcomeBytes = written
+	outcomeReason = "complete"
 	if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 		recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
 	}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -765,6 +765,71 @@ func TestConnect_RequireReceiptsSyncFailureBlocksBeforeEgress(t *testing.T) {
 	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="durability",transport="connect"} 1`)
 }
 
+func TestConnect_RequireReceiptsSuccessEmitsIntentOutcomePair(t *testing.T) {
+	lc := net.ListenConfig{}
+	targetLn, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("target listen: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := targetLn.Close(); closeErr != nil {
+			t.Errorf("target listener close: %v", closeErr)
+		}
+	})
+	go func() {
+		conn, acceptErr := targetLn.Accept()
+		if acceptErr != nil {
+			return
+		}
+		_ = conn.Close()
+	}()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	conn := dialProxy(t, proxyAddr)
+	target := targetLn.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+	_ = resp.Body.Close()
+	_ = conn.Close()
+
+	testwait.For(t, 2*time.Second, func() bool {
+		for _, rcpt := range extractReceiptsFromDir(t, rph.dir) {
+			if rcpt.ActionRecord.DecisionPhase == receipt.DecisionPhaseOutcome {
+				return true
+			}
+		}
+		return false
+	}, "connect outcome receipt")
+	receipts := rph.findReceipts(t)
+	if len(receipts) != 2 {
+		t.Fatalf("receipt count = %d, want intent/outcome pair", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("intent phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+	if receipts[1].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
+		t.Fatalf("outcome phase = %q, want %q", receipts[1].ActionRecord.DecisionPhase, receipt.DecisionPhaseOutcome)
+	}
+	if receipts[1].ActionRecord.ActionID != receipts[0].ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %s, want %s", receipts[1].ActionRecord.ActionID, receipts[0].ActionRecord.ActionID)
+	}
+	if !strings.Contains(receipts[1].ActionRecord.Pattern, "status=200") {
+		t.Fatalf("outcome pattern = %q, want status=200", receipts[1].ActionRecord.Pattern)
+	}
+}
+
 func TestConnect_RequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
 	var hits atomic.Int32
 	lc := net.ListenConfig{}
@@ -854,7 +919,7 @@ func TestForwardProxy_ReceiptFailureWithoutRequireStillForwards(t *testing.T) {
 	assertMetricsNotContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="forward"} 1`)
 }
 
-func TestForwardProxy_RequireReceiptsSuccessEmitsSingleAllow(t *testing.T) {
+func TestForwardProxy_RequireReceiptsSuccessEmitsIntentOutcomePair(t *testing.T) {
 	var hits atomic.Int32
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		hits.Add(1)
@@ -880,8 +945,8 @@ func TestForwardProxy_RequireReceiptsSuccessEmitsSingleAllow(t *testing.T) {
 	}
 
 	receipts := rph.findReceipts(t)
-	if len(receipts) != 1 {
-		t.Fatalf("receipt count = %d, want exactly one pre-egress allow receipt", len(receipts))
+	if len(receipts) != 2 {
+		t.Fatalf("receipt count = %d, want intent/outcome pair", len(receipts))
 	}
 	if receipts[0].ActionRecord.Verdict != config.ActionAllow {
 		t.Fatalf("receipt verdict = %q, want allow", receipts[0].ActionRecord.Verdict)
@@ -889,6 +954,155 @@ func TestForwardProxy_RequireReceiptsSuccessEmitsSingleAllow(t *testing.T) {
 	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
 		t.Fatalf("receipt decision_phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
 	}
+	if receipts[1].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
+		t.Fatalf("outcome decision_phase = %q, want %q", receipts[1].ActionRecord.DecisionPhase, receipt.DecisionPhaseOutcome)
+	}
+	if receipts[1].ActionRecord.ActionID != receipts[0].ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %s, want %s", receipts[1].ActionRecord.ActionID, receipts[0].ActionRecord.ActionID)
+	}
+	if !strings.Contains(receipts[1].ActionRecord.Pattern, "status=200") {
+		t.Fatalf("outcome pattern = %q, want status=200", receipts[1].ActionRecord.Pattern)
+	}
+}
+
+func TestForwardProxy_RequireReceiptsCompressedBlockOutcomeStatus(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write([]byte("compressed bytes"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+		cfg.ResponseScanning.Enabled = true
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelper(t)
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	resp := doGet(t, forwardHTTPClient(t, proxyAddr), upstream.URL)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+
+	receipts := rph.findReceipts(t)
+	var intent, outcome receipt.Receipt
+	for _, rcpt := range receipts {
+		switch rcpt.ActionRecord.DecisionPhase {
+		case receipt.DecisionPhaseIntent:
+			intent = rcpt
+		case receipt.DecisionPhaseOutcome:
+			outcome = rcpt
+		}
+	}
+	if intent.ActionRecord.ActionID == "" {
+		t.Fatal("missing durable intent receipt")
+	}
+	if outcome.ActionRecord.ActionID != intent.ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %s, want %s", outcome.ActionRecord.ActionID, intent.ActionRecord.ActionID)
+	}
+	if !strings.Contains(outcome.ActionRecord.Pattern, "status=403") {
+		t.Fatalf("outcome pattern = %q, want status=403", outcome.ActionRecord.Pattern)
+	}
+	if strings.Contains(outcome.ActionRecord.Pattern, "status=unknown") {
+		t.Fatalf("outcome pattern = %q, must not contain status=unknown", outcome.ActionRecord.Pattern)
+	}
+}
+
+func TestForwardProxy_RequireReceiptsA2ASSEWarnOutcomeStatus(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprintf(w, "event: message\ndata: {\"result\":{\"parts\":[{\"text\":\"%s\"}]}}\n\n", testInjectionPayload)
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = config.ActionWarn
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelper(t)
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, upstream.URL+"/message:send", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/a2a+json")
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	receipts := rph.findReceipts(t)
+	var intent, outcome receipt.Receipt
+	for _, rcpt := range receipts {
+		switch rcpt.ActionRecord.DecisionPhase {
+		case receipt.DecisionPhaseIntent:
+			intent = rcpt
+		case receipt.DecisionPhaseOutcome:
+			outcome = rcpt
+		}
+	}
+	if intent.ActionRecord.ActionID == "" {
+		t.Fatal("missing durable intent receipt")
+	}
+	if outcome.ActionRecord.ActionID != intent.ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %s, want %s", outcome.ActionRecord.ActionID, intent.ActionRecord.ActionID)
+	}
+	if !strings.Contains(outcome.ActionRecord.Pattern, "status=200") {
+		t.Fatalf("outcome pattern = %q, want status=200", outcome.ActionRecord.Pattern)
+	}
+	if strings.Contains(outcome.ActionRecord.Pattern, "status=unknown") {
+		t.Fatalf("outcome pattern = %q, must not contain status=unknown", outcome.ActionRecord.Pattern)
+	}
+}
+
+func TestForwardProxy_RequireReceiptsOutcomeEmitFailureDoesNotFailRequest(t *testing.T) {
+	var rph *receiptProxyHelper
+	var closed atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if closed.CompareAndSwap(false, true) {
+			if err := rph.rec.Close(); err != nil {
+				t.Errorf("recorder.Close: %v", err)
+			}
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+		cfg.ResponseScanning.Enabled = false
+	})
+	defer cleanup()
+	rph = newReceiptProxyHelperWithMetrics(t, p.metrics)
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	resp := doGet(t, forwardHTTPClient(t, proxyAddr), upstream.URL)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want ok", body)
+	}
+	receipts := extractReceiptsFromDir(t, rph.dir)
+	if len(receipts) != 1 {
+		t.Fatalf("receipt count after outcome failure = %d, want durable intent only", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("receipt phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 }
 
 // TestForwardProxy_ResponseScanCapOverrunBlocks proves the forward proxy blocks
@@ -1286,6 +1500,7 @@ func TestForwardProxy_UnscannablePassthroughStreamsUnscanned(t *testing.T) {
 		t.Fatalf("parse upstream URL: %v", err)
 	}
 	_, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
 		cfg.ResponseScanning.Enabled = true
 		cfg.ResponseScanning.Action = config.ActionBlock
 		cfg.ResponseScanning.SizeExemptDomains = []string{u.Hostname()}
@@ -1300,6 +1515,8 @@ func TestForwardProxy_UnscannablePassthroughStreamsUnscanned(t *testing.T) {
 		cfg.FetchProxy.Monitoring.MaxDataPerMinute = 0
 	})
 	defer cleanup()
+	rph := newReceiptProxyHelper(t)
+	p.receiptEmitterPtr.Store(rph.emitter)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, upstream.URL+"/opaque/pkg.bin", nil)
 	req.RemoteAddr = "127.0.0.1:12345"
@@ -1311,6 +1528,35 @@ func TestForwardProxy_UnscannablePassthroughStreamsUnscanned(t *testing.T) {
 	}
 	if w.Body.String() != body {
 		t.Fatalf("body mismatch: got %d bytes want %d", w.Body.Len(), len(body))
+	}
+
+	receipts := rph.findReceipts(t)
+	var intentCount, outcomeCount int
+	var intentID, outcomeID string
+	for _, rcpt := range receipts {
+		switch rcpt.ActionRecord.DecisionPhase {
+		case receipt.DecisionPhaseIntent:
+			intentCount++
+			intentID = rcpt.ActionRecord.ActionID
+		case receipt.DecisionPhaseOutcome:
+			outcomeCount++
+			outcomeID = rcpt.ActionRecord.ActionID
+			if !strings.Contains(rcpt.ActionRecord.Pattern, "status=200") {
+				t.Fatalf("outcome pattern = %q, want status=200", rcpt.ActionRecord.Pattern)
+			}
+			if !strings.Contains(rcpt.ActionRecord.Pattern, "reason=unscannable_passthrough") {
+				t.Fatalf("outcome pattern = %q, want unscannable passthrough reason", rcpt.ActionRecord.Pattern)
+			}
+		}
+	}
+	if intentCount != 1 {
+		t.Fatalf("intent receipt count = %d, want exactly one", intentCount)
+	}
+	if outcomeCount != 1 {
+		t.Fatalf("outcome receipt count = %d, want exactly one", outcomeCount)
+	}
+	if outcomeID != intentID {
+		t.Fatalf("outcome action_id = %s, want %s", outcomeID, intentID)
 	}
 }
 

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -10,12 +10,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -32,6 +34,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
@@ -577,6 +580,38 @@ func TestForwardProxy_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
 	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="forward"} 1`)
 }
 
+func TestForwardProxy_RequireReceiptsSyncFailureBlocksBeforeEgress(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+		cfg.ResponseScanning.Enabled = false
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	syncErr := errors.New("injected durable sync failure")
+	rph.rec.SetSyncForTest(func(*os.File) error {
+		return syncErr
+	})
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	resp := doGet(t, forwardHTTPClient(t, proxyAddr), upstream.URL)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (durable intent sync failure must block before egress)", got)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="sync"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="durability",transport="forward"} 1`)
+}
+
 func TestForwardProxy_RequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
 	var hits atomic.Int32
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -667,6 +702,67 @@ func TestConnect_RequireReceiptsBlocksEmissionFailure(t *testing.T) {
 	}
 	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="connect"} 1`)
+}
+
+func TestConnect_RequireReceiptsSyncFailureBlocksBeforeEgress(t *testing.T) {
+	var hits atomic.Int32
+	lc := net.ListenConfig{}
+	targetLn, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("target listen: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := targetLn.Close(); closeErr != nil {
+			t.Errorf("target listener close: %v", closeErr)
+		}
+	})
+	go func() {
+		for {
+			conn, acceptErr := targetLn.Accept()
+			if acceptErr != nil {
+				return
+			}
+			hits.Add(1)
+			_ = conn.Close()
+		}
+	}()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	syncErr := errors.New("injected durable sync failure")
+	rph.rec.SetSyncForTest(func(*os.File) error {
+		return syncErr
+	})
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	conn := dialProxy(t, proxyAddr)
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Errorf("proxy connection close: %v", closeErr)
+		}
+	}()
+	target := targetLn.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("CONNECT response body close: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("CONNECT status = %d, want 403", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("target hits = %d, want 0 (durable intent sync failure must block before dial)", got)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="sync"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="durability",transport="connect"} 1`)
 }
 
 func TestConnect_RequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
@@ -789,6 +885,9 @@ func TestForwardProxy_RequireReceiptsSuccessEmitsSingleAllow(t *testing.T) {
 	}
 	if receipts[0].ActionRecord.Verdict != config.ActionAllow {
 		t.Fatalf("receipt verdict = %q, want allow", receipts[0].ActionRecord.Verdict)
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("receipt decision_phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
 	}
 }
 

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -267,6 +267,17 @@ func interceptEmitRequiredReceipt(ic *InterceptContext, opts receipt.EmitOpts) e
 	return nil
 }
 
+func interceptEmitOutcomeReceipt(ic *InterceptContext, opts receipt.EmitOpts, status int, bytesTransferred int64, reason string) {
+	if ic == nil || ic.Config == nil || !ic.Config.FlightRecorder.RequireReceipts {
+		return
+	}
+	opts.DecisionPhase = receipt.DecisionPhaseOutcome
+	opts.Verdict = config.ActionAllow
+	opts.Layer = receiptOutcomeLayer
+	opts.Pattern = receiptOutcomePattern(strconv.Itoa(status), bytesTransferred, reason)
+	_ = interceptEmitReceipt(ic, opts)
+}
+
 func interceptReceiptMetrics(ic *InterceptContext) *metrics.Metrics {
 	if ic == nil {
 		return nil
@@ -1539,6 +1550,19 @@ func newInterceptHandler(
 				return
 			}
 
+			sseAllowReceipt := withInterceptRedaction(receipt.EmitOpts{
+				ActionID:  actionID,
+				Verdict:   config.ActionAllow,
+				Transport: "intercept",
+				Method:    r.Method,
+				Target:    targetURL,
+				RequestID: ic.RequestID,
+				Agent:     ic.Agent,
+			})
+			if interceptEmitReceiptOrBlock(ic, w, actx, sseAllowReceipt) {
+				return
+			}
+
 			// Copy response headers to client before streaming.
 			for k, vv := range resp.Header {
 				for _, v := range vv {
@@ -1574,17 +1598,13 @@ func newInterceptHandler(
 					}))
 				}
 			}
-			// Emit receipt for completed SSE stream (clean or warn-only).
+			// Emit outcome for the completed client-visible SSE stream. In
+			// block mode headers are already sent, so the final HTTP status is
+			// still the upstream status and the close reason carries the block.
 			if streamErr == nil || (IsSSEStreamFinding(streamErr) && sseAction == config.ActionWarn) {
-				_ = interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{
-					ActionID:  actionID,
-					Verdict:   config.ActionAllow,
-					Transport: "intercept",
-					Method:    r.Method,
-					Target:    targetURL,
-					RequestID: ic.RequestID,
-					Agent:     ic.Agent,
-				}))
+				interceptEmitOutcomeReceipt(ic, sseAllowReceipt, resp.StatusCode, -1, "sse_stream")
+			} else {
+				interceptEmitOutcomeReceipt(ic, sseAllowReceipt, resp.StatusCode, -1, sseLayer)
 			}
 			return
 		}
@@ -1628,6 +1648,15 @@ func newInterceptHandler(
 			removeHopByHopHeaders(w.Header())
 			w.WriteHeader(resp.StatusCode)
 			written, _ := io.Copy(w, resp.Body)
+			interceptEmitOutcomeReceipt(ic, withInterceptRedaction(receipt.EmitOpts{
+				ActionID:  actionID,
+				Verdict:   config.ActionAllow,
+				Transport: "intercept",
+				Method:    r.Method,
+				Target:    targetURL,
+				RequestID: ic.RequestID,
+				Agent:     ic.Agent,
+			}), resp.StatusCode, written, "complete")
 			// Account streamed bytes against the per-domain data budget so a
 			// trusted download still decrements it (no scan-size cap: the host
 			// is trusted to carry large files).
@@ -1718,6 +1747,17 @@ func newInterceptHandler(
 					removeHopByHopHeaders(w.Header())
 					w.WriteHeader(resp.StatusCode)
 					written, _ := io.Copy(w, io.MultiReader(bytes.NewReader(respBody), resp.Body))
+					interceptEmitOutcomeReceipt(ic, withInterceptRedaction(receipt.EmitOpts{
+						ActionID:  actionID,
+						Verdict:   config.ActionAllow,
+						Layer:     "unscannable_passthrough",
+						Pattern:   reason,
+						Transport: "intercept",
+						Method:    r.Method,
+						Target:    targetURL,
+						RequestID: ic.RequestID,
+						Agent:     ic.Agent,
+					}), resp.StatusCode, written, "unscannable_passthrough")
 					ic.Scanner.RecordRequest(strings.ToLower(ic.TargetHost), int(written))
 					if ic.Proxy != nil {
 						ic.Proxy.captureObs.ObserveResponseVerdict(r.Context(), &capture.ResponseVerdictRecord{
@@ -2090,7 +2130,8 @@ func newInterceptHandler(
 		}
 		removeHopByHopHeaders(w.Header())
 		w.WriteHeader(resp.StatusCode)
-		_, _ = w.Write(respBody)
+		written, _ := w.Write(respBody)
+		interceptEmitOutcomeReceipt(ic, allowReceipt, resp.StatusCode, int64(written), "complete")
 	})
 }
 

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -214,7 +214,13 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) error {
 }
 
 func interceptEmitReceiptOrBlock(ic *InterceptContext, w http.ResponseWriter, actx audit.LogContext, opts receipt.EmitOpts) bool {
-	if err := interceptEmitReceipt(ic, opts); err != nil && ic.Config != nil && ic.Config.FlightRecorder.RequireReceipts {
+	var err error
+	if ic.Config != nil && ic.Config.FlightRecorder.RequireReceipts {
+		err = interceptEmitRequiredReceipt(ic, opts)
+	} else {
+		err = interceptEmitReceipt(ic, opts)
+	}
+	if err != nil && ic.Config != nil && ic.Config.FlightRecorder.RequireReceipts {
 		if m := interceptReceiptMetrics(ic); m != nil {
 			if errors.Is(err, errReceiptEmitterUnavailable) {
 				m.RecordEmitFailure(receipt.FailReasonUnavailable)
@@ -229,6 +235,36 @@ func interceptEmitReceiptOrBlock(ic *InterceptContext, w http.ResponseWriter, ac
 		return true
 	}
 	return false
+}
+
+func interceptEmitRequiredReceipt(ic *InterceptContext, opts receipt.EmitOpts) error {
+	if ic.Proxy == nil {
+		if ic.Logger != nil {
+			ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), receiptEmissionError(opts, errReceiptEmitterUnavailable))
+		}
+		return errReceiptEmitterUnavailable
+	}
+	if ic.Config != nil {
+		opts = withReceiptPolicyHash(opts, ic.Config.CanonicalPolicyHash())
+	}
+	ic.Proxy.reloadMu.RLock()
+	e := ic.Proxy.receiptEmitterPtr.Load()
+	ic.Proxy.reloadMu.RUnlock()
+	if e == nil {
+		return errReceiptEmitterUnavailable
+	}
+	opts.DecisionPhase = receipt.DecisionPhaseIntent
+	if err := e.EmitDurable(opts); err != nil {
+		ic.Proxy.logReceiptEmissionFailure(opts, err)
+		// v1 stays authoritative: skip v2 when v1 failed to record.
+		return err
+	}
+	emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
+		if ic.Logger != nil {
+			ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
+		}
+	})
+	return nil
 }
 
 func interceptReceiptMetrics(ic *InterceptContext) *metrics.Metrics {

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -3170,6 +3170,99 @@ func TestInterceptTunnel_A2ASSEStreamScanning(t *testing.T) {
 	// generic response-body path (which would mean A2A SSE was NOT detected).
 }
 
+func TestInterceptTunnel_SSERequireReceiptsEmitsIntentOutcomePair(t *testing.T) {
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	cfg.FlightRecorder.RequireReceipts = true
+	p, err := New(cfg, logger, sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	host := testLoopbackIP
+	port := "9999"
+	rt := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			Body: io.NopCloser(strings.NewReader("data: ok\n\n")),
+		}, nil
+	})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"https://"+net.JoinHostPort(host, port)+"/events", nil)
+
+	resp := interceptWithRT(t, cache, pool, cfg, sc, logger, m, rt,
+		&InterceptContext{Proxy: p, TargetHost: host, TargetPort: port}, req)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "data: ok") {
+		t.Fatalf("body = %q, want SSE payload", body)
+	}
+
+	receipts := rph.findReceipts(t)
+	if len(receipts) != 2 {
+		t.Fatalf("receipt count = %d, want intent/outcome pair", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("intent decision_phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+	if receipts[1].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
+		t.Fatalf("outcome decision_phase = %q, want %q", receipts[1].ActionRecord.DecisionPhase, receipt.DecisionPhaseOutcome)
+	}
+	if receipts[1].ActionRecord.ActionID != receipts[0].ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %s, want %s", receipts[1].ActionRecord.ActionID, receipts[0].ActionRecord.ActionID)
+	}
+	if !strings.Contains(receipts[1].ActionRecord.Pattern, "status=200") {
+		t.Fatalf("outcome pattern = %q, want status=200", receipts[1].ActionRecord.Pattern)
+	}
+}
+
+func TestInterceptTunnel_SSERequireReceiptsFailureBlocksBeforeClientDelivery(t *testing.T) {
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	cfg.FlightRecorder.RequireReceipts = true
+	p, err := New(cfg, logger, sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	if err := rph.rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	host := testLoopbackIP
+	port := "9999"
+	rt := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			Body: io.NopCloser(strings.NewReader("data: must-not-deliver\n\n")),
+		}, nil
+	})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"https://"+net.JoinHostPort(host, port)+"/events", nil)
+
+	resp := interceptWithRT(t, cache, pool, cfg, sc, logger, m, rt,
+		&InterceptContext{Proxy: p, TargetHost: host, TargetPort: port}, req)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if strings.Contains(string(body), "must-not-deliver") {
+		t.Fatalf("body = %q, SSE bytes reached client after required receipt failure", body)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="intercept"} 1`)
+}
+
 // TestInterceptTunnel_A2ACompressedSSEStreamBlocked verifies that a compressed
 // A2A SSE stream is explicitly blocked (defense-in-depth guard at ~line 751).
 func TestInterceptTunnel_A2ACompressedSSEStreamBlocked(t *testing.T) {

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -111,6 +113,104 @@ func TestInterceptEmitReceiptOrBlockRequiresReceipt(t *testing.T) {
 	}
 	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="intercept"} 1`)
+}
+
+func TestInterceptEmitReceiptOrBlockRequireReceiptsEmitsIntent(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.FlightRecorder.RequireReceipts = true
+	cfg.ApplyDefaults()
+	cfg.Internal = nil
+
+	m := metrics.New()
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, audit.NewNop(), sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	ic := &InterceptContext{
+		Proxy:     p,
+		Config:    cfg,
+		Logger:    audit.NewNop(),
+		RequestID: "req-intercept-intent",
+		Agent:     "agent",
+	}
+	rr := httptest.NewRecorder()
+	blocked := interceptEmitReceiptOrBlock(ic, rr, audit.NewRequestLogContext(ic.RequestID), receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: TransportConnect,
+		Method:    http.MethodGet,
+		Target:    "https://example.test/",
+		RequestID: ic.RequestID,
+		Agent:     ic.Agent,
+	})
+	if blocked {
+		t.Fatal("clean required receipt blocked")
+	}
+	waitForReceiptOrTimeout(t, rph.dir)
+	if err := rph.rec.Close(); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
+	receipts := extractReceiptsFromDir(t, rph.dir)
+	if len(receipts) != 1 {
+		t.Fatalf("receipt count = %d, want 1", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("decision_phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+}
+
+func TestInterceptEmitReceiptOrBlockRequireReceiptsSyncFailureBlocks(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.FlightRecorder.RequireReceipts = true
+	cfg.ApplyDefaults()
+	cfg.Internal = nil
+
+	m := metrics.New()
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, audit.NewNop(), sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	syncErr := errors.New("injected durable sync failure")
+	rph.rec.SetSyncForTest(func(*os.File) error {
+		return syncErr
+	})
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	ic := &InterceptContext{
+		Proxy:     p,
+		Config:    cfg,
+		Logger:    audit.NewNop(),
+		RequestID: "req-intercept-durable-fail",
+		Agent:     "agent",
+	}
+	rr := httptest.NewRecorder()
+	blocked := interceptEmitReceiptOrBlock(ic, rr, audit.NewRequestLogContext(ic.RequestID), receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: TransportConnect,
+		Method:    http.MethodGet,
+		Target:    "https://example.test/",
+		RequestID: ic.RequestID,
+		Agent:     ic.Agent,
+	})
+	if !blocked {
+		t.Fatal("durability failure did not fail closed")
+	}
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="durability",transport="connect"} 1`)
+	if err := rph.rec.Close(); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
 }
 
 func TestInterceptEmitReceiptOrBlockUnavailableEmitterRecordsMetric(t *testing.T) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -10,6 +10,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -1132,6 +1133,10 @@ type receiptEmitterStage struct {
 	// key as emitter and dual-emitted with it. nil when receipts are
 	// disabled. Published to p.v2EmitterPtr alongside emitter.
 	v2 *proxydecision.Emitter
+	// reuseExisting is true when the staged v1 emitter is the already-live
+	// emitter for the same signing key. Publish must update its config hash but
+	// must not emit a second session_open.
+	reuseExisting bool
 	// keyPath is the signing key path that was actually loaded, or ""
 	// when receipts are disabled. The caller assigns this to
 	// p.receiptKeyPath at publish time.
@@ -1179,6 +1184,28 @@ func (p *Proxy) buildReceiptEmitter(cfg *config.Config) (receiptEmitterStage, er
 	// (e.g. key rotation). Cross-restart the chain restarts at genesis; the
 	// recorder's outer hash chain provides tamper-evidence across restarts.
 	resumeSeq, resumePrev := p.v2EmitterPtr.Load().ChainState()
+	currentKeyHex := fmt.Sprintf("%x", privKey.Public().(ed25519.PublicKey))
+	if current := p.receiptEmitterPtr.Load(); current != nil && current.InitError() == nil && current.SignerKeyHex() == currentKeyHex {
+		v2 := p.v2EmitterPtr.Load()
+		if v2 == nil {
+			v2 = proxydecision.NewEmitter(proxydecision.EmitterConfig{
+				Recorder:       p.recorder,
+				Signer:         proxydecision.NewKeyedSigner(privKey),
+				Sanitize:       proxydecision.SanitizeFromRedactor(p.recorder.ReceiptRedactor()),
+				Principal:      "local",
+				Actor:          "pipelock",
+				ResumeSeq:      resumeSeq,
+				ResumePrevHash: resumePrev,
+			})
+		}
+		return receiptEmitterStage{
+			emitter:       current,
+			v2:            v2,
+			reuseExisting: true,
+			keyPath:       keyPath,
+		}, nil
+	}
+
 	emitter := receipt.NewEmitter(receipt.EmitterConfig{
 		Recorder:   p.recorder,
 		PrivKey:    privKey,
@@ -1615,7 +1642,9 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		// rotation segment. Emit the signed open synchronously before publishing
 		// the pointer so no request can be attested under the new emitter before
 		// its run window is recorded.
-		if receiptStage.emitter != nil {
+		if receiptStage.reuseExisting {
+			receiptStage.emitter.UpdateConfigHash(cfg.Hash())
+		} else if receiptStage.emitter != nil {
 			if err := receiptStage.emitter.EmitSessionOpen(); err != nil {
 				p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
 					fmt.Errorf("session_open receipt emit failed, keeping old config: %w", err))
@@ -1716,9 +1745,9 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 	}
 	p.updateCEEStats()
 
-	// Receipt emitter hash is updated by the receipt emitter build above.
-	// No separate UpdateConfigHash needed - emitter is always (re)created
-	// with the current cfg.Hash() when a signing key is configured.
+	// Receipt emitter hash is updated by the receipt emitter publish above.
+	// Same-key reloads reuse the live v1/v2 emitters to avoid stale-pointer
+	// chain forks; signer rotations still create a new segment.
 	return true
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -96,6 +97,10 @@ const (
 	// into ModifyResponse so required response passthrough allow receipts can
 	// reuse the same action identity before client egress.
 	ctxKeyReverseActionID
+	// ctxKeyReverseOutcome carries the per-request reverse-proxy outcome
+	// tracker. httputil.ReverseProxy completes through callbacks, so ServeHTTP
+	// owns final emission while callbacks only record status/bytes/reason.
+	ctxKeyReverseOutcome
 
 	// ctxKeyEnvelopeEmitter snapshots the fetch/forward envelope emitter
 	// decision, including an explicit nil when signing was off at
@@ -1038,6 +1043,33 @@ func (p *Proxy) emitRequiredReceiptWithEmitter(opts receipt.EmitOpts, e *receipt
 	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
 	p.emitV2Receipt(opts)
 	return nil
+}
+
+const receiptOutcomeLayer = "outcome"
+
+func receiptOutcomePattern(status string, bytesTransferred int64, reason string) string {
+	if status == "" {
+		status = "unknown"
+	}
+	if reason == "" {
+		reason = "complete"
+	}
+	bytesValue := "unknown"
+	if bytesTransferred >= 0 {
+		bytesValue = strconv.FormatInt(bytesTransferred, 10)
+	}
+	return fmt.Sprintf("status=%s bytes=%s reason=%s", status, bytesValue, reason)
+}
+
+func (p *Proxy) emitOutcomeReceipt(cfg *config.Config, opts receipt.EmitOpts, status string, bytesTransferred int64, reason string) {
+	if cfg == nil || !cfg.FlightRecorder.RequireReceipts {
+		return
+	}
+	opts.DecisionPhase = receipt.DecisionPhaseOutcome
+	opts.Verdict = config.ActionAllow
+	opts.Layer = receiptOutcomeLayer
+	opts.Pattern = receiptOutcomePattern(status, bytesTransferred, reason)
+	_ = p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
 }
 
 func (p *Proxy) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter) error {
@@ -4134,6 +4166,12 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	outcomeStatus := "unknown"
+	outcomeBytes := int64(-1)
+	outcomeReason := "incomplete"
+	defer func() {
+		p.emitOutcomeReceipt(cfg, fetchAllowReceipt, outcomeStatus, outcomeBytes, outcomeReason)
+	}()
 
 	resp, err := p.client.Do(req) //nolint:gosec // G704: URL validated by scanner pipeline before reaching here
 	if err != nil {
@@ -4170,6 +4208,8 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			writeBlockedJSON(w,
 				redirectBlockedInfo(blockedErr),
 				http.StatusForbidden, resp)
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeReason = blockedErr.layer
 			return
 		}
 		log.LogError(actx, err)
@@ -4178,6 +4218,8 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			Agent: agent,
 			Error: fmt.Sprintf("fetch failed: %v", err),
 		})
+		outcomeStatus = strconv.Itoa(http.StatusBadGateway)
+		outcomeReason = "fetch_failed"
 		return
 	}
 	defer safeClose(resp.Body, "resp.Body", p.logger)
@@ -4211,6 +4253,8 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 				Blocked:     true,
 				BlockReason: "compressed response cannot be scanned",
 			})
+		outcomeStatus = strconv.Itoa(http.StatusForbidden)
+		outcomeReason = "compressed_response"
 		return
 	}
 
@@ -4236,6 +4280,8 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			Agent: agent,
 			Error: fmt.Sprintf("reading response: %v", err),
 		})
+		outcomeStatus = strconv.Itoa(http.StatusBadGateway)
+		outcomeReason = "response_read_error"
 		return
 	}
 	if int64(len(body)) > maxBytes {
@@ -4265,6 +4311,8 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 					Blocked:     true,
 					BlockReason: reason,
 				})
+			outcomeStatus = strconv.Itoa(http.StatusBadGateway)
+			outcomeReason = "response_size"
 			return
 		}
 		// Budget was the limiter: return 429.
@@ -4291,6 +4339,9 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 				Blocked:     true,
 				BlockReason: reason,
 			})
+		outcomeStatus = strconv.Itoa(http.StatusTooManyRequests)
+		outcomeBytes = int64(len(body))
+		outcomeReason = "budget"
 		return
 	}
 
@@ -4324,6 +4375,9 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 				URL: displayURL, Agent: agent, Blocked: true,
 				BlockReason: "response body exceeds browser shield size limit",
 			})
+		outcomeStatus = strconv.Itoa(http.StatusForbidden)
+		outcomeBytes = int64(len(body))
+		outcomeReason = "shield_oversize"
 		return
 	}
 
@@ -4358,6 +4412,9 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 				URL: displayURL, Agent: agent, Blocked: true,
 				BlockReason: mediaVerdict.BlockReason,
 			})
+		outcomeStatus = strconv.Itoa(http.StatusForbidden)
+		outcomeBytes = int64(len(body))
+		outcomeReason = "media_policy"
 		return
 	}
 	if mediaVerdict.StripResult != nil && mediaVerdict.StripResult.Changed() {
@@ -4387,6 +4444,9 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			// Exempt domains: scan for visibility but pin to warn, no adaptive scoring.
 			blocked, _, found := p.filterAndActOnResponseScan(w, rawResult, content, displayURL, agent, clientIP, requestID, actionID, sc, cfg, log, recEscalationLevel(fetchRec), responseScanExempt)
 			if blocked {
+				outcomeStatus = strconv.Itoa(http.StatusForbidden)
+				outcomeBytes = int64(len(body))
+				outcomeReason = "response_scan"
 				return
 			}
 			if found {
@@ -4435,6 +4495,9 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			blockInfoFor(blockreason.PromptInjection, ""),
 			http.StatusForbidden,
 			FetchResponse{URL: displayURL, Agent: agent, Blocked: true, BlockReason: reason})
+		outcomeStatus = strconv.Itoa(http.StatusForbidden)
+		outcomeBytes = int64(len(body))
+		outcomeReason = "response_scan"
 		return
 	}
 
@@ -4482,6 +4545,9 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		}
 		if blocked {
 			p.metrics.RecordBlocked(parsed.Hostname(), "response_scan", time.Since(start), agentLabel)
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeBytes = int64(len(body))
+			outcomeReason = "response_scan"
 			return
 		}
 		content = newContent
@@ -4522,6 +4588,9 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		Content:     content,
 		Blocked:     false,
 	})
+	outcomeStatus = strconv.Itoa(resp.StatusCode)
+	outcomeBytes = int64(len(body))
+	outcomeReason = "complete"
 }
 
 func recordSuppressedResponseScanExempts(m *metrics.Metrics, matches []scanner.ResponseMatch, transport string) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1556,6 +1556,21 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		p.v2EmitterPtr.Store(nil)
 		p.receiptKeyPath = ""
 	} else if p.recorder != nil {
+		// A rebuilt emitter has a fresh run_nonce and may represent a signer
+		// rotation segment. Emit the signed open synchronously before publishing
+		// the pointer so no request can be attested under the new emitter before
+		// its run window is recorded.
+		if receiptStage.emitter != nil {
+			if err := receiptStage.emitter.EmitSessionOpen(); err != nil {
+				p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
+					fmt.Errorf("session_open receipt emit failed, keeping old config: %w", err))
+				sc.Close()
+				if newEd != nil {
+					newEd.Close()
+				}
+				return false
+			}
+		}
 		p.receiptEmitterPtr.Store(receiptStage.emitter)
 		p.v2EmitterPtr.Store(receiptStage.v2)
 		p.receiptKeyPath = receiptStage.keyPath

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -92,6 +92,10 @@ const (
 	// reload between ServeHTTP and RoundTrip could flip signing on/off
 	// mid-request - a TOCTOU race flagged by CodeRabbit on PR #403.
 	ctxKeyReverseEnvelopeEmitter
+	// ctxKeyReverseActionID carries the reverse-proxy admission action_id
+	// into ModifyResponse so required response passthrough allow receipts can
+	// reuse the same action identity before client egress.
+	ctxKeyReverseActionID
 
 	// ctxKeyEnvelopeEmitter snapshots the fetch/forward envelope emitter
 	// decision, including an explicit nil when signing was off at
@@ -997,6 +1001,9 @@ func requiredReceiptBlockMetricReason(err error) string {
 	if errors.Is(err, errReceiptEmitterUnavailable) {
 		return receipt.FailReasonUnavailable
 	}
+	if errors.Is(err, recorder.ErrDurability) {
+		return "durability"
+	}
 	return "emit_error"
 }
 
@@ -1010,10 +1017,26 @@ func (p *Proxy) emitRequiredReceipt(opts receipt.EmitOpts) error {
 		p.recordRequiredReceiptBlock(err, opts.Transport)
 		return err
 	}
-	if err := p.emitReceiptWithEmitter(opts, e); err != nil {
+	if err := p.emitRequiredReceiptWithEmitter(opts, e); err != nil {
 		p.recordRequiredReceiptBlock(err, opts.Transport)
 		return err
 	}
+	return nil
+}
+
+func (p *Proxy) emitRequiredReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter) error {
+	if e == nil {
+		return nil
+	}
+	opts.DecisionPhase = receipt.DecisionPhaseIntent
+	if err := e.EmitDurable(opts); err != nil {
+		p.logReceiptEmissionFailure(opts, err)
+		// v1 stays authoritative: skip v2 when v1 failed to record, so a
+		// proxy_decision never outlives its action_receipt sibling.
+		return err
+	}
+	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
+	p.emitV2Receipt(opts)
 	return nil
 }
 

--- a/internal/proxy/receipt_coverage_test.go
+++ b/internal/proxy/receipt_coverage_test.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -138,6 +139,9 @@ func TestReceiptCoverage_ChainIntegrity_CrossTransport(t *testing.T) {
 
 	dir := t.TempDir()
 	emitter, rec, pubKey := newCoverageEmitter(t, dir)
+	if err := emitter.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
 
 	// Emit receipts across three different transports.
 	transports := []struct {
@@ -173,8 +177,8 @@ func TestReceiptCoverage_ChainIntegrity_CrossTransport(t *testing.T) {
 	}
 
 	receipts := extractReceiptsFromDir(t, dir)
-	if len(receipts) != 3 {
-		t.Fatalf("expected 3 receipts, got %d", len(receipts))
+	if len(receipts) != 4 {
+		t.Fatalf("expected 4 receipts, got %d", len(receipts))
 	}
 
 	// Verify chain via receipt.VerifyChain.
@@ -183,14 +187,14 @@ func TestReceiptCoverage_ChainIntegrity_CrossTransport(t *testing.T) {
 	if !result.Valid {
 		t.Fatalf("VerifyChain failed: %s (broken at seq %d)", result.Error, result.BrokenAtSeq)
 	}
-	if result.ReceiptCount != 3 {
-		t.Errorf("receipt_count = %d, want 3", result.ReceiptCount)
+	if result.ReceiptCount != 4 {
+		t.Errorf("receipt_count = %d, want 4", result.ReceiptCount)
 	}
 
-	// Assert first receipt has genesis prev_hash.
-	if receipts[0].ActionRecord.ChainPrevHash != receipt.GenesisHash {
-		t.Errorf("first receipt chain_prev_hash = %q, want %q",
-			receipts[0].ActionRecord.ChainPrevHash, receipt.GenesisHash)
+	// Assert first receipt has bound session-open genesis.
+	if receipts[0].ActionRecord.SessionControl == nil ||
+		receipts[0].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
+		t.Fatalf("first receipt session_control = %+v, want session_open", receipts[0].ActionRecord.SessionControl)
 	}
 
 	// Assert chain_seq increments monotonically.
@@ -214,9 +218,10 @@ func TestReceiptCoverage_ChainIntegrity_CrossTransport(t *testing.T) {
 
 	// Assert each receipt has the correct transport.
 	for i, tc := range transports {
-		if receipts[i].ActionRecord.Transport != tc.transport {
+		idx := i + 1
+		if receipts[idx].ActionRecord.Transport != tc.transport {
 			t.Errorf("receipt[%d] transport = %q, want %q",
-				i, receipts[i].ActionRecord.Transport, tc.transport)
+				idx, receipts[idx].ActionRecord.Transport, tc.transport)
 		}
 	}
 }
@@ -769,6 +774,9 @@ func TestReceiptCoverage_ChainIntegrity_FiveTransports(t *testing.T) {
 
 	dir := t.TempDir()
 	emitter, rec, pubKey := newCoverageEmitter(t, dir)
+	if err := emitter.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
 
 	allTransports := []struct {
 		transport string
@@ -806,8 +814,8 @@ func TestReceiptCoverage_ChainIntegrity_FiveTransports(t *testing.T) {
 	}
 
 	receipts := extractReceiptsFromDir(t, dir)
-	if len(receipts) != 5 {
-		t.Fatalf("expected 5 receipts, got %d", len(receipts))
+	if len(receipts) != 6 {
+		t.Fatalf("expected 6 receipts, got %d", len(receipts))
 	}
 
 	keyHex := hex.EncodeToString(pubKey)
@@ -815,11 +823,11 @@ func TestReceiptCoverage_ChainIntegrity_FiveTransports(t *testing.T) {
 	if !result.Valid {
 		t.Fatalf("VerifyChain failed across 5 transports: %s", result.Error)
 	}
-	if result.ReceiptCount != 5 {
-		t.Errorf("receipt_count = %d, want 5", result.ReceiptCount)
+	if result.ReceiptCount != 6 {
+		t.Errorf("receipt_count = %d, want 6", result.ReceiptCount)
 	}
-	if result.FinalSeq != 4 {
-		t.Errorf("final_seq = %d, want 4", result.FinalSeq)
+	if result.FinalSeq != 5 {
+		t.Errorf("final_seq = %d, want 5", result.FinalSeq)
 	}
 
 	// Verify timestamps are ordered.
@@ -1042,6 +1050,38 @@ func (rph *receiptProxyHelper) requireReceipt(t *testing.T, layer string) receip
 	return receipt.Receipt{} // unreachable
 }
 
+func (rph *receiptProxyHelper) emitSessionOpen(t *testing.T) {
+	t.Helper()
+	if err := rph.emitter.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+}
+
+func assertSessionOpenPrecedesTransport(t *testing.T, receipts []receipt.Receipt, transport string) {
+	t.Helper()
+	if len(receipts) < 2 {
+		t.Fatalf("receipt count = %d, want session_open plus %s receipt", len(receipts), transport)
+	}
+	if receipts[0].ActionRecord.SessionControl == nil ||
+		receipts[0].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
+		t.Fatalf("first receipt session_control = %+v, want session_open before %s egress",
+			receipts[0].ActionRecord.SessionControl, transport)
+	}
+	for i, r := range receipts[1:] {
+		if r.ActionRecord.Transport == transport {
+			if r.ActionRecord.SessionControl != nil {
+				t.Fatalf("transport receipt %d carried session_control: %+v", i+1, r.ActionRecord.SessionControl)
+			}
+			return
+		}
+	}
+	var transports []string
+	for _, r := range receipts {
+		transports = append(transports, r.ActionRecord.Transport)
+	}
+	t.Fatalf("no %s receipt found after session_open; transports=%v", transport, transports)
+}
+
 // setupFetchProxyWithReceipts creates a proxy handler (httptest style) with
 // receipt emission enabled.
 func setupFetchProxyWithReceipts(t *testing.T, rph *receiptProxyHelper, cfgMod func(*config.Config)) http.Handler {
@@ -1206,6 +1246,103 @@ func setupForwardProxyWithReceipts(t *testing.T, rph *receiptProxyHelper, cfgMod
 		cancel()
 		_ = ln.Close()
 		p.Close()
+	}
+}
+
+func TestReceiptCoverage_SessionOpenPrecedesFirstEgressPerHTTPTransport(t *testing.T) {
+	tests := map[string]struct {
+		wantTransport string
+		run           func(t *testing.T, rph *receiptProxyHelper)
+	}{
+		"fetch": {
+			wantTransport: TransportFetch,
+			run: func(t *testing.T, rph *receiptProxyHelper) {
+				handler := setupFetchProxyWithReceipts(t, rph, func(cfg *config.Config) {
+					cfg.Enforce = ptrBool(true)
+					cfg.FetchProxy.Monitoring.Blocklist = []string{"evil.example.com"}
+				})
+				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url=https://evil.example.com/exfil", nil)
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("fetch status = %d, want 403; body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		"forward": {
+			wantTransport: TransportForward,
+			run: func(t *testing.T, rph *receiptProxyHelper) {
+				proxyAddr, cleanup := setupForwardProxyWithReceipts(t, rph, func(cfg *config.Config) {
+					cfg.Enforce = ptrBool(true)
+					cfg.FetchProxy.Monitoring.Blocklist = []string{"evil.example.com"}
+				})
+				defer cleanup()
+				conn, err := (&net.Dialer{Timeout: 5 * time.Second}).DialContext(t.Context(), "tcp", proxyAddr)
+				if err != nil {
+					t.Fatalf("dial forward proxy: %v", err)
+				}
+				defer func() { _ = conn.Close() }()
+				_, _ = fmt.Fprintf(conn, "GET http://evil.example.com/exfil HTTP/1.1\r\nHost: evil.example.com\r\n\r\n")
+				resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+				if err != nil {
+					t.Fatalf("read forward response: %v", err)
+				}
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode != http.StatusForbidden {
+					t.Fatalf("forward status = %d, want 403", resp.StatusCode)
+				}
+			},
+		},
+		"connect": {
+			wantTransport: TransportConnect,
+			run: func(t *testing.T, rph *receiptProxyHelper) {
+				proxyAddr, cleanup := setupForwardProxyWithReceipts(t, rph, func(cfg *config.Config) {
+					cfg.Enforce = ptrBool(true)
+					cfg.FetchProxy.Monitoring.Blocklist = []string{"evil.example.com"}
+				})
+				defer cleanup()
+				conn, err := (&net.Dialer{Timeout: 5 * time.Second}).DialContext(t.Context(), "tcp", proxyAddr)
+				if err != nil {
+					t.Fatalf("dial forward proxy: %v", err)
+				}
+				defer func() { _ = conn.Close() }()
+				_, _ = fmt.Fprintf(conn, "CONNECT evil.example.com:443 HTTP/1.1\r\nHost: evil.example.com:443\r\n\r\n")
+				resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+				if err != nil {
+					t.Fatalf("read CONNECT response: %v", err)
+				}
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode != http.StatusForbidden {
+					t.Fatalf("CONNECT status = %d, want 403", resp.StatusCode)
+				}
+			},
+		},
+		"websocket": {
+			wantTransport: TransportWS,
+			run: func(t *testing.T, rph *receiptProxyHelper) {
+				proxyAddr, cleanup := setupWSProxyWithReceipts(t, rph, func(cfg *config.Config) {
+					cfg.Enforce = ptrBool(true)
+					cfg.FetchProxy.Monitoring.Blocklist = []string{"evil.example.com"}
+				})
+				defer cleanup()
+				wsURL := fmt.Sprintf("ws://%s/ws?url=ws://evil.example.com/ws", proxyAddr)
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_, _, _, err := ws.Dialer{}.Dial(ctx, wsURL)
+				if err == nil {
+					t.Fatal("expected websocket dial to fail for blocklisted domain")
+				}
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			rph := newReceiptProxyHelper(t)
+			rph.emitSessionOpen(t)
+			tc.run(t, rph)
+			assertSessionOpenPrecedesTransport(t, rph.findReceipts(t), tc.wantTransport)
+		})
 	}
 }
 

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -380,6 +380,11 @@ func TestRequiredReceiptBlockMetricReason(t *testing.T) {
 			want: "emit_error",
 		},
 		{
+			name: "durability failure",
+			err:  fmt.Errorf("recording receipt: %w", recorder.ErrDurability),
+			want: "durability",
+		},
+		{
 			name: "nil",
 			err:  nil,
 			want: "emit_error",

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/crypto/nacl/box"
+
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
@@ -780,6 +782,184 @@ fetch_proxy:
 	t.Fatal("no receipt found after aborted reload")
 }
 
+func TestProxy_ReloadSessionOpenEmitFailurePreservesLiveEmitter(t *testing.T) {
+	t.Parallel()
+
+	recDir := t.TempDir()
+	keyDir := t.TempDir()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	recipientPub, _, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("box.GenerateKey: %v", err)
+	}
+
+	keyPath := filepath.Join(keyDir, "receipt.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                recDir,
+		CheckpointInterval: 1000,
+		RawEscrow:          true,
+		EscrowPublicKey:    hex.EncodeToString(recipientPub[:]),
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+
+	startCfgPath := filepath.Join(keyDir, "start.yaml")
+	startYAML := fmt.Sprintf(`mode: balanced
+flight_recorder:
+  signing_key_path: %s
+fetch_proxy:
+  monitoring:
+    blocklist:
+      - evil.example.com
+`, keyPath)
+	if err := os.WriteFile(startCfgPath, []byte(startYAML), 0o600); err != nil {
+		t.Fatalf("WriteFile start config: %v", err)
+	}
+	cfg, err := config.Load(startCfgPath)
+	if err != nil {
+		t.Fatalf("config.Load start: %v", err)
+	}
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: cfg.Hash(),
+		Principal:  "local",
+		Actor:      "pipelock",
+	})
+	if err := emitter.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen startup: %v", err)
+	}
+
+	logger := audit.NewNop()
+	sc := scanner.New(cfg)
+	m := metrics.New()
+
+	p, pErr := New(cfg, logger, sc, m,
+		WithRecorder(rec),
+		WithReceiptEmitter(emitter),
+		WithReceiptKeyPath(keyPath),
+	)
+	if pErr != nil {
+		t.Fatalf("proxy.New: %v", pErr)
+	}
+	defer func() { _ = rec.Close() }()
+
+	beforeEmitter := p.receiptEmitterPtr.Load()
+	if beforeEmitter == nil {
+		t.Fatal("expected non-nil emitter before reload")
+	}
+
+	reloadCfgPath := filepath.Join(keyDir, "reload.yaml")
+	reloadYAML := fmt.Sprintf(`mode: balanced
+flight_recorder:
+  signing_key_path: %s
+fetch_proxy:
+  monitoring:
+    blocklist:
+      - other.example.com
+`, keyPath)
+	if err := os.WriteFile(reloadCfgPath, []byte(reloadYAML), 0o600); err != nil {
+		t.Fatalf("WriteFile reload config: %v", err)
+	}
+	reloadCfg, err := config.Load(reloadCfgPath)
+	if err != nil {
+		t.Fatalf("config.Load reload: %v", err)
+	}
+	reloadCfg.Internal = nil
+	reloadCfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	if cfg.Hash() == reloadCfg.Hash() {
+		t.Fatal("expected distinct config hashes for failed reload")
+	}
+
+	if err := os.Chmod(recDir, 0o500); err != nil { // #nosec G302 -- deliberately read-only dir to force raw-escrow write failure
+		t.Fatalf("Chmod recDir read-only: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(recDir, 0o750) // #nosec G302 -- restore traversable dir perms for TempDir cleanup
+	})
+
+	reloadSc := scanner.New(reloadCfg)
+	if p.Reload(reloadCfg, reloadSc) {
+		t.Fatal("reload unexpectedly succeeded after session_open emit failure")
+	}
+
+	if err := os.Chmod(recDir, 0o750); err != nil { // #nosec G302 -- restore recorder dir after forced failure
+		t.Fatalf("Chmod recDir writable: %v", err)
+	}
+	if p.CurrentConfig() != cfg {
+		t.Fatal("session_open emit failure should preserve the old config")
+	}
+	if afterEmitter := p.receiptEmitterPtr.Load(); afterEmitter != beforeEmitter {
+		t.Fatal("receipt emitter changed even though reload session_open emission failed")
+	}
+
+	handler := p.buildHandler(p.buildMux())
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url=https://evil.example.com/exfil", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for old blocklist after aborted reload, got %d", w.Code)
+	}
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	entries := readAllEntries(t, recDir)
+	var receipts []receipt.Receipt
+	for _, e := range entries {
+		if e.Type != receiptEntryType {
+			continue
+		}
+		detailJSON, mErr := json.Marshal(e.Detail)
+		if mErr != nil {
+			t.Fatalf("marshal detail: %v", mErr)
+		}
+		r, uErr := receipt.Unmarshal(detailJSON)
+		if uErr != nil {
+			t.Fatalf("unmarshal receipt: %v", uErr)
+		}
+		receipts = append(receipts, r)
+	}
+	if len(receipts) != 2 {
+		t.Fatalf("receipt count = %d, want old session_open and old-policy block receipt", len(receipts))
+	}
+	if receipts[0].ActionRecord.SessionControl == nil ||
+		receipts[0].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
+		t.Fatalf("first receipt session_control = %+v, want old session_open",
+			receipts[0].ActionRecord.SessionControl)
+	}
+	if receipts[1].ActionRecord.SessionControl != nil {
+		t.Fatalf("post-failure request unexpectedly carried session_control: %+v",
+			receipts[1].ActionRecord.SessionControl)
+	}
+	if receipts[1].ActionRecord.PolicyHash != cfg.Hash() {
+		t.Fatalf("post-failure receipt policy hash = %q, want old hash %q",
+			receipts[1].ActionRecord.PolicyHash, cfg.Hash())
+	}
+	if receipts[1].ActionRecord.PolicyHash == reloadCfg.Hash() {
+		t.Fatal("post-failure receipt unexpectedly attested failed reload config")
+	}
+	result := receipt.VerifyChainTrusted(receipts, []string{hex.EncodeToString(pub)})
+	if !result.Valid {
+		t.Fatalf("old emitter chain did not verify after failed reload: %s", result.Error)
+	}
+}
+
 // TestProxy_ReloadReceiptEmitter_NoRecorder verifies that when there is no
 // flight recorder, reload with a signing key is a no-op.
 func TestProxy_ReloadReceiptEmitter_NoRecorder(t *testing.T) {
@@ -935,7 +1115,7 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 	keyDir := t.TempDir()
 
 	// Generate two distinct Ed25519 key pairs.
-	_, privA, err := ed25519.GenerateKey(rand.Reader)
+	pubA, privA, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey A: %v", err)
 	}
@@ -970,6 +1150,9 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 		Principal:  "local",
 		Actor:      "pipelock",
 	})
+	if err := emitterA.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen A: %v", err)
+	}
 
 	// Start proxy with key A.
 	cfg := config.Defaults()
@@ -1033,7 +1216,7 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 
 	expectedKeyHex := hex.EncodeToString(pubB)
 
-	var found bool
+	var receipts []receipt.Receipt
 	for _, e := range entries {
 		if e.Type == receiptEntryType {
 			detailJSON, mErr := json.Marshal(e.Detail)
@@ -1048,16 +1231,38 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 			if err := receipt.VerifyInternalConsistencyOnly(r); err != nil {
 				t.Fatalf("receipt verification failed: %v", err)
 			}
-			// Verify it was signed with key B, not key A.
-			if r.SignerKey != expectedKeyHex {
-				t.Errorf("receipt signed with wrong key: got %s, want %s", r.SignerKey, expectedKeyHex)
-			}
-			found = true
-			break
+			receipts = append(receipts, r)
 		}
 	}
-	if !found {
+	if len(receipts) == 0 {
 		t.Fatal("no receipt found after key rotation reload")
+	}
+	if len(receipts) != 3 {
+		t.Fatalf("receipt count = %d, want startup open, rotated open, and blocked fetch receipt", len(receipts))
+	}
+	if receipts[0].ActionRecord.SessionControl == nil ||
+		receipts[0].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
+		t.Fatalf("first receipt session_control = %+v, want session_open", receipts[0].ActionRecord.SessionControl)
+	}
+	if receipts[1].ActionRecord.SessionControl == nil ||
+		receipts[1].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
+		t.Fatalf("rotated first receipt session_control = %+v, want session_open", receipts[1].ActionRecord.SessionControl)
+	}
+	if receipts[1].ActionRecord.KeyTransition == nil {
+		t.Fatal("rotated session_open missing key_transition")
+	}
+	if receipts[2].ActionRecord.SessionControl != nil {
+		t.Fatalf("post-reload egress receipt unexpectedly carried session_control: %+v", receipts[2].ActionRecord.SessionControl)
+	}
+	if receipts[2].SignerKey != expectedKeyHex {
+		t.Errorf("post-reload egress receipt signed with wrong key: got %s, want %s", receipts[2].SignerKey, expectedKeyHex)
+	}
+	result := receipt.VerifyChainTrusted(receipts, []string{
+		hex.EncodeToString(pubA),
+		expectedKeyHex,
+	})
+	if !result.Valid {
+		t.Fatalf("rotated session_open chain did not verify: %s", result.Error)
 	}
 }
 

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -797,6 +797,10 @@ func TestProxy_ReloadSessionOpenEmitFailurePreservesLiveEmitter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
+	_, reloadPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey reload: %v", err)
+	}
 	recipientPub, _, err := box.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("box.GenerateKey: %v", err)
@@ -805,6 +809,10 @@ func TestProxy_ReloadSessionOpenEmitFailurePreservesLiveEmitter(t *testing.T) {
 	keyPath := filepath.Join(keyDir, "receipt.key")
 	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
 		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	reloadKeyPath := filepath.Join(keyDir, "receipt-reload.key")
+	if err := signing.SavePrivateKey(reloadPriv, reloadKeyPath); err != nil {
+		t.Fatalf("SavePrivateKey reload: %v", err)
 	}
 
 	rec, err := recorder.New(recorder.Config{
@@ -875,7 +883,7 @@ fetch_proxy:
   monitoring:
     blocklist:
       - other.example.com
-`, keyPath)
+`, reloadKeyPath)
 	if err := os.WriteFile(reloadCfgPath, []byte(reloadYAML), 0o600); err != nil {
 		t.Fatalf("WriteFile reload config: %v", err)
 	}
@@ -1065,8 +1073,11 @@ func TestProxy_ReloadReceiptEmitter_UpdatesHash(t *testing.T) {
 	}
 	defer func() { _ = rec.Close() }()
 
-	// Reload with a different config (same key path) - emitter is recreated
-	// (always re-reads key file to detect in-place rotation) but uses updated hash.
+	origEmitter := p.receiptEmitterPtr.Load()
+
+	// Reload with a different config and the same signing key. The v1 emitter
+	// must be reused so in-flight heartbeats/actions cannot race a replacement
+	// emitter that snapshotted an older chain tail.
 	reloadCfg := config.Defaults()
 	reloadCfg.Internal = nil
 	reloadCfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
@@ -1078,6 +1089,9 @@ func TestProxy_ReloadReceiptEmitter_UpdatesHash(t *testing.T) {
 
 	if p.receiptEmitterPtr.Load() == nil {
 		t.Fatal("expected non-nil emitter after reload with same key")
+	}
+	if got := p.receiptEmitterPtr.Load(); got != origEmitter {
+		t.Fatal("same-key reload replaced the v1 receipt emitter")
 	}
 
 	// Verify the updated hash is used in emitted receipts.
@@ -1108,6 +1122,101 @@ func TestProxy_ReloadReceiptEmitter_UpdatesHash(t *testing.T) {
 		}
 	}
 	t.Fatal("no receipt found after reload")
+}
+
+func TestProxy_ReloadSameSigningKeyReusesEmitterSoStaleHeartbeatCannotFork(t *testing.T) {
+	t.Parallel()
+
+	recDir := t.TempDir()
+	keyDir := t.TempDir()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyPath := filepath.Join(keyDir, "receipt.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                recDir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: "hash-v1",
+		Principal:  "local",
+		Actor:      "pipelock",
+	})
+	if err := emitter.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.FlightRecorder.SigningKeyPath = keyPath
+
+	p, pErr := New(cfg, audit.NewNop(), scanner.New(cfg), metrics.New(),
+		WithRecorder(rec),
+		WithReceiptEmitter(emitter),
+		WithReceiptKeyPath(keyPath),
+	)
+	if pErr != nil {
+		t.Fatalf("proxy.New: %v", pErr)
+	}
+	origEmitter := p.receiptEmitterPtr.Load()
+
+	reloadCfg := config.Defaults()
+	reloadCfg.Internal = nil
+	reloadCfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	reloadCfg.FlightRecorder.SigningKeyPath = keyPath
+	reloadCfg.FetchProxy.Monitoring.Blocklist = []string{"evil.example.com"}
+	if !p.Reload(reloadCfg, scanner.New(reloadCfg)) {
+		t.Fatal("Reload returned false")
+	}
+	if got := p.receiptEmitterPtr.Load(); got != origEmitter {
+		t.Fatal("same-key reload replaced the v1 receipt emitter")
+	}
+
+	// Simulate a heartbeat tick that captured the pre-reload pointer. If reload
+	// had created a replacement emitter, that stale tick would append from the
+	// old chain head after the replacement's session_open and fork the v1 chain.
+	if err := origEmitter.EmitHeartbeat(); err != nil {
+		t.Fatalf("stale-pointer EmitHeartbeat: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	var receipts []receipt.Receipt
+	for _, e := range readAllEntries(t, recDir) {
+		if e.Type != receiptEntryType {
+			continue
+		}
+		detailJSON, mErr := json.Marshal(e.Detail)
+		if mErr != nil {
+			t.Fatalf("marshal receipt detail: %v", mErr)
+		}
+		rcpt, uErr := receipt.Unmarshal(detailJSON)
+		if uErr != nil {
+			t.Fatalf("unmarshal receipt: %v", uErr)
+		}
+		receipts = append(receipts, rcpt)
+	}
+	if len(receipts) != 2 {
+		t.Fatalf("receipts = %d, want session_open + heartbeat", len(receipts))
+	}
+	if res := receipt.VerifyChainTrusted(receipts, []string{hex.EncodeToString(pub)}); !res.Valid {
+		t.Fatalf("VerifyChainTrusted: %s", res.Error)
+	}
 }
 
 // TestProxy_ReloadRotatesSigningKey verifies that changing the signing key

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -299,6 +299,17 @@ func (rp *ReverseProxyHandler) emitRequiredReceiptWithEmitter(opts receipt.EmitO
 	return nil
 }
 
+func (rp *ReverseProxyHandler) emitOutcomeReceipt(cfg *config.Config, opts receipt.EmitOpts, status string, bytesTransferred int64, reason string) {
+	if cfg == nil || !cfg.FlightRecorder.RequireReceipts {
+		return
+	}
+	opts.DecisionPhase = receipt.DecisionPhaseOutcome
+	opts.Verdict = config.ActionAllow
+	opts.Layer = receiptOutcomeLayer
+	opts.Pattern = receiptOutcomePattern(status, bytesTransferred, reason)
+	_ = rp.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+}
+
 func (rp *ReverseProxyHandler) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter) error {
 	if e == nil {
 		return nil
@@ -895,7 +906,16 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
-	r = r.WithContext(context.WithValue(r.Context(), ctxKeyReverseActionID, reverseActionID))
+	var outcomeTracker *reverseOutcomeTracker
+	if cfg.FlightRecorder.RequireReceipts {
+		outcomeTracker = newReverseOutcomeTracker(cfg, withReceiptPolicyHash(reverseAllowReceipt, cfg.CanonicalPolicyHash()))
+		defer outcomeTracker.EmitOnce(rp)
+	}
+	ctx = context.WithValue(r.Context(), ctxKeyReverseActionID, reverseActionID)
+	if outcomeTracker != nil {
+		ctx = context.WithValue(ctx, ctxKeyReverseOutcome, outcomeTracker)
+	}
+	r = r.WithContext(ctx)
 
 	// Stash envelope build metadata on the request context so the
 	// signing RoundTripper (installed on rp.proxy.Transport) can
@@ -954,6 +974,68 @@ type reverseBlockReceiptInput struct {
 	RequestID string
 	Agent     string
 	Target    string
+}
+
+type reverseOutcomeTracker struct {
+	mu               sync.Mutex
+	cfg              *config.Config
+	opts             receipt.EmitOpts
+	status           string
+	bytesTransferred int64
+	reason           string
+	emitted          bool
+}
+
+func newReverseOutcomeTracker(cfg *config.Config, opts receipt.EmitOpts) *reverseOutcomeTracker {
+	return &reverseOutcomeTracker{
+		cfg:              cfg,
+		opts:             opts,
+		status:           "unknown",
+		bytesTransferred: -1,
+		reason:           "incomplete",
+	}
+}
+
+func reverseOutcomeFromContext(ctx context.Context) *reverseOutcomeTracker {
+	tracker, _ := ctx.Value(ctxKeyReverseOutcome).(*reverseOutcomeTracker)
+	return tracker
+}
+
+func (t *reverseOutcomeTracker) Record(status int, bytesTransferred int64, reason string) {
+	if t == nil {
+		return
+	}
+	statusText := "unknown"
+	if status > 0 {
+		statusText = strconv.Itoa(status)
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.emitted {
+		return
+	}
+	t.status = statusText
+	t.bytesTransferred = bytesTransferred
+	t.reason = reason
+}
+
+func (t *reverseOutcomeTracker) EmitOnce(rp *ReverseProxyHandler) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	if t.emitted {
+		t.mu.Unlock()
+		return
+	}
+	t.emitted = true
+	cfg := t.cfg
+	opts := t.opts
+	status := t.status
+	bytesTransferred := t.bytesTransferred
+	reason := t.reason
+	t.mu.Unlock()
+	rp.emitOutcomeReceipt(cfg, opts, status, bytesTransferred, reason)
 }
 
 // RoundTrip implements http.RoundTripper. It runs envelope injection
@@ -1204,6 +1286,10 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		requestActionID = actionID
 	}
 	targetURL := resp.Request.URL.String()
+	outcomeTracker := reverseOutcomeFromContext(resp.Request.Context())
+	recordReverseOutcome := func(status int, bytesTransferred int64, reason string) {
+		outcomeTracker.Record(status, bytesTransferred, reason)
+	}
 
 	// Record the final client-visible status at each exit point, not here.
 	// The upstream status may be rewritten to 403 by scanning decisions.
@@ -1213,7 +1299,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 	revHost := resp.Request.URL.Hostname()
 	revRespExempt := isResponseScanExempt(revHost, cfg.ResponseScanning.ExemptDomains)
 	revRespSizeExempt := isResponseSizeExempt(revHost, cfg.ResponseScanning.SizeExemptDomains)
-	emitUnscannablePassthrough := func(actx audit.LogContext, reason string) error {
+	emitUnscannablePassthrough := func(reason string) {
 		passthroughReceipt := receipt.EmitOpts{
 			ActionID:  requestActionID,
 			Verdict:   config.ActionAllow,
@@ -1226,15 +1312,12 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 			Agent:     agent,
 		}
 		if cfg.FlightRecorder.RequireReceipts {
-			if err := rp.emitRequiredReceipt(withReceiptPolicyHash(passthroughReceipt, cfg.CanonicalPolicyHash())); err != nil {
-				blockedErr := newReceiptEmissionBlockedRequest(err)
-				rp.logger.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
-				return err
-			}
-			return nil
+			// The reverse admission intent is already durable before upstream
+			// egress. Under require_receipts, keep that as the single intent and
+			// let the structural outcome finalizer record the passthrough reason.
+			return
 		}
 		emitReverseReceipt(passthroughReceipt)
-		return nil
 	}
 
 	// Media policy runs regardless of response-scanning state so an
@@ -1276,6 +1359,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 				rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
 				rp.metrics.RecordReverseProxyScanBlocked(scanDirectionResponse, "media_policy")
 				replaceWithMediaBlockResponse(resp, verdict.BlockReason)
+				recordReverseOutcome(http.StatusForbidden, -1, "media_policy")
 				return nil
 			}
 			// Fall through to the isBinaryMIME skip below so the
@@ -1286,6 +1370,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 			// run the content-sniffing fallback for generic types
 			// (application/octet-stream, empty, etc.) that might
 			// actually be images.
+			outcomeReason := "media_policy"
 			maxRead := cfg.MediaPolicy.EffectiveMaxImageBytes()
 			if maxRead <= 0 {
 				maxRead = config.DefaultMaxImageBytes
@@ -1306,6 +1391,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 				rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
 				rp.metrics.RecordReverseProxyScanBlocked(scanDirectionResponse, "media_policy")
 				replaceWithMediaBlockResponse(resp, "media response read error")
+				recordReverseOutcome(http.StatusForbidden, -1, "media_policy")
 				return nil
 			}
 			oversize := int64(len(body)) > maxRead
@@ -1332,6 +1418,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 				rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
 				rp.metrics.RecordReverseProxyScanBlocked(scanDirectionResponse, "media_policy")
 				replaceWithMediaBlockResponse(resp, verdict.BlockReason)
+				recordReverseOutcome(http.StatusForbidden, int64(len(body)), "media_policy")
 				return nil
 			}
 			if verdict.StripResult != nil && verdict.StripResult.Changed() {
@@ -1357,11 +1444,8 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 				}, cfg.ResponseScanning.UnscannablePassthrough); ok {
 					reason := unscannablePassthroughReason(revHost, resp.Request.URL.EscapedPath(), match.ContentType, match.Entry.Reason)
 					rp.logger.LogAnomaly(actx, "unscannable_passthrough", reason, 0)
-					if err := emitUnscannablePassthrough(actx, reason); err != nil {
-						rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
-						replaceWithBlockResponse(resp, []string{receiptEmissionBlockReason})
-						return nil
-					}
+					emitUnscannablePassthrough(reason)
+					outcomeReason = "unscannable_passthrough"
 				}
 			}
 			// Media responses do not go through text injection
@@ -1370,6 +1454,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 			resp.ContentLength = int64(len(body))
 			rp.metrics.RecordReverseProxyRequest(resp.Request.Method,
 				strconv.Itoa(resp.StatusCode))
+			recordReverseOutcome(resp.StatusCode, int64(len(body)), outcomeReason)
 			return nil
 		}
 	}
@@ -1397,6 +1482,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 					Agent:     agent,
 				})
 				replaceWithBlockResponse(resp, []string{"response read error"})
+				recordReverseOutcome(http.StatusForbidden, -1, "response_read_error")
 				return nil
 			}
 			if len(body) > reverseProxyMaxBodyBytes {
@@ -1412,12 +1498,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 					actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
 					reason := unscannablePassthroughReason(revHost, resp.Request.URL.EscapedPath(), match.ContentType, match.Entry.Reason)
 					rp.logger.LogAnomaly(actx, "unscannable_passthrough", reason, 0)
-					if err := emitUnscannablePassthrough(actx, reason); err != nil {
-						_ = resp.Body.Close()
-						rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
-						replaceWithBlockResponse(resp, []string{receiptEmissionBlockReason})
-						return nil
-					}
+					emitUnscannablePassthrough(reason)
 				}
 				resp.Body = readCloserWithClose{
 					Reader: io.MultiReader(bytes.NewReader(body), resp.Body),
@@ -1431,6 +1512,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		}
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method,
 			strconv.Itoa(resp.StatusCode))
+		recordReverseOutcome(resp.StatusCode, resp.ContentLength, "binary_passthrough")
 		return nil
 	}
 
@@ -1440,6 +1522,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 	if !cfg.ResponseScanning.Enabled {
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method,
 			strconv.Itoa(resp.StatusCode))
+		recordReverseOutcome(resp.StatusCode, resp.ContentLength, "complete")
 		return nil
 	}
 	if revRespExempt {
@@ -1474,6 +1557,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 			Agent:     agent,
 		})
 		replaceWithBlockResponse(resp, []string{"compressed response cannot be scanned"})
+		recordReverseOutcome(http.StatusForbidden, -1, "compressed_response")
 		return nil
 	}
 
@@ -1541,6 +1625,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		resp.ContentLength = -1
 		resp.Header.Del("Content-Length")
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method, strconv.Itoa(resp.StatusCode))
+		recordReverseOutcome(resp.StatusCode, -1, "sse_stream")
 		return nil
 	}
 
@@ -1568,6 +1653,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 			Agent:     agent,
 		})
 		replaceWithBlockResponse(resp, []string{"response read error"})
+		recordReverseOutcome(http.StatusForbidden, -1, "response_read_error")
 		return nil
 	}
 
@@ -1589,12 +1675,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 				actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
 				reason := unscannablePassthroughReason(revHost, resp.Request.URL.EscapedPath(), match.ContentType, match.Entry.Reason)
 				rp.logger.LogAnomaly(actx, "unscannable_passthrough", reason, 0)
-				if err := emitUnscannablePassthrough(actx, reason); err != nil {
-					_ = resp.Body.Close()
-					rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
-					replaceWithBlockResponse(resp, []string{receiptEmissionBlockReason})
-					return nil
-				}
+				emitUnscannablePassthrough(reason)
 				resp.Body = readCloserWithClose{
 					Reader: io.MultiReader(bytes.NewReader(body), resp.Body),
 					Closer: resp.Body,
@@ -1614,6 +1695,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 					Outcome:           captureOutcome(config.ActionAllow, true),
 				})
 				rp.metrics.RecordReverseProxyRequest(resp.Request.Method, strconv.Itoa(resp.StatusCode))
+				recordReverseOutcome(resp.StatusCode, resp.ContentLength, "unscannable_passthrough")
 				return nil
 			}
 			var scanFailure *sizeExemptResponseReadError
@@ -1640,6 +1722,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 					Agent:     agent,
 				})
 				replaceWithBlockResponse(resp, []string{scanFailure.Reason})
+				recordReverseOutcome(http.StatusForbidden, -1, string(scanFailure.Kind))
 				return nil
 			}
 			defer releaseSizeExemptScan()
@@ -1661,6 +1744,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 				Agent:     agent,
 			})
 			replaceWithBlockResponse(resp, []string{"response exceeds scanning limit"})
+			recordReverseOutcome(http.StatusForbidden, int64(len(body)), "oversized")
 			return nil
 		}
 	}
@@ -1674,6 +1758,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		resp.ContentLength = 0
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method,
 			strconv.Itoa(resp.StatusCode))
+		recordReverseOutcome(resp.StatusCode, 0, "complete")
 		return nil
 	}
 
@@ -1758,6 +1843,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		resp.ContentLength = int64(len(body))
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method,
 			strconv.Itoa(resp.StatusCode))
+		recordReverseOutcome(resp.StatusCode, int64(len(body)), "complete")
 		return nil
 	}
 
@@ -1794,6 +1880,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
 		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionResponse, "injection")
 		replaceWithBlockResponse(resp, patternNames)
+		recordReverseOutcome(http.StatusForbidden, int64(len(body)), "response_scan")
 		return nil
 	}
 
@@ -1811,6 +1898,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 			resp.Header.Del("Digest")
 			rp.metrics.RecordReverseProxyRequest(resp.Request.Method,
 				strconv.Itoa(resp.StatusCode))
+			recordReverseOutcome(resp.StatusCode, int64(len(stripped)), "strip")
 			return nil
 		}
 		// Strip failed: detection came from a transformed pass (vowel-fold,
@@ -1832,6 +1920,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
 		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionResponse, "injection")
 		replaceWithBlockResponse(resp, patternNames)
+		recordReverseOutcome(http.StatusForbidden, int64(len(body)), "response_scan")
 		return nil
 	}
 
@@ -1840,6 +1929,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 	resp.ContentLength = int64(len(body))
 	rp.metrics.RecordReverseProxyRequest(resp.Request.Method,
 		strconv.Itoa(resp.StatusCode))
+	recordReverseOutcome(resp.StatusCode, int64(len(body)), "complete")
 	return nil
 }
 
@@ -1849,14 +1939,19 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 func (rp *ReverseProxyHandler) errorHandler(w http.ResponseWriter, r *http.Request, err error) {
 	clientIP, _ := r.Context().Value(ctxKeyClientIP).(string)
 	requestID, _ := r.Context().Value(ctxKeyRequestID).(string)
+	outcomeTracker := reverseOutcomeFromContext(r.Context())
+	recordErrorOutcome := func(status int, bytesTransferred int64, reason string) {
+		outcomeTracker.Record(status, bytesTransferred, reason)
+	}
 	actx := newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, "")
 	if blockedErr, ok := blockedRequestErrorFrom(err); ok {
 		rp.metrics.RecordReverseProxyRequest(r.Method, "403")
 		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, blockedErr.layer)
 		rp.logger.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
-		writeReverseProxyBlock(w, http.StatusForbidden,
+		written := writeReverseProxyBlock(w, http.StatusForbidden,
 			blockInfoFor(blockreason.EnvelopeVerifyFailed, blockedErr.layer),
 			blockedErr.reason)
+		recordErrorOutcome(http.StatusForbidden, written, blockedErr.layer)
 		return
 	}
 
@@ -1868,7 +1963,10 @@ func (rp *ReverseProxyHandler) errorHandler(w http.ResponseWriter, r *http.Reque
 		Error:   "upstream unavailable",
 		Blocked: false,
 	}
-	_ = json.NewEncoder(w).Encode(resp)
+	body, _ := json.Marshal(resp)
+	body = append(body, '\n')
+	written, _ := w.Write(body)
+	recordErrorOutcome(http.StatusBadGateway, int64(written), "upstream_error")
 }
 
 // writeReverseProxyBlock writes a JSON block response for request-side blocks
@@ -1876,7 +1974,7 @@ func (rp *ReverseProxyHandler) errorHandler(w http.ResponseWriter, r *http.Reque
 //
 // Sets the X-Pipelock-Block-Reason header set from info BEFORE WriteHeader so
 // agents can react intelligently. Every caller MUST supply a non-zero info.
-func writeReverseProxyBlock(w http.ResponseWriter, status int, info blockreason.Info, reason string) {
+func writeReverseProxyBlock(w http.ResponseWriter, status int, info blockreason.Info, reason string) int64 {
 	info.SetHeaders(w.Header())
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -1886,7 +1984,10 @@ func writeReverseProxyBlock(w http.ResponseWriter, status int, info blockreason.
 		BlockReason: reason,
 		Direction:   scanDirectionRequest,
 	}
-	_ = json.NewEncoder(w).Encode(resp)
+	body, _ := json.Marshal(resp)
+	body = append(body, '\n')
+	written, _ := w.Write(body)
+	return int64(written)
 }
 
 // replaceWithBlockResponse replaces the upstream response with a 403 JSON

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -259,7 +259,7 @@ func (rp *ReverseProxyHandler) emitRequiredReceipt(opts receipt.EmitOpts) error 
 		rp.recordRequiredReceiptBlock(err, opts.Transport)
 		return err
 	}
-	if err := rp.emitReceiptWithEmitter(opts, e); err != nil {
+	if err := rp.emitRequiredReceiptWithEmitter(opts, e); err != nil {
 		rp.recordRequiredReceiptBlock(err, opts.Transport)
 		return err
 	}
@@ -271,6 +271,32 @@ func (rp *ReverseProxyHandler) receiptEmitter() *receipt.Emitter {
 		return nil
 	}
 	return rp.receiptEmitterPtr.Load()
+}
+
+func (rp *ReverseProxyHandler) emitRequiredReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter) error {
+	if e == nil {
+		return nil
+	}
+	if rp.cfgPtr != nil {
+		if cfg := rp.cfgPtr.Load(); cfg != nil {
+			opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
+		}
+	}
+	opts.DecisionPhase = receipt.DecisionPhaseIntent
+	if err := e.EmitDurable(opts); err != nil {
+		rp.logReceiptEmissionFailure(opts, err)
+		// v1 stays authoritative: skip v2 when v1 failed to record.
+		return err
+	}
+	emitV2(rp.v2EmitterPtr, opts, func(err error) {
+		if rp.logger == nil {
+			return
+		}
+		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
+			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s transport=%s: %w",
+				opts.ActionID, opts.Verdict, opts.Transport, err))
+	})
+	return nil
 }
 
 func (rp *ReverseProxyHandler) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter) error {
@@ -840,8 +866,9 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	reverseActionID := receipt.NewActionID()
 	reverseAllowReceipt := withReverseContractReceipt(receipt.EmitOpts{
-		ActionID:  receipt.NewActionID(),
+		ActionID:  reverseActionID,
 		Verdict:   config.ActionAllow,
 		Transport: TransportReverse,
 		Method:    r.Method,
@@ -868,6 +895,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
+	r = r.WithContext(context.WithValue(r.Context(), ctxKeyReverseActionID, reverseActionID))
 
 	// Stash envelope build metadata on the request context so the
 	// signing RoundTripper (installed on rp.proxy.Transport) can
@@ -1171,6 +1199,10 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 	// but the ID is also referenced from the SSE onComplete closure
 	// which runs asynchronously.
 	actionID := receipt.NewActionID()
+	requestActionID, _ := resp.Request.Context().Value(ctxKeyReverseActionID).(string)
+	if requestActionID == "" {
+		requestActionID = actionID
+	}
 	targetURL := resp.Request.URL.String()
 
 	// Record the final client-visible status at each exit point, not here.
@@ -1181,6 +1213,29 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 	revHost := resp.Request.URL.Hostname()
 	revRespExempt := isResponseScanExempt(revHost, cfg.ResponseScanning.ExemptDomains)
 	revRespSizeExempt := isResponseSizeExempt(revHost, cfg.ResponseScanning.SizeExemptDomains)
+	emitUnscannablePassthrough := func(actx audit.LogContext, reason string) error {
+		passthroughReceipt := receipt.EmitOpts{
+			ActionID:  requestActionID,
+			Verdict:   config.ActionAllow,
+			Layer:     "unscannable_passthrough",
+			Pattern:   reason,
+			Transport: TransportReverse,
+			Method:    resp.Request.Method,
+			Target:    targetURL,
+			RequestID: requestID,
+			Agent:     agent,
+		}
+		if cfg.FlightRecorder.RequireReceipts {
+			if err := rp.emitRequiredReceipt(withReceiptPolicyHash(passthroughReceipt, cfg.CanonicalPolicyHash())); err != nil {
+				blockedErr := newReceiptEmissionBlockedRequest(err)
+				rp.logger.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
+				return err
+			}
+			return nil
+		}
+		emitReverseReceipt(passthroughReceipt)
+		return nil
+	}
 
 	// Media policy runs regardless of response-scanning state so an
 	// operator who disables response scanning for performance cannot
@@ -1290,6 +1345,25 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 				resp.Header.Del("Digest")
 				resp.Header.Del("Content-MD5")
 			}
+			if cfg.FlightRecorder.RequireReceipts && cfg.ResponseScanning.Enabled && revRespSizeExempt && len(body) > reverseProxyMaxBodyBytes {
+				if match, ok := matchUnscannablePassthrough(unscannablePassthroughRequest{
+					Host:              revHost,
+					Path:              resp.Request.URL.EscapedPath(),
+					ContentType:       resp.Header.Get("Content-Type"),
+					Header:            resp.Header,
+					ContentLength:     resp.ContentLength,
+					SizeExemptDomains: cfg.ResponseScanning.SizeExemptDomains,
+					Now:               time.Now(),
+				}, cfg.ResponseScanning.UnscannablePassthrough); ok {
+					reason := unscannablePassthroughReason(revHost, resp.Request.URL.EscapedPath(), match.ContentType, match.Entry.Reason)
+					rp.logger.LogAnomaly(actx, "unscannable_passthrough", reason, 0)
+					if err := emitUnscannablePassthrough(actx, reason); err != nil {
+						rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
+						replaceWithBlockResponse(resp, []string{receiptEmissionBlockReason})
+						return nil
+					}
+				}
+			}
 			// Media responses do not go through text injection
 			// scanning - rewrap the body and return.
 			resp.Body = io.NopCloser(bytes.NewReader(body))
@@ -1302,6 +1376,59 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 
 	// Skip remaining binary content types (non-media application/*, etc.).
 	if isBinaryMIME(mediaCT) {
+		if cfg.FlightRecorder.RequireReceipts && cfg.ResponseScanning.Enabled && revRespSizeExempt {
+			limited := io.LimitReader(resp.Body, int64(reverseProxyMaxBodyBytes)+1)
+			body, err := io.ReadAll(limited)
+			if err != nil {
+				_ = resp.Body.Close()
+				rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
+				rp.metrics.RecordReverseProxyScanBlocked(scanDirectionResponse, "read_error")
+				actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
+				rp.logger.LogResponseScan(actx, config.ActionBlock, 0, []string{"response_read_error"}, nil)
+				emitReverseReceipt(receipt.EmitOpts{
+					ActionID:  actionID,
+					Verdict:   config.ActionBlock,
+					Layer:     LayerReverseResponseBlocked,
+					Pattern:   "response read error",
+					Transport: TransportReverse,
+					Method:    resp.Request.Method,
+					Target:    targetURL,
+					RequestID: requestID,
+					Agent:     agent,
+				})
+				replaceWithBlockResponse(resp, []string{"response read error"})
+				return nil
+			}
+			if len(body) > reverseProxyMaxBodyBytes {
+				if match, ok := matchUnscannablePassthrough(unscannablePassthroughRequest{
+					Host:              revHost,
+					Path:              resp.Request.URL.EscapedPath(),
+					ContentType:       resp.Header.Get("Content-Type"),
+					Header:            resp.Header,
+					ContentLength:     resp.ContentLength,
+					SizeExemptDomains: cfg.ResponseScanning.SizeExemptDomains,
+					Now:               time.Now(),
+				}, cfg.ResponseScanning.UnscannablePassthrough); ok {
+					actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
+					reason := unscannablePassthroughReason(revHost, resp.Request.URL.EscapedPath(), match.ContentType, match.Entry.Reason)
+					rp.logger.LogAnomaly(actx, "unscannable_passthrough", reason, 0)
+					if err := emitUnscannablePassthrough(actx, reason); err != nil {
+						_ = resp.Body.Close()
+						rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
+						replaceWithBlockResponse(resp, []string{receiptEmissionBlockReason})
+						return nil
+					}
+				}
+				resp.Body = readCloserWithClose{
+					Reader: io.MultiReader(bytes.NewReader(body), resp.Body),
+					Closer: resp.Body,
+				}
+			} else {
+				_ = resp.Body.Close()
+				resp.Body = io.NopCloser(bytes.NewReader(body))
+				resp.ContentLength = int64(len(body))
+			}
+		}
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method,
 			strconv.Itoa(resp.StatusCode))
 		return nil
@@ -1462,28 +1589,11 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 				actx := newHTTPAuditContext(rp.logger, resp.Request.Method, resp.Request.URL.String(), clientIP, requestID, "")
 				reason := unscannablePassthroughReason(revHost, resp.Request.URL.EscapedPath(), match.ContentType, match.Entry.Reason)
 				rp.logger.LogAnomaly(actx, "unscannable_passthrough", reason, 0)
-				passthroughReceipt := receipt.EmitOpts{
-					ActionID:  actionID,
-					Verdict:   config.ActionAllow,
-					Layer:     "unscannable_passthrough",
-					Pattern:   reason,
-					Transport: "reverse",
-					Method:    resp.Request.Method,
-					Target:    targetURL,
-					RequestID: requestID,
-					Agent:     agent,
-				}
-				if cfg.FlightRecorder.RequireReceipts {
-					if err := rp.emitRequiredReceipt(withReceiptPolicyHash(passthroughReceipt, cfg.CanonicalPolicyHash())); err != nil {
-						_ = resp.Body.Close()
-						blockedErr := newReceiptEmissionBlockedRequest(err)
-						rp.logger.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
-						rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
-						replaceWithBlockResponse(resp, []string{receiptEmissionBlockReason})
-						return nil
-					}
-				} else {
-					emitReverseReceipt(passthroughReceipt)
+				if err := emitUnscannablePassthrough(actx, reason); err != nil {
+					_ = resp.Body.Close()
+					rp.metrics.RecordReverseProxyRequest(resp.Request.Method, "403")
+					replaceWithBlockResponse(resp, []string{receiptEmissionBlockReason})
+					return nil
 				}
 				resp.Body = readCloserWithClose{
 					Reader: io.MultiReader(bytes.NewReader(body), resp.Body),

--- a/internal/proxy/reverse_receipt_parity_test.go
+++ b/internal/proxy/reverse_receipt_parity_test.go
@@ -10,11 +10,13 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -480,10 +482,145 @@ func TestReverseProxy_RequireReceiptsSuccessEmitsSingleAllow(t *testing.T) {
 			rcpt.ActionRecord.Transport == TransportReverse &&
 			rcpt.ActionRecord.Layer == "" {
 			allowCount++
+			if rcpt.ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+				t.Fatalf("reverse allow decision_phase = %q, want %q", rcpt.ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+			}
 		}
 	}
 	if allowCount != 1 {
 		t.Fatalf("reverse allow receipt count = %d, want 1 (receipts: %d)", allowCount, len(receipts))
+	}
+}
+
+func TestReverseProxy_RequireReceiptsSyncFailureBlocksBeforeEgress(t *testing.T) {
+	var hits atomic.Int32
+	cfg := reverseTestConfig()
+	cfg.ResponseScanning.Enabled = false
+	cfg.FlightRecorder.RequireReceipts = true
+
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	m := metrics.New()
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, audit.NewNop(), m, killswitch.New(cfg), nil, nil)
+	dir := t.TempDir()
+	emitter, rec, _ := newCoverageEmitter(t, dir)
+	syncErr := errors.New("injected durable sync failure")
+	rec.SetSyncForTest(func(*os.File) error {
+		return syncErr
+	})
+	var emPtr atomic.Pointer[receipt.Emitter]
+	emPtr.Store(emitter)
+	handler.SetReceiptEmitter(&emPtr)
+
+	proxySrv := newIPv4Server(t, handler)
+	t.Cleanup(proxySrv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/clean", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET reverse proxy: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("response body close: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (durable intent sync failure must block before egress)", got)
+	}
+	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="durability",transport="reverse"} 1`)
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
+}
+
+func TestReverseProxy_UnscannablePassthroughRequireReceiptsEmitsIntent(t *testing.T) {
+	cfg := reverseTestConfig()
+	cfg.FlightRecorder.RequireReceipts = true
+	cfg.ResponseScanning.Enabled = true
+	cfg.ResponseScanning.Action = config.ActionBlock
+	cfg.ResponseScanning.SizeExemptDomains = []string{"127.0.0.1"}
+	cfg.ResponseScanning.UnscannablePassthrough = []config.UnscannablePassthroughEntry{{
+		Host:         "127.0.0.1",
+		Paths:        []string{"/artifact.bin"},
+		ContentTypes: []string{"application/octet-stream"},
+		Reason:       "opaque test artifact",
+		Expires:      "2099-01-01",
+	}}
+	cfg.ResponseScanning.SizeExemptScanMaxBytes = reverseProxyMaxBodyBytes
+	cfg.ResponseScanning.SizeExemptScanMaxInflightBytes = 2 * reverseProxyMaxBodyBytes
+
+	body := bytes.Repeat([]byte{0x42}, reverseProxyMaxBodyBytes+1)
+	proxySrv, dir, closeRec := reverseReceiptParitySetup(t, cfg, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", "attachment; filename=artifact.bin")
+		w.Header().Set("Content-Length", fmt.Sprint(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/artifact.bin", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET reverse proxy: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("response body close: %v", closeErr)
+		}
+	}()
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("body length = %d, want %d", len(got), len(body))
+	}
+
+	waitForReceiptOrTimeout(t, dir)
+	closeRec()
+	receipts := extractReceiptsFromDir(t, dir)
+	passthrough := findReceiptByLayer(t, receipts, "unscannable_passthrough")
+	admission := findReverseAdmissionAllowReceipt(t, receipts)
+	if passthrough.ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("passthrough decision_phase = %q, want %q",
+			passthrough.ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+	if passthrough.ActionRecord.ActionID == "" {
+		t.Fatal("passthrough receipt action_id is empty")
+	}
+	if passthrough.ActionRecord.ActionID != admission.ActionRecord.ActionID {
+		t.Fatalf("passthrough action_id = %q, want admission action_id %q",
+			passthrough.ActionRecord.ActionID, admission.ActionRecord.ActionID)
 	}
 }
 
@@ -500,6 +637,18 @@ func findReceiptByLayer(t *testing.T, receipts []receipt.Receipt, wantLayer stri
 		}
 	}
 	t.Fatalf("no receipt with Layer=%q in %d emitted receipts", wantLayer, len(receipts))
+	return receipt.Receipt{} // unreachable
+}
+
+func findReverseAdmissionAllowReceipt(t *testing.T, receipts []receipt.Receipt) receipt.Receipt {
+	t.Helper()
+	for _, r := range receipts {
+		ar := r.ActionRecord
+		if ar.Transport == TransportReverse && ar.Verdict == config.ActionAllow && ar.Layer == "" {
+			return r
+		}
+	}
+	t.Fatalf("no reverse admission allow receipt in %d emitted receipts", len(receipts))
 	return receipt.Receipt{} // unreachable
 }
 

--- a/internal/proxy/reverse_receipt_parity_test.go
+++ b/internal/proxy/reverse_receipt_parity_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -477,6 +478,7 @@ func TestReverseProxy_RequireReceiptsSuccessEmitsSingleAllow(t *testing.T) {
 	closeRec()
 	receipts := extractReceiptsFromDir(t, dir)
 	var allowCount int
+	var outcome receipt.Receipt
 	for _, rcpt := range receipts {
 		if rcpt.ActionRecord.Verdict == config.ActionAllow &&
 			rcpt.ActionRecord.Transport == TransportReverse &&
@@ -486,9 +488,305 @@ func TestReverseProxy_RequireReceiptsSuccessEmitsSingleAllow(t *testing.T) {
 				t.Fatalf("reverse allow decision_phase = %q, want %q", rcpt.ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
 			}
 		}
+		if rcpt.ActionRecord.DecisionPhase == receipt.DecisionPhaseOutcome &&
+			rcpt.ActionRecord.Transport == TransportReverse {
+			outcome = rcpt
+		}
 	}
 	if allowCount != 1 {
 		t.Fatalf("reverse allow receipt count = %d, want 1 (receipts: %d)", allowCount, len(receipts))
+	}
+	if outcome.ActionRecord.ActionID == "" {
+		t.Fatal("missing reverse outcome receipt")
+	}
+	if !strings.Contains(outcome.ActionRecord.Pattern, "status=200") {
+		t.Fatalf("reverse outcome pattern = %q, want status=200", outcome.ActionRecord.Pattern)
+	}
+}
+
+func TestReverseProxy_RequireReceiptsUpstreamErrorEmitsOutcome(t *testing.T) {
+	cfg := reverseTestConfig()
+	cfg.ResponseScanning.Enabled = false
+	cfg.FlightRecorder.RequireReceipts = true
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	upstreamURL, err := url.Parse("http://" + ln.Addr().String())
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, audit.NewNop(), metrics.New(), killswitch.New(cfg), nil, nil)
+	dir := t.TempDir()
+	emitter, rec, _ := newCoverageEmitter(t, dir)
+	var emPtr atomic.Pointer[receipt.Emitter]
+	emPtr.Store(emitter)
+	handler.SetReceiptEmitter(&emPtr)
+
+	proxySrv := newIPv4Server(t, handler)
+	t.Cleanup(proxySrv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/unreachable", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET reverse proxy: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("response body close: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+
+	waitForReceiptOrTimeout(t, dir)
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
+	receipts := extractReceiptsFromDir(t, dir)
+	admission := findReverseAdmissionAllowReceipt(t, receipts)
+	var outcome receipt.Receipt
+	var outcomeCount int
+	for _, rcpt := range receipts {
+		if rcpt.ActionRecord.DecisionPhase == receipt.DecisionPhaseOutcome &&
+			rcpt.ActionRecord.Transport == TransportReverse {
+			outcome = rcpt
+			outcomeCount++
+		}
+	}
+	if outcomeCount != 1 {
+		t.Fatalf("reverse outcome receipt count = %d, want 1", outcomeCount)
+	}
+	if outcome.ActionRecord.ActionID != admission.ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %q, want admission action_id %q",
+			outcome.ActionRecord.ActionID, admission.ActionRecord.ActionID)
+	}
+	for _, want := range []string{"status=502", "reason=upstream_error"} {
+		if !strings.Contains(outcome.ActionRecord.Pattern, want) {
+			t.Fatalf("reverse outcome pattern = %q, want %s", outcome.ActionRecord.Pattern, want)
+		}
+	}
+}
+
+func TestReverseProxy_RequireReceiptsMediaBlockEmitsOutcome(t *testing.T) {
+	var hits atomic.Int32
+	cfg := reverseTestConfig()
+	cfg.FlightRecorder.RequireReceipts = true
+
+	proxySrv, dir, closeRec := reverseReceiptParitySetup(t, cfg, func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("audio bytes"))
+	})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/clip.mp3", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET reverse proxy: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("response body close: %v", closeErr)
+		}
+	}()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream hits = %d, want 1", got)
+	}
+
+	waitForReceiptOrTimeout(t, dir)
+	closeRec()
+	receipts := extractReceiptsFromDir(t, dir)
+	admission := findReverseAdmissionAllowReceipt(t, receipts)
+	var outcome receipt.Receipt
+	var outcomeCount int
+	for _, rcpt := range receipts {
+		if rcpt.ActionRecord.DecisionPhase == receipt.DecisionPhaseOutcome &&
+			rcpt.ActionRecord.Transport == TransportReverse {
+			outcome = rcpt
+			outcomeCount++
+		}
+	}
+	if outcomeCount != 1 {
+		t.Fatalf("reverse outcome receipt count = %d, want 1", outcomeCount)
+	}
+	if outcome.ActionRecord.ActionID != admission.ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %q, want admission action_id %q",
+			outcome.ActionRecord.ActionID, admission.ActionRecord.ActionID)
+	}
+	if !strings.Contains(outcome.ActionRecord.Pattern, "status=403") {
+		t.Fatalf("reverse outcome pattern = %q, want status=403", outcome.ActionRecord.Pattern)
+	}
+	if !strings.Contains(outcome.ActionRecord.Pattern, "reason=media_policy") {
+		t.Fatalf("reverse outcome pattern = %q, want reason=media_policy", outcome.ActionRecord.Pattern)
+	}
+	if strings.Contains(outcome.ActionRecord.Pattern, "status=unknown") {
+		t.Fatalf("reverse outcome pattern = %q, must not contain status=unknown", outcome.ActionRecord.Pattern)
+	}
+}
+
+func TestReverseProxy_RequireReceiptsStructuralOutcomeCoverage(t *testing.T) {
+	type reverseOutcomeCase struct {
+		name        string
+		path        string
+		wantStatus  int
+		wantPattern []string
+		setup       func(t *testing.T, cfg *config.Config) (*httptest.Server, string, func())
+	}
+
+	largeBody := bytes.Repeat([]byte{0x42}, reverseProxyMaxBodyBytes+1)
+	cases := []reverseOutcomeCase{
+		{
+			name:        "normal response",
+			path:        "/clean",
+			wantStatus:  http.StatusOK,
+			wantPattern: []string{"status=200", "reason=complete"},
+			setup: func(t *testing.T, cfg *config.Config) (*httptest.Server, string, func()) {
+				t.Helper()
+				cfg.ResponseScanning.Enabled = false
+				return reverseReceiptParitySetup(t, cfg, func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("ok"))
+				})
+			},
+		},
+		{
+			name:        "media block",
+			path:        "/clip.mp3",
+			wantStatus:  http.StatusForbidden,
+			wantPattern: []string{"status=403", "reason=media_policy"},
+			setup: func(t *testing.T, cfg *config.Config) (*httptest.Server, string, func()) {
+				t.Helper()
+				return reverseReceiptParitySetup(t, cfg, func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "audio/mpeg")
+					_, _ = w.Write([]byte("audio bytes"))
+				})
+			},
+		},
+		{
+			name:        "error handler 502",
+			path:        "/unreachable",
+			wantStatus:  http.StatusBadGateway,
+			wantPattern: []string{"status=502", "reason=upstream_error"},
+			setup: func(t *testing.T, cfg *config.Config) (*httptest.Server, string, func()) {
+				t.Helper()
+				cfg.ResponseScanning.Enabled = false
+				var lc net.ListenConfig
+				ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+				if err != nil {
+					t.Fatalf("listen: %v", err)
+				}
+				upstreamURL, err := url.Parse("http://" + ln.Addr().String())
+				if err != nil {
+					t.Fatalf("parse upstream URL: %v", err)
+				}
+				if err := ln.Close(); err != nil {
+					t.Fatalf("close listener: %v", err)
+				}
+
+				sc := scanner.New(cfg)
+				t.Cleanup(sc.Close)
+
+				var cfgPtr atomic.Pointer[config.Config]
+				var scPtr atomic.Pointer[scanner.Scanner]
+				cfgPtr.Store(cfg)
+				scPtr.Store(sc)
+
+				handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, audit.NewNop(), metrics.New(), killswitch.New(cfg), nil, nil)
+				dir := t.TempDir()
+				emitter, rec, _ := newCoverageEmitter(t, dir)
+				var emPtr atomic.Pointer[receipt.Emitter]
+				emPtr.Store(emitter)
+				handler.SetReceiptEmitter(&emPtr)
+
+				proxySrv := newIPv4Server(t, handler)
+				t.Cleanup(proxySrv.Close)
+				return proxySrv, dir, func() {
+					if err := rec.Close(); err != nil {
+						t.Fatalf("recorder close: %v", err)
+					}
+				}
+			},
+		},
+		{
+			name:        "size-exempt passthrough",
+			path:        "/artifact.bin",
+			wantStatus:  http.StatusOK,
+			wantPattern: []string{"status=200", "reason=unscannable_passthrough"},
+			setup: func(t *testing.T, cfg *config.Config) (*httptest.Server, string, func()) {
+				t.Helper()
+				cfg.ResponseScanning.Enabled = true
+				cfg.ResponseScanning.Action = config.ActionBlock
+				cfg.ResponseScanning.SizeExemptDomains = []string{"127.0.0.1"}
+				cfg.ResponseScanning.UnscannablePassthrough = []config.UnscannablePassthroughEntry{{
+					Host:         "127.0.0.1",
+					Paths:        []string{"/artifact.bin"},
+					ContentTypes: []string{"application/octet-stream"},
+					Reason:       "opaque test artifact",
+					Expires:      "2099-01-01",
+				}}
+				cfg.ResponseScanning.SizeExemptScanMaxBytes = reverseProxyMaxBodyBytes
+				cfg.ResponseScanning.SizeExemptScanMaxInflightBytes = 2 * reverseProxyMaxBodyBytes
+				return reverseReceiptParitySetup(t, cfg, func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/octet-stream")
+					w.Header().Set("Content-Disposition", "attachment; filename=artifact.bin")
+					w.Header().Set("Content-Length", fmt.Sprint(len(largeBody)))
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(largeBody)
+				})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := reverseTestConfig()
+			cfg.FlightRecorder.RequireReceipts = true
+			proxySrv, dir, closeRec := tc.setup(t, cfg)
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+tc.path, nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("GET reverse proxy: %v", err)
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			if err := resp.Body.Close(); err != nil {
+				t.Fatalf("response body close: %v", err)
+			}
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+
+			waitForReceiptOrTimeout(t, dir)
+			closeRec()
+			receipts := extractReceiptsFromDir(t, dir)
+			assertReverseIntentOutcomePair(t, receipts, tc.wantPattern...)
+		})
 	}
 }
 
@@ -557,7 +855,7 @@ func TestReverseProxy_RequireReceiptsSyncFailureBlocksBeforeEgress(t *testing.T)
 	}
 }
 
-func TestReverseProxy_UnscannablePassthroughRequireReceiptsEmitsIntent(t *testing.T) {
+func TestReverseProxy_UnscannablePassthroughRequireReceiptsEmitsSingleIntentOutcomePair(t *testing.T) {
 	cfg := reverseTestConfig()
 	cfg.FlightRecorder.RequireReceipts = true
 	cfg.ResponseScanning.Enabled = true
@@ -609,19 +907,7 @@ func TestReverseProxy_UnscannablePassthroughRequireReceiptsEmitsIntent(t *testin
 	waitForReceiptOrTimeout(t, dir)
 	closeRec()
 	receipts := extractReceiptsFromDir(t, dir)
-	passthrough := findReceiptByLayer(t, receipts, "unscannable_passthrough")
-	admission := findReverseAdmissionAllowReceipt(t, receipts)
-	if passthrough.ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
-		t.Fatalf("passthrough decision_phase = %q, want %q",
-			passthrough.ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
-	}
-	if passthrough.ActionRecord.ActionID == "" {
-		t.Fatal("passthrough receipt action_id is empty")
-	}
-	if passthrough.ActionRecord.ActionID != admission.ActionRecord.ActionID {
-		t.Fatalf("passthrough action_id = %q, want admission action_id %q",
-			passthrough.ActionRecord.ActionID, admission.ActionRecord.ActionID)
-	}
+	assertReverseIntentOutcomePair(t, receipts, "status=200", "reason=unscannable_passthrough")
 }
 
 // findReceiptByLayer returns the first receipt whose ActionRecord.Layer
@@ -650,6 +936,44 @@ func findReverseAdmissionAllowReceipt(t *testing.T, receipts []receipt.Receipt) 
 	}
 	t.Fatalf("no reverse admission allow receipt in %d emitted receipts", len(receipts))
 	return receipt.Receipt{} // unreachable
+}
+
+func assertReverseIntentOutcomePair(t *testing.T, receipts []receipt.Receipt, wantPattern ...string) {
+	t.Helper()
+	var intent, outcome receipt.Receipt
+	var intentCount, outcomeCount int
+	for _, rcpt := range receipts {
+		ar := rcpt.ActionRecord
+		if ar.Transport != TransportReverse {
+			continue
+		}
+		switch ar.DecisionPhase {
+		case receipt.DecisionPhaseIntent:
+			intent = rcpt
+			intentCount++
+		case receipt.DecisionPhaseOutcome:
+			outcome = rcpt
+			outcomeCount++
+		}
+	}
+	if intentCount != 1 {
+		t.Fatalf("reverse intent receipt count = %d, want 1", intentCount)
+	}
+	if outcomeCount != 1 {
+		t.Fatalf("reverse outcome receipt count = %d, want 1", outcomeCount)
+	}
+	if outcome.ActionRecord.ActionID != intent.ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %q, want intent action_id %q",
+			outcome.ActionRecord.ActionID, intent.ActionRecord.ActionID)
+	}
+	for _, want := range wantPattern {
+		if !strings.Contains(outcome.ActionRecord.Pattern, want) {
+			t.Fatalf("reverse outcome pattern = %q, want %s", outcome.ActionRecord.Pattern, want)
+		}
+	}
+	if strings.Contains(outcome.ActionRecord.Pattern, "status=unknown") {
+		t.Fatalf("reverse outcome pattern = %q, must not contain status=unknown", outcome.ActionRecord.Pattern)
+	}
 }
 
 func gzipBody(t *testing.T, raw []byte) []byte {

--- a/internal/proxy/v2receipt_test.go
+++ b/internal/proxy/v2receipt_test.go
@@ -454,6 +454,191 @@ func TestDualEmit_HotReloadPreservesV2Chain(t *testing.T) {
 	}
 }
 
+func TestDualEmit_SameKeyReloadReusesV2EmitterSoStalePointerCannotFork(t *testing.T) {
+	recDir := t.TempDir()
+	keyDir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyPath := filepath.Join(keyDir, "receipt.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled: true, Dir: recDir, CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.FlightRecorder.SigningKeyPath = keyPath
+	v1 := receipt.NewEmitter(receipt.EmitterConfig{Recorder: rec, PrivKey: priv, Principal: "local", Actor: "pipelock"})
+	signer := proxydecision.NewKeyedSigner(priv)
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder: rec, Signer: signer, Principal: "local", Actor: "pipelock",
+	})
+	p, err := New(cfg, audit.NewNop(), scanner.New(cfg), metrics.New(),
+		WithRecorder(rec), WithReceiptEmitter(v1), WithV2ReceiptEmitter(v2),
+		WithReceiptKeyPath(keyPath))
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	opts := receipt.EmitOpts{
+		ActionID: "a1", Transport: TransportForward, Method: "GET",
+		Target: "https://x.example/a", Verdict: "allow", RequestID: "r1",
+	}
+	mustEmitReceipt(t, p, opts) // v2 seq 0
+	origV2 := p.v2EmitterPtr.Load()
+	if origV2 == nil {
+		t.Fatal("v2 emitter nil before reload")
+	}
+
+	reloadCfg := config.Defaults()
+	reloadCfg.Internal = nil
+	reloadCfg.FlightRecorder.SigningKeyPath = keyPath
+	if !p.Reload(reloadCfg, scanner.New(reloadCfg)) {
+		t.Fatal("Reload returned false")
+	}
+	if got := p.v2EmitterPtr.Load(); got != origV2 {
+		t.Fatal("same-key reload replaced the v2 receipt emitter")
+	}
+
+	mustEmitReceipt(t, p, opts) // v2 seq 1 on the live emitter
+	staleDecision, ok := v2DecisionFromOpts(withReceiptPolicyHash(opts, reloadCfg.CanonicalPolicyHash()))
+	if !ok {
+		t.Fatal("v2DecisionFromOpts returned false")
+	}
+	// Simulate an in-flight request that captured the pre-reload v2 pointer.
+	// Replacing v2 on same-key reload would make this stale emit reuse seq 1.
+	if err := origV2.Emit(staleDecision); err != nil {
+		t.Fatalf("stale v2 Emit: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	v2s, err := contractreceipt.ExtractEvidenceReceiptsFromSessionDir(recDir, "proxy")
+	if err != nil {
+		t.Fatalf("ExtractEvidenceReceiptsFromSessionDir: %v", err)
+	}
+	if len(v2s) != 3 {
+		t.Fatalf("got %d v2 receipts, want 3", len(v2s))
+	}
+	result := contractreceipt.VerifyChain(v2s, contractreceipt.ChainVerifyOptions{
+		PinnedKey: pub, ExpectSignerKeyID: signer.KeyID(),
+		ExpectPayloadKind: contractreceipt.PayloadProxyDecision,
+	})
+	if !result.Valid {
+		t.Fatalf("VerifyChain: %s", result.Error)
+	}
+}
+
+func TestDualEmit_SameKeyReloadUsesUpdatedPolicyHash(t *testing.T) {
+	recDir := t.TempDir()
+	keyDir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyPath := filepath.Join(keyDir, "receipt.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled: true, Dir: recDir, CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.FlightRecorder.SigningKeyPath = keyPath
+	v1 := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder: rec, PrivKey: priv, ConfigHash: cfg.Hash(),
+		Principal: "local", Actor: "pipelock",
+	})
+	signer := proxydecision.NewKeyedSigner(priv)
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder: rec, Signer: signer, Principal: "local", Actor: "pipelock",
+	})
+	p, err := New(cfg, audit.NewNop(), scanner.New(cfg), metrics.New(),
+		WithRecorder(rec), WithReceiptEmitter(v1), WithV2ReceiptEmitter(v2),
+		WithReceiptKeyPath(keyPath))
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	reloadCfg := config.Defaults()
+	reloadCfg.Internal = nil
+	reloadCfg.FlightRecorder.SigningKeyPath = keyPath
+	reloadCfg.FetchProxy.Monitoring.Blocklist = []string{"blocked.vendor.example"}
+	if reloadCfg.CanonicalPolicyHash() == cfg.CanonicalPolicyHash() {
+		t.Fatal("reload fixture did not change canonical policy hash")
+	}
+	if !p.Reload(reloadCfg, scanner.New(reloadCfg)) {
+		t.Fatal("Reload returned false")
+	}
+	if got := p.v2EmitterPtr.Load(); got != v2 {
+		t.Fatal("same-key reload replaced the v2 receipt emitter")
+	}
+
+	mustEmitReceipt(t, p, receipt.EmitOpts{
+		ActionID: "a1", Transport: TransportForward, Method: "GET",
+		Target: "https://blocked.vendor.example/a", Verdict: "block",
+		Layer: "domain_block", Pattern: "blocked.vendor.example", RequestID: "r1",
+	})
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	var (
+		v1Policy string
+		v2Policy string
+	)
+	for _, e := range readRecorderEntries(t, recDir) {
+		switch e.Type {
+		case "action_receipt":
+			var r receipt.Receipt
+			if err := json.Unmarshal(e.Detail, &r); err != nil {
+				t.Fatalf("unmarshal v1 receipt: %v", err)
+			}
+			if r.ActionRecord.ActionID == "a1" {
+				v1Policy = r.ActionRecord.PolicyHash
+			}
+		case "evidence_receipt":
+			if e.EventKind != string(contractreceipt.PayloadProxyDecision) {
+				continue
+			}
+			var r contractreceipt.EvidenceReceipt
+			if err := json.Unmarshal(e.Detail, &r); err != nil {
+				t.Fatalf("unmarshal v2 receipt: %v", err)
+			}
+			if err := contractreceipt.VerifyWithKey(r, pub, signer.KeyID()); err != nil {
+				t.Fatalf("v2 receipt verify: %v", err)
+			}
+			v2Policy = r.PolicyHash
+		}
+	}
+	if v1Policy != reloadCfg.Hash() {
+		t.Fatalf("v1 policy_hash = %q, want reload cfg.Hash %q", v1Policy, reloadCfg.Hash())
+	}
+	wantV2Policy := contractreceipt.NormalizePolicyHash(reloadCfg.CanonicalPolicyHash())
+	if v2Policy != wantV2Policy {
+		t.Fatalf("v2 policy_hash = %q, want reload canonical policy hash %q", v2Policy, wantV2Policy)
+	}
+}
+
 // TestDualEmit_V1FailureSkipsV2 proves v1 stays authoritative: when the v1
 // emitter rejects (here, a sealed chain), no v2 proxy_decision is written, so a
 // v2 receipt never outlives its v1 action_receipt sibling.

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -764,6 +765,18 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	outcomeStatus := "unknown"
+	outcomeBytes := int64(-1)
+	outcomeReason := "incomplete"
+	outcomeEmitted := false
+	if cfg.FlightRecorder.RequireReceipts {
+		defer func() {
+			if !outcomeEmitted {
+				p.emitOutcomeReceipt(cfg, admissionReceipt, outcomeStatus, outcomeBytes, outcomeReason)
+			}
+		}()
+	}
+
 	if cfg.FlightRecorder.RequireReceipts {
 		// Upgrade the client connection only after the required intent receipt is
 		// durable. A 101 response is client egress; under require_receipts it must
@@ -783,6 +796,9 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	if dialErr != nil {
 		log.LogError(actx, fmt.Errorf("upstream dial: %w", dialErr))
 		plwsutil.WriteCloseFrame(clientConn, ws.StatusInternalServerError, "upstream dial failed")
+		outcomeStatus = strconv.Itoa(int(ws.StatusInternalServerError))
+		outcomeBytes = 0
+		outcomeReason = "upstream_dial_failed"
 		return
 	}
 	defer safeClose(upstreamConn, "ws.upstreamConn", log)
@@ -859,6 +875,14 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		BinaryFrames:   stats.binaryFrames,
 		Duration:       duration,
 	})
+	outcomeCloseCode := ws.StatusNormalClosure
+	outcomeReason = "complete"
+	if stats.blocked {
+		outcomeCloseCode = ws.StatusPolicyViolation
+		outcomeReason = "policy_blocked"
+	}
+	p.emitOutcomeReceipt(cfg, admissionReceipt, strconv.Itoa(int(outcomeCloseCode)), stats.clientToServer+stats.serverToClient, outcomeReason)
+	outcomeEmitted = true
 
 	closeVerdict := config.ActionAllow
 	if stats.blocked {

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -595,17 +595,26 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		admissionReceipt = withContractReceipt(wsGate, admissionReceipt)
 	}
 
-	// Upgrade the client connection.
-	upgrader := ws.HTTPUpgrader{
-		Timeout: 10 * time.Second,
+	var clientConn net.Conn
+	upgradeClient := func() bool {
+		upgrader := ws.HTTPUpgrader{
+			Timeout: 10 * time.Second,
+		}
+		var upgradeErr error
+		clientConn, _, _, upgradeErr = upgrader.Upgrade(r, w)
+		if upgradeErr != nil {
+			log.LogError(actx, fmt.Errorf("client upgrade: %w", upgradeErr))
+			// If Upgrade fails, it already wrote the HTTP error response.
+			return false
+		}
+		return true
 	}
-	clientConn, _, _, upgradeErr := upgrader.Upgrade(r, w)
-	if upgradeErr != nil {
-		log.LogError(actx, fmt.Errorf("client upgrade: %w", upgradeErr))
-		// If Upgrade fails, it already wrote the HTTP error response.
-		return
+	if !cfg.FlightRecorder.RequireReceipts {
+		if !upgradeClient() {
+			return
+		}
+		defer safeClose(clientConn, "ws.clientConn", log)
 	}
-	defer safeClose(clientConn, "ws.clientConn", log)
 
 	// Obtain a live session recorder for the relay. This provides live
 	// escalation level lookups instead of a stale snapshot, so that
@@ -637,16 +646,22 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 				RequestID: requestID,
 				Agent:     agent,
 			})
-			plwsutil.WriteCloseFrame(clientConn, ws.StatusPolicyViolation,
-				blockInfoFor(blockreason.AirlockActive, "").CloseFramePayload())
+			if clientConn != nil {
+				plwsutil.WriteCloseFrame(clientConn, ws.StatusPolicyViolation,
+					blockInfoFor(blockreason.AirlockActive, "").CloseFramePayload())
+			} else {
+				writeBlockedError(w,
+					blockInfoFor(blockreason.AirlockActive, ""),
+					"WebSocket blocked: airlock: WebSocket blocked during quarantine", http.StatusForbidden)
+			}
 			return
 		}
 	}
 
 	// Inject mediation envelope after all admission checks but before the
-	// upstream handshake so the forwarded headers on the accepted connection
-	// carry the final verdict. WebSocket handshakes are body-less GETs, so
-	// content-digest is always dropped from the declared component list;
+	// upstream handshake so the forwarded headers carry the final verdict.
+	// WebSocket handshakes are body-less GETs, so content-digest is always
+	// dropped from the declared component list;
 	// signing covers @method, @target-uri, and pipelock-mediation.
 	//
 	// gobwas/ws does not expose the *http.Request it synthesizes before
@@ -686,8 +701,14 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 				RequestID: requestID,
 				Agent:     agent,
 			})
-			plwsutil.WriteCloseFrame(clientConn, ws.StatusPolicyViolation,
-				blockInfoFor(blockreason.OutboundEnvelopeFailed, blockedErr.layer).CloseFramePayload())
+			if clientConn != nil {
+				plwsutil.WriteCloseFrame(clientConn, ws.StatusPolicyViolation,
+					blockInfoFor(blockreason.OutboundEnvelopeFailed, blockedErr.layer).CloseFramePayload())
+			} else {
+				writeBlockedError(w,
+					blockInfoFor(blockreason.OutboundEnvelopeFailed, blockedErr.layer),
+					"WebSocket blocked: "+blockedErr.reason, http.StatusForbidden)
+			}
 			return
 		}
 		synthReq := &http.Request{
@@ -719,8 +740,14 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 				RequestID: requestID,
 				Agent:     agent,
 			})
-			plwsutil.WriteCloseFrame(clientConn, ws.StatusPolicyViolation,
-				blockInfoFor(blockreason.OutboundEnvelopeFailed, blockedErr.layer).CloseFramePayload())
+			if clientConn != nil {
+				plwsutil.WriteCloseFrame(clientConn, ws.StatusPolicyViolation,
+					blockInfoFor(blockreason.OutboundEnvelopeFailed, blockedErr.layer).CloseFramePayload())
+			} else {
+				writeBlockedError(w,
+					blockInfoFor(blockreason.OutboundEnvelopeFailed, blockedErr.layer),
+					"WebSocket blocked: "+blockedErr.reason, http.StatusForbidden)
+			}
 			return
 		}
 	}
@@ -730,10 +757,25 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			blockedErr := newReceiptEmissionBlockedRequest(err)
 			log.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
 			p.metrics.RecordWSBlocked()
-			plwsutil.WriteCloseFrame(clientConn, ws.StatusPolicyViolation,
-				blockInfoFor(blockreason.ReceiptEmissionFailed, blockedErr.layer).CloseFramePayload())
+			writeBlockedError(w,
+				blockInfoFor(blockreason.ReceiptEmissionFailed, blockedErr.layer),
+				"WebSocket blocked: "+blockedErr.reason, http.StatusForbidden)
 			return
 		}
+	}
+
+	if cfg.FlightRecorder.RequireReceipts {
+		// Upgrade the client connection only after the required intent receipt is
+		// durable. A 101 response is client egress; under require_receipts it must
+		// not be written before fsync succeeds.
+		if !upgradeClient() {
+			return
+		}
+		defer safeClose(clientConn, "ws.clientConn", log)
+	}
+	if clientConn == nil {
+		log.LogError(actx, fmt.Errorf("websocket client connection unavailable after admission"))
+		return
 	}
 
 	// Dial upstream via SSRF-safe dialer.

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -624,12 +625,23 @@ func TestWSProxyRequireReceipts_RedactedSuccessEmitsCloseSummary(t *testing.T) {
 	}, "websocket redaction close receipt")
 
 	receipts := rph.findReceipts(t)
-	var allowCount, redactionCloseCount int
+	var allowID string
+	var allowCount, outcomeCount, redactionCloseCount int
 	for _, rcpt := range receipts {
 		if rcpt.ActionRecord.Verdict == config.ActionAllow && rcpt.ActionRecord.Layer == "" {
 			allowCount++
+			allowID = rcpt.ActionRecord.ActionID
 			if rcpt.ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
 				t.Fatalf("admission decision_phase = %q, want %q", rcpt.ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+			}
+		}
+		if rcpt.ActionRecord.DecisionPhase == receipt.DecisionPhaseOutcome {
+			outcomeCount++
+			if rcpt.ActionRecord.ActionID != allowID {
+				t.Fatalf("outcome action_id = %s, want %s", rcpt.ActionRecord.ActionID, allowID)
+			}
+			if !strings.Contains(rcpt.ActionRecord.Pattern, "status=1000") {
+				t.Fatalf("outcome pattern = %q, want status=1000", rcpt.ActionRecord.Pattern)
 			}
 		}
 		if rcpt.ActionRecord.Layer == "session_close" && rcpt.ActionRecord.Redaction != nil {
@@ -639,8 +651,97 @@ func TestWSProxyRequireReceipts_RedactedSuccessEmitsCloseSummary(t *testing.T) {
 	if allowCount != 1 {
 		t.Fatalf("allow receipt count = %d, want one admission receipt", allowCount)
 	}
+	if outcomeCount != 1 {
+		t.Fatalf("outcome receipt count = %d, want one outcome receipt", outcomeCount)
+	}
 	if redactionCloseCount != 1 {
 		t.Fatalf("redaction close receipt count = %d, want one signed close summary", redactionCloseCount)
+	}
+}
+
+func TestWSProxyRequireReceipts_UpstreamDialFailureEmitsOutcome(t *testing.T) {
+	lc := net.ListenConfig{}
+	backendLn, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen backend: %v", err)
+	}
+	backendAddr := backendLn.Addr().String()
+	if closeErr := backendLn.Close(); closeErr != nil {
+		t.Fatalf("close backend listener: %v", closeErr)
+	}
+
+	rph := newReceiptProxyHelper(t)
+	proxyAddr, p, proxyCleanup := setupWSProxyDefaultWithProxy(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+	})
+	defer proxyCleanup()
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	conn := dialWS(t, proxyAddr, backendAddr)
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Errorf("conn.Close: %v", closeErr)
+		}
+	}()
+	if deadlineErr := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); deadlineErr != nil {
+		t.Fatalf("set read deadline: %v", deadlineErr)
+	}
+	hdr, err := ws.ReadHeader(conn)
+	if err != nil {
+		t.Fatalf("read close frame header: %v", err)
+	}
+	if hdr.OpCode != ws.OpClose {
+		t.Fatalf("opcode = %v, want OpClose", hdr.OpCode)
+	}
+	payload := make([]byte, hdr.Length)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		t.Fatalf("read close frame payload: %v", err)
+	}
+	if len(payload) < 2 {
+		t.Fatalf("close frame payload length = %d, want status code", len(payload))
+	}
+	if got := ws.StatusCode(binary.BigEndian.Uint16(payload[:2])); got != ws.StatusInternalServerError {
+		t.Fatalf("close code = %v, want %v", got, ws.StatusInternalServerError)
+	}
+
+	testwait.For(t, 2*time.Second, func() bool {
+		for _, rcpt := range extractReceiptsFromDir(t, rph.dir) {
+			if rcpt.ActionRecord.DecisionPhase == receipt.DecisionPhaseOutcome {
+				return true
+			}
+		}
+		return false
+	}, "websocket upstream dial failure outcome receipt")
+
+	receipts := rph.findReceipts(t)
+	var intentID string
+	var intentCount, outcomeCount int
+	var outcome receipt.Receipt
+	for _, rcpt := range receipts {
+		switch {
+		case rcpt.ActionRecord.DecisionPhase == receipt.DecisionPhaseIntent &&
+			rcpt.ActionRecord.Verdict == config.ActionAllow &&
+			rcpt.ActionRecord.Layer == "":
+			intentCount++
+			intentID = rcpt.ActionRecord.ActionID
+		case rcpt.ActionRecord.DecisionPhase == receipt.DecisionPhaseOutcome:
+			outcomeCount++
+			outcome = rcpt
+		}
+	}
+	if intentCount != 1 {
+		t.Fatalf("intent receipt count = %d, want 1", intentCount)
+	}
+	if outcomeCount != 1 {
+		t.Fatalf("outcome receipt count = %d, want 1", outcomeCount)
+	}
+	if outcome.ActionRecord.ActionID != intentID {
+		t.Fatalf("outcome action_id = %s, want %s", outcome.ActionRecord.ActionID, intentID)
+	}
+	for _, want := range []string{"status=1011", "bytes=0", "reason=upstream_dial_failed"} {
+		if !strings.Contains(outcome.ActionRecord.Pattern, want) {
+			t.Fatalf("outcome pattern = %q, want %s", outcome.ActionRecord.Pattern, want)
+		}
 	}
 }
 

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -4,9 +4,11 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -24,10 +26,10 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/addressprotect"
 	"github.com/luckyPipewrench/pipelock/internal/audit"
-	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/session"
@@ -242,6 +244,33 @@ func dialWS(t *testing.T, proxyAddr, backendAddr string) net.Conn {
 		t.Fatalf("ws dial: %v", err)
 	}
 	return conn
+}
+
+func assertWSHandshakeStatus(t *testing.T, proxyAddr, backendAddr string, want int) {
+	t.Helper()
+
+	conn, err := (&net.Dialer{}).DialContext(t.Context(), "tcp4", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Errorf("proxy connection close: %v", closeErr)
+		}
+	}()
+	_, _ = fmt.Fprintf(conn, "GET /ws?url=ws://%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n", backendAddr, proxyAddr)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read websocket handshake response: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("response body close: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != want {
+		t.Fatalf("websocket handshake status = %d, want %d", resp.StatusCode, want)
+	}
 }
 
 func TestWebSocket_ScopedAirlockDoesNotBlockUnrelatedHost(t *testing.T) {
@@ -599,6 +628,9 @@ func TestWSProxyRequireReceipts_RedactedSuccessEmitsCloseSummary(t *testing.T) {
 	for _, rcpt := range receipts {
 		if rcpt.ActionRecord.Verdict == config.ActionAllow && rcpt.ActionRecord.Layer == "" {
 			allowCount++
+			if rcpt.ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+				t.Fatalf("admission decision_phase = %q, want %q", rcpt.ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+			}
 		}
 		if rcpt.ActionRecord.Layer == "session_close" && rcpt.ActionRecord.Redaction != nil {
 			redactionCloseCount++
@@ -640,20 +672,7 @@ func TestWSProxyRequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *test
 	})
 	defer proxyCleanup()
 
-	conn := dialWS(t, proxyAddr, backendLn.Addr().String())
-	defer func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("websocket connection close: %v", closeErr)
-		}
-	}()
-	_, _, err = wsutil.ReadServerData(conn)
-	if err == nil {
-		t.Fatal("expected websocket close error for required receipt failure")
-	}
-	if errText := err.Error(); errText != "EOF" &&
-		(!strings.Contains(errText, "1008") || !strings.Contains(errText, string(blockreason.ReceiptEmissionFailed))) {
-		t.Fatalf("close error = %q, want EOF or policy violation receipt emission failure", errText)
-	}
+	assertWSHandshakeStatus(t, proxyAddr, backendLn.Addr().String(), http.StatusForbidden)
 	if got := upstreamHits.Load(); got != 0 {
 		t.Fatalf("upstream hits = %d, want 0", got)
 	}
@@ -694,25 +713,54 @@ func TestWSProxyRequireReceiptsEmissionFailureBlocksAndRecordsMetrics(t *testing
 	}
 	p.receiptEmitterPtr.Store(rph.emitter)
 
-	conn := dialWS(t, proxyAddr, backendLn.Addr().String())
-	defer func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("websocket connection close: %v", closeErr)
-		}
-	}()
-	_, _, err = wsutil.ReadServerData(conn)
-	if err == nil {
-		t.Fatal("expected websocket close error for required receipt failure")
-	}
-	if errText := err.Error(); errText != "EOF" &&
-		(!strings.Contains(errText, "1008") || !strings.Contains(errText, string(blockreason.ReceiptEmissionFailed))) {
-		t.Fatalf("close error = %q, want EOF or policy violation receipt emission failure", errText)
-	}
+	assertWSHandshakeStatus(t, proxyAddr, backendLn.Addr().String(), http.StatusForbidden)
 	if got := upstreamHits.Load(); got != 0 {
 		t.Fatalf("upstream hits = %d, want 0", got)
 	}
 	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="websocket"} 1`)
+}
+
+func TestWSProxyRequireReceiptsSyncFailureBlocksBeforeEgress(t *testing.T) {
+	var upstreamHits atomic.Int32
+	lc := net.ListenConfig{}
+	backendLn, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen backend: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := backendLn.Close(); closeErr != nil {
+			t.Errorf("backend listener close: %v", closeErr)
+		}
+	})
+	go func() {
+		for {
+			conn, acceptErr := backendLn.Accept()
+			if acceptErr != nil {
+				return
+			}
+			upstreamHits.Add(1)
+			_ = conn.Close()
+		}
+	}()
+
+	proxyAddr, p, proxyCleanup := setupWSProxyDefaultWithProxy(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+	})
+	defer proxyCleanup()
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	syncErr := errors.New("injected durable sync failure")
+	rph.rec.SetSyncForTest(func(*os.File) error {
+		return syncErr
+	})
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	assertWSHandshakeStatus(t, proxyAddr, backendLn.Addr().String(), http.StatusForbidden)
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (durable intent sync failure must block before dial)", got)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="sync"} 1`)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="durability",transport="websocket"} 1`)
 }
 
 func TestWSProxyRedaction_BinaryNonJSONBlocked(t *testing.T) {

--- a/internal/receipt/action.go
+++ b/internal/receipt/action.go
@@ -195,6 +195,12 @@ type ActionRecord struct {
 	// tamper-evidence layer.
 	KeyTransition *KeyTransition `json:"key_transition,omitempty"`
 
+	// SessionControl carries an inline session-lifecycle record (open,
+	// heartbeat, or close) when this receipt IS a session-control record.
+	// Absent on ordinary action receipts; verifiers canonicalize absence the
+	// same as the Go omitempty zero value.
+	SessionControl *SessionControl `json:"session_control,omitempty"`
+
 	// Jurisdictional fields - present in schema for forward compatibility.
 	// Empty in v1; populated when jurisdiction engine ships.
 	Venue              string   `json:"venue,omitempty"`

--- a/internal/receipt/action.go
+++ b/internal/receipt/action.go
@@ -18,6 +18,8 @@ import (
 )
 
 const (
+	DecisionPhaseIntent     = "intent"
+	DecisionPhaseOutcome    = "outcome"
 	DecisionPhaseDefer      = "defer"
 	DecisionPhaseResolution = "resolution"
 )

--- a/internal/receipt/action_test.go
+++ b/internal/receipt/action_test.go
@@ -82,6 +82,12 @@ func TestNewActionID_UUIDv7(t *testing.T) {
 
 func TestDecisionPhaseConstants(t *testing.T) {
 	t.Parallel()
+	if DecisionPhaseIntent != "intent" {
+		t.Fatalf("DecisionPhaseIntent = %q", DecisionPhaseIntent)
+	}
+	if DecisionPhaseOutcome != "outcome" {
+		t.Fatalf("DecisionPhaseOutcome = %q", DecisionPhaseOutcome)
+	}
 	if DecisionPhaseDefer != "defer" {
 		t.Fatalf("DecisionPhaseDefer = %q", DecisionPhaseDefer)
 	}

--- a/internal/receipt/canonical.go
+++ b/internal/receipt/canonical.go
@@ -76,6 +76,7 @@ func canonicalActionRecordV1(ar ActionRecord) ([]byte, error) {
 		ChainSeq:              ar.ChainSeq,
 		RunNonce:              ar.RunNonce,
 		KeyTransition:         canonicalKeyTransitionV1(ar.KeyTransition),
+		SessionControl:        canonicalSessionControlV1(ar.SessionControl),
 		Venue:                 ar.Venue,
 		Jurisdiction:          ar.Jurisdiction,
 		RulebookID:            ar.RulebookID,
@@ -146,8 +147,9 @@ type actionRecordCanonicalV1 struct {
 	ChainPrevHash string `json:"chain_prev_hash"`
 	ChainSeq      uint64 `json:"chain_seq"`
 
-	RunNonce      string                    `json:"run_nonce,omitempty"`
-	KeyTransition *keyTransitionCanonicalV1 `json:"key_transition,omitempty"`
+	RunNonce       string                     `json:"run_nonce,omitempty"`
+	KeyTransition  *keyTransitionCanonicalV1  `json:"key_transition,omitempty"`
+	SessionControl *sessionControlCanonicalV1 `json:"session_control,omitempty"`
 
 	Venue              string   `json:"venue,omitempty"`
 	Jurisdiction       string   `json:"jurisdiction,omitempty"`
@@ -198,6 +200,127 @@ func canonicalKeyTransitionV1(in *KeyTransition) *keyTransitionCanonicalV1 {
 		PriorSignerKey: in.PriorSignerKey,
 		PriorChainSeq:  in.PriorChainSeq,
 		PriorChainHash: in.PriorChainHash,
+	}
+}
+
+type sessionControlCanonicalV1 struct {
+	Kind      SessionControlKind           `json:"kind"`
+	Open      *sessionOpenCanonicalV1      `json:"open,omitempty"`
+	Heartbeat *sessionHeartbeatCanonicalV1 `json:"heartbeat,omitempty"`
+	Close     *sessionCloseCanonicalV1     `json:"close,omitempty"`
+}
+
+type sessionOpenCanonicalV1 struct {
+	RunNonce         string `json:"run_nonce"`
+	OpenNonce        string `json:"open_nonce"`
+	RecorderSession  string `json:"recorder_session"`
+	PolicyHash       string `json:"policy_hash"`
+	SignerKeyEpoch   string `json:"signer_key_epoch"`
+	HeartbeatSeconds int    `json:"heartbeat_seconds"`
+
+	ChainOpenSeq   uint64 `json:"chain_open_seq"`
+	PriorChainHead string `json:"prior_chain_head,omitempty"`
+	PriorChainSeq  uint64 `json:"prior_chain_seq,omitempty"`
+
+	GenesisHash       string `json:"genesis_hash,omitempty"`
+	GenesisAnchorHead string `json:"genesis_anchor_head,omitempty"`
+	GenesisAnchorLog  string `json:"genesis_anchor_log,omitempty"`
+
+	PostureCapsuleSHA256 string `json:"posture_capsule_sha256,omitempty"`
+	PostureSignerKeyID   string `json:"posture_signer_key_id,omitempty"`
+	ContainmentNonce     string `json:"containment_nonce,omitempty"`
+	ContainedUID         string `json:"contained_uid,omitempty"`
+}
+
+type sessionHeartbeatCanonicalV1 struct {
+	RunNonce      string `json:"run_nonce"`
+	OpenNonce     string `json:"open_nonce"`
+	Beat          uint64 `json:"beat"`
+	ChainHead     string `json:"chain_head"`
+	ChainSeqHead  uint64 `json:"chain_seq_head"`
+	HeartbeatTime string `json:"heartbeat_time"`
+
+	FsyncErrorsGated uint64 `json:"fsync_errors_gated"`
+	DurabilityBlocks uint64 `json:"durability_blocks"`
+}
+
+type sessionCloseCanonicalV1 struct {
+	RunNonce     string `json:"run_nonce"`
+	OpenNonce    string `json:"open_nonce"`
+	FinalSeq     uint64 `json:"final_seq"`
+	RootHash     string `json:"root_hash"`
+	ReceiptCount uint64 `json:"receipt_count"`
+	CloseReason  string `json:"close_reason"`
+
+	FsyncErrorsGated uint64 `json:"fsync_errors_gated"`
+	DurabilityBlocks uint64 `json:"durability_blocks"`
+}
+
+func canonicalSessionControlV1(in *SessionControl) *sessionControlCanonicalV1 {
+	if in == nil {
+		return nil
+	}
+	return &sessionControlCanonicalV1{
+		Kind:      in.Kind,
+		Open:      canonicalSessionOpenV1(in.Open),
+		Heartbeat: canonicalSessionHeartbeatV1(in.Heartbeat),
+		Close:     canonicalSessionCloseV1(in.Close),
+	}
+}
+
+func canonicalSessionOpenV1(in *SessionOpen) *sessionOpenCanonicalV1 {
+	if in == nil {
+		return nil
+	}
+	return &sessionOpenCanonicalV1{
+		RunNonce:             in.RunNonce,
+		OpenNonce:            in.OpenNonce,
+		RecorderSession:      in.RecorderSession,
+		PolicyHash:           in.PolicyHash,
+		SignerKeyEpoch:       in.SignerKeyEpoch,
+		HeartbeatSeconds:     in.HeartbeatSeconds,
+		ChainOpenSeq:         in.ChainOpenSeq,
+		PriorChainHead:       in.PriorChainHead,
+		PriorChainSeq:        in.PriorChainSeq,
+		GenesisHash:          in.GenesisHash,
+		GenesisAnchorHead:    in.GenesisAnchorHead,
+		GenesisAnchorLog:     in.GenesisAnchorLog,
+		PostureCapsuleSHA256: in.PostureCapsuleSHA256,
+		PostureSignerKeyID:   in.PostureSignerKeyID,
+		ContainmentNonce:     in.ContainmentNonce,
+		ContainedUID:         in.ContainedUID,
+	}
+}
+
+func canonicalSessionHeartbeatV1(in *SessionHeartbeat) *sessionHeartbeatCanonicalV1 {
+	if in == nil {
+		return nil
+	}
+	return &sessionHeartbeatCanonicalV1{
+		RunNonce:         in.RunNonce,
+		OpenNonce:        in.OpenNonce,
+		Beat:             in.Beat,
+		ChainHead:        in.ChainHead,
+		ChainSeqHead:     in.ChainSeqHead,
+		HeartbeatTime:    in.HeartbeatTime,
+		FsyncErrorsGated: in.FsyncErrorsGated,
+		DurabilityBlocks: in.DurabilityBlocks,
+	}
+}
+
+func canonicalSessionCloseV1(in *SessionClose) *sessionCloseCanonicalV1 {
+	if in == nil {
+		return nil
+	}
+	return &sessionCloseCanonicalV1{
+		RunNonce:         in.RunNonce,
+		OpenNonce:        in.OpenNonce,
+		FinalSeq:         in.FinalSeq,
+		RootHash:         in.RootHash,
+		ReceiptCount:     in.ReceiptCount,
+		CloseReason:      in.CloseReason,
+		FsyncErrorsGated: in.FsyncErrorsGated,
+		DurabilityBlocks: in.DurabilityBlocks,
 	}
 }
 

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -398,6 +398,8 @@ func (v *chainVerifier) validateRestartOpen(r Receipt, open *SessionOpen, priorH
 func (v *chainVerifier) validateSessionControl(r Receipt) (ChainResult, bool) {
 	ctrl := r.ActionRecord.SessionControl
 	open := sessionOpen(ctrl)
+	heartbeat := sessionHeartbeat(ctrl)
+	closeRecord := sessionClose(ctrl)
 	if ctrl != nil {
 		payloads := 0
 		if ctrl.Open != nil {
@@ -412,19 +414,46 @@ func (v *chainVerifier) validateSessionControl(r Receipt) (ChainResult, bool) {
 		if payloads != 1 {
 			return v.brokenAt(r, "session_control must carry exactly one payload"), false
 		}
-		if open == nil && ctrl.Kind == SessionControlOpen {
-			return v.brokenAt(r, "session_open kind missing open payload"), false
-		}
-		if open != nil && ctrl.Kind != SessionControlOpen {
-			return v.brokenAt(r, "open payload kind mismatch"), false
+		switch ctrl.Kind {
+		case SessionControlOpen:
+			if open == nil {
+				return v.brokenAt(r, "session_open kind missing open payload"), false
+			}
+		case SessionControlHeartbeat:
+			if heartbeat == nil {
+				return v.brokenAt(r, "heartbeat kind missing heartbeat payload"), false
+			}
+		case SessionControlClose:
+			if closeRecord == nil {
+				return v.brokenAt(r, "session_close kind missing close payload"), false
+			}
+		default:
+			return v.brokenAt(r, "unknown session_control kind"), false
 		}
 	}
 	if r.ActionRecord.RunNonce == "" {
 		return ChainResult{}, true
 	}
 	if open == nil {
-		if _, ok := v.runNonces[r.ActionRecord.RunNonce]; !ok {
+		openNonce, ok := v.runNonces[r.ActionRecord.RunNonce]
+		if !ok {
 			return v.brokenAt(r, "run_nonce first receipt is not a matching session_open"), false
+		}
+		if heartbeat != nil {
+			if heartbeat.RunNonce != r.ActionRecord.RunNonce {
+				return v.brokenAt(r, "heartbeat run_nonce does not match receipt run_nonce"), false
+			}
+			if heartbeat.OpenNonce != openNonce {
+				return v.brokenAt(r, "heartbeat open_nonce does not match session_open"), false
+			}
+		}
+		if closeRecord != nil {
+			if closeRecord.RunNonce != r.ActionRecord.RunNonce {
+				return v.brokenAt(r, "session_close run_nonce does not match receipt run_nonce"), false
+			}
+			if closeRecord.OpenNonce != openNonce {
+				return v.brokenAt(r, "session_close open_nonce does not match session_open"), false
+			}
 		}
 		return ChainResult{}, true
 	}
@@ -446,6 +475,20 @@ func sessionOpen(ctrl *SessionControl) *SessionOpen {
 		return nil
 	}
 	return ctrl.Open
+}
+
+func sessionHeartbeat(ctrl *SessionControl) *SessionHeartbeat {
+	if ctrl == nil || ctrl.Kind != SessionControlHeartbeat {
+		return nil
+	}
+	return ctrl.Heartbeat
+}
+
+func sessionClose(ctrl *SessionControl) *SessionClose {
+	if ctrl == nil || ctrl.Kind != SessionControlClose {
+		return nil
+	}
+	return ctrl.Close
 }
 
 func (v *chainVerifier) verifyReceipt(r Receipt, index uint64) (ChainResult, bool) {

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -42,15 +42,20 @@ func ReceiptHash(r Receipt) (string, error) {
 
 // ChainResult describes the outcome of chain verification.
 type ChainResult struct {
-	Valid         bool
-	ReceiptCount  uint64
-	FinalSeq      uint64
-	RootHash      string
-	StartTime     time.Time
-	EndTime       time.Time
-	Error         string // empty if valid
-	BrokenAtSeq   uint64 // set when chain breaks
-	BrokenAtIndex int    // zero-based receipt index where chain verification failed
+	Valid bool
+	// IntegrityVerified means receipt signatures, trusted signer keys, sequence
+	// numbers, and hash links verified without applying session lifecycle
+	// rules. It can be true when Valid is false for a lifecycle-only failure.
+	IntegrityVerified bool
+	ReceiptCount      uint64
+	FinalSeq          uint64
+	RootHash          string
+	StartTime         time.Time
+	EndTime           time.Time
+	Error             string // empty if valid
+	FailureKind       ChainFailureKind
+	BrokenAtSeq       uint64 // set when chain breaks
+	BrokenAtIndex     int    // zero-based receipt index where chain verification failed
 
 	// SignerKeys is the ordered, de-duplicated set of signer public keys
 	// (hex) observed across the chain's segments, in segment order. A
@@ -67,6 +72,16 @@ type ChainResult struct {
 	// trusted set or an attacker-introduced key to investigate.
 	UntrustedSignerKey string
 }
+
+// ChainFailureKind classifies why chain verification failed.
+type ChainFailureKind string
+
+const (
+	ChainFailureIntegrity     ChainFailureKind = "integrity"
+	ChainFailureTrust         ChainFailureKind = "trust"
+	ChainFailureLifecycle     ChainFailureKind = "lifecycle"
+	ChainFailureLifecycleOpen ChainFailureKind = "lifecycle_missing_open"
+)
 
 // ChainSegment summarizes one single-key run within a (possibly rotated) chain.
 type ChainSegment struct {
@@ -89,6 +104,15 @@ func VerifyChain(receipts []Receipt, expectedKeyHex string) ChainResult {
 		return VerifyChainTrusted(receipts, nil)
 	}
 	return VerifyChainTrusted(receipts, []string{expectedKeyHex})
+}
+
+// VerifyChainIntegrity verifies signatures, trusted signer keys, sequence
+// numbers, and hash links while ignoring session-control lifecycle rules.
+func VerifyChainIntegrity(receipts []Receipt, expectedKeyHex string) ChainResult {
+	if expectedKeyHex == "" {
+		return VerifyChainIntegrityTrusted(receipts, nil)
+	}
+	return VerifyChainIntegrityTrusted(receipts, []string{expectedKeyHex})
 }
 
 // VerifyChainTrusted verifies hash-chain integrity across signing-key rotation
@@ -133,8 +157,34 @@ func VerifyChain(receipts []Receipt, expectedKeyHex string) ChainResult {
 //     receipt mid-chain (no marker, prev_hash != genesis), is rejected. This
 //     preserves the genesis check for ordinary receipts (no weakening).
 func VerifyChainTrusted(receipts []Receipt, trustedKeys []string) ChainResult {
+	res := verifyChainTrusted(receipts, trustedKeys, false)
+	if res.FailureKind != ChainFailureLifecycleOpen {
+		return res
+	}
+	integrity := verifyChainTrusted(receipts, trustedKeys, true)
+	if !integrity.Valid {
+		return integrity
+	}
+	res.IntegrityVerified = true
+	res.ReceiptCount = integrity.ReceiptCount
+	res.FinalSeq = integrity.FinalSeq
+	res.RootHash = integrity.RootHash
+	res.StartTime = integrity.StartTime
+	res.EndTime = integrity.EndTime
+	res.SignerKeys = integrity.SignerKeys
+	res.Segments = integrity.Segments
+	return res
+}
+
+// VerifyChainIntegrityTrusted is VerifyChainIntegrity with an explicit trusted
+// signer key set.
+func VerifyChainIntegrityTrusted(receipts []Receipt, trustedKeys []string) ChainResult {
+	return verifyChainTrusted(receipts, trustedKeys, true)
+}
+
+func verifyChainTrusted(receipts []Receipt, trustedKeys []string, integrityOnly bool) ChainResult {
 	if len(receipts) == 0 {
-		return ChainResult{Valid: true}
+		return ChainResult{Valid: true, IntegrityVerified: true}
 	}
 
 	normalizedKeys, err := normalizeTrustedKeys(trustedKeys)
@@ -144,6 +194,7 @@ func VerifyChainTrusted(receipts []Receipt, trustedKeys []string) ChainResult {
 			BrokenAtSeq:   receipts[0].ActionRecord.ChainSeq,
 			BrokenAtIndex: 0,
 			Error:         fmt.Sprintf("seq %d: trusted key set: %v", receipts[0].ActionRecord.ChainSeq, err),
+			FailureKind:   ChainFailureTrust,
 		}
 	}
 
@@ -152,8 +203,9 @@ func VerifyChainTrusted(receipts []Receipt, trustedKeys []string) ChainResult {
 		trusted[k] = struct{}{}
 	}
 	v := &chainVerifier{
-		trusted:   trusted,
-		runNonces: make(map[string]string),
+		trusted:       trusted,
+		runNonces:     make(map[string]string),
+		integrityOnly: integrityOnly,
 	}
 	return v.run(receipts)
 }
@@ -188,6 +240,8 @@ type chainVerifier struct {
 	curSeg     *ChainSegment
 	index      int
 	runNonces  map[string]string
+
+	integrityOnly bool
 }
 
 func (v *chainVerifier) run(receipts []Receipt) ChainResult {
@@ -208,8 +262,10 @@ func (v *chainVerifier) run(receipts []Receipt) ChainResult {
 			return res
 		}
 
-		if res, ok := v.validateSessionControl(r); !ok {
-			return res
+		if !v.integrityOnly {
+			if res, ok := v.validateSessionControl(r); !ok {
+				return res
+			}
 		}
 
 		if res, ok := v.verifyReceipt(r, uint64(i)); !ok {
@@ -221,14 +277,15 @@ func (v *chainVerifier) run(receipts []Receipt) ChainResult {
 	first := receipts[0].ActionRecord
 	last := receipts[len(receipts)-1].ActionRecord
 	return ChainResult{
-		Valid:        true,
-		ReceiptCount: uint64(len(receipts)),
-		FinalSeq:     last.ChainSeq,
-		RootHash:     v.prevHash,
-		StartTime:    first.Timestamp,
-		EndTime:      last.Timestamp,
-		SignerKeys:   v.signerKeys,
-		Segments:     v.segments,
+		Valid:             true,
+		IntegrityVerified: true,
+		ReceiptCount:      uint64(len(receipts)),
+		FinalSeq:          last.ChainSeq,
+		RootHash:          v.prevHash,
+		StartTime:         first.Timestamp,
+		EndTime:           last.Timestamp,
+		SignerKeys:        v.signerKeys,
+		Segments:          v.segments,
 	}
 }
 
@@ -265,7 +322,7 @@ func (v *chainVerifier) startFirstSegment(r Receipt) (ChainResult, bool) {
 		if r.ActionRecord.ChainPrevHash != GenesisHash {
 			return v.brokenAt(r, "genesis receipt chain_prev_hash must be genesis or a bound session_open g1 hash"), false
 		}
-		if sessionOpen(r.ActionRecord.SessionControl) != nil {
+		if !v.integrityOnly && sessionOpen(r.ActionRecord.SessionControl) != nil {
 			return v.brokenAt(r, "session_open on legacy genesis must use bound g1 chain_prev_hash"), false
 		}
 		v.prevHash = GenesisHash
@@ -298,7 +355,7 @@ func (v *chainVerifier) startRotatedSegment(r Receipt, marker *KeyTransition) (C
 	if v.curSeg != nil && marker.PriorChainSeq != v.curSeg.FinalSeq {
 		return v.brokenAt(r, "key_transition prior_chain_seq does not match prior segment final seq"), false
 	}
-	if open := sessionOpen(r.ActionRecord.SessionControl); open != nil {
+	if open := sessionOpen(r.ActionRecord.SessionControl); !v.integrityOnly && open != nil {
 		if res, ok := v.validateRestartOpen(r, open, marker.PriorChainHash, marker.PriorChainSeq); !ok {
 			return res, false
 		}
@@ -326,7 +383,7 @@ func (v *chainVerifier) keyTrusted(key string) bool {
 // it, so the operator can decide whether it is a legitimate rotation (re-run
 // with the key added to the trusted set) or an attacker key.
 func (v *chainVerifier) untrusted(r Receipt) ChainResult {
-	res := v.brokenAt(r, fmt.Sprintf("signer key %s is not in the trusted set", r.SignerKey))
+	res := v.brokenAtKind(r, fmt.Sprintf("signer key %s is not in the trusted set", r.SignerKey), ChainFailureTrust)
 	res.UntrustedSignerKey = r.SignerKey
 	res.SignerKeys = v.signerKeys
 	return res
@@ -341,7 +398,7 @@ func (v *chainVerifier) checkContinuation(r Receipt) (ChainResult, bool) {
 	if r.ActionRecord.ChainSeq == 0 {
 		return v.brokenAt(r, "unexpected seq 0 without a key_transition boundary"), false
 	}
-	if open := sessionOpen(r.ActionRecord.SessionControl); open != nil {
+	if open := sessionOpen(r.ActionRecord.SessionControl); !v.integrityOnly && open != nil {
 		if v.curSeg == nil {
 			return v.brokenAt(r, "session_open continuation has no prior segment"), false
 		}
@@ -412,23 +469,23 @@ func (v *chainVerifier) validateSessionControl(r Receipt) (ChainResult, bool) {
 			payloads++
 		}
 		if payloads != 1 {
-			return v.brokenAt(r, "session_control must carry exactly one payload"), false
+			return v.brokenAtKind(r, "session_control must carry exactly one payload", ChainFailureLifecycle), false
 		}
 		switch ctrl.Kind {
 		case SessionControlOpen:
 			if open == nil {
-				return v.brokenAt(r, "session_open kind missing open payload"), false
+				return v.brokenAtKind(r, "session_open kind missing open payload", ChainFailureLifecycle), false
 			}
 		case SessionControlHeartbeat:
 			if heartbeat == nil {
-				return v.brokenAt(r, "heartbeat kind missing heartbeat payload"), false
+				return v.brokenAtKind(r, "heartbeat kind missing heartbeat payload", ChainFailureLifecycle), false
 			}
 		case SessionControlClose:
 			if closeRecord == nil {
-				return v.brokenAt(r, "session_close kind missing close payload"), false
+				return v.brokenAtKind(r, "session_close kind missing close payload", ChainFailureLifecycle), false
 			}
 		default:
-			return v.brokenAt(r, "unknown session_control kind"), false
+			return v.brokenAtKind(r, "unknown session_control kind", ChainFailureLifecycle), false
 		}
 	}
 	if r.ActionRecord.RunNonce == "" {
@@ -437,34 +494,34 @@ func (v *chainVerifier) validateSessionControl(r Receipt) (ChainResult, bool) {
 	if open == nil {
 		openNonce, ok := v.runNonces[r.ActionRecord.RunNonce]
 		if !ok {
-			return v.brokenAt(r, "run_nonce first receipt is not a matching session_open"), false
+			return v.brokenAtKind(r, "run_nonce first receipt is not a matching session_open", ChainFailureLifecycleOpen), false
 		}
 		if heartbeat != nil {
 			if heartbeat.RunNonce != r.ActionRecord.RunNonce {
-				return v.brokenAt(r, "heartbeat run_nonce does not match receipt run_nonce"), false
+				return v.brokenAtKind(r, "heartbeat run_nonce does not match receipt run_nonce", ChainFailureLifecycle), false
 			}
 			if heartbeat.OpenNonce != openNonce {
-				return v.brokenAt(r, "heartbeat open_nonce does not match session_open"), false
+				return v.brokenAtKind(r, "heartbeat open_nonce does not match session_open", ChainFailureLifecycle), false
 			}
 		}
 		if closeRecord != nil {
 			if closeRecord.RunNonce != r.ActionRecord.RunNonce {
-				return v.brokenAt(r, "session_close run_nonce does not match receipt run_nonce"), false
+				return v.brokenAtKind(r, "session_close run_nonce does not match receipt run_nonce", ChainFailureLifecycle), false
 			}
 			if closeRecord.OpenNonce != openNonce {
-				return v.brokenAt(r, "session_close open_nonce does not match session_open"), false
+				return v.brokenAtKind(r, "session_close open_nonce does not match session_open", ChainFailureLifecycle), false
 			}
 		}
 		return ChainResult{}, true
 	}
 	if open.RunNonce != r.ActionRecord.RunNonce {
-		return v.brokenAt(r, "session_open run_nonce does not match receipt run_nonce"), false
+		return v.brokenAtKind(r, "session_open run_nonce does not match receipt run_nonce", ChainFailureLifecycle), false
 	}
 	if open.OpenNonce == "" {
-		return v.brokenAt(r, "session_open open_nonce is empty"), false
+		return v.brokenAtKind(r, "session_open open_nonce is empty", ChainFailureLifecycle), false
 	}
 	if _, exists := v.runNonces[r.ActionRecord.RunNonce]; exists {
-		return v.brokenAt(r, "duplicate session_open for run_nonce"), false
+		return v.brokenAtKind(r, "duplicate session_open for run_nonce", ChainFailureLifecycle), false
 	}
 	v.runNonces[r.ActionRecord.RunNonce] = open.OpenNonce
 	return ChainResult{}, true
@@ -554,11 +611,16 @@ func (v *chainVerifier) appendSignerKey(key string) {
 }
 
 func (v *chainVerifier) brokenAt(r Receipt, msg string) ChainResult {
+	return v.brokenAtKind(r, msg, ChainFailureIntegrity)
+}
+
+func (v *chainVerifier) brokenAtKind(r Receipt, msg string, kind ChainFailureKind) ChainResult {
 	return ChainResult{
 		Valid:         false,
 		BrokenAtSeq:   r.ActionRecord.ChainSeq,
 		BrokenAtIndex: v.index,
 		Error:         fmt.Sprintf("seq %d: %s", r.ActionRecord.ChainSeq, msg),
+		FailureKind:   kind,
 		SignerKeys:    v.signerKeys,
 	}
 }

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -151,7 +151,10 @@ func VerifyChainTrusted(receipts []Receipt, trustedKeys []string) ChainResult {
 	for _, k := range normalizedKeys {
 		trusted[k] = struct{}{}
 	}
-	v := &chainVerifier{trusted: trusted}
+	v := &chainVerifier{
+		trusted:   trusted,
+		runNonces: make(map[string]string),
+	}
 	return v.run(receipts)
 }
 
@@ -184,6 +187,7 @@ type chainVerifier struct {
 	segments   []ChainSegment
 	curSeg     *ChainSegment
 	index      int
+	runNonces  map[string]string
 }
 
 func (v *chainVerifier) run(receipts []Receipt) ChainResult {
@@ -201,6 +205,10 @@ func (v *chainVerifier) run(receipts []Receipt) ChainResult {
 				return res
 			}
 		} else if res, ok := v.checkContinuation(r); !ok {
+			return res
+		}
+
+		if res, ok := v.validateSessionControl(r); !ok {
 			return res
 		}
 
@@ -246,8 +254,20 @@ func (v *chainVerifier) startFirstSegment(r Receipt) (ChainResult, bool) {
 		// a marker on the first receipt would allow deletion/truncation of the
 		// prior segment while still returning CHAIN VALID for the suffix.
 		return v.brokenAt(r, "chain starts at a key_transition segment without the prior segment"), false
+	case strings.HasPrefix(r.ActionRecord.ChainPrevHash, genesisSessionOpenPrefix):
+		if res, ok := v.validateBoundGenesisOpen(r); !ok {
+			return res, false
+		}
+		v.prevHash = r.ActionRecord.ChainPrevHash
+		v.beginSegment(r, false)
 	default:
 		// Ordinary genesis: prev_hash must be the genesis sentinel.
+		if r.ActionRecord.ChainPrevHash != GenesisHash {
+			return v.brokenAt(r, "genesis receipt chain_prev_hash must be genesis or a bound session_open g1 hash"), false
+		}
+		if sessionOpen(r.ActionRecord.SessionControl) != nil {
+			return v.brokenAt(r, "session_open on legacy genesis must use bound g1 chain_prev_hash"), false
+		}
 		v.prevHash = GenesisHash
 		v.beginSegment(r, false)
 	}
@@ -277,6 +297,11 @@ func (v *chainVerifier) startRotatedSegment(r Receipt, marker *KeyTransition) (C
 	}
 	if v.curSeg != nil && marker.PriorChainSeq != v.curSeg.FinalSeq {
 		return v.brokenAt(r, "key_transition prior_chain_seq does not match prior segment final seq"), false
+	}
+	if open := sessionOpen(r.ActionRecord.SessionControl); open != nil {
+		if res, ok := v.validateRestartOpen(r, open, marker.PriorChainHash, marker.PriorChainSeq); !ok {
+			return res, false
+		}
 	}
 	// The boundary is structurally valid, but trust is NOT delegated by the
 	// marker (it is signed by the new key, which an attacker with write access
@@ -316,7 +341,111 @@ func (v *chainVerifier) checkContinuation(r Receipt) (ChainResult, bool) {
 	if r.ActionRecord.ChainSeq == 0 {
 		return v.brokenAt(r, "unexpected seq 0 without a key_transition boundary"), false
 	}
+	if open := sessionOpen(r.ActionRecord.SessionControl); open != nil {
+		if v.curSeg == nil {
+			return v.brokenAt(r, "session_open continuation has no prior segment"), false
+		}
+		if res, ok := v.validateRestartOpen(r, open, v.prevHash, v.curSeg.FinalSeq); !ok {
+			return res, false
+		}
+	}
 	return ChainResult{}, true
+}
+
+func (v *chainVerifier) validateBoundGenesisOpen(r Receipt) (ChainResult, bool) {
+	open := sessionOpen(r.ActionRecord.SessionControl)
+	if open == nil {
+		return v.brokenAt(r, "g1 chain_prev_hash requires SessionControl.Open"), false
+	}
+	if r.ActionRecord.ChainSeq != 0 {
+		return v.brokenAt(r, "bound session_open genesis must be chain_seq 0"), false
+	}
+	computed := ComputeSessionOpenGenesis(*open)
+	if r.ActionRecord.ChainPrevHash != computed {
+		return v.brokenAt(r, "session_open genesis hash mismatch"), false
+	}
+	if open.GenesisHash != computed {
+		return v.brokenAt(r, "session_open genesis_hash mismatch"), false
+	}
+	if open.ChainOpenSeq != r.ActionRecord.ChainSeq {
+		return v.brokenAt(r, "session_open chain_open_seq does not match receipt chain_seq"), false
+	}
+	if open.PriorChainHead != "" || open.PriorChainSeq != 0 {
+		return v.brokenAt(r, "bound genesis session_open must not carry prior chain tail"), false
+	}
+	return ChainResult{}, true
+}
+
+func (v *chainVerifier) validateRestartOpen(r Receipt, open *SessionOpen, priorHead string, priorSeq uint64) (ChainResult, bool) {
+	if strings.HasPrefix(r.ActionRecord.ChainPrevHash, genesisSessionOpenPrefix) {
+		return v.brokenAt(r, "restart session_open must not use g1 chain_prev_hash"), false
+	}
+	if open.GenesisHash != "" {
+		return v.brokenAt(r, "restart session_open must not carry genesis_hash"), false
+	}
+	if open.ChainOpenSeq != r.ActionRecord.ChainSeq {
+		return v.brokenAt(r, "session_open chain_open_seq does not match receipt chain_seq"), false
+	}
+	if open.PriorChainHead != priorHead {
+		return v.brokenAt(r, "session_open prior_chain_head does not match prior tail hash"), false
+	}
+	if open.PriorChainSeq != priorSeq {
+		return v.brokenAt(r, "session_open prior_chain_seq does not match prior tail seq"), false
+	}
+	return ChainResult{}, true
+}
+
+func (v *chainVerifier) validateSessionControl(r Receipt) (ChainResult, bool) {
+	ctrl := r.ActionRecord.SessionControl
+	open := sessionOpen(ctrl)
+	if ctrl != nil {
+		payloads := 0
+		if ctrl.Open != nil {
+			payloads++
+		}
+		if ctrl.Heartbeat != nil {
+			payloads++
+		}
+		if ctrl.Close != nil {
+			payloads++
+		}
+		if payloads != 1 {
+			return v.brokenAt(r, "session_control must carry exactly one payload"), false
+		}
+		if open == nil && ctrl.Kind == SessionControlOpen {
+			return v.brokenAt(r, "session_open kind missing open payload"), false
+		}
+		if open != nil && ctrl.Kind != SessionControlOpen {
+			return v.brokenAt(r, "open payload kind mismatch"), false
+		}
+	}
+	if r.ActionRecord.RunNonce == "" {
+		return ChainResult{}, true
+	}
+	if open == nil {
+		if _, ok := v.runNonces[r.ActionRecord.RunNonce]; !ok {
+			return v.brokenAt(r, "run_nonce first receipt is not a matching session_open"), false
+		}
+		return ChainResult{}, true
+	}
+	if open.RunNonce != r.ActionRecord.RunNonce {
+		return v.brokenAt(r, "session_open run_nonce does not match receipt run_nonce"), false
+	}
+	if open.OpenNonce == "" {
+		return v.brokenAt(r, "session_open open_nonce is empty"), false
+	}
+	if _, exists := v.runNonces[r.ActionRecord.RunNonce]; exists {
+		return v.brokenAt(r, "duplicate session_open for run_nonce"), false
+	}
+	v.runNonces[r.ActionRecord.RunNonce] = open.OpenNonce
+	return ChainResult{}, true
+}
+
+func sessionOpen(ctrl *SessionControl) *SessionOpen {
+	if ctrl == nil || ctrl.Kind != SessionControlOpen {
+		return nil
+	}
+	return ctrl.Open
 }
 
 func (v *chainVerifier) verifyReceipt(r Receipt, index uint64) (ChainResult, bool) {

--- a/internal/receipt/chain_test.go
+++ b/internal/receipt/chain_test.go
@@ -239,6 +239,187 @@ func TestVerifyChain_InvalidSignature(t *testing.T) {
 	}
 }
 
+func TestVerifyChainIntegrityOnlyNoOpen(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateTestKey(t)
+	keyHex := hex.EncodeToString(pub)
+	ar := ActionRecord{
+		Version:       ActionRecordVersion,
+		ActionID:      NewActionID(),
+		ActionType:    ActionUnclassified,
+		Timestamp:     time.Date(2026, 7, 6, 14, 0, 0, 0, time.UTC),
+		Target:        "pipelock://session/heartbeat",
+		Verdict:       testVerdict,
+		Transport:     "session_control",
+		ChainPrevHash: GenesisHash,
+		ChainSeq:      0,
+		RunNonce:      "run-no-open-integrity",
+		SessionControl: &SessionControl{
+			Kind: SessionControlHeartbeat,
+			Heartbeat: &SessionHeartbeat{
+				RunNonce:         "run-no-open-integrity",
+				OpenNonce:        "open-no-open-integrity",
+				Beat:             1,
+				HeartbeatTime:    time.Date(2026, 7, 6, 14, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+				DurabilityBlocks: 1,
+			},
+		},
+	}
+	r, err := Sign(ar, priv)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	chain := []Receipt{r}
+
+	result := VerifyChain(chain, keyHex)
+	if result.Valid {
+		t.Fatal("chain with run_nonce and no session_open should be invalid")
+	}
+	if result.FailureKind != ChainFailureLifecycleOpen || !result.IntegrityVerified {
+		t.Fatalf("result kind/integrity = %q/%t, want %q/true: %#v",
+			result.FailureKind, result.IntegrityVerified, ChainFailureLifecycleOpen, result)
+	}
+	if integrity := VerifyChainIntegrity(chain, keyHex); !integrity.Valid {
+		t.Fatalf("integrity-only verification failed: %s", integrity.Error)
+	}
+
+	chain[0].ActionRecord.Target = "https://api.vendor.example/forged-no-open"
+	result = VerifyChain(chain, keyHex)
+	if result.Valid || result.FailureKind != ChainFailureIntegrity || result.IntegrityVerified {
+		t.Fatalf("forged no-open result = valid %t kind %q integrity %t, want integrity failure: %#v",
+			result.Valid, result.FailureKind, result.IntegrityVerified, result)
+	}
+}
+
+func TestVerifyChainFailureKindsDoNotOverDowngrade(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 6, 15, 0, 0, 0, time.UTC)
+
+	t.Run("forged_first_receipt", func(t *testing.T) {
+		t.Parallel()
+		pub, priv := generateTestKey(t)
+		chain := []Receipt{signBoundOpen(t, priv, base)}
+		chain[0].ActionRecord.Target = "https://api.vendor.example/forged-first"
+
+		requireChainFailure(t, VerifyChain(chain, hex.EncodeToString(pub)), ChainFailureIntegrity)
+	})
+
+	t.Run("forged_mid_chain_receipt", func(t *testing.T) {
+		t.Parallel()
+		pub, priv := generateTestKey(t)
+		open := signBoundOpen(t, priv, base)
+		action := signRunReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, base.Add(time.Second))
+		action.ActionRecord.Target = "https://api.vendor.example/forged-mid"
+
+		requireChainFailure(t, VerifyChain([]Receipt{open, action}, hex.EncodeToString(pub)), ChainFailureIntegrity)
+	})
+
+	t.Run("forged_heartbeat_in_open_chain", func(t *testing.T) {
+		t.Parallel()
+		pub, priv := generateTestKey(t)
+		open := signBoundOpen(t, priv, base)
+		heartbeat := signHeartbeatReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, "open-a", base.Add(time.Second))
+		heartbeat.ActionRecord.Target = "https://api.vendor.example/forged-heartbeat"
+
+		requireChainFailure(t, VerifyChain([]Receipt{open, heartbeat}, hex.EncodeToString(pub)), ChainFailureIntegrity)
+	})
+
+	t.Run("forged_close_in_open_chain", func(t *testing.T) {
+		t.Parallel()
+		pub, priv := generateTestKey(t)
+		open := signBoundOpen(t, priv, base)
+		closeReceipt := signCloseReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, "open-a", base.Add(time.Second))
+		closeReceipt.ActionRecord.Target = "https://api.vendor.example/forged-close"
+
+		requireChainFailure(t, VerifyChain([]Receipt{open, closeReceipt}, hex.EncodeToString(pub)), ChainFailureIntegrity)
+	})
+
+	t.Run("untrusted_signer_key", func(t *testing.T) {
+		t.Parallel()
+		pubA, privA := generateTestKey(t)
+		pubB, privB := generateTestKey(t)
+		open := signBoundOpen(t, privA, base)
+		priorHash := mustHash(t, open)
+		marker := &KeyTransition{
+			PriorSignerKey: hex.EncodeToString(pubA),
+			PriorChainSeq:  open.ActionRecord.ChainSeq,
+			PriorChainHash: priorHash,
+		}
+		rotated := signRestartOpen(t, privB, 0, priorHash, open.ActionRecord.ChainSeq, sessionOpenTestRunB, base.Add(time.Second), marker)
+
+		requireChainFailure(t, VerifyChainTrusted([]Receipt{open, rotated}, []string{hex.EncodeToString(pubA)}), ChainFailureTrust)
+		requireChainFailure(t, VerifyChainIntegrityTrusted([]Receipt{open, rotated}, []string{hex.EncodeToString(pubA)}), ChainFailureTrust)
+		if res := VerifyChainTrusted([]Receipt{open, rotated}, []string{hex.EncodeToString(pubA), hex.EncodeToString(pubB)}); !res.Valid {
+			t.Fatalf("trusted rotation should verify: %s", res.Error)
+		}
+	})
+
+	t.Run("duplicate_open_lifecycle_failure", func(t *testing.T) {
+		t.Parallel()
+		pub, priv := generateTestKey(t)
+		open := signBoundOpen(t, priv, base)
+		priorHash := mustHash(t, open)
+		duplicate := signRestartOpen(t, priv, 1, priorHash, open.ActionRecord.ChainSeq, sessionOpenTestRunA, base.Add(time.Second), nil)
+
+		requireChainFailure(t, VerifyChain([]Receipt{open, duplicate}, hex.EncodeToString(pub)), ChainFailureLifecycle)
+		if integrity := VerifyChainIntegrity([]Receipt{open, duplicate}, hex.EncodeToString(pub)); !integrity.Valid {
+			t.Fatalf("integrity-only duplicate-open chain should verify structurally: %s", integrity.Error)
+		}
+	})
+
+	t.Run("wrong_open_nonce_lifecycle_failure", func(t *testing.T) {
+		t.Parallel()
+		pub, priv := generateTestKey(t)
+		open := signBoundOpen(t, priv, base)
+		heartbeat := signHeartbeatReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, "wrong-open", base.Add(time.Second))
+
+		requireChainFailure(t, VerifyChain([]Receipt{open, heartbeat}, hex.EncodeToString(pub)), ChainFailureLifecycle)
+		if integrity := VerifyChainIntegrity([]Receipt{open, heartbeat}, hex.EncodeToString(pub)); !integrity.Valid {
+			t.Fatalf("integrity-only wrong-open-nonce chain should verify structurally: %s", integrity.Error)
+		}
+	})
+}
+
+func signHeartbeatReceipt(t *testing.T, priv ed25519.PrivateKey, seq uint64, prevHash, runNonce, openNonce string, ts time.Time) Receipt {
+	t.Helper()
+	return signSessionReceipt(t, priv, seq, prevHash, ts, runNonce, &SessionControl{
+		Kind: SessionControlHeartbeat,
+		Heartbeat: &SessionHeartbeat{
+			RunNonce:         runNonce,
+			OpenNonce:        openNonce,
+			Beat:             1,
+			HeartbeatTime:    ts.Format(time.RFC3339Nano),
+			DurabilityBlocks: 1,
+		},
+	}, nil)
+}
+
+func signCloseReceipt(t *testing.T, priv ed25519.PrivateKey, seq uint64, prevHash, runNonce, openNonce string, ts time.Time) Receipt {
+	t.Helper()
+	return signSessionReceipt(t, priv, seq, prevHash, ts, runNonce, &SessionControl{
+		Kind: SessionControlClose,
+		Close: &SessionClose{
+			RunNonce:         runNonce,
+			OpenNonce:        openNonce,
+			FinalSeq:         seq - 1,
+			RootHash:         prevHash,
+			ReceiptCount:     seq,
+			CloseReason:      "normal",
+			DurabilityBlocks: 1,
+		},
+	}, nil)
+}
+
+func requireChainFailure(t *testing.T, res ChainResult, want ChainFailureKind) {
+	t.Helper()
+	if res.Valid || res.FailureKind != want || res.IntegrityVerified {
+		t.Fatalf("result = valid %t kind %q integrity %t, want invalid %q integrity false: %#v",
+			res.Valid, res.FailureKind, res.IntegrityVerified, want, res)
+	}
+}
+
 func TestVerifyChain_NoKeyPinning(t *testing.T) {
 	t.Parallel()
 

--- a/internal/receipt/chain_test.go
+++ b/internal/receipt/chain_test.go
@@ -358,6 +358,7 @@ func TestExtractReceipts_HappyPath(t *testing.T) {
 		ConfigHash: "testhash",
 		Principal:  "test-principal",
 	})
+	emitSessionOpenForTest(t, e)
 
 	for i := 0; i < 3; i++ {
 		if err := e.Emit(EmitOpts{
@@ -388,8 +389,8 @@ func TestExtractReceipts_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExtractReceipts: %v", err)
 	}
-	if len(receipts) != 3 {
-		t.Fatalf("expected 3 receipts, got %d", len(receipts))
+	if len(receipts) != 4 {
+		t.Fatalf("expected 4 receipts, got %d", len(receipts))
 	}
 
 	// Verify the extracted chain
@@ -711,6 +712,7 @@ func TestResume_AfterTranscriptRoot_DoesNotBrick(t *testing.T) {
 	// Run 1: emit 2 receipts, seal with a transcript root, shut down.
 	rec1 := newTestRecorder(t, dir, priv)
 	e1 := NewEmitter(EmitterConfig{Recorder: rec1, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+	emitSessionOpenForTest(t, e1)
 	for range 2 {
 		if err := emit(e1); err != nil {
 			t.Fatalf("run1 Emit: %v", err)
@@ -732,6 +734,7 @@ func TestResume_AfterTranscriptRoot_DoesNotBrick(t *testing.T) {
 	if err := e2.InitError(); err != nil {
 		t.Fatalf("resume after sealed shutdown errored (should resume cleanly): %v", err)
 	}
+	emitSessionOpenForTest(t, e2)
 	// The post-seal restart MUST emit (not be bricked by ErrChainSealed).
 	for range 2 {
 		if err := emit(e2); err != nil {
@@ -742,7 +745,8 @@ func TestResume_AfterTranscriptRoot_DoesNotBrick(t *testing.T) {
 		t.Fatalf("close rec2: %v", err)
 	}
 
-	// All 4 action receipts (2 per run) form one continuous, verifiable chain.
+	// All 6 action receipts (session_open + 2 decisions per run) form one
+	// continuous, verifiable chain.
 	entries := readAllEntriesFromDir(t, dir)
 	var receipts []Receipt
 	for i := range entries {
@@ -755,15 +759,15 @@ func TestResume_AfterTranscriptRoot_DoesNotBrick(t *testing.T) {
 		}
 		receipts = append(receipts, *r)
 	}
-	if len(receipts) != 4 {
-		t.Fatalf("expected 4 action receipts across both runs, got %d", len(receipts))
+	if len(receipts) != 6 {
+		t.Fatalf("expected 6 action receipts across both runs, got %d", len(receipts))
 	}
 	res := VerifyChain(receipts, "")
 	if !res.Valid {
 		t.Fatalf("post-seal chain failed to verify: %s", res.Error)
 	}
-	if res.ReceiptCount != 4 {
-		t.Errorf("ReceiptCount = %d, want 4 (seq must continue across the seal, not reset)", res.ReceiptCount)
+	if res.ReceiptCount != 6 {
+		t.Errorf("ReceiptCount = %d, want 6 (seq must continue across the seal, not reset)", res.ReceiptCount)
 	}
 }
 
@@ -857,6 +861,7 @@ func TestEmitter_ChainState(t *testing.T) {
 		Principal:  testPrincipal,
 		Actor:      testActor,
 	})
+	emitSessionOpenForTest(t, e)
 
 	const chainLen = 5
 	for range chainLen {
@@ -878,14 +883,14 @@ func TestEmitter_ChainState(t *testing.T) {
 
 	// Read all receipts and verify chain integrity.
 	receipts := readAllReceiptsFromDir(t, dir, pub)
-	if len(receipts) != chainLen {
-		t.Fatalf("expected %d receipts, got %d", chainLen, len(receipts))
+	if len(receipts) != chainLen+1 {
+		t.Fatalf("expected %d receipts, got %d", chainLen+1, len(receipts))
 	}
 
-	// First receipt should have genesis prev_hash.
-	if receipts[0].ActionRecord.ChainPrevHash != GenesisHash {
-		t.Errorf("first receipt chain_prev_hash = %q, want %q",
-			receipts[0].ActionRecord.ChainPrevHash, GenesisHash)
+	// First receipt should have a bound session-open genesis prev_hash.
+	if !strings.HasPrefix(receipts[0].ActionRecord.ChainPrevHash, genesisSessionOpenPrefix) {
+		t.Errorf("first receipt chain_prev_hash = %q, want %q prefix",
+			receipts[0].ActionRecord.ChainPrevHash, genesisSessionOpenPrefix)
 	}
 
 	// Each receipt's seq should increment by 1.
@@ -914,8 +919,8 @@ func TestEmitter_ChainState(t *testing.T) {
 	if !result.Valid {
 		t.Fatalf("VerifyChain failed: %s", result.Error)
 	}
-	if result.ReceiptCount != chainLen {
-		t.Errorf("VerifyChain receipt_count = %d, want %d", result.ReceiptCount, chainLen)
+	if result.ReceiptCount != chainLen+1 {
+		t.Errorf("VerifyChain receipt_count = %d, want %d", result.ReceiptCount, chainLen+1)
 	}
 }
 
@@ -1030,6 +1035,7 @@ func TestEmitter_ResumesChainAfterRestart(t *testing.T) {
 		if e == nil {
 			t.Fatal("NewEmitter() returned nil")
 		}
+		emitSessionOpenForTest(t, e)
 		return rec, e
 	}
 
@@ -1067,8 +1073,8 @@ func TestEmitter_ResumesChainAfterRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("QuerySession(): %v", err)
 	}
-	if len(result.Entries) != 3 {
-		t.Fatalf("receipt entry count = %d, want 3", len(result.Entries))
+	if len(result.Entries) != 5 {
+		t.Fatalf("receipt entry count = %d, want 5", len(result.Entries))
 	}
 
 	receipts := make([]Receipt, 0, len(result.Entries))
@@ -1116,6 +1122,7 @@ func TestExtractReceiptsWithSessionID_HappyPath(t *testing.T) {
 		ConfigHash: testConfigHash,
 		Principal:  testPrincipal,
 	})
+	emitSessionOpenForTest(t, e)
 
 	for i := 0; i < 3; i++ {
 		if err := e.Emit(EmitOpts{
@@ -1147,8 +1154,8 @@ func TestExtractReceiptsWithSessionID_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExtractReceiptsWithSessionID: %v", err)
 	}
-	if len(receipts) != 3 {
-		t.Fatalf("expected 3 receipts, got %d", len(receipts))
+	if len(receipts) != 4 {
+		t.Fatalf("expected 4 receipts, got %d", len(receipts))
 	}
 	if sessionID == "" {
 		t.Fatal("expected non-empty session ID")

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -54,6 +55,8 @@ const (
 	FailReasonMarshal = "marshal"
 	// FailReasonRecord is a recorder-write failure.
 	FailReasonRecord = "record"
+	// FailReasonSync is a recorder durability-sync failure.
+	FailReasonSync = "sync"
 	// FailReasonSealed is an emit attempt after the transcript root was emitted.
 	FailReasonSealed = "sealed"
 	// FailReasonUnavailable is a required-receipt emission attempt when no
@@ -261,6 +264,16 @@ func (e *Emitter) EmitSessionOpen() error {
 // Errors are returned but should be logged, not propagated to callers.
 // Safe to call on a nil Emitter (no-op).
 func (e *Emitter) Emit(opts EmitOpts) error {
+	return e.emit(opts, false)
+}
+
+// EmitDurable creates, signs, records, and fsync-confirms an action receipt for
+// a proxy decision. Safe to call on a nil Emitter (no-op).
+func (e *Emitter) EmitDurable(opts EmitOpts) error {
+	return e.emit(opts, true)
+}
+
+func (e *Emitter) emit(opts EmitOpts, durable bool) error {
 	if e == nil {
 		return nil
 	}
@@ -281,9 +294,9 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 
 	// Chain integrity: lock covers stamp → sign → hash → persist → advance.
 	// The mutex must span from timestamp through persist so concurrent Emit
-	// calls produce monotonic timestamps in chain order. State is only
-	// advanced after successful write; a failed Record leaves the chain at
-	// the previous position.
+	// calls produce monotonic timestamps in chain order. State advances before
+	// recorder persistence so a failed Record leaves a detectable gap instead
+	// of reusing the same prev_hash/seq and forking the chain.
 	e.chainMu.Lock()
 	defer e.chainMu.Unlock()
 
@@ -408,16 +421,27 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 		e.sessionOpenEmitted = true
 	}
 
-	if err := e.recorder.Record(recorder.Entry{
+	entry := recorder.Entry{
 		SessionID: recorderSessionID,
 		Type:      recorderEntryType,
 		EventKind: string(ar.ActionType),
 		Transport: opts.Transport,
 		Summary:   fmt.Sprintf("receipt: %s %s %s", ar.Verdict, ar.ActionType, ar.Transport),
 		Detail:    json.RawMessage(receiptJSON),
-	}); err != nil {
-		e.recordFailure(FailReasonRecord)
-		return fmt.Errorf("recording receipt: %w", err)
+	}
+	var recordErr error
+	if durable {
+		recordErr = e.recorder.RecordDurable(entry)
+	} else {
+		recordErr = e.recorder.Record(entry)
+	}
+	if recordErr != nil {
+		if durable && errors.Is(recordErr, recorder.ErrDurability) {
+			e.recordFailure(FailReasonSync)
+		} else {
+			e.recordFailure(FailReasonRecord)
+		}
+		return fmt.Errorf("recording receipt: %w", recordErr)
 	}
 
 	// Notify the observer (if any) AFTER the receipt is durably recorded, so a

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/session"
@@ -89,6 +90,15 @@ type Emitter struct {
 	// segment by the next Emit, then cleared. nil when there is no pending
 	// segment boundary.
 	pendingTransition *KeyTransition
+
+	// hasPriorTail carries the on-disk tail observed by resumeChain for this
+	// process run. SessionOpen uses it to distinguish restart-open receipts
+	// from a first-chain bound genesis.
+	hasPriorTail  bool
+	priorTailSeq  uint64
+	priorTailHash string
+
+	sessionOpenEmitted bool
 }
 
 // EmitterConfig holds the configuration for creating an Emitter.
@@ -201,6 +211,49 @@ type EmitOpts struct {
 	// MCP-specific fields
 	ToolName  string
 	MCPMethod string
+
+	// SessionControl is set only for signed lifecycle control records such as
+	// session_open. Ordinary action receipts leave it nil.
+	SessionControl *SessionControl
+}
+
+// ErrSessionOpenAlreadyEmitted is returned when a process run tries to emit a
+// second session_open. A restart gets a fresh Emitter and fresh run_nonce.
+var ErrSessionOpenAlreadyEmitted = fmt.Errorf("session_open already emitted for this run")
+
+const (
+	sessionControlTransport = "receipt_session"
+	sessionOpenTarget       = "pipelock://session/open"
+)
+
+// EmitSessionOpen emits the signed session_open control receipt for this
+// emitter process run through the normal Emit/Record path. It is intentionally
+// non-durable in this build unit; the durable receipt gate lands later.
+func (e *Emitter) EmitSessionOpen() error {
+	if e == nil {
+		return nil
+	}
+	openNonce, err := newOpenNonce()
+	if err != nil {
+		e.recordFailure(FailReasonSign)
+		return fmt.Errorf("generate open nonce: %w", err)
+	}
+	return e.Emit(EmitOpts{
+		ActionID:  NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: sessionControlTransport,
+		Target:    sessionOpenTarget,
+		SessionControl: &SessionControl{
+			Kind: SessionControlOpen,
+			Open: &SessionOpen{
+				RunNonce:        e.runNonce,
+				OpenNonce:       openNonce,
+				RecorderSession: recorderSessionID,
+				PolicyHash:      configHashString(e.configHash.Load()),
+				SignerKeyEpoch:  fmt.Sprintf("%x", e.privKey.Public().(ed25519.PublicKey)),
+			},
+		},
+	})
 }
 
 // Emit creates, signs, and records an action receipt for a proxy decision.
@@ -237,6 +290,10 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 	if e.rootEmitted {
 		e.recordFailure(FailReasonSealed)
 		return ErrChainSealed
+	}
+	sessionControl, chainPrevHash, err := e.prepareSessionControlLocked(opts.SessionControl)
+	if err != nil {
+		return err
 	}
 
 	// Sanitize secret-bearing fields BEFORE signing. When redaction is enabled
@@ -301,14 +358,15 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 		Redaction:             redactionSummaryFromReport(opts.RedactionProfile, opts.RedactionReport),
 		Shield:                cloneShieldSummary(opts.Shield),
 		RequestID:             opts.RequestID,
-		ChainPrevHash:         e.chainPrevHash,
+		ChainPrevHash:         chainPrevHash,
 		ChainSeq:              e.chainSeq,
 		RunNonce:              e.runNonce,
 		// pendingTransition is non-nil only on the first receipt of a new
 		// segment opened by resumeChain after a legitimate key rotation. It
 		// is bound into the signed record so the segment boundary is provable
 		// from this receipt alone, then cleared after a successful write.
-		KeyTransition: e.pendingTransition,
+		KeyTransition:  e.pendingTransition,
+		SessionControl: sessionControl,
 	}
 
 	rcpt, err := Sign(ar, e.privKey)
@@ -346,6 +404,9 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 	// claim a second segment boundary). Cleared with the rest of the
 	// advance-before-persist state for the same fork-avoidance reason.
 	e.pendingTransition = nil
+	if isSessionOpenControl(sessionControl) {
+		e.sessionOpenEmitted = true
+	}
 
 	if err := e.recorder.Record(recorder.Entry{
 		SessionID: recorderSessionID,
@@ -370,6 +431,67 @@ func (e *Emitter) Emit(opts EmitOpts) error {
 	}
 
 	return nil
+}
+
+func (e *Emitter) prepareSessionControlLocked(in *SessionControl) (*SessionControl, string, error) {
+	chainPrevHash := e.chainPrevHash
+	if in == nil {
+		return nil, chainPrevHash, nil
+	}
+	if !isSessionOpenControl(in) {
+		return cloneSessionControl(in), chainPrevHash, nil
+	}
+	if e.sessionOpenEmitted {
+		e.recordFailure(FailReasonRecord)
+		return nil, "", ErrSessionOpenAlreadyEmitted
+	}
+
+	out := cloneSessionControl(in)
+	open := out.Open
+	open.RunNonce = e.runNonce
+	open.RecorderSession = recorderSessionID
+	open.PolicyHash = configHashString(e.configHash.Load())
+	open.SignerKeyEpoch = fmt.Sprintf("%x", e.privKey.Public().(ed25519.PublicKey))
+	open.ChainOpenSeq = e.chainSeq
+
+	if e.hasPriorTail {
+		open.PriorChainHead = e.priorTailHash
+		open.PriorChainSeq = e.priorTailSeq
+		open.GenesisHash = ""
+		return out, chainPrevHash, nil
+	}
+
+	if e.chainSeq == 0 && e.chainPrevHash == GenesisHash {
+		open.GenesisHash = ""
+		genesis := ComputeSessionOpenGenesis(*open)
+		open.GenesisHash = genesis
+		chainPrevHash = genesis
+	}
+	return out, chainPrevHash, nil
+}
+
+func isSessionOpenControl(in *SessionControl) bool {
+	return in != nil && in.Kind == SessionControlOpen && in.Open != nil
+}
+
+func cloneSessionControl(in *SessionControl) *SessionControl {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.Open != nil {
+		open := *in.Open
+		out.Open = &open
+	}
+	if in.Heartbeat != nil {
+		heartbeat := *in.Heartbeat
+		out.Heartbeat = &heartbeat
+	}
+	if in.Close != nil {
+		closeRecord := *in.Close
+		out.Close = &closeRecord
+	}
+	return &out
 }
 
 // recordFailure increments the emit-failure metric for reason when a sink is
@@ -493,6 +615,14 @@ func configHashString(v any) string {
 }
 
 func newRunNonce() (string, error) {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(nonce[:]), nil
+}
+
+func newOpenNonce() (string, error) {
 	var nonce [16]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
 		return "", err
@@ -640,6 +770,9 @@ func (e *Emitter) resumeChain() error {
 			}
 			e.chainSeq = 0
 			e.chainPrevHash = hash
+			e.hasPriorTail = true
+			e.priorTailSeq = lastReceipt.ActionRecord.ChainSeq
+			e.priorTailHash = hash
 			e.pendingTransition = &KeyTransition{
 				PriorSignerKey: lastReceipt.SignerKey,
 				PriorChainSeq:  lastReceipt.ActionRecord.ChainSeq,
@@ -660,6 +793,9 @@ func (e *Emitter) resumeChain() error {
 	e.chainPrevHash = hash
 	e.chainSeq = lastReceipt.ActionRecord.ChainSeq + 1
 	e.chainEnd = lastReceipt.ActionRecord.Timestamp
+	e.hasPriorTail = true
+	e.priorTailSeq = lastReceipt.ActionRecord.ChainSeq
+	e.priorTailHash = hash
 	if firstReceipt != nil {
 		e.chainStart = firstReceipt.ActionRecord.Timestamp
 	}

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -86,6 +87,9 @@ type Emitter struct {
 	chainStart    time.Time // timestamp of first receipt
 	chainEnd      time.Time // timestamp of most recent receipt
 	rootEmitted   bool      // true after EmitTranscriptRoot; prevents duplicate roots
+	closeEmitted  bool      // true after session_close; prevents duplicate closes
+	openNonce     string
+	heartbeatBeat uint64
 
 	// pendingTransition is set by resumeChain when the on-disk tail was
 	// signed by a DIFFERENT (but self-valid) key, meaning a legitimate key
@@ -102,6 +106,7 @@ type Emitter struct {
 	priorTailHash string
 
 	sessionOpenEmitted bool
+	durabilityBlocks   atomic.Uint64
 }
 
 // EmitterConfig holds the configuration for creating an Emitter.
@@ -166,6 +171,16 @@ func (e *Emitter) InitError() error {
 	return e.initErr
 }
 
+// SignerKeyHex returns the Ed25519 public key hex for receipts this emitter
+// signs. It is used by reload code to distinguish a policy-only reload from a
+// signer rotation without replacing a live emitter unnecessarily.
+func (e *Emitter) SignerKeyHex() string {
+	if e == nil || len(e.privKey) != ed25519.PrivateKeySize {
+		return ""
+	}
+	return fmt.Sprintf("%x", e.privKey.Public().(ed25519.PublicKey))
+}
+
 // EmitOpts holds the per-decision context for emitting a receipt.
 type EmitOpts struct {
 	ActionID              string
@@ -227,6 +242,8 @@ var ErrSessionOpenAlreadyEmitted = fmt.Errorf("session_open already emitted for 
 const (
 	sessionControlTransport = "receipt_session"
 	sessionOpenTarget       = "pipelock://session/open"
+	sessionHeartbeatTarget  = "pipelock://session/heartbeat"
+	sessionCloseTarget      = "pipelock://session/close"
 )
 
 // EmitSessionOpen emits the signed session_open control receipt for this
@@ -259,21 +276,100 @@ func (e *Emitter) EmitSessionOpen() error {
 	})
 }
 
+// DurabilityBlocks returns the cumulative number of durable emits whose
+// fsync confirmation failed and therefore blocked egress. Nil emitters report
+// zero.
+func (e *Emitter) DurabilityBlocks() uint64 {
+	if e == nil {
+		return 0
+	}
+	return e.durabilityBlocks.Load()
+}
+
+// EmitHeartbeat emits a best-effort signed heartbeat control receipt. The
+// heartbeat snapshots the current chain head under chainMu via emitWithControl,
+// before the heartbeat receipt itself advances the chain, so ChainHead and
+// ChainSeqHead are a race-free pair.
+func (e *Emitter) EmitHeartbeat() error {
+	if e == nil {
+		return nil
+	}
+	return e.emitWithControl(EmitOpts{
+		ActionID:  NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: sessionControlTransport,
+		Target:    sessionHeartbeatTarget,
+	}, false, func() (*SessionControl, error) {
+		e.heartbeatBeat++
+		return &SessionControl{
+			Kind: SessionControlHeartbeat,
+			Heartbeat: &SessionHeartbeat{
+				RunNonce:         e.runNonce,
+				OpenNonce:        e.openNonce,
+				Beat:             e.heartbeatBeat,
+				ChainHead:        e.chainPrevHash,
+				ChainSeqHead:     e.chainSeq,
+				HeartbeatTime:    time.Now().UTC().Format(time.RFC3339Nano),
+				FsyncErrorsGated: e.recorder.FsyncErrorsGated(),
+				DurabilityBlocks: e.DurabilityBlocks(),
+			},
+		}, nil
+	})
+}
+
+// EmitSessionClose emits a signed session_close control receipt that seals the
+// current pre-close chain tail. The compat transcript_root remains separate and
+// should be emitted after this method so it anchors the chain including close.
+func (e *Emitter) EmitSessionClose(closeReason string) error {
+	if e == nil {
+		return nil
+	}
+	return e.emitWithControl(EmitOpts{
+		ActionID:  NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: sessionControlTransport,
+		Target:    sessionCloseTarget,
+	}, false, func() (*SessionControl, error) {
+		if e.rootEmitted || e.closeEmitted || e.chainSeq == 0 {
+			return nil, nil
+		}
+		finalSeq := uint64(0)
+		if e.chainSeq > 0 {
+			finalSeq = e.chainSeq - 1
+		}
+		return &SessionControl{
+			Kind: SessionControlClose,
+			Close: &SessionClose{
+				RunNonce:         e.runNonce,
+				OpenNonce:        e.openNonce,
+				FinalSeq:         finalSeq,
+				RootHash:         e.chainPrevHash,
+				ReceiptCount:     e.chainSeq,
+				CloseReason:      closeReason,
+				FsyncErrorsGated: e.recorder.FsyncErrorsGated(),
+				DurabilityBlocks: e.DurabilityBlocks(),
+			},
+		}, nil
+	})
+}
+
 // Emit creates, signs, and records an action receipt for a proxy decision.
 // The call is synchronous through the recorder mutex - same as recordDecision.
 // Errors are returned but should be logged, not propagated to callers.
 // Safe to call on a nil Emitter (no-op).
 func (e *Emitter) Emit(opts EmitOpts) error {
-	return e.emit(opts, false)
+	return e.emitWithControl(opts, false, nil)
 }
 
 // EmitDurable creates, signs, records, and fsync-confirms an action receipt for
 // a proxy decision. Safe to call on a nil Emitter (no-op).
 func (e *Emitter) EmitDurable(opts EmitOpts) error {
-	return e.emit(opts, true)
+	return e.emitWithControl(opts, true, nil)
 }
 
-func (e *Emitter) emit(opts EmitOpts, durable bool) error {
+type lockedSessionControlBuilder func() (*SessionControl, error)
+
+func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lockedSessionControlBuilder) error {
 	if e == nil {
 		return nil
 	}
@@ -303,6 +399,16 @@ func (e *Emitter) emit(opts EmitOpts, durable bool) error {
 	if e.rootEmitted {
 		e.recordFailure(FailReasonSealed)
 		return ErrChainSealed
+	}
+	if buildControl != nil {
+		sessionControl, buildErr := buildControl()
+		if buildErr != nil {
+			return buildErr
+		}
+		if sessionControl == nil {
+			return nil
+		}
+		opts.SessionControl = sessionControl
 	}
 	sessionControl, chainPrevHash, err := e.prepareSessionControlLocked(opts.SessionControl)
 	if err != nil {
@@ -417,9 +523,8 @@ func (e *Emitter) emit(opts EmitOpts, durable bool) error {
 	// claim a second segment boundary). Cleared with the rest of the
 	// advance-before-persist state for the same fork-avoidance reason.
 	e.pendingTransition = nil
-	if isSessionOpenControl(sessionControl) {
-		e.sessionOpenEmitted = true
-	}
+	openControl := isSessionOpenControl(sessionControl)
+	closeControl := isSessionCloseControl(sessionControl)
 
 	entry := recorder.Entry{
 		SessionID: recorderSessionID,
@@ -436,12 +541,37 @@ func (e *Emitter) emit(opts EmitOpts, durable bool) error {
 		recordErr = e.recorder.Record(entry)
 	}
 	if recordErr != nil {
+		// Persist failed AFTER the chain state advanced (advance-before-persist,
+		// above). For the single-shot control receipts (open/close) mark the guard
+		// "emitted" only when the receipt bytes actually reached disk — i.e. the
+		// write succeeded but a later checkpoint/rotation/sync-confirm step failed
+		// (receiptHashRecorded reads the evidence back to confirm). Then the record
+		// exists and a retry must NOT duplicate it. If the bytes did NOT reach disk
+		// (the write itself failed), leave the guard unset so a retry can re-emit;
+		// the failed attempt left a detectable gap, and suppressing the retry would
+		// instead let a transcript root seal a MISSING open/close as if present
+		// (fail-open). Confirming on disk keeps this path fail-closed.
+		if openControl && e.receiptHashRecorded(receiptHash) {
+			e.sessionOpenEmitted = true
+			e.openNonce = sessionControl.Open.OpenNonce
+		}
+		if closeControl && e.receiptHashRecorded(receiptHash) {
+			e.closeEmitted = true
+		}
 		if durable && errors.Is(recordErr, recorder.ErrDurability) {
+			e.durabilityBlocks.Add(1)
 			e.recordFailure(FailReasonSync)
 		} else {
 			e.recordFailure(FailReasonRecord)
 		}
 		return fmt.Errorf("recording receipt: %w", recordErr)
+	}
+	if openControl {
+		e.sessionOpenEmitted = true
+		e.openNonce = sessionControl.Open.OpenNonce
+	}
+	if closeControl {
+		e.closeEmitted = true
 	}
 
 	// Notify the observer (if any) AFTER the receipt is durably recorded, so a
@@ -498,6 +628,10 @@ func isSessionOpenControl(in *SessionControl) bool {
 	return in != nil && in.Kind == SessionControlOpen && in.Open != nil
 }
 
+func isSessionCloseControl(in *SessionControl) bool {
+	return in != nil && in.Kind == SessionControlClose && in.Close != nil
+}
+
 func cloneSessionControl(in *SessionControl) *SessionControl {
 	if in == nil {
 		return nil
@@ -516,6 +650,36 @@ func cloneSessionControl(in *SessionControl) *SessionControl {
 		out.Close = &closeRecord
 	}
 	return &out
+}
+
+func (e *Emitter) receiptHashRecorded(wantHash string) bool {
+	if e == nil || e.recorder == nil || wantHash == "" {
+		return false
+	}
+	files, err := recorderFiles(e.recorder.Dir())
+	if err != nil {
+		return false
+	}
+	for _, file := range files {
+		entries, readErr := recorder.ReadEntries(file)
+		if readErr != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.Type != recorderEntryType {
+				continue
+			}
+			raw, rawErr := receiptBytesFromEntry(entry)
+			if rawErr != nil {
+				continue
+			}
+			hash := sha256.Sum256(raw)
+			if hex.EncodeToString(hash[:]) == wantHash {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // recordFailure increments the emit-failure metric for reason when a sink is
@@ -827,15 +991,26 @@ func (e *Emitter) resumeChain() error {
 }
 
 func receiptFromEntry(entry recorder.Entry) (*Receipt, error) {
-	detailJSON, err := json.Marshal(entry.Detail)
+	detailJSON, err := receiptBytesFromEntry(entry)
 	if err != nil {
-		return nil, fmt.Errorf("marshal existing receipt detail at seq %d: %w", entry.Sequence, err)
+		return nil, err
 	}
 	rcpt, err := Unmarshal(detailJSON)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal existing receipt at seq %d: %w", entry.Sequence, err)
 	}
 	return &rcpt, nil
+}
+
+func receiptBytesFromEntry(entry recorder.Entry) ([]byte, error) {
+	if len(entry.RawDetail) > 0 {
+		return entry.RawDetail, nil
+	}
+	detailJSON, err := json.Marshal(entry.Detail)
+	if err != nil {
+		return nil, fmt.Errorf("marshal existing receipt detail at seq %d: %w", entry.Sequence, err)
+	}
+	return detailJSON, nil
 }
 
 func recorderFiles(dir string) ([]string, error) {

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -78,6 +78,8 @@ type Emitter struct {
 	metrics    MetricsSink
 	onReceipt  func(rcpt *Receipt)
 	initErr    error
+	healthMu   sync.RWMutex
+	healthErr  error
 	runNonce   string
 
 	// Chain state - mutex-protected, updated on each Emit.
@@ -169,6 +171,30 @@ func (e *Emitter) InitError() error {
 		return nil
 	}
 	return e.initErr
+}
+
+// MarkUnhealthy bricks future emissions after a runtime receipt failure that
+// makes the chain untrustworthy for required-receipt policy. Safe on nil.
+func (e *Emitter) MarkUnhealthy(err error) {
+	if e == nil || err == nil {
+		return
+	}
+	e.healthMu.Lock()
+	defer e.healthMu.Unlock()
+	if e.healthErr == nil {
+		e.healthErr = err
+	}
+}
+
+// HealthError returns the first runtime health failure recorded by
+// MarkUnhealthy. Safe on nil.
+func (e *Emitter) HealthError() error {
+	if e == nil {
+		return nil
+	}
+	e.healthMu.RLock()
+	defer e.healthMu.RUnlock()
+	return e.healthErr
 }
 
 // SignerKeyHex returns the Ed25519 public key hex for receipts this emitter
@@ -376,6 +402,10 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 	if e.initErr != nil {
 		e.recordFailure(FailReasonChainInit)
 		return fmt.Errorf("resume receipt chain: %w", e.initErr)
+	}
+	if healthErr := e.HealthError(); healthErr != nil {
+		e.recordFailure(FailReasonUnavailable)
+		return fmt.Errorf("receipt emitter unhealthy: %w", healthErr)
 	}
 
 	actionType := e.classifyAction(opts)

--- a/internal/receipt/emitter_durable_test.go
+++ b/internal/receipt/emitter_durable_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+func TestEmitter_EmitDurable_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+
+	e := NewEmitter(EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: testConfigHash,
+		Principal:  testPrincipal,
+		Actor:      testActor,
+	})
+	if e == nil {
+		t.Fatal("NewEmitter() returned nil")
+	}
+	if err := e.EmitDurable(EmitOpts{
+		ActionID:  NewActionID(),
+		Target:    testTarget,
+		Verdict:   config.ActionAllow,
+		Transport: testTransport,
+		Method:    http.MethodGet,
+	}); err != nil {
+		t.Fatalf("EmitDurable(): %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close(): %v", err)
+	}
+
+	got := readReceiptFromDir(t, dir, pub)
+	if got.ActionRecord.ChainSeq != 0 {
+		t.Fatalf("chain_seq = %d, want 0", got.ActionRecord.ChainSeq)
+	}
+}
+
+func TestEmitter_EmitDurable_SyncFailureLeavesReceiptGapNotFork(t *testing.T) {
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	defer func() { _ = rec.Close() }()
+
+	syncErr := errors.New("injected sync failure")
+	var calls int
+	rec.SetSyncForTest(func(*os.File) error {
+		calls++
+		if calls == 1 {
+			return syncErr
+		}
+		return nil
+	})
+
+	metrics := &stubMetrics{}
+	e := NewEmitter(EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: testConfigHash,
+		Principal:  testPrincipal,
+		Actor:      testActor,
+		Metrics:    metrics,
+	})
+	if e == nil {
+		t.Fatal("NewEmitter() returned nil")
+	}
+
+	err := e.EmitDurable(EmitOpts{
+		ActionID:  NewActionID(),
+		Target:    testTarget,
+		Verdict:   config.ActionAllow,
+		Transport: testTransport,
+		Method:    http.MethodGet,
+	})
+	if !errors.Is(err, recorder.ErrDurability) {
+		t.Fatalf("first EmitDurable error = %v, want ErrDurability", err)
+	}
+	if got := metrics.snapshot(); len(got) != 1 || got[0] != FailReasonSync {
+		t.Fatalf("emit failure reasons = %v, want [%q]", got, FailReasonSync)
+	}
+
+	if err := e.EmitDurable(EmitOpts{
+		ActionID:  NewActionID(),
+		Target:    testTarget,
+		Verdict:   config.ActionAllow,
+		Transport: testTransport,
+		Method:    http.MethodGet,
+	}); err != nil {
+		t.Fatalf("second EmitDurable: %v", err)
+	}
+
+	receipts := allReceiptsRaw(t, dir)
+	if len(receipts) < 2 {
+		t.Fatalf("receipts = %d, want at least 2", len(receipts))
+	}
+	if receipts[0].ActionRecord.ChainSeq != 0 || receipts[1].ActionRecord.ChainSeq != 1 {
+		t.Fatalf("receipt chain seqs = %d,%d; rollback would have duplicated seq 0",
+			receipts[0].ActionRecord.ChainSeq, receipts[1].ActionRecord.ChainSeq)
+	}
+	if receipts[1].ActionRecord.ChainPrevHash == GenesisHash {
+		t.Fatal("second receipt linked to genesis; durable failure rolled back receipt state")
+	}
+}

--- a/internal/receipt/emitter_test.go
+++ b/internal/receipt/emitter_test.go
@@ -41,6 +41,13 @@ func newTestRecorder(t *testing.T, dir string, priv ed25519.PrivateKey) *recorde
 	return rec
 }
 
+func emitSessionOpenForTest(t *testing.T, e *Emitter) {
+	t.Helper()
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+}
+
 func TestNewEmitter_NilRecorder(t *testing.T) {
 	t.Parallel()
 
@@ -198,6 +205,7 @@ func TestEmitter_RunNoncePerProcessRun(t *testing.T) {
 	if eA == nil {
 		t.Fatal("NewEmitter A returned nil")
 	}
+	emitSessionOpenForTest(t, eA)
 
 	for i := 0; i < 2; i++ {
 		if err := eA.Emit(EmitOpts{
@@ -215,15 +223,19 @@ func TestEmitter_RunNoncePerProcessRun(t *testing.T) {
 	}
 
 	receiptsA := readAllReceiptsFromDir(t, dirA, pubA)
-	if len(receiptsA) != 2 {
-		t.Fatalf("receipts A = %d, want 2", len(receiptsA))
+	if len(receiptsA) != 3 {
+		t.Fatalf("receipts A = %d, want 3", len(receiptsA))
 	}
-	if receiptsA[0].ActionRecord.RunNonce == "" {
-		t.Fatal("first run_nonce is empty")
+	if receiptsA[0].ActionRecord.SessionControl == nil ||
+		receiptsA[0].ActionRecord.SessionControl.Kind != SessionControlOpen {
+		t.Fatalf("first receipt A session_control = %+v, want session_open", receiptsA[0].ActionRecord.SessionControl)
 	}
-	if receiptsA[0].ActionRecord.RunNonce != receiptsA[1].ActionRecord.RunNonce {
+	if receiptsA[1].ActionRecord.RunNonce == "" {
+		t.Fatal("first action run_nonce is empty")
+	}
+	if receiptsA[1].ActionRecord.RunNonce != receiptsA[2].ActionRecord.RunNonce {
 		t.Fatalf("same emitter produced different run_nonce values: %q != %q",
-			receiptsA[0].ActionRecord.RunNonce, receiptsA[1].ActionRecord.RunNonce)
+			receiptsA[1].ActionRecord.RunNonce, receiptsA[2].ActionRecord.RunNonce)
 	}
 
 	dirB := t.TempDir()
@@ -239,6 +251,7 @@ func TestEmitter_RunNoncePerProcessRun(t *testing.T) {
 	if eB == nil {
 		t.Fatal("NewEmitter B returned nil")
 	}
+	emitSessionOpenForTest(t, eB)
 	if err := eB.Emit(EmitOpts{
 		ActionID:  NewActionID(),
 		Target:    testTarget,
@@ -253,11 +266,117 @@ func TestEmitter_RunNoncePerProcessRun(t *testing.T) {
 	}
 
 	receiptsB := readAllReceiptsFromDir(t, dirB, pubB)
-	if len(receiptsB) != 1 {
-		t.Fatalf("receipts B = %d, want 1", len(receiptsB))
+	if len(receiptsB) != 2 {
+		t.Fatalf("receipts B = %d, want 2", len(receiptsB))
 	}
-	if receiptsA[0].ActionRecord.RunNonce == receiptsB[0].ActionRecord.RunNonce {
-		t.Fatalf("different emitters reused run_nonce %q", receiptsA[0].ActionRecord.RunNonce)
+	if receiptsB[0].ActionRecord.SessionControl == nil ||
+		receiptsB[0].ActionRecord.SessionControl.Kind != SessionControlOpen {
+		t.Fatalf("first receipt B session_control = %+v, want session_open", receiptsB[0].ActionRecord.SessionControl)
+	}
+	if receiptsA[1].ActionRecord.RunNonce == receiptsB[1].ActionRecord.RunNonce {
+		t.Fatalf("different emitters reused run_nonce %q", receiptsA[1].ActionRecord.RunNonce)
+	}
+}
+
+func TestEmitter_EmitSessionOpenFirstChainBoundGenesis(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: testConfigHash,
+		Principal:  testPrincipal,
+		Actor:      testActor,
+	})
+	if e == nil {
+		t.Fatal("NewEmitter returned nil")
+	}
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	receipts := readAllReceiptsFromDir(t, dir, pub)
+	if len(receipts) != 1 {
+		t.Fatalf("receipt count = %d, want 1", len(receipts))
+	}
+	ar := receipts[0].ActionRecord
+	open := ar.SessionControl.Open
+	if ar.SessionControl == nil || ar.SessionControl.Kind != SessionControlOpen || open == nil {
+		t.Fatalf("first receipt is not session_open: %+v", ar.SessionControl)
+	}
+	if ar.ChainSeq != 0 {
+		t.Fatalf("chain_seq = %d, want 0", ar.ChainSeq)
+	}
+	if ar.ChainPrevHash != ComputeSessionOpenGenesis(*open) {
+		t.Fatalf("chain_prev_hash = %q, want computed genesis %q", ar.ChainPrevHash, ComputeSessionOpenGenesis(*open))
+	}
+	if open.GenesisHash != ar.ChainPrevHash {
+		t.Fatalf("open genesis_hash = %q, want %q", open.GenesisHash, ar.ChainPrevHash)
+	}
+	if res := VerifyChain(receipts, hex.EncodeToString(pub)); !res.Valid {
+		t.Fatalf("VerifyChain: %s", res.Error)
+	}
+}
+
+func TestEmitter_EmitSessionOpenRestartLinksPriorTail(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec1 := newTestRecorder(t, dir, priv)
+	e1 := NewEmitter(EmitterConfig{Recorder: rec1, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+	if err := e1.EmitSessionOpen(); err != nil {
+		t.Fatalf("run1 open: %v", err)
+	}
+	if err := e1.Emit(EmitOpts{
+		ActionID:  NewActionID(),
+		Target:    testTarget,
+		Verdict:   config.ActionAllow,
+		Transport: testTransport,
+		Method:    http.MethodGet,
+	}); err != nil {
+		t.Fatalf("run1 Emit: %v", err)
+	}
+	if err := rec1.Close(); err != nil {
+		t.Fatalf("Close run1: %v", err)
+	}
+
+	before := readAllReceiptsFromDir(t, dir, pub)
+	priorTail := before[len(before)-1]
+	priorHash := mustHash(t, priorTail)
+
+	rec2 := newTestRecorder(t, dir, priv)
+	e2 := NewEmitter(EmitterConfig{Recorder: rec2, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+	if err := e2.EmitSessionOpen(); err != nil {
+		t.Fatalf("run2 open: %v", err)
+	}
+	if err := rec2.Close(); err != nil {
+		t.Fatalf("Close run2: %v", err)
+	}
+
+	receipts := readAllReceiptsFromDir(t, dir, pub)
+	restart := receipts[len(receipts)-1].ActionRecord
+	open := restart.SessionControl.Open
+	if restart.ChainPrevHash != priorHash {
+		t.Fatalf("restart chain_prev_hash = %q, want prior tail %q", restart.ChainPrevHash, priorHash)
+	}
+	if open.PriorChainHead != priorHash {
+		t.Fatalf("prior_chain_head = %q, want %q", open.PriorChainHead, priorHash)
+	}
+	if open.PriorChainSeq != priorTail.ActionRecord.ChainSeq {
+		t.Fatalf("prior_chain_seq = %d, want %d", open.PriorChainSeq, priorTail.ActionRecord.ChainSeq)
+	}
+	if open.GenesisHash != "" {
+		t.Fatalf("restart genesis_hash = %q, want empty", open.GenesisHash)
+	}
+	if res := VerifyChain(receipts, hex.EncodeToString(pub)); !res.Valid {
+		t.Fatalf("VerifyChain: %s", res.Error)
 	}
 }
 

--- a/internal/receipt/session_control.go
+++ b/internal/receipt/session_control.go
@@ -1,0 +1,152 @@
+package receipt
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+)
+
+// SessionControlKind names the three within-run session-lifecycle control
+// records. They are signed v1 receipts carried inline on an ActionRecord via
+// the SessionControl field, so a verifier can prove offline when a covered
+// process window opened, that it kept beating, and how it closed.
+type SessionControlKind string
+
+const (
+	// SessionControlOpen marks the first receipt of a process run. It replaces
+	// the literal "genesis" sentinel on a brand-new chain and, on a restart,
+	// binds the new run_nonce window to the prior chain tail.
+	SessionControlOpen SessionControlKind = "session_open"
+	// SessionControlHeartbeat is a periodic signed liveness+durability snapshot
+	// so a crash mid-stream leaves a signed floor, not silence.
+	SessionControlHeartbeat SessionControlKind = "heartbeat"
+	// SessionControlClose is the signed end-of-run record: final seq, root hash,
+	// receipt count, and cumulative durability counters.
+	SessionControlClose SessionControlKind = "session_close"
+)
+
+// genesisSessionOpenPrefix tags a chain_prev_hash whose value is a bound
+// session-open genesis rather than the legacy literal "genesis" sentinel.
+// A verifier that sees this prefix MUST recompute ComputeSessionOpenGenesis
+// over the receipt's signed SessionControl.Open and require equality.
+const genesisSessionOpenPrefix = "g1:"
+
+// sessionOpenGenesisLabel domain-separates the session-open genesis preimage
+// from every other hash in the system. Changing this string is a breaking
+// verifier change and MUST bump the label version suffix.
+const sessionOpenGenesisLabel = "pipelock.receipt.session_open.v1"
+
+// SessionControl is the inline session-lifecycle payload on an ActionRecord.
+// Exactly one of Open/Heartbeat/Close is set, matching Kind.
+type SessionControl struct {
+	Kind SessionControlKind `json:"kind"`
+
+	Open      *SessionOpen      `json:"open,omitempty"`
+	Heartbeat *SessionHeartbeat `json:"heartbeat,omitempty"`
+	Close     *SessionClose     `json:"close,omitempty"`
+}
+
+// SessionOpen is the signed opening record for one process run. Its digest,
+// via ComputeSessionOpenGenesis, is the chain_prev_hash of the first receipt
+// on a brand-new chain (prefixed with genesisSessionOpenPrefix). On a restart
+// that resumes an existing chain, PriorChainHead/PriorChainSeq carry the
+// observed tail and the open is an ordinary continuation, not chain genesis.
+type SessionOpen struct {
+	RunNonce         string `json:"run_nonce"`
+	OpenNonce        string `json:"open_nonce"`
+	RecorderSession  string `json:"recorder_session"`
+	PolicyHash       string `json:"policy_hash"`
+	SignerKeyEpoch   string `json:"signer_key_epoch"`
+	HeartbeatSeconds int    `json:"heartbeat_seconds"`
+
+	ChainOpenSeq   uint64 `json:"chain_open_seq"`
+	PriorChainHead string `json:"prior_chain_head,omitempty"`
+	PriorChainSeq  uint64 `json:"prior_chain_seq,omitempty"`
+
+	// GenesisHash is the value the emitter computed for the first-chain case;
+	// it MUST equal ComputeSessionOpenGenesis(open) and the receipt's
+	// ChainPrevHash. Empty on restart/continuation opens.
+	GenesisHash       string `json:"genesis_hash,omitempty"`
+	GenesisAnchorHead string `json:"genesis_anchor_head,omitempty"`
+	GenesisAnchorLog  string `json:"genesis_anchor_log,omitempty"`
+
+	// Posture/containment binding. Present only when a signed posture capsule
+	// binds this run to a contained UID; the containment grade gate consumes it.
+	PostureCapsuleSHA256 string `json:"posture_capsule_sha256,omitempty"`
+	PostureSignerKeyID   string `json:"posture_signer_key_id,omitempty"`
+	ContainmentNonce     string `json:"containment_nonce,omitempty"`
+	ContainedUID         string `json:"contained_uid,omitempty"`
+}
+
+// SessionHeartbeat is a periodic signed cumulative snapshot. The durability
+// counters are the offline-verifiable interface the evidence-health scorecard
+// consumes to prove the fsync-gated invariant held.
+type SessionHeartbeat struct {
+	RunNonce      string `json:"run_nonce"`
+	OpenNonce     string `json:"open_nonce"`
+	Beat          uint64 `json:"beat"`
+	ChainHead     string `json:"chain_head"`
+	ChainSeqHead  uint64 `json:"chain_seq_head"`
+	HeartbeatTime string `json:"heartbeat_time"`
+
+	FsyncErrorsGated uint64 `json:"fsync_errors_gated"`
+	DurabilityBlocks uint64 `json:"durability_blocks"`
+}
+
+// SessionClose is the signed end-of-run record. It promotes the existing
+// transcript-root fields to a signed receipt and carries the same cumulative
+// durability counters as the heartbeat.
+type SessionClose struct {
+	RunNonce     string `json:"run_nonce"`
+	OpenNonce    string `json:"open_nonce"`
+	FinalSeq     uint64 `json:"final_seq"`
+	RootHash     string `json:"root_hash"`
+	ReceiptCount uint64 `json:"receipt_count"`
+	CloseReason  string `json:"close_reason"`
+
+	FsyncErrorsGated uint64 `json:"fsync_errors_gated"`
+	DurabilityBlocks uint64 `json:"durability_blocks"`
+}
+
+// ComputeSessionOpenGenesis returns the bound genesis value for a first-chain
+// session_open: genesisSessionOpenPrefix + hex(sha256(length-framed preimage)).
+//
+// The preimage is LENGTH-FRAMED (each field prefixed with its 8-byte big-endian
+// length) so no two distinct field sets can collide by concatenation — the
+// classic ("a","bc") vs ("ab","c") ambiguity. Every field is always framed,
+// including empty optionals (framed as length 0), so the value is fully
+// deterministic and a verifier recomputes it offline. Field order and the
+// domain label are frozen; any change is a breaking verifier change.
+func ComputeSessionOpenGenesis(o SessionOpen) string {
+	h := sha256.New()
+	frame := func(b []byte) {
+		var l [8]byte
+		binary.BigEndian.PutUint64(l[:], uint64(len(b)))
+		_, _ = h.Write(l[:])
+		_, _ = h.Write(b)
+	}
+	frame([]byte(sessionOpenGenesisLabel))
+	frame([]byte(o.RunNonce))
+	frame([]byte(o.OpenNonce))
+	frame([]byte(o.RecorderSession))
+	frame([]byte(o.PolicyHash))
+	frame([]byte(o.SignerKeyEpoch))
+
+	// A heartbeat interval is never negative; clamp defensively so the
+	// conversion is provably in range and the preimage stays deterministic.
+	hbSecs := o.HeartbeatSeconds
+	if hbSecs < 0 {
+		hbSecs = 0
+	}
+	var hb [8]byte
+	binary.BigEndian.PutUint64(hb[:], uint64(hbSecs))
+	frame(hb[:])
+
+	frame([]byte(o.GenesisAnchorHead))
+	frame([]byte(o.GenesisAnchorLog))
+	frame([]byte(o.PostureCapsuleSHA256))
+	frame([]byte(o.ContainmentNonce))
+	frame([]byte(o.ContainedUID))
+
+	return genesisSessionOpenPrefix + hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/receipt/session_control_emit_test.go
+++ b/internal/receipt/session_control_emit_test.go
@@ -1,0 +1,416 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/nacl/box"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+func TestEmitter_EmitHeartbeatSignedSnapshotCountersAndNonce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	syncErr := errors.New("injected sync failure")
+	rec.SetSyncForTest(func(*os.File) error { return syncErr })
+	err := e.EmitDurable(EmitOpts{
+		ActionID:  NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: testTransport,
+		Method:    http.MethodPost,
+		Target:    "https://api.vendor.example/durable",
+	})
+	if !errors.Is(err, recorder.ErrDurability) {
+		t.Fatalf("EmitDurable error = %v, want ErrDurability", err)
+	}
+	rec.SetSyncForTest(nil)
+
+	receiptsBeforeHeartbeat := readAllReceiptsFromDir(t, dir, pub)
+	preHeartbeatTail := mustHash(t, receiptsBeforeHeartbeat[len(receiptsBeforeHeartbeat)-1])
+	preHeartbeatSeqHead := uint64(len(receiptsBeforeHeartbeat))
+
+	if err := e.EmitHeartbeat(); err != nil {
+		t.Fatalf("EmitHeartbeat #1: %v", err)
+	}
+	if err := e.EmitHeartbeat(); err != nil {
+		t.Fatalf("EmitHeartbeat #2: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	receipts := readAllReceiptsFromDir(t, dir, pub)
+	if res := VerifyChain(receipts, hex.EncodeToString(pub)); !res.Valid {
+		t.Fatalf("VerifyChain: %s", res.Error)
+	}
+	open := receipts[0].ActionRecord.SessionControl.Open
+	hb1 := receipts[len(receipts)-2].ActionRecord.SessionControl.Heartbeat
+	hb2 := receipts[len(receipts)-1].ActionRecord.SessionControl.Heartbeat
+	if hb1 == nil || hb2 == nil {
+		t.Fatalf("tail receipts are not heartbeats: %#v %#v",
+			receipts[len(receipts)-2].ActionRecord.SessionControl,
+			receipts[len(receipts)-1].ActionRecord.SessionControl)
+	}
+	if hb1.Beat != 1 || hb2.Beat != 2 {
+		t.Fatalf("heartbeat beats = %d,%d; want 1,2", hb1.Beat, hb2.Beat)
+	}
+	if hb1.ChainHead != preHeartbeatTail || hb1.ChainSeqHead != preHeartbeatSeqHead {
+		t.Fatalf("heartbeat snapshot = (%s,%d), want (%s,%d)",
+			hb1.ChainHead, hb1.ChainSeqHead, preHeartbeatTail, preHeartbeatSeqHead)
+	}
+	if hb1.FsyncErrorsGated != 1 || hb1.DurabilityBlocks != 1 {
+		t.Fatalf("heartbeat counters fsync=%d blocks=%d, want 1/1", hb1.FsyncErrorsGated, hb1.DurabilityBlocks)
+	}
+	if hb1.OpenNonce != open.OpenNonce || hb2.OpenNonce != open.OpenNonce {
+		t.Fatalf("heartbeat open_nonce did not bind to session_open nonce")
+	}
+}
+
+func TestEmitter_EmitSessionCloseFinalReceiptAndRoot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := e.Emit(EmitOpts{
+		ActionID:  NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: testTransport,
+		Method:    http.MethodGet,
+		Target:    "https://api.vendor.example/close",
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	preCloseReceipts := readAllReceiptsFromDir(t, dir, pub)
+	preCloseTail := mustHash(t, preCloseReceipts[len(preCloseReceipts)-1])
+	if err := e.EmitSessionClose("graceful_shutdown"); err != nil {
+		t.Fatalf("EmitSessionClose: %v", err)
+	}
+	if err := e.EmitSessionClose("duplicate"); err != nil {
+		t.Fatalf("duplicate EmitSessionClose should no-op before root: %v", err)
+	}
+	if err := e.EmitTranscriptRoot("session"); err != nil {
+		t.Fatalf("EmitTranscriptRoot: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	receipts := readAllReceiptsFromDir(t, dir, pub)
+	if len(receipts) != len(preCloseReceipts)+1 {
+		t.Fatalf("receipt count after duplicate close = %d, want %d", len(receipts), len(preCloseReceipts)+1)
+	}
+	if res := VerifyChain(receipts, hex.EncodeToString(pub)); !res.Valid {
+		t.Fatalf("VerifyChain: %s", res.Error)
+	}
+	closeRecord := receipts[len(receipts)-1].ActionRecord.SessionControl.Close
+	if closeRecord == nil {
+		t.Fatalf("last receipt is not session_close: %#v", receipts[len(receipts)-1].ActionRecord.SessionControl)
+	}
+	if closeRecord.FinalSeq != 1 || closeRecord.ReceiptCount != 2 || closeRecord.RootHash != preCloseTail {
+		t.Fatalf("close sealed final_seq=%d count=%d root=%s; want 1/2/%s",
+			closeRecord.FinalSeq, closeRecord.ReceiptCount, closeRecord.RootHash, preCloseTail)
+	}
+	if closeRecord.OpenNonce != receipts[0].ActionRecord.SessionControl.Open.OpenNonce {
+		t.Fatal("close open_nonce did not bind to session_open nonce")
+	}
+
+	root := readTranscriptRootFromDir(t, dir)
+	closeHash := mustHash(t, receipts[len(receipts)-1])
+	if root.ReceiptCount != uint64(len(receipts)) || root.RootHash != closeHash {
+		t.Fatalf("transcript root count/hash = %d/%s, want %d/%s",
+			root.ReceiptCount, root.RootHash, len(receipts), closeHash)
+	}
+}
+
+func TestEmitter_EmitSessionClosePersistFailureCanRetryToDetectableGap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	recipientPub, _, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("box.GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+		RawEscrow:          true,
+		EscrowPublicKey:    hex.EncodeToString(recipientPub[:]),
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := e.Emit(EmitOpts{
+		ActionID:  NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: testTransport,
+		Method:    http.MethodGet,
+		Target:    "https://api.vendor.example/pre-close",
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	closeEscrowPath := filepath.Join(dir, "evidence-proxy-2.raw.enc")
+	if err := os.Mkdir(closeEscrowPath, 0o750); err != nil {
+		t.Fatalf("mkdir close escrow collision: %v", err)
+	}
+	closeErr := e.EmitSessionClose("probe")
+	if err := os.Remove(closeEscrowPath); err != nil {
+		t.Fatalf("remove close escrow collision: %v", err)
+	}
+	if closeErr == nil {
+		t.Fatal("EmitSessionClose unexpectedly succeeded")
+	}
+
+	if err := e.EmitSessionClose("retry"); err != nil {
+		t.Fatalf("retry EmitSessionClose: %v", err)
+	}
+	if err := e.EmitTranscriptRoot("session"); err != nil {
+		t.Fatalf("EmitTranscriptRoot: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	receipts := readAllReceiptsFromDir(t, dir, pub)
+	closeCount := 0
+	for _, r := range receipts {
+		if isSessionCloseControl(r.ActionRecord.SessionControl) {
+			closeCount++
+		}
+	}
+	if closeCount != 1 {
+		t.Fatalf("session_close receipts = %d, want 1 retry close", closeCount)
+	}
+	root := readTranscriptRootFromDir(t, dir)
+	if root.ReceiptCount != 4 {
+		t.Fatalf("root receipt_count = %d, want 4 including the failed close seq gap", root.ReceiptCount)
+	}
+	res := VerifyChain(receipts, hex.EncodeToString(pub))
+	if res.Valid {
+		t.Fatal("VerifyChain unexpectedly accepted chain with missing failed close seq")
+	}
+	if !strings.Contains(res.Error, "seq gap") {
+		t.Fatalf("VerifyChain error = %q, want seq gap", res.Error)
+	}
+}
+
+func TestEmitter_EmitSessionOpenPersistFailureCanRetryToDetectableGap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	recipientPub, _, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("box.GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+		RawEscrow:          true,
+		EscrowPublicKey:    hex.EncodeToString(recipientPub[:]),
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+
+	openEscrowPath := filepath.Join(dir, "evidence-proxy-0.raw.enc")
+	if err := os.Mkdir(openEscrowPath, 0o750); err != nil {
+		t.Fatalf("mkdir open escrow collision: %v", err)
+	}
+	openErr := e.EmitSessionOpen()
+	if err := os.Remove(openEscrowPath); err != nil {
+		t.Fatalf("remove open escrow collision: %v", err)
+	}
+	if openErr == nil {
+		t.Fatal("EmitSessionOpen unexpectedly succeeded")
+	}
+
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("retry EmitSessionOpen: %v", err)
+	}
+	if err := e.EmitHeartbeat(); err != nil {
+		t.Fatalf("EmitHeartbeat: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	receipts := readAllReceiptsFromDir(t, dir, pub)
+	openCount := 0
+	for _, r := range receipts {
+		if isSessionOpenControl(r.ActionRecord.SessionControl) {
+			openCount++
+		}
+	}
+	if openCount != 1 {
+		t.Fatalf("session_open receipts = %d, want 1 retry open", openCount)
+	}
+	res := VerifyChain(receipts, hex.EncodeToString(pub))
+	if res.Valid {
+		t.Fatal("VerifyChain unexpectedly accepted chain with missing failed open seq")
+	}
+	if !strings.Contains(res.Error, "genesis receipt chain_prev_hash") {
+		t.Fatalf("VerifyChain error = %q, want genesis chain_prev_hash gap", res.Error)
+	}
+}
+
+func TestEmitter_ReceiptHashRecordedUsesRawStoredReceiptBytes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := e.EmitSessionClose("raw_confirm"); err != nil {
+		t.Fatalf("EmitSessionClose: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	entries, err := recorder.ReadEntries(filepath.Join(dir, "evidence-proxy-0.jsonl"))
+	if err != nil {
+		t.Fatalf("ReadEntries: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Type != recorderEntryType {
+			continue
+		}
+		rcpt, receiptErr := receiptFromEntry(entry)
+		if receiptErr != nil {
+			t.Fatalf("receiptFromEntry: %v", receiptErr)
+		}
+		if !isSessionCloseControl(rcpt.ActionRecord.SessionControl) {
+			continue
+		}
+		rawHash := sha256.Sum256(entry.RawDetail)
+		rawHashHex := hex.EncodeToString(rawHash[:])
+		if !e.receiptHashRecorded(rawHashHex) {
+			t.Fatalf("receiptHashRecorded(%s) = false for stored close receipt", rawHashHex)
+		}
+		structHash, hashErr := ReceiptHash(*rcpt)
+		if hashErr != nil {
+			t.Fatalf("ReceiptHash: %v", hashErr)
+		}
+		if structHash != rawHashHex {
+			t.Fatalf("close receipt raw hash = %s, structured hash = %s", rawHashHex, structHash)
+		}
+		if err := VerifyWithKey(*rcpt, hex.EncodeToString(pub)); err != nil {
+			t.Fatalf("VerifyWithKey: %v", err)
+		}
+		return
+	}
+	t.Fatal("no session_close receipt found")
+}
+
+func TestEmitter_EmitSessionCloseEmptyChainNoOp(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash})
+	if err := e.EmitSessionClose("empty"); err != nil {
+		t.Fatalf("EmitSessionClose empty: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if receipts := readAllReceiptsFromDir(t, dir, pub); len(receipts) != 0 {
+		t.Fatalf("empty close emitted %d receipts, want 0", len(receipts))
+	}
+}
+
+func TestEmitter_HeartbeatAndCloseWithoutSessionOpenUseEmptyOpenNonce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash})
+	if err := e.EmitHeartbeat(); err != nil {
+		t.Fatalf("EmitHeartbeat: %v", err)
+	}
+	if err := e.EmitSessionClose("no_open"); err != nil {
+		t.Fatalf("EmitSessionClose: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	receipts := readAllReceiptsFromDir(t, dir, pub)
+	if len(receipts) != 2 {
+		t.Fatalf("receipts = %d, want heartbeat+close", len(receipts))
+	}
+	if receipts[0].ActionRecord.SessionControl.Heartbeat.OpenNonce != "" {
+		t.Fatalf("heartbeat open_nonce = %q, want empty", receipts[0].ActionRecord.SessionControl.Heartbeat.OpenNonce)
+	}
+	if receipts[1].ActionRecord.SessionControl.Close.OpenNonce != "" {
+		t.Fatalf("close open_nonce = %q, want empty", receipts[1].ActionRecord.SessionControl.Close.OpenNonce)
+	}
+	for _, r := range receipts {
+		if err := VerifyWithKey(r, hex.EncodeToString(pub)); err != nil {
+			t.Fatalf("VerifyWithKey without open: %v", err)
+		}
+	}
+}
+
+func readTranscriptRootFromDir(t *testing.T, dir string) TranscriptRoot {
+	t.Helper()
+	entries := readAllEntriesFromDir(t, dir)
+	for _, entry := range entries {
+		if entry.Type != transcriptRootEntryType {
+			continue
+		}
+		detailJSON, err := json.Marshal(entry.Detail)
+		if err != nil {
+			t.Fatalf("json.Marshal(root): %v", err)
+		}
+		var root TranscriptRoot
+		if err := json.Unmarshal(detailJSON, &root); err != nil {
+			t.Fatalf("json.Unmarshal(root): %v", err)
+		}
+		return root
+	}
+	t.Fatal("transcript root not found")
+	return TranscriptRoot{}
+}

--- a/internal/receipt/session_control_test.go
+++ b/internal/receipt/session_control_test.go
@@ -1,0 +1,140 @@
+package receipt
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// goldenSessionOpenGenesis locks the length-framed session_open genesis
+// preimage. If this value changes, the on-wire genesis format changed and
+// every deployed verifier must be updated — that is a breaking change, not a
+// refactor. Do not "fix" this constant to match new output without treating it
+// as a wire-format break.
+const goldenSessionOpenGenesis = "g1:4e3d35d36683d6d5c65e427b447ada0d2e9098befff7caad954972bdadd405ec"
+
+func fixedSessionOpen() SessionOpen {
+	return SessionOpen{
+		RunNonce:             "run-nonce-aaaa",
+		OpenNonce:            "open-nonce-bbbb",
+		RecorderSession:      "rec-sess-cccc",
+		PolicyHash:           "policy-hash-dddd",
+		SignerKeyEpoch:       "epoch-3",
+		HeartbeatSeconds:     60,
+		ChainOpenSeq:         0,
+		GenesisAnchorHead:    "anchor-head-eeee",
+		GenesisAnchorLog:     "anchor-log-ffff",
+		PostureCapsuleSHA256: "capsule-sha-0000",
+		ContainmentNonce:     "contain-nonce-1111",
+		ContainedUID:         "966",
+	}
+}
+
+func TestComputeSessionOpenGenesis_Golden(t *testing.T) {
+	got := ComputeSessionOpenGenesis(fixedSessionOpen())
+
+	if !strings.HasPrefix(got, genesisSessionOpenPrefix) {
+		t.Fatalf("genesis missing %q prefix: %q", genesisSessionOpenPrefix, got)
+	}
+	// prefix + 64 hex chars.
+	if len(got) != len(genesisSessionOpenPrefix)+64 {
+		t.Fatalf("genesis wrong length: got %d, want %d (%q)",
+			len(got), len(genesisSessionOpenPrefix)+64, got)
+	}
+	if got != goldenSessionOpenGenesis {
+		t.Fatalf("session_open genesis drifted from golden.\n got=%q\nwant=%q\n"+
+			"If this is an intentional wire-format change, update the golden AND "+
+			"every deployed verifier.", got, goldenSessionOpenGenesis)
+	}
+}
+
+func TestComputeSessionOpenGenesis_Deterministic(t *testing.T) {
+	o := fixedSessionOpen()
+	if a, b := ComputeSessionOpenGenesis(o), ComputeSessionOpenGenesis(o); a != b {
+		t.Fatalf("genesis not deterministic: %q != %q", a, b)
+	}
+}
+
+func TestComputeSessionOpenGenesis_FieldSensitivity(t *testing.T) {
+	base := ComputeSessionOpenGenesis(fixedSessionOpen())
+
+	mutators := map[string]func(*SessionOpen){
+		"run_nonce":         func(o *SessionOpen) { o.RunNonce += "x" },
+		"open_nonce":        func(o *SessionOpen) { o.OpenNonce += "x" },
+		"recorder_session":  func(o *SessionOpen) { o.RecorderSession += "x" },
+		"policy_hash":       func(o *SessionOpen) { o.PolicyHash += "x" },
+		"signer_key_epoch":  func(o *SessionOpen) { o.SignerKeyEpoch += "x" },
+		"heartbeat_seconds": func(o *SessionOpen) { o.HeartbeatSeconds++ },
+		"anchor_head":       func(o *SessionOpen) { o.GenesisAnchorHead += "x" },
+		"anchor_log":        func(o *SessionOpen) { o.GenesisAnchorLog += "x" },
+		"posture_capsule":   func(o *SessionOpen) { o.PostureCapsuleSHA256 += "x" },
+		"containment_nonce": func(o *SessionOpen) { o.ContainmentNonce += "x" },
+		"contained_uid":     func(o *SessionOpen) { o.ContainedUID += "x" },
+	}
+	for name, mut := range mutators {
+		t.Run(name, func(t *testing.T) {
+			o := fixedSessionOpen()
+			mut(&o)
+			if got := ComputeSessionOpenGenesis(o); got == base {
+				t.Fatalf("mutating %s did not change the genesis hash — field not bound", name)
+			}
+		})
+	}
+}
+
+// TestComputeSessionOpenGenesis_NoBoundaryCollision proves the length-framing
+// defeats concatenation ambiguity: two SessionOpens whose adjacent fields
+// share the same concatenation but split at a different byte boundary MUST
+// produce different genesis values. Without length framing these collide.
+func TestComputeSessionOpenGenesis_NoBoundaryCollision(t *testing.T) {
+	a := SessionOpen{RunNonce: "ab", OpenNonce: "c"}
+	b := SessionOpen{RunNonce: "a", OpenNonce: "bc"}
+	if ComputeSessionOpenGenesis(a) == ComputeSessionOpenGenesis(b) {
+		t.Fatal("boundary collision: ('ab','c') and ('a','bc') hashed equal — length framing is broken")
+	}
+}
+
+// TestCanonicalActionRecordV1_SessionControlOmitted proves an ordinary receipt
+// (no SessionControl) canonicalizes with NO session_control key — existing
+// receipts and their signatures are unaffected by this additive field.
+func TestCanonicalActionRecordV1_SessionControlOmitted(t *testing.T) {
+	ar := ActionRecord{Version: 1, ActionID: "a1"}
+	b, err := canonicalActionRecordV1(ar)
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	if bytes.Contains(b, []byte("session_control")) {
+		t.Fatalf("bare record leaked a session_control key: %s", b)
+	}
+}
+
+// TestCanonicalActionRecordV1_SessionControlPresent proves a session-control
+// receipt canonicalizes deterministically and carries the nested open shape.
+func TestCanonicalActionRecordV1_SessionControlPresent(t *testing.T) {
+	o := fixedSessionOpen()
+	ar := ActionRecord{
+		Version:        1,
+		ActionID:       "open-1",
+		SessionControl: &SessionControl{Kind: SessionControlOpen, Open: &o},
+	}
+	first, err := canonicalActionRecordV1(ar)
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	second, err := canonicalActionRecordV1(ar)
+	if err != nil {
+		t.Fatalf("canonicalize (2): %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatalf("canonical projection not byte-stable:\n%s\n%s", first, second)
+	}
+	for _, want := range []string{`"session_control"`, `"kind":"session_open"`, `"open"`, `"run_nonce":"run-nonce-aaaa"`} {
+		if !bytes.Contains(first, []byte(want)) {
+			t.Fatalf("canonical projection missing %s: %s", want, first)
+		}
+	}
+	// Heartbeat/Close were not set — they must be omitted, not rendered null.
+	if bytes.Contains(first, []byte(`"heartbeat"`)) || bytes.Contains(first, []byte(`"close"`)) {
+		t.Fatalf("unset session-control variants not omitted: %s", first)
+	}
+}

--- a/internal/receipt/session_open_chain_test.go
+++ b/internal/receipt/session_open_chain_test.go
@@ -276,6 +276,88 @@ func TestVerifyChain_SessionOpenAdversarialRejections(t *testing.T) {
 			},
 			wantErr: "duplicate session_open",
 		},
+		"heartbeat_kind_with_close_payload": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				return []Receipt{
+					open,
+					signSessionReceipt(t, priv, 1, mustHash(t, open), base.Add(time.Second), sessionOpenTestRunA, &SessionControl{
+						Kind: SessionControlHeartbeat,
+						Close: &SessionClose{
+							RunNonce:     sessionOpenTestRunA,
+							OpenNonce:    "open-a",
+							FinalSeq:     0,
+							RootHash:     mustHash(t, open),
+							ReceiptCount: 1,
+							CloseReason:  "forged",
+						},
+					}, nil),
+				}
+			},
+			wantErr: "heartbeat kind missing heartbeat payload",
+		},
+		"close_kind_with_heartbeat_payload": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				return []Receipt{
+					open,
+					signSessionReceipt(t, priv, 1, mustHash(t, open), base.Add(time.Second), sessionOpenTestRunA, &SessionControl{
+						Kind: SessionControlClose,
+						Heartbeat: &SessionHeartbeat{
+							RunNonce:     sessionOpenTestRunA,
+							OpenNonce:    "open-a",
+							Beat:         1,
+							ChainHead:    mustHash(t, open),
+							ChainSeqHead: 1,
+						},
+					}, nil),
+				}
+			},
+			wantErr: "session_close kind missing close payload",
+		},
+		"heartbeat_open_nonce_mismatch": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				return []Receipt{
+					open,
+					signSessionReceipt(t, priv, 1, mustHash(t, open), base.Add(time.Second), sessionOpenTestRunA, &SessionControl{
+						Kind: SessionControlHeartbeat,
+						Heartbeat: &SessionHeartbeat{
+							RunNonce:     sessionOpenTestRunA,
+							OpenNonce:    "wrong-open",
+							Beat:         1,
+							ChainHead:    mustHash(t, open),
+							ChainSeqHead: 1,
+						},
+					}, nil),
+				}
+			},
+			wantErr: "heartbeat open_nonce does not match session_open",
+		},
+		"close_run_nonce_mismatch": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				return []Receipt{
+					open,
+					signSessionReceipt(t, priv, 1, mustHash(t, open), base.Add(time.Second), sessionOpenTestRunA, &SessionControl{
+						Kind: SessionControlClose,
+						Close: &SessionClose{
+							RunNonce:     sessionOpenTestRunB,
+							OpenNonce:    "open-a",
+							FinalSeq:     0,
+							RootHash:     mustHash(t, open),
+							ReceiptCount: 1,
+							CloseReason:  "forged",
+						},
+					}, nil),
+				}
+			},
+			wantErr: "session_close run_nonce does not match receipt run_nonce",
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/receipt/session_open_chain_test.go
+++ b/internal/receipt/session_open_chain_test.go
@@ -1,0 +1,390 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	sessionOpenTestPolicy = "policy-hash"
+	sessionOpenTestRunA   = "run-a"
+	sessionOpenTestRunB   = "run-b"
+)
+
+func testSessionOpen(runNonce, openNonce string, seq uint64) SessionOpen {
+	return SessionOpen{
+		RunNonce:         runNonce,
+		OpenNonce:        openNonce,
+		RecorderSession:  recorderSessionID,
+		PolicyHash:       sessionOpenTestPolicy,
+		SignerKeyEpoch:   "signer-epoch",
+		HeartbeatSeconds: 0,
+		ChainOpenSeq:     seq,
+	}
+}
+
+func signSessionReceipt(
+	t *testing.T,
+	priv ed25519.PrivateKey,
+	seq uint64,
+	prevHash string,
+	ts time.Time,
+	runNonce string,
+	ctrl *SessionControl,
+	marker *KeyTransition,
+) Receipt {
+	t.Helper()
+	ar := ActionRecord{
+		Version:        ActionRecordVersion,
+		ActionID:       NewActionID(),
+		ActionType:     ActionUnclassified,
+		Timestamp:      ts,
+		Target:         sessionOpenTarget,
+		PolicyHash:     sessionOpenTestPolicy,
+		Verdict:        config.ActionAllow,
+		Transport:      sessionControlTransport,
+		ChainPrevHash:  prevHash,
+		ChainSeq:       seq,
+		RunNonce:       runNonce,
+		KeyTransition:  marker,
+		SessionControl: ctrl,
+	}
+	r, err := Sign(ar, priv)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	return r
+}
+
+func signBoundOpen(t *testing.T, priv ed25519.PrivateKey, ts time.Time) Receipt {
+	t.Helper()
+	open := testSessionOpen(sessionOpenTestRunA, "open-a", 0)
+	genesis := ComputeSessionOpenGenesis(open)
+	open.GenesisHash = genesis
+	return signSessionReceipt(t, priv, 0, genesis, ts, sessionOpenTestRunA, &SessionControl{
+		Kind: SessionControlOpen,
+		Open: &open,
+	}, nil)
+}
+
+func signRestartOpen(
+	t *testing.T,
+	priv ed25519.PrivateKey,
+	seq uint64,
+	priorHash string,
+	priorSeq uint64,
+	runNonce string,
+	ts time.Time,
+	marker *KeyTransition,
+) Receipt {
+	t.Helper()
+	open := testSessionOpen(runNonce, "open-"+runNonce, seq)
+	open.PriorChainHead = priorHash
+	open.PriorChainSeq = priorSeq
+	return signSessionReceipt(t, priv, seq, priorHash, ts, runNonce, &SessionControl{
+		Kind: SessionControlOpen,
+		Open: &open,
+	}, marker)
+}
+
+func signRunReceipt(t *testing.T, priv ed25519.PrivateKey, seq uint64, prevHash, runNonce string, ts time.Time) Receipt {
+	t.Helper()
+	ar := ActionRecord{
+		Version:       ActionRecordVersion,
+		ActionID:      NewActionID(),
+		ActionType:    ActionRead,
+		Timestamp:     ts,
+		Target:        chainTestTarget,
+		PolicyHash:    sessionOpenTestPolicy,
+		Verdict:       config.ActionAllow,
+		Transport:     chainTestTransport,
+		ChainPrevHash: prevHash,
+		ChainSeq:      seq,
+		RunNonce:      runNonce,
+	}
+	r, err := Sign(ar, priv)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	return r
+}
+
+func TestVerifyChain_LegacyGenesisWithoutRunNonceStillAccepted(t *testing.T) {
+	t.Parallel()
+	pub, priv := generateTestKey(t)
+
+	legacy := signChainReceipt(t, priv, 0, GenesisHash, time.Now().UTC())
+	res := VerifyChain([]Receipt{legacy}, hex.EncodeToString(pub))
+	if !res.Valid {
+		t.Fatalf("legacy genesis should verify: %s", res.Error)
+	}
+}
+
+func TestVerifyChain_BoundSessionOpenGenesisAccepted(t *testing.T) {
+	t.Parallel()
+	pub, priv := generateTestKey(t)
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+
+	open := signBoundOpen(t, priv, base)
+	next := signRunReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, base.Add(time.Second))
+
+	res := VerifyChain([]Receipt{open, next}, hex.EncodeToString(pub))
+	if !res.Valid {
+		t.Fatalf("bound session_open chain should verify: %s", res.Error)
+	}
+}
+
+func TestVerifyChain_RestartSessionOpenAccepted(t *testing.T) {
+	t.Parallel()
+	pub, priv := generateTestKey(t)
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+
+	firstOpen := signBoundOpen(t, priv, base)
+	firstTail := signRunReceipt(t, priv, 1, mustHash(t, firstOpen), sessionOpenTestRunA, base.Add(time.Second))
+	priorHash := mustHash(t, firstTail)
+	restartOpen := signRestartOpen(t, priv, 2, priorHash, firstTail.ActionRecord.ChainSeq, sessionOpenTestRunB, base.Add(2*time.Second), nil)
+	afterRestart := signRunReceipt(t, priv, 3, mustHash(t, restartOpen), sessionOpenTestRunB, base.Add(3*time.Second))
+
+	res := VerifyChain([]Receipt{firstOpen, firstTail, restartOpen, afterRestart}, hex.EncodeToString(pub))
+	if !res.Valid {
+		t.Fatalf("restart session_open chain should verify: %s", res.Error)
+	}
+}
+
+func TestVerifyChain_KeyRotationSessionOpenAccepted(t *testing.T) {
+	t.Parallel()
+	pubA, privA := generateTestKey(t)
+	pubB, privB := generateTestKey(t)
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+
+	firstOpen := signBoundOpen(t, privA, base)
+	firstTail := signRunReceipt(t, privA, 1, mustHash(t, firstOpen), sessionOpenTestRunA, base.Add(time.Second))
+	priorHash := mustHash(t, firstTail)
+	marker := &KeyTransition{
+		PriorSignerKey: hex.EncodeToString(pubA),
+		PriorChainSeq:  firstTail.ActionRecord.ChainSeq,
+		PriorChainHash: priorHash,
+	}
+	rotatedOpen := signRestartOpen(t, privB, 0, priorHash, firstTail.ActionRecord.ChainSeq, sessionOpenTestRunB, base.Add(time.Hour), marker)
+
+	res := VerifyChainTrusted([]Receipt{firstOpen, firstTail, rotatedOpen}, []string{
+		hex.EncodeToString(pubA),
+		hex.EncodeToString(pubB),
+	})
+	if !res.Valid {
+		t.Fatalf("key-rotation session_open chain should verify: %s", res.Error)
+	}
+}
+
+func TestVerifyChain_SessionOpenAdversarialRejections(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build   func(t *testing.T, priv ed25519.PrivateKey) []Receipt
+		wantErr string
+	}{
+		"forged_g1_without_open": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				return []Receipt{signSessionReceipt(t, priv, 0, genesisSessionOpenPrefix+strings.Repeat("0", 64), time.Now().UTC(), "", nil, nil)}
+			},
+			wantErr: "requires SessionControl.Open",
+		},
+		"bound_open_chain_prev_hash_mismatch": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				open := testSessionOpen(sessionOpenTestRunA, "open-a", 0)
+				computed := ComputeSessionOpenGenesis(open)
+				open.GenesisHash = computed
+				return []Receipt{
+					signSessionReceipt(t, priv, 0, genesisSessionOpenPrefix+strings.Repeat("1", 64), time.Now().UTC(), sessionOpenTestRunA, &SessionControl{
+						Kind: SessionControlOpen,
+						Open: &open,
+					}, nil),
+				}
+			},
+			wantErr: "genesis hash mismatch",
+		},
+		"bound_open_payload_genesis_hash_mismatch": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				open := testSessionOpen(sessionOpenTestRunA, "open-a", 0)
+				computed := ComputeSessionOpenGenesis(open)
+				open.GenesisHash = genesisSessionOpenPrefix + strings.Repeat("2", 64)
+				return []Receipt{
+					signSessionReceipt(t, priv, 0, computed, time.Now().UTC(), sessionOpenTestRunA, &SessionControl{
+						Kind: SessionControlOpen,
+						Open: &open,
+					}, nil),
+				}
+			},
+			wantErr: "genesis_hash mismatch",
+		},
+		"run_nonce_without_matching_open": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				return []Receipt{signRunReceipt(t, priv, 0, GenesisHash, sessionOpenTestRunA, time.Now().UTC())}
+			},
+			wantErr: "first receipt is not a matching session_open",
+		},
+		"open_out_of_position_without_prior_link": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				legacy := signChainReceipt(t, priv, 0, GenesisHash, base)
+				open := testSessionOpen(sessionOpenTestRunA, "open-a", 1)
+				return []Receipt{
+					legacy,
+					signSessionReceipt(t, priv, 1, mustHash(t, legacy), base.Add(time.Second), sessionOpenTestRunA, &SessionControl{
+						Kind: SessionControlOpen,
+						Open: &open,
+					}, nil),
+				}
+			},
+			wantErr: "prior_chain_head",
+		},
+		"restart_open_prior_tail_mismatch": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				tail := signRunReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, base.Add(time.Second))
+				bad := testSessionOpen(sessionOpenTestRunB, "open-b", 2)
+				bad.PriorChainHead = "wrong-prior-head"
+				bad.PriorChainSeq = tail.ActionRecord.ChainSeq
+				return []Receipt{
+					open,
+					tail,
+					signSessionReceipt(t, priv, 2, mustHash(t, tail), base.Add(2*time.Second), sessionOpenTestRunB, &SessionControl{
+						Kind: SessionControlOpen,
+						Open: &bad,
+					}, nil),
+				}
+			},
+			wantErr: "prior_chain_head",
+		},
+		"second_open_same_run_nonce": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				tail := signRunReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, base.Add(time.Second))
+				priorHash := mustHash(t, tail)
+				second := signRestartOpen(t, priv, 2, priorHash, tail.ActionRecord.ChainSeq, sessionOpenTestRunA, base.Add(2*time.Second), nil)
+				return []Receipt{open, tail, second}
+			},
+			wantErr: "duplicate session_open",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pub, priv := generateTestKey(t)
+			res := VerifyChain(tc.build(t, priv), hex.EncodeToString(pub))
+			if res.Valid {
+				t.Fatal("malformed session_open chain verified")
+			}
+			if !strings.Contains(res.Error, tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", res.Error, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestVerifyChain_SessionOpenDeletionAndReorderRejected(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		build   func(t *testing.T, priv ed25519.PrivateKey) []Receipt
+		wantErr string
+	}{
+		"drop_first_session_open": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				first := signRunReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, base.Add(time.Second))
+				second := signRunReceipt(t, priv, 2, mustHash(t, first), sessionOpenTestRunA, base.Add(2*time.Second))
+				return []Receipt{first, second}
+			},
+			wantErr: "genesis receipt chain_prev_hash",
+		},
+		"drop_middle_receipt": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				first := signRunReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, base.Add(time.Second))
+				second := signRunReceipt(t, priv, 2, mustHash(t, first), sessionOpenTestRunA, base.Add(2*time.Second))
+				return []Receipt{open, second}
+			},
+			wantErr: "seq gap",
+		},
+		"reorder_receipts": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				first := signRunReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, base.Add(time.Second))
+				second := signRunReceipt(t, priv, 2, mustHash(t, first), sessionOpenTestRunA, base.Add(2*time.Second))
+				return []Receipt{open, second, first}
+			},
+			wantErr: "seq gap",
+		},
+		"restart_open_prior_tail_missing": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				first := signRunReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, base.Add(time.Second))
+				priorHash := mustHash(t, first)
+				restart := signRestartOpen(t, priv, 2, priorHash, first.ActionRecord.ChainSeq, sessionOpenTestRunB, base.Add(2*time.Second), nil)
+				return []Receipt{open, restart}
+			},
+			wantErr: "prior_chain_head",
+		},
+		"key_rotation_session_open_prior_tail_missing": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				_, privB := generateTestKey(t)
+				base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+				open := signBoundOpen(t, priv, base)
+				first := signRunReceipt(t, priv, 1, mustHash(t, open), sessionOpenTestRunA, base.Add(time.Second))
+				priorHash := mustHash(t, first)
+				marker := &KeyTransition{
+					PriorSignerKey: hex.EncodeToString(priv.Public().(ed25519.PublicKey)),
+					PriorChainSeq:  first.ActionRecord.ChainSeq,
+					PriorChainHash: priorHash,
+				}
+				rotated := signRestartOpen(t, privB, 0, priorHash, first.ActionRecord.ChainSeq, sessionOpenTestRunB, base.Add(2*time.Second), marker)
+				return []Receipt{open, rotated}
+			},
+			wantErr: "prior_chain_hash",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pub, priv := generateTestKey(t)
+			res := VerifyChain(tc.build(t, priv), hex.EncodeToString(pub))
+			if res.Valid {
+				t.Fatal("tampered session_open chain verified")
+			}
+			if !strings.Contains(res.Error, tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", res.Error, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestVerifyChain_RunNonceScopeIsPerVerifyCall(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateTestKey(t)
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	first := signBoundOpen(t, priv, base)
+	second := signBoundOpen(t, priv, base.Add(time.Minute))
+
+	if res := VerifyChain([]Receipt{first}, hex.EncodeToString(pub)); !res.Valid {
+		t.Fatalf("first VerifyChain: %s", res.Error)
+	}
+	if res := VerifyChain([]Receipt{second}, hex.EncodeToString(pub)); !res.Valid {
+		t.Fatalf("second VerifyChain with reused run_nonce should not inherit prior call state: %s", res.Error)
+	}
+}

--- a/internal/recorder/durable_test.go
+++ b/internal/recorder/durable_test.go
@@ -247,6 +247,9 @@ func TestRecordDurable_BatchSyncFailurePropagatesToFollowersAndKeepsGap(t *testi
 	}
 
 	rec.runDurabilitySync(leader.batch)
+	if got := rec.FsyncErrorsGated(); got != 1 {
+		t.Fatalf("FsyncErrorsGated after one failed batch = %d, want 1", got)
+	}
 	for _, tt := range []struct {
 		name       string
 		batch      *durableBatch
@@ -286,6 +289,25 @@ func TestRecordDurable_BatchSyncFailurePropagatesToFollowersAndKeepsGap(t *testi
 	}
 	if entries[2].PrevHash != entries[1].Hash {
 		t.Fatalf("later PrevHash = %q, want failed follower hash %q", entries[2].PrevHash, entries[1].Hash)
+	}
+	if got := rec.FsyncErrorsGated(); got != 1 {
+		t.Fatalf("FsyncErrorsGated after later success = %d, want 1", got)
+	}
+}
+
+func TestRecorder_FsyncErrorsGatedNilAndNop(t *testing.T) {
+	t.Parallel()
+
+	var nilRecorder *Recorder
+	if got := nilRecorder.FsyncErrorsGated(); got != 0 {
+		t.Fatalf("nil FsyncErrorsGated = %d, want 0", got)
+	}
+	nop, err := New(Config{Enabled: false}, nil, nil)
+	if err != nil {
+		t.Fatalf("New nop: %v", err)
+	}
+	if got := nop.FsyncErrorsGated(); got != 0 {
+		t.Fatalf("nop FsyncErrorsGated = %d, want 0", got)
 	}
 }
 

--- a/internal/recorder/durable_test.go
+++ b/internal/recorder/durable_test.go
@@ -1,0 +1,483 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package recorder
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type durableTestObserver struct {
+	mu      sync.Mutex
+	entries []Entry
+	seen    chan Entry
+}
+
+func newDurableTestObserver() *durableTestObserver {
+	return &durableTestObserver{seen: make(chan Entry, 16)}
+}
+
+func (o *durableTestObserver) ObserveRecorderEntry(e Entry) {
+	o.mu.Lock()
+	o.entries = append(o.entries, e)
+	o.mu.Unlock()
+	o.seen <- e
+}
+
+func (o *durableTestObserver) count() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return len(o.entries)
+}
+
+func newDurableTestRecorder(t *testing.T, cfg Config) *Recorder {
+	t.Helper()
+	if cfg.Dir == "" {
+		cfg.Dir = t.TempDir()
+	}
+	cfg.Enabled = true
+	if cfg.CheckpointInterval == 0 {
+		cfg.CheckpointInterval = 1000
+	}
+	rec, err := New(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return rec
+}
+
+func waitForDone[T any](t *testing.T, ch <-chan T, label string) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-timeAfterTest():
+		t.Fatalf("timed out waiting for %s", label)
+		var zero T
+		return zero
+	}
+}
+
+func timeAfterTest() <-chan time.Time {
+	return time.After(5 * time.Second)
+}
+
+func TestRecordDurable_WaitsForSyncBeforeSuccessAndObserver(t *testing.T) {
+	rec := newDurableTestRecorder(t, Config{})
+	defer func() { _ = rec.Close() }()
+
+	syncEntered := make(chan struct{})
+	releaseSync := make(chan struct{})
+	var once sync.Once
+	rec.SetObserver(newDurableTestObserver())
+	rec.SetSyncForTest(func(*os.File) error {
+		once.Do(func() { close(syncEntered) })
+		<-releaseSync
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- rec.RecordDurable(Entry{
+			SessionID: "durable-session",
+			Type:      "request",
+			Summary:   "durable wait",
+		})
+	}()
+
+	waitForDone(t, syncEntered, "sync entry")
+	select {
+	case err := <-done:
+		t.Fatalf("RecordDurable returned before sync release: %v", err)
+	default:
+	}
+	if got := rec.observer.(*durableTestObserver).count(); got != 0 {
+		t.Fatalf("observer fired before sync success: got %d entries", got)
+	}
+
+	close(releaseSync)
+	if err := waitForDone(t, done, "RecordDurable completion"); err != nil {
+		t.Fatalf("RecordDurable: %v", err)
+	}
+	if got := rec.observer.(*durableTestObserver).count(); got != 1 {
+		t.Fatalf("observer count after durable success = %d, want 1", got)
+	}
+}
+
+func TestRecordDurable_SyncFailureDoesNotRollBackChainState(t *testing.T) {
+	dir := t.TempDir()
+	rec := newDurableTestRecorder(t, Config{Dir: dir})
+	defer func() { _ = rec.Close() }()
+
+	syncErr := errors.New("injected sync failure")
+	var calls int
+	rec.SetSyncForTest(func(*os.File) error {
+		calls++
+		if calls == 1 {
+			return syncErr
+		}
+		return nil
+	})
+
+	err := rec.RecordDurable(Entry{
+		SessionID: "durable-session",
+		Type:      "request",
+		Summary:   "first fails sync",
+	})
+	if !errors.Is(err, ErrDurability) {
+		t.Fatalf("RecordDurable first error = %v, want ErrDurability", err)
+	}
+	if !errors.Is(err, syncErr) {
+		t.Fatalf("RecordDurable first error = %v, want injected sync error", err)
+	}
+	if err := rec.RecordDurable(Entry{
+		SessionID: "durable-session",
+		Type:      "request",
+		Summary:   "second succeeds",
+	}); err != nil {
+		t.Fatalf("RecordDurable second: %v", err)
+	}
+
+	entries := readEntriesForSession(t, dir, "durable-session")
+	if len(entries) < 2 {
+		t.Fatalf("entries = %d, want at least 2", len(entries))
+	}
+	if entries[0].Sequence != 0 || entries[1].Sequence != 1 {
+		t.Fatalf("sequences after sync failure = %d,%d; rollback would have duplicated seq 0", entries[0].Sequence, entries[1].Sequence)
+	}
+	if entries[1].PrevHash != entries[0].Hash {
+		t.Fatalf("second PrevHash = %q, want first hash %q", entries[1].PrevHash, entries[0].Hash)
+	}
+}
+
+func TestRecordDurable_BatchSyncCoversJoinedFollowers(t *testing.T) {
+	dir := t.TempDir()
+	rec := newDurableTestRecorder(t, Config{Dir: dir, CheckpointInterval: 1000, MaxEntriesPerFile: 1000})
+	defer func() { _ = rec.Close() }()
+
+	var (
+		hookErr  error
+		syncSeqs []uint64
+		diskSeqs = make(map[uint64]bool)
+	)
+	rec.SetSyncForTest(func(f *os.File) error {
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+
+		if rec.durableBatch == nil || !rec.durableBatch.syncing {
+			hookErr = errors.New("sync hook ran without an active syncing batch")
+			return hookErr
+		}
+		for _, entry := range rec.durableBatch.entries {
+			syncSeqs = append(syncSeqs, entry.seq)
+		}
+		entries, err := ReadEntries(f.Name())
+		if err != nil {
+			hookErr = fmt.Errorf("read entries during sync: %w", err)
+			return hookErr
+		}
+		for _, entry := range entries {
+			diskSeqs[entry.Sequence] = true
+		}
+		return nil
+	})
+
+	leader, leaderWritten := reserveDurableEntryForTest(t, rec, "leader")
+	follower, followerWritten := reserveDurableEntryForTest(t, rec, "follower")
+	if !leader.leader {
+		t.Fatal("first reservation was not the batch leader")
+	}
+	if follower.leader {
+		t.Fatal("second reservation unexpectedly became a new batch leader")
+	}
+	if leader.batch != follower.batch {
+		t.Fatal("follower did not join the leader batch")
+	}
+
+	rec.runDurabilitySync(leader.batch)
+	if err := rec.waitDurability(leader.batch, leader.batch.generation, leaderWritten.Sequence); err != nil {
+		t.Fatalf("leader waitDurability: %v", err)
+	}
+	if err := rec.waitDurability(follower.batch, follower.batch.generation, followerWritten.Sequence); err != nil {
+		t.Fatalf("follower waitDurability: %v", err)
+	}
+	if hookErr != nil {
+		t.Fatalf("sync hook: %v", hookErr)
+	}
+
+	wantSeqs := []uint64{leaderWritten.Sequence, followerWritten.Sequence}
+	if fmt.Sprint(syncSeqs) != fmt.Sprint(wantSeqs) {
+		t.Fatalf("batch seqs at sync = %v, want %v", syncSeqs, wantSeqs)
+	}
+	for _, seq := range wantSeqs {
+		if !diskSeqs[seq] {
+			t.Fatalf("seq %d was in the durable batch but not readable from disk at sync time", seq)
+		}
+	}
+}
+
+func TestRecordDurable_BatchSyncFailurePropagatesToFollowersAndKeepsGap(t *testing.T) {
+	dir := t.TempDir()
+	rec := newDurableTestRecorder(t, Config{Dir: dir, CheckpointInterval: 1000, MaxEntriesPerFile: 1000})
+	defer func() { _ = rec.Close() }()
+
+	syncErr := errors.New("injected sync failure")
+	var calls int
+	rec.SetSyncForTest(func(*os.File) error {
+		calls++
+		if calls == 1 {
+			return syncErr
+		}
+		return nil
+	})
+
+	leader, leaderWritten := reserveDurableEntryForTest(t, rec, "leader fails")
+	follower, followerWritten := reserveDurableEntryForTest(t, rec, "follower fails")
+	if leader.batch != follower.batch {
+		t.Fatal("follower did not join the leader batch")
+	}
+
+	rec.runDurabilitySync(leader.batch)
+	for _, tt := range []struct {
+		name       string
+		batch      *durableBatch
+		generation uint64
+		seq        uint64
+	}{
+		{name: "leader", batch: leader.batch, generation: leader.batch.generation, seq: leaderWritten.Sequence},
+		{name: "follower", batch: follower.batch, generation: follower.batch.generation, seq: followerWritten.Sequence},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rec.waitDurability(tt.batch, tt.generation, tt.seq)
+			if !errors.Is(err, ErrDurability) {
+				t.Fatalf("waitDurability error = %v, want ErrDurability", err)
+			}
+			if !errors.Is(err, syncErr) {
+				t.Fatalf("waitDurability error = %v, want injected sync error", err)
+			}
+		})
+	}
+
+	if err := rec.RecordDurable(Entry{
+		SessionID: "durable-session",
+		Type:      "request",
+		Summary:   "later succeeds",
+	}); err != nil {
+		t.Fatalf("later RecordDurable: %v", err)
+	}
+
+	entries := readEntriesForSession(t, dir, "durable-session")
+	if len(entries) < 3 {
+		t.Fatalf("entries = %d, want at least 3", len(entries))
+	}
+	for i := range 3 {
+		if entries[i].Sequence != uint64(i) {
+			t.Fatalf("entry %d sequence = %d, want %d", i, entries[i].Sequence, i)
+		}
+	}
+	if entries[2].PrevHash != entries[1].Hash {
+		t.Fatalf("later PrevHash = %q, want failed follower hash %q", entries[2].PrevHash, entries[1].Hash)
+	}
+}
+
+func TestRecordDurable_SyncPanicReturnsDurabilityErrorAndDoesNotPoisonRecorder(t *testing.T) {
+	rec := newDurableTestRecorder(t, Config{})
+	defer func() { _ = rec.Close() }()
+
+	rec.SetSyncForTest(func(*os.File) error {
+		panic("injected sync panic")
+	})
+	done := make(chan error, 1)
+	go func() {
+		done <- rec.RecordDurable(Entry{
+			SessionID: "durable-session",
+			Type:      "request",
+			Summary:   "panic becomes durability error",
+		})
+	}()
+
+	err := waitForDone(t, done, "RecordDurable panic recovery")
+	if !errors.Is(err, ErrDurability) {
+		t.Fatalf("RecordDurable error = %v, want ErrDurability", err)
+	}
+	if !strings.Contains(err.Error(), "injected sync panic") {
+		t.Fatalf("RecordDurable error = %v, want injected panic detail", err)
+	}
+
+	rec.SetSyncForTest(nil)
+	if err := rec.RecordDurable(Entry{
+		SessionID: "durable-session",
+		Type:      "request",
+		Summary:   "recorder still usable",
+	}); err != nil {
+		t.Fatalf("RecordDurable after panic: %v", err)
+	}
+}
+
+func TestRecordDurable_ConcurrentReservationsKeepUniqueValidChain(t *testing.T) {
+	dir := t.TempDir()
+	rec := newDurableTestRecorder(t, Config{Dir: dir, CheckpointInterval: 1000, MaxEntriesPerFile: 1000})
+
+	const goroutines = 32
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			errs <- rec.RecordDurable(Entry{
+				SessionID: "durable-session",
+				Type:      "request",
+				Summary:   fmt.Sprintf("entry %d", id),
+			})
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("RecordDurable concurrent error: %v", err)
+		}
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	entries := readEntriesForSession(t, dir, "durable-session")
+	dataEntries := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		if e.Type == "request" {
+			dataEntries = append(dataEntries, e)
+		}
+	}
+	if len(dataEntries) != goroutines {
+		t.Fatalf("data entries = %d, want %d", len(dataEntries), goroutines)
+	}
+	prev := GenesisHash
+	for i, e := range dataEntries {
+		if e.Sequence != uint64(i) {
+			t.Fatalf("entry %d sequence = %d, want %d", i, e.Sequence, i)
+		}
+		if e.PrevHash != prev {
+			t.Fatalf("entry %d PrevHash = %q, want %q", i, e.PrevHash, prev)
+		}
+		prev = e.Hash
+	}
+}
+
+type shortWriteSink struct{}
+
+func (shortWriteSink) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return len(p) - 1, nil
+}
+
+func TestWriteEntry_ReturnsShortWrite(t *testing.T) {
+	rec := &Recorder{writer: bufio.NewWriterSize(shortWriteSink{}, 1)}
+	err := rec.writeEntry(Entry{
+		Version:   EntryVersion,
+		Sequence:  0,
+		SessionID: "durable-session",
+		Type:      "request",
+		Summary:   "short write",
+		PrevHash:  GenesisHash,
+	}, false)
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("writeEntry error = %v, want io.ErrShortWrite", err)
+	}
+}
+
+func TestRecordDurable_RotationWaitsForPendingSync(t *testing.T) {
+	rec := newDurableTestRecorder(t, Config{MaxEntriesPerFile: 1, CheckpointInterval: 1000})
+	defer func() { _ = rec.Close() }()
+
+	observer := newDurableTestObserver()
+	rec.SetObserver(observer)
+	syncEntered := make(chan struct{})
+	releaseSync := make(chan struct{})
+	var once sync.Once
+	rec.SetSyncForTest(func(*os.File) error {
+		once.Do(func() { close(syncEntered) })
+		<-releaseSync
+		return nil
+	})
+
+	durableDone := make(chan error, 1)
+	go func() {
+		durableDone <- rec.RecordDurable(Entry{
+			SessionID: "durable-session",
+			Type:      "request",
+			Summary:   "durable pending",
+		})
+	}()
+	waitForDone(t, syncEntered, "durable sync entry")
+
+	recordDone := make(chan error, 1)
+	go func() {
+		recordDone <- rec.Record(Entry{
+			SessionID: "durable-session",
+			Type:      "request",
+			Summary:   "rotation waits",
+		})
+	}()
+	observed := waitForDone(t, observer.seen, "non-durable observer")
+	if observed.Summary != "rotation waits" {
+		t.Fatalf("observed summary = %q, want rotation waits", observed.Summary)
+	}
+	select {
+	case err := <-recordDone:
+		t.Fatalf("Record completed before durable sync released: %v", err)
+	default:
+	}
+
+	close(releaseSync)
+	if err := waitForDone(t, durableDone, "durable completion"); err != nil {
+		t.Fatalf("RecordDurable: %v", err)
+	}
+	if err := waitForDone(t, recordDone, "record completion"); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+}
+
+func readEntriesForSession(t *testing.T, dir, sessionID string) []Entry {
+	t.Helper()
+	path := filepath.Join(filepath.Clean(dir), fmt.Sprintf("evidence-%s-0.jsonl", sessionID))
+	entries, err := ReadEntries(path)
+	if err != nil {
+		t.Fatalf("ReadEntries(%q): %v", path, err)
+	}
+	return entries
+}
+
+func reserveDurableEntryForTest(t *testing.T, rec *Recorder, summary string) (durableReservation, Entry) {
+	t.Helper()
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	written, err := rec.prepareAndWriteEntryLocked(Entry{
+		SessionID: "durable-session",
+		Type:      "request",
+		Summary:   summary,
+	}, false)
+	if err != nil {
+		t.Fatalf("prepareAndWriteEntryLocked(%q): %v", summary, err)
+	}
+	rec.prevHash = written.Hash
+	rec.seq++
+	rec.sinceCheckpoint++
+	rec.fileEntryCount++
+
+	return rec.enqueueDurabilityLocked(rec.fileGeneration, written.Sequence, rec.lastEntryOffsetLocked(written)), written
+}

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -104,6 +104,30 @@ type EntryObserver interface {
 	ObserveRecorderEntry(Entry)
 }
 
+// ErrDurability means a durable recorder write reached the userspace flush
+// stage but could not be confirmed with File.Sync.
+var ErrDurability = errors.New("recorder durability confirmation failed")
+
+type durableBatch struct {
+	file           *os.File
+	generation     uint64
+	leaderAssigned bool
+	syncing        bool
+	done           chan struct{}
+	err            error
+	entries        []durableBatchEntry
+}
+
+type durableBatchEntry struct {
+	seq    uint64
+	offset int64
+}
+
+type durableReservation struct {
+	batch  *durableBatch
+	leader bool
+}
+
 // Recorder writes hash-chained evidence entries to JSONL files.
 type Recorder struct {
 	cfg       Config
@@ -119,6 +143,7 @@ type Recorder struct {
 	file           *os.File
 	fileEntryCount int
 	fileSeqStart   uint64
+	fileGeneration uint64
 	sessionID      string
 
 	// Checkpoint tracking
@@ -127,6 +152,12 @@ type Recorder struct {
 	firstSeqInSpan      uint64
 	closed              bool
 	nop                 bool
+
+	fileSync       func(*os.File) error
+	durableCond    *sync.Cond
+	durableBatch   *durableBatch
+	durableSyncing bool
+	durablePending map[uint64]int
 }
 
 // New creates a Recorder. The redactFn is used for DLP redaction (can be nil to skip).
@@ -174,7 +205,10 @@ func New(cfg Config, redactFn RedactFunc, privKey ed25519.PrivateKey) (*Recorder
 		privKey:             privKey,
 		prevHash:            GenesisHash,
 		checkpointThreshold: safeUint64(cfg.CheckpointInterval, 1),
+		fileSync:            func(f *os.File) error { return f.Sync() },
+		durablePending:      make(map[uint64]int),
 	}
+	r.durableCond = sync.NewCond(&r.mu)
 
 	if cfg.RawEscrow && cfg.EscrowPublicKey != "" {
 		keyBytes, err := hex.DecodeString(cfg.EscrowPublicKey)
@@ -190,6 +224,24 @@ func New(cfg Config, redactFn RedactFunc, privKey ed25519.PrivateKey) (*Recorder
 	}
 
 	return r, nil
+}
+
+// SetSyncForTest replaces the File.Sync implementation used by RecordDurable.
+// Passing nil restores the production implementation. This hook is exported
+// because receipt package tests need to inject recorder durability failures
+// across the internal package boundary; it is not wired to config or agent
+// input, and production recorders default to real File.Sync.
+func (r *Recorder) SetSyncForTest(syncFn func(*os.File) error) {
+	if r == nil || r.nop {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if syncFn == nil {
+		r.fileSync = func(f *os.File) error { return f.Sync() }
+		return
+	}
+	r.fileSync = syncFn
 }
 
 // Dir returns the recorder evidence directory. Empty for nil or no-op recorders.
@@ -223,91 +275,66 @@ func (r *Recorder) Record(e Entry) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.closed {
-		return fmt.Errorf("recorder is closed")
-	}
-
-	// Session ID validation: require non-empty, reject path separators
-	// (defense against path traversal in filenames), and reject mismatches.
-	if e.SessionID == "" {
-		return errors.New("recorder: session_id required")
-	}
-	if strings.ContainsAny(e.SessionID, `/\`) {
-		return fmt.Errorf("recorder: session_id contains path separator")
-	}
-	if r.sessionID == "" {
-		if err := r.resumeSessionLocked(e.SessionID); err != nil {
-			return fmt.Errorf("recorder: resume chain state: %w", err)
-		}
-	}
-	if e.SessionID != r.sessionID {
-		return fmt.Errorf("recorder: session_id mismatch (expected %q, got %q)", r.sessionID, e.SessionID)
-	}
-
-	e.Version = EntryVersion
-	e.Sequence = r.seq
-	e.Timestamp = time.Now().UTC()
-	e.PrevHash = r.prevHash
-
-	// Raw escrow: encrypt detail before redaction. Escrow must succeed
-	// when enabled -- silent drops would lose raw evidence.
-	if r.cfg.RawEscrow && r.escrowPub != nil {
-		rawJSON, err := json.Marshal(e.Detail)
-		if err != nil {
-			return fmt.Errorf("marshal raw escrow: %w", err)
-		}
-		escrowPath, err := r.writeEscrow(rawJSON)
-		if err != nil {
-			return fmt.Errorf("write raw escrow: %w", err)
-		}
-		e.RawRef = filepath.Base(escrowPath)
-	}
-
-	// DLP redaction: receipt emitters sanitize target/pattern before signing
-	// when recorder redaction is enabled, so receipt redaction is normally a
-	// no-op and on-disk receipts still verify. This pass remains fail-closed
-	// for malformed or legacy receipt details that still contain DLP hits.
-	// Raw escrow preserves the exact detail passed to the recorder for
-	// forensic replay.
-	if r.cfg.Redact && r.redactFn != nil {
-		if e.Type == recorderTypeReceipt {
-			e.Detail = r.redactReceiptDetail(e.Detail)
-		} else {
-			e.Detail = r.redactDetail(e.Detail)
-		}
-	}
-
-	e.Hash = ComputeHash(e)
-
-	if err := r.ensureFile(e.SessionID, e.Sequence); err != nil {
-		return fmt.Errorf("opening evidence file: %w", err)
-	}
-
-	if err := r.writeEntry(e); err != nil {
-		return fmt.Errorf("writing entry: %w", err)
+	written, err := r.prepareAndWriteEntryLocked(e, true)
+	if err != nil {
+		return err
 	}
 
 	// Advance chain state AFTER successful write. If ensureFile or
 	// writeEntry fails, the next entry must re-link to the same prevHash
 	// so the chain stays consistent with what reached disk.
-	r.prevHash = e.Hash
+	r.prevHash = written.Hash
 	r.seq++
 
 	r.sinceCheckpoint++
-	if r.sinceCheckpoint >= r.checkpointThreshold {
-		if err := r.checkpointLocked(); err != nil {
-			return fmt.Errorf("writing checkpoint: %w", err)
-		}
-	}
-
-	// File rotation
 	r.fileEntryCount++
-	if r.fileEntryCount >= r.cfg.MaxEntriesPerFile {
-		if err := r.rotateFile(); err != nil {
-			return fmt.Errorf("rotating file: %w", err)
-		}
+	if err := r.runPostRecordMaintenanceLocked(); err != nil {
+		return err
 	}
 
+	return nil
+}
+
+// RecordDurable writes an entry and returns success only after File.Sync has
+// confirmed the file generation that contains the entry.
+func (r *Recorder) RecordDurable(e Entry) error {
+	if r.nop {
+		return nil
+	}
+
+	r.mu.Lock()
+	written, err := r.prepareAndWriteEntryLocked(e, false)
+	if err != nil {
+		r.mu.Unlock()
+		return err
+	}
+
+	r.prevHash = written.Hash
+	r.seq++
+	r.sinceCheckpoint++
+	r.fileEntryCount++
+
+	generation := r.fileGeneration
+	reservation := r.enqueueDurabilityLocked(generation, written.Sequence, r.lastEntryOffsetLocked(written))
+	r.mu.Unlock()
+
+	if reservation.leader {
+		r.runDurabilitySync(reservation.batch)
+	}
+	if err := r.waitDurability(reservation.batch, generation, written.Sequence); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	err = r.runPostRecordMaintenanceLocked()
+	r.mu.Unlock()
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	r.notifyObserver(written)
+	r.mu.Unlock()
 	return nil
 }
 
@@ -371,6 +398,178 @@ func (r *Recorder) RecordDecision(dr DecisionRecord) error {
 	})
 }
 
+// prepareAndWriteEntryLocked validates, stamps, redacts, hashes, opens the
+// target file, and writes one JSONL entry. The recorder mutex must be held.
+func (r *Recorder) prepareAndWriteEntryLocked(e Entry, notify bool) (Entry, error) {
+	if r.closed {
+		return Entry{}, fmt.Errorf("recorder is closed")
+	}
+
+	// Session ID validation: require non-empty, reject path separators
+	// (defense against path traversal in filenames), and reject mismatches.
+	if e.SessionID == "" {
+		return Entry{}, errors.New("recorder: session_id required")
+	}
+	if strings.ContainsAny(e.SessionID, `/\`) {
+		return Entry{}, fmt.Errorf("recorder: session_id contains path separator")
+	}
+	if r.sessionID == "" {
+		if err := r.resumeSessionLocked(e.SessionID); err != nil {
+			return Entry{}, fmt.Errorf("recorder: resume chain state: %w", err)
+		}
+	}
+	if e.SessionID != r.sessionID {
+		return Entry{}, fmt.Errorf("recorder: session_id mismatch (expected %q, got %q)", r.sessionID, e.SessionID)
+	}
+
+	e.Version = EntryVersion
+	e.Sequence = r.seq
+	e.Timestamp = time.Now().UTC()
+	e.PrevHash = r.prevHash
+
+	// Raw escrow: encrypt detail before redaction. Escrow must succeed
+	// when enabled -- silent drops would lose raw evidence.
+	if r.cfg.RawEscrow && r.escrowPub != nil {
+		rawJSON, err := json.Marshal(e.Detail)
+		if err != nil {
+			return Entry{}, fmt.Errorf("marshal raw escrow: %w", err)
+		}
+		escrowPath, err := r.writeEscrow(rawJSON)
+		if err != nil {
+			return Entry{}, fmt.Errorf("write raw escrow: %w", err)
+		}
+		e.RawRef = filepath.Base(escrowPath)
+	}
+
+	// DLP redaction: receipt emitters sanitize target/pattern before signing
+	// when recorder redaction is enabled, so receipt redaction is normally a
+	// no-op and on-disk receipts still verify. This pass remains fail-closed
+	// for malformed or legacy receipt details that still contain DLP hits.
+	// Raw escrow preserves the exact detail passed to the recorder for
+	// forensic replay.
+	if r.cfg.Redact && r.redactFn != nil {
+		if e.Type == recorderTypeReceipt {
+			e.Detail = r.redactReceiptDetail(e.Detail)
+		} else {
+			e.Detail = r.redactDetail(e.Detail)
+		}
+	}
+
+	e.Hash = ComputeHash(e)
+
+	if err := r.ensureFile(e.SessionID, e.Sequence); err != nil {
+		return Entry{}, fmt.Errorf("opening evidence file: %w", err)
+	}
+
+	if err := r.writeEntry(e, notify); err != nil {
+		return Entry{}, fmt.Errorf("writing entry: %w", err)
+	}
+	return e, nil
+}
+
+// runPostRecordMaintenanceLocked applies checkpoint and rotation thresholds
+// after an entry has already advanced the chain state. The recorder mutex must
+// be held.
+func (r *Recorder) runPostRecordMaintenanceLocked() error {
+	needsCheckpoint := r.sinceCheckpoint >= r.checkpointThreshold
+	needsRotation := r.fileEntryCount >= r.cfg.MaxEntriesPerFile
+	if needsCheckpoint || needsRotation {
+		r.waitDurableForCurrentFileLocked()
+	}
+	if needsCheckpoint {
+		if err := r.checkpointLocked(); err != nil {
+			return fmt.Errorf("writing checkpoint: %w", err)
+		}
+	}
+	if needsRotation {
+		if err := r.rotateFile(); err != nil {
+			return fmt.Errorf("rotating file: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *Recorder) enqueueDurabilityLocked(generation, seq uint64, offset int64) durableReservation {
+	batch := r.durableBatch
+	if batch == nil || batch.syncing || batch.generation != generation {
+		batch = &durableBatch{
+			file:       r.file,
+			generation: generation,
+			done:       make(chan struct{}),
+		}
+		r.durableBatch = batch
+	}
+	// A caller joins a batch only after writeEntry has flushed its JSONL bytes
+	// under r.mu. The leader also marks batch.syncing under r.mu before
+	// File.Sync, so a follower in this batch necessarily wrote before the
+	// leader could start syncing; once syncing is true, later entries must use
+	// a new batch.
+	batch.entries = append(batch.entries, durableBatchEntry{seq: seq, offset: offset})
+	r.durablePending[generation]++
+	if !batch.leaderAssigned {
+		batch.leaderAssigned = true
+		return durableReservation{batch: batch, leader: true}
+	}
+	return durableReservation{batch: batch}
+}
+
+func (r *Recorder) runDurabilitySync(batch *durableBatch) {
+	var err error
+	syncStarted := false
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if recoveredErr, ok := recovered.(error); ok {
+				err = fmt.Errorf("panic during recorder durability sync: %w", recoveredErr)
+			} else {
+				err = fmt.Errorf("panic during recorder durability sync: %v", recovered)
+			}
+		}
+
+		r.mu.Lock()
+		batch.err = err
+		if syncStarted {
+			r.durableSyncing = false
+		}
+		if r.durableBatch == batch {
+			r.durableBatch = nil
+		}
+		close(batch.done)
+		r.durableCond.Broadcast()
+		r.mu.Unlock()
+	}()
+
+	r.mu.Lock()
+	for r.durableSyncing {
+		r.durableCond.Wait()
+	}
+	batch.syncing = true
+	// Keep syncStarted adjacent to durableSyncing. There must be no panicking
+	// operation between these two assignments, or panic recovery could leave
+	// later durable syncs waiting forever on durableSyncing.
+	r.durableSyncing = true
+	syncStarted = true
+	r.mu.Unlock()
+
+	err = r.fileSync(batch.file)
+}
+
+func (r *Recorder) waitDurability(batch *durableBatch, generation, seq uint64) error {
+	<-batch.done
+
+	r.mu.Lock()
+	r.durablePending[generation]--
+	if r.durablePending[generation] <= 0 {
+		delete(r.durablePending, generation)
+	}
+	r.durableCond.Broadcast()
+	r.mu.Unlock()
+
+	if batch.err != nil {
+		return fmt.Errorf("%w: file generation %d seq %d: %w", ErrDurability, generation, seq, batch.err)
+	}
+	return nil
+}
+
 // Close flushes and closes the recorder, writing a final checkpoint.
 func (r *Recorder) Close() error {
 	if r.nop {
@@ -386,6 +585,7 @@ func (r *Recorder) Close() error {
 	r.closed = true
 
 	if r.sinceCheckpoint > 0 {
+		r.waitDurableForCurrentFileLocked()
 		if err := r.checkpointLocked(); err != nil {
 			// Close the file even if checkpoint failed, but return
 			// the checkpoint error since it means chain state is incomplete.
@@ -429,7 +629,7 @@ func (r *Recorder) checkpointLocked() error {
 	e.Hash = ComputeHash(e)
 
 	if r.file != nil {
-		if err := r.writeEntry(e); err != nil {
+		if err := r.writeEntry(e, true); err != nil {
 			return err
 		}
 		r.fileEntryCount++
@@ -698,6 +898,7 @@ func (r *Recorder) ensureFile(sessionID string, seqStart uint64) error {
 		// recreated directory. Ignore close errors - the fd was
 		// already pointing at an unlinked inode.
 		if r.file != nil {
+			r.waitDurableForCurrentFileLocked()
 			_ = r.file.Close()
 			r.file = nil
 			r.writer = nil
@@ -727,6 +928,7 @@ func (r *Recorder) ensureFile(sessionID string, seqStart uint64) error {
 	r.writer = bufio.NewWriter(f)
 	r.fileEntryCount = 0
 	r.fileSeqStart = seqStart
+	r.fileGeneration++
 	if r.sinceCheckpoint == 0 {
 		r.firstSeqInSpan = seqStart
 	}
@@ -734,22 +936,47 @@ func (r *Recorder) ensureFile(sessionID string, seqStart uint64) error {
 }
 
 // writeEntry serializes and writes a single entry as a JSONL line.
-func (r *Recorder) writeEntry(e Entry) error {
+func (r *Recorder) writeEntry(e Entry, notify bool) error {
 	data, err := json.Marshal(e)
 	if err != nil {
 		return fmt.Errorf("marshaling entry: %w", err)
 	}
-	if _, err := r.writer.Write(data); err != nil {
+	if n, err := r.writer.Write(data); err != nil {
 		return err
+	} else if n != len(data) {
+		return io.ErrShortWrite
 	}
-	if _, err := r.writer.Write([]byte("\n")); err != nil {
+	if n, err := r.writer.Write([]byte("\n")); err != nil {
 		return err
+	} else if n != 1 {
+		return io.ErrShortWrite
 	}
 	if err := r.writer.Flush(); err != nil {
 		return err
 	}
-	r.notifyObserver(e)
+	if notify {
+		r.notifyObserver(e)
+	}
 	return nil
+}
+
+func (r *Recorder) lastEntryOffsetLocked(e Entry) int64 {
+	if r.file == nil {
+		return 0
+	}
+	info, err := r.file.Stat()
+	if err != nil {
+		return 0
+	}
+	data, err := json.Marshal(e)
+	if err != nil {
+		return 0
+	}
+	offset := info.Size() - int64(len(data)+1)
+	if offset < 0 {
+		return 0
+	}
+	return offset
 }
 
 func (r *Recorder) notifyObserver(e Entry) {
@@ -767,6 +994,7 @@ func (r *Recorder) closeFile() error {
 	if r.file == nil {
 		return nil
 	}
+	r.waitDurableForCurrentFileLocked()
 	if err := r.writer.Flush(); err != nil {
 		_ = r.file.Close()
 		r.file = nil
@@ -782,6 +1010,15 @@ func (r *Recorder) closeFile() error {
 // rotateFile closes the current file so the next write opens a new one.
 func (r *Recorder) rotateFile() error {
 	return r.closeFile()
+}
+
+func (r *Recorder) waitDurableForCurrentFileLocked() {
+	if r.durableCond == nil || r.file == nil {
+		return
+	}
+	for r.durablePending[r.fileGeneration] > 0 {
+		r.durableCond.Wait()
+	}
 }
 
 // ExpireOldFiles removes evidence files older than RetentionDays.

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/crypto/nacl/box"
@@ -158,6 +159,8 @@ type Recorder struct {
 	durableBatch   *durableBatch
 	durableSyncing bool
 	durablePending map[uint64]int
+
+	fsyncErrorsGated atomic.Uint64
 }
 
 // New creates a Recorder. The redactFn is used for DLP redaction (can be nil to skip).
@@ -242,6 +245,16 @@ func (r *Recorder) SetSyncForTest(syncFn func(*os.File) error) {
 		return
 	}
 	r.fileSync = syncFn
+}
+
+// FsyncErrorsGated returns the cumulative count of failed durable sync batches.
+// It counts File.Sync failures, not the number of callers blocked by one batch.
+// Nil and no-op recorders report zero.
+func (r *Recorder) FsyncErrorsGated() uint64 {
+	if r == nil || r.nop {
+		return 0
+	}
+	return r.fsyncErrorsGated.Load()
 }
 
 // Dir returns the recorder evidence directory. Empty for nil or no-op recorders.
@@ -527,6 +540,9 @@ func (r *Recorder) runDurabilitySync(batch *durableBatch) {
 
 		r.mu.Lock()
 		batch.err = err
+		if err != nil {
+			r.fsyncErrorsGated.Add(1)
+		}
 		if syncStarted {
 			r.durableSyncing = false
 		}

--- a/internal/replaycapture/allowlist.go
+++ b/internal/replaycapture/allowlist.go
@@ -65,6 +65,10 @@ var safeRequestIDRE = regexp.MustCompile(`^req-[0-9]+$`)
 // packet gate still constrains the shape so arbitrary strings cannot publish.
 var safeRunNonceRE = regexp.MustCompile(`^[0-9a-f]{32}$`)
 
+var safeSessionOpenGenesisRE = regexp.MustCompile(`^g1:[0-9a-f]{64}$`)
+
+var safeSignerEpochRE = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
 // secretShapeRE is a backstop: if any of these shapes survive into a target or
 // pattern, redaction-before-sign failed and the artifact must not publish. This
 // is defense-in-depth behind the emitter's pre-sign sanitizer.
@@ -85,6 +89,9 @@ func ValidateReceiptPublicSafe(ar receipt.ActionRecord) error {
 	}
 	if _, ok := allowedActors[ar.Actor]; !ok {
 		return fmt.Errorf("%w: actor %q not in lab allowlist", errAllowlist, ar.Actor)
+	}
+	if ar.SessionControl != nil {
+		return validatePublicSessionOpen(ar)
 	}
 
 	// Target host must be synthetic / reserved / documentation-space.
@@ -124,6 +131,48 @@ func ValidateReceiptPublicSafe(ar receipt.ActionRecord) error {
 	// contract/manifest identity, jurisdiction, intent, or data-class labels.
 	// None of these are populated in the synthetic lab; a non-empty value means
 	// an unexpected code path leaked context.
+	return validateDisallowedEmpty(ar)
+}
+
+func validatePublicSessionOpen(ar receipt.ActionRecord) error {
+	if ar.Target != "pipelock://session/open" {
+		return fmt.Errorf("%w: session_open target %q is not the expected control target", errAllowlist, ar.Target)
+	}
+	if ar.SessionControl.Kind != receipt.SessionControlOpen || ar.SessionControl.Open == nil ||
+		ar.SessionControl.Heartbeat != nil || ar.SessionControl.Close != nil {
+		return fmt.Errorf("%w: only session_open control receipts are public-safe", errAllowlist)
+	}
+	open := ar.SessionControl.Open
+	if ar.RunNonce == "" || open.RunNonce != ar.RunNonce || !safeRunNonceRE.MatchString(ar.RunNonce) {
+		return fmt.Errorf("%w: session_open run_nonce is not the expected nonce shape", errAllowlist)
+	}
+	if !safeRunNonceRE.MatchString(open.OpenNonce) {
+		return fmt.Errorf("%w: session_open open_nonce is not the expected nonce shape", errAllowlist)
+	}
+	if open.RecorderSession != "proxy" {
+		return fmt.Errorf("%w: session_open recorder_session %q is not public-safe", errAllowlist, open.RecorderSession)
+	}
+	if !strings.HasPrefix(open.PolicyHash, policyHashLabelPrefix) {
+		return fmt.Errorf("%w: session_open policy_hash %q is not labeled", errAllowlist, open.PolicyHash)
+	}
+	if !safeSignerEpochRE.MatchString(open.SignerKeyEpoch) {
+		return fmt.Errorf("%w: session_open signer_key_epoch is not a hex public key", errAllowlist)
+	}
+	if open.HeartbeatSeconds != 0 {
+		return fmt.Errorf("%w: session_open heartbeat_seconds = %d, want 0 for this build", errAllowlist, open.HeartbeatSeconds)
+	}
+	if open.ChainOpenSeq != ar.ChainSeq {
+		return fmt.Errorf("%w: session_open chain_open_seq does not match chain_seq", errAllowlist)
+	}
+	if open.GenesisHash != ar.ChainPrevHash || !safeSessionOpenGenesisRE.MatchString(open.GenesisHash) {
+		return fmt.Errorf("%w: session_open genesis hash is not the expected g1 shape", errAllowlist)
+	}
+	if open.PriorChainHead != "" || open.PriorChainSeq != 0 ||
+		open.GenesisAnchorHead != "" || open.GenesisAnchorLog != "" ||
+		open.PostureCapsuleSHA256 != "" || open.PostureSignerKeyID != "" ||
+		open.ContainmentNonce != "" || open.ContainedUID != "" {
+		return fmt.Errorf("%w: session_open carries unsupported public-gallery binding fields", errAllowlist)
+	}
 	return validateDisallowedEmpty(ar)
 }
 

--- a/internal/replaycapture/allowlist_test.go
+++ b/internal/replaycapture/allowlist_test.go
@@ -168,6 +168,7 @@ func TestValidateReceiptPublicSafe_ActionRecordFieldCoverage(t *testing.T) {
 		"ChainSeq":              {},
 		"RunNonce":              {},
 		"KeyTransition":         {},
+		"SessionControl":        {},
 		"Venue":                 {},
 		"Jurisdiction":          {},
 		"RulebookID":            {},

--- a/internal/replaycapture/assemble.go
+++ b/internal/replaycapture/assemble.go
@@ -159,6 +159,9 @@ func summarize(receipts []receipt.Receipt) auditpacket.Summary {
 		if ar.Layer != "" {
 			layers[ar.Layer]++
 		}
+		if ar.SessionControl != nil {
+			continue
+		}
 		if h := hostOf(ar.Target); h != "" {
 			hosts = append(hosts, h)
 		}

--- a/internal/replaycapture/capture.go
+++ b/internal/replaycapture/capture.go
@@ -150,6 +150,9 @@ func (e *Engine) Capture(s Scenario) (*CapturedScenario, error) {
 	if emitter == nil {
 		return nil, fmt.Errorf("scenario %s: emitter construction failed", s.ID)
 	}
+	if err := emitter.EmitSessionOpen(); err != nil {
+		return nil, fmt.Errorf("scenario %s: session_open receipt: %w", s.ID, err)
+	}
 
 	p, err := proxy.New(cfg, audit.NewNop(), sc, metrics.New(),
 		proxy.WithRecorder(rec),

--- a/internal/replaycapture/capture.go
+++ b/internal/replaycapture/capture.go
@@ -45,7 +45,12 @@ const policyHashLabelPrefix = "sha256:"
 // the synthetic AWS example key is detected. Public-rule-id-by-construction.
 const awsKeyPatternName = "AWS Access Key ID"
 
-var afterEarlyRecorderCloseForTest func()
+var (
+	afterEarlyRecorderCloseForTest  func()
+	afterRecorderConstructedForTest func(*recorder.Recorder)
+	beforeProxyConstructedForTest   func(*config.Config)
+	beforeDriveScenarioForTest      func(*Scenario)
+)
 
 // CapturedScenario is the genuine result of driving one scenario through a real
 // Pipelock proxy: the signed receipt chain plus the metadata needed to assemble
@@ -152,6 +157,9 @@ func (e *Engine) Capture(s Scenario) (_ *CapturedScenario, err error) {
 			}
 		}
 	}()
+	if afterRecorderConstructedForTest != nil {
+		afterRecorderConstructedForTest(rec)
+	}
 
 	policyHash := configHash(cfg)
 	emitter := receipt.NewEmitter(receipt.EmitterConfig{
@@ -168,6 +176,9 @@ func (e *Engine) Capture(s Scenario) (_ *CapturedScenario, err error) {
 		return nil, fmt.Errorf("scenario %s: session_open receipt: %w", s.ID, err)
 	}
 
+	if beforeProxyConstructedForTest != nil {
+		beforeProxyConstructedForTest(cfg)
+	}
 	p, err := proxy.New(cfg, audit.NewNop(), sc, metrics.New(),
 		proxy.WithRecorder(rec),
 		proxy.WithReceiptEmitter(emitter),
@@ -180,6 +191,9 @@ func (e *Engine) Capture(s Scenario) (_ *CapturedScenario, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), captureTimeout)
 	defer cancel()
 
+	if beforeDriveScenarioForTest != nil {
+		beforeDriveScenarioForTest(&s)
+	}
 	if err := driveScenario(ctx, s, p.Handler()); err != nil {
 		return nil, fmt.Errorf("scenario %s: drive: %w", s.ID, err)
 	}

--- a/internal/replaycapture/capture.go
+++ b/internal/replaycapture/capture.go
@@ -45,6 +45,8 @@ const policyHashLabelPrefix = "sha256:"
 // the synthetic AWS example key is detected. Public-rule-id-by-construction.
 const awsKeyPatternName = "AWS Access Key ID"
 
+var afterEarlyRecorderCloseForTest func()
+
 // CapturedScenario is the genuine result of driving one scenario through a real
 // Pipelock proxy: the signed receipt chain plus the metadata needed to assemble
 // an Audit Packet and a replay manifest.
@@ -145,6 +147,9 @@ func (e *Engine) Capture(s Scenario) (_ *CapturedScenario, err error) {
 	defer func() {
 		if err != nil && !recClosed {
 			_ = rec.Close()
+			if afterEarlyRecorderCloseForTest != nil {
+				afterEarlyRecorderCloseForTest()
+			}
 		}
 	}()
 

--- a/internal/replaycapture/capture.go
+++ b/internal/replaycapture/capture.go
@@ -113,7 +113,7 @@ func (e *Engine) PublicKeyHex() string { return e.pubKeyHex }
 // Capture drives one scenario's synthetic request(s) through a real proxy and
 // returns the captured, signed receipt chain. The verdict comes entirely from
 // the real scanner pipeline; nothing here simulates a decision.
-func (e *Engine) Capture(s Scenario) (*CapturedScenario, error) {
+func (e *Engine) Capture(s Scenario) (_ *CapturedScenario, err error) {
 	evidenceDir := filepath.Join(e.workDir, s.ID)
 	if err := os.MkdirAll(evidenceDir, 0o750); err != nil {
 		return nil, fmt.Errorf("scenario %s: evidence dir: %w", s.ID, err)
@@ -138,6 +138,15 @@ func (e *Engine) Capture(s Scenario) (*CapturedScenario, error) {
 	if err != nil {
 		return nil, fmt.Errorf("scenario %s: recorder: %w", s.ID, err)
 	}
+	// Close the recorder on any early-error return before it is closed on the
+	// success path below; without this, a failure after construction (emitter,
+	// session_open, proxy, or drive) leaks the recorder's open file handle.
+	recClosed := false
+	defer func() {
+		if err != nil && !recClosed {
+			_ = rec.Close()
+		}
+	}()
 
 	policyHash := configHash(cfg)
 	emitter := receipt.NewEmitter(receipt.EmitterConfig{
@@ -170,7 +179,8 @@ func (e *Engine) Capture(s Scenario) (*CapturedScenario, error) {
 		return nil, fmt.Errorf("scenario %s: drive: %w", s.ID, err)
 	}
 
-	if err := rec.Close(); err != nil {
+	recClosed = true
+	if err = rec.Close(); err != nil {
 		return nil, fmt.Errorf("scenario %s: recorder close: %w", s.ID, err)
 	}
 

--- a/internal/replaycapture/capture_test.go
+++ b/internal/replaycapture/capture_test.go
@@ -6,14 +6,17 @@ package replaycapture
 import (
 	"context"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/proxy"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
@@ -120,29 +123,77 @@ func TestCapture_AllScenarios(t *testing.T) {
 }
 
 func TestCapture_EarlyErrorAfterRecorderConstructionClosesRecorder(t *testing.T) {
-	eng := newTestEngine(t)
-	eng.privKey = nil
-
-	closed := make(chan struct{}, 1)
-	afterEarlyRecorderCloseForTest = func() {
-		closed <- struct{}{}
+	cases := map[string]struct {
+		configure func(*Engine)
+		wantErr   string
+	}{
+		"emitter construction": {
+			configure: func(eng *Engine) {
+				eng.privKey = nil
+			},
+			wantErr: "emitter construction failed",
+		},
+		"session open": {
+			configure: func(_ *Engine) {
+				afterRecorderConstructedForTest = func(rec *recorder.Recorder) {
+					_ = rec.Close()
+				}
+			},
+			wantErr: "session_open receipt",
+		},
+		"proxy construction": {
+			configure: func(_ *Engine) {
+				beforeProxyConstructedForTest = func(cfg *config.Config) {
+					cfg.MediationEnvelope.Enabled = true
+					cfg.MediationEnvelope.Sign = true
+					cfg.MediationEnvelope.SigningKeyPath = filepath.Join(t.TempDir(), "missing-envelope.key")
+				}
+			},
+			wantErr: "proxy:",
+		},
+		"drive": {
+			configure: func(_ *Engine) {
+				beforeDriveScenarioForTest = func(s *Scenario) {
+					s.ID = "unknown-after-proxy"
+				}
+			},
+			wantErr: "drive:",
+		},
 	}
-	t.Cleanup(func() {
-		afterEarlyRecorderCloseForTest = nil
-	})
 
-	_, err := eng.Capture(DefaultScenarios()[0])
-	if err == nil {
-		t.Fatal("Capture unexpectedly succeeded with missing private key")
-	}
-	if !strings.Contains(err.Error(), "emitter construction failed") {
-		t.Fatalf("Capture error = %q, want emitter construction failure", err)
-	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			afterRecorderConstructedForTest = nil
+			beforeProxyConstructedForTest = nil
+			beforeDriveScenarioForTest = nil
+			closed := make(chan struct{}, 1)
+			afterEarlyRecorderCloseForTest = func() {
+				closed <- struct{}{}
+			}
+			t.Cleanup(func() {
+				afterEarlyRecorderCloseForTest = nil
+				afterRecorderConstructedForTest = nil
+				beforeProxyConstructedForTest = nil
+				beforeDriveScenarioForTest = nil
+			})
 
-	select {
-	case <-closed:
-	case <-time.After(5 * time.Second):
-		t.Fatal("recorder close hook was not invoked on early Capture error")
+			eng := newTestEngine(t)
+			tc.configure(eng)
+
+			_, err := eng.Capture(DefaultScenarios()[0])
+			if err == nil {
+				t.Fatalf("Capture unexpectedly succeeded for %s", name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Capture error = %q, want %q", err, tc.wantErr)
+			}
+
+			select {
+			case <-closed:
+			case <-time.After(5 * time.Second):
+				t.Fatal("recorder close hook was not invoked on early Capture error")
+			}
+		})
 	}
 }
 

--- a/internal/replaycapture/capture_test.go
+++ b/internal/replaycapture/capture_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
@@ -115,6 +116,33 @@ func TestCapture_AllScenarios(t *testing.T) {
 				s.ID, got.ReceiptCount, decisive.ActionRecord.Verdict,
 				decisive.ActionRecord.Layer, decisive.ActionRecord.Pattern, decisive.ActionRecord.Target)
 		})
+	}
+}
+
+func TestCapture_EarlyErrorAfterRecorderConstructionClosesRecorder(t *testing.T) {
+	eng := newTestEngine(t)
+	eng.privKey = nil
+
+	closed := make(chan struct{}, 1)
+	afterEarlyRecorderCloseForTest = func() {
+		closed <- struct{}{}
+	}
+	t.Cleanup(func() {
+		afterEarlyRecorderCloseForTest = nil
+	})
+
+	_, err := eng.Capture(DefaultScenarios()[0])
+	if err == nil {
+		t.Fatal("Capture unexpectedly succeeded with missing private key")
+	}
+	if !strings.Contains(err.Error(), "emitter construction failed") {
+		t.Fatalf("Capture error = %q, want emitter construction failure", err)
+	}
+
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("recorder close hook was not invoked on early Capture error")
 	}
 }
 

--- a/scripts/config-consumption-allowlist.txt
+++ b/scripts/config-consumption-allowlist.txt
@@ -26,6 +26,7 @@ MaxImageBytes  # (A) MediaPolicy.EffectiveMaxImageBytes() schema_receiver_method
 SaltSource  # (A) Learn normalizer (normalize.go:16) resolves it; contract/privacy/salt.go:58 + cli/contain/config_migrate.go consume the resolved value
 MinimumSignatures  # (A) LearnLock.EffectiveMinimumSignatures() schema.go:1806 -> mcp/contractgate.go:58, proxy/contractgate.go:151
 TrustedMCPServers  # (A) Config.TaintTrustsMCPServer() schema.go:1501 -> runtime/server_lifecycle.go:718, runtime/mcp.go:233, diag/doctor_config_semantics.go:220
+HeartbeatInterval  # (A) FlightRecorder.HeartbeatIntervalDuration() schema.go:1440 -> runtime/server_lifecycle.go:332, runtime/mcp.go:1032
 
 # --- (B) validation-only by design ---
 MatchAbsPath  # (B) enforces absolute-path constraint on RedirectProfile.Exec[0] at validate.go:816; nothing to read after validation passes


### PR DESCRIPTION
## What changed

This adds the durable receipt-evidence lifecycle and an honest completeness verifier, so a covered process run leaves signed, offline-verifiable evidence of what the boundary decided, with no silent gaps.

Session lifecycle: every process run now signs a session_open before egress. On a fresh chain that open is the bound genesis, so the first receipt's chain_prev_hash is a length-framed g1:<sha256> over the signed open, replacing the literal "genesis" sentinel and making the run window provable from the chain itself. A periodic signed heartbeat and a signed session_close bracket the run, so a crash mid-run leaves a signed floor rather than silence.

Durability: the flight recorder gains a fail-closed durability gate. A durable write returns only after File.Sync confirms the bytes, and a sync failure blocks egress with a detectable gap rather than forking the chain. Every required-receipt allow gate emits a durable intent receipt before egress across all transports (fetch, forward, CONNECT tunnel and intercept, WebSocket, reverse, MCP) and denies fail-closed on a durability error. Each egress is paired with a best-effort post-egress outcome receipt correlated to its intent by action id.

Completeness verifier: a new internal/evidence/completeness library and a `pipelock-verifier completeness` command grade a receipt chain with a deliberately non-green vocabulary of LIMITED, BROKEN, or UNVERIFIED, never a green COMPLETE. The best result is LIMITED, because Pipelock can bound the mediated egress it observed but cannot prove the agent had no egress path outside that boundary. A forged chain is BROKEN rather than UNVERIFIED; an intent without a matching outcome, a session_close whose sealed totals contradict the chain, and any record after a close are all fail-closed.

## Notes

First of three stacked evidence-layer PRs. This one is the receipt lifecycle plus the completeness verifier. The follow-ups add durable intent on intercept inner requests, and the cross-language verifier ports that let non-Go clients verify the new g1 format. All three ship before the next tag, because the g1 emission introduced here is not verifiable by the released Rust, TypeScript, Python, or in-browser verifiers until the third PR lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `pipelock-verifier completeness` CLI command for bounded lifecycle completeness analysis with JSON/human output and defined exit codes.
  * Introduced signed session lifecycle receipts (open/heartbeat/close) plus periodic receipt heartbeats and clearer shutdown anchoring.
  * Enhanced “require receipts” mode to emit durable intent/outcome receipt pairs across MCP, proxy, reverse proxy, and WebSocket flows.
* **Bug Fixes**
  * Improved session/open and chain-lifecycle ordering, completeness verdicting, and fail-closed behavior when required receipts can’t be emitted.
* **Tests**
  * Expanded integration coverage for completeness, receipt/session lifecycle, durability, chain integrity, and required-receipts ordering/output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->