### PR TITLE
fix(reload): fail closed when a bundle-resolution error would drop live detection rules

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ Config changes are picked up automatically via file watcher or SIGHUP signal (10
 
 On reload, the scanner and session manager are atomically swapped. Kill switch state (all 4 sources) is preserved. Existing MCP sessions retain the old scanner until the next request.
 
-If a reload fails validation (invalid regex, security downgrade), the old config is retained and a warning is logged.
+If a reload fails validation (invalid regex, security downgrade), the old config is retained and a warning is logged. A reload is also rejected, in any mode, when a rule-bundle resolution error (bad signature, missing lock file, version mismatch, filesystem error) would drop detection rules that are currently live: the previous config is kept so a transient bundle failure cannot silently weaken coverage. An unrelated bundle error that does not remove any live rule does not block the reload. At startup there is no prior config to preserve, so a bundle resolution error is surfaced loudly and the proxy runs on its remaining (core plus compiled) patterns rather than refusing to start.
 
 **Reload exceptions:** the Sentry crash-report sanitizer captures the DLP pattern list at startup and does **not** update on reload. If you add DLP patterns used to scrub Sentry events, restart pipelock to propagate them. A warning is logged on any reload that changes `dlp.patterns` while Sentry is enabled: `DLP patterns changed; Sentry scrubber uses init-time patterns until restart`.
 

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -876,6 +876,29 @@ func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 	}
 }
 
