### PR TITLE
fix(baseline): restore Windows regular-file reads without following symlinks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,6 +261,9 @@ jobs:
       - name: Key-free MCP capture writer smoke (#696)
         run: go test -count=1 -run "TestBuildCaptureWriter|TestParseCaptureEscrowKey" ./internal/cli/runtime/...
 
+      - name: Baseline no-follow reads work on Windows
+        run: go test -count=1 -run "TestWindows" ./internal/proxy/baseline/...
+
   lint:
     needs: [security-scan]
     runs-on: ubuntu-latest

--- a/internal/proxy/baseline/nofollow_windows.go
+++ b/internal/proxy/baseline/nofollow_windows.go
@@ -7,14 +7,51 @@ package baseline
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 )
 
-var (
-	errELOOP               = errors.New("ELOOP-not-supported-on-windows")
-	errNoFollowUnsupported = errors.New("secure nofollow baseline reads are unsupported on windows")
-)
+// errELOOP is a Windows sentinel: the Unix ELOOP symlink-loop error has no
+// portable Windows equivalent, so this value never matches a real open error.
+// The shared caller's errors.Is(err, errELOOP) branch is therefore inert on
+// Windows, and a rejected symlink surfaces via the explicit checks below.
+var errELOOP = errors.New("ELOOP-not-supported-on-windows")
 
