### PR TITLE
fix(anchor): make the Rekor hashedrekord hash algorithm configurable (default sha256)

### DIFF
--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -45,6 +45,11 @@ const (
 	// deployment whose schema requires SHA-512 sets HashAlgorithm explicitly;
 	// hardcoding either algorithm would break the other class of Rekor server.
 	rekorDefaultSubmitHashAlgorithm = rekorSHA256Algorithm
+
+	// DefaultRekorHashAlgorithm is the hashedrekord data.hash.algorithm used
+	// when RekorLog.HashAlgorithm is unset. It is exported so CLI defaults stay
+	// tied to the anchor package behavior.
+	DefaultRekorHashAlgorithm = rekorDefaultSubmitHashAlgorithm
 )
 
 // RekorLog submits receipt-chain checkpoints to Rekor and stores the returned

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -11,6 +11,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
@@ -37,6 +38,13 @@ const (
 	rekorHashedRekordKind       = "hashedrekord"
 	rekorHashedRekordAPIVersion = "0.0.1"
 	rekorSHA256Algorithm        = "sha256"
+	rekorSHA512Algorithm        = "sha512"
+	// rekorDefaultSubmitHashAlgorithm is used when RekorLog.HashAlgorithm is
+	// unset. It defaults to SHA-256, which the hashedrekord 0.0.1 schema has
+	// always accepted and which public/common Rekor deployments support. A
+	// deployment whose schema requires SHA-512 sets HashAlgorithm explicitly;
+	// hardcoding either algorithm would break the other class of Rekor server.
+	rekorDefaultSubmitHashAlgorithm = rekorSHA256Algorithm
 )
 
 // RekorLog submits receipt-chain checkpoints to Rekor and stores the returned
