### PR TITLE
feat(dashboard): add RBAC permission seam

### DIFF
--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -202,13 +202,14 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 	}
 
 	inner := dashboard.New(dashboard.Options{
-		ReceiptDir:     opts.receiptDir,
-		TrustedKeys:    trusted,
-		Config:         loadedConfig,
-		ExemptionStore: exemptionStore,
-		HasFeature:     dashboardRuntimeHasFeature(lic),
-		Authorize:      dashboardAuthorizeFunc(metaAuthorized),
-		AuthorizeRaw:   dashboardAuthorizeFunc(rawAuthorized),
+		ReceiptDir:          opts.receiptDir,
+		TrustedKeys:         trusted,
+		Config:              loadedConfig,
+		ExemptionStore:      exemptionStore,
+		HasFeature:          dashboardRuntimeHasFeature(lic),
+		Authorize:           dashboardAuthorizeFunc(metaAuthorized),
+		AuthorizePermission: dashboardAuthorizePermissionFunc(metaAuthorized, rawAuthorized),
+		AuthorizeRaw:        dashboardAuthorizeFunc(rawAuthorized),
 		// Viewing evidence is itself audited; the access log goes to stderr.
 		AuditWriter: cmd.ErrOrStderr(),
 		// TODO(DASH-3A): wire live conductor source when dashboard serve owns a
@@ -328,6 +329,31 @@ func dashboardAuthorizeFunc(authorized func(*http.Request) bool) func(*http.Requ
 			return errors.New("dashboard request not authenticated")
 		}
 		return nil
+	}
+}
+
+func dashboardAuthorizePermissionFunc(
+	metaAuthorized func(*http.Request) bool,
+	rawAuthorized func(*http.Request) bool,
+) func(*http.Request, dashboard.Permission) error {
+	return func(r *http.Request, permission dashboard.Permission) error {
+		switch permission {
+		case dashboard.PermissionEvidenceRead,
+			dashboard.PermissionExemptionsRead,
+			dashboard.PermissionAgentsRead,
+			dashboard.PermissionBudgetsRead,
+			dashboard.PermissionFleetRead,
+			dashboard.PermissionSignedActionRead,
+			dashboard.PermissionIncidentRead:
+			if metaAuthorized(r) {
+				return nil
+			}
+		case dashboard.PermissionRawRead:
+			if rawAuthorized(r) {
+				return nil
+			}
+		}
+		return fmt.Errorf("dashboard permission %q denied", permission)
 	}
 }
 

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -908,6 +908,68 @@ func TestDashboardTokenMatches(t *testing.T) {
 	}
 }
 
