### PR TITLE
chore(release): set v3.2.0 changelog date to tag date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.2.0] - 2026-07-16
+## [3.2.0] - 2026-07-17
 
 ### Added
 


### PR DESCRIPTION
Sets the v3.2.0 CHANGELOG date to the actual tag date. The date was staged as 2026-07-16 when the release was expected a day earlier, and tagging is happening 2026-07-17.

This is the last change before the tag. The release-readiness gate confirms the section is dated correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Pipelock 3.2.0 release date in the changelog to July 17, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->