### PR TITLE
harden(evidence,anchor): bound evidence receipt reads and fix Rekor hashedrekord artifact signatures

### DIFF
--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -514,21 +514,6 @@ func signRekorArtifact(data []byte, algorithm string, priv ed25519.PrivateKey) (
 	return publicKey, base64.StdEncoding.EncodeToString(sig), nil
 }
 
-func signRekorCheckpoint(data []byte, priv ed25519.PrivateKey) (publicKey string, signature string, err error) {
-	if err := domsigning.ValidatePrivateKeyConsistency(priv); err != nil {
-		return "", "", fmt.Errorf("validate rekor signing key: %w", err)
-	}
-	pub, ok := priv.Public().(ed25519.PublicKey)
-	if !ok {
-		return "", "", errors.New("rekor signing key public key is not ed25519")
-	}
-	publicKey, err = encodeRekorPublicKey(pub)
-	if err != nil {
-		return "", "", err
-	}
-	return publicKey, base64.StdEncoding.EncodeToString(ed25519.Sign(priv, data)), nil
-}
-
 func encodeRekorPublicKey(pub ed25519.PublicKey) (string, error) {
 	der, err := x509.MarshalPKIXPublicKey(pub)
 	if err != nil {
@@ -563,12 +548,21 @@ func verifyRekorSignature(data []byte, algorithm, publicKey, signature string) e
 	if err != nil {
 		return fmt.Errorf("decode rekor signature: %w", err)
 	}
-	digest, _, err := rekorSignatureDigest(algorithm, data)
-	if err != nil {
-		return err
-	}
-	if err := ed25519.VerifyWithOptions(pub, digest, sig, &ed25519.Options{Hash: crypto.SHA512}); err != nil {
-		return errors.New("rekor hashedrekord signature invalid")
+	switch algorithm {
+	case rekorSHA512Algorithm:
+		digest, _, err := rekorSignatureDigest(algorithm, data)
+		if err != nil {
+			return err
+		}
+		if err := ed25519.VerifyWithOptions(pub, digest, sig, &ed25519.Options{Hash: crypto.SHA512}); err != nil {
+			return errors.New("rekor hashedrekord signature invalid")
+		}
+	case rekorSHA256Algorithm:
+		if !ed25519.Verify(pub, data, sig) {
+			return errors.New("rekor legacy checkpoint signature invalid")
+		}
+	default:
+		return fmt.Errorf("unsupported rekor hash algorithm %q", algorithm)
 	}
 	return nil
 }

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -40,11 +40,9 @@ const (
 	rekorSHA256Algorithm        = "sha256"
 	rekorSHA512Algorithm        = "sha512"
 	// rekorDefaultSubmitHashAlgorithm is used when RekorLog.HashAlgorithm is
-	// unset. It defaults to SHA-256, which the hashedrekord 0.0.1 schema has
-	// always accepted and which public/common Rekor deployments support. A
-	// deployment whose schema requires SHA-512 sets HashAlgorithm explicitly;
-	// hardcoding either algorithm would break the other class of Rekor server.
-	rekorDefaultSubmitHashAlgorithm = rekorSHA256Algorithm
+	// unset. Pipelock Rekor submissions use Ed25519 keys; Rekor v1 validates
+	// those hashedrekord signatures as Ed25519ph over a SHA-512 digest.
+	rekorDefaultSubmitHashAlgorithm = rekorSHA512Algorithm
 
 	// DefaultRekorHashAlgorithm is the hashedrekord data.hash.algorithm used
 	// when RekorLog.HashAlgorithm is unset. It is exported so CLI defaults stay
@@ -60,10 +58,9 @@ type RekorLog struct {
 	HTTPClient     *http.Client
 	Signer         ed25519.PrivateKey
 	TrustedLogKeys []crypto.PublicKey
-	// HashAlgorithm selects the hashedrekord data.hash.algorithm for
-	// submissions ("sha256" or "sha512"). Empty means the default
-	// (rekorDefaultSubmitHashAlgorithm). Set it to match the target Rekor
-	// deployment's supported schema.
+	// HashAlgorithm selects the hashedrekord data.hash.algorithm for Ed25519
+	// submissions. Rekor v1 accepts SHA-512 for this key type. Empty means the
+	// default (rekorDefaultSubmitHashAlgorithm).
 	HashAlgorithm string
 }
 
@@ -76,10 +73,12 @@ func (r RekorLog) submitHashAlgorithm() (string, error) {
 		return rekorDefaultSubmitHashAlgorithm, nil
 	}
 	switch algo {
-	case rekorSHA256Algorithm, rekorSHA512Algorithm:
+	case rekorSHA512Algorithm:
 		return algo, nil
+	case rekorSHA256Algorithm:
+		return "", fmt.Errorf("unsupported rekor hash algorithm %q for ed25519 hashedrekord submissions (want %q)", algo, rekorSHA512Algorithm)
 	default:
-		return "", fmt.Errorf("unsupported rekor hash algorithm %q (want %q or %q)", algo, rekorSHA256Algorithm, rekorSHA512Algorithm)
+		return "", fmt.Errorf("unsupported rekor hash algorithm %q (want %q)", algo, rekorSHA512Algorithm)
 	}
 }
 
@@ -152,11 +151,11 @@ func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
 	if err != nil {
 		return Proof{}, err
 	}
-	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, r.Signer)
+	hashAlgorithm, err := r.submitHashAlgorithm()
 	if err != nil {
 		return Proof{}, err
 	}
-	hashAlgorithm, err := r.submitHashAlgorithm()
+	publicKey, signature, err := signRekorArtifact(checkpointBytes, hashAlgorithm, r.Signer)
 	if err != nil {
 		return Proof{}, err
 	}
@@ -313,9 +312,6 @@ func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
 	if err != nil {
 		return err
 	}
-	if err := verifyRekorSignature(checkpointBytes, proof.Rekor.PublicKey, proof.Rekor.Signature); err != nil {
-		return err
-	}
 	bodyBytes, err := base64.StdEncoding.DecodeString(proof.Rekor.Body)
 	if err != nil {
 		return fmt.Errorf("decode rekor body: %w", err)
@@ -342,6 +338,9 @@ func validateRekorSubmissionRecord(proof Proof, checkpoint Checkpoint) error {
 	}
 	if body.Spec.Signature.PublicKey.Content != proof.Rekor.PublicKey {
 		return errors.New("rekor body public key does not match proof public key")
+	}
+	if err := verifyRekorSignature(checkpointBytes, body.Spec.Data.Hash.Algorithm, proof.Rekor.PublicKey, proof.Rekor.Signature); err != nil {
+		return err
 	}
 	return nil
 }
@@ -492,6 +491,29 @@ func rekorDigestHex(algorithm string, data []byte) string {
 	}
 }
 
+func signRekorArtifact(data []byte, algorithm string, priv ed25519.PrivateKey) (publicKey string, signature string, err error) {
+	if err := domsigning.ValidatePrivateKeyConsistency(priv); err != nil {
+		return "", "", fmt.Errorf("validate rekor signing key: %w", err)
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return "", "", errors.New("rekor signing key public key is not ed25519")
+	}
+	publicKey, err = encodeRekorPublicKey(pub)
+	if err != nil {
+		return "", "", err
+	}
+	digest, signerOpts, err := rekorSignatureDigest(algorithm, data)
+	if err != nil {
+		return "", "", err
+	}
+	sig, err := priv.Sign(nil, digest, signerOpts)
+	if err != nil {
+		return "", "", fmt.Errorf("sign rekor artifact digest: %w", err)
+	}
+	return publicKey, base64.StdEncoding.EncodeToString(sig), nil
+}
+
 func signRekorCheckpoint(data []byte, priv ed25519.PrivateKey) (publicKey string, signature string, err error) {
 	if err := domsigning.ValidatePrivateKeyConsistency(priv); err != nil {
 		return "", "", fmt.Errorf("validate rekor signing key: %w", err)
@@ -500,45 +522,75 @@ func signRekorCheckpoint(data []byte, priv ed25519.PrivateKey) (publicKey string
 	if !ok {
 		return "", "", errors.New("rekor signing key public key is not ed25519")
 	}
+	publicKey, err = encodeRekorPublicKey(pub)
+	if err != nil {
+		return "", "", err
+	}
+	return publicKey, base64.StdEncoding.EncodeToString(ed25519.Sign(priv, data)), nil
+}
+
+func encodeRekorPublicKey(pub ed25519.PublicKey) (string, error) {
 	der, err := x509.MarshalPKIXPublicKey(pub)
 	if err != nil {
-		return "", "", fmt.Errorf("marshal rekor public key: %w", err)
+		return "", fmt.Errorf("marshal rekor public key: %w", err)
 	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
 	if len(pemBytes) == 0 {
-		return "", "", errors.New("encode rekor public key")
+		return "", errors.New("encode rekor public key")
 	}
-	return base64.StdEncoding.EncodeToString(pemBytes), base64.StdEncoding.EncodeToString(ed25519.Sign(priv, data)), nil
+	return base64.StdEncoding.EncodeToString(pemBytes), nil
 }
 
-func verifyRekorSignature(data []byte, publicKey, signature string) error {
+func rekorSignatureDigest(algorithm string, data []byte) ([]byte, crypto.SignerOpts, error) {
+	switch algorithm {
+	case rekorSHA512Algorithm:
+		sum := sha512.Sum512(data)
+		return sum[:], crypto.SHA512, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported rekor hash algorithm %q", algorithm)
+	}
+}
+
+func verifyRekorSignature(data []byte, algorithm, publicKey, signature string) error {
 	if publicKey == "" || signature == "" {
 		return errors.New("rekor proof public key and signature required")
 	}
-	pemBytes, err := base64.StdEncoding.DecodeString(publicKey)
+	pub, err := parseRekorEd25519PublicKey(publicKey)
 	if err != nil {
-		return fmt.Errorf("decode rekor public key: %w", err)
-	}
-	block, _ := pem.Decode(pemBytes)
-	if block == nil || block.Type != "PUBLIC KEY" {
-		return errors.New("parse rekor public key PEM")
-	}
-	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return fmt.Errorf("parse rekor public key: %w", err)
-	}
-	pub, ok := parsed.(ed25519.PublicKey)
-	if !ok {
-		return errors.New("rekor public key is not ed25519")
+		return err
 	}
 	sig, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {
 		return fmt.Errorf("decode rekor signature: %w", err)
 	}
-	if !ed25519.Verify(pub, data, sig) {
-		return errors.New("rekor checkpoint signature invalid")
+	digest, _, err := rekorSignatureDigest(algorithm, data)
+	if err != nil {
+		return err
+	}
+	if err := ed25519.VerifyWithOptions(pub, digest, sig, &ed25519.Options{Hash: crypto.SHA512}); err != nil {
+		return errors.New("rekor hashedrekord signature invalid")
 	}
 	return nil
+}
+
+func parseRekorEd25519PublicKey(publicKey string) (ed25519.PublicKey, error) {
+	pemBytes, err := base64.StdEncoding.DecodeString(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode rekor public key: %w", err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return nil, errors.New("parse rekor public key PEM")
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse rekor public key: %w", err)
+	}
+	pub, ok := parsed.(ed25519.PublicKey)
+	if !ok {
+		return nil, errors.New("rekor public key is not ed25519")
+	}
+	return pub, nil
 }
 
 func verifyRekorSET(proof Proof, keys []crypto.PublicKey) error {

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -141,12 +141,12 @@ func TestRekorLogSubmitHashAlgorithm(t *testing.T) {
 		t.Fatalf("Submit(sha256) err = %v, want unsupported algorithm error", err)
 	}
 
-	legacy := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
+	legacyWithWrongSignature := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
 		body.Spec.Data.Hash.Algorithm = rekorSHA256Algorithm
 		body.Spec.Data.Hash.Value = sha256Hex(checkpointBytes)
 	})
-	if err := validateRekorSubmissionRecord(legacy, checkpoint); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
-		t.Fatalf("validateRekorSubmissionRecord err = %v, want unsupported algorithm", err)
+	if err := validateRekorSubmissionRecord(legacyWithWrongSignature, checkpoint); err == nil || !strings.Contains(err.Error(), "signature invalid") {
+		t.Fatalf("validateRekorSubmissionRecord err = %v, want signature invalid", err)
 	}
 
 	mismatched := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
@@ -248,7 +248,7 @@ func TestRekorLogSubmitHashedRekordSignatureCoversArtifactDigest(t *testing.T) {
 	}
 }
 
-func TestRekorLogVerifyRejectsSHA256Ed25519HashedRekordDigest(t *testing.T) {
+func TestRekorLogVerifyAcceptsLegacySHA256Ed25519CheckpointSignature(t *testing.T) {
 	receipts, keyHex := testReceiptChain(t, 1)
 	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
 	if err != nil {
@@ -262,25 +262,28 @@ func TestRekorLogVerifyRejectsSHA256Ed25519HashedRekordDigest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey entry: %v", err)
 	}
-	proof := selfConsistentRekorProofWithAlgorithm(t, checkpoint, entryPriv, logPriv, rekorSHA512Algorithm)
+	proof := selfConsistentLegacySHA256RekorProof(t, checkpoint, entryPriv, logPriv)
 	checkpointBytes, err := checkpointBytes(checkpoint)
 	if err != nil {
 		t.Fatalf("checkpointBytes: %v", err)
 	}
-	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, entryPriv)
+
+	if err := (RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}}).Verify(proof, checkpoint); err != nil {
+		t.Fatalf("Verify legacy SHA-256 raw Ed25519 proof: %v", err)
+	}
+
+	publicKey, signature, err := signRekorArtifact(checkpointBytes, rekorSHA512Algorithm, entryPriv)
 	if err != nil {
-		t.Fatalf("signRekorCheckpoint: %v", err)
+		t.Fatalf("signRekorArtifact: %v", err)
 	}
 	candidate := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
-		body.Spec.Data.Hash.Algorithm = rekorSHA256Algorithm
-		body.Spec.Data.Hash.Value = sha256Hex(checkpointBytes)
 		body.Spec.Signature.Content = signature
 		body.Spec.Signature.PublicKey.Content = publicKey
 	})
 	candidate.Rekor.PublicKey = publicKey
 	candidate.Rekor.Signature = signature
