### PR TITLE
harden(conductor): honest fleet provenance and fail-closed rollback ordering

### DIFF
--- a/enterprise/conductor/controlplane/dryrun.go
+++ b/enterprise/conductor/controlplane/dryrun.go
@@ -29,6 +29,9 @@ const (
 	// EmergencyConflictStaleCounter: the monotonic counter does not exceed the
 	// highest counter already stored for this org/fleet.
 	EmergencyConflictStaleCounter = "stale_counter"
+	// RollbackConflictHeadPreviewFailed: the emergency authorization exists but
+	// the rollback-head preview path could not re-derive the apply side.
+	RollbackConflictHeadPreviewFailed = "head_preview_failed"
 )
 
 // PublishEvaluation is the read-only verdict a publish dry-run or replay reports.
@@ -414,7 +417,7 @@ func (h *Handler) replayPublish(w http.ResponseWriter, r *http.Request, bundle c
 		return
 	}
 	result.Recorded = recorded
-	if recorded != nil && recorded.Accepted && !eval.Valid {
+	if recorded != nil && recorded.Accepted && !eval.Valid && !result.Divergence {
 		result.Divergence = true
 		result.DivergenceReason = "recorded as accepted but re-derived decision would reject (" + eval.Conflict + ")"
 	}
@@ -482,10 +485,6 @@ func (h *Handler) replayRemoteKill(w http.ResponseWriter, r *http.Request, msg c
 		writeStoreError(w, err)
 		return
 	}
-	if err := msg.VerifySignaturesAt(now, h.emergencyKeys); err != nil {
-		writeStoreError(w, err)
-		return
-	}
 	hash, err := msg.CanonicalHash()
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
@@ -495,6 +494,18 @@ func (h *Handler) replayRemoteKill(w http.ResponseWriter, r *http.Request, msg c
 		ActionKind:   actionKindRemoteKill,
 		ArtifactHash: hash,
 		ReplayedAt:   now,
+	}
+	recorded, err := h.recordedRemoteKill(r.Context(), hash)
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	result.Recorded = recorded
+	if err := msg.VerifySignaturesAt(now, h.emergencyKeys); err != nil {
+		if recorded == nil || !recorded.Accepted {
+			writeStoreError(w, err)
+			return
+		}
 	}
 	eval := &RemoteKillEvaluation{}
 	preview, err := previewer.PreviewRemoteKill(r.Context(), msg, now)
@@ -509,14 +520,7 @@ func (h *Handler) replayRemoteKill(w http.ResponseWriter, r *http.Request, msg c
 		*eval = remoteKillEvaluationFrom(preview, false)
 	}
 	result.RemoteKill = eval
-
-	recorded, err := h.recordedRemoteKill(r.Context(), hash)
-	if err != nil {
-		writeStoreError(w, err)
-		return
-	}
-	result.Recorded = recorded
-	if recorded != nil && recorded.Accepted && !eval.Valid {
+	if recorded != nil && recorded.Accepted && !eval.Valid && !result.Divergence {
 		result.Divergence = true
 		result.DivergenceReason = "recorded as accepted but re-derived decision would reject (" + eval.Conflict + ")"
 	}
@@ -524,6 +528,23 @@ func (h *Handler) replayRemoteKill(w http.ResponseWriter, r *http.Request, msg c
 }
 
 func (h *Handler) recordedRemoteKill(ctx context.Context, hash string) (*RecordedDecision, error) {
+	if lister, ok := h.emergencyControls.(recordedRemoteKillEnumerator); ok {
+		records, err := lister.RecordedRemoteKills(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, record := range records {
+			if record.MessageHash == hash {
+				return &RecordedDecision{
+					Present:      true,
+					Accepted:     true,
+					RecordedHash: record.MessageHash,
+					PublishedAt:  record.PublishedAt,
+				}, nil
+			}
+		}
+		return nil, nil
+	}
 	lister, ok := h.emergencyControls.(remoteKillEnumerator)
 	if !ok {
 		return nil, nil
@@ -572,10 +593,6 @@ func (h *Handler) replayRollback(w http.ResponseWriter, r *http.Request, auth co
 		writeStoreError(w, err)
 		return
 	}
-	if err := auth.VerifySignaturesAt(now, h.emergencyKeys); err != nil {
-		writeStoreError(w, err)
-		return
-	}
 	hash, err := auth.CanonicalHash()
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
@@ -586,14 +603,32 @@ func (h *Handler) replayRollback(w http.ResponseWriter, r *http.Request, auth co
 		ArtifactHash: hash,
 		ReplayedAt:   now,
 	}
+	recorded, err := h.recordedRollback(r.Context(), hash)
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	result.Recorded = recorded
+	if err := auth.VerifySignaturesAt(now, h.emergencyKeys); err != nil {
+		if recorded == nil || !recorded.Accepted {
+			writeStoreError(w, err)
+			return
+		}
+	}
 	eval := &RollbackEvaluation{}
 	authPreview, err := authPreviewer.PreviewRollbackAuthorization(r.Context(), auth, now)
 	switch {
 	case err == nil:
 		headPreview, headErr := headPreviewer.PreviewRollbackHead(r.Context(), auth)
 		if headErr != nil {
-			writeStoreError(w, headErr)
-			return
+			if recorded == nil || !recorded.Accepted {
+				writeStoreError(w, headErr)
+				return
+			}
+			*eval = RollbackEvaluation{Valid: false, Conflict: RollbackConflictHeadPreviewFailed, Counter: auth.Counter}
+			result.Divergence = true
+			result.DivergenceReason = "recorded as accepted but rollback head preview failed (" + headErr.Error() + ")"
+			break
 		}
 		*eval = rollbackEvaluationFrom(authPreview, headPreview, false)
 	case errors.Is(err, ErrEmergencyConflict) || errors.Is(err, ErrEmergencyStaleCounter):
@@ -603,14 +638,7 @@ func (h *Handler) replayRollback(w http.ResponseWriter, r *http.Request, auth co
 		return
 	}
 	result.Rollback = eval
-
-	recorded, err := h.recordedRollback(r.Context(), hash)
-	if err != nil {
-		writeStoreError(w, err)
-		return
-	}
-	result.Recorded = recorded
-	if recorded != nil && recorded.Accepted && !eval.Valid {
+	if recorded != nil && recorded.Accepted && !eval.Valid && !result.Divergence {
 		result.Divergence = true
 		result.DivergenceReason = "recorded as accepted but re-derived decision would reject (" + eval.Conflict + ")"
 	}
@@ -618,6 +646,23 @@ func (h *Handler) replayRollback(w http.ResponseWriter, r *http.Request, auth co
 }
 
 func (h *Handler) recordedRollback(ctx context.Context, hash string) (*RecordedDecision, error) {
+	if lister, ok := h.emergencyControls.(recordedRollbackAuthorizationEnumerator); ok {
+		records, err := lister.RecordedRollbackAuthorizations(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, record := range records {
+			if record.AuthorizationHash == hash {
+				return &RecordedDecision{
+					Present:      true,
+					Accepted:     true,
+					RecordedHash: record.AuthorizationHash,
+					PublishedAt:  record.PublishedAt,
+				}, nil
+			}
+		}
+		return nil, nil
+	}
 	lister, ok := h.emergencyControls.(rollbackAuthorizationEnumerator)
 	if !ok {
 		return nil, nil

--- a/enterprise/conductor/controlplane/dryrun.go
+++ b/enterprise/conductor/controlplane/dryrun.go
@@ -7,6 +7,7 @@ package controlplane
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -625,9 +626,16 @@ func (h *Handler) replayRollback(w http.ResponseWriter, r *http.Request, auth co
 				writeStoreError(w, headErr)
 				return
 			}
+			// Do not serialize the store error into the response: backend
+			// errors can carry paths/keys/operational internals. Return a
+			// stable reason plus the structured conflict code, log details
+			// server-side.
+			if h.logger != nil {
+				h.logger.ErrorContext(r.Context(), "conductor_rollback_replay_head_preview_failed", slog.String("error", headErr.Error()))
+			}
 			*eval = RollbackEvaluation{Valid: false, Conflict: RollbackConflictHeadPreviewFailed, Counter: auth.Counter}
 			result.Divergence = true
-			result.DivergenceReason = "recorded as accepted but rollback head preview failed (" + headErr.Error() + ")"
+			result.DivergenceReason = "recorded as accepted but rollback head preview failed"
 			break
 		}
 		*eval = rollbackEvaluationFrom(authPreview, headPreview, false)

--- a/enterprise/conductor/controlplane/dryrun_test.go
+++ b/enterprise/conductor/controlplane/dryrun_test.go
@@ -1255,6 +1255,83 @@ func TestReplayRollback_Divergence(t *testing.T) {
 	}
 }
 
+func TestReplayRollback_HeadPreviewFailureReturnsStructuredDivergence(t *testing.T) {
+	store := mustStore(t)
+	current, target := seedRollbackReplayBundles(t, store, "rb-replay-head-preview")
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rb-replay-head-preview", current, target, testNow)
+	emergency := mustEmergencyStore(t)
+	if _, created, err := emergency.PublishRollbackAuthorization(context.Background(), auth, testNow); err != nil || !created {
+		t.Fatalf("seed rollback created=%v err=%v, want created", created, err)
+	}
+	handler := newDryRunTestHandler(t, rollbackHeadPreviewErrorStore{BundleStore: store, err: errDryRunTestStore}, emergency, resolver)
+
+	w := replayJSON(t, handler, decisionReplayRequest{Rollback: &auth}, true, false)
+	if w.Code != http.StatusOK {
+		t.Fatalf("rollback replay head-preview code=%d body=%s, want 200 structured divergence", w.Code, w.Body.String())
+	}
+	result := decodeReplay(t, w)
+	if result.Recorded == nil || !result.Recorded.Accepted {
+		t.Fatalf("rollback replay head-preview recorded=%+v, want present+accepted", result.Recorded)
+	}
+	if result.Rollback == nil || result.Rollback.Valid || result.Rollback.Conflict != RollbackConflictHeadPreviewFailed {
+		t.Fatalf("rollback replay head-preview eval=%+v, want valid=false conflict=head_preview_failed", result.Rollback)
+	}
+	if !result.Divergence || result.DivergenceReason == "" {
+		t.Fatalf("rollback replay head-preview divergence=%v reason=%q, want structured divergence", result.Divergence, result.DivergenceReason)
+	}
+}
+
+func TestReplayRollback_HistoricalRecordedDecisionSurvivesExpiredKey(t *testing.T) {
+	store := mustStore(t)
+	current, target := seedRollbackReplayBundles(t, store, "rb-replay-historical-key")
+	recordedAt := testNow.Add(-30 * time.Minute)
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rb-replay-historical-key", current, target, recordedAt)
+	expiringResolver := resolverWithKeyNotAfter(t, resolver, testNow.Add(-15*time.Minute))
+	emergency := mustEmergencyStore(t)
+	if _, created, err := emergency.PublishRollbackAuthorization(context.Background(), auth, recordedAt); err != nil || !created {
+		t.Fatalf("seed rollback created=%v err=%v, want created", created, err)
+	}
+	handler := newDryRunTestHandler(t, store, emergency, expiringResolver)
+
+	w := replayJSON(t, handler, decisionReplayRequest{Rollback: &auth}, true, false)
+	if w.Code != http.StatusOK {
+		t.Fatalf("rollback replay expired-key code=%d body=%s, want 200", w.Code, w.Body.String())
+	}
+	result := decodeReplay(t, w)
+	if result.Recorded == nil || !result.Recorded.Accepted {
+		t.Fatalf("rollback replay expired-key recorded=%+v, want present+accepted historical decision", result.Recorded)
+	}
+}
+
+func TestReplayRollback_HistoricalRecordedDecisionRejectsRevokedKey(t *testing.T) {
+	store := mustStore(t)
+	current, target := seedRollbackReplayBundles(t, store, "rb-replay-revoked-key")
+	recordedAt := testNow.Add(-30 * time.Minute)
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rb-replay-revoked-key", current, target, recordedAt)
+	revokedResolver := resolverWithKeyRevokedAt(t, resolver, testNow.Add(-15*time.Minute))
+	emergency := mustEmergencyStore(t)
+	if _, created, err := emergency.PublishRollbackAuthorization(context.Background(), auth, recordedAt); err != nil || !created {
+		t.Fatalf("seed rollback created=%v err=%v, want created", created, err)
+	}
+	handler := newDryRunTestHandler(t, store, emergency, revokedResolver)
+	hash, err := auth.CanonicalHash()
+	if err != nil {
+		t.Fatalf("CanonicalHash(rollback): %v", err)
+	}
+	recorded, err := handler.recordedRollback(context.Background(), hash)
+	if err != nil {
+		t.Fatalf("recordedRollback(revoked): %v", err)
+	}
+	if recorded != nil {
+		t.Fatalf("recordedRollback(revoked) = %+v, want nil because revocation overrides historical replay", recorded)
+	}
+
+	w := replayJSON(t, handler, decisionReplayRequest{Rollback: &auth}, true, false)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("rollback replay revoked-key code=%d body=%s, want 422", w.Code, w.Body.String())
+	}
+}
+
 func TestReplayRollback_UnknownArtifact_EvaluationOnly(t *testing.T) {
 	store := mustStore(t)
 	current, target := seedRollbackReplayBundles(t, store, "rb-replay-unknown")
@@ -1592,6 +1669,31 @@ func resignRollbackAuthorization(t *testing.T, auth *conductor.RollbackAuthoriza
 		t.Fatalf("rollback authorization VerifySignaturesAt() error = %v", err)
 	}
 	return resolver
+}
+
+func resolverWithKeyNotAfter(t *testing.T, inner conductor.SignatureKeyResolver, notAfter time.Time) conductor.SignatureKeyResolver {
+	t.Helper()
+	return func(keyID string) (conductor.SignatureKey, error) {
+		key, err := inner(keyID)
+		if err != nil {
+			return conductor.SignatureKey{}, err
+		}
+		key.NotAfter = notAfter.UTC()
+		return key, nil
+	}
+}
+
+func resolverWithKeyRevokedAt(t *testing.T, inner conductor.SignatureKeyResolver, revokedAt time.Time) conductor.SignatureKeyResolver {
+	t.Helper()
+	revoked := revokedAt.UTC()
+	return func(keyID string) (conductor.SignatureKey, error) {
+		key, err := inner(keyID)
+		if err != nil {
+			return conductor.SignatureKey{}, err
+		}
+		key.RevokedAt = &revoked
+		return key, nil
+	}
 }
 
 // TestDryRunReplay_NoSecretsInResponsesOrLogs proves invariant 6: no signing

--- a/enterprise/conductor/controlplane/dryrun_test.go
+++ b/enterprise/conductor/controlplane/dryrun_test.go
@@ -1279,6 +1279,12 @@ func TestReplayRollback_HeadPreviewFailureReturnsStructuredDivergence(t *testing
 	if !result.Divergence || result.DivergenceReason == "" {
 		t.Fatalf("rollback replay head-preview divergence=%v reason=%q, want structured divergence", result.Divergence, result.DivergenceReason)
 	}
+	// The raw backend store error must not leak into the caller-visible
+	// response: it can carry paths, keys, or operational internals. The
+	// DivergenceReason must be the stable canned string only.
+	if strings.Contains(result.DivergenceReason, errDryRunTestStore.Error()) || strings.Contains(w.Body.String(), errDryRunTestStore.Error()) {
+		t.Fatalf("raw store error leaked into replay response: reason=%q body=%s", result.DivergenceReason, w.Body.String())
+	}
 }
 
 func TestReplayRollback_HistoricalRecordedDecisionSurvivesExpiredKey(t *testing.T) {

--- a/enterprise/conductor/controlplane/emergency_verified.go
+++ b/enterprise/conductor/controlplane/emergency_verified.go
@@ -77,6 +77,14 @@ type rawRemoteKillEnumerator interface {
 	enumerateRemoteKills(context.Context) ([]StoredRemoteKill, error)
 }
 
+type recordedRollbackAuthorizationEnumerator interface {
+	RecordedRollbackAuthorizations(context.Context) ([]StoredRollbackAuthorization, error)
+}
+
+type recordedRemoteKillEnumerator interface {
+	RecordedRemoteKills(context.Context) ([]StoredRemoteKill, error)
+}
+
 // newVerifiedEmergencyStore wraps an EmergencyStore in the signature-verifying
 // view. inner==nil yields nil (the Handler treats a nil store as "no emergency
 // controls configured", same as before). resolve may be nil/empty; in that case
@@ -335,6 +343,59 @@ func (v *verifiedEmergencyStore) verifiedRemoteKills(ctx context.Context, now ti
 		}
 	}
 	return verified, nil
+}
+
+// RecordedRollbackAuthorizations returns records that verify at their recorded
+// acceptance time. It is for replay/inspection only; live serving continues to
+// use RollbackAuthorizations, which verifies at current wall-clock time.
+func (v *verifiedEmergencyStore) RecordedRollbackAuthorizations(ctx context.Context) ([]StoredRollbackAuthorization, error) {
+	if v.enumRoll == nil {
+		return nil, nil
+	}
+	records, err := v.enumRoll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	verified := make([]StoredRollbackAuthorization, 0, len(records))
+	for _, record := range records {
+		if v.verifyRollback(record, rollbackRecordVerificationTime(record)) {
+			verified = append(verified, record)
+		}
+	}
+	return verified, nil
+}
+
+// RecordedRemoteKills mirrors RecordedRollbackAuthorizations for remote-kill
+// replay/inspection.
+func (v *verifiedEmergencyStore) RecordedRemoteKills(ctx context.Context) ([]StoredRemoteKill, error) {
+	if v.enumKills == nil {
+		return nil, nil
+	}
+	records, err := v.enumKills(ctx)
+	if err != nil {
+		return nil, err
+	}
+	verified := make([]StoredRemoteKill, 0, len(records))
+	for _, record := range records {
+		if v.verifyRemoteKill(record, remoteKillRecordVerificationTime(record)) {
+			verified = append(verified, record)
+		}
+	}
+	return verified, nil
+}
+
+func rollbackRecordVerificationTime(record StoredRollbackAuthorization) time.Time {
+	if !record.PublishedAt.IsZero() {
+		return record.PublishedAt.UTC()
+	}
+	return record.Authorization.CreatedAt.UTC()
+}
+
+func remoteKillRecordVerificationTime(record StoredRemoteKill) time.Time {
+	if !record.PublishedAt.IsZero() {
+		return record.PublishedAt.UTC()
+	}
+	return record.Message.CreatedAt.UTC()
 }
 
 // RollbackAuthorizations satisfies rollbackAuthorizationEnumerator. It returns

--- a/enterprise/conductor/controlplane/emergency_verified_test.go
+++ b/enterprise/conductor/controlplane/emergency_verified_test.go
@@ -9,9 +9,11 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -326,8 +328,16 @@ func TestVerifiedEmergencyStore_LegitRecordStillApplies(t *testing.T) {
 	}
 	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "vstore-rollback", v2, v1, testNow)
 	handler := newTestHandlerWithOptions(t, store, nil, resolver)
-	if _, created, err := handler.emergencyControls.PublishRollbackAuthorization(t.Context(), auth, testNow); err != nil || !created {
-		t.Fatalf("PublishRollbackAuthorization created=%v err=%v", created, err)
+	body, err := json.Marshal(publishRollbackAuthorizationRequest{Authorization: auth})
+	if err != nil {
+		t.Fatalf("Marshal(rollback): %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, bytes.NewReader(body))
+	req.Header.Set("X-Pipelock-Admin", "ok")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("rollback publish status=%d body=%s, want 201", resp.Code, resp.Body.String())
 	}
 	w := latestPolicyBundle(t, handler, nil)
 	assertLatestBundleID(t, w, "vstore-v1")

--- a/enterprise/conductor/controlplane/followers.go
+++ b/enterprise/conductor/controlplane/followers.go
@@ -137,13 +137,20 @@ func (h *Handler) enrichFollowerStatus(r *http.Request, query FollowerListQuery,
 			signedPtr = &signedCopy
 		}
 		expected := expectedBundleForFollower(streams, follower, now)
-		health, drift := classifyFollowerHealth(follower, statusPtr, expected, now, defaultRuntimeStatusStaleAfter)
+		health, drift, source := classifyFollowerFleetStatus(follower, statusPtr, signedPtr, expected, now, defaultRuntimeStatusStaleAfter)
+		var driftSource *FleetFieldProvenance
+		if drift != "" {
+			sourceCopy := source
+			driftSource = &sourceCopy
+		}
 		out = append(out, FollowerFleetStatus{
 			FollowerSummary:    follower,
 			RuntimeStatus:      statusPtr,
 			SignedAppliedState: signedPtr,
 			Health:             health,
+			HealthSource:       source,
 			Drift:              drift,
+			DriftSource:        driftSource,
 			ExpectedBundle:     expected,
 		})
 	}

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -1056,8 +1056,19 @@ func (h *Handler) handlePublishRollbackAuthorization(w http.ResponseWriter, r *h
 		writeError(w, http.StatusInternalServerError, ErrRollbackHeadPreviewUnsupported)
 		return
 	}
-	if _, err := headPreviewer.PreviewRollbackHead(r.Context(), req.Authorization); err != nil {
+	prePreview, err := headPreviewer.PreviewRollbackHead(r.Context(), req.Authorization)
+	if err != nil {
 		writeStoreError(w, err)
+		return
+	}
+	// Fail fast when the rollback is already superseded by a later forward
+	// publish at preview time. Noop is set only for that case (an already-at-
+	// target idempotent retry returns a non-noop apply verdict), and the
+	// hash-mismatch guard keeps the legitimate already-at-target case out. This
+	// avoids durably accepting then compensating-clearing an authorization that
+	// cannot move the head, mirroring the post-apply supersession check below.
+	if prePreview.Noop && prePreview.CurrentHeadHash != prePreview.WouldRollToHash {
+		writeStoreError(w, fmt.Errorf("%w: rollback superseded by current stream head", ErrBundleConflict))
 		return
 	}
 	if previewer, ok := h.emergencyControls.(rollbackAuthPreviewer); ok && previewer != nil {

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -1071,17 +1071,34 @@ func (h *Handler) handlePublishRollbackAuthorization(w http.ResponseWriter, r *h
 		writeStoreError(w, err)
 		return
 	}
+	// The auth is now durably recorded as accepted. If the head does not end up
+	// at the rollback target (apply failure or a concurrent forward-publish
+	// supersede), compensate by clearing the just-created record so replay and
+	// audit never report an accepted-but-unapplied rollback. Best-effort: a
+	// failed clear is logged and the record remains for the operator clear path.
+	failClosed := func(cause error) {
+		if created {
+			if clearer, ok := h.emergencyControls.(rollbackClearer); ok && clearer != nil {
+				if _, clearErr := clearer.ClearRollbackAuthorization(r.Context(), record.Authorization.AuthorizationID); clearErr != nil && h.logger != nil {
+					h.logger.ErrorContext(r.Context(), "conductor_rollback_compensating_clear_failed",
+						slog.String("authorization_id", record.Authorization.AuthorizationID),
+						slog.String("error", clearErr.Error()))
+				}
+			}
+		}
+		writeStoreError(w, cause)
+	}
 	if err := h.store.ApplyRollbackHead(r.Context(), req.Authorization, now); err != nil {
-		writeStoreError(w, err)
+		failClosed(err)
 		return
 	}
 	applied, err := headPreviewer.PreviewRollbackHead(r.Context(), req.Authorization)
 	if err != nil {
-		writeStoreError(w, err)
+		failClosed(err)
 		return
 	}
 	if applied.CurrentHeadHash != applied.WouldRollToHash {
-		writeStoreError(w, fmt.Errorf("%w: rollback superseded by current stream head", ErrBundleConflict))
+		failClosed(fmt.Errorf("%w: rollback superseded by current stream head", ErrBundleConflict))
 		return
 	}
 	status := http.StatusOK

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -789,10 +789,14 @@ func (h *Handler) publishPreflight(r *http.Request, bundle conductor.PolicyBundl
 		StaleAfterSeconds: int(defaultRuntimeStatusStaleAfter / time.Second),
 	}
 	if h.enrollments == nil {
+		baseSummary.Unavailable = true
+		baseSummary.UnavailableReason = "enrollment_store_unavailable"
 		return baseSummary, fmt.Errorf("%w: enrollment store unavailable", ErrRuntimeStatusStoreRequired)
 	}
 	statusStore, ok := h.enrollments.(RuntimeStatusStore)
 	if !ok || statusStore == nil {
+		baseSummary.Unavailable = true
+		baseSummary.UnavailableReason = "runtime_status_store_unavailable"
 		return baseSummary, fmt.Errorf("%w: runtime status store unavailable", ErrRuntimeStatusStoreRequired)
 	}
 	followerQuery := FollowerListQuery{
@@ -897,11 +901,6 @@ func (h *Handler) handleLatestPolicyBundle(w http.ResponseWriter, r *http.Reques
 		writeStoreError(w, err)
 		return
 	}
-	record, err = h.applyRollbackCeiling(r, identity, record, now)
-	if err != nil {
-		writeStoreError(w, err)
-		return
-	}
 	etag := fmt.Sprintf("%q", record.BundleHash)
 	if ifNoneMatchMatches(r.Header.Get("If-None-Match"), etag) {
 		w.Header().Set("ETag", etag)
@@ -910,41 +909,6 @@ func (h *Handler) handleLatestPolicyBundle(w http.ResponseWriter, r *http.Reques
 	}
 	w.Header().Set("ETag", etag)
 	writeJSON(w, http.StatusOK, record.Bundle)
-}
-
-func (h *Handler) applyRollbackCeiling(r *http.Request, identity FollowerIdentity, latest PublishedBundle, now time.Time) (PublishedBundle, error) {
-	if h.emergencyControls == nil {
-		return latest, nil
-	}
-	rollback, ok, err := h.emergencyControls.ActiveRollbackForFollower(r.Context(), identity, now)
-	if err != nil {
-		return PublishedBundle{}, err
-	}
-	if !ok {
-		return latest, nil
-	}
-	auth := rollback.Authorization
-	if latest.Bundle.Version > auth.CurrentVersion {
-		return latest, nil
-	}
-	current, err := h.store.BundleByIDVersion(r.Context(), auth.CurrentBundleID, auth.CurrentVersion)
-	if err != nil {
-		if errors.Is(err, ErrBundleNotFound) {
-			return PublishedBundle{}, fmt.Errorf("active rollback current unavailable: %w", err)
-		}
-		return PublishedBundle{}, err
-	}
-	target, err := h.store.BundleByIDVersion(r.Context(), auth.TargetBundleID, auth.TargetVersion)
-	if err != nil {
-		if errors.Is(err, ErrBundleNotFound) {
-			return PublishedBundle{}, fmt.Errorf("active rollback target unavailable: %w", err)
-		}
-		return PublishedBundle{}, err
-	}
-	if current.StreamKey != latest.StreamKey || target.StreamKey != latest.StreamKey {
-		return latest, nil
-	}
-	return target, nil
 }
 
 func (h *Handler) handleRemoteKill(w http.ResponseWriter, r *http.Request) {
@@ -1087,6 +1051,21 @@ func (h *Handler) handlePublishRollbackAuthorization(w http.ResponseWriter, r *h
 		h.respondRollbackDryRun(w, r, req.Authorization, now)
 		return
 	}
+	headPreviewer, ok := h.store.(rollbackHeadPreviewer)
+	if !ok || headPreviewer == nil {
+		writeError(w, http.StatusInternalServerError, ErrRollbackHeadPreviewUnsupported)
+		return
+	}
+	if _, err := headPreviewer.PreviewRollbackHead(r.Context(), req.Authorization); err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	if previewer, ok := h.emergencyControls.(rollbackAuthPreviewer); ok && previewer != nil {
+		if _, err := previewer.PreviewRollbackAuthorization(r.Context(), req.Authorization, now); err != nil {
+			writeStoreError(w, err)
+			return
+		}
+	}
 	record, created, err := h.emergencyControls.PublishRollbackAuthorization(r.Context(), req.Authorization, now)
 	if err != nil {
 		writeStoreError(w, err)
@@ -1094,6 +1073,15 @@ func (h *Handler) handlePublishRollbackAuthorization(w http.ResponseWriter, r *h
 	}
 	if err := h.store.ApplyRollbackHead(r.Context(), req.Authorization, now); err != nil {
 		writeStoreError(w, err)
+		return
+	}
+	applied, err := headPreviewer.PreviewRollbackHead(r.Context(), req.Authorization)
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	if applied.CurrentHeadHash != applied.WouldRollToHash {
+		writeStoreError(w, fmt.Errorf("%w: rollback superseded by current stream head", ErrBundleConflict))
 		return
 	}
 	status := http.StatusOK
@@ -1194,7 +1182,44 @@ func (h *Handler) handleLatestRollbackAuthorization(w http.ResponseWriter, r *ht
 		writeStoreError(w, err)
 		return
 	}
+	active, err := h.rollbackAuthorizationActiveOnBundleHead(r.Context(), identity, record.Authorization, h.now())
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	if !active {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 	writeJSON(w, http.StatusOK, record.Authorization)
+}
+
+func (h *Handler) rollbackAuthorizationActiveOnBundleHead(ctx context.Context, identity FollowerIdentity, auth conductor.RollbackAuthorization, now time.Time) (bool, error) {
+	latest, err := h.store.Latest(ctx, identity, now)
+	if err != nil {
+		if errors.Is(err, ErrBundleNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	current, err := h.store.BundleByIDVersion(ctx, auth.CurrentBundleID, auth.CurrentVersion)
+	if err != nil {
+		if errors.Is(err, ErrBundleNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	target, err := h.store.BundleByIDVersion(ctx, auth.TargetBundleID, auth.TargetVersion)
+	if err != nil {
+		if errors.Is(err, ErrBundleNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	if current.StreamKey != latest.StreamKey || target.StreamKey != latest.StreamKey {
+		return false, nil
+	}
+	return latest.BundleHash == target.BundleHash, nil
 }
 
 func rollbackLookupFromRequest(r *http.Request) (RollbackLookup, error) {

--- a/enterprise/conductor/controlplane/handler_test.go
+++ b/enterprise/conductor/controlplane/handler_test.go
@@ -535,6 +535,145 @@ func TestHandlerPublishRollbackAuthorizationClearFailureResidualRecordIsNotServe
 	}
 }
 
+func TestHandlerPublishRollbackAuthorizationSupersededAtPreviewFailsFastWithoutRecord(t *testing.T) {
+	base := mustStore(t)
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-handler-preview-superseded-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := base.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-handler-preview-superseded-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - api2.example.com\n",
+	})
+	r2, _, err := base.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)})
+	if err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	v3 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-handler-preview-superseded-v3",
+		version:      3,
+		previousHash: r2.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - api3.example.com\n",
+	})
+	if _, _, err := base.Publish(t.Context(), v3, PublishOptions{Now: testNow.Add(2 * time.Minute)}); err != nil {
+		t.Fatalf("Publish(v3) error = %v", err)
+	}
+	// The authorization was signed to roll v2 -> v1, but the stream head has
+	// already advanced to v3, so the rollback can never move the head. The
+	// request must fail fast at preview time and never durably accept an
+	// authorization it cannot apply (no accept-then-compensating-clear churn).
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rollback-handler-preview-superseded", v2, v1, testNow)
+	// Spy on ApplyRollbackHead: the fast-fail must reject the superseded request
+	// before any apply is attempted. Without the fast-fail the request would
+	// still end at 409 (via the post-apply supersession check) after a wasted
+	// accept+apply+compensating-clear, so asserting apply is never called is
+	// what actually pins the fast-fail behavior.
+	store := &applyRollbackSpyStore{FileBundleStore: base}
+	handler := newTestHandlerWithOptions(t, store, nil, resolver)
+	body, err := json.Marshal(publishRollbackAuthorizationRequest{Authorization: auth})
+	if err != nil {
+		t.Fatalf("Marshal(rollback): %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, strings.NewReader(string(body)))
+	req.Header.Set("X-Pipelock-Admin", "ok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("rollback superseded-at-preview status=%d body=%s, want 409", w.Code, w.Body.String())
+	}
+	if got := store.applyCalls(); got != 0 {
+		t.Fatalf("ApplyRollbackHead called %d times for a superseded-at-preview request, want 0 (fast-fail before apply)", got)
+	}
+	latest := latestPolicyBundle(t, handler, nil)
+	assertLatestBundleID(t, latest, "bundle-handler-preview-superseded-v3")
+	lookup := RollbackLookup{
+		CurrentBundleID: auth.CurrentBundleID,
+		CurrentVersion:  auth.CurrentVersion,
+		TargetBundleID:  auth.TargetBundleID,
+		TargetVersion:   auth.TargetVersion,
+	}
+	// The fast-fail runs before PublishRollbackAuthorization, so no record is
+	// ever created for the superseded authorization.
+	if _, err := handler.emergencyControls.LatestRollbackAuthorization(t.Context(), defaultFollowerIdentity(), lookup, testNow); !errors.Is(err, ErrEmergencyNotFound) {
+		t.Fatalf("LatestRollbackAuthorization(superseded at preview) err=%v, want ErrEmergencyNotFound (no record created)", err)
+	}
+}
+
+func TestHandlerPublishRollbackAuthorizationReplayApplyFailureKeepsPersistedRecord(t *testing.T) {
+	base := mustStore(t)
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-handler-replay-fail-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := base.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-handler-replay-fail-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - api2.example.com\n",
+	})
+	if _, _, err := base.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rollback-handler-replay-fail", v2, v1, testNow)
+	// Apply succeeds on the first request (head moves to the target and the
+	// authorization is durably recorded) and errors on the replay.
+	store := &applyRollbackFailOnReplayStore{FileBundleStore: base, err: errHandlerApplyRollbackFailed}
+	handler := newTestHandlerWithOptions(t, store, nil, resolver)
+	body, err := json.Marshal(publishRollbackAuthorizationRequest{Authorization: auth})
+	if err != nil {
+		t.Fatalf("Marshal(rollback): %v", err)
+	}
+	first := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, strings.NewReader(string(body)))
+	first.Header.Set("X-Pipelock-Admin", "ok")
+	fw := httptest.NewRecorder()
+	handler.ServeHTTP(fw, first)
+	if fw.Code != http.StatusCreated {
+		t.Fatalf("rollback first publish status=%d body=%s, want 201", fw.Code, fw.Body.String())
+	}
+
+	// Replay the same authorization: PublishRollbackAuthorization reports
+	// created=false, and the re-apply errors. Because the compensating clear is
+	// gated on created, the replay must NOT clear the legitimately-persisted
+	// record; the still-active rollback (head at target) keeps it servable.
+	replay := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, strings.NewReader(string(body)))
+	replay.Header.Set("X-Pipelock-Admin", "ok")
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, replay)
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("rollback replay apply-fail status=%d body=%s, want 500", rw.Code, rw.Body.String())
+	}
+	lookup := RollbackLookup{
+		CurrentBundleID: auth.CurrentBundleID,
+		CurrentVersion:  auth.CurrentVersion,
+		TargetBundleID:  auth.TargetBundleID,
+		TargetVersion:   auth.TargetVersion,
+	}
+	if record, err := handler.emergencyControls.LatestRollbackAuthorization(t.Context(), defaultFollowerIdentity(), lookup, testNow); err != nil || record.Authorization.AuthorizationID != auth.AuthorizationID {
+		t.Fatalf("LatestRollbackAuthorization(after replay apply failure) = %+v, %v; want persisted record %q (created=false must skip compensating clear)", record.Authorization, err, auth.AuthorizationID)
+	}
+	servedAuth := latestRollbackAuthorization(t, handler, auth)
+	if servedAuth.Code != http.StatusOK {
+		t.Fatalf("rollback auth after replay apply failure status=%d body=%s, want 200 (still active on head)", servedAuth.Code, servedAuth.Body.String())
+	}
+}
+
 func TestHandlerPublishRollbackAuthorizationRecordFailureDoesNotMoveHead(t *testing.T) {
 	base := mustStore(t)
 	signer := newTestSigner(t)
@@ -1348,6 +1487,48 @@ func (s applyRollbackFailureStore) PreviewRollbackHead(ctx context.Context, auth
 		return RollbackHeadPreview{}, ErrRollbackHeadPreviewUnsupported
 	}
 	return previewer.PreviewRollbackHead(ctx, auth)
+}
+
+// applyRollbackSpyStore counts ApplyRollbackHead invocations while otherwise
+// delegating to the real store, so a test can assert apply was never reached.
+type applyRollbackSpyStore struct {
+	*FileBundleStore
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *applyRollbackSpyStore) ApplyRollbackHead(ctx context.Context, auth conductor.RollbackAuthorization, now time.Time) error {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	return s.FileBundleStore.ApplyRollbackHead(ctx, auth, now)
+}
+
+func (s *applyRollbackSpyStore) applyCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// applyRollbackFailOnReplayStore applies the rollback normally on the first
+// ApplyRollbackHead call and errors on every subsequent call, modeling a replay
+// whose re-apply fails after the authorization was already durably recorded.
+type applyRollbackFailOnReplayStore struct {
+	*FileBundleStore
+	err   error
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *applyRollbackFailOnReplayStore) ApplyRollbackHead(ctx context.Context, auth conductor.RollbackAuthorization, now time.Time) error {
+	s.mu.Lock()
+	s.calls++
+	n := s.calls
+	s.mu.Unlock()
+	if n > 1 {
+		return s.err
+	}
+	return s.FileBundleStore.ApplyRollbackHead(ctx, auth, now)
 }
 
 type publishBeforeRollbackApplyStore struct {

--- a/enterprise/conductor/controlplane/handler_test.go
+++ b/enterprise/conductor/controlplane/handler_test.go
@@ -359,12 +359,12 @@ func TestHandlerPublishRollbackAuthorizationApplyFailureRecordIsNotServed(t *tes
 		TargetBundleID:  auth.TargetBundleID,
 		TargetVersion:   auth.TargetVersion,
 	}
-	record, err := handler.emergencyControls.LatestRollbackAuthorization(t.Context(), defaultFollowerIdentity(), lookup, testNow)
-	if err != nil {
-		t.Fatalf("LatestRollbackAuthorization(after apply failure) error = %v", err)
-	}
-	if record.Authorization.AuthorizationID != auth.AuthorizationID {
-		t.Fatalf("recorded authorization_id = %q, want %q", record.Authorization.AuthorizationID, auth.AuthorizationID)
+	// The apply failed, so the just-created authorization record is
+	// compensating-cleared: replay and audit must never surface an
+	// accepted-but-unapplied rollback (split-brain). The record must be gone,
+	// not merely un-served.
+	if _, err := handler.emergencyControls.LatestRollbackAuthorization(t.Context(), defaultFollowerIdentity(), lookup, testNow); !errors.Is(err, ErrEmergencyNotFound) {
+		t.Fatalf("LatestRollbackAuthorization(after apply failure) err=%v, want ErrEmergencyNotFound (compensating clear)", err)
 	}
 }
 
@@ -416,6 +416,122 @@ func TestHandlerPublishRollbackAuthorizationConcurrentForwardPublishSupersedesRo
 	servedAuth := latestRollbackAuthorization(t, handler, auth)
 	if servedAuth.Code != http.StatusNoContent {
 		t.Fatalf("rollback auth after race status=%d body=%s, want 204", servedAuth.Code, servedAuth.Body.String())
+	}
+}
+
+func TestHandlerPublishRollbackAuthorizationAppliedThenSupersededKeepsRollbackMarker(t *testing.T) {
+	base := mustStore(t)
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-handler-applied-superseded-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := base.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-handler-applied-superseded-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - applied-superseded2.example.com\n",
+	})
+	if _, _, err := base.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	v3 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-handler-applied-superseded-v3",
+		version:      3,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - applied-superseded3.example.com\n",
+	})
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rollback-handler-applied-superseded", v2, v1, testNow)
+	handler := newTestHandlerWithOptions(t, &publishAfterRollbackApplyStore{FileBundleStore: base, bundle: v3}, nil, resolver)
+	body, err := json.Marshal(publishRollbackAuthorizationRequest{Authorization: auth})
+	if err != nil {
+		t.Fatalf("Marshal(rollback): %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, strings.NewReader(string(body)))
+	req.Header.Set("X-Pipelock-Admin", "ok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("rollback applied-then-superseded status=%d body=%s, want 409", w.Code, w.Body.String())
+	}
+	latest := latestPolicyBundle(t, handler, nil)
+	assertLatestBundleID(t, latest, "bundle-handler-applied-superseded-v3")
+	if _, ok := base.rollbackHeads[r1.StreamKey]; !ok {
+		t.Fatal("rollback marker missing after applied rollback was superseded")
+	}
+	servedAuth := latestRollbackAuthorization(t, handler, auth)
+	if servedAuth.Code != http.StatusNoContent {
+		t.Fatalf("rollback auth after applied supersede status=%d body=%s, want 204", servedAuth.Code, servedAuth.Body.String())
+	}
+	lookup := RollbackLookup{
+		CurrentBundleID: auth.CurrentBundleID,
+		CurrentVersion:  auth.CurrentVersion,
+		TargetBundleID:  auth.TargetBundleID,
+		TargetVersion:   auth.TargetVersion,
+	}
+	if _, err := handler.emergencyControls.LatestRollbackAuthorization(t.Context(), defaultFollowerIdentity(), lookup, testNow); !errors.Is(err, ErrEmergencyNotFound) {
+		t.Fatalf("LatestRollbackAuthorization(after applied supersede) err=%v, want ErrEmergencyNotFound", err)
+	}
+}
+
+func TestHandlerPublishRollbackAuthorizationClearFailureResidualRecordIsNotServed(t *testing.T) {
+	base := mustStore(t)
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-handler-clear-fail-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := base.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-handler-clear-fail-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - clear-fail2.example.com\n",
+	})
+	if _, _, err := base.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rollback-handler-clear-fail", v2, v1, testNow)
+	handler := newTestHandlerWithOptions(t, applyRollbackFailureStore{BundleStore: base, err: errHandlerApplyRollbackFailed}, nil, resolver)
+	handler.emergencyControls = newVerifiedEmergencyStore(rollbackClearFailureEmergencyStore{
+		FileEmergencyStore: mustEmergencyStore(t),
+		err:                errors.New("forced rollback clear failure"),
+	}, resolver, nil, nil)
+	body, err := json.Marshal(publishRollbackAuthorizationRequest{Authorization: auth})
+	if err != nil {
+		t.Fatalf("Marshal(rollback): %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, strings.NewReader(string(body)))
+	req.Header.Set("X-Pipelock-Admin", "ok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("rollback clear-fail status=%d body=%s, want 500", w.Code, w.Body.String())
+	}
+	lookup := RollbackLookup{
+		CurrentBundleID: auth.CurrentBundleID,
+		CurrentVersion:  auth.CurrentVersion,
+		TargetBundleID:  auth.TargetBundleID,
+		TargetVersion:   auth.TargetVersion,
+	}
+	if record, err := handler.emergencyControls.LatestRollbackAuthorization(t.Context(), defaultFollowerIdentity(), lookup, testNow); err != nil || record.Authorization.AuthorizationID != auth.AuthorizationID {
+		t.Fatalf("LatestRollbackAuthorization(clear failure) = %+v, %v; want residual record %q", record.Authorization, err, auth.AuthorizationID)
+	}
+	servedAuth := latestRollbackAuthorization(t, handler, auth)
+	if servedAuth.Code != http.StatusNoContent {
+		t.Fatalf("rollback residual auth after clear failure status=%d body=%s, want 204", servedAuth.Code, servedAuth.Body.String())
 	}
 }
 
@@ -1249,6 +1365,32 @@ func (s *publishBeforeRollbackApplyStore) ApplyRollbackHead(ctx context.Context,
 		return publishErr
 	}
 	return s.FileBundleStore.ApplyRollbackHead(ctx, auth, now)
+}
+
+type publishAfterRollbackApplyStore struct {
+	*FileBundleStore
+	bundle conductor.PolicyBundle
+	once   sync.Once
+}
+
+func (s *publishAfterRollbackApplyStore) ApplyRollbackHead(ctx context.Context, auth conductor.RollbackAuthorization, now time.Time) error {
+	if err := s.FileBundleStore.ApplyRollbackHead(ctx, auth, now); err != nil {
+		return err
+	}
+	var publishErr error
+	s.once.Do(func() {
+		_, _, publishErr = s.Publish(ctx, s.bundle, PublishOptions{Now: now.Add(time.Second)})
+	})
+	return publishErr
+}
+
+type rollbackClearFailureEmergencyStore struct {
+	*FileEmergencyStore
+	err error
+}
+
+func (s rollbackClearFailureEmergencyStore) ClearRollbackAuthorization(context.Context, string) (bool, error) {
+	return false, s.err
 }
 
 func newTestHandler(t *testing.T, store BundleStore, identity FollowerIdentityResolver) *Handler {

--- a/enterprise/conductor/controlplane/handler_test.go
+++ b/enterprise/conductor/controlplane/handler_test.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -77,7 +79,7 @@ func TestHandlerPublishesAndServesLatestBundle(t *testing.T) {
 	}
 }
 
-func TestHandlerLatestPolicyBundleHonorsRollbackCeiling(t *testing.T) {
+func TestHandlerLatestPolicyBundleRequiresRollbackHead(t *testing.T) {
 	store := mustStore(t)
 	signer := newTestSigner(t)
 	audience := conductor.Audience{InstanceIDs: []string{"*"}}
@@ -97,8 +99,7 @@ func TestHandlerLatestPolicyBundleHonorsRollbackCeiling(t *testing.T) {
 		audience:     audience,
 		configYAML:   "mode: strict\napi_allowlist:\n  - api2.example.com\n",
 	})
-	r2, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)})
-	if err != nil {
+	if _, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
 		t.Fatalf("Publish(v2) error = %v", err)
 	}
 	// The rollback ceiling is served through the signature-verifying view, so
