### PR TITLE
feat(dashboard): OIDC bearer-token authentication

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -68,7 +68,7 @@ openssl rand -hex 32 > /etc/pipelock/dashboard.token
 |---|---|---|
 | `--receipt-dir` | (required) | Flight-recorder evidence directory holding action receipts (the runtime's `flight_recorder.dir`). |
 | `--config` | none | Optional Pipelock config file for the read-only Exemptions inventory. When omitted, `/exemptions` renders an explicit "no config loaded" state and the Evidence view still works. |
-| `--auth-token-file` | (required) | File containing the operator token required on every request. Grants the redacted metadata view. |
+| `--auth-token-file` | (required) | File containing the operator token for token-authenticated requests. Grants the redacted metadata view. |
 | `--raw-token-file` | none | Optional second, higher-privilege token that unlocks raw destinations and signed payloads. Must differ from `--auth-token-file`. |
 | `--compliance-token-file` | none | Optional distinct auditor token granting only `dashboard:compliance:read`; it cannot reach evidence, raw, fleet-control preparation, or signed-action routes. |
 | `--legal-hold-store` | none | Optional atomic JSON legal-hold metadata store displayed read-only by `/compliance`. |
@@ -76,6 +76,68 @@ openssl rand -hex 32 > /etc/pipelock/dashboard.token
 | `--trusted-signer` | none | Trusted receipt signing key: `(inline=HEX_OR_VERSIONED_PUBLIC_KEY\|file=/path)[,source=LABEL]`. Repeatable. `source` is shown in the UI as the reason the key is trusted. |
 | `--license-crl-file` | none | Signed license revocation list; falls back to `PIPELOCK_LICENSE_CRL_FILE`. |
 | `--tls-cert`, `--tls-key` | none | TLS server certificate and key. Both or neither. |
+| `--require-client-cert` | `false` | Require a verified client certificate on every TLS connection and authorize it through the role map. Requires all three mTLS file flags below. |
+| `--client-ca-file` | none | PEM bundle of trust anchors used by TLS to verify client certificates. |
+| `--client-cert-role-map` | none | YAML file mapping client-certificate SPKI SHA-256 fingerprints to roles and bounded dashboard permissions. |
+
+### Mutual TLS client authentication
+
+Mutual TLS is additive: token-only deployments keep their existing behavior,
+while an operator can enable verified client-certificate authentication with
+all of `--require-client-cert`, `--client-ca-file`, and
+`--client-cert-role-map`. Server TLS (`--tls-cert` and `--tls-key`) is also
+required. When enabled, TLS requires a client certificate on every connection;
+the certificate therefore cannot be replaced by a bearer token at the TLS
+handshake.
+
+The role map uses the SHA-256 fingerprint of the leaf certificate's DER-encoded
+SubjectPublicKeyInfo (SPKI). This identity remains stable when a certificate is
+renewed with the same key. Role permissions must come from the dashboard's
+bounded permission vocabulary. Grant `dashboard:raw:read` only to roles that
+may view raw destinations and signed payloads.
+
+<!-- dashboard-mtls-role-map-start -->
+```yaml
+version: 1
+roles:
+  metadata:
+    permissions:
+      - dashboard:evidence:read
+      - dashboard:exemptions:read
+  raw:
+    permissions:
+      - dashboard:evidence:read
+      - dashboard:exemptions:read
+      - dashboard:raw:read
+certificates:
+  0000000000000000000000000000000000000000000000000000000000000000: metadata
+```
+<!-- dashboard-mtls-role-map-end -->
+
+Replace the all-zero example key with the client certificate's SPKI SHA-256
+fingerprint. The map also accepts colon-separated hexadecimal and an optional
+`sha256:` prefix. Unknown permissions, roles, fields, or fingerprints are hard
+startup errors; an empty certificate map is never treated as allow-all.
+
+Start the dashboard with client-certificate verification:
+
+```bash
+pipelock dashboard serve \
+  --receipt-dir /var/lib/pipelock/evidence \
+  --auth-token-file /etc/pipelock/dashboard.token \
+  --tls-cert /etc/pipelock/dashboard-server.pem \
+  --tls-key /etc/pipelock/dashboard-server.key \
+  --require-client-cert \
+  --client-ca-file /etc/pipelock/dashboard-client-ca.pem \
+  --client-cert-role-map /etc/pipelock/dashboard-client-roles.yaml
+```
+
+The standard library verifies the chain, validity period, and client-auth key
+usage before HTTP handling. Pipelock then maps only the verified leaf SPKI. A
+missing, expired, wrong-CA, or unmapped certificate is denied. If a request
+also carries a token, its certificate role remains authoritative for route and
+raw-view permissions; a metadata certificate cannot use a raw token to
+escalate.
 
 ### License resolution
 
@@ -101,9 +163,11 @@ the server is running stops serving.
   a different user is deployment guidance (containment/network policy), not a
   property this command can enforce by itself — which is why the token is
   required even on loopback.
-- **The license check is entitlement, not identity.** Every request must also
-  carry the operator token (constant-time comparison), as a `Bearer` header or
-  as the Basic-auth password. Requests without it get `401` and no evidence.
+- **The license check is entitlement, not identity.** In the default mode,
+  every request must carry the operator token (constant-time comparison), as a
+  `Bearer` header or as the Basic-auth password. With mutual TLS enabled, every
+  connection must instead present a verified certificate mapped to a role.
+  Missing or invalid authentication gets no evidence.
 - **Cleartext refusal.** Without TLS the listener only accepts loopback
   addresses; serving a non-loopback address over plain HTTP is refused at
   startup because the operator token would transit in cleartext.
@@ -114,11 +178,12 @@ the server is running stops serving.
   scorecard, hashes, timeline verdicts/reasons/timestamps, and the offline
   verify command — but receipt destinations and full signed payloads are
   redacted, because a destination URL can carry a capability token and the raw
-  payload is the largest exfil surface. Raw detail is shown only to a request
-  that authenticates with `--raw-token-file`; with no raw token configured, raw
-  is redacted for everyone (fail closed). Redaction happens before templating,
-  so the raw bytes never reach a metadata-view response. The scorecard — the
-  actual proof — does not depend on the raw fields.
+  payload is the largest exfil surface. Token-authenticated requests receive
+  raw detail only with `--raw-token-file`; client-certificate requests receive
+  it only when their mapped role includes `dashboard:raw:read` (fail closed).
+  Redaction happens before templating, so the raw bytes never reach a
+  metadata-view response. The scorecard — the actual proof — does not depend
+  on the raw fields.
 - **Access is audited.** Every authenticated request is written to an access log
   on stderr (role `metadata` or `raw`, method, path, session, remote address).
   Viewing evidence is itself a recorded action.
@@ -224,5 +289,6 @@ versions, and the free-text divergence reason are hidden; the computed status �
 validity, the bounded conflict code, and the loud divergence flag — is always
 shown. The fleet applied-state summary is counts only, carries no follower
 identifiers, and is shown in full even in the metadata view. Raw detail is shown
-only to a request that authenticates with `--raw-token-file`. There is
+only to a request that authenticates with `--raw-token-file` or a mapped client
+certificate role containing `dashboard:raw:read`. There is
 deliberately no aggregate "all clear".

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -317,6 +318,7 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 	)
 	authenticated := dashboardGlobalAuthorized(metaAuthorized, complianceAuthorized)
 
+	auditWriter := cmd.ErrOrStderr()
 	inner := dashboard.New(dashboard.Options{
 		ReceiptDir:          opts.receiptDir,
 		TrustedKeys:         trusted,
@@ -332,7 +334,7 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 		AuthorizePermission: authorizePermission,
 		AuthorizeRaw:        dashboardAuthorizeFunc(rawAuthorized),
 		// Viewing evidence is itself audited; the access log goes to stderr.
-		AuditWriter: cmd.ErrOrStderr(),
+		AuditWriter: auditWriter,
 		// TODO(DASH-3A): wire live conductor source when dashboard serve owns a
 		// conductor audit/status store handle. Until then /fleet renders the
 		// read-only empty state instead of inventing a fake conductor client.
@@ -347,7 +349,21 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 		ConductorSource: nil,
 		BudgetSource:    dashboard.NewSnapshotBudgetSource(runtimeSnapshotFile, runtimeSnapshotMaxAge),
 	})
-	handler := dashboardAuthHandler(authenticated, inner)
+	authAuditInfo := authorization.authAuditInfo
+	if clientCertAuth != nil {
+		authAuditInfo = func(r *http.Request) dashboard.AuthAuditInfo {
+			principal, ok := clientCertAuth.principal(r)
+			if !ok {
+				return dashboard.AuthAuditInfo{Method: "mtls", FailureReason: "missing_client_certificate"}
+			}
+			var subject string
+			if r != nil && r.TLS != nil && len(r.TLS.VerifiedChains) > 0 && len(r.TLS.VerifiedChains[0]) > 0 {
+				subject = dashboardClientCertSPKIFingerprint(r.TLS.VerifiedChains[0][0])
+			}
+			return dashboard.AuthAuditInfo{Method: "mtls", Subject: subject, Roles: []string{principal.role}}
+		}
+	}
+	handler := dashboardAuthHandler(authenticated, authAuditInfo, auditWriter, inner)
 	if oidcAuthenticator != nil {
 		handler = oidcAuthenticator.middleware(handler)
 	}
