### PR TITLE
feat: add durable SIEM event forwarding

### DIFF
--- a/.github/workflows/hardening.yaml
+++ b/.github/workflows/hardening.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           version: v2.12.2
           skip-cache: true
-          args: --disable-all --enable dupl --enable gocyclo --enable gocognit --enable maintidx ./...
+          args: --default none --enable dupl --enable gocyclo --enable gocognit --enable maintidx ./...
 
       - name: Summarize hardening report
         if: always()

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -535,6 +535,16 @@ mcp_session_binding:
 #     min_severity: warn
 #     facility: local0
 #     tag: pipelock
+#   # Enterprise durable HTTP forwarding. Exact-host allowlist; no wildcards.
+#   forwarder:
+#     url: "https://api.vendor.example/events"
+#     destination_allowlist: ["api.vendor.example"]
+#     spool_file: "/var/lib/pipelock/siem-forward.spool"
+#     cursor_file: "/var/lib/pipelock/siem-forward.cursor"
+#     auth_token: ""
+#     min_severity: warn
+#     timeout_seconds: 5
+#     queue_size: 256
 
 logging:
   format: json

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -541,10 +541,12 @@ mcp_session_binding:
 #     destination_allowlist: ["api.vendor.example"]
 #     spool_file: "/var/lib/pipelock/siem-forward.spool"
 #     cursor_file: "/var/lib/pipelock/siem-forward.cursor"
-#     auth_token: ""
+#     auth_token: ""               # requires an https:// url (loopback exempt)
 #     min_severity: warn
 #     timeout_seconds: 5
 #     queue_size: 256
+#     max_spool_bytes: 104857600   # 100 MiB cap; new events drop when full
+#     allow_insecure_http: false   # permit plaintext http to a non-loopback host
 
 logging:
   format: json

--- a/docs/guides/siem-integration.md
+++ b/docs/guides/siem-integration.md
@@ -121,10 +121,12 @@ emit:
     destination_allowlist: ["api.vendor.example"]
     spool_file: "/var/lib/pipelock/siem-forward.spool"
     cursor_file: "/var/lib/pipelock/siem-forward.cursor"
-    auth_token: "" # optional Bearer token
+    auth_token: "" # optional Bearer token; requires an https:// url
     min_severity: "warn"
     timeout_seconds: 5
     queue_size: 256
+    max_spool_bytes: 104857600 # 100 MiB spool ceiling (default)
+    allow_insecure_http: false # permit plaintext http to a non-loopback host
 ```
 
 The destination allowlist is mandatory and matches exact hostnames only. The
@@ -133,6 +135,12 @@ cloud-metadata addresses at startup and again in the connection path. The
 connection uses the already-checked address, which closes the DNS-rebinding
 gap. Redirects are refused. An empty allowlist or invalid destination prevents
 startup; there is no forward-anywhere default.
+
+Transport confidentiality is enforced. A plaintext `http://` url to a
+non-loopback host is rejected unless `allow_insecure_http: true` is set, and an
+`auth_token` over `http://` to a non-loopback host is rejected regardless —
+a bearer token must not travel in cleartext. Loopback destinations (a local
+collector) may use `http://` without the flag.
 
 An operator may deliberately target an internal service only by using that IP
 literal as the URL host and listing the same literal exactly. An allowlisted
@@ -147,6 +155,15 @@ source path, byte offset, and SHA-256 hash of the acknowledged record. A
 restart verifies that binding before replay. A corrupt cursor fails closed
 instead of silently skipping evidence. Delivery is at least once, so a remote
 receiver should deduplicate if a response is lost after it accepted an event.
+Once every spooled record has been acknowledged the spool is truncated, so
+healthy operation stays bounded rather than growing without limit.
+
+The on-disk spool is capped at `max_spool_bytes` (default 100 MiB). When the
+endpoint is unreachable and an append would exceed the cap, the new event is
+dropped and counted rather than retried, so a stalled endpoint cannot exhaust
+host disk. An event that can never be encoded (for example a non-finite number
+in its fields) is likewise dropped with a sanitized diagnostic instead of
+blocking every later event behind an unencodable one.
 
 The producer-facing queue remains bounded and non-blocking. A full queue drops
 the new event and increments `pipelock_siem_forwarder_dropped_total`; it does
@@ -158,6 +175,7 @@ the spool. Health is exposed through these Prometheus series:
 - `pipelock_siem_forwarder_failed_total`
 - `pipelock_siem_forwarder_dropped_total`
 - `pipelock_siem_forwarder_last_success_timestamp_seconds`
+- `pipelock_siem_forwarder_spool_bytes`
 
 The durable wire envelope is versioned:
 
@@ -181,7 +199,10 @@ Operator lifecycle:
 
 - Create: configure both state paths; Pipelock creates parent directories and
   files with restrictive permissions. Give every Pipelock process its own
-  spool/cursor pair; the files are not a shared multi-process queue.
+  spool/cursor pair; the files are not a shared multi-process queue. This is
+  enforced by an exclusive advisory lock on a `<spool_file>.lock` sidecar — a
+  second process pointed at the same spool fails to start delivery rather than
+  racing the cursor.
 - Inspect: watch the forwarder metrics and the cursor's offset/hash while
   treating the spool as the delivery source of truth.
 - Rotate: stop Pipelock, confirm the cursor offset equals the spool size,

--- a/docs/guides/siem-integration.md
+++ b/docs/guides/siem-integration.md
@@ -2,6 +2,8 @@
 
 Pipelock pushes structured security events to external systems via webhook
 (HTTP POST), syslog (RFC 5424), and OTLP (OpenTelemetry HTTP/protobuf) sinks.
+Enterprise builds also provide a durable HTTP forwarder for at-least-once
+delivery from a local append-only spool.
 This guide covers the event schema, forwarding setup for common SIEM
 platforms, detection rule examples, and automated kill switch response.
 
