### PR TITLE
harden(evidence): dev-build rules, checkpoint signing, rekor egress, idempotent bundle merge

### DIFF
--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -99,6 +99,7 @@ Because the recorder is on by default, two footguns are bounded by the defaults 
 
 - **Disk growth.** Evidence files rotate at `max_entries_per_file` (default 10000) and can auto-expire with `retention_days`. Leave rotation on so a busy proxy cannot silently fill the disk; set `retention_days` for a hard cap.
 - **Privacy.** Receipts record the *targets* of mediated traffic. `redact` (default `true`) DLP-scrubs each entry before it touches disk so secrets are not persisted in the clear. Do not disable it unless you have a separate control around the evidence directory.
+- **Sign-without-a-key.** `sign_checkpoints` defaults to `true`, so once you set a `dir` the recorder expects a signing key. Starting a persisting recorder with `sign_checkpoints: true` and no `signing_key_path` is a hard startup error (it would otherwise write checkpoints with an empty signature that `verify-receipt` later rejects as "missing signature"). Provide `signing_key_path`, or set `sign_checkpoints: false` for an explicitly unsigned hash-chained recorder. `pipelock init` sets both, so this only bites hand-written configs.
 
 ### Completeness anchor (transcript root)
 
@@ -374,3 +375,39 @@ hash, err := recorder.ComputeFileHash("/var/lib/pipelock/evidence/evidence-abc12
 ```
 
 This hash can be committed to an external ledger or included in an assessment artifact manifest to prove the evidence file has not been modified.
+
+### Verify a live receipt chain end-to-end
+
+Signed action receipts are produced once `flight_recorder` is enabled with a
+`dir` and a `signing_key_path` (all three are needed — without a key the
+recorder can only hash-chain, not sign). Setting `require_receipts: true`
+additionally makes a successful signed emission a precondition for allow-path
+traffic, so a receipt failure fails closed instead of forwarding silently.
+
+The full loop uses only shipped commands and verifies offline against the public
+key — no server, no account:
+
+```bash
+# 1. Provision the recorder: pipelock init writes flight_recorder.enabled/dir/
+#    signing_key_path into the config, generates the Ed25519 signing key, and
+#    writes the shareable public-key sidecar at <signing_key_path>.pub.
+pipelock init
+
+# 2. Run the proxy. Every mediated allow/block decision is signed into the
+#    hash-linked chain under flight_recorder.dir.
+pipelock run --config /etc/pipelock/pipelock.yaml
+
+# 3. Stop it cleanly (Ctrl-C / SIGTERM). Graceful shutdown seals the chain with
+#    a transcript_root completeness anchor; a SIGKILL skips the seal and leaves
+#    the tail unsealed (verification then reports no root rather than VALID).
+
+# 4. Verify the entire chain offline with the public-key sidecar. Use the dir
+#    and .pub path that step 1 wrote into your config.
+pipelock verify-receipt --chain /var/lib/pipelock/evidence \
+  --key /etc/pipelock/keys/flight-recorder-signing.key.pub
+```
+
+`--chain` walks every evidence file in the directory (across rotations and
+restarts), checks `prev_hash` linkage and sequence continuity, verifies each
+signature against the pinned key, and confirms the sealed `transcript_root`. If
+the chain rotated its signing key, pass each public key with a repeated `--key`.

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -103,6 +103,17 @@ func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
 	if len(r.Signer) == 0 {
 		return Proof{}, errors.New("rekor signing key required")
 	}
+	// Fail closed on an empty submission URL. Defaulting to the public
+	// rekor.sigstore.dev would silently publish receipt-chain checkpoint hash
+	// metadata to a public transparency log, outside the operator's trust
+	// boundary — the opposite of "your evidence stays where you put it". The
+	// caller must name the target log explicitly; there is no public default
+	// for submission. (Verification of an already-recorded proof is separate:
+	// it reads the URL embedded in the proof, not this field.)
+	if strings.TrimSpace(r.URL) == "" {
+		return Proof{}, errors.New("rekor anchor URL is required for submission; " +
+			"set an explicit transparency-log URL (no public default — receipt metadata must stay in your trust boundary)")
+	}
 	checkpointBytes, err := checkpointBytes(checkpoint)
 	if err != nil {
 		return Proof{}, err

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -584,6 +584,15 @@ func TestRekorLogSubmitRejectsRequestFailures(t *testing.T) {
 	if _, err := (RekorLog{URL: "://bad-url", Signer: priv}).Submit(checkpoint); err == nil || !strings.Contains(err.Error(), "parse rekor URL") {
 		t.Fatalf("Submit bad URL err = %v, want parse error", err)
 	}
+	// Empty URL must fail closed rather than defaulting to the public
+	// rekor.sigstore.dev: submission is an egress of checkpoint hash metadata
+	// and must stay inside the operator's declared trust boundary.
+	if _, err := (RekorLog{URL: "", Signer: priv}).Submit(checkpoint); err == nil || !strings.Contains(err.Error(), "rekor anchor URL is required") {
+		t.Fatalf("Submit empty URL err = %v, want required-URL error", err)
+	}
+	if _, err := (RekorLog{URL: "   ", Signer: priv}).Submit(checkpoint); err == nil || !strings.Contains(err.Error(), "rekor anchor URL is required") {
+		t.Fatalf("Submit blank URL err = %v, want required-URL error", err)
+	}
 	listener, err := new(net.ListenConfig).Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Listen: %v", err)

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -72,7 +72,7 @@ verify Rekor bundles with pipelock-verifier independent --rekor-log-key.`,
 	cmd.Flags().StringVar(&opts.backend, "backend", anchorpkg.LocalBackend, "anchor backend: local or rekor")
 	cmd.Flags().StringVar(&opts.logPath, "local-log", "", "local fake-log JSONL path (required for local backend)")
 	cmd.Flags().StringVar(&opts.logID, "log-id", anchorpkg.DefaultLocalLogID, "local fake-log identifier")
-	cmd.Flags().StringVar(&opts.rekorURL, "rekor-url", anchorpkg.DefaultRekorURL, "Rekor base URL")
+	cmd.Flags().StringVar(&opts.rekorURL, "rekor-url", "", "Rekor base URL (required for the rekor backend; no public default so receipt metadata stays in your trust boundary)")
 	cmd.Flags().StringVar(&opts.rekorKey, "rekor-key", "", "Ed25519 private key file used to sign the Rekor checkpoint entry")
 	cmd.Flags().BoolVar(&opts.rekorYes, "yes-send-to-remote-log", false, "acknowledge Rekor anchoring sends checkpoint material to the configured remote log")
 	cmd.Flags().StringVar(&opts.output, "out", "", "anchor bundle output path")
@@ -257,6 +257,11 @@ func resolveBackend(opts receiptsOptions) (anchorpkg.Backend, error) {
 		}
 		return anchorpkg.LocalLog{Path: opts.logPath, LogID: opts.logID}, nil
 	case anchorpkg.RekorBackend:
+		if strings.TrimSpace(opts.rekorURL) == "" {
+			return nil, fmt.Errorf("--rekor-url is required for the rekor anchor backend; " +
+				"point it at your own transparency log (there is no public default, so receipt " +
+				"metadata is never silently sent to a public log)")
+		}
 		if strings.TrimSpace(opts.rekorKey) == "" {
 			return nil, fmt.Errorf("--rekor-key is required for the rekor anchor backend")
 		}

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -242,6 +242,26 @@ func TestReceiptsCmdRequiresLocalLogAndOutput(t *testing.T) {
 	}
 }
 
+func TestReceiptsCmdRequiresRekorURL(t *testing.T) {
+	receiptsPath, keyHex := cliReceiptJSONL(t)
+	dir := t.TempDir()
+	cmd := receiptsCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	// Rekor backend with a key and the remote acknowledgement but NO --rekor-url
+	// must fail closed rather than silently defaulting to the public log.
+	cmd.SetArgs([]string{
+		receiptsPath,
+		"--key", keyHex,
+		"--backend", anchorpkg.RekorBackend,
+		"--rekor-key", writeRekorKey(t, dir),
+		"--yes-send-to-remote-log",
+		"--out", filepath.Join(filepath.Dir(receiptsPath), "bundle.json"),
+	})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--rekor-url is required") {
+		t.Fatalf("Execute err = %v, want Rekor URL error", err)
+	}
+}
+
 func TestReceiptsCmdRequiresRekorKey(t *testing.T) {
 	receiptsPath, keyHex := cliReceiptJSONL(t)
 	cmd := receiptsCmd()
@@ -250,6 +270,7 @@ func TestReceiptsCmdRequiresRekorKey(t *testing.T) {
 		receiptsPath,
 		"--key", keyHex,
 		"--backend", anchorpkg.RekorBackend,
+		"--rekor-url", "https://rekor.internal.example",
 		"--out", filepath.Join(filepath.Dir(receiptsPath), "bundle.json"),
 	})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--rekor-key is required") {
