### PR TITLE
fix(evidence): fail closed when a coverage certificate signer is not in the pinned trusted-signer set

### DIFF
--- a/enterprise/cli/dashboard_coveragecert.go
+++ b/enterprise/cli/dashboard_coveragecert.go
@@ -274,7 +274,12 @@ func coverageCertVerifyCmd() *cobra.Command {
 		Short: "Verify a coverage certificate offline",
 		Long: `Verify a coverage certificate's Ed25519 signature and check the signer
 against the trusted-signer set. Re-derives aggregate counts from the sessions
-and flags any mismatch. Fully offline: no license, no server.`,
+and flags any mismatch. Fully offline: no license, no server.
+
+Fails closed with a non-zero exit if the signature is invalid, the aggregate
+counts do not match, or a trusted-signer set is supplied and the certificate
+signer is not in it. With no trusted-signer set, verification is
+structural-only and exits zero.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runCoverageCertVerify(cmd, opts)
@@ -293,6 +298,5 @@ func runCoverageCertVerify(cmd *cobra.Command, opts coverageCertVerifyOptions) e
 		CertFile:       opts.certFile,
 		TrustedSigners: opts.trustedSigners,
 		Out:            cmd.OutOrStdout(),
-		Err:            cmd.ErrOrStderr(),
 	})
 }

--- a/enterprise/cli/dashboard_coveragecert_test.go
+++ b/enterprise/cli/dashboard_coveragecert_test.go
@@ -388,19 +388,16 @@ func TestRunCoverageCertVerify(t *testing.T) {
 		}
 	})
 