@@ -544,15 +560,71 @@ func dashboardTrustCRLSource(configuredPath string) (func() (*license.CRL, error
 // with a WWW-Authenticate challenge so browsers prompt for credentials; the
 // inner dashboard handler re-checks the same predicate via Options.Authorize as
 // defense in depth.
-func dashboardAuthHandler(authorized func(*http.Request) bool, next http.Handler) http.Handler {
+func dashboardAuthHandler(
+	authorized func(*http.Request) bool,
+	authInfo func(*http.Request) dashboard.AuthAuditInfo,
+	auditWriter io.Writer,
+	next http.Handler,
+) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !authorized(r) {
+			recordDashboardAuthDenied(auditWriter, r, authInfo)
 			w.Header().Set("WWW-Authenticate", `Basic realm="pipelock dashboard", charset="UTF-8"`)
 			http.Error(w, "authentication required", http.StatusUnauthorized)
 			return
 		}
+		if authInfo != nil {
+			r = r.WithContext(dashboard.WithAuthAuditInfo(r.Context(), authInfo(r)))
+		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func recordDashboardAuthDenied(auditWriter io.Writer, r *http.Request, authInfo func(*http.Request) dashboard.AuthAuditInfo) {
+	if auditWriter == nil {
+		return
+	}
+	info := dashboard.AuthAuditInfo{Method: "none", FailureReason: "missing_token"}
+	if authInfo != nil {
+		info = authInfo(r)
+	}
+	if info.FailureReason == "" {
+		info.FailureReason = "unauthorized"
+	}
+	_, _ = fmt.Fprintf(auditWriter, "%s pipelock-dashboard denied method=%s path=%q auth_method=%s auth_subject=%q auth_roles=%q reason=%s remote=%s\n",
+		time.Now().UTC().Format(time.RFC3339), r.Method, r.URL.Path,
+		dashboardAuditLogValue(info.Method), dashboardAuditLogValue(info.Subject),
+		strings.Join(dashboardAuditLogValues(info.Roles), ","), dashboardAuditLogValue(info.FailureReason), r.RemoteAddr)
+}
+
+func dashboardAuditLogValues(values []string) []string {
+	if len(values) == 0 {
+		return []string{"-"}
+	}
+	out := make([]string, len(values))
+	for i, value := range values {
+		out[i] = dashboardAuditLogValue(value)
+	}
+	return out
+}
+
+func dashboardAuditLogValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	var b strings.Builder
+	for _, r := range value {
+		if r >= 0x20 && r <= 0x7e {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('?')
+	}
+	if b.Len() == 0 {
+		return "-"
+	}
+	return b.String()
 }
 
 // dashboardTokenMatches accepts the operator token as either a Bearer token

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -75,6 +75,11 @@ type dashboardServeOptions struct {
 	readModelIndex      string
 	legalHoldStore      string
 	complianceTokenFile string
+	oidcIssuer          string
+	oidcAudience        string
+	oidcClientID        string
+	oidcRoleClaim       string
+	oidcRoleMap         string
 }
 
 func dashboardServeCmd() *cobra.Command {
@@ -83,20 +88,20 @@ func dashboardServeCmd() *cobra.Command {
 		Use:   "serve",
 		Short: "Serve the read-only Evidence dashboard on a dedicated listener",
 		Long: `Serve the read-only Evidence dashboard over a flight-recorder evidence
-directory. Every request must authenticate with the operator token from
---auth-token-file or, when --require-client-cert is enabled, a verified client
-certificate mapped to a dashboard role. The license feature check is
-entitlement, not identity; the token and client certificate are authentication
-boundaries.
+directory. Every request must authenticate through a configured local operator
+token, OIDC bearer token, or, when --require-client-cert is enabled, a verified
+client certificate mapped to a dashboard role. The license feature check is
+entitlement, not identity; the selected authenticator is the identity boundary.
 
 By default the view is redacted: receipt destinations and signed payloads are
 hidden, because a destination URL can carry a capability token and the payload
 is the largest exfil surface. Supply --raw-token-file to issue a second,
-higher-privilege token whose holders see the full raw detail. Every
-authenticated request is written to the access log on stderr.
+higher-privilege token whose holders see the full raw detail, or grant
+dashboard:raw:read to an OIDC role. Every authenticated request is written to
+the access log on stderr.
 
 Without --tls-cert/--tls-key the listener refuses non-loopback addresses,
-because the operator token would transit in cleartext.`,
+because credentials would transit in cleartext.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// License gate: the dashboard is a paid surface. Fail closed before
@@ -124,7 +129,7 @@ because the operator token would transit in cleartext.`,
 	cmd.Flags().StringVar(&opts.legalHoldStore, "legal-hold-store", "",
 		"optional legal-hold metadata store file for read-only compliance display")
 	cmd.Flags().StringVar(&opts.authTokenFile, "auth-token-file", "",
-		"file containing the operator token required on every dashboard request (redacted metadata view)")
+		"optional file containing a dashboard operator token (redacted metadata view); required unless OIDC is configured")
 	cmd.Flags().StringVar(&opts.rawTokenFile, "raw-token-file", "",
 		"optional file containing a higher-privilege token that unlocks raw destinations and signed payloads; must differ from --auth-token-file")
 	cmd.Flags().StringVar(&opts.complianceTokenFile, "compliance-token-file", "",
@@ -147,8 +152,17 @@ because the operator token would transit in cleartext.`,
 	cmd.Flags().StringVar(&opts.clientCAFile, "client-ca-file", "", "PEM trust anchor bundle for dashboard client certificates")
 	cmd.Flags().BoolVar(&opts.requireClientCert, "require-client-cert", false, "require and verify a mapped dashboard client certificate")
 	cmd.Flags().StringVar(&opts.clientCertRoleMap, "client-cert-role-map", "", "YAML file mapping client certificate SPKI SHA-256 fingerprints to permission roles")
+	cmd.Flags().StringVar(&opts.oidcIssuer, "oidc-issuer", "",
+		"OIDC issuer URL used for discovery and exact iss validation")
+	cmd.Flags().StringVar(&opts.oidcAudience, "oidc-audience", "",
+		"expected OIDC aud value for dashboard bearer tokens")
+	cmd.Flags().StringVar(&opts.oidcClientID, "oidc-client-id", "",
+		"alias for --oidc-audience; both values must match if both are set")
+	cmd.Flags().StringVar(&opts.oidcRoleClaim, "oidc-role-claim", "",
+		"verified token claim containing role or group values")
+	cmd.Flags().StringVar(&opts.oidcRoleMap, "oidc-role-map", "",
+		`JSON object: {"claim_values":{"GROUP":"ROLE"},"roles":{"ROLE":["dashboard:evidence:read"]}}`)
 	_ = cmd.MarkFlagRequired("receipt-dir")
-	_ = cmd.MarkFlagRequired("auth-token-file")
 	return cmd
 }
 
@@ -170,9 +184,16 @@ func verifyDashboardLicenseWithOptions(in license.FleetVerifyInputs) (license.Li
 }
 
 func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic license.License) error {
-	token, err := loadDashboardTokenFile("--auth-token-file", opts.authTokenFile)
-	if err != nil {
+	if err := validateDashboardAuthenticatorConfig(opts); err != nil {
 		return err
+	}
+	var token string
+	var err error
+	if strings.TrimSpace(opts.authTokenFile) != "" {
+		token, err = loadDashboardTokenFile("--auth-token-file", opts.authTokenFile)
+		if err != nil {
+			return err
+		}
 	}
 	// Optional raw-access token: elevates a request from the redacted metadata
 	// view to full destinations + signed payloads. Must differ from the
@@ -197,6 +218,10 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 			(rawToken != "" && subtle.ConstantTimeCompare([]byte(complianceToken), []byte(rawToken)) == 1) {
 			return errors.New("--compliance-token-file must differ from operator and raw token files")
 		}
+	}
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	trusted, err := signingflag.ParseTrustedSigners(opts.trustedSigners)
 	if err != nil {
@@ -267,28 +292,28 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 		}
 	}
 
-	// Token auth retains its metadata/raw split. When mTLS is enabled, the
-	// verified certificate's mapped role supplies both route and raw-view
-	// permissions and takes precedence over any token on the same request.
-	tokenMetaAuthorized := func(r *http.Request) bool {
-		if dashboardTokenMatches(r, token) {
-			return true
+	var oidcAuthenticator *dashboardOIDCAuthenticator
+	if strings.TrimSpace(opts.oidcIssuer) != "" {
+		oidcAuthenticator, err = newDashboardOIDCAuthenticator(ctx, dashboardOIDCOptions{
+			Issuer:      opts.oidcIssuer,
+			Audience:    dashboardOIDCAudience(opts),
+			RoleClaim:   opts.oidcRoleClaim,
+			RoleMapJSON: opts.oidcRoleMap,
+		})
+		if err != nil {
+			return err
 		}
-		return rawToken != "" && dashboardTokenMatches(r, rawToken)
 	}
-	tokenRawAuthorized := func(r *http.Request) bool {
-		return rawToken != "" && dashboardTokenMatches(r, rawToken)
-	}
-	// The compliance token is a token-based authorizer scoped to the compliance
-	// path. When mTLS is authoritative it must not bypass the certificate
-	// requirement, so it applies only when client certificates are not required;
-	// a certificate operator that needs compliance access is granted
-	// dashboard:compliance:read directly through its role map.
+	authorization := newDashboardRequestAuthorization(token, rawToken, complianceToken, oidcAuthenticator)
+	// Token/OIDC auth retains its metadata/raw split. When mTLS is enabled, the
+	// verified certificate's mapped role supplies both route and raw-view
+	// permissions and takes precedence over any token or OIDC principal on the
+	// same request.
 	complianceAuthorized := func(r *http.Request) bool {
-		return clientCertAuth == nil && complianceToken != "" && dashboardTokenMatches(r, complianceToken)
+		return clientCertAuth == nil && authorization.complianceAuthorized(r)
 	}
 	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
-		clientCertAuth, tokenMetaAuthorized, tokenRawAuthorized, complianceAuthorized,
+		clientCertAuth, authorization.metaAuthorized, authorization.rawAuthorized, complianceAuthorized,
 	)
 	authenticated := dashboardGlobalAuthorized(metaAuthorized, complianceAuthorized)
 
@@ -323,10 +348,8 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 		BudgetSource:    dashboard.NewSnapshotBudgetSource(runtimeSnapshotFile, runtimeSnapshotMaxAge),
 	})
 	handler := dashboardAuthHandler(authenticated, inner)
-
-	ctx := cmd.Context()
-	if ctx == nil {
-		ctx = context.Background()
+	if oidcAuthenticator != nil {
+		handler = oidcAuthenticator.middleware(handler)
 	}
 	baseCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -67,6 +67,9 @@ type dashboardServeOptions struct {
 	rekorLogKeys        []string
 	tlsCert             string
 	tlsKey              string
+	clientCAFile        string
+	clientCertRoleMap   string
+	requireClientCert   bool
 	exemptionStore      string
 	deliveryInbox       string
 	readModelIndex      string
@@ -81,9 +84,10 @@ func dashboardServeCmd() *cobra.Command {
 		Short: "Serve the read-only Evidence dashboard on a dedicated listener",
 		Long: `Serve the read-only Evidence dashboard over a flight-recorder evidence
 directory. Every request must authenticate with the operator token from
---auth-token-file, sent either as "Authorization: Bearer <token>" or as the
-password of an HTTP Basic prompt (any username). The license feature check is
-entitlement, not identity; the token is the authentication boundary.
+--auth-token-file or, when --require-client-cert is enabled, a verified client
+certificate mapped to a dashboard role. The license feature check is
+entitlement, not identity; the token and client certificate are authentication
+boundaries.
 
 By default the view is redacted: receipt destinations and signed payloads are
 hidden, because a destination URL can carry a capability token and the payload
@@ -140,6 +144,9 @@ because the operator token would transit in cleartext.`,
 		"pinned Rekor log public key used to verify SET, checkpoint, and inclusion proof; repeat for rotations")
 	cmd.Flags().StringVar(&opts.tlsCert, "tls-cert", "", "TLS server certificate file")
 	cmd.Flags().StringVar(&opts.tlsKey, "tls-key", "", "TLS server private key file")
+	cmd.Flags().StringVar(&opts.clientCAFile, "client-ca-file", "", "PEM trust anchor bundle for dashboard client certificates")
+	cmd.Flags().BoolVar(&opts.requireClientCert, "require-client-cert", false, "require and verify a mapped dashboard client certificate")
+	cmd.Flags().StringVar(&opts.clientCertRoleMap, "client-cert-role-map", "", "YAML file mapping client certificate SPKI SHA-256 fingerprints to permission roles")
 	_ = cmd.MarkFlagRequired("receipt-dir")
 	_ = cmd.MarkFlagRequired("auth-token-file")
 	return cmd
@@ -198,6 +205,13 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 	if err := validateDashboardListen(opts); err != nil {
 		return err
 	}
+	var clientCertAuth *dashboardClientCertAuthorizer
+	if opts.requireClientCert {
+		clientCertAuth, err = loadDashboardClientCertRoleMap(opts.clientCertRoleMap)
+		if err != nil {
+			return err
+		}
+	}
 	info, err := os.Stat(filepath.Clean(opts.receiptDir))
 	if err != nil {
 		return fmt.Errorf("--receipt-dir: %w", err)
@@ -253,22 +267,30 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 		}
 	}
 
-	// metaAuthorized gates all access: the metadata token OR the raw token (a
-	// raw holder is also a valid operator). rawAuthorized gates only the
-	// sensitive raw view and matches the raw token alone.
-	metaAuthorized := func(r *http.Request) bool {
+	// Token auth retains its metadata/raw split. When mTLS is enabled, the
+	// verified certificate's mapped role supplies both route and raw-view
+	// permissions and takes precedence over any token on the same request.
+	tokenMetaAuthorized := func(r *http.Request) bool {
 		if dashboardTokenMatches(r, token) {
 			return true
 		}
 		return rawToken != "" && dashboardTokenMatches(r, rawToken)
 	}
-	complianceAuthorized := func(r *http.Request) bool {
-		return complianceToken != "" && dashboardTokenMatches(r, complianceToken)
-	}
-	authenticated := dashboardGlobalAuthorized(metaAuthorized, complianceAuthorized)
-	rawAuthorized := func(r *http.Request) bool {
+	tokenRawAuthorized := func(r *http.Request) bool {
 		return rawToken != "" && dashboardTokenMatches(r, rawToken)
 	}
+	// The compliance token is a token-based authorizer scoped to the compliance
+	// path. When mTLS is authoritative it must not bypass the certificate
+	// requirement, so it applies only when client certificates are not required;
+	// a certificate operator that needs compliance access is granted
+	// dashboard:compliance:read directly through its role map.
+	complianceAuthorized := func(r *http.Request) bool {
+		return clientCertAuth == nil && complianceToken != "" && dashboardTokenMatches(r, complianceToken)
+	}
+	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
+		clientCertAuth, tokenMetaAuthorized, tokenRawAuthorized, complianceAuthorized,
+	)
+	authenticated := dashboardGlobalAuthorized(metaAuthorized, complianceAuthorized)
 
 	inner := dashboard.New(dashboard.Options{
 		ReceiptDir:          opts.receiptDir,
@@ -282,7 +304,7 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 		LegalHoldStore:      legalHoldStore,
 		HasFeature:          dashboardRuntimeHasFeature(lic),
 		Authorize:           dashboardAuthorizeFunc(authenticated),
-		AuthorizePermission: dashboardAuthorizePermissionFunc(metaAuthorized, rawAuthorized, complianceAuthorized),
+		AuthorizePermission: authorizePermission,
 		AuthorizeRaw:        dashboardAuthorizeFunc(rawAuthorized),
 		// Viewing evidence is itself audited; the access log goes to stderr.
 		AuditWriter: cmd.ErrOrStderr(),
@@ -360,10 +382,19 @@ func dashboardTLSConfig(opts dashboardServeOptions) (*tls.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load dashboard TLS certificate: %w", err)
 	}
-	return &tls.Config{
+	config := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   tls.VersionTLS12,
-	}, nil
+	}
+	if opts.requireClientCert {
+		clientCAs, err := loadDashboardClientCAs(opts.clientCAFile)
+		if err != nil {
+			return nil, err
+		}
+		config.ClientAuth = tls.RequireAndVerifyClientCert
+		config.ClientCAs = clientCAs
+	}
+	return config, nil
 }
 
 // validateDashboardListen refuses configurations that would put the operator
@@ -372,6 +403,19 @@ func dashboardTLSConfig(opts dashboardServeOptions) (*tls.Config, error) {
 func validateDashboardListen(opts dashboardServeOptions) error {
 	if (opts.tlsCert == "") != (opts.tlsKey == "") {
 		return errors.New("--tls-cert and --tls-key must be set together")
+	}
+	if opts.requireClientCert {
+		if opts.tlsCert == "" {
+			return errors.New("--require-client-cert requires --tls-cert/--tls-key")
+		}
+		if strings.TrimSpace(opts.clientCAFile) == "" {
+			return errors.New("--require-client-cert requires --client-ca-file")
+		}
+		if strings.TrimSpace(opts.clientCertRoleMap) == "" {
+			return errors.New("--require-client-cert requires --client-cert-role-map")
+		}
+	} else if strings.TrimSpace(opts.clientCAFile) != "" || strings.TrimSpace(opts.clientCertRoleMap) != "" {
+		return errors.New("--client-ca-file and --client-cert-role-map require --require-client-cert")
 	}
 	if opts.tlsCert != "" {
 		return nil

--- a/enterprise/cli/dashboard_mtls.go
+++ b/enterprise/cli/dashboard_mtls.go
@@ -1,0 +1,263 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package entcli
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/dashboard"
+)
+
+const dashboardClientCertRoleMapMaxBytes = 1 << 20
+
+type dashboardClientCertRoleMapFile struct {
+	Version      int                                `yaml:"version"`
+	Roles        map[string]dashboardClientCertRole `yaml:"roles"`
+	Certificates map[string]string                  `yaml:"certificates"`
+}
+
+type dashboardClientCertRole struct {
+	Permissions []dashboard.Permission `yaml:"permissions"`
+}
+
+type dashboardClientCertPrincipal struct {
+	role        string
+	permissions map[dashboard.Permission]struct{}
+}
+
+type dashboardClientCertAuthorizer struct {
+	principals map[[sha256.Size]byte]dashboardClientCertPrincipal
+}
+
+func loadDashboardClientCertRoleMap(path string) (*dashboardClientCertAuthorizer, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("--client-cert-role-map is required when --require-client-cert is set")
+	}
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("read --client-cert-role-map: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(file, dashboardClientCertRoleMapMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read --client-cert-role-map: %w", err)
+	}
+	if len(data) > dashboardClientCertRoleMapMaxBytes {
+		return nil, fmt.Errorf("--client-cert-role-map exceeds %d bytes", dashboardClientCertRoleMapMaxBytes)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil, errors.New("--client-cert-role-map is empty")
+	}
+
+	decoder := yaml.NewDecoder(strings.NewReader(string(data)))
+	decoder.KnownFields(true)
+	var mapping dashboardClientCertRoleMapFile
+	if err := decoder.Decode(&mapping); err != nil {
+		return nil, fmt.Errorf("parse --client-cert-role-map: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return nil, fmt.Errorf("parse --client-cert-role-map: %w", err)
+		}
+		return nil, errors.New("--client-cert-role-map must contain exactly one YAML document")
+	}
+	if mapping.Version != 1 {
+		return nil, fmt.Errorf("--client-cert-role-map version must be 1, got %d", mapping.Version)
+	}
+	if len(mapping.Certificates) == 0 {
+		return nil, errors.New("--client-cert-role-map must map at least one certificate")
+	}
+
+	knownPermissions := dashboardPermissionSet()
+	roles := make(map[string]dashboardClientCertPrincipal, len(mapping.Roles))
+	for roleName, role := range mapping.Roles {
+		if strings.TrimSpace(roleName) == "" || roleName != strings.TrimSpace(roleName) {
+			return nil, fmt.Errorf("--client-cert-role-map contains invalid role name %q", roleName)
+		}
+		if len(role.Permissions) == 0 {
+			return nil, fmt.Errorf("--client-cert-role-map role %q must grant at least one permission", roleName)
+		}
+		permissions := make(map[dashboard.Permission]struct{}, len(role.Permissions))
+		for _, permission := range role.Permissions {
+			if _, ok := knownPermissions[permission]; !ok {
+				return nil, fmt.Errorf("--client-cert-role-map role %q has unknown permission %q", roleName, permission)
+			}
+			if _, duplicate := permissions[permission]; duplicate {
+				return nil, fmt.Errorf("--client-cert-role-map role %q has duplicate permission %q", roleName, permission)
+			}
+			permissions[permission] = struct{}{}
+		}
+		roles[roleName] = dashboardClientCertPrincipal{role: roleName, permissions: permissions}
+	}
+
+	principals := make(map[[sha256.Size]byte]dashboardClientCertPrincipal, len(mapping.Certificates))
+	for fingerprintText, roleName := range mapping.Certificates {
+		fingerprint, err := parseDashboardClientCertFingerprint(fingerprintText)
+		if err != nil {
+			return nil, fmt.Errorf("--client-cert-role-map certificate fingerprint %q: %w", fingerprintText, err)
+		}
+		principal, ok := roles[roleName]
+		if !ok {
+			return nil, fmt.Errorf("--client-cert-role-map certificate fingerprint %q references unknown role %q", fingerprintText, roleName)
+		}
+		if _, duplicate := principals[fingerprint]; duplicate {
+			return nil, fmt.Errorf("--client-cert-role-map contains duplicate normalized fingerprint %q", fingerprintText)
+		}
+		principals[fingerprint] = principal
+	}
+	return &dashboardClientCertAuthorizer{principals: principals}, nil
+}
+
+func dashboardPermissionSet() map[dashboard.Permission]struct{} {
+	permissions := dashboard.AllPermissions()
+	known := make(map[dashboard.Permission]struct{}, len(permissions))
+	for _, permission := range permissions {
+		known[permission] = struct{}{}
+	}
+	return known
+}
+
+func parseDashboardClientCertFingerprint(value string) ([sha256.Size]byte, error) {
+	var fingerprint [sha256.Size]byte
+	normalized := strings.TrimSpace(value)
+	if len(normalized) >= len("sha256:") && strings.EqualFold(normalized[:len("sha256:")], "sha256:") {
+		normalized = normalized[len("sha256:"):]
+	}
+	normalized = strings.ReplaceAll(normalized, ":", "")
+	decoded, err := hex.DecodeString(normalized)
+	if err != nil || len(decoded) != sha256.Size {
+		return fingerprint, errors.New("SPKI SHA-256 fingerprint must be 32 bytes of hexadecimal")
+	}
+	copy(fingerprint[:], decoded)
+	return fingerprint, nil
+}
+
+func dashboardClientCertSPKIFingerprint(cert *x509.Certificate) string {
+	if cert == nil {
+		return ""
+	}
+	fingerprint := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return hex.EncodeToString(fingerprint[:])
+}
+
+func (a *dashboardClientCertAuthorizer) principal(r *http.Request) (dashboardClientCertPrincipal, bool) {
+	if a == nil || r == nil || r.TLS == nil || len(r.TLS.VerifiedChains) == 0 || len(r.TLS.VerifiedChains[0]) == 0 {
+		return dashboardClientCertPrincipal{}, false
+	}
+	leaf := r.TLS.VerifiedChains[0][0]
+	if leaf == nil {
+		return dashboardClientCertPrincipal{}, false
+	}
+	fingerprint := sha256.Sum256(leaf.RawSubjectPublicKeyInfo)
+	principal, ok := a.principals[fingerprint]
+	return principal, ok
+}
+
+func (a *dashboardClientCertAuthorizer) authorized(r *http.Request) bool {
+	_, ok := a.principal(r)
+	return ok
+}
+
+func (a *dashboardClientCertAuthorizer) authorizePermission(r *http.Request, permission dashboard.Permission) error {
+	principal, ok := a.principal(r)
+	if !ok {
+		return errors.New("dashboard client certificate not authenticated")
+	}
+	if _, ok := principal.permissions[permission]; !ok {
+		return fmt.Errorf("dashboard client certificate role %q denied permission %q", principal.role, permission)
+	}
+	return nil
+}
+
+func (a *dashboardClientCertAuthorizer) authorizeRaw(r *http.Request) error {
+	return a.authorizePermission(r, dashboard.PermissionRawRead)
+}
+
+func dashboardClientCertAuthorizers(
+	clientCertAuth *dashboardClientCertAuthorizer,
+	tokenMetaAuthorized func(*http.Request) bool,
+	tokenRawAuthorized func(*http.Request) bool,
+	tokenComplianceAuthorized func(*http.Request) bool,
+) (
+	func(*http.Request) bool,
+	func(*http.Request, dashboard.Permission) error,
+	func(*http.Request) bool,
+) {
+	// When mutual TLS is enabled the verified client certificate is
+	// authoritative: authorization never falls back to the operator token, so a
+	// server-wiring, proxy, or ordering bug that lets a request reach the handler
+	// without a verified certificate fails closed instead of silently degrading
+	// to token access. The TLS layer already rejects certificate-less handshakes;
+	// this keeps the application layer fail-closed independently of it.
+	metaAuthorized := func(r *http.Request) bool {
+		if clientCertAuth != nil {
+			return clientCertAuth.authorized(r)
+		}
+		return tokenMetaAuthorized(r)
+	}
+	rawAuthorized := func(r *http.Request) bool {
+		if clientCertAuth != nil {
+			return clientCertAuth.authorizeRaw(r) == nil
+		}
+		return tokenRawAuthorized(r)
+	}
+	tokenAuthorizePermission := dashboardAuthorizePermissionFunc(tokenMetaAuthorized, tokenRawAuthorized, tokenComplianceAuthorized)
+	authorizePermission := func(r *http.Request, permission dashboard.Permission) error {
+		if clientCertAuth != nil {
+			return clientCertAuth.authorizePermission(r, permission)
+		}
+		return tokenAuthorizePermission(r, permission)
+	}
+	return metaAuthorized, authorizePermission, rawAuthorized
+}
+
+func loadDashboardClientCAs(path string) (*x509.CertPool, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("--client-ca-file is required when --require-client-cert is set")
+	}
+	pemBytes, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("read --client-ca-file: %w", err)
+	}
+	// Parse every certificate block explicitly instead of AppendCertsFromPEM,
+	// which silently skips malformed blocks and would start the dashboard with a
+	// partial trust set. A trust anchor bundle must load completely or fail loud.
+	pool := x509.NewCertPool()
+	var added int
+	for rest := pemBytes; ; {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			return nil, fmt.Errorf("--client-ca-file contains a non-certificate PEM block %q", block.Type)
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("--client-ca-file contains a malformed certificate: %w", err)
+		}
+		pool.AddCert(cert)
+		added++
+	}
+	if added == 0 {
+		return nil, errors.New("--client-ca-file contains no valid PEM certificates")
+	}
+	return pool, nil
+}

--- a/enterprise/cli/dashboard_mtls_test.go
+++ b/enterprise/cli/dashboard_mtls_test.go
@@ -477,7 +477,7 @@ func TestDashboardMTLS_RoutePermissionsAndRaw(t *testing.T) {
 		AuthorizePermission: authorizePermission,
 		AuthorizeRaw:        dashboardAuthorizeFunc(rawAuthorized),
 	})
-	server := httptest.NewUnstartedServer(dashboardAuthHandler(metaAuthorized, inner))
+	server := httptest.NewUnstartedServer(dashboardAuthHandler(metaAuthorized, nil, nil, inner))
 	server.TLS = &tls.Config{
 		Certificates: []tls.Certificate{pki.serverCert},
 		ClientAuth:   tls.RequireAndVerifyClientCert,

--- a/enterprise/cli/dashboard_mtls_test.go
+++ b/enterprise/cli/dashboard_mtls_test.go
@@ -1,0 +1,709 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package entcli
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/dashboard"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+type dashboardMTLSTestPKI struct {
+	caCert     *x509.Certificate
+	caKey      ed25519.PrivateKey
+	caFile     string
+	serverCert tls.Certificate
+	serverPool *x509.CertPool
+}
+
+func newDashboardMTLSTestPKI(t *testing.T) dashboardMTLSTestPKI {
+	t.Helper()
+	now := time.Now()
+	caPub, caKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(CA): %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(100),
+		Subject:               pkix.Name{CommonName: "dashboard test CA"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, caPub, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(CA): %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("ParseCertificate(CA): %v", err)
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	caFile := filepath.Join(t.TempDir(), "client-ca.pem")
+	if err := os.WriteFile(caFile, caPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile(CA): %v", err)
+	}
+
+	serverCert, serverLeaf := issueDashboardMTLSTestCert(t, caCert, caKey, dashboardMTLSTestCertOptions{
+		serial:     101,
+		commonName: "dashboard server",
+		server:     true,
+		notBefore:  now.Add(-time.Hour),
+		notAfter:   now.Add(time.Hour),
+	})
+	serverPool := x509.NewCertPool()
+	serverPool.AddCert(serverLeaf)
+	return dashboardMTLSTestPKI{
+		caCert:     caCert,
+		caKey:      caKey,
+		caFile:     caFile,
+		serverCert: serverCert,
+		serverPool: serverPool,
+	}
+}
+
+type dashboardMTLSTestCertOptions struct {
+	serial     int64
+	commonName string
+	server     bool
+	notBefore  time.Time
+	notAfter   time.Time
+}
+
+func issueDashboardMTLSTestCert(
+	t *testing.T,
+	caCert *x509.Certificate,
+	caKey ed25519.PrivateKey,
+	opts dashboardMTLSTestCertOptions,
+) (tls.Certificate, *x509.Certificate) {
+	t.Helper()
+	pub, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(%s): %v", opts.commonName, err)
+	}
+	extUsage := x509.ExtKeyUsageClientAuth
+	if opts.server {
+		extUsage = x509.ExtKeyUsageServerAuth
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(opts.serial),
+		Subject:      pkix.Name{CommonName: opts.commonName},
+		NotBefore:    opts.notBefore,
+		NotAfter:     opts.notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{extUsage},
+	}
+	if opts.server {
+		template.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, caCert, pub, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(%s): %v", opts.commonName, err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("ParseCertificate(%s): %v", opts.commonName, err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}, leaf
+}
+
+func writeDashboardMTLSRoleMap(t *testing.T, entries map[string]string, roles string) string {
+	t.Helper()
+	var body strings.Builder
+	body.WriteString("version: 1\nroles:\n")
+	body.WriteString(roles)
+	body.WriteString("certificates:\n")
+	for fingerprint, role := range entries {
+		body.WriteString("  ")
+		body.WriteString(fingerprint)
+		body.WriteString(": ")
+		body.WriteString(role)
+		body.WriteByte('\n')
+	}
+	path := filepath.Join(t.TempDir(), "client-cert-roles.yaml")
+	if err := os.WriteFile(path, []byte(body.String()), 0o600); err != nil {
+		t.Fatalf("WriteFile(role map): %v", err)
+	}
+	return path
+}
+
+func dashboardMTLSTestRequest(t *testing.T, leaf *x509.Certificate, verified bool) *http.Request {
+	t.Helper()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil)
+	req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}
+	if verified {
+		req.TLS.VerifiedChains = [][]*x509.Certificate{{leaf}}
+	}
+	return req
+}
+
+func TestLoadDashboardClientCertRoleMap(t *testing.T) {
+	pki := newDashboardMTLSTestPKI(t)
+	_, leaf := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 102, commonName: "mapped operator", notBefore: time.Now().Add(-time.Hour), notAfter: time.Now().Add(time.Hour),
+	})
+	fingerprint := dashboardClientCertSPKIFingerprint(leaf)
+	validRoles := "  metadata:\n    permissions:\n      - dashboard:evidence:read\n"
+
+	t.Run("valid", func(t *testing.T) {
+		path := writeDashboardMTLSRoleMap(t, map[string]string{fingerprint: "metadata"}, validRoles)
+		authorizer, err := loadDashboardClientCertRoleMap(path)
+		if err != nil {
+			t.Fatalf("load role map: %v", err)
+		}
+		req := dashboardMTLSTestRequest(t, leaf, true)
+		if !authorizer.authorized(req) {
+			t.Fatal("mapped verified certificate was not authenticated")
+		}
+		if err := authorizer.authorizePermission(req, dashboard.PermissionEvidenceRead); err != nil {
+			t.Fatalf("mapped permission denied: %v", err)
+		}
+		if err := authorizer.authorizePermission(req, dashboard.PermissionRawRead); err == nil {
+			t.Fatal("permission absent from role was allowed")
+		}
+	})
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{"empty file", "", "empty"},
+		{"unknown field", "version: 1\nroles: {}\ncertificates: {}\nsurprise: true\n", "field surprise"},
+		{"unknown role field", "version: 1\nroles:\n  metadata:\n    permissions:\n      - dashboard:evidence:read\n    surprise: true\ncertificates:\n  " + fingerprint + ": metadata\n", "field surprise"},
+		{"duplicate version key", "version: 1\nversion: 1\nroles: {}\ncertificates: {}\n", "already defined"},
+		{"duplicate role key", "version: 1\nroles:\n  metadata:\n    permissions:\n      - dashboard:evidence:read\n  metadata:\n    permissions:\n      - dashboard:raw:read\ncertificates:\n  " + fingerprint + ": metadata\n", "already defined"},
+		{"duplicate permissions key", "version: 1\nroles:\n  metadata:\n    permissions:\n      - dashboard:evidence:read\n    permissions:\n      - dashboard:raw:read\ncertificates:\n  " + fingerprint + ": metadata\n", "already defined"},
+		{"duplicate certificate key", "version: 1\nroles:\n  metadata:\n    permissions:\n      - dashboard:evidence:read\ncertificates:\n  " + fingerprint + ": metadata\n  " + fingerprint + ": metadata\n", "already defined"},
+		{"wrong version", "version: 2\nroles: {}\ncertificates: {}\n", "version"},
+		{"empty certificates", "version: 1\nroles:\n  metadata:\n    permissions:\n      - dashboard:evidence:read\ncertificates: {}\n", "at least one certificate"},
+		{"unknown permission", "version: 1\nroles:\n  metadata:\n    permissions:\n      - dashboard:unknown\ncertificates:\n  " + fingerprint + ": metadata\n", "unknown permission"},
+		{"duplicate permission", "version: 1\nroles:\n  metadata:\n    permissions:\n      - dashboard:evidence:read\n      - dashboard:evidence:read\ncertificates:\n  " + fingerprint + ": metadata\n", "duplicate permission"},
+		{"bad fingerprint", "version: 1\nroles:\n  metadata:\n    permissions:\n      - dashboard:evidence:read\ncertificates:\n  not-a-fingerprint: metadata\n", "fingerprint"},
+		{"duplicate normalized fingerprint", "version: 1\nroles:\n  metadata:\n    permissions:\n      - dashboard:evidence:read\ncertificates:\n  " + fingerprint + ": metadata\n  sha256:" + fingerprint + ": metadata\n", "duplicate normalized fingerprint"},
+		{"unknown role", "version: 1\nroles:\n  metadata:\n    permissions:\n      - dashboard:evidence:read\ncertificates:\n  " + fingerprint + ": missing\n", "unknown role"},
+		{"whitespace role name", "version: 1\nroles:\n  ' metadata ':\n    permissions:\n      - dashboard:evidence:read\ncertificates:\n  " + fingerprint + ": ' metadata '\n", "invalid role name"},
+		{"empty role permissions", "version: 1\nroles:\n  metadata:\n    permissions: []\ncertificates:\n  " + fingerprint + ": metadata\n", "at least one permission"},
+		{"multiple documents", "version: 1\nroles: {}\ncertificates: {}\n---\nversion: 1\n", "one YAML document"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "roles.yaml")
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if _, err := loadDashboardClientCertRoleMap(path); err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestLoadDashboardClientCertRoleMap_RejectsOversizeFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "roles.yaml")
+	data := strings.Repeat(" ", dashboardClientCertRoleMapMaxBytes+1)
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := loadDashboardClientCertRoleMap(path); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("oversize role map: want size error, got %v", err)
+	}
+}
+
+func TestParseDashboardClientCertFingerprint(t *testing.T) {
+	plain := strings.Repeat("a1", sha256.Size)
+	colonSeparated := strings.TrimSuffix(strings.Repeat("A1:", sha256.Size), ":")
+	want, err := parseDashboardClientCertFingerprint(plain)
+	if err != nil {
+		t.Fatalf("parse plain fingerprint: %v", err)
+	}
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{"plain hex", plain},
+		{"sha256 prefix with colons and padding", "  SHA256:" + colonSeparated + "  "},
+	} {
+		t.Run("valid/"+tc.name, func(t *testing.T) {
+			got, err := parseDashboardClientCertFingerprint(tc.value)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.value, err)
+			}
+			if got != want {
+				t.Fatalf("parse %q normalized to %x, want %x", tc.value, got, want)
+			}
+		})
+	}
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{"too short", strings.Repeat("a1", sha256.Size-1)},
+		{"too long", strings.Repeat("a1", sha256.Size+1)},
+		{"non-hex", strings.Repeat("zz", sha256.Size)},
+		{"double prefix", "sha256:sha256:" + plain},
+	} {
+		t.Run("malformed/"+tc.name, func(t *testing.T) {
+			if _, err := parseDashboardClientCertFingerprint(tc.value); err == nil {
+				t.Fatalf("parse malformed fingerprint %q: want error", tc.value)
+			}
+		})
+	}
+}
+
+func TestLoadDashboardClientCAs(t *testing.T) {
+	pki := newDashboardMTLSTestPKI(t)
+	validPEM, err := os.ReadFile(pki.caFile)
+	if err != nil {
+		t.Fatalf("read CA file: %v", err)
+	}
+
+	t.Run("valid bundle loads", func(t *testing.T) {
+		if _, err := loadDashboardClientCAs(pki.caFile); err != nil {
+			t.Fatalf("valid CA bundle rejected: %v", err)
+		}
+	})
+
+	t.Run("mixed valid and malformed bundle is rejected", func(t *testing.T) {
+		malformed := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a DER certificate")})
+		bundle := append(append([]byte{}, validPEM...), malformed...)
+		path := filepath.Join(t.TempDir(), "mixed-ca.pem")
+		if err := os.WriteFile(path, bundle, 0o600); err != nil {
+			t.Fatalf("write mixed bundle: %v", err)
+		}
+		if _, err := loadDashboardClientCAs(path); err == nil {
+			t.Fatal("mixed valid/malformed CA bundle accepted; a malformed certificate must fail loud")
+		}
+	})
+
+	t.Run("empty path rejected", func(t *testing.T) {
+		if _, err := loadDashboardClientCAs("  "); err == nil {
+			t.Fatal("empty --client-ca-file path accepted")
+		}
+	})
+}
+
+func TestDashboardClientCertRoleMap_DocumentedExampleParses(t *testing.T) {
+	const docPath = "../../docs/cli/dashboard.md"
+	doc, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", docPath, err)
+	}
+	const start = "<!-- dashboard-mtls-role-map-start -->\n```yaml\n"
+	const end = "\n```\n<!-- dashboard-mtls-role-map-end -->"
+	startIndex := strings.Index(string(doc), start)
+	if startIndex < 0 {
+		t.Fatalf("documented role map start marker %q not found", start)
+	}
+	after := string(doc[startIndex+len(start):])
+	example, _, ok := strings.Cut(after, end)
+	if !ok {
+		t.Fatalf("documented role map end marker %q not found", end)
+	}
+	path := filepath.Join(t.TempDir(), "documented-role-map.yaml")
+	if err := os.WriteFile(path, []byte(example), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := loadDashboardClientCertRoleMap(path); err != nil {
+		t.Fatalf("documented role map does not parse: %v", err)
+	}
+}
+
+func TestDashboardClientCertAuthorizer_FailsClosed(t *testing.T) {
+	pki := newDashboardMTLSTestPKI(t)
+	now := time.Now()
+	_, mapped := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 103, commonName: "mapped operator", notBefore: now.Add(-time.Hour), notAfter: now.Add(time.Hour),
+	})
+	_, unmapped := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 104, commonName: "unmapped operator", notBefore: now.Add(-time.Hour), notAfter: now.Add(time.Hour),
+	})
+	path := writeDashboardMTLSRoleMap(t, map[string]string{
+		dashboardClientCertSPKIFingerprint(mapped): "metadata",
+	}, "  metadata:\n    permissions:\n      - dashboard:evidence:read\n")
+	authorizer, err := loadDashboardClientCertRoleMap(path)
+	if err != nil {
+		t.Fatalf("load role map: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		req  *http.Request
+		want bool
+	}{
+		{"verified mapped", dashboardMTLSTestRequest(t, mapped, true), true},
+		{"unverified mapped", dashboardMTLSTestRequest(t, mapped, false), false},
+		{"verified unmapped", dashboardMTLSTestRequest(t, unmapped, true), false},
+		{"no TLS", httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://dashboard.example/", nil), false},
+		{"TLS without client certificate", func() *http.Request {
+			r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil)
+			r.TLS = &tls.ConnectionState{}
+			return r
+		}(), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := authorizer.authorized(tc.req); got != tc.want {
+				t.Fatalf("authorized = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDashboardClientCertAuthorizers_VerifiedChainCannotFallThroughToRawToken(t *testing.T) {
+	pki := newDashboardMTLSTestPKI(t)
+	_, leaf := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 110, commonName: "metadata operator", notBefore: time.Now().Add(-time.Hour), notAfter: time.Now().Add(time.Hour),
+	})
+	fingerprint := sha256.Sum256(leaf.RawSubjectPublicKeyInfo)
+	authorizer := &dashboardClientCertAuthorizer{principals: map[[sha256.Size]byte]dashboardClientCertPrincipal{
+		fingerprint: {
+			role: "metadata",
+			permissions: map[dashboard.Permission]struct{}{
+				dashboard.PermissionEvidenceRead: {},
+			},
+		},
+	}}
+	_, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
+		authorizer,
+		func(*http.Request) bool { return true },
+		func(*http.Request) bool { return true },
+		func(*http.Request) bool { return false },
+	)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil)
+	// Construct the divergent state explicitly: the verified leaf is present,
+	// but PeerCertificates is empty. The verified identity must remain
+	// authoritative instead of falling through to the broader token tier.
+	req.TLS = &tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{leaf}}}
+
+	if rawAuthorized(req) {
+		t.Fatal("verified metadata certificate fell through to raw-token authorization")
+	}
+	if err := authorizePermission(req, dashboard.PermissionExemptionsRead); err == nil {
+		t.Fatal("verified metadata certificate fell through to token route permissions")
+	}
+}
+
+func TestDashboardClientCertAuthorizers_NoTokenFallbackWhenMTLSEnabled(t *testing.T) {
+	pki := newDashboardMTLSTestPKI(t)
+	_, leaf := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 111, commonName: "metadata operator", notBefore: time.Now().Add(-time.Hour), notAfter: time.Now().Add(time.Hour),
+	})
+	fingerprint := sha256.Sum256(leaf.RawSubjectPublicKeyInfo)
+	authorizer := &dashboardClientCertAuthorizer{principals: map[[sha256.Size]byte]dashboardClientCertPrincipal{
+		fingerprint: {
+			role:        "metadata",
+			permissions: map[dashboard.Permission]struct{}{dashboard.PermissionEvidenceRead: {}},
+		},
+	}}
+	// Token callbacks that would authorize everything. With mTLS enabled the
+	// verified certificate is authoritative, so these must never be consulted.
+	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
+		authorizer,
+		func(*http.Request) bool { return true },
+		func(*http.Request) bool { return true },
+		func(*http.Request) bool { return false },
+	)
+	// A request carrying a matching operator token but NO client certificate:
+	// the TLS layer would normally reject this, but the application layer must
+	// also fail closed rather than fall back to the token.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil)
+	req.Header.Set("Authorization", "Bearer "+dashTestToken)
+
+	if metaAuthorized(req) {
+		t.Fatal("mTLS mode authorized a certificate-less request via token fallback")
+	}
+	if rawAuthorized(req) {
+		t.Fatal("mTLS mode granted raw access to a certificate-less request via token fallback")
+	}
+	if err := authorizePermission(req, dashboard.PermissionEvidenceRead); err == nil {
+		t.Fatal("mTLS mode granted route permission to a certificate-less request via token fallback")
+	}
+}
+
+func TestDashboardMTLS_RoutePermissionsAndRaw(t *testing.T) {
+	pki := newDashboardMTLSTestPKI(t)
+	now := time.Now()
+	metadataCert, metadataLeaf := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 105, commonName: "metadata operator", notBefore: now.Add(-time.Hour), notAfter: now.Add(time.Hour),
+	})
+	rawCert, rawLeaf := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 106, commonName: "raw operator", notBefore: now.Add(-time.Hour), notAfter: now.Add(time.Hour),
+	})
+	unmappedCert, _ := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 107, commonName: "unmapped operator", notBefore: now.Add(-time.Hour), notAfter: now.Add(time.Hour),
+	})
+	roleMap := writeDashboardMTLSRoleMap(t, map[string]string{
+		dashboardClientCertSPKIFingerprint(metadataLeaf): "metadata",
+		dashboardClientCertSPKIFingerprint(rawLeaf):      "raw",
+	}, "  metadata:\n    permissions:\n      - dashboard:evidence:read\n"+
+		"  raw:\n    permissions:\n      - dashboard:evidence:read\n      - dashboard:exemptions:read\n      - dashboard:raw:read\n")
+	authorizer, err := loadDashboardClientCertRoleMap(roleMap)
+	if err != nil {
+		t.Fatalf("load role map: %v", err)
+	}
+
+	tokenMetaAuthorized := func(r *http.Request) bool { return dashboardTokenMatches(r, dashTestToken) }
+	tokenRawAuthorized := func(r *http.Request) bool { return dashboardTokenMatches(r, "raw-token") }
+	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
+		authorizer, tokenMetaAuthorized, tokenRawAuthorized,
+		func(*http.Request) bool { return false },
+	)
+	inner := dashboard.New(dashboard.Options{
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          func(string) bool { return true },
+		Authorize:           dashboardAuthorizeFunc(metaAuthorized),
+		AuthorizePermission: authorizePermission,
+		AuthorizeRaw:        dashboardAuthorizeFunc(rawAuthorized),
+	})
+	server := httptest.NewUnstartedServer(dashboardAuthHandler(metaAuthorized, inner))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{pki.serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    x509.NewCertPool(),
+		MinVersion:   tls.VersionTLS12,
+	}
+	server.TLS.ClientCAs.AddCert(pki.caCert)
+	server.StartTLS()
+	defer server.Close()
+
+	requestStatus := func(t *testing.T, certs []tls.Certificate, path, token string) (int, error) {
+		t.Helper()
+		transport := &http.Transport{TLSClientConfig: &tls.Config{
+			RootCAs:      pki.serverPool,
+			Certificates: certs,
+			MinVersion:   tls.VersionTLS12,
+		}}
+		defer transport.CloseIdleConnections()
+		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+path, nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return 0, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode, nil
+	}
+
+	tests := []struct {
+		name       string
+		cert       tls.Certificate
+		path       string
+		token      string
+		wantStatus int
+	}{
+		{"metadata evidence allowed", metadataCert, "/", "", http.StatusOK},
+		{"metadata exemptions denied", metadataCert, "/exemptions", "", http.StatusForbidden},
+		{"metadata raw token cannot elevate", metadataCert, "/exemptions", "raw-token", http.StatusForbidden},
+		{"raw role reaches additional route", rawCert, "/exemptions", "", http.StatusOK},
+		{"unmapped verified cert denied", unmappedCert, "/", dashTestToken, http.StatusUnauthorized},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status, err := requestStatus(t, []tls.Certificate{tc.cert}, tc.path, tc.token)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			if status != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", status, tc.wantStatus)
+			}
+		})
+	}
+
+	t.Run("raw role receives raw permission", func(t *testing.T) {
+		req := dashboardMTLSTestRequest(t, rawLeaf, true)
+		if !rawAuthorized(req) {
+			t.Fatal("raw role was denied raw authorization")
+		}
+		if err := authorizePermission(req, dashboard.PermissionRawRead); err != nil {
+			t.Fatalf("raw role was denied raw permission: %v", err)
+		}
+	})
+
+	t.Run("no client certificate rejected by handshake", func(t *testing.T) {
+		if _, err := requestStatus(t, nil, "/", dashTestToken); err == nil {
+			t.Fatal("request without client certificate unexpectedly completed")
+		}
+	})
+}
+
+func TestDashboardMTLS_ExpiredAndWrongCARejected(t *testing.T) {
+	pki := newDashboardMTLSTestPKI(t)
+	otherPKI := newDashboardMTLSTestPKI(t)
+	now := time.Now()
+	expiredCert, expiredLeaf := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 108, commonName: "expired operator", notBefore: now.Add(-2 * time.Hour), notAfter: now.Add(-time.Hour),
+	})
+	wrongCert, wrongLeaf := issueDashboardMTLSTestCert(t, otherPKI.caCert, otherPKI.caKey, dashboardMTLSTestCertOptions{
+		serial: 109, commonName: "wrong CA operator", notBefore: now.Add(-time.Hour), notAfter: now.Add(time.Hour),
+	})
+	roleMap := writeDashboardMTLSRoleMap(t, map[string]string{
+		dashboardClientCertSPKIFingerprint(expiredLeaf): "metadata",
+		dashboardClientCertSPKIFingerprint(wrongLeaf):   "metadata",
+	}, "  metadata:\n    permissions:\n      - dashboard:evidence:read\n")
+	authorizer, err := loadDashboardClientCertRoleMap(roleMap)
+	if err != nil {
+		t.Fatalf("load role map: %v", err)
+	}
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !authorizer.authorized(r) {
+			http.Error(w, "denied", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{pki.serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    x509.NewCertPool(),
+		MinVersion:   tls.VersionTLS12,
+	}
+	server.TLS.ClientCAs.AddCert(pki.caCert)
+	server.StartTLS()
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name string
+		cert tls.Certificate
+	}{
+		{"expired", expiredCert},
+		{"wrong CA", wrongCert},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cert := tc.cert
+			var presented bool
+			client := &http.Client{
+				Timeout: 5 * time.Second,
+				Transport: &http.Transport{TLSClientConfig: &tls.Config{
+					RootCAs: pki.serverPool,
+					// GetClientCertificate forces the test certificate to be
+					// presented even when its issuer is absent from the server's
+					// AcceptableCAs. Default selection would silently drop the
+					// wrong-CA certificate, collapsing this case into the
+					// no-client-certificate path instead of exercising the
+					// certificate-verification rejection under test.
+					GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+						presented = true
+						return &cert, nil
+					},
+					MinVersion: tls.VersionTLS12,
+				}},
+			}
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err == nil {
+				_ = resp.Body.Close()
+				t.Fatalf("%s certificate unexpectedly completed TLS with status %d", tc.name, resp.StatusCode)
+			}
+			if !presented {
+				t.Fatalf("%s certificate was never presented; test did not exercise certificate verification", tc.name)
+			}
+		})
+	}
+}
+
+func TestDashboardTLSConfig_ClientCertificates(t *testing.T) {
+	pki := newDashboardMTLSTestPKI(t)
+	certFile, keyFile, _ := writeDashTLSCert(t)
+	opts := dashboardServeOptions{
+		tlsCert:           certFile,
+		tlsKey:            keyFile,
+		requireClientCert: true,
+		clientCAFile:      pki.caFile,
+		clientCertRoleMap: "roles.yaml",
+	}
+	config, err := dashboardTLSConfig(opts)
+	if err != nil {
+		t.Fatalf("dashboardTLSConfig: %v", err)
+	}
+	if config.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Fatalf("ClientAuth = %v, want RequireAndVerifyClientCert", config.ClientAuth)
+	}
+	if config.ClientCAs == nil {
+		t.Fatal("ClientCAs is empty")
+	}
+}
+
+func TestValidateDashboardListen_ClientCertificateFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    dashboardServeOptions
+		wantErr string
+	}{
+		{"complete", dashboardServeOptions{listen: "127.0.0.1:8896", tlsCert: "server.pem", tlsKey: "server.key", requireClientCert: true, clientCAFile: "ca.pem", clientCertRoleMap: "roles.yaml"}, ""},
+		{"requires server TLS", dashboardServeOptions{listen: "127.0.0.1:8896", requireClientCert: true, clientCAFile: "ca.pem", clientCertRoleMap: "roles.yaml"}, "--tls-cert"},
+		{"requires CA", dashboardServeOptions{listen: "127.0.0.1:8896", tlsCert: "server.pem", tlsKey: "server.key", requireClientCert: true, clientCertRoleMap: "roles.yaml"}, "--client-ca-file"},
+		{"requires role map", dashboardServeOptions{listen: "127.0.0.1:8896", tlsCert: "server.pem", tlsKey: "server.key", requireClientCert: true, clientCAFile: "ca.pem"}, "--client-cert-role-map"},
+		{"CA without enable refused", dashboardServeOptions{listen: "127.0.0.1:8896", tlsCert: "server.pem", tlsKey: "server.key", clientCAFile: "ca.pem"}, "--require-client-cert"},
+		{"role map without enable refused", dashboardServeOptions{listen: "127.0.0.1:8896", tlsCert: "server.pem", tlsKey: "server.key", clientCertRoleMap: "roles.yaml"}, "--require-client-cert"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDashboardListen(tc.opts)
+			if tc.wantErr == "" && err != nil {
+				t.Fatalf("want nil, got %v", err)
+			}
+			if tc.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestDashboardMTLSAuthorizer_AllPermissionValuesAreRecognized(t *testing.T) {
+	known := dashboardPermissionSet()
+	for _, permission := range dashboard.AllPermissions() {
+		if _, ok := known[permission]; !ok {
+			t.Errorf("permission %q missing from mTLS role-map validator", permission)
+		}
+	}
+	if _, ok := known[dashboard.Permission("dashboard:unknown")]; ok {
+		t.Fatal("unknown permission unexpectedly recognized")
+	}
+}
+
+func TestDashboardMTLS_DoesNotChangeLicenseEntitlement(t *testing.T) {
+	inner := dashboard.New(dashboard.Options{
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          func(string) bool { return false },
+		Authorize:           func(*http.Request) error { return nil },
+		AuthorizePermission: func(*http.Request, dashboard.Permission) error { return nil },
+		AuthorizeRaw:        func(*http.Request) error { return nil },
+	})
+	recorder := httptest.NewRecorder()
+	inner.ServeHTTP(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil))
+	if recorder.Code != http.StatusForbidden || !strings.Contains(recorder.Body.String(), license.FeatureAgents) {
+		t.Fatalf("status/body = %d %q, want entitlement denial", recorder.Code, recorder.Body.String())
+	}
+}

--- a/enterprise/cli/dashboard_oidc.go
+++ b/enterprise/cli/dashboard_oidc.go
@@ -1,0 +1,730 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package entcli
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/dashboard"
+)
+
+const (
+	dashboardOIDCAlgorithm       = "RS256"
+	dashboardOIDCClockLeeway     = 30 * time.Second
+	dashboardOIDCDefaultCacheTTL = 5 * time.Minute
+	dashboardOIDCHTTPTimeout     = 5 * time.Second
+	dashboardOIDCMaxDocumentSize = 1 << 20
+	dashboardOIDCMaxTokenSize    = 16 << 10
+	dashboardOIDCMaxRoleValues   = 64
+	dashboardOIDCMaxRoleLength   = 256
+	dashboardOIDCMinKeyRefresh   = 30 * time.Second
+)
+
+type dashboardOIDCOptions struct {
+	Issuer       string
+	Audience     string
+	RoleClaim    string
+	RoleMapJSON  string
+	HTTPClient   *http.Client
+	Now          func() time.Time
+	JWKSCacheTTL time.Duration
+}
+
+func validateDashboardAuthenticatorConfig(opts dashboardServeOptions) error {
+	issuerConfigured := strings.TrimSpace(opts.oidcIssuer) != ""
+	anyOIDCOption := issuerConfigured || strings.TrimSpace(opts.oidcAudience) != "" ||
+		strings.TrimSpace(opts.oidcClientID) != "" || strings.TrimSpace(opts.oidcRoleClaim) != "" ||
+		strings.TrimSpace(opts.oidcRoleMap) != ""
+	if anyOIDCOption && !issuerConfigured {
+		return errors.New("--oidc-issuer is required when any OIDC option is set")
+	}
+	if strings.TrimSpace(opts.authTokenFile) == "" && !issuerConfigured {
+		return errors.New("one authenticator is required: set --auth-token-file or --oidc-issuer")
+	}
+	if strings.TrimSpace(opts.rawTokenFile) != "" && strings.TrimSpace(opts.authTokenFile) == "" {
+		return errors.New("--raw-token-file requires --auth-token-file")
+	}
+	if !issuerConfigured {
+		return nil
+	}
+	if strings.TrimSpace(opts.oidcAudience) == "" && strings.TrimSpace(opts.oidcClientID) == "" {
+		return errors.New("--oidc-audience or --oidc-client-id is required with --oidc-issuer")
+	}
+	if strings.TrimSpace(opts.oidcAudience) != "" && strings.TrimSpace(opts.oidcClientID) != "" &&
+		strings.TrimSpace(opts.oidcAudience) != strings.TrimSpace(opts.oidcClientID) {
+		return errors.New("--oidc-audience and --oidc-client-id must match when both are set")
+	}
+	if strings.TrimSpace(opts.oidcRoleClaim) == "" {
+		return errors.New("--oidc-role-claim is required with --oidc-issuer")
+	}
+	if strings.TrimSpace(opts.oidcRoleMap) == "" {
+		return errors.New("--oidc-role-map must not be empty when OIDC is enabled")
+	}
+	return nil
+}
+
+func dashboardOIDCAudience(opts dashboardServeOptions) string {
+	if strings.TrimSpace(opts.oidcAudience) != "" {
+		return strings.TrimSpace(opts.oidcAudience)
+	}
+	return strings.TrimSpace(opts.oidcClientID)
+}
+
+type dashboardOIDCAuthenticator struct {
+	issuer    string
+	audience  string
+	roleClaim string
+	roleMap   dashboardOIDCRoleMap
+	keys      *dashboardJWKSCache
+	now       func() time.Time
+}
+
+type dashboardOIDCPrincipal struct {
+	Subject     string
+	Roles       []string
+	permissions map[dashboard.Permission]struct{}
+}
+
+func (p *dashboardOIDCPrincipal) hasPermission(permission dashboard.Permission) bool {
+	if p == nil {
+		return false
+	}
+	_, ok := p.permissions[permission]
+	return ok
+}
+
+type dashboardOIDCRoleMap struct {
+	claimValues map[string]string
+	roles       map[string]map[dashboard.Permission]struct{}
+}
+
+type dashboardOIDCRoleMapDocument struct {
+	ClaimValues map[string]string   `json:"claim_values"`
+	Roles       map[string][]string `json:"roles"`
+}
+
+func parseDashboardOIDCRoleMap(value string) (dashboardOIDCRoleMap, error) {
+	if strings.TrimSpace(value) == "" {
+		return dashboardOIDCRoleMap{}, errors.New("--oidc-role-map must contain a JSON role map")
+	}
+	if len(value) > dashboardOIDCMaxDocumentSize {
+		return dashboardOIDCRoleMap{}, errors.New("--oidc-role-map exceeds the 1 MiB limit")
+	}
+	var document dashboardOIDCRoleMapDocument
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&document); err != nil {
+		return dashboardOIDCRoleMap{}, fmt.Errorf("parse --oidc-role-map: %w", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return dashboardOIDCRoleMap{}, fmt.Errorf("parse --oidc-role-map: %w", err)
+	}
+	if len(document.ClaimValues) == 0 {
+		return dashboardOIDCRoleMap{}, errors.New("--oidc-role-map claim_values must not be empty")
+	}
+	if len(document.Roles) == 0 {
+		return dashboardOIDCRoleMap{}, errors.New("--oidc-role-map roles must not be empty")
+	}
+
+	knownPermissions := make(map[dashboard.Permission]struct{})
+	for _, permission := range dashboard.AllPermissions() {
+		knownPermissions[permission] = struct{}{}
+	}
+	roles := make(map[string]map[dashboard.Permission]struct{}, len(document.Roles))
+	for role, configuredPermissions := range document.Roles {
+		if strings.TrimSpace(role) == "" || len(role) > dashboardOIDCMaxRoleLength {
+			return dashboardOIDCRoleMap{}, errors.New("--oidc-role-map contains an empty or overlong role name")
+		}
+		if len(configuredPermissions) == 0 {
+			return dashboardOIDCRoleMap{}, fmt.Errorf("--oidc-role-map role %q must grant at least one permission", role)
+		}
+		permissions := make(map[dashboard.Permission]struct{}, len(configuredPermissions))
+		for _, configured := range configuredPermissions {
+			permission := dashboard.Permission(configured)
+			if _, ok := knownPermissions[permission]; !ok {
+				return dashboardOIDCRoleMap{}, fmt.Errorf("--oidc-role-map role %q has unknown permission %q", role, configured)
+			}
+			permissions[permission] = struct{}{}
+		}
+		roles[role] = permissions
+	}
+	for claimValue, role := range document.ClaimValues {
+		if strings.TrimSpace(claimValue) == "" || len(claimValue) > dashboardOIDCMaxRoleLength {
+			return dashboardOIDCRoleMap{}, errors.New("--oidc-role-map contains an empty or overlong claim value")
+		}
+		if _, ok := roles[role]; !ok {
+			return dashboardOIDCRoleMap{}, fmt.Errorf("--oidc-role-map claim value %q references unknown role %q", claimValue, role)
+		}
+	}
+	return dashboardOIDCRoleMap{claimValues: document.ClaimValues, roles: roles}, nil
+}
+
+type dashboardOIDCDiscovery struct {
+	Issuer  string `json:"issuer"`
+	JWKSURI string `json:"jwks_uri"`
+}
+
+func newDashboardOIDCAuthenticator(ctx context.Context, opts dashboardOIDCOptions) (*dashboardOIDCAuthenticator, error) {
+	issuer := strings.TrimSpace(opts.Issuer)
+	if err := validateDashboardOIDCURL("--oidc-issuer", issuer); err != nil {
+		return nil, err
+	}
+	audience := strings.TrimSpace(opts.Audience)
+	if audience == "" {
+		return nil, errors.New("--oidc-audience or --oidc-client-id is required with --oidc-issuer")
+	}
+	roleClaim := strings.TrimSpace(opts.RoleClaim)
+	if roleClaim == "" || len(roleClaim) > dashboardOIDCMaxRoleLength {
+		return nil, errors.New("--oidc-role-claim must be non-empty and at most 256 bytes")
+	}
+	roleMap, err := parseDashboardOIDCRoleMap(opts.RoleMapJSON)
+	if err != nil {
+		return nil, err
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	cacheTTL := opts.JWKSCacheTTL
+	if cacheTTL <= 0 {
+		cacheTTL = dashboardOIDCDefaultCacheTTL
+	}
+	client := &http.Client{Timeout: dashboardOIDCHTTPTimeout}
+	if opts.HTTPClient != nil {
+		client = new(http.Client)
+		*client = *opts.HTTPClient
+	}
+	// Discovery and JWKS endpoints are fixed trust anchors. Following even a
+	// same-origin redirect makes their effective destination mutable and can
+	// turn provider metadata into an SSRF or downgrade hop. Clone injected
+	// clients above so this policy cannot be weakened by their redirect hook.
+	client.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	discoveryURL := strings.TrimSuffix(issuer, "/") + "/.well-known/openid-configuration"
+	var discovery dashboardOIDCDiscovery
+	if err := fetchDashboardOIDCJSON(ctx, client, discoveryURL, &discovery); err != nil {
+		return nil, fmt.Errorf("OIDC discovery: %w", err)
+	}
+	if discovery.Issuer != issuer {
+		return nil, fmt.Errorf("OIDC discovery issuer %q does not match configured issuer %q", discovery.Issuer, issuer)
+	}
+	if err := validateDashboardOIDCURL("OIDC jwks_uri", discovery.JWKSURI); err != nil {
+		return nil, err
+	}
+	keys := &dashboardJWKSCache{
+		uri:    discovery.JWKSURI,
+		client: client,
+		now:    now,
+		ttl:    cacheTTL,
+	}
+	if err := keys.refresh(ctx); err != nil {
+		return nil, fmt.Errorf("load OIDC JWKS: %w", err)
+	}
+	return &dashboardOIDCAuthenticator{
+		issuer: issuer, audience: audience, roleClaim: roleClaim,
+		roleMap: roleMap, keys: keys, now: now,
+	}, nil
+}
+
+func validateDashboardOIDCURL(label, value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("%s: %w", label, err)
+	}
+	if parsed.User != nil || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("%s must be an absolute URL without credentials, query, or fragment", label)
+	}
+	if parsed.Scheme == "https" {
+		return nil
+	}
+	if parsed.Scheme == "http" {
+		host := parsed.Hostname()
+		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s must use HTTPS (HTTP is allowed only for a loopback test issuer)", label)
+}
+
+func fetchDashboardOIDCJSON(ctx context.Context, client *http.Client, endpoint string, dst any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("%s returned HTTP %d", endpoint, resp.StatusCode)
+	}
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, dashboardOIDCMaxDocumentSize+1))
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	return requireJSONEOF(decoder)
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("unexpected trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+type dashboardJWKSCache struct {
+	mu        sync.Mutex
+	uri       string
+	client    *http.Client
+	now       func() time.Time
+	ttl       time.Duration
+	keys      map[string]*rsa.PublicKey
+	expiresAt time.Time
+	lastMiss  time.Time
+}
+
+type dashboardJWKS struct {
+	Keys []dashboardJWK `json:"keys"`
+}
+
+type dashboardJWK struct {
+	KeyType string   `json:"kty"`
+	KeyID   string   `json:"kid"`
+	Use     string   `json:"use"`
+	Alg     string   `json:"alg"`
+	KeyOps  []string `json:"key_ops"`
+	N       string   `json:"n"`
+	E       string   `json:"e"`
+}
+
+func (c *dashboardJWKSCache) key(ctx context.Context, keyID string) (*rsa.PublicKey, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.keys == nil || !c.now().Before(c.expiresAt) {
+		if err := c.refreshLocked(ctx); err != nil {
+			return nil, err
+		}
+	}
+	if key := c.keys[keyID]; key != nil {
+		return key, nil
+	}
+	// An unknown kid commonly means the provider rotated keys before this
+	// cache entry expired. Refresh at a bounded rate; attacker-chosen kids must
+	// not turn the dashboard into a JWKS request amplifier.
+	if !c.lastMiss.IsZero() && c.now().Before(c.lastMiss.Add(dashboardOIDCMinKeyRefresh)) {
+		return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
+	}
+	c.lastMiss = c.now()
+	if err := c.refreshLocked(ctx); err != nil {
+		return nil, err
+	}
+	key := c.keys[keyID]
+	if key == nil {
+		return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
+	}
+	return key, nil
+}
+
+func (c *dashboardJWKSCache) refresh(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.refreshLocked(ctx)
+}
+
+func (c *dashboardJWKSCache) refreshLocked(ctx context.Context) error {
+	var set dashboardJWKS
+	if err := fetchDashboardOIDCJSON(ctx, c.client, c.uri, &set); err != nil {
+		return err
+	}
+	keys := make(map[string]*rsa.PublicKey)
+	for _, jwk := range set.Keys {
+		key, include, err := parseDashboardRSAJWK(jwk)
+		if err != nil {
+			return err
+		}
+		if !include {
+			continue
+		}
+		if _, duplicate := keys[jwk.KeyID]; duplicate {
+			return fmt.Errorf("OIDC JWKS contains duplicate kid %q", jwk.KeyID)
+		}
+		keys[jwk.KeyID] = key
+	}
+	if len(keys) == 0 {
+		return errors.New("OIDC JWKS contains no usable RS256 signing keys")
+	}
+	c.keys = keys
+	c.expiresAt = c.now().Add(c.ttl)
+	return nil
+}
+
+func parseDashboardRSAJWK(jwk dashboardJWK) (*rsa.PublicKey, bool, error) {
+	if jwk.KeyType != "RSA" || (jwk.Use != "" && jwk.Use != "sig") || (jwk.Alg != "" && jwk.Alg != dashboardOIDCAlgorithm) {
+		return nil, false, nil
+	}
+	if jwk.KeyID == "" || len(jwk.KeyID) > dashboardOIDCMaxRoleLength {
+		return nil, false, errors.New("OIDC JWKS has a usable RSA key with an empty or overlong kid")
+	}
+	if len(jwk.KeyOps) > 0 && !containsString(jwk.KeyOps, "verify") {
+		return nil, false, nil
+	}
+	nBytes, err := base64.RawURLEncoding.Strict().DecodeString(jwk.N)
+	if err != nil {
+		return nil, false, fmt.Errorf("decode OIDC JWK %q modulus: %w", jwk.KeyID, err)
+	}
+	eBytes, err := base64.RawURLEncoding.Strict().DecodeString(jwk.E)
+	if err != nil {
+		return nil, false, fmt.Errorf("decode OIDC JWK %q exponent: %w", jwk.KeyID, err)
+	}
+	n := new(big.Int).SetBytes(nBytes)
+	eBig := new(big.Int).SetBytes(eBytes)
+	if n.BitLen() < 2048 {
+		return nil, false, fmt.Errorf("OIDC JWK %q RSA modulus is smaller than 2048 bits", jwk.KeyID)
+	}
+	if !eBig.IsInt64() {
+		return nil, false, fmt.Errorf("OIDC JWK %q exponent is out of range", jwk.KeyID)
+	}
+	e := eBig.Int64()
+	if e < 3 || e > int64(^uint(0)>>1) || e%2 == 0 {
+		return nil, false, fmt.Errorf("OIDC JWK %q exponent is invalid", jwk.KeyID)
+	}
+	return &rsa.PublicKey{N: n, E: int(e)}, true, nil
+}
+
+type dashboardJWTHeader struct {
+	Algorithm string   `json:"alg"`
+	KeyID     string   `json:"kid"`
+	Critical  []string `json:"crit"`
+}
+
+func (a *dashboardOIDCAuthenticator) authenticate(r *http.Request) (*dashboardOIDCPrincipal, error) {
+	token, err := dashboardBearerToken(r)
+	if err != nil {
+		return nil, err
+	}
+	if len(token) > dashboardOIDCMaxTokenSize {
+		return nil, errors.New("OIDC bearer token is too large")
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return nil, errors.New("OIDC bearer token must be a signed compact JWT")
+	}
+	headerBytes, err := base64.RawURLEncoding.Strict().DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("decode OIDC JWT header: %w", err)
+	}
+	var header dashboardJWTHeader
+	if err := decodeDashboardJWTJSON(headerBytes, &header); err != nil {
+		return nil, fmt.Errorf("decode OIDC JWT header: %w", err)
+	}
+	if header.Algorithm != dashboardOIDCAlgorithm {
+		return nil, fmt.Errorf("OIDC JWT algorithm %q is not allowed; expected RS256", header.Algorithm)
+	}
+	if header.KeyID == "" || len(header.KeyID) > dashboardOIDCMaxRoleLength {
+		return nil, errors.New("OIDC JWT kid is empty or overlong")
+	}
+	if len(header.Critical) != 0 {
+		return nil, errors.New("OIDC JWT uses unsupported critical headers")
+	}
+	signature, err := base64.RawURLEncoding.Strict().DecodeString(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("decode OIDC JWT signature: %w", err)
+	}
+	key, err := a.keys.key(r.Context(), header.KeyID)
+	if err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	if err := rsa.VerifyPKCS1v15(key, crypto.SHA256, digest[:], signature); err != nil {
+		return nil, errors.New("OIDC JWT signature verification failed")
+	}
+
+	// Claims are decoded only after the signature succeeds; no identity or
+	// authorization decision is ever made from an unverified payload.
+	claimsBytes, err := base64.RawURLEncoding.Strict().DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode verified OIDC claims: %w", err)
+	}
+	var claims map[string]json.RawMessage
+	if err := decodeDashboardJWTJSON(claimsBytes, &claims); err != nil {
+		return nil, fmt.Errorf("decode verified OIDC claims: %w", err)
+	}
+	return a.principalFromClaims(claims)
+}
+
+func decodeDashboardJWTJSON(data []byte, dst any) error {
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.UseNumber()
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	return requireJSONEOF(decoder)
+}
+
+func dashboardBearerToken(r *http.Request) (string, error) {
+	parts := strings.Fields(r.Header.Get("Authorization"))
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || parts[1] == "" {
+		return "", errors.New("OIDC bearer token is missing")
+	}
+	return parts[1], nil
+}
+
+func (a *dashboardOIDCAuthenticator) principalFromClaims(claims map[string]json.RawMessage) (*dashboardOIDCPrincipal, error) {
+	issuer, err := requiredStringClaim(claims, "iss")
+	if err != nil || issuer != a.issuer {
+		return nil, errors.New("OIDC issuer claim is missing or does not match")
+	}
+	subject, err := requiredStringClaim(claims, "sub")
+	if err != nil {
+		return nil, errors.New("OIDC subject claim is missing or invalid")
+	}
+	audiences, err := audienceClaim(claims["aud"])
+	if err != nil || !containsString(audiences, a.audience) {
+		return nil, errors.New("OIDC audience claim is missing or does not match")
+	}
+	if rawAZP, present := claims["azp"]; present {
+		var azp string
+		if err := json.Unmarshal(rawAZP, &azp); err != nil || azp != a.audience {
+			return nil, errors.New("OIDC authorized-party claim does not match the expected audience")
+		}
+	} else if len(audiences) > 1 {
+		return nil, errors.New("OIDC token with multiple audiences is missing azp")
+	}
+
+	now := a.now()
+	expiresAt, err := numericDateClaim(claims, "exp", true)
+	if err != nil || !now.Before(expiresAt.Add(dashboardOIDCClockLeeway)) {
+		return nil, errors.New("OIDC token is expired or has an invalid exp claim")
+	}
+	if notBefore, err := numericDateClaim(claims, "nbf", false); err != nil {
+		return nil, errors.New("OIDC token has an invalid nbf claim")
+	} else if !notBefore.IsZero() && now.Add(dashboardOIDCClockLeeway).Before(notBefore) {
+		return nil, errors.New("OIDC token is not yet valid")
+	}
+
+	claimValues, err := roleClaimValues(claims[a.roleClaim])
+	if err != nil {
+		return nil, err
+	}
+	principal := &dashboardOIDCPrincipal{
+		Subject: subject, permissions: make(map[dashboard.Permission]struct{}),
+	}
+	seenRoles := make(map[string]struct{})
+	for _, claimValue := range claimValues {
+		role, mapped := a.roleMap.claimValues[claimValue]
+		if !mapped {
+			continue
+		}
+		if _, seen := seenRoles[role]; seen {
+			continue
+		}
+		seenRoles[role] = struct{}{}
+		principal.Roles = append(principal.Roles, role)
+		for permission := range a.roleMap.roles[role] {
+			principal.permissions[permission] = struct{}{}
+		}
+	}
+	if len(principal.Roles) == 0 {
+		return nil, errors.New("OIDC role claim has no mapped value")
+	}
+	return principal, nil
+}
+
+func requiredStringClaim(claims map[string]json.RawMessage, name string) (string, error) {
+	raw, ok := claims[name]
+	if !ok {
+		return "", errors.New("claim missing")
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil || strings.TrimSpace(value) == "" || len(value) > dashboardOIDCMaxTokenSize {
+		return "", errors.New("claim invalid")
+	}
+	return value, nil
+}
+
+func audienceClaim(raw json.RawMessage) ([]string, error) {
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		if single == "" {
+			return nil, errors.New("audience is empty")
+		}
+		return []string{single}, nil
+	}
+	var multiple []string
+	if err := json.Unmarshal(raw, &multiple); err != nil || len(multiple) == 0 || len(multiple) > dashboardOIDCMaxRoleValues {
+		return nil, errors.New("audience is invalid")
+	}
+	for _, audience := range multiple {
+		if audience == "" || len(audience) > dashboardOIDCMaxRoleLength {
+			return nil, errors.New("audience is invalid")
+		}
+	}
+	return multiple, nil
+}
+
+func numericDateClaim(claims map[string]json.RawMessage, name string, required bool) (time.Time, error) {
+	raw, ok := claims[name]
+	if !ok {
+		if required {
+			return time.Time{}, errors.New("claim missing")
+		}
+		return time.Time{}, nil
+	}
+	text := strings.TrimSpace(string(raw))
+	if text == "" || text[0] == '"' {
+		return time.Time{}, errors.New("numeric date must be a JSON number")
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err != nil {
+		return time.Time{}, err
+	}
+	seconds, err := strconv.ParseInt(number.String(), 10, 64)
+	if err != nil || seconds < 0 {
+		return time.Time{}, errors.New("numeric date is invalid")
+	}
+	return time.Unix(seconds, 0), nil
+}
+
+func roleClaimValues(raw json.RawMessage) ([]string, error) {
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		if single == "" || len(single) > dashboardOIDCMaxRoleLength {
+			return nil, errors.New("OIDC role claim is empty or overlong")
+		}
+		return []string{single}, nil
+	}
+	var multiple []string
+	if err := json.Unmarshal(raw, &multiple); err != nil || len(multiple) == 0 || len(multiple) > dashboardOIDCMaxRoleValues {
+		return nil, errors.New("OIDC role claim must be a string or a bounded string array")
+	}
+	for _, value := range multiple {
+		if value == "" || len(value) > dashboardOIDCMaxRoleLength {
+			return nil, errors.New("OIDC role claim contains an empty or overlong value")
+		}
+	}
+	return multiple, nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+type dashboardOIDCPrincipalContextKey struct{}
+
+func dashboardOIDCPrincipalFromRequest(r *http.Request) *dashboardOIDCPrincipal {
+	principal, _ := r.Context().Value(dashboardOIDCPrincipalContextKey{}).(*dashboardOIDCPrincipal)
+	return principal
+}
+
+func (a *dashboardOIDCAuthenticator) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		principal, err := a.authenticate(r)
+		if err == nil {
+			ctx := context.WithValue(r.Context(), dashboardOIDCPrincipalContextKey{}, principal)
+			r = r.WithContext(ctx)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+type dashboardRequestAuthorization struct {
+	metadataToken   string
+	rawToken        string
+	complianceToken string
+	oidc            *dashboardOIDCAuthenticator
+	legacy          func(*http.Request, dashboard.Permission) error
+}
+
+func newDashboardRequestAuthorization(metadataToken, rawToken, complianceToken string, oidc *dashboardOIDCAuthenticator) *dashboardRequestAuthorization {
+	return &dashboardRequestAuthorization{
+		metadataToken:   metadataToken,
+		rawToken:        rawToken,
+		complianceToken: complianceToken,
+		oidc:            oidc,
+		legacy: dashboardAuthorizePermissionFunc(
+			func(req *http.Request) bool {
+				return dashboardTokenMatches(req, metadataToken) || dashboardTokenMatches(req, rawToken)
+			},
+			func(req *http.Request) bool { return dashboardTokenMatches(req, rawToken) },
+			func(req *http.Request) bool {
+				return complianceToken != "" && dashboardTokenMatches(req, complianceToken)
+			},
+		),
+	}
+}
+
+func (a *dashboardRequestAuthorization) metaAuthorized(r *http.Request) bool {
+	return dashboardTokenMatches(r, a.metadataToken) ||
+		dashboardTokenMatches(r, a.rawToken) ||
+		dashboardOIDCPrincipalFromRequest(r) != nil
+}
+
+// complianceAuthorized recognizes the optional auditor token, which is scoped to
+// the compliance path by authenticated/dashboardGlobalAuthorized.
+func (a *dashboardRequestAuthorization) complianceAuthorized(r *http.Request) bool {
+	return a.complianceToken != "" && dashboardTokenMatches(r, a.complianceToken)
+}
+
+// authenticated is the global gate: any operator/OIDC identity, or the
+// compliance token restricted to the compliance path.
+func (a *dashboardRequestAuthorization) authenticated(r *http.Request) bool {
+	if a.metaAuthorized(r) {
+		return true
+	}
+	return r.URL.Path == dashboard.CompliancePath && a.complianceAuthorized(r)
+}
+
+func (a *dashboardRequestAuthorization) rawAuthorized(r *http.Request) bool {
+	return dashboardTokenMatches(r, a.rawToken) ||
+		dashboardOIDCPrincipalFromRequest(r).hasPermission(dashboard.PermissionRawRead)
+}
+
+func (a *dashboardRequestAuthorization) authorizePermission(r *http.Request, permission dashboard.Permission) error {
+	if dashboardOIDCPrincipalFromRequest(r).hasPermission(permission) {
+		return nil
+	}
+	if err := a.legacy(r, permission); err == nil {
+		return nil
+	}
+	return fmt.Errorf("dashboard permission %q denied", permission)
+}
+
+func (a *dashboardRequestAuthorization) wrap(next http.Handler) http.Handler {
+	handler := dashboardAuthHandler(a.authenticated, next)
+	if a.oidc != nil {
+		return a.oidc.middleware(handler)
+	}
+	return handler
+}

--- a/enterprise/cli/dashboard_oidc.go
+++ b/enterprise/cli/dashboard_oidc.go
@@ -300,14 +300,16 @@ func requireJSONEOF(decoder *json.Decoder) error {
 }
 
 type dashboardJWKSCache struct {
-	mu        sync.Mutex
-	uri       string
-	client    *http.Client
-	now       func() time.Time
-	ttl       time.Duration
-	keys      map[string]*rsa.PublicKey
-	expiresAt time.Time
-	lastMiss  time.Time
+	mu         sync.Mutex
+	uri        string
+	client     *http.Client
+	now        func() time.Time
+	ttl        time.Duration
+	keys       map[string]*rsa.PublicKey
+	expiresAt  time.Time
+	lastMiss   time.Time
+	refreshCh  chan struct{}
+	refreshErr error
 }
 
 type dashboardJWKS struct {
@@ -326,26 +328,32 @@ type dashboardJWK struct {
 
 func (c *dashboardJWKSCache) key(ctx context.Context, keyID string) (*rsa.PublicKey, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.keys == nil || !c.now().Before(c.expiresAt) {
-		if err := c.refreshLocked(ctx); err != nil {
+		c.mu.Unlock()
+		if err := c.refresh(ctx); err != nil {
 			return nil, err
 		}
+		c.mu.Lock()
 	}
 	if key := c.keys[keyID]; key != nil {
+		c.mu.Unlock()
 		return key, nil
 	}
 	// An unknown kid commonly means the provider rotated keys before this
 	// cache entry expired. Refresh at a bounded rate; attacker-chosen kids must
 	// not turn the dashboard into a JWKS request amplifier.
 	if !c.lastMiss.IsZero() && c.now().Before(c.lastMiss.Add(dashboardOIDCMinKeyRefresh)) {
+		c.mu.Unlock()
 		return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
 	}
 	c.lastMiss = c.now()
-	if err := c.refreshLocked(ctx); err != nil {
+	c.mu.Unlock()
+	if err := c.refresh(ctx); err != nil {
 		return nil, err
 	}
+	c.mu.Lock()
 	key := c.keys[keyID]
+	c.mu.Unlock()
 	if key == nil {
 		return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
 	}
@@ -354,11 +362,34 @@ func (c *dashboardJWKSCache) key(ctx context.Context, keyID string) (*rsa.Public
 
 func (c *dashboardJWKSCache) refresh(ctx context.Context) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.refreshLocked(ctx)
+	if c.refreshCh != nil {
+		refreshCh := c.refreshCh
+		c.mu.Unlock()
+		select {
+		case <-refreshCh:
+			c.mu.Lock()
+			err := c.refreshErr
+			c.mu.Unlock()
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	refreshCh := make(chan struct{})
+	c.refreshCh = refreshCh
+	c.mu.Unlock()
+
+	err := c.fetchAndStore(ctx)
+
+	c.mu.Lock()
+	c.refreshErr = err
+	close(refreshCh)
+	c.refreshCh = nil
+	c.mu.Unlock()
+	return err
 }
 
-func (c *dashboardJWKSCache) refreshLocked(ctx context.Context) error {
+func (c *dashboardJWKSCache) fetchAndStore(ctx context.Context) error {
 	var set dashboardJWKS
 	if err := fetchDashboardOIDCJSON(ctx, c.client, c.uri, &set); err != nil {
 		return err
@@ -380,6 +411,8 @@ func (c *dashboardJWKSCache) refreshLocked(ctx context.Context) error {
 	if len(keys) == 0 {
 		return errors.New("OIDC JWKS contains no usable RS256 signing keys")
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.keys = keys
 	c.expiresAt = c.now().Add(c.ttl)
 	return nil
@@ -643,9 +676,16 @@ func containsString(values []string, want string) bool {
 
 type dashboardOIDCPrincipalContextKey struct{}
 
+type dashboardOIDCFailureContextKey struct{}
+
 func dashboardOIDCPrincipalFromRequest(r *http.Request) *dashboardOIDCPrincipal {
 	principal, _ := r.Context().Value(dashboardOIDCPrincipalContextKey{}).(*dashboardOIDCPrincipal)
 	return principal
+}
+
+func dashboardOIDCFailureReasonFromRequest(r *http.Request) string {
+	reason, _ := r.Context().Value(dashboardOIDCFailureContextKey{}).(string)
+	return reason
 }
 
 func (a *dashboardOIDCAuthenticator) middleware(next http.Handler) http.Handler {
@@ -654,9 +694,36 @@ func (a *dashboardOIDCAuthenticator) middleware(next http.Handler) http.Handler 
 		if err == nil {
 			ctx := context.WithValue(r.Context(), dashboardOIDCPrincipalContextKey{}, principal)
 			r = r.WithContext(ctx)
+		} else if dashboardBearerAttempted(r) {
+			ctx := context.WithValue(r.Context(), dashboardOIDCFailureContextKey{}, dashboardOIDCFailureCategory(err))
+			r = r.WithContext(ctx)
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func dashboardBearerAttempted(r *http.Request) bool {
+	parts := strings.Fields(r.Header.Get("Authorization"))
+	return len(parts) > 0 && strings.EqualFold(parts[0], "Bearer")
+}
+
+func dashboardOIDCFailureCategory(err error) string {
+	if err == nil {
+		return "-"
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "missing"):
+		return "missing_token"
+	case strings.Contains(msg, "signature"):
+		return "invalid_signature"
+	case strings.Contains(msg, "expired"):
+		return "expired"
+	case strings.Contains(msg, "role claim has no mapped value"):
+		return "permission_denied"
+	default:
+		return "invalid_token"
+	}
 }
 
 type dashboardRequestAuthorization struct {
@@ -675,26 +742,30 @@ func newDashboardRequestAuthorization(metadataToken, rawToken, complianceToken s
 		oidc:            oidc,
 		legacy: dashboardAuthorizePermissionFunc(
 			func(req *http.Request) bool {
-				return dashboardTokenMatches(req, metadataToken) || dashboardTokenMatches(req, rawToken)
+				return dashboardConfiguredTokenMatches(req, metadataToken) || dashboardConfiguredTokenMatches(req, rawToken)
 			},
-			func(req *http.Request) bool { return dashboardTokenMatches(req, rawToken) },
+			func(req *http.Request) bool { return dashboardConfiguredTokenMatches(req, rawToken) },
 			func(req *http.Request) bool {
-				return complianceToken != "" && dashboardTokenMatches(req, complianceToken)
+				return dashboardConfiguredTokenMatches(req, complianceToken)
 			},
 		),
 	}
 }
 
+func dashboardConfiguredTokenMatches(r *http.Request, token string) bool {
+	return token != "" && dashboardTokenMatches(r, token)
+}
+
 func (a *dashboardRequestAuthorization) metaAuthorized(r *http.Request) bool {
-	return dashboardTokenMatches(r, a.metadataToken) ||
-		dashboardTokenMatches(r, a.rawToken) ||
+	return dashboardConfiguredTokenMatches(r, a.metadataToken) ||
+		dashboardConfiguredTokenMatches(r, a.rawToken) ||
 		dashboardOIDCPrincipalFromRequest(r) != nil
 }
 
 // complianceAuthorized recognizes the optional auditor token, which is scoped to
 // the compliance path by authenticated/dashboardGlobalAuthorized.
 func (a *dashboardRequestAuthorization) complianceAuthorized(r *http.Request) bool {
-	return a.complianceToken != "" && dashboardTokenMatches(r, a.complianceToken)
+	return dashboardConfiguredTokenMatches(r, a.complianceToken)
 }
 
 // authenticated is the global gate: any operator/OIDC identity, or the
@@ -707,7 +778,7 @@ func (a *dashboardRequestAuthorization) authenticated(r *http.Request) bool {
 }
 
 func (a *dashboardRequestAuthorization) rawAuthorized(r *http.Request) bool {
-	return dashboardTokenMatches(r, a.rawToken) ||
+	return dashboardConfiguredTokenMatches(r, a.rawToken) ||
 		dashboardOIDCPrincipalFromRequest(r).hasPermission(dashboard.PermissionRawRead)
 }
 
@@ -721,8 +792,26 @@ func (a *dashboardRequestAuthorization) authorizePermission(r *http.Request, per
 	return fmt.Errorf("dashboard permission %q denied", permission)
 }
 
-func (a *dashboardRequestAuthorization) wrap(next http.Handler) http.Handler {
-	handler := dashboardAuthHandler(a.authenticated, next)
+func (a *dashboardRequestAuthorization) authAuditInfo(r *http.Request) dashboard.AuthAuditInfo {
+	if principal := dashboardOIDCPrincipalFromRequest(r); principal != nil {
+		return dashboard.AuthAuditInfo{Method: "oidc", Subject: principal.Subject, Roles: principal.Roles}
+	}
+	switch {
+	case dashboardConfiguredTokenMatches(r, a.rawToken):
+		return dashboard.AuthAuditInfo{Method: "static-raw-token"}
+	case dashboardConfiguredTokenMatches(r, a.metadataToken):
+		return dashboard.AuthAuditInfo{Method: "static-metadata-token"}
+	case dashboardConfiguredTokenMatches(r, a.complianceToken):
+		return dashboard.AuthAuditInfo{Method: "static-compliance-token"}
+	case dashboardOIDCFailureReasonFromRequest(r) != "":
+		return dashboard.AuthAuditInfo{Method: "oidc", FailureReason: dashboardOIDCFailureReasonFromRequest(r)}
+	default:
+		return dashboard.AuthAuditInfo{Method: "none", FailureReason: "missing_token"}
+	}
+}
+
+func (a *dashboardRequestAuthorization) wrap(next http.Handler, auditWriter io.Writer) http.Handler {
+	handler := dashboardAuthHandler(a.authenticated, a.authAuditInfo, auditWriter, next)
 	if a.oidc != nil {
 		return a.oidc.middleware(handler)
 	}

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -32,6 +33,7 @@ const (
 type oidcTestProvider struct {
 	server    *httptest.Server
 	private   *rsa.PrivateKey
+	jwksDelay time.Duration
 	jwksReads atomic.Int32
 }
 
@@ -49,6 +51,9 @@ func newOIDCTestProvider(t *testing.T) *oidcTestProvider {
 				p.server.URL, p.server.URL+"/jwks", p.server.URL+"/authorize")
 		case "/jwks":
 			p.jwksReads.Add(1)
+			if p.jwksDelay > 0 {
+				time.Sleep(p.jwksDelay)
+			}
 			w.Header().Set("Cache-Control", "max-age=3600")
 			n := base64.RawURLEncoding.EncodeToString(private.N.Bytes())
 			e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(private.PublicKey.E)).Bytes())
@@ -367,7 +372,7 @@ func TestDashboardOIDC_RoutePermissionsOnly(t *testing.T) {
 		AuthorizePermission: authorization.authorizePermission,
 		AuthorizeRaw:        dashboardAuthorizeFunc(authorization.rawAuthorized),
 	})
-	handler := authorization.wrap(inner)
+	handler := authorization.wrap(inner, nil)
 	token := p.token(t, p.validClaims(now))
 
 	tests := []struct {
@@ -396,10 +401,10 @@ func TestDashboardOIDC_OIDCOnlyModeRejectsEmptyCredentials(t *testing.T) {
 	now := time.Unix(2_000_000_000, 0)
 	p := newOIDCTestProvider(t)
 	auth := newOIDCTestAuthenticator(t, p, now)
-	// OIDC-only deployment: both static operator tokens are empty. Every token
-	// comparison routes through dashboardTokenMatches, which fails closed on an
-	// empty configured token, so a missing, empty, or malformed credential must
-	// never authorize; only a verified OIDC bearer may.
+	// OIDC-only deployment: all static operator tokens are empty, so every
+	// optional-token match must fail at the call site before comparing request
+	// credentials. Missing, empty, or malformed credentials must never
+	// authorize; only a verified OIDC bearer may.
 	authorization := newDashboardRequestAuthorization("", "", "", auth)
 	inner := dashboard.New(dashboard.Options{
 		ReceiptDir:          t.TempDir(),
@@ -408,7 +413,7 @@ func TestDashboardOIDC_OIDCOnlyModeRejectsEmptyCredentials(t *testing.T) {
 		AuthorizePermission: authorization.authorizePermission,
 		AuthorizeRaw:        dashboardAuthorizeFunc(authorization.rawAuthorized),
 	})
-	handler := authorization.wrap(inner)
+	handler := authorization.wrap(inner, nil)
 
 	newReq := func(mutate func(*http.Request)) *http.Request {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/", nil)
@@ -442,6 +447,60 @@ func TestDashboardOIDC_OIDCOnlyModeRejectsEmptyCredentials(t *testing.T) {
 	}
 }
 
+func TestDashboardOIDC_AuditRecordsPrincipalAndDeniedOIDCFailure(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+	authorization := newDashboardRequestAuthorization("", "", "", auth)
+	var audit strings.Builder
+	inner := dashboard.New(dashboard.Options{
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          func(string) bool { return true },
+		Authorize:           dashboardAuthorizeFunc(authorization.metaAuthorized),
+		AuthorizePermission: authorization.authorizePermission,
+		AuthorizeRaw:        dashboardAuthorizeFunc(authorization.rawAuthorized),
+		AuditWriter:         &audit,
+	})
+	handler := authorization.wrap(inner, &audit)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, requestWithBearer(t, p.token(t, p.validClaims(now))))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("valid OIDC request status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	log := audit.String()
+	for _, want := range []string{
+		"pipelock-dashboard access",
+		"permission=\"dashboard:evidence:read\"",
+		"auth_method=oidc",
+		"auth_subject=\"operator-a\"",
+		"auth_roles=\"evidence-reader\"",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("audit log missing %q: %s", want, log)
+		}
+	}
+	if strings.Contains(log, p.token(t, p.validClaims(now))) {
+		t.Fatalf("audit log leaked bearer token: %s", log)
+	}
+
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, requestWithBearer(t, "not-a-jwt"))
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("malformed OIDC request status = %d, want 401", rr.Code)
+	}
+	log = audit.String()
+	for _, want := range []string{
+		"pipelock-dashboard denied",
+		"auth_method=oidc",
+		"reason=invalid_token",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("denied audit log missing %q: %s", want, log)
+		}
+	}
+}
+
 func TestDashboardOIDC_RawPermission(t *testing.T) {
 	now := time.Unix(2_000_000_000, 0)
 	p := newOIDCTestProvider(t)
@@ -460,7 +519,7 @@ func TestDashboardOIDC_RawPermission(t *testing.T) {
 			t.Errorf("raw-mapped OIDC principal denied raw permission: %v", err)
 		}
 		w.WriteHeader(http.StatusNoContent)
-	})).ServeHTTP(rr, req)
+	}), nil).ServeHTTP(rr, req)
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
 	}
@@ -502,6 +561,40 @@ func TestDashboardOIDC_UnknownKeyRefreshIsRateLimited(t *testing.T) {
 	}
 }
 
+func TestDashboardOIDC_JWKSCacheCoalescesConcurrentRefresh(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	p.jwksDelay = 50 * time.Millisecond
+	auth := newOIDCTestAuthenticator(t, p, now)
+	token := p.token(t, p.validClaims(now))
+
+	auth.keys.mu.Lock()
+	auth.keys.expiresAt = now.Add(-time.Second)
+	auth.keys.mu.Unlock()
+
+	const requests = 8
+	errs := make(chan error, requests)
+	var wg sync.WaitGroup
+	for range requests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := auth.authenticate(requestWithBearer(t, token))
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("authenticate during coalesced refresh: %v", err)
+		}
+	}
+	if got := p.jwksReads.Load(); got != 2 {
+		t.Fatalf("JWKS reads = %d, want initial fetch plus one coalesced refresh", got)
+	}
+}
+
 func TestDashboardOIDC_StaticTokenRemainsAdditive(t *testing.T) {
 	now := time.Unix(2_000_000_000, 0)
 	p := newOIDCTestProvider(t)
@@ -514,7 +607,7 @@ func TestDashboardOIDC_StaticTokenRemainsAdditive(t *testing.T) {
 			t.Error("existing static token was denied when OIDC was also configured")
 		}
 		w.WriteHeader(http.StatusNoContent)
-	})).ServeHTTP(rr, requestWithBearer(t, dashTestToken))
+	}), nil).ServeHTTP(rr, requestWithBearer(t, dashTestToken))
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
 	}

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -33,7 +33,9 @@ const (
 type oidcTestProvider struct {
 	server    *httptest.Server
 	private   *rsa.PrivateKey
-	jwksDelay time.Duration
+	mu        sync.Mutex
+	jwksBlock <-chan struct{}
+	jwksStart chan<- struct{}
 	jwksReads atomic.Int32
 }
 
@@ -51,8 +53,9 @@ func newOIDCTestProvider(t *testing.T) *oidcTestProvider {
 				p.server.URL, p.server.URL+"/jwks", p.server.URL+"/authorize")
 		case "/jwks":
 			p.jwksReads.Add(1)
-			if p.jwksDelay > 0 {
-				time.Sleep(p.jwksDelay)
+			if err := p.waitForJWKSBlock(r.Context()); err != nil {
+				http.Error(w, err.Error(), http.StatusGatewayTimeout)
+				return
 			}
 			w.Header().Set("Cache-Control", "max-age=3600")
 			n := base64.RawURLEncoding.EncodeToString(private.N.Bytes())
@@ -65,6 +68,35 @@ func newOIDCTestProvider(t *testing.T) *oidcTestProvider {
 	}))
 	t.Cleanup(p.server.Close)
 	return p
