### PR TITLE
fix(flight-recorder,runtime): record heartbeat cadence in session_open and report the resolved listener port at startup

### DIFF
--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1018,13 +1018,14 @@ Key-free evidence capture:
 				// nil MetricsSink is a safe no-op in the emitter, so emit-
 				// failure counters are wired opportunistically here.
 				receiptEmitter = receipt.NewEmitter(receipt.EmitterConfig{
-					Recorder:       rec,
-					PrivKey:        recPrivKey,
-					ConfigHash:     cfg.Hash(),
-					Principal:      "local",
-					Actor:          "pipelock",
-					Metrics:        mcpMetrics,
-					PostureBinding: postureBinding,
+					Recorder:         rec,
+					PrivKey:          recPrivKey,
+					ConfigHash:       cfg.Hash(),
+					Principal:        "local",
+					Actor:            "pipelock",
+					Metrics:          mcpMetrics,
+					PostureBinding:   postureBinding,
+					HeartbeatSeconds: cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
 				})
 
 				cmd.PrintErrf("  Recorder: %s (flight recorder enabled)\n", cfg.FlightRecorder.Dir)

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -1374,74 +1374,92 @@ func TestRunCmd_ReverseUpstreamInvalidURL(t *testing.T) {
 }
 
 // TestRunCmd_EarlyBindErrorJoinsListenerGoroutines guards the runtime shutdown
-// lifecycle. When the fetch proxy fails to bind (an early-error return) after
-// an MCP listener goroutine has already been spawned, Server.cleanup() must
-// not run before that goroutine is joined: the goroutine reads shared Server
-// fields (e.g. s.logger) while cleanup() closes and nils them. The MCP
-// listener binds and its serving goroutine starts before proxy.Start, so
-// pre-binding the fetch port reliably reaches the early return with a live
-// goroutine. Without the lifecycle join, the race detector reports a write to
-// s.logger in cleanup() racing the goroutine's read. This is a regression
-// guard: it must pass under -race.
+// lifecycle. When a listener bind fails (an early-error return) after a listener
+// goroutine that reads shared Server state is already live, Server.cleanup()
+// must not run before that goroutine is joined: the deferred cancel() +
+// lifecycleWG.Wait() must complete before cleanup() closes and nils those
+// fields. Without the join, the race detector reports the cleanup write racing
+// the goroutine.
+//
+// The fetch listener now pre-binds before the other listeners, so holding the
+// fetch port would fail before any goroutine spawns. Instead we let the MCP
+// listener bind successfully — its serving goroutine reads s.logger — and hold
+// the reverse_proxy listener port, so the reverse-proxy bind (which runs after
+// the MCP goroutine is live) takes the early-error return with that goroutine
+// still in lifecycleWG. Must pass under -race.
 func TestRunCmd_EarlyBindErrorJoinsListenerGoroutines(t *testing.T) {
-	// Hold the fetch_proxy.listen port open so proxy.Start fails to bind and
-	// Start() takes the early-error return path.
-	blocker, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp4", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen blocker: %v", err)
-	}
-	defer func() { _ = blocker.Close() }()
-	mainAddr := blocker.Addr().String()
+	testport.WithRetry(t, 1, func(addrs []string) error {
+		fetchAddr := addrs[0]
 
-	mcpUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer mcpUpstream.Close()
+		// Hold the reverse_proxy.listen port so its bind fails and Start() takes
+		// the early-error return after the MCP listener goroutine is live.
+		blocker, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp4", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen blocker: %v", err)
+		}
+		defer func() { _ = blocker.Close() }()
+		heldReverseAddr := blocker.Addr().String()
 
-	cfgYAML := fmt.Sprintf(`version: 1
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer upstream.Close()
+
+		cfgYAML := fmt.Sprintf(`version: 1
 mode: balanced
 fetch_proxy:
   listen: %q
   timeout_seconds: 5
+reverse_proxy:
+  enabled: true
+  upstream: %q
+  listen: %q
 logging:
   format: json
   output: stdout
-`, mainAddr)
+`, fetchAddr, upstream.URL, heldReverseAddr)
 