-	if err := (RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}}).Verify(candidate, checkpoint); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
-		t.Fatalf("Verify SHA-256 Ed25519 body err = %v, want unsupported algorithm", err)
+	if err := validateRekorSubmissionRecord(candidate, checkpoint); err == nil || !strings.Contains(err.Error(), "signature invalid") {
+		t.Fatalf("validate SHA-256 proof with SHA-512ph signature err = %v, want signature invalid", err)
 	}
 }
 
@@ -332,8 +335,8 @@ func TestRekorArtifactSignatureRejectsUnsupportedAlgorithms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("signRekorArtifact SHA-512: %v", err)
 	}
-	if err := verifyRekorSignature([]byte("artifact"), rekorSHA256Algorithm, publicKey, signature); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
-		t.Fatalf("verifyRekorSignature SHA-256 err = %v, want unsupported algorithm", err)
+	if err := verifyRekorSignature([]byte("artifact"), rekorSHA256Algorithm, publicKey, signature); err == nil || !strings.Contains(err.Error(), "signature invalid") {
+		t.Fatalf("verifyRekorSignature SHA-256 with SHA-512ph signature err = %v, want signature invalid", err)
 	}
 }
 
@@ -1207,6 +1210,21 @@ func rekorPublicKeyForTest(t *testing.T, pub ed25519.PublicKey) string {
 	return base64.StdEncoding.EncodeToString(pemBytes)
 }
 
