### PR TITLE
chore(ci): fail CI when a shipped config example cannot start

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -305,6 +305,9 @@ jobs:
       - name: Config consumption policy
         run: bash scripts/check-config-consumption.sh
 
+      - name: Config example startability policy
+        run: bash scripts/check-config-examples.sh
+
   helm:
     needs: [security-scan]
     runs-on: ubuntu-latest

--- a/docs/false-positive-tuning.md
+++ b/docs/false-positive-tuning.md
@@ -51,6 +51,7 @@ For example, enable the recorder:
 flight_recorder:
   enabled: true
   dir: /var/lib/pipelock/evidence
+  signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key   # `pipelock init` writes this next to your config
 ```
 
 The recorder keeps receipt and decision context, but sensitive content is redacted before it is written unless you explicitly configure raw escrow. Expect pattern names and redacted evidence, not plaintext secrets.

--- a/docs/guides/cline.md
+++ b/docs/guides/cline.md
@@ -73,6 +73,7 @@ flight_recorder:
   enabled: true
   dir: /var/lib/pipelock/cline-evidence
   sign_checkpoints: true
+  signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key   # `pipelock init` writes this next to your config
   redact: true
 ```
 

--- a/docs/guides/codex.md
+++ b/docs/guides/codex.md
@@ -200,6 +200,7 @@ flight_recorder:
   enabled: true
   dir: /tmp/pipelock-codex-evidence
   sign_checkpoints: true
+  signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key   # `pipelock init` writes this next to your config
   redact: true
 ```
 

--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -26,6 +26,7 @@ flight_recorder:
   redact: true                   # DLP redaction before commit (recommended)
   require_receipts: false        # fail closed before forwarding when allow receipts cannot be emitted
   sign_checkpoints: true         # Ed25519 signed checkpoints
+  signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key   # `pipelock init` writes this next to your config
   max_entries_per_file: 10000    # rotate to a new file after this many entries
   raw_escrow: false              # encrypted raw sidecar (see below)
   escrow_public_key: ""          # X25519 hex public key for raw escrow
@@ -305,6 +306,7 @@ To enable raw escrow:
 flight_recorder:
   enabled: true
   dir: /var/lib/pipelock/evidence
+  signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key   # `pipelock init` writes this next to your config
   redact: true
   raw_escrow: true
   escrow_public_key: "a1b2c3d4e5f6..."  # 32-byte X25519 key, hex-encoded

--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -309,7 +309,7 @@ flight_recorder:
   signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key   # `pipelock init` writes this next to your config
   redact: true
   raw_escrow: true
-  escrow_public_key: "a1b2c3d4e5f6..."  # 32-byte X25519 key, hex-encoded
+  escrow_public_key: "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"  # 32-byte X25519 key, 64 hex chars
 ```
 
 Generate an X25519 key pair with standard Go tooling or a library of your choice. Store the private key offline (not on the pipelock host). The escrow public key is safe to include in config.

--- a/docs/guides/opencode.md
+++ b/docs/guides/opencode.md
@@ -86,6 +86,7 @@ flight_recorder:
   enabled: true
   dir: /var/lib/pipelock/opencode-evidence
   sign_checkpoints: true
+  signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key   # `pipelock init` writes this next to your config
   redact: true
 ```
 

--- a/docs/guides/zed.md
+++ b/docs/guides/zed.md
@@ -218,6 +218,7 @@ flight_recorder:
   enabled: true
   dir: /tmp/pipelock-zed-evidence
   sign_checkpoints: true
+  signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key   # `pipelock init` writes this next to your config
   redact: true
 ```
 

--- a/scripts/check-config-examples.sh
+++ b/scripts/check-config-examples.sh
@@ -43,6 +43,22 @@ if [ -z "$BIN" ]; then
 fi
 [ -x "$BIN" ] || { echo "config-examples: no usable pipelock binary at '$BIN'" >&2; exit 1; }
 
