### PR TITLE
Fix A2A forward request-body scanning

### DIFF
--- a/enterprise/siemforward/forwarder_test.go
+++ b/enterprise/siemforward/forwarder_test.go
@@ -663,7 +663,18 @@ func TestForwarderConcurrentCloseReplaysAcceptedEventsAtLeastOnce(t *testing.T) 
 	if err != nil {
 		t.Fatalf("New after shutdown: %v", err)
 	}
-	waitFor(t, func() bool { return received.Load() >= accepted.Load() })
+	waitFor(t, func() bool {
+		acceptedMu.Lock()
+		defer acceptedMu.Unlock()
+		receivedMu.Lock()
+		defer receivedMu.Unlock()
+		for sequence := range acceptedSequences {
+			if receivedBySequence[sequence] == 0 {
+				return false
+			}
+		}
+		return true
+	})
 	if err := f2.Close(); err != nil {
 		t.Fatalf("Close restarted forwarder: %v", err)
 	}

--- a/examples/kill-switch/verify.sh
+++ b/examples/kill-switch/verify.sh
@@ -85,8 +85,12 @@ wait_for_health() {
 health_field() {
   local port="$1"
   local field="$2"
-  curl -sf "http://127.0.0.1:${port}/health" | python3 -c \
-    'import json,sys; print(json.load(sys.stdin).get(sys.argv[1],""))' "$field"
+  local health_json
+  health_json="$(mktemp "$WORK/health.XXXXXX.json")"
+  curl -sf -o "$health_json" "http://127.0.0.1:${port}/health"
+  python3 -c \
+    'import json,sys; print(json.load(open(sys.argv[2], encoding="utf-8")).get(sys.argv[1],""))' \
+    "$field" "$health_json"
 }
 
 start_echo() {

--- a/internal/mcp/a2a_scan_test.go
+++ b/internal/mcp/a2a_scan_test.go
@@ -498,6 +498,42 @@ func TestScanAgentCard_BenignURLFieldsPass(t *testing.T) {
 	}
 }
 
+func TestScanAgentCard_BenignSecurityToolPasses(t *testing.T) {
+	cfg := enabledA2ACfg()
+	cfg.DetectCardDrift = false
+	scannerCfg := config.Defaults()
+	scannerCfg.Internal = nil
+	sc := scanner.MustNew(scannerCfg)
+	defer sc.Close()
+
+	card := A2AAgentCard{
+		Name:        "security-scanner",
+		Description: "Scans code repositories for vulnerabilities and security issues.",
+		URL:         "https://security.example.com/agent",
+		Skills: []A2ASkill{
+			{
+				ID:          "scan",
+				Name:        "Vulnerability Scan",
+				Description: "Scans for SQL injection, XSS, command injection, and other OWASP Top 10 vulnerabilities.",
+			},
+			{
+				ID:          "report",
+				Name:        "Security Report",
+				Description: "Generates a security assessment report with findings and remediation steps.",
+			},
+		},
+	}
+	body, err := json.Marshal(card)
+	if err != nil {
+		t.Fatalf("marshal card: %v", err)
+	}
+	result := ScanAgentCard(context.Background(), body, sc, NewCardBaseline(10),
+		CardCacheKeyFromRequest("https://security.example.com/.well-known/agent-card.json", ""), cfg)
+	if !result.Clean {
+		t.Fatalf("benign security Agent Card should pass: %+v", result)
+	}
+}
+
 func TestScanAgentCard_DriftDetection(t *testing.T) {
 	card1 := A2AAgentCard{
 		Name:   "Agent",

--- a/internal/mcp/a2a_scan_test.go
+++ b/internal/mcp/a2a_scan_test.go
@@ -736,7 +736,9 @@ func TestScanA2ARequestBody_URLFieldScanned(t *testing.T) {
 
 func TestScanA2ARequestBody_FilePartURISSRFScanned(t *testing.T) {
 	cfg := enabledA2ACfg()
-	sc := scanner.MustNew(config.Defaults())
+	scanCfg := config.Defaults()
+	scanCfg.Internal = []string{"169.254.0.0/16"}
+	sc := scanner.MustNew(scanCfg)
 	defer sc.Close()
 
 	body := []byte(`{"jsonrpc":"2.0","id":"req-012","method":"message/send","params":{"message":{"messageId":"msg-012","role":"user","parts":[{"kind":"file","file":{"uri":"http://169.254.169.254/latest/meta-data/iam/security-credentials/","mimeType":"text/plain"}}]}}}`)
@@ -746,6 +748,9 @@ func TestScanA2ARequestBody_FilePartURISSRFScanned(t *testing.T) {
 	}
 	if len(result.URLFindings) == 0 {
 		t.Fatal("expected URL finding for FilePart URI")
+	}
+	if got := result.URLFindings[0].Scanner; got != scanner.ScannerSSRFMetadata {
+		t.Fatalf("URL scanner = %s, want %s", got, scanner.ScannerSSRFMetadata)
 	}
 }
 

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1344,6 +1344,56 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// A2A request body scanning: field-aware classification of JSON leaves.
+		// Generic body DLP sees opaque text, but A2A file/url fields need the
+		// protocol-aware URL scanner so non-text FilePart URIs cannot bypass
+		// SSRF protections on the plain forward-proxy path.
+		if isA2A && buf != nil {
+			a2aBodyResult := mcp.ScanA2ARequestBody(r.Context(), buf, sc, &cfg.A2AScanning)
+			if !a2aBodyResult.Clean {
+				if !a2aBodyResult.IsInfrastructureError() {
+					hasFinding = true
+				}
+				action := a2aBodyResult.Action
+				if action == "" {
+					action = cfg.A2AScanning.Action
+				}
+				reason := a2aBodyResult.Reason
+				if reason == "" {
+					reason = "a2a: request body finding"
+				}
+				if action == config.ActionAsk || (action == config.ActionBlock && cfg.EnforceEnabled()) {
+					p.logger.LogBlocked(actx, scannerLabelA2A, reason)
+					emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
+						ActionID:            actionID,
+						Verdict:             config.ActionBlock,
+						Layer:               scannerLabelA2A,
+						Pattern:             reason,
+						Transport:           "forward",
+						Method:              r.Method,
+						Target:              targetURL,
+						RequestID:           requestID,
+						Agent:               agent,
+						SessionTaintLevel:   forwardTaint.Risk.Level.String(),
+						SessionContaminated: forwardTaint.Risk.Contaminated,
+						RecentTaintSources:  forwardTaint.Risk.Sources,
+						SessionTaskID:       forwardTaint.Task.CurrentTaskID,
+						SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
+						AuthorityKind:       forwardTaint.Authority.String(),
+						TaintDecision:       forwardTaint.Result.Decision.String(),
+						TaintDecisionReason: forwardTaint.Result.Reason,
+						TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
+					}))
+					p.metrics.RecordBlocked(r.URL.Hostname(), scannerLabelA2A, time.Since(start), agentLabel)
+					writeBlockedError(w,
+						blockInfoFor(blockreason.DLPMatch, scannerLabelA2A),
+						"blocked: "+reason, http.StatusForbidden)
+					return
+				}
+				p.logger.LogAnomaly(actx, scannerLabelA2A, reason, 0.8)
+			}
+		}
+
 		// Re-wrap body so the forwarded request gets the buffered bytes.
 		// GetBody is set so stdlib can replay on 307/308 redirects when
 		// the forward proxy's client follows a method-preserving hop.

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1124,6 +1124,96 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// the signer would have to re-drain req.Body itself and the caller
 	// would lose deterministic bookkeeping about byte counts.
 	var forwardBodyBytes []byte
+	scanA2AForwardBody := func(buf []byte) bool {
+		a2aBodyResult := mcp.ScanA2ARequestBody(r.Context(), buf, sc, &cfg.A2AScanning)
+		if a2aBodyResult.Clean {
+			return false
+		}
+		if !a2aBodyResult.IsInfrastructureError() {
+			hasFinding = true
+		}
+		action := a2aBodyResult.Action
+		if action == "" {
+			action = cfg.A2AScanning.Action
+		}
+		reason := a2aBodyResult.Reason
+		if reason == "" {
+			reason = "a2a: request body finding"
+		}
+		if action == config.ActionAsk || (action == config.ActionBlock && cfg.EnforceEnabled()) {
+			p.logger.LogBlocked(actx, scannerLabelA2A, reason)
+			blockReason := a2aBodyBlockReason(a2aBodyResult)
+			emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
+				ActionID:            actionID,
+				Verdict:             config.ActionBlock,
+				Layer:               scannerLabelA2A,
+				Pattern:             reason,
+				Transport:           "forward",
+				Method:              r.Method,
+				Target:              targetURL,
+				RequestID:           requestID,
+				Agent:               agent,
+				SessionTaintLevel:   forwardTaint.Risk.Level.String(),
+				SessionContaminated: forwardTaint.Risk.Contaminated,
+				RecentTaintSources:  forwardTaint.Risk.Sources,
+				SessionTaskID:       forwardTaint.Task.CurrentTaskID,
+				SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
+				AuthorityKind:       forwardTaint.Authority.String(),
+				TaintDecision:       forwardTaint.Result.Decision.String(),
+				TaintDecisionReason: forwardTaint.Result.Reason,
+				TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
+			}))
+			p.metrics.RecordBlocked(r.URL.Hostname(), scannerLabelA2A, time.Since(start), agentLabel)
+			writeBlockedError(w,
+				blockInfoFor(blockReason, scannerLabelA2A),
+				"blocked: "+reason, http.StatusForbidden)
+			return true
+		}
+		p.logger.LogAnomaly(actx, scannerLabelA2A, reason, 0.8)
+		return false
+	}
+	if !cfg.RequestBodyScanning.Enabled && isA2A && cfg.A2AScanning.Enabled && r.Body != nil && r.Body != http.NoBody {
+		buf, err := readForwardBodyForProtocolScan(r.Body, r.Header.Get("Content-Encoding"), cfg.RequestBodyScanning.MaxBodyBytes)
+		if err != nil {
+			reason := "a2a: " + err.Error()
+			p.logger.LogBlocked(actx, scannerLabelA2A, reason)
+			emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
+				ActionID:            actionID,
+				Verdict:             config.ActionBlock,
+				Layer:               scannerLabelA2A,
+				Pattern:             reason,
+				Transport:           "forward",
+				Method:              r.Method,
+				Target:              targetURL,
+				RequestID:           requestID,
+				Agent:               agent,
+				SessionTaintLevel:   forwardTaint.Risk.Level.String(),
+				SessionContaminated: forwardTaint.Risk.Contaminated,
+				RecentTaintSources:  forwardTaint.Risk.Sources,
+				SessionTaskID:       forwardTaint.Task.CurrentTaskID,
+				SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
+				AuthorityKind:       forwardTaint.Authority.String(),
+				TaintDecision:       forwardTaint.Result.Decision.String(),
+				TaintDecisionReason: forwardTaint.Result.Reason,
+				TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
+			}))
+			p.metrics.RecordBlocked(r.URL.Hostname(), scannerLabelA2A, time.Since(start), agentLabel)
+			writeBlockedError(w,
+				blockInfoFor(blockreason.ParseError, scannerLabelA2A),
+				"blocked: "+reason, http.StatusForbidden)
+			return
+		}
+		if scanA2AForwardBody(buf) {
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewReader(buf))
+		r.ContentLength = int64(len(buf))
+		bufCopy := buf
+		r.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bufCopy)), nil
+		}
+		forwardBodyBytes = buf
+	}
 	if cfg.RequestBodyScanning.Enabled && r.Body != nil && r.Body != http.NoBody {
 		bodyReq := BodyScanRequest{
 			Body:            r.Body,
@@ -1348,51 +1438,8 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		// Generic body DLP sees opaque text, but A2A file/url fields need the
 		// protocol-aware URL scanner so non-text FilePart URIs cannot bypass
 		// SSRF protections on the plain forward-proxy path.
-		if isA2A && buf != nil {
-			a2aBodyResult := mcp.ScanA2ARequestBody(r.Context(), buf, sc, &cfg.A2AScanning)
-			if !a2aBodyResult.Clean {
-				if !a2aBodyResult.IsInfrastructureError() {
-					hasFinding = true
-				}
-				action := a2aBodyResult.Action
-				if action == "" {
-					action = cfg.A2AScanning.Action
-				}
-				reason := a2aBodyResult.Reason
-				if reason == "" {
-					reason = "a2a: request body finding"
-				}
-				if action == config.ActionAsk || (action == config.ActionBlock && cfg.EnforceEnabled()) {
-					p.logger.LogBlocked(actx, scannerLabelA2A, reason)
-					blockReason := a2aBodyBlockReason(a2aBodyResult)
-					emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
-						ActionID:            actionID,
-						Verdict:             config.ActionBlock,
-						Layer:               scannerLabelA2A,
-						Pattern:             reason,
-						Transport:           "forward",
-						Method:              r.Method,
-						Target:              targetURL,
-						RequestID:           requestID,
-						Agent:               agent,
-						SessionTaintLevel:   forwardTaint.Risk.Level.String(),
-						SessionContaminated: forwardTaint.Risk.Contaminated,
-						RecentTaintSources:  forwardTaint.Risk.Sources,
-						SessionTaskID:       forwardTaint.Task.CurrentTaskID,
-						SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
-						AuthorityKind:       forwardTaint.Authority.String(),
-						TaintDecision:       forwardTaint.Result.Decision.String(),
-						TaintDecisionReason: forwardTaint.Result.Reason,
-						TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
-					}))
-					p.metrics.RecordBlocked(r.URL.Hostname(), scannerLabelA2A, time.Since(start), agentLabel)
-					writeBlockedError(w,
-						blockInfoFor(blockReason, scannerLabelA2A),
-						"blocked: "+reason, http.StatusForbidden)
-					return
-				}
-				p.logger.LogAnomaly(actx, scannerLabelA2A, reason, 0.8)
-			}
+		if isA2A && cfg.A2AScanning.Enabled && buf != nil && scanA2AForwardBody(buf) {
+			return
 		}
 
 		// Re-wrap body so the forwarded request gets the buffered bytes.