-	cfgPath := filepath.Join(t.TempDir(), "pipelock-earlybind.yaml")
-	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+		cfgPath := filepath.Join(t.TempDir(), "pipelock-earlybind.yaml")
+		if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	cmd := RunCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{
-		"--config", cfgPath,
-		// Ephemeral MCP listen port: the test never dials it, it only needs
-		// the listener goroutine to spawn (and read s.logger) before the held
-		// fetch port forces the early-error return. :0 avoids close-then-reuse
-		// TOCTOU for a port that is never connected to.
-		"--mcp-listen", "127.0.0.1:0",
-		"--mcp-upstream", mcpUpstream.URL,
+		cmd := RunCmd()
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{
+			"--config", cfgPath,
+			// Ephemeral MCP listen: its serving goroutine (which reads s.logger)
+			// spawns before the held reverse-proxy bind fails.
+			"--mcp-listen", "127.0.0.1:0",
+			"--mcp-upstream", upstream.URL,
+		})
+		var stderr syncBuffer
+		cmd.SetErr(&stderr)
+		cmd.SetOut(&stderr)
+
+		// Synchronous run: the held reverse_proxy port forces a fast bind error
+		// after the MCP goroutine is live. Start() must join it before cleanup()
+		// returns, so by the time Execute() returns no goroutine is still reading
+		// the fields cleanup() nils.
+		err = cmd.Execute()
+		if err == nil {
+			t.Fatal("expected reverse_proxy bind error, got nil")
+		}
+		if strings.Contains(err.Error(), "reverse_proxy.listen bind") {
+			return nil // the guarded early-error path ran with the MCP goroutine live
+		}
+		// A fetch bind conflict is a port TOCTOU (another process grabbed the
+		// testport-provided address), not the scenario under test — signal
+		// testport to retry with fresh ports rather than failing.
+		if strings.Contains(err.Error(), "bind") {
+			return err
+		}
+		t.Errorf("expected reverse_proxy bind error, got: %v", err)
+		return nil
 	})
-	var stderr syncBuffer
-	cmd.SetErr(&stderr)
-	cmd.SetOut(&stderr)
-
-	// Synchronous run: the held fetch port forces a fast bind error. Start()
-	// must join the spawned MCP listener goroutine before cleanup() returns,
-	// so by the time Execute() returns there is no goroutine still reading the
-	// fields cleanup() nils.
-	err = cmd.Execute()
-	if err == nil {
-		t.Fatal("expected fetch_proxy bind error, got nil")
-	}
-	if !strings.Contains(err.Error(), "proxy error") {
-		t.Errorf("expected proxy bind error, got: %v", err)
-	}
 }
 
 // TestRunCmd_MCPListenerAskModeShutdown exercises the MCP approver lifecycle.

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -540,13 +540,14 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		// effective policy should produce identical envelope ph
 		// regardless of YAML formatting.
 		s.receiptEmitter = receipt.NewEmitter(receipt.EmitterConfig{
-			Recorder:       rec,
-			PrivKey:        recPrivKey,
-			ConfigHash:     cfg.Hash(),
-			Principal:      "local",
-			Actor:          "pipelock",
-			Metrics:        m,
-			PostureBinding: postureBinding,
+			Recorder:         rec,
+			PrivKey:          recPrivKey,
+			ConfigHash:       cfg.Hash(),
+			Principal:        "local",
+			Actor:            "pipelock",
+			Metrics:          m,
+			PostureBinding:   postureBinding,
+			HeartbeatSeconds: cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
 		})
 		if s.receiptEmitter != nil {
 			// Loud, one-time startup signal when the chain could not be

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -104,11 +104,15 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 	}, nil
 }
 
