### PR TITLE
feat(dashboard): land on Overview at root; restyle the free evidence console

### DIFF
--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -139,7 +139,7 @@ type navRouteSpec struct {
 
 var dashboardNavRouteSpecs = []navRouteSpec{
 	{key: "overview", label: "Overview", pattern: "/overview"},
-	{key: "evidence", label: "Evidence", pattern: "/"},
+	{key: "evidence", label: "Evidence", pattern: "/evidence"},
 	{key: "exemptions", label: "Exemptions", pattern: "/exemptions"},
 	{key: "agents", label: "Agents", pattern: "/agents"},
 	{key: "budgets", label: "Budgets", pattern: "/budgets"},
@@ -162,6 +162,15 @@ var (
 		},
 		{
 			pattern:          "/",
+			feature:          license.FeatureAgents,
+			forbiddenMessage: agentsFeatureForbidden,
+			permission:       PermissionEvidenceRead,
+			handler: func(d *dashboardHandler) http.Handler {
+				return http.HandlerFunc(d.handleOverview)
+			},
+		},
+		{
+			pattern:          "/evidence",
 			feature:          license.FeatureAgents,
 			forbiddenMessage: agentsFeatureForbidden,
 			permission:       PermissionEvidenceRead,
@@ -731,9 +740,9 @@ func (d *dashboardHandler) navContext(r *http.Request, cache *routeAuthorization
 
 func activeNavKey(path string) string {
 	switch {
-	case path == "/overview":
+	case path == "/", path == "/overview":
 		return "overview"
-	case path == "/", strings.HasPrefix(path, "/session/"):
+	case path == "/evidence", strings.HasPrefix(path, "/session/"):
 		return "evidence"
 	case path == "/exemptions":
 		return "exemptions"
@@ -773,7 +782,7 @@ func knownPermission(permission Permission) bool {
 }
 
 func (d *dashboardHandler) handleOverview(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/overview" {
+	if r.URL.Path != "/" && r.URL.Path != "/overview" {
 		http.NotFound(w, r)
 		return
 	}
@@ -803,7 +812,7 @@ func (d *dashboardHandler) handleOverview(w http.ResponseWriter, r *http.Request
 }
 
 func (d *dashboardHandler) handleIndex(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/" {
+	if r.URL.Path != "/evidence" {
 		http.NotFound(w, r)
 		return
 	}

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -151,33 +151,15 @@ var dashboardNavRouteSpecs = []navRouteSpec{
 
 var (
 	dashboardRouteSpecList = []routeSpec{
-		{
-			pattern:          "/overview",
-			feature:          license.FeatureAgents,
-			forbiddenMessage: agentsFeatureForbidden,
-			permission:       PermissionEvidenceRead,
-			handler: func(d *dashboardHandler) http.Handler {
-				return http.HandlerFunc(d.handleOverview)
-			},
-		},
-		{
-			pattern:          "/",
-			feature:          license.FeatureAgents,
-			forbiddenMessage: agentsFeatureForbidden,
-			permission:       PermissionEvidenceRead,
-			handler: func(d *dashboardHandler) http.Handler {
-				return http.HandlerFunc(d.handleOverview)
-			},
-		},
-		{
-			pattern:          "/evidence",
-			feature:          license.FeatureAgents,
-			forbiddenMessage: agentsFeatureForbidden,
-			permission:       PermissionEvidenceRead,
-			handler: func(d *dashboardHandler) http.Handler {
-				return http.HandlerFunc(d.handleIndex)
-			},
-		},
+		evidenceRouteSpec("/overview", func(d *dashboardHandler) http.Handler {
+			return http.HandlerFunc(d.handleOverview)
+		}),
+		evidenceRouteSpec("/", func(d *dashboardHandler) http.Handler {
+			return http.HandlerFunc(d.handleOverview)
+		}),
+		evidenceRouteSpec("/evidence", func(d *dashboardHandler) http.Handler {
+			return http.HandlerFunc(d.handleIndex)
+		}),
 		{
 			pattern:          "/exemptions",
 			feature:          license.FeatureAgents,
@@ -289,6 +271,16 @@ var (
 	}
 	dashboardRouteSpecsByPattern = routeSpecsByPattern(dashboardRouteSpecList)
 )
+
+func evidenceRouteSpec(pattern string, handler func(*dashboardHandler) http.Handler) routeSpec {
+	return routeSpec{
+		pattern:          pattern,
+		feature:          license.FeatureAgents,
+		forbiddenMessage: agentsFeatureForbidden,
+		permission:       PermissionEvidenceRead,
+		handler:          handler,
+	}
+}
 
 func routeSpecsByPattern(specs []routeSpec) map[string]routeSpec {
 	out := make(map[string]routeSpec, len(specs))

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -109,7 +109,7 @@ func TestHandler_AllowedRendersScorecard(t *testing.T) {
 		HasFeature:       allowAgentsFeature,
 	})
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/evidence", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
@@ -350,7 +350,7 @@ func TestHandler_EvidenceNoSessionsExplainsReceiptSource(t *testing.T) {
 		HasFeature:       allowAgentsFeature,
 	})
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/evidence", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
@@ -362,6 +362,41 @@ func TestHandler_EvidenceNoSessionsExplainsReceiptSource(t *testing.T) {
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("evidence no-sessions body missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestHandler_RootRendersOverviewNotEvidence(t *testing.T) {
+	t.Parallel()
+
+	handler := New(Options{
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       allowAgentsFeature,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"Operator Overview",
+		"Where do I need to look, and what can I prove?",
+		"No aggregate score.",
+		`class="active" aria-current="page">Overview</a>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("root overview body missing %q: %s", want, body)
+		}
+	}
+	for _, notWant := range []string{
+		"Evidence proves receipt ordering, signer trust, and per-session decisions",
+		"Receipt Timeline",
+		"Evidence Scorecard",
+	} {
+		if strings.Contains(body, notWant) {
+			t.Fatalf("root rendered evidence content %q: %s", notWant, body)
 		}
 	}
 }
@@ -551,6 +586,7 @@ func TestHandler_RoutePermissionFailsClosed(t *testing.T) {
 
 	for _, path := range []string{
 		"/",
+		"/evidence",
 		"/exemptions",
 		"/session/" + testSessionID,
 		"/session/" + testSessionID + "/receipt/0",
@@ -593,6 +629,7 @@ func TestHandler_RoutePermissionUsesSpecificPermission(t *testing.T) {
 		want Permission
 	}{
 		{path: "/", want: PermissionEvidenceRead},
+		{path: "/evidence", want: PermissionEvidenceRead},
 		{path: "/exemptions", want: PermissionExemptionsRead},
 		{path: "/session/" + testSessionID, want: PermissionEvidenceRead},
 		{path: "/agents", want: PermissionAgentsRead},
@@ -630,7 +667,8 @@ func TestHandler_SharedNavReachabilityFromRenderedViews(t *testing.T) {
 		path      string
 		activeKey string
 	}{
-		{path: "/", activeKey: "evidence"},
+		{path: "/", activeKey: "overview"},
+		{path: "/evidence", activeKey: "evidence"},
 		{path: "/session/" + testSessionID, activeKey: "evidence"},
 		{path: "/session/" + testSessionID + "/receipt/0", activeKey: "evidence"},
 		{path: "/exemptions", activeKey: "exemptions"},
@@ -672,6 +710,7 @@ func TestHandler_SharedHeaderCSSSingleSourcedAcrossRenderedViews(t *testing.T) {
 	wantStyle := extractDashboardHeaderStyle(t, overview)
 	for _, path := range []string{
 		"/",
+		"/evidence",
 		"/session/" + testSessionID,
 		"/session/" + testSessionID + "/receipt/0",
 		"/exemptions",
@@ -691,7 +730,8 @@ func TestHandler_SharedHeaderCSSSingleSourcedAcrossRenderedViews(t *testing.T) {
 		t.Fatalf("overview brand wordmark does not link to /overview: %s", overview)
 	}
 	assertActiveNavLink(t, overview, "overview")
-	assertActiveNavLink(t, renderDashboardPath(t, handler, "/"), "evidence")
+	assertActiveNavLink(t, renderDashboardPath(t, handler, "/"), "overview")
+	assertActiveNavLink(t, renderDashboardPath(t, handler, "/evidence"), "evidence")
 }
 
 func TestHandler_SharedNavMatchesRouteGateAuthorization(t *testing.T) {

--- a/enterprise/dashboard/operability_test.go
+++ b/enterprise/dashboard/operability_test.go
@@ -1040,12 +1040,14 @@ func TestDashboardRendersDeliveryFailureAndStaleReadModelLoudly(t *testing.T) {
 	handler := New(Options{
 		TrustedOuterAuth: true, ReceiptDir: dir, DeliveryInboxPath: inboxPath, ReadModelIndexPath: indexPath, HasFeature: allowAgentsFeature,
 	})
-	recorder := httptest.NewRecorder()
-	handler.ServeHTTP(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/evidence", nil))
-	body := recorder.Body.String()
-	for _, want := range []string{"DELIVERY HEALTH UNAVAILABLE", "READ MODEL STALE", "source of truth"} {
-		if !strings.Contains(body, want) {
-			t.Fatalf("dashboard body missing %q: %s", want, body)
+	for _, path := range []string{"/", "/overview", "/evidence"} {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
+		body := recorder.Body.String()
+		for _, want := range []string{"DELIVERY HEALTH UNAVAILABLE", "READ MODEL STALE", "source of truth"} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("%s dashboard body missing %q: %s", path, want, body)
+			}
 		}
 	}
 }

--- a/enterprise/dashboard/operability_test.go
+++ b/enterprise/dashboard/operability_test.go
@@ -1041,14 +1041,17 @@ func TestDashboardRendersDeliveryFailureAndStaleReadModelLoudly(t *testing.T) {
 		TrustedOuterAuth: true, ReceiptDir: dir, DeliveryInboxPath: inboxPath, ReadModelIndexPath: indexPath, HasFeature: allowAgentsFeature,
 	})
 	for _, path := range []string{"/", "/overview", "/evidence"} {
-		recorder := httptest.NewRecorder()
-		handler.ServeHTTP(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
-		body := recorder.Body.String()
-		for _, want := range []string{"DELIVERY HEALTH UNAVAILABLE", "READ MODEL STALE", "source of truth"} {
-			if !strings.Contains(body, want) {
-				t.Fatalf("%s dashboard body missing %q: %s", path, want, body)
+		path := path
+		t.Run(path, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
+			body := recorder.Body.String()
+			for _, want := range []string{"DELIVERY HEALTH UNAVAILABLE", "READ MODEL STALE", "source of truth"} {
+				if !strings.Contains(body, want) {
+					t.Fatalf("dashboard body missing %q: %s", want, body)
+				}
 			}
-		}
+		})
 	}
 }
 

--- a/enterprise/dashboard/operability_test.go
+++ b/enterprise/dashboard/operability_test.go
@@ -1045,7 +1045,18 @@ func TestDashboardRendersDeliveryFailureAndStaleReadModelLoudly(t *testing.T) {
 		t.Run(path, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil))
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("GET %s: got status %d, want %d", path, recorder.Code, http.StatusOK)
+			}
 			body := recorder.Body.String()
+			routeMarker := map[string]string{
+				"/":         "CRL status",
+				"/overview": "CRL status",
+				"/evidence": "Disposable read model",
+			}[path]
+			if !strings.Contains(body, routeMarker) {
+				t.Fatalf("dashboard body missing route marker %q: %s", routeMarker, body)
+			}
 			for _, want := range []string{"DELIVERY HEALTH UNAVAILABLE", "READ MODEL STALE", "source of truth"} {
 				if !strings.Contains(body, want) {
 					t.Fatalf("dashboard body missing %q: %s", want, body)

--- a/enterprise/dashboard/operability_test.go
+++ b/enterprise/dashboard/operability_test.go
@@ -1041,7 +1041,7 @@ func TestDashboardRendersDeliveryFailureAndStaleReadModelLoudly(t *testing.T) {
 		TrustedOuterAuth: true, ReceiptDir: dir, DeliveryInboxPath: inboxPath, ReadModelIndexPath: indexPath, HasFeature: allowAgentsFeature,
 	})
 	recorder := httptest.NewRecorder()
-	handler.ServeHTTP(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+	handler.ServeHTTP(recorder, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/evidence", nil))
 	body := recorder.Body.String()
 	for _, want := range []string{"DELIVERY HEALTH UNAVAILABLE", "READ MODEL STALE", "source of truth"} {
 		if !strings.Contains(body, want) {

--- a/enterprise/dashboard/overview.go
+++ b/enterprise/dashboard/overview.go
@@ -172,6 +172,8 @@ type OverviewGovernance struct {
 	AlertFailures         int
 	DeliveryConfigured    bool
 	DeliveryError         string
+	IndexConfigured       bool
+	IndexStatus           string
 	LegalHoldConfigured   bool
 	LegalHoldError        string
 	ActiveLegalHolds      int
@@ -582,6 +584,8 @@ func (m *ReadModel) overviewGovernance(exemptions ExemptionInventory, trust Trus
 		CRLDetail:          trust.CRLDetail,
 		DeliveryConfigured: health.DeliveryConfigured,
 		DeliveryError:      health.DeliveryError,
+		IndexConfigured:    health.IndexConfigured,
+		IndexStatus:        health.IndexStatus,
 	}
 	for _, entry := range exemptions.Entries {
 		switch {

--- a/enterprise/dashboard/overview.tmpl.html
+++ b/enterprise/dashboard/overview.tmpl.html
@@ -494,6 +494,7 @@
           <div><h3>CRL status</h3><p class="muted">{{.Governance.CRLStatus}}</p>{{if .Governance.CRLDetail}}<p class="dim">{{.Governance.CRLDetail}}</p>{{end}}</div>
           <div><h3>Legal holds</h3>{{if .Governance.LegalHoldConfigured}}{{if .Governance.LegalHoldError}}<p class="amber">{{.Governance.LegalHoldError}}</p>{{else}}<p class="muted">{{.Governance.ActiveLegalHolds}} active holds</p>{{end}}{{else}}<p class="dim">No legal-hold store configured; no hold claim is made.</p>{{end}}</div>
           <div><h3>Delivery source</h3>{{if .Governance.DeliveryConfigured}}{{if .Governance.DeliveryError}}<p class="red">{{.Governance.DeliveryError}}</p>{{else}}<p class="muted">delivery inbox loaded</p>{{end}}{{else}}<p class="dim">No alert-delivery inbox configured.</p>{{end}}</div>
+          <div><h3>Read model</h3>{{if .Governance.IndexConfigured}}<p class="muted">{{.Governance.IndexStatus}}</p><p class="dim">Recorder evidence remains the source of truth.</p>{{else}}<p class="dim">No disposable read-model index configured.</p>{{end}}</div>
         </div>
       </div>
     </section>

--- a/internal/evidenceview/render_test.go
+++ b/internal/evidenceview/render_test.go
@@ -73,6 +73,67 @@ func TestRenderSingleAgentHTML(t *testing.T) {
 	}
 }
 
+func TestRenderSingleAgentHTML_OperatorConsoleThemeAndHonestScorecard(t *testing.T) {
+	fixedTime := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	_, priv := generateTestKey(t)
+	chain := buildTestChain(t, priv, 1)
+	ev := SessionEvidenceOf("sess-theme", chain, nil, false, 5000, 500)
+
+	var buf bytes.Buffer
+	err := RenderSingleAgentHTML(&buf, ev, nil, RenderOptions{
+		GeneratedAt: fixedTime,
+	})
+	if err != nil {
+		t.Fatalf("RenderSingleAgentHTML error: %v", err)
+	}
+	html := buf.String()
+
+	for _, want := range []string{
+		`--accent:#00e5a0`,
+		`--bg:#09090b`,
+		`Pipelock <span>&middot; Operator Console / Evidence Report</span>`,
+		`READ-ONLY`,
+		`class="scorecard"`,
+		`class="section"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("HTML missing operator-console theme marker: %q", want)
+		}
+	}
+
+	for _, want := range []string{
+		"Unverified",
+		"Authentic",
+		"Chain intact",
+		"Untampered",
+		"Not anchored",
+		"Anchored",
+		"Boundary-limited",
+		"Completeness",
+		"Each line is independently evaluated. There is no aggregate status.",
+		"Import the signer key from an operator-controlled source to upgrade this line.",
+		"Every receipt links to the previous receipt hash.",
+		"Add an external inclusion proof before treating ordering as independently anchored.",
+		"Cannot prove that no unmediated action occurred outside the boundary.",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("HTML missing honest scorecard content: %q", want)
+		}
+	}
+
+	for _, banned := range []string{
+		"aggregate healthy",
+		"aggregate verified",
+		"aggregate complete",
+		"verified complete",
+		"healthy",
+	} {
+		if strings.Contains(strings.ToLower(html), banned) {
+			t.Errorf("HTML contains banned aggregate wording: %q", banned)
+		}
+	}
+}
+
 func TestRenderSingleAgentHTML_EmptyEvidence(t *testing.T) {
 	fixedTime := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
 	ev := SessionEvidenceOf("sess-empty", nil, nil, false, 5000, 500)

--- a/internal/evidenceview/render_test.go
+++ b/internal/evidenceview/render_test.go
@@ -132,6 +132,11 @@ func TestRenderSingleAgentHTML_OperatorConsoleThemeAndHonestScorecard(t *testing
 			t.Errorf("HTML contains banned aggregate wording: %q", banned)
 		}
 	}
+	for _, notWant := range []string{"Decision Detail", `class="explanation"`} {
+		if strings.Contains(html, notWant) {
+			t.Errorf("HTML should not contain %q when Explanations is nil", notWant)
+		}
+	}
 }
 
 func TestRenderSingleAgentHTML_EmptyEvidence(t *testing.T) {

--- a/internal/evidenceview/single_agent.tmpl.html
+++ b/internal/evidenceview/single_agent.tmpl.html
@@ -14,7 +14,7 @@
   --border-strong:rgba(255,255,255,0.13);
   --text:#e2e8f0;
   --text-muted:#94a3b8;
-  --text-dim:#64748b;
+  --text-dim:#7c8ba3;
   --warn:#f59e0b;
   --danger:#ef4444;
 }
@@ -165,7 +165,7 @@ h3 {
 }
 .chip-verify { background: var(--accent); }
 .chip-warn, .chip-limited { background: var(--warn); }
-.chip-fail { background: var(--danger); color: white; }
+.chip-fail { background: var(--danger); color: #1a0505; }
 .detail {
   color: var(--text);
   overflow-wrap: anywhere;

--- a/internal/evidenceview/single_agent.tmpl.html
+++ b/internal/evidenceview/single_agent.tmpl.html
@@ -5,108 +5,347 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{.Title}}</title>
 <style>
-body { font-family: system-ui, -apple-system, sans-serif; margin: 2rem; color: #1a1a2e; background: #fafafa; }
-h1 { font-size: 1.5rem; }
-h2 { font-size: 1.2rem; border-bottom: 1px solid #ddd; padding-bottom: 0.3rem; }
-.meta { color: #555; font-size: 0.85rem; margin-bottom: 1.5rem; }
-.scorecard { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
-.line { border: 1px solid #ddd; border-radius: 6px; padding: 1rem; background: #fff; }
-.line .chip { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 0.8rem; font-weight: 600; }
-.chip-verify { background: #d4edda; color: #155724; }
-.chip-warn { background: #fff3cd; color: #856404; }
-.chip-fail { background: #f8d7da; color: #721c24; }
-.chip-limited { background: #e2e3e5; color: #383d41; }
-.line .detail { margin-top: 0.5rem; font-size: 0.9rem; }
-.line .sub { margin-top: 0.3rem; font-size: 0.8rem; color: #666; }
-table { width: 100%; border-collapse: collapse; margin-bottom: 2rem; font-size: 0.85rem; }
-th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid #eee; }
-th { background: #f0f0f0; font-weight: 600; }
-tr.unverifiable { background: #fff5f5; }
-.explanation { border: 1px solid #e0e0e0; border-radius: 6px; padding: 1rem; margin-bottom: 1rem; background: #fff; }
-.explanation h3 { margin-top: 0; font-size: 1rem; }
-.field { margin: 0.3rem 0; font-size: 0.85rem; }
-.field .label { font-weight: 600; color: #444; }
-.field .absent { color: #999; font-style: italic; }
+:root {
+  --accent:#00e5a0;
+  --bg:#09090b;
+  --bg-elevated:#0e0e11;
+  --panel:#0b0b0e;
+  --border:rgba(255,255,255,0.07);
+  --border-strong:rgba(255,255,255,0.13);
+  --text:#e2e8f0;
+  --text-muted:#94a3b8;
+  --text-dim:#64748b;
+  --warn:#f59e0b;
+  --danger:#ef4444;
+}
+* { box-sizing: border-box; }
+html { min-height: 100%; background: var(--bg); }
+body {
+  min-height: 100vh;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.45 Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.mono, code {
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 0.8rem 1.5rem;
+  background: rgba(9,9,11,0.9);
+  border-bottom: 1px solid var(--border-strong);
+}
+.brand {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text);
+  font-weight: 700;
+  white-space: nowrap;
+}
+.brand span {
+  color: var(--text-dim);
+  font-weight: 500;
+}
+.read-only {
+  padding: 0.22rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-dim);
+  font-size: 0.66rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+main {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 26px 24px 80px;
+}
+h1, h2, h3, p { margin-top: 0; }
+h1 {
+  margin-bottom: 8px;
+  font-size: 26px;
+  letter-spacing: 0;
+  line-height: 1.15;
+}
+h2 {
+  margin: 0 0 12px;
+  font-size: 16px;
+  letter-spacing: 0;
+}
+h3 {
+  margin: 0 0 10px;
+  font-size: 13px;
+  letter-spacing: 0;
+}
+.page-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+  flex-wrap: wrap;
+  margin-bottom: 22px;
+}
+.eyebrow {
+  margin-bottom: 8px;
+  color: var(--accent);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.meta {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+.meta b {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+.section {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--panel);
+  margin-bottom: 18px;
+  overflow: hidden;
+}
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 15px 18px;
+  border-bottom: 1px solid var(--border);
+}
+.section-head p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.section-body { padding: 16px 18px 18px; }
+.scorecard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 10px;
+}
+.line {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--bg-elevated);
+}
+.line-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.line-name { font-weight: 700; }
+.chip {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 128px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  color: #050507;
+  font-size: 12px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+.chip-verify { background: var(--accent); }
+.chip-warn, .chip-limited { background: var(--warn); }
+.chip-fail { background: var(--danger); color: white; }
+.detail {
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+.sub {
+  margin-top: 4px;
+  color: var(--text-dim);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+.table-wrap {
+  overflow-x: auto;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+th, td {
+  text-align: left;
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+th {
+  color: var(--text-dim);
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+tbody tr:hover { background: rgba(255,255,255,0.025); }
+tr.unverifiable { background: rgba(245,158,11,0.10); }
+code {
+  color: var(--accent);
+  font-size: 12px;
+}
+.explanation {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  margin-bottom: 10px;
+  background: var(--bg-elevated);
+}
+.field {
+  display: grid;
+  grid-template-columns: 170px minmax(0, 1fr);
+  gap: 12px;
+  padding: 7px 0;
+  border-top: 1px solid var(--border);
+  font-size: 13px;
+}
+.field .label {
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.field span:last-child {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.field .absent {
+  color: var(--text-dim);
+  font-style: italic;
+}
+@media (max-width: 760px) {
+  .topbar { padding: 0.65rem 1rem; }
+  main { padding: 18px 14px 56px; }
+  .line-head, .field { display: block; }
+  .chip { margin-top: 8px; }
+}
 </style>
 </head>
 <body>
-<h1>{{.Title}}</h1>
-<div class="meta">
-  Agent: {{.Evidence.Agent}} |
-  Session: {{.Evidence.ID}} |
-  Receipts: {{.Evidence.ReceiptCount}} |
-  Generated: {{.GeneratedAt}}
+<header class="topbar">
+  <div class="brand mono">Pipelock <span>&middot; Operator Console / Evidence Report</span></div>
+  <div class="read-only mono">READ-ONLY</div>
+</header>
+<main>
+<div class="page-head">
+  <div>
+    <div class="eyebrow mono">Single-agent evidence</div>
+    <h1>{{.Title}}</h1>
+    <div class="meta">
+      <span><b>Agent</b> {{.Evidence.Agent}}</span>
+      <span><b>Session</b> {{.Evidence.ID}}</span>
+      <span><b>Receipts</b> {{.Evidence.ReceiptCount}}</span>
+    </div>
+  </div>
+  <div class="meta mono"><span><b>Generated</b> {{.GeneratedAt}}</span></div>
 </div>
 
-<h2>Evidence Scorecard</h2>
-<p style="font-size:0.85rem;color:#666;">Each line is independently evaluated. There is no aggregate status.</p>
-<div class="scorecard">
-  {{with .Evidence.Scorecard.Authentic}}
-  <div class="line">
-    <span class="chip chip-{{.State}}">{{.Chip}}</span>
-    <strong>Authentic</strong>
-    <div class="detail">{{.Detail}}</div>
-    <div class="sub">{{.Sub}}</div>
+<section class="section">
+  <div class="section-head">
+    <div>
+      <h2>Evidence Scorecard</h2>
+      <p>Each line is independently evaluated. There is no aggregate status.</p>
+    </div>
   </div>
-  {{end}}
-  {{with .Evidence.Scorecard.Untampered}}
-  <div class="line">
-    <span class="chip chip-{{.State}}">{{.Chip}}</span>
-    <strong>Untampered</strong>
-    <div class="detail">{{.Detail}}</div>
-    <div class="sub">{{.Sub}}</div>
+  <div class="section-body">
+    <div class="scorecard">
+      {{with .Evidence.Scorecard.Authentic}}
+      <div class="line">
+        <div class="line-head"><span class="line-name">Authentic</span><span class="chip chip-{{.State}}">{{.Chip}}</span></div>
+        <div class="detail">{{.Detail}}</div>
+        <div class="sub">{{.Sub}}</div>
+      </div>
+      {{end}}
+      {{with .Evidence.Scorecard.Untampered}}
+      <div class="line">
+        <div class="line-head"><span class="line-name">Untampered</span><span class="chip chip-{{.State}}">{{.Chip}}</span></div>
+        <div class="detail">{{.Detail}}</div>
+        <div class="sub">{{.Sub}}</div>
+      </div>
+      {{end}}
+      {{with .Evidence.Scorecard.Anchored}}
+      <div class="line">
+        <div class="line-head"><span class="line-name">Anchored</span><span class="chip chip-{{.State}}">{{.Chip}}</span></div>
+        <div class="detail">{{.Detail}}</div>
+        <div class="sub">{{.Sub}}</div>
+      </div>
+      {{end}}
+      {{with .Evidence.Scorecard.Completeness}}
+      <div class="line">
+        <div class="line-head"><span class="line-name">Completeness</span><span class="chip chip-{{.State}}">{{.Chip}}</span></div>
+        <div class="detail">{{.Detail}}</div>
+        <div class="sub">{{.Sub}}</div>
+      </div>
+      {{end}}
+    </div>
   </div>
-  {{end}}
-  {{with .Evidence.Scorecard.Anchored}}
-  <div class="line">
-    <span class="chip chip-{{.State}}">{{.Chip}}</span>
-    <strong>Anchored</strong>
-    <div class="detail">{{.Detail}}</div>
-    <div class="sub">{{.Sub}}</div>
-  </div>
-  {{end}}
-  {{with .Evidence.Scorecard.Completeness}}
-  <div class="line">
-    <span class="chip chip-{{.State}}">{{.Chip}}</span>
-    <strong>Completeness</strong>
-    <div class="detail">{{.Detail}}</div>
-    <div class="sub">{{.Sub}}</div>
-  </div>
-  {{end}}
-</div>
+</section>
 
 {{if .Evidence.ReceiptsEnabled}}
-<h2>Timeline ({{len .Evidence.Timeline}} entries{{if .Evidence.TimelineLimited}}, {{.Evidence.TimelineWindow}} window{{end}})</h2>
-<table>
-<thead><tr><th>Seq</th><th>Time</th><th>Verdict</th><th>Reason</th><th>Prev</th><th>Hash</th></tr></thead>
-<tbody>
-{{range .Evidence.Timeline}}
-<tr{{if .Unverifiable}} class="unverifiable"{{end}}>
-  <td>{{.Seq}}</td>
-  <td>{{.Time.Format "15:04:05"}}</td>
-  <td>{{.Verdict}}</td>
-  <td>{{.Reason}}</td>
-  <td><code>{{.PrevShort}}</code></td>
-  <td><code>{{.HashShort}}</code></td>
-</tr>
-{{end}}
-</tbody>
-</table>
+<section class="section">
+  <div class="section-head">
+    <h2>Timeline ({{len .Evidence.Timeline}} entries{{if .Evidence.TimelineLimited}}, {{.Evidence.TimelineWindow}} window{{end}})</h2>
+  </div>
+  <div class="table-wrap">
+    <table>
+    <thead><tr><th>Seq</th><th>Time</th><th>Verdict</th><th>Reason</th><th>Prev</th><th>Hash</th></tr></thead>
+    <tbody>
+    {{range .Evidence.Timeline}}
+    <tr{{if .Unverifiable}} class="unverifiable"{{end}}>
+      <td class="mono">{{.Seq}}</td>
+      <td class="mono">{{.Time.Format "15:04:05"}}</td>
+      <td>{{.Verdict}}</td>
+      <td>{{.Reason}}</td>
+      <td><code>{{.PrevShort}}</code></td>
+      <td><code>{{.HashShort}}</code></td>
+    </tr>
+    {{end}}
+    </tbody>
+    </table>
+  </div>
+</section>
 
 {{if .Explanations}}
-<h2>Decision Detail</h2>
-{{range .Explanations}}
-<div class="explanation">
-  <h3>Seq {{.ChainSeq.Detail}} — {{.Verdict.Detail}}</h3>
-  {{range $f := .Fields}}
-  <div class="field">
-    <span class="label">{{$f.Label}}:</span>
-    {{if $f.Present}}<span>{{$f.Detail}}</span>{{else}}<span class="absent">{{$f.Detail}}</span>{{end}}
+<section class="section">
+  <div class="section-head">
+    <h2>Decision Detail</h2>
   </div>
-  {{end}}
-</div>
+  <div class="section-body">
+    {{range .Explanations}}
+    <div class="explanation">
+      <h3>Seq {{.ChainSeq.Detail}} - {{.Verdict.Detail}}</h3>
+      {{range $f := .Fields}}
+      <div class="field">
+        <span class="label">{{$f.Label}}:</span>
+        {{if $f.Present}}<span>{{$f.Detail}}</span>{{else}}<span class="absent">{{$f.Detail}}</span>{{end}}
+      </div>
+      {{end}}
+    </div>
+    {{end}}
+  </div>
+</section>
 {{end}}
 {{end}}
-{{end}}
+</main>
 </body>
 </html>


### PR DESCRIPTION
## What changed

The Pro/Enterprise dashboard now lands on the Overview page at the root path instead of the Evidence timeline. Evidence keeps its own `/evidence` route and nav target, and `/session/<id>` deep links are preserved.

The free single-agent evidence console (`pipelock evidence view` and `pipelock evidence serve`) is restyled to match the revamped dark operator-console theme: brand lockup, read-only marker, carded scorecard rows, and dark table/detail styling. The styling is inlined so the free viewer stays in Apache core and does not import the enterprise package, and no external assets are requested.

The honesty framing is preserved exactly: every independently-evaluated scorecard line and the "there is no aggregate status" wording is unchanged, and no aggregate status label was introduced.

## Why

The free console is the top-of-funnel showcase and was still rendering the old plain report template, which looked nothing like the revamped dashboard. The root path landing on Evidence was also disorienting; Overview is the intended entry point.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated dashboard **/evidence** page for evidence and session details.
  - Updated dashboard routing so **/** and **/overview** show **Overview**, while **/evidence** activates **Evidence**.
  - Enhanced **Governance Debt** with a new **Read model** metric (configured vs not configured).

- **Style**
  - Refreshed the evidence view with a dark operator-console theme, including clearer **READ-ONLY** labeling and improved sectioned layout.

- **Tests / Bug Fixes**
  - Expanded coverage for routing, active navigation, and permission gating across **/**, **/overview**, and **/evidence**, plus added evidence HTML rendering assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->