### PR TITLE
fix(baseline): fingerprint integrity diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Discord community
+    url: https://discord.gg/badNfhGKTc
+    about: Ask questions and discuss Pipelock with the community.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,6 +230,7 @@ Pipelock keeps its direct dependency set intentionally small. Any new dependency
 - **Bugs**: Open a GitHub issue with steps to reproduce
 - **Features**: Open a GitHub issue describing the use case
 - **Scanner bypasses**: Use the security bypass issue template
+- **Questions and community discussion**: Join the Discord community at https://discord.gg/badNfhGKTc
 
 ## Contributor License Agreement
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://github.com/luckyPipewrench/pipelock/actions/workflows/ci.yaml"><img alt="CI" src="https://github.com/luckyPipewrench/pipelock/actions/workflows/ci.yaml/badge.svg"></a>
   <a href="https://github.com/luckyPipewrench/pipelock/actions/workflows/security.yaml"><img alt="Security" src="https://github.com/luckyPipewrench/pipelock/actions/workflows/security.yaml/badge.svg"></a>
   <a href="https://github.com/luckyPipewrench/pipelock/releases"><img alt="Release" src="https://img.shields.io/github/v/release/luckyPipewrench/pipelock"></a>
+  <a href="https://discord.gg/badNfhGKTc"><img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white"></a>
   <a href="LICENSE"><img alt="Core Apache 2.0" src="https://img.shields.io/badge/Core-Apache_2.0-blue.svg"></a>
   <a href="enterprise/LICENSE"><img alt="Enterprise ELv2" src="https://img.shields.io/badge/Enterprise-ELv2-orange.svg"></a>
   <a href="https://landscape.cncf.io/?item=provisioning--security-compliance--pipelock"><img alt="CNCF Landscape: Security &amp; Compliance" src="https://img.shields.io/badge/CNCF%20Landscape-Security%20%26%20Compliance-1a73e8?logo=cncf&logoColor=white"></a>
@@ -17,7 +18,6 @@
   <a href="https://scorecard.dev/viewer/?uri=github.com/luckyPipewrench/pipelock"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/luckyPipewrench/pipelock/badge"></a>
   <a href="https://www.bestpractices.dev/projects/11948"><img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/11948/badge?level=silver"></a>
   <a href="https://codecov.io/gh/luckyPipewrench/pipelock"><img alt="codecov" src="https://codecov.io/gh/luckyPipewrench/pipelock/graph/badge.svg"></a>
-  <a href="https://goreportcard.com/report/github.com/luckyPipewrench/pipelock"><img alt="Go Report" src="https://goreportcard.com/badge/github.com/luckyPipewrench/pipelock"></a>
   <a href="https://github.com/luckyPipewrench/pipelock/blob/main/.github/workflows/ci.yaml#L21-L35"><img alt="pipelock self-scanned" src="https://img.shields.io/badge/pipelock-self--scanned-00FFC8?style=flat&labelColor=1A1A2E&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNCAxNCI+PHBhdGggZmlsbD0iIzAwRkZDOCIgZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik03IDAuNWMtMS45MyAwLTMuNSAxLjY2LTMuNSAzLjd2MS4zSDNjLS44MyAwLTEuNSAuNjctMS41IDEuNXY2YzAgLjgzLjY3IDEuNSAxLjUgMS41aDhjLjgzIDAgMS41LS42NyAxLjUtMS41VjdjMC0uODMtLjY3LTEuNS0xLjUtMS41aC0uNVY0LjJjMC0yLjA0LTEuNTctMy43LTMuNS0zLjdabS0yIDVWNC4yYzAtMS40OSAxLjEyLTIuNyAyLjUtMi43czIuNSAxLjIxIDIuNSAyLjd2MS4zSDVaTTIuNSA1aDJ2MS4yaC0yVjVabTcgMGgydjEuMmgtMlY1Wk03IDguMmMtLjY5IDAtMS4yNS41Ni0xLjI1IDEuMjUgMCAuNDQuMjMuODMuNTcgMS4wNXYxLjVoMS4zNnYtMS41Yy4zNC0uMjIuNTctLjYxLjU3LTEuMDUgMC0uNjktLjU2LTEuMjUtMS4yNS0xLjI1WiIvPjwvc3ZnPgo="></a>
 </p>
 

--- a/internal/proxy/baseline/baseline.go
+++ b/internal/proxy/baseline/baseline.go
@@ -1198,14 +1198,15 @@ func (m *Manager) integrityLogAttrs(failureClass string, err error, attrs ...any
 		"key_path", m.cfg.IntegrityKeyPath,
 		"high_water_path", m.integrityHighWaterPath(),
 		"deviation_action", m.cfg.DeviationAction,
-		"error", err,
 	})
+	if err != nil {
+		fields = append(fields, "error_sha256", logValueFingerprint("baseline-integrity-error-v1", err.Error()))
+	}
 	// Caller-supplied attrs carry agent-influenced identifiers (agent_key,
