### PR TITLE
fix(dashboard): harden auth boundary, store loading, and evidence read bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enterprise Evidence dashboard redacts receipt destinations and signed payloads
   by default before template rendering.
 - Enterprise Evidence dashboard handlers constructed directly from Go now fail
-  closed when both authorization callbacks are nil. Embedders that rely on an
-  already-authenticated outer router must explicitly set `TrustedOuterAuth`;
-  `pipelock dashboard serve` wires its token auth boundary itself.
+  closed when both authorization callbacks are nil unless `TrustedOuterAuth` is
+  explicitly set. Embedders that rely on an already-authenticated outer router
+  must opt in to `TrustedOuterAuth`; `pipelock dashboard serve` wires its token
+  auth boundary itself.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enterprise Evidence dashboard redacts receipt destinations and signed payloads
   by default before template rendering.
+- Enterprise Evidence dashboard handlers constructed directly from Go now fail
+  closed when both authorization callbacks are nil. Embedders that rely on an
+  already-authenticated outer router must explicitly set `TrustedOuterAuth`;
+  `pipelock dashboard serve` wires its token auth boundary itself.
 
 ### Fixed
 

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -104,6 +104,12 @@ the server is running stops serving.
 - **The license check is entitlement, not identity.** Every request must also
   carry the operator token (constant-time comparison), as a `Bearer` header or
   as the Basic-auth password. Requests without it get `401` and no evidence.
+- **Embedded handlers fail closed without an auth boundary.** The
+  `pipelock dashboard serve` command wires the token-auth boundary into the
+  dashboard handler. Go embedders that construct the dashboard handler directly
+  and authenticate in an outer router must explicitly set `TrustedOuterAuth`;
+  leaving both authorization callbacks nil now returns `403` for every route
+  instead of serving unauthenticated.
 - **Cleartext refusal.** Without TLS the listener only accepts loopback
   addresses; serving a non-loopback address over plain HTTP is refused at
   startup because the operator token would transit in cleartext.

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -178,8 +178,8 @@ the server is running stops serving.
   `pipelock dashboard serve` command wires its configured token, OIDC, or mTLS
   auth boundary into the dashboard handler. Go embedders that construct the
   dashboard handler directly and authenticate in an outer router must explicitly
-  set `TrustedOuterAuth`; leaving both authorization callbacks nil now returns
-  `403` for every route instead of serving unauthenticated.
+  set `TrustedOuterAuth`; otherwise, leaving both authorization callbacks nil
+  returns `403` for every route instead of serving unauthenticated.
 - **Cleartext refusal.** Without TLS the listener only accepts loopback
   addresses; serving a non-loopback address over plain HTTP is refused at
   startup because the operator token would transit in cleartext.