@@ -2563,6 +2610,21 @@ func a2aBodyBlockReason(result mcp.A2AScanResult) blockreason.Reason {
 		return blockreason.DLPMatch
 	}
 	return blockreason.ParseError
+}
+
+func readForwardBodyForProtocolScan(body io.Reader, contentEncoding string, maxBytes int) ([]byte, error) {
+	if hasNonIdentityEncoding(contentEncoding) {
+		return nil, fmt.Errorf("request body uses Content-Encoding %q; compressed bodies cannot be scanned", contentEncoding)
+	}
+
+	buf, err := io.ReadAll(io.LimitReader(body, int64(maxBytes)+1))
+	if err != nil {
+		return nil, fmt.Errorf("error reading request body: %w", err)
+	}
+	if len(buf) > maxBytes {
+		return nil, fmt.Errorf("request body exceeds max_body_bytes (%d)", maxBytes)
+	}
+	return buf, nil
 }
 
 // copyResponseHeaders copies upstream response headers to the client response,

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1364,6 +1364,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 				if action == config.ActionAsk || (action == config.ActionBlock && cfg.EnforceEnabled()) {
 					p.logger.LogBlocked(actx, scannerLabelA2A, reason)
+					blockReason := a2aBodyBlockReason(a2aBodyResult)
 					emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
 						ActionID:            actionID,
 						Verdict:             config.ActionBlock,
@@ -1386,7 +1387,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 					}))
 					p.metrics.RecordBlocked(r.URL.Hostname(), scannerLabelA2A, time.Since(start), agentLabel)
 					writeBlockedError(w,
-						blockInfoFor(blockreason.DLPMatch, scannerLabelA2A),
+						blockInfoFor(blockReason, scannerLabelA2A),
 						"blocked: "+reason, http.StatusForbidden)
 					return
 				}
