### PR TITLE
fix(conductor): additively merge published detection content onto follower baseline

### DIFF
--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -144,7 +144,9 @@ func (s *Server) ApplyConductorPolicyBundle(bundle conductor.PolicyBundle, opts 
 		LocalVersion: cliutil.Version,
 		LoadConfig:   config.Load,
 		Reload: func(newCfg *config.Config) error {
-			preserveConductorBundleLocalRuntimeState(cfg, newCfg)
+			if err := preserveConductorBundleLocalRuntimeState(cfg, newCfg, bundle.Payload.ConfigYAML); err != nil {
+				return err
+			}
 			return s.Reload(newCfg)
 		},
 		// Close the in-flight apply window: teardownConductor sets conductorDown
@@ -161,8 +163,8 @@ func (s *Server) ApplyConductorPolicyBundle(bundle conductor.PolicyBundle, opts 
 	})
 }
 
-func preserveConductorBundleLocalRuntimeState(oldCfg, newCfg *config.Config) {
-	config.PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg)
+func preserveConductorBundleLocalRuntimeState(oldCfg, newCfg *config.Config, bundleYAML string) error {
+	return config.PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, bundleYAML)
 }
 
 func buildConductorAuditTransport(cfg *config.Config, m *metrics.Metrics) (*auditbatcher.Queue, *auditbatcher.Transport, error) {

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -764,9 +764,13 @@ func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 	oldCfg.Sandbox.Enabled = true
 	oldCfg.Sandbox.Workspace = "/tmp/pipelock-sandbox"
 	oldCfg.LicenseFile = "/etc/pipelock/license.token"
+	bundleDLP := config.DLPPattern{Name: "bundle-secret", Regex: `BUNDLE_SECRET_[A-Z]+`, Severity: config.SeverityCritical}
 	oldCfg.ApplyDefaults()
 	expectedLocal := oldCfg.Clone()
 	rules.MergeIntoConfig(expectedLocal, cliutil.Version)
+	expectedWithBundleDLP := oldCfg.Clone()
+	expectedWithBundleDLP.DLP.Patterns = append(expectedWithBundleDLP.DLP.Patterns, bundleDLP)
+	rules.MergeIntoConfig(expectedWithBundleDLP, cliutil.Version)
 
 	// Enforcement-only bundle: policy bundles may carry only enforcement-policy
 	// sections (default-deny allowlist), so flight_recorder/conductor/etc. are
@@ -777,6 +781,12 @@ func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 		"mode: strict",
 		"api_allowlist:",
 		"  - api.example.com",
+		"dlp:",
+		"  include_defaults: false",
+		"  patterns:",
+		"    - name: " + bundleDLP.Name,
+		"      regex: " + strconv.Quote(bundleDLP.Regex),
+		"      severity: " + bundleDLP.Severity,
 		"",
 	}, "\n"))
 
@@ -834,8 +844,8 @@ func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 	if !reflect.DeepEqual(live.Sandbox, oldCfg.Sandbox) {
 		t.Fatalf("sandbox config = %+v, want preserved %+v", live.Sandbox, oldCfg.Sandbox)
 	}
-	if !reflect.DeepEqual(live.DLP, expectedLocal.DLP) {
-		t.Fatalf("dlp config = %+v, want preserved %+v", live.DLP, expectedLocal.DLP)
+	if !reflect.DeepEqual(live.DLP, expectedWithBundleDLP.DLP) {
+		t.Fatalf("dlp config = %+v, want local plus bundle-added %+v", live.DLP, expectedWithBundleDLP.DLP)
 	}
 	if !reflect.DeepEqual(live.ResponseScanning, expectedLocal.ResponseScanning) {
 		t.Fatalf("response_scanning = %+v, want preserved %+v", live.ResponseScanning, expectedLocal.ResponseScanning)
@@ -873,6 +883,81 @@ func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 		t.Fatalf("agent identity config = agents=%+v default=%q bind=%v, want agents=%+v default=%q bind=%v",
 			live.Agents, live.DefaultAgentIdentity, live.BindDefaultAgentIdentity,
 			oldCfg.Agents, oldCfg.DefaultAgentIdentity, oldCfg.BindDefaultAgentIdentity)
+	}
+	sc := s.proxy.ScannerPtr().Load()
+	if sc == nil {
+		t.Fatal("reloaded scanner is nil")
+	}
+	if result := sc.ScanTextForDLP(t.Context(), "exfil LOCAL_SECRET_ALPHA"); result.Clean {
+		t.Fatalf("local DLP pattern did not enforce after conductor apply: %+v", result)
+	}
+	if result := sc.ScanTextForDLP(t.Context(), "exfil BUNDLE_SECRET_BRAVO"); result.Clean {
+		t.Fatalf("bundle-added DLP pattern did not enforce after conductor apply: %+v", result)
+	}
+}
+
+func TestApplyConductorPolicyBundleRejectsConflictingDLPRedefinition(t *testing.T) {
+	s, signer := newConductorApplyTestServer(t)
+	oldCfg := s.proxy.CurrentConfig()
+	oldCfg.DLP.Patterns = []config.DLPPattern{{Name: "local-secret", Regex: `LOCAL_SECRET_[A-Z]+`, Severity: config.SeverityHigh}}
+	oldCfg.ApplyDefaults()
+	oldLive := s.proxy.CurrentConfig()
+	oldScanner := s.proxy.ScannerPtr().Load()
+
+	bundle := signedRuntimePolicyBundle(t, signer, "bundle-conflict", 1, "", strings.Join([]string{
+		"mode: strict",
+		"api_allowlist:",
+		"  - api.example.com",
+		"dlp:",
+		"  patterns:",
+		"    - name: local-secret",
+		"      regex: " + strconv.Quote(`BUNDLE_SECRET_[A-Z]+`),
+		"      severity: " + config.SeverityHigh,
+		"",
+	}, "\n"))
+
+	_, err := s.ApplyConductorPolicyBundle(bundle, ConductorApplyOptions{Resolver: signer.resolver()})
+	if err == nil || !strings.Contains(err.Error(), `cannot redefine local dlp.patterns item "local-secret"`) {
+		t.Fatalf("ApplyConductorPolicyBundle() error = %v, want DLP conflict rejection", err)
+	}
+	if s.proxy.CurrentConfig() != oldLive {
+		t.Fatal("conflicting bundle changed live config")
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("conflicting bundle changed live scanner")
+	}
+}
+
+func TestApplyConductorPolicyBundlePreservesReloadDowngradeGuardAfterAdditiveMerge(t *testing.T) {
+	s, signer := newConductorApplyTestServer(t)
+	oldCfg := s.proxy.CurrentConfig()
+	oldCfg.Mode = config.ModeStrict
+	oldCfg.DLP.Patterns = []config.DLPPattern{{Name: "local-secret", Regex: `LOCAL_SECRET_[A-Z]+`, Severity: config.SeverityHigh}}
+	oldCfg.ApplyDefaults()
+	oldLive := s.proxy.CurrentConfig()
+	oldScanner := s.proxy.ScannerPtr().Load()
+
+	bundle := signedRuntimePolicyBundle(t, signer, "bundle-downgrade", 1, "", strings.Join([]string{
+		"mode: balanced",
+		"api_allowlist:",
+		"  - api.example.com",
+		"dlp:",
+		"  patterns:",
+		"    - name: bundle-secret",
+		"      regex: " + strconv.Quote(`BUNDLE_SECRET_[A-Z]+`),
+		"      severity: " + config.SeverityHigh,
+		"",
+	}, "\n"))
+
+	_, err := s.ApplyConductorPolicyBundle(bundle, ConductorApplyOptions{Resolver: signer.resolver()})
+	if err == nil || !strings.Contains(err.Error(), "security downgrade from strict mode") {
+		t.Fatalf("ApplyConductorPolicyBundle() error = %v, want reload downgrade rejection", err)
+	}
+	if s.proxy.CurrentConfig() != oldLive {
+		t.Fatal("downgrade bundle changed live config")
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("downgrade bundle changed live scanner")
 	}
 }
 

