### PR TITLE
fix(config): make internal/config tests build on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,14 @@
 # Windows checkouts get CRLF and tests fail byte-for-byte against
 # the LF-committed goldens without any real content drift.
 **/testdata/** text eol=lf
+
+# Markdown is content-asserted by TestDocsDeclareLiveStatsAndDefaults, which
+# matches multi-line literals containing "\n". A CRLF working-tree checkout
+# breaks those matches on Windows for the same reason as the goldens above,
+# with no real content drift.
+*.md text eol=lf
+
+# gofumpt and the gofmt-family linters treat a CRLF file as unformatted, so a
+# Windows checkout with core.autocrlf=true (the Git for Windows default) makes
+# `make lint` report every Go file as needing formatting.
+*.go text eol=lf

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -233,10 +233,14 @@ jobs:
   # (#696) regress on real Windows undetected. This is a TARGETED lane, not full
   # parity: the full suite asserts Unix file modes that Go can't report on
   # Windows (it derives FileMode from the read-only attribute, never the ACL),
-  # and internal/config test files use unix-only syscalls. So we run the
-  # OS-split predicate plus the load/capture paths that #695/#696 touch, scoped
-  # with -run. config's perm behavior is proven transitively by the secperm
-  # Windows test (all masks skip when secperm.Enforced is false).
+  # so internal/config still has ~27 permission-model failures here. So we run
+  # the OS-split predicate plus the load/capture paths that #695/#696 touch,
+  # scoped with -run. config's perm behavior is proven transitively by the
+  # secperm Windows test (all masks skip when secperm.Enforced is false).
+  # internal/config's test package previously could not COMPILE on Windows
+  # (syscall.Mkfifo), which `go build ./...` cannot catch because it never
+  # builds _test.go files. The scoped run below compiles that package so the
+  # break cannot return silently.
   test-windows:
     needs: [security-scan]
     runs-on: windows-latest
@@ -271,6 +275,10 @@ jobs:
 
       - name: Baseline no-follow reads work on Windows
         run: go test -count=1 -run "TestWindows" ./internal/proxy/baseline/...
+
+      # Compiling this package is the point: it guards the Mkfifo-class break.
+      - name: internal/config test package builds on Windows
+        run: go test -count=1 -run "TestWindows" ./internal/config/...
 
   lint:
     needs: [security-scan]

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -9732,28 +9731,6 @@ func TestLicenseKeyFileOversized(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "exceeds") {
 		t.Errorf("error should mention exceeds, got: %v", err)
-	}
-}
-
-func TestLicenseKeyFileNonRegular(t *testing.T) {
-	tmp := t.TempDir()
-
-	fifoPath := filepath.Join(tmp, "license.token")
-	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
-		t.Skipf("cannot create FIFO: %v", err)
-	}
-
-	cfgPath := filepath.Join(tmp, "cfg.yaml")
-	if err := os.WriteFile(cfgPath, []byte(testLicenseFileCfg), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-
-	_, err := Load(cfgPath)
-	if err == nil {
-		t.Fatal("expected error for non-regular license_file")
-	}
-	if !strings.Contains(err.Error(), "regular file") {
-		t.Errorf("error should mention regular file, got: %v", err)
 	}
 }
 

--- a/internal/config/license_nonregular_test.go
+++ b/internal/config/license_nonregular_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// requireNonRegularLicenseRejected asserts that Load rejects a license_file
+// that is not a regular file. The caller creates the non-regular
+// license.token inside tmp using whatever mechanism its platform supports;
+// the security meaning of the rejection is identical either way.
+func requireNonRegularLicenseRejected(t *testing.T, tmp string) {
+	t.Helper()
+
+	cfgPath := filepath.Join(tmp, "cfg.yaml")
+	if err := os.WriteFile(cfgPath, []byte(testLicenseFileCfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for non-regular license_file")
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Errorf("error should mention regular file, got: %v", err)
+	}
+}

--- a/internal/config/license_nonregular_unix_test.go
+++ b/internal/config/license_nonregular_unix_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package config
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestLicenseKeyFileNonRegular covers the FIFO case called out in
+// (*Config).resolveLicenseKey: a FIFO can block the reader indefinitely, so it
+// must be rejected before any read is attempted.
+func TestLicenseKeyFileNonRegular(t *testing.T) {
+	tmp := t.TempDir()
+
+	fifoPath := filepath.Join(tmp, "license.token")
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Skipf("cannot create FIFO: %v", err)
+	}
+
+	requireNonRegularLicenseRejected(t, tmp)
+}

--- a/internal/config/license_nonregular_windows_test.go
+++ b/internal/config/license_nonregular_windows_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWindowsLicenseKeyFileNonRegular is the Windows counterpart to the FIFO
+// case in license_nonregular_unix_test.go. Windows has no mkfifo, but a
+// directory is equally non-regular, so it exercises the same
+// Mode().IsRegular() rejection in (*Config).resolveLicenseKey rather than
+// skipping the coverage entirely.
+func TestWindowsLicenseKeyFileNonRegular(t *testing.T) {
+	tmp := t.TempDir()
+
+	dirPath := filepath.Join(tmp, "license.token")
+	if err := os.Mkdir(dirPath, 0o750); err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+
+	requireNonRegularLicenseRejected(t, tmp)
+}


### PR DESCRIPTION
`internal/config` tests could not compile on Windows: `config_test.go` called `syscall.Mkfifo`, which does not exist there. Because the failure was at compile time, the package's existing `t.Skipf` fallback could never run, and every test in the package was unreachable on Windows — including the ones `make docs-check` and `make stats` depend on.

The Windows lane did not catch this: `go build ./...` never compiles `_test.go` files, and the targeted `go test` steps cover five other packages, none of which is `internal/config`.

## Changes

- **Split the FIFO case by build tag.** `license_nonregular_unix_test.go` keeps the FIFO, which is what `resolveLicenseKey` specifically guards against since a FIFO can block the reader. `license_nonregular_windows_test.go` uses a directory instead — Windows has no `mkfifo`, but a directory is equally non-regular, so it exercises the same `Mode().IsRegular()` rejection rather than dropping the coverage. `license_nonregular_test.go` holds the shared assertion.
- **Wire it into the Windows lane** so this cannot regress silently. Compiling the package is the actual guard; `go build ./...` cannot provide it. The stale lane comment claiming `internal/config` uses unix-only syscalls is updated.
- **Force LF for `*.md` and `*.go`.** Git for Windows defaults `core.autocrlf=true`, and a CRLF checkout breaks two gates with no real content drift: `TestDocsDeclareLiveStatsAndDefaults` matches multi-line literals containing `\n` (`docs_accuracy_test.go:26`), and gofumpt treats a CRLF file as unformatted, so `make lint` reports every Go file in the repo as needing formatting. This follows the existing `**/testdata/**` rule, present for the same reason.

No committed `.go` or `.md` blob contains CRLF today, so these rules normalize nothing and produce no renormalization diff. On Linux they are a no-op.

## Scope

This makes the package compile and fixes the doc and lint gates. **27 tests in `internal/config` still fail on Windows** — they assert Unix permission-model behavior (world-readable CA key, group-writable `license_file`, owner-executable `0o700`, private temp base). Those need either explicit Windows skips or ACL equivalents, which is a separate decision and is left untouched here.

## Verification

- `make docs-check` passes on Windows
- `golangci-lint run ./internal/config/...` — 0 issues
- `gofumpt -l .` clean
- `go vet ./...` clean repo-wide
- the new CI step runs and passes: `go test -count=1 -run TestWindows ./internal/config/...`

## Open question

The `.gitattributes` fix is surgical (`*.md`, `*.go`). A single `* text=auto eol=lf` would prevent the next instance of this class. Happy to switch if maintainers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Unix and Windows coverage to ensure license key paths that aren’t regular files (e.g., FIFOs or directories) are rejected with the expected error.
  * Updated the Windows CI lane to compile and run the Windows-specific configuration test subset.
* **Chores**
  * Standardized line endings for Markdown and Go files to prevent cross-platform formatting and byte/content matching issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->