--- a/enterprise/dashboard/agents_test.go
+++ b/enterprise/dashboard/agents_test.go
@@ -41,7 +41,8 @@ func TestHandler_NewRouteGating(t *testing.T) {
 
 	t.Run("no_feature", func(t *testing.T) {
 		handler := New(Options{
-			ReceiptDir: dir,
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir,
 			TrustedKeys: map[string]TrustedKey{
 				keyHex: {Source: trustedKeySource},
 			},
@@ -59,7 +60,8 @@ func TestHandler_NewRouteGating(t *testing.T) {
 
 	t.Run("nil_feature", func(t *testing.T) {
 		handler := New(Options{
-			ReceiptDir: dir,
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir,
 			TrustedKeys: map[string]TrustedKey{
 				keyHex: {Source: trustedKeySource},
 			},
@@ -76,7 +78,8 @@ func TestHandler_NewRouteGating(t *testing.T) {
 
 	t.Run("authorize_rejects", func(t *testing.T) {
 		handler := New(Options{
-			ReceiptDir: dir,
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir,
 			TrustedKeys: map[string]TrustedKey{
 				keyHex: {Source: trustedKeySource},
 			},
@@ -98,7 +101,8 @@ func TestHandler_NewRouteGating(t *testing.T) {
 
 	t.Run("wrong_tier", func(t *testing.T) {
 		handler := New(Options{
-			ReceiptDir: dir,
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir,
 			TrustedKeys: map[string]TrustedKey{
 				keyHex: {Source: trustedKeySource},
 			},
@@ -125,9 +129,10 @@ func TestHandler_AgentsRendersGroups(t *testing.T) {
 
 	dir, trusted := writeTrustedHandlerSession(t)
 	handler := New(Options{
-		ReceiptDir:  dir,
-		TrustedKeys: trusted,
-		HasFeature:  allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(
@@ -170,9 +175,10 @@ func TestHandler_AgentsHostileEvidenceEscapedAndNoAggregateGreen(t *testing.T) {
 	writeReceiptsToDir(t, dir, []receipt.Receipt{resigned})
 
 	handler := New(Options{
-		ReceiptDir:  dir,
-		TrustedKeys: map[string]TrustedKey{keyHex: {Source: trustedKeySource}},
-		HasFeature:  allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      map[string]TrustedKey{keyHex: {Source: trustedKeySource}},
+		HasFeature:       allowAgentsFeature,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(
@@ -201,9 +207,10 @@ func TestHandler_AgentDetail(t *testing.T) {
 
 	dir, trusted := writeTrustedHandlerSession(t)
 	handler := New(Options{
-		ReceiptDir:  dir,
-		TrustedKeys: trusted,
-		HasFeature:  allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
 	})
 
 	t.Run("found", func(t *testing.T) {
@@ -258,9 +265,10 @@ func TestHandler_Investigator(t *testing.T) {
 	trusted := map[string]TrustedKey{keyHex: {Source: trustedKeySource}}
 
 	handler := New(Options{
-		ReceiptDir:  dir,
-		TrustedKeys: trusted,
-		HasFeature:  allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
 	})
 
 	t.Run("found_seq_0", func(t *testing.T) {
@@ -376,10 +384,11 @@ func TestHandler_InvestigatorHostileEvidenceEscaped(t *testing.T) {
 
 	t.Run("raw_view_escapes", func(t *testing.T) {
 		handler := New(Options{
-			ReceiptDir:   dir,
-			TrustedKeys:  map[string]TrustedKey{keyHex: {Source: trustedKeySource}},
-			HasFeature:   allowAgentsFeature,
-			AuthorizeRaw: allowRawAccess,
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir,
+			TrustedKeys:      map[string]TrustedKey{keyHex: {Source: trustedKeySource}},
+			HasFeature:       allowAgentsFeature,
+			AuthorizeRaw:     allowRawAccess,
 		})
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, httptest.NewRequestWithContext(
@@ -405,9 +414,10 @@ func TestHandler_InvestigatorHostileEvidenceEscaped(t *testing.T) {
 
 	t.Run("metadata_view_redacts_target", func(t *testing.T) {
 		handler := New(Options{
-			ReceiptDir:  dir,
-			TrustedKeys: map[string]TrustedKey{keyHex: {Source: trustedKeySource}},
-			HasFeature:  allowAgentsFeature,
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir,
+			TrustedKeys:      map[string]TrustedKey{keyHex: {Source: trustedKeySource}},
+			HasFeature:       allowAgentsFeature,
 			// No AuthorizeRaw => metadata view.
 		})
 		rec := httptest.NewRecorder()
@@ -477,9 +487,10 @@ func TestHandler_InvestigatorMetadataRedactsRawExplanationFields(t *testing.T) {
 	writeReceiptsToDir(t, dir, []receipt.Receipt{resigned})
 
 	handler := New(Options{
-		ReceiptDir:  dir,
-		TrustedKeys: map[string]TrustedKey{keyHex: {Source: trustedKeySource}},
-		HasFeature:  allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      map[string]TrustedKey{keyHex: {Source: trustedKeySource}},
+		HasFeature:       allowAgentsFeature,
 		// No AuthorizeRaw => metadata view.
 	})
 	rec := httptest.NewRecorder()
@@ -692,7 +703,9 @@ func TestHandler_NoLicenseAllRoutes(t *testing.T) {
 		"/exemptions",
 	}
 
-	handler := New(Options{ReceiptDir: dir})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: dir,
+	})
 	for _, path := range allPaths {
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, httptest.NewRequestWithContext(
@@ -774,9 +787,10 @@ func TestHandler_SessionPathStillWorks(t *testing.T) {
 
 	dir, trusted := writeTrustedHandlerSession(t)
 	handler := New(Options{
-		ReceiptDir:  dir,
-		TrustedKeys: trusted,
-		HasFeature:  allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
 	})
 
 	t.Run("direct_session", func(t *testing.T) {

--- a/enterprise/dashboard/budgets_test.go
+++ b/enterprise/dashboard/budgets_test.go
@@ -101,10 +101,11 @@ func TestBudgets_Gating(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			handler := New(Options{
-				ReceiptDir:   t.TempDir(),
-				HasFeature:   tt.hasFeature,
-				BudgetSource: &fakeBudgetSource{agents: []AgentBudgetView{budgetAgentWithSession()}},
-				AuthorizeRaw: allowRawAccess,
+				TrustedOuterAuth: true,
+				ReceiptDir:       t.TempDir(),
+				HasFeature:       tt.hasFeature,
+				BudgetSource:     &fakeBudgetSource{agents: []AgentBudgetView{budgetAgentWithSession()}},
+				AuthorizeRaw:     allowRawAccess,
 			})
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/budgets", nil))
@@ -123,9 +124,10 @@ func TestBudgets_Gating(t *testing.T) {
 func TestBudgets_NilSourceDegrades(t *testing.T) {
 	t.Parallel()
 	handler := New(Options{
-		ReceiptDir:   t.TempDir(),
-		HasFeature:   func(f string) bool { return f == license.FeatureAgents },
-		AuthorizeRaw: allowRawAccess,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       func(f string) bool { return f == license.FeatureAgents },
+		AuthorizeRaw:     allowRawAccess,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/budgets", nil))
@@ -144,10 +146,11 @@ func TestBudgets_RouteExactMethodAndSourceError(t *testing.T) {
 		t.Parallel()
 		source := &fakeBudgetSource{agents: []AgentBudgetView{budgetAgentWithSession()}}
 		handler := New(Options{
-			ReceiptDir:   t.TempDir(),
-			HasFeature:   func(f string) bool { return f == license.FeatureAgents },
-			BudgetSource: source,
-			AuthorizeRaw: allowRawAccess,
+			TrustedOuterAuth: true,
+			ReceiptDir:       t.TempDir(),
+			HasFeature:       func(f string) bool { return f == license.FeatureAgents },
+			BudgetSource:     source,
+			AuthorizeRaw:     allowRawAccess,
 		})
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/budgets/", nil))
@@ -163,10 +166,11 @@ func TestBudgets_RouteExactMethodAndSourceError(t *testing.T) {
 		t.Parallel()
 		source := &fakeBudgetSource{agents: []AgentBudgetView{budgetAgentWithSession()}}
 		handler := New(Options{
-			ReceiptDir:   t.TempDir(),
-			HasFeature:   func(f string) bool { return f == license.FeatureAgents },
-			BudgetSource: source,
-			AuthorizeRaw: allowRawAccess,
+			TrustedOuterAuth: true,
+			ReceiptDir:       t.TempDir(),
+			HasFeature:       func(f string) bool { return f == license.FeatureAgents },
+			BudgetSource:     source,
+			AuthorizeRaw:     allowRawAccess,
 		})
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/budgets", nil))
@@ -185,10 +189,11 @@ func TestBudgets_RouteExactMethodAndSourceError(t *testing.T) {
 		t.Parallel()
 		source := &fakeBudgetSource{err: fmt.Errorf("backend details should not leak")}
 		handler := New(Options{
-			ReceiptDir:   t.TempDir(),
-			HasFeature:   func(f string) bool { return f == license.FeatureAgents },
-			BudgetSource: source,
-			AuthorizeRaw: allowRawAccess,
+			TrustedOuterAuth: true,
+			ReceiptDir:       t.TempDir(),
+			HasFeature:       func(f string) bool { return f == license.FeatureAgents },
+			BudgetSource:     source,
+			AuthorizeRaw:     allowRawAccess,
 		})
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/budgets", nil))
@@ -208,10 +213,11 @@ func TestBudgets_SessionIDRedaction(t *testing.T) {
 
 	newHandler := func(raw func(*http.Request) error) http.Handler {
 		return New(Options{
-			ReceiptDir:   t.TempDir(),
-			HasFeature:   func(f string) bool { return f == license.FeatureAgents },
-			BudgetSource: &fakeBudgetSource{agents: []AgentBudgetView{budgetAgentWithSession()}},
-			AuthorizeRaw: raw,
+			TrustedOuterAuth: true,
+			ReceiptDir:       t.TempDir(),
+			HasFeature:       func(f string) bool { return f == license.FeatureAgents },
+			BudgetSource:     &fakeBudgetSource{agents: []AgentBudgetView{budgetAgentWithSession()}},
+			AuthorizeRaw:     raw,
 		})
 	}
 

--- a/enterprise/dashboard/compliance_test.go
+++ b/enterprise/dashboard/compliance_test.go
@@ -169,9 +169,10 @@ func TestComplianceReadPrincipalReachesOnlyComplianceRoutes(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
-		ReceiptDir: t.TempDir(),
-		HasFeature: func(string) bool { return true },
-		Authorize:  func(*http.Request) error { return nil },
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       func(string) bool { return true },
+		Authorize:        func(*http.Request) error { return nil },
 		AuthorizeRaw: func(*http.Request) error {
 			return errors.New("raw denied")
 		},
@@ -228,7 +229,8 @@ func TestComplianceHTTPHasNoLegalHoldMutationAuthority(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 	handler := New(Options{
-		ReceiptDir: t.TempDir(), LegalHoldStore: store,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(), LegalHoldStore: store,
 		HasFeature:          func(string) bool { return true },
 		Authorize:           func(*http.Request) error { return nil },
 		AuthorizePermission: func(*http.Request, Permission) error { return nil },
@@ -416,8 +418,8 @@ type complianceFleetFake struct {
 	err      error
 }
 
-func (f *complianceFleetFake) ListFleetFollowers(context.Context, string, string, int) ([]FleetFollowerView, error) {
-	return nil, nil
+func (f *complianceFleetFake) ListFleetFollowers(context.Context, string, string, int) (FleetFollowerPage, error) {
+	return FleetFollowerPage{CompletenessKnown: true}, nil
 }
 
 func (f *complianceFleetFake) ListFleetAgentCoverage(context.Context, string, string, int) ([]FleetAgentCoverage, error) {

--- a/enterprise/dashboard/delivery_inbox.go
+++ b/enterprise/dashboard/delivery_inbox.go
@@ -112,7 +112,7 @@ func OpenDeliveryInbox(opts DeliveryInboxOptions) (*DeliveryInbox, error) {
 	state := deliveryInboxState{Version: deliveryInboxVersion}
 	data, err := readBoundedDeliveryInbox(path)
 	if err == nil {
-		if err := decodeStrictJSON(data, &state); err != nil || validateDeliveryState(state) != nil {
+		if err := decodeStrictJSON(data, &state); err != nil || normalizeDeliveryState(&state) != nil {
 			return nil, errors.New("delivery inbox: invalid persisted state")
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -140,7 +140,7 @@ func (i *DeliveryInbox) Record(attempt DeliveryAttempt) bool {
 	case i.queue <- attempt:
 		return true
 	default:
-		i.pendingDrops.Add(1)
+		saturatingAddAtomicUint64(&i.pendingDrops, 1)
 		select {
 		case i.dropSignal <- struct{}{}:
 		default:
@@ -175,9 +175,6 @@ func validateDeliveryState(state deliveryInboxState) error {
 	if state.Version != deliveryInboxVersion {
 		return errors.New("unknown delivery inbox version")
 	}
-	if len(state.Attempts) > maxPersistedDeliveryAttempts || len(state.DeadLetters) > maxPersistedDeadLetters {
-		return errors.New("delivery inbox exceeds persisted sample limit")
-	}
 	var sampled deliveryTotals
 	for _, attempt := range state.Attempts {
 		if err := validateDeliveryAttempt(attempt); err != nil {
@@ -200,6 +197,40 @@ func validateDeliveryState(state deliveryInboxState) error {
 		}
 	}
 	return nil
+}
+
+func normalizeDeliveryState(state *deliveryInboxState) error {
+	if err := validateDeliveryState(*state); err != nil {
+		return err
+	}
+	trimDeliveryRetention(state)
+	return nil
+}
+
+func trimDeliveryRetention(state *deliveryInboxState) {
+	if len(state.Attempts) > maxPersistedDeliveryAttempts {
+		state.Attempts = append([]DeliveryAttempt(nil), state.Attempts[len(state.Attempts)-maxPersistedDeliveryAttempts:]...)
+	}
+	if len(state.DeadLetters) > maxPersistedDeadLetters {
+		state.DeadLetters = append([]DeliveryAttempt(nil), state.DeadLetters[len(state.DeadLetters)-maxPersistedDeadLetters:]...)
+	}
+}
+
+func saturatingAddUint64(value, delta uint64) uint64 {
+	if ^uint64(0)-value < delta {
+		return ^uint64(0)
+	}
+	return value + delta
+}
+
+func saturatingAddAtomicUint64(value *atomic.Uint64, delta uint64) {
+	for {
+		current := value.Load()
+		next := saturatingAddUint64(current, delta)
+		if value.CompareAndSwap(current, next) {
+			return
+		}
+	}
 }
 
 func truncateUTF8(value string, maxBytes int) string {
@@ -314,11 +345,11 @@ func (i *DeliveryInbox) apply(attempt DeliveryAttempt) {
 	}
 	i.state.UpdatedAt = attempt.AttemptedAt.UTC()
 	drops := i.pendingDrops.Swap(0)
-	i.state.Dropped += drops
+	i.state.Dropped = saturatingAddUint64(i.state.Dropped, drops)
 	if err := i.persistLocked(); err != nil {
 		i.workerErr = errors.Join(i.workerErr, err)
 		i.state = priorState
-		i.pendingDrops.Add(drops)
+		saturatingAddAtomicUint64(&i.pendingDrops, drops)
 	}
 	i.mu.Unlock()
 }
@@ -332,27 +363,29 @@ func (i *DeliveryInbox) flushDrops() {
 	release, err := i.acquireMutationLock()
 	if err != nil {
 		i.workerErr = errors.Join(i.workerErr, err)
-		i.pendingDrops.Add(drops)
+		saturatingAddAtomicUint64(&i.pendingDrops, drops)
 		i.mu.Unlock()
 		return
 	}
 	defer release()
 	if err := i.reloadLocked(); err != nil {
 		i.workerErr = errors.Join(i.workerErr, err)
-		i.pendingDrops.Add(drops)
+		saturatingAddAtomicUint64(&i.pendingDrops, drops)
 		i.mu.Unlock()
 		return
 	}
-	i.state.Dropped += drops
+	priorDropped := i.state.Dropped
+	i.state.Dropped = saturatingAddUint64(i.state.Dropped, drops)
 	if err := i.persistLocked(); err != nil {
 		i.workerErr = errors.Join(i.workerErr, err)
-		i.state.Dropped -= drops
-		i.pendingDrops.Add(drops)
+		i.state.Dropped = priorDropped
+		saturatingAddAtomicUint64(&i.pendingDrops, drops)
 	}
 	i.mu.Unlock()
 }
 
 func (i *DeliveryInbox) persistLocked() error {
+	trimDeliveryRetention(&i.state)
 	var data bytes.Buffer
 	encoder := json.NewEncoder(&data)
 	encoder.SetEscapeHTML(false)
@@ -390,7 +423,7 @@ func (i *DeliveryInbox) reloadLocked() error {
 		return fmt.Errorf("delivery inbox: reload: %w", err)
 	}
 	var state deliveryInboxState
-	if err := decodeStrictJSON(data, &state); err != nil || validateDeliveryState(state) != nil {
+	if err := decodeStrictJSON(data, &state); err != nil || normalizeDeliveryState(&state) != nil {
 		return errors.New("delivery inbox: reload invalid persisted state")
 	}
 	i.state = state
@@ -409,7 +442,7 @@ func (i *DeliveryInbox) Health() DeliveryHealth {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	health := deliveryHealthFromState(i.state)
-	health.Dropped += i.pendingDrops.Load()
+	health.Dropped = saturatingAddUint64(health.Dropped, i.pendingDrops.Load())
 	return health
 }
 
@@ -438,7 +471,7 @@ func deliveryHealthFromState(state deliveryInboxState) DeliveryHealth {
 }
 
 func readBoundedDeliveryInbox(path string) ([]byte, error) {
-	file, err := os.Open(filepath.Clean(path))
+	file, _, err := openRegularDashboardFile(path, "delivery inbox")
 	if err != nil {
 		return nil, err
 	}
@@ -455,6 +488,8 @@ func readBoundedDeliveryInbox(path string) ([]byte, error) {
 
 // Pending returns queued and failed attempts for a future forwarder. The
 // returned slice is detached from the store and cannot mutate durable state.
+// TODO: define the producer acknowledge/retry/archive/purge lifecycle before
+// delivery forwarding depends on this retention sample.
 func (i *DeliveryInbox) Pending() []DeliveryAttempt {
 	i.mu.RLock()
 	defer i.mu.RUnlock()

--- a/enterprise/dashboard/evidence_nonblock_unix.go
+++ b/enterprise/dashboard/evidence_nonblock_unix.go
@@ -1,0 +1,9 @@
+//go:build enterprise && !windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import "syscall"
+
+const evidenceNonblockFlag = syscall.O_NONBLOCK

--- a/enterprise/dashboard/evidence_nonblock_windows.go
+++ b/enterprise/dashboard/evidence_nonblock_windows.go
@@ -1,0 +1,7 @@
+//go:build enterprise && windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+const evidenceNonblockFlag = 0

--- a/enterprise/dashboard/exemption_store.go
+++ b/enterprise/dashboard/exemption_store.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -20,6 +21,8 @@ import (
 // Stale threshold for exemption records: if a record has a LastMatched
 // timestamp older than this duration before "now", it is considered stale.
 const staleThreshold = 30 * 24 * time.Hour // 30 days
+
+const maxExemptionStoreFileBytes = 8 << 20
 
 // Bounded lifecycle status strings returned by ExemptionRecord.Status.
 const (
@@ -91,7 +94,7 @@ func OpenExemptionStore(path string) (*ExemptionStore, error) {
 	}
 
 	s := &ExemptionStore{path: cleanPath}
-	data, err := os.ReadFile(cleanPath)
+	data, err := readBoundedExemptionStore(cleanPath)
 	if errors.Is(err, os.ErrNotExist) {
 		return s, nil
 	}
@@ -307,7 +310,7 @@ func (s *ExemptionStore) acquireMutationLock() (func(), error) {
 }
 
 func (s *ExemptionStore) reloadLocked() error {
-	data, err := os.ReadFile(s.path)
+	data, err := readBoundedExemptionStore(s.path)
 	if errors.Is(err, os.ErrNotExist) {
 		s.records = nil
 		return nil
@@ -325,10 +328,39 @@ func (s *ExemptionStore) reloadLocked() error {
 	return nil
 }
 
+func readBoundedExemptionStore(path string) ([]byte, error) {
+	file, _, err := openRegularDashboardFile(path, "exemption store")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	data, err := io.ReadAll(io.LimitReader(file, maxExemptionStoreFileBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxExemptionStoreFileBytes {
+		return nil, fmt.Errorf("exemption store exceeds %d bytes", maxExemptionStoreFileBytes)
+	}
+	return data, nil
+}
+
 func (s *ExemptionStore) decodeRecords(data []byte) error {
 	var records []ExemptionRecord
-	if err := json.Unmarshal(data, &records); err != nil {
+	if err := decodeStrictJSON(data, &records); err != nil {
 		return err
+	}
+	if records == nil {
+		return errors.New("exemption store: root must be a JSON array")
+	}
+	seen := make(map[string]struct{}, len(records))
+	for _, record := range records {
+		if err := validateExemptionRecordForAdd(record); err != nil {
+			return err
+		}
+		if _, duplicate := seen[record.ID]; duplicate {
+			return fmt.Errorf("exemption store: duplicate id %q", record.ID)
+		}
+		seen[record.ID] = struct{}{}
 	}
 	s.records = records
 	return nil

--- a/enterprise/dashboard/exemption_store.go
+++ b/enterprise/dashboard/exemption_store.go
@@ -334,7 +334,7 @@ func readBoundedExemptionStore(path string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = file.Close() }()
-	if err := requireOwnerOnlyDashboardFile(info, "exemption store"); err != nil {
+	if err := requireOwnerOnlyDashboardFile(file, info, "exemption store"); err != nil {
 		return nil, err
 	}
 	data, err := io.ReadAll(io.LimitReader(file, maxExemptionStoreFileBytes+1))

--- a/enterprise/dashboard/exemption_store.go
+++ b/enterprise/dashboard/exemption_store.go
@@ -329,11 +329,14 @@ func (s *ExemptionStore) reloadLocked() error {
 }
 
 func readBoundedExemptionStore(path string) ([]byte, error) {
-	file, _, err := openRegularDashboardFile(path, "exemption store")
+	file, info, err := openRegularDashboardFile(path, "exemption store")
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = file.Close() }()
+	if err := requireOwnerOnlyDashboardFile(info, "exemption store"); err != nil {
+		return nil, err
+	}
 	data, err := io.ReadAll(io.LimitReader(file, maxExemptionStoreFileBytes+1))
 	if err != nil {
 		return nil, err

--- a/enterprise/dashboard/exemption_store_lock_windows.go
+++ b/enterprise/dashboard/exemption_store_lock_windows.go
@@ -4,23 +4,43 @@
 
 package dashboard
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
 
 type exemptionStoreFileLock struct {
-	file *os.File
+	file       *os.File
+	overlapped windows.Overlapped
 }
 
 func acquireExemptionStoreFileLock(path string) (*exemptionStoreFileLock, error) {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	file, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, err
 	}
-	return &exemptionStoreFileLock{file: file}, nil
+	lock := &exemptionStoreFileLock{file: file}
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, ^uint32(0), ^uint32(0), &lock.overlapped); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock file: %w", err)
+	}
+	return lock, nil
 }
 
 func (l *exemptionStoreFileLock) Close() error {
 	if l == nil || l.file == nil {
 		return nil
 	}
-	return l.file.Close()
+	unlockErr := windows.UnlockFileEx(windows.Handle(l.file.Fd()), 0, ^uint32(0), ^uint32(0), &l.overlapped)
+	closeErr := l.file.Close()
+	if unlockErr != nil {
+		return fmt.Errorf("unlock: %w", unlockErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close lock file: %w", closeErr)
+	}
+	return nil
 }

--- a/enterprise/dashboard/exemption_store_lock_windows_test.go
+++ b/enterprise/dashboard/exemption_store_lock_windows_test.go
@@ -1,0 +1,40 @@
+//go:build enterprise && windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestExemptionStoreFileLockWindowsExcludesOtherHandles(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.lock")
+	lock, err := acquireExemptionStoreFileLock(path)
+	if err != nil {
+		t.Fatalf("acquireExemptionStoreFileLock: %v", err)
+	}
+	defer func() { _ = lock.Close() }()
+
+	file, err := os.OpenFile(filepath.Clean(path), os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	var overlapped windows.Overlapped
+	err = windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, ^uint32(0), ^uint32(0), &overlapped)
+	if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		if err == nil {
+			_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, ^uint32(0), ^uint32(0), &overlapped)
+		}
+		t.Fatalf("competing lock error = %v, want ERROR_LOCK_VIOLATION", err)
+	}
+}

--- a/enterprise/dashboard/exemption_store_test.go
+++ b/enterprise/dashboard/exemption_store_test.go
@@ -122,6 +122,72 @@ func TestExemptionStore_CorruptedJSONReturnsError(t *testing.T) {
 	}
 }
 
+func TestOpenExemptionStoreRejectsAmbiguousOrInvalidDirectLoad(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	base := `{"id":"exm-a","scope":"api.vendor.example","owner":"ops-team","reason":"reviewed exemption","created":"` + now.Format(time.RFC3339) + `","expiry":"` + now.Add(time.Hour).Format(time.RFC3339) + `"}`
+	tests := []struct {
+		name string
+		data string
+	}{
+		{name: "duplicate json key", data: `[` + strings.Replace(base, `"id":"exm-a"`, `"id":"exm-a","id":"exm-b"`, 1) + `]`},
+		{name: "unknown field", data: `[` + strings.Replace(base, `"scope":`, `"future":true,"scope":`, 1) + `]`},
+		{name: "invalid record", data: `[` + strings.Replace(base, `"owner":"ops-team"`, `"owner":""`, 1) + `]`},
+		{name: "duplicate id", data: `[` + base + `,` + base + `]`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "exemptions.json")
+			if err := os.WriteFile(path, []byte(test.data), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := OpenExemptionStore(path); err == nil {
+				t.Fatal("OpenExemptionStore accepted invalid direct-load JSON")
+			}
+		})
+	}
+}
+
+func TestOpenExemptionStoreRejectsOversizedDirectLoad(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "exemptions.json")
+	file, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) // #nosec G304 -- test file under t.TempDir
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(maxExemptionStoreFileBytes + 1); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenExemptionStore(path); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("OpenExemptionStore oversized error = %v", err)
+	}
+}
+
+func TestOpenExemptionStoreRejectsSymlinkDirectLoad(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.json")
+	if err := os.WriteFile(target, []byte(`[]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "exemptions.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenExemptionStore(link); err == nil {
+		t.Fatal("OpenExemptionStore accepted a symlink")
+	}
+}
+
 func TestExemptionStore_ValidationRejects(t *testing.T) {
 	t.Parallel()
 

--- a/enterprise/dashboard/exemptions_test.go
+++ b/enterprise/dashboard/exemptions_test.go
@@ -314,11 +314,12 @@ func TestExemptions_DefaultBaselinesDoNotBecomeAttentionWhenFeatureDisabled(t *t
 	}
 
 	handler := New(Options{
-		ReceiptDir:   t.TempDir(),
-		Config:       cfg,
-		HasFeature:   allowAgentsFeature,
-		Authorize:    func(*http.Request) error { return nil },
-		AuthorizeRaw: allowRawAccess,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		Config:           cfg,
+		HasFeature:       allowAgentsFeature,
+		Authorize:        func(*http.Request) error { return nil },
+		AuthorizeRaw:     allowRawAccess,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/exemptions", nil))
@@ -451,10 +452,11 @@ func TestHandler_ExemptionsHostileConfigEscapes(t *testing.T) {
 		}},
 	}
 	handler := New(Options{
-		ReceiptDir: t.TempDir(),
-		Config:     cfg,
-		HasFeature: allowAgentsFeature,
-		Authorize:  func(*http.Request) error { return nil },
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		Config:           cfg,
+		HasFeature:       allowAgentsFeature,
+		Authorize:        func(*http.Request) error { return nil },
 		// Raw access so the hostile config values are actually rendered (and
 		// therefore html/template-escaped); the metadata-only path redacts them
 		// instead and is covered by TestHandler_ExemptionsMetadataViewRedactsRawValues.

--- a/enterprise/dashboard/fleetoverview.go
+++ b/enterprise/dashboard/fleetoverview.go
@@ -37,9 +37,16 @@ var (
 // FleetDataSource is the dashboard-local read seam for conductor fleet state.
 // Implementations must be read-only: the Fleet Overview route has no write or
 // control authority. The limit is a hard maximum requested by the dashboard;
-// implementations should apply it at the backing query boundary.
+// implementations should apply it at the backing query boundary and must return
+// an explicit completeness signal. Unknown completeness is treated as truncated.
 type FleetDataSource interface {
-	ListFleetFollowers(ctx context.Context, orgID, fleetID string, limit int) ([]FleetFollowerView, error)
+	ListFleetFollowers(ctx context.Context, orgID, fleetID string, limit int) (FleetFollowerPage, error)
+}
+
+type FleetFollowerPage struct {
+	Followers         []FleetFollowerView
+	CompletenessKnown bool
+	HasMore           bool
 }
 
 // FleetFollowerView is the dashboard-local follower row. It intentionally
@@ -119,12 +126,16 @@ func (m *ReadModel) FleetOverview(ctx context.Context, orgID, fleetID string, ra
 	if m.fleetSource == nil {
 		return overview, nil
 	}
-	followers, err := m.fleetSource.ListFleetFollowers(ctx, orgID, fleetID, fleetOverviewFollowerLimit+1)
+	page, err := m.fleetSource.ListFleetFollowers(ctx, orgID, fleetID, fleetOverviewFollowerLimit+1)
 	if err != nil {
 		return FleetOverview{}, fmt.Errorf("list fleet followers: %w", err)
 	}
+	followers := page.Followers
 	if len(followers) > fleetOverviewFollowerLimit {
 		followers = followers[:fleetOverviewFollowerLimit]
+		overview.Truncated = true
+	}
+	if !page.CompletenessKnown || page.HasMore {
 		overview.Truncated = true
 	}
 	followers = normalizeFleetFollowers(followers)

--- a/enterprise/dashboard/fleetoverview_test.go
+++ b/enterprise/dashboard/fleetoverview_test.go
@@ -42,22 +42,24 @@ const (
 
 type fakeFleetSource struct {
 	followers []FleetFollowerView
+	hasMore   bool
+	unknown   bool
 	err       error
 	gotOrgID  string
 	gotFleet  string
 	gotLimit  int
 }
 
-func (f *fakeFleetSource) ListFleetFollowers(_ context.Context, orgID, fleetID string, limit int) ([]FleetFollowerView, error) {
+func (f *fakeFleetSource) ListFleetFollowers(_ context.Context, orgID, fleetID string, limit int) (FleetFollowerPage, error) {
 	f.gotOrgID = orgID
 	f.gotFleet = fleetID
 	f.gotLimit = limit
 	if f.err != nil {
-		return nil, f.err
+		return FleetFollowerPage{}, f.err
 	}
 	out := make([]FleetFollowerView, len(f.followers))
 	copy(out, f.followers)
-	return out, nil
+	return FleetFollowerPage{Followers: out, CompletenessKnown: !f.unknown, HasMore: f.hasMore}, nil
 }
 
 func TestFleetOverview_Gating(t *testing.T) {
@@ -101,6 +103,7 @@ func TestFleetOverview_Gating(t *testing.T) {
 			t.Parallel()
 
 			handler := New(Options{
+				TrustedOuterAuth:    true,
 				ReceiptDir:          t.TempDir(),
 				HasFeature:          tt.hasFeature,
 				FleetSource:         &fakeFleetSource{},
@@ -131,7 +134,8 @@ func TestFleetOverview_CrossTierGating(t *testing.T) {
 		"/session/example/receipt/0",
 	}
 	fleetOnly := New(Options{
-		ReceiptDir: t.TempDir(),
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
 		HasFeature: func(feature string) bool {
 			return feature == license.FeatureFleet
 		},
@@ -146,7 +150,8 @@ func TestFleetOverview_CrossTierGating(t *testing.T) {
 	}
 
 	agentsOnly := New(Options{
-		ReceiptDir: t.TempDir(),
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
 		HasFeature: func(feature string) bool {
 			return feature == license.FeatureAgents
 		},
@@ -163,8 +168,9 @@ func TestFleetOverview_NilSourceRendersEmptyState(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
-		ReceiptDir: t.TempDir(),
-		HasFeature: allowFleetFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       allowFleetFeature,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fleet", nil))
@@ -196,6 +202,7 @@ func TestFleetOverview_FailClosedScopeAuthorization(t *testing.T) {
 
 			source := &fakeFleetSource{followers: testFleetFollowers()}
 			handler := New(Options{
+				TrustedOuterAuth:    true,
 				ReceiptDir:          t.TempDir(),
 				HasFeature:          allowFleetFeature,
 				FleetSource:         source,
@@ -218,6 +225,7 @@ func TestFleetOverview_RendersSignedUnsignedAndHonestyWording(t *testing.T) {
 
 	source := &fakeFleetSource{followers: testFleetFollowers()}
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		FleetSource:         source,
@@ -266,9 +274,10 @@ func TestFleetOverview_RedactsMetadataView(t *testing.T) {
 
 	source := &fakeFleetSource{followers: testFleetFollowers()[:1]}
 	handler := New(Options{
-		ReceiptDir:  t.TempDir(),
-		HasFeature:  allowFleetFeature,
-		FleetSource: source,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       allowFleetFeature,
+		FleetSource:      source,
 		// No AuthorizeRaw: metadata view must fail closed.
 		AuthorizeFleetScope: allowFleetScope,
 	})
@@ -339,6 +348,7 @@ func TestFleetOverview_RawViewEscapesFollowerStrings(t *testing.T) {
 	follower.BatchID = hostileImage
 	follower.LastApplyErrorMessage = hostileScript
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		FleetSource:         &fakeFleetSource{followers: []FleetFollowerView{follower}},
@@ -367,6 +377,7 @@ func TestFleetOverview_SourceErrorReturnsServerError(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		FleetSource:         &fakeFleetSource{err: errors.New("source unavailable")},
@@ -383,6 +394,7 @@ func TestFleetOverview_RejectsInvalidScope(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		FleetSource:         &fakeFleetSource{},
@@ -423,6 +435,7 @@ func TestFleetOverview_TruncatesFollowerRows(t *testing.T) {
 		}
 	}
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		FleetSource:         &fakeFleetSource{followers: followers},
@@ -439,13 +452,48 @@ func TestFleetOverview_TruncatesFollowerRows(t *testing.T) {
 	}
 }
 
+func TestFleetOverview_FailClosedUnknownCompleteness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source *fakeFleetSource
+	}{
+		{name: "unknown", source: &fakeFleetSource{followers: testFleetFollowers()[:1], unknown: true}},
+		{name: "has_more", source: &fakeFleetSource{followers: testFleetFollowers()[:1], hasMore: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := New(Options{
+				TrustedOuterAuth:    true,
+				ReceiptDir:          t.TempDir(),
+				HasFeature:          allowFleetFeature,
+				FleetSource:         tt.source,
+				AuthorizeRaw:        allowRawAccess,
+				AuthorizeFleetScope: allowFleetScope,
+			})
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fleet?org_id="+fleetTestOrgID+"&fleet_id="+fleetTestFleetID, nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "Showing the first") {
+				t.Fatalf("unknown completeness was not reported as truncated: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestFleetOverview_RejectsNonGet(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
-		ReceiptDir:  t.TempDir(),
-		HasFeature:  allowFleetFeature,
-		FleetSource: &fakeFleetSource{},
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       allowFleetFeature,
+		FleetSource:      &fakeFleetSource{},
 	})
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
 		t.Run(method, func(t *testing.T) {
@@ -467,9 +515,10 @@ func TestFleetOverview_RejectsNonExactPath(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
-		ReceiptDir:  t.TempDir(),
-		HasFeature:  allowFleetFeature,
-		FleetSource: &fakeFleetSource{},
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       allowFleetFeature,
+		FleetSource:      &fakeFleetSource{},
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fleet/extra", nil))

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -252,8 +252,9 @@ func AllPermissions() []Permission {
 // license-feature check is NOT authentication. Mount this handler ONLY on an
 // authenticated, admin-only listener, and never on the agent-reachable proxy
 // port. Set Options.Authorize to enforce an authenticated principal per
-// request; it fails closed when it returns an error. When Authorize is nil the
-// surrounding router MUST provide the authentication boundary.
+// request; it fails closed when it returns an error. When both Authorize and
+// AuthorizePermission are nil, set Options.TrustedOuterAuth only if the
+// surrounding router provides the authentication boundary.
 func New(opts Options) http.Handler {
 	model := NewReadModel(opts)
 	mux := http.NewServeMux()
@@ -264,6 +265,7 @@ func New(opts Options) http.Handler {
 		authorizePermission: opts.AuthorizePermission,
 		authorizeRaw:        opts.AuthorizeRaw,
 		authorizeFleetScope: opts.AuthorizeFleetScope,
+		trustedOuterAuth:    opts.TrustedOuterAuth,
 		auditWriter:         opts.AuditWriter,
 	}
 	for _, spec := range dashboardRouteSpecs() {
@@ -279,6 +281,7 @@ type dashboardHandler struct {
 	authorizePermission func(*http.Request, Permission) error
 	authorizeRaw        func(*http.Request) error
 	authorizeFleetScope func(*http.Request, DecisionScope, bool) error
+	trustedOuterAuth    bool
 	auditWriter         io.Writer
 	auditMu             sync.Mutex
 }
@@ -443,6 +446,12 @@ func (d *dashboardHandler) routeGate(spec routeSpec, next http.Handler) http.Han
 		}
 		// Authentication boundary. The license check above is entitlement, not
 		// identity; fail closed when a configured authorizer rejects the request.
+		if d.authorize == nil && d.authorizePermission == nil && !d.trustedOuterAuth {
+			w.Header().Set("Content-Type", contentTypeText)
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("dashboard authentication required\n"))
+			return
+		}
 		if d.authorize != nil {
 			if err := d.authorize(r); err != nil {
 				w.Header().Set("Content-Type", contentTypeText)

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -32,7 +32,9 @@ func TestHandler_Gating(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	handler := New(Options{ReceiptDir: dir})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: dir,
+	})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
@@ -44,7 +46,8 @@ func TestHandler_Gating(t *testing.T) {
 	}
 
 	handler = New(Options{
-		ReceiptDir: dir,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
 		HasFeature: func(string) bool {
 			return false
 		},
@@ -73,9 +76,10 @@ func TestHandler_AllowedRendersScorecard(t *testing.T) {
 
 	dir, trusted := writeTrustedHandlerSession(t)
 	handler := New(Options{
-		ReceiptDir:  dir,
-		TrustedKeys: trusted,
-		HasFeature:  allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
@@ -100,6 +104,86 @@ func TestHandler_AllowedRendersScorecard(t *testing.T) {
 	}
 }
 
+func TestHandler_RequiresExplicitAuthBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		opts       Options
+		wantStatus int
+	}{
+		{
+			name: "nil auth callbacks deny",
+			opts: Options{
+				ReceiptDir: t.TempDir(),
+				HasFeature: allowAgentsFeature,
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "trusted outer auth explicit opt in",
+			opts: Options{
+				ReceiptDir:       t.TempDir(),
+				HasFeature:       allowAgentsFeature,
+				TrustedOuterAuth: true,
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "handler auth callback configured",
+			opts: Options{
+				ReceiptDir: t.TempDir(),
+				HasFeature: allowAgentsFeature,
+				Authorize:  func(*http.Request) error { return nil },
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "permission auth callback configured",
+			opts: Options{
+				ReceiptDir: t.TempDir(),
+				HasFeature: allowAgentsFeature,
+				AuthorizePermission: func(*http.Request, Permission) error {
+					return nil
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "raw callback alone denies",
+			opts: Options{
+				ReceiptDir:   t.TempDir(),
+				HasFeature:   allowAgentsFeature,
+				AuthorizeRaw: allowRawAccess,
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "fleet scope callback alone denies",
+			opts: Options{
+				ReceiptDir: t.TempDir(),
+				HasFeature: allowAgentsFeature,
+				AuthorizeFleetScope: func(*http.Request, DecisionScope, bool) error {
+					return nil
+				},
+			},
+			wantStatus: http.StatusForbidden,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := New(test.opts)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, test.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestHandler_ExemptionsAllowedRendersInventory(t *testing.T) {
 	t.Parallel()
 
@@ -111,12 +195,13 @@ func TestHandler_ExemptionsAllowedRendersInventory(t *testing.T) {
 	}
 	var audit strings.Builder
 	handler := New(Options{
-		ReceiptDir:   t.TempDir(),
-		Config:       cfg,
-		HasFeature:   allowAgentsFeature,
-		Authorize:    func(*http.Request) error { return nil },
-		AuditWriter:  &audit,
-		AuthorizeRaw: allowRawAccess,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		Config:           cfg,
+		HasFeature:       allowAgentsFeature,
+		Authorize:        func(*http.Request) error { return nil },
+		AuditWriter:      &audit,
+		AuthorizeRaw:     allowRawAccess,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/exemptions", nil))
@@ -156,7 +241,8 @@ func TestHandler_HostileEvidenceRenderEscapesReceiptFields(t *testing.T) {
 	writeReceiptsToDir(t, dir, []receipt.Receipt{resigned})
 
 	handler := New(Options{
-		ReceiptDir: dir,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
 		TrustedKeys: map[string]TrustedKey{
 			keyHex: {Source: trustedKeySource},
 		},
@@ -213,8 +299,9 @@ func TestHandler_MethodAndPathRejection(t *testing.T) {
 
 	dir := t.TempDir()
 	handler := New(Options{
-		ReceiptDir: dir,
-		HasFeature: allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		HasFeature:       allowAgentsFeature,
 	})
 
 	tests := []struct {
@@ -273,10 +360,11 @@ func TestHandler_RoutePermissionFailsClosed(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
-		ReceiptDir:   t.TempDir(),
-		HasFeature:   allowAllDashboardFeatures,
-		Authorize:    func(*http.Request) error { return nil },
-		AuthorizeRaw: allowRawAccess,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       allowAllDashboardFeatures,
+		Authorize:        func(*http.Request) error { return nil },
+		AuthorizeRaw:     allowRawAccess,
 		AuthorizePermission: func(*http.Request, Permission) error {
 			return errors.New("permission denied")
 		},
@@ -311,9 +399,10 @@ func TestHandler_RoutePermissionUsesSpecificPermission(t *testing.T) {
 
 	var got []Permission
 	handler := New(Options{
-		ReceiptDir: t.TempDir(),
-		HasFeature: allowAllDashboardFeatures,
-		Authorize:  func(*http.Request) error { return nil },
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       allowAllDashboardFeatures,
+		Authorize:        func(*http.Request) error { return nil },
 		AuthorizePermission: func(_ *http.Request, permission Permission) error {
 			got = append(got, permission)
 			return nil
@@ -351,6 +440,7 @@ func TestHandler_RawViewShownWhenRawPermissionGranted(t *testing.T) {
 
 	dir, trusted := writeTrustedHandlerSession(t)
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          dir,
 		TrustedKeys:         trusted,
 		HasFeature:          allowAgentsFeature,
@@ -400,11 +490,12 @@ func TestHandler_RawViewRequiresRawPermission(t *testing.T) {
 
 	dir, trusted := writeTrustedHandlerSession(t)
 	handler := New(Options{
-		ReceiptDir:   dir,
-		TrustedKeys:  trusted,
-		HasFeature:   allowAgentsFeature,
-		Authorize:    func(*http.Request) error { return nil },
-		AuthorizeRaw: allowRawAccess,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
+		Authorize:        func(*http.Request) error { return nil },
+		AuthorizeRaw:     allowRawAccess,
 		AuthorizePermission: func(_ *http.Request, permission Permission) error {
 			if permission == PermissionRawRead {
 				return errors.New("raw denied")
@@ -435,6 +526,7 @@ func TestHandler_ReadLimitWarning(t *testing.T) {
 	writeReceiptsToDir(t, dir, buildDashboardChain(t, priv, 4))
 
 	handler := New(Options{
+		TrustedOuterAuth: true,
 		ReceiptDir:       dir,
 		ReceiptReadLimit: 2,
 		TimelineLimit:    1,
@@ -468,8 +560,9 @@ func TestHandler_AbsenceRender(t *testing.T) {
 	dir := t.TempDir()
 	writeZeroReceiptSessionFile(t, dir, zeroSessionID)
 	handler := New(Options{
-		ReceiptDir: dir,
-		HasFeature: allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		HasFeature:       allowAgentsFeature,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+zeroSessionID, nil))
@@ -492,9 +585,10 @@ func TestHandler_AuthorizeFailsClosed(t *testing.T) {
 
 	// A rejecting authorizer must fail closed even when the feature is present.
 	denied := New(Options{
-		ReceiptDir: dir,
-		HasFeature: allowAgentsFeature,
-		Authorize:  func(*http.Request) error { return errors.New("no principal") },
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		HasFeature:       allowAgentsFeature,
+		Authorize:        func(*http.Request) error { return errors.New("no principal") },
 	})
 	rec := httptest.NewRecorder()
 	denied.ServeHTTP(rec, req)
@@ -507,9 +601,10 @@ func TestHandler_AuthorizeFailsClosed(t *testing.T) {
 
 	// An accepting authorizer reaches the handler.
 	allowed := New(Options{
-		ReceiptDir: dir,
-		HasFeature: allowAgentsFeature,
-		Authorize:  func(*http.Request) error { return nil },
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		HasFeature:       allowAgentsFeature,
+		Authorize:        func(*http.Request) error { return nil },
 	})
 	rec = httptest.NewRecorder()
 	allowed.ServeHTTP(rec, req)
@@ -541,9 +636,10 @@ func TestHandler_RedactsRawByDefault(t *testing.T) {
 
 	// No AuthorizeRaw configured => raw is redacted for everyone (fail closed).
 	handler := New(Options{
-		ReceiptDir:  dir,
-		TrustedKeys: trusted,
-		HasFeature:  allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
@@ -595,10 +691,11 @@ func TestHandler_RawAccessShowsDetail(t *testing.T) {
 	dir, trusted := writeTrustedHandlerSession(t)
 
 	handler := New(Options{
-		ReceiptDir:   dir,
-		TrustedKeys:  trusted,
-		HasFeature:   allowAgentsFeature,
-		AuthorizeRaw: allowRawAccess,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
+		AuthorizeRaw:     allowRawAccess,
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/session/"+testSessionID, nil))
@@ -627,9 +724,10 @@ func TestHandler_RawAccessDecisionIsCachedPerRequest(t *testing.T) {
 	var calls int
 	var audit strings.Builder
 	handler := New(Options{
-		ReceiptDir:  dir,
-		TrustedKeys: trusted,
-		HasFeature:  allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
 		AuthorizeRaw: func(*http.Request) error {
 			calls++
 			if calls == 1 {
@@ -662,7 +760,8 @@ func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 	t.Run("metadata_role_and_path_session", func(t *testing.T) {
 		var meta strings.Builder
 		metaHandler := New(Options{
-			ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
 			AuditWriter: &meta,
 		})
 		metaHandler.ServeHTTP(httptest.NewRecorder(),
@@ -681,7 +780,8 @@ func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 	t.Run("query_param_session", func(t *testing.T) {
 		var q strings.Builder
 		qHandler := New(Options{
-			ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
 			AuditWriter: &q,
 		})
 		qHandler.ServeHTTP(httptest.NewRecorder(),
@@ -694,7 +794,8 @@ func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 	t.Run("empty_session", func(t *testing.T) {
 		var none strings.Builder
 		noneHandler := New(Options{
-			ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
 			AuditWriter: &none,
 		})
 		noneHandler.ServeHTTP(httptest.NewRecorder(),
@@ -707,7 +808,8 @@ func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 	t.Run("raw_role", func(t *testing.T) {
 		var raw strings.Builder
 		rawHandler := New(Options{
-			ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
 			AuthorizeRaw: allowRawAccess, AuditWriter: &raw,
 		})
 		rawHandler.ServeHTTP(httptest.NewRecorder(),
@@ -751,11 +853,12 @@ func TestHandler_AuditWriterSerializesConcurrentRequests(t *testing.T) {
 
 	var audit strings.Builder
 	handler := New(Options{
-		ReceiptDir:   dir,
-		TrustedKeys:  trusted,
-		HasFeature:   allowAgentsFeature,
-		AuditWriter:  &audit,
-		AuthorizeRaw: allowRawAccess,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
+		AuditWriter:      &audit,
+		AuthorizeRaw:     allowRawAccess,
 	})
 
 	const requests = 25
@@ -785,7 +888,8 @@ func TestHandler_AuditNotWrittenForUnauthorized(t *testing.T) {
 
 	var buf strings.Builder
 	handler := New(Options{
-		ReceiptDir: dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
 		Authorize:   func(*http.Request) error { return errors.New("denied") },
 		AuditWriter: &buf,
 	})

--- a/enterprise/dashboard/incident.go
+++ b/enterprise/dashboard/incident.go
@@ -100,13 +100,17 @@ func (m *ReadModel) Incident(ctx context.Context, scope DecisionScope, rawAllowe
 // counts. It reuses the fleet overview's read seam and its follower limit, and
 // it normalizes health/drift through the same bounded classifier.
 func (m *ReadModel) fleetAppliedSummary(ctx context.Context, orgID, fleetID string) (FleetAppliedSummary, error) {
-	followers, err := m.fleetSource.ListFleetFollowers(ctx, orgID, fleetID, fleetOverviewFollowerLimit+1)
+	page, err := m.fleetSource.ListFleetFollowers(ctx, orgID, fleetID, fleetOverviewFollowerLimit+1)
 	if err != nil {
 		return FleetAppliedSummary{}, fmt.Errorf("list fleet followers: %w", err)
 	}
+	followers := page.Followers
 	var summary FleetAppliedSummary
 	if len(followers) > fleetOverviewFollowerLimit {
 		followers = followers[:fleetOverviewFollowerLimit]
+		summary.Truncated = true
+	}
+	if !page.CompletenessKnown || page.HasMore {
 		summary.Truncated = true
 	}
 	followers = normalizeFleetFollowers(followers)

--- a/enterprise/dashboard/incident_test.go
+++ b/enterprise/dashboard/incident_test.go
@@ -20,7 +20,9 @@ func incidentTarget() string {
 func TestIncident_ScopePromptWhenEmpty(t *testing.T) {
 	t.Parallel()
 
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature,
+	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/incident", nil))
 	if rec.Code != http.StatusOK {
@@ -37,7 +39,9 @@ func TestIncident_ScopePromptWhenEmpty(t *testing.T) {
 func TestIncident_UnconfiguredSourcesRenderAbsence(t *testing.T) {
 	t.Parallel()
 
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature,
+	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
 	if rec.Code != http.StatusOK {
@@ -57,6 +61,7 @@ func TestIncident_CorrelatesDecisionAndAppliedSummary(t *testing.T) {
 	source := &fakeConductorSource{view: testReplayView(), found: true}
 	fleet := &fakeFleetSource{followers: testFleetFollowers()}
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		ConductorSource:     source,
@@ -122,10 +127,11 @@ func TestIncident_MetadataViewRedactsDecision(t *testing.T) {
 	view.Conflict = "source error for " + wbSensitiveHash
 	source := &fakeConductorSource{view: view, found: true}
 	handler := New(Options{
-		ReceiptDir:      t.TempDir(),
-		HasFeature:      allowFleetFeature,
-		ConductorSource: source,
-		FleetSource:     &fakeFleetSource{followers: testFleetFollowers()},
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       allowFleetFeature,
+		ConductorSource:  source,
+		FleetSource:      &fakeFleetSource{followers: testFleetFollowers()},
 		// No AuthorizeRaw: fail closed.
 		AuthorizeFleetScope: allowFleetScope,
 	})
@@ -157,7 +163,9 @@ func TestIncident_DecisionMissingRendersEmpty(t *testing.T) {
 	t.Parallel()
 
 	source := &fakeConductorSource{found: false}
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope,
+	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, incidentTarget(), nil))
 	if rec.Code != http.StatusOK {
@@ -172,6 +180,7 @@ func TestIncident_FleetSourceErrorReturnsServerError(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		ConductorSource:     &fakeConductorSource{found: false},
@@ -189,6 +198,7 @@ func TestIncident_DecisionSourceErrorReturnsServerError(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		ConductorSource:     &fakeConductorSource{err: errors.New("replay unavailable")},

--- a/enterprise/dashboard/legal_hold_store.go
+++ b/enterprise/dashboard/legal_hold_store.go
@@ -267,7 +267,7 @@ func (s *LegalHoldStore) reloadLocked() error {
 		return fmt.Errorf("legal hold store: read: %w", err)
 	}
 	defer func() { _ = file.Close() }()
-	if err := requireOwnerOnlyDashboardFile(info, "legal hold store"); err != nil {
+	if err := requireOwnerOnlyDashboardFile(file, info, "legal hold store"); err != nil {
 		return err
 	}
 	data, err := io.ReadAll(io.LimitReader(file, legalHoldFileMaxBytes+1))

--- a/enterprise/dashboard/legal_hold_store.go
+++ b/enterprise/dashboard/legal_hold_store.go
@@ -83,18 +83,6 @@ func OpenLegalHoldStore(path string) (*LegalHoldStore, error) {
 	if strings.TrimSpace(path) == "" || cleanPath == "." {
 		return nil, errors.New("legal hold store: path is required")
 	}
-	info, err := os.Stat(cleanPath)
-	if err == nil {
-		if !info.Mode().IsRegular() {
-			return nil, errors.New("legal hold store: path must be a regular file")
-		}
-		insecureModeMask := os.FileMode(0o077)
-		if info.Mode().Perm()&insecureModeMask != 0 {
-			return nil, fmt.Errorf("legal hold store: permissions must be 0600, got %#o", info.Mode().Perm())
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("legal hold store: stat: %w", err)
-	}
 	if err := os.MkdirAll(filepath.Dir(cleanPath), 0o750); err != nil {
 		return nil, fmt.Errorf("legal hold store: create dir: %w", err)
 	}
@@ -270,7 +258,7 @@ func (s *LegalHoldStore) acquireMutationLock() (func(), error) {
 }
 
 func (s *LegalHoldStore) reloadLocked() error {
-	file, err := os.Open(s.path)
+	file, info, err := openRegularDashboardFile(s.path, "legal hold store")
 	if errors.Is(err, os.ErrNotExist) {
 		s.records = nil
 		return nil
@@ -279,6 +267,9 @@ func (s *LegalHoldStore) reloadLocked() error {
 		return fmt.Errorf("legal hold store: read: %w", err)
 	}
 	defer func() { _ = file.Close() }()
+	if err := requireOwnerOnlyDashboardFile(info, "legal hold store"); err != nil {
+		return err
+	}
 	data, err := io.ReadAll(io.LimitReader(file, legalHoldFileMaxBytes+1))
 	if err != nil {
 		return fmt.Errorf("legal hold store: read: %w", err)

--- a/enterprise/dashboard/legal_hold_store_test.go
+++ b/enterprise/dashboard/legal_hold_store_test.go
@@ -220,6 +220,23 @@ func TestOpenLegalHoldStoreRejectsInsecureOrNonRegularFile(t *testing.T) {
 	})
 }
 
+func TestOpenLegalHoldStoreRejectsSymlinkAfterOpen(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.json")
+	if err := os.WriteFile(target, []byte(`[]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "holds.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenLegalHoldStore(link); err == nil {
+		t.Fatal("OpenLegalHoldStore accepted a symlink")
+	}
+}
+
 func TestLegalHoldStoreSnapshotReloadsAndPostStartCorruptionFailsClosed(t *testing.T) {
 	t.Parallel()
 

--- a/enterprise/dashboard/operability_errors_test.go
+++ b/enterprise/dashboard/operability_errors_test.go
@@ -275,67 +275,86 @@ func TestDeliveryInbox_NormalizesRetentionAndSaturatesDrops(t *testing.T) {
 	t.Parallel()
 
 	when := time.Unix(100, 0).UTC()
-	attempts := make([]DeliveryAttempt, maxPersistedDeliveryAttempts+2)
-	for index := range attempts {
-		attempts[index] = DeliveryAttempt{ID: fmt.Sprintf("attempt-%04d", index), AlertID: "alert-a", Status: DeliveryQueued, AttemptedAt: when.Add(time.Duration(index) * time.Second)}
-	}
-	deadLetters := make([]DeliveryAttempt, maxPersistedDeadLetters+2)
-	for index := range deadLetters {
-		deadLetters[index] = DeliveryAttempt{ID: fmt.Sprintf("failed-%04d", index), AlertID: "alert-a", Status: DeliveryFailed, AttemptedAt: when.Add(time.Duration(index) * time.Second), Error: "provider-token unavailable"}
-	}
-	state := deliveryInboxState{
-		Version:     deliveryInboxVersion,
-		Attempts:    attempts,
-		DeadLetters: deadLetters,
-		Totals:      &deliveryTotals{Queued: uint64(len(attempts)), Failed: uint64(len(deadLetters)), DeadLetters: uint64(len(deadLetters))},
-		Dropped:     ^uint64(0) - 1,
-		UpdatedAt:   when,
-	}
-	if err := normalizeDeliveryState(&state); err != nil {
-		t.Fatalf("normalizeDeliveryState: %v", err)
-	}
-	if len(state.Attempts) != maxPersistedDeliveryAttempts || state.Attempts[0].ID != "attempt-0002" {
-		t.Fatalf("attempt retention = len %d first %q", len(state.Attempts), state.Attempts[0].ID)
-	}
-	if len(state.DeadLetters) != maxPersistedDeadLetters || state.DeadLetters[0].ID != "failed-0002" {
-		t.Fatalf("dead-letter retention = len %d first %q", len(state.DeadLetters), state.DeadLetters[0].ID)
-	}
-	inbox := &DeliveryInbox{state: state}
-	inbox.pendingDrops.Store(3)
-	if got := inbox.Health().Dropped; got != ^uint64(0) {
-		t.Fatalf("saturated dropped = %d, want max uint64", got)
-	}
-	full := &DeliveryInbox{queue: make(chan DeliveryAttempt), dropSignal: make(chan struct{}, 1)}
-	full.pendingDrops.Store(^uint64(0))
-	if full.Record(DeliveryAttempt{ID: "overflow-drop", AlertID: "alert-a", Status: DeliveryQueued, AttemptedAt: when}) {
-		t.Fatal("Record unexpectedly queued on a full inbox")
-	}
-	if got := full.pendingDrops.Load(); got != ^uint64(0) {
-		t.Fatalf("pending dropped wrapped to %d, want max uint64", got)
+
+	overflowState := func() deliveryInboxState {
+		attempts := make([]DeliveryAttempt, maxPersistedDeliveryAttempts+2)
+		for index := range attempts {
+			attempts[index] = DeliveryAttempt{ID: fmt.Sprintf("attempt-%04d", index), AlertID: "alert-a", Status: DeliveryQueued, AttemptedAt: when.Add(time.Duration(index) * time.Second)}
+		}
+		deadLetters := make([]DeliveryAttempt, maxPersistedDeadLetters+2)
+		for index := range deadLetters {
+			deadLetters[index] = DeliveryAttempt{ID: fmt.Sprintf("failed-%04d", index), AlertID: "alert-a", Status: DeliveryFailed, AttemptedAt: when.Add(time.Duration(index) * time.Second), Error: "provider-token unavailable"}
+		}
+		return deliveryInboxState{
+			Version:     deliveryInboxVersion,
+			Attempts:    attempts,
+			DeadLetters: deadLetters,
+			Totals:      &deliveryTotals{Queued: uint64(len(attempts)), Failed: uint64(len(deadLetters)), DeadLetters: uint64(len(deadLetters))},
+			Dropped:     ^uint64(0) - 1,
+			UpdatedAt:   when,
+		}
 	}
 
-	path := filepath.Join(t.TempDir(), DeliveryInboxStateFile)
-	persisted := deliveryInboxState{Version: deliveryInboxVersion, Dropped: ^uint64(0) - 1}
-	data, err := json.Marshal(persisted)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	flush := &DeliveryInbox{path: path, state: persisted}
-	flush.pendingDrops.Store(3)
-	flush.flushDrops()
-	if flush.workerErr != nil {
-		t.Fatalf("flushDrops: %v", flush.workerErr)
-	}
-	health, err := LoadDeliveryHealth(path)
-	if err != nil {
-		t.Fatalf("LoadDeliveryHealth: %v", err)
-	}
-	if health.Dropped != ^uint64(0) {
-		t.Fatalf("persisted dropped = %d, want max uint64", health.Dropped)
-	}
+	t.Run("retention", func(t *testing.T) {
+		state := overflowState()
+		if err := normalizeDeliveryState(&state); err != nil {
+			t.Fatalf("normalizeDeliveryState: %v", err)
+		}
+		if len(state.Attempts) != maxPersistedDeliveryAttempts || state.Attempts[0].ID != "attempt-0002" {
+			t.Fatalf("attempt retention = len %d first %q", len(state.Attempts), state.Attempts[0].ID)
+		}
+		if len(state.DeadLetters) != maxPersistedDeadLetters || state.DeadLetters[0].ID != "failed-0002" {
+			t.Fatalf("dead-letter retention = len %d first %q", len(state.DeadLetters), state.DeadLetters[0].ID)
+		}
+	})
+
+	t.Run("in-memory saturation", func(t *testing.T) {
+		state := overflowState()
+		if err := normalizeDeliveryState(&state); err != nil {
+			t.Fatalf("normalizeDeliveryState: %v", err)
+		}
+		inbox := &DeliveryInbox{state: state}
+		inbox.pendingDrops.Store(3)
+		if got := inbox.Health().Dropped; got != ^uint64(0) {
+			t.Fatalf("saturated dropped = %d, want max uint64", got)
+		}
+	})
+
+	t.Run("full-queue drop saturation", func(t *testing.T) {
+		full := &DeliveryInbox{queue: make(chan DeliveryAttempt), dropSignal: make(chan struct{}, 1)}
+		full.pendingDrops.Store(^uint64(0))
+		if full.Record(DeliveryAttempt{ID: "overflow-drop", AlertID: "alert-a", Status: DeliveryQueued, AttemptedAt: when}) {
+			t.Fatal("Record unexpectedly queued on a full inbox")
+		}
+		if got := full.pendingDrops.Load(); got != ^uint64(0) {
+			t.Fatalf("pending dropped wrapped to %d, want max uint64", got)
+		}
+	})
+
+	t.Run("persisted saturation", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), DeliveryInboxStateFile)
+		persisted := deliveryInboxState{Version: deliveryInboxVersion, Dropped: ^uint64(0) - 1}
+		data, err := json.Marshal(persisted)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		flush := &DeliveryInbox{path: path, state: persisted}
+		flush.pendingDrops.Store(3)
+		flush.flushDrops()
+		if flush.workerErr != nil {
+			t.Fatalf("flushDrops: %v", flush.workerErr)
+		}
+		health, err := LoadDeliveryHealth(path)
+		if err != nil {
+			t.Fatalf("LoadDeliveryHealth: %v", err)
+		}
+		if health.Dropped != ^uint64(0) {
+			t.Fatalf("persisted dropped = %d, want max uint64", health.Dropped)
+		}
+	})
 }
 
 func TestDeliveryInboxApply_ErrorPaths(t *testing.T) {

--- a/enterprise/dashboard/operability_errors_test.go
+++ b/enterprise/dashboard/operability_errors_test.go
@@ -271,6 +271,73 @@ func TestDeliveryValidationAndPending(t *testing.T) {
 	}
 }
 
+func TestDeliveryInbox_NormalizesRetentionAndSaturatesDrops(t *testing.T) {
+	t.Parallel()
+
+	when := time.Unix(100, 0).UTC()
+	attempts := make([]DeliveryAttempt, maxPersistedDeliveryAttempts+2)
+	for index := range attempts {
+		attempts[index] = DeliveryAttempt{ID: fmt.Sprintf("attempt-%04d", index), AlertID: "alert-a", Status: DeliveryQueued, AttemptedAt: when.Add(time.Duration(index) * time.Second)}
+	}
+	deadLetters := make([]DeliveryAttempt, maxPersistedDeadLetters+2)
+	for index := range deadLetters {
+		deadLetters[index] = DeliveryAttempt{ID: fmt.Sprintf("failed-%04d", index), AlertID: "alert-a", Status: DeliveryFailed, AttemptedAt: when.Add(time.Duration(index) * time.Second), Error: "provider-token unavailable"}
+	}
+	state := deliveryInboxState{
+		Version:     deliveryInboxVersion,
+		Attempts:    attempts,
+		DeadLetters: deadLetters,
+		Totals:      &deliveryTotals{Queued: uint64(len(attempts)), Failed: uint64(len(deadLetters)), DeadLetters: uint64(len(deadLetters))},
+		Dropped:     ^uint64(0) - 1,
+		UpdatedAt:   when,
+	}
+	if err := normalizeDeliveryState(&state); err != nil {
+		t.Fatalf("normalizeDeliveryState: %v", err)
+	}
+	if len(state.Attempts) != maxPersistedDeliveryAttempts || state.Attempts[0].ID != "attempt-0002" {
+		t.Fatalf("attempt retention = len %d first %q", len(state.Attempts), state.Attempts[0].ID)
+	}
+	if len(state.DeadLetters) != maxPersistedDeadLetters || state.DeadLetters[0].ID != "failed-0002" {
+		t.Fatalf("dead-letter retention = len %d first %q", len(state.DeadLetters), state.DeadLetters[0].ID)
+	}
+	inbox := &DeliveryInbox{state: state}
+	inbox.pendingDrops.Store(3)
+	if got := inbox.Health().Dropped; got != ^uint64(0) {
+		t.Fatalf("saturated dropped = %d, want max uint64", got)
+	}
+	full := &DeliveryInbox{queue: make(chan DeliveryAttempt), dropSignal: make(chan struct{}, 1)}
+	full.pendingDrops.Store(^uint64(0))
+	if full.Record(DeliveryAttempt{ID: "overflow-drop", AlertID: "alert-a", Status: DeliveryQueued, AttemptedAt: when}) {
+		t.Fatal("Record unexpectedly queued on a full inbox")
+	}
+	if got := full.pendingDrops.Load(); got != ^uint64(0) {
+		t.Fatalf("pending dropped wrapped to %d, want max uint64", got)
+	}
+
+	path := filepath.Join(t.TempDir(), DeliveryInboxStateFile)
+	persisted := deliveryInboxState{Version: deliveryInboxVersion, Dropped: ^uint64(0) - 1}
+	data, err := json.Marshal(persisted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	flush := &DeliveryInbox{path: path, state: persisted}
+	flush.pendingDrops.Store(3)
+	flush.flushDrops()
+	if flush.workerErr != nil {
+		t.Fatalf("flushDrops: %v", flush.workerErr)
+	}
+	health, err := LoadDeliveryHealth(path)
+	if err != nil {
+		t.Fatalf("LoadDeliveryHealth: %v", err)
+	}
+	if health.Dropped != ^uint64(0) {
+		t.Fatalf("persisted dropped = %d, want max uint64", health.Dropped)
+	}
+}
+
 func TestDeliveryInboxApply_ErrorPaths(t *testing.T) {
 	attempt := DeliveryAttempt{ID: "delivery", AlertID: "alert", Status: DeliveryDelivered, AttemptedAt: time.Unix(100, 0).UTC()}
 
@@ -381,6 +448,20 @@ func TestLoadDeliveryHealth_ErrorPaths(t *testing.T) {
 			t.Fatalf("oversized delivery inbox error = %v", err)
 		}
 	})
+	t.Run("symlink", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "outside.json")
+		if err := os.WriteFile(target, []byte(`{"version":1,"attempts":[],"dead_letters":[],"dropped":0,"updated_at":"0001-01-01T00:00:00Z"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(dir, "delivery-inbox-link.json")
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadDeliveryHealth(link); err == nil {
+			t.Fatal("symlinked delivery inbox was accepted")
+		}
+	})
 }
 
 func TestInspectReadModelIndex_ErrorPaths(t *testing.T) {
@@ -396,6 +477,17 @@ func TestInspectReadModelIndex_ErrorPaths(t *testing.T) {
 		}
 		if _, _, err := InspectReadModelIndex(path, t.TempDir()); err == nil {
 			t.Fatal("invalid index was accepted")
+		}
+	})
+	t.Run("symlink index", func(t *testing.T) {
+		sourceDir := t.TempDir()
+		target := writeTestReadModel(t, sourceDir)
+		link := filepath.Join(t.TempDir(), ReadModelIndexFile)
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := InspectReadModelIndex(link, sourceDir); err == nil {
+			t.Fatal("symlinked read-model index was accepted")
 		}
 	})
 	t.Run("missing source directory", func(t *testing.T) {

--- a/enterprise/dashboard/operability_health.go
+++ b/enterprise/dashboard/operability_health.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 )
 
@@ -169,7 +168,7 @@ func validateReadModelIndex(index ReadModelIndex) error {
 }
 
 func readFileLimit(path string, limit int64) ([]byte, error) {
-	file, err := os.Open(filepath.Clean(path))
+	file, _, err := openRegularDashboardFile(path, "read model index")
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/dashboard/operability_test.go
+++ b/enterprise/dashboard/operability_test.go
@@ -655,7 +655,9 @@ func TestDashboardRendersDeliveryFailureAndStaleReadModelLoudly(t *testing.T) {
 	if err := os.WriteFile(indexPath, []byte(`{"rebuild_version":1,"sources":[{"file":"evidence-missing-0.jsonl","sha256":"00"}]}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	handler := New(Options{ReceiptDir: dir, DeliveryInboxPath: inboxPath, ReadModelIndexPath: indexPath, HasFeature: allowAgentsFeature})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: dir, DeliveryInboxPath: inboxPath, ReadModelIndexPath: indexPath, HasFeature: allowAgentsFeature,
+	})
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
 	body := recorder.Body.String()

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -37,6 +37,8 @@ const (
 
 const fleetRedactionKeySize = 32
 
+const dashboardEvidenceDirectoryEntryLimit = 256
+
 // FilterSpec describes a bounded filter for the agent/session list. Unknown
 // non-empty enum values fail closed to no matches.
 type FilterSpec struct {
@@ -71,6 +73,10 @@ type Options struct {
 	// Nil preserves the legacy token-only model where Authorize owns all
 	// metadata-route access.
 	AuthorizePermission func(*http.Request, Permission) error
+	// TrustedOuterAuth explicitly opts into mounting the dashboard behind an
+	// authentication boundary outside this handler. It is required when both
+	// Authorize and AuthorizePermission are nil; otherwise routes fail closed.
+	TrustedOuterAuth bool
 	// AuthorizeRaw gates the sensitive raw view (receipt destinations and full
 	// signed payloads). A request is shown raw detail only when AuthorizeRaw is
 	// non-nil AND returns nil for it; every other authenticated request gets the
@@ -185,14 +191,14 @@ func NewReadModel(opts Options) *ReadModel {
 
 // Sessions lists available recorder sessions and computes their compact state.
 func (m *ReadModel) Sessions() ([]SessionSummary, error) {
-	ids, err := recorder.ListSessions(m.receiptDir)
+	ids, err := recorder.ListSessionsBounded(m.receiptDir, dashboardEvidenceDirectoryEntryLimit)
 	if err != nil {
 		return nil, fmt.Errorf("list sessions: %w", err)
 	}
 
 	summaries := make([]SessionSummary, 0, len(ids))
 	for _, id := range ids {
-		receipts, readLimited, err := receipt.ExtractReceiptsFromSessionDirBounded(m.receiptDir, id, m.receiptReadLimit)
+		receipts, readLimited, err := receipt.ExtractReceiptsFromSessionDirWithLimits(m.receiptDir, id, m.receiptReadLimit, dashboardEvidenceDirectoryEntryLimit)
 		if err != nil {
 			return nil, fmt.Errorf("read session %s receipts: %w", id, err)
 		}
@@ -203,7 +209,7 @@ func (m *ReadModel) Sessions() ([]SessionSummary, error) {
 
 // Session reads one session's complete evidence.
 func (m *ReadModel) Session(id string) (SessionEvidence, error) {
-	receipts, readLimited, err := receipt.ExtractReceiptsFromSessionDirBounded(m.receiptDir, id, m.receiptReadLimit)
+	receipts, readLimited, err := receipt.ExtractReceiptsFromSessionDirWithLimits(m.receiptDir, id, m.receiptReadLimit, dashboardEvidenceDirectoryEntryLimit)
 	if err != nil {
 		return SessionEvidence{}, fmt.Errorf("read session %s receipts: %w", id, err)
 	}
@@ -238,7 +244,7 @@ func (m *ReadModel) Agent(id string, filter FilterSpec) (evidenceview.AgentGroup
 // ReceiptDetail loads one receipt by session ID and chain sequence number,
 // returning a DecisionExplanation. The CALLER redacts per RBAC.
 func (m *ReadModel) ReceiptDetail(sessionID string, seq uint64) (evidenceview.DecisionExplanation, bool, error) {
-	receipts, _, err := receipt.ExtractReceiptsFromSessionDirBounded(m.receiptDir, sessionID, m.receiptReadLimit)
+	receipts, _, err := receipt.ExtractReceiptsFromSessionDirWithLimits(m.receiptDir, sessionID, m.receiptReadLimit, dashboardEvidenceDirectoryEntryLimit)
 	if err != nil {
 		return evidenceview.DecisionExplanation{}, false, fmt.Errorf("read session %s receipts: %w", sessionID, err)
 	}

--- a/enterprise/dashboard/readmodel_test.go
+++ b/enterprise/dashboard/readmodel_test.go
@@ -7,6 +7,7 @@ package dashboard
 import (
 	"crypto/ed25519"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -144,6 +145,22 @@ func TestReadModel_ReadLimitDowngradesEvidence(t *testing.T) {
 	}
 	if evidence.TimelineWindow != "first" {
 		t.Fatalf("TimelineWindow = %q, want first", evidence.TimelineWindow)
+	}
+}
+
+func TestReadModelSessionsRejectsUnboundedEvidenceDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for index := 0; index <= dashboardEvidenceDirectoryEntryLimit; index++ {
+		path := filepath.Join(dir, fmt.Sprintf("junk-%03d", index))
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	model := NewReadModel(Options{ReceiptDir: dir})
+	if _, err := model.Sessions(); err == nil {
+		t.Fatal("Sessions accepted an evidence directory beyond the request read bound")
 	}
 }
 

--- a/enterprise/dashboard/rebuild.go
+++ b/enterprise/dashboard/rebuild.go
@@ -218,21 +218,5 @@ func openRegularEvidence(path string) (*os.File, os.FileInfo, error) {
 	if err != nil || canonicalDir != filepath.Dir(cleanPath) {
 		return nil, nil, errors.New("source evidence is outside its canonical source directory")
 	}
-	before, err := os.Lstat(cleanPath)
-	if err != nil {
-		return nil, nil, err
-	}
-	if before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
-		return nil, nil, errors.New("source evidence is non-regular")
-	}
-	file, err := os.OpenFile(cleanPath, os.O_RDONLY|evidenceNoFollowFlag, 0)
-	if err != nil {
-		return nil, nil, err
-	}
-	after, err := file.Stat()
-	if err != nil || !after.Mode().IsRegular() || !os.SameFile(before, after) {
-		_ = file.Close()
-		return nil, nil, errors.New("source evidence changed or is non-regular")
-	}
-	return file, after, nil
+	return openRegularDashboardFile(cleanPath, "source evidence")
 }

--- a/enterprise/dashboard/regular_open.go
+++ b/enterprise/dashboard/regular_open.go
@@ -1,0 +1,48 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func openRegularDashboardFile(path, label string) (*os.File, os.FileInfo, error) {
+	cleanPath := filepath.Clean(path)
+	file, err := os.OpenFile(cleanPath, os.O_RDONLY|evidenceNoFollowFlag, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	pathInfo, err := os.Lstat(cleanPath)
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || !os.SameFile(pathInfo, info) {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("%s is symlinked, changed, or non-regular", label)
+	}
+	return file, info, nil
+}
+
+func requireOwnerOnlyDashboardFile(info os.FileInfo, label string) error {
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s must be a regular file", label)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("%s permissions must be 0600, got %#o", label, info.Mode().Perm())
+	}
+	if !dashboardFileOwnedByCurrentUser(info) {
+		return errors.New(label + " must be owned by the current user")
+	}
+	return nil
+}

--- a/enterprise/dashboard/regular_open.go
+++ b/enterprise/dashboard/regular_open.go
@@ -13,7 +13,14 @@ import (
 
 func openRegularDashboardFile(path, label string) (*os.File, os.FileInfo, error) {
 	cleanPath := filepath.Clean(path)
-	file, err := os.OpenFile(cleanPath, os.O_RDONLY|evidenceNoFollowFlag, 0)
+	before, err := os.Lstat(cleanPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("%s is symlinked or non-regular", label)
+	}
+	file, err := os.OpenFile(cleanPath, os.O_RDONLY|evidenceNoFollowFlag|evidenceNonblockFlag, 0)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -22,26 +29,21 @@ func openRegularDashboardFile(path, label string) (*os.File, os.FileInfo, error)
 		_ = file.Close()
 		return nil, nil, err
 	}
-	pathInfo, err := os.Lstat(cleanPath)
-	if err != nil {
+	if !info.Mode().IsRegular() || !os.SameFile(before, info) {
 		_ = file.Close()
-		return nil, nil, err
-	}
-	if pathInfo.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || !os.SameFile(pathInfo, info) {
-		_ = file.Close()
-		return nil, nil, fmt.Errorf("%s is symlinked, changed, or non-regular", label)
+		return nil, nil, fmt.Errorf("%s changed or is non-regular", label)
 	}
 	return file, info, nil
 }
 
-func requireOwnerOnlyDashboardFile(info os.FileInfo, label string) error {
+func requireOwnerOnlyDashboardFile(file *os.File, info os.FileInfo, label string) error {
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("%s must be a regular file", label)
 	}
 	if info.Mode().Perm()&0o077 != 0 {
 		return fmt.Errorf("%s permissions must be 0600, got %#o", label, info.Mode().Perm())
 	}
-	if !dashboardFileOwnedByCurrentUser(info) {
+	if !dashboardFileOwnedByCurrentUser(file, info) {
 		return errors.New(label + " must be owned by the current user")
 	}
 	return nil

--- a/enterprise/dashboard/regular_open_owner_unix.go
+++ b/enterprise/dashboard/regular_open_owner_unix.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 )
 
-func dashboardFileOwnedByCurrentUser(info os.FileInfo) bool {
+func dashboardFileOwnedByCurrentUser(_ *os.File, info os.FileInfo) bool {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	return ok && int(stat.Uid) == os.Geteuid()
 }

--- a/enterprise/dashboard/regular_open_owner_unix.go
+++ b/enterprise/dashboard/regular_open_owner_unix.go
@@ -1,0 +1,15 @@
+//go:build enterprise && !windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"os"
+	"syscall"
+)
+
+func dashboardFileOwnedByCurrentUser(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && int(stat.Uid) == os.Geteuid()
+}

--- a/enterprise/dashboard/regular_open_owner_windows.go
+++ b/enterprise/dashboard/regular_open_owner_windows.go
@@ -6,6 +6,11 @@ package dashboard
 
 import "os"
 
+// dashboardFileOwnedByCurrentUser fails closed on Windows: the Unix owner-uid
+// comparison used on other platforms has no direct equivalent here, so rather
+// than silently accept any owner we refuse. A real Windows ACL ownership check
+// is a follow-up; until then the owner-gated dashboard stores are not served on
+// Windows (mode and no-follow checks still apply on every platform).
 func dashboardFileOwnedByCurrentUser(os.FileInfo) bool {
-	return true
+	return false
 }

--- a/enterprise/dashboard/regular_open_owner_windows.go
+++ b/enterprise/dashboard/regular_open_owner_windows.go
@@ -1,0 +1,11 @@
+//go:build enterprise && windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import "os"
+
+func dashboardFileOwnedByCurrentUser(os.FileInfo) bool {
+	return true
+}

--- a/enterprise/dashboard/regular_open_owner_windows.go
+++ b/enterprise/dashboard/regular_open_owner_windows.go
@@ -4,13 +4,28 @@
 
 package dashboard
 
-import "os"
+import (
+	"os"
 
-// dashboardFileOwnedByCurrentUser fails closed on Windows: the Unix owner-uid
-// comparison used on other platforms has no direct equivalent here, so rather
-// than silently accept any owner we refuse. A real Windows ACL ownership check
-// is a follow-up; until then the owner-gated dashboard stores are not served on
-// Windows (mode and no-follow checks still apply on every platform).
-func dashboardFileOwnedByCurrentUser(os.FileInfo) bool {
-	return false
+	"golang.org/x/sys/windows"
+)
+
+func dashboardFileOwnedByCurrentUser(file *os.File, _ os.FileInfo) bool {
+	if file == nil {
+		return false
+	}
+	sd, err := windows.GetSecurityInfo(windows.Handle(file.Fd()), windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+	if err != nil || sd == nil {
+		return false
+	}
+	owner, _, err := sd.Owner()
+	if err != nil || owner == nil {
+		return false
+	}
+	token := windows.GetCurrentProcessToken()
+	user, err := token.GetTokenUser()
+	if err != nil || user == nil || user.User.Sid == nil {
+		return false
+	}
+	return windows.EqualSid(owner, user.User.Sid)
 }

--- a/enterprise/dashboard/regular_open_unix_test.go
+++ b/enterprise/dashboard/regular_open_unix_test.go
@@ -1,0 +1,44 @@
+//go:build enterprise && !windows
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestOpenRegularDashboardFileRejectsFIFOWithoutBlocking(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("Mkfifo: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		file, _, err := openRegularDashboardFile(path, "dashboard state")
+		if file != nil {
+			_ = file.Close()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "non-regular") {
+			t.Fatalf("openRegularDashboardFile FIFO error = %v, want non-regular", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		if writer, err := os.OpenFile(path, os.O_WRONLY|syscall.O_NONBLOCK, 0); err == nil { // #nosec G304 -- test FIFO under t.TempDir
+			_ = writer.Close()
+		}
+		t.Fatal("openRegularDashboardFile blocked on FIFO")
+	}
+}

--- a/enterprise/dashboard/snapshot_budget_source_test.go
+++ b/enterprise/dashboard/snapshot_budget_source_test.go
@@ -107,10 +107,11 @@ func TestBudgetsHandlerSnapshotUnavailableRendersMessage(t *testing.T) {
 	}
 	source := &snapshotBudgetSource{path: path, maxAge: 10 * time.Second, now: func() time.Time { return now }}
 	handler := New(Options{
-		ReceiptDir:   t.TempDir(),
-		HasFeature:   func(f string) bool { return f == license.FeatureAgents },
-		BudgetSource: source,
-		AuthorizeRaw: allowRawAccess,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       func(f string) bool { return f == license.FeatureAgents },
+		BudgetSource:     source,
+		AuthorizeRaw:     allowRawAccess,
 	})
 
 	rec := httptest.NewRecorder()

--- a/enterprise/dashboard/trustkeys_test.go
+++ b/enterprise/dashboard/trustkeys_test.go
@@ -618,7 +618,8 @@ func TestTrustKeysRouteUsesDedicatedPermission(t *testing.T) {
 
 	var got Permission
 	handler := New(Options{
-		ReceiptDir: t.TempDir(), HasFeature: allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(), HasFeature: allowAgentsFeature,
 		Authorize: func(*http.Request) error { return nil },
 		AuthorizePermission: func(_ *http.Request, permission Permission) error {
 			got = permission
@@ -637,7 +638,8 @@ func TestTrustKeysPermissionCannotReachOtherRoutes(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{
-		ReceiptDir: t.TempDir(), HasFeature: allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(), HasFeature: allowAgentsFeature,
 		Authorize: func(*http.Request) error { return nil },
 		AuthorizePermission: func(_ *http.Request, permission Permission) error {
 			if permission == PermissionTrustKeysRead {
@@ -660,7 +662,8 @@ func TestTrustKeysTemplateEscapesHostileMetadata(t *testing.T) {
 
 	pub, _ := generateDashboardKey(t)
 	handler := New(Options{
-		ReceiptDir: t.TempDir(), HasFeature: allowAgentsFeature,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(), HasFeature: allowAgentsFeature,
 		TrustedKeys: map[string]TrustedKey{hex.EncodeToString(pub): {
 			Source: `<script>alert("source")</script>`, ProvenanceKind: `<img src=x onerror=alert(1)>`, Location: `"><svg/onload=alert(2)>`,
 		}},
@@ -706,7 +709,9 @@ func TestTrustKeysHandlerFailures(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := New(Options{ReceiptDir: tc.dir, HasFeature: allowAgentsFeature})
+			handler := New(Options{
+				TrustedOuterAuth: true, ReceiptDir: tc.dir, HasFeature: allowAgentsFeature,
+			})
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), tc.method, "/trust-keys", nil))
 			if rec.Code != tc.want {

--- a/enterprise/dashboard/workbench_test.go
+++ b/enterprise/dashboard/workbench_test.go
@@ -98,7 +98,9 @@ func TestWorkbench_Gating(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: tt.hasFeature})
+			handler := New(Options{
+				TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: tt.hasFeature,
+			})
 			for _, path := range []string{"/workbench", "/incident"} {
 				rec := httptest.NewRecorder()
 				handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
@@ -124,6 +126,7 @@ func TestWorkbench_NoStateMutatingRoute(t *testing.T) {
 
 	source := &fakeConductorSource{view: testReplayView(), found: true}
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		ConductorSource:     source,
@@ -165,6 +168,7 @@ func TestWorkbench_FailClosedScopeAuthorization(t *testing.T) {
 
 			source := &fakeConductorSource{view: testReplayView(), found: true}
 			handler := New(Options{
+				TrustedOuterAuth:    true,
 				ReceiptDir:          t.TempDir(),
 				HasFeature:          allowFleetFeature,
 				ConductorSource:     source,
@@ -188,6 +192,7 @@ func TestWorkbench_ScopeAuditRedactsIdentifiers(t *testing.T) {
 	var audit strings.Builder
 	source := &fakeConductorSource{view: testReplayView(), found: true}
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		ConductorSource:     source,
@@ -231,8 +236,9 @@ func TestWorkbench_FailClosedLicense(t *testing.T) {
 	t.Parallel()
 
 	noFleet := New(Options{
-		ReceiptDir: t.TempDir(),
-		HasFeature: func(f string) bool { return f == license.FeatureAgents },
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       func(f string) bool { return f == license.FeatureAgents },
 	})
 	for _, path := range []string{"/workbench", "/incident"} {
 		rec := httptest.NewRecorder()
@@ -248,7 +254,9 @@ func TestWorkbench_FailClosedLicense(t *testing.T) {
 		t.Fatalf("agents-tier /agents with agents license = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
 
-	withFleet := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature})
+	withFleet := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature,
+	})
 	for _, path := range []string{"/workbench", "/incident"} {
 		rec := httptest.NewRecorder()
 		withFleet.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
@@ -261,7 +269,9 @@ func TestWorkbench_FailClosedLicense(t *testing.T) {
 func TestWorkbench_PrepareGuidanceAndNeverAuthority(t *testing.T) {
 	t.Parallel()
 
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature,
+	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/workbench", nil))
 	if rec.Code != http.StatusOK {
@@ -292,6 +302,7 @@ func TestWorkbench_ReplayRawView(t *testing.T) {
 
 	source := &fakeConductorSource{view: testReplayView(), found: true}
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		ConductorSource:     source,
@@ -322,9 +333,10 @@ func TestWorkbench_ReplayMetadataViewRedacts(t *testing.T) {
 	view.Conflict = "source error for " + wbSensitiveHash
 	source := &fakeConductorSource{view: view, found: true}
 	handler := New(Options{
-		ReceiptDir:      t.TempDir(),
-		HasFeature:      allowFleetFeature,
-		ConductorSource: source,
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       allowFleetFeature,
+		ConductorSource:  source,
 		// No AuthorizeRaw: metadata view must fail closed.
 		AuthorizeFleetScope: allowFleetScope,
 	})
@@ -356,6 +368,7 @@ func TestWorkbench_ReplayRawEscapesHostileStrings(t *testing.T) {
 	view.DivergenceReason = hostileScript
 	source := &fakeConductorSource{view: view, found: true}
 	handler := New(Options{
+		TrustedOuterAuth:    true,
 		ReceiptDir:          t.TempDir(),
 		HasFeature:          allowFleetFeature,
 		ConductorSource:     source,
@@ -382,7 +395,9 @@ func TestWorkbench_ReplayNotFound(t *testing.T) {
 	t.Parallel()
 
 	source := &fakeConductorSource{found: false}
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope,
+	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
 	if rec.Code != http.StatusOK {
@@ -397,7 +412,9 @@ func TestWorkbench_ReplayNotFoundMetadataRedactsScope(t *testing.T) {
 	t.Parallel()
 
 	source := &fakeConductorSource{found: false}
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope,
+	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
 	if rec.Code != http.StatusOK {
@@ -418,7 +435,9 @@ func TestWorkbench_SourceErrorReturnsServerError(t *testing.T) {
 	t.Parallel()
 
 	source := &fakeConductorSource{err: errors.New("source unavailable")}
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: source, AuthorizeFleetScope: allowFleetScope,
+	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, wbReplayTarget(), nil))
 	if rec.Code != http.StatusInternalServerError {
@@ -429,7 +448,9 @@ func TestWorkbench_SourceErrorReturnsServerError(t *testing.T) {
 func TestWorkbench_RejectsInvalidScope(t *testing.T) {
 	t.Parallel()
 
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: &fakeConductorSource{}, AuthorizeFleetScope: allowFleetScope})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature, ConductorSource: &fakeConductorSource{}, AuthorizeFleetScope: allowFleetScope,
+	})
 	for _, target := range []string{
 		"/workbench?artifact_hash=" + wbTestArtifactHash,                            // hash without org/fleet
 		"/workbench?org_id=" + wbTestOrgID + "&artifact_hash=" + wbTestArtifactHash, // missing fleet
@@ -452,7 +473,9 @@ func TestWorkbench_RejectsInvalidScope(t *testing.T) {
 func TestWorkbench_RejectsNonExactPath(t *testing.T) {
 	t.Parallel()
 
-	handler := New(Options{ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature})
+	handler := New(Options{
+		TrustedOuterAuth: true, ReceiptDir: t.TempDir(), HasFeature: allowFleetFeature,
+	})
 	for _, path := range []string{"/workbench/extra", "/incident/extra"} {
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))

--- a/enterprise/siemforward/forwarder.go
+++ b/enterprise/siemforward/forwarder.go
@@ -94,6 +94,7 @@ type Envelope struct {
 }
 
 type DeliveryEvent struct {
+	ID         string         `json:"id"`
 	Severity   string         `json:"severity"`
 	Type       string         `json:"type"`
 	Timestamp  string         `json:"timestamp"`
@@ -673,11 +674,17 @@ func isPermanentAppendErr(err error) bool {
 }
 
 func (f *Forwarder) append(event emit.Event) error {
-	envelope := Envelope{Schema: SchemaV1, Event: DeliveryEvent{
+	deliveryEvent := DeliveryEvent{
 		Severity: event.Severity.String(), Type: event.Type,
 		Timestamp:  event.Timestamp.UTC().Format(time.RFC3339Nano),
 		InstanceID: event.InstanceID, Fields: event.Fields,
-	}}
+	}
+	id, err := deliveryEventID(deliveryEvent)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errPermanentEncode, err)
+	}
+	deliveryEvent.ID = id
+	envelope := Envelope{Schema: SchemaV1, Event: deliveryEvent}
 	b, err := json.Marshal(envelope)
 	if err != nil {
 		// A serialization failure (NaN/Inf, unsupported type) is permanent:
@@ -821,6 +828,16 @@ func (f *Forwarder) deliver(record []byte) error {
 		return fmt.Errorf("siem forwarder endpoint returned HTTP %d", resp.StatusCode)
 	}
 	return nil
+}
+
+func deliveryEventID(event DeliveryEvent) (string, error) {
+	event.ID = ""
+	b, err := json.Marshal(event)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func openRegularFile(path string, flags int, perm os.FileMode) (*os.File, error) {

--- a/enterprise/siemforward/forwarder_test.go
+++ b/enterprise/siemforward/forwarder_test.go
@@ -544,12 +544,12 @@ func TestForwarderConcurrentCloseDoesNotLoseAcceptedEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New after shutdown: %v", err)
 	}
-	waitFor(t, func() bool { return received.Load() == accepted.Load() })
+	waitFor(t, func() bool { return received.Load() >= accepted.Load() })
 	if err := f2.Close(); err != nil {
 		t.Fatalf("Close restarted forwarder: %v", err)
 	}
-	if got, want := received.Load(), accepted.Load(); got != want {
-		t.Fatalf("received %d events, want all %d accepted across shutdown replay", got, want)
+	if got, wantAtLeast := received.Load(), accepted.Load(); got < wantAtLeast {
+		t.Fatalf("received %d events, want at least all %d accepted across shutdown replay", got, wantAtLeast)
 	}
 }
 

--- a/enterprise/siemforward/forwarder_test.go
+++ b/enterprise/siemforward/forwarder_test.go
@@ -6,6 +6,7 @@ package siemforward
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -501,10 +502,28 @@ func TestForwarderQueueFullDropsWithoutBlocking(t *testing.T) {
 	}
 }
 
-func TestForwarderConcurrentCloseDoesNotLoseAcceptedEvents(t *testing.T) {
+func TestForwarderConcurrentCloseReplaysAcceptedEventsAtLeastOnce(t *testing.T) {
 	t.Parallel()
 	var received atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var receivedMu sync.Mutex
+	receivedBySequence := make(map[int]int)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		var envelope Envelope
+		if err := decodeEnvelope(r.Body, &envelope); err != nil {
+			t.Errorf("decode envelope: %v", err)
+			http.Error(w, "bad envelope", http.StatusBadRequest)
+			return
+		}
+		sequence, ok := envelope.Event.Fields["sequence"].(float64)
+		if !ok || envelope.Event.ID == "" {
+			t.Errorf("delivered event missing stable dedupe fields: %+v", envelope.Event)
+			http.Error(w, "bad envelope", http.StatusBadRequest)
+			return
+		}
+		receivedMu.Lock()
+		receivedBySequence[int(sequence)]++
+		receivedMu.Unlock()
 		received.Add(1)
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -519,6 +538,8 @@ func TestForwarderConcurrentCloseDoesNotLoseAcceptedEvents(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	var accepted atomic.Int32
+	var acceptedMu sync.Mutex
+	acceptedSequences := make(map[int]struct{})
 	var producers sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		producers.Add(1)
@@ -526,6 +547,9 @@ func TestForwarderConcurrentCloseDoesNotLoseAcceptedEvents(t *testing.T) {
 			defer producers.Done()
 			if err := f.Emit(t.Context(), testEvent(sequence)); err == nil {
 				accepted.Add(1)
+				acceptedMu.Lock()
+				acceptedSequences[sequence] = struct{}{}
+				acceptedMu.Unlock()
 			} else if !errors.Is(err, errClosed) {
 				t.Errorf("Emit: %v", err)
 			}
@@ -550,6 +574,51 @@ func TestForwarderConcurrentCloseDoesNotLoseAcceptedEvents(t *testing.T) {
 	}
 	if got, wantAtLeast := received.Load(), accepted.Load(); got < wantAtLeast {
 		t.Fatalf("received %d events, want at least all %d accepted across shutdown replay", got, wantAtLeast)
+	}
+	acceptedMu.Lock()
+	defer acceptedMu.Unlock()
+	receivedMu.Lock()
+	defer receivedMu.Unlock()
+	for sequence := range acceptedSequences {
+		if receivedBySequence[sequence] == 0 {
+			t.Fatalf("accepted sequence %d was not delivered; received=%v", sequence, receivedBySequence)
+		}
+	}
+}
+
+func TestDeliveryEventIDIsStableForDeduplication(t *testing.T) {
+	t.Parallel()
+
+	event := DeliveryEvent{
+		Severity:   "warn",
+		Type:       "blocked",
+		Timestamp:  time.Unix(42, 0).UTC().Format(time.RFC3339Nano),
+		InstanceID: "agent-a",
+		Fields:     map[string]any{"sequence": 7, "reason": "policy"},
+	}
+	first, err := deliveryEventID(event)
+	if err != nil {
+		t.Fatalf("deliveryEventID: %v", err)
+	}
+	event.ID = "ignored"
+	second, err := deliveryEventID(event)
+	if err != nil {
+		t.Fatalf("deliveryEventID with existing ID: %v", err)
+	}
+	if first == "" || first != second {
+		t.Fatalf("deliveryEventID stability mismatch: first=%q second=%q", first, second)
+	}
+	event.ID = first
+	b, err := json.Marshal(Envelope{Schema: SchemaV1, Event: event})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var envelope Envelope
+	if err := decodeEnvelope(strings.NewReader(string(b)), &envelope); err != nil {
+		t.Fatalf("decodeEnvelope: %v", err)
+	}
+	if envelope.Event.ID != event.ID {
+		t.Fatalf("decoded event ID = %q, want %q", envelope.Event.ID, event.ID)
 	}
 }
 

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -790,8 +790,15 @@ func ExtractReceiptsFromSessionDir(dir, sessionID string) ([]Receipt, error) {
 // an optional hard ceiling on parsed recorder entries. The returned boolean is
 // true when the ceiling was reached before the full session was loaded.
 func ExtractReceiptsFromSessionDirBounded(dir, sessionID string, maxEntriesRead int) ([]Receipt, bool, error) {
+	return ExtractReceiptsFromSessionDirWithLimits(dir, sessionID, maxEntriesRead, 0)
+}
+
+// ExtractReceiptsFromSessionDirWithLimits reads action receipts for a session
+// with hard ceilings on parsed recorder entries and evidence directory entries.
+func ExtractReceiptsFromSessionDirWithLimits(dir, sessionID string, maxEntriesRead, maxDirectoryEntries int) ([]Receipt, bool, error) {
 	result, err := recorder.QuerySession(filepath.Clean(dir), sessionID, &recorder.QueryFilter{
-		MaxEntriesRead: maxEntriesRead,
+		MaxEntriesRead:      maxEntriesRead,
+		MaxDirectoryEntries: maxDirectoryEntries,
 	})
 	if err != nil {
 		return nil, false, fmt.Errorf("querying session receipts: %w", err)

--- a/internal/recorder/query.go
+++ b/internal/recorder/query.go
@@ -4,7 +4,9 @@
 package recorder
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -27,6 +29,9 @@ type QueryFilter struct {
 	// MaxEntriesRead is a hard ceiling on parsed recorder entries for callers
 	// that render evidence in an online UI. Zero means unbounded.
 	MaxEntriesRead int
+	// MaxDirectoryEntries is a hard ceiling on evidence directory entries read
+	// before filtering to one session. Zero means unbounded.
+	MaxDirectoryEntries int
 }
 
 // QueryResult holds the results of an evidence query.
@@ -41,7 +46,7 @@ type QueryResult struct {
 // QuerySession reads evidence files for a session and applies filters.
 func QuerySession(dir, sessionID string, filter *QueryFilter) (*QueryResult, error) {
 	dir = filepath.Clean(dir)
-	dirEntries, err := os.ReadDir(dir)
+	dirEntries, err := readDirectoryEntries(dir, maxDirectoryEntries(filter))
 	if err != nil {
 		return nil, fmt.Errorf("reading evidence directory: %w", err)
 	}
@@ -106,8 +111,14 @@ func QuerySession(dir, sessionID string, filter *QueryFilter) (*QueryResult, err
 
 // ListSessions returns the unique session IDs found in evidence files.
 func ListSessions(dir string) ([]string, error) {
+	return ListSessionsBounded(dir, 0)
+}
+
+// ListSessionsBounded returns unique session IDs while enforcing a hard ceiling
+// on directory entries read. Zero means unbounded.
+func ListSessionsBounded(dir string, maxEntries int) ([]string, error) {
 	dir = filepath.Clean(dir)
-	dirEntries, err := os.ReadDir(dir)
+	dirEntries, err := readDirectoryEntries(dir, maxEntries)
 	if err != nil {
 		return nil, fmt.Errorf("reading evidence directory: %w", err)
 	}
@@ -133,6 +144,32 @@ func ListSessions(dir string) ([]string, error) {
 	}
 	sort.Strings(sessions)
 	return sessions, nil
+}
+
+func maxDirectoryEntries(filter *QueryFilter) int {
+	if filter == nil {
+		return 0
+	}
+	return filter.MaxDirectoryEntries
+}
+
+func readDirectoryEntries(dir string, maxEntries int) ([]os.DirEntry, error) {
+	if maxEntries <= 0 {
+		return os.ReadDir(dir)
+	}
+	directory, err := os.Open(filepath.Clean(dir))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = directory.Close() }()
+	entries, err := directory.ReadDir(maxEntries + 1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	if len(entries) > maxEntries {
+		return nil, fmt.Errorf("directory entry count exceeds %d", maxEntries)
+	}
+	return entries, nil
 }
 
 func evidenceFileSessionID(name string) (string, bool) {

--- a/internal/recorder/query.go
+++ b/internal/recorder/query.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -162,7 +163,13 @@ func readDirectoryEntries(dir string, maxEntries int) ([]os.DirEntry, error) {
 		return nil, err
 	}
 	defer func() { _ = directory.Close() }()
-	entries, err := directory.ReadDir(maxEntries + 1)
+	// maxEntries+1 would overflow to a negative value at math.MaxInt, and a
+	// non-positive count makes ReadDir read the whole directory unbounded.
+	readLimit := maxEntries
+	if readLimit < math.MaxInt {
+		readLimit++
+	}
+	entries, err := directory.ReadDir(readLimit)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}

--- a/internal/recorder/query_internal_test.go
+++ b/internal/recorder/query_internal_test.go
@@ -3,6 +3,7 @@
 package recorder
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,5 +39,22 @@ func TestReadDirectoryEntriesBounded(t *testing.T) {
 	// A missing directory surfaces the open error rather than silently succeeding.
 	if _, err := readDirectoryEntries(filepath.Join(dir, "missing"), 1); err == nil {
 		t.Fatal("readDirectoryEntries accepted a missing directory")
+	}
+}
+
+func TestReadDirectoryEntriesMaxIntNoOverflow(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for _, name := range []string{"a", "b"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatalf("seed entry %q: %v", name, err)
+		}
+	}
+	// maxEntries at math.MaxInt must not overflow maxEntries+1 into a negative
+	// count (which would make ReadDir read the directory unbounded).
+	entries, err := readDirectoryEntries(dir, math.MaxInt)
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("readDirectoryEntries(MaxInt) = %d entries, err %v; want 2 entries, nil", len(entries), err)
 	}
 }

--- a/internal/recorder/query_internal_test.go
+++ b/internal/recorder/query_internal_test.go
@@ -1,0 +1,42 @@
+// Licensed under the Apache License, Version 2.0. See LICENSE.
+
+package recorder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadDirectoryEntriesBounded(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for _, name := range []string{"a", "b", "c"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatalf("seed entry %q: %v", name, err)
+		}
+	}
+
+	// Unbounded (maxEntries <= 0) returns every entry.
+	all, err := readDirectoryEntries(dir, 0)
+	if err != nil || len(all) != 3 {
+		t.Fatalf("unbounded readDirectoryEntries = %d entries, err %v; want 3", len(all), err)
+	}
+
+	// Bounded at or above the entry count succeeds.
+	within, err := readDirectoryEntries(dir, 3)
+	if err != nil || len(within) != 3 {
+		t.Fatalf("bounded-within readDirectoryEntries = %d entries, err %v; want 3", len(within), err)
+	}
+
+	// Bounded below the entry count fails closed.
+	if _, err := readDirectoryEntries(dir, 2); err == nil {
+		t.Fatal("readDirectoryEntries accepted a directory exceeding the entry cap")
+	}
+
+	// A missing directory surfaces the open error rather than silently succeeding.
+	if _, err := readDirectoryEntries(filepath.Join(dir, "missing"), 1); err == nil {
+		t.Fatal("readDirectoryEntries accepted a missing directory")
+	}
+}


### PR DESCRIPTION
## What changed

Hardening pass on the enterprise dashboard, covering the authentication boundary, on-disk store loading, and request-path read bounds. Fail-closed throughout.

- Fail closed when the dashboard is built with no authorization callbacks: serving now requires an explicit `TrustedOuterAuth` opt-in instead of running unauthenticated by omission.
- Exemption store direct loader strict-decodes, rejects duplicate ids and invalid records, bounds the read size, and refuses symlinked or non-regular files.
- Legal-hold store opens the file then fstats the handle (no-follow, same-file check) instead of stat-then-open, closing a path-replacement window.
- Delivery-inbox and read-model-index reads use the same no-follow bounded open for parity.
- Directory-entry scans on the sessions and receipt request path are now bounded.
- Fleet data source reports completeness explicitly, so a backend capped below the display limit is not shown as a complete fleet.
- Delivery-inbox dropped-message counter saturates on every mutation path, including the queue-full path, so it cannot wrap.
- Windows durable-store lock now provides real cross-process exclusion.

No new dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enterprise dashboard routes now fail closed unless an explicit trusted authentication boundary is configured (including when constructed directly).
  * Dashboard stores and evidence reads reject unsafe inputs (oversized/malformed/duplicate records), reject symlinks, and enforce owner-only permissions (including legal holds and exemption stores).
  * Windows exemption-store locking now uses an exclusive lock to prevent concurrent access.
* **Reliability**
  * Evidence/session and evidence-directory reads enforce directory-entry bounds (“fails closed” when exceeded).
  * Delivery inbox state now trims retention and saturates drop counters at maximum values.
  * Fleet/incident “truncated/incomplete” messaging is improved when follower completeness is unknown.
* **Documentation**
  * Updated dashboard security model and changelog guidance for embedding/constructing handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->