+func signRekorCheckpoint(data []byte, priv ed25519.PrivateKey) (publicKey string, signature string, err error) {
+	if err := domsigning.ValidatePrivateKeyConsistency(priv); err != nil {
+		return "", "", fmt.Errorf("validate rekor signing key: %w", err)
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return "", "", errors.New("rekor signing key public key is not ed25519")
+	}
+	publicKey, err = encodeRekorPublicKey(pub)
+	if err != nil {
+		return "", "", err
+	}
+	return publicKey, base64.StdEncoding.EncodeToString(ed25519.Sign(priv, data)), nil
+}
+
 func writeDirectRekorEntry(t *testing.T, w http.ResponseWriter, r *http.Request, logID, body string) {
 	t.Helper()
 	if body == "body" {
@@ -1257,6 +1275,60 @@ func encodedRekorRequestBody(t *testing.T, r *http.Request) string {
 func selfConsistentRekorProof(t *testing.T, checkpoint Checkpoint, entrySigner, logSigner ed25519.PrivateKey) Proof {
 	t.Helper()
 	return selfConsistentRekorProofWithAlgorithm(t, checkpoint, entrySigner, logSigner, rekorDefaultSubmitHashAlgorithm)
+}
+
+func selfConsistentLegacySHA256RekorProof(t *testing.T, checkpoint Checkpoint, entrySigner, logSigner ed25519.PrivateKey) Proof {
+	t.Helper()
+	checkpointBytes, err := checkpointBytes(checkpoint)
+	if err != nil {
+		t.Fatalf("checkpointBytes: %v", err)
+	}
+	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, entrySigner)
+	if err != nil {
+		t.Fatalf("signRekorCheckpoint: %v", err)
+	}
+	body := rekorSubmitRequest{
+		APIVersion: rekorHashedRekordAPIVersion,
+		Kind:       rekorHashedRekordKind,
+		Spec: rekorSubmitSpec{
+			Data: rekorData{Hash: rekorHash{
+				Algorithm: rekorSHA256Algorithm,
+				Value:     rekorDigestHex(rekorSHA256Algorithm, checkpointBytes),
+			}},
+			Signature: rekorSignature{
+				Content:   signature,
+				PublicKey: rekorPublicKey{Content: publicKey},
+			},
+		},
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	encodedBody := base64.StdEncoding.EncodeToString(bodyBytes)
+	rootHash := rfc6962LeafHash(bodyBytes)
+	return Proof{
+		Backend:     RekorBackend,
+		LogID:       "fake-rekor-log",
+		LogIndex:    0,
+		EntryHash:   sha256Hex([]byte(encodedBody)),
+		LogRootHash: hex.EncodeToString(rootHash),
+		Rekor: &RekorProof{
+			URL:                  "https://rekor.example.invalid",
+			UUID:                 "fake-uuid",
+			Body:                 encodedBody,
+			PublicKey:            publicKey,
+			Signature:            signature,
+			IntegratedTime:       fakeRekorIntegratedTime,
+			SignedEntryTimestamp: signedEntryTimestampForTest(t, "fake-rekor-log", 0, encodedBody, logSigner),
+			InclusionProof: &RekorInclusionProof{
+				RootHash:   hex.EncodeToString(rootHash),
+				LogIndex:   0,
+				TreeSize:   1,
+				Checkpoint: signedCheckpointForTest(t, 1, rootHash, logSigner),
+			},
+		},
+	}
 }
 
 func selfConsistentRekorProofWithAlgorithm(t *testing.T, checkpoint Checkpoint, entrySigner, logSigner ed25519.PrivateKey, algorithm string) Proof {

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -284,6 +284,109 @@ func TestRekorLogVerifyRejectsSHA256Ed25519HashedRekordDigest(t *testing.T) {
 	}
 }
 
+func TestRekorArtifactSignatureRoundTripAndTampering(t *testing.T) {
+	artifact := []byte("checkpoint artifact bytes")
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	publicKey, signature, err := signRekorArtifact(artifact, rekorSHA512Algorithm, priv)
+	if err != nil {
+		t.Fatalf("signRekorArtifact: %v", err)
+	}
+	if got := decodeRekorEd25519PublicKeyForTest(t, publicKey); !got.Equal(pub) {
+		t.Fatal("encoded Rekor public key does not match signer")
+	}
+	if err := verifyRekorSignature(artifact, rekorSHA512Algorithm, publicKey, signature); err != nil {
+		t.Fatalf("verifyRekorSignature: %v", err)
+	}
+
+	tamperedArtifact := append([]byte(nil), artifact...)
+	tamperedArtifact[0] ^= 0x01
+	if err := verifyRekorSignature(tamperedArtifact, rekorSHA512Algorithm, publicKey, signature); err == nil || !strings.Contains(err.Error(), "signature invalid") {
+		t.Fatalf("verifyRekorSignature tampered artifact err = %v, want signature invalid", err)
+	}
+
+	wrongPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey wrong: %v", err)
+	}
+	wrongPublicKey := rekorPublicKeyForTest(t, wrongPub)
+	if err := verifyRekorSignature(artifact, rekorSHA512Algorithm, wrongPublicKey, signature); err == nil || !strings.Contains(err.Error(), "signature invalid") {
+		t.Fatalf("verifyRekorSignature wrong key err = %v, want signature invalid", err)
+	}
+}
+
+func TestRekorArtifactSignatureRejectsUnsupportedAlgorithms(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if _, _, err := signRekorArtifact([]byte("artifact"), rekorSHA256Algorithm, priv); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
+		t.Fatalf("signRekorArtifact SHA-256 err = %v, want unsupported algorithm", err)
+	}
+	if _, _, err := signRekorArtifact([]byte("artifact"), "sha3-512", priv); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
+		t.Fatalf("signRekorArtifact sha3 err = %v, want unsupported algorithm", err)
+	}
+	publicKey, signature, err := signRekorArtifact([]byte("artifact"), rekorSHA512Algorithm, priv)
+	if err != nil {
+		t.Fatalf("signRekorArtifact SHA-512: %v", err)
+	}
+	if err := verifyRekorSignature([]byte("artifact"), rekorSHA256Algorithm, publicKey, signature); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
+		t.Fatalf("verifyRekorSignature SHA-256 err = %v, want unsupported algorithm", err)
+	}
+}
+
+func TestRekorArtifactSignatureRejectsMalformedInputs(t *testing.T) {
+	artifact := []byte("checkpoint artifact bytes")
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	publicKey, signature, err := signRekorArtifact(artifact, rekorSHA512Algorithm, priv)
+	if err != nil {
+		t.Fatalf("signRekorArtifact: %v", err)
+	}
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa GenerateKey: %v", err)
+	}
+	rsaDER, err := x509.MarshalPKIXPublicKey(&rsaKey.PublicKey)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey rsa: %v", err)
+	}
+	rsaPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: rsaDER})
+
+	badDERPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: []byte("not der")})
+	cases := []struct {
+		name      string
+		publicKey string
+		signature string
+		want      string
+	}{
+		{name: "missing public key", publicKey: "", signature: signature, want: "required"},
+		{name: "bad public key base64", publicKey: "not base64!", signature: signature, want: "decode rekor public key"},
+		{name: "bad public key pem", publicKey: base64.StdEncoding.EncodeToString([]byte("not pem")), signature: signature, want: "parse rekor public key PEM"},
+		{name: "bad public key der", publicKey: base64.StdEncoding.EncodeToString(badDERPEM), signature: signature, want: "parse rekor public key"},
+		{name: "non ed25519 public key", publicKey: base64.StdEncoding.EncodeToString(rsaPEM), signature: signature, want: "not ed25519"},
+		{name: "bad signature base64", publicKey: publicKey, signature: "not base64!", want: "decode rekor signature"},
+		{name: "malformed signature", publicKey: publicKey, signature: base64.StdEncoding.EncodeToString([]byte("short signature")), want: "signature invalid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := verifyRekorSignature(artifact, rekorSHA512Algorithm, tc.publicKey, tc.signature); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("verifyRekorSignature err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	corruptPriv := ed25519.PrivateKey(make([]byte, ed25519.PrivateKeySize))
+	if _, _, err := signRekorArtifact(artifact, rekorSHA512Algorithm, corruptPriv); err == nil || !strings.Contains(err.Error(), "validate rekor signing key") {
+		t.Fatalf("signRekorArtifact corrupt key err = %v, want validation error", err)
+	}
+}
+
 func TestRekorLogVerifyRejectsCheckpointSubstitution(t *testing.T) {
 	receipts, keyHex := testReceiptChain(t, 1)
 	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -97,24 +98,25 @@ func TestRekorLogSubmitHashAlgorithm(t *testing.T) {
 		t.Fatalf("GenerateKey: %v", err)
 	}
 
-	// Default (HashAlgorithm unset) submits SHA-256: the hashedrekord schema
-	// default that public/common Rekor deployments accept.
+	// Default (HashAlgorithm unset) submits SHA-512: Rekor v1 verifies
+	// Ed25519 hashedrekord entries as Ed25519ph over a SHA-512 digest.
 	defProof, err := (RekorLog{URL: fakeRekorServer(t).URL, Signer: priv}).Submit(checkpoint)
 	if err != nil {
 		t.Fatalf("Submit(default): %v", err)
 	}
 	defBody := decodeSubmittedRekorBody(t, defProof)
-	if defBody.Spec.Data.Hash.Algorithm != rekorSHA256Algorithm {
-		t.Fatalf("default hash algorithm = %q, want %q", defBody.Spec.Data.Hash.Algorithm, rekorSHA256Algorithm)
+	if defBody.Spec.Data.Hash.Algorithm != rekorSHA512Algorithm {
+		t.Fatalf("default hash algorithm = %q, want %q", defBody.Spec.Data.Hash.Algorithm, rekorSHA512Algorithm)
 	}
-	if got, want := defBody.Spec.Data.Hash.Value, sha256Hex(checkpointBytes); got != want {
-		t.Fatalf("default hash value = %q, want SHA-256 %q", got, want)
+	defSum := sha512.Sum512(checkpointBytes)
+	if got, want := defBody.Spec.Data.Hash.Value, hex.EncodeToString(defSum[:]); got != want {
+		t.Fatalf("default hash value = %q, want SHA-512 %q", got, want)
 	}
 	if err := validateRekorSubmissionRecord(defProof, checkpoint); err != nil {
 		t.Fatalf("validateRekorSubmissionRecord(default): %v", err)
 	}
 
-	// Explicit SHA-512: for a deployment whose schema requires it.
+	// Explicit SHA-512 remains accepted.
 	proof, err := (RekorLog{URL: fakeRekorServer(t).URL, Signer: priv, HashAlgorithm: rekorSHA512Algorithm}).Submit(checkpoint)
 	if err != nil {
 		t.Fatalf("Submit(sha512): %v", err)
@@ -135,13 +137,16 @@ func TestRekorLogSubmitHashAlgorithm(t *testing.T) {
 	if _, err := (RekorLog{URL: fakeRekorServer(t).URL, Signer: priv, HashAlgorithm: "sha3-256"}).Submit(checkpoint); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
 		t.Fatalf("Submit(unsupported algorithm) err = %v, want unsupported algorithm error", err)
 	}
+	if _, err := (RekorLog{URL: fakeRekorServer(t).URL, Signer: priv, HashAlgorithm: rekorSHA256Algorithm}).Submit(checkpoint); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
+		t.Fatalf("Submit(sha256) err = %v, want unsupported algorithm error", err)
+	}
 
 	legacy := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
 		body.Spec.Data.Hash.Algorithm = rekorSHA256Algorithm
 		body.Spec.Data.Hash.Value = sha256Hex(checkpointBytes)
 	})
-	if err := validateRekorSubmissionRecord(legacy, checkpoint); err != nil {
-		t.Fatalf("validateRekorSubmissionRecord accepted legacy SHA-256 body: %v", err)
+	if err := validateRekorSubmissionRecord(legacy, checkpoint); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
+		t.Fatalf("validateRekorSubmissionRecord err = %v, want unsupported algorithm", err)
 	}
 
 	mismatched := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
@@ -162,7 +167,88 @@ func TestRekorLogSubmitHashAlgorithm(t *testing.T) {
 	}
 }
 
-func TestRekorLogVerifyAcceptsLegacySHA256HashedRekordDigest(t *testing.T) {
+func TestRekorLogSubmitHashedRekordSignatureCoversArtifactDigest(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	checkpointBytes, err := checkpointBytes(checkpoint)
+	if err != nil {
+		t.Fatalf("checkpointBytes: %v", err)
+	}
+	logPub, logPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey log: %v", err)
+	}
+	_, entryPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey entry: %v", err)
+	}
+
+	checkpointPublicKey, checkpointSignature, err := signRekorCheckpoint(checkpointBytes, entryPriv)
+	if err != nil {
+		t.Fatalf("signRekorCheckpoint: %v", err)
+	}
+	checkpointSignedBody := rekorSubmitRequest{
+		APIVersion: rekorHashedRekordAPIVersion,
+		Kind:       rekorHashedRekordKind,
+		Spec: rekorSubmitSpec{
+			Data: rekorData{Hash: rekorHash{
+				Algorithm: rekorSHA512Algorithm,
+				Value:     rekorDigestHex(rekorSHA512Algorithm, checkpointBytes),
+			}},
+			Signature: rekorSignature{
+				Content:   checkpointSignature,
+				PublicKey: rekorPublicKey{Content: checkpointPublicKey},
+			},
+		},
+	}
+	if verifyRekorV1HashedRekordEd25519Signature(t, checkpointSignedBody, checkpointBytes) {
+		t.Fatal("Rekor v1 verifier accepted checkpoint signature as hashedrekord artifact signature")
+	}
+
+	server := rekorServerWithEntryValidation(t, logPriv, func(body rekorSubmitRequest) error {
+		if !verifyRekorV1HashedRekordEd25519Signature(t, body, checkpointBytes) {
+			return errors.New("verifying signature: failed to verify signature: ed25519: invalid signature")
+		}
+		return nil
+	})
+	proof, err := (RekorLog{
+		URL:           server.URL,
+		Signer:        entryPriv,
+		HashAlgorithm: rekorSHA512Algorithm,
+	}).Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	body := decodeSubmittedRekorBody(t, proof)
+	if !verifyRekorV1HashedRekordEd25519Signature(t, body, checkpointBytes) {
+		t.Fatal("submitted hashedrekord signature does not verify under Rekor v1 rules")
+	}
+
+	tamperedArtifact := append([]byte(nil), checkpointBytes...)
+	tamperedArtifact[len(tamperedArtifact)-1] ^= 0x01
+	if verifyRekorV1HashedRekordEd25519Signature(t, body, tamperedArtifact) {
+		t.Fatal("Rekor v1 verifier accepted signature for tampered artifact")
+	}
+
+	otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey wrong: %v", err)
+	}
+	wrongKeyBody := body
+	wrongKeyBody.Spec.Signature.PublicKey.Content = rekorPublicKeyForTest(t, otherPub)
+	if verifyRekorV1HashedRekordEd25519Signature(t, wrongKeyBody, checkpointBytes) {
+		t.Fatal("Rekor v1 verifier accepted signature under wrong key")
+	}
+
+	if err := (RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}}).Verify(proof, checkpoint); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+}
+
+func TestRekorLogVerifyRejectsSHA256Ed25519HashedRekordDigest(t *testing.T) {
 	receipts, keyHex := testReceiptChain(t, 1)
 	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
 	if err != nil {
@@ -176,13 +262,29 @@ func TestRekorLogVerifyAcceptsLegacySHA256HashedRekordDigest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey entry: %v", err)
 	}
-	proof := selfConsistentRekorProofWithAlgorithm(t, checkpoint, entryPriv, logPriv, rekorSHA256Algorithm)
-	if err := (RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}}).Verify(proof, checkpoint); err != nil {
-		t.Fatalf("Verify legacy SHA-256 body: %v", err)
+	proof := selfConsistentRekorProofWithAlgorithm(t, checkpoint, entryPriv, logPriv, rekorSHA512Algorithm)
+	checkpointBytes, err := checkpointBytes(checkpoint)
+	if err != nil {
+		t.Fatalf("checkpointBytes: %v", err)
+	}
+	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, entryPriv)
+	if err != nil {
+		t.Fatalf("signRekorCheckpoint: %v", err)
+	}
+	candidate := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
+		body.Spec.Data.Hash.Algorithm = rekorSHA256Algorithm
+		body.Spec.Data.Hash.Value = sha256Hex(checkpointBytes)
+		body.Spec.Signature.Content = signature
+		body.Spec.Signature.PublicKey.Content = publicKey
+	})
+	candidate.Rekor.PublicKey = publicKey
+	candidate.Rekor.Signature = signature
+	if err := (RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}}).Verify(candidate, checkpoint); err == nil || !strings.Contains(err.Error(), "unsupported rekor hash algorithm") {
+		t.Fatalf("Verify SHA-256 Ed25519 body err = %v, want unsupported algorithm", err)
 	}
 }
 
