### PR TITLE
fix(anchor): versioned per-session state index and hostile-filesystem fail-closed loading

### DIFF
--- a/enterprise/dashboard/trustkeys.go
+++ b/enterprise/dashboard/trustkeys.go
@@ -5,11 +5,9 @@
 package dashboard
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -20,7 +18,6 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/anchor"
-	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
@@ -166,122 +163,17 @@ func loadAnchorMarker(baseDir string) (anchorStateMarker, bool, error) {
 }
 
 func loadAnchorMarkers(baseDir string) ([]anchorStateMarker, error) {
-	var markers []anchorStateMarker
-	legacy, found, err := loadAnchorMarkerFile(baseDir, "anchor-state.json")
+	markers, err := anchor.LoadStateMarkers(baseDir)
 	if err != nil {
 		return nil, err
 	}
-	if found {
-		markers = append(markers, legacy)
-	}
-	indexMarkers, err := loadAnchorIndexMarkers(baseDir)
-	if err != nil {
-		return nil, err
-	}
-	seen := make(map[string]string, len(markers)+len(indexMarkers))
+	now := time.Now()
 	for _, marker := range markers {
-		seen[anchorStateIdentity(marker)] = "anchor-state.json"
-	}
-	for _, indexed := range indexMarkers {
-		key := anchorStateIdentity(indexed.marker)
-		if previous, ok := seen[key]; ok {
-			return nil, fmt.Errorf("anchor-state marker %q duplicates %q", indexed.name, previous)
+		if marker.AnchoredAt.IsZero() || marker.AnchoredAt.After(now) {
+			return nil, errors.New("anchor-state marker has invalid required fields")
 		}
-		seen[key] = indexed.name
-		markers = append(markers, indexed.marker)
 	}
 	return markers, nil
-}
-
-type indexedAnchorMarker struct {
-	name   string
-	marker anchorStateMarker
-}
-
-func loadAnchorIndexMarkers(baseDir string) ([]indexedAnchorMarker, error) {
-	indexDir := filepath.Join(baseDir, "anchor-state.d")
-	indexInfo, err := os.Lstat(indexDir)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("inspect anchor-state index: %w", err)
-	}
-	if indexInfo.Mode()&os.ModeSymlink != 0 || !indexInfo.IsDir() {
-		return nil, errors.New("anchor-state index is not a regular directory")
-	}
-	entries, err := os.ReadDir(indexDir)
-	if err != nil {
-		return nil, fmt.Errorf("read anchor-state index: %w", err)
-	}
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
-	markers := make([]indexedAnchorMarker, 0, len(entries))
-	for _, entry := range entries {
-		name := entry.Name()
-		if anchor.IsStateMarkerTempName(name) {
-			continue
-		}
-		if entry.IsDir() || filepath.Ext(name) != ".json" {
-			return nil, fmt.Errorf("read anchor-state index: unexpected marker %q", name)
-		}
-		info, err := entry.Info()
-		if err != nil {
-			return nil, fmt.Errorf("inspect anchor-state marker %q: %w", name, err)
-		}
-		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-			return nil, fmt.Errorf("read anchor-state marker %q: not a regular file", name)
-		}
-		marker, found, err := loadAnchorMarkerFile(baseDir, filepath.Join("anchor-state.d", name))
-		if err != nil {
-			return nil, err
-		}
-		if !found {
-			continue
-		}
-		wantPath, err := anchor.StateMarkerPath(baseDir, marker)
-		if err != nil {
-			return nil, err
-		}
-		if filepath.Base(wantPath) != name {
-			return nil, fmt.Errorf("anchor-state marker %q does not match marker identity", name)
-		}
-		markers = append(markers, indexedAnchorMarker{name: name, marker: marker})
-	}
-	return markers, nil
-}
-
-func loadAnchorMarkerFile(baseDir, relativePath string) (anchorStateMarker, bool, error) {
-	data, err := readConfinedRegularFile(baseDir, relativePath, maxAnchorMarkerBytes, "anchor-state marker")
-	if errors.Is(err, os.ErrNotExist) {
-		return anchorStateMarker{}, false, nil
-	}
-	if err != nil {
-		return anchorStateMarker{}, false, err
-	}
-	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
-		return anchorStateMarker{}, false, fmt.Errorf("parse anchor-state marker: %w", err)
-	}
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.DisallowUnknownFields()
-	var marker anchorStateMarker
-	if err := dec.Decode(&marker); err != nil {
-		return anchorStateMarker{}, false, fmt.Errorf("parse anchor-state marker: %w", err)
-	}
-	var extra any
-	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
-		return anchorStateMarker{}, false, errors.New("parse anchor-state marker: trailing JSON")
-	}
-	if marker.Schema != "pipelock.anchorstate.v1" || strings.TrimSpace(marker.SessionID) == "" ||
-		strings.TrimSpace(marker.BundlePath) == "" || marker.AnchoredAt.IsZero() || marker.AnchoredAt.After(time.Now()) ||
-		len(marker.RootHash) != sha256.Size*2 ||
-		len(marker.BundleSHA256) != sha256.Size*2 {
-		return anchorStateMarker{}, false, errors.New("anchor-state marker has invalid required fields")
-	}
-	return marker, true, nil
-}
-
-func anchorStateIdentity(marker anchorStateMarker) string {
-	return marker.SessionID + "\x00" + fmt.Sprint(marker.FinalSeq) + "\x00" + marker.RootHash
 }
 
 func readConfinedRegularFile(baseDir, relativePath string, maxBytes int64, label string) ([]byte, error) {

--- a/enterprise/dashboard/trustkeys.go
+++ b/enterprise/dashboard/trustkeys.go
@@ -218,6 +218,9 @@ func loadAnchorIndexMarkers(baseDir string) ([]indexedAnchorMarker, error) {
 	markers := make([]indexedAnchorMarker, 0, len(entries))
 	for _, entry := range entries {
 		name := entry.Name()
+		if anchor.IsStateMarkerTempName(name) {
+			continue
+		}
 		if entry.IsDir() || filepath.Ext(name) != ".json" {
 			return nil, fmt.Errorf("read anchor-state index: unexpected marker %q", name)
 		}

--- a/enterprise/dashboard/trustkeys.go
+++ b/enterprise/dashboard/trustkeys.go
@@ -96,19 +96,30 @@ func newFileAnchorResolver(
 		return nil, errors.New("receipt directory is not a directory")
 	}
 	return func(sessionID string) (*anchor.Bundle, anchor.Backend, bool, error) {
-		marker, found, loadErr := loadAnchorMarker(baseDir)
+		markers, loadErr := loadAnchorMarkers(baseDir)
 		if loadErr != nil {
 			return nil, nil, true, loadErr
 		}
-		if !found {
+		if len(markers) == 0 {
 			return nil, nil, expected, nil
 		}
-		if marker.SessionID != sessionID {
-			// A marker proves anchoring is in use in this receipt directory. Since
-			// the v1 state format has only one slot, a later session can overwrite
-			// an older session's marker. Treat the displaced session as expected-
-			// but-missing instead of letting the overwrite downgrade it to "not
-			// expected" when the global policy flag is false.
+		var marker anchorStateMarker
+		found := false
+		for _, candidate := range markers {
+			if candidate.SessionID != sessionID {
+				continue
+			}
+			if found {
+				return nil, nil, true, fmt.Errorf("ambiguous anchor-state markers for session %q", sessionID)
+			}
+			marker = candidate
+			found = true
+		}
+		if !found {
+			// A marker proves anchoring is in use in this receipt directory. Treat
+			// sessions without their own marker as expected-but-missing instead of
+			// downgrading them to "not expected" when the global policy flag is
+			// false.
 			return nil, nil, true, nil
 		}
 		bundleBytes, readErr := readConfinedRegularFile(
@@ -138,20 +149,106 @@ func newFileAnchorResolver(
 	}, nil
 }
 
-type anchorStateMarker struct {
-	Schema       string    `json:"schema"`
-	SessionID    string    `json:"session_id"`
-	FinalSeq     uint64    `json:"final_seq"`
-	RootHash     string    `json:"root_hash"`
-	Backend      string    `json:"backend"`
-	LogIndex     uint64    `json:"log_index"`
-	AnchoredAt   time.Time `json:"anchored_at"`
-	BundleSHA256 string    `json:"bundle_sha256"`
-	BundlePath   string    `json:"bundle_path"`
-}
+type anchorStateMarker = anchor.StateMarker
 
 func loadAnchorMarker(baseDir string) (anchorStateMarker, bool, error) {
-	data, err := readConfinedRegularFile(baseDir, "anchor-state.json", maxAnchorMarkerBytes, "anchor-state marker")
+	markers, err := loadAnchorMarkers(baseDir)
+	if err != nil {
+		return anchorStateMarker{}, false, err
+	}
+	if len(markers) == 0 {
+		return anchorStateMarker{}, false, nil
+	}
+	if len(markers) > 1 {
+		return anchorStateMarker{}, false, errors.New("anchor-state index has multiple markers")
+	}
+	return markers[0], true, nil
+}
+
+func loadAnchorMarkers(baseDir string) ([]anchorStateMarker, error) {
+	var markers []anchorStateMarker
+	legacy, found, err := loadAnchorMarkerFile(baseDir, "anchor-state.json")
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		markers = append(markers, legacy)
+	}
+	indexMarkers, err := loadAnchorIndexMarkers(baseDir)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]string, len(markers)+len(indexMarkers))
+	for _, marker := range markers {
+		seen[anchorStateIdentity(marker)] = "anchor-state.json"
+	}
+	for _, indexed := range indexMarkers {
+		key := anchorStateIdentity(indexed.marker)
+		if previous, ok := seen[key]; ok {
+			return nil, fmt.Errorf("anchor-state marker %q duplicates %q", indexed.name, previous)
+		}
+		seen[key] = indexed.name
+		markers = append(markers, indexed.marker)
+	}
+	return markers, nil
+}
+
+type indexedAnchorMarker struct {
+	name   string
+	marker anchorStateMarker
+}
+
+func loadAnchorIndexMarkers(baseDir string) ([]indexedAnchorMarker, error) {
+	indexDir := filepath.Join(baseDir, "anchor-state.d")
+	indexInfo, err := os.Lstat(indexDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inspect anchor-state index: %w", err)
+	}
+	if indexInfo.Mode()&os.ModeSymlink != 0 || !indexInfo.IsDir() {
+		return nil, errors.New("anchor-state index is not a regular directory")
+	}
+	entries, err := os.ReadDir(indexDir)
+	if err != nil {
+		return nil, fmt.Errorf("read anchor-state index: %w", err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	markers := make([]indexedAnchorMarker, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || filepath.Ext(name) != ".json" {
+			return nil, fmt.Errorf("read anchor-state index: unexpected marker %q", name)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("inspect anchor-state marker %q: %w", name, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("read anchor-state marker %q: not a regular file", name)
+		}
+		marker, found, err := loadAnchorMarkerFile(baseDir, filepath.Join("anchor-state.d", name))
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		wantPath, err := anchor.StateMarkerPath(baseDir, marker)
+		if err != nil {
+			return nil, err
+		}
+		if filepath.Base(wantPath) != name {
+			return nil, fmt.Errorf("anchor-state marker %q does not match marker identity", name)
+		}
+		markers = append(markers, indexedAnchorMarker{name: name, marker: marker})
+	}
+	return markers, nil
+}
+
+func loadAnchorMarkerFile(baseDir, relativePath string) (anchorStateMarker, bool, error) {
+	data, err := readConfinedRegularFile(baseDir, relativePath, maxAnchorMarkerBytes, "anchor-state marker")
 	if errors.Is(err, os.ErrNotExist) {
 		return anchorStateMarker{}, false, nil
 	}
@@ -178,6 +275,10 @@ func loadAnchorMarker(baseDir string) (anchorStateMarker, bool, error) {
 		return anchorStateMarker{}, false, errors.New("anchor-state marker has invalid required fields")
 	}
 	return marker, true, nil
+}
+
+func anchorStateIdentity(marker anchorStateMarker) string {
+	return marker.SessionID + "\x00" + fmt.Sprint(marker.FinalSeq) + "\x00" + marker.RootHash
 }
 
 func readConfinedRegularFile(baseDir, relativePath string, maxBytes int64, label string) ([]byte, error) {

--- a/enterprise/dashboard/trustkeys_test.go
+++ b/enterprise/dashboard/trustkeys_test.go
@@ -409,6 +409,56 @@ func TestFileAnchorResolver_FailsClosedOnMalformedState(t *testing.T) {
 	})
 }
 
+func TestFileAnchorResolver_FailsClosedOnResolverMaterialMismatches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		localLogPath func(string) string
+		mutateMarker func(anchor.StateMarker) anchor.StateMarker
+		wantErr      string
+	}{
+		{
+			name: "bundle marker field mismatch",
+			localLogPath: func(dir string) string {
+				return filepath.Join(dir, "anchors.jsonl")
+			},
+			mutateMarker: func(marker anchor.StateMarker) anchor.StateMarker {
+				marker.RootHash = strings.Repeat("c", 64)
+				return marker
+			},
+			wantErr: "does not match anchor-state marker",
+		},
+		{
+			name: "backend error",
+			localLogPath: func(string) string {
+				return ""
+			},
+			wantErr: "local anchor log path is required",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			_, bundleBytes, marker := resolverFixture(t)
+			if tc.mutateMarker != nil {
+				marker = tc.mutateMarker(marker)
+			}
+			if err := os.WriteFile(filepath.Join(dir, marker.BundlePath), bundleBytes, anchorTestFileMode); err != nil {
+				t.Fatalf("WriteFile bundle: %v", err)
+			}
+			writeResolverMarker(t, dir, marker)
+			resolver, err := NewFileAnchorResolver(dir, tc.localLogPath(dir), nil, false)
+			if err != nil {
+				t.Fatalf("NewFileAnchorResolver: %v", err)
+			}
+			if _, _, _, err := resolver(testSessionID); err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("resolver err = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestFileAnchorResolver_ConfinesAndBoundsEvidenceFiles(t *testing.T) {
 	t.Parallel()
 

--- a/enterprise/dashboard/trustkeys_test.go
+++ b/enterprise/dashboard/trustkeys_test.go
@@ -185,23 +185,26 @@ func TestFileAnchorResolver_VerifiesExistingMarkerMaterial(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("WriteStateMarker: %v", err)
 	}
+	alias := filepath.Join(t.TempDir(), "receipt-alias")
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on Windows")
+	}
+	if err := os.Symlink(dir, alias); err != nil {
+		t.Fatalf("Symlink receipt dir: %v", err)
+	}
 	markers, err := loadAnchorMarkers(dir)
 	if err != nil {
 		t.Fatalf("loadAnchorMarkers: %v", err)
 	}
-	if len(markers) != 1 || markers[0].SessionID != testSessionID {
+	if len(markers) != 1 {
 		t.Fatalf("markers = %+v, want %q", markers, testSessionID)
 	}
-	resolvedDir, err := filepath.EvalSymlinks(dir)
+	resolvedMarkers, err := loadAnchorMarkers(alias)
 	if err != nil {
-		t.Fatalf("EvalSymlinks: %v", err)
+		t.Fatalf("loadAnchorMarkers alias: %v", err)
 	}
-	resolvedMarkers, err := loadAnchorMarkers(resolvedDir)
-	if err != nil {
-		t.Fatalf("loadAnchorMarkers resolved: %v", err)
-	}
-	if len(resolvedMarkers) != 1 || resolvedMarkers[0].SessionID != testSessionID {
-		t.Fatalf("resolved markers = %+v, want %q", resolvedMarkers, testSessionID)
+	if len(resolvedMarkers) != 1 || resolvedMarkers[0] != markers[0] {
+		t.Fatalf("alias markers = %+v, want %+v", resolvedMarkers, markers)
 	}
 	resolver, err := NewFileAnchorResolver(dir, logPath, nil, false)
 	if err != nil {

--- a/enterprise/dashboard/trustkeys_test.go
+++ b/enterprise/dashboard/trustkeys_test.go
@@ -225,6 +225,52 @@ func TestFileAnchorResolver_VerifiesExistingMarkerMaterial(t *testing.T) {
 	}
 }
 
+func TestLoadAnchorMarkersIgnoresWriterTempFiles(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	chain := buildDashboardChain(t, priv, 2)
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "anchors.jsonl")
+	bundlePath := filepath.Join(dir, "bundle.json")
+	backend := anchor.LocalLog{Path: logPath, LogID: "resolver-test-log"}
+	checkpoint, err := anchor.BuildCheckpoint(testSessionID, chain, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	proof, err := backend.Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	bundle := anchor.NewBundle(checkpoint, proof)
+	if err := anchor.WriteBundle(bundlePath, bundle); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	bundleBytes, err := os.ReadFile(filepath.Clean(bundlePath))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	bundleSum := sha256.Sum256(bundleBytes)
+	if err := anchor.WriteStateMarker(dir, anchor.StateMarker{
+		SessionID: testSessionID, FinalSeq: checkpoint.FinalSeq, RootHash: checkpoint.RootHash,
+		Backend: proof.Backend, LogIndex: proof.LogIndex, AnchoredAt: time.Now().Add(-time.Minute),
+		BundleSHA256: hex.EncodeToString(bundleSum[:]), BundlePath: filepath.Base(bundlePath),
+	}); err != nil {
+		t.Fatalf("WriteStateMarker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "anchor-state.d", ".anchor-state-123456789.tmp"), []byte("partial"), anchorTestFileMode); err != nil {
+		t.Fatalf("WriteFile temp marker: %v", err)
+	}
+	markers, err := loadAnchorMarkers(dir)
+	if err != nil {
+		t.Fatalf("loadAnchorMarkers: %v", err)
+	}
+	if len(markers) != 1 || markers[0].SessionID != testSessionID {
+		t.Fatalf("markers = %+v, want committed marker only", markers)
+	}
+}
+
 func TestFileAnchorResolverDiscoversIndexedIndependentSessions(t *testing.T) {
 	t.Parallel()
 

--- a/enterprise/dashboard/trustkeys_test.go
+++ b/enterprise/dashboard/trustkeys_test.go
@@ -5,6 +5,7 @@
 package dashboard
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/ed25519"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/anchor"
+	anchorcmd "github.com/luckyPipewrench/pipelock/internal/cli/anchor"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
@@ -182,6 +184,24 @@ func TestFileAnchorResolver_VerifiesExistingMarkerMaterial(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("WriteStateMarker: %v", err)
 	}
+	markers, err := loadAnchorMarkers(dir)
+	if err != nil {
+		t.Fatalf("loadAnchorMarkers: %v", err)
+	}
+	if len(markers) != 1 || markers[0].SessionID != testSessionID {
+		t.Fatalf("markers = %+v, want %q", markers, testSessionID)
+	}
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	resolvedMarkers, err := loadAnchorMarkers(resolvedDir)
+	if err != nil {
+		t.Fatalf("loadAnchorMarkers resolved: %v", err)
+	}
+	if len(resolvedMarkers) != 1 || resolvedMarkers[0].SessionID != testSessionID {
+		t.Fatalf("resolved markers = %+v, want %q", resolvedMarkers, testSessionID)
+	}
 	resolver, err := NewFileAnchorResolver(dir, logPath, nil, false)
 	if err != nil {
 		t.Fatalf("NewFileAnchorResolver: %v", err)
@@ -202,6 +222,121 @@ func TestFileAnchorResolver_VerifiesExistingMarkerMaterial(t *testing.T) {
 	}
 	if _, _, _, err := resolver(testSessionID); err == nil || !strings.Contains(err.Error(), "hash does not match") {
 		t.Fatalf("mutated anchor bundle error = %v, want hash mismatch", err)
+	}
+}
+
+func TestFileAnchorResolverDiscoversIndexedIndependentSessions(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	first, firstBytes, firstMarker := resolverFixture(t)
+	firstPath := filepath.Join(dir, firstMarker.BundlePath)
+	if err := os.WriteFile(firstPath, firstBytes, anchorTestFileMode); err != nil {
+		t.Fatalf("WriteFile first bundle: %v", err)
+	}
+	if err := anchor.WriteStateMarker(dir, firstMarker); err != nil {
+		t.Fatalf("WriteStateMarker first: %v", err)
+	}
+
+	second := first
+	second.Checkpoint.SessionID = "session-beta"
+	second.Checkpoint.FinalSeq = 2
+	second.Checkpoint.RootHash = strings.Repeat("c", 64)
+	secondBytes, err := json.Marshal(second)
+	if err != nil {
+		t.Fatalf("Marshal second bundle: %v", err)
+	}
+	secondSum := sha256.Sum256(secondBytes)
+	secondMarker := firstMarker
+	secondMarker.SessionID = second.Checkpoint.SessionID
+	secondMarker.FinalSeq = second.Checkpoint.FinalSeq
+	secondMarker.RootHash = second.Checkpoint.RootHash
+	secondMarker.BundleSHA256 = hex.EncodeToString(secondSum[:])
+	secondMarker.BundlePath = "bundle-beta.json"
+	if err := os.WriteFile(filepath.Join(dir, secondMarker.BundlePath), secondBytes, anchorTestFileMode); err != nil {
+		t.Fatalf("WriteFile second bundle: %v", err)
+	}
+	if err := anchor.WriteStateMarker(dir, secondMarker); err != nil {
+		t.Fatalf("WriteStateMarker second: %v", err)
+	}
+
+	resolver, err := NewFileAnchorResolver(dir, filepath.Join(dir, "anchors.jsonl"), nil, false)
+	if err != nil {
+		t.Fatalf("NewFileAnchorResolver: %v", err)
+	}
+	for _, sessionID := range []string{first.Checkpoint.SessionID, second.Checkpoint.SessionID} {
+		got, backend, expected, err := resolver(sessionID)
+		if err != nil || got == nil || backend == nil || !expected {
+			t.Fatalf("resolve %q bundle=%v backend=%T expected=%t err=%v", sessionID, got, backend, expected, err)
+		}
+		if got.Checkpoint.SessionID != sessionID {
+			t.Fatalf("resolve %q got session %q", sessionID, got.Checkpoint.SessionID)
+		}
+	}
+}
+
+func TestFileAnchorResolverFailsClosedOnCorruptIndexedMarker(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, bundleBytes, marker := resolverFixture(t)
+	if err := os.WriteFile(filepath.Join(dir, marker.BundlePath), bundleBytes, anchorTestFileMode); err != nil {
+		t.Fatalf("WriteFile bundle: %v", err)
+	}
+	if err := anchor.WriteStateMarker(dir, marker); err != nil {
+		t.Fatalf("WriteStateMarker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "anchor-state.d", "corrupt.json"), []byte(`{"schema":`), anchorTestFileMode); err != nil {
+		t.Fatalf("WriteFile corrupt marker: %v", err)
+	}
+	resolver, err := NewFileAnchorResolver(dir, filepath.Join(dir, "anchors.jsonl"), nil, false)
+	if err != nil {
+		t.Fatalf("NewFileAnchorResolver: %v", err)
+	}
+	if _, _, _, err := resolver(testSessionID); err == nil || !strings.Contains(err.Error(), "parse anchor-state marker") {
+		t.Fatalf("resolver err = %v, want corrupt index failure", err)
+	}
+}
+
+func TestFileAnchorResolverVerifiesProducerRelativeBundlePath(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateDashboardKey(t)
+	keyHex := hex.EncodeToString(pub)
+	chain := buildDashboardChain(t, priv, 2)
+	dir := t.TempDir()
+	receiptsPath := writeDashboardReceiptsJSONL(t, dir, chain)
+	logPath := filepath.Join(dir, "anchors.jsonl")
+
+	cmd := anchorcmd.Cmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{
+		"receipts",
+		receiptsPath,
+		"--key", keyHex,
+		"--local-log", logPath,
+		"--log-id", "dashboard-roundtrip-log",
+		"--out", "bundle.json",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute anchor receipts: %v", err)
+	}
+
+	resolver, err := NewFileAnchorResolver(dir, logPath, nil, false)
+	if err != nil {
+		t.Fatalf("NewFileAnchorResolver: %v", err)
+	}
+	gotBundle, gotBackend, expected, err := resolver("file")
+	if err != nil || gotBundle == nil || gotBackend == nil || !expected {
+		t.Fatalf("resolve bundle=%v backend=%T expected=%t err=%v", gotBundle, gotBackend, expected, err)
+	}
+	got := AuditReceiptChain(ChainAuditInput{
+		SessionID: "file", Receipts: chain, TrustedKeys: []string{keyHex},
+		AnchorExpected: expected, AnchorBundle: gotBundle, AnchorBackend: gotBackend,
+	})
+	if !got.Consistent || got.AnchorStatus != AnchorCurrent {
+		t.Fatalf("audit = %+v, want producer bundle to verify through dashboard confinement", got)
 	}
 }
 
@@ -475,6 +610,24 @@ func resolverFixture(t *testing.T) (anchor.Bundle, []byte, anchor.StateMarker) {
 	return bundle, data, marker
 }
 
+func writeDashboardReceiptsJSONL(t *testing.T, dir string, receipts []receipt.Receipt) string {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, r := range receipts {
+		line, err := receipt.Marshal(r)
+		if err != nil {
+			t.Fatalf("Marshal receipt: %v", err)
+		}
+		_, _ = buf.Write(line)
+		_ = buf.WriteByte('\n')
+	}
+	path := filepath.Join(dir, "receipts.jsonl")
+	if err := os.WriteFile(path, buf.Bytes(), anchorTestFileMode); err != nil {
+		t.Fatalf("WriteFile receipts: %v", err)
+	}
+	return path
+}
+
 func writeResolverMarker(t *testing.T, dir string, marker anchor.StateMarker) {
 	t.Helper()
 	writeResolverMarkerAt(t, filepath.Join(dir, "anchor-state.json"), marker)
@@ -745,3 +898,108 @@ type testTrustError struct{ message string }
 func (e *testTrustError) Error() string { return e.message }
 
 var _ ed25519.PublicKey
+
+func TestFileAnchorResolverRejectsHostileIndexEntries(t *testing.T) {
+	t.Parallel()
+	_, bundleBytes, marker := resolverFixture(t)
+
+	mkIndexDir := func(t *testing.T, dir string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(dir, "anchor-state.d"), 0o750); err != nil {
+			t.Fatalf("mkdir index: %v", err)
+		}
+	}
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+	}{
+		{name: "symlinked index directory", setup: func(t *testing.T, dir string) {
+			if err := os.Symlink(t.TempDir(), filepath.Join(dir, "anchor-state.d")); err != nil {
+				t.Fatalf("symlink index dir: %v", err)
+			}
+		}},
+		{name: "non json entry", setup: func(t *testing.T, dir string) {
+			mkIndexDir(t, dir)
+			if err := os.WriteFile(filepath.Join(dir, "anchor-state.d", "note.txt"), []byte("x"), anchorTestFileMode); err != nil {
+				t.Fatalf("write entry: %v", err)
+			}
+		}},
+		{name: "symlinked marker entry", setup: func(t *testing.T, dir string) {
+			mkIndexDir(t, dir)
+			target := filepath.Join(dir, "target.json")
+			if err := os.WriteFile(target, []byte("{}"), anchorTestFileMode); err != nil {
+				t.Fatalf("write target: %v", err)
+			}
+			if err := os.Symlink(target, filepath.Join(dir, "anchor-state.d", "link.json")); err != nil {
+				t.Fatalf("symlink entry: %v", err)
+			}
+		}},
+		{name: "identity mismatch filename", setup: func(t *testing.T, dir string) {
+			mkIndexDir(t, dir)
+			data, err := json.Marshal(marker)
+			if err != nil {
+				t.Fatalf("marshal marker: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "anchor-state.d", "wrong-name.json"), data, anchorTestFileMode); err != nil {
+				t.Fatalf("write marker: %v", err)
+			}
+		}},
+		{name: "duplicate legacy and index identity", setup: func(t *testing.T, dir string) {
+			if err := anchor.WriteStateMarker(dir, marker); err != nil {
+				t.Fatalf("write indexed marker: %v", err)
+			}
+			data, err := json.Marshal(marker)
+			if err != nil {
+				t.Fatalf("marshal marker: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "anchor-state.json"), data, anchorTestFileMode); err != nil {
+				t.Fatalf("write legacy marker: %v", err)
+			}
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, marker.BundlePath), bundleBytes, anchorTestFileMode); err != nil {
+				t.Fatalf("write bundle: %v", err)
+			}
+			tc.setup(t, dir)
+			resolver, err := NewFileAnchorResolver(dir, filepath.Join(dir, "anchors.jsonl"), nil, false)
+			if err != nil {
+				t.Fatalf("NewFileAnchorResolver: %v", err)
+			}
+			if _, _, _, err := resolver(testSessionID); err == nil {
+				t.Fatal("resolver accepted hostile index state")
+			}
+		})
+	}
+}
+
+func TestFileAnchorResolverRejectsAmbiguousSessionMarkers(t *testing.T) {
+	t.Parallel()
+	_, bundleBytes, marker := resolverFixture(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, marker.BundlePath), bundleBytes, anchorTestFileMode); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	if err := anchor.WriteStateMarker(dir, marker); err != nil {
+		t.Fatalf("write indexed marker: %v", err)
+	}
+	second := marker
+	second.FinalSeq = marker.FinalSeq + 1
+	data, err := json.Marshal(second)
+	if err != nil {
+		t.Fatalf("marshal second: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "anchor-state.json"), data, anchorTestFileMode); err != nil {
+		t.Fatalf("write legacy marker: %v", err)
+	}
+	resolver, err := NewFileAnchorResolver(dir, filepath.Join(dir, "anchors.jsonl"), nil, false)
+	if err != nil {
+		t.Fatalf("NewFileAnchorResolver: %v", err)
+	}
+	if _, _, _, err := resolver(testSessionID); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("resolver err = %v, want ambiguous", err)
+	}
+}

--- a/enterprise/dashboard/trustkeys_test.go
+++ b/enterprise/dashboard/trustkeys_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -588,7 +589,7 @@ func TestFileAnchorResolver_ConfinesAndBoundsEvidenceFiles(t *testing.T) {
 					t.Fatalf("Symlink marker: %v", err)
 				}
 			},
-			wantErr: "symlink",
+			wantErr: "not a regular file",
 		},
 		{
 			name: "marker is not regular",
@@ -1010,6 +1011,9 @@ func TestFileAnchorResolverRejectsHostileIndexEntries(t *testing.T) {
 		setup func(t *testing.T, dir string)
 	}{
 		{name: "symlinked index directory", setup: func(t *testing.T, dir string) {
+			if runtime.GOOS == "windows" {
+				t.Skip("symlink creation needs privileges on Windows")
+			}
 			if err := os.Symlink(t.TempDir(), filepath.Join(dir, "anchor-state.d")); err != nil {
 				t.Fatalf("symlink index dir: %v", err)
 			}
@@ -1021,6 +1025,9 @@ func TestFileAnchorResolverRejectsHostileIndexEntries(t *testing.T) {
 			}
 		}},
 		{name: "symlinked marker entry", setup: func(t *testing.T, dir string) {
+			if runtime.GOOS == "windows" {
+				t.Skip("symlink creation needs privileges on Windows")
+			}
 			mkIndexDir(t, dir)
 			target := filepath.Join(dir, "target.json")
 			if err := os.WriteFile(target, []byte("{}"), anchorTestFileMode); err != nil {

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -295,7 +295,7 @@ func validateStateMarkerIndexDir(indexDir string) error {
 func LoadStateMarkers(dir string) ([]StateMarker, error) {
 	cleanDir := filepath.Clean(dir)
 	var markers []StateMarker
-	if marker, found, err := loadStateMarkerFile(filepath.Join(cleanDir, legacyStateMarker)); err != nil {
+	if marker, found, err := LoadStateMarkerFile(filepath.Join(cleanDir, legacyStateMarker)); err != nil {
 		return nil, err
 	} else if found {
 		markers = append(markers, marker)
@@ -340,7 +340,7 @@ func LoadStateMarkers(dir string) ([]StateMarker, error) {
 			return nil, fmt.Errorf("read anchor-state index: %s is not a regular marker", entry.Name())
 		}
 		path := filepath.Join(indexDir, entry.Name())
-		marker, found, err := loadStateMarkerFile(path)
+		marker, found, err := LoadStateMarkerFile(path)
 		if err != nil {
 			return nil, err
 		}
@@ -405,7 +405,10 @@ func stateMarkerTempName() (string, error) {
 	return ".anchor-state-" + hex.EncodeToString(raw[:]) + ".tmp", nil
 }
 
-func loadStateMarkerFile(path string) (StateMarker, bool, error) {
+// LoadStateMarkerFile strictly reads and validates one anchor-state marker file.
+// It rejects symlinks, non-regular files, oversized files, duplicate JSON keys,
+// unknown fields, trailing JSON, and local replacement races.
+func LoadStateMarkerFile(path string) (StateMarker, bool, error) {
 	clean := filepath.Clean(path)
 	info, err := os.Lstat(clean)
 	if errors.Is(err, os.ErrNotExist) {

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -14,6 +14,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
@@ -30,6 +33,11 @@ const (
 
 	dirPermissions  = 0o750
 	filePermissions = 0o600
+
+	stateMarkerSchema   = "pipelock.anchorstate.v1"
+	stateMarkerIndexDir = "anchor-state.d"
+	legacyStateMarker   = "anchor-state.json"
+	maxStateMarkerBytes = 64 * 1024
 )
 
 var DefaultLimits = []string{
@@ -244,16 +252,24 @@ func WriteBundle(path string, b Bundle) error {
 }
 
 func WriteStateMarker(dir string, marker StateMarker) error {
-	marker.Schema = "pipelock.anchorstate.v1"
+	marker.Schema = stateMarkerSchema
 	data, err := json.Marshal(marker)
 	if err != nil {
 		return fmt.Errorf("marshal anchor-state marker: %w", err)
 	}
 	cleanDir := filepath.Clean(dir)
-	if err := os.MkdirAll(cleanDir, dirPermissions); err != nil {
+	indexDir := filepath.Join(cleanDir, stateMarkerIndexDir)
+	path, err := StateMarkerPath(cleanDir, marker)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(indexDir, dirPermissions); err != nil {
 		return fmt.Errorf("create anchor-state directory: %w", err)
 	}
-	tmp, err := os.CreateTemp(cleanDir, ".anchor-state-*.tmp")
+	if err := validateStateMarkerIndexDir(indexDir); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(indexDir, ".anchor-state-*.tmp")
 	if err != nil {
 		return fmt.Errorf("create anchor-state temp file: %w", err)
 	}
@@ -274,10 +290,191 @@ func WriteStateMarker(dir string, marker StateMarker) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close anchor-state temp file: %w", err)
 	}
-	if err := os.Rename(tmpPath, filepath.Join(cleanDir, "anchor-state.json")); err != nil {
+	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("rename anchor-state marker: %w", err)
 	}
 	return nil
+}
+
+func StateMarkerPath(dir string, marker StateMarker) (string, error) {
+	name, err := stateMarkerFileName(marker)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Clean(dir), stateMarkerIndexDir, name), nil
+}
+
+func validateStateMarkerIndexDir(indexDir string) error {
+	info, err := os.Lstat(indexDir)
+	if err != nil {
+		return fmt.Errorf("inspect anchor-state directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return errors.New("anchor-state directory is not a regular directory")
+	}
+	return nil
+}
+
+func LoadStateMarkers(dir string) ([]StateMarker, error) {
+	cleanDir := filepath.Clean(dir)
+	var markers []StateMarker
+	if marker, found, err := loadStateMarkerFile(filepath.Join(cleanDir, legacyStateMarker)); err != nil {
+		return nil, err
+	} else if found {
+		markers = append(markers, marker)
+	}
+
+	indexDir := filepath.Join(cleanDir, stateMarkerIndexDir)
+	_, err := os.Lstat(indexDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return markers, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inspect anchor-state index: %w", err)
+	}
+	if err := validateStateMarkerIndexDir(indexDir); err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(indexDir)
+	if err != nil {
+		return nil, fmt.Errorf("read anchor-state index: %w", err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	seen := make(map[string]string, len(markers)+len(entries))
+	for _, marker := range markers {
+		key := stateMarkerIdentity(marker)
+		seen[key] = legacyStateMarker
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return nil, fmt.Errorf("read anchor-state index: %s is not a regular marker", entry.Name())
+		}
+		if filepath.Ext(entry.Name()) != ".json" {
+			return nil, fmt.Errorf("read anchor-state index: unexpected marker name %q", entry.Name())
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("inspect anchor-state marker %q: %w", entry.Name(), err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("read anchor-state index: %s is not a regular marker", entry.Name())
+		}
+		path := filepath.Join(indexDir, entry.Name())
+		marker, found, err := loadStateMarkerFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		want, err := stateMarkerFileName(marker)
+		if err != nil {
+			return nil, err
+		}
+		if entry.Name() != want {
+			return nil, fmt.Errorf("anchor-state marker %q does not match marker identity", entry.Name())
+		}
+		key := stateMarkerIdentity(marker)
+		if previous, ok := seen[key]; ok {
+			return nil, fmt.Errorf("anchor-state marker %q duplicates %q", entry.Name(), previous)
+		}
+		seen[key] = entry.Name()
+		markers = append(markers, marker)
+	}
+	return markers, nil
+}
+
+func loadStateMarkerFile(path string) (StateMarker, bool, error) {
+	clean := filepath.Clean(path)
+	info, err := os.Lstat(clean)
+	if errors.Is(err, os.ErrNotExist) {
+		return StateMarker{}, false, nil
+	}
+	if err != nil {
+		return StateMarker{}, false, fmt.Errorf("inspect anchor-state marker: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return StateMarker{}, false, errors.New("anchor-state marker is not a regular file")
+	}
+	if info.Size() > maxStateMarkerBytes {
+		return StateMarker{}, false, fmt.Errorf("anchor-state marker exceeds size limit of %d bytes", maxStateMarkerBytes)
+	}
+	file, err := os.Open(clean) // #nosec G304 -- caller supplies an anchor-state path; Lstat and fstat below fail closed on races.
+	if err != nil {
+		return StateMarker{}, false, fmt.Errorf("read anchor-state marker: %w", err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return StateMarker{}, false, fmt.Errorf("inspect opened anchor-state marker: %w", err)
+	}
+	if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		return StateMarker{}, false, errors.New("anchor-state marker changed during validation")
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxStateMarkerBytes+1))
+	if err != nil {
+		return StateMarker{}, false, fmt.Errorf("read anchor-state marker: %w", err)
+	}
+	if len(data) > maxStateMarkerBytes {
+		return StateMarker{}, false, fmt.Errorf("anchor-state marker exceeds size limit of %d bytes", maxStateMarkerBytes)
+	}
+	var marker StateMarker
+	if err := decodeStrict(data, &marker); err != nil {
+		return StateMarker{}, false, fmt.Errorf("parse anchor-state marker: %w", err)
+	}
+	if err := validateStateMarker(marker); err != nil {
+		return StateMarker{}, false, err
+	}
+	return marker, true, nil
+}
+
+func validateStateMarker(marker StateMarker) error {
+	if marker.Schema != stateMarkerSchema {
+		return fmt.Errorf("anchor-state marker schema %q is invalid", marker.Schema)
+	}
+	if strings.TrimSpace(marker.SessionID) == "" {
+		return errors.New("anchor-state marker session_id is empty")
+	}
+	if !isLowerHexBytes(marker.RootHash, sha256.Size) {
+		return errors.New("anchor-state marker root_hash is invalid")
+	}
+	if !isLowerHexBytes(marker.BundleSHA256, sha256.Size) {
+		return errors.New("anchor-state marker bundle_sha256 is invalid")
+	}
+	if strings.TrimSpace(marker.BundlePath) == "" {
+		return errors.New("anchor-state marker bundle_path is empty")
+	}
+	return nil
+}
+
+func stateMarkerFileName(marker StateMarker) (string, error) {
+	if marker.SessionID == "" {
+		return "", errors.New("anchor-state marker session_id is empty")
+	}
+	if marker.RootHash == "" {
+		return "", errors.New("anchor-state marker root_hash is empty")
+	}
+	sum := sha256.Sum256([]byte(stateMarkerIdentity(marker)))
+	return hex.EncodeToString(sum[:]) + ".json", nil
+}
+
+func stateMarkerIdentity(marker StateMarker) string {
+	return marker.SessionID + "\x00" + strconv.FormatUint(marker.FinalSeq, 10) + "\x00" + marker.RootHash
+}
+
+func isLowerHexBytes(value string, bytesLen int) bool {
+	if len(value) != bytesLen*2 {
+		return false
+	}
+	for _, ch := range value {
+		if (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func checkpointsEqual(a, b Checkpoint) bool {

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -253,6 +253,9 @@ func WriteBundle(path string, b Bundle) error {
 
 func WriteStateMarker(dir string, marker StateMarker) error {
 	marker.Schema = stateMarkerSchema
+	if err := validateStateMarker(marker); err != nil {
+		return err
+	}
 	data, err := json.Marshal(marker)
 	if err != nil {
 		return fmt.Errorf("marshal anchor-state marker: %w", err)

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -6,6 +6,7 @@ package anchor
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -241,14 +242,22 @@ func WriteBundle(path string, b Bundle) error {
 	if err != nil {
 		return fmt.Errorf("marshal anchor bundle: %w", err)
 	}
-	clean := filepath.Clean(path)
-	if err := os.MkdirAll(filepath.Dir(clean), dirPermissions); err != nil {
-		return fmt.Errorf("create anchor bundle directory: %w", err)
+	return writeBundleFile(filepath.Clean(path), append(data, '\n'))
+}
+
+// WriteBundleUnderDir writes an anchor bundle under root without trusting
+// pathnames after the caller has resolved policy. On Unix-like platforms it uses
+// descriptor-relative no-follow operations for every component.
+func WriteBundleUnderDir(root, rel string, b Bundle) error {
+	cleanRel := filepath.Clean(filepath.FromSlash(rel))
+	if filepath.IsAbs(cleanRel) || cleanRel == "." || cleanRel == ".." || strings.HasPrefix(cleanRel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("anchor bundle path must stay under receipt directory")
 	}
-	if err := os.WriteFile(clean, append(data, '\n'), filePermissions); err != nil {
-		return fmt.Errorf("write anchor bundle: %w", err)
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal anchor bundle: %w", err)
 	}
-	return nil
+	return writeBundleFileUnderDir(filepath.Clean(root), cleanRel, append(data, '\n'))
 }
 
 func WriteStateMarker(dir string, marker StateMarker) error {
@@ -261,42 +270,7 @@ func WriteStateMarker(dir string, marker StateMarker) error {
 		return fmt.Errorf("marshal anchor-state marker: %w", err)
 	}
 	cleanDir := filepath.Clean(dir)
-	indexDir := filepath.Join(cleanDir, stateMarkerIndexDir)
-	path, err := StateMarkerPath(cleanDir, marker)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(indexDir, dirPermissions); err != nil {
-		return fmt.Errorf("create anchor-state directory: %w", err)
-	}
-	if err := validateStateMarkerIndexDir(indexDir); err != nil {
-		return err
-	}
-	tmp, err := os.CreateTemp(indexDir, ".anchor-state-*.tmp")
-	if err != nil {
-		return fmt.Errorf("create anchor-state temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-	defer func() { _ = os.Remove(tmpPath) }()
-	if _, err := tmp.Write(append(data, '\n')); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("write anchor-state temp file: %w", err)
-	}
-	if err := tmp.Chmod(filePermissions); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("chmod anchor-state temp file: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("sync anchor-state temp file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close anchor-state temp file: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("rename anchor-state marker: %w", err)
-	}
-	return nil
+	return writeStateMarkerFile(cleanDir, marker, append(data, '\n'))
 }
 
 func StateMarkerPath(dir string, marker StateMarker) (string, error) {
@@ -349,6 +323,9 @@ func LoadStateMarkers(dir string) ([]StateMarker, error) {
 		seen[key] = legacyStateMarker
 	}
 	for _, entry := range entries {
+		if IsStateMarkerTempName(entry.Name()) {
+			continue
+		}
 		if entry.IsDir() {
 			return nil, fmt.Errorf("read anchor-state index: %s is not a regular marker", entry.Name())
 		}
@@ -385,6 +362,47 @@ func LoadStateMarkers(dir string) ([]StateMarker, error) {
 		markers = append(markers, marker)
 	}
 	return markers, nil
+}
+
+// IsStateMarkerTempName reports whether name matches the private temp-file
+// pattern produced by WriteStateMarker before the final atomic rename.
+func IsStateMarkerTempName(name string) bool {
+	const (
+		prefix = ".anchor-state-"
+		suffix = ".tmp"
+	)
+	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+		return false
+	}
+	random := strings.TrimSuffix(strings.TrimPrefix(name, prefix), suffix)
+	if len(random) == 0 {
+		return false
+	}
+	if len(random) <= 10 {
+		for _, r := range random {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+		return true
+	}
+	if len(random) != 32 {
+		return false
+	}
+	for _, r := range random {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func stateMarkerTempName() (string, error) {
+	var raw [16]byte
+	if _, err := crand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate anchor-state temp name: %w", err)
+	}
+	return ".anchor-state-" + hex.EncodeToString(raw[:]) + ".tmp", nil
 }
 
 func loadStateMarkerFile(path string) (StateMarker, bool, error) {

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -238,26 +238,37 @@ func LoadBundleBytes(data []byte) (Bundle, error) {
 }
 
 func WriteBundle(path string, b Bundle) error {
-	data, err := json.MarshalIndent(b, "", "  ")
+	data, err := bundleBytes(b)
 	if err != nil {
-		return fmt.Errorf("marshal anchor bundle: %w", err)
+		return err
 	}
-	return writeBundleFile(filepath.Clean(path), append(data, '\n'))
+	return writeBundleFile(filepath.Clean(path), data)
 }
 
 // WriteBundleUnderDir writes an anchor bundle under root without trusting
 // pathnames after the caller has resolved policy. On Unix-like platforms it uses
 // descriptor-relative no-follow operations for every component.
-func WriteBundleUnderDir(root, rel string, b Bundle) error {
+func WriteBundleUnderDir(root, rel string, b Bundle) ([]byte, error) {
 	cleanRel := filepath.Clean(filepath.FromSlash(rel))
 	if filepath.IsAbs(cleanRel) || cleanRel == "." || cleanRel == ".." || strings.HasPrefix(cleanRel, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("anchor bundle path must stay under receipt directory")
+		return nil, fmt.Errorf("anchor bundle path must stay under receipt directory")
 	}
+	data, err := bundleBytes(b)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeBundleFileUnderDir(filepath.Clean(root), cleanRel, data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func bundleBytes(b Bundle) ([]byte, error) {
 	data, err := json.MarshalIndent(b, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal anchor bundle: %w", err)
+		return nil, fmt.Errorf("marshal anchor bundle: %w", err)
 	}
-	return writeBundleFileUnderDir(filepath.Clean(root), cleanRel, append(data, '\n'))
+	return append(data, '\n'), nil
 }
 
 func WriteStateMarker(dir string, marker StateMarker) error {

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -148,6 +148,28 @@ func TestWriteBundleRejectsBadFilesystemTargets(t *testing.T) {
 	}
 }
 
+func TestWriteBundleUnderDirRejectsSymlinkComponents(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on Windows")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	bundle := NewBundle(Checkpoint{SessionID: "proxy", FinalSeq: 1, RootHash: strings.Repeat("a", 64)}, Proof{Backend: LocalBackend})
+	if err := WriteBundleUnderDir(root, filepath.Join("link", "bundle.json"), bundle); err == nil {
+		t.Fatal("WriteBundleUnderDir accepted a symlinked parent")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("ReadDir outside: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("symlinked parent received bundle data: %v", entries)
+	}
+}
+
 func TestWriteStateMarkerWritesCanonicalPrivateJSON(t *testing.T) {
 	dir := t.TempDir()
 	anchoredAt := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
@@ -206,6 +228,38 @@ func TestWriteStateMarkerWritesCanonicalPrivateJSON(t *testing.T) {
 		got.BundleSHA256 != marker.BundleSHA256 ||
 		got.BundlePath != marker.BundlePath {
 		t.Fatalf("anchor-state marker = %+v, want fields from %+v with canonical schema", got, marker)
+	}
+}
+
+func TestLoadStateMarkersIgnoresWriterTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	marker := StateMarker{
+		SessionID:    "session-a",
+		FinalSeq:     1,
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "bundle.json",
+	}
+	if err := WriteStateMarker(dir, marker); err != nil {
+		t.Fatalf("WriteStateMarker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "anchor-state.d", ".anchor-state-123456789.tmp"), []byte("partial"), 0o600); err != nil {
+		t.Fatalf("WriteFile temp marker: %v", err)
+	}
+	markers, err := LoadStateMarkers(dir)
+	if err != nil {
+		t.Fatalf("LoadStateMarkers: %v", err)
+	}
+	if len(markers) != 1 || markers[0].SessionID != marker.SessionID {
+		t.Fatalf("markers = %+v, want only the committed marker", markers)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "anchor-state.d", ".anchor-state-leftover.tmp"), []byte("partial"), 0o600); err != nil {
+		t.Fatalf("WriteFile foreign temp: %v", err)
+	}
+	if _, err := LoadStateMarkers(dir); err == nil || !strings.Contains(err.Error(), "unexpected marker") {
+		t.Fatalf("LoadStateMarkers foreign temp err = %v, want unexpected marker", err)
 	}
 }
 

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -410,6 +410,137 @@ func TestLoadStateMarkersFailsClosedOnHostileFilesystemState(t *testing.T) {
 	}
 }
 
+func TestLoadStateMarkerFileRejectsMalformedFiles(t *testing.T) {
+	valid := StateMarker{
+		Schema:       stateMarkerSchema,
+		SessionID:    "session-a",
+		FinalSeq:     1,
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "bundle.json",
+	}
+	validData, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatalf("Marshal valid marker: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, path string)
+		wantErr string
+	}{
+		{
+			name: "symlink",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if runtime.GOOS == "windows" {
+					t.Skip("symlink creation needs privileges on Windows")
+				}
+				target := filepath.Join(filepath.Dir(path), "target-marker.json")
+				if err := os.WriteFile(target, append(validData, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile target: %v", err)
+				}
+				if err := os.Symlink(filepath.Base(target), path); err != nil {
+					t.Fatalf("Symlink marker: %v", err)
+				}
+			},
+			wantErr: "not a regular file",
+		},
+		{
+			name: "non regular",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Mkdir(path, 0o750); err != nil {
+					t.Fatalf("Mkdir marker path: %v", err)
+				}
+			},
+			wantErr: "not a regular file",
+		},
+		{
+			name: "oversized",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, make([]byte, maxStateMarkerBytes+1), 0o600); err != nil {
+					t.Fatalf("WriteFile oversized marker: %v", err)
+				}
+			},
+			wantErr: "exceeds size limit",
+		},
+		{
+			name: "corrupt JSON",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte(`{"schema":`), 0o600); err != nil {
+					t.Fatalf("WriteFile corrupt marker: %v", err)
+				}
+			},
+			wantErr: "parse anchor-state marker",
+		},
+		{
+			name: "schema mismatch",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				invalid := valid
+				invalid.Schema = "wrong-schema"
+				data, err := json.Marshal(invalid)
+				if err != nil {
+					t.Fatalf("Marshal invalid marker: %v", err)
+				}
+				if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile invalid marker: %v", err)
+				}
+			},
+			wantErr: "schema",
+		},
+		{
+			name: "blank required field",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				invalid := valid
+				invalid.BundlePath = " "
+				data, err := json.Marshal(invalid)
+				if err != nil {
+					t.Fatalf("Marshal invalid marker: %v", err)
+				}
+				if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile invalid marker: %v", err)
+				}
+			},
+			wantErr: "bundle_path is empty",
+		},
+		{
+			name: "valid",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, append(validData, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile valid marker: %v", err)
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "anchor-state.json")
+			tc.setup(t, path)
+			got, found, err := loadStateMarkerFile(path)
+			if tc.wantErr != "" {
+				if err == nil || found || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("loadStateMarkerFile found=%v err=%v, want %q", found, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil || !found {
+				t.Fatalf("loadStateMarkerFile found=%v err=%v, want valid marker", found, err)
+			}
+			if got.SessionID != valid.SessionID || got.BundleSHA256 != valid.BundleSHA256 {
+				t.Fatalf("loadStateMarkerFile = %+v, want valid marker", got)
+			}
+		})
+	}
+}
+
 func TestWriteStateMarkerRejectsBadFilesystemTarget(t *testing.T) {
 	dir := t.TempDir()
 	blocker := filepath.Join(dir, "not-a-directory")
@@ -832,5 +963,46 @@ func TestWriteStateMarkerRejectsMarkerWithoutIdentity(t *testing.T) {
 	t.Parallel()
 	if err := WriteStateMarker(t.TempDir(), StateMarker{RootHash: "abc"}); err == nil {
 		t.Fatal("WriteStateMarker accepted marker with empty session id")
+	}
+}
+
+func TestWriteStateMarkerRejectsInvalidMarkerDigests(t *testing.T) {
+	valid := StateMarker{
+		SessionID:    "session-a",
+		FinalSeq:     1,
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "bundle.json",
+	}
+	tests := []struct {
+		name   string
+		mutate func(StateMarker) StateMarker
+		want   string
+	}{
+		{
+			name: "short root hash",
+			mutate: func(marker StateMarker) StateMarker {
+				marker.RootHash = "abc"
+				return marker
+			},
+			want: "root_hash is invalid",
+		},
+		{
+			name: "short bundle sha",
+			mutate: func(marker StateMarker) StateMarker {
+				marker.BundleSHA256 = "abc"
+				return marker
+			},
+			want: "bundle_sha256 is invalid",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := WriteStateMarker(t.TempDir(), tc.mutate(valid)); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("WriteStateMarker err = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -736,18 +736,18 @@ func TestLoadStateMarkerFileRejectsMalformedFiles(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "anchor-state.json")
 			tc.setup(t, path)
-			got, found, err := loadStateMarkerFile(path)
+			got, found, err := LoadStateMarkerFile(path)
 			if tc.wantErr != "" {
 				if err == nil || found || !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("loadStateMarkerFile found=%v err=%v, want %q", found, err, tc.wantErr)
+					t.Fatalf("LoadStateMarkerFile found=%v err=%v, want %q", found, err, tc.wantErr)
 				}
 				return
 			}
 			if err != nil || !found {
-				t.Fatalf("loadStateMarkerFile found=%v err=%v, want valid marker", found, err)
+				t.Fatalf("LoadStateMarkerFile found=%v err=%v, want valid marker", found, err)
 			}
 			if got.SessionID != valid.SessionID || got.BundleSHA256 != valid.BundleSHA256 {
-				t.Fatalf("loadStateMarkerFile = %+v, want valid marker", got)
+				t.Fatalf("LoadStateMarkerFile = %+v, want valid marker", got)
 			}
 		})
 	}
@@ -1173,8 +1173,15 @@ func writeLocalLogEntries(t *testing.T, path string, entries []LocalLogEntry) {
 
 func TestWriteStateMarkerRejectsMarkerWithoutIdentity(t *testing.T) {
 	t.Parallel()
-	if err := WriteStateMarker(t.TempDir(), StateMarker{RootHash: "abc"}); err == nil {
-		t.Fatal("WriteStateMarker accepted marker with empty session id")
+	err := WriteStateMarker(t.TempDir(), StateMarker{
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "bundle.json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "session_id is empty") {
+		t.Fatalf("WriteStateMarker err = %v, want session_id rejection", err)
 	}
 }
 

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -153,7 +153,7 @@ func TestWriteBundleUnderDirWritesNestedBundle(t *testing.T) {
 	bundle := NewBundle(Checkpoint{SessionID: "proxy", FinalSeq: 1, RootHash: strings.Repeat("a", 64)}, Proof{Backend: LocalBackend})
 	rel := filepath.Join("nested", "deeper", "bundle.json")
 
-	if err := WriteBundleUnderDir(root, rel, bundle); err != nil {
+	if _, err := WriteBundleUnderDir(root, rel, bundle); err != nil {
 		t.Fatalf("WriteBundleUnderDir: %v", err)
 	}
 	loaded, err := LoadBundle(filepath.Join(root, rel))
@@ -171,7 +171,7 @@ func TestWriteBundleUnderDirRejectsEscapes(t *testing.T) {
 	bundle := NewBundle(Checkpoint{SessionID: "proxy", FinalSeq: 1, RootHash: strings.Repeat("a", 64)}, Proof{Backend: LocalBackend})
 	for _, rel := range []string{abs, ".", "..", filepath.Join("..", "bundle.json")} {
 		t.Run(rel, func(t *testing.T) {
-			if err := WriteBundleUnderDir(root, rel, bundle); err == nil || !strings.Contains(err.Error(), "stay under receipt directory") {
+			if _, err := WriteBundleUnderDir(root, rel, bundle); err == nil || !strings.Contains(err.Error(), "stay under receipt directory") {
 				t.Fatalf("WriteBundleUnderDir(%q) err = %v, want escape rejection", rel, err)
 			}
 		})
@@ -188,7 +188,7 @@ func TestWriteBundleUnderDirRejectsSymlinkComponents(t *testing.T) {
 		t.Fatalf("Symlink: %v", err)
 	}
 	bundle := NewBundle(Checkpoint{SessionID: "proxy", FinalSeq: 1, RootHash: strings.Repeat("a", 64)}, Proof{Backend: LocalBackend})
-	if err := WriteBundleUnderDir(root, filepath.Join("link", "bundle.json"), bundle); err == nil {
+	if _, err := WriteBundleUnderDir(root, filepath.Join("link", "bundle.json"), bundle); err == nil {
 		t.Fatal("WriteBundleUnderDir accepted a symlinked parent")
 	}
 	entries, err := os.ReadDir(outside)
@@ -212,7 +212,7 @@ func TestWriteBundleUnderDirRejectsSymlinkRootAndFinalPath(t *testing.T) {
 		if err := os.Symlink(outside, root); err != nil {
 			t.Fatalf("Symlink root: %v", err)
 		}
-		if err := WriteBundleUnderDir(root, "bundle.json", bundle); err == nil || !strings.Contains(err.Error(), "open anchor bundle directory") {
+		if _, err := WriteBundleUnderDir(root, "bundle.json", bundle); err == nil || !strings.Contains(err.Error(), "open anchor bundle directory") {
 			t.Fatalf("WriteBundleUnderDir symlink root err = %v, want refusal", err)
 		}
 	})
@@ -226,7 +226,7 @@ func TestWriteBundleUnderDirRejectsSymlinkRootAndFinalPath(t *testing.T) {
 		if err := os.Symlink(outside, filepath.Join(root, "bundle.json")); err != nil {
 			t.Fatalf("Symlink final path: %v", err)
 		}
-		if err := WriteBundleUnderDir(root, "bundle.json", bundle); err == nil || !strings.Contains(err.Error(), "write anchor bundle") {
+		if _, err := WriteBundleUnderDir(root, "bundle.json", bundle); err == nil || !strings.Contains(err.Error(), "write anchor bundle") {
 			t.Fatalf("WriteBundleUnderDir symlink final err = %v, want write refusal", err)
 		}
 		data, err := os.ReadFile(filepath.Clean(outside))

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -165,7 +166,10 @@ func TestWriteStateMarkerWritesCanonicalPrivateJSON(t *testing.T) {
 		t.Fatalf("WriteStateMarker: %v", err)
 	}
 
-	path := filepath.Join(dir, "anchor-state.json")
+	path, err := StateMarkerPath(dir, marker)
+	if err != nil {
+		t.Fatalf("StateMarkerPath: %v", err)
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("Stat anchor-state: %v", err)
@@ -173,7 +177,7 @@ func TestWriteStateMarkerWritesCanonicalPrivateJSON(t *testing.T) {
 	if got := info.Mode().Perm(); got != filePermissions {
 		t.Fatalf("anchor-state permissions = %#o, want %#o", got, filePermissions)
 	}
-	matches, err := filepath.Glob(filepath.Join(dir, ".anchor-state-*.tmp"))
+	matches, err := filepath.Glob(filepath.Join(dir, "anchor-state.d", ".anchor-state-*.tmp"))
 	if err != nil {
 		t.Fatalf("Glob temp markers: %v", err)
 	}
@@ -205,6 +209,207 @@ func TestWriteStateMarkerWritesCanonicalPrivateJSON(t *testing.T) {
 	}
 }
 
+func TestLoadStateMarkersDiscoversIndependentSessions(t *testing.T) {
+	dir := t.TempDir()
+	first := StateMarker{
+		SessionID:    "session-a",
+		FinalSeq:     1,
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "a-bundle.json",
+	}
+	second := StateMarker{
+		SessionID:    "session-b",
+		FinalSeq:     2,
+		RootHash:     strings.Repeat("c", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("d", 64),
+		BundlePath:   "b-bundle.json",
+	}
+
+	if err := WriteStateMarker(dir, first); err != nil {
+		t.Fatalf("WriteStateMarker first: %v", err)
+	}
+	if err := WriteStateMarker(dir, second); err != nil {
+		t.Fatalf("WriteStateMarker second: %v", err)
+	}
+
+	markers, err := LoadStateMarkers(dir)
+	if err != nil {
+		t.Fatalf("LoadStateMarkers: %v", err)
+	}
+	got := map[string]StateMarker{}
+	for _, marker := range markers {
+		got[marker.SessionID] = marker
+	}
+	if len(got) != 2 || got[first.SessionID].RootHash != first.RootHash || got[second.SessionID].RootHash != second.RootHash {
+		t.Fatalf("markers = %+v, want both independent sessions", markers)
+	}
+}
+
+func TestLoadStateMarkersReadsLegacySingleFile(t *testing.T) {
+	dir := t.TempDir()
+	legacy := StateMarker{
+		Schema:       "pipelock.anchorstate.v1",
+		SessionID:    "legacy-session",
+		FinalSeq:     1,
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "legacy-bundle.json",
+	}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("Marshal legacy marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "anchor-state.json"), append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile legacy marker: %v", err)
+	}
+
+	markers, err := LoadStateMarkers(dir)
+	if err != nil {
+		t.Fatalf("LoadStateMarkers: %v", err)
+	}
+	if len(markers) != 1 || markers[0].SessionID != legacy.SessionID {
+		t.Fatalf("markers = %+v, want legacy marker", markers)
+	}
+}
+
+func TestLoadStateMarkersFailsClosedOnCorruptIndex(t *testing.T) {
+	dir := t.TempDir()
+	marker := StateMarker{
+		SessionID:    "session-a",
+		FinalSeq:     1,
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "a-bundle.json",
+	}
+	if err := WriteStateMarker(dir, marker); err != nil {
+		t.Fatalf("WriteStateMarker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "anchor-state.d", "bad.json"), []byte(`{"schema":`), 0o600); err != nil {
+		t.Fatalf("WriteFile corrupt marker: %v", err)
+	}
+	if _, err := LoadStateMarkers(dir); err == nil || !strings.Contains(err.Error(), "parse anchor-state marker") {
+		t.Fatalf("LoadStateMarkers err = %v, want corrupt index failure", err)
+	}
+}
+
+func TestLoadStateMarkersFailsClosedOnHostileFilesystemState(t *testing.T) {
+	valid := StateMarker{
+		Schema:       stateMarkerSchema,
+		SessionID:    "session-a",
+		FinalSeq:     1,
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "bundle.json",
+	}
+	validData, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatalf("Marshal valid marker: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		arrange func(t *testing.T, dir string)
+		want    string
+	}{
+		{
+			name: "legacy marker symlink",
+			arrange: func(t *testing.T, dir string) {
+				t.Helper()
+				if runtime.GOOS == "windows" {
+					t.Skip("symlink creation needs privileges on Windows")
+				}
+				target := filepath.Join(dir, "marker-target.json")
+				if err := os.WriteFile(target, append(validData, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile target: %v", err)
+				}
+				if err := os.Symlink(filepath.Base(target), filepath.Join(dir, "anchor-state.json")); err != nil {
+					t.Fatalf("Symlink marker: %v", err)
+				}
+			},
+			want: "not a regular file",
+		},
+		{
+			name: "index directory symlink",
+			arrange: func(t *testing.T, dir string) {
+				t.Helper()
+				if runtime.GOOS == "windows" {
+					t.Skip("symlink creation needs privileges on Windows")
+				}
+				outside := filepath.Join(t.TempDir(), "outside-index")
+				if err := os.Mkdir(outside, 0o750); err != nil {
+					t.Fatalf("Mkdir outside index: %v", err)
+				}
+				if err := os.Symlink(outside, filepath.Join(dir, "anchor-state.d")); err != nil {
+					t.Fatalf("Symlink index: %v", err)
+				}
+			},
+			want: "not a regular directory",
+		},
+		{
+			name: "oversized legacy marker",
+			arrange: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, "anchor-state.json"), make([]byte, maxStateMarkerBytes+1), 0o600); err != nil {
+					t.Fatalf("WriteFile oversized marker: %v", err)
+				}
+			},
+			want: "exceeds size limit",
+		},
+		{
+			name: "empty required field",
+			arrange: func(t *testing.T, dir string) {
+				t.Helper()
+				invalid := valid
+				invalid.SessionID = " "
+				data, err := json.Marshal(invalid)
+				if err != nil {
+					t.Fatalf("Marshal invalid marker: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "anchor-state.json"), append(data, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile invalid marker: %v", err)
+				}
+			},
+			want: "session_id is empty",
+		},
+		{
+			name: "invalid digest field",
+			arrange: func(t *testing.T, dir string) {
+				t.Helper()
+				invalid := valid
+				invalid.BundleSHA256 = strings.Repeat("B", 64)
+				data, err := json.Marshal(invalid)
+				if err != nil {
+					t.Fatalf("Marshal invalid marker: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "anchor-state.json"), append(data, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile invalid marker: %v", err)
+				}
+			},
+			want: "bundle_sha256 is invalid",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.arrange(t, dir)
+			if _, err := LoadStateMarkers(dir); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("LoadStateMarkers err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestWriteStateMarkerRejectsBadFilesystemTarget(t *testing.T) {
 	dir := t.TempDir()
 	blocker := filepath.Join(dir, "not-a-directory")
@@ -224,10 +429,17 @@ func TestWriteStateMarkerRejectsBadFilesystemTarget(t *testing.T) {
 	}
 }
 
-func TestWriteStateMarkerRejectsDirectoryAtFinalPath(t *testing.T) {
+func TestWriteStateMarkerRejectsSymlinkedIndexDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on Windows")
+	}
 	dir := t.TempDir()
-	if err := os.Mkdir(filepath.Join(dir, "anchor-state.json"), 0o750); err != nil {
-		t.Fatalf("Mkdir final path: %v", err)
+	outside := filepath.Join(t.TempDir(), "outside-index")
+	if err := os.Mkdir(outside, 0o750); err != nil {
+		t.Fatalf("Mkdir outside index: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "anchor-state.d")); err != nil {
+		t.Fatalf("Symlink index: %v", err)
 	}
 	err := WriteStateMarker(dir, StateMarker{
 		SessionID:    "proxy",
@@ -235,12 +447,42 @@ func TestWriteStateMarkerRejectsDirectoryAtFinalPath(t *testing.T) {
 		Backend:      LocalBackend,
 		AnchoredAt:   time.Now().UTC(),
 		BundleSHA256: strings.Repeat("b", 64),
-		BundlePath:   filepath.Join(dir, "bundle.json"),
+		BundlePath:   "bundle.json",
 	})
+	if err == nil || !strings.Contains(err.Error(), "not a regular directory") {
+		t.Fatalf("WriteStateMarker err = %v, want symlinked index refusal", err)
+	}
+	entries, readErr := os.ReadDir(outside)
+	if readErr != nil {
+		t.Fatalf("ReadDir outside index: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("symlinked index received marker data: %v", entries)
+	}
+}
+
+func TestWriteStateMarkerRejectsDirectoryAtFinalPath(t *testing.T) {
+	dir := t.TempDir()
+	marker := StateMarker{
+		SessionID:    "proxy",
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   filepath.Join(dir, "bundle.json"),
+	}
+	path, err := StateMarkerPath(dir, marker)
+	if err != nil {
+		t.Fatalf("StateMarkerPath: %v", err)
+	}
+	if err := os.MkdirAll(path, 0o750); err != nil {
+		t.Fatalf("Mkdir final path: %v", err)
+	}
+	err = WriteStateMarker(dir, marker)
 	if err == nil || !strings.Contains(err.Error(), "rename anchor-state marker") {
 		t.Fatalf("WriteStateMarker err = %v, want rename failure", err)
 	}
-	matches, globErr := filepath.Glob(filepath.Join(dir, ".anchor-state-*.tmp"))
+	matches, globErr := filepath.Glob(filepath.Join(dir, "anchor-state.d", ".anchor-state-*.tmp"))
 	if globErr != nil {
 		t.Fatalf("Glob temp markers: %v", globErr)
 	}
@@ -583,5 +825,12 @@ func writeLocalLogEntries(t *testing.T, path string, entries []LocalLogEntry) {
 	}
 	if err := os.WriteFile(path, lines, 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestWriteStateMarkerRejectsMarkerWithoutIdentity(t *testing.T) {
+	t.Parallel()
+	if err := WriteStateMarker(t.TempDir(), StateMarker{RootHash: "abc"}); err == nil {
+		t.Fatal("WriteStateMarker accepted marker with empty session id")
 	}
 }

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -148,6 +148,36 @@ func TestWriteBundleRejectsBadFilesystemTargets(t *testing.T) {
 	}
 }
 
+func TestWriteBundleUnderDirWritesNestedBundle(t *testing.T) {
+	root := t.TempDir()
+	bundle := NewBundle(Checkpoint{SessionID: "proxy", FinalSeq: 1, RootHash: strings.Repeat("a", 64)}, Proof{Backend: LocalBackend})
+	rel := filepath.Join("nested", "deeper", "bundle.json")
+
+	if err := WriteBundleUnderDir(root, rel, bundle); err != nil {
+		t.Fatalf("WriteBundleUnderDir: %v", err)
+	}
+	loaded, err := LoadBundle(filepath.Join(root, rel))
+	if err != nil {
+		t.Fatalf("LoadBundle: %v", err)
+	}
+	if loaded.Checkpoint.SessionID != bundle.Checkpoint.SessionID || loaded.Checkpoint.RootHash != bundle.Checkpoint.RootHash {
+		t.Fatalf("loaded bundle = %+v, want %+v", loaded, bundle)
+	}
+}
+
+func TestWriteBundleUnderDirRejectsEscapes(t *testing.T) {
+	root := t.TempDir()
+	abs := filepath.Join(root, "bundle.json")
+	bundle := NewBundle(Checkpoint{SessionID: "proxy", FinalSeq: 1, RootHash: strings.Repeat("a", 64)}, Proof{Backend: LocalBackend})
+	for _, rel := range []string{abs, ".", "..", filepath.Join("..", "bundle.json")} {
+		t.Run(rel, func(t *testing.T) {
+			if err := WriteBundleUnderDir(root, rel, bundle); err == nil || !strings.Contains(err.Error(), "stay under receipt directory") {
+				t.Fatalf("WriteBundleUnderDir(%q) err = %v, want escape rejection", rel, err)
+			}
+		})
+	}
+}
+
 func TestWriteBundleUnderDirRejectsSymlinkComponents(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation needs privileges on Windows")
@@ -168,6 +198,45 @@ func TestWriteBundleUnderDirRejectsSymlinkComponents(t *testing.T) {
 	if len(entries) != 0 {
 		t.Fatalf("symlinked parent received bundle data: %v", entries)
 	}
+}
+
+func TestWriteBundleUnderDirRejectsSymlinkRootAndFinalPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on Windows")
+	}
+	bundle := NewBundle(Checkpoint{SessionID: "proxy", FinalSeq: 1, RootHash: strings.Repeat("a", 64)}, Proof{Backend: LocalBackend})
+
+	t.Run("root", func(t *testing.T) {
+		outside := t.TempDir()
+		root := filepath.Join(t.TempDir(), "root-link")
+		if err := os.Symlink(outside, root); err != nil {
+			t.Fatalf("Symlink root: %v", err)
+		}
+		if err := WriteBundleUnderDir(root, "bundle.json", bundle); err == nil || !strings.Contains(err.Error(), "open anchor bundle directory") {
+			t.Fatalf("WriteBundleUnderDir symlink root err = %v, want refusal", err)
+		}
+	})
+
+	t.Run("final path", func(t *testing.T) {
+		root := t.TempDir()
+		outside := filepath.Join(t.TempDir(), "outside-bundle.json")
+		if err := os.WriteFile(outside, []byte("do not overwrite"), 0o600); err != nil {
+			t.Fatalf("WriteFile outside: %v", err)
+		}
+		if err := os.Symlink(outside, filepath.Join(root, "bundle.json")); err != nil {
+			t.Fatalf("Symlink final path: %v", err)
+		}
+		if err := WriteBundleUnderDir(root, "bundle.json", bundle); err == nil || !strings.Contains(err.Error(), "write anchor bundle") {
+			t.Fatalf("WriteBundleUnderDir symlink final err = %v, want write refusal", err)
+		}
+		data, err := os.ReadFile(filepath.Clean(outside))
+		if err != nil {
+			t.Fatalf("ReadFile outside: %v", err)
+		}
+		if string(data) != "do not overwrite" {
+			t.Fatalf("symlink target was overwritten: %q", data)
+		}
+	})
 }
 
 func TestWriteStateMarkerWritesCanonicalPrivateJSON(t *testing.T) {
@@ -228,6 +297,25 @@ func TestWriteStateMarkerWritesCanonicalPrivateJSON(t *testing.T) {
 		got.BundleSHA256 != marker.BundleSHA256 ||
 		got.BundlePath != marker.BundlePath {
 		t.Fatalf("anchor-state marker = %+v, want fields from %+v with canonical schema", got, marker)
+	}
+}
+
+func TestIsStateMarkerTempName(t *testing.T) {
+	tests := map[string]bool{
+		".anchor-state-1.tmp":                                true,
+		".anchor-state-1234567890.tmp":                       true,
+		".anchor-state-0123456789abcdef0123456789abcdef.tmp": true,
+		".anchor-state-.tmp":                                 false,
+		".anchor-state-12345678901.tmp":                      false,
+		".anchor-state-0123456789abcdef0123456789abcdeg.tmp": false,
+		".anchor-state-leftover.tmp":                         false,
+		"anchor-state-123.tmp":                               false,
+		".anchor-state-123.json":                             false,
+	}
+	for name, want := range tests {
+		if got := IsStateMarkerTempName(name); got != want {
+			t.Fatalf("IsStateMarkerTempName(%q) = %v, want %v", name, got, want)
+		}
 	}
 }
 
@@ -301,6 +389,76 @@ func TestLoadStateMarkersDiscoversIndependentSessions(t *testing.T) {
 	}
 	if len(got) != 2 || got[first.SessionID].RootHash != first.RootHash || got[second.SessionID].RootHash != second.RootHash {
 		t.Fatalf("markers = %+v, want both independent sessions", markers)
+	}
+}
+
+func TestLoadStateMarkersFailsClosedOnStrictIndexViolations(t *testing.T) {
+	valid := StateMarker{
+		Schema:       stateMarkerSchema,
+		SessionID:    "session-a",
+		FinalSeq:     1,
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "bundle.json",
+	}
+	validData, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatalf("Marshal valid marker: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		arrange func(t *testing.T, dir string)
+		want    string
+	}{
+		{
+			name: "directory entry",
+			arrange: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(dir, stateMarkerIndexDir, "bad.json"), 0o750); err != nil {
+					t.Fatalf("Mkdir bad marker dir: %v", err)
+				}
+			},
+			want: "not a regular marker",
+		},
+		{
+			name: "filename identity mismatch",
+			arrange: func(t *testing.T, dir string) {
+				t.Helper()
+				indexDir := filepath.Join(dir, stateMarkerIndexDir)
+				if err := os.MkdirAll(indexDir, 0o750); err != nil {
+					t.Fatalf("Mkdir index: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(indexDir, "wrong-name.json"), append(validData, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile wrong marker: %v", err)
+				}
+			},
+			want: "does not match marker identity",
+		},
+		{
+			name: "duplicate legacy and indexed marker",
+			arrange: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, legacyStateMarker), append(validData, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile legacy marker: %v", err)
+				}
+				if err := WriteStateMarker(dir, valid); err != nil {
+					t.Fatalf("WriteStateMarker duplicate: %v", err)
+				}
+			},
+			want: "duplicates",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.arrange(t, dir)
+			if _, err := LoadStateMarkers(dir); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("LoadStateMarkers err = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/anchor/raceflag_norace_test.go
+++ b/internal/anchor/raceflag_norace_test.go
@@ -1,0 +1,8 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !race
+
+package anchor
+
+const raceEnabled = false

--- a/internal/anchor/raceflag_test.go
+++ b/internal/anchor/raceflag_test.go
@@ -1,0 +1,8 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build race
+
+package anchor
+
+const raceEnabled = true

--- a/internal/anchor/write_files_unix.go
+++ b/internal/anchor/write_files_unix.go
@@ -94,7 +94,9 @@ func writeStateMarkerFile(cleanDir string, marker StateMarker, data []byte) erro
 	if err := unix.Renameat(indexFD, tempName, indexFD, name); err != nil {
 		return fmt.Errorf("rename anchor-state marker: %w", err)
 	}
-	_ = unix.Fsync(indexFD)
+	if err := unix.Fsync(indexFD); err != nil {
+		return fmt.Errorf("sync anchor-state directory: %w", err)
+	}
 	return nil
 }
 
@@ -131,11 +133,30 @@ func writeFileUnderDir(rootFD int, rel string, data []byte) error {
 	if name == "" || name == "." || name == ".." {
 		return fmt.Errorf("anchor bundle path must name a file")
 	}
-	fd, err := unix.Openat(dirFD, name, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC|unix.O_CLOEXEC|unix.O_NOFOLLOW, filePermissions)
-	if err != nil {
-		return fmt.Errorf("write anchor bundle: %w", err)
+	if err := validateBundleFinalAt(dirFD, name); err != nil {
+		return err
 	}
-	file := os.NewFile(uintptr(fd), name)
+	var tempName string
+	var err error
+	tempFD := -1
+	for attempts := 0; attempts < 16; attempts++ {
+		tempName, err = stateMarkerTempName()
+		if err != nil {
+			return err
+		}
+		tempFD, err = unix.Openat(dirFD, tempName, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, filePermissions)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, unix.EEXIST) {
+			return fmt.Errorf("create anchor bundle temp file: %w", err)
+		}
+	}
+	if tempFD < 0 {
+		return fmt.Errorf("create anchor bundle temp file: %w", err)
+	}
+	file := os.NewFile(uintptr(tempFD), tempName)
+	defer func() { _ = unix.Unlinkat(dirFD, tempName, 0) }()
 	if _, err := file.Write(data); err != nil {
 		_ = file.Close()
 		return fmt.Errorf("write anchor bundle: %w", err)
@@ -146,6 +167,26 @@ func writeFileUnderDir(rootFD int, rel string, data []byte) error {
 	}
 	if err := file.Close(); err != nil {
 		return fmt.Errorf("close anchor bundle: %w", err)
+	}
+	if err := unix.Renameat(dirFD, tempName, dirFD, name); err != nil {
+		return fmt.Errorf("rename anchor bundle: %w", err)
+	}
+	if err := unix.Fsync(dirFD); err != nil {
+		return fmt.Errorf("sync anchor bundle directory: %w", err)
+	}
+	return nil
+}
+
+func validateBundleFinalAt(dirFD int, name string) error {
+	var stat unix.Stat_t
+	if err := unix.Fstatat(dirFD, name, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil
+		}
+		return fmt.Errorf("inspect anchor bundle: %w", err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		return fmt.Errorf("write anchor bundle: not a regular file")
 	}
 	return nil
 }

--- a/internal/anchor/write_files_unix.go
+++ b/internal/anchor/write_files_unix.go
@@ -1,0 +1,151 @@
+//go:build !windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package anchor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+func writeBundleFile(path string, data []byte) error {
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, dirPermissions); err != nil {
+		return fmt.Errorf("create anchor bundle directory: %w", err)
+	}
+	return writeBundleFileUnderDir(parent, filepath.Base(path), data)
+}
+
+func writeBundleFileUnderDir(root, rel string, data []byte) error {
+	rootFD, err := openAnchorDir(root)
+	if err != nil {
+		return fmt.Errorf("open anchor bundle directory: %w", err)
+	}
+	defer func() { _ = unix.Close(rootFD) }()
+	return writeFileUnderDir(rootFD, rel, data)
+}
+
+func writeStateMarkerFile(cleanDir string, marker StateMarker, data []byte) error {
+	if err := os.MkdirAll(cleanDir, dirPermissions); err != nil {
+		return fmt.Errorf("create anchor-state directory: %w", err)
+	}
+	rootFD, err := openAnchorDir(cleanDir)
+	if err != nil {
+		return fmt.Errorf("create anchor-state directory: %w", err)
+	}
+	defer func() { _ = unix.Close(rootFD) }()
+	if err := unix.Mkdirat(rootFD, stateMarkerIndexDir, dirPermissions); err != nil && !errors.Is(err, unix.EEXIST) {
+		return fmt.Errorf("create anchor-state directory: %w", err)
+	}
+	indexFD, err := unix.Openat(rootFD, stateMarkerIndexDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		if validateErr := validateStateMarkerIndexDir(filepath.Join(cleanDir, stateMarkerIndexDir)); validateErr != nil {
+			return validateErr
+		}
+		return fmt.Errorf("inspect anchor-state directory: %w", err)
+	}
+	defer func() { _ = unix.Close(indexFD) }()
+	name, err := stateMarkerFileName(marker)
+	if err != nil {
+		return err
+	}
+	var tempName string
+	tempFD := -1
+	for attempts := 0; attempts < 16; attempts++ {
+		tempName, err = stateMarkerTempName()
+		if err != nil {
+			return err
+		}
+		tempFD, err = unix.Openat(indexFD, tempName, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, filePermissions)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, unix.EEXIST) {
+			return fmt.Errorf("create anchor-state temp file: %w", err)
+		}
+	}
+	if tempFD < 0 {
+		return fmt.Errorf("create anchor-state temp file: %w", err)
+	}
+	tempFile := os.NewFile(uintptr(tempFD), tempName)
+	defer func() { _ = unix.Unlinkat(indexFD, tempName, 0) }()
+	if _, err := tempFile.Write(data); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("write anchor-state temp file: %w", err)
+	}
+	if err := tempFile.Chmod(filePermissions); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("chmod anchor-state temp file: %w", err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("sync anchor-state temp file: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("close anchor-state temp file: %w", err)
+	}
+	if err := unix.Renameat(indexFD, tempName, indexFD, name); err != nil {
+		return fmt.Errorf("rename anchor-state marker: %w", err)
+	}
+	_ = unix.Fsync(indexFD)
+	return nil
+}
+
+func openAnchorDir(path string) (int, error) {
+	return unix.Open(filepath.Clean(path), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+}
+
+func writeFileUnderDir(rootFD int, rel string, data []byte) error {
+	cleanRel := filepath.Clean(rel)
+	parts := strings.Split(cleanRel, string(filepath.Separator))
+	dirFD := rootFD
+	closeDir := false
+	for _, part := range parts[:len(parts)-1] {
+		if part == "" || part == "." || part == ".." {
+			return fmt.Errorf("anchor bundle path must stay under receipt directory")
+		}
+		if err := unix.Mkdirat(dirFD, part, dirPermissions); err != nil && !errors.Is(err, unix.EEXIST) {
+			return fmt.Errorf("create anchor bundle directory: %w", err)
+		}
+		nextFD, err := unix.Openat(dirFD, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			return fmt.Errorf("open anchor bundle directory: %w", err)
+		}
+		if closeDir {
+			_ = unix.Close(dirFD)
+		}
+		dirFD = nextFD
+		closeDir = true
+	}
+	if closeDir {
+		defer func() { _ = unix.Close(dirFD) }()
+	}
+	name := parts[len(parts)-1]
+	if name == "" || name == "." || name == ".." {
+		return fmt.Errorf("anchor bundle path must name a file")
+	}
+	fd, err := unix.Openat(dirFD, name, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC|unix.O_CLOEXEC|unix.O_NOFOLLOW, filePermissions)
+	if err != nil {
+		return fmt.Errorf("write anchor bundle: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write anchor bundle: %w", err)
+	}
+	if err := file.Chmod(filePermissions); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("chmod anchor bundle: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close anchor bundle: %w", err)
+	}
+	return nil
+}

--- a/internal/anchor/write_files_windows.go
+++ b/internal/anchor/write_files_windows.go
@@ -6,15 +6,21 @@
 package anchor
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func writeBundleFile(path string, data []byte) error {
 	clean := filepath.Clean(path)
-	if err := os.MkdirAll(filepath.Dir(clean), dirPermissions); err != nil {
+	parent := filepath.Dir(clean)
+	if err := ensureWindowsDirNoReparse(parent, "anchor bundle directory"); err != nil {
 		return fmt.Errorf("create anchor bundle directory: %w", err)
+	}
+	if err := validateWindowsFinalFile(clean, "anchor bundle"); err != nil {
+		return err
 	}
 	if err := os.WriteFile(clean, data, filePermissions); err != nil {
 		return fmt.Errorf("write anchor bundle: %w", err)
@@ -23,7 +29,24 @@ func writeBundleFile(path string, data []byte) error {
 }
 
 func writeBundleFileUnderDir(root, rel string, data []byte) error {
-	return writeBundleFile(filepath.Join(filepath.Clean(root), filepath.Clean(rel)), data)
+	cleanRoot := filepath.Clean(root)
+	cleanRel := filepath.Clean(rel)
+	if filepath.IsAbs(cleanRel) || cleanRel == "." || cleanRel == ".." || strings.HasPrefix(cleanRel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("anchor bundle path must stay under receipt directory")
+	}
+	parentRel := filepath.Dir(cleanRel)
+	if parentRel == "." {
+		parentRel = ""
+	}
+	parent := filepath.Join(cleanRoot, parentRel)
+	if err := ensureWindowsDirNoReparse(parent, "anchor bundle directory"); err != nil {
+		return fmt.Errorf("create anchor bundle directory: %w", err)
+	}
+	path := filepath.Join(cleanRoot, cleanRel)
+	if err := validateWindowsFinalFile(path, "anchor bundle"); err != nil {
+		return err
+	}
+	return writeBundleFile(path, data)
 }
 
 func writeStateMarkerFile(cleanDir string, marker StateMarker, data []byte) error {
@@ -32,7 +55,7 @@ func writeStateMarkerFile(cleanDir string, marker StateMarker, data []byte) erro
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(indexDir, dirPermissions); err != nil {
+	if err := ensureWindowsDirNoReparse(indexDir, "anchor-state directory"); err != nil {
 		return fmt.Errorf("create anchor-state directory: %w", err)
 	}
 	if err := validateStateMarkerIndexDir(indexDir); err != nil {
@@ -66,4 +89,47 @@ func writeStateMarkerFile(cleanDir string, marker StateMarker, data []byte) erro
 		return fmt.Errorf("rename anchor-state marker: %w", err)
 	}
 	return nil
+}
+
+func ensureWindowsDirNoReparse(path, label string) error {
+	clean := filepath.Clean(path)
+	parent := filepath.Dir(clean)
+	if parent != clean {
+		if err := ensureWindowsDirNoReparse(parent, label); err != nil {
+			return err
+		}
+	}
+	info, err := os.Lstat(clean)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.Mkdir(clean, dirPermissions); err != nil && !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		info, err = os.Lstat(clean)
+	}
+	if err != nil {
+		return err
+	}
+	if isWindowsReparseOrSymlink(info) || !info.IsDir() {
+		return fmt.Errorf("%s is not a regular directory", label)
+	}
+	return nil
+}
+
+func validateWindowsFinalFile(path, label string) error {
+	info, err := os.Lstat(filepath.Clean(path))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect %s: %w", label, err)
+	}
+	if isWindowsReparseOrSymlink(info) || !info.Mode().IsRegular() {
+		return fmt.Errorf("write %s: not a regular file", label)
+	}
+	return nil
+}
+
+func isWindowsReparseOrSymlink(info os.FileInfo) bool {
+	mode := info.Mode()
+	return mode&os.ModeSymlink != 0 || mode&os.ModeIrregular != 0
 }

--- a/internal/anchor/write_files_windows.go
+++ b/internal/anchor/write_files_windows.go
@@ -1,0 +1,69 @@
+//go:build windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package anchor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func writeBundleFile(path string, data []byte) error {
+	clean := filepath.Clean(path)
+	if err := os.MkdirAll(filepath.Dir(clean), dirPermissions); err != nil {
+		return fmt.Errorf("create anchor bundle directory: %w", err)
+	}
+	if err := os.WriteFile(clean, data, filePermissions); err != nil {
+		return fmt.Errorf("write anchor bundle: %w", err)
+	}
+	return nil
+}
+
+func writeBundleFileUnderDir(root, rel string, data []byte) error {
+	return writeBundleFile(filepath.Join(filepath.Clean(root), filepath.Clean(rel)), data)
+}
+
+func writeStateMarkerFile(cleanDir string, marker StateMarker, data []byte) error {
+	indexDir := filepath.Join(cleanDir, stateMarkerIndexDir)
+	path, err := StateMarkerPath(cleanDir, marker)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(indexDir, dirPermissions); err != nil {
+		return fmt.Errorf("create anchor-state directory: %w", err)
+	}
+	if err := validateStateMarkerIndexDir(indexDir); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(indexDir, ".anchor-state-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create anchor-state temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write anchor-state temp file: %w", err)
+	}
+	if err := tmp.Chmod(filePermissions); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod anchor-state temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync anchor-state temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close anchor-state temp file: %w", err)
+	}
+	if err := validateStateMarkerIndexDir(indexDir); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename anchor-state marker: %w", err)
+	}
+	return nil
+}

--- a/internal/anchor/write_state_marker_unix_test.go
+++ b/internal/anchor/write_state_marker_unix_test.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestWriteStateMarkerRejectsTempFileWriteFailure(t *testing.T) {
@@ -80,5 +82,131 @@ func TestWriteStateMarkerRejectsUnwritableDirectory(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "create anchor-state directory") {
 		t.Fatalf("WriteStateMarker err = %v, want create directory failure", err)
+	}
+}
+
+func TestWriteStateMarkerRejectsSymlinkRoot(t *testing.T) {
+	outside := t.TempDir()
+	root := filepath.Join(t.TempDir(), "root-link")
+	if err := os.Symlink(outside, root); err != nil {
+		t.Fatalf("Symlink root: %v", err)
+	}
+	err := WriteStateMarker(root, StateMarker{
+		SessionID:    "proxy",
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "bundle.json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "create anchor-state directory") {
+		t.Fatalf("WriteStateMarker err = %v, want symlink root refusal", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "anchor-state.d")); !os.IsNotExist(statErr) {
+		t.Fatalf("symlink target anchor-state.d stat err = %v, want not exist", statErr)
+	}
+}
+
+func TestWriteStateMarkerRejectsFileAtIndexDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "anchor-state.d"), []byte("blocker"), 0o600); err != nil {
+		t.Fatalf("WriteFile index blocker: %v", err)
+	}
+	err := WriteStateMarker(dir, StateMarker{
+		SessionID:    "proxy",
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "bundle.json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a regular directory") {
+		t.Fatalf("WriteStateMarker err = %v, want index directory refusal", err)
+	}
+}
+
+func TestWriteStateMarkerRejectsUnreadableIndexDirectory(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root user")
+	}
+	dir := t.TempDir()
+	indexDir := filepath.Join(dir, "anchor-state.d")
+	if err := os.Mkdir(indexDir, 0o750); err != nil {
+		t.Fatalf("Mkdir index: %v", err)
+	}
+	if err := os.Chmod(indexDir, 0); err != nil {
+		t.Fatalf("Chmod index: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Chmod(indexDir, 0o750)
+	})
+	err := WriteStateMarker(dir, StateMarker{
+		SessionID:    "proxy",
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "bundle.json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "inspect anchor-state directory") {
+		t.Fatalf("WriteStateMarker err = %v, want unreadable index refusal", err)
+	}
+}
+
+func TestWriteStateMarkerFileRejectsMissingIdentity(t *testing.T) {
+	err := writeStateMarkerFile(t.TempDir(), StateMarker{
+		RootHash:     strings.Repeat("a", 64),
+		Backend:      LocalBackend,
+		AnchoredAt:   time.Now().UTC(),
+		BundleSHA256: strings.Repeat("b", 64),
+		BundlePath:   "bundle.json",
+	}, []byte("{}\n"))
+	if err == nil || !strings.Contains(err.Error(), "session_id is empty") {
+		t.Fatalf("writeStateMarkerFile err = %v, want identity failure", err)
+	}
+}
+
+func TestWriteFileUnderDirRejectsInvalidAndBlockedPaths(t *testing.T) {
+	root := t.TempDir()
+	rootFD, err := openAnchorDir(root)
+	if err != nil {
+		t.Fatalf("openAnchorDir: %v", err)
+	}
+	t.Cleanup(func() { _ = unix.Close(rootFD) })
+
+	for _, rel := range []string{"", ".", filepath.Join("..", "bundle.json")} {
+		t.Run(rel, func(t *testing.T) {
+			if err := writeFileUnderDir(rootFD, rel, []byte("bundle")); err == nil {
+				t.Fatalf("writeFileUnderDir(%q) err = nil, want rejection", rel)
+			}
+		})
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "blocked"), []byte("blocker"), 0o600); err != nil {
+		t.Fatalf("WriteFile blocker: %v", err)
+	}
+	if err := writeFileUnderDir(rootFD, filepath.Join("blocked", "bundle.json"), []byte("bundle")); err == nil || !strings.Contains(err.Error(), "open anchor bundle directory") {
+		t.Fatalf("writeFileUnderDir blocked parent err = %v, want open directory failure", err)
+	}
+}
+
+func TestWriteFileUnderDirRejectsUnwritableDirectory(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root user")
+	}
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o500); err != nil { // #nosec G302 -- test needs searchable but unwritable directory permissions.
+		t.Fatalf("Chmod root: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Chmod(root, 0o700)
+	})
+	rootFD, err := openAnchorDir(root)
+	if err != nil {
+		t.Fatalf("openAnchorDir: %v", err)
+	}
+	t.Cleanup(func() { _ = unix.Close(rootFD) })
+	if err := writeFileUnderDir(rootFD, filepath.Join("nested", "bundle.json"), []byte("bundle")); err == nil || !strings.Contains(err.Error(), "create anchor bundle directory") {
+		t.Fatalf("writeFileUnderDir unwritable root err = %v, want mkdir failure", err)
 	}
 }

--- a/internal/anchor/write_state_marker_unix_test.go
+++ b/internal/anchor/write_state_marker_unix_test.go
@@ -16,13 +16,19 @@ import (
 )
 
 func TestWriteStateMarkerRejectsTempFileWriteFailure(t *testing.T) {
+	if raceEnabled {
+		t.Skip("RLIMIT_FSIZE is process-wide and can interfere with the race test harness")
+	}
 	var old syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &old); err != nil {
 		t.Fatalf("Getrlimit: %v", err)
 	}
 	signal.Ignore(syscall.SIGXFSZ)
-	t.Cleanup(func() {
+	restoreLimit := func() {
 		_ = syscall.Setrlimit(syscall.RLIMIT_FSIZE, &old)
+	}
+	t.Cleanup(func() {
+		restoreLimit()
 		signal.Reset(syscall.SIGXFSZ)
 	})
 	limited := old
@@ -40,10 +46,11 @@ func TestWriteStateMarkerRejectsTempFileWriteFailure(t *testing.T) {
 		BundleSHA256: strings.Repeat("b", 64),
 		BundlePath:   filepath.Join(dir, "bundle.json"),
 	})
+	restoreLimit()
 	if err == nil || !strings.Contains(err.Error(), "write anchor-state temp file") {
 		t.Fatalf("WriteStateMarker err = %v, want temp write failure", err)
 	}
-	matches, globErr := filepath.Glob(filepath.Join(dir, ".anchor-state-*.tmp"))
+	matches, globErr := filepath.Glob(filepath.Join(dir, "anchor-state.d", ".anchor-state-*.tmp"))
 	if globErr != nil {
 		t.Fatalf("Glob temp markers: %v", globErr)
 	}
@@ -71,7 +78,7 @@ func TestWriteStateMarkerRejectsUnwritableDirectory(t *testing.T) {
 		BundleSHA256: strings.Repeat("b", 64),
 		BundlePath:   filepath.Join(dir, "bundle.json"),
 	})
-	if err == nil || !strings.Contains(err.Error(), "create anchor-state temp file") {
-		t.Fatalf("WriteStateMarker err = %v, want create temp file failure", err)
+	if err == nil || !strings.Contains(err.Error(), "create anchor-state directory") {
+		t.Fatalf("WriteStateMarker err = %v, want create directory failure", err)
 	}
 }

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -208,11 +208,11 @@ func validateBundleOutputPath(receiptDir, bundlePath string) error {
 	for {
 		info, err := os.Lstat(parent)
 		if err == nil {
-			if !info.IsDir() {
-				return fmt.Errorf("--out parent is not a directory")
-			}
 			if info.Mode()&os.ModeSymlink != 0 {
 				return fmt.Errorf("--out parent must not be a symlink")
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("--out parent is not a directory")
 			}
 			resolved, err := filepath.EvalSymlinks(parent)
 			if err != nil {

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -112,10 +112,11 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 		return err
 	}
 	bundle := anchorpkg.NewBundle(checkpoint, proof)
-	if err := anchorpkg.WriteBundleUnderDir(output.receiptDir, output.markerPath, bundle); err != nil {
+	bundleBytes, err := anchorpkg.WriteBundleUnderDir(output.receiptDir, output.markerPath, bundle)
+	if err != nil {
 		return err
 	}
-	if err := writeAnchorStateMarker(output, checkpoint, proof); err != nil {
+	if err := writeAnchorStateMarker(output, checkpoint, proof, bundleBytes); err != nil {
 		return err
 	}
 
@@ -234,11 +235,7 @@ func validateBundleOutputPath(receiptDir, bundlePath string) error {
 	}
 }
 
-func writeAnchorStateMarker(output bundleOutput, checkpoint anchorpkg.Checkpoint, proof anchorpkg.Proof) error {
-	bundleBytes, err := os.ReadFile(filepath.Clean(output.bundlePath))
-	if err != nil {
-		return fmt.Errorf("read anchor bundle for state marker: %w", err)
-	}
+func writeAnchorStateMarker(output bundleOutput, checkpoint anchorpkg.Checkpoint, proof anchorpkg.Proof, bundleBytes []byte) error {
 	sum := sha256.Sum256(bundleBytes)
 	return anchorpkg.WriteStateMarker(output.receiptDir, anchorpkg.StateMarker{
 		SessionID:    checkpoint.SessionID,

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -193,8 +193,13 @@ func receiptDirectory(target string, asDir bool) (string, error) {
 }
 
 func validateBundleOutputPath(receiptDir, bundlePath string) error {
-	if info, err := os.Lstat(bundlePath); err == nil && info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("--out must not be a symlink")
+	if info, err := os.Lstat(bundlePath); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("--out must not be a symlink")
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("--out must be a regular file")
+		}
 	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("inspect --out: %w", err)
 	}

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -95,6 +95,10 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 	if err != nil {
 		return err
 	}
+	output, err := resolveBundleOutput(target, opts)
+	if err != nil {
+		return err
+	}
 	checkpoint, err := anchorpkg.BuildCheckpoint(sessionID, receipts, trustedKeys)
 	if err != nil {
 		return err
@@ -108,14 +112,14 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 		return err
 	}
 	bundle := anchorpkg.NewBundle(checkpoint, proof)
-	if err := anchorpkg.WriteBundle(opts.output, bundle); err != nil {
+	if err := anchorpkg.WriteBundle(output.bundlePath, bundle); err != nil {
 		return err
 	}
-	if err := writeAnchorStateMarker(target, opts, checkpoint, proof); err != nil {
+	if err := writeAnchorStateMarker(output, checkpoint, proof); err != nil {
 		return err
 	}
 
-	_, _ = fmt.Fprintf(out, "ANCHOR BUNDLE WRITTEN: %s\n", filepath.Clean(opts.output))
+	_, _ = fmt.Fprintf(out, "ANCHOR BUNDLE WRITTEN: %s\n", output.bundlePath)
 	_, _ = fmt.Fprintf(out, "  Backend:       %s\n", proof.Backend)
 	if proof.Rekor != nil {
 		_, _ = fmt.Fprintf(out, "  Rekor URL:     %s\n", proof.Rekor.URL)
@@ -131,17 +135,107 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 	return nil
 }
 
-func writeAnchorStateMarker(target string, opts receiptsOptions, checkpoint anchorpkg.Checkpoint, proof anchorpkg.Proof) error {
-	bundleBytes, err := os.ReadFile(filepath.Clean(opts.output))
+type bundleOutput struct {
+	receiptDir string
+	bundlePath string
+	markerPath string
+}
+
+func resolveBundleOutput(target string, opts receiptsOptions) (bundleOutput, error) {
+	receiptDir, err := receiptDirectory(target, opts.asDir)
+	if err != nil {
+		return bundleOutput{}, err
+	}
+	requested := filepath.Clean(opts.output)
+	var bundlePath string
+	if filepath.IsAbs(requested) {
+		bundlePath = requested
+	} else {
+		bundlePath = filepath.Join(receiptDir, requested)
+	}
+	bundlePath, err = filepath.Abs(bundlePath)
+	if err != nil {
+		return bundleOutput{}, fmt.Errorf("resolve --out: %w", err)
+	}
+	rel, err := filepath.Rel(receiptDir, bundlePath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return bundleOutput{}, fmt.Errorf("--out must resolve under the receipt directory")
+	}
+	if rel == "." {
+		return bundleOutput{}, fmt.Errorf("--out must name an anchor bundle file under the receipt directory")
+	}
+	if err := validateBundleOutputPath(receiptDir, bundlePath); err != nil {
+		return bundleOutput{}, err
+	}
+	return bundleOutput{receiptDir: receiptDir, bundlePath: bundlePath, markerPath: filepath.ToSlash(rel)}, nil
+}
+
+func receiptDirectory(target string, asDir bool) (string, error) {
+	cleanTarget, err := filepath.Abs(filepath.Clean(target))
+	if err != nil {
+		return "", fmt.Errorf("resolve receipt directory: %w", err)
+	}
+	if !asDir {
+		cleanTarget = filepath.Dir(cleanTarget)
+	}
+	resolved, err := filepath.EvalSymlinks(cleanTarget)
+	if err != nil {
+		return "", fmt.Errorf("resolve receipt directory: %w", err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("inspect receipt directory: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("receipt directory is not a directory")
+	}
+	return resolved, nil
+}
+
+func validateBundleOutputPath(receiptDir, bundlePath string) error {
+	if info, err := os.Lstat(bundlePath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("--out must not be a symlink")
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("inspect --out: %w", err)
+	}
+	parent := filepath.Dir(bundlePath)
+	for {
+		info, err := os.Lstat(parent)
+		if err == nil {
+			if !info.IsDir() {
+				return fmt.Errorf("--out parent is not a directory")
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("--out parent must not be a symlink")
+			}
+			resolved, err := filepath.EvalSymlinks(parent)
+			if err != nil {
+				return fmt.Errorf("resolve --out parent: %w", err)
+			}
+			rel, err := filepath.Rel(receiptDir, resolved)
+			if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				return fmt.Errorf("--out parent resolves outside the receipt directory")
+			}
+			return nil
+		}
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect --out parent: %w", err)
+		}
+		next := filepath.Dir(parent)
+		if next == parent {
+			return fmt.Errorf("resolve --out parent: no existing parent directory")
+		}
+		parent = next
+	}
+}
+
+func writeAnchorStateMarker(output bundleOutput, checkpoint anchorpkg.Checkpoint, proof anchorpkg.Proof) error {
+	bundleBytes, err := os.ReadFile(filepath.Clean(output.bundlePath))
 	if err != nil {
 		return fmt.Errorf("read anchor bundle for state marker: %w", err)
 	}
 	sum := sha256.Sum256(bundleBytes)
-	dir := filepath.Dir(filepath.Clean(target))
-	if opts.asDir {
-		dir = filepath.Clean(target)
-	}
-	return anchorpkg.WriteStateMarker(dir, anchorpkg.StateMarker{
+	return anchorpkg.WriteStateMarker(output.receiptDir, anchorpkg.StateMarker{
 		SessionID:    checkpoint.SessionID,
 		FinalSeq:     checkpoint.FinalSeq,
 		RootHash:     checkpoint.RootHash,
@@ -149,7 +243,7 @@ func writeAnchorStateMarker(target string, opts receiptsOptions, checkpoint anch
 		LogIndex:     proof.LogIndex,
 		AnchoredAt:   time.Now().UTC(),
 		BundleSHA256: hex.EncodeToString(sum[:]),
-		BundlePath:   filepath.Clean(opts.output),
+		BundlePath:   output.markerPath,
 	})
 }
 

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -112,7 +112,7 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 		return err
 	}
 	bundle := anchorpkg.NewBundle(checkpoint, proof)
-	if err := anchorpkg.WriteBundle(output.bundlePath, bundle); err != nil {
+	if err := anchorpkg.WriteBundleUnderDir(output.receiptDir, output.markerPath, bundle); err != nil {
 		return err
 	}
 	if err := writeAnchorStateMarker(output, checkpoint, proof); err != nil {

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -406,6 +406,18 @@ func TestResolveBundleOutputRejectsHostilePaths(t *testing.T) {
 			wantErr: "must name an anchor bundle file",
 		},
 		{
+			name: "existing directory output",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := filepath.Join(receiptDir, "bundle-dir")
+				if err := os.Mkdir(dir, 0o750); err != nil {
+					t.Fatalf("Mkdir output dir: %v", err)
+				}
+				return dir
+			},
+			wantErr: "must be a regular file",
+		},
+		{
 			name: "missing parent chain",
 			setup: func(t *testing.T) string {
 				t.Helper()

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -340,6 +341,95 @@ func TestReceiptsCmdRejectsOutsideBundleOutput(t *testing.T) {
 	})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "under the receipt directory") {
 		t.Fatalf("Execute err = %v, want outside --out refusal", err)
+	}
+}
+
+func TestResolveBundleOutputRejectsHostilePaths(t *testing.T) {
+	receiptsPath, _ := cliReceiptJSONL(t)
+	receiptDir := filepath.Dir(receiptsPath)
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) string
+		wantErr string
+		wantRel string
+	}{
+		{
+			name: "output symlink",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				if runtime.GOOS == "windows" {
+					t.Skip("symlink creation needs privileges on Windows")
+				}
+				target := filepath.Join(receiptDir, "target-bundle.json")
+				if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+					t.Fatalf("WriteFile target: %v", err)
+				}
+				link := filepath.Join(receiptDir, "bundle-link.json")
+				if err := os.Symlink(filepath.Base(target), link); err != nil {
+					t.Fatalf("Symlink bundle: %v", err)
+				}
+				return link
+			},
+			wantErr: "must not be a symlink",
+		},
+		{
+			name: "parent symlink",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				if runtime.GOOS == "windows" {
+					t.Skip("symlink creation needs privileges on Windows")
+				}
+				outside := t.TempDir()
+				link := filepath.Join(receiptDir, "linked-parent")
+				if err := os.Symlink(outside, link); err != nil {
+					t.Fatalf("Symlink parent: %v", err)
+				}
+				return filepath.Join(link, "bundle.json")
+			},
+			wantErr: "parent is not a directory",
+		},
+		{
+			name: "absolute dotdot outside",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return filepath.Join(receiptDir, "..", "outside-bundle.json")
+			},
+			wantErr: "under the receipt directory",
+		},
+		{
+			name: "receipt directory",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return receiptDir
+			},
+			wantErr: "must name an anchor bundle file",
+		},
+		{
+			name: "missing parent chain",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return filepath.Join("nested", "new", "bundle.json")
+			},
+			wantRel: filepath.ToSlash(filepath.Join("nested", "new", "bundle.json")),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := resolveBundleOutput(receiptsPath, receiptsOptions{output: tc.setup(t)})
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("resolveBundleOutput err = %v, want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveBundleOutput: %v", err)
+			}
+			if output.markerPath != tc.wantRel {
+				t.Fatalf("markerPath = %q, want %q", output.markerPath, tc.wantRel)
+			}
+		})
 	}
 }
 

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -73,7 +73,7 @@ func TestReceiptsCmdWritesLocalAnchorBundle(t *testing.T) {
 	receiptsPath, keyHex := cliReceiptJSONL(t)
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "anchor.jsonl")
-	bundlePath := filepath.Join(dir, "bundle.json")
+	bundlePath := filepath.Join(filepath.Dir(receiptsPath), "bundle.json")
 
 	cmd := receiptsCmd()
 	var out bytes.Buffer
@@ -98,6 +98,13 @@ func TestReceiptsCmdWritesLocalAnchorBundle(t *testing.T) {
 	if bundle.Proof.Backend != anchorpkg.LocalBackend || bundle.Proof.LogIndex != 0 {
 		t.Fatalf("unexpected bundle proof: %+v", bundle.Proof)
 	}
+	markers, err := anchorpkg.LoadStateMarkers(filepath.Dir(receiptsPath))
+	if err != nil {
+		t.Fatalf("LoadStateMarkers: %v", err)
+	}
+	if len(markers) != 1 || markers[0].BundlePath != "bundle.json" {
+		t.Fatalf("anchor markers = %+v, want receipt-directory-relative bundle path", markers)
+	}
 	entries, err := anchorpkg.ReadLocalLog(logPath)
 	if err != nil {
 		t.Fatalf("ReadLocalLog: %v", err)
@@ -110,7 +117,7 @@ func TestReceiptsCmdWritesLocalAnchorBundle(t *testing.T) {
 func TestReceiptsCmdWritesRekorAnchorBundle(t *testing.T) {
 	receiptsPath, keyHex := cliReceiptJSONL(t)
 	dir := t.TempDir()
-	bundlePath := filepath.Join(dir, "bundle.json")
+	bundlePath := filepath.Join(filepath.Dir(receiptsPath), "bundle.json")
 	rekorKey := writeRekorKey(t, dir)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/log/entries" {
@@ -205,6 +212,7 @@ func TestCmdRegistersReceiptsSubcommand(t *testing.T) {
 
 func TestReceiptsCmdRequiresLocalLogAndOutput(t *testing.T) {
 	receiptsPath, keyHex := cliReceiptJSONL(t)
+	receiptDir := filepath.Dir(receiptsPath)
 	tests := []struct {
 		name string
 		args []string
@@ -212,7 +220,7 @@ func TestReceiptsCmdRequiresLocalLogAndOutput(t *testing.T) {
 	}{
 		{
 			name: "local log",
-			args: []string{receiptsPath, "--key", keyHex, "--out", filepath.Join(t.TempDir(), "bundle.json")},
+			args: []string{receiptsPath, "--key", keyHex, "--out", filepath.Join(receiptDir, "bundle.json")},
 			want: "--local-log is required",
 		},
 		{
@@ -241,7 +249,7 @@ func TestReceiptsCmdRequiresRekorKey(t *testing.T) {
 		receiptsPath,
 		"--key", keyHex,
 		"--backend", anchorpkg.RekorBackend,
-		"--out", filepath.Join(t.TempDir(), "bundle.json"),
+		"--out", filepath.Join(filepath.Dir(receiptsPath), "bundle.json"),
 	})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--rekor-key is required") {
 		t.Fatalf("Execute err = %v, want Rekor key error", err)
@@ -258,7 +266,7 @@ func TestReceiptsCmdRequiresRekorRemoteAcknowledgement(t *testing.T) {
 		"--key", keyHex,
 		"--backend", anchorpkg.RekorBackend,
 		"--rekor-key", writeRekorKey(t, dir),
-		"--out", filepath.Join(dir, "bundle.json"),
+		"--out", filepath.Join(filepath.Dir(receiptsPath), "bundle.json"),
 	})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--yes-send-to-remote-log is required") {
 		t.Fatalf("Execute err = %v, want Rekor acknowledgement error", err)
@@ -272,7 +280,7 @@ func TestReceiptsCmdRequiresPinnedKey(t *testing.T) {
 	cmd.SetArgs([]string{
 		receiptsPath,
 		"--local-log", filepath.Join(t.TempDir(), "anchor.jsonl"),
-		"--out", filepath.Join(t.TempDir(), "bundle.json"),
+		"--out", filepath.Join(filepath.Dir(receiptsPath), "bundle.json"),
 	})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "at least one --key") {
 		t.Fatalf("Execute err = %v, want pinned-key error", err)
@@ -290,7 +298,7 @@ func TestReceiptsCmdRejectsBlankPinnedKey(t *testing.T) {
 				"--key", key,
 				"--key", keyHex,
 				"--local-log", filepath.Join(t.TempDir(), "anchor.jsonl"),
-				"--out", filepath.Join(t.TempDir(), "bundle.json"),
+				"--out", filepath.Join(filepath.Dir(receiptsPath), "bundle.json"),
 			})
 			if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "public key is empty") {
 				t.Fatalf("Execute err = %v, want blank-key error", err)
@@ -308,7 +316,7 @@ func TestReceiptsCmdReturnsFallbackExtractionError(t *testing.T) {
 		missingPath,
 		"--key", keyHex,
 		"--local-log", filepath.Join(t.TempDir(), "anchor.jsonl"),
-		"--out", filepath.Join(t.TempDir(), "bundle.json"),
+		"--out", "bundle.json",
 	})
 	err := cmd.Execute()
 	if err == nil {
@@ -316,6 +324,22 @@ func TestReceiptsCmdReturnsFallbackExtractionError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "reading raw receipts") {
 		t.Fatalf("Execute err = %v, want fallback raw-receipt error", err)
+	}
+}
+
+func TestReceiptsCmdRejectsOutsideBundleOutput(t *testing.T) {
+	receiptsPath, keyHex := cliReceiptJSONL(t)
+	outside := filepath.Join(t.TempDir(), "bundle.json")
+	cmd := receiptsCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		receiptsPath,
+		"--key", keyHex,
+		"--local-log", filepath.Join(t.TempDir(), "anchor.jsonl"),
+		"--out", outside,
+	})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "under the receipt directory") {
+		t.Fatalf("Execute err = %v, want outside --out refusal", err)
 	}
 }
 

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -387,7 +387,7 @@ func TestResolveBundleOutputRejectsHostilePaths(t *testing.T) {
 				}
 				return filepath.Join(link, "bundle.json")
 			},
-			wantErr: "parent is not a directory",
+			wantErr: "parent must not be a symlink",
 		},
 		{
 			name: "absolute dotdot outside",

--- a/internal/cli/runtime/evidence_health.go
+++ b/internal/cli/runtime/evidence_health.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/anchor"
 	"github.com/luckyPipewrench/pipelock/internal/config"
-	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
@@ -536,50 +535,14 @@ type anchorState struct {
 const maxEvidenceAnchorStateBytes = 64 * 1024
 
 func readAnchorState(path string) (anchorState, error) {
-	clean := filepath.Clean(path)
-	info, err := os.Lstat(clean)
+	marker, found, err := anchor.LoadStateMarkerFile(path)
 	if err != nil {
 		return anchorState{}, err
 	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return anchorState{}, errors.New("anchor-state is not a regular file")
+	if !found {
+		return anchorState{}, fmt.Errorf("read anchor-state: %w", os.ErrNotExist)
 	}
-	if info.Size() > maxEvidenceAnchorStateBytes {
-		return anchorState{}, fmt.Errorf("anchor-state exceeds size limit of %d bytes", maxEvidenceAnchorStateBytes)
-	}
-	file, err := os.Open(clean) // #nosec G304 -- lstat/fstat below fail closed on local replacement races.
-	if err != nil {
-		return anchorState{}, err
-	}
-	defer func() { _ = file.Close() }()
-	openedInfo, err := file.Stat()
-	if err != nil {
-		return anchorState{}, err
-	}
-	if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
-		return anchorState{}, errors.New("anchor-state changed during validation")
-	}
-	data, err := io.ReadAll(io.LimitReader(file, maxEvidenceAnchorStateBytes+1))
-	if err != nil {
-		return anchorState{}, err
-	}
-	if int64(len(data)) > maxEvidenceAnchorStateBytes {
-		return anchorState{}, fmt.Errorf("anchor-state exceeds size limit of %d bytes", maxEvidenceAnchorStateBytes)
-	}
-	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
-		return anchorState{}, err
-	}
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.DisallowUnknownFields()
-	var state anchorState
-	if err := dec.Decode(&state); err != nil {
-		return anchorState{}, err
-	}
-	var extra any
-	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
-		return anchorState{}, errors.New("anchor-state has trailing JSON")
-	}
-	return state, nil
+	return anchorStateFromMarker(marker), nil
 }
 
 func readAnchorStateForSession(dir, sessionID string) (anchorState, bool, error) {
@@ -596,18 +559,19 @@ func readAnchorStateForSession(dir, sessionID string) (anchorState, bool, error)
 	}
 	var selected anchorState
 	found := false
+	seenSeq := map[uint64]string{}
 	for _, marker := range markers {
 		if marker.SessionID != sessionID {
 			continue
 		}
 		state := anchorStateFromMarker(marker)
+		if previousRoot, ok := seenSeq[state.FinalSeq]; ok && previousRoot != state.RootHash {
+			return anchorState{}, false, fmt.Errorf("ambiguous anchor-state markers for session %q at final_seq %d", sessionID, state.FinalSeq)
+		}
+		seenSeq[state.FinalSeq] = state.RootHash
 		if !found || state.FinalSeq > selected.FinalSeq {
 			selected = state
 			found = true
-			continue
-		}
-		if state.FinalSeq == selected.FinalSeq && state.RootHash != selected.RootHash {
-			return anchorState{}, false, fmt.Errorf("ambiguous anchor-state markers for session %q at final_seq %d", sessionID, state.FinalSeq)
 		}
 	}
 	return selected, found, nil

--- a/internal/cli/runtime/evidence_health.go
+++ b/internal/cli/runtime/evidence_health.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/anchor"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
@@ -183,11 +184,13 @@ func (h *evidenceHealthMonitor) refreshAnchor() {
 		h.setAnchor(nil)
 		return
 	}
-	state, err := readAnchorState(filepath.Join(h.recorder.Dir(), evidenceAnchorStateFile))
+	state, found, err := readAnchorStateForSession(h.recorder.Dir(), transcriptRootSessionID)
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			h.fail("sampler_error", err)
-		}
+		h.setAnchor(nil)
+		h.fail("sampler_error", err)
+		return
+	}
+	if !found {
 		h.setAnchor(nil)
 		return
 	}
@@ -549,6 +552,51 @@ func readAnchorState(path string) (anchorState, error) {
 		return anchorState{}, errors.New("anchor-state has trailing JSON")
 	}
 	return state, nil
+}
+
+func readAnchorStateForSession(dir, sessionID string) (anchorState, bool, error) {
+	legacy, err := readAnchorState(filepath.Join(dir, evidenceAnchorStateFile))
+	if err == nil && legacy.SessionID != sessionID {
+		return anchorState{}, false, fmt.Errorf("anchor-state session_id %q does not match %q", legacy.SessionID, sessionID)
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return anchorState{}, false, err
+	}
+	markers, err := anchor.LoadStateMarkers(dir)
+	if err != nil {
+		return anchorState{}, false, err
+	}
+	var selected anchorState
+	found := false
+	for _, marker := range markers {
+		if marker.SessionID != sessionID {
+			continue
+		}
+		state := anchorStateFromMarker(marker)
+		if !found || state.FinalSeq > selected.FinalSeq {
+			selected = state
+			found = true
+			continue
+		}
+		if state.FinalSeq == selected.FinalSeq && state.RootHash != selected.RootHash {
+			return anchorState{}, false, fmt.Errorf("ambiguous anchor-state markers for session %q at final_seq %d", sessionID, state.FinalSeq)
+		}
+	}
+	return selected, found, nil
+}
+
+func anchorStateFromMarker(marker anchor.StateMarker) anchorState {
+	return anchorState{
+		Schema:       marker.Schema,
+		SessionID:    marker.SessionID,
+		FinalSeq:     marker.FinalSeq,
+		RootHash:     marker.RootHash,
+		Backend:      marker.Backend,
+		LogIndex:     marker.LogIndex,
+		AnchoredAt:   marker.AnchoredAt,
+		BundleSHA256: marker.BundleSHA256,
+		BundlePath:   marker.BundlePath,
+	}
 }
 
 func validateAnchorStateMarker(state anchorState, now time.Time) error {

--- a/internal/cli/runtime/evidence_health.go
+++ b/internal/cli/runtime/evidence_health.go
@@ -533,10 +533,38 @@ type anchorState struct {
 	BundlePath   string    `json:"bundle_path"`
 }
 
+const maxEvidenceAnchorStateBytes = 64 * 1024
+
 func readAnchorState(path string) (anchorState, error) {
-	data, err := os.ReadFile(filepath.Clean(path))
+	clean := filepath.Clean(path)
+	info, err := os.Lstat(clean)
 	if err != nil {
 		return anchorState{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return anchorState{}, errors.New("anchor-state is not a regular file")
+	}
+	if info.Size() > maxEvidenceAnchorStateBytes {
+		return anchorState{}, fmt.Errorf("anchor-state exceeds size limit of %d bytes", maxEvidenceAnchorStateBytes)
+	}
+	file, err := os.Open(clean) // #nosec G304 -- lstat/fstat below fail closed on local replacement races.
+	if err != nil {
+		return anchorState{}, err
+	}
+	defer func() { _ = file.Close() }()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return anchorState{}, err
+	}
+	if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		return anchorState{}, errors.New("anchor-state changed during validation")
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxEvidenceAnchorStateBytes+1))
+	if err != nil {
+		return anchorState{}, err
+	}
+	if int64(len(data)) > maxEvidenceAnchorStateBytes {
+		return anchorState{}, fmt.Errorf("anchor-state exceeds size limit of %d bytes", maxEvidenceAnchorStateBytes)
 	}
 	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
 		return anchorState{}, err

--- a/internal/cli/runtime/evidence_health_test.go
+++ b/internal/cli/runtime/evidence_health_test.go
@@ -569,6 +569,31 @@ func TestReadAnchorStateForSessionFailsClosedOnConflicts(t *testing.T) {
 			},
 			wantErr: "ambiguous anchor-state markers",
 		},
+		{
+			name: "ambiguous lower sequence markers",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				first := anchorStateToMarker(validEvidenceHealthAnchorState())
+				first.FinalSeq = 1
+				if err := anchorpkg.WriteStateMarker(dir, first); err != nil {
+					t.Fatalf("WriteStateMarker first: %v", err)
+				}
+				higher := first
+				higher.FinalSeq = 2
+				higher.RootHash = strings.Repeat("c", 64)
+				higher.BundleSHA256 = strings.Repeat("d", 64)
+				if err := anchorpkg.WriteStateMarker(dir, higher); err != nil {
+					t.Fatalf("WriteStateMarker higher: %v", err)
+				}
+				conflictingLower := first
+				conflictingLower.RootHash = strings.Repeat("e", 64)
+				conflictingLower.BundleSHA256 = strings.Repeat("f", 64)
+				if err := anchorpkg.WriteStateMarker(dir, conflictingLower); err != nil {
+					t.Fatalf("WriteStateMarker conflicting lower: %v", err)
+				}
+			},
+			wantErr: "ambiguous anchor-state markers",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/runtime/evidence_health_test.go
+++ b/internal/cli/runtime/evidence_health_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -445,6 +446,138 @@ func TestReadAnchorStateStrictJSON(t *testing.T) {
 	}
 	if _, err := readAnchorState(filepath.Join(t.TempDir(), "missing.json")); err == nil {
 		t.Fatal("readAnchorState missing file err = nil, want failure")
+	}
+}
+
+func TestReadAnchorStateFilesystemGuards(t *testing.T) {
+	valid := validEvidenceHealthAnchorState()
+	valid.AnchoredAt = time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	validData, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatalf("Marshal valid anchor state: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, dir string) string
+		wantErr string
+	}{
+		{
+			name: "symlink",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				if runtime.GOOS == "windows" {
+					t.Skip("symlink creation needs privileges on Windows")
+				}
+				target := filepath.Join(dir, "target-anchor-state.json")
+				if err := os.WriteFile(target, append(validData, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile target: %v", err)
+				}
+				link := filepath.Join(dir, evidenceAnchorStateFile)
+				if err := os.Symlink(filepath.Base(target), link); err != nil {
+					t.Fatalf("Symlink anchor state: %v", err)
+				}
+				return link
+			},
+			wantErr: "not a regular file",
+		},
+		{
+			name: "non regular",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				path := filepath.Join(dir, evidenceAnchorStateFile)
+				if err := os.Mkdir(path, 0o750); err != nil {
+					t.Fatalf("Mkdir anchor state: %v", err)
+				}
+				return path
+			},
+			wantErr: "not a regular file",
+		},
+		{
+			name: "oversized",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				path := filepath.Join(dir, evidenceAnchorStateFile)
+				if err := os.WriteFile(path, make([]byte, maxEvidenceAnchorStateBytes+1), 0o600); err != nil {
+					t.Fatalf("WriteFile oversized anchor state: %v", err)
+				}
+				return path
+			},
+			wantErr: "exceeds size limit",
+		},
+		{
+			name: "valid",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				path := filepath.Join(dir, evidenceAnchorStateFile)
+				if err := os.WriteFile(path, append(validData, '\n'), 0o600); err != nil {
+					t.Fatalf("WriteFile valid anchor state: %v", err)
+				}
+				return path
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := readAnchorState(tc.setup(t, t.TempDir()))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("readAnchorState err = %v, want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readAnchorState: %v", err)
+			}
+			if got.SessionID != valid.SessionID || got.BundleSHA256 != valid.BundleSHA256 {
+				t.Fatalf("readAnchorState = %+v, want valid marker", got)
+			}
+		})
+	}
+}
+
+func TestReadAnchorStateForSessionFailsClosedOnConflicts(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, dir string)
+		wantErr string
+	}{
+		{
+			name: "legacy session mismatch",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				state := validEvidenceHealthAnchorState()
+				state.SessionID = "different-session"
+				writeEvidenceHealthAnchorState(t, dir, state)
+			},
+			wantErr: "does not match",
+		},
+		{
+			name: "ambiguous indexed markers",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				first := anchorStateToMarker(validEvidenceHealthAnchorState())
+				if err := anchorpkg.WriteStateMarker(dir, first); err != nil {
+					t.Fatalf("WriteStateMarker first: %v", err)
+				}
+				second := first
+				second.RootHash = strings.Repeat("c", 64)
+				second.BundleSHA256 = strings.Repeat("d", 64)
+				if err := anchorpkg.WriteStateMarker(dir, second); err != nil {
+					t.Fatalf("WriteStateMarker second: %v", err)
+				}
+			},
+			wantErr: "ambiguous anchor-state markers",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.setup(t, dir)
+			if _, found, err := readAnchorStateForSession(dir, transcriptRootSessionID); err == nil || found || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("readAnchorStateForSession found=%v err=%v, want %q", found, err, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/runtime/evidence_health_test.go
+++ b/internal/cli/runtime/evidence_health_test.go
@@ -17,6 +17,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
+	anchorpkg "github.com/luckyPipewrench/pipelock/internal/anchor"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
@@ -544,6 +545,45 @@ func TestEvidenceHealthAnchorStateValidMarkerCanOnlyUseAcceptedFreshness(t *test
 	}
 }
 
+func TestEvidenceHealthReadsIndexedAnchorStateMarkers(t *testing.T) {
+	h, _, e, _ := newEvidenceHealthTestMonitor(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+	})
+	emitEvidenceHealthTestReceipt(t, e, "https://api.vendor.example/baseline")
+	if _, err := os.Stat(filepath.Join(h.recorder.Dir(), evidenceAnchorStateFile)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy anchor-state presence err = %v, want absent legacy marker", err)
+	}
+
+	older := validEvidenceHealthAnchorState()
+	older.FinalSeq = 0
+	if err := anchorpkg.WriteStateMarker(h.recorder.Dir(), anchorStateToMarker(older)); err != nil {
+		t.Fatalf("WriteStateMarker older: %v", err)
+	}
+	newer := validEvidenceHealthAnchorState()
+	newer.FinalSeq = 1
+	newer.RootHash = strings.Repeat("c", 64)
+	newer.BundleSHA256 = strings.Repeat("d", 64)
+	if err := anchorpkg.WriteStateMarker(h.recorder.Dir(), anchorStateToMarker(newer)); err != nil {
+		t.Fatalf("WriteStateMarker newer: %v", err)
+	}
+
+	h.runPass()
+
+	stats, ok := h.stats()
+	if !ok {
+		t.Fatal("stats unavailable")
+	}
+	if stats.Anchor == nil {
+		t.Fatal("indexed anchor-state marker did not produce anchor stats")
+	}
+	if stats.Anchor.FinalSeq != newer.FinalSeq || stats.Anchor.RootHash != newer.RootHash {
+		t.Fatalf("anchor stats = %+v, want latest indexed marker final_seq/root", stats.Anchor)
+	}
+	if !stats.Requirements[metrics.EvidenceRequirementAnchoringFresh] {
+		t.Fatal("fresh indexed marker did not set anchoring_fresh")
+	}
+}
+
 func newEvidenceHealthTestMonitor(
 	t *testing.T,
 	mutate func(*config.Config),
@@ -648,6 +688,20 @@ func writeEvidenceHealthAnchorState(t *testing.T, dir string, state anchorState)
 	}
 	if err := os.WriteFile(filepath.Join(dir, evidenceAnchorStateFile), append(data, '\n'), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func anchorStateToMarker(state anchorState) anchorpkg.StateMarker {
+	return anchorpkg.StateMarker{
+		Schema:       state.Schema,
+		SessionID:    state.SessionID,
+		FinalSeq:     state.FinalSeq,
+		RootHash:     state.RootHash,
+		Backend:      state.Backend,
+		LogIndex:     state.LogIndex,
+		AnchoredAt:   state.AnchoredAt,
+		BundleSHA256: state.BundleSHA256,
+		BundlePath:   state.BundlePath,
 	}
 }
 

--- a/internal/license/crl_highwater.go
+++ b/internal/license/crl_highwater.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -132,22 +133,12 @@ func ReadCRLHighWater(crlFile string) (generation uint64, found bool, err error)
 }
 
 func readCRLHighWaterFileForContext(path, label, crlFile string) (generation uint64, found bool, err error) {
-	info, statErr := os.Stat(path)
-	if statErr != nil {
-		if errors.Is(statErr, os.ErrNotExist) {
-			return 0, false, nil
-		}
-		return 0, false, fmt.Errorf("stat %s: %w", label, statErr)
-	}
-	if !info.Mode().IsRegular() {
-		return 0, false, fmt.Errorf("%s must be a regular file", label)
-	}
-	if info.Size() > crlHighWaterMaxSize {
-		return 0, false, fmt.Errorf("%s exceeds maximum size", label)
-	}
-	data, readErr := os.ReadFile(path) // #nosec G304 -- path derives from operator-configured CRL file, cleaned and size-capped
+	data, found, readErr := readCRLHighWaterStateBytes(path, label)
 	if readErr != nil {
-		return 0, false, fmt.Errorf("read %s: %w", label, readErr)
+		return 0, false, readErr
+	}
+	if !found {
+		return 0, false, nil
 	}
 	var state crlHighWaterState
 	if jsonErr := json.Unmarshal(data, &state); jsonErr != nil {
@@ -252,22 +243,12 @@ func writeCRLHighWater(crlFile string, generation uint64) error {
 
 func readCRLHighWaterContext(crlFile string) (bool, error) {
 	path := crlHighWaterContextPath(crlFile)
-	info, statErr := os.Stat(path)
-	if statErr != nil {
-		if errors.Is(statErr, os.ErrNotExist) {
-			return false, nil
-		}
-		return false, fmt.Errorf("stat license CRL high-water context: %w", statErr)
-	}
-	if !info.Mode().IsRegular() {
-		return false, fmt.Errorf("license CRL high-water context must be a regular file")
-	}
-	if info.Size() > crlHighWaterMaxSize {
-		return false, fmt.Errorf("license CRL high-water context exceeds maximum size")
-	}
-	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- path derives from operator-configured CRL file and protected state root
+	data, found, err := readCRLHighWaterStateBytes(path, "license CRL high-water context")
 	if err != nil {
-		return false, fmt.Errorf("read license CRL high-water context: %w", err)
+		return false, err
+	}
+	if !found {
+		return false, nil
 	}
 	var ctx crlHighWaterContext
 	if err := json.Unmarshal(data, &ctx); err != nil {
@@ -277,6 +258,45 @@ func readCRLHighWaterContext(crlFile string) (bool, error) {
 		return false, fmt.Errorf("license CRL high-water context mismatch")
 	}
 	return true, nil
+}
+
+func readCRLHighWaterStateBytes(path, label string) ([]byte, bool, error) {
+	clean := filepath.Clean(path)
+	info, statErr := os.Lstat(clean)
+	if statErr != nil {
+		if errors.Is(statErr, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("stat %s: %w", label, statErr)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, false, fmt.Errorf("%s must be a regular file", label)
+	}
+	if info.Size() > crlHighWaterMaxSize {
+		return nil, false, fmt.Errorf("%s exceeds maximum size", label)
+	}
+	file, err := os.Open(clean) // #nosec G304 -- path derives from operator-configured CRL file; lstat/fstat fail closed on local replacement races.
+	if err != nil {
+		return nil, false, fmt.Errorf("read %s: %w", label, err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return nil, false, fmt.Errorf("stat opened %s: %w", label, err)
+	}
+	if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		return nil, false, fmt.Errorf("%s changed during validation", label)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, crlHighWaterMaxSize+1))
+	if err != nil {
+		return nil, false, fmt.Errorf("read %s: %w", label, err)
+	}
+	if len(data) > crlHighWaterMaxSize {
+		return nil, false, fmt.Errorf("%s exceeds maximum size", label)
+	}
+	return data, true, nil
 }
 
 func writeCRLHighWaterContext(crlFile string) error {

--- a/internal/license/crl_highwater.go
+++ b/internal/license/crl_highwater.go
@@ -4,6 +4,7 @@
 package license
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
 )
 
 const (
@@ -141,8 +143,8 @@ func readCRLHighWaterFileForContext(path, label, crlFile string) (generation uin
 		return 0, false, nil
 	}
 	var state crlHighWaterState
-	if jsonErr := json.Unmarshal(data, &state); jsonErr != nil {
-		return 0, false, fmt.Errorf("parse %s: %w", label, jsonErr)
+	if err := decodeCRLHighWaterJSON(data, label, &state); err != nil {
+		return 0, false, err
 	}
 	if crlFile != "" {
 		if state.Context != "" && state.Context != crlHighWaterContextID(crlFile) {
@@ -251,13 +253,29 @@ func readCRLHighWaterContext(crlFile string) (bool, error) {
 		return false, nil
 	}
 	var ctx crlHighWaterContext
-	if err := json.Unmarshal(data, &ctx); err != nil {
-		return false, fmt.Errorf("parse license CRL high-water context: %w", err)
+	if err := decodeCRLHighWaterJSON(data, "license CRL high-water context", &ctx); err != nil {
+		return false, err
 	}
 	if ctx.Context != crlHighWaterContextID(crlFile) {
 		return false, fmt.Errorf("license CRL high-water context mismatch")
 	}
 	return true, nil
+}
+
+func decodeCRLHighWaterJSON(data []byte, label string, dst any) error {
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		return fmt.Errorf("parse %s: %w", label, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return fmt.Errorf("parse %s: %w", label, err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("parse %s: trailing JSON", label)
+	}
+	return nil
 }
 
 func readCRLHighWaterStateBytes(path, label string) ([]byte, bool, error) {

--- a/internal/license/crl_highwater_test.go
+++ b/internal/license/crl_highwater_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -105,6 +106,47 @@ func TestReadCRLHighWater(t *testing.T) {
 		}
 		if _, _, err := ReadCRLHighWater(crlFile); err == nil {
 			t.Fatal("corrupt high-water must error, got nil")
+		}
+	})
+
+	t.Run("symlink high-water fails closed", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation needs privileges on Windows")
+		}
+		crlFile := filepath.Join(t.TempDir(), "crl.json")
+		target := filepath.Join(t.TempDir(), "target.highwater")
+		if err := writeCRLHighWaterFileForCRL(target, crlFile, 7); err != nil {
+			t.Fatalf("write target high-water: %v", err)
+		}
+		if err := os.Symlink(target, CRLHighWaterPath(crlFile)); err != nil {
+			t.Fatalf("symlink high-water: %v", err)
+		}
+		if _, _, err := ReadCRLHighWater(crlFile); err == nil || !strings.Contains(err.Error(), "regular file") {
+			t.Fatalf("symlink high-water err = %v, want regular-file failure", err)
+		}
+	})
+
+	t.Run("symlink context file fails closed", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation needs privileges on Windows")
+		}
+		crlFile := filepath.Join(t.TempDir(), "crl.json")
+		target := filepath.Join(t.TempDir(), "context.json")
+		data, err := json.Marshal(crlHighWaterContext{Context: crlHighWaterContextID(crlFile)})
+		if err != nil {
+			t.Fatalf("marshal context: %v", err)
+		}
+		if err := os.WriteFile(target, data, 0o600); err != nil {
+			t.Fatalf("write target context: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(crlHighWaterContextPath(crlFile)), 0o750); err != nil {
+			t.Fatalf("mkdir context dir: %v", err)
+		}
+		if err := os.Symlink(target, crlHighWaterContextPath(crlFile)); err != nil {
+			t.Fatalf("symlink context: %v", err)
+		}
+		if _, err := readCRLHighWaterContext(crlFile); err == nil || !strings.Contains(err.Error(), "regular file") {
+			t.Fatalf("symlink context err = %v, want regular-file failure", err)
 		}
 	})
 }

--- a/internal/license/crl_highwater_test.go
+++ b/internal/license/crl_highwater_test.go
@@ -370,6 +370,48 @@ func TestCRLHighWaterContextAndDigestMismatchFailClosed(t *testing.T) {
 		}
 	})
 
+	t.Run("state duplicate key failure", func(t *testing.T) {
+		crlFile := filepath.Join(t.TempDir(), "crl.json")
+		data := []byte(`{"generation":1,"generation":2,"context":"` + crlHighWaterContextID(crlFile) + `"}`)
+		if err := os.WriteFile(CRLHighWaterPath(crlFile), data, 0o600); err != nil {
+			t.Fatalf("write state: %v", err)
+		}
+
+		_, _, err := ReadCRLHighWater(crlFile)
+		if err == nil || !strings.Contains(err.Error(), "parse license CRL high-water") {
+			t.Fatalf("ReadCRLHighWater duplicate-key error = %v, want parse failure", err)
+		}
+	})
+
+	t.Run("state unknown field failure", func(t *testing.T) {
+		crlFile := filepath.Join(t.TempDir(), "crl.json")
+		data := []byte(`{"generation":1,"context":"` + crlHighWaterContextID(crlFile) + `","extra":true}`)
+		if err := os.WriteFile(CRLHighWaterPath(crlFile), data, 0o600); err != nil {
+			t.Fatalf("write state: %v", err)
+		}
+
+		_, _, err := ReadCRLHighWater(crlFile)
+		if err == nil || !strings.Contains(err.Error(), "parse license CRL high-water") {
+			t.Fatalf("ReadCRLHighWater unknown-field error = %v, want parse failure", err)
+		}
+	})
+
+	t.Run("context duplicate key failure", func(t *testing.T) {
+		crlFile := filepath.Join(t.TempDir(), "crl.json")
+		if err := os.MkdirAll(filepath.Dir(crlHighWaterContextPath(crlFile)), 0o750); err != nil {
+			t.Fatalf("mkdir context dir: %v", err)
+		}
+		data := []byte(`{"context":"` + crlHighWaterContextID(crlFile) + `","context":"wrong"}`)
+		if err := os.WriteFile(crlHighWaterContextPath(crlFile), data, 0o600); err != nil {
+			t.Fatalf("write context: %v", err)
+		}
+
+		_, _, err := readDurableCRLHighWater(crlFile)
+		if err == nil || !strings.Contains(err.Error(), "parse license CRL high-water context") {
+			t.Fatalf("readDurableCRLHighWater context duplicate-key error = %v, want parse failure", err)
+		}
+	})
+
 	t.Run("context identity mismatch", func(t *testing.T) {
 		crlFile := filepath.Join(t.TempDir(), "crl.json")
 		if err := os.MkdirAll(filepath.Dir(crlHighWaterContextPath(crlFile)), 0o750); err != nil {


### PR DESCRIPTION
## What changed

Hardening pass on the receipt-anchor subsystem: multi-session state, hostile-filesystem loading, and producer/consumer path confinement. Fail-closed throughout.

- Anchor state markers move from a single fixed file per receipt directory to a versioned per-session index, so anchoring a second session no longer silently overwrites the first session's discoverable marker. Legacy single-file state is still read.
- Marker loading fails closed on hostile local filesystem state: symlinked, non-regular, oversized, blank, or digest-invalid markers are rejected with lstat/open/fstat checks and strict decoding, and corrupt, duplicate, or ambiguous index entries error rather than resolve to a wrong session.
- The index directory is validated before writing, so a pre-planted symlinked directory cannot redirect marker writes.
- The `anchor receipts --out` producer is confined to write bundles under the receipt directory and records a receipt-directory-relative marker path, so a produced bundle always verifies against the dashboard's path confinement.
- The anchor bundle is read once, and the same bytes are hashed and parsed, removing a double-read.
- Indexed markers are surfaced in evidence-health sampling, and the same lstat/open/fstat/limited-read hardening is applied to the license revocation high-water state files.

Known residual, tracked separately: a same-user TOCTOU window remains on a newly-created `--out` parent directory (an attacker at that point already holds the process's privileges); a fuller openat-based confined writer is the follow-up.

No new dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anchor state now persists and resolves via indexed, per-marker storage (one file per marker), supporting multiple independent sessions with legacy compatibility.
  * Receipt-bundle and marker output paths are resolved safely relative to the receipts directory.
* **Bug Fixes**
  * Marker resolution is stricter: ambiguity, corrupt/malformed content, oversized data, and unsafe filesystem layouts now fail closed.
  * Evidence health selects the correct session’s latest marker and detects conflicting matches; CRL high-water reads are hardened against symlinks/races.
* **Tests**
  * Added extensive CLI, filesystem-safety, and indexed/legacy anchor-state regression coverage; improved fail-closed and validation assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->