### PR TITLE
Fail closed when replay verification is unpinned

### DIFF
--- a/cmd/pipelock-verifier/replay.go
+++ b/cmd/pipelock-verifier/replay.go
@@ -33,6 +33,7 @@ import (
 type replayOptions struct {
 	policyPath    string
 	signerKey     string
+	keyProvided   bool
 	jsonOutput    bool
 	allowUnpinned bool
 }
@@ -72,6 +73,7 @@ Exit codes:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.keyProvided = cmd.Flags().Changed("key")
 			return runReplay(cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], opts)
 		},
 	}
@@ -88,22 +90,24 @@ Exit codes:
 // replayReport is the structured output emitted by `replay`. Stable JSON
 // shape so external tooling can consume it.
 type replayReport struct {
-	ReceiptPath        string   `json:"receipt_path"`
-	PolicyPath         string   `json:"policy_path"`
-	ActionID           string   `json:"action_id,omitempty"`
-	Target             string   `json:"target,omitempty"`
-	Transport          string   `json:"transport,omitempty"`
-	OriginalVerdict    string   `json:"original_verdict,omitempty"`
-	ReplayVerdict      string   `json:"replay_verdict,omitempty"`
-	ReplayScanner      string   `json:"replay_scanner,omitempty"`
-	ReplayReason       string   `json:"replay_reason,omitempty"`
-	VerdictChanged     bool     `json:"verdict_changed"`
-	ReceiptValid       bool     `json:"receipt_valid"`
-	SignaturesVerified bool     `json:"signatures_verified"`
-	Unpinned           bool     `json:"unpinned,omitempty"`
-	Warnings           []string `json:"warnings,omitempty"`
-	Details            []string `json:"details,omitempty"`
-	Error              string   `json:"error,omitempty"`
+	ReceiptPath          string   `json:"receipt_path"`
+	PolicyPath           string   `json:"policy_path"`
+	ActionID             string   `json:"action_id,omitempty"`
+	Target               string   `json:"target,omitempty"`
+	Transport            string   `json:"transport,omitempty"`
+	OriginalVerdict      string   `json:"original_verdict,omitempty"`
+	ReplayVerdict        string   `json:"replay_verdict,omitempty"`
+	ReplayScanner        string   `json:"replay_scanner,omitempty"`
+	ReplayReason         string   `json:"replay_reason,omitempty"`
+	VerdictChanged       bool     `json:"verdict_changed"`
+	ReceiptValid         bool     `json:"receipt_valid"`
+	StructuralValid      bool     `json:"structural_valid"`
+	VerificationAccepted bool     `json:"verification_accepted"`
+	SignaturesVerified   bool     `json:"signatures_verified"`
+	Unpinned             bool     `json:"unpinned,omitempty"`
+	Warnings             []string `json:"warnings,omitempty"`
+	Details              []string `json:"details,omitempty"`
+	Error                string   `json:"error,omitempty"`
 }
 
 // Verdict tags emitted by `replay`. Aligned with config.Action* but kept as
@@ -143,8 +147,21 @@ func runReplay(stdout, stderr io.Writer, receiptPath string, opts replayOptions)
 	report.Transport = r.ActionRecord.Transport
 	report.OriginalVerdict = r.ActionRecord.Verdict
 