@@ -105,6 +107,92 @@ emit:
     facility: "local0"                # local0-local7, auth, daemon, etc.
     tag: "pipelock"
 ```
+
+### Durable HTTP forwarding (Enterprise)
+
+Use `emit.forwarder` when delivery must resume after a restart. This is a
+narrow forwarding pipe into an operator-owned endpoint; it is not a SIEM,
+search index, or second evidence database.
+
+```yaml
+emit:
+  forwarder:
+    url: "https://api.vendor.example/events"
+    destination_allowlist: ["api.vendor.example"]
+    spool_file: "/var/lib/pipelock/siem-forward.spool"
+    cursor_file: "/var/lib/pipelock/siem-forward.cursor"
+    auth_token: "" # optional Bearer token
+    min_severity: "warn"
+    timeout_seconds: 5
+    queue_size: 256
+```
+
+The destination allowlist is mandatory and matches exact hostnames only. The
+forwarder resolves and rejects loopback, private, link-local, multicast, and
+cloud-metadata addresses at startup and again in the connection path. The
+connection uses the already-checked address, which closes the DNS-rebinding
+gap. Redirects are refused. An empty allowlist or invalid destination prevents
+startup; there is no forward-anywhere default.
+
+An operator may deliberately target an internal service only by using that IP
+literal as the URL host and listing the same literal exactly. An allowlisted
+hostname that later resolves to an internal address is still denied.
+If DNS is unavailable at startup, Pipelock starts with forwarding degraded
+rather than taking down the mediation proxy. No event is sent until a later
+dial-time resolution succeeds and passes the same SSRF checks.
+
+Accepted events are appended to `spool_file` with mode `0600`. After the
+endpoint returns a 2xx response, `cursor_file` advances atomically with the
+source path, byte offset, and SHA-256 hash of the acknowledged record. A
+restart verifies that binding before replay. A corrupt cursor fails closed
+instead of silently skipping evidence. Delivery is at least once, so a remote
+receiver should deduplicate if a response is lost after it accepted an event.
+
+The producer-facing queue remains bounded and non-blocking. A full queue drops
+the new event and increments `pipelock_siem_forwarder_dropped_total`; it does
+not stall proxy traffic. The durable guarantee begins after an event reaches
+the spool. Health is exposed through these Prometheus series:
+
+- `pipelock_siem_forwarder_queued`
+- `pipelock_siem_forwarder_delivered_total`
+- `pipelock_siem_forwarder_failed_total`
+- `pipelock_siem_forwarder_dropped_total`
+- `pipelock_siem_forwarder_last_success_timestamp_seconds`
+
+The durable wire envelope is versioned:
+
+```json
+{
+  "schema": "pipelock.siem.event.v1",
+  "event": {
+    "severity": "warn",
+    "type": "blocked",
+    "timestamp": "2026-02-25T12:34:56.789Z",
+    "pipelock_instance": "agent-a",
+    "fields": {"scanner": "dlp", "action": "block"}
+  }
+}
+```
+
+The existing syslog sink remains the CEF option (`format: cef`) for receivers
+that require CEF, but it is best-effort and does not use the durable cursor.
+
+Operator lifecycle:
+
+- Create: configure both state paths; Pipelock creates parent directories and
+  files with restrictive permissions. Give every Pipelock process its own
+  spool/cursor pair; the files are not a shared multi-process queue.
+- Inspect: watch the forwarder metrics and the cursor's offset/hash while
+  treating the spool as the delivery source of truth.
+- Rotate: stop Pipelock, confirm the cursor offset equals the spool size,
+  archive the pair, then restart with new paths. Never rotate only one file.
+- Recover: restore a matching spool/cursor pair. If only the cursor is corrupt,
+  moving it aside replays the spool from offset zero (duplicates, but no silent
+  skip). Preserve the corrupt pair for investigation first.
+- Revoke: remove `emit.forwarder.url` and reload; Pipelock closes the worker and
+  leaves state files for operator-controlled retention or deletion.
+- Approve changes: destination or state-path changes are config-controlled and
+  revalidated before the replacement worker starts.
 
 **Severity filtering:** Events below `min_severity` are silently dropped before
 reaching the sink. Set to `warn` for all security events (recommended), or

--- a/enterprise/siemforward/forwarder.go
+++ b/enterprise/siemforward/forwarder.go
@@ -356,12 +356,20 @@ func validateResolvedHost(ctx context.Context, resolver scanner.Resolver, host s
 	if len(ips) == 0 {
 		return fmt.Errorf("%w: DNS returned no addresses for %s", errDestinationUnresolved, host)
 	}
+	return assertResolvedIPsSafe(host, ips, internal, allowPrivateLiteral)
+}
+
+// assertResolvedIPsSafe rejects a resolved address set that contains an
+// unparseable entry or an internal IP (unless allowPrivate). Startup validation
+// and connection-time pinning both call it so the resolved-IP SSRF rule stays
+// in lock-step and cannot drift between the two paths.
+func assertResolvedIPsSafe(host string, ips []string, internal func(net.IP) bool, allowPrivate bool) error {
 	for _, rawIP := range ips {
 		ip := net.ParseIP(stripZone(rawIP))
 		if ip == nil {
 			return fmt.Errorf("SSRF blocked: unparseable DNS address %q for %s", rawIP, host)
 		}
-		if internal(ip) {
+		if internal(ip) && !allowPrivate {
 			return fmt.Errorf("SSRF blocked: %s resolves to internal IP %s", host, rawIP)
 		}
 	}
@@ -880,11 +888,8 @@ func (f *Forwarder) safeDialContext(ctx context.Context, network, addr string) (
 	if len(ips) == 0 {
 		return nil, fmt.Errorf("SSRF blocked: DNS returned no addresses for %s", host)
 	}
-	for _, rawIP := range ips {
-		ip := net.ParseIP(stripZone(rawIP))
-		if ip == nil || (f.isInternalIP(ip) && !f.allowPrivateLiteral) {
-			return nil, fmt.Errorf("SSRF blocked: %s resolved to unsafe IP %q", host, rawIP)
-		}
+	if err := assertResolvedIPsSafe(host, ips, f.isInternalIP, f.allowPrivateLiteral); err != nil {
+		return nil, err
 	}
 	return f.dial(ctx, network, net.JoinHostPort(stripZone(ips[0]), port))
 }

--- a/enterprise/siemforward/forwarder.go
+++ b/enterprise/siemforward/forwarder.go
@@ -34,29 +34,40 @@ import (
 )
 
 const (
-	SchemaV1         = "pipelock.siem.event.v1"
-	cursorVersion    = 1
-	defaultQueueSize = 256
-	defaultTimeout   = 5 * time.Second
-	defaultRetry     = time.Second
+	SchemaV1             = "pipelock.siem.event.v1"
+	cursorVersion        = 1
+	defaultQueueSize     = 256
+	defaultTimeout       = 5 * time.Second
+	defaultRetry         = time.Second
+	defaultMaxSpoolBytes = int64(100) << 20 // 100 MiB
 )
 
 var (
 	ErrQueueFull             = errors.New("siem forwarder queue full, event dropped")
 	errClosed                = errors.New("siem forwarder closed")
 	errDestinationUnresolved = errors.New("siem forwarder destination unresolved")
+	// errPermanentEncode marks an event that can never be serialized (e.g. a
+	// NaN/Inf or unsupported type in Fields). Retrying it forever would block
+	// the worker, so it is dropped instead.
+	errPermanentEncode = errors.New("siem forwarder event cannot be encoded")
+	// errSpoolFull marks a refused append because the on-disk spool has reached
+	// its configured ceiling. The new event is dropped so a stalled endpoint
+	// cannot exhaust host disk.
+	errSpoolFull = errors.New("siem forwarder spool at capacity")
 )
 
 type Config struct {
-	URL           string
-	AllowedHosts  []string
-	SpoolFile     string
-	CursorFile    string
-	AuthToken     string
-	QueueSize     int
-	Timeout       time.Duration
-	RetryInterval time.Duration
-	MinSeverity   emit.Severity
+	URL               string
+	AllowedHosts      []string
+	SpoolFile         string
+	CursorFile        string
+	AuthToken         string
+	QueueSize         int
+	Timeout           time.Duration
+	RetryInterval     time.Duration
+	MinSeverity       emit.Severity
+	MaxSpoolBytes     int64
+	AllowInsecureHTTP bool
 }
 
 type Options struct {
@@ -74,6 +85,7 @@ type Observer interface {
 	RecordFailed()
 	RecordDropped()
 	SetLastSuccess(time.Time)
+	SetSpoolBytes(float64)
 }
 
 type Envelope struct {
@@ -123,6 +135,13 @@ type Forwarder struct {
 	closeResources      func()
 	allowPrivateLiteral bool
 	appendEvent         func(emit.Event) error
+	maxSpoolBytes       int64
+	lockFile            *os.File
+
+	// deliverCtx is cancelled by Close so an in-flight HTTP delivery aborts
+	// promptly instead of blocking shutdown/reload for the whole backlog.
+	deliverCtx    context.Context
+	deliverCancel context.CancelFunc
 
 	cursorMu sync.Mutex
 	cursor   cursor
@@ -145,10 +164,13 @@ func New(cfg Config, opts Options) (*Forwarder, error) {
 	if cfg.RetryInterval <= 0 {
 		cfg.RetryInterval = defaultRetry
 	}
+	if cfg.MaxSpoolBytes <= 0 {
+		cfg.MaxSpoolBytes = defaultMaxSpoolBytes
+	}
 	if cfg.SpoolFile == "" || cfg.CursorFile == "" {
 		return nil, errors.New("siem forwarder spool_file and cursor_file are required")
 	}
-	target, err := validateTarget(cfg.URL, cfg.AllowedHosts)
+	target, err := validateTarget(cfg.URL, cfg.AllowedHosts, cfg.AuthToken, cfg.AllowInsecureHTTP)
 	if err != nil {
 		return nil, err
 	}
@@ -202,6 +224,7 @@ func New(cfg Config, opts Options) (*Forwarder, error) {
 	if dial == nil {
 		dial = (&net.Dialer{Timeout: cfg.Timeout}).DialContext
 	}
+	deliverCtx, deliverCancel := context.WithCancel(context.Background())
 	f := &Forwarder{
 		cfg:                 cfg,
 		target:              target,
@@ -213,6 +236,9 @@ func New(cfg Config, opts Options) (*Forwarder, error) {
 		isInternalIP:        internalIP,
 		closeResources:      closeResources,
 		allowPrivateLiteral: allowPrivateLiteral,
+		maxSpoolBytes:       cfg.MaxSpoolBytes,
+		deliverCtx:          deliverCtx,
+		deliverCancel:       deliverCancel,
 		cursor:              c,
 	}
 	f.appendEvent = f.append
@@ -249,12 +275,24 @@ func (f *Forwarder) Start() {
 		if f.closed {
 			return
 		}
+		// Acquire the exclusive state lock at delivery time, not in New: a
+		// reload builds the replacement while the outgoing forwarder still
+		// holds the lock, and only releases it on Close before this Start
+		// runs. Locking here still blocks a second OS process pointed at the
+		// same spool/cursor. A failed lock fails safe: no worker runs, so
+		// events queue and overflow rather than racing another writer.
+		lock, err := acquireStateLock(f.cfg.SpoolFile)
+		if err != nil {
+			f.recordFailure(err)
+			return
+		}
+		f.lockFile = lock
 		f.worker.Add(1)
 		go f.run()
 	})
 }
 
-func validateTarget(rawURL string, allowedHosts []string) (*url.URL, error) {
+func validateTarget(rawURL string, allowedHosts []string, authToken string, allowInsecureHTTP bool) (*url.URL, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
 		return nil, fmt.Errorf("invalid siem forwarder url %q: must be http:// or https:// with a host", rawURL)
@@ -277,11 +315,31 @@ func validateTarget(rawURL string, allowedHosts []string) (*url.URL, error) {
 	if _, ok := allowed[host]; !ok {
 		return nil, fmt.Errorf("siem forwarder destination host %q is not exactly allowlisted", host)
 	}
+	if u.Scheme == "http" && !hostIsLoopback(host) {
+		if authToken != "" {
+			return nil, errors.New("siem forwarder auth_token requires an https:// url: plaintext http would expose the bearer token (loopback destinations are exempt)")
+		}
+		if !allowInsecureHTTP {
+			return nil, fmt.Errorf("siem forwarder url uses plaintext http:// to non-loopback host %q: use https:// or set allow_insecure_http", host)
+		}
+	}
 	return u, nil
 }
 
 func normalizeHost(host string) string {
 	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+}
+
+// hostIsLoopback reports whether an already-normalized host refers to the local
+// machine, where plaintext http forwarding is acceptable.
+func hostIsLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 func validateResolvedHost(ctx context.Context, resolver scanner.Resolver, host string, internal func(net.IP) bool, allowPrivateLiteral bool) error {
@@ -453,8 +511,13 @@ func (f *Forwarder) Close() error {
 		close(f.done)
 	}
 	f.lifecycleMu.Unlock()
+	// Abort any in-flight HTTP delivery so Close returns promptly. The worker
+	// still persists already-queued events to the spool within the bounded
+	// shutdown deadline; undelivered spool records replay after restart.
+	f.deliverCancel()
 	f.worker.Wait()
 	f.resourceClose.Do(func() {
+		releaseStateLock(f.lockFile)
 		if f.closeResources != nil {
 			f.closeResources()
 		}
@@ -507,11 +570,15 @@ func (f *Forwarder) run() {
 // shutdown deadline used to drain the rest of the queue.
 func (f *Forwarder) persistAccepted(event emit.Event) (bool, time.Time) {
 	for {
-		if err := f.appendEvent(event); err == nil {
+		err := f.appendEvent(event)
+		if err == nil {
 			return true, time.Time{}
-		} else {
-			f.recordFailure(err)
 		}
+		if isPermanentAppendErr(err) {
+			f.recordDroppedEvent(event, err)
+			return false, time.Time{}
+		}
+		f.recordFailure(err)
 
 		timer := time.NewTimer(f.cfg.RetryInterval)
 		select {
@@ -533,11 +600,15 @@ func (f *Forwarder) persistAccepted(event emit.Event) (bool, time.Time) {
 // shutdown deadline expires.
 func (f *Forwarder) persistUntil(event emit.Event, deadline time.Time) bool {
 	for {
-		if err := f.appendEvent(event); err == nil {
+		err := f.appendEvent(event)
+		if err == nil {
 			return true
-		} else {
-			f.recordFailure(err)
 		}
+		if isPermanentAppendErr(err) {
+			f.recordDroppedEvent(event, err)
+			return false
+		}
+		f.recordFailure(err)
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
 			f.recordDropped()
@@ -572,6 +643,27 @@ func (f *Forwarder) recordDropped() {
 	}
 }
 
+// recordDroppedEvent drops an event that can never be persisted (permanent
+// encode failure or a full spool) and emits a sanitized diagnostic. Only the
+// event type and the sentinel reason are logged; the untrusted Fields are never
+// written out.
+func (f *Forwarder) recordDroppedEvent(event emit.Event, err error) {
+	f.dropped.Add(1)
+	if f.observer != nil {
+		f.observer.RecordDropped()
+	}
+	f.healthMu.Lock()
+	f.lastError = err.Error()
+	f.healthMu.Unlock()
+	_, _ = fmt.Fprintf(os.Stderr, "siem forwarder dropped event type=%q: %v\n", event.Type, err)
+}
+
+// isPermanentAppendErr reports whether an append failure should not be retried:
+// the event is unencodable or the spool is at capacity.
+func isPermanentAppendErr(err error) bool {
+	return errors.Is(err, errPermanentEncode) || errors.Is(err, errSpoolFull)
+}
+
 func (f *Forwarder) append(event emit.Event) error {
 	envelope := Envelope{Schema: SchemaV1, Event: DeliveryEvent{
 		Severity: event.Severity.String(), Type: event.Type,
@@ -580,9 +672,15 @@ func (f *Forwarder) append(event emit.Event) error {
 	}}
 	b, err := json.Marshal(envelope)
 	if err != nil {
-		return fmt.Errorf("marshal siem forwarder envelope: %w", err)
+		// A serialization failure (NaN/Inf, unsupported type) is permanent:
+		// retrying the same event never succeeds. Wrap it so the caller drops
+		// it instead of head-of-line blocking every later audit event.
+		return fmt.Errorf("%w: %w", errPermanentEncode, err)
 	}
 	b = append(b, '\n')
+	if info, statErr := os.Stat(f.cfg.SpoolFile); statErr == nil && info.Size()+int64(len(b)) > f.maxSpoolBytes {
+		return fmt.Errorf("%w: spool at %d of %d bytes", errSpoolFull, info.Size(), f.maxSpoolBytes)
+	}
 	file, err := openRegularFile(f.cfg.SpoolFile, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("open siem forwarder spool: %w", err)
@@ -594,6 +692,7 @@ func (f *Forwarder) append(event emit.Event) error {
 	if err := file.Sync(); err != nil {
 		return fmt.Errorf("sync siem forwarder spool: %w", err)
 	}
+	f.setSpoolBytes()
 	return nil
 }
 
@@ -612,9 +711,14 @@ func (f *Forwarder) deliverPending() {
 	}
 	reader := bufio.NewReader(file)
 	for {
+		// Stop promptly on shutdown/reload instead of walking the whole
+		// backlog: any undelivered record stays spooled for replay.
+		if f.deliverCtx.Err() != nil {
+			return
+		}
 		line, readErr := reader.ReadBytes('\n')
 		if errors.Is(readErr, io.EOF) && len(line) == 0 {
-			return
+			break
 		}
 		if readErr != nil {
 			f.recordFailure(fmt.Errorf("read siem forwarder spool: %w", readErr))
@@ -642,6 +746,41 @@ func (f *Forwarder) deliverPending() {
 		f.lastOK = now
 		f.healthMu.Unlock()
 	}
+	f.compactIfDrained(file)
+}
+
+// compactIfDrained truncates the spool once every record has been delivered so
+// healthy operation stays bounded and the max_spool_bytes cap only trips under
+// a genuine delivery backlog. The cursor is reset to zero on disk before the
+// truncate, so a crash in the window replays the (already-delivered) tail —
+// at-least-once, never a gap. Runs on the worker goroutine, so it never races
+// append.
+func (f *Forwarder) compactIfDrained(spool *os.File) {
+	info, err := spool.Stat()
+	if err != nil || f.cursor.Offset == 0 || f.cursor.Offset != info.Size() {
+		return
+	}
+	reset := cursor{Version: cursorVersion, SourceFile: f.cursor.SourceFile}
+	if err := persistCursor(f.cfg.CursorFile, reset); err != nil {
+		f.recordFailure(fmt.Errorf("reset siem forwarder cursor for compaction: %w", err))
+		return
+	}
+	wf, err := openRegularFile(f.cfg.SpoolFile, os.O_WRONLY, 0)
+	if err != nil {
+		f.recordFailure(fmt.Errorf("open siem forwarder spool for compaction: %w", err))
+		return
+	}
+	defer func() { _ = wf.Close() }()
+	if err := wf.Truncate(0); err != nil {
+		f.recordFailure(fmt.Errorf("truncate siem forwarder spool: %w", err))
+		return
+	}
+	if err := wf.Sync(); err != nil {
+		f.recordFailure(fmt.Errorf("sync siem forwarder spool after compaction: %w", err))
+		return
+	}
+	f.cursor = reset
+	f.setSpoolBytes()
 }
 
 func (f *Forwarder) deliver(record []byte) error {
@@ -652,7 +791,7 @@ func (f *Forwarder) deliver(record []byte) error {
 	if envelope.Schema != SchemaV1 {
 		return fmt.Errorf("unsupported siem forwarder schema %q", envelope.Schema)
 	}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, f.target.String(), bytes.NewReader(record))
+	req, err := http.NewRequestWithContext(f.deliverCtx, http.MethodPost, f.target.String(), bytes.NewReader(record))
 	if err != nil {
 		return fmt.Errorf("create siem forwarder request: %w", err)
 	}
@@ -805,5 +944,16 @@ func (f *Forwarder) recordFailure(err error) {
 func (f *Forwarder) setQueued() {
 	if f.observer != nil {
 		f.observer.SetQueued(float64(len(f.queue)))
+	}
+}
+
+// setSpoolBytes publishes the current on-disk spool size so operators can see
+// backlog growth toward the max_spool_bytes ceiling.
+func (f *Forwarder) setSpoolBytes() {
+	if f.observer == nil {
+		return
+	}
+	if info, err := os.Stat(f.cfg.SpoolFile); err == nil {
+		f.observer.SetSpoolBytes(float64(info.Size()))
 	}
 }

--- a/enterprise/siemforward/forwarder.go
+++ b/enterprise/siemforward/forwarder.go
@@ -122,6 +122,7 @@ type Forwarder struct {
 	isInternalIP        func(net.IP) bool
 	closeResources      func()
 	allowPrivateLiteral bool
+	appendEvent         func(emit.Event) error
 
 	cursorMu sync.Mutex
 	cursor   cursor
@@ -214,6 +215,7 @@ func New(cfg Config, opts Options) (*Forwarder, error) {
 		allowPrivateLiteral: allowPrivateLiteral,
 		cursor:              c,
 	}
+	f.appendEvent = f.append
 	transport := &http.Transport{
 		Proxy:                 nil,
 		DialContext:           f.safeDialContext,
@@ -482,26 +484,91 @@ func (f *Forwarder) run() {
 		select {
 		case event := <-f.queue:
 			f.setQueued()
-			if err := f.append(event); err != nil {
-				f.recordFailure(err)
-				continue
+			persisted, shutdownDeadline := f.persistAccepted(event)
+			if !shutdownDeadline.IsZero() {
+				f.drainQueue(shutdownDeadline)
+				return
 			}
-			f.deliverPending()
+			if persisted {
+				f.deliverPending()
+			}
 		case <-retry.C:
 			f.deliverPending()
 		case <-f.done:
-			for {
+			f.drainQueue(time.Now().Add(f.cfg.Timeout))
+			return
+		}
+	}
+}
+
+// persistAccepted keeps an accepted event at the head of the worker until it
+// reaches durable storage. It does not consume another queued event while the
+// spool is unavailable. Close switches the retry loop to the same bounded
+// shutdown deadline used to drain the rest of the queue.
+func (f *Forwarder) persistAccepted(event emit.Event) (bool, time.Time) {
+	for {
+		if err := f.appendEvent(event); err == nil {
+			return true, time.Time{}
+		} else {
+			f.recordFailure(err)
+		}
+
+		timer := time.NewTimer(f.cfg.RetryInterval)
+		select {
+		case <-timer.C:
+		case <-f.done:
+			if !timer.Stop() {
 				select {
-				case event := <-f.queue:
-					if err := f.append(event); err != nil {
-						f.recordFailure(err)
-					}
+				case <-timer.C:
 				default:
-					f.setQueued()
-					return
 				}
 			}
+			deadline := time.Now().Add(f.cfg.Timeout)
+			return f.persistUntil(event, deadline), deadline
 		}
+	}
+}
+
+// persistUntil retries one accepted event until it is durable or the shared
+// shutdown deadline expires.
+func (f *Forwarder) persistUntil(event emit.Event, deadline time.Time) bool {
+	for {
+		if err := f.appendEvent(event); err == nil {
+			return true
+		} else {
+			f.recordFailure(err)
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			f.recordDropped()
+			return false
+		}
+		wait := min(f.cfg.RetryInterval, remaining)
+		timer := time.NewTimer(wait)
+		<-timer.C
+	}
+}
+
+// drainQueue persists queued events in order without extending Close's single
+// shutdown deadline for each event.
+func (f *Forwarder) drainQueue(deadline time.Time) {
+	for {
+		select {
+		case event := <-f.queue:
+			_ = f.persistUntil(event, deadline)
+		default:
+			f.setQueued()
+			return
+		}
+	}
+}
+
+// recordDropped exposes the otherwise unavoidable loss when storage stays
+// unavailable through the bounded shutdown window.
+func (f *Forwarder) recordDropped() {
+	f.dropped.Add(1)
+	if f.observer != nil {
+		f.observer.RecordDropped()
 	}
 }
 

--- a/enterprise/siemforward/forwarder.go
+++ b/enterprise/siemforward/forwarder.go
@@ -1,0 +1,742 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+// Package siemforward provides durable, asynchronous HTTP forwarding for
+// Pipelock audit events. Accepted events are first appended to a local spool;
+// a content-bound cursor advances only after the remote endpoint acknowledges
+// delivery, giving at-least-once replay across process restarts.
+package siemforward
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/emit"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+const (
+	SchemaV1         = "pipelock.siem.event.v1"
+	cursorVersion    = 1
+	defaultQueueSize = 256
+	defaultTimeout   = 5 * time.Second
+	defaultRetry     = time.Second
+)
+
+var (
+	ErrQueueFull             = errors.New("siem forwarder queue full, event dropped")
+	errClosed                = errors.New("siem forwarder closed")
+	errDestinationUnresolved = errors.New("siem forwarder destination unresolved")
+)
+
+type Config struct {
+	URL           string
+	AllowedHosts  []string
+	SpoolFile     string
+	CursorFile    string
+	AuthToken     string
+	QueueSize     int
+	Timeout       time.Duration
+	RetryInterval time.Duration
+	MinSeverity   emit.Severity
+}
+
+type Options struct {
+	Resolver      scanner.Resolver
+	DialContext   func(context.Context, string, string) (net.Conn, error)
+	IsInternalIP  func(net.IP) bool
+	Close         func()
+	Observer      Observer
+	DeferredStart bool
+}
+
+type Observer interface {
+	SetQueued(float64)
+	RecordDelivered()
+	RecordFailed()
+	RecordDropped()
+	SetLastSuccess(time.Time)
+}
+
+type Envelope struct {
+	Schema string        `json:"schema"`
+	Event  DeliveryEvent `json:"event"`
+}
+
+type DeliveryEvent struct {
+	Severity   string         `json:"severity"`
+	Type       string         `json:"type"`
+	Timestamp  string         `json:"timestamp"`
+	InstanceID string         `json:"pipelock_instance"`
+	Fields     map[string]any `json:"fields,omitempty"`
+}
+
+type Health struct {
+	Queued      int       `json:"queued"`
+	Delivered   uint64    `json:"delivered"`
+	Failed      uint64    `json:"failed"`
+	Dropped     uint64    `json:"dropped"`
+	LastError   string    `json:"last_error,omitempty"`
+	LastSuccess time.Time `json:"last_success_time,omitempty"`
+}
+
+type cursor struct {
+	Version     int    `json:"version"`
+	SourceFile  string `json:"source_file"`
+	Offset      int64  `json:"offset"`
+	ContentHash string `json:"content_hash"`
+}
+
+type Forwarder struct {
+	cfg                 Config
+	target              *url.URL
+	resolver            scanner.Resolver
+	dial                func(context.Context, string, string) (net.Conn, error)
+	client              *http.Client
+	queue               chan emit.Event
+	done                chan struct{}
+	worker              sync.WaitGroup
+	start               sync.Once
+	lifecycleMu         sync.Mutex
+	closed              bool
+	resourceClose       sync.Once
+	observer            Observer
+	isInternalIP        func(net.IP) bool
+	closeResources      func()
+	allowPrivateLiteral bool
+
+	cursorMu sync.Mutex
+	cursor   cursor
+
+	delivered atomic.Uint64
+	failed    atomic.Uint64
+	dropped   atomic.Uint64
+	healthMu  sync.RWMutex
+	lastError string
+	lastOK    time.Time
+}
+
+func New(cfg Config, opts Options) (*Forwarder, error) {
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = defaultQueueSize
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultTimeout
+	}
+	if cfg.RetryInterval <= 0 {
+		cfg.RetryInterval = defaultRetry
+	}
+	if cfg.SpoolFile == "" || cfg.CursorFile == "" {
+		return nil, errors.New("siem forwarder spool_file and cursor_file are required")
+	}
+	target, err := validateTarget(cfg.URL, cfg.AllowedHosts)
+	if err != nil {
+		return nil, err
+	}
+	resolver := opts.Resolver
+	internalIP := opts.IsInternalIP
+	closeResources := opts.Close
+	if resolver == nil || internalIP == nil {
+		ssrfScanner := scanner.New(config.Defaults())
+		if resolver == nil {
+			resolver = ssrfScanner.HostResolver()
+		}
+		if internalIP == nil {
+			internalIP = ssrfScanner.IsInternalIP
+		}
+		priorClose := closeResources
+		closeResources = func() {
+			ssrfScanner.Close()
+			if priorClose != nil {
+				priorClose()
+			}
+		}
+	}
+	allowPrivateLiteral := net.ParseIP(target.Hostname()) != nil
+	validationCtx, validationCancel := context.WithTimeout(context.Background(), cfg.Timeout)
+	defer validationCancel()
+	var startupResolutionErr error
+	if err := validateResolvedHost(validationCtx, resolver, target.Hostname(), internalIP, allowPrivateLiteral); err != nil {
+		if errors.Is(err, errDestinationUnresolved) {
+			startupResolutionErr = err
+		} else {
+			if closeResources != nil {
+				closeResources()
+			}
+			return nil, fmt.Errorf("siem forwarder destination validation: %w", err)
+		}
+	}
+	if err := prepareStateFiles(cfg.SpoolFile, cfg.CursorFile); err != nil {
+		if closeResources != nil {
+			closeResources()
+		}
+		return nil, err
+	}
+	c, err := loadCursor(cfg.SpoolFile, cfg.CursorFile)
+	if err != nil {
+		if closeResources != nil {
+			closeResources()
+		}
+		return nil, err
+	}
+	dial := opts.DialContext
+	if dial == nil {
+		dial = (&net.Dialer{Timeout: cfg.Timeout}).DialContext
+	}
+	f := &Forwarder{
+		cfg:                 cfg,
+		target:              target,
+		resolver:            resolver,
+		dial:                dial,
+		queue:               make(chan emit.Event, cfg.QueueSize),
+		done:                make(chan struct{}),
+		observer:            opts.Observer,
+		isInternalIP:        internalIP,
+		closeResources:      closeResources,
+		allowPrivateLiteral: allowPrivateLiteral,
+		cursor:              c,
+	}
+	transport := &http.Transport{
+		Proxy:                 nil,
+		DialContext:           f.safeDialContext,
+		DisableKeepAlives:     true,
+		TLSHandshakeTimeout:   cfg.Timeout,
+		ResponseHeaderTimeout: cfg.Timeout,
+	}
+	f.client = &http.Client{
+		Transport: transport,
+		Timeout:   cfg.Timeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errors.New("siem forwarder redirects are disabled")
+		},
+	}
+	if startupResolutionErr != nil {
+		f.recordFailure(startupResolutionErr)
+	}
+	if !opts.DeferredStart {
+		f.Start()
+	}
+	return f, nil
+}
+
+// Start activates replay and delivery. Runtime reloads build a dormant
+// replacement, close the old sink, then start the replacement so two workers
+// never race the same spool and cursor.
+func (f *Forwarder) Start() {
+	f.start.Do(func() {
+		f.lifecycleMu.Lock()
+		defer f.lifecycleMu.Unlock()
+		if f.closed {
+			return
+		}
+		f.worker.Add(1)
+		go f.run()
+	})
+}
+
+func validateTarget(rawURL string, allowedHosts []string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return nil, fmt.Errorf("invalid siem forwarder url %q: must be http:// or https:// with a host", rawURL)
+	}
+	if u.User != nil || u.Fragment != "" {
+		return nil, errors.New("siem forwarder url must not contain userinfo or a fragment")
+	}
+	allowed := make(map[string]struct{}, len(allowedHosts))
+	for _, entry := range allowedHosts {
+		host := normalizeHost(entry)
+		if host == "" || (net.ParseIP(host) == nil && strings.ContainsAny(host, "*/:@[]")) {
+			return nil, fmt.Errorf("invalid siem forwarder allowed host %q: use an exact hostname only", entry)
+		}
+		allowed[host] = struct{}{}
+	}
+	host := normalizeHost(u.Hostname())
+	if len(allowed) == 0 {
+		return nil, errors.New("siem forwarder requires a non-empty destination allowlist")
+	}
+	if _, ok := allowed[host]; !ok {
+		return nil, fmt.Errorf("siem forwarder destination host %q is not exactly allowlisted", host)
+	}
+	return u, nil
+}
+
+func normalizeHost(host string) string {
+	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+}
+
+func validateResolvedHost(ctx context.Context, resolver scanner.Resolver, host string, internal func(net.IP) bool, allowPrivateLiteral bool) error {
+	if ip := net.ParseIP(host); ip != nil {
+		if internal(ip) && !allowPrivateLiteral {
+			return fmt.Errorf("SSRF blocked: destination is internal IP %s", host)
+		}
+		return nil
+	}
+	ips, err := resolver.LookupHost(ctx, host)
+	if err != nil {
+		return fmt.Errorf("%w: resolve %q: %w", errDestinationUnresolved, host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("%w: DNS returned no addresses for %s", errDestinationUnresolved, host)
+	}
+	for _, rawIP := range ips {
+		ip := net.ParseIP(stripZone(rawIP))
+		if ip == nil {
+			return fmt.Errorf("SSRF blocked: unparseable DNS address %q for %s", rawIP, host)
+		}
+		if internal(ip) {
+			return fmt.Errorf("SSRF blocked: %s resolves to internal IP %s", host, rawIP)
+		}
+	}
+	return nil
+}
+
+func stripZone(ip string) string {
+	if idx := strings.IndexByte(ip, '%'); idx >= 0 {
+		return ip[:idx]
+	}
+	return ip
+}
+
+func prepareStateFiles(spoolPath, cursorPath string) error {
+	for _, path := range []string{spoolPath, cursorPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			return fmt.Errorf("create siem forwarder state directory: %w", err)
+		}
+		info, err := os.Lstat(path)
+		if err == nil && (info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular()) {
+			return fmt.Errorf("siem forwarder state path %q is not a regular file", path)
+		}
+		if err == nil {
+			file, openErr := openRegularFile(path, os.O_RDWR, 0)
+			if openErr != nil {
+				return fmt.Errorf("open siem forwarder state path %q: %w", path, openErr)
+			}
+			if chmodErr := file.Chmod(0o600); chmodErr != nil {
+				_ = file.Close()
+				return fmt.Errorf("secure siem forwarder state path %q: %w", path, chmodErr)
+			}
+			if closeErr := file.Close(); closeErr != nil {
+				return fmt.Errorf("close siem forwarder state path %q: %w", path, closeErr)
+			}
+		}
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("inspect siem forwarder state path %q: %w", path, err)
+		}
+	}
+	file, err := openRegularFile(spoolPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open siem forwarder spool: %w", err)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("secure siem forwarder spool: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close siem forwarder spool: %w", err)
+	}
+	return nil
+}
+
+func loadCursor(spoolPath, cursorPath string) (cursor, error) {
+	wantSource, err := filepath.Abs(spoolPath)
+	if err != nil {
+		return cursor{}, fmt.Errorf("resolve spool path: %w", err)
+	}
+	c := cursor{Version: cursorVersion, SourceFile: wantSource}
+	file, err := openRegularFile(cursorPath, os.O_RDONLY, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		return c, nil
+	}
+	if err != nil {
+		return cursor{}, fmt.Errorf("read siem forwarder cursor: %w", err)
+	}
+	b, err := io.ReadAll(file)
+	closeErr := file.Close()
+	if err != nil {
+		return cursor{}, fmt.Errorf("read siem forwarder cursor: %w", err)
+	}
+	if closeErr != nil {
+		return cursor{}, fmt.Errorf("close siem forwarder cursor: %w", closeErr)
+	}
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
+		return cursor{}, fmt.Errorf("parse siem forwarder cursor: %w", err)
+	}
+	if err := requireJSONEOF(dec); err != nil {
+		return cursor{}, fmt.Errorf("parse siem forwarder cursor: %w", err)
+	}
+	if c.Version != cursorVersion || c.SourceFile != wantSource || c.Offset < 0 {
+		return cursor{}, errors.New("siem forwarder cursor metadata is invalid")
+	}
+	if err := verifyCursor(spoolPath, c); err != nil {
+		return cursor{}, err
+	}
+	return c, nil
+}
+
+func verifyCursor(spoolPath string, c cursor) error {
+	if c.Offset == 0 {
+		if c.ContentHash != "" {
+			return errors.New("siem forwarder zero cursor has a content hash")
+		}
+		return nil
+	}
+	file, err := openRegularFile(spoolPath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open siem forwarder spool for cursor verification: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	reader := bufio.NewReader(file)
+	var offset int64
+	var last []byte
+	for offset < c.Offset {
+		line, readErr := reader.ReadBytes('\n')
+		if readErr != nil {
+			return fmt.Errorf("siem forwarder cursor is not on a complete record boundary: %w", readErr)
+		}
+		offset += int64(len(line))
+		last = bytes.TrimSuffix(line, []byte{'\n'})
+	}
+	if offset != c.Offset || hashRecord(last) != c.ContentHash {
+		return errors.New("siem forwarder cursor content hash mismatch")
+	}
+	return nil
+}
+
+func (f *Forwarder) Emit(_ context.Context, event emit.Event) error {
+	if event.Severity < f.cfg.MinSeverity {
+		return nil
+	}
+	f.lifecycleMu.Lock()
+	defer f.lifecycleMu.Unlock()
+	if f.closed {
+		return errClosed
+	}
+	select {
+	case f.queue <- event:
+		f.setQueued()
+		return nil
+	default:
+		f.dropped.Add(1)
+		if f.observer != nil {
+			f.observer.RecordDropped()
+		}
+		return ErrQueueFull
+	}
+}
+
+func (f *Forwarder) Close() error {
+	f.lifecycleMu.Lock()
+	if !f.closed {
+		f.closed = true
+		close(f.done)
+	}
+	f.lifecycleMu.Unlock()
+	f.worker.Wait()
+	f.resourceClose.Do(func() {
+		if f.closeResources != nil {
+			f.closeResources()
+		}
+	})
+	return nil
+}
+
+func (f *Forwarder) Health() Health {
+	f.healthMu.RLock()
+	defer f.healthMu.RUnlock()
+	return Health{
+		Queued:      len(f.queue),
+		Delivered:   f.delivered.Load(),
+		Failed:      f.failed.Load(),
+		Dropped:     f.dropped.Load(),
+		LastError:   f.lastError,
+		LastSuccess: f.lastOK,
+	}
+}
+
+func (f *Forwarder) run() {
+	defer f.worker.Done()
+	retry := time.NewTicker(f.cfg.RetryInterval)
+	defer retry.Stop()
+	f.deliverPending()
+	for {
+		select {
+		case event := <-f.queue:
+			f.setQueued()
+			if err := f.append(event); err != nil {
+				f.recordFailure(err)
+				continue
+			}
+			f.deliverPending()
+		case <-retry.C:
+			f.deliverPending()
+		case <-f.done:
+			for {
+				select {
+				case event := <-f.queue:
+					if err := f.append(event); err != nil {
+						f.recordFailure(err)
+					}
+				default:
+					f.setQueued()
+					return
+				}
+			}
+		}
+	}
+}
+
+func (f *Forwarder) append(event emit.Event) error {
+	envelope := Envelope{Schema: SchemaV1, Event: DeliveryEvent{
+		Severity: event.Severity.String(), Type: event.Type,
+		Timestamp:  event.Timestamp.UTC().Format(time.RFC3339Nano),
+		InstanceID: event.InstanceID, Fields: event.Fields,
+	}}
+	b, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("marshal siem forwarder envelope: %w", err)
+	}
+	b = append(b, '\n')
+	file, err := openRegularFile(f.cfg.SpoolFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open siem forwarder spool: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.Write(b); err != nil {
+		return fmt.Errorf("append siem forwarder spool: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync siem forwarder spool: %w", err)
+	}
+	return nil
+}
+
+func (f *Forwarder) deliverPending() {
+	f.cursorMu.Lock()
+	defer f.cursorMu.Unlock()
+	file, err := openRegularFile(f.cfg.SpoolFile, os.O_RDONLY, 0)
+	if err != nil {
+		f.recordFailure(fmt.Errorf("open siem forwarder spool: %w", err))
+		return
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.Seek(f.cursor.Offset, io.SeekStart); err != nil {
+		f.recordFailure(fmt.Errorf("seek siem forwarder spool: %w", err))
+		return
+	}
+	reader := bufio.NewReader(file)
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if errors.Is(readErr, io.EOF) && len(line) == 0 {
+			return
+		}
+		if readErr != nil {
+			f.recordFailure(fmt.Errorf("read siem forwarder spool: %w", readErr))
+			return
+		}
+		record := bytes.TrimSuffix(line, []byte{'\n'})
+		if err := f.deliver(record); err != nil {
+			f.recordFailure(err)
+			return
+		}
+		f.cursor.Offset += int64(len(line))
+		f.cursor.ContentHash = hashRecord(record)
+		if err := persistCursor(f.cfg.CursorFile, f.cursor); err != nil {
+			f.recordFailure(err)
+			return
+		}
+		f.delivered.Add(1)
+		now := time.Now().UTC()
+		if f.observer != nil {
+			f.observer.RecordDelivered()
+			f.observer.SetLastSuccess(now)
+		}
+		f.healthMu.Lock()
+		f.lastError = ""
+		f.lastOK = now
+		f.healthMu.Unlock()
+	}
+}
+
+func (f *Forwarder) deliver(record []byte) error {
+	var envelope Envelope
+	if err := decodeEnvelope(bytes.NewReader(record), &envelope); err != nil {
+		return fmt.Errorf("decode siem forwarder spool record: %w", err)
+	}
+	if envelope.Schema != SchemaV1 {
+		return fmt.Errorf("unsupported siem forwarder schema %q", envelope.Schema)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, f.target.String(), bytes.NewReader(record))
+	if err != nil {
+		return fmt.Errorf("create siem forwarder request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "pipelock-siem-forwarder/1")
+	if f.cfg.AuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+f.cfg.AuthToken)
+	}
+	resp, err := f.client.Do(req)
+	if err != nil {
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			err = urlErr.Err
+		}
+		return fmt.Errorf("deliver siem forwarder event: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("siem forwarder endpoint returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func openRegularFile(path string, flags int, perm os.FileMode) (*os.File, error) {
+	cleanPath := filepath.Clean(path)
+	file, err := os.OpenFile(cleanPath, flags|noFollowFlag, perm)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("stat state file %q: %w", cleanPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("state path %q is not a regular file", cleanPath)
+	}
+	return file, nil
+}
+
+func decodeEnvelope(r io.Reader, dst *Envelope) error {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	if err := requireJSONEOF(dec); err != nil {
+		return err
+	}
+	if dst.Schema == "" || dst.Event.Type == "" || dst.Event.Timestamp == "" {
+		return errors.New("incomplete siem forwarder envelope")
+	}
+	return nil
+}
+
+func requireJSONEOF(dec *json.Decoder) error {
+	var extra any
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("unexpected trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func (f *Forwarder) safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("siem forwarder split destination %q: %w", addr, err)
+	}
+	if normalizeHost(host) != normalizeHost(f.target.Hostname()) {
+		return nil, fmt.Errorf("siem forwarder refused unexpected destination host %q", host)
+	}
+	if literalIP := net.ParseIP(host); literalIP != nil {
+		if f.isInternalIP(literalIP) && !f.allowPrivateLiteral {
+			return nil, fmt.Errorf("SSRF blocked: destination is internal IP %s", host)
+		}
+		return f.dial(ctx, network, net.JoinHostPort(literalIP.String(), port))
+	}
+	ips, err := f.resolver.LookupHost(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("siem forwarder resolve %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("SSRF blocked: DNS returned no addresses for %s", host)
+	}
+	for _, rawIP := range ips {
+		ip := net.ParseIP(stripZone(rawIP))
+		if ip == nil || (f.isInternalIP(ip) && !f.allowPrivateLiteral) {
+			return nil, fmt.Errorf("SSRF blocked: %s resolved to unsafe IP %q", host, rawIP)
+		}
+	}
+	return f.dial(ctx, network, net.JoinHostPort(stripZone(ips[0]), port))
+}
+
+func persistCursor(path string, c cursor) error {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("marshal siem forwarder cursor: %w", err)
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".siem-cursor-*")
+	if err != nil {
+		return fmt.Errorf("create siem forwarder cursor temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("secure siem forwarder cursor: %w", err)
+	}
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write siem forwarder cursor: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync siem forwarder cursor: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close siem forwarder cursor: %w", err)
+	}
+	if err := os.Rename(tmpName, filepath.Clean(path)); err != nil {
+		return fmt.Errorf("replace siem forwarder cursor: %w", err)
+	}
+	return nil
+}
+
+func hashRecord(record []byte) string {
+	sum := sha256.Sum256(record)
+	return hex.EncodeToString(sum[:])
+}
+
+func (f *Forwarder) recordFailure(err error) {
+	f.failed.Add(1)
+	if f.observer != nil {
+		f.observer.RecordFailed()
+	}
+	f.healthMu.Lock()
+	changed := f.lastError != err.Error()
+	f.lastError = err.Error()
+	f.healthMu.Unlock()
+	if changed {
+		_, _ = fmt.Fprintf(os.Stderr, "siem forwarder delivery error: %v\n", err)
+	}
+}
+
+func (f *Forwarder) setQueued() {
+	if f.observer != nil {
+		f.observer.SetQueued(float64(len(f.queue)))
+	}
+}

--- a/enterprise/siemforward/forwarder_test.go
+++ b/enterprise/siemforward/forwarder_test.go
@@ -582,6 +582,49 @@ func TestForwarderRetriesPendingWithoutNewEvent(t *testing.T) {
 	}
 }
 
+func TestForwarderRetriesSpoolAppendWithoutDroppingAcceptedEvent(t *testing.T) {
+	t.Parallel()
+	received := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received <- struct{}{}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	cfg.RetryInterval = 10 * time.Millisecond
+	f, err := New(cfg, Options{
+		Resolver:      &sequenceResolver{answers: [][]string{{testPublicIP}}},
+		DialContext:   routeToServer(t, srv),
+		DeferredStart: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	originalAppend := f.appendEvent
+	var attempts atomic.Int32
+	f.appendEvent = func(event emit.Event) error {
+		if attempts.Add(1) == 1 {
+			return errors.New("temporary spool failure")
+		}
+		return originalAppend(event)
+	}
+	f.Start()
+	t.Cleanup(func() { _ = f.Close() })
+	if err := f.Emit(t.Context(), testEvent(1)); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	select {
+	case <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("accepted event was not delivered after spool recovery")
+	}
+	waitFor(t, func() bool { return f.Health().Delivered == 1 })
+	health := f.Health()
+	if health.Failed == 0 || health.Dropped != 0 {
+		t.Fatalf("health = %+v, want a recorded failure and no drop", health)
+	}
+}
+
 func routeToServer(t *testing.T, srv *httptest.Server) func(context.Context, string, string) (net.Conn, error) {
 	t.Helper()
 	addr := srv.Listener.Addr().String()

--- a/enterprise/siemforward/forwarder_test.go
+++ b/enterprise/siemforward/forwarder_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -63,6 +64,10 @@ func testConfig(t *testing.T, rawURL string) Config {
 		CursorFile:   filepath.Join(dir, "forward.cursor"),
 		QueueSize:    8,
 		Timeout:      time.Second,
+		// The harness talks plaintext http to a fake endpoint; opt in so the
+		// transport-confidentiality policy does not reject the fixture URLs.
+		// Dedicated tests exercise that policy with the flag unset.
+		AllowInsecureHTTP: true,
 	}
 }
 
@@ -198,7 +203,9 @@ func TestForwarderDoesNotPersistOrReportEndpointCredentials(t *testing.T) {
 		querySecret = "query-secret-value"
 		authSecret  = "bearer-secret-value"
 	)
-	cfg := testConfig(t, "http://api.vendor.example/events?token="+querySecret)
+	// https because an auth_token over plaintext http to a non-loopback host is
+	// rejected by policy; this test exercises credential handling, not scheme.
+	cfg := testConfig(t, "https://api.vendor.example/events?token="+querySecret)
 	cfg.AuthToken = authSecret
 	f, err := New(cfg, Options{
 		Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}},
@@ -242,7 +249,10 @@ func TestForwarderRefusesRedirectWithoutForwardingAuthorization(t *testing.T) {
 		http.Redirect(w, r, redirected.URL+"/steal", http.StatusTemporaryRedirect)
 	}))
 	t.Cleanup(origin.Close)
-	cfg := testConfig(t, "http://api.vendor.example/events")
+	// Loopback host: http with an auth_token is allowed only for loopback, and
+	// the dial is routed to the httptest origin regardless of the literal.
+	cfg := testConfig(t, "http://127.0.0.1/events")
+	cfg.AllowedHosts = []string{"127.0.0.1"}
 	cfg.AuthToken = token
 	f, err := New(cfg, Options{
 		Resolver:    &sequenceResolver{answers: [][]string{{testPublicIP}}},
@@ -622,6 +632,232 @@ func TestForwarderRetriesSpoolAppendWithoutDroppingAcceptedEvent(t *testing.T) {
 	health := f.Health()
 	if health.Failed == 0 || health.Dropped != 0 {
 		t.Fatalf("health = %+v, want a recorded failure and no drop", health)
+	}
+}
+
+func TestNewEnforcesTransportConfidentiality(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		rawURL    string
+		allowed   []string
+		authToken string
+		insecure  bool
+		wantErr   string
+	}{
+		{name: "http remote without flag", rawURL: "http://api.vendor.example/e", allowed: []string{"api.vendor.example"}, wantErr: "allow_insecure_http"},
+		{name: "http remote with token even with flag", rawURL: "http://api.vendor.example/e", allowed: []string{"api.vendor.example"}, authToken: "secret", insecure: true, wantErr: "requires an https"},
+		{name: "http remote with flag no token ok", rawURL: "http://api.vendor.example/e", allowed: []string{"api.vendor.example"}, insecure: true},
+		{name: "http loopback with token ok", rawURL: "http://127.0.0.1/e", allowed: []string{"127.0.0.1"}, authToken: "secret"},
+		{name: "https remote with token ok", rawURL: "https://api.vendor.example/e", allowed: []string{"api.vendor.example"}, authToken: "secret"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := testConfig(t, tc.rawURL)
+			cfg.AllowedHosts = tc.allowed
+			cfg.AuthToken = tc.authToken
+			cfg.AllowInsecureHTTP = tc.insecure
+			f, err := New(cfg, Options{Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}}})
+			if tc.wantErr != "" {
+				if err == nil {
+					_ = f.Close()
+					t.Fatalf("New succeeded, want error containing %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("New error = %q, want contains %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			_ = f.Close()
+		})
+	}
+}
+
+func TestStartTakesExclusiveStateLock(t *testing.T) {
+	t.Parallel()
+	failingDial := func(context.Context, string, string) (net.Conn, error) {
+		return nil, errors.New("no endpoint")
+	}
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	first, err := New(cfg, Options{Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}}, DialContext: failingDial})
+	if err != nil {
+		t.Fatalf("New first: %v", err)
+	}
+	// A second forwarder on the same spool/cursor cannot start delivery: the
+	// exclusive lock is already held, so it fails safe rather than racing.
+	second, err := New(cfg, Options{Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}}, DialContext: failingDial})
+	if err != nil {
+		t.Fatalf("New second: %v", err)
+	}
+	if got := second.Health().LastError; !strings.Contains(got, "locked by another process") {
+		t.Fatalf("second forwarder LastError = %q, want a lock conflict", got)
+	}
+	_ = second.Close()
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close first: %v", err)
+	}
+	// Once the first releases the lock, a fresh forwarder acquires it cleanly.
+	third, err := New(cfg, Options{Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}}, DialContext: failingDial})
+	if err != nil {
+		t.Fatalf("New third: %v", err)
+	}
+	t.Cleanup(func() { _ = third.Close() })
+	if got := third.Health().LastError; strings.Contains(got, "locked by another process") {
+		t.Fatalf("third forwarder still reports a lock conflict: %q", got)
+	}
+}
+
+func TestForwarderDropsUnencodableEventWithoutBlocking(t *testing.T) {
+	t.Parallel()
+	delivered := make(chan int, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		var envelope Envelope
+		if err := decodeEnvelope(r.Body, &envelope); err != nil {
+			http.Error(w, "bad", http.StatusBadRequest)
+			return
+		}
+		delivered <- int(envelope.Event.Fields["sequence"].(float64))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	f, err := New(cfg, Options{Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}}, DialContext: routeToServer(t, srv)})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	// A non-finite float can never be JSON-encoded. It must be dropped, not
+	// retried forever ahead of every later event.
+	bad := emit.Event{Severity: emit.SeverityWarn, Type: "blocked", Timestamp: time.Unix(1, 0).UTC(), InstanceID: "agent-a", Fields: map[string]any{"bad": math.Inf(1)}}
+	if err := f.Emit(t.Context(), bad); err != nil {
+		t.Fatalf("Emit bad: %v", err)
+	}
+	if err := f.Emit(t.Context(), testEvent(2)); err != nil {
+		t.Fatalf("Emit good: %v", err)
+	}
+	select {
+	case seq := <-delivered:
+		if seq != 2 {
+			t.Fatalf("delivered sequence %d, want the good event (2)", seq)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("good event was blocked behind the unencodable one")
+	}
+	waitFor(t, func() bool { return f.Health().Dropped == 1 })
+}
+
+func TestForwarderDropsNewEventsWhenSpoolAtCapacity(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	cfg.MaxSpoolBytes = 150 // room for roughly one record, not two
+	f, err := New(cfg, Options{
+		Resolver:      &sequenceResolver{answers: [][]string{{testPublicIP}}},
+		DeferredStart: true,
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("endpoint down")
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	f.Start()
+	t.Cleanup(func() { _ = f.Close() })
+	for i := 1; i <= 5; i++ {
+		if err := f.Emit(t.Context(), testEvent(i)); err != nil {
+			t.Fatalf("Emit(%d): %v", i, err)
+		}
+	}
+	waitFor(t, func() bool { return f.Health().Dropped > 0 })
+	info, err := os.Stat(cfg.SpoolFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() > cfg.MaxSpoolBytes {
+		t.Fatalf("spool grew to %d bytes, past the %d cap", info.Size(), cfg.MaxSpoolBytes)
+	}
+}
+
+func TestForwarderCompactsSpoolAfterFullDelivery(t *testing.T) {
+	t.Parallel()
+	var delivered atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		delivered.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	f, err := New(cfg, Options{Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}}, DialContext: routeToServer(t, srv)})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	for i := 1; i <= 4; i++ {
+		if err := f.Emit(t.Context(), testEvent(i)); err != nil {
+			t.Fatalf("Emit(%d): %v", i, err)
+		}
+	}
+	waitFor(t, func() bool { return f.Health().Delivered == 4 })
+	// After every record is acknowledged the spool is truncated so the file
+	// does not grow without bound during healthy operation.
+	waitFor(t, func() bool {
+		info, statErr := os.Stat(cfg.SpoolFile)
+		return statErr == nil && info.Size() == 0
+	})
+	c, err := loadCursor(cfg.SpoolFile, cfg.CursorFile)
+	if err != nil {
+		t.Fatalf("loadCursor after compaction: %v", err)
+	}
+	if c.Offset != 0 {
+		t.Fatalf("cursor offset = %d after compaction, want 0", c.Offset)
+	}
+}
+
+func TestCloseAbortsInFlightDeliveryPromptly(t *testing.T) {
+	t.Parallel()
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		// Block until the client aborts the request (the behavior under test)
+		// or the test releases us, so srv.Close never waits on a stuck handler.
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) }) // LIFO: runs before srv.Close
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	cfg.Timeout = 30 * time.Second // Close must beat this via cancellation, not timeout
+	f, err := New(cfg, Options{Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}}, DialContext: routeToServer(t, srv)})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := f.Emit(t.Context(), testEvent(1)); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("delivery did not reach the endpoint")
+	}
+	done := make(chan struct{})
+	go func() {
+		_ = f.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close blocked on in-flight delivery instead of cancelling it")
 	}
 }
 

--- a/enterprise/siemforward/forwarder_test.go
+++ b/enterprise/siemforward/forwarder_test.go
@@ -1,0 +1,597 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package siemforward
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/emit"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
+)
+
+const testPublicIP = "203.0.113.10"
+
+type sequenceResolver struct {
+	mu      sync.Mutex
+	answers [][]string
+	calls   int
+}
+
+type blockingResolver struct{}
+
+func (blockingResolver) LookupHost(ctx context.Context, _ string) ([]string, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (r *sequenceResolver) LookupHost(_ context.Context, _ string) ([]string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.answers) == 0 {
+		return nil, errors.New("no resolver answer")
+	}
+	idx := r.calls
+	if idx >= len(r.answers) {
+		idx = len(r.answers) - 1
+	}
+	r.calls++
+	return append([]string(nil), r.answers[idx]...), nil
+}
+
+func testConfig(t *testing.T, rawURL string) Config {
+	t.Helper()
+	dir := t.TempDir()
+	return Config{
+		URL:          rawURL,
+		AllowedHosts: []string{"api.vendor.example"},
+		SpoolFile:    filepath.Join(dir, "forward.spool"),
+		CursorFile:   filepath.Join(dir, "forward.cursor"),
+		QueueSize:    8,
+		Timeout:      time.Second,
+	}
+}
+
+func testEvent(n int) emit.Event {
+	return emit.Event{
+		Severity:   emit.SeverityWarn,
+		Type:       "blocked",
+		Timestamp:  time.Unix(int64(n), 0).UTC(),
+		InstanceID: "agent-a",
+		Fields:     map[string]any{"sequence": n},
+	}
+}
+
+func TestNewFailsClosedForUnsafeDestinations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		rawURL  string
+		allowed []string
+		resolve []string
+	}{
+		{name: "loopback DNS", rawURL: "http://api.vendor.example/events", allowed: []string{"api.vendor.example"}, resolve: []string{"127.0.0.1"}},
+		{name: "private DNS", rawURL: "http://api.vendor.example/events", allowed: []string{"api.vendor.example"}, resolve: []string{"10.2.3.4"}},
+		{name: "link local DNS", rawURL: "http://api.vendor.example/events", allowed: []string{"api.vendor.example"}, resolve: []string{"169.254.10.2"}},
+		{name: "metadata DNS", rawURL: "http://api.vendor.example/events", allowed: []string{"api.vendor.example"}, resolve: []string{"169.254.169.254"}},
+		{name: "private DNS", rawURL: "https://api.vendor.example/events", allowed: []string{"api.vendor.example"}, resolve: []string{"192.168.1.20"}},
+		{name: "missing allowlist", rawURL: "https://api.vendor.example/events", resolve: []string{testPublicIP}},
+		{name: "wrong allowlist", rawURL: "https://api.vendor.example/events", allowed: []string{"other.vendor.example"}, resolve: []string{testPublicIP}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testConfig(t, tc.rawURL)
+			cfg.AllowedHosts = tc.allowed
+			resolver := &sequenceResolver{answers: [][]string{tc.resolve}}
+			if _, err := New(cfg, Options{Resolver: resolver}); err == nil {
+				t.Fatal("New() succeeded for unsafe destination")
+			}
+		})
+	}
+}
+
+func TestNewBoundsStartupDNSResolution(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	cfg.Timeout = 20 * time.Millisecond
+	f, err := New(cfg, Options{Resolver: blockingResolver{}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !strings.Contains(f.Health().LastError, "destination unresolved") {
+		t.Fatalf("health = %+v, want degraded resolver state", f.Health())
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestNewAllowsExplicitPrivateIPLiteral(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "http://127.0.0.1/events")
+	cfg.AllowedHosts = []string{"127.0.0.1"}
+	f, err := New(cfg, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestForwarderIPLiteralCannotBeRetargetedByResolver(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "http://"+testPublicIP+"/events")
+	cfg.AllowedHosts = []string{testPublicIP}
+	dialed := make(chan string, 1)
+	f, err := New(cfg, Options{
+		Resolver: &sequenceResolver{answers: [][]string{{"127.0.0.1"}}},
+		DialContext: func(_ context.Context, _, addr string) (net.Conn, error) {
+			dialed <- addr
+			return nil, errors.New("test dial failure")
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if err := f.Emit(t.Context(), testEvent(1)); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	select {
+	case addr := <-dialed:
+		if addr != net.JoinHostPort(testPublicIP, "80") {
+			t.Fatalf("dial address = %q, want pinned literal", addr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("dial was not attempted")
+	}
+}
+
+func TestForwarderDeniesDNSRebindingAtSendTime(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	resolver := &sequenceResolver{answers: [][]string{{testPublicIP}, {"127.0.0.1"}}}
+	dialed := make(chan struct{}, 1)
+	f, err := New(cfg, Options{
+		Resolver: resolver,
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			dialed <- struct{}{}
+			return nil, errors.New("must not dial")
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if err := f.Emit(t.Context(), testEvent(1)); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	waitFor(t, func() bool { return f.Health().Failed > 0 })
+	select {
+	case <-dialed:
+		t.Fatal("dialer called after DNS rebound to loopback")
+	default:
+	}
+	if got := f.Health().Delivered; got != 0 {
+		t.Fatalf("Delivered = %d, want 0", got)
+	}
+}
+
+func TestForwarderDoesNotPersistOrReportEndpointCredentials(t *testing.T) {
+	t.Parallel()
+	const (
+		querySecret = "query-secret-value"
+		authSecret  = "bearer-secret-value"
+	)
+	cfg := testConfig(t, "http://api.vendor.example/events?token="+querySecret)
+	cfg.AuthToken = authSecret
+	f, err := New(cfg, Options{
+		Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}},
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("test dial failure")
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if err := f.Emit(t.Context(), testEvent(1)); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	waitFor(t, func() bool { return f.Health().Failed > 0 })
+	health := f.Health()
+	if strings.Contains(health.LastError, querySecret) || strings.Contains(health.LastError, authSecret) {
+		t.Fatalf("delivery health leaked endpoint credential: %q", health.LastError)
+	}
+	spool, err := os.ReadFile(cfg.SpoolFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(spool), querySecret) || strings.Contains(string(spool), authSecret) {
+		t.Fatal("spool contains endpoint credential")
+	}
+}
+
+func TestForwarderRefusesRedirectWithoutForwardingAuthorization(t *testing.T) {
+	t.Parallel()
+	const token = "redirect-test-token"
+	var redirectedHits atomic.Int32
+	redirected := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectedHits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(redirected.Close)
+	authSeen := make(chan string, 1)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authSeen <- r.Header.Get("Authorization")
+		http.Redirect(w, r, redirected.URL+"/steal", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(origin.Close)
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	cfg.AuthToken = token
+	f, err := New(cfg, Options{
+		Resolver:    &sequenceResolver{answers: [][]string{{testPublicIP}}},
+		DialContext: routeToServer(t, origin),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if err := f.Emit(t.Context(), testEvent(1)); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	select {
+	case auth := <-authSeen:
+		if auth != "Bearer "+token {
+			t.Fatalf("origin Authorization = %q", auth)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("origin did not receive delivery")
+	}
+	waitFor(t, func() bool { return f.Health().Failed > 0 })
+	if redirectedHits.Load() != 0 {
+		t.Fatal("redirect target received a request")
+	}
+}
+
+func TestForwarderReplayCursorResumesWithoutGap(t *testing.T) {
+	t.Parallel()
+	received := make(chan int, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		var envelope Envelope
+		if err := decodeEnvelope(r.Body, &envelope); err != nil {
+			t.Errorf("decode envelope: %v", err)
+			http.Error(w, "bad envelope", http.StatusBadRequest)
+			return
+		}
+		received <- int(envelope.Event.Fields["sequence"].(float64))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	resolver := &sequenceResolver{answers: [][]string{{testPublicIP}}}
+	dial := routeToServer(t, srv)
+	f, err := New(cfg, Options{Resolver: resolver, DialContext: dial})
+	if err != nil {
+		t.Fatalf("New first: %v", err)
+	}
+	for i := 1; i <= 3; i++ {
+		if err := f.Emit(t.Context(), testEvent(i)); err != nil {
+			t.Fatalf("Emit(%d): %v", i, err)
+		}
+	}
+	waitFor(t, func() bool { return f.Health().Delivered == 3 })
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close first: %v", err)
+	}
+
+	f2, err := New(cfg, Options{Resolver: resolver, DialContext: dial})
+	if err != nil {
+		t.Fatalf("New restart: %v", err)
+	}
+	t.Cleanup(func() { _ = f2.Close() })
+	if err := f2.Emit(t.Context(), testEvent(4)); err != nil {
+		t.Fatalf("Emit(4): %v", err)
+	}
+	waitFor(t, func() bool { return f2.Health().Delivered == 1 })
+
+	var got []int
+	for len(received) > 0 {
+		got = append(got, <-received)
+	}
+	want := []int{1, 2, 3, 4}
+	if len(got) != len(want) {
+		t.Fatalf("received = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("received = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestForwarderCorruptCursorFailsClosed(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	if err := os.WriteFile(cfg.CursorFile, []byte(`{"version":1,"source_file":"wrong","offset":100,"content_hash":"bad"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resolver := &sequenceResolver{answers: [][]string{{testPublicIP}}}
+	if _, err := New(cfg, Options{Resolver: resolver}); err == nil {
+		t.Fatal("New succeeded with corrupt cursor")
+	}
+}
+
+func TestNewRestrictsExistingStateFilePermissions(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	absSpool, err := filepath.Abs(cfg.SpoolFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursorJSON := fmt.Sprintf(`{"version":1,"source_file":%q,"offset":0,"content_hash":""}`, absSpool)
+	if err := os.WriteFile(cfg.CursorFile, []byte(cursorJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cursorFile, err := os.OpenFile(filepath.Clean(cfg.CursorFile), os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cursorFile.Chmod(0o666); err != nil {
+		_ = cursorFile.Close()
+		t.Fatal(err)
+	}
+	if err := cursorFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := New(cfg, Options{Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	for _, path := range []string{cfg.SpoolFile, cfg.CursorFile} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("%s mode = 0o%03o, want 0o600", path, got)
+		}
+	}
+}
+
+func TestForwarderRejectsSpoolSymlinkSwappedAfterValidation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows has no O_NOFOLLOW equivalent")
+	}
+	t.Parallel()
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	f, err := New(cfg, Options{Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	victim := filepath.Join(t.TempDir(), "victim")
+	const victimContent = "must-not-change"
+	if err := os.WriteFile(victim, []byte(victimContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(cfg.SpoolFile); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victim, cfg.SpoolFile); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Emit(t.Context(), testEvent(1)); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	waitFor(t, func() bool { return f.Health().Failed > 0 })
+	got, err := os.ReadFile(filepath.Clean(victim))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != victimContent {
+		t.Fatalf("symlink target changed to %q", got)
+	}
+}
+
+func TestForwarderDeferredStartDoesNotReplayUntilActivated(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	resolver := &sequenceResolver{answers: [][]string{{testPublicIP}}}
+	dials := make(chan struct{}, 1)
+	f, err := New(cfg, Options{
+		Resolver:      resolver,
+		DeferredStart: true,
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			dials <- struct{}{}
+			return nil, errors.New("test dial")
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := f.Emit(t.Context(), testEvent(1)); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	select {
+	case <-dials:
+		t.Fatal("delivery started before Start")
+	case <-time.After(50 * time.Millisecond):
+	}
+	f.Start()
+	waitFor(t, func() bool { return f.Health().Failed > 0 })
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestForwarderQueueFullDropsWithoutBlocking(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	cfg.QueueSize = 1
+	release := make(chan struct{})
+	dialStarted := make(chan struct{}, 1)
+	f, err := New(cfg, Options{
+		Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}},
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			select {
+			case dialStarted <- struct{}{}:
+			default:
+			}
+			<-release
+			return nil, errors.New("released")
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() {
+		close(release)
+		_ = f.Close()
+	}()
+	if err := f.Emit(t.Context(), testEvent(1)); err != nil {
+		t.Fatalf("first Emit: %v", err)
+	}
+	select {
+	case <-dialStarted:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not start delivery")
+	}
+
+	deadline := time.Now().Add(250 * time.Millisecond)
+	drops := 0
+	for i := 2; i < 1000; i++ {
+		if errors.Is(f.Emit(t.Context(), testEvent(i)), ErrQueueFull) {
+			drops++
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Emit blocked while queue was full")
+		}
+	}
+	if drops == 0 || f.Health().Dropped == 0 {
+		t.Fatalf("drops = %d, health = %+v", drops, f.Health())
+	}
+}
+
+func TestForwarderConcurrentCloseDoesNotLoseAcceptedEvents(t *testing.T) {
+	t.Parallel()
+	var received atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	cfg.QueueSize = 256
+	f, err := New(cfg, Options{
+		Resolver:    &sequenceResolver{answers: [][]string{{testPublicIP}}},
+		DialContext: routeToServer(t, srv),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var accepted atomic.Int32
+	var producers sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		producers.Add(1)
+		go func(sequence int) {
+			defer producers.Done()
+			if err := f.Emit(t.Context(), testEvent(sequence)); err == nil {
+				accepted.Add(1)
+			} else if !errors.Is(err, errClosed) {
+				t.Errorf("Emit: %v", err)
+			}
+		}(i)
+	}
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- f.Close() }()
+	producers.Wait()
+	if err := <-closeDone; err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	f2, err := New(cfg, Options{
+		Resolver:    &sequenceResolver{answers: [][]string{{testPublicIP}}},
+		DialContext: routeToServer(t, srv),
+	})
+	if err != nil {
+		t.Fatalf("New after shutdown: %v", err)
+	}
+	waitFor(t, func() bool { return received.Load() == accepted.Load() })
+	if err := f2.Close(); err != nil {
+		t.Fatalf("Close restarted forwarder: %v", err)
+	}
+	if got, want := received.Load(), accepted.Load(); got != want {
+		t.Fatalf("received %d events, want all %d accepted across shutdown replay", got, want)
+	}
+}
+
+func TestForwarderRetriesPendingWithoutNewEvent(t *testing.T) {
+	t.Parallel()
+	received := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received <- struct{}{}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	cfg := testConfig(t, "http://api.vendor.example/events")
+	cfg.RetryInterval = 20 * time.Millisecond
+	var attempts atomic.Int32
+	route := routeToServer(t, srv)
+	f, err := New(cfg, Options{
+		Resolver: &sequenceResolver{answers: [][]string{{testPublicIP}}},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if attempts.Add(1) == 1 {
+				return nil, errors.New("temporary outage")
+			}
+			return route(ctx, network, addr)
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if err := f.Emit(t.Context(), testEvent(1)); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	select {
+	case <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pending event was not retried")
+	}
+	waitFor(t, func() bool { return f.Health().Delivered == 1 })
+	if f.Health().Delivered != 1 || f.Health().Failed == 0 {
+		t.Fatalf("health = %+v", f.Health())
+	}
+}
+
+func routeToServer(t *testing.T, srv *httptest.Server) func(context.Context, string, string) (net.Conn, error) {
+	t.Helper()
+	addr := srv.Listener.Addr().String()
+	d := &net.Dialer{Timeout: time.Second}
+	return func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return d.DialContext(ctx, network, addr)
+	}
+}
+
+func waitFor(t *testing.T, ok func() bool) {
+	t.Helper()
+	testwait.For(t, 3*time.Second, ok, "forwarder condition")
+}

--- a/enterprise/siemforward/lock_unix.go
+++ b/enterprise/siemforward/lock_unix.go
@@ -1,0 +1,38 @@
+//go:build enterprise && !windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package siemforward
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// acquireStateLock takes an exclusive advisory lock on a sidecar lock file so a
+// second process cannot deliver against the same spool and cursor. The lock is
+// held for the forwarder's lifetime and released by releaseStateLock on Close.
+func acquireStateLock(spoolPath string) (*os.File, error) {
+	lockPath := filepath.Clean(spoolPath + ".lock")
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open siem forwarder lock file %q: %w", lockPath, err)
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("siem forwarder state files %q are locked by another process: %w", spoolPath, err)
+	}
+	return file, nil
+}
+
+// releaseStateLock unlocks and closes the lock file. Safe to call with nil.
+func releaseStateLock(file *os.File) {
+	if file == nil {
+		return
+	}
+	_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+	_ = file.Close()
+}

--- a/enterprise/siemforward/lock_windows.go
+++ b/enterprise/siemforward/lock_windows.go
@@ -1,0 +1,44 @@
+//go:build enterprise && windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package siemforward
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// acquireStateLock takes an exclusive lock on a sidecar lock file so a second
+// process cannot deliver against the same spool and cursor. The lock is held
+// for the forwarder's lifetime and released by releaseStateLock on Close.
+func acquireStateLock(spoolPath string) (*os.File, error) {
+	lockPath := filepath.Clean(spoolPath + ".lock")
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open siem forwarder lock file %q: %w", lockPath, err)
+	}
+	overlapped := new(windows.Overlapped)
+	err = windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, overlapped,
+	)
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("siem forwarder state files %q are locked by another process: %w", spoolPath, err)
+	}
+	return file, nil
+}
+
+// releaseStateLock unlocks and closes the lock file. Safe to call with nil.
+func releaseStateLock(file *os.File) {
+	if file == nil {
+		return
+	}
+	_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, new(windows.Overlapped))
+	_ = file.Close()
+}

--- a/enterprise/siemforward/nofollow_unix.go
+++ b/enterprise/siemforward/nofollow_unix.go
@@ -1,0 +1,10 @@
+//go:build enterprise && !windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package siemforward
+
+import "syscall"
+
+// noFollowFlag closes the Lstat-to-open race on the final path component.
+const noFollowFlag = syscall.O_NOFOLLOW

--- a/enterprise/siemforward/nofollow_windows.go
+++ b/enterprise/siemforward/nofollow_windows.go
@@ -1,0 +1,9 @@
+//go:build enterprise && windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package siemforward
+
+// Windows has no os.OpenFile equivalent of O_NOFOLLOW. Lstat rejection and
+// post-open regular-file verification still apply.
+const noFollowFlag = 0

--- a/internal/cli/runtime/emit_forwarder_enterprise.go
+++ b/internal/cli/runtime/emit_forwarder_enterprise.go
@@ -22,9 +22,8 @@ func appendEnterpriseEmitSinks(cfg *config.Config, sinks []emit.Sink, observer e
 	// The forwarder's SSRF floor must not inherit `internal: null`, which is a
 	// deliberate escape hatch for the main request scanner. Forwarding always
 	// denies the immutable default ranges plus any operator-added ranges.
-	ssrfCfg := *cfg
-	ssrfCfg.Internal = append(append([]string(nil), config.Defaults().Internal...), cfg.Internal...)
-	ssrfScanner := scanner.New(&ssrfCfg)
+	ssrfCfg := cfg.WithSIEMForwarderSSRFFloor()
+	ssrfScanner := scanner.New(ssrfCfg)
 	forwarder, err := siemforward.New(siemforward.Config{
 		URL:          forwardCfg.URL,
 		AllowedHosts: forwardCfg.DestinationAllowlist,

--- a/internal/cli/runtime/emit_forwarder_enterprise.go
+++ b/internal/cli/runtime/emit_forwarder_enterprise.go
@@ -25,14 +25,16 @@ func appendEnterpriseEmitSinks(cfg *config.Config, sinks []emit.Sink, observer e
 	ssrfCfg := cfg.WithSIEMForwarderSSRFFloor()
 	ssrfScanner := scanner.New(ssrfCfg)
 	forwarder, err := siemforward.New(siemforward.Config{
-		URL:          forwardCfg.URL,
-		AllowedHosts: forwardCfg.DestinationAllowlist,
-		SpoolFile:    forwardCfg.SpoolFile,
-		CursorFile:   forwardCfg.CursorFile,
-		AuthToken:    forwardCfg.AuthToken,
-		QueueSize:    forwardCfg.QueueSize,
-		Timeout:      time.Duration(forwardCfg.TimeoutSeconds) * time.Second,
-		MinSeverity:  emit.ParseSeverity(forwardCfg.MinSeverity),
+		URL:               forwardCfg.URL,
+		AllowedHosts:      forwardCfg.DestinationAllowlist,
+		SpoolFile:         forwardCfg.SpoolFile,
+		CursorFile:        forwardCfg.CursorFile,
+		AuthToken:         forwardCfg.AuthToken,
+		QueueSize:         forwardCfg.QueueSize,
+		Timeout:           time.Duration(forwardCfg.TimeoutSeconds) * time.Second,
+		MinSeverity:       emit.ParseSeverity(forwardCfg.MinSeverity),
+		MaxSpoolBytes:     forwardCfg.MaxSpoolBytes,
+		AllowInsecureHTTP: forwardCfg.AllowInsecureHTTP,
 	}, siemforward.Options{
 		Resolver:      ssrfScanner.HostResolver(),
 		IsInternalIP:  ssrfScanner.IsInternalIP,

--- a/internal/cli/runtime/emit_forwarder_enterprise.go
+++ b/internal/cli/runtime/emit_forwarder_enterprise.go
@@ -1,0 +1,49 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package runtime
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/siemforward"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/emit"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+func appendEnterpriseEmitSinks(cfg *config.Config, sinks []emit.Sink, observer emitDeliveryObserver) ([]emit.Sink, error) {
+	forwardCfg := cfg.Emit.Forwarder
+	if forwardCfg.URL == "" {
+		return sinks, nil
+	}
+	// The forwarder's SSRF floor must not inherit `internal: null`, which is a
+	// deliberate escape hatch for the main request scanner. Forwarding always
+	// denies the immutable default ranges plus any operator-added ranges.
+	ssrfCfg := *cfg
+	ssrfCfg.Internal = append(append([]string(nil), config.Defaults().Internal...), cfg.Internal...)
+	ssrfScanner := scanner.New(&ssrfCfg)
+	forwarder, err := siemforward.New(siemforward.Config{
+		URL:          forwardCfg.URL,
+		AllowedHosts: forwardCfg.DestinationAllowlist,
+		SpoolFile:    forwardCfg.SpoolFile,
+		CursorFile:   forwardCfg.CursorFile,
+		AuthToken:    forwardCfg.AuthToken,
+		QueueSize:    forwardCfg.QueueSize,
+		Timeout:      time.Duration(forwardCfg.TimeoutSeconds) * time.Second,
+		MinSeverity:  emit.ParseSeverity(forwardCfg.MinSeverity),
+	}, siemforward.Options{
+		Resolver:      ssrfScanner.HostResolver(),
+		IsInternalIP:  ssrfScanner.IsInternalIP,
+		Close:         ssrfScanner.Close,
+		Observer:      observer,
+		DeferredStart: true,
+	})
+	if err != nil {
+		ssrfScanner.Close()
+		return sinks, fmt.Errorf("creating durable SIEM forwarder: %w", err)
+	}
+	return append(sinks, forwarder), nil
+}

--- a/internal/cli/runtime/emit_forwarder_enterprise_test.go
+++ b/internal/cli/runtime/emit_forwarder_enterprise_test.go
@@ -5,19 +5,33 @@
 package runtime
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/emit"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 func TestBuildEmitSinksCreatesDormantEnterpriseForwarder(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	var delivered atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		delivered.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
 	cfg := config.Defaults()
-	cfg.DNS.HostOverrides = map[string][]string{"api.vendor.example": {"203.0.113.10"}}
 	cfg.Emit.Forwarder = config.ForwarderConfig{
-		URL: "https://api.vendor.example/events", DestinationAllowlist: []string{"api.vendor.example"},
+		URL: srv.URL + "/events", DestinationAllowlist: []string{"127.0.0.1"},
 		SpoolFile: dir + "/spool", CursorFile: dir + "/cursor", MinSeverity: config.SeverityWarn,
 		TimeoutSeconds: 1, QueueSize: 4,
 	}
@@ -28,9 +42,68 @@ func TestBuildEmitSinksCreatesDormantEnterpriseForwarder(t *testing.T) {
 	if len(sinks) != 1 {
 		t.Fatalf("len(sinks) = %d, want 1", len(sinks))
 	}
+	if err := sinks[0].Emit(context.Background(), emit.Event{Severity: emit.SeverityWarn, Type: "blocked", Timestamp: time.Now()}); err != nil {
+		t.Fatalf("Emit before activation: %v", err)
+	}
+	if delivered.Load() != 0 {
+		t.Fatal("dormant forwarder delivered before activation")
+	}
+	info, err := os.Stat(cfg.Emit.Forwarder.SpoolFile)
+	if err != nil {
+		t.Fatalf("stat spool: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("dormant spool size = %d, want 0", info.Size())
+	}
 	activateEmitSinks(sinks)
+	testwait.For(t, 2*time.Second, func() bool { return delivered.Load() == 1 }, "delivery after activation")
 	if err := sinks[0].Close(); err != nil {
 		t.Fatalf("Close: %v", err)
+	}
+}
+
+type closeTrackingSink struct {
+	inner  emit.Sink
+	closed atomic.Bool
+}
+
+func (s *closeTrackingSink) Emit(ctx context.Context, event emit.Event) error {
+	return s.inner.Emit(ctx, event)
+}
+
+func (s *closeTrackingSink) Close() error {
+	s.closed.Store(true)
+	return s.inner.Close()
+}
+
+func TestBuildEmitSinksClosesExistingSinkWhenForwarderConstructionFails(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	cfg := config.Defaults()
+	cfg.Emit.Webhook.URL = srv.URL
+	cfg.Emit.Webhook.MinSeverity = config.SeverityInfo
+	var existing *closeTrackingSink
+	wantErr := errors.New("forwarder construction failed")
+	appendFailure := func(_ *config.Config, sinks []emit.Sink, _ emitDeliveryObserver) ([]emit.Sink, error) {
+		if len(sinks) != 1 {
+			t.Fatalf("existing sinks = %d, want webhook sink", len(sinks))
+		}
+		existing = &closeTrackingSink{inner: sinks[0]}
+		return []emit.Sink{existing}, wantErr
+	}
+
+	sinks, err := buildEmitSinks(cfg, nil, appendFailure)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("BuildEmitSinks error = %v, want %v", err, wantErr)
+	}
+	if sinks != nil {
+		t.Fatalf("sinks = %v, want nil", sinks)
+	}
+	if existing == nil || !existing.closed.Load() {
+		t.Fatal("existing sink was not closed after forwarder construction failure")
 	}
 }
 

--- a/internal/cli/runtime/emit_forwarder_enterprise_test.go
+++ b/internal/cli/runtime/emit_forwarder_enterprise_test.go
@@ -1,0 +1,52 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestBuildEmitSinksCreatesDormantEnterpriseForwarder(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg := config.Defaults()
+	cfg.DNS.HostOverrides = map[string][]string{"api.vendor.example": {"203.0.113.10"}}
+	cfg.Emit.Forwarder = config.ForwarderConfig{
+		URL: "https://api.vendor.example/events", DestinationAllowlist: []string{"api.vendor.example"},
+		SpoolFile: dir + "/spool", CursorFile: dir + "/cursor", MinSeverity: config.SeverityWarn,
+		TimeoutSeconds: 1, QueueSize: 4,
+	}
+	sinks, err := BuildEmitSinks(cfg)
+	if err != nil {
+		t.Fatalf("BuildEmitSinks: %v", err)
+	}
+	if len(sinks) != 1 {
+		t.Fatalf("len(sinks) = %d, want 1", len(sinks))
+	}
+	activateEmitSinks(sinks)
+	if err := sinks[0].Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestBuildEmitSinksForwarderKeepsSSRFFloorWhenMainScannerDisablesIt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DNS.HostOverrides = map[string][]string{"api.vendor.example": {"127.0.0.1"}}
+	cfg.Emit.Forwarder = config.ForwarderConfig{
+		URL: "https://api.vendor.example/events", DestinationAllowlist: []string{"api.vendor.example"},
+		SpoolFile: dir + "/spool", CursorFile: dir + "/cursor", MinSeverity: config.SeverityWarn,
+		TimeoutSeconds: 1, QueueSize: 4,
+	}
+	_, err := BuildEmitSinks(cfg)
+	if err == nil || !strings.Contains(err.Error(), "internal IP") {
+		t.Fatalf("BuildEmitSinks error = %v, want internal-IP denial", err)
+	}
+}

--- a/internal/cli/runtime/emit_forwarder_stub.go
+++ b/internal/cli/runtime/emit_forwarder_stub.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !enterprise
+
+package runtime
+
+import (
+	"errors"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/emit"
+)
+
+func appendEnterpriseEmitSinks(cfg *config.Config, sinks []emit.Sink, _ emitDeliveryObserver) ([]emit.Sink, error) {
+	if cfg.Emit.Forwarder.URL != "" {
+		return sinks, errors.New("emit.forwarder requires an enterprise build")
+	}
+	return sinks, nil
+}

--- a/internal/cli/runtime/emit_forwarder_stub_test.go
+++ b/internal/cli/runtime/emit_forwarder_stub_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !enterprise
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestBuildEmitSinksForwarderRequiresEnterpriseBuild(t *testing.T) {
+	t.Parallel()
+	cfg := config.Defaults()
+	cfg.Emit.Forwarder.URL = "https://api.vendor.example/events"
+	cfg.Emit.Forwarder.DestinationAllowlist = []string{"api.vendor.example"}
+	cfg.Emit.Forwarder.SpoolFile = t.TempDir() + "/spool"
+	cfg.Emit.Forwarder.CursorFile = t.TempDir() + "/cursor"
+	_, err := BuildEmitSinks(cfg)
+	if err == nil || !strings.Contains(err.Error(), "enterprise build") {
+		t.Fatalf("BuildEmitSinks error = %v", err)
+	}
+}

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -216,6 +216,18 @@ type emitDeliveryObserver interface {
 // BuildEmitSinks creates emit sinks from the current config.
 // Used at startup and during hot-reload.
 func BuildEmitSinks(cfg *config.Config, observers ...emitDeliveryObserver) ([]emit.Sink, error) {
+	var observer emitDeliveryObserver
+	if len(observers) > 0 {
+		observer = observers[0]
+	}
+	return buildEmitSinks(cfg, observer, appendEnterpriseEmitSinks)
+}
+
+type enterpriseSinkAppender func(*config.Config, []emit.Sink, emitDeliveryObserver) ([]emit.Sink, error)
+
+// buildEmitSinks accepts the edition-specific appender as a seam so cleanup of
+// already-created sinks can be verified on Enterprise construction failures.
+func buildEmitSinks(cfg *config.Config, observer emitDeliveryObserver, appendEnterprise enterpriseSinkAppender) ([]emit.Sink, error) {
 	var sinks []emit.Sink
 
 	if cfg.Emit.Webhook.URL != "" {
@@ -272,12 +284,8 @@ func BuildEmitSinks(cfg *config.Config, observers ...emitDeliveryObserver) ([]em
 		}
 		sinks = append(sinks, otlpSink)
 	}
-	var observer emitDeliveryObserver
-	if len(observers) > 0 {
-		observer = observers[0]
-	}
 	var err error
-	sinks, err = appendEnterpriseEmitSinks(cfg, sinks, observer)
+	sinks, err = appendEnterprise(cfg, sinks, observer)
 	if err != nil {
 		for _, sink := range sinks {
 			_ = sink.Close()

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -205,9 +205,17 @@ func agentArgsAfterDash(args []string, dashIdx int) []string {
 	return nil
 }
 
+type emitDeliveryObserver interface {
+	SetQueued(float64)
+	RecordDelivered()
+	RecordFailed()
+	RecordDropped()
+	SetLastSuccess(time.Time)
+}
+
 // BuildEmitSinks creates emit sinks from the current config.
 // Used at startup and during hot-reload.
-func BuildEmitSinks(cfg *config.Config) ([]emit.Sink, error) {
+func BuildEmitSinks(cfg *config.Config, observers ...emitDeliveryObserver) ([]emit.Sink, error) {
 	var sinks []emit.Sink
 
 	if cfg.Emit.Webhook.URL != "" {
@@ -264,6 +272,18 @@ func BuildEmitSinks(cfg *config.Config) ([]emit.Sink, error) {
 		}
 		sinks = append(sinks, otlpSink)
 	}
+	var observer emitDeliveryObserver
+	if len(observers) > 0 {
+		observer = observers[0]
+	}
+	var err error
+	sinks, err = appendEnterpriseEmitSinks(cfg, sinks, observer)
+	if err != nil {
+		for _, sink := range sinks {
+			_ = sink.Close()
+		}
+		return nil, err
+	}
 
 	return applyEmitFilter(sinks, cfg.Emit.Filter), nil
 }
@@ -282,6 +302,14 @@ func applyEmitFilter(sinks []emit.Sink, cfg config.EmitFilter) []emit.Sink {
 		wrapped = append(wrapped, emit.NewFilteringSink(sink, filter))
 	}
 	return wrapped
+}
+
+func activateEmitSinks(sinks []emit.Sink) {
+	for _, sink := range sinks {
+		if starter, ok := sink.(interface{ Start() }); ok {
+			starter.Start()
+		}
+	}
 }
 
 // RedactEndpoint strips userinfo, query, and fragment from an endpoint URL

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -211,6 +211,7 @@ type emitDeliveryObserver interface {
 	RecordFailed()
 	RecordDropped()
 	SetLastSuccess(time.Time)
+	SetSpoolBytes(float64)
 }
 
 // BuildEmitSinks creates emit sinks from the current config.

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -303,7 +303,9 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	}
 	s.logger = logger
 
-	emitSinks, emitErr := BuildEmitSinks(cfg)
+	m := metrics.New()
+	s.metrics = m
+	emitSinks, emitErr := BuildEmitSinks(cfg, m)
 	if emitErr != nil {
 		s.cleanup()
 		return nil, fmt.Errorf("creating emit sinks: %w", emitErr)
@@ -313,6 +315,7 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		instanceID = emit.DefaultInstanceID()
 	}
 	emitter := emit.NewEmitter(instanceID, emitSinks...)
+	activateEmitSinks(emitSinks)
 	logger.SetEmitter(emitter)
 	s.emitter = emitter
 	emitLicenseExpiryWarning(cfg, logger, sentryClient, opts.Stderr)
@@ -348,8 +351,6 @@ func NewServer(opts ServerOpts) (*Server, error) {
 
 	sc := scanner.New(cfg)
 	s.scanner = sc
-	m := metrics.New()
-	s.metrics = m
 	// License gate for the follower-side Conductor runtime. When
 	// conductor.enabled is true the operator has explicitly opted into
 	// central governance (remote kill, audit ingest, policy distribution);

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -371,7 +371,7 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 
 	// Reload emit sinks: build new sinks from config, swap into
 	// emitter, close old sinks.
-	newSinks, sinkErr := BuildEmitSinks(newCfg)
+	newSinks, sinkErr := BuildEmitSinks(newCfg, s.metrics)
 	if sinkErr != nil {
 		s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile),
 			fmt.Errorf("emit sink rebuild failed: %w", sinkErr))
@@ -383,6 +383,7 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 					fmt.Errorf("closing old emit sink: %w", closeErr))
 			}
 		}
+		activateEmitSinks(newSinks)
 	}
 
 	if needsHITLApprover(newCfg) && !s.hasApprover {

--- a/internal/cli/support/redact.go
+++ b/internal/cli/support/redact.go
@@ -67,6 +67,13 @@ func redactConfig(cfg *config.Config) map[string]any {
 			"otlp_endpoint":  redactURL(cfg.Emit.OTLP.Endpoint),
 			"otlp_headers":   redactHeaders(cfg.Emit.OTLP.Headers),
 			"syslog_address": redactURL(cfg.Emit.Syslog.Address),
+			"forwarder_url":  redactURL(cfg.Emit.Forwarder.URL),
+			"forwarder_auth_token": func() string {
+				if cfg.Emit.Forwarder.AuthToken != "" {
+					return redactedPlaceholder
+				}
+				return ""
+			}(),
 		},
 		"kill_switch": map[string]any{
 			"enabled":       cfg.KillSwitch.Enabled,

--- a/internal/config/forwarder_test.go
+++ b/internal/config/forwarder_test.go
@@ -36,6 +36,9 @@ func TestLoadForwarderDefaultsAndNulls(t *testing.T) {
 			if cfg.Emit.Forwarder.MinSeverity != SeverityWarn || cfg.Emit.Forwarder.TimeoutSeconds != 5 || cfg.Emit.Forwarder.QueueSize != 256 {
 				t.Fatalf("forwarder defaults = %+v", cfg.Emit.Forwarder)
 			}
+			if cfg.Emit.Forwarder.MaxSpoolBytes != defaultForwarderMaxSpoolBytes {
+				t.Fatalf("forwarder max_spool_bytes = %d, want default %d", cfg.Emit.Forwarder.MaxSpoolBytes, defaultForwarderMaxSpoolBytes)
+			}
 		})
 	}
 }
@@ -58,6 +61,16 @@ func TestValidateForwarderFailClosed(t *testing.T) {
 		{name: "fragment", mutate: func(c *ForwarderConfig) { c.URL = "https://api.vendor.example/events#secret" }, wantError: "fragment"},
 		{name: "userinfo", mutate: func(c *ForwarderConfig) { c.URL = "https://user:pass@api.vendor.example/events" }, wantError: "userinfo"},
 		{name: "bad severity", mutate: func(c *ForwarderConfig) { c.MinSeverity = "debug" }, wantError: "min_severity"},
+		{name: "http remote without flag", mutate: func(c *ForwarderConfig) { c.URL = "http://api.vendor.example/events" }, wantError: "allow_insecure_http"},
+		{name: "http remote with token", mutate: func(c *ForwarderConfig) {
+			c.URL = "http://api.vendor.example/events"
+			c.AuthToken = "bearer"
+		}, wantError: "requires an https"},
+		{name: "http remote token ignores insecure flag", mutate: func(c *ForwarderConfig) {
+			c.URL = "http://api.vendor.example/events"
+			c.AuthToken = "bearer"
+			c.AllowInsecureHTTP = true
+		}, wantError: "requires an https"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -87,5 +100,42 @@ func TestValidateForwarderValid(t *testing.T) {
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestValidateForwarderTransportPolicyAllowsSafe(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*ForwarderConfig)
+	}{
+		{name: "loopback http with token", mutate: func(c *ForwarderConfig) {
+			c.URL = "http://127.0.0.1/events"
+			c.DestinationAllowlist = []string{"127.0.0.1"}
+			c.AuthToken = "bearer"
+		}},
+		{name: "localhost http", mutate: func(c *ForwarderConfig) {
+			c.URL = "http://localhost/events"
+			c.DestinationAllowlist = []string{"localhost"}
+		}},
+		{name: "remote http with explicit insecure flag", mutate: func(c *ForwarderConfig) {
+			c.URL = "http://api.vendor.example/events"
+			c.AllowInsecureHTTP = true
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Defaults()
+			cfg.Emit.Forwarder = ForwarderConfig{
+				URL: "https://api.vendor.example/events", DestinationAllowlist: []string{"api.vendor.example"},
+				SpoolFile: "/var/lib/pipelock/siem.spool", CursorFile: "/var/lib/pipelock/siem.cursor",
+				MinSeverity: SeverityWarn, TimeoutSeconds: 5, QueueSize: 256,
+			}
+			tc.mutate(&cfg.Emit.Forwarder)
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+		})
 	}
 }

--- a/internal/config/forwarder_test.go
+++ b/internal/config/forwarder_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadForwarderDefaultsAndNulls(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		extra string
+	}{
+		{name: "omitted"},
+		{name: "blank", extra: "    min_severity:\n    timeout_seconds:\n    queue_size:\n"},
+		{name: "null", extra: "    min_severity: null\n    timeout_seconds: null\n    queue_size: null\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			yaml := "version: 1\nemit:\n  forwarder:\n" + tc.extra
+			if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.Emit.Forwarder.MinSeverity != SeverityWarn || cfg.Emit.Forwarder.TimeoutSeconds != 5 || cfg.Emit.Forwarder.QueueSize != 256 {
+				t.Fatalf("forwarder defaults = %+v", cfg.Emit.Forwarder)
+			}
+		})
+	}
+}
+
+func TestValidateForwarderFailClosed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		mutate    func(*ForwarderConfig)
+		wantError string
+	}{
+		{name: "no allowlist", mutate: func(c *ForwarderConfig) { c.DestinationAllowlist = nil }, wantError: "exactly present"},
+		{name: "wrong host", mutate: func(c *ForwarderConfig) { c.DestinationAllowlist = []string{"other.vendor.example"} }, wantError: "exactly present"},
+		{name: "wildcard", mutate: func(c *ForwarderConfig) { c.DestinationAllowlist = []string{"*.vendor.example"} }, wantError: "exact hostnames"},
+		{name: "missing spool", mutate: func(c *ForwarderConfig) { c.SpoolFile = "" }, wantError: "spool_file"},
+		{name: "userinfo", mutate: func(c *ForwarderConfig) { c.URL = "https://user:pass@api.vendor.example/events" }, wantError: "userinfo"},
+		{name: "bad severity", mutate: func(c *ForwarderConfig) { c.MinSeverity = "debug" }, wantError: "min_severity"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Defaults()
+			cfg.Emit.Forwarder = ForwarderConfig{
+				URL: "https://api.vendor.example/events", DestinationAllowlist: []string{"api.vendor.example"},
+				SpoolFile: "/var/lib/pipelock/siem.spool", CursorFile: "/var/lib/pipelock/siem.cursor",
+				MinSeverity: SeverityWarn, TimeoutSeconds: 5, QueueSize: 256,
+			}
+			tc.mutate(&cfg.Emit.Forwarder)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("Validate error = %v, want substring %q", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateForwarderValid(t *testing.T) {
+	t.Parallel()
+	cfg := Defaults()
+	cfg.Emit.Forwarder = ForwarderConfig{
+		URL: "https://api.vendor.example/events", DestinationAllowlist: []string{"API.VENDOR.EXAMPLE."},
+		SpoolFile: "/var/lib/pipelock/siem.spool", CursorFile: "/var/lib/pipelock/siem.cursor",
+		MinSeverity: SeverityWarn, TimeoutSeconds: 5, QueueSize: 256,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}

--- a/internal/config/forwarder_test.go
+++ b/internal/config/forwarder_test.go
@@ -51,6 +51,11 @@ func TestValidateForwarderFailClosed(t *testing.T) {
 		{name: "wrong host", mutate: func(c *ForwarderConfig) { c.DestinationAllowlist = []string{"other.vendor.example"} }, wantError: "exactly present"},
 		{name: "wildcard", mutate: func(c *ForwarderConfig) { c.DestinationAllowlist = []string{"*.vendor.example"} }, wantError: "exact hostnames"},
 		{name: "missing spool", mutate: func(c *ForwarderConfig) { c.SpoolFile = "" }, wantError: "spool_file"},
+		{name: "missing cursor", mutate: func(c *ForwarderConfig) { c.CursorFile = "" }, wantError: "cursor_file"},
+		{name: "zero timeout", mutate: func(c *ForwarderConfig) { c.TimeoutSeconds = 0 }, wantError: "must be positive"},
+		{name: "negative queue", mutate: func(c *ForwarderConfig) { c.QueueSize = -1 }, wantError: "must be positive"},
+		{name: "invalid scheme", mutate: func(c *ForwarderConfig) { c.URL = "ftp://api.vendor.example/events" }, wantError: "must be http:// or https://"},
+		{name: "fragment", mutate: func(c *ForwarderConfig) { c.URL = "https://api.vendor.example/events#secret" }, wantError: "fragment"},
 		{name: "userinfo", mutate: func(c *ForwarderConfig) { c.URL = "https://user:pass@api.vendor.example/events" }, wantError: "userinfo"},
 		{name: "bad severity", mutate: func(c *ForwarderConfig) { c.MinSeverity = "debug" }, wantError: "min_severity"},
 	}

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -495,6 +495,9 @@ func (c *Config) ApplyDefaults() {
 	if c.Emit.Forwarder.QueueSize <= 0 {
 		c.Emit.Forwarder.QueueSize = 256
 	}
+	if c.Emit.Forwarder.MaxSpoolBytes <= 0 {
+		c.Emit.Forwarder.MaxSpoolBytes = defaultForwarderMaxSpoolBytes
+	}
 	if c.Emit.Syslog.Facility == "" {
 		c.Emit.Syslog.Facility = "local0"
 	}

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -486,6 +486,15 @@ func (c *Config) ApplyDefaults() {
 	if c.Emit.OTLP.QueueSize <= 0 {
 		c.Emit.OTLP.QueueSize = 256
 	}
+	if c.Emit.Forwarder.MinSeverity == "" {
+		c.Emit.Forwarder.MinSeverity = SeverityWarn
+	}
+	if c.Emit.Forwarder.TimeoutSeconds <= 0 {
+		c.Emit.Forwarder.TimeoutSeconds = 5
+	}
+	if c.Emit.Forwarder.QueueSize <= 0 {
+		c.Emit.Forwarder.QueueSize = 256
+	}
 	if c.Emit.Syslog.Facility == "" {
 		c.Emit.Syslog.Facility = "local0"
 	}

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -522,6 +522,12 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 			Message: "OTLP log emission disabled",
 		})
 	}
+	if old.Emit.Forwarder.URL != "" && updated.Emit.Forwarder.URL == "" {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "emit.forwarder.url",
+			Message: "durable SIEM forwarding disabled",
+		})
+	}
 
 	// Kill switch API listen address changed (requires restart)
 	if old.KillSwitch.APIListen != updated.KillSwitch.APIListen {

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -205,6 +205,16 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 		})
 	}
 
+	if added := forwarderDestinationsAdded(
+		old.Emit.Forwarder.DestinationAllowlist,
+		updated.Emit.Forwarder.DestinationAllowlist,
+	); len(added) > 0 {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "emit.forwarder.destination_allowlist",
+			Message: fmt.Sprintf("SIEM forwarder destination allowlist expanded: %s — forwarding can now reach additional hosts", strings.Join(added, ", ")),
+		})
+	}
+
 	// Adaptive enforcement disabled
 	if old.AdaptiveEnforcement.Enabled && !updated.AdaptiveEnforcement.Enabled {
 		warnings = append(warnings, ReloadWarning{
@@ -1225,6 +1235,23 @@ func passthroughDomainsAdded(old, updated []string) []string {
 	for _, d := range updated {
 		if _, exists := oldSet[strings.ToLower(d)]; !exists {
 			added = append(added, d)
+		}
+	}
+	return added
+}
+
+// forwarderDestinationsAdded compares exact DNS hosts using the same
+// normalization as forwarder validation.
+func forwarderDestinationsAdded(old, updated []string) []string {
+	oldSet := make(map[string]struct{}, len(old))
+	for _, host := range old {
+		oldSet[strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))] = struct{}{}
+	}
+	var added []string
+	for _, host := range updated {
+		normalized := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+		if _, exists := oldSet[normalized]; !exists {
+			added = append(added, host)
 		}
 	}
 	return added

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -215,6 +215,13 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 		})
 	}
 
+	if !old.Emit.Forwarder.AllowInsecureHTTP && updated.Emit.Forwarder.AllowInsecureHTTP {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "emit.forwarder.allow_insecure_http",
+			Message: "SIEM forwarder cleartext http enabled — audit payloads may now be forwarded to a non-loopback host without TLS",
+		})
+	}
+
 	// Adaptive enforcement disabled
 	if old.AdaptiveEnforcement.Enabled && !updated.AdaptiveEnforcement.Enabled {
 		warnings = append(warnings, ReloadWarning{

--- a/internal/config/reloadwarn_test.go
+++ b/internal/config/reloadwarn_test.go
@@ -8,6 +8,37 @@ import (
 	"testing"
 )
 
+func TestValidateReload_ForwarderDestinationAllowlistExpanded(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		oldHosts []string
+		newHosts []string
+		want     bool
+	}{
+		{name: "expanded", oldHosts: []string{"old.example"}, newHosts: []string{"old.example", "new.example"}, want: true},
+		{name: "case and trailing dot are equivalent", oldHosts: []string{"SIEM.EXAMPLE."}, newHosts: []string{"siem.example"}},
+		{name: "contracted", oldHosts: []string{"old.example", "removed.example"}, newHosts: []string{"old.example"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			old := Defaults()
+			old.Emit.Forwarder.DestinationAllowlist = tc.oldHosts
+			updated := Defaults()
+			updated.Emit.Forwarder.DestinationAllowlist = tc.newHosts
+			got := false
+			for _, warning := range ValidateReload(old, updated) {
+				if warning.Field == "emit.forwarder.destination_allowlist" {
+					got = true
+				}
+			}
+			if got != tc.want {
+				t.Fatalf("allowlist expansion warning = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestValidateReload_AgentTrustedDomainsAdded covers the per-agent
 // trusted_domains expansion path: any agent profile whose trusted_domains
 // gains entries on reload should produce a deterministic ReloadWarning

--- a/internal/config/reloadwarn_test.go
+++ b/internal/config/reloadwarn_test.go
@@ -39,6 +39,37 @@ func TestValidateReload_ForwarderDestinationAllowlistExpanded(t *testing.T) {
 	}
 }
 
+func TestValidateReload_ForwarderInsecureHTTPEnabled(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		from bool
+		to   bool
+		want bool
+	}{
+		{name: "enabled", from: false, to: true, want: true},
+		{name: "already on", from: true, to: true},
+		{name: "disabled", from: true, to: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			old := Defaults()
+			old.Emit.Forwarder.AllowInsecureHTTP = tc.from
+			updated := Defaults()
+			updated.Emit.Forwarder.AllowInsecureHTTP = tc.to
+			got := false
+			for _, warning := range ValidateReload(old, updated) {
+				if warning.Field == "emit.forwarder.allow_insecure_http" {
+					got = true
+				}
+			}
+			if got != tc.want {
+				t.Fatalf("insecure http warning = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestValidateReload_AgentTrustedDomainsAdded covers the per-agent
 // trusted_domains expansion path: any agent profile whose trusted_domains
 // gains entries on reload should produce a deterministic ReloadWarning

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -141,6 +141,17 @@ func (c *Config) ResolveRuntime(opts RuntimeResolveOpts) (*Config, ResolveRuntim
 	return clone, info
 }
 
+// WithSIEMForwarderSSRFFloor returns a cloned config whose internal-address
+// policy contains Pipelock's immutable default ranges plus any operator-added
+// ranges. Forwarding deliberately does not inherit `internal: null`, which is
+// a supported escape hatch for the main request scanner but must not disable
+// the audit sink's SSRF floor.
+func (c *Config) WithSIEMForwarderSSRFFloor() *Config {
+	clone := c.Clone()
+	clone.Internal = append(append([]string(nil), Defaults().Internal...), c.Internal...)
+	return clone
+}
+
 func resolvedKillSwitchAPITokenValue(yamlToken string) string {
 	if envToken := os.Getenv(EnvKillSwitchAPIToken); envToken != "" {
 		return envToken

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -56,6 +56,39 @@ func TestResolveRuntime_LoadedConfigNotMutated(t *testing.T) {
 	}
 }
 
+func TestWithSIEMForwarderSSRFFloor(t *testing.T) {
+	t.Parallel()
+	defaults := Defaults().Internal
+	tests := []struct {
+		name     string
+		internal []string
+	}{
+		{name: "null keeps immutable floor"},
+		{name: "operator ranges are additive", internal: []string{"198.51.100.0/24"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.Internal = append([]string(nil), tc.internal...)
+			resolved := cfg.WithSIEMForwarderSSRFFloor()
+
+			want := append(append([]string(nil), defaults...), tc.internal...)
+			if !reflect.DeepEqual(resolved.Internal, want) {
+				t.Fatalf("resolved Internal = %v, want %v", resolved.Internal, want)
+			}
+			if !reflect.DeepEqual(cfg.Internal, tc.internal) {
+				t.Fatalf("receiver Internal mutated: got %v, want %v", cfg.Internal, tc.internal)
+			}
+			if len(tc.internal) > 0 {
+				resolved.Internal[len(defaults)] = mutatedSentinel
+				if cfg.Internal[0] == mutatedSentinel {
+					t.Fatal("resolved Internal aliases receiver")
+				}
+			}
+		})
+	}
+}
+
 func TestResolveRuntime_KillSwitchAPITokenEffectiveState(t *testing.T) {
 	const (
 		yamlToken = "yaml-token"

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1271,7 +1271,23 @@ type ForwarderConfig struct {
 	MinSeverity          string   `yaml:"min_severity"`
 	TimeoutSeconds       int      `yaml:"timeout_seconds"`
 	QueueSize            int      `yaml:"queue_size"`
+
+	// MaxSpoolBytes caps the on-disk spool. Once an append would exceed it
+	// while the endpoint is unreachable, new events are dropped (counted, not
+	// retried forever) so a stalled forwarder cannot exhaust host disk.
+	// Defaults to 100 MiB when zero or negative.
+	MaxSpoolBytes int64 `yaml:"max_spool_bytes"`
+
+	// AllowInsecureHTTP permits a plaintext http:// destination to a
+	// non-loopback host. Off by default: cleartext forwarding exposes audit
+	// payloads on the wire, and an auth_token over plaintext is refused
+	// regardless of this flag (loopback destinations excepted).
+	AllowInsecureHTTP bool `yaml:"allow_insecure_http" json:"-"`
 }
+
+// defaultForwarderMaxSpoolBytes bounds the SIEM forwarder spool at 100 MiB when
+// the operator does not set max_spool_bytes.
+const defaultForwarderMaxSpoolBytes int64 = 100 << 20
 
 // EmitFilter configures additive export filtering across all emit sinks.
 type EmitFilter struct {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1252,11 +1252,25 @@ func (h HealthWatchdog) IntervalDuration() time.Duration {
 
 // EmitConfig configures external event emission (webhook, syslog, and OTLP).
 type EmitConfig struct {
-	InstanceID string        `yaml:"instance_id"` // defaults to hostname
-	Filter     EmitFilter    `yaml:"filter" json:"-"`
-	Webhook    WebhookConfig `yaml:"webhook"`
-	Syslog     SyslogConfig  `yaml:"syslog"`
-	OTLP       OTLPConfig    `yaml:"otlp"`
+	InstanceID string          `yaml:"instance_id"` // defaults to hostname
+	Filter     EmitFilter      `yaml:"filter" json:"-"`
+	Webhook    WebhookConfig   `yaml:"webhook"`
+	Syslog     SyslogConfig    `yaml:"syslog"`
+	OTLP       OTLPConfig      `yaml:"otlp"`
+	Forwarder  ForwarderConfig `yaml:"forwarder" json:"-"`
+}
+
+// ForwarderConfig configures the Enterprise durable SIEM HTTP forwarder.
+// An empty URL disables it. DestinationAllowlist accepts exact hosts only.
+type ForwarderConfig struct {
+	URL                  string   `yaml:"url"`
+	DestinationAllowlist []string `yaml:"destination_allowlist"`
+	SpoolFile            string   `yaml:"spool_file"`
+	CursorFile           string   `yaml:"cursor_file"`
+	AuthToken            string   `yaml:"auth_token" json:"-"`
+	MinSeverity          string   `yaml:"min_severity"`
+	TimeoutSeconds       int      `yaml:"timeout_seconds"`
+	QueueSize            int      `yaml:"queue_size"`
 }
 
 // EmitFilter configures additive export filtering across all emit sinks.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2488,6 +2488,38 @@ func (c *Config) validateEmit() error {
 			return fmt.Errorf("emit.otlp.queue_size must be positive")
 		}
 	}
+	if c.Emit.Forwarder.URL != "" {
+		u, forwardErr := url.Parse(c.Emit.Forwarder.URL)
+		if forwardErr != nil || u.Host == "" || (u.Scheme != schemeHTTP && u.Scheme != schemeHTTPS) {
+			return fmt.Errorf("invalid emit.forwarder.url %q: must be http:// or https:// with a host", c.Emit.Forwarder.URL)
+		}
+		if u.User != nil || u.Fragment != "" {
+			return fmt.Errorf("emit.forwarder.url must not contain userinfo or a fragment")
+		}
+		host := strings.ToLower(strings.TrimSuffix(u.Hostname(), "."))
+		allowed := false
+		for _, entry := range c.Emit.Forwarder.DestinationAllowlist {
+			normalized := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(entry), "."))
+			if normalized == "" || (net.ParseIP(normalized) == nil && strings.ContainsAny(normalized, "*/:@[]")) {
+				return fmt.Errorf("invalid emit.forwarder.destination_allowlist entry %q: exact hostnames only", entry)
+			}
+			allowed = allowed || normalized == host
+		}
+		if !allowed {
+			return fmt.Errorf("emit.forwarder.url host %q must be exactly present in destination_allowlist", host)
+		}
+		if c.Emit.Forwarder.SpoolFile == "" || c.Emit.Forwarder.CursorFile == "" {
+			return fmt.Errorf("emit.forwarder.spool_file and cursor_file are required when forwarding is configured")
+		}
+		switch c.Emit.Forwarder.MinSeverity {
+		case SeverityInfo, SeverityWarn, SeverityCritical:
+		default:
+			return fmt.Errorf("invalid emit.forwarder.min_severity %q: must be info, warn, or critical", c.Emit.Forwarder.MinSeverity)
+		}
+		if c.Emit.Forwarder.TimeoutSeconds <= 0 || c.Emit.Forwarder.QueueSize <= 0 {
+			return fmt.Errorf("emit.forwarder.timeout_seconds and queue_size must be positive")
+		}
+	}
 	return nil
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2519,8 +2519,28 @@ func (c *Config) validateEmit() error {
 		if c.Emit.Forwarder.TimeoutSeconds <= 0 || c.Emit.Forwarder.QueueSize <= 0 {
 			return fmt.Errorf("emit.forwarder.timeout_seconds and queue_size must be positive")
 		}
+		if u.Scheme == schemeHTTP && !forwarderHostIsLoopback(host) {
+			if c.Emit.Forwarder.AuthToken != "" {
+				return fmt.Errorf("emit.forwarder.auth_token requires an https:// url: a plaintext http:// destination would expose the bearer token on the wire (loopback destinations are exempt)")
+			}
+			if !c.Emit.Forwarder.AllowInsecureHTTP {
+				return fmt.Errorf("emit.forwarder.url uses plaintext http:// to non-loopback host %q: use https://, or set emit.forwarder.allow_insecure_http: true to accept cleartext forwarding", host)
+			}
+		}
 	}
 	return nil
+}
+
+// forwarderHostIsLoopback reports whether an already-normalized forwarder host
+// refers to the local machine, where plaintext http is acceptable.
+func forwarderHostIsLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 func validateEmitFilterValues(name string, values []string) error {

--- a/internal/emit/filter.go
+++ b/internal/emit/filter.go
@@ -85,6 +85,12 @@ func (s *FilteringSink) Close() error {
 	return s.sink.Close()
 }
 
+func (s *FilteringSink) Start() {
+	if starter, ok := s.sink.(interface{ Start() }); ok {
+		starter.Start()
+	}
+}
+
 func containsFold(values []string, candidate string) bool {
 	candidate = strings.TrimSpace(candidate)
 	if candidate == "" {

--- a/internal/emit/filter_test.go
+++ b/internal/emit/filter_test.go
@@ -149,6 +149,26 @@ func TestNewFilteringSinkDisabledOrNil(t *testing.T) {
 	}
 }
 
+type startableMockSink struct {
+	mockSink
+	started bool
+}
+
+func (s *startableMockSink) Start() { s.started = true }
+
+func TestFilteringSinkStartsWrappedSink(t *testing.T) {
+	inner := &startableMockSink{}
+	sink := NewFilteringSink(inner, Filter{Actions: []string{conventionActionBlock}})
+	starter, ok := sink.(interface{ Start() })
+	if !ok {
+		t.Fatal("filtered sink does not expose deferred startup")
+	}
+	starter.Start()
+	if !inner.started {
+		t.Fatal("wrapped sink was not started")
+	}
+}
+
 func TestNormalizeEventActionAliases(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -157,6 +157,13 @@ type Metrics struct {
 	evidenceHealthFunc          func() (EvidenceHealthStats, bool)
 	evidenceCollector           *evidenceCollector
 
+	// Enterprise durable SIEM forwarder (siem_forwarder.go).
+	siemForwarderQueued      prometheus.Gauge
+	siemForwarderDelivered   prometheus.Counter
+	siemForwarderFailed      prometheus.Counter
+	siemForwarderDropped     prometheus.Counter
+	siemForwarderLastSuccess prometheus.Gauge
+
 	// Stats endpoint state (stats_handler.go).
 	mu                     sync.Mutex
 	startTime              time.Time
@@ -227,6 +234,7 @@ func New() *Metrics {
 	m.registerEnvelopeMetrics(reg)
 	m.registerReceiptMetrics(reg)
 	m.registerEvidenceMetrics(reg)
+	m.registerSIEMForwarderMetrics(reg)
 
 	// Built-in Go runtime + process collectors. These expose
 	// go_memstats_heap_alloc_bytes, go_goroutines, process_resident_memory_bytes,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -163,6 +163,7 @@ type Metrics struct {
 	siemForwarderFailed      prometheus.Counter
 	siemForwarderDropped     prometheus.Counter
 	siemForwarderLastSuccess prometheus.Gauge
+	siemForwarderSpoolBytes  prometheus.Gauge
 
 	// Stats endpoint state (stats_handler.go).
 	mu                     sync.Mutex

--- a/internal/metrics/siem_forwarder.go
+++ b/internal/metrics/siem_forwarder.go
@@ -31,7 +31,11 @@ func (m *Metrics) registerSIEMForwarderMetrics(reg *prometheus.Registry) {
 		Name: "pipelock_siem_forwarder_last_success_timestamp_seconds",
 		Help: "Unix timestamp of the last SIEM forwarder delivery acknowledged by the endpoint.",
 	})
-	reg.MustRegister(m.siemForwarderQueued, m.siemForwarderDelivered, m.siemForwarderFailed, m.siemForwarderDropped, m.siemForwarderLastSuccess)
+	m.siemForwarderSpoolBytes = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "pipelock_siem_forwarder_spool_bytes",
+		Help: "Current on-disk size of the durable SIEM forwarder spool, bounded by max_spool_bytes.",
+	})
+	reg.MustRegister(m.siemForwarderQueued, m.siemForwarderDelivered, m.siemForwarderFailed, m.siemForwarderDropped, m.siemForwarderLastSuccess, m.siemForwarderSpoolBytes)
 }
 
 func (m *Metrics) SetQueued(value float64) { m.siemForwarderQueued.Set(value) }
@@ -41,3 +45,4 @@ func (m *Metrics) RecordDropped()          { m.siemForwarderDropped.Inc() }
 func (m *Metrics) SetLastSuccess(at time.Time) {
 	m.siemForwarderLastSuccess.Set(float64(at.Unix()))
 }
+func (m *Metrics) SetSpoolBytes(value float64) { m.siemForwarderSpoolBytes.Set(value) }

--- a/internal/metrics/siem_forwarder.go
+++ b/internal/metrics/siem_forwarder.go
@@ -1,0 +1,43 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func (m *Metrics) registerSIEMForwarderMetrics(reg *prometheus.Registry) {
+	m.siemForwarderQueued = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "pipelock_siem_forwarder_queued",
+		Help: "Current number of audit events waiting in the in-memory SIEM forwarder queue.",
+	})
+	m.siemForwarderDelivered = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pipelock_siem_forwarder_delivered_total",
+		Help: "Audit events acknowledged by the configured SIEM forwarding endpoint.",
+	})
+	m.siemForwarderFailed = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pipelock_siem_forwarder_failed_total",
+		Help: "SIEM forwarding persistence or delivery failures.",
+	})
+	m.siemForwarderDropped = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pipelock_siem_forwarder_dropped_total",
+		Help: "Audit events dropped because the SIEM forwarder queue was full.",
+	})
+	m.siemForwarderLastSuccess = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "pipelock_siem_forwarder_last_success_timestamp_seconds",
+		Help: "Unix timestamp of the last SIEM forwarder delivery acknowledged by the endpoint.",
+	})
+	reg.MustRegister(m.siemForwarderQueued, m.siemForwarderDelivered, m.siemForwarderFailed, m.siemForwarderDropped, m.siemForwarderLastSuccess)
+}
+
+func (m *Metrics) SetQueued(value float64) { m.siemForwarderQueued.Set(value) }
+func (m *Metrics) RecordDelivered()        { m.siemForwarderDelivered.Inc() }
+func (m *Metrics) RecordFailed()           { m.siemForwarderFailed.Inc() }
+func (m *Metrics) RecordDropped()          { m.siemForwarderDropped.Inc() }
+func (m *Metrics) SetLastSuccess(at time.Time) {
+	m.siemForwarderLastSuccess.Set(float64(at.Unix()))
+}

--- a/internal/metrics/siem_forwarder_stub.go
+++ b/internal/metrics/siem_forwarder_stub.go
@@ -20,6 +20,7 @@ func (m *Metrics) registerSIEMForwarderMetrics(_ *prometheus.Registry) {
 	_ = m.siemForwarderFailed
 	_ = m.siemForwarderDropped
 	_ = m.siemForwarderLastSuccess
+	_ = m.siemForwarderSpoolBytes
 }
 
 func (*Metrics) SetQueued(float64)        {}
@@ -27,3 +28,4 @@ func (*Metrics) RecordDelivered()         {}
 func (*Metrics) RecordFailed()            {}
 func (*Metrics) RecordDropped()           {}
 func (*Metrics) SetLastSuccess(time.Time) {}
+func (*Metrics) SetSpoolBytes(float64)    {}

--- a/internal/metrics/siem_forwarder_stub.go
+++ b/internal/metrics/siem_forwarder_stub.go
@@ -1,0 +1,29 @@
+//go:build !enterprise
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func (m *Metrics) registerSIEMForwarderMetrics(_ *prometheus.Registry) {
+	if m == nil {
+		return
+	}
+	_ = m.siemForwarderQueued
+	_ = m.siemForwarderDelivered
+	_ = m.siemForwarderFailed
+	_ = m.siemForwarderDropped
+	_ = m.siemForwarderLastSuccess
+}
+
+func (*Metrics) SetQueued(float64)        {}
+func (*Metrics) RecordDelivered()         {}
+func (*Metrics) RecordFailed()            {}
+func (*Metrics) RecordDropped()           {}
+func (*Metrics) SetLastSuccess(time.Time) {}

--- a/internal/metrics/siem_forwarder_stub_test.go
+++ b/internal/metrics/siem_forwarder_stub_test.go
@@ -18,6 +18,7 @@ func TestSIEMForwarderMetricStubs(t *testing.T) {
 	m.RecordFailed()
 	m.RecordDropped()
 	m.SetLastSuccess(time.Unix(1, 0))
+	m.SetSpoolBytes(1024)
 
 	families, err := m.Registry().Gather()
 	if err != nil {

--- a/internal/metrics/siem_forwarder_stub_test.go
+++ b/internal/metrics/siem_forwarder_stub_test.go
@@ -1,0 +1,31 @@
+//go:build !enterprise
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSIEMForwarderMetricStubs(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.SetQueued(2)
+	m.RecordDelivered()
+	m.RecordFailed()
+	m.RecordDropped()
+	m.SetLastSuccess(time.Unix(1, 0))
+
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() == "pipelock_siem_forwarder_queued" {
+			t.Fatal("OSS metrics registry exposed Enterprise SIEM forwarder metrics")
+		}
+	}
+}

--- a/internal/metrics/siem_forwarder_test.go
+++ b/internal/metrics/siem_forwarder_test.go
@@ -1,0 +1,42 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package metrics
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSIEMForwarderMetricsEnterprise(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.SetQueued(3)
+	m.RecordDelivered()
+	m.RecordFailed()
+	m.RecordDropped()
+	m.SetLastSuccess(time.Unix(1_700_000_000, 0))
+	m.SetSpoolBytes(4096)
+
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	found := make(map[string]bool)
+	for _, family := range families {
+		found[family.GetName()] = true
+	}
+	for _, name := range []string{
+		"pipelock_siem_forwarder_queued",
+		"pipelock_siem_forwarder_delivered_total",
+		"pipelock_siem_forwarder_failed_total",
+		"pipelock_siem_forwarder_dropped_total",
+		"pipelock_siem_forwarder_last_success_timestamp_seconds",
+		"pipelock_siem_forwarder_spool_bytes",
+	} {
+		if !found[name] {
+			t.Errorf("enterprise metrics registry missing %q", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add an Enterprise HTTP forwarder with a durable spool and content-bound replay cursor
- require an exact-host destination allowlist and enforce an immutable SSRF floor at startup and connection time
- pin connections to validated addresses, refuse redirects, and keep endpoint credentials out of durable records and health errors
- provide bounded asynchronous delivery, retry behavior, delivery-health metrics, and restart-safe replay
- document the wire schema, failure behavior, state lifecycle, and per-process storage requirements

DNS outages degrade forwarding without taking down the mediation proxy. Forwarding remains fail-closed until resolution succeeds and every returned address passes the SSRF checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Enterprise durable HTTP forwarding for at-least-once SIEM delivery with bounded buffering, local spool/cursor replay, and forwarding progress tracking.
  * Added Prometheus metrics for queued/delivered/failed/dropped events plus forwarder spool size.
* **Documentation**
  * Expanded the SIEM integration guide with the full “Durable HTTP forwarding (Enterprise)” configuration and operator lifecycle steps.
* **Tests**
  * Added Enterprise and non-Enterprise test coverage for fail-closed safety, persistence/replay correctness, redirects, retries, queue/spool limits, lifecycle activation, config validation, and reload warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->