@@ -2549,6 +2550,19 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
 		recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), cfg.AdaptiveEnforcement.DecayPerCleanRequest)
 	}
+}
+
+func a2aBodyBlockReason(result mcp.A2AScanResult) blockreason.Reason {
+	if len(result.URLFindings) > 0 {
+		return reasonFromScanner(result.URLFindings[0].Scanner)
+	}
+	if len(result.InjectFindings) > 0 {
+		return blockreason.PromptInjection
+	}
+	if len(result.DLPFindings) > 0 {
+		return blockreason.DLPMatch
+	}
+	return blockreason.ParseError
 }
 
 // copyResponseHeaders copies upstream response headers to the client response,

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -419,6 +419,48 @@ func TestForwardLiveLock_ScannerBlockWinsOverContractAllow(t *testing.T) {
 	}
 }
 
+func TestForwardA2ARequestBodyFilePartURIBlocked(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"req-012","result":{"ok":true}}`))
+	}))
+	defer backend.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.Internal = []string{"169.254.0.0/16"}
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = config.ActionBlock
+		cfg.RequestBodyScanning.Enabled = true
+		cfg.RequestBodyScanning.Action = config.ActionWarn
+	})
+	defer cleanup()
+	installForwardTestDialer(p, backend.Listener.Addr().String())
+
+	body := `{"jsonrpc":"2.0","id":"req-012","method":"message/send","params":{"message":{"messageId":"msg-012","role":"user","parts":[{"kind":"file","file":{"uri":"http://169.254.169.254/latest/meta-data/iam/security-credentials/","mimeType":"text/plain"}}]}}}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/message:send", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/a2a+json")
+
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.SSRFPrivateIP) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.SSRFPrivateIP)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
 func TestForwardLiveLock_ShadowModeObservesWithoutBlocking(t *testing.T) {
 	var hits atomic.Int32
 	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -503,6 +503,147 @@ func TestForwardA2ARequestBodyFilePartURIBlockedWithGenericBodyScanningDisabled(
 	}
 }
 