+	if opts.keyProvided && strings.TrimSpace(opts.signerKey) == "" {
+		err := fmt.Errorf("--key was provided but empty")
+		report.Error = fmt.Sprintf("resolve signer key: %v", err)
+		emitReplayReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+	}
+
 	keyHex, err := resolveSignerKey(strings.TrimSpace(opts.signerKey))
 	if err != nil {
+		report.Error = fmt.Sprintf("resolve signer key: %v", err)
+		emitReplayReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+	}
+	if opts.keyProvided && keyHex == "" {
+		err := fmt.Errorf("--key resolved to empty signer key")
 		report.Error = fmt.Sprintf("resolve signer key: %v", err)
 		emitReplayReport(stdout, stderr, report, opts.jsonOutput)
 		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
@@ -152,13 +169,16 @@ func runReplay(stdout, stderr io.Writer, receiptPath string, opts replayOptions)
 	if keyHex == "" {
 		if verifyErr := receipt.VerifyInternalConsistencyOnly(r); verifyErr != nil {
 			report.ReceiptValid = false
+			report.StructuralValid = false
 			report.Error = fmt.Sprintf("verify receipt: %v", verifyErr)
 			emitReplayReport(stdout, stderr, report, opts.jsonOutput)
 			return cliutil.ExitCodeError(cliutil.ExitGeneral, verifyErr)
 		}
+		report.StructuralValid = true
+		report.VerificationAccepted = opts.allowUnpinned
 		report.Unpinned = true
 		report.Warnings = append(report.Warnings, unpinnedReceiptBanner)
-		report.ReceiptValid = opts.allowUnpinned
+		report.ReceiptValid = false
 		if !opts.allowUnpinned {
 			report.Error = "verification unpinned: pass --key for provenance or --allow-unpinned for structural-only verification"
 			emitReplayReport(stdout, stderr, report, opts.jsonOutput)
@@ -171,6 +191,8 @@ func runReplay(stdout, stderr io.Writer, receiptPath string, opts replayOptions)
 			emitReplayReport(stdout, stderr, report, opts.jsonOutput)
 			return cliutil.ExitCodeError(cliutil.ExitGeneral, verifyErr)
 		}
+		report.StructuralValid = true
+		report.VerificationAccepted = true
 		report.SignaturesVerified = true
 		report.ReceiptValid = true
 	}
@@ -260,7 +282,7 @@ func emitReplayReport(stdout, stderr io.Writer, report replayReport, jsonOutput 
 	}
 
 	dst := stdout
-	if report.Error != "" || !report.ReceiptValid {
+	if report.Error != "" || !report.VerificationAccepted {
 		dst = stderr
 	}
 
@@ -276,11 +298,13 @@ func emitReplayReport(stdout, stderr io.Writer, report replayReport, jsonOutput 
 		_, _ = fmt.Fprintf(dst, "transport:     %s\n", report.Transport)
 	}
 	_, _ = fmt.Fprintf(dst, "receipt_valid: %v\n", report.ReceiptValid)
+	_, _ = fmt.Fprintf(dst, "structural_valid: %v\n", report.StructuralValid)
+	_, _ = fmt.Fprintf(dst, "verification_accepted: %v\n", report.VerificationAccepted)
 	_, _ = fmt.Fprintf(dst, "signatures_verified: %v\n", report.SignaturesVerified)
 	if report.Unpinned {
 		_, _ = fmt.Fprintf(dst, "unpinned:      true\n")
 		_, _ = fmt.Fprintf(dst, "warning:       %s\n", unpinnedReceiptBanner)
-		_, _ = fmt.Fprintln(dst, "signature:     not checked (self-consistency only; pass --key for provenance)")
+		_, _ = fmt.Fprintln(dst, "signature:     not checked (self-consistency only; receipt_valid=false; pass --key for provenance)")
 	}
 	if report.Error != "" {
 		_, _ = fmt.Fprintf(dst, "error:         %s\n", report.Error)

--- a/cmd/pipelock-verifier/replay.go
+++ b/cmd/pipelock-verifier/replay.go
@@ -187,6 +187,11 @@ func runReplay(stdout, stderr io.Writer, receiptPath string, opts replayOptions)
 	} else {
 		if verifyErr := receipt.VerifyWithKey(r, keyHex); verifyErr != nil {
 			report.ReceiptValid = false
+			if structuralErr := receipt.VerifyInternalConsistencyOnly(r); structuralErr == nil {
+				report.StructuralValid = true
+			} else {
+				report.Details = append(report.Details, fmt.Sprintf("structural verification: %v", structuralErr))
+			}
 			report.Error = fmt.Sprintf("verify receipt: %v", verifyErr)
 			emitReplayReport(stdout, stderr, report, opts.jsonOutput)
 			return cliutil.ExitCodeError(cliutil.ExitGeneral, verifyErr)
@@ -304,7 +309,7 @@ func emitReplayReport(stdout, stderr io.Writer, report replayReport, jsonOutput 
 	if report.Unpinned {
 		_, _ = fmt.Fprintf(dst, "unpinned:      true\n")
 		_, _ = fmt.Fprintf(dst, "warning:       %s\n", unpinnedReceiptBanner)
-		_, _ = fmt.Fprintln(dst, "signature:     not checked (self-consistency only; receipt_valid=false; pass --key for provenance)")
+		_, _ = fmt.Fprintln(dst, "signature:     verified against untrusted embedded signer_key only (provenance not verified; receipt_valid=false; pass --key for trusted provenance)")
 	}
 	if report.Error != "" {
 		_, _ = fmt.Fprintf(dst, "error:         %s\n", report.Error)

--- a/cmd/pipelock-verifier/replay.go
+++ b/cmd/pipelock-verifier/replay.go
@@ -6,8 +6,8 @@ package main
 // `pipelock-verifier replay` re-evaluates a Pipelock action receipt against
 // a current policy. The point: turn receipts from "what happened" into
 // "what would happen today under current policy" - the governance-evidence
-// shift. Codex 2026-05-21 leadership review framed this as the
-// load-bearing primitive for receipts as evidence rather than logs.
+// shift. This is the load-bearing primitive for treating receipts as
+// evidence rather than logs.
 //
 // Free-tier scope (single-agent): load one receipt, load one YAML policy,
 // re-run the scanner pipeline against the receipt's preserved target URL,
@@ -31,9 +31,10 @@ import (
 )
 
 type replayOptions struct {
-	policyPath string
-	signerKey  string
-	jsonOutput bool
+	policyPath    string
+	signerKey     string
+	jsonOutput    bool
+	allowUnpinned bool
 }
 
 func newReplayCmd() *cobra.Command {
@@ -49,9 +50,9 @@ The receipt's preserved target URL is fed through the same scanner pipeline
 the live proxy uses, with the loaded policy as the current ground truth.
 The replay verdict is compared against the receipt's original verdict.
 
-The receipt is also re-verified against its embedded signer key (or the key
-supplied via --key); a tampered or unverifiable receipt is reported as a
-replay-blocking error before any policy comparison is attempted.
+The receipt is also re-verified against the key supplied via --key. Without
+--key, replay fails closed unless --allow-unpinned is passed for loud
+structural-only verification. Self-consistency does not prove provenance.
 
 Use cases:
   - Confirm a previously-blocked action would still be blocked under the
@@ -62,9 +63,10 @@ Use cases:
     ("policy loosened; surface this for review").
 
 Exit codes:
-  0  receipt verified and policy verdict matches original (no change)
-  1  receipt verified but policy verdict differs from original
-  2  receipt malformed, signature invalid, or policy could not be loaded
+  0  receipt verification accepted and policy verdict matches original (no change)
+  1  receipt verification accepted but policy verdict differs, verification
+     failed, or unpinned structural-only verification was not explicitly allowed
+  2  receipt malformed, signer key could not be loaded, or policy could not be loaded
   64 usage error`,
 		Args:          exactOneArg,
 		SilenceUsage:  true,
@@ -78,6 +80,7 @@ Exit codes:
 	cmd.Flags().StringVar(&opts.policyPath, "policy", "", "path to YAML policy to replay against (required)")
 	cmd.Flags().StringVar(&opts.signerKey, "key", "", "expected signer public key (hex, public-key text, or file path)")
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON report on stdout")
+	cmd.Flags().BoolVar(&opts.allowUnpinned, "allow-unpinned", false, "allow structural-only verification without a trusted signer key")
 
 	return cmd
 }
@@ -85,19 +88,22 @@ Exit codes:
 // replayReport is the structured output emitted by `replay`. Stable JSON
 // shape so external tooling can consume it.
 type replayReport struct {
-	ReceiptPath     string   `json:"receipt_path"`
-	PolicyPath      string   `json:"policy_path"`
-	ActionID        string   `json:"action_id,omitempty"`
-	Target          string   `json:"target,omitempty"`
-	Transport       string   `json:"transport,omitempty"`
-	OriginalVerdict string   `json:"original_verdict,omitempty"`
-	ReplayVerdict   string   `json:"replay_verdict,omitempty"`
-	ReplayScanner   string   `json:"replay_scanner,omitempty"`
-	ReplayReason    string   `json:"replay_reason,omitempty"`
-	VerdictChanged  bool     `json:"verdict_changed"`
-	ReceiptValid    bool     `json:"receipt_valid"`
-	Details         []string `json:"details,omitempty"`
-	Error           string   `json:"error,omitempty"`
+	ReceiptPath        string   `json:"receipt_path"`
+	PolicyPath         string   `json:"policy_path"`
+	ActionID           string   `json:"action_id,omitempty"`
+	Target             string   `json:"target,omitempty"`
+	Transport          string   `json:"transport,omitempty"`
+	OriginalVerdict    string   `json:"original_verdict,omitempty"`
+	ReplayVerdict      string   `json:"replay_verdict,omitempty"`
+	ReplayScanner      string   `json:"replay_scanner,omitempty"`
+	ReplayReason       string   `json:"replay_reason,omitempty"`
+	VerdictChanged     bool     `json:"verdict_changed"`
+	ReceiptValid       bool     `json:"receipt_valid"`
+	SignaturesVerified bool     `json:"signatures_verified"`
+	Unpinned           bool     `json:"unpinned,omitempty"`
+	Warnings           []string `json:"warnings,omitempty"`
+	Details            []string `json:"details,omitempty"`
+	Error              string   `json:"error,omitempty"`
 }
 
 // Verdict tags emitted by `replay`. Aligned with config.Action* but kept as
@@ -143,19 +149,31 @@ func runReplay(stdout, stderr io.Writer, receiptPath string, opts replayOptions)
 		emitReplayReport(stdout, stderr, report, opts.jsonOutput)
 		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 	}
-	var verifyErr error
 	if keyHex == "" {
-		verifyErr = receipt.VerifyInternalConsistencyOnly(r)
+		if verifyErr := receipt.VerifyInternalConsistencyOnly(r); verifyErr != nil {
+			report.ReceiptValid = false
+			report.Error = fmt.Sprintf("verify receipt: %v", verifyErr)
+			emitReplayReport(stdout, stderr, report, opts.jsonOutput)
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, verifyErr)
+		}
+		report.Unpinned = true
+		report.Warnings = append(report.Warnings, unpinnedReceiptBanner)
+		report.ReceiptValid = opts.allowUnpinned
+		if !opts.allowUnpinned {
+			report.Error = "verification unpinned: pass --key for provenance or --allow-unpinned for structural-only verification"
+			emitReplayReport(stdout, stderr, report, opts.jsonOutput)
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("replay verification unpinned"))
+		}
 	} else {
-		verifyErr = receipt.VerifyWithKey(r, keyHex)
+		if verifyErr := receipt.VerifyWithKey(r, keyHex); verifyErr != nil {
+			report.ReceiptValid = false
+			report.Error = fmt.Sprintf("verify receipt: %v", verifyErr)
+			emitReplayReport(stdout, stderr, report, opts.jsonOutput)
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, verifyErr)
+		}
+		report.SignaturesVerified = true
+		report.ReceiptValid = true
 	}
-	if verifyErr != nil {
-		report.ReceiptValid = false
-		report.Error = fmt.Sprintf("verify receipt: %v", verifyErr)
-		emitReplayReport(stdout, stderr, report, opts.jsonOutput)
-		return cliutil.ExitCodeError(cliutil.ExitConfig, verifyErr)
-	}
-	report.ReceiptValid = true
 
 	// Step 2: load the current policy.
 	cfg, err := config.Load(filepath.Clean(opts.policyPath))
@@ -258,6 +276,12 @@ func emitReplayReport(stdout, stderr io.Writer, report replayReport, jsonOutput 
 		_, _ = fmt.Fprintf(dst, "transport:     %s\n", report.Transport)
 	}
 	_, _ = fmt.Fprintf(dst, "receipt_valid: %v\n", report.ReceiptValid)
+	_, _ = fmt.Fprintf(dst, "signatures_verified: %v\n", report.SignaturesVerified)
+	if report.Unpinned {
+		_, _ = fmt.Fprintf(dst, "unpinned:      true\n")
+		_, _ = fmt.Fprintf(dst, "warning:       %s\n", unpinnedReceiptBanner)
+		_, _ = fmt.Fprintln(dst, "signature:     not checked (self-consistency only; pass --key for provenance)")
+	}
 	if report.Error != "" {
 		_, _ = fmt.Fprintf(dst, "error:         %s\n", report.Error)
 		return

--- a/cmd/pipelock-verifier/replay_test.go
+++ b/cmd/pipelock-verifier/replay_test.go
@@ -21,12 +21,16 @@ import (
 )
 
 // writeSignedReceiptFile signs an ActionRecord and writes the receipt JSON
-// under dir/receipt.json. Returns the path. (The public-key hex is recovered
-// inside receipt.VerifyWithKey via the receipt's embedded signer_key field
-// when --key is not passed, so the test helper doesn't need to return it.)
+// under dir/receipt.json. Returns the path.
 func writeSignedReceiptFile(t *testing.T, dir string, ar receipt.ActionRecord) string {
 	t.Helper()
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	path, _ := writeSignedReceiptFileWithKey(t, dir, ar)
+	return path
+}
+
+func writeSignedReceiptFileWithKey(t *testing.T, dir string, ar receipt.ActionRecord) (string, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("keypair: %v", err)
 	}
@@ -42,7 +46,7 @@ func writeSignedReceiptFile(t *testing.T, dir string, ar receipt.ActionRecord) s
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("write receipt: %v", err)
 	}
-	return path
+	return path, hex.EncodeToString(pub)
 }
 
 // writePolicyFile writes a YAML pipelock config under dir/policy.yaml. The
@@ -116,11 +120,12 @@ func TestReplay_StableVerdict(t *testing.T) {
 		ChainSeq:      0,
 		PolicyHash:    "policy-fixture",
 	}
-	receiptPath := writeSignedReceiptFile(t, dir, ar)
+	receiptPath, signerKey := writeSignedReceiptFileWithKey(t, dir, ar)
 	policyPath := writePolicyFile(t, dir, nil)
 
 	report, _, exitCode := runReplayCommand(t,
 		"--policy", policyPath,
+		"--key", signerKey,
 		"--json",
 		receiptPath,
 	)
@@ -137,8 +142,59 @@ func TestReplay_StableVerdict(t *testing.T) {
 	if report.VerdictChanged {
 		t.Errorf("verdicts should agree, got changed=true")
 	}
+	if !report.SignaturesVerified {
+		t.Error("trusted replay should report signatures_verified=true")
+	}
+	if report.Unpinned {
+		t.Error("trusted replay should not report unpinned=true")
+	}
 	if exitCode != 0 {
 		t.Errorf("exit code: got %d, want 0", exitCode)
+	}
+}
+
+func TestReplay_ForgedSelfConsistentReceiptFailsClosedWithoutPinnedKey(t *testing.T) {
+	dir := t.TempDir()
+	ar := receipt.ActionRecord{
+		Version:       receipt.ActionRecordVersion,
+		ActionID:      receipt.NewActionID(),
+		ActionType:    receipt.ActionRead,
+		Timestamp:     time.Now(),
+		Target:        "https://allowed.example/",
+		Verdict:       "allow",
+		Transport:     "https",
+		ChainPrevHash: receipt.GenesisHash,
+		ChainSeq:      0,
+		PolicyHash:    "policy-fixture",
+	}
+	receiptPath := writeSignedReceiptFile(t, dir, ar)
+	policyPath := writePolicyFile(t, dir, nil)
+
+	report, _, exitCode := runReplayCommand(t,
+		"--policy", policyPath,
+		"--json",
+		receiptPath,
+	)
+
+	if report.ReceiptValid {
+		t.Error("self-consistent receipt should not be accepted without --key or --allow-unpinned")
+	}
+	if !report.Unpinned {
+		t.Error("self-consistent no-key replay should report unpinned=true")
+	}
+	if report.SignaturesVerified {
+		t.Error("self-consistent no-key replay should not report signatures_verified=true")
+	}
+	if len(report.Warnings) == 0 || !strings.Contains(report.Warnings[0], "UNPINNED") {
+		t.Fatalf("self-consistent no-key replay should report JSON warning, got %#v", report.Warnings)
+	}
+	for _, want := range []string{"pass --key for provenance", "--allow-unpinned for structural-only verification"} {
+		if !strings.Contains(report.Error, want) {
+			t.Errorf("error missing %q: %q", want, report.Error)
+		}
+	}
+	if exitCode != cliutil.ExitGeneral {
+		t.Errorf("exit code: got %d, want %d", exitCode, cliutil.ExitGeneral)
 	}
 }
 
@@ -162,6 +218,7 @@ func TestReplay_VerdictChanged_PolicyTightened(t *testing.T) {
 
 	report, _, exitCode := runReplayCommand(t,
 		"--policy", policyPath,
+		"--allow-unpinned",
 		"--json",
 		receiptPath,
 	)
@@ -177,6 +234,15 @@ func TestReplay_VerdictChanged_PolicyTightened(t *testing.T) {
 	}
 	if !report.VerdictChanged {
 		t.Error("VerdictChanged should be true")
+	}
+	if !report.Unpinned {
+		t.Error("structural-only replay should report unpinned=true")
+	}
+	if report.SignaturesVerified {
+		t.Error("structural-only replay should not report signatures_verified=true")
+	}
+	if len(report.Warnings) == 0 || !strings.Contains(report.Warnings[0], "UNPINNED") {
+		t.Fatalf("structural-only replay should report JSON warning, got %#v", report.Warnings)
 	}
 	if exitCode != cliutil.ExitGeneral {
 		t.Errorf("exit code: got %d want %d (ExitGeneral)", exitCode, cliutil.ExitGeneral)
@@ -203,6 +269,7 @@ func TestReplay_VerdictChanged_PolicyLoosened(t *testing.T) {
 
 	report, _, exitCode := runReplayCommand(t,
 		"--policy", policyPath,
+		"--allow-unpinned",
 		"--json",
 		receiptPath,
 	)
@@ -215,6 +282,12 @@ func TestReplay_VerdictChanged_PolicyLoosened(t *testing.T) {
 	}
 	if !report.VerdictChanged {
 		t.Error("VerdictChanged should be true (block -> allow)")
+	}
+	if !report.Unpinned {
+		t.Error("structural-only replay should report unpinned=true")
+	}
+	if len(report.Warnings) == 0 || !strings.Contains(report.Warnings[0], "UNPINNED") {
+		t.Fatalf("structural-only replay should report JSON warning, got %#v", report.Warnings)
 	}
 	if exitCode != cliutil.ExitGeneral {
 		t.Errorf("exit code: got %d want %d", exitCode, cliutil.ExitGeneral)
@@ -303,8 +376,156 @@ func TestReplay_BadKeyMismatch(t *testing.T) {
 	if report.ReceiptValid {
 		t.Error("receipt signed by another key should not validate against the supplied --key")
 	}
-	if exitCode != cliutil.ExitConfig {
-		t.Errorf("exit code: got %d want %d", exitCode, cliutil.ExitConfig)
+	if exitCode != cliutil.ExitGeneral {
+		t.Errorf("exit code: got %d want %d", exitCode, cliutil.ExitGeneral)
+	}
+}
+
+func TestReplay_AllowUnpinnedDoesNotWeakenPinnedVerification(t *testing.T) {
+	dir := t.TempDir()
+	ar := receipt.ActionRecord{
+		Version:       receipt.ActionRecordVersion,
+		ActionID:      receipt.NewActionID(),
+		ActionType:    receipt.ActionRead,
+		Timestamp:     time.Now(),
+		Target:        "https://example.com/",
+		Verdict:       "allow",
+		Transport:     "https",
+		ChainPrevHash: receipt.GenesisHash,
+		ChainSeq:      0,
+		PolicyHash:    "policy-fixture",
+	}
+	receiptPath, signerKey := writeSignedReceiptFileWithKey(t, dir, ar)
+	policyPath := writePolicyFile(t, dir, nil)
+	otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherKeyHex := hex.EncodeToString(otherPub)
+
+	report, _, exitCode := runReplayCommand(t,
+		"--policy", policyPath,
+		"--key", otherKeyHex,
+		"--allow-unpinned",
+		"--json",
+		receiptPath,
+	)
+	if report.ReceiptValid {
+		t.Fatal("--allow-unpinned must not accept a receipt signed by a different pinned key")
+	}
+	if report.Unpinned {
+		t.Fatal("--allow-unpinned with --key should stay on the pinned path, not report unpinned")
+	}
+	if report.SignaturesVerified {
+		t.Fatal("mismatched pinned key should not report signatures_verified=true")
+	}
+	if exitCode != cliutil.ExitGeneral {
+		t.Fatalf("exit code with wrong pinned key: got %d want %d", exitCode, cliutil.ExitGeneral)
+	}
+
+	report, _, exitCode = runReplayCommand(t,
+		"--policy", policyPath,
+		"--key", signerKey,
+		"--allow-unpinned",
+		"--json",
+		receiptPath,
+	)
+	if !report.ReceiptValid || !report.SignaturesVerified || report.Unpinned {
+		t.Fatalf("correct pinned key with --allow-unpinned should remain trusted: %#v", report)
+	}
+	if len(report.Warnings) != 0 {
+		t.Fatalf("trusted replay should not report unpinned warnings: %#v", report.Warnings)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exit code with correct pinned key: got %d want 0", exitCode)
+	}
+}
+
+func TestReplay_EmptyKeyFlagStillFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	ar := receipt.ActionRecord{
+		Version:       receipt.ActionRecordVersion,
+		ActionID:      receipt.NewActionID(),
+		ActionType:    receipt.ActionRead,
+		Timestamp:     time.Now(),
+		Target:        "https://allowed.example/",
+		Verdict:       "allow",
+		Transport:     "https",
+		ChainPrevHash: receipt.GenesisHash,
+		ChainSeq:      0,
+		PolicyHash:    "policy-fixture",
+	}
+	receiptPath := writeSignedReceiptFile(t, dir, ar)
+	policyPath := writePolicyFile(t, dir, nil)
+
+	report, _, exitCode := runReplayCommand(t,
+		"--policy", policyPath,
+		"--key", "",
+		"--json",
+		receiptPath,
+	)
+
+	if report.ReceiptValid {
+		t.Fatal(`--key "" should be treated as unpinned and fail closed without --allow-unpinned`)
+	}
+	if !report.Unpinned || report.SignaturesVerified {
+		t.Fatalf(`--key "" report = %#v, want unpinned structural-only without signatures`, report)
+	}
+	if exitCode != cliutil.ExitGeneral {
+		t.Fatalf("exit code: got %d want %d", exitCode, cliutil.ExitGeneral)
+	}
+}
+
+func TestReplay_MalformedEmbeddedSignerFailsClosedEvenWhenUnpinnedAllowed(t *testing.T) {
+	dir := t.TempDir()
+	ar := receipt.ActionRecord{
+		Version:       receipt.ActionRecordVersion,
+		ActionID:      receipt.NewActionID(),
+		ActionType:    receipt.ActionRead,
+		Timestamp:     time.Now(),
+		Target:        "https://allowed.example/",
+		Verdict:       "allow",
+		Transport:     "https",
+		ChainPrevHash: receipt.GenesisHash,
+		ChainSeq:      0,
+		PolicyHash:    "policy-fixture",
+	}
+	receiptPath := writeSignedReceiptFile(t, dir, ar)
+	data, err := os.ReadFile(filepath.Clean(receiptPath))
+	if err != nil {
+		t.Fatalf("read receipt: %v", err)
+	}
+	r, err := receipt.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("unmarshal receipt: %v", err)
+	}
+	r.SignerKey = ""
+	data, err = receipt.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+	if err := os.WriteFile(receiptPath, data, 0o600); err != nil {
+		t.Fatalf("write malformed receipt: %v", err)
+	}
+	policyPath := writePolicyFile(t, dir, nil)
+
+	for _, args := range [][]string{
+		{"--policy", policyPath, "--json", receiptPath},
+		{"--policy", policyPath, "--allow-unpinned", "--json", receiptPath},
+	} {
+		report, _, exitCode := runReplayCommand(t, args...)
+		if report.ReceiptValid {
+			t.Fatalf("%v accepted receipt with empty signer_key: %#v", args, report)
+		}
+		if report.Unpinned || report.SignaturesVerified {
+			t.Fatalf("%v report = %#v, want invalid before unpinned/trusted states", args, report)
+		}
+		if !strings.Contains(report.Error, "receipt has no signer_key") {
+			t.Fatalf("%v error = %q, want signer_key failure", args, report.Error)
+		}
+		if exitCode != cliutil.ExitGeneral {
+			t.Fatalf("%v exit code: got %d want %d", args, exitCode, cliutil.ExitGeneral)
+		}
 	}
 }
 
@@ -327,13 +548,24 @@ func TestReplay_HumanReadableOutput(t *testing.T) {
 
 	_, stdout, exitCode := runReplayCommand(t,
 		"--policy", policyPath,
+		"--allow-unpinned",
 		receiptPath,
 	)
 
 	if exitCode != 0 {
 		t.Errorf("exit code: got %d want 0", exitCode)
 	}
-	mustContain := []string{"receipt:", "policy:", "receipt_valid: true", "original:", "replay:", "verdict:"}
+	mustContain := []string{
+		"receipt:",
+		"policy:",
+		"receipt_valid: true",
+		"signatures_verified: false",
+		"unpinned:      true",
+		"self-consistency only",
+		"original:",
+		"replay:",
+		"verdict:",
+	}
 	for _, want := range mustContain {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("stdout missing %q\n%s", want, stdout)

--- a/cmd/pipelock-verifier/replay_test.go
+++ b/cmd/pipelock-verifier/replay_test.go
@@ -133,6 +133,12 @@ func TestReplay_StableVerdict(t *testing.T) {
 	if !report.ReceiptValid {
 		t.Errorf("receipt should be valid, got error %q", report.Error)
 	}
+	if !report.StructuralValid {
+		t.Error("trusted replay should report structural_valid=true")
+	}
+	if !report.VerificationAccepted {
+		t.Error("trusted replay should report verification_accepted=true")
+	}
 	if report.OriginalVerdict != "allow" {
 		t.Errorf("original verdict: got %q, want allow", report.OriginalVerdict)
 	}
@@ -179,6 +185,12 @@ func TestReplay_ForgedSelfConsistentReceiptFailsClosedWithoutPinnedKey(t *testin
 	if report.ReceiptValid {
 		t.Error("self-consistent receipt should not be accepted without --key or --allow-unpinned")
 	}
+	if !report.StructuralValid {
+		t.Error("self-consistent receipt should report structural_valid=true")
+	}
+	if report.VerificationAccepted {
+		t.Error("self-consistent receipt should not be accepted without --allow-unpinned")
+	}
 	if !report.Unpinned {
 		t.Error("self-consistent no-key replay should report unpinned=true")
 	}
@@ -223,8 +235,11 @@ func TestReplay_VerdictChanged_PolicyTightened(t *testing.T) {
 		receiptPath,
 	)
 
-	if !report.ReceiptValid {
-		t.Fatalf("receipt should be valid, got %q", report.Error)
+	if report.ReceiptValid {
+		t.Fatalf("structural-only replay should not report receipt_valid=true: %#v", report)
+	}
+	if !report.StructuralValid || !report.VerificationAccepted {
+		t.Fatalf("structural-only replay should be accepted but not trusted: %#v", report)
 	}
 	if report.OriginalVerdict != "allow" {
 		t.Errorf("original verdict: got %q want allow", report.OriginalVerdict)
@@ -274,8 +289,11 @@ func TestReplay_VerdictChanged_PolicyLoosened(t *testing.T) {
 		receiptPath,
 	)
 
-	if !report.ReceiptValid {
-		t.Fatalf("receipt should be valid, got %q", report.Error)
+	if report.ReceiptValid {
+		t.Fatalf("structural-only replay should not report receipt_valid=true: %#v", report)
+	}
+	if !report.StructuralValid || !report.VerificationAccepted {
+		t.Fatalf("structural-only replay should be accepted but not trusted: %#v", report)
 	}
 	if report.ReplayVerdict != "allow" {
 		t.Errorf("replay verdict: got %q want allow", report.ReplayVerdict)
@@ -430,7 +448,7 @@ func TestReplay_AllowUnpinnedDoesNotWeakenPinnedVerification(t *testing.T) {
 		"--json",
 		receiptPath,
 	)
-	if !report.ReceiptValid || !report.SignaturesVerified || report.Unpinned {
+	if !report.ReceiptValid || !report.StructuralValid || !report.VerificationAccepted || !report.SignaturesVerified || report.Unpinned {
 		t.Fatalf("correct pinned key with --allow-unpinned should remain trusted: %#v", report)
 	}
 	if len(report.Warnings) != 0 {
@@ -458,21 +476,66 @@ func TestReplay_EmptyKeyFlagStillFailsClosed(t *testing.T) {
 	receiptPath := writeSignedReceiptFile(t, dir, ar)
 	policyPath := writePolicyFile(t, dir, nil)
 
+	for _, args := range [][]string{
+		{"--policy", policyPath, "--key", "", "--json", receiptPath},
+		{"--policy", policyPath, "--key", "", "--allow-unpinned", "--json", receiptPath},
+	} {
+		report, _, exitCode := runReplayCommand(t, args...)
+		if report.ReceiptValid || report.StructuralValid || report.VerificationAccepted {
+			t.Fatalf(`%v report = %#v, want no trusted or structural acceptance`, args, report)
+		}
+		if report.Unpinned || report.SignaturesVerified {
+			t.Fatalf(`%v report = %#v, want config failure before unpinned/trusted states`, args, report)
+		}
+		if !strings.Contains(report.Error, "--key was provided but empty") {
+			t.Fatalf("%v error = %q, want empty --key config error", args, report.Error)
+		}
+		if exitCode != cliutil.ExitConfig {
+			t.Fatalf("%v exit code: got %d want %d", args, exitCode, cliutil.ExitConfig)
+		}
+	}
+}
+
+func TestReplay_EmptyKeyFileFailsClosedEvenWhenUnpinnedAllowed(t *testing.T) {
+	dir := t.TempDir()
+	ar := receipt.ActionRecord{
+		Version:       receipt.ActionRecordVersion,
+		ActionID:      receipt.NewActionID(),
+		ActionType:    receipt.ActionRead,
+		Timestamp:     time.Now(),
+		Target:        "https://allowed.example/",
+		Verdict:       "allow",
+		Transport:     "https",
+		ChainPrevHash: receipt.GenesisHash,
+		ChainSeq:      0,
+		PolicyHash:    "policy-fixture",
+	}
+	receiptPath := writeSignedReceiptFile(t, dir, ar)
+	policyPath := writePolicyFile(t, dir, nil)
+	emptyKeyPath := filepath.Join(dir, "empty.pub")
+	if err := os.WriteFile(emptyKeyPath, nil, 0o600); err != nil {
+		t.Fatalf("write empty key file: %v", err)
+	}
+
 	report, _, exitCode := runReplayCommand(t,
 		"--policy", policyPath,
-		"--key", "",
+		"--key", emptyKeyPath,
+		"--allow-unpinned",
 		"--json",
 		receiptPath,
 	)
 
-	if report.ReceiptValid {
-		t.Fatal(`--key "" should be treated as unpinned and fail closed without --allow-unpinned`)
+	if report.ReceiptValid || report.StructuralValid || report.VerificationAccepted {
+		t.Fatalf("empty key file report = %#v, want no trusted or structural acceptance", report)
 	}
-	if !report.Unpinned || report.SignaturesVerified {
-		t.Fatalf(`--key "" report = %#v, want unpinned structural-only without signatures`, report)
+	if report.Unpinned || report.SignaturesVerified {
+		t.Fatalf("empty key file report = %#v, want config failure before unpinned/trusted states", report)
 	}
-	if exitCode != cliutil.ExitGeneral {
-		t.Fatalf("exit code: got %d want %d", exitCode, cliutil.ExitGeneral)
+	if !strings.Contains(report.Error, "resolve signer key:") || !strings.Contains(report.Error, "public key") {
+		t.Fatalf("error = %q, want public-key resolution failure", report.Error)
+	}
+	if exitCode != cliutil.ExitConfig {
+		t.Fatalf("exit code: got %d want %d", exitCode, cliutil.ExitConfig)
 	}
 }
 
@@ -558,9 +621,12 @@ func TestReplay_HumanReadableOutput(t *testing.T) {
 	mustContain := []string{
 		"receipt:",
 		"policy:",
-		"receipt_valid: true",
+		"receipt_valid: false",
+		"structural_valid: true",
+		"verification_accepted: true",
 		"signatures_verified: false",
 		"unpinned:      true",
+		"receipt_valid=false",
 		"self-consistency only",
 		"original:",
 		"replay:",

--- a/cmd/pipelock-verifier/replay_test.go
+++ b/cmd/pipelock-verifier/replay_test.go
@@ -176,37 +176,49 @@ func TestReplay_ForgedSelfConsistentReceiptFailsClosedWithoutPinnedKey(t *testin
 	receiptPath := writeSignedReceiptFile(t, dir, ar)
 	policyPath := writePolicyFile(t, dir, nil)
 
-	report, _, exitCode := runReplayCommand(t,
-		"--policy", policyPath,
-		"--json",
-		receiptPath,
-	)
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "omitted_allow_unpinned",
+			args: []string{"--policy", policyPath, "--json", receiptPath},
+		},
+		{
+			name: "explicit_allow_unpinned_false",
+			args: []string{"--policy", policyPath, "--allow-unpinned=false", "--json", receiptPath},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			report, _, exitCode := runReplayCommand(t, tc.args...)
 
-	if report.ReceiptValid {
-		t.Error("self-consistent receipt should not be accepted without --key or --allow-unpinned")
-	}
-	if !report.StructuralValid {
-		t.Error("self-consistent receipt should report structural_valid=true")
-	}
-	if report.VerificationAccepted {
-		t.Error("self-consistent receipt should not be accepted without --allow-unpinned")
-	}
-	if !report.Unpinned {
-		t.Error("self-consistent no-key replay should report unpinned=true")
-	}
-	if report.SignaturesVerified {
-		t.Error("self-consistent no-key replay should not report signatures_verified=true")
-	}
-	if len(report.Warnings) == 0 || !strings.Contains(report.Warnings[0], "UNPINNED") {
-		t.Fatalf("self-consistent no-key replay should report JSON warning, got %#v", report.Warnings)
-	}
-	for _, want := range []string{"pass --key for provenance", "--allow-unpinned for structural-only verification"} {
-		if !strings.Contains(report.Error, want) {
-			t.Errorf("error missing %q: %q", want, report.Error)
-		}
-	}
-	if exitCode != cliutil.ExitGeneral {
-		t.Errorf("exit code: got %d, want %d", exitCode, cliutil.ExitGeneral)
+			if report.ReceiptValid {
+				t.Error("self-consistent receipt should not be accepted without --key or --allow-unpinned")
+			}
+			if !report.StructuralValid {
+				t.Error("self-consistent receipt should report structural_valid=true")
+			}
+			if report.VerificationAccepted {
+				t.Error("self-consistent receipt should not be accepted without --allow-unpinned")
+			}
+			if !report.Unpinned {
+				t.Error("self-consistent no-key replay should report unpinned=true")
+			}
+			if report.SignaturesVerified {
+				t.Error("self-consistent no-key replay should not report signatures_verified=true")
+			}
+			if len(report.Warnings) == 0 || !strings.Contains(report.Warnings[0], "UNPINNED") {
+				t.Fatalf("self-consistent no-key replay should report JSON warning, got %#v", report.Warnings)
+			}
+			for _, want := range []string{"pass --key for provenance", "--allow-unpinned for structural-only verification"} {
+				if !strings.Contains(report.Error, want) {
+					t.Errorf("error missing %q: %q", want, report.Error)
+				}
+			}
+			if exitCode != cliutil.ExitGeneral {
+				t.Errorf("exit code: got %d, want %d", exitCode, cliutil.ExitGeneral)
+			}
+		})
 	}
 }
 
@@ -394,6 +406,12 @@ func TestReplay_BadKeyMismatch(t *testing.T) {
 	if report.ReceiptValid {
 		t.Error("receipt signed by another key should not validate against the supplied --key")
 	}
+	if !report.StructuralValid {
+		t.Error("receipt signed by another key should still report structural_valid=true when internally self-consistent")
+	}
+	if report.VerificationAccepted {
+		t.Error("receipt signed by another key should not be accepted")
+	}
 	if exitCode != cliutil.ExitGeneral {
 		t.Errorf("exit code: got %d want %d", exitCode, cliutil.ExitGeneral)
 	}
@@ -430,6 +448,12 @@ func TestReplay_AllowUnpinnedDoesNotWeakenPinnedVerification(t *testing.T) {
 	)
 	if report.ReceiptValid {
 		t.Fatal("--allow-unpinned must not accept a receipt signed by a different pinned key")
+	}
+	if !report.StructuralValid {
+		t.Fatal("wrong pinned key should still report structural_valid=true for internally self-consistent receipt")
+	}
+	if report.VerificationAccepted {
+		t.Fatal("wrong pinned key should not report verification_accepted=true")
 	}
 	if report.Unpinned {
 		t.Fatal("--allow-unpinned with --key should stay on the pinned path, not report unpinned")
@@ -476,23 +500,34 @@ func TestReplay_EmptyKeyFlagStillFailsClosed(t *testing.T) {
 	receiptPath := writeSignedReceiptFile(t, dir, ar)
 	policyPath := writePolicyFile(t, dir, nil)
 
-	for _, args := range [][]string{
-		{"--policy", policyPath, "--key", "", "--json", receiptPath},
-		{"--policy", policyPath, "--key", "", "--allow-unpinned", "--json", receiptPath},
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "empty_key",
+			args: []string{"--policy", policyPath, "--key", "", "--json", receiptPath},
+		},
+		{
+			name: "empty_key_with_allow_unpinned",
+			args: []string{"--policy", policyPath, "--key", "", "--allow-unpinned", "--json", receiptPath},
+		},
 	} {
-		report, _, exitCode := runReplayCommand(t, args...)
-		if report.ReceiptValid || report.StructuralValid || report.VerificationAccepted {
-			t.Fatalf(`%v report = %#v, want no trusted or structural acceptance`, args, report)
-		}
-		if report.Unpinned || report.SignaturesVerified {
-			t.Fatalf(`%v report = %#v, want config failure before unpinned/trusted states`, args, report)
-		}
-		if !strings.Contains(report.Error, "--key was provided but empty") {
-			t.Fatalf("%v error = %q, want empty --key config error", args, report.Error)
-		}
-		if exitCode != cliutil.ExitConfig {
-			t.Fatalf("%v exit code: got %d want %d", args, exitCode, cliutil.ExitConfig)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			report, _, exitCode := runReplayCommand(t, tc.args...)
+			if report.ReceiptValid || report.StructuralValid || report.VerificationAccepted {
+				t.Fatalf(`%v report = %#v, want no trusted or structural acceptance`, tc.args, report)
+			}
+			if report.Unpinned || report.SignaturesVerified {
+				t.Fatalf(`%v report = %#v, want config failure before unpinned/trusted states`, tc.args, report)
+			}
+			if !strings.Contains(report.Error, "--key was provided but empty") {
+				t.Fatalf("%v error = %q, want empty --key config error", tc.args, report.Error)
+			}
+			if exitCode != cliutil.ExitConfig {
+				t.Fatalf("%v exit code: got %d want %d", tc.args, exitCode, cliutil.ExitConfig)
+			}
+		})
 	}
 }
 
@@ -572,23 +607,41 @@ func TestReplay_MalformedEmbeddedSignerFailsClosedEvenWhenUnpinnedAllowed(t *tes
 	}
 	policyPath := writePolicyFile(t, dir, nil)
 
-	for _, args := range [][]string{
-		{"--policy", policyPath, "--json", receiptPath},
-		{"--policy", policyPath, "--allow-unpinned", "--json", receiptPath},
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "no_key",
+			args: []string{"--policy", policyPath, "--json", receiptPath},
+		},
+		{
+			name: "allow_unpinned",
+			args: []string{"--policy", policyPath, "--allow-unpinned", "--json", receiptPath},
+		},
+		{
+			name: "pinned_key",
+			args: []string{"--policy", policyPath, "--key", strings.Repeat("0", 64), "--json", receiptPath},
+		},
 	} {
-		report, _, exitCode := runReplayCommand(t, args...)
-		if report.ReceiptValid {
-			t.Fatalf("%v accepted receipt with empty signer_key: %#v", args, report)
-		}
-		if report.Unpinned || report.SignaturesVerified {
-			t.Fatalf("%v report = %#v, want invalid before unpinned/trusted states", args, report)
-		}
-		if !strings.Contains(report.Error, "receipt has no signer_key") {
-			t.Fatalf("%v error = %q, want signer_key failure", args, report.Error)
-		}
-		if exitCode != cliutil.ExitGeneral {
-			t.Fatalf("%v exit code: got %d want %d", args, exitCode, cliutil.ExitGeneral)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			report, _, exitCode := runReplayCommand(t, tc.args...)
+			if report.ReceiptValid {
+				t.Fatalf("%v accepted receipt with empty signer_key: %#v", tc.args, report)
+			}
+			if report.Unpinned || report.SignaturesVerified || report.StructuralValid || report.VerificationAccepted {
+				t.Fatalf("%v report = %#v, want invalid before unpinned/trusted states", tc.args, report)
+			}
+			if tc.name == "pinned_key" && len(report.Details) == 0 {
+				t.Fatalf("%v report = %#v, want structural verification detail", tc.args, report)
+			}
+			if !strings.Contains(report.Error, "receipt has no signer_key") {
+				t.Fatalf("%v error = %q, want signer_key failure", tc.args, report.Error)
+			}
+			if exitCode != cliutil.ExitGeneral {
+				t.Fatalf("%v exit code: got %d want %d", tc.args, exitCode, cliutil.ExitGeneral)
+			}
+		})
 	}
 }
 
@@ -627,7 +680,8 @@ func TestReplay_HumanReadableOutput(t *testing.T) {
 		"signatures_verified: false",
 		"unpinned:      true",
 		"receipt_valid=false",
-		"self-consistency only",
+		"untrusted embedded signer_key",
+		"provenance not verified",
 		"original:",
 		"replay:",
 		"verdict:",


### PR DESCRIPTION
## What changed

`pipelock-verifier replay` accepted a receipt with no trusted signer key and reported it valid with exit code zero. An internally consistent but forged receipt, signed with an attacker's own key, therefore replayed as verified to any automation reading the exit status. The no-key path now fails closed unless `--allow-unpinned` is passed explicitly.

This was the last verify surface still exiting zero on an unpinned check. `verify-receipt`, and the `receipt`, `chain`, and `completeness` verifier subcommands already require `--allow-unpinned`; `audit-packet` requires `--allow-self-consistent-only`; and `coverage-cert` was aligned in #1014. Replay now matches that contract.

## Behavior

| Invocation | Before | After |
| --- | --- | --- |
| no `--key` | exit 0, `receipt_valid: true` | exit 1, names both remedies |
| `--allow-unpinned` | flag did not exist | exit 0, `signatures_verified: false` plus an explicit warning |
| correct `--key` | exit 0 | unchanged |
| wrong `--key` | exit 2 | exit 1, matching the sibling verifiers |

Structural-only verification under `--allow-unpinned` reports `signatures_verified: false` and carries a warning in both the human and JSON output, so a consumer cannot read `receipt_valid` alone as proof of provenance.

## Breaking changes

Unpinned replay now requires either `--key` or `--allow-unpinned`. A script that relied on unpinned replay exiting zero must add `--allow-unpinned` to keep its current behavior, and should prefer `--key` where the signer is known.

Verification failures now exit 1 rather than 2. Exit 2 remains reserved for input and configuration errors, matching the other verifier subcommands. A script that branched on exit 2 to detect a signature mismatch must branch on exit 1.

## Notes

The report struct gains `signatures_verified`, `unpinned`, and `warnings`. These are additive on an unsigned report; no existing field was removed or repurposed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit trusted-key vs unpinned (structural-only) verification for replay.
  * Introduced `--allow-unpinned` to accept structural validity without trusted receipt verification.
  * Replay reports now include structural validity, verification-acceptance, signature status, and unpinned warnings; output routing and exit behavior align with acceptance.

* **Bug Fixes**
  * Improved failure-closed behavior for missing/empty/malformed or mismatched signer keys, including `--key ""` rejection even with `--allow-unpinned`.
  * Updated human-readable and JSON/plain report fields and semantics accordingly.

* **Tests**
  * Extended replay tests to cover pinned vs unpinned paths, warnings, and exit-code expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->