### PR TITLE
harden(receipt): fail-closed receipt-emission completeness across MCP, proxy, and reverse

### DIFF
--- a/internal/mcp/pipeline_decision.go
+++ b/internal/mcp/pipeline_decision.go
@@ -154,10 +154,8 @@ func EmitMCPDecision(
 		return outbound, escalateErr
 	}
 	if v1Emitted && v2Emitter != nil {
-		if v2Decision, ok := mcpV2DecisionFromReceipt(d.Receipt); ok {
-			if v2Err := v2Emitter.Emit(v2Decision); v2Err != nil && err == nil {
-				err = fmt.Errorf("%w: %w", errMCPV2ReceiptEmit, v2Err)
-			}
+		if v2Err := emitMCPV2Decision(v2Emitter, d.Receipt, receiptRequired); v2Err != nil && err == nil {
+			err = v2Err
 		}
 	}
 	if done, escalateErr := escalateReceiptError(); done {
@@ -173,6 +171,24 @@ func EmitMCPDecision(
 	}
 
 	return outbound, err
+}
+
+func emitMCPV2Decision(v2Emitter *proxydecision.Emitter, opts receipt.EmitOpts, required bool) error {
+	if v2Emitter == nil {
+		return nil
+	}
+	v2Decision, ok := mcpV2DecisionFromReceipt(opts)
+	if !ok {
+		if required {
+			return fmt.Errorf("%w: could not derive v2 decision action_id=%s transport=%s target=%q",
+				errMCPV2ReceiptEmit, opts.ActionID, opts.Transport, opts.Target)
+		}
+		return nil
+	}
+	if err := v2Emitter.Emit(v2Decision); err != nil {
+		return fmt.Errorf("%w: %w", errMCPV2ReceiptEmit, err)
+	}
+	return nil
 }
 
 func emitMCPOutcomeReceipt(

--- a/internal/mcp/pipeline_decision.go
+++ b/internal/mcp/pipeline_decision.go
@@ -152,6 +152,12 @@ func EmitMCPDecision(
 			}
 		}
 	}