+func TestDashboardAuthorizePermissionFunc(t *testing.T) {
+	metaReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest meta: %v", err)
+	}
+	metaReq.Header.Set("Authorization", "Bearer "+dashTestToken)
+
+	rawReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest raw: %v", err)
+	}
+	rawReq.Header.Set("Authorization", "Bearer raw-"+dashTestToken)
+
+	authorize := dashboardAuthorizePermissionFunc(
+		func(r *http.Request) bool { return dashboardTokenMatches(r, dashTestToken) },
+		func(r *http.Request) bool { return dashboardTokenMatches(r, "raw-"+dashTestToken) },
+	)
+
+	for _, permission := range []dashboard.Permission{
+		dashboard.PermissionEvidenceRead,
+		dashboard.PermissionExemptionsRead,
+		dashboard.PermissionAgentsRead,
+		dashboard.PermissionBudgetsRead,
+		dashboard.PermissionFleetRead,
+		dashboard.PermissionSignedActionRead,
+		dashboard.PermissionIncidentRead,
+	} {
+		if err := authorize(metaReq, permission); err != nil {
+			t.Fatalf("metadata token denied %s: %v", permission, err)
+		}
+	}
+	if err := authorize(metaReq, dashboard.PermissionRawRead); err == nil {
+		t.Fatal("metadata token unexpectedly granted raw permission")
+	}
+	if err := authorize(rawReq, dashboard.PermissionRawRead); err != nil {
+		t.Fatalf("raw token denied raw permission: %v", err)
+	}
+	if err := authorize(metaReq, dashboard.Permission("dashboard:unknown")); err == nil {
+		t.Fatal("unknown dashboard permission unexpectedly allowed")
+	}
+}
+
+// TestDashboardAuthorizePermissionFunc_MapsEveryPermission fails when a new
+// dashboard route permission is added without updating the CLI token mapping.
+// An unmapped permission fails closed in dashboardAuthorizePermissionFunc, so
+// forgetting the mapping would silently 403 the new route in `dashboard serve`.
+func TestDashboardAuthorizePermissionFunc_MapsEveryPermission(t *testing.T) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	authorize := dashboardAuthorizePermissionFunc(
+		func(*http.Request) bool { return true },
+		func(*http.Request) bool { return true },
+	)
+	for _, permission := range dashboard.AllPermissions() {
+		if err := authorize(req, permission); err != nil {
+			t.Errorf("dashboard permission %s has no CLI token mapping: %v", permission, err)
+		}
+	}
+}
+
 func TestValidateDashboardListen(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -57,6 +57,166 @@ type exemptionsPageData struct {
 	Inventory ExemptionInventory
 }
 
+// Permission is the bounded dashboard route/action vocabulary consumed by the
+// RBAC seam. Keep these stable: external auth adapters map identities to these
+// strings, while handlers stay unaware of user/role storage.
+type Permission string
+
+const (
+	PermissionEvidenceRead     Permission = "dashboard:evidence:read"
+	PermissionRawRead          Permission = "dashboard:raw:read"
+	PermissionExemptionsRead   Permission = "dashboard:exemptions:read"
+	PermissionAgentsRead       Permission = "dashboard:agents:read"
+	PermissionBudgetsRead      Permission = "dashboard:budgets:read"
+	PermissionFleetRead        Permission = "dashboard:fleet:read"
+	PermissionSignedActionRead Permission = "dashboard:signed_action:read"
+	PermissionIncidentRead     Permission = "dashboard:incident:read"
+)
+
+const (
+	agentsFeatureForbidden = "Pipelock Enterprise agents feature required\n"
+	fleetFeatureForbidden  = "Pipelock Enterprise fleet feature required\n"
+)
+
+type routeSpec struct {
+	pattern          string
+	feature          string
+	forbiddenMessage string
+	permission       Permission
+	handler          func(*dashboardHandler) http.Handler
+}
+
+func dashboardRouteSpecs() []routeSpec {
+	return []routeSpec{
+		{
+			pattern:          "/",
+			feature:          license.FeatureAgents,
+			forbiddenMessage: agentsFeatureForbidden,
+			permission:       PermissionEvidenceRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleIndex)
+			},
+		},
+		{
+			pattern:          "/exemptions",
+			feature:          license.FeatureAgents,
+			forbiddenMessage: agentsFeatureForbidden,
+			permission:       PermissionExemptionsRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleExemptions)
+			},
+		},
+		{
+			pattern:          "/session/",
+			feature:          license.FeatureAgents,
+			forbiddenMessage: agentsFeatureForbidden,
+			permission:       PermissionEvidenceRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleSession)
+			},
+		},
+		{
+			pattern:          "/agents",
+			feature:          license.FeatureAgents,
+			forbiddenMessage: agentsFeatureForbidden,
+			permission:       PermissionAgentsRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleAgents)
+			},
+		},
+		{
+			pattern:          "/agent/",
+			feature:          license.FeatureAgents,
+			forbiddenMessage: agentsFeatureForbidden,
+			permission:       PermissionAgentsRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleAgent)
+			},
+		},
+		{
+			pattern:          "/budgets",
+			feature:          license.FeatureAgents,
+			forbiddenMessage: agentsFeatureForbidden,
+			permission:       PermissionBudgetsRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleBudgets)
+			},
+		},
+		{
+			pattern:          "/fleet",
+			feature:          license.FeatureFleet,
+			forbiddenMessage: fleetFeatureForbidden,
+			permission:       PermissionFleetRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleFleetOverview)
+			},
+		},
+		{
+			pattern:          "/fleet/",
+			feature:          license.FeatureFleet,
+			forbiddenMessage: fleetFeatureForbidden,
+			permission:       PermissionFleetRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleFleetOverview)
+			},
+		},
+		{
+			pattern:          "/workbench",
+			feature:          license.FeatureFleet,
+			forbiddenMessage: fleetFeatureForbidden,
+			permission:       PermissionSignedActionRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleWorkbench)
+			},
+		},
+		{
+			pattern:          "/workbench/",
+			feature:          license.FeatureFleet,
+			forbiddenMessage: fleetFeatureForbidden,
+			permission:       PermissionSignedActionRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleWorkbench)
+			},
+		},
+		{
+			pattern:          "/incident",
+			feature:          license.FeatureFleet,
+			forbiddenMessage: fleetFeatureForbidden,
+			permission:       PermissionIncidentRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleIncident)
+			},
+		},
+		{
+			pattern:          "/incident/",
+			feature:          license.FeatureFleet,
+			forbiddenMessage: fleetFeatureForbidden,
+			permission:       PermissionIncidentRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleIncident)
+			},
+		},
+	}
+}
+
+// AllPermissions returns the complete bounded permission vocabulary: every
+// permission referenced by a dashboard route plus the raw-view elevation.
+// Derived from the route specs so it cannot drift from what handlers actually
+// require; auth adapters use it to prove their mapping covers every permission
+// (an unmapped permission fails closed and disables its route).
+func AllPermissions() []Permission {
+	seen := map[Permission]struct{}{PermissionRawRead: {}}
+	all := []Permission{PermissionRawRead}
+	for _, spec := range dashboardRouteSpecs() {
+		if _, ok := seen[spec.permission]; ok {
+			continue
+		}
+		seen[spec.permission] = struct{}{}
+		all = append(all, spec.permission)
+	}
+	return all
+}
+
 // New returns a read-only HTTP handler for the Enterprise Evidence dashboard.
 //
 // SECURITY: this handler serves sensitive evidence (signed receipt payloads,