-func openRegularFileNoSymlinkBelowRoot(_, _, displayPath string) (*os.File, error) {
-	return nil, errNoFollowUnsupported
+// openRegularFileNoSymlinkBelowRoot opens a regular file below canonicalRoot
+// without following a symlink or reparse point at the final path component.
+//
+// Windows has no portable openat/O_NOFOLLOW per-component walk like the Unix
+// build, so this mirrors the no-follow guarantee at the final component with an
+// Lstat reject and relies on the shared caller
+// (readRegularFileNoSymlinkInRootWithOpenHook) for the two guards that ARE
+// portable: rejectSymlinkParents Lstat-walks every parent directory, and the
+// post-open os.SameFile identity re-check closes the TOCTOU window between this
+// Lstat and the open. Normal regular-file reads succeed; only symlinks and
+// reparse points are rejected. (Earlier this function failed every Windows read
+// unconditionally, breaking baseline profile and integrity-state loading on
+// Windows; that fail-closed denial is removed here.)
+func openRegularFileNoSymlinkBelowRoot(canonicalRoot, relPath, displayPath string) (*os.File, error) {
+	fullPath := filepath.Clean(filepath.Join(canonicalRoot, relPath))
+	info, err := os.Lstat(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("lstat %s: %w", displayPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%s must not be a symlink", displayPath)
+	}
+	// A non-symlink reparse point (junction, mount point, or other name
+	// surrogate) surfaces with the irregular mode bit; reject it so a
+	// redirected read cannot escape the trusted root.
+	if info.Mode()&os.ModeIrregular != 0 {
+		return nil, fmt.Errorf("%s must not be a reparse point", displayPath)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s must be a regular file", displayPath)
+	}
+	f, err := os.Open(fullPath)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
 }

--- a/internal/proxy/baseline/nofollow_windows_test.go
+++ b/internal/proxy/baseline/nofollow_windows_test.go
@@ -41,4 +41,13 @@ func TestWindowsBaselineNoSymlinkReadsRegularFileAndRejectsSymlink(t *testing.T)
 	if _, err := readRegularFileNoSymlink(link, "baseline profile", integrityStateMaxSize); err == nil {
 		t.Fatal("readRegularFileNoSymlink(symlink) succeeded, want rejection")
 	}
+
+	// The read above rejects via the shared, cross-platform Lstat pre-check in
+	// readRegularFileNoSymlinkInRootWithOpenHook, which runs before the
+	// Windows-specific opener. Call the new opener directly so its own
+	// symlink-rejection logic is exercised, not just the outer guard.
+	if f, err := openRegularFileNoSymlinkBelowRoot(dir, "profile-link.json", link); err == nil {
+		_ = f.Close()
+		t.Fatal("openRegularFileNoSymlinkBelowRoot(symlink) succeeded, want rejection")
+	}
 }

--- a/internal/proxy/baseline/nofollow_windows_test.go
+++ b/internal/proxy/baseline/nofollow_windows_test.go
@@ -6,19 +6,39 @@
 package baseline
 
 import (
-	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
-func TestOpenRegularFileNoSymlinkBelowRootWindowsFailsClosed(t *testing.T) {
-	f, err := openRegularFileNoSymlinkBelowRoot("C:\\baseline", "profile.json", "C:\\baseline\\profile.json")
-	if err == nil {
-		t.Fatal("openRegularFileNoSymlinkBelowRoot succeeded on Windows")
+// TestWindowsBaselineNoSymlinkReadsRegularFileAndRejectsSymlink proves the
+// Windows no-follow read path reads a normal regular file (the regression: this
+// path previously failed every Windows read unconditionally, breaking baseline
+// and integrity-state loading) and still rejects a final-component symlink.
+func TestWindowsBaselineNoSymlinkReadsRegularFileAndRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	regular := filepath.Join(dir, "profile.json")
+	want := []byte(`{"schema":1}`)
+	if err := os.WriteFile(regular, want, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
-	if f != nil {
-		t.Fatalf("openRegularFileNoSymlinkBelowRoot file = %v, want nil", f)
+
+	got, err := readRegularFileNoSymlink(regular, "baseline profile", integrityStateMaxSize)
+	if err != nil {
+		t.Fatalf("readRegularFileNoSymlink(regular) error = %v, want success", err)
 	}
-	if !errors.Is(err, errNoFollowUnsupported) {
-		t.Fatalf("openRegularFileNoSymlinkBelowRoot error = %v, want errNoFollowUnsupported", err)
+	if string(got) != string(want) {
+		t.Fatalf("readRegularFileNoSymlink(regular) = %q, want %q", got, want)
+	}
+
+	// Symlink creation needs SeCreateSymbolicLinkPrivilege (developer mode or
+	// admin). Where the runner grants it, the read must reject a symlinked
+	// final component; where it does not, skip only the symlink assertion.
+	link := filepath.Join(dir, "profile-link.json")
+	if err := os.Symlink(regular, link); err != nil {
+		t.Skipf("symlink creation unsupported on this runner (%v); regular-file read verified", err)
+	}
+	if _, err := readRegularFileNoSymlink(link, "baseline profile", integrityStateMaxSize); err == nil {
+		t.Fatal("readRegularFileNoSymlink(symlink) succeeded, want rejection")
 	}
 }


### PR DESCRIPTION
## What changed

The Windows implementation of the baseline no-follow file open returned an "unsupported" error for every call. Once baseline profile and integrity-state reads were routed through that helper, every such read failed on Windows: a fail-closed denial of baseline enforcement and integrity verification on that platform. This restores normal Windows reads while preserving the no-follow guarantee.

The Windows helper now opens a normal regular file below the trusted root and rejects a final-component symlink or reparse point via `Lstat` (symlink bit or the irregular-mode reparse indicator), then opens the file. The rest of the no-follow guarantee comes from the shared, cross-platform caller, which already Lstat-walks every parent directory to reject a symlinked parent and performs a post-open `os.SameFile` identity re-check that closes the TOCTOU window between the Lstat and the open. Windows lacks a portable per-component `openat`/`O_NOFOLLOW` walk like the Unix build, so this is the closest faithful equivalent that does not break normal reads.

The existing Windows unit test asserted the old always-fail behavior; it is replaced with a test that reads a normal regular file successfully (the regression) and rejects a final-component symlink, skipping only the symlink assertion where the runner lacks symlink-creation privilege.

A Windows CI step now runs the baseline no-follow test on `windows-latest`, so this path is exercised on the platform it targets rather than only building there.

## Verification

Built for Windows locally (`GOOS=windows go build` and `go vet`, OSS and enterprise tags) and validated the Linux surface (full build, scoped lint clean). The Windows runtime assertions run on the new `windows-latest` CI step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Windows baseline file handling to securely open regular files while rejecting unsafe targets.
  - Reads are now validated to prevent symlink and unsupported reparse-point scenarios.

- **Bug Fixes**
  - Fixed Windows behavior that previously blocked opening supported baseline files.

- **Tests**
  - Updated Windows baseline tests to confirm successful regular-file reads and correct symlink rejection.
  - Windows CI now runs the relevant test suite to verify this behavior automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->