+	if receiptRequired && err != nil && !errors.Is(err, ErrReceiptRequired) {
+		err = fmt.Errorf("%w: %w", ErrReceiptRequired, err)
+	}
+	if receiptRequired && err != nil {
+		return outbound, err
+	}
 
 	if envelopeEmitter != nil && d.Envelope != nil && d.InboundMsg != nil {
 		var envelopeErr error

--- a/internal/mcp/pipeline_decision.go
+++ b/internal/mcp/pipeline_decision.go
@@ -16,6 +16,8 @@ import (
 
 var ErrReceiptRequired = errors.New("receipt required but not emitted")
 
+var errMCPV2ReceiptEmit = errors.New("mcp v2 proxydecision receipt emit failed")
+
 // MCPDecision bundles the per-decision state a gate in the inbound
 // MCP pipeline needs to emit. Today each gate calls
 // receiptEmitter.Emit(...) and (for allow/warn tool calls) the
@@ -154,7 +156,7 @@ func EmitMCPDecision(
 	if v1Emitted && v2Emitter != nil {
 		if v2Decision, ok := mcpV2DecisionFromReceipt(d.Receipt); ok {
 			if v2Err := v2Emitter.Emit(v2Decision); v2Err != nil && err == nil {
-				err = v2Err
+				err = fmt.Errorf("%w: %w", errMCPV2ReceiptEmit, v2Err)
 			}
 		}
 	}

--- a/internal/mcp/pipeline_decision.go
+++ b/internal/mcp/pipeline_decision.go
@@ -97,6 +97,15 @@ func EmitMCPDecision(
 
 	v1Emitted := false
 	receiptRequired := d.RequireReceipt
+	escalateReceiptError := func() (bool, error) {
+		if !receiptRequired || err == nil {
+			return false, nil
+		}
+		if !errors.Is(err, ErrReceiptRequired) {
+			err = fmt.Errorf("%w: %w", ErrReceiptRequired, err)
+		}
+		return true, err
+	}
 	// A forwardable verdict is one whose request or response actually egresses to
 	// its peer: allow, warn, and forward carry a request upstream, and strip
 	// writes the redacted response back to the client. redirect goes to an
@@ -139,11 +148,8 @@ func EmitMCPDecision(
 		// RequireReceipt gate below upgrades errors to fail-closed before
 		// envelope mutation.
 	}
-	if receiptRequired && err != nil && !errors.Is(err, ErrReceiptRequired) {
-		err = fmt.Errorf("%w: %w", ErrReceiptRequired, err)
-	}
-	if receiptRequired && err != nil {
-		return outbound, err
+	if done, escalateErr := escalateReceiptError(); done {
+		return outbound, escalateErr
 	}
 	if v1Emitted && v2Emitter != nil {
 		if v2Decision, ok := mcpV2DecisionFromReceipt(d.Receipt); ok {
@@ -152,11 +158,8 @@ func EmitMCPDecision(
 			}
 		}
 	}
-	if receiptRequired && err != nil && !errors.Is(err, ErrReceiptRequired) {
-		err = fmt.Errorf("%w: %w", ErrReceiptRequired, err)
-	}
-	if receiptRequired && err != nil {
-		return outbound, err
+	if done, escalateErr := escalateReceiptError(); done {
+		return outbound, escalateErr
 	}
 
 	if envelopeEmitter != nil && d.Envelope != nil && d.InboundMsg != nil {

--- a/internal/mcp/pipeline_decision_test.go
+++ b/internal/mcp/pipeline_decision_test.go
@@ -556,6 +556,34 @@ func TestEmitMCPDecision_RequiredV2EmitErrorFailsClosed(t *testing.T) {
 	}
 }
 
+func TestEmitMCPV2Decision_RequiredDerivationFailureFailsClosed(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder: failingMCPV2Recorder{},
+		Signer:   proxydecision.NewKeyedSigner(priv),
+	})
+	if v2 == nil {
+		t.Fatal("expected v2 emitter")
+	}
+
+	err = emitMCPV2Decision(v2, receipt.EmitOpts{
+		ActionID:  "mcp-required-missing-target",
+		Verdict:   config.ActionAllow,
+		Transport: transportMCPStdio,
+		// Target intentionally empty: v1 currently rejects this too, but the
+		// required v2 helper must not silently skip configured v2 emission.
+	}, true)
+	if !errors.Is(err, errMCPV2ReceiptEmit) {
+		t.Fatalf("emitMCPV2Decision error = %v, want errMCPV2ReceiptEmit", err)
+	}
+	if !strings.Contains(err.Error(), "could not derive v2 decision") {
+		t.Fatalf("emitMCPV2Decision error = %v, want derivation failure detail", err)
+	}
+}
+
 func TestEmitMCPDecision_OptionalV2EmitErrorStillInjectsEnvelope(t *testing.T) {
 	h := newMCPDecisionReceiptHarness(t)
 	_, priv, err := ed25519.GenerateKey(rand.Reader)

--- a/internal/mcp/pipeline_decision_test.go
+++ b/internal/mcp/pipeline_decision_test.go
@@ -515,6 +515,88 @@ func TestEmitMCPDecision_V2EmitErrorSurfacesAfterV1(t *testing.T) {
 	}
 }
 
+func TestEmitMCPDecision_RequiredV2EmitErrorFailsClosed(t *testing.T) {
+	h := newMCPDecisionReceiptHarness(t)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder: failingMCPV2Recorder{},
+		Signer:   proxydecision.NewKeyedSigner(priv),
+	})
+	if v2 == nil {
+		t.Fatal("expected v2 emitter")
+	}
+
+	_, err = EmitMCPDecision(h.v1, v2, nil, MCPDecision{
+		Receipt: receipt.EmitOpts{
+			ActionID:   "mcp-v2-required-error",
+			Verdict:    config.ActionAllow,
+			Transport:  transportMCPStdio,
+			Target:     "fetch",
+			MCPMethod:  methodToolsCall,
+			ToolName:   "fetch",
+			PolicyHash: mcpTestPolicyHash,
+		},
+		RequireReceipt: true,
+	})
+	if !errors.Is(err, ErrReceiptRequired) {
+		t.Fatalf("EmitMCPDecision error = %v, want ErrReceiptRequired", err)
+	}
+	if !strings.Contains(err.Error(), "v2 record failed") {
+		t.Fatalf("EmitMCPDecision error = %v, want v2 record failure", err)
+	}
+	receipts := decisionReceiptLogFor(t, h.dir)
+	if len(receipts) != 1 {
+		t.Fatalf("got %d v1 receipts, want 1", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("decision_phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+}
+
+func TestEmitMCPDecision_OptionalV2EmitErrorStillInjectsEnvelope(t *testing.T) {
+	h := newMCPDecisionReceiptHarness(t)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder: failingMCPV2Recorder{},
+		Signer:   proxydecision.NewKeyedSigner(priv),
+	})
+	envEmitter := envelope.NewEmitter(envelope.EmitterConfig{ConfigHash: "policy-h"})
+	inbound := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fetch","arguments":{}}}`)
+
+	out, err := EmitMCPDecision(h.v1, v2, envEmitter, MCPDecision{
+		Receipt: receipt.EmitOpts{
+			ActionID:   "mcp-v2-optional-error",
+			Verdict:    config.ActionAllow,
+			Transport:  transportMCPStdio,
+			Target:     "fetch",
+			MCPMethod:  methodToolsCall,
+			ToolName:   "fetch",
+			PolicyHash: mcpTestPolicyHash,
+		},
+		Envelope: &envelope.BuildOpts{
+			ActionID: "mcp-v2-optional-error",
+			Action:   "tool_call",
+			Verdict:  config.ActionAllow,
+		},
+		InboundMsg: inbound,
+	})
+	if err == nil || !strings.Contains(err.Error(), "v2 record failed") {
+		t.Fatalf("EmitMCPDecision error = %v, want surfaced v2 record failure", err)
+	}
+	if errors.Is(err, ErrReceiptRequired) {
+		t.Fatalf("optional v2 error = %v, must not be ErrReceiptRequired", err)
+	}
+	if bytes.Equal(out, inbound) || !strings.Contains(string(out), "com.pipelock/mediation") {
+		t.Fatalf("optional v2 failure did not preserve envelope injection: %s", out)
+	}
+}
+
 // TestMCPV2DecisionFromReceipt_SkipsEmptyTarget proves the helper refuses to
 // build a v2 payload without a target, mirroring the forward proxy's
 // v2DecisionFromOpts. The v2 emitter's validator requires a non-empty target,

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -681,6 +681,21 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 				outbound = blockResponseReason(verdict.ID, "receipt emission failed")
 				effectiveAction = config.ActionBlock
 				writeContext = "writing block response"
+				if _, blockEmitErr := EmitMCPDecision(receiptEmitter, v2ReceiptEmitter, nil, MCPDecision{
+					Receipt: opts.withReceiptPolicyHash(receipt.EmitOpts{
+						ActionID:  receipt.NewActionID(),
+						Verdict:   config.ActionBlock,
+						Transport: opts.Transport,
+						Target:    target,
+						RequestID: requestID,
+						Layer:     "receipt_emission_failed",
+						Pattern:   "mcp_response_scan receipt emission failed",
+						Severity:  config.SeverityHigh,
+					}),
+					RequireReceipt: true,
+				}); blockEmitErr != nil {
+					logReceiptEmitFailure(logW, blockEmitErr, true, config.ActionBlock)
+				}
 			}
 		}
 		if err := writer.WriteMessage(outbound); err != nil {

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -664,7 +664,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			pattern = names[0]
 		}
 		originalActionID := receipt.NewActionID()
-		if _, emitErr := EmitMCPDecision(receiptEmitter, v2ReceiptEmitter, nil, MCPDecision{
+		_, emitErr := EmitMCPDecision(receiptEmitter, v2ReceiptEmitter, nil, MCPDecision{
 			Receipt: opts.withReceiptPolicyHash(receipt.EmitOpts{
 				ActionID:  originalActionID,
 				Verdict:   effectiveAction,
@@ -676,24 +676,29 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 				Severity:  config.SeverityHigh,
 			}),
 			RequireReceipt: opts.requireReceipts() && effectiveAction != config.ActionBlock,
-		}); emitErr != nil {
+		})
+		originalReceiptPersisted := emitErr != nil && errors.Is(emitErr, errMCPV2ReceiptEmit)
+		if emitErr != nil {
 			logReceiptEmitFailure(logW, emitErr, opts.requireReceipts(), effectiveAction)
 			if opts.requireReceipts() && effectiveAction != config.ActionBlock {
 				outbound = blockResponseReason(verdict.ID, "receipt emission failed")
 				effectiveAction = config.ActionBlock
 				writeContext = "writing block response"
+				replacementOpts := opts.withReceiptPolicyHash(receipt.EmitOpts{
+					ActionID:  receipt.NewActionID(),
+					Verdict:   config.ActionBlock,
+					Transport: opts.Transport,
+					Target:    target,
+					RequestID: requestID,
+					Layer:     "receipt_emission_failed",
+					Pattern:   "mcp_response_scan receipt emission failed",
+					Severity:  config.SeverityHigh,
+				})
+				if originalReceiptPersisted {
+					replacementOpts.ParentActionID = originalActionID
+				}
 				if _, blockEmitErr := EmitMCPDecision(receiptEmitter, v2ReceiptEmitter, nil, MCPDecision{
-					Receipt: opts.withReceiptPolicyHash(receipt.EmitOpts{
-						ActionID:       receipt.NewActionID(),
-						ParentActionID: originalActionID,
-						Verdict:        config.ActionBlock,
-						Transport:      opts.Transport,
-						Target:         target,
-						RequestID:      requestID,
-						Layer:          "receipt_emission_failed",
-						Pattern:        "mcp_response_scan receipt emission failed",
-						Severity:       config.SeverityHigh,
-					}),
+					Receipt:        replacementOpts,
 					RequireReceipt: true,
 				}); blockEmitErr != nil {
 					logReceiptEmitFailure(logW, blockEmitErr, true, config.ActionBlock)

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -663,9 +663,10 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 		if len(names) > 0 {
 			pattern = names[0]
 		}
+		originalActionID := receipt.NewActionID()
 		if _, emitErr := EmitMCPDecision(receiptEmitter, v2ReceiptEmitter, nil, MCPDecision{
 			Receipt: opts.withReceiptPolicyHash(receipt.EmitOpts{
-				ActionID:  receipt.NewActionID(),
+				ActionID:  originalActionID,
 				Verdict:   effectiveAction,
 				Transport: opts.Transport,
 				Target:    target,
@@ -683,14 +684,15 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 				writeContext = "writing block response"
 				if _, blockEmitErr := EmitMCPDecision(receiptEmitter, v2ReceiptEmitter, nil, MCPDecision{
 					Receipt: opts.withReceiptPolicyHash(receipt.EmitOpts{
-						ActionID:  receipt.NewActionID(),
-						Verdict:   config.ActionBlock,
-						Transport: opts.Transport,
-						Target:    target,
-						RequestID: requestID,
-						Layer:     "receipt_emission_failed",
-						Pattern:   "mcp_response_scan receipt emission failed",
-						Severity:  config.SeverityHigh,
+						ActionID:       receipt.NewActionID(),
+						ParentActionID: originalActionID,
+						Verdict:        config.ActionBlock,
+						Transport:      opts.Transport,
+						Target:         target,
+						RequestID:      requestID,
+						Layer:          "receipt_emission_failed",
+						Pattern:        "mcp_response_scan receipt emission failed",
+						Severity:       config.SeverityHigh,
 					}),
 					RequireReceipt: true,
 				}); blockEmitErr != nil {

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -707,6 +708,62 @@ func TestForwardScanned_ResponseReceiptFailureEmitsReplacementBlockReceipt(t *te
 	}
 	if replacement.ActionRecord.ParentActionID != originalActionID {
 		t.Fatalf("replacement parent_action_id = %q, want original action_id %q", replacement.ActionRecord.ParentActionID, originalActionID)
+	}
+}
+
+func TestForwardScanned_ResponseReceiptFailureOmitsParentWhenOriginalNotDurable(t *testing.T) {
+	sc := testScannerWithAction(t, config.ActionWarn)
+	var out, log bytes.Buffer
+	emitter, rec, dir, _ := newReceiptTestHarness(t)
+	var syncCalls atomic.Int32
+	rec.SetSyncForTest(func(*os.File) error {
+		if syncCalls.Add(1) == 1 {
+			return errors.New("injected first durable sync failure")
+		}
+		return nil
+	})
+
+	tracker := NewRequestTracker()
+	tracker.Track(json.RawMessage(`42`))
+
+	found, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(injectionResponse+"\n")),
+		transport.NewStdioWriter(&out),
+		&log,
+		tracker,
+		MCPProxyOpts{
+			Scanner:         sc,
+			ReceiptEmitter:  emitter,
+			Transport:       transportMCPStdio,
+			RequireReceipts: true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if !found {
+		t.Fatal("expected injection detected")
+	}
+	if !strings.Contains(out.String(), "receipt emission failed") {
+		t.Fatalf("expected fail-closed receipt error response, got: %s", out.String())
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	receipts := readActionReceipts(t, dir)
+	var replacement receipt.Receipt
+	for _, rcpt := range receipts {
+		if rcpt.ActionRecord.Verdict == config.ActionBlock &&
+			rcpt.ActionRecord.Layer == "receipt_emission_failed" &&
+			strings.Contains(rcpt.ActionRecord.Pattern, "mcp_response_scan receipt emission failed") {
+			replacement = rcpt
+		}
+	}
+	if replacement.ActionRecord.ActionID == "" {
+		t.Fatalf("missing replacement block receipt in %d receipts", len(receipts))
+	}
+	if replacement.ActionRecord.ParentActionID != "" {
+		t.Fatalf("replacement parent_action_id = %q, want empty after original durable failure", replacement.ActionRecord.ParentActionID)
 	}
 }
 

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -687,16 +687,26 @@ func TestForwardScanned_ResponseReceiptFailureEmitsReplacementBlockReceipt(t *te
 		t.Fatalf("recorder.Close: %v", err)
 	}
 	receipts := readActionReceipts(t, dir)
-	var foundBlock bool
+	var originalActionID string
+	var replacement receipt.Receipt
 	for _, rcpt := range receipts {
+		if rcpt.ActionRecord.Layer == "mcp_response_scan" {
+			originalActionID = rcpt.ActionRecord.ActionID
+		}
 		if rcpt.ActionRecord.Verdict == config.ActionBlock &&
 			rcpt.ActionRecord.Layer == "receipt_emission_failed" &&
 			strings.Contains(rcpt.ActionRecord.Pattern, "mcp_response_scan receipt emission failed") {
-			foundBlock = true
+			replacement = rcpt
 		}
 	}
-	if !foundBlock {
+	if replacement.ActionRecord.ActionID == "" {
 		t.Fatalf("missing replacement block receipt in %d receipts", len(receipts))
+	}
+	if originalActionID == "" {
+		t.Fatalf("missing original mcp_response_scan receipt in %d receipts", len(receipts))
+	}
+	if replacement.ActionRecord.ParentActionID != originalActionID {
+		t.Fatalf("replacement parent_action_id = %q, want original action_id %q", replacement.ActionRecord.ParentActionID, originalActionID)
 	}
 }
 

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -6,6 +6,8 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -22,6 +24,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/hitl"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
@@ -636,6 +639,64 @@ func TestForwardScanned_StripRequireReceiptsDurabilityFailureBlocksResponse(t *t
 	}
 	if !strings.Contains(log.String(), "receipt emission failed") {
 		t.Fatalf("expected receipt failure log, got: %s", log.String())
+	}
+}
+
+func TestForwardScanned_ResponseReceiptFailureEmitsReplacementBlockReceipt(t *testing.T) {
+	sc := testScannerWithAction(t, config.ActionWarn)
+	var out, log bytes.Buffer
+	emitter, rec, dir, _ := newReceiptTestHarness(t)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder: failingMCPV2Recorder{},
+		Signer:   proxydecision.NewKeyedSigner(priv),
+	})
+
+	tracker := NewRequestTracker()
+	tracker.Track(json.RawMessage(`42`))
+
+	found, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(injectionResponse+"\n")),
+		transport.NewStdioWriter(&out),
+		&log,
+		tracker,
+		MCPProxyOpts{
+			Scanner:          sc,
+			ReceiptEmitter:   emitter,
+			V2ReceiptEmitter: v2,
+			Transport:        transportMCPStdio,
+			RequireReceipts:  true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if !found {
+		t.Fatal("expected injection detected")
+	}
+	if !strings.Contains(out.String(), "receipt emission failed") {
+		t.Fatalf("expected fail-closed receipt error response, got: %s", out.String())
+	}
+	if !strings.Contains(log.String(), "audit_gap=true") {
+		t.Fatalf("expected v2 block receipt audit-gap log, got: %s", log.String())
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	receipts := readActionReceipts(t, dir)
+	var foundBlock bool
+	for _, rcpt := range receipts {
+		if rcpt.ActionRecord.Verdict == config.ActionBlock &&
+			rcpt.ActionRecord.Layer == "receipt_emission_failed" &&
+			strings.Contains(rcpt.ActionRecord.Pattern, "mcp_response_scan receipt emission failed") {
+			foundBlock = true
+		}
+	}
+	if !foundBlock {
+		t.Fatalf("missing replacement block receipt in %d receipts", len(receipts))
 	}
 }
 

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -358,10 +358,8 @@ func emitMCPToolReceipt(opts mcpToolReceiptOpts) error {
 		logReceiptEmitFailure(opts.Log, err, opts.RequireReceipts, opts.Verdict)
 		// Only a failure of the authoritative v1 action receipt under
 		// RequireReceipt escalates to a block (ErrReceiptRequired). A
-		// best-effort emit failure (require off) or a v2-only failure
-		// stays non-blocking, preserving the default warn-and-forward
-		// posture and matching the forward proxy, which fails closed on
-		// v1 emission only.
+		// best-effort emit failure with require off stays non-blocking,
+		// preserving the default warn-and-forward posture.
 		if errors.Is(err, ErrReceiptRequired) {
 			return err
 		}

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -356,10 +356,10 @@ func emitMCPToolReceipt(opts mcpToolReceiptOpts) error {
 		RequireReceipt: opts.RequireReceipt,
 	}); err != nil {
 		logReceiptEmitFailure(opts.Log, err, opts.RequireReceipts, opts.Verdict)
-		// Only a failure of the authoritative v1 action receipt under
-		// RequireReceipt escalates to a block (ErrReceiptRequired). A
-		// best-effort emit failure with require off stays non-blocking,
-		// preserving the default warn-and-forward posture.
+		// RequireReceipt escalates v1 or v2 decision-receipt failures to a
+		// block (ErrReceiptRequired). A best-effort emit failure with require
+		// off stays non-blocking, preserving the default warn-and-forward
+		// posture.
 		if errors.Is(err, ErrReceiptRequired) {
 			return err
 		}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1697,6 +1697,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			emitForwardReceipt(forwardAllowReceipt)
 		}
 	}
+	responseBudgetTruncated := false
 
 	resp, err := p.client.Do(outReq)
 	if err != nil {
@@ -2436,10 +2437,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		if budgetRemaining >= 0 && written >= budgetRemaining {
 			reason := fmt.Sprintf("response truncated at byte budget: %d bytes written", written)
 			p.logger.LogAnomaly(actx, "budget_truncated", reason, 0)
-			outcomeStatus = strconv.Itoa(resp.StatusCode)
-			outcomeBytes = written
-			outcomeReason = "budget_truncated"
-			return
+			responseBudgetTruncated = true
 		}
 
 		duration := time.Since(start)
@@ -2449,6 +2447,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		outcomeStatus = strconv.Itoa(resp.StatusCode)
 		outcomeBytes = written
 		outcomeReason = "complete"
+		if responseBudgetTruncated {
+			outcomeReason = "budget_truncated"
+		}
 		if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 			recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
 		}
@@ -2476,10 +2477,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	if budgetRemaining >= 0 && written >= budgetRemaining {
 		reason := fmt.Sprintf("response truncated at byte budget: %d bytes written", written)
 		p.logger.LogAnomaly(actx, "budget_truncated", reason, 0)
-		outcomeStatus = strconv.Itoa(resp.StatusCode)
-		outcomeBytes = written
-		outcomeReason = "budget_truncated"
-		return
+		responseBudgetTruncated = true
 	}
 
 	duration := time.Since(start)
@@ -2489,6 +2487,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	outcomeStatus = strconv.Itoa(resp.StatusCode)
 	outcomeBytes = written
 	outcomeReason = "complete"
+	if responseBudgetTruncated {
+		outcomeReason = "budget_truncated"
+	}
 	if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 		recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
 	}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/certgen"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
@@ -678,6 +679,41 @@ func TestForwardProxy_RequireReceiptsSyncFailureBlocksBeforeEgress(t *testing.T)
 	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="durability",transport="forward"} 1`)
 }
 
+func TestForwardProxy_RequireReceiptsV2FailureBlocksBeforeEgress(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+		cfg.ResponseScanning.Enabled = false
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	p.receiptEmitterPtr.Store(rph.emitter)
+	p.v2EmitterPtr.Store(proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder:  failingProxyV2Recorder{},
+		Signer:    proxydecision.NewKeyedSigner(rph.priv),
+		Principal: "local",
+		Actor:     "pipelock",
+	}))
+
+	resp := doGet(t, forwardHTTPClient(t, proxyAddr), upstream.URL)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (required v2 receipt failure must block before egress)", got)
+	}
+	receipts := rph.findReceipts(t)
+	requireReceiptEmissionFailedLayer(t, receipts)
+	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="forward"} 1`)
+}
+
 func TestForwardProxy_RequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
 	var hits atomic.Int32
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -705,6 +741,55 @@ func TestForwardProxy_RequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t
 	}
 	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`)
 	assertMetricsContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="forward"} 1`)
+}
+
+func TestForwardProxy_RequireReceiptsOutcomeV2FailureEmitsGapMarker(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+		cfg.ResponseScanning.Enabled = false
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	p.receiptEmitterPtr.Store(rph.emitter)
+	p.v2EmitterPtr.Store(proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder:  &failAfterProxyV2Recorder{allowed: 1},
+		Signer:    proxydecision.NewKeyedSigner(rph.priv),
+		Principal: "local",
+		Actor:     "pipelock",
+	}))
+
+	resp := doGet(t, forwardHTTPClient(t, proxyAddr), upstream.URL)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream hits = %d, want 1", got)
+	}
+
+	testwait.For(t, 2*time.Second, func() bool {
+		for _, rcpt := range extractReceiptsFromDir(t, rph.dir) {
+			if rcpt.ActionRecord.Layer == receiptEmissionFailedLayer {
+				return true
+			}
+		}
+		return false
+	}, "forward outcome receipt failure marker")
+	receipts := rph.findReceipts(t)
+	marker := requireReceiptEmissionFailedLayer(t, receipts)
+	if !strings.Contains(marker.ActionRecord.Pattern, "outcome receipt emission failed") {
+		t.Fatalf("marker pattern = %q, want outcome receipt emission failed", marker.ActionRecord.Pattern)
+	}
 }
 
 func TestConnect_RequireReceiptsBlocksEmissionFailure(t *testing.T) {

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
+	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
@@ -48,6 +49,71 @@ type readerConn struct {
 
 func (c readerConn) Read(p []byte) (int, error) {
 	return c.Reader.Read(p)
+}
+
+type fixedBudgetEdition struct {
+	cfg    *config.Config
+	sc     *scanner.Scanner
+	budget edition.BudgetChecker
+}
+
+func (e fixedBudgetEdition) ResolveAgent(context.Context, *http.Request) (*edition.ResolvedAgent, edition.AgentIdentity) {
+	return &edition.ResolvedAgent{
+		Name:    edition.ProfileDefault,
+		Config:  e.cfg,
+		Scanner: e.sc,
+		Budget:  e.budget,
+	}, edition.AgentIdentity{Name: edition.ProfileDefault, Profile: edition.ProfileDefault}
+}
+
+func (e fixedBudgetEdition) LookupProfile(string) (*edition.ResolvedAgent, bool) {
+	return &edition.ResolvedAgent{
+		Name:    edition.ProfileDefault,
+		Config:  e.cfg,
+		Scanner: e.sc,
+		Budget:  e.budget,
+	}, true
+}
+
+func (fixedBudgetEdition) Reload(*config.Config, *scanner.Scanner) (edition.Edition, error) {
+	return nil, nil
+}
+
+func (fixedBudgetEdition) KnownProfiles() map[string]bool {
+	return map[string]bool{edition.ProfileDefault: true}
+}
+
+func (fixedBudgetEdition) Ports() map[string]string {
+	return nil
+}
+
+func (fixedBudgetEdition) Close() {}
+
+type fixedRemainingBudget struct {
+	remaining atomic.Int64
+}
+
+func newFixedRemainingBudget(remaining int64) *fixedRemainingBudget {
+	b := &fixedRemainingBudget{}
+	b.remaining.Store(remaining)
+	return b
+}
+
+func (b *fixedRemainingBudget) CheckAdmission(string) error {
+	return nil
+}
+
+func (b *fixedRemainingBudget) RecordBytes(n int64) error {
+	b.remaining.Add(-n)
+	return nil
+}
+
+func (b *fixedRemainingBudget) RecordRequest(string, int64) error {
+	return nil
+}
+
+func (b *fixedRemainingBudget) RemainingBytes() int64 {
+	return b.remaining.Load()
 }
 
 // setupForwardProxy creates a running pipelock proxy with forward_proxy enabled
@@ -962,6 +1028,55 @@ func TestForwardProxy_RequireReceiptsSuccessEmitsIntentOutcomePair(t *testing.T)
 	}
 	if !strings.Contains(receipts[1].ActionRecord.Pattern, "status=200") {
 		t.Fatalf("outcome pattern = %q, want status=200", receipts[1].ActionRecord.Pattern)
+	}
+}
+
+func TestForwardProxy_BudgetTruncatedResponseStillEmitsAllowReceipt(t *testing.T) {
+	const budgetBytes = 32
+	body := strings.Repeat("x", 128)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = false
+		cfg.ResponseScanning.Enabled = false
+	})
+	defer cleanup()
+	rph := newReceiptProxyHelper(t)
+	p.receiptEmitterPtr.Store(rph.emitter)
+	p.editionPtr.Store(&editionSnapshot{fixedBudgetEdition{
+		cfg:    p.cfgPtr.Load(),
+		sc:     p.scannerPtr.Load(),
+		budget: newFixedRemainingBudget(budgetBytes),
+	}})
+
+	resp := doGet(t, forwardHTTPClient(t, proxyAddr), upstream.URL)
+	defer func() { _ = resp.Body.Close() }()
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if len(got) != budgetBytes {
+		t.Fatalf("body length = %d, want budget-truncated %d", len(got), budgetBytes)
+	}
+
+	receipts := rph.findReceipts(t)
+	var allowCount int
+	for _, rcpt := range receipts {
+		if rcpt.ActionRecord.Verdict == config.ActionAllow &&
+			rcpt.ActionRecord.Transport == "forward" &&
+			rcpt.ActionRecord.DecisionPhase == "" {
+			allowCount++
+		}
+	}
+	if allowCount != 1 {
+		t.Fatalf("allow receipt count = %d, want 1 after budget-truncated egress (receipts: %d)", allowCount, len(receipts))
 	}
 }
 

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -790,6 +790,11 @@ func TestForwardProxy_RequireReceiptsOutcomeV2FailureEmitsGapMarker(t *testing.T
 	if !strings.Contains(marker.ActionRecord.Pattern, "outcome receipt emission failed") {
 		t.Fatalf("marker pattern = %q, want outcome receipt emission failed", marker.ActionRecord.Pattern)
 	}
+	if marker.ActionRecord.Verdict != config.ActionAllow {
+		t.Fatalf("marker verdict = %q, want %q for post-response outcome gap", marker.ActionRecord.Verdict, config.ActionAllow)
+	}
+	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsNotContain(t, p.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="forward"} 1`)
 }
 
 func TestConnect_RequireReceiptsBlocksEmissionFailure(t *testing.T) {

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -203,14 +203,12 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) error {
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}
-	// Dual-emit the v2 proxy_decision receipt. The atomic load is current at
-	// call time so long-lived tunnels pick up the post-reload emitter.
-	if err := emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
+	// Dual-emit the v2 proxy_decision receipt best-effort. The atomic load is
+	// current at call time so long-lived tunnels pick up the post-reload emitter.
+	_ = emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
 		recordV2ReceiptEmitFailure(ic.Proxy.metrics)
 		logV2EmitFailure(ic.Logger, opts, err)
-	}); err != nil {
-		return err
-	}
+	})
 	return nil
 }
 
@@ -260,7 +258,7 @@ func interceptEmitRequiredReceipt(ic *InterceptContext, opts receipt.EmitOpts) e
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}
-	if err := emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
+	if err := emitRequiredV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
 		recordV2ReceiptEmitFailure(ic.Proxy.metrics)
 		logV2EmitFailure(ic.Logger, opts, err)
 	}); err != nil {
@@ -280,7 +278,28 @@ func interceptEmitOutcomeReceipt(ic *InterceptContext, opts receipt.EmitOpts, ve
 	opts.Verdict = verdict
 	opts.Layer = receiptOutcomeLayer
 	opts.Pattern = receiptOutcomePattern(strconv.Itoa(status), bytesTransferred, reason)
-	_ = interceptEmitReceipt(ic, opts)
+	if ic.Proxy == nil {
+		return
+	}
+	if ic.Config != nil {
+		opts = withReceiptPolicyHash(opts, ic.Config.CanonicalPolicyHash())
+	}
+	ic.Proxy.reloadMu.RLock()
+	e := ic.Proxy.receiptEmitterPtr.Load()
+	ic.Proxy.reloadMu.RUnlock()
+	if e == nil {
+		return
+	}
+	if err := e.Emit(opts); err != nil {
+		ic.Proxy.logReceiptEmissionFailure(opts, err)
+		return
+	}
+	if err := emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
+		recordV2ReceiptEmitFailure(ic.Proxy.metrics)
+		logV2EmitFailure(ic.Logger, opts, err)
+	}); err != nil {
+		_ = ic.Proxy.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
+	}
 }
 
 func interceptReceiptMetrics(ic *InterceptContext) *metrics.Metrics {

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -205,11 +205,12 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) error {
 	}
 	// Dual-emit the v2 proxy_decision receipt. The atomic load is current at
 	// call time so long-lived tunnels pick up the post-reload emitter.
-	_ = emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
-		if ic.Logger != nil {
-			ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
-		}
-	})
+	if err := emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
+		recordV2ReceiptEmitFailure(ic.Proxy.metrics)
+		logV2EmitFailure(ic.Logger, opts, err)
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -259,11 +260,12 @@ func interceptEmitRequiredReceipt(ic *InterceptContext, opts receipt.EmitOpts) e
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}
-	_ = emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
-		if ic.Logger != nil {
-			ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
-		}
-	})
+	if err := emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
+		recordV2ReceiptEmitFailure(ic.Proxy.metrics)
+		logV2EmitFailure(ic.Logger, opts, err)
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -264,6 +264,9 @@ func interceptEmitRequiredReceipt(ic *InterceptContext, opts receipt.EmitOpts) e
 		recordV2ReceiptEmitFailure(ic.Proxy.metrics)
 		logV2EmitFailure(ic.Logger, opts, err)
 	}); err != nil {
+		if markerErr := ic.Proxy.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed", config.ActionBlock); markerErr != nil {
+			return errors.Join(err, markerErr)
+		}
 		return err
 	}
 	return nil

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -205,7 +205,7 @@ func interceptEmitReceipt(ic *InterceptContext, opts receipt.EmitOpts) error {
 	}
 	// Dual-emit the v2 proxy_decision receipt. The atomic load is current at
 	// call time so long-lived tunnels pick up the post-reload emitter.
-	emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
+	_ = emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
 		if ic.Logger != nil {
 			ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
 		}
@@ -259,7 +259,7 @@ func interceptEmitRequiredReceipt(ic *InterceptContext, opts receipt.EmitOpts) e
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}
-	emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
+	_ = emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {
 		if ic.Logger != nil {
 			ic.Logger.LogError(audit.NewRequestLogContext(opts.RequestID), err)
 		}

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/certgen"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	contractruntime "github.com/luckyPipewrench/pipelock/internal/contract/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
@@ -106,6 +107,58 @@ func TestInterceptEmitReceiptOrBlockRequiresReceipt(t *testing.T) {
 	})
 	if !blocked {
 		t.Fatal("receipt emission failure did not fail closed")
+	}
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+	if got := rr.Header().Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.ReceiptEmissionFailed)
+	}
+	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="intercept"} 1`)
+}
+
+func TestInterceptEmitReceiptOrBlockRequiresReceiptBlocksV2Failure(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.FlightRecorder.RequireReceipts = true
+	cfg.ApplyDefaults()
+	cfg.Internal = nil
+
+	m := metrics.New()
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, audit.NewNop(), sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	p.receiptEmitterPtr.Store(rph.emitter)
+	p.v2EmitterPtr.Store(proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder:  failingProxyV2Recorder{},
+		Signer:    proxydecision.NewKeyedSigner(rph.priv),
+		Principal: "local",
+		Actor:     "pipelock",
+	}))
+
+	ic := &InterceptContext{
+		Proxy:     p,
+		Config:    cfg,
+		Logger:    audit.NewNop(),
+		RequestID: "req-intercept-v2-receipt",
+		Agent:     "agent",
+	}
+	rr := httptest.NewRecorder()
+	blocked := interceptEmitReceiptOrBlock(ic, rr, audit.NewRequestLogContext(ic.RequestID), receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: "intercept",
+		Method:    http.MethodGet,
+		Target:    "https://example.test/",
+		RequestID: ic.RequestID,
+		Agent:     ic.Agent,
+	})
+	if !blocked {
+		t.Fatal("v2 receipt emission failure did not fail closed")
 	}
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -168,21 +168,12 @@ func TestInterceptEmitReceiptOrBlockRequiresReceiptBlocksV2Failure(t *testing.T)
 	}
 	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="intercept"} 1`)
-	receipts := rph.findReceipts(t)
-	var marker receipt.Receipt
-	layers := make([]string, 0, len(receipts))
-	for _, rcpt := range receipts {
-		layers = append(layers, rcpt.ActionRecord.Layer+":"+rcpt.ActionRecord.Verdict)
-		if rcpt.ActionRecord.Layer == receiptEmissionFailedLayer {
-			marker = rcpt
-			break
-		}
-	}
-	if marker.ActionRecord.ActionID == "" {
-		t.Fatalf("missing %q marker in %d receipts: %v", receiptEmissionFailedLayer, len(receipts), layers)
-	}
+	marker := requireReceiptEmissionFailedLayer(t, rph.findReceipts(t))
 	if marker.ActionRecord.Verdict != config.ActionBlock {
 		t.Fatalf("failure marker verdict = %q, want %q", marker.ActionRecord.Verdict, config.ActionBlock)
+	}
+	if marker.ActionRecord.Pattern != "proxydecision receipt emission failed" {
+		t.Fatalf("failure marker pattern = %q, want %q", marker.ActionRecord.Pattern, "proxydecision receipt emission failed")
 	}
 }
 

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -168,6 +168,22 @@ func TestInterceptEmitReceiptOrBlockRequiresReceiptBlocksV2Failure(t *testing.T)
 	}
 	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="intercept"} 1`)