+# Fixture a real recorder signing key. Without this the check is CIRCULAR: a snippet
+# that correctly sets signing_key_path names a file this host does not have, gets
+# skipped as environment-dependent, and is never booted — so the policy would not
+# exercise the very examples it exists to protect. A signing key is trivially
+# fixture-creatable (init generates one), so it must be fixtured, not skipped. Skips
+# are reserved for dependencies that cannot reasonably be created here (a real signed
+# license, an operator's CA). `init` writes keys/ next to the config it generates.
+FIXTURE_KEY=""
+if "$BIN" init --output "$WORK/keygen/pipelock.yaml" --skip-canary --skip-validate >/dev/null 2>&1 \
+    && [ -s "$WORK/keygen/keys/flight-recorder-signing.key" ]; then
+    FIXTURE_KEY="$WORK/keygen/keys/flight-recorder-signing.key"
+else
+    echo "config-examples: WARNING - could not fixture a recorder signing key;" >&2
+    echo "  snippets naming signing_key_path will be skipped instead of booted." >&2
+fi
+
 # Top-level keys of config.Config. A yaml block is a pipelock config only if every
 # top-level key it declares is one of these — that excludes k8s manifests, Helm
 # values, CI workflows, and JSON without hand-maintaining an ignore list.
@@ -149,6 +165,13 @@ probe() {
         >"$run_cfg"
     mkdir -p "$WORK/d$total"
 
+    # Point signing_key_path at the fixtured key so a snippet that correctly names one
+    # is BOOTED rather than skipped. This is what makes the policy actually verify the
+    # recorder examples instead of only detecting a missing key line.
+    if [ -n "$FIXTURE_KEY" ]; then
+        sed -i -E "s@^([[:space:]]*signing_key_path:[[:space:]])(\"[^\"]+\"|'[^']+'|[^\"'[:space:]#]([^#]*[^[:space:]#])?)([[:space:]]*#.*)?\$@\1\"$FIXTURE_KEY\"\4@" "$run_cfg"
+    fi
+
     local check_ok=0 check_out="$WORK/check-$total.txt"
     "$BIN" check --config "$run_cfg" >"$check_out" 2>&1 && check_ok=1
     if [ "$check_ok" -eq 0 ]; then
@@ -169,7 +192,12 @@ probe() {
         port="$(choose_port)" || { echo "config-examples: could not find a free probe port" >&2; exit 1; }
         "$BIN" run --listen "127.0.0.1:$port" --config "$run_cfg" >"$out_file" 2>&1 </dev/null &
         RUN_PID=$!
-        deadline=$((SECONDS + 10))
+        # Generous backstop, not the gate: readiness is detected the instant /health
+        # answers (~60ms), so a large deadline costs nothing on success and only
+        # protects a legitimately slow boot (cold TLS cert generation, sandbox init)
+        # on a loaded runner from being misreported as a config-shape failure. A
+        # timeout here is NOT retried, so it must not be the thing that fires first.
+        deadline=$((SECONDS + ${CONFIG_EXAMPLES_BOOT_TIMEOUT:-30}))
         while (( SECONDS < deadline )); do
             kill -0 "$RUN_PID" 2>/dev/null || break
             if http_ready "$port"; then

--- a/scripts/check-config-examples.sh
+++ b/scripts/check-config-examples.sh
@@ -169,7 +169,10 @@ probe() {
     # is BOOTED rather than skipped. This is what makes the policy actually verify the
     # recorder examples instead of only detecting a missing key line.
     if [ -n "$FIXTURE_KEY" ]; then
-        sed -i -E "s@^([[:space:]]*signing_key_path:[[:space:]])(\"[^\"]+\"|'[^']+'|[^\"'[:space:]#]([^#]*[^[:space:]#])?)([[:space:]]*#.*)?\$@\1\"$FIXTURE_KEY\"\4@" "$run_cfg"
+        local key_cfg="${run_cfg}.key.tmp"
+        sed -E "s@^([[:space:]]*signing_key_path:[[:space:]])(\"[^\"]+\"|'[^']+'|[^\"'[:space:]#]([^#]*[^[:space:]#])?)([[:space:]]*#.*)?\$@\1\"$FIXTURE_KEY\"\4@" \
+            "$run_cfg" >"$key_cfg"
+        mv "$key_cfg" "$run_cfg"
     fi
 
     local check_ok=0 check_out="$WORK/check-$total.txt"

--- a/scripts/check-config-examples.sh
+++ b/scripts/check-config-examples.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# check-config-examples.sh — shipped config snippets must actually START.
+#
+# `pipelock check` is a parse/semantic pass; it does not exercise runtime startup
+# preconditions. A snippet can therefore pass `check` and still kill `pipelock run`
+# at boot — a config we ship that bricks the user who trusted the guide.
+#
+# This catches the CLASS: any doc/example config that `check` blesses but the
+# runtime refuses. Config examples are executable claims — render and RUN them.
+#
+# Scope discipline (deliberately conservative — no false positives):
+#   Every recognized block that passes `check` is booted. A startup refusal is
+#   skipped only when its actual error identifies an unavailable external input
+#   (key/license/cert, placeholder destination, or required watched resource).
+#   Merely mentioning one cannot exempt an unrelated broken config. What remains
+#   is a pure SHAPE failure — e.g. sign_checkpoints:true with a persisted dir and
+#   no signing_key_path named at all. Skips and check rejections are both printed.
+#
+# Usage:  scripts/check-config-examples.sh [path/to/pipelock]
+# Exit:   0 = every bootable snippet starts;  1 = a shipped snippet won't start.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORK="$(mktemp -d)"
+RUN_PID=""
+cleanup() {
+    if [ -n "$RUN_PID" ]; then
+        kill -TERM "$RUN_PID" 2>/dev/null || true
+        wait "$RUN_PID" 2>/dev/null || true
+    fi
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+BIN="${1:-}"
+if [ -z "$BIN" ]; then
+    BIN="$WORK/pipelock"
+    echo "config-examples: building pipelock..."
+    go build -o "$BIN" ./cmd/pipelock
+fi
+[ -x "$BIN" ] || { echo "config-examples: no usable pipelock binary at '$BIN'" >&2; exit 1; }
+
+# Top-level keys of config.Config. A yaml block is a pipelock config only if every
+# top-level key it declares is one of these — that excludes k8s manifests, Helm
+# values, CI workflows, and JSON without hand-maintaining an ignore list.
+CONFIG_KEYS="$(sed -n '/^type Config struct {/,/^}/p' internal/config/schema.go \
+    | grep -oP 'yaml:"\K[a-z_0-9]+' | sort -u)"
+[ -n "$CONFIG_KEYS" ] || { echo "config-examples: could not read Config keys from schema.go" >&2; exit 1; }
+
+total=0; booted=0; skipped=0; rejected=0; failed=0
+FAILURES="$WORK/failures.txt"; : >"$FAILURES"
+SKIPS="$WORK/skips.txt"; : >"$SKIPS"
+REJECTED="$WORK/rejected.txt"; : >"$REJECTED"
+
+# KNOWN LIMIT (deliberate): a block is only booted when EVERY top-level key is a
+# Config field. A pipelock config carrying a typo'd top-level key (`flight_recoder:`)
+# therefore drops out of this check silently, and yaml would ignore that key at
+# runtime too. Gating on "some known + some unknown" was tried and rejected: every
+# real occurrence is a DIFFERENT schema that merely shares a key name — Helm values
+# (image/license), docker-compose (services/networks), the rules bundle
+# (format_version/tier), the policy spec — so it produced 11 noise rows and zero
+# signal, and a noisy tripwire gets deleted. The real fix is explicit fence intent
+# (mark a block complete-config vs fragment) and is tracked separately.
+is_config_block() {
+    local keys
+    keys="$(grep -oP '^[a-z_0-9]+(?=:)' "$1" 2>/dev/null | sort -u)" || return 1
+    [ -n "$keys" ] || return 1
+    while IFS= read -r k; do
+        grep -qxF "$k" <<<"$CONFIG_KEYS" || return 1
+    done <<<"$keys"
+    return 0
+}
+
+# Classify a refusal as environment-dependent only after it actually occurs.
+# Merely mentioning a path or placeholder host must not exempt the entire block:
+# allowlists, regexes, optional sentinel files, and output paths do not need those
+# resources at startup and must still exercise the runtime.
+environment_failure_reason() {
+    local cfg="$1" out="$2"
+
+    if grep -qE "^[[:space:]]*(license_file|license_crl_file|license_intermediate_file|trust_roster_path|server_ca_file|client_cert_path|client_key_path|enrollment_token_path|ca_cert|ca_key|secrets_file|signing_key_path|manifest_path|signature_path|keystore|roster_path):[[:space:]]*(\"[^\"]+\"|'[^']+'|[^\"'[:space:]#][^#]*)" "$cfg" \
+        && grep -qiE '(no such file|permission denied|not found|cannot (open|read)|failed to (open|read|load)|load(ing)? .*(file|key|cert|roster|manifest))' "$out"; then
+        echo "needs an external input file"
+        return
+    fi
+
+    if grep -qE '\.(example|invalid|test)(\.[a-z]+)?\b' "$cfg" \
+        && grep -qiE '(no such host|temporary failure in name resolution|name or service not known|network is unreachable|connection refused)' "$out"; then
+        echo "placeholder destination is unavailable"
+        return
+    fi
+
+    if grep -qE '^[[:space:]-]*required:[[:space:]]*true([[:space:]]*(#.*)?)?$' "$cfg" \
+        && grep -qiE '(file sentry|watch).*(failed|missing|no such file|permission denied)' "$out"; then
+        echo "required resource is unavailable"
+        return
+    fi
+
+    if grep -qiE 'requires an enterprise build' "$out"; then
+        echo "requires an enterprise build"
+        return
+    fi
+
+    echo ""
+}
+
+choose_port() {
+    local port i
+    for ((i=0; i<40; i++)); do
+        port=$((20000 + RANDOM % 30000))
+        if ! (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+            echo "$port"
+            return 0
+        fi
+    done
+    return 1
+}
+
+http_ready() {
+    local port="$1" status
+    status="$({
+        exec 3<>"/dev/tcp/127.0.0.1/$port"
+        printf 'GET /health HTTP/1.0\r\n\r\n' >&3
+        IFS= read -r -t 1 status <&3
+        printf '%s' "$status"
+    } 2>/dev/null)" || return 1
+    [[ "$status" == HTTP/* ]]
+}
+
+probe() {
+    local snippet="$1" label="$2"
+    is_config_block "$snippet" || return 0
+    total=$((total+1))
+
+    # Relocate runtime-created OUTPUT paths into the sandbox so a doc's /var/lib
+    # path is not a permission failure caused by this check. Covers output files
+    # (spool_file/cursor_file) as well as dirs: they are created at startup, so a
+    # doc pointing them at /var/lib fails on permissions, not on config shape.
+    # Relocating them keeps the block booted; skipping it would hollow out cover.
+    # Input dirs such as rules_dir and learn_lock.store_dir are deliberately
+    # excluded: replacing them with an empty directory could conceal a refusal.
+    local run_cfg="$WORK/run-$total.yaml"
+    sed -E "s@^([[:space:]]*(dir|profile_dir|bundle_cache_dir|durable_audit_queue_dir|quarantine_dir|capture_dir):[[:space:]])(\"[^\"]+\"|'[^']+'|[^\"'[:space:]#]([^#]*[^[:space:]#])?)([[:space:]]*#.*)?\$@\1\"$WORK/d$total\"\5@" \
+        "$snippet" \
+    | sed -E "s@^([[:space:]]*(spool_file|cursor_file):[[:space:]])(\"[^\"]+\"|'[^']+'|[^\"'[:space:]#]([^#]*[^[:space:]#])?)([[:space:]]*#.*)?\$@\1\"$WORK/d$total/\2\"\5@" \
+        >"$run_cfg"
+    mkdir -p "$WORK/d$total"
+
+    local check_ok=0 check_out="$WORK/check-$total.txt"
+    "$BIN" check --config "$run_cfg" >"$check_out" 2>&1 && check_ok=1
+    if [ "$check_ok" -eq 0 ]; then
+        rejected=$((rejected+1))
+        {
+            echo "  check rejected: $label"
+            echo "      $(grep -m1 -vE '^[[:space:]]*$' "$check_out" | head -c 180)"
+        } >>"$REJECTED"
+        return 0
+    fi
+
+    # The startup banner is printed before auxiliary and main listeners bind, so
+    # it is not a readiness marker. Complete an HTTP exchange with the main
+    # listener, then allow a short grace window for immediate post-bind failures.
+    local port out_file="$WORK/out-$total.txt" ready attempt deadline
+    for attempt in 1 2 3; do
+        ready=0
+        port="$(choose_port)" || { echo "config-examples: could not find a free probe port" >&2; exit 1; }
+        "$BIN" run --listen "127.0.0.1:$port" --config "$run_cfg" >"$out_file" 2>&1 </dev/null &
+        RUN_PID=$!
+        deadline=$((SECONDS + 10))
+        while (( SECONDS < deadline )); do
+            kill -0 "$RUN_PID" 2>/dev/null || break
+            if http_ready "$port"; then
+                ready=1
+                break
+            fi
+            sleep 0.05
+        done
+        if [ "$ready" -eq 1 ]; then
+            sleep 0.05
+        fi
+
+        if [ "$ready" -eq 1 ] && kill -0 "$RUN_PID" 2>/dev/null; then
+            kill -TERM "$RUN_PID" 2>/dev/null || true
+            wait "$RUN_PID" 2>/dev/null || true
+            RUN_PID=""
+            booted=$((booted+1))
+            return 0
+        fi
+
+        kill -TERM "$RUN_PID" 2>/dev/null || true
+        wait "$RUN_PID" 2>/dev/null || true
+        RUN_PID=""
+
+        # Port selection is necessarily check-then-bind. If another process wins
+        # that race, retry with a new port rather than creating a flaky failure.
+        grep -qE "(fetch_proxy.listen|holds) .*127\\.0\\.0\\.1:$port" "$out_file" || break
+    done
+
+    # Gate on the DIVERGENCE (check PASS + run REFUSED), not on "run refused".
+    #
+    # That is deliberate and self-limiting in the right direction. A snippet `check`
+    # also rejects is not silent — the user runs check and gets a clear error — and
+    # gating on refusal alone floods on reference docs: docs/configuration.md and
+    # docs/policy-spec-v0.1.md document ONE section per block, which by design does
+    # not stand up as a whole config ("mcp_session_binding requires
+    # mcp_tool_scanning"). Those are field references, not copy-paste configs, and
+    # `check` filters them out for free.
+    #
+    # The dangerous case is exactly the one left: we told the operator the file was
+    # VALID and then refused to boot on it. If a future release teaches `check` to
+    # reject more shapes, this reports fewer rows — that is `check` doing its job,
+    # not this going blind.
+    #
+    # Known limit: a snippet BOTH reject is reported above but is not gated.
+    local why
+    why="$(environment_failure_reason "$run_cfg" "$out_file")"
+    if [ -n "$why" ]; then
+        skipped=$((skipped+1))
+        echo "  skip ($why): $label" >>"$SKIPS"
+        return 0
+    fi
+
+    failed=$((failed+1))
+    {
+        echo "  ✗ $label"
+        echo "      check: PASS   run: REFUSED   <- validator/runtime divergence"
+        echo "      $(grep -vE '^[[:space:]]*$' "$out_file" | tail -1 | head -c 180)"
+    } >>"$FAILURES"
+}
+
+mapfile -t FILES < <(git ls-files \
+    'docs/*.md' 'docs/**/*.md' \
+    'examples/**/*.yaml' 'examples/**/*.yml' \
+    'charts/**/examples/*.yaml' \
+    'configs/*.yaml' 2>/dev/null | sort -u)
+
+for f in "${FILES[@]}"; do
+    [ -f "$f" ] || continue
+    case "$f" in
+    *.md)
+        tag="$(tr '/' '_' <<<"$f")"
+        awk -v outdir="$WORK" -v tag="$tag" '
+            { sub(/\r$/, "") }
+            /^[ ]?[ ]?[ ]?```ya?ml[[:space:]]*$/ { n++; inblk=1; out=outdir "/" tag "-" n ".yaml"; next }
+            /^[ ]?[ ]?[ ]?```/                    { inblk=0; next }
+            inblk        { print > out }
+        ' "$f"
+        n=0
+        while :; do
+            n=$((n+1))
+            blk="$WORK/$tag-$n.yaml"
+            [ -f "$blk" ] || break
+            probe "$blk" "$f (yaml block $n)"
+        done
+        ;;
+    *)
+        probe "$f" "$f"
+        ;;
+    esac
+done
+
+echo ""
+echo "config-examples: $total config blocks | $booted booted OK | $skipped skipped | $rejected check-rejected | $failed FAILED"
+[ "$skipped" -gt 0 ] && { echo "skipped (not silently dropped):"; cat "$SKIPS"; }
+[ "$rejected" -gt 0 ] && { echo "rejected by pipelock check (reference fragments, not gated):"; cat "$REJECTED"; }
+
+if [ "$failed" -gt 0 ]; then
+    echo ""
+    echo "FAIL: shipped config snippet(s) pass 'pipelock check' but will not start:"
+    cat "$FAILURES"
+    echo ""
+    echo "Each is a config a user can copy-paste that bricks their install."
+    echo "Fix the snippet, or make 'pipelock check' reject the shape so the"
+    echo "validator and the runtime agree."
+    exit 1
+fi
+
+echo "config-examples: OK"


### PR DESCRIPTION
## What changed

`pipelock check` is a parse and semantic pass. It does not exercise runtime startup preconditions, so a config can pass `check` and still refuse to boot. That means we can tell an operator a file is valid and then fail to start on it, which is a validator/runtime divergence an operator cannot debug from the tooling we hand them.

Seven shipped snippets were in exactly that state. A persisting flight recorder with `sign_checkpoints` (which defaults to `true`) and no `signing_key_path` is a hard startup error. The four IDE guides, the flight-recorder guide's own two recorder examples, and the false-positive-tuning guide each documented that shape. `false-positive-tuning.md` never mentioned signing at all and still failed, because the default alone is enough to trip it. Every one of them now sets `signing_key_path`.

`pipelock init` and the `configs/*.yaml` presets were already correct and are unchanged. The break lived only in hand-written guide snippets, which is the one surface no existing check rendered.

## The check

`scripts/check-config-examples.sh` runs in the lint job next to the existing policy checks. It extracts every yaml block from `docs/`, `examples/`, `charts/*/examples/` and `configs/`, identifies pipelock configs by reading the `Config` struct tags out of `schema.go` so it cannot drift from the schema, boots each one against a real binary, and fails when `check` passes a config the runtime refuses.

Three decisions are load-bearing and are commented in the script:

Readiness is a real HTTP exchange with the listener, not the startup banner. The banner is printed before the listeners bind, so a config with an unusable listen address would otherwise be counted as booted.

A refusal is classified as environment-dependent only from the error it actually produced. Merely mentioning a key path or a placeholder host cannot exempt an unrelated broken config. Runtime-created output paths are relocated into a sandbox rather than skipped, while input dirs are deliberately left alone because substituting an empty directory could conceal a real refusal.

Blocks that `check` rejects are reported rather than gated. Reference docs such as `configuration.md` and `policy-spec-v0.1.md` document one config section per block by design and cannot stand up as whole configs, and `check` already surfaces those to a user directly.

## Coverage

180 config blocks, 145 booted, 13 skipped, 22 check-rejected, 0 failed, about 30 seconds.

Known limit, documented in the script: a config carrying a typo'd top-level key drops out silently, because gating on mixed known/unknown keys produced only false positives (Helm values, docker-compose, the rules bundle and the policy spec all share key names with `Config`). The durable fix is explicit fence intent, marking a block as a complete config or a fragment, and is tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated flight recorder and evidence/audit trail configuration examples across product guides to include `signing_key_path`, with notes about where initialization writes the signing key.

* **Bug Fixes**
  * Improved validation of published configuration snippets by detecting cases where snippets pass checks but cannot start at runtime.

* **Chores**
  * Added a CI lint policy step that runs a startability scan for configuration examples using an automated local boot test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->