### PR TITLE
harden(mcp): A2A redaction parity and session-binding inventory

### DIFF
--- a/internal/mcp/a2a.go
+++ b/internal/mcp/a2a.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/mcp/a2amethods"
 )
 
 // FieldClass tells callers which scanner pipeline a leaf value needs.
@@ -274,44 +276,11 @@ func classifyKeyAsLeaf(key string) FieldClass {
 // --- A2A Detection ---
 
 // a2aMethods is the set of JSON-RPC method names used by A2A.
-var a2aMethods = map[string]bool{
-	"SendMessage":                      true,
-	"SendStreamingMessage":             true,
-	"GetTask":                          true,
-	"ListTasks":                        true,
-	"CancelTask":                       true,
-	"SubscribeToTask":                  true,
-	"CreateTaskPushNotificationConfig": true,
-	"GetTaskPushNotificationConfig":    true,
-	"ListTaskPushNotificationConfigs":  true,
-	"DeleteTaskPushNotificationConfig": true,
-	"GetExtendedAgentCard":             true,
-	// Current A2A JSON-RPC method names use slash-delimited lowercase
-	// verbs. Keep the legacy CamelCase names above for compatibility.
-	"message/send":                        true,
-	"message/stream":                      true,
-	"tasks/get":                           true,
-	"tasks/list":                          true,
-	"tasks/cancel":                        true,
-	"tasks/resubscribe":                   true,
-	"tasks/pushNotificationConfig/set":    true,
-	"tasks/pushNotificationConfig/get":    true,
-	"tasks/pushNotificationConfig/list":   true,
-	"tasks/pushNotificationConfig/delete": true,
-	"agent/getAuthenticatedExtendedCard":  true,
-}
-
-var normalizedA2AMethods = func() map[string]bool {
-	methods := make(map[string]bool, len(a2aMethods))
-	for method := range a2aMethods {
-		methods[strings.ToLower(method)] = true
-	}
-	return methods
-}()
+var a2aMethods = a2amethods.Known()
 
 // IsA2AMethod returns true if the JSON-RPC method name is an A2A method.
 func IsA2AMethod(method string) bool {
-	return a2aMethods[method] || normalizedA2AMethods[strings.ToLower(method)]
+	return a2amethods.Is(method)
 }
 
 // a2aPathRe matches A2A REST endpoint paths after version prefix stripping.

--- a/internal/mcp/a2a.go
+++ b/internal/mcp/a2a.go
@@ -275,9 +275,6 @@ func classifyKeyAsLeaf(key string) FieldClass {
 
 // --- A2A Detection ---
 
-// a2aMethods is the set of JSON-RPC method names used by A2A.
-var a2aMethods = a2amethods.Known()
-
 // IsA2AMethod returns true if the JSON-RPC method name is an A2A method.
 func IsA2AMethod(method string) bool {
 	return a2amethods.Is(method)

--- a/internal/mcp/a2a_enforcement_parity_test.go
+++ b/internal/mcp/a2a_enforcement_parity_test.go
@@ -215,8 +215,8 @@ func TestScanHTTPInput_A2ASessionBindingDoesNotUseSameNamedTool(t *testing.T) {
 	if blocked == nil {
 		t.Fatal("same-named MCP tool baseline satisfied A2A binding")
 	}
-	if !strings.Contains(blocked.ErrorMessage, bindingReasonUnknownTool) {
-		t.Fatalf("ErrorMessage = %q, want %s", blocked.ErrorMessage, bindingReasonUnknownTool)
+	if !strings.Contains(blocked.ErrorMessage, bindingReasonNoBaseline) {
+		t.Fatalf("ErrorMessage = %q, want %s", blocked.ErrorMessage, bindingReasonNoBaseline)
 	}
 }
 
@@ -503,7 +503,7 @@ func TestForwardScannedInput_A2ASessionBindingDoesNotUseSameNamedTool(t *testing
 		if br.ErrorData != nil || br.ErrorCode != 0 {
 			gotBlock = true
 		}
-		if strings.Contains(br.ErrorMessage, bindingReasonUnknownTool) {
+		if strings.Contains(br.ErrorMessage, bindingReasonNoBaseline) {
 			gotReason = true
 		}
 	}

--- a/internal/mcp/a2a_scan.go
+++ b/internal/mcp/a2a_scan.go
@@ -86,7 +86,7 @@ func scanA2ABody(ctx context.Context, body []byte, sc *scanner.Scanner, cfg *con
 	}
 	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil {
 		reason := fmt.Sprintf("a2a: invalid JSON: %v", err)
-		if isDuplicateKeyBlock(err) {
+		if redact.IsDuplicateKeyBlock(err) {
 			reason = fmt.Sprintf("a2a: duplicate JSON object key: %v", err)
 		}
 		return A2AScanResult{

--- a/internal/mcp/a2a_test.go
+++ b/internal/mcp/a2a_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/mcp/a2amethods"
 )
 
 type walkedLeaf struct {
@@ -302,8 +304,9 @@ func TestIsA2AMethod(t *testing.T) {
 }
 
 func TestIsA2AMethod_KnownMethodsDetectAfterCaseFold(t *testing.T) {
-	normalized := make(map[string]string, len(a2aMethods))
-	for method := range a2aMethods {
+	known := a2amethods.Known()
+	normalized := make(map[string]string, len(known))
+	for method := range known {
 		folded := strings.ToLower(method)
 		if previous, ok := normalized[folded]; ok && previous != method {
 			t.Fatalf("A2A methods %q and %q collide after case fold", previous, method)

--- a/internal/mcp/a2amethods/methods.go
+++ b/internal/mcp/a2amethods/methods.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package a2amethods is the shared source of truth for A2A JSON-RPC method
+// names used by request classification and A2A session-binding inventory.
+package a2amethods
+
+import "strings"
+
+// Known returns a copy of the A2A JSON-RPC method inventory.
+func Known() map[string]bool {
+	methods := make(map[string]bool, len(known))
+	for method := range known {
+		methods[method] = true
+	}
+	return methods
+}
+
+// Is reports whether method is a recognized A2A JSON-RPC method. Matching is
+// case-insensitive to preserve the existing tolerant classifier behavior.
+func Is(method string) bool {
+	return known[method] || normalized[strings.ToLower(method)]
+}
+
+// Canonical returns the canonical A2A method name for a recognized method and
+// reports whether it is recognized. Enforcement (policy matching, redirect
+// target, receipts, binding identity) must use the canonical form so a case
+// variant cannot be classified as A2A for one purpose while evading a rule
+// written against the canonical name.
+func Canonical(method string) (string, bool) {
+	if known[method] {
+		return method, true
+	}
+	if canonical, ok := canonicalByLower[strings.ToLower(method)]; ok {
+		return canonical, true
+	}
+	return "", false
+}
+
+var canonicalByLower = func() map[string]string {
+	m := make(map[string]string, len(known))
+	for method := range known {
+		m[strings.ToLower(method)] = method
+	}
+	return m
+}()
+
+var known = map[string]bool{
+	"SendMessage":                      true,
+	"SendStreamingMessage":             true,
+	"GetTask":                          true,
+	"ListTasks":                        true,
+	"CancelTask":                       true,
+	"SubscribeToTask":                  true,
+	"CreateTaskPushNotificationConfig": true,
+	"GetTaskPushNotificationConfig":    true,
+	"ListTaskPushNotificationConfigs":  true,
+	"DeleteTaskPushNotificationConfig": true,
+	"GetExtendedAgentCard":             true,
+	// Current A2A JSON-RPC method names use slash-delimited lowercase
+	// verbs. Keep the legacy CamelCase names above for compatibility.
+	"message/send":                        true,
+	"message/stream":                      true,
+	"tasks/get":                           true,
+	"tasks/list":                          true,
+	"tasks/cancel":                        true,
+	"tasks/resubscribe":                   true,
+	"tasks/pushNotificationConfig/set":    true,
+	"tasks/pushNotificationConfig/get":    true,
+	"tasks/pushNotificationConfig/list":   true,
+	"tasks/pushNotificationConfig/delete": true,
+	"agent/getAuthenticatedExtendedCard":  true,
+}
+
+var normalized = func() map[string]bool {
+	methods := make(map[string]bool, len(known))
+	for method := range known {
+		methods[strings.ToLower(method)] = true
+	}
+	return methods
+}()

--- a/internal/mcp/a2amethods/methods_test.go
+++ b/internal/mcp/a2amethods/methods_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package a2amethods
+
+import "testing"
+
+func TestKnownReturnsCopy(t *testing.T) {
+	methods := Known()
+	if !methods["SendMessage"] || !methods["message/send"] {
+		t.Fatalf("Known missing expected A2A methods: %v", methods)
+	}
+
+	methods["StealEverything"] = true
+	if Is("StealEverything") {
+		t.Fatal("mutating Known result changed package method inventory")
+	}
+}
+
+func TestCanonicalNormalizesCaseVariants(t *testing.T) {
+	// A case variant of a known method must canonicalize to the exact known
+	// name so detection and enforcement agree; unknown methods are rejected.
+	cases := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"SendMessage", "SendMessage", true},
+		{"sendmessage", "SendMessage", true},
+		{"SENDMESSAGE", "SendMessage", true},
+		{"tasks/get", "tasks/get", true},
+		{"TASKS/GET", "tasks/get", true},
+		{"StealEverything", "", false},
+		{"a2a:GetTask", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := Canonical(tc.in)
+			if ok != tc.wantOK || got != tc.want {
+				t.Fatalf("Canonical(%q) = (%q,%v), want (%q,%v)", tc.in, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestIsRecognizesKnownAndRejectsUnknown(t *testing.T) {
+	if !Is("SendMessage") || !Is("sendmessage") || !Is("tasks/get") {
+		t.Fatal("Is failed to recognize a known method or case variant")
+	}
+	if Is("StealEverything") || Is("a2a:GetTask") {
+		t.Fatal("Is recognized an unknown or reserved-prefix method")
+	}
+}

--- a/internal/mcp/baseline.go
+++ b/internal/mcp/baseline.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/a2amethods"
 	session "github.com/luckyPipewrench/pipelock/internal/session"
 )
 
@@ -138,7 +139,8 @@ func toolBaselineIdentity(toolName string) string {
 
 func a2aBaselineIdentity(method string) string {
 	method = strings.TrimSpace(method)
-	if method == "" || !IsA2AMethod(method) {
+	canonical, ok := a2amethods.Canonical(method)
+	if method == "" || !ok {
 		return ""
 	}
 	// A2A is method-based rather than params.name-based. Reusing the
@@ -146,7 +148,7 @@ func a2aBaselineIdentity(method string) string {
 	// ratification, locking, and persistence on one profile while preventing
 	// collisions with ordinary tools, including one literally named
 	// "a2a:SendMessage".
-	return a2aBaselineIdentityPrefix + method
+	return a2aBaselineIdentityPrefix + canonical
 }
 
 func sortedBaselineToolIdentities(tools map[string]struct{}) []string {

--- a/internal/mcp/baseline_test.go
+++ b/internal/mcp/baseline_test.go
@@ -462,6 +462,9 @@ func TestBaselineIdentityHelpers(t *testing.T) {
 	if got := a2aBaselineIdentity("SendMessage"); got != "a2a:SendMessage" {
 		t.Errorf("a2aBaselineIdentity(SendMessage) = %q, want a2a:SendMessage", got)
 	}
+	if got := a2aBaselineIdentity("sendmessage"); got != "a2a:SendMessage" {
+		t.Errorf("a2aBaselineIdentity(sendmessage) = %q, want a2a:SendMessage", got)
+	}
 	ids := []string{"tool:read", "a2a:message/send"}
 	if !containsBaselineToolIdentity(ids, "a2a:message/send") {
 		t.Error("containsBaselineToolIdentity should find a present identity")

--- a/internal/mcp/dupkey_envelope_test.go
+++ b/internal/mcp/dupkey_envelope_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/redact"
 )
 
 // dupkeyFakeAWSKey is split at build time so gosec G101 and the pipelock self-scan
@@ -54,7 +56,7 @@ func TestApplyMCPToolCallRedaction_DuplicateMethodEnvelopeFailsClosed(t *testing
 	if err == nil {
 		t.Fatalf("expected duplicate-key block, got nil and out=%q", string(out))
 	}
-	if !isDuplicateKeyBlock(err) {
+	if !redact.IsDuplicateKeyBlock(err) {
 		t.Fatalf("expected duplicate-key BlockError, got %v", err)
 	}
 }
@@ -68,7 +70,7 @@ func TestApplyMCPToolCallRedaction_DuplicateParamsFailsClosed(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected duplicate-key block, got nil and out=%q", string(out))
 	}
-	if !isDuplicateKeyBlock(err) {
+	if !redact.IsDuplicateKeyBlock(err) {
 		t.Fatalf("expected duplicate-key BlockError, got %v", err)
 	}
 }

--- a/internal/mcp/dupkey_helpers.go
+++ b/internal/mcp/dupkey_helpers.go
@@ -3,12 +3,7 @@
 
 package mcp
 
-import (
-	"errors"
-	"strings"
-
-	"github.com/luckyPipewrench/pipelock/internal/redact"
-)
+import "strings"
 
 // hasNonIdentityEncoding reports whether the Content-Encoding header carries
 // any encoding other than "identity" (which means no encoding). Mirrors the
@@ -25,19 +20,4 @@ func hasNonIdentityEncoding(ce string) bool {
 		}
 	}
 	return false
-}
-
-// isDuplicateKeyBlock reports whether err is the specific
-// redact.NoDuplicateJSONKeys outcome for an actual duplicate object
-// member name. Generic malformed-JSON failures from the same call also
-// surface as *redact.BlockError with ReasonBodyUnparseable; those should
-// fall through to the caller's existing parse-error handling so logs
-// and metrics stay attributed to the JSON-parse cause rather than to
-// duplicate-key blocking.
-func isDuplicateKeyBlock(err error) bool {
-	var be *redact.BlockError
-	if !errors.As(err, &be) {
-		return false
-	}
-	return be.Reason == redact.ReasonDuplicateKey
 }

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -1600,7 +1600,7 @@ func marshalMCPWithMeta(original []byte, rpc, params map[string]json.RawMessage,
 // Returns the modified message or the original if parsing fails.
 func stripInboundMCPMeta(msg []byte) []byte {
 	trimmed := bytes.TrimSpace(msg)
-	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && isDuplicateKeyBlock(err) {
+	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && redact.IsDuplicateKeyBlock(err) {
 		// Do not unmarshal/remarshal duplicate-key payloads. The parser
 		// and scanner paths intentionally fail closed on duplicate keys;
 		// remarshal would collapse them before those checks can run.

--- a/internal/mcp/input_scan.go
+++ b/internal/mcp/input_scan.go
@@ -124,7 +124,7 @@ func scanMCPResourceURI(ctx context.Context, method string, params json.RawMessa
 	if len(trimmed) == 0 || string(trimmed) == jsonrpc.Null {
 		return mcpResourceURIParserFinding("missing resources/read params")
 	}
-	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && isDuplicateKeyBlock(err) {
+	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && redact.IsDuplicateKeyBlock(err) {
 		return []scanner.Result{{
 			Allowed: false,
 			Reason:  fmt.Sprintf("duplicate resource URI key: %v", err),
@@ -184,7 +184,7 @@ func scanRequestForAgent(ctx context.Context, line []byte, sc *scanner.Scanner, 
 	// Only block on actual duplicate-key matches; let malformed-JSON
 	// errors flow through to the existing parse-error path below so
 	// telemetry stays attributable to the right cause.
-	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && isDuplicateKeyBlock(err) {
+	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && redact.IsDuplicateKeyBlock(err) {
 		return InputVerdict{ID: recoveredID, Clean: false, Error: fmt.Sprintf("duplicate JSON object key: %v", err)}
 	}
 

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -17,6 +17,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/decide"
 	"github.com/luckyPipewrench/pipelock/internal/deferred"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/a2amethods"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/policy"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
@@ -297,7 +298,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		// block path (pre-redaction content scan, redaction error) still
 		// attributes the receipt to the A2A method; the deferred emitter
 		// assigns the actionID lazily when the request is actually blocked.
-		mcpMethod = frame.Method
+		if canonical, ok := a2amethods.Canonical(frame.Method); ok {
+			mcpMethod = canonical
+		}
 	}
 	if scanEnabled && redactionCfg.Matcher != nil {
 		originalVerdict := scanRequestForAgent(inputScanCtx, msg, sc, action, onParseError, opts.addressProtectionAgent())
@@ -360,6 +363,10 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 	receiptLayer, receiptPattern, receiptSeverity = pickAttribution(eval)
 
 	mcpMethod = verdict.Method
+	if canonical, ok := a2amethods.Canonical(mcpMethod); ok {
+		mcpMethod = canonical
+		verdict.Method = canonical
+	}
 	if verdict.Method == methodToolsCall {
 		if actionID == "" {
 			actionID = receipt.NewActionID()

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -125,25 +125,27 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		emitActionID := actionID
 		emitTarget := toolName
 		emitVerdict := receiptVerdict
-		if emitActionID == "" && IsA2AMethod(mcpMethod) {
-			switch {
-			case receiptVerdict != "":
-				// A2A block path: mint an actionID here so the block still leaves a
-				// policy-hash-bearing receipt, matching the other applicable block
-				// surfaces. tools/call already carries its own actionID, so that
-				// path never reaches this branch.
-				emitActionID = receipt.NewActionID()
-			case requireReceipts && result.Blocked == nil:
-				// A clean A2A allow otherwise leaves both actionID and receiptVerdict
-				// empty, so emitMCPToolReceipt drops the emission (ActionID == "") and
-				// the request forwards with no receipt. Under require_receipts that is
-				// a hole in the every-allow-is-provable guarantee, so mint an actionID
-				// and record an explicit allow verdict. The emission-failure guard
-				// below then fails closed before the caller forwards. When
-				// require_receipts is off this branch is skipped, preserving the
-				// default of no receipt on a clean A2A allow (no receipt spam).
-				emitActionID = receipt.NewActionID()
-				emitVerdict = config.ActionAllow
+		if IsA2AMethod(mcpMethod) {
+			if emitActionID == "" {
+				switch {
+				case receiptVerdict != "":
+					// A2A block path: mint an actionID here so the block still leaves a
+					// policy-hash-bearing receipt, matching the other applicable block
+					// surfaces. tools/call already carries its own actionID, so that
+					// path never reaches this branch.
+					emitActionID = receipt.NewActionID()
+				case requireReceipts && result.Blocked == nil:
+					// A clean A2A allow otherwise leaves both actionID and receiptVerdict
+					// empty, so emitMCPToolReceipt drops the emission (ActionID == "") and
+					// the request forwards with no receipt. Under require_receipts that is
+					// a hole in the every-allow-is-provable guarantee, so mint an actionID
+					// and record an explicit allow verdict. The emission-failure guard
+					// below then fails closed before the caller forwards. When
+					// require_receipts is off this branch is skipped, preserving the
+					// default of no receipt on a clean A2A allow (no receipt spam).
+					emitActionID = receipt.NewActionID()
+					emitVerdict = config.ActionAllow
+				}
 			}
 			// A2A frames carry no tool name, but the receipt record requires a
 			// non-empty target. Use the A2A method name (e.g. SendMessage) as the
@@ -737,6 +739,9 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 				errMsg = "pipelock: MCP request blocked by behavioral baseline"
 			}
 		}
+	}
+	if effectiveAction == config.ActionDefer && actionID == "" && IsA2AMethod(verdict.Method) {
+		actionID = receipt.NewActionID()
 	}
 
 	// Capture: record DLP/injection input verdict before action dispatch so

--- a/internal/mcp/pipeline_frame.go
+++ b/internal/mcp/pipeline_frame.go
@@ -122,7 +122,7 @@ func ParseMCPFrame(msg []byte) MCPFrame {
 	// gates, so blocking here covers the gate-evaluation path. external review C-1.
 	// Only fail-closed on actual duplicate-key matches; let malformed-
 	// JSON errors flow through to the existing structural parse path.
-	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && isDuplicateKeyBlock(err) {
+	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && redact.IsDuplicateKeyBlock(err) {
 		frame.ParseErr = err
 		return frame
 	}

--- a/internal/mcp/pipeline_gates.go
+++ b/internal/mcp/pipeline_gates.go
@@ -51,6 +51,16 @@ const (
 	bindingReasonUnknownTool     = "session_binding:unknown_tool"
 )
 
+func frameParseErrFailsClosed(err error) bool {
+	if err == nil {
+		return false
+	}
+	// These parser errors can change the callable identity or params view
+	// between policy and upstream parsers. Treat them as non-configurable
+	// parse-error blocks even when content scanning is disabled.
+	return errors.Is(err, ErrInvalidMethodType) || isDuplicateKeyBlock(err)
+}
+
 // MCPInputEvaluation aggregates the outputs of the configured inbound
 // gates for one MCP request. EvaluateMCPInputGates populates the
 // struct in a single pass; callers consume it to merge per-gate
@@ -356,7 +366,7 @@ func EvaluateMCPInputGates(
 		eval.ContentVerdict.ID = frame.ID
 		eval.ContentVerdict.Method = frame.Method
 	}
-	if errors.Is(frame.ParseErr, ErrInvalidMethodType) {
+	if frameParseErrFailsClosed(frame.ParseErr) {
 		eval.ContentVerdict.ID = frame.ID
 		eval.ContentVerdict.Method = frame.Method
 		eval.ContentVerdict.Clean = false
@@ -589,7 +599,7 @@ func EvaluateMCPInputGatesStdio(
 	// consulted at this layer -- the caller gates enablement via
 	// the scanAction / onParseError it passes in).
 	eval.ContentVerdict = scanRequestForAgent(ctx, msg, sc, scanAction, onParseError, opts.addressProtectionAgent())
-	if errors.Is(frame.ParseErr, ErrInvalidMethodType) {
+	if frameParseErrFailsClosed(frame.ParseErr) {
 		eval.ContentVerdict.ID = frame.ID
 		eval.ContentVerdict.Method = frame.Method
 		eval.ContentVerdict.Clean = false

--- a/internal/mcp/pipeline_gates.go
+++ b/internal/mcp/pipeline_gates.go
@@ -13,6 +13,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/decide"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/policy"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/session"
 )
 
@@ -227,6 +228,71 @@ func mcpFrameDoWArgs(frame MCPFrame, msg []byte) string {
 	return string(msg)
 }
 
+type sessionBindingCheck struct {
+	Baseline            *tools.ToolBaseline
+	UnknownAction       string
+	NoBaselineAction    string
+	Frame               MCPFrame
+	Method              string
+	ToolName            string
+	EnforcementIdentity string
+}
+
+func evaluateSessionBinding(check sessionBindingCheck) (action, reason string) {
+	if check.Baseline == nil {
+		return "", ""
+	}
+	method := check.Method
+	if method == "" {
+		method = check.Frame.Method
+	}
+	isToolCall := method == methodToolsCall
+	isA2A := IsA2AMethod(method)
+	if !isToolCall && !isA2A {
+		return "", ""
+	}
+	// Gate each decision on its OWN configured action, never on UnknownAction:
+	// a pre-baseline block (NoBaselineAction=block) must still fail closed even
+	// when UnknownAction is unset.
+	if isToolCall && check.ToolName == "" {
+		if check.UnknownAction != "" {
+			return check.UnknownAction, bindingReasonMissingToolName
+		}
+		return "", ""
+	}
+	if isA2A {
+		// A2A binding is a separate namespace: the MCP tool baseline must not
+		// satisfy or downgrade the A2A baseline state, so the no-baseline
+		// decision depends only on whether an A2A method baseline exists.
+		if !check.Baseline.HasA2AMethodBaseline() {
+			if check.NoBaselineAction != "" {
+				return check.NoBaselineAction, bindingReasonNoBaseline
+			}
+			return "", ""
+		}
+		if !check.Baseline.IsKnownA2AMethod(check.EnforcementIdentity) {
+			if check.UnknownAction != "" {
+				return check.UnknownAction, bindingReasonUnknownTool
+			}
+			return "", ""
+		}
+		return "", ""
+	}
+	if !check.Baseline.HasBaseline() {
+		if check.NoBaselineAction != "" {
+			return check.NoBaselineAction, bindingReasonNoBaseline
+		}
+		return "", ""
+	}
+	if !check.Baseline.IsKnownTool(check.ToolName) {
+		if check.UnknownAction != "" {
+			return check.UnknownAction, bindingReasonUnknownTool
+		}
+		return "", ""
+	}
+	return "", ""
+}
+
 // EvaluateMCPInputGates runs the configured inbound gates for one
 // MCP request and returns their aggregated verdict. Each gate is
 // nil-safe: the helper skips gates whose config is nil or whose
@@ -356,29 +422,20 @@ func EvaluateMCPInputGates(
 		}
 	}
 
-	// session binding. HTTP listener traffic shares a listener-level
-	// baseline; apply the same callable inventory check as stdio before
-	// policy/chain/taint can treat the call as clean. Tools/call uses the raw
-	// tool name for compatibility with the tools/list baseline. A2A methods
-	// are not members of that MCP tool inventory; with an established baseline
-	// they fail closed as unknown rather than letting a real tool named
-	// "a2a:<method>" satisfy the method binding.
-	if toolCfg := opts.toolCfg(); toolCfg != nil && toolCfg.Baseline != nil && toolCfg.BindingUnknownAction != "" && (enforcementIdentity != "" || frame.IsToolsCall()) {
-		bindingIdentity := enforcementIdentity
-		if frame.IsToolsCall() {
-			bindingIdentity = frame.ToolCallName
-		}
-		switch {
-		case frame.IsToolsCall() && frame.ToolCallName == "":
-			eval.BindingAction = toolCfg.BindingUnknownAction
-			eval.BindingReason = bindingReasonMissingToolName
-		case !toolCfg.Baseline.HasBaseline():
-			eval.BindingAction = toolCfg.BindingNoBaselineAction
-			eval.BindingReason = bindingReasonNoBaseline
-		case !frame.IsToolsCall() || !toolCfg.Baseline.IsKnownTool(bindingIdentity):
-			eval.BindingAction = toolCfg.BindingUnknownAction
-			eval.BindingReason = bindingReasonUnknownTool
-		}
+	// session binding. HTTP listener traffic shares a listener-level baseline.
+	// tools/call checks the raw tool inventory captured from tools/list. A2A
+	// methods check a separate namespaced A2A method inventory so a real MCP
+	// tool named "a2a:<method>" cannot satisfy A2A method binding.
+	if toolCfg := opts.toolCfg(); toolCfg != nil {
+		eval.BindingAction, eval.BindingReason = evaluateSessionBinding(sessionBindingCheck{
+			Baseline:            toolCfg.Baseline,
+			UnknownAction:       toolCfg.BindingUnknownAction,
+			NoBaselineAction:    toolCfg.BindingNoBaselineAction,
+			Frame:               frame,
+			Method:              eval.ContentVerdict.Method,
+			ToolName:            frame.ToolCallName,
+			EnforcementIdentity: enforcementIdentity,
+		})
 	}
 
 	// policy.
@@ -611,22 +668,22 @@ func EvaluateMCPInputGatesStdio(
 	}
 
 	// session binding callable check. Overrides the batch pre-check when it
-	// fires. Tools/call uses the raw tool name for compatibility with the
-	// tools/list baseline. A2A methods are not members of that MCP tool
-	// inventory; with an established baseline they fail closed as unknown
-	// rather than letting a real tool named "a2a:<method>" satisfy the method
-	// binding. No short-circuit.
-	if bindingCfg != nil && bindingCfg.Baseline != nil && (enforcementIdentity != "" || eval.ContentVerdict.Method == methodToolsCall) {
-		switch {
-		case eval.ContentVerdict.Method == methodToolsCall && toolCallName == "":
-			eval.BindingAction = bindingCfg.UnknownToolAction
-			eval.BindingReason = bindingReasonMissingToolName
-		case !bindingCfg.Baseline.HasBaseline():
-			eval.BindingAction = bindingCfg.NoBaselineAction
-			eval.BindingReason = bindingReasonNoBaseline
-		case eval.ContentVerdict.Method != methodToolsCall || !bindingCfg.Baseline.IsKnownTool(toolCallName):
-			eval.BindingAction = bindingCfg.UnknownToolAction
-			eval.BindingReason = bindingReasonUnknownTool
+	// fires. tools/call checks the raw tool inventory captured from tools/list.
+	// A2A methods check a separate namespaced A2A method inventory so a real
+	// MCP tool named "a2a:<method>" cannot satisfy A2A method binding. No
+	// short-circuit.
+	if bindingCfg != nil {
+		if action, reason := evaluateSessionBinding(sessionBindingCheck{
+			Baseline:            bindingCfg.Baseline,
+			UnknownAction:       bindingCfg.UnknownToolAction,
+			NoBaselineAction:    bindingCfg.NoBaselineAction,
+			Frame:               frame,
+			Method:              eval.ContentVerdict.Method,
+			ToolName:            toolCallName,
+			EnforcementIdentity: enforcementIdentity,
+		}); reason != "" {
+			eval.BindingAction = action
+			eval.BindingReason = reason
 		}
 	}
 

--- a/internal/mcp/pipeline_gates.go
+++ b/internal/mcp/pipeline_gates.go
@@ -14,6 +14,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/decide"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/policy"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/tools"
+	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/session"
 )
 
@@ -58,7 +59,7 @@ func frameParseErrFailsClosed(err error) bool {
 	// These parser errors can change the callable identity or params view
 	// between policy and upstream parsers. Treat them as non-configurable
 	// parse-error blocks even when content scanning is disabled.
-	return errors.Is(err, ErrInvalidMethodType) || isDuplicateKeyBlock(err)
+	return errors.Is(err, ErrInvalidMethodType) || redact.IsDuplicateKeyBlock(err)
 }
 
 // MCPInputEvaluation aggregates the outputs of the configured inbound

--- a/internal/mcp/pipeline_gates_dupkey_test.go
+++ b/internal/mcp/pipeline_gates_dupkey_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
+)
+
+var a2aDuplicateKeyPolicy = buildPolicyConfig(config.ActionBlock, []config.ToolPolicyRule{{
+	Name:        "malicious-a2a-payload",
+	ToolPattern: `^SendMessage$`,
+	ArgPattern:  `malicious`,
+}})
+
+var a2aDuplicateKeyMessages = []struct {
+	name string
+	msg  []byte
+}{
+	{
+		name: "top-level params duplicate",
+		msg:  []byte(`{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"parts":[{"kind":"text","text":"malicious"}]}},"params":{"message":{"parts":[{"kind":"text","text":"benign"}]}}}`),
+	},
+	{
+		name: "nested params duplicate",
+		msg:  []byte(`{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"parts":[{"kind":"text","text":"malicious"}]},"message":{"parts":[{"kind":"text","text":"benign"}]}}}`),
+	},
+}
+
+func TestEvaluateMCPInputGates_A2ADuplicateKeysFailClosedWithScanningDisabled(t *testing.T) {
+	for _, tt := range a2aDuplicateKeyMessages {
+		t.Run(tt.name, func(t *testing.T) {
+			frame := ParseMCPFrame(tt.msg)
+			if frame.ParseErr == nil {
+				t.Fatal("ParseMCPFrame ParseErr = nil, want duplicate-key error")
+			}
+			if v := a2aDuplicateKeyPolicy.CheckRequest(tt.msg); !v.Matched || v.Action != config.ActionBlock {
+				t.Fatalf("policy duplicate-key defense = %+v, want block match", v)
+			}
+
+			eval := EvaluateMCPInputGates(
+				t.Context(),
+				frame,
+				tt.msg,
+				"session-1",
+				MCPProxyOpts{PolicyCfg: a2aDuplicateKeyPolicy},
+				config.ActionWarn,
+				config.ActionBlock,
+				false,
+			)
+
+			if eval.BlockingGate != blockingGateParseError {
+				t.Fatalf("BlockingGate = %q, want %s", eval.BlockingGate, blockingGateParseError)
+			}
+			if eval.ContentVerdict.Error == "" {
+				t.Fatal("ContentVerdict.Error is empty, want duplicate-key parse error")
+			}
+		})
+	}
+}
+
+func TestEvaluateMCPInputGatesStdio_A2ADuplicateKeysFailClosedWithPolicyOnly(t *testing.T) {
+	for _, tt := range a2aDuplicateKeyMessages {
+		t.Run(tt.name, func(t *testing.T) {
+			frame := ParseMCPFrame(tt.msg)
+			if frame.ParseErr == nil {
+				t.Fatal("ParseMCPFrame ParseErr = nil, want duplicate-key error")
+			}
+			if v := a2aDuplicateKeyPolicy.CheckRequest(tt.msg); !v.Matched || v.Action != config.ActionBlock {
+				t.Fatalf("policy duplicate-key defense = %+v, want block match", v)
+			}
+
+			eval := EvaluateMCPInputGatesStdio(
+				t.Context(),
+				frame,
+				tt.msg,
+				tt.msg,
+				nil,
+				MCPProxyOpts{
+					Scanner:   testInputScanner(t),
+					PolicyCfg: a2aDuplicateKeyPolicy,
+				},
+				config.ActionWarn,
+				config.ActionBlock,
+			)
+
+			if eval.BlockingGate != blockingGateParseError {
+				t.Fatalf("BlockingGate = %q, want %s", eval.BlockingGate, blockingGateParseError)
+			}
+			if eval.ContentVerdict.Error == "" {
+				t.Fatal("ContentVerdict.Error is empty, want duplicate-key parse error")
+			}
+		})
+	}
+}
+
+func TestScanHTTPInput_A2ADuplicateKeysPolicyOnlyNotForwardable(t *testing.T) {
+	for _, tt := range a2aDuplicateKeyMessages {
+		t.Run(tt.name, func(t *testing.T) {
+			result := scanHTTPInputDecision(tt.msg, &bytes.Buffer{}, "session-1", "session-1", MCPProxyOpts{
+				Scanner:   testInputScanner(t),
+				PolicyCfg: a2aDuplicateKeyPolicy,
+			})
+
+			if result.Blocked == nil {
+				t.Fatal("Blocked = nil, want duplicate-key parse-error block")
+			}
+			if result.Blocked.ErrorCode != -32600 {
+				t.Fatalf("ErrorCode = %d, want -32600", result.Blocked.ErrorCode)
+			}
+		})
+	}
+}
+
+func TestForwardScannedInput_A2ADuplicateKeysPolicyOnlyNotForwarded(t *testing.T) {
+	for _, tt := range a2aDuplicateKeyMessages {
+		t.Run(tt.name, func(t *testing.T) {
+			var serverIn bytes.Buffer
+			var logW bytes.Buffer
+			blockedCh := make(chan BlockedRequest, 1)
+
+			ForwardScannedInput(
+				transport.NewStdioReader(strings.NewReader(string(tt.msg)+"\n")),
+				transport.NewStdioWriter(&serverIn),
+				&logW,
+				config.ActionWarn,
+				config.ActionBlock,
+				blockedCh,
+				nil,
+				nil,
+				MCPProxyOpts{
+					Scanner:   testInputScanner(t),
+					PolicyCfg: a2aDuplicateKeyPolicy,
+				},
+			)
+
+			if serverIn.Len() > 0 {
+				t.Fatalf("unsafe duplicate-key request was forwarded upstream: %q", serverIn.String())
+			}
+			var gotBlocked bool
+			for br := range blockedCh {
+				gotBlocked = true
+				if br.ErrorCode != -32600 {
+					t.Fatalf("ErrorCode = %d, want -32600", br.ErrorCode)
+				}
+			}
+			if !gotBlocked {
+				t.Fatal("blockedCh produced no duplicate-key parse-error block")
+			}
+		})
+	}
+}

--- a/internal/mcp/pipeline_gates_identity_test.go
+++ b/internal/mcp/pipeline_gates_identity_test.go
@@ -279,6 +279,8 @@ func TestEvaluateSessionBinding_NoBaselineFailClosed(t *testing.T) {
 func TestEvaluateSessionBinding_A2AUnknownMethodWithBaseline(t *testing.T) {
 	baseline := tools.NewToolBaseline()
 	baseline.SetKnownA2AMethods([]string{"SendMessage"})
+	frame := MCPFrame{Method: "GetTask"}
+	enforcementIdentity := mcpFrameCollisionSafeCallableIdentity(frame, frame.Method)
 
 	if !baseline.HasA2AMethodBaseline() {
 		t.Fatal("expected A2A baseline to be established")
@@ -286,11 +288,14 @@ func TestEvaluateSessionBinding_A2AUnknownMethodWithBaseline(t *testing.T) {
 	if baseline.IsKnownA2AMethod("GetTask") {
 		t.Fatal("GetTask must not be known before exercising unknown-method path")
 	}
+	if want := a2aBaselineIdentity("GetTask"); enforcementIdentity != want {
+		t.Fatalf("production A2A identity = %q, want %q", enforcementIdentity, want)
+	}
 
 	action, reason := evaluateSessionBinding(sessionBindingCheck{
 		Baseline:            baseline,
-		Method:              "GetTask",
-		EnforcementIdentity: a2aBaselineIdentity("GetTask"),
+		Frame:               frame,
+		EnforcementIdentity: enforcementIdentity,
 		UnknownAction:       config.ActionWarn,
 		NoBaselineAction:    config.ActionBlock,
 	})
@@ -299,5 +304,43 @@ func TestEvaluateSessionBinding_A2AUnknownMethodWithBaseline(t *testing.T) {
 	}
 	if reason != bindingReasonUnknownTool {
 		t.Fatalf("reason = %q, want %q", reason, bindingReasonUnknownTool)
+	}
+}
+
+func TestEvaluateSessionBinding_EarlyReturnsNonBlocking(t *testing.T) {
+	baseline := tools.NewToolBaseline()
+	baseline.SetKnownTools([]string{"search"})
+
+	cases := []struct {
+		name  string
+		check sessionBindingCheck
+	}{
+		{
+			name: "nil baseline",
+			check: sessionBindingCheck{
+				Baseline:         nil,
+				Method:           methodToolsCall,
+				ToolName:         "search",
+				UnknownAction:    config.ActionBlock,
+				NoBaselineAction: config.ActionBlock,
+			},
+		},
+		{
+			name: "non-callable method",
+			check: sessionBindingCheck{
+				Baseline:         baseline,
+				Method:           "initialize",
+				UnknownAction:    config.ActionBlock,
+				NoBaselineAction: config.ActionBlock,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			action, reason := evaluateSessionBinding(tc.check)
+			if action != "" || reason != "" {
+				t.Fatalf("evaluateSessionBinding = (%q,%q), want non-blocking empty action and reason", action, reason)
+			}
+		})
 	}
 }

--- a/internal/mcp/pipeline_gates_identity_test.go
+++ b/internal/mcp/pipeline_gates_identity_test.go
@@ -121,7 +121,10 @@ func TestEvaluateMCPInputGates_HTTPBindingReservedPrefixIdentity(t *testing.T) {
 			msg:           a2aMethodMsg,
 			baselineTools: []string{reservedTool},
 			wantIdentity:  "a2a:message/send",
-			wantReason:    bindingReasonUnknownTool,
+			// No A2A method baseline was ever established (only MCP tools were
+			// seeded), so the correct classification is no-baseline, not
+			// unknown: an MCP tool inventory does not satisfy the A2A namespace.
+			wantReason: bindingReasonNoBaseline,
 		},
 		{
 			// Attack path: a reserved-prefix tools/call whose raw name is absent
@@ -171,6 +174,103 @@ func TestEvaluateMCPInputGates_HTTPBindingReservedPrefixIdentity(t *testing.T) {
 			}
 			if eval.BindingAction != config.ActionBlock {
 				t.Fatalf("BindingAction = %q, want %q", eval.BindingAction, config.ActionBlock)
+			}
+		})
+	}
+}
+
+func TestEvaluateMCPInputGates_A2ABindingAllowsPinnedMethodOnly(t *testing.T) {
+	knownMsg := testA2ARequest(1, testA2AMethod)
+	unknownMsg := testA2ARequest(2, testA2ASecondMethod)
+
+	baseline := tools.NewToolBaseline()
+	baseline.SetKnownTools([]string{"read_file"})
+	baseline.SetKnownA2AMethods([]string{testA2AMethod})
+
+	tests := []struct {
+		name       string
+		msg        []byte
+		wantReason string
+	}{
+		{
+			name:       "pinned a2a method allowed",
+			msg:        knownMsg,
+			wantReason: "",
+		},
+		{
+			name:       "unknown a2a method fails closed",
+			msg:        unknownMsg,
+			wantReason: bindingReasonUnknownTool,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frame := ParseMCPFrame(tt.msg)
+			eval := EvaluateMCPInputGates(
+				t.Context(),
+				frame,
+				tt.msg,
+				"session-1",
+				MCPProxyOpts{
+					ToolCfg: &tools.ToolScanConfig{
+						Baseline:                baseline,
+						BindingUnknownAction:    config.ActionBlock,
+						BindingNoBaselineAction: config.ActionBlock,
+					},
+				},
+				config.ActionBlock,
+				config.ActionBlock,
+				false,
+			)
+
+			if tt.wantReason == "" {
+				if eval.BindingReason != "" || eval.BindingAction != "" {
+					t.Fatalf("expected acceptance, got binding action=%q reason=%q", eval.BindingAction, eval.BindingReason)
+				}
+				return
+			}
+			if eval.BindingReason != tt.wantReason {
+				t.Fatalf("BindingReason = %q, want %q", eval.BindingReason, tt.wantReason)
+			}
+			if eval.BindingAction != config.ActionBlock {
+				t.Fatalf("BindingAction = %q, want %q", eval.BindingAction, config.ActionBlock)
+			}
+		})
+	}
+}
+
+// Regression for two fail-open holes: NoBaselineAction must fire independently
+// of UnknownAction, and A2A no-baseline must be decided only by the A2A method
+// baseline (an MCP tool baseline must not downgrade it to "unknown").
+func TestEvaluateSessionBinding_NoBaselineFailClosed(t *testing.T) {
+	empty := tools.NewToolBaseline()
+	mcpOnly := tools.NewToolBaseline()
+	mcpOnly.SetKnownTools([]string{"search"})
+	cases := []struct {
+		name       string
+		check      sessionBindingCheck
+		wantAction string
+		wantReason string
+	}{
+		{
+			name:       "toolcall pre-baseline blocks even with UnknownAction unset",
+			check:      sessionBindingCheck{Baseline: empty, Method: methodToolsCall, ToolName: "x", NoBaselineAction: config.ActionBlock, UnknownAction: ""},
+			wantAction: config.ActionBlock,
+			wantReason: bindingReasonNoBaseline,
+		},
+		{
+			name:       "a2a with mcp baseline but no a2a baseline uses NoBaselineAction, not UnknownAction",
+			check:      sessionBindingCheck{Baseline: mcpOnly, Method: "message/send", EnforcementIdentity: "a2a:message/send", NoBaselineAction: config.ActionBlock, UnknownAction: config.ActionAllow},
+			wantAction: config.ActionBlock,
+			wantReason: bindingReasonNoBaseline,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, r := evaluateSessionBinding(tc.check)
+			if a != tc.wantAction || r != tc.wantReason {
+				t.Fatalf("evaluateSessionBinding = (%q,%q), want (%q,%q)", a, r, tc.wantAction, tc.wantReason)
 			}
 		})
 	}

--- a/internal/mcp/pipeline_gates_identity_test.go
+++ b/internal/mcp/pipeline_gates_identity_test.go
@@ -275,3 +275,29 @@ func TestEvaluateSessionBinding_NoBaselineFailClosed(t *testing.T) {
 		})
 	}
 }
+
+func TestEvaluateSessionBinding_A2AUnknownMethodWithBaseline(t *testing.T) {
+	baseline := tools.NewToolBaseline()
+	baseline.SetKnownA2AMethods([]string{"SendMessage"})
+
+	if !baseline.HasA2AMethodBaseline() {
+		t.Fatal("expected A2A baseline to be established")
+	}
+	if baseline.IsKnownA2AMethod("GetTask") {
+		t.Fatal("GetTask must not be known before exercising unknown-method path")
+	}
+
+	action, reason := evaluateSessionBinding(sessionBindingCheck{
+		Baseline:            baseline,
+		Method:              "GetTask",
+		EnforcementIdentity: a2aBaselineIdentity("GetTask"),
+		UnknownAction:       config.ActionWarn,
+		NoBaselineAction:    config.ActionBlock,
+	})
+	if action != config.ActionWarn {
+		t.Fatalf("action = %q, want %q", action, config.ActionWarn)
+	}
+	if reason != bindingReasonUnknownTool {
+		t.Fatalf("reason = %q, want %q", reason, bindingReasonUnknownTool)
+	}
+}

--- a/internal/mcp/policy/policy.go
+++ b/internal/mcp/policy/policy.go
@@ -26,6 +26,7 @@ import (
 const (
 	uninspectableJSONDepthRule = "uninspectable_json_depth"
 	duplicateJSONKeyRule       = "duplicate_json_object_key"
+	malformedA2AParamsRule     = "malformed_a2a_params"
 )
 
 // shellExpansionRe matches shell variable expansions used as whitespace substitutes.
@@ -676,6 +677,9 @@ func (pc *Config) checkSingle(line []byte) Verdict {
 		errors.Is(err, &redact.BlockError{Reason: redact.ReasonDuplicateKey}) {
 		return duplicateJSONKeyVerdict()
 	}
+	if hasMalformedA2AParams(line) {
+		return malformedA2AParamsVerdict()
+	}
 	tc := parsePolicyCallable(line)
 	if tc == nil {
 		return Verdict{}
@@ -728,6 +732,40 @@ func duplicateJSONKeyVerdict() Verdict {
 		Action:  config.ActionBlock,
 		Rules:   []string{duplicateJSONKeyRule},
 	}
+}
+
+// malformedA2AParamsVerdict is a fail-closed result for known A2A methods with
+// present, non-null params that are not a JSON object. A2A policy rules inspect
+// object params; scalar and array params are malformed enough that skipping
+// policy would be fail-open.
+func malformedA2AParamsVerdict() Verdict {
+	return Verdict{
+		Matched: true,
+		Action:  config.ActionBlock,
+		Rules:   []string{malformedA2AParamsRule},
+	}
+}
+
+func hasMalformedA2AParams(line []byte) bool {
+	var rpc struct {
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(line, &rpc); err != nil {
+		return false
+	}
+	if _, ok := a2amethods.Canonical(rpc.Method); !ok {
+		return false
+	}
+	if len(rpc.Params) == 0 || bytes.Equal(bytes.TrimSpace(rpc.Params), []byte(jsonrpc.Null)) {
+		return false
+	}
+	return !rawMessageIsJSONObject(rpc.Params)
+}
+
+func rawMessageIsJSONObject(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) != 0 && trimmed[0] == '{'
 }
 
 func uninspectableStructuralArgsVerdict(ruleName string) Verdict {

--- a/internal/mcp/policy/policy.go
+++ b/internal/mcp/policy/policy.go
@@ -8,6 +8,7 @@ package policy
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"math/big"
 	"regexp"
@@ -19,9 +20,13 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/mcp/a2amethods"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/jsonrpc"
 	"github.com/luckyPipewrench/pipelock/internal/normalize"
+	"github.com/luckyPipewrench/pipelock/internal/redact"
 )
 
-const uninspectableJSONDepthRule = "uninspectable_json_depth"
+const (
+	uninspectableJSONDepthRule = "uninspectable_json_depth"
+	duplicateJSONKeyRule       = "duplicate_json_object_key"
+)
 
 // shellExpansionRe matches shell variable expansions used as whitespace substitutes.
 // Attackers use ${IFS} or $IFS to replace spaces: "rm${IFS}-rf" expands to "rm -rf"
@@ -667,6 +672,10 @@ func (pc *Config) CheckRequest(line []byte) Verdict {
 
 // checkSingle parses one JSON-RPC request and checks it against policy.
 func (pc *Config) checkSingle(line []byte) Verdict {
+	if err := redact.NoDuplicateJSONKeys(bytes.TrimSpace(line)); err != nil &&
+		errors.Is(err, &redact.BlockError{Reason: redact.ReasonDuplicateKey}) {
+		return duplicateJSONKeyVerdict()
+	}
 	tc := parsePolicyCallable(line)
 	if tc == nil {
 		return Verdict{}
@@ -706,6 +715,18 @@ func uninspectableJSONDepthVerdict() Verdict {
 		Matched: true,
 		Action:  config.ActionBlock,
 		Rules:   []string{uninspectableJSONDepthRule},
+	}
+}
+
+// duplicateJSONKeyVerdict is a defense-in-depth fail-closed result for direct
+// policy callers. The transport gates already block duplicate-key frames before
+// policy evaluation; keeping policy block-capable prevents future callers from
+// reintroducing a last-wins policy view against a first-wins upstream parser.
+func duplicateJSONKeyVerdict() Verdict {
+	return Verdict{
+		Matched: true,
+		Action:  config.ActionBlock,
+		Rules:   []string{duplicateJSONKeyRule},
 	}
 }
 

--- a/internal/mcp/policy/policy.go
+++ b/internal/mcp/policy/policy.go
@@ -16,6 +16,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/a2amethods"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/jsonrpc"
 	"github.com/luckyPipewrench/pipelock/internal/normalize"
 )
@@ -645,7 +646,7 @@ func canonicalStructuralValue(value interface{}) (string, bool) {
 }
 
 // CheckRequest evaluates a JSON-RPC request (single or batch) against policy.
-// Returns a clean verdict for non-tools/call methods and unparseable messages.
+// Returns a clean verdict for non-callable methods and unparseable messages.
 func (pc *Config) CheckRequest(line []byte) Verdict {
 	if pc == nil {
 		return Verdict{}
@@ -666,7 +667,7 @@ func (pc *Config) CheckRequest(line []byte) Verdict {
 
 // checkSingle parses one JSON-RPC request and checks it against policy.
 func (pc *Config) checkSingle(line []byte) Verdict {
-	tc := parseToolCall(line)
+	tc := parsePolicyCallable(line)
 	if tc == nil {
 		return Verdict{}
 	}
@@ -775,10 +776,11 @@ type toolCallParams struct {
 	Arguments json.RawMessage
 }
 
-// parseToolCall extracts tool name and arguments from a tools/call JSON-RPC request.
-// Returns nil if the method is not "tools/call", params don't contain a name field,
-// or the message can't be parsed.
-func parseToolCall(line []byte) *toolCallParams {
+// parsePolicyCallable extracts the callable name and arguments from a JSON-RPC
+// request. tools/call returns params.name and params.arguments; A2A methods
+// return the method name and params object. Returns nil when the method is not a
+// policy-scoped callable or the message cannot be parsed.
+func parsePolicyCallable(line []byte) *toolCallParams {
 	var rpc struct {
 		Method string          `json:"method"`
 		Params json.RawMessage `json:"params"`
@@ -787,7 +789,14 @@ func parseToolCall(line []byte) *toolCallParams {
 		return nil
 	}
 	if rpc.Method != "tools/call" {
-		return nil
+		canonical, ok := a2amethods.Canonical(rpc.Method)
+		if !ok {
+			return nil
+		}
+		return &toolCallParams{
+			Name:      canonical,
+			Arguments: rpc.Params,
+		}
 	}
 	if len(rpc.Params) == 0 || string(rpc.Params) == jsonrpc.Null {
 		return nil
@@ -808,6 +817,10 @@ func parseToolCall(line []byte) *toolCallParams {
 		Name:      params.Name,
 		Arguments: params.Arguments,
 	}
+}
+
+func parseToolCall(line []byte) *toolCallParams {
+	return parsePolicyCallable(line)
 }
 
 // actionRank maps action strings to strictness levels for comparison.

--- a/internal/mcp/policy/policy.go
+++ b/internal/mcp/policy/policy.go
@@ -673,9 +673,11 @@ func (pc *Config) CheckRequest(line []byte) Verdict {
 
 // checkSingle parses one JSON-RPC request and checks it against policy.
 func (pc *Config) checkSingle(line []byte) Verdict {
-	if err := redact.NoDuplicateJSONKeys(bytes.TrimSpace(line)); err != nil &&
-		errors.Is(err, &redact.BlockError{Reason: redact.ReasonDuplicateKey}) {
-		return duplicateJSONKeyVerdict()
+	if err := redact.NoDuplicateJSONKeys(bytes.TrimSpace(line)); err != nil {
+		var blockErr *redact.BlockError
+		if errors.As(err, &blockErr) && blockErr.Reason == redact.ReasonDuplicateKey {
+			return duplicateJSONKeyVerdict()
+		}
 	}
 	if hasMalformedA2AParams(line) {
 		return malformedA2AParamsVerdict()

--- a/internal/mcp/policy/policy.go
+++ b/internal/mcp/policy/policy.go
@@ -8,7 +8,6 @@ package policy
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"io"
 	"math/big"
 	"regexp"
@@ -674,8 +673,7 @@ func (pc *Config) CheckRequest(line []byte) Verdict {
 // checkSingle parses one JSON-RPC request and checks it against policy.
 func (pc *Config) checkSingle(line []byte) Verdict {
 	if err := redact.NoDuplicateJSONKeys(bytes.TrimSpace(line)); err != nil {
-		var blockErr *redact.BlockError
-		if errors.As(err, &blockErr) && blockErr.Reason == redact.ReasonDuplicateKey {
+		if redact.IsDuplicateKeyBlock(err) {
 			return duplicateJSONKeyVerdict()
 		}
 	}
@@ -762,12 +760,7 @@ func hasMalformedA2AParams(line []byte) bool {
 	if len(rpc.Params) == 0 || bytes.Equal(bytes.TrimSpace(rpc.Params), []byte(jsonrpc.Null)) {
 		return false
 	}
-	return !rawMessageIsJSONObject(rpc.Params)
-}
-
-func rawMessageIsJSONObject(raw json.RawMessage) bool {
-	trimmed := bytes.TrimSpace(raw)
-	return len(trimmed) != 0 && trimmed[0] == '{'
+	return !redact.IsJSONObject(rpc.Params)
 }
 
 func uninspectableStructuralArgsVerdict(ruleName string) Verdict {

--- a/internal/mcp/policy/policy_test.go
+++ b/internal/mcp/policy/policy_test.go
@@ -451,9 +451,65 @@ func TestCheckRequest_A2AMethodPolicyMatch(t *testing.T) {
 		})
 	}
 
-	nonA2A := []byte(`{"jsonrpc":"2.0","id":1,"method":"not/a2a","params":{"message":{"parts":[{"kind":"text","text":"deploy now"}]}}}`)
-	if v := pc.CheckRequest(nonA2A); v.Matched {
-		t.Fatalf("non-A2A method matched policy: %+v", v)
+	rejectPolicy := &Config{
+		Action: config.ActionWarn,
+		Rules: []*CompiledRule{{
+			Name:        "any-deploy",
+			ToolPattern: mustCompile(`.*`),
+			ArgPattern:  mustCompile(`deploy`),
+		}},
+	}
+	rejects := map[string][]byte{
+		"non-callable": []byte(`{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"file:///deploy"}}`),
+		"unknown-a2a":  []byte(`{"jsonrpc":"2.0","id":1,"method":"not/a2a","params":{"message":{"parts":[{"kind":"text","text":"deploy now"}]}}}`),
+	}
+	for name, req := range rejects {
+		t.Run(name, func(t *testing.T) {
+			if v := rejectPolicy.CheckRequest(req); v.Matched {
+				t.Fatalf("%s matched policy: %+v", name, v)
+			}
+		})
+	}
+}
+
+func TestCheckRequest_A2AMalformedParamsFailClosed(t *testing.T) {
+	pc := &Config{
+		Action: config.ActionWarn,
+		Rules: []*CompiledRule{{
+			Name:        "a2a-send",
+			ToolPattern: mustCompile(`^message/send$`),
+		}},
+	}
+
+	blocked := map[string][]byte{
+		"scalar": []byte(`{"jsonrpc":"2.0","id":1,"method":"message/send","params":"x"}`),
+		"array":  []byte(`{"jsonrpc":"2.0","id":1,"method":"message/send","params":[]}`),
+	}
+	for name, req := range blocked {
+		t.Run(name, func(t *testing.T) {
+			v := pc.CheckRequest(req)
+			if !v.Matched {
+				t.Fatal("malformed A2A params did not fail closed")
+			}
+			if v.Action != config.ActionBlock {
+				t.Fatalf("action = %q, want block", v.Action)
+			}
+			if got := strings.Join(v.Rules, ","); got != malformedA2AParamsRule {
+				t.Fatalf("rules = %q, want %s", got, malformedA2AParamsRule)
+			}
+		})
+	}
+
+	validObject := []byte(`{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"parts":[{"kind":"text","text":"x"}]}}}`)
+	v := pc.CheckRequest(validObject)
+	if !v.Matched {
+		t.Fatal("valid A2A object params did not match policy")
+	}
+	if v.Action != config.ActionWarn {
+		t.Fatalf("action = %q, want warn", v.Action)
+	}
+	if got := strings.Join(v.Rules, ","); got != "a2a-send" {
+		t.Fatalf("rules = %q, want a2a-send", got)
 	}
 }
 

--- a/internal/mcp/policy/policy_test.go
+++ b/internal/mcp/policy/policy_test.go
@@ -412,12 +412,48 @@ func TestCheckRequest_SingleRequest_NoMatch(t *testing.T) {
 	}
 }
 
-func TestCheckRequest_NonToolsCall_Skipped(t *testing.T) {
+func TestCheckRequest_NonCallableMethodSkipped(t *testing.T) {
 	pc := testConfig(t)
 	line := `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"file:///etc/shadow"}}`
 	v := pc.CheckRequest([]byte(line))
 	if v.Matched {
-		t.Error("non-tools/call should be skipped")
+		t.Error("non-callable method should be skipped")
+	}
+}
+
+func TestCheckRequest_A2AMethodPolicyMatch(t *testing.T) {
+	pc := New(config.MCPToolPolicy{
+		Enabled: true,
+		Action:  config.ActionWarn,
+		Rules: []config.ToolPolicyRule{{
+			Name:        "a2a-send-deploy",
+			ToolPattern: `^SendMessage$`,
+			ArgPattern:  `deploy`,
+		}},
+	})
+	requests := map[string][]byte{
+		"canonical": []byte(`{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"parts":[{"kind":"text","text":"deploy now"}]}}}`),
+		"case-fold": []byte(`{"jsonrpc":"2.0","id":1,"method":"sendmessage","params":{"message":{"parts":[{"kind":"text","text":"deploy now"}]}}}`),
+	}
+
+	for name, req := range requests {
+		t.Run(name, func(t *testing.T) {
+			v := pc.CheckRequest(req)
+			if !v.Matched {
+				t.Fatal("A2A method policy did not match")
+			}
+			if v.Action != config.ActionWarn {
+				t.Fatalf("action = %q, want warn", v.Action)
+			}
+			if got := strings.Join(v.Rules, ","); got != "a2a-send-deploy" {
+				t.Fatalf("rules = %q, want a2a-send-deploy", got)
+			}
+		})
+	}
+
+	nonA2A := []byte(`{"jsonrpc":"2.0","id":1,"method":"not/a2a","params":{"message":{"parts":[{"kind":"text","text":"deploy now"}]}}}`)
+	if v := pc.CheckRequest(nonA2A); v.Matched {
+		t.Fatalf("non-A2A method matched policy: %+v", v)
 	}
 }
 

--- a/internal/mcp/policy/policy_test.go
+++ b/internal/mcp/policy/policy_test.go
@@ -457,6 +457,30 @@ func TestCheckRequest_A2AMethodPolicyMatch(t *testing.T) {
 	}
 }
 
+func TestCheckRequest_DuplicateKeyFailsClosed(t *testing.T) {
+	pc := testConfig(t)
+	tests := map[string][]byte{
+		"tools-call": []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"bash","arguments":{"command":"echo ok"},"arguments":{"command":"echo hidden"}}}`),
+		"a2a":        []byte(`{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"parts":[{"kind":"text","text":"ok"}]},"message":{"parts":[{"kind":"text","text":"hidden"}]}}}`),
+		"batch":      []byte(`[{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}},{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bash","arguments":{"command":"echo ok"},"arguments":{"command":"echo hidden"}}}]`),
+	}
+
+	for name, req := range tests {
+		t.Run(name, func(t *testing.T) {
+			v := pc.CheckRequest(req)
+			if !v.Matched {
+				t.Fatal("duplicate-key request did not fail closed")
+			}
+			if v.Action != config.ActionBlock {
+				t.Fatalf("action = %q, want block", v.Action)
+			}
+			if got := strings.Join(v.Rules, ","); got != duplicateJSONKeyRule {
+				t.Fatalf("rules = %q, want %s", got, duplicateJSONKeyRule)
+			}
+		})
+	}
+}
+
 func TestCheckRequest_Batch_OneMatch(t *testing.T) {
 	pc := testConfig(t)
 	cmd := "rm" + " -rf /"

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -423,6 +423,12 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			// Runs after provenance so blocked responses don't poison the baseline.
 			toolInventoryDecision := ""
 			if toolResult.IsToolsList && toolCfg.Baseline != nil && len(toolResult.ToolNames) > 0 {
+				// Do NOT seed the A2A method inventory from tools/list: a
+				// tools/list response is an MCP tool inventory, not an A2A
+				// capability source, so an MCP tool named "SendMessage" would
+				// otherwise authorize the A2A SendMessage method (a cross-
+				// protocol namespace collision). A2A binding stays fail-closed
+				// until seeded from a validated A2A capability source.
 				hadBaseline := toolCfg.Baseline.HasBaseline()
 				if !hadBaseline {
 					toolCfg.Baseline.SetKnownTools(toolResult.ToolNames)

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -1077,6 +1077,13 @@ func TestScanHTTPInputDecision_A2APolicyDeferStoresRedactedParams(t *testing.T) 
 	if !strings.Contains(decision.Deferred.Arguments, mcpPlaceholderAWS) {
 		t.Fatalf("deferred A2A arguments missing redaction placeholder: %s", decision.Deferred.Arguments)
 	}
+	forwardMessage := string(decision.Deferred.ForwardMessage)
+	if strings.Contains(forwardMessage, secret) {
+		t.Fatalf("deferred A2A forward message leaked secret: %s", forwardMessage)
+	}
+	if !strings.Contains(forwardMessage, mcpPlaceholderAWS) {
+		t.Fatalf("deferred A2A forward message missing redaction placeholder: %s", forwardMessage)
+	}
 }
 
 func TestScanHTTPInput_PolicyRedirectMissingProfileBlocks(t *testing.T) {

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -1086,6 +1086,59 @@ func TestScanHTTPInputDecision_A2APolicyDeferStoresRedactedParams(t *testing.T) 
 	}
 }
 
+func TestScanHTTPInputDecision_A2AReceiptUsesCanonicalMethod(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	msg := []byte(`{"jsonrpc":"2.0","id":72,"method":"sendmessage","params":{"message":{"parts":[{"kind":"text","text":"deploy"}]}}}`)
+	resolutionPolicy := config.DeferResolutionPolicy{
+		AllowOn: config.DeferAllowOn{PolicyPermits: true},
+	}
+	policyCfg := &policy.Config{
+		Action: config.ActionWarn,
+		Rules: []*policy.CompiledRule{{
+			Name:             "defer-canonical-a2a",
+			ToolPattern:      regexp.MustCompile(`^SendMessage$`),
+			Action:           config.ActionDefer,
+			ResolutionPolicy: resolutionPolicy,
+		}},
+	}
+	manager := deferred.NewManager(deferred.Config{
+		Enabled:              true,
+		Timeout:              time.Second,
+		MaxPending:           4,
+		MaxPendingPerSession: 4,
+		MaxPendingBytes:      4096,
+	})
+	receiptEmitter, receiptRecorder, receiptDir := newTestReceiptEmitter(t)
+
+	decision := scanHTTPInputDecision(msg, io.Discard, "sess", "orig", MCPProxyOpts{
+		Scanner:        sc,
+		PolicyCfg:      policyCfg,
+		DeferManager:   manager,
+		ReceiptEmitter: receiptEmitter,
+		Transport:      deferred.SurfaceMCPHTTPUpstream,
+	})
+	if err := receiptRecorder.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	if decision.Blocked != nil {
+		t.Fatalf("A2A defer decision blocked: %+v", decision.Blocked)
+	}
+	if decision.Deferred == nil {
+		t.Fatal("expected deferred A2A request")
+	}
+	if decision.Deferred.Method != "SendMessage" {
+		t.Fatalf("deferred method = %q, want SendMessage", decision.Deferred.Method)
+	}
+	if decision.Deferred.BaselineIdentity != "a2a:SendMessage" {
+		t.Fatalf("deferred baseline identity = %q, want a2a:SendMessage", decision.Deferred.BaselineIdentity)
+	}
+
+	record := findActionReceiptHTTP(t, readReceiptEntriesHTTP(t, receiptDir)).ActionRecord
+	if record.Target != "SendMessage" {
+		t.Fatalf("receipt target = %q, want SendMessage", record.Target)
+	}
+}
+
 func TestScanHTTPInput_PolicyRedirectMissingProfileBlocks(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.Internal = nil

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -1021,6 +1021,64 @@ func TestScanHTTPInputDecision_PolicyDeferEmitsReceipt(t *testing.T) {
 	}
 }
 
+func TestScanHTTPInputDecision_A2APolicyDeferStoresRedactedParams(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	secret := mcpRedactionSecret()
+	msg := []byte(`{"jsonrpc":"2.0","id":71,"method":"SendMessage","params":{"message":{"parts":[{"kind":"text","text":"use ` + secret + ` to deploy"}]}}}`)
+	resolutionPolicy := config.DeferResolutionPolicy{
+		AllowOn: config.DeferAllowOn{PolicyPermits: true},
+	}
+	policyCfg := &policy.Config{
+		Action: config.ActionWarn,
+		Rules: []*policy.CompiledRule{{
+			Name:             "defer-redacted-a2a",
+			ToolPattern:      regexp.MustCompile(`^SendMessage$`),
+			ArgPattern:       regexp.MustCompile(regexp.QuoteMeta(mcpPlaceholderAWS)),
+			Action:           config.ActionDefer,
+			ResolutionPolicy: resolutionPolicy,
+		}},
+	}
+	manager := deferred.NewManager(deferred.Config{
+		Enabled:              true,
+		Timeout:              time.Second,
+		MaxPending:           4,
+		MaxPendingPerSession: 4,
+		MaxPendingBytes:      4096,
+	})
+	receiptEmitter, receiptRecorder, _ := newTestReceiptEmitter(t)
+
+	decision := scanHTTPInputDecision(msg, io.Discard, "sess", "orig", MCPProxyOpts{
+		Scanner:        sc,
+		PolicyCfg:      policyCfg,
+		RedactMatcher:  testRedactionMatcher(),
+		RedactLimits:   redact.DefaultLimits().ToLimits(),
+		DeferManager:   manager,
+		ReceiptEmitter: receiptEmitter,
+		Transport:      deferred.SurfaceMCPHTTPUpstream,
+	})
+	if err := receiptRecorder.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	if decision.Blocked != nil {
+		t.Fatalf("A2A defer decision blocked: %+v", decision.Blocked)
+	}
+	if decision.Deferred == nil {
+		t.Fatal("expected deferred A2A request")
+	}
+	if decision.Deferred.DeferID == "" {
+		t.Fatal("A2A deferred request has empty DeferID")
+	}
+	if decision.Deferred.Method != "SendMessage" {
+		t.Fatalf("deferred method = %q, want SendMessage", decision.Deferred.Method)
+	}
+	if strings.Contains(decision.Deferred.Arguments, secret) {
+		t.Fatalf("deferred A2A arguments leaked secret: %s", decision.Deferred.Arguments)
+	}
+	if !strings.Contains(decision.Deferred.Arguments, mcpPlaceholderAWS) {
+		t.Fatalf("deferred A2A arguments missing redaction placeholder: %s", decision.Deferred.Arguments)
+	}
+}
+
 func TestScanHTTPInput_PolicyRedirectMissingProfileBlocks(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.Internal = nil
@@ -1105,6 +1163,65 @@ func TestScanHTTPInput_PolicyRedirectSuccess(t *testing.T) {
 	}
 	if !strings.Contains(resp.Result.Content[0].Text, "safe output") {
 		t.Errorf("content = %q, want to contain 'safe output'", resp.Result.Content[0].Text)
+	}
+}
+
+func TestScanHTTPInputDecision_A2APolicyRedirectReceivesRedactedParams(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("exec test requires unix shell")
+	}
+	sc := testScannerForHTTP(t)
+	secret := mcpRedactionSecret()
+	msg := []byte(`{"jsonrpc":"2.0","id":72,"method":"SendMessage","params":{"message":{"parts":[{"kind":"text","text":"use ` + secret + ` to deploy"}]}}}`)
+	policyCfg := &policy.Config{
+		Action: config.ActionWarn,
+		RedirectProfiles: map[string]config.RedirectProfile{
+			"echo-args": {
+				Exec:         []string{"/bin/sh", "-c", `printf %s "$1"`, "pipelock-test"},
+				Reason:       "audited",
+				PreserveArgv: true,
+			},
+		},
+		Rules: []*policy.CompiledRule{{
+			Name:            "redirect-redacted-a2a",
+			ToolPattern:     regexp.MustCompile(`^SendMessage$`),
+			ArgPattern:      regexp.MustCompile(regexp.QuoteMeta(mcpPlaceholderAWS)),
+			Action:          config.ActionRedirect,
+			RedirectProfile: "echo-args",
+		}},
+	}
+
+	decision := scanHTTPInputDecision(msg, io.Discard, "sess", "orig", MCPProxyOpts{
+		Scanner:       sc,
+		PolicyCfg:     policyCfg,
+		RedactMatcher: testRedactionMatcher(),
+		RedactLimits:  redact.DefaultLimits().ToLimits(),
+	})
+	if decision.Blocked == nil {
+		t.Fatal("expected A2A redirect synthetic response")
+	}
+	if decision.Blocked.SyntheticResponse == nil {
+		t.Fatalf("expected synthetic response, got block: %+v", decision.Blocked)
+	}
+	var resp struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(decision.Blocked.SyntheticResponse, &resp); err != nil {
+		t.Fatalf("invalid synthetic response: %v", err)
+	}
+	if len(resp.Result.Content) == 0 {
+		t.Fatal("expected redirect content")
+	}
+	text := resp.Result.Content[0].Text
+	if strings.Contains(text, secret) {
+		t.Fatalf("redirect handler received leaked secret: %s", text)
+	}
+	if !strings.Contains(text, mcpPlaceholderAWS) {
+		t.Fatalf("redirect handler output missing redaction placeholder: %s", text)
 	}
 }
 

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -77,6 +77,48 @@ func testScannerWithAction(t *testing.T, action string) *scanner.Scanner {
 	return sc
 }
 
+// A tools/list response is an MCP tool inventory, not an A2A capability source.
+// Even a tool whose name collides with a known A2A method (e.g. "SendMessage")
+// must NOT be allowlisted as an A2A method, or a server-controlled tool
+// inventory could expand the authorized A2A surface (cross-protocol collision).
+func TestForwardScanned_DoesNotSeedA2AMethodsFromToolsList(t *testing.T) {
+	sc := testScannerWithAction(t, config.ActionBlock)
+	baseline := tools.NewToolBaseline()
+	toolCfg := &tools.ToolScanConfig{
+		Baseline: baseline,
+		Action:   config.ActionBlock,
+	}
+	resp := `{"jsonrpc":"2.0","id":1,"result":{"tools":[` +
+		`{"name":"SendMessage","description":"safe"},` +
+		`{"name":"GetTask","description":"safe"}` +
+		`]}}`
+
+	var out bytes.Buffer
+	found, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(resp+"\n")),
+		transport.NewStdioWriter(&out),
+		io.Discard,
+		nil,
+		MCPProxyOpts{Scanner: sc, ToolCfg: toolCfg},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if found {
+		t.Fatal("safe tools/list response reported injection")
+	}
+	if baseline.HasA2AMethodBaseline() {
+		t.Fatal("tools/list must not seed an A2A method baseline (cross-protocol collision)")
+	}
+	if baseline.IsKnownA2AMethod("SendMessage") {
+		t.Fatal("an MCP tool named SendMessage must not be authorized as the A2A SendMessage method")
+	}
+	// The MCP tool inventory itself is still seeded from tools/list.
+	if !baseline.HasBaseline() {
+		t.Fatal("tools/list should still seed the MCP tool baseline")
+	}
+}
+
 // cleanResponse is a JSON-RPC 2.0 response with safe text content.
 const cleanResponse = `{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"The weather is sunny today."}]}}`
 

--- a/internal/mcp/redaction.go
+++ b/internal/mcp/redaction.go
@@ -81,19 +81,7 @@ func applyMCPToolCallRedactionWithConfig(line []byte, cfg MCPRedactionConfig) ([
 	}
 
 	if IsA2AMethod(method) {
-		if err := redact.NoDuplicateJSONKeys(paramsRaw); err != nil && isDuplicateKeyBlock(err) {
-			return nil, nil, err
-		}
-
-		var params map[string]json.RawMessage
-		if err := json.Unmarshal(paramsRaw, &params); err != nil {
-			return nil, nil, &redact.BlockError{
-				Reason: redact.ReasonBodyUnparseable,
-				Detail: fmt.Sprintf("invalid A2A params object: %v", err),
-			}
-		}
-
-		rewrittenParams, report, err := redact.RewriteJSON(paramsRaw, cfg.Matcher, redact.NewRedactor(), cfg.Limits)
+		rewrittenParams, report, _, err := rewriteRedactableJSON(paramsRaw, cfg, "A2A params", false)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -135,13 +123,13 @@ func applyMCPToolCallRedactionWithConfig(line []byte, cfg MCPRedactionConfig) ([
 	if !ok || len(argsRaw) == 0 || string(argsRaw) == jsonrpc.Null {
 		return line, nil, nil
 	}
-	if !isJSONObjectRawMessage(argsRaw) {
-		return line, nil, nil
-	}
 
-	rewrittenArgs, report, err := redact.RewriteJSON(argsRaw, cfg.Matcher, redact.NewRedactor(), cfg.Limits)
+	rewrittenArgs, report, didRewrite, err := rewriteRedactableJSON(argsRaw, cfg, "tools/call arguments", true)
 	if err != nil {
 		return nil, nil, err
+	}
+	if !didRewrite {
+		return line, nil, nil
 	}
 	params["arguments"] = rewrittenArgs
 
@@ -171,6 +159,26 @@ func applyMCPToolCallRedactionWithConfig(line []byte, cfg MCPRedactionConfig) ([
 	_, _ = rewritten.Write(rewrittenLine)
 	_, _ = rewritten.Write(suffix)
 	return rewritten.Bytes(), report, nil
+}
+
+func rewriteRedactableJSON(raw json.RawMessage, cfg MCPRedactionConfig, objectKind string, skipOnNonObject bool) ([]byte, *redact.Report, bool, error) {
+	if err := redact.NoDuplicateJSONKeys(raw); err != nil && isDuplicateKeyBlock(err) {
+		return nil, nil, false, err
+	}
+	if !isJSONObjectRawMessage(raw) {
+		if skipOnNonObject {
+			return raw, nil, false, nil
+		}
+		return nil, nil, false, &redact.BlockError{
+			Reason: redact.ReasonBodyUnparseable,
+			Detail: fmt.Sprintf("invalid %s object: expected JSON object", objectKind),
+		}
+	}
+	rewritten, report, err := redact.RewriteJSON(raw, cfg.Matcher, redact.NewRedactor(), cfg.Limits)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return rewritten, report, true, nil
 }
 
 func marshalMCPMessage(v any) ([]byte, error) {

--- a/internal/mcp/redaction.go
+++ b/internal/mcp/redaction.go
@@ -12,10 +12,11 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 )
 
-// applyMCPToolCallRedaction rewrites tools/call params.arguments through the
-// shared redaction engine. A nil matcher disables the feature. Fail-closed:
-// malformed JSON-RPC envelopes or arguments that cannot be safely rewritten
-// return a *redact.BlockError.
+// applyMCPToolCallRedaction rewrites callable request params through the shared
+// redaction engine. tools/call rewrites params.arguments; A2A methods rewrite
+// params. A nil matcher disables the feature. Fail-closed: malformed JSON-RPC
+// envelopes or callable params that cannot be safely rewritten return a
+// *redact.BlockError.
 func applyMCPToolCallRedaction(line []byte, opts MCPProxyOpts) ([]byte, *redact.Report, error) {
 	return applyMCPToolCallRedactionWithConfig(line, opts.redactionConfig())
 }
@@ -70,13 +71,50 @@ func applyMCPToolCallRedactionWithConfig(line []byte, cfg MCPRedactionConfig) ([
 	if err := json.Unmarshal(methodRaw, &method); err != nil {
 		return line, nil, nil
 	}
-	if method != methodToolsCall {
+	if method != methodToolsCall && !IsA2AMethod(method) {
 		return line, nil, nil
 	}
 
 	paramsRaw, ok := env["params"]
 	if !ok || len(paramsRaw) == 0 || string(paramsRaw) == jsonrpc.Null {
 		return line, nil, nil
+	}
+
+	if IsA2AMethod(method) {
+		if err := redact.NoDuplicateJSONKeys(paramsRaw); err != nil && isDuplicateKeyBlock(err) {
+			return nil, nil, err
+		}
+
+		var params map[string]json.RawMessage
+		if err := json.Unmarshal(paramsRaw, &params); err != nil {
+			return nil, nil, &redact.BlockError{
+				Reason: redact.ReasonBodyUnparseable,
+				Detail: fmt.Sprintf("invalid A2A params object: %v", err),
+			}
+		}
+
+		rewrittenParams, report, err := redact.RewriteJSON(paramsRaw, cfg.Matcher, redact.NewRedactor(), cfg.Limits)
+		if err != nil {
+			return nil, nil, err
+		}
+		env["params"] = rewrittenParams
+
+		rewrittenLine, err := marshalMCPMessage(env)
+		if err != nil {
+			return nil, nil, &redact.BlockError{
+				Reason:             redact.ReasonRemarshalFailed,
+				MatchesBeforeBlock: reportTotal(report),
+				Detail:             fmt.Sprintf("marshal rewritten A2A message: %v", err),
+			}
+		}
+		if len(prefix) == 0 && len(suffix) == 0 {
+			return rewrittenLine, report, nil
+		}
+		var rewritten bytes.Buffer
+		_, _ = rewritten.Write(prefix)
+		_, _ = rewritten.Write(rewrittenLine)
+		_, _ = rewritten.Write(suffix)
+		return rewritten.Bytes(), report, nil
 	}
 
 	// Same dup-key trap on params: a duplicate `arguments` could hide

--- a/internal/mcp/redaction.go
+++ b/internal/mcp/redaction.go
@@ -48,7 +48,7 @@ func applyMCPToolCallRedactionWithConfig(line []byte, cfg MCPRedactionConfig) ([
 	// differential. external review C-1. Only block on actual duplicate-key
 	// matches; let malformed-JSON errors flow through to the existing
 	// parse-error path so the BlockError reason stays attributable.
-	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && isDuplicateKeyBlock(err) {
+	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && redact.IsDuplicateKeyBlock(err) {
 		return nil, nil, err
 	}
 
@@ -107,7 +107,7 @@ func applyMCPToolCallRedactionWithConfig(line []byte, cfg MCPRedactionConfig) ([
 
 	// Same dup-key trap on params: a duplicate `arguments` could hide
 	// secret-bearing args behind a benign sibling that wins last-wins.
-	if err := redact.NoDuplicateJSONKeys(paramsRaw); err != nil && isDuplicateKeyBlock(err) {
+	if err := redact.NoDuplicateJSONKeys(paramsRaw); err != nil && redact.IsDuplicateKeyBlock(err) {
 		return nil, nil, err
 	}
 
@@ -162,10 +162,10 @@ func applyMCPToolCallRedactionWithConfig(line []byte, cfg MCPRedactionConfig) ([
 }
 
 func rewriteRedactableJSON(raw json.RawMessage, cfg MCPRedactionConfig, objectKind string, skipOnNonObject bool) ([]byte, *redact.Report, bool, error) {
-	if err := redact.NoDuplicateJSONKeys(raw); err != nil && isDuplicateKeyBlock(err) {
+	if err := redact.NoDuplicateJSONKeys(raw); err != nil && redact.IsDuplicateKeyBlock(err) {
 		return nil, nil, false, err
 	}
-	if !isJSONObjectRawMessage(raw) {
+	if !redact.IsJSONObject(raw) {
 		if skipOnNonObject {
 			return raw, nil, false, nil
 		}
@@ -200,9 +200,4 @@ func reportTotal(report *redact.Report) int {
 
 func isNullRawMessage(raw json.RawMessage) bool {
 	return len(raw) != 0 && bytes.Equal(bytes.TrimSpace(raw), []byte(jsonrpc.Null))
-}
-
-func isJSONObjectRawMessage(raw json.RawMessage) bool {
-	trimmed := bytes.TrimSpace(raw)
-	return len(trimmed) != 0 && trimmed[0] == '{'
 }

--- a/internal/mcp/redaction_test.go
+++ b/internal/mcp/redaction_test.go
@@ -101,7 +101,7 @@ func TestApplyMCPToolCallRedaction_A2ADuplicateParamsFailClosed(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected duplicate-key block error")
 	}
-	if !isDuplicateKeyBlock(err) {
+	if !redact.IsDuplicateKeyBlock(err) {
 		t.Fatalf("expected duplicate-key block error, got %T: %v", err, err)
 	}
 }

--- a/internal/mcp/redaction_test.go
+++ b/internal/mcp/redaction_test.go
@@ -42,6 +42,70 @@ func TestApplyMCPToolCallRedaction_PreservesWhitespace(t *testing.T) {
 	}
 }
 
+func TestApplyMCPToolCallRedaction_RedactsA2AParams(t *testing.T) {
+	secret := mcpRedactionSecret()
+	line := []byte("  " +
+		`{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"messageId":"msg-1","role":"user","parts":[{"kind":"text","text":"use ` +
+		secret + ` to deploy"}]}}}` + "\n")
+
+	rewritten, report, err := applyMCPToolCallRedaction(line, MCPProxyOpts{
+		RedactMatcher: testRedactionMatcher(),
+		RedactLimits:  redact.DefaultLimits().ToLimits(),
+	})
+	if err != nil {
+		t.Fatalf("applyMCPToolCallRedaction: %v", err)
+	}
+	if !bytes.HasPrefix(rewritten, []byte("  ")) {
+		t.Fatalf("rewritten line lost leading whitespace: %q", string(rewritten))
+	}
+	if !bytes.HasSuffix(rewritten, []byte("\n")) {
+		t.Fatalf("rewritten line lost trailing newline: %q", string(rewritten))
+	}
+	if bytes.Contains(rewritten, []byte(secret)) {
+		t.Fatalf("rewritten A2A line leaked secret: %s", rewritten)
+	}
+	if !bytes.Contains(rewritten, []byte(mcpPlaceholderAWS)) {
+		t.Fatalf("rewritten A2A line missing placeholder: %s", rewritten)
+	}
+	if reportTotal(report) != 1 {
+		t.Fatalf("report total = %d, want 1", reportTotal(report))
+	}
+}
+
+func TestApplyMCPToolCallRedaction_A2AMalformedParamsFailClosed(t *testing.T) {
+	line := []byte(`{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":"oops"}`)
+
+	_, _, err := applyMCPToolCallRedaction(line, MCPProxyOpts{
+		RedactMatcher: testRedactionMatcher(),
+		RedactLimits:  redact.DefaultLimits().ToLimits(),
+	})
+	if err == nil {
+		t.Fatal("expected block error")
+	}
+	var blockErr *redact.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %T", err)
+	}
+	if blockErr.Reason != redact.ReasonBodyUnparseable {
+		t.Fatalf("reason = %q, want %q", blockErr.Reason, redact.ReasonBodyUnparseable)
+	}
+}
+
+func TestApplyMCPToolCallRedaction_A2ADuplicateParamsFailClosed(t *testing.T) {
+	line := []byte(`{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"parts":[{"kind":"text","text":"safe"}]},"message":{"parts":[{"kind":"text","text":"secret"}]}}}`)
+
+	_, _, err := applyMCPToolCallRedaction(line, MCPProxyOpts{
+		RedactMatcher: testRedactionMatcher(),
+		RedactLimits:  redact.DefaultLimits().ToLimits(),
+	})
+	if err == nil {
+		t.Fatal("expected duplicate-key block error")
+	}
+	if !isDuplicateKeyBlock(err) {
+		t.Fatalf("expected duplicate-key block error, got %T: %v", err, err)
+	}
+}
+
 func TestApplyMCPToolCallRedaction_NonToolsCallBypasses(t *testing.T) {
 	line := []byte(" " + jsonToolsList + "\n")
 

--- a/internal/mcp/redirect.go
+++ b/internal/mcp/redirect.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/a2amethods"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/jsonrpc"
 )
 
@@ -71,23 +72,30 @@ type RedirectResult struct {
 	LatencyMs int64
 }
 
-// extractToolCallFields extracts the tool name and arguments JSON from a
-// tools/call JSON-RPC request. Returns empty strings if parsing fails.
+// extractToolCallFields extracts the callable target and argument JSON from a
+// JSON-RPC request. tools/call returns params.name and params.arguments; A2A
+// methods return the method name and params object. Returns empty strings if
+// parsing fails.
 func extractToolCallFields(line []byte) (toolName string, argsJSON string) {
-	var rpc struct {
-		Params struct {
-			Name      string          `json:"name"`
-			Arguments json.RawMessage `json:"arguments"`
-		} `json:"params"`
-	}
-	if err := json.Unmarshal(line, &rpc); err != nil {
+	frame := ParseMCPFrame(line)
+	if frame.ParseErr != nil {
 		return "", ""
 	}
-	args := string(rpc.Params.Arguments)
-	if args == "" || args == jsonrpc.Null {
-		args = "{}"
+	if frame.IsToolsCall() {
+		args := string(frame.Args)
+		if args == "" || args == jsonrpc.Null {
+			args = "{}"
+		}
+		return frame.ToolCallName, args
 	}
-	return rpc.Params.Name, args
+	if canonical, ok := a2amethods.Canonical(frame.Method); ok {
+		args := mcpFrameCallableArgs(frame)
+		if args == "" || args == jsonrpc.Null {
+			args = "{}"
+		}
+		return canonical, args
+	}
+	return "", ""
 }
 
 // executeRedirect runs a redirect profile handler and returns a synthetic

--- a/internal/mcp/redirect_test.go
+++ b/internal/mcp/redirect_test.go
@@ -221,6 +221,18 @@ func TestExtractToolCallFields_Valid(t *testing.T) {
 	}
 }
 
+func TestExtractToolCallFields_A2AParams(t *testing.T) {
+	line := []byte(`{"jsonrpc":"2.0","id":1,"method":"sendmessage","params":{"message":{"messageId":"msg-1","role":"user","parts":[{"kind":"text","text":"hello"}]}}}`)
+	name, args := extractToolCallFields(line)
+	if name != "SendMessage" {
+		t.Errorf("name = %q, want SendMessage", name)
+	}
+	want := `{"message":{"messageId":"msg-1","role":"user","parts":[{"kind":"text","text":"hello"}]}}`
+	if args != want {
+		t.Errorf("args = %q, want %s", args, want)
+	}
+}
+
 func TestExtractToolCallFields_InvalidJSON(t *testing.T) {
 	name, args := extractToolCallFields([]byte(`not json`))
 	if name != "" || args != "" {

--- a/internal/mcp/scan.go
+++ b/internal/mcp/scan.go
@@ -68,7 +68,7 @@ func ScanResponseOpts(line []byte, sc *scanner.Scanner, opts ResponseScanOptions
 	if len(trimmed) > 0 && trimmed[0] == '[' {
 		return scanBatch(trimmed, sc, opts)
 	}
-	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && isDuplicateKeyBlock(err) {
+	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && redact.IsDuplicateKeyBlock(err) {
 		return jsonrpc.ScanVerdict{
 			ID:    recoverTopLevelJSONRPCID(trimmed),
 			Clean: false,
@@ -218,7 +218,7 @@ func isToolsListResponse(line []byte) bool {
 // like result.note or result.cursor, so those must be scanned.
 func scanToolsListNonToolFields(line []byte, sc *scanner.Scanner, opts ResponseScanOptions) jsonrpc.ScanVerdict {
 	trimmed := bytes.TrimSpace(line)
-	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && isDuplicateKeyBlock(err) {
+	if err := redact.NoDuplicateJSONKeys(trimmed); err != nil && redact.IsDuplicateKeyBlock(err) {
 		return jsonrpc.ScanVerdict{
 			ID:    recoverTopLevelJSONRPCID(trimmed),
 			Clean: false,

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/luckyPipewrench/pipelock/internal/mcp/a2amethods"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/jsonrpc"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/provenance"
 	"github.com/luckyPipewrench/pipelock/internal/normalize"
@@ -103,7 +104,9 @@ type ToolBaseline struct {
 	descs       map[string]string   // tool name → last known description text
 	params      map[string][]string // tool name → last known parameter names (sorted)
 	knownTools  map[string]bool     // session binding: tool name set from first tools/list
+	knownA2A    map[string]bool     // session binding: A2A method identity set from trusted inventory
 	hasBaseline bool                // true after first SetKnownTools call
+	hasA2A      bool                // true after first SetKnownA2AMethods call
 }
 
 // NewToolBaseline creates a new empty tool baseline.
@@ -118,6 +121,15 @@ func NewToolBaseline() *ToolBaseline {
 // maxBaselineTools caps the number of tracked tools to prevent unbounded
 // memory growth from a malicious server sending unlimited unique tool names.
 const maxBaselineTools = 10000
+
+const a2aMethodIdentityPrefix = "a2a:"
+
+func baselineInventoryMapCapacity(n int) int {
+	if n > maxBaselineTools {
+		return maxBaselineTools
+	}
+	return n
+}
 
 // ShouldSkip returns true if the tool name is unknown and the baseline is at
 // capacity. Callers should skip expensive hash computation in this case to
@@ -358,7 +370,7 @@ func (tb *ToolBaseline) SetKnownTools(names []string) {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 	if tb.knownTools == nil {
-		tb.knownTools = make(map[string]bool, len(names))
+		tb.knownTools = make(map[string]bool, baselineInventoryMapCapacity(len(names)))
 	}
 	for _, n := range names {
 		if !tb.knownTools[n] && len(tb.knownTools) >= maxBaselineTools {
@@ -369,6 +381,32 @@ func (tb *ToolBaseline) SetKnownTools(names []string) {
 	tb.hasBaseline = true
 }
 
+// SetKnownA2AMethods sets the session baseline from a trusted response-derived
+// A2A method inventory. Methods are stored in the same namespaced identity form
+// used by the MCP input gates, case-folded to match A2A method detection.
+// Subsequent calls add newly seen methods. Respects maxBaselineTools to prevent
+// unbounded memory growth. Unknown method names and reserved-prefix tool
+// identities are ignored so an attacker-influenced inventory cannot create
+// arbitrary allowlist entries.
+func (tb *ToolBaseline) SetKnownA2AMethods(methods []string) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	if tb.knownA2A == nil {
+		tb.knownA2A = make(map[string]bool, baselineInventoryMapCapacity(len(methods)))
+	}
+	for _, method := range methods {
+		identity := a2aInventoryMethodIdentity(method)
+		if identity == "" {
+			continue
+		}
+		if !tb.knownA2A[identity] && len(tb.knownA2A) >= maxBaselineTools {
+			break
+		}
+		tb.knownA2A[identity] = true
+	}
+	tb.hasA2A = true
+}
+
 // HasBaseline reports whether a tool inventory baseline has been established.
 func (tb *ToolBaseline) HasBaseline() bool {
 	tb.mu.Lock()
@@ -376,11 +414,27 @@ func (tb *ToolBaseline) HasBaseline() bool {
 	return tb.hasBaseline
 }
 
+// HasA2AMethodBaseline reports whether an A2A method inventory baseline has
+// been established.
+func (tb *ToolBaseline) HasA2AMethodBaseline() bool {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	return tb.hasA2A
+}
+
 // IsKnownTool reports whether the given tool name is in the session baseline.
 func (tb *ToolBaseline) IsKnownTool(name string) bool {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 	return tb.knownTools[name]
+}
+
+// IsKnownA2AMethod reports whether the given A2A method identity is in the
+// session baseline.
+func (tb *ToolBaseline) IsKnownA2AMethod(method string) bool {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	return tb.knownA2A[a2aMethodIdentity(method)]
 }
 
 // CheckNewTools compares a list of tool names against the baseline and returns
@@ -400,6 +454,31 @@ func (tb *ToolBaseline) CheckNewTools(names []string) []string {
 		}
 	}
 	return added
+}
+
+func a2aMethodIdentity(method string) string {
+	method = strings.TrimSpace(method)
+	if method == "" {
+		return ""
+	}
+	if strings.HasPrefix(method, a2aMethodIdentityPrefix) {
+		method = strings.TrimSpace(strings.TrimPrefix(method, a2aMethodIdentityPrefix))
+	}
+	if !a2amethods.Is(method) {
+		return ""
+	}
+	return a2aMethodIdentityPrefix + strings.ToLower(method)
+}
+
+func a2aInventoryMethodIdentity(method string) string {
+	method = strings.TrimSpace(method)
+	if method == "" || strings.HasPrefix(method, a2aMethodIdentityPrefix) {
+		return ""
+	}
+	if !a2amethods.Is(method) {
+		return ""
+	}
+	return a2aMethodIdentityPrefix + strings.ToLower(method)
 }
 
 // compiledToolPattern is a precompiled regex for tool-specific poisoning detection.

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -394,6 +394,7 @@ func (tb *ToolBaseline) SetKnownA2AMethods(methods []string) {
 	if tb.knownA2A == nil {
 		tb.knownA2A = make(map[string]bool, baselineInventoryMapCapacity(len(methods)))
 	}
+	added := false
 	for _, method := range methods {
 		identity := a2aInventoryMethodIdentity(method)
 		if identity == "" {
@@ -402,9 +403,14 @@ func (tb *ToolBaseline) SetKnownA2AMethods(methods []string) {
 		if !tb.knownA2A[identity] && len(tb.knownA2A) >= maxBaselineTools {
 			break
 		}
+		if !tb.knownA2A[identity] {
+			added = true
+		}
 		tb.knownA2A[identity] = true
 	}
-	tb.hasA2A = true
+	if added {
+		tb.hasA2A = true
+	}
 }
 
 // HasBaseline reports whether a tool inventory baseline has been established.

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -2423,6 +2423,87 @@ func TestToolBaseline_KnownToolsCap(t *testing.T) {
 	}
 }
 
+func TestToolBaseline_A2AMethodInventory(t *testing.T) {
+	tb := NewToolBaseline()
+
+	if tb.HasA2AMethodBaseline() {
+		t.Error("expected no A2A baseline before SetKnownA2AMethods")
+	}
+	if tb.IsKnownA2AMethod("SendMessage") {
+		t.Error("expected unknown A2A method before baseline")
+	}
+
+	tb.SetKnownA2AMethods([]string{"SendMessage"})
+
+	if !tb.HasA2AMethodBaseline() {
+		t.Fatal("expected A2A baseline after SetKnownA2AMethods")
+	}
+	if !tb.IsKnownA2AMethod("SendMessage") {
+		t.Error("expected SendMessage to be known")
+	}
+	if !tb.IsKnownA2AMethod("a2a:SendMessage") {
+		t.Error("expected namespaced SendMessage identity to be known")
+	}
+	if !tb.IsKnownA2AMethod("sendmessage") {
+		t.Error("expected case-folded SendMessage to be known")
+	}
+	if tb.IsKnownA2AMethod("GetTask") {
+		t.Error("expected GetTask to be unknown")
+	}
+	tb.SetKnownA2AMethods([]string{"GetTask"})
+	if !tb.IsKnownA2AMethod("GetTask") {
+		t.Error("expected subsequent A2A inventory to add GetTask")
+	}
+
+	poisoned := NewToolBaseline()
+	poisoned.SetKnownA2AMethods([]string{"SendMessage", "StealEverything"})
+	if poisoned.IsKnownA2AMethod("StealEverything") {
+		t.Fatal("unknown A2A method was injected into the allowlist")
+	}
+
+	prefixed := NewToolBaseline()
+	prefixed.SetKnownA2AMethods([]string{"a2a:SendMessage"})
+	if prefixed.IsKnownA2AMethod("SendMessage") {
+		t.Fatal("reserved-prefix tool name was injected into the A2A allowlist")
+	}
+}
+
+func TestToolBaseline_A2AMethodInventoryCap(t *testing.T) {
+	tb := NewToolBaseline()
+
+	methods := make([]string, maxBaselineTools)
+	for i := range methods {
+		methods[i] = "SendMessage"
+	}
+	tb.SetKnownA2AMethods(methods)
+
+	if !tb.HasA2AMethodBaseline() {
+		t.Fatal("expected A2A baseline after SetKnownA2AMethods")
+	}
+	if len(tb.knownA2A) != 1 {
+		t.Fatalf("duplicate methods should collapse to one identity, got %d", len(tb.knownA2A))
+	}
+}
+
+func TestToolBaseline_InventoryMapCapacityClamped(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{name: "below cap", in: 7, want: 7},
+		{name: "at cap", in: maxBaselineTools, want: maxBaselineTools},
+		{name: "above cap", in: maxBaselineTools + 1, want: maxBaselineTools},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := baselineInventoryMapCapacity(tt.in); got != tt.want {
+				t.Fatalf("baselineInventoryMapCapacity(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestToolScanResult_ToolNames(t *testing.T) {
 	// Verify ScanTools populates ToolNames from tools/list responses.
 	cfg := config.Defaults()

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -2466,6 +2466,15 @@ func TestToolBaseline_A2AMethodInventory(t *testing.T) {
 	if prefixed.IsKnownA2AMethod("SendMessage") {
 		t.Fatal("reserved-prefix tool name was injected into the A2A allowlist")
 	}
+	if prefixed.HasA2AMethodBaseline() {
+		t.Fatal("invalid-only A2A inventory established a baseline")
+	}
+
+	invalidOnly := NewToolBaseline()
+	invalidOnly.SetKnownA2AMethods([]string{"", "StealEverything", "a2a:GetTask"})
+	if invalidOnly.HasA2AMethodBaseline() {
+		t.Fatal("invalid-only A2A inventory established a baseline")
+	}
 }
 
 func TestToolBaseline_A2AMethodInventoryCap(t *testing.T) {

--- a/internal/redact/helpers.go
+++ b/internal/redact/helpers.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+)
+
+// IsDuplicateKeyBlock reports whether err is the specific NoDuplicateJSONKeys
+// outcome for an actual duplicate object member name.
+func IsDuplicateKeyBlock(err error) bool {
+	var be *BlockError
+	if !errors.As(err, &be) {
+		return false
+	}
+	return be.Reason == ReasonDuplicateKey
+}
+
+// IsJSONObject reports whether raw is shaped like a JSON object.
+func IsJSONObject(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) != 0 && trimmed[0] == '{'
+}

--- a/internal/redact/helpers_test.go
+++ b/internal/redact/helpers_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package redact
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestIsDuplicateKeyBlock(t *testing.T) {
+	err := NoDuplicateJSONKeys([]byte(`{"a":1,"a":2}`))
+	if !IsDuplicateKeyBlock(err) {
+		t.Fatalf("IsDuplicateKeyBlock(%v) = false, want true", err)
+	}
+	if IsDuplicateKeyBlock(&BlockError{Reason: ReasonBodyUnparseable}) {
+		t.Fatal("body-unparseable block must not be classified as duplicate-key block")
+	}
+	if IsDuplicateKeyBlock(errors.New("boom")) {
+		t.Fatal("non-BlockError must not be classified as duplicate-key block")
+	}
+}
+
+func TestIsJSONObject(t *testing.T) {
+	tests := map[string]struct {
+		raw  json.RawMessage
+		want bool
+	}{
+		"object":          {raw: json.RawMessage(`{"a":1}`), want: true},
+		"spaced object":   {raw: json.RawMessage(" \n\t{}"), want: true},
+		"array":           {raw: json.RawMessage(`[]`), want: false},
+		"null":            {raw: json.RawMessage(`null`), want: false},
+		"empty":           {raw: nil, want: false},
+		"malformed shape": {raw: json.RawMessage(`{`), want: true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := IsJSONObject(tt.raw); got != tt.want {
+				t.Fatalf("IsJSONObject(%q) = %v, want %v", string(tt.raw), got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

This gives agent-to-agent (A2A) methods the same content scanning and session-binding treatment as MCP `tools/call`, closing a redaction bypass and making the A2A binding inventory usable.

Previously the redaction, redirect, and defer paths extracted only `tools/call` fields, so a secret carried in an A2A method's params was forwarded unredacted. A2A method params are now redacted and scanned on all three paths, and A2A methods are reachable through policy matching so the redirect and defer extraction is live rather than latent.

Session binding gains a positive A2A method inventory backed by a fixed known-method allowlist, so binding can pin recognized A2A methods rather than treating every A2A call as unknown. The inventory is deliberately NOT seeded from an MCP `tools/list` response, because a tool inventory is not an A2A capability source and a tool named `SendMessage` must not authorize the A2A `SendMessage` method (a cross-protocol namespace collision). Until a validated, A2A-scoped capability source is wired, A2A session binding remains fail-closed for A2A methods; the inventory plumbing and its capacity bound are in place for that follow-up. A2A method names are canonicalized before detection, policy matching, redirect targets, and binding identity, so a case variant cannot be classified as A2A for one purpose while evading a rule written against the canonical name.

Regression tests prove an A2A secret is redacted on the redaction, redirect, and defer paths, that a tool named `SendMessage` in a tools/list response is not authorized as an A2A method, that method canonicalization is consistent, and that A2A policy matching is reachable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded policy evaluation to support additional A2A JSON-RPC methods with canonical, case-insensitive matching.
  * Added trusted A2A method allowlisting for session-binding enforcement.
  * Improved handling of deferred and redirected A2A requests (canonical method/identity, correct action propagation).
  * Enhanced redaction to rewrite secrets inside A2A request parameters while preserving redaction outputs in deferred/redirected flows.
* **Bug Fixes**
  * Prevented `tools/list` from seeding or authorizing A2A method baselines.
  * Tightened fail-closed session-binding decisions for missing/unpinned A2A baselines, including reserved-prefix cases.
  * Enforced fail-closed behavior for malformed A2A parameters and duplicate JSON keys across pipeline entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->