### PR TITLE
feat(conductor): add --dry-run to publish/kill/rollback and a replay CLI

### DIFF
--- a/docs/guides/conductor-production-runbook.md
+++ b/docs/guides/conductor-production-runbook.md
@@ -396,10 +396,12 @@ publish is rejected if the server's current bundle does not match). For a
 loopback dev conductor without TLS, `--allow-plaintext-loopback` permits an
 `http://127.0.0.1` URL.
 
-Add `--dry-run` to send the same signed bundle to the same publish endpoint with
-`dry_run: true`. Conductor returns the publish evaluation, including whether the
-bundle would be created, the resulting hash/version, fleet preflight summary,
-and any conflict code, without mutating the bundle store.
+Add `--dry-run` to send the same signed bundle to Conductor's read-only publish
+evaluation endpoint. Conductor returns the publish evaluation, including whether
+the bundle would be created, the resulting hash/version, fleet preflight
+summary, and any conflict code, without mutating the bundle store. Older
+Conductors that do not expose the evaluation endpoint fail closed instead of
+silently treating a dry-run as a publish.
 
 **Prove on apply:** after publishing, confirm followers picked up the new version
 (watch the follower logs for the bundle-apply line, or `pipelock conductor fleet
@@ -481,9 +483,9 @@ fail closed within one `poll_interval`; clearing it lets them recover on the
 next poll.
 
 Add `--dry-run` to `kill` or `resume` to sign the same remote-kill message and
-ask Conductor for the read-only evaluation. The response reports the would-be
-counter/hash decision and conflict code without publishing the kill/resume
-state.
+ask Conductor's read-only evaluation endpoint for the verdict. The response
+reports the would-be counter/hash decision and conflict code without publishing
+the kill/resume state.
 
 ## 9. Roll back a bad bundle
 
@@ -510,35 +512,32 @@ rollback whose window exceeds `--rollback-max-validity` (default `24h`). Because
 kill and rollback keys are purpose-scoped, a rollback key cannot issue a kill or
 vice versa.
 
-Add `--dry-run` to sign the same rollback authorization and ask Conductor for
-the read-only rollback evaluation. The response reports whether the
+Add `--dry-run` to sign the same rollback authorization and ask Conductor's
+read-only evaluation endpoint for the verdict. The response reports whether the
 authorization would be created and which bundle/version/hash the stream head
 would roll to, without writing either the authorization or stream-head mutation.
 
 ## 9a. Replay a publish decision
 
-`pipelock conductor replay` rebuilds and signs a policy-bundle artifact from the
-same bundle inputs as `conductor publish`, then POSTs it to Conductor's
-decision-replay endpoint. Replay re-derives the publish verdict under current
-store/fleet state and reports whether that diverges from any recorded accepted
-decision.
+`pipelock conductor replay --bundle-artifact <bundle.json>` POSTs an exact
+previously saved signed policy-bundle artifact to Conductor's decision-replay
+endpoint. Replay re-derives the publish verdict under current store/fleet state
+and reports whether that diverges from any recorded accepted decision.
 
 ```bash
 pipelock conductor replay \
   --conductor-url https://conductor.pipelock-control.svc.cluster.local:8895 \
-  --config /etc/pipelock/fleet-policy.yaml \
-  --bundle-id prod-2026-06-11 \
-  --org org-acme --fleet prod --env prod \
-  --audience '*' \
-  --version 7 \
-  --validity 720h \
-  --min-pipelock-version 2.7.0 \
-  --signing-key /etc/pipelock/fleet-keys/policy-signing.json \
+  --bundle-artifact /var/lib/pipelock/conductor/exported/prod-2026-06-11.json \
   --publisher-token-file /etc/pipelock/conductor/tokens/publisher/token \
   --tls-cert /etc/pipelock/operator.crt \
   --tls-key /etc/pipelock/operator.key \
   --server-ca /etc/pipelock/conductor-ca.pem
 ```
+
+Without `--bundle-artifact`, replay rebuilds and signs a new hypothetical bundle
+from the same inputs as `conductor publish`. Use that mode for "what would this
+input do now?" checks, not for exact audit replay, because the rebuilt artifact
+has fresh timestamps and signatures.
 
 Pass `--state-snapshot snapshot.json` to replay the publish preflight against a
 captured follower/runtime-status snapshot. The snapshot applies only to bundle

--- a/docs/guides/conductor-production-runbook.md
+++ b/docs/guides/conductor-production-runbook.md
@@ -387,13 +387,19 @@ pipelock conductor publish \
 ```
 
 The command computes the canonical `policy_hash` / `payload_sha256`, stamps the
-validity window from `--validity`, and assigns a monotonic version server-side.
+validity window from `--validity`, and carries the operator-supplied monotonic
+`--version`.
 Add `--rule-bundle <path>` (repeatable) to ship signed rule bundles alongside the
 config, `--audience` to narrow the addressed followers, and
 `--previous-bundle-hash <hex>` to pin continuity against the prior bundle (the
 publish is rejected if the server's current bundle does not match). For a
 loopback dev conductor without TLS, `--allow-plaintext-loopback` permits an
 `http://127.0.0.1` URL.
+
+Add `--dry-run` to send the same signed bundle to the same publish endpoint with
+`dry_run: true`. Conductor returns the publish evaluation, including whether the
+bundle would be created, the resulting hash/version, fleet preflight summary,
+and any conflict code, without mutating the bundle store.
 
 **Prove on apply:** after publishing, confirm followers picked up the new version
 (watch the follower logs for the bundle-apply line, or `pipelock conductor fleet
@@ -474,6 +480,11 @@ Conductor rejects a kill whose validity window exceeds
 fail closed within one `poll_interval`; clearing it lets them recover on the
 next poll.
 
+Add `--dry-run` to `kill` or `resume` to sign the same remote-kill message and
+ask Conductor for the read-only evaluation. The response reports the would-be
+counter/hash decision and conflict code without publishing the kill/resume
+state.
+
 ## 9. Roll back a bad bundle
 
 `pipelock conductor rollback` authorizes a signed revert to a prior bundle
@@ -498,6 +509,41 @@ Signed with the policy-bundle-rollback (threshold) key. Conductor rejects a
 rollback whose window exceeds `--rollback-max-validity` (default `24h`). Because
 kill and rollback keys are purpose-scoped, a rollback key cannot issue a kill or
 vice versa.
+
+Add `--dry-run` to sign the same rollback authorization and ask Conductor for
+the read-only rollback evaluation. The response reports whether the
+authorization would be created and which bundle/version/hash the stream head
+would roll to, without writing either the authorization or stream-head mutation.
+
+## 9a. Replay a publish decision
+
+`pipelock conductor replay` rebuilds and signs a policy-bundle artifact from the
+same bundle inputs as `conductor publish`, then POSTs it to Conductor's
+decision-replay endpoint. Replay re-derives the publish verdict under current
+store/fleet state and reports whether that diverges from any recorded accepted
+decision.
+
+```bash
+pipelock conductor replay \
+  --conductor-url https://conductor.pipelock-control.svc.cluster.local:8895 \
+  --config /etc/pipelock/fleet-policy.yaml \
+  --bundle-id prod-2026-06-11 \
+  --org org-acme --fleet prod --env prod \
+  --audience '*' \
+  --version 7 \
+  --validity 720h \
+  --min-pipelock-version 2.7.0 \
+  --signing-key /etc/pipelock/fleet-keys/policy-signing.json \
+  --publisher-token-file /etc/pipelock/conductor/tokens/publisher/token \
+  --tls-cert /etc/pipelock/operator.crt \
+  --tls-key /etc/pipelock/operator.key \
+  --server-ca /etc/pipelock/conductor-ca.pem
+```
+
+Pass `--state-snapshot snapshot.json` to replay the publish preflight against a
+captured follower/runtime-status snapshot. The snapshot applies only to bundle
+replay preflight; the policy-bundle store chain is still evaluated against
+current Conductor state.
 
 ## 10. Recover follower bundle state
 

--- a/docs/guides/conductor.md
+++ b/docs/guides/conductor.md
@@ -318,6 +318,14 @@ fleet:
 Both are signed with a purpose-scoped control key, so an operator cannot reuse a
 rollback key to issue a kill (or vice versa).
 
+The publish, remote-kill, and rollback CLIs also expose `--dry-run`. Dry-runs
+send the signed action to read-only evaluation endpoints, not the mutating
+publish endpoints, so an older Conductor that lacks evaluation support fails
+closed instead of applying the action. Decision replay can use an exact signed
+bundle artifact with `--bundle-artifact`; rebuilding from publish inputs is a
+hypothetical replay because new timestamps and signatures create a different
+artifact.
+
 ## Evidence and verification
 
 Every follower emits Ed25519-signed, hash-chained evidence (the

--- a/docs/guides/conductor.md
+++ b/docs/guides/conductor.md
@@ -10,8 +10,9 @@ instances. It distributes signed policy bundles to follower instances, ingests
 and stores their signed evidence for audit, and coordinates fleet-wide
 operations — enrollment, remote kill, and policy rollback. It is **General
 Availability as of v2.7**, with a shipped operator command surface (publish,
-kill/resume, rollback, enroll, enrollment-token, fleet status, audit query)
-documented in the [production runbook](conductor-production-runbook.md).
+publish dry-run, decision replay, kill/resume, rollback, enroll,
+enrollment-token, fleet status, audit query) documented in the
+[production runbook](conductor-production-runbook.md).
 
 Conductor preserves Pipelock's capability separation. Followers enforce policy
 locally and stay fail-closed on their own; Conductor coordinates distribution,

--- a/enterprise/cli/conductor/cmd.go
+++ b/enterprise/cli/conductor/cmd.go
@@ -87,6 +87,7 @@ func Cmd() *cobra.Command {
 	cmd.AddCommand(serveCmd())
 	cmd.AddCommand(bootstrapCmd())
 	cmd.AddCommand(publishCmd())
+	cmd.AddCommand(replayCmd())
 	cmd.AddCommand(auditCmd())
 	cmd.AddCommand(fleetCmd())
 	cmd.AddCommand(streamCmd())

--- a/enterprise/cli/conductor/dryrun_replay_cli_test.go
+++ b/enterprise/cli/conductor/dryrun_replay_cli_test.go
@@ -1,0 +1,451 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	conductorcore "github.com/luckyPipewrench/pipelock/enterprise/conductor"
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+)
+
+func TestConductorDryRunFlagsAndReplayCommandRegistered(t *testing.T) {
+	root := Cmd()
+	for _, path := range [][]string{{"publish"}, {"kill"}, {"resume"}, {"rollback"}} {
+		cmd := findCommandPath(t, root, path...)
+		flag := cmd.Flags().Lookup("dry-run")
+		if flag == nil {
+			t.Fatalf("%s missing --dry-run flag", strings.Join(path, " "))
+		}
+		if flag.Value.Type() != "bool" {
+			t.Fatalf("%s --dry-run type = %q, want bool", strings.Join(path, " "), flag.Value.Type())
+		}
+	}
+	if cmd := findCommandPath(t, root, "replay"); cmd == nil {
+		t.Fatal("conductor replay command is not registered")
+	}
+}
+
+func findCommandPath(t *testing.T, root *cobra.Command, path ...string) *cobra.Command {
+	t.Helper()
+	cmd := root
+	for _, name := range path {
+		next, _, err := cmd.Find([]string{name})
+		if err != nil {
+			t.Fatalf("find %s: %v", strings.Join(path, " "), err)
+		}
+		if next == nil || next.Name() != name {
+			t.Fatalf("find %s returned %v", name, next)
+		}
+		cmd = next
+	}
+	return cmd
+}
+
+func TestRunPublishDryRunSendsDryRunAndRendersEvaluation(t *testing.T) {
+	dir := t.TempDir()
+	opts := publishDryRunTestOptions(t, dir)
+	var gotDryRun bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != controlplane.PublishPolicyBundlePath {
+			t.Fatalf("path = %q, want %q", r.URL.Path, controlplane.PublishPolicyBundlePath)
+		}
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		if r.Header.Get("Authorization") != "Bearer "+testPubToken {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		var body struct {
+			Bundle conductorcore.PolicyBundle `json:"bundle"`
+			DryRun bool                       `json:"dry_run"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotDryRun = body.DryRun
+		if body.Bundle.BundleID == "" || body.Bundle.Signatures == nil {
+			t.Fatalf("request bundle not built/signed: %+v", body.Bundle)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(controlplane.PublishEvaluation{
+			DryRun:         true,
+			Valid:          true,
+			WouldCreate:    true,
+			ResultVersion:  7,
+			ResultHash:     strings.Repeat("a", 64),
+			HasCurrentHead: false,
+			Preflight: controlplane.PublishPreflightSummary{
+				CanApply: 1,
+			},
+		})
+	}))
+	defer srv.Close()
+	opts.conductorURL = srv.URL
+
+	var out bytes.Buffer
+	if err := runPublish(t.Context(), &out, opts); err != nil {
+		t.Fatalf("runPublish dry-run: %v", err)
+	}
+	if !gotDryRun {
+		t.Fatal("publish request dry_run = false, want true")
+	}
+	gotOut := out.String()
+	for _, want := range []string{"dry-run policy bundle", "valid=true", "would_create=true", "result_version=7", "fleet preflight"} {
+		if !strings.Contains(gotOut, want) {
+			t.Fatalf("output %q missing %q", gotOut, want)
+		}
+	}
+}
+
+func TestPostBundleDryRunErrorPaths(t *testing.T) {
+	bundle := minimalBundle(t)
+	t.Run("malformed json", func(t *testing.T) {
+		url := newStubStatusServer(t, http.StatusOK, "not json")
+		_, err := postBundleDryRun(t.Context(), &http.Client{Timeout: time.Second}, url, "tok", bundle, postBundleOptions{})
+		if err == nil || !strings.Contains(err.Error(), "decode publish dry-run response") {
+			t.Fatalf("error = %v, want dry-run decode error", err)
+		}
+	})
+	t.Run("server error", func(t *testing.T) {
+		url := newStubStatusServer(t, http.StatusInternalServerError, `{"error":"boom"}`)
+		_, err := postBundleDryRun(t.Context(), &http.Client{Timeout: time.Second}, url, "tok", bundle, postBundleOptions{})
+		if err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+			t.Fatalf("error = %v, want HTTP 500", err)
+		}
+	})
+	t.Run("oversized success response", func(t *testing.T) {
+		validPrefix, err := json.Marshal(controlplane.PublishEvaluation{
+			DryRun:        true,
+			Valid:         true,
+			WouldCreate:   true,
+			ResultVersion: 7,
+			ResultHash:    strings.Repeat("a", 64),
+		})
+		if err != nil {
+			t.Fatalf("marshal valid prefix: %v", err)
+		}
+		url := newStubStatusServer(t, http.StatusOK, string(validPrefix)+strings.Repeat(" ", publishMaxResponseBytes))
+		_, err = postBundleDryRun(t.Context(), &http.Client{Timeout: time.Second}, url, "tok", bundle, postBundleOptions{})
+		if err == nil || !strings.Contains(err.Error(), "response exceeds") {
+			t.Fatalf("error = %v, want oversized response error", err)
+		}
+	})
+}
+
+func TestPostBundleNonDryRunOmitsDryRun(t *testing.T) {
+	var sawDryRun bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_, sawDryRun = body["dry_run"]
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(publishResult{
+			BundleID:   "bundle-1",
+			BundleHash: strings.Repeat("c", 64),
+			Version:    7,
+			Created:    true,
+		})
+	}))
+	defer srv.Close()
+
+	if _, err := postBundle(t.Context(), srv.Client(), srv.URL, "tok", minimalBundle(t), postBundleOptions{}); err != nil {
+		t.Fatalf("postBundle: %v", err)
+	}
+	if sawDryRun {
+		t.Fatal("normal publish request included dry_run; want omitted")
+	}
+}
+
+func TestRunRemoteKillDryRunSendsDryRunAndDoesNotApply(t *testing.T) {
+	rig := newKillRig(t, 0)
+	rig.opts.dryRun = true
+	cmd, out := newCobraForRun(t)
+	if err := runRemoteKill(cmd, rig.opts, conductorcore.KillSwitchActive); err != nil {
+		t.Fatalf("runRemoteKill dry-run: %v", err)
+	}
+	gotOut := out.String()
+	for _, want := range []string{"dry-run remote-kill", "valid=true", "would_create=true", "counter=100"} {
+		if !strings.Contains(gotOut, want) {
+			t.Fatalf("output %q missing %q", gotOut, want)
+		}
+	}
+
+	follower := controlplane.FollowerIdentity{OrgID: testOrgID, FleetID: testFleetID, InstanceID: testInstanceID, Environment: testEnvironment}
+	if _, err := rig.srv.emergency.LatestRemoteKill(t.Context(), follower, rig.now); !errors.Is(err, controlplane.ErrEmergencyNotFound) {
+		t.Fatalf("remote-kill dry-run stored a kill: err=%v, want ErrEmergencyNotFound", err)
+	}
+
+	realOpts := rig.opts
+	realOpts.dryRun = false
+	cmd2, out2 := newCobraForRun(t)
+	if err := runRemoteKill(cmd2, realOpts, conductorcore.KillSwitchActive); err != nil {
+		t.Fatalf("runRemoteKill after dry-run: %v", err)
+	}
+	if !strings.Contains(out2.String(), "remote-kill published") {
+		t.Fatalf("non-dry-run output = %q, want publish", out2.String())
+	}
+
+	stored, err := rig.srv.emergency.LatestRemoteKill(t.Context(), follower, rig.now)
+	if err != nil {
+		t.Fatalf("latest remote kill after real publish: %v", err)
+	}
+	if stored.Message.State != conductorcore.KillSwitchActive || stored.Message.Counter != rig.opts.counter {
+		t.Fatalf("latest remote kill = state %s counter %d, want active counter %d", stored.Message.State, stored.Message.Counter, rig.opts.counter)
+	}
+
+	resumeOpts := rig.opts
+	resumeOpts.counter = rig.opts.counter + 1
+	resumeOpts.dryRun = true
+	cmd3, out3 := newCobraForRun(t)
+	if err := runRemoteKill(cmd3, resumeOpts, conductorcore.KillSwitchInactive); err != nil {
+		t.Fatalf("runRemoteKill resume dry-run: %v", err)
+	}
+	if !strings.Contains(out3.String(), "dry-run remote-kill") {
+		t.Fatalf("resume dry-run output = %q, want dry-run", out3.String())
+	}
+	stored, err = rig.srv.emergency.LatestRemoteKill(t.Context(), follower, rig.now)
+	if err != nil {
+		t.Fatalf("latest remote kill after resume dry-run: %v", err)
+	}
+	if stored.Message.State != conductorcore.KillSwitchActive || stored.Message.Counter != rig.opts.counter {
+		t.Fatalf("resume dry-run mutated latest remote kill: state %s counter %d, want active counter %d", stored.Message.State, stored.Message.Counter, rig.opts.counter)
+	}
+}
+
+func TestRunRollbackDryRunSendsDryRunAndDoesNotApply(t *testing.T) {
+	opts := newRollbackRig(t, 0)
+	opts.dryRun = true
+	cmd, out := rollbackCobra(t)
+	if err := runRollback(cmd, opts); err != nil {
+		t.Fatalf("runRollback dry-run: %v", err)
+	}
+	gotOut := out.String()
+	for _, want := range []string{"dry-run rollback", "valid=true", "would_create=true", "would_roll_to_version=41"} {
+		if !strings.Contains(gotOut, want) {
+			t.Fatalf("output %q missing %q", gotOut, want)
+		}
+	}
+
+	srv, ok := opts.transport.(*testServer)
+	if !ok {
+		t.Fatalf("rollback test transport = %T, want *testServer", opts.transport)
+	}
+	follower := controlplane.FollowerIdentity{OrgID: testOrgID, FleetID: testFleetID, InstanceID: testInstanceID, Environment: testEnvironment}
+	if _, active, err := srv.emergency.ActiveRollbackForFollower(t.Context(), follower, opts.now()); err != nil || active {
+		t.Fatalf("rollback dry-run active rollback = %t err=%v, want none", active, err)
+	}
+	head, err := srv.store.Latest(t.Context(), follower, opts.now())
+	if err != nil {
+		t.Fatalf("latest bundle after rollback dry-run: %v", err)
+	}
+	if head.Bundle.Version != opts.currentVersion || head.Bundle.BundleID != opts.currentBundleID {
+		t.Fatalf("rollback dry-run moved stream head to %s v%d, want %s v%d", head.Bundle.BundleID, head.Bundle.Version, opts.currentBundleID, opts.currentVersion)
+	}
+
+	realOpts := opts
+	realOpts.dryRun = false
+	cmd2, out2 := rollbackCobra(t)
+	if err := runRollback(cmd2, realOpts); err != nil {
+		t.Fatalf("runRollback after dry-run: %v", err)
+	}
+	if !strings.Contains(out2.String(), "rollback published") {
+		t.Fatalf("non-dry-run output = %q, want publish", out2.String())
+	}
+	if _, active, err := srv.emergency.ActiveRollbackForFollower(t.Context(), follower, opts.now()); err != nil || !active {
+		t.Fatalf("rollback real publish active rollback = %t err=%v, want active", active, err)
+	}
+	head, err = srv.store.Latest(t.Context(), follower, opts.now())
+	if err != nil {
+		t.Fatalf("latest bundle after rollback publish: %v", err)
+	}
+	if head.Bundle.Version != opts.targetVersion || head.Bundle.BundleID != opts.targetBundleID {
+		t.Fatalf("rollback real publish stream head = %s v%d, want %s v%d", head.Bundle.BundleID, head.Bundle.Version, opts.targetBundleID, opts.targetVersion)
+	}
+}
+
+func TestRunReplayPostsBundleAndRendersResult(t *testing.T) {
+	dir := t.TempDir()
+	opts := replayOptions{publish: publishDryRunTestOptions(t, dir)}
+	snapshotPath := filepath.Join(dir, "snapshot.json")
+	writeClientFile(t, snapshotPath, []byte(`{"followers":[],"runtime_statuses":[]}`))
+	opts.stateSnapshot = snapshotPath
+	var gotPath string
+	var gotSnapshot bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.Header.Get("Authorization") != "Bearer "+testPubToken {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		requestBody := readRequestBody(t, r)
+		var body struct {
+			Bundle        *conductorcore.PolicyBundle `json:"bundle"`
+			StateSnapshot json.RawMessage             `json:"state_snapshot"`
+		}
+		if err := json.NewDecoder(bytes.NewReader(requestBody)).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if body.Bundle == nil || body.Bundle.BundleID == "" || len(body.Bundle.Signatures) == 0 {
+			t.Fatalf("request missing signed bundle: %+v", body.Bundle)
+		}
+		gotSnapshot = len(body.StateSnapshot) > 0
+		var raw map[string]json.RawMessage
+		if err := json.NewDecoder(bytes.NewReader(requestBody)).Decode(&raw); err != nil {
+			t.Fatalf("decode raw request: %v", err)
+		}
+		for key := range raw {
+			if key != "bundle" && key != "state_snapshot" {
+				t.Fatalf("replay request included unexpected key %q", key)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(controlplane.DecisionReplayResult{
+			ActionKind:        "publish",
+			ArtifactHash:      strings.Repeat("b", 64),
+			UsedStateSnapshot: true,
+			ReplayedAt:        testFixedNow(t),
+			PublishEvaluation: &controlplane.PublishEvaluation{
+				Valid:          false,
+				Conflict:       controlplane.PublishConflictFleetSkew,
+				WouldCreate:    false,
+				ResultVersion:  7,
+				HasCurrentHead: true,
+			},
+			Divergence:       true,
+			DivergenceReason: "recorded as accepted but re-derived decision would reject (fleet_skew)",
+		})
+	}))
+	defer srv.Close()
+	opts.publish.conductorURL = srv.URL
+
+	cmd, out := replayCobra(t)
+	if err := runReplay(cmd, opts); err != nil {
+		t.Fatalf("runReplay: %v", err)
+	}
+	if gotPath != controlplane.DecisionReplayPath {
+		t.Fatalf("path = %q, want %q", gotPath, controlplane.DecisionReplayPath)
+	}
+	if !gotSnapshot {
+		t.Fatal("replay request omitted state_snapshot")
+	}
+	gotOut := out.String()
+	for _, want := range []string{"decision replay action=publish", "divergence=true", "conflict=fleet_skew", "used_state_snapshot=true"} {
+		if !strings.Contains(gotOut, want) {
+			t.Fatalf("output %q missing %q", gotOut, want)
+		}
+	}
+}
+
+func TestRunReplayErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+	opts := replayOptions{publish: publishDryRunTestOptions(t, dir)}
+	cmd, _ := replayCobra(t)
+	opts.publish.publisherTok = ""
+	if err := runReplay(cmd, opts); err == nil || !strings.Contains(err.Error(), "--publisher-token-file") {
+		t.Fatalf("missing token error = %v, want publisher token required", err)
+	}
+
+	opts = replayOptions{publish: publishDryRunTestOptions(t, dir)}
+	opts.stateSnapshot = writeFile(t, dir, "bad-snapshot.json", "{not json")
+	cmd, _ = replayCobra(t)
+	if err := runReplay(cmd, opts); err == nil || !strings.Contains(err.Error(), "parse --state-snapshot") {
+		t.Fatalf("bad snapshot error = %v, want parse error", err)
+	}
+
+	opts = replayOptions{publish: publishDryRunTestOptions(t, dir)}
+	url := newStubStatusServer(t, http.StatusBadGateway, `{"error":"upstream unavailable"}`)
+	opts.publish.conductorURL = url
+	cmd, _ = replayCobra(t)
+	if err := runReplay(cmd, opts); err == nil || !strings.Contains(err.Error(), "HTTP 502") {
+		t.Fatalf("server error = %v, want HTTP 502", err)
+	}
+
+	opts = replayOptions{publish: publishDryRunTestOptions(t, dir)}
+	opts.stateSnapshot = filepath.Join(dir, "oversized-snapshot.json")
+	if err := os.WriteFile(opts.stateSnapshot, []byte(`{"padding":"`+strings.Repeat("x", replayMaxStateSnapshotBytes)+`"}`), 0o600); err != nil {
+		t.Fatalf("write oversized snapshot: %v", err)
+	}
+	cmd, _ = replayCobra(t)
+	if err := runReplay(cmd, opts); err == nil || !strings.Contains(err.Error(), "--state-snapshot exceeds") {
+		t.Fatalf("oversized snapshot error = %v, want size cap error", err)
+	}
+
+	opts = replayOptions{publish: publishDryRunTestOptions(t, dir)}
+	resultPrefix, err := json.Marshal(controlplane.DecisionReplayResult{
+		ActionKind:   "publish",
+		ArtifactHash: strings.Repeat("b", 64),
+		ReplayedAt:   testFixedNow(t),
+		PublishEvaluation: &controlplane.PublishEvaluation{
+			Valid:       true,
+			WouldCreate: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal replay prefix: %v", err)
+	}
+	url = newStubStatusServer(t, http.StatusOK, string(resultPrefix)+strings.Repeat(" ", publishMaxResponseBytes))
+	opts.publish.conductorURL = url
+	cmd, _ = replayCobra(t)
+	if err := runReplay(cmd, opts); err == nil || !strings.Contains(err.Error(), "response exceeds") {
+		t.Fatalf("oversized replay response error = %v, want size cap error", err)
+	}
+}
+
+func publishDryRunTestOptions(t *testing.T, dir string) publishOptions {
+	t.Helper()
+	keyPath, _ := writePolicyKeyFile(t, dir, wantPurposeFlag, "policy-key-dryrun")
+	return publishOptions{
+		configFile:     writeFile(t, dir, "policy.yaml", testConfigYAML),
+		orgID:          testOrg,
+		fleetID:        testFleet,
+		environment:    testEnv,
+		audience:       []string{"*"},
+		version:        7,
+		validity:       time.Hour,
+		minVersion:     "1.2.3",
+		signingKey:     keyPath,
+		publisherTok:   writeFile(t, dir, "publisher.token", testPubToken),
+		insecure:       true,
+		dryRun:         true,
+		allowFleetSkew: false,
+	}
+}
+
+func replayCobra(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(&bytes.Buffer{})
+	return cmd, out
+}
+
+func readRequestBody(t *testing.T, r *http.Request) []byte {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	return body
+}

--- a/enterprise/cli/conductor/dryrun_replay_cli_test.go
+++ b/enterprise/cli/conductor/dryrun_replay_cli_test.go
@@ -21,6 +21,7 @@ import (
 
 	conductorcore "github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
 func TestConductorDryRunFlagsAndReplayCommandRegistered(t *testing.T) {
@@ -38,6 +39,32 @@ func TestConductorDryRunFlagsAndReplayCommandRegistered(t *testing.T) {
 	if cmd := findCommandPath(t, root, "replay"); cmd == nil {
 		t.Fatal("conductor replay command is not registered")
 	}
+}
+
+func TestReplayCommandRunELicenseGateAndRunReplay(t *testing.T) {
+	t.Run("without license", func(t *testing.T) {
+		t.Setenv(license.EnvLicenseKey, "")
+		t.Setenv(license.EnvLicensePublicKey, "")
+		t.Setenv(license.EnvLicenseCRLFile, "")
+		cmd := replayCmd()
+		cmd.SetArgs([]string{})
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		if err := cmd.Execute(); err == nil || !errors.Is(err, license.ErrFleetLicenseRequired) {
+			t.Fatalf("replay without license error = %v, want ErrFleetLicenseRequired", err)
+		}
+	})
+
+	t.Run("with license reaches runReplay", func(t *testing.T) {
+		installFleetLicense(t)
+		cmd := replayCmd()
+		cmd.SetArgs([]string{})
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--publisher-token-file") {
+			t.Fatalf("licensed replay error = %v, want runReplay publisher token error", err)
+		}
+	})
 }
 
 func findCommandPath(t *testing.T, root *cobra.Command, path ...string) *cobra.Command {
@@ -61,8 +88,8 @@ func TestRunPublishDryRunSendsDryRunAndRendersEvaluation(t *testing.T) {
 	opts := publishDryRunTestOptions(t, dir)
 	var gotDryRun bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != controlplane.PublishPolicyBundlePath {
-			t.Fatalf("path = %q, want %q", r.URL.Path, controlplane.PublishPolicyBundlePath)
+		if r.URL.Path != controlplane.PublishPolicyEvaluatePath {
+			t.Fatalf("path = %q, want %q", r.URL.Path, controlplane.PublishPolicyEvaluatePath)
 		}
 		if r.Method != http.MethodPut {
 			t.Fatalf("method = %s, want PUT", r.Method)
@@ -128,6 +155,20 @@ func TestPostBundleDryRunErrorPaths(t *testing.T) {
 			t.Fatalf("error = %v, want HTTP 500", err)
 		}
 	})
+	t.Run("created response rejected", func(t *testing.T) {
+		url := newStubStatusServer(t, http.StatusCreated, `{"bundle_id":"bundle-1","created":true}`)
+		_, err := postBundleDryRun(t.Context(), &http.Client{Timeout: time.Second}, url, "tok", bundle, postBundleOptions{})
+		if err == nil || !strings.Contains(err.Error(), "201 Created") {
+			t.Fatalf("error = %v, want created-response rejection", err)
+		}
+	})
+	t.Run("missing dry run marker", func(t *testing.T) {
+		url := newStubStatusServer(t, http.StatusOK, `{"valid":true,"would_create":true}`)
+		_, err := postBundleDryRun(t.Context(), &http.Client{Timeout: time.Second}, url, "tok", bundle, postBundleOptions{})
+		if err == nil || !strings.Contains(err.Error(), "missing dry_run=true") {
+			t.Fatalf("error = %v, want missing dry_run marker error", err)
+		}
+	})
 	t.Run("oversized success response", func(t *testing.T) {
 		validPrefix, err := json.Marshal(controlplane.PublishEvaluation{
 			DryRun:        true,
@@ -171,6 +212,29 @@ func TestPostBundleNonDryRunOmitsDryRun(t *testing.T) {
 	if sawDryRun {
 		t.Fatal("normal publish request included dry_run; want omitted")
 	}
+}
+
+func TestPostEmergencyJSONStatusConstructionAndReadErrors(t *testing.T) {
+	t.Run("marshal request", func(t *testing.T) {
+		_, err := postEmergencyJSONStatus(t.Context(), &staticEmergencyTransport{}, "https://conductor.example", "/ok", "tok", make(chan int), nil)
+		if err == nil || !strings.Contains(err.Error(), "marshal request") {
+			t.Fatalf("error = %v, want marshal request error", err)
+		}
+	})
+
+	t.Run("build request", func(t *testing.T) {
+		_, err := postEmergencyJSONStatus(t.Context(), &staticEmergencyTransport{}, "https://conductor.example", "/bad%zz", "tok", map[string]string{"ok": "yes"}, nil)
+		if err == nil || !strings.Contains(err.Error(), "build request") {
+			t.Fatalf("error = %v, want build request error", err)
+		}
+	})
+
+	t.Run("read capped body", func(t *testing.T) {
+		_, err := readCappedResponseBody(errReader{}, 16)
+		if err == nil || !strings.Contains(err.Error(), "read conductor response") {
+			t.Fatalf("error = %v, want read conductor response error", err)
+		}
+	})
 }
 
 func TestRunRemoteKillDryRunSendsDryRunAndDoesNotApply(t *testing.T) {
@@ -229,6 +293,79 @@ func TestRunRemoteKillDryRunSendsDryRunAndDoesNotApply(t *testing.T) {
 	}
 }
 
+func TestRunRemoteKillDryRunErrorAndConflictPathsDoNotApply(t *testing.T) {
+	follower := controlplane.FollowerIdentity{OrgID: testOrgID, FleetID: testFleetID, InstanceID: testInstanceID, Environment: testEnvironment}
+	validEval, err := json.Marshal(controlplane.RemoteKillEvaluation{
+		DryRun:      true,
+		Valid:       true,
+		WouldCreate: true,
+		Counter:     100,
+		MessageHash: strings.Repeat("d", 64),
+	})
+	if err != nil {
+		t.Fatalf("marshal valid remote-kill eval: %v", err)
+	}
+	conflictEval, err := json.Marshal(controlplane.RemoteKillEvaluation{
+		DryRun:   true,
+		Valid:    false,
+		Conflict: controlplane.EmergencyConflictStaleCounter,
+		Counter:  100,
+	})
+	if err != nil {
+		t.Fatalf("marshal conflict remote-kill eval: %v", err)
+	}
+	createdResponse, err := json.Marshal(publishRemoteKillResponse{
+		MessageID: "old-server-mutated",
+		Created:   true,
+	})
+	if err != nil {
+		t.Fatalf("marshal created remote-kill response: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		status   int
+		body     string
+		wantErr  string
+		wantOut  string
+		wantPath string
+	}{
+		{name: "malformed json", status: http.StatusOK, body: "not json", wantErr: "decode conductor response"},
+		{name: "server error", status: http.StatusInternalServerError, body: `{"error":"boom"}`, wantErr: "status=500"},
+		{name: "created response rejected", status: http.StatusCreated, body: string(createdResponse), wantErr: "201 Created"},
+		{name: "missing dry run marker", status: http.StatusOK, body: `{"valid":true,"would_create":true,"counter":100}`, wantErr: "missing dry_run=true"},
+		{name: "oversized response", status: http.StatusOK, body: string(validEval) + strings.Repeat(" ", maxEmergencyResponseBytes), wantErr: "response exceeds"},
+		{name: "conflict evaluation", status: http.StatusOK, body: string(conflictEval), wantOut: "valid=false"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rig := newKillRig(t, 0)
+			rig.opts.dryRun = true
+			transport := &staticEmergencyTransport{status: tc.status, body: tc.body}
+			rig.opts.transport = transport
+			cmd, out := newCobraForRun(t)
+			err := runRemoteKill(cmd, rig.opts, conductorcore.KillSwitchActive)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("runRemoteKill conflict dry-run error = %v", err)
+			}
+			if tc.wantOut != "" && !strings.Contains(out.String(), tc.wantOut) {
+				t.Fatalf("output %q missing %q", out.String(), tc.wantOut)
+			}
+			if transport.path != controlplane.RemoteKillEvaluatePath {
+				t.Fatalf("path = %q, want %q", transport.path, controlplane.RemoteKillEvaluatePath)
+			}
+			if _, err := rig.srv.emergency.LatestRemoteKill(t.Context(), follower, rig.now); !errors.Is(err, controlplane.ErrEmergencyNotFound) {
+				t.Fatalf("remote-kill dry-run error path stored a kill: err=%v, want ErrEmergencyNotFound", err)
+			}
+		})
+	}
+}
+
 func TestRunRollbackDryRunSendsDryRunAndDoesNotApply(t *testing.T) {
 	opts := newRollbackRig(t, 0)
 	opts.dryRun = true
@@ -277,6 +414,95 @@ func TestRunRollbackDryRunSendsDryRunAndDoesNotApply(t *testing.T) {
 	}
 	if head.Bundle.Version != opts.targetVersion || head.Bundle.BundleID != opts.targetBundleID {
 		t.Fatalf("rollback real publish stream head = %s v%d, want %s v%d", head.Bundle.BundleID, head.Bundle.Version, opts.targetBundleID, opts.targetVersion)
+	}
+}
+
+func TestRunRollbackDryRunErrorAndConflictPathsDoNotApply(t *testing.T) {
+	validEval, err := json.Marshal(controlplane.RollbackEvaluation{
+		DryRun:              true,
+		Valid:               true,
+		WouldCreate:         true,
+		Counter:             100,
+		WouldRollToBundleID: "bundle-target",
+		WouldRollToVersion:  41,
+		WouldRollToHash:     strings.Repeat("e", 64),
+	})
+	if err != nil {
+		t.Fatalf("marshal valid rollback eval: %v", err)
+	}
+	conflictEval, err := json.Marshal(controlplane.RollbackEvaluation{
+		DryRun:   true,
+		Valid:    false,
+		Conflict: controlplane.EmergencyConflictStaleCounter,
+		Counter:  100,
+	})
+	if err != nil {
+		t.Fatalf("marshal conflict rollback eval: %v", err)
+	}
+	createdResponse, err := json.Marshal(publishRollbackAuthorizationResponse{
+		AuthorizationID: "old-server-mutated",
+		Created:         true,
+	})
+	if err != nil {
+		t.Fatalf("marshal created rollback response: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		status  int
+		body    string
+		wantErr string
+		wantOut string
+	}{
+		{name: "malformed json", status: http.StatusOK, body: "not json", wantErr: "decode conductor response"},
+		{name: "server error", status: http.StatusInternalServerError, body: `{"error":"boom"}`, wantErr: "status=500"},
+		{name: "created response rejected", status: http.StatusCreated, body: string(createdResponse), wantErr: "201 Created"},
+		{name: "missing dry run marker", status: http.StatusOK, body: `{"valid":true,"would_create":true,"counter":100}`, wantErr: "missing dry_run=true"},
+		{name: "oversized response", status: http.StatusOK, body: string(validEval) + strings.Repeat(" ", maxEmergencyResponseBytes), wantErr: "response exceeds"},
+		{name: "conflict evaluation", status: http.StatusOK, body: string(conflictEval), wantOut: "valid=false"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := newRollbackRig(t, 0)
+			opts.dryRun = true
+			srv, ok := opts.transport.(*testServer)
+			if !ok {
+				t.Fatalf("rollback test transport = %T, want *testServer", opts.transport)
+			}
+			follower := controlplane.FollowerIdentity{OrgID: testOrgID, FleetID: testFleetID, InstanceID: testInstanceID, Environment: testEnvironment}
+			headBefore, err := srv.store.Latest(t.Context(), follower, opts.now())
+			if err != nil {
+				t.Fatalf("latest bundle before rollback dry-run error path: %v", err)
+			}
+			transport := &staticEmergencyTransport{status: tc.status, body: tc.body}
+			opts.transport = transport
+			cmd, out := rollbackCobra(t)
+			err = runRollback(cmd, opts)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("runRollback conflict dry-run error = %v", err)
+			}
+			if tc.wantOut != "" && !strings.Contains(out.String(), tc.wantOut) {
+				t.Fatalf("output %q missing %q", out.String(), tc.wantOut)
+			}
+			if transport.path != controlplane.RollbackEvaluatePath {
+				t.Fatalf("path = %q, want %q", transport.path, controlplane.RollbackEvaluatePath)
+			}
+			if _, active, err := srv.emergency.ActiveRollbackForFollower(t.Context(), follower, opts.now()); err != nil || active {
+				t.Fatalf("rollback dry-run error path active rollback = %t err=%v, want none", active, err)
+			}
+			headAfter, err := srv.store.Latest(t.Context(), follower, opts.now())
+			if err != nil {
+				t.Fatalf("latest bundle after rollback dry-run error path: %v", err)
+			}
+			if headAfter.BundleHash != headBefore.BundleHash {
+				t.Fatalf("rollback dry-run error path moved head from %s to %s", headBefore.BundleHash, headAfter.BundleHash)
+			}
+		})
 	}
 }
 
@@ -355,6 +581,127 @@ func TestRunReplayPostsBundleAndRendersResult(t *testing.T) {
 	}
 }
 
+func TestRunReplayBundleArtifactPostsExactBundle(t *testing.T) {
+	dir := t.TempDir()
+	buildOpts := publishDryRunTestOptions(t, dir)
+	bundle, _, priv, err := buildSignedBundle(buildOpts)
+	if err != nil {
+		t.Fatalf("buildSignedBundle: %v", err)
+	}
+	defer zeroizeKey(priv)
+	artifact, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal bundle artifact: %v", err)
+	}
+	artifactPath := filepath.Join(dir, "bundle-artifact.json")
+	writeClientFile(t, artifactPath, artifact)
+
+	opts := replayOptions{
+		publish: publishDryRunTestOptions(t, dir),
+	}
+	opts.bundleArtifact = artifactPath
+	opts.publish.configFile = ""
+	opts.publish.signingKey = ""
+	opts.publish.version = 0
+
+	var gotBundleID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestBody := readRequestBody(t, r)
+		var body struct {
+			Bundle *conductorcore.PolicyBundle `json:"bundle"`
+		}
+		if err := json.NewDecoder(bytes.NewReader(requestBody)).Decode(&body); err != nil {
+			t.Fatalf("decode replay request: %v", err)
+		}
+		if body.Bundle == nil {
+			t.Fatal("replay request omitted bundle")
+		}
+		gotBundleID = body.Bundle.BundleID
+		if !body.Bundle.CreatedAt.Equal(bundle.CreatedAt) || !body.Bundle.NotBefore.Equal(bundle.NotBefore) || !body.Bundle.ExpiresAt.Equal(bundle.ExpiresAt) {
+			t.Fatalf("replay bundle timestamps changed: got created=%s not_before=%s expires=%s want created=%s not_before=%s expires=%s",
+				body.Bundle.CreatedAt, body.Bundle.NotBefore, body.Bundle.ExpiresAt, bundle.CreatedAt, bundle.NotBefore, bundle.ExpiresAt)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(controlplane.DecisionReplayResult{
+			ActionKind:   "publish",
+			ArtifactHash: strings.Repeat("b", 64),
+			ReplayedAt:   testFixedNow(t),
+			PublishEvaluation: &controlplane.PublishEvaluation{
+				Valid:       true,
+				WouldCreate: true,
+			},
+		})
+	}))
+	defer srv.Close()
+	opts.publish.conductorURL = srv.URL
+
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runReplay(cmd, opts); err != nil {
+		t.Fatalf("runReplay with artifact: %v", err)
+	}
+	if gotBundleID != bundle.BundleID {
+		t.Fatalf("replay posted bundle_id=%q, want exact artifact bundle_id=%q", gotBundleID, bundle.BundleID)
+	}
+}
+
+func TestRunReplayResolvesPreviousHashAuto(t *testing.T) {
+	dir := t.TempDir()
+	opts := replayOptions{publish: publishDryRunTestOptions(t, dir)}
+	opts.publish.previousHash = previousHashAuto
+	resolvedHash := strings.Repeat("f", 64)
+	var replayPreviousHash string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case controlplane.StreamStatusPath:
+			if r.Method != http.MethodGet {
+				t.Fatalf("stream status method = %s, want GET", r.Method)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"streams": []map[string]any{{
+					"environment":      testEnv,
+					"audience":         conductorcore.Audience{InstanceIDs: []string{"*"}},
+					"head_bundle_hash": resolvedHash,
+				}},
+			})
+		case controlplane.DecisionReplayPath:
+			var body struct {
+				Bundle conductorcore.PolicyBundle `json:"bundle"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode replay request: %v", err)
+			}
+			replayPreviousHash = body.Bundle.PreviousBundleHash
+			_ = json.NewEncoder(w).Encode(controlplane.DecisionReplayResult{
+				ActionKind:   "publish",
+				ArtifactHash: strings.Repeat("b", 64),
+				ReplayedAt:   testFixedNow(t),
+				PublishEvaluation: &controlplane.PublishEvaluation{
+					Valid:       true,
+					WouldCreate: true,
+				},
+			})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	opts.publish.conductorURL = srv.URL
+
+	cmd, out := replayCobra(t)
+	if err := runReplay(cmd, opts); err != nil {
+		t.Fatalf("runReplay auto previous hash: %v", err)
+	}
+	if replayPreviousHash != resolvedHash {
+		t.Fatalf("replay previous hash = %q, want %q", replayPreviousHash, resolvedHash)
+	}
+	if !strings.Contains(out.String(), "resolved --previous-bundle-hash auto to "+resolvedHash) {
+		t.Fatalf("output %q missing resolved hash", out.String())
+	}
+}
+
 func TestRunReplayErrorPaths(t *testing.T) {
 	dir := t.TempDir()
 	opts := replayOptions{publish: publishDryRunTestOptions(t, dir)}
@@ -408,6 +755,87 @@ func TestRunReplayErrorPaths(t *testing.T) {
 	if err := runReplay(cmd, opts); err == nil || !strings.Contains(err.Error(), "response exceeds") {
 		t.Fatalf("oversized replay response error = %v, want size cap error", err)
 	}
+
+	opts = replayOptions{publish: publishDryRunTestOptions(t, dir)}
+	opts.bundleArtifact = writeFile(t, dir, "bad-bundle-artifact.json", "{not json")
+	opts.publish.conductorURL = newStubStatusServer(t, http.StatusOK, `{}`)
+	cmd, _ = replayCobra(t)
+	if err := runReplay(cmd, opts); err == nil || !strings.Contains(err.Error(), "parse --bundle-artifact") {
+		t.Fatalf("bad bundle artifact error = %v, want parse error", err)
+	}
+}
+
+func TestReadReplayBundleArtifactErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := readReplayBundleArtifact(filepath.Join(dir, "missing.json")); err == nil || !strings.Contains(err.Error(), "read --bundle-artifact") {
+		t.Fatalf("missing artifact error = %v, want read error", err)
+	}
+	if _, err := readReplayBundleArtifact(dir); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("directory artifact error = %v, want regular file error", err)
+	}
+	oversized := filepath.Join(dir, "oversized.json")
+	if err := os.WriteFile(oversized, []byte(strings.Repeat("x", replayMaxBundleArtifactBytes+1)), 0o600); err != nil {
+		t.Fatalf("write oversized artifact: %v", err)
+	}
+	if _, err := readReplayBundleArtifact(oversized); err == nil || !strings.Contains(err.Error(), "--bundle-artifact exceeds") {
+		t.Fatalf("oversized artifact error = %v, want size error", err)
+	}
+	invalid := filepath.Join(dir, "invalid.json")
+	if err := os.WriteFile(invalid, []byte(`{"schema_version":1}`), 0o600); err != nil {
+		t.Fatalf("write invalid artifact: %v", err)
+	}
+	if _, err := readReplayBundleArtifact(invalid); err == nil || !strings.Contains(err.Error(), "validate --bundle-artifact") {
+		t.Fatalf("invalid artifact error = %v, want validation error", err)
+	}
+	trailing := filepath.Join(dir, "trailing.json")
+	if err := os.WriteFile(trailing, []byte(`{} {}`), 0o600); err != nil {
+		t.Fatalf("write trailing artifact: %v", err)
+	}
+	if _, err := readReplayBundleArtifact(trailing); err == nil || !strings.Contains(err.Error(), "trailing JSON") {
+		t.Fatalf("trailing artifact error = %v, want trailing JSON error", err)
+	}
+}
+
+func TestReadReplayStateSnapshotErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+	if snapshot, err := readReplayStateSnapshot("  "); err != nil || snapshot != nil {
+		t.Fatalf("empty snapshot path = (%s, %v), want nil nil", snapshot, err)
+	}
+	if _, err := readReplayStateSnapshot(filepath.Join(dir, "missing.json")); err == nil || !strings.Contains(err.Error(), "read --state-snapshot") {
+		t.Fatalf("missing snapshot error = %v, want read error", err)
+	}
+	if _, err := readReplayStateSnapshot(dir); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("directory snapshot error = %v, want regular file error", err)
+	}
+	empty := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(empty, []byte(" \n\t"), 0o600); err != nil {
+		t.Fatalf("write empty snapshot: %v", err)
+	}
+	if _, err := readReplayStateSnapshot(empty); err == nil || !strings.Contains(err.Error(), "--state-snapshot is empty") {
+		t.Fatalf("empty snapshot error = %v, want empty error", err)
+	}
+}
+
+type staticEmergencyTransport struct {
+	status int
+	body   string
+	path   string
+}
+
+func (s *staticEmergencyTransport) Do(req *http.Request) (*http.Response, error) {
+	s.path = req.URL.Path
+	return &http.Response{
+		StatusCode: s.status,
+		Body:       io.NopCloser(strings.NewReader(s.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
 }
 
 func publishDryRunTestOptions(t *testing.T, dir string) publishOptions {

--- a/enterprise/cli/conductor/emergency_common.go
+++ b/enterprise/cli/conductor/emergency_common.go
@@ -331,9 +331,16 @@ func postEmergencyJSON(ctx context.Context, client emergencyTransport, baseURL, 
 		return fmt.Errorf("conductor request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxEmergencyResponseBytes))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxEmergencyResponseBytes+1))
 	if err != nil {
 		return fmt.Errorf("read conductor response: %w", err)
+	}
+	// Read one byte past the cap and reject an over-limit body outright rather
+	// than silently truncating it: a truncated-but-valid JSON prefix (with
+	// oversized trailing data) must fail closed, not decode into a misleading
+	// success/error. Mirrors readPublishResponseBody on the publish path.
+	if len(body) > maxEmergencyResponseBytes {
+		return fmt.Errorf("conductor response exceeds %d bytes", maxEmergencyResponseBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("conductor rejected request: status=%d body=%s", resp.StatusCode, emergencySnippet(body, bearer))

--- a/enterprise/cli/conductor/emergency_common.go
+++ b/enterprise/cli/conductor/emergency_common.go
@@ -309,17 +309,22 @@ func loadBearerToken(path string) (string, error) {
 // the request (under-threshold, expired window, wrong purpose) instead of a bare
 // status code. The body read is capped to maxEmergencyResponseBytes.
 func postEmergencyJSON(ctx context.Context, client emergencyTransport, baseURL, path, bearer string, reqBody, out any) error {
+	_, err := postEmergencyJSONStatus(ctx, client, baseURL, path, bearer, reqBody, out)
+	return err
+}
+
+func postEmergencyJSONStatus(ctx context.Context, client emergencyTransport, baseURL, path, bearer string, reqBody, out any) (int, error) {
 	baseURL, _, err := conductorWriteBaseURL(baseURL)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	payload, err := json.Marshal(reqBody)
 	if err != nil {
-		return fmt.Errorf("marshal request: %w", err)
+		return 0, fmt.Errorf("marshal request: %w", err)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+path, bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
+		return 0, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
@@ -328,29 +333,33 @@ func postEmergencyJSON(ctx context.Context, client emergencyTransport, baseURL, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("conductor request: %w", err)
+		return 0, fmt.Errorf("conductor request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxEmergencyResponseBytes+1))
+	body, err := readCappedResponseBody(resp.Body, maxEmergencyResponseBytes)
 	if err != nil {
-		return fmt.Errorf("read conductor response: %w", err)
-	}
-	// Read one byte past the cap and reject an over-limit body outright rather
-	// than silently truncating it: a truncated-but-valid JSON prefix (with
-	// oversized trailing data) must fail closed, not decode into a misleading
-	// success/error. Mirrors readPublishResponseBody on the publish path.
-	if len(body) > maxEmergencyResponseBytes {
-		return fmt.Errorf("conductor response exceeds %d bytes", maxEmergencyResponseBytes)
+		return resp.StatusCode, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("conductor rejected request: status=%d body=%s", resp.StatusCode, emergencySnippet(body, bearer))
+		return resp.StatusCode, fmt.Errorf("conductor rejected request: status=%d body=%s", resp.StatusCode, emergencySnippet(body, bearer))
 	}
 	if out != nil {
 		if err := json.Unmarshal(body, out); err != nil {
-			return fmt.Errorf("decode conductor response: %w", err)
+			return resp.StatusCode, fmt.Errorf("decode conductor response: %w", err)
 		}
 	}
-	return nil
+	return resp.StatusCode, nil
+}
+
+func readCappedResponseBody(r io.Reader, maxBytes int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read conductor response: %w", err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("conductor response exceeds %d bytes", maxBytes)
+	}
+	return body, nil
 }
 
 func conductorWriteBaseURL(rawBaseURL string) (string, string, error) {

--- a/enterprise/cli/conductor/emergency_common_test.go
+++ b/enterprise/cli/conductor/emergency_common_test.go
@@ -131,9 +131,10 @@ func emergencyResolverFromKeys(keys map[string]conductorcore.SignatureKey) condu
 // separately; the producer logic under test is the message construction +
 // signing + the server's acceptance of it.
 type testServer struct {
-	url    string
-	client *http.Client
-	store  *controlplane.FileBundleStore
+	url       string
+	client    *http.Client
+	store     *controlplane.FileBundleStore
+	emergency *controlplane.FileEmergencyStore
 }
 
 type testServerOptions struct {
@@ -210,7 +211,7 @@ func newTestServer(t *testing.T, opts testServerOptions) *testServer {
 	}
 	srv := httptest.NewTLSServer(handler)
 	t.Cleanup(srv.Close)
-	return &testServer{url: srv.URL, client: srv.Client(), store: store}
+	return &testServer{url: srv.URL, client: srv.Client(), store: store, emergency: emergencyControls}
 }
 
 func (s *testServer) Do(req *http.Request) (*http.Response, error) { return s.client.Do(req) }
@@ -511,6 +512,28 @@ func TestPostEmergencyJSONSurfacesServerError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "status=422") {
 		t.Fatalf("postEmergencyJSON error = %v, want status code", err)
+	}
+}
+
+// An oversized response with a valid JSON prefix (e.g. a well-formed
+// acknowledgement followed by megabytes of trailing bytes) must fail closed
+// rather than truncate-and-decode into a misleading success. The kill/resume/
+// rollback dry-run and real emergency paths all read through postEmergencyJSON,
+// so this guards every emergency control response, matching the publish path.
+func TestPostEmergencyJSONRejectsOversizedResponse(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"accepted":true}`))
+		_, _ = w.Write([]byte(strings.Repeat(" ", maxEmergencyResponseBytes)))
+	}))
+	defer srv.Close()
+	var out map[string]any
+	err := postEmergencyJSON(context.Background(), srv.Client(), srv.URL, "/x", "tok", map[string]string{"a": "b"}, &out)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("postEmergencyJSON error = %v, want oversized-response error", err)
+	}
+	if out != nil {
+		t.Fatalf("out = %v, want nil (oversized response must not decode)", out)
 	}
 }
 