@@ -110,10 +111,24 @@ func TestHandlerLatestPolicyBundleHonorsRollbackCeiling(t *testing.T) {
 	}
 
 	w := latestPolicyBundle(t, handler, nil)
+	assertLatestBundleID(t, w, rollbackCeilingBundleV2)
+	w = latestRollbackAuthorization(t, handler, auth)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("residual rollback auth status=%d body=%s, want 204 until bundle head is rolled back", w.Code, w.Body.String())
+	}
+
+	if err := store.ApplyRollbackHead(t.Context(), auth, testNow); err != nil {
+		t.Fatalf("ApplyRollbackHead() error = %v", err)
+	}
+	w = latestPolicyBundle(t, handler, nil)
 	assertLatestBundleID(t, w, rollbackCeilingBundleV1)
 	etag := w.Header().Get("ETag")
 	if etag == "" {
 		t.Fatal("rollback-ceiling latest ETag empty")
+	}
+	w = latestRollbackAuthorization(t, handler, auth)
+	if w.Code != http.StatusOK {
+		t.Fatalf("active rollback auth status=%d body=%s, want 200 after bundle head is rolled back", w.Code, w.Body.String())
 	}
 	w304 := latestPolicyBundle(t, handler, map[string]string{"If-None-Match": etag})
 	if w304.Code != http.StatusNotModified {
@@ -173,18 +188,17 @@ func TestHandlerLatestPolicyBundleHonorsRollbackCeiling(t *testing.T) {
 		t.Fatalf("PublishRollbackAuthorization(missing target) created=%v err=%v, want created", created, err)
 	}
 	w = latestPolicyBundle(t, missingHandler, nil)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("missing rollback target status=%d body=%s, want 404", w.Code, w.Body.String())
-	}
-	if strings.Contains(w.Body.String(), rollbackCeilingBundleV2) {
-		t.Fatalf("missing rollback target served current bundle body=%s", w.Body.String())
+	assertLatestBundleID(t, w, rollbackCeilingBundleV2)
+	w = latestRollbackAuthorization(t, missingHandler, missingAuth)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("missing rollback target auth status=%d body=%s, want 204", w.Code, w.Body.String())
 	}
 
 	handler.followerIdentity = nil
 	v3 := signedControlBundle(t, signer, bundleSpec{
 		id:           rollbackCeilingBundleV3,
 		version:      3,
-		previousHash: r2.BundleHash,
+		previousHash: r1.BundleHash,
 		audience:     audience,
 		configYAML:   "mode: strict\napi_allowlist:\n  - api3.example.com\n",
 	})
