### PR TITLE
feat(verifier): wasm raw receipt-chain verification with parity harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LDFLAGS := -ldflags "-s -w \
 	-X $(MODULE)/internal/license.PublicKeyHex=$(LICENSE_PUBLIC_KEY) \
 	-X $(MODULE)/internal/rules.KeyringHex=$(RULES_KEYRING_HEX)"
 
-.PHONY: all build build-verifier test bench bench-egress bench-egress-long bench-egress-release lint test-stability-check clean docker install fmt vet tidy-check fuzz stats docs-check \
+.PHONY: all build build-verifier test test-wasm-verifier bench bench-egress bench-egress-long bench-egress-release lint test-stability-check clean docker install fmt vet tidy-check fuzz stats docs-check \
 	test-runtime-critical test-replay-harness release-audit runtime-policy-audit debt-check release-check hermes-e2e test-liveproof
 
 all: build
@@ -38,6 +38,9 @@ install:
 
 test:
 	go test -race -count=1 ./...
+
+test-wasm-verifier:
+	node --test deploy/wasm-verify/chain-parity.test.js
 
 test-runtime-critical:
 	go test -race -count=1 ./internal/config ./internal/cli ./internal/mcp ./internal/proxy

--- a/cmd/pipelock-verifier-wasm/main.go
+++ b/cmd/pipelock-verifier-wasm/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"strings"
 	"syscall/js"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/playground"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
@@ -46,6 +47,7 @@ type wasmChainSegment struct {
 	SignerKey string `json:"signerKey"`
 	FirstSeq  uint64 `json:"firstSeq"`
 	FinalSeq  uint64 `json:"finalSeq"`
+	Count     uint64 `json:"count"`
 	Boundary  bool   `json:"boundary"`
 }
 
@@ -266,10 +268,10 @@ func chainResult(result receipt.ChainResult, observed int) wasmResult {
 		out.BrokenAtIndex = &brokenAtIndex
 	}
 	if !result.StartTime.IsZero() {
-		out.StartTime = result.StartTime.Format("2006-01-02T15:04:05Z")
+		out.StartTime = result.StartTime.Format(time.RFC3339Nano)
 	}
 	if !result.EndTime.IsZero() {
-		out.EndTime = result.EndTime.Format("2006-01-02T15:04:05Z")
+		out.EndTime = result.EndTime.Format(time.RFC3339Nano)
 	}
 	if len(result.Segments) > 0 {
 		out.Segments = make([]wasmChainSegment, 0, len(result.Segments))
@@ -278,6 +280,7 @@ func chainResult(result receipt.ChainResult, observed int) wasmResult {
 				SignerKey: segment.SignerKey,
 				FirstSeq:  segment.FirstSeq,
 				FinalSeq:  segment.FinalSeq,
+				Count:     segment.Count,
 				Boundary:  segment.Boundary,
 			})
 		}

--- a/cmd/pipelock-verifier-wasm/main.go
+++ b/cmd/pipelock-verifier-wasm/main.go
@@ -157,6 +157,21 @@ func bytesValue(v js.Value, label string, stringFn func(string) ([]byte, error))
 	}
 }
 
