### PR TITLE
ci: shard Linux race tests and stabilize reload test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,12 +76,13 @@ jobs:
   test-oss:
     needs: [security-scan]
     runs-on: ubuntu-latest
-    name: test-oss (${{ matrix.go-version }})
+    name: test-oss (${{ matrix.go-version }}, ${{ matrix.shard }})
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         go-version: ['1.25', '1.26']
+        shard: ['proxy', 'scanner', 'mcp', 'rest']
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -103,12 +104,14 @@ jobs:
 
       - name: Run tests (OSS)
         env:
-          TEST_LABEL: OSS Go ${{ matrix.go-version }}
+          TEST_LABEL: OSS Go ${{ matrix.go-version }} ${{ matrix.shard }}
+          TEST_SHARD: ${{ matrix.shard }}
         run: |
           set -o pipefail
           set +e
-          go test -race -count=1 -json ./... \
-            | tee /tmp/go-test-oss.json >/dev/null
+          packages="$(python3 scripts/ci_test_packages.py --shard "$TEST_SHARD")" || exit $?
+          go test -race -timeout=15m -count=1 -json $packages \
+            | python3 scripts/stream_go_test_json.py --label "$TEST_LABEL" --json-out /tmp/go-test-oss.json
           test_status=$?
           python3 scripts/summarize_go_test_json.py --label "$TEST_LABEL" < /tmp/go-test-oss.json
           summary_status=$?
@@ -120,12 +123,13 @@ jobs:
   test-enterprise:
     needs: [security-scan]
     runs-on: ubuntu-latest
-    name: test-enterprise (${{ matrix.go-version }})
+    name: test-enterprise (${{ matrix.go-version }}, ${{ matrix.shard }})
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         go-version: ['1.25', '1.26']
+        shard: ['proxy', 'scanner', 'mcp', 'rest']
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -145,12 +149,14 @@ jobs:
       - name: Run tests (enterprise with coverage)
         if: matrix.go-version == '1.25'
         env:
-          TEST_LABEL: enterprise Go ${{ matrix.go-version }}
+          TEST_LABEL: enterprise Go ${{ matrix.go-version }} ${{ matrix.shard }}
+          TEST_SHARD: ${{ matrix.shard }}
         run: |
           set -o pipefail
           set +e
-          go test -tags enterprise -race -count=1 -coverprofile=coverage.out -json ./... \
-            | tee /tmp/go-test-enterprise.json >/dev/null
+          packages="$(python3 scripts/ci_test_packages.py --tags enterprise --shard "$TEST_SHARD")" || exit $?
+          go test -tags enterprise -race -timeout=15m -count=1 -coverprofile="coverage-${TEST_SHARD}.out" -json $packages \
+            | python3 scripts/stream_go_test_json.py --label "$TEST_LABEL" --json-out /tmp/go-test-enterprise.json
           test_status=$?
           python3 scripts/summarize_go_test_json.py --label "$TEST_LABEL" < /tmp/go-test-enterprise.json
           summary_status=$?
@@ -162,12 +168,14 @@ jobs:
       - name: Run tests (enterprise)
         if: matrix.go-version != '1.25'
         env:
-          TEST_LABEL: enterprise Go ${{ matrix.go-version }}
+          TEST_LABEL: enterprise Go ${{ matrix.go-version }} ${{ matrix.shard }}
+          TEST_SHARD: ${{ matrix.shard }}
         run: |
           set -o pipefail
           set +e
-          go test -tags enterprise -race -count=1 -json ./... \
-            | tee /tmp/go-test-enterprise.json >/dev/null
+          packages="$(python3 scripts/ci_test_packages.py --tags enterprise --shard "$TEST_SHARD")" || exit $?
+          go test -tags enterprise -race -timeout=15m -count=1 -json $packages \
+            | python3 scripts/stream_go_test_json.py --label "$TEST_LABEL" --json-out /tmp/go-test-enterprise.json
           test_status=$?
           python3 scripts/summarize_go_test_json.py --label "$TEST_LABEL" < /tmp/go-test-enterprise.json
           summary_status=$?
@@ -180,7 +188,7 @@ jobs:
         if: matrix.go-version == '1.25'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
