### PR TITLE
chore(release): reconcile v3.2.0 changelog, chart, and broken instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Pipelock will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.2.0] - UNRELEASED
 
 ### Added
 
@@ -13,31 +13,131 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   proxy modes can require a reloadable bearer-token file and an exact browser
   Origin allowlist. Listener credentials are consumed before request scanning
   and are never forwarded upstream; browser preflight and MCP protocol-version
-  headers are handled explicitly.
+  headers are handled explicitly. (#1010)
+- **Runnable security examples now ship with offline verification.** New
+  examples cover MCP tool policy, fetch-proxy SSRF blocking, and kill-switch
+  activation with scripts that stand up the scenario and prove the expected
+  allow and deny paths locally. (#1004, #1005, #1006)
+- **Coverage-certificate signing keys are first-class.** `pipelock signing key
+  generate --purpose coverage-cert-signing` now emits keys with the purpose
+  expected by coverage-certificate generation and verification. (#1012)
 
 ### Changed
 
 - **Non-loopback MCP HTTP listeners now fail closed by default.** Operators must
   configure a listener token file or explicitly acknowledge unauthenticated
   operation behind a verified network boundary. Helm MCP sidecars enforce the
-  same choice and reject Service/listener port mismatches.
+  same choice and reject Service/listener port mismatches. (#1010)
+- **Startup validation is now split between config-lint checks and
+  startup-equivalent doctor checks.** `pipelock check` still catches parse
+  errors, deterministic semantic contradictions, and path existence and
+  permission-shape errors. Preconditions that must open and read a file, such as
+  a secrets file that exists but cannot be read, moved to `pipelock doctor
+  --startup`, so operators keep a startup-equivalent preflight. (#1012)
+- **Scanner construction now returns operator errors instead of panicking.**
+  Invalid merged scanner inputs, such as unreadable secrets files, invalid DLP
+  validators, bad CIDRs, or invalid response patterns, now produce ordinary
+  startup errors; hot reload preserves the running scanner when a replacement
+  cannot be built. (#1012)
+- **Executable config examples are release-gated.** CI now extracts shipped YAML
+  examples, runs `pipelock check`, boots valid runtime configs, and fails when a
+  documented config cannot start; examples that referenced unsupported fields
+  or non-booting recorder settings were corrected. (#1009, #1011)
+- **Credential guard watches are exact.** Contained-install credential guards
+  now watch the configured credential files and atomic rewrites directly instead
+  of broad parent-directory changes. (#1008)
 
 ### Fixed
 
+- **Coverage-certificate verification now fails closed without trusted
+  signers.** `dashboard coverage-cert verify` and `evidence verify-cert` now
+  exit non-zero when no trusted signer is supplied, separate structural
+  validity from signer trust in the result, and require the explicit
+  `--allow-unpinned` opt-in for structural-only checks. (#1014)
+- **Receipt replay verification now fails closed without a pinned signer.**
+  `pipelock-verifier replay` previously accepted a receipt's own embedded key as
+  proof, so a forged self-consistent receipt replayed as verified. Replay now
+  requires `--key`, or the explicit `--allow-unpinned` opt-in for structural-only
+  verification, and reports verification failure as exit 1 to match the sibling
+  verifiers. A `warnings` field distinguishes a structurally valid receipt whose
+  signatures were not verified. (#1016)
+- **A2A forward-proxy request bodies are scanned.** A2A request bodies now flow
+  through the plain forward-proxy scanning path, block reasons are mapped from
+  scanner findings, and FilePart metadata URI SSRF coverage protects the
+  regression case. (#1013)
 - **MCP HTTP listener boundary hardening.** Tokenless loopback listeners reject
   DNS-rebound or wrong-port Host authorities; listener credentials are scrubbed
   from both authentication headers, including duplicate-value attacks; and
   operator-pinned Authorization, MCP protocol-version, and A2A service headers
   cannot be replaced by client input. Duplicate or malformed session,
   protocol-version, and A2A service headers fail closed before scanning or
-  upstream forwarding.
-
+  upstream forwarding. (#1010)
 - **Cross-language evidence parsing now rejects ambiguous JSON.** Go,
-  TypeScript, and Rust verifier paths reject duplicate keys, invalid UTF-8, and
-  numbers outside JavaScript's exact integer range before trusting receipts or
-  audit packets.
+  TypeScript, Rust, and Python verifier paths reject duplicate keys, invalid
+  UTF-8, and numbers outside JavaScript's exact integer range before trusting
+  receipts or audit packets. Python also rejects CPython's non-standard
+  `NaN` and `Infinity` constants during receipt parsing. (#1010)
+- **Parser and trust-boundary inputs are bounded.** Internal duplicate-key
+  parsing, secure file reads, tool-chain matching, verifier inputs, OIDC
+  discovery documents, JWKS responses, release-manifest payloads, and related
+  trust-boundary parsers now enforce fixed input bounds before parsing or
+  verification. (#1010)
+- **Scanner cleanup goroutines no longer leak per instance.** Scanner lifetime
+  cleanup now avoids creating per-instance background goroutines for rate-limit,
+  data-budget, entropy, and fragment buffers. (#1010)
 
-### Removed
+### Dependencies / CI
+
+- **Python conformance verifier `setuptools` bumped to 83.0.0** (security
+  advisory). (#1007)
+
+### ⚠️ Breaking Changes / Upgrade Notes
+
+Six of the seven below fail closed: they reject configuration or an invocation that
+v3.1.0 accepted, and none of them opens a hole. The seventh moves a check rather
+than removing it, so a CI gate that depended on the old location needs updating.
+Review before upgrading.
+
+- **Non-loopback MCP HTTP listeners require an explicit auth choice.**
+  `pipelock run --mcp-listen 0.0.0.0:PORT --mcp-upstream ...` now refuses to
+  start without listener authentication or an explicit unauthenticated
+  acknowledgement. For combined `pipelock run` mode, set
+  `--mcp-auth-token-file` to a secure bearer-token file, or set
+  `--mcp-allow-unauthenticated` only behind a verified network boundary. For
+  standalone `pipelock mcp proxy --listen`, use `--listener-auth-token-file` or
+  `--listener-allow-unauthenticated`. Helm users can set
+  `mcp.authTokenFile` or, behind a verified NetworkPolicy boundary,
+  `mcp.allowUnauthenticated`. (#1010)
+- **Helm MCP Service ports must match the listener port.** The chart now rejects
+  values where `mcp.listen` does not end with `service.mcpPort`, because that
+  rendered a Service port where Pipelock was not actually listening. Set
+  `service.mcpPort` to the port in `mcp.listen`, or change `mcp.listen` to end
+  with the existing Service port. (#1010)
+- **Unpinned verification now exits non-zero.** `pipelock-verifier replay`,
+  `dashboard coverage-cert verify`, and `evidence verify-cert` previously exited
+  zero when no trusted signer was supplied, so a consumer keying on the exit code
+  could treat a forged artifact as verified. All three now fail closed. Pass the
+  trusted signer (`--key` for replay, `--trusted-signer` for the certificate
+  verifiers), or pass `--allow-unpinned` for an explicit structural-only check
+  that reports the signer as untrusted. Replay's verification-failure exit code
+  also moved from 2 to 1 to match the sibling verifiers; exit 2 now means
+  malformed input or an unloadable key or policy. (#1014, #1016)
+- **File-loaded `fetch_proxy.listen: ":0"` is rejected.** Config files must use
+  a real TCP port for fetch-proxy listeners instead of asking the runtime to
+  pick an ephemeral port. (#1012)
+- **Required receipts now require a signing key.** A config with
+  `flight_recorder.require_receipts: true` and no `signing_key_path` is
+  rejected because the old shape silently wrote no signed receipts. Set
+  `flight_recorder.signing_key_path` to a recorder signing key. (#1012)
+- **Raw escrow now validates its public key offline.** A config with
+  `flight_recorder.raw_escrow: true` is rejected unless
+  `escrow_public_key` is exactly 64 hexadecimal characters. (#1012)
+- **Some host-dependent startup checks moved out of `pipelock check`.** CI gates
+  that relied on `pipelock check` to catch an existing but unreadable
+  `dlp.secrets_file` will now pass that config and fail at startup instead.
+  Missing files and unsafe permission shapes are still config-validation errors.
+  Use `pipelock doctor --startup --config FILE` when the mounted host files are
+  present and startup-equivalent validation is required. (#1012)
 
 ## [3.1.0] - 2026-07-13
 

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pipelock
 description: Agent firewall for AI agents. Network scanning, process containment, and tool policy enforcement.
 type: application
-version: 0.7.0
-appVersion: "3.1.0"
+version: 0.8.0
+appVersion: "3.2.0"
 home: https://pipelab.org
 sources:
   - https://github.com/luckyPipewrench/pipelock
@@ -30,15 +30,15 @@ annotations:
     - name: Audit Packet verifier
       url: https://github.com/luckyPipewrench/pipelock-verify-python
   artifacthub.io/changes: |
-    - kind: added
-      description: Pipelock appVersion 3.1.0. Operator dashboard revamp with evidence, agents, budgets, trust and keys, fleet overview, signed-action workbench, incident cockpit, and a free single-session evidence viewer.
-    - kind: added
-      description: Conductor dry-run and decision replay for publish, kill, resume, and rollback actions, plus runtime/apply-state drift preflight for policy publish.
     - kind: changed
-      description: Receipt and evidence verification hardening - strict unknown-field rejection, durable session lifecycle evidence, evidence-health metrics, cross-language verifier parity, and honest kernel_observed containment wording.
+      description: Pipelock appVersion 3.2.0. MCP listener authentication, Origin allowlists, non-loopback fail-closed defaults, and parser hardening across trust boundaries.
+    - kind: changed
+      description: Startup validation now separates offline config checks from host-dependent doctor checks, with scanner construction returning errors and failed reloads preserving the running scanner.
+    - kind: changed
+      description: Executable config examples are release-gated in CI, so shipped YAML examples must pass check and boot when they claim to be runnable.
     - kind: added
-      description: Dashboard mTLS/OIDC/token authentication, RBAC permissions, exemption lifecycle records, coverage certificates, backup/restore, and durable SIEM forwarding.
+      description: Verified runnable examples for MCP tool policy, fetch-proxy SSRF blocking, and kill-switch activation.
     - kind: fixed
-      description: Rekor anchoring now requires an explicit URL, submits Ed25519 Rekor v1 hashedrekord entries with sha512 by default, and verifies anchored receipts with pinned Rekor log keys.
+      description: Coverage-certificate verification fails closed without trusted signers unless --allow-unpinned is set for structural-only checks.
     - kind: fixed
-      description: Reloads fail closed when bundle-resolution errors would drop live detections; coverage-certificate verification fails closed on untrusted pinned signers.
+      description: A2A forward-proxy request bodies are scanned, credential guard watches are exact, and release certification runs faster with sharded race-test gates.

--- a/docs/guides/deployment-recipes.md
+++ b/docs/guides/deployment-recipes.md
@@ -88,6 +88,10 @@ services:
       --listen 0.0.0.0:8888
       --mcp-listen 0.0.0.0:8889
       --mcp-upstream http://mcp-server:3000/mcp
+      --mcp-auth-token-file /run/pipelock/mcp-listener.token
+    volumes:
+      - ./pipelock.yaml:/config/pipelock.yaml:ro
+      - ./mcp-listener.token:/run/pipelock/mcp-listener.token:ro
     # ...
 
   mcp-server:
@@ -95,6 +99,8 @@ services:
     networks:
       - agent-internal
 ```
+
+Create `mcp-listener.token` with a long random bearer token and mount it read-only. Non-loopback MCP listeners fail closed unless you provide a token file or explicitly acknowledge unauthenticated operation behind a verified network boundary.
 
 ### Kill Switch API on a Separate Port
 

--- a/docs/guides/suppression.md
+++ b/docs/guides/suppression.md
@@ -119,19 +119,24 @@ Use the `exclude-paths` input (one pattern per line):
 
 ### Config-level suppression
 
-Use the `config` input to provide inline YAML config with suppress entries:
+Write a Pipelock config file, then pass its path with the `config` input:
 
 ```yaml
+- name: Write Pipelock config
+  run: |
+    cat > pipelock-ci.yaml <<'EOF'
+    suppress:
+      - rule: "Credential in URL"
+        path: "docs/"
+        reason: "Documentation examples"
+      - rule: "JWT Token"
+        path: "test/"
+        reason: "Test tokens"
+    EOF
+
 - uses: luckyPipewrench/pipelock@v2
   with:
-    config: |
-      suppress:
-        - rule: "Credential in URL"
-          path: "docs/"
-          reason: "Documentation examples"
-        - rule: "JWT Token"
-          path: "test/"
-          reason: "Test tokens"
+    config: pipelock-ci.yaml
 ```
 
 ### Inline comments

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -186,7 +186,9 @@ rules:
 DLP rules may set `pattern.validator` to `luhn`, `mod97`, `aba`, or `wif` when
 the identifier carries that checksum. Pipelock applies the validator after a
 regex match, so malformed lookalikes do not become DLP findings. Bundle
-validators require Pipelock 3.2 or newer; set `min_pipelock` accordingly.
+authors should declare `required_features: ["checksum"]` and set
+`min_pipelock` to the oldest Pipelock release whose rule-bundle loader supports
+the `pattern.validator` field.
 
 `format_version: 1` bundles still load for backwards compatibility, but new bundles should use `format_version: 2` so they can declare `tier`, `required_features`, and freshness metadata. The v2 validation also requires `monotonic_version`, `published_at`, and `expires_at`.
 

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -132,7 +132,9 @@ Examples:
   pipelock run                                       # standalone proxy
   pipelock run --config pipelock.yaml                # with config file (hot-reload)
   pipelock run --mode strict --listen 0.0.0.0:9999   # override mode and listen address
-  pipelock run --mcp-listen 0.0.0.0:8889 --mcp-upstream http://mcp-server:3000/mcp`,
+  pipelock run --mcp-listen 0.0.0.0:8889 \
+    --mcp-upstream http://mcp-server:3000/mcp \
+    --mcp-auth-token-file /run/pipelock/mcp-listener.token`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			dashIdx := cmd.ArgsLenAtDash()
 			switch {

--- a/internal/report/compliance/hipaa_test.go
+++ b/internal/report/compliance/hipaa_test.go
@@ -53,10 +53,10 @@ func TestHIPAASecurityRule_StructuralInvariants(t *testing.T) {
 	}
 }
 
-// TestHIPAASecurityRule_NoFabricatedClaims guards against the class of
-// overclaim Codex caught on 2026-05-21 (HTTPS-only enforcement, MRN
-// detection). Add a phrase here when a future edit risks promising
-// behavior the binary does not implement.
+// TestHIPAASecurityRule_NoFabricatedClaims guards against a class of overclaim
+// an independent review found: HTTPS-only enforcement and MRN detection are not
+// implemented by the binary. Add a phrase here when a future edit risks
+// promising behavior the binary does not implement.
 func TestHIPAASecurityRule_NoFabricatedClaims(t *testing.T) {
 	f := HIPAASecurityRule()
 	type forbidden struct {


### PR DESCRIPTION
## What changed

Reconciles the release surface for v3.2.0. The `[Unreleased]` changelog had four bullets covering about a third of one PR while twelve PRs had landed since v3.1.0. This rewrites it to cover all twelve, bumps the chart, and fixes four shipped instructions that no longer work.

### Changelog

Complete coverage of every PR merged since v3.1.0, with a `Breaking Changes / Upgrade Notes` section that names the exact remedy flag for each rejection rather than describing the rejection alone.

The version date is a literal `UNRELEASED` placeholder on purpose. It gets stamped at tag time. This has shipped wrong twice: v3.0.0 needed a correction PR, and v3.1.0 is still wrong on main right now (tagged 07-14, changelog says 07-13).

Two corrections to already-shipped entries: a bullet credited ambiguous-JSON rejection to three verifier languages when Python was hardened in the same PR, and the unpinned-verification changes were documented as fixes without noting that they reject an invocation v3.1.0 accepted.

### Chart

`appVersion` 3.1.0 to 3.2.0, and chart `version` 0.7.0 to 0.8.0.

Both are required. `values.yaml` defaults `image.tag` to `.Chart.AppVersion`, so tagging without the appVersion bump makes a chart install from v3.2.0 source deploy the 3.1.0 image. The chart version feeds the `helm.sh/chart` label on every rendered resource, and every prior minor bumped it (0.5.0 for v2.8.0, 0.6.0 for v3.0.0, 0.7.0 for v3.1.0), so leaving it at 0.7.0 would label two charts with different content identically.

### Broken instructions

Four fixes, each verified by running the documented command against a candidate binary:

The Docker MCP recipe and the `run --help` example both told operators to run `pipelock run --mcp-listen 0.0.0.0:PORT` with no listener auth. That command now refuses to start. Both now pass `--mcp-auth-token-file` and the recipe mounts the token file.

The suppression guide passed inline YAML to an input that only accepts a path, which never worked.

`docs/rules.md` claimed a validator requirement that does not exist.

One OPSEC scrub in `hipaa_test.go`.

## Verification

The old documented invocation exits 1 with the remedy message. The fixed invocation starts, serves health, binds the MCP listener, and returns 407 for both an absent and a wrong bearer token. The chart lints and renders `helm.sh/chart: pipelock-0.8.0` with image tag 3.2.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated MCP HTTP listener support with bearer tokens and browser Origin allowlists.
  * Added runnable security examples with offline verification.
  * Added coverage-certificate signing key support.

* **Security & Reliability**
  * Hardened listener, receipt, certificate, evidence, and scanning verification with fail-closed behavior.
  * Improved scanner reload handling and prevented cleanup leaks.
  * Added stricter validation for hosts, ports, headers, and ambiguous inputs.

* **Documentation**
  * Updated deployment, suppression, rule-bundle, and command guidance for the 3.2.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->