+// tryDecodeBase64 attempts standard then raw (unpadded) base64 decoding of an
+// already-whitespace-compacted string. Shared by the bundle and chain string
+// paths so the two decode attempts cannot drift; only the non-base64 fallback
+// differs between callers (bundle compacts whitespace, chain preserves it for
+// JSONL parsing).
+func tryDecodeBase64(compact string) ([]byte, bool) {
+	if decoded, err := base64.StdEncoding.DecodeString(compact); err == nil {
+		return decoded, true
+	}
+	if decoded, err := base64.RawStdEncoding.DecodeString(compact); err == nil {
+		return decoded, true
+	}
+	return nil, false
+}
+
 func stringBundleBytes(s string) ([]byte, error) {
 	s = strings.TrimSpace(s)
 	if i := strings.IndexByte(s, ','); strings.HasPrefix(s, "data:") && i >= 0 {
@@ -166,10 +181,7 @@ func stringBundleBytes(s string) ([]byte, error) {
 	if s == "" {
 		return nil, fmt.Errorf("bundle string is empty")
 	}
-	if decoded, err := base64.StdEncoding.DecodeString(s); err == nil {
-		return decoded, nil
-	}
-	if decoded, err := base64.RawStdEncoding.DecodeString(s); err == nil {
+	if decoded, ok := tryDecodeBase64(s); ok {
 		return decoded, nil
 	}
 	return []byte(s), nil
@@ -183,11 +195,7 @@ func stringChainBytes(s string) ([]byte, error) {
 	if raw == "" {
 		return nil, fmt.Errorf("chain string is empty")
 	}
-	compact := compactASCIIWhitespace(raw)
-	if decoded, err := base64.StdEncoding.DecodeString(compact); err == nil {
-		return decoded, nil
-	}
-	if decoded, err := base64.RawStdEncoding.DecodeString(compact); err == nil {
+	if decoded, ok := tryDecodeBase64(compactASCIIWhitespace(raw)); ok {
 		return decoded, nil
 	}
 	return []byte(raw), nil

--- a/cmd/pipelock-verifier-wasm/main.go
+++ b/cmd/pipelock-verifier-wasm/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall/js"
 
 	"github.com/luckyPipewrench/pipelock/internal/playground"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
 
 type wasmCheck struct {
@@ -21,15 +22,36 @@ type wasmCheck struct {
 }
 
 type wasmResult struct {
-	Valid    bool        `json:"valid"`
-	Checks   []wasmCheck `json:"checks"`
-	RunNonce string      `json:"runNonce,omitempty"`
-	Observed int         `json:"observed"`
-	Error    string      `json:"error,omitempty"`
+	Valid              bool               `json:"valid"`
+	Checks             []wasmCheck        `json:"checks"`
+	RunNonce           string             `json:"runNonce,omitempty"`
+	Observed           int                `json:"observed"`
+	Error              string             `json:"error,omitempty"`
+	Reason             string             `json:"reason,omitempty"`
+	IntegrityVerified  bool               `json:"integrityVerified,omitempty"`
+	ReceiptCount       uint64             `json:"receiptCount,omitempty"`
+	FinalSeq           uint64             `json:"finalSeq,omitempty"`
+	RootHash           string             `json:"rootHash,omitempty"`
+	StartTime          string             `json:"startTime,omitempty"`
+	EndTime            string             `json:"endTime,omitempty"`
+	FailureKind        string             `json:"failureKind,omitempty"`
+	BrokenAtSeq        *uint64            `json:"brokenAtSeq,omitempty"`
+	BrokenAtIndex      *int               `json:"brokenAtIndex,omitempty"`
+	SignerKeys         []string           `json:"signerKeys,omitempty"`
+	Segments           []wasmChainSegment `json:"segments,omitempty"`
+	UntrustedSignerKey string             `json:"untrustedSignerKey,omitempty"`
+}
+
+type wasmChainSegment struct {
+	SignerKey string `json:"signerKey"`
+	FirstSeq  uint64 `json:"firstSeq"`
+	FinalSeq  uint64 `json:"finalSeq"`
+	Boundary  bool   `json:"boundary"`
 }
 
 func main() {
 	js.Global().Set("pipelockVerifyBundle", js.FuncOf(verifyBundle))
+	js.Global().Set("pipelockVerifyChain", js.FuncOf(verifyChain))
 	select {}
 }
 
@@ -64,12 +86,61 @@ func verifyBundle(_ js.Value, args []js.Value) (ret any) {
 	return resultValue(out)
 }
 
+func verifyChain(_ js.Value, args []js.Value) (ret any) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = resultValue(wasmResult{Valid: false, Error: fmt.Sprintf("verify panic: %v", r)})
+		}
+	}()
+	if len(args) != 2 {
+		return resultValue(wasmResult{Valid: false, Error: "expected chain bytes and trusted key argument"})
+	}
+	chain, err := chainBytes(args[0])
+	if err != nil {
+		return resultValue(wasmResult{Valid: false, Error: err.Error()})
+	}
+	keys, err := trustedKeys(args[1])
+	if err != nil {
+		return resultValue(wasmResult{Valid: false, Error: err.Error()})
+	}
+	receipts, err := receipt.ExtractReceiptsBytes(chain)
+	if err != nil {
+		return resultValue(wasmResult{
+			Valid:  false,
+			Checks: []wasmCheck{{Name: "raw_receipts_extracted", Pass: false}},
+			Error:  err.Error(),
+		})
+	}
+	if len(receipts) == 0 {
+		return resultValue(wasmResult{
+			Valid:  false,
+			Checks: []wasmCheck{{Name: "raw_receipts_extracted", Pass: false}},
+			Error:  "no receipts found in chain",
+		})
+	}
+	result := receipt.VerifyChainTrusted(receipts, keys)
+	out := chainResult(result, len(receipts))
+	out.Checks = []wasmCheck{
+		{Name: "raw_receipts_extracted", Pass: true},
+		{Name: "receipt_chain_verified", Pass: result.Valid},
+	}
+	return resultValue(out)
+}
+
 func bundleBytes(v js.Value) ([]byte, error) {
+	return bytesValue(v, "bundle", stringBundleBytes)
+}
+
+func chainBytes(v js.Value) ([]byte, error) {
+	return bytesValue(v, "chain", stringChainBytes)
+}
+
+func bytesValue(v js.Value, label string, stringFn func(string) ([]byte, error)) ([]byte, error) {
 	uint8Array := js.Global().Get("Uint8Array")
 	arrayBuffer := js.Global().Get("ArrayBuffer")
 	switch {
 	case v.Type() == js.TypeString:
-		return stringBundleBytes(v.String())
+		return stringFn(v.String())
 	case uint8Array.Truthy() && v.InstanceOf(uint8Array):
 		out := make([]byte, v.Get("byteLength").Int())
 		js.CopyBytesToGo(out, v)
@@ -80,7 +151,7 @@ func bundleBytes(v js.Value) ([]byte, error) {
 		js.CopyBytesToGo(out, u8)
 		return out, nil
 	default:
-		return nil, fmt.Errorf("bundle must be a Uint8Array, ArrayBuffer, or base64 string")
+		return nil, fmt.Errorf("%s must be a Uint8Array, ArrayBuffer, or base64 string", label)
 	}
 }
 
@@ -89,14 +160,7 @@ func stringBundleBytes(s string) ([]byte, error) {
 	if i := strings.IndexByte(s, ','); strings.HasPrefix(s, "data:") && i >= 0 {
 		s = s[i+1:]
 	}
-	s = strings.Map(func(r rune) rune {
-		switch r {
-		case '\r', '\n', '\t', ' ':
-			return -1
-		default:
-			return r
-		}
-	}, s)
+	s = compactASCIIWhitespace(s)
 	if s == "" {
 		return nil, fmt.Errorf("bundle string is empty")
 	}
@@ -107,6 +171,118 @@ func stringBundleBytes(s string) ([]byte, error) {
 		return decoded, nil
 	}
 	return []byte(s), nil
+}
+
+func stringChainBytes(s string) ([]byte, error) {
+	raw := strings.TrimSpace(s)
+	if i := strings.IndexByte(raw, ','); strings.HasPrefix(raw, "data:") && i >= 0 {
+		raw = raw[i+1:]
+	}
+	if raw == "" {
+		return nil, fmt.Errorf("chain string is empty")
+	}
+	compact := compactASCIIWhitespace(raw)
+	if decoded, err := base64.StdEncoding.DecodeString(compact); err == nil {
+		return decoded, nil
+	}
+	if decoded, err := base64.RawStdEncoding.DecodeString(compact); err == nil {
+		return decoded, nil
+	}
+	return []byte(raw), nil
+}
+
+func compactASCIIWhitespace(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\r', '\n', '\t', ' ':
+			return -1
+		default:
+			return r
+		}
+	}, s)
+}
+
+func trustedKeys(v js.Value) ([]string, error) {
+	if v.Type() == js.TypeString {
+		return splitTrustedKeys(v.String())
+	}
+	array := js.Global().Get("Array")
+	if array.Truthy() && array.Call("isArray", v).Bool() {
+		keys := make([]string, 0, v.Get("length").Int())
+		for i := 0; i < v.Get("length").Int(); i++ {
+			item := v.Index(i)
+			if item.Type() != js.TypeString {
+				return nil, fmt.Errorf("trusted key at index %d must be a hex string", i)
+			}
+			key := strings.TrimSpace(item.String())
+			if key == "" {
+				return nil, fmt.Errorf("trusted key at index %d is empty", i)
+			}
+			keys = append(keys, key)
+		}
+		if len(keys) == 0 {
+			return nil, fmt.Errorf("at least one trusted key is required")
+		}
+		return keys, nil
+	}
+	return nil, fmt.Errorf("trusted keys must be a hex string or array of hex strings")
+}
+
+func splitTrustedKeys(s string) ([]string, error) {
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\r' || r == '\t' || r == ' '
+	})
+	keys := make([]string, 0, len(fields))
+	for _, field := range fields {
+		key := strings.TrimSpace(field)
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("at least one trusted key is required")
+	}
+	return keys, nil
+}
+
+func chainResult(result receipt.ChainResult, observed int) wasmResult {
+	out := wasmResult{
+		Valid:              result.Valid,
+		Observed:           observed,
+		Error:              result.Error,
+		Reason:             result.Error,
+		IntegrityVerified:  result.IntegrityVerified,
+		ReceiptCount:       result.ReceiptCount,
+		FinalSeq:           result.FinalSeq,
+		RootHash:           result.RootHash,
+		FailureKind:        string(result.FailureKind),
+		SignerKeys:         result.SignerKeys,
+		UntrustedSignerKey: result.UntrustedSignerKey,
+	}
+	if !result.Valid {
+		brokenAtSeq := result.BrokenAtSeq
+		brokenAtIndex := result.BrokenAtIndex
+		out.BrokenAtSeq = &brokenAtSeq
+		out.BrokenAtIndex = &brokenAtIndex
+	}
+	if !result.StartTime.IsZero() {
+		out.StartTime = result.StartTime.Format("2006-01-02T15:04:05Z")
+	}
+	if !result.EndTime.IsZero() {
+		out.EndTime = result.EndTime.Format("2006-01-02T15:04:05Z")
+	}
+	if len(result.Segments) > 0 {
+		out.Segments = make([]wasmChainSegment, 0, len(result.Segments))
+		for _, segment := range result.Segments {
+			out.Segments = append(out.Segments, wasmChainSegment{
+				SignerKey: segment.SignerKey,
+				FirstSeq:  segment.FirstSeq,
+				FinalSeq:  segment.FinalSeq,
+				Boundary:  segment.Boundary,
+			})
+		}
+	}
+	return out
 }
 
 func resultValue(result wasmResult) js.Value {

--- a/deploy/wasm-verify/chain-parity.test.js
+++ b/deploy/wasm-verify/chain-parity.test.js
@@ -146,6 +146,23 @@ if (!isMainThread) {
       }
       waiting.resolve(message.result);
     });
