### PR TITLE
chore: audit public claims and OpenSSF Gold evidence

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -eu
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 
 # Register the go-118-fuzz-build/testing dependency required by
 # compile_native_go_fuzzer. Build-time-only, not in go.mod.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -308,6 +308,15 @@ jobs:
       - name: Config example startability policy
         run: bash scripts/check-config-examples.sh
 
+      - name: Documentation accuracy and local links
+        run: make docs-check
+
+      - name: Source file headers
+        run: make source-header-check
+
+      - name: Reproducible OSS build
+        run: make reproducible-build-check
+
   helm:
     needs: [security-scan]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,6 +145,9 @@ jobs:
       - name: Run runtime policy audit
         run: make runtime-policy-audit
 
+      - name: Verify reproducible OSS build
+        run: make reproducible-build-check
+
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ builds:
       - enterprise
     flags:
       - -trimpath
+      - -buildvcs=false
+    mod_timestamp: "{{ .CommitTimestamp }}"
     goos:
       - linux
       - darwin
@@ -24,7 +26,7 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/luckyPipewrench/pipelock/internal/cliutil.Version={{.Version}}
-      - -X github.com/luckyPipewrench/pipelock/internal/cliutil.BuildDate={{.Date}}
+      - -X github.com/luckyPipewrench/pipelock/internal/cliutil.BuildDate={{.CommitDate}}
       - -X github.com/luckyPipewrench/pipelock/internal/cliutil.GitCommit={{.ShortCommit}}
       - -X github.com/luckyPipewrench/pipelock/internal/cliutil.GoVersion={{.Env.GOVERSION}}
       - -X github.com/luckyPipewrench/pipelock/internal/proxy.Version={{.Version}}
@@ -43,6 +45,8 @@ builds:
       - enterprise
     flags:
       - -trimpath
+      - -buildvcs=false
+    mod_timestamp: "{{ .CommitTimestamp }}"
     goos:
       - linux
     goarch:
@@ -66,6 +70,8 @@ builds:
       - CGO_ENABLED=0
     flags:
       - -trimpath
+      - -buildvcs=false
+    mod_timestamp: "{{ .CommitTimestamp }}"
     goos:
       - linux
       - darwin
@@ -76,7 +82,7 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/luckyPipewrench/pipelock/internal/cliutil.Version={{.Version}}
-      - -X github.com/luckyPipewrench/pipelock/internal/cliutil.BuildDate={{.Date}}
+      - -X github.com/luckyPipewrench/pipelock/internal/cliutil.BuildDate={{.CommitDate}}
       - -X github.com/luckyPipewrench/pipelock/internal/cliutil.GitCommit={{.ShortCommit}}
       - -X github.com/luckyPipewrench/pipelock/internal/cliutil.GoVersion={{.Env.GOVERSION}}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,30 @@ go test -race -count=1 ./...     # All tests with race detector
 3. Address reviewer feedback and bot comments. Automated AI review (e.g. CodeRabbit) is **advisory only** — maintainers make all security decisions, and a bot's passing status or summary does not by itself mean a change was security-reviewed.
 4. PRs are squash-merged
 
+### Review Standard
+
+Every change to `main` goes through a pull request and requires approval from a
+human code owner other than the author. The main-branch ruleset dismisses stale
+approvals after a push, requires approval of the latest revision, requires all
+review threads to be resolved, and blocks merging until the required status
+checks pass.
+
+Reviewers check:
+
+- whether the change is useful, scoped, and compatible with documented behavior;
+- correctness at normal, boundary, malformed, concurrent, and failure inputs;
+- fail-open versus fail-closed behavior at security boundaries;
+- tests for changed behavior and regression coverage for fixed defects;
+- documentation and example-config accuracy, including transport-specific limits;
+- secret handling, authorization, path/network trust boundaries, and dependency risk;
+- backward compatibility, operator lifecycle, and recovery behavior where applicable.
+
+A change is acceptable only when the reviewer can explain the behavior, required
+tests and checks pass, security-relevant claims are supported by code or
+reproduction, no unresolved blocking feedback remains, and the latest revision
+has a human approval. Bot review may provide evidence but cannot replace that
+approval.
+
 ## Testing
 
 ### Requirements
@@ -148,7 +172,11 @@ make build    # Build with version metadata
 make test     # Run tests
 make lint     # Lint
 make docker   # Build Docker image
+make reproducible-build-check # Compare two byte-identical OSS builds
 ```
+
+See [Reproducible Builds](docs/reproducible-builds.md) for the fixed inputs,
+release integration, and the exact scope of the reproducibility claim.
 
 ## Project Structure
 
@@ -157,14 +185,14 @@ cmd/pipelock/          CLI entry point
 internal/
   cli/                 20+ Cobra commands (run, check, report, tls, mcp, audit, generate, ...)
   config/              YAML config loading, validation, defaults, hot-reload (fsnotify)
-  scanner/             11-layer URL scanning pipeline + response injection detection
+  scanner/             Ordered URL scanning pipeline + response injection detection
   audit/               Structured JSON audit logging (zerolog) + event emission dispatch
   proxy/               HTTP proxy: fetch, forward (CONNECT), WebSocket, TLS interception
   certgen/             ECDSA P-256 CA + leaf certificate generation, cache
   mcp/                 MCP proxy + bidirectional scanning + tool poisoning + chains
   report/              HTML/JSON audit report generation from JSONL event logs
-  killswitch/          Emergency deny-all (4 sources) + port-isolated API
-  emit/                Event emission (webhook + syslog sinks)
+  killswitch/          Emergency deny-all (6 sources) + port-isolated API
+  emit/                Event emission (webhook + syslog + OTLP sinks)
   metrics/             Prometheus metrics + JSON stats endpoint
   normalize/           Unicode normalization (NFKC, confusables, combining marks)
   hitl/                Human-in-the-loop terminal approval
@@ -186,7 +214,7 @@ docs/                  Guides, OWASP mapping, comparison
 
 See [CLAUDE.md](CLAUDE.md) for the full architecture guide, including:
 
-- Scanner pipeline (11 layers)
+- Ordered scanner pipeline and security-control sequence
 - MCP proxy design
 - Config system and hot-reload
 - Package structure and conventions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Multi-stage build for minimal image size
 FROM golang:1.26.5-alpine@sha256:99e12cfb19b753915f9b9fdc5a99f1869a24a69d3a0955832d5702e7fa68f1be AS builder
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,3 +1,6 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Used by GoReleaser — copies the pre-built binary instead of building from source.
 # For local/manual builds, use the main Dockerfile instead.
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS certs

--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -1,3 +1,6 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Init container for K8s sidecar deployments.
 # Copies the pipelock binary to a shared volume for MCP stdio wrapping.
 #

--- a/Dockerfile.license-service
+++ b/Dockerfile.license-service
@@ -1,3 +1,6 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Used by GoReleaser — copies the pre-built binary instead of building from source.
 # Alpine-based because the license service needs a writable filesystem for
 # SQLite (entitlement DB) and the append-only audit ledger.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,7 +6,7 @@ Pipelock is maintained by Joshua Waldrep ([@luckyPipewrench](https://github.com/
 
 ## Decision-Making
 
-This is a single-maintainer project. Joshua Waldrep makes final decisions on:
+This is a single-project-lead project. Joshua Waldrep makes final decisions on:
 
 - Feature direction and roadmap priorities
 - Release timing and versioning
@@ -34,7 +34,11 @@ Vulnerabilities are reported through [GitHub Security Advisories](https://github
 
 ## Continuity
 
-Repository admin access is shared with at least one additional maintainer to ensure the project can continue accepting contributions, triaging issues, and cutting releases if the primary maintainer is unavailable.
+Repository admin access is shared with at least one trusted continuity
+administrator so the project can continue accepting contributions, triaging
+issues, and cutting releases if the project lead is unavailable. Continuity or
+review access does not by itself make that person a Pipelab employee,
+representative, or project decision-maker.
 
 ## Contact
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LDFLAGS := -ldflags "-s -w \
 	-X $(MODULE)/internal/license.PublicKeyHex=$(LICENSE_PUBLIC_KEY) \
 	-X $(MODULE)/internal/rules.KeyringHex=$(RULES_KEYRING_HEX)"
 
-.PHONY: all build build-verifier test test-wasm-verifier bench bench-egress bench-egress-long bench-egress-release lint test-stability-check clean docker install fmt vet tidy-check fuzz stats docs-check \
+.PHONY: all build build-verifier test test-wasm-verifier bench bench-egress bench-egress-long bench-egress-release lint test-stability-check clean docker install fmt vet tidy-check fuzz stats docs-check source-header-check reproducible-build-check \
 	test-runtime-critical test-replay-harness test-sharded test-sharded-enterprise release-audit runtime-policy-audit debt-check release-check hermes-e2e test-liveproof
 
 all: build
@@ -178,3 +178,9 @@ stats: ## Print canonical stats
 
 docs-check: ## Check public docs for known stale claims and print canonical stats
 	@./scripts/docs-check.sh
+
+source-header-check: ## Verify source files carry the required copyright and license notices
+	@./scripts/check-source-headers.sh
+
+reproducible-build-check: ## Build the OSS binary twice and require identical bytes
+	@./scripts/check-reproducible-build.sh

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ pipelock verify-receipt "$(ls ./out/*.json | head -1)" --key ./out/signer.pub  #
 ```
 
 <div align="center">
-  <img src="docs/assets/dashboard/evidence-viewer-pinned.png" alt="Pipelock evidence report: the scorecard (Authentic, Untampered, Anchored, Completeness, each with its honest limit) above a signed receipt timeline of every mediated decision, verdict, and hash link" width="860">
+  <img src="docs/assets/dashboard/evidence-viewer-pinned.png" alt="Pipelock evidence report: the scorecard (Authentic, Untampered, Anchored, Completeness, each with its honest limit) above a signed receipt timeline of recorded mediated decisions, verdicts, and hash links" width="860">
 </div>
 
-The scorecard grades each claim on its own and states what it does not prove: whether anything happened outside the boundary Pipelock mediates. Below it, the receipt timeline lists every mediated decision with its verdict and hash link. A receipt that is honest about its own limits beats a green checkmark that hides them.
+The scorecard grades each claim on its own and states what it does not prove: whether anything happened outside the boundary Pipelock mediates. Below it, the receipt timeline lists the recorded mediated decisions with their verdicts and hash links. A receipt that is honest about its own limits beats a green checkmark that hides them.
 
 The evidence viewer is free and needs no license:
 