@@ -73,26 +233,14 @@ func New(opts Options) http.Handler {
 		model:               model,
 		hasFeature:          opts.HasFeature,
 		authorize:           opts.Authorize,
+		authorizePermission: opts.AuthorizePermission,
 		authorizeRaw:        opts.AuthorizeRaw,
 		authorizeFleetScope: opts.AuthorizeFleetScope,
 		auditWriter:         opts.AuditWriter,
 	}
-	mux.Handle("/", d.gate(http.HandlerFunc(d.handleIndex)))
-	mux.Handle("/exemptions", d.gate(http.HandlerFunc(d.handleExemptions)))
-	mux.Handle("/session/", d.gate(http.HandlerFunc(d.handleSession)))
-	mux.Handle("/agents", d.gate(http.HandlerFunc(d.handleAgents)))
-	mux.Handle("/agent/", d.gate(http.HandlerFunc(d.handleAgent)))
-	mux.Handle("/budgets", d.gate(http.HandlerFunc(d.handleBudgets)))
-	mux.Handle("/fleet", d.fleetGate(http.HandlerFunc(d.handleFleetOverview)))
-	mux.Handle("/fleet/", d.fleetGate(http.HandlerFunc(d.handleFleetOverview)))
-	// DASH-3B: the Signed Action Workbench and Incident Cockpit are Enterprise
-	// fleet-tier, prepare/verify/replay-only surfaces. They are GET-only and
-	// reach no write path; the trailing-slash routes exist only to reject
-	// deeper paths with 404, never to add a mutating handler.
-	mux.Handle("/workbench", d.fleetGate(http.HandlerFunc(d.handleWorkbench)))
-	mux.Handle("/workbench/", d.fleetGate(http.HandlerFunc(d.handleWorkbench)))
-	mux.Handle("/incident", d.fleetGate(http.HandlerFunc(d.handleIncident)))
-	mux.Handle("/incident/", d.fleetGate(http.HandlerFunc(d.handleIncident)))
+	for _, spec := range dashboardRouteSpecs() {
+		mux.Handle(spec.pattern, d.routeGate(spec, spec.handler(d)))
+	}
 	return mux
 }
 