+func TestForwardA2ARequestBodyForwardedWithGenericBodyScanningDisabled(t *testing.T) {
+	var gotBody atomic.Value
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read upstream body: %v", err)
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		gotBody.Store(string(body))
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"req-013","result":{"ok":true}}`))
+	}))
+	defer backend.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = config.ActionBlock
+		cfg.RequestBodyScanning.Enabled = false
+	})
+	defer cleanup()
+	installForwardTestDialer(p, backend.Listener.Addr().String())
+
+	body := `{"jsonrpc":"2.0","id":"req-013","method":"message/send","params":{"message":{"messageId":"msg-013","role":"user","parts":[{"kind":"text","text":"hello"}]}}}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/message:send", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/a2a+json")
+
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got, ok := gotBody.Load().(string); !ok || got != body {
+		t.Fatalf("upstream body = %q, want %q", got, body)
+	}
+}
+
+func TestForwardA2ARequestBodyFailsClosedWithGenericBodyScanningDisabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		config   func(*config.Config)
+		request  func(*http.Request)
+		rawShort bool
+	}{
+		{
+			name: "compressed",
+			body: `{"jsonrpc":"2.0","id":"req-014","method":"message/send","params":{"message":{"messageId":"msg-014","role":"user","parts":[{"kind":"text","text":"hello"}]}}}`,
+			request: func(req *http.Request) {
+				req.Header.Set("Content-Encoding", "gzip")
+			},
+		},
+		{
+			name: "oversized",
+			body: `{"jsonrpc":"2.0","id":"req-015","method":"message/send","params":{"message":{"messageId":"msg-015","role":"user","parts":[{"kind":"text","text":"hello"}]}}}`,
+			config: func(cfg *config.Config) {
+				cfg.RequestBodyScanning.MaxBodyBytes = 8
+			},
+		},
+		{
+			name:     "read error",
+			body:     `{"jsonrpc":"2.0","id":"req-016"`,
+			rawShort: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var hits atomic.Int32
+			backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				hits.Add(1)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"req","result":{"ok":true}}`))
+			}))
+			defer backend.Close()
+
+			proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+				cfg.A2AScanning.Enabled = true
+				cfg.A2AScanning.Action = config.ActionBlock
+				cfg.RequestBodyScanning.Enabled = false
+				if tt.config != nil {
+					tt.config(cfg)
+				}
+			})
+			defer cleanup()
+			installForwardTestDialer(p, backend.Listener.Addr().String())
+
+			var resp *http.Response
+			var err error
+			if tt.rawShort {
+				resp, err = rawA2AForwardRequestWithShortBody(t, proxyAddr, tt.body, len(tt.body)+32)
+			} else {
+				req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/message:send", strings.NewReader(tt.body))
+				if reqErr != nil {
+					t.Fatalf("NewRequest: %v", reqErr)
+				}
+				req.Header.Set("Content-Type", "application/a2a+json")
+				if tt.request != nil {
+					tt.request(req)
+				}
+				resp, err = forwardHTTPClient(t, proxyAddr).Do(req)
+			}
+			if err != nil {
+				t.Fatalf("forward request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403", resp.StatusCode)
+			}
+			if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.ParseError) {
+				t.Fatalf("block reason = %q, want %s", got, blockreason.ParseError)
+			}
+			if hits.Load() != 0 {
+				t.Fatalf("upstream hits = %d, want 0", hits.Load())
+			}
+		})
+	}
+}
+
+func rawA2AForwardRequestWithShortBody(t *testing.T, proxyAddr, body string, contentLength int) (*http.Response, error) {
+	t.Helper()
+	conn, err := (&net.Dialer{Timeout: 2 * time.Second}).DialContext(t.Context(), "tcp", proxyAddr)
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	_, err = fmt.Fprintf(conn, "POST http://api.example.com/message:send HTTP/1.1\r\nHost: api.example.com\r\nContent-Type: application/a2a+json\r\nContent-Length: %d\r\n\r\n%s", contentLength, body)
+	if err != nil {
+		return nil, err
+	}
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		_ = tcpConn.CloseWrite()
+	}
+	return http.ReadResponse(bufio.NewReader(conn), nil)
+}
+
 func TestA2ABodyBlockReason(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -462,6 +462,47 @@ func TestForwardA2ARequestBodyFilePartURIBlocked(t *testing.T) {
 	}
 }
 
+func TestForwardA2ARequestBodyFilePartURIBlockedWithGenericBodyScanningDisabled(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"req-012","result":{"ok":true}}`))
+	}))
+	defer backend.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.Internal = []string{"169.254.0.0/16"}
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = config.ActionBlock
+		cfg.RequestBodyScanning.Enabled = false
+	})
+	defer cleanup()
+	installForwardTestDialer(p, backend.Listener.Addr().String())
+
+	body := `{"jsonrpc":"2.0","id":"req-012","method":"message/send","params":{"message":{"messageId":"msg-012","role":"user","parts":[{"kind":"file","file":{"uri":"http://169.254.169.254/latest/meta-data/iam/security-credentials/","mimeType":"text/plain"}}]}}}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/message:send", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/a2a+json")
+
+	resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.SSRFPrivateIP) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.SSRFPrivateIP)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
 func TestA2ABodyBlockReason(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -439,7 +439,7 @@ func TestForwardA2ARequestBodyFilePartURIBlocked(t *testing.T) {
 	installForwardTestDialer(p, backend.Listener.Addr().String())
 
 	body := `{"jsonrpc":"2.0","id":"req-012","method":"message/send","params":{"message":{"messageId":"msg-012","role":"user","parts":[{"kind":"file","file":{"uri":"http://169.254.169.254/latest/meta-data/iam/security-credentials/","mimeType":"text/plain"}}]}}}`
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/message:send", strings.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, backend.URL+"/message:send", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
@@ -454,8 +454,8 @@ func TestForwardA2ARequestBodyFilePartURIBlocked(t *testing.T) {
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403", resp.StatusCode)
 	}
-	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.SSRFPrivateIP) {
-		t.Fatalf("block reason = %q, want %s", got, blockreason.SSRFPrivateIP)
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.SSRFMetadata) {
+		t.Fatalf("block reason = %q, want %s; layer=%q", got, blockreason.SSRFMetadata, resp.Header.Get(blockreason.HeaderLayer))
 	}
 	if hits.Load() != 0 {
 		t.Fatalf("upstream hits = %d, want 0", hits.Load())
@@ -480,7 +480,7 @@ func TestForwardA2ARequestBodyFilePartURIBlockedWithGenericBodyScanningDisabled(
 	installForwardTestDialer(p, backend.Listener.Addr().String())
 
 	body := `{"jsonrpc":"2.0","id":"req-012","method":"message/send","params":{"message":{"messageId":"msg-012","role":"user","parts":[{"kind":"file","file":{"uri":"http://169.254.169.254/latest/meta-data/iam/security-credentials/","mimeType":"text/plain"}}]}}}`
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/message:send", strings.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, backend.URL+"/message:send", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
@@ -495,7 +495,72 @@ func TestForwardA2ARequestBodyFilePartURIBlockedWithGenericBodyScanningDisabled(
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403", resp.StatusCode)
 	}
-	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.SSRFPrivateIP) {
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.SSRFMetadata) {
+		t.Fatalf("block reason = %q, want %s; layer=%q", got, blockreason.SSRFMetadata, resp.Header.Get(blockreason.HeaderLayer))
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestForwardA2ARequestBodyDirectBlockWithGenericBodyScanningDisabled(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"req-013","result":{"ok":true}}`))
+	}))
+	defer backend.Close()
+
+	_, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.Internal = []string{"10.0.0.0/8"}
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = config.ActionBlock
+		cfg.RequestBodyScanning.Enabled = false
+	})
+	defer cleanup()
+
+	body := `{"jsonrpc":"2.0","id":"req-013","method":"message/send","params":{"message":{"messageId":"msg-013","role":"user","parts":[{"kind":"file","file":{"uri":"http://10.0.0.5/private/object","mimeType":"text/plain"}}]}}}`
+	req := newA2AForwardBodyRequest(t, backend.URL+"/message:send", body)
+	w := httptest.NewRecorder()
+	p.handleForwardHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get(blockreason.HeaderReason); got != string(blockreason.SSRFPrivateIP) {
+		t.Fatalf("block reason = %q, want %s", got, blockreason.SSRFPrivateIP)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestForwardA2ARequestBodyDirectBlockAfterGenericBodyScanningWarn(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"req-014","result":{"ok":true}}`))
+	}))
+	defer backend.Close()
+
+	_, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.Internal = []string{"10.0.0.0/8"}
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = config.ActionBlock
+		cfg.RequestBodyScanning.Enabled = true
+		cfg.RequestBodyScanning.Action = config.ActionWarn
+	})
+	defer cleanup()
+
+	body := `{"jsonrpc":"2.0","id":"req-014","method":"message/send","params":{"message":{"messageId":"msg-014","role":"user","parts":[{"kind":"file","file":{"uri":"http://10.0.0.5/private/object","mimeType":"text/plain"}}]}}}`
+	req := newA2AForwardBodyRequest(t, backend.URL+"/message:send", body)
+	w := httptest.NewRecorder()
+	p.handleForwardHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get(blockreason.HeaderReason); got != string(blockreason.SSRFPrivateIP) {
 		t.Fatalf("block reason = %q, want %s", got, blockreason.SSRFPrivateIP)
 	}
 	if hits.Load() != 0 {
@@ -526,7 +591,7 @@ func TestForwardA2ARequestBodyForwardedWithGenericBodyScanningDisabled(t *testin
 	installForwardTestDialer(p, backend.Listener.Addr().String())
 
 	body := `{"jsonrpc":"2.0","id":"req-013","method":"message/send","params":{"message":{"messageId":"msg-013","role":"user","parts":[{"kind":"text","text":"hello"}]}}}`
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/message:send", strings.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://api.example.com/message:send", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
@@ -543,6 +608,56 @@ func TestForwardA2ARequestBodyForwardedWithGenericBodyScanningDisabled(t *testin
 	}
 	if got, ok := gotBody.Load().(string); !ok || got != body {
 		t.Fatalf("upstream body = %q, want %q", got, body)
+	}
+}
+
+func TestForwardA2ARequestBodyWarnModeForwardsAndReplaysBufferedBody(t *testing.T) {
+	var gotBody atomic.Value
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read upstream body: %v", err)
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		gotBody.Store(string(body))
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"req-015","result":{"ok":true}}`))
+	}))
+	defer backend.Close()
+
+	_, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.Internal = []string{"10.0.0.0/8"}
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = config.ActionWarn
+		cfg.RequestBodyScanning.Enabled = false
+	})
+	defer cleanup()
+
+	body := `{"jsonrpc":"2.0","id":"req-015","method":"message/send","params":{"message":{"messageId":"msg-015","role":"user","parts":[{"kind":"file","file":{"uri":"http://10.0.0.5/private/object","mimeType":"text/plain"}}]}}}`
+	req := newA2AForwardBodyRequest(t, backend.URL+"/message:send", body)
+	w := httptest.NewRecorder()
+	p.handleForwardHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if got, ok := gotBody.Load().(string); !ok || got != body {
+		t.Fatalf("upstream body = %q, want %q", got, body)
+	}
+	if req.GetBody == nil {
+		t.Fatal("GetBody was not installed")
+	}
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatalf("GetBody: %v", err)
+	}
+	defer func() { _ = replay.Close() }()
+	replayBody, err := io.ReadAll(replay)
+	if err != nil {
+		t.Fatalf("read replay body: %v", err)
+	}
+	if string(replayBody) != body {
+		t.Fatalf("replay body = %q, want %q", string(replayBody), body)
 	}
 }
 
