### PR TITLE
fix(coveragecert): fail closed when no trusted signer is supplied

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -390,9 +390,15 @@ pipelock dashboard coverage-cert generate \
   --agent agent-a \
   --window-start 2026-07-01T00:00:00Z \
   --window-end 2026-07-12T00:00:00Z \
+  --trusted-receipt-signer file=/etc/pipelock/keys/receipt-signing.pub,source=security-team \
   --signing-key /etc/pipelock/keys/coverage-cert.key \
   --out agent-a-coverage.json
 ```
+
+When `--trusted-receipt-signer` is supplied, generation verifies each session's
+receipt chain against that trusted signer set. Its CLI output says
+`receipt chains: verified against trusted signer set`. Without it, generation
+uses self-consistency checks and prints `receipt chains: self-consistent only`.
 
 Verify is free and offline:
 
@@ -402,8 +408,11 @@ pipelock evidence verify-cert \
   --trusted-signer file=/etc/pipelock/keys/coverage-cert.pub,source=security-team
 ```
 
-With a `--trusted-signer` set, verification exits non-zero when the certificate
-signer is not trusted. With no trusted signer, verification is structural-only.
+Verification exits zero only when the certificate signer is in the
+`--trusted-signer` set. With no trusted signer, verification fails closed by
+default. Pass `--allow-unpinned` only for an explicit structural-only
+check; that output is labeled `STRUCTURAL ONLY` and does not report the signer
+as trusted.
 
 ## Backup, restore, and read-model rebuild
 

--- a/enterprise/cli/dashboard_coveragecert.go
+++ b/enterprise/cli/dashboard_coveragecert.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"github.com/luckyPipewrench/pipelock/internal/signingflag"
 )
 
 const coverageCertReceiptReadLimit = 100000
