### PR TITLE
fix(dashboard): accept mutual TLS as a sole authenticator

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -62,6 +62,24 @@ umask 077
 openssl rand -hex 32 > /etc/pipelock/dashboard.token
 ```
 
+### Authentication modes
+
+The dashboard requires exactly one of three authenticators, and each is a
+complete sole authenticator — none depends on the others:
+
+- **Operator token** (`--auth-token-file`): a bearer token, optionally paired
+  with a higher-privilege `--raw-token-file`.
+- **OIDC** (`--oidc-issuer` plus its required options): a verified bearer token
+  whose mapped claim grants bounded permissions.
+- **Mutual TLS** (`--require-client-cert` plus the three mTLS file flags): a
+  verified client certificate authorized through the role map.
+
+You may combine token and OIDC, but mutual TLS is exclusive: when
+`--require-client-cert` is set the verified certificate is authoritative and
+supplies both route and raw-view permissions, so `--auth-token-file` and OIDC
+are neither required nor consulted. Starting with none of the three is a
+startup error.
+
 ### Flags
 
 | Flag | Default | Purpose |
@@ -87,13 +105,16 @@ openssl rand -hex 32 > /etc/pipelock/dashboard.token
 
 ### Mutual TLS client authentication
 
-Mutual TLS is additive: token-only deployments keep their existing behavior,
-while an operator can enable verified client-certificate authentication with
-all of `--require-client-cert`, `--client-ca-file`, and
-`--client-cert-role-map`. Server TLS (`--tls-cert` and `--tls-key`) is also
-required. When enabled, TLS requires a client certificate on every connection;
-the certificate therefore cannot be replaced by a bearer token at the TLS
-handshake.
+Mutual TLS is a complete authenticator on its own: enable it with all of
+`--require-client-cert`, `--client-ca-file`, and `--client-cert-role-map` (plus
+server TLS via `--tls-cert`/`--tls-key`), with or without an operator token or
+OIDC. When enabled, the verified client certificate is authoritative: TLS
+requires a certificate on every connection, and the certificate's mapped role
+supplies both route and raw-view permissions and takes precedence over any
+token or OIDC principal. An absent, wrong-CA, or unmapped certificate is denied
+(the TLS layer rejects the first two; the fingerprint role map rejects the
+third), so a server-wiring or ordering bug cannot silently fall back to token
+access.
 
 The role map uses the SHA-256 fingerprint of the leaf certificate's DER-encoded
 SubjectPublicKeyInfo (SPKI). This identity remains stable when a certificate is
@@ -124,12 +145,13 @@ fingerprint. The map also accepts colon-separated hexadecimal and an optional
 `sha256:` prefix. Unknown permissions, roles, fields, or fingerprints are hard
 startup errors; an empty certificate map is never treated as allow-all.
 
-Start the dashboard with client-certificate verification:
+Start the dashboard with client-certificate verification as the sole
+authenticator (no `--auth-token-file`; add one only if you also want token
+access to non-mTLS paths, though the certificate role stays authoritative):
 
 ```bash
 pipelock dashboard serve \
   --receipt-dir /var/lib/pipelock/evidence \
-  --auth-token-file /etc/pipelock/dashboard.token \
   --tls-cert /etc/pipelock/dashboard-server.pem \
   --tls-key /etc/pipelock/dashboard-server.key \
   --require-client-cert \

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -64,8 +64,8 @@ openssl rand -hex 32 > /etc/pipelock/dashboard.token
 
 ### Authentication modes
 
-The dashboard requires exactly one of three authenticators, and each is a
-complete sole authenticator — none depends on the others:
+The dashboard requires at least one of three authenticators, and each is a
+complete authenticator on its own — none depends on the others:
 
 - **Operator token** (`--auth-token-file`): a bearer token, optionally paired
   with a higher-privilege `--raw-token-file`.

--- a/enterprise/cli/dashboard_mtls_test.go
+++ b/enterprise/cli/dashboard_mtls_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"encoding/pem"
 	"math/big"
 	"net"