@@ -47,6 +55,27 @@ type RekorLog struct {
 	HTTPClient     *http.Client
 	Signer         ed25519.PrivateKey
 	TrustedLogKeys []crypto.PublicKey
+	// HashAlgorithm selects the hashedrekord data.hash.algorithm for
+	// submissions ("sha256" or "sha512"). Empty means the default
+	// (rekorDefaultSubmitHashAlgorithm). Set it to match the target Rekor
+	// deployment's supported schema.
+	HashAlgorithm string
+}
+
+// submitHashAlgorithm resolves the configured submission hash algorithm,
+// falling back to the default when unset and rejecting anything the verifier
+// cannot recompute. Fail closed: an unsupported algorithm never submits.
+func (r RekorLog) submitHashAlgorithm() (string, error) {
+	algo := strings.TrimSpace(r.HashAlgorithm)
+	if algo == "" {
+		return rekorDefaultSubmitHashAlgorithm, nil
+	}
+	switch algo {
+	case rekorSHA256Algorithm, rekorSHA512Algorithm:
+		return algo, nil
+	default:
+		return "", fmt.Errorf("unsupported rekor hash algorithm %q (want %q or %q)", algo, rekorSHA256Algorithm, rekorSHA512Algorithm)
+	}
 }
 
 type rekorSubmitRequest struct {
@@ -122,13 +151,17 @@ func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
 	if err != nil {
 		return Proof{}, err
 	}
+	hashAlgorithm, err := r.submitHashAlgorithm()
+	if err != nil {
+		return Proof{}, err
+	}
 	body := rekorSubmitRequest{
 		APIVersion: rekorHashedRekordAPIVersion,
 		Kind:       rekorHashedRekordKind,
 		Spec: rekorSubmitSpec{
 			Data: rekorData{Hash: rekorHash{
-				Algorithm: rekorSHA256Algorithm,
-				Value:     sha256Hex(checkpointBytes),
+				Algorithm: hashAlgorithm,
+				Value:     rekorDigestHex(hashAlgorithm, checkpointBytes),
 			}},
 			Signature: rekorSignature{
 				Content:   signature,
@@ -292,10 +325,11 @@ func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
 	if body.APIVersion != rekorHashedRekordAPIVersion || body.Kind != rekorHashedRekordKind {
 		return fmt.Errorf("unsupported rekor body %s/%s", body.Kind, body.APIVersion)
 	}
-	if body.Spec.Data.Hash.Algorithm != rekorSHA256Algorithm {
-		return fmt.Errorf("unsupported rekor hash algorithm %q", body.Spec.Data.Hash.Algorithm)
+	expectedDigest, err := rekorDigestHexForAlgorithm(body.Spec.Data.Hash.Algorithm, checkpointBytes)
+	if err != nil {
+		return err
 	}
-	if body.Spec.Data.Hash.Value != sha256Hex(checkpointBytes) {
+	if body.Spec.Data.Hash.Value != expectedDigest {
 		return errors.New("rekor body checkpoint digest does not match bundle checkpoint")
 	}
 	if body.Spec.Signature.Content != proof.Rekor.Signature {
@@ -432,6 +466,25 @@ func checkpointBytes(checkpoint Checkpoint) ([]byte, error) {
 		return nil, fmt.Errorf("marshal checkpoint: %w", err)
 	}
 	return data, nil
+}
+
+func rekorDigestHexForAlgorithm(algorithm string, data []byte) (string, error) {
+	switch algorithm {
+	case rekorSHA256Algorithm, rekorSHA512Algorithm:
+		return rekorDigestHex(algorithm, data), nil
+	default:
+		return "", fmt.Errorf("unsupported rekor hash algorithm %q", algorithm)
+	}
+}
+
+func rekorDigestHex(algorithm string, data []byte) string {
+	switch algorithm {
+	case rekorSHA512Algorithm:
+		sum := sha512.Sum512(data)
+		return hex.EncodeToString(sum[:])
+	default:
+		return sha256Hex(data)
+	}
 }
 
 func signRekorCheckpoint(data []byte, priv ed25519.PrivateKey) (publicKey string, signature string, err error) {

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
@@ -81,6 +82,180 @@ func TestRekorLogSubmitRecordsSubmissionProof(t *testing.T) {
 	}
 }
 
+func TestRekorLogSubmitHashAlgorithm(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	checkpointBytes, err := checkpointBytes(checkpoint)
+	if err != nil {
+		t.Fatalf("checkpointBytes: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	// Default (HashAlgorithm unset) submits SHA-256: the hashedrekord schema
+	// default that public/common Rekor deployments accept.
+	defProof, err := (RekorLog{URL: fakeRekorServer(t).URL, Signer: priv}).Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit(default): %v", err)
+	}
+	defBody := decodeSubmittedRekorBody(t, defProof)
+	if defBody.Spec.Data.Hash.Algorithm != rekorSHA256Algorithm {
+		t.Fatalf("default hash algorithm = %q, want %q", defBody.Spec.Data.Hash.Algorithm, rekorSHA256Algorithm)
+	}
+	if got, want := defBody.Spec.Data.Hash.Value, sha256Hex(checkpointBytes); got != want {
+		t.Fatalf("default hash value = %q, want SHA-256 %q", got, want)
+	}
+	if err := validateRekorSubmissionRecord(defProof, checkpoint); err != nil {
+		t.Fatalf("validateRekorSubmissionRecord(default): %v", err)
+	}
+
+	// Explicit SHA-512: for a deployment whose schema requires it.
+	proof, err := (RekorLog{URL: fakeRekorServer(t).URL, Signer: priv, HashAlgorithm: rekorSHA512Algorithm}).Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit(sha512): %v", err)
+	}
+	body := decodeSubmittedRekorBody(t, proof)
+	if body.Spec.Data.Hash.Algorithm != rekorSHA512Algorithm {
+		t.Fatalf("hash algorithm = %q, want %q", body.Spec.Data.Hash.Algorithm, rekorSHA512Algorithm)
+	}
+	sum := sha512.Sum512(checkpointBytes)
+	if got, want := body.Spec.Data.Hash.Value, hex.EncodeToString(sum[:]); got != want {
+		t.Fatalf("hash value = %q, want SHA-512 %q", got, want)
+	}
+	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
+		t.Fatalf("validateRekorSubmissionRecord: %v", err)
+	}
+
+	// An unsupported algorithm fails closed at submit (never sends).
+	if _, err := (RekorLog{URL: fakeRekorServer(t).URL, Signer: priv, HashAlgorithm: "sha3-256"}).Submit(checkpoint); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
+		t.Fatalf("Submit(unsupported algorithm) err = %v, want unsupported algorithm error", err)
+	}
+
+	legacy := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
+		body.Spec.Data.Hash.Algorithm = rekorSHA256Algorithm
+		body.Spec.Data.Hash.Value = sha256Hex(checkpointBytes)
+	})
+	if err := validateRekorSubmissionRecord(legacy, checkpoint); err != nil {
+		t.Fatalf("validateRekorSubmissionRecord accepted legacy SHA-256 body: %v", err)
+	}
+
+	mismatched := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
+		body.Spec.Data.Hash.Value = sha256Hex(checkpointBytes)
+	})
+	if err := validateRekorSubmissionRecord(mismatched, checkpoint); err == nil || !strings.Contains(err.Error(), "digest") {
+		t.Fatalf("validateRekorSubmissionRecord err = %v, want digest mismatch", err)
+	}
+
+	tampered := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
+		body.Spec.Data.Hash.Value = strings.Repeat("0", sha512.Size*2)
+	})
+	if err := validateRekorSubmissionRecord(tampered, checkpoint); err == nil || !strings.Contains(err.Error(), "digest") {
+		t.Fatalf("validateRekorSubmissionRecord err = %v, want digest mismatch", err)
+	}
+	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
+		t.Fatalf("validateRekorSubmissionRecord after restore: %v", err)
+	}
+}
+
+func TestRekorLogVerifyAcceptsLegacySHA256HashedRekordDigest(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	logPub, logPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	_, entryPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey entry: %v", err)
+	}
+	proof := selfConsistentRekorProofWithAlgorithm(t, checkpoint, entryPriv, logPriv, rekorSHA256Algorithm)
+	if err := (RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}}).Verify(proof, checkpoint); err != nil {
+		t.Fatalf("Verify legacy SHA-256 body: %v", err)
+	}
+}
+
+func TestRekorLogVerifyRejectsCheckpointSubstitutionUnderBothHashAlgorithms(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	tamperedCheckpoint := checkpoint
+	tamperedCheckpoint.RootHash = strings.Repeat("f", sha256.Size*2)
+	if tamperedCheckpoint.RootHash == checkpoint.RootHash {
+		t.Fatal("tampered checkpoint did not change root hash")
+	}
+	logPub, logPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey log: %v", err)
+	}
+	_, entryPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey entry: %v", err)
+	}
+	_, attackerPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey attacker: %v", err)
+	}
+	verifier := RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}}
+
+	for _, algorithm := range []string{rekorSHA512Algorithm, rekorSHA256Algorithm} {
+		t.Run(algorithm, func(t *testing.T) {
+			proof := selfConsistentRekorProofWithAlgorithm(t, checkpoint, entryPriv, logPriv, algorithm)
+			if err := verifier.Verify(proof, checkpoint); err != nil {
+				t.Fatalf("Verify original proof: %v", err)
+			}
+			if err := verifier.Verify(proof, tamperedCheckpoint); err == nil {
+				t.Fatal("Verify accepted original proof for tampered checkpoint")
+			}
+
+			forged := proofWithRekorBodyForCheckpoint(t, proof, tamperedCheckpoint, attackerPriv, algorithm)
+			if err := validateRekorSubmissionRecord(forged, tamperedCheckpoint); err != nil {
+				t.Fatalf("validate forged submission record: %v", err)
+			}
+			if err := verifier.Verify(forged, tamperedCheckpoint); err == nil || !strings.Contains(err.Error(), "signed_entry_timestamp") {
+				t.Fatalf("Verify forged logged body err = %v, want SET failure", err)
+			}
+		})
+	}
+}
+
+func TestRekorSubmissionRecordRejectsUnsupportedHashAlgorithmBeforeDigestFallback(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	checkpointBytes, err := checkpointBytes(checkpoint)
+	if err != nil {
+		t.Fatalf("checkpointBytes: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	proof, err := (RekorLog{URL: fakeRekorServer(t).URL, Signer: priv}).Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	candidate := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
+		body.Spec.Data.Hash.Algorithm = "sha3-512"
+		body.Spec.Data.Hash.Value = sha256Hex(checkpointBytes)
+	})
+	if err := validateRekorSubmissionRecord(candidate, checkpoint); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
+		t.Fatalf("validateRekorSubmissionRecord err = %v, want unsupported algorithm", err)
+	}
+}
+
 func TestRekorSubmissionRecordRejectsTampering(t *testing.T) {
 	receipts, keyHex := testReceiptChain(t, 1)
 	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
@@ -99,23 +274,9 @@ func TestRekorSubmissionRecordRejectsTampering(t *testing.T) {
 	if proof.Rekor == nil {
 		t.Fatal("proof.Rekor nil")
 	}
-	bodyBytes, err := base64.StdEncoding.DecodeString(proof.Rekor.Body)
-	if err != nil {
-		t.Fatalf("DecodeString: %v", err)
-	}
-	var body rekorSubmitRequest
-	if err := json.Unmarshal(bodyBytes, &body); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	body.Spec.Data.Hash.Value = strings.Repeat("0", 64)
-	tamperedBody, err := json.Marshal(body)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	tampered := proof
-	tampered.Rekor = cloneRekorProof(proof.Rekor)
-	tampered.Rekor.Body = base64.StdEncoding.EncodeToString(tamperedBody)
-	tampered.EntryHash = sha256Hex([]byte(tampered.Rekor.Body))
+	tampered := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
+		body.Spec.Data.Hash.Value = strings.Repeat("0", sha512.Size*2)
+	})
 	if err := validateRekorSubmissionRecord(tampered, checkpoint); err == nil || !strings.Contains(err.Error(), "digest") {
 		t.Fatalf("validateRekorSubmissionRecord err = %v, want digest mismatch", err)
 	}