-          files: ./coverage.out
+          files: ./coverage-${{ matrix.shard }}.out
           fail_ci_if_error: false
 
   test:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2212,9 +2212,10 @@ func TestGenerateDockerComposeCmd_WriteError(t *testing.T) {
 }
 
 func TestRunCmd_ReloadRejectsMetricsListenChange(t *testing.T) {
-	testport.WithRetry(t, 2, func(addrs []string) error {
+	testport.WithRetry(t, 3, func(addrs []string) error {
 		mainAddr := addrs[0]
 		metricsAddr := addrs[1]
+		newMetricsAddr := addrs[2]
 
 		dir := t.TempDir()
 		cfgPath := filepath.Join(dir, "test.yaml")
@@ -2259,11 +2260,11 @@ fetch_proxy:
 		// Hot-reload: change metrics_listen (should be rejected).
 		updatedCfg := fmt.Sprintf(`version: 1
 mode: balanced
-metrics_listen: "127.0.0.1:19999"
+metrics_listen: "%s"
 fetch_proxy:
   listen: "%s"
   timeout_seconds: 5
-`, mainAddr)
+`, newMetricsAddr, mainAddr)
 		if writeErr := os.WriteFile(cfgPath, []byte(updatedCfg), 0o600); writeErr != nil {
 			t.Fatal(writeErr)
 		}

--- a/scripts/ci_test_packages.py
+++ b/scripts/ci_test_packages.py
@@ -31,13 +31,18 @@ def package_suffix(package: str) -> str:
     return "internal/" + package.rsplit(marker, 1)[1]
 
 
+def package_in_tree(package: str, root: str) -> bool:
+    suffix = package_suffix(package)
+    return suffix == root or suffix.startswith(root + "/")
+
+
 def select_packages(packages: list[str], shard: str) -> list[str]:
-    heavy_packages = set(HEAVY_SHARDS.values())
+    heavy_roots = tuple(HEAVY_SHARDS.values())
     if shard == "rest":
-        return [pkg for pkg in packages if package_suffix(pkg) not in heavy_packages]
+        return [pkg for pkg in packages if not any(package_in_tree(pkg, root) for root in heavy_roots)]
 
     wanted = HEAVY_SHARDS[shard]
-    selected = [pkg for pkg in packages if package_suffix(pkg) == wanted]
+    selected = [pkg for pkg in packages if package_in_tree(pkg, wanted)]
     if not selected:
         raise ValueError(f"no packages matched shard {shard!r}")
     return selected

--- a/scripts/ci_test_packages.py
+++ b/scripts/ci_test_packages.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Print the package list for a CI test shard."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+HEAVY_SHARDS = {
+    "proxy": "internal/proxy",
+    "scanner": "internal/scanner",
+    "mcp": "internal/mcp",
+}
+
+
+def list_packages(tags: str) -> list[str]:
+    cmd = ["go", "list"]
+    if tags:
+        cmd.extend(["-tags", tags])
+    cmd.append("./...")
+    result = subprocess.run(cmd, check=True, text=True, capture_output=True)
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def package_suffix(package: str) -> str:
+    marker = "/internal/"
+    if marker not in package:
+        return ""
+    return "internal/" + package.rsplit(marker, 1)[1]
+
+
+def select_packages(packages: list[str], shard: str) -> list[str]:
+    heavy_packages = set(HEAVY_SHARDS.values())
+    if shard == "rest":
+        return [pkg for pkg in packages if package_suffix(pkg) not in heavy_packages]
+
+    wanted = HEAVY_SHARDS[shard]
+    selected = [pkg for pkg in packages if package_suffix(pkg) == wanted]
+    if not selected:
+        raise ValueError(f"no packages matched shard {shard!r}")
+    return selected
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Select CI package shard")
+    parser.add_argument(
+        "--shard",
+        required=True,
+        choices=[*HEAVY_SHARDS.keys(), "rest"],
+        help="package shard to print",
+    )
+    parser.add_argument("--tags", default="", help="go build tags for go list")
+    args = parser.parse_args()
+
+    try:
+        packages = select_packages(list_packages(args.tags), args.shard)
+    except (subprocess.CalledProcessError, ValueError) as err:
+        print(f"ci_test_packages.py: {err}", file=sys.stderr)
+        return 1
+
+    print(" ".join(packages))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/stream_go_test_json.py
+++ b/scripts/stream_go_test_json.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Mirror `go test -json` to a file while printing live package completions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def format_duration(seconds: float) -> str:
+    if seconds >= 60:
+        minutes, remainder = divmod(seconds, 60)
+        return f"{int(minutes)}m{remainder:04.1f}s"
+    return f"{seconds:.1f}s"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Stream package completions from go test -json while saving raw JSON."
+    )
+    parser.add_argument("--json-out", required=True, help="path to write raw go test JSON")
+    parser.add_argument("--label", default="go test", help="label printed in progress lines")
+    args = parser.parse_args()
+
+    with open(args.json_out, "w", encoding="utf-8") as raw:
+        for line in sys.stdin:
+            raw.write(line)
+            raw.flush()
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if event.get("Test"):
+                continue
+
+            action = event.get("Action")
+            package = event.get("Package")
+            if action not in {"pass", "fail", "skip"} or not isinstance(package, str):
+                continue
+
+            elapsed = event.get("Elapsed", 0.0)
+            if not isinstance(elapsed, (int, float)):
+                elapsed = 0.0
+
+            print(
+                f"[{args.label}] {action:<4} {format_duration(float(elapsed)):>8} {package}",
+                flush=True,
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- shard Linux OSS and enterprise race-test jobs into proxy, scanner, mcp, and rest package groups
- stream package-level Go test progress into CI logs while preserving the final timing summary
- remove a fixed metrics reload-test port that could collide with other listeners
- raise the Go package timeout used by CI race jobs so slow security packages do not fail at the default 10-minute cliff

## Why
The Linux race jobs were running multiple large packages inside one long, mostly silent full-package Go test process. That made normal runner variance look like hangs, and left `internal/proxy` close to Go's default package timeout. The new layout keeps the same security-focused race coverage and Go-version matrix, but reduces the long monolithic job shape that caused expensive reruns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Go test jobs now run in parallel shards for faster, more targeted validation.
  * Test progress is displayed by package, with results saved for later review.
  * Coverage reports are generated and uploaded separately for each test shard.

* **Bug Fixes**
  * Improved test reliability by using dynamically assigned metrics listener addresses during configuration reload checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->