### PR TITLE
ci: bump pinned Go toolchains to patched releases for govulncheck

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -325,14 +325,16 @@ jobs:
         with:
           # Pin the exact patched release. govulncheck analyzes the active
           # toolchain's stdlib (go env GOVERSION), so the setup-go version is the
-          # lever, not the go.mod directive. go1.26.4 (2026-05-29) fixes
-          # GO-2026-5039 net/textproto + GO-2026-5037 crypto/x509, but it is not
-          # yet in the actions/go-versions manifest, so a float to '1.26' resolves
-          # to the stale 1.26.3 and the scan stays red. An EXACT version makes
-          # setup-go fall back to a direct download from the official Go
-          # distribution, bypassing the manifest. Revert to '1.26' + check-latest
-          # for steady-state self-healing once the manifest includes 1.26.4.
-          go-version: '1.26.4'
+          # lever, not the go.mod directive. go1.26.5 (2026-07-07) fixes
+          # GO-2026-5856 crypto/tls + GO-2026-4970 os after go1.26.4 fixed
+          # GO-2026-5039 net/textproto + GO-2026-5037 crypto/x509. A float to
+          # '1.26' can lag on the actions/go-versions manifest, so the scan stays
+          # red until the manifest publishes the patched toolchain. An EXACT
+          # version makes setup-go fall back to a direct download from the
+          # official Go distribution, bypassing the manifest. Revert to '1.26'
+          # + check-latest for steady-state self-healing once the manifest
+          # includes 1.26.5.
+          go-version: '1.26.5'
           check-latest: true
 
       - name: Verify Go version
@@ -341,7 +343,7 @@ jobs:
         run: |
           got="$(go env GOVERSION)"
           echo "GOVERSION=$got"
-          test "$got" = "go1.26.4"
+          test "$got" = "go1.26.5"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,14 +22,14 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
           check-latest: true
 
       - name: Verify Go version
         run: |
           got="$(go env GOVERSION)"
           echo "GOVERSION=$got"
-          test "$got" = "go1.25.11"
+          test "$got" = "go1.25.12"
 
       - name: Verify dependencies
         run: go mod verify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal image size
-FROM golang:1.26-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14 AS builder
+FROM golang:1.26.5-alpine@sha256:99e12cfb19b753915f9b9fdc5a99f1869a24a69d3a0955832d5702e7fa68f1be AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./


### PR DESCRIPTION
## What changed

Four Go standard-library vulnerabilities (GO-2026-5856 `crypto/tls`, GO-2026-5039 `net/textproto`, GO-2026-5037 `crypto/x509`, GO-2026-4970 `os`) were published in the 2026-07-07 security patch set. The govulncheck CI job pins an exact Go toolchain because it analyzes the active toolchain's stdlib, and its previous pin (go1.26.4) predates the `crypto/tls` and `os` fixes, so the scan went red on main and every open PR.

This bumps the govulncheck job to go1.26.5 and the release build to go1.25.12, the patched releases that clear all four, and updates the version assertions and the local Docker builder image to match. `govulncheck ./...` reports no called vulnerabilities under both toolchains. The floating test-matrix versions and the `go.mod` language-version directive are unchanged, so this only moves the exact-pinned toolchains that build or scan shipping artifacts. A single uncalled dependency-module vulnerability remains reported (govulncheck exits 0) and is tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain used in CI and release workflows to newer patched versions.
  * Aligned version checks in automation to the updated Go releases.
  * Refreshed the build environment to use the latest pinned Go 1.26.5 image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->