### PR TITLE
fix(receipt): bind receipt policy_hash to the request config snapshot

### DIFF
--- a/internal/cli/runtime/dlp_warn_emit.go
+++ b/internal/cli/runtime/dlp_warn_emit.go
@@ -50,14 +50,15 @@ func dlpWarnReceiptOpts(
 	patternName, severity, transport string,
 ) receipt.EmitOpts {
 	opts := receipt.EmitOpts{
-		ActionID:  receipt.NewActionID(),
-		Verdict:   config.ActionWarn,
-		Layer:     scanner.ScannerDLP,
-		Pattern:   patternName,
-		Severity:  severity,
-		Transport: transport,
-		RequestID: wc.RequestID,
-		Agent:     wc.Agent,
+		ActionID:   receipt.NewActionID(),
+		Verdict:    config.ActionWarn,
+		Layer:      scanner.ScannerDLP,
+		Pattern:    patternName,
+		Severity:   severity,
+		Transport:  transport,
+		RequestID:  wc.RequestID,
+		Agent:      wc.Agent,
+		PolicyHash: wc.PolicyHash,
 	}
 
 	switch {

--- a/internal/cli/runtime/dlp_warn_emit_test.go
+++ b/internal/cli/runtime/dlp_warn_emit_test.go
@@ -24,6 +24,7 @@ const (
 	mcpInitializeResource = "initialize"
 	mcpToolsListResource  = "tools/list"
 	mcpToolsCallResource  = "tools/call"
+	runtimeTestPolicyHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 )
 
 func TestEmitDLPWarnWritesReceiptAndMetric(t *testing.T) {
@@ -65,7 +66,7 @@ func TestEmitDLPWarnWritesReceiptAndMetric(t *testing.T) {
 		RequestID:  "req-warn-1",
 		Agent:      "agent-1",
 		Transport:  "fetch",
-		PolicyHash: "snapshot-policy-hash",
+		PolicyHash: runtimeTestPolicyHash,
 	})
 
 	emitDLPWarn(audit.NewNop(), m, emitter, ctx, "warn-url", "high")
@@ -101,8 +102,8 @@ func TestEmitDLPWarnWritesReceiptAndMetric(t *testing.T) {
 	if rcpt.ActionRecord.Target != "https://example.com/api" {
 		t.Fatalf("receipt target = %q, want https://example.com/api", rcpt.ActionRecord.Target)
 	}
-	if rcpt.ActionRecord.PolicyHash != "snapshot-policy-hash" {
-		t.Fatalf("receipt policy_hash = %q, want snapshot-policy-hash", rcpt.ActionRecord.PolicyHash)
+	if rcpt.ActionRecord.PolicyHash != runtimeTestPolicyHash {
+		t.Fatalf("receipt policy_hash = %q, want %q", rcpt.ActionRecord.PolicyHash, runtimeTestPolicyHash)
 	}
 
 	recorderBody := httptest.NewRecorder()

--- a/internal/cli/runtime/dlp_warn_emit_test.go
+++ b/internal/cli/runtime/dlp_warn_emit_test.go
@@ -59,12 +59,13 @@ func TestEmitDLPWarnWritesReceiptAndMetric(t *testing.T) {
 
 	m := metrics.New()
 	ctx := scanner.WithDLPWarnContext(context.Background(), scanner.DLPWarnContext{
-		Method:    http.MethodGet,
-		URL:       "https://example.com/api",
-		ClientIP:  "10.0.0.1",
-		RequestID: "req-warn-1",
-		Agent:     "agent-1",
-		Transport: "fetch",
+		Method:     http.MethodGet,
+		URL:        "https://example.com/api",
+		ClientIP:   "10.0.0.1",
+		RequestID:  "req-warn-1",
+		Agent:      "agent-1",
+		Transport:  "fetch",
+		PolicyHash: "snapshot-policy-hash",
 	})
 
 	emitDLPWarn(audit.NewNop(), m, emitter, ctx, "warn-url", "high")
@@ -99,6 +100,9 @@ func TestEmitDLPWarnWritesReceiptAndMetric(t *testing.T) {
 	}
 	if rcpt.ActionRecord.Target != "https://example.com/api" {
 		t.Fatalf("receipt target = %q, want https://example.com/api", rcpt.ActionRecord.Target)
+	}
+	if rcpt.ActionRecord.PolicyHash != "snapshot-policy-hash" {
+		t.Fatalf("receipt policy_hash = %q, want snapshot-policy-hash", rcpt.ActionRecord.PolicyHash)
 	}
 
 	recorderBody := httptest.NewRecorder()

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -249,6 +249,13 @@ func TestRecoverDeferredActionsBlocksPendingJournal(t *testing.T) {
 	if log.String() != "" {
 		t.Fatalf("recovery log = %q, want empty", log.String())
 	}
+	records := readRuntimeActionRecords(t, filepath.Join(dir, "receipts"))
+	if len(records) != 1 {
+		t.Fatalf("recovery receipt count = %d, want 1", len(records))
+	}
+	if records[0].PolicyHash != runtimeTestPolicyHash {
+		t.Fatalf("recovery policy_hash = %q, want %q", records[0].PolicyHash, runtimeTestPolicyHash)
+	}
 }
 
 func TestRecoverDeferredActionsRunsWithoutLiveManager(t *testing.T) {
@@ -325,6 +332,9 @@ func TestRecoverDeferredActionsRunsWithoutLiveManager(t *testing.T) {
 	for _, record := range records {
 		if record.ResolutionSource != deferred.SourceRestartRecovery {
 			t.Fatalf("resolution_source = %q, want restart_recovery", record.ResolutionSource)
+		}
+		if record.PolicyHash != runtimeTestPolicyHash {
+			t.Fatalf("recovery policy_hash = %q, want %q", record.PolicyHash, runtimeTestPolicyHash)
 		}
 	}
 	var childPolicy deferred.ReceiptPolicy

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -236,7 +236,7 @@ func TestRecoverDeferredActionsBlocksPendingJournal(t *testing.T) {
 	}
 
 	var log bytes.Buffer
-	if err := recoverDeferredActions(manager, manager.JournalPath(), emitter, nil, "policy-hash", &log); err != nil {
+	if err := recoverDeferredActions(manager, manager.JournalPath(), emitter, nil, runtimeTestPolicyHash, &log); err != nil {
 		t.Fatalf("recoverDeferredActions: %v", err)
 	}
 	pending, err = deferred.PendingJournal(manager.JournalPath())
@@ -302,7 +302,7 @@ func TestRecoverDeferredActionsRunsWithoutLiveManager(t *testing.T) {
 	}
 
 	var log bytes.Buffer
-	if err := recoverDeferredActions(nil, manager.JournalPath(), emitter, nil, "policy-hash", &log); err != nil {
+	if err := recoverDeferredActions(nil, manager.JournalPath(), emitter, nil, runtimeTestPolicyHash, &log); err != nil {
 		t.Fatalf("recoverDeferredActions without manager: %v", err)
 	}
 	if err := rec.Close(); err != nil {

--- a/internal/mcp/a2a_receipt_parity_test.go
+++ b/internal/mcp/a2a_receipt_parity_test.go
@@ -41,10 +41,6 @@ const (
 	// across literals so gitleaks/gosec G101 do not flag it. It trips the DLP
 	// scanner the same way a real leaked token would.
 	fakeGHTokenA2A = "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
-	// a2aEmitterConfigHash is the configHash the test emitter stamps onto every
-	// v1 receipt. In production this is cfg.CanonicalPolicyHash(); pinning it
-	// lets the tests assert the receipt is bound to a non-empty policy hash.
-	a2aEmitterConfigHash = "test-config-hash"
 )
 
 // a2aBlockReceipts returns the v1 action receipts in dir whose verdict is block.
@@ -157,8 +153,8 @@ func TestA2AHeaderBlock_EmitsReceiptWithPolicyHash(t *testing.T) {
 		t.Fatalf("receipt verify: %v", err)
 	}
 	ar := r.ActionRecord
-	if ar.PolicyHash != a2aEmitterConfigHash {
-		t.Errorf("PolicyHash = %q, want non-empty %q", ar.PolicyHash, a2aEmitterConfigHash)
+	if ar.PolicyHash != mcpTestPolicyHash {
+		t.Errorf("PolicyHash = %q, want non-empty %q", ar.PolicyHash, mcpTestPolicyHash)
 	}
 	if ar.Transport != a2aReceiptListenerTrans {
 		t.Errorf("Transport = %q, want %q", ar.Transport, a2aReceiptListenerTrans)
@@ -216,8 +212,8 @@ func TestA2ABodyBlock_A2AGate_DualEmitsWithPolicyHash(t *testing.T) {
 		t.Fatalf("v1 verify: %v", err)
 	}
 	ar := v1s[0].ActionRecord
-	if ar.PolicyHash != a2aEmitterConfigHash {
-		t.Errorf("v1 PolicyHash = %q, want %q", ar.PolicyHash, a2aEmitterConfigHash)
+	if ar.PolicyHash != mcpTestPolicyHash {
+		t.Errorf("v1 PolicyHash = %q, want %q", ar.PolicyHash, mcpTestPolicyHash)
 	}
 	if ar.Layer != mcpReceiptLayerA2A {
 		t.Errorf("v1 Layer = %q, want %q", ar.Layer, mcpReceiptLayerA2A)
@@ -277,8 +273,8 @@ func TestA2ABodyBlock_ContentScan_EmitsReceiptWithPolicyHash(t *testing.T) {
 		t.Fatalf("expected exactly 1 block receipt for A2A content-scan block, got %d", len(blocks))
 	}
 	ar := blocks[0].ActionRecord
-	if ar.PolicyHash != a2aEmitterConfigHash {
-		t.Errorf("PolicyHash = %q, want %q", ar.PolicyHash, a2aEmitterConfigHash)
+	if ar.PolicyHash != mcpTestPolicyHash {
+		t.Errorf("PolicyHash = %q, want %q", ar.PolicyHash, mcpTestPolicyHash)
 	}
 	if ar.Verdict != config.ActionBlock {
 		t.Errorf("Verdict = %q, want %q", ar.Verdict, config.ActionBlock)
@@ -315,8 +311,8 @@ func TestA2ABodyBlock_PreRedaction_EmitsReceipt(t *testing.T) {
 	if len(blocks) != 1 {
 		t.Fatalf("expected exactly 1 block receipt for pre-redaction A2A block, got %d", len(blocks))
 	}
-	if blocks[0].ActionRecord.PolicyHash != a2aEmitterConfigHash {
-		t.Errorf("PolicyHash = %q, want %q", blocks[0].ActionRecord.PolicyHash, a2aEmitterConfigHash)
+	if blocks[0].ActionRecord.PolicyHash != mcpTestPolicyHash {
+		t.Errorf("PolicyHash = %q, want %q", blocks[0].ActionRecord.PolicyHash, mcpTestPolicyHash)
 	}
 }
 

--- a/internal/mcp/a2a_receipt_parity_test.go
+++ b/internal/mcp/a2a_receipt_parity_test.go
@@ -153,8 +153,9 @@ func TestA2AHeaderBlock_EmitsReceiptWithPolicyHash(t *testing.T) {
 		t.Fatalf("receipt verify: %v", err)
 	}
 	ar := r.ActionRecord
-	if ar.PolicyHash != mcpTestPolicyHash {
-		t.Errorf("PolicyHash = %q, want non-empty %q", ar.PolicyHash, mcpTestPolicyHash)
+	wantV1PolicyHash := strings.TrimPrefix(mcpTestPolicyHash, "sha256:")
+	if ar.PolicyHash != wantV1PolicyHash {
+		t.Errorf("PolicyHash = %q, want raw %q", ar.PolicyHash, wantV1PolicyHash)
 	}
 	if ar.Transport != a2aReceiptListenerTrans {
 		t.Errorf("Transport = %q, want %q", ar.Transport, a2aReceiptListenerTrans)
@@ -212,8 +213,9 @@ func TestA2ABodyBlock_A2AGate_DualEmitsWithPolicyHash(t *testing.T) {
 		t.Fatalf("v1 verify: %v", err)
 	}
 	ar := v1s[0].ActionRecord
-	if ar.PolicyHash != mcpTestPolicyHash {
-		t.Errorf("v1 PolicyHash = %q, want %q", ar.PolicyHash, mcpTestPolicyHash)
+	wantV1PolicyHash := strings.TrimPrefix(mcpTestPolicyHash, "sha256:")
+	if ar.PolicyHash != wantV1PolicyHash {
+		t.Errorf("v1 PolicyHash = %q, want raw %q", ar.PolicyHash, wantV1PolicyHash)
 	}
 	if ar.Layer != mcpReceiptLayerA2A {
 		t.Errorf("v1 Layer = %q, want %q", ar.Layer, mcpReceiptLayerA2A)
@@ -273,8 +275,9 @@ func TestA2ABodyBlock_ContentScan_EmitsReceiptWithPolicyHash(t *testing.T) {
 		t.Fatalf("expected exactly 1 block receipt for A2A content-scan block, got %d", len(blocks))
 	}
 	ar := blocks[0].ActionRecord
-	if ar.PolicyHash != mcpTestPolicyHash {
-		t.Errorf("PolicyHash = %q, want %q", ar.PolicyHash, mcpTestPolicyHash)
+	wantV1PolicyHash := strings.TrimPrefix(mcpTestPolicyHash, "sha256:")
+	if ar.PolicyHash != wantV1PolicyHash {
+		t.Errorf("PolicyHash = %q, want raw %q", ar.PolicyHash, wantV1PolicyHash)
 	}
 	if ar.Verdict != config.ActionBlock {
 		t.Errorf("Verdict = %q, want %q", ar.Verdict, config.ActionBlock)
@@ -311,8 +314,9 @@ func TestA2ABodyBlock_PreRedaction_EmitsReceipt(t *testing.T) {
 	if len(blocks) != 1 {
 		t.Fatalf("expected exactly 1 block receipt for pre-redaction A2A block, got %d", len(blocks))
 	}
-	if blocks[0].ActionRecord.PolicyHash != mcpTestPolicyHash {
-		t.Errorf("PolicyHash = %q, want %q", blocks[0].ActionRecord.PolicyHash, mcpTestPolicyHash)
+	wantV1PolicyHash := strings.TrimPrefix(mcpTestPolicyHash, "sha256:")
+	if blocks[0].ActionRecord.PolicyHash != wantV1PolicyHash {
+		t.Errorf("PolicyHash = %q, want raw %q", blocks[0].ActionRecord.PolicyHash, wantV1PolicyHash)
 	}
 }
 

--- a/internal/mcp/defer_resolution_test.go
+++ b/internal/mcp/defer_resolution_test.go
@@ -21,7 +21,7 @@ func TestEmitDeferredResolutionReceiptCarriesCascadePolicy(t *testing.T) {
 
 	opts := MCPProxyOpts{
 		ReceiptEmitter:  emitter,
-		PolicyHash:      "policy-hash",
+		PolicyHash:      mcpTestPolicyHash,
 		RequireReceipts: true,
 		Transport:       deferred.SurfaceMCPStdio,
 	}
@@ -83,7 +83,7 @@ func TestEmitDeferredResolutionReceiptNonCascadeCarriesBounds(t *testing.T) {
 
 	opts := MCPProxyOpts{
 		ReceiptEmitter:  emitter,
-		PolicyHash:      "policy-hash",
+		PolicyHash:      mcpTestPolicyHash,
 		RequireReceipts: true,
 		Transport:       deferred.SurfaceMCPStdio,
 	}
@@ -142,7 +142,7 @@ func TestEmitDeferredResolutionReceiptBlockFailureLogsAuditGap(t *testing.T) {
 
 	opts := MCPProxyOpts{
 		ReceiptEmitter:  emitter,
-		PolicyHash:      "policy-hash",
+		PolicyHash:      mcpTestPolicyHash,
 		RequireReceipts: true,
 		Transport:       deferred.SurfaceMCPStdio,
 	}

--- a/internal/mcp/defer_resolution_test.go
+++ b/internal/mcp/defer_resolution_test.go
@@ -18,6 +18,7 @@ import (
 func TestEmitDeferredResolutionReceiptCarriesCascadePolicy(t *testing.T) {
 	emitter, rec, dir := newTestReceiptEmitter(t)
 	t.Cleanup(func() { _ = rec.Close() })
+	wantPolicyHash := strings.TrimPrefix(mcpTestPolicyHash, "sha256:")
 
 	opts := MCPProxyOpts{
 		ReceiptEmitter:  emitter,
@@ -75,11 +76,15 @@ func TestEmitDeferredResolutionReceiptCarriesCascadePolicy(t *testing.T) {
 		policy.Bounds.MaxCascadeDepth != 8 {
 		t.Fatalf("resolution_policy = %+v", policy)
 	}
+	if recorded.PolicyHash != wantPolicyHash {
+		t.Fatalf("policy_hash = %q, want %q", recorded.PolicyHash, wantPolicyHash)
+	}
 }
 
 func TestEmitDeferredResolutionReceiptNonCascadeCarriesBounds(t *testing.T) {
 	emitter, rec, dir := newTestReceiptEmitter(t)
 	t.Cleanup(func() { _ = rec.Close() })
+	wantPolicyHash := strings.TrimPrefix(mcpTestPolicyHash, "sha256:")
 
 	opts := MCPProxyOpts{
 		ReceiptEmitter:  emitter,
@@ -131,6 +136,9 @@ func TestEmitDeferredResolutionReceiptNonCascadeCarriesBounds(t *testing.T) {
 	}
 	if policy.Bounds.MaxCascadeDepth != 8 || policy.Bounds.MaxPending != 64 {
 		t.Fatalf("resolution_policy bounds = %+v", policy.Bounds)
+	}
+	if recorded.PolicyHash != wantPolicyHash {
+		t.Fatalf("policy_hash = %q, want %q", recorded.PolicyHash, wantPolicyHash)
 	}
 }
 

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -309,6 +309,9 @@ func ForwardScannedInput(
 		rpcID := frame.ID
 		warnCtx := scanner.DLPWarnContextFromCtx(opts.warnContext())
 		warnCtx.Transport = transportMCPStdio
+		if warnCtx.PolicyHash == "" {
+			warnCtx.PolicyHash = policyHash
+		}
 		stdioInputCtx := scanner.WithDLPWarnContext(opts.warnContext(), warnCtx)
 		if redactionCfg.Matcher != nil {
 			originalVerdict := scanRequestForAgent(stdioInputCtx, line, sc, action, onParseError, opts.addressProtectionAgent())
@@ -1025,6 +1028,9 @@ func ForwardScannedInput(
 				stdioWarnCtxMeta.Transport = transportMCPStdio
 				stdioWarnCtxMeta.Method = mcpWarnMethod
 				stdioWarnCtxMeta.Resource = mcpWarnResource(verdict.Method, line)
+				if stdioWarnCtxMeta.PolicyHash == "" {
+					stdioWarnCtxMeta.PolicyHash = policyHash
+				}
 				stdioWarnCtx := scanner.WithDLPWarnContext(stdioInputCtx, stdioWarnCtxMeta)
 				dlpResult := sc.ScanTextForDLP(stdioWarnCtx, string(result.Response))
 				// Capture: record redirect output scan verdict.

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -309,7 +309,7 @@ func ForwardScannedInput(
 		rpcID := frame.ID
 		warnCtx := scanner.DLPWarnContextFromCtx(opts.warnContext())
 		warnCtx.Transport = transportMCPStdio
-		if warnCtx.PolicyHash == "" {
+		if policyHash != "" {
 			warnCtx.PolicyHash = policyHash
 		}
 		stdioInputCtx := scanner.WithDLPWarnContext(opts.warnContext(), warnCtx)
@@ -1028,7 +1028,7 @@ func ForwardScannedInput(
 				stdioWarnCtxMeta.Transport = transportMCPStdio
 				stdioWarnCtxMeta.Method = mcpWarnMethod
 				stdioWarnCtxMeta.Resource = mcpWarnResource(verdict.Method, line)
-				if stdioWarnCtxMeta.PolicyHash == "" {
+				if policyHash != "" {
 					stdioWarnCtxMeta.PolicyHash = policyHash
 				}
 				stdioWarnCtx := scanner.WithDLPWarnContext(stdioInputCtx, stdioWarnCtxMeta)

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -2166,9 +2166,11 @@ func TestForwardScannedInput_PolicyRedirectOutputWarnPreservesWarnContext(t *tes
 
 	opts := testOpts(sc)
 	opts.PolicyCfg = policyCfg
+	opts.PolicyHash = mcpTestPolicyHash
 	opts.WarnContext = scanner.WithDLPWarnContext(context.Background(), scanner.DLPWarnContext{
-		RequestID: testWarnContextRequestID,
-		Agent:     testWarnContextAgent,
+		RequestID:  testWarnContextRequestID,
+		Agent:      testWarnContextAgent,
+		PolicyHash: "stale-policy-hash",
 	})
 
 	ForwardScannedInput(
@@ -2202,6 +2204,9 @@ func TestForwardScannedInput_PolicyRedirectOutputWarnPreservesWarnContext(t *tes
 	}
 	if got.Agent != testWarnContextAgent {
 		t.Fatalf("agent = %q, want %q", got.Agent, testWarnContextAgent)
+	}
+	if got.PolicyHash != mcpTestPolicyHash {
+		t.Fatalf("policyHash = %q, want authoritative %q", got.PolicyHash, mcpTestPolicyHash)
 	}
 }
 

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -277,8 +277,8 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	// scans share the same DLPWarnContext.
 	inputScanCtx := opts.warnContext()
 	wc := scanner.DLPWarnContextFromCtx(inputScanCtx)
-	if wc.PolicyHash == "" {
-		wc.PolicyHash = opts.receiptPolicyHash()
+	if policyHash := opts.receiptPolicyHash(); policyHash != "" {
+		wc.PolicyHash = policyHash
 	}
 	if wc.Transport == "" {
 		wc.Transport = transportMCPHTTP
@@ -871,8 +871,8 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			}
 			wc.Method = mcpWarnMethod
 			wc.Resource = mcpWarnResource(verdict.Method, msg)
-			if wc.PolicyHash == "" {
-				wc.PolicyHash = opts.receiptPolicyHash()
+			if policyHash := opts.receiptPolicyHash(); policyHash != "" {
+				wc.PolicyHash = policyHash
 			}
 			httpWarnCtx := scanner.WithDLPWarnContext(inputScanCtx, wc)
 			dlpResult := sc.ScanTextForDLP(httpWarnCtx, string(redirectResult.Response))

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -277,10 +277,13 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	// scans share the same DLPWarnContext.
 	inputScanCtx := opts.warnContext()
 	wc := scanner.DLPWarnContextFromCtx(inputScanCtx)
+	if wc.PolicyHash == "" {
+		wc.PolicyHash = opts.receiptPolicyHash()
+	}
 	if wc.Transport == "" {
 		wc.Transport = transportMCPHTTP
-		inputScanCtx = scanner.WithDLPWarnContext(inputScanCtx, wc)
 	}
+	inputScanCtx = scanner.WithDLPWarnContext(inputScanCtx, wc)
 
 	if pendingToolName := frame.ToolCallName; pendingToolName != "" {
 		toolName = pendingToolName
@@ -868,6 +871,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			}
 			wc.Method = mcpWarnMethod
 			wc.Resource = mcpWarnResource(verdict.Method, msg)
+			if wc.PolicyHash == "" {
+				wc.PolicyHash = opts.receiptPolicyHash()
+			}
 			httpWarnCtx := scanner.WithDLPWarnContext(inputScanCtx, wc)
 			dlpResult := sc.ScanTextForDLP(httpWarnCtx, string(redirectResult.Response))
 			if !scanVerdict.Clean {

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -355,6 +355,9 @@ func RunHTTPListenerProxy(
 		}
 		warnCtx.Method = mcpWarnMethod
 		warnCtx.Resource = r.URL.Path
+		if warnCtx.PolicyHash == "" {
+			warnCtx.PolicyHash = baseOpts.receiptPolicyHash()
+		}
 		if warnCtx.ClientIP == "" {
 			host, _, err := net.SplitHostPort(r.RemoteAddr)
 			if err != nil {

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -355,8 +355,8 @@ func RunHTTPListenerProxy(
 		}
 		warnCtx.Method = mcpWarnMethod
 		warnCtx.Resource = r.URL.Path
-		if warnCtx.PolicyHash == "" {
-			warnCtx.PolicyHash = baseOpts.receiptPolicyHash()
+		if policyHash := baseOpts.receiptPolicyHash(); policyHash != "" {
+			warnCtx.PolicyHash = policyHash
 		}
 		if warnCtx.ClientIP == "" {
 			host, _, err := net.SplitHostPort(r.RemoteAddr)

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -4823,10 +4823,12 @@ func TestScanHTTPInput_RedirectOutputWarnPreservesWarnContext(t *testing.T) {
 	var logBuf bytes.Buffer
 	opts := testOpts(sc)
 	opts.PolicyCfg = policyCfg
+	opts.PolicyHash = mcpTestPolicyHash
 	opts.WarnContext = scanner.WithDLPWarnContext(context.Background(), scanner.DLPWarnContext{
-		Transport: testWarnContextHTTPTransport,
-		RequestID: testWarnContextRequestID,
-		Agent:     testWarnContextAgent,
+		Transport:  testWarnContextHTTPTransport,
+		RequestID:  testWarnContextRequestID,
+		Agent:      testWarnContextAgent,
+		PolicyHash: "stale-policy-hash",
 	})
 
 	blocked := scanHTTPInput(msg, &logBuf, "sess", "sess", opts)
@@ -4849,6 +4851,9 @@ func TestScanHTTPInput_RedirectOutputWarnPreservesWarnContext(t *testing.T) {
 	}
 	if got.Agent != testWarnContextAgent {
 		t.Fatalf("agent = %q, want %q", got.Agent, testWarnContextAgent)
+	}
+	if got.PolicyHash != mcpTestPolicyHash {
+		t.Fatalf("policyHash = %q, want authoritative %q", got.PolicyHash, mcpTestPolicyHash)
 	}
 }
 

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -174,7 +174,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// Scan through all layers (URL pipeline).
 	connectScanCtx := scanner.WithDLPWarnContext(r.Context(), scanner.DLPWarnContext{
 		Method: http.MethodConnect, URL: syntheticURL, Target: target,
-		ClientIP: clientIP, RequestID: requestID, Agent: agent, Transport: "connect",
+		ClientIP: clientIP, RequestID: requestID, Agent: agent, Transport: "connect", PolicyHash: cfg.CanonicalPolicyHash(),
 	})
 	r = r.WithContext(connectScanCtx)
 	result := sc.Scan(connectScanCtx, syntheticURL)
@@ -824,7 +824,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// Scan through all layers (URL pipeline)
 	fwdScanCtx := scanner.WithDLPWarnContext(r.Context(), scanner.DLPWarnContext{
 		Method: r.Method, URL: targetURL, ClientIP: clientIP,
-		RequestID: requestID, Agent: agent, Transport: "forward",
+		RequestID: requestID, Agent: agent, Transport: "forward", PolicyHash: cfg.CanonicalPolicyHash(),
 	})
 	r = r.WithContext(fwdScanCtx)
 	result := sc.Scan(fwdScanCtx, targetURL)

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -682,7 +682,7 @@ func newInterceptHandler(
 		interceptScanCtx := scanner.WithDLPWarnContext(r.Context(), scanner.DLPWarnContext{
 			Method: r.Method, URL: targetURL, Target: target,
 			ClientIP: ic.ClientIP, RequestID: ic.RequestID,
-			Agent: ic.Agent, Transport: "intercept",
+			Agent: ic.Agent, Transport: "intercept", PolicyHash: ic.Config.CanonicalPolicyHash(),
 		})
 		r = r.WithContext(interceptScanCtx)
 		urlResult := ic.Scanner.Scan(interceptScanCtx, targetURL)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -650,6 +650,7 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			redirectWarnCtx.ClientIP = clientIP
 			redirectWarnCtx.RequestID = requestID
 			redirectWarnCtx.Agent = agentName
+			redirectWarnCtx.PolicyHash = currentCfg.CanonicalPolicyHash()
 			// Derive transport from the original request context so
 			// forward-proxy redirects log and audit as "forward" and
 			// fetch-proxy redirects log as "fetch". Hard-coding
@@ -696,7 +697,7 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 				Agent:       agentName,
 				AuditCtx:    newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName),
 				Emit: func(opts receipt.EmitOpts) {
-					_ = p.emitReceipt(opts)
+					_ = p.emitReceipt(withReceiptPolicyHash(opts, currentCfg.CanonicalPolicyHash()))
 				},
 			}); rpRes.Block {
 				return newRedirectBlockedRequest(blockLayerRequestPolicy, rpRes.Reason)
@@ -3520,7 +3521,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	// Scan URL through all scanners
 	scanCtx := scanner.WithDLPWarnContext(r.Context(), scanner.DLPWarnContext{
 		Method: http.MethodGet, URL: targetURL, ClientIP: clientIP,
-		RequestID: requestID, Agent: agent, Transport: "fetch",
+		RequestID: requestID, Agent: agent, Transport: "fetch", PolicyHash: cfg.CanonicalPolicyHash(),
 	})
 	r = r.WithContext(scanCtx)
 	result := sc.Scan(scanCtx, targetURL)

--- a/internal/proxy/receipt_coverage_test.go
+++ b/internal/proxy/receipt_coverage_test.go
@@ -980,6 +980,10 @@ type receiptProxyHelper struct {
 	emitter *receipt.Emitter
 	priv    ed25519.PrivateKey
 	pubHex  string
+	// cfg is the resolved config the proxy was built with, captured at
+	// construction so tests can assert a receipt carries the deciding config's
+	// canonical policy hash (what the per-emission PolicyHash now binds to).
+	cfg *config.Config
 }
 
 func newReceiptProxyHelper(t *testing.T) *receiptProxyHelper {
@@ -1095,6 +1099,7 @@ func setupFetchProxyWithReceipts(t *testing.T, rph *receiptProxyHelper, cfgMod f
 	}
 
 	logger := audit.NewNop()
+	rph.cfg = cfg
 	sc := scanner.New(cfg)
 	p, err := New(cfg, logger, sc, metrics.New(),
 		WithRecorder(rph.rec),
@@ -1131,6 +1136,7 @@ func setupWSProxyWithReceipts(t *testing.T, rph *receiptProxyHelper, cfgMod func
 	}
 
 	logger := audit.NewNop()
+	rph.cfg = cfg
 	sc := scanner.New(cfg)
 	p, err := New(cfg, logger, sc, metrics.New(),
 		WithRecorder(rph.rec),
@@ -1201,6 +1207,7 @@ func setupForwardProxyWithReceipts(t *testing.T, rph *receiptProxyHelper, cfgMod
 	cfg.Internal = savedInternal
 
 	logger := audit.NewNop()
+	rph.cfg = cfg
 	sc := scanner.New(cfg)
 	p, err := New(cfg, logger, sc, metrics.New(),
 		WithRecorder(rph.rec),
@@ -1386,8 +1393,9 @@ func TestReceiptCoverage_FetchHeaderDLP_EmitsReceipt(t *testing.T) {
 	if r.ActionRecord.Verdict != config.ActionBlock {
 		t.Errorf("verdict = %q, want %q", r.ActionRecord.Verdict, config.ActionBlock)
 	}
-	if r.ActionRecord.PolicyHash != coverageTestConfigHash {
-		t.Errorf("policy_hash = %q, want %q", r.ActionRecord.PolicyHash, coverageTestConfigHash)
+	wantPolicyHash := rph.cfg.CanonicalPolicyHash()
+	if r.ActionRecord.PolicyHash != wantPolicyHash {
+		t.Errorf("policy_hash = %q, want %q", r.ActionRecord.PolicyHash, wantPolicyHash)
 	}
 }
 

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -152,8 +152,11 @@ func TestProxy_ReceiptEmission_FetchBlock(t *testing.T) {
 	if r.ActionRecord.Transport != "fetch" {
 		t.Errorf("expected transport fetch, got %q", r.ActionRecord.Transport)
 	}
-	if r.ActionRecord.PolicyHash != "test-config-hash" {
-		t.Errorf("expected policy_hash test-config-hash, got %q", r.ActionRecord.PolicyHash)
+	// The receipt binds to the deciding config's canonical policy hash (the
+	// per-emission PolicyHash the proxy stamps), not the emitter's mutable
+	// config-hash atomic.
+	if want := cfg.CanonicalPolicyHash(); r.ActionRecord.PolicyHash != want {
+		t.Errorf("expected policy_hash %q, got %q", want, r.ActionRecord.PolicyHash)
 	}
 
 	if err := receipt.VerifyWithKey(r, r.SignerKey); err != nil {
@@ -736,8 +739,8 @@ fetch_proxy:
 	}
 	reloadCfg.Internal = nil
 	reloadCfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
-	if cfg.Hash() == reloadCfg.Hash() {
-		t.Fatal("expected distinct raw config hashes for aborted-reload receipt test")
+	if cfg.CanonicalPolicyHash() == reloadCfg.CanonicalPolicyHash() {
+		t.Fatal("expected distinct canonical policy hashes for aborted-reload receipt test")
 	}
 	reloadSc := scanner.New(reloadCfg)
 
@@ -776,10 +779,10 @@ fetch_proxy:
 		if uErr != nil {
 			t.Fatalf("unmarshal receipt: %v", uErr)
 		}
-		if r.ActionRecord.PolicyHash != cfg.Hash() {
-			t.Fatalf("expected aborted reload to preserve receipt policy hash %q, got %q", cfg.Hash(), r.ActionRecord.PolicyHash)
+		if want := cfg.CanonicalPolicyHash(); r.ActionRecord.PolicyHash != want {
+			t.Fatalf("expected aborted reload to preserve receipt policy hash %q, got %q", want, r.ActionRecord.PolicyHash)
 		}
-		if r.ActionRecord.PolicyHash == reloadCfg.Hash() {
+		if r.ActionRecord.PolicyHash == reloadCfg.CanonicalPolicyHash() {
 			t.Fatal("receipt unexpectedly attested the aborted reload config hash")
 		}
 		return
@@ -893,8 +896,8 @@ fetch_proxy:
 	}
 	reloadCfg.Internal = nil
 	reloadCfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
-	if cfg.Hash() == reloadCfg.Hash() {
-		t.Fatal("expected distinct config hashes for failed reload")
+	if cfg.CanonicalPolicyHash() == reloadCfg.CanonicalPolicyHash() {
+		t.Fatal("expected distinct canonical policy hashes for failed reload")
 	}
 
 	if err := os.Chmod(recDir, 0o500); err != nil { // #nosec G302 -- deliberately read-only dir to force raw-escrow write failure
@@ -960,11 +963,11 @@ fetch_proxy:
 		t.Fatalf("post-failure request unexpectedly carried session_control: %+v",
 			receipts[1].ActionRecord.SessionControl)
 	}
-	if receipts[1].ActionRecord.PolicyHash != cfg.Hash() {
+	if want := cfg.CanonicalPolicyHash(); receipts[1].ActionRecord.PolicyHash != want {
 		t.Fatalf("post-failure receipt policy hash = %q, want old hash %q",
-			receipts[1].ActionRecord.PolicyHash, cfg.Hash())
+			receipts[1].ActionRecord.PolicyHash, want)
 	}
-	if receipts[1].ActionRecord.PolicyHash == reloadCfg.Hash() {
+	if receipts[1].ActionRecord.PolicyHash == reloadCfg.CanonicalPolicyHash() {
 		t.Fatal("post-failure receipt unexpectedly attested failed reload config")
 	}
 	result := receipt.VerifyChainTrusted(receipts, []string{hex.EncodeToString(pub)})
@@ -1115,8 +1118,8 @@ func TestProxy_ReloadReceiptEmitter_UpdatesHash(t *testing.T) {
 			if uErr != nil {
 				t.Fatalf("unmarshal receipt: %v", uErr)
 			}
-			if r.ActionRecord.PolicyHash != reloadCfg.Hash() {
-				t.Errorf("expected policy hash %q, got %q", reloadCfg.Hash(), r.ActionRecord.PolicyHash)
+			if want := reloadCfg.CanonicalPolicyHash(); r.ActionRecord.PolicyHash != want {
+				t.Errorf("expected policy hash %q, got %q", want, r.ActionRecord.PolicyHash)
 			}
 			return
 		}

--- a/internal/proxy/requestpolicy_enforcement_test.go
+++ b/internal/proxy/requestpolicy_enforcement_test.go
@@ -4,6 +4,10 @@
 package proxy
 
 import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +20,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
@@ -692,6 +697,88 @@ func TestRequestPolicy_RedirectHopReportsRequestPolicyReason(t *testing.T) {
 	}
 	if got := w.Header().Get("X-Pipelock-Block-Reason-Retry"); got != "policy" {
 		t.Errorf("retry hint = %q, want policy", got)
+	}
+}
+
+func TestRequestPolicy_RedirectHopReceiptUsesRedirectSnapshotPolicyHash(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := reqPolicyConfig(blockRule(http.MethodGet))
+	newCfg := reqPolicyConfig(blockRule(http.MethodPost))
+	if oldCfg.CanonicalPolicyHash() == newCfg.CanonicalPolicyHash() {
+		t.Fatal("expected distinct policy hashes")
+	}
+
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: oldCfg.Hash(),
+		Principal:  "test-principal",
+		Actor:      "test-actor",
+	})
+	oldSc := scanner.New(oldCfg)
+	t.Cleanup(oldSc.Close)
+	p, err := New(oldCfg, audit.NewNop(), oldSc, metrics.New(), WithRecorder(rec), WithReceiptEmitter(emitter))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	p.cfgPtr.Store(newCfg)
+	ctx := context.WithValue(t.Context(), ctxKeyAgentConfig, oldCfg)
+	ctx = context.WithValue(ctx, ctxKeyAgentScanner, oldSc)
+	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportFetch)
+	ctx = context.WithValue(ctx, ctxKeyRequestID, "req-redirect-policy-hash")
+	ctx = context.WithValue(ctx, ctxKeyAgent, "agent-a")
+	redirectReq := httptest.NewRequestWithContext(ctx, http.MethodGet, "http://"+rpTestHost+"/v1/secret", nil)
+	originalReq := httptest.NewRequestWithContext(ctx, http.MethodGet, "http://origin.example/start", nil)
+
+	if err := p.client.CheckRedirect(redirectReq, []*http.Request{originalReq}); err == nil {
+		t.Fatal("CheckRedirect unexpectedly allowed request_policy-blocked redirect")
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	var got *receipt.Receipt
+	for _, entry := range readAllEntries(t, dir) {
+		if entry.Type != receiptEntryType {
+			continue
+		}
+		detailJSON, marshalErr := json.Marshal(entry.Detail)
+		if marshalErr != nil {
+			t.Fatalf("marshal detail: %v", marshalErr)
+		}
+		r, unmarshalErr := receipt.Unmarshal(detailJSON)
+		if unmarshalErr != nil {
+			t.Fatalf("unmarshal receipt: %v", unmarshalErr)
+		}
+		if r.ActionRecord.Layer == blockLayerRequestPolicy {
+			got = &r
+			break
+		}
+	}
+	if got == nil {
+		t.Fatal("no request_policy receipt found")
+	}
+	if want := oldCfg.CanonicalPolicyHash(); got.ActionRecord.PolicyHash != want {
+		t.Fatalf("redirect request_policy policy_hash = %q, want redirect snapshot %q", got.ActionRecord.PolicyHash, want)
+	}
+	if got.ActionRecord.PolicyHash == newCfg.CanonicalPolicyHash() {
+		t.Fatal("redirect request_policy receipt used live post-reload config hash")
 	}
 }
 

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -534,7 +534,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	ctx := scanner.WithDLPWarnContext(r.Context(), scanner.DLPWarnContext{
 		Method: r.Method, URL: targetURL, ClientIP: clientIP,
-		RequestID: requestID, Agent: agent, Transport: "reverse",
+		RequestID: requestID, Agent: agent, Transport: "reverse", PolicyHash: cfg.CanonicalPolicyHash(),
 	})
 	ctx = context.WithValue(ctx, ctxKeyClientIP, clientIP)
 	ctx = context.WithValue(ctx, ctxKeyRequestID, requestID)

--- a/internal/proxy/v2receipt_test.go
+++ b/internal/proxy/v2receipt_test.go
@@ -725,8 +725,11 @@ func TestDualEmit_SameKeyReloadUsesUpdatedPolicyHash(t *testing.T) {
 			v2Policy = r.PolicyHash
 		}
 	}
-	if v1Policy != reloadCfg.Hash() {
-		t.Fatalf("v1 policy_hash = %q, want reload cfg.Hash %q", v1Policy, reloadCfg.Hash())
+	// v1 and v2 now bind to the SAME per-emission canonical policy hash of the
+	// deciding config; the v1 receipt no longer diverges onto the emitter's
+	// mutable config-hash atomic.
+	if want := reloadCfg.CanonicalPolicyHash(); v1Policy != want {
+		t.Fatalf("v1 policy_hash = %q, want reload canonical policy hash %q", v1Policy, want)
 	}
 	wantV2Policy := contractreceipt.NormalizePolicyHash(reloadCfg.CanonicalPolicyHash())
 	if v2Policy != wantV2Policy {

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -257,7 +257,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Run through all 9 scanner layers.
 	wsScanCtx := scanner.WithDLPWarnContext(r.Context(), scanner.DLPWarnContext{
 		Method: "WS", URL: scanURL, ClientIP: clientIP,
-		RequestID: requestID, Agent: agent, Transport: TransportWS,
+		RequestID: requestID, Agent: agent, Transport: TransportWS, PolicyHash: cfg.CanonicalPolicyHash(),
 	})
 	r = r.WithContext(wsScanCtx)
 	result := sc.Scan(wsScanCtx, scanURL)

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -285,8 +285,13 @@ type EmitOpts struct {
 	ContractSelectorID    string
 	ContractGeneration    uint64
 	// PolicyHash is the canonical policy hash for the resolved runtime config
-	// that produced this decision. V2 EvidenceReceipt emission consumes this;
-	// v1 action receipts keep using the emitter's config hash snapshot.
+	// snapshot that produced this decision. Both v1 action receipts and V2
+	// EvidenceReceipt emission consume it: when non-empty it is stamped on the
+	// receipt in preference to the emitter's mutable config-hash atomic, binding
+	// the receipt to the policy that decided the request even if a hot reload
+	// has since advanced the live policy. Callers with no request snapshot
+	// (session_open, non-proxy emitters) leave it empty and fall back to the
+	// emitter's atomic.
 	PolicyHash string
 
 	DecisionPhase     string
@@ -499,6 +504,20 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 		return err
 	}
 
+	// PolicyHash precedence: a non-empty per-emission opts.PolicyHash is the
+	// canonical policy hash of the config snapshot that actually decided this
+	// request, so it wins over the emitter's mutable configHash atomic. The
+	// atomic is updated on hot reload and can advance to the NEW policy while an
+	// in-flight request decided under the OLD policy is still being receipted;
+	// preferring the per-emission hash binds the receipt to the policy that made
+	// the decision. Callers with no request snapshot (session_open, non-proxy
+	// emitters) leave opts.PolicyHash empty and fall back to the atomic exactly
+	// as before.
+	policyHash := configHashString(e.configHash.Load())
+	if opts.PolicyHash != "" {
+		policyHash = opts.PolicyHash
+	}
+
 	// Sanitize secret-bearing fields BEFORE signing. When redaction is enabled
 	// the recorder would otherwise redact target/pattern AFTER signing,
 	// desyncing the on-disk canonical bytes from both the signature and the
@@ -528,7 +547,7 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 		Target:                target,
 		SideEffectClass:       sideEffect,
 		Reversibility:         reversibility,
-		PolicyHash:            configHashString(e.configHash.Load()),
+		PolicyHash:            policyHash,
 		Verdict:               NormalizeVerdict(opts.Verdict),
 		DecisionPhase:         opts.DecisionPhase,
 		DeferID:               opts.DeferID,

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -284,14 +284,14 @@ type EmitOpts struct {
 	ContractHash          string
 	ContractSelectorID    string
 	ContractGeneration    uint64
-	// PolicyHash is the canonical policy hash for the resolved runtime config
-	// snapshot that produced this decision. Both v1 action receipts and V2
-	// EvidenceReceipt emission consume it: when non-empty it is stamped on the
-	// receipt in preference to the emitter's mutable config-hash atomic, binding
-	// the receipt to the policy that decided the request even if a hot reload
-	// has since advanced the live policy. Callers with no request snapshot
-	// (session_open, non-proxy emitters) leave it empty and fall back to the
-	// emitter's atomic.
+	// PolicyHash is the canonical SHA-256 policy hash for the resolved runtime
+	// config snapshot that produced this decision. Both raw 64-character hex and
+	// "sha256:"-labeled forms are accepted; action receipts normalize it to raw
+	// hex. When non-empty it is stamped on the receipt in preference to the
+	// emitter's mutable config-hash atomic, binding the receipt to the policy
+	// that decided the request even if a hot reload has since advanced the live
+	// policy. Callers with no request snapshot (session_open, non-proxy
+	// emitters) leave it empty and fall back to the emitter's atomic.
 	PolicyHash string
 
 	DecisionPhase     string
@@ -515,7 +515,12 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 	// as before.
 	policyHash := configHashString(e.configHash.Load())
 	if opts.PolicyHash != "" {
-		policyHash = opts.PolicyHash
+		normalizedPolicyHash, normalizeErr := normalizeCanonicalPolicyHash(opts.PolicyHash)
+		if normalizeErr != nil {
+			e.recordFailure(FailReasonHash)
+			return fmt.Errorf("policy hash override: %w", normalizeErr)
+		}
+		policyHash = normalizedPolicyHash
 	}
 
 	// Sanitize secret-bearing fields BEFORE signing. When redaction is enabled
@@ -942,6 +947,29 @@ func configHashString(v any) string {
 		return s
 	}
 	return ""
+}
+
+const canonicalPolicyHashLabel = "sha256:"
+
+func normalizeCanonicalPolicyHash(value string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	if strings.TrimSpace(value) != value {
+		return "", fmt.Errorf("must not contain leading or trailing whitespace")
+	}
+	value = strings.TrimPrefix(value, canonicalPolicyHashLabel)
+	if len(value) != sha256.Size*2 {
+		return "", fmt.Errorf("must be a %d-character SHA-256 hex digest", sha256.Size*2)
+	}
+	for i := range len(value) {
+		c := value[i]
+		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') {
+			continue
+		}
+		return "", fmt.Errorf("must be lowercase SHA-256 hex")
+	}
+	return value, nil
 }
 
 func newRunNonce() (string, error) {

--- a/internal/receipt/emitter_test.go
+++ b/internal/receipt/emitter_test.go
@@ -383,6 +383,18 @@ func TestEmitter_RejectsMalformedPolicyHashOverride(t *testing.T) {
 	}
 }
 
+func TestNormalizeCanonicalPolicyHash_EmptyValue(t *testing.T) {
+	t.Parallel()
+
+	got, err := normalizeCanonicalPolicyHash("")
+	if err != nil {
+		t.Fatalf("normalizeCanonicalPolicyHash empty error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("normalizeCanonicalPolicyHash empty = %q, want empty", got)
+	}
+}
+
 func TestEmitter_RunNoncePerProcessRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/receipt/emitter_test.go
+++ b/internal/receipt/emitter_test.go
@@ -201,8 +201,8 @@ func TestEmitter_InFlightReceiptStampsSnapshotPolicyHashAcrossReload(t *testing.
 	t.Parallel()
 
 	const (
-		oldPolicyHash = "old-policy-hash-1111111111111111"
-		newPolicyHash = "new-policy-hash-2222222222222222"
+		oldPolicyHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		newPolicyHash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 	)
 
 	dir := t.TempDir()
@@ -283,6 +283,103 @@ func TestEmitter_InFlightReceiptStampsSnapshotPolicyHashAcrossReload(t *testing.
 	}
 	if got := byID[fallbackID]; got != newPolicyHash {
 		t.Errorf("fallback receipt policy_hash = %q, want live atomic NEW %q", got, newPolicyHash)
+	}
+}
+
+func TestEmitter_NormalizesLabeledPolicyHashOverride(t *testing.T) {
+	t.Parallel()
+
+	const rawPolicyHash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: testConfigHash,
+		Principal:  testPrincipal,
+		Actor:      testActor,
+	})
+	if e == nil {
+		t.Fatal("NewEmitter() returned nil")
+	}
+
+	actionID := NewActionID()
+	if err := e.Emit(EmitOpts{
+		ActionID:   actionID,
+		Target:     testTarget,
+		Verdict:    config.ActionBlock,
+		Transport:  testTransport,
+		Method:     http.MethodGet,
+		PolicyHash: "sha256:" + rawPolicyHash,
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	for _, r := range readAllReceiptsFromDir(t, dir, pub) {
+		if r.ActionRecord.ActionID == actionID {
+			if r.ActionRecord.PolicyHash != rawPolicyHash {
+				t.Fatalf("policy_hash = %q, want normalized raw %q", r.ActionRecord.PolicyHash, rawPolicyHash)
+			}
+			return
+		}
+	}
+	t.Fatalf("receipt for action_id %q not found", actionID)
+}
+
+func TestEmitter_RejectsMalformedPolicyHashOverride(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		hash string
+	}{
+		{name: "short", hash: "sha256:abc"},
+		{name: "unlabeled junk", hash: "not-a-policy-hash"},
+		{name: "uppercase", hash: "sha256:0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef"},
+		{name: "leading whitespace", hash: " sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+		{name: "trailing newline", hash: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n"},
+		{name: "control character", hash: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde\x00"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			_, priv := generateTestKey(t)
+			rec := newTestRecorder(t, dir, priv)
+			defer func() { _ = rec.Close() }()
+			e := NewEmitter(EmitterConfig{
+				Recorder:   rec,
+				PrivKey:    priv,
+				ConfigHash: testConfigHash,
+				Principal:  testPrincipal,
+				Actor:      testActor,
+			})
+			if e == nil {
+				t.Fatal("NewEmitter() returned nil")
+			}
+
+			err := e.Emit(EmitOpts{
+				ActionID:   NewActionID(),
+				Target:     testTarget,
+				Verdict:    config.ActionBlock,
+				Transport:  testTransport,
+				Method:     http.MethodGet,
+				PolicyHash: tc.hash,
+			})
+			if err == nil {
+				t.Fatal("Emit succeeded with malformed policy hash")
+			}
+			if !strings.Contains(err.Error(), "policy hash override") {
+				t.Fatalf("error = %v, want policy hash override context", err)
+			}
+		})
 	}
 }
 

--- a/internal/receipt/emitter_test.go
+++ b/internal/receipt/emitter_test.go
@@ -189,6 +189,103 @@ func TestEmitter_Emit_HappyPath(t *testing.T) {
 	}
 }
 
+// TestEmitter_InFlightReceiptStampsSnapshotPolicyHashAcrossReload proves that a
+// request decided under the OLD policy but emitted AFTER a same-key hot reload
+// advanced the emitter's config-hash atomic is still stamped with the policy
+// that actually decided it. Before the per-emission PolicyHash preference, the
+// in-flight receipt inherited the mutated atomic (the NEW policy), so a shown
+// receipt could claim a policy that never evaluated the request. The test is
+// deterministic: it drives Emit directly with two config snapshots and does not
+// depend on a live reload goroutine.
+func TestEmitter_InFlightReceiptStampsSnapshotPolicyHashAcrossReload(t *testing.T) {
+	t.Parallel()
+
+	const (
+		oldPolicyHash = "old-policy-hash-1111111111111111"
+		newPolicyHash = "new-policy-hash-2222222222222222"
+	)
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+
+	// The emitter starts with the OLD policy in its config-hash atomic.
+	e := NewEmitter(EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: oldPolicyHash,
+		Principal:  testPrincipal,
+		Actor:      testActor,
+	})
+	if e == nil {
+		t.Fatal("NewEmitter() returned nil")
+	}
+
+	// A hot reload advances the live config-hash atomic to the NEW policy. This
+	// is the mutation that historically restamped an in-flight receipt.
+	inFlightID := NewActionID()
+	e.UpdateConfigHash(newPolicyHash)
+
+	// The in-flight request (decided under the OLD policy, so it captured the
+	// OLD snapshot hash in EmitOpts.PolicyHash) emits AFTER the atomic advanced.
+	// It must still carry the OLD policy hash.
+	if err := e.Emit(EmitOpts{
+		ActionID:   inFlightID,
+		Target:     testTarget,
+		Verdict:    config.ActionBlock,
+		Transport:  testTransport,
+		Method:     http.MethodGet,
+		PolicyHash: oldPolicyHash,
+	}); err != nil {
+		t.Fatalf("in-flight Emit: %v", err)
+	}
+
+	// A request decided AFTER the reload carries the NEW snapshot hash.
+	postReloadID := NewActionID()
+	if err := e.Emit(EmitOpts{
+		ActionID:   postReloadID,
+		Target:     testTarget,
+		Verdict:    config.ActionAllow,
+		Transport:  testTransport,
+		Method:     http.MethodGet,
+		PolicyHash: newPolicyHash,
+	}); err != nil {
+		t.Fatalf("post-reload Emit: %v", err)
+	}
+
+	// A caller with no request snapshot (empty PolicyHash) falls back to the
+	// live atomic, exactly as before this change.
+	fallbackID := NewActionID()
+	if err := e.Emit(EmitOpts{
+		ActionID:  fallbackID,
+		Target:    testTarget,
+		Verdict:   config.ActionAllow,
+		Transport: testTransport,
+		Method:    http.MethodGet,
+	}); err != nil {
+		t.Fatalf("fallback Emit: %v", err)
+	}
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	byID := make(map[string]string)
+	for _, r := range readAllReceiptsFromDir(t, dir, pub) {
+		byID[r.ActionRecord.ActionID] = r.ActionRecord.PolicyHash
+	}
+
+	if got := byID[inFlightID]; got != oldPolicyHash {
+		t.Errorf("in-flight receipt policy_hash = %q, want OLD %q (a reload must not restamp an in-flight decision)", got, oldPolicyHash)
+	}
+	if got := byID[postReloadID]; got != newPolicyHash {
+		t.Errorf("post-reload receipt policy_hash = %q, want NEW %q", got, newPolicyHash)
+	}
+	if got := byID[fallbackID]; got != newPolicyHash {
+		t.Errorf("fallback receipt policy_hash = %q, want live atomic NEW %q", got, newPolicyHash)
+	}
+}
+
 func TestEmitter_RunNoncePerProcessRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/replaycapture/capture.go
+++ b/internal/replaycapture/capture.go
@@ -9,9 +9,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -60,7 +58,7 @@ type CapturedScenario struct {
 	Receipts     []receipt.Receipt
 	EvidenceFile string // recorder JSONL the verifier reads (evidence-proxy-0.jsonl)
 	SignerKeyHex string // ed25519 public key hex
-	PolicyHash   string // config hash; equals each receipt's policy_hash
+	PolicyHash   string // "sha256:"-labeled canonical policy hash; action receipts carry the raw form of the same digest
 	RootHash     string // chain root hash after the final receipt
 	FinalSeq     uint64
 	ReceiptCount int
@@ -161,6 +159,11 @@ func (e *Engine) Capture(s Scenario) (_ *CapturedScenario, err error) {
 		afterRecorderConstructedForTest(rec)
 	}
 
+	// policyHash is the "sha256:"-labeled canonical policy hash. It is stamped on
+	// the session_open control receipt (via the emitter's config-hash atomic)
+	// and reported as the packet/launch-manifest policy hash, so those all agree
+	// and the public-gallery allowlist sees a labeled hash. Proxy action
+	// receipts carry the raw (unlabeled) canonical form of the same digest.
 	policyHash := configHash(cfg)
 	emitter := receipt.NewEmitter(receipt.EmitterConfig{
 		Recorder:       rec,
@@ -400,18 +403,14 @@ func singleEvidenceFile(dir string) (string, error) {
 	return matches[0], nil
 }
 
-// configHash returns a deterministic "sha256:<hex>" digest of the lab config
-// that produced the receipts. Stamped as the receipt policy hash so the packet
-// policy hash honestly reflects the policy in force.
+// configHash returns the "sha256:<hex>" labeled canonical policy hash of the lab
+// config that produced the receipts. This is the same policy view the proxy
+// binds to action receipts (cfg.CanonicalPolicyHash()), labeled for the
+// session_open control receipt so the packet honestly reflects the policy in
+// force. Action receipts carry the raw (unlabeled) form; the label only marks
+// the session_open policy hash for the public-gallery allowlist.
 func configHash(cfg *config.Config) string {
-	data, err := json.Marshal(cfg)
-	if err != nil {
-		// config.Config marshals cleanly; a failure here is a programming error,
-		// not runtime input. Fall back to a stable sentinel rather than panic.
-		data = []byte(cfg.Mode)
-	}
-	sum := sha256.Sum256(data)
-	return policyHashLabelPrefix + hex.EncodeToString(sum[:])
+	return policyHashLabelPrefix + cfg.CanonicalPolicyHash()
 }
 
 // labPrincipal / labActor are the synthetic, public-safe identity stamped into

--- a/internal/replaycapture/capture_test.go
+++ b/internal/replaycapture/capture_test.go
@@ -109,6 +109,9 @@ func TestCapture_AllScenarios(t *testing.T) {
 			// The decisive action receipt carries the raw canonical policy hash the
 			// proxy binds per-emission; the packet reports the "sha256:"-labeled
 			// form of the same digest. Compare after stripping the label.
+			if !strings.HasPrefix(got.PolicyHash, "sha256:") {
+				t.Fatalf("packet policy_hash = %q, want sha256-labeled hash", got.PolicyHash)
+			}
 			wantPolicyHash := strings.TrimPrefix(got.PolicyHash, "sha256:")
 			if decisive.ActionRecord.PolicyHash != wantPolicyHash {
 				t.Errorf("policy hash mismatch: receipt=%q engine(unlabeled)=%q (labeled=%q)",

--- a/internal/replaycapture/capture_test.go
+++ b/internal/replaycapture/capture_test.go
@@ -106,10 +106,13 @@ func TestCapture_AllScenarios(t *testing.T) {
 					s.ExpectedVerdict, verdictsOf(got.Receipts))
 			}
 
-			// Policy hash on the receipt must equal the config hash we stamped.
-			if decisive.ActionRecord.PolicyHash != got.PolicyHash {
-				t.Errorf("policy hash mismatch: receipt=%q engine=%q",
-					decisive.ActionRecord.PolicyHash, got.PolicyHash)
+			// The decisive action receipt carries the raw canonical policy hash the
+			// proxy binds per-emission; the packet reports the "sha256:"-labeled
+			// form of the same digest. Compare after stripping the label.
+			wantPolicyHash := strings.TrimPrefix(got.PolicyHash, "sha256:")
+			if decisive.ActionRecord.PolicyHash != wantPolicyHash {
+				t.Errorf("policy hash mismatch: receipt=%q engine(unlabeled)=%q (labeled=%q)",
+					decisive.ActionRecord.PolicyHash, wantPolicyHash, got.PolicyHash)
 			}
 			if s.ExpectedLayer != "" && decisive.ActionRecord.Layer != s.ExpectedLayer {
 				t.Errorf("decisive layer=%q want %q", decisive.ActionRecord.Layer, s.ExpectedLayer)
@@ -319,6 +322,13 @@ func TestCapture_RedactsSecretBeforeSign(t *testing.T) {
 
 func decisiveReceipt(receipts []receipt.Receipt, verdict string) *receipt.Receipt {
 	for i := range receipts {
+		// Skip session-control receipts (session_open/heartbeat/close): the
+		// decisive receipt is the request decision, not the run anchor. The
+		// session_open carries the labeled policy hash for the allowlist, while
+		// action receipts carry the raw canonical policy hash the proxy binds.
+		if receipts[i].ActionRecord.SessionControl != nil {
+			continue
+		}
 		if receipts[i].ActionRecord.Verdict == verdict {
 			return &receipts[i]
 		}

--- a/internal/scanner/warnctx.go
+++ b/internal/scanner/warnctx.go
@@ -7,14 +7,15 @@ import "context"
 
 // DLPWarnContext carries per-request metadata for DLP warn emission.
 type DLPWarnContext struct {
-	Method    string
-	URL       string
-	Target    string
-	Resource  string
-	ClientIP  string
-	RequestID string
-	Agent     string
-	Transport string // "fetch", "forward", "connect", "intercept", "reverse", "websocket", "mcp_stdio", "mcp_http"
+	Method     string
+	URL        string
+	Target     string
+	Resource   string
+	ClientIP   string
+	RequestID  string
+	Agent      string
+	Transport  string // "fetch", "forward", "connect", "intercept", "reverse", "websocket", "mcp_stdio", "mcp_http"
+	PolicyHash string
 }
 
 type dlpWarnCtxKey struct{}


### PR DESCRIPTION
## What changed

Bind a receipt's `policy_hash` to the config snapshot that actually decided the request. The v1 receipt emitter previously stamped `policy_hash` from a mutable config-hash atomic that a hot reload advances, so an in-flight request decided under the old policy could get a receipt bearing the new policy hash once a reload landed mid-flight. Because the dashboard and coverage certificates surface policy-hash-bearing evidence, a wrong hash in a shown receipt undermines the verifiable-evidence story.

`Emit` now prefers a non-empty per-emission policy hash bound to the request's resolved config snapshot, and falls back to the mutable atomic only for callers that have no snapshot (session open and other non-proxy emitters), so their behavior is unchanged.

Every per-request emit path binds the snapshot hash: fetch, forward, CONNECT, TLS intercept, reverse, WebSocket, and the MCP transports, including redirect request-policy receipts and DLP-warn receipts (the DLP warn context now carries the snapshot hash). The replay-capture packet reports the labeled canonical policy hash so it agrees with the action receipts.

## Verification

A regression test proves an old-policy in-flight request across a same-key reload stamps the old hash while a post-reload request stamps the new one; a redirect-hop test proves the receipt keeps the request snapshot hash even after the live config pointer advances. Both are proven by neutralization (binding the live pointer instead of the snapshot fails the tests). Build and lint clean; full race tests green across receipt, scanner, replaycapture, cli runtime, mcp, and proxy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Action receipts now consistently record the canonical policy hash that governed each decision, including DLP warnings, redirects, proxy requests, WebSocket, reverse-proxy flows, runtime behavior, and replay/capture scenarios.
  * Policy-hash propagation into DLP warning context is now reliable across CONNECT, forwarding, proxying, MCP scanning, and redirect-output flows.
  * Per-emission policy-hash overrides are normalized (including optional `sha256:` label) and invalid overrides are rejected.
* **Tests**
  * Expanded/updated receipt and warning-context assertions across redirects, reloads, blocked flows, policy redirects, and capture parity. 
* **Documentation**
  * Updated guidance around how canonical policy hashes are represented and stamped in receipts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->