@@ -100,6 +248,7 @@ type dashboardHandler struct {
 	model               *ReadModel
 	hasFeature          func(string) bool
 	authorize           func(*http.Request) error
+	authorizePermission func(*http.Request, Permission) error
 	authorizeRaw        func(*http.Request) error
 	authorizeFleetScope func(*http.Request, DecisionScope, bool) error
 	auditWriter         io.Writer
@@ -112,7 +261,13 @@ type rawAllowedContextKey struct{}
 // and full signed payloads). Fail closed: raw is shown only when an authorizer
 // is configured and accepts the request.
 func (d *dashboardHandler) rawAllowed(r *http.Request) bool {
-	return d.authorizeRaw != nil && d.authorizeRaw(r) == nil
+	if d.authorizeRaw == nil || d.authorizeRaw(r) != nil {
+		return false
+	}
+	if d.authorizePermission != nil {
+		return d.authorizePermission(r, PermissionRawRead) == nil
+	}
+	return true
 }
 
 func rawAllowedFromContext(r *http.Request) bool {
@@ -240,30 +395,30 @@ func (d *dashboardHandler) authorizeFleetScopeRequest(w http.ResponseWriter, r *
 	return true
 }
 
-func (d *dashboardHandler) gate(next http.Handler) http.Handler {
-	return d.featureGate(license.FeatureAgents, "Pipelock Enterprise agents feature required\n", next)
-}
-
-func (d *dashboardHandler) fleetGate(next http.Handler) http.Handler {
-	return d.featureGate(license.FeatureFleet, "Pipelock Enterprise fleet feature required\n", next)
-}
-
-func (d *dashboardHandler) featureGate(feature, forbiddenMessage string, next http.Handler) http.Handler {
+func (d *dashboardHandler) routeGate(spec routeSpec, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
 		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Referrer-Policy", "no-referrer")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
-		if d.hasFeature == nil || !d.hasFeature(feature) {
+		if d.hasFeature == nil || !d.hasFeature(spec.feature) {
 			w.Header().Set("Content-Type", contentTypeText)
 			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte(forbiddenMessage))
+			_, _ = w.Write([]byte(spec.forbiddenMessage))
 			return
 		}
 		// Authentication boundary. The license check above is entitlement, not
 		// identity; fail closed when a configured authorizer rejects the request.
 		if d.authorize != nil {
 			if err := d.authorize(r); err != nil {
+				w.Header().Set("Content-Type", contentTypeText)
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("forbidden\n"))
+				return
+			}
+		}
+		if d.authorizePermission != nil {
+			if err := d.authorizePermission(r, spec.permission); err != nil {
 				w.Header().Set("Content-Type", contentTypeText)
 				w.WriteHeader(http.StatusForbidden)
 				_, _ = w.Write([]byte("forbidden\n"))

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -333,12 +333,14 @@ func TestHandler_RoutePermissionUsesSpecificPermission(t *testing.T) {
 		{path: "/incident", want: PermissionIncidentRead},
 	}
 	for _, tc := range tests {
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
-		handler.ServeHTTP(rec, req)
-		if len(got) == 0 || got[len(got)-1] != tc.want {
-			t.Fatalf("%s permission = %v, want last permission %q", tc.path, got, tc.want)
-		}
+		t.Run(tc.path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
+			handler.ServeHTTP(rec, req)
+			if len(got) == 0 || got[len(got)-1] != tc.want {
+				t.Fatalf("%s permission = %v, want last permission %q", tc.path, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -242,6 +242,186 @@ func TestHandler_MethodAndPathRejection(t *testing.T) {
 	}
 }
 
+func TestHandler_RouteSpecsDeclarePermissions(t *testing.T) {
+	t.Parallel()
+
+	seen := map[string]struct{}{}
+	for _, spec := range dashboardRouteSpecs() {
+		if spec.pattern == "" {
+			t.Fatal("dashboard route spec has empty pattern")
+		}
+		if spec.feature == "" {
+			t.Fatalf("dashboard route %q has empty feature", spec.pattern)
+		}
+		if spec.forbiddenMessage == "" {
+			t.Fatalf("dashboard route %q has empty forbidden message", spec.pattern)
+		}
+		if spec.permission == "" {
+			t.Fatalf("dashboard route %q has empty permission", spec.pattern)
+		}
+		if spec.handler == nil {
+			t.Fatalf("dashboard route %q has nil handler", spec.pattern)
+		}
+		if _, ok := seen[spec.pattern]; ok {
+			t.Fatalf("dashboard route %q is registered twice", spec.pattern)
+		}
+		seen[spec.pattern] = struct{}{}
+	}
+}
+
+func TestHandler_RoutePermissionFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	handler := New(Options{
+		ReceiptDir:   t.TempDir(),
+		HasFeature:   allowAllDashboardFeatures,
+		Authorize:    func(*http.Request) error { return nil },
+		AuthorizeRaw: allowRawAccess,
+		AuthorizePermission: func(*http.Request, Permission) error {
+			return errors.New("permission denied")
+		},
+	})
+
+	for _, path := range []string{
+		"/",
+		"/exemptions",
+		"/session/" + testSessionID,
+		"/session/" + testSessionID + "/receipt/0",
+		"/agents",
+		"/agent/agent-one",
+		"/budgets",
+		"/fleet",
+		"/workbench",
+		"/incident",
+	} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+			handler.ServeHTTP(rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("%s status = %d, want %d; body=%s", path, rec.Code, http.StatusForbidden, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandler_RoutePermissionUsesSpecificPermission(t *testing.T) {
+	t.Parallel()
+
+	var got []Permission
+	handler := New(Options{
+		ReceiptDir: t.TempDir(),
+		HasFeature: allowAllDashboardFeatures,
+		Authorize:  func(*http.Request) error { return nil },
+		AuthorizePermission: func(_ *http.Request, permission Permission) error {
+			got = append(got, permission)
+			return nil
+		},
+	})
+
+	tests := []struct {
+		path string
+		want Permission
+	}{
+		{path: "/", want: PermissionEvidenceRead},
+		{path: "/exemptions", want: PermissionExemptionsRead},
+		{path: "/session/" + testSessionID, want: PermissionEvidenceRead},
+		{path: "/agents", want: PermissionAgentsRead},
+		{path: "/budgets", want: PermissionBudgetsRead},
+		{path: "/fleet", want: PermissionFleetRead},
+		{path: "/workbench", want: PermissionSignedActionRead},
+		{path: "/incident", want: PermissionIncidentRead},
+	}
+	for _, tc := range tests {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
+		handler.ServeHTTP(rec, req)
+		if len(got) == 0 || got[len(got)-1] != tc.want {
+			t.Fatalf("%s permission = %v, want last permission %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestHandler_RawViewShownWhenRawPermissionGranted(t *testing.T) {
+	t.Parallel()
+
+	dir, trusted := writeTrustedHandlerSession(t)
+	handler := New(Options{
+		ReceiptDir:          dir,
+		TrustedKeys:         trusted,
+		HasFeature:          allowAgentsFeature,
+		Authorize:           func(*http.Request) error { return nil },
+		AuthorizeRaw:        allowRawAccess,
+		AuthorizePermission: func(*http.Request, Permission) error { return nil },
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, testTarget) {
+		t.Fatalf("raw view should show the destination %q when %s is granted", testTarget, PermissionRawRead)
+	}
+	if strings.Contains(body, redactedDestination) {
+		t.Fatal("raw view should not show the redaction placeholder when raw permission is granted")
+	}
+}
+
+func TestHandler_AllPermissionsCoversRouteSpecs(t *testing.T) {
+	t.Parallel()
+
+	all := map[Permission]struct{}{}
+	for _, permission := range AllPermissions() {
+		if permission == "" {
+			t.Fatal("AllPermissions returned an empty permission")
+		}
+		if _, ok := all[permission]; ok {
+			t.Fatalf("AllPermissions returned duplicate permission %q", permission)
+		}
+		all[permission] = struct{}{}
+	}
+	if _, ok := all[PermissionRawRead]; !ok {
+		t.Fatalf("AllPermissions must include %s", PermissionRawRead)
+	}
+	for _, spec := range dashboardRouteSpecs() {
+		if _, ok := all[spec.permission]; !ok {
+			t.Fatalf("route %q permission %q missing from AllPermissions", spec.pattern, spec.permission)
+		}
+	}
+}
+
+func TestHandler_RawViewRequiresRawPermission(t *testing.T) {
+	t.Parallel()
+
+	dir, trusted := writeTrustedHandlerSession(t)
+	handler := New(Options{
+		ReceiptDir:   dir,
+		TrustedKeys:  trusted,
+		HasFeature:   allowAgentsFeature,
+		Authorize:    func(*http.Request) error { return nil },
+		AuthorizeRaw: allowRawAccess,
+		AuthorizePermission: func(_ *http.Request, permission Permission) error {
+			if permission == PermissionRawRead {
+				return errors.New("raw denied")
+			}
+			return nil
+		},
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, testTarget) {
+		t.Fatalf("raw destination leaked without %s", PermissionRawRead)
+	}
+	if !strings.Contains(body, redactedDestination) {
+		t.Fatal("metadata view should show the redaction placeholder when raw permission is denied")
+	}
+}
+
 func TestHandler_ReadLimitWarning(t *testing.T) {
 	t.Parallel()
 
@@ -342,6 +522,10 @@ func TestHandler_AuthorizeFailsClosed(t *testing.T) {
 
 func allowAgentsFeature(feature string) bool {
 	return feature == license.FeatureAgents
+}
+
+func allowAllDashboardFeatures(feature string) bool {
+	return feature == license.FeatureAgents || feature == license.FeatureFleet
 }
 
 // allowRawAccess is an AuthorizeRaw that grants every request the raw view.

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -55,12 +55,21 @@ type Options struct {
 	// authentication/authorization seam, distinct from the license entitlement
 	// check. Nil means the surrounding router must own authentication.
 	Authorize func(*http.Request) error
+	// AuthorizePermission, when non-nil, gates route/action access after the
+	// request passes the coarse authentication boundary. It is the RBAC seam:
+	// callers can map local users, mTLS identities, or OIDC claims to the
+	// bounded dashboard permission vocabulary without changing handlers.
+	// Nil preserves the legacy token-only model where Authorize owns all
+	// metadata-route access.
+	AuthorizePermission func(*http.Request, Permission) error
 	// AuthorizeRaw gates the sensitive raw view (receipt destinations and full
 	// signed payloads). A request is shown raw detail only when AuthorizeRaw is
 	// non-nil AND returns nil for it; every other authenticated request gets the
 	// redacted metadata view. Nil means raw detail is redacted for everyone
 	// (fail closed): a destination URL can carry a capability token, and the raw
 	// payload is the largest exfil surface, so raw is least-privilege by default.
+	// When AuthorizePermission is configured, raw detail also requires
+	// PermissionRawRead.
 	AuthorizeRaw func(*http.Request) error
 	// AuthorizeFleetScope gates reads keyed by an operator-supplied org/fleet
 	// scope before any conductor replay or fleet source is called. Nil is


### PR DESCRIPTION
## Summary

Adds an explicit dashboard permission model for the Enterprise dashboard route layer.

The dashboard now registers routes through a small route spec table that binds each handler to its license feature and RBAC permission. `dashboard.New` accepts an optional `AuthorizePermission` hook, so future local-user, mTLS, or OIDC integrations can map identities to stable dashboard permissions without rewriting handlers.

`dashboard serve` preserves the current token behavior by mapping the metadata token to metadata route permissions and the raw token to `dashboard:raw:read`.

## Details

- Adds bounded dashboard permissions for evidence, raw evidence, exemptions, agents, budgets, fleet overview, signed action workbench, and incident cockpit.
- Derives `AllPermissions()` from the route specs so CLI/auth adapters can test complete coverage.
- Keeps raw access fail-closed: raw rendering requires both the raw authorization hook and the raw permission when a permission hook is configured.
- Adds regression tests for route permission coverage, permission denial, positive and negative raw rendering, and CLI permission mapping drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission-based access controls across dashboard sections.
  * Restricted sensitive raw views to users with explicit raw-read permission.
* **Bug Fixes**
  * Enforced fail-closed authorization for denied permissions, returning clear forbidden responses.
  * Ensured dashboard permission coverage stays complete as new permissions are added.
* **Tests**
  * Added comprehensive authorization and routing coverage for permission and raw-view behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->