+}
+
+func (p *oidcTestProvider) setJWKSBlock(block <-chan struct{}, start chan<- struct{}) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.jwksBlock = block
+	p.jwksStart = start
+}
+
+func (p *oidcTestProvider) waitForJWKSBlock(ctx context.Context) error {
+	p.mu.Lock()
+	block := p.jwksBlock
+	start := p.jwksStart
+	p.mu.Unlock()
+	if block == nil {
+		return nil
+	}
+	if start != nil {
+		select {
+		case start <- struct{}{}:
+		default:
+		}
+	}
+	select {
+	case <-block:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (p *oidcTestProvider) token(t *testing.T, claims map[string]any) string {
@@ -564,9 +596,12 @@ func TestDashboardOIDC_UnknownKeyRefreshIsRateLimited(t *testing.T) {
 func TestDashboardOIDC_JWKSCacheCoalescesConcurrentRefresh(t *testing.T) {
 	now := time.Unix(2_000_000_000, 0)
 	p := newOIDCTestProvider(t)
-	p.jwksDelay = 50 * time.Millisecond
 	auth := newOIDCTestAuthenticator(t, p, now)
 	token := p.token(t, p.validClaims(now))
+	block := make(chan struct{})
+	start := make(chan struct{}, 1)
+	p.setJWKSBlock(block, start)
+	defer p.setJWKSBlock(nil, nil)
 
 	auth.keys.mu.Lock()
 	auth.keys.expiresAt = now.Add(-time.Second)
@@ -583,6 +618,12 @@ func TestDashboardOIDC_JWKSCacheCoalescesConcurrentRefresh(t *testing.T) {
 			errs <- err
 		}()
 	}
+	select {
+	case <-start:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for JWKS refresh to start")
+	}
+	close(block)
 	wg.Wait()
 	close(errs)
 	for err := range errs {

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -1,0 +1,849 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package entcli
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/dashboard"
+)
+
+const (
+	oidcTestAudience = "pipelock-dashboard"
+	oidcTestKeyID    = "test-signing-key"
+)
+
+type oidcTestProvider struct {
+	server    *httptest.Server
+	private   *rsa.PrivateKey
+	jwksReads atomic.Int32
+}
+
+func newOIDCTestProvider(t *testing.T) *oidcTestProvider {
+	t.Helper()
+	private, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	p := &oidcTestProvider{private: private}
+	p.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			_, _ = fmt.Fprintf(w, `{"issuer":%q,"jwks_uri":%q,"authorization_endpoint":%q}`,
+				p.server.URL, p.server.URL+"/jwks", p.server.URL+"/authorize")
+		case "/jwks":
+			p.jwksReads.Add(1)
+			w.Header().Set("Cache-Control", "max-age=3600")
+			n := base64.RawURLEncoding.EncodeToString(private.N.Bytes())
+			e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(private.PublicKey.E)).Bytes())
+			_, _ = fmt.Fprintf(w, `{"keys":[{"kty":"RSA","kid":%q,"use":"sig","alg":"RS256","n":%q,"e":%q,"x5c":[]}]}`,
+				oidcTestKeyID, n, e)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(p.server.Close)
+	return p
+}
+
+func (p *oidcTestProvider) token(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	return p.tokenWithHeader(t, map[string]any{"alg": "RS256", "kid": oidcTestKeyID, "typ": "JWT"}, claims, true)
+}
+
+func (p *oidcTestProvider) tokenWithHeader(t *testing.T, header, claims map[string]any, sign bool) string {
+	t.Helper()
+	encode := func(v any) string {
+		data, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("Marshal JWT: %v", err)
+		}
+		return base64.RawURLEncoding.EncodeToString(data)
+	}
+	signingInput := encode(header) + "." + encode(claims)
+	if !sign {
+		return signingInput + "."
+	}
+	return p.signInput(t, signingInput)
+}
+
+func (p *oidcTestProvider) signInput(t *testing.T, signingInput string) string {
+	t.Helper()
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, p.private, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("SignPKCS1v15: %v", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func (p *oidcTestProvider) validClaims(now time.Time) map[string]any {
+	return map[string]any{
+		"iss":    p.server.URL,
+		"sub":    "operator-a",
+		"aud":    oidcTestAudience,
+		"azp":    oidcTestAudience,
+		"exp":    now.Add(5 * time.Minute).Unix(),
+		"nbf":    now.Add(-time.Minute).Unix(),
+		"groups": []string{"evidence-team"},
+	}
+}
+
+func oidcTestRoleMap() string {
+	return `{"claim_values":{"evidence-team":"evidence-reader","raw-team":"raw-reader"},` +
+		`"roles":{"evidence-reader":["dashboard:evidence:read"],` +
+		`"raw-reader":["dashboard:evidence:read","dashboard:raw:read"]}}`
+}
+
+func newOIDCTestAuthenticator(t *testing.T, p *oidcTestProvider, now time.Time) *dashboardOIDCAuthenticator {
+	t.Helper()
+	auth, err := newDashboardOIDCAuthenticator(context.Background(), dashboardOIDCOptions{
+		Issuer:       p.server.URL,
+		Audience:     oidcTestAudience,
+		RoleClaim:    "groups",
+		RoleMapJSON:  oidcTestRoleMap(),
+		HTTPClient:   p.server.Client(),
+		Now:          func() time.Time { return now },
+		JWKSCacheTTL: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("newDashboardOIDCAuthenticator: %v", err)
+	}
+	return auth
+}
+
+func requestWithBearer(t *testing.T, token string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req
+}
+
+func TestDashboardOIDCAuthenticate_VerifiesTokenAndMapsPermissions(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+
+	principal, err := auth.authenticate(requestWithBearer(t, p.token(t, p.validClaims(now))))
+	if err != nil {
+		t.Fatalf("authenticate valid token: %v", err)
+	}
+	if principal.Subject != "operator-a" {
+		t.Fatalf("Subject = %q, want operator-a", principal.Subject)
+	}
+	if !principal.hasPermission(dashboard.PermissionEvidenceRead) {
+		t.Fatalf("mapped principal missing %s", dashboard.PermissionEvidenceRead)
+	}
+	if principal.hasPermission(dashboard.PermissionRawRead) {
+		t.Fatalf("evidence-only principal unexpectedly has %s", dashboard.PermissionRawRead)
+	}
+	if got := p.jwksReads.Load(); got != 1 {
+		t.Fatalf("JWKS reads = %d, want one cached fetch", got)
+	}
+}
+
+func TestDashboardOIDCAuthenticate_FailsClosed(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+
+	tests := []struct {
+		name  string
+		token func(*testing.T) string
+	}{
+		{
+			name: "expired",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["exp"] = now.Add(-time.Minute).Unix()
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "missing expiration",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				delete(claims, "exp")
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "not yet valid beyond leeway",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["nbf"] = now.Add(time.Minute).Unix()
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "invalid not-before type",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["nbf"] = "soon"
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "wrong audience",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["aud"] = "different-dashboard"
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "wrong issuer",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["iss"] = "https://issuer.example"
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "wrong authorized party",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["azp"] = "different-client"
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "invalid authorized party type",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["azp"] = []string{oidcTestAudience}
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "multiple audiences without authorized party",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["aud"] = []string{oidcTestAudience, "another-service"}
+				delete(claims, "azp")
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "tampered signature",
+			token: func(t *testing.T) string {
+				token := p.token(t, p.validClaims(now))
+				parts := strings.Split(token, ".")
+				sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+				if err != nil {
+					t.Fatalf("DecodeString signature: %v", err)
+				}
+				sig[0] ^= 0xff
+				parts[2] = base64.RawURLEncoding.EncodeToString(sig)
+				return strings.Join(parts, ".")
+			},
+		},
+		{
+			name: "alg none",
+			token: func(t *testing.T) string {
+				return p.tokenWithHeader(t, map[string]any{"alg": "none", "kid": oidcTestKeyID}, p.validClaims(now), false)
+			},
+		},
+		{
+			name: "alg none mixed case",
+			token: func(t *testing.T) string {
+				return p.tokenWithHeader(t, map[string]any{"alg": "nOnE", "kid": oidcTestKeyID}, p.validClaims(now), true)
+			},
+		},
+		{
+			name: "missing algorithm",
+			token: func(t *testing.T) string {
+				return p.tokenWithHeader(t, map[string]any{"kid": oidcTestKeyID}, p.validClaims(now), true)
+			},
+		},
+		{
+			name: "algorithm confusion",
+			token: func(t *testing.T) string {
+				return p.tokenWithHeader(t, map[string]any{"alg": "HS256", "kid": oidcTestKeyID}, p.validClaims(now), true)
+			},
+		},
+		{
+			name: "unmapped role",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["groups"] = []string{"unmapped-team"}
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "missing subject",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				delete(claims, "sub")
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "empty subject",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["sub"] = ""
+				return p.token(t, claims)
+			},
+		},
+		{
+			name: "invalid role claim type",
+			token: func(t *testing.T) string {
+				claims := p.validClaims(now)
+				claims["groups"] = map[string]string{"team": "evidence-team"}
+				return p.token(t, claims)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if principal, err := auth.authenticate(requestWithBearer(t, tc.token(t))); err == nil || principal != nil {
+				t.Fatalf("authenticate = (%+v, %v), want nil principal and error", principal, err)
+			}
+		})
+	}
+}
+
+func TestDashboardOIDCAuthenticate_RejectsMalformedJWT(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+	encode := func(value string) string { return base64.RawURLEncoding.EncodeToString([]byte(value)) }
+	validHeader := encode(`{"alg":"RS256","kid":"test-signing-key"}`)
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{"missing", ""},
+		{"overlong", strings.Repeat("a", dashboardOIDCMaxTokenSize+1)},
+		{"wrong segment count", "a.b"},
+		{"bad header base64", "!.payload.signature"},
+		{"bad header JSON", encode("{") + ".payload.signature"},
+		{"missing kid", p.tokenWithHeader(t, map[string]any{"alg": "RS256"}, p.validClaims(now), true)},
+		{"critical header", p.tokenWithHeader(t, map[string]any{"alg": "RS256", "kid": oidcTestKeyID, "crit": []string{"unknown"}}, p.validClaims(now), true)},
+		{"bad signature base64", validHeader + ".payload.!"},
+		{"bad payload base64", p.signInput(t, validHeader+".!")},
+		{"bad payload JSON", p.signInput(t, validHeader+"."+encode("{"))},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if principal, err := auth.authenticate(requestWithBearer(t, tc.token)); err == nil || principal != nil {
+				t.Fatalf("authenticate = (%+v, %v), want denial", principal, err)
+			}
+		})
+	}
+}
+
+func TestDashboardOIDC_RoutePermissionsOnly(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+	authorization := newDashboardRequestAuthorization("", "", "", auth)
+
+	inner := dashboard.New(dashboard.Options{
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          func(string) bool { return true },
+		Authorize:           dashboardAuthorizeFunc(authorization.metaAuthorized),
+		AuthorizePermission: authorization.authorizePermission,
+		AuthorizeRaw:        dashboardAuthorizeFunc(authorization.rawAuthorized),
+	})
+	handler := authorization.wrap(inner)
+	token := p.token(t, p.validClaims(now))
+
+	tests := []struct {
+		name string
+		path string
+		want int
+	}{
+		{"mapped evidence route", "/", http.StatusOK},
+		{"unmapped exemptions permission", "/exemptions", http.StatusForbidden},
+		{"unmapped fleet permission", "/fleet", http.StatusForbidden},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := requestWithBearer(t, token)
+			req.URL.Path = tc.path
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != tc.want {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, tc.want, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestDashboardOIDC_OIDCOnlyModeRejectsEmptyCredentials(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+	// OIDC-only deployment: both static operator tokens are empty. Every token
+	// comparison routes through dashboardTokenMatches, which fails closed on an
+	// empty configured token, so a missing, empty, or malformed credential must
+	// never authorize; only a verified OIDC bearer may.
+	authorization := newDashboardRequestAuthorization("", "", "", auth)
+	inner := dashboard.New(dashboard.Options{
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          func(string) bool { return true },
+		Authorize:           dashboardAuthorizeFunc(authorization.metaAuthorized),
+		AuthorizePermission: authorization.authorizePermission,
+		AuthorizeRaw:        dashboardAuthorizeFunc(authorization.rawAuthorized),
+	})
+	handler := authorization.wrap(inner)
+
+	newReq := func(mutate func(*http.Request)) *http.Request {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		if mutate != nil {
+			mutate(req)
+		}
+		return req
+	}
+
+	tests := []struct {
+		name    string
+		request *http.Request
+	}{
+		{"no authorization header", newReq(nil)},
+		{"empty bearer", newReq(func(r *http.Request) { r.Header.Set("Authorization", "Bearer ") })},
+		{"basic empty password", newReq(func(r *http.Request) { r.SetBasicAuth("operator", "") })},
+		{"basic empty user and password", newReq(func(r *http.Request) { r.SetBasicAuth("", "") })},
+		{"malformed bearer", newReq(func(r *http.Request) { r.Header.Set("Authorization", "Bearer not-a-jwt") })},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, tc.request)
+			if rr.Code == http.StatusOK {
+				t.Fatalf("OIDC-only mode authorized %s (status %d); empty configured tokens must fail closed", tc.name, rr.Code)
+			}
+		})
+	}
+}
+
+func TestDashboardOIDC_RawPermission(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+	authorization := newDashboardRequestAuthorization("", "", "", auth)
+
+	claims := p.validClaims(now)
+	claims["groups"] = []string{"raw-team"}
+	req := requestWithBearer(t, p.token(t, claims))
+	rr := httptest.NewRecorder()
+	authorization.wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !authorization.rawAuthorized(r) {
+			t.Error("raw-mapped OIDC principal was denied raw authorization")
+		}
+		if err := authorization.authorizePermission(r, dashboard.PermissionRawRead); err != nil {
+			t.Errorf("raw-mapped OIDC principal denied raw permission: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+}
+
+func TestDashboardOIDC_JWKSCacheRefreshesAfterExpiry(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+	token := p.token(t, p.validClaims(now))
+
+	if _, err := auth.authenticate(requestWithBearer(t, token)); err != nil {
+		t.Fatalf("first authenticate: %v", err)
+	}
+	auth.keys.mu.Lock()
+	auth.keys.expiresAt = now.Add(-time.Second)
+	auth.keys.mu.Unlock()
+	if _, err := auth.authenticate(requestWithBearer(t, token)); err != nil {
+		t.Fatalf("authenticate after cache expiry: %v", err)
+	}
+	if got := p.jwksReads.Load(); got != 2 {
+		t.Fatalf("JWKS reads = %d, want initial fetch plus expiry refresh", got)
+	}
+}
+
+func TestDashboardOIDC_UnknownKeyRefreshIsRateLimited(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+	token := p.tokenWithHeader(t, map[string]any{"alg": "RS256", "kid": "unknown-key"}, p.validClaims(now), true)
+
+	for range 2 {
+		if principal, err := auth.authenticate(requestWithBearer(t, token)); err == nil || principal != nil {
+			t.Fatalf("unknown signing key authenticate = (%+v, %v), want denial", principal, err)
+		}
+	}
+	if got := p.jwksReads.Load(); got != 2 {
+		t.Fatalf("JWKS reads = %d, want initial fetch plus one rate-limited miss refresh", got)
+	}
+}
+
+func TestDashboardOIDC_StaticTokenRemainsAdditive(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+	authorization := newDashboardRequestAuthorization(dashTestToken, "", "", auth)
+
+	rr := httptest.NewRecorder()
+	authorization.wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !authorization.metaAuthorized(r) {
+			t.Error("existing static token was denied when OIDC was also configured")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(rr, requestWithBearer(t, dashTestToken))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+}
+
+func TestParseDashboardOIDCRoleMap_FailsClosed(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{"empty", "", "role map"},
+		{"malformed JSON", "{", "--oidc-role-map"},
+		{"empty maps", `{"claim_values":{},"roles":{}}`, "claim_values"},
+		{"unknown role", `{"claim_values":{"team":"missing"},"roles":{"reader":["dashboard:evidence:read"]}}`, "missing"},
+		{"empty permissions", `{"claim_values":{"team":"reader"},"roles":{"reader":[]}}`, "permission"},
+		{"unknown permission", `{"claim_values":{"team":"reader"},"roles":{"reader":["dashboard:unknown"]}}`, "dashboard:unknown"},
+		{"unknown field", `{"claim_values":{"team":"reader"},"roles":{"reader":["dashboard:evidence:read"]},"extra":true}`, "unknown field"},
+		{"trailing JSON", oidcTestRoleMap() + `{}`, "trailing"},
+		{"empty role name", `{"claim_values":{"team":""},"roles":{"": ["dashboard:evidence:read"]}}`, "role name"},
+		{"empty claim value", `{"claim_values":{"":"reader"},"roles":{"reader":["dashboard:evidence:read"]}}`, "claim value"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseDashboardOIDCRoleMap(tc.value); err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("parseDashboardOIDCRoleMap error = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDashboardOIDCConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    dashboardServeOptions
+		wantErr string
+	}{
+		{"token only", dashboardServeOptions{authTokenFile: "token"}, ""},
+		{"OIDC only", dashboardServeOptions{oidcIssuer: "https://issuer.example", oidcAudience: oidcTestAudience, oidcRoleClaim: "groups", oidcRoleMap: oidcTestRoleMap()}, ""},
+		{"no authenticator", dashboardServeOptions{}, "auth-token-file"},
+		{"OIDC missing audience", dashboardServeOptions{oidcIssuer: "https://issuer.example", oidcRoleClaim: "groups", oidcRoleMap: oidcTestRoleMap()}, "audience"},
+		{"OIDC missing role claim", dashboardServeOptions{oidcIssuer: "https://issuer.example", oidcAudience: oidcTestAudience, oidcRoleMap: oidcTestRoleMap()}, "role-claim"},
+		{"OIDC empty role map", dashboardServeOptions{oidcIssuer: "https://issuer.example", oidcAudience: oidcTestAudience, oidcRoleClaim: "groups"}, "role-map"},
+		{"OIDC option without issuer", dashboardServeOptions{authTokenFile: "token", oidcAudience: oidcTestAudience}, "oidc-issuer"},
+		{"raw token without metadata token", dashboardServeOptions{rawTokenFile: "raw", oidcIssuer: "https://issuer.example", oidcAudience: oidcTestAudience, oidcRoleClaim: "groups", oidcRoleMap: oidcTestRoleMap()}, "raw-token-file"},
+		{"conflicting audience aliases", dashboardServeOptions{oidcIssuer: "https://issuer.example", oidcAudience: "aud-a", oidcClientID: "aud-b", oidcRoleClaim: "groups", oidcRoleMap: oidcTestRoleMap()}, "must match"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDashboardAuthenticatorConfig(tc.opts)
+			if tc.wantErr == "" && err != nil {
+				t.Fatalf("validateDashboardAuthenticatorConfig: %v", err)
+			}
+			if tc.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDashboardOIDCURLValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"HTTPS", "https://issuer.example/tenant", false},
+		{"loopback HTTP v4", "http://127.0.0.1:8080", false},
+		{"loopback HTTP v6", "http://[::1]:8080", false},
+		{"public HTTP", "http://issuer.example", true},
+		{"credentials", "https://operator@issuer.example", true},
+		{"query", "https://issuer.example?tenant=a", true},
+		{"relative", "/issuer", true},
+		{"malformed", "://", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDashboardOIDCURL("issuer", tc.value)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateDashboardOIDCURL(%q) = %v, wantErr %v", tc.value, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseDashboardRSAJWK(t *testing.T) {
+	private, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	encodeInt := func(value *big.Int) string {
+		return base64.RawURLEncoding.EncodeToString(value.Bytes())
+	}
+	valid := dashboardJWK{
+		KeyType: "RSA", KeyID: "key-a", Use: "sig", Alg: "RS256",
+		N: encodeInt(private.N), E: encodeInt(big.NewInt(int64(private.E))),
+	}
+	tests := []struct {
+		name    string
+		mutate  func(*dashboardJWK)
+		wantKey bool
+		wantErr bool
+	}{
+		{"valid", func(*dashboardJWK) {}, true, false},
+		{"wrong key type ignored", func(j *dashboardJWK) { j.KeyType = "EC" }, false, false},
+		{"wrong use ignored", func(j *dashboardJWK) { j.Use = "enc" }, false, false},
+		{"wrong algorithm ignored", func(j *dashboardJWK) { j.Alg = "RS512" }, false, false},
+		{"key ops without verify ignored", func(j *dashboardJWK) { j.KeyOps = []string{"sign"} }, false, false},
+		{"empty key id", func(j *dashboardJWK) { j.KeyID = "" }, false, true},
+		{"bad modulus encoding", func(j *dashboardJWK) { j.N = "!" }, false, true},
+		{"bad exponent encoding", func(j *dashboardJWK) { j.E = "!" }, false, true},
+		{"weak modulus", func(j *dashboardJWK) { j.N = encodeInt(big.NewInt(17)) }, false, true},
+		{"even exponent", func(j *dashboardJWK) { j.E = encodeInt(big.NewInt(4)) }, false, true},
+		{"huge exponent", func(j *dashboardJWK) { j.E = encodeInt(new(big.Int).Lsh(big.NewInt(1), 80)) }, false, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			jwk := valid
+			tc.mutate(&jwk)
+			key, included, err := parseDashboardRSAJWK(jwk)
+			if (err != nil) != tc.wantErr || included != tc.wantKey || (key != nil) != tc.wantKey {
+				t.Fatalf("parseDashboardRSAJWK = (key=%v, included=%v, err=%v), wantKey %v wantErr %v",
+					key != nil, included, err, tc.wantKey, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDashboardOIDCClaimParsers(t *testing.T) {
+	t.Run("audience forms", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			raw     string
+			wantErr bool
+		}{
+			{"string", `"dashboard"`, false},
+			{"array", `["dashboard","other"]`, false},
+			{"empty string", `""`, true},
+			{"empty array", `[]`, true},
+			{"wrong type", `{}`, true},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := audienceClaim(json.RawMessage(tc.raw))
+				if (err != nil) != tc.wantErr {
+					t.Fatalf("audienceClaim = %v, wantErr %v", err, tc.wantErr)
+				}
+			})
+		}
+	})
+	t.Run("numeric dates", func(t *testing.T) {
+		for _, tc := range []struct {
+			name     string
+			claims   map[string]json.RawMessage
+			required bool
+			wantErr  bool
+		}{
+			{"valid", map[string]json.RawMessage{"exp": json.RawMessage(`2000000000`)}, true, false},
+			{"optional missing", nil, false, false},
+			{"required missing", nil, true, true},
+			{"string rejected", map[string]json.RawMessage{"exp": json.RawMessage(`"2000000000"`)}, true, true},
+			{"fraction rejected", map[string]json.RawMessage{"exp": json.RawMessage(`1.5`)}, true, true},
+			{"negative rejected", map[string]json.RawMessage{"exp": json.RawMessage(`-1`)}, true, true},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := numericDateClaim(tc.claims, "exp", tc.required)
+				if (err != nil) != tc.wantErr {
+					t.Fatalf("numericDateClaim = %v, wantErr %v", err, tc.wantErr)
+				}
+			})
+		}
+	})
+	t.Run("role forms", func(t *testing.T) {
+		for _, tc := range []struct {
+			raw     string
+			wantErr bool
+		}{
+			{`"team"`, false}, {`["team","other"]`, false}, {`""`, true}, {`[]`, true}, {`{}`, true},
+		} {
+			_, err := roleClaimValues(json.RawMessage(tc.raw))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("roleClaimValues(%s) = %v, wantErr %v", tc.raw, err, tc.wantErr)
+			}
+		}
+	})
+}
+
+func TestDashboardOIDCAuthenticatorRejectsBadDiscovery(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.Handler
+		wantErr string
+	}{
+		{"HTTP error", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { http.Error(w, "no", http.StatusBadGateway) }), "HTTP 502"},
+		{"malformed JSON", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("{")) }), "unexpected EOF"},
+		{"trailing JSON", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{} {}`)) }), "trailing"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+			_, err := newDashboardOIDCAuthenticator(context.Background(), dashboardOIDCOptions{
+				Issuer: server.URL, Audience: oidcTestAudience, RoleClaim: "groups",
+				RoleMapJSON: oidcTestRoleMap(), HTTPClient: server.Client(),
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("newDashboardOIDCAuthenticator error = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDashboardOIDCAuthenticatorRejectsBadConfiguration(t *testing.T) {
+	tests := []struct {
+		name string
+		opts dashboardOIDCOptions
+	}{
+		{"insecure issuer", dashboardOIDCOptions{Issuer: "http://issuer.example", Audience: oidcTestAudience, RoleClaim: "groups", RoleMapJSON: oidcTestRoleMap()}},
+		{"missing audience", dashboardOIDCOptions{Issuer: "https://issuer.example", RoleClaim: "groups", RoleMapJSON: oidcTestRoleMap()}},
+		{"missing role claim", dashboardOIDCOptions{Issuer: "https://issuer.example", Audience: oidcTestAudience, RoleMapJSON: oidcTestRoleMap()}},
+		{"bad role map", dashboardOIDCOptions{Issuer: "https://issuer.example", Audience: oidcTestAudience, RoleClaim: "groups", RoleMapJSON: "{}"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if auth, err := newDashboardOIDCAuthenticator(context.Background(), tc.opts); err == nil || auth != nil {
+				t.Fatalf("newDashboardOIDCAuthenticator = (%v, %v), want error", auth, err)
+			}
+		})
+	}
+}
+
+func TestDashboardOIDCAuthenticator_DefaultHTTPClient(t *testing.T) {
+	p := newOIDCTestProvider(t)
+	if _, err := newDashboardOIDCAuthenticator(context.Background(), dashboardOIDCOptions{
+		Issuer: p.server.URL, Audience: oidcTestAudience, RoleClaim: "groups",
+		RoleMapJSON: oidcTestRoleMap(),
+	}); err != nil {
+		t.Fatalf("newDashboardOIDCAuthenticator with default client: %v", err)
+	}
+}
+
+func TestDashboardOIDCAuthenticator_RejectsRedirects(t *testing.T) {
+	private, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	n := base64.RawURLEncoding.EncodeToString(private.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(private.PublicKey.E)).Bytes())
+
+	for _, endpoint := range []string{"discovery", "JWKS"} {
+		t.Run(endpoint, func(t *testing.T) {
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/.well-known/openid-configuration":
+					if endpoint == "discovery" {
+						http.Redirect(w, r, "/redirected-discovery", http.StatusFound)
+						return
+					}
+					_, _ = fmt.Fprintf(w, `{"issuer":%q,"jwks_uri":%q}`, server.URL, server.URL+"/jwks")
+				case "/redirected-discovery":
+					_, _ = fmt.Fprintf(w, `{"issuer":%q,"jwks_uri":%q}`, server.URL, server.URL+"/jwks")
+				case "/jwks":
+					if endpoint == "JWKS" {
+						http.Redirect(w, r, "/redirected-jwks", http.StatusFound)
+						return
+					}
+					_, _ = fmt.Fprintf(w, `{"keys":[{"kty":"RSA","kid":%q,"use":"sig","alg":"RS256","n":%q,"e":%q}]}`,
+						oidcTestKeyID, n, e)
+				case "/redirected-jwks":
+					_, _ = fmt.Fprintf(w, `{"keys":[{"kty":"RSA","kid":%q,"use":"sig","alg":"RS256","n":%q,"e":%q}]}`,
+						oidcTestKeyID, n, e)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			for _, clientMode := range []string{"default client", "injected client"} {
+				t.Run(clientMode, func(t *testing.T) {
+					var client *http.Client
+					if clientMode == "injected client" {
+						client = server.Client()
+					}
+					if auth, err := newDashboardOIDCAuthenticator(context.Background(), dashboardOIDCOptions{
+						Issuer: server.URL, Audience: oidcTestAudience, RoleClaim: "groups",
+						RoleMapJSON: oidcTestRoleMap(), HTTPClient: client,
+					}); err == nil || auth != nil {
+						t.Fatalf("redirecting %s endpoint accepted: auth=%v err=%v", endpoint, auth, err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestDashboardOIDCAuthenticatorValidatesDiscoveryMetadata(t *testing.T) {
+	for _, mode := range []string{"issuer mismatch", "insecure JWKS", "empty JWKS"} {
+		t.Run(mode, func(t *testing.T) {
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/jwks" {
+					_, _ = w.Write([]byte(`{"keys":[]}`))
+					return
+				}
+				issuer, jwksURI := server.URL, server.URL+"/jwks"
+				if mode == "issuer mismatch" {
+					issuer = "https://issuer.example"
+				}
+				if mode == "insecure JWKS" {
+					jwksURI = "http://issuer.example/jwks"
+				}
+				_, _ = fmt.Fprintf(w, `{"issuer":%q,"jwks_uri":%q}`, issuer, jwksURI)
+			}))
+			defer server.Close()
+			if auth, err := newDashboardOIDCAuthenticator(context.Background(), dashboardOIDCOptions{
+				Issuer: server.URL, Audience: oidcTestAudience, RoleClaim: "groups",
+				RoleMapJSON: oidcTestRoleMap(), HTTPClient: server.Client(),
+			}); err == nil || auth != nil {
+				t.Fatalf("newDashboardOIDCAuthenticator = (%v, %v), want error", auth, err)
+			}
+		})
+	}
+}
+
+func TestDashboardOIDCAudienceAlias(t *testing.T) {
+	if got := dashboardOIDCAudience(dashboardServeOptions{oidcAudience: " audience ", oidcClientID: "client"}); got != "audience" {
+		t.Fatalf("audience precedence = %q", got)
+	}
+	if got := dashboardOIDCAudience(dashboardServeOptions{oidcClientID: " client "}); got != "client" {
+		t.Fatalf("client-id alias = %q", got)
+	}
+}

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -760,7 +760,7 @@ func TestDashboardGlobalAuthorizationScopesComplianceToken(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			called := false
-			handler := dashboardAuthHandler(authorized, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			handler := dashboardAuthHandler(authorized, nil, nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				called = true
 				w.WriteHeader(http.StatusNoContent)
 			}))

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -128,7 +128,7 @@ func TestDashboardCmd_Tree(t *testing.T) {
 	if err != nil || serve.Use != "serve" {
 		t.Fatalf("dashboard serve subcommand not found: %v", err)
 	}
-	for _, flag := range []string{"listen", "receipt-dir", "config", "exemption-store", "delivery-inbox", "read-model-index", "legal-hold-store", "auth-token-file", "raw-token-file", "compliance-token-file", "runtime-snapshot-file", "trusted-signer", "license-crl-file", "anchor-expected", "anchor-local-log", "rekor-log-key", "tls-cert", "tls-key"} {
+	for _, flag := range []string{"listen", "receipt-dir", "config", "exemption-store", "delivery-inbox", "read-model-index", "legal-hold-store", "auth-token-file", "raw-token-file", "compliance-token-file", "runtime-snapshot-file", "trusted-signer", "license-crl-file", "anchor-expected", "anchor-local-log", "rekor-log-key", "tls-cert", "tls-key", "client-ca-file", "require-client-cert", "client-cert-role-map"} {
 		if serve.Flags().Lookup(flag) == nil {
 			t.Errorf("serve is missing --%s", flag)
 		}

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -285,6 +285,25 @@ type dashboardHandler struct {
 
 type rawAllowedContextKey struct{}
 
+type authAuditInfoContextKey struct{}
+
+// AuthAuditInfo is the bounded identity metadata appended to dashboard access
+// logs. Callers must pass only sanitized values, never bearer tokens or raw
+// claims.
+type AuthAuditInfo struct {
+	Method        string
+	Subject       string
+	Roles         []string
+	FailureReason string
+}
+
+// WithAuthAuditInfo attaches dashboard authentication metadata to a request
+// context for access logging.
+func WithAuthAuditInfo(ctx context.Context, info AuthAuditInfo) context.Context {
+	info.Roles = append([]string(nil), info.Roles...)
+	return context.WithValue(ctx, authAuditInfoContextKey{}, info)
+}
+
 // rawAllowed reports whether this request may see the raw view (destinations
 // and full signed payloads). Fail closed: raw is shown only when an authorizer
 // is configured and accepts the request.
@@ -303,9 +322,23 @@ func rawAllowedFromContext(r *http.Request) bool {
 	return raw
 }
 
+func authAuditInfoFromRequest(r *http.Request) AuthAuditInfo {
+	info, _ := r.Context().Value(authAuditInfoContextKey{}).(AuthAuditInfo)
+	info.Method = auditLogValue(info.Method)
+	info.Subject = auditLogValue(info.Subject)
+	if len(info.Roles) == 0 {
+		info.Roles = []string{"-"}
+	}
+	for i, role := range info.Roles {
+		info.Roles[i] = auditLogValue(role)
+	}
+	info.FailureReason = auditLogValue(info.FailureReason)
+	return info
+}
+
 // recordAudit writes one access-log line for an authenticated request. Viewing
 // evidence is itself an audited action. No-op when no writer is configured.
-func (d *dashboardHandler) recordAudit(r *http.Request, raw bool) {
+func (d *dashboardHandler) recordAudit(r *http.Request, raw bool, permission Permission) {
 	if d.auditWriter == nil {
 		return
 	}
@@ -328,12 +361,13 @@ func (d *dashboardHandler) recordAudit(r *http.Request, raw bool) {
 		session = "-"
 	}
 	sessionDisplay, sessionHash := auditSessionField(session)
+	auth := authAuditInfoFromRequest(r)
 	d.auditMu.Lock()
 	defer d.auditMu.Unlock()
-	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s method=%s path=%q session=%q session_sha256=%s org_sha256=%s fleet_sha256=%s artifact_sha256=%s remote=%s\n",
-		time.Now().UTC().Format(time.RFC3339), role, r.Method, r.URL.Path, sessionDisplay, sessionHash,
+	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s permission=%q method=%s path=%q session=%q session_sha256=%s org_sha256=%s fleet_sha256=%s artifact_sha256=%s auth_method=%s auth_subject=%q auth_roles=%q remote=%s\n",
+		time.Now().UTC().Format(time.RFC3339), role, permission, r.Method, r.URL.Path, sessionDisplay, sessionHash,
 		auditHashField(r.URL.Query().Get("org_id")), auditHashField(r.URL.Query().Get("fleet_id")),
-		auditHashField(r.URL.Query().Get("artifact_hash")), r.RemoteAddr)
+		auditHashField(r.URL.Query().Get("artifact_hash")), auth.Method, auth.Subject, strings.Join(auth.Roles, ","), r.RemoteAddr)
 }
 
 func auditSessionField(session string) (display, hash string) {
@@ -370,6 +404,25 @@ func auditHashField(value string) string {
 	}
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:])
+}
+
+func auditLogValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	var b strings.Builder
+	for _, r := range value {
+		if r >= 0x20 && r <= 0x7e {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('?')
+	}
+	if b.Len() == 0 {
+		return "-"
+	}
+	return b.String()
 }
 
 func (d *dashboardHandler) recordDecisionScopeAudit(r *http.Request, raw bool, scope DecisionScope, page any) {
@@ -460,7 +513,7 @@ func (d *dashboardHandler) routeGate(spec routeSpec, next http.Handler) http.Han
 			}
 		}
 		raw := d.rawAllowed(r)
-		d.recordAudit(r, raw)
+		d.recordAudit(r, raw, spec.permission)
 		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), rawAllowedContextKey{}, raw)))
 	})
 }


### PR DESCRIPTION
Adds OIDC bearer-token authentication as an additive authenticator for the enterprise dashboard, alongside the existing operator token. Operators choose either or both.

## What changed

- New flags on `dashboard serve`: `--oidc-issuer` (issuer URL, discovered to a JWKS endpoint), `--oidc-audience`/`--oidc-client-id` (expected audience), `--oidc-role-claim` (the claim carrying roles or groups), and `--oidc-role-map` (maps a claim value to a role and a bounded dashboard permission set, including raw access).
- Verifies the presented bearer token's RS256 signature against the issuer JWKS on every request, with cached JWKS refresh, and enforces issuer, audience, expiry, not-before, and optional authorized-party claims with a small clock-skew leeway.
- The algorithm is pinned to RS256 and only parsed RSA keys are used, so unsigned and algorithm-substitution tokens are rejected; token claims are read only after the signature verifies.
- Discovery and JWKS are treated as fixed trust anchors and fetched without following redirects.
- Maps the verified role claim to a bounded permission set and fails closed on any verification failure, excessive clock skew, or unmapped role; an empty role map is a startup error.
- Additive and non-weakening: token authentication is unchanged, and the existing token/raw split and non-loopback-requires-TLS guard are preserved.
- Stdlib-only implementation; no new dependencies. Enterprise build tag; the non-enterprise build is unaffected.

## Notes

This and the mTLS authenticator PR both extend the same authorizer-construction block in `enterprise/cli/dashboard.go`; whichever merges second will need a small rebase to compose all three identity sources (token, mTLS, OIDC).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OIDC authentication for the dashboard, mapping JWT roles to dashboard permissions.
  * Added enterprise mTLS authorization using client-certificate fingerprints to grant permissions and raw access.
* **Security / Improvements**
  * Tightened TLS and client-certificate flag validation and fail-closed behavior when certificate auth is enabled.
  * Improved authentication failure handling and enhanced audit/access logging with sanitized auth context.
* **Documentation**
  * Updated dashboard CLI docs to cover OIDC and mTLS authentication, redaction behavior, and required flags.
* **Tests**
  * Added end-to-end OIDC and mTLS test coverage for validation, caching, routing, and permission gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->