+	receipts := rph.findReceipts(t)
+	var marker receipt.Receipt
+	layers := make([]string, 0, len(receipts))
+	for _, rcpt := range receipts {
+		layers = append(layers, rcpt.ActionRecord.Layer+":"+rcpt.ActionRecord.Verdict)
+		if rcpt.ActionRecord.Layer == receiptEmissionFailedLayer {
+			marker = rcpt
+			break
+		}
+	}
+	if marker.ActionRecord.ActionID == "" {
+		t.Fatalf("missing %q marker in %d receipts: %v", receiptEmissionFailedLayer, len(receipts), layers)
+	}
+	if marker.ActionRecord.Verdict != config.ActionBlock {
+		t.Fatalf("failure marker verdict = %q, want %q", marker.ActionRecord.Verdict, config.ActionBlock)
+	}
 }
 
 func TestInterceptEmitReceiptOrBlockRequireReceiptsEmitsIntent(t *testing.T) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1044,7 +1044,7 @@ func (p *Proxy) emitRequiredReceiptWithEmitter(opts receipt.EmitOpts, e *receipt
 	}
 	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
 	if err := p.emitV2Receipt(opts); err != nil {
-		p.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed", config.ActionBlock)
+		_ = p.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed", config.ActionBlock)
 		return err
 	}
 	return nil
