### PR TITLE
chore(release): group and filter changelog, add branded release footer

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -121,7 +121,7 @@ signs:
     output: true
 
 changelog:
-  use: github
+  use: git
   sort: asc
   filters:
     exclude:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -121,12 +121,43 @@ signs:
     output: true
 
 changelog:
+  use: github
   sort: asc
   filters:
     exclude:
       - '^docs:'
       - '^test:'
       - '^chore:'
+      - '^ci:'
+      - '^style:'
+      - '^build:'
+      - '^Merge '
+      - 'go mod tidy'
+  groups:
+    - title: '🚀 Features'
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: '🐛 Bug Fixes'
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: '🔒 Security'
+      regexp: '^.*?sec(urity)?(\(.+\))??!?:.+$'
+      order: 2
+    - title: '⚡ Performance'
+      regexp: '^.*?perf(\(.+\))??!?:.+$'
+      order: 3
+    - title: '📦 Dependencies'
+      regexp: '^.*?deps(\(.+\))??!?:.+$'
+      order: 4
+    - title: 'Other Changes'
+      order: 999
+
+release:
+  footer: |
+    ---
+    📚 Docs: https://pipelab.org  •  💬 Community: https://discord.gg/badNfhGKTc
+
+    Pipelock is an open-source agent firewall. Come poke holes in it.
 
 brews:
   - ids: [pipelock]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -147,7 +147,7 @@ changelog:
       regexp: '^.*?perf(\(.+\))??!?:.+$'
       order: 3
     - title: '📦 Dependencies'
-      regexp: '^.*?deps(\(.+\))??!?:.+$'
+      regexp: '^.*?((build|chore)\(deps.*?\)|deps(\(.+\))?)!?:.+$'
       order: 4
     - title: 'Other Changes'
       order: 999


### PR DESCRIPTION
Groups and filters the GoReleaser changelog so release notes come out organized by type instead of a flat commit dump. Sections are Features, Bug Fixes, Security, Performance, Dependencies, and Other Changes, and noise is excluded (docs, test, chore, ci, style, build, merge commits, tidy). Switches to GitHub mode so releases get PR links and an automatic New Contributors section.

Adds a small branded release footer linking the docs (pipelab.org) and the community Discord.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved changelog organization by grouping entries into clearer categories (including an “Other Changes” catch-all).
  * Added a consistent release footer with a separator, community/docs links, and a short product description.

* **Chores**
  * Expanded commit/message filtering to omit non-user-facing entries, producing cleaner and more relevant release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->