### PR TITLE
feat(dashboard): read-only Signed Action Workbench and Incident Cockpit

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -124,3 +124,65 @@ offline `pipelock-verifier verify-run` command that re-verifies the same
 receipts against the trusted key, so anything the dashboard claims can be
 independently re-checked against the signed evidence — without trusting this
 server.
+
+## Signed Action Workbench and Incident Cockpit (Enterprise fleet tier)
+
+The dashboard adds two Enterprise fleet-tier pages, `/workbench` and
+`/incident`. Both require a license that grants the `fleet` feature; a license
+with only the `agents` feature gets `403` on these routes while the agent-tier
+Evidence, Agents, and Exemptions views keep working. They are served by the same
+`pipelock dashboard serve` command and reuse its authentication,
+cleartext-refusal, audit-log, and redaction seams.
+
+Both pages are **prepare / verify / replay only**. Neither can execute, submit,
+or otherwise mutate fleet state:
+
+- Every route is GET-only; a mutating HTTP method returns `405`.
+- The only conductor seam these pages consume is read-only: it re-derives a
+  decision (dry-run / replay) and never publishes, kills, resumes, or rolls back
+  anything. There is no publish/kill/rollback method on that seam and no write
+  path reachable from the dashboard.
+- The operator prepares and submits an action with the shipped conductor CLI
+  **outside** the dashboard. The workbench's job ends at "here is the predicted
+  effect and the exact command to run".
+
+### Signed Action Workbench (`/workbench`)
+
+The workbench has two parts. **Prepare and submit guidance** is a static,
+per-request-identical list of the shipped conductor commands an operator runs
+outside the dashboard: `pipelock conductor publish …`, `pipelock conductor kill …`
+(and `resume`), and `pipelock conductor rollback …`. The dashboard only displays
+these commands; it never runs them.
+
+**Verify / replay a past decision**: with a conductor decision source wired,
+supply `?org_id=<org>&fleet_id=<fleet>&artifact_hash=<hash>` to re-derive the
+conductor authorization and effect decision for a past signed action under the
+current fleet and policy state. The panel surfaces the re-derived verdict and a
+loud **Divergence** flag when the re-derived decision no longer matches what was
+recorded. Replay does not re-derive proxy content-scan verdicts, and does not
+prove any action executed or was prevented outside the conductor decision. Until
+the dashboard is wired to a conductor read source, the replay panel renders an
+explicit "no conductor decision source configured" state; the prepare guidance
+and the other views do not depend on that source.
+
+### Incident Cockpit (`/incident`)
+
+A read-only correlation lens. Supply
+`?org_id=<org>&fleet_id=<fleet>&artifact_hash=<hash>` to correlate one conductor
+decision with its **replay divergence** (from the read-only decision source) and
+a bounded **fleet applied-state summary** — counts of enrolled followers by
+applied-state source (verified / signed-but-unverified / unsigned / no report),
+plus drift and apply-failed counts. The cockpit never kills an agent, publishes,
+or mutates fleet state, and does not prove no bypass occurred outside Pipelock,
+outside enrolled followers, or outside the report window.
+
+### Redaction on these pages
+
+Like the other views, these pages redact by default. In the metadata view
+(`--auth-token-file`), decision artifact/result/recorded hashes, result
+versions, and the free-text divergence reason are hidden; the computed status —
+validity, the bounded conflict code, and the loud divergence flag — is always
+shown. The fleet applied-state summary is counts only, carries no follower
+identifiers, and is shown in full even in the metadata view. Raw detail is shown
+only to a request that authenticates with `--raw-token-file`. There is
+deliberately no aggregate "all clear".

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -144,7 +144,7 @@ or otherwise mutate fleet state:
   path reachable from the dashboard.
 - The operator prepares and submits an action with the shipped conductor CLI
   **outside** the dashboard. The workbench's job ends at "here is the predicted
-  effect and the exact command to run".
+  effect and the command template to run".
 
 ### Signed Action Workbench (`/workbench`)
 

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -215,6 +215,14 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 		// conductor audit/status store handle. Until then /fleet renders the
 		// read-only empty state instead of inventing a fake conductor client.
 		FleetSource: nil,
+		// TODO(DASH-3B): wire the read-only conductor decision replay/dry-run
+		// source when dashboard serve owns a conductor read handle. Until then
+		// /workbench renders its prepare guidance plus the unconfigured-replay
+		// state, and /incident renders the unconfigured-decision-source state.
+		// The seam is read-only by construction (no publish/kill/rollback
+		// method), so the dashboard holds no fleet-control authority even once
+		// wired.
+		ConductorSource: nil,
 	})
 	handler := dashboardAuthHandler(metaAuthorized, inner)
 

--- a/enterprise/dashboard/fleetoverview.go
+++ b/enterprise/dashboard/fleetoverview.go
@@ -105,16 +105,21 @@ func (m *ReadModel) FleetOverview(ctx context.Context, orgID, fleetID string, ra
 	}
 	overview := FleetOverview{
 		SourceConfigured: m.fleetSource != nil,
-		OrgID:            orgID,
-		FleetID:          fleetID,
-		Claim:            fleetCompletenessClaim,
-		NonClaim:         fleetCompletenessNonClaim,
-		RawAllowed:       rawAllowed,
+		// Display labels are redacted in metadata mode; the real scope is kept
+		// in the orgID/fleetID locals below for the source query. Rendering the
+		// raw scope here would leak operator infra identifiers to a
+		// metadata-only viewer (the same RBAC class as the workbench/incident
+		// scope labels).
+		OrgID:      metadataScopeDisplay(orgID, rawAllowed),
+		FleetID:    metadataScopeDisplay(fleetID, rawAllowed),
+		Claim:      fleetCompletenessClaim,
+		NonClaim:   fleetCompletenessNonClaim,
+		RawAllowed: rawAllowed,
 	}
 	if m.fleetSource == nil {
 		return overview, nil
 	}
-	followers, err := m.fleetSource.ListFleetFollowers(ctx, overview.OrgID, overview.FleetID, fleetOverviewFollowerLimit+1)
+	followers, err := m.fleetSource.ListFleetFollowers(ctx, orgID, fleetID, fleetOverviewFollowerLimit+1)
 	if err != nil {
 		return FleetOverview{}, fmt.Errorf("list fleet followers: %w", err)
 	}
@@ -193,6 +198,11 @@ func (m *ReadModel) redactFleetFollowers(in []FleetFollowerView) []FleetFollower
 		follower.BuildDate = redactedFleetString(follower.BuildDate)
 		follower.LastApplyErrorCode = redactedFleetString(follower.LastApplyErrorCode)
 		follower.LastApplyErrorMessage = redactedFleetString(follower.LastApplyErrorMessage)
+		// Redact the per-follower scope labels too. These are the same org/fleet
+		// infra identifiers redacted at the page level; the InstanceID hash above
+		// consumes the raw values as salt first, so this must run after it.
+		follower.OrgID = redactedFleetString(follower.OrgID)
+		follower.FleetID = redactedFleetString(follower.FleetID)
 		out[i] = follower
 	}
 	return out