-	// declared_agent_key, profile names). Neutralize log-control characters in
-	// every value before it reaches the log sink so a crafted identifier cannot
-	// forge or split a log line. slog handlers already quote attribute values;
-	// this adds a concrete sanitizer for static analysis and defense-in-depth.
-	return append(fields, sanitizeLogAttrs(attrs)...)
+	// declared_agent_key, profile names). Preserve correlation through stable
+	// fingerprints instead of logging attacker-influenced strings in the generic
+	// integrity failure sinks.
+	return append(fields, integrityDiagnosticLogAttrs(attrs)...)
 }
 
 func (m *Manager) pendingProfileIntegrityNonEnforcingLogAttrs(agentKey string) []any {
@@ -1218,6 +1219,40 @@ func (m *Manager) pendingProfileIntegrityNonEnforcingLogAttrs(agentKey string) [
 		"deviation_action", m.cfg.DeviationAction,
 		"agent_key_sha256", logValueFingerprint("baseline-agent-key-v1", agentKey),
 	})
+}
+
+func integrityDiagnosticLogAttrs(attrs []any) []any {
+	if len(attrs) == 0 {
+		return attrs
+	}
+	out := make([]any, 0, len(attrs))
+	for i := 0; i < len(attrs); i++ {
+		if attr, ok := attrs[i].(slog.Attr); ok {
+			appendIntegrityDiagnosticLogAttr(&out, attr.Key, attr.Value.Any())
+			continue
+		}
+		key, ok := attrs[i].(string)
+		if !ok || i+1 >= len(attrs) {
+			continue
+		}
+		i++
+		appendIntegrityDiagnosticLogAttr(&out, key, attrs[i])
+	}
+	return out
+}
+
+func appendIntegrityDiagnosticLogAttr(out *[]any, key string, value any) {
+	key = sanitizeLogValue(key)
+	switch v := value.(type) {
+	case string:
+		*out = append(*out, key+"_sha256", logValueFingerprint("baseline-integrity-"+key+"-v1", v))
+	case error:
+		*out = append(*out, key+"_sha256", logValueFingerprint("baseline-integrity-"+key+"-v1", v.Error()))
+	case slog.Attr:
+		appendIntegrityDiagnosticLogAttr(out, v.Key, v.Value.Any())
+	default:
+		*out = append(*out, key, value)
+	}
 }
 
 func logValueFingerprint(scope, value string) string {

--- a/internal/proxy/baseline/log_injection_test.go
+++ b/internal/proxy/baseline/log_injection_test.go
@@ -90,10 +90,14 @@ func TestSanitizeLogAttrsNeutralizesStringValues(t *testing.T) {
 	}
 }
 
-func TestIntegrityLogAttrsSanitizesErrors(t *testing.T) {
+func TestIntegrityLogAttrsFingerprintsUserInfluencedDiagnostics(t *testing.T) {
 	mgr := &Manager{cfg: Config{ProfileDir: "profiles\n", DeviationAction: deviationActionBlock}}
 	err := fmt.Errorf("wrapping raw failure: %w", errors.New("disk\nforged=true\x1b[31m"))
-	attrs := mgr.integrityLogAttrs("failure\nclass", err, "agent_key", "evil\ragent")
+	attrs := mgr.integrityLogAttrs("failure\nclass", err,
+		"agent_key", "evil\ragent",
+		"generation", uint64(7),
+		slog.String("declared_agent_key", "declared\nagent"),
+	)
 
 	attrValues := map[string]any{}
 	for i := 0; i < len(attrs)-1; i += 2 {
@@ -103,7 +107,7 @@ func TestIntegrityLogAttrsSanitizesErrors(t *testing.T) {
 		}
 		attrValues[key] = attrs[i+1]
 	}
-	for _, key := range []string{"failure_class", "profile_dir", "error", "agent_key"} {
+	for _, key := range []string{"failure_class", "profile_dir"} {
 		got, ok := attrValues[key].(string)
 		if !ok {
 			t.Fatalf("attr %q = %#v, want sanitized string", key, attrValues[key])
@@ -111,6 +115,23 @@ func TestIntegrityLogAttrsSanitizesErrors(t *testing.T) {
 		if containsUnsafeLogRune(got) {
 			t.Fatalf("attr %q retained a log-control rune: %q", key, got)
 		}
+	}
+	for _, key := range []string{"error", "agent_key", "declared_agent_key"} {
+		if _, ok := attrValues[key]; ok {
+			t.Fatalf("attr %q must not expose raw user-influenced text: %#v", key, attrValues[key])
+		}
+	}
+	for _, key := range []string{"error_sha256", "agent_key_sha256", "declared_agent_key_sha256"} {
+		got, ok := attrValues[key].(string)
+		if !ok {
+			t.Fatalf("attr %q = %#v, want string fingerprint", key, attrValues[key])
+		}
+		if len(got) != sha256HexLength || containsUnsafeLogRune(got) {
+			t.Fatalf("attr %q is not a safe fingerprint: %q", key, got)
+		}
+	}
+	if attrValues["generation"] != uint64(7) {
+		t.Fatalf("generation attr = %#v, want 7", attrValues["generation"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- fingerprint baseline integrity diagnostic values before generic failure logging
- keep operator correlation fields without logging raw agent-influenced text
- add Discord community links and remove the sunset Go Report Card badge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Discord community option to issue reporting and contribution guidance.
  * Added a community badge to the README header.

* **Bug Fixes**
  * Improved logging safety by masking sensitive or user-provided details in failure logs while still keeping useful diagnostics.

* **Documentation**
  * Updated contributor and README documentation to point to the community channel for questions and discussion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->