@@ -1081,7 +1081,7 @@ func (p *Proxy) emitOutcomeReceipt(cfg *config.Config, opts receipt.EmitOpts, st
 	if err := p.emitReceipt(opts); err != nil {
 		if errors.Is(err, errV2ReceiptEmit) {
 			e := p.receiptEmitterPtr.Load()
-			p.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
+			_ = p.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
 		}
 	}
 }
@@ -1119,20 +1119,22 @@ func receiptEmissionFailureMarkerOpts(opts receipt.EmitOpts, pattern, verdict st
 	return marker
 }
 
-func emitReceiptFailureMarkerWithLogger(e *receipt.Emitter, opts receipt.EmitOpts, pattern, verdict string, logErr func(receipt.EmitOpts, error)) {
+func emitReceiptFailureMarkerWithLogger(e *receipt.Emitter, opts receipt.EmitOpts, pattern, verdict string, logErr func(receipt.EmitOpts, error)) error {
 	if e == nil {
-		return
+		return nil
 	}
 	marker := receiptEmissionFailureMarkerOpts(opts, pattern, verdict)
 	if err := e.EmitDurable(marker); err != nil {
 		if logErr != nil {
 			logErr(marker, err)
 		}
+		return err
 	}
+	return nil
 }
 
-func (p *Proxy) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern, verdict string) {
-	emitReceiptFailureMarkerWithLogger(e, opts, pattern, verdict, p.logReceiptEmissionFailure)
+func (p *Proxy) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern, verdict string) error {
+	return emitReceiptFailureMarkerWithLogger(e, opts, pattern, verdict, p.logReceiptEmissionFailure)
 }
 
 func (p *Proxy) recordReceiptEmitterUnavailable(opts receipt.EmitOpts) error {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1044,7 +1044,9 @@ func (p *Proxy) emitRequiredReceiptWithEmitter(opts receipt.EmitOpts, e *receipt
 	}
 	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
 	if err := p.emitV2Receipt(opts); err != nil {
-		_ = p.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed", config.ActionBlock)
+		if markerErr := p.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed", config.ActionBlock); markerErr != nil {
+			return errors.Join(err, markerErr)
+		}
 		return err
 	}
 	return nil

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1044,7 +1044,7 @@ func (p *Proxy) emitRequiredReceiptWithEmitter(opts receipt.EmitOpts, e *receipt
 	}
 	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
 	if err := p.emitV2Receipt(opts); err != nil {
-		p.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed")
+		p.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed", config.ActionBlock)
 		return err
 	}
 	return nil
@@ -1079,10 +1079,9 @@ func (p *Proxy) emitOutcomeReceipt(cfg *config.Config, opts receipt.EmitOpts, st
 	opts.Pattern = receiptOutcomePattern(status, bytesTransferred, reason)
 	opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 	if err := p.emitReceipt(opts); err != nil {
-		p.recordRequiredReceiptBlock(err, opts.Transport)
 		if errors.Is(err, errV2ReceiptEmit) {
 			e := p.receiptEmitterPtr.Load()
-			p.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed")
+			p.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
 		}
 	}
 }
@@ -1104,11 +1103,11 @@ func (p *Proxy) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter
 	return nil
 }
 
