### PR TITLE
chore(release): stamp v3.2.0 date and add release-readiness gate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,24 @@ on:
 permissions: {}
 
 jobs:
+  # Hard gate: runs first, every build/publish job needs it. Fails the release
+  # BEFORE anything is built if the tag's metadata is wrong (CHANGELOG dated
+  # UNRELEASED/placeholder, or Chart appVersion not bumped). These are the
+  # recurring release mistakes that a human checklist kept missing.
+  release-preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Release-readiness gate
+        run: scripts/check-release-ready.sh "$GITHUB_REF_NAME"
+
   release-tests:
+    needs: [release-preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
   # UNRELEASED/placeholder, or Chart appVersion not bumped). These are the
   # recurring release mistakes that a human checklist kept missing.
   release-preflight:
+    name: release-preflight (metadata gate)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to Pipelock will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.0] - UNRELEASED
+## [Unreleased]
+
+## [3.2.0] - 2026-07-16
 
 ### Added
 

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -35,14 +35,14 @@ echo "release-ready gate: version=$VER"
 line="$(grep -E "^## \[${VER//./\\.}\]" "$CHANGELOG" | head -1 || true)"
 if [ -z "$line" ]; then
   note "CHANGELOG.md has no '## [$VER]' section. The version heading never landed on this ref."
-elif ! printf '%s' "$line" | grep -qE "^## \[${VER//./\\.}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}( .*)?$"; then
+elif ! printf '%s\n' "$line" | grep -qE "^## \[${VER//./\\.}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}( .*)?$"; then
   note "CHANGELOG.md '$VER' section is not dated YYYY-MM-DD (found: '${line}'). Stamp the real release date; 'UNRELEASED' and blanks are the recurring bug."
 else
   echo "  [ok]   CHANGELOG: ${line}"
 fi
 
 # 2. Chart appVersion must equal the release version.