@@ -38,13 +40,14 @@ func coverageCertCmd() *cobra.Command {
 }
 
 type coverageCertGenerateOptions struct {
-	agent          string
-	receiptDir     string
-	signingKeyFile string
-	windowStart    string
-	windowEnd      string
-	outFile        string
-	licenseCRLFile string
+	agent                 string
+	receiptDir            string
+	signingKeyFile        string
+	trustedReceiptSigners []string
+	windowStart           string
+	windowEnd             string
+	outFile               string
+	licenseCRLFile        string
 }
 
 func coverageCertGenerateCmd() *cobra.Command {
@@ -75,6 +78,9 @@ the Ed25519 private key specified by --signing-key.`,
 		"flight-recorder evidence directory holding action receipts")
 	cmd.Flags().StringVar(&opts.signingKeyFile, "signing-key", "",
 		"Ed25519 private key file for signing the certificate")
+	cmd.Flags().StringArrayVar(&opts.trustedReceiptSigners, "trusted-receipt-signer", nil,
+		"trusted receipt signing key as comma-separated kv pairs: "+
+			"'(inline=HEX_OR_VERSIONED_PUBLIC_KEY|file=/path)[,source=LABEL]'; repeatable")
 	cmd.Flags().StringVar(&opts.windowStart, "window-start", "",
 		"coverage window start (RFC3339)")
 	cmd.Flags().StringVar(&opts.windowEnd, "window-end", "",
@@ -137,6 +143,14 @@ func runCoverageCertGenerate(cmd *cobra.Command, opts coverageCertGenerateOption
 		return fmt.Errorf("--signing-key: not an Ed25519 private key")
 	}
 	pubHex := hex.EncodeToString(pub)
+	trustedReceiptKeys, err := parseCoverageCertTrustedReceiptSigners(opts.trustedReceiptSigners)
+	if err != nil {
+		return err
+	}
+	receiptChainSummary := "self-consistent only"
+	if len(trustedReceiptKeys) > 0 {
+		receiptChainSummary = "verified against trusted signer set"
+	}
 
 	var sessionCoverages []coveragecert.SessionCoverage
 	var totalReceipts uint64
@@ -160,7 +174,7 @@ func runCoverageCertGenerate(cmd *cobra.Command, opts coverageCertGenerateOption
 			continue
 		}
 
-		chainResult := receipt.VerifyChainTrusted(receipts, nil)
+		chainResult := receipt.VerifyChainTrusted(receipts, trustedReceiptKeys)
 		report := completeness.Analyze(receipts, chainResult)
 
 		intact := chainResult.Valid
@@ -218,11 +232,33 @@ func runCoverageCertGenerate(cmd *cobra.Command, opts coverageCertGenerateOption
 			return fmt.Errorf("--out: %w", writeErr)
 		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "coverage certificate written to %s\n", cleanOut)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "receipt chains: %s\n", receiptChainSummary)
 		return nil
 	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", data)
 	return nil
+}
+
+func parseCoverageCertTrustedReceiptSigners(raw []string) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(raw))
+	keys := make([]string, 0, len(raw))
+	for _, value := range raw {
+		keyHex, _, err := signingflag.ParseTrustedSignerSpec(value)
+		if err != nil {
+			return nil, fmt.Errorf("--trusted-receipt-signer %q: %w", value, err)
+		}
+		if _, ok := seen[keyHex]; ok {
+			return nil, fmt.Errorf("--trusted-receipt-signer %q: duplicate key %s", value, keyHex)
+		}
+		seen[keyHex] = struct{}{}
+		keys = append(keys, keyHex)
+	}
+	sort.Strings(keys)
+	return keys, nil
 }
 
 func loadCoverageCertSessionReceipts(dir, sessionID string, limit int) ([]receipt.Receipt, error) {
@@ -312,6 +348,7 @@ func sessionBelongsToAgent(sessionID string, receipts []receipt.Receipt, agent s
 type coverageCertVerifyOptions struct {
 	certFile       string
 	trustedSigners []string
+	allowUnpinned  bool
 }
 
 func coverageCertVerifyCmd() *cobra.Command {
@@ -324,9 +361,9 @@ against the trusted-signer set. Re-derives aggregate counts from the sessions
 and flags any mismatch. Fully offline: no license, no server.
 
 Fails closed with a non-zero exit if the signature is invalid, the aggregate
-counts do not match, or a trusted-signer set is supplied and the certificate
-signer is not in it. With no trusted-signer set, verification is
-structural-only and exits zero.`,
+counts do not match, the certificate signer is not in the trusted-signer set,
+or no trusted-signer set is supplied. Pass --allow-unpinned only
+for an explicit structural-only check whose signer is not trusted.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runCoverageCertVerify(cmd, opts)
@@ -336,6 +373,8 @@ structural-only and exits zero.`,
 	cmd.Flags().StringArrayVar(&opts.trustedSigners, "trusted-signer", nil,
 		"trusted signing key as comma-separated kv pairs: "+
 			"'(inline=HEX_OR_VERSIONED_PUBLIC_KEY|file=/path)[,source=LABEL]'; repeatable")
+	cmd.Flags().BoolVar(&opts.allowUnpinned, "allow-unpinned", false,
+		"allow structural-only verification when no trusted-signer set is supplied")
 	_ = cmd.MarkFlagRequired("cert")
 	return cmd
 }
@@ -344,6 +383,7 @@ func runCoverageCertVerify(cmd *cobra.Command, opts coverageCertVerifyOptions) e
 	return coveragecertverify.Run(coveragecertverify.Options{
 		CertFile:       opts.certFile,
 		TrustedSigners: opts.trustedSigners,
+		AllowUnpinned:  opts.allowUnpinned,
 		Out:            cmd.OutOrStdout(),
 	})
 }

--- a/enterprise/cli/dashboard_coveragecert_test.go
+++ b/enterprise/cli/dashboard_coveragecert_test.go
@@ -192,6 +192,9 @@ func TestRunCoverageCertGenerate_RoundTrip(t *testing.T) {
 	if cert.Body.Agent != actor {
 		t.Errorf("cert agent = %q, want %q", cert.Body.Agent, actor)
 	}
+	if !strings.Contains(out.String(), "receipt chains: self-consistent only") {
+		t.Fatalf("generate output = %q, want self-consistent-only receipt-chain label", out.String())
+	}
 	// Honest boundary wording is present and never over-claims.
 	if !bytes.Contains(data, []byte("mediated egress inside the declared Pipelock boundary")) {
 		t.Error("cert boundary is missing the required mediated-egress phrase")
@@ -201,6 +204,103 @@ func TestRunCoverageCertGenerate_RoundTrip(t *testing.T) {
 	}
 	if len(cert.Body.Sessions) == 0 {
 		t.Error("cert should summarize at least one session")
+	}
+}
+
+func TestRunCoverageCertGenerate_TrustedReceiptSignerMode(t *testing.T) {
+	dir := t.TempDir()
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	writeCoverageCertEvidenceSession(t, dir, priv, "trusted-chain", "agent-a", 2)
+
+	keyFile := filepath.Join(t.TempDir(), "signing.key")
+	if err := signing.SavePrivateKey(priv, keyFile); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	certFile := filepath.Join(t.TempDir(), "cert.json")
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := runCoverageCertGenerate(cmd, coverageCertGenerateOptions{
+		agent:                 "agent-a",
+		receiptDir:            dir,
+		signingKeyFile:        keyFile,
+		trustedReceiptSigners: []string{"inline=" + hex.EncodeToString(pub)},
+		windowStart:           start.Format(time.RFC3339),
+		windowEnd:             start.Add(time.Hour).Format(time.RFC3339),
+		outFile:               certFile,
+	}); err != nil {
+		t.Fatalf("runCoverageCertGenerate: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(certFile))
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	cert, err := coveragecert.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal cert: %v", err)
+	}
+	if cert.Body.ChainsIntact != 1 || !cert.Body.Sessions[0].ChainIntact {
+		t.Fatalf("trusted receipt signer chain_intact = body:%d session:%v, want trusted intact",
+			cert.Body.ChainsIntact, cert.Body.Sessions[0].ChainIntact)
+	}
+	if !strings.Contains(out.String(), "receipt chains: verified against trusted signer set") {
+		t.Fatalf("generate output = %q, want trusted receipt-chain label", out.String())
+	}
+}
+
+func TestRunCoverageCertGenerate_UntrustedReceiptSignerMarksChainBroken(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	otherPub, _, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair other: %v", err)
+	}
+	writeCoverageCertEvidenceSession(t, dir, priv, "untrusted-chain", "agent-a", 2)
+
+	keyFile := filepath.Join(t.TempDir(), "signing.key")
+	if err := signing.SavePrivateKey(priv, keyFile); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	certFile := filepath.Join(t.TempDir(), "cert.json")
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := runCoverageCertGenerate(cmd, coverageCertGenerateOptions{
+		agent:                 "agent-a",
+		receiptDir:            dir,
+		signingKeyFile:        keyFile,
+		trustedReceiptSigners: []string{"inline=" + hex.EncodeToString(otherPub)},
+		windowStart:           start.Format(time.RFC3339),
+		windowEnd:             start.Add(time.Hour).Format(time.RFC3339),
+		outFile:               certFile,
+	}); err != nil {
+		t.Fatalf("runCoverageCertGenerate: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(certFile))
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	cert, err := coveragecert.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal cert: %v", err)
+	}
+	if cert.Body.ChainsBroken != 1 || cert.Body.Sessions[0].ChainIntact {
+		t.Fatalf("untrusted receipt signer chain result = broken:%d session:%v, want broken",
+			cert.Body.ChainsBroken, cert.Body.Sessions[0].ChainIntact)
 	}
 }
 
@@ -388,6 +488,33 @@ func TestRunCoverageCertVerify(t *testing.T) {
 		}
 	})
 
+	t.Run("no trusted signer fails closed by default", func(t *testing.T) {
+		cmd, buf := newCmd()
+		err := runCoverageCertVerify(cmd, coverageCertVerifyOptions{
+			certFile: certFile,
+		})
+		if err == nil || !strings.Contains(err.Error(), "no trusted-signer set supplied") {
+			t.Fatalf("verify (unpinned default) err = %v, want fail-closed missing trusted-signer error", err)
+		}
+		if strings.Contains(buf.String(), "STRUCTURAL ONLY") {
+			t.Fatalf("verify output = %q, must not report structural-only opt-in by default", buf.String())
+		}
+	})
+
+	t.Run("no trusted signer structural opt in exits zero", func(t *testing.T) {
+		cmd, buf := newCmd()
+		err := runCoverageCertVerify(cmd, coverageCertVerifyOptions{
+			certFile:      certFile,
+			allowUnpinned: true,
+		})
+		if err != nil {
+			t.Fatalf("verify (structural opt-in) error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "STRUCTURAL ONLY — signer NOT trusted") {
+			t.Fatalf("verify output = %q, want explicit structural-only label", buf.String())
+		}
+	})
+
 	t.Run("untrusted signer fails closed", func(t *testing.T) {
 		_, otherPriv, _ := signing.GenerateKeyPair()
 		otherPub := otherPriv.Public().(ed25519.PublicKey)
@@ -456,6 +583,12 @@ func TestCoverageCertCmd_Structure(t *testing.T) {
 	}
 	if coverageCertVerifyCmd().Flags().Lookup("cert") == nil {
 		t.Error("verify missing --cert flag")
+	}
+	if coverageCertVerifyCmd().Flags().Lookup("allow-unpinned") == nil {
+		t.Error("verify missing --allow-unpinned flag")
+	}
+	if coverageCertGenerateCmd().Flags().Lookup("trusted-receipt-signer") == nil {
+		t.Error("generate missing --trusted-receipt-signer flag")
 	}
 }
 

--- a/internal/cli/evidence/evidence.go
+++ b/internal/cli/evidence/evidence.go
@@ -382,6 +382,7 @@ func resolveServeSession(dir, explicit string) (string, error) {
 type verifyCertOptions struct {
 	certFile       string
 	trustedSigners []string
+	allowUnpinned  bool
 }
 
 func verifyCertCmd() *cobra.Command {
@@ -397,9 +398,10 @@ Fully offline: no license, no server, no network. The Free viewer
 VERIFIES a Pro-issued certificate; only Pro issues one.
 
 Fails closed with a non-zero exit if the signature is invalid, the
-aggregate counts do not match, or a trusted-signer set is supplied and the
-certificate signer is not in it. With no trusted-signer set, verification is
-structural-only and exits zero. The signer status is always reported.`,
+aggregate counts do not match, the certificate signer is not in the trusted-
+signer set, or no trusted-signer set is supplied. Pass
+--allow-unpinned only for an explicit structural-only check whose
+signer is not trusted. The signer status is always reported.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runVerifyCert(cmd, opts)
@@ -409,6 +411,8 @@ structural-only and exits zero. The signer status is always reported.`,
 	cmd.Flags().StringArrayVar(&opts.trustedSigners, "trusted-signer", nil,
 		"trusted signing key as comma-separated kv pairs: "+
 			"'(inline=HEX_OR_VERSIONED_PUBLIC_KEY|file=/path)[,source=LABEL]'; repeatable")
+	cmd.Flags().BoolVar(&opts.allowUnpinned, "allow-unpinned", false,
+		"allow structural-only verification when no trusted-signer set is supplied")
 	_ = cmd.MarkFlagRequired("cert")
 	return cmd
 }
@@ -417,6 +421,7 @@ func runVerifyCert(cmd *cobra.Command, opts verifyCertOptions) error {
 	return coveragecertverify.Run(coveragecertverify.Options{
 		CertFile:       opts.certFile,
 		TrustedSigners: opts.trustedSigners,
+		AllowUnpinned:  opts.allowUnpinned,
 		Out:            cmd.OutOrStdout(),
 	})
 }

--- a/internal/cli/evidence/evidence_test.go
+++ b/internal/cli/evidence/evidence_test.go
@@ -908,6 +908,60 @@ func TestVerifyCertCmd_UntrustedSigner_Reported(t *testing.T) {
 	}
 }
 
+func TestVerifyCertCmd_NoTrustedSigner_DefaultFailsClosed(t *testing.T) {
+	t.Parallel()
+	pub, priv := genKey(t)
+	certData := signTestCert(t, pub, priv)
+	certFile := filepath.Join(t.TempDir(), "cert.json")
+	if err := os.WriteFile(certFile, certData, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := Cmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"verify-cert",
+		"--cert", certFile,
+	})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "no trusted-signer set supplied") {
+		t.Fatalf("Execute err = %v, want fail-closed missing trusted-signer error", err)
+	}
+	if strings.Contains(stdout.String(), "STRUCTURAL ONLY") {
+		t.Fatalf("stdout = %q, must not report structural-only opt-in by default", stdout.String())
+	}
+}
+
+func TestVerifyCertCmd_AllowUnpinned(t *testing.T) {
+	t.Parallel()
+	pub, priv := genKey(t)
+	certData := signTestCert(t, pub, priv)
+	certFile := filepath.Join(t.TempDir(), "cert.json")
+	if err := os.WriteFile(certFile, certData, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := Cmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"verify-cert",
+		"--cert", certFile,
+		"--allow-unpinned",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "STRUCTURAL ONLY — signer NOT trusted") {
+		t.Fatalf("stdout = %q, want explicit structural-only label", stdout.String())
+	}
+}
+
 func TestVerifyCertCmd_Tampered_NonZero(t *testing.T) {
 	t.Parallel()
 	pub, priv := genKey(t)
@@ -1069,6 +1123,7 @@ func TestVerifyCertCmd_NoLicenseRequired(t *testing.T) {
 	cmd.SetArgs([]string{
 		"verify-cert",
 		"--cert", certFile,
+		"--trusted-signer", "inline=" + hex.EncodeToString(pub),
 	})
 
 	if err := cmd.Execute(); err != nil {

--- a/internal/coveragecert/coveragecert.go
+++ b/internal/coveragecert/coveragecert.go
@@ -105,11 +105,12 @@ type Certificate struct {
 
 // VerifyResult is the output of offline verification.
 type VerifyResult struct {
-	SignatureValid bool     `json:"signature_valid"`
-	SignerTrusted  bool     `json:"signer_trusted"`
-	AggregateValid bool     `json:"aggregate_valid"`
-	Body           Body     `json:"body"`
-	Lines          []string `json:"lines"`
+	SignatureValid  bool     `json:"signature_valid"`
+	AggregateValid  bool     `json:"aggregate_valid"`
+	StructuralValid bool     `json:"structural_valid"`
+	SignerTrusted   bool     `json:"signer_trusted"`
+	Body            Body     `json:"body"`
+	Lines           []string `json:"lines"`
 }
 
 // SignablePreimage returns JCS-canonical bytes of the body for signing and
@@ -384,9 +385,12 @@ func Verify(cert Certificate, trustedKeys map[string]struct{}) (VerifyResult, er
 	// Verify signature.
 	result.SignatureValid = ed25519.Verify(signerKeyBytes, preimage, sigBytes)
 	if !result.SignatureValid {
+		result.StructuralValid = false
 		result.Lines = buildVerifyLines(cert, result, nil)
 		return result, fmt.Errorf("%w: signature is invalid", ErrVerifyFailed)
 	}
+	result.AggregateValid = true
+	result.StructuralValid = true
 
 	// Check signer trust (NEVER TOFU).
 	if trustedKeys != nil {
@@ -396,8 +400,6 @@ func Verify(cert Certificate, trustedKeys map[string]struct{}) (VerifyResult, er
 			return result, fmt.Errorf("%w: signer is not in the trusted-signer set", ErrVerifyFailed)
 		}
 	}
-
-	result.AggregateValid = true
 
 	// Build bounded per-fact lines.
 	result.Lines = buildVerifyLines(cert, result, nil)

--- a/internal/coveragecert/coveragecert_test.go
+++ b/internal/coveragecert/coveragecert_test.go
@@ -80,6 +80,12 @@ func TestSignVerifyRoundTrip(t *testing.T) {
 	if !result.SignatureValid {
 		t.Error("expected SignatureValid=true")
 	}
+	if !result.AggregateValid {
+		t.Error("expected AggregateValid=true")
+	}
+	if !result.StructuralValid {
+		t.Error("expected StructuralValid=true")
+	}
 	if !result.SignerTrusted {
 		t.Error("expected SignerTrusted=true")
 	}
@@ -178,6 +184,22 @@ func TestVerify_UntrustedSigner_NotTOFU(t *testing.T) {
 	}
 	if resultNil.SignerTrusted {
 		t.Error("expected SignerTrusted=false with nil trusted keys")
+	}
+	if !resultNil.StructuralValid {
+		t.Error("expected StructuralValid=true with nil trusted keys")
+	}
+	resultJSON, err := json.Marshal(resultNil)
+	if err != nil {
+		t.Fatalf("Marshal VerifyResult: %v", err)
+	}
+	if !strings.Contains(string(resultJSON), `"structural_valid":true`) {
+		t.Fatalf("VerifyResult JSON = %s, want structural_valid=true", resultJSON)
+	}
+	if !strings.Contains(string(resultJSON), `"signer_trusted":false`) {
+		t.Fatalf("VerifyResult JSON = %s, want signer_trusted=false", resultJSON)
+	}
+	if strings.Contains(string(resultJSON), `"valid":true`) {
+		t.Fatalf("VerifyResult JSON = %s, must not expose bare valid=true", resultJSON)
 	}
 }
 

--- a/internal/coveragecertverify/verify.go
+++ b/internal/coveragecertverify/verify.go
@@ -17,10 +17,19 @@ import (
 
 const maxCertificateBytes int64 = 1 << 20
 
+const noTrustedSignerSetError = "no trusted-signer set supplied; refusing to report the certificate as verified — pass --trusted-signer to check trust, or --allow-unpinned for an explicit structural-only check."
+
+type noTrustedSignerSetSuppliedError struct{}
+
+func (noTrustedSignerSetSuppliedError) Error() string {
+	return noTrustedSignerSetError
+}
+
 // Options configures one offline certificate verification run.
 type Options struct {
 	CertFile       string
 	TrustedSigners []string
+	AllowUnpinned  bool
 	Out            io.Writer
 }
 
@@ -73,10 +82,14 @@ func Run(opts Options) error {
 		// Fail closed: the caller pinned a trusted-signer set and the certificate
 		// signer is not in it. A cryptographically valid signature from an
 		// untrusted key must not verify, or an operator scripting on exit code
-		// would accept a certificate signed by an unrecognized key. (When no
-		// trusted set is provided the check above is skipped: that is the
-		// explicit unpinned/structural case.)
+		// would accept a certificate signed by an unrecognized key.
 		return errors.New("coverage certificate signer is not in the trusted-signer set")
+	}
+	if len(trustedKeySet) == 0 {
+		if !opts.AllowUnpinned {
+			return noTrustedSignerSetSuppliedError{}
+		}
+		_, _ = fmt.Fprintln(out, "STRUCTURAL ONLY — signer NOT trusted")
 	}
 	return nil
 }

--- a/internal/coveragecertverify/verify_test.go
+++ b/internal/coveragecertverify/verify_test.go
@@ -124,6 +124,97 @@ func TestRunTrustedSignerVerifies(t *testing.T) {
 	}
 }
 
+func TestRunNoTrustedSignerFailsClosedByDefault(t *testing.T) {
+	certFile, _ := writeCoverageCertVerifyFixture(t)
+	var out bytes.Buffer
+
+	err := Run(Options{
+		CertFile: certFile,
+		Out:      &out,
+	})
+	if err == nil || !strings.Contains(err.Error(), "no trusted-signer set supplied") {
+		t.Fatalf("Run err = %v, want fail-closed missing trusted-signer error", err)
+	}
+	if strings.Contains(out.String(), "STRUCTURAL ONLY") {
+		t.Fatalf("Run output = %q, must not label default verification as structural-only opt-in", out.String())
+	}
+}
+
+func TestRunTrustModeTable(t *testing.T) {
+	certFile, pubHex := writeCoverageCertVerifyFixture(t)
+	otherPub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	otherPubHex := hex.EncodeToString(otherPub)
+
+	tests := []struct {
+		name             string
+		trustedSigners   []string
+		allowStructural  bool
+		wantErrContains  string
+		wantOutContains  []string
+		rejectOutContain []string
+	}{
+		{
+			name:            "no trusted set no flag fails nonzero",
+			wantErrContains: "no trusted-signer set supplied",
+			wantOutContains: []string{"Signature: valid", "Signer: NOT TRUSTED"},
+		},
+		{
+			name:            "no trusted set structural flag exits zero",
+			allowStructural: true,
+			wantOutContains: []string{"Signature: valid", "Signer: NOT TRUSTED", "STRUCTURAL ONLY — signer NOT trusted"},
+		},
+		{
+			name:             "trusted set matching signer verifies",
+			trustedSigners:   []string{"inline=" + pubHex},
+			wantOutContains:  []string{"Signature: valid", "Signer: TRUSTED"},
+			rejectOutContain: []string{"STRUCTURAL ONLY"},
+		},
+		{
+			name:            "trusted set wrong signer fails",
+			trustedSigners:  []string{"inline=" + otherPubHex},
+			wantErrContains: "not in the trusted-signer set",
+			wantOutContains: []string{"Signature: valid", "Signer: NOT TRUSTED"},
+		},
+		{
+			name:            "forged self-signed cert fails by default",
+			wantErrContains: "no trusted-signer set supplied",
+			wantOutContains: []string{"Signature: valid", "Signer: NOT TRUSTED"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := Run(Options{
+				CertFile:       certFile,
+				TrustedSigners: tt.trustedSigners,
+				AllowUnpinned:  tt.allowStructural,
+				Out:            &out,
+			})
+			if tt.wantErrContains == "" {
+				if err != nil {
+					t.Fatalf("Run err = %v, want nil", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Fatalf("Run err = %v, want containing %q", err, tt.wantErrContains)
+			}
+			for _, want := range tt.wantOutContains {
+				if !strings.Contains(out.String(), want) {
+					t.Fatalf("Run output = %q, want containing %q", out.String(), want)
+				}
+			}
+			for _, reject := range tt.rejectOutContain {
+				if strings.Contains(out.String(), reject) {
+					t.Fatalf("Run output = %q, must not contain %q", out.String(), reject)
+				}
+			}
+		})
+	}
+}
+
 func TestRunUntrustedSignerFailsClosed(t *testing.T) {
 	certFile, _ := writeCoverageCertVerifyFixture(t)
 	otherPub, _, err := ed25519.GenerateKey(nil)


### PR DESCRIPTION
## What changed

- `coverage-cert verify` and the free `evidence verify-cert` viewer now fail closed by default: with no `--trusted-signer` set, verification exits non-zero instead of exiting zero for a self-signed certificate.
- `--allow-unpinned` is a new explicit opt-in for a structural-only check; it exits zero but reports that the signer is not trusted. This matches the `--allow-unpinned` flag the receipt and chain verifiers already use.
- The verification result separates `signature_valid`, `aggregate_valid`, `structural_valid`, and `signer_trusted`, and the exit code reflects signer trust, so an automated consumer cannot mistake structural validity for trust.
- `coverage-cert generate` gains `--trusted-receipt-signer`: when supplied, each session's receipt chain is verified against that trusted set instead of trust-on-first-use, and generation output states whether chains are self-consistent only or verified against a trusted signer set.

## Why

- Verifying a certificate with no trusted-signer set previously skipped the signer-trust check and exited zero, so a forged self-signed certificate passed an exit-code check; a badge or CI job keying on the exit code would treat it as verified. The receipt and chain verifiers already fail closed in this case; this brings coverage-cert into line with them.

## Upgrade note (breaking)

- `coverage-cert verify` and `evidence verify-cert` now require either `--trusted-signer` or the explicit `--allow-unpinned` flag. A script that relied on the previous no-flag "structural-only, exit zero" behavior must add `--allow-unpinned`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trusted receipt signer options for coverage certificate generation.
  * Added `--allow-unpinned` for explicit structural-only certificate verification.
  * Added receipt-chain status summaries to generation output.

* **Bug Fixes**
  * Certificate verification now fails closed when no trusted signer is configured.
  * Verification results more accurately distinguish valid structure, valid signatures, and trusted signers.

* **Documentation**
  * Clarified trusted signer requirements, receipt-chain verification, and structural-only checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->