@@ -295,6 +309,158 @@ func TestHandlerPublishRollbackAuthorizationMissingTargetDoesNotRecord(t *testin
 	}
 	if _, err := handler.emergencyControls.LatestRollbackAuthorization(t.Context(), defaultFollowerIdentity(), lookup, testNow); !errors.Is(err, ErrEmergencyNotFound) {
 		t.Fatalf("LatestRollbackAuthorization(after missing target) err=%v, want ErrEmergencyNotFound", err)
+	}
+}
+
+func TestHandlerPublishRollbackAuthorizationApplyFailureRecordIsNotServed(t *testing.T) {
+	base := mustStore(t)
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-handler-apply-fail-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := base.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-handler-apply-fail-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - api2.example.com\n",
+	})
+	if _, _, err := base.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rollback-handler-apply-fail", v2, v1, testNow)
+	handler := newTestHandlerWithOptions(t, applyRollbackFailureStore{BundleStore: base, err: errHandlerApplyRollbackFailed}, nil, resolver)
+	body, err := json.Marshal(publishRollbackAuthorizationRequest{Authorization: auth})
+	if err != nil {
+		t.Fatalf("Marshal(rollback): %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, strings.NewReader(string(body)))
+	req.Header.Set("X-Pipelock-Admin", "ok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("rollback apply-fail status=%d body=%s, want 500", w.Code, w.Body.String())
+	}
+	latest := latestPolicyBundle(t, handler, nil)
+	assertLatestBundleID(t, latest, "bundle-handler-apply-fail-v2")
+	servedAuth := latestRollbackAuthorization(t, handler, auth)
+	if servedAuth.Code != http.StatusNoContent {
+		t.Fatalf("rollback auth after apply failure status=%d body=%s, want 204", servedAuth.Code, servedAuth.Body.String())
+	}
+	lookup := RollbackLookup{
+		CurrentBundleID: auth.CurrentBundleID,
+		CurrentVersion:  auth.CurrentVersion,
+		TargetBundleID:  auth.TargetBundleID,
+		TargetVersion:   auth.TargetVersion,
+	}
+	record, err := handler.emergencyControls.LatestRollbackAuthorization(t.Context(), defaultFollowerIdentity(), lookup, testNow)
+	if err != nil {
+		t.Fatalf("LatestRollbackAuthorization(after apply failure) error = %v", err)
+	}
+	if record.Authorization.AuthorizationID != auth.AuthorizationID {
+		t.Fatalf("recorded authorization_id = %q, want %q", record.Authorization.AuthorizationID, auth.AuthorizationID)
+	}
+}
+
+func TestHandlerPublishRollbackAuthorizationConcurrentForwardPublishSupersedesRollback(t *testing.T) {
+	base := mustStore(t)
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-handler-race-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := base.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-handler-race-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - api2.example.com\n",
+	})
+	r2, _, err := base.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)})
+	if err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	v3 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-handler-race-v3",
+		version:      3,
+		previousHash: r2.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - api3.example.com\n",
+	})
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rollback-handler-race", v2, v1, testNow)
+	handler := newTestHandlerWithOptions(t, &publishBeforeRollbackApplyStore{FileBundleStore: base, bundle: v3}, nil, resolver)
+	body, err := json.Marshal(publishRollbackAuthorizationRequest{Authorization: auth})
+	if err != nil {
+		t.Fatalf("Marshal(rollback): %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, strings.NewReader(string(body)))
+	req.Header.Set("X-Pipelock-Admin", "ok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("rollback race status=%d body=%s, want 409", w.Code, w.Body.String())
+	}
+	latest := latestPolicyBundle(t, handler, nil)
+	assertLatestBundleID(t, latest, "bundle-handler-race-v3")
+	servedAuth := latestRollbackAuthorization(t, handler, auth)
+	if servedAuth.Code != http.StatusNoContent {
+		t.Fatalf("rollback auth after race status=%d body=%s, want 204", servedAuth.Code, servedAuth.Body.String())
+	}
+}
+
+func TestHandlerPublishRollbackAuthorizationRecordFailureDoesNotMoveHead(t *testing.T) {
+	base := mustStore(t)
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-handler-record-fail-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := base.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-handler-record-fail-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - api2.example.com\n",
+	})
+	if _, _, err := base.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rollback-handler-record-fail", v2, v1, testNow)
+	handler := newTestHandlerWithOptions(t, base, nil, resolver)
+	handler.emergencyControls = failingEmergencyStore{}
+	body, err := json.Marshal(publishRollbackAuthorizationRequest{Authorization: auth})
+	if err != nil {
+		t.Fatalf("Marshal(rollback): %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, strings.NewReader(string(body)))
+	req.Header.Set("X-Pipelock-Admin", "ok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("rollback record-fail status=%d body=%s, want 500", w.Code, w.Body.String())
+	}
+	latest, err := base.Latest(t.Context(), defaultFollowerIdentity(), testNow)
+	if err != nil {
+		t.Fatalf("Latest(after record failure) error = %v", err)
+	}
+	if latest.Bundle.BundleID != "bundle-handler-record-fail-v2" {
+		t.Fatalf("Latest(after record failure) bundle_id = %q, want bundle-handler-record-fail-v2", latest.Bundle.BundleID)
 	}
 }
 
@@ -951,6 +1117,21 @@ func latestPolicyBundle(t *testing.T, handler *Handler, headers map[string]strin
 	return w
 }
 
+func latestRollbackAuthorization(t *testing.T, handler *Handler, auth conductor.RollbackAuthorization) *httptest.ResponseRecorder {
+	t.Helper()
+	target := fmt.Sprintf("%s?current_bundle_id=%s&current_version=%d&target_bundle_id=%s&target_version=%d",
+		RollbackAuthorizationsPath,
+		auth.CurrentBundleID,
+		auth.CurrentVersion,
+		auth.TargetBundleID,
+		auth.TargetVersion,
+	)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
 func assertLatestBundleID(t *testing.T, w *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if w.Code != http.StatusOK {
@@ -1032,6 +1213,42 @@ func publishRollbackTargetAndCurrent(t *testing.T, handler *Handler, auth conduc
 	if _, _, err := handler.store.Publish(t.Context(), current, PublishOptions{Now: testNow.Add(time.Minute)}); err != nil {
 		t.Fatalf("Publish(rollback current) error = %v", err)
 	}
+}
+
+var errHandlerApplyRollbackFailed = errors.New("forced rollback head apply failure")
+
+type applyRollbackFailureStore struct {
+	BundleStore
+	err error
+}
+
+func (s applyRollbackFailureStore) ApplyRollbackHead(context.Context, conductor.RollbackAuthorization, time.Time) error {
+	return s.err
+}
+
+func (s applyRollbackFailureStore) PreviewRollbackHead(ctx context.Context, auth conductor.RollbackAuthorization) (RollbackHeadPreview, error) {
+	previewer, ok := s.BundleStore.(rollbackHeadPreviewer)
+	if !ok {
+		return RollbackHeadPreview{}, ErrRollbackHeadPreviewUnsupported
+	}
+	return previewer.PreviewRollbackHead(ctx, auth)
+}
+
+type publishBeforeRollbackApplyStore struct {
+	*FileBundleStore
+	bundle conductor.PolicyBundle
+	once   sync.Once
+}
+
+func (s *publishBeforeRollbackApplyStore) ApplyRollbackHead(ctx context.Context, auth conductor.RollbackAuthorization, now time.Time) error {
+	var publishErr error
+	s.once.Do(func() {
+		_, _, publishErr = s.Publish(ctx, s.bundle, PublishOptions{Now: now.Add(time.Second)})
+	})
+	if publishErr != nil {
+		return publishErr
+	}
+	return s.FileBundleStore.ApplyRollbackHead(ctx, auth, now)
 }
 
 func newTestHandler(t *testing.T, store BundleStore, identity FollowerIdentityResolver) *Handler {

--- a/enterprise/conductor/controlplane/preview.go
+++ b/enterprise/conductor/controlplane/preview.go
@@ -20,6 +20,9 @@ var (
 	// ErrEmergencyPreviewUnsupported is the emergency-store counterpart of
 	// ErrDryRunUnsupported.
 	ErrEmergencyPreviewUnsupported = errors.New("conductor emergency store does not support dry-run preview")
+	// ErrRollbackHeadPreviewUnsupported is returned when live rollback cannot
+	// preflight the head mutation needed to avoid split-write orphan state.
+	ErrRollbackHeadPreviewUnsupported = errors.New("conductor bundle store does not support rollback head preview")
 )
 
 // Preview types are the read-only projections a dry-run reports. Each Preview*

--- a/enterprise/conductor/controlplane/rollback_coverage_test.go
+++ b/enterprise/conductor/controlplane/rollback_coverage_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -459,14 +458,11 @@ func (stubBundleStore) StreamOverview(context.Context, StreamStatusQuery) ([]Str
 	return nil, nil
 }
 
-// TestApplyRollbackCeilingUnavailableBundles drives the leader-side ceiling
-// helper through the current-unavailable, target-unavailable, and cross-stream
-// branches by serving GET latest with a published rollback authorization whose
-// referenced bundles are missing or live in a different stream.
-func TestApplyRollbackCeilingUnavailableBundles(t *testing.T) {
+func TestLatestPolicyBundleIgnoresRollbackAuthorizationUnavailableBundles(t *testing.T) {
 	// current unavailable: rollback references a current bundle that was never
-	// published, while the target IS present. The ceiling returns a 404-mapped
-	// error rather than serving any bundle.
+	// published, while the target IS present. Latest policy still serves the
+	// bundle-store head; the rollback-auth poller refuses to serve the residual
+	// auth because it cannot confirm the current bundle.
 	t.Run("current unavailable", func(t *testing.T) {
 		store := mustStore(t)
 		signer := newTestSigner(t)
@@ -492,14 +488,17 @@ func TestApplyRollbackCeilingUnavailableBundles(t *testing.T) {
 			t.Fatalf("PublishRollbackAuthorization() created=%v err=%v, want created", created, err)
 		}
 		w := latestPolicyBundle(t, handler, nil)
-		if w.Code != http.StatusNotFound {
-			t.Fatalf("current-unavailable status=%d body=%s, want 404", w.Code, w.Body.String())
+		assertLatestBundleID(t, w, "bundle-ceiling-cur-target")
+		w = latestRollbackAuthorization(t, handler, auth)
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("current-unavailable rollback status=%d body=%s, want 204", w.Code, w.Body.String())
 		}
 	})
 
 	// target unavailable: rollback references a current bundle that IS present
-	// but a target bundle that was never published. The ceiling returns a
-	// 404-mapped error.
+	// but a target bundle that was never published. Latest policy still serves
+	// the current store head; the rollback-auth poller refuses to serve the
+	// residual auth because it cannot confirm the target bundle.
 	t.Run("target unavailable", func(t *testing.T) {
 		store := mustStore(t)
 		signer := newTestSigner(t)
@@ -525,8 +524,10 @@ func TestApplyRollbackCeilingUnavailableBundles(t *testing.T) {
 			t.Fatalf("PublishRollbackAuthorization() created=%v err=%v, want created", created, err)
 		}
 		w := latestPolicyBundle(t, handler, nil)
-		if w.Code != http.StatusNotFound {
-			t.Fatalf("target-unavailable status=%d body=%s, want 404", w.Code, w.Body.String())
+		assertLatestBundleID(t, w, "bundle-ceiling-tgt-current")
+		w = latestRollbackAuthorization(t, handler, auth)
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("target-unavailable rollback status=%d body=%s, want 204", w.Code, w.Body.String())
 		}
 	})
 
@@ -581,9 +582,7 @@ func TestApplyRollbackCeilingUnavailableBundles(t *testing.T) {
 	})
 }
 
-// TestApplyRollbackCeilingNilEmergencyControls covers the early return when the
-// handler has no emergency controls configured.
-func TestApplyRollbackCeilingNilEmergencyControls(t *testing.T) {
+func TestLatestPolicyBundleNilEmergencyControlsServesStoreHead(t *testing.T) {
 	store := mustStore(t)
 	signer := newTestSigner(t)
 	v1 := signedControlBundle(t, signer, bundleSpec{
@@ -596,24 +595,11 @@ func TestApplyRollbackCeilingNilEmergencyControls(t *testing.T) {
 	}
 	handler := newTestHandler(t, store, nil)
 	handler.emergencyControls = nil
-	got, err := handler.applyRollbackCeiling(
-		httptest.NewRequestWithContext(context.Background(), http.MethodGet, LatestPolicyBundlePath, nil),
-		defaultFollowerIdentity(),
-		PublishedBundle{Bundle: v1},
-		testNow,
-	)
-	if err != nil {
-		t.Fatalf("applyRollbackCeiling(nil emergency) error = %v", err)
-	}
-	if got.Bundle.BundleID != "bundle-ceiling-noemerg" {
-		t.Fatalf("applyRollbackCeiling(nil emergency) bundle=%q, want latest unchanged", got.Bundle.BundleID)
-	}
+	w := latestPolicyBundle(t, handler, nil)
+	assertLatestBundleID(t, w, "bundle-ceiling-noemerg")
 }
 
-// TestApplyRollbackCeilingActiveLookupError covers the branch where
-// ActiveRollbackForFollower returns an error: the ceiling propagates it rather
-// than serving a possibly-stale bundle.
-func TestApplyRollbackCeilingActiveLookupError(t *testing.T) {
+func TestLatestPolicyBundleIgnoresEmergencyLookupForPolicyServing(t *testing.T) {
 	store := mustStore(t)
 	signer := newTestSigner(t)
 	v1 := signedControlBundle(t, signer, bundleSpec{
@@ -626,13 +612,6 @@ func TestApplyRollbackCeilingActiveLookupError(t *testing.T) {
 	}
 	handler := newTestHandler(t, store, nil)
 	handler.emergencyControls = failingEmergencyStore{}
-	_, err := handler.applyRollbackCeiling(
-		httptest.NewRequestWithContext(context.Background(), http.MethodGet, LatestPolicyBundlePath, nil),
-		defaultFollowerIdentity(),
-		PublishedBundle{Bundle: v1},
-		testNow,
-	)
-	if err == nil || !strings.Contains(err.Error(), "emergency store failed") {
-		t.Fatalf("applyRollbackCeiling(active lookup error) err=%v, want propagated error", err)
-	}
+	w := latestPolicyBundle(t, handler, nil)
+	assertLatestBundleID(t, w, "bundle-ceiling-activeerr")
 }

--- a/enterprise/conductor/controlplane/runtime_status.go
+++ b/enterprise/conductor/controlplane/runtime_status.go
@@ -44,6 +44,14 @@ const (
 	FleetHealthUnknown     FleetHealth = "unknown"
 )
 
+type FleetFieldSource string
+
+const (
+	FleetFieldSourceNone               FleetFieldSource = "none"
+	FleetFieldSourceRuntimeStatus      FleetFieldSource = "runtime_status"
+	FleetFieldSourceSignedAppliedState FleetFieldSource = "signed_applied_state"
+)
+
 type FollowerRuntimeStatus struct {
 	OrgID                          string    `json:"org_id"`
 	FleetID                        string    `json:"fleet_id"`
@@ -98,8 +106,18 @@ type FollowerFleetStatus struct {
 	// prefer SignedAppliedState when present.
 	SignedAppliedState *VerifiedAppliedState `json:"signed_applied_state,omitempty"`
 	Health             FleetHealth           `json:"health"`
+	HealthSource       FleetFieldProvenance  `json:"health_source"`
 	Drift              string                `json:"drift,omitempty"`
+	DriftSource        *FleetFieldProvenance `json:"drift_source,omitempty"`
 	ExpectedBundle     ExpectedBundle        `json:"expected_bundle,omitempty"`
+}
+
+type FleetFieldProvenance struct {
+	Source       FleetFieldSource `json:"source"`
+	Verified     bool             `json:"verified"`
+	ObservedAt   *time.Time       `json:"observed_at,omitempty"`
+	VerifiedAt   *time.Time       `json:"verified_at,omitempty"`
+	ProvenanceAt *time.Time       `json:"provenance_at,omitempty"`
 }
 
 type PublishPreflightSummary struct {
@@ -112,6 +130,8 @@ type PublishPreflightSummary struct {
 	AllowFleetSkew    bool   `json:"allow_fleet_skew"`
 	FleetSkewReason   string `json:"fleet_skew_reason,omitempty"`
 	StaleAfterSeconds int    `json:"stale_after_seconds"`
+	Unavailable       bool   `json:"unavailable,omitempty"`
+	UnavailableReason string `json:"unavailable_reason,omitempty"`
 }
 
 func (s FollowerRuntimeStatus) Identity() FollowerIdentity {
@@ -339,6 +359,80 @@ func classifyFollowerHealth(follower FollowerSummary, status *FollowerRuntimeSta
 		return FleetHealthStale, "inactive_enrollment"
 	}
 	return FleetHealthOK, ""
+}
+
+func classifyFollowerFleetStatus(
+	follower FollowerSummary,
+	status *FollowerRuntimeStatus,
+	signed *VerifiedAppliedState,
+	expected ExpectedBundle,
+	now time.Time,
+	staleAfter time.Duration,
+) (FleetHealth, string, FleetFieldProvenance) {
+	if signed != nil && signed.Verified {
+		health, drift := classifySignedAppliedState(follower, *signed, expected, now, staleAfter)
+		return health, drift, signedAppliedStateProvenance(*signed)
+	}
+	health, drift := classifyFollowerHealth(follower, status, expected, now, staleAfter)
+	return health, drift, runtimeStatusProvenance(status)
+}
+
+func classifySignedAppliedState(follower FollowerSummary, signed VerifiedAppliedState, expected ExpectedBundle, now time.Time, staleAfter time.Duration) (FleetHealth, string) {
+	if staleAfter <= 0 {
+		staleAfter = defaultRuntimeStatusStaleAfter
+	}
+	if signed.VerifiedAt.IsZero() || now.Sub(signed.VerifiedAt) > staleAfter {
+		return FleetHealthStale, "signed_state_stale"
+	}
+	applied := signed.AppliedState
+	if applied.LastApplyErrorCode != "" || applied.LastApplyErrorMessage != "" {
+		return FleetHealthApplyFailed, "last_apply_failed"
+	}
+	if expected.AudienceLabelsUnavailable {
+		return FleetHealthUnknown, "audience_labels_unavailable"
+	}
+	minVersion := expected.MinPipelockVersion
+	if minVersion == "" {
+		minVersion = applied.ActiveBundleMinPipelockVersion
+	}
+	if minVersion != "" && rules.CheckMinPipelock(minVersion, applied.PipelockVersion) != nil {
+		return FleetHealthUnsupported, "runtime_below_minimum"
+	}
+	if expected.BundleHash != "" && !strings.EqualFold(applied.ActiveBundleHash, expected.BundleHash) {
+		return FleetHealthStale, "bundle_mismatch"
+	}
+	if !follower.Active {
+		return FleetHealthStale, "inactive_enrollment"
+	}
+	return FleetHealthOK, ""
+}
+
+func runtimeStatusProvenance(status *FollowerRuntimeStatus) FleetFieldProvenance {
+	p := FleetFieldProvenance{Source: FleetFieldSourceNone}
+	if status == nil {
+		return p
+	}
+	p.Source = FleetFieldSourceRuntimeStatus
+	p.ObservedAt = utcTimePtr(status.LastSeenAt)
+	return p
+}
+
+func signedAppliedStateProvenance(signed VerifiedAppliedState) FleetFieldProvenance {
+	return FleetFieldProvenance{
+		Source:       FleetFieldSourceSignedAppliedState,
+		Verified:     true,
+		ObservedAt:   utcTimePtr(signed.ObservedAt),
+		VerifiedAt:   utcTimePtr(signed.VerifiedAt),
+		ProvenanceAt: utcTimePtr(signed.AppliedState.ProvenanceAt),
+	}
+}
+
+func utcTimePtr(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	utc := t.UTC()
+	return &utc
 }
 
 func preflightAudienceMatches(audience conductor.Audience, follower FollowerSummary) bool {

--- a/enterprise/conductor/controlplane/runtime_status.go
+++ b/enterprise/conductor/controlplane/runtime_status.go
@@ -381,10 +381,22 @@ func classifySignedAppliedState(follower FollowerSummary, signed VerifiedApplied
 	if staleAfter <= 0 {
 		staleAfter = defaultRuntimeStatusStaleAfter
 	}
-	if signed.VerifiedAt.IsZero() || now.Sub(signed.VerifiedAt) > staleAfter {
+	applied := signed.AppliedState
+	// The signed state must be fresh by BOTH the server's receipt time AND the
+	// follower's own provenance time. Relying on VerifiedAt alone lets a stale
+	// applied-state resubmitted in a fresh audit batch look current and mask
+	// drift. ProvenanceAt is the follower's freshness stamp; fall back to
+	// ObservedAt for legacy clients. Reject zero, too-old, and too-far-future.
+	if signed.VerifiedAt.IsZero() || now.Sub(signed.VerifiedAt) > staleAfter || signed.VerifiedAt.After(now.Add(staleAfter)) {
 		return FleetHealthStale, "signed_state_stale"
 	}
-	applied := signed.AppliedState
+	provenance := applied.ProvenanceAt
+	if provenance.IsZero() {
+		provenance = applied.ObservedAt
+	}
+	if provenance.IsZero() || now.Sub(provenance) > staleAfter || provenance.After(now.Add(staleAfter)) {
+		return FleetHealthStale, "signed_state_stale"
+	}
 	if applied.LastApplyErrorCode != "" || applied.LastApplyErrorMessage != "" {
 		return FleetHealthApplyFailed, "last_apply_failed"
 	}

--- a/enterprise/conductor/controlplane/runtime_status_test.go
+++ b/enterprise/conductor/controlplane/runtime_status_test.go
@@ -1305,3 +1305,96 @@ func (s truncatedPreflightEnrollmentStore) ListFollowerRuntimeStatus(context.Con
 func (s truncatedPreflightEnrollmentStore) ListEnrolledFollowersForPreflight(context.Context, FollowerListQuery) ([]FollowerSummary, bool, error) {
 	return s.followers, s.truncated, nil
 }
+
+// TestClassifySignedAppliedState_DualFreshnessGate proves the signed
+// applied-state classifier requires BOTH the server receipt time (VerifiedAt)
+// AND the follower provenance time to be fresh. A stale applied-state
+// resubmitted inside a fresh audit batch (fresh VerifiedAt, stale provenance)
+// must classify Stale, not OK — otherwise a replayed old state masks drift.
+func TestClassifySignedAppliedState_DualFreshnessGate(t *testing.T) {
+	const staleAfter = defaultRuntimeStatusStaleAfter
+	follower := FollowerSummary{
+		OrgID:      "org-main",
+		FleetID:    "prod",
+		InstanceID: "inst-1",
+		Active:     true,
+	}
+	// Everything is otherwise healthy so a missing freshness gate would return OK.
+	newApplied := func(provenance, observed time.Time) conductor.FollowerAppliedState {
+		a := validTestAppliedState(observed)
+		a.ProvenanceAt = provenance
+		return a
+	}
+	expected := ExpectedBundle{BundleHash: strings.Repeat("ab", 32)}
+
+	cases := []struct {
+		name       string
+		verifiedAt time.Time
+		provenance time.Time
+		observed   time.Time
+		wantHealth FleetHealth
+		wantDrift  string
+	}{
+		{
+			name:       "fresh verified and provenance is healthy",
+			verifiedAt: testNow.Add(-30 * time.Second),
+			provenance: testNow.Add(-30 * time.Second),
+			observed:   testNow.Add(-30 * time.Second),
+			wantHealth: FleetHealthOK,
+			wantDrift:  "",
+		},
+		{
+			name:       "fresh verified but stale provenance is stale",
+			verifiedAt: testNow.Add(-30 * time.Second),
+			provenance: testNow.Add(-2 * staleAfter),
+			observed:   testNow.Add(-2 * staleAfter),
+			wantHealth: FleetHealthStale,
+			wantDrift:  "signed_state_stale",
+		},
+		{
+			name:       "fresh verified but zero provenance falls back to stale observed",
+			verifiedAt: testNow.Add(-30 * time.Second),
+			provenance: time.Time{},
+			observed:   testNow.Add(-2 * staleAfter),
+			wantHealth: FleetHealthStale,
+			wantDrift:  "signed_state_stale",
+		},
+		{
+			name:       "future-skewed provenance beyond window is stale",
+			verifiedAt: testNow.Add(-30 * time.Second),
+			provenance: testNow.Add(2 * staleAfter),
+			observed:   testNow.Add(2 * staleAfter),
+			wantHealth: FleetHealthStale,
+			wantDrift:  "signed_state_stale",
+		},
+		{
+			name:       "future-skewed verified receipt beyond window is stale",
+			verifiedAt: testNow.Add(2 * staleAfter),
+			provenance: testNow.Add(-30 * time.Second),
+			observed:   testNow.Add(-30 * time.Second),
+			wantHealth: FleetHealthStale,
+			wantDrift:  "signed_state_stale",
+		},
+		{
+			name:       "stale verified receipt is stale even with fresh provenance",
+			verifiedAt: testNow.Add(-2 * staleAfter),
+			provenance: testNow.Add(-30 * time.Second),
+			observed:   testNow.Add(-30 * time.Second),
+			wantHealth: FleetHealthStale,
+			wantDrift:  "signed_state_stale",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			signed := VerifiedAppliedState{
+				AppliedState: newApplied(tc.provenance, tc.observed),
+				VerifiedAt:   tc.verifiedAt,
+				Verified:     true,
+			}
+			health, drift := classifySignedAppliedState(follower, signed, expected, testNow, staleAfter)
+			if health != tc.wantHealth || drift != tc.wantDrift {
+				t.Fatalf("classifySignedAppliedState = %q/%q, want %q/%q", health, drift, tc.wantHealth, tc.wantDrift)
+			}
+		})
+	}
+}

--- a/enterprise/conductor/controlplane/runtime_status_test.go
+++ b/enterprise/conductor/controlplane/runtime_status_test.go
@@ -316,6 +316,149 @@ func TestFleetStatusClassifiesRuntimeHealth(t *testing.T) {
 	}
 }
 
+func TestFleetStatusLabelsHealthAndDriftSource(t *testing.T) {
+	enrollments, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	auditStore := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	defer func() { _ = auditStore.Close() }()
+	store := mustStore(t)
+	signer := newTestSigner(t)
+	bundle := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-source-expected",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	published, _, err := store.Publish(context.Background(), bundle, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	mustEnrollFollower(t, enrollments, "tok-source", identity, "audit-key-source")
+	unsigned := runtimeStatus(identity, "1.2.3", published.BundleHash)
+	unsigned.ActiveBundleID = bundle.BundleID
+	unsigned.ActiveBundleVersion = bundle.Version
+	if _, err := enrollments.UpsertFollowerRuntimeStatus(context.Background(), unsigned); err != nil {
+		t.Fatalf("UpsertFollowerRuntimeStatus() error = %v", err)
+	}
+	applied := validTestAppliedState(testNow.Add(-time.Minute))
+	applied.ActiveBundleID = "bundle-source-signed"
+	applied.ActiveBundleVersion = 7
+	applied.ActiveBundleHash = strings.Repeat("b", 64)
+	applied.PipelockVersion = "1.2.3"
+	applied.ProvenanceAt = testNow.Add(-2 * time.Minute)
+	batch := appliedStateBatch(t, identity, "audit-batch-source", 10, 10, &applied, false)
+	batch.ReceivedAt = testNow.Add(-30 * time.Second)
+	if _, err := auditStore.put(context.Background(), batch); err != nil {
+		t.Fatalf("put(applied state) error = %v", err)
+	}
+	handler := newAppliedStateFleetHandler(t, enrollments, auditStore)
+	handler.store = store
+
+	w := getFollowers(t, handler, FollowersPath+"?org_id=org-main&fleet_id=prod&limit=10", followerAdminToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("fleet status code = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	var resp listFollowersResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Followers) != 1 {
+		t.Fatalf("followers = %d, want 1", len(resp.Followers))
+	}
+	got := resp.Followers[0]
+	if got.Health != FleetHealthStale || got.Drift != "bundle_mismatch" {
+		t.Fatalf("health/drift = %q/%q, want signed stale/bundle_mismatch", got.Health, got.Drift)
+	}
+	if got.HealthSource.Source != FleetFieldSourceSignedAppliedState || !got.HealthSource.Verified {
+		t.Fatalf("health source = %+v, want verified signed_applied_state", got.HealthSource)
+	}
+	if got.DriftSource == nil || got.DriftSource.Source != FleetFieldSourceSignedAppliedState || !got.DriftSource.Verified {
+		t.Fatalf("drift source = %+v, want verified signed_applied_state", got.DriftSource)
+	}
+	if got.HealthSource.VerifiedAt == nil || !got.HealthSource.VerifiedAt.Equal(batch.ReceivedAt.UTC()) {
+		t.Fatalf("health verified_at = %v, want %v", got.HealthSource.VerifiedAt, batch.ReceivedAt.UTC())
+	}
+	if got.HealthSource.ObservedAt == nil || !got.HealthSource.ObservedAt.Equal(applied.ObservedAt.UTC()) {
+		t.Fatalf("health observed_at = %v, want %v", got.HealthSource.ObservedAt, applied.ObservedAt.UTC())
+	}
+	if got.HealthSource.ProvenanceAt == nil || !got.HealthSource.ProvenanceAt.Equal(applied.ProvenanceAt.UTC()) {
+		t.Fatalf("health provenance_at = %v, want %v", got.HealthSource.ProvenanceAt, applied.ProvenanceAt.UTC())
+	}
+	var raw struct {
+		Followers []map[string]any `json:"followers"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw response: %v", err)
+	}
+	healthSource, ok := raw.Followers[0]["health_source"].(map[string]any)
+	if !ok {
+		t.Fatalf("raw health_source = %#v, want object", raw.Followers[0]["health_source"])
+	}
+	for _, field := range []string{"observed_at", "verified_at", "provenance_at"} {
+		if _, ok := healthSource[field]; !ok {
+			t.Fatalf("signed health_source missing %q in raw response: %#v", field, healthSource)
+		}
+	}
+}
+
+func TestFleetStatusUnsignedRuntimeStatusDoesNotRenderVerifiedTimestamps(t *testing.T) {
+	enrollments, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	mustEnrollFollower(t, enrollments, "tok-unsigned-source", identity, "audit-key-unsigned-source")
+	unsigned := runtimeStatus(identity, "1.2.3", strings.Repeat("a", 64))
+	unsigned.LastSeenAt = testNow.Add(-30 * time.Second)
+	unsigned.LastPolicyPollAt = testNow.Add(-time.Minute)
+	if _, err := enrollments.UpsertFollowerRuntimeStatus(context.Background(), unsigned); err != nil {
+		t.Fatalf("UpsertFollowerRuntimeStatus() error = %v", err)
+	}
+	handler := newRuntimeStatusTestHandler(t, enrollments, identity)
+
+	w := getFollowers(t, handler, FollowersPath+"?org_id=org-main&fleet_id=prod&limit=10", followerAdminToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("fleet status code = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	var resp listFollowersResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Followers) != 1 {
+		t.Fatalf("followers = %d, want 1", len(resp.Followers))
+	}
+	source := resp.Followers[0].HealthSource
+	if source.Source != FleetFieldSourceRuntimeStatus || source.Verified {
+		t.Fatalf("health source = %+v, want unverified runtime_status", source)
+	}
+	if source.ObservedAt == nil || !source.ObservedAt.Equal(unsigned.LastSeenAt.UTC()) {
+		t.Fatalf("observed_at = %v, want %v", source.ObservedAt, unsigned.LastSeenAt.UTC())
+	}
+	if source.VerifiedAt != nil || source.ProvenanceAt != nil {
+		t.Fatalf("unsigned source rendered verified/provenance timestamps: %+v", source)
+	}
+	var raw struct {
+		Followers []map[string]any `json:"followers"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw response: %v", err)
+	}
+	healthSource, ok := raw.Followers[0]["health_source"].(map[string]any)
+	if !ok {
+		t.Fatalf("raw health_source = %#v, want object", raw.Followers[0]["health_source"])
+	}
+	if _, ok := healthSource["observed_at"]; !ok {
+		t.Fatalf("unsigned health_source missing observed_at: %#v", healthSource)
+	}
+	for _, field := range []string{"verified_at", "provenance_at"} {
+		if _, ok := healthSource[field]; ok {
+			t.Fatalf("unsigned health_source rendered %q: %#v", field, healthSource)
+		}
+	}
+}
+
 func TestFleetStatusMarksLabelAudienceUnverifiableWithoutLabels(t *testing.T) {
 	enrollments, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
 	if err != nil {
@@ -861,8 +1004,12 @@ func TestPublishPreflightRequiresRuntimeStatusStore(t *testing.T) {
 				enrollments: tc.enrollments,
 				now:         func() time.Time { return testNow },
 			}
-			if _, err := handler.publishPreflight(req, bundle, false, ""); !errors.Is(err, ErrRuntimeStatusStoreRequired) {
+			summary, err := handler.publishPreflight(req, bundle, false, "")
+			if !errors.Is(err, ErrRuntimeStatusStoreRequired) {
 				t.Fatalf("publishPreflight(%s) error = %v, want ErrRuntimeStatusStoreRequired", tc.name, err)
+			}
+			if !summary.Unavailable || summary.UnavailableReason == "" {
+				t.Fatalf("publishPreflight(%s) summary = %+v, want explicit unavailable signal", tc.name, summary)
 			}
 		})
 	}

--- a/enterprise/conductor/controlplane/store_test.go
+++ b/enterprise/conductor/controlplane/store_test.go
@@ -289,6 +289,72 @@ func TestRollbackHeadReconciliationRecoversAfterTTL(t *testing.T) {
 	}
 }
 
+func TestRollbackHeadReconciliationDoesNotRearmSupersededAuthorization(t *testing.T) {
+	store, err := OpenFileBundleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore() error = %v", err)
+	}
+	emergencyStore, err := OpenFileEmergencyStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore() error = %v", err)
+	}
+	signer := newTestSigner(t)
+	v1 := signedControlBundle(t, signer, bundleSpec{
+		id:       "bundle-reconcile-superseded-v1",
+		version:  1,
+		audience: conductor.Audience{InstanceIDs: []string{"*"}},
+	})
+	r1, _, err := store.Publish(t.Context(), v1, PublishOptions{Now: testNow})
+	if err != nil {
+		t.Fatalf("Publish(v1) error = %v", err)
+	}
+	v2 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-reconcile-superseded-v2",
+		version:      2,
+		previousHash: r1.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - reconcile-superseded2.example.com\n",
+	})
+	r2, _, err := store.Publish(t.Context(), v2, PublishOptions{Now: testNow.Add(time.Minute)})
+	if err != nil {
+		t.Fatalf("Publish(v2) error = %v", err)
+	}
+	auth, resolver := signedRollbackAuthorizationForBundlesWithResolver(t, "rollback-reconcile-superseded", v2, v1, testNow)
+	if _, created, err := emergencyStore.PublishRollbackAuthorization(t.Context(), auth, testNow); err != nil || !created {
+		t.Fatalf("PublishRollbackAuthorization() created=%v err=%v, want created", created, err)
+	}
+	v3 := signedControlBundle(t, signer, bundleSpec{
+		id:           "bundle-reconcile-superseded-v3",
+		version:      3,
+		previousHash: r2.BundleHash,
+		audience:     conductor.Audience{InstanceIDs: []string{"*"}},
+		configYAML:   "mode: strict\napi_allowlist:\n  - reconcile-superseded3.example.com\n",
+	})
+	if _, _, err := store.Publish(t.Context(), v3, PublishOptions{Now: testNow.Add(2 * time.Minute)}); err != nil {
+		t.Fatalf("Publish(v3) error = %v", err)
+	}
+
+	reopenedStore, err := OpenFileBundleStore(store.dir)
+	if err != nil {
+		t.Fatalf("OpenFileBundleStore(reopen) error = %v", err)
+	}
+	reopenedEmergency, err := OpenFileEmergencyStore(emergencyStore.dir)
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore(reopen) error = %v", err)
+	}
+	verified := newVerifiedEmergencyStore(reopenedEmergency, resolver, nil, nil)
+	if err := reconcileRollbackHeads(reopenedStore, verified, testNow.Add(3*time.Minute), nil); err != nil {
+		t.Fatalf("reconcileRollbackHeads(superseded) error = %v", err)
+	}
+	latest, err := reopenedStore.Latest(t.Context(), defaultFollowerIdentity(), testNow.Add(3*time.Minute))
+	if err != nil {
+		t.Fatalf("Latest(after superseded reconcile) error = %v", err)
+	}
+	if latest.Bundle.BundleID != "bundle-reconcile-superseded-v3" {
+		t.Fatalf("Latest(after superseded reconcile) bundle=%q, want bundle-reconcile-superseded-v3", latest.Bundle.BundleID)
+	}
+}
+
 func TestRollbackHeadReconciliationLoadsLegacyAudienceEmergencyState(t *testing.T) {
 	store, err := OpenFileBundleStore(t.TempDir())
 	if err != nil {

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -389,6 +389,7 @@ type FollowerAppliedState struct {
 	LastApplyErrorCode             string    `json:"last_apply_error_code,omitempty"`
 	LastApplyErrorMessage          string    `json:"last_apply_error_message,omitempty"`
 	ObservedAt                     time.Time `json:"observed_at"`
+	ProvenanceAt                   time.Time `json:"provenance_at,omitempty"`
 }
 
 type AuditBatchEnvelope struct {
@@ -1000,6 +1001,7 @@ func (a AuditBatchEnvelope) SignablePreimage() ([]byte, error) {
 		applied.LastPolicyPollAt = applied.LastPolicyPollAt.UTC()
 		applied.LastSuccessfulApplyAt = applied.LastSuccessfulApplyAt.UTC()
 		applied.ObservedAt = applied.ObservedAt.UTC()
+		applied.ProvenanceAt = applied.ProvenanceAt.UTC()
 		unsigned.AppliedState = &applied
 	}
 	return canonicalPreimage(unsigned, "audit_batch")

--- a/internal/cli/runtime/conductor_applied_state_test.go
+++ b/internal/cli/runtime/conductor_applied_state_test.go
@@ -64,8 +64,28 @@ func TestAppliedStateProvider_ValidBeforeAnyPoll(t *testing.T) {
 	if state.ObservedAt.IsZero() {
 		t.Fatal("ObservedAt not set before first poll")
 	}
+	if state.ProvenanceAt.IsZero() {
+		t.Fatal("ProvenanceAt not set before first poll")
+	}
 	if err := state.Validate(); err != nil {
 		t.Fatalf("applied-state before first poll is invalid: %v", err)
+	}
+}
+
+func TestAppliedStateProvider_SeparatesPollObservationFromProvenanceTime(t *testing.T) {
+	reporter := newAppliedStateReporter(t)
+	pollAt := time.Date(2026, 5, 24, 12, 30, 0, 0, time.UTC)
+	before := time.Now().UTC()
+	state := reporter.buildAppliedState(policysync.StatusEvent{PollAt: pollAt})
+	after := time.Now().UTC()
+	if !state.ObservedAt.Equal(pollAt) {
+		t.Fatalf("ObservedAt = %v, want poll time %v", state.ObservedAt, pollAt)
+	}
+	if state.ProvenanceAt.Before(before) || state.ProvenanceAt.After(after) {
+		t.Fatalf("ProvenanceAt = %v, want construction time between %v and %v", state.ProvenanceAt, before, after)
+	}
+	if state.ProvenanceAt.Equal(state.ObservedAt) {
+		t.Fatalf("ProvenanceAt = ObservedAt = %v, want separate provenance freshness", state.ProvenanceAt)
 	}
 }
 

--- a/internal/cli/runtime/conductor_status.go
+++ b/internal/cli/runtime/conductor_status.go
@@ -165,6 +165,7 @@ func (r *conductorPolicyStatusReporter) buildAppliedState(ev policysync.StatusEv
 		BuildDate:        boundAppliedStateString(cliutil.BuildDate),
 		LastPolicyPollAt: pollAt.UTC(),
 		ObservedAt:       pollAt.UTC(),
+		ProvenanceAt:     time.Now().UTC(),
 	}
 	if ev.ApplyError != nil {
 		applied.LastApplyErrorCode = boundAppliedStateString(applyErrorCode(ev.ApplyError))


### PR DESCRIPTION
## What changed

This makes the conductor fleet view label signed versus unsigned state honestly, and makes the rollback control-plane path fail closed on partial failure.

Fleet health and drift are now labeled per field with their source, and a field is marked verified only when it comes from signed applied-state. The `verified_at` and `provenance_at` timestamps are populated from signed state only, never from an unsigned runtime poll, so unsigned status is never presented as verified. The publish preflight now returns an explicit unavailable signal for every enrollment-store shape instead of silently skipping when a store cannot report runtime status.

The rollback path now records the authorization before applying the head and serves policy only off the bundle-store head. A failed apply is therefore never served and never leaves an applied-but-unrecorded state, and the head is re-checked after preview so a rollback superseded by a concurrent publish is rejected rather than applied. Replay uses the historical verification window, so an expired-but-recorded key stays inspectable while a revoked key is still rejected, and a superseded rollback does not re-arm across a leader restart.

Every behavior is covered by a red-first regression test, including that a rollback whose apply fails is not served, a concurrent forward publish supersedes a pending rollback, an unsigned source carries no verified provenance timestamp, and restart preserves the served head.

The Pro/Enterprise dashboard should consume the new per-field source labels in a follow-up; this change is control-plane only and does not touch the dashboard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet status now shows whether health and drift information comes from runtime data or verified applied state, including freshness details.
  * Publish preflight responses now indicate when required status information is unavailable and explain why.
* **Bug Fixes**
  * Rollback authorization endpoints now only display authorizations that are actively applied.
  * Rollback operations fail safely when validation or application fails.
  * Decision replays provide clearer divergence results instead of exposing internal storage errors.
  * Historical emergency decisions are evaluated using their recorded acceptance time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->