@@ -599,7 +714,7 @@ func TestForwardA2ARequestBodyFailsClosedWithGenericBodyScanningDisabled(t *test
 			if tt.rawShort {
 				resp, err = rawA2AForwardRequestWithShortBody(t, proxyAddr, tt.body, len(tt.body)+32)
 			} else {
-				req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://api.example.com/message:send", strings.NewReader(tt.body))
+				req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://api.example.com/message:send", strings.NewReader(tt.body))
 				if reqErr != nil {
 					t.Fatalf("NewRequest: %v", reqErr)
 				}
@@ -627,6 +742,17 @@ func TestForwardA2ARequestBodyFailsClosedWithGenericBodyScanningDisabled(t *test
 	}
 }
 
+func newA2AForwardBodyRequest(t *testing.T, targetURL, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, targetURL, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/a2a+json")
+	req.RemoteAddr = "127.0.0.1:12345"
+	return req
+}
+
 func rawA2AForwardRequestWithShortBody(t *testing.T, proxyAddr, body string, contentLength int) (*http.Response, error) {
 	t.Helper()
 	conn, err := (&net.Dialer{Timeout: 2 * time.Second}).DialContext(t.Context(), "tcp", proxyAddr)
@@ -634,6 +760,7 @@ func rawA2AForwardRequestWithShortBody(t *testing.T, proxyAddr, body string, con
 		return nil, err
 	}
 	t.Cleanup(func() { _ = conn.Close() })
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
 	_, err = fmt.Fprintf(conn, "POST http://api.example.com/message:send HTTP/1.1\r\nHost: api.example.com\r\nContent-Type: application/a2a+json\r\nContent-Length: %d\r\n\r\n%s", contentLength, body)
 	if err != nil {
 		return nil, err
@@ -656,6 +783,13 @@ func TestA2ABodyBlockReason(t *testing.T) {
 				URLFindings: []scanner.Result{{Scanner: scanner.ScannerSSRF}},
 			},
 			want: blockreason.SSRFPrivateIP,
+		},
+		{
+			name: "url metadata ssrf",
+			result: mcp.A2AScanResult{
+				URLFindings: []scanner.Result{{Scanner: scanner.ScannerSSRFMetadata}},
+			},
+			want: blockreason.SSRFMetadata,
 		},
 		{
 			name: "prompt injection",

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/hitl"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+	"github.com/luckyPipewrench/pipelock/internal/mcp"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
@@ -458,6 +459,48 @@ func TestForwardA2ARequestBodyFilePartURIBlocked(t *testing.T) {
 	}
 	if hits.Load() != 0 {
 		t.Fatalf("upstream hits = %d, want 0", hits.Load())
+	}
+}
+
+func TestA2ABodyBlockReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		result mcp.A2AScanResult
+		want   blockreason.Reason
+	}{
+		{
+			name: "url ssrf",
+			result: mcp.A2AScanResult{
+				URLFindings: []scanner.Result{{Scanner: scanner.ScannerSSRF}},
+			},
+			want: blockreason.SSRFPrivateIP,
+		},
+		{
+			name: "prompt injection",
+			result: mcp.A2AScanResult{
+				InjectFindings: []scanner.ResponseMatch{{PatternName: "prompt_injection"}},
+			},
+			want: blockreason.PromptInjection,
+		},
+		{
+			name: "dlp",
+			result: mcp.A2AScanResult{
+				DLPFindings: []scanner.TextDLPMatch{{PatternName: "api_key"}},
+			},
+			want: blockreason.DLPMatch,
+		},
+		{
+			name:   "parser fallback",
+			result: mcp.A2AScanResult{Reason: "a2a: invalid JSON: empty body"},
+			want:   blockreason.ParseError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := a2aBodyBlockReason(tt.result); got != tt.want {
+				t.Fatalf("reason = %s, want %s", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- scan A2A request bodies on the plain forward-proxy path before forwarding
- add regression coverage for FilePart metadata URI SSRF
- avoid pipe-to-interpreter health parsing in the kill-switch verifier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added A2A-aware request body inspection for structured content and file-related references, with HTTP 403 enforcement and categorized block reasons.
* **Bug Fixes**
  * Improved kill-switch health-check verification by parsing JSON responses more robustly via temporary-file handling.
* **Tests**
  * Expanded A2A request-body coverage (private-IP SSRF blocking, pass-through, direct-block behavior, fail-closed parse/size/encoding cases) and validated block-reason mapping.
  * Tightened concurrency replay assertions to verify per-sequence delivery during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->