### PR TITLE
feat(config): recognize the HTTP QUERY method

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3111,7 +3111,7 @@ reverse_proxy:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `profile` | `""` | Empty keeps generic reverse-proxy behavior. `submit` enables the constrained submission gate. |
-| `allowed_methods` | `["POST"]` | HTTP methods allowed by the submit listener. Values must be known methods. |
+| `allowed_methods` | `["POST"]` | HTTP methods allowed by the submit listener. Values must be known methods (the standard verbs plus the safe body-bearing `QUERY` method). |
 | `allowed_paths` | required | Exact canonical paths allowed by the submit listener. Entries must start with `/`; encoded dot, slash, backslash, semicolon path parameters, and non-canonical request paths are rejected. |
 | `trusted_upstream` | required | Auditable host+port trust declaration. `host` and `port` must exactly match `upstream`; IP literals are rejected; `reason` and `added` are required; expired `expires` dates fail config load. |
 | `max_body_bytes` | required | Positive listener body cap. The effective cap is the smaller of this value and `request_body_scanning.max_body_bytes`. |

--- a/docs/guides/request-policy.md
+++ b/docs/guides/request-policy.md
@@ -143,7 +143,10 @@ A request that tunnels a different verb through `X-HTTP-Method-Override`,
 method and the overridden method, and the stricter result wins. This stops a `POST`
 with `X-HTTP-Method-Override: DELETE` from dodging a `DELETE`-scoped rule, and
 equally stops a real `POST` from being downgraded by an override the upstream
-ignores.
+ignores. The recognized verbs include the HTTP `QUERY` method
+(draft-ietf-httpbis-safe-method-w-body), a safe method that carries a request
+body; `methods: ["QUERY"]` is valid in a route and its body is scanned like any
+other body-bearing request.
 
 ## Transport coverage
 