-func (s *Server) startupSummaryLine(cfg *config.Config) string {
+// startupSummaryLine renders the one-line startup diagnostic. fetchAddr is the
+// resolved fetch listener address (the OS-chosen port when the configured
+// address is ephemeral), so the summary matches the per-endpoint lines instead
+// of echoing a stale ":0".
+func (s *Server) startupSummaryLine(cfg *config.Config, fetchAddr string) string {
 	return fmt.Sprintf(
 		"  Check:  mode=%s listeners=%s allowlist=%d dlp_patterns=%d checks=%d entropy=%s; run `pipelock explain` to see why a request was blocked",
 		cfg.Mode,
-		strings.Join(s.startupListeners(cfg), ","),
+		strings.Join(s.startupListeners(cfg, fetchAddr), ","),
 		len(cfg.APIAllowlist),
 		len(cfg.DLP.Patterns),
 		startupEnabledCheckCount(cfg),
@@ -116,8 +120,8 @@ func (s *Server) startupSummaryLine(cfg *config.Config) string {
 	)
 }
 
-func (s *Server) startupListeners(cfg *config.Config) []string {
-	listeners := []string{"fetch=" + cfg.FetchProxy.Listen}
+func (s *Server) startupListeners(cfg *config.Config, fetchAddr string) []string {
+	listeners := []string{"fetch=" + fetchAddr}
 	if cfg.MetricsListen != "" && cfg.MetricsListen != cfg.FetchProxy.Listen {
 		listeners = append(listeners, "stats="+cfg.MetricsListen)
 	}
@@ -125,7 +129,7 @@ func (s *Server) startupListeners(cfg *config.Config) []string {
 		listeners = append(listeners, "forward=enabled")
 	}
 	if cfg.WebSocketProxy.Enabled {
-		listeners = append(listeners, "ws="+cfg.FetchProxy.Listen)
+		listeners = append(listeners, "ws="+fetchAddr)
 	}
 	if cfg.ScanAPI.Listen != "" {
 		listeners = append(listeners, "scan_api="+cfg.ScanAPI.Listen)
@@ -134,7 +138,7 @@ func (s *Server) startupListeners(cfg *config.Config) []string {
 		if s.apiOnSeparatePort {
 			listeners = append(listeners, "kill_api="+cfg.KillSwitch.APIListen)
 		} else {
-			listeners = append(listeners, "kill_api="+cfg.FetchProxy.Listen)
+			listeners = append(listeners, "kill_api="+fetchAddr)
 		}
 	}
 	if s.hasMCPListen {
@@ -374,22 +378,43 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	defer stopFileSentry()
 
+	// Pre-bind the fetch listener so the startup summary reports the real
+	// OS-chosen address when the configured port is ephemeral (":0"), instead
+	// of echoing the literal ":0". Pre-binding also fails fast here on
+	// a bind conflict rather than at Serve. The listener is handed to the proxy
+	// below via StartWithListener. http.Server.Serve closes it when serving ends;
+	// this deferred close is an idempotent backstop guaranteeing the listener is
+	// released on EVERY early-return path before serving (a double close on an
+	// already-closed listener returns net.ErrClosed, ignored here). It is
+	// unconditional so the "closed unless owned" invariant can never be defeated
+	// by a future early return added inside proxy.start before it reaches Serve.
+	fetchLn, fetchLnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.FetchProxy.Listen)
+	if fetchLnErr != nil {
+		err := wrapBindError("fetch_proxy.listen", cfg.FetchProxy.Listen, fetchLnErr)
+		if s.sentry != nil {
+			s.sentry.CaptureError(err)
+		}
+		return err
+	}
+	defer func() { _ = fetchLn.Close() }()
+	boundFetchAddr := fetchLn.Addr().String()
+
 	_, _ = fmt.Fprintf(s.opts.Stderr, "Pipelock %s starting\n", cliutil.DisplayVersion())
-	_, _ = fmt.Fprintln(s.opts.Stderr, s.startupSummaryLine(cfg))
+	_, _ = fmt.Fprintln(s.opts.Stderr, s.startupSummaryLine(cfg, boundFetchAddr))
 	_, _ = fmt.Fprintf(s.opts.Stderr, "  Mode:   %s\n", cfg.Mode)
-	_, _ = fmt.Fprintf(s.opts.Stderr, "  Listen: %s\n", cfg.FetchProxy.Listen)
-	_, _ = fmt.Fprintf(s.opts.Stderr, "  Fetch:  http://%s/fetch?url=<url>\n", cfg.FetchProxy.Listen)
-	_, _ = fmt.Fprintf(s.opts.Stderr, "  Health: http://%s/health\n", cfg.FetchProxy.Listen)
+	_, _ = fmt.Fprintf(s.opts.Stderr, "  Listen: %s\n", boundFetchAddr)
+	_, _ = fmt.Fprintf(s.opts.Stderr, "  Fetch:  http://%s/fetch?url=<url>\n", boundFetchAddr)
+	_, _ = fmt.Fprintf(s.opts.Stderr, "  Health: http://%s/health\n", boundFetchAddr)
 	if cfg.MetricsListen != "" {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "  Stats:  http://%s/stats (separate port)\n", cfg.MetricsListen)
 	} else {
-		_, _ = fmt.Fprintf(s.opts.Stderr, "  Stats:  http://%s/stats\n", cfg.FetchProxy.Listen)
+		_, _ = fmt.Fprintf(s.opts.Stderr, "  Stats:  http://%s/stats\n", boundFetchAddr)
 	}
 	if cfg.ForwardProxy.Enabled {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "  Proxy:  HTTP/HTTPS forward proxy enabled (CONNECT + absolute-URI)\n")
 	}
 	if cfg.WebSocketProxy.Enabled {
-		_, _ = fmt.Fprintf(s.opts.Stderr, "  WS:     http://%s/ws?url=<ws-url> (WebSocket proxy enabled)\n", cfg.FetchProxy.Listen)
+		_, _ = fmt.Fprintf(s.opts.Stderr, "  WS:     http://%s/ws?url=<ws-url> (WebSocket proxy enabled)\n", boundFetchAddr)
 	}
 	if cfg.Emit.Webhook.URL != "" {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "  Emit:   webhook -> %s (min_severity: %s)\n", RedactEndpoint(cfg.Emit.Webhook.URL), cfg.Emit.Webhook.MinSeverity)
@@ -401,7 +426,7 @@ func (s *Server) Start(ctx context.Context) error {
 		if s.apiOnSeparatePort {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "  API:    http://%s/api/v1/killswitch (kill switch remote control, separate port)\n", cfg.KillSwitch.APIListen)
 		} else {
-			_, _ = fmt.Fprintf(s.opts.Stderr, "  API:    http://%s/api/v1/killswitch (kill switch remote control)\n", cfg.FetchProxy.Listen)
+			_, _ = fmt.Fprintf(s.opts.Stderr, "  API:    http://%s/api/v1/killswitch (kill switch remote control)\n", boundFetchAddr)
 		}
 	}
 	if s.opts.ConfigFile != "" {
@@ -444,7 +469,7 @@ func (s *Server) Start(ctx context.Context) error {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "  Agent:  %v\n", s.opts.AgentArgs)
 		_, _ = fmt.Fprintln(s.opts.Stderr, "\nNote: agent process launching is not yet implemented (Phase 2).")
 		_, _ = fmt.Fprintln(s.opts.Stderr, "The fetch proxy is running — configure your agent to use:")
-		_, _ = fmt.Fprintf(s.opts.Stderr, "  PIPELOCK_FETCH_URL=http://%s/fetch\n\n", cfg.FetchProxy.Listen)
+		_, _ = fmt.Fprintf(s.opts.Stderr, "  PIPELOCK_FETCH_URL=http://%s/fetch\n\n", boundFetchAddr)
 	}
 
 	var conductorWG sync.WaitGroup
@@ -1102,12 +1127,14 @@ func (s *Server) Start(ctx context.Context) error {
 		}()
 	}
 
-	// Start the fetch proxy (blocks until context cancelled or error).
-	if err := s.proxy.Start(ctx); err != nil {
+	// Start the fetch proxy on the pre-bound listener (blocks until context
+	// cancelled or error). The listener was already bound above, so an error
+	// here is a serve/runtime failure, not a bind failure — do not relabel it as
+	// a bind error.
+	if err := s.proxy.StartWithListener(ctx, fetchLn); err != nil {
 		if heartbeatErr := getRequiredHeartbeatErr(); heartbeatErr != nil {
 			return heartbeatErr
 		}
-		err = wrapBindError("fetch_proxy.listen", cfg.FetchProxy.Listen, err)
 		if s.sentry != nil {
 			s.sentry.CaptureError(err)
 		}

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -344,11 +345,14 @@ func TestStartupSummaryLine(t *testing.T) {
 		o.ListenChanged = true
 	})
 
-	line := s.startupSummaryLine(s.cfg)
+	// Pass a resolved address DISTINCT from cfg.FetchProxy.Listen (":0") so the
+	// assertions prove the summary uses the passed fetchAddr rather than
+	// re-reading the configured listen value.
+	line := s.startupSummaryLine(s.cfg, "127.0.0.1:65432")
 	for _, want := range []string{
 		"Check:",
 		"mode=balanced",
-		"listeners=fetch=127.0.0.1:0",
+		"listeners=fetch=127.0.0.1:65432",
 		"allowlist=6",
 		"dlp_patterns=",
 		"checks=",
@@ -375,7 +379,10 @@ kill_switch:
 		o.ConfigFile = cfgPath
 	})
 
-	line := s.startupSummaryLine(s.cfg)
+	// Pass a resolved address DISTINCT from cfg.FetchProxy.Listen (":0") so the
+	// assertions prove the summary uses the passed fetchAddr rather than
+	// re-reading the configured listen value.
+	line := s.startupSummaryLine(s.cfg, "127.0.0.1:65432")
 	if !strings.Contains(line, "kill_api=127.0.0.1:19091") {
 		t.Fatalf("summary missing env-token kill API listener:\n%s", line)
 	}
@@ -403,7 +410,7 @@ func TestStartupSummaryLineKillAPIResolvedMatrix(t *testing.T) {
 kill_switch:
   api_token: "yaml-token"
 `,
-			want: "kill_api=127.0.0.1:0",
+			want: "kill_api=127.0.0.1:65432",
 		},
 		{
 			name: "yaml token separate listener",
@@ -438,7 +445,10 @@ kill_switch:
 				o.ConfigFile = cfgPath
 			})
 
-			line := s.startupSummaryLine(s.cfg)
+			// Pass a resolved address DISTINCT from cfg.FetchProxy.Listen (":0") so the
+			// assertions prove the summary uses the passed fetchAddr rather than
+			// re-reading the configured listen value.
+			line := s.startupSummaryLine(s.cfg, "127.0.0.1:65432")
 			if tt.want != "" && !strings.Contains(line, tt.want) {
 				t.Fatalf("summary missing %q:\n%s", tt.want, line)
 			}
@@ -835,6 +845,80 @@ func TestServer_StartShutdown(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatalf("Start did not return within 5s of Shutdown")
 	}
+}
+
+// TestServer_StartupReportsResolvedFetchPort asserts the startup summary
+// reports the OS-chosen port when the listen address is ephemeral (:0), not
+// the literal ":0". An operator or script must be able to learn the
+// real port from stdout without shelling out to `ss`.
+func TestServer_StartupReportsResolvedFetchPort(t *testing.T) {
+	s, buf := newTestServer(t, func(o *ServerOpts) {
+		o.Listen = serverTestEphemeralListen // 127.0.0.1:0
+		o.ListenChanged = true
+		o.AgentArgs = []string{"agent", "--flag"}
+	})
+
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		errCh <- s.Start(ctx)
+	}()
+
+	waitForServerCancel(t, s)
+	// Wait for the LAST-printed address line (PIPELOCK_FETCH_URL, emitted after
+	// the "Listen:" line) before snapshotting, so both are present and the
+	// snapshot is not racing the URL assertion.
+	waitForServerOutput(t, buf, "PIPELOCK_FETCH_URL=http://127.0.0.1:")
+
+	out := buf.String()
+	if strings.Contains(out, "Listen: 127.0.0.1:0\n") {
+		t.Fatalf("startup still reports the ephemeral :0 instead of the resolved port:\n%s", out)
+	}
+	port := resolvedListenPort(t, out)
+	if port <= 0 {
+		t.Fatalf("resolved fetch port = %d, want a real OS-chosen port:\n%s", port, out)
+	}
+	if strings.Contains(out, "127.0.0.1:0") {
+		t.Fatalf("startup output still contains unresolved ephemeral listen address:\n%s", out)
+	}
+	if want := fmt.Sprintf("PIPELOCK_FETCH_URL=http://127.0.0.1:%d/fetch", port); !strings.Contains(out, want) {
+		t.Fatalf("startup agent fetch URL missing resolved port %q:\n%s", want, out)
+	}
+	if want := fmt.Sprintf("fetch=127.0.0.1:%d", port); !strings.Contains(out, want) {
+		t.Fatalf("startup summary listeners line missing the resolved fetch port %q:\n%s", want, out)
+	}
+
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Start returned error after Shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Start did not return within 5s of Shutdown")
+	}
+}
+
+// resolvedListenPort extracts the port from the startup "Listen: 127.0.0.1:<port>" line.
+func resolvedListenPort(t *testing.T, out string) int {
+	t.Helper()
+	const marker = "Listen: 127.0.0.1:"
+	i := strings.Index(out, marker)
+	if i < 0 {
+		t.Fatalf("no %q line in startup output:\n%s", marker, out)
+	}
+	rest := out[i+len(marker):]
+	if end := strings.IndexAny(rest, "\n \t"); end >= 0 {
+		rest = rest[:end]
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(rest))
+	if err != nil {
+		t.Fatalf("parse port from %q: %v", rest, err)
+	}
+	return port
 }
 
 func TestServer_StartArmsFileSentry(t *testing.T) {

--- a/internal/config/heartbeat_seconds_test.go
+++ b/internal/config/heartbeat_seconds_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "testing"
+
+func TestFlightRecorder_HeartbeatIntervalSecondsForReceipt(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		interval string
+		want     int
+	}{
+		{"unset uses the 60s default", "", 60},
+		{"whole seconds", "5s", 5},
+		{"sub-second rounds up to 1, never 0 (which means disabled)", "500ms", 1},
+		{"tiny positive interval still records 1", "1ms", 1},
+		{"fractional rounds to nearest second (up)", "1500ms", 2},
+		{"fractional rounds to nearest second (down)", "1400ms", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var f FlightRecorder
+			f.Completeness.HeartbeatInterval = tc.interval
+			if got := f.HeartbeatIntervalSecondsForReceipt(); got != tc.want {
+				t.Fatalf("HeartbeatIntervalSecondsForReceipt(%q) = %d, want %d", tc.interval, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1498,6 +1498,20 @@ func (f FlightRecorder) HeartbeatIntervalDuration() time.Duration {
 	return interval
 }
 
+// HeartbeatIntervalSecondsForReceipt returns the heartbeat cadence in whole
+// seconds for the session_open receipt's audit field. HeartbeatIntervalDuration
+// always yields a positive interval (empty, unparseable, or non-positive values
+// fall back to the default), so this rounds to the nearest second and floors at
+// 1: a sub-second cadence is never truncated to 0, which the field documents as
+// "unset / heartbeats disabled".
+func (f FlightRecorder) HeartbeatIntervalSecondsForReceipt() int {
+	secs := int((f.HeartbeatIntervalDuration() + 500*time.Millisecond) / time.Second)
+	if secs < 1 {
+		secs = 1
+	}
+	return secs
+}
+
 func (f FlightRecorder) EvidenceHealthEnabled() bool {
 	if !f.Enabled {
 		return false

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1290,13 +1290,14 @@ func (p *Proxy) buildReceiptEmitter(cfg *config.Config) (receiptEmitterStage, er
 		return receiptEmitterStage{}, fmt.Errorf("loading posture binding: %w", bindErr)
 	}
 	emitter := receipt.NewEmitter(receipt.EmitterConfig{
-		Recorder:       p.recorder,
-		PrivKey:        privKey,
-		ConfigHash:     cfg.Hash(),
-		Principal:      "local",
-		Actor:          "pipelock",
-		Metrics:        p.metrics,
-		PostureBinding: postureBinding,
+		Recorder:         p.recorder,
+		PrivKey:          privKey,
+		ConfigHash:       cfg.Hash(),
+		Principal:        "local",
+		Actor:            "pipelock",
+		Metrics:          p.metrics,
+		PostureBinding:   postureBinding,
+		HeartbeatSeconds: cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
 	})
 	if emitter != nil {
 		if initErr := emitter.InitError(); initErr != nil {
@@ -3317,6 +3318,17 @@ func (p *Proxy) Handler() http.Handler {
 // is cancelled or the server encounters a fatal error.
 func (p *Proxy) Start(ctx context.Context) error {
 	return p.start(ctx, nil)
+}
+
+// StartWithListener runs the proxy on an already-bound listener instead of
+// binding cfg.FetchProxy.Listen itself. It lets the runtime pre-bind the fetch
+// listener so a bind failure surfaces before serving and the OS-chosen address
+// (when the configured port is ephemeral, e.g. ":0") can be read back and
+// reported at startup. The listener is owned by the proxy once passed:
+// http.Server.Serve closes it when it returns. A nil listener is equivalent to
+// Start (the proxy binds cfg.FetchProxy.Listen itself).
+func (p *Proxy) StartWithListener(ctx context.Context, ln net.Listener) error {
+	return p.start(ctx, ln)
 }
 
 func (p *Proxy) start(ctx context.Context, ln net.Listener) error {

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -1413,6 +1413,9 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 		receipts[1].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
 		t.Fatalf("rotated first receipt session_control = %+v, want session_open", receipts[1].ActionRecord.SessionControl)
 	}
+	if got := receipts[1].ActionRecord.SessionControl.Open.HeartbeatSeconds; got != 60 {
+		t.Fatalf("rotated session_open heartbeat_seconds = %d, want configured default 60", got)
+	}
 	if receipts[1].ActionRecord.KeyTransition == nil {
 		t.Fatal("rotated session_open missing key_transition")
 	}

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -106,6 +106,12 @@ type Emitter struct {
 	openNonce     string
 	heartbeatBeat uint64
 
+	// heartbeatSeconds is the configured heartbeat cadence (seconds) recorded
+	// in the session_open record's Open.HeartbeatSeconds so a witness reading
+	// the anchor learns the expected liveness interval without having to infer
+	// it from observed heartbeat spacing. 0 means "not configured".
+	heartbeatSeconds int
+
 	postureBinding PostureBinding
 
 	// pendingTransition is set by resumeChain when the on-disk tail was
@@ -149,6 +155,11 @@ type EmitterConfig struct {
 	// containment assessment can bind a receipt chain to a signed posture
 	// capsule and contained UID.
 	PostureBinding PostureBinding
+	// HeartbeatSeconds is the configured heartbeat cadence in seconds. It is
+	// recorded verbatim in the session_open record so a consumer can read the
+	// expected liveness interval off the run anchor. 0 (the default) means the
+	// cadence is unset / heartbeats disabled.
+	HeartbeatSeconds int
 }
 
 // PostureBinding carries the signed posture-capsule fields that session_open
@@ -171,15 +182,16 @@ func NewEmitter(cfg EmitterConfig) *Emitter {
 	}
 	runNonce, nonceErr := newRunNonce()
 	e := &Emitter{
-		recorder:       cfg.Recorder,
-		privKey:        cfg.PrivKey,
-		principal:      cfg.Principal,
-		actor:          cfg.Actor,
-		metrics:        cfg.Metrics,
-		onReceipt:      cfg.OnReceipt,
-		runNonce:       runNonce,
-		chainPrevHash:  GenesisHash,
-		postureBinding: cfg.PostureBinding,
+		recorder:         cfg.Recorder,
+		privKey:          cfg.PrivKey,
+		principal:        cfg.Principal,
+		actor:            cfg.Actor,
+		metrics:          cfg.Metrics,
+		onReceipt:        cfg.OnReceipt,
+		runNonce:         runNonce,
+		chainPrevHash:    GenesisHash,
+		postureBinding:   cfg.PostureBinding,
+		heartbeatSeconds: cfg.HeartbeatSeconds,
 	}
 	e.configHash.Store(cfg.ConfigHash)
 	if nonceErr != nil {
@@ -351,6 +363,7 @@ func (e *Emitter) EmitSessionOpen() error {
 				RunNonce:             e.runNonce,
 				OpenNonce:            openNonce,
 				RecorderSession:      recorderSessionID,
+				HeartbeatSeconds:     e.heartbeatSeconds,
 				PolicyHash:           configHashString(e.configHash.Load()),
 				SignerKeyEpoch:       fmt.Sprintf("%x", e.privKey.Public().(ed25519.PublicKey)),
 				PostureCapsuleSHA256: e.postureBinding.CapsuleSHA256,

--- a/internal/receipt/session_control_emit_test.go
+++ b/internal/receipt/session_control_emit_test.go
@@ -87,6 +87,44 @@ func TestEmitter_EmitHeartbeatSignedSnapshotCountersAndNonce(t *testing.T) {
 	}
 }
 
+func TestEmitter_SessionOpenRecordsConfiguredHeartbeatSeconds(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{
+		Recorder:         rec,
+		PrivKey:          priv,
+		ConfigHash:       testConfigHash,
+		Principal:        testPrincipal,
+		Actor:            testActor,
+		HeartbeatSeconds: 5,
+	})
+
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	receipts := readAllReceiptsFromDir(t, dir, pub)
+	if len(receipts) == 0 {
+		t.Fatal("no receipts emitted")
+	}
+	open := receipts[0].ActionRecord.SessionControl.Open
+	if open == nil {
+		t.Fatalf("first receipt is not session_open: %#v", receipts[0].ActionRecord.SessionControl)
+	}
+	// The configured cadence must be recorded on the run anchor so a witness
+	// reading session_open learns the expected liveness interval without
+	// inferring it from observed heartbeat spacing (previously left at 0).
+	if open.HeartbeatSeconds != 5 {
+		t.Fatalf("session_open HeartbeatSeconds = %d, want 5 (the configured cadence)", open.HeartbeatSeconds)
+	}
+}
+
 func TestEmitter_EmitSessionOpenIsDurableAndGatesOnFsync(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

Two flight-recorder / startup observability fixes.

The `session_open` control receipt left `heartbeat_seconds` at 0 even when a heartbeat interval was configured, so a consumer reading the run anchor could not learn the expected liveness cadence without inferring it from heartbeat spacing. The configured cadence is now threaded into the receipt emitter, including the signing-key reload path so a rotated `session_open` records it too.

The startup summary echoed the configured listen address verbatim, printing `:0` for an ephemeral port instead of the OS-chosen port an operator or script needs. The fetch listener is now pre-bound so the summary, the per-endpoint URLs, and the agent `PIPELOCK_FETCH_URL` line report the real bound address; a bind conflict fails fast at pre-bind, and the listener is handed to the proxy via `StartWithListener`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Server startup now pre-binds the fetch listener to fail fast on port conflicts.
  - Startup output and `PIPELOCK_FETCH_URL` now always reflect the resolved fetch port when using ephemeral ports.
  - Proxy startup can reuse an already-bound listener to reduce early-startup lifecycle/race issues.
  - Flight-recorder session receipts now record the configured heartbeat cadence in `session_open` for more accurate monitoring.
- **Tests**
  - Updated startup-summary and lifecycle/race tests to match resolved-port behavior and validated configured heartbeat seconds (plus added coverage for heartbeat interval calculation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->