-app="$(grep -E '^appVersion:' "$CHART" | head -1 | sed -E 's/^appVersion:[[:space:]]*"?([^"[:space:]]+)"?.*/\1/')"
+app="$(grep -E '^appVersion:' "$CHART" | head -1 | sed -E 's/^appVersion:[[:space:]]*"?([^"[:space:]]+)"?.*/\1/' || true)"
 if [ "$app" != "$VER" ]; then
   note "charts/pipelock/Chart.yaml appVersion is '$app', expected '$VER'. values.yaml defaults image.tag to appVersion, so a mismatch deploys the wrong image."
 else

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -32,13 +32,21 @@ note() { printf '  [FAIL] %s\n' "$1" >&2; fail=1; }
 echo "release-ready gate: version=$VER"
 
 # 1. CHANGELOG: a "## [<ver>] - <YYYY-MM-DD>" heading must exist with a real date.
-line="$(grep -E "^## \[${VER//./\\.}\]" "$CHANGELOG" | head -n 1 || true)"
-if [ -z "$line" ]; then
-  note "CHANGELOG.md has no '## [$VER]' section. The version heading never landed on this ref."
-elif ! printf '%s\n' "$line" | grep -qE "^## \[${VER//./\\.}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}( .*)?$"; then
-  note "CHANGELOG.md '$VER' section is not dated YYYY-MM-DD (found: '${line}'). Stamp the real release date; 'UNRELEASED' and blanks are the recurring bug."
+# Match the version LITERALLY (grep -F) so metacharacters in a version string
+# (e.g. the '+' in '3.2.0+build.1') are never interpreted as regex; validate the
+# date part on its own, where no version text is interpolated.
+heading="$(grep -F "## [$VER] - " "$CHANGELOG" | head -n 1 || true)"
+if [ -n "$heading" ]; then
+  date_part="${heading#"## [$VER] - "}"
+  if printf '%s\n' "$date_part" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}( .*)?$'; then
+    echo "  [ok]   CHANGELOG: ${heading}"
+  else
+    note "CHANGELOG.md '$VER' date is '${date_part}', not YYYY-MM-DD. Stamp the real release date; 'UNRELEASED' and blanks are the recurring bug."
+  fi
+elif grep -Fq "## [$VER]" "$CHANGELOG"; then
+  note "CHANGELOG.md '$VER' section exists but has no '## [$VER] - <date>' heading. Stamp the real release date; 'UNRELEASED' and blanks are the recurring bug."
 else
-  echo "  [ok]   CHANGELOG: ${line}"
+  note "CHANGELOG.md has no '## [$VER]' section. The version heading never landed on this ref."
 fi
 
 # 2. Chart appVersion must equal the release version.

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -32,7 +32,7 @@ note() { printf '  [FAIL] %s\n' "$1" >&2; fail=1; }
 echo "release-ready gate: version=$VER"
 
 # 1. CHANGELOG: a "## [<ver>] - <YYYY-MM-DD>" heading must exist with a real date.
-line="$(grep -E "^## \[${VER//./\\.}\]" "$CHANGELOG" | head -1 || true)"
+line="$(grep -E "^## \[${VER//./\\.}\]" "$CHANGELOG" | head -n 1 || true)"
 if [ -z "$line" ]; then
   note "CHANGELOG.md has no '## [$VER]' section. The version heading never landed on this ref."
 elif ! printf '%s\n' "$line" | grep -qE "^## \[${VER//./\\.}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}( .*)?$"; then
@@ -42,7 +42,7 @@ else
 fi
 
 # 2. Chart appVersion must equal the release version.
-app="$(grep -E '^appVersion:' "$CHART" | head -1 | sed -E 's/^appVersion:[[:space:]]*"?([^"[:space:]]+)"?.*/\1/' || true)"
+app="$(grep -E '^appVersion:' "$CHART" | head -n 1 | sed -E 's/^appVersion:[[:space:]]*"?([^"[:space:]]+)"?.*/\1/' || true)"
 if [ "$app" != "$VER" ]; then
   note "charts/pipelock/Chart.yaml appVersion is '$app', expected '$VER'. values.yaml defaults image.tag to appVersion, so a mismatch deploys the wrong image."
 else

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Release-readiness gate. Hard-fails a release whose metadata does not match the
+# tag, BEFORE anything is built. Catches the recurring release mistakes that no
+# human checklist reliably caught:
+#   - CHANGELOG version section missing, or dated UNRELEASED / a placeholder
+#     (shipped wrong on v3.0.0 and v3.1.0).
+#   - Chart appVersion not bumped to the release version (values.yaml defaults
+#     image.tag to appVersion, so a stale one deploys the previous image).
+#
+# Usage:
+#   scripts/check-release-ready.sh v3.2.0     # explicit tag
+#   scripts/check-release-ready.sh            # reads $GITHUB_REF_NAME (CI tag push)
+#
+# Exit 0 = ready. Exit 1 = a blocking problem (printed). Run it locally before
+# tagging; release CI runs it as the first gate every other release job needs.
+set -euo pipefail
+
+VERSION="${1:-${GITHUB_REF_NAME:-}}"
+if [ -z "$VERSION" ]; then
+  echo "check-release-ready: no version given and GITHUB_REF_NAME unset" >&2
+  exit 2
+fi
+VER="${VERSION#v}" # strip leading v -> bare semver used in CHANGELOG/Chart
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+CHART="$REPO_ROOT/charts/pipelock/Chart.yaml"
+
+fail=0
+note() { printf '  [FAIL] %s\n' "$1" >&2; fail=1; }
+
+echo "release-ready gate: version=$VER"
+
+# 1. CHANGELOG: a "## [<ver>] - <YYYY-MM-DD>" heading must exist with a real date.
+line="$(grep -E "^## \[${VER//./\\.}\]" "$CHANGELOG" | head -1 || true)"
+if [ -z "$line" ]; then
+  note "CHANGELOG.md has no '## [$VER]' section. The version heading never landed on this ref."
+elif ! printf '%s' "$line" | grep -qE "^## \[${VER//./\\.}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}( .*)?$"; then
+  note "CHANGELOG.md '$VER' section is not dated YYYY-MM-DD (found: '${line}'). Stamp the real release date; 'UNRELEASED' and blanks are the recurring bug."
+else
+  echo "  [ok]   CHANGELOG: ${line}"
+fi
+
+# 2. Chart appVersion must equal the release version.
+app="$(grep -E '^appVersion:' "$CHART" | head -1 | sed -E 's/^appVersion:[[:space:]]*"?([^"[:space:]]+)"?.*/\1/')"
+if [ "$app" != "$VER" ]; then
+  note "charts/pipelock/Chart.yaml appVersion is '$app', expected '$VER'. values.yaml defaults image.tag to appVersion, so a mismatch deploys the wrong image."
+else
+  echo "  [ok]   Chart appVersion: $app"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "release-ready gate: FAILED — fix the above before tagging $VERSION." >&2
+  exit 1
+fi
+echo "release-ready gate: OK"


### PR DESCRIPTION
## What this does

This is the final PR before tagging v3.2.0. It does two things: stamps the release date, and adds a mechanical gate so the release mistakes that keep shipping cannot ship again.

## Date stamp

`CHANGELOG.md` moves from `## [3.2.0] - UNRELEASED` to `## [3.2.0] - 2026-07-16`, with a fresh empty `## [Unreleased]` section on top for the next cycle. The `UNRELEASED` placeholder shipped as the literal release date on both v3.0.0 and v3.1.0 because it depended on someone remembering to stamp it at tag time.

## Release-readiness gate

`scripts/check-release-ready.sh` runs against a tag version and fails if the release metadata is wrong. A new `release-preflight` job runs it first, and every build and publish job depends on it, so a bad tag produces no release at all.

The gate blocks two things, each proven by reproduction:

A CHANGELOG version section that is missing, or dated `UNRELEASED` or any non-date placeholder. This is the bug above, now caught at the tag instead of by memory.

A chart `appVersion` that does not equal the tag version. `values.yaml` defaults `image.tag` to `appVersion`, so a stale one installs the previous release's image from new chart source.

The script is also runnable locally before tagging: `scripts/check-release-ready.sh v3.2.0`.

## Verification

The gate passes on the current tree, and fails on each defect it targets: date reverted to `UNRELEASED` fails, chart appVersion reverted to 3.1.0 fails, a version with no CHANGELOG section fails. v3.2.0 is the first tag this gate guards, so it proves itself on the way out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Added a release preflight validation gate that runs before the release test matrix.
  * Releases now stop early if the release tag’s metadata is invalid—specifically, the changelog version/date format and the app version in the deployment chart must match.
* **Documentation**
  * Updated the changelog formatting to use the standard “Unreleased” header.
  * Adjusted the 3.2.0 entry to be a properly dated release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->