### PR TITLE
harden(evidence): strict CSP + no-store on the free evidence-serve console

### DIFF
--- a/internal/cli/evidence/evidence.go
+++ b/internal/cli/evidence/evidence.go
@@ -201,6 +201,9 @@ func runServe(cmd *cobra.Command, opts serveOptions) error {
 
 func evidenceServeHandler(dir, sessionID string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", evidenceServeCSP)
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Referrer-Policy", "no-referrer")
 		if r.URL.Path != "/" {
 			http.NotFound(w, r)
 			return
@@ -217,9 +220,6 @@ func evidenceServeHandler(dir, sessionID string) http.Handler {
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Header().Set("Content-Security-Policy", evidenceServeCSP)
-		w.Header().Set("Cache-Control", "no-store")
-		w.Header().Set("Referrer-Policy", "no-referrer")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		_, _ = w.Write(html)
 	})

--- a/internal/cli/evidence/evidence.go
+++ b/internal/cli/evidence/evidence.go
@@ -42,6 +42,7 @@ func Cmd() *cobra.Command {
 
 const (
 	defaultEvidenceServeListen     = "127.0.0.1:0"
+	evidenceServeCSP               = "default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; object-src 'none'; form-action 'none'"
 	evidenceServeReadHeaderTimeout = 5 * time.Second
 	evidenceServeReadTimeout       = 30 * time.Second
 	evidenceServeWriteTimeout      = 30 * time.Second
@@ -216,6 +217,9 @@ func evidenceServeHandler(dir, sessionID string) http.Handler {
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Content-Security-Policy", evidenceServeCSP)
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Referrer-Policy", "no-referrer")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		_, _ = w.Write(html)
 	})

--- a/internal/cli/evidence/evidence_test.go
+++ b/internal/cli/evidence/evidence_test.go
@@ -412,15 +412,26 @@ func TestServeCmd_ExplicitSessionServesBoundReport(t *testing.T) {
 	if strings.Contains(body, testActorAlpha) {
 		t.Fatalf("GET / rendered unbound agent %q: %s", testActorAlpha, body)
 	}
-	if got := rec.Header().Get("Content-Security-Policy"); got != evidenceServeCSP {
-		t.Fatalf("Content-Security-Policy = %q, want %q", got, evidenceServeCSP)
-	}
+	assertEvidenceServeSecurityHeaders(t, rec.Header())
 	for header, want := range map[string]string{
-		"Cache-Control":          "no-store",
-		"Referrer-Policy":        "no-referrer",
 		"X-Content-Type-Options": "nosniff",
 	} {
 		if got := rec.Header().Get(header); got != want {
+			t.Fatalf("%s = %q, want %q", header, got, want)
+		}
+	}
+}
+
+func assertEvidenceServeSecurityHeaders(t *testing.T, headers http.Header) {
+	t.Helper()
+	if got := headers.Get("Content-Security-Policy"); got != evidenceServeCSP {
+		t.Fatalf("Content-Security-Policy = %q, want %q", got, evidenceServeCSP)
+	}
+	for header, want := range map[string]string{
+		"Cache-Control":   "no-store",
+		"Referrer-Policy": "no-referrer",
+	} {
+		if got := headers.Get(header); got != want {
 			t.Fatalf("%s = %q, want %q", header, got, want)
 		}
 	}
@@ -507,6 +518,7 @@ func TestServeCmd_MixedActorSessionFailsClosed(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("GET / status = %d, want 500; body=%s", rec.Code, rec.Body.String())
 	}
+	assertEvidenceServeSecurityHeaders(t, rec.Header())
 	body := rec.Body.String()
 	if strings.Contains(body, testActorBravo) || strings.Contains(body, testBravoTargetSecret) {
 		t.Fatalf("GET / leaked mixed-actor evidence: %s", body)
@@ -588,6 +600,7 @@ func TestServeCmd_NoEndpointCanSwitchBoundSession(t *testing.T) {
 			if rec.Code != http.StatusNotFound {
 				t.Fatalf("GET %s status = %d, want 404; body=%s", target, rec.Code, rec.Body.String())
 			}
+			assertEvidenceServeSecurityHeaders(t, rec.Header())
 		})
 	}
 }
@@ -604,6 +617,7 @@ func TestServeCmd_NonGETRootReturnsMethodNotAllowed(t *testing.T) {
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("POST / status = %d, want 405; body=%s", rec.Code, rec.Body.String())
 	}
+	assertEvidenceServeSecurityHeaders(t, rec.Header())
 	if rec.Header().Get("Allow") != http.MethodGet {
 		t.Fatalf("Allow = %q, want GET", rec.Header().Get("Allow"))
 	}

--- a/internal/cli/evidence/evidence_test.go
+++ b/internal/cli/evidence/evidence_test.go
@@ -412,6 +412,18 @@ func TestServeCmd_ExplicitSessionServesBoundReport(t *testing.T) {
 	if strings.Contains(body, testActorAlpha) {
 		t.Fatalf("GET / rendered unbound agent %q: %s", testActorAlpha, body)
 	}
+	if got := rec.Header().Get("Content-Security-Policy"); got != evidenceServeCSP {
+		t.Fatalf("Content-Security-Policy = %q, want %q", got, evidenceServeCSP)
+	}
+	for header, want := range map[string]string{
+		"Cache-Control":          "no-store",
+		"Referrer-Policy":        "no-referrer",
+		"X-Content-Type-Options": "nosniff",
+	} {
+		if got := rec.Header().Get(header); got != want {
+			t.Fatalf("%s = %q, want %q", header, got, want)
+		}
+	}
 }
 
 func TestServeCmd_NoLicenseRequired(t *testing.T) {

--- a/internal/evidenceview/render_test.go
+++ b/internal/evidenceview/render_test.go
@@ -209,3 +209,100 @@ func TestRenderSingleAgentHTML_HTMLEscapesAttackerContent(t *testing.T) {
 		t.Error("expected HTML-escaped script tag in output")
 	}
 }
+
+func TestRenderSingleAgentHTML_EscapesEveryTemplateDataSurface(t *testing.T) {
+	fixedTime := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	scriptPayload := `<script>alert("xss")</script>`
+	imagePayload := `"><img src=x onerror=alert(1)>`
+	assetPayload := `"><link rel="stylesheet" href="https://evil.example/x.css"><script src="https://evil.example/x.js"></script>`
+
+	ev := SessionEvidence{
+		ID:              "sess-" + imagePayload,
+		Agent:           "agent-" + scriptPayload,
+		ReceiptsEnabled: true,
+		ReceiptCount:    1,
+		Scorecard: Scorecard{
+			Authentic: Line{
+				State:  StateWarn,
+				Chip:   "Signer " + imagePayload,
+				Detail: "Signer key " + scriptPayload + " is not in the trusted-key set.",
+				Sub:    "Source " + assetPayload,
+			},
+			Untampered: Line{
+				State:  StateFail,
+				Chip:   "Reason " + scriptPayload,
+				Detail: "Receipt reason " + imagePayload,
+				Sub:    "Block reason " + scriptPayload,
+			},
+			Anchored: Line{
+				State:  StateWarn,
+				Chip:   "Anchor " + imagePayload,
+				Detail: "Destination " + scriptPayload,
+				Sub:    "Proof " + imagePayload,
+			},
+			Completeness: Line{
+				State:  StateLimited,
+				Chip:   "Boundary " + scriptPayload,
+				Detail: "Session " + imagePayload,
+				Sub:    "Agent " + scriptPayload,
+			},
+		},
+		Timeline: []TimelineItem{
+			{
+				Seq:          7,
+				Time:         fixedTime,
+				Verdict:      "block " + scriptPayload,
+				Reason:       "dlp / " + imagePayload,
+				PrevShort:    "prev-" + scriptPayload,
+				HashShort:    "hash-" + imagePayload,
+				Unverifiable: true,
+			},
+		},
+	}
+	explanations := []DecisionExplanation{
+		{
+			Verdict:     ExplanationField{Present: true, Label: "Verdict", Detail: "block " + scriptPayload},
+			ChainSeq:    ExplanationField{Present: true, Label: "Chain Seq", Detail: "7 " + imagePayload},
+			Pattern:     ExplanationField{Present: true, Label: "Pattern", Detail: "pattern " + scriptPayload},
+			TaintReason: ExplanationField{Present: true, Label: "Taint Decision Reason", Detail: "taint " + imagePayload},
+			Target:      ExplanationField{Present: true, Label: "Target", Detail: "https://api.vendor.example/" + assetPayload},
+			Actor:       ExplanationField{Present: true, Label: "Actor", Detail: "actor " + scriptPayload},
+			Principal:   ExplanationField{Present: true, Label: "Principal", Detail: "principal " + imagePayload},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := RenderSingleAgentHTML(&buf, ev, explanations, RenderOptions{
+		Title:       "Title " + scriptPayload,
+		GeneratedAt: fixedTime,
+	}); err != nil {
+		t.Fatalf("RenderSingleAgentHTML error: %v", err)
+	}
+	html := buf.String()
+
+	for _, raw := range []string{scriptPayload, imagePayload, assetPayload} {
+		if strings.Contains(html, raw) {
+			t.Fatalf("rendered HTML contains unescaped attacker payload %q: %s", raw, html)
+		}
+	}
+	for _, escaped := range []string{
+		"&lt;script&gt;alert(&#34;xss&#34;)&lt;/script&gt;",
+		"&#34;&gt;&lt;img src=x onerror=alert(1)&gt;",
+		"&lt;link rel=&#34;stylesheet&#34; href=&#34;https://evil.example/x.css&#34;&gt;",
+	} {
+		if !strings.Contains(html, escaped) {
+			t.Fatalf("rendered HTML missing escaped payload %q: %s", escaped, html)
+		}
+	}
+	for _, banned := range []string{
+		`<script`,
+		`<img`,
+		`<link rel="stylesheet"`,
+		`src="https://evil.example`,
+		`href="https://evil.example`,
+	} {
+		if strings.Contains(html, banned) {
+			t.Fatalf("rendered HTML contains executable/external asset surface %q: %s", banned, html)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

The free single-agent evidence web console (`pipelock evidence serve`) served its HTML report without a Content-Security-Policy, cache, or referrer header. The report renders agent-influenced fields (session id, agent name, receipt reasons, destinations), so a browser applied no content restrictions to it.

This adds a deny-by-default CSP (`default-src 'none'`, inline styles only, self and data images, no `frame-ancestors`/`base-uri`/`object-src`/`form-action`), `Cache-Control: no-store`, and `Referrer-Policy: no-referrer` on the served report. It also adds hostile-field render coverage across session id, agent, signer text, receipt reason, destination, and block/taint reason to lock in the existing `html/template` auto-escaping.

## Why

Defense in depth for the top-of-funnel free console. Even though the template auto-escapes, a served page that reflects agent-controlled data should carry a strict CSP so a future template change or a browser quirk cannot turn a reflected field into script execution in the operator's browser. Follow-up to the free-console restyle in #995, which shipped the styling without the header hardening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Added stronger browser security and privacy protections to evidence server responses (including a more restrictive content security policy, no-store caching, and tighter referrer handling).
  * Enhanced HTML rendering defenses by expanding escaping coverage to ensure attacker-controlled data cannot introduce executable or externally-loadable content. 
  * Expanded automated checks to verify these security headers and XSS protections across multiple server scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->