### PR TITLE
harden(receipt): fail-closed audit-completeness for defer, receipts, and baseline reads

### DIFF
--- a/internal/deferred/manager.go
+++ b/internal/deferred/manager.go
@@ -17,11 +17,17 @@ import (
 )
 
 const (
-	StateHeld                     = "deferred_held"
-	StateResolving                = "resolving"
-	StateResolvedAllow            = "resolved_allow"
-	StateResolvedBlock            = "resolved_block"
-	StateResolvedStepUp           = "resolved_step_up"
+	StateHeld           = "deferred_held"
+	StateResolving      = "resolving"
+	StateResolvedAllow  = "resolved_allow"
+	StateResolvedBlock  = "resolved_block"
+	StateResolvedStepUp = "resolved_step_up"
+	// StateAdmissionRejected records an action that was NEVER successfully
+	// held (duplicate defer_id, capacity, cascade-limit). It is an audit-only
+	// marker and must never be replayed as a hold-lifecycle transition: for a
+	// duplicate defer_id it shares the id of a live hold, so treating it as a
+	// resolution would delete that live hold from restart recovery.
+	StateAdmissionRejected        = "admission_rejected"
 	SourceContext                 = "context"
 	SourceTimeout                 = "timeout"
 	SourceCancel                  = "cancel"
@@ -30,6 +36,7 @@ const (
 	SourceCapacity                = "capacity"
 	SourceCascade                 = "cascade"
 	SourceCascadeLimit            = "cascade_limit"
+	SourceDuplicateDeferID        = "duplicate_defer_id"
 	SourcePolicyReload            = "policy_reload"
 	SourceApproval                = "approval"
 	SourceOperator                = "operator"
@@ -275,6 +282,7 @@ func (m *Manager) Hold(action HeldAction) error {
 	m.mu.Lock()
 	if _, exists := m.holds[action.DeferID]; exists {
 		m.mu.Unlock()
+		m.journalRejectedHold(action, SourceDuplicateDeferID)
 		return fmt.Errorf("defer hold %q already exists", action.DeferID)
 	}
 	if len(m.holds) >= m.cfg.MaxPending ||
@@ -282,6 +290,7 @@ func (m *Manager) Hold(action HeldAction) error {
 		action.SizeBytes > m.cfg.MaxPendingBytes ||
 		m.totalBytes > m.cfg.MaxPendingBytes-action.SizeBytes {
 		m.mu.Unlock()
+		m.journalRejectedHold(action, SourceCapacity)
 		return ErrCapacity
 	}
 	action.Linkage = LinkageSessionPendingAncestor
@@ -305,24 +314,26 @@ func (m *Manager) Hold(action HeldAction) error {
 			Limit:         m.cfg.MaxCascadeDepth,
 			ParentDeferID: action.ParentDeferID,
 		}
-		if err := m.appendJournal(journalEntryFromHeld(action, StateResolvedBlock, SourceCascadeLimit)); err != nil {
-			m.warnf("pipelock: warning event=deferred_journal_write_failed audit_gap=true source=%s defer_id=%s parent_defer_id=%s cascade_depth=%d: %v\n",
-				SourceCascadeLimit, action.DeferID, action.ParentDeferID, action.CascadeDepth, err)
-		}
+		m.journalRejectedHold(action, SourceCascadeLimit)
 		return limitErr
 	}
 	journalAction := action
 	stored := action
 	held := &stored
+	// Commit the StateHeld journal entry BEFORE publishing the hold, while still
+	// holding m.mu. A concurrent admission rejection for a related id blocks on
+	// m.mu until this returns, so it cannot append its StateAdmissionRejected
+	// entry ahead of this hold's StateHeld and causally invert the audit trail.
+	// On journal failure nothing is published, so no rollback is needed.
+	if err := m.appendJournal(journalEntryFromHeld(journalAction, StateHeld, "")); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("journal defer hold: %w", err)
+	}
 	m.holds[action.DeferID] = held
 	m.sessionHolds[action.Authority.SessionID] = append(m.sessionHolds[action.Authority.SessionID], action.DeferID)
 	m.totalBytes += action.SizeBytes
 	m.mu.Unlock()
 
-	if err := m.appendJournal(journalEntryFromHeld(journalAction, StateHeld, "")); err != nil {
-		_ = m.Resolve(action.DeferID, "block", SourceCancel)
-		return fmt.Errorf("journal defer hold: %w", err)
-	}
 	m.mu.Lock()
 	if live := m.holds[action.DeferID]; live != nil && live.state == StateHeld {
 		live.timer = time.AfterFunc(m.cfg.Timeout, func() {
@@ -331,6 +342,22 @@ func (m *Manager) Hold(action HeldAction) error {
 	}
 	m.mu.Unlock()
 	return nil
+}
+
+func (m *Manager) journalRejectedHold(action HeldAction, source string) {
+	// Duplicate and capacity rejections happen before Hold derives lineage, so
+	// the action still carries caller-supplied ParentDeferID/CascadeDepth/
+	// Linkage. Never let a caller inject false ancestry into the audit journal;
+	// only cascade-limit rejections have computed lineage worth preserving.
+	if source != SourceCascadeLimit {
+		action.ParentDeferID = ""
+		action.CascadeDepth = 0
+		action.Linkage = ""
+	}
+	if err := m.appendJournal(journalEntryFromHeld(action, StateAdmissionRejected, source)); err != nil {
+		m.warnf("pipelock: warning event=deferred_journal_write_failed audit_gap=true source=%s defer_id=%s parent_defer_id=%s cascade_depth=%d: %v\n",
+			source, action.DeferID, action.ParentDeferID, action.CascadeDepth, err)
+	}
 }
 
 // Resolve atomically transitions a held action and invokes its callback once.
@@ -704,6 +731,11 @@ func PendingJournal(path string) ([]HeldAction, error) {
 		case StateResolvedAllow, StateResolvedBlock, StateResolvedStepUp:
 			delete(pending, entry.DeferID)
 			terminal[entry.DeferID] = struct{}{}
+		case StateAdmissionRejected:
+			// Audit-only marker for an action that was never held. It must not
+			// touch hold lifecycle: for a duplicate defer_id it shares a live
+			// hold's id, so resolving/terminalizing it here would drop that
+			// live hold from recovery.
 		default:
 			return nil, fmt.Errorf("defer journal integrity: unknown state %q for defer_id %q", entry.State, entry.DeferID)
 		}

--- a/internal/deferred/manager_test.go
+++ b/internal/deferred/manager_test.go
@@ -86,6 +86,112 @@ func TestManagerCapacityRejectsNewHold(t *testing.T) {
 	}
 }
 
+func TestManagerAdmissionRejectionsAreJournaled(t *testing.T) {
+	tests := []struct {
+		name        string
+		wantErr     error
+		wantSource  string
+		wantDeferID string
+		reject      func(t *testing.T, m *Manager, base HeldAction) error
+	}{
+		{
+			name:        "capacity",
+			wantErr:     ErrCapacity,
+			wantSource:  SourceCapacity,
+			wantDeferID: "d2",
+			reject: func(t *testing.T, m *Manager, base HeldAction) error {
+				t.Helper()
+				if err := m.Hold(base); err != nil {
+					t.Fatalf("first Hold: %v", err)
+				}
+				base.DeferID = "d2"
+				base.ActionID = "d2"
+				return m.Hold(base)
+			},
+		},
+		{
+			name:        "duplicate_defer_id",
+			wantSource:  SourceDuplicateDeferID,
+			wantDeferID: "d1",
+			reject: func(t *testing.T, m *Manager, base HeldAction) error {
+				t.Helper()
+				if err := m.Hold(base); err != nil {
+					t.Fatalf("first Hold: %v", err)
+				}
+				return m.Hold(base)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "deferred-actions.jsonl")
+			m := NewManager(Config{
+				Enabled:              true,
+				Timeout:              time.Hour,
+				MaxPending:           1,
+				MaxPendingPerSession: 1,
+				MaxPendingBytes:      1024,
+				JournalPath:          path,
+			})
+			base := HeldAction{
+				DeferID:   "d1",
+				ActionID:  "d1",
+				Target:    "tool",
+				Surface:   SurfaceMCPStdio,
+				Method:    "tools/call",
+				Reason:    "defer test",
+				SizeBytes: 1,
+				Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+				Resolve:   func(Resolution) {},
+			}
+			err := tc.reject(t, m, base)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("Hold error = %v, want %v", err, tc.wantErr)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), "already exists") {
+				t.Fatalf("Hold error = %v, want duplicate error", err)
+			}
+			entries := readJournalEntries(t, path)
+			gotDenials := 0
+			heldEntries := 0
+			for _, entry := range entries {
+				if entry.DeferID != tc.wantDeferID {
+					continue
+				}
+				switch entry.State {
+				case StateAdmissionRejected:
+					if entry.Source != tc.wantSource {
+						t.Fatalf("admission rejection has wrong source: %+v", entry)
+					}
+					gotDenials++
+					if entry.Target != base.Target || entry.Method != base.Method || entry.Surface != base.Surface {
+						t.Fatalf("rejection journal entry lost action fields: %+v", entry)
+					}
+				case StateHeld:
+					heldEntries++
+				case StateResolvedAllow, StateResolvedBlock, StateResolvedStepUp:
+					t.Fatalf("rejected id %q must not have a resolved lifecycle entry: %+v", tc.wantDeferID, entry)
+				default:
+					t.Fatalf("unexpected journal state for id %q: %+v", tc.wantDeferID, entry)
+				}
+			}
+			if gotDenials != 1 {
+				t.Fatalf("admission-rejected entries for id %q = %d, want 1; entries=%+v", tc.wantDeferID, gotDenials, entries)
+			}
+			// The duplicate case's rejected id is a live hold (one StateHeld);
+			// the capacity case's id was never held (zero).
+			wantHeld := 0
+			if tc.wantSource == SourceDuplicateDeferID {
+				wantHeld = 1
+			}
+			if heldEntries != wantHeld {
+				t.Fatalf("StateHeld entries for id %q = %d, want %d", tc.wantDeferID, heldEntries, wantHeld)
+			}
+		})
+	}
+}
+
 func TestManagerCapacityRejectsOverflowSize(t *testing.T) {
 	m := NewManager(Config{
 		Enabled:              true,
@@ -617,7 +723,7 @@ func TestManagerCascadeLimitDenialJournal(t *testing.T) {
 				if entry.State == StateHeld {
 					t.Fatalf("limit-denied action has held journal entry: %+v", entry)
 				}
-				if entry.State == StateResolvedBlock && entry.Source == SourceCascadeLimit {
+				if entry.State == StateAdmissionRejected && entry.Source == SourceCascadeLimit {
 					gotDenials++
 					if entry.ParentDeferID != "b" || entry.CascadeDepth != 3 || entry.Linkage != LinkageSessionPendingAncestor {
 						t.Fatalf("cascade-limit journal entry = %+v", entry)
@@ -1312,4 +1418,68 @@ func waitResolution(t *testing.T, ch <-chan Resolution) Resolution {
 		t.Fatal("timed out waiting for deferred resolution")
 	}
 	return Resolution{}
+}
+
+// A duplicate-defer_id rejection must NOT terminalize the live hold it collides
+// with: replaying the journal must still recover the original held action.
+func TestManagerDuplicateRejectionDoesNotDropLiveHoldOnReplay(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deferred-actions.jsonl")
+	m := NewManager(Config{
+		Enabled:              true,
+		Timeout:              time.Hour,
+		MaxPending:           8,
+		MaxPendingPerSession: 8,
+		MaxPendingBytes:      1024,
+		JournalPath:          path,
+	})
+	base := HeldAction{
+		DeferID:   "live-1",
+		ActionID:  "live-1",
+		Target:    "tool",
+		Surface:   SurfaceMCPStdio,
+		Method:    "tools/call",
+		Reason:    "defer test",
+		SizeBytes: 1,
+		Authority: AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+		Resolve:   func(Resolution) {},
+	}
+	if err := m.Hold(base); err != nil {
+		t.Fatalf("first Hold: %v", err)
+	}
+	// The duplicate carries DISTINCT metadata plus caller-supplied lineage, so
+	// the test proves recovery kept the ORIGINAL (not the rejection) and that
+	// the rejection cannot inject false ancestry into the journal.
+	duplicate := base
+	duplicate.ActionID = "rejected-attempt"
+	duplicate.Target = "rejected-tool"
+	duplicate.ParentDeferID = "attacker-parent"
+	duplicate.CascadeDepth = 99
+	duplicate.Linkage = "attacker-linkage"
+	if err := m.Hold(duplicate); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("duplicate Hold error = %v, want duplicate rejection", err)
+	}
+	pending, err := PendingJournal(path)
+	if err != nil {
+		t.Fatalf("PendingJournal: %v", err)
+	}
+	var recovered *HeldAction
+	for i := range pending {
+		if pending[i].DeferID == "live-1" {
+			recovered = &pending[i]
+		}
+	}
+	if recovered == nil {
+		t.Fatalf("live hold live-1 was dropped from recovery by the duplicate rejection; pending=%+v", pending)
+	}
+	if recovered.ActionID != "live-1" || recovered.Target != "tool" {
+		t.Fatalf("recovery returned the rejection's metadata, not the live hold: %+v", recovered)
+	}
+	// The admission-rejection entry must carry no caller-supplied lineage.
+	for _, entry := range readJournalEntries(t, path) {
+		if entry.State == StateAdmissionRejected {
+			if entry.ParentDeferID != "" || entry.CascadeDepth != 0 || entry.Linkage != "" {
+				t.Fatalf("admission rejection retained caller-supplied lineage: %+v", entry)
+			}
+		}
+	}
 }

--- a/internal/mcp/defer_resolution.go
+++ b/internal/mcp/defer_resolution.go
@@ -81,8 +81,9 @@ type holdFailureResolution struct {
 
 // emitHoldFailureResolution classifies a failed Hold (capacity vs cascade
 // limit), emits the blocking resolution receipt, and returns the client-facing
-// error message. Shared by the stdio and HTTP-forward defer paths.
-func emitHoldFailureResolution(opts MCPProxyOpts, logW io.Writer, holdErr error, hf holdFailureResolution) string {
+// error message plus any receipt gap. Shared by the stdio and HTTP-forward
+// defer paths.
+func emitHoldFailureResolution(opts MCPProxyOpts, logW io.Writer, holdErr error, hf holdFailureResolution) (string, error) {
 	source := deferred.HoldFailureSource(holdErr)
 	cascadeDepth := 0
 	parentDeferID := ""
@@ -93,7 +94,7 @@ func emitHoldFailureResolution(opts MCPProxyOpts, logW io.Writer, holdErr error,
 		parentDeferID = limitErr.ParentDeferID
 		linkage = deferred.LinkageSessionPendingAncestor
 	}
-	_ = emitDeferredResolutionReceipt(opts, logW, deferred.Resolution{
+	emitErr := emitDeferredResolutionReceipt(opts, logW, deferred.Resolution{
 		DeferID:          hf.DeferID,
 		ParentActionID:   hf.DeferID,
 		FinalDecision:    config.ActionBlock,
@@ -108,7 +109,7 @@ func emitHoldFailureResolution(opts MCPProxyOpts, logW io.Writer, holdErr error,
 		Reason:           hf.Reason,
 	})
 	if source == deferred.SourceCascadeLimit {
-		return "pipelock: defer cascade depth exceeded"
+		return "pipelock: defer cascade depth exceeded", emitErr
 	}
-	return "pipelock: defer capacity exceeded"
+	return "pipelock: defer capacity exceeded", emitErr
 }

--- a/internal/mcp/defer_resolution_test.go
+++ b/internal/mcp/defer_resolution_test.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -173,4 +174,63 @@ func TestEmitDeferredResolutionReceiptBlockFailureLogsAuditGap(t *testing.T) {
 	if !strings.Contains(log.String(), "audit_gap=true") {
 		t.Fatalf("missing audit_gap marker in log: %s", log.String())
 	}
+}
+
+func TestEmitHoldFailureResolutionSurfacesReceiptEmitError(t *testing.T) {
+	emitter, rec, _ := newTestReceiptEmitter(t)
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
+	opts := MCPProxyOpts{
+		ReceiptEmitter:  emitter,
+		RequireReceipts: true,
+		Transport:       deferred.SurfaceMCPStdio,
+	}
+	var log bytes.Buffer
+	msg, err := emitHoldFailureResolution(opts, &log, deferred.ErrCapacity, holdFailureResolution{
+		DeferID: "capacity-defer",
+		Authority: deferred.AuthoritySnapshot{
+			SessionID:         "session-a",
+			SessionIDOriginal: "session-a",
+		},
+		Policy: deferred.ResolutionPolicy{
+			Timeout:              2 * time.Second,
+			MaxPending:           1,
+			MaxPendingPerSession: 1,
+			MaxPendingBytes:      8,
+			MaxCascadeDepth:      2,
+		},
+		Target: "neutral_tool",
+		Method: "tools/call",
+		Reason: "capacity",
+	})
+	if msg != "pipelock: defer capacity exceeded" {
+		t.Fatalf("message = %q, want capacity exceeded", msg)
+	}
+	if err == nil {
+		t.Fatal("emitHoldFailureResolution error = nil, want receipt emission failure")
+	}
+	if !errors.Is(err, ErrReceiptRequired) {
+		t.Fatalf("emitHoldFailureResolution error = %v, want ErrReceiptRequired", err)
+	}
+	if !strings.Contains(log.String(), "event=block_receipt_emit_failed") {
+		t.Fatalf("log = %q, want block_receipt_emit_failed", log.String())
+	}
+}
+
+func TestLogHoldFailureReceiptGap(t *testing.T) {
+	var log bytes.Buffer
+	logHoldFailureReceiptGap(&log, "defer-xyz", errors.New("emit boom"))
+	got := log.String()
+	for _, want := range []string{"audit_gap=true", "defer_id=defer-xyz", "emit boom"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("log = %q, want %q", got, want)
+		}
+	}
+	log.Reset()
+	logHoldFailureReceiptGap(&log, "defer-xyz", nil)
+	if log.String() != "" {
+		t.Fatalf("expected no log on nil error, got %q", log.String())
+	}
+	logHoldFailureReceiptGap(nil, "defer-xyz", errors.New("x")) // must not panic on nil writer
 }

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -1205,7 +1205,7 @@ func ForwardScannedInput(
 				},
 			})
 			if holdErr != nil {
-				errorMessage := emitHoldFailureResolution(opts, logW, holdErr, holdFailureResolution{
+				errorMessage, emitErr := emitHoldFailureResolution(opts, logW, holdErr, holdFailureResolution{
 					DeferID: actionID,
 					Authority: deferred.AuthoritySnapshot{
 						SessionID:         receiptSessionID,
@@ -1216,6 +1216,7 @@ func ForwardScannedInput(
 					Method: verdict.Method,
 					Reason: reasonStr,
 				})
+				logHoldFailureReceiptGap(logW, actionID, emitErr)
 				if !isNotification {
 					blockedCh <- BlockedRequest{
 						ID:           verdict.ID,

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -303,7 +303,7 @@ func RunHTTPProxy(
 				},
 			})
 			if holdErr != nil {
-				errorMessage := emitHoldFailureResolution(fwdOpts, safeLogW, holdErr, holdFailureResolution{
+				errorMessage, emitErr := emitHoldFailureResolution(fwdOpts, safeLogW, holdErr, holdFailureResolution{
 					DeferID: deferredReq.DeferID,
 					Authority: deferred.AuthoritySnapshot{
 						SessionID:         deferredReq.SessionID,
@@ -314,6 +314,7 @@ func RunHTTPProxy(
 					Method: deferredReq.Method,
 					Reason: deferredReq.Reason,
 				})
+				logHoldFailureReceiptGap(safeLogW, deferredReq.DeferID, emitErr)
 				if !deferredReq.IsNotification {
 					_ = safeClientOut.WriteMessage(blockRequestResponse(BlockedRequest{
 						ID:           deferredReq.ID,

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -680,10 +680,12 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 		originalReceiptPersisted := emitErr != nil && errors.Is(emitErr, errMCPV2ReceiptEmit)
 		if emitErr != nil {
 			logReceiptEmitFailure(logW, emitErr, opts.requireReceipts(), effectiveAction)
-			if opts.requireReceipts() && effectiveAction != config.ActionBlock {
-				outbound = blockResponseReason(verdict.ID, "receipt emission failed")
-				effectiveAction = config.ActionBlock
-				writeContext = "writing block response"
+			if opts.requireReceipts() {
+				if effectiveAction != config.ActionBlock {
+					outbound = blockResponseReason(verdict.ID, "receipt emission failed")
+					effectiveAction = config.ActionBlock
+					writeContext = "writing block response"
+				}
 				replacementOpts := opts.withReceiptPolicyHash(receipt.EmitOpts{
 					ActionID:  receipt.NewActionID(),
 					Verdict:   config.ActionBlock,

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -767,6 +767,70 @@ func TestForwardScanned_ResponseReceiptFailureOmitsParentWhenOriginalNotDurable(
 	}
 }
 
+func TestForwardScanned_BlockResponseReceiptFailureEmitsReplacementBlockReceipt(t *testing.T) {
+	sc := testScannerWithAction(t, config.ActionBlock)
+	var out, log bytes.Buffer
+	emitter, rec, dir, _ := newReceiptTestHarness(t)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder: failingMCPV2Recorder{},
+		Signer:   proxydecision.NewKeyedSigner(priv),
+	})
+	tracker := NewRequestTracker()
+	tracker.Track(json.RawMessage(`42`))
+
+	found, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(injectionResponse+"\n")),
+		transport.NewStdioWriter(&out),
+		&log,
+		tracker,
+		MCPProxyOpts{
+			Scanner:          sc,
+			ReceiptEmitter:   emitter,
+			V2ReceiptEmitter: v2,
+			Transport:        transportMCPStdio,
+			RequireReceipts:  true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if !found {
+		t.Fatal("expected injection detected")
+	}
+	if !strings.Contains(out.String(), "prompt injection detected") {
+		t.Fatalf("expected original block response to remain intact, got: %s", out.String())
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	receipts := readActionReceipts(t, dir)
+	var replacement, original receipt.Receipt
+	for _, rcpt := range receipts {
+		switch {
+		case rcpt.ActionRecord.Verdict == config.ActionBlock &&
+			rcpt.ActionRecord.Layer == "receipt_emission_failed" &&
+			strings.Contains(rcpt.ActionRecord.Pattern, "mcp_response_scan receipt emission failed"):
+			replacement = rcpt
+		case rcpt.ActionRecord.Verdict == config.ActionBlock:
+			original = rcpt
+		}
+	}
+	if replacement.ActionRecord.ActionID == "" {
+		t.Fatalf("missing replacement block receipt in %d receipts", len(receipts))
+	}
+	// The original v1 block receipt persisted here (only the v2 emit failed), so
+	// the replacement marker must link to it via ParentActionID for audit chaining.
+	if original.ActionRecord.ActionID != "" &&
+		replacement.ActionRecord.ParentActionID != original.ActionRecord.ActionID {
+		t.Fatalf("replacement parent_action_id = %q, want original action_id %q",
+			replacement.ActionRecord.ParentActionID, original.ActionRecord.ActionID)
+	}
+}
+
 func TestForwardScanned_Notification(t *testing.T) {
 	sc := testScannerWithAction(t, "block")
 	var out, log bytes.Buffer

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -384,6 +384,16 @@ func logBlockReceiptAuditGap(logW io.Writer, err error) {
 	_, _ = fmt.Fprintf(logW, "pipelock: warning event=block_receipt_emit_failed audit_gap=true %v\n", err)
 }
 
+// logHoldFailureReceiptGap records the audit gap when a hold-failure resolution
+// receipt cannot be emitted. The denial itself stays fail-closed; this makes a
+// journaled resolution without its receipt detectable across both transports.
+func logHoldFailureReceiptGap(logW io.Writer, deferID string, err error) {
+	if logW == nil || err == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(logW, "pipelock: warning event=hold_failure_receipt_emit_failed audit_gap=true defer_id=%s: %v\n", deferID, err)
+}
+
 // pickAttribution derives the receipt Layer / Pattern / Severity for a
 // block verdict, based on which gate inside MCPInputEvaluation fired.
 //

--- a/internal/posturebinding/binding.go
+++ b/internal/posturebinding/binding.go
@@ -92,6 +92,12 @@ func LoadFile(path string) (receipt.PostureBinding, error) {
 	if err := posture.VerifyAt(&capsule, ed25519.PublicKey(pub), time.Now().UTC()); err != nil {
 		return receipt.PostureBinding{}, fmt.Errorf("verify posture proof: %w", err)
 	}
+	// CapsuleSHA256 binds the canonical posture capsule, not the raw proof.json
+	// bytes. That matches contain-run proofs and verifier-side canonical capsule
+	// hashing: insignificant JSON whitespace/key-order differences in a
+	// hand-written proof file do not change the signed receipt binding. Operators
+	// comparing the receipt field directly to sha256sum(proof.json) must
+	// canonicalize the file first.
 	canonical, err := json.Marshal(&capsule)
 	if err != nil {
 		return receipt.PostureBinding{}, fmt.Errorf("marshal posture proof: %w", err)

--- a/internal/posturebinding/binding_test.go
+++ b/internal/posturebinding/binding_test.go
@@ -189,27 +189,7 @@ func TestLoadFileMissingReturnsZeroBinding(t *testing.T) {
 }
 
 func TestLoadFileDerivesContainmentBinding(t *testing.T) {
-	_, priv, err := ed25519.GenerateKey(nil)
-	if err != nil {
-		t.Fatalf("GenerateKey: %v", err)
-	}
-	capsule, err := posture.Emit(config.Defaults(), posture.Options{
-		SigningKey: priv,
-		Containment: &posture.ContainmentEvidence{
-			Mode:                     posture.ContainmentModeKernelNFTOwnerMatch,
-			BoundaryVerified:         true,
-			ProbeRefusedDirectEgress: true,
-			KernelRuleHash:           "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			TargetUID:                "966",
-		},
-	})
-	if err != nil {
-		t.Fatalf("posture.Emit: %v", err)
-	}
-	data, err := json.Marshal(capsule)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
+	capsule, data := mintContainmentCapsule(t)
 	path := filepath.Join(t.TempDir(), "proof.json")
 	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
@@ -219,9 +199,17 @@ func TestLoadFileDerivesContainmentBinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFile: %v", err)
 	}
-	sum := sha256.Sum256(data)
-	if got.CapsuleSHA256 != hex.EncodeToString(sum[:]) {
-		t.Fatalf("CapsuleSHA256 = %q, want hash of proof", got.CapsuleSHA256)
+	canonicalSum := sha256.Sum256(data)
+	if got.CapsuleSHA256 != hex.EncodeToString(canonicalSum[:]) {
+		t.Fatalf("CapsuleSHA256 = %q, want canonical capsule hash", got.CapsuleSHA256)
+	}
+	raw, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	rawSum := sha256.Sum256(raw)
+	if got.CapsuleSHA256 == hex.EncodeToString(rawSum[:]) {
+		t.Fatal("CapsuleSHA256 unexpectedly matched raw proof file hash; want canonical capsule hash")
 	}
 	if got.SignerKeyID != capsule.SignerKeyID || got.ContainmentNonce != capsule.Signature || got.ContainedUID != "966" {
 		t.Fatalf("binding = %+v, want signer/signature/uid from capsule", got)

--- a/internal/proxy/baseline/baseline.go
+++ b/internal/proxy/baseline/baseline.go
@@ -935,7 +935,7 @@ func (m *Manager) integrityGenerationDigest(generation uint64, manifestHMAC stri
 
 func (m *Manager) loadIntegrityKey(create bool) ([]byte, error) {
 	path := filepath.Clean(m.cfg.IntegrityKeyPath)
-	data, err := readRegularFileNoSymlink(path, "baseline integrity key", integrityStateMaxSize)
+	data, err := readRegularFileNoSymlinkInRoot(path, filepath.Dir(path), "baseline integrity key", integrityStateMaxSize)
 	if err == nil {
 		key, decodeErr := hex.DecodeString(strings.TrimSpace(string(data)))
 		if decodeErr != nil {
@@ -965,7 +965,7 @@ func (m *Manager) loadIntegrityKey(create bool) ([]byte, error) {
 
 func (m *Manager) readIntegrityHighWater(key []byte) (uint64, string, bool, error) {
 	path := m.integrityHighWaterPath()
-	data, err := readRegularFileNoSymlink(path, "baseline integrity generation high-water", integrityStateMaxSize)
+	data, err := readRegularFileNoSymlinkInRoot(path, filepath.Dir(path), "baseline integrity generation high-water", integrityStateMaxSize)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return 0, "", false, nil
@@ -1130,6 +1130,18 @@ func (m *Manager) integrityTrustedStateExists() (bool, error) {
 }
 
 func readRegularFileNoSymlink(path, label string, maxSize int64) ([]byte, error) {
+	return readRegularFileNoSymlinkInRootWithOpenHook(path, filepath.Dir(filepath.Clean(path)), label, maxSize, nil)
+}
+
+func readRegularFileNoSymlinkWithOpenHook(path, label string, maxSize int64, beforeOpen func() error) ([]byte, error) {
+	return readRegularFileNoSymlinkInRootWithOpenHook(path, filepath.Dir(filepath.Clean(path)), label, maxSize, beforeOpen)
+}
+
+func readRegularFileNoSymlinkInRoot(path, trustedRoot, label string, maxSize int64) ([]byte, error) {
+	return readRegularFileNoSymlinkInRootWithOpenHook(path, trustedRoot, label, maxSize, nil)
+}
+
+func readRegularFileNoSymlinkInRootWithOpenHook(path, trustedRoot, label string, maxSize int64, beforeOpen func() error) ([]byte, error) {
 	cleanPath := filepath.Clean(path)
 	info, err := os.Lstat(cleanPath)
 	if err != nil {
@@ -1144,11 +1156,103 @@ func readRegularFileNoSymlink(path, label string, maxSize int64) ([]byte, error)
 	if maxSize > 0 && info.Size() > maxSize {
 		return nil, fmt.Errorf("%s exceeds maximum size", label)
 	}
-	data, err := os.ReadFile(cleanPath)
+	canonicalRoot, relPath, err := trustedRootRelativePath(trustedRoot, cleanPath, label)
+	if err != nil {
+		return nil, err
+	}
+	if err := rejectSymlinkParents(canonicalRoot, relPath, label); err != nil {
+		return nil, err
+	}
+	if beforeOpen != nil {
+		if err := beforeOpen(); err != nil {
+			return nil, fmt.Errorf("prepare open %s: %w", label, err)
+		}
+	}
+	f, err := openRegularFileNoSymlinkBelowRoot(canonicalRoot, relPath, cleanPath)
+	if err != nil {
+		if errors.Is(err, errELOOP) {
+			return nil, fmt.Errorf("%s symlink raced into place", label)
+		}
+		return nil, fmt.Errorf("open %s: %w", label, err)
+	}
+	defer func() { _ = f.Close() }()
+	after, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat opened %s: %w", label, err)
+	}
+	if !after.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s must be a regular file", label)
+	}
+	if !os.SameFile(info, after) {
+		return nil, fmt.Errorf("%s changed during read; retry after quiescing writes", label)
+	}
+	if maxSize > 0 && after.Size() > maxSize {
+		return nil, fmt.Errorf("%s exceeds maximum size", label)
+	}
+	reader := io.Reader(f)
+	if maxSize > 0 {
+		reader = io.LimitReader(f, maxSize+1)
+	}
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", label, err)
 	}
+	if maxSize > 0 && int64(len(data)) > maxSize {
+		return nil, fmt.Errorf("%s exceeds maximum size", label)
+	}
 	return data, nil
+}
+
+func trustedRootRelativePath(trustedRoot, cleanPath, label string) (string, string, error) {
+	if trustedRoot == "" {
+		return "", "", fmt.Errorf("%s trusted root is empty", label)
+	}
+	rootAbs, err := filepath.Abs(filepath.Clean(trustedRoot))
+	if err != nil {
+		return "", "", fmt.Errorf("resolve trusted root for %s: %w", label, err)
+	}
+	pathAbs, err := filepath.Abs(cleanPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve path for %s: %w", label, err)
+	}
+	relPath, err := filepath.Rel(rootAbs, pathAbs)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve relative path for %s: %w", label, err)
+	}
+	if relPath == "." || relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
+		return "", "", fmt.Errorf("%s path %q escapes trusted root %q", label, cleanPath, trustedRoot)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return "", "", fmt.Errorf("canonicalize trusted root for %s: %w", label, err)
+	}
+	return canonicalRoot, relPath, nil
+}
+
+func rejectSymlinkParents(canonicalRoot, relPath, label string) error {
+	if relPath == "." || relPath == "" {
+		return nil
+	}
+
+	current := canonicalRoot
+	parts := strings.Split(filepath.Clean(relPath), string(os.PathSeparator))
+	for _, part := range parts[:len(parts)-1] {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return fmt.Errorf("stat parent directory for %s: %w", label, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s parent directory %q must not be a symlink", label, current)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%s parent path %q must be a directory", label, current)
+		}
+	}
+	return nil
 }
 
 func readExistingRegularFileForRestore(path, label string, maxSize int64) ([]byte, bool, error) {
@@ -1465,7 +1569,7 @@ func (m *Manager) persistIntegrityManifestLocked(exclude map[string]bool) error 
 			return fmt.Errorf("refusing to manifest baseline profile: %w", err)
 		}
 		path := filepath.Join(m.cfg.ProfileDir, agentKey+profileFileExt)
-		data, err := readRegularFileNoSymlink(path, "baseline profile", baselineProfileMaxSize)
+		data, err := readRegularFileNoSymlinkInRoot(path, m.cfg.ProfileDir, "baseline profile", baselineProfileMaxSize)
 		if err != nil {
 			return m.logIntegrityPersistenceFailure("profile_read_failed", fmt.Errorf("reading profile %q for integrity manifest: %w", agentKey, err), "agent_key", agentKey)
 		}
@@ -1572,7 +1676,7 @@ func (m *Manager) verifyPendingProfileIntegrityForRatify(agentKey string) error 
 func (m *Manager) verifyPersistedProfileIntegrity(agentKey string) error {
 	const wantState = StateRatify
 
-	manifestData, err := readRegularFileNoSymlink(m.integrityManifestPath(), "baseline integrity manifest", baselineProfileMaxSize)
+	manifestData, err := readRegularFileNoSymlinkInRoot(m.integrityManifestPath(), m.cfg.ProfileDir, "baseline integrity manifest", baselineProfileMaxSize)
 	if err != nil {
 		return fmt.Errorf("reading baseline integrity manifest: %w", err)
 	}
@@ -1592,7 +1696,7 @@ func (m *Manager) verifyPersistedProfileIntegrity(agentKey string) error {
 			return fmt.Errorf("baseline integrity manifest entry for agent %q has state %q, want %q", agentKey, expected.State, wantState)
 		}
 		path := filepath.Join(m.cfg.ProfileDir, agentKey+profileFileExt)
-		data, err := readRegularFileNoSymlink(path, "pending baseline profile", baselineProfileMaxSize)
+		data, err := readRegularFileNoSymlinkInRoot(path, m.cfg.ProfileDir, "pending baseline profile", baselineProfileMaxSize)
 		if err != nil {
 			return fmt.Errorf("reading pending baseline profile %q required by integrity manifest: %w", agentKey, err)
 		}
@@ -1633,7 +1737,7 @@ func (m *Manager) verifyPersistedIntegrity(entries []os.DirEntry) (map[string]Pr
 		hasProfileFiles = true
 	}
 
-	manifestData, err := readRegularFileNoSymlink(m.integrityManifestPath(), "baseline integrity manifest", baselineProfileMaxSize)
+	manifestData, err := readRegularFileNoSymlinkInRoot(m.integrityManifestPath(), m.cfg.ProfileDir, "baseline integrity manifest", baselineProfileMaxSize)
 	if errors.Is(err, os.ErrNotExist) {
 		if hasProfileFiles {
 			err := fmt.Errorf("baseline integrity manifest missing while persisted profiles exist under enforcing deviation_action %q", m.cfg.DeviationAction)
@@ -1681,7 +1785,7 @@ func (m *Manager) verifyPersistedIntegrity(entries []os.DirEntry) (map[string]Pr
 		}
 
 		path := filepath.Join(m.cfg.ProfileDir, expected.AgentKey+profileFileExt)
-		data, err := readRegularFileNoSymlink(path, "integrity-bound baseline profile", baselineProfileMaxSize)
+		data, err := readRegularFileNoSymlinkInRoot(path, m.cfg.ProfileDir, "integrity-bound baseline profile", baselineProfileMaxSize)
 		if err != nil {
 			err := fmt.Errorf("reading integrity-bound baseline profile %q required by integrity manifest: %w", expected.AgentKey, err)
 			return nil, m.logIntegrityVerificationFailure("profile_read_failed", err, "agent_key", expected.AgentKey, "generation", manifest.Generation)
@@ -1751,7 +1855,7 @@ func (m *Manager) loadProfiles() error {
 			profile = verifiedProfile
 		} else {
 			path := filepath.Join(m.cfg.ProfileDir, entry.Name())
-			data, err := readRegularFileNoSymlink(path, "persisted baseline profile", baselineProfileMaxSize)
+			data, err := readRegularFileNoSymlinkInRoot(path, m.cfg.ProfileDir, "persisted baseline profile", baselineProfileMaxSize)
 			if err != nil {
 				// A persisted profile that exists but cannot be read may be a
 				// locked, enforcing profile. Under an enforcing action we cannot

--- a/internal/proxy/baseline/baseline_test.go
+++ b/internal/proxy/baseline/baseline_test.go
@@ -78,6 +78,169 @@ func TestNewManager_Defaults(t *testing.T) {
 	}
 }
 
+func TestReadRegularFileNoSymlinkReadsRegularFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("secure no-follow baseline reads fail closed on Windows; see the Windows-specific fail-closed test")
+	}
+	path := filepath.Join(t.TempDir(), "profile.json")
+	if err := os.WriteFile(path, []byte("profile"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := readRegularFileNoSymlink(path, "baseline profile", 1024)
+	if err != nil {
+		t.Fatalf("readRegularFileNoSymlink: %v", err)
+	}
+	if string(got) != "profile" {
+		t.Fatalf("data = %q, want profile", got)
+	}
+}
+
+func TestReadRegularFileNoSymlinkRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows symlink creation requires privileges on some CI hosts")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.json")
+	link := filepath.Join(dir, "profile.json")
+	if err := os.WriteFile(target, []byte("profile"), 0o600); err != nil {
+		t.Fatalf("WriteFile target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if _, err := readRegularFileNoSymlink(link, "baseline profile", 1024); err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("readRegularFileNoSymlink symlink error = %v, want symlink rejection", err)
+	}
+}
+
+func TestReadRegularFileNoSymlinkRejectsSymlinkParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows symlink creation requires privileges on some CI hosts")
+	}
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	if err := os.Mkdir(root, 0o750); err != nil {
+		t.Fatalf("Mkdir root: %v", err)
+	}
+	realDir := filepath.Join(root, "real")
+	if err := os.Mkdir(realDir, 0o750); err != nil {
+		t.Fatalf("Mkdir realDir: %v", err)
+	}
+	path := filepath.Join(realDir, "profile.json")
+	if err := os.WriteFile(path, []byte("profile"), 0o600); err != nil {
+		t.Fatalf("WriteFile profile: %v", err)
+	}
+	linkDir := filepath.Join(root, "linked")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("Symlink parent: %v", err)
+	}
+	_, err := readRegularFileNoSymlinkInRoot(filepath.Join(linkDir, "profile.json"), root, "baseline profile", 1024)
+	if err == nil || !strings.Contains(err.Error(), "parent directory") || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("readRegularFileNoSymlink parent symlink error = %v, want parent symlink rejection", err)
+	}
+}
+
+func TestReadRegularFileNoSymlinkAllowsSymlinkedPrefixAboveTrustedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows symlink creation requires privileges on some CI hosts")
+	}
+	dir := t.TempDir()
+	realPrefix := filepath.Join(dir, "real-prefix")
+	if err := os.Mkdir(realPrefix, 0o750); err != nil {
+		t.Fatalf("Mkdir realPrefix: %v", err)
+	}
+	trustedRoot := filepath.Join(realPrefix, "baseline")
+	if err := os.Mkdir(trustedRoot, 0o750); err != nil {
+		t.Fatalf("Mkdir trustedRoot: %v", err)
+	}
+	path := filepath.Join(trustedRoot, "profile.json")
+	if err := os.WriteFile(path, []byte("profile"), 0o600); err != nil {
+		t.Fatalf("WriteFile profile: %v", err)
+	}
+	prefixLink := filepath.Join(dir, "linked-prefix")
+	if err := os.Symlink(realPrefix, prefixLink); err != nil {
+		t.Fatalf("Symlink prefix: %v", err)
+	}
+
+	rootThroughPrefix := filepath.Join(prefixLink, "baseline")
+	got, err := readRegularFileNoSymlinkInRoot(filepath.Join(rootThroughPrefix, "profile.json"), rootThroughPrefix, "baseline profile", 1024)
+	if err != nil {
+		t.Fatalf("readRegularFileNoSymlinkInRoot through symlinked prefix: %v", err)
+	}
+	if string(got) != "profile" {
+		t.Fatalf("data = %q, want profile", got)
+	}
+}
+
+func TestReadRegularFileNoSymlinkRejectsSymlinkSwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows lacks O_NOFOLLOW for a deterministic post-Lstat symlink swap rejection")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.json")
+	target := filepath.Join(dir, "target.json")
+	if err := os.WriteFile(path, []byte("profile"), 0o600); err != nil {
+		t.Fatalf("WriteFile profile: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("replacement"), 0o600); err != nil {
+		t.Fatalf("WriteFile target: %v", err)
+	}
+	_, err := readRegularFileNoSymlinkWithOpenHook(path, "baseline profile", 1024, func() error {
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+		return os.Symlink(target, path)
+	})
+	if err == nil {
+		t.Fatal("readRegularFileNoSymlinkWithOpenHook succeeded after symlink swap")
+	}
+	if !strings.Contains(err.Error(), "symlink raced into place") && !strings.Contains(err.Error(), "changed during read") {
+		t.Fatalf("swap error = %v, want symlink race or changed-file rejection", err)
+	}
+}
+
+func TestReadRegularFileNoSymlinkRejectsParentSymlinkSwapWithinTrustedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows lacks O_NOFOLLOW for a deterministic parent symlink swap rejection")
+	}
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	if err := os.Mkdir(root, 0o750); err != nil {
+		t.Fatalf("Mkdir root: %v", err)
+	}
+	profiles := filepath.Join(root, "profiles")
+	if err := os.Mkdir(profiles, 0o750); err != nil {
+		t.Fatalf("Mkdir profiles: %v", err)
+	}
+	path := filepath.Join(profiles, "profile.json")
+	if err := os.WriteFile(path, []byte("profile"), 0o600); err != nil {
+		t.Fatalf("WriteFile profile: %v", err)
+	}
+	outside := filepath.Join(dir, "outside")
+	if err := os.Mkdir(outside, 0o750); err != nil {
+		t.Fatalf("Mkdir outside: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "profile.json"), []byte("replacement"), 0o600); err != nil {
+		t.Fatalf("WriteFile outside profile: %v", err)
+	}
+
+	_, err := readRegularFileNoSymlinkInRootWithOpenHook(path, root, "baseline profile", 1024, func() error {
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+		if err := os.Remove(profiles); err != nil {
+			return err
+		}
+		return os.Symlink(outside, profiles)
+	})
+	if err == nil {
+		t.Fatal("readRegularFileNoSymlinkInRootWithOpenHook succeeded after parent symlink swap")
+	}
+	if !strings.Contains(err.Error(), "symlink raced into place") && !strings.Contains(err.Error(), "parent directory") {
+		t.Fatalf("swap error = %v, want parent symlink race rejection", err)
+	}
+}
+
 func TestBaseline_InvalidDeviationActionRejected(t *testing.T) {
 	tests := []struct {
 		name string
@@ -3671,4 +3834,127 @@ func TestBaseline_PersistIntegrityManifestProfileFaults(t *testing.T) {
 			t.Fatal("persistIntegrityManifest: want missing high-water generation error")
 		}
 	})
+}
+
+func TestReadRegularFileNoSymlinkRejectsPathEscapingTrustedRoot(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	if err := os.Mkdir(root, 0o750); err != nil {
+		t.Fatalf("Mkdir root: %v", err)
+	}
+	outside := filepath.Join(dir, "outside.json")
+	if err := os.WriteFile(outside, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile outside: %v", err)
+	}
+	_, err := readRegularFileNoSymlinkInRoot(outside, root, "baseline profile", 1024)
+	if err == nil || !strings.Contains(err.Error(), "escapes trusted root") {
+		t.Fatalf("escape error = %v, want escapes trusted root", err)
+	}
+}
+
+func TestReadRegularFileNoSymlinkRejectsEmptyTrustedRoot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.json")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := readRegularFileNoSymlinkInRoot(path, "", "baseline profile", 1024)
+	if err == nil || !strings.Contains(err.Error(), "trusted root is empty") {
+		t.Fatalf("empty root error = %v, want trusted root is empty", err)
+	}
+}
+
+func TestReadRegularFileNoSymlinkBeforeOpenHookError(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	if err := os.Mkdir(root, 0o750); err != nil {
+		t.Fatalf("Mkdir root: %v", err)
+	}
+	path := filepath.Join(root, "profile.json")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	sentinel := errors.New("prepare failed")
+	_, err := readRegularFileNoSymlinkInRootWithOpenHook(path, root, "baseline profile", 1024, func() error { return sentinel })
+	if err == nil || !strings.Contains(err.Error(), "prepare open") {
+		t.Fatalf("beforeOpen error = %v, want prepare open", err)
+	}
+}
+
+func TestReadRegularFileNoSymlinkRejectsOversizeFile(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	if err := os.Mkdir(root, 0o750); err != nil {
+		t.Fatalf("Mkdir root: %v", err)
+	}
+	path := filepath.Join(root, "profile.json")
+	if err := os.WriteFile(path, []byte("0123456789"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := readRegularFileNoSymlinkInRoot(path, root, "baseline profile", 4)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("oversize error = %v, want exceeds maximum size", err)
+	}
+}
+
+func TestReadRegularFileNoSymlinkRejectsPostOpenFileSwap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("secure no-follow baseline reads fail closed on Windows")
+	}
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	if err := os.Mkdir(root, 0o750); err != nil {
+		t.Fatalf("Mkdir root: %v", err)
+	}
+	path := filepath.Join(root, "profile.json")
+	if err := os.WriteFile(path, []byte("original"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	// Pre-create a distinct file so the swap has a guaranteed-different inode
+	// (os.Remove + os.WriteFile can reuse the original inode on some
+	// filesystems, which would defeat the os.SameFile check and flake).
+	other := filepath.Join(root, "other-profile.json")
+	if err := os.WriteFile(other, []byte("swapped"), 0o600); err != nil {
+		t.Fatalf("WriteFile other: %v", err)
+	}
+	// The open hook fires after the pre-open Lstat but before the open, so
+	// renaming a different inode over the path makes the opened file a
+	// different inode and the post-open os.SameFile check must reject the read.
+	swap := func() error {
+		return os.Rename(other, path)
+	}
+	_, err := readRegularFileNoSymlinkInRootWithOpenHook(path, root, "baseline profile", 1024, swap)
+	if err == nil || !strings.Contains(err.Error(), "changed during read") {
+		t.Fatalf("post-open swap error = %v, want changed-during-read rejection", err)
+	}
+}
+
+func TestReadRegularFileNoSymlinkRejectsPostOpenGrowthPastLimit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("secure no-follow baseline reads fail closed on Windows")
+	}
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	if err := os.Mkdir(root, 0o750); err != nil {
+		t.Fatalf("Mkdir root: %v", err)
+	}
+	path := filepath.Join(root, "profile.json")
+	if err := os.WriteFile(path, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	// Append past the limit in the open hook (same inode, so SameFile passes)
+	// to exercise the post-open size check.
+	grow := func() error {
+		f, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		_, err = f.Write([]byte("0123456789"))
+		return err
+	}
+	_, err := readRegularFileNoSymlinkInRootWithOpenHook(path, root, "baseline profile", 4, grow)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("post-open growth error = %v, want exceeds maximum size", err)
+	}
 }

--- a/internal/proxy/baseline/nofollow_unix.go
+++ b/internal/proxy/baseline/nofollow_unix.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package baseline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+var errELOOP error = unix.ELOOP
+
+func openRegularFileNoSymlinkBelowRoot(canonicalRoot, relPath, displayPath string) (*os.File, error) {
+	rootFD, err := unix.Open(canonicalRoot, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open trusted root %q: %w", canonicalRoot, err)
+	}
+	dirFD := rootFD
+	closeDir := true
+	defer func() {
+		if closeDir {
+			_ = unix.Close(dirFD)
+		}
+	}()
+
+	parts := splitRelativePath(relPath)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("%s has no file component", displayPath)
+	}
+	for _, part := range parts[:len(parts)-1] {
+		nextFD, err := unix.Openat(dirFD, part, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			return nil, fmt.Errorf("open parent directory %q below trusted root: %w", part, err)
+		}
+		_ = unix.Close(dirFD)
+		dirFD = nextFD
+	}
+
+	fileFD, err := unix.Openat(dirFD, parts[len(parts)-1], unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	f := os.NewFile(uintptr(fileFD), displayPath)
+	if f == nil {
+		_ = unix.Close(fileFD)
+		return nil, fmt.Errorf("open %s: invalid file descriptor", displayPath)
+	}
+	return f, nil
+}
+
+func splitRelativePath(relPath string) []string {
+	clean := filepath.Clean(relPath)
+	if clean == "." {
+		return nil
+	}
+	parts := make([]string, 0)
+	for _, part := range strings.Split(clean, string(os.PathSeparator)) {
+		if part != "" && part != "." {
+			parts = append(parts, part)
+		}
+	}
+	return parts
+}

--- a/internal/proxy/baseline/nofollow_windows.go
+++ b/internal/proxy/baseline/nofollow_windows.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package baseline
+
+import (
+	"errors"
+	"os"
+)
+
+var (
+	errELOOP               = errors.New("ELOOP-not-supported-on-windows")
+	errNoFollowUnsupported = errors.New("secure nofollow baseline reads are unsupported on windows")
+)
+
+func openRegularFileNoSymlinkBelowRoot(_, _, displayPath string) (*os.File, error) {
+	return nil, errNoFollowUnsupported
+}

--- a/internal/proxy/baseline/nofollow_windows_test.go
+++ b/internal/proxy/baseline/nofollow_windows_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package baseline
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestOpenRegularFileNoSymlinkBelowRootWindowsFailsClosed(t *testing.T) {
+	f, err := openRegularFileNoSymlinkBelowRoot("C:\\baseline", "profile.json", "C:\\baseline\\profile.json")
+	if err == nil {
+		t.Fatal("openRegularFileNoSymlinkBelowRoot succeeded on Windows")
+	}
+	if f != nil {
+		t.Fatalf("openRegularFileNoSymlinkBelowRoot file = %v, want nil", f)
+	}
+	if !errors.Is(err, errNoFollowUnsupported) {
+		t.Fatalf("openRegularFileNoSymlinkBelowRoot error = %v, want errNoFollowUnsupported", err)
+	}
+}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -1390,6 +1390,13 @@ func TestForwardProxy_RequireReceiptsOutcomeEmitFailureDoesNotFailRequest(t *tes
 		cfg.ResponseScanning.Enabled = false
 	})
 	defer cleanup()
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	logger, err := audit.New("json", "file", auditPath, false, false)
+	if err != nil {
+		t.Fatalf("audit.New: %v", err)
+	}
+	t.Cleanup(logger.Close)
+	p.logger = logger
 	rph = newReceiptProxyHelperWithMetrics(t, p.metrics)
 	p.receiptEmitterPtr.Store(rph.emitter)
 
@@ -1408,6 +1415,15 @@ func TestForwardProxy_RequireReceiptsOutcomeEmitFailureDoesNotFailRequest(t *tes
 	}
 	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
 		t.Fatalf("receipt phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+	auditLog, err := os.ReadFile(filepath.Clean(auditPath))
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	for _, want := range []string{"event=receipt_channel_broken", "audit_gap=true", "phase=outcome", "layer=outcome"} {
+		if !strings.Contains(string(auditLog), want) {
+			t.Fatalf("audit log %q missing %q", string(auditLog), want)
+		}
 	}
 	assertMetricsContain(t, p.metrics, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 }

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -254,7 +254,7 @@ func interceptEmitRequiredReceipt(ic *InterceptContext, opts receipt.EmitOpts) e
 	}
 	opts.DecisionPhase = receipt.DecisionPhaseIntent
 	if err := e.EmitDurable(opts); err != nil {
-		ic.Proxy.logReceiptEmissionFailure(opts, err)
+		ic.Proxy.logReceiptChannelBroken(opts, err)
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}
@@ -291,7 +291,7 @@ func interceptEmitOutcomeReceipt(ic *InterceptContext, opts receipt.EmitOpts, ve
 		return
 	}
 	if err := e.Emit(opts); err != nil {
-		ic.Proxy.logReceiptEmissionFailure(opts, err)
+		ic.Proxy.logReceiptChannelBroken(opts, err)
 		return
 	}
 	if err := emitV2(&ic.Proxy.v2EmitterPtr, opts, func(err error) {

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -78,7 +78,13 @@ func TestInterceptEmitReceiptOrBlockRequiresReceipt(t *testing.T) {
 	m := metrics.New()
 	sc := scanner.New(cfg)
 	t.Cleanup(sc.Close)
-	p, err := New(cfg, audit.NewNop(), sc, m)
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	logger, err := audit.New("json", "file", auditPath, false, false)
+	if err != nil {
+		t.Fatalf("audit.New: %v", err)
+	}
+	t.Cleanup(func() { logger.Close() })
+	p, err := New(cfg, logger, sc, m)
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
@@ -113,6 +119,16 @@ func TestInterceptEmitReceiptOrBlockRequiresReceipt(t *testing.T) {
 	}
 	if got := rr.Header().Get(blockreason.HeaderReason); got != string(blockreason.ReceiptEmissionFailed) {
 		t.Fatalf("block reason = %q, want %s", got, blockreason.ReceiptEmissionFailed)
+	}
+	logger.Close()
+	auditLog, err := os.ReadFile(filepath.Clean(auditPath))
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	for _, want := range []string{"event=receipt_channel_broken", "audit_gap=true", "phase=intent"} {
+		if !strings.Contains(string(auditLog), want) {
+			t.Fatalf("audit log %q missing %q", string(auditLog), want)
+		}
 	}
 	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="intercept"} 1`)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1038,7 +1038,7 @@ func (p *Proxy) emitRequiredReceiptWithEmitter(opts receipt.EmitOpts, e *receipt
 	}
 	opts.DecisionPhase = receipt.DecisionPhaseIntent
 	if err := e.EmitDurable(opts); err != nil {
-		p.logReceiptEmissionFailure(opts, err)
+		p.logReceiptChannelBroken(opts, err)
 		// v1 stays authoritative: skip v2 when v1 failed to record, so a
 		// proxy_decision never outlives its action_receipt sibling.
 		return err
@@ -1086,7 +1086,7 @@ func (p *Proxy) emitOutcomeReceipt(cfg *config.Config, opts receipt.EmitOpts, st
 		return
 	}
 	if err := e.Emit(opts); err != nil {
-		p.logReceiptEmissionFailure(opts, err)
+		p.logReceiptChannelBroken(opts, err)
 		return
 	}
 	if err := p.emitV2Receipt(opts); err != nil {
@@ -1168,10 +1168,33 @@ func (p *Proxy) logReceiptEmissionFailure(opts receipt.EmitOpts, err error) {
 	p.logger.LogError(audit.NewRequestLogContext(opts.RequestID), receiptEmissionError(opts, err))
 }
 
+// logReceiptChannelBrokenTo records the out-of-band receipt-channel-broken audit
+// marker. Shared by the forward Proxy and the ReverseProxyHandler so the
+// security-significant marker format cannot drift between them.
+func logReceiptChannelBrokenTo(logger *audit.Logger, opts receipt.EmitOpts, err error) {
+	if logger == nil || err == nil {
+		return
+	}
+	logger.LogError(audit.NewRequestLogContext(opts.RequestID), receiptChannelBrokenError(opts, err))
+}
+
+func (p *Proxy) logReceiptChannelBroken(opts receipt.EmitOpts, err error) {
+	if p == nil {
+		return
+	}
+	logReceiptChannelBrokenTo(p.logger, opts, err)
+}
+
 func receiptEmissionError(opts receipt.EmitOpts, err error) error {
 	return fmt.Errorf("emit receipt action_id=%s verdict=%s layer=%s pattern=%q transport=%s method=%s: %w",
 		opts.ActionID, opts.Verdict, opts.Layer, opts.Pattern,
 		opts.Transport, opts.Method, err)
+}
+
+func receiptChannelBrokenError(opts receipt.EmitOpts, err error) error {
+	return fmt.Errorf("event=receipt_channel_broken audit_gap=true action_id=%s verdict=%s phase=%s layer=%s pattern=%q transport=%s method=%s: %w",
+		opts.ActionID, opts.Verdict, opts.DecisionPhase, opts.Layer,
+		opts.Pattern, opts.Transport, opts.Method, err)
 }
 
 // receiptEmitterStage is the staged result of a receipt-emitter reload.

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -332,6 +332,54 @@ func TestEmitRequiredReceipt_UnavailableEmitterRecordsMetric(t *testing.T) {
 	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="unavailable",transport="fetch"} 1`)
 }
 
+func TestEmitRequiredReceipt_V1FailureLogsReceiptChannelBrokenAuditGap(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	logger, err := audit.New("json", "file", auditPath, false, false)
+	if err != nil {
+		t.Fatalf("audit.New: %v", err)
+	}
+	t.Cleanup(func() { logger.Close() })
+	m := metrics.New()
+	rph := newReceiptProxyHelperWithMetrics(t, m)
+	p, err := New(cfg, logger, sc, m, WithReceiptEmitter(rph.emitter))
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	if err := rph.rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	err = p.emitRequiredReceipt(receipt.EmitOpts{
+		ActionID:  receipt.NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: TransportFetch,
+		Method:    http.MethodGet,
+		Target:    "https://example.test/required",
+		RequestID: "req-required-v1-failed",
+		Agent:     "agent",
+	})
+	if err == nil {
+		t.Fatal("emitRequiredReceipt error = nil, want v1 recorder failure")
+	}
+	logger.Close()
+	auditLog, err := os.ReadFile(filepath.Clean(auditPath))
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	for _, want := range []string{"event=receipt_channel_broken", "audit_gap=true", "phase=intent"} {
+		if !strings.Contains(string(auditLog), want) {
+			t.Fatalf("audit log %q missing %q", string(auditLog), want)
+		}
+	}
+	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
+	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="fetch"} 1`)
+}
+
 func TestReceiptEmissionError_OmitsRawTargetAndAgent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -287,7 +287,7 @@ func (rp *ReverseProxyHandler) emitRequiredReceiptWithEmitter(opts receipt.EmitO
 	}
 	opts.DecisionPhase = receipt.DecisionPhaseIntent
 	if err := e.EmitDurable(opts); err != nil {
-		rp.logReceiptEmissionFailure(opts, err)
+		rp.logReceiptChannelBroken(opts, err)
 		// v1 stays authoritative: skip v2 when v1 failed to record.
 		return err
 	}
@@ -317,7 +317,7 @@ func (rp *ReverseProxyHandler) emitOutcomeReceipt(cfg *config.Config, opts recei
 		return
 	}
 	if err := e.Emit(opts); err != nil {
-		rp.logReceiptEmissionFailure(opts, err)
+		rp.logReceiptChannelBroken(opts, err)
 		return
 	}
 	if err := emitV2(rp.v2EmitterPtr, opts, func(err error) {
@@ -375,6 +375,13 @@ func (rp *ReverseProxyHandler) logReceiptEmissionFailure(opts receipt.EmitOpts, 
 		return
 	}
 	rp.logger.LogError(audit.NewRequestLogContext(opts.RequestID), receiptEmissionError(opts, err))
+}
+
+func (rp *ReverseProxyHandler) logReceiptChannelBroken(opts receipt.EmitOpts, err error) {
+	if rp == nil {
+		return
+	}
+	logReceiptChannelBrokenTo(rp.logger, opts, err)
 }
 
 func reverseTargetURL(upstream *url.URL, r *http.Request) string {

--- a/internal/proxy/reverse_receipt_parity_test.go
+++ b/internal/proxy/reverse_receipt_parity_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1050,6 +1051,96 @@ func TestReverseProxy_RequireReceiptsV2FailureBlocksBeforeEgress(t *testing.T) {
 	}
 	requireReceiptEmissionFailedLayer(t, rph.findReceipts(t))
 	assertMetricsContain(t, m, `pipelock_required_receipt_blocks_total{reason="emit_error",transport="reverse"} 1`)
+}
+
+func TestReverseProxy_RequireReceiptsOutcomeV1FailureLogsReceiptChannelBroken(t *testing.T) {
+	var hits atomic.Int32
+	var rec *recorder.Recorder
+	var closed atomic.Bool
+	cfg := reverseTestConfig()
+	cfg.ResponseScanning.Enabled = false
+	cfg.FlightRecorder.RequireReceipts = true
+
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		if closed.CompareAndSwap(false, true) {
+			if err := rec.Close(); err != nil {
+				t.Errorf("recorder.Close: %v", err)
+			}
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	sc := scanner.New(cfg)
+	t.Cleanup(sc.Close)
+
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	logger, err := audit.New("json", "file", auditPath, false, false)
+	if err != nil {
+		t.Fatalf("audit.New: %v", err)
+	}
+	t.Cleanup(logger.Close)
+	m := metrics.New()
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, logger, m, killswitch.New(cfg), nil, nil)
+	rph := newReceiptProxyHelperWithMetrics(t, m)
+	rec = rph.rec
+	var emPtr atomic.Pointer[receipt.Emitter]
+	emPtr.Store(rph.emitter)
+	handler.SetReceiptEmitter(&emPtr)
+
+	proxySrv := newIPv4Server(t, handler)
+	t.Cleanup(proxySrv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/clean", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET reverse proxy: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Errorf("response body close: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("upstream hits = %d, want 1", got)
+	}
+	receipts := extractReceiptsFromDir(t, rph.dir)
+	if len(receipts) != 1 {
+		t.Fatalf("receipt count after outcome failure = %d, want durable intent only", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent {
+		t.Fatalf("receipt phase = %q, want %q", receipts[0].ActionRecord.DecisionPhase, receipt.DecisionPhaseIntent)
+	}
+	auditLog, err := os.ReadFile(filepath.Clean(auditPath))
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	for _, want := range []string{"event=receipt_channel_broken", "audit_gap=true", "phase=outcome", "layer=outcome"} {
+		if !strings.Contains(string(auditLog), want) {
+			t.Fatalf("audit log %q missing %q", string(auditLog), want)
+		}
+	}
+	assertMetricsContain(t, m, `pipelock_receipt_emit_failures_total{reason="record"} 1`)
 }
 
 func TestReverseProxy_RequireReceiptsOutcomeV2FailureEmitsGapMarker(t *testing.T) {

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -102,6 +102,7 @@ type Emitter struct {
 	rootEmitted   bool      // true after EmitTranscriptRoot; prevents duplicate roots
 	closeEmitted  bool      // true after session_close; prevents duplicate closes
 	closeErr      error     // sticky error for a written session_close whose durability confirmation failed
+	openErr       error     // sticky error for a written session_open whose durability confirmation failed
 	openNonce     string
 	heartbeatBeat uint64
 
@@ -663,6 +664,9 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 		if openControl && e.receiptHashRecorded(receiptHash) {
 			e.sessionOpenEmitted = true
 			e.openNonce = sessionControl.Open.OpenNonce
+			if durable && errors.Is(recordErr, recorder.ErrDurability) {
+				e.openErr = emitErr
+			}
 		}
 		if closeControl && e.receiptHashRecorded(receiptHash) {
 			e.closeEmitted = true
@@ -743,6 +747,9 @@ func (e *Emitter) prepareSessionControlLocked(in *SessionControl) (*SessionContr
 		return cloneSessionControl(in), chainPrevHash, nil
 	}
 	if e.sessionOpenEmitted {
+		if e.openErr != nil {
+			return nil, "", e.openErr
+		}
 		e.recordFailure(FailReasonRecord)
 		return nil, "", ErrSessionOpenAlreadyEmitted
 	}

--- a/internal/receipt/session_control_emit_test.go
+++ b/internal/receipt/session_control_emit_test.go
@@ -108,6 +108,13 @@ func TestEmitter_EmitSessionOpenIsDurableAndGatesOnFsync(t *testing.T) {
 		t.Fatalf("DurabilityBlocks = %d, want 1 after gated session_open", e.DurabilityBlocks())
 	}
 	rec.SetSyncForTest(nil)
+	retryErr := e.EmitSessionOpen()
+	if !errors.Is(retryErr, recorder.ErrDurability) {
+		t.Fatalf("retry EmitSessionOpen error = %v, want sticky ErrDurability", retryErr)
+	}
+	if !errors.Is(retryErr, syncErr) {
+		t.Fatalf("retry EmitSessionOpen error = %v, want original sync error", retryErr)
+	}
 
 	// The bytes still reached disk (fsync failed, not the write), so the chain
 	// opens correctly and a heartbeat can snapshot it.


### PR DESCRIPTION
## What changed

This hardens receipt and defer audit-completeness so that a fail-closed action always leaves verifiable evidence, and tightens the baseline profile reads against symlink races.

Deferred admission rejections (capacity and duplicate-id) are now journaled instead of receipt-only, closing an audit-completeness gap for resource-admission pressure. Hold-failure resolution and the required intent and outcome receipt paths now surface receipt-emit failures with an out-of-band `receipt_channel_broken audit_gap=true` marker across the forward, reverse, and intercept transports, and a response-side receipt-emit failure now emits a replacement block receipt so a denied action is never recorded as clean. When a `session_open` write reaches disk but the fsync fails, the retry now returns the original durability cause rather than a generic already-emitted error, matching the existing session_close behavior.

Baseline profile, manifest, key, and high-water reads now use a race-free `openat` plus `O_NOFOLLOW` descriptor walk bounded to the trusted baseline root. A symlinked path prefix above the trusted root is accepted, so legitimate symlinked mounts still work, while a symlink swap of any component within the writable boundary is rejected. On platforms without a handle-based no-follow equivalent the secure read fails closed rather than falling back to a weaker pathname check.

Every behavior above is covered by a red-first regression test, including a symlink-swap-within-root case that only the descriptor walk catches and an audit-gap test per transport.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admission denials are now recorded as audit-only “admission rejected” outcomes, including provenance for duplicate defer IDs, and replay recovery ignores these entries.
  * Hold/receipt failures now emit additional audit-gap context and improve replacement block-receipt behavior when receipts are required.
* **Bug Fixes**
  * Admission denial journaling is centralized, and caller-supplied lineage is withheld from audit logs (except cascade-limit rejections).
  * Receipt-channel failures are logged distinctly across MCP and reverse-proxy paths.
* **Security**
  * Hardened baseline integrity/profile file reads against symlink and file-swap attacks (Windows fail-closed).
* **Tests**
  * Added/updated coverage for journaling/replay, receipt-gap logging, replacement receipts, and baseline security boundaries.
* **Documentation**
  * Clarified canonical posture capsule hashing behavior and updated related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->