--- a/enterprise/cli/conductor/kill.go
+++ b/enterprise/cli/conductor/kill.go
@@ -6,6 +6,7 @@ package conductor
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -35,6 +36,7 @@ type killOptions struct {
 	counter        uint64
 	reason         string
 	ttl            time.Duration
+	dryRun         bool
 	licenseCRLFile string
 
 	// now and transport are test seams. Production leaves them nil so the
@@ -103,6 +105,7 @@ func bindRemoteKillFlags(cmd *cobra.Command, opts *killOptions) {
 	cmd.Flags().Uint64Var(&opts.counter, "counter", 0, "monotonic counter; defaults to the current Unix time so each publish supersedes the prior one")
 	cmd.Flags().StringVar(&opts.reason, "reason", "", "operator reason recorded in the signed message")
 	cmd.Flags().DurationVar(&opts.ttl, "ttl", remoteKillDefaultTTL, "validity window for the message; must not exceed the Conductor's configured remote-kill max validity")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "evaluate the signed remote-kill without mutating Conductor state")
 	cmd.Flags().StringVar(&opts.tlsCert, "tls-cert", "", "operator client TLS certificate for Conductor mTLS (required)")
 	cmd.Flags().StringVar(&opts.tlsKey, "tls-key", "", "operator client TLS private key for Conductor mTLS (required)")
 	cmd.Flags().StringVar(&opts.serverCA, "server-ca", "", "CA bundle that signed the Conductor server certificate (required)")
@@ -182,6 +185,16 @@ func runRemoteKill(cmd *cobra.Command, opts killOptions, state conductorcore.Kil
 		return err
 	}
 
+	if opts.dryRun {
+		var eval controlplane.RemoteKillEvaluation
+		if err := postEmergencyJSON(cmd.Context(), client, opts.baseURL, controlplane.RemoteKillPath, adminToken,
+			publishRemoteKillRequest{Message: msg, DryRun: true}, &eval); err != nil {
+			return err
+		}
+		writeRemoteKillEvaluation(cmd.OutOrStdout(), eval)
+		return nil
+	}
+
 	var resp publishRemoteKillResponse
 	if err := postEmergencyJSON(cmd.Context(), client, opts.baseURL, controlplane.RemoteKillPath, adminToken,
 		publishRemoteKillRequest{Message: msg}, &resp); err != nil {
@@ -200,6 +213,7 @@ func runRemoteKill(cmd *cobra.Command, opts killOptions, state conductorcore.Kil
 // round-trips against the server.
 type publishRemoteKillRequest struct {
 	Message conductorcore.RemoteKillMessage `json:"message"`
+	DryRun  bool                            `json:"dry_run,omitempty"`
 }
 
 type publishRemoteKillResponse struct {
@@ -208,4 +222,10 @@ type publishRemoteKillResponse struct {
 	Counter     uint64    `json:"counter"`
 	PublishedAt time.Time `json:"published_at"`
 	Created     bool      `json:"created"`
+}
+
+func writeRemoteKillEvaluation(out io.Writer, eval controlplane.RemoteKillEvaluation) {
+	_, _ = fmt.Fprintf(out,
+		"dry-run remote-kill valid=%t would_create=%t counter=%d message_hash=%s conflict=%s has_current_max_counter=%t current_max_counter=%d\n",
+		eval.Valid, eval.WouldCreate, eval.Counter, eval.MessageHash, eval.Conflict, eval.HasCurrentMaxCounter, eval.CurrentMaxCounter)
 }

--- a/enterprise/cli/conductor/kill.go
+++ b/enterprise/cli/conductor/kill.go
@@ -5,8 +5,10 @@
 package conductor
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -187,11 +189,18 @@ func runRemoteKill(cmd *cobra.Command, opts killOptions, state conductorcore.Kil
 
 	if opts.dryRun {
 		var eval controlplane.RemoteKillEvaluation
-		if err := postEmergencyJSON(cmd.Context(), client, opts.baseURL, controlplane.RemoteKillPath, adminToken,
-			publishRemoteKillRequest{Message: msg, DryRun: true}, &eval); err != nil {
+		status, err := postEmergencyJSONStatus(cmd.Context(), client, opts.baseURL, controlplane.RemoteKillEvaluatePath, adminToken,
+			publishRemoteKillRequest{Message: msg, DryRun: true}, &eval)
+		if err != nil {
 			return err
 		}
-		writeRemoteKillEvaluation(cmd.OutOrStdout(), eval)
+		if status == http.StatusCreated {
+			return errors.New("conductor returned 201 Created for remote-kill dry-run; refusing ambiguous mutating response")
+		}
+		if err := requireDryRunEvaluation("remote-kill", eval.DryRun); err != nil {
+			return err
+		}
+		writeRemoteKillEvaluation(cmd.OutOrStdout(), "dry-run", eval)
 		return nil
 	}
 
@@ -224,8 +233,8 @@ type publishRemoteKillResponse struct {
 	Created     bool      `json:"created"`
 }
 
-func writeRemoteKillEvaluation(out io.Writer, eval controlplane.RemoteKillEvaluation) {
+func writeRemoteKillEvaluation(out io.Writer, label string, eval controlplane.RemoteKillEvaluation) {
 	_, _ = fmt.Fprintf(out,
-		"dry-run remote-kill valid=%t would_create=%t counter=%d message_hash=%s conflict=%s has_current_max_counter=%t current_max_counter=%d\n",
-		eval.Valid, eval.WouldCreate, eval.Counter, eval.MessageHash, eval.Conflict, eval.HasCurrentMaxCounter, eval.CurrentMaxCounter)
+		"%s remote-kill valid=%t would_create=%t counter=%d message_hash=%s conflict=%s has_current_max_counter=%t current_max_counter=%d\n",
+		label, eval.Valid, eval.WouldCreate, eval.Counter, eval.MessageHash, eval.Conflict, eval.HasCurrentMaxCounter, eval.CurrentMaxCounter)
 }

--- a/enterprise/cli/conductor/publish.go
+++ b/enterprise/cli/conductor/publish.go
@@ -121,6 +121,7 @@ type publishOptions struct {
 	switchSigningKeys  []string
 	allowFleetSkew     bool
 	fleetSkewReason    string
+	dryRun             bool
 	publisherTok       string
 	tlsCert            string
 	tlsKey             string
@@ -187,6 +188,17 @@ Example:
 			return runPublish(cmd.Context(), cmd.OutOrStdout(), opts)
 		},
 	}
+	bindPublishFlags(cmd, &opts, publishFlagOptions{fleetSkew: true, dryRun: true, license: true})
+	return cmd
+}
+
+type publishFlagOptions struct {
+	fleetSkew bool
+	dryRun    bool
+	license   bool
+}
+
+func bindPublishFlags(cmd *cobra.Command, opts *publishOptions, flagOpts publishFlagOptions) {
 	cmd.Flags().StringVar(&opts.conductorURL, "conductor-url", "", "base URL of the Conductor control plane (e.g. https://conductor.example:8895)")
 	cmd.Flags().StringVar(&opts.configFile, "config", "", "path to the pipelock config YAML to publish as the bundle policy")
 	cmd.Flags().StringArrayVar(&opts.ruleBundles, "rule-bundle", nil, "rule bundle reference as comma-separated kv pairs: 'name=NAME,version=VER,sha256=HEX'; repeatable")
@@ -208,15 +220,21 @@ Example:
 	cmd.Flags().StringVar(&opts.switchReason, "stream-switch-reason", "", "operator reason recorded in the stream switch authorization")
 	cmd.Flags().DurationVar(&opts.switchTTL, "stream-switch-ttl", time.Hour, "validity window for the stream switch authorization")
 	cmd.Flags().StringArrayVar(&opts.switchSigningKeys, "stream-switch-signing-key", nil, "path to a policy-bundle-rollback keypair file; repeat to supply the M-of-N stream-switch signers")
-	cmd.Flags().BoolVar(&opts.allowFleetSkew, "allow-fleet-skew", false, "accept publish preflight skew for stale/unseen or unsupported followers; prefer a narrow --audience canary instead of overriding globally")
-	cmd.Flags().StringVar(&opts.fleetSkewReason, "allow-fleet-skew-reason", "", "operator reason required with --allow-fleet-skew; recorded by the Conductor")
+	if flagOpts.fleetSkew {
+		cmd.Flags().BoolVar(&opts.allowFleetSkew, "allow-fleet-skew", false, "accept publish preflight skew for stale/unseen or unsupported followers; prefer a narrow --audience canary instead of overriding globally")
+		cmd.Flags().StringVar(&opts.fleetSkewReason, "allow-fleet-skew-reason", "", "operator reason required with --allow-fleet-skew; recorded by the Conductor")
+	}
+	if flagOpts.dryRun {
+		cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "evaluate the signed publish without mutating Conductor state")
+	}
 	cmd.Flags().StringVar(&opts.publisherTok, "publisher-token-file", "", "file containing the publisher bearer token")
 	cmd.Flags().StringVar(&opts.tlsCert, "tls-cert", "", "mTLS client certificate file")
 	cmd.Flags().StringVar(&opts.tlsKey, "tls-key", "", "mTLS client private key file")
 	cmd.Flags().StringVar(&opts.serverCA, "server-ca", "", "PEM bundle of CAs that may validate the Conductor server certificate")
-	cmd.Flags().StringVar(&opts.licenseCRL, "license-crl-file", "", "signed license revocation list file; falls back to PIPELOCK_LICENSE_CRL_FILE")
+	if flagOpts.license {
+		cmd.Flags().StringVar(&opts.licenseCRL, "license-crl-file", "", "signed license revocation list file; falls back to PIPELOCK_LICENSE_CRL_FILE")
+	}
 	cmd.Flags().BoolVar(&opts.insecure, "allow-plaintext-loopback", false, "permit publishing without mTLS material against an http:// loopback URL (dev only)")
-	return cmd
 }
 
 // previousHashAuto is the sentinel value for --previous-bundle-hash that
@@ -258,6 +276,18 @@ func runPublish(ctx context.Context, out io.Writer, opts publishOptions) error {
 	token, err := readPublisherToken(opts.publisherTok)
 	if err != nil {
 		return err
+	}
+	if opts.dryRun {
+		eval, err := postBundleDryRun(ctx, client, opts.conductorURL, token, bundle, postBundleOptions{
+			allowFleetSkew:  opts.allowFleetSkew,
+			fleetSkewReason: opts.fleetSkewReason,
+		})
+		if err != nil {
+			return err
+		}
+		writePublishEvaluation(out, eval)
+		_, _ = fmt.Fprintf(out, "signed by %s\n", keyID)
+		return nil
 	}
 	resp, err := postBundle(ctx, client, opts.conductorURL, token, bundle, postBundleOptions{
 		allowFleetSkew:  opts.allowFleetSkew,
@@ -783,33 +813,16 @@ func isLoopbackHost(host string) bool {
 type postBundleOptions struct {
 	allowFleetSkew  bool
 	fleetSkewReason string
+	dryRun          bool
 }
 
 func postBundle(ctx context.Context, client *http.Client, baseURL, token string, bundle conductorcore.PolicyBundle, opts postBundleOptions) (publishResult, error) {
-	envelope := struct {
-		Bundle          conductorcore.PolicyBundle `json:"bundle"`
-		AllowFleetSkew  bool                       `json:"allow_fleet_skew,omitempty"`
-		FleetSkewReason string                     `json:"fleet_skew_reason,omitempty"`
-	}{Bundle: bundle, AllowFleetSkew: opts.allowFleetSkew, FleetSkewReason: strings.TrimSpace(opts.fleetSkewReason)}
-	body, err := json.Marshal(envelope)
+	opts.dryRun = false
+	statusCode, respBody, err := postBundleRaw(ctx, client, baseURL, token, bundle, opts)
 	if err != nil {
-		return publishResult{}, fmt.Errorf("marshal publish request: %w", err)
+		return publishResult{}, err
 	}
-	endpoint := strings.TrimRight(baseURL, "/") + controlplane.PublishPolicyBundlePath
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(body))
-	if err != nil {
-		return publishResult{}, fmt.Errorf("build publish request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		return publishResult{}, fmt.Errorf("publish request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, publishMaxResponseBytes))
-
-	switch resp.StatusCode {
+	switch statusCode {
 	case http.StatusOK, http.StatusCreated:
 		var result publishResult
 		if err := json.Unmarshal(respBody, &result); err != nil {
@@ -819,10 +832,71 @@ func postBundle(ctx context.Context, client *http.Client, baseURL, token string,
 	case http.StatusConflict:
 		return publishResult{}, fmt.Errorf("%w: %s", conflictSentinel(respBody), serverErrorDetail(respBody, token))
 	case http.StatusForbidden, http.StatusUnauthorized:
-		return publishResult{}, fmt.Errorf("publisher not authorized (HTTP %d): %s", resp.StatusCode, serverErrorDetail(respBody, token))
+		return publishResult{}, fmt.Errorf("publisher not authorized (HTTP %d): %s", statusCode, serverErrorDetail(respBody, token))
 	default:
-		return publishResult{}, fmt.Errorf("conductor rejected publish (HTTP %d): %s", resp.StatusCode, serverErrorDetail(respBody, token))
+		return publishResult{}, fmt.Errorf("conductor rejected publish (HTTP %d): %s", statusCode, serverErrorDetail(respBody, token))
 	}
+}
+
+func postBundleDryRun(ctx context.Context, client *http.Client, baseURL, token string, bundle conductorcore.PolicyBundle, opts postBundleOptions) (controlplane.PublishEvaluation, error) {
+	opts.dryRun = true
+	statusCode, respBody, err := postBundleRaw(ctx, client, baseURL, token, bundle, opts)
+	if err != nil {
+		return controlplane.PublishEvaluation{}, err
+	}
+	switch statusCode {
+	case http.StatusOK, http.StatusCreated:
+		var eval controlplane.PublishEvaluation
+		if err := json.Unmarshal(respBody, &eval); err != nil {
+			return controlplane.PublishEvaluation{}, fmt.Errorf("decode publish dry-run response: %w", err)
+		}
+		return eval, nil
+	case http.StatusForbidden, http.StatusUnauthorized:
+		return controlplane.PublishEvaluation{}, fmt.Errorf("publisher not authorized (HTTP %d): %s", statusCode, serverErrorDetail(respBody, token))
+	default:
+		return controlplane.PublishEvaluation{}, fmt.Errorf("conductor rejected publish dry-run (HTTP %d): %s", statusCode, serverErrorDetail(respBody, token))
+	}
+}
+
+func postBundleRaw(ctx context.Context, client *http.Client, baseURL, token string, bundle conductorcore.PolicyBundle, opts postBundleOptions) (int, []byte, error) {
+	envelope := struct {
+		Bundle          conductorcore.PolicyBundle `json:"bundle"`
+		AllowFleetSkew  bool                       `json:"allow_fleet_skew,omitempty"`
+		FleetSkewReason string                     `json:"fleet_skew_reason,omitempty"`
+		DryRun          bool                       `json:"dry_run,omitempty"`
+	}{Bundle: bundle, AllowFleetSkew: opts.allowFleetSkew, FleetSkewReason: strings.TrimSpace(opts.fleetSkewReason), DryRun: opts.dryRun}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		return 0, nil, fmt.Errorf("marshal publish request: %w", err)
+	}
+	endpoint := strings.TrimRight(baseURL, "/") + controlplane.PublishPolicyBundlePath
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, fmt.Errorf("build publish request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("publish request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := readPublishResponseBody(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, respBody, nil
+}
+
+func readPublishResponseBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, publishMaxResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read conductor response: %w", err)
+	}
+	if len(body) > publishMaxResponseBytes {
+		return nil, fmt.Errorf("conductor response exceeds %d bytes", publishMaxResponseBytes)
+	}
+	return body, nil
 }
 
 type publishResult struct {
@@ -844,6 +918,15 @@ func writePublishPreflight(out io.Writer, p controlplane.PublishPreflightSummary
 		_, _ = fmt.Fprintf(out, "accepted fleet skew with --allow-fleet-skew: unsupported=%d stale/unseen=%d last-apply-failed=%d; prefer a narrow --audience canary when possible\n",
 			p.Unsupported, p.StaleUnseen, p.LastApplyFailed)
 	}
+}
+
+func writePublishEvaluation(out io.Writer, eval controlplane.PublishEvaluation) {
+	_, _ = fmt.Fprintf(out, "dry-run policy bundle valid=%t would_create=%t result_version=%d result_hash=%s conflict=%s\n",
+		eval.Valid, eval.WouldCreate, eval.ResultVersion, eval.ResultHash, eval.Conflict)
+	if eval.HasCurrentHead {
+		_, _ = fmt.Fprintf(out, "current head version=%d hash=%s\n", eval.CurrentHeadVersion, eval.CurrentHeadHash)
+	}
+	writePublishPreflight(out, eval.Preflight)
 }
 
 // conflictSentinel selects the distinct CLI sentinel for an HTTP 409 publish
@@ -992,7 +1075,10 @@ func resolveAutoHash(ctx context.Context, opts publishOptions) (string, error) {
 		return "", fmt.Errorf("stream-status request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, publishMaxResponseBytes))
+	body, err := readPublishResponseBody(resp.Body)
+	if err != nil {
+		return "", err
+	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("stream-status returned HTTP %d: %s", resp.StatusCode, serverErrorDetail(body, token))
 	}

--- a/enterprise/cli/conductor/publish.go
+++ b/enterprise/cli/conductor/publish.go
@@ -845,12 +845,17 @@ func postBundleDryRun(ctx context.Context, client *http.Client, baseURL, token s
 		return controlplane.PublishEvaluation{}, err
 	}
 	switch statusCode {
-	case http.StatusOK, http.StatusCreated:
+	case http.StatusOK:
 		var eval controlplane.PublishEvaluation
 		if err := json.Unmarshal(respBody, &eval); err != nil {
 			return controlplane.PublishEvaluation{}, fmt.Errorf("decode publish dry-run response: %w", err)
 		}
+		if err := requireDryRunEvaluation("publish", eval.DryRun); err != nil {
+			return controlplane.PublishEvaluation{}, err
+		}
 		return eval, nil
+	case http.StatusCreated:
+		return controlplane.PublishEvaluation{}, errors.New("conductor returned 201 Created for publish dry-run; refusing ambiguous mutating response")
 	case http.StatusForbidden, http.StatusUnauthorized:
 		return controlplane.PublishEvaluation{}, fmt.Errorf("publisher not authorized (HTTP %d): %s", statusCode, serverErrorDetail(respBody, token))
 	default:
@@ -869,7 +874,11 @@ func postBundleRaw(ctx context.Context, client *http.Client, baseURL, token stri
 	if err != nil {
 		return 0, nil, fmt.Errorf("marshal publish request: %w", err)
 	}
-	endpoint := strings.TrimRight(baseURL, "/") + controlplane.PublishPolicyBundlePath
+	endpointPath := controlplane.PublishPolicyBundlePath
+	if opts.dryRun {
+		endpointPath = controlplane.PublishPolicyEvaluatePath
+	}
+	endpoint := strings.TrimRight(baseURL, "/") + endpointPath
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return 0, nil, fmt.Errorf("build publish request: %w", err)
@@ -889,14 +898,7 @@ func postBundleRaw(ctx context.Context, client *http.Client, baseURL, token stri
 }
 
 func readPublishResponseBody(r io.Reader) ([]byte, error) {
-	body, err := io.ReadAll(io.LimitReader(r, publishMaxResponseBytes+1))
-	if err != nil {
-		return nil, fmt.Errorf("read conductor response: %w", err)
-	}
-	if len(body) > publishMaxResponseBytes {
-		return nil, fmt.Errorf("conductor response exceeds %d bytes", publishMaxResponseBytes)
-	}
-	return body, nil
+	return readCappedResponseBody(r, publishMaxResponseBytes)
 }
 
 type publishResult struct {
@@ -921,12 +923,24 @@ func writePublishPreflight(out io.Writer, p controlplane.PublishPreflightSummary
 }
 
 func writePublishEvaluation(out io.Writer, eval controlplane.PublishEvaluation) {
-	_, _ = fmt.Fprintf(out, "dry-run policy bundle valid=%t would_create=%t result_version=%d result_hash=%s conflict=%s\n",
+	writePublishEvaluationLabeled(out, "dry-run policy bundle", eval)
+}
+
+func writePublishEvaluationLabeled(out io.Writer, label string, eval controlplane.PublishEvaluation) {
+	_, _ = fmt.Fprintf(out, "%s valid=%t would_create=%t result_version=%d result_hash=%s conflict=%s\n",
+		label,
 		eval.Valid, eval.WouldCreate, eval.ResultVersion, eval.ResultHash, eval.Conflict)
 	if eval.HasCurrentHead {
 		_, _ = fmt.Fprintf(out, "current head version=%d hash=%s\n", eval.CurrentHeadVersion, eval.CurrentHeadHash)
 	}
 	writePublishPreflight(out, eval.Preflight)
+}
+
+func requireDryRunEvaluation(kind string, dryRun bool) error {
+	if dryRun {
+		return nil
+	}
+	return fmt.Errorf("conductor %s dry-run response missing dry_run=true; refusing ambiguous response", kind)
 }
 
 // conflictSentinel selects the distinct CLI sentinel for an HTTP 409 publish

--- a/enterprise/cli/conductor/replay.go
+++ b/enterprise/cli/conductor/replay.go
@@ -1,0 +1,202 @@
+//go:build enterprise
+
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	conductorcore "github.com/luckyPipewrench/pipelock/enterprise/conductor"
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+)
+
+const replayMaxStateSnapshotBytes = conductorcore.MaxConfigYAMLBytes
+
+type replayOptions struct {
+	publish       publishOptions
+	stateSnapshot string
+}
+
+func replayCmd() *cobra.Command {
+	opts := replayOptions{
+		publish: publishOptions{validity: defaultPublishValidity},
+	}
+	cmd := &cobra.Command{
+		Use:   "replay",
+		Short: "Replay a signed Conductor decision artifact against current state",
+		Long: `Replay builds and signs a policy bundle with the same inputs as
+conductor publish, then asks the Conductor decision-replay endpoint to
+re-derive the would-be publish decision under current fleet and policy state.
+Pass --state-snapshot to replay the publish preflight against a captured fleet
+snapshot instead of the current roster/runtime-status view.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.publish.licenseCRL}); err != nil {
+				return err
+			}
+			return runReplay(cmd, opts)
+		},
+	}
+	bindPublishFlags(cmd, &opts.publish, publishFlagOptions{license: true})
+	cmd.Flags().StringVar(&opts.stateSnapshot, "state-snapshot", "", "optional JSON fleet state snapshot for bundle replay preflight")
+	return cmd
+}
+
+func runReplay(cmd *cobra.Command, opts replayOptions) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	token, err := readPublisherToken(opts.publish.publisherTok)
+	if err != nil {
+		return err
+	}
+	snapshot, err := readReplayStateSnapshot(opts.stateSnapshot)
+	if err != nil {
+		return err
+	}
+	client, err := publishHTTPClient(opts.publish)
+	if err != nil {
+		return err
+	}
+	if strings.EqualFold(strings.TrimSpace(opts.publish.previousHash), previousHashAuto) {
+		resolved, err := resolveAutoHash(ctx, opts.publish)
+		if err != nil {
+			return fmt.Errorf("resolve --previous-bundle-hash auto: %w", err)
+		}
+		opts.publish.previousHash = resolved
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "resolved --previous-bundle-hash auto to %s\n", resolved)
+	}
+	bundle, _, priv, err := buildSignedBundle(opts.publish)
+	if err != nil {
+		return err
+	}
+	defer zeroizeKey(priv)
+	result, err := postDecisionReplay(ctx, client, opts.publish.conductorURL, token, bundle, snapshot)
+	if err != nil {
+		return err
+	}
+	writeDecisionReplayResult(cmd.OutOrStdout(), result)
+	return nil
+}
+
+func readReplayStateSnapshot(path string) (json.RawMessage, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	cleanPath := filepath.Clean(path)
+	f, err := os.Open(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("read --state-snapshot: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("read --state-snapshot: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("--state-snapshot must be a regular file")
+	}
+	data, err := io.ReadAll(io.LimitReader(f, replayMaxStateSnapshotBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read --state-snapshot: %w", err)
+	}
+	if len(data) > replayMaxStateSnapshotBytes {
+		return nil, fmt.Errorf("--state-snapshot exceeds %d bytes", replayMaxStateSnapshotBytes)
+	}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, errors.New("--state-snapshot is empty")
+	}
+	if !json.Valid(trimmed) {
+		return nil, errors.New("parse --state-snapshot: invalid JSON")
+	}
+	return json.RawMessage(trimmed), nil
+}
+
+func postDecisionReplay(ctx context.Context, client *http.Client, baseURL, token string, bundle conductorcore.PolicyBundle, snapshot json.RawMessage) (controlplane.DecisionReplayResult, error) {
+	envelope := struct {
+		Bundle        conductorcore.PolicyBundle `json:"bundle"`
+		StateSnapshot json.RawMessage            `json:"state_snapshot,omitempty"`
+	}{
+		Bundle:        bundle,
+		StateSnapshot: snapshot,
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		return controlplane.DecisionReplayResult{}, fmt.Errorf("marshal replay request: %w", err)
+	}
+	endpoint := strings.TrimRight(baseURL, "/") + controlplane.DecisionReplayPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return controlplane.DecisionReplayResult{}, fmt.Errorf("build replay request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return controlplane.DecisionReplayResult{}, fmt.Errorf("replay request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := readPublishResponseBody(resp.Body)
+	if err != nil {
+		return controlplane.DecisionReplayResult{}, err
+	}
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		var result controlplane.DecisionReplayResult
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return controlplane.DecisionReplayResult{}, fmt.Errorf("decode replay response: %w", err)
+		}
+		return result, nil
+	case http.StatusForbidden, http.StatusUnauthorized:
+		return controlplane.DecisionReplayResult{}, fmt.Errorf("publisher not authorized (HTTP %d): %s", resp.StatusCode, serverErrorDetail(respBody, token))
+	default:
+		return controlplane.DecisionReplayResult{}, fmt.Errorf("conductor rejected replay (HTTP %d): %s", resp.StatusCode, serverErrorDetail(respBody, token))
+	}
+}
+
+func writeDecisionReplayResult(out io.Writer, result controlplane.DecisionReplayResult) {
+	_, _ = fmt.Fprintf(out,
+		"decision replay action=%s artifact_hash=%s divergence=%t used_state_snapshot=%t replayed_at=%s\n",
+		result.ActionKind, result.ArtifactHash, result.Divergence, result.UsedStateSnapshot, result.ReplayedAt.UTC().Format(time.RFC3339))
+	if result.DivergenceReason != "" {
+		_, _ = fmt.Fprintf(out, "divergence_reason=%s\n", result.DivergenceReason)
+	}
+	if result.Recorded != nil {
+		_, _ = fmt.Fprintf(out, "recorded present=%t accepted=%t hash=%s\n", result.Recorded.Present, result.Recorded.Accepted, result.Recorded.RecordedHash)
+	}
+	if result.PublishEvaluation != nil {
+		writeReplayPublishEvaluation(out, *result.PublishEvaluation)
+	}
+	if result.RemoteKill != nil {
+		writeRemoteKillEvaluation(out, *result.RemoteKill)
+	}
+	if result.Rollback != nil {
+		writeRollbackEvaluation(out, *result.Rollback)
+	}
+}
+
+func writeReplayPublishEvaluation(out io.Writer, eval controlplane.PublishEvaluation) {
+	_, _ = fmt.Fprintf(out, "replay publish valid=%t would_create=%t result_version=%d result_hash=%s conflict=%s\n",
+		eval.Valid, eval.WouldCreate, eval.ResultVersion, eval.ResultHash, eval.Conflict)
+	if eval.HasCurrentHead {
+		_, _ = fmt.Fprintf(out, "current head version=%d hash=%s\n", eval.CurrentHeadVersion, eval.CurrentHeadHash)
+	}
+	writePublishPreflight(out, eval.Preflight)
+}

--- a/enterprise/cli/conductor/replay.go
+++ b/enterprise/cli/conductor/replay.go
@@ -7,6 +7,7 @@ package conductor
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,11 +25,15 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
-const replayMaxStateSnapshotBytes = conductorcore.MaxConfigYAMLBytes
+const (
+	replayMaxStateSnapshotBytes  = conductorcore.MaxConfigYAMLBytes
+	replayMaxBundleArtifactBytes = conductorcore.MaxConfigYAMLBytes * 2
+)
 
 type replayOptions struct {
-	publish       publishOptions
-	stateSnapshot string
+	publish        publishOptions
+	stateSnapshot  string
+	bundleArtifact string
 }
 
 func replayCmd() *cobra.Command {
@@ -38,9 +43,12 @@ func replayCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "replay",
 		Short: "Replay a signed Conductor decision artifact against current state",
-		Long: `Replay builds and signs a policy bundle with the same inputs as
-conductor publish, then asks the Conductor decision-replay endpoint to
-re-derive the would-be publish decision under current fleet and policy state.
+		Long: `Replay sends a signed policy bundle artifact to the Conductor
+decision-replay endpoint to re-derive the publish decision under current fleet
+and policy state. Pass --bundle-artifact to replay an exact previously saved
+signed bundle. Without --bundle-artifact, replay rebuilds and signs a new
+hypothetical bundle from the same inputs as conductor publish.
+
 Pass --state-snapshot to replay the publish preflight against a captured fleet
 snapshot instead of the current roster/runtime-status view.`,
 		Args: cobra.NoArgs,
@@ -52,6 +60,7 @@ snapshot instead of the current roster/runtime-status view.`,
 		},
 	}
 	bindPublishFlags(cmd, &opts.publish, publishFlagOptions{license: true})
+	cmd.Flags().StringVar(&opts.bundleArtifact, "bundle-artifact", "", "path to an exact signed policy bundle JSON artifact to replay instead of rebuilding from publish inputs")
 	cmd.Flags().StringVar(&opts.stateSnapshot, "state-snapshot", "", "optional JSON fleet state snapshot for bundle replay preflight")
 	return cmd
 }
@@ -73,25 +82,71 @@ func runReplay(cmd *cobra.Command, opts replayOptions) error {
 	if err != nil {
 		return err
 	}
-	if strings.EqualFold(strings.TrimSpace(opts.publish.previousHash), previousHashAuto) {
-		resolved, err := resolveAutoHash(ctx, opts.publish)
+	var bundle conductorcore.PolicyBundle
+	var priv ed25519.PrivateKey
+	if strings.TrimSpace(opts.bundleArtifact) != "" {
+		bundle, err = readReplayBundleArtifact(opts.bundleArtifact)
 		if err != nil {
-			return fmt.Errorf("resolve --previous-bundle-hash auto: %w", err)
+			return err
 		}
-		opts.publish.previousHash = resolved
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "resolved --previous-bundle-hash auto to %s\n", resolved)
+	} else {
+		if strings.EqualFold(strings.TrimSpace(opts.publish.previousHash), previousHashAuto) {
+			resolved, err := resolveAutoHash(ctx, opts.publish)
+			if err != nil {
+				return fmt.Errorf("resolve --previous-bundle-hash auto: %w", err)
+			}
+			opts.publish.previousHash = resolved
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "resolved --previous-bundle-hash auto to %s\n", resolved)
+		}
+		var err error
+		bundle, _, priv, err = buildSignedBundle(opts.publish)
+		if err != nil {
+			return err
+		}
+		defer zeroizeKey(priv)
 	}
-	bundle, _, priv, err := buildSignedBundle(opts.publish)
-	if err != nil {
-		return err
-	}
-	defer zeroizeKey(priv)
 	result, err := postDecisionReplay(ctx, client, opts.publish.conductorURL, token, bundle, snapshot)
 	if err != nil {
 		return err
 	}
 	writeDecisionReplayResult(cmd.OutOrStdout(), result)
 	return nil
+}
+
+func readReplayBundleArtifact(path string) (conductorcore.PolicyBundle, error) {
+	cleanPath := filepath.Clean(path)
+	f, err := os.Open(cleanPath)
+	if err != nil {
+		return conductorcore.PolicyBundle{}, fmt.Errorf("read --bundle-artifact: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return conductorcore.PolicyBundle{}, fmt.Errorf("read --bundle-artifact: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return conductorcore.PolicyBundle{}, errors.New("--bundle-artifact must be a regular file")
+	}
+	data, err := io.ReadAll(io.LimitReader(f, replayMaxBundleArtifactBytes+1))
+	if err != nil {
+		return conductorcore.PolicyBundle{}, fmt.Errorf("read --bundle-artifact: %w", err)
+	}
+	if len(data) > replayMaxBundleArtifactBytes {
+		return conductorcore.PolicyBundle{}, fmt.Errorf("--bundle-artifact exceeds %d bytes", replayMaxBundleArtifactBytes)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var bundle conductorcore.PolicyBundle
+	if err := dec.Decode(&bundle); err != nil {
+		return conductorcore.PolicyBundle{}, fmt.Errorf("parse --bundle-artifact: %w", err)
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return conductorcore.PolicyBundle{}, errors.New("parse --bundle-artifact: trailing JSON")
+	}
+	if err := bundle.Validate(); err != nil {
+		return conductorcore.PolicyBundle{}, fmt.Errorf("validate --bundle-artifact: %w", err)
+	}
+	return bundle, nil
 }
 
 func readReplayStateSnapshot(path string) (json.RawMessage, error) {
@@ -185,18 +240,13 @@ func writeDecisionReplayResult(out io.Writer, result controlplane.DecisionReplay
 		writeReplayPublishEvaluation(out, *result.PublishEvaluation)
 	}
 	if result.RemoteKill != nil {
-		writeRemoteKillEvaluation(out, *result.RemoteKill)
+		writeRemoteKillEvaluation(out, "replay", *result.RemoteKill)
 	}
 	if result.Rollback != nil {
-		writeRollbackEvaluation(out, *result.Rollback)
+		writeRollbackEvaluation(out, "replay", *result.Rollback)
 	}
 }
 
 func writeReplayPublishEvaluation(out io.Writer, eval controlplane.PublishEvaluation) {
-	_, _ = fmt.Fprintf(out, "replay publish valid=%t would_create=%t result_version=%d result_hash=%s conflict=%s\n",
-		eval.Valid, eval.WouldCreate, eval.ResultVersion, eval.ResultHash, eval.Conflict)
-	if eval.HasCurrentHead {
-		_, _ = fmt.Fprintf(out, "current head version=%d hash=%s\n", eval.CurrentHeadVersion, eval.CurrentHeadHash)
-	}
-	writePublishPreflight(out, eval.Preflight)
+	writePublishEvaluationLabeled(out, "replay publish", eval)
 }

--- a/enterprise/cli/conductor/rollback.go
+++ b/enterprise/cli/conductor/rollback.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -166,11 +167,18 @@ func runRollback(cmd *cobra.Command, opts rollbackOptions) error {
 
 	if opts.dryRun {
 		var eval controlplane.RollbackEvaluation
-		if err := postEmergencyJSON(cmd.Context(), client, opts.baseURL, controlplane.RollbackAuthorizationsPath, adminToken,
-			publishRollbackAuthorizationRequest{Authorization: auth, DryRun: true}, &eval); err != nil {
+		status, err := postEmergencyJSONStatus(cmd.Context(), client, opts.baseURL, controlplane.RollbackEvaluatePath, adminToken,
+			publishRollbackAuthorizationRequest{Authorization: auth, DryRun: true}, &eval)
+		if err != nil {
 			return err
 		}
-		writeRollbackEvaluation(cmd.OutOrStdout(), eval)
+		if status == http.StatusCreated {
+			return errors.New("conductor returned 201 Created for rollback dry-run; refusing ambiguous mutating response")
+		}
+		if err := requireDryRunEvaluation("rollback", eval.DryRun); err != nil {
+			return err
+		}
+		writeRollbackEvaluation(cmd.OutOrStdout(), "dry-run", eval)
 		return nil
 	}
 
@@ -201,8 +209,8 @@ type publishRollbackAuthorizationResponse struct {
 	Created           bool      `json:"created"`
 }
 
-func writeRollbackEvaluation(out io.Writer, eval controlplane.RollbackEvaluation) {
+func writeRollbackEvaluation(out io.Writer, label string, eval controlplane.RollbackEvaluation) {
 	_, _ = fmt.Fprintf(out,
-		"dry-run rollback valid=%t would_create=%t counter=%d would_roll_to_bundle_id=%s would_roll_to_version=%d would_roll_to_hash=%s noop=%t conflict=%s current_head_version=%d current_head_hash=%s\n",
-		eval.Valid, eval.WouldCreate, eval.Counter, eval.WouldRollToBundleID, eval.WouldRollToVersion, eval.WouldRollToHash, eval.Noop, eval.Conflict, eval.CurrentHeadVersion, eval.CurrentHeadHash)
+		"%s rollback valid=%t would_create=%t counter=%d would_roll_to_bundle_id=%s would_roll_to_version=%d would_roll_to_hash=%s noop=%t conflict=%s current_head_version=%d current_head_hash=%s\n",
+		label, eval.Valid, eval.WouldCreate, eval.Counter, eval.WouldRollToBundleID, eval.WouldRollToVersion, eval.WouldRollToHash, eval.Noop, eval.Conflict, eval.CurrentHeadVersion, eval.CurrentHeadHash)
 }

--- a/enterprise/cli/conductor/rollback.go
+++ b/enterprise/cli/conductor/rollback.go
@@ -7,6 +7,7 @@ package conductor
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -40,6 +41,7 @@ type rollbackOptions struct {
 	counter         uint64
 	reason          string
 	ttl             time.Duration
+	dryRun          bool
 	licenseCRLFile  string
 
 	now       func() time.Time
@@ -82,6 +84,7 @@ are not supported. It requires at least ` + fmt.Sprintf("%d", conductorcore.Requ
 	cmd.Flags().Uint64Var(&opts.counter, "counter", 0, "monotonic counter; defaults to the current Unix time so each publish supersedes the prior one")
 	cmd.Flags().StringVar(&opts.reason, "reason", "", "operator reason recorded in the signed authorization")
 	cmd.Flags().DurationVar(&opts.ttl, "ttl", rollbackDefaultTTL, "validity window; must not exceed the Conductor's configured rollback max validity")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "evaluate the signed rollback without mutating Conductor state")
 	cmd.Flags().StringVar(&opts.tlsCert, "tls-cert", "", "operator client TLS certificate for Conductor mTLS (required)")
 	cmd.Flags().StringVar(&opts.tlsKey, "tls-key", "", "operator client TLS private key for Conductor mTLS (required)")
 	cmd.Flags().StringVar(&opts.serverCA, "server-ca", "", "CA bundle that signed the Conductor server certificate (required)")
@@ -161,6 +164,16 @@ func runRollback(cmd *cobra.Command, opts rollbackOptions) error {
 		return err
 	}
 
+	if opts.dryRun {
+		var eval controlplane.RollbackEvaluation
+		if err := postEmergencyJSON(cmd.Context(), client, opts.baseURL, controlplane.RollbackAuthorizationsPath, adminToken,
+			publishRollbackAuthorizationRequest{Authorization: auth, DryRun: true}, &eval); err != nil {
+			return err
+		}
+		writeRollbackEvaluation(cmd.OutOrStdout(), eval)
+		return nil
+	}
+
 	var resp publishRollbackAuthorizationResponse
 	if err := postEmergencyJSON(cmd.Context(), client, opts.baseURL, controlplane.RollbackAuthorizationsPath, adminToken,
 		publishRollbackAuthorizationRequest{Authorization: auth}, &resp); err != nil {
@@ -177,6 +190,7 @@ func runRollback(cmd *cobra.Command, opts rollbackOptions) error {
 // handler's unexported wire shapes; field tags match exactly.
 type publishRollbackAuthorizationRequest struct {
 	Authorization conductorcore.RollbackAuthorization `json:"authorization"`
+	DryRun        bool                                `json:"dry_run,omitempty"`
 }
 
 type publishRollbackAuthorizationResponse struct {
@@ -185,4 +199,10 @@ type publishRollbackAuthorizationResponse struct {
 	Counter           uint64    `json:"counter"`
 	PublishedAt       time.Time `json:"published_at"`
 	Created           bool      `json:"created"`
+}
+
+func writeRollbackEvaluation(out io.Writer, eval controlplane.RollbackEvaluation) {
+	_, _ = fmt.Fprintf(out,
+		"dry-run rollback valid=%t would_create=%t counter=%d would_roll_to_bundle_id=%s would_roll_to_version=%d would_roll_to_hash=%s noop=%t conflict=%s current_head_version=%d current_head_hash=%s\n",
+		eval.Valid, eval.WouldCreate, eval.Counter, eval.WouldRollToBundleID, eval.WouldRollToVersion, eval.WouldRollToHash, eval.Noop, eval.Conflict, eval.CurrentHeadVersion, eval.CurrentHeadHash)
 }

--- a/enterprise/conductor/controlplane/dryrun_test.go
+++ b/enterprise/conductor/controlplane/dryrun_test.go
@@ -467,6 +467,19 @@ func publishJSON(t *testing.T, handler *Handler, req publishPolicyBundleRequest)
 	return w
 }
 
+func publishEvaluateJSON(t *testing.T, handler *Handler, req publishPolicyBundleRequest) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal publish evaluate request: %v", err)
+	}
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPut, PublishPolicyEvaluatePath, bytes.NewReader(body))
+	r.Header.Set("X-Pipelock-Publisher", "ok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	return w
+}
+
 func decodePublishEvaluation(t *testing.T, w *httptest.ResponseRecorder) PublishEvaluation {
 	t.Helper()
 	var eval PublishEvaluation
@@ -519,7 +532,7 @@ func TestPublishDryRun_ValidWouldCreate_NoWrite(t *testing.T) {
 		audience: conductor.Audience{InstanceIDs: []string{"*"}},
 	})
 	before := dirDigest(t, sh.bundleDir)
-	w := publishJSON(t, sh.handler, publishPolicyBundleRequest{Bundle: bundle, DryRun: true})
+	w := publishEvaluateJSON(t, sh.handler, publishPolicyBundleRequest{Bundle: bundle})
 	if w.Code != http.StatusOK {
 		t.Fatalf("dry-run publish code=%d body=%s, want 200", w.Code, w.Body.String())
 	}
@@ -747,7 +760,7 @@ func remoteKillJSON(t *testing.T, handler *Handler, req publishRemoteKillRequest
 	if err != nil {
 		t.Fatalf("marshal remote kill request: %v", err)
 	}
-	r := httptest.NewRequestWithContext(context.Background(), http.MethodPut, RemoteKillPath, bytes.NewReader(body))
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPut, RemoteKillEvaluatePath, bytes.NewReader(body))
 	r.Header.Set("X-Pipelock-Admin", "ok")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
@@ -877,7 +890,7 @@ func rollbackJSON(t *testing.T, handler *Handler, req publishRollbackAuthorizati
 	if err != nil {
 		t.Fatalf("marshal rollback request: %v", err)
 	}
-	r := httptest.NewRequestWithContext(context.Background(), http.MethodPut, RollbackAuthorizationsPath, bytes.NewReader(body))
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPut, RollbackEvaluatePath, bytes.NewReader(body))
 	r.Header.Set("X-Pipelock-Admin", "ok")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -24,9 +24,12 @@ const (
 	defaultConductorID = "conductor"
 
 	PublishPolicyBundlePath    = "/api/v1/conductor/policy-bundles"
+	PublishPolicyEvaluatePath  = "/api/v1/conductor/policy-bundles/evaluate"
 	LatestPolicyBundlePath     = "/api/v1/conductor/policy/latest"
 	RemoteKillPath             = "/api/v1/conductor/remote-kill"
+	RemoteKillEvaluatePath     = "/api/v1/conductor/remote-kill/evaluate"
 	RollbackAuthorizationsPath = "/api/v1/conductor/rollback-authorizations"
+	RollbackEvaluatePath       = "/api/v1/conductor/rollback-authorizations/evaluate"
 	AuditBatchesPath           = conductor.AuditBatchesPath
 	FollowersPath              = "/api/v1/conductor/followers"
 	StreamStatusPath           = "/api/v1/conductor/stream"
@@ -499,12 +502,18 @@ func (h *Handler) serveControlHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleEnroll(w, r)
 	case RemoteKillPath:
 		h.handleRemoteKill(w, r)
+	case RemoteKillEvaluatePath:
+		h.handleEvaluateRemoteKill(w, r)
 	case RollbackAuthorizationsPath:
 		h.handleRollbackAuthorizations(w, r)
+	case RollbackEvaluatePath:
+		h.handleEvaluateRollbackAuthorization(w, r)
 	case DecisionReplayPath:
 		h.handleDecisionReplay(w, r)
 	case PublishPolicyBundlePath:
 		h.handlePublishPolicyBundle(w, r)
+	case PublishPolicyEvaluatePath:
+		h.handleEvaluatePolicyBundle(w, r)
 	case LatestPolicyBundlePath:
 		h.handleLatestPolicyBundle(w, r)
 	case AuditBatchesPath:
@@ -573,7 +582,7 @@ func conductorRoute(path string) string {
 		return AuditBatchesPath
 	}
 	switch path {
-	case HealthPath, HealthzPath, MetricsPath, ReadyzPath, conductor.CapabilitiesPath, EnrollmentTokensPath, EnrollPath, RemoteKillPath, RollbackAuthorizationsPath, DecisionReplayPath, PublishPolicyBundlePath, LatestPolicyBundlePath, AuditBatchesPath, FollowersPath, FollowerRuntimeStatusPath, StreamStatusPath:
+	case HealthPath, HealthzPath, MetricsPath, ReadyzPath, conductor.CapabilitiesPath, EnrollmentTokensPath, EnrollPath, RemoteKillPath, RemoteKillEvaluatePath, RollbackAuthorizationsPath, RollbackEvaluatePath, DecisionReplayPath, PublishPolicyBundlePath, PublishPolicyEvaluatePath, LatestPolicyBundlePath, AuditBatchesPath, FollowersPath, FollowerRuntimeStatusPath, StreamStatusPath:
 		return path
 	default:
 		return "unknown"
@@ -693,43 +702,51 @@ func (h *Handler) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, h.capabilities)
 }
 
-func (h *Handler) handlePublishPolicyBundle(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) validatePublishBundleRequest(w http.ResponseWriter, r *http.Request) (publishPolicyBundleRequest, string, bool) {
 	if r.Method != http.MethodPut && r.Method != http.MethodPost {
 		writeMethodNotAllowed(w, http.MethodPut, http.MethodPost)
-		return
+		return publishPolicyBundleRequest{}, "", false
 	}
 	if err := h.authorizePublisher(r); err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
-		return
+		return publishPolicyBundleRequest{}, "", false
 	}
 	var req publishPolicyBundleRequest
 	if err := decodeStrictJSON(w, r, h.maxRequestBody, &req); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			writeError(w, http.StatusRequestEntityTooLarge, conductor.ErrPayloadTooLarge)
-			return
+			return publishPolicyBundleRequest{}, "", false
 		}
 		writeError(w, http.StatusBadRequest, err)
-		return
+		return publishPolicyBundleRequest{}, "", false
 	}
 	if err := h.authorizeBundle(r, req.Bundle); err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
-		return
+		return publishPolicyBundleRequest{}, "", false
 	}
 	fleetSkewReason, err := normalizeFleetSkewReason(req.AllowFleetSkew, req.FleetSkewReason)
 	if err != nil {
 		if errors.Is(err, conductor.ErrPayloadTooLarge) {
 			writeError(w, http.StatusRequestEntityTooLarge, conductor.ErrPayloadTooLarge)
-			return
+			return publishPolicyBundleRequest{}, "", false
 		}
 		writeError(w, http.StatusBadRequest, err)
-		return
+		return publishPolicyBundleRequest{}, "", false
 	}
 	if req.AllowFleetSkew {
 		if err := h.authorizeFleetSkewOverride(r, req.Bundle, fleetSkewReason); err != nil {
 			writeError(w, http.StatusForbidden, ErrPublisherForbidden)
-			return
+			return publishPolicyBundleRequest{}, "", false
 		}
+	}
+	return req, fleetSkewReason, true
+}
+
+func (h *Handler) handlePublishPolicyBundle(w http.ResponseWriter, r *http.Request) {
+	req, fleetSkewReason, ok := h.validatePublishBundleRequest(w, r)
+	if !ok {
+		return
 	}
 	if req.DryRun {
 		h.respondPublishDryRun(w, r, req.Bundle, req.AllowFleetSkew, fleetSkewReason)
@@ -922,36 +939,56 @@ func (h *Handler) handleRemoteKill(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) handlePublishRemoteKill(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) handleEvaluatePolicyBundle(w http.ResponseWriter, r *http.Request) {
+	req, fleetSkewReason, ok := h.validatePublishBundleRequest(w, r)
+	if !ok {
+		return
+	}
+	h.respondPublishDryRun(w, r, req.Bundle, req.AllowFleetSkew, fleetSkewReason)
+}
+
+func (h *Handler) validateRemoteKillRequest(w http.ResponseWriter, r *http.Request) (publishRemoteKillRequest, time.Time, bool) {
+	if r.Method != http.MethodPut && r.Method != http.MethodPost {
+		writeMethodNotAllowed(w, http.MethodPut, http.MethodPost)
+		return publishRemoteKillRequest{}, time.Time{}, false
+	}
 	if h.emergencyControls == nil {
 		writeError(w, http.StatusNotImplemented, ErrEmergencyStoreRequired)
-		return
+		return publishRemoteKillRequest{}, time.Time{}, false
 	}
 	if err := h.authorizeAdmin(r); err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
-		return
+		return publishRemoteKillRequest{}, time.Time{}, false
 	}
 	if h.emergencyKeys == nil {
 		writeError(w, http.StatusNotImplemented, ErrEmergencyKeyRequired)
-		return
+		return publishRemoteKillRequest{}, time.Time{}, false
 	}
 	var req publishRemoteKillRequest
 	if err := decodeStrictJSON(w, r, h.maxRequestBody, &req); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			writeError(w, http.StatusRequestEntityTooLarge, conductor.ErrPayloadTooLarge)
-			return
+			return publishRemoteKillRequest{}, time.Time{}, false
 		}
 		writeError(w, http.StatusBadRequest, err)
-		return
+		return publishRemoteKillRequest{}, time.Time{}, false
 	}
 	now := h.now()
 	if err := validateRemoteKillPublishInput(req.Message, h.remoteKillMaxTTL); err != nil {
 		writeStoreError(w, err)
-		return
+		return publishRemoteKillRequest{}, time.Time{}, false
 	}
 	if err := req.Message.VerifySignaturesAt(now, h.emergencyKeys); err != nil {
 		writeStoreError(w, err)
+		return publishRemoteKillRequest{}, time.Time{}, false
+	}
+	return req, now, true
+}
+
+func (h *Handler) handlePublishRemoteKill(w http.ResponseWriter, r *http.Request) {
+	req, now, ok := h.validateRemoteKillRequest(w, r)
+	if !ok {
 		return
 	}
 	if req.DryRun {
@@ -974,6 +1011,14 @@ func (h *Handler) handlePublishRemoteKill(w http.ResponseWriter, r *http.Request
 		PublishedAt: record.PublishedAt,
 		Created:     created,
 	})
+}
+
+func (h *Handler) handleEvaluateRemoteKill(w http.ResponseWriter, r *http.Request) {
+	req, now, ok := h.validateRemoteKillRequest(w, r)
+	if !ok {
+		return
+	}
+	h.respondRemoteKillDryRun(w, r, req.Message, now)
 }
 
 func (h *Handler) handleLatestRemoteKill(w http.ResponseWriter, r *http.Request) {
@@ -1011,40 +1056,52 @@ func (h *Handler) handleRollbackAuthorizations(w http.ResponseWriter, r *http.Re
 	}
 }
 
-func (h *Handler) handlePublishRollbackAuthorization(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) validateRollbackAuthorizationRequest(w http.ResponseWriter, r *http.Request) (publishRollbackAuthorizationRequest, time.Time, bool) {
+	if r.Method != http.MethodPut && r.Method != http.MethodPost {
+		writeMethodNotAllowed(w, http.MethodPut, http.MethodPost)
+		return publishRollbackAuthorizationRequest{}, time.Time{}, false
+	}
 	if h.emergencyControls == nil {
 		writeError(w, http.StatusNotImplemented, ErrEmergencyStoreRequired)
-		return
+		return publishRollbackAuthorizationRequest{}, time.Time{}, false
 	}
 	if err := h.authorizeAdmin(r); err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
-		return
+		return publishRollbackAuthorizationRequest{}, time.Time{}, false
 	}
 	if h.emergencyKeys == nil {
 		writeError(w, http.StatusNotImplemented, ErrEmergencyKeyRequired)
-		return
+		return publishRollbackAuthorizationRequest{}, time.Time{}, false
 	}
 	var req publishRollbackAuthorizationRequest
 	if err := decodeStrictJSON(w, r, h.maxRequestBody, &req); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			writeError(w, http.StatusRequestEntityTooLarge, conductor.ErrPayloadTooLarge)
-			return
+			return publishRollbackAuthorizationRequest{}, time.Time{}, false
 		}
 		writeError(w, http.StatusBadRequest, err)
-		return
+		return publishRollbackAuthorizationRequest{}, time.Time{}, false
 	}
 	now := h.now()
 	if err := validateRollbackPublishInput(req.Authorization, h.rollbackMaxTTL); err != nil {
 		writeStoreError(w, err)
-		return
+		return publishRollbackAuthorizationRequest{}, time.Time{}, false
 	}
 	if err := req.Authorization.VerifySignaturesAt(now, h.emergencyKeys); err != nil {
 		writeStoreError(w, err)
-		return
+		return publishRollbackAuthorizationRequest{}, time.Time{}, false
 	}
 	if _, err := h.store.BundleByIDVersion(r.Context(), req.Authorization.TargetBundleID, req.Authorization.TargetVersion); err != nil {
 		writeStoreError(w, err)
+		return publishRollbackAuthorizationRequest{}, time.Time{}, false
+	}
+	return req, now, true
+}
+
+func (h *Handler) handlePublishRollbackAuthorization(w http.ResponseWriter, r *http.Request) {
+	req, now, ok := h.validateRollbackAuthorizationRequest(w, r)
+	if !ok {
 		return
 	}
 	if req.DryRun {
@@ -1123,6 +1180,14 @@ func (h *Handler) handlePublishRollbackAuthorization(w http.ResponseWriter, r *h
 		PublishedAt:       record.PublishedAt,
 		Created:           created,
 	})
+}
+
+func (h *Handler) handleEvaluateRollbackAuthorization(w http.ResponseWriter, r *http.Request) {
+	req, now, ok := h.validateRollbackAuthorizationRequest(w, r)
+	if !ok {
+		return
+	}
+	h.respondRollbackDryRun(w, r, req.Authorization, now)
 }
 
 // rollbackClearer is the optional interface an [EmergencyStore] may implement


### PR DESCRIPTION
## What changed

Adds a `--dry-run` flag to `conductor publish`, `kill`, `resume`, and `rollback`, and a new `conductor replay` command, giving the conductor dry-run and decision-replay control-plane endpoints first-class CLI parity with the existing publish/kill/rollback commands.

With `--dry-run`, each command builds and signs its message exactly as for a real submission, sends it to the same endpoint with the dry-run field set, renders the would-be effect (preflight summary, conflict code, divergence), and mutates no conductor state. `conductor replay` re-derives a past signed policy-bundle decision under current fleet and policy state, with an optional state snapshot, hitting the read-only decision-replay endpoint.

Both new paths reuse the existing publisher token, mutual-TLS material, and HTTP client of the real commands and fail closed when any credential is missing.

## Why

Dry-run and decision-replay were HTTP-only control-plane operations with no CLI, so an operator had to hand-craft curl requests to preview an action or re-derive a past decision, unlike publish/kill/rollback which each have a command. This closes that operator-surface gap.

## Notes

Conductor response reads on both the publish and emergency control paths are now bounded so an oversized body with a valid JSON prefix fails closed instead of truncating into a misleading success, and the replay state-snapshot file read is size-capped.

Kill and rollback replay input modes are intentionally out of scope here (replay binds the policy-bundle artifact); they are a natural follow-up. Conductor CLI docs updated for the new flag and command.

## Tests

New tests build each emitted dry-run request against a fake control plane and assert the dry-run field is sent and no mutation occurs (verified against the backing emergency store and stream head), that the normal path omits it and still applies, that replay posts the expected artifact and renders the result, and that oversized responses and missing credentials fail closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--dry-run` for Conductor publish, kill/resume, and rollback, providing read-only evaluation output without mutating state.
  - Added `conductor replay` to re-derive prior publish decisions from an exact signed bundle or a hypothetical rebuild, with optional `--state-snapshot`.
- **Bug Fixes**
  - Hardened client/server handling by rejecting oversized HTTP responses to prevent partial/truncated evaluation data.
- **Documentation**
  - Updated Conductor runbooks and command guides with dry-run and replay workflows, flags, and expected output behavior.
- **Tests**
  - Added/expanded CLI and control-plane tests covering dry-run, replay, validation, and error/conflict paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->