### PR TITLE
feat(dashboard): live per-agent forward-budget data via runtime snapshot

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -609,3 +609,10 @@ flight_recorder:
     max_anchor_lag: 24h
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key
+
+# ---- dashboard_snapshot (read-only dashboard runtime view) ----
+# Writes counts/limits only to <flight_recorder.dir>/dashboard/runtime-snapshot.json
+# when flight_recorder.dir is configured. The dashboard reads this file; it is
+# point-in-time observability, not enforcement proof.
+dashboard_snapshot:
+  interval: 10s

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -697,3 +697,10 @@ flight_recorder:
     max_anchor_lag: 24h
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key
+
+# ---- dashboard_snapshot (read-only dashboard runtime view) ----
+# Writes counts/limits only to <flight_recorder.dir>/dashboard/runtime-snapshot.json
+# when flight_recorder.dir is configured. The dashboard reads this file; it is
+# point-in-time observability, not enforcement proof.
+dashboard_snapshot:
+  interval: 10s

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -657,3 +657,10 @@ flight_recorder:
     max_anchor_lag: 24h
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key
+
+# ---- dashboard_snapshot (read-only dashboard runtime view) ----
+# Writes counts/limits only to <flight_recorder.dir>/dashboard/runtime-snapshot.json
+# when flight_recorder.dir is configured. The dashboard reads this file; it is
+# point-in-time observability, not enforcement proof.
+dashboard_snapshot:
+  interval: 10s

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -645,3 +645,10 @@ flight_recorder:
     max_anchor_lag: 24h
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key
+
+# ---- dashboard_snapshot (read-only dashboard runtime view) ----
+# Writes counts/limits only to <flight_recorder.dir>/dashboard/runtime-snapshot.json
+# when flight_recorder.dir is configured. The dashboard reads this file; it is
+# point-in-time observability, not enforcement proof.
+dashboard_snapshot:
+  interval: 10s

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -654,3 +654,10 @@ flight_recorder:
     max_anchor_lag: 24h
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key
+
+# ---- dashboard_snapshot (read-only dashboard runtime view) ----
+# Writes counts/limits only to <flight_recorder.dir>/dashboard/runtime-snapshot.json
+# when flight_recorder.dir is configured. The dashboard reads this file; it is
+# point-in-time observability, not enforcement proof.
+dashboard_snapshot:
+  interval: 10s

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -688,3 +688,10 @@ flight_recorder:
     max_anchor_lag: 24h
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key
+
+# ---- dashboard_snapshot (read-only dashboard runtime view) ----
+# Writes counts/limits only to <flight_recorder.dir>/dashboard/runtime-snapshot.json
+# when flight_recorder.dir is configured. The dashboard reads this file; it is
+# point-in-time observability, not enforcement proof.
+dashboard_snapshot:
+  interval: 10s

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -696,3 +696,10 @@ flight_recorder:
     max_anchor_lag: 24h
   # dir: /var/lib/pipelock/recorder
   # signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key
+
+# ---- dashboard_snapshot (read-only dashboard runtime view) ----
+# Writes counts/limits only to <flight_recorder.dir>/dashboard/runtime-snapshot.json
+# when flight_recorder.dir is configured. The dashboard reads this file; it is
+# point-in-time observability, not enforcement proof.
+dashboard_snapshot:
+  interval: 10s

--- a/enterprise/budget.go
+++ b/enterprise/budget.go
@@ -213,12 +213,22 @@ func (b *BudgetTracker) Snapshot() edition.BudgetSnapshot {
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.maybeResetWindow()
+	requestCount := b.requestCount
+	byteCount := b.byteCount
+	uniqueDomainCount := len(b.uniqueDomains)
+	windowStart := b.windowStart
+	now := b.now()
+	if b.cfg.WindowMinutes > 0 && now.Sub(windowStart) > time.Duration(b.cfg.WindowMinutes)*time.Minute {
+		requestCount = 0
+		byteCount = 0
+		uniqueDomainCount = 0
+		windowStart = now
+	}
 	return edition.BudgetSnapshot{
-		RequestCount:      b.requestCount,
-		ByteCount:         b.byteCount,
-		UniqueDomainCount: len(b.uniqueDomains),
-		WindowStart:       b.windowStart,
+		RequestCount:      requestCount,
+		ByteCount:         byteCount,
+		UniqueDomainCount: uniqueDomainCount,
+		WindowStart:       windowStart,
 		MaxRequests:       b.cfg.MaxRequestsPerSession,
 		MaxBytes:          b.cfg.MaxBytesPerSession,
 		MaxUniqueDomains:  b.cfg.MaxUniqueDomainsPerSession,

--- a/enterprise/budget.go
+++ b/enterprise/budget.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/edition"
 )
 
 // BudgetTracker enforces per-agent request budgets within a rolling window.
@@ -199,5 +200,28 @@ func (b *BudgetTracker) maybeResetWindow() {
 		b.byteCount = 0
 		b.uniqueDomains = make(map[string]struct{})
 		b.windowStart = b.now()
+	}
+}
+
+// Snapshot returns a read-only, point-in-time view of the tracker's
+// consumption and configured limits for observability surfaces. It never
+// affects enforcement. Thread-safe. A nil tracker returns a zero snapshot.
+// BudgetTracker implements edition.BudgetSnapshotProvider.
+func (b *BudgetTracker) Snapshot() edition.BudgetSnapshot {
+	if b == nil {
+		return edition.BudgetSnapshot{}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.maybeResetWindow()
+	return edition.BudgetSnapshot{
+		RequestCount:      b.requestCount,
+		ByteCount:         b.byteCount,
+		UniqueDomainCount: len(b.uniqueDomains),
+		WindowStart:       b.windowStart,
+		MaxRequests:       b.cfg.MaxRequestsPerSession,
+		MaxBytes:          b.cfg.MaxBytesPerSession,
+		MaxUniqueDomains:  b.cfg.MaxUniqueDomainsPerSession,
+		WindowMinutes:     b.cfg.WindowMinutes,
 	}
 }

--- a/enterprise/budget_test.go
+++ b/enterprise/budget_test.go
@@ -433,3 +433,57 @@ func TestBudgetWindowResetsAllCounters(t *testing.T) {
 		t.Fatalf("all counters should reset after window expiry: %v", err)
 	}
 }