@@ -266,6 +287,7 @@ func TestReceiptsCmdRequiresRekorRemoteAcknowledgement(t *testing.T) {
 		receiptsPath,
 		"--key", keyHex,
 		"--backend", anchorpkg.RekorBackend,
+		"--rekor-url", "https://rekor.internal.example",
 		"--rekor-key", writeRekorKey(t, dir),
 		"--out", filepath.Join(filepath.Dir(receiptsPath), "bundle.json"),
 	})

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -34,8 +34,10 @@ import (
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/applycache"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/emergency"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/rules"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
@@ -763,6 +765,8 @@ func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 	oldCfg.Sandbox.Workspace = "/tmp/pipelock-sandbox"
 	oldCfg.LicenseFile = "/etc/pipelock/license.token"
 	oldCfg.ApplyDefaults()
+	expectedLocal := oldCfg.Clone()
+	rules.MergeIntoConfig(expectedLocal, cliutil.Version)
 
 	// Enforcement-only bundle: policy bundles may carry only enforcement-policy
 	// sections (default-deny allowlist), so flight_recorder/conductor/etc. are
@@ -830,11 +834,11 @@ func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 	if !reflect.DeepEqual(live.Sandbox, oldCfg.Sandbox) {
 		t.Fatalf("sandbox config = %+v, want preserved %+v", live.Sandbox, oldCfg.Sandbox)
 	}
-	if !reflect.DeepEqual(live.DLP, oldCfg.DLP) {
-		t.Fatalf("dlp config = %+v, want preserved %+v", live.DLP, oldCfg.DLP)
+	if !reflect.DeepEqual(live.DLP, expectedLocal.DLP) {
+		t.Fatalf("dlp config = %+v, want preserved %+v", live.DLP, expectedLocal.DLP)
 	}
-	if !reflect.DeepEqual(live.ResponseScanning, oldCfg.ResponseScanning) {
-		t.Fatalf("response_scanning = %+v, want preserved %+v", live.ResponseScanning, oldCfg.ResponseScanning)
+	if !reflect.DeepEqual(live.ResponseScanning, expectedLocal.ResponseScanning) {
+		t.Fatalf("response_scanning = %+v, want preserved %+v", live.ResponseScanning, expectedLocal.ResponseScanning)
 	}
 	if !reflect.DeepEqual(live.RequestBodyScanning, oldCfg.RequestBodyScanning) {
 		t.Fatalf("request_body_scanning = %+v, want preserved %+v", live.RequestBodyScanning, oldCfg.RequestBodyScanning)

--- a/internal/cli/runtime/server_require_receipts_test.go
+++ b/internal/cli/runtime/server_require_receipts_test.go
@@ -45,6 +45,12 @@ func TestNewServer_RequireReceiptsWithoutEmitterFailsClosed(t *testing.T) {
 				"flight_recorder:",
 				"  enabled: true",
 				"  require_receipts: true",
+				// sign_checkpoints: false isolates this case to the
+				// require_receipts guard: without it, the recorder's own
+				// sign-without-a-key fail-closed fires first (its own test).
+				// require_receipts still fails here because no signing key means
+				// no live signed receipt emitter.
+				"  sign_checkpoints: false",
 				"  dir: " + strconv.Quote(t.TempDir()),
 			},
 		},

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -45,7 +45,7 @@ func writeServerTestConfig(t *testing.T, content string) string {
 	return path
 }
 
-func installServerTestStandardBundle(t *testing.T, xdgDataHome string) {
+func installServerTestStandardBundle(t *testing.T, xdgDataHome string, includeResponse bool) {
 	t.Helper()
 
 	pub, priv, err := ed25519.GenerateKey(nil)
@@ -78,7 +78,9 @@ rules:
     confidence: high
     pattern:
       regex: 'test-anthropic-[A-Za-z0-9]{8,}'
-  - id: response-new-instructions
+`
+	if includeResponse {
+		bundleYAML += `  - id: response-new-instructions
     type: injection
     status: stable
     name: New Instructions
@@ -88,6 +90,7 @@ rules:
     pattern:
       regex: '(?i)test-new-instructions'
 `
+	}
 	bundlePath := filepath.Join(bundleDir, "bundle.yaml")
 	if err := os.WriteFile(bundlePath, []byte(bundleYAML), 0o600); err != nil {
 		t.Fatalf("write bundle.yaml: %v", err)
@@ -96,8 +99,14 @@ rules:
 	if err != nil {
 		t.Fatalf("sign bundle.yaml: %v", err)
 	}
-	if err := signing.SaveSignature(sig, bundlePath+signing.SigExtension); err != nil {
+	sigPath := bundlePath + signing.SigExtension
+	if err := signing.SaveSignature(sig, sigPath); err != nil {
 		t.Fatalf("save bundle signature: %v", err)
+	}
+	// Keep the generated signature owner-only (project file-perm convention);
+	// SaveSignature writes 0o644 and this is a test fixture in a temp dir.
+	if err := os.Chmod(sigPath, 0o600); err != nil {
+		t.Fatalf("chmod bundle signature: %v", err)
 	}
 	sum := sha256.Sum256([]byte(bundleYAML))
 	if err := rules.WriteLockFile(filepath.Join(bundleDir, "bundle.lock"), &rules.LockFile{
@@ -1114,18 +1123,20 @@ func TestServer_Reload_StrictRejectsActionDowngrade(t *testing.T) {
 func TestServer_Reload_StrictAllowsRuleBundleResolvedReloadAndRejectsRealDowngrade(t *testing.T) {
 	xdgDataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", xdgDataHome)
-	installServerTestStandardBundle(t, xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
 
 	s, _ := newTestServer(t, func(o *ServerOpts) {
 		o.Mode = config.ModeStrict
 		o.ModeChanged = true
 	})
 	oldLive := s.proxy.CurrentConfig()
+	// Prove the SIGNED standard bundle was actually selected, not that compiled
+	// defaults (also nonzero) masked a discovery/signature/keyring failure: the
+	// fixture's replacement patterns must be present with the bundle name and
+	// the fixture regexes.
+	requireBundlePatternSelected(t, oldLive.DLP.Patterns, oldLive.ResponseScanning.Patterns)
 	oldDLPCount := len(oldLive.DLP.Patterns)
 	oldResponseCount := len(oldLive.ResponseScanning.Patterns)
-	if oldDLPCount == 0 || oldResponseCount == 0 {
-		t.Fatalf("test bundle startup produced empty pattern sets: dlp=%d response=%d", oldDLPCount, oldResponseCount)
-	}
 
 	rotated := oldLive.Clone()
 	rotated.KillSwitch.APIToken = "rotated-token"
@@ -1157,7 +1168,7 @@ func TestServer_Reload_StrictAllowsRuleBundleResolvedReloadAndRejectsRealDowngra
 func TestServer_Reload_StrictWithRuleBundleRejectsResponsePatternRemoval(t *testing.T) {
 	xdgDataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", xdgDataHome)
-	installServerTestStandardBundle(t, xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
 
 	cfgPath := writeServerTestConfig(t, strings.Join([]string{
 		"mode: strict",
@@ -1193,6 +1204,76 @@ func TestServer_Reload_StrictWithRuleBundleRejectsResponsePatternRemoval(t *test
 	}
 	if !buf.contains("response_scanning.patterns") {
 		t.Fatalf("stderr missing response pattern downgrade warning:\n%s", buf.String())
+	}
+}
+
+// TestServer_StartupPartialStandardBundleKeepsResponseFallback proves the
+// per-surface fix (AF-81 / CodeRabbit): a standard bundle that provides ONLY
+// DLP patterns must NOT empty the response-scanning surface. Before the fix a
+// single "standard bundle loaded" flag stripped the compiled response fallback
+// and left response scanning empty (a fail-open detection loss).
+func TestServer_StartupPartialStandardBundleKeepsResponseFallback(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, false) // DLP-only standard bundle
+
+	s, _ := newTestServer(t, nil)
+	live := s.proxy.CurrentConfig()
+
+	// DLP came from the bundle...
+	if p, ok := dlpByName(live.DLP.Patterns, "Anthropic API Key"); !ok || p.Bundle != rules.StandardBundleName {
+		t.Fatalf("DLP Anthropic API Key not from the standard bundle: %+v ok=%v", p, ok)
+	}
+	// ...but the response surface, which the bundle did NOT provide, keeps its
+	// compiled fallback instead of being emptied.
+	if len(live.ResponseScanning.Patterns) == 0 {
+		t.Fatal("DLP-only standard bundle emptied the response patterns — fail-open detection loss")
+	}
+	if !hasResponsePatternNamed(live.ResponseScanning.Patterns, "New Instructions") {
+		t.Fatal("compiled response fallback (New Instructions) missing after a DLP-only standard bundle")
+	}
+	for _, p := range live.ResponseScanning.Patterns {
+		if p.Bundle == rules.StandardBundleName {
+			t.Fatalf("response pattern %q claims the standard bundle, but the bundle provided no response rules", p.Name)
+		}
+	}
+}
+
+func dlpByName(patterns []config.DLPPattern, name string) (config.DLPPattern, bool) {
+	for _, p := range patterns {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return config.DLPPattern{}, false
+}
+
+// requireBundlePatternSelected proves the signed test standard bundle (installed
+// by installServerTestStandardBundle) was actually selected: the fixture's DLP
+// "Anthropic API Key" and response "New Instructions" replacements must be
+// present, sourced from the standard bundle, with the fixture regexes.
+func requireBundlePatternSelected(t *testing.T, dlp []config.DLPPattern, resp []config.ResponseScanPattern) {
+	t.Helper()
+	var dlpOK bool
+	for _, p := range dlp {
+		if p.Name == "Anthropic API Key" {
+			if p.Bundle != rules.StandardBundleName || p.Regex != "test-anthropic-[A-Za-z0-9]{8,}" {
+				t.Fatalf("DLP %q not from the standard bundle: bundle=%q regex=%q", p.Name, p.Bundle, p.Regex)
+			}
+			dlpOK = true
+		}
+	}
+	var respOK bool
+	for _, p := range resp {
+		if p.Name == "New Instructions" {
+			if p.Bundle != rules.StandardBundleName || p.Regex != "(?i)test-new-instructions" {
+				t.Fatalf("response %q not from the standard bundle: bundle=%q regex=%q", p.Name, p.Bundle, p.Regex)
+			}
+			respOK = true
+		}
+	}
+	if !dlpOK || !respOK {
+		t.Fatalf("standard bundle not selected: dlpSelected=%v responseSelected=%v", dlpOK, respOK)
 	}
 }
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -6,6 +6,9 @@ package runtime
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"os"
 	"path/filepath"
@@ -19,6 +22,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	mcptools "github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/rules"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
@@ -39,6 +43,81 @@ func writeServerTestConfig(t *testing.T, content string) string {
 		t.Fatalf("write config: %v", err)
 	}
 	return path
+}
+
+func installServerTestStandardBundle(t *testing.T, xdgDataHome string) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate bundle signing key: %v", err)
+	}
+	oldKeyring := rules.KeyringHex
+	rules.KeyringHex = strings.Join(nonEmptyStrings(oldKeyring, hex.EncodeToString(pub)), ",")
+	t.Cleanup(func() {
+		rules.KeyringHex = oldKeyring
+	})
+
+	bundleDir := filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName)
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("mkdir rules bundle dir: %v", err)
+	}
+	bundleYAML := `format_version: 1
+name: pipelock-standard
+version: "2026.07.0"
+author: Test Author
+description: Test standard bundle
+license: Apache-2.0
+rules:
+  - id: dlp-anthropic-api-key
+    type: dlp
+    status: stable
+    name: Anthropic API Key
+    description: Replaces the compiled standard Anthropic key pattern
+    severity: critical
+    confidence: high
+    pattern:
+      regex: 'test-anthropic-[A-Za-z0-9]{8,}'
+  - id: response-new-instructions
+    type: injection
+    status: stable
+    name: New Instructions
+    description: Replaces the compiled standard response instruction pattern
+    severity: high
+    confidence: high
+    pattern:
+      regex: '(?i)test-new-instructions'
+`
+	bundlePath := filepath.Join(bundleDir, "bundle.yaml")
+	if err := os.WriteFile(bundlePath, []byte(bundleYAML), 0o600); err != nil {
+		t.Fatalf("write bundle.yaml: %v", err)
+	}
+	sig, err := signing.SignFile(bundlePath, priv)
+	if err != nil {
+		t.Fatalf("sign bundle.yaml: %v", err)
+	}
+	if err := signing.SaveSignature(sig, bundlePath+signing.SigExtension); err != nil {
+		t.Fatalf("save bundle signature: %v", err)
+	}
+	sum := sha256.Sum256([]byte(bundleYAML))
+	if err := rules.WriteLockFile(filepath.Join(bundleDir, "bundle.lock"), &rules.LockFile{
+		InstalledVersion:  "2026.07.0",
+		Source:            "test",
+		BundleSHA256:      hex.EncodeToString(sum[:]),
+		SignerFingerprint: rules.KeyFingerprint(pub),
+	}); err != nil {
+		t.Fatalf("write bundle.lock: %v", err)
+	}
+}
+
+func nonEmptyStrings(values ...string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 func TestNeedsHITLApprover(t *testing.T) {
@@ -1030,6 +1109,110 @@ func TestServer_Reload_StrictRejectsActionDowngrade(t *testing.T) {
 	if !buf.contains("response_scanning.action") {
 		t.Fatalf("stderr missing action downgrade warning:\n%s", buf.String())
 	}
+}
+
+func TestServer_Reload_StrictAllowsRuleBundleResolvedReloadAndRejectsRealDowngrade(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome)
+
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.Mode = config.ModeStrict
+		o.ModeChanged = true
+	})
+	oldLive := s.proxy.CurrentConfig()
+	oldDLPCount := len(oldLive.DLP.Patterns)
+	oldResponseCount := len(oldLive.ResponseScanning.Patterns)
+	if oldDLPCount == 0 || oldResponseCount == 0 {
+		t.Fatalf("test bundle startup produced empty pattern sets: dlp=%d response=%d", oldDLPCount, oldResponseCount)
+	}
+
+	rotated := oldLive.Clone()
+	rotated.KillSwitch.APIToken = "rotated-token"
+	if err := s.Reload(rotated); err != nil {
+		t.Fatalf("strict reload with installed standard bundle should not error, got: %v", err)
+	}
+	live := s.proxy.CurrentConfig()
+	if len(live.DLP.Patterns) != oldDLPCount {
+		t.Fatalf("DLP patterns changed after idempotent reload: got %d, want %d", len(live.DLP.Patterns), oldDLPCount)
+	}
+	if len(live.ResponseScanning.Patterns) != oldResponseCount {
+		t.Fatalf("response patterns changed after idempotent reload: got %d, want %d", len(live.ResponseScanning.Patterns), oldResponseCount)
+	}
+	if live.KillSwitch.APIToken != "rotated-token" {
+		t.Fatalf("api_token = %q, want rotated-token", live.KillSwitch.APIToken)
+	}
+
+	s.lastReloadAt = time.Time{}
+	downgraded := live.Clone()
+	downgraded.Mode = config.ModeBalanced
+	if err := s.Reload(downgraded); err == nil || !strings.Contains(err.Error(), "security downgrade") {
+		t.Fatalf("strict mode downgrade error = %v, want security downgrade rejection", err)
+	}
+	if got := s.proxy.CurrentConfig().Mode; got != config.ModeStrict {
+		t.Fatalf("live mode after rejected downgrade = %q, want %q", got, config.ModeStrict)
+	}
+}
+
+func TestServer_Reload_StrictWithRuleBundleRejectsResponsePatternRemoval(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome)
+
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: strict",
+		"api_allowlist:",
+		"  - api.vendor.example",
+		"response_scanning:",
+		"  patterns:",
+		"    - name: Local Guard",
+		"      regex: '(?i)local-response-downgrade-sentinel'",
+		"",
+	}, "\n"))
+	s, buf := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+	})
+	oldScanner := s.proxy.ScannerPtr().Load()
+	live := s.proxy.CurrentConfig()
+	if !hasResponsePatternNamed(live.ResponseScanning.Patterns, "Local Guard") {
+		t.Fatal("test setup missing local response pattern")
+	}
+
+	downgraded := live.Clone()
+	downgraded.ResponseScanning.Patterns = removeResponsePatternByName(downgraded.ResponseScanning.Patterns, "Local Guard")
+	buf.reset()
+	err := s.Reload(downgraded)
+	if err == nil || !strings.Contains(err.Error(), "security downgrade") {
+		t.Fatalf("strict response pattern removal error = %v, want security downgrade rejection", err)
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("scanner swapped despite rejected response pattern removal")
+	}
+	if !hasResponsePatternNamed(s.proxy.CurrentConfig().ResponseScanning.Patterns, "Local Guard") {
+		t.Fatal("rejected reload removed local response pattern from live config")
+	}
+	if !buf.contains("response_scanning.patterns") {
+		t.Fatalf("stderr missing response pattern downgrade warning:\n%s", buf.String())
+	}
+}
+
+func hasResponsePatternNamed(patterns []config.ResponseScanPattern, name string) bool {
+	for _, p := range patterns {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func removeResponsePatternByName(patterns []config.ResponseScanPattern, name string) []config.ResponseScanPattern {
+	out := make([]config.ResponseScanPattern, 0, len(patterns))
+	for _, p := range patterns {
+		if p.Name != name {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func TestServer_Reload_BalancedAllowsActionTuningWithWarning(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3900,6 +3900,34 @@ func TestValidateReload_DLPPatternRenamed_WarnsAsRemoval(t *testing.T) {
 	}
 }
 
+func TestValidateReload_ResponsePatternRemovedOrRegexSwapped_Warns(t *testing.T) {
+	old := &Config{ResponseScanning: ResponseScanning{Patterns: []ResponseScanPattern{
+		{Name: "Custom Injection", Regex: `(?i)ignore all safety rules`},
+		{Name: "Stable Injection", Regex: `(?i)stable-injection`},
+	}}}
+	updated := &Config{ResponseScanning: ResponseScanning{Patterns: []ResponseScanPattern{
+		{Name: "Custom Injection", Regex: `(?i)ignore`},
+	}}}
+
+	warnings := ValidateReload(old, updated)
+	found := false
+	for _, w := range warnings {
+		if w.Field != "response_scanning.patterns" {
+			continue
+		}
+		found = true
+		if !strings.Contains(w.Message, "Custom Injection (regex changed)") {
+			t.Errorf("warning should name swapped response pattern, got: %s", w.Message)
+		}
+		if !strings.Contains(w.Message, "Stable Injection") {
+			t.Errorf("warning should name removed response pattern, got: %s", w.Message)
+		}
+	}
+	if !found {
+		t.Fatal("expected warning when response patterns are removed or regex-swapped on reload")
+	}
+}
+
 // TestValidateReload_DLPIncludeDefaultsFlipLosesPatterns_BothSignalsFire
 // pins the defense-in-depth contract flagged on PR #433: when
 // include_defaults flips true -> false and the post-merge pattern

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -1422,38 +1422,37 @@ func checkEscalationWeakening(old, updated *EscalationLevels, warnings *[]Reload
 // also triggers a warning; operators can resolve by reviewing the diff,
 // which is the point. Renames appear as both a removal (old name) and an
 // implicit add (new name), which the reload surface does not warn about.
-func removedOrWeakenedDLPPatterns(old, updated []DLPPattern) []string {
+// removedOrWeakenedPatterns is the shared name+regex reload-downgrade diff for
+// any named-regex pattern set (DLP, response scanning). One helper so the two
+// security surfaces cannot drift: a pattern present in old but absent in
+// updated is "removed", and a matching name with a changed regex is "regex
+// changed". Both are downgrades a strict reload rejects.
+func removedOrWeakenedPatterns[T any](old, updated []T, nameOf, regexOf func(T) string) []string {
 	updatedByName := make(map[string]string, len(updated))
 	for _, p := range updated {
-		updatedByName[p.Name] = p.Regex
+		updatedByName[nameOf(p)] = regexOf(p)
 	}
 	var changed []string
 	for _, p := range old {
-		newRegex, ok := updatedByName[p.Name]
+		newRegex, ok := updatedByName[nameOf(p)]
 		switch {
 		case !ok:
-			changed = append(changed, p.Name)
-		case newRegex != p.Regex:
-			changed = append(changed, p.Name+" (regex changed)")
+			changed = append(changed, nameOf(p))
+		case newRegex != regexOf(p):
+			changed = append(changed, nameOf(p)+" (regex changed)")
 		}
 	}
 	return changed
 }
 
+func removedOrWeakenedDLPPatterns(old, updated []DLPPattern) []string {
+	return removedOrWeakenedPatterns(old, updated,
+		func(p DLPPattern) string { return p.Name },
+		func(p DLPPattern) string { return p.Regex })
+}
+
 func removedOrWeakenedResponsePatterns(old, updated []ResponseScanPattern) []string {
-	updatedByName := make(map[string]string, len(updated))
-	for _, p := range updated {
-		updatedByName[p.Name] = p.Regex
-	}
-	var changed []string
-	for _, p := range old {
-		newRegex, ok := updatedByName[p.Name]
-		switch {
-		case !ok:
-			changed = append(changed, p.Name)
-		case newRegex != p.Regex:
-			changed = append(changed, p.Name+" (regex changed)")
-		}
-	}
-	return changed
+	return removedOrWeakenedPatterns(old, updated,
+		func(p ResponseScanPattern) string { return p.Name },
+		func(p ResponseScanPattern) string { return p.Regex })
 }

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -51,6 +51,12 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 			Message: "DLP patterns removed or regex-swapped on reload: " + strings.Join(removed, ", "),
 		})
 	}
+	if removed := removedOrWeakenedResponsePatterns(old.ResponseScanning.Patterns, updated.ResponseScanning.Patterns); len(removed) > 0 {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "response_scanning.patterns",
+			Message: "response scanning patterns removed or regex-swapped on reload: " + strings.Join(removed, ", "),
+		})
+	}
 
 	// DLP include_defaults disabled
 	oldInclude := old.DLP.IncludeDefaults == nil || *old.DLP.IncludeDefaults
@@ -1417,6 +1423,24 @@ func checkEscalationWeakening(old, updated *EscalationLevels, warnings *[]Reload
 // which is the point. Renames appear as both a removal (old name) and an
 // implicit add (new name), which the reload surface does not warn about.
 func removedOrWeakenedDLPPatterns(old, updated []DLPPattern) []string {
+	updatedByName := make(map[string]string, len(updated))
+	for _, p := range updated {
+		updatedByName[p.Name] = p.Regex
+	}
+	var changed []string
+	for _, p := range old {
+		newRegex, ok := updatedByName[p.Name]
+		switch {
+		case !ok:
+			changed = append(changed, p.Name)
+		case newRegex != p.Regex:
+			changed = append(changed, p.Name+" (regex changed)")
+		}
+	}
+	return changed
+}
+
+func removedOrWeakenedResponsePatterns(old, updated []ResponseScanPattern) []string {
 	updatedByName := make(map[string]string, len(updated))
 	for _, p := range updated {
 		updatedByName[p.Name] = p.Regex

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -176,6 +176,25 @@ func New(cfg Config, redactFn RedactFunc, privKey ed25519.PrivateKey) (*Recorder
 	if !cfg.Enabled {
 		return &Recorder{nop: true}, nil
 	}
+	if strings.TrimSpace(cfg.Dir) == "" {
+		return &Recorder{nop: true}, nil
+	}
+
+	// Fail closed on the sign-without-a-key footgun: SignCheckpoints defaults on,
+	// so a persisted recorder (Dir set) with no signing key would silently write
+	// checkpoints carrying an EMPTY signature — records that VerifyCheckpoints
+	// later rejects as "missing signature", and that mislead an operator who
+	// believes signing is active. Refuse to construct such a recorder so the
+	// signed-vs-unsigned choice is explicit. Blank Dir returned a no-op above:
+	// callers that never persist (e.g. the default MCP proxy path) are
+	// unaffected, and the key-load path already fails closed on a
+	// set-but-unloadable key upstream, so a nil key here means no key was
+	// configured at all.
+	if cfg.SignCheckpoints && privKey == nil {
+		return nil, fmt.Errorf("flight recorder sign_checkpoints is enabled but no signing key was provided; " +
+			"set flight_recorder.signing_key_path, or set flight_recorder.sign_checkpoints: false for an " +
+			"unsigned hash-chained recorder")
+	}
 
 	if cfg.CheckpointInterval <= 0 {
 		cfg.CheckpointInterval = defaultCheckpointInterval

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -190,8 +190,11 @@ func New(cfg Config, redactFn RedactFunc, privKey ed25519.PrivateKey) (*Recorder
 	// unaffected, and the key-load path already fails closed on a
 	// set-but-unloadable key upstream, so a nil key here means no key was
 	// configured at all.
-	if cfg.SignCheckpoints && privKey == nil {
-		return nil, fmt.Errorf("flight recorder sign_checkpoints is enabled but no signing key was provided; " +
+	// Validate the key LENGTH, not just non-nil: ed25519.PrivateKey is a byte
+	// slice, so a non-nil zero-length or truncated key would pass a bare nil
+	// check and then panic (or produce an unverifiable signature) at sign time.
+	if cfg.SignCheckpoints && len(privKey) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("flight recorder sign_checkpoints is enabled but no valid signing key was provided; " +
 			"set flight_recorder.signing_key_path, or set flight_recorder.sign_checkpoints: false for an " +
 			"unsigned hash-chained recorder")
 	}

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -2218,6 +2218,18 @@ func TestNew_SignCheckpointsWithoutKeyFailsClosed(t *testing.T) {
 		}
 	})
 
+	t.Run("dir set, sign on, wrong-length key -> error", func(t *testing.T) {
+		// A non-nil but truncated key must be rejected too: it would pass a bare
+		// nil check and then panic (or sign unverifiably) at checkpoint time.
+		_, err := recorder.New(recorder.Config{Enabled: true, Dir: t.TempDir(), SignCheckpoints: true}, nil, ed25519.PrivateKey{1, 2, 3})
+		if err == nil {
+			t.Fatal("expected error for a wrong-length signing key")
+		}
+		if !strings.Contains(err.Error(), "sign_checkpoints") {
+			t.Fatalf("error = %q, want it to mention sign_checkpoints", err)
+		}
+	})
+
 	t.Run("dir set, sign on, key provided -> ok", func(t *testing.T) {
 		rec, err := recorder.New(recorder.Config{Enabled: true, Dir: t.TempDir(), SignCheckpoints: true}, nil, priv)
 		if err != nil {

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -2195,3 +2195,81 @@ type panicEntryObserver struct{}
 func (panicEntryObserver) ObserveRecorderEntry(recorder.Entry) {
 	panic("observer panic")
 }
+
+// TestNew_SignCheckpointsWithoutKeyFailsClosed pins the sign-without-a-key
+// footgun: SignCheckpoints defaults on, so a persisted recorder with no signing
+// key would silently write empty-signature checkpoints that later verification
+// rejects as "missing signature". New must refuse to build such a recorder,
+// while still allowing the two honest configurations (a real key, or an
+// explicitly unsigned recorder) and the non-persisting default (Dir == "").
+func TestNew_SignCheckpointsWithoutKeyFailsClosed(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	t.Run("dir set, sign on, no key -> error", func(t *testing.T) {
+		_, err := recorder.New(recorder.Config{Enabled: true, Dir: t.TempDir(), SignCheckpoints: true}, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for sign_checkpoints without a signing key")
+		}
+		if !strings.Contains(err.Error(), "sign_checkpoints") {
+			t.Fatalf("error = %q, want it to mention sign_checkpoints", err)
+		}
+	})
+
+	t.Run("dir set, sign on, key provided -> ok", func(t *testing.T) {
+		rec, err := recorder.New(recorder.Config{Enabled: true, Dir: t.TempDir(), SignCheckpoints: true}, nil, priv)
+		if err != nil {
+			t.Fatalf("New with key: %v", err)
+		}
+		_ = rec.Close()
+	})
+
+	t.Run("dir set, sign explicitly off, no key -> ok (unsigned recorder)", func(t *testing.T) {
+		rec, err := recorder.New(recorder.Config{Enabled: true, Dir: t.TempDir(), SignCheckpoints: false}, nil, nil)
+		if err != nil {
+			t.Fatalf("New unsigned: %v", err)
+		}
+		_ = rec.Close()
+	})
+
+	t.Run("no dir, sign on, no key -> ok (non-persisting)", func(t *testing.T) {
+		rec, err := recorder.New(recorder.Config{Enabled: true, Dir: "", SignCheckpoints: true}, nil, nil)
+		if err != nil {
+			t.Fatalf("New non-persisting: %v", err)
+		}
+		_ = rec.Close()
+	})
+
+	t.Run("no dir, sign on, no key -> no cwd persistence", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+
+		rec, err := recorder.New(recorder.Config{Enabled: true, Dir: " \t", SignCheckpoints: true}, nil, nil)
+		if err != nil {
+			t.Fatalf("New non-persisting: %v", err)
+		}
+		if err := rec.Record(recorder.Entry{
+			SessionID: "empty-dir",
+			Type:      "decision",
+			Summary:   "should be discarded",
+		}); err != nil {
+			t.Fatalf("Record non-persisting: %v", err)
+		}
+		if err := rec.Close(); err != nil {
+			t.Fatalf("Close non-persisting: %v", err)
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("ReadDir: %v", err)
+		}
+		if len(entries) != 0 {
+			names := make([]string, 0, len(entries))
+			for _, entry := range entries {
+				names = append(names, entry.Name())
+			}
+			t.Fatalf("non-persisting recorder wrote files in cwd: %v", names)
+		}
+	})
+}

--- a/internal/rules/bundle.go
+++ b/internal/rules/bundle.go
@@ -409,14 +409,14 @@ func CheckMinPipelock(minVersion, currentVersion string) error {
 	}
 	curSemver, err := parseSemverVersion(currentVersion)
 	if err != nil {
-		// A current version that is not orderable semver is a development build
-		// (a `git describe` string like "2-147-gabc1234", a `go install`
-		// pseudo-version, or an unset build). It carries no release number to
-		// compare against, so treat it as newest and let the bundle load. A real
-		// tagged release always carries a clean major.minor.patch, so this never
-		// weakens the minimum gate for a shipped release. (minVersion is still
-		// parsed strictly above, so a malformed bundle min_pipelock still errors.)
-		return nil
+		// Not orderable semver AND not a recognized development build
+		// (isDevelopmentCurrentVersion above already returned true for those:
+		// git-describe strings, `-dev`, `devel`, unset). A version that reaches
+		// here is genuinely malformed, so fail CLOSED (skip the bundle) rather
+		// than treating it as newest — a mis-stamped binary must not silently
+		// load bundles requiring a newer Pipelock. minVersion is parsed strictly
+		// above, so a malformed bundle min_pipelock still errors too.
+		return fmt.Errorf("check min pipelock: unrecognized current version %q (not a release or a known development build)", currentVersion)
 	}
 
 	if compareSemverVersion(curSemver, minSemver) < 0 {
@@ -499,25 +499,27 @@ func prereleaseHasIdentifier(prerelease, ident string) bool {
 	return false
 }
 
+// isGitDescribeVersion recognizes a `git describe --tags` string by its SHAPE:
+// "<tag>-<commits>-g<shorthash>" (e.g. "v3.0.0-146-gabc1234" or "2-147-gf1c242a0"
+// with a bare-number tag). It keys off the trailing "-<digits>-g<hex>" so a
+// source/CI build is recognized regardless of the tag's own format. It does NOT
+// match arbitrary malformed strings ("abc") or Go pseudo-versions (whose short
+// hash carries no "g" prefix); those fall through to strict parsing and fail
+// closed rather than being treated as a dev build.
 func isGitDescribeVersion(s string) bool {
-	core, rest, ok := strings.Cut(s, "-")
-	if !ok {
+	parts := strings.Split(s, "-")
+	if len(parts) < 3 {
 		return false
 	}
-	if _, _, _, err := parseSemver(core); err != nil {
+	commits := parts[len(parts)-2]
+	shorthash := parts[len(parts)-1]
+	if _, err := strconv.ParseUint(commits, 10, 64); err != nil {
 		return false
 	}
-	parts := strings.Split(rest, "-")
-	if len(parts) < 2 {
+	if !strings.HasPrefix(shorthash, "g") || len(shorthash) == 1 {
 		return false
 	}
-	if _, err := strconv.ParseUint(parts[0], 10, 64); err != nil {
-		return false
-	}
-	if !strings.HasPrefix(parts[1], "g") || len(parts[1]) == 1 {
-		return false
-	}
-	return isHexString(parts[1][1:])
+	return isHexString(shorthash[1:])
 }
 
 func isHexString(s string) bool {

--- a/internal/rules/bundle.go
+++ b/internal/rules/bundle.go
@@ -394,61 +394,185 @@ func NamespacedID(bundleName, ruleID string) string {
 
 // CheckMinPipelock verifies that currentVersion meets the minimum required
 // pipelock version. If minVersion is empty, the check always passes.
-// Both versions are parsed as semver (major.minor.patch), with any
-// pre-release/build suffix (after first "-" or "+") stripped before comparison.
 func CheckMinPipelock(minVersion, currentVersion string) error {
 	if minVersion == "" {
 		return nil
 	}
 
-	minMajor, minMinor, minPatch, err := parseSemver(minVersion)
+	minSemver, err := parseSemverVersion(minVersion)
 	if err != nil {
 		return fmt.Errorf("check min pipelock: invalid min_pipelock %q: %w", minVersion, err)
 	}
 
-	curMajor, curMinor, curPatch, err := parseSemver(currentVersion)
+	if isDevelopmentCurrentVersion(currentVersion) {
+		return nil
+	}
+	curSemver, err := parseSemverVersion(currentVersion)
 	if err != nil {
-		return fmt.Errorf("check min pipelock: invalid current version %q: %w", currentVersion, err)
+		// A current version that is not orderable semver is a development build
+		// (a `git describe` string like "2-147-gabc1234", a `go install`
+		// pseudo-version, or an unset build). It carries no release number to
+		// compare against, so treat it as newest and let the bundle load. A real
+		// tagged release always carries a clean major.minor.patch, so this never
+		// weakens the minimum gate for a shipped release. (minVersion is still
+		// parsed strictly above, so a malformed bundle min_pipelock still errors.)
+		return nil
 	}
 
-	if compareSemver(curMajor, curMinor, curPatch, minMajor, minMinor, minPatch) < 0 {
+	if compareSemverVersion(curSemver, minSemver) < 0 {
 		return fmt.Errorf("check min pipelock: current version %q is below minimum %q", currentVersion, minVersion)
 	}
 
 	return nil
 }
 
+type semverVersion struct {
+	major      int
+	minor      int
+	patch      int
+	prerelease string
+}
+
 // parseSemver parses a semver string into major, minor, patch integers.
 // Pre-release/build suffixes (anything after the first "-" or "+") are stripped.
 func parseSemver(s string) (major, minor, patch int, err error) {
+	v, err := parseSemverVersion(s)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return v.major, v.minor, v.patch, nil
+}
+
+func parseSemverVersion(s string) (semverVersion, error) {
 	// Strip "v" prefix (e.g. "v2.1.0" → "2.1.0").
 	s = strings.TrimPrefix(s, "v")
-	// Strip pre-release/build suffix.
-	if idx := strings.IndexAny(s, "-+"); idx >= 0 {
+	prerelease := ""
+	if idx := strings.Index(s, "+"); idx >= 0 {
+		s = s[:idx]
+	}
+	if idx := strings.Index(s, "-"); idx >= 0 {
+		prerelease = s[idx+1:]
 		s = s[:idx]
 	}
 
 	parts := strings.Split(s, ".")
 	if len(parts) != 3 {
-		return 0, 0, 0, fmt.Errorf("expected 3 segments, got %d in %q", len(parts), s)
+		return semverVersion{}, fmt.Errorf("expected 3 segments, got %d in %q", len(parts), s)
 	}
 
-	major, err = strconv.Atoi(parts[0])
+	major, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("invalid major %q: %w", parts[0], err)
+		return semverVersion{}, fmt.Errorf("invalid major %q: %w", parts[0], err)
 	}
 
-	minor, err = strconv.Atoi(parts[1])
+	minor, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("invalid minor %q: %w", parts[1], err)
+		return semverVersion{}, fmt.Errorf("invalid minor %q: %w", parts[1], err)
 	}
 
-	patch, err = strconv.Atoi(parts[2])
+	patch, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("invalid patch %q: %w", parts[2], err)
+		return semverVersion{}, fmt.Errorf("invalid patch %q: %w", parts[2], err)
 	}
 
-	return major, minor, patch, nil
+	return semverVersion{major: major, minor: minor, patch: patch, prerelease: prerelease}, nil
+}
+
+func isDevelopmentCurrentVersion(s string) bool {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "v")
+	if s == "" || s == "devel" || s == "(devel)" {
+		return true
+	}
+	v, err := parseSemverVersion(s)
+	if err == nil && prereleaseHasIdentifier(v.prerelease, "dev") {
+		return true
+	}
+	return isGitDescribeVersion(s)
+}
+
+func prereleaseHasIdentifier(prerelease, ident string) bool {
+	for _, part := range strings.FieldsFunc(prerelease, func(r rune) bool { return r == '.' || r == '-' }) {
+		if strings.EqualFold(part, ident) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGitDescribeVersion(s string) bool {
+	core, rest, ok := strings.Cut(s, "-")
+	if !ok {
+		return false
+	}
+	if _, _, _, err := parseSemver(core); err != nil {
+		return false
+	}
+	parts := strings.Split(rest, "-")
+	if len(parts) < 2 {
+		return false
+	}
+	if _, err := strconv.ParseUint(parts[0], 10, 64); err != nil {
+		return false
+	}
+	if !strings.HasPrefix(parts[1], "g") || len(parts[1]) == 1 {
+		return false
+	}
+	return isHexString(parts[1][1:])
+}
+
+func isHexString(s string) bool {
+	for _, r := range s {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func compareSemverVersion(a, b semverVersion) int {
+	if cmp := compareSemver(a.major, a.minor, a.patch, b.major, b.minor, b.patch); cmp != 0 {
+		return cmp
+	}
+	if a.prerelease == b.prerelease {
+		return 0
+	}
+	if a.prerelease == "" {
+		return 1
+	}
+	if b.prerelease == "" {
+		return -1
+	}
+	return comparePrerelease(a.prerelease, b.prerelease)
+}
+
+func comparePrerelease(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	for i := 0; i < len(aParts) && i < len(bParts); i++ {
+		if aParts[i] == bParts[i] {
+			continue
+		}
+		aNum, aErr := strconv.ParseUint(aParts[i], 10, 64)
+		bNum, bErr := strconv.ParseUint(bParts[i], 10, 64)
+		switch {
+		case aErr == nil && bErr == nil:
+			if aNum < bNum {
+				return -1
+			}
+			if aNum == bNum {
+				continue
+			}
+			return 1
+		case aErr == nil:
+			return -1
+		case bErr == nil:
+			return 1
+		default:
+			return strings.Compare(aParts[i], bParts[i])
+		}
+	}
+	return cmpInt(len(aParts), len(bParts))
 }
 
 // compareSemver returns -1 if a < b, 0 if equal, 1 if a > b.

--- a/internal/rules/bundle_test.go
+++ b/internal/rules/bundle_test.go
@@ -780,12 +780,16 @@ func TestCheckMinPipelock_InvalidVersions(t *testing.T) {
 		minVersion string
 		curVersion string
 	}{
-		// Only a malformed min_pipelock (bundle-authored) is an error. A
-		// malformed CURRENT version is a dev build and passes (covered in
-		// TestCheckMinPipelock as "treated as newest"), so it is intentionally
-		// absent here.
+		// A malformed min_pipelock (bundle-authored) errors. A malformed CURRENT
+		// version that is NOT a recognized development build (git-describe, -dev,
+		// devel, unset) now also fails closed: a mis-stamped binary must not be
+		// treated as newest and silently load bundles requiring a newer Pipelock.
+		// Recognized dev builds still pass — see TestCheckMinPipelock.
 		{"invalid min", "abc", "1.3.0"},
 		{"both invalid falls to min", "abc", "def"},
+		{"malformed current fails closed", "1.3.0", "abc"},
+		{"unrecognized current fails closed", "1.3.0", "not-a-version"},
+		{"pseudo-version zero base below min", "3.0.0", "v0.0.0-20260101000000-abcdef123456"},
 	}
 
 	for _, tc := range tests {

--- a/internal/rules/bundle_test.go
+++ b/internal/rules/bundle_test.go
@@ -737,13 +737,27 @@ func TestCheckMinPipelock(t *testing.T) {
 		{"current below min", "1.4.0", "1.3.0", true},
 		{"major below", "2.0.0", "1.3.0", true},
 		{"major above", "1.0.0", "2.0.0", false},
-		{"pre-release stripped from current", "1.3.0", "1.3.0-rc1", false},
-		{"pre-release stripped from min", "1.3.0-beta", "1.3.0", false},
+		{"pre-release current below final min", "1.3.0", "1.3.0-alpha1", true},
+		{"final current exceeds pre-release min", "1.3.0-beta", "1.3.0", false},
 		{"build metadata stripped from current", "1.3.0", "1.3.0+incompatible", false},
 		{"build metadata stripped from min", "1.3.0+metadata", "1.3.0", false},
 		{"pseudo-version below normal release", "1.0.0", "0.0.0-20260709120000-abcdefabcdef", true},
 		{"patch comparison", "1.3.1", "1.3.0", true},
 		{"patch meets", "1.3.0", "1.3.1", false},
+		{"prerelease below final min", "1.3.0", "1.3.0-beta.1", true},
+		{"prerelease meets same prerelease min", "1.3.0-beta.1", "1.3.0-beta.1", false},
+		{"prerelease numeric ordering below", "1.3.0-beta.10", "1.3.0-beta.2", true},
+		{"prerelease numeric ordering above", "1.3.0-beta.2", "1.3.0-beta.10", false},
+		// A non-semver CURRENT version is a development build (git describe,
+		// go install from source, unset) with no orderable release number, so
+		// it is treated as newest and the bundle loads. A real release always
+		// carries clean semver, so this never weakens the gate for a tagged
+		// release (see the "current below min" cases above, which still error).
+		{"git-describe current treated as newest", "3.0.0", "2-147-gf1c242a0", false},
+		{"tag-distance git-describe current treated as newest", "3.0.0", "2.0.0-147-gf1c242a0", false},
+		{"default source-build current treated as newest", "3.0.0", "0.1.0-dev", false},
+		{"go-install devel current treated as newest", "3.0.0", "devel", false},
+		{"empty current treated as newest", "3.0.0", "", false},
 	}
 
 	for _, tc := range tests {
@@ -766,9 +780,12 @@ func TestCheckMinPipelock_InvalidVersions(t *testing.T) {
 		minVersion string
 		curVersion string
 	}{
+		// Only a malformed min_pipelock (bundle-authored) is an error. A
+		// malformed CURRENT version is a dev build and passes (covered in
+		// TestCheckMinPipelock as "treated as newest"), so it is intentionally
+		// absent here.
 		{"invalid min", "abc", "1.3.0"},
-		{"invalid current", "1.3.0", "abc"},
-		{"both invalid", "abc", "def"},
+		{"both invalid falls to min", "abc", "def"},
 	}
 
 	for _, tc := range tests {

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -69,11 +69,11 @@ func testDLPRule(id, confidence, status string) Rule {
 }
 
 // testInjectionRule creates a valid injection rule.
-func testInjectionRule(id, confidence, status string) Rule {
+func testInjectionRule(id, confidence string) Rule {
 	return Rule{
 		ID:          id,
 		Type:        RuleTypeInjection,
-		Status:      status,
+		Status:      StatusStable,
 		Name:        "Test Injection Rule " + id,
 		Description: "Detects injection pattern " + id,
 		Severity:    severityMedium,
@@ -225,7 +225,7 @@ func TestLoadBundles_ValidUnsignedBundle(t *testing.T) {
 
 	b := testBundle(testBundleName, []Rule{
 		testDLPRule("dlp-rule-001", confidenceHigh, StatusStable),
-		testInjectionRule("inj-rule-001", confidenceMedium, StatusStable),
+		testInjectionRule("inj-rule-001", confidenceMedium),
 		testToolPoisonRule("tp-rule-001", confidenceHigh, StatusStable, scanFieldDescription),
 	})
 	writeUnsignedBundle(t, bundleDir, b)
@@ -700,7 +700,7 @@ func TestLoadBundles_DisabledByGlobPattern(t *testing.T) {
 	b := testBundle("glob-test", []Rule{
 		testDLPRule("dlp-rule-001", confidenceHigh, StatusStable),
 		testDLPRule("dlp-rule-002", confidenceHigh, StatusStable),
-		testInjectionRule("inj-rule-001", confidenceHigh, StatusStable),
+		testInjectionRule("inj-rule-001", confidenceHigh),
 	})
 	writeUnsignedBundle(t, bundleDir, b)
 
@@ -883,7 +883,7 @@ func TestLoadBundles_RuleTypeRouting(t *testing.T) {
 	b := testBundle("routing-test", []Rule{
 		testDLPRule("dlp-001", confidenceHigh, StatusStable),
 		testDLPRule("dlp-002", confidenceHigh, StatusStable),
-		testInjectionRule("inj-001", confidenceHigh, StatusStable),
+		testInjectionRule("inj-001", confidenceHigh),
 		testToolPoisonRule("tp-001", confidenceHigh, StatusStable, scanFieldName),
 	})
 	writeUnsignedBundle(t, bundleDir, b)

--- a/internal/rules/merge.go
+++ b/internal/rules/merge.go
@@ -152,15 +152,6 @@ func MergeIntoConfig(cfg *config.Config, pipelockVersion string) *LoadResult {
 	dlpDefaultsDisabled := cfg.DLP.IncludeDefaults != nil && !*cfg.DLP.IncludeDefaults
 	responseDefaultsDisabled := cfg.ResponseScanning.IncludeDefaults != nil && !*cfg.ResponseScanning.IncludeDefaults
 
-	// Find the standard bundle in loaded bundles (if any).
-	standardLoaded := false
-	for _, lb := range result.Loaded {
-		if lb.Name == StandardBundleName {
-			standardLoaded = true
-			break
-		}
-	}
-
 	// Separate standard bundle patterns from community/pro patterns.
 	var standardDLP []config.DLPPattern
 	var standardInj []config.ResponseScanPattern
@@ -181,6 +172,16 @@ func MergeIntoConfig(cfg *config.Config, pipelockVersion string) *LoadResult {
 		}
 	}
 
+	// Standard-tier availability is PER SURFACE, not a single "is the standard
+	// bundle loaded" flag: a standard bundle may populate DLP but not response
+	// (or vice versa). Keying both surfaces off one flag would let a partial
+	// standard bundle strip the compiled fallback from the surface it did NOT
+	// provide and leave it empty (a fail-open detection loss). Each surface
+	// uses the bundle only when the bundle actually provided patterns for it,
+	// and otherwise restores the compiled fallback.
+	standardDLPLoaded := len(standardDLP) > 0
+	standardResponseLoaded := len(standardInj) > 0
+
 	// Standard tier source selection (per-subsystem).
 	//
 	// At this point, cfg.DLP.Patterns and cfg.ResponseScanning.Patterns
@@ -195,7 +196,7 @@ func MergeIntoConfig(cfg *config.Config, pipelockVersion string) *LoadResult {
 	cfg.DLP.Patterns = removeBundleDLP(cfg.DLP.Patterns)
 	if dlpDefaultsDisabled {
 		result.StandardDLP = StandardSourceNone
-	} else if standardLoaded {
+	} else if standardDLPLoaded {
 		cfg.DLP.Patterns = removeStandardTierDLP(cfg.DLP.Patterns)
 		cfg.DLP.Patterns = append(cfg.DLP.Patterns, standardDLP...)
 		result.StandardDLP = StandardSourceBundle
@@ -208,7 +209,7 @@ func MergeIntoConfig(cfg *config.Config, pipelockVersion string) *LoadResult {
 	cfg.ResponseScanning.Patterns = removeBundleResponse(cfg.ResponseScanning.Patterns)
 	if responseDefaultsDisabled {
 		result.StandardResponse = StandardSourceNone
-	} else if standardLoaded {
+	} else if standardResponseLoaded {
 		cfg.ResponseScanning.Patterns = removeStandardTierResponse(cfg.ResponseScanning.Patterns)
 		cfg.ResponseScanning.Patterns = append(cfg.ResponseScanning.Patterns, standardInj...)
 		result.StandardResponse = StandardSourceBundle
@@ -224,102 +225,90 @@ func MergeIntoConfig(cfg *config.Config, pipelockVersion string) *LoadResult {
 	return result
 }
 
-func removeBundleDLP(patterns []config.DLPPattern) []config.DLPPattern {
-	kept := make([]config.DLPPattern, 0, len(patterns))
+// removeBundlePatterns drops every bundle-sourced pattern (Bundle != "") so a
+// re-resolution can re-apply the current bundle load without doubling patterns.
+// One generic keeps the DLP and response idempotency semantics identical.
+func removeBundlePatterns[T any](patterns []T, bundleOf func(T) string) []T {
+	kept := make([]T, 0, len(patterns))
 	for _, p := range patterns {
-		if p.Bundle != "" {
+		if bundleOf(p) != "" {
 			continue
 		}
 		kept = append(kept, p)
 	}
 	return kept
+}
+
+// restoreCompiledStandardPatterns rebuilds the compiled standard-tier fallback
+// (used when no standard bundle provides this surface) in first-load order so a
+// re-resolution's canonical policy hash matches a fresh load. It restores the
+// compiled standard patterns that a prior standard-bundle resolution stripped,
+// keeps any compiled default that is still present, drops nothing the operator
+// overrode (non-compiled = user override), and preserves all non-default
+// (user/community/pro) patterns. One generic keeps DLP and response identical.
+func restoreCompiledStandardPatterns[T any](
+	patterns, defaults []T,
+	nameOf func(T) string,
+	compiledOf func(T) bool,
+	compiledStandardNames map[string]bool,
+) []T {
+	defaultNames := make(map[string]struct{}, len(defaults))
+	for _, p := range defaults {
+		defaultNames[nameOf(p)] = struct{}{}
+	}
+
+	existingCompiledDefaults := make(map[string]struct{}, len(patterns))
+	userOverrides := make(map[string]struct{}, len(patterns))
+	for _, p := range patterns {
+		if _, ok := defaultNames[nameOf(p)]; ok && compiledOf(p) {
+			existingCompiledDefaults[nameOf(p)] = struct{}{}
+		}
+		if !compiledOf(p) {
+			userOverrides[nameOf(p)] = struct{}{}
+		}
+	}
+
+	restored := make([]T, 0, len(patterns)+len(compiledStandardNames))
+	for _, p := range defaults {
+		if _, overridden := userOverrides[nameOf(p)]; overridden {
+			continue
+		}
+		if !compiledStandardNames[nameOf(p)] {
+			if _, present := existingCompiledDefaults[nameOf(p)]; !present {
+				continue
+			}
+		}
+		restored = append(restored, p)
+	}
+	for _, p := range patterns {
+		if _, isDefault := defaultNames[nameOf(p)]; isDefault && compiledOf(p) {
+			continue
+		}
+		restored = append(restored, p)
+	}
+	return restored
+}
+
+func removeBundleDLP(patterns []config.DLPPattern) []config.DLPPattern {
+	return removeBundlePatterns(patterns, func(p config.DLPPattern) string { return p.Bundle })
 }
 
 func removeBundleResponse(patterns []config.ResponseScanPattern) []config.ResponseScanPattern {
-	kept := make([]config.ResponseScanPattern, 0, len(patterns))
-	for _, p := range patterns {
-		if p.Bundle != "" {
-			continue
-		}
-		kept = append(kept, p)
-	}
-	return kept
+	return removeBundlePatterns(patterns, func(p config.ResponseScanPattern) string { return p.Bundle })
 }
 
 func restoreCompiledStandardDLP(patterns []config.DLPPattern) []config.DLPPattern {
-	defaultNames := make(map[string]struct{}, len(config.Defaults().DLP.Patterns))
-	for _, p := range config.Defaults().DLP.Patterns {
-		defaultNames[p.Name] = struct{}{}
-	}
-
-	existingCompiledDefaults := make(map[string]struct{}, len(patterns))
-	userOverrides := make(map[string]struct{}, len(patterns))
-	for _, p := range patterns {
-		if _, ok := defaultNames[p.Name]; ok && p.Compiled {
-			existingCompiledDefaults[p.Name] = struct{}{}
-		}
-		if !p.Compiled {
-			userOverrides[p.Name] = struct{}{}
-		}
-	}
-
-	restored := make([]config.DLPPattern, 0, len(patterns)+len(compiledStandardDLPNames))
-	for _, p := range config.Defaults().DLP.Patterns {
-		if _, overridden := userOverrides[p.Name]; overridden {
-			continue
-		}
-		if !compiledStandardDLPNames[p.Name] {
-			if _, present := existingCompiledDefaults[p.Name]; !present {
-				continue
-			}
-		}
-		restored = append(restored, p)
-	}
-	for _, p := range patterns {
-		if _, isDefault := defaultNames[p.Name]; isDefault && p.Compiled {
-			continue
-		}
-		restored = append(restored, p)
-	}
-	return restored
+	return restoreCompiledStandardPatterns(patterns, config.Defaults().DLP.Patterns,
+		func(p config.DLPPattern) string { return p.Name },
+		func(p config.DLPPattern) bool { return p.Compiled },
+		compiledStandardDLPNames)
 }
 
 func restoreCompiledStandardResponse(patterns []config.ResponseScanPattern) []config.ResponseScanPattern {
-	defaultNames := make(map[string]struct{}, len(config.Defaults().ResponseScanning.Patterns))
-	for _, p := range config.Defaults().ResponseScanning.Patterns {
-		defaultNames[p.Name] = struct{}{}
-	}
-
-	existingCompiledDefaults := make(map[string]struct{}, len(patterns))
-	userOverrides := make(map[string]struct{}, len(patterns))
-	for _, p := range patterns {
-		if _, ok := defaultNames[p.Name]; ok && p.Compiled {
-			existingCompiledDefaults[p.Name] = struct{}{}
-		}
-		if !p.Compiled {
-			userOverrides[p.Name] = struct{}{}
-		}
-	}
-
-	restored := make([]config.ResponseScanPattern, 0, len(patterns)+len(compiledStandardResponseNames))
-	for _, p := range config.Defaults().ResponseScanning.Patterns {
-		if _, overridden := userOverrides[p.Name]; overridden {
-			continue
-		}
-		if !compiledStandardResponseNames[p.Name] {
-			if _, present := existingCompiledDefaults[p.Name]; !present {
-				continue
-			}
-		}
-		restored = append(restored, p)
-	}
-	for _, p := range patterns {
-		if _, isDefault := defaultNames[p.Name]; isDefault && p.Compiled {
-			continue
-		}
-		restored = append(restored, p)
-	}
-	return restored
+	return restoreCompiledStandardPatterns(patterns, config.Defaults().ResponseScanning.Patterns,
+		func(p config.ResponseScanPattern) string { return p.Name },
+		func(p config.ResponseScanPattern) bool { return p.Compiled },
+		compiledStandardResponseNames)
 }
 
 // removeStandardTierDLP removes compiled standard-tier DLP patterns, keeping

--- a/internal/rules/merge.go
+++ b/internal/rules/merge.go
@@ -148,6 +148,19 @@ func MergeIntoConfig(cfg *config.Config, pipelockVersion string) *LoadResult {
 		TierKeyMapping:      buildTierKeyMapping(cfg.Rules.TrustedKeys),
 	})
 
+	// Fail closed on a bundle LOAD failure. A bundle that failed to load
+	// (signature, lockfile, min-version, or filesystem error) is NOT in the
+	// resolved sets built below, so proceeding would strip previously-validated
+	// bundle patterns from an already-resolved config (re-resolution happens on
+	// every hot reload and conductor policy apply) and fall back to compiled
+	// defaults — a fail-open weakening triggered by a transient error. Preserve
+	// the caller's existing resolved patterns instead; the caller surfaces
+	// result.Errors, and the reload downgrade guard still rejects any real
+	// weakening under strict mode.
+	if len(result.Errors) > 0 {
+		return result
+	}
+
 	// Check if include_defaults is explicitly false (disables standard tier).
 	dlpDefaultsDisabled := cfg.DLP.IncludeDefaults != nil && !*cfg.DLP.IncludeDefaults
 	responseDefaultsDisabled := cfg.ResponseScanning.IncludeDefaults != nil && !*cfg.ResponseScanning.IncludeDefaults

--- a/internal/rules/merge.go
+++ b/internal/rules/merge.go
@@ -192,6 +192,7 @@ func MergeIntoConfig(cfg *config.Config, pipelockVersion string) *LoadResult {
 	// standard DLP defaults while keeping standard response defaults.
 
 	// DLP subsystem.
+	cfg.DLP.Patterns = removeBundleDLP(cfg.DLP.Patterns)
 	if dlpDefaultsDisabled {
 		result.StandardDLP = StandardSourceNone
 	} else if standardLoaded {
@@ -199,10 +200,12 @@ func MergeIntoConfig(cfg *config.Config, pipelockVersion string) *LoadResult {
 		cfg.DLP.Patterns = append(cfg.DLP.Patterns, standardDLP...)
 		result.StandardDLP = StandardSourceBundle
 	} else {
+		cfg.DLP.Patterns = restoreCompiledStandardDLP(cfg.DLP.Patterns)
 		result.StandardDLP = StandardSourceCompiled
 	}
 
 	// Response subsystem.
+	cfg.ResponseScanning.Patterns = removeBundleResponse(cfg.ResponseScanning.Patterns)
 	if responseDefaultsDisabled {
 		result.StandardResponse = StandardSourceNone
 	} else if standardLoaded {
@@ -210,6 +213,7 @@ func MergeIntoConfig(cfg *config.Config, pipelockVersion string) *LoadResult {
 		cfg.ResponseScanning.Patterns = append(cfg.ResponseScanning.Patterns, standardInj...)
 		result.StandardResponse = StandardSourceBundle
 	} else {
+		cfg.ResponseScanning.Patterns = restoreCompiledStandardResponse(cfg.ResponseScanning.Patterns)
 		result.StandardResponse = StandardSourceCompiled
 	}
 
@@ -218,6 +222,104 @@ func MergeIntoConfig(cfg *config.Config, pipelockVersion string) *LoadResult {
 	cfg.ResponseScanning.Patterns = append(cfg.ResponseScanning.Patterns, otherInj...)
 
 	return result
+}
+
+func removeBundleDLP(patterns []config.DLPPattern) []config.DLPPattern {
+	kept := make([]config.DLPPattern, 0, len(patterns))
+	for _, p := range patterns {
+		if p.Bundle != "" {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	return kept
+}
+
+func removeBundleResponse(patterns []config.ResponseScanPattern) []config.ResponseScanPattern {
+	kept := make([]config.ResponseScanPattern, 0, len(patterns))
+	for _, p := range patterns {
+		if p.Bundle != "" {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	return kept
+}
+
+func restoreCompiledStandardDLP(patterns []config.DLPPattern) []config.DLPPattern {
+	defaultNames := make(map[string]struct{}, len(config.Defaults().DLP.Patterns))
+	for _, p := range config.Defaults().DLP.Patterns {
+		defaultNames[p.Name] = struct{}{}
+	}
+
+	existingCompiledDefaults := make(map[string]struct{}, len(patterns))
+	userOverrides := make(map[string]struct{}, len(patterns))
+	for _, p := range patterns {
+		if _, ok := defaultNames[p.Name]; ok && p.Compiled {
+			existingCompiledDefaults[p.Name] = struct{}{}
+		}
+		if !p.Compiled {
+			userOverrides[p.Name] = struct{}{}
+		}
+	}
+
+	restored := make([]config.DLPPattern, 0, len(patterns)+len(compiledStandardDLPNames))
+	for _, p := range config.Defaults().DLP.Patterns {
+		if _, overridden := userOverrides[p.Name]; overridden {
+			continue
+		}
+		if !compiledStandardDLPNames[p.Name] {
+			if _, present := existingCompiledDefaults[p.Name]; !present {
+				continue
+			}
+		}
+		restored = append(restored, p)
+	}
+	for _, p := range patterns {
+		if _, isDefault := defaultNames[p.Name]; isDefault && p.Compiled {
+			continue
+		}
+		restored = append(restored, p)
+	}
+	return restored
+}
+
+func restoreCompiledStandardResponse(patterns []config.ResponseScanPattern) []config.ResponseScanPattern {
+	defaultNames := make(map[string]struct{}, len(config.Defaults().ResponseScanning.Patterns))
+	for _, p := range config.Defaults().ResponseScanning.Patterns {
+		defaultNames[p.Name] = struct{}{}
+	}
+
+	existingCompiledDefaults := make(map[string]struct{}, len(patterns))
+	userOverrides := make(map[string]struct{}, len(patterns))
+	for _, p := range patterns {
+		if _, ok := defaultNames[p.Name]; ok && p.Compiled {
+			existingCompiledDefaults[p.Name] = struct{}{}
+		}
+		if !p.Compiled {
+			userOverrides[p.Name] = struct{}{}
+		}
+	}
+
+	restored := make([]config.ResponseScanPattern, 0, len(patterns)+len(compiledStandardResponseNames))
+	for _, p := range config.Defaults().ResponseScanning.Patterns {
+		if _, overridden := userOverrides[p.Name]; overridden {
+			continue
+		}
+		if !compiledStandardResponseNames[p.Name] {
+			if _, present := existingCompiledDefaults[p.Name]; !present {
+				continue
+			}
+		}
+		restored = append(restored, p)
+	}
+	for _, p := range patterns {
+		if _, isDefault := defaultNames[p.Name]; isDefault && p.Compiled {
+			continue
+		}
+		restored = append(restored, p)
+	}
+	return restored
 }
 
 // removeStandardTierDLP removes compiled standard-tier DLP patterns, keeping

--- a/internal/rules/merge_test.go
+++ b/internal/rules/merge_test.go
@@ -344,6 +344,46 @@ func TestMergeIntoConfig_RestoresCompiledStandardFallbackAfterStandardBundleRemo
 	}
 }
 
+func TestMergeIntoConfig_PreservesResolvedPatternsOnBundleLoadError(t *testing.T) {
+	// A bundle that fails to load (here: missing bundle.lock) produces
+	// result.Errors and contributes no patterns. Re-resolving an
+	// already-bundle-resolved config must NOT strip its previously-validated
+	// bundle patterns and degrade to compiled fallback — that would be a
+	// fail-open weakening triggered by a transient load error.
+	rulesDir := t.TempDir()
+	bundleDir := filepath.Join(rulesDir, "community-x")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// bundle.yaml with NO bundle.lock -> loader appends a load error and skips.
+	if err := os.WriteFile(filepath.Join(bundleDir, "bundle.yaml"), []byte(
+		"format_version: 1\nname: community-x\nversion: \"1.0.0\"\nauthor: t\ndescription: d\nlicense: Apache-2.0\nrules:\n  - id: dlp-1\n    type: dlp\n    status: stable\n    name: X\n    description: d\n    severity: high\n    confidence: high\n    pattern:\n      regex: 'abc'\n"),
+		0o600); err != nil {
+		t.Fatalf("write bundle.yaml: %v", err)
+	}
+
+	cfg := config.Defaults()
+	cfg.Rules.RulesDir = rulesDir
+	// Simulate an already-resolved config carrying a validated bundle pattern.
+	cfg.DLP.Patterns = append(cfg.DLP.Patterns, config.DLPPattern{
+		Name: "Prior Bundle DLP", Regex: `prior-secret-[0-9]+`,
+		Severity: config.SeverityHigh, Bundle: "prior-bundle", BundleVersion: "1.0.0",
+	})
+	before := append([]config.DLPPattern(nil), cfg.DLP.Patterns...)
+	beforeResp := append([]config.ResponseScanPattern(nil), cfg.ResponseScanning.Patterns...)
+
+	result := MergeIntoConfig(cfg, "1.0.0")
+	if len(result.Errors) == 0 {
+		t.Fatal("expected a load error from the lock-less bundle")
+	}
+	if !reflect.DeepEqual(cfg.DLP.Patterns, before) {
+		t.Fatalf("bundle load error stripped previously-resolved DLP patterns (fail-open); got %d want %d", len(cfg.DLP.Patterns), len(before))
+	}
+	if !reflect.DeepEqual(cfg.ResponseScanning.Patterns, beforeResp) {
+		t.Fatal("bundle load error mutated response patterns")
+	}
+}
+
 func installUnsignedMergeTestBundle(t *testing.T, rulesDir, name string, rules []Rule) string {
 	t.Helper()
 	bundleDir := filepath.Join(rulesDir, name)

--- a/internal/rules/merge_test.go
+++ b/internal/rules/merge_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -181,6 +182,214 @@ rules:
 	if result.ToolPoison[0].Name != "test-bundle:test-poison-rule" {
 		t.Fatalf("unexpected poison name: %s", result.ToolPoison[0].Name)
 	}
+}
+
+func TestMergeIntoConfig_IdempotentForAlreadyMergedBundlePatterns(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.Rules.RulesDir = t.TempDir()
+
+	bundleDir := filepath.Join(cfg.Rules.RulesDir, testBundleName)
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("mkdir bundle dir: %v", err)
+	}
+	writeUnsignedBundle(t, bundleDir, testBundle(testBundleName, []Rule{
+		testDLPRule("dlp-rule-001", confidenceHigh, StatusStable),
+		testInjectionRule("inj-rule-001", confidenceHigh),
+	}))
+
+	first := MergeIntoConfig(cfg, "1.0.0")
+	if len(first.Errors) != 0 {
+		t.Fatalf("first merge errors: %v", first.Errors)
+	}
+	dlpCount := len(cfg.DLP.Patterns)
+	responseCount := len(cfg.ResponseScanning.Patterns)
+	wantDLP := append([]config.DLPPattern(nil), cfg.DLP.Patterns...)
+	wantResponse := append([]config.ResponseScanPattern(nil), cfg.ResponseScanning.Patterns...)
+
+	second := MergeIntoConfig(cfg, "1.0.0")
+	if len(second.Errors) != 0 {
+		t.Fatalf("second merge errors: %v", second.Errors)
+	}
+	if len(cfg.DLP.Patterns) != dlpCount {
+		t.Fatalf("second merge DLP count = %d, want %d", len(cfg.DLP.Patterns), dlpCount)
+	}
+	if len(cfg.ResponseScanning.Patterns) != responseCount {
+		t.Fatalf("second merge response count = %d, want %d", len(cfg.ResponseScanning.Patterns), responseCount)
+	}
+	if !reflect.DeepEqual(cfg.DLP.Patterns, wantDLP) {
+		t.Fatal("second merge changed DLP pattern slice; want byte-identical resolved policy")
+	}
+	if !reflect.DeepEqual(cfg.ResponseScanning.Patterns, wantResponse) {
+		t.Fatal("second merge changed response pattern slice; want byte-identical resolved policy")
+	}
+	if got := countDLPPatternsFromBundle(cfg, testBundleName); got != 1 {
+		t.Fatalf("bundle DLP patterns = %d, want 1", got)
+	}
+	if got := countResponsePatternsFromBundle(cfg, testBundleName); got != 1 {
+		t.Fatalf("bundle response patterns = %d, want 1", got)
+	}
+}
+
+func TestMergeIntoConfig_ReResolveDifferentBundleReplacesPreviousBundlePatterns(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.Rules.RulesDir = t.TempDir()
+
+	bundleADir := installUnsignedMergeTestBundle(t, cfg.Rules.RulesDir, "bundle-a", []Rule{
+		testDLPRule("dlp-rule-a", confidenceHigh, StatusStable),
+		testInjectionRule("inj-rule-a", confidenceHigh),
+	})
+	first := MergeIntoConfig(cfg, "1.0.0")
+	if len(first.Errors) != 0 {
+		t.Fatalf("first merge errors: %v", first.Errors)
+	}
+	if got := countDLPPatternsFromBundle(cfg, "bundle-a"); got != 1 {
+		t.Fatalf("bundle-a DLP patterns after first merge = %d, want 1", got)
+	}
+	if got := countResponsePatternsFromBundle(cfg, "bundle-a"); got != 1 {
+		t.Fatalf("bundle-a response patterns after first merge = %d, want 1", got)
+	}
+
+	if err := os.RemoveAll(bundleADir); err != nil {
+		t.Fatalf("remove bundle-a: %v", err)
+	}
+	installUnsignedMergeTestBundle(t, cfg.Rules.RulesDir, "bundle-b", []Rule{
+		testDLPRule("dlp-rule-b", confidenceHigh, StatusStable),
+		testInjectionRule("inj-rule-b", confidenceHigh),
+	})
+	second := MergeIntoConfig(cfg, "1.0.0")
+	if len(second.Errors) != 0 {
+		t.Fatalf("second merge errors: %v", second.Errors)
+	}
+	if got := countDLPPatternsFromBundle(cfg, "bundle-a"); got != 0 {
+		t.Fatalf("bundle-a DLP patterns after bundle swap = %d, want 0", got)
+	}
+	if got := countResponsePatternsFromBundle(cfg, "bundle-a"); got != 0 {
+		t.Fatalf("bundle-a response patterns after bundle swap = %d, want 0", got)
+	}
+	if got := countDLPPatternsFromBundle(cfg, "bundle-b"); got != 1 {
+		t.Fatalf("bundle-b DLP patterns after bundle swap = %d, want 1", got)
+	}
+	if got := countResponsePatternsFromBundle(cfg, "bundle-b"); got != 1 {
+		t.Fatalf("bundle-b response patterns after bundle swap = %d, want 1", got)
+	}
+}
+
+func TestMergeIntoConfig_RestoresCompiledStandardFallbackAfterStandardBundleRemoved(t *testing.T) {
+	rulesDir := t.TempDir()
+	userDLP := config.DLPPattern{
+		Name:     "User DLP",
+		Regex:    `user-secret-[0-9]+`,
+		Severity: config.SeverityHigh,
+	}
+	userResponse := config.ResponseScanPattern{
+		Name:  "User Response",
+		Regex: `(?i)user-response`,
+	}
+
+	firstLoad := config.Defaults()
+	firstLoad.Rules.RulesDir = rulesDir
+	firstLoad.DLP.Patterns = append(firstLoad.DLP.Patterns, userDLP)
+	firstLoad.ResponseScanning.Patterns = append(firstLoad.ResponseScanning.Patterns, userResponse)
+	firstResult := MergeIntoConfig(firstLoad, "1.0.0")
+	if len(firstResult.Errors) != 0 {
+		t.Fatalf("first-load merge errors: %v", firstResult.Errors)
+	}
+
+	cfg := config.Defaults()
+	cfg.Rules.RulesDir = rulesDir
+	cfg.DLP.Patterns = append(cfg.DLP.Patterns, userDLP)
+	cfg.ResponseScanning.Patterns = append(cfg.ResponseScanning.Patterns, userResponse)
+	cfg.DLP.Patterns = append(removeStandardTierDLP(cfg.DLP.Patterns), config.DLPPattern{
+		Name:          "Anthropic API Key",
+		Regex:         `bundle-anthropic-[A-Z]+`,
+		Severity:      config.SeverityCritical,
+		Bundle:        StandardBundleName,
+		BundleVersion: "2026.07.0",
+	})
+	cfg.ResponseScanning.Patterns = append(removeStandardTierResponse(cfg.ResponseScanning.Patterns), config.ResponseScanPattern{
+		Name:          "New Instructions",
+		Regex:         `(?i)bundle-new-instructions`,
+		Bundle:        StandardBundleName,
+		BundleVersion: "2026.07.0",
+	})
+
+	result := MergeIntoConfig(cfg, "1.0.0")
+	if len(result.Errors) != 0 {
+		t.Fatalf("merge errors: %v", result.Errors)
+	}
+	if result.StandardDLP != StandardSourceCompiled {
+		t.Fatalf("StandardDLP = %s, want %s", result.StandardDLP, StandardSourceCompiled)
+	}
+	if result.StandardResponse != StandardSourceCompiled {
+		t.Fatalf("StandardResponse = %s, want %s", result.StandardResponse, StandardSourceCompiled)
+	}
+	if p, ok := dlpPatternByName(cfg.DLP.Patterns, "Anthropic API Key"); !ok || !p.Compiled || p.Bundle != "" {
+		t.Fatalf("Anthropic API Key fallback = %+v, ok=%v; want compiled non-bundle default", p, ok)
+	}
+	if p, ok := responsePatternByName(cfg.ResponseScanning.Patterns, "New Instructions"); !ok || !p.Compiled || p.Bundle != "" {
+		t.Fatalf("New Instructions fallback = %+v, ok=%v; want compiled non-bundle default", p, ok)
+	}
+	if !reflect.DeepEqual(cfg.DLP.Patterns, firstLoad.DLP.Patterns) {
+		t.Fatal("restored DLP fallback differs from first-load compiled defaults plus user patterns")
+	}
+	if !reflect.DeepEqual(cfg.ResponseScanning.Patterns, firstLoad.ResponseScanning.Patterns) {
+		t.Fatal("restored response fallback differs from first-load compiled defaults plus user patterns")
+	}
+	if got, want := cfg.CanonicalPolicyHash(), firstLoad.CanonicalPolicyHash(); got != want {
+		t.Fatalf("restored fallback canonical policy hash = %s, want first-load hash %s", got, want)
+	}
+}
+
+func installUnsignedMergeTestBundle(t *testing.T, rulesDir, name string, rules []Rule) string {
+	t.Helper()
+	bundleDir := filepath.Join(rulesDir, name)
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("mkdir bundle dir %q: %v", name, err)
+	}
+	writeUnsignedBundle(t, bundleDir, testBundle(name, rules))
+	return bundleDir
+}
+
+func dlpPatternByName(patterns []config.DLPPattern, name string) (config.DLPPattern, bool) {
+	for _, p := range patterns {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return config.DLPPattern{}, false
+}
+
+func responsePatternByName(patterns []config.ResponseScanPattern, name string) (config.ResponseScanPattern, bool) {
+	for _, p := range patterns {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return config.ResponseScanPattern{}, false
+}
+
+func countDLPPatternsFromBundle(cfg *config.Config, bundle string) int {
+	count := 0
+	for _, p := range cfg.DLP.Patterns {
+		if p.Bundle == bundle {
+			count++
+		}
+	}
+	return count
+}
+
+func countResponsePatternsFromBundle(cfg *config.Config, bundle string) int {
+	count := 0
+	for _, p := range cfg.ResponseScanning.Patterns {
+		if p.Bundle == bundle {
+			count++
+		}
+	}
+	return count
 }
 
 func TestConvertToolPoison(t *testing.T) {


### PR DESCRIPTION
## What changed

Fail-closed fixes on the evidence and rule-bundle paths.

Rule bundles and `pipelock demo` / `diagnose` no longer break on a development build. A binary built from source or `go install` reports a non-semver version (a `git describe` string like `2-147-gabc1234`), which the rule-bundle `min_pipelock` check rejected as an invalid current version. That silently skipped every bundle carrying a `min_pipelock` and hard-aborted `demo` and `diagnose`. Development builds (git-describe forms, `-dev`, unset, and other non-orderable versions) are now treated as newest so bundles load, while release prereleases are ordered correctly against the minimum, so a prerelease build no longer satisfies a gate for the final release. The minimum gate is unchanged for real tagged releases.

The flight recorder refuses to start a persisting recorder that is configured to sign checkpoints but has no signing key. `sign_checkpoints` defaults on, so once an operator sets a `dir` the recorder was silently writing checkpoints with an empty signature, records that later verification rejects as "missing signature". It now fails closed with a clear message. A blank or whitespace `dir` is a genuine no-op recorder that never touches the filesystem, so the non-persisting default cannot write empty-signature evidence to the working directory either. An explicitly unsigned recorder (`sign_checkpoints: false`) and conductor mode, which enforces the same key requirement independently, are unaffected.

Rekor receipt anchoring no longer defaults to the public `rekor.sigstore.dev`. Submitting a checkpoint with an empty URL now fails closed at both the CLI and the library, because silently publishing receipt-chain hash metadata to a public transparency log is an egress outside the operator's declared trust boundary. The operator must name their own log explicitly. Verification of an already-recorded proof is unaffected, since it reads the URL embedded in the proof rather than a default.

Rule-bundle merging is now idempotent. Re-resolving an already-bundle-resolved config, which every hot reload and conductor policy apply does, re-appended the bundle's DLP and response patterns each time, growing the pattern set and tripping a spurious "patterns changed" reload warning. Under strict mode that warning was rejected as a security downgrade, so a strict-mode deployment with a rule bundle installed could not rotate its kill-switch token or apply a conductor policy bundle at all. The merge now strips prior bundle-sourced patterns before re-applying the current load and restores the compiled standard fallback in first-load order when a standard bundle is no longer present, so re-resolution is stable and the canonical policy hash is unaffected. First-load output is unchanged.

The reload downgrade guard now also diffs `response_scanning.patterns`, not only `dlp.patterns`. Previously a strict-mode reload could remove or regex-swap a local response-scanning pattern and still be accepted; both pattern sets are now checked, so a genuine removal or weakening is still rejected under strict mode while the idempotent bundle re-resolution above is not mistaken for one.

The flight recorder guide documents the sign-without-a-key fail-closed and adds an end-to-end recipe for verifying a live receipt chain offline against the public-key sidecar.

## Reproduction

Each fix is proven by neutralizing it and watching a dedicated test fail, then restoring. Two are especially sharp: with the rekor guard removed, an empty submission URL actually reaches the public `rekor.sigstore.dev` endpoint; and the bundle-merge fix carries a hermetic regression test that installs a standard bundle, proves a strict-mode reload is accepted without the pattern set growing, and proves a genuine strict-to-balanced downgrade and a real response-pattern removal are both still rejected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation for offline verification of the live receipt hash chain, including pinned public key workflow and guidance for signing-key rotation.
  * Enhanced version gating for development/prerelease builds when evaluating `min_pipelock`.

* **Bug Fixes**
  * Receipt metadata publishing now fails closed if the anchor URL is missing/blank.
  * Checkpoint signing now fails closed when signing is enabled but no signing key is provided.
  * Strict policy reloads now reject security downgrades and emit clearer warnings when response-scanning patterns are removed or regex-changed.

* **Tests**
  * Expanded coverage for Rekor URL requirements, checkpoint signing behavior, and strict reload/security downgrade scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->