--- a/internal/config/requestpolicy_validate_test.go
+++ b/internal/config/requestpolicy_validate_test.go
@@ -132,6 +132,22 @@ func TestValidateRequestPolicy_Errors(t *testing.T) {
 
 // Disabled sections are still structurally validated so dormant bad config
 // cannot activate silently on reload.
+func TestValidHTTPMethodRecognizesQuery(t *testing.T) {
+	if !validHTTPMethod("QUERY") {
+		t.Fatal("validHTTPMethod(QUERY) = false, want true (the HTTP QUERY method must be a valid request_policy method)")
+	}
+	if validHTTPMethod("FOO") {
+		t.Fatal("validHTTPMethod(FOO) = true, want false")
+	}
+}
+
+func TestValidateRequestPolicy_RequestPolicyQueryMethodAccepted(t *testing.T) {
+	cfg := enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Methods: []string{"QUERY"}}})
+	if _, err := cfg.ValidateWithWarnings(); err != nil {
+		t.Fatalf("request_policy rule with QUERY method must validate, got %v", err)
+	}
+}
+
 func TestValidateRequestPolicy_DormantValidation(t *testing.T) {
 	c := Defaults()
 	c.RequestPolicy = RequestPolicy{

--- a/internal/config/reverse_submit_validate_test.go
+++ b/internal/config/reverse_submit_validate_test.go
@@ -219,6 +219,14 @@ func TestValidate_ReverseProxySubmit_UnknownMethodRejected(t *testing.T) {
 	}
 }
 
+func TestValidate_ReverseProxySubmit_QueryMethodAccepted(t *testing.T) {
+	cfg := submitValidCfg()
+	cfg.ReverseProxy.AllowedMethods = []string{"QUERY"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("QUERY method must be accepted in reverse_proxy.allowed_methods, got %v", err)
+	}
+}
+
 func TestValidate_ReverseProxySubmit_BodyBytesRequiredPositive(t *testing.T) {
 	cfg := submitValidCfg()
 	cfg.ReverseProxy.MaxBodyBytes = 0

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1695,11 +1695,21 @@ func validateRequestPolicyDiscriminator(rule string, d *RequestPolicyDiscriminat
 	return nil
 }
 
+// methodQuery is the HTTP QUERY method (draft-ietf-httpbis-safe-method-w-body).
+// Go's net/http has no constant for it. It is a safe method that carries a
+// request body, so operators may want to name it in request_policy rules and
+// reverse_proxy allow-lists.
+const methodQuery = "QUERY"
+
 func validHTTPMethod(m string) bool {
 	switch m {
 	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
 		http.MethodPatch, http.MethodDelete, http.MethodConnect,
-		http.MethodOptions, http.MethodTrace:
+		http.MethodOptions, http.MethodTrace,
+		// The HTTP QUERY method (draft-ietf-httpbis-safe-method-w-body) is a
+		// safe method that carries a request body; recognize it so operators
+		// can write request_policy rules that target QUERY requests.
+		methodQuery:
 		return true
 	default:
 		return false
@@ -3046,7 +3056,7 @@ func (c *Config) validateReverseProxySubmit(u *url.URL) error {
 	for i, m := range rp.AllowedMethods {
 		switch strings.ToUpper(m) {
 		case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
-			http.MethodPatch, http.MethodDelete, http.MethodOptions:
+			http.MethodPatch, http.MethodDelete, http.MethodOptions, methodQuery:
 		default:
 			return fmt.Errorf("reverse_proxy.allowed_methods[%d] %q is not a recognized HTTP method", i, m)
 		}

--- a/internal/metrics/normalize_test.go
+++ b/internal/metrics/normalize_test.go
@@ -20,6 +20,7 @@ func TestNormalizeHTTPMethod(t *testing.T) {
 		{"PATCH", "PATCH", "PATCH"},
 		{"HEAD", "HEAD", "HEAD"},
 		{"OPTIONS", "OPTIONS", "OPTIONS"},
+		{"QUERY", "QUERY", "QUERY"},
 		{"unknown TRACE", "TRACE", "OTHER"},
 		{"unknown CONNECT", "CONNECT", "OTHER"},
 		{"empty string", "", "OTHER"},

--- a/internal/metrics/proxy.go
+++ b/internal/metrics/proxy.go
@@ -170,7 +170,7 @@ func (m *Metrics) RecordReverseProxyScanBlocked(direction, reason string) {
 // Unknown methods are grouped as "OTHER" to prevent cardinality explosion.
 func normalizeHTTPMethod(method string) string {
 	switch method {
-	case "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS":
+	case "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "QUERY":
 		return method
 	default:
 		return "OTHER"

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -233,9 +233,9 @@ func liveRunProxyConfig(opts LiveRunOpts) (*config.Config, error) {
 		cfg.BindDefaultAgentIdentity = true
 
 		// The benign read host is the one approved interactive destination, so lock
-		// it to reads: a request_policy rule blocks the standard write methods at
-		// the proxy (with a signed receipt), so a shell `curl -X POST` cannot use
-		// the approved host as a body-exfil channel. NOTE: this is a method
+		// it to reads: a request_policy rule blocks the standard write/body-bearing
+		// methods at the proxy (with a signed receipt), so a shell `curl -X POST`
+		// cannot use the approved host as a body-exfil channel. NOTE: this is a method
 		// deny-list, not a true default-deny "only GET" route (an exotic custom
 		// verb is not covered here -- the SafeTarget handler 405s those as
 		// defense-in-depth). Route-level default-deny allow-routes with receipts is
@@ -249,7 +249,7 @@ func liveRunProxyConfig(opts LiveRunOpts) (*config.Config, error) {
 			Action: config.ActionBlock,
 			Route: config.RequestPolicyRoute{
 				Hosts:   []string{liveRunSafeHost},
-				Methods: []string{"POST", "PUT", "PATCH", "DELETE"},
+				Methods: []string{"POST", "PUT", "PATCH", "DELETE", "QUERY"},
 			},
 			Reason: "benign lab read host is GET-only; a write method could carry a secret body",
 		})

--- a/internal/proxy/requestpolicy_enforcement_test.go
+++ b/internal/proxy/requestpolicy_enforcement_test.go
@@ -95,6 +95,25 @@ func TestEvaluateRequestPolicy_MethodOverrideCannotDowngrade(t *testing.T) {
 	}
 }
 
+func TestEvaluateRequestPolicy_QueryMatchesAndOverrideIsDoubleChecked(t *testing.T) {
+	t.Parallel()
+
+	p := newTestProxyWithConfig(t, reqPolicyConfig(blockRule("QUERY")))
+	if d := p.evaluateRequestPolicy(rpTestHost, "QUERY", http.Header{}, "/v1/search", "", requestPolicyBody{}); d.Action != config.ActionBlock {
+		t.Fatalf("real QUERY request should match QUERY-scoped rule, got action=%q", d.Action)
+	}
+
+	h := http.Header{}
+	h.Set("X-HTTP-Method-Override", "QUERY")
+	if d := p.evaluateRequestPolicy(rpTestHost, http.MethodPost, h, "/v1/search", "", requestPolicyBody{}); d.Action != config.ActionBlock {
+		t.Fatalf("POST with override QUERY should match QUERY-scoped rule, got action=%q", d.Action)
+	}
+
+	if d := p.evaluateRequestPolicy(rpTestHost, http.MethodPost, http.Header{}, "/v1/search", "", requestPolicyBody{}); d.Matched() {
+		t.Fatalf("bare POST should not match a QUERY-only rule, got %+v", d)
+	}
+}
+
 // --- Shared helper: block / warn / shadow + metric + receipt ----------------
 
 func TestApplyRequestPolicy_Outcomes(t *testing.T) {

--- a/internal/proxy/reverse_submit_test.go
+++ b/internal/proxy/reverse_submit_test.go
@@ -158,6 +158,46 @@ func TestSubmitProfile_BodyDLPBlocksBeforeForward(t *testing.T) {
 	}
 }
 
+func TestSubmitProfile_QueryBodyDLPBlocksBeforeForward(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		upstreamHit.Store(true)
+		t.Errorf("upstream MUST NOT be invoked when QUERY body trips DLP; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	cfg.ReverseProxy.AllowedMethods = []string{"QUERY"}
+	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
+
+	body := `{"k":"AKIA` + `IOSFODNN7EXAMPLE"}`
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		"QUERY",
+		proxy.URL+"/v1/batch",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (QUERY DLP body match must block)", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.DLPMatch) {
+		t.Errorf("block reason = %q, want %s", got, blockreason.DLPMatch)
+	}
+	if upstreamHit.Load() {
+		t.Error("upstream was invoked despite QUERY body DLP block - fail-closed contract violated")
+	}
+}
+
 // TestSubmitProfile_MethodNotAllowed verifies the per-listener method
 // allowlist rejects requests with a non-allowed method before any
 // scanning or upstream dial.

--- a/internal/receipt/classify.go
+++ b/internal/receipt/classify.go
@@ -9,14 +9,22 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/session"
 )
 
+// methodQuery is the HTTP QUERY method (draft-ietf-httpbis-safe-method-w-body).
+// It is defined safe and idempotent but carries a request body. Go's net/http
+// has no constant for it. For risk, side-effect, and taint purposes Pipelock
+// classifies QUERY with the body-bearing write methods rather than the bodyless
+// safe methods: the body is an exfil vector and a non-conformant upstream may
+// treat QUERY as mutating, so the conservative (fail-closed) grouping applies.
+const methodQuery = "QUERY"
+
 // ClassifyHTTP infers an action type from an HTTP method.
-// GET/HEAD/OPTIONS → read, POST/PUT/PATCH/DELETE → write.
+// GET/HEAD/OPTIONS → read, POST/PUT/PATCH/DELETE/QUERY → write.
 // Unknown methods are classified as unclassified (high-risk by definition).
 func ClassifyHTTP(method string) ActionType {
 	switch method {
 	case http.MethodGet, http.MethodHead, http.MethodOptions:
 		return ActionRead
-	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, methodQuery:
 		return ActionWrite
 	case http.MethodTrace:
 		return ActionRead
@@ -34,7 +42,7 @@ func SideEffectFromMethod(method string) SideEffectClass {
 	switch method {
 	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace, http.MethodConnect:
 		return SideEffectExternalRead
-	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, methodQuery:
 		return SideEffectExternalWrite
 	default:
 		return SideEffectNone
@@ -49,7 +57,7 @@ func ReversibilityFromMethod(method string) Reversibility {
 		return ReversibilityFull
 	case http.MethodDelete:
 		return ReversibilityIrreversible
-	case http.MethodPost, http.MethodPut, http.MethodPatch:
+	case http.MethodPost, http.MethodPut, http.MethodPatch, methodQuery:
 		return ReversibilityCompensatable
 	default:
 		return ReversibilityUnknown

--- a/internal/receipt/classify_test.go
+++ b/internal/receipt/classify_test.go
@@ -27,6 +27,7 @@ func TestClassifyHTTP(t *testing.T) {
 		{name: "PUT", method: http.MethodPut, want: ActionWrite},
 		{name: "PATCH", method: http.MethodPatch, want: ActionWrite},
 		{name: "DELETE", method: http.MethodDelete, want: ActionWrite},
+		{name: "QUERY", method: "QUERY", want: ActionWrite},
 		{name: "custom_method", method: "CUSTOM", want: ActionUnclassified},
 		{name: "empty_method", method: "", want: ActionUnclassified},
 	}
@@ -59,6 +60,7 @@ func TestSideEffectFromMethod(t *testing.T) {
 		{name: "PUT", method: http.MethodPut, want: SideEffectExternalWrite},
 		{name: "PATCH", method: http.MethodPatch, want: SideEffectExternalWrite},
 		{name: "DELETE", method: http.MethodDelete, want: SideEffectExternalWrite},
+		{name: "QUERY", method: "QUERY", want: SideEffectExternalWrite},
 		{name: "custom_method", method: "CUSTOM", want: SideEffectNone},
 		{name: "empty_method", method: "", want: SideEffectNone},
 	}
@@ -91,6 +93,7 @@ func TestReversibilityFromMethod(t *testing.T) {
 		{name: "POST", method: http.MethodPost, want: ReversibilityCompensatable},
 		{name: "PUT", method: http.MethodPut, want: ReversibilityCompensatable},
 		{name: "PATCH", method: http.MethodPatch, want: ReversibilityCompensatable},
+		{name: "QUERY", method: "QUERY", want: ReversibilityCompensatable},
 		{name: "custom_method", method: "CUSTOM", want: ReversibilityUnknown},
 		{name: "empty_method", method: "", want: ReversibilityUnknown},
 	}

--- a/internal/reqpolicy/policy.go
+++ b/internal/reqpolicy/policy.go
@@ -519,12 +519,21 @@ func isStandardMethod(method string) bool {
 	switch method {
 	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
 		http.MethodPatch, http.MethodDelete, http.MethodConnect,
-		http.MethodOptions, http.MethodTrace:
+		http.MethodOptions, http.MethodTrace,
+		// The HTTP QUERY method (draft-ietf-httpbis-safe-method-w-body). A
+		// method-override header carrying QUERY must be recognized so the
+		// dual base/override rule check cannot be evaded via QUERY.
+		methodQuery:
 		return true
 	default:
 		return false
 	}
 }
+
+// methodQuery is the HTTP QUERY method (draft-ietf-httpbis-safe-method-w-body),
+// a safe method that carries a request body. Go's net/http has no constant for
+// it.
+const methodQuery = "QUERY"
 
 // NormalizeHost lowercases a host and strips a DNS trailing dot, optional URL
 // scheme, and optional port. It is deliberately permissive because callers may

--- a/internal/reqpolicy/policy_test.go
+++ b/internal/reqpolicy/policy_test.go
@@ -306,6 +306,7 @@ func TestEffectiveMethod(t *testing.T) {
 		{"x-http-method-override", "POST", map[string]string{"X-HTTP-Method-Override": "DELETE"}, "DELETE"},
 		{"x-method-override", "POST", map[string]string{"X-Method-Override": "delete"}, "DELETE"},
 		{"x-http-method", "POST", map[string]string{"X-HTTP-Method": "PATCH"}, "PATCH"},
+		{"query override recognized as standard", "POST", map[string]string{"X-HTTP-Method-Override": "QUERY"}, "QUERY"},
 		{"invalid override falls back to base method", "POST", map[string]string{"X-HTTP-Method-Override": "DELETE, GET"}, "POST"},
 	}
 	for _, tc := range tests {

--- a/internal/session/taint_classify.go
+++ b/internal/session/taint_classify.go
@@ -126,6 +126,10 @@ func failSafeSensitivity(opts ClassificationOptions, confident bool) ActionSensi
 	return SensitivityNormal
 }
 
+// methodQuery is the HTTP QUERY method (draft-ietf-httpbis-safe-method-w-body),
+// a safe method that carries a request body. Go's net/http has no constant.
+const methodQuery = "QUERY"
+
 // ClassifyHTTPAction returns the taint policy action class for an HTTP request.
 func ClassifyHTTPAction(method, targetPath string, protectedPatterns, elevatedPatterns []string) (ActionClass, ActionSensitivity) {
 	classified := ClassifyHTTPActionWithOptions(method, targetPath, protectedPatterns, elevatedPatterns, ClassificationOptions{})
@@ -139,7 +143,10 @@ func ClassifyHTTPActionWithOptions(method, targetPath string, protectedPatterns,
 	switch strings.ToUpper(method) {
 	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
 		return ActionClassification{Class: ActionClassRead, Sensitivity: failSafeSensitivity(opts, pathClass.Confident), Confident: pathClass.Confident}
-	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, methodQuery:
+		// The HTTP QUERY method (draft-ietf-httpbis-safe-method-w-body) carries a
+		// request body; classify it with the body-bearing write methods so an
+		// agent cannot move a body to an upstream at lower taint risk than POST.
 		return ActionClassification{Class: ActionClassPublish, Sensitivity: pathClass.Sensitivity, Confident: pathClass.Confident}
 	default:
 		return ActionClassification{Class: ActionClassNetwork, Sensitivity: pathClass.Sensitivity, Confident: false}
@@ -417,7 +424,7 @@ func hasMutatingNetworkIntent(argsJSON string) bool {
 	}
 	lower := normalizeIntentJSON(argsJSON)
 	return containsAny(lower,
-		`"method":"post"`, `"method":"put"`, `"method":"patch"`, `"method":"delete"`,
+		`"method":"post"`, `"method":"put"`, `"method":"patch"`, `"method":"delete"`, `"method":"query"`,
 		`"webhook"`, `"endpoint"`, `"payload"`, `"request_body"`, `"form_data"`, `"upload"`)
 }
 
@@ -448,7 +455,7 @@ func hasMutatingNetworkMethod(argsJSON string) bool {
 	if !ok {
 		lower := normalizeIntentJSON(argsJSON)
 		return containsAny(lower,
-			`"method":"post"`, `"method":"put"`, `"method":"patch"`, `"method":"delete"`)
+			`"method":"post"`, `"method":"put"`, `"method":"patch"`, `"method":"delete"`, `"method":"query"`)
 	}
 	return jsonWalk(decoded, func(key string, value any) bool {
 		if !strings.EqualFold(key, "method") {
@@ -459,7 +466,7 @@ func hasMutatingNetworkMethod(argsJSON string) bool {
 			return false
 		}
 		switch strings.ToUpper(strings.TrimSpace(method)) {
-		case "POST", "PUT", "PATCH", "DELETE":
+		case "POST", "PUT", "PATCH", "DELETE", methodQuery:
 			return true
 		default:
 			return false

--- a/internal/session/taint_classify_test.go
+++ b/internal/session/taint_classify_test.go
@@ -174,6 +174,40 @@ func TestClassifyMCPToolCallWithOptions_FailSafeUnknownTool(t *testing.T) {
 	}
 }
 
+func TestClassifyHTTPAction_QueryIsPublish(t *testing.T) {
+	t.Parallel()
+
+	// The HTTP QUERY method carries a request body; it is classified with the
+	// body-bearing write methods (Publish), not the bodyless read methods, so an
+	// agent cannot move a body to an upstream at lower taint risk than POST.
+	class, _ := session.ClassifyHTTPAction("QUERY", "/search", nil, nil)
+	if class != session.ActionClassPublish {
+		t.Fatalf("ClassifyHTTPAction(QUERY) class = %v, want publish", class)
+	}
+}
+
+func TestClassifyMCPToolCall_QueryMethodIsMutatingNetworkIntent(t *testing.T) {
+	t.Parallel()
+
+	// An MCP tool call that tunnels a QUERY request (a body-bearing method)
+	// must classify as publish, exactly like POST — otherwise an agent could
+	// move a body to an upstream at lower taint risk by choosing QUERY. The
+	// neutral tool name "invoke" isolates the method-based classification: it
+	// matches no name heuristic, so only the QUERY method drives the verdict.
+	class, _, target := session.ClassifyMCPToolCall(
+		"invoke",
+		`{"method":"QUERY","url":"https://api.example.com/search"}`,
+		nil,
+		nil,
+	)
+	if class != session.ActionClassPublish {
+		t.Fatalf("ClassifyMCPToolCall(invoke, method=QUERY) class = %v, want publish", class)
+	}
+	if target != "https://api.example.com/search" {
+		t.Fatalf("target = %q, want the request URL", target)
+	}
+}
+
 func TestClassifyMCPToolCall_MutatingNetworkIntentWithSpacedJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

Pipelock now recognizes the HTTP QUERY method (draft-ietf-httpbis-safe-method-w-body) as a first-class method. It is accepted in `request_policy` rule method lists and in `reverse_proxy.allowed_methods`, recognized by the request-policy method-override evasion check, and given its own reverse-proxy metrics label instead of collapsing to `OTHER`.

## Why

QUERY is a safe method that carries a request body: the read semantics of GET with the body of POST, which is an exfil surface. Because it carries a body, it is classified with the body-bearing write methods everywhere risk, side-effect, action, and taint are inferred from the HTTP method, so an agent cannot move a request body to an upstream at lower taint or exfil risk by choosing QUERY over POST. The body is already scanned for DLP on body presence, independent of method. Operators can now write request_policy rules and reverse-proxy allow-lists that target QUERY.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the safe, body-bearing HTTP `QUERY` method across request policies, method overrides, reverse-proxy submit profiles, and request handling.
  * `QUERY` requests are now inspected for policy and DLP before forwarding, and are classified correctly for metrics and session/receipt behavior.
  * Updated enforcement to account for `QUERY` during override handling, including mutating-intent detection.
* **Documentation**
  * Clarified which HTTP method values are considered valid “known methods” and how method override rules treat `QUERY`.
* **Tests**
  * Added coverage for `QUERY` validation, classification, enforcement, and DLP blocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->