@@ -19,12 +20,14 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/dashboard"
 	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 type dashboardMTLSTestPKI struct {
@@ -772,5 +775,135 @@ func TestDashboardMTLS_DoesNotChangeLicenseEntitlement(t *testing.T) {
 	inner.ServeHTTP(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil))
 	if recorder.Code != http.StatusForbidden || !strings.Contains(recorder.Body.String(), license.FeatureAgents) {
 		t.Fatalf("status/body = %d %q, want entitlement denial", recorder.Code, recorder.Body.String())
+	}
+}
+
+// TestDashboardServe_MTLSOnlyStartsAndEnforces proves the whole cert-only path
+// end-to-end through runDashboardServe: a dashboard configured with ONLY
+// --require-client-cert (no --auth-token-file, no --oidc-issuer) starts (the
+// validation gate must accept mTLS as a sole authenticator), and enforcement is
+// fail-closed — a valid mapped client certificate is allowed, an absent
+// certificate cannot complete the handshake, and a valid-CA-but-unmapped
+// certificate is denied. Before the validation fix this configuration could not
+// start at all (validateDashboardAuthenticatorConfig rejected it).
+func TestDashboardServe_MTLSOnlyStartsAndEnforces(t *testing.T) {
+	licPub, licPriv := newDashKeyPair(t)
+	setDashLicenseEnv(t, issueDashLicense(t, licPriv, []string{license.FeatureAgents}), hex.EncodeToString(licPub))
+
+	pki := newDashboardMTLSTestPKI(t)
+	now := time.Now()
+	dir := t.TempDir()
+
+	// Server certificate + key as files for --tls-cert/--tls-key.
+	serverCert, _ := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 201, commonName: "mtls-only server", server: true,
+		notBefore: now.Add(-time.Hour), notAfter: now.Add(time.Hour),
+	})
+	serverCertFile := filepath.Join(dir, "server.crt")
+	if err := os.WriteFile(serverCertFile,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverCert.Certificate[0]}), 0o600); err != nil {
+		t.Fatalf("write server cert: %v", err)
+	}
+	serverKeyDER, err := x509.MarshalPKCS8PrivateKey(serverCert.PrivateKey)
+	if err != nil {
+		t.Fatalf("marshal server key: %v", err)
+	}
+	serverKeyFile := filepath.Join(dir, "server.key")
+	if err := os.WriteFile(serverKeyFile,
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: serverKeyDER}), 0o600); err != nil {
+		t.Fatalf("write server key: %v", err)
+	}
+
+	// Client trust anchor file for --client-ca-file.
+	clientCAFile := filepath.Join(dir, "client-ca.crt")
+	if err := os.WriteFile(clientCAFile,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: pki.caCert.Raw}), 0o600); err != nil {
+		t.Fatalf("write client CA: %v", err)
+	}
+
+	// One mapped client (allowed) and one unmapped client (valid CA, denied).
+	mappedCert, mappedLeaf := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 202, commonName: "mapped operator",
+		notBefore: now.Add(-time.Hour), notAfter: now.Add(time.Hour),
+	})
+	unmappedCert, _ := issueDashboardMTLSTestCert(t, pki.caCert, pki.caKey, dashboardMTLSTestCertOptions{
+		serial: 203, commonName: "unmapped operator",
+		notBefore: now.Add(-time.Hour), notAfter: now.Add(time.Hour),
+	})
+	roleMap := writeDashboardMTLSRoleMap(t, map[string]string{
+		dashboardClientCertSPKIFingerprint(mappedLeaf): "operator",
+	}, "  operator:\n    permissions:\n      - dashboard:evidence:read\n")
+
+	out := &dashSyncBuffer{}
+	errOut := &dashSyncBuffer{}
+	cmd := dashboardServeCmd()
+	cmd.SetArgs([]string{
+		"--receipt-dir", t.TempDir(),
+		"--listen", "127.0.0.1:0",
+		"--require-client-cert",
+		"--tls-cert", serverCertFile,
+		"--tls-key", serverKeyFile,
+		"--client-ca-file", clientCAFile,
+		"--client-cert-role-map", roleMap,
+	})
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- cmd.ExecuteContext(ctx) }()
+
+	testwait.For(t, 10*time.Second, func() bool { return out.contains("dashboard listening on") },
+		"serve never printed the listening banner; stderr: %s", errOut.String())
+	m := regexp.MustCompile(`listening on https://(127\.0\.0\.1:\d+)`).FindStringSubmatch(out.String())
+	if m == nil {
+		t.Fatalf("could not parse TLS listen address from %q", out.String())
+	}
+	base := "https://" + m[1]
+
+	serverRoots := x509.NewCertPool()
+	serverRoots.AddCert(pki.caCert)
+	get := func(t *testing.T, clientCert *tls.Certificate) (int, error) {
+		t.Helper()
+		tlsCfg := &tls.Config{RootCAs: serverRoots, MinVersion: tls.VersionTLS12}
+		if clientCert != nil {
+			tlsCfg.Certificates = []tls.Certificate{*clientCert}
+		}
+		client := &http.Client{Timeout: 5 * time.Second, Transport: &http.Transport{TLSClientConfig: tlsCfg}}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return 0, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode, nil
+	}
+
+	// Mapped certificate: authenticated and authorized for evidence read.
+	if code, err := get(t, &mappedCert); err != nil || code != http.StatusOK {
+		t.Fatalf("mapped client cert: code=%d err=%v, want 200", code, err)
+	}
+	// Valid-CA-but-unmapped certificate: handshake succeeds, authentication
+	// fails closed at the outer boundary.
+	if code, err := get(t, &unmappedCert); err != nil || code != http.StatusUnauthorized {
+		t.Fatalf("unmapped client cert: code=%d err=%v, want 401", code, err)
+	}
+	// No client certificate: RequireAndVerifyClientCert refuses the handshake.
+	if _, err := get(t, nil); err == nil {
+		t.Fatal("absent client cert: request succeeded, want TLS handshake failure")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("serve shutdown error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("serve did not shut down")
 	}
 }