-	t.Run("untrusted signer warns but does not fail", func(t *testing.T) {
+	t.Run("untrusted signer fails closed", func(t *testing.T) {
 		_, otherPriv, _ := signing.GenerateKeyPair()
 		otherPub := otherPriv.Public().(ed25519.PublicKey)
-		cmd, buf := newCmd()
+		cmd, _ := newCmd()
 		err := runCoverageCertVerify(cmd, coverageCertVerifyOptions{
 			certFile:       certFile,
 			trustedSigners: []string{"inline=" + hex.EncodeToString(otherPub)},
 		})
-		if err != nil {
-			t.Fatalf("verify (untrusted) should not error: %v", err)
-		}
-		if !strings.Contains(buf.String(), "not in the trusted-signer set") {
-			t.Errorf("expected untrusted-signer warning, got: %s", buf.String())
+		if err == nil || !strings.Contains(err.Error(), "not in the trusted-signer set") {
+			t.Fatalf("verify (untrusted) err = %v, want fail-closed error", err)
 		}
 	})
 

--- a/internal/cli/evidence/evidence.go
+++ b/internal/cli/evidence/evidence.go
@@ -191,8 +191,10 @@ per-session data and flags any mismatch with the signed aggregates.
 Fully offline: no license, no server, no network. The Free viewer
 VERIFIES a Pro-issued certificate; only Pro issues one.
 
-An untrusted signer is reported (never silently accepted). Non-zero exit
-if the signature is invalid.`,
+Fails closed with a non-zero exit if the signature is invalid, the
+aggregate counts do not match, or a trusted-signer set is supplied and the
+certificate signer is not in it. With no trusted-signer set, verification is
+structural-only and exits zero. The signer status is always reported.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runVerifyCert(cmd, opts)
@@ -211,6 +213,5 @@ func runVerifyCert(cmd *cobra.Command, opts verifyCertOptions) error {
 		CertFile:       opts.certFile,
 		TrustedSigners: opts.trustedSigners,
 		Out:            cmd.OutOrStdout(),
-		Err:            cmd.ErrOrStderr(),
 	})
 }

--- a/internal/cli/evidence/evidence_test.go
+++ b/internal/cli/evidence/evidence_test.go
@@ -612,17 +612,15 @@ func TestVerifyCertCmd_UntrustedSigner_Reported(t *testing.T) {
 		"--trusted-signer", "inline=" + otherKeyHex,
 	})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute: %v", err)
+	execErr := cmd.Execute()
+	if execErr == nil || !strings.Contains(execErr.Error(), "not in the trusted-signer set") {
+		t.Fatalf("Execute err = %v, want fail-closed untrusted-signer error", execErr)
 	}
 
+	// The diagnostic line is still emitted to stdout before the fail-closed return.
 	out := stdout.String()
 	if !strings.Contains(out, "Signer: NOT TRUSTED") {
 		t.Error("output should report untrusted signer")
-	}
-	// Stderr should warn.
-	if !strings.Contains(stderr.String(), "not in the trusted-signer set") {
-		t.Error("stderr should warn about untrusted signer")
 	}
 }
 

--- a/internal/coveragecertverify/verify.go
+++ b/internal/coveragecertverify/verify.go
@@ -21,7 +21,6 @@ type Options struct {
 	CertFile       string
 	TrustedSigners []string
 	Out            io.Writer
-	Err            io.Writer
 }
 
 // Run reads and verifies a coverage certificate, prints bounded verification
@@ -67,12 +66,13 @@ func Run(opts Options) error {
 		return errors.New("coverage certificate aggregate counts do not match sessions")
 	}
 	if !result.SignerTrusted && len(trustedKeySet) > 0 {
-		errOut := opts.Err
-		if errOut == nil {
-			errOut = io.Discard
-		}
-		_, _ = fmt.Fprintln(errOut,
-			"pipelock: warning: the certificate signer is not in the trusted-signer set")
+		// Fail closed: the caller pinned a trusted-signer set and the certificate
+		// signer is not in it. A cryptographically valid signature from an
+		// untrusted key must not verify, or an operator scripting on exit code
+		// would accept a certificate signed by an unrecognized key. (When no
+		// trusted set is provided the check above is skipped: that is the
+		// explicit unpinned/structural case.)
+		return errors.New("coverage certificate signer is not in the trusted-signer set")
 	}
 	return nil
 }

--- a/internal/coveragecertverify/verify_test.go
+++ b/internal/coveragecertverify/verify_test.go
@@ -75,23 +75,25 @@ func TestRunTrustedSignerVerifies(t *testing.T) {
 	}
 }
 
-func TestRunUntrustedSignerWarns(t *testing.T) {
+func TestRunUntrustedSignerFailsClosed(t *testing.T) {
 	certFile, _ := writeCoverageCertVerifyFixture(t)
 	otherPub, _, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
-	var stderr bytes.Buffer
+	var out bytes.Buffer
 
-	if err := Run(Options{
+	err = Run(Options{
 		CertFile:       certFile,
 		TrustedSigners: []string{"inline=" + hex.EncodeToString(otherPub)},
-		Err:            &stderr,
-	}); err != nil {
-		t.Fatalf("Run: %v", err)
+		Out:            &out,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not in the trusted-signer set") {
+		t.Fatalf("Run err = %v, want fail-closed untrusted-signer error", err)
 	}
-	if !strings.Contains(stderr.String(), "not in the trusted-signer set") {
-		t.Fatalf("stderr = %q, want untrusted warning", stderr.String())
+	// The diagnostic line is still emitted before the fail-closed return.
+	if !strings.Contains(out.String(), "NOT TRUSTED") {
+		t.Fatalf("Run output = %q, want NOT TRUSTED diagnostic line", out.String())
 	}
 }
 


### PR DESCRIPTION
## What

`coverage-cert verify` (both `pipelock dashboard coverage-cert verify` and the Free `pipelock evidence verify-cert`) now fails closed with a non-zero exit when a trusted-signer set is supplied and the certificate signer is not in it. Previously it printed a stderr warning and exited 0.

## Why

With `--trusted-signer` pinned, a cryptographically valid signature from an untrusted key must not verify. Exiting 0 meant automation keying on the exit code would accept a coverage certificate signed by an unrecognized key, which defeats the point of pinning a trusted signer. This aligns coverage-certificate verification with the receipt verifier, which already fails closed on an untrusted or unpinned signer.

## Behavior

Fails closed (non-zero exit) on an invalid signature, an aggregate-count mismatch, or a pinned-but-untrusted signer. With no trusted-signer set supplied, verification stays structural-only and exits zero. The diagnostic lines, including the NOT TRUSTED signer status, are still emitted before the fail-closed return, so the operator sees why. Command help text in both verify surfaces is updated to state the contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate verification now fails with a non-zero exit when a certificate signer is not included in the specified trusted-signer set.
  * Verification still reports signer status, including `NOT TRUSTED`, before returning the failure.
  * Invalid signatures and aggregate mismatches continue to fail closed.

* **Documentation**
  * Updated command help to clarify offline verification, structural-only verification when no trusted-signer set is provided, and exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->