@@ -669,6 +830,58 @@ func cloneRekorProof(in *RekorProof) *RekorProof {
 	return &out
 }
 
+func decodeSubmittedRekorBody(t *testing.T, proof Proof) rekorSubmitRequest {
+	t.Helper()
+	if proof.Rekor == nil {
+		t.Fatal("proof.Rekor nil")
+	}
+	bodyBytes, err := base64.StdEncoding.DecodeString(proof.Rekor.Body)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	var body rekorSubmitRequest
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	return body
+}
+
+func proofWithRekorBody(t *testing.T, proof Proof, edit func(*rekorSubmitRequest)) Proof {
+	t.Helper()
+	body := decodeSubmittedRekorBody(t, proof)
+	edit(&body)
+	tamperedBody, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	candidate := proof
+	candidate.Rekor = cloneRekorProof(proof.Rekor)
+	candidate.Rekor.Body = base64.StdEncoding.EncodeToString(tamperedBody)
+	candidate.EntryHash = sha256Hex([]byte(candidate.Rekor.Body))
+	return candidate
+}
+
+func proofWithRekorBodyForCheckpoint(t *testing.T, proof Proof, checkpoint Checkpoint, signer ed25519.PrivateKey, algorithm string) Proof {
+	t.Helper()
+	checkpointBytes, err := checkpointBytes(checkpoint)
+	if err != nil {
+		t.Fatalf("checkpointBytes: %v", err)
+	}
+	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, signer)
+	if err != nil {
+		t.Fatalf("signRekorCheckpoint: %v", err)
+	}
+	candidate := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
+		body.Spec.Data.Hash.Algorithm = algorithm
+		body.Spec.Data.Hash.Value = rekorDigestHex(algorithm, checkpointBytes)
+		body.Spec.Signature.Content = signature
+		body.Spec.Signature.PublicKey.Content = publicKey
+	})
+	candidate.Rekor.PublicKey = publicKey
+	candidate.Rekor.Signature = signature
+	return candidate
+}
+
 func mustEd25519PublicKey(t *testing.T) ed25519.PublicKey {
 	t.Helper()
 	pub, _, err := ed25519.GenerateKey(rand.Reader)
@@ -779,6 +992,11 @@ func encodedRekorRequestBody(t *testing.T, r *http.Request) string {
 
 func selfConsistentRekorProof(t *testing.T, checkpoint Checkpoint, entrySigner, logSigner ed25519.PrivateKey) Proof {
 	t.Helper()
+	return selfConsistentRekorProofWithAlgorithm(t, checkpoint, entrySigner, logSigner, rekorDefaultSubmitHashAlgorithm)
+}
+
+func selfConsistentRekorProofWithAlgorithm(t *testing.T, checkpoint Checkpoint, entrySigner, logSigner ed25519.PrivateKey, algorithm string) Proof {
+	t.Helper()
 	checkpointBytes, err := checkpointBytes(checkpoint)
 	if err != nil {
 		t.Fatalf("checkpointBytes: %v", err)
@@ -792,8 +1010,8 @@ func selfConsistentRekorProof(t *testing.T, checkpoint Checkpoint, entrySigner, 
 		Kind:       rekorHashedRekordKind,
 		Spec: rekorSubmitSpec{
 			Data: rekorData{Hash: rekorHash{
-				Algorithm: rekorSHA256Algorithm,
-				Value:     sha256Hex(checkpointBytes),
+				Algorithm: algorithm,
+				Value:     rekorDigestHex(algorithm, checkpointBytes),
 			}},
 			Signature: rekorSignature{
 				Content:   signature,

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -75,7 +75,7 @@ verify Rekor bundles with pipelock-verifier independent --rekor-log-key.`,
 	cmd.Flags().StringVar(&opts.logID, "log-id", anchorpkg.DefaultLocalLogID, "local fake-log identifier")
 	cmd.Flags().StringVar(&opts.rekorURL, "rekor-url", "", "Rekor base URL (required for the rekor backend; no public default so receipt metadata stays in your trust boundary)")
 	cmd.Flags().StringVar(&opts.rekorKey, "rekor-key", "", "Ed25519 private key file used to sign the Rekor checkpoint entry")
-	cmd.Flags().StringVar(&opts.rekorHash, "rekor-hash-algorithm", "sha256", "hashedrekord data hash algorithm to submit (sha256 or sha512); match the target Rekor deployment's supported schema")
+	cmd.Flags().StringVar(&opts.rekorHash, "rekor-hash-algorithm", anchorpkg.DefaultRekorHashAlgorithm, "hashedrekord data hash algorithm to submit (sha256 or sha512); match the target Rekor deployment's supported schema")
 	cmd.Flags().BoolVar(&opts.rekorYes, "yes-send-to-remote-log", false, "acknowledge Rekor anchoring sends checkpoint material to the configured remote log")
 	cmd.Flags().StringVar(&opts.output, "out", "", "anchor bundle output path")
 	return cmd

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -29,6 +29,7 @@ type receiptsOptions struct {
 	logID     string
 	rekorURL  string
 	rekorKey  string
+	rekorHash string
 	rekorYes  bool
 	output    string
 }
@@ -74,6 +75,7 @@ verify Rekor bundles with pipelock-verifier independent --rekor-log-key.`,
 	cmd.Flags().StringVar(&opts.logID, "log-id", anchorpkg.DefaultLocalLogID, "local fake-log identifier")
 	cmd.Flags().StringVar(&opts.rekorURL, "rekor-url", "", "Rekor base URL (required for the rekor backend; no public default so receipt metadata stays in your trust boundary)")
 	cmd.Flags().StringVar(&opts.rekorKey, "rekor-key", "", "Ed25519 private key file used to sign the Rekor checkpoint entry")
+	cmd.Flags().StringVar(&opts.rekorHash, "rekor-hash-algorithm", "sha256", "hashedrekord data hash algorithm to submit (sha256 or sha512); match the target Rekor deployment's supported schema")
 	cmd.Flags().BoolVar(&opts.rekorYes, "yes-send-to-remote-log", false, "acknowledge Rekor anchoring sends checkpoint material to the configured remote log")
 	cmd.Flags().StringVar(&opts.output, "out", "", "anchor bundle output path")
 	return cmd
@@ -272,7 +274,7 @@ func resolveBackend(opts receiptsOptions) (anchorpkg.Backend, error) {
 		if err != nil {
 			return nil, err
 		}
-		return anchorpkg.RekorLog{URL: opts.rekorURL, Signer: key}, nil
+		return anchorpkg.RekorLog{URL: opts.rekorURL, Signer: key, HashAlgorithm: opts.rekorHash}, nil
 	default:
 		return nil, fmt.Errorf("unsupported anchor backend %q", opts.backend)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -102,18 +102,27 @@ func installReloadWaiter(t *testing.T) <-chan struct{} {
 // an HTTP effect rather than a stderr message.
 func awaitReloadCycle(t *testing.T, reloaded <-chan struct{}, buf *cliTestBuffer, errCh <-chan error, cancel context.CancelFunc) {
 	t.Helper()
+	if err := awaitReloadCycleResult(reloaded, buf, errCh); err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+}
+
+func awaitReloadCycleResult(reloaded <-chan struct{}, buf *cliTestBuffer, errCh <-chan error) error {
 	dump := ""
 	if buf != nil {
 		dump = "\nstderr:\n" + buf.String()
 	}
 	select {
 	case <-reloaded:
+		return nil
 	case cmdErr := <-errCh:
-		cancel()
-		t.Fatalf("run exited before reload completed: %v%s", cmdErr, dump)
+		if cmdErr == nil {
+			return fmt.Errorf("run exited before reload completed%s", dump)
+		}
+		return fmt.Errorf("run exited before reload completed: %w%s", cmdErr, dump)
 	case <-time.After(reloadWaitBackstop):
-		cancel()
-		t.Fatalf("timed out waiting for config reload cycle%s", dump)
+		return fmt.Errorf("timed out waiting for config reload cycle%s", dump)
 	}
 }
 
@@ -123,11 +132,20 @@ func awaitReloadCycle(t *testing.T, reloaded <-chan struct{}, buf *cliTestBuffer
 // against a wall-clock deadline.
 func requireCLIOutputAfterReload(t *testing.T, reloaded <-chan struct{}, buf *cliTestBuffer, errCh <-chan error, cancel context.CancelFunc, want string) {
 	t.Helper()
-	awaitReloadCycle(t, reloaded, buf, errCh, cancel)
-	if !buf.contains(want) {
+	if err := requireCLIOutputAfterReloadResult(reloaded, buf, errCh, want); err != nil {
 		cancel()
-		t.Fatalf("expected %q in stderr after reload, got:\n%s", want, buf.String())
+		t.Fatal(err)
 	}
+}
+
+func requireCLIOutputAfterReloadResult(reloaded <-chan struct{}, buf *cliTestBuffer, errCh <-chan error, want string) error {
+	if err := awaitReloadCycleResult(reloaded, buf, errCh); err != nil {
+		return err
+	}
+	if !buf.contains(want) {
+		return fmt.Errorf("expected %q in stderr after reload, got:\n%s", want, buf.String())
+	}
+	return nil
 }
 
 func waitForRunHTTP(
@@ -2250,7 +2268,10 @@ fetch_proxy:
 			t.Fatal(writeErr)
 		}
 
-		requireCLIOutputAfterReload(t, reloaded, stderr, errCh, cancel, "metrics_listen changed")
+		if err := requireCLIOutputAfterReloadResult(reloaded, stderr, errCh, "metrics_listen changed"); err != nil {
+			cancel()
+			return err
+		}
 
 		cancel()
 		select {


### PR DESCRIPTION
## What

Makes the Rekor hashedrekord submission hash algorithm configurable (`--rekor-hash-algorithm`, `RekorLog.HashAlgorithm`), defaulting to `sha256`, instead of hardcoding it.

## Why

Rekor deployments disagree on the hashedrekord `data.hash.algorithm`: SHA-256 is the 0.0.1 schema default that public and common instances accept, while some deployments require SHA-512. Hardcoding either algorithm breaks the other class of server, and a hardcoded SHA-512 could be rejected by a common Rekor, silently failing all checkpoint anchoring. Defaulting to SHA-256 keeps the compatible behavior; an operator whose Rekor requires SHA-512 selects it explicitly.

## Behavior

Submission uses the configured algorithm (default `sha256`) and fails closed on an unsupported value without sending anything. Verification recomputes the expected digest from the body's declared algorithm, accepting `sha256` and `sha512` and rejecting anything else. The Ed25519 checkpoint signature and the inclusion proof against the pinned log key remain the trust anchor, so a tampered checkpoint fails verification regardless of which digest algorithm the body declares.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SHA-256 and SHA-512 hashing when anchoring checkpoints in Rekor.
  * Added the `--rekor-hash-algorithm` CLI option (default: SHA-256) and use it during Rekor submission.
  * Rekor verification now uses the hash algorithm recorded in each submission.

* **Bug Fixes**
  * Unsupported hash algorithms are rejected safely (no digest fallback).
  * Strengthened protections against checkpoint substitution/tampered Rekor records.
  * Maintains compatibility with existing SHA-256 Rekor records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->