### PR TITLE
docs(dashboard): document OIDC identity-provider audience setup

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -166,6 +166,32 @@ also carries a token, its certificate role remains authoritative for route and
 raw-view permissions; a metadata certificate cannot use a raw token to
 escalate.
 
+### OIDC identity-provider setup
+
+In OIDC mode the dashboard validates every bearer token against the configured
+issuer and audience before authorizing it. Three claim checks are relevant when
+wiring an identity provider:
+
+- `iss` must exactly equal `--oidc-issuer`.
+- `aud` must contain `--oidc-audience` (aliased by `--oidc-client-id`).
+- `azp`, when present, must equal that same audience; a token with multiple
+  audiences and no `azp` is rejected.
+
+The common setup failure is the `aud` check. Many providers do not put the
+client ID in the access token's audience by default, so the token is rejected
+even though sign-in succeeds. Keycloak, for example, issues access tokens with
+`aud: "account"` unless you add an audience mapper. To use the dashboard with
+Keycloak, add an **Audience** protocol mapper to the client (or to a client
+scope it uses) whose included client audience is the dashboard client ID, then
+set `--oidc-audience` to that same client ID. The issued token then carries
+`aud: <client-id>` and passes the audience check.
+
+Pick a role source with `--oidc-role-claim` and map it to bounded dashboard
+permissions with `--oidc-role-map`. The role claim can be `azp` (the client ID,
+useful for a single-client deployment) or a groups/roles claim your provider
+adds to the token. As with the mTLS role map, permissions must come from the
+dashboard's bounded vocabulary and an unmapped principal is denied.
+
 ### License resolution
 
 `dashboard serve` loads `--config` only when the flag is provided, using the

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -183,8 +183,12 @@ even though sign-in succeeds. Keycloak, for example, issues access tokens with
 `aud: "account"` unless you add an audience mapper. To use the dashboard with
 Keycloak, add an **Audience** protocol mapper to the client (or to a client
 scope it uses) whose included client audience is the dashboard client ID, then
-set `--oidc-audience` to that same client ID. The issued token then carries
-`aud: <client-id>` and passes the audience check.
+set `--oidc-audience` to that same client ID. The issued token then includes
+the client ID in its `aud` claim (alongside any audiences the provider already
+sets, such as `account`), so the "aud contains `--oidc-audience`" check passes.
+A token that then carries multiple audiences must also set `azp` to the client
+ID, which Keycloak does for the client that obtained the token; the dashboard
+requires that `azp` match when more than one audience is present.
 
 Pick a role source with `--oidc-role-claim` and map it to bounded dashboard
 permissions with `--oidc-role-map`. The role claim can be `azp` (the client ID,


### PR DESCRIPTION
## What

Adds an "OIDC identity-provider setup" section to the operator console CLI docs (`docs/cli/dashboard.md`), documenting how the dashboard validates OIDC bearer tokens and the identity-provider configuration required to make OIDC mode work.

## Why

The dashboard validates `iss` (exact), `aud` (must contain the configured audience), and `azp` (must equal it when present) on every OIDC bearer token. The common wiring failure is the audience check: providers such as Keycloak issue access tokens with `aud: "account"` by default, so the token is rejected even though sign-in succeeds. Operators had no doc pointing at the audience-mapper step, so a correct-looking OIDC config failed with an opaque audience error.

## Contents

Explains the three claim checks, the audience-mapper requirement (with Keycloak as the concrete example), and how the `--oidc-audience` and `--oidc-role-claim` flags relate to the token claims. Sits alongside the existing mutual-TLS section as a parallel identity-provider guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring OIDC identity-provider setup for the dashboard.
  * Documented how the dashboard validates `iss`, `aud`, and `azp` during token authorization.
  * Included troubleshooting for common audience-mismatch failures, with Keycloak audience-mapper recommendations.
  * Clarified role/permission mapping using the configured role claim and role map, including denial of unmapped principals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->