+func TestApplyConductorPolicyBundleWithBundleResolutionErrorPreservesCoverage(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+
+	s, signer := newConductorApplyTestServer(t)
+	requireBundlePatternSelected(t, s.proxy.CurrentConfig().DLP.Patterns, s.proxy.CurrentConfig().ResponseScanning.Patterns)
+	if err := os.Remove(filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName, "bundle.lock")); err != nil {
+		t.Fatalf("remove standard bundle lock: %v", err)
+	}
+
+	bundle := signedRuntimePolicyBundle(t, signer, "bundle-with-broken-rules-dir", 1, "", strings.Join([]string{
+		"mode: strict",
+		"api_allowlist:",
+		"  - api.example.com",
+		"",
+	}, "\n"))
+	if _, err := s.ApplyConductorPolicyBundle(bundle, ConductorApplyOptions{Resolver: signer.resolver()}); err != nil {
+		t.Fatalf("valid conductor apply should preserve local bundle coverage and reload despite rules-dir error: %v", err)
+	}
+	requireBundlePatternSelected(t, s.proxy.CurrentConfig().DLP.Patterns, s.proxy.CurrentConfig().ResponseScanning.Patterns)
+}
+
 func TestApplyConductorPolicyBundleFailsClosed(t *testing.T) {
 	if _, err := (*Server)(nil).ApplyConductorPolicyBundle(conductor.PolicyBundle{}, ConductorApplyOptions{}); err == nil {
 		t.Fatal("nil server ApplyConductorPolicyBundle() = nil, want error")

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -181,6 +181,13 @@ type Server struct {
 	// pointer out of sync with the running config.
 	conductorApplyMu sync.Mutex
 
+	// reloadMu serializes the whole hot-reload activation boundary: old-state
+	// snapshot, bundle downgrade gates, proxy publication, and runtime mirror
+	// refresh. proxy.Reload has its own lock, but that only covers lower-level
+	// pointer publication; the server-level gates also depend on s.stateMu-backed
+	// mirrors such as mcpToolExtraPoison.
+	reloadMu sync.Mutex
+
 	stateMu            sync.RWMutex
 	toolPolicyCfg      *policy.Config
 	mcpChainMatcher    *chains.Matcher
@@ -341,6 +348,11 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: %s\n", w)
 	}
 	if bundleResult.Degraded {
+		// Startup has no previous live bundle-resolved config to preserve, so a
+		// corrupt installed bundle is surfaced loudly but does not hard-fail the
+		// proxy. Hard-failing here would let one bad optional bundle deny service
+		// for the whole control. Hot reload has a separate activation-boundary
+		// gate that rejects bundle errors only when they would drop live coverage.
 		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: DEGRADED — standard pack failed, running core patterns only\n")
 	}
 	if hasMCPListen {

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -564,11 +564,16 @@ func bundleResolutionRejectReason(
 		return ""
 	}
 
+	// The dropped patterns above name exactly what was lost per surface. The
+	// suffix lists the bundle load errors observed during this reload as
+	// context; it is not a causal attribution (an unrelated bundle can error in
+	// the same reload without dropping any live rule), so it is labelled as
+	// such to avoid pointing an operator at the wrong bundle.
 	names := make([]string, 0, len(result.Errors))
 	for _, e := range result.Errors {
 		names = append(names, e.Name)
 	}
-	return strings.Join(reasons, "; ") + " (bundle errors: " + strings.Join(names, ", ") + ")"
+	return strings.Join(reasons, "; ") + " (bundle load errors this reload: " + strings.Join(names, ", ") + ")"
 }
 
 func removedBundleDLPPatterns(old, updated []config.DLPPattern) []string {

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -364,7 +364,7 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		// currently-live bundle rules. This gate is mode-independent so balanced
 		// and audit deployments fail closed for the real weakening without
 		// rejecting unrelated bundle errors that do not remove live coverage.
-		if reason := bundleResolutionRejectReason(oldCfg, newCfg, warnings, reloadBundleResult, s.currentMCPToolExtraPoison()); reason != "" {
+		if reason := bundleResolutionRejectReason(oldCfg, newCfg, reloadBundleResult, s.currentMCPToolExtraPoison()); reason != "" {
 			rejectErr := fmt.Errorf("rejected: bundle resolution error would drop live detection rules: %s", reason)
 			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload rejected: %v\n", rejectErr)
 			s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
@@ -538,7 +538,6 @@ func reloadDowngradeRejectReason(oldCfg *config.Config, warnings []config.Reload
 
 func bundleResolutionRejectReason(
 	oldCfg, newCfg *config.Config,
-	warnings []config.ReloadWarning,
 	result *rules.LoadResult,
 	oldToolPoison []*tools.ExtraPoisonPattern,
 ) string {
@@ -546,16 +545,17 @@ func bundleResolutionRejectReason(
 		return ""
 	}
 
+	// Enforce by comparing the live bundle-sourced rules against the resolved
+	// candidate directly, independent of whether ValidateReload emitted a
+	// warning for the same drop. Coupling enforcement to warning generation
+	// would be brittle: a suppressed, renamed, or missed warning must not be
+	// able to bypass this coverage-drop check.
 	var reasons []string
-	if reloadWarningsContainField(warnings, "dlp.patterns") {
-		if dropped := removedBundleDLPPatterns(oldCfg.DLP.Patterns, newCfg.DLP.Patterns); len(dropped) > 0 {
-			reasons = append(reasons, "dlp.patterns: "+strings.Join(dropped, ", "))
-		}
+	if dropped := removedBundleDLPPatterns(oldCfg.DLP.Patterns, newCfg.DLP.Patterns); len(dropped) > 0 {
+		reasons = append(reasons, "dlp.patterns: "+strings.Join(dropped, ", "))
 	}
-	if reloadWarningsContainField(warnings, "response_scanning.patterns") {
-		if dropped := removedBundleResponsePatterns(oldCfg.ResponseScanning.Patterns, newCfg.ResponseScanning.Patterns); len(dropped) > 0 {
-			reasons = append(reasons, "response_scanning.patterns: "+strings.Join(dropped, ", "))
-		}
+	if dropped := removedBundleResponsePatterns(oldCfg.ResponseScanning.Patterns, newCfg.ResponseScanning.Patterns); len(dropped) > 0 {
+		reasons = append(reasons, "response_scanning.patterns: "+strings.Join(dropped, ", "))
 	}
 	if dropped := removedBundleToolPoisonPatterns(oldToolPoison, rules.ConvertToolPoison(result.ToolPoison)); len(dropped) > 0 {
 		reasons = append(reasons, "mcp_tool_scanning.tool_poison: "+strings.Join(dropped, ", "))
@@ -569,15 +569,6 @@ func bundleResolutionRejectReason(
 		names = append(names, e.Name)
 	}
 	return strings.Join(reasons, "; ") + " (bundle errors: " + strings.Join(names, ", ") + ")"
-}
-
-func reloadWarningsContainField(warnings []config.ReloadWarning, field string) bool {
-	for _, w := range warnings {
-		if w.Field == field {
-			return true
-		}
-	}
-	return false
 }
 
 func removedBundleDLPPatterns(old, updated []config.DLPPattern) []string {

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -17,6 +17,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/policy"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/rules"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
@@ -32,6 +33,9 @@ import (
 // "proxy kept the previous config" fail-safe path when proxy.Reload aborts its
 // internal swap. Silent no-ops (dedup, restart-only field changes) return nil.
 func (s *Server) Reload(newCfg *config.Config) (err error) {
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
+
 	defer func() {
 		if r := recover(); r != nil {
 			ReloadPanicHandler(r, s.sentry, s.logger, s.opts.ConfigFile)
@@ -354,6 +358,18 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
 			return rejectErr
 		}
+		// Bundle load failures are warning-only at startup because there is no
+		// previous live bundle coverage to preserve. At reload there is: a fresh
+		// config that fails bundle resolution must not activate if it would drop
+		// currently-live bundle rules. This gate is mode-independent so balanced
+		// and audit deployments fail closed for the real weakening without
+		// rejecting unrelated bundle errors that do not remove live coverage.
+		if reason := bundleResolutionRejectReason(oldCfg, newCfg, warnings, reloadBundleResult, s.currentMCPToolExtraPoison()); reason != "" {
+			rejectErr := fmt.Errorf("rejected: bundle resolution error would drop live detection rules: %s", reason)
+			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload rejected: %v\n", rejectErr)
+			s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
+			return rejectErr
+		}
 	}
 	newSc := scanner.New(newCfg)
 	newSc.SetDLPWarnHook(func(ctx context.Context, patternName, severity string) {
@@ -362,6 +378,7 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 	if !s.proxy.Reload(newCfg, newSc) {
 		return errors.New("reload failed: proxy kept previous config")
 	}
+	fireReloadAfterProxySwapHook(s)
 	s.refreshRuntimeState(oldCfg, newCfg, reloadBundleResult, s.proxy.ScannerPtr().Load())
 	if reloadErr := s.proxy.LoadCertCache(newCfg); reloadErr != nil {
 		s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile),
@@ -517,6 +534,128 @@ func reloadDowngradeRejectReason(oldCfg *config.Config, warnings []config.Reload
 		return ""
 	}
 	return "required security mode (" + strings.Join(required, ", ") + ")"
+}
+
+func bundleResolutionRejectReason(
+	oldCfg, newCfg *config.Config,
+	warnings []config.ReloadWarning,
+	result *rules.LoadResult,
+	oldToolPoison []*tools.ExtraPoisonPattern,
+) string {
+	if oldCfg == nil || newCfg == nil || result == nil || len(result.Errors) == 0 {
+		return ""
+	}
+
+	var reasons []string
+	if reloadWarningsContainField(warnings, "dlp.patterns") {
+		if dropped := removedBundleDLPPatterns(oldCfg.DLP.Patterns, newCfg.DLP.Patterns); len(dropped) > 0 {
+			reasons = append(reasons, "dlp.patterns: "+strings.Join(dropped, ", "))
+		}
+	}
+	if reloadWarningsContainField(warnings, "response_scanning.patterns") {
+		if dropped := removedBundleResponsePatterns(oldCfg.ResponseScanning.Patterns, newCfg.ResponseScanning.Patterns); len(dropped) > 0 {
+			reasons = append(reasons, "response_scanning.patterns: "+strings.Join(dropped, ", "))
+		}
+	}
+	if dropped := removedBundleToolPoisonPatterns(oldToolPoison, rules.ConvertToolPoison(result.ToolPoison)); len(dropped) > 0 {
+		reasons = append(reasons, "mcp_tool_scanning.tool_poison: "+strings.Join(dropped, ", "))
+	}
+	if len(reasons) == 0 {
+		return ""
+	}
+
+	names := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		names = append(names, e.Name)
+	}
+	return strings.Join(reasons, "; ") + " (bundle errors: " + strings.Join(names, ", ") + ")"
+}
+
+func reloadWarningsContainField(warnings []config.ReloadWarning, field string) bool {
+	for _, w := range warnings {
+		if w.Field == field {
+			return true
+		}
+	}
+	return false
+}
+
+func removedBundleDLPPatterns(old, updated []config.DLPPattern) []string {
+	return removedBundleNamedRegexPatterns(old, updated,
+		func(p config.DLPPattern) string { return p.Name },
+		func(p config.DLPPattern) string { return p.Regex },
+		func(p config.DLPPattern) string { return p.Bundle })
+}
+
+func removedBundleResponsePatterns(old, updated []config.ResponseScanPattern) []string {
+	return removedBundleNamedRegexPatterns(old, updated,
+		func(p config.ResponseScanPattern) string { return p.Name },
+		func(p config.ResponseScanPattern) string { return p.Regex },
+		func(p config.ResponseScanPattern) string { return p.Bundle })
+}
+
+func removedBundleNamedRegexPatterns[T any](
+	old, updated []T,
+	nameOf func(T) string,
+	regexOf func(T) string,
+	bundleOf func(T) string,
+) []string {
+	updatedByName := make(map[string]string, len(updated))
+	for _, p := range updated {
+		updatedByName[nameOf(p)] = regexOf(p)
+	}
+
+	var removed []string
+	for _, p := range old {
+		if bundleOf(p) == "" {
+			continue
+		}
+		name := nameOf(p)
+		newRegex, ok := updatedByName[name]
+		switch {
+		case !ok:
+			removed = append(removed, name)
+		case newRegex != regexOf(p):
+			removed = append(removed, name+" (regex changed)")
+		}
+	}
+	return removed
+}
+
+func removedBundleToolPoisonPatterns(old, updated []*tools.ExtraPoisonPattern) []string {
+	updatedByName := make(map[string]string, len(updated))
+	for _, p := range updated {
+		if p == nil {
+			continue
+		}
+		updatedByName[p.Name] = toolPoisonPatternIdentity(p)
+	}
+
+	var removed []string
+	for _, p := range old {
+		if p == nil || p.Bundle == "" {
+			continue
+		}
+		identity, ok := updatedByName[p.Name]
+		switch {
+		case !ok:
+			removed = append(removed, p.Name)
+		case identity != toolPoisonPatternIdentity(p):
+			removed = append(removed, p.Name+" (regex or scan_field changed)")
+		}
+	}
+	return removed
+}
+
+func toolPoisonPatternIdentity(p *tools.ExtraPoisonPattern) string {
+	if p == nil {
+		return ""
+	}
+	regex := ""
+	if p.Re != nil {
+		regex = p.Re.String()
+	}
+	return regex + "\x00" + p.ScanField
 }
 
 func hasRejectableDowngradeWarning(warnings []config.ReloadWarning) bool {

--- a/internal/cli/runtime/server_reload_hooks.go
+++ b/internal/cli/runtime/server_reload_hooks.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import "sync/atomic"
+
+var reloadAfterProxySwapHook atomic.Pointer[func(*Server)]
+
+func setReloadAfterProxySwapHookForTest(fn func(*Server)) (restore func()) {
+	prev := reloadAfterProxySwapHook.Load()
+	if fn == nil {
+		reloadAfterProxySwapHook.Store(nil)
+	} else {
+		reloadAfterProxySwapHook.Store(&fn)
+	}
+	return func() { reloadAfterProxySwapHook.Store(prev) }
+}
+
+func fireReloadAfterProxySwapHook(s *Server) {
+	if p := reloadAfterProxySwapHook.Load(); p != nil {
+		(*p)(s)
+	}
+}

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -116,6 +117,66 @@ rules:
 		SignerFingerprint: rules.KeyFingerprint(pub),
 	}); err != nil {
 		t.Fatalf("write bundle.lock: %v", err)
+	}
+}
+
+func installServerTestToolPoisonBundle(t *testing.T, xdgDataHome string) string {
+	t.Helper()
+
+	bundleDir := filepath.Join(xdgDataHome, "pipelock", "rules", "community-tool-poison")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("mkdir tool-poison bundle dir: %v", err)
+	}
+	bundleYAML := `format_version: 1
+name: community-tool-poison
+version: "2026.07.0"
+author: Test Author
+description: Test tool-poison bundle
+license: Apache-2.0
+rules:
+  - id: tool-poison-shell
+    type: tool-poison
+    status: stable
+    name: Shell Tool Poison
+    description: Detects shell-like tool poison
+    severity: critical
+    confidence: high
+    pattern:
+      regex: 'test-tool-poison'
+      scan_field: description
+`
+	bundlePath := filepath.Join(bundleDir, "bundle.yaml")
+	if err := os.WriteFile(bundlePath, []byte(bundleYAML), 0o600); err != nil {
+		t.Fatalf("write tool-poison bundle.yaml: %v", err)
+	}
+	sum := sha256.Sum256([]byte(bundleYAML))
+	if err := rules.WriteLockFile(filepath.Join(bundleDir, "bundle.lock"), &rules.LockFile{
+		InstalledVersion: "2026.07.0",
+		Source:           "test",
+		BundleSHA256:     hex.EncodeToString(sum[:]),
+		Unsigned:         true,
+	}); err != nil {
+		t.Fatalf("write tool-poison bundle.lock: %v", err)
+	}
+	return bundleDir
+}
+
+func installServerTestBrokenBundle(t *testing.T, xdgDataHome string) {
+	t.Helper()
+
+	bundleDir := filepath.Join(xdgDataHome, "pipelock", "rules", "broken-community")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("mkdir broken bundle dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "bundle.yaml"), []byte(`format_version: 1
+name: broken-community
+version: "2026.07.0"
+author: Test Author
+description: Broken bundle without a lock file
+license: Apache-2.0
+rules: []
+`), 0o600); err != nil {
+		t.Fatalf("write broken bundle.yaml: %v", err)
 	}
 }
 
@@ -1118,6 +1179,241 @@ func TestServer_Reload_StrictRejectsActionDowngrade(t *testing.T) {
 	if !buf.contains("response_scanning.action") {
 		t.Fatalf("stderr missing action downgrade warning:\n%s", buf.String())
 	}
+}
+
+func TestServer_Reload_BundleResolutionErrorRejectsBalancedCoverageDrop(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+
+	s, buf := newTestServer(t, nil)
+	oldLive := s.proxy.CurrentConfig()
+	oldScanner := s.proxy.ScannerPtr().Load()
+	requireBundlePatternSelected(t, oldLive.DLP.Patterns, oldLive.ResponseScanning.Patterns)
+
+	if err := os.Remove(filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName, "bundle.lock")); err != nil {
+		t.Fatalf("remove standard bundle lock: %v", err)
+	}
+	buf.reset()
+
+	reloaded := config.Defaults()
+	reloaded.KillSwitch.APIToken = "should-not-activate"
+	err := s.Reload(reloaded)
+	if err == nil {
+		t.Fatal("balanced reload with bundle error dropping live bundle patterns should reject")
+	}
+	if !strings.Contains(err.Error(), "bundle resolution error would drop live detection rules") {
+		t.Fatalf("error = %q, want bundle-resolution coverage-drop rejection", err.Error())
+	}
+	if s.proxy.CurrentConfig() != oldLive {
+		t.Fatal("live config pointer changed after rejected bundle-resolution reload")
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("scanner swapped despite rejected bundle-resolution reload")
+	}
+	requireBundlePatternSelected(t, s.proxy.CurrentConfig().DLP.Patterns, s.proxy.CurrentConfig().ResponseScanning.Patterns)
+	if live := s.proxy.CurrentConfig(); live.KillSwitch.APIToken == "should-not-activate" {
+		t.Fatal("rejected bundle-resolution reload activated unrelated config edit")
+	}
+	if !buf.contains("dlp.patterns") || !buf.contains("response_scanning.patterns") {
+		t.Fatalf("stderr missing bundle pattern removal warnings:\n%s", buf.String())
+	}
+}
+
+func TestServer_Reload_CleanBundleResolutionStillApplies(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+
+	s, _ := newTestServer(t, nil)
+	requireBundlePatternSelected(t, s.proxy.CurrentConfig().DLP.Patterns, s.proxy.CurrentConfig().ResponseScanning.Patterns)
+
+	reloaded := config.Defaults()
+	reloaded.KillSwitch.APIToken = "clean-reload-token"
+	if err := s.Reload(reloaded); err != nil {
+		t.Fatalf("clean bundle-resolved reload should apply: %v", err)
+	}
+	live := s.proxy.CurrentConfig()
+	if live.KillSwitch.APIToken != "clean-reload-token" {
+		t.Fatalf("api token = %q, want clean-reload-token", live.KillSwitch.APIToken)
+	}
+	requireBundlePatternSelected(t, live.DLP.Patterns, live.ResponseScanning.Patterns)
+}
+
+func TestServer_Reload_StrictBundleResolutionErrorStillUsesStrictDowngradeGate(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.Mode = config.ModeStrict
+		o.ModeChanged = true
+	})
+	oldLive := s.proxy.CurrentConfig()
+	oldScanner := s.proxy.ScannerPtr().Load()
+	requireBundlePatternSelected(t, oldLive.DLP.Patterns, oldLive.ResponseScanning.Patterns)
+
+	if err := os.Remove(filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName, "bundle.lock")); err != nil {
+		t.Fatalf("remove standard bundle lock: %v", err)
+	}
+
+	reloaded := config.Defaults()
+	reloaded.Mode = config.ModeStrict
+	err := s.Reload(reloaded)
+	if err == nil || !strings.Contains(err.Error(), "security downgrade from strict mode") {
+		t.Fatalf("strict bundle-error reload error = %v, want strict security downgrade rejection", err)
+	}
+	if s.proxy.CurrentConfig() != oldLive {
+		t.Fatal("live config pointer changed after rejected strict bundle reload")
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("scanner swapped despite rejected strict bundle reload")
+	}
+}
+
+func TestServer_Reload_UnrelatedBundleErrorWithoutLiveBundleCoverageApplies(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestBrokenBundle(t, xdgDataHome)
+
+	s, buf := newTestServer(t, nil)
+	for _, p := range s.proxy.CurrentConfig().DLP.Patterns {
+		if p.Bundle != "" {
+			t.Fatalf("test setup unexpectedly has live bundle DLP pattern: %+v", p)
+		}
+	}
+	for _, p := range s.proxy.CurrentConfig().ResponseScanning.Patterns {
+		if p.Bundle != "" {
+			t.Fatalf("test setup unexpectedly has live bundle response pattern: %+v", p)
+		}
+	}
+
+	buf.reset()
+	reloaded := config.Defaults()
+	reloaded.KillSwitch.APIToken = "allowed-with-unrelated-bundle-error"
+	if err := s.Reload(reloaded); err != nil {
+		t.Fatalf("bundle error with no live bundle coverage drop should not wedge reload: %v", err)
+	}
+	if live := s.proxy.CurrentConfig(); live.KillSwitch.APIToken != "allowed-with-unrelated-bundle-error" {
+		t.Fatalf("api token = %q, want reload to apply", live.KillSwitch.APIToken)
+	}
+	if !buf.contains("bundle broken-community") {
+		t.Fatalf("stderr missing broken bundle warning:\n%s", buf.String())
+	}
+}
+
+func TestServer_Reload_BundleResolutionErrorRejectsToolPoisonCoverageDrop(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	bundleDir := installServerTestToolPoisonBundle(t, xdgDataHome)
+
+	s, _ := newTestServer(t, nil)
+	oldLive := s.proxy.CurrentConfig()
+	oldScanner := s.proxy.ScannerPtr().Load()
+	if got := s.currentMCPToolExtraPoison(); len(got) != 1 || got[0].Name != "community-tool-poison:tool-poison-shell" {
+		t.Fatalf("live tool-poison patterns = %+v, want installed bundle pattern", got)
+	}
+	if err := os.Remove(filepath.Join(bundleDir, "bundle.lock")); err != nil {
+		t.Fatalf("remove tool-poison bundle lock: %v", err)
+	}
+
+	reloaded := config.Defaults()
+	reloaded.KillSwitch.APIToken = "tool-poison-drop"
+	err := s.Reload(reloaded)
+	if err == nil {
+		t.Fatal("reload dropping live bundle tool-poison patterns should reject")
+	}
+	if !strings.Contains(err.Error(), "mcp_tool_scanning.tool_poison") {
+		t.Fatalf("error = %q, want tool-poison coverage-drop rejection", err.Error())
+	}
+	if s.proxy.CurrentConfig() != oldLive {
+		t.Fatal("live config pointer changed after rejected tool-poison reload")
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("scanner swapped despite rejected tool-poison reload")
+	}
+	if got := s.currentMCPToolExtraPoison(); len(got) != 1 || got[0].Name != "community-tool-poison:tool-poison-shell" {
+		t.Fatalf("live tool-poison patterns after rejection = %+v, want preserved bundle pattern", got)
+	}
+}
+
+func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+
+	s, _ := newTestServer(t, nil)
+	if got := s.currentMCPToolExtraPoison(); len(got) != 0 {
+		t.Fatalf("initial tool-poison patterns = %+v, want none", got)
+	}
+	bundleDir := installServerTestToolPoisonBundle(t, xdgDataHome)
+
+	firstPaused := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var hookCalls atomic.Int32
+	restoreHook := setReloadAfterProxySwapHookForTest(func(*Server) {
+		if hookCalls.Add(1) != 1 {
+			return
+		}
+		close(firstPaused)
+		<-releaseFirst
+	})
+	defer restoreHook()
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- s.Reload(loadServerTestReloadConfig(t, "first-clean-tool-poison"))
+	}()
+
+	<-firstPaused
+	if err := os.Remove(filepath.Join(bundleDir, "bundle.lock")); err != nil {
+		t.Fatalf("remove tool-poison bundle lock: %v", err)
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- s.Reload(loadServerTestReloadConfig(t, "second-should-not-activate"))
+	}()
+
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second reload completed before first reload refreshed runtime mirrors: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first clean reload: %v", err)
+	}
+	if got := s.currentMCPToolExtraPoison(); len(got) != 1 || got[0].Name != "community-tool-poison:tool-poison-shell" {
+		t.Fatalf("tool-poison patterns after first reload = %+v, want installed bundle pattern", got)
+	}
+
+	err := <-secondDone
+	if err == nil {
+		t.Fatal("second bundle-error reload should reject after seeing refreshed live tool-poison coverage")
+	}
+	if !strings.Contains(err.Error(), "mcp_tool_scanning.tool_poison") {
+		t.Fatalf("second reload error = %q, want tool-poison coverage-drop rejection", err.Error())
+	}
+	if live := s.proxy.CurrentConfig(); live.KillSwitch.APIToken != "first-clean-tool-poison" {
+		t.Fatalf("live api token = %q, want first reload preserved", live.KillSwitch.APIToken)
+	}
+}
+
+func loadServerTestReloadConfig(t *testing.T, apiToken string) *config.Config {
+	t.Helper()
+
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"kill_switch:",
+		"  api_token: " + apiToken,
+		"",
+	}, "\n"))
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load reload config: %v", err)
+	}
+	return cfg
 }
 
 func TestServer_Reload_StrictAllowsRuleBundleResolvedReloadAndRejectsRealDowngrade(t *testing.T) {


### PR DESCRIPTION
## What changed

A hot config reload now fails closed when a rule-bundle resolution error would drop detection rules that are currently live. Previously, in balanced and audit mode, a transient bundle load failure during a reload could silently weaken coverage.

## Why

On a hot reload the new config comes from a fresh load that carries only the compiled and user patterns, with no bundle patterns yet resolved. When a bundle then fails to resolve (bad signature, missing or oversized lock file, minimum-version mismatch, filesystem or freshness error), the merge preserves only those compiled and user defaults, so the previously live bundle patterns are not present in the candidate config. The reload path already detects the dropped patterns and logs a warning, but it only turned that warning into a hard rejection under strict mode or an explicit required-security contract. In balanced and audit mode the weakened config was applied anyway, so a momentary bundle failure could silently remove active detection rules. Strict mode was already protected; this closes the same gap for the non-strict modes.

## The fix

The reload activation boundary gains a mode-independent gate. When bundle resolution reports an error, the reload is rejected and the previous live config is kept, but only when the error would actually drop coverage that is currently active: a bundle-sourced DLP pattern, a bundle-sourced response pattern, or an MCP tool-poison rule that is live now and absent or changed in the candidate. A bundle error that does not remove any live rule (for example an unrelated community bundle that was already broken) does not block the reload, so an operator can still apply an unrelated config edit. Because conductor policy apply flows through the same reload boundary, it is covered by the same gate, and a valid conductor apply is unaffected because its already-resolved config preserves its live patterns on a bundle error.

At startup there is no prior live config to preserve, so a bundle resolution error stays a loud, non-suppressible warning plus a degraded signal, and the proxy runs on its remaining core and compiled patterns rather than refusing to boot. Hard-failing startup on a single bad optional bundle would deny service for the whole control, and there is no first-class required-bundle concept to key a narrower startup hard-fail on.

The whole reload path is serialized so a second concurrent reload cannot observe half-updated runtime state (config swapped but the live rule mirrors not yet refreshed) and miss a coverage drop.

Documentation for the reload behavior is updated to describe the new rejection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hot reloads now preserve active detection coverage when bundle resolution issues would otherwise remove existing live rules.
  * Reloads continue safely when bundle errors don’t impact currently-covered rules, with warnings when bundles are broken.
  * Concurrent hot reloads are serialized to avoid inconsistent runtime behavior.
* **Documentation**
  * Updated hot reload and startup semantics: validation/bundle errors keep the prior config when appropriate, and degraded bundle handling is surfaced clearly without blocking startup when possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->