-func receiptEmissionFailureMarkerOpts(opts receipt.EmitOpts, pattern string) receipt.EmitOpts {
+func receiptEmissionFailureMarkerOpts(opts receipt.EmitOpts, pattern, verdict string) receipt.EmitOpts {
 	marker := opts
 	marker.ActionID = receipt.NewActionID()
 	marker.ParentActionID = opts.ActionID
-	marker.Verdict = config.ActionBlock
+	marker.Verdict = verdict
 	marker.Layer = receiptEmissionFailedLayer
 	marker.Pattern = pattern
 	marker.Severity = config.SeverityHigh
@@ -1120,14 +1119,20 @@ func receiptEmissionFailureMarkerOpts(opts receipt.EmitOpts, pattern string) rec
 	return marker
 }
 
-func (p *Proxy) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern string) {
+func emitReceiptFailureMarkerWithLogger(e *receipt.Emitter, opts receipt.EmitOpts, pattern, verdict string, logErr func(receipt.EmitOpts, error)) {
 	if e == nil {
 		return
 	}
-	marker := receiptEmissionFailureMarkerOpts(opts, pattern)
+	marker := receiptEmissionFailureMarkerOpts(opts, pattern, verdict)
 	if err := e.EmitDurable(marker); err != nil {
-		p.logReceiptEmissionFailure(marker, err)
+		if logErr != nil {
+			logErr(marker, err)
+		}
 	}
+}
+
+func (p *Proxy) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern, verdict string) {
+	emitReceiptFailureMarkerWithLogger(e, opts, pattern, verdict, p.logReceiptEmissionFailure)
 }
 
 func (p *Proxy) recordReceiptEmitterUnavailable(opts receipt.EmitOpts) error {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1043,7 +1043,7 @@ func (p *Proxy) emitRequiredReceiptWithEmitter(opts receipt.EmitOpts, e *receipt
 		return err
 	}
 	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
-	if err := p.emitV2Receipt(opts); err != nil {
+	if err := p.emitRequiredV2Receipt(opts); err != nil {
 		if markerErr := p.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed", config.ActionBlock); markerErr != nil {
 			return errors.Join(err, markerErr)
 		}
@@ -1080,11 +1080,16 @@ func (p *Proxy) emitOutcomeReceipt(cfg *config.Config, opts receipt.EmitOpts, st
 	opts.Layer = receiptOutcomeLayer
 	opts.Pattern = receiptOutcomePattern(status, bytesTransferred, reason)
 	opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
-	if err := p.emitReceipt(opts); err != nil {
-		if errors.Is(err, errV2ReceiptEmit) {
-			e := p.receiptEmitterPtr.Load()
-			_ = p.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
-		}
+	e := p.receiptEmitterPtr.Load()
+	if e == nil {
+		return
+	}
+	if err := e.Emit(opts); err != nil {
+		p.logReceiptEmissionFailure(opts, err)
+		return
+	}
+	if err := p.emitV2Receipt(opts); err != nil {
+		_ = p.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
 	}
 }
 
@@ -1098,10 +1103,9 @@ func (p *Proxy) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter
 		// proxy_decision never outlives its action_receipt sibling.
 		return err
 	}
-	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
-	if err := p.emitV2Receipt(opts); err != nil {
-		return err
-	}
+	// Dual-emit the v2 proxy_decision receipt best-effort. Optional v2 outages
+	// are logged/metriced by emitV2Receipt but do not affect traffic.
+	_ = p.emitV2Receipt(opts)
 	return nil
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1043,11 +1043,17 @@ func (p *Proxy) emitRequiredReceiptWithEmitter(opts receipt.EmitOpts, e *receipt
 		return err
 	}
 	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
-	p.emitV2Receipt(opts)
+	if err := p.emitV2Receipt(opts); err != nil {
+		p.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed")
+		return err
+	}
 	return nil
 }
 
-const receiptOutcomeLayer = "outcome"
+const (
+	receiptOutcomeLayer        = "outcome"
+	receiptEmissionFailedLayer = "receipt_emission_failed"
+)
 
 func receiptOutcomePattern(status string, bytesTransferred int64, reason string) string {
 	if status == "" {
@@ -1071,7 +1077,14 @@ func (p *Proxy) emitOutcomeReceipt(cfg *config.Config, opts receipt.EmitOpts, st
 	opts.Verdict = config.ActionAllow
 	opts.Layer = receiptOutcomeLayer
 	opts.Pattern = receiptOutcomePattern(status, bytesTransferred, reason)
-	_ = p.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+	opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
+	if err := p.emitReceipt(opts); err != nil {
+		p.recordRequiredReceiptBlock(err, opts.Transport)
+		if errors.Is(err, errV2ReceiptEmit) {
+			e := p.receiptEmitterPtr.Load()
+			p.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed")
+		}
+	}
 }
 
 func (p *Proxy) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter) error {
@@ -1085,8 +1098,36 @@ func (p *Proxy) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter
 		return err
 	}
 	// Dual-emit the v2 proxy_decision receipt (expand phase; v1 stays live).
-	p.emitV2Receipt(opts)
+	if err := p.emitV2Receipt(opts); err != nil {
+		return err
+	}
 	return nil
+}
+
+func receiptEmissionFailureMarkerOpts(opts receipt.EmitOpts, pattern string) receipt.EmitOpts {
+	marker := opts
+	marker.ActionID = receipt.NewActionID()
+	marker.ParentActionID = opts.ActionID
+	marker.Verdict = config.ActionBlock
+	marker.Layer = receiptEmissionFailedLayer
+	marker.Pattern = pattern
+	marker.Severity = config.SeverityHigh
+	marker.DecisionPhase = ""
+	marker.DeferID = ""
+	marker.ResolutionPolicy = ""
+	marker.ResolutionSource = ""
+	marker.SessionControl = nil
+	return marker
+}
+
+func (p *Proxy) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern string) {
+	if e == nil {
+		return
+	}
+	marker := receiptEmissionFailureMarkerOpts(opts, pattern)
+	if err := e.EmitDurable(marker); err != nil {
+		p.logReceiptEmissionFailure(marker, err)
+	}
 }
 
 func (p *Proxy) recordReceiptEmitterUnavailable(opts receipt.EmitOpts) error {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -290,14 +290,10 @@ func (rp *ReverseProxyHandler) emitRequiredReceiptWithEmitter(opts receipt.EmitO
 		return err
 	}
 	if err := emitV2(rp.v2EmitterPtr, opts, func(err error) {
-		if rp.logger == nil {
-			return
-		}
-		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
-			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s transport=%s: %w",
-				opts.ActionID, opts.Verdict, opts.Transport, err))
+		recordV2ReceiptEmitFailure(rp.metrics)
+		logV2EmitFailure(rp.logger, opts, err)
 	}); err != nil {
-		rp.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed")
+		rp.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed", config.ActionBlock)
 		return err
 	}
 	return nil
@@ -313,10 +309,9 @@ func (rp *ReverseProxyHandler) emitOutcomeReceipt(cfg *config.Config, opts recei
 	opts.Pattern = receiptOutcomePattern(status, bytesTransferred, reason)
 	opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 	if err := rp.emitReceipt(opts); err != nil {
-		rp.recordRequiredReceiptBlock(err, opts.Transport)
 		if errors.Is(err, errV2ReceiptEmit) {
 			e := rp.receiptEmitter()
-			rp.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed")
+			rp.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
 		}
 	}
 }
@@ -336,26 +331,16 @@ func (rp *ReverseProxyHandler) emitReceiptWithEmitter(opts receipt.EmitOpts, e *
 		return err
 	}
 	if err := emitV2(rp.v2EmitterPtr, opts, func(err error) {
-		if rp.logger == nil {
-			return
-		}
-		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
-			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s transport=%s: %w",
-				opts.ActionID, opts.Verdict, opts.Transport, err))
+		recordV2ReceiptEmitFailure(rp.metrics)
+		logV2EmitFailure(rp.logger, opts, err)
 	}); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (rp *ReverseProxyHandler) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern string) {
-	if e == nil {
-		return
-	}
-	marker := receiptEmissionFailureMarkerOpts(opts, pattern)
-	if err := e.EmitDurable(marker); err != nil {
-		rp.logReceiptEmissionFailure(marker, err)
-	}
+func (rp *ReverseProxyHandler) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern, verdict string) {
+	emitReceiptFailureMarkerWithLogger(e, opts, pattern, verdict, rp.logReceiptEmissionFailure)
 }
 
 func (rp *ReverseProxyHandler) recordReceiptEmitterUnavailable(opts receipt.EmitOpts) error {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -289,7 +289,7 @@ func (rp *ReverseProxyHandler) emitRequiredReceiptWithEmitter(opts receipt.EmitO
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}
-	if err := emitV2(rp.v2EmitterPtr, opts, func(err error) {
+	if err := emitRequiredV2(rp.v2EmitterPtr, opts, func(err error) {
 		recordV2ReceiptEmitFailure(rp.metrics)
 		logV2EmitFailure(rp.logger, opts, err)
 	}); err != nil {
@@ -310,11 +310,19 @@ func (rp *ReverseProxyHandler) emitOutcomeReceipt(cfg *config.Config, opts recei
 	opts.Layer = receiptOutcomeLayer
 	opts.Pattern = receiptOutcomePattern(status, bytesTransferred, reason)
 	opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
-	if err := rp.emitReceipt(opts); err != nil {
-		if errors.Is(err, errV2ReceiptEmit) {
-			e := rp.receiptEmitter()
-			_ = rp.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
-		}
+	e := rp.receiptEmitter()
+	if e == nil {
+		return
+	}
+	if err := e.Emit(opts); err != nil {
+		rp.logReceiptEmissionFailure(opts, err)
+		return
+	}
+	if err := emitV2(rp.v2EmitterPtr, opts, func(err error) {
+		recordV2ReceiptEmitFailure(rp.metrics)
+		logV2EmitFailure(rp.logger, opts, err)
+	}); err != nil {
+		_ = rp.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
 	}
 }
 
@@ -332,12 +340,10 @@ func (rp *ReverseProxyHandler) emitReceiptWithEmitter(opts receipt.EmitOpts, e *
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}
-	if err := emitV2(rp.v2EmitterPtr, opts, func(err error) {
+	_ = emitV2(rp.v2EmitterPtr, opts, func(err error) {
 		recordV2ReceiptEmitFailure(rp.metrics)
 		logV2EmitFailure(rp.logger, opts, err)
-	}); err != nil {
-		return err
-	}
+	})
 	return nil
 }
 

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -293,7 +293,9 @@ func (rp *ReverseProxyHandler) emitRequiredReceiptWithEmitter(opts receipt.EmitO
 		recordV2ReceiptEmitFailure(rp.metrics)
 		logV2EmitFailure(rp.logger, opts, err)
 	}); err != nil {
-		rp.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed", config.ActionBlock)
+		if markerErr := rp.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed", config.ActionBlock); markerErr != nil {
+			return errors.Join(err, markerErr)
+		}
 		return err
 	}
 	return nil
@@ -311,7 +313,7 @@ func (rp *ReverseProxyHandler) emitOutcomeReceipt(cfg *config.Config, opts recei
 	if err := rp.emitReceipt(opts); err != nil {
 		if errors.Is(err, errV2ReceiptEmit) {
 			e := rp.receiptEmitter()
-			rp.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
+			_ = rp.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed", config.ActionAllow)
 		}
 	}
 }
@@ -339,8 +341,8 @@ func (rp *ReverseProxyHandler) emitReceiptWithEmitter(opts receipt.EmitOpts, e *
 	return nil
 }
 
-func (rp *ReverseProxyHandler) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern, verdict string) {
-	_ = emitReceiptFailureMarkerWithLogger(e, opts, pattern, verdict, rp.logReceiptEmissionFailure)
+func (rp *ReverseProxyHandler) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern, verdict string) error {
+	return emitReceiptFailureMarkerWithLogger(e, opts, pattern, verdict, rp.logReceiptEmissionFailure)
 }
 
 func (rp *ReverseProxyHandler) recordReceiptEmitterUnavailable(opts receipt.EmitOpts) error {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -288,14 +289,17 @@ func (rp *ReverseProxyHandler) emitRequiredReceiptWithEmitter(opts receipt.EmitO
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}
-	emitV2(rp.v2EmitterPtr, opts, func(err error) {
+	if err := emitV2(rp.v2EmitterPtr, opts, func(err error) {
 		if rp.logger == nil {
 			return
 		}
 		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
 			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s transport=%s: %w",
 				opts.ActionID, opts.Verdict, opts.Transport, err))
-	})
+	}); err != nil {
+		rp.emitReceiptFailureMarker(e, opts, "proxydecision receipt emission failed")
+		return err
+	}
 	return nil
 }
 
@@ -307,7 +311,14 @@ func (rp *ReverseProxyHandler) emitOutcomeReceipt(cfg *config.Config, opts recei
 	opts.Verdict = config.ActionAllow
 	opts.Layer = receiptOutcomeLayer
 	opts.Pattern = receiptOutcomePattern(status, bytesTransferred, reason)
-	_ = rp.emitReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+	opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
+	if err := rp.emitReceipt(opts); err != nil {
+		rp.recordRequiredReceiptBlock(err, opts.Transport)
+		if errors.Is(err, errV2ReceiptEmit) {
+			e := rp.receiptEmitter()
+			rp.emitReceiptFailureMarker(e, opts, "outcome receipt emission failed")
+		}
+	}
 }
 
 func (rp *ReverseProxyHandler) emitReceiptWithEmitter(opts receipt.EmitOpts, e *receipt.Emitter) error {
@@ -324,15 +335,27 @@ func (rp *ReverseProxyHandler) emitReceiptWithEmitter(opts receipt.EmitOpts, e *
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}
-	emitV2(rp.v2EmitterPtr, opts, func(err error) {
+	if err := emitV2(rp.v2EmitterPtr, opts, func(err error) {
 		if rp.logger == nil {
 			return
 		}
 		rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
 			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s transport=%s: %w",
 				opts.ActionID, opts.Verdict, opts.Transport, err))
-	})
+	}); err != nil {
+		return err
+	}
 	return nil