-func TestRekorLogVerifyRejectsCheckpointSubstitutionUnderBothHashAlgorithms(t *testing.T) {
+func TestRekorLogVerifyRejectsCheckpointSubstitution(t *testing.T) {
 	receipts, keyHex := testReceiptChain(t, 1)
 	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
 	if err != nil {
@@ -207,24 +309,20 @@ func TestRekorLogVerifyRejectsCheckpointSubstitutionUnderBothHashAlgorithms(t *t
 	}
 	verifier := RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}}
 
-	for _, algorithm := range []string{rekorSHA512Algorithm, rekorSHA256Algorithm} {
-		t.Run(algorithm, func(t *testing.T) {
-			proof := selfConsistentRekorProofWithAlgorithm(t, checkpoint, entryPriv, logPriv, algorithm)
-			if err := verifier.Verify(proof, checkpoint); err != nil {
-				t.Fatalf("Verify original proof: %v", err)
-			}
-			if err := verifier.Verify(proof, tamperedCheckpoint); err == nil {
-				t.Fatal("Verify accepted original proof for tampered checkpoint")
-			}
+	proof := selfConsistentRekorProofWithAlgorithm(t, checkpoint, entryPriv, logPriv, rekorSHA512Algorithm)
+	if err := verifier.Verify(proof, checkpoint); err != nil {
+		t.Fatalf("Verify original proof: %v", err)
+	}
+	if err := verifier.Verify(proof, tamperedCheckpoint); err == nil {
+		t.Fatal("Verify accepted original proof for tampered checkpoint")
+	}
 
-			forged := proofWithRekorBodyForCheckpoint(t, proof, tamperedCheckpoint, attackerPriv, algorithm)
-			if err := validateRekorSubmissionRecord(forged, tamperedCheckpoint); err != nil {
-				t.Fatalf("validate forged submission record: %v", err)
-			}
-			if err := verifier.Verify(forged, tamperedCheckpoint); err == nil || !strings.Contains(err.Error(), "signed_entry_timestamp") {
-				t.Fatalf("Verify forged logged body err = %v, want SET failure", err)
-			}
-		})
+	forged := proofWithRekorBodyForCheckpoint(t, proof, tamperedCheckpoint, attackerPriv, rekorSHA512Algorithm)
+	if err := validateRekorSubmissionRecord(forged, tamperedCheckpoint); err != nil {
+		t.Fatalf("validate forged submission record: %v", err)
+	}
+	if err := verifier.Verify(forged, tamperedCheckpoint); err == nil || !strings.Contains(err.Error(), "signed_entry_timestamp") {
+		t.Fatalf("Verify forged logged body err = %v, want SET failure", err)
 	}
 }
 
@@ -867,9 +965,9 @@ func proofWithRekorBodyForCheckpoint(t *testing.T, proof Proof, checkpoint Check
 	if err != nil {
 		t.Fatalf("checkpointBytes: %v", err)
 	}
-	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, signer)
+	publicKey, signature, err := signRekorArtifact(checkpointBytes, algorithm, signer)
 	if err != nil {
-		t.Fatalf("signRekorCheckpoint: %v", err)
+		t.Fatalf("signRekorArtifact: %v", err)
 	}
 	candidate := proofWithRekorBody(t, proof, func(body *rekorSubmitRequest) {
 		body.Spec.Data.Hash.Algorithm = algorithm
@@ -903,6 +1001,12 @@ func fakeTrustedRekorServer(t *testing.T) (*httptest.Server, ed25519.PublicKey) 
 	if err != nil {
 		t.Fatalf("GenerateKey log: %v", err)
 	}
+	server := rekorServerWithEntryValidation(t, logPriv, nil)
+	return server, logPub
+}
+
+func rekorServerWithEntryValidation(t *testing.T, logPriv ed25519.PrivateKey, validate func(rekorSubmitRequest) error) *httptest.Server {
+	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/log/entries" {
 			http.Error(w, "not found", http.StatusNotFound)
@@ -912,6 +1016,12 @@ func fakeTrustedRekorServer(t *testing.T) (*httptest.Server, ed25519.PublicKey) 
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
+		}
+		if validate != nil {
+			if err := validate(body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 		}
 		raw, err := json.Marshal(body)
 		if err != nil {
@@ -940,7 +1050,58 @@ func fakeTrustedRekorServer(t *testing.T) (*httptest.Server, ed25519.PublicKey) 
 		_ = json.NewEncoder(w).Encode(map[string]rekorEntry{"fake-uuid": entry})
 	}))
 	t.Cleanup(server.Close)
-	return server, logPub
+	return server
+}
+
+func verifyRekorV1HashedRekordEd25519Signature(t *testing.T, body rekorSubmitRequest, artifact []byte) bool {
+	t.Helper()
+	if body.Spec.Data.Hash.Algorithm != rekorSHA512Algorithm {
+		t.Fatalf("test Rekor v1 Ed25519 helper supports %q, got %q", rekorSHA512Algorithm, body.Spec.Data.Hash.Algorithm)
+	}
+	sum := sha512.Sum512(artifact)
+	if body.Spec.Data.Hash.Value != hex.EncodeToString(sum[:]) {
+		return false
+	}
+	pub := decodeRekorEd25519PublicKeyForTest(t, body.Spec.Signature.PublicKey.Content)
+	sig, err := base64.StdEncoding.DecodeString(body.Spec.Signature.Content)
+	if err != nil {
+		t.Fatalf("DecodeString signature: %v", err)
+	}
+	return ed25519.VerifyWithOptions(pub, sum[:], sig, &ed25519.Options{Hash: crypto.SHA512}) == nil
+}
+
+func decodeRekorEd25519PublicKeyForTest(t *testing.T, encoded string) ed25519.PublicKey {
+	t.Helper()
+	pemBytes, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("DecodeString public key: %v", err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		t.Fatal("public key is not PEM PUBLIC KEY")
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("ParsePKIXPublicKey: %v", err)
+	}
+	pub, ok := parsed.(ed25519.PublicKey)
+	if !ok {
+		t.Fatalf("public key type = %T, want ed25519.PublicKey", parsed)
+	}
+	return pub
+}
+
+func rekorPublicKeyForTest(t *testing.T, pub ed25519.PublicKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	if len(pemBytes) == 0 {
+		t.Fatal("EncodeToMemory public key")
+	}
+	return base64.StdEncoding.EncodeToString(pemBytes)
 }
 
 func writeDirectRekorEntry(t *testing.T, w http.ResponseWriter, r *http.Request, logID, body string) {
@@ -1001,9 +1162,9 @@ func selfConsistentRekorProofWithAlgorithm(t *testing.T, checkpoint Checkpoint, 
 	if err != nil {
 		t.Fatalf("checkpointBytes: %v", err)
 	}
-	publicKey, signature, err := signRekorCheckpoint(checkpointBytes, entrySigner)
+	publicKey, signature, err := signRekorArtifact(checkpointBytes, algorithm, entrySigner)
 	if err != nil {
-		t.Fatalf("signRekorCheckpoint: %v", err)
+		t.Fatalf("signRekorArtifact: %v", err)
 	}
 	body := rekorSubmitRequest{
 		APIVersion: rekorHashedRekordAPIVersion,

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -75,7 +75,7 @@ verify Rekor bundles with pipelock-verifier independent --rekor-log-key.`,
 	cmd.Flags().StringVar(&opts.logID, "log-id", anchorpkg.DefaultLocalLogID, "local fake-log identifier")
 	cmd.Flags().StringVar(&opts.rekorURL, "rekor-url", "", "Rekor base URL (required for the rekor backend; no public default so receipt metadata stays in your trust boundary)")
 	cmd.Flags().StringVar(&opts.rekorKey, "rekor-key", "", "Ed25519 private key file used to sign the Rekor checkpoint entry")
-	cmd.Flags().StringVar(&opts.rekorHash, "rekor-hash-algorithm", anchorpkg.DefaultRekorHashAlgorithm, "hashedrekord data hash algorithm to submit (sha256 or sha512); match the target Rekor deployment's supported schema")
+	cmd.Flags().StringVar(&opts.rekorHash, "rekor-hash-algorithm", anchorpkg.DefaultRekorHashAlgorithm, "hashedrekord data hash algorithm to submit (sha512 for Ed25519 Rekor v1)")
 	cmd.Flags().BoolVar(&opts.rekorYes, "yes-send-to-remote-log", false, "acknowledge Rekor anchoring sends checkpoint material to the configured remote log")
 	cmd.Flags().StringVar(&opts.output, "out", "", "anchor bundle output path")
 	return cmd

--- a/internal/envelope/emitter.go
+++ b/internal/envelope/emitter.go
@@ -377,6 +377,9 @@ func bufferRequestBody(req *http.Request, maxBytes int) ([]byte, error) {
 	return data, nil
 }
 
+// defaultBufferRequestBodyMaxBytes is the defensive fallback cap when
+// bufferRequestBody is called without an explicit positive maxBytes.
+// Keep this in parity with config.DefaultEnvelopeSignMaxBodyBytes.
 const defaultBufferRequestBodyMaxBytes = 1 << 20
 
 // ErrRequestBodyReadLimitExceeded marks a fail-closed defensive body-buffer cap

--- a/internal/envelope/emitter.go
+++ b/internal/envelope/emitter.go
@@ -291,21 +291,30 @@ func requestHasBody(req *http.Request) bool {
 // GetBody is set to a closure that returns a fresh reader so the
 // stdlib redirect machinery can replay the body on 307/308.
 //
-// maxBytes == 0 means "no cap" - read until EOF. A positive maxBytes
-// reads one extra byte past the cap to detect overflow; on overflow
-// the function returns nil and no error, signaling "signable without
-// content-digest" to the caller. Crucially, the original request body
-// is preserved for the upstream transport - oversize requests lose
-// only Content-Digest coverage, not their payload.
+// maxBytes <= 0 falls back to defaultBufferRequestBodyMaxBytes. A positive
+// caller-provided maxBytes reads one extra byte past the cap to detect
+// overflow; on overflow the function returns nil and no error, signaling
+// "signable without content-digest" to the caller. Crucially, the original
+// request body is preserved for the upstream transport - oversize requests lose
+// only Content-Digest coverage, not their payload. A non-positive maxBytes is a
+// defensive fallback for direct callers and fails closed above the default cap.
 func bufferRequestBody(req *http.Request, maxBytes int) ([]byte, error) {
 	if req.Body == nil || req.Body == http.NoBody {
 		return nil, nil
+	}
+
+	failClosedOnOverflow := maxBytes <= 0
+	if maxBytes <= 0 {
+		maxBytes = defaultBufferRequestBodyMaxBytes
 	}
 
 	// Known oversize: skip buffering entirely and let the request
 	// flow with its original body. The signer will omit
 	// content-digest because it receives nil body bytes.
 	if maxBytes > 0 && req.ContentLength > int64(maxBytes) {
+		if failClosedOnOverflow {
+			return nil, fmt.Errorf("%w: request body exceeds %d bytes", ErrRequestBodyReadLimitExceeded, maxBytes)
+		}
 		return nil, nil
 	}
 
@@ -314,17 +323,8 @@ func bufferRequestBody(req *http.Request, maxBytes int) ([]byte, error) {
 	origContentLength := req.ContentLength
 
 	// Read maxBytes + 1 so we can distinguish "fits exactly" from
-	// "overflowed" without a second syscall. maxBytes == 0 uses the
-	// io.ReadAll path to mean "no limit".
-	var (
-		data []byte
-		err  error
-	)
-	if maxBytes > 0 {
-		data, err = io.ReadAll(io.LimitReader(origBody, int64(maxBytes)+1))
-	} else {
-		data, err = io.ReadAll(origBody)
-	}
+	// "overflowed" without a second syscall.
+	data, err := io.ReadAll(io.LimitReader(origBody, int64(maxBytes)+1))
 	if err != nil {
 		return nil, fmt.Errorf("reading request body: %w", err)
 	}
@@ -346,6 +346,9 @@ func bufferRequestBody(req *http.Request, maxBytes int) ([]byte, error) {
 	//     upstreams later. GPT-5.4 review on PR #403 flagged the
 	//     silent case as a correctness gap.
 	if maxBytes > 0 && len(data) > maxBytes {
+		if failClosedOnOverflow {
+			return nil, fmt.Errorf("%w: request body exceeds %d bytes", ErrRequestBodyReadLimitExceeded, maxBytes)
+		}
 		req.Body = &readPreservingCloser{
 			Reader: io.MultiReader(bytes.NewReader(data), origBody),
 			Closer: origBody,
@@ -373,6 +376,12 @@ func bufferRequestBody(req *http.Request, maxBytes int) ([]byte, error) {
 	}
 	return data, nil
 }
+
+const defaultBufferRequestBodyMaxBytes = 1 << 20
+
+// ErrRequestBodyReadLimitExceeded marks a fail-closed defensive body-buffer cap
+// hit when bufferRequestBody is called without an explicit positive cap.
+var ErrRequestBodyReadLimitExceeded = fmt.Errorf("envelope: request body read limit exceeded")
 
 // readPreservingCloser wraps a Reader and delegates Close to the
 // original request body so overflow preservation does not leak the

--- a/internal/envelope/emitter.go
+++ b/internal/envelope/emitter.go
@@ -346,9 +346,6 @@ func bufferRequestBody(req *http.Request, maxBytes int) ([]byte, error) {
 	//     upstreams later. GPT-5.4 review on PR #403 flagged the
 	//     silent case as a correctness gap.
 	if maxBytes > 0 && len(data) > maxBytes {
-		if failClosedOnOverflow {
-			return nil, fmt.Errorf("%w: request body exceeds %d bytes", ErrRequestBodyReadLimitExceeded, maxBytes)
-		}
 		req.Body = &readPreservingCloser{
 			Reader: io.MultiReader(bytes.NewReader(data), origBody),
 			Closer: origBody,
@@ -358,6 +355,9 @@ func bufferRequestBody(req *http.Request, maxBytes int) ([]byte, error) {
 			req.GetBody = origGetBody
 		} else {
 			req.GetBody = overCapGetBody
+		}
+		if failClosedOnOverflow {
+			return nil, fmt.Errorf("%w: request body exceeds %d bytes", ErrRequestBodyReadLimitExceeded, maxBytes)
 		}
 		return nil, nil
 	}

--- a/internal/envelope/emitter_test.go
+++ b/internal/envelope/emitter_test.go
@@ -659,12 +659,37 @@ func TestBufferRequestBodyZeroMaxFailsClosedAfterReadOverDefaultCap(t *testing.T
 	t.Parallel()
 
 	body := strings.Repeat("Z", defaultBufferRequestBodyMaxBytes+1)
-	req := newTestRequest(t, http.MethodPost, "https://upstream.example/api", strings.NewReader(body))
+	origBody := &trackingReadCloser{Reader: strings.NewReader(body)}
+	req := newTestRequest(t, http.MethodPost, "https://upstream.example/api", nil)
+	req.Body = origBody
 	req.ContentLength = -1
+	req.GetBody = nil
 
 	_, err := bufferRequestBody(req, 0)
 	if !errors.Is(err, ErrRequestBodyReadLimitExceeded) {
 		t.Fatalf("bufferRequestBody error = %v, want ErrRequestBodyReadLimitExceeded", err)
+	}
+	drained, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("reading preserved body after fail-closed overflow: %v", err)
+	}
+	if got := string(drained); got != body {
+		t.Fatalf("preserved body after fail-closed overflow = %q, want %q", got, body)
+	}
+	if req.ContentLength != -1 {
+		t.Fatalf("ContentLength after fail-closed overflow = %d, want -1", req.ContentLength)
+	}
+	if req.GetBody == nil {
+		t.Fatal("GetBody after fail-closed overflow = nil, want replay-error sentinel")
+	}
+	if _, err := req.GetBody(); !errors.Is(err, ErrOverCapRedirectReplay) {
+		t.Fatalf("GetBody after fail-closed overflow error = %v, want ErrOverCapRedirectReplay", err)
+	}
+	if err := req.Body.Close(); err != nil {
+		t.Fatalf("closing preserved fail-closed body: %v", err)
+	}
+	if !origBody.closed {
+		t.Fatal("closing preserved fail-closed body did not close original body")
 	}
 }
 

--- a/internal/envelope/emitter_test.go
+++ b/internal/envelope/emitter_test.go
@@ -655,6 +655,19 @@ func TestBufferRequestBodyZeroMaxFailsClosedOverDefaultCap(t *testing.T) {
 	}
 }
 
+func TestBufferRequestBodyZeroMaxFailsClosedAfterReadOverDefaultCap(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Repeat("Z", defaultBufferRequestBodyMaxBytes+1)
+	req := newTestRequest(t, http.MethodPost, "https://upstream.example/api", strings.NewReader(body))
+	req.ContentLength = -1
+
+	_, err := bufferRequestBody(req, 0)
+	if !errors.Is(err, ErrRequestBodyReadLimitExceeded) {
+		t.Fatalf("bufferRequestBody error = %v, want ErrRequestBodyReadLimitExceeded", err)
+	}
+}
+
 // assertOverCapSignatureVerifies reconstructs the RFC 9421 signature
 // base from the signed request (without content-digest, which is what
 // the over-cap path drops) and runs ed25519.Verify against the

--- a/internal/envelope/emitter_test.go
+++ b/internal/envelope/emitter_test.go
@@ -668,6 +668,22 @@ func TestBufferRequestBodyZeroMaxFailsClosedAfterReadOverDefaultCap(t *testing.T
 	}
 }
 
+func TestBufferRequestBodyZeroMaxAcceptsBodyExactlyAtDefaultCap(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Repeat("Z", defaultBufferRequestBodyMaxBytes)
+	req := newTestRequest(t, http.MethodPost, "https://upstream.example/api", strings.NewReader(body))
+	req.ContentLength = -1
+
+	got, err := bufferRequestBody(req, 0)
+	if err != nil {
+		t.Fatalf("bufferRequestBody at cap error = %v, want nil", err)
+	}
+	if len(got) != defaultBufferRequestBodyMaxBytes {
+		t.Fatalf("bufferRequestBody at cap returned %d bytes, want %d", len(got), defaultBufferRequestBodyMaxBytes)
+	}
+}
+
 // assertOverCapSignatureVerifies reconstructs the RFC 9421 signature
 // base from the signed request (without content-digest, which is what
 // the over-cap path drops) and runs ed25519.Verify against the

--- a/internal/envelope/emitter_test.go
+++ b/internal/envelope/emitter_test.go
@@ -643,6 +643,18 @@ func TestEmitter_InjectAndSign_OverCapUnknownLengthPreservesBody(t *testing.T) {
 	}
 }
 
+func TestBufferRequestBodyZeroMaxFailsClosedOverDefaultCap(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Repeat("Z", defaultBufferRequestBodyMaxBytes+1)
+	req := newTestRequest(t, http.MethodPost, "https://upstream.example/api", strings.NewReader(body))
+
+	_, err := bufferRequestBody(req, 0)
+	if !errors.Is(err, ErrRequestBodyReadLimitExceeded) {
+		t.Fatalf("bufferRequestBody error = %v, want ErrRequestBodyReadLimitExceeded", err)
+	}
+}
+
 // assertOverCapSignatureVerifies reconstructs the RFC 9421 signature
 // base from the signed request (without content-digest, which is what
 // the over-cap path drops) and runs ed25519.Verify against the

--- a/internal/envelope/signer.go
+++ b/internal/envelope/signer.go
@@ -119,15 +119,15 @@ type SignerConfig struct {
 	SignedComponents []string
 
 	// MaxBodyBytes caps the size of body the Signer is willing to
-	// buffer when it has to compute Content-Digest itself. Zero is
-	// treated by SignRequest as "do not cap" - SignRequest will
-	// accept any body the caller hands it. The proxy fills this from
+	// buffer when it has to compute Content-Digest itself. Zero falls
+	// back to the package's defensive default when InjectAndSign has
+	// to buffer req.Body itself. SignRequest still accepts any body
+	// bytes the caller explicitly hands it. The proxy fills this from
 	// MediationEnvelope.MaxBodyBytes. Note: the config validator at
 	// internal/config/config.go:validateMediationEnvelope replaces a
 	// zero field with the DefaultEnvelopeSignMaxBodyBytes constant
 	// (1 MiB) at load time, so in the CLI-facing path a zero value
-	// never reaches this field. Test callers that construct a Signer
-	// directly can still pass MaxBodyBytes=0 to opt out of the cap.
+	// never reaches this field.
 	MaxBodyBytes int
 
 	// Expires is the per-signature lifetime emitted as

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -867,7 +866,7 @@ func extractReceiptsFromEntries(entries []recorder.Entry) ([]Receipt, error) {
 }
 
 func extractRawReceiptsJSONLFile(path string) ([]Receipt, error) {
-	data, err := os.ReadFile(filepath.Clean(path))
+	data, err := recorder.ReadEvidenceFileBounded(filepath.Clean(path), recorder.MaxEvidenceReadFileBytes)
 	if err != nil {
 		return nil, fmt.Errorf("reading raw receipts: %w", err)
 	}

--- a/internal/receipt/chain_test.go
+++ b/internal/receipt/chain_test.go
@@ -760,6 +760,31 @@ func TestExtractReceipts_RawJSONLRejectsMissingFieldsTail(t *testing.T) {
 	}
 }
 
+func TestExtractReceipts_RawJSONLRejectsOverCapFile(t *testing.T) {
+	t.Parallel()
+
+	_, priv := generateTestKey(t)
+	r := signChainReceipt(t, priv, 0, GenesisHash, time.Now().UTC())
+	paddingLen := int(recorder.MaxEvidenceReadFileBytes) + 1
+	r.Ext = json.RawMessage(`{"pad":"` + strings.Repeat("x", paddingLen) + `"}`)
+	data, err := Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(data) <= int(recorder.MaxEvidenceReadFileBytes) {
+		t.Fatalf("test receipt is %d bytes, want over cap %d", len(data), recorder.MaxEvidenceReadFileBytes)
+	}
+	path := filepath.Join(t.TempDir(), "raw-over-cap.jsonl")
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err = ExtractReceipts(path)
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("ExtractReceipts error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+}
+
 func TestExtractReceipts_RawJSONLIgnoresNonReceiptFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/recorder/durable_test.go
+++ b/internal/recorder/durable_test.go
@@ -5,6 +5,7 @@ package recorder
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -405,18 +406,23 @@ func (shortWriteSink) Write(p []byte) (int, error) {
 	return len(p) - 1, nil
 }
 
-func TestWriteEntry_ReturnsShortWrite(t *testing.T) {
+func TestWriteEntryData_ReturnsShortWrite(t *testing.T) {
 	rec := &Recorder{writer: bufio.NewWriterSize(shortWriteSink{}, 1)}
-	err := rec.writeEntry(Entry{
+	entry := Entry{
 		Version:   EntryVersion,
 		Sequence:  0,
 		SessionID: "durable-session",
 		Type:      "request",
 		Summary:   "short write",
 		PrevHash:  GenesisHash,
-	}, false)
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	err = rec.writeEntryData(data, entry, false)
 	if !errors.Is(err, io.ErrShortWrite) {
-		t.Fatalf("writeEntry error = %v, want io.ErrShortWrite", err)
+		t.Fatalf("writeEntryData error = %v, want io.ErrShortWrite", err)
 	}
 }
 

--- a/internal/recorder/evidence_read.go
+++ b/internal/recorder/evidence_read.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package recorder
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// MaxEvidenceReadFileBytes matches the bounded dashboard evidence
+	// verification ceiling: one evidence source may contribute at most 8 MiB
+	// to in-memory verifier/resume reads.
+	MaxEvidenceReadFileBytes int64 = 8 << 20
+
+	// MaxEvidenceReadDirectoryEntries matches the bounded dashboard evidence
+	// directory ceiling.
+	MaxEvidenceReadDirectoryEntries = 256
+
+	// MaxEvidenceReadEntries matches the recorder's default shard size. A
+	// healthy default shard can be resumed, while appended over-cap records fail
+	// closed instead of being silently ignored.
+	MaxEvidenceReadEntries = defaultMaxEntriesPerFile
+)
+
+// ErrEvidenceReadLimitExceeded marks a fail-closed evidence read cap hit.
+var ErrEvidenceReadLimitExceeded = errors.New("evidence read limit exceeded")
+
+func openRegularEvidenceFile(path, label string) (*os.File, os.FileInfo, error) {
+	cleanPath := filepath.Clean(path)
+	before, err := os.Lstat(cleanPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("%s is symlinked or non-regular", label)
+	}
+	file, err := os.OpenFile(cleanPath, os.O_RDONLY|evidenceReadNoFollowFlag|evidenceReadNonblockFlag, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	if !info.Mode().IsRegular() || !os.SameFile(before, info) {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("%s changed or is non-regular", label)
+	}
+	return file, info, nil
+}
+
+// ReadEvidenceFileBounded reads a regular evidence file through a no-follow
+// open and returns an error if the file exceeds maxBytes.
+func ReadEvidenceFileBounded(path string, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		maxBytes = MaxEvidenceReadFileBytes
+	}
+	file, info, err := openRegularEvidenceFile(path, "evidence file")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Size() > maxBytes {
+		return nil, fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(path), maxBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(path), maxBytes)
+	}
+	after, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if after.Size() != info.Size() || after.ModTime() != info.ModTime() {
+		return nil, errors.New("evidence file changed during read")
+	}
+	return data, nil
+}
+
+func computeEvidenceFileHashBounded(path string, maxBytes int64) (string, error) {
+	if maxBytes <= 0 {
+		maxBytes = MaxEvidenceReadFileBytes
+	}
+	file, info, err := openRegularEvidenceFile(path, "evidence file")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Size() > maxBytes {
+		return "", fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(path), maxBytes)
+	}
+	h := sha256.New()
+	written, err := io.Copy(h, io.LimitReader(file, maxBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if written > maxBytes {
+		return "", fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(path), maxBytes)
+	}
+	after, err := file.Stat()
+	if err != nil {
+		return "", err
+	}
+	if after.Size() != info.Size() || after.ModTime() != info.ModTime() {
+		return "", errors.New("evidence file changed during read")
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/recorder/evidence_read.go
+++ b/internal/recorder/evidence_read.go
@@ -4,6 +4,7 @@
 package recorder
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -57,63 +58,55 @@ func openRegularEvidenceFile(path, label string) (*os.File, os.FileInfo, error) 
 	return file, info, nil
 }
 
+// readBoundedEvidence opens path as a regular no-follow file and copies at
+// most maxBytes into sink. It is the single fail-closed read path shared by
+// ReadEvidenceFileBounded and computeEvidenceFileHashBounded: it rejects the
+// read if the file exceeds maxBytes (both by pre-read size and by actual bytes
+// copied) or if the file changes during the read. A non-positive maxBytes
+// falls back to MaxEvidenceReadFileBytes.
+func readBoundedEvidence(path string, maxBytes int64, sink io.Writer) error {
+	if maxBytes <= 0 {
+		maxBytes = MaxEvidenceReadFileBytes
+	}
+	file, info, err := openRegularEvidenceFile(path, "evidence file")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Size() > maxBytes {
+		return fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(path), maxBytes)
+	}
+	written, err := io.Copy(sink, io.LimitReader(file, maxBytes+1))
+	if err != nil {
+		return err
+	}
+	if written > maxBytes {
+		return fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(path), maxBytes)
+	}
+	after, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if after.Size() != info.Size() || after.ModTime() != info.ModTime() {
+		return errors.New("evidence file changed during read")
+	}
+	return nil
+}
+
 // ReadEvidenceFileBounded reads a regular evidence file through a no-follow
 // open and returns an error if the file exceeds maxBytes.
 func ReadEvidenceFileBounded(path string, maxBytes int64) ([]byte, error) {
-	if maxBytes <= 0 {
-		maxBytes = MaxEvidenceReadFileBytes
-	}
-	file, info, err := openRegularEvidenceFile(path, "evidence file")
-	if err != nil {
+	var buf bytes.Buffer
+	if err := readBoundedEvidence(path, maxBytes, &buf); err != nil {
 		return nil, err
 	}
-	defer func() { _ = file.Close() }()
-	if info.Size() > maxBytes {
-		return nil, fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(path), maxBytes)
-	}
-	data, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
-	if err != nil {
-		return nil, err
-	}
-	if int64(len(data)) > maxBytes {
-		return nil, fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(path), maxBytes)
-	}
-	after, err := file.Stat()
-	if err != nil {
-		return nil, err
-	}
-	if after.Size() != info.Size() || after.ModTime() != info.ModTime() {
-		return nil, errors.New("evidence file changed during read")
-	}
-	return data, nil
+	return buf.Bytes(), nil
 }
 
 func computeEvidenceFileHashBounded(path string, maxBytes int64) (string, error) {
-	if maxBytes <= 0 {
-		maxBytes = MaxEvidenceReadFileBytes
-	}
-	file, info, err := openRegularEvidenceFile(path, "evidence file")
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = file.Close() }()
-	if info.Size() > maxBytes {
-		return "", fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(path), maxBytes)
-	}
 	h := sha256.New()
-	written, err := io.Copy(h, io.LimitReader(file, maxBytes+1))
-	if err != nil {
+	if err := readBoundedEvidence(path, maxBytes, h); err != nil {
 		return "", err
-	}
-	if written > maxBytes {
-		return "", fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(path), maxBytes)
-	}
-	after, err := file.Stat()
-	if err != nil {
-		return "", err
-	}
-	if after.Size() != info.Size() || after.ModTime() != info.ModTime() {
-		return "", errors.New("evidence file changed during read")
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/recorder/evidence_read_bounds_test.go
+++ b/internal/recorder/evidence_read_bounds_test.go
@@ -61,6 +61,34 @@ func TestReadEvidenceFileBounded_NonPositiveMaxUsesDefault(t *testing.T) {
 	}
 }
 
+func TestReadEvidenceFileBounded_ExactCapSucceeds(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence.jsonl")
+	content := []byte(strings.Repeat("A", 16))
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := ReadEvidenceFileBounded(path, int64(len(content)))
+	if err != nil {
+		t.Fatalf("ReadEvidenceFileBounded at cap: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("content = %q, want %q", got, content)
+	}
+
+	hash, err := computeEvidenceFileHashBounded(path, int64(len(content)))
+	if err != nil {
+		t.Fatalf("computeEvidenceFileHashBounded at cap: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	if want := hex.EncodeToString(sum[:]); hash != want {
+		t.Fatalf("hash = %s, want %s", hash, want)
+	}
+}
+
 func TestReadEvidenceFileBounded_OverCapFailsClosed(t *testing.T) {
 	t.Parallel()
 

--- a/internal/recorder/evidence_read_bounds_test.go
+++ b/internal/recorder/evidence_read_bounds_test.go
@@ -120,3 +120,26 @@ func TestReadEvidenceFileBounded_MissingFile(t *testing.T) {
 		t.Fatal("computeEvidenceFileHashBounded on missing file = nil error, want error")
 	}
 }
+
+func TestReadEvidenceFileBounded_UnreadableFileRejected(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read chmod 000 files")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence.jsonl")
+	if err := os.WriteFile(path, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(path, 0); err != nil {
+		t.Fatalf("chmod unreadable: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	if _, err := ReadEvidenceFileBounded(path, MaxEvidenceReadFileBytes); err == nil {
+		t.Fatal("ReadEvidenceFileBounded on unreadable file = nil error, want error")
+	}
+	if _, err := computeEvidenceFileHashBounded(path, MaxEvidenceReadFileBytes); err == nil {
+		t.Fatal("computeEvidenceFileHashBounded on unreadable file = nil error, want error")
+	}
+}

--- a/internal/recorder/evidence_read_bounds_test.go
+++ b/internal/recorder/evidence_read_bounds_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package recorder
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadEvidenceFileBounded_HappyPathAndHash(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence.jsonl")
+	content := []byte("bounded evidence body\n")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := ReadEvidenceFileBounded(path, MaxEvidenceReadFileBytes)
+	if err != nil {
+		t.Fatalf("ReadEvidenceFileBounded: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("content = %q, want %q", got, content)
+	}
+
+	hash, err := computeEvidenceFileHashBounded(path, MaxEvidenceReadFileBytes)
+	if err != nil {
+		t.Fatalf("computeEvidenceFileHashBounded: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	if want := hex.EncodeToString(sum[:]); hash != want {
+		t.Fatalf("hash = %s, want %s", hash, want)
+	}
+}
+
+func TestReadEvidenceFileBounded_NonPositiveMaxUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence.jsonl")
+	if err := os.WriteFile(path, []byte("small"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	for _, max := range []int64{0, -1} {
+		got, err := ReadEvidenceFileBounded(path, max)
+		if err != nil {
+			t.Fatalf("ReadEvidenceFileBounded(max=%d): %v", max, err)
+		}
+		if string(got) != "small" {
+			t.Fatalf("max=%d content = %q, want %q", max, got, "small")
+		}
+	}
+}
+
+func TestReadEvidenceFileBounded_OverCapFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Repeat("A", 64)), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := ReadEvidenceFileBounded(path, 16); !errors.Is(err, ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("ReadEvidenceFileBounded over cap err = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+	if _, err := computeEvidenceFileHashBounded(path, 16); !errors.Is(err, ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("computeEvidenceFileHashBounded over cap err = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+}
+
+func TestReadEvidenceFileBounded_SymlinkRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	if _, err := ReadEvidenceFileBounded(link, MaxEvidenceReadFileBytes); err == nil {
+		t.Fatal("ReadEvidenceFileBounded on symlink = nil error, want rejection")
+	}
+	if _, err := computeEvidenceFileHashBounded(link, MaxEvidenceReadFileBytes); err == nil {
+		t.Fatal("computeEvidenceFileHashBounded on symlink = nil error, want rejection")
+	}
+}
+
+func TestReadEvidenceFileBounded_NonRegularRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// A directory is non-regular.
+	if _, err := ReadEvidenceFileBounded(dir, MaxEvidenceReadFileBytes); err == nil {
+		t.Fatal("ReadEvidenceFileBounded on directory = nil error, want rejection")
+	}
+}
+
+func TestReadEvidenceFileBounded_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := ReadEvidenceFileBounded(missing, MaxEvidenceReadFileBytes); err == nil {
+		t.Fatal("ReadEvidenceFileBounded on missing file = nil error, want error")
+	}
+	if _, err := computeEvidenceFileHashBounded(missing, MaxEvidenceReadFileBytes); err == nil {
+		t.Fatal("computeEvidenceFileHashBounded on missing file = nil error, want error")
+	}
+}

--- a/internal/recorder/evidence_read_unix.go
+++ b/internal/recorder/evidence_read_unix.go
@@ -1,0 +1,13 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package recorder
+
+import "syscall"
+
+const (
+	evidenceReadNoFollowFlag = syscall.O_NOFOLLOW
+	evidenceReadNonblockFlag = syscall.O_NONBLOCK
+)

--- a/internal/recorder/evidence_read_windows.go
+++ b/internal/recorder/evidence_read_windows.go
@@ -1,0 +1,11 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package recorder
+
+const (
+	evidenceReadNoFollowFlag = 0
+	evidenceReadNonblockFlag = 0
+)

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -499,11 +499,7 @@ func (r *Recorder) prepareAndWriteEntryLocked(e Entry, notify bool) (Entry, erro
 
 	e.Hash = ComputeHash(e)
 
-	if err := r.ensureFile(e.SessionID, e.Sequence); err != nil {
-		return Entry{}, fmt.Errorf("opening evidence file: %w", err)
-	}
-
-	if err := r.writeEntry(e, notify); err != nil {
+	if err := r.writeEntryBounded(e, notify); err != nil {
 		return Entry{}, fmt.Errorf("writing entry: %w", err)
 	}
 	return e, nil
@@ -677,7 +673,7 @@ func (r *Recorder) checkpointLocked() error {
 	e.Hash = ComputeHash(e)
 
 	if r.file != nil {
-		if err := r.writeEntry(e, true); err != nil {
+		if err := r.writeEntryBounded(e, true); err != nil {
 			return err
 		}
 		r.fileEntryCount++
@@ -891,20 +887,33 @@ func (r *Recorder) resumeSessionLocked(sessionID string) error {
 
 func (r *Recorder) sessionFiles(sessionID string) ([]string, error) {
 	dir := filepath.Clean(r.cfg.Dir)
-	dirEntries, err := readDirectoryEntries(dir, MaxEvidenceReadDirectoryEntries)
+	directory, err := os.Open(dir)
 	if err != nil {
 		return nil, fmt.Errorf("reading evidence directory: %w", err)
 	}
+	defer func() { _ = directory.Close() }()
 
 	prefix := "evidence-" + filepath.Base(sessionID) + "-"
 	files := make([]string, 0)
-	for _, de := range dirEntries {
-		if de.IsDir() {
-			continue
+	for {
+		dirEntries, readErr := directory.ReadDir(128)
+		for _, de := range dirEntries {
+			if de.IsDir() {
+				continue
+			}
+			name := de.Name()
+			if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, ".jsonl") {
+				files = append(files, filepath.Join(dir, name))
+				if len(files) > MaxEvidenceReadDirectoryEntries {
+					return nil, fmt.Errorf("%w: evidence session %s exceeds %d matching files", ErrEvidenceReadLimitExceeded, sessionID, MaxEvidenceReadDirectoryEntries)
+				}
+			}
 		}
-		name := de.Name()
-		if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, ".jsonl") {
-			files = append(files, filepath.Join(dir, name))
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return nil, fmt.Errorf("reading evidence directory: %w", readErr)
 		}
 	}
 
@@ -998,12 +1007,22 @@ func (r *Recorder) ensureFile(sessionID string, seqStart uint64) error {
 	return nil
 }
 
-// writeEntry serializes and writes a single entry as a JSONL line.
-func (r *Recorder) writeEntry(e Entry, notify bool) error {
+// writeEntryBounded serializes and writes a single entry as a JSONL line,
+// rotating or rejecting before Pipelock can create a shard its bounded readers
+// refuse to resume, hash, or verify.
+func (r *Recorder) writeEntryBounded(e Entry, notify bool) error {
 	data, err := json.Marshal(e)
 	if err != nil {
 		return fmt.Errorf("marshaling entry: %w", err)
 	}
+	lineBytes := int64(len(data) + 1)
+	if err := r.ensureEntryCapacityLocked(e.SessionID, e.Sequence, lineBytes); err != nil {
+		return err
+	}
+	return r.writeEntryData(data, e, notify)
+}
+
+func (r *Recorder) writeEntryData(data []byte, e Entry, notify bool) error {
 	if n, err := r.writer.Write(data); err != nil {
 		return err
 	} else if n != len(data) {
@@ -1019,6 +1038,38 @@ func (r *Recorder) writeEntry(e Entry, notify bool) error {
 	}
 	if notify {
 		r.notifyObserver(e)
+	}
+	return nil
+}
+
+func (r *Recorder) ensureEntryCapacityLocked(sessionID string, seq uint64, lineBytes int64) error {
+	if lineBytes > MaxEvidenceReadFileBytes {
+		return fmt.Errorf("%w: serialized evidence entry exceeds %d bytes", ErrEvidenceReadLimitExceeded, MaxEvidenceReadFileBytes)
+	}
+	if r.file == nil {
+		if err := r.ensureFile(sessionID, seq); err != nil {
+			return fmt.Errorf("opening evidence file: %w", err)
+		}
+	}
+	info, err := r.file.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Size()+lineBytes <= MaxEvidenceReadFileBytes {
+		return nil
+	}
+	if err := r.rotateFile(); err != nil {
+		return err
+	}
+	if err := r.ensureFile(sessionID, seq); err != nil {
+		return fmt.Errorf("opening evidence file: %w", err)
+	}
+	info, err = r.file.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Size()+lineBytes > MaxEvidenceReadFileBytes {
+		return fmt.Errorf("%w: evidence file %s would exceed %d bytes", ErrEvidenceReadLimitExceeded, filepath.Base(r.file.Name()), MaxEvidenceReadFileBytes)
 	}
 	return nil
 }

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -5,10 +5,10 @@ package recorder
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -852,7 +852,7 @@ func (r *Recorder) resumeSessionLocked(sessionID string) error {
 		return err
 	}
 	for i := len(files) - 1; i >= 0; i-- {
-		entries, readErr := ReadEntries(files[i])
+		entries, readErr := readEntriesForResume(files[i])
 		if readErr != nil {
 			return fmt.Errorf("reading existing evidence file %s: %w", filepath.Base(files[i]), readErr)
 		}
@@ -891,7 +891,7 @@ func (r *Recorder) resumeSessionLocked(sessionID string) error {
 
 func (r *Recorder) sessionFiles(sessionID string) ([]string, error) {
 	dir := filepath.Clean(r.cfg.Dir)
-	dirEntries, err := os.ReadDir(dir)
+	dirEntries, err := readDirectoryEntries(dir, MaxEvidenceReadDirectoryEntries)
 	if err != nil {
 		return nil, fmt.Errorf("reading evidence directory: %w", err)
 	}
@@ -912,6 +912,21 @@ func (r *Recorder) sessionFiles(sessionID string) ([]string, error) {
 		return extractSeqStart(files[i]) < extractSeqStart(files[j])
 	})
 	return files, nil
+}
+
+func readEntriesForResume(path string) ([]Entry, error) {
+	data, err := ReadEvidenceFileBounded(path, MaxEvidenceReadFileBytes)
+	if err != nil {
+		return nil, err
+	}
+	entries, truncated, err := readEntriesFromReader(bytes.NewReader(data), MaxEvidenceReadEntries)
+	if err != nil {
+		return nil, err
+	}
+	if truncated {
+		return nil, fmt.Errorf("%w: evidence file %s exceeds %d entries", ErrEvidenceReadLimitExceeded, filepath.Base(path), MaxEvidenceReadEntries)
+	}
+	return entries, nil
 }
 
 // ensureFile opens a JSONL file if none is open.
@@ -1118,17 +1133,11 @@ func isEvidenceFile(name string) bool {
 
 // ComputeFileHash computes SHA-256 of an evidence file for external verification.
 func ComputeFileHash(path string) (string, error) {
-	f, err := os.Open(filepath.Clean(path))
+	hash, err := computeEvidenceFileHashBounded(path, MaxEvidenceReadFileBytes)
 	if err != nil {
-		return "", fmt.Errorf("opening file: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
 		return "", fmt.Errorf("hashing file: %w", err)
 	}
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return hash, nil
 }
 
 // maxCheckpointBound caps the checkpoint interval to a value that fits safely

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -913,7 +913,7 @@ func TestRecorder_NilDetail(t *testing.T) {
 	}
 }
 
-func TestRecorder_ResumeRejectsOverCapDirectoryEntries(t *testing.T) {
+func TestRecorder_ResumeIgnoresUnrelatedDirectoryNoise(t *testing.T) {
 	dir := t.TempDir()
 	for i := 0; i <= recorder.MaxEvidenceReadDirectoryEntries; i++ {
 		path := filepath.Join(dir, fmt.Sprintf("noise-%03d.txt", i))
@@ -939,8 +939,39 @@ func TestRecorder_ResumeRejectsOverCapDirectoryEntries(t *testing.T) {
 		Summary:   "must fail closed before unbounded directory scan",
 		Detail:    map[string]string{"safe": "value"},
 	})
-	if err == nil || !strings.Contains(err.Error(), "directory entry count exceeds") {
-		t.Fatalf("Record error = %v, want directory entry cap", err)
+	if err != nil {
+		t.Fatalf("Record with unrelated directory noise: %v", err)
+	}
+}
+
+func TestRecorder_ResumeRejectsOverCapMatchingSessionFiles(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i <= recorder.MaxEvidenceReadDirectoryEntries; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("evidence-matching-cap-%03d.jsonl", i))
+		if err := os.WriteFile(path, []byte(""), filePermissions); err != nil {
+			t.Fatalf("WriteFile(%q): %v", path, err)
+		}
+	}
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 100,
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+
+	err = rec.Record(recorder.Entry{
+		SessionID: "matching-cap",
+		Type:      testType,
+		Transport: testTransport,
+		Summary:   "must cap matching evidence shards only",
+		Detail:    map[string]string{"safe": "value"},
+	})
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("Record error = %v, want ErrEvidenceReadLimitExceeded", err)
 	}
 }
 
@@ -1041,6 +1072,88 @@ func TestComputeFileHash_RejectsOverCapFile(t *testing.T) {
 	_, err := recorder.ComputeFileHash(path)
 	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
 		t.Fatalf("ComputeFileHash error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+}
+
+func TestRecorder_RecordRejectsSingleEntryOverReadCap(t *testing.T) {
+	dir := t.TempDir()
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+
+	err = rec.Record(recorder.Entry{
+		SessionID: "oversized-entry",
+		Type:      testType,
+		Transport: testTransport,
+		Summary:   strings.Repeat("x", int(recorder.MaxEvidenceReadFileBytes)+1),
+		Detail:    map[string]string{"safe": "value"},
+	})
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("Record oversized entry error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+
+	if err := rec.Record(recorder.Entry{
+		SessionID: "oversized-entry",
+		Type:      testType,
+		Transport: testTransport,
+		Summary:   "small entry after rejected oversized entry",
+		Detail:    map[string]string{"safe": "value"},
+	}); err != nil {
+		t.Fatalf("Record after rejected oversized entry: %v", err)
+	}
+}
+
+func TestRecorder_RecordRotatesBeforeEvidenceReadCap(t *testing.T) {
+	dir := t.TempDir()
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+		MaxEntriesPerFile:  100,
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	for i := range 2 {
+		if err := rec.Record(recorder.Entry{
+			SessionID: "byte-rotation",
+			Type:      testType,
+			Transport: testTransport,
+			Summary:   strings.Repeat("x", 5<<20),
+			Detail:    map[string]string{"idx": fmt.Sprintf("%d", i)},
+		}); err != nil {
+			t.Fatalf("Record(%d): %v", i, err)
+		}
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	files, err := filepath.Glob(filepath.Join(dir, "evidence-byte-rotation-*.jsonl"))
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("evidence file count = %d, want 2", len(files))
+	}
+	for _, path := range files {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat(%q): %v", path, err)
+		}
+		if info.Size() > recorder.MaxEvidenceReadFileBytes {
+			t.Fatalf("%s size = %d, want <= %d", filepath.Base(path), info.Size(), recorder.MaxEvidenceReadFileBytes)
+		}
+		if _, err := recorder.ComputeFileHash(path); err != nil {
+			t.Fatalf("ComputeFileHash(%q): %v", path, err)
+		}
 	}
 }
 

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -912,6 +913,97 @@ func TestRecorder_NilDetail(t *testing.T) {
 	}
 }
 
+func TestRecorder_ResumeRejectsOverCapDirectoryEntries(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i <= recorder.MaxEvidenceReadDirectoryEntries; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("noise-%03d.txt", i))
+		if err := os.WriteFile(path, []byte("x"), filePermissions); err != nil {
+			t.Fatalf("WriteFile(%q): %v", path, err)
+		}
+	}
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 100,
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+
+	err = rec.Record(recorder.Entry{
+		SessionID: "resume-dir-cap",
+		Type:      testType,
+		Transport: testTransport,
+		Summary:   "must fail closed before unbounded directory scan",
+		Detail:    map[string]string{"safe": "value"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "directory entry count exceeds") {
+		t.Fatalf("Record error = %v, want directory entry cap", err)
+	}
+}
+
+func TestRecorder_ResumeRejectsOverCapTailRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence-resume-tail-cap-0.jsonl")
+	file, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePermissions)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	var written int64
+	for seq := uint64(0); written <= recorder.MaxEvidenceReadFileBytes; seq++ {
+		entry := recorder.Entry{
+			Version:   recorder.EntryVersion,
+			Sequence:  seq,
+			Timestamp: time.Unix(1712345678, 0).UTC(),
+			SessionID: "resume-tail-cap",
+			Type:      testType,
+			Transport: testTransport,
+			Summary:   strings.Repeat("x", 512<<10),
+			Detail:    map[string]string{"safe": "value"},
+			PrevHash:  recorder.GenesisHash,
+			Hash:      "non-empty-tail-hash",
+		}
+		line, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("Marshal entry: %v", err)
+		}
+		line = append(line, '\n')
+		n, err := file.Write(line)
+		if err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		written += int64(n)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 100,
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+
+	err = rec.Record(recorder.Entry{
+		SessionID: "resume-tail-cap",
+		Type:      testType,
+		Transport: testTransport,
+		Summary:   "must fail closed before unbounded tail read",
+		Detail:    map[string]string{"safe": "value"},
+	})
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("Record error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+}
+
 func TestComputeFileHash(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.jsonl")
@@ -935,6 +1027,20 @@ func TestComputeFileHash(t *testing.T) {
 	}
 	if hash != hash2 {
 		t.Error("same file should produce same hash")
+	}
+}
+
+func TestComputeFileHash_RejectsOverCapFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oversized.jsonl")
+	content := strings.Repeat("x", int(recorder.MaxEvidenceReadFileBytes)+1)
+	if err := os.WriteFile(path, []byte(content), filePermissions); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := recorder.ComputeFileHash(path)
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("ComputeFileHash error = %v, want ErrEvidenceReadLimitExceeded", err)
 	}
 }
 

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -1044,6 +1044,48 @@ func TestComputeFileHash_RejectsOverCapFile(t *testing.T) {
 	}
 }
 
+func TestReadEvidenceFileBounded_RejectsOverCapFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oversized.jsonl")
+	if err := os.WriteFile(path, []byte("over-cap"), filePermissions); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := recorder.ReadEvidenceFileBounded(path, 4)
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("ReadEvidenceFileBounded error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+}
+
+func TestReadEvidenceFileBounded_DefaultLimitReadsSmallFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence.jsonl")
+	content := []byte("small evidence\n")
+	if err := os.WriteFile(path, content, filePermissions); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := recorder.ReadEvidenceFileBounded(path, 0)
+	if err != nil {
+		t.Fatalf("ReadEvidenceFileBounded: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("ReadEvidenceFileBounded = %q, want %q", got, content)
+	}
+}
+
+func TestReadEvidenceFileBounded_RejectsNonRegularPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "not-regular")
+	if err := os.Mkdir(path, 0o750); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	if _, err := recorder.ReadEvidenceFileBounded(path, 4); err == nil || !strings.Contains(err.Error(), "non-regular") {
+		t.Fatalf("ReadEvidenceFileBounded error = %v, want non-regular error", err)
+	}
+}
+
 func TestComputeFileHash_NotFound(t *testing.T) {
 	_, err := recorder.ComputeFileHash("/nonexistent/file")
 	if err == nil {


### PR DESCRIPTION
## Summary

This bundles two evidence/anchor hardening fixes.

Bound the remaining unbounded evidence and receipt read paths (recorder resume enumeration and tail read, `ComputeFileHash`, the envelope emitter zero-max read, and the raw receipt-chain fallback) with a fail-closed size and entry-count cap that returns an error above the cap instead of reading unbounded input. This closes the sibling reads left out of the earlier bounded-read pass.

Fix Rekor hashedrekord submission and verification for Ed25519. Submissions previously placed a checkpoint signature into `spec.signature.content`, but a Rekor v1 log verifies Ed25519ph over the SHA-512 artifact digest in `spec.data.hash`, so a stock Rekor rejected every submission with `ed25519: invalid signature`. The submit and independent-verify paths now use the artifact digest, and SHA-256 Ed25519 fails closed.

## Live verification

The Rekor fix was exercised end to end against a live Rekor v1 log: a real receipt chain submitted successfully and returned an inclusion proof, the offline independent verifier accepted the resulting bundle, and a tampered bundle was rejected. Each read bound is covered by a negative test where an over-cap input fails closed, and the Rekor change adds tampered-signature, wrong-key, and unsupported-algorithm negatives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rekor hashed record submissions now use algorithm-aware digest/signing, defaulting to SHA-512 for Ed25519 Rekor v1.

- **Bug Fixes**
  - Stricter Rekor verification: signatures/digests are validated against the Rekor request contents, rejecting legacy SHA-256 hashedrekord bodies and unsupported/malformed inputs.
  - Request-body buffering is more secure: when limits are exceeded (including `max=0`), it fails closed with an explicit “read limit exceeded” error.
  - Evidence file reading and hashing are now bounded and fail closed; oversized/unreadable/non-regular inputs are rejected, and receipt extraction/resumption follows the same limits.

- **Documentation**
  - Clarified CLI help for `--rekor-hash-algorithm` (Ed25519 Rekor v1 → `sha512`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->