--- a/enterprise/cli/dashboard_oidc.go
+++ b/enterprise/cli/dashboard_oidc.go
@@ -56,8 +56,14 @@ func validateDashboardAuthenticatorConfig(opts dashboardServeOptions) error {
 	if anyOIDCOption && !issuerConfigured {
 		return errors.New("--oidc-issuer is required when any OIDC option is set")
 	}
-	if strings.TrimSpace(opts.authTokenFile) == "" && !issuerConfigured {
-		return errors.New("one authenticator is required: set --auth-token-file or --oidc-issuer")
+	// A verified mTLS client certificate is a first-class sole authenticator:
+	// with --require-client-cert the mapped certificate role supplies both route
+	// and raw-view permissions and takes precedence over any token/OIDC principal
+	// (dashboardClientCertAuthorizers), and an absent, wrong-CA, or unmapped
+	// certificate is denied by the TLS layer and the fingerprint role map. So
+	// --require-client-cert alone is a complete, fail-closed authenticator.
+	if strings.TrimSpace(opts.authTokenFile) == "" && !issuerConfigured && !opts.requireClientCert {
+		return errors.New("one authenticator is required: set --auth-token-file, --oidc-issuer, or --require-client-cert")
 	}
 	if strings.TrimSpace(opts.rawTokenFile) != "" && strings.TrimSpace(opts.authTokenFile) == "" {
 		return errors.New("--raw-token-file requires --auth-token-file")

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -714,6 +714,11 @@ func TestDashboardOIDCConfigValidation(t *testing.T) {
 	}{
 		{"token only", dashboardServeOptions{authTokenFile: "token"}, ""},
 		{"OIDC only", dashboardServeOptions{oidcIssuer: "https://issuer.example", oidcAudience: oidcTestAudience, oidcRoleClaim: "groups", oidcRoleMap: oidcTestRoleMap()}, ""},
+		// A verified client certificate is a complete sole authenticator: the
+		// mapped cert role supplies route + raw permissions and an absent/wrong/
+		// unmapped cert is denied. Rejecting cert-only contradicts the flag help.
+		{"client cert only", dashboardServeOptions{requireClientCert: true}, ""},
+		{"no authenticator lists cert mode", dashboardServeOptions{}, "require-client-cert"},
 		{"no authenticator", dashboardServeOptions{}, "auth-token-file"},
 		{"OIDC missing audience", dashboardServeOptions{oidcIssuer: "https://issuer.example", oidcRoleClaim: "groups", oidcRoleMap: oidcTestRoleMap()}, "audience"},
 		{"OIDC missing role claim", dashboardServeOptions{oidcIssuer: "https://issuer.example", oidcAudience: oidcTestAudience, oidcRoleMap: oidcTestRoleMap()}, "role-claim"},

--- a/enterprise/dashboard/workbench.go
+++ b/enterprise/dashboard/workbench.go
@@ -79,19 +79,26 @@ func prepareSteps() []PrepareStep {
 			Kind:        actionKindPublish,
 			Title:       "Publish a policy bundle",
 			Description: "Sign a config as a policy bundle and publish it to the fleet's stream head.",
-			Command:     "pipelock conductor publish --conductor-url <url> --config <policy.yaml> --org <org> --fleet <fleet> --version <n> --signing-key <key>",
+			Command: "pipelock conductor publish --conductor-url <url> --org <org> --fleet <fleet> --audience '*' " +
+				"--config <policy.yaml> --version <n> --signing-key <policy-bundle-signing.key> " +
+				"--publisher-token-file <publisher-token> --tls-cert <client.crt> --tls-key <client.key> --server-ca <server-ca.crt>",
 		},
 		{
 			Kind:        actionKindRemoteKill,
 			Title:       "Remote kill / resume",
 			Description: "Publish a signed remote-kill (or resume) message that halts or restores follower egress.",
-			Command:     "pipelock conductor kill --conductor-url <url> --org <org> --fleet <fleet> --counter <n> --signing-key <key>",
+			Command: "pipelock conductor kill --conductor-url <url> --org <org> --fleet <fleet> --instance '*' " +
+				"--counter <n> --signing-key <remote-kill-signing.key> --admin-token-file <admin-token> " +
+				"--tls-cert <client.crt> --tls-key <client.key> --server-ca <server-ca.crt>",
 		},
 		{
 			Kind:        actionKindRollback,
 			Title:       "Roll back the stream head",
 			Description: "Publish a signed rollback authorization that moves the effective head to a prior bundle.",
-			Command:     "pipelock conductor rollback --conductor-url <url> --org <org> --fleet <fleet> --to-version <n> --counter <n> --signing-key <key>",
+			Command: "pipelock conductor rollback --conductor-url <url> --org <org> --fleet <fleet> " +
+				"--current-bundle-id <id> --current-version <n> --target-bundle-id <id> --target-version <n> " +
+				"--counter <n> --signing-key <policy-bundle-rollback.key> --admin-token-file <admin-token> " +
+				"--tls-cert <client.crt> --tls-key <client.key> --server-ca <server-ca.crt>",
 		},
 	}
 }

--- a/enterprise/dashboard/workbench_test.go
+++ b/enterprise/dashboard/workbench_test.go
@@ -14,6 +14,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/cli/conductor"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
@@ -518,4 +521,68 @@ func TestWorkbench_ReplayViewHelperBranches(t *testing.T) {
 	if got := (DecisionReplayView{Divergence: false}).DivergenceClass(); got != "verified" {
 		t.Fatalf("DivergenceClass = %q", got)
 	}
+}
+
+// TestPrepareSteps_TemplatesReferenceRealConductorFlags is a drift guard: every
+// --flag in a workbench prepare template must exist on the matching shipped
+// conductor subcommand. Without it, a flag rename in conductor publish/kill/
+// rollback silently leaves the dashboard telling operators to run a command
+// that no longer parses (the exact defect this replaced: rollback used the
+// nonexistent --to-version, and publish/kill omitted mandatory auth/TLS flags).
+func TestPrepareSteps_TemplatesReferenceRealConductorFlags(t *testing.T) {
+	kindToSubcommand := map[string]string{
+		actionKindPublish:    "publish",
+		actionKindRemoteKill: "kill",
+		actionKindRollback:   "rollback",
+	}
+
+	root := conductor.Cmd()
+	subcommands := make(map[string]*cobra.Command)
+	for _, c := range root.Commands() {
+		subcommands[c.Name()] = c
+	}
+
+	for _, step := range prepareSteps() {
+		step := step
+		t.Run(step.Kind, func(t *testing.T) {
+			name, ok := kindToSubcommand[step.Kind]
+			if !ok {
+				t.Fatalf("prepare step kind %q has no conductor subcommand mapping", step.Kind)
+			}
+			sub, ok := subcommands[name]
+			if !ok {
+				t.Fatalf("conductor has no %q subcommand", name)
+			}
+			flags := prepareTemplateFlags(step.Command)
+			if len(flags) == 0 {
+				t.Fatalf("template for %q defines no flags: %q", step.Kind, step.Command)
+			}
+			for _, flag := range flags {
+				if sub.Flag(flag) == nil {
+					t.Errorf("template for %q references --%s, which conductor %s does not define",
+						step.Kind, flag, name)
+				}
+			}
+		})
+	}
+}
+
+// prepareTemplateFlags extracts the long-flag names ("--foo bar" -> "foo") from
+// a shell command template. Placeholders (<...>, '*') are ignored because they
+// are not flags.
+func prepareTemplateFlags(command string) []string {
+	var flags []string
+	for _, token := range strings.Fields(command) {
+		if !strings.HasPrefix(token, "--") {
+			continue
+		}
+		name := strings.TrimPrefix(token, "--")
+		if i := strings.IndexByte(name, '='); i >= 0 {
+			name = name[:i]
+		}
+		if name != "" {
+			flags = append(flags, name)
+		}
+	}
+	return flags
 }


### PR DESCRIPTION
## What changed

The dashboard serve startup validation refused a configuration whose only authenticator was `--require-client-cert` (mutual TLS, no operator token and no OIDC), returning "one authenticator is required: set --auth-token-file or --oidc-issuer". This contradicted both the `--auth-token-file` flag help ("Required unless OIDC or `--require-client-cert` is configured") and the mTLS guide. A verified client certificate is already a complete, fail-closed authenticator: when `--require-client-cert` is set the mapped certificate role supplies route and raw-view permissions and takes precedence over any token or OIDC principal, and an absent, wrong-CA, or unmapped certificate is denied (the TLS layer rejects the first two; the fingerprint role map rejects the third). This accepts `--require-client-cert` as a valid sole authenticator and lists all three modes in the error.

New coverage proves the whole cert-only path, not just the validation: a validation case shows cert-only is accepted, and an end-to-end `dashboard serve` test starts a cert-only server through the real startup path, then confirms a mapped certificate is allowed, an unmapped (valid-CA) certificate is denied with 401, and an absent certificate cannot complete the TLS handshake.

It also corrects the read-only Workbench conductor command templates, which emitted commands that no longer parse: the rollback template used a nonexistent `--to-version`, and publish, kill, and rollback all omitted mandatory authentication and TLS flags. Each template is rewritten to a valid runnable command, and a drift guard now fails if any template references a flag the shipped conductor subcommand does not define.

Docs make the three dashboard authentication modes explicit and show a certificate-only serve example.

## Why it is safe

The enforcement path is unchanged and independently fail-closed: authorization derives identity only from `r.TLS.VerifiedChains`, so any request without a verified certificate is denied at the outer boundary and at every per-permission check, and the token and OIDC predicates are never consulted when mutual TLS is enabled. The fix only removes the startup gate that blocked a configuration the enforcement layer already handles correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running the dashboard with mutual TLS as the sole authentication method.
  - Dashboard access (including raw-view permissions) is now determined by mapped client certificates.
- **Bug Fixes**
  - Client-certificate-only configuration is accepted for OIDC authentication validation.
  - Missing, invalid, or unmapped certificates are denied and no longer fall back to token/OIDC access.
- **Documentation**
  - Clarified dashboard authentication modes and mutual TLS setup.
  - Expanded shipped workbench guidance for publish, remote kill/resume, and rollback commands (including TLS and signing options).
- **Tests**
  - Added end-to-end coverage for the mTLS-only dashboard serving path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->