--- a/internal/config/conductor_bundle.go
+++ b/internal/config/conductor_bundle.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"slices"
@@ -448,15 +449,83 @@ func preserveConductorBundleMCPToolPolicy(newCfg, oldCfg *Config, bundleOwnsSect
 	if err != nil {
 		return err
 	}
+	validationPolicy := newCfg.MCPToolPolicy
+	validationPolicy.Rules = merged
+	if err := validateConductorBundleToolPolicyRuleActions(validationPolicy, oldCfg.Defer, bundleRules); err != nil {
+		return err
+	}
 	newCfg.MCPToolPolicy.Rules = merged
-	if newCfg.MCPToolPolicy.Enabled {
-		validateCfg := &Config{
-			MCPToolPolicy: newCfg.MCPToolPolicy,
-			Defer:         oldCfg.Defer,
+	return nil
+}
+
+func validateConductorBundleToolPolicyRuleActions(policy MCPToolPolicy, deferCfg DeferConfig, bundleRules []ToolPolicyRule) error {
+	for _, rule := range bundleRules {
+		effectiveAction := rule.Action
+		if effectiveAction == "" {
+			effectiveAction = policy.Action
 		}
-		if err := validateCfg.validateMCPToolPolicy(); err != nil {
-			return err
+		switch effectiveAction {
+		case "", ActionWarn, ActionBlock:
+			continue
+		case ActionRedirect:
+			if err := validateConductorBundleToolPolicyRedirectRule(policy, rule); err != nil {
+				return err
+			}
+		case ActionDefer:
+			if err := validateConductorBundleToolPolicyDeferRule(policy, deferCfg, rule); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("mcp_tool_policy rule %q inherits invalid action %q: must be warn, block, redirect, or defer", rule.Name, effectiveAction)
 		}
+	}
+	return nil
+}
+
+func validateConductorBundleToolPolicyRedirectRule(policy MCPToolPolicy, rule ToolPolicyRule) error {
+	if rule.RedirectProfile == "" {
+		return fmt.Errorf("mcp_tool_policy rule %q has action=redirect but no redirect_profile", rule.Name)
+	}
+	profile, ok := policy.RedirectProfiles[rule.RedirectProfile]
+	if !ok {
+		return fmt.Errorf("mcp_tool_policy rule %q references unknown redirect_profile %q", rule.Name, rule.RedirectProfile)
+	}
+	return validateConductorBundleToolPolicyProfile("redirect_profile", rule.RedirectProfile, profile.Exec, profile.MatchAbsPath)
+}
+
+func validateConductorBundleToolPolicyDeferRule(policy MCPToolPolicy, deferCfg DeferConfig, rule ToolPolicyRule) error {
+	if !deferCfg.Enabled {
+		return fmt.Errorf("mcp_tool_policy rule %q has action=defer but defer.enabled is false", rule.Name)
+	}
+	if rule.ResolutionPolicy == nil {
+		return fmt.Errorf("mcp_tool_policy rule %q has action=defer but no affirmative resolution_policy", rule.Name)
+	}
+	if rule.ResolutionPolicy.AllowOn.PolicyPermits {
+		return fmt.Errorf("mcp_tool_policy rule %q has resolution_policy.allow_on.policy_permits but policy_reload cannot fire on supported defer transports yet", rule.Name)
+	}
+	if !rule.ResolutionPolicy.HasAffirmativeSignal() {
+		return fmt.Errorf("mcp_tool_policy rule %q has action=defer but no affirmative resolution_policy", rule.Name)
+	}
+	approvalRequested := rule.ResolutionPolicy.AllowOn.Approval || rule.ResolutionPolicy.StepUpOn.ApprovalRequestsHuman
+	if !approvalRequested {
+		return nil
+	}
+	if rule.ResolutionPolicy.ResolverProfile == "" {
+		return fmt.Errorf("mcp_tool_policy rule %q uses approval resolution but has no resolution_policy.resolver_profile", rule.Name)
+	}
+	profile, ok := policy.DeferResolverProfiles[rule.ResolutionPolicy.ResolverProfile]
+	if !ok {
+		return fmt.Errorf("mcp_tool_policy rule %q references unknown defer resolver profile %q", rule.Name, rule.ResolutionPolicy.ResolverProfile)
+	}
+	return validateConductorBundleToolPolicyProfile("defer_resolver_profile", rule.ResolutionPolicy.ResolverProfile, profile.Exec, profile.MatchAbsPath)
+}
+
+func validateConductorBundleToolPolicyProfile(kind, name string, exec []string, matchAbsPath bool) error {
+	if len(exec) == 0 || exec[0] == "" {
+		return fmt.Errorf("mcp_tool_policy %s %q has empty exec", kind, name)
+	}
+	if matchAbsPath && !filepath.IsAbs(exec[0]) {
+		return fmt.Errorf("mcp_tool_policy %s %q: match_abs_path is true but exec[0] %q is not absolute", kind, name, exec[0])
 	}
 	return nil
 }

--- a/internal/config/conductor_bundle.go
+++ b/internal/config/conductor_bundle.go
@@ -3,20 +3,42 @@
 
 package config
 
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
 // PreserveConductorBundleLocalRuntimeState copies follower-local runtime and
-// scanner settings from oldCfg onto newCfg before a Conductor enforcement-only
-// bundle is applied.
-func PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg *Config) {
+// scanner settings from oldCfg onto newCfg before a Conductor policy bundle is
+// applied. Detection list sections explicitly present in bundleYAML are merged
+// additively: follower-local coverage stays first, and bundle entries may only
+// add new named definitions.
+func PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg *Config, bundleYAML string) error {
 	if oldCfg == nil || newCfg == nil {
-		return
+		return nil
 	}
-	// Current Conductor bundles are enforcement-only deltas: they own fleet
-	// posture fields (mode/enforce/api_allowlist) and deliberately omit the
-	// follower's local scanner baseline. Preserve local runtime plumbing and
-	// scanner coverage here so an omitted YAML section cannot reset a follower
-	// to defaults or silently drop locally enabled enforcement. A future full
-	// policy-bundle format should carry an explicit ownership/version marker
-	// before this preservation is relaxed.
+	sections, err := conductorBundleTopLevelSections(bundleYAML)
+	if err != nil {
+		return err
+	}
+	rawBundleCfg, err := conductorBundleRawConfig(bundleYAML)
+	if err != nil {
+		return err
+	}
+	// Current Conductor bundles own fleet posture fields
+	// (mode/enforce/api_allowlist). Runtime plumbing and ambiguous scanner
+	// controls remain follower-local so an omitted YAML section cannot reset a
+	// follower to defaults or silently drop locally enabled enforcement. Pure
+	// detection lists are merged additively below; every struct/scalar surface
+	// still needs an explicit ownership/version marker before it can be remotely
+	// overridden.
 	newCfg.FetchProxy = oldCfg.FetchProxy
 	newCfg.ForwardProxy = oldCfg.ForwardProxy
 	newCfg.WebSocketProxy = oldCfg.WebSocketProxy
@@ -49,12 +71,20 @@ func PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg *Config) {
 	newCfg.SSRF = oldCfg.SSRF
 	newCfg.DNS = oldCfg.DNS
 	newCfg.Suppress = append([]SuppressEntry(nil), oldCfg.Suppress...)
-	newCfg.DLP = oldCfg.DLP
-	newCfg.CanaryTokens = oldCfg.CanaryTokens
-	newCfg.ResponseScanning = oldCfg.ResponseScanning
+	if err := preserveConductorBundleDLP(newCfg, oldCfg, sections["dlp"], rawBundleCfg.DLP.Patterns); err != nil {
+		return err
+	}
+	if err := preserveConductorBundleCanaryTokens(newCfg, oldCfg, sections["canary_tokens"], rawBundleCfg.CanaryTokens); err != nil {
+		return err
+	}
+	if err := preserveConductorBundleResponseScanning(newCfg, oldCfg, sections["response_scanning"], rawBundleCfg.ResponseScanning.Patterns); err != nil {
+		return err
+	}
 	newCfg.MCPInputScanning = oldCfg.MCPInputScanning
 	newCfg.MCPToolScanning = oldCfg.MCPToolScanning
-	newCfg.MCPToolPolicy = oldCfg.MCPToolPolicy
+	if err := preserveConductorBundleMCPToolPolicy(newCfg, oldCfg, sections["mcp_tool_policy"], rawBundleCfg.MCPToolPolicy.Rules); err != nil {
+		return err
+	}
 	newCfg.Defer = oldCfg.Defer
 	newCfg.GitProtection = oldCfg.GitProtection
 	newCfg.RequestBodyScanning = oldCfg.RequestBodyScanning
@@ -82,4 +112,381 @@ func PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg *Config) {
 	newCfg.LearnLock = oldCfg.LearnLock
 	newCfg.DefaultAgentIdentity = oldCfg.DefaultAgentIdentity
 	newCfg.BindDefaultAgentIdentity = oldCfg.BindDefaultAgentIdentity
+	return nil
+}
+
+func conductorBundleTopLevelSections(src string) (map[string]bool, error) {
+	sections := make(map[string]bool)
+	dec := yaml.NewDecoder(strings.NewReader(src))
+	var doc yaml.Node
+	if err := dec.Decode(&doc); err != nil {
+		if errors.Is(err, io.EOF) {
+			return sections, nil
+		}
+		return nil, fmt.Errorf("parse conductor policy bundle config sections: %w", err)
+	}
+	var extra yaml.Node
+	err := dec.Decode(&extra)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("parse conductor policy bundle config sections: %w", err)
+	}
+	if err == nil {
+		return nil, errors.New("parse conductor policy bundle config sections: multiple YAML documents")
+	}
+	if len(doc.Content) == 0 {
+		return sections, nil
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return sections, nil
+	}
+	collectConductorBundleTopLevelSections(root, sections, make(map[*yaml.Node]bool))
+	return sections, nil
+}
+
+func collectConductorBundleTopLevelSections(n *yaml.Node, sections map[string]bool, seen map[*yaml.Node]bool) {
+	if n == nil {
+		return
+	}
+	if n.Kind == yaml.AliasNode {
+		collectConductorBundleTopLevelSections(n.Alias, sections, seen)
+		return
+	}
+	if seen[n] {
+		return
+	}
+	seen[n] = true
+	if n.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		key := n.Content[i]
+		value := n.Content[i+1]
+		if key.Value == "<<" {
+			collectConductorBundleMergeSections(value, sections, seen)
+			continue
+		}
+		sections[key.Value] = true
+	}
+}
+
+func collectConductorBundleMergeSections(n *yaml.Node, sections map[string]bool, seen map[*yaml.Node]bool) {
+	if n == nil {
+		return
+	}
+	switch n.Kind {
+	case yaml.AliasNode, yaml.MappingNode:
+		collectConductorBundleTopLevelSections(n, sections, seen)
+	case yaml.SequenceNode:
+		for _, item := range n.Content {
+			collectConductorBundleTopLevelSections(item, sections, seen)
+		}
+	}
+}
+
+func conductorBundleRawConfig(src string) (*Config, error) {
+	cfg := &Config{}
+	dec := yaml.NewDecoder(strings.NewReader(src))
+	dec.KnownFields(true)
+	if err := dec.Decode(cfg); err != nil {
+		if errors.Is(err, io.EOF) {
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("parse conductor policy bundle raw config: %w", err)
+	}
+	var extra yaml.Node
+	err := dec.Decode(&extra)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("parse conductor policy bundle raw config: %w", err)
+	}
+	if err == nil {
+		return nil, errors.New("parse conductor policy bundle raw config: multiple YAML documents")
+	}
+	if err := normalizeConductorBundleRawConfig(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func normalizeConductorBundleRawConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := cfg.validateDLPPatternConfig(); err != nil {
+		return fmt.Errorf("parse conductor policy bundle raw config: %w", err)
+	}
+	if err := validateConductorBundleRawResponsePatterns(cfg.ResponseScanning.Patterns); err != nil {
+		return fmt.Errorf("parse conductor policy bundle raw config: %w", err)
+	}
+	if err := validateConductorBundleRawToolPolicyRules(cfg.MCPToolPolicy.Rules); err != nil {
+		return fmt.Errorf("parse conductor policy bundle raw config: %w", err)
+	}
+	return nil
+}
+
+func validateConductorBundleRawResponsePatterns(patterns []ResponseScanPattern) error {
+	for _, p := range patterns {
+		if p.Name == "" {
+			return fmt.Errorf("response scanning pattern missing name")
+		}
+		if p.Regex == "" {
+			return fmt.Errorf("response scanning pattern %q missing regex", p.Name)
+		}
+		if _, err := regexp.Compile(p.Regex); err != nil {
+			return fmt.Errorf("response scanning pattern %q has invalid regex: %w", p.Name, err)
+		}
+	}
+	return nil
+}
+
+func validateConductorBundleRawToolPolicyRules(rules []ToolPolicyRule) error {
+	for i, r := range rules {
+		if r.Name == "" {
+			return fmt.Errorf("mcp_tool_policy rule %d missing name", i)
+		}
+		if r.ToolPattern == "" {
+			return fmt.Errorf("mcp_tool_policy rule %q missing tool_pattern", r.Name)
+		}
+		if _, err := regexp.Compile(r.ToolPattern); err != nil {
+			return fmt.Errorf("mcp_tool_policy rule %q has invalid tool_pattern: %w", r.Name, err)
+		}
+		if r.ArgPattern != "" {
+			if _, err := regexp.Compile(r.ArgPattern); err != nil {
+				return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_pattern: %w", r.Name, err)
+			}
+		}
+		hasStructuralValidators := r.hasStructuralArgValidators()
+		if r.ArgKey != "" {
+			if r.ArgPattern == "" && !hasStructuralValidators {
+				return fmt.Errorf("mcp_tool_policy rule %q has arg_key without arg_pattern", r.Name)
+			}
+			if _, err := regexp.Compile(r.ArgKey); err != nil {
+				return fmt.Errorf("mcp_tool_policy rule %q has invalid arg_key: %w", r.Name, err)
+			}
+		} else if hasStructuralValidators {
+			return fmt.Errorf("mcp_tool_policy rule %q has structural argument validators but no arg_key", r.Name)
+		}
+		if err := validateToolPolicyStructuralArgs(r); err != nil {
+			return err
+		}
+		if r.Action != "" {
+			switch r.Action {
+			case ActionWarn, ActionBlock, ActionRedirect, ActionDefer:
+			default:
+				return fmt.Errorf("mcp_tool_policy rule %q has invalid action %q: must be warn, block, redirect, or defer", r.Name, r.Action)
+			}
+		}
+	}
+	return nil
+}
+
+func preserveConductorBundleDLP(newCfg, oldCfg *Config, bundleOwnsSection bool, bundlePatterns []DLPPattern) error {
+	newCfg.DLP = oldCfg.DLP
+	newCfg.DLP.Patterns = cloneDLPPatterns(oldCfg.DLP.Patterns)
+	if !bundleOwnsSection {
+		return nil
+	}
+	merged, err := mergeConductorBundleDLPPatterns(newCfg.DLP.Patterns, bundlePatterns)
+	if err != nil {
+		return err
+	}
+	newCfg.DLP.Patterns = merged
+	return nil
+}
+
+func mergeConductorBundleDLPPatterns(local, bundle []DLPPattern) ([]DLPPattern, error) {
+	merged := cloneDLPPatterns(local)
+	byName := make(map[string]DLPPattern, len(local))
+	byIdentity := make(map[string]struct{}, len(local))
+	for _, p := range local {
+		byName[p.Name] = p
+		byIdentity[dlpPatternIdentity(p)] = struct{}{}
+	}
+	for _, p := range bundle {
+		if existing, ok := byName[p.Name]; ok {
+			if !sameDLPPatternDefinition(existing, p) {
+				return nil, fmt.Errorf("conductor policy bundle cannot redefine local dlp.patterns item %q", p.Name)
+			}
+			continue
+		}
+		key := dlpPatternIdentity(p)
+		if _, ok := byIdentity[key]; ok {
+			continue
+		}
+		byName[p.Name] = p
+		byIdentity[key] = struct{}{}
+		merged = append(merged, p)
+	}
+	return merged, nil
+}
+
+func dlpPatternIdentity(p DLPPattern) string {
+	return p.Name + "\x00" + p.Regex
+}
+
+func sameDLPPatternDefinition(a, b DLPPattern) bool {
+	return a.Name == b.Name &&
+		a.Regex == b.Regex &&
+		a.Severity == b.Severity &&
+		a.Validator == b.Validator &&
+		a.Action == b.Action &&
+		slices.Equal(a.ExemptDomains, b.ExemptDomains)
+}
+
+func preserveConductorBundleCanaryTokens(newCfg, oldCfg *Config, bundleOwnsSection bool, bundleCanaryTokens CanaryTokens) error {
+	bundleTokens := cloneCanaryTokens(bundleCanaryTokens.Tokens)
+	newCfg.CanaryTokens = CanaryTokens{
+		Enabled: oldCfg.CanaryTokens.Enabled,
+		Tokens:  cloneCanaryTokens(oldCfg.CanaryTokens.Tokens),
+	}
+	if !bundleOwnsSection {
+		return nil
+	}
+	merged, err := mergeConductorBundleCanaryTokens(newCfg.CanaryTokens.Tokens, bundleTokens)
+	if err != nil {
+		return err
+	}
+	newCfg.CanaryTokens.Enabled = oldCfg.CanaryTokens.Enabled || bundleCanaryTokens.Enabled
+	newCfg.CanaryTokens.Tokens = merged
+	return nil
+}
+
+func mergeConductorBundleCanaryTokens(local, bundle []CanaryToken) ([]CanaryToken, error) {
+	merged := cloneCanaryTokens(local)
+	byName := make(map[string]CanaryToken, len(local))
+	byIdentity := make(map[string]struct{}, len(local))
+	for _, token := range local {
+		byName[token.Name] = token
+		byIdentity[canaryTokenIdentity(token)] = struct{}{}
+	}
+	for _, token := range bundle {
+		if existing, ok := byName[token.Name]; ok {
+			if existing != token {
+				return nil, fmt.Errorf("conductor policy bundle cannot redefine local canary_tokens.tokens item %q", token.Name)
+			}
+			continue
+		}
+		key := canaryTokenIdentity(token)
+		if _, ok := byIdentity[key]; ok {
+			continue
+		}
+		byName[token.Name] = token
+		byIdentity[key] = struct{}{}
+		merged = append(merged, token)
+	}
+	return merged, nil
+}
+
+func canaryTokenIdentity(token CanaryToken) string {
+	return token.Name + "\x00" + token.Value + "\x00" + token.EnvVar
+}
+
+func cloneCanaryTokens(src []CanaryToken) []CanaryToken {
+	if src == nil {
+		return nil
+	}
+	dst := make([]CanaryToken, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func preserveConductorBundleResponseScanning(newCfg, oldCfg *Config, bundleOwnsSection bool, bundlePatterns []ResponseScanPattern) error {
+	newCfg.ResponseScanning = oldCfg.ResponseScanning
+	newCfg.ResponseScanning.Patterns = cloneResponseScanPatterns(oldCfg.ResponseScanning.Patterns)
+	if !bundleOwnsSection {
+		return nil
+	}
+	merged, err := mergeConductorBundleResponsePatterns(newCfg.ResponseScanning.Patterns, bundlePatterns)
+	if err != nil {
+		return err
+	}
+	newCfg.ResponseScanning.Patterns = merged
+	return nil
+}
+
+func mergeConductorBundleResponsePatterns(local, bundle []ResponseScanPattern) ([]ResponseScanPattern, error) {
+	merged := cloneResponseScanPatterns(local)
+	byName := make(map[string]ResponseScanPattern, len(local))
+	byIdentity := make(map[string]struct{}, len(local))
+	for _, p := range local {
+		byName[p.Name] = p
+		byIdentity[responsePatternIdentity(p)] = struct{}{}
+	}
+	for _, p := range bundle {
+		if existing, ok := byName[p.Name]; ok {
+			if !sameResponsePatternDefinition(existing, p) {
+				return nil, fmt.Errorf("conductor policy bundle cannot redefine local response_scanning.patterns item %q", p.Name)
+			}
+			continue
+		}
+		key := responsePatternIdentity(p)
+		if _, ok := byIdentity[key]; ok {
+			continue
+		}
+		byName[p.Name] = p
+		byIdentity[key] = struct{}{}
+		merged = append(merged, p)
+	}
+	return merged, nil
+}
+
+func responsePatternIdentity(p ResponseScanPattern) string {
+	return p.Name + "\x00" + p.Regex
+}
+
+func sameResponsePatternDefinition(a, b ResponseScanPattern) bool {
+	return a.Name == b.Name && a.Regex == b.Regex
+}
+
+func preserveConductorBundleMCPToolPolicy(newCfg, oldCfg *Config, bundleOwnsSection bool, bundleRules []ToolPolicyRule) error {
+	newCfg.MCPToolPolicy = oldCfg.MCPToolPolicy
+	newCfg.MCPToolPolicy.Rules = cloneToolPolicyRules(oldCfg.MCPToolPolicy.Rules)
+	if !bundleOwnsSection {
+		return nil
+	}
+	merged, err := mergeConductorBundleToolPolicyRules(newCfg.MCPToolPolicy.Rules, bundleRules)
+	if err != nil {
+		return err
+	}
+	newCfg.MCPToolPolicy.Rules = merged
+	if newCfg.MCPToolPolicy.Enabled {
+		validateCfg := &Config{
+			MCPToolPolicy: newCfg.MCPToolPolicy,
+			Defer:         oldCfg.Defer,
+		}
+		if err := validateCfg.validateMCPToolPolicy(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mergeConductorBundleToolPolicyRules(local, bundle []ToolPolicyRule) ([]ToolPolicyRule, error) {
+	merged := cloneToolPolicyRules(local)
+	byName := make(map[string]ToolPolicyRule, len(local))
+	byIdentity := make(map[string]struct{}, len(local))
+	for _, rule := range local {
+		byName[rule.Name] = rule
+		byIdentity[toolPolicyRuleIdentity(rule)] = struct{}{}
+	}
+	for _, rule := range bundle {
+		if existing, ok := byName[rule.Name]; ok {
+			if !reflect.DeepEqual(existing, rule) {
+				return nil, fmt.Errorf("conductor policy bundle cannot redefine local mcp_tool_policy.rules item %q", rule.Name)
+			}
+			continue
+		}
+		key := toolPolicyRuleIdentity(rule)
+		if _, ok := byIdentity[key]; ok {
+			continue
+		}
+		byName[rule.Name] = rule
+		byIdentity[key] = struct{}{}
+		merged = append(merged, rule)
+	}
+	return merged, nil
+}
+
+func toolPolicyRuleIdentity(rule ToolPolicyRule) string {
+	return rule.Name + "\x00" + rule.ToolPattern + "\x00" + rule.ArgPattern + "\x00" + rule.ArgKey
 }

--- a/internal/config/conductor_bundle.go
+++ b/internal/config/conductor_bundle.go
@@ -449,6 +449,9 @@ func preserveConductorBundleMCPToolPolicy(newCfg, oldCfg *Config, bundleOwnsSect
 	if err != nil {
 		return err
 	}
+	// Bundles contribute only rules here. Redirect and defer resolver profiles
+	// stay follower-local, so bundle redirect/defer rules must reference
+	// profiles that already exist in the preserved local policy.
 	validationPolicy := newCfg.MCPToolPolicy
 	validationPolicy.Rules = merged
 	if err := validateConductorBundleToolPolicyRuleActions(validationPolicy, oldCfg.Defer, bundleRules); err != nil {

--- a/internal/config/conductor_bundle_test.go
+++ b/internal/config/conductor_bundle_test.go
@@ -5,14 +5,19 @@ package config
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
 func TestPreserveConductorBundleLocalRuntimeStateNilInputs(t *testing.T) {
 	t.Parallel()
 
-	PreserveConductorBundleLocalRuntimeState(nil, &Config{})
-	PreserveConductorBundleLocalRuntimeState(&Config{}, nil)
+	if err := PreserveConductorBundleLocalRuntimeState(nil, &Config{}, ""); err != nil {
+		t.Fatalf("nil new config error = %v", err)
+	}
+	if err := PreserveConductorBundleLocalRuntimeState(&Config{}, nil, ""); err != nil {
+		t.Fatalf("nil old config error = %v", err)
+	}
 }
 
 func TestPreserveConductorBundleLocalRuntimeStateCopiesFollowerLocalFields(t *testing.T) {
@@ -42,7 +47,9 @@ func TestPreserveConductorBundleLocalRuntimeStateCopiesFollowerLocalFields(t *te
 		Conductor:            Conductor{Enabled: true, FleetID: "fleet-from-bundle"},
 	}
 
-	PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg)
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, "mode: strict\n"); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
 
 	if newCfg.FetchProxy.Listen != oldCfg.FetchProxy.Listen {
 		t.Fatalf("FetchProxy.Listen = %q, want %q", newCfg.FetchProxy.Listen, oldCfg.FetchProxy.Listen)
@@ -88,4 +95,612 @@ func TestPreserveConductorBundleLocalRuntimeStateCopiesFollowerLocalFields(t *te
 	if reflect.DeepEqual(newCfg.Agents["builder"], oldCfg.Agents["builder"]) {
 		t.Fatal("Agents map aliases old config")
 	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateAdditiveDLPPatterns(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{DLP: DLP{
+		ScanEnv:         true,
+		IncludeDefaults: boolPtr(true),
+		Patterns: []DLPPattern{{
+			Name:     "local-secret",
+			Regex:    `LOCAL_SECRET_[A-Z]+`,
+			Severity: SeverityHigh,
+		}},
+	}}
+	newCfg := &Config{DLP: DLP{
+		ScanEnv:         false,
+		IncludeDefaults: boolPtr(false),
+		Patterns: []DLPPattern{{
+			Name:     "bundle-secret",
+			Regex:    `BUNDLE_SECRET_[A-Z]+`,
+			Severity: SeverityCritical,
+		}},
+	}}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, strings.Join([]string{
+		"dlp:",
+		"  patterns:",
+		"    - name: bundle-secret",
+		"      regex: BUNDLE_SECRET_[A-Z]+",
+		"      severity: critical",
+		"",
+	}, "\n")); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+
+	if !newCfg.DLP.ScanEnv {
+		t.Fatal("bundle dlp.scan_env disabled local baseline")
+	}
+	if newCfg.DLP.IncludeDefaults == nil || !*newCfg.DLP.IncludeDefaults {
+		t.Fatalf("DLP.IncludeDefaults = %v, want local true", newCfg.DLP.IncludeDefaults)
+	}
+	if names := dlpPatternNames(newCfg.DLP.Patterns); !reflect.DeepEqual(names, []string{"local-secret", "bundle-secret"}) {
+		t.Fatalf("DLP pattern names = %v", names)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateDLPDuplicateDefaultDedupes(t *testing.T) {
+	t.Parallel()
+
+	defaultPattern := Defaults().DLP.Patterns[0]
+	oldCfg := &Config{DLP: DLP{Patterns: []DLPPattern{defaultPattern}}}
+	newCfg := &Config{DLP: DLP{Patterns: []DLPPattern{defaultPattern}}}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, "dlp:\n  patterns: []\n"); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if len(newCfg.DLP.Patterns) != 1 {
+		t.Fatalf("DLP pattern count = %d, want 1", len(newCfg.DLP.Patterns))
+	}
+	if newCfg.DLP.Patterns[0].Name != defaultPattern.Name {
+		t.Fatalf("DLP pattern[0] = %q, want %q", newCfg.DLP.Patterns[0].Name, defaultPattern.Name)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateDLPConflictRejected(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{DLP: DLP{Patterns: []DLPPattern{{
+		Name:     "local-secret",
+		Regex:    `LOCAL_SECRET_[A-Z]+`,
+		Severity: SeverityHigh,
+	}}}}
+	newCfg := &Config{DLP: DLP{Patterns: []DLPPattern{{
+		Name:     "local-secret",
+		Regex:    `BUNDLE_SECRET_[A-Z]+`,
+		Severity: SeverityHigh,
+	}}}}
+
+	err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, strings.Join([]string{
+		"dlp:",
+		"  patterns:",
+		"    - name: local-secret",
+		"      regex: BUNDLE_SECRET_[A-Z]+",
+		"      severity: high",
+		"",
+	}, "\n"))
+	if err == nil || !strings.Contains(err.Error(), `cannot redefine local dlp.patterns item "local-secret"`) {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v, want dlp conflict", err)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateDLPUsesNormalizedRawDomains(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{DLP: DLP{Patterns: []DLPPattern{{
+		Name:          "local-secret",
+		Regex:         `LOCAL_SECRET_[A-Z]+`,
+		Severity:      SeverityHigh,
+		ExemptDomains: []string{"api.vendor.example"},
+	}}}}
+	rawBundleYAML := strings.Join([]string{
+		"dlp:",
+		"  include_defaults: false",
+		"  patterns:",
+		"    - name: local-secret",
+		"      regex: LOCAL_SECRET_[A-Z]+",
+		"      severity: high",
+		"      exempt_domains:",
+		"        - ' API.VENDOR.EXAMPLE. '",
+		"",
+	}, "\n")
+	newCfg, err := LoadBytes([]byte(rawBundleYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, rawBundleYAML); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if got := dlpPatternNames(newCfg.DLP.Patterns); !reflect.DeepEqual(got, []string{"local-secret"}) {
+		t.Fatalf("DLP pattern names = %v", got)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateDLPIncludeDefaultsFalseKeepsLocalDefaults(t *testing.T) {
+	t.Parallel()
+
+	localDefaults := Defaults().DLP.Patterns
+	oldCfg := &Config{DLP: DLP{IncludeDefaults: boolPtr(true), Patterns: localDefaults}}
+	newCfg := &Config{DLP: DLP{
+		IncludeDefaults: boolPtr(false),
+		Patterns: []DLPPattern{{
+			Name:     "bundle-only-secret",
+			Regex:    `BUNDLE_ONLY_[A-Z]+`,
+			Severity: SeverityHigh,
+		}},
+	}}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, strings.Join([]string{
+		"dlp:",
+		"  include_defaults: false",
+		"  patterns:",
+		"    - name: bundle-only-secret",
+		"      regex: BUNDLE_ONLY_[A-Z]+",
+		"      severity: high",
+		"",
+	}, "\n")); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if len(newCfg.DLP.Patterns) != len(localDefaults)+1 {
+		t.Fatalf("DLP pattern count = %d, want local defaults plus bundle item %d", len(newCfg.DLP.Patterns), len(localDefaults)+1)
+	}
+	if !hasDLPPattern(newCfg.DLP.Patterns, localDefaults[0].Name) {
+		t.Fatalf("local default pattern %q missing after include_defaults:false bundle", localDefaults[0].Name)
+	}
+	if !hasDLPPattern(newCfg.DLP.Patterns, "bundle-only-secret") {
+		t.Fatal("bundle-added pattern missing")
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateEmptyBundleSectionNoop(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{DLP: DLP{Patterns: []DLPPattern{{Name: "local-secret", Regex: `LOCAL_[A-Z]+`, Severity: SeverityHigh}}}}
+	newCfg := &Config{}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, "dlp: {}\n"); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if !reflect.DeepEqual(newCfg.DLP, oldCfg.DLP) {
+		t.Fatalf("DLP = %+v, want local %+v", newCfg.DLP, oldCfg.DLP)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateEmptyDLPSectionDoesNotImportLoadedDefaults(t *testing.T) {
+	t.Parallel()
+
+	defaultPattern := Defaults().DLP.Patterns[0]
+	oldCfg := &Config{DLP: DLP{Patterns: []DLPPattern{{
+		Name:     defaultPattern.Name,
+		Regex:    `LOCAL_OVERRIDE_[A-Z]+`,
+		Severity: SeverityHigh,
+	}}}}
+	rawBundleYAML := "dlp:\n  patterns: []\n"
+	newCfg, err := LoadBytes([]byte(rawBundleYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, rawBundleYAML); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if !reflect.DeepEqual(newCfg.DLP, oldCfg.DLP) {
+		t.Fatalf("DLP = %+v, want local-only %+v", newCfg.DLP, oldCfg.DLP)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateEmptyResponseSectionDoesNotImportLoadedDefaults(t *testing.T) {
+	t.Parallel()
+
+	defaultPattern := Defaults().ResponseScanning.Patterns[0]
+	oldCfg := &Config{ResponseScanning: ResponseScanning{
+		Enabled: true,
+		Action:  ActionBlock,
+		Patterns: []ResponseScanPattern{{
+			Name:  defaultPattern.Name,
+			Regex: `LOCAL_RESPONSE_OVERRIDE`,
+		}},
+	}}
+	rawBundleYAML := "response_scanning:\n  enabled: true\n"
+	newCfg, err := LoadBytes([]byte(rawBundleYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, rawBundleYAML); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if !reflect.DeepEqual(newCfg.ResponseScanning, oldCfg.ResponseScanning) {
+		t.Fatalf("ResponseScanning = %+v, want local-only %+v", newCfg.ResponseScanning, oldCfg.ResponseScanning)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateOmittedSectionDoesNotImportResolvedDefaults(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{DLP: DLP{Patterns: []DLPPattern{{Name: "local-secret", Regex: `LOCAL_[A-Z]+`, Severity: SeverityHigh}}}}
+	newCfg := &Config{DLP: Defaults().DLP}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, "mode: strict\n"); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if !reflect.DeepEqual(newCfg.DLP, oldCfg.DLP) {
+		t.Fatalf("DLP = %+v, want local-only %+v", newCfg.DLP, oldCfg.DLP)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateAdditiveCanaryTokens(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{CanaryTokens: CanaryTokens{
+		Enabled: false,
+		Tokens:  []CanaryToken{{Name: "local", Value: "local-canary-token"}},
+	}}
+	newCfg := &Config{CanaryTokens: CanaryTokens{
+		Enabled: true,
+		Tokens:  []CanaryToken{{Name: "bundle", Value: "bundle-canary-token"}},
+	}}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, strings.Join([]string{
+		"canary_tokens:",
+		"  enabled: true",
+		"  tokens:",
+		"    - name: bundle",
+		"      value: bundle-canary-token",
+		"",
+	}, "\n")); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if !newCfg.CanaryTokens.Enabled {
+		t.Fatal("bundle canary_tokens.enabled=true should enable additive canary coverage")
+	}
+	if got := canaryTokenNames(newCfg.CanaryTokens.Tokens); !reflect.DeepEqual(got, []string{"local", "bundle"}) {
+		t.Fatalf("canary token names = %v", got)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateCanariesUseNormalizedRawItems(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{CanaryTokens: CanaryTokens{
+		Enabled: true,
+		Tokens: []CanaryToken{{
+			Name:   "local",
+			Value:  "local-canary-token",
+			EnvVar: "LOCAL_CANARY",
+		}},
+	}}
+	rawBundleYAML := strings.Join([]string{
+		"canary_tokens:",
+		"  enabled: true",
+		"  tokens:",
+		"    - name: ' local '",
+		"      value: ' local-canary-token '",
+		"      env_var: ' LOCAL_CANARY '",
+		"",
+	}, "\n")
+	newCfg, err := LoadBytes([]byte(rawBundleYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, rawBundleYAML); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if got := canaryTokenNames(newCfg.CanaryTokens.Tokens); !reflect.DeepEqual(got, []string{"local"}) {
+		t.Fatalf("canary token names = %v", got)
+	}
+	if !reflect.DeepEqual(newCfg.CanaryTokens.Tokens, oldCfg.CanaryTokens.Tokens) {
+		t.Fatalf("canary tokens = %+v, want normalized local-only %+v", newCfg.CanaryTokens.Tokens, oldCfg.CanaryTokens.Tokens)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateResponseAndToolRulesAdditive(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{
+		ResponseScanning: ResponseScanning{
+			Enabled: true,
+			Action:  ActionBlock,
+			Patterns: []ResponseScanPattern{{
+				Name:  "local-response",
+				Regex: `LOCAL_RESPONSE`,
+			}},
+		},
+		MCPToolPolicy: MCPToolPolicy{
+			Enabled: true,
+			Action:  ActionBlock,
+			Rules: []ToolPolicyRule{{
+				Name:        "local-tool",
+				ToolPattern: `^local_`,
+				Action:      ActionBlock,
+			}},
+		},
+	}
+	newCfg := &Config{
+		ResponseScanning: ResponseScanning{
+			Enabled: false,
+			Action:  ActionWarn,
+			Patterns: []ResponseScanPattern{{
+				Name:  "bundle-response",
+				Regex: `BUNDLE_RESPONSE`,
+			}},
+		},
+		MCPToolPolicy: MCPToolPolicy{
+			Enabled: false,
+			Action:  ActionWarn,
+			Rules: []ToolPolicyRule{{
+				Name:        "bundle-tool",
+				ToolPattern: `^bundle_`,
+				Action:      ActionWarn,
+			}},
+		},
+	}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, strings.Join([]string{
+		"response_scanning:",
+		"  patterns:",
+		"    - name: bundle-response",
+		"      regex: BUNDLE_RESPONSE",
+		"mcp_tool_policy:",
+		"  rules:",
+		"    - name: bundle-tool",
+		"      tool_pattern: ^bundle_",
+		"      action: warn",
+		"",
+	}, "\n")); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if !newCfg.ResponseScanning.Enabled || newCfg.ResponseScanning.Action != ActionBlock {
+		t.Fatalf("response scalar fields = enabled %v action %q, want local true/block", newCfg.ResponseScanning.Enabled, newCfg.ResponseScanning.Action)
+	}
+	if got := responsePatternNames(newCfg.ResponseScanning.Patterns); !reflect.DeepEqual(got, []string{"local-response", "bundle-response"}) {
+		t.Fatalf("response pattern names = %v", got)
+	}
+	if !newCfg.MCPToolPolicy.Enabled || newCfg.MCPToolPolicy.Action != ActionBlock {
+		t.Fatalf("tool policy scalar fields = enabled %v action %q, want local true/block", newCfg.MCPToolPolicy.Enabled, newCfg.MCPToolPolicy.Action)
+	}
+	if got := toolPolicyRuleNames(newCfg.MCPToolPolicy.Rules); !reflect.DeepEqual(got, []string{"local-tool", "bundle-tool"}) {
+		t.Fatalf("tool policy rule names = %v", got)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateRejectsDormantInvalidResponsePattern(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{ResponseScanning: ResponseScanning{
+		Enabled: true,
+		Action:  ActionBlock,
+		Patterns: []ResponseScanPattern{{
+			Name:  "local-response",
+			Regex: `LOCAL_RESPONSE`,
+		}},
+	}}
+	rawBundleYAML := strings.Join([]string{
+		"response_scanning:",
+		"  enabled: false",
+		"  patterns:",
+		"    - name: dormant-invalid",
+		"      regex: '['",
+		"",
+	}, "\n")
+	newCfg, err := LoadBytes([]byte(rawBundleYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+
+	err = PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, rawBundleYAML)
+	if err == nil || !strings.Contains(err.Error(), `response scanning pattern "dormant-invalid" has invalid regex`) {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v, want dormant response regex rejection", err)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateRejectsDormantInvalidToolPolicyRule(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{MCPToolPolicy: MCPToolPolicy{
+		Enabled: true,
+		Action:  ActionBlock,
+		Rules: []ToolPolicyRule{{
+			Name:        "local-tool",
+			ToolPattern: `^local_`,
+			Action:      ActionBlock,
+		}},
+	}}
+	rawBundleYAML := strings.Join([]string{
+		"mcp_tool_policy:",
+		"  enabled: false",
+		"  rules:",
+		"    - name: dormant-invalid",
+		"      tool_pattern: '['",
+		"      action: block",
+		"",
+	}, "\n")
+	newCfg, err := LoadBytes([]byte(rawBundleYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+
+	err = PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, rawBundleYAML)
+	if err == nil || !strings.Contains(err.Error(), `mcp_tool_policy rule "dormant-invalid" has invalid tool_pattern`) {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v, want dormant tool policy regex rejection", err)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateRejectsDormantInvalidToolPolicyRedirect(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{MCPToolPolicy: MCPToolPolicy{
+		Enabled: true,
+		Action:  ActionBlock,
+		Rules: []ToolPolicyRule{{
+			Name:        "local-tool",
+			ToolPattern: `^local_`,
+			Action:      ActionBlock,
+		}},
+	}}
+	rawBundleYAML := strings.Join([]string{
+		"mcp_tool_policy:",
+		"  enabled: false",
+		"  rules:",
+		"    - name: dormant-redirect",
+		"      tool_pattern: ^bundle_",
+		"      action: redirect",
+		"",
+	}, "\n")
+	newCfg, err := LoadBytes([]byte(rawBundleYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+
+	err = PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, rawBundleYAML)
+	if err == nil || !strings.Contains(err.Error(), `mcp_tool_policy rule "dormant-redirect" has action=redirect but no redirect_profile`) {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v, want dormant redirect rejection", err)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateRejectsTrailingEmptyYAMLDocument(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{}
+	newCfg := &Config{}
+
+	err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, "mode: strict\n---\n")
+	if err == nil || !strings.Contains(err.Error(), "multiple YAML documents") {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v, want multi-document rejection", err)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateTopLevelMergeKeySections(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{
+		DLP: DLP{Patterns: []DLPPattern{{
+			Name:     "local-secret",
+			Regex:    `LOCAL_SECRET_[A-Z]+`,
+			Severity: SeverityHigh,
+		}}},
+		CanaryTokens: CanaryTokens{Tokens: []CanaryToken{{
+			Name:  "local-canary",
+			Value: "local-canary-token",
+		}}},
+		ResponseScanning: ResponseScanning{
+			Enabled: true,
+			Action:  ActionBlock,
+			Patterns: []ResponseScanPattern{{
+				Name:  "local-response",
+				Regex: `LOCAL_RESPONSE`,
+			}},
+		},
+		MCPToolPolicy: MCPToolPolicy{
+			Enabled: true,
+			Action:  ActionBlock,
+			Rules: []ToolPolicyRule{{
+				Name:        "local-tool",
+				ToolPattern: `^local_`,
+				Action:      ActionBlock,
+			}},
+		},
+	}
+	rawBundleYAML := strings.Join([]string{
+		"<<:",
+		"  - &bundle_sections",
+		"    dlp:",
+		"      include_defaults: false",
+		"      patterns:",
+		"        - name: bundle-secret",
+		"          regex: BUNDLE_SECRET_[A-Z]+",
+		"          severity: high",
+		"    canary_tokens:",
+		"      enabled: true",
+		"      tokens:",
+		"        - name: bundle-canary",
+		"          value: bundle-canary-token",
+		"    response_scanning:",
+		"      enabled: true",
+		"      include_defaults: false",
+		"      patterns:",
+		"        - name: bundle-response",
+		"          regex: BUNDLE_RESPONSE",
+		"    mcp_tool_policy:",
+		"      enabled: true",
+		"      action: warn",
+		"      rules:",
+		"        - name: bundle-tool",
+		"          tool_pattern: ^bundle_",
+		"          action: warn",
+		"  - *bundle_sections",
+		"mode: strict",
+		"api_allowlist:",
+		"  - api.vendor.example",
+		"",
+	}, "\n")
+	newCfg, err := LoadBytes([]byte(rawBundleYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, rawBundleYAML); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+
+	if got := dlpPatternNames(newCfg.DLP.Patterns); !reflect.DeepEqual(got, []string{"local-secret", "bundle-secret"}) {
+		t.Fatalf("DLP pattern names = %v", got)
+	}
+	if !newCfg.CanaryTokens.Enabled {
+		t.Fatal("merged top-level canary_tokens.enabled=true did not enable canary coverage")
+	}
+	if got := canaryTokenNames(newCfg.CanaryTokens.Tokens); !reflect.DeepEqual(got, []string{"local-canary", "bundle-canary"}) {
+		t.Fatalf("canary token names = %v", got)
+	}
+	if got := responsePatternNames(newCfg.ResponseScanning.Patterns); !reflect.DeepEqual(got, []string{"local-response", "bundle-response"}) {
+		t.Fatalf("response pattern names = %v", got)
+	}
+	if got := toolPolicyRuleNames(newCfg.MCPToolPolicy.Rules); !reflect.DeepEqual(got, []string{"local-tool", "bundle-tool"}) {
+		t.Fatalf("tool policy rule names = %v", got)
+	}
+}
+
+func dlpPatternNames(patterns []DLPPattern) []string {
+	names := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		names = append(names, pattern.Name)
+	}
+	return names
+}
+
+func hasDLPPattern(patterns []DLPPattern, name string) bool {
+	for _, pattern := range patterns {
+		if pattern.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func canaryTokenNames(tokens []CanaryToken) []string {
+	names := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		names = append(names, token.Name)
+	}
+	return names
+}
+
+func responsePatternNames(patterns []ResponseScanPattern) []string {
+	names := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		names = append(names, pattern.Name)
+	}
+	return names
+}
+
+func toolPolicyRuleNames(rules []ToolPolicyRule) []string {
+	names := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		names = append(names, rule.Name)
+	}
+	return names
 }

--- a/internal/config/conductor_bundle_test.go
+++ b/internal/config/conductor_bundle_test.go
@@ -468,6 +468,81 @@ func TestPreserveConductorBundleLocalRuntimeStateResponseAndToolRulesAdditive(t 
 	}
 }
 
+func TestPreserveConductorBundleLocalRuntimeStateDetectionConflictsRejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		oldCfg  *Config
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "canary token",
+			oldCfg: &Config{CanaryTokens: CanaryTokens{Tokens: []CanaryToken{{
+				Name:  "shared-canary",
+				Value: "local-token",
+			}}}},
+			yaml: strings.Join([]string{
+				"canary_tokens:",
+				"  tokens:",
+				"    - name: shared-canary",
+				"      value: bundle-token",
+				"",
+			}, "\n"),
+			wantErr: `conductor policy bundle cannot redefine local canary_tokens.tokens item "shared-canary"`,
+		},
+		{
+			name: "response pattern",
+			oldCfg: &Config{ResponseScanning: ResponseScanning{Patterns: []ResponseScanPattern{{
+				Name:  "shared-response",
+				Regex: "LOCAL_RESPONSE",
+			}}}},
+			yaml: strings.Join([]string{
+				"response_scanning:",
+				"  patterns:",
+				"    - name: shared-response",
+				"      regex: BUNDLE_RESPONSE",
+				"",
+			}, "\n"),
+			wantErr: `conductor policy bundle cannot redefine local response_scanning.patterns item "shared-response"`,
+		},
+		{
+			name: "tool policy rule",
+			oldCfg: &Config{MCPToolPolicy: MCPToolPolicy{Rules: []ToolPolicyRule{{
+				Name:        "shared-tool",
+				ToolPattern: "^local_",
+				Action:      ActionBlock,
+			}}}},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  rules:",
+				"    - name: shared-tool",
+				"      tool_pattern: ^bundle_",
+				"      action: warn",
+				"",
+			}, "\n"),
+			wantErr: `conductor policy bundle cannot redefine local mcp_tool_policy.rules item "shared-tool"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			newCfg, err := LoadBytes([]byte(tt.yaml))
+			if err != nil {
+				t.Fatalf("LoadBytes() error = %v", err)
+			}
+
+			err = PreserveConductorBundleLocalRuntimeState(newCfg, tt.oldCfg, tt.yaml)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestPreserveConductorBundleLocalRuntimeStateRejectsDormantInvalidResponsePattern(t *testing.T) {
 	t.Parallel()
 
@@ -502,7 +577,7 @@ func TestPreserveConductorBundleLocalRuntimeStateRejectsDormantInvalidToolPolicy
 	t.Parallel()
 
 	oldCfg := &Config{MCPToolPolicy: MCPToolPolicy{
-		Enabled: true,
+		Enabled: false,
 		Action:  ActionBlock,
 		Rules: []ToolPolicyRule{{
 			Name:        "local-tool",
@@ -559,6 +634,411 @@ func TestPreserveConductorBundleLocalRuntimeStateRejectsDormantInvalidToolPolicy
 	err = PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, rawBundleYAML)
 	if err == nil || !strings.Contains(err.Error(), `mcp_tool_policy rule "dormant-redirect" has action=redirect but no redirect_profile`) {
 		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v, want dormant redirect rejection", err)
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateRejectsDormantToolPolicyActionRequirements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		oldCfg  *Config
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "unknown redirect profile",
+			oldCfg: &Config{MCPToolPolicy: MCPToolPolicy{
+				Enabled: false,
+				Action:  ActionBlock,
+				Rules: []ToolPolicyRule{{
+					Name:        "local-tool",
+					ToolPattern: `^local_`,
+					Action:      ActionBlock,
+				}},
+			}},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-redirect",
+				"      tool_pattern: ^bundle_",
+				"      action: redirect",
+				"      redirect_profile: missing",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy rule "dormant-redirect" references unknown redirect_profile "missing"`,
+		},
+		{
+			name: "inherited redirect action requires profile",
+			oldCfg: &Config{MCPToolPolicy: MCPToolPolicy{
+				Enabled: false,
+				Action:  ActionRedirect,
+				RedirectProfiles: map[string]RedirectProfile{
+					"safe-fetch": {Exec: []string{"/usr/bin/safe-fetch"}},
+				},
+				Rules: []ToolPolicyRule{{
+					Name:            "local-tool",
+					ToolPattern:     `^local_`,
+					RedirectProfile: "safe-fetch",
+				}},
+			}},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-inherited-redirect",
+				"      tool_pattern: ^bundle_",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy rule "dormant-inherited-redirect" has action=redirect but no redirect_profile`,
+		},
+		{
+			name: "redirect profile empty exec",
+			oldCfg: &Config{MCPToolPolicy: MCPToolPolicy{
+				Enabled: false,
+				Action:  ActionBlock,
+				RedirectProfiles: map[string]RedirectProfile{
+					"bad-fetch": {Exec: nil},
+				},
+				Rules: []ToolPolicyRule{{
+					Name:        "local-tool",
+					ToolPattern: `^local_`,
+					Action:      ActionBlock,
+				}},
+			}},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-redirect",
+				"      tool_pattern: ^bundle_",
+				"      action: redirect",
+				"      redirect_profile: bad-fetch",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy redirect_profile "bad-fetch" has empty exec`,
+		},
+		{
+			name: "redirect profile relative exec with absolute matching",
+			oldCfg: &Config{MCPToolPolicy: MCPToolPolicy{
+				Enabled: false,
+				Action:  ActionBlock,
+				RedirectProfiles: map[string]RedirectProfile{
+					"bad-fetch": {Exec: []string{"relative-fetch"}, MatchAbsPath: true},
+				},
+				Rules: []ToolPolicyRule{{
+					Name:        "local-tool",
+					ToolPattern: `^local_`,
+					Action:      ActionBlock,
+				}},
+			}},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-redirect",
+				"      tool_pattern: ^bundle_",
+				"      action: redirect",
+				"      redirect_profile: bad-fetch",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy redirect_profile "bad-fetch": match_abs_path is true but exec[0] "relative-fetch" is not absolute`,
+		},
+		{
+			name: "inherited invalid action",
+			oldCfg: &Config{MCPToolPolicy: MCPToolPolicy{
+				Enabled: false,
+				Action:  ActionStrip,
+				Rules: []ToolPolicyRule{{
+					Name:        "local-tool",
+					ToolPattern: `^local_`,
+					Action:      ActionBlock,
+				}},
+			}},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-inherited-invalid",
+				"      tool_pattern: ^bundle_",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy rule "dormant-inherited-invalid" inherits invalid action "strip": must be warn, block, redirect, or defer`,
+		},
+		{
+			name: "defer while defer disabled",
+			oldCfg: &Config{
+				Defer: DeferConfig{Enabled: false},
+				MCPToolPolicy: MCPToolPolicy{
+					Enabled: false,
+					Action:  ActionBlock,
+					Rules: []ToolPolicyRule{{
+						Name:        "local-tool",
+						ToolPattern: `^local_`,
+						Action:      ActionBlock,
+					}},
+				},
+			},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-defer",
+				"      tool_pattern: ^bundle_",
+				"      action: defer",
+				"      resolution_policy:",
+				"        allow_on:",
+				"          tool_inventory_baseline: true",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy rule "dormant-defer" has action=defer but defer.enabled is false`,
+		},
+		{
+			name: "defer missing affirmative resolution",
+			oldCfg: &Config{
+				Defer: DeferConfig{Enabled: true},
+				MCPToolPolicy: MCPToolPolicy{
+					Enabled: false,
+					Action:  ActionBlock,
+					Rules: []ToolPolicyRule{{
+						Name:        "local-tool",
+						ToolPattern: `^local_`,
+						Action:      ActionBlock,
+					}},
+				},
+			},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-defer",
+				"      tool_pattern: ^bundle_",
+				"      action: defer",
+				"      resolution_policy:",
+				"        resolver_profile: approve",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy rule "dormant-defer" has action=defer but no affirmative resolution_policy`,
+		},
+		{
+			name: "defer missing resolution policy",
+			oldCfg: &Config{
+				Defer: DeferConfig{Enabled: true},
+				MCPToolPolicy: MCPToolPolicy{
+					Enabled: false,
+					Action:  ActionBlock,
+					Rules: []ToolPolicyRule{{
+						Name:        "local-tool",
+						ToolPattern: `^local_`,
+						Action:      ActionBlock,
+					}},
+				},
+			},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-defer",
+				"      tool_pattern: ^bundle_",
+				"      action: defer",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy rule "dormant-defer" has action=defer but no affirmative resolution_policy`,
+		},
+		{
+			name: "defer policy permits unsupported",
+			oldCfg: &Config{
+				Defer: DeferConfig{Enabled: true},
+				MCPToolPolicy: MCPToolPolicy{
+					Enabled: false,
+					Action:  ActionBlock,
+					Rules: []ToolPolicyRule{{
+						Name:        "local-tool",
+						ToolPattern: `^local_`,
+						Action:      ActionBlock,
+					}},
+				},
+			},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-defer",
+				"      tool_pattern: ^bundle_",
+				"      action: defer",
+				"      resolution_policy:",
+				"        allow_on:",
+				"          policy_permits: true",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy rule "dormant-defer" has resolution_policy.allow_on.policy_permits but policy_reload cannot fire on supported defer transports yet`,
+		},
+		{
+			name: "defer approval missing resolver profile",
+			oldCfg: &Config{
+				Defer: DeferConfig{Enabled: true},
+				MCPToolPolicy: MCPToolPolicy{
+					Enabled: false,
+					Action:  ActionBlock,
+					Rules: []ToolPolicyRule{{
+						Name:        "local-tool",
+						ToolPattern: `^local_`,
+						Action:      ActionBlock,
+					}},
+				},
+			},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-defer-approval",
+				"      tool_pattern: ^bundle_",
+				"      action: defer",
+				"      resolution_policy:",
+				"        allow_on:",
+				"          approval: true",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy rule "dormant-defer-approval" uses approval resolution but has no resolution_policy.resolver_profile`,
+		},
+		{
+			name: "defer approval unknown resolver profile",
+			oldCfg: &Config{
+				Defer: DeferConfig{Enabled: true},
+				MCPToolPolicy: MCPToolPolicy{
+					Enabled: false,
+					Action:  ActionBlock,
+					Rules: []ToolPolicyRule{{
+						Name:        "local-tool",
+						ToolPattern: `^local_`,
+						Action:      ActionBlock,
+					}},
+				},
+			},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-defer-approval",
+				"      tool_pattern: ^bundle_",
+				"      action: defer",
+				"      resolution_policy:",
+				"        resolver_profile: missing",
+				"        allow_on:",
+				"          approval: true",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy rule "dormant-defer-approval" references unknown defer resolver profile "missing"`,
+		},
+		{
+			name: "defer resolver profile empty exec",
+			oldCfg: &Config{
+				Defer: DeferConfig{Enabled: true},
+				MCPToolPolicy: MCPToolPolicy{
+					Enabled: false,
+					Action:  ActionBlock,
+					DeferResolverProfiles: map[string]DeferResolverProfile{
+						"approve": {Exec: []string{""}},
+					},
+					Rules: []ToolPolicyRule{{
+						Name:        "local-tool",
+						ToolPattern: `^local_`,
+						Action:      ActionBlock,
+					}},
+				},
+			},
+			yaml: strings.Join([]string{
+				"mcp_tool_policy:",
+				"  enabled: false",
+				"  rules:",
+				"    - name: dormant-defer-approval",
+				"      tool_pattern: ^bundle_",
+				"      action: defer",
+				"      resolution_policy:",
+				"        resolver_profile: approve",
+				"        allow_on:",
+				"          approval: true",
+				"",
+			}, "\n"),
+			wantErr: `mcp_tool_policy defer_resolver_profile "approve" has empty exec`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			newCfg, err := LoadBytes([]byte(tt.yaml))
+			if err != nil {
+				t.Fatalf("LoadBytes() error = %v", err)
+			}
+
+			err = PreserveConductorBundleLocalRuntimeState(newCfg, tt.oldCfg, tt.yaml)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPreserveConductorBundleLocalRuntimeStateAcceptsDormantValidToolPolicyActions(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &Config{
+		Defer: DeferConfig{Enabled: true},
+		MCPToolPolicy: MCPToolPolicy{
+			Enabled: false,
+			Action:  ActionBlock,
+			RedirectProfiles: map[string]RedirectProfile{
+				"safe-fetch": {Exec: []string{"/usr/bin/safe-fetch"}, MatchAbsPath: true},
+			},
+			DeferResolverProfiles: map[string]DeferResolverProfile{
+				"approve": {Exec: []string{"/usr/bin/approve-tool"}, MatchAbsPath: true},
+			},
+			Rules: []ToolPolicyRule{{
+				Name:        "local-tool",
+				ToolPattern: `^local_`,
+				Action:      ActionBlock,
+			}},
+		},
+	}
+	rawBundleYAML := strings.Join([]string{
+		"mcp_tool_policy:",
+		"  enabled: false",
+		"  rules:",
+		"    - name: dormant-redirect",
+		"      tool_pattern: ^fetch_",
+		"      action: redirect",
+		"      redirect_profile: safe-fetch",
+		"    - name: dormant-defer",
+		"      tool_pattern: ^write_",
+		"      action: defer",
+		"      resolution_policy:",
+		"        resolver_profile: approve",
+		"        allow_on:",
+		"          approval: true",
+		"    - name: dormant-baseline-defer",
+		"      tool_pattern: ^baseline_",
+		"      action: defer",
+		"      resolution_policy:",
+		"        allow_on:",
+		"          tool_inventory_baseline: true",
+		"",
+	}, "\n")
+	newCfg, err := LoadBytes([]byte(rawBundleYAML))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+
+	if err := PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, rawBundleYAML); err != nil {
+		t.Fatalf("PreserveConductorBundleLocalRuntimeState() error = %v", err)
+	}
+	if newCfg.MCPToolPolicy.Enabled {
+		t.Fatal("bundle action validation should not enable local dormant tool policy")
+	}
+	if got := toolPolicyRuleNames(newCfg.MCPToolPolicy.Rules); !reflect.DeepEqual(got, []string{"local-tool", "dormant-redirect", "dormant-defer", "dormant-baseline-defer"}) {
+		t.Fatalf("tool policy rule names = %v", got)
 	}
 }
 

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -339,14 +339,37 @@ func cloneResponseScanPatterns(src []ResponseScanPattern) []ResponseScanPattern 
 	return dst
 }
 
-// cloneToolPolicyRules returns a deep copy of src. ToolPolicyRule has only
-// scalar fields today; the helper keeps the pattern consistent with the
-// other clone helpers and gives future nested-slice additions a clear home.
+// cloneToolPolicyRules returns a deep copy of src.
 func cloneToolPolicyRules(src []ToolPolicyRule) []ToolPolicyRule {
 	if src == nil {
 		return nil
 	}
 	dst := make([]ToolPolicyRule, len(src))
-	copy(dst, src)
+	for i := range src {
+		dst[i] = src[i]
+		if src[i].ArgNumberGT != nil {
+			v := *src[i].ArgNumberGT
+			dst[i].ArgNumberGT = &v
+		}
+		if src[i].ArgNumberLT != nil {
+			v := *src[i].ArgNumberLT
+			dst[i].ArgNumberLT = &v
+		}
+		if src[i].ArgLenGT != nil {
+			v := *src[i].ArgLenGT
+			dst[i].ArgLenGT = &v
+		}
+		if src[i].ArgLenLT != nil {
+			v := *src[i].ArgLenLT
+			dst[i].ArgLenLT = &v
+		}
+		if src[i].ArgValueIn != nil {
+			dst[i].ArgValueIn = append([]string(nil), src[i].ArgValueIn...)
+		}
+		if src[i].ResolutionPolicy != nil {
+			v := *src[i].ResolutionPolicy
+			dst[i].ResolutionPolicy = &v
+		}
+	}
 	return dst
 }

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -627,6 +628,67 @@ func TestCloneHelpers_NilAndEmpty(t *testing.T) {
 	}
 	if got := cloneToolPolicyRules(nil); got != nil {
 		t.Errorf("cloneToolPolicyRules(nil) = %v, want nil", got)
+	}
+}
+
+func TestCloneToolPolicyRulesDeepCopiesNestedFields(t *testing.T) {
+	argGT := json.Number("10")
+	argLT := json.Number("20")
+	lenGT := 3
+	lenLT := 9
+	src := []ToolPolicyRule{{
+		Name:        "nested",
+		ToolPattern: "^shell$",
+		ArgKey:      "^path$",
+		ArgNumberGT: &argGT,
+		ArgNumberLT: &argLT,
+		ArgLenGT:    &lenGT,
+		ArgLenLT:    &lenLT,
+		ArgValueIn:  []string{"rm", "curl"},
+		ResolutionPolicy: &DeferResolutionPolicy{
+			ResolverProfile: "operator",
+			AllowOn:         DeferAllowOn{Approval: true},
+			StepUpOn:        DeferStepUpOn{ApprovalRequestsHuman: true},
+		},
+	}}
+
+	clone := cloneToolPolicyRules(src)
+	if !reflect.DeepEqual(clone, src) {
+		t.Fatalf("cloneToolPolicyRules() = %+v, want %+v", clone, src)
+	}
+
+	*clone[0].ArgNumberGT = json.Number("11")
+	*clone[0].ArgNumberLT = json.Number("21")
+	*clone[0].ArgLenGT = 4
+	*clone[0].ArgLenLT = 10
+	clone[0].ArgValueIn[0] = "python"
+	clone[0].ResolutionPolicy.ResolverProfile = "mutated"
+	clone[0].ResolutionPolicy.AllowOn.Approval = false
+	clone[0].ResolutionPolicy.StepUpOn.ApprovalRequestsHuman = false
+
+	if got := src[0].ArgNumberGT.String(); got != "10" {
+		t.Fatalf("source ArgNumberGT mutated to %q", got)
+	}
+	if got := src[0].ArgNumberLT.String(); got != "20" {
+		t.Fatalf("source ArgNumberLT mutated to %q", got)
+	}
+	if got := *src[0].ArgLenGT; got != 3 {
+		t.Fatalf("source ArgLenGT mutated to %d", got)
+	}
+	if got := *src[0].ArgLenLT; got != 9 {
+		t.Fatalf("source ArgLenLT mutated to %d", got)
+	}
+	if got := src[0].ArgValueIn[0]; got != "rm" {
+		t.Fatalf("source ArgValueIn[0] mutated to %q", got)
+	}
+	if got := src[0].ResolutionPolicy.ResolverProfile; got != "operator" {
+		t.Fatalf("source resolver profile mutated to %q", got)
+	}
+	if !src[0].ResolutionPolicy.AllowOn.Approval {
+		t.Fatal("source approval flag mutated")
+	}
+	if !src[0].ResolutionPolicy.StepUpOn.ApprovalRequestsHuman {
+		t.Fatal("source step-up approval flag mutated")
 	}
 }
 


### PR DESCRIPTION
## What changed

Conductor policy bundles now distribute the detection content operators publish. Previously a published bundle's `dlp`, `response_scanning`, `canary_tokens`, and `mcp_tool_policy` list entries were accepted and signed at publish time and shown active on the dashboard, but the follower dropped them on apply by overwriting the bundle's scanner sections with its local values, so only `mode`, `enforce`, and `api_allowlist` ever took effect.

Follower apply now additively merges the bundle's explicitly declared detection-list entries onto the follower's local baseline. Local coverage is preserved first, a bundle may only add new named definitions, and a bundle can never reduce a follower's local coverage. Same-name redefinitions are rejected rather than silently replaced. Raw bundle entries are parsed from the signed config payload, normalized to match the loader, and validated before merge so a disabled section cannot smuggle an invalid or unvalidated entry into the active local section.

`suppress` and struct or scalar sections stay follower-local, since a remotely added suppression could reduce coverage and ambiguous struct ownership needs an explicit ownership marker. The reload downgrade guard still runs after the merge, and tool-policy strictest-wins means an added rule can never loosen an existing decision.

## Why

An operator publishing detection policy to a fleet saw the bundle marked active while followers silently enforced only their local defaults. This closes that gap so published detection content is actually enforced, while preserving the fail-closed guarantee that a bundle can never weaken a follower's local coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Policy bundles now merge detection and scanning settings additively (DLP, canary tokens, response scanning, and tool policies) without overwriting existing local rules.
  - Bundle reload now preserves local runtime state using the bundle’s configuration content.

- **Bug Fixes**
  - Bundle reload will fail if local runtime state preservation encounters an error.
  - Conflicting bundle redefinitions of existing local rules are rejected, keeping the active configuration and enforcement unchanged.
  - Bundle validation is stricter for patterns, structural consistency, and policy actions.
  - Tool policy rules are now deep-cloned to prevent unintended shared mutations.

- **Tests**
  - Added/expanded coverage for additive merges, conflict rejection, reload-guard preservation, validation failures, and deep-copy correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->