+}
+
+func (rp *ReverseProxyHandler) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern string) {
+	if e == nil {
+		return
+	}
+	marker := receiptEmissionFailureMarkerOpts(opts, pattern)
+	if err := e.EmitDurable(marker); err != nil {
+		rp.logReceiptEmissionFailure(marker, err)
+	}
 }
 
 func (rp *ReverseProxyHandler) recordReceiptEmitterUnavailable(opts receipt.EmitOpts) error {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -1461,6 +1461,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 
 	// Skip remaining binary content types (non-media application/*, etc.).
 	if isBinaryMIME(mediaCT) {
+		binaryOutcomeReason := "binary_passthrough"
 		if cfg.FlightRecorder.RequireReceipts && cfg.ResponseScanning.Enabled && revRespSizeExempt {
 			limited := io.LimitReader(resp.Body, int64(reverseProxyMaxBodyBytes)+1)
 			body, err := io.ReadAll(limited)
@@ -1499,6 +1500,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 					reason := unscannablePassthroughReason(revHost, resp.Request.URL.EscapedPath(), match.ContentType, match.Entry.Reason)
 					rp.logger.LogAnomaly(actx, "unscannable_passthrough", reason, 0)
 					emitUnscannablePassthrough(reason)
+					binaryOutcomeReason = "unscannable_passthrough"
 				}
 				resp.Body = readCloserWithClose{
 					Reader: io.MultiReader(bytes.NewReader(body), resp.Body),
@@ -1512,7 +1514,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 		}
 		rp.metrics.RecordReverseProxyRequest(resp.Request.Method,
 			strconv.Itoa(resp.StatusCode))
-		recordReverseOutcome(resp.StatusCode, resp.ContentLength, "binary_passthrough")
+		recordReverseOutcome(resp.StatusCode, resp.ContentLength, binaryOutcomeReason)
 		return nil
 	}
 

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -340,7 +340,7 @@ func (rp *ReverseProxyHandler) emitReceiptWithEmitter(opts receipt.EmitOpts, e *
 }
 
 func (rp *ReverseProxyHandler) emitReceiptFailureMarker(e *receipt.Emitter, opts receipt.EmitOpts, pattern, verdict string) {
-	emitReceiptFailureMarkerWithLogger(e, opts, pattern, verdict, rp.logReceiptEmissionFailure)
+	_ = emitReceiptFailureMarkerWithLogger(e, opts, pattern, verdict, rp.logReceiptEmissionFailure)
 }
 
 func (rp *ReverseProxyHandler) recordReceiptEmitterUnavailable(opts receipt.EmitOpts) error {

--- a/internal/proxy/reverse_receipt_parity_test.go
+++ b/internal/proxy/reverse_receipt_parity_test.go
@@ -855,6 +855,142 @@ func TestReverseProxy_RequireReceiptsSyncFailureBlocksBeforeEgress(t *testing.T)
 	}
 }
 