+    // A worker that crashes or exits AFTER startup emits an error/exit event,
+    // not a message, so without these handlers any in-flight verify calls would
+    // hang until the after() cleanup. Reject them promptly instead.
+    const failPending = (err) => {
+      for (const { reject } of pending.values()) {
+        reject(err);
+      }
+      pending.clear();
+    };
+    worker.on("error", (err) => {
+      failPending(err instanceof Error ? err : new Error(String(err)));
+    });
+    worker.on("exit", (code) => {
+      if (code !== 0) {
+        failPending(new Error(`wasm worker exited with code ${code}`));
+      }
+    });
   });
 
   after(async () => {
@@ -246,6 +263,30 @@ if (!isMainThread) {
     );
     assert.equal(wrongTypedChain.valid, false);
     assert.match(wrongTypedChain.error || "", /chain must be/u);
+
+    // A valid chain must not verify when a non-receipt line is appended or
+    // spliced in: the extractor rejects the malformed record rather than
+    // silently skipping it and certifying the surrounding chain.
+    const validBytes = readFileSync(path.join(testdata, "g1-valid-chain.jsonl"));
+    const garbage = Buffer.from('{"not":"a receipt","x":123}\n');
+    const trailingGarbage = await verifyBytes(
+      Buffer.concat([validBytes, Buffer.from("\n"), garbage]),
+      primaryKey,
+      "uint8array",
+    );
+    assert.equal(trailingGarbage.valid, false, trailingGarbage.error);
+
+    const firstNewline = validBytes.indexOf(0x0a);
+    const middleGarbage = await verifyBytes(
+      Buffer.concat([
+        validBytes.subarray(0, firstNewline + 1),
+        garbage,
+        validBytes.subarray(firstNewline + 1),
+      ]),
+      primaryKey,
+      "uint8array",
+    );
+    assert.equal(middleGarbage.valid, false, middleGarbage.error);
   });
 
   async function verifyFixture(name, mode) {
@@ -361,22 +402,26 @@ function assertCaseListCoversTopLevelJSONLFixtures(cases, testdata) {
 }
 
 function comparableChainResult(result) {
+  // Default ONLY missing (null/undefined) fields with `??`, never `||`: a
+  // present-but-falsey value (e.g. a drifted `receiptCount: false` or an
+  // `integrityVerified: 0`) must survive into the comparison so deepEqual
+  // catches wasm/Go schema or type drift instead of masking it to the default.
   return {
     valid: result.valid,
-    observed: result.observed || 0,
-    error: result.error || "",
-    reason: result.reason || "",
-    integrityVerified: result.integrityVerified || false,
-    receiptCount: result.receiptCount || 0,
-    finalSeq: result.finalSeq || 0,
-    rootHash: result.rootHash || "",
-    startTime: result.startTime || "",
-    endTime: result.endTime || "",
-    failureKind: result.failureKind || "",
+    observed: result.observed ?? 0,
+    error: result.error ?? "",
+    reason: result.reason ?? "",
+    integrityVerified: result.integrityVerified ?? false,
+    receiptCount: result.receiptCount ?? 0,
+    finalSeq: result.finalSeq ?? 0,
+    rootHash: result.rootHash ?? "",
+    startTime: result.startTime ?? "",
+    endTime: result.endTime ?? "",
+    failureKind: result.failureKind ?? "",
     brokenAtSeq: result.brokenAtSeq ?? null,
     brokenAtIndex: result.brokenAtIndex ?? null,
-    signerKeys: result.signerKeys || [],
-    segments: result.segments || [],
-    untrustedSignerKey: result.untrustedSignerKey || "",
+    signerKeys: result.signerKeys ?? [],
+    segments: result.segments ?? [],
+    untrustedSignerKey: result.untrustedSignerKey ?? "",
   };
 }

--- a/deploy/wasm-verify/chain-parity.test.js
+++ b/deploy/wasm-verify/chain-parity.test.js
@@ -3,7 +3,7 @@
 
 const assert = require("node:assert/strict");
 const { execFileSync } = require("node:child_process");
-const { existsSync, mkdtempSync, readFileSync, rmSync } = require("node:fs");
+const { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } = require("node:fs");
 const { tmpdir } = require("node:os");
 const path = require("node:path");
 const { after, before, test } = require("node:test");
@@ -191,9 +191,18 @@ if (!isMainThread) {
   });
 
   test("all raw JSONL golden fixtures match the Go receipt verifier", async () => {
+    assertCaseListCoversTopLevelJSONLFixtures(cases, testdata);
     for (const tc of cases) {
       const result = await verifyFixture(tc.name, "uint8array");
       assertChainParity(result, oracleByName.get(tc.name), tc.name);
+      assert.deepEqual(
+        result.checks || [],
+        [
+          { name: "raw_receipts_extracted", pass: true },
+          { name: "receipt_chain_verified", pass: tc.valid },
+        ],
+        `${tc.name}: chain checks`,
+      );
       assert.equal(result.valid, tc.valid, `${tc.name}: ${result.error || "unexpected result"}`);
       if (tc.reason) {
         assert.match(result.error || "", tc.reason, tc.name);
@@ -213,6 +222,30 @@ if (!isMainThread) {
     );
     assert.equal(badKey.valid, false);
     assert.match(badKey.error || "", /at least one trusted key is required/u);
+
+    const missingKey = await verifyBytes(
+      readFileSync(path.join(testdata, "g1-valid-chain.jsonl")),
+      undefined,
+      "uint8array",
+    );
+    assert.equal(missingKey.valid, false);
+    assert.match(missingKey.error || "", /trusted keys must be/u);
+
+    const wrongTypedKey = await verifyBytes(
+      readFileSync(path.join(testdata, "g1-valid-chain.jsonl")),
+      [primaryKey, 7],
+      "uint8array",
+    );
+    assert.equal(wrongTypedKey.valid, false);
+    assert.match(wrongTypedKey.error || "", /trusted key at index 1/u);
+
+    const wrongTypedChain = await verifyBytes(
+      readFileSync(path.join(testdata, "g1-valid-chain.jsonl")),
+      primaryKey,
+      "plainobject",
+    );
+    assert.equal(wrongTypedChain.valid, false);
+    assert.match(wrongTypedChain.error || "", /chain must be/u);
   });
 
   async function verifyFixture(name, mode) {
@@ -270,6 +303,8 @@ function wasmInput(bytes, mode) {
       return Buffer.from(bytes).toString("utf8");
     case "uint8array":
       return bytes;
+    case "plainobject":
+      return { bytes: Array.from(bytes) };
     default:
       throw new Error(`unknown wasm input mode ${mode}`);
   }
@@ -317,15 +352,26 @@ function assertChainParity(actual, expected, name) {
   assert.deepEqual(comparableChainResult(actual), comparableChainResult(expected), name);
 }
 
+function assertCaseListCoversTopLevelJSONLFixtures(cases, testdata) {
+  const expected = readdirSync(testdata)
+    .filter((name) => name.endsWith(".jsonl"))
+    .sort();
+  const actual = cases.map((tc) => tc.name).sort();
+  assert.deepEqual(actual, expected, "raw JSONL fixture case list drifted");
+}
+
 function comparableChainResult(result) {
   return {
     valid: result.valid,
+    observed: result.observed || 0,
     error: result.error || "",
     reason: result.reason || "",
     integrityVerified: result.integrityVerified || false,
     receiptCount: result.receiptCount || 0,
     finalSeq: result.finalSeq || 0,
     rootHash: result.rootHash || "",
+    startTime: result.startTime || "",
+    endTime: result.endTime || "",
     failureKind: result.failureKind || "",
     brokenAtSeq: result.brokenAtSeq ?? null,
     brokenAtIndex: result.brokenAtIndex ?? null,

--- a/deploy/wasm-verify/chain-parity.test.js
+++ b/deploy/wasm-verify/chain-parity.test.js
@@ -1,0 +1,336 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const { existsSync, mkdtempSync, readFileSync, rmSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const path = require("node:path");
+const { after, before, test } = require("node:test");
+const { isMainThread, parentPort, Worker, workerData } = require("node:worker_threads");
+
+if (!isMainThread) {
+  runWasmWorker().catch((error) => {
+    parentPort.postMessage({ error: error.stack || String(error) });
+  });
+} else {
+  const repoRoot = path.resolve(__dirname, "../..");
+  const testdata = path.join(repoRoot, "sdk/conformance/testdata");
+  const keyInfo = JSON.parse(readFileSync(path.join(testdata, "test-key.json"), "utf8"));
+  const primaryKey = keyInfo.public_key_hex;
+  const rotatedKey = keyInfo.rotated_public_key_hex;
+  const tempRoot = process.env.TMPDIR || tmpdir();
+  let outDir;
+  let worker;
+  let oracleByName;
+  let nextID = 1;
+  const pending = new Map();
+
+  const cases = [
+    { name: "valid-chain.jsonl", valid: true },
+    { name: "g1-valid-chain.jsonl", valid: true },
+    { name: "g1-restart-chain.jsonl", valid: true },
+    {
+      name: "broken-chain.jsonl",
+      valid: false,
+      reason: /chain_prev_hash mismatch/u,
+    },
+    {
+      name: "g1-broken-genesis.jsonl",
+      valid: false,
+      reason: /session_open genesis hash mismatch/u,
+    },
+    {
+      name: "g1-legacy-open-genesis.jsonl",
+      valid: false,
+      reason: /session_open on legacy genesis/u,
+    },
+    {
+      name: "g1-inconsistent-heartbeat.jsonl",
+      valid: false,
+      reason: /heartbeat chain_head mismatch/u,
+    },
+    {
+      name: "g1-inconsistent-close.jsonl",
+      valid: false,
+      reason: /session_close root_hash mismatch/u,
+    },
+    {
+      name: "g1-ambiguous-session-control.jsonl",
+      valid: false,
+      reason: /session_control must carry exactly one payload/u,
+    },
+    {
+      name: "g1-ambiguous-open-close.jsonl",
+      valid: false,
+      reason: /session_control must carry exactly one payload/u,
+    },
+    {
+      name: "g1-ambiguous-heartbeat-close.jsonl",
+      valid: false,
+      reason: /session_control must carry exactly one payload/u,
+    },
+    {
+      name: "g1-rotated-close-count-valid.jsonl",
+      valid: true,
+      keys: [primaryKey, rotatedKey],
+    },
+    {
+      name: "g1-rotated-close-count-invalid.jsonl",
+      valid: false,
+      keys: [primaryKey, rotatedKey],
+      reason: /session_close receipt_count mismatch/u,
+    },
+    {
+      name: "g1-plain-after-close.jsonl",
+      valid: false,
+      reason: /record observed after session_close/u,
+    },
+    {
+      name: "g1-empty-run-nonce-after-close.jsonl",
+      valid: true,
+    },
+    {
+      name: "g1-heartbeat-after-close.jsonl",
+      valid: false,
+      reason: /record observed after session_close/u,
+    },
+    {
+      name: "g1-close-without-open.jsonl",
+      valid: false,
+      reason: /first receipt is not a matching session_open/u,
+    },
+    {
+      name: "g1-new-session-after-close.jsonl",
+      valid: true,
+    },
+    {
+      name: "g1-reopen-closed-run.jsonl",
+      valid: false,
+      reason: /duplicate session_open for run_nonce/u,
+    },
+  ].map((tc) => ({
+    ...tc,
+    path: path.join(testdata, tc.name),
+    keys: tc.keys || [primaryKey],
+  }));
+
+  before(async () => {
+    outDir = mkdtempSync(path.join(tempRoot, "pipelock-wasm-verify-"));
+    execFileSync("bash", ["deploy/wasm-verify/build.sh", outDir], {
+      cwd: repoRoot,
+      env: process.env,
+      encoding: "utf8",
+    });
+    oracleByName = runOracle(cases, repoRoot);
+    worker = await startWorker(outDir);
+    worker.on("message", (message) => {
+      if (message.error) {
+        for (const { reject } of pending.values()) {
+          reject(new Error(message.error));
+        }
+        pending.clear();
+        return;
+      }
+      if (!message.id) {
+        return;
+      }
+      const waiting = pending.get(message.id);
+      if (!waiting) {
+        return;
+      }
+      pending.delete(message.id);
+      if (message.callError) {
+        waiting.reject(new Error(message.callError));
+        return;
+      }
+      waiting.resolve(message.result);
+    });
+  });
+
+  after(async () => {
+    for (const { reject } of pending.values()) {
+      reject(new Error("test ended before wasm call completed"));
+    }
+    pending.clear();
+    if (worker) {
+      await worker.terminate();
+    }
+    if (outDir) {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  test("build emits wasm and standard Go wasm glue", () => {
+    assert.ok(existsSync(path.join(outDir, "pipelock-verifier.wasm")));
+    assert.ok(existsSync(path.join(outDir, "wasm_exec.js")));
+  });
+
+  test("clean g1 raw chain verifies with the trusted key", async () => {
+    const result = await verifyFixture("g1-valid-chain.jsonl", "uint8array");
+    assert.equal(result.valid, true, result.error);
+    assert.equal(result.receiptCount, 5);
+    assert.equal(result.finalSeq, 4);
+    assert.deepEqual(result.signerKeys, [primaryKey]);
+  });
+
+  test("rotated g1 raw chain verifies with multi-key input", async () => {
+    const result = await verifyFixture("g1-rotated-close-count-valid.jsonl", "uint8array");
+    assert.equal(result.valid, true, result.error);
+    assert.equal(result.receiptCount, 6);
+    assert.equal(result.finalSeq, 2);
+    assert.deepEqual(result.signerKeys, [primaryKey, rotatedKey]);
+  });
+
+  test("raw chain input accepts ArrayBuffer and string forms", async () => {
+    const arrayBufferResult = await verifyFixture("g1-valid-chain.jsonl", "arraybuffer");
+    assert.equal(arrayBufferResult.valid, true, arrayBufferResult.error);
+
+    const stringResult = await verifyFixture("g1-valid-chain.jsonl", "string");
+    assert.equal(stringResult.valid, true, stringResult.error);
+  });
+
+  test("all raw JSONL golden fixtures match the Go receipt verifier", async () => {
+    for (const tc of cases) {
+      const result = await verifyFixture(tc.name, "uint8array");
+      assertChainParity(result, oracleByName.get(tc.name), tc.name);
+      assert.equal(result.valid, tc.valid, `${tc.name}: ${result.error || "unexpected result"}`);
+      if (tc.reason) {
+        assert.match(result.error || "", tc.reason, tc.name);
+      }
+    }
+  });
+
+  test("malformed raw chain inputs fail closed", async () => {
+    const empty = await verifyBytes(Buffer.alloc(0), primaryKey, "uint8array");
+    assert.equal(empty.valid, false);
+    assert.match(empty.error || "", /chain string is empty|no receipts found in chain/u);
+
+    const badKey = await verifyBytes(
+      readFileSync(path.join(testdata, "g1-valid-chain.jsonl")),
+      [],
+      "uint8array",
+    );
+    assert.equal(badKey.valid, false);
+    assert.match(badKey.error || "", /at least one trusted key is required/u);
+  });
+
+  async function verifyFixture(name, mode) {
+    const tc = cases.find((candidate) => candidate.name === name);
+    assert.ok(tc, `missing test case ${name}`);
+    return verifyBytes(
+      readFileSync(tc.path),
+      tc.keys.length === 1 ? tc.keys[0] : tc.keys,
+      mode,
+    );
+  }
+
+  async function verifyBytes(bytes, keys, mode) {
+    const id = nextID++;
+    const result = new Promise((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+    });
+    worker.postMessage({ id, bytes: Uint8Array.from(bytes), keys, mode });
+    return result;
+  }
+}
+
+async function runWasmWorker() {
+  require(workerData.wasmExec);
+  const go = new globalThis.Go();
+  const wasm = readFileSync(workerData.wasm);
+  const { instance } = await WebAssembly.instantiate(wasm, go.importObject);
+  go.run(instance).catch((error) => {
+    parentPort.postMessage({ error: error.stack || String(error) });
+  });
+  parentPort.on("message", (message) => {
+    try {
+      const bytes = new Uint8Array(message.bytes);
+      const input = wasmInput(bytes, message.mode);
+      const result = globalThis.pipelockVerifyChain(input, message.keys);
+      parentPort.postMessage({
+        id: message.id,
+        result: JSON.parse(JSON.stringify(result)),
+      });
+    } catch (error) {
+      parentPort.postMessage({
+        id: message.id,
+        callError: error.stack || String(error),
+      });
+    }
+  });
+  parentPort.postMessage({ ready: true });
+}
+
+function wasmInput(bytes, mode) {
+  switch (mode) {
+    case "arraybuffer":
+      return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    case "string":
+      return Buffer.from(bytes).toString("utf8");
+    case "uint8array":
+      return bytes;
+    default:
+      throw new Error(`unknown wasm input mode ${mode}`);
+  }
+}
+
+function runOracle(cases, repoRoot) {
+  const input = JSON.stringify(
+    cases.map((tc) => ({
+      name: tc.name,
+      path: tc.path,
+      keys: tc.keys,
+    })),
+  );
+  const output = execFileSync("go", ["run", "./deploy/wasm-verify/chain_oracle.go"], {
+    cwd: repoRoot,
+    env: process.env,
+    input,
+    encoding: "utf8",
+  });
+  return new Map(JSON.parse(output).map((result) => [result.name, result]));
+}
+
+function startWorker(outDir) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(__filename, {
+      workerData: {
+        wasm: path.join(outDir, "pipelock-verifier.wasm"),
+        wasmExec: path.join(outDir, "wasm_exec.js"),
+      },
+    });
+    worker.once("error", reject);
+    worker.once("message", (message) => {
+      if (message.error) {
+        reject(new Error(message.error));
+        return;
+      }
+      assert.equal(message.ready, true);
+      resolve(worker);
+    });
+  });
+}
+
+function assertChainParity(actual, expected, name) {
+  assert.ok(expected, `${name}: missing Go oracle result`);
+  assert.deepEqual(comparableChainResult(actual), comparableChainResult(expected), name);
+}
+
+function comparableChainResult(result) {
+  return {
+    valid: result.valid,
+    error: result.error || "",
+    reason: result.reason || "",
+    integrityVerified: result.integrityVerified || false,
+    receiptCount: result.receiptCount || 0,
+    finalSeq: result.finalSeq || 0,
+    rootHash: result.rootHash || "",
+    failureKind: result.failureKind || "",
+    brokenAtSeq: result.brokenAtSeq ?? null,
+    brokenAtIndex: result.brokenAtIndex ?? null,
+    signerKeys: result.signerKeys || [],
+    segments: result.segments || [],
+    untrustedSignerKey: result.untrustedSignerKey || "",
+  };
+}

--- a/deploy/wasm-verify/chain_oracle.go
+++ b/deploy/wasm-verify/chain_oracle.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build ignore
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+type oracleCase struct {
+	Name string   `json:"name"`
+	Path string   `json:"path"`
+	Keys []string `json:"keys"`
+}
+
+type oracleResult struct {
+	Name               string               `json:"name"`
+	Valid              bool                 `json:"valid"`
+	Error              string               `json:"error,omitempty"`
+	Reason             string               `json:"reason,omitempty"`
+	IntegrityVerified  bool                 `json:"integrityVerified,omitempty"`
+	ReceiptCount       uint64               `json:"receiptCount,omitempty"`
+	FinalSeq           uint64               `json:"finalSeq,omitempty"`
+	RootHash           string               `json:"rootHash,omitempty"`
+	FailureKind        string               `json:"failureKind,omitempty"`
+	BrokenAtSeq        *uint64              `json:"brokenAtSeq,omitempty"`
+	BrokenAtIndex      *int                 `json:"brokenAtIndex,omitempty"`
+	SignerKeys         []string             `json:"signerKeys,omitempty"`
+	Segments           []oracleChainSegment `json:"segments,omitempty"`
+	UntrustedSignerKey string               `json:"untrustedSignerKey,omitempty"`
+}
+
+type oracleChainSegment struct {
+	SignerKey string `json:"signerKey"`
+	FirstSeq  uint64 `json:"firstSeq"`
+	FinalSeq  uint64 `json:"finalSeq"`
+	Boundary  bool   `json:"boundary"`
+}
+
+func main() {
+	var cases []oracleCase
+	if err := json.NewDecoder(os.Stdin).Decode(&cases); err != nil {
+		fatalf("decode cases: %v", err)
+	}
+	results := make([]oracleResult, 0, len(cases))
+	for _, tc := range cases {
+		result, err := runCase(tc)
+		if err != nil {
+			fatalf("%s: %v", tc.Name, err)
+		}
+		results = append(results, result)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(results); err != nil {
+		fatalf("encode results: %v", err)
+	}
+}
+
+func runCase(tc oracleCase) (oracleResult, error) {
+	data, err := os.ReadFile(tc.Path)
+	if err != nil {
+		return oracleResult{}, fmt.Errorf("read fixture: %w", err)
+	}
+	receipts, err := receipt.ExtractReceiptsBytes(data)
+	if err != nil {
+		return oracleResult{
+			Name:  tc.Name,
+			Valid: false,
+			Error: err.Error(),
+		}, nil
+	}
+	if len(receipts) == 0 {
+		return oracleResult{
+			Name:  tc.Name,
+			Valid: false,
+			Error: "no receipts found in chain",
+		}, nil
+	}
+	return chainResult(tc.Name, receipt.VerifyChainTrusted(receipts, tc.Keys)), nil
+}
+
+func chainResult(name string, result receipt.ChainResult) oracleResult {
+	out := oracleResult{
+		Name:               name,
+		Valid:              result.Valid,
+		Error:              result.Error,
+		Reason:             result.Error,
+		IntegrityVerified:  result.IntegrityVerified,
+		ReceiptCount:       result.ReceiptCount,
+		FinalSeq:           result.FinalSeq,
+		RootHash:           result.RootHash,
+		FailureKind:        string(result.FailureKind),
+		SignerKeys:         result.SignerKeys,
+		UntrustedSignerKey: result.UntrustedSignerKey,
+	}
+	if !result.Valid {
+		brokenAtSeq := result.BrokenAtSeq
+		brokenAtIndex := result.BrokenAtIndex
+		out.BrokenAtSeq = &brokenAtSeq
+		out.BrokenAtIndex = &brokenAtIndex
+	}
+	if len(result.Segments) > 0 {
+		out.Segments = make([]oracleChainSegment, 0, len(result.Segments))
+		for _, segment := range result.Segments {
+			out.Segments = append(out.Segments, oracleChainSegment{
+				SignerKey: segment.SignerKey,
+				FirstSeq:  segment.FirstSeq,
+				FinalSeq:  segment.FinalSeq,
+				Boundary:  segment.Boundary,
+			})
+		}
+	}
+	return out
+}
+
+func fatalf(format string, args ...any) {
+	_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/deploy/wasm-verify/chain_oracle.go
+++ b/deploy/wasm-verify/chain_oracle.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
@@ -22,12 +23,15 @@ type oracleCase struct {
 type oracleResult struct {
 	Name               string               `json:"name"`
 	Valid              bool                 `json:"valid"`
+	Observed           int                  `json:"observed"`
 	Error              string               `json:"error,omitempty"`
 	Reason             string               `json:"reason,omitempty"`
 	IntegrityVerified  bool                 `json:"integrityVerified,omitempty"`
 	ReceiptCount       uint64               `json:"receiptCount,omitempty"`
 	FinalSeq           uint64               `json:"finalSeq,omitempty"`
 	RootHash           string               `json:"rootHash,omitempty"`
+	StartTime          string               `json:"startTime,omitempty"`
+	EndTime            string               `json:"endTime,omitempty"`
 	FailureKind        string               `json:"failureKind,omitempty"`
 	BrokenAtSeq        *uint64              `json:"brokenAtSeq,omitempty"`
 	BrokenAtIndex      *int                 `json:"brokenAtIndex,omitempty"`
@@ -40,6 +44,7 @@ type oracleChainSegment struct {
 	SignerKey string `json:"signerKey"`
 	FirstSeq  uint64 `json:"firstSeq"`
 	FinalSeq  uint64 `json:"finalSeq"`
+	Count     uint64 `json:"count"`
 	Boundary  bool   `json:"boundary"`
 }
 
@@ -81,13 +86,14 @@ func runCase(tc oracleCase) (oracleResult, error) {
 			Error: "no receipts found in chain",
 		}, nil
 	}
-	return chainResult(tc.Name, receipt.VerifyChainTrusted(receipts, tc.Keys)), nil
+	return chainResult(tc.Name, receipt.VerifyChainTrusted(receipts, tc.Keys), len(receipts)), nil
 }
 
-func chainResult(name string, result receipt.ChainResult) oracleResult {
+func chainResult(name string, result receipt.ChainResult, observed int) oracleResult {
 	out := oracleResult{
 		Name:               name,
 		Valid:              result.Valid,
+		Observed:           observed,
 		Error:              result.Error,
 		Reason:             result.Error,
 		IntegrityVerified:  result.IntegrityVerified,
@@ -104,6 +110,12 @@ func chainResult(name string, result receipt.ChainResult) oracleResult {
 		out.BrokenAtSeq = &brokenAtSeq
 		out.BrokenAtIndex = &brokenAtIndex
 	}
+	if !result.StartTime.IsZero() {
+		out.StartTime = result.StartTime.Format(time.RFC3339Nano)
+	}
+	if !result.EndTime.IsZero() {
+		out.EndTime = result.EndTime.Format(time.RFC3339Nano)
+	}
 	if len(result.Segments) > 0 {
 		out.Segments = make([]oracleChainSegment, 0, len(result.Segments))
 		for _, segment := range result.Segments {
@@ -111,6 +123,7 @@ func chainResult(name string, result receipt.ChainResult) oracleResult {
 				SignerKey: segment.SignerKey,
 				FirstSeq:  segment.FirstSeq,
 				FinalSeq:  segment.FinalSeq,
+				Count:     segment.Count,
 				Boundary:  segment.Boundary,
 			})
 		}


### PR DESCRIPTION
## What changed

Adds a raw receipt-chain verification entrypoint to the WebAssembly verifier and a cross-language parity harness that proves it. The in-browser verifier previously could only check a published bundle, so the shared receipt-chain golden fixtures were verified in Go, Rust, TypeScript, and Python but never against the WebAssembly build.

The new entrypoint delegates raw chain extraction and verification to the same Go receipt package the command-line verifier uses, so the WebAssembly result is the Go result by construction rather than a reimplementation that could drift. A Node harness runs the WebAssembly verifier over every top-level chain fixture and compares its full result against a Go oracle over the same bytes, covering valid chains, tampered and broken chains, and malformed inputs, which must fail closed. The harness asserts its case list covers every chain fixture so a newly added fixture cannot slip through untested, and a make target runs it.

## Notes

This is additive: the existing bundle verification entrypoint and its behavior are unchanged, and no receipt verification logic was modified.

Worktree: `~/dev/pipelock-wt/verifier-parity`
Branch: `feat/verifier-wasm-chain-parity`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WASM chain verification entrypoint with richer results, including per-segment details, RFC3339Nano timing, and improved failure context.
  * Expanded accepted inputs for chain data and trusted keys (supports multiple binary representations and delimited or array-based hex keys).

* **Bug Fixes**
  * Improved “fail closed” handling for malformed, empty, or wrong-type inputs, including stricter behavior for malformed JSONL fixture records and whitespace/base64 decoding.

* **Tests**
  * Added Node-based WASM parity tests that compare outputs against a Go oracle across valid and invalid fixtures.
  * Added a Makefile target to run the WASM verifier test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->