### PR TITLE
fix(coverage-cert): re-validate certificate body on verify and bind signer key

### DIFF
--- a/internal/coveragecert/coveragecert.go
+++ b/internal/coveragecert/coveragecert.go
@@ -108,6 +108,16 @@ func (b Body) SignablePreimage() ([]byte, error) {
 // Validate checks structural invariants on the body. It refuses ill-formed or
 // over-claiming bodies (fail closed). Called by Sign before signing.
 func (b Body) Validate() error {
+	if err := b.validateStructure(); err != nil {
+		return err
+	}
+	if mismatches := rederiveAggregates(b); len(mismatches) > 0 {
+		return fmt.Errorf("%w: %w: %s", ErrBodyInvalid, ErrAggregateMismatch, strings.Join(mismatches, "; "))
+	}
+	return nil
+}
+
+func (b Body) validateStructure() error {
 	if b.Schema != Schema {
 		return fmt.Errorf("%w: schema=%q, want %q", ErrBodyInvalid, b.Schema, Schema)
 	}
@@ -128,8 +138,8 @@ func (b Body) Validate() error {
 	if strings.Contains(strings.ToLower(b.Boundary), "all agent activity") {
 		return fmt.Errorf("%w: boundary must not claim coverage of all agent activity", ErrBodyInvalid)
 	}
-	if mismatches := rederiveAggregates(b); len(mismatches) > 0 {
-		return fmt.Errorf("%w: %w: %s", ErrBodyInvalid, ErrAggregateMismatch, strings.Join(mismatches, "; "))
+	if err := validateCoverageCertSignerKey(b.TrustedSignerKey); err != nil {
+		return fmt.Errorf("%w: trusted_signer_key: %w", ErrBodyInvalid, err)
 	}
 	return nil
 }
@@ -177,6 +187,12 @@ func Verify(cert Certificate, trustedKeys map[string]struct{}) (VerifyResult, er
 		return result, fmt.Errorf("%w: signer key length %d, want %d",
 			ErrVerifyFailed, len(signerKeyBytes), ed25519.PublicKeySize)
 	}
+	if err := cert.Body.validateStructure(); err != nil {
+		return result, fmt.Errorf("%w: body: %w", ErrVerifyFailed, err)
+	}
+	if cert.Body.TrustedSignerKey != cert.SignerKey {
+		return result, fmt.Errorf("%w: body trusted_signer_key does not match certificate signer_key", ErrVerifyFailed)
+	}
 
 	// Decode signature.
 	sigBytes, err := hex.DecodeString(cert.Signature)
@@ -205,6 +221,20 @@ func Verify(cert Certificate, trustedKeys map[string]struct{}) (VerifyResult, er
 	result.Lines = buildVerifyLines(cert, result, mismatches)
 
 	return result, nil
+}
+
+func validateCoverageCertSignerKey(value string) error {
+	keyBytes, err := hex.DecodeString(value)
+	if err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	if len(keyBytes) != ed25519.PublicKeySize {
+		return fmt.Errorf("length %d, want %d", len(keyBytes), ed25519.PublicKeySize)
+	}
+	if value != strings.ToLower(value) {
+		return errors.New("must be lowercase hex")
+	}
+	return nil
 }
 
 // rederiveAggregates recomputes aggregate counts from Sessions and returns

--- a/internal/coveragecert/coveragecert_test.go
+++ b/internal/coveragecert/coveragecert_test.go
@@ -215,6 +215,52 @@ func TestVerify_AggregateMismatch_Flagged(t *testing.T) {
 	}
 }
 
+func TestVerify_TrustedSignatureWithInvalidBodyFailsClosed(t *testing.T) {
+	t.Parallel()
+	pub, priv := genTestKey(t)
+	body := validBody(pub)
+	body.Boundary = "Coverage of all agent activity and mediated egress inside the declared Pipelock boundary"
+
+	cert := signCoverageCertBodyUnchecked(t, body, pub, priv)
+	_, err := Verify(cert, map[string]struct{}{hex.EncodeToString(pub): {}})
+	if err == nil {
+		t.Fatal("trusted valid signature over invalid body should fail closed")
+	}
+	if !strings.Contains(err.Error(), ErrBodyInvalid.Error()) {
+		t.Fatalf("error = %q, want body validation failure", err.Error())
+	}
+}
+
+func TestVerify_TrustedSignerKeyMustMatchEnvelopeSigner(t *testing.T) {
+	t.Parallel()
+	pub, priv := genTestKey(t)
+	otherPub, _ := genTestKey(t)
+	body := validBody(pub)
+	body.TrustedSignerKey = hex.EncodeToString(otherPub)
+
+	cert := signCoverageCertBodyUnchecked(t, body, pub, priv)
+	_, err := Verify(cert, map[string]struct{}{hex.EncodeToString(pub): {}})
+	if err == nil {
+		t.Fatal("trusted signature with mismatched trusted_signer_key should fail closed")
+	}
+	if !strings.Contains(err.Error(), "trusted_signer_key") {
+		t.Fatalf("error = %q, want trusted_signer_key mismatch", err.Error())
+	}
+}
+
+func signCoverageCertBodyUnchecked(t *testing.T, body Body, pub ed25519.PublicKey, priv ed25519.PrivateKey) Certificate {
+	t.Helper()
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage: %v", err)
+	}
+	return Certificate{
+		Body:      body,
+		Signature: hex.EncodeToString(ed25519.Sign(priv, preimage)),
+		SignerKey: hex.EncodeToString(pub),
+	}
+}
+
 func TestSign_AggregateOverclaimRejected(t *testing.T) {
 	t.Parallel()
 	pub, priv := genTestKey(t)

--- a/internal/coveragecert/coveragecert_test.go
+++ b/internal/coveragecert/coveragecert_test.go
@@ -248,6 +248,52 @@ func TestVerify_TrustedSignerKeyMustMatchEnvelopeSigner(t *testing.T) {
 	}
 }
 
+func TestValidate_TrustedSignerKeyMalformedFailsClosed(t *testing.T) {
+	t.Parallel()
+	pub, _ := genTestKey(t)
+
+	tests := []struct {
+		name      string
+		signerKey string
+		wantErr   string
+	}{
+		{
+			name:      "non hex",
+			signerKey: "not-hex",
+			wantErr:   "decode",
+		},
+		{
+			name:      "wrong length",
+			signerKey: "abcd",
+			wantErr:   "length",
+		},
+		{
+			name:      "uppercase",
+			signerKey: strings.ToUpper(hex.EncodeToString(pub)),
+			wantErr:   "lowercase hex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body := validBody(pub)
+			body.TrustedSignerKey = tt.signerKey
+
+			err := body.Validate()
+			if err == nil {
+				t.Fatal("expected malformed trusted_signer_key to fail closed")
+			}
+			if !strings.Contains(err.Error(), "trusted_signer_key") {
+				t.Fatalf("error = %q, want trusted_signer_key context", err.Error())
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
 func signCoverageCertBodyUnchecked(t *testing.T, body Body, pub ed25519.PublicKey, priv ed25519.PrivateKey) Certificate {
 	t.Helper()
 	preimage, err := body.SignablePreimage()

--- a/internal/coveragecertverify/verify_test.go
+++ b/internal/coveragecertverify/verify_test.go
@@ -59,6 +59,55 @@ func writeCoverageCertVerifyFixture(t *testing.T) (certFile, pubHex string) {
 	return certFile, hex.EncodeToString(pub)
 }
 
+func writeCoverageCertInvalidBodyFixture(t *testing.T) (certFile, pubHex string) {
+	t.Helper()
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	pubHex = hex.EncodeToString(pub)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	body := coveragecert.Body{
+		Schema:        coveragecert.Schema,
+		KeyPurpose:    coveragecert.KeyPurpose,
+		Agent:         "agent-a",
+		WindowStart:   start,
+		WindowEnd:     start.Add(time.Hour),
+		TotalReceipts: 2,
+		Sessions: []coveragecert.SessionCoverage{{
+			ID:                 "session-a",
+			ReceiptCount:       2,
+			ChainIntact:        true,
+			Anchored:           "local",
+			CompletenessStatus: "LIMITED",
+			CompletenessReason: "bounded_closed",
+		}},
+		SessionsCovered:    1,
+		ChainsIntact:       1,
+		TrustedSignerKey:   pubHex,
+		Boundary:           "Coverage of all agent activity and mediated egress inside the declared Pipelock boundary",
+		StandingExclusions: coveragecert.DefaultStandingExclusions(),
+	}
+	preimage, err := body.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage: %v", err)
+	}
+	cert := coveragecert.Certificate{
+		Body:      body,
+		Signature: hex.EncodeToString(ed25519.Sign(priv, preimage)),
+		SignerKey: pubHex,
+	}
+	data, err := coveragecert.Marshal(cert)
+	if err != nil {
+		t.Fatalf("coveragecert.Marshal: %v", err)
+	}
+	certFile = filepath.Join(t.TempDir(), "invalid-body-cert.json")
+	if err := os.WriteFile(certFile, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return certFile, pubHex
+}
+
 func TestRunTrustedSignerVerifies(t *testing.T) {
 	certFile, pubHex := writeCoverageCertVerifyFixture(t)
 	var out bytes.Buffer
@@ -94,6 +143,20 @@ func TestRunUntrustedSignerFailsClosed(t *testing.T) {
 	// The diagnostic line is still emitted before the fail-closed return.
 	if !strings.Contains(out.String(), "NOT TRUSTED") {
 		t.Fatalf("Run output = %q, want NOT TRUSTED diagnostic line", out.String())
+	}
+}
+
+func TestRunInvalidBodyFailsClosedEvenWithTrustedSignature(t *testing.T) {
+	certFile, pubHex := writeCoverageCertInvalidBodyFixture(t)
+	var out bytes.Buffer
+
+	err := Run(Options{
+		CertFile:       certFile,
+		TrustedSigners: []string{"inline=" + pubHex},
+		Out:            &out,
+	})
+	if err == nil || !strings.Contains(err.Error(), "body validation failed") {
+		t.Fatalf("Run invalid body err = %v, want body validation failure", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

The offline coverage-certificate verifier checked the envelope signature but did not re-run body structural validation or bind the signed body's declared signer key to the envelope signer. A holder of a trusted signing key could therefore sign a structurally invalid or over-claiming body (for example a boundary claiming coverage of all agent activity, or a body naming a different `trusted_signer_key`) and have `Verify` accept it.

`Verify` now re-validates the body structure so ill-formed or over-claiming bodies fail closed, and requires the body's `trusted_signer_key` to equal the certificate's `signer_key`.

## Why

A coverage certificate is meant to be independently verifiable offline. Without re-validating the body at verify time, the guarantee reduced to "some trusted key signed some bytes", which let a trusted key forge a false coverage claim that still passed verification. This restores the property that a verified certificate's body is well formed, not over-claiming, and bound to the signer it names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened coverage certificate validation with additional “fail closed” checks for malformed bodies, including stricter trusted signer key format (lowercase hex, correct Ed25519 public key length).
  * Verification now rejects certificates when the trusted signer key doesn’t match the certificate’s envelope signer key, even if the signature is otherwise valid.
* **Tests**
  * Added coverage certificate verification and validation tests to confirm failure-closed behavior for invalid bodies and signer key mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->