+func TestReverseProxy_RequireReceiptsV2FailureBlocksBeforeEgress(t *testing.T) {
+	var hits atomic.Int32
+	cfg := reverseTestConfig()
+	cfg.ResponseScanning.Enabled = false
+	cfg.FlightRecorder.RequireReceipts = true
+
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	m := metrics.New()
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, audit.NewNop(), m, killswitch.New(cfg), nil, nil)
+	rph := newReceiptProxyHelperWithMetrics(t, m)
+	var emPtr atomic.Pointer[receipt.Emitter]
+	emPtr.Store(rph.emitter)
+	handler.SetReceiptEmitter(&emPtr)
+	var v2Ptr atomic.Pointer[proxydecision.Emitter]
+	v2Ptr.Store(proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder:  failingProxyV2Recorder{},
+		Signer:    proxydecision.NewKeyedSigner(rph.priv),
+		Principal: "local",
+		Actor:     "pipelock",
+	}))
+	handler.SetV2ReceiptEmitter(&v2Ptr)
+
+	proxySrv := newIPv4Server(t, handler)
+	t.Cleanup(proxySrv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/clean", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET reverse proxy: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("response body close: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (required v2 receipt failure must block before reverse egress)", got)
+	}
+	requireReceiptEmissionFailedLayer(t, rph.findReceipts(t))
+	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="reverse"} 1`)
+}
+
+func TestReverseProxy_RequireReceiptsOutcomeV2FailureEmitsGapMarker(t *testing.T) {
+	var hits atomic.Int32
+	cfg := reverseTestConfig()
+	cfg.ResponseScanning.Enabled = false
+	cfg.FlightRecorder.RequireReceipts = true
+
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, audit.NewNop(), metrics.New(), killswitch.New(cfg), nil, nil)
+	rph := newReceiptProxyHelper(t)
+	var emPtr atomic.Pointer[receipt.Emitter]
+	emPtr.Store(rph.emitter)
+	handler.SetReceiptEmitter(&emPtr)
+	var v2Ptr atomic.Pointer[proxydecision.Emitter]
+	v2Ptr.Store(proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder:  &failAfterProxyV2Recorder{allowed: 1},
+		Signer:    proxydecision.NewKeyedSigner(rph.priv),
+		Principal: "local",
+		Actor:     "pipelock",
+	}))
+	handler.SetV2ReceiptEmitter(&v2Ptr)
+
+	proxySrv := newIPv4Server(t, handler)
+	t.Cleanup(proxySrv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/clean", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET reverse proxy: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("response body close: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream hits = %d, want 1", got)
+	}
+	marker := requireReceiptEmissionFailedLayer(t, rph.findReceipts(t))
+	if !strings.Contains(marker.ActionRecord.Pattern, "outcome receipt emission failed") {
+		t.Fatalf("marker pattern = %q, want outcome receipt emission failed", marker.ActionRecord.Pattern)
+	}
+}
+
 func TestReverseProxy_UnscannablePassthroughRequireReceiptsEmitsSingleIntentOutcomePair(t *testing.T) {
 	cfg := reverseTestConfig()
 	cfg.FlightRecorder.RequireReceipts = true

--- a/internal/proxy/reverse_receipt_parity_test.go
+++ b/internal/proxy/reverse_receipt_parity_test.go
@@ -910,6 +910,55 @@ func TestReverseProxy_UnscannablePassthroughRequireReceiptsEmitsSingleIntentOutc
 	assertReverseIntentOutcomePair(t, receipts, "status=200", "reason=unscannable_passthrough")
 }
 
+func TestReverseProxy_BinaryUnscannablePassthroughOutcomeReason(t *testing.T) {
+	cfg := reverseTestConfig()
+	cfg.FlightRecorder.RequireReceipts = true
+	cfg.ResponseScanning.Enabled = true
+	cfg.ResponseScanning.Action = config.ActionBlock
+	mediaPolicyDisabled := false
+	cfg.MediaPolicy.Enabled = &mediaPolicyDisabled
+	cfg.ResponseScanning.SizeExemptDomains = []string{"127.0.0.1"}
+	cfg.ResponseScanning.UnscannablePassthrough = []config.UnscannablePassthroughEntry{{
+		Host:         "127.0.0.1",
+		Paths:        []string{"/clip.mp3"},
+		ContentTypes: []string{"audio/mpeg"},
+		Reason:       "opaque audio artifact",
+		Expires:      "2099-01-01",
+	}}
+	cfg.ResponseScanning.SizeExemptScanMaxBytes = reverseProxyMaxBodyBytes
+	cfg.ResponseScanning.SizeExemptScanMaxInflightBytes = 2 * reverseProxyMaxBodyBytes
+
+	body := bytes.Repeat([]byte{0x42}, reverseProxyMaxBodyBytes+1)
+	proxySrv, dir, closeRec := reverseReceiptParitySetup(t, cfg, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.Header().Set("Content-Disposition", "attachment; filename=clip.mp3")
+		w.Header().Set("Content-Length", fmt.Sprint(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/clip.mp3", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET reverse proxy: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("response body close: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	waitForReceiptOrTimeout(t, dir)
+	closeRec()
+	receipts := extractReceiptsFromDir(t, dir)
+	assertReverseIntentOutcomePair(t, receipts, "status=200", "reason=unscannable_passthrough")
+}
+
 // findReceiptByLayer returns the first receipt whose ActionRecord.Layer
 // matches the wanted label. Tests use this instead of indexing
 // receipts[0] so they cannot silently validate a different receipt if a

--- a/internal/proxy/reverse_receipt_parity_test.go
+++ b/internal/proxy/reverse_receipt_parity_test.go
@@ -989,6 +989,11 @@ func TestReverseProxy_RequireReceiptsOutcomeV2FailureEmitsGapMarker(t *testing.T
 	if !strings.Contains(marker.ActionRecord.Pattern, "outcome receipt emission failed") {
 		t.Fatalf("marker pattern = %q, want outcome receipt emission failed", marker.ActionRecord.Pattern)
 	}
+	if marker.ActionRecord.Verdict != config.ActionAllow {
+		t.Fatalf("marker verdict = %q, want %q for post-response outcome gap", marker.ActionRecord.Verdict, config.ActionAllow)
+	}
+	assertMetricsContain(t, handler.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsNotContain(t, handler.metrics, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="reverse"} 1`)
 }
 
 func TestReverseProxy_UnscannablePassthroughRequireReceiptsEmitsSingleIntentOutcomePair(t *testing.T) {

--- a/internal/proxy/v2receipt.go
+++ b/internal/proxy/v2receipt.go
@@ -150,6 +150,35 @@ func emitV2(ptr *atomic.Pointer[proxydecision.Emitter], opts receipt.EmitOpts, l
 	return nil
 }
 
+// emitRequiredV2 is the fail-closed variant for RequireReceipts paths. Once a
+// v1 sibling has been durably recorded, a configured v2 emitter must either
+// record the proxy_decision or surface why it could not.
+func emitRequiredV2(ptr *atomic.Pointer[proxydecision.Emitter], opts receipt.EmitOpts, logErr func(error)) error {
+	if ptr == nil {
+		return nil
+	}
+	e := ptr.Load()
+	if e == nil {
+		return nil
+	}
+	d, ok := v2DecisionFromOpts(opts)
+	if !ok {
+		err := fmt.Errorf("%w: could not derive v2 decision action_id=%s transport=%s target=%q",
+			errV2ReceiptEmit, opts.ActionID, opts.Transport, opts.Target)
+		if logErr != nil {
+			logErr(err)
+		}
+		return err
+	}
+	if err := e.Emit(d); err != nil {
+		if logErr != nil {
+			logErr(err)
+		}
+		return fmt.Errorf("%w: %w", errV2ReceiptEmit, err)
+	}
+	return nil
+}
+
 func recordV2ReceiptEmitFailure(metrics receipt.MetricsSink) {
 	if metrics != nil {
 		metrics.RecordEmitFailure(receipt.FailReasonRecord)
@@ -168,6 +197,13 @@ func logV2EmitFailure(logger *audit.Logger, opts receipt.EmitOpts, err error) {
 // emitV2Receipt dual-emits the v2 proxy_decision for opts on the main proxy.
 func (p *Proxy) emitV2Receipt(opts receipt.EmitOpts) error {
 	return emitV2(&p.v2EmitterPtr, opts, func(err error) {
+		recordV2ReceiptEmitFailure(p.metrics)
+		logV2EmitFailure(p.logger, opts, err)
+	})
+}
+
+func (p *Proxy) emitRequiredV2Receipt(opts receipt.EmitOpts) error {
+	return emitRequiredV2(&p.v2EmitterPtr, opts, func(err error) {
 		recordV2ReceiptEmitFailure(p.metrics)
 		logV2EmitFailure(p.logger, opts, err)
 	})

--- a/internal/proxy/v2receipt.go
+++ b/internal/proxy/v2receipt.go
@@ -150,11 +150,25 @@ func emitV2(ptr *atomic.Pointer[proxydecision.Emitter], opts receipt.EmitOpts, l
 	return nil
 }
 
+func recordV2ReceiptEmitFailure(metrics receipt.MetricsSink) {
+	if metrics != nil {
+		metrics.RecordEmitFailure(receipt.FailReasonRecord)
+	}
+}
+
+func logV2EmitFailure(logger *audit.Logger, opts receipt.EmitOpts, err error) {
+	if logger == nil {
+		return
+	}
+	logger.LogError(audit.NewRequestLogContext(opts.RequestID),
+		fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s layer=%s transport=%s: %w",
+			opts.ActionID, opts.Verdict, opts.Layer, opts.Transport, err))
+}
+
 // emitV2Receipt dual-emits the v2 proxy_decision for opts on the main proxy.
 func (p *Proxy) emitV2Receipt(opts receipt.EmitOpts) error {
 	return emitV2(&p.v2EmitterPtr, opts, func(err error) {
-		p.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
-			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s layer=%s transport=%s: %w",
-				opts.ActionID, opts.Verdict, opts.Layer, opts.Transport, err))
+		recordV2ReceiptEmitFailure(p.metrics)
+		logV2EmitFailure(p.logger, opts, err)
 	})
 }

--- a/internal/proxy/v2receipt.go
+++ b/internal/proxy/v2receipt.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
 	"sync/atomic"
 
@@ -11,6 +12,8 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
+
+var errV2ReceiptEmit = errors.New("v2 proxydecision receipt emit failed")
 
 // v2 action_type labels for the proxy_decision payload. They classify the
 // action surface and are distinct from the v1 ActionRecord's semantic action
@@ -123,30 +126,33 @@ func ensureSource(sources []string, want string) []string {
 }
 
 // emitV2 loads the v2 emitter from ptr and dual-emits a proxy_decision receipt
-// for opts. Safe when the emitter is nil (no-op). v2 emission failures are
-// logged via logErr and never propagate; the v1 receipt is the authoritative
-// audit record during the expand phase, so a v2 hiccup must not affect the
-// proxy decision.
-func emitV2(ptr *atomic.Pointer[proxydecision.Emitter], opts receipt.EmitOpts, logErr func(error)) {
+// for opts. Safe when the emitter is nil (no-op). Callers that run in
+// best-effort mode may ignore the returned error; required-receipt callers use
+// it to fail closed after the v1 sibling has been durably recorded.
+func emitV2(ptr *atomic.Pointer[proxydecision.Emitter], opts receipt.EmitOpts, logErr func(error)) error {
 	if ptr == nil {
-		return
+		return nil
 	}
 	e := ptr.Load()
 	if e == nil {
-		return
+		return nil
 	}
 	d, ok := v2DecisionFromOpts(opts)
 	if !ok {
-		return
+		return nil
 	}
-	if err := e.Emit(d); err != nil && logErr != nil {
-		logErr(err)
+	if err := e.Emit(d); err != nil {
+		if logErr != nil {
+			logErr(err)
+		}
+		return fmt.Errorf("%w: %w", errV2ReceiptEmit, err)
 	}
+	return nil
 }
 
 // emitV2Receipt dual-emits the v2 proxy_decision for opts on the main proxy.
-func (p *Proxy) emitV2Receipt(opts receipt.EmitOpts) {
-	emitV2(&p.v2EmitterPtr, opts, func(err error) {
+func (p *Proxy) emitV2Receipt(opts receipt.EmitOpts) error {
+	return emitV2(&p.v2EmitterPtr, opts, func(err error) {
 		p.logger.LogError(audit.NewRequestLogContext(opts.RequestID),
 			fmt.Errorf("emit v2 proxy_decision action_id=%s verdict=%s layer=%s transport=%s: %w",
 				opts.ActionID, opts.Verdict, opts.Layer, opts.Transport, err))

--- a/internal/proxy/v2receipt_test.go
+++ b/internal/proxy/v2receipt_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -392,6 +393,65 @@ func TestDualEmit_DisabledWhenNoV2Emitter(t *testing.T) {
 			t.Error("v2 proxy_decision emitted despite no v2 emitter configured")
 		}
 	}
+}
+
+func TestEmitRequiredV2_DerivationFailureSurfaces(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder:  failingProxyV2Recorder{},
+		Signer:    proxydecision.NewKeyedSigner(priv),
+		Principal: "local",
+		Actor:     "pipelock",
+	})
+	var ptr atomic.Pointer[proxydecision.Emitter]
+	ptr.Store(v2)
+	logged := false
+
+	err = emitRequiredV2(&ptr, receipt.EmitOpts{
+		ActionID:  "required-missing-target",
+		Transport: TransportFetch,
+		Verdict:   config.ActionAllow,
+		// Target intentionally empty: v1 currently rejects this too, but the
+		// required v2 helper must be self-defending if that coupling changes.
+	}, func(error) { logged = true })
+	if !errors.Is(err, errV2ReceiptEmit) {
+		t.Fatalf("emitRequiredV2 error = %v, want errV2ReceiptEmit", err)
+	}
+	if !strings.Contains(err.Error(), "could not derive v2 decision") {
+		t.Fatalf("emitRequiredV2 error = %v, want derivation failure detail", err)
+	}
+	if !logged {
+		t.Fatal("required v2 derivation failure was not logged")
+	}
+}
+
+func TestEmitReceipt_OptionalV2FailureDoesNotPropagate(t *testing.T) {
+	f := newDualEmitFixture(t, false)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	f.p.v2EmitterPtr.Store(proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder:  failingProxyV2Recorder{},
+		Signer:    proxydecision.NewKeyedSigner(priv),
+		Principal: "local",
+		Actor:     "pipelock",
+	}))
+
+	if err := f.p.emitReceipt(receipt.EmitOpts{
+		ActionID:  "optional-v2-failure",
+		Transport: TransportForward,
+		Method:    http.MethodGet,
+		Target:    "https://x.example/a",
+		Verdict:   config.ActionAllow,
+		RequestID: "r1",
+	}); err != nil {
+		t.Fatalf("optional emitReceipt returned v2 error = %v, want nil", err)
+	}
+	assertMetricsContain(t, f.p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 }
 
 // TestDualEmit_HotReloadPreservesV2Chain proves the v2 proxy_decision chain

--- a/internal/proxy/v2receipt_test.go
+++ b/internal/proxy/v2receipt_test.go
@@ -7,9 +7,11 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
@@ -22,6 +24,39 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+type failingProxyV2Recorder struct{}
+
+func (failingProxyV2Recorder) Record(recorder.Entry) error {
+	return errors.New("v2 record failed")
+}
+
+type failAfterProxyV2Recorder struct {
+	allowed int64
+	count   atomic.Int64
+}
+
+func (r *failAfterProxyV2Recorder) Record(recorder.Entry) error {
+	if r.count.Add(1) > r.allowed {
+		return errors.New("v2 record failed")
+	}
+	return nil
+}
+
+func requireReceiptEmissionFailedLayer(t *testing.T, receipts []receipt.Receipt) receipt.Receipt {
+	t.Helper()
+	for _, rcpt := range receipts {
+		if rcpt.ActionRecord.Layer == receiptEmissionFailedLayer {
+			return rcpt
+		}
+	}
+	var layers []string
+	for _, rcpt := range receipts {
+		layers = append(layers, rcpt.ActionRecord.Layer)
+	}
+	t.Fatalf("missing receipt layer %q in layers %v", receiptEmissionFailedLayer, layers)
+	return receipt.Receipt{}
+}
 
 // --- Unit tests for the EmitOpts -> v2 Decision derivation ---
 

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -687,21 +687,26 @@ func TestWSProxyRequireReceipts_UpstreamDialFailureEmitsOutcome(t *testing.T) {
 		t.Fatalf("set read deadline: %v", deadlineErr)
 	}
 	hdr, err := ws.ReadHeader(conn)
-	if err != nil {
+	if errors.Is(err, io.EOF) {
+		// The security contract is the durable outcome receipt below. The close
+		// frame is best-effort once the upstream dial has failed and the handler
+		// returns, so some kernels surface EOF before the client parses it.
+	} else if err != nil {
 		t.Fatalf("read close frame header: %v", err)
-	}
-	if hdr.OpCode != ws.OpClose {
-		t.Fatalf("opcode = %v, want OpClose", hdr.OpCode)
-	}
-	payload := make([]byte, hdr.Length)
-	if _, err := io.ReadFull(conn, payload); err != nil {
-		t.Fatalf("read close frame payload: %v", err)
-	}
-	if len(payload) < 2 {
-		t.Fatalf("close frame payload length = %d, want status code", len(payload))
-	}
-	if got := ws.StatusCode(binary.BigEndian.Uint16(payload[:2])); got != ws.StatusInternalServerError {
-		t.Fatalf("close code = %v, want %v", got, ws.StatusInternalServerError)
+	} else {
+		if hdr.OpCode != ws.OpClose {
+			t.Fatalf("opcode = %v, want OpClose", hdr.OpCode)
+		}
+		payload := make([]byte, hdr.Length)
+		if _, err := io.ReadFull(conn, payload); err != nil {
+			t.Fatalf("read close frame payload: %v", err)
+		}
+		if len(payload) < 2 {
+			t.Fatalf("close frame payload length = %d, want status code", len(payload))
+		}
+		if got := ws.StatusCode(binary.BigEndian.Uint16(payload[:2])); got != ws.StatusInternalServerError {
+			t.Fatalf("close code = %v, want %v", got, ws.StatusInternalServerError)
+		}
 	}
 
 	testwait.For(t, 2*time.Second, func() bool {

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -373,19 +373,9 @@ func (e *Emitter) EmitHeartbeat() error {
 		Transport: sessionControlTransport,
 		Target:    sessionHeartbeatTarget,
 	}, false, func() (*SessionControl, error) {
-		e.heartbeatBeat++
 		return &SessionControl{
-			Kind: SessionControlHeartbeat,
-			Heartbeat: &SessionHeartbeat{
-				RunNonce:         e.runNonce,
-				OpenNonce:        e.openNonce,
-				Beat:             e.heartbeatBeat,
-				ChainHead:        e.chainPrevHash,
-				ChainSeqHead:     PreviousChainSeq(e.chainSeq),
-				HeartbeatTime:    time.Now().UTC().Format(time.RFC3339Nano),
-				FsyncErrorsGated: e.recorder.FsyncErrorsGated(),
-				DurabilityBlocks: e.DurabilityBlocks(),
-			},
+			Kind:      SessionControlHeartbeat,
+			Heartbeat: &SessionHeartbeat{},
 		}, nil
 	})
 }
@@ -407,17 +397,8 @@ func (e *Emitter) EmitSessionClose(closeReason string) error {
 			return nil, nil
 		}
 		return &SessionControl{
-			Kind: SessionControlClose,
-			Close: &SessionClose{
-				RunNonce:         e.runNonce,
-				OpenNonce:        e.openNonce,
-				FinalSeq:         e.chainSeq,
-				RootHash:         e.chainPrevHash,
-				ReceiptCount:     e.chainSeq + 1,
-				CloseReason:      closeReason,
-				FsyncErrorsGated: e.recorder.FsyncErrorsGated(),
-				DurabilityBlocks: e.DurabilityBlocks(),
-			},
+			Kind:  SessionControlClose,
+			Close: &SessionClose{CloseReason: closeReason},
 		}, nil
 	})
 }
@@ -664,6 +645,41 @@ func (e *Emitter) prepareSessionControlLocked(in *SessionControl) (*SessionContr
 	chainPrevHash := e.chainPrevHash
 	if in == nil {
 		return nil, chainPrevHash, nil
+	}
+	if in.Kind == SessionControlHeartbeat {
+		e.heartbeatBeat++
+		return &SessionControl{
+			Kind: SessionControlHeartbeat,
+			Heartbeat: &SessionHeartbeat{
+				RunNonce:         e.runNonce,
+				OpenNonce:        e.openNonce,
+				Beat:             e.heartbeatBeat,
+				ChainHead:        e.chainPrevHash,
+				ChainSeqHead:     PreviousChainSeq(e.chainSeq),
+				HeartbeatTime:    time.Now().UTC().Format(time.RFC3339Nano),
+				FsyncErrorsGated: e.recorder.FsyncErrorsGated(),
+				DurabilityBlocks: e.DurabilityBlocks(),
+			},
+		}, chainPrevHash, nil
+	}
+	if in.Kind == SessionControlClose {
+		closeReason := ""
+		if in.Close != nil {
+			closeReason = in.Close.CloseReason
+		}
+		return &SessionControl{
+			Kind: SessionControlClose,
+			Close: &SessionClose{
+				RunNonce:         e.runNonce,
+				OpenNonce:        e.openNonce,
+				FinalSeq:         e.chainSeq,
+				RootHash:         e.chainPrevHash,
+				ReceiptCount:     e.chainSeq + 1,
+				CloseReason:      closeReason,
+				FsyncErrorsGated: e.recorder.FsyncErrorsGated(),
+				DurabilityBlocks: e.DurabilityBlocks(),
+			},
+		}, chainPrevHash, nil
 	}
 	if !isSessionOpenControl(in) {
 		return cloneSessionControl(in), chainPrevHash, nil

--- a/internal/receipt/session_control_emit_test.go
+++ b/internal/receipt/session_control_emit_test.go
@@ -579,6 +579,13 @@ func TestEmitter_ForgedHeartbeatAndCloseFieldsAreRecomputed(t *testing.T) {
 	if heartbeat.HeartbeatTime == "2099-01-01T00:00:00Z" {
 		t.Fatalf("heartbeat_time preserved forged value")
 	}
+	hbControl := afterHeartbeatReceipts[len(afterHeartbeatReceipts)-1].ActionRecord.SessionControl
+	if hbControl.Open != nil {
+		t.Fatalf("forged Open sub-struct persisted in heartbeat receipt")
+	}
+	if hbControl.Close != nil {
+		t.Fatalf("forged Close sub-struct persisted in heartbeat receipt")
+	}
 
 	preCloseReceipts := readAllReceiptsFromDir(t, dir, pub)
 	preCloseTail := mustHash(t, preCloseReceipts[len(preCloseReceipts)-1])
@@ -629,6 +636,13 @@ func TestEmitter_ForgedHeartbeatAndCloseFieldsAreRecomputed(t *testing.T) {
 	}
 	if res := VerifyChain(receipts, hex.EncodeToString(pub)); !res.Valid {
 		t.Fatalf("VerifyChain: %s", res.Error)
+	}
+	closeControl := receipts[len(receipts)-1].ActionRecord.SessionControl
+	if closeControl.Open != nil {
+		t.Fatalf("forged Open sub-struct persisted in close receipt")
+	}
+	if closeControl.Heartbeat != nil {
+		t.Fatalf("forged Heartbeat sub-struct persisted in close receipt")
 	}
 }
 

--- a/internal/receipt/session_control_emit_test.go
+++ b/internal/receipt/session_control_emit_test.go
@@ -510,6 +510,128 @@ func TestEmitter_HeartbeatAndCloseWithoutSessionOpenUseEmptyOpenNonce(t *testing
 	}
 }
 
+func TestEmitter_ForgedHeartbeatAndCloseFieldsAreRecomputed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, Principal: testPrincipal, Actor: testActor})
+
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := e.Emit(EmitOpts{
+		ActionID:  NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: testTransport,
+		Method:    http.MethodGet,
+		Target:    "https://api.vendor.example/pre-forge",
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	preHeartbeatReceipts := readAllReceiptsFromDir(t, dir, pub)
+	preHeartbeatTail := mustHash(t, preHeartbeatReceipts[len(preHeartbeatReceipts)-1])
+	preHeartbeatSeqHead := uint64(len(preHeartbeatReceipts)) - 1
+	openNonce := preHeartbeatReceipts[0].ActionRecord.SessionControl.Open.OpenNonce
+
+	if err := e.Emit(EmitOpts{
+		ActionID:  NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: sessionControlTransport,
+		Target:    sessionHeartbeatTarget,
+		SessionControl: &SessionControl{
+			Kind: SessionControlHeartbeat,
+			Open: &SessionOpen{
+				RunNonce: "forged-open",
+			},
+			Heartbeat: &SessionHeartbeat{
+				RunNonce:         "forged-run",
+				OpenNonce:        "forged-open",
+				Beat:             999,
+				ChainHead:        "forged-chain-head",
+				ChainSeqHead:     999,
+				HeartbeatTime:    "2099-01-01T00:00:00Z",
+				FsyncErrorsGated: 999,
+				DurabilityBlocks: 999,
+			},
+			Close: &SessionClose{
+				RootHash: "forged-close",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("forged heartbeat Emit: %v", err)
+	}
+	afterHeartbeatReceipts := readAllReceiptsFromDir(t, dir, pub)
+	heartbeat := afterHeartbeatReceipts[len(afterHeartbeatReceipts)-1].ActionRecord.SessionControl.Heartbeat
+	if heartbeat == nil {
+		t.Fatalf("tail receipt is not heartbeat: %#v", afterHeartbeatReceipts[len(afterHeartbeatReceipts)-1].ActionRecord.SessionControl)
+	}
+	if heartbeat.RunNonce != e.runNonce ||
+		heartbeat.OpenNonce != openNonce ||
+		heartbeat.Beat != 1 ||
+		heartbeat.ChainHead != preHeartbeatTail ||
+		heartbeat.ChainSeqHead != preHeartbeatSeqHead ||
+		heartbeat.FsyncErrorsGated != 0 ||
+		heartbeat.DurabilityBlocks != 0 {
+		t.Fatalf("heartbeat was not recomputed from chain state: %+v", heartbeat)
+	}
+	if heartbeat.HeartbeatTime == "2099-01-01T00:00:00Z" {
+		t.Fatalf("heartbeat_time preserved forged value")
+	}
+
+	preCloseReceipts := readAllReceiptsFromDir(t, dir, pub)
+	preCloseTail := mustHash(t, preCloseReceipts[len(preCloseReceipts)-1])
+	if err := e.Emit(EmitOpts{
+		ActionID:  NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: sessionControlTransport,
+		Target:    sessionCloseTarget,
+		SessionControl: &SessionControl{
+			Kind: SessionControlClose,
+			Open: &SessionOpen{
+				RunNonce: "forged-open",
+			},
+			Heartbeat: &SessionHeartbeat{
+				ChainHead: "forged-heartbeat",
+			},
+			Close: &SessionClose{
+				RunNonce:         "forged-run",
+				OpenNonce:        "forged-open",
+				FinalSeq:         999,
+				RootHash:         "forged-root",
+				ReceiptCount:     999,
+				CloseReason:      "operator_shutdown",
+				FsyncErrorsGated: 999,
+				DurabilityBlocks: 999,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("forged close Emit: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	receipts := readAllReceiptsFromDir(t, dir, pub)
+	closeRecord := receipts[len(receipts)-1].ActionRecord.SessionControl.Close
+	if closeRecord == nil {
+		t.Fatalf("tail receipt is not session_close: %#v", receipts[len(receipts)-1].ActionRecord.SessionControl)
+	}
+	if closeRecord.RunNonce != e.runNonce ||
+		closeRecord.OpenNonce != openNonce ||
+		closeRecord.FinalSeq != uint64(len(preCloseReceipts)) ||
+		closeRecord.RootHash != preCloseTail ||
+		closeRecord.ReceiptCount != uint64(len(preCloseReceipts))+1 ||
+		closeRecord.FsyncErrorsGated != 0 ||
+		closeRecord.DurabilityBlocks != 0 ||
+		closeRecord.CloseReason != "operator_shutdown" {
+		t.Fatalf("close was not recomputed from chain state: %+v", closeRecord)
+	}
+	if res := VerifyChain(receipts, hex.EncodeToString(pub)); !res.Valid {
+		t.Fatalf("VerifyChain: %s", res.Error)
+	}
+}
+
 func readTranscriptRootFromDir(t *testing.T, dir string) TranscriptRoot {
 	t.Helper()
 	entries := readAllEntriesFromDir(t, dir)


### PR DESCRIPTION
## What changed

This closes a class of receipt-emission completeness gaps where an egress happened or a decision was made but the signed evidence for it was dropped, mislabeled, or forgeable. It hardens the same class across every mediated transport: MCP, the generic forward/CONNECT proxy, and the reverse proxy.

Under `flight_recorder.require_receipts`, a v2 proxy-decision emit failure now fails closed instead of being silently non-blocking. This holds on the MCP path and, for parity, on the generic proxy and reverse-proxy paths, where a required v2 receipt failure now blocks before egress and records a signed `receipt_emission_failed` gap marker rather than letting the request through unrecorded.

When a response-side required-receipt emission fails and flips the client response to a block, a replacement block receipt is now emitted so a denied action always leaves signed evidence. The same gap-marker treatment now covers the generic proxy and reverse outcome paths.

Two outcome-accounting fixes make the receipt match what actually egressed: budget-truncated responses now route through allow finalization so the allow receipt is emitted for the bytes that were sent, and the reverse-proxy outcome reason reflects the `unscannable_passthrough` sub-case instead of a hardcoded `binary_passthrough`.

Session heartbeat and close lifecycle fields are now recomputed from authoritative chain state before signing, so a caller supplying an out-of-band `SessionControl` cannot sign a lifecycle receipt with false chain-position claims. A normal heartbeat or close is unchanged; a forged inbound one is overwritten with the real chain values.

## Why

These are all fail-safe hardenings on the evidence path: every one either restores a dropped receipt for an egress that happened, blocks an egress that could not be recorded under `require_receipts`, corrects an outcome record so it matches reality, or removes a way to sign a false lifecycle claim. Each fix is proven by a test that fails without it. Behavior is unchanged when `require_receipts` is off (best-effort emission).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened fail-closed behavior for required receipts: v2 receipt emission failures now reliably block when required and emit durable “receipt emission failed”/outcome gap markers (including replacement block receipts where applicable).
  * Ensured optional receipts still fail gracefully while surfacing the underlying v2 emission error.
  * Refined forward-proxy response-budget truncation finalization and labeling.
  * Hardened session-control heartbeat/close recomputation and improved WebSocket close-frame handling on upstream dial failures.
* **Tests**
  * Expanded coverage for required vs optional v2 receipt failure handling across forward, reverse, and intercept paths, plus budget-truncated egress and WebSocket behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->