@@ -285,14 +285,14 @@ Pipelock is an [AI egress proxy](https://pipelab.org/learn/ai-egress-proxy/) and
 
 ### Detection And Scanning
 
-- **11-layer URL scanner:** scheme validation, CRLF injection detection, path traversal blocking, domain blocklist, DLP pattern matching, path entropy analysis, subdomain entropy analysis, SSRF protection with DNS-rebinding prevention, per-domain rate limiting, URL length limits, and per-domain data budgets. DLP runs before DNS resolution, so secrets are caught before a DNS query leaves the proxy. See [docs/bypass-resistance.md](docs/bypass-resistance.md).
+- **Ordered URL scanner pipeline:** URL length and parsing checks, scheme validation, CRLF and path-traversal detection, allowlist and blocklist policy, immutable literal-IP SSRF and core-DLP floors, configured DLP, path and subdomain entropy analysis, DNS SSRF and rebinding protection, per-domain rate limits, data budgets, and final context checks. DLP runs before DNS resolution, so secrets are caught before a DNS query leaves the proxy. See [docs/bypass-resistance.md](docs/bypass-resistance.md).
 - **DLP:** 65 built-in patterns for API keys, tokens, credentials, cryptocurrency keys, environment secrets, and financial identifiers with checksum validation. BIP-39 seed phrase detection uses dictionary lookup, sliding windows, and SHA-256 checksum validation.
 - **Response scanning:** 32 built-in prompt-injection and state/control poisoning patterns, plus 6-pass normalization for zero-width characters, homoglyphs, leetspeak, optional whitespace, vowel folding, base64, and hex. Actions are `block`, `strip`, `warn`, or `ask`.
 - **Streaming SSE:** `text/event-stream` responses from LLM gateways and MCP HTTP/SSE flow token by token with per-event and rolling cross-event DLP and injection scanning. A detection terminates the stream fail-closed. See [SSE streaming guide](docs/guides/sse-streaming.md).
 - **Request body scanning:** headers and bodies are scanned before they leave the protected path across JSON, form data, raw text, reverse proxy requests, TLS-intercepted CONNECT traffic, and outbound WebSocket client frames.
 - **Request redaction:** optional JSON rewriting replaces matched secret values with typed placeholders such as `<pl:aws-access-key:1>` across HTTP, WebSocket, and MCP `tools/call` arguments. Receipts record the active profile and per-class counts instead of plaintext secrets.
 - **Address protection:** ETH, BTC, SOL, and BNB address validation catches lookalike destination swaps using prefix/suffix fingerprinting and an operator allowlist.
-- **Every block explains itself:** `pipelock explain <url>` (also `explain event <id>` and `explain mcp`) prints the scanner, layer, matching rule, inspected surface, and the exact narrowest config knob to fix a false positive. An un-fixable false positive is why teams rip a scanner out; this is the answer. See [`docs/cli/explain.md`](docs/cli/explain.md).
+- **Explainable findings:** `pipelock explain <url>` (also `explain event <id>` and `explain mcp`) prints the scanner, layer, matching rule, inspected surface, and the narrowest available config knob for a false positive. See [`docs/cli/explain.md`](docs/cli/explain.md).
 - **Canary tokens:** `pipelock canary` generates honeytoken config. A synthetic secret showing up in outbound traffic proves an agent or something in its chain is exfiltrating environment variables. See [canary tokens](docs/guides/canary-tokens.md).
 - **Skill-file scanning:** `pipelock skill-scan` inventories agent skill files, compares them to an operator-owned lock file, and flags source-to-sink combinations such as credential-to-network-sink or shell-to-write with line evidence before anything runs. See [`docs/cli/skill-scan.md`](docs/cli/skill-scan.md).
 
@@ -342,9 +342,15 @@ pipelock contain run -- claude-code
 ### Evidence And Receipts
 
 - **Flight recorder:** hash-chained JSONL evidence log with Ed25519-signed checkpoints and DLP redaction. `pipelock init` provisions a recorder directory and signing key for stock installs, while the recorder stays inert until a directory and key exist. See [Flight Recorder](docs/guides/flight-recorder.md).
-- **Action receipts:** signed records of each mediated action, verdict, policy hash, transport, and scanner layer. Verify with `pipelock verify-receipt --key <signer.pub>`. Unpinned runs are structural-only and exit non-zero unless `--allow-unpinned` is passed.
+- **Action receipts:** signed records emitted for mediated actions, carrying verdict, policy hash, transport, and scanner layer. Blocks produce receipts; allow-path receipt enforcement requires `flight_recorder.require_receipts`. Verify with `pipelock verify-receipt --key <signer.pub>`. Unpinned runs are structural-only and exit non-zero unless `--allow-unpinned` is passed.
 - **Mediation envelope:** RFC 8941 sideband metadata on forwarded HTTP requests and MCP `_meta`, with action type, verdict, actor identity, policy hash, taint context, and receipt correlation ID. See [federation guide](docs/guides/federation.md).
-- **Receipt conformance:** five independent verifier implementations (Go, TypeScript, Rust, Python, wasm) reject the same malformed and forgeable inputs, including duplicate keys, integer overflow, and unpaired surrogates, against one shared [conformance corpus](sdk/conformance/). A parser differential is a skeptic's first move against an offline verifier, so all five fail closed on it. AARP/SVID appraisal remains an offline verifier profile, not runtime identity enforcement.
+- **Receipt conformance:** four independent cross-language verifier implementations
+  (Go, TypeScript, Rust, and Python) run against one shared
+  [conformance corpus](sdk/conformance/), including malformed and forgeable
+  inputs such as duplicate keys, integer overflow, and unpaired surrogates. A
+  browser wasm surface reuses the Go verifier implementation. AARP/SVID
+  appraisal remains an offline verifier profile, not runtime identity
+  enforcement.
 - **Anchors:** `pipelock anchor receipts` records receipt-chain checkpoints to a local backend or Rekor. Rekor anchoring is proof material for later audit; Rekor verification requires pinned log keys and the end-to-end operator-independence path is still being proven.
 - **Posture capsule:** `pipelock posture emit` and `pipelock posture verify` produce and check a signed snapshot of a deployment's enforcement posture, with a CI gate and scoring model, so a reviewer can confirm the boundary was configured the way it claims.
 
@@ -352,7 +358,7 @@ pipelock contain run -- claude-code
 
 - **Operator dashboard:** `pipelock dashboard serve` is a read-only console over signed evidence. Pro unlocks the Overview, Evidence, Exemptions, Agents, Budgets, and Trust & Keys views; Enterprise adds the Fleet, Workbench, and Incident views. See [`docs/cli/dashboard.md`](docs/cli/dashboard.md).
 - **Free evidence viewer:** `pipelock evidence serve` and `pipelock evidence view` render one selected recorder session without a license or cross-agent enumeration. `pipelock evidence verify-cert` verifies Pro-issued coverage certificates offline.
-- **Conductor:** Enterprise fleet control plane for signed policy-bundle distribution, signed evidence sink (`pipelock fleet-sink`), enrollment, remote kill, rollback, dry-run, decision replay, and runtime/apply-state drift preflight over mTLS/SPIFFE. Followers enforce locally and stay fail-closed; Conductor holds no agent secrets. See the [Conductor guide](docs/guides/conductor.md).
+- **Conductor:** Enterprise fleet control plane for signed policy-bundle distribution, signed evidence sink (`pipelock fleet-sink`), enrollment, remote kill, rollback, dry-run, decision replay, and runtime/apply-state drift preflight over mTLS/SPIFFE. Followers enforce locally; the default stale-policy mode engages an independent deny source after its grace window, while the documented `continue_last_known_good` override weakens that posture. Conductor holds no agent secrets. See the [Conductor guide](docs/guides/conductor.md).
 - **Legal hold:** `pipelock dashboard legal-hold add/list/release` manages preservation holds as compliance metadata kept outside the dashboard's HTTP authority, so a compromised dashboard can read holds but never forge or delete them.
 - **Behavioral baseline:** profile-then-lock for MCP tool behavior with `pipelock baseline list/show/ratify/forget` for operator approval and relearning. See [`docs/cli/baseline.md`](docs/cli/baseline.md).
 
@@ -389,13 +395,13 @@ pipelock contain run -- claude-code
 | **Fleet Monitoring** | Per-instance Prometheus metrics plus ready-to-import [Grafana dashboard](configs/grafana-dashboard.json). Free single-instance monitoring, distinct from Conductor. |
 | **Operator Dashboard** (v3.1, Pro/Enterprise) | `pipelock dashboard serve` gives read-only Overview, Evidence, Exemptions, Agents, Budgets, Trust & Keys, Fleet, Workbench, and Incident views with token, OIDC, or mTLS auth, bounded RBAC, raw-view elevation, backup/restore, exemption lifecycle records, and coverage certificates. See [`docs/cli/dashboard.md`](docs/cli/dashboard.md). |
 | **Free Evidence Viewer** (v3.1) | `pipelock evidence serve` serves one selected recorder session as a read-only HTML report without a license and without cross-agent enumeration. `pipelock evidence verify-cert` verifies Pro-issued coverage certificates offline. |
-| **Conductor: fleet control plane** (v2.7, Enterprise) | Signed policy-bundle distribution, signed-evidence audit sink (`pipelock fleet-sink`), enrollment, remote kill, policy rollback, dry-run, decision replay, and runtime/apply-state drift preflight over mTLS/SPIFFE. Gated by the `fleet` license feature, fail-closed. See the [Conductor guide](docs/guides/conductor.md). |
+| **Conductor: fleet control plane** (v2.7, Enterprise) | Signed policy-bundle distribution, signed-evidence audit sink (`pipelock fleet-sink`), enrollment, remote kill, policy rollback, dry-run, decision replay, and runtime/apply-state drift preflight over mTLS/SPIFFE. Gated by the `fleet` license feature; stale-policy behavior is explicit and defaults to strict deny. See the [Conductor guide](docs/guides/conductor.md). |
 | **A2A Scanning** | Agent Card poisoning detection, card drift monitoring, and session smuggling prevention for Google's Agent-to-Agent protocol on forward/MCP paths. |
 | **Behavioral Baseline** | Profile-then-lock for MCP tool behavior with `pipelock baseline list/show/ratify/forget` for operator approval and relearning. See [`docs/cli/baseline.md`](docs/cli/baseline.md). |
 | **Denial-of-Wallet** | Per-agent budgets for retries, fan-out, and concurrent tool calls. |
 | **Taint Escalation** | Exposure-based policy escalation across MCP and task boundaries until trust is restored. |
 | **Mediation Envelope** | RFC 8941 sideband metadata on forwarded HTTP requests and MCP `_meta`, with inbound verification, replay protection, SPIFFE actor format, and an RFC 9421 signing-key directory. See [federation guide](docs/guides/federation.md). |
-| **Receipt Conformance** | Cross-implementation receipt verification suite (`sdk/conformance/`) plus first-party Go, TypeScript, Rust, Python, and wasm verifier surfaces. `EvidenceReceipt v2` uses RFC 8785/JCS canonicalization. AARP/SVID appraisal remains offline verifier-side. |
+| **Receipt Conformance** | Cross-implementation receipt verification suite (`sdk/conformance/`) across independent Go, TypeScript, Rust, and Python implementations, plus a browser wasm surface backed by Go. `EvidenceReceipt v2` uses RFC 8785/JCS canonicalization. AARP/SVID appraisal remains offline verifier-side. |
 | **Learn-and-Lock** (v2.4) | Per-agent behavioral contracts: observe traffic, compile a signed candidate contract, replay captured observations in shadow, ratify per rule, promote the signed active manifest, and enforce live on URL-bearing transports plus MCP tool calls. See [learn-and-lock guide](docs/guides/learn-and-lock.md). |
 | **Block-Reason Header** (v2.4) | `X-Pipelock-Block-Reason` on HTTP-capable block paths, with the same reason vocabulary on MCP JSON-RPC error metadata. See [block-reason header](docs/guides/block-reason-header.md). |
 | **Wedge-Detection Watchdog** (v2.4) | `health_watchdog` returns `/health` 503 when a subsystem heartbeat goes stale. See [health endpoint guide](docs/guides/health.md). |
@@ -418,7 +424,7 @@ All detection, enforcement, containment, and single-agent evidence is free forev
 
 | Capability | Free | Pro | Enterprise |
 |---|:--:|:--:|:--:|
-| Scanning and detection (11-layer URL, DLP, injection, SSRF, streaming SSE, redaction, address protection) | Yes | Yes | Yes |
+| Scanning and detection (ordered URL pipeline, DLP, injection, SSRF, streaming SSE, redaction, address protection) | Yes | Yes | Yes |
 | MCP and A2A scanning (input, response, tool policy, tool chain, poisoning, integrity, authenticated listeners) | Yes | Yes | Yes |
 | Containment, sandbox, host `contain`, 6-source kill switch | Yes | Yes | Yes |
 | Action receipts, flight recorder, anchors, free evidence viewer, `verify-cert`, standalone verifier | Yes | Yes | Yes |
@@ -443,7 +449,7 @@ Pipelock uses **capability separation**: in an enforced deployment, the agent pr
 Three HTTP proxy modes (same port), plus a dedicated MCP proxy and A2A inspection on the forward and MCP paths:
 
 - **Fetch proxy** (`/fetch?url=...`): Fetches the URL, extracts text, scans for injection, returns clean content.
-- **Forward proxy** (`HTTPS_PROXY`): Standard HTTP CONNECT tunneling. Zero code changes. Optional TLS interception for full payload scanning.
+- **Forward proxy** (`HTTPS_PROXY`): Standard HTTP CONNECT tunneling without application code changes. Proxy configuration is still required. Optional TLS interception enables payload scanning.
 - **WebSocket proxy** (`/ws?url=ws://...`): Bidirectional frame scanning with DLP + injection detection.
 - **MCP proxy** (`pipelock mcp proxy`): Wraps stdio or HTTP MCP servers with bidirectional scanning.
 - **A2A inspection**: Inspects Google Agent-to-Agent protocol traffic as it crosses the forward and MCP paths.
@@ -454,18 +460,35 @@ Three HTTP proxy modes (same port), plus a dedicated MCP proxy and A2A inspectio
 <summary>Text diagram (for terminals)</summary>
 
 ```
-┌──────────────────────┐         ┌───────────────────────┐
-│  PRIVILEGED ZONE     │         │  FIREWALL ZONE        │
-│                      │         │                       │
-│  AI Agent            │  IPC    │  Pipelock             │
-│  - Has API keys      │────────>│  - No agent secrets   │
-│  - Has credentials   │ fetch / │  - Full internet      │
-│  - Restricted network│ CONNECT │  - Returns text       │
-│                      │ /ws/MCP │  - WS frame scanning  │
-│                      │<────────│  - URL scanning       │
-│                      │ content │  - Audit logging      │
-│                      │         │                       │
-└──────────────────────┘         └───────────────────────┘
+┌──────────────────────────────────────────────────────────┐
+│ PRIVILEGED ZONE                                          │
+│                                                          │
+│ AI Agent                                                 │
+│ - API keys, credentials, private code and context        │
+│ - Network-isolated by deployment                         │
+└────────────────────────────┬─────────────────────────────┘
+                             │ mediated request
+                             │ fetch / CONNECT / WS / MCP / A2A
+                             ▼
+┌──────────────────────────────────────────────────────────┐
+│ FIREWALL ZONE                                            │
+│                                                          │
+│ Pipelock Agent Firewall                                  │
+│ - Destination: URL, SSRF, and DNS checks                 │
+│ - Data: DLP, secret detection, and budgets               │
+│ - Content: prompt injection and tool poisoning           │
+│ - Policy: allow, block, or redact                        │
+│ - No agent secrets                                       │
+└────────────────────────────┬─────────────────────────────┘
+                             │ approved request
+                             ▼
+┌──────────────────────────────────────────────────────────┐
+│ INTERNET                                                 │
+│                                                          │
+│ Web APIs, websites, MCP servers, tools, and A2A services │
+└──────────────────────────────────────────────────────────┘
+
+Internet -- response --> Pipelock -- scanned content --> AI Agent
 ```
 
 </details>
@@ -623,6 +646,8 @@ Full docs directory: [docs/](docs/)
 | [Community Rules](docs/rules.md) | Install, configure, and create signed rule bundles |
 | [Security Assurance](docs/security-assurance.md) | Security model, trust boundaries, supply chain |
 | [Security Documents](docs/security/) | Disclosure policy, unsupported paths, key rotation, TLS CA and Audit Packet threat models |
+| [Enterprise Readiness](docs/enterprise-readiness.md) | Shipped enterprise controls, evaluation path, deployment decisions, and explicit boundaries |
+| [Reproducible Builds](docs/reproducible-builds.md) | Byte-for-byte OSS binary check, stable inputs, release integration, and scope |
 | [Finding Suppression](docs/guides/suppression.md) | Rule names, path matching, inline comments |
 | [Transport Modes](docs/guides/transport-modes.md) | All proxy modes and their scanning capabilities |
 | [OWASP MCP Top 10](docs/compliance/owasp-mcp-top10.md) | OWASP MCP Top 10 coverage |
@@ -676,7 +701,7 @@ internal/
     session/           `pipelock session`, `pipelock adaptive`, and `pipelock baseline` operator CLIs
     setup/             `pipelock init sidecar`: companion-proxy manifest generation (K8s)
   config/              YAML config, validation, defaults, hot-reload (fsnotify)
-  scanner/             11-layer URL scanning pipeline + response injection detection
+  scanner/             Ordered URL scanning pipeline + response injection detection
   audit/               Structured JSON logging (zerolog) + event emission dispatch
   proxy/               HTTP proxy: fetch, forward (CONNECT), WebSocket, DNS pinning, TLS
   mcp/                 MCP proxy + bidirectional scanning + tool poisoning + chains

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ Pipelock supports the current major release line. Security fixes are shipped on 
 
 | Version | Supported |
 |---|---:|
-| 2.x | Yes |
+| 3.x | Yes |
 | Earlier release lines | No |
 
 The current shipped release line is documented in [CHANGELOG.md](CHANGELOG.md).

--- a/bench/egress/cmd/bench-egress/main.go
+++ b/bench/egress/cmd/bench-egress/main.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Command bench-egress is the entry point for pipelock's agent-egress overhead
 // benchmark. It drives traffic across five transports (HTTP, SSE, tool-chain,
 // MCP stdio, WebSocket) directly against in-process mocks and through a

--- a/bench/egress/harness/coldstart.go
+++ b/bench/egress/harness/coldstart.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package harness
 
 import (

--- a/bench/egress/harness/latency.go
+++ b/bench/egress/harness/latency.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package harness
 
 import (

--- a/bench/egress/harness/memory.go
+++ b/bench/egress/harness/memory.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package harness
 
 import (

--- a/bench/egress/harness/memory_test.go
+++ b/bench/egress/harness/memory_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package harness
 
 import (

--- a/bench/egress/harness/probe.go
+++ b/bench/egress/harness/probe.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package harness
 
 import (

--- a/bench/egress/harness/stats.go
+++ b/bench/egress/harness/stats.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package harness implements the egress-overhead benchmark harness. It drives
 // traffic through five transports (HTTP, SSE, tool-chain, MCP stdio,
 // WebSocket) both directly against in-process mocks and through a running

--- a/bench/egress/harness/stats_test.go
+++ b/bench/egress/harness/stats_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package harness
 
 import (

--- a/bench/egress/mocks/httpecho/server.go
+++ b/bench/egress/mocks/httpecho/server.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package httpecho is a deterministic HTTP mock server used by the egress
 // benchmark harness. It returns a fixed 1 KiB body so that latency
 // measurements reflect pipelock's overhead rather than backend variance.

--- a/bench/egress/mocks/mcpstdio/main.go
+++ b/bench/egress/mocks/mcpstdio/main.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Command mcpstdio is a deterministic MCP stdio server used by the egress
 // benchmark. It implements just enough of the MCP protocol (initialize,
 // tools/list, tools/call) to be wrapped by `pipelock mcp proxy --` and also

--- a/bench/egress/mocks/sse/server.go
+++ b/bench/egress/mocks/sse/server.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package sse is a deterministic Server-Sent Events mock used by the egress
 // benchmark. It streams a fixed number of chunks at a fixed cadence so that
 // TTFB (time to first byte) and full-stream duration can be measured.

--- a/bench/egress/mocks/toolchain/server.go
+++ b/bench/egress/mocks/toolchain/server.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package toolchain is a deterministic LLM-shape mock for benchmarking
 // tool-use sequences. It returns Claude-shaped responses with tool_use blocks
 // so the harness can drive an N-step tool-call chain through pipelock without

--- a/bench/egress/mocks/toolchain/server_test.go
+++ b/bench/egress/mocks/toolchain/server_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package toolchain
 
 import (

--- a/bench/egress/mocks/wsfeed/server.go
+++ b/bench/egress/mocks/wsfeed/server.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package wsfeed is a deterministic WebSocket mock used by the egress
 // benchmark. It implements a minimal text-frame responder using raw TCP +
 // hand-rolled WebSocket frame parsing. Hand-rolled to keep the bench

--- a/bench/egress/run-all.sh
+++ b/bench/egress/run-all.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # bench/egress/run-all.sh - run the agent-egress overhead benchmark.
 #
 # Defaults to quick mode (usually 1-3 minutes). Use --release to run the full suite

--- a/cmd/license-service/admin.go
+++ b/cmd/license-service/admin.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package main

--- a/cmd/license-service/admin_import_test.go
+++ b/cmd/license-service/admin_import_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package main

--- a/cmd/license-service/admin_test.go
+++ b/cmd/license-service/admin_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package main

--- a/cmd/license-service/main.go
+++ b/cmd/license-service/main.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package main is the entry point for the Pipelock license service.

--- a/cmd/license-service/main_test.go
+++ b/cmd/license-service/main_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package main

--- a/cmd/pipelock/enterprise.go
+++ b/cmd/pipelock/enterprise.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package main

--- a/deploy/wasm-verify/build.sh
+++ b/deploy/wasm-verify/build.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -81,7 +81,7 @@ The matrix below compares Pipelock to earlier-generation tools (AIP, agentsh, sr
 ### Use Pipelock when:
 - You need to **prevent credential exfiltration** from AI agents with API keys
 - You want **content inspection** (DLP, injection detection) on what agents fetch
-- You need **audit logging** of all agent network activity
+- You need **audit logging** for network activity mediated by the proxy
 - You want a **single binary** with no dependencies or kernel modules
 - You're running agents in **CI/CD** and need machine-readable output
 - You want **workspace integrity monitoring** to detect file tampering

--- a/docs/compliance/eu-ai-act-mapping.md
+++ b/docs/compliance/eu-ai-act-mapping.md
@@ -6,9 +6,10 @@ How Pipelock's runtime security controls map to the [EU AI Act (Regulation 2024/
 
 **Disclaimer:** This document maps Pipelock's security features to EU AI Act requirements for informational purposes. It does not constitute legal advice or guarantee regulatory compliance. Organizations should consult qualified legal counsel for compliance obligations specific to their AI systems.
 
-**Last updated:** May 2026 (reviewed against the v2.6 feature set. v2.5 added the host containment lifecycle CLI (`pipelock contain install / verify / rollback / add-tool / grant-workspace / revoke-workspace / ca-refresh`) implementing a 3-UID kernel-level nftables owner-match separation with kernel-observed posture attestation strengthening Art. 14 Human Oversight (operator-enforced separation of duties between the operator and the agent process), Art. 15 Cybersecurity (kernel-level owner-match egress containment with kernel-observed posture attestation, TOFU binary integrity and explicit workspace ACL lifecycle), and Art. 26 Deployer Obligations (operator-visible install / verify / rollback path); the canonical Audit Packet v0 schema plus first-party Go / TypeScript / Rust / standalone verifier implementations strengthening Art. 12 Record-Keeping and Art. 13 Transparency (language-portable, independent verification of every signed receipt without depending on Pipelock); strict-default SPIFFE actor enforcement on inbound mediation envelopes plus the `pipelock envelope trust` operator CLI strengthening Art. 14 Identification of Deployers and cross-organisational verifiability; activation-time tombstone enforcement preventing re-promotion of withdrawn contracts strengthening Art. 9 Risk Management System (operator-driven withdrawal stays withdrawn); skill-poisoning instruction-recognition coverage strengthening Art. 15 Cybersecurity at the agent-content boundary; rules-bundle keyring separated from license key strengthening Art. 15 cryptographic isolation between commercial keys and detection keys; optional OTel `agent.threat.detection.*` attributes strengthening Art. 12 Record-Keeping for observability-driven audit. Builds on the v2.4 baseline (learn-and-lock contracts for Art. 12 / Art. 14, inbound envelope verification + replay protection for Art. 13, SPIFFE actor format + RFC 9421 directory for Art. 14, `X-Pipelock-Block-Reason` for Art. 13, Gemini provider redaction extending Art. 10), the v2.3.0 baseline (class-preserving redaction across HTTP / WebSocket / MCP, generic SSE streaming with per-event body scanning), and the v2.2.0 baseline (mediation envelope, signed action receipts across all transports, taint-aware policy escalation, posture verify CLI, companion-proxy deployment, session operator CLI).
+**Last reviewed:** July 2026 against v3.2.0. This mapping describes current
+behavior; see [CHANGELOG.md](../../CHANGELOG.md) for release history.
 
-v2.6 review (May 2026):
+Recent control additions reviewed:
 
 - Art. 12: block-reason receipts, scan API tool-call findings, and file_sentry skip visibility improve operator records for mediated decisions and uninspected local files.
 - Art. 13: `request_policy_deny` block reasons and explicit scan-cap failure behavior make denial causes more transparent to operators and agent clients.
@@ -28,7 +29,7 @@ Coverage levels: **Full** = Pipelock feature directly implements the requirement
 | Article | Topic | Coverage |
 |---------|-------|----------|
 | Art. 9 | Risk Management System | Partial (runtime controls only) |
-| Art. 12 | Record-Keeping | Full (logging requirements) |
+| Art. 12 | Record-Keeping | Partial (mediated events; core delivery is best-effort) |
 | Art. 13 | Transparency | Moderate |
 | Art. 14 | Human Oversight | Moderate (terminal-only HITL) |
 | Art. 15 | Accuracy, Robustness, Cybersecurity | Moderate |
@@ -44,12 +45,12 @@ Article 9 requires a continuous, iterative risk management process throughout th
 
 | Requirement | Pipelock Feature | Coverage |
 |-------------|-----------------|----------|
-| Identify and analyze known risks (Art. 9(2)(a)) | 11-layer scanner pipeline classifies network-level risks: scheme validation, CRLF injection, path traversal, domain blocklist, DLP (inc. env leak), path entropy, subdomain entropy, SSRF, rate limiting, URL length, data budget | Partial |
+| Identify and analyze known risks (Art. 9(2)(a)) | Ordered scanner pipeline classifies mediated network risks through URL validation, destination policy, DLP, entropy analysis, SSRF/rebinding protection, rate limiting, and data budgets | Partial |
 | Evaluate risks under foreseeable misuse (Art. 9(2)(b)) | Adversarial testing of bypass attempts (encoded secrets, DNS exfiltration, zero-width injection, split-key attacks) | Partial |
 | Post-market monitoring data (Art. 9(2)(c)) | Prometheus metrics (`/metrics`), JSON stats (`/stats`), structured audit logs | Partial |
 | Eliminate risks through design (Art. 9(5)(a)) | Capability separation reduces network-based credential exfiltration risk: agent holds secrets with no network; proxy has network with no agent secrets. Deployment enforces the boundary | Partial |
 | Mitigation and control measures (Art. 9(5)(b)) | Multi-layer scanning, domain blocklist, rate limiting, DLP patterns, HITL approval | Full |
-| Residual risk information to deployers (Art. 9(5)(c)) | Audit logs document every scan decision; `/stats` endpoint surfaces top threats | Partial |
+| Residual risk information to deployers (Art. 9(5)(c)) | Audit events document mediated scanner and policy decisions; `/stats` surfaces observed threats. Completeness still depends on deployment routing and sink delivery | Partial |
 | Prior defined metrics and thresholds (Art. 9(8)) | Configurable thresholds per scanner layer; Prometheus counters for block rates by category | Full |
 | Continuous lifecycle process (Art. 9(2)) | Hot-reload config (fsnotify + SIGHUP) for live policy updates without restart | Partial |
 
@@ -63,12 +64,15 @@ Article 12 requires automatic event logging in high-risk AI systems for risk ide
 
 | Requirement | Pipelock Feature | Coverage |
 |-------------|-----------------|----------|
-| Automatic recording of events (Art. 12(1)) | Structured JSON audit logging (zerolog) for every request: URL, domain, agent name, scan result, scanner reason, timestamp, duration | Full |
+| Automatic recording of events (Art. 12(1)) | Structured JSON logging records mediated scanner and policy events with transport-appropriate fields. External emission is best-effort unless the Enterprise durable SIEM path is used | Partial |
 | Identify risk situations (Art. 12(2)(a)) | Categorized threat events: SSRF, DLP match, prompt injection, env leak, entropy anomaly, rate limit, redirect chain | Full |
 | Support post-market monitoring (Art. 12(2)(b)) | Prometheus metrics with counters, histograms, and alerting integration; Grafana dashboard (`configs/grafana-dashboard.json`) | Full |
-| Enable deployer monitoring (Art. 12(2)(c)) | Per-agent profiles with named identity, independent config, and per-agent budgets; agent name in every log entry | Full |
+| Enable deployer monitoring (Art. 12(2)(c)) | Per-agent profiles provide named identity, independent config, and per-agent budgets; mediated events carry resolved agent identity when available | Partial |
 
-**Gap:** None for the logging requirements Pipelock addresses. Full Art. 12 includes biometric system requirements (Art. 12(3)) that don't apply.
+**Gap:** Pipelock cannot prove that traffic bypassing the mediated boundary was
+recorded, and core external emission is best-effort. Full Article 12 also
+includes system-level retention and biometric requirements that are outside
+this component's scope.
 
 ---
 
@@ -82,7 +86,7 @@ Article 13 requires sufficient operational transparency for deployers to underst
 | Limitations documented | Each OWASP mapping doc includes explicit coverage gaps and "out of scope" sections | Full |
 | Logging mechanism description | Audit log format, event types, and fields documented in CLAUDE.md and guides | Full |
 | Human oversight measures described (Art. 14 ref) | HITL documentation in guides and config presets | Partial |
-| Computational/hardware requirements | Single static binary (~18MB), documented in README | Full |
+| Computational/hardware requirements | Single-binary deployment and reproducible performance benchmarks are documented; artifact size varies by platform, build tags, and release flags | Partial |
 
 **Gap:** Full Art. 13 compliance requires system-level documentation that depends on the deployer's AI system, not just the security layer.
 

--- a/docs/compliance/nist-800-53.md
+++ b/docs/compliance/nist-800-53.md
@@ -6,9 +6,10 @@ See also: [NIST AI RMF crosswalk](eu-ai-act-mapping.md#nist-ai-rmf-10-crosswalk)
 
 > **Scope:** Pipelock is an application-layer agent firewall with process containment. It covers network egress filtering, content inspection, audit logging, process isolation, and human oversight for AI agent deployments. It does not cover identity management, physical security, personnel security, or full-lifecycle system authorization. This mapping is for informational purposes and does not constitute compliance certification.
 
-**Last updated:** July 2026 (reviewed against the v3.1.0 feature set. v3.1.0 adds Enterprise Conductor fleet policy-bundle distribution, remote kill, rollback authorization, follower drift preflight, and signed fleet audit surfaces, strengthening CM-2/CM-3 Configuration Management, IR-4 Incident Handling, AU-6/AU-12 Audit Review and Generation, and SC-7 Boundary Protection for enterprise fleets. Builds on the v2.6 baseline (`request_policy` operation rails, header-DLP parity, scan API tool-call scanning, response scan-cap fail-closed behavior, SSRF-safe submit-profile reverse-proxy dialing, WebSocket per-frame `request_policy` checks, media canonical-end truncation, and redaction passthrough hardening), the v2.5 baseline (host containment lifecycle CLI, Audit Packet v0 verifier implementations, strict-default SPIFFE actor enforcement on inbound mediation envelopes, activation-time tombstone enforcement, skill-poisoning instruction recognition, separated rules-bundle keyring, scanner-decision OTel attributes, and fail-closed `pipelock claude-hook` behavior), the v2.4 baseline (learn-and-lock per-agent behavioral contracts with signed `EvidenceReceipt v2`, inbound mediation envelope verification with replay protection, SPIFFE actor format with RFC 9421 directory discovery, `X-Pipelock-Block-Reason` response visibility, and Gemini provider redaction), the v2.3.0 baseline (class-preserving request redaction and generic SSE streaming with per-event body scanning), and the v2.2.0 baseline (mediation envelope, expanded signed action receipt coverage, taint-aware policy escalation, posture verify CLI + CI gate, and companion-proxy deployment).
+**Last reviewed:** July 2026 against v3.2.0. This mapping describes current
+behavior; see [CHANGELOG.md](../../CHANGELOG.md) for release history.
 
-v3.1.0 review:
+Recent control additions reviewed:
 
 - CM-2 / CM-3: Enterprise Conductor distributes signed policy bundles to enrolled followers and performs follower drift preflight before activation.
 - IR-4: Enterprise Conductor remote kill and rollback authorization provide fleet-level emergency controls while followers continue to enforce locally.
@@ -43,10 +44,10 @@ v3.1.0 review:
 | Control | Name | Pipelock Feature | Coverage |
 |---------|------|-----------------|----------|
 | AC-3 | Access Enforcement | Tool policy rules enforce per-tool allow/deny decisions. Per-agent profiles with independent budgets and rate limits. Sandbox restricts filesystem and network access. | **Strong** |
-| AC-4 | Information Flow Enforcement | Capability separation: agent (secrets, no network) communicates only through pipelock (network, no secrets). DLP scanning on all egress surfaces prevents secret leakage. Sandbox network namespaces enforce flow boundaries. | **Strong** |
-| AC-4(4) | Content Check | 11-layer scanner pipeline inspects all content: DLP patterns, entropy analysis, prompt injection detection, SSRF prevention. Full-schema tool poisoning detection. | **Strong** |
+| AC-4 | Information Flow Enforcement | Capability separation: agent (secrets, no direct network) communicates through Pipelock (policy-controlled egress, no agent secrets). DLP scanning applies on inspection-capable mediated surfaces; deployment isolation enforces the flow boundary. | **Strong** |
+| AC-4(4) | Content Check | The ordered scanner pipeline applies destination, DLP, entropy, injection, and SSRF controls where each transport exposes the relevant content. Plain CONNECT without TLS interception remains hostname-only. Full-schema tool-poisoning detection applies to mediated MCP tool metadata. | **Strong** |
 | AC-6 | Least Privilege | Per-agent profiles constrain each agent to specific listeners, rate limits, and data budgets. Sandbox Landlock restricts filesystem to declared paths only. Seccomp restricts syscalls to an allowlist. | **Strong** |
-| AC-6(9) | Log Use of Privileged Functions | Every tool call, scan decision, and policy action is logged with agent identity, tool name, and timestamp. | **Strong** |
+| AC-6(9) | Log Use of Privileged Functions | Mediated tool calls, scanner decisions, and policy actions produce structured records with the identity and operation fields available to that transport. | **Strong** |
 | AC-17 | Remote Access | Kill switch API with bearer-token authentication and optional IP allowlist. Port isolation prevents agent self-deactivation. | **Moderate** |
 
 **Gap:** Agent identity is config-based (HTTP header or listener binding), not certificate-based. mTLS agent authentication is on the enterprise roadmap.
@@ -57,13 +58,13 @@ v3.1.0 review:
 
 | Control | Name | Pipelock Feature | Coverage |
 |---------|------|-----------------|----------|
-| AU-2 | Event Logging | Every request (allow, block, warn, ask, strip) generates a structured audit event with category, severity, agent identity, and scan reasoning. Every enforcement decision also emits an Ed25519-signed action receipt covering fetch, forward, CONNECT, TLS interception, WebSocket, MCP stdio, MCP HTTP, MCP HTTP reverse proxy, and A2A forward-proxy paths. | **Strong** |
+| AU-2 | Event Logging | Mediated enforcement and scanner events generate structured audit records with category, severity, agent identity, and scan reasoning where available. Blocks emit signed action receipts; allow receipts are opt-in with `require_receipts`, and clean stream frames are summarized. | **Strong** |
 | AU-3 | Content of Audit Records | Events include: timestamp, agent name, source IP, destination URL/domain, scan result, scanner reason, matched pattern, action taken, duration. Receipts additionally include `policy_hash`, `action_id` (UUIDv7), transport, and taint-aware fields (`session_taint_level`, `authority_kind`, `session_task_id`). | **Strong** |
 | AU-3(1) | Additional Audit Information | Session profiling adds risk scores, domain burst detection, and behavioral anomaly indicators per session. Mediation envelope (`Pipelock-Mediation` header) carries the same action ID + policy hash on the wire for downstream correlation. | **Strong** |
 | AU-6 | Audit Record Review, Analysis, Reporting | Prometheus metrics with counters and histograms. Grafana dashboard template. SARIF output for CI integration. Report generation with risk rating and evidence appendix. `pipelock session inspect/explain` surfaces recent events and trigger/evidence for active airlock escalations. | **Strong** |
 | AU-8 | Time Stamps | All events use RFC 3339 timestamps from the system clock. | **Strong** |
 | AU-10 | Non-Repudiation | Action receipts are Ed25519-signed with a hash-chained sequence (`chain_prev_hash`, `chain_seq`). Transcript root commits seal sections of the chain. `pipelock verify-receipt` and the cross-implementation conformance suite (`sdk/conformance/`) let third parties verify receipts without trusting pipelock. | **Strong** |
-| AU-12 | Audit Record Generation | Three emission targets: webhook (async buffered), syslog (UDP), and OTLP (HTTP/protobuf). Prometheus `/metrics` endpoint. Flight recorder writes receipts as signed JSONL. | **Strong** |
+| AU-12 | Audit Record Generation | Three queued emission targets: webhook, syslog (UDP or TCP, JSON or CEF), and OTLP (HTTP/protobuf). Prometheus `/metrics` endpoint. The flight recorder writes signed JSONL receipts when configured. | **Strong** |
 
 **Partial:** Core per-instance emission is best-effort. The Enterprise durable SIEM forwarder adds at-least-once delivery with an on-disk spool and replay across restarts, and the Enterprise Conductor provides a signed-evidence fleet audit sink namespaced per org, fleet, and instance.
 
@@ -97,10 +98,10 @@ v3.1.0 review:
 
 | Control | Name | Pipelock Feature | Coverage |
 |---------|------|-----------------|----------|
-| IR-4 | Incident Handling | Kill switch provides emergency deny-all from 4 independent sources (config, API, SIGUSR1, sentinel file). Any source active blocks all traffic. OR-composed: deactivating one source doesn't affect others. | **Strong** |
+| IR-4 | Incident Handling | Kill switch provides emergency deny-all from six independent sources: config, API, Conductor remote kill, Conductor stale-bundle detection, SIGUSR1, and sentinel file. Any active source denies normal traffic, subject to configured endpoint and IP exemptions. Deactivating one source does not affect the others. | **Strong** |
 | IR-4(1) | Automated Incident Handling | Adaptive enforcement automatically escalates from warn to block when per-session risk threshold is exceeded. | **Moderate** |
 | IR-5 | Incident Monitoring | Prometheus metrics track blocked requests by category. Session profiling identifies high-risk sessions. Event emission forwards alerts to SIEM in real time. | **Strong** |
-| IR-6 | Incident Reporting | Structured audit events with MITRE ATT&CK technique mapping (T1048 exfiltration, T1059 injection, T1195.002 supply chain). Report generation produces signed evidence packages. | **Strong** |
+| IR-6 | Incident Reporting | Structured audit events include MITRE ATT&CK mappings for applicable threat classes. Report generation can produce Ed25519-signed evidence packages when signing is configured. | **Strong** |
 
 ---
 
@@ -109,7 +110,7 @@ v3.1.0 review:
 | Control | Name | Pipelock Feature | Coverage |
 |---------|------|-----------------|----------|
 | SC-4 | Information in Shared Resources | Per-agent profiles isolate budgets, rate limits, and session state. Sandbox provides process-level isolation via Landlock, network namespaces, and seccomp. | **Strong** |
-| SC-7 | Boundary Protection | Capability separation enforces a network boundary between the agent (privileged, no network) and the internet (via pipelock proxy). 11-layer scanner inspects all cross-boundary traffic. | **Strong** |
+| SC-7 | Boundary Protection | Capability separation enforces a deployment boundary between the agent (privileged, no direct network) and policy-controlled egress through Pipelock. The ordered URL pipeline inspects mediated destination data; content inspection depends on transport visibility, with plain CONNECT remaining hostname-only. | **Strong** |
 | SC-7(5) | Deny by Default / Allow by Exception | Strict mode denies all traffic except explicitly allowlisted API domains. Fail-closed on timeout, parse error, and context cancellation. | **Strong** |
 | SC-8 | Transmission Confidentiality and Integrity | TLS interception for CONNECT tunnels with per-host certificate generation. Ed25519 signing for reports, rules, and integrity manifests. | **Moderate** |
 | SC-13 | Cryptographic Protection | Ed25519 for signing (keys, reports, community rules, integrity manifests). SHA-256 for tool baseline hashing and file integrity. TLS for proxy traffic. | **Moderate** |
@@ -125,7 +126,7 @@ v3.1.0 review:
 |---------|------|-----------------|----------|
 | SI-3 | Malicious Code Protection | Tool poisoning detection scans all schema fields for injected instructions. Response scanning detects prompt injection in tool results. DLP prevents secret exfiltration. | **Strong** |
 | SI-4 | System Monitoring | Continuous scanning of mediated HTTP, WebSocket, and MCP traffic. Prometheus metrics, structured logging, session profiling, and adaptive enforcement provide layered monitoring. | **Strong** |
-| SI-4(4) | Inbound and Outbound Communications Traffic | Bidirectional MCP scanning: outbound (agent-to-server) for DLP leaks, inbound (server-to-agent) for injection. URL scanner covers all HTTP egress. WebSocket frame scanning covers bidirectional channels. | **Strong** |
+| SI-4(4) | Inbound and Outbound Communications Traffic | Bidirectional MCP scanning checks mediated outbound tool input for DLP and inbound results for injection. The URL scanner covers mediated HTTP destinations, while payload visibility depends on transport mode. The WebSocket proxy scans frames in both directions. | **Strong** |
 | SI-7 | Software, Firmware, and Information Integrity | Binary integrity monitoring (`pipelock integrity`). Community rule bundle signature verification. Tool baseline drift detection (SHA-256 per session). SLSA provenance on releases. | **Strong** |
 | SI-10 | Information Input Validation | MCP input scanning validates tool call arguments for DLP and injection patterns. Shell obfuscation detection (octal, hex, brace expansion, variable substitution, command substitution) normalizes input before matching. | **Strong** |
 

--- a/docs/compliance/owasp-mcp-top10.md
+++ b/docs/compliance/owasp-mcp-top10.md
@@ -6,7 +6,9 @@ See also: [OWASP Agentic Top 10 mapping](../owasp-mapping.md) | [OWASP AIVSS cov
 
 > **Note:** Coverage levels reflect architectural capabilities against known attack patterns, not guarantees of threat prevention. Pipelock is a network-layer proxy; some MCP risks require complementary controls at the client, server, or identity layer. This mapping is for informational purposes and does not constitute compliance certification.
 
-**Last updated:** May 2026, reviewed against the v2.5 feature set. See [CHANGELOG.md](../../CHANGELOG.md) for full release history; the appendix at the bottom of this document lists v2.5-specific deltas mapped to MCP categories.
+**Last reviewed:** July 2026 against v3.2.0. This mapping describes current
+behavior; see [CHANGELOG.md](../../CHANGELOG.md) for release history. The
+appendix remains an explicitly historical list of v2.5 deltas.
 
 ---
 
@@ -154,8 +156,8 @@ See also: [OWASP Agentic Top 10 mapping](../owasp-mapping.md) | [OWASP AIVSS cov
 
 **Pipelock coverage:**
 
-- **Structured audit logging:** every scan decision (allow, block, warn, ask, strip) is logged as structured JSON with timestamp, agent identity, tool name, scan result, scanner reason, and duration.
-- **Three emission targets:** webhook (async buffered), syslog (UDP), and OTLP (HTTP/protobuf). All fire-and-forget to avoid blocking the proxy.
+- **Structured audit logging:** mediated scanner and policy decisions are logged as structured JSON with the fields available to that transport, such as timestamp, agent identity, tool name, result, reason, and duration.
+- **Three queued emission targets:** webhook, syslog (UDP or TCP, JSON or CEF), and OTLP (HTTP/protobuf). Queue pressure or delivery failures are reported and may drop best-effort events rather than blocking the proxy.
 - **Prometheus metrics:** counters and histograms for all scan categories, exportable to any monitoring stack.
 - **Session profiling:** per-session event history with risk scoring for forensic analysis.
 - **SARIF output:** `pipelock audit` produces SARIF for integration with GitHub Code Scanning and CI/CD workflows.
@@ -192,7 +194,9 @@ See also: [OWASP Agentic Top 10 mapping](../owasp-mapping.md) | [OWASP AIVSS cov
 - **Cross-request exfiltration detection (CEE):** tracks entropy budget across requests to detect slow data exfiltration spread across multiple tool calls within a session.
 - **Per-agent isolation:** separate config profiles, budgets, and session state per agent identity prevent cross-agent data leakage through the proxy layer.
 - **Data budget enforcement:** per-domain byte limits prevent bulk data extraction through allowed endpoints.
-- **DLP on all surfaces:** secrets in tool results, error messages, and nested JSON are caught by DLP pattern matching with full encoding resistance.
+- **DLP on mediated MCP content:** tool arguments, results, error messages, and
+  nested JSON routed through enabled MCP scanning are checked by DLP pattern
+  matching and normalization.
 
 **Configuration:** `cross_request_detection`, `agents`, `dlp`
 
@@ -202,7 +206,13 @@ See also: [OWASP Agentic Top 10 mapping](../owasp-mapping.md) | [OWASP AIVSS cov
 
 ## Architectural Note
 
-Pipelock operates at the **network transport layer** between the MCP client (agent) and MCP server. This provides visibility into all traffic regardless of the agent framework, programming language, or MCP server implementation. However, some MCP risks that exist purely at the application layer (in-memory state, local variable access, semantic argument validation) are outside the proxy's architectural scope.
+Pipelock operates at the **network transport layer** between the MCP client
+(agent) and MCP server. It provides framework-independent visibility into MCP
+traffic that is actually routed through a Pipelock MCP proxy or listener.
+Direct or in-process MCP traffic that bypasses Pipelock is not visible. Some
+MCP risks that exist purely at the application layer (in-memory state, local
+variable access, semantic argument validation) are also outside the proxy's
+architectural scope.
 
 For multi-layer MCP security, combine network-layer enforcement (Pipelock) with:
 - **Pre-deployment scanning** (Snyk Agent Scan, Aguara) for static tool/skill analysis

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,10 @@ pipelock audit ./my-project -o pipelock.yaml
 
 Config changes are picked up automatically via file watcher or SIGHUP signal (100ms debounce). Most fields reload without restart. Fields that require a restart are marked below.
 
-On reload, the scanner and session manager are atomically swapped. Kill switch state (all 4 sources) is preserved. Existing MCP sessions retain the old scanner until the next request.
+On reload, the scanner and session manager are atomically swapped. Runtime
+kill-switch state is preserved, including the API, signal, Conductor remote,
+and Conductor stale-bundle sources. Existing MCP sessions retain the old
+scanner until the next request.
 
 If a reload fails validation (invalid regex, security downgrade), the old config is retained and a warning is logged. A reload is also rejected, in any mode, when a rule-bundle resolution error (bad signature, missing lock file, version mismatch, filesystem error) would drop detection rules that are currently live: the previous config is kept so a transient bundle failure cannot silently weaken coverage. An unrelated bundle error that does not remove any live rule does not block the reload. At startup there is no prior config to preserve, so a bundle resolution error is surfaced loudly and the proxy runs on its remaining (core plus compiled) patterns rather than refusing to start.
 
@@ -1275,7 +1278,13 @@ Session profiling detects domain bursts (many unique domains in a short window).
 
 ## Kill Switch
 
-Emergency deny-all with four independent activation sources (`enabled`, `sentinel_file`, `api`, `SIGUSR1`). Any one active denies normal traffic (OR-composed) except for configured exemptions (`health_exempt`, `metrics_exempt`, `api_exempt`, `allowlist_ips`). See [Kill Switch](../README.md#kill-switch) for operational details.
+Emergency deny-all with six independent activation sources: `enabled`,
+`sentinel_file`, API, `SIGUSR1`, Conductor remote kill, and Conductor
+stale-bundle detection. Any one active denies normal traffic (OR-composed)
+except for configured exemptions (`health_exempt`, `metrics_exempt`,
+`api_exempt`, `allowlist_ips`). The two Conductor-driven sources are activated
+by the enterprise follower runtime. See [Kill Switch](../README.md#operability)
+for operational details.
 
 > **Heads-up on `enabled`:** the `enabled` field is a source, not a subsystem switch. Setting `enabled: true` immediately activates the kill switch and denies all traffic from startup (all requests return HTTP 503). To configure the API/signal/sentinel sources for future activation without engaging the kill switch at startup, leave `enabled: false`.
 
@@ -2346,7 +2355,7 @@ dashboard_snapshot:
 | `redact` | `true` | DLP-redact evidence content before writing. Receipt entries get field-level redaction (target/pattern scrubbed, signature preserved). |
 | `require_receipts` | `false` | Require allow-path receipt emission before forwarding traffic. When true, signing/recorder failures block with `receipt_emission_failed`; this includes TLS-intercepted CONNECT inner HTTP requests before their upstream request. Block-path receipts remain best-effort because the action is already denied. |
 | `sign_checkpoints` | `true` | Ed25519 sign checkpoint entries |
-| `signing_key_path` | (empty) | Ed25519 private key for signed action receipts. When set, every proxy decision produces a signed receipt. Without it, the flight recorder can still write non-receipt evidence entries. Generate a key with `pipelock keygen <name>`. Verify receipts with `pipelock verify-receipt <file> --key <signer.pub>` (pin the signer key — an unpinned run is structural-only and exits non-zero unless you pass `--allow-unpinned`). In `pipelock run`, changing the configured path requires restart; reload re-reads updated key bytes only when the same path stays configured. |
+| `signing_key_path` | (empty) | Ed25519 private key for signed action receipts. When set, blocks produce signed receipts; allow receipts also require `require_receipts: true`, and clean stream frames are summarized. Without a key, the flight recorder can still write non-receipt evidence entries. Generate a key with `pipelock keygen <name>`. Verify receipts with `pipelock verify-receipt <file> --key <signer.pub>` (pin the signer key — an unpinned run is structural-only and exits non-zero unless you pass `--allow-unpinned`). In `pipelock run`, changing the configured path requires restart; reload re-reads updated key bytes only when the same path stays configured. |
 | `max_entries_per_file` | `10000` | Rotate to a new file after this many entries |
 | `raw_escrow` | `false` | Encrypt raw (pre-redaction) detail to sidecar files |
 | `escrow_public_key` | (required if raw_escrow) | X25519 public key (hex) for escrow encryption |
@@ -3025,12 +3034,25 @@ conductor:
 | `max_min_version_major_skew` | `0` | Reserved (see below). |
 | `max_min_version_minor_skew` | `1` | Reserved (see below). |
 | `max_capability_threshold` | `7` | Reserved (see below). |
-| `stale_policy.grace_multiplier` | `1` | Reserved (see below). |
-| `stale_policy.after_grace` | `strict_deny_all` | Reserved (see below). `continue_last_known_good` is accepted with an advisory warning because it weakens the fail-closed default. |
+| `stale_policy.grace_multiplier` | `1` | Number of original bundle-validity windows added after expiry before the after-grace action applies. Must be greater than zero. |
+| `stale_policy.after_grace` | `strict_deny_all` | Runtime action after the grace window. `strict_deny_all` engages the independent `conductor_stale` kill-switch source; `continue_last_known_good` keeps serving the expired last-applied bundle and emits an advisory warning. |
 
 When `enabled: true`, validation additionally requires the [flight recorder](#flight-recorder-v21) enabled with `sign_checkpoints: true` and a configured `signing_key_path` (a follower must produce signed evidence to participate), all file paths absolute, and no world-writable ancestor directory on any configured path.
 
-**Reserved fields.** The fields marked reserved are parsed and validated at startup but not yet enforced by the follower runtime in v2.8; they reserve the config surface for upcoming bundle-staleness and capability-negotiation work. This includes `emergency_stream`, `created_skew_seconds`, `max_min_version_major_skew` (`MaxMinVersionMajorSkew`), `max_min_version_minor_skew` (`MaxMinVersionMinorSkew`), `max_capability_threshold`, and `stale_policy.*` (`StalePolicy`). Today a bundle's validity window is enforced when the bundle is verified and applied (an expired bundle fails verification), and a follower that cannot reach Conductor keeps enforcing the policy it already has.
+**Stale-policy enforcement.** The follower evaluates the active bundle
+immediately at startup and on the runtime check interval. A missing, unreadable,
+or corrupt active bundle engages `conductor_stale` regardless of
+`after_grace`. An expired bundle remains last-known-good through the configured
+grace window. After that window, the default `strict_deny_all` action engages
+the kill switch until a fresh in-grace bundle applies;
+`continue_last_known_good` keeps serving the last applied bundle with a
+weakened-posture warning. These fields are restart-only.
+
+**Reserved fields.** `emergency_stream`, `created_skew_seconds`,
+`max_min_version_major_skew`, `max_min_version_minor_skew`, and
+`max_capability_threshold` are parsed and validated but are not yet consumed by
+the follower runtime. They reserve the config surface for later emergency-stream
+and capability-negotiation work.
 
 See the [Conductor guide](guides/conductor.md) for the full architecture, server-side flags, and licensing.
 

--- a/docs/enterprise-readiness.md
+++ b/docs/enterprise-readiness.md
@@ -1,0 +1,100 @@
+<!--
+Copyright 2026 Josh Waldrep
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Enterprise Readiness
+
+Pipelock can run inside an organization's own boundary: enforcement, evidence,
+keys, policy, and audit storage do not require a Pipelab-hosted control plane.
+This page gives security reviewers and platform teams a practical map of the
+shipped enterprise surfaces and the responsibilities that remain with the
+deployment.
+
+It is a technical readiness guide, not a certification, uptime commitment,
+support contract, or data-processing agreement.
+
+## What Ships
+
+| Area | Shipped surface | Start here |
+|---|---|---|
+| Boundary enforcement | HTTP, WebSocket, MCP, A2A, sandbox, host containment, Kubernetes topology, kill switch | [Deployment recipes](guides/deployment-recipes.md), [transport modes](guides/transport-modes.md) |
+| Fleet control | Signed policy distribution, mTLS follower enrollment, remote kill, rollback, dry-run, replay, drift and applied-state reporting | [Conductor](guides/conductor.md), [production runbook](guides/conductor-production-runbook.md) |
+| Identity and access | Dashboard token, OIDC, or mTLS authentication; bounded read permissions and separate raw-evidence elevation | [Dashboard](cli/dashboard.md) |
+| Verifiable evidence | Signed action receipts, EvidenceReceipt v2, hash chains, checkpoints, coverage certificates, Audit Packets, offline verifiers | [Receipt verification](guides/receipt-verification.md), [security assurance](security-assurance.md) |
+| Key lifecycle | Purpose-bound signing keys, trusted rosters, rotation, revocation, recovery, and trust-key inspection | [Key rotation](security/key-rotation-runbook.md), [keys CLI](cli/keys.md) |
+| Audit integration | JSON logs, durable Enterprise forwarding, webhook, syslog, CEF, OTLP, Prometheus, Grafana | [SIEM integration](guides/siem-integration.md), [metrics](metrics.md) |
+| Operations | Health/readiness probes, support bundle, backup/restore, retention controls, legal-hold metadata, incident and fleet views | [Support bundle](cli/support.md), [Conductor backup/restore](guides/conductor-backup-restore.md) |
+| Software supply chain | Signed releases, checksums, provenance attestations, SBOMs, vulnerability scanning, reproducible OSS build check | [Install verification](cli/verify-install.md), [reproducible builds](reproducible-builds.md) |
+
+## Evaluation Path
+
+An evaluation should prove behavior on the buyer's intended topology, not only
+show a dashboard:
+
+1. Run `pipelock demo --receipts-dir ./out` and verify one receipt with the
+   generated public key.
+2. Run `pipelock check`, `pipelock doctor`, and `pipelock audit score` against
+   the candidate configuration.
+3. Use `pipelock contain verify` or the Kubernetes deployment proof appropriate
+   to the topology to show whether direct egress is actually blocked.
+4. Exercise the exact HTTP, WebSocket, MCP, A2A, and TLS visibility paths the
+   deployment will claim.
+5. Run `pipelock conductor bootstrap` in an isolated evaluation environment to
+   prove enrollment, signed audit ingest, query, and offline verification.
+6. Restore a Conductor backup on the buyer's storage class before agreeing to an
+   RTO or RPO.
+7. Export a secret-redacted `pipelock support bundle`, review it manually, and
+   confirm the organization's support-data handling process.
+
+The [security assessment mapping](compliance/assess-mapping.md) connects
+deployment evidence to common frameworks without claiming certification.
+
+## Deployment Review
+
+| Question | Required enterprise decision |
+|---|---|
+| Which process or network control prevents direct agent egress? | Select and test host containment, separate users, container controls, NetworkPolicy, or an equivalent boundary. |
+| Which transports expose payload content? | Decide where TLS interception is permitted and document CONNECT passthrough as metadata-only. |
+| Who controls signing and trust keys? | Define creation, storage, rotation, revocation, recovery, and relying-party distribution. |
+| Which identity provider protects the dashboard? | Configure OIDC or mTLS role mapping; reserve raw-evidence permission for a narrower group. |
+| How are Conductor write operations authorized? | Protect deployment PKI and publisher/admin role tokens; dashboard OIDC does not automatically govern Conductor mutation APIs. |
+| Where is evidence stored and for how long? | Set retention, legal hold, storage encryption, backup encryption, deletion, and access policy. |
+| Which events must reach the SIEM? | Choose sinks, alert thresholds, queue/drop monitoring, and an outage procedure. |
+| What is the availability target? | Prove replica, storage, failover, restore, and upgrade behavior on the intended platform before committing to an SLO. |
+| What leaves the customer's environment? | Pipelock can run locally; any hosted service or support exchange needs its own approved data-flow and privacy terms. |
+
+## Current Boundaries
+
+These are explicit boundaries, not hidden footnotes:
+
+- Complete mediation is a deployment property. Installing the binary beside an
+  unrestricted process does not block that process from opening another socket.
+- The dashboard supports OIDC, but Conductor's mutating operator APIs currently
+  use deployment mTLS plus file-backed role tokens rather than SCIM-managed
+  workforce identity.
+- Local Conductor and fleet-sink evidence uses filesystem and SQLite storage.
+  Pipelock does not provide universal application-layer encryption at rest; use
+  encrypted volumes, restricted service identities, and protected backups.
+- Retention controls prune the configured store. Organization-wide retention,
+  deletion, litigation hold, and privacy policy remain operator responsibilities.
+- The repository does not promise multi-region high availability, a fleet-size
+  ceiling, RTO, RPO, or support response outside a separate proved deployment
+  and commercial commitment.
+- Signed receipts prove integrity and signer binding for supplied records, not
+  completeness against the key holder or traffic outside the mediated boundary.
+
+## Review Material
+
+- [Security assurance case](security-assurance.md)
+- [Product and Conductor threat model](security/agent-firewall-conductor-threat-model.md)
+- [Evidence hard limits](evidence/hard-limits.md)
+- [Current unsupported paths](security/current-unsupported-paths.md)
+- [Vulnerability policy](../SECURITY.md)
+- [Tier-gating audit matrix](security/tier-gating-audit-matrix.md)
+- [Compliance mappings](compliance/)
+
+Security questionnaires should cite the shipped control and its verification
+path, then mark deployment-dependent controls as deployment-dependent. Claims
+about certification, support, pricing, legal terms, data processing, fleet
+scale, or availability require separate owner-approved evidence.

--- a/docs/enterprise-sale-gap-checklist.md
+++ b/docs/enterprise-sale-gap-checklist.md
@@ -3,37 +3,7 @@ Copyright 2026 Josh Waldrep
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Enterprise Sale Gap Checklist
+# Enterprise Readiness
 
-This is a technical readiness checklist for an Enterprise buyer conversation.
-It is not a contract, price sheet, or legal commitment.
-
-## Technical Artifacts
-
-| Artifact | Status | Owner action |
-|---|---|---|
-| Product threat model | Drafted in `docs/security/agent-firewall-conductor-threat-model.md` | Review for buyer-specific claims before sharing. |
-| Offline-verifiable evidence explainer | Drafted in `docs/security/demonstration-over-attestation.md` | Pair with a live verifier demo. |
-| Vulnerability disclosure policy | Present in `SECURITY.md` | Owner should confirm SLA language is acceptable for public commitments. |
-| Conductor production runbook | Present in `docs/guides/conductor-production-runbook.md` | Run against the buyer topology before calling it proven. |
-| Backup/restore runbook | Present in `docs/guides/conductor-backup-restore.md` | Run on the target storage class before quoting an RTO/RPO. |
-| Tier-gating audit matrix | Present in `docs/security/tier-gating-audit-matrix.md` | Keep current when new paid surfaces ship. |
-
-## DRAFT-FOR-OWNER Business Items
-
-| Item | Draft stance | Owner decision needed |
-|---|---|---|
-| Support tiers | DRAFT: define named tiers with response targets, channels, and escalation path. | Pick actual tier names and staffing coverage. |
-| SLA targets | DRAFT: do not promise uptime or response windows beyond `SECURITY.md` without operational capacity. | Legal/business approval. |
-| License terms | DRAFT: point to the applicable commercial agreement; do not encode legal terms in docs. | Counsel-approved contract. |
-| Pricing | DRAFT: custom Enterprise pricing, not committed in repo docs. | Owner-approved quote process. |
-| Security questionnaire | DRAFT: answer from shipped controls and evidence only; mark deployment-dependent controls as deployment-dependent. | Buyer-specific review. |
-| Data processing | DRAFT: Pipelock can run locally; any hosted/support data flow needs a separate data-processing statement. | Counsel/privacy review. |
-
-## Do Not Promise Without Proof
-
-- Fleet scale above the latest load proof.
-- RTO/RPO before running restore on the buyer's storage class.
-- Complete egress mediation unless the deployment blocks direct egress around
-  Pipelock.
-- Legal, compliance, or pricing commitments not approved by the owner.
+This checklist has moved to the maintained
+[Enterprise Readiness](enterprise-readiness.md) guide.

--- a/docs/guides/conductor-production-runbook.md
+++ b/docs/guides/conductor-production-runbook.md
@@ -304,7 +304,7 @@ authenticates with its client cert, whose SPIFFE URI SAN is its fleet identity
 (`org`/`fleet`/`instance`/`environment`). Enrollment is **token-gated**: the
 follower registers its audit-batch public key with the Conductor by presenting a
 single-use enrollment token whose scope must match its certificate identity.
-Mint the token first ([step 9](#9-mint-enrollment-tokens)), then deliver it to
+Mint the token first ([step 11](#11-mint-enrollment-tokens)), then deliver it to
 the follower one of two ways:
 
 - **Auto-enroll on startup (recommended).** Point `conductor.enrollment_token_path`
@@ -317,7 +317,7 @@ the follower one of two ways:
   local marker write fails, the next restart may retry the already-consumed
   token and log a warning; enforcement still continues.
 - **One-shot operator command.** Run `pipelock conductor enroll` (see
-  [step 9](#9-mint-enrollment-tokens)) with the token, the follower's audit key,
+  [step 11](#11-mint-enrollment-tokens)) with the token, the follower's audit key,
   and the follower's mTLS material. Use this when the follower is provisioned out
   of band.
 

--- a/docs/guides/detection-integration.md
+++ b/docs/guides/detection-integration.md
@@ -49,12 +49,16 @@ feed that detector.
 ## The primitive: signed action receipts
 
 When `flight_recorder.signing_key_path` is set in the Pipelock
-config, every proxy decision produces a signed action receipt.
-Receipts are Ed25519-signed, JSON-structured, and linked into a
-SHA-256 hash chain so any deletion or reordering is detectable
-after the fact. Without a signing key configured, Pipelock still
-enforces, and the flight recorder can still write other evidence
-entries, but the signed receipt stream is not produced.
+config, enforcement blocks produce signed action receipts. Allow
+receipts are emitted when `flight_recorder.require_receipts: true`;
+clean streaming frames are summarized rather than individually
+receipted. Receipts are Ed25519-signed, JSON-structured, and linked
+into a SHA-256 hash chain so deletion or reordering within an observed
+chain is detectable after the fact. This proves tamper evidence, not
+that every mediated action was recorded. Without a signing key
+configured, Pipelock still enforces, and the flight recorder can still
+write other evidence entries, but the signed receipt stream is not
+produced.
 
 Generate a key with `pipelock keygen <name>`, set
 `flight_recorder.signing_key_path`, and start or restart Pipelock.
@@ -118,11 +122,12 @@ stream in different wrappers.
 
 When a SIEM rule fires or an agent's session looks suspicious, an
 analyst can pull the full receipt stream for that `session_id` and
-reconstruct every decision in order. The hash chain confirms the
-stream has not been edited since it was written. The `policy_hash`
-confirms which policy version was in force. The `signature`
-confirms the record came from Pipelock and not from a tampered
-agent log.
+reconstruct the recorded decisions in order. The hash chain confirms
+the observed stream has not been edited since it was written. It
+cannot prove that a missing action was never attempted. The
+`policy_hash` confirms which policy version was in force. A signature
+verified against a separately pinned key confirms the record came
+from the expected Pipelock signer rather than a tampered agent log.
 
 This is the audit-trail use case. Receipts are designed to be
 presentable to a third party (auditor, incident responder, internal

--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -1,6 +1,14 @@
 # Flight Recorder Guide
 
-The flight recorder writes every enforcement decision pipelock makes to a hash-chained, tamper-evident evidence log. Each entry is cryptographically linked to the one before it, so any deletion or modification breaks the chain. Signed checkpoints let auditors verify the chain was intact at specific points in time without replaying every entry. The recorder is designed for post-incident investigation, compliance evidence, and forensic replay.
+The flight recorder writes configured enforcement evidence to a hash-chained,
+tamper-evident log. Blocks produce receipts; allow receipts require
+`flight_recorder.require_receipts: true`, and clean stream frames are summarized
+rather than individually receipted. Each recorded entry is cryptographically
+linked to the one before it, so deletion or modification within an observed
+chain breaks verification. Signed checkpoints prove the chain state observed at
+specific points; they do not prove that traffic which bypassed Pipelock was
+recorded. The recorder is designed for post-incident investigation, compliance
+evidence, and forensic replay.
 
 **On by default.** `enabled` defaults to `true` so receipts are available out of the box ("verify the boundary"). It only *records* once a `dir` and a signing key are configured, though: without them the recorder is inert and writes nothing, so the default flip never breaks an existing config. `pipelock init` generates a recorder directory and an Ed25519 signing key and writes them into the config, which is what makes receipts live. Receipt emission is best-effort by default; set `require_receipts: true` when allow-path receipt failures must fail closed before traffic is forwarded.
 

--- a/docs/guides/openclaw.md
+++ b/docs/guides/openclaw.md
@@ -65,7 +65,11 @@ pipelock generate mcporter -i servers.json --in-place --backup
 └─────────────────────────────────────────────────────────┘
 ```
 
-In an enforced deployment, the agent has secrets but no direct network access. Pipelock has no agent secrets but full network access. Deployment controls such as Docker networking, host containment, firewall rules, or K8s NetworkPolicy enforce this boundary. This capability separation prevents a compromised agent from exfiltrating secrets directly.
+In an enforced deployment, the agent has secrets but no direct network access.
+Pipelock has no agent secrets and provides policy-controlled network egress.
+Deployment controls such as Docker networking, host containment, firewall
+rules, or K8s NetworkPolicy enforce this boundary. This capability separation
+prevents a compromised agent from exfiltrating secrets directly.
 
 ## Two Protection Layers
 
@@ -84,7 +88,7 @@ Wraps the OpenClaw gateway connection with bidirectional scanning:
 
 When the agent makes outbound HTTP requests through pipelock's fetch proxy:
 
-- 11-layer URL scanning (CRLF, path traversal, blocklist, DLP, SSRF, rate limiting, entropy checks)
+- Ordered URL scanning (CRLF, path traversal, destination policy, DLP, SSRF, rate limiting, entropy checks)
 - Response injection detection on fetched content
 - Data budget tracking per domain
 
@@ -269,7 +273,7 @@ Mapped to the CVE-2026-25253 attack chain:
 | Data exfiltration via tool args | Input scanning catches secrets in outbound calls | MCP proxy |
 | Prompt injection in tool results | Response scanning detects injection attempts | MCP proxy |
 | Read-then-exfil tool sequences | Chain detection catches multi-step patterns | MCP proxy |
-| Outbound HTTP exfiltration | 11-layer URL scanning, DLP on request URLs | HTTP proxy |
+| Outbound HTTP exfiltration | Ordered URL scanning, DLP on request URLs | HTTP proxy |
 
 Pipelock does not patch the CVE itself (that requires OpenClaw origin validation). It adds defense-in-depth by scanning the mediated traffic between agent and gateway, catching exploitation attempts at multiple points in the attack chain.
 

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -427,9 +427,10 @@ jobs.
 
 ## Language-portable verifier packages
 
-Pipelock v2.5.0 publishes first-party verifier libraries for three runtimes,
-all of which validate the same canonical conformance vectors used by the
-Go reference verifier. Pick whichever fits your downstream audit pipeline:
+Pipelock provides four independent cross-language verifier implementations
+(Go, TypeScript, Rust, and Python) that run against the shared conformance
+corpus. A browser wasm surface reuses the Go verifier implementation. Pick the
+surface that fits your downstream audit pipeline:
 
 | Runtime | Path | Use case |
 |---|---|---|
@@ -437,6 +438,7 @@ Go reference verifier. Pick whichever fits your downstream audit pipeline:
 | TypeScript | [`sdk/verifiers/ts/`](../../sdk/verifiers/ts/) | Node-based audit / SIEM, browser-side evidence inspection |
 | Rust | [`sdk/verifiers/rust/`](../../sdk/verifiers/rust/) | Embedded use, audit-platform sidecars, no-runtime environments |
 | Python (companion) | [`pipelock-verify-python`](https://github.com/luckyPipewrench/pipelock-verify-python) | Python-based audit pipelines and Jupyter analysis. v1 chains today; EvidenceReceipt v2 envelopes after the prepared 0.2.0 release. |
+| Browser wasm (Go implementation) | `cmd/pipelock-verifier-wasm/` | In-browser receipt and chain verification without treating wasm as an independent fifth implementation |
 
 The TypeScript and Rust verifiers ship with their own test suites that
 exercise the canonical vectors from the Go schema package, so a schema

--- a/docs/guides/siem-integration.md
+++ b/docs/guides/siem-integration.md
@@ -527,15 +527,19 @@ curl http://pipelock:9090/api/v1/killswitch/status \
   "sources": {
     "config": false,
     "api": true,
+    "conductor_remote": false,
+    "conductor_stale": false,
     "signal": false,
     "sentinel": false
   }
 }
 ```
 
-The kill switch uses OR logic across four independent sources (config, API,
-SIGUSR1 signal, sentinel file). If *any* source is active, all traffic is
-denied. Deactivating one doesn't affect the others.
+The kill switch uses OR logic across six independent sources (config, API,
+Conductor remote kill, Conductor stale-bundle detection, SIGUSR1 signal, and
+sentinel file). If *any* source is active, all traffic is denied. Deactivating
+one doesn't affect the others. The Conductor sources remain false when the
+enterprise follower is not in use.
 
 **Rate limiting:** `POST /api/v1/killswitch` is limited to 10 requests per
 60-second window. Exceeding it returns `429` with a `Retry-After: 60` header.

--- a/docs/guides/transport-modes.md
+++ b/docs/guides/transport-modes.md
@@ -22,12 +22,12 @@ Pipelock supports multiple proxy modes, each with different scanning capabilitie
 The highest-protection mode. Designed for AI agents that need web content.
 
 **Scanning:**
-- 11-layer URL scan (scheme, CRLF injection, path traversal, blocklist, DLP, path entropy, subdomain entropy, SSRF, rate limit, URL length, data budget)
+- Ordered URL scan (length/parsing, scheme, CRLF injection, path traversal, destination policy, immutable SSRF/DLP floors, configured DLP, entropy, DNS SSRF/rebinding, rate limit, data budget, and context checks)
 - `request_policy` route and operation checks, including followed redirect hops
 - Raw HTML scan for injection in hidden elements (script, style, comments, hidden divs)
 - Readability text extraction (strips HTML, returns clean text)
 - Response injection detection on extracted content
-- Redirect chain: each hop scanned through all 11 layers
+- Redirect chain: each hop traverses the ordered URL scanner pipeline
 
 **What the agent receives:** Extracted text content, not raw HTML. Hidden injection is detected even though the agent never sees it.
 
@@ -42,12 +42,12 @@ curl "http://localhost:8888/fetch?url=https://example.com"
 Standard HTTP CONNECT proxy. Without TLS interception, pipelock cannot see the encrypted traffic after the tunnel is established.
 
 **Scanning (without TLS interception):**
-- 11-layer URL scan on the target hostname (before tunnel)
+- Ordered URL scan on the target hostname (before tunnel)
 - No content inspection during the tunnel (encrypted bytes)
 - No response scanning
 
 **Scanning (with `tls_interception.enabled: true`):**
-- 11-layer URL scan on the target hostname (before tunnel)
+- Ordered URL scan on the target hostname (before tunnel)
 - Full request body DLP (JSON, form, multipart extraction)
 - Request header DLP scanning
 - Authority enforcement (Host must match CONNECT target)
@@ -74,7 +74,7 @@ HTTPS_PROXY=http://localhost:8888 curl --cacert ~/.pipelock/ca.pem https://examp
 Handles plaintext HTTP requests where the client sends the full URL as the request target.
 
 **Scanning:**
-- 11-layer URL scan on the full URL
+- Ordered URL scan on the full URL
 - `request_policy` route and operation checks
 - Response injection scanning (buffer-then-scan-then-send, fail-closed on compressed responses)
 - Response body buffered (up to MaxResponseMB), scanned for injection, then forwarded; oversized buffered responses are blocked fail-closed
@@ -93,7 +93,7 @@ HTTP_PROXY=http://localhost:8888 curl http://example.com
 Bidirectional WebSocket proxy with frame-level scanning.
 
 **Scanning:**
-- 11-layer URL scan on the target URL
+- Ordered URL scan on the target URL
 - `request_policy` route-only checks on the upgrade and per-frame operation checks on reassembled text frames
 - DLP scanning on WebSocket upgrade request headers
 - Bidirectional frame scanning (both client-to-server and server-to-client)
@@ -213,7 +213,7 @@ With TLS interception enabled, pipelock performs a TLS MITM: it terminates TLS w
 **Without interception:**
 - DLP cannot detect secrets in HTTPS request/response bodies
 - Response injection scanning does not apply
-- Only the 11-layer URL scan provides protection
+- Only destination-visible URL scanning applies; encrypted request and response content remains opaque
 
 **With interception:**
 - Full request body DLP (JSON, form, multipart)
@@ -227,7 +227,7 @@ If your agent handles secrets and you need content-level DLP on HTTPS traffic, e
 
 | Concern | Fetch Proxy | CONNECT (no interception) | CONNECT (TLS interception) |
 |---------|-------------|---------------------------|---------------------------|
-| URL scanning | 11 layers | 11 layers | 11 layers |
+| URL scanning | Ordered pipeline | Ordered pipeline | Ordered pipeline |
 | DLP on request bodies | N/A | No (encrypted) | Yes |
 | DLP on responses | Yes | No (encrypted) | Yes |
 | Injection detection | Yes | No (encrypted) | Yes |

--- a/docs/owasp-agentic-top15-mapping.md
+++ b/docs/owasp-agentic-top15-mapping.md
@@ -48,7 +48,7 @@ This is separate from the [OWASP Top 10 for Agentic Applications](owasp-mapping.
 
 **Pipelock coverage:**
 
-- **Fetch proxy as controlled tool:** the agent's only network access is through the proxy. Every request goes through the 11-layer scanner pipeline.
+- **Fetch proxy as controlled tool:** in an enforced deployment, the agent's network access is routed through the proxy. Each mediated fetch traverses the ordered URL scanner pipeline.
 - **MCP proxy:** `pipelock mcp proxy` wraps MCP servers and scans tool responses for injection payloads.
 - **Tool description scanning:** `tools/list` responses are scanned for poisoned descriptions containing hidden instructions, file exfiltration directives, or cross-tool manipulation. Rug-pull detection tracks SHA256 hashes per session and alerts on mid-session changes.
 - **HITL approvals:** suspicious requests can trigger human-in-the-loop terminal approval before proceeding.
@@ -82,7 +82,9 @@ This is separate from the [OWASP Top 10 for Agentic Applications](owasp-mapping.
 - **DLP scanning:** catches API keys, tokens, and credentials in outbound URLs regardless of why the agent is sending them.
 - **Entropy analysis:** flags high-entropy URL segments that look like encoded secrets, even if they don't match known patterns.
 - **Domain blocklist:** known exfiltration targets (pastebin, transfer.sh, etc.) are blocked.
-- **Audit logging:** every request is logged with zerolog, creating a verifiable trail of all agent network activity.
+- **Audit and receipt evidence:** mediated scanner and policy events are logged
+  with zerolog. Signed receipts provide tamper evidence for recorded actions;
+  they do not prove completeness for traffic that bypasses Pipelock.
 
 **Coverage: Strong.** DLP + entropy + blocklist catches most exfiltration attempts. Audit trail enables post-incident analysis.
 

--- a/docs/owasp-mapping.md
+++ b/docs/owasp-mapping.md
@@ -148,7 +148,7 @@ Use `pipelock generate config --preset balanced` for the complete default patter
 - **Per-domain rate limiting:** sliding window rate limiter prevents bulk requests from one agent overwhelming external services.
 - **Response size limits:** `max_response_mb` caps the size of fetched content, preventing memory exhaustion.
 - **Request timeouts:** configurable per-request timeout prevents hanging connections that block agent pipelines.
-- **Structured logging:** every request is logged with zerolog, enabling rapid diagnosis of failure chains across agents.
+- **Structured logging:** mediated scanner and policy events are logged with zerolog, supporting diagnosis of observed failure chains across agents.
 
 **Gap:** No circuit-breaker pattern or agent-level health checks yet.
 
@@ -161,7 +161,9 @@ Use `pipelock generate config --preset balanced` for the complete default patter
 **Pipelock coverage:**
 
 - **HITL terminal approval:** `action: ask` prompts the human operator with a terminal y/N/s dialog when suspicious content is detected. The human can approve, deny, or strip before the request proceeds.
-- **Audit logging:** every request and scanner detection is logged, giving humans a verifiable record to review.
+- **Audit and receipt evidence:** mediated scanner and policy events are logged.
+  Signed receipts add tamper evidence for recorded enforcement actions, but do
+  not prove that bypassed traffic or every allowed stream frame was captured.
 - **Prometheus metrics:** `/metrics` and `/stats` endpoints surface block rates, scanner hits, and top domains for human oversight dashboards.
 
 **Gap:** No user-facing UI for non-terminal environments. HITL is terminal-only.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,6 +1,9 @@
 # Performance
 
-Pipelock adds microseconds of overhead per request. The proxy is I/O bound (waiting for upstream responses), not CPU bound. For the request-side URL scanning hot path, CPU is never the bottleneck. Response scanning and MCP scanning on large payloads can use measurable CPU at high throughput (see tables below).
+Pipelock's request-side URL scanner adds microseconds of overhead in the
+benchmarks below. The proxy is generally I/O bound while waiting for upstream
+responses. Response scanning and MCP scanning on large payloads can use
+measurable CPU at high throughput (see tables below).
 
 All numbers from Go benchmarks on AMD Ryzen 7 7800X3D (8 cores / 16 threads) / Go 1.25 / Linux. Run `make bench` to reproduce on your hardware. See [benchmarks.md](benchmarks.md) for raw ns/op data.
 
@@ -8,7 +11,10 @@ All numbers from Go benchmarks on AMD Ryzen 7 7800X3D (8 cores / 16 threads) / G
 
 ### URL Scanning (fetch/forward proxy hot path)
 
-11-layer pipeline: scheme, CRLF injection, path traversal, blocklist, DLP, path entropy, subdomain entropy, SSRF, rate limit, URL length, data budget.
+Ordered URL pipeline: length and parsing checks, scheme, CRLF injection, path
+traversal, allowlist/blocklist policy, immutable SSRF and DLP floors, configured
+DLP, path and subdomain entropy, DNS SSRF/rebinding, rate limit, data budget,
+and final context checks.
 
 | Operation | Latency | Throughput (1 core) |
 |-----------|---------|--------------------:|
@@ -31,7 +37,8 @@ JSON-RPC parsing + text extraction + prompt injection pattern matching.
 
 ### Response Scanning (fetched content injection detection)
 
-Pattern matching against 25 prompt injection patterns (including 6 state/control patterns and 4 CJK-language patterns) on fetched page content.
+Pattern matching against 32 prompt-injection and state/control patterns on
+fetched page content.
 
 | Operation | Latency | Throughput (1 core) |
 |-----------|---------|--------------------:|

--- a/docs/receipts/versioning.md
+++ b/docs/receipts/versioning.md
@@ -42,9 +42,12 @@ ignored sidecar field lets a downstream consumer trust content the signature nev
 Duplicate object keys (at any depth) and trailing tokens after the receipt are rejected for
 the same parser-differential reasons.
 
-All five reference verifiers — Go (`internal/receipt`), Rust, TypeScript, Python, and the
-in-browser wasm verifier — enforce this identically, and the cross-language conformance gate
-(`sdk/conformance/corpus-gate.sh`) fails if any of them disagree on accept/reject.
+The four independent reference implementations — Go (`internal/receipt`), Rust,
+TypeScript, and Python — enforce this identically. The cross-language
+conformance gate (`sdk/conformance/corpus-gate.sh`) fails if they disagree on
+accept/reject. The in-browser wasm surface compiles the Go implementation, so it
+inherits the Go parser rather than counting as a fifth independent
+implementation.
 
 #### The `ext` forward-compat bag
 
@@ -119,10 +122,11 @@ require a bump:
 Adding a NEW field to a signed object (`action_record` or any nested signed object) is a
 **coordinated schema change**, not a silently-tolerated addition: because verifiers reject
 unknown fields (see "Strict unknown-field contract" above), a new signed field must be added
-to all five reference verifiers' schemas in lockstep, and it enters the canonical signing
-projection. Purely advisory, non-authoritative metadata that must NOT be signed goes in the
-top-level `ext` bag instead and needs no verifier change. Removing or renaming existing
-required fields requires a version bump.
+to all four independent reference implementations in lockstep, and it enters
+the canonical signing projection. The wasm surface follows the Go schema when
+rebuilt. Purely advisory, non-authoritative metadata that must NOT be signed
+goes in the top-level `ext` bag instead and needs no verifier change. Removing
+or renaming existing required fields requires a version bump.
 
 ### AARP assurance envelope
 

--- a/docs/reproducible-builds.md
+++ b/docs/reproducible-builds.md
@@ -1,0 +1,46 @@
+# Reproducible Builds
+
+Pipelock tests that the open-source `pipelock` binary builds byte-for-byte
+identically when the source tree, dependencies, Go toolchain, target, and build
+metadata are held constant.
+
+Run the check from the repository root:
+
+```bash
+make reproducible-build-check
+```
+
+The check builds `./cmd/pipelock` twice in separate output paths and compares
+the resulting files with `cmp`. It uses:
+
+- `CGO_ENABLED=0`;
+- `-trimpath` to remove local source paths;
+- `-buildvcs=false` to avoid embedding checkout-specific VCS metadata;
+- the current commit timestamp instead of the wall clock;
+- fixed version, commit, and Go-version linker values.
+
+Success prints the shared SHA-256 digest:
+
+```text
+reproducible-build: OK sha256:<digest>
+```
+
+CI runs this check on pull requests, and the release workflow runs it again
+before GoReleaser publishes artifacts. GoReleaser uses the same stable build
+inputs and normalizes archive member timestamps to the source commit time.
+Release CI pins the Go toolchain version.
+
+## Scope
+
+This check proves repeatability for the open-source `pipelock` binary on the
+current CI target. Reproducing an official release artifact also requires the
+same tagged source, dependency graph, Go version, target OS and architecture,
+build tags, and public linker inputs. Signatures and attestations are separate
+artifacts and are not expected to have identical bytes.
+
+The Enterprise build embeds deployment-independent public verification keys
+provided by release CI. Reproducing that binary requires the same public linker
+inputs; private signing material is never embedded in the binary.
+
+See [`scripts/check-reproducible-build.sh`](../scripts/check-reproducible-build.sh)
+and [`.goreleaser.yaml`](../.goreleaser.yaml) for the executable build contract.

--- a/docs/scan-api.md
+++ b/docs/scan-api.md
@@ -48,7 +48,7 @@ Returns `401` if missing or invalid.
 
 | Kind | What it scans | Required input field |
 |------|--------------|---------------------|
-| `url` | Full 11-layer URL scanner pipeline | `input.url` (valid http/https URL) |
+| `url` | Full ordered URL scanner pipeline | `input.url` (valid http/https URL) |
 | `dlp` | DLP pattern matching on arbitrary text | `input.text` |
 | `prompt_injection` | Prompt injection detection on content | `input.content` |
 | `tool_call` | Tool policy + DLP/injection on a tool invocation | `input.tool_name` (required), `input.arguments` (optional raw JSON) |

--- a/docs/security-assurance.md
+++ b/docs/security-assurance.md
@@ -1,122 +1,272 @@
 # Security Assurance Case
 
-This document describes Pipelock's security model, trust boundaries, threat coverage, and known limitations. It serves as the project's assurance case: a structured argument that security requirements are met.
+**Status:** Living assurance case. Unless a section names a release, its claims
+apply to the repository revision that contains this file. Release support and
+security-fix eligibility remain defined by [SECURITY.md](../SECURITY.md).
 
-## Threat Model
+This assurance case states what Pipelock is intended to protect, which trust
+boundaries must exist for those protections to hold, what evidence the product
+can produce, and what that evidence cannot prove. It is a product security
+argument, not a certification and not a claim that every deployment is secure.
 
-Pipelock protects against AI agents being tricked into harmful actions. The primary threats are:
+The reporting policy, supported release line, and severity framework are in
+[SECURITY.md](../SECURITY.md). Known unmediated paths are maintained separately
+in [current unsupported paths](security/current-unsupported-paths.md).
 
-1. **Credential exfiltration:** Agent leaks API keys, tokens, or secrets through HTTP requests, DNS queries, URL parameters, or MCP tool arguments.
-2. **Prompt injection:** Attacker-controlled text in web pages or tool results redirects the agent's behavior.
-3. **Tool misuse:** Agent executes destructive commands (file deletion, force-push, reverse shells) due to injection or misconfiguration.
-4. **Tool poisoning:** MCP server descriptions contain hidden instructions or change definitions mid-session to manipulate agent behavior.
-5. **Data exfiltration:** Agent sends sensitive workspace data to external endpoints through legitimate-looking requests.
+## Security Objectives
 
-These map to the [OWASP Top 10 for Agentic Applications](owasp-mapping.md) and are tested against a full evasion test suite (see [README testing metrics](../README.md#testing)).
+Pipelock is designed to reduce these risks at agent communication boundaries:
+
+1. **Credential and data exfiltration:** secrets or sensitive workspace data
+   leaving through URLs, headers, bodies, WebSocket frames, MCP arguments, or
+   tool results.
+2. **SSRF and destination abuse:** requests reaching metadata services, private
+   networks, blocked destinations, or rebinding targets through a mediated
+   transport.
+3. **Prompt injection and tool poisoning:** attacker-controlled content or MCP
+   descriptions manipulating an agent across a boundary Pipelock inspects.
+4. **Tool misuse:** dangerous MCP calls reaching a server despite configured
+   tool, argument, chain, integrity, provenance, or session policy.
+5. **Unverifiable enforcement:** operators being unable to show which mediated
+   action Pipelock evaluated, what it decided, and which policy context applied.
+6. **Fleet control-plane compromise:** unsigned, stale, wrongly scoped, or
+   unauthorized policy and emergency messages reaching Enterprise followers.
+
+These objectives map to the [OWASP Top 10 for Agentic Applications](owasp-mapping.md),
+the [OWASP Agentic AI Threats and Mitigations](owasp-agentic-top15-mapping.md),
+and the [NIST SP 800-53 mapping](compliance/nist-800-53.md).
 
 ## Trust Boundaries
 
-Pipelock is designed to be deployed in a capability-separated architecture:
+### 1. Agent to Pipelock
 
 ```text
-+-----------------------+          +------------------------+          +----------+
-|       Agent           |   --->   |     Pipelock Proxy     |   --->   | Internet |
-| (has secrets/API keys |          | (has network access,   |          |          |
-|  no network access)   |          |  no agent secrets)     |          |          |
-+-----------------------+          +------------------------+          +----------+
++----------------------+      +----------------------+      +------------------+
+| Agent environment    |      | Pipelock boundary    |      | External systems |
+| secrets + workspace  | ---> | network + tool       | ---> | APIs, MCP, A2A   |
+| no direct egress     |      | policy, no secrets   |      | and web content  |
++----------------------+      +----------------------+      +------------------+
+        deployment                 binary-enforced                untrusted
+        enforcement                mediated paths
 ```
 
-**Trust boundary 1: Agent → Proxy.** In an enforced deployment, outbound agent HTTP traffic is routed through the fetch, forward, reverse, WebSocket, sidecar, or sandbox proxy path. The agent cannot reach the network directly because container networking, host containment, firewall rules, NetworkPolicy, or OS-level restrictions enforce that boundary.
+Pipelock enforces decisions only for traffic that reaches a Pipelock proxy,
+wrapper, listener, hook, or containment path. The deployment must prevent the
+agent from opening an unmediated route around that boundary. Host containment,
+separate users or processes, container networking, Kubernetes NetworkPolicy,
+firewall rules, or an equivalent control provide that no-bypass property.
 
-**Trust boundary 2: MCP Client → MCP Server.** The MCP proxy sits between the agent and any MCP server that is launched through `pipelock mcp proxy` or reached through a Pipelock MCP listener. Client requests are checked for DLP leaks and injection. Server responses are checked for prompt injection and poisoned tool descriptions.
+Pipelock reads configured local values for leak detection, but the proxy is not
+intended to hold the agent's provider credentials. A deployment that gives the
+proxy the same broad secret and workspace access as the agent weakens capability
+separation.
 
-**Trust boundary 3: Tool call → Execution.** The tool call policy engine evaluates MCP `tools/call` requests against configurable rules before they reach the server. Destructive operations can be blocked regardless of how the agent was tricked into requesting them.
+### 2. MCP Client to MCP Server
 
-## Security Controls
+`pipelock mcp proxy` and Pipelock MCP listeners mediate the JSON-RPC path.
+Requests can be checked for input injection, DLP, tool policy, tool chains,
+binary integrity, provenance, session binding, contracts, media policy, and
+taint. Responses and tool descriptions can be checked before the client
+consumes them. An MCP server launched or contacted outside these paths is not
+covered merely because Pipelock is installed.
 
-### Defense in Depth
+### 3. Tool Call to Execution
 
-No single control is assumed to be sufficient. The scanner pipeline applies 11 layers:
+MCP `tools/call` policy runs before a mediated request reaches the MCP server.
+It scopes which tools and argument shapes may run. It does not mint a separate
+credential for every action, prove the model's intent, or control a tool invoked
+through an unwrapped local path.
 
-| Layer | Protects Against |
-|-------|-----------------|
-| Scheme enforcement | Non-HTTP protocol abuse |
-| CRLF injection detection | HTTP header injection via encoded CR/LF |
-| Path traversal detection | Directory escape attempts via encoded dot-dot sequences |
-| Domain blocklist/allowlist | Known-bad destinations, scope control |
-| DLP pattern matching | Credential leakage (65 patterns, encoding-aware) |
-| Path entropy analysis | Exfiltration via high-entropy URL segments |
-| Subdomain entropy analysis | DNS-based exfiltration |
-| SSRF protection | Private network access, DNS rebinding |
-| Rate limiting | Slow-drip exfiltration |
-| URL length limits | Oversized exfiltration payloads |
-| Data budgets | Per-domain byte limits |
+### 4. Operator and Configuration to Runtime
 
-Response scanning adds prompt injection detection on fetched content. MCP scanning adds bidirectional inspection of tool calls and results.
+Configuration, trusted keys, signing keys, exemptions, suppression rules, and
+deployment topology are security inputs. A permissive operator can intentionally
+reduce coverage. `pipelock check`, `pipelock doctor`, `pipelock audit score`,
+`pipelock contain verify`, and `pipelock assess` expose different parts of the
+configured-versus-enforceable state; none can prove that an unseen bypass does
+not exist.
 
-### Fail-Closed Design
+### 5. Follower to Enterprise Conductor
 
-All ambiguous states default to blocking:
+Conductor followers enforce locally and do not send agent credentials to the
+control plane. Deployment-provided mTLS identifies followers; signed,
+audience-bound messages carry policy, rollback, and emergency state. The
+Conductor boundary includes its deployment PKI, role tokens, signing-key roster,
+storage, retention policy, and backup process. See the
+[Conductor threat model](security/agent-firewall-conductor-threat-model.md) and
+[production runbook](guides/conductor-production-runbook.md).
 
-- HITL timeout → block
-- Non-terminal input → block
-- JSON parse errors → block (configurable)
-- Context cancellation → block
-- Unknown policy actions → treated as block
+### 6. Evidence Producer to Verifier
 
-### Evasion Resistance
+The process holding an evidence signing key is a trusted producer. A verifier
+must pin the expected public key or a trusted roster. Signature validity proves
+that the key holder signed the verified bytes; it does not prove that the key
+holder was honest, that no record was omitted, or that no unmediated action
+happened.
 
-DLP and injection scanners are tested against encoding chains (base64, hex, multi-layer URL encoding), Unicode confusables (Cyrillic, Greek, Armenian, Cherokee), combining marks, control character insertion, field splitting, and whitespace manipulation. See the test suite for the full evasion catalog.
+## Security Requirements and Evidence
 
-## What Pipelock Does NOT Protect Against
+| Requirement | Product mechanism | Verification and limit |
+|---|---|---|
+| SR-1: Mediate the claimed transport before enforcing it | Fetch, forward, reverse, TLS-intercept, WebSocket, MCP, hook, sandbox, host-containment, and deployment integrations | Transport tests and `doctor`/`contain verify`; direct-egress prevention remains deployment-enforced. |
+| SR-2: Apply non-disableable minimum URL protections | Literal-IP SSRF and core DLP floors run independently of configured policy | Unit, integration, fuzz, and evasion tests; novel encodings and opaque encrypted content remain residual risks. |
+| SR-3: Deny before a blocked mediated action executes | Scanner, request, MCP, contract, kill-switch, and policy gates run before forwarding on their covered paths | Black-box transport and exploit regression tests; observe/off modes intentionally do not enforce. |
+| SR-4: Reject unsafe or ambiguous security state where the feature promises enforcement | Validation, unknown-action rejection, context checks, authenticated listeners, trusted-key pinning, and feature-specific fail-closed paths | Negative tests cover malformed, missing, expired, revoked, and stale inputs; behavior is feature- and mode-specific rather than universally fail-closed. |
+| SR-5: Make recorded mediated decisions tamper-evident | Signed receipts, hash-linked chains, signed checkpoints, and offline verifiers | Verification proves integrity and ordering of supplied records, not completeness outside the observed chain. |
+| SR-6: Keep evidence claims scoped to the identity actually observed | Receipts record mediator-attested actor, principal, delegation, transport, policy, and verdict context | The mediator's signature is not workload non-repudiation; runtime SVID binding is not claimed where only offline appraisal exists. |
+| SR-7: Keep fleet policy and emergency control scoped, authenticated, and recoverable | mTLS follower identity, signed audience-bound messages, monotonic state, rollback, remote kill, key rosters, backup and restore | Conductor tests and operator runbooks; availability and PKI custody remain deployment responsibilities. |
+| SR-8: Make shipped artifacts inspectable and attributable | Reproducible OSS build check, signed releases, provenance, checksums, SBOMs, CodeQL, gosec, dependency and vulnerability scanning | Build provenance covers the released artifact, not the honesty of the running host or operator. |
 
-Honest assessment of limitations:
+## Ordered URL Scanner Pipeline
 
-- **Model-level attacks:** If the model itself is compromised or fine-tuned to be malicious, Pipelock cannot detect this. We operate at the communication boundary, not inside the model.
-- **Novel evasion techniques:** Pattern-based detection catches known techniques. Novel bypasses require scanner updates. We do not claim complete coverage.
-- **Encrypted or steganographic exfiltration:** Data hidden within legitimate-looking content (e.g., encoded in image pixels or timing channels) is beyond pattern-based detection.
-- **Insider threats:** If the agent operator intentionally configures Pipelock to be permissive, the tool respects that configuration.
-- **Attacks that don't cross a boundary:** If an agent and its tools run in the same process with no proxy, Pipelock has nothing to inspect.
-- **Deployment paths that are configured but not consumed:** Pipelock can generate proxy variables, MCP launcher configs, sidecar manifests, and NetworkPolicies, but the agent launcher and cluster CNI must actually consume/enforce them.
+The URL scanner checks maximum length before parsing. After parsing and hostname
+canonicalization, the current order is:
 
-## Compliance Mappings
+1. Scheme restriction to HTTP or HTTPS
+2. CRLF injection
+3. Path traversal
+4. Strict-mode allowlist
+5. Domain blocklist
+6. Core literal-IP SSRF floor, including private and metadata addresses
+7. SigV4 presigned-URL credential carve-out
+8. Core DLP floor
+9. Configured DLP
+10. Path entropy
+11. Subdomain entropy
+12. DNS-based SSRF, private-address, metadata, and rebinding checks
+13. Rate limiting
+14. Data budget
+15. Final context check
 
-Detailed mappings to security frameworks:
+Core and configured DLP run before DNS resolution, so a detected secret can be
+blocked before the proxy performs a destination lookup. Response, body,
+streaming, WebSocket, MCP, A2A, and tool-policy paths add controls appropriate
+to the bytes and semantics each transport exposes.
 
-- [OWASP Top 10 for Agentic Applications](owasp-mapping.md) (coverage of ASI01–ASI10)
-- [OWASP Agentic AI Threats & Mitigations](owasp-agentic-top15-mapping.md) (coverage of T1–T15)
-- [EU AI Act Compliance Mapping](compliance/eu-ai-act-mapping.md) (Articles 9, 12–15, 26 with NIST AI RMF crosswalk)
+## Failure Behavior
 
-## Verification
+"Fail closed" applies to a named enforcement path, not to every Pipelock mode or
+subsystem:
 
-Security claims are verified through four testing layers, static analysis, and supply chain controls.
+- A block verdict on a mediated enforcement path is denied before forwarding.
+- Unknown policy actions, expired context, and security-sensitive validation
+  failures are rejected.
+- HITL timeouts and non-terminal operator input block rather than silently
+  approving the action.
+- Parse-error behavior is configurable on some inspection surfaces and must be
+  reviewed in the deployment configuration.
+- Observe and off modes intentionally allow traffic and must not be represented
+  as enforcement.
+- Receipt emission is best-effort by default. With
+  `flight_recorder.require_receipts`, an allow-path receipt failure blocks before
+  forwarding. Block-path receipts remain best-effort because the action is
+  already denied.
+- A fail-closed evidence or storage setting trades availability for integrity;
+  storage stalls can therefore become a denial-of-service condition.
 
-### Testing Layers
+## Verifiable Evidence
 
-1. **Unit and integration tests:** Full test suite with race detector enabled in CI. See [README testing metrics](../README.md#testing) for current numbers.
-2. **Evasion test suite:** Encoding chains (base64, hex, base32, double-encoding), Unicode confusables (Cyrillic, Greek, Armenian, Cherokee), combining marks, control character insertion, field splitting, and whitespace manipulation tested against all scanner layers.
-3. **Black-box binary tests:** End-to-end tests run against a built binary, exercising the full proxy and scanner pipeline through real HTTP, WebSocket, and MCP requests.
-4. **Private adversarial corpus:** A separate adversarial test suite covers real-world evasion and attack classes against the production binary. This corpus is private for the same reason mature security vendors do not publish every regression: a test suite should improve defense, not double as an attacker playbook.
+Pipelock ships several evidence surfaces with different proof boundaries:
 
-`pipelock doctor` complements the test layers by checking configured-vs-enforceable status for the local deployment. It reports when a protection is enabled in YAML but still needs a readable file, a wrapper proof, TLS visibility, telemetry configuration, or a direct-egress boundary before it can be claimed as enforcing.
+- **ActionReceipt v1:** signed per-action evidence for mediated decisions,
+  including verdict, policy and transport context, actor fields, and hash-chain
+  linkage.
+- **EvidenceReceipt v2:** RFC 8785/JCS-canonicalized typed evidence for contract
+  lifecycle, shadow, drift, and contract-aware proxy decisions.
+- **Flight recorder:** configured evidence storage with chain continuity and
+  signed checkpoints. It records blocks; allow receipts require the configured
+  receipt mode, and clean stream frames may be summarized rather than emitted
+  one by one.
+- **Audit Packet v0:** posture-bundled receipts plus verifier output. Its relying
+  party must pin the expected trust inputs described in the
+  [Audit Packet threat model](security/audit-packet-threat-model.md).
+- **Coverage certificates:** signed summaries over an observed evidence set.
+  They may honestly report `LIMITED`; they do not convert missing mediation into
+  `COMPLETE`.
+- **Anchors:** local or Rekor checkpoints can constrain later deletion or
+  rewriting after an observed anchor. They do not prove whole-session
+  completeness before the first trusted anchor.
 
-The adversarial suite covers:
+Four independent cross-language verifier implementations (Go, TypeScript, Rust,
+and Python) exercise a shared conformance corpus. The browser wasm surface
+reuses the Go implementation and is not counted as an independent fifth
+implementation. Pinned verification is the security claim; unpinned structural
+inspection is explicitly weaker.
 
-- Encoded data exfiltration via DNS subdomains and HTTP parameters
-- Traffic blending with legitimate request profiles
-- Multi-encoding evasion chains (layered encoding, interleaved noise)
-- Scanner layer boundary testing (entropy thresholds, label length limits)
-- Config downgrade and hot-reload state attacks
-- Operator terminal injection (escape sequences, bidirectional overrides)
-- MCP response injection via non-standard result shapes
-- Tool description manipulation and session binding attacks
-- Scan API authentication, rate limiting, and fail-closed behavior
+The complete evidence caveats are cataloged in
+[Evidence Hard Limits](evidence/hard-limits.md). In particular, a key holder can
+omit records or forge records under a compromised key, a modified recorder
+cannot vouch for itself, and receipts cannot prove traffic was unable to bypass
+the mediator.
 
-The suite is updated alongside every release and whenever new evasion classes are discovered. Every confirmed finding becomes a permanent regression test.
+## Key Lifecycle
 
-### Static Analysis and Supply Chain
+Signing and trust material must have an operator-owned lifecycle:
 
-- **Static analysis:** CodeQL (security-and-quality) and golangci-lint with gosec
-- **Dependency monitoring:** Renovate (10-day cooldown for routine updates, security fast-track for vulnerability alerts) plus govulncheck in CI
-- **Signed releases:** Cosign signatures, SLSA provenance attestations, CycloneDX SBOM
-- **Vulnerability disclosure:** Responsible disclosure via [GitHub Security Advisories](https://github.com/luckyPipewrench/pipelock/security/advisories)
+- **Create:** generate purpose-bound keys with restricted file permissions.
+- **Rotate:** introduce new trust before retiring old trust so historical
+  evidence remains verifiable.
+- **Revoke:** distribute signed revocation or roster state and stop accepting the
+  retired key for new artifacts.
+- **Recover:** use the documented root or high-water recovery path rather than
+  weakening verification.
+- **Inspect:** record fingerprints, purposes, provenance, blast radius, and
+  current status in an operator-visible trust inventory.
+
+The [key rotation runbook](security/key-rotation-runbook.md), dashboard Trust &
+Keys view, receipt-verification guide, and Conductor runbooks cover the shipped
+surfaces. Hardware-backed custody and KMS/HSM integration remain deployment
+choices unless a specific integration says otherwise.
+
+## Known Limitations
+
+- Pipelock does not detect a maliciously trained or compromised model merely
+  because it produced a request.
+- Novel parser differentials, encoding chains, semantic evasions, steganography,
+  timing channels, or encrypted exfiltration may require new controls.
+- CONNECT passthrough exposes destination and connection metadata, not the
+  encrypted request or response body. Payload claims require TLS interception
+  or another content-visible path.
+- Same-process or otherwise unwrapped tools and MCP servers are outside the
+  boundary.
+- Agent identity is often configured or mediator-observed. It is not universally
+  certificate-bound workload identity.
+- Local evidence is not an independent witness when the same operator controls
+  the runtime, signing key, and retained records.
+- Pipelock does not encrypt every audit store at rest. Regulated deployments must
+  provide storage encryption, access control, retention, and backup protection.
+- High availability, RTO, RPO, support response, and legal compliance depend on
+  the deployment and commercial agreement; the repository does not promise
+  them without separate proof.
+
+## Verification Program
+
+Security requirements are exercised through:
+
+1. Unit and integration tests, including race-detector CI shards.
+2. Fuzz targets and public evasion tests for malformed and adversarial input.
+3. Black-box binary tests across real HTTP, WebSocket, MCP, and deployment paths.
+4. A private adversarial corpus for regression classes whose full payload set is
+   not published.
+5. Cross-language receipt and Audit Packet conformance vectors.
+6. Static analysis with CodeQL, golangci-lint, and gosec.
+7. Dependency monitoring, `govulncheck`, signed releases, provenance, SBOMs, and
+   reproducible-build checks.
+
+Every confirmed security finding should become a durable regression test. A
+green test run proves the tested invariant at that revision; it does not erase
+the limitations above.
+
+## Review Cadence
+
+This assurance case should receive a human review at least annually and after a
+material change to transport coverage, containment, identity, evidence formats,
+key lifecycle, or the Enterprise control plane. The reviewer should compare the
+claims with non-test call sites, negative tests, current unsupported paths, and
+the shipped release before recording the review.
+
+### Review Record
+
+| Date | Reviewer | Scope and result |
+|---|---|---|
+| 2026-07-17 | Joshua Waldrep, project lead | Reviewed the security objectives, trust boundaries, requirements, evidence claims, and stated limitations against the shipped implementation and approved the assurance case for publication. |

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,6 +4,7 @@ This directory holds policy and threat-model documents that integrators and proc
 
 | Document | Purpose |
 |---|---|
+| [../security-assurance.md](../security-assurance.md) | Current product security objectives, trust boundaries, evidence model, limitations, and review cadence. |
 | [current-unsupported-paths.md](current-unsupported-paths.md) | Egress paths the current binary does not intercept. Integrator action required for each. |
 | [browser-shield-production-readiness.md](browser-shield-production-readiness.md) | Browser Shield boundary, receipt behavior, adaptive signal, and anti-bot non-goals. |
 | [key-rotation-runbook.md](key-rotation-runbook.md) | Operational procedure for rotating Ed25519 signing keys without breaking the live-lock roster. |
@@ -11,6 +12,7 @@ This directory holds policy and threat-model documents that integrators and proc
 | [coordinated-disclosure.md](coordinated-disclosure.md) | Vulnerability disclosure policy, response SLA, embargo handling, and CVE process. |
 | [per-deployment-ca-threat-model.md](per-deployment-ca-threat-model.md) | Threat model for the per-deployment TLS interception CA, including snapshot-restoration and root-compromise blast radius. |
 | [audit-packet-threat-model.md](audit-packet-threat-model.md) | Threat model for the Audit Packet evidence bundle. What a verified packet proves, what it does not prove, and the trust assumptions a relying party should pin before treating a `valid` verdict as provenance. |
+| [../evidence/hard-limits.md](../evidence/hard-limits.md) | Stable identifiers for evidence completeness, keyholder, recorder, containment, metadata, and availability limits. |
 
 These documents describe what the current binary enforces today. Behaviour planned for later versions is tracked in the project roadmap and is out of scope here.
 
@@ -18,4 +20,5 @@ These documents describe what the current binary enforces today. Behaviour plann
 
 - [SECURITY.md](../../SECURITY.md): reporting channel and supported versions
 - [CHARTER.md](../../CHARTER.md): project governance, disclosure SLA source
+- [Enterprise readiness](../enterprise-readiness.md): evaluation path and deployment-owned controls
 - [README.md](../../README.md): supported transports and scanner layers

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -26,7 +26,7 @@ Pipelock follower instances
   -> local enforcement, local recorder, local receipts
   -> signed audit batches
 Conductor audit sink
-  -> verification, DLP scanning, append-only ingest, indexed search
+  -> verification, DLP scanning, durable ingest, bounded metadata query
 ```
 
 Conductor is not a scanner and must not become an inline dependency for enforcement.
@@ -55,24 +55,25 @@ evidence operations, fleet visibility, and auditor workflows.
 - No bearer-only follower-to-Conductor transport.
 - No single online signing key that can silently compromise the whole fleet.
 
-## Hard MVP Gates
+## Original Design Gates and Current Status
 
-No implementation should start until these are accepted as product/security
-requirements:
+This design began with ten proposed gates. The table distinguishes binary
+enforcement from deployment requirements and unshipped integrations; the
+current [Conductor guide](../guides/conductor.md) is authoritative for operator
+behavior.
 
-1. Bundle signing uses KMS/HSM-backed keys and never stores signing private keys
-   on Conductor disk.
-2. Every signed bundle hash is written to an append-only transparency log.
-3. Catastrophic messages require threshold approval and a separate key purpose.
-4. Enrollment is concrete: one-shot token exchange for per-instance mTLS
-   identity and per-instance signing material.
-5. Bundle signed preimages include `org_id`, `fleet_id`, environment, and
-   audience selectors.
-6. Rollback is a first-class signed operation with its own key purpose.
-7. Remote kill switch state is not ordinary bundle state.
-8. License metadata is excluded from policy bundles.
-9. Audit payloads are treated as hostile input even after signature validation.
-10. Follower-to-Conductor transport is mTLS.
+| Original gate | Current status |
+|---|---|
+| KMS/HSM-backed bundle signing, no signing key on Conductor disk | **Deployment requirement, no built-in KMS/HSM provider.** Conductor verifies signed messages and need not hold publisher private keys; custody and signing integration are operator-provided. |
+| Append-only transparency entry for every bundle | **Not a shipped universal guarantee.** Local signed state and audit evidence ship; external transparency integration remains a roadmap choice. |
+| Threshold approval and separate key purposes for catastrophic messages | **Shipped.** Remote kill, rollback, and trust rotation use purpose-bound threshold verification. |
+| One-shot enrollment into per-instance mTLS and audit identity | **Shipped.** Enrollment tokens are single-use and follower identity is derived from verified mTLS. |
+| Audience-bound signed bundle preimages | **Shipped.** Organization, fleet, environment, instance, and label selectors are validated. |
+| First-class signed rollback | **Shipped.** Rollback authorization is purpose-bound, threshold-signed, scoped, and replay-controlled. |
+| Remote kill separate from ordinary bundle state | **Shipped.** Remote kill and stale-policy denial are independent kill-switch sources. |
+| License metadata excluded from policy bundles | **Shipped.** Forbidden local and license fields are rejected before storage/apply. |
+| Audit payloads remain hostile after signature verification | **Shipped.** Ingest performs schema, scope, signature, continuity, and content-safety checks. |
+| Follower-to-Conductor transport uses mTLS | **Shipped.** Deployment PKI remains an operator responsibility. |
 
 ## Trust Model
 
@@ -938,7 +939,11 @@ must be stronger than ordinary follower deployment:
 - pinned dependencies
 - release attestation verified by deployment tooling
 
-## Implementation Phases
+## Historical Implementation Phases
+
+This is the original implementation sequence, retained as design history rather
+than a current feature checklist. The GA guide and production runbook identify
+what ships now.
 
 ### Phase 0: Spec and Schema
 
@@ -1028,11 +1033,7 @@ Required test coverage:
 
 ## Open Decisions
 
-- Transparency log implementation: external Rekor-style service, embedded
-  append-only log, or both.
 - KMS/HSM provider abstraction and minimum supported provider.
-- Exact trust roster file format.
-- Whether local follower receipt signing key is reused for checkpoints or a
-  separate checkpoint key is required.
+- External transparency or WORM integration for fleet policy and evidence.
 - Whether FIPS support is a documented limitation or a near-term build target.
-- WORM storage backend for first enterprise deployment.
+- Supported high-availability storage and failover topology.

--- a/enterprise/budget.go
+++ b/enterprise/budget.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enterprise

--- a/enterprise/budget_test.go
+++ b/enterprise/budget_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enterprise

--- a/enterprise/cli/conductor/audit_query.go
+++ b/enterprise/cli/conductor/audit_query.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/bootstrap.go
+++ b/enterprise/cli/conductor/bootstrap.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/bootstrap_test.go
+++ b/enterprise/cli/conductor/bootstrap_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/client.go
+++ b/enterprise/cli/conductor/client.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/client_test.go
+++ b/enterprise/cli/conductor/client_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/cmd.go
+++ b/enterprise/cli/conductor/cmd.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/cmd_test.go
+++ b/enterprise/cli/conductor/cmd_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/degenerate_key_test.go
+++ b/enterprise/cli/conductor/degenerate_key_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/dryrun_replay_cli_test.go
+++ b/enterprise/cli/conductor/dryrun_replay_cli_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/emergency_common.go
+++ b/enterprise/cli/conductor/emergency_common.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/emergency_common_test.go
+++ b/enterprise/cli/conductor/emergency_common_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/enroll.go
+++ b/enterprise/cli/conductor/enroll.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/enroll_keyload_test.go
+++ b/enterprise/cli/conductor/enroll_keyload_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/enroll_test.go
+++ b/enterprise/cli/conductor/enroll_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/enrollment_token.go
+++ b/enterprise/cli/conductor/enrollment_token.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/enrollment_token_lifecycle_test.go
+++ b/enterprise/cli/conductor/enrollment_token_lifecycle_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/enrollment_token_test.go
+++ b/enterprise/cli/conductor/enrollment_token_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/fleet_report.go
+++ b/enterprise/cli/conductor/fleet_report.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/fleet_report_test.go
+++ b/enterprise/cli/conductor/fleet_report_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/fleet_status.go
+++ b/enterprise/cli/conductor/fleet_status.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/follower.go
+++ b/enterprise/cli/conductor/follower.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/follower_test.go
+++ b/enterprise/cli/conductor/follower_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/kill.go
+++ b/enterprise/cli/conductor/kill.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/kill_status.go
+++ b/enterprise/cli/conductor/kill_status.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/kill_status_test.go
+++ b/enterprise/cli/conductor/kill_status_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/kill_test.go
+++ b/enterprise/cli/conductor/kill_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/observability_cmd_test.go
+++ b/enterprise/cli/conductor/observability_cmd_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/publish.go
+++ b/enterprise/cli/conductor/publish.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/publish_auto_hash_test.go
+++ b/enterprise/cli/conductor/publish_auto_hash_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/publish_test.go
+++ b/enterprise/cli/conductor/publish_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/recovery_errorpaths_test.go
+++ b/enterprise/cli/conductor/recovery_errorpaths_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/recovery_success_test.go
+++ b/enterprise/cli/conductor/recovery_success_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/recovery_test_helpers.go
+++ b/enterprise/cli/conductor/recovery_test_helpers.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/replay.go
+++ b/enterprise/cli/conductor/replay.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/rollback.go
+++ b/enterprise/cli/conductor/rollback.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/rollback_clear.go
+++ b/enterprise/cli/conductor/rollback_clear.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/rollback_clear_run_test.go
+++ b/enterprise/cli/conductor/rollback_clear_run_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/rollback_clear_test.go
+++ b/enterprise/cli/conductor/rollback_clear_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/rollback_test.go
+++ b/enterprise/cli/conductor/rollback_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/store_dump.go
+++ b/enterprise/cli/conductor/store_dump.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/store_offline.go
+++ b/enterprise/cli/conductor/store_offline.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/store_offline_test.go
+++ b/enterprise/cli/conductor/store_offline_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/stream_reset.go
+++ b/enterprise/cli/conductor/stream_reset.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/stream_reset_test.go
+++ b/enterprise/cli/conductor/stream_reset_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/stream_status.go
+++ b/enterprise/cli/conductor/stream_status.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/stream_status_test.go
+++ b/enterprise/cli/conductor/stream_status_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/token_file.go
+++ b/enterprise/cli/conductor/token_file.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/conductor/token_file_test.go
+++ b/enterprise/cli/conductor/token_file_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/cli/coverage_boost_test.go
+++ b/enterprise/cli/coverage_boost_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_conductor_source.go
+++ b/enterprise/cli/dashboard_conductor_source.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_conductor_source_test.go
+++ b/enterprise/cli/dashboard_conductor_source_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_coveragecert.go
+++ b/enterprise/cli/dashboard_coveragecert.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_coveragecert_test.go
+++ b/enterprise/cli/dashboard_coveragecert_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_exemption.go
+++ b/enterprise/cli/dashboard_exemption.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_exemption_test.go
+++ b/enterprise/cli/dashboard_exemption_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_legal_hold.go
+++ b/enterprise/cli/dashboard_legal_hold.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_legal_hold_errors_test.go
+++ b/enterprise/cli/dashboard_legal_hold_errors_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_legal_hold_test.go
+++ b/enterprise/cli/dashboard_legal_hold_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_mtls.go
+++ b/enterprise/cli/dashboard_mtls.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_mtls_test.go
+++ b/enterprise/cli/dashboard_mtls_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_oidc.go
+++ b/enterprise/cli/dashboard_oidc.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_operability.go
+++ b/enterprise/cli/dashboard_operability.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_operability_test.go
+++ b/enterprise/cli/dashboard_operability_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/fleet/license_test.go
+++ b/enterprise/cli/fleet/license_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package fleet

--- a/enterprise/cli/fleet/sink.go
+++ b/enterprise/cli/fleet/sink.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package fleet

--- a/enterprise/cli/fleet/sink_test.go
+++ b/enterprise/cli/fleet/sink_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package fleet

--- a/enterprise/cli/license.go
+++ b/enterprise/cli/license.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/license_crl.go
+++ b/enterprise/cli/license_crl.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/license_crl_test.go
+++ b/enterprise/cli/license_crl_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/license_gate_test.go
+++ b/enterprise/cli/license_gate_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/license_intermediate.go
+++ b/enterprise/cli/license_intermediate.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/license_intermediate_test.go
+++ b/enterprise/cli/license_intermediate_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/license_test.go
+++ b/enterprise/cli/license_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package entcli

--- a/enterprise/cli/register.go
+++ b/enterprise/cli/register.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package entcli provides enterprise CLI commands (license, conductor, fleet,

--- a/enterprise/conductor/applied_state_test.go
+++ b/enterprise/conductor/applied_state_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/conductor/applycache/bootstrap_trust_test.go
+++ b/enterprise/conductor/applycache/bootstrap_trust_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package applycache

--- a/enterprise/conductor/applycache/boundary.go
+++ b/enterprise/conductor/applycache/boundary.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package applycache

--- a/enterprise/conductor/applycache/boundary_entitlement_test.go
+++ b/enterprise/conductor/applycache/boundary_entitlement_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package applycache

--- a/enterprise/conductor/applycache/cache.go
+++ b/enterprise/conductor/applycache/cache.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package applycache verifies and durably activates Conductor policy bundles.

--- a/enterprise/conductor/applycache/cache_integrity_test.go
+++ b/enterprise/conductor/applycache/cache_integrity_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package applycache

--- a/enterprise/conductor/applycache/cache_test.go
+++ b/enterprise/conductor/applycache/cache_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package applycache

--- a/enterprise/conductor/applycache/duplicate_state_test.go
+++ b/enterprise/conductor/applycache/duplicate_state_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package applycache

--- a/enterprise/conductor/applycache/stale.go
+++ b/enterprise/conductor/applycache/stale.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package applycache

--- a/enterprise/conductor/applycache/stale_enforcer.go
+++ b/enterprise/conductor/applycache/stale_enforcer.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package applycache

--- a/enterprise/conductor/applycache/stale_enforcer_test.go
+++ b/enterprise/conductor/applycache/stale_enforcer_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package applycache

--- a/enterprise/conductor/auditbatcher/applied_state_test.go
+++ b/enterprise/conductor/auditbatcher/applied_state_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package auditbatcher

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package auditbatcher

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package auditbatcher

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package auditbatcher provides follower-side durable queuing primitives for

--- a/enterprise/conductor/auditbatcher/queue_lock_unix.go
+++ b/enterprise/conductor/auditbatcher/queue_lock_unix.go
@@ -1,5 +1,6 @@
 //go:build enterprise && !windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package auditbatcher

--- a/enterprise/conductor/auditbatcher/queue_lock_windows.go
+++ b/enterprise/conductor/auditbatcher/queue_lock_windows.go
@@ -1,5 +1,6 @@
 //go:build enterprise && windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package auditbatcher

--- a/enterprise/conductor/auditbatcher/queue_test.go
+++ b/enterprise/conductor/auditbatcher/queue_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package auditbatcher

--- a/enterprise/conductor/auditbatcher/sign.go
+++ b/enterprise/conductor/auditbatcher/sign.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package auditbatcher

--- a/enterprise/conductor/auditbatcher/sign_test.go
+++ b/enterprise/conductor/auditbatcher/sign_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package auditbatcher

--- a/enterprise/conductor/auditbatcher/transport.go
+++ b/enterprise/conductor/auditbatcher/transport.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package auditbatcher

--- a/enterprise/conductor/auditbatcher/transport_test.go
+++ b/enterprise/conductor/auditbatcher/transport_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package auditbatcher

--- a/enterprise/conductor/bootstrap/bootstrap.go
+++ b/enterprise/conductor/bootstrap/bootstrap.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/bootstrap/bootstrap_test.go
+++ b/enterprise/conductor/bootstrap/bootstrap_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/bootstrap/config.go
+++ b/enterprise/conductor/bootstrap/config.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/bootstrap/coverage_test.go
+++ b/enterprise/conductor/bootstrap/coverage_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/bootstrap/exploit_test.go
+++ b/enterprise/conductor/bootstrap/exploit_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/bootstrap/fault_test.go
+++ b/enterprise/conductor/bootstrap/fault_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/bootstrap/identity.go
+++ b/enterprise/conductor/bootstrap/identity.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package bootstrap stands up a complete, self-verifying Conductor dev fleet on

--- a/enterprise/conductor/bootstrap/layout.go
+++ b/enterprise/conductor/bootstrap/layout.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/bootstrap/material.go
+++ b/enterprise/conductor/bootstrap/material.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/bootstrap/material_keyfile_test.go
+++ b/enterprise/conductor/bootstrap/material_keyfile_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/bootstrap/quickstart.go
+++ b/enterprise/conductor/bootstrap/quickstart.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/bootstrap/roundtrip.go
+++ b/enterprise/conductor/bootstrap/roundtrip.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package bootstrap

--- a/enterprise/conductor/capabilities.go
+++ b/enterprise/conductor/capabilities.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/conductor/capabilities_test.go
+++ b/enterprise/conductor/capabilities_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/conductor/controlplane/adversarial_test.go
+++ b/enterprise/conductor/controlplane/adversarial_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/applied_state_test.go
+++ b/enterprise/conductor/controlplane/applied_state_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/audit_evidence.go
+++ b/enterprise/conductor/controlplane/audit_evidence.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/audit_ingest.go
+++ b/enterprise/conductor/controlplane/audit_ingest.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/audit_ingest_test.go
+++ b/enterprise/conductor/controlplane/audit_ingest_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/audit_query.go
+++ b/enterprise/conductor/controlplane/audit_query.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/audit_store.go
+++ b/enterprise/conductor/controlplane/audit_store.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/audit_store_nofollow_unix.go
+++ b/enterprise/conductor/controlplane/audit_store_nofollow_unix.go
@@ -1,5 +1,6 @@
 //go:build enterprise && !windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/audit_store_nofollow_windows.go
+++ b/enterprise/conductor/controlplane/audit_store_nofollow_windows.go
@@ -1,5 +1,6 @@
 //go:build enterprise && windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/audit_store_test.go
+++ b/enterprise/conductor/controlplane/audit_store_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/auth.go
+++ b/enterprise/conductor/controlplane/auth.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/auth_test.go
+++ b/enterprise/conductor/controlplane/auth_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/dryrun.go
+++ b/enterprise/conductor/controlplane/dryrun.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/dryrun_test.go
+++ b/enterprise/conductor/controlplane/dryrun_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/duplicate_state_test.go
+++ b/enterprise/conductor/controlplane/duplicate_state_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/emergency_store.go
+++ b/enterprise/conductor/controlplane/emergency_store.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/emergency_store_clear_test.go
+++ b/enterprise/conductor/controlplane/emergency_store_clear_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/emergency_store_test.go
+++ b/enterprise/conductor/controlplane/emergency_store_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/emergency_verified.go
+++ b/enterprise/conductor/controlplane/emergency_verified.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/emergency_verified_test.go
+++ b/enterprise/conductor/controlplane/emergency_verified_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/enrollment.go
+++ b/enterprise/conductor/controlplane/enrollment.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
+++ b/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/enrollment_test.go
+++ b/enterprise/conductor/controlplane/enrollment_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/followers.go
+++ b/enterprise/conductor/controlplane/followers.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/followers_test.go
+++ b/enterprise/conductor/controlplane/followers_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/handler_errors_test.go
+++ b/enterprise/conductor/controlplane/handler_errors_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/handler_test.go
+++ b/enterprise/conductor/controlplane/handler_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/offline_recovery.go
+++ b/enterprise/conductor/controlplane/offline_recovery.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/offline_recovery_test.go
+++ b/enterprise/conductor/controlplane/offline_recovery_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/preview.go
+++ b/enterprise/conductor/controlplane/preview.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/rollback_clear_handler_test.go
+++ b/enterprise/conductor/controlplane/rollback_clear_handler_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/rollback_coverage_test.go
+++ b/enterprise/conductor/controlplane/rollback_coverage_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/runtime_status.go
+++ b/enterprise/conductor/controlplane/runtime_status.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/runtime_status_handler.go
+++ b/enterprise/conductor/controlplane/runtime_status_handler.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/runtime_status_test.go
+++ b/enterprise/conductor/controlplane/runtime_status_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/store.go
+++ b/enterprise/conductor/controlplane/store.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package controlplane provides the Conductor follower-facing HTTP boundary.

--- a/enterprise/conductor/controlplane/store_fork_recovery_test.go
+++ b/enterprise/conductor/controlplane/store_fork_recovery_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/store_test.go
+++ b/enterprise/conductor/controlplane/store_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/stream_status.go
+++ b/enterprise/conductor/controlplane/stream_status.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/controlplane/stream_status_test.go
+++ b/enterprise/conductor/controlplane/stream_status_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package controlplane

--- a/enterprise/conductor/emergency/poller.go
+++ b/enterprise/conductor/emergency/poller.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package emergency

--- a/enterprise/conductor/emergency/poller_test.go
+++ b/enterprise/conductor/emergency/poller_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package emergency

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package emergency applies Conductor emergency control messages on followers.

--- a/enterprise/conductor/emergency/remote_kill_baseline_test.go
+++ b/enterprise/conductor/emergency/remote_kill_baseline_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package emergency

--- a/enterprise/conductor/emergency/remote_kill_parser_test.go
+++ b/enterprise/conductor/emergency/remote_kill_parser_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package emergency

--- a/enterprise/conductor/emergency/remote_kill_test.go
+++ b/enterprise/conductor/emergency/remote_kill_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package emergency

--- a/enterprise/conductor/enrollmentclient/client.go
+++ b/enterprise/conductor/enrollmentclient/client.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enrollmentclient

--- a/enterprise/conductor/enrollmentclient/client_test.go
+++ b/enterprise/conductor/enrollmentclient/client_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enrollmentclient

--- a/enterprise/conductor/fleetreport/report.go
+++ b/enterprise/conductor/fleetreport/report.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package fleetreport mints Fleet Receipt Reports from locally accepted

--- a/enterprise/conductor/fleetreport/report_test.go
+++ b/enterprise/conductor/fleetreport/report_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package fleetreport

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package conductor defines Conductor signed message bodies.

--- a/enterprise/conductor/messages_notbefore_skew_test.go
+++ b/enterprise/conductor/messages_notbefore_skew_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor

--- a/enterprise/conductor/policysync/poller.go
+++ b/enterprise/conductor/policysync/poller.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package policysync polls a Conductor leader for the latest signed policy

--- a/enterprise/conductor/policysync/poller_test.go
+++ b/enterprise/conductor/policysync/poller_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package policysync

--- a/enterprise/conductor/policysync/rollback_poller.go
+++ b/enterprise/conductor/policysync/rollback_poller.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package policysync

--- a/enterprise/conductor/policysync/rollback_poller_test.go
+++ b/enterprise/conductor/policysync/rollback_poller_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package policysync

--- a/enterprise/config.go
+++ b/enterprise/config.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enterprise

--- a/enterprise/config_test.go
+++ b/enterprise/config_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enterprise

--- a/enterprise/coverage_boost_test.go
+++ b/enterprise/coverage_boost_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enterprise

--- a/enterprise/dashboard/agents_test.go
+++ b/enterprise/dashboard/agents_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/aliases.go
+++ b/enterprise/dashboard/aliases.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/backup.go
+++ b/enterprise/dashboard/backup.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/budgets.go
+++ b/enterprise/dashboard/budgets.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/budgets_test.go
+++ b/enterprise/dashboard/budgets_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/delivery_inbox.go
+++ b/enterprise/dashboard/delivery_inbox.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/evidence_nofollow_unix.go
+++ b/enterprise/dashboard/evidence_nofollow_unix.go
@@ -1,5 +1,6 @@
 //go:build enterprise && !windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/evidence_nofollow_windows.go
+++ b/enterprise/dashboard/evidence_nofollow_windows.go
@@ -1,5 +1,6 @@
 //go:build enterprise && windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/evidence_nonblock_unix.go
+++ b/enterprise/dashboard/evidence_nonblock_unix.go
@@ -1,5 +1,6 @@
 //go:build enterprise && !windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/evidence_nonblock_windows.go
+++ b/enterprise/dashboard/evidence_nonblock_windows.go
@@ -1,5 +1,6 @@
 //go:build enterprise && windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/exemption_store.go
+++ b/enterprise/dashboard/exemption_store.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/exemption_store_lock_unix.go
+++ b/enterprise/dashboard/exemption_store_lock_unix.go
@@ -1,5 +1,6 @@
 //go:build enterprise && !windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/exemption_store_lock_windows.go
+++ b/enterprise/dashboard/exemption_store_lock_windows.go
@@ -1,5 +1,6 @@
 //go:build enterprise && windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/exemption_store_lock_windows_test.go
+++ b/enterprise/dashboard/exemption_store_lock_windows_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise && windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/exemption_store_test.go
+++ b/enterprise/dashboard/exemption_store_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/exemptions.go
+++ b/enterprise/dashboard/exemptions.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/exemptions_test.go
+++ b/enterprise/dashboard/exemptions_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/fleetoverview.go
+++ b/enterprise/dashboard/fleetoverview.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/fleetoverview_test.go
+++ b/enterprise/dashboard/fleetoverview_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/incident.go
+++ b/enterprise/dashboard/incident.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/incident_test.go
+++ b/enterprise/dashboard/incident_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/legal_hold_review_test.go
+++ b/enterprise/dashboard/legal_hold_review_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/legal_hold_store.go
+++ b/enterprise/dashboard/legal_hold_store.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/legal_hold_store_test.go
+++ b/enterprise/dashboard/legal_hold_store_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/operability_errors_test.go
+++ b/enterprise/dashboard/operability_errors_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/operability_health.go
+++ b/enterprise/dashboard/operability_health.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/operability_test.go
+++ b/enterprise/dashboard/operability_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/overview.go
+++ b/enterprise/dashboard/overview.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/overview_test.go
+++ b/enterprise/dashboard/overview_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/readmodel.go
+++ b/enterprise/dashboard/readmodel.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/readmodel_test.go
+++ b/enterprise/dashboard/readmodel_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/rebuild.go
+++ b/enterprise/dashboard/rebuild.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/regular_open.go
+++ b/enterprise/dashboard/regular_open.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/regular_open_owner_unix.go
+++ b/enterprise/dashboard/regular_open_owner_unix.go
@@ -1,5 +1,6 @@
 //go:build enterprise && !windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/regular_open_owner_windows.go
+++ b/enterprise/dashboard/regular_open_owner_windows.go
@@ -1,5 +1,6 @@
 //go:build enterprise && windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/regular_open_unix_test.go
+++ b/enterprise/dashboard/regular_open_unix_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise && !windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/runtimesnapshot/duplicate_state_test.go
+++ b/enterprise/dashboard/runtimesnapshot/duplicate_state_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtimesnapshot

--- a/enterprise/dashboard/runtimesnapshot/snapshot.go
+++ b/enterprise/dashboard/runtimesnapshot/snapshot.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtimesnapshot

--- a/enterprise/dashboard/runtimesnapshot/snapshot_test.go
+++ b/enterprise/dashboard/runtimesnapshot/snapshot_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtimesnapshot

--- a/enterprise/dashboard/scorecard.go
+++ b/enterprise/dashboard/scorecard.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/scorecard_test.go
+++ b/enterprise/dashboard/scorecard_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Scorecard tests moved to internal/evidenceview/scorecard_ported_test.go as

--- a/enterprise/dashboard/snapshot_budget_source.go
+++ b/enterprise/dashboard/snapshot_budget_source.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/snapshot_budget_source_test.go
+++ b/enterprise/dashboard/snapshot_budget_source_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/testhelpers_test.go
+++ b/enterprise/dashboard/testhelpers_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/trustkeys.go
+++ b/enterprise/dashboard/trustkeys.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/trustkeys_test.go
+++ b/enterprise/dashboard/trustkeys_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/workbench.go
+++ b/enterprise/dashboard/workbench.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/dashboard/workbench_test.go
+++ b/enterprise/dashboard/workbench_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package dashboard

--- a/enterprise/edition.go
+++ b/enterprise/edition.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enterprise

--- a/enterprise/edition_test.go
+++ b/enterprise/edition_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enterprise

--- a/enterprise/fleet/sink/doc.go
+++ b/enterprise/fleet/sink/doc.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package sink implements Conductor audit batch ingest and query storage for

--- a/enterprise/fleet/sink/ingest.go
+++ b/enterprise/fleet/sink/ingest.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package sink

--- a/enterprise/fleet/sink/ingest_auth_test.go
+++ b/enterprise/fleet/sink/ingest_auth_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package sink

--- a/enterprise/fleet/sink/ingest_test.go
+++ b/enterprise/fleet/sink/ingest_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package sink

--- a/enterprise/fleet/sink/query.go
+++ b/enterprise/fleet/sink/query.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package sink

--- a/enterprise/fleet/sink/storage.go
+++ b/enterprise/fleet/sink/storage.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package sink

--- a/enterprise/fleet/sink/storage_nofollow_unix.go
+++ b/enterprise/fleet/sink/storage_nofollow_unix.go
@@ -1,5 +1,6 @@
 //go:build enterprise && !windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package sink

--- a/enterprise/fleet/sink/storage_nofollow_windows.go
+++ b/enterprise/fleet/sink/storage_nofollow_windows.go
@@ -1,5 +1,6 @@
 //go:build enterprise && windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package sink

--- a/enterprise/fleet/sink/types.go
+++ b/enterprise/fleet/sink/types.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package sink

--- a/enterprise/licenseservice/audit.go
+++ b/enterprise/licenseservice/audit.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/audit_test.go
+++ b/enterprise/licenseservice/audit_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/config.go
+++ b/enterprise/licenseservice/config.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/config_test.go
+++ b/enterprise/licenseservice/config_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/coverage_boost_test.go
+++ b/enterprise/licenseservice/coverage_boost_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/crl_generation_test.go
+++ b/enterprise/licenseservice/crl_generation_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/cron.go
+++ b/enterprise/licenseservice/cron.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/cron_test.go
+++ b/enterprise/licenseservice/cron_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/email.go
+++ b/enterprise/licenseservice/email.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/email_test.go
+++ b/enterprise/licenseservice/email_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/entitlement.go
+++ b/enterprise/licenseservice/entitlement.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/entitlement_test.go
+++ b/enterprise/licenseservice/entitlement_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/eval.go
+++ b/enterprise/licenseservice/eval.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/eval_coverage_test.go
+++ b/enterprise/licenseservice/eval_coverage_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/eval_store.go
+++ b/enterprise/licenseservice/eval_store.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/eval_store_test.go
+++ b/enterprise/licenseservice/eval_store_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/eval_test.go
+++ b/enterprise/licenseservice/eval_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/import_signed_test.go
+++ b/enterprise/licenseservice/import_signed_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/import_table.go
+++ b/enterprise/licenseservice/import_table.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/import_table_test.go
+++ b/enterprise/licenseservice/import_table_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/intermediate_revocation_test.go
+++ b/enterprise/licenseservice/intermediate_revocation_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/normalize.go
+++ b/enterprise/licenseservice/normalize.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/normalize_test.go
+++ b/enterprise/licenseservice/normalize_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/polar.go
+++ b/enterprise/licenseservice/polar.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/polar_test.go
+++ b/enterprise/licenseservice/polar_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/server.go
+++ b/enterprise/licenseservice/server.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package licenseservice implements the Pipelock license service: a standalone

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice

--- a/enterprise/registry.go
+++ b/enterprise/registry.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enterprise

--- a/enterprise/registry_test.go
+++ b/enterprise/registry_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package enterprise

--- a/enterprise/siemforward/forwarder.go
+++ b/enterprise/siemforward/forwarder.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package siemforward provides durable, asynchronous HTTP forwarding for

--- a/enterprise/siemforward/forwarder_test.go
+++ b/enterprise/siemforward/forwarder_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package siemforward

--- a/enterprise/siemforward/lock_unix.go
+++ b/enterprise/siemforward/lock_unix.go
@@ -1,5 +1,6 @@
 //go:build enterprise && !windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package siemforward

--- a/enterprise/siemforward/lock_windows.go
+++ b/enterprise/siemforward/lock_windows.go
@@ -1,5 +1,6 @@
 //go:build enterprise && windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package siemforward

--- a/enterprise/siemforward/nofollow_unix.go
+++ b/enterprise/siemforward/nofollow_unix.go
@@ -1,5 +1,6 @@
 //go:build enterprise && !windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package siemforward

--- a/enterprise/siemforward/nofollow_windows.go
+++ b/enterprise/siemforward/nofollow_windows.go
@@ -1,5 +1,6 @@
 //go:build enterprise && windows
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package siemforward

--- a/enterprise/testinit/init.go
+++ b/enterprise/testinit/init.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package testinit activates enterprise edition hooks for package-level tests.

--- a/examples/canary-tokens/verify.sh
+++ b/examples/canary-tokens/verify.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Canary token verification for examples/canary-tokens/
 #
 # Exercises pipelock canary snippet generation and URL detection without a

--- a/examples/cursor-integration/verify.sh
+++ b/examples/cursor-integration/verify.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Cursor integration verification for examples/cursor-integration/
 #
 # Exercises pipelock cursor install/hook/remove without requiring Cursor IDE.

--- a/examples/demo-readme.sh
+++ b/examples/demo-readme.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Quick Pipelock demo for README recording.
 # Shows a 4-step attack escalation: raw key, encoded key, DNS exfil, then clean pass.
 #
@@ -68,6 +71,6 @@ pause
 
 # --- Done ---
 echo ""
-echo -e "${GREEN}Single binary. 11-layer scanner. DLP, DNS exfil, SSRF, and more.${RESET}"
+echo -e "${GREEN}Single binary. Ordered scanner pipeline. DLP, DNS exfil, SSRF, and more.${RESET}"
 echo -e "${GREEN}go install github.com/luckyPipewrench/pipelock/cmd/pipelock@latest${RESET}"
 echo ""

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Pipelock Demo — shows DLP blocking, domain blocking, and integrity detection.
 #
 # Prerequisites:

--- a/examples/docker-compose-proxy/verify.sh
+++ b/examples/docker-compose-proxy/verify.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Docker Compose proxy verification for examples/docker-compose-proxy/
 #
 # Starts docker-compose (local upstream + pipelock) and verifies:

--- a/examples/fetch-proxy-ssrf/verify.sh
+++ b/examples/fetch-proxy-ssrf/verify.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Fetch proxy + SSRF / response-scan verification.
 #
 # Usage:

--- a/examples/kill-switch/verify.sh
+++ b/examples/kill-switch/verify.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Kill switch verification for examples/kill-switch/
 #
 # Starts a local echo server + pipelock, proves fetch works, then activates a

--- a/examples/mcp-tool-policy/policy_decoy_server.py
+++ b/examples/mcp-tool-policy/policy_decoy_server.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Benign stdio MCP decoy for examples/mcp-tool-policy/.
 
 Exposes clean tools so Pipelock mcp_tool_policy rules (not poisoning or

--- a/examples/mcp-tool-policy/verify.sh
+++ b/examples/mcp-tool-policy/verify.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # MCP tool-policy verification for examples/mcp-tool-policy/
 #
 # Drives pipelock mcp proxy against a benign stdio decoy and proves allow vs

--- a/examples/quickstart/mock-mcp-server.sh
+++ b/examples/quickstart/mock-mcp-server.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Mock MCP server: responds to tools/list with a poisoned tool description.
 # Used by verify.sh to test pipelock's MCP tool scanning.
 # POSIX sh compatible (runs on Alpine/BusyBox ash).

--- a/examples/quickstart/verify.sh
+++ b/examples/quickstart/verify.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Pipelock quickstart verification: 5 tests proving isolation and scanning work.
 # Runs inside the verify container (pipelock-init image: Alpine + /pipelock binary).
 # Exit 0 = all pass, exit 1 = any fail. CI-friendly.

--- a/examples/tool-poisoning-honeypot/decoy_mcp_server.py
+++ b/examples/tool-poisoning-honeypot/decoy_mcp_server.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Decoy adversarial MCP server for the tool-poisoning-honeypot example.
 
 This server speaks MCP over stdio JSON-RPC, matching Pipelock's stdio MCP

--- a/examples/tool-poisoning-honeypot/verify.sh
+++ b/examples/tool-poisoning-honeypot/verify.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Verification for examples/tool-poisoning-honeypot/
 #
 # Runs the real `pipelock mcp proxy` round-trip against the decoy server and

--- a/examples/tool-response-injection/demo.py
+++ b/examples/tool-response-injection/demo.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Multi-transport reproduction harness for MCP tool-response prompt injection."""
 
 from __future__ import annotations

--- a/examples/tool-response-injection/demo_capability_separation.py
+++ b/examples/tool-response-injection/demo_capability_separation.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Check what happens when the agent can touch the harness files directly."""
 
 from __future__ import annotations

--- a/examples/tool-response-injection/demo_support.py
+++ b/examples/tool-response-injection/demo_support.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared helpers for the tool-response-injection demos."""
 
 from __future__ import annotations

--- a/examples/tool-response-injection/malicious_mcp_server.py
+++ b/examples/tool-response-injection/malicious_mcp_server.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Adversarial MCP server for the tool-response-injection example.
 
 This server speaks MCP in two modes:

--- a/examples/websocket-proxy/verify.sh
+++ b/examples/websocket-proxy/verify.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # WebSocket proxy verification for examples/websocket-proxy/
 #
 # Starts a local echo server and pipelock with websocket_proxy enabled, then

--- a/examples/websocket-proxy/ws_echo.go
+++ b/examples/websocket-proxy/ws_echo.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build ignore
 
 // WebSocket echo server for examples/websocket-proxy/verify.sh.

--- a/examples/websocket-proxy/ws_probe.go
+++ b/examples/websocket-proxy/ws_probe.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build ignore
 
 // WebSocket probe client for examples/websocket-proxy/verify.sh.

--- a/internal/cli/hermes/plugin_template/__init__.py
+++ b/internal/cli/hermes/plugin_template/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Pipelock security plugin for Hermes Agent.
 
 Registers the hooks pipelock cares about (pre_tool_call, transform_tool_result,

--- a/internal/cli/hermes/plugin_template/plugin.py
+++ b/internal/cli/hermes/plugin_template/plugin.py
@@ -1,3 +1,6 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Pipelock plugin implementation.
 
 Each registered hook builds a payload matching Hermes' shell-hook wire schema

--- a/internal/cli/root_enterprise_test.go
+++ b/internal/cli/root_enterprise_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Lives in package cli_test (not cli) so the blank import of

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_applied_state_test.go
+++ b/internal/cli/runtime/conductor_applied_state_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_enrollment.go
+++ b/internal/cli/runtime/conductor_enrollment.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_enrollment_duplicate_test.go
+++ b/internal/cli/runtime/conductor_enrollment_duplicate_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_enrollment_test.go
+++ b/internal/cli/runtime/conductor_enrollment_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_labels_test.go
+++ b/internal/cli/runtime/conductor_labels_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_rollback_test.go
+++ b/internal/cli/runtime/conductor_rollback_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_stale_test.go
+++ b/internal/cli/runtime/conductor_stale_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_status.go
+++ b/internal/cli/runtime/conductor_status.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_status_test.go
+++ b/internal/cli/runtime/conductor_status_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_targetbundle_test.go
+++ b/internal/cli/runtime/conductor_targetbundle_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/dashboard_snapshot_enterprise.go
+++ b/internal/cli/runtime/dashboard_snapshot_enterprise.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/dashboard_snapshot_enterprise_test.go
+++ b/internal/cli/runtime/dashboard_snapshot_enterprise_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/emit_forwarder_enterprise.go
+++ b/internal/cli/runtime/emit_forwarder_enterprise.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/emit_forwarder_enterprise_test.go
+++ b/internal/cli/runtime/emit_forwarder_enterprise_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/server_conductor_test.go
+++ b/internal/cli/runtime/server_conductor_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/runtime/test_file_helpers_enterprise_test.go
+++ b/internal/cli/runtime/test_file_helpers_enterprise_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime

--- a/internal/cli/scan/scan.go
+++ b/internal/cli/scan/scan.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package scan implements the `pipelock scan` command: it inspects files for
 // invisible-Unicode and bidi-control injection (the supply-chain vector that
 // hides instructions in agent-context files). It complements the network

--- a/internal/cli/scan/scan_test.go
+++ b/internal/cli/scan/scan_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package scan
 
 import (

--- a/internal/config/config_enterprise_test.go
+++ b/internal/config/config_enterprise_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package config_test

--- a/internal/config/docs_accuracy_test.go
+++ b/internal/config/docs_accuracy_test.go
@@ -1,13 +1,20 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
+
+var markdownLinkPattern = regexp.MustCompile(`!?\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)`)
 
 func TestDocsDeclareLiveStatsAndDefaults(t *testing.T) {
 	t.Parallel()
@@ -20,6 +27,12 @@ func TestDocsDeclareLiveStatsAndDefaults(t *testing.T) {
 		mustContain(t, configDoc, "| `enabled` | `true` | Enable request body/header DLP scanning")
 		mustContain(t, configDoc, "Omitting `request_body_scanning.enabled` or `request_body_scanning.scan_headers` defaults both to `true`")
 		mustNotContain(t, configDoc, "omitting the field from your YAML file gives `false`")
+	})
+
+	t.Run("SECURITY.md", func(t *testing.T) {
+		securityPolicy := readDocAccuracyFile(t, root, "SECURITY.md")
+		mustContain(t, securityPolicy, "| 3.x | Yes |")
+		mustNotContain(t, securityPolicy, "| 2.x | Yes |")
 	})
 
 	t.Run("AGENTS.md", func(t *testing.T) {
@@ -58,6 +71,143 @@ func TestDocsDeclareLiveStatsAndDefaults(t *testing.T) {
 		mustContain(t, priorArt, "may carry a receipt ID")
 		mustNotContain(t, priorArt, "response header (opaque ULID receipt ID)")
 	})
+}
+
+func TestDocsLocalLinksResolve(t *testing.T) {
+	t.Parallel()
+
+	root := repoRootForDocsAccuracy(t)
+	var docs []string
+	for _, top := range []string{"README.md", "CONTRIBUTING.md", "GOVERNANCE.md", "SECURITY.md"} {
+		docs = append(docs, filepath.Join(root, top))
+	}
+	err := filepath.WalkDir(filepath.Join(root, "docs"), func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.IsDir() && strings.EqualFold(filepath.Ext(path), ".md") {
+			docs = append(docs, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk documentation: %v", err)
+	}
+	slices.Sort(docs)
+
+	anchorCache := make(map[string]map[string]struct{}, len(docs))
+	for _, doc := range docs {
+		body, readErr := os.ReadFile(filepath.Clean(doc))
+		if readErr != nil {
+			t.Fatalf("read %s: %v", doc, readErr)
+		}
+		for _, match := range markdownLinkPattern.FindAllStringSubmatch(string(body), -1) {
+			target := strings.Trim(match[1], "<>")
+			if target == "" || strings.HasPrefix(target, "http://") ||
+				strings.HasPrefix(target, "https://") ||
+				strings.HasPrefix(target, "mailto:") ||
+				strings.HasPrefix(target, "data:") {
+				continue
+			}
+
+			pathPart, fragment, _ := strings.Cut(target, "#")
+			targetPath := doc
+			if pathPart != "" {
+				if strings.HasPrefix(pathPart, "/") {
+					// Root-relative website routes are not repository files.
+					continue
+				}
+				targetPath = filepath.Clean(filepath.Join(filepath.Dir(doc), pathPart))
+				withinRoot, relErr := filepath.Rel(root, targetPath)
+				if relErr != nil || withinRoot == ".." || strings.HasPrefix(withinRoot, ".."+string(filepath.Separator)) {
+					t.Errorf("%s: local link escapes repository: %s", relativeDocPath(root, doc), target)
+					continue
+				}
+				if _, statErr := os.Stat(targetPath); statErr != nil {
+					t.Errorf("%s: local link target does not exist: %s", relativeDocPath(root, doc), target)
+					continue
+				}
+			}
+
+			if fragment == "" || !strings.EqualFold(filepath.Ext(targetPath), ".md") {
+				continue
+			}
+			anchors, ok := anchorCache[targetPath]
+			if !ok {
+				anchors = markdownHeadingAnchors(t, targetPath)
+				anchorCache[targetPath] = anchors
+			}
+			if _, ok := anchors[strings.ToLower(fragment)]; !ok {
+				t.Errorf("%s: Markdown anchor does not exist: %s", relativeDocPath(root, doc), target)
+			}
+		}
+	}
+}
+
+func markdownHeadingAnchors(t *testing.T, path string) map[string]struct{} {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read anchor target %s: %v", path, err)
+	}
+
+	anchors := make(map[string]struct{})
+	counts := make(map[string]int)
+	inFence := false
+	for _, line := range strings.Split(string(body), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence || !strings.HasPrefix(line, "#") {
+			continue
+		}
+		level := 0
+		for level < len(line) && line[level] == '#' {
+			level++
+		}
+		if level == 0 || level > 6 || level >= len(line) || line[level] != ' ' {
+			continue
+		}
+		slug := githubHeadingSlug(strings.TrimSpace(strings.TrimRight(line[level+1:], "# ")))
+		if slug == "" {
+			continue
+		}
+		n := counts[slug]
+		counts[slug]++
+		if n > 0 {
+			slug = fmt.Sprintf("%s-%d", slug, n)
+		}
+		anchors[slug] = struct{}{}
+	}
+	return anchors
+}
+
+func githubHeadingSlug(heading string) string {
+	heading = strings.ToLower(heading)
+	var out strings.Builder
+	for _, r := range heading {
+		switch {
+		case r == ' ' || r == '-':
+			out.WriteRune(r)
+		case r == '_':
+			out.WriteRune(r)
+		case r >= 'a' && r <= 'z':
+			out.WriteRune(r)
+		case r >= '0' && r <= '9':
+			out.WriteRune(r)
+		}
+	}
+	return strings.ReplaceAll(out.String(), " ", "-")
+}
+
+func relativeDocPath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return path
+	}
+	return filepath.ToSlash(rel)
 }
 
 func repoRootForDocsAccuracy(t *testing.T) string {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1202,8 +1202,9 @@ type CrossRequestFragments struct {
 
 // KillSwitch configures the emergency deny-all kill switch.
 // When active, all requests are rejected except health/metrics endpoints
-// and allowlisted IPs. Three activation sources (config, SIGUSR1, sentinel
-// file) are OR-composed: any one active means the kill switch is engaged.
+// and allowlisted IPs. Six activation sources (config, API, Conductor remote
+// kill, Conductor stale bundle, SIGUSR1, sentinel file) are OR-composed: any
+// one active means the kill switch is engaged.
 type KillSwitch struct {
 	Enabled       bool     `yaml:"enabled"`
 	SentinelFile  string   `yaml:"sentinel_file"`

--- a/internal/config/stats_test.go
+++ b/internal/config/stats_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/filescan/filescan.go
+++ b/internal/filescan/filescan.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package filescan detects invisible-Unicode and bidi-control characters
 // embedded in files. This is the product surface for the supply-chain injection
 // vector where an attacker plants hidden instructions in agent-context files

--- a/internal/filescan/filescan_test.go
+++ b/internal/filescan/filescan_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package filescan
 
 import (

--- a/internal/health/watchdog.go
+++ b/internal/health/watchdog.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package health provides a wedge-detection watchdog for pipelock.
 //
 // The /health endpoint historically answered 200 as long as the HTTP handler

--- a/internal/health/watchdog_test.go
+++ b/internal/health/watchdog_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package health
 
 import (

--- a/internal/mcp/mcp_http_reverse_header_precedence_test.go
+++ b/internal/mcp/mcp_http_reverse_header_precedence_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/internal/mcp/pipeline_gates_identity_test.go
+++ b/internal/mcp/pipeline_gates_identity_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/internal/metrics/conductor.go
+++ b/internal/metrics/conductor.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package metrics

--- a/internal/metrics/conductor_test.go
+++ b/internal/metrics/conductor_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package metrics

--- a/internal/metrics/siem_forwarder.go
+++ b/internal/metrics/siem_forwarder.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package metrics

--- a/internal/metrics/siem_forwarder_test.go
+++ b/internal/metrics/siem_forwarder_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package metrics

--- a/internal/proxy/adaptive_upgrade.go
+++ b/internal/proxy/adaptive_upgrade.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import (

--- a/internal/proxy/adaptive_upgrade_test.go
+++ b/internal/proxy/adaptive_upgrade_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import (

--- a/internal/proxy/dns_overrides_e2e_test.go
+++ b/internal/proxy/dns_overrides_e2e_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import (

--- a/internal/proxy/proxy_enterprise_test.go
+++ b/internal/proxy/proxy_enterprise_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package proxy

--- a/internal/proxy/redaction_runtime_key_enterprise_test.go
+++ b/internal/proxy/redaction_runtime_key_enterprise_test.go
@@ -1,5 +1,6 @@
 //go:build enterprise
 
+// Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package proxy

--- a/internal/proxy/sessionkey.go
+++ b/internal/proxy/sessionkey.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 // sessionKeyFor builds the per-session key used for adaptive-enforcement

--- a/internal/proxy/sessionkey_test.go
+++ b/internal/proxy/sessionkey_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import "testing"

--- a/internal/proxy/wsprobe_bench_test.go
+++ b/internal/proxy/wsprobe_bench_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import (

--- a/internal/receipt/session_control.go
+++ b/internal/receipt/session_control.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package receipt
 
 import (

--- a/internal/receipt/session_control_test.go
+++ b/internal/receipt/session_control_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package receipt
 
 import (

--- a/internal/recorder/query_internal_test.go
+++ b/internal/recorder/query_internal_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Licensed under the Apache License, Version 2.0. See LICENSE.
 
 package recorder

--- a/internal/scanner/dnsresolver.go
+++ b/internal/scanner/dnsresolver.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // dnsresolver.go - host-level DNS resolver used by SSRF checks and the
 // proxy dial path. The default resolver is net.DefaultResolver. Operators
 // may configure dns.host_overrides to map specific hostnames to static IPs

--- a/internal/scanner/dnsresolver_test.go
+++ b/internal/scanner/dnsresolver_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package scanner
 
 import (

--- a/internal/scanner/validate.go
+++ b/internal/scanner/validate.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package scanner
 
 import (

--- a/internal/scanner/validate_test.go
+++ b/internal/scanner/validate_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package scanner
 
 import (

--- a/internal/seedprotect/audit_test.go
+++ b/internal/seedprotect/audit_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package seedprotect
 
 import "testing"

--- a/internal/sentry/client.go
+++ b/internal/sentry/client.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package plsentry
 
 import (

--- a/internal/sentry/client_test.go
+++ b/internal/sentry/client_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package plsentry
 
 import (

--- a/internal/sentry/scrub.go
+++ b/internal/sentry/scrub.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package plsentry provides opt-in Sentry error reporting with event minimization.
 // Events are structurally allowlisted and scrubbed before leaving the process.
 package plsentry

--- a/internal/sentry/scrub_test.go
+++ b/internal/sentry/scrub_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package plsentry
 
 import (

--- a/internal/shield/bench_test.go
+++ b/internal/shield/bench_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package shield
 
 import (

--- a/internal/shield/patterns.go
+++ b/internal/shield/patterns.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package shield
 
 import "regexp"

--- a/internal/shield/shield.go
+++ b/internal/shield/shield.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Package shield implements inline HTML/JS rewriting that strips
 // fingerprinting, extension probing, telemetry beacons, and agent traps
 // from response bodies before the browser renders them.

--- a/internal/shield/shield_test.go
+++ b/internal/shield/shield_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package shield
 
 import (

--- a/internal/shield/shims.go
+++ b/internal/shield/shims.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package shield
 
 import (

--- a/scripts/check-cloudflare-ranges.sh
+++ b/scripts/check-cloudflare-ranges.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 # check-cloudflare-ranges.sh — manual operator tool (NOT wired into required CI).

--- a/scripts/check-config-consumption.sh
+++ b/scripts/check-config-consumption.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 # Tripwire: flag config schema fields that nothing outside internal/config

--- a/scripts/check-config-examples.sh
+++ b/scripts/check-config-examples.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # check-config-examples.sh — shipped config snippets must actually START.
 #
 # `pipelock check` is a parse/semantic pass; it does not exercise runtime startup

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 chart="charts/pipelock"

--- a/scripts/check-python-pins.sh
+++ b/scripts/check-python-pins.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # check-python-pins.sh
 #
 # Enforces the full Python dep policy on every tracked requirements*.txt:

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Release-readiness gate. Hard-fails a release whose metadata does not match the
 # tag, BEFORE anything is built. Catches the recurring release mistakes that no
 # human checklist reliably caught:

--- a/scripts/check-reproducible-build.sh
+++ b/scripts/check-reproducible-build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+for command in git go cmp sha256sum; do
+	if ! command -v "$command" >/dev/null 2>&1; then
+		echo "reproducible-build: required command not found: $command" >&2
+		exit 1
+	fi
+done
+
+version="${VERSION:-$(git describe --tags --always --dirty | sed 's/^v//')}"
+build_date="$(git show -s --format=%cI HEAD)"
+git_commit="$(git rev-parse --short HEAD)"
+go_version="$(go env GOVERSION)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/pipelock-repro.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+ldflags="-s -w
+	-X github.com/luckyPipewrench/pipelock/internal/cliutil.Version=$version
+	-X github.com/luckyPipewrench/pipelock/internal/cliutil.BuildDate=$build_date
+	-X github.com/luckyPipewrench/pipelock/internal/cliutil.GitCommit=$git_commit
+	-X github.com/luckyPipewrench/pipelock/internal/cliutil.GoVersion=$go_version
+	-X github.com/luckyPipewrench/pipelock/internal/proxy.Version=$version"
+
+build() {
+	local output="$1"
+	CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags "$ldflags" \
+		-o "$output" ./cmd/pipelock
+}
+
+build "$tmp_dir/pipelock-a"
+build "$tmp_dir/pipelock-b"
+
+if ! cmp -s "$tmp_dir/pipelock-a" "$tmp_dir/pipelock-b"; then
+	echo "reproducible-build: repeated builds produced different bytes" >&2
+	sha256sum "$tmp_dir/pipelock-a" "$tmp_dir/pipelock-b" >&2
+	exit 1
+fi
+
+digest="$(sha256sum "$tmp_dir/pipelock-a" | cut -d' ' -f1)"
+echo "reproducible-build: OK sha256:$digest"

--- a/scripts/check-source-headers.sh
+++ b/scripts/check-source-headers.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+missing=0
+while IFS= read -r -d '' path; do
+	case "$path" in
+		testdata/* | */testdata/*)
+			continue
+			;;
+	esac
+
+	if ! grep -q 'Copyright' "$path"; then
+		echo "$path: missing copyright statement" >&2
+		missing=1
+	fi
+
+	# Enterprise-tagged sources carry the repository's ELv2 notice instead of
+	# the Apache SPDX identifier used by the open-source core.
+	if grep -q 'Licensed under the Elastic License 2.0' "$path"; then
+		continue
+	fi
+	if ! grep -q 'SPDX-License-Identifier: Apache-2.0' "$path"; then
+		echo "$path: missing SPDX-License-Identifier: Apache-2.0" >&2
+		missing=1
+	fi
+done < <(
+	git ls-files -z \
+		'*.go' '*.sh' '*.py' '*.js' '*.ts' '*.rs' \
+		'Dockerfile' 'Dockerfile.*'
+)
+
+if ((missing != 0)); then
+	echo "source-headers: FAILED" >&2
+	exit 1
+fi
+
+echo "source-headers: OK"

--- a/scripts/check-test-stability.sh
+++ b/scripts/check-test-stability.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 # Tripwire: forbid the two flaky-test root causes (fixed wall-clock sleeps and

--- a/scripts/ci-retry.sh
+++ b/scripts/ci-retry.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Retry a command up to 3 times with linear backoff, to absorb transient
 # network flakes (e.g. a one-off module-proxy blip on `go mod download`)
 # without failing a whole CI matrix leg. Usage: ci-retry.sh <cmd> [args...]

--- a/scripts/ci_test_packages.py
+++ b/scripts/ci_test_packages.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Print the package list for a CI test shard."""
 
 from __future__ import annotations

--- a/scripts/coverage-with-subprocess.sh
+++ b/scripts/coverage-with-subprocess.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # coverage-with-subprocess.sh — Collects coverage from both the test process
 # and any child processes (sandbox init, standalone init, etc.) using GOCOVERDIR.
 #

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-scope=(README.md CLAUDE.md docs)
+scope=(README.md CLAUDE.md CONTRIBUTING.md GOVERNANCE.md SECURITY.md docs examples)
 
 check_no_match() {
 	local pattern="$1"
@@ -27,8 +30,21 @@ check_no_match '10,800\+' 'old test count'
 check_no_match '47 DLP patterns' 'old DLP pattern count'
 check_no_match '47 regex patterns' 'old DLP regex count'
 check_no_match '47 DLP-pattern' 'old DLP pattern count'
+check_no_match '\b11-layer\b|\b11 layers\b' 'fixed scanner-layer count'
+check_no_match '\b(all|All) 4 sources\b|\bfour independent (activation )?sources\b|\b4 independent sources\b' 'four-source kill-switch count'
+check_no_match 'verifiable trail of all agent network activity' 'unprovable audit-completeness claim'
+check_no_match 'inspects all cross-boundary traffic' 'unscoped transport-inspection claim'
+check_no_match 'every proxy decision produces a signed (action )?receipt' 'unprovable receipt-completeness claim'
+check_no_match 'all five reference verifiers|five independent verifier implementations' 'wasm-as-independent-verifier claim'
+check_no_match 'timeline (lists|of) every mediated decision' 'unprovable evidence-timeline completeness claim'
+check_no_match 'stale_policy\.(grace_multiplier|after_grace).*\| Reserved' 'stale-policy-as-reserved claim'
+check_no_match 'Every signed bundle hash is written to an append-only transparency log' 'unshipped universal transparency-log claim'
+check_no_match 'No implementation should start until these are accepted' 'obsolete Conductor pre-implementation gate'
 
 echo "docs-check: printing canonical local stats"
 make stats
+
+echo "docs-check: validating current claims and local Markdown links"
+go test -count=1 -run 'TestDocs(DeclareLiveStatsAndDefaults|LocalLinksResolve)$' ./internal/config/
 
 echo "docs-check: ok"

--- a/scripts/e2e/cline-install.sh
+++ b/scripts/e2e/cline-install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # E2E test for `pipelock cline install` and `pipelock cline remove`.
 #
 # Exercises the full install flow against the installed pipelock binary:

--- a/scripts/e2e/cline-mcp-runtime.py
+++ b/scripts/e2e/cline-mcp-runtime.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Real-upstream MCP runtime E2E for `pipelock cline install`.
 
 Builds the pipelock binary from the worktree (or reuses one passed via

--- a/scripts/e2e/opencode-install.sh
+++ b/scripts/e2e/opencode-install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # E2E test for `pipelock opencode install` and `pipelock opencode remove`.
 #
 # Exercises the full install flow against the installed pipelock binary:

--- a/scripts/e2e/opencode-mcp-runtime.py
+++ b/scripts/e2e/opencode-mcp-runtime.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Real-upstream MCP runtime E2E for `pipelock opencode install`.
 
 Builds the pipelock binary from the worktree (or reuses one passed via

--- a/scripts/pr-review.py
+++ b/scripts/pr-review.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """AI-powered PR review for Pipelock.
 
 Triggered by /review comments on PRs. Supports multiple review modes:

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for scripts/pr-review.py."""
 
 import importlib.util

--- a/scripts/release-audit.sh
+++ b/scripts/release-audit.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/runtime-policy-audit.sh
+++ b/scripts/runtime-policy-audit.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/stream_go_test_json.py
+++ b/scripts/stream_go_test_json.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Mirror `go test -json` to a file while printing live package completions."""
 
 from __future__ import annotations

--- a/scripts/summarize_go_test_json.py
+++ b/scripts/summarize_go_test_json.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Print a compact package timing summary from `go test -json` output."""
 
 from __future__ import annotations

--- a/scripts/summarize_go_test_json_test.py
+++ b/scripts/summarize_go_test_json_test.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 
 import io
 import json

--- a/scripts/test_ci_test_packages.py
+++ b/scripts/test_ci_test_packages.py
@@ -1,3 +1,6 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Adversarial tests for release and CI package sharding."""
 
 from __future__ import annotations

--- a/sdk/conformance/aarp-corpus-gate.sh
+++ b/sdk/conformance/aarp-corpus-gate.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Cross-language AARP assurance-envelope conformance gate.
 #
 # Runs the four reference verifiers (Go, TypeScript, Rust, Python) over the

--- a/sdk/conformance/check-corpus-drift.sh
+++ b/sdk/conformance/check-corpus-drift.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Drift guard for the vendored conformance corpus.
 #
 # The corpus under testdata/corpus is a VENDORED copy of the master maintained

--- a/sdk/conformance/check-killsuite-drift.sh
+++ b/sdk/conformance/check-killsuite-drift.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Drift check for the Evidence Theater Kill Suite.
 #
 # The kill suite is GENERATED in this repo by the Go reference verifier (it needs

--- a/sdk/conformance/corpus-gate.sh
+++ b/sdk/conformance/corpus-gate.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Cross-language receipt-verifier conformance gate.
 #
 # Runs the four reference verifiers (Go, TypeScript, Rust, Python) over every

--- a/sdk/verifiers/rust/build.rs
+++ b/sdk/verifiers/rust/build.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() {
     // The schema is vendored into the crate root so the crate is self-contained
     // for `cargo publish`. Watch the in-crate copy, not the canonical source

--- a/sdk/verifiers/rust/src/audit_packet.rs
+++ b/sdk/verifiers/rust/src/audit_packet.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::chain::{compute_totals, verify_chain_with_options};
 use crate::recorder::extract_receipts;
 use crate::schema::validate_audit_packet;

--- a/sdk/verifiers/rust/src/canonical.rs
+++ b/sdk/verifiers/rust/src/canonical.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde_json::{Map, Number, Value};
 use unicode_normalization::UnicodeNormalization;
 

--- a/sdk/verifiers/rust/src/chain.rs
+++ b/sdk/verifiers/rust/src/chain.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::canonical::{canonicalize_jcs_value, canonicalize_receipt};
 use crate::signing::{
     normalize_evidence_receipt, verify_receipt, verify_receipt_with_options,

--- a/sdk/verifiers/rust/src/cli.rs
+++ b/sdk/verifiers/rust/src/cli.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::audit_packet::{verify_audit_packet, AuditPacketOptions};
 use crate::chain::verify_chain_with_options;
 use crate::output::{emit_audit_packet, emit_chain, emit_receipt};

--- a/sdk/verifiers/rust/src/lib.rs
+++ b/sdk/verifiers/rust/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod aarp;
 pub mod audit_packet;
 pub mod canonical;

--- a/sdk/verifiers/rust/src/main.rs
+++ b/sdk/verifiers/rust/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() {
     let args = std::env::args().skip(1).collect::<Vec<_>>();
     match pipelock_verifier_rs::cli::run(&args) {

--- a/sdk/verifiers/rust/src/output.rs
+++ b/sdk/verifiers/rust/src/output.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::types::{AuditPacketReport, ChainCommandReport, ReceiptReport};
 use crate::util::{Result, VerifierError};
 

--- a/sdk/verifiers/rust/src/receipt.rs
+++ b/sdk/verifiers/rust/src/receipt.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::signing::{
     normalize_evidence_receipt, verify_receipt_with_options, UNPINNED_RECEIPT_BANNER,
 };

--- a/sdk/verifiers/rust/src/recorder.rs
+++ b/sdk/verifiers/rust/src/recorder.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::types::Receipt;
 use crate::util::{parse_json_line, reject_duplicate_keys, Result, VerifierError};
 use std::fs;

--- a/sdk/verifiers/rust/src/schema.rs
+++ b/sdk/verifiers/rust/src/schema.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::types::{AuditPacket, Totals};
 use jsonschema::{Draft, JSONSchema};
 use serde_json::Value;

--- a/sdk/verifiers/rust/src/signing.rs
+++ b/sdk/verifiers/rust/src/signing.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::canonical::{canonicalize_action_record, canonicalize_jcs_value};
 use crate::types::Receipt;
 use crate::util::{decode_hex, VerifierError};

--- a/sdk/verifiers/rust/src/strict.rs
+++ b/sdk/verifiers/rust/src/strict.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 //! Strict v1-receipt schema validation (the EV2-FU-1 verifier contract).
 //!
 //! A signed v1 receipt and every signed object nested inside it

--- a/sdk/verifiers/rust/src/types.rs
+++ b/sdk/verifiers/rust/src/types.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::Serialize;
 use serde_json::Value;
 

--- a/sdk/verifiers/rust/src/util.rs
+++ b/sdk/verifiers/rust/src/util.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use base64::Engine;
 use serde_json::Value;
 use sha2::{Digest, Sha256};

--- a/sdk/verifiers/rust/tests/audit_packet.rs
+++ b/sdk/verifiers/rust/tests/audit_packet.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod common;
 
 use pipelock_verifier_rs::audit_packet::{verify_audit_packet, AuditPacketOptions};

--- a/sdk/verifiers/rust/tests/canonical.rs
+++ b/sdk/verifiers/rust/tests/canonical.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "256"]
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
 
 use pipelock_verifier_rs::canonical::{canonicalize_action_record, canonicalize_receipt};
 use pipelock_verifier_rs::signing::verify_receipt_with_options;

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod common;
 
 use ed25519_dalek::{Signer, SigningKey};

--- a/sdk/verifiers/rust/tests/common.rs
+++ b/sdk/verifiers/rust/tests/common.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::PathBuf;
 
 pub fn repo_root() -> PathBuf {

--- a/sdk/verifiers/rust/tests/conformance_corpus.rs
+++ b/sdk/verifiers/rust/tests/conformance_corpus.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Cross-language conformance corpus checks for the Rust verifier. Paths are
 // relative to the crate directory (cargo test CWD), matching the vendored
 // corpus shared by all four reference verifiers.

--- a/sdk/verifiers/rust/tests/receipt.rs
+++ b/sdk/verifiers/rust/tests/receipt.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod common;
 
 use base64::Engine;

--- a/sdk/verifiers/rust/tests/schema.rs
+++ b/sdk/verifiers/rust/tests/schema.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 mod common;
 
 use pipelock_verifier_rs::schema::validate_audit_packet;

--- a/sdk/verifiers/rust/tests/util.rs
+++ b/sdk/verifiers/rust/tests/util.rs
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use pipelock_verifier_rs::util::resolve_artifact_path;
 use std::fs;
 

--- a/sdk/verifiers/ts/src/audit-packet.ts
+++ b/sdk/verifiers/ts/src/audit-packet.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { readFileSync } from "node:fs";
 import type { AuditPacket, AuditPacketReport, ChainResult, Receipt, Totals } from "./types.js";
 import { computeTotals, verifyChain } from "./chain.js";

--- a/sdk/verifiers/ts/src/canonical.ts
+++ b/sdk/verifiers/ts/src/canonical.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import type { ActionRecord, Receipt, JSONValue } from "./types.js";
 
 type FieldSpec = readonly [name: string, omitempty: boolean, nested?: NestedKind];

--- a/sdk/verifiers/ts/src/chain.ts
+++ b/sdk/verifiers/ts/src/chain.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { createHash } from "node:crypto";
 import type { ChainResult, Receipt } from "./types.js";
 import { canonicalizeReceipt } from "./canonical.js";

--- a/sdk/verifiers/ts/src/cli.ts
+++ b/sdk/verifiers/ts/src/cli.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { statSync } from "node:fs";
 import * as path from "node:path";
 import { parseArgs } from "node:util";

--- a/sdk/verifiers/ts/src/output.ts
+++ b/sdk/verifiers/ts/src/output.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import type { AuditPacketReport } from "./types.js";
 import type { ReceiptReport } from "./receipt.js";
 import type { ChainCommandReport } from "./cli.js";

--- a/sdk/verifiers/ts/src/receipt.ts
+++ b/sdk/verifiers/ts/src/receipt.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import type { Receipt } from "./types.js";

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import * as path from "node:path";
 import type { Receipt, RecorderEntry } from "./types.js";

--- a/sdk/verifiers/ts/src/schema.ts
+++ b/sdk/verifiers/ts/src/schema.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";

--- a/sdk/verifiers/ts/src/signing.ts
+++ b/sdk/verifiers/ts/src/signing.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { createHash } from "node:crypto";
 import * as ed25519 from "@noble/ed25519";
 import type { ActionRecord, JSONObject, Receipt } from "./types.js";

--- a/sdk/verifiers/ts/src/strict.ts
+++ b/sdk/verifiers/ts/src/strict.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 // Strict v1-receipt schema validation (the EV2-FU-1 verifier contract).
 //
 // A signed v1 receipt and every signed object nested inside it (action_record,

--- a/sdk/verifiers/ts/src/types.ts
+++ b/sdk/verifiers/ts/src/types.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 export type JSONValue =
   | null
   | boolean

--- a/sdk/verifiers/ts/src/util.ts
+++ b/sdk/verifiers/ts/src/util.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import * as path from "node:path";

--- a/sdk/verifiers/ts/tests/audit-packet.test.ts
+++ b/sdk/verifiers/ts/tests/audit-packet.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/sdk/verifiers/ts/tests/canonical.test.ts
+++ b/sdk/verifiers/ts/tests/canonical.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { createHash } from "node:crypto";
 import test from "node:test";
 import assert from "node:assert/strict";

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";

--- a/sdk/verifiers/ts/tests/conformance-corpus.test.ts
+++ b/sdk/verifiers/ts/tests/conformance-corpus.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import assert from "node:assert/strict";

--- a/sdk/verifiers/ts/tests/receipt.test.ts
+++ b/sdk/verifiers/ts/tests/receipt.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";

--- a/sdk/verifiers/ts/tests/schema.test.ts
+++ b/sdk/verifiers/ts/tests/schema.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import assert from "node:assert/strict";

--- a/test/secureiqlab/scripts/fp-test.sh
+++ b/test/secureiqlab/scripts/fp-test.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # SecureIQLab Harness — False Positive Test Suite
 #
 # Sends 8 categories of benign traffic through pipelock and verifies

--- a/test/secureiqlab/scripts/smoke-test.sh
+++ b/test/secureiqlab/scripts/smoke-test.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # SecureIQLab Harness — Smoke Test
 #
 # Quick validation that all containers are healthy and pipelock is scanning.

--- a/tests/pentest.sh
+++ b/tests/pentest.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Section 10: Tool Call Policy
 #
 # Tests pre-execution policy blocking of dangerous tool calls: destructive ops,


### PR DESCRIPTION
## Summary

- reconcile public documentation with shipped behavior and evidence boundaries
- add current security-assurance and enterprise-readiness guidance
- add documentation, source-header, and reproducible-build CI controls
- apply copyright and SPDX notices across tracked source