--- a/enterprise/dashboard/fleetoverview_test.go
+++ b/enterprise/dashboard/fleetoverview_test.go
@@ -228,10 +228,11 @@ func TestFleetOverview_RendersSignedUnsignedAndHonestyWording(t *testing.T) {
 func TestFleetOverview_RedactsMetadataView(t *testing.T) {
 	t.Parallel()
 
+	source := &fakeFleetSource{followers: testFleetFollowers()[:1]}
 	handler := New(Options{
 		ReceiptDir:  t.TempDir(),
 		HasFeature:  allowFleetFeature,
-		FleetSource: &fakeFleetSource{followers: testFleetFollowers()[:1]},
+		FleetSource: source,
 		// No AuthorizeRaw: metadata view must fail closed.
 	})
 	rec := httptest.NewRecorder()
@@ -239,8 +240,16 @@ func TestFleetOverview_RedactsMetadataView(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
+	// The real scope must still reach the source query even though the
+	// page-level scope labels are redacted in metadata mode.
+	if source.gotOrgID != fleetTestOrgID || source.gotFleet != fleetTestFleetID {
+		t.Fatalf("source scope = (%q, %q), want (%q, %q); redaction must not corrupt the query",
+			source.gotOrgID, source.gotFleet, fleetTestOrgID, fleetTestFleetID)
+	}
 	body := rec.Body.String()
 	for _, secret := range []string{
+		fleetTestOrgID,
+		fleetTestFleetID,
 		fleetTestInstanceID,
 		fleetTestEnvironment,
 		fleetTestAuditKeyID,

--- a/enterprise/dashboard/fleetoverview_test.go
+++ b/enterprise/dashboard/fleetoverview_test.go
@@ -101,10 +101,11 @@ func TestFleetOverview_Gating(t *testing.T) {
 			t.Parallel()
 
 			handler := New(Options{
-				ReceiptDir:   t.TempDir(),
-				HasFeature:   tt.hasFeature,
-				FleetSource:  &fakeFleetSource{},
-				AuthorizeRaw: allowRawAccess,
+				ReceiptDir:          t.TempDir(),
+				HasFeature:          tt.hasFeature,
+				FleetSource:         &fakeFleetSource{},
+				AuthorizeRaw:        allowRawAccess,
+				AuthorizeFleetScope: allowFleetScope,
 			})
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fleet?org_id="+fleetTestOrgID+"&fleet_id="+fleetTestFleetID, nil))
@@ -178,15 +179,50 @@ func TestFleetOverview_NilSourceRendersEmptyState(t *testing.T) {
 	}
 }
 
+func TestFleetOverview_FailClosedScopeAuthorization(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		authorize func(*http.Request, DecisionScope, bool) error
+	}{
+		{name: "missing_authorizer", authorize: nil},
+		{name: "denied_authorizer", authorize: func(*http.Request, DecisionScope, bool) error {
+			return errors.New("wrong fleet")
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := &fakeFleetSource{followers: testFleetFollowers()}
+			handler := New(Options{
+				ReceiptDir:          t.TempDir(),
+				HasFeature:          allowFleetFeature,
+				FleetSource:         source,
+				AuthorizeFleetScope: tt.authorize,
+			})
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fleet?org_id="+fleetTestOrgID+"&fleet_id="+fleetTestFleetID, nil))
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+			}
+			if source.gotOrgID != "" || source.gotFleet != "" {
+				t.Fatalf("source scope = (%q,%q), want no source call before authorization", source.gotOrgID, source.gotFleet)
+			}
+		})
+	}
+}
+
 func TestFleetOverview_RendersSignedUnsignedAndHonestyWording(t *testing.T) {
 	t.Parallel()
 
 	source := &fakeFleetSource{followers: testFleetFollowers()}
 	handler := New(Options{
-		ReceiptDir:   t.TempDir(),
-		HasFeature:   allowFleetFeature,
-		FleetSource:  source,
-		AuthorizeRaw: allowRawAccess,
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		FleetSource:         source,
+		AuthorizeRaw:        allowRawAccess,
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(
@@ -234,6 +270,7 @@ func TestFleetOverview_RedactsMetadataView(t *testing.T) {
 		HasFeature:  allowFleetFeature,
 		FleetSource: source,
 		// No AuthorizeRaw: metadata view must fail closed.
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fleet?org_id="+fleetTestOrgID+"&fleet_id="+fleetTestFleetID, nil))
@@ -302,10 +339,11 @@ func TestFleetOverview_RawViewEscapesFollowerStrings(t *testing.T) {
 	follower.BatchID = hostileImage
 	follower.LastApplyErrorMessage = hostileScript
 	handler := New(Options{
-		ReceiptDir:   t.TempDir(),
-		HasFeature:   allowFleetFeature,
-		FleetSource:  &fakeFleetSource{followers: []FleetFollowerView{follower}},
-		AuthorizeRaw: allowRawAccess,
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		FleetSource:         &fakeFleetSource{followers: []FleetFollowerView{follower}},
+		AuthorizeRaw:        allowRawAccess,
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fleet?org_id="+fleetTestOrgID+"&fleet_id="+fleetTestFleetID, nil))
@@ -329,9 +367,10 @@ func TestFleetOverview_SourceErrorReturnsServerError(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
-		ReceiptDir:  t.TempDir(),
-		HasFeature:  allowFleetFeature,
-		FleetSource: &fakeFleetSource{err: errors.New("source unavailable")},
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		FleetSource:         &fakeFleetSource{err: errors.New("source unavailable")},
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fleet?org_id="+fleetTestOrgID+"&fleet_id="+fleetTestFleetID, nil))
@@ -344,9 +383,10 @@ func TestFleetOverview_RejectsInvalidScope(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
-		ReceiptDir:  t.TempDir(),
-		HasFeature:  allowFleetFeature,
-		FleetSource: &fakeFleetSource{},
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		FleetSource:         &fakeFleetSource{},
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	for _, target := range []string{
 		"/fleet",
@@ -383,10 +423,11 @@ func TestFleetOverview_TruncatesFollowerRows(t *testing.T) {
 		}
 	}
 	handler := New(Options{
-		ReceiptDir:   t.TempDir(),
-		HasFeature:   allowFleetFeature,
-		FleetSource:  &fakeFleetSource{followers: followers},
-		AuthorizeRaw: allowRawAccess,
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		FleetSource:         &fakeFleetSource{followers: followers},
+		AuthorizeRaw:        allowRawAccess,
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fleet?org_id="+fleetTestOrgID+"&fleet_id="+fleetTestFleetID, nil))

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -31,7 +31,7 @@ const (
 	auditSessionMaxBytes  = 128
 )
 
-//go:embed evidence.tmpl.html exemptions.tmpl.html agents.tmpl.html investigator.tmpl.html fleetoverview.tmpl.html
+//go:embed evidence.tmpl.html exemptions.tmpl.html agents.tmpl.html investigator.tmpl.html fleetoverview.tmpl.html workbench.tmpl.html incident.tmpl.html
 var templateFS embed.FS
 
 var (
@@ -40,6 +40,8 @@ var (
 	agentsTemplate        = template.Must(template.ParseFS(templateFS, "agents.tmpl.html"))
 	investigatorTemplate  = template.Must(template.ParseFS(templateFS, "investigator.tmpl.html"))
 	fleetoverviewTemplate = template.Must(template.ParseFS(templateFS, "fleetoverview.tmpl.html"))
+	workbenchTemplate     = template.Must(template.ParseFS(templateFS, "workbench.tmpl.html"))
+	incidentTemplate      = template.Must(template.ParseFS(templateFS, "incident.tmpl.html"))
 )
 
 type pageData struct {
@@ -80,6 +82,14 @@ func New(opts Options) http.Handler {
 	mux.Handle("/agent/", d.gate(http.HandlerFunc(d.handleAgent)))
 	mux.Handle("/fleet", d.fleetGate(http.HandlerFunc(d.handleFleetOverview)))
 	mux.Handle("/fleet/", d.fleetGate(http.HandlerFunc(d.handleFleetOverview)))
+	// DASH-3B: the Signed Action Workbench and Incident Cockpit are Enterprise
+	// fleet-tier, prepare/verify/replay-only surfaces. They are GET-only and
+	// reach no write path; the trailing-slash routes exist only to reject
+	// deeper paths with 404, never to add a mutating handler.
+	mux.Handle("/workbench", d.fleetGate(http.HandlerFunc(d.handleWorkbench)))
+	mux.Handle("/workbench/", d.fleetGate(http.HandlerFunc(d.handleWorkbench)))
+	mux.Handle("/incident", d.fleetGate(http.HandlerFunc(d.handleIncident)))
+	mux.Handle("/incident/", d.fleetGate(http.HandlerFunc(d.handleIncident)))
 	return mux
 }
 
@@ -358,6 +368,76 @@ func (d *dashboardHandler) handleFleetOverview(w http.ResponseWriter, r *http.Re
 	}
 	w.Header().Set("Content-Type", contentTypeHTML)
 	_, _ = w.Write(buf.Bytes())
+}
+
+// handleWorkbench serves the read-only Signed Action Workbench. It is GET-only
+// and reaches no write path: it renders static prepare guidance and, when a
+// conductor decision source is wired and an artifact hash is supplied, the
+// read-only replay of that past decision.
+func (d *dashboardHandler) handleWorkbench(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/workbench" {
+		http.NotFound(w, r)
+		return
+	}
+	if !requireGet(w, r) {
+		return
+	}
+	scope := decisionScopeFromRequest(r)
+	if err := validateDecisionScope(scope); err != nil {
+		http.Error(w, "invalid decision scope", http.StatusBadRequest)
+		return
+	}
+	page, err := d.model.Workbench(r.Context(), scope, rawAllowedFromContext(r))
+	if err != nil {
+		http.Error(w, "could not build workbench view", http.StatusInternalServerError)
+		return
+	}
+	var buf bytes.Buffer
+	if err := workbenchTemplate.Execute(&buf, page); err != nil {
+		http.Error(w, "could not render workbench", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", contentTypeHTML)
+	_, _ = w.Write(buf.Bytes())
+}
+
+// handleIncident serves the read-only Incident Cockpit. It is GET-only and
+// reaches no write path: it correlates a conductor decision replay with the
+// bounded fleet applied-state summary.
+func (d *dashboardHandler) handleIncident(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/incident" {
+		http.NotFound(w, r)
+		return
+	}
+	if !requireGet(w, r) {
+		return
+	}
+	scope := decisionScopeFromRequest(r)
+	if err := validateDecisionScope(scope); err != nil {
+		http.Error(w, "invalid decision scope", http.StatusBadRequest)
+		return
+	}
+	page, err := d.model.Incident(r.Context(), scope, rawAllowedFromContext(r))
+	if err != nil {
+		http.Error(w, "could not build incident view", http.StatusInternalServerError)
+		return
+	}
+	var buf bytes.Buffer
+	if err := incidentTemplate.Execute(&buf, page); err != nil {
+		http.Error(w, "could not render incident view", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", contentTypeHTML)
+	_, _ = w.Write(buf.Bytes())
+}
+
+func decisionScopeFromRequest(r *http.Request) DecisionScope {
+	q := r.URL.Query()
+	return DecisionScope{
+		OrgID:        q.Get("org_id"),
+		FleetID:      q.Get("fleet_id"),
+		ArtifactHash: q.Get("artifact_hash"),
+	}
 }
 
 func (d *dashboardHandler) handleSession(w http.ResponseWriter, r *http.Request) {

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -370,12 +370,16 @@ func (d *dashboardHandler) handleFleetOverview(w http.ResponseWriter, r *http.Re
 	_, _ = w.Write(buf.Bytes())
 }
 
-// handleWorkbench serves the read-only Signed Action Workbench. It is GET-only
-// and reaches no write path: it renders static prepare guidance and, when a
-// conductor decision source is wired and an artifact hash is supplied, the
-// read-only replay of that past decision.
-func (d *dashboardHandler) handleWorkbench(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/workbench" {
+func (d *dashboardHandler) serveDecisionScopePage(
+	w http.ResponseWriter,
+	r *http.Request,
+	path string,
+	tmpl *template.Template,
+	buildErr string,
+	renderErr string,
+	build func(context.Context, DecisionScope, bool) (any, error),
+) {
+	if r.URL.Path != path {
 		http.NotFound(w, r)
 		return
 	}
@@ -387,48 +391,43 @@ func (d *dashboardHandler) handleWorkbench(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "invalid decision scope", http.StatusBadRequest)
 		return
 	}
-	page, err := d.model.Workbench(r.Context(), scope, rawAllowedFromContext(r))
+	page, err := build(r.Context(), scope, rawAllowedFromContext(r))
 	if err != nil {
-		http.Error(w, "could not build workbench view", http.StatusInternalServerError)
+		http.Error(w, buildErr, http.StatusInternalServerError)
 		return
 	}
 	var buf bytes.Buffer
-	if err := workbenchTemplate.Execute(&buf, page); err != nil {
-		http.Error(w, "could not render workbench", http.StatusInternalServerError)
+	if err := tmpl.Execute(&buf, page); err != nil {
+		http.Error(w, renderErr, http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", contentTypeHTML)
 	_, _ = w.Write(buf.Bytes())
 }
 
+// handleWorkbench serves the read-only Signed Action Workbench. It is GET-only
+// and reaches no write path: it renders static prepare guidance and, when a
+// conductor decision source is wired and an artifact hash is supplied, the
+// read-only replay of that past decision.
+func (d *dashboardHandler) handleWorkbench(w http.ResponseWriter, r *http.Request) {
+	d.serveDecisionScopePage(w, r, "/workbench", workbenchTemplate,
+		"could not build workbench view",
+		"could not render workbench",
+		func(ctx context.Context, scope DecisionScope, raw bool) (any, error) {
+			return d.model.Workbench(ctx, scope, raw)
+		})
+}
+
 // handleIncident serves the read-only Incident Cockpit. It is GET-only and
 // reaches no write path: it correlates a conductor decision replay with the
 // bounded fleet applied-state summary.
 func (d *dashboardHandler) handleIncident(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/incident" {
-		http.NotFound(w, r)
-		return
-	}
-	if !requireGet(w, r) {
-		return
-	}
-	scope := decisionScopeFromRequest(r)
-	if err := validateDecisionScope(scope); err != nil {
-		http.Error(w, "invalid decision scope", http.StatusBadRequest)
-		return
-	}
-	page, err := d.model.Incident(r.Context(), scope, rawAllowedFromContext(r))
-	if err != nil {
-		http.Error(w, "could not build incident view", http.StatusInternalServerError)
-		return
-	}
-	var buf bytes.Buffer
-	if err := incidentTemplate.Execute(&buf, page); err != nil {
-		http.Error(w, "could not render incident view", http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", contentTypeHTML)
-	_, _ = w.Write(buf.Bytes())
+	d.serveDecisionScopePage(w, r, "/incident", incidentTemplate,
+		"could not build incident view",
+		"could not render incident view",
+		func(ctx context.Context, scope DecisionScope, raw bool) (any, error) {
+			return d.model.Incident(ctx, scope, raw)
+		})
 }
 
 func decisionScopeFromRequest(r *http.Request) DecisionScope {

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -370,16 +370,16 @@ func (d *dashboardHandler) handleFleetOverview(w http.ResponseWriter, r *http.Re
 	_, _ = w.Write(buf.Bytes())
 }
 
-func (d *dashboardHandler) serveDecisionScopePage(
-	w http.ResponseWriter,
-	r *http.Request,
-	path string,
-	tmpl *template.Template,
-	buildErr string,
-	renderErr string,
-	build func(context.Context, DecisionScope, bool) (any, error),
-) {
-	if r.URL.Path != path {
+type decisionScopePageOptions struct {
+	path      string
+	tmpl      *template.Template
+	buildErr  string
+	renderErr string
+	build     func(context.Context, DecisionScope, bool) (any, error)
+}
+
+func (d *dashboardHandler) serveDecisionScopePage(w http.ResponseWriter, r *http.Request, opts decisionScopePageOptions) {
+	if r.URL.Path != opts.path {
 		http.NotFound(w, r)
 		return
 	}
@@ -391,14 +391,14 @@ func (d *dashboardHandler) serveDecisionScopePage(
 		http.Error(w, "invalid decision scope", http.StatusBadRequest)
 		return
 	}
-	page, err := build(r.Context(), scope, rawAllowedFromContext(r))
+	page, err := opts.build(r.Context(), scope, rawAllowedFromContext(r))
 	if err != nil {
-		http.Error(w, buildErr, http.StatusInternalServerError)
+		http.Error(w, opts.buildErr, http.StatusInternalServerError)
 		return
 	}
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, page); err != nil {
-		http.Error(w, renderErr, http.StatusInternalServerError)
+	if err := opts.tmpl.Execute(&buf, page); err != nil {
+		http.Error(w, opts.renderErr, http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", contentTypeHTML)
@@ -410,24 +410,30 @@ func (d *dashboardHandler) serveDecisionScopePage(
 // conductor decision source is wired and an artifact hash is supplied, the
 // read-only replay of that past decision.
 func (d *dashboardHandler) handleWorkbench(w http.ResponseWriter, r *http.Request) {
-	d.serveDecisionScopePage(w, r, "/workbench", workbenchTemplate,
-		"could not build workbench view",
-		"could not render workbench",
-		func(ctx context.Context, scope DecisionScope, raw bool) (any, error) {
+	d.serveDecisionScopePage(w, r, decisionScopePageOptions{
+		path:      "/workbench",
+		tmpl:      workbenchTemplate,
+		buildErr:  "could not build workbench view",
+		renderErr: "could not render workbench",
+		build: func(ctx context.Context, scope DecisionScope, raw bool) (any, error) {
 			return d.model.Workbench(ctx, scope, raw)
-		})
+		},
+	})
 }
 
 // handleIncident serves the read-only Incident Cockpit. It is GET-only and
 // reaches no write path: it correlates a conductor decision replay with the
 // bounded fleet applied-state summary.
 func (d *dashboardHandler) handleIncident(w http.ResponseWriter, r *http.Request) {
-	d.serveDecisionScopePage(w, r, "/incident", incidentTemplate,
-		"could not build incident view",
-		"could not render incident view",
-		func(ctx context.Context, scope DecisionScope, raw bool) (any, error) {
+	d.serveDecisionScopePage(w, r, decisionScopePageOptions{
+		path:      "/incident",
+		tmpl:      incidentTemplate,
+		buildErr:  "could not build incident view",
+		renderErr: "could not render incident view",
+		build: func(ctx context.Context, scope DecisionScope, raw bool) (any, error) {
 			return d.model.Incident(ctx, scope, raw)
-		})
+		},
+	})
 }
 
 func decisionScopeFromRequest(r *http.Request) DecisionScope {

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -69,11 +69,12 @@ func New(opts Options) http.Handler {
 	model := NewReadModel(opts)
 	mux := http.NewServeMux()
 	d := &dashboardHandler{
-		model:        model,
-		hasFeature:   opts.HasFeature,
-		authorize:    opts.Authorize,
-		authorizeRaw: opts.AuthorizeRaw,
-		auditWriter:  opts.AuditWriter,
+		model:               model,
+		hasFeature:          opts.HasFeature,
+		authorize:           opts.Authorize,
+		authorizeRaw:        opts.AuthorizeRaw,
+		authorizeFleetScope: opts.AuthorizeFleetScope,
+		auditWriter:         opts.AuditWriter,
 	}
 	mux.Handle("/", d.gate(http.HandlerFunc(d.handleIndex)))
 	mux.Handle("/exemptions", d.gate(http.HandlerFunc(d.handleExemptions)))
@@ -94,12 +95,13 @@ func New(opts Options) http.Handler {
 }
 
 type dashboardHandler struct {
-	model        *ReadModel
-	hasFeature   func(string) bool
-	authorize    func(*http.Request) error
-	authorizeRaw func(*http.Request) error
-	auditWriter  io.Writer
-	auditMu      sync.Mutex
+	model               *ReadModel
+	hasFeature          func(string) bool
+	authorize           func(*http.Request) error
+	authorizeRaw        func(*http.Request) error
+	authorizeFleetScope func(*http.Request, DecisionScope, bool) error
+	auditWriter         io.Writer
+	auditMu             sync.Mutex
 }
 
 type rawAllowedContextKey struct{}
@@ -143,8 +145,10 @@ func (d *dashboardHandler) recordAudit(r *http.Request, raw bool) {
 	sessionDisplay, sessionHash := auditSessionField(session)
 	d.auditMu.Lock()
 	defer d.auditMu.Unlock()
-	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s method=%s path=%q session=%q session_sha256=%s remote=%s\n",
-		time.Now().UTC().Format(time.RFC3339), role, r.Method, r.URL.Path, sessionDisplay, sessionHash, r.RemoteAddr)
+	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s method=%s path=%q session=%q session_sha256=%s org_sha256=%s fleet_sha256=%s artifact_sha256=%s remote=%s\n",
+		time.Now().UTC().Format(time.RFC3339), role, r.Method, r.URL.Path, sessionDisplay, sessionHash,
+		auditHashField(r.URL.Query().Get("org_id")), auditHashField(r.URL.Query().Get("fleet_id")),
+		auditHashField(r.URL.Query().Get("artifact_hash")), r.RemoteAddr)
 }
 
 func auditSessionField(session string) (display, hash string) {
@@ -172,6 +176,66 @@ func auditSessionField(session string) (display, hash string) {
 		display = "-"
 	}
 	return display, hash
+}
+
+func auditHashField(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func (d *dashboardHandler) recordDecisionScopeAudit(r *http.Request, raw bool, scope DecisionScope, page any) {
+	if d.auditWriter == nil {
+		return
+	}
+	role := "metadata"
+	if raw {
+		role = "raw"
+	}
+	var decisionSource, fleetSource, decisionFound, fleetFound, divergence bool
+	conflict := "-"
+	switch p := page.(type) {
+	case WorkbenchPage:
+		decisionSource = p.SourceConfigured
+		decisionFound = p.HasReplay
+		divergence = p.HasReplay && p.Replay.Divergence
+		if p.HasReplay && p.Replay.Conflict != "" {
+			conflict = p.Replay.Conflict
+		}
+	case IncidentPage:
+		decisionSource = p.DecisionSourceConfigured
+		fleetSource = p.FleetSourceConfigured
+		decisionFound = p.HasDecision
+		fleetFound = p.HasFleet
+		divergence = p.HasDecision && p.Decision.Divergence
+		if p.HasDecision && p.Decision.Conflict != "" {
+			conflict = p.Decision.Conflict
+		}
+	}
+	d.auditMu.Lock()
+	defer d.auditMu.Unlock()
+	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard scope role=%s method=%s path=%q org_sha256=%s fleet_sha256=%s artifact_sha256=%s decision_source=%t fleet_source=%t decision_found=%t fleet_found=%t divergence=%t conflict=%q remote=%s\n",
+		time.Now().UTC().Format(time.RFC3339), role, r.Method, r.URL.Path,
+		auditHashField(scope.OrgID), auditHashField(scope.FleetID), auditHashField(scope.ArtifactHash),
+		decisionSource, fleetSource, decisionFound, fleetFound, divergence, conflict, r.RemoteAddr)
+}
+
+func (d *dashboardHandler) authorizeFleetScopeRequest(w http.ResponseWriter, r *http.Request, scope DecisionScope, sourceConfigured bool, raw bool) bool {
+	if !sourceConfigured {
+		return true
+	}
+	if d.authorizeFleetScope == nil {
+		http.Error(w, "fleet scope authorization required", http.StatusForbidden)
+		return false
+	}
+	if err := d.authorizeFleetScope(r, normalizeDecisionScope(scope), raw); err != nil {
+		http.Error(w, "fleet scope not authorized", http.StatusForbidden)
+		return false
+	}
+	return true
 }
 
 func (d *dashboardHandler) gate(next http.Handler) http.Handler {
@@ -352,6 +416,13 @@ func (d *dashboardHandler) handleFleetOverview(w http.ResponseWriter, r *http.Re
 		return
 	}
 	q := r.URL.Query()
+	if err := validateFleetScope(q.Get("org_id"), q.Get("fleet_id"), d.model.fleetSource != nil); err != nil {
+		http.Error(w, "invalid fleet scope", http.StatusBadRequest)
+		return
+	}
+	if !d.authorizeFleetScopeRequest(w, r, DecisionScope{OrgID: q.Get("org_id"), FleetID: q.Get("fleet_id")}, d.model.fleetSource != nil, rawAllowedFromContext(r)) {
+		return
+	}
 	overview, err := d.model.FleetOverview(r.Context(), q.Get("org_id"), q.Get("fleet_id"), rawAllowedFromContext(r))
 	if err != nil {
 		if errors.Is(err, errInvalidFleetScope) {
@@ -371,11 +442,12 @@ func (d *dashboardHandler) handleFleetOverview(w http.ResponseWriter, r *http.Re
 }
 
 type decisionScopePageOptions struct {
-	path      string
-	tmpl      *template.Template
-	buildErr  string
-	renderErr string
-	build     func(context.Context, DecisionScope, bool) (any, error)
+	path             string
+	tmpl             *template.Template
+	buildErr         string
+	renderErr        string
+	sourceConfigured func(*ReadModel) bool
+	build            func(context.Context, DecisionScope, bool) (any, error)
 }
 
 func (d *dashboardHandler) serveDecisionScopePage(w http.ResponseWriter, r *http.Request, opts decisionScopePageOptions) {
@@ -391,10 +463,18 @@ func (d *dashboardHandler) serveDecisionScopePage(w http.ResponseWriter, r *http
 		http.Error(w, "invalid decision scope", http.StatusBadRequest)
 		return
 	}
-	page, err := opts.build(r.Context(), scope, rawAllowedFromContext(r))
+	raw := rawAllowedFromContext(r)
+	sourceConfigured := scope.ArtifactHash != "" && opts.sourceConfigured != nil && opts.sourceConfigured(d.model)
+	if !d.authorizeFleetScopeRequest(w, r, scope, sourceConfigured, raw) {
+		return
+	}
+	page, err := opts.build(r.Context(), scope, raw)
 	if err != nil {
 		http.Error(w, opts.buildErr, http.StatusInternalServerError)
 		return
+	}
+	if scope.ArtifactHash != "" {
+		d.recordDecisionScopeAudit(r, raw, scope, page)
 	}
 	var buf bytes.Buffer
 	if err := opts.tmpl.Execute(&buf, page); err != nil {
@@ -415,6 +495,9 @@ func (d *dashboardHandler) handleWorkbench(w http.ResponseWriter, r *http.Reques
 		tmpl:      workbenchTemplate,
 		buildErr:  "could not build workbench view",
 		renderErr: "could not render workbench",
+		sourceConfigured: func(m *ReadModel) bool {
+			return m.conductorSource != nil
+		},
 		build: func(ctx context.Context, scope DecisionScope, raw bool) (any, error) {
 			return d.model.Workbench(ctx, scope, raw)
 		},
@@ -430,6 +513,9 @@ func (d *dashboardHandler) handleIncident(w http.ResponseWriter, r *http.Request
 		tmpl:      incidentTemplate,
 		buildErr:  "could not build incident view",
 		renderErr: "could not render incident view",
+		sourceConfigured: func(m *ReadModel) bool {
+			return m.conductorSource != nil || m.fleetSource != nil
+		},
 		build: func(ctx context.Context, scope DecisionScope, raw bool) (any, error) {
 			return d.model.Incident(ctx, scope, raw)
 		},

--- a/enterprise/dashboard/incident.go
+++ b/enterprise/dashboard/incident.go
@@ -1,0 +1,133 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"context"
+	"fmt"
+)
+
+// The Incident Cockpit is a READ-ONLY correlation lens. It joins one conductor
+// decision (re-derived by the read-only replay seam) with the mediated applied
+// state reported by enrolled followers. It embeds no agent-kill, no publish, and
+// no authority: like every other page in this package it is GET-only and reaches
+// no write path.
+
+// IncidentPage is the rendered incident cockpit view.
+type IncidentPage struct {
+	Claim    string
+	NonClaim string
+
+	DecisionSourceConfigured bool
+	FleetSourceConfigured    bool
+	RawAllowed               bool
+
+	ScopeProvided bool
+	OrgID         string
+	FleetID       string
+
+	HasDecision     bool
+	DecisionMissing bool
+	Decision        DecisionReplayView
+
+	HasFleet bool
+	Applied  FleetAppliedSummary
+}
+
+// FleetAppliedSummary is a bounded, non-identifying rollup of follower applied
+// state for the scoped fleet. It carries only counts (never instance ids,
+// hostnames, hashes, or versions), so it is safe in the metadata view without
+// per-field redaction.
+type FleetAppliedSummary struct {
+	Total            int
+	Verified         int
+	SignedUnverified int
+	Unsigned         int
+	NoReport         int
+	Drift            int
+	ApplyFailed      int
+	Truncated        bool
+}
+
+// Incident builds the read-only incident cockpit view. Each correlated source is
+// independent: a missing conductor decision source or fleet source renders an
+// explicit unconfigured state without failing the other half, mirroring the
+// fleet overview's per-source absence handling.
+func (m *ReadModel) Incident(ctx context.Context, scope DecisionScope, rawAllowed bool) (IncidentPage, error) {
+	scope = normalizeDecisionScope(scope)
+	page := IncidentPage{
+		Claim:                    incidentClaim,
+		NonClaim:                 incidentNonClaim,
+		DecisionSourceConfigured: m.conductorSource != nil,
+		FleetSourceConfigured:    m.fleetSource != nil,
+		RawAllowed:               rawAllowed,
+		OrgID:                    metadataScopeDisplay(scope.OrgID, rawAllowed),
+		FleetID:                  metadataScopeDisplay(scope.FleetID, rawAllowed),
+		ScopeProvided:            scope.ArtifactHash != "",
+	}
+	if scope.ArtifactHash == "" {
+		return page, nil
+	}
+	if m.conductorSource != nil {
+		view, found, err := m.conductorSource.ReplayDecision(ctx, scope)
+		if err != nil {
+			return IncidentPage{}, fmt.Errorf("replay decision: %w", err)
+		}
+		if !found {
+			page.DecisionMissing = true
+		} else {
+			page.HasDecision = true
+			page.Decision = normalizeReplayView(view)
+			if !rawAllowed {
+				page.Decision = redactReplayView(page.Decision)
+			}
+		}
+	}
+	if m.fleetSource != nil {
+		summary, err := m.fleetAppliedSummary(ctx, scope.OrgID, scope.FleetID)
+		if err != nil {
+			return IncidentPage{}, err
+		}
+		page.HasFleet = true
+		page.Applied = summary
+	}
+	return page, nil
+}
+
+// fleetAppliedSummary reads the scoped followers and reduces them to bounded
+// counts. It reuses the fleet overview's read seam and its follower limit, and
+// it normalizes health/drift through the same bounded classifier.
+func (m *ReadModel) fleetAppliedSummary(ctx context.Context, orgID, fleetID string) (FleetAppliedSummary, error) {
+	followers, err := m.fleetSource.ListFleetFollowers(ctx, orgID, fleetID, fleetOverviewFollowerLimit+1)
+	if err != nil {
+		return FleetAppliedSummary{}, fmt.Errorf("list fleet followers: %w", err)
+	}
+	var summary FleetAppliedSummary
+	if len(followers) > fleetOverviewFollowerLimit {
+		followers = followers[:fleetOverviewFollowerLimit]
+		summary.Truncated = true
+	}
+	followers = normalizeFleetFollowers(followers)
+	summary.Total = len(followers)
+	for _, f := range followers {
+		switch f.SourceClass() {
+		case "verified":
+			summary.Verified++
+		case "signed-unverified":
+			summary.SignedUnverified++
+		case "unsigned":
+			summary.Unsigned++
+		default:
+			summary.NoReport++
+		}
+		if f.Drift == "drift" {
+			summary.Drift++
+		}
+		if f.FleetHealth == "apply_failed" {
+			summary.ApplyFailed++
+		}
+	}
+	return summary, nil
+}

--- a/enterprise/dashboard/incident.tmpl.html
+++ b/enterprise/dashboard/incident.tmpl.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Pipelock Incident Cockpit</title>
+  <style>
+    :root {
+      --accent:#00e5a0;
+      --bg:#09090b;
+      --bg-elevated:#0e0e11;
+      --border:rgba(255,255,255,0.07);
+      --border-strong:rgba(255,255,255,0.13);
+      --text:#e2e8f0;
+      --text-muted:#94a3b8;
+      --text-dim:#64748b;
+      --warn:#f59e0b;
+      --danger:#ef4444;
+    }
+    * { box-sizing: border-box; }
+    html, body { min-height: 100%; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.45 Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .topbar {
+      min-height: 56px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 14px;
+      padding: 0 24px;
+      border-bottom: 1px solid var(--border-strong);
+      background: #08080a;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+    .brand { font-weight: 650; }
+    .brand span { color: var(--text-muted); font-weight: 500; }
+    .nav { display: flex; align-items: center; gap: 14px; color: var(--text-dim); font-size: 13px; flex-wrap: wrap; }
+    .nav a { color: var(--text-muted); text-decoration: none; }
+    .nav a:hover { color: var(--text); }
+    main { min-width: 0; padding: 24px; }
+    .panel { max-width: 1100px; margin: 0 auto; }
+    h1, h2 { margin: 0; letter-spacing: 0; }
+    h1 { font-size: 24px; }
+    h2 { font-size: 16px; margin: 24px 0 12px; }
+    .muted { color: var(--text-muted); }
+    .dim { color: var(--text-dim); }
+    .mono { font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .scope { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 8px; }
+    .scope-item { border: 1px solid var(--border); background: var(--bg-elevated); border-radius: 8px; padding: 8px 10px; }
+    .callout {
+      border: 1px solid var(--border-strong);
+      background: #0b0f0e;
+      padding: 14px;
+      border-radius: 8px;
+      margin: 14px 0;
+    }
+    .card {
+      border: 1px solid var(--border);
+      background: var(--bg-elevated);
+      border-radius: 8px;
+      padding: 14px;
+      margin-bottom: 12px;
+    }
+    .kv { display: grid; grid-template-columns: 220px 1fr; gap: 6px 16px; margin-top: 8px; }
+    .kv dt { color: var(--text-muted); }
+    .kv dd { margin: 0; overflow-wrap: anywhere; }
+    .counts { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 8px; }
+    .count { border: 1px solid var(--border); background: #0b0b0e; border-radius: 8px; padding: 8px 12px; min-width: 120px; }
+    .count .n { font-size: 20px; font-weight: 700; }
+    .count .l { color: var(--text-muted); font-size: 12px; }
+    .chip {
+      display: inline-flex;
+      justify-content: center;
+      min-width: 122px;
+      padding: 4px 9px;
+      border-radius: 999px;
+      color: #050507;
+      font-size: 12px;
+      font-weight: 800;
+      white-space: nowrap;
+    }
+    .chip.verified { background: var(--accent); }
+    .chip.signed-unverified { background: var(--warn); }
+    .chip.unsigned { background: #64748b; color: #f8fafc; }
+    .chip.missing { background: var(--danger); color: white; }
+    .empty { color: var(--text-muted); padding: 20px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-elevated); }
+    .absence { border: 1px solid rgba(245,158,11,0.7); background: rgba(245,158,11,0.10); padding: 16px; border-radius: 8px; }
+    .absence h2 { color: #fde68a; font-size: 18px; margin-top: 0; }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">Pipelock <span>- Operator Console / Incident</span></div>
+    <div class="nav"><a href="/">Evidence</a><a href="/fleet">Fleet</a><a href="/workbench">Workbench</a><a href="/exemptions">Exemptions</a><span class="mono">read-only</span></div>
+  </header>
+  <main>
+    <div class="panel">
+      <h1>Incident Cockpit</h1>
+      <div class="muted">{{.Claim}}</div>
+      <div class="scope">
+        <span class="scope-item">org <span class="mono">{{if .OrgID}}{{.OrgID}}{{else}}-{{end}}</span></span>
+        <span class="scope-item">fleet <span class="mono">{{if .FleetID}}{{.FleetID}}{{else}}-{{end}}</span></span>
+      </div>
+
+      <div class="callout muted">This cockpit reads and correlates; it never kills an agent, publishes, or mutates fleet state. It {{.NonClaim}}.</div>
+      {{if not .RawAllowed}}
+        <div class="callout muted">Metadata view: decision hashes and versions are hidden. Fleet applied-state counts are always shown; they carry no follower identifiers.</div>
+      {{end}}
+
+      {{if not .ScopeProvided}}
+        <section class="empty">Supply <span class="mono">?org_id=&lt;org&gt;&amp;fleet_id=&lt;fleet&gt;&amp;artifact_hash=&lt;hash&gt;</span> to correlate a conductor decision with its fleet applied state.</section>
+      {{else}}
+        <h2>Conductor decision</h2>
+        {{if not .DecisionSourceConfigured}}
+          <section class="absence"><h2>No conductor decision source configured</h2><p class="muted">Decision replay requires the dashboard to be wired to a conductor read source.</p></section>
+        {{else if .DecisionMissing}}
+          <section class="empty">No recorded decision matched this artifact hash.</section>
+        {{else if .HasDecision}}
+          {{with .Decision}}
+          <section class="card">
+            <div>
+              <span class="chip {{.VerdictClass}}">{{.VerdictLabel}}</span>
+              <span class="chip {{.DivergenceClass}}">{{.DivergenceLabel}}</span>
+            </div>
+            <dl class="kv">
+              <dt>Action kind</dt><dd>{{.KindLabel}}</dd>
+              <dt>Recorded</dt><dd>{{.RecordedLabel}}</dd>
+              <dt>Replayed at</dt><dd>{{.ReplayedAtDisplay}}</dd>
+              <dt>Conflict code</dt><dd>{{.ConflictDisplay}}</dd>
+              <dt>Divergence reason</dt><dd>{{.DivergenceReasonDisplay}}</dd>
+              <dt>Result version</dt><dd class="mono">{{.ResultVersionDisplay}}</dd>
+              <dt>Artifact hash</dt><dd class="mono">{{.ArtifactHashDisplay}}</dd>
+              <dt>Recorded hash</dt><dd class="mono">{{.RecordedHashDisplay}}</dd>
+            </dl>
+          </section>
+          {{end}}
+        {{end}}
+
+        <h2>Fleet applied state</h2>
+        {{if not .FleetSourceConfigured}}
+          <section class="absence"><h2>No conductor fleet source configured</h2><p class="muted">Applied-state correlation requires the dashboard to be wired to a conductor read source.</p></section>
+        {{else if .HasFleet}}
+          {{with .Applied}}
+          {{if .Truncated}}<div class="callout muted">Showing counts for the first 500 followers returned by this scoped query.</div>{{end}}
+          <section class="card">
+            <div class="counts">
+              <div class="count"><div class="n">{{.Total}}</div><div class="l">followers</div></div>
+              <div class="count"><div class="n">{{.Verified}}</div><div class="l">verified applied</div></div>
+              <div class="count"><div class="n">{{.SignedUnverified}}</div><div class="l">signed, unverified</div></div>
+              <div class="count"><div class="n">{{.Unsigned}}</div><div class="l">unsigned/self-reported</div></div>
+              <div class="count"><div class="n">{{.NoReport}}</div><div class="l">no applied-state report</div></div>
+              <div class="count"><div class="n">{{.Drift}}</div><div class="l">drift</div></div>
+              <div class="count"><div class="n">{{.ApplyFailed}}</div><div class="l">apply failed</div></div>
+            </div>
+          </section>
+          {{end}}
+        {{end}}
+      {{end}}
+    </div>
+  </main>
+</body>
+</html>

--- a/enterprise/dashboard/incident_test.go
+++ b/enterprise/dashboard/incident_test.go
@@ -57,11 +57,12 @@ func TestIncident_CorrelatesDecisionAndAppliedSummary(t *testing.T) {
 	source := &fakeConductorSource{view: testReplayView(), found: true}
 	fleet := &fakeFleetSource{followers: testFleetFollowers()}
 	handler := New(Options{
-		ReceiptDir:      t.TempDir(),
-		HasFeature:      allowFleetFeature,
-		ConductorSource: source,
-		FleetSource:     fleet,
-		AuthorizeRaw:    allowRawAccess,
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		ConductorSource:     source,
+		FleetSource:         fleet,
+		AuthorizeRaw:        allowRawAccess,
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
@@ -126,6 +127,7 @@ func TestIncident_MetadataViewRedactsDecision(t *testing.T) {
 		ConductorSource: source,
 		FleetSource:     &fakeFleetSource{followers: testFleetFollowers()},
 		// No AuthorizeRaw: fail closed.
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
@@ -155,7 +157,7 @@ func TestIncident_DecisionMissingRendersEmpty(t *testing.T) {
 	t.Parallel()
 
 	source := &fakeConductorSource{found: false}
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source})
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
 	if rec.Code != http.StatusOK {
@@ -170,10 +172,11 @@ func TestIncident_FleetSourceErrorReturnsServerError(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
-		ReceiptDir:      t.TempDir(),
-		HasFeature:      allowFleetFeature,
-		ConductorSource: &fakeConductorSource{found: false},
-		FleetSource:     &fakeFleetSource{err: errors.New("fleet unavailable")},
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		ConductorSource:     &fakeConductorSource{found: false},
+		FleetSource:         &fakeFleetSource{err: errors.New("fleet unavailable")},
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
@@ -186,9 +189,10 @@ func TestIncident_DecisionSourceErrorReturnsServerError(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
-		ReceiptDir:      t.TempDir(),
-		HasFeature:      allowFleetFeature,
-		ConductorSource: &fakeConductorSource{err: errors.New("replay unavailable")},
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		ConductorSource:     &fakeConductorSource{err: errors.New("replay unavailable")},
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))

--- a/enterprise/dashboard/incident_test.go
+++ b/enterprise/dashboard/incident_test.go
@@ -102,6 +102,15 @@ func TestIncident_AppliedSummaryCountsAreCorrect(t *testing.T) {
 		t.Fatalf("counts = verified %d / signed-unverified %d / unsigned %d, want 1/1/1",
 			summary.Verified, summary.SignedUnverified, summary.Unsigned)
 	}
+	if summary.NoReport != 0 {
+		t.Fatalf("NoReport = %d, want 0", summary.NoReport)
+	}
+	if summary.Drift != 0 {
+		t.Fatalf("Drift = %d, want 0", summary.Drift)
+	}
+	if summary.ApplyFailed != 0 {
+		t.Fatalf("ApplyFailed = %d, want 0", summary.ApplyFailed)
+	}
 }
 
 func TestIncident_MetadataViewRedactsDecision(t *testing.T) {

--- a/enterprise/dashboard/incident_test.go
+++ b/enterprise/dashboard/incident_test.go
@@ -1,0 +1,189 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func incidentTarget() string {
+	return "/incident?org_id=" + wbTestOrgID + "&fleet_id=" + wbTestFleetID + "&artifact_hash=" + wbTestArtifactHash
+}
+
+func TestIncident_ScopePromptWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/incident", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{incidentClaim, incidentNonClaim, "Supply", "never kills an agent"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("incident body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestIncident_UnconfiguredSourcesRenderAbsence(t *testing.T) {
+	t.Parallel()
+
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"No conductor decision source configured", "No conductor fleet source configured"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("incident body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestIncident_CorrelatesDecisionAndAppliedSummary(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeConductorSource{view: testReplayView(), found: true}
+	fleet := &fakeFleetSource{followers: testFleetFollowers()}
+	handler := New(Options{
+		ReceiptDir:      t.TempDir(),
+		HasFeature:      allowFleetFeature,
+		ConductorSource: source,
+		FleetSource:     fleet,
+		AuthorizeRaw:    allowRawAccess,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if fleet.gotOrgID != wbTestOrgID || fleet.gotFleet != wbTestFleetID {
+		t.Fatalf("fleet scope = (%q,%q), want (%q,%q)", fleet.gotOrgID, fleet.gotFleet, wbTestOrgID, wbTestFleetID)
+	}
+	if fleet.gotLimit != fleetOverviewFollowerLimit+1 {
+		t.Fatalf("fleet limit = %d, want %d", fleet.gotLimit, fleetOverviewFollowerLimit+1)
+	}
+	body := rec.Body.String()
+	// testFleetFollowers(): 1 verified, 1 signed-unverified, 1 unsigned.
+	for _, want := range []string{
+		"Rollback", "Divergence",
+		"verified applied", "signed, unverified", "unsigned/self-reported",
+		"followers",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("incident body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestIncident_AppliedSummaryCountsAreCorrect(t *testing.T) {
+	t.Parallel()
+
+	model := NewReadModel(Options{ReceiptDir: t.TempDir(), FleetSource: &fakeFleetSource{followers: testFleetFollowers()}})
+	summary, err := model.fleetAppliedSummary(context.Background(), wbTestOrgID, wbTestFleetID)
+	if err != nil {
+		t.Fatalf("fleetAppliedSummary: %v", err)
+	}
+	if summary.Total != 3 {
+		t.Fatalf("Total = %d, want 3", summary.Total)
+	}
+	if summary.Verified != 1 || summary.SignedUnverified != 1 || summary.Unsigned != 1 {
+		t.Fatalf("counts = verified %d / signed-unverified %d / unsigned %d, want 1/1/1",
+			summary.Verified, summary.SignedUnverified, summary.Unsigned)
+	}
+}
+
+func TestIncident_MetadataViewRedactsDecision(t *testing.T) {
+	t.Parallel()
+
+	view := testReplayView()
+	view.Valid = false
+	view.Conflict = "source error for " + wbSensitiveHash
+	source := &fakeConductorSource{view: view, found: true}
+	handler := New(Options{
+		ReceiptDir:      t.TempDir(),
+		HasFeature:      allowFleetFeature,
+		ConductorSource: source,
+		FleetSource:     &fakeFleetSource{followers: testFleetFollowers()},
+		// No AuthorizeRaw: fail closed.
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, secret := range []string{wbSensitiveHash, wbSensitiveResult, wbSensitiveReason, wbTestOrgID, wbTestFleetID, "source error"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("metadata incident leaked %q: %s", secret, body)
+		}
+	}
+	if !strings.Contains(body, "org <span class=\"mono\">"+fleetRedacted+"</span>") ||
+		!strings.Contains(body, "fleet <span class=\"mono\">"+fleetRedacted+"</span>") {
+		t.Fatalf("metadata incident missing redacted scope: %s", body)
+	}
+	if !strings.Contains(body, "Would be rejected: unknown") {
+		t.Fatalf("metadata incident missing bounded conflict code: %s", body)
+	}
+	// Applied-state counts (non-identifying) are still shown in the metadata view.
+	if !strings.Contains(body, "verified applied") {
+		t.Fatalf("metadata incident missing applied counts: %s", body)
+	}
+}
+
+func TestIncident_DecisionMissingRendersEmpty(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeConductorSource{found: false}
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "No recorded decision matched") {
+		t.Fatalf("body missing decision-missing state: %s", rec.Body.String())
+	}
+}
+
+func TestIncident_FleetSourceErrorReturnsServerError(t *testing.T) {
+	t.Parallel()
+
+	handler := New(Options{
+		ReceiptDir:      t.TempDir(),
+		HasFeature:      allowFleetFeature,
+		ConductorSource: &fakeConductorSource{found: false},
+		FleetSource:     &fakeFleetSource{err: errors.New("fleet unavailable")},
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestIncident_DecisionSourceErrorReturnsServerError(t *testing.T) {
+	t.Parallel()
+
+	handler := New(Options{
+		ReceiptDir:      t.TempDir(),
+		HasFeature:      allowFleetFeature,
+		ConductorSource: &fakeConductorSource{err: errors.New("replay unavailable")},
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -65,8 +65,14 @@ type Options struct {
 	// AuditWriter, when non-nil, receives one line per authenticated dashboard
 	// request (role, method, path, session, remote address). Viewing evidence is
 	// itself an audited action. Nil disables the access log.
-	AuditWriter      io.Writer
-	FleetSource      FleetDataSource
+	AuditWriter io.Writer
+	FleetSource FleetDataSource
+	// ConductorSource, when non-nil, is the read-only conductor decision
+	// dry-run/replay seam (BE-2) consumed by the Signed Action Workbench and
+	// Incident Cockpit. It exposes no publish/kill/rollback method, so no write
+	// path to fleet state is reachable through it. Nil renders the explicit
+	// unconfigured-replay state, exactly like FleetSource.
+	ConductorSource  ConductorDecisionSource
 	ReceiptReadLimit int
 	TimelineLimit    int
 	// FilterPresets maps named presets to bounded filter specs. Loaded from
@@ -90,6 +96,7 @@ type ReadModel struct {
 	timelineLimit     int
 	filterPresets     map[string]FilterSpec
 	fleetSource       FleetDataSource
+	conductorSource   ConductorDecisionSource
 	fleetRedactionKey [fleetRedactionKeySize]byte
 	exemptionStore    *ExemptionStore
 	now               func() time.Time
@@ -121,6 +128,7 @@ func NewReadModel(opts Options) *ReadModel {
 		timelineLimit:     timelineLimit,
 		filterPresets:     opts.FilterPresets,
 		fleetSource:       opts.FleetSource,
+		conductorSource:   opts.ConductorSource,
 		fleetRedactionKey: fleetRedactionKey,
 		exemptionStore:    opts.ExemptionStore,
 		now:               now,

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -62,9 +62,15 @@ type Options struct {
 	// (fail closed): a destination URL can carry a capability token, and the raw
 	// payload is the largest exfil surface, so raw is least-privilege by default.
 	AuthorizeRaw func(*http.Request) error
-	// AuditWriter, when non-nil, receives one line per authenticated dashboard
-	// request (role, method, path, session, remote address). Viewing evidence is
-	// itself an audited action. Nil disables the access log.
+	// AuthorizeFleetScope gates reads keyed by an operator-supplied org/fleet
+	// scope before any conductor replay or fleet source is called. Nil is
+	// fail-closed when a read source is configured for the requested page.
+	AuthorizeFleetScope func(*http.Request, DecisionScope, bool) error
+	// AuditWriter, when non-nil, receives access lines for authenticated
+	// dashboard requests and scope lines for replay/fleet correlation lookups.
+	// Scope values are logged as stable hashes, not raw org/fleet/artifact
+	// identifiers. Viewing evidence is itself an audited action. Nil disables
+	// the access log.
 	AuditWriter io.Writer
 	FleetSource FleetDataSource
 	// ConductorSource, when non-nil, is the read-only conductor decision

--- a/enterprise/dashboard/testhelpers_test.go
+++ b/enterprise/dashboard/testhelpers_test.go
@@ -33,6 +33,10 @@ func generateDashboardKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) 
 	return pub, priv
 }
 
+func allowFleetScope(*http.Request, DecisionScope, bool) error {
+	return nil
+}
+
 func buildDashboardChain(t *testing.T, priv ed25519.PrivateKey, count int) []receipt.Receipt {
 	t.Helper()
 	chain := make([]receipt.Receipt, 0, count)

--- a/enterprise/dashboard/workbench.go
+++ b/enterprise/dashboard/workbench.go
@@ -1,0 +1,345 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// artifactHashPattern bounds the operator-supplied artifact hash to a canonical
+// hash shape (hex/base32/base64url plus the "sha256:" style prefix). It rejects
+// path traversal, whitespace, and control characters before the value reaches
+// any source.
+var artifactHashPattern = regexp.MustCompile(`^[A-Za-z0-9:_-]{1,128}$`)
+
+// Signed Action Workbench and Incident Cockpit are PREPARE / VERIFY / REPLAY
+// surfaces only. They hold no control authority: the dashboard exposes no route
+// that publishes a policy, kills or resumes a fleet, rolls back a stream, or
+// otherwise mutates conductor state. Every route in this package is GET-only and
+// the only conductor seam it consumes (ConductorDecisionSource) is read-only.
+// An operator PREPARES and SUBMITS an action with the shipped conductor CLI
+// OUTSIDE the dashboard; the workbench's job ends at "here is the predicted
+// effect and the exact command to run".
+
+const (
+	// Bounded conductor action kinds. A replay whose kind is none of these is
+	// rendered as "unknown" rather than echoed back.
+	actionKindPublish    = "publish"
+	actionKindRemoteKill = "remote_kill"
+	actionKindRollback   = "rollback"
+	actionKindUnknown    = "unknown"
+
+	replayConflictIDConflict            = "conflict"
+	replayConflictStaleCounter          = "stale_counter"
+	replayConflictRollbackAttempt       = "rollback_attempt"
+	replayConflictVersionBelowStreamMax = "version_below_stream_max"
+	replayConflictPreviousHashMismatch  = "previous_hash_mismatch"
+	replayConflictFleetSkew             = "fleet_skew"
+	replayConflictUnknown               = "unknown"
+
+	workbenchNeverAuthority = "This dashboard never publishes, kills, resumes, or rolls back a fleet. " +
+		"It prepares and verifies an action and shows its predicted effect; you submit it with the shipped " +
+		"conductor CLI outside the dashboard."
+
+	workbenchReplayClaim = "Replay re-derives the conductor authorization and effect decision for a past " +
+		"signed action under current fleet and policy state."
+	workbenchReplayNonClaim = "does not re-derive proxy content-scan verdicts, and does not prove any action " +
+		"executed or was prevented outside the conductor decision"
+
+	incidentClaim = "Correlates one conductor decision with its replay divergence and the mediated applied " +
+		"state reported by enrolled followers."
+	incidentNonClaim = "does not prove no bypass occurred outside Pipelock, outside enrolled followers, or " +
+		"outside the report window"
+
+	workbenchArtifactHashLimit = 128
+)
+
+// PrepareStep is one row of static, honest guidance: the shipped conductor CLI
+// command an operator runs OUTSIDE the dashboard to prepare and submit an
+// action, plus the read-only dry-run they can run first. It carries no operator
+// input and no fleet state, so it is identical for every request.
+type PrepareStep struct {
+	Kind        string
+	Title       string
+	Description string
+	Command     string
+}
+
+// prepareSteps is the fixed set of shipped conductor commands surfaced as
+// prepare/submit guidance. The dashboard never runs these; it only shows them.
+func prepareSteps() []PrepareStep {
+	return []PrepareStep{
+		{
+			Kind:        actionKindPublish,
+			Title:       "Publish a policy bundle",
+			Description: "Sign a config as a policy bundle and publish it to the fleet's stream head.",
+			Command:     "pipelock conductor publish --conductor-url <url> --config <policy.yaml> --org <org> --fleet <fleet> --version <n> --signing-key <key>",
+		},
+		{
+			Kind:        actionKindRemoteKill,
+			Title:       "Remote kill / resume",
+			Description: "Publish a signed remote-kill (or resume) message that halts or restores follower egress.",
+			Command:     "pipelock conductor kill --conductor-url <url> --org <org> --fleet <fleet> --counter <n> --signing-key <key>",
+		},
+		{
+			Kind:        actionKindRollback,
+			Title:       "Roll back the stream head",
+			Description: "Publish a signed rollback authorization that moves the effective head to a prior bundle.",
+			Command:     "pipelock conductor rollback --conductor-url <url> --org <org> --fleet <fleet> --to-version <n> --counter <n> --signing-key <key>",
+		},
+	}
+}
+
+// DecisionScope identifies one past decision to replay. All fields are operator
+// input and are validated before use; ArtifactHash is the canonical hash of the
+// signed action as printed by the conductor CLI when the action was submitted.
+type DecisionScope struct {
+	OrgID        string
+	FleetID      string
+	ArtifactHash string
+}
+
+// ConductorDecisionSource is the dashboard-local read seam for the conductor's
+// read-only decision dry-run/replay surface (BE-2). Implementations MUST be
+// read-only: replaying a decision mutates no store. This is the ONLY conductor
+// seam the workbench and cockpit consume, and it deliberately exposes no
+// publish/kill/rollback method, so no write path to fleet state is reachable
+// from the dashboard.
+type ConductorDecisionSource interface {
+	// ReplayDecision re-derives the conductor decision for the signed action
+	// identified by scope.ArtifactHash under current fleet/policy state and
+	// reports whether that decision diverges from what was recorded. It returns
+	// found=false when no such recorded decision exists. Read-only.
+	ReplayDecision(ctx context.Context, scope DecisionScope) (DecisionReplayView, bool, error)
+}
+
+// DecisionReplayView is the dashboard-local projection of a replay result. It
+// carries NO bundle payload, signature bytes, or signing material: only the
+// re-derived verdict, the loud divergence flag, and identifiers/versions that
+// the RBAC redaction step strips for metadata-token holders.
+type DecisionReplayView struct {
+	ActionKind        string
+	ArtifactHash      string // redacted in metadata view
+	ResultVersion     uint64 // redacted in metadata view (0 = hidden)
+	ResultHash        string // redacted in metadata view
+	UsedStateSnapshot bool
+	ReplayedAt        time.Time
+
+	// Computed status: kept in the metadata view.
+	Valid            bool
+	Conflict         string // bounded conflict code (e.g. "stale_counter"), or ""
+	Divergence       bool
+	DivergenceReason string // redacted in metadata view (may carry identifiers)
+
+	RecordedPresent  bool
+	RecordedAccepted bool
+	RecordedHash     string // redacted in metadata view
+	RecordedAt       time.Time
+}
+
+// WorkbenchPage is the rendered workbench view.
+type WorkbenchPage struct {
+	NeverAuthority   string
+	PrepareSteps     []PrepareStep
+	ReplayClaim      string
+	ReplayNonClaim   string
+	SourceConfigured bool
+	RawAllowed       bool
+
+	// Replay panel: populated only when an artifact hash was supplied AND a
+	// conductor source is wired AND the decision was found.
+	ScopeProvided  bool
+	OrgID          string
+	FleetID        string
+	HasReplay      bool
+	Replay         DecisionReplayView
+	ReplayNotFound bool
+}
+
+// Workbench builds the read-only workbench view. When no conductor source is
+// wired it renders the prepare guidance plus an explicit unconfigured-replay
+// state, exactly like the fleet overview's unconfigured-source state.
+func (m *ReadModel) Workbench(ctx context.Context, scope DecisionScope, rawAllowed bool) (WorkbenchPage, error) {
+	scope = normalizeDecisionScope(scope)
+	page := WorkbenchPage{
+		NeverAuthority:   workbenchNeverAuthority,
+		PrepareSteps:     prepareSteps(),
+		ReplayClaim:      workbenchReplayClaim,
+		ReplayNonClaim:   workbenchReplayNonClaim,
+		SourceConfigured: m.conductorSource != nil,
+		RawAllowed:       rawAllowed,
+		OrgID:            metadataScopeDisplay(scope.OrgID, rawAllowed),
+		FleetID:          metadataScopeDisplay(scope.FleetID, rawAllowed),
+		ScopeProvided:    scope.ArtifactHash != "",
+	}
+	if scope.ArtifactHash == "" || m.conductorSource == nil {
+		return page, nil
+	}
+	view, found, err := m.conductorSource.ReplayDecision(ctx, scope)
+	if err != nil {
+		return WorkbenchPage{}, fmt.Errorf("replay decision: %w", err)
+	}
+	if !found {
+		page.ReplayNotFound = true
+		return page, nil
+	}
+	page.HasReplay = true
+	page.Replay = normalizeReplayView(view)
+	if !rawAllowed {
+		page.Replay = redactReplayView(page.Replay)
+	}
+	return page, nil
+}
+
+func normalizeDecisionScope(scope DecisionScope) DecisionScope {
+	scope.OrgID = strings.TrimSpace(scope.OrgID)
+	scope.FleetID = strings.TrimSpace(scope.FleetID)
+	scope.ArtifactHash = strings.TrimSpace(scope.ArtifactHash)
+	return scope
+}
+
+// validateDecisionScope requires a well-formed org/fleet scope and artifact hash
+// whenever an artifact hash is supplied. An empty artifact hash is valid (the
+// workbench renders prepare guidance only); a supplied hash requires org+fleet.
+func validateDecisionScope(scope DecisionScope) error {
+	scope = normalizeDecisionScope(scope)
+	if scope.ArtifactHash == "" {
+		if scope.OrgID != "" || scope.FleetID != "" {
+			return fmt.Errorf("%w: org_id and fleet_id require an artifact_hash", errInvalidFleetScope)
+		}
+		return nil
+	}
+	if scope.OrgID == "" || scope.FleetID == "" {
+		return fmt.Errorf("%w: org_id and fleet_id are required with an artifact_hash", errInvalidFleetScope)
+	}
+	if !fleetScopePattern.MatchString(scope.OrgID) || !fleetScopePattern.MatchString(scope.FleetID) {
+		return fmt.Errorf("%w: org_id and fleet_id must match [A-Za-z0-9._:-]{1,128}", errInvalidFleetScope)
+	}
+	if len(scope.ArtifactHash) > workbenchArtifactHashLimit || !artifactHashPattern.MatchString(scope.ArtifactHash) {
+		return fmt.Errorf("%w: artifact_hash must match [A-Za-z0-9:_-]{1,128}", errInvalidFleetScope)
+	}
+	return nil
+}
+
+func normalizeReplayView(v DecisionReplayView) DecisionReplayView {
+	switch v.ActionKind {
+	case actionKindPublish, actionKindRemoteKill, actionKindRollback:
+		// kept
+	default:
+		v.ActionKind = actionKindUnknown
+	}
+	v.Conflict = normalizeReplayConflict(v.Conflict)
+	return v
+}
+
+func normalizeReplayConflict(conflict string) string {
+	conflict = strings.TrimSpace(conflict)
+	switch conflict {
+	case "", replayConflictIDConflict, replayConflictStaleCounter, replayConflictRollbackAttempt,
+		replayConflictVersionBelowStreamMax, replayConflictPreviousHashMismatch, replayConflictFleetSkew:
+		return conflict
+	default:
+		return replayConflictUnknown
+	}
+}
+
+func metadataScopeDisplay(value string, rawAllowed bool) string {
+	if rawAllowed {
+		return value
+	}
+	return redactedFleetString(value)
+}
+
+// redactReplayView strips identifiers, versions, hashes, and the free-text
+// divergence reason for the metadata view, keeping only computed status
+// (validity, the bounded conflict code, and the loud divergence flag).
+func redactReplayView(v DecisionReplayView) DecisionReplayView {
+	v.ArtifactHash = redactedFleetString(v.ArtifactHash)
+	v.ResultHash = redactedFleetString(v.ResultHash)
+	v.RecordedHash = redactedFleetString(v.RecordedHash)
+	v.ResultVersion = 0
+	if strings.TrimSpace(v.DivergenceReason) != "" {
+		v.DivergenceReason = fleetRedacted
+	}
+	return v
+}
+
+// Kind returns a stable human label for the bounded action kind.
+func (v DecisionReplayView) KindLabel() string {
+	switch v.ActionKind {
+	case actionKindPublish:
+		return "Policy publish"
+	case actionKindRemoteKill:
+		return "Remote kill / resume"
+	case actionKindRollback:
+		return "Rollback"
+	default:
+		return "Unknown action"
+	}
+}
+
+// VerdictLabel is a bounded, never-green status phrase for the re-derived
+// decision. Divergence is surfaced loudly and separately.
+func (v DecisionReplayView) VerdictLabel() string {
+	if v.Valid {
+		return "Would be accepted"
+	}
+	if strings.TrimSpace(v.Conflict) != "" {
+		return "Would be rejected: " + v.Conflict
+	}
+	return "Would be rejected"
+}
+
+func (v DecisionReplayView) VerdictClass() string {
+	if v.Valid {
+		return "signed-unverified"
+	}
+	return "missing"
+}
+
+func (v DecisionReplayView) DivergenceLabel() string {
+	if v.Divergence {
+		return "Divergence"
+	}
+	return "No divergence"
+}
+
+func (v DecisionReplayView) DivergenceClass() string {
+	if v.Divergence {
+		return "missing"
+	}
+	return "verified"
+}
+
+func (v DecisionReplayView) ArtifactHashDisplay() string { return displayFleetString(v.ArtifactHash) }
+func (v DecisionReplayView) ResultHashDisplay() string   { return displayFleetString(v.ResultHash) }
+func (v DecisionReplayView) RecordedHashDisplay() string { return displayFleetString(v.RecordedHash) }
+func (v DecisionReplayView) DivergenceReasonDisplay() string {
+	return displayFleetString(v.DivergenceReason)
+}
+func (v DecisionReplayView) ConflictDisplay() string   { return displayFleetString(v.Conflict) }
+func (v DecisionReplayView) ReplayedAtDisplay() string { return displayFleetTime(v.ReplayedAt) }
+func (v DecisionReplayView) RecordedAtDisplay() string { return displayFleetTime(v.RecordedAt) }
+
+func (v DecisionReplayView) ResultVersionDisplay() string {
+	if v.ResultVersion == 0 {
+		return fleetEmptyDash
+	}
+	return fmt.Sprintf("%d", v.ResultVersion)
+}
+
+func (v DecisionReplayView) RecordedLabel() string {
+	if v.RecordedPresent && v.RecordedAccepted {
+		return "recorded (accepted)"
+	}
+	if v.RecordedPresent {
+		return "recorded (not accepted)"
+	}
+	return "no recorded decision"
+}

--- a/enterprise/dashboard/workbench.tmpl.html
+++ b/enterprise/dashboard/workbench.tmpl.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Pipelock Signed Action Workbench</title>
+  <style>
+    :root {
+      --accent:#00e5a0;
+      --bg:#09090b;
+      --bg-elevated:#0e0e11;
+      --border:rgba(255,255,255,0.07);
+      --border-strong:rgba(255,255,255,0.13);
+      --text:#e2e8f0;
+      --text-muted:#94a3b8;
+      --text-dim:#64748b;
+      --warn:#f59e0b;
+      --danger:#ef4444;
+    }
+    * { box-sizing: border-box; }
+    html, body { min-height: 100%; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.45 Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .topbar {
+      min-height: 56px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 14px;
+      padding: 0 24px;
+      border-bottom: 1px solid var(--border-strong);
+      background: #08080a;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+    .brand { font-weight: 650; }
+    .brand span { color: var(--text-muted); font-weight: 500; }
+    .nav { display: flex; align-items: center; gap: 14px; color: var(--text-dim); font-size: 13px; flex-wrap: wrap; }
+    .nav a { color: var(--text-muted); text-decoration: none; }
+    .nav a:hover { color: var(--text); }
+    main { min-width: 0; padding: 24px; }
+    .panel { max-width: 1100px; margin: 0 auto; }
+    h1, h2 { margin: 0; letter-spacing: 0; }
+    h1 { font-size: 24px; }
+    h2 { font-size: 16px; margin: 24px 0 12px; }
+    .muted { color: var(--text-muted); }
+    .dim { color: var(--text-dim); }
+    .mono { font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .banner {
+      border: 1px solid rgba(0,229,160,0.4);
+      background: rgba(0,229,160,0.06);
+      padding: 14px;
+      border-radius: 8px;
+      margin: 14px 0 8px;
+      color: #b9f6dc;
+    }
+    .callout {
+      border: 1px solid var(--border-strong);
+      background: #0b0f0e;
+      padding: 14px;
+      border-radius: 8px;
+      margin: 14px 0;
+    }
+    .step {
+      border: 1px solid var(--border);
+      background: var(--bg-elevated);
+      border-radius: 8px;
+      padding: 14px;
+      margin-bottom: 12px;
+    }
+    .step h3 { margin: 0 0 4px; font-size: 14px; }
+    pre {
+      overflow-x: auto;
+      background: #08080a;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 10px 12px;
+      margin: 8px 0 0;
+    }
+    code { font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12.5px; }
+    .kv { display: grid; grid-template-columns: 220px 1fr; gap: 6px 16px; margin-top: 8px; }
+    .kv dt { color: var(--text-muted); }
+    .kv dd { margin: 0; overflow-wrap: anywhere; }
+    .chip {
+      display: inline-flex;
+      justify-content: center;
+      min-width: 122px;
+      padding: 4px 9px;
+      border-radius: 999px;
+      color: #050507;
+      font-size: 12px;
+      font-weight: 800;
+      white-space: nowrap;
+    }
+    .chip.verified { background: var(--accent); }
+    .chip.signed-unverified { background: var(--warn); }
+    .chip.unsigned { background: #64748b; color: #f8fafc; }
+    .chip.missing { background: var(--danger); color: white; }
+    .empty {
+      color: var(--text-muted);
+      padding: 20px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg-elevated);
+    }
+    .absence {
+      border: 1px solid rgba(245,158,11,0.7);
+      background: rgba(245,158,11,0.10);
+      padding: 16px;
+      border-radius: 8px;
+    }
+    .absence h2 { color: #fde68a; font-size: 18px; margin-top: 0; }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">Pipelock <span>- Operator Console / Workbench</span></div>
+    <div class="nav"><a href="/">Evidence</a><a href="/fleet">Fleet</a><a href="/incident">Incident</a><a href="/exemptions">Exemptions</a><span class="mono">read-only</span></div>
+  </header>
+  <main>
+    <div class="panel">
+      <h1>Signed Action Workbench</h1>
+      <div class="banner">{{.NeverAuthority}}</div>
+
+      <h2>Prepare and submit (outside the dashboard)</h2>
+      <div class="callout muted">These are the shipped conductor commands you run yourself. The dashboard shows them; it does not run them and has no button that submits an action.</div>
+      {{range .PrepareSteps}}
+        <div class="step">
+          <h3>{{.Title}}</h3>
+          <div class="muted">{{.Description}}</div>
+          <pre><code>{{.Command}}</code></pre>
+        </div>
+      {{end}}
+
+      <h2>Verify / replay a past decision</h2>
+      <div class="callout muted">{{.ReplayClaim}} It {{.ReplayNonClaim}}.</div>
+      {{if not .RawAllowed}}
+        <div class="callout muted">Metadata view: artifact and result hashes and versions are hidden. Raw access is required to view those fields; computed validity and divergence are always shown.</div>
+      {{end}}
+
+      {{if not .SourceConfigured}}
+        <section class="absence">
+          <h2>No conductor decision source configured</h2>
+          <p class="muted">Replay requires the dashboard to be wired to a conductor read source. The prepare guidance above and the other dashboard views do not depend on that source.</p>
+        </section>
+      {{else if not .ScopeProvided}}
+        <section class="empty">Supply <span class="mono">?org_id=&lt;org&gt;&amp;fleet_id=&lt;fleet&gt;&amp;artifact_hash=&lt;hash&gt;</span> to replay a past signed action's decision.</section>
+      {{else if .ReplayNotFound}}
+        <section class="empty">No recorded decision matched artifact hash for org <span class="mono">{{.OrgID}}</span> / fleet <span class="mono">{{.FleetID}}</span>.</section>
+      {{else if .HasReplay}}
+        {{with .Replay}}
+        <section class="step">
+          <div>
+            <span class="chip {{.VerdictClass}}">{{.VerdictLabel}}</span>
+            <span class="chip {{.DivergenceClass}}">{{.DivergenceLabel}}</span>
+          </div>
+          <dl class="kv">
+            <dt>Action kind</dt><dd>{{.KindLabel}}</dd>
+            <dt>Recorded</dt><dd>{{.RecordedLabel}}</dd>
+            <dt>Used state snapshot</dt><dd>{{.UsedStateSnapshot}}</dd>
+            <dt>Replayed at</dt><dd>{{.ReplayedAtDisplay}}</dd>
+            <dt>Conflict code</dt><dd>{{.ConflictDisplay}}</dd>
+            <dt>Divergence reason</dt><dd>{{.DivergenceReasonDisplay}}</dd>
+            <dt>Result version</dt><dd class="mono">{{.ResultVersionDisplay}}</dd>
+            <dt>Artifact hash</dt><dd class="mono">{{.ArtifactHashDisplay}}</dd>
+            <dt>Result hash</dt><dd class="mono">{{.ResultHashDisplay}}</dd>
+            <dt>Recorded hash</dt><dd class="mono">{{.RecordedHashDisplay}}</dd>
+            <dt>Recorded at</dt><dd>{{.RecordedAtDisplay}}</dd>
+          </dl>
+        </section>
+        {{end}}
+      {{end}}
+    </div>
+  </main>
+</body>
+</html>

--- a/enterprise/dashboard/workbench_test.go
+++ b/enterprise/dashboard/workbench_test.go
@@ -124,11 +124,12 @@ func TestWorkbench_NoStateMutatingRoute(t *testing.T) {
 
 	source := &fakeConductorSource{view: testReplayView(), found: true}
 	handler := New(Options{
-		ReceiptDir:      t.TempDir(),
-		HasFeature:      allowFleetFeature,
-		ConductorSource: source,
-		FleetSource:     &fakeFleetSource{},
-		AuthorizeRaw:    allowRawAccess,
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		ConductorSource:     source,
+		FleetSource:         &fakeFleetSource{},
+		AuthorizeRaw:        allowRawAccess,
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	paths := []string{"/workbench", wbReplayTarget(), "/incident", "/incident?org_id=" + wbTestOrgID + "&fleet_id=" + wbTestFleetID + "&artifact_hash=" + wbTestArtifactHash}
 	mutating := []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
@@ -144,6 +145,79 @@ func TestWorkbench_NoStateMutatingRoute(t *testing.T) {
 	}
 	if got := source.calls.Load(); got != 0 {
 		t.Fatalf("read-only source was invoked %d times by mutating requests; a mutating method reached the model", got)
+	}
+}
+
+func TestWorkbench_FailClosedScopeAuthorization(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		authorize func(*http.Request, DecisionScope, bool) error
+	}{
+		{name: "missing_authorizer", authorize: nil},
+		{name: "denied_authorizer", authorize: func(*http.Request, DecisionScope, bool) error {
+			return errors.New("wrong fleet")
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := &fakeConductorSource{view: testReplayView(), found: true}
+			handler := New(Options{
+				ReceiptDir:          t.TempDir(),
+				HasFeature:          allowFleetFeature,
+				ConductorSource:     source,
+				AuthorizeFleetScope: tt.authorize,
+			})
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+			}
+			if got := source.calls.Load(); got != 0 {
+				t.Fatalf("source calls = %d, want 0 before scope authorization", got)
+			}
+		})
+	}
+}
+
+func TestWorkbench_ScopeAuditRedactsIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	var audit strings.Builder
+	source := &fakeConductorSource{view: testReplayView(), found: true}
+	handler := New(Options{
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		ConductorSource:     source,
+		AuthorizeFleetScope: allowFleetScope,
+		AuditWriter:         &audit,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	log := audit.String()
+	for _, secret := range []string{wbTestOrgID, wbTestFleetID, wbTestArtifactHash, wbSensitiveReason} {
+		if strings.Contains(log, secret) {
+			t.Fatalf("scope audit leaked %q: %s", secret, log)
+		}
+	}
+	for _, want := range []string{
+		"pipelock-dashboard scope",
+		"org_sha256=",
+		"fleet_sha256=",
+		"artifact_sha256=",
+		"decision_source=true",
+		"decision_found=true",
+		"divergence=true",
+		`conflict="-"`,
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("scope audit missing %q: %s", want, log)
+		}
 	}
 }
 
@@ -218,10 +292,11 @@ func TestWorkbench_ReplayRawView(t *testing.T) {
 
 	source := &fakeConductorSource{view: testReplayView(), found: true}
 	handler := New(Options{
-		ReceiptDir:      t.TempDir(),
-		HasFeature:      allowFleetFeature,
-		ConductorSource: source,
-		AuthorizeRaw:    allowRawAccess,
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		ConductorSource:     source,
+		AuthorizeRaw:        allowRawAccess,
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
@@ -251,6 +326,7 @@ func TestWorkbench_ReplayMetadataViewRedacts(t *testing.T) {
 		HasFeature:      allowFleetFeature,
 		ConductorSource: source,
 		// No AuthorizeRaw: metadata view must fail closed.
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
@@ -280,10 +356,11 @@ func TestWorkbench_ReplayRawEscapesHostileStrings(t *testing.T) {
 	view.DivergenceReason = hostileScript
 	source := &fakeConductorSource{view: view, found: true}
 	handler := New(Options{
-		ReceiptDir:      t.TempDir(),
-		HasFeature:      allowFleetFeature,
-		ConductorSource: source,
-		AuthorizeRaw:    allowRawAccess,
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          allowFleetFeature,
+		ConductorSource:     source,
+		AuthorizeRaw:        allowRawAccess,
+		AuthorizeFleetScope: allowFleetScope,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
@@ -305,7 +382,7 @@ func TestWorkbench_ReplayNotFound(t *testing.T) {
 	t.Parallel()
 
 	source := &fakeConductorSource{found: false}
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source})
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
 	if rec.Code != http.StatusOK {
@@ -320,7 +397,7 @@ func TestWorkbench_ReplayNotFoundMetadataRedactsScope(t *testing.T) {
 	t.Parallel()
 
 	source := &fakeConductorSource{found: false}
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source})
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
 	if rec.Code != http.StatusOK {
@@ -341,7 +418,7 @@ func TestWorkbench_SourceErrorReturnsServerError(t *testing.T) {
 	t.Parallel()
 
 	source := &fakeConductorSource{err: errors.New("source unavailable")}
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source})
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
 	if rec.Code != http.StatusInternalServerError {
@@ -352,7 +429,7 @@ func TestWorkbench_SourceErrorReturnsServerError(t *testing.T) {
 func TestWorkbench_RejectsInvalidScope(t *testing.T) {
 	t.Parallel()
 
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: &fakeConductorSource{}})
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: &fakeConductorSource{}, AuthorizeFleetScope: allowFleetScope})
 	for _, target := range []string{
 		"/workbench?artifact_hash=" + wbTestArtifactHash,                            // hash without org/fleet
 		"/workbench?org_id=" + wbTestOrgID + "&artifact_hash=" + wbTestArtifactHash, // missing fleet

--- a/enterprise/dashboard/workbench_test.go
+++ b/enterprise/dashboard/workbench_test.go
@@ -1,0 +1,421 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+const (
+	wbTestOrgID        = "org-test"
+	wbTestFleetID      = "fleet-test"
+	wbTestArtifactHash = "sha256:abc123"
+	wbSensitiveHash    = "sha256:sensitive-artifact"
+	wbSensitiveResult  = "sha256:sensitive-result"
+	wbSensitiveReason  = "reason-sensitive-detail"
+)
+
+// fakeConductorSource is a read-only ConductorDecisionSource. It records the
+// arguments it saw and how many times it was called so tests can assert that
+// mutating HTTP methods never reach it (the never-authority invariant).
+type fakeConductorSource struct {
+	view    DecisionReplayView
+	found   bool
+	err     error
+	calls   atomic.Int64
+	gotHash string
+}
+
+func (f *fakeConductorSource) ReplayDecision(_ context.Context, scope DecisionScope) (DecisionReplayView, bool, error) {
+	f.calls.Add(1)
+	f.gotHash = scope.ArtifactHash
+	if f.err != nil {
+		return DecisionReplayView{}, false, f.err
+	}
+	return f.view, f.found, nil
+}
+
+func testReplayView() DecisionReplayView {
+	return DecisionReplayView{
+		ActionKind:        actionKindRollback,
+		ArtifactHash:      wbSensitiveHash,
+		ResultVersion:     42,
+		ResultHash:        wbSensitiveResult,
+		UsedStateSnapshot: false,
+		ReplayedAt:        time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC),
+		Valid:             true,
+		Conflict:          "",
+		Divergence:        true,
+		DivergenceReason:  wbSensitiveReason,
+		RecordedPresent:   true,
+		RecordedAccepted:  true,
+		RecordedHash:      wbSensitiveResult,
+		RecordedAt:        time.Date(2026, 7, 9, 11, 0, 0, 0, time.UTC),
+	}
+}
+
+func wbReplayTarget() string {
+	return "/workbench?org_id=" + wbTestOrgID + "&fleet_id=" + wbTestFleetID + "&artifact_hash=" + wbTestArtifactHash
+}
+
+func TestWorkbench_Gating(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		hasFeature func(string) bool
+		wantStatus int
+	}{
+		{name: "nil_feature", hasFeature: nil, wantStatus: http.StatusForbidden},
+		{
+			name:       "agents_only_wrong_tier",
+			hasFeature: func(f string) bool { return f == license.FeatureAgents },
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "fleet_only_allowed",
+			hasFeature: func(f string) bool { return f == license.FeatureFleet },
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "enterprise_allowed",
+			hasFeature: func(f string) bool { return f == license.FeatureAgents || f == license.FeatureFleet },
+			wantStatus: http.StatusOK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: tt.hasFeature})
+			for _, path := range []string{"/workbench", "/incident"} {
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
+				if rec.Code != tt.wantStatus {
+					t.Fatalf("%s status = %d, want %d; body=%s", path, rec.Code, tt.wantStatus, rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// TestWorkbench_NoStateMutatingRoute proves the never-authority invariant: the
+// workbench and incident page-set expose no state-mutating route. Every
+// non-GET method on every route returns 405 BEFORE any model/source call, so no
+// write path is reachable, and the only conductor seam wired is read-only.
+//
+// A reviewer neutralizes this by adding a mutating handler: e.g. register a
+// POST route in New(), or delete the requireGet guard in handleWorkbench /
+// handleIncident. The test then fails because a mutating method returns 200
+// instead of 405 (or the fake source's mutating-call counter fires).
+func TestWorkbench_NoStateMutatingRoute(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeConductorSource{view: testReplayView(), found: true}
+	handler := New(Options{
+		ReceiptDir:      t.TempDir(),
+		HasFeature:      allowFleetFeature,
+		ConductorSource: source,
+		FleetSource:     &fakeFleetSource{},
+		AuthorizeRaw:    allowRawAccess,
+	})
+	paths := []string{"/workbench", wbReplayTarget(), "/incident", "/incident?org_id=" + wbTestOrgID + "&fleet_id=" + wbTestFleetID + "&artifact_hash=" + wbTestArtifactHash}
+	mutating := []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
+	for _, path := range paths {
+		for _, method := range mutating {
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), method, path, strings.NewReader("body=payload")))
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("%s %s status = %d, want %d (no mutating route may exist); body=%s",
+					method, path, rec.Code, http.StatusMethodNotAllowed, rec.Body.String())
+			}
+		}
+	}
+	if got := source.calls.Load(); got != 0 {
+		t.Fatalf("read-only source was invoked %d times by mutating requests; a mutating method reached the model", got)
+	}
+}
+
+// TestWorkbench_FailClosedLicense is the gating proof: with NO fleet license the
+// workbench/incident routes refuse (403) AND the free agent-tier detection pages
+// still render; with the fleet license they render (200).
+//
+// Neutralize by changing d.fleetGate to d.gate (FeatureAgents) on the workbench
+// route in New(): the agents-only case then renders 200 instead of 403.
+func TestWorkbench_FailClosedLicense(t *testing.T) {
+	t.Parallel()
+
+	noFleet := New(Options{
+		ReceiptDir: t.TempDir(),
+		HasFeature: func(f string) bool { return f == license.FeatureAgents },
+	})
+	for _, path := range []string{"/workbench", "/incident"} {
+		rec := httptest.NewRecorder()
+		noFleet.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("no-fleet-license %s = %d, want 403; body=%s", path, rec.Code, rec.Body.String())
+		}
+	}
+	// The free agent-tier detection page is unaffected by the fleet gate.
+	rec := httptest.NewRecorder()
+	noFleet.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/agents", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("agents-tier /agents with agents license = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	withFleet := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature})
+	for _, path := range []string{"/workbench", "/incident"} {
+		rec := httptest.NewRecorder()
+		withFleet.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("fleet-license %s = %d, want 200; body=%s", path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestWorkbench_PrepareGuidanceAndNeverAuthority(t *testing.T) {
+	t.Parallel()
+
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/workbench", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		workbenchNeverAuthority,
+		"pipelock conductor publish",
+		"pipelock conductor kill",
+		"pipelock conductor rollback",
+		"No conductor decision source configured",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("workbench body missing %q: %s", want, body)
+		}
+	}
+	// Bounded claims: no aggregate "all clear" / green language.
+	for _, banned := range []string{"all clear", "everything verified", "fully compliant", "all green"} {
+		if strings.Contains(strings.ToLower(body), banned) {
+			t.Fatalf("workbench leaked aggregate-green wording %q", banned)
+		}
+	}
+}
+
+func TestWorkbench_ReplayRawView(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeConductorSource{view: testReplayView(), found: true}
+	handler := New(Options{
+		ReceiptDir:      t.TempDir(),
+		HasFeature:      allowFleetFeature,
+		ConductorSource: source,
+		AuthorizeRaw:    allowRawAccess,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if source.gotHash != wbTestArtifactHash {
+		t.Fatalf("source got hash %q, want %q", source.gotHash, wbTestArtifactHash)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Rollback", "Divergence", wbSensitiveHash, wbSensitiveResult, wbSensitiveReason, "42"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("raw replay body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestWorkbench_ReplayMetadataViewRedacts(t *testing.T) {
+	t.Parallel()
+
+	view := testReplayView()
+	view.Valid = false
+	view.Conflict = "source error for " + wbSensitiveHash
+	source := &fakeConductorSource{view: view, found: true}
+	handler := New(Options{
+		ReceiptDir:      t.TempDir(),
+		HasFeature:      allowFleetFeature,
+		ConductorSource: source,
+		// No AuthorizeRaw: metadata view must fail closed.
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, secret := range []string{wbSensitiveHash, wbSensitiveResult, wbSensitiveReason, "source error", ">42<"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("metadata view leaked %q: %s", secret, body)
+		}
+	}
+	// Computed status is kept even in the redacted view.
+	for _, want := range []string{"Rollback", "Divergence", "Would be rejected: unknown", fleetRedacted} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metadata replay body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestWorkbench_ReplayRawEscapesHostileStrings(t *testing.T) {
+	t.Parallel()
+
+	view := testReplayView()
+	view.ArtifactHash = hostileScript
+	view.ResultHash = hostileImage
+	view.DivergenceReason = hostileScript
+	source := &fakeConductorSource{view: view, found: true}
+	handler := New(Options{
+		ReceiptDir:      t.TempDir(),
+		HasFeature:      allowFleetFeature,
+		ConductorSource: source,
+		AuthorizeRaw:    allowRawAccess,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, raw := range []string{hostileScript, hostileImage} {
+		if strings.Contains(body, raw) {
+			t.Fatalf("raw view rendered unescaped hostile value %q: %s", raw, body)
+		}
+	}
+	if !strings.Contains(body, "&lt;script&gt;alert(1)&lt;/script&gt;") {
+		t.Fatalf("body missing escaped hostile value: %s", body)
+	}
+}
+
+func TestWorkbench_ReplayNotFound(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeConductorSource{found: false}
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "No recorded decision matched") {
+		t.Fatalf("body missing not-found state: %s", rec.Body.String())
+	}
+}
+
+func TestWorkbench_ReplayNotFoundMetadataRedactsScope(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeConductorSource{found: false}
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, secret := range []string{wbTestOrgID, wbTestFleetID} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("metadata not-found view leaked scope %q: %s", secret, body)
+		}
+	}
+	if !strings.Contains(body, "org <span class=\"mono\">"+fleetRedacted+"</span> / fleet <span class=\"mono\">"+fleetRedacted+"</span>") {
+		t.Fatalf("metadata not-found view missing redacted scope: %s", body)
+	}
+}
+
+func TestWorkbench_SourceErrorReturnsServerError(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeConductorSource{err: errors.New("source unavailable")}
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestWorkbench_RejectsInvalidScope(t *testing.T) {
+	t.Parallel()
+
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: &fakeConductorSource{}})
+	for _, target := range []string{
+		"/workbench?artifact_hash=" + wbTestArtifactHash,                            // hash without org/fleet
+		"/workbench?org_id=" + wbTestOrgID + "&artifact_hash=" + wbTestArtifactHash, // missing fleet
+		"/workbench?org_id=../prod&fleet_id=" + wbTestFleetID + "&artifact_hash=" + wbTestArtifactHash,
+		"/workbench?org_id=" + wbTestOrgID + "&fleet_id=" + wbTestFleetID + "&artifact_hash=bad%0Ahash",
+		"/workbench?org_id=" + wbTestOrgID, // scope without hash
+	} {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, target, nil))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestWorkbench_RejectsNonExactPath(t *testing.T) {
+	t.Parallel()
+
+	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature})
+	for _, path := range []string{"/workbench/extra", "/incident/extra"} {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("%s status = %d, want 404; body=%s", path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestWorkbench_ReplayViewHelperBranches(t *testing.T) {
+	t.Parallel()
+
+	unknown := normalizeReplayView(DecisionReplayView{ActionKind: "wat"})
+	if unknown.ActionKind != actionKindUnknown {
+		t.Fatalf("ActionKind = %q, want unknown", unknown.ActionKind)
+	}
+	if got := unknown.KindLabel(); got != "Unknown action" {
+		t.Fatalf("KindLabel = %q", got)
+	}
+	rejected := DecisionReplayView{Valid: false, Conflict: "stale_counter"}
+	if got := rejected.VerdictLabel(); got != "Would be rejected: stale_counter" {
+		t.Fatalf("VerdictLabel = %q", got)
+	}
+	if got := (DecisionReplayView{}).VerdictLabel(); got != "Would be rejected" {
+		t.Fatalf("VerdictLabel empty = %q", got)
+	}
+	if got := (DecisionReplayView{}).RecordedLabel(); got != "no recorded decision" {
+		t.Fatalf("RecordedLabel = %q", got)
+	}
+	present := DecisionReplayView{RecordedPresent: true}
+	if got := present.RecordedLabel(); got != "recorded (not accepted)" {
+		t.Fatalf("RecordedLabel present = %q", got)
+	}
+	if got := (DecisionReplayView{}).ResultVersionDisplay(); got != fleetEmptyDash {
+		t.Fatalf("ResultVersionDisplay(0) = %q", got)
+	}
+	if got := (DecisionReplayView{ResultVersion: 3}).ResultVersionDisplay(); got != "3" {
+		t.Fatalf("ResultVersionDisplay(3) = %q", got)
+	}
+	if got := (DecisionReplayView{Divergence: false}).DivergenceClass(); got != "verified" {
+		t.Fatalf("DivergenceClass = %q", got)
+	}
+}


### PR DESCRIPTION
## What changed

Add two read-only Enterprise fleet-tier dashboard pages: a Signed Action Workbench and an Incident Cockpit. The workbench lets an operator prepare a signed conductor action, verify it through the dry-run path (full authorize, verify, and preflight with zero writes), and replay a past decision (re-derive it and surface a divergence flag). The cockpit correlates a decision with its receipts and fleet applied-state as a read-only lens.

Both pages are prepare, verify, and replay only. They never hold authority: the routes are GET-only, reach no write path, and consume the conductor dry-run and decision-replay backend read-only. Submitting an action with effect stays outside the dashboard, through the authenticated control-plane path. A test asserts no state-mutating route exists.

Both routes are gated on the fleet license and fail closed (a missing or wrong-tier license returns 403), share the existing CSP, operator-token auth, and access-audit seams, and apply the same raw-vs-metadata RBAC redaction as the other pages.

This also closes a metadata-view scope leak in the existing Fleet Overview page: the page-level and per-follower org and fleet labels were rendered raw in metadata mode. They are now redacted for a metadata-only viewer while the real scope is still used for the underlying source query.

## Verification

Every guard is proven by neutralization: disabling the method check fails the no-mutating-route test; disabling the license check fails the gating and fail-closed tests; disabling the scope redaction fails the metadata-view tests. Build and lint clean on both the default and enterprise tags; enterprise race tests and patch coverage green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Enterprise-only **Workbench** and **Incident Cockpit** pages (`/workbench`, `/incident`) for GET-only preparation and replay verification, including **divergence** indicators and bounded fleet applied-state summaries.
* **Documentation**
  * Documented route behavior, access requirements, and how metadata vs raw views affect what’s shown.
* **Bug Fixes**
  * Improved fleet overview scoping and metadata redaction to prevent sensitive follower details from leaking.
* **Tests**
  * Added coverage for gating, fail-closed authorization, redaction, replay/not-found/error rendering, and correlation correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->