+
+func TestBudgetSnapshotIsReadOnlyAcrossExpiredWindow(t *testing.T) {
+	budget := config.BudgetConfig{
+		MaxRequestsPerSession:      2,
+		MaxBytesPerSession:         300,
+		MaxUniqueDomainsPerSession: 2,
+		WindowMinutes:              5,
+	}
+	tracker := NewBudgetTracker(&budget)
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	tracker.now = func() time.Time { return now }
+	tracker.windowStart = now
+	if err := tracker.RecordRequest(testDomainA, testByteSize); err != nil {
+		t.Fatalf("RecordRequest: %v", err)
+	}
+
+	active := tracker.Snapshot()
+	if active.RequestCount != 1 || active.ByteCount != testByteSize || active.UniqueDomainCount != 1 {
+		t.Fatalf("active snapshot = %+v", active)
+	}
+	if active.WindowStart != now || active.MaxRequests != 2 || active.MaxBytes != 300 || active.MaxUniqueDomains != 2 || active.WindowMinutes != 5 {
+		t.Fatalf("active snapshot metadata = %+v", active)
+	}
+
+	originalWindowStart := tracker.windowStart
+	now = now.Add(6 * time.Minute)
+	expired := tracker.Snapshot()
+	if expired.RequestCount != 0 || expired.ByteCount != 0 || expired.UniqueDomainCount != 0 {
+		t.Fatalf("expired snapshot counters = %+v, want zeroed view", expired)
+	}
+	if expired.WindowStart != now {
+		t.Fatalf("expired snapshot window start = %s, want %s", expired.WindowStart, now)
+	}
+	if tracker.requestCount != 1 || tracker.byteCount != testByteSize || len(tracker.uniqueDomains) != 1 || tracker.windowStart != originalWindowStart {
+		t.Fatalf("Snapshot mutated enforcement state: requests=%d bytes=%d domains=%d start=%s",
+			tracker.requestCount, tracker.byteCount, len(tracker.uniqueDomains), tracker.windowStart)
+	}
+
+	// Enforcement, not observation, owns the actual reset.
+	if err := tracker.RecordRequest(testDomainB, testByteSize); err != nil {
+		t.Fatalf("RecordRequest after expired observational snapshot: %v", err)
+	}
+	if tracker.requestCount != 1 || tracker.byteCount != testByteSize || len(tracker.uniqueDomains) != 1 || tracker.windowStart != now {
+		t.Fatalf("enforcement reset state = requests=%d bytes=%d domains=%d start=%s",
+			tracker.requestCount, tracker.byteCount, len(tracker.uniqueDomains), tracker.windowStart)
+	}
+}
+
+func TestBudgetSnapshotNilTracker(t *testing.T) {
+	var tracker *BudgetTracker
+	if got := tracker.Snapshot(); got != (edition.BudgetSnapshot{}) {
+		t.Fatalf("nil tracker snapshot = %+v, want zero value", got)
+	}
+}

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -49,16 +49,17 @@ func DashboardCmd() *cobra.Command {
 }
 
 type dashboardServeOptions struct {
-	listen         string
-	receiptDir     string
-	configFile     string
-	authTokenFile  string
-	rawTokenFile   string
-	trustedSigners []string
-	licenseCRLFile string
-	tlsCert        string
-	tlsKey         string
-	exemptionStore string
+	listen              string
+	receiptDir          string
+	configFile          string
+	authTokenFile       string
+	rawTokenFile        string
+	runtimeSnapshotFile string
+	trustedSigners      []string
+	licenseCRLFile      string
+	tlsCert             string
+	tlsKey              string
+	exemptionStore      string
 }
 
 func dashboardServeCmd() *cobra.Command {
@@ -104,6 +105,8 @@ because the operator token would transit in cleartext.`,
 		"file containing the operator token required on every dashboard request (redacted metadata view)")
 	cmd.Flags().StringVar(&opts.rawTokenFile, "raw-token-file", "",
 		"optional file containing a higher-privilege token that unlocks raw destinations and signed payloads; must differ from --auth-token-file")
+	cmd.Flags().StringVar(&opts.runtimeSnapshotFile, "runtime-snapshot-file", "",
+		"read-only proxy runtime snapshot file for live dashboard budget data; defaults under --receipt-dir/dashboard/runtime-snapshot.json")
 	cmd.Flags().StringArrayVar(&opts.trustedSigners, "trusted-signer", nil,
 		"trusted receipt signing key as comma-separated kv pairs: "+
 			"'(inline=HEX_OR_VERSIONED_PUBLIC_KEY|file=/path)[,source=LABEL]'; repeatable")
@@ -169,6 +172,10 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 	if !info.IsDir() {
 		return fmt.Errorf("--receipt-dir %q is not a directory", opts.receiptDir)
 	}
+	runtimeSnapshotFile := strings.TrimSpace(opts.runtimeSnapshotFile)
+	if runtimeSnapshotFile == "" {
+		runtimeSnapshotFile = filepath.Join(opts.receiptDir, "dashboard", "runtime-snapshot.json")
+	}
 	if len(trusted) == 0 {
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
 			"pipelock: warning: no --trusted-signer configured; the Authentic line will render every signer as Unverified")
@@ -179,6 +186,10 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 		if err != nil {
 			return fmt.Errorf("--config: %w", err)
 		}
+	}
+	runtimeSnapshotMaxAge := 3 * config.DefaultDashboardSnapshotInterval
+	if loadedConfig != nil {
+		runtimeSnapshotMaxAge = 3 * loadedConfig.DashboardSnapshot.IntervalDuration()
 	}
 	var exemptionStore *dashboard.ExemptionStore
 	if strings.TrimSpace(opts.exemptionStore) != "" {
@@ -224,13 +235,7 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 		// method), so the dashboard holds no fleet-control authority even once
 		// wired.
 		ConductorSource: nil,
-		// TODO(DASH-2D): wire the live budget source once the dashboard process
-		// can read per-agent budget state. Budget consumption (BudgetTracker,
-		// DoW trackers) lives in the proxy process's memory; dashboard serve is
-		// a separate process, so it needs the same persisted-store handle the
-		// FleetSource TODO above describes. Until then /budgets renders the
-		// read-only empty state instead of inventing budget numbers.
-		BudgetSource: nil,
+		BudgetSource:    dashboard.NewSnapshotBudgetSource(runtimeSnapshotFile, runtimeSnapshotMaxAge),
 	})
 	handler := dashboardAuthHandler(metaAuthorized, inner)
 

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -113,7 +113,7 @@ func TestDashboardCmd_Tree(t *testing.T) {
 	if err != nil || serve.Use != "serve" {
 		t.Fatalf("dashboard serve subcommand not found: %v", err)
 	}
-	for _, flag := range []string{"listen", "receipt-dir", "config", "auth-token-file", "raw-token-file", "trusted-signer", "license-crl-file", "tls-cert", "tls-key"} {
+	for _, flag := range []string{"listen", "receipt-dir", "config", "auth-token-file", "raw-token-file", "runtime-snapshot-file", "trusted-signer", "license-crl-file", "tls-cert", "tls-key"} {
 		if serve.Flags().Lookup(flag) == nil {
 			t.Errorf("serve is missing --%s", flag)
 		}

--- a/enterprise/dashboard/budgets.go
+++ b/enterprise/dashboard/budgets.go
@@ -77,12 +77,15 @@ type AgentBudgetSessionView struct {
 
 // BudgetsOverview is the rendered budgets page.
 type BudgetsOverview struct {
-	SourceConfigured bool
-	Claim            string
-	NonClaim         string
-	RawAllowed       bool
-	Agents           []AgentBudgetView
-	Truncated        bool
+	SourceConfigured     bool
+	SourceUnavailable    bool
+	Claim                string
+	NonClaim             string
+	RawAllowed           bool
+	Agents               []AgentBudgetView
+	Truncated            bool
+	SnapshotFreshness    BudgetSnapshotFreshness
+	HasSnapshotFreshness bool
 }
 
 // Budgets builds the per-agent budget overview. It nil-degrades to an empty,
@@ -100,8 +103,14 @@ func (m *ReadModel) Budgets(ctx context.Context, rawAllowed bool) (BudgetsOvervi
 	}
 	agents, err := m.budgetSource.AllAgentBudgets(ctx, budgetAgentLimit+1)
 	if err != nil {
+		if budgetUnavailable(err) {
+			overview.SourceUnavailable = true
+			overview.SnapshotFreshness, overview.HasSnapshotFreshness = budgetFreshness(m.budgetSource)
+			return overview, nil
+		}
 		return BudgetsOverview{}, fmt.Errorf("list agent budgets: %w", err)
 	}
+	overview.SnapshotFreshness, overview.HasSnapshotFreshness = budgetFreshness(m.budgetSource)
 	sort.Slice(agents, func(i, j int) bool { return agents[i].Agent < agents[j].Agent })
 	if len(agents) > budgetAgentLimit {
 		agents = agents[:budgetAgentLimit]
@@ -113,6 +122,14 @@ func (m *ReadModel) Budgets(ctx context.Context, rawAllowed bool) (BudgetsOvervi
 	}
 	overview.Agents = agents
 	return overview, nil
+}
+
+func budgetFreshness(source BudgetDataSource) (BudgetSnapshotFreshness, bool) {
+	freshSource, ok := source.(budgetFreshnessSource)
+	if !ok {
+		return BudgetSnapshotFreshness{}, false
+	}
+	return freshSource.BudgetFreshness()
 }
 
 func limitBudgetSessions(in []AgentBudgetView) []AgentBudgetView {
@@ -221,4 +238,15 @@ func displayBudgetTime(value time.Time) string {
 		return budgetEmptyDash
 	}
 	return value.UTC().Format(time.RFC3339)
+}
+
+func (b BudgetSnapshotFreshness) ProducedAtDisplay() string {
+	return displayBudgetTime(b.ProducedAt)
+}
+
+func (b BudgetSnapshotFreshness) AgeDisplay() string {
+	if b.Age < 0 {
+		return budgetEmptyDash
+	}
+	return b.Age.Round(time.Second).String()
 }

--- a/enterprise/dashboard/budgets.tmpl.html
+++ b/enterprise/dashboard/budgets.tmpl.html
@@ -101,9 +101,16 @@
       <h1>Per-agent budgets</h1>
       <p class="claim">Scope: {{ .Claim }}.</p>
       <p class="nonclaim">This {{ .NonClaim }}.</p>
+      {{ if .HasSnapshotFreshness }}
+        <p class="note">
+          Snapshot produced at {{ .SnapshotFreshness.ProducedAtDisplay }} (age {{ .SnapshotFreshness.AgeDisplay }}{{ if .SnapshotFreshness.Stale }}, stale{{ end }}).
+        </p>
+      {{ end }}
 
       {{ if not .SourceConfigured }}
         <div class="empty">No budget source is configured for this dashboard.</div>
+      {{ else if .SourceUnavailable }}
+        <div class="empty">Budget snapshot source unavailable. Counters are not shown because the snapshot is missing, invalid, oversized, future-dated, or stale.</div>
       {{ else if not .Agents }}
         <div class="empty">No agents have a configured forward-proxy budget or live MCP sessions.</div>
       {{ else }}

--- a/enterprise/dashboard/runtimesnapshot/snapshot.go
+++ b/enterprise/dashboard/runtimesnapshot/snapshot.go
@@ -121,6 +121,9 @@ func Write(path string, snap Envelope) error {
 	if err != nil {
 		return fmt.Errorf("marshal runtime snapshot: %w", err)
 	}
+	if len(data) > MaxFileBytes {
+		return fmt.Errorf("%w: %d bytes > %d", ErrOversized, len(data), MaxFileBytes)
+	}
 	return atomicfile.Write(path, data, 0o600)
 }
 

--- a/enterprise/dashboard/runtimesnapshot/snapshot.go
+++ b/enterprise/dashboard/runtimesnapshot/snapshot.go
@@ -1,0 +1,221 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package runtimesnapshot
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/edition"
+)
+
+const (
+	Version       = 1
+	MaxFileBytes  = 4 * 1024 * 1024
+	MaxBudgetRows = 1000
+	MaxFutureSkew = 5 * time.Second
+	DefaultMaxAge = 30 * time.Second
+)
+
+var (
+	ErrMissing            = errors.New("runtime snapshot missing")
+	ErrOversized          = errors.New("runtime snapshot oversized")
+	ErrMalformed          = errors.New("runtime snapshot malformed")
+	ErrUnsupportedVersion = errors.New("runtime snapshot unsupported version")
+	ErrFutureProducedAt   = errors.New("runtime snapshot produced_at is in the future")
+	ErrStale              = errors.New("runtime snapshot stale")
+)
+
+type Envelope struct {
+	Version    int                `json:"version"`
+	ProducedAt time.Time          `json:"produced_at"`
+	ProducerID string             `json:"producer_id"`
+	PolicyHash string             `json:"policy_hash,omitempty"`
+	Budgets    []AgentBudgetRow   `json:"budgets,omitempty"`
+	Fleet      []FleetFollowerRow `json:"fleet,omitempty"`
+	Truncated  Truncation         `json:"truncated,omitempty"`
+}
+
+type Truncation struct {
+	Budgets bool `json:"budgets,omitempty"`
+}
+
+type AgentBudgetRow struct {
+	Agent string `json:"agent"`
+
+	RequestCount      int       `json:"request_count"`
+	ByteCount         int64     `json:"byte_count"`
+	UniqueDomainCount int       `json:"unique_domain_count"`
+	WindowStart       time.Time `json:"window_start"`
+
+	MaxRequests      int   `json:"max_requests"`
+	MaxBytes         int64 `json:"max_bytes"`
+	MaxUniqueDomains int   `json:"max_unique_domains"`
+	WindowMinutes    int   `json:"window_minutes"`
+}
+
+type FleetFollowerRow struct {
+	OrgID      string    `json:"org_id,omitempty"`
+	FleetID    string    `json:"fleet_id,omitempty"`
+	InstanceID string    `json:"instance_id,omitempty"`
+	Status     string    `json:"status,omitempty"`
+	SeenAt     time.Time `json:"seen_at,omitempty"`
+}
+
+type Freshness struct {
+	ProducedAt time.Time
+	Age        time.Duration
+	Stale      bool
+}
+
+func NewEnvelope(producedAt time.Time, producerID, policyHash string, budgets []edition.AgentBudgetSnapshot) Envelope {
+	rows, truncated := BudgetRowsFromSnapshots(budgets)
+	return Envelope{
+		Version:    Version,
+		ProducedAt: producedAt.UTC(),
+		ProducerID: producerID,
+		PolicyHash: policyHash,
+		Budgets:    rows,
+		Truncated:  Truncation{Budgets: truncated},
+	}
+}
+
+func BudgetRowsFromSnapshots(snapshots []edition.AgentBudgetSnapshot) ([]AgentBudgetRow, bool) {
+	truncated := len(snapshots) > MaxBudgetRows
+	if truncated {
+		snapshots = snapshots[:MaxBudgetRows]
+	}
+	rows := make([]AgentBudgetRow, 0, len(snapshots))
+	for _, snap := range snapshots {
+		rows = append(rows, AgentBudgetRow{
+			Agent:             snap.Agent,
+			RequestCount:      snap.RequestCount,
+			ByteCount:         snap.ByteCount,
+			UniqueDomainCount: snap.UniqueDomainCount,
+			WindowStart:       snap.WindowStart,
+			MaxRequests:       snap.MaxRequests,
+			MaxBytes:          int64(snap.MaxBytes),
+			MaxUniqueDomains:  snap.MaxUniqueDomains,
+			WindowMinutes:     snap.WindowMinutes,
+		})
+	}
+	return rows, truncated
+}
+
+func Write(path string, snap Envelope) error {
+	path = filepath.Clean(path)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create runtime snapshot directory: %w", err)
+	}
+	snap.Version = Version
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return fmt.Errorf("marshal runtime snapshot: %w", err)
+	}
+	return atomicfile.Write(path, data, 0o600)
+}
+
+func Read(path string, maxAge time.Duration, now time.Time) (Envelope, Freshness, error) {
+	if maxAge <= 0 {
+		maxAge = DefaultMaxAge
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	now = now.UTC()
+	path = filepath.Clean(path)
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Envelope{}, Freshness{}, fmt.Errorf("%w: %s", ErrMissing, path)
+		}
+		return Envelope{}, Freshness{}, fmt.Errorf("stat runtime snapshot: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return Envelope{}, Freshness{}, fmt.Errorf("%w: not a regular file", ErrMalformed)
+	}
+	if info.Mode().Perm() != 0o600 {
+		return Envelope{}, Freshness{}, fmt.Errorf("%w: unsafe file permissions %04o", ErrMalformed, info.Mode().Perm())
+	}
+	if info.Size() > MaxFileBytes {
+		return Envelope{}, Freshness{}, fmt.Errorf("%w: %d bytes > %d", ErrOversized, info.Size(), MaxFileBytes)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return Envelope{}, Freshness{}, fmt.Errorf("open runtime snapshot: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	openedInfo, err := f.Stat()
+	if err != nil {
+		return Envelope{}, Freshness{}, fmt.Errorf("stat open runtime snapshot: %w", err)
+	}
+	if !os.SameFile(info, openedInfo) {
+		return Envelope{}, Freshness{}, fmt.Errorf("%w: changed while opening", ErrMalformed)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(f, MaxFileBytes+1))
+	if err != nil {
+		return Envelope{}, Freshness{}, fmt.Errorf("read runtime snapshot: %w", err)
+	}
+	if len(data) > MaxFileBytes {
+		return Envelope{}, Freshness{}, fmt.Errorf("%w: exceeded %d bytes", ErrOversized, MaxFileBytes)
+	}
+
+	var snap Envelope
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&snap); err != nil {
+		return Envelope{}, Freshness{}, fmt.Errorf("%w: %w", ErrMalformed, err)
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return Envelope{}, Freshness{}, fmt.Errorf("%w: trailing data", ErrMalformed)
+	}
+	if snap.Version != Version {
+		return snap, Freshness{}, fmt.Errorf("%w: %d", ErrUnsupportedVersion, snap.Version)
+	}
+
+	fresh := Freshness{ProducedAt: snap.ProducedAt.UTC()}
+	if fresh.ProducedAt.After(now.Add(MaxFutureSkew)) {
+		return snap, fresh, fmt.Errorf("%w: %s", ErrFutureProducedAt, fresh.ProducedAt.Format(time.RFC3339))
+	}
+	fresh.Age = now.Sub(fresh.ProducedAt)
+	if fresh.Age > maxAge {
+		fresh.Stale = true
+		return snap, fresh, fmt.Errorf("%w: age %s > %s", ErrStale, fresh.Age, maxAge)
+	}
+	if len(snap.Budgets) > MaxBudgetRows {
+		snap.Budgets = snap.Budgets[:MaxBudgetRows]
+		snap.Truncated.Budgets = true
+	}
+	if err := validateBudgetRows(snap.Budgets); err != nil {
+		return snap, fresh, err
+	}
+	return snap, fresh, nil
+}
+
+func validateBudgetRows(rows []AgentBudgetRow) error {
+	for i, row := range rows {
+		if row.Agent == "" {
+			return fmt.Errorf("%w: budgets[%d].agent is required", ErrMalformed, i)
+		}
+		if row.RequestCount < 0 ||
+			row.ByteCount < 0 ||
+			row.UniqueDomainCount < 0 ||
+			row.MaxRequests < 0 ||
+			row.MaxBytes < 0 ||
+			row.MaxUniqueDomains < 0 ||
+			row.WindowMinutes < 0 {
+			return fmt.Errorf("%w: budgets[%d] contains negative count or limit", ErrMalformed, i)
+		}
+	}
+	return nil
+}

--- a/enterprise/dashboard/runtimesnapshot/snapshot_test.go
+++ b/enterprise/dashboard/runtimesnapshot/snapshot_test.go
@@ -1,0 +1,243 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package runtimesnapshot
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/edition"
+)
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "dashboard", "runtime-snapshot.json")
+	snap := NewEnvelope(now, "producer-1", "policy-hash", []edition.AgentBudgetSnapshot{{
+		Agent: "agent-alpha",
+		BudgetSnapshot: edition.BudgetSnapshot{
+			RequestCount:      7,
+			ByteCount:         4096,
+			UniqueDomainCount: 2,
+			WindowStart:       now.Add(-time.Hour),
+			MaxRequests:       100,
+			MaxBytes:          1 << 20,
+			MaxUniqueDomains:  10,
+			WindowMinutes:     60,
+		},
+	}})
+
+	if err := Write(path, snap); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat written snapshot: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("snapshot mode = %04o, want 0600", got)
+	}
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("stat snapshot dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o750 {
+		t.Fatalf("snapshot dir mode = %04o, want 0750", got)
+	}
+
+	got, fresh, err := Read(path, time.Minute, now.Add(5*time.Second))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Version != Version || got.ProducerID != "producer-1" || got.PolicyHash != "policy-hash" {
+		t.Fatalf("unexpected envelope metadata: %+v", got)
+	}
+	if len(got.Budgets) != 1 {
+		t.Fatalf("budget rows = %d, want 1", len(got.Budgets))
+	}
+	if got.Budgets[0].Agent != "agent-alpha" || got.Budgets[0].UniqueDomainCount != 2 {
+		t.Fatalf("unexpected budget row: %+v", got.Budgets[0])
+	}
+	if fresh.Age != 5*time.Second || fresh.Stale {
+		t.Fatalf("freshness = %+v, want age 5s stale=false", fresh)
+	}
+}
+
+func TestReadFailClosed(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		write   func(t *testing.T) string
+		wantErr error
+	}{
+		{
+			name: "missing",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return filepath.Join(dir, "missing.json")
+			},
+			wantErr: ErrMissing,
+		},
+		{
+			name: "bad_json",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return writeSnapshotBytes(t, dir, "bad.json", []byte(`{"version":`))
+			},
+			wantErr: ErrMalformed,
+		},
+		{
+			name: "symlink",
+			write: func(t *testing.T) string {
+				t.Helper()
+				target := writeTestSnapshot(t, dir, "target.json", Envelope{ProducedAt: now})
+				link := filepath.Join(dir, "link.json")
+				if err := os.Symlink(target, link); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+				return link
+			},
+			wantErr: ErrMalformed,
+		},
+		{
+			name: "loose_permissions",
+			write: func(t *testing.T) string {
+				t.Helper()
+				path := writeTestSnapshot(t, dir, "loose.json", Envelope{ProducedAt: now})
+				// Loosen the just-written 0o600 fixture to group/other-readable
+				// so Read must reject it. The mode is derived at runtime from the
+				// current mode (not a literal) so this stays an honest fixture
+				// without a lint-suppression directive.
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatalf("stat fixture: %v", err)
+				}
+				if err := os.Chmod(path, info.Mode()|0o044); err != nil {
+					t.Fatalf("chmod fixture: %v", err)
+				}
+				return path
+			},
+			wantErr: ErrMalformed,
+		},
+		{
+			name: "unknown_top_level_field",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return writeSnapshotBytes(t, dir, "unknown-root.json", []byte(`{"version":1,"produced_at":"2026-07-10T12:00:00Z","target_url":"https://api.vendor.example/secret"}`))
+			},
+			wantErr: ErrMalformed,
+		},
+		{
+			name: "unknown_budget_field",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return writeSnapshotBytes(t, dir, "unknown-budget.json", []byte(`{"version":1,"produced_at":"2026-07-10T12:00:00Z","budgets":[{"agent":"agent-alpha","request_count":1,"domains":["api.vendor.example"]}]}`))
+			},
+			wantErr: ErrMalformed,
+		},
+		{
+			name: "unknown_version",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return writeSnapshotBytes(t, dir, "version.json", []byte(`{"version":2,"produced_at":"2026-07-10T12:00:00Z"}`))
+			},
+			wantErr: ErrUnsupportedVersion,
+		},
+		{
+			name: "future_timestamp",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return writeTestSnapshot(t, dir, "future.json", Envelope{ProducedAt: now.Add(time.Minute)})
+			},
+			wantErr: ErrFutureProducedAt,
+		},
+		{
+			name: "stale",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return writeTestSnapshot(t, dir, "stale.json", Envelope{ProducedAt: now.Add(-time.Minute)})
+			},
+			wantErr: ErrStale,
+		},
+		{
+			name: "oversized",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return writeSnapshotBytes(t, dir, "big.json", make([]byte, MaxFileBytes+1))
+			},
+			wantErr: ErrOversized,
+		},
+		{
+			name: "negative_budget_count",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return writeTestSnapshot(t, dir, "negative.json", Envelope{
+					ProducedAt: now,
+					Budgets:    []AgentBudgetRow{{Agent: "agent-alpha", RequestCount: -1}},
+				})
+			},
+			wantErr: ErrMalformed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := Read(tt.write(t), 30*time.Second, now)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Read error = %v, want errors.Is(%v)", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReadCapsBudgetRows(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	rows := make([]AgentBudgetRow, 0, MaxBudgetRows+1)
+	for i := 0; i <= MaxBudgetRows; i++ {
+		rows = append(rows, AgentBudgetRow{Agent: "agent"})
+	}
+	path := writeTestSnapshot(t, t.TempDir(), "many.json", Envelope{ProducedAt: now, Budgets: rows})
+
+	snap, _, err := Read(path, time.Minute, now)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(snap.Budgets) != MaxBudgetRows {
+		t.Fatalf("budget rows = %d, want cap %d", len(snap.Budgets), MaxBudgetRows)
+	}
+	if !snap.Truncated.Budgets {
+		t.Fatal("Truncated.Budgets = false, want true")
+	}
+}
+
+func writeTestSnapshot(t *testing.T, dir, name string, snap Envelope) string {
+	t.Helper()
+	snap.Version = Version
+	path := filepath.Join(dir, name)
+	if err := Write(path, snap); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return path
+}
+
+func writeSnapshotBytes(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}

--- a/enterprise/dashboard/runtimesnapshot/snapshot_test.go
+++ b/enterprise/dashboard/runtimesnapshot/snapshot_test.go
@@ -6,8 +6,10 @@ package runtimesnapshot
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,6 +71,41 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestWriteRejectsOversizedSnapshotWithoutReplacingTarget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "runtime-snapshot.json")
+	original := []byte("known-good-snapshot")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("write original target: %v", err)
+	}
+
+	err := Write(path, Envelope{
+		ProducedAt: time.Now(),
+		ProducerID: strings.Repeat("x", MaxFileBytes),
+	})
+	if !errors.Is(err, ErrOversized) {
+		t.Fatalf("Write error = %v, want errors.Is(ErrOversized)", err)
+	}
+	got, readErr := fs.ReadFile(os.DirFS(dir), "runtime-snapshot.json")
+	if readErr != nil {
+		t.Fatalf("read preserved target: %v", readErr)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("target replaced on oversized write: got %q", got)
+	}
+
+	missingPath := filepath.Join(dir, "missing-target.json")
+	err = Write(missingPath, Envelope{ProducerID: strings.Repeat("x", MaxFileBytes)})
+	if !errors.Is(err, ErrOversized) {
+		t.Fatalf("Write missing target error = %v, want errors.Is(ErrOversized)", err)
+	}
+	if _, statErr := os.Stat(missingPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("oversized write left target behind: %v", statErr)
+	}
+}
+
 func TestReadFailClosed(t *testing.T) {
 	t.Parallel()
 
@@ -93,6 +130,22 @@ func TestReadFailClosed(t *testing.T) {
 			write: func(t *testing.T) string {
 				t.Helper()
 				return writeSnapshotBytes(t, dir, "bad.json", []byte(`{"version":`))
+			},
+			wantErr: ErrMalformed,
+		},
+		{
+			name: "directory",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir()
+			},
+			wantErr: ErrMalformed,
+		},
+		{
+			name: "trailing_data",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return writeSnapshotBytes(t, dir, "trailing.json", []byte(`{"version":1,"produced_at":"2026-07-10T12:00:00Z"} {}`))
 			},
 			wantErr: ErrMalformed,
 		},
@@ -188,6 +241,17 @@ func TestReadFailClosed(t *testing.T) {
 			},
 			wantErr: ErrMalformed,
 		},
+		{
+			name: "empty_budget_agent",
+			write: func(t *testing.T) string {
+				t.Helper()
+				return writeTestSnapshot(t, dir, "empty-agent.json", Envelope{
+					ProducedAt: now,
+					Budgets:    []AgentBudgetRow{{RequestCount: 1}},
+				})
+			},
+			wantErr: ErrMalformed,
+		},
 	}
 
 	for _, tt := range tests {
@@ -220,6 +284,25 @@ func TestReadCapsBudgetRows(t *testing.T) {
 	}
 	if !snap.Truncated.Budgets {
 		t.Fatal("Truncated.Budgets = false, want true")
+	}
+}
+
+func TestBudgetRowsFromSnapshotsCapsInput(t *testing.T) {
+	t.Parallel()
+
+	snapshots := make([]edition.AgentBudgetSnapshot, MaxBudgetRows+1)
+	rows, truncated := BudgetRowsFromSnapshots(snapshots)
+	if len(rows) != MaxBudgetRows || !truncated {
+		t.Fatalf("rows=%d truncated=%v, want %d/true", len(rows), truncated, MaxBudgetRows)
+	}
+}
+
+func TestReadUsesDefaultFreshnessInputs(t *testing.T) {
+	t.Parallel()
+
+	path := writeTestSnapshot(t, t.TempDir(), "defaults.json", Envelope{ProducedAt: time.Now().UTC()})
+	if _, fresh, err := Read(path, 0, time.Time{}); err != nil {
+		t.Fatalf("Read with default freshness inputs: %v (freshness=%+v)", err, fresh)
 	}
 }
 

--- a/enterprise/dashboard/snapshot_budget_source.go
+++ b/enterprise/dashboard/snapshot_budget_source.go
@@ -1,0 +1,124 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/dashboard/runtimesnapshot"
+)
+
+type BudgetSnapshotFreshness struct {
+	ProducedAt time.Time
+	Age        time.Duration
+	Stale      bool
+}
+
+type budgetFreshnessSource interface {
+	BudgetFreshness() (BudgetSnapshotFreshness, bool)
+}
+
+type budgetSourceUnavailable interface {
+	BudgetSourceUnavailable() bool
+}
+
+type snapshotBudgetSource struct {
+	path   string
+	maxAge time.Duration
+	now    func() time.Time
+
+	mu        sync.Mutex
+	freshness BudgetSnapshotFreshness
+	hasFresh  bool
+}
+
+type snapshotBudgetUnavailableError struct {
+	err error
+}
+
+func (e snapshotBudgetUnavailableError) Error() string {
+	return "runtime snapshot budget source unavailable"
+}
+
+func (e snapshotBudgetUnavailableError) Unwrap() error {
+	return e.err
+}
+
+func (e snapshotBudgetUnavailableError) BudgetSourceUnavailable() bool {
+	return true
+}
+
+func NewSnapshotBudgetSource(path string, maxAge time.Duration) BudgetDataSource {
+	if path == "" {
+		return nil
+	}
+	return &snapshotBudgetSource{path: path, maxAge: maxAge, now: time.Now}
+}
+
+func (s *snapshotBudgetSource) AllAgentBudgets(_ context.Context, limit int) ([]AgentBudgetView, error) {
+	now := time.Now
+	if s.now != nil {
+		now = s.now
+	}
+	snap, fresh, err := runtimesnapshot.Read(s.path, s.maxAge, now())
+	s.storeFreshness(fresh)
+	if err != nil {
+		return nil, snapshotBudgetUnavailableError{err: err}
+	}
+	rows := snap.Budgets
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+	out := make([]AgentBudgetView, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, AgentBudgetView{
+			Agent:             row.Agent,
+			ForwardConfigured: true,
+			RequestCount:      row.RequestCount,
+			ByteCount:         row.ByteCount,
+			UniqueDomainCount: row.UniqueDomainCount,
+			WindowStart:       row.WindowStart,
+			MaxRequests:       row.MaxRequests,
+			MaxBytes:          row.MaxBytes,
+			MaxUniqueDomains:  row.MaxUniqueDomains,
+			WindowMinutes:     row.WindowMinutes,
+		})
+	}
+	return out, nil
+}
+
+func (s *snapshotBudgetSource) BudgetFreshness() (BudgetSnapshotFreshness, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.freshness, s.hasFresh
+}
+
+func (s *snapshotBudgetSource) storeFreshness(fresh runtimesnapshot.Freshness) {
+	if fresh.ProducedAt.IsZero() {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.freshness = BudgetSnapshotFreshness{
+		ProducedAt: fresh.ProducedAt,
+		Age:        fresh.Age,
+		Stale:      fresh.Stale,
+	}
+	s.hasFresh = true
+}
+
+func budgetUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var unavailable budgetSourceUnavailable
+	if errors.As(err, &unavailable) {
+		return unavailable.BudgetSourceUnavailable()
+	}
+	return false
+}

--- a/enterprise/dashboard/snapshot_budget_source_test.go
+++ b/enterprise/dashboard/snapshot_budget_source_test.go
@@ -1,0 +1,137 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/dashboard/runtimesnapshot"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+func TestSnapshotBudgetSourceMapsForwardRows(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "dashboard", "runtime-snapshot.json")
+	if err := runtimesnapshot.Write(path, runtimesnapshot.Envelope{
+		Version:    runtimesnapshot.Version,
+		ProducedAt: now,
+		ProducerID: "producer-1",
+		Budgets: []runtimesnapshot.AgentBudgetRow{{
+			Agent:             "agent-alpha",
+			RequestCount:      7,
+			ByteCount:         4096,
+			UniqueDomainCount: 2,
+			WindowStart:       now.Add(-time.Hour),
+			MaxRequests:       100,
+			MaxBytes:          1 << 20,
+			MaxUniqueDomains:  10,
+			WindowMinutes:     60,
+		}},
+	}); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	source := &snapshotBudgetSource{path: path, maxAge: time.Minute, now: func() time.Time { return now.Add(5 * time.Second) }}
+	rows, err := source.AllAgentBudgets(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("AllAgentBudgets: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.Agent != "agent-alpha" || !row.ForwardConfigured || row.RequestCount != 7 || row.UniqueDomainCount != 2 {
+		t.Fatalf("unexpected mapped row: %+v", row)
+	}
+	if row.DoWConfigured || row.ActiveSessions != 0 || len(row.Sessions) != 0 {
+		t.Fatalf("DoW fields should stay empty in this PR: %+v", row)
+	}
+	fresh, ok := source.BudgetFreshness()
+	if !ok || fresh.ProducedAt != now || fresh.Stale {
+		t.Fatalf("freshness = %+v ok=%v, want produced_at and stale=false", fresh, ok)
+	}
+}
+
+func TestReadModelBudgetsSnapshotUnavailableRendersHonestState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "runtime-snapshot.json")
+	if err := runtimesnapshot.Write(path, runtimesnapshot.Envelope{
+		Version:    runtimesnapshot.Version,
+		ProducedAt: now.Add(-time.Minute),
+		ProducerID: "producer-1",
+	}); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	source := &snapshotBudgetSource{path: path, maxAge: 10 * time.Second, now: func() time.Time { return now }}
+	model := NewReadModel(Options{BudgetSource: source})
+
+	overview, err := model.Budgets(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Budgets: %v", err)
+	}
+	if !overview.SourceConfigured || !overview.SourceUnavailable {
+		t.Fatalf("overview source state = configured:%v unavailable:%v, want true/true", overview.SourceConfigured, overview.SourceUnavailable)
+	}
+	if len(overview.Agents) != 0 {
+		t.Fatalf("agents = %d, want 0 for unavailable source", len(overview.Agents))
+	}
+	if !overview.HasSnapshotFreshness || !overview.SnapshotFreshness.Stale {
+		t.Fatalf("freshness = %+v has=%v, want stale freshness", overview.SnapshotFreshness, overview.HasSnapshotFreshness)
+	}
+}
+
+func TestBudgetsHandlerSnapshotUnavailableRendersMessage(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "runtime-snapshot.json")
+	if err := runtimesnapshot.Write(path, runtimesnapshot.Envelope{
+		Version:    runtimesnapshot.Version,
+		ProducedAt: now.Add(-time.Minute),
+		ProducerID: "producer-1",
+	}); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	source := &snapshotBudgetSource{path: path, maxAge: 10 * time.Second, now: func() time.Time { return now }}
+	handler := New(Options{
+		ReceiptDir:   t.TempDir(),
+		HasFeature:   func(f string) bool { return f == license.FeatureAgents },
+		BudgetSource: source,
+		AuthorizeRaw: allowRawAccess,
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/budgets", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Budget snapshot source unavailable") || !strings.Contains(body, "stale") {
+		t.Fatalf("body did not render unavailable freshness state: %s", body)
+	}
+}
+
+func TestSnapshotBudgetSourceMissingFileUnavailable(t *testing.T) {
+	t.Parallel()
+
+	source := NewSnapshotBudgetSource(filepath.Join(t.TempDir(), "missing.json"), time.Minute)
+	_, err := source.AllAgentBudgets(context.Background(), 10)
+	if err == nil || !budgetUnavailable(err) {
+		t.Fatalf("AllAgentBudgets error = %v, want source unavailable", err)
+	}
+	if strings.Contains(err.Error(), "missing.json") {
+		t.Fatalf("unavailable error leaked path through Error(): %q", err.Error())
+	}
+}

--- a/enterprise/dashboard/snapshot_budget_source_test.go
+++ b/enterprise/dashboard/snapshot_budget_source_test.go
@@ -6,6 +6,7 @@ package dashboard
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -133,5 +134,50 @@ func TestSnapshotBudgetSourceMissingFileUnavailable(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "missing.json") {
 		t.Fatalf("unavailable error leaked path through Error(): %q", err.Error())
+	}
+}
+
+func TestSnapshotBudgetSourceHelpersAndLimit(t *testing.T) {
+	t.Parallel()
+
+	if got := NewSnapshotBudgetSource("", time.Minute); got != nil {
+		t.Fatalf("NewSnapshotBudgetSource(empty) = %T, want nil", got)
+	}
+	if budgetUnavailable(nil) {
+		t.Fatal("budgetUnavailable(nil) = true")
+	}
+	if budgetUnavailable(errors.New("ordinary error")) {
+		t.Fatal("ordinary error marked unavailable")
+	}
+	if got := (BudgetSnapshotFreshness{Age: -time.Second}).AgeDisplay(); got != budgetEmptyDash {
+		t.Fatalf("negative freshness age display = %q, want %q", got, budgetEmptyDash)
+	}
+
+	now := time.Now().UTC()
+	path := filepath.Join(t.TempDir(), "runtime-snapshot.json")
+	if err := runtimesnapshot.Write(path, runtimesnapshot.Envelope{
+		ProducedAt: now,
+		Budgets: []runtimesnapshot.AgentBudgetRow{
+			{Agent: "alpha"},
+			{Agent: "bravo"},
+		},
+	}); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	source, ok := NewSnapshotBudgetSource(path, time.Minute).(*snapshotBudgetSource)
+	if !ok {
+		t.Fatal("NewSnapshotBudgetSource returned unexpected implementation")
+	}
+	rows, err := source.AllAgentBudgets(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("AllAgentBudgets: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Agent != "alpha" {
+		t.Fatalf("limited rows = %+v", rows)
+	}
+
+	wrapped := snapshotBudgetUnavailableError{err: errors.New("root cause")}
+	if wrapped.Error() != "runtime snapshot budget source unavailable" || wrapped.Unwrap() == nil || !wrapped.BudgetSourceUnavailable() {
+		t.Fatalf("unavailable wrapper contract failed: %+v", wrapped)
 	}
 }

--- a/enterprise/edition.go
+++ b/enterprise/edition.go
@@ -7,6 +7,7 @@ package enterprise
 import (
 	"context"
 	"net/http"
+	"sort"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
@@ -79,6 +80,44 @@ func (e *enterpriseEdition) KnownProfiles() map[string]bool {
 		m[name] = true
 	}
 	return m
+}
+
+// defaultAgentBudgetSnapshotLimit caps how many per-agent budget snapshots are
+// returned when the caller passes a non-positive limit, bounding output
+// cardinality for the read-only observability surface.
+const defaultAgentBudgetSnapshotLimit = 1000
+
+// AgentBudgetSnapshots implements edition.AgentBudgetSnapshotProvider. It walks
+// configured profiles and returns a read-only, point-in-time forward-budget
+// snapshot for each agent whose budget tracker exposes one. NoopBudget does not
+// implement edition.BudgetSnapshotProvider, so agents without a configured
+// forward budget are omitted. It never mutates budget or enforcement state.
+// Profiles are sorted for deterministic output and bounded by limit.
+func (e *enterpriseEdition) AgentBudgetSnapshots(_ context.Context, limit int) ([]edition.AgentBudgetSnapshot, error) {
+	if limit <= 0 {
+		limit = defaultAgentBudgetSnapshotLimit
+	}
+	names := append([]string(nil), e.registry.Profiles()...)
+	sort.Strings(names)
+	out := make([]edition.AgentBudgetSnapshot, 0, len(names))
+	for _, name := range names {
+		if len(out) >= limit {
+			break
+		}
+		ra := e.registry.Lookup(name)
+		if ra == nil {
+			continue
+		}
+		sp, ok := ra.Budget.(edition.BudgetSnapshotProvider)
+		if !ok {
+			continue
+		}
+		out = append(out, edition.AgentBudgetSnapshot{
+			Agent:          name,
+			BudgetSnapshot: sp.Snapshot(),
+		})
+	}
+	return out, nil
 }
 
 // Ports returns address->profile mappings for per-agent listeners.

--- a/enterprise/edition_test.go
+++ b/enterprise/edition_test.go
@@ -326,3 +326,58 @@ func TestEnterpriseEdition_Close(t *testing.T) {
 	ed.Close()
 	ed.Close() // idempotent
 }
+
+func TestEnterpriseEditionAgentBudgetSnapshots(t *testing.T) {
+	cfg := testConfig()
+	cfg.Agents = map[string]config.AgentProfile{
+		"zulu": {
+			Budget: config.BudgetConfig{MaxRequestsPerSession: 5, WindowMinutes: 60},
+		},
+		"alpha": {
+			Budget: config.BudgetConfig{MaxBytesPerSession: 1000, WindowMinutes: 60},
+		},
+		"unlimited": {},
+	}
+	sc := scanner.New(cfg)
+	defer sc.Close()
+
+	ed, err := NewEdition(cfg, sc)
+	if err != nil {
+		t.Fatalf("NewEdition: %v", err)
+	}
+	defer ed.Close()
+
+	alpha, found := ed.LookupProfile("alpha")
+	if !found {
+		t.Fatal("alpha profile not found")
+	}
+	if err := alpha.Budget.RecordRequest(testDomainA, testByteSize); err != nil {
+		t.Fatalf("record alpha budget: %v", err)
+	}
+
+	provider, ok := ed.(edition.AgentBudgetSnapshotProvider)
+	if !ok {
+		t.Fatal("enterprise edition does not implement AgentBudgetSnapshotProvider")
+	}
+	all, err := provider.AgentBudgetSnapshots(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("AgentBudgetSnapshots(default limit): %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("snapshots = %+v, want two budgeted agents", all)
+	}
+	if all[0].Agent != "alpha" || all[1].Agent != "zulu" {
+		t.Fatalf("snapshot order = [%s %s], want [alpha zulu]", all[0].Agent, all[1].Agent)
+	}
+	if all[0].RequestCount != 1 || all[0].ByteCount != testByteSize {
+		t.Fatalf("alpha snapshot = %+v", all[0])
+	}
+
+	bounded, err := provider.AgentBudgetSnapshots(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("AgentBudgetSnapshots(limit 1): %v", err)
+	}
+	if len(bounded) != 1 || bounded[0].Agent != "alpha" {
+		t.Fatalf("bounded snapshots = %+v, want alpha only", bounded)
+	}
+}

--- a/internal/cli/runtime/dashboard_snapshot.go
+++ b/internal/cli/runtime/dashboard_snapshot.go
@@ -9,16 +9,18 @@ import (
 	"sync"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/proxy"
 )
 
 type dashboardRuntimeSnapshotOptions struct {
-	Context       context.Context
-	WaitGroup     *sync.WaitGroup
-	Proxy         *proxy.Proxy
-	StartupConfig *config.Config
-	CurrentConfig func() *config.Config
-	Stderr        io.Writer
+	Context        context.Context
+	WaitGroup      *sync.WaitGroup
+	Proxy          *proxy.Proxy
+	BudgetProvider edition.AgentBudgetSnapshotProvider
+	StartupConfig  *config.Config
+	CurrentConfig  func() *config.Config
+	Stderr         io.Writer
 }
 
 var startDashboardRuntimeSnapshotHook func(dashboardRuntimeSnapshotOptions)

--- a/internal/cli/runtime/dashboard_snapshot.go
+++ b/internal/cli/runtime/dashboard_snapshot.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+)
+
+type dashboardRuntimeSnapshotOptions struct {
+	Context       context.Context
+	WaitGroup     *sync.WaitGroup
+	Proxy         *proxy.Proxy
+	StartupConfig *config.Config
+	CurrentConfig func() *config.Config
+	Stderr        io.Writer
+}
+
+var startDashboardRuntimeSnapshotHook func(dashboardRuntimeSnapshotOptions)
+
+func (s *Server) startDashboardRuntimeSnapshot(ctx context.Context, wg *sync.WaitGroup, cfg *config.Config) {
+	if startDashboardRuntimeSnapshotHook == nil {
+		return
+	}
+	startDashboardRuntimeSnapshotHook(dashboardRuntimeSnapshotOptions{
+		Context:       ctx,
+		WaitGroup:     wg,
+		Proxy:         s.proxy,
+		StartupConfig: cfg,
+		CurrentConfig: s.currentConfig,
+		Stderr:        s.opts.Stderr,
+	})
+}

--- a/internal/cli/runtime/dashboard_snapshot_enterprise.go
+++ b/internal/cli/runtime/dashboard_snapshot_enterprise.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 func startDashboardRuntimeSnapshotEnterprise(opts dashboardRuntimeSnapshotOptions) {
-	if opts.Context == nil || opts.WaitGroup == nil || opts.Proxy == nil || opts.StartupConfig == nil {
+	if opts.Context == nil || opts.WaitGroup == nil || opts.StartupConfig == nil {
 		return
 	}
 	cfg := opts.StartupConfig
@@ -30,7 +30,7 @@ func startDashboardRuntimeSnapshotEnterprise(opts dashboardRuntimeSnapshotOption
 		return
 	}
 	interval := cfg.DashboardSnapshot.IntervalDuration()
-	if _, ok := opts.Proxy.Edition().(edition.AgentBudgetSnapshotProvider); !ok {
+	if dashboardRuntimeSnapshotProvider(opts) == nil {
 		return
 	}
 
@@ -53,8 +53,8 @@ func startDashboardRuntimeSnapshotEnterprise(opts dashboardRuntimeSnapshotOption
 }
 
 func writeDashboardRuntimeSnapshotTick(opts dashboardRuntimeSnapshotOptions, path, producerID string) {
-	provider, ok := opts.Proxy.Edition().(edition.AgentBudgetSnapshotProvider)
-	if !ok {
+	provider := dashboardRuntimeSnapshotProvider(opts)
+	if provider == nil {
 		return
 	}
 	policyHash := ""
@@ -72,6 +72,17 @@ func writeDashboardRuntimeSnapshotTick(opts dashboardRuntimeSnapshotOptions, pat
 	if err := runtimesnapshot.Write(path, snap); err != nil {
 		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: dashboard runtime snapshot write failed: %v\n", err)
 	}
+}
+
+func dashboardRuntimeSnapshotProvider(opts dashboardRuntimeSnapshotOptions) edition.AgentBudgetSnapshotProvider {
+	if opts.BudgetProvider != nil {
+		return opts.BudgetProvider
+	}
+	if opts.Proxy == nil {
+		return nil
+	}
+	provider, _ := opts.Proxy.Edition().(edition.AgentBudgetSnapshotProvider)
+	return provider
 }
 
 func buildDashboardRuntimeSnapshot(

--- a/internal/cli/runtime/dashboard_snapshot_enterprise.go
+++ b/internal/cli/runtime/dashboard_snapshot_enterprise.go
@@ -1,0 +1,93 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/dashboard/runtimesnapshot"
+	"github.com/luckyPipewrench/pipelock/internal/edition"
+)
+
+func init() {
+	startDashboardRuntimeSnapshotHook = startDashboardRuntimeSnapshotEnterprise
+}
+
+func startDashboardRuntimeSnapshotEnterprise(opts dashboardRuntimeSnapshotOptions) {
+	if opts.Context == nil || opts.WaitGroup == nil || opts.Proxy == nil || opts.StartupConfig == nil {
+		return
+	}
+	cfg := opts.StartupConfig
+	if !cfg.DashboardSnapshot.EnabledWithRecorderDir(cfg.FlightRecorder.Dir) {
+		return
+	}
+	path := cfg.DashboardSnapshot.PathWithRecorderDir(cfg.FlightRecorder.Dir)
+	if path == "" {
+		return
+	}
+	interval := cfg.DashboardSnapshot.IntervalDuration()
+	if _, ok := opts.Proxy.Edition().(edition.AgentBudgetSnapshotProvider); !ok {
+		return
+	}
+
+	producerID := dashboardRuntimeSnapshotProducerID()
+	opts.WaitGroup.Add(1)
+	go func() {
+		defer opts.WaitGroup.Done()
+		writeDashboardRuntimeSnapshotTick(opts, path, producerID)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-opts.Context.Done():
+				return
+			case <-ticker.C:
+				writeDashboardRuntimeSnapshotTick(opts, path, producerID)
+			}
+		}
+	}()
+}
+
+func writeDashboardRuntimeSnapshotTick(opts dashboardRuntimeSnapshotOptions, path, producerID string) {
+	provider, ok := opts.Proxy.Edition().(edition.AgentBudgetSnapshotProvider)
+	if !ok {
+		return
+	}
+	policyHash := ""
+	if opts.CurrentConfig != nil {
+		cfg := opts.CurrentConfig()
+		if cfg != nil {
+			policyHash = cfg.CanonicalPolicyHash()
+		}
+	}
+	snap, err := buildDashboardRuntimeSnapshot(opts.Context, provider, time.Now().UTC(), producerID, policyHash)
+	if err != nil {
+		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: dashboard runtime snapshot unavailable: %v\n", err)
+		return
+	}
+	if err := runtimesnapshot.Write(path, snap); err != nil {
+		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: dashboard runtime snapshot write failed: %v\n", err)
+	}
+}
+
+func buildDashboardRuntimeSnapshot(
+	ctx context.Context,
+	provider edition.AgentBudgetSnapshotProvider,
+	now time.Time,
+	producerID string,
+	policyHash string,
+) (runtimesnapshot.Envelope, error) {
+	budgets, err := provider.AgentBudgetSnapshots(ctx, runtimesnapshot.MaxBudgetRows+1)
+	if err != nil {
+		return runtimesnapshot.Envelope{}, fmt.Errorf("read agent budget snapshots: %w", err)
+	}
+	return runtimesnapshot.NewEnvelope(now, producerID, policyHash, budgets), nil
+}
+
+func dashboardRuntimeSnapshotProducerID() string {
+	return "pipelock-run"
+}

--- a/internal/cli/runtime/dashboard_snapshot_enterprise_test.go
+++ b/internal/cli/runtime/dashboard_snapshot_enterprise_test.go
@@ -1,0 +1,127 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/dashboard/runtimesnapshot"
+	"github.com/luckyPipewrench/pipelock/internal/edition"
+)
+
+type fakeAgentBudgetSnapshotProvider struct {
+	snaps []edition.AgentBudgetSnapshot
+	err   error
+	limit int
+}
+
+func (f *fakeAgentBudgetSnapshotProvider) AgentBudgetSnapshots(_ context.Context, limit int) ([]edition.AgentBudgetSnapshot, error) {
+	f.limit = limit
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.snaps, nil
+}
+
+func TestBuildDashboardRuntimeSnapshotMapsAndBoundsBudgets(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	provider := &fakeAgentBudgetSnapshotProvider{snaps: []edition.AgentBudgetSnapshot{{
+		Agent: "agent-alpha",
+		BudgetSnapshot: edition.BudgetSnapshot{
+			RequestCount:      3,
+			ByteCount:         99,
+			UniqueDomainCount: 2,
+			WindowStart:       now.Add(-time.Hour),
+			MaxRequests:       10,
+			MaxBytes:          1000,
+			MaxUniqueDomains:  4,
+			WindowMinutes:     60,
+		},
+	}}}
+
+	snap, err := buildDashboardRuntimeSnapshot(context.Background(), provider, now, "producer-1", "policy-1")
+	if err != nil {
+		t.Fatalf("buildDashboardRuntimeSnapshot: %v", err)
+	}
+	if provider.limit != runtimesnapshot.MaxBudgetRows+1 {
+		t.Fatalf("provider limit = %d, want %d", provider.limit, runtimesnapshot.MaxBudgetRows+1)
+	}
+	if snap.Version != runtimesnapshot.Version || snap.ProducerID != "producer-1" || snap.PolicyHash != "policy-1" {
+		t.Fatalf("unexpected metadata: %+v", snap)
+	}
+	if len(snap.Budgets) != 1 || snap.Budgets[0].Agent != "agent-alpha" || snap.Budgets[0].ByteCount != 99 {
+		t.Fatalf("unexpected budget rows: %+v", snap.Budgets)
+	}
+	if snap.Truncated.Budgets {
+		t.Fatal("Truncated.Budgets = true, want false")
+	}
+}
+
+func TestBuildDashboardRuntimeSnapshotDoesNotPersistHostProducerMetadata(t *testing.T) {
+	t.Parallel()
+
+	snap, err := buildDashboardRuntimeSnapshot(
+		context.Background(),
+		&fakeAgentBudgetSnapshotProvider{},
+		time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC),
+		dashboardRuntimeSnapshotProducerID(),
+		"",
+	)
+	if err != nil {
+		t.Fatalf("buildDashboardRuntimeSnapshot: %v", err)
+	}
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	host, _ := os.Hostname()
+	body := string(data)
+	if host != "" && strings.Contains(body, host) {
+		t.Fatalf("snapshot persisted hostname metadata: %s", body)
+	}
+	if strings.Contains(body, strconv.Itoa(os.Getpid())) {
+		t.Fatalf("snapshot persisted process id metadata: %s", body)
+	}
+}
+
+func TestBuildDashboardRuntimeSnapshotTruncatesOverLimit(t *testing.T) {
+	t.Parallel()
+
+	snaps := make([]edition.AgentBudgetSnapshot, 0, runtimesnapshot.MaxBudgetRows+1)
+	for i := 0; i <= runtimesnapshot.MaxBudgetRows; i++ {
+		snaps = append(snaps, edition.AgentBudgetSnapshot{Agent: "agent"})
+	}
+	provider := &fakeAgentBudgetSnapshotProvider{snaps: snaps}
+
+	snap, err := buildDashboardRuntimeSnapshot(context.Background(), provider, time.Now(), "producer-1", "")
+	if err != nil {
+		t.Fatalf("buildDashboardRuntimeSnapshot: %v", err)
+	}
+	if len(snap.Budgets) != runtimesnapshot.MaxBudgetRows {
+		t.Fatalf("budget rows = %d, want %d", len(snap.Budgets), runtimesnapshot.MaxBudgetRows)
+	}
+	if !snap.Truncated.Budgets {
+		t.Fatal("Truncated.Budgets = false, want true")
+	}
+}
+
+func TestBuildDashboardRuntimeSnapshotPropagatesProviderError(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("provider unavailable")
+	_, err := buildDashboardRuntimeSnapshot(context.Background(), &fakeAgentBudgetSnapshotProvider{err: want}, time.Now(), "producer-1", "")
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want provider error", err)
+	}
+}

--- a/internal/cli/runtime/dashboard_snapshot_enterprise_test.go
+++ b/internal/cli/runtime/dashboard_snapshot_enterprise_test.go
@@ -9,12 +9,15 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/dashboard/runtimesnapshot"
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
 )
 
@@ -123,5 +126,115 @@ func TestBuildDashboardRuntimeSnapshotPropagatesProviderError(t *testing.T) {
 	_, err := buildDashboardRuntimeSnapshot(context.Background(), &fakeAgentBudgetSnapshotProvider{err: want}, time.Now(), "producer-1", "")
 	if !errors.Is(err, want) {
 		t.Fatalf("error = %v, want provider error", err)
+	}
+}
+
+func TestStartDashboardRuntimeSnapshotEnterpriseWritesAndStops(t *testing.T) {
+	cfg := config.Defaults()
+	enabled := true
+	cfg.DashboardSnapshot.Enabled = &enabled
+	cfg.DashboardSnapshot.Path = filepath.Join(t.TempDir(), "dashboard", "runtime-snapshot.json")
+	cfg.DashboardSnapshot.Interval = "1s"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	var stderr strings.Builder
+	startDashboardRuntimeSnapshotEnterprise(dashboardRuntimeSnapshotOptions{
+		Context:        ctx,
+		WaitGroup:      &wg,
+		BudgetProvider: &fakeAgentBudgetSnapshotProvider{},
+		StartupConfig:  cfg,
+		CurrentConfig:  func() *config.Config { return cfg },
+		Stderr:         &stderr,
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(cfg.DashboardSnapshot.Path); err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat runtime snapshot: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("runtime snapshot was not written; stderr=%q", stderr.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// Let the ticker fire once so the periodic lane is covered in addition to
+	// the immediate startup write.
+	time.Sleep(1100 * time.Millisecond)
+	cancel()
+	wg.Wait()
+
+	snap, _, err := runtimesnapshot.Read(cfg.DashboardSnapshot.Path, time.Minute, time.Now())
+	if err != nil {
+		t.Fatalf("Read runtime snapshot: %v", err)
+	}
+	if snap.ProducerID != dashboardRuntimeSnapshotProducerID() {
+		t.Fatalf("producer ID = %q", snap.ProducerID)
+	}
+	if snap.PolicyHash != cfg.CanonicalPolicyHash() {
+		t.Fatalf("policy hash = %q, want current config hash", snap.PolicyHash)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestStartDashboardRuntimeSnapshotEnterpriseGuards(t *testing.T) {
+	t.Parallel()
+
+	startDashboardRuntimeSnapshotEnterprise(dashboardRuntimeSnapshotOptions{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var wg sync.WaitGroup
+	cfg := config.Defaults()
+	startDashboardRuntimeSnapshotEnterprise(dashboardRuntimeSnapshotOptions{
+		Context:       ctx,
+		WaitGroup:     &wg,
+		StartupConfig: cfg,
+	})
+	wg.Wait()
+
+	enabled := true
+	cfg.DashboardSnapshot.Enabled = &enabled
+	cfg.DashboardSnapshot.Path = ""
+	startDashboardRuntimeSnapshotEnterprise(dashboardRuntimeSnapshotOptions{
+		Context:        context.Background(),
+		WaitGroup:      &wg,
+		StartupConfig:  cfg,
+		BudgetProvider: &fakeAgentBudgetSnapshotProvider{},
+	})
+	wg.Wait()
+
+	writeDashboardRuntimeSnapshotTick(dashboardRuntimeSnapshotOptions{}, filepath.Join(t.TempDir(), "unused.json"), "producer")
+}
+
+func TestWriteDashboardRuntimeSnapshotTickReportsWriteFailure(t *testing.T) {
+	var stderr strings.Builder
+	path := t.TempDir()
+	writeDashboardRuntimeSnapshotTick(dashboardRuntimeSnapshotOptions{
+		Context:        context.Background(),
+		BudgetProvider: &fakeAgentBudgetSnapshotProvider{},
+		CurrentConfig:  func() *config.Config { return nil },
+		Stderr:         &stderr,
+	}, path, "producer")
+	if !strings.Contains(stderr.String(), "dashboard runtime snapshot write failed") {
+		t.Fatalf("stderr = %q, want write failure", stderr.String())
+	}
+}
+
+func TestWriteDashboardRuntimeSnapshotTickReportsProviderFailure(t *testing.T) {
+	var stderr strings.Builder
+	writeDashboardRuntimeSnapshotTick(dashboardRuntimeSnapshotOptions{
+		Context: context.Background(),
+		BudgetProvider: &fakeAgentBudgetSnapshotProvider{
+			err: errors.New("provider unavailable"),
+		},
+		Stderr: &stderr,
+	}, filepath.Join(t.TempDir(), "runtime-snapshot.json"), "producer")
+	if !strings.Contains(stderr.String(), "dashboard runtime snapshot unavailable") {
+		t.Fatalf("stderr = %q, want provider failure", stderr.String())
 	}
 }

--- a/internal/cli/runtime/dashboard_snapshot_enterprise_test.go
+++ b/internal/cli/runtime/dashboard_snapshot_enterprise_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/enterprise/dashboard/runtimesnapshot"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 type fakeAgentBudgetSnapshotProvider struct {
@@ -148,21 +149,14 @@ func TestStartDashboardRuntimeSnapshotEnterpriseWritesAndStops(t *testing.T) {
 		Stderr:         &stderr,
 	})
 
-	deadline := time.Now().Add(2 * time.Second)
-	for {
+	testwait.For(t, 2*time.Second, func() bool {
 		if _, err := os.Stat(cfg.DashboardSnapshot.Path); err == nil {
-			break
+			return true
 		} else if !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("stat runtime snapshot: %v", err)
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("runtime snapshot was not written; stderr=%q", stderr.String())
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	// Let the ticker fire once so the periodic lane is covered in addition to
-	// the immediate startup write.
-	time.Sleep(1100 * time.Millisecond)
+		return false
+	}, "runtime snapshot to be written; stderr=%s", stderr.String())
 	cancel()
 	wg.Wait()
 

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -355,6 +355,7 @@ func (s *Server) Start(ctx context.Context) error {
 	if cfg.FlightRecorder.EvidenceHealthEnabled() && s.recorder != nil && s.metrics != nil {
 		newEvidenceHealthMonitor(s.recorder, s.metrics, s.liveReceiptEmitter, s.currentConfig, s.opts.Stderr).start(ctx, &lifecycleWG)
 	}
+	s.startDashboardRuntimeSnapshot(ctx, &lifecycleWG, cfg)
 	stopFileSentry, fsErr := s.startFileSentry(ctx, cfg, cancel)
 	if fsErr != nil {
 		return fsErr

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -152,6 +152,10 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: file_sentry settings changed — watcher cannot rebind at runtime, ignoring (restart required)\n")
 			newCfg.FileSentry = oldCfg.FileSentry
 		}
+		if !reflect.DeepEqual(oldCfg.DashboardSnapshot, newCfg.DashboardSnapshot) {
+			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: dashboard_snapshot settings changed — writer is built at startup and cannot rebind at runtime, ignoring (restart required)\n")
+			newCfg.DashboardSnapshot = oldCfg.DashboardSnapshot
+		}
 
 		// Dedupe identical-hash reload EVENTS within a short window.
 		// fsnotify + SIGHUP stack up so a single `echo cfg > path;

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1680,6 +1680,8 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	oldCfg.Conductor.ConductorURL = "https://boss-old.example"
 	oldCfg.FileSentry.Enabled = true
 	oldCfg.FileSentry.Action = config.ActionWarn
+	oldCfg.DashboardSnapshot.Path = "/tmp/old-runtime-snapshot.json"
+	oldCfg.DashboardSnapshot.Interval = "10s"
 
 	newCfg := oldCfg.Clone()
 	newCfg.FetchProxy.Listen = "127.0.0.1:28079"
@@ -1692,6 +1694,8 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	newCfg.FlightRecorder.RequireReceipts = true
 	newCfg.Conductor.ConductorURL = "https://boss-new.example"
 	newCfg.FileSentry.Action = config.ActionBlock // file_sentry is restart-only; this change must be ignored
+	newCfg.DashboardSnapshot.Path = "/tmp/new-runtime-snapshot.json"
+	newCfg.DashboardSnapshot.Interval = "2s"
 	newCfg.ReverseProxy.Listen = "127.0.0.1:28084"
 	newCfg.ReverseProxy.Upstream = "http://127.0.0.1:2"
 
@@ -1724,6 +1728,9 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	}
 	if !reflect.DeepEqual(live.FileSentry, oldCfg.FileSentry) {
 		t.Fatalf("file_sentry settings not preserved (watcher cannot rebind at runtime): %+v", live.FileSentry)
+	}
+	if !reflect.DeepEqual(live.DashboardSnapshot, oldCfg.DashboardSnapshot) {
+		t.Fatalf("dashboard_snapshot settings not preserved (writer cannot rebind at runtime): %+v", live.DashboardSnapshot)
 	}
 	if !reflect.DeepEqual(live.ReverseProxy, oldCfg.ReverseProxy) {
 		t.Fatalf("reverse proxy settings not preserved: %+v", live.ReverseProxy)

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1744,6 +1744,7 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 		"flight_recorder.signing_key_path changed",
 		"reverse_proxy settings changed",
 		"file_sentry settings changed",
+		"dashboard_snapshot settings changed",
 	} {
 		if !buf.contains(want) {
 			t.Fatalf("stderr missing %q:\n%s", want, buf.String())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10657,6 +10657,125 @@ func TestLoad_FlightRecorderDefaults(t *testing.T) {
 	}
 }
 
+func TestLoad_DashboardSnapshotDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dash-snapshot.yaml")
+	content := "mode: balanced\nflight_recorder:\n  enabled: true\n  dir: " + filepath.Join(dir, "recorder") + "\n"
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if !cfg.DashboardSnapshot.EnabledWithRecorderDir(cfg.FlightRecorder.Dir) {
+		t.Fatal("dashboard snapshot should default enabled when flight_recorder.dir is set")
+	}
+	if got := cfg.DashboardSnapshot.PathWithRecorderDir(cfg.FlightRecorder.Dir); got != filepath.Join(cfg.FlightRecorder.Dir, "dashboard", "runtime-snapshot.json") {
+		t.Fatalf("snapshot path = %q, want derived recorder path", got)
+	}
+	if got := cfg.DashboardSnapshot.IntervalDuration(); got != DefaultDashboardSnapshotInterval {
+		t.Fatalf("snapshot interval = %s, want %s", got, DefaultDashboardSnapshotInterval)
+	}
+}
+
+func TestLoad_DashboardSnapshotEnabledStates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		section string
+		want    bool
+	}{
+		{name: "omitted", section: "", want: true},
+		{name: "key_null", section: "dashboard_snapshot:\n  enabled:\n", want: true},
+		{name: "key_blank", section: "dashboard_snapshot:\n  enabled: \n", want: true},
+		{name: "explicit_false", section: "dashboard_snapshot:\n  enabled: false\n", want: false},
+		{name: "explicit_true", section: "dashboard_snapshot:\n  enabled: true\n", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "cfg.yaml")
+			content := "mode: balanced\nflight_recorder:\n  dir: " + filepath.Join(dir, "recorder") + "\n" + tt.section
+			if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(cfgPath)
+			if err != nil {
+				t.Fatalf("Load() error: %v", err)
+			}
+			if got := cfg.DashboardSnapshot.EnabledWithRecorderDir(cfg.FlightRecorder.Dir); got != tt.want {
+				t.Fatalf("EnabledWithRecorderDir() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateDashboardSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{
+			name: "invalid_interval",
+			mutate: func(c *Config) {
+				c.DashboardSnapshot.Interval = "soon"
+			},
+			wantErr: "dashboard_snapshot.interval must parse as a duration",
+		},
+		{
+			name: "subsecond_interval",
+			mutate: func(c *Config) {
+				c.DashboardSnapshot.Interval = "500ms"
+			},
+			wantErr: "dashboard_snapshot.interval must be >= 1s",
+		},
+		{
+			name: "explicit_enabled_without_path",
+			mutate: func(c *Config) {
+				c.FlightRecorder.Dir = ""
+				c.DashboardSnapshot.Enabled = ptrBool(true)
+				c.DashboardSnapshot.Path = ""
+			},
+			wantErr: "dashboard_snapshot.path is required",
+		},
+		{
+			name: "explicit_disabled_without_path",
+			mutate: func(c *Config) {
+				c.FlightRecorder.Dir = ""
+				c.DashboardSnapshot.Enabled = ptrBool(false)
+				c.DashboardSnapshot.Path = ""
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Defaults()
+			cfg.ApplyDefaults()
+			tt.mutate(cfg)
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want contains %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestLoad_FlightRecorderFileMode(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "fr-mode.yaml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10715,6 +10715,81 @@ func TestLoad_DashboardSnapshotEnabledStates(t *testing.T) {
 	}
 }
 
+func TestLoad_DashboardSnapshotImplicitlyDisabledWithoutRecorderDir(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		section string
+	}{
+		{name: "omitted", section: ""},
+		{name: "blank_enabled", section: "dashboard_snapshot:\n  enabled: \n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "cfg.yaml")
+			if err := os.WriteFile(path, []byte("mode: balanced\n"+tt.section), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.DashboardSnapshot.EnabledWithRecorderDir(cfg.FlightRecorder.Dir) {
+				t.Fatal("dashboard snapshot enabled without explicit opt-in or recorder dir")
+			}
+			if got := cfg.DashboardSnapshot.PathWithRecorderDir(cfg.FlightRecorder.Dir); got != "" {
+				t.Fatalf("derived path = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestDashboardSnapshotDerivedValues(t *testing.T) {
+	t.Parallel()
+
+	explicitPath := filepath.Join(t.TempDir(), "explicit.json")
+	dash := DashboardSnapshot{Path: explicitPath}
+	if got := dash.PathWithRecorderDir("/ignored/recorder"); got != explicitPath {
+		t.Fatalf("PathWithRecorderDir() = %q, want explicit %q", got, explicitPath)
+	}
+
+	for _, tt := range []struct {
+		name     string
+		interval string
+	}{
+		{name: "invalid", interval: "soon"},
+		{name: "subsecond", interval: "500ms"},
+		{name: "empty", interval: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := (DashboardSnapshot{Interval: tt.interval}).IntervalDuration(); got != DefaultDashboardSnapshotInterval {
+				t.Fatalf("IntervalDuration() = %s, want %s", got, DefaultDashboardSnapshotInterval)
+			}
+		})
+	}
+}
+
+func TestLoad_DashboardSnapshotTrimsInterval(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cfg.yaml")
+	content := "mode: balanced\ndashboard_snapshot:\n  enabled: false\n  interval: ' 10s '\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := cfg.DashboardSnapshot.IntervalDuration(); got != 10*time.Second {
+		t.Fatalf("IntervalDuration() = %s, want 10s", got)
+	}
+}
+
 func TestValidateDashboardSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -403,6 +403,9 @@ func Defaults() *Config {
 				MaxAnchorLag:      "24h",
 			},
 		},
+		DashboardSnapshot: DashboardSnapshot{
+			Interval: "10s",
+		},
 		MCPToolProvenance: MCPToolProvenance{
 			Action:      ActionWarn,
 			Mode:        ProvenanceModePipelock,

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -739,6 +739,9 @@ func (c *Config) ApplyDefaults() {
 	if c.FlightRecorder.EvidenceHealth.MaxAnchorLag == "" {
 		c.FlightRecorder.EvidenceHealth.MaxAnchorLag = "24h"
 	}
+	if c.DashboardSnapshot.Interval == "" {
+		c.DashboardSnapshot.Interval = "10s"
+	}
 
 	// MCP tool provenance defaults
 	if c.MCPToolProvenance.Enabled {

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -740,7 +740,7 @@ func (c *Config) ApplyDefaults() {
 		c.FlightRecorder.EvidenceHealth.MaxAnchorLag = "24h"
 	}
 	if c.DashboardSnapshot.Interval == "" {
-		c.DashboardSnapshot.Interval = "10s"
+		c.DashboardSnapshot.Interval = DefaultDashboardSnapshotInterval.String()
 	}
 
 	// MCP tool provenance defaults

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -548,6 +548,14 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 			Message: "health_watchdog config changes require restart — ignored on reload",
 		})
 	}
+	if !boolPtrEqual(old.DashboardSnapshot.Enabled, updated.DashboardSnapshot.Enabled) ||
+		old.DashboardSnapshot.Path != updated.DashboardSnapshot.Path ||
+		old.DashboardSnapshot.Interval != updated.DashboardSnapshot.Interval {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "dashboard_snapshot",
+			Message: "dashboard_snapshot config changes require restart — ignored on reload",
+		})
+	}
 
 	// Secrets file changed or removed (security-relevant)
 	if old.DLP.SecretsFile != updated.DLP.SecretsFile {

--- a/internal/config/reloadwarn_test.go
+++ b/internal/config/reloadwarn_test.go
@@ -175,6 +175,19 @@ func TestValidateReload_DashboardSnapshotChanged(t *testing.T) {
 	t.Fatal("expected dashboard_snapshot restart-only warning")
 }
 
+func TestValidateReload_DashboardSnapshotUnchanged_NoWarning(t *testing.T) {
+	t.Parallel()
+
+	old := Defaults()
+	updated := Defaults()
+
+	for _, w := range ValidateReload(old, updated) {
+		if w.Field == "dashboard_snapshot" {
+			t.Fatalf("unexpected dashboard_snapshot warning when config unchanged: %+v", w)
+		}
+	}
+}
+
 func TestValidateReload_QueryEntropyParamExclusionsAdded(t *testing.T) {
 	old := Defaults()
 	updated := Defaults()

--- a/internal/config/reloadwarn_test.go
+++ b/internal/config/reloadwarn_test.go
@@ -159,6 +159,22 @@ func TestValidateReload_ReverseProxyProfileUnchanged_NoWarning(t *testing.T) {
 	}
 }
 
+func TestValidateReload_DashboardSnapshotChanged(t *testing.T) {
+	t.Parallel()
+
+	old := Defaults()
+	updated := Defaults()
+	updated.DashboardSnapshot.Path = "/tmp/other-runtime-snapshot.json"
+
+	warnings := ValidateReload(old, updated)
+	for _, w := range warnings {
+		if w.Field == "dashboard_snapshot" {
+			return
+		}
+	}
+	t.Fatal("expected dashboard_snapshot restart-only warning")
+}
+
 func TestValidateReload_QueryEntropyParamExclusionsAdded(t *testing.T) {
 	old := Defaults()
 	updated := Defaults()

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -7,6 +7,7 @@ package config
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -415,6 +416,7 @@ type Config struct {
 	FileSentry               FileSentry              `yaml:"file_sentry"`
 	Sandbox                  Sandbox                 `yaml:"sandbox"`
 	FlightRecorder           FlightRecorder          `yaml:"flight_recorder"`
+	DashboardSnapshot        DashboardSnapshot       `yaml:"dashboard_snapshot" json:"-"` // operational dashboard read-model snapshot, excluded from canonical policy hash
 	MCPBinaryIntegrity       MCPBinaryIntegrity      `yaml:"mcp_binary_integrity"`
 	MCPToolProvenance        MCPToolProvenance       `yaml:"mcp_tool_provenance"`
 	BehavioralBaseline       BehavioralBaseline      `yaml:"behavioral_baseline"`
@@ -1446,6 +1448,7 @@ const (
 	DefaultFlightRecorderHeartbeatInterval = 60 * time.Second
 	DefaultEvidenceHealthSelfAuditInterval = 30 * time.Second
 	DefaultEvidenceHealthMaxAnchorLag      = 24 * time.Hour
+	DefaultDashboardSnapshotInterval       = 10 * time.Second
 )
 
 func (f FlightRecorder) HeartbeatIntervalDuration() time.Duration {
@@ -1498,6 +1501,45 @@ func (f FlightRecorder) EvidenceMaxAnchorLagDuration() time.Duration {
 		return DefaultEvidenceHealthMaxAnchorLag
 	}
 	return lag
+}
+
+// DashboardSnapshot configures the proxy-produced, read-only dashboard runtime
+// snapshot. The enabled pointer preserves three states: omitted means "write
+// when flight_recorder.dir is configured", explicit false disables it, and
+// explicit true writes to the configured or derived path.
+type DashboardSnapshot struct {
+	Enabled  *bool  `yaml:"enabled,omitempty"`
+	Path     string `yaml:"path,omitempty"`
+	Interval string `yaml:"interval,omitempty"`
+}
+
+func (d DashboardSnapshot) EnabledWithRecorderDir(recorderDir string) bool {
+	if d.Enabled != nil {
+		return *d.Enabled
+	}
+	return strings.TrimSpace(recorderDir) != ""
+}
+
+func (d DashboardSnapshot) PathWithRecorderDir(recorderDir string) string {
+	if strings.TrimSpace(d.Path) != "" {
+		return d.Path
+	}
+	if strings.TrimSpace(recorderDir) == "" {
+		return ""
+	}
+	return filepath.Join(recorderDir, "dashboard", "runtime-snapshot.json")
+}
+
+func (d DashboardSnapshot) IntervalDuration() time.Duration {
+	raw := strings.TrimSpace(d.Interval)
+	if raw == "" {
+		return DefaultDashboardSnapshotInterval
+	}
+	interval, err := time.ParseDuration(raw)
+	if err != nil || interval < time.Second {
+		return DefaultDashboardSnapshotInterval
+	}
+	return interval
 }
 
 // MediationEnvelope configures sideband metadata on proxied requests.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -322,6 +322,9 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateFlightRecorder(); err != nil {
 		return warnings, err
 	}
+	if err := c.validateDashboardSnapshot(); err != nil {
+		return warnings, err
+	}
 	if err := c.validateMCPBinaryIntegrity(); err != nil {
 		return warnings, err
 	}
@@ -3031,6 +3034,23 @@ func (c *Config) validateFlightRecorder() error {
 	}
 	if c.FlightRecorder.RawEscrow && c.FlightRecorder.EscrowPublicKey == "" {
 		return fmt.Errorf("flight_recorder.escrow_public_key is required when raw_escrow is enabled")
+	}
+	return nil
+}
+
+func (c *Config) validateDashboardSnapshot() error {
+	if strings.TrimSpace(c.DashboardSnapshot.Interval) != "" {
+		interval, err := time.ParseDuration(c.DashboardSnapshot.Interval)
+		if err != nil {
+			return fmt.Errorf("dashboard_snapshot.interval must parse as a duration: %w", err)
+		}
+		if interval < time.Second {
+			return fmt.Errorf("dashboard_snapshot.interval must be >= 1s")
+		}
+	}
+	if c.DashboardSnapshot.EnabledWithRecorderDir(c.FlightRecorder.Dir) &&
+		c.DashboardSnapshot.PathWithRecorderDir(c.FlightRecorder.Dir) == "" {
+		return fmt.Errorf("dashboard_snapshot.path is required when dashboard_snapshot.enabled is true and flight_recorder.dir is empty")
 	}
 	return nil
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3039,8 +3039,9 @@ func (c *Config) validateFlightRecorder() error {
 }
 
 func (c *Config) validateDashboardSnapshot() error {
-	if strings.TrimSpace(c.DashboardSnapshot.Interval) != "" {
-		interval, err := time.ParseDuration(c.DashboardSnapshot.Interval)
+	raw := strings.TrimSpace(c.DashboardSnapshot.Interval)
+	if raw != "" {
+		interval, err := time.ParseDuration(raw)
 		if err != nil {
 			return fmt.Errorf("dashboard_snapshot.interval must parse as a duration: %w", err)
 		}

--- a/internal/edition/edition.go
+++ b/internal/edition/edition.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
@@ -85,6 +86,50 @@ func (noopBudget) CheckAdmission(string) error       { return nil }
 func (noopBudget) RecordBytes(int64) error           { return nil }
 func (noopBudget) RecordRequest(string, int64) error { return nil }
 func (noopBudget) RemainingBytes() int64             { return -1 }
+
+// BudgetSnapshot is a read-only, point-in-time view of a per-agent budget
+// tracker's consumption and configured limits, for observability surfaces
+// such as the Pro dashboard. It never affects enforcement. Limit fields of 0
+// mean unlimited for that dimension.
+type BudgetSnapshot struct {
+	RequestCount      int
+	ByteCount         int64
+	UniqueDomainCount int
+	WindowStart       time.Time
+
+	MaxRequests      int
+	MaxBytes         int
+	MaxUniqueDomains int
+	WindowMinutes    int
+}
+
+// BudgetSnapshotProvider is an OPT-IN, read-only observability interface a
+// BudgetChecker may additionally implement to expose current consumption. It
+// is intentionally separate from BudgetChecker so the enforcement contract
+// stays minimal and NoopBudget (unlimited) simply does not implement it.
+// Callers must type-assert and degrade gracefully when the assertion fails.
+type BudgetSnapshotProvider interface {
+	Snapshot() BudgetSnapshot
+}
+
+// AgentBudgetSnapshot pairs an agent's display name with its point-in-time
+// forward-budget snapshot, for read-only observability surfaces such as the
+// Pro dashboard. It never affects enforcement.
+type AgentBudgetSnapshot struct {
+	Agent string
+	BudgetSnapshot
+}
+
+// AgentBudgetSnapshotProvider is an OPT-IN, read-only interface an Edition may
+// additionally implement to enumerate per-agent forward-budget snapshots for an
+// observability surface. It is intentionally separate from Edition so the core
+// Edition contract stays minimal and the noop edition simply does not implement
+// it; callers type-assert and degrade gracefully when the assertion fails.
+// limit bounds the number of agents returned; a limit <= 0 means the provider's
+// own safe default cap.
+type AgentBudgetSnapshotProvider interface {
+	AgentBudgetSnapshots(ctx context.Context, limit int) ([]AgentBudgetSnapshot, error)
+}
 
 // AgentIdentity carries the resolved agent name and profile key.
 type AgentIdentity struct {


### PR DESCRIPTION
## What changed

The Pro dashboard runs as a separate process from the proxy, so its budget panel had no live source and rendered an empty state. This adds a read-only runtime snapshot: the proxy periodically writes a counts-only JSON file beside the flight-recorder evidence directory, and `dashboard serve` reads it to populate the forward-proxy per-agent budget columns (requests, bytes, unique-domain count against their limits, plus the rolling window).

## Producer

An enterprise writer goroutine reads live budget state each tick through the proxy edition (reload-safe), enumerating per-agent forward-budget snapshots via a new opt-in `edition.AgentBudgetSnapshotProvider`. The core runtime invokes it through a nil-able hook, so the core build carries no enterprise dependency and no-ops without the enterprise tag.

## Reader is strict and fail-closed

Bounded file size, owner-only permissions, symlink and TOCTOU rejection, unknown-field and trailing-data rejection, version check, future-timestamp and staleness checks, and per-row count validation. Any invalid or stale snapshot renders the panel as unavailable or stale rather than fabricating or zeroing data. Counts and limits only reach the file: no destinations, arguments, bodies, or tokens.

## Config

An optional `dashboard_snapshot` section (enabled tri-state, path, interval) that defaults to on when a flight-recorder directory is set and is excluded from the canonical policy hash. Fleet and MCP denial-of-wallet data live in other process contexts and are intentionally out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic, read-only dashboard runtime snapshot support for observability (default **10s**), writing `runtime-snapshot.json` alongside flight recorder data when configured.
  * Dashboard now shows per-agent runtime budget snapshot freshness (produced time, age, and stale status).
  * Added a dashboard server option to control the runtime snapshot file path.
* **Bug Fixes**
  * Improved UI messaging for missing/invalid/oversized/future-dated/stale snapshots, including clearer “hidden counters” details.
  * Runtime snapshot data is strictly validated and bounded before being displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->