### PR TITLE
feat(proxy): body-DLP tuning knobs and a distinct ssrf_dns_rebind reason

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -339,7 +339,7 @@ request_body_scanning:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `enabled` | `true` | Enable request body/header DLP scanning and request body prompt-injection scanning |
-| `action` | `warn` | `warn` logs ordinary findings, `block` rejects ordinary findings (requires enforce mode). Critical DLP and prompt-injection hard-blocks still reject non-provider destinations in enforce mode. |
+| `action` | `warn` | `warn` logs ordinary findings, `block` rejects ordinary findings (requires enforce mode). Immutable core DLP findings and prompt-injection hard-blocks still reject non-provider destinations in enforce mode; non-core DLP findings follow this action or a per-pattern override. |
 | `pattern_actions` | `{}` | Map of exact DLP pattern name to `warn` or `block` for request body/header DLP. The per-pattern action overrides `action` for that pattern only. Unknown pattern names and unsupported actions are rejected at config load. Immutable core DLP patterns cannot be downgraded to `warn`. |
 | `disable_patterns` | `[]` | Exact DLP pattern names to skip for request body/header DLP only. Unknown names are rejected at config load. Immutable core DLP patterns cannot be disabled. Disabling one pattern does not suppress other DLP matches in the same body or header set. |
 | `max_body_bytes` | `5242880` | Max body size to buffer; bodies exceeding this are always blocked (fail-closed) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,6 +321,9 @@ Scans request bodies and headers for secret exfiltration and prompt injection be
 request_body_scanning:
   enabled: true
   action: warn              # warn or block (no strip for bodies)
+  pattern_actions:          # optional per-DLP-pattern body/header action override
+    Custom Body Secret: warn
+  disable_patterns: []      # optional exact DLP pattern names to skip on this surface
   max_body_bytes: 5242880   # 5MB; fail-closed above this
   scan_headers: true        # scan request headers for DLP
   header_mode: sensitive    # "sensitive" (listed headers) or "all" (everything except ignore list)
@@ -337,6 +340,8 @@ request_body_scanning:
 |-------|---------|-------------|
 | `enabled` | `true` | Enable request body/header DLP scanning and request body prompt-injection scanning |
 | `action` | `warn` | `warn` logs ordinary findings, `block` rejects ordinary findings (requires enforce mode). Critical DLP and prompt-injection hard-blocks still reject non-provider destinations in enforce mode. |
+| `pattern_actions` | `{}` | Map of exact DLP pattern name to `warn` or `block` for request body/header DLP. The per-pattern action overrides `action` for that pattern only. Unknown pattern names and unsupported actions are rejected at config load. Immutable core DLP patterns cannot be downgraded to `warn`. |
+| `disable_patterns` | `[]` | Exact DLP pattern names to skip for request body/header DLP only. Unknown names are rejected at config load. Immutable core DLP patterns cannot be disabled. Disabling one pattern does not suppress other DLP matches in the same body or header set. |
 | `max_body_bytes` | `5242880` | Max body size to buffer; bodies exceeding this are always blocked (fail-closed) |
 | `scan_headers` | `true` | Scan request headers for DLP patterns |
 | `header_mode` | `sensitive` | `sensitive`: scan only listed headers. `all`: scan all headers except ignore list |
@@ -358,7 +363,9 @@ request_body_scanning:
 
 **Header scanning:** Headers are scanned regardless of destination host. An agent can exfiltrate secrets via `Authorization: Bearer <secret>` to any host, including allowlisted ones. The URL allowlist controls URL-level blocking, not header DLP bypass.
 
-**Security hard-blocks:** In enforce mode, critical-severity DLP findings in request bodies hard-block with `X-Pipelock-Block-Reason: dlp_match` even when `request_body_scanning.action: warn`. Request-body prompt-injection findings hard-block non-provider destinations with `X-Pipelock-Block-Reason: prompt_injection`. Operators that need audit-only rollout for selected critical patterns can set those individual patterns to `action: warn` or run the deployment with `enforce: false`.
+**Security hard-blocks:** In enforce mode, immutable core DLP findings in request bodies and headers hard-block with `X-Pipelock-Block-Reason: dlp_match` even when `request_body_scanning.action: warn`; they cannot be disabled or downgraded by `pattern_actions`. Request-body prompt-injection findings hard-block non-provider destinations with `X-Pipelock-Block-Reason: prompt_injection`. Operators that need audit-only rollout for selected non-core critical body-DLP patterns can set those exact names under `request_body_scanning.pattern_actions` with `warn`, or run the deployment with `enforce: false`.
+
+**Adaptive enforcement interaction:** A body/header DLP action of `warn`, including a per-pattern `pattern_actions` downgrade, still enters the existing adaptive enforcement path and can be upgraded to `block` unless the destination is adaptive-exempt. `disable_patterns` removes only the named DLP finding from this request-body/header surface; it does not create a destination exemption and does not affect URL, response, MCP, or file DLP scanning.
 
 **Note on security defaults:** Omitting `request_body_scanning.enabled` or `request_body_scanning.scan_headers` defaults both to `true`. Set either field to `false` explicitly only when you intend to disable that protection.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -322,7 +322,7 @@ request_body_scanning:
   enabled: true
   action: warn              # warn or block (no strip for bodies)
   pattern_actions:          # optional per-DLP-pattern body/header action override
-    Custom Body Secret: warn
+    Google API Key: warn
   disable_patterns: []      # optional exact DLP pattern names to skip on this surface
   max_body_bytes: 5242880   # 5MB; fail-closed above this
   scan_headers: true        # scan request headers for DLP

--- a/internal/blockreason/production_path_matrix_test.go
+++ b/internal/blockreason/production_path_matrix_test.go
@@ -104,16 +104,6 @@ var nonProductionEmitReasons = map[blockreason.Reason]string{
 	// alongside real blocks without forking into observed-vs-blocking.
 	blockreason.ContractObservedOnly: "shadow/capture mode annotation; never emitted on a block path",
 
-	// SSRFDNSRebind is part of the SSRF reason set on the wire, but the
-	// scanner pipeline currently emits SSRFPrivateIP / SSRFMetadata from
-	// the DNS rebinding TOCTOU path because the rebind detection lives
-	// upstream of the blockheaders helper that maps to the typed Reason.
-	// Vocabulary stays in the canonical allowlist so receipts and the
-	// public spec doc can name DNS rebinding distinctly from generic
-	// private-IP SSRF; the wire emit site lands when the SSRF block path
-	// is refactored to surface the more specific reason.
-	blockreason.SSRFDNSRebind: "vocabulary placeholder; SSRF block path collapses TOCTOU rebinds onto SSRFPrivateIP today",
-
 	// Timeout is reserved for fail-closed timeouts on scanner / HITL
 	// surfaces. Today the timeout paths return ParseError or do not
 	// surface a header at all (HITL has no HTTP response surface). The

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -293,7 +293,10 @@ const (
 	// exfiltration without bridging coordinated objects like "send your invoice
 	// and include your account token ... [billing]". See
 	// TestCore_MarkdownLinkCredentialExfiltrationIntentAnchor.
-	goldenHashDefaults = "f0368215f7fc693880af230b3f7a41bdfbc0b78adb9244418a532a817ff76a0f"
+	// Re-bumped for request_body_scanning.disable_patterns and pattern_actions:
+	// these per-pattern body/header DLP tuning knobs change enforcement and
+	// must flow into signed policy hashes, even when empty in defaults.
+	goldenHashDefaults = "c56bf20543cddac23d0828721a078181af0a845c50c83c983bd7210b8dd2810a"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -433,7 +436,7 @@ const (
 	// shifts in lockstep.
 	// Re-bumped for the Markdown Link Credential Exfiltration verb-to-noun
 	// separator. See goldenHashDefaults note above.
-	goldenHashRichConfig = "21595dabe082d838709dd9af8a6871e491672a77a056862e00ca7c2ccb0ee568"
+	goldenHashRichConfig = "cfc38baedc12555b6faeb3c308a86e39da1dee9e59c6cb6ab860adfd1df10cf6"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -362,25 +362,13 @@ func TestCanonicalPolicyHash_PolicyFieldsDoAffect(t *testing.T) {
 		{
 			name: "request_body_scanning.disable_patterns changed",
 			mut: func(c *Config) {
-				c.RequestBodyScanning.Enabled = true
-				c.DLP.Patterns = append(c.DLP.Patterns, DLPPattern{
-					Name:     "Custom Body Secret",
-					Regex:    `CUSTOMBODY-[A-Z0-9]{12}`,
-					Severity: SeverityCritical,
-				})
-				c.RequestBodyScanning.DisablePatterns = []string{"Custom Body Secret"}
+				c.RequestBodyScanning.DisablePatterns = []string{"Google API Key"}
 			},
 		},
 		{
 			name: "request_body_scanning.pattern_actions changed",
 			mut: func(c *Config) {
-				c.RequestBodyScanning.Enabled = true
-				c.DLP.Patterns = append(c.DLP.Patterns, DLPPattern{
-					Name:     "Custom Body Secret",
-					Regex:    `CUSTOMBODY-[A-Z0-9]{12}`,
-					Severity: SeverityCritical,
-				})
-				c.RequestBodyScanning.PatternActions = map[string]string{"Custom Body Secret": ActionWarn}
+				c.RequestBodyScanning.PatternActions = map[string]string{"Google API Key": ActionWarn}
 			},
 		},
 		{

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -360,6 +360,30 @@ func TestCanonicalPolicyHash_PolicyFieldsDoAffect(t *testing.T) {
 			},
 		},
 		{
+			name: "request_body_scanning.disable_patterns changed",
+			mut: func(c *Config) {
+				c.RequestBodyScanning.Enabled = true
+				c.DLP.Patterns = append(c.DLP.Patterns, DLPPattern{
+					Name:     "Custom Body Secret",
+					Regex:    `CUSTOMBODY-[A-Z0-9]{12}`,
+					Severity: SeverityCritical,
+				})
+				c.RequestBodyScanning.DisablePatterns = []string{"Custom Body Secret"}
+			},
+		},
+		{
+			name: "request_body_scanning.pattern_actions changed",
+			mut: func(c *Config) {
+				c.RequestBodyScanning.Enabled = true
+				c.DLP.Patterns = append(c.DLP.Patterns, DLPPattern{
+					Name:     "Custom Body Secret",
+					Regex:    `CUSTOMBODY-[A-Z0-9]{12}`,
+					Severity: SeverityCritical,
+				})
+				c.RequestBodyScanning.PatternActions = map[string]string{"Custom Body Secret": ActionWarn}
+			},
+		},
+		{
 			// Transport timeouts are enforcement-relevant (DoS
 			// exposure bound, tunnel lifetime) so they must flip ph.
 			// Listen / Upstream addresses are separately excluded as

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8764,6 +8764,86 @@ func TestValidate_RequestBodyScanning_ValidActions(t *testing.T) {
 	}
 }
 
+func TestValidate_RequestBodyScanning_PatternKnobs(t *testing.T) {
+	cases := []struct {
+		name            string
+		disablePatterns []string
+		patternActions  map[string]string
+		wantErr         string
+	}{
+		{
+			name:            "known disabled pattern",
+			disablePatterns: []string{"Custom Body Secret"},
+		},
+		{
+			name:           "known pattern action",
+			patternActions: map[string]string{"Custom Body Secret": ActionWarn},
+		},
+		{
+			name:            "core disabled pattern rejected",
+			disablePatterns: []string{"AWS Access ID"},
+			wantErr:         "immutable core DLP",
+		},
+		{
+			name:           "core warn downgrade rejected",
+			patternActions: map[string]string{"AWS Access ID": ActionWarn},
+			wantErr:        "immutable core DLP",
+		},
+		{
+			name:           "core block action allowed",
+			patternActions: map[string]string{"AWS Access ID": ActionBlock},
+		},
+		{
+			name:            "unknown disabled pattern rejected",
+			disablePatterns: []string{"No Such Pattern"},
+			wantErr:         "request_body_scanning.disable_patterns",
+		},
+		{
+			name:           "unknown pattern action rejected",
+			patternActions: map[string]string{"No Such Pattern": ActionWarn},
+			wantErr:        "request_body_scanning.pattern_actions",
+		},
+		{
+			name:           "invalid pattern action rejected",
+			patternActions: map[string]string{"Custom Body Secret": ActionAsk},
+			wantErr:        "request_body_scanning.pattern_actions",
+		},
+		{
+			name:            "pattern action cannot target disabled pattern",
+			disablePatterns: []string{"Custom Body Secret"},
+			patternActions:  map[string]string{"Custom Body Secret": ActionWarn},
+			wantErr:         "request_body_scanning.pattern_actions",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.RequestBodyScanning.Enabled = true
+			cfg.DLP.Patterns = append(cfg.DLP.Patterns, DLPPattern{
+				Name:     "Custom Body Secret",
+				Regex:    `CUSTOMBODY-[A-Z0-9]{12}`,
+				Severity: SeverityCritical,
+			})
+			cfg.RequestBodyScanning.DisablePatterns = tc.disablePatterns
+			cfg.RequestBodyScanning.PatternActions = tc.patternActions
+			err := cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() error = nil, want containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidate_RedactionRequiresRequestBodyScanning(t *testing.T) {
 	cfg := Defaults()
 	cfg.RequestBodyScanning.Enabled = false

--- a/internal/config/dlp_patterns.go
+++ b/internal/config/dlp_patterns.go
@@ -358,6 +358,22 @@ var coreOnlyDLPPatterns = []DLPPattern{
 	{Name: "GCP Service Account Key", Regex: `"type"\s*:\s*"service_account"`, Severity: SeverityCritical},
 }
 
+// IsCoreDLPPatternName reports whether name belongs to the immutable DLP
+// safety floor used by the scanner.
+func IsCoreDLPPatternName(name string) bool {
+	for _, coreName := range coreDLPPatternNames {
+		if name == coreName {
+			return true
+		}
+	}
+	for _, pattern := range coreOnlyDLPPatterns {
+		if name == pattern.Name {
+			return true
+		}
+	}
+	return false
+}
+
 // PresetDLPPatterns returns the generated DLP pattern set for a shipped preset
 // profile. Profile-specific deltas preserve current shipped YAML behavior.
 func PresetDLPPatterns(profile string) ([]DLPPattern, error) {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1165,13 +1165,15 @@ type A2ATrustedCardKey struct {
 // smuggled in Authorization/Cookie headers. CONNECT tunnels are out of scope
 // (TLS-encrypted, can't scan without MITM).
 type RequestBodyScanning struct {
-	Enabled          bool     `yaml:"enabled"`
-	Action           string   `yaml:"action"`            // warn, block (no strip for bodies)
-	MaxBodyBytes     int      `yaml:"max_body_bytes"`    // fail-closed above this limit
-	ScanHeaders      bool     `yaml:"scan_headers"`      // scan request headers for DLP
-	HeaderMode       string   `yaml:"header_mode"`       // "sensitive" (listed headers) or "all" (everything except ignore list)
-	SensitiveHeaders []string `yaml:"sensitive_headers"` // headers to scan in sensitive mode
-	IgnoreHeaders    []string `yaml:"ignore_headers"`    // headers to skip in all mode
+	Enabled          bool              `yaml:"enabled"`
+	Action           string            `yaml:"action"`            // warn, block (no strip for bodies)
+	PatternActions   map[string]string `yaml:"pattern_actions"`   // per-DLP-pattern action override: warn or block; cannot downgrade core DLP
+	DisablePatterns  []string          `yaml:"disable_patterns"`  // non-core DLP pattern names skipped by request body/header scanning
+	MaxBodyBytes     int               `yaml:"max_body_bytes"`    // fail-closed above this limit
+	ScanHeaders      bool              `yaml:"scan_headers"`      // scan request headers for DLP
+	HeaderMode       string            `yaml:"header_mode"`       // "sensitive" (listed headers) or "all" (everything except ignore list)
+	SensitiveHeaders []string          `yaml:"sensitive_headers"` // headers to scan in sensitive mode
+	IgnoreHeaders    []string          `yaml:"ignore_headers"`    // headers to skip in all mode
 }
 
 // CrossRequestDetection configures cross-request exfiltration detection.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2129,15 +2129,52 @@ func validOptionalCardOriginPort(hostport, port string) bool {
 }
 
 func (c *Config) validateRequestBodyScanning() error {
+	knownPatterns := c.effectiveBodyDLPPatternNames()
+	disabledPatterns := make(map[string]struct{}, len(c.RequestBodyScanning.DisablePatterns))
+	for i, pattern := range c.RequestBodyScanning.DisablePatterns {
+		if pattern == "" {
+			return fmt.Errorf("request_body_scanning.disable_patterns[%d] must not be empty", i)
+		}
+		if _, ok := knownPatterns[pattern]; !ok {
+			return fmt.Errorf("request_body_scanning.disable_patterns[%d] %q does not match any effective DLP pattern", i, pattern)
+		}
+		if IsCoreDLPPatternName(pattern) {
+			return fmt.Errorf("request_body_scanning.disable_patterns[%d] %q targets immutable core DLP and cannot be disabled", i, pattern)
+		}
+		disabledPatterns[pattern] = struct{}{}
+	}
+	for pattern, action := range c.RequestBodyScanning.PatternActions {
+		if pattern == "" {
+			return fmt.Errorf("request_body_scanning.pattern_actions contains an empty pattern name")
+		}
+		if _, ok := knownPatterns[pattern]; !ok {
+			return fmt.Errorf("request_body_scanning.pattern_actions[%q] does not match any effective DLP pattern", pattern)
+		}
+		switch action {
+		case ActionWarn, ActionBlock:
+			// valid
+		default:
+			return fmt.Errorf("request_body_scanning.pattern_actions[%q] has invalid action %q: must be warn or block", pattern, action)
+		}
+		if action == ActionWarn && IsCoreDLPPatternName(pattern) {
+			return fmt.Errorf("request_body_scanning.pattern_actions[%q] cannot downgrade immutable core DLP to warn", pattern)
+		}
+		if _, disabled := disabledPatterns[pattern]; disabled {
+			return fmt.Errorf("request_body_scanning.pattern_actions[%q] is inert because the pattern is also listed in request_body_scanning.disable_patterns", pattern)
+		}
+	}
+
 	// Validate request body scanning config
+	if c.RequestBodyScanning.Enabled {
+		switch c.RequestBodyScanning.Action {
+		case ActionWarn, ActionBlock:
+			// valid
+		default:
+			return fmt.Errorf("invalid request_body_scanning.action %q: must be warn or block", c.RequestBodyScanning.Action)
+		}
+	}
 	if !c.RequestBodyScanning.Enabled {
 		return nil
-	}
-	switch c.RequestBodyScanning.Action {
-	case ActionWarn, ActionBlock:
-		// valid
-	default:
-		return fmt.Errorf("invalid request_body_scanning.action %q: must be warn or block", c.RequestBodyScanning.Action)
 	}
 	if c.RequestBodyScanning.MaxBodyBytes <= 0 {
 		return fmt.Errorf("request_body_scanning.max_body_bytes must be positive")
@@ -2149,6 +2186,36 @@ func (c *Config) validateRequestBodyScanning() error {
 		return fmt.Errorf("invalid request_body_scanning.header_mode %q: must be sensitive or all", c.RequestBodyScanning.HeaderMode)
 	}
 	return nil
+}
+
+func (c *Config) effectiveBodyDLPPatternNames() map[string]struct{} {
+	names := make(map[string]struct{}, len(c.DLP.Patterns)+len(c.CanaryTokens.Tokens)+8)
+	for _, pattern := range CoreDLPPatterns() {
+		names[pattern.Name] = struct{}{}
+	}
+	for _, pattern := range c.DLP.Patterns {
+		if pattern.Name != "" {
+			names[pattern.Name] = struct{}{}
+		}
+	}
+	if c.SeedPhraseDetection.Enabled == nil || *c.SeedPhraseDetection.Enabled {
+		names["BIP-39 Seed Phrase"] = struct{}{}
+	}
+	names["Hostname Exfiltration"] = struct{}{}
+	if c.DLP.ScanEnv {
+		names["Environment Variable Leak"] = struct{}{}
+	}
+	if c.DLP.SecretsFile != "" {
+		names["Known Secret Leak"] = struct{}{}
+	}
+	if c.CanaryTokens.Enabled {
+		for _, token := range c.CanaryTokens.Tokens {
+			if token.Name != "" {
+				names["Canary Token ("+token.Name+")"] = struct{}{}
+			}
+		}
+	}
+	return names
 }
 
 func (c *Config) validateSeedPhraseDetection() error {

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -710,11 +710,12 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 }
 
 func scanBodyTextsForDLP(ctx context.Context, sc *scanner.Scanner, texts []string, target string, suppress []config.SuppressEntry, disabled map[string]struct{}) []scanner.TextDLPMatch {
+	var allMatches []scanner.TextDLPMatch
 	for _, text := range texts {
 		result := sc.ScanTextForDLP(ctx, text)
 		if !result.Clean {
 			if matches := filterBodyDLPMatches(result.Matches, target, suppress, disabled); len(matches) > 0 {
-				return matches
+				allMatches = append(allMatches, matches...)
 			}
 		}
 	}
@@ -722,10 +723,10 @@ func scanBodyTextsForDLP(ctx context.Context, sc *scanner.Scanner, texts []strin
 	result := sc.ScanTextForDLP(ctx, joined)
 	if !result.Clean {
 		if matches := filterBodyDLPMatches(result.Matches, target, suppress, disabled); len(matches) > 0 {
-			return matches
+			allMatches = append(allMatches, matches...)
 		}
 	}
-	return nil
+	return uniqueBodyDLPMatches(allMatches)
 }
 
 func (req BodyScanRequest) suppressTarget() string {
@@ -769,6 +770,23 @@ func bodyDLPDisabledSet(patterns []string) map[string]struct{} {
 		disabled[pattern] = struct{}{}
 	}
 	return disabled
+}
+
+func uniqueBodyDLPMatches(matches []scanner.TextDLPMatch) []scanner.TextDLPMatch {
+	if len(matches) <= 1 {
+		return matches
+	}
+	seen := make(map[string]struct{}, len(matches))
+	unique := make([]scanner.TextDLPMatch, 0, len(matches))
+	for _, match := range matches {
+		key := match.PatternName + "\x00" + match.Encoded
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, match)
+	}
+	return unique
 }
 
 func requestBodyDLPAction(matches []scanner.TextDLPMatch, defaultAction string, patternActions map[string]string) string {
@@ -1287,17 +1305,15 @@ func scanRequestHeadersForTarget(ctx context.Context, headers http.Header, cfg *
 func scanRequestHeadersWithSuppress(ctx context.Context, headers http.Header, cfg *config.Config, sc *scanner.Scanner, target string, suppress []config.SuppressEntry) *BodyScanResult {
 	bodyCfg := cfg.RequestBodyScanning
 	disabled := bodyDLPDisabledSet(bodyCfg.DisablePatterns)
-	resultForMatches := func(headerName string, matches []scanner.TextDLPMatch) *BodyScanResult {
-		matches = filterBodyDLPMatches(matches, target, suppress, disabled)
-		if len(matches) == 0 {
-			return nil
+	var allMatches []scanner.TextDLPMatch
+	matchedHeaders := map[string]struct{}{}
+	addMatches := func(headerName string, matches []scanner.TextDLPMatch) {
+		filtered := filterBodyDLPMatches(matches, target, suppress, disabled)
+		if len(filtered) == 0 {
+			return
 		}
-		return &BodyScanResult{
-			Clean:      false,
-			Action:     requestBodyDLPAction(matches, bodyCfg.Action, bodyCfg.PatternActions),
-			DLPMatches: matches,
-			HeaderName: headerName,
-		}
+		allMatches = append(allMatches, filtered...)
+		matchedHeaders[headerName] = struct{}{}
 	}
 
 	// Build the set of headers to scan based on mode.
@@ -1334,17 +1350,22 @@ func scanRequestHeadersWithSuppress(ctx context.Context, headers http.Header, cf
 	}
 
 	// Per-value scanning: catches per-header encoded secrets.
+	headerNames := make([]string, 0, len(headersToScan))
+	for name := range headersToScan {
+		headerNames = append(headerNames, name)
+	}
+	sort.Strings(headerNames)
+
 	var allValues []string
-	for name, values := range headersToScan {
+	for _, name := range headerNames {
+		values := headersToScan[name]
 		// In "all" mode, scan header names too (catches exfil via custom
 		// header names like X-AKIA1234). No noisy prefix skip: agents
 		// (unlike browsers) control all header names, including Sec-*.
 		if bodyCfg.HeaderMode == config.HeaderModeAll {
 			result := sc.ScanTextForDLP(ctx, name)
 			if !result.Clean {
-				if headerResult := resultForMatches(name, result.Matches); headerResult != nil {
-					return headerResult
-				}
+				addMatches(name, result.Matches)
 			}
 			// Include header name in joined scan to catch secrets split
 			// across the name:value boundary (e.g., X-AKIA1234: EXAMPLE).
@@ -1355,9 +1376,7 @@ func scanRequestHeadersWithSuppress(ctx context.Context, headers http.Header, cf
 			allValues = append(allValues, v)
 			result := sc.ScanTextForDLP(ctx, v)
 			if !result.Clean {
-				if headerResult := resultForMatches(name, result.Matches); headerResult != nil {
-					return headerResult
-				}
+				addMatches(name, result.Matches)
 			}
 			// In "all" mode, scan name+value concatenation to catch secrets
 			// split across the header name:value boundary.
@@ -1365,9 +1384,7 @@ func scanRequestHeadersWithSuppress(ctx context.Context, headers http.Header, cf
 				combined := name + v
 				combinedResult := sc.ScanTextForDLP(ctx, combined)
 				if !combinedResult.Clean {
-					if headerResult := resultForMatches(name, combinedResult.Matches); headerResult != nil {
-						return headerResult
-					}
+					addMatches(name, combinedResult.Matches)
 				}
 			}
 		}
@@ -1381,13 +1398,32 @@ func scanRequestHeadersWithSuppress(ctx context.Context, headers http.Header, cf
 		joined := strings.Join(allValues, "\n")
 		result := sc.ScanTextForDLP(ctx, joined)
 		if !result.Clean {
-			if headerResult := resultForMatches("(joined)", result.Matches); headerResult != nil {
-				return headerResult
-			}
+			addMatches("(joined)", result.Matches)
 		}
 	}
 
-	return nil
+	allMatches = uniqueBodyDLPMatches(allMatches)
+	if len(allMatches) == 0 {
+		return nil
+	}
+	return &BodyScanResult{
+		Clean:      false,
+		Action:     requestBodyDLPAction(allMatches, bodyCfg.Action, bodyCfg.PatternActions),
+		DLPMatches: allMatches,
+		HeaderName: headerDLPMatchSource(matchedHeaders),
+	}
+}
+
+func headerDLPMatchSource(headers map[string]struct{}) string {
+	switch len(headers) {
+	case 0:
+		return ""
+	case 1:
+		for header := range headers {
+			return header
+		}
+	}
+	return "(multiple)"
 }
 
 // evalHeaderDLP scans request headers, logs matches, and records metrics.

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -741,10 +741,6 @@ func (req BodyScanRequest) suppressTarget() string {
 	return req.Host + req.Path
 }
 
-func unsuppressedDLPMatches(matches []scanner.TextDLPMatch, target string, suppress []config.SuppressEntry) []scanner.TextDLPMatch {
-	return filterBodyDLPMatches(matches, target, suppress, nil)
-}
-
 func filterBodyDLPMatches(matches []scanner.TextDLPMatch, target string, suppress []config.SuppressEntry, disabled map[string]struct{}) []scanner.TextDLPMatch {
 	if len(matches) == 0 || len(suppress) == 0 || target == "" {
 		if len(matches) == 0 || len(disabled) == 0 {

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -407,9 +407,28 @@ func shouldHardBlockCriticalDLP(matches []scanner.TextDLPMatch, enforceEnabled b
 	return false
 }
 
+func shouldHardBlockRequestDLP(matches []scanner.TextDLPMatch, cfg *config.Config) bool {
+	if cfg == nil || !cfg.EnforceEnabled() {
+		return false
+	}
+	for _, match := range matches {
+		if match.Warn {
+			continue
+		}
+		if !strings.EqualFold(match.Severity, config.SeverityCritical) {
+			continue
+		}
+		if cfg.RequestBodyScanning.PatternActions[match.PatternName] == config.ActionWarn &&
+			!config.IsCoreDLPPatternName(match.PatternName) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 func shouldHardBlockBodyCriticalDLP(result BodyScanResult, hostname string, cfg *config.Config) bool {
-	enforceEnabled := cfg != nil && cfg.EnforceEnabled()
-	if !shouldHardBlockCriticalDLP(result.DLPMatches, enforceEnabled) {
+	if !shouldHardBlockRequestDLP(result.DLPMatches, cfg) {
 		return false
 	}
 	if result.RedactedDLPOnly &&
@@ -490,6 +509,12 @@ type BodyScanRequest struct {
 	Target string
 	// Suppress contains config-level finding suppressions.
 	Suppress []config.SuppressEntry
+	// Action is the global request_body_scanning.action for DLP matches.
+	Action string
+	// DisablePatterns lists DLP pattern names skipped by body/header scanning.
+	DisablePatterns []string
+	// PatternActions maps DLP pattern names to body/header-specific actions.
+	PatternActions map[string]string
 }
 
 // scanRequestBody reads, buffers, and scans an HTTP request body for
@@ -535,7 +560,7 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 	if req.RedactMatcher != nil {
 		texts, parseErr := extractBodyText(buf, req)
 		if parseErr == "" {
-			preRedactionDLP = scanBodyTextsForDLP(ctx, req.Scanner, texts, req.suppressTarget(), req.Suppress)
+			preRedactionDLP = scanBodyTextsForDLP(ctx, req.Scanner, texts, req.suppressTarget(), req.Suppress, bodyDLPDisabledSet(req.DisablePatterns))
 		}
 	}
 
@@ -599,6 +624,7 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 		if len(preRedactionDLP) > 0 {
 			return buf, BodyScanResult{
 				Clean:           false,
+				Action:          requestBodyDLPAction(preRedactionDLP, req.Action, req.PatternActions),
 				DLPMatches:      preRedactionDLP,
 				RedactedDLPOnly: redactReport != nil && redactReport.Applied,
 				RedactionReport: redactReport,
@@ -608,9 +634,10 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 	}
 
 	// Scan each extracted string individually (catches per-field encoded secrets).
-	if matches := scanBodyTextsForDLP(ctx, req.Scanner, texts, req.suppressTarget(), req.Suppress); len(matches) > 0 {
+	if matches := scanBodyTextsForDLP(ctx, req.Scanner, texts, req.suppressTarget(), req.Suppress, bodyDLPDisabledSet(req.DisablePatterns)); len(matches) > 0 {
 		return buf, BodyScanResult{
 			Clean:           false,
+			Action:          requestBodyDLPAction(matches, req.Action, req.PatternActions),
 			DLPMatches:      matches,
 			RedactionReport: redactReport,
 		}
@@ -618,6 +645,7 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 	if len(preRedactionDLP) > 0 {
 		return buf, BodyScanResult{
 			Clean:           false,
+			Action:          requestBodyDLPAction(preRedactionDLP, req.Action, req.PatternActions),
 			DLPMatches:      preRedactionDLP,
 			RedactedDLPOnly: redactReport != nil && redactReport.Applied,
 			RedactionReport: redactReport,
@@ -681,11 +709,11 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 	return buf, BodyScanResult{Clean: true, RedactionReport: redactReport}
 }
 
-func scanBodyTextsForDLP(ctx context.Context, sc *scanner.Scanner, texts []string, target string, suppress []config.SuppressEntry) []scanner.TextDLPMatch {
+func scanBodyTextsForDLP(ctx context.Context, sc *scanner.Scanner, texts []string, target string, suppress []config.SuppressEntry, disabled map[string]struct{}) []scanner.TextDLPMatch {
 	for _, text := range texts {
 		result := sc.ScanTextForDLP(ctx, text)
 		if !result.Clean {
-			if matches := unsuppressedDLPMatches(result.Matches, target, suppress); len(matches) > 0 {
+			if matches := filterBodyDLPMatches(result.Matches, target, suppress, disabled); len(matches) > 0 {
 				return matches
 			}
 		}
@@ -693,7 +721,7 @@ func scanBodyTextsForDLP(ctx context.Context, sc *scanner.Scanner, texts []strin
 	joined := strings.Join(sortedBodyTexts(texts), bodyDLPJoinSeparator)
 	result := sc.ScanTextForDLP(ctx, joined)
 	if !result.Clean {
-		if matches := unsuppressedDLPMatches(result.Matches, target, suppress); len(matches) > 0 {
+		if matches := filterBodyDLPMatches(result.Matches, target, suppress, disabled); len(matches) > 0 {
 			return matches
 		}
 	}
@@ -714,17 +742,54 @@ func (req BodyScanRequest) suppressTarget() string {
 }
 
 func unsuppressedDLPMatches(matches []scanner.TextDLPMatch, target string, suppress []config.SuppressEntry) []scanner.TextDLPMatch {
+	return filterBodyDLPMatches(matches, target, suppress, nil)
+}
+
+func filterBodyDLPMatches(matches []scanner.TextDLPMatch, target string, suppress []config.SuppressEntry, disabled map[string]struct{}) []scanner.TextDLPMatch {
 	if len(matches) == 0 || len(suppress) == 0 || target == "" {
-		return matches
+		if len(matches) == 0 || len(disabled) == 0 {
+			return matches
+		}
 	}
 	filtered := matches[:0]
 	for _, match := range matches {
+		if _, skip := disabled[match.PatternName]; skip && !config.IsCoreDLPPatternName(match.PatternName) {
+			continue
+		}
 		if config.IsSuppressed(match.PatternName, target, suppress) {
 			continue
 		}
 		filtered = append(filtered, match)
 	}
 	return filtered
+}
+
+func bodyDLPDisabledSet(patterns []string) map[string]struct{} {
+	if len(patterns) == 0 {
+		return nil
+	}
+	disabled := make(map[string]struct{}, len(patterns))
+	for _, pattern := range patterns {
+		disabled[pattern] = struct{}{}
+	}
+	return disabled
+}
+
+func requestBodyDLPAction(matches []scanner.TextDLPMatch, defaultAction string, patternActions map[string]string) string {
+	action := ""
+	for _, match := range matches {
+		matchAction := defaultAction
+		if override := patternActions[match.PatternName]; override != "" && !config.IsCoreDLPPatternName(match.PatternName) {
+			matchAction = override
+		}
+		if matchAction == config.ActionBlock {
+			return config.ActionBlock
+		}
+		if matchAction == config.ActionWarn {
+			action = config.ActionWarn
+		}
+	}
+	return action
 }
 
 func sortedBodyTexts(texts []string) []string {
@@ -1225,15 +1290,15 @@ func scanRequestHeadersForTarget(ctx context.Context, headers http.Header, cfg *
 
 func scanRequestHeadersWithSuppress(ctx context.Context, headers http.Header, cfg *config.Config, sc *scanner.Scanner, target string, suppress []config.SuppressEntry) *BodyScanResult {
 	bodyCfg := cfg.RequestBodyScanning
+	disabled := bodyDLPDisabledSet(bodyCfg.DisablePatterns)
 	resultForMatches := func(headerName string, matches []scanner.TextDLPMatch) *BodyScanResult {
-		if len(suppress) > 0 {
-			matches = unsuppressedDLPMatches(matches, target, suppress)
-			if len(matches) == 0 {
-				return nil
-			}
+		matches = filterBodyDLPMatches(matches, target, suppress, disabled)
+		if len(matches) == 0 {
+			return nil
 		}
 		return &BodyScanResult{
 			Clean:      false,
+			Action:     requestBodyDLPAction(matches, bodyCfg.Action, bodyCfg.PatternActions),
 			DLPMatches: matches,
 			HeaderName: headerName,
 		}
@@ -1362,8 +1427,11 @@ func (p *Proxy) evalHeaderDLP(ctx context.Context, e headerDLPParams) (blocked b
 	if headerResult == nil {
 		return false, false
 	}
-	action := e.cfg.RequestBodyScanning.Action
-	headerHardBlock := shouldHardBlockCriticalDLP(headerResult.DLPMatches, e.cfg.EnforceEnabled())
+	action := headerResult.Action
+	if action == "" {
+		action = e.cfg.RequestBodyScanning.Action
+	}
+	headerHardBlock := shouldHardBlockRequestDLP(headerResult.DLPMatches, e.cfg)
 	if headerHardBlock {
 		action = config.ActionBlock
 	}

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -110,6 +110,7 @@ func TestScanRequestBody_DisablePatternsAndPatternActions(t *testing.T) {
 	cases := []struct {
 		name            string
 		body            string
+		defaultAction   string
 		disablePatterns []string
 		patternActions  map[string]string
 		wantClean       bool
@@ -128,6 +129,14 @@ func TestScanRequestBody_DisablePatternsAndPatternActions(t *testing.T) {
 			disablePatterns: []string{testBodyDLPPatternName},
 			wantAction:      config.ActionBlock,
 			wantPatterns:    []string{"AWS Access ID"},
+		},
+		{
+			name:           "pattern action block overrides global warn",
+			body:           `{"key":"` + fakeBodyDLPSecret() + `"}`,
+			defaultAction:  config.ActionWarn,
+			patternActions: map[string]string{testBodyDLPPatternName: config.ActionBlock},
+			wantAction:     config.ActionBlock,
+			wantPatterns:   []string{testBodyDLPPatternName},
 		},
 		{
 			name:           "pattern action warn overrides global block",
@@ -149,6 +158,9 @@ func TestScanRequestBody_DisablePatternsAndPatternActions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := testScannerConfig()
 			addBodyDLPTestPattern(cfg)
+			if tc.defaultAction != "" {
+				cfg.RequestBodyScanning.Action = tc.defaultAction
+			}
 			cfg.RequestBodyScanning.DisablePatterns = tc.disablePatterns
 			cfg.RequestBodyScanning.PatternActions = tc.patternActions
 			sc := scanner.MustNew(cfg)

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,6 +17,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
@@ -197,6 +200,193 @@ func TestScanRequestBody_DisablePatternsAndPatternActions(t *testing.T) {
 				if hasDLPMatchName(result.DLPMatches, disabled) {
 					t.Fatalf("disabled pattern %q still present in matches %v", disabled, dlpMatchNames(result.DLPMatches))
 				}
+			}
+		})
+	}
+}
+
+func TestRequestDLPPatternControlsAcrossTransports(t *testing.T) {
+	t.Run("forward HTTP", func(t *testing.T) {
+		runForwardHTTPHeaderDLPPatternControls(t)
+	})
+	t.Run("intercepted CONNECT", func(t *testing.T) {
+		runInterceptHeaderDLPPatternControls(t)
+	})
+	t.Run("reverse", func(t *testing.T) {
+		runReverseHeaderDLPPatternControls(t)
+	})
+}
+
+func requestDLPPatternControlCases() []struct {
+	name            string
+	configure       func(*config.Config)
+	wantStatus      int
+	wantUpstreamHit bool
+} {
+	return []struct {
+		name            string
+		configure       func(*config.Config)
+		wantStatus      int
+		wantUpstreamHit bool
+	}{
+		{
+			name: "disabled pattern omitted and forwarded",
+			configure: func(cfg *config.Config) {
+				cfg.RequestBodyScanning.Action = config.ActionBlock
+				cfg.RequestBodyScanning.DisablePatterns = []string{testBodyDLPPatternName}
+			},
+			wantStatus:      http.StatusOK,
+			wantUpstreamHit: true,
+		},
+		{
+			name: "pattern block overrides global warn",
+			configure: func(cfg *config.Config) {
+				cfg.RequestBodyScanning.Action = config.ActionWarn
+				cfg.RequestBodyScanning.PatternActions = map[string]string{testBodyDLPPatternName: config.ActionBlock}
+			},
+			wantStatus:      http.StatusForbidden,
+			wantUpstreamHit: false,
+		},
+	}
+}
+
+func runForwardHTTPHeaderDLPPatternControls(t *testing.T) {
+	t.Helper()
+
+	for _, tc := range requestDLPPatternControlCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			var upstreamHit atomic.Bool
+			backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upstreamHit.Store(true)
+				if got := r.Header.Get("Authorization"); !strings.Contains(got, fakeBodyDLPSecret()) {
+					t.Fatalf("Authorization header = %q, want test secret", got)
+				}
+				_, _ = fmt.Fprint(w, "ok")
+			}))
+			t.Cleanup(backend.Close)
+
+			proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+				cfg.Mode = config.ModeStrict
+				cfg.RequestBodyScanning.Enabled = true
+				cfg.RequestBodyScanning.ScanHeaders = true
+				cfg.RequestBodyScanning.HeaderMode = config.HeaderModeSensitive
+				cfg.RequestBodyScanning.SensitiveHeaders = []string{"Authorization"}
+				addBodyDLPTestPattern(cfg)
+				tc.configure(cfg)
+			})
+			t.Cleanup(cleanup)
+			installForwardTestDialer(p, backend.Listener.Addr().String())
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://api.example.com/v1/chat", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Authorization", "Bearer "+fakeBodyDLPSecret())
+
+			resp, err := forwardHTTPClient(t, proxyAddr).Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			t.Cleanup(func() { _ = resp.Body.Close() })
+
+			if resp.StatusCode != tc.wantStatus {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, tc.wantStatus, body)
+			}
+			if upstreamHit.Load() != tc.wantUpstreamHit {
+				t.Fatalf("upstream hit = %v, want %v", upstreamHit.Load(), tc.wantUpstreamHit)
+			}
+		})
+	}
+}
+
+func runInterceptHeaderDLPPatternControls(t *testing.T) {
+	t.Helper()
+
+	for _, tc := range requestDLPPatternControlCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			var upstreamHit atomic.Bool
+			upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upstreamHit.Store(true)
+				if got := r.Header.Get("Authorization"); !strings.Contains(got, fakeBodyDLPSecret()) {
+					t.Fatalf("Authorization header = %q, want test secret", got)
+				}
+				_, _ = fmt.Fprint(w, "ok")
+			}))
+			t.Cleanup(upstream.Close)
+
+			cache, pool, cfg, _, logger, m := testInterceptSetup(t)
+			cfg.Mode = config.ModeStrict
+			host := upstream.Listener.Addr().(*net.TCPAddr).IP.String()
+			cfg.APIAllowlist = []string{host}
+			cfg.RequestBodyScanning.Enabled = true
+			cfg.RequestBodyScanning.ScanHeaders = true
+			cfg.RequestBodyScanning.HeaderMode = config.HeaderModeSensitive
+			cfg.RequestBodyScanning.SensitiveHeaders = []string{"Authorization"}
+			addBodyDLPTestPattern(cfg)
+			tc.configure(cfg)
+			sc := scanner.MustNew(cfg)
+			t.Cleanup(sc.Close)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://"+upstream.Listener.Addr().String()+"/api", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Authorization", "Bearer "+fakeBodyDLPSecret())
+
+			resp := interceptAndRequest(t, upstream, cache, pool, cfg, sc, logger, m, req)
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tc.wantStatus {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, tc.wantStatus, body)
+			}
+			if upstreamHit.Load() != tc.wantUpstreamHit {
+				t.Fatalf("upstream hit = %v, want %v", upstreamHit.Load(), tc.wantUpstreamHit)
+			}
+		})
+	}
+}
+
+func runReverseHeaderDLPPatternControls(t *testing.T) {
+	t.Helper()
+
+	for _, tc := range requestDLPPatternControlCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := reverseTestConfig()
+			cfg.Mode = config.ModeStrict
+			cfg.RequestBodyScanning.ScanHeaders = true
+			cfg.RequestBodyScanning.HeaderMode = "all"
+			addBodyDLPTestPattern(cfg)
+			tc.configure(cfg)
+
+			var upstreamHit atomic.Bool
+			upstream := func(w http.ResponseWriter, r *http.Request) {
+				upstreamHit.Store(true)
+				if got := r.Header.Get("Authorization"); !strings.Contains(got, fakeBodyDLPSecret()) {
+					t.Fatalf("Authorization header = %q, want test secret", got)
+				}
+				_, _ = fmt.Fprint(w, "ok")
+			}
+			proxy := reverseTestSetup(t, cfg, upstream)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, proxy.URL+"/api/data", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Authorization", "Bearer "+fakeBodyDLPSecret())
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			t.Cleanup(func() { _ = resp.Body.Close() })
+
+			if resp.StatusCode != tc.wantStatus {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, tc.wantStatus, body)
+			}
+			if upstreamHit.Load() != tc.wantUpstreamHit {
+				t.Fatalf("upstream hit = %v, want %v", upstreamHit.Load(), tc.wantUpstreamHit)
 			}
 		})
 	}

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -11,12 +11,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/decide"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
@@ -49,6 +52,20 @@ func fakeAPIKey() string {
 
 func fakeGitHubToken() string {
 	return "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl"
+}
+
+const testBodyDLPPatternName = "Request Body Test Secret"
+
+func fakeBodyDLPSecret() string {
+	return "REQDLPTEST-" + "ABCDEF123456"
+}
+
+func addBodyDLPTestPattern(cfg *config.Config) {
+	cfg.DLP.Patterns = append(cfg.DLP.Patterns, config.DLPPattern{
+		Name:     testBodyDLPPatternName,
+		Regex:    `REQDLPTEST-[A-Z0-9]{12}`,
+		Severity: config.SeverityCritical,
+	})
 }
 
 func stackedBodyDLPFixture(secret string, layers int) string {
@@ -87,6 +104,284 @@ func TestScanRequestBody_JSONWithSecret(t *testing.T) {
 	if got := result.DLPMatches[0].PatternName; got != "AWS Access ID" {
 		t.Fatalf("pattern = %q, want AWS Access ID", got)
 	}
+}
+
+func TestScanRequestBody_DisablePatternsAndPatternActions(t *testing.T) {
+	cases := []struct {
+		name            string
+		body            string
+		disablePatterns []string
+		patternActions  map[string]string
+		wantClean       bool
+		wantAction      string
+		wantPatterns    []string
+	}{
+		{
+			name:            "disabled pattern allows body",
+			body:            `{"key":"` + fakeBodyDLPSecret() + `"}`,
+			disablePatterns: []string{testBodyDLPPatternName},
+			wantClean:       true,
+		},
+		{
+			name:            "non-disabled pattern still blocks same body",
+			body:            `{"custom":"` + fakeBodyDLPSecret() + `","aws":"` + fakeAPIKey() + `"}`,
+			disablePatterns: []string{testBodyDLPPatternName},
+			wantAction:      config.ActionBlock,
+			wantPatterns:    []string{"AWS Access ID"},
+		},
+		{
+			name:           "pattern action warn overrides global block",
+			body:           `{"key":"` + fakeBodyDLPSecret() + `"}`,
+			patternActions: map[string]string{testBodyDLPPatternName: config.ActionWarn},
+			wantAction:     config.ActionWarn,
+			wantPatterns:   []string{testBodyDLPPatternName},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testScannerConfig()
+			addBodyDLPTestPattern(cfg)
+			cfg.RequestBodyScanning.DisablePatterns = tc.disablePatterns
+			cfg.RequestBodyScanning.PatternActions = tc.patternActions
+			sc := scanner.MustNew(cfg)
+			defer sc.Close()
+
+			_, result := scanRequestBody(context.Background(), BodyScanRequest{
+				Body:            strings.NewReader(tc.body),
+				ContentType:     contentTypeJSON,
+				MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+				Scanner:         sc,
+				Action:          cfg.RequestBodyScanning.Action,
+				DisablePatterns: cfg.RequestBodyScanning.DisablePatterns,
+				PatternActions:  cfg.RequestBodyScanning.PatternActions,
+			})
+
+			if result.Clean != tc.wantClean {
+				t.Fatalf("Clean = %v, want %v; matches=%v", result.Clean, tc.wantClean, dlpMatchNames(result.DLPMatches))
+			}
+			if tc.wantClean {
+				if len(result.DLPMatches) != 0 {
+					t.Fatalf("DLPMatches = %v, want none", dlpMatchNames(result.DLPMatches))
+				}
+				return
+			}
+			if result.Action != tc.wantAction {
+				t.Fatalf("Action = %q, want %q", result.Action, tc.wantAction)
+			}
+			for _, want := range tc.wantPatterns {
+				if !hasDLPMatchName(result.DLPMatches, want) {
+					t.Fatalf("DLPMatches = %v, missing %q", dlpMatchNames(result.DLPMatches), want)
+				}
+			}
+			for _, disabled := range tc.disablePatterns {
+				if hasDLPMatchName(result.DLPMatches, disabled) {
+					t.Fatalf("disabled pattern %q still present in matches %v", disabled, dlpMatchNames(result.DLPMatches))
+				}
+			}
+		})
+	}
+}
+
+func TestScanRequestBody_DisablePatternsMatchDynamicRuntimeNames(t *testing.T) {
+	const (
+		fileSecret = "file-secret-value-5qP8mZr2TnY7"
+		seedPhrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+		hexHost    = "4a6f686e446f65.53656372657431.313233343536.exfil.evil.example.com"
+	)
+	envSecret := "envLeakValue" + "5qP8mZr2TnY7"
+
+	cases := []struct {
+		name        string
+		body        string
+		patternName string
+		setup       func(t *testing.T, cfg *config.Config)
+	}{
+		{
+			name:        "configured pattern",
+			body:        `{"key":"` + fakeBodyDLPSecret() + `"}`,
+			patternName: testBodyDLPPatternName,
+			setup: func(_ *testing.T, cfg *config.Config) {
+				addBodyDLPTestPattern(cfg)
+			},
+		},
+		{
+			name:        "canary token",
+			body:        `{"token":"canary-token-value-12345"}`,
+			patternName: "Canary Token (body-canary)",
+			setup: func(_ *testing.T, cfg *config.Config) {
+				cfg.CanaryTokens.Enabled = true
+				cfg.CanaryTokens.Tokens = []config.CanaryToken{{
+					Name:  "body-canary",
+					Value: "canary-token-value-12345",
+				}}
+			},
+		},
+		{
+			name:        "environment leak",
+			body:        `{"value":"` + envSecret + `"}`,
+			patternName: "Environment Variable Leak",
+			setup: func(t *testing.T, cfg *config.Config) {
+				t.Setenv("PIPELOCK_BODY_DLP_TEST_SECRET", envSecret)
+				cfg.DLP.ScanEnv = true
+			},
+		},
+		{
+			name:        "known secret file leak",
+			body:        `{"value":"` + fileSecret + `"}`,
+			patternName: "Known Secret Leak",
+			setup: func(t *testing.T, cfg *config.Config) {
+				path := filepath.Join(t.TempDir(), "secrets.txt")
+				if err := os.WriteFile(path, []byte(fileSecret+"\n"), 0o600); err != nil {
+					t.Fatalf("write secrets file: %v", err)
+				}
+				cfg.DLP.SecretsFile = path
+			},
+		},
+		{
+			name:        "seed phrase",
+			body:        `{"phrase":"` + seedPhrase + `"}`,
+			patternName: "BIP-39 Seed Phrase",
+			setup:       func(_ *testing.T, _ *config.Config) {},
+		},
+		{
+			name:        "hostname exfiltration",
+			body:        `{"url":"https://` + hexHost + `/ping"}`,
+			patternName: "Hostname Exfiltration",
+			setup:       func(_ *testing.T, _ *config.Config) {},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testScannerConfig()
+			tc.setup(t, cfg)
+			sc := scanner.MustNew(cfg)
+			defer sc.Close()
+
+			_, detected := scanRequestBody(context.Background(), BodyScanRequest{
+				Body:        strings.NewReader(tc.body),
+				ContentType: contentTypeJSON,
+				MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+				Scanner:     sc,
+				Action:      cfg.RequestBodyScanning.Action,
+			})
+			if detected.Clean || !hasDLPMatchName(detected.DLPMatches, tc.patternName) {
+				t.Fatalf("baseline DLPMatches = %v, want %q", dlpMatchNames(detected.DLPMatches), tc.patternName)
+			}
+
+			cfg = testScannerConfig()
+			tc.setup(t, cfg)
+			cfg.RequestBodyScanning.DisablePatterns = []string{tc.patternName}
+			sc = scanner.MustNew(cfg)
+			defer sc.Close()
+
+			_, disabled := scanRequestBody(context.Background(), BodyScanRequest{
+				Body:            strings.NewReader(tc.body),
+				ContentType:     contentTypeJSON,
+				MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+				Scanner:         sc,
+				Action:          cfg.RequestBodyScanning.Action,
+				DisablePatterns: cfg.RequestBodyScanning.DisablePatterns,
+			})
+			if !disabled.Clean {
+				t.Fatalf("disabled DLPMatches = %v, want clean", dlpMatchNames(disabled.DLPMatches))
+			}
+		})
+	}
+}
+
+func TestScanRequestBody_NonCorePatternWarnOverrideSkipsCriticalHardBlock(t *testing.T) {
+	cfg := testScannerConfig()
+	addBodyDLPTestPattern(cfg)
+	cfg.RequestBodyScanning.PatternActions = map[string]string{testBodyDLPPatternName: config.ActionWarn}
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:            strings.NewReader(`{"key":"` + fakeBodyDLPSecret() + `"}`),
+		ContentType:     contentTypeJSON,
+		MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:         sc,
+		Action:          cfg.RequestBodyScanning.Action,
+		PatternActions:  cfg.RequestBodyScanning.PatternActions,
+		DisablePatterns: cfg.RequestBodyScanning.DisablePatterns,
+	})
+	if result.Clean {
+		t.Fatal("expected DLP finding")
+	}
+	if result.Action != config.ActionWarn {
+		t.Fatalf("Action = %q, want %q", result.Action, config.ActionWarn)
+	}
+	if shouldHardBlockBodyCriticalDLP(result, "api.vendor.example", cfg) {
+		t.Fatal("per-pattern warn override must not be erased by critical body-DLP hard block")
+	}
+}
+
+func TestScanRequestBody_CorePatternKnobsCannotWeakenCriticalFloor(t *testing.T) {
+	cfg := testScannerConfig()
+	cfg.RequestBodyScanning.DisablePatterns = []string{"AWS Access ID"}
+	cfg.RequestBodyScanning.PatternActions = map[string]string{"AWS Access ID": config.ActionWarn}
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:            strings.NewReader(`{"key":"` + fakeAPIKey() + `"}`),
+		ContentType:     contentTypeJSON,
+		MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:         sc,
+		Action:          cfg.RequestBodyScanning.Action,
+		PatternActions:  cfg.RequestBodyScanning.PatternActions,
+		DisablePatterns: cfg.RequestBodyScanning.DisablePatterns,
+	})
+	if result.Clean {
+		t.Fatal("core DLP finding was disabled")
+	}
+	if !hasDLPMatchName(result.DLPMatches, "AWS Access ID") {
+		t.Fatalf("DLPMatches = %v, want AWS Access ID", dlpMatchNames(result.DLPMatches))
+	}
+	if result.Action != config.ActionBlock {
+		t.Fatalf("Action = %q, want %q", result.Action, config.ActionBlock)
+	}
+	if !shouldHardBlockBodyCriticalDLP(result, "api.vendor.example", cfg) {
+		t.Fatal("core DLP warn override skipped critical hard block")
+	}
+}
+
+func TestScanRequestBody_PatternWarnOverrideStillFeedsAdaptiveUpgrade(t *testing.T) {
+	cfg := testScannerConfig()
+	addBodyDLPTestPattern(cfg)
+	cfg.RequestBodyScanning.PatternActions = map[string]string{testBodyDLPPatternName: config.ActionWarn}
+	cfg.AdaptiveEnforcement.Enabled = true
+	upgradeWarn := config.ActionBlock
+	cfg.AdaptiveEnforcement.Levels.Elevated.UpgradeWarn = &upgradeWarn
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:            strings.NewReader(`{"key":"` + fakeBodyDLPSecret() + `"}`),
+		ContentType:     contentTypeJSON,
+		MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:         sc,
+		Action:          cfg.RequestBodyScanning.Action,
+		PatternActions:  cfg.RequestBodyScanning.PatternActions,
+		DisablePatterns: cfg.RequestBodyScanning.DisablePatterns,
+	})
+	if result.Action != config.ActionWarn {
+		t.Fatalf("Action = %q, want %q", result.Action, config.ActionWarn)
+	}
+	if got := decide.UpgradeAction(result.Action, 1, &cfg.AdaptiveEnforcement); got != config.ActionBlock {
+		t.Fatalf("UpgradeAction(per-pattern warn, elevated) = %q, want %q", got, config.ActionBlock)
+	}
+}
+
+func hasDLPMatchName(matches []scanner.TextDLPMatch, name string) bool {
+	for _, match := range matches {
+		if match.PatternName == name {
+			return true
+		}
+	}
+	return false
 }
 
 func TestScanRequestBody_StackedDecodeFixpoint(t *testing.T) {
@@ -865,6 +1160,26 @@ func TestScanRequestHeaders_XApiKey(t *testing.T) {
 	result := scanRequestHeaders(context.Background(), headers, cfg, sc)
 	if result == nil || result.Clean {
 		t.Fatal("expected DLP match in X-Api-Key header")
+	}
+}
+
+func TestScanRequestHeaders_DisabledPatternDoesNotMaskCoreMatch(t *testing.T) {
+	cfg := testScannerConfig()
+	addBodyDLPTestPattern(cfg)
+	cfg.RequestBodyScanning.DisablePatterns = []string{testBodyDLPPatternName}
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+fakeBodyDLPSecret())
+	headers.Set("X-Api-Key", fakeAPIKey())
+
+	result := scanRequestHeaders(context.Background(), headers, cfg, sc)
+	if result == nil || result.Clean {
+		t.Fatal("expected non-disabled DLP match after disabled header match")
+	}
+	if !hasDLPMatchName(result.DLPMatches, "AWS Access ID") {
+		t.Fatalf("DLPMatches = %v, want AWS Access ID", dlpMatchNames(result.DLPMatches))
 	}
 }
 

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -136,6 +136,13 @@ func TestScanRequestBody_DisablePatternsAndPatternActions(t *testing.T) {
 			wantAction:     config.ActionWarn,
 			wantPatterns:   []string{testBodyDLPPatternName},
 		},
+		{
+			name:           "warn override does not mask later core match",
+			body:           `{"custom":"` + fakeBodyDLPSecret() + `","aws":"` + fakeAPIKey() + `"}`,
+			patternActions: map[string]string{testBodyDLPPatternName: config.ActionWarn},
+			wantAction:     config.ActionBlock,
+			wantPatterns:   []string{testBodyDLPPatternName, "AWS Access ID"},
+		},
 	}
 
 	for _, tc := range cases {
@@ -1180,6 +1187,31 @@ func TestScanRequestHeaders_DisabledPatternDoesNotMaskCoreMatch(t *testing.T) {
 	}
 	if !hasDLPMatchName(result.DLPMatches, "AWS Access ID") {
 		t.Fatalf("DLPMatches = %v, want AWS Access ID", dlpMatchNames(result.DLPMatches))
+	}
+}
+
+func TestScanRequestHeaders_WarnPatternDoesNotMaskCoreMatch(t *testing.T) {
+	cfg := testScannerConfig()
+	addBodyDLPTestPattern(cfg)
+	cfg.RequestBodyScanning.PatternActions = map[string]string{testBodyDLPPatternName: config.ActionWarn}
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+fakeBodyDLPSecret())
+	headers.Set("X-Api-Key", fakeAPIKey())
+
+	result := scanRequestHeaders(context.Background(), headers, cfg, sc)
+	if result == nil || result.Clean {
+		t.Fatal("expected core DLP match after warn-only header match")
+	}
+	if result.Action != config.ActionBlock {
+		t.Fatalf("Action = %q, want %q", result.Action, config.ActionBlock)
+	}
+	for _, want := range []string{testBodyDLPPatternName, "AWS Access ID"} {
+		if !hasDLPMatchName(result.DLPMatches, want) {
+			t.Fatalf("DLPMatches = %v, missing %q", dlpMatchNames(result.DLPMatches), want)
+		}
 	}
 }
 

--- a/internal/proxy/dlp_warn_context_test.go
+++ b/internal/proxy/dlp_warn_context_test.go
@@ -126,7 +126,7 @@ func TestDLPScanWSHeaders_PropagatesWarnContext(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer "+fakeAPIKey()+" "+testWarnHookToken)
 	cfg := testScannerConfig()
-	blocked, _, reason := (&Proxy{}).dlpScanWSHeaders(ctx, headers, sc, cfg, testWSURL)
+	blocked, _, _, reason := (&Proxy{}).dlpScanWSHeaders(ctx, headers, sc, cfg, testWSURL)
 	if !blocked {
 		t.Fatal("expected DLP match in websocket headers")
 	}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -2703,9 +2703,14 @@ func copyResponseHeaders(dst, src http.Header) {
 
 // dlpMatchNames extracts pattern names from a slice of DLP matches.
 func dlpMatchNames(matches []scanner.TextDLPMatch) []string {
-	names := make([]string, len(matches))
-	for i, m := range matches {
-		names[i] = m.PatternName
+	names := make([]string, 0, len(matches))
+	seen := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		if _, ok := seen[m.PatternName]; ok {
+			continue
+		}
+		seen[m.PatternName] = struct{}{}
+		names = append(names, m.PatternName)
 	}
 	return names
 }

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -6,6 +6,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -178,6 +179,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	})
 	r = r.WithContext(connectScanCtx)
 	result := sc.Scan(connectScanCtx, syntheticURL)
+	r = r.WithContext(withAllowedSSRFDialScanSnapshot(r.Context(), sc, host, result))
 
 	// Capture observer: record CONNECT URL verdict for policy replay.
 	{
@@ -570,6 +572,26 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 
 	targetConn, err := p.ssrfSafeDialContext(dialCtx, "tcp", target)
 	if err != nil {
+		var ssrfErr *ssrfDialBlockError
+		if errors.As(err, &ssrfErr) {
+			p.logger.LogBlocked(targetCtx, scanner.ScannerSSRF, ssrfErr.logDetail())
+			p.metrics.RecordTunnelBlocked(agentLabel)
+			_ = p.emitReceipt(withReceiptPolicyHash(receipt.EmitOpts{
+				ActionID:  actionID,
+				Verdict:   config.ActionBlock,
+				Layer:     scanner.ScannerSSRF,
+				Pattern:   string(ssrfErr.reason),
+				Transport: TransportConnect,
+				Method:    http.MethodConnect,
+				Target:    connectReceiptTarget,
+				RequestID: requestID,
+				Agent:     agent,
+			}, cfg.CanonicalPolicyHash()))
+			writeBlockedError(w, ssrfErr.blockInfo(), "CONNECT blocked: "+ssrfErr.detail, http.StatusForbidden)
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeReason = string(ssrfErr.reason)
+			return
+		}
 		p.logger.LogError(targetCtx, err)
 		http.Error(w, "tunnel dial failed", http.StatusBadGateway)
 		outcomeStatus = strconv.Itoa(http.StatusBadGateway)
@@ -1705,6 +1727,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = context.WithValue(ctx, ctxKeyAgentScanner, sc)
 	ctx = context.WithValue(ctx, ctxKeyAgentContractLoader, snapshotContractLoader)
 	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportForward)
+	ctx = withAllowedSSRFDialScanSnapshot(ctx, sc, r.URL.Hostname(), result)
 	outReq := r.Clone(ctx)
 	outReq.RequestURI = "" // required for http.Client
 	outReq = outReq.WithContext(context.WithValue(outReq.Context(), ctxKeyEnvelopeEmitter, envelopeEmitterSnapshot{emitter: envEmitter}))
@@ -1814,6 +1837,35 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := p.client.Do(outReq)
 	if err != nil {
+		var ssrfErr *ssrfDialBlockError
+		if errors.As(err, &ssrfErr) {
+			p.logger.LogBlocked(actx, scanner.ScannerSSRF, ssrfErr.logDetail())
+			emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
+				ActionID:            actionID,
+				Verdict:             config.ActionBlock,
+				Layer:               scanner.ScannerSSRF,
+				Pattern:             string(ssrfErr.reason),
+				Transport:           "forward",
+				Method:              r.Method,
+				Target:              targetURL,
+				RequestID:           requestID,
+				Agent:               agent,
+				SessionTaintLevel:   forwardTaint.Risk.Level.String(),
+				SessionContaminated: forwardTaint.Risk.Contaminated,
+				RecentTaintSources:  forwardTaint.Risk.Sources,
+				SessionTaskID:       forwardTaint.Task.CurrentTaskID,
+				SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
+				AuthorityKind:       forwardTaint.Authority.String(),
+				TaintDecision:       forwardTaint.Result.Decision.String(),
+				TaintDecisionReason: forwardTaint.Result.Reason,
+				TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
+			}))
+			p.metrics.RecordBlocked(r.URL.Hostname(), scanner.ScannerSSRF, time.Since(start), agentLabel)
+			writeBlockedError(w, ssrfErr.blockInfo(), "blocked: "+ssrfErr.detail, http.StatusForbidden)
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeReason = string(ssrfErr.reason)
+			return
+		}
 		if blockedErr, ok := blockedRequestErrorFrom(err); ok {
 			p.logger.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
 			emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1230,6 +1230,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			Path:            r.URL.Path,
 			Target:          targetURL,
 			Suppress:        cfg.Suppress,
+			Action:          cfg.RequestBodyScanning.Action,
+			DisablePatterns: cfg.RequestBodyScanning.DisablePatterns,
+			PatternActions:  cfg.RequestBodyScanning.PatternActions,
 		}
 		applyBodyScanRedaction(&bodyReq, p.currentRedactionRuntimeFor(cfg))
 		buf, bodyResult := scanRequestBody(r.Context(), bodyReq)

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -4732,6 +4732,88 @@ func TestForwardHTTPHeaderDLPAuditMode_NoCleanDecay(t *testing.T) {
 	}
 }
 
+func TestForwardHTTPSSRFDialBlockErrorResponse(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.FetchProxy.TimeoutSeconds = 5
+
+	logger := audit.NewNop()
+	sc := scanner.MustNew(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Close()
+	p.client = &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		ip := net.ParseIP("127.0.0.1")
+		return nil, newSSRFDialBlockError(req.Context(), req.URL.Hostname(), ip, ssrfDialBlockDetail(req.URL.Hostname(), ip))
+	})}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://api.vendor.example/data", nil)
+	req.RemoteAddr = "192.0.2.10:12345"
+	w := httptest.NewRecorder()
+
+	p.handleForwardHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusForbidden, w.Body.String())
+	}
+	if got := w.Header().Get(blockreason.HeaderReason); got != string(blockreason.SSRFPrivateIP) {
+		t.Fatalf("%s = %q, want %q", blockreason.HeaderReason, got, blockreason.SSRFPrivateIP)
+	}
+	if !strings.Contains(w.Body.String(), "api.vendor.example") {
+		t.Fatalf("body = %q, want blocked host detail", w.Body.String())
+	}
+}
+
+func TestSSRFDialBlockHelpersEdgeCases(t *testing.T) {
+	var nilErr *ssrfDialBlockError
+	if nilErr.Error() != "" {
+		t.Fatalf("nil Error() = %q, want empty", nilErr.Error())
+	}
+	if got := nilErr.blockInfo().Reason; got != blockreason.SSRFPrivateIP {
+		t.Fatalf("nil block reason = %q, want %q", got, blockreason.SSRFPrivateIP)
+	}
+	if nilErr.logDetail() != "" {
+		t.Fatalf("nil logDetail() = %q, want empty", nilErr.logDetail())
+	}
+
+	ctx := withSSRFDialScanSnapshot(context.Background(), " Rebind.Test. ", []string{"bad-ip", "203.0.113.10", "2001:db8::1%eth0"})
+	if ctx == nil {
+		t.Fatal("snapshot context is nil")
+	}
+	var nilContext context.Context
+	if isSSRFDNSRebind(nilContext, "rebind.test", net.ParseIP("127.0.0.1")) {
+		t.Fatal("nil context reported DNS rebind")
+	}
+	if isSSRFDNSRebind(ctx, "other.test", net.ParseIP("127.0.0.1")) {
+		t.Fatal("different host reported DNS rebind")
+	}
+	if isSSRFDNSRebind(ctx, "rebind.test", nil) {
+		t.Fatal("nil IP reported DNS rebind")
+	}
+	if isSSRFDNSRebind(ctx, "rebind.test", net.ParseIP("203.0.113.10")) {
+		t.Fatal("scan-time IP reported DNS rebind")
+	}
+	if !isSSRFDNSRebind(ctx, "rebind.test", net.ParseIP("127.0.0.1")) {
+		t.Fatal("new private IP did not report DNS rebind")
+	}
+	if got := normalizeSSRFDialHost("Example.COM."); got != "example.com" {
+		t.Fatalf("normalize host = %q, want example.com", got)
+	}
+	if got := normalizeSSRFDialIP(nil); got != nil {
+		t.Fatalf("normalize nil IP = %v, want nil", got)
+	}
+	if got := stripIPv6Zone("2001:db8::1%eth0"); got != "2001:db8::1" {
+		t.Fatalf("stripIPv6Zone = %q, want 2001:db8::1", got)
+	}
+	if got := stripIPv6Zone("203.0.113.10"); got != "203.0.113.10" {
+		t.Fatalf("stripIPv6Zone no-zone = %q, want 203.0.113.10", got)
+	}
+}
+
 // TestForwardHTTPResponseCleanPasses verifies that clean forward HTTP
 // responses pass through when response scanning is enabled.
 func TestForwardHTTPResponseCleanPasses(t *testing.T) {

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -3498,6 +3498,22 @@ func TestSSRFSafeDialContext_DNSRebindBlockCarriesDistinctReason(t *testing.T) {
 	}
 }
 
+func TestAllowedSSRFDialScanSnapshotPreservesPublicAllowlistedIP(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.SSRF.IPAllowlist = []string{"203.0.113.0/24"}
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	ctx := withAllowedSSRFDialScanSnapshot(context.Background(), sc, "rebind.test", scanner.Result{
+		Allowed:         true,
+		SSRFResolvedIPs: []string{"203.0.113.10"},
+	})
+
+	if !isSSRFDNSRebind(ctx, "rebind.test", net.ParseIP("127.0.0.1")) {
+		t.Fatal("expected public allowlisted scan-time IP to preserve DNS-rebind snapshot")
+	}
+}
+
 func TestSSRFSafeDialContext_DNSRebindToCoreCIDRsBlockedWhenInternalConfigNil(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -2997,6 +2997,8 @@ func TestHealthIncludesForwardProxy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
+	t.Cleanup(p.Close)
+	t.Cleanup(p.Close)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
@@ -3379,6 +3381,8 @@ func TestSSRFSafeDialContext_DirectIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
+	t.Cleanup(p.Close)
+	t.Cleanup(p.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -3403,6 +3407,7 @@ func TestSSRFSafeDialContext_InvalidAddr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
+	t.Cleanup(p.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -3424,6 +3429,7 @@ func TestSSRFSafeDialContext_LoopbackBlocked(t *testing.T) {
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
+	t.Cleanup(p.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -3537,6 +3543,7 @@ func TestSSRFSafeDialContext_DNSRebindToCoreCIDRsBlockedWhenInternalConfigNil(t 
 			if err != nil {
 				t.Fatalf("proxy.New: %v", err)
 			}
+			t.Cleanup(p.Close)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
@@ -3571,6 +3578,7 @@ func TestSSRFSafeDialContext_PrivateFromStartStaysPrivateIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
+	t.Cleanup(p.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -3605,6 +3613,7 @@ func TestFetchDialDNSRebindEmitsDistinctBlockReason(t *testing.T) {
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
+	t.Cleanup(p.Close)
 	p.client.Transport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		ip := net.ParseIP("127.0.0.1")
 		return nil, newSSRFDialBlockError(req.Context(), req.URL.Hostname(), ip, ssrfDialBlockDetail(req.URL.Hostname(), ip))

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -3520,6 +3520,87 @@ func TestAllowedSSRFDialScanSnapshotPreservesPublicAllowlistedIP(t *testing.T) {
 	}
 }
 
+func TestAllowedSSRFDialScanSnapshotClearsIneligibleSameHost(t *testing.T) {
+	tests := []struct {
+		name   string
+		result scanner.Result
+	}{
+		{
+			name: "blocked current scan",
+			result: scanner.Result{
+				Allowed:         false,
+				SSRFResolvedIPs: []string{"203.0.113.10"},
+			},
+		},
+		{
+			name: "no current IPs",
+			result: scanner.Result{
+				Allowed: true,
+			},
+		},
+		{
+			name: "private current IP",
+			result: scanner.Result{
+				Allowed:         true,
+				SSRFResolvedIPs: []string{"127.0.0.1"},
+			},
+		},
+		{
+			name: "metadata current IP",
+			result: scanner.Result{
+				Allowed:         true,
+				SSRFResolvedIPs: []string{"169.254.169.254"},
+			},
+		},
+		{
+			name: "invalid current IP",
+			result: scanner.Result{
+				Allowed:         true,
+				SSRFResolvedIPs: []string{"not-an-ip"},
+			},
+		},
+		{
+			name: "nil scanner",
+			result: scanner.Result{
+				Allowed:         true,
+				SSRFResolvedIPs: []string{"203.0.113.10"},
+			},
+		},
+	}
+
+	cfg := config.Defaults()
+	cfg.Internal = []string{"127.0.0.0/8"}
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+
+	var nilCtx context.Context
+	if got := withAllowedSSRFDialScanSnapshot(nilCtx, sc, "rebind.test", scanner.Result{
+		Allowed:         true,
+		SSRFResolvedIPs: []string{"203.0.113.10"},
+	}); got != nil {
+		t.Fatal("nil context should remain nil")
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := withSSRFDialScanSnapshot(context.Background(), "rebind.test", []string{"203.0.113.10"})
+			currentScanner := sc
+			if tc.name == "nil scanner" {
+				currentScanner = nil
+			}
+			ctx = withAllowedSSRFDialScanSnapshot(ctx, currentScanner, "rebind.test", tc.result)
+
+			if isSSRFDNSRebind(ctx, "rebind.test", net.ParseIP("127.0.0.1")) {
+				t.Fatal("stale same-host public snapshot survived an ineligible current scan")
+			}
+			blocked := newSSRFDialBlockError(ctx, "rebind.test", net.ParseIP("127.0.0.1"), "blocked")
+			if blocked.reason != blockreason.SSRFPrivateIP {
+				t.Fatalf("block reason = %s, want %s", blocked.reason, blockreason.SSRFPrivateIP)
+			}
+		})
+	}
+}
+
 func TestSSRFSafeDialContext_DNSRebindToCoreCIDRsBlockedWhenInternalConfigNil(t *testing.T) {
 	tests := []struct {
 		name string
@@ -3574,6 +3655,7 @@ func TestSSRFSafeDialContext_PrivateFromStartStaysPrivateIP(t *testing.T) {
 
 	logger := audit.NewNop()
 	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
 	p, err := New(cfg, logger, sc, metrics.New())
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
@@ -4710,12 +4792,12 @@ func TestForwardHTTPHeaderDLPAuditMode_NoCleanDecay(t *testing.T) {
 
 	logger := audit.NewNop()
 	sc := scanner.MustNew(cfg)
-	// p.Close() closes the scanner; no separate defer sc.Close() needed.
+	t.Cleanup(sc.Close)
 	p, err := New(cfg, logger, sc, metrics.New())
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
-	defer p.Close()
+	t.Cleanup(p.Close)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, backend.URL+"/safe", nil)
 	if err != nil {

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -3465,6 +3465,150 @@ func TestSSRFSafeDialContext_DNSResolvesToInternal(t *testing.T) {
 	}
 }
 
+func TestSSRFSafeDialContext_DNSRebindBlockCarriesDistinctReason(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = []string{"127.0.0.0/8"}
+	cfg.DNS.HostOverrides = map[string][]string{"rebind.test": {"127.0.0.1"}}
+
+	logger := audit.NewNop()
+	sc := scanner.MustNew(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ctx = withSSRFDialScanSnapshot(ctx, "rebind.test", []string{"203.0.113.10"})
+
+	conn, err := p.ssrfSafeDialContext(ctx, "tcp", "rebind.test:443")
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if err == nil {
+		t.Fatal("expected SSRF DNS rebind block, got nil")
+	}
+
+	var blocked *ssrfDialBlockError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("error type = %T, want *ssrfDialBlockError: %v", err, err)
+	}
+	if blocked.reason != blockreason.SSRFDNSRebind {
+		t.Fatalf("block reason = %s, want %s", blocked.reason, blockreason.SSRFDNSRebind)
+	}
+}
+
+func TestSSRFSafeDialContext_DNSRebindToCoreCIDRsBlockedWhenInternalConfigNil(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		ip   string
+	}{
+		{name: "metadata", host: "metadata-rebind.test", ip: "169.254.169.254"},
+		{name: "private", host: "private-rebind.test", ip: "10.0.0.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.Internal = nil
+			cfg.DNS.HostOverrides = map[string][]string{tt.host: {tt.ip}}
+
+			logger := audit.NewNop()
+			sc := scanner.MustNew(cfg)
+			t.Cleanup(sc.Close)
+			p, err := New(cfg, logger, sc, metrics.New())
+			if err != nil {
+				t.Fatalf("proxy.New: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			ctx = withSSRFDialScanSnapshot(ctx, tt.host, []string{"203.0.113.10"})
+
+			conn, err := p.ssrfSafeDialContext(ctx, "tcp", net.JoinHostPort(tt.host, "443"))
+			if conn != nil {
+				_ = conn.Close()
+			}
+			if err == nil {
+				t.Fatal("expected SSRF DNS rebind block, got nil")
+			}
+
+			var blocked *ssrfDialBlockError
+			if !errors.As(err, &blocked) {
+				t.Fatalf("error type = %T, want *ssrfDialBlockError: %v", err, err)
+			}
+			if blocked.reason != blockreason.SSRFDNSRebind {
+				t.Fatalf("block reason = %s, want %s", blocked.reason, blockreason.SSRFDNSRebind)
+			}
+		})
+	}
+}
+
+func TestSSRFSafeDialContext_PrivateFromStartStaysPrivateIP(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = []string{"127.0.0.0/8"}
+
+	logger := audit.NewNop()
+	sc := scanner.MustNew(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := p.ssrfSafeDialContext(ctx, "tcp", "127.0.0.1:443")
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if err == nil {
+		t.Fatal("expected SSRF private IP block, got nil")
+	}
+
+	var blocked *ssrfDialBlockError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("error type = %T, want *ssrfDialBlockError: %v", err, err)
+	}
+	if blocked.reason != blockreason.SSRFPrivateIP {
+		t.Fatalf("block reason = %s, want %s", blocked.reason, blockreason.SSRFPrivateIP)
+	}
+}
+
+func TestFetchDialDNSRebindEmitsDistinctBlockReason(t *testing.T) {
+	cfg := config.Defaults()
+	enforce := true
+	cfg.Enforce = &enforce
+	cfg.Internal = []string{"127.0.0.0/8"}
+	cfg.DNS.HostOverrides = map[string][]string{"rebind.test": {"203.0.113.10"}}
+
+	logger := audit.NewNop()
+	sc := scanner.MustNew(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	p.client.Transport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		ip := net.ParseIP("127.0.0.1")
+		return nil, newSSRFDialBlockError(req.Context(), req.URL.Hostname(), ip, ssrfDialBlockDetail(req.URL.Hostname(), ip))
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fetch?url=http://rebind.test/", nil)
+	w := httptest.NewRecorder()
+
+	p.handleFetch(w, req)
+
+	resp := w.Result()
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.SSRFDNSRebind) {
+		t.Fatalf("%s = %q, want %q", blockreason.HeaderReason, got, blockreason.SSRFDNSRebind)
+	}
+}
+
 func TestSSRFSafeDialContext_AllowedIP(t *testing.T) {
 	// Start a local listener to accept the connection
 	lc := net.ListenConfig{}

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -914,6 +914,9 @@ func newInterceptHandler(
 				Path:            r.URL.Path,
 				Target:          targetURL,
 				Suppress:        ic.Config.Suppress,
+				Action:          ic.Config.RequestBodyScanning.Action,
+				DisablePatterns: ic.Config.RequestBodyScanning.DisablePatterns,
+				PatternActions:  ic.Config.RequestBodyScanning.PatternActions,
 			}
 			applyBodyScanRedaction(&bodyReq, redaction)
 			bodyBytes, result := scanRequestBody(r.Context(), bodyReq)
@@ -1163,8 +1166,11 @@ func newInterceptHandler(
 				hdrHasFinding := headerResult != nil && !headerResult.Clean
 				hdrAction := config.ActionAllow
 				if hdrHasFinding {
-					hdrAction = ic.Config.RequestBodyScanning.Action
-					if shouldHardBlockCriticalDLP(headerResult.DLPMatches, ic.Config.EnforceEnabled()) {
+					hdrAction = headerResult.Action
+					if hdrAction == "" {
+						hdrAction = ic.Config.RequestBodyScanning.Action
+					}
+					if shouldHardBlockRequestDLP(headerResult.DLPMatches, ic.Config) {
 						hdrAction = config.ActionBlock
 					}
 				}
@@ -1187,8 +1193,11 @@ func newInterceptHandler(
 
 			if headerResult != nil && !headerResult.Clean {
 				hasFinding = true
-				action := ic.Config.RequestBodyScanning.Action
-				headerHardBlock := shouldHardBlockCriticalDLP(headerResult.DLPMatches, ic.Config.EnforceEnabled())
+				action := headerResult.Action
+				if action == "" {
+					action = ic.Config.RequestBodyScanning.Action
+				}
+				headerHardBlock := shouldHardBlockRequestDLP(headerResult.DLPMatches, ic.Config)
 				if headerHardBlock {
 					action = config.ActionBlock
 				}

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -686,6 +686,7 @@ func newInterceptHandler(
 		})
 		r = r.WithContext(interceptScanCtx)
 		urlResult := ic.Scanner.Scan(interceptScanCtx, targetURL)
+		r = r.WithContext(withAllowedSSRFDialScanSnapshot(r.Context(), ic.Scanner, r.URL.Hostname(), urlResult))
 
 		// Capture observer: record intercept URL verdict for policy replay.
 		if ic.Proxy != nil {
@@ -1519,6 +1520,25 @@ func newInterceptHandler(
 		// Forward to upstream.
 		resp, err := upstream.RoundTrip(r)
 		if err != nil {
+			var ssrfErr *ssrfDialBlockError
+			if errors.As(err, &ssrfErr) {
+				ic.Logger.LogBlocked(actx, scanner.ScannerSSRF, ssrfErr.logDetail())
+				ic.Metrics.RecordTLSRequestBlocked("url_scan")
+				_ = interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{
+					ActionID:  actionID,
+					Verdict:   config.ActionBlock,
+					Layer:     scanner.ScannerSSRF,
+					Pattern:   string(ssrfErr.reason),
+					Transport: "intercept",
+					Method:    r.Method,
+					Target:    targetURL,
+					RequestID: ic.RequestID,
+					Agent:     ic.Agent,
+				}))
+				writeBlockedError(w, ssrfErr.blockInfo(), "blocked: "+ssrfErr.detail, http.StatusForbidden)
+				emitBlockedPostRoundTripOutcome(http.StatusForbidden, string(ssrfErr.reason))
+				return
+			}
 			ic.Logger.LogError(actx, err)
 			http.Error(w, "upstream error", http.StatusBadGateway)
 			emitBlockedPostRoundTripOutcome(http.StatusBadGateway, "upstream_error")

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1174,6 +1174,7 @@ func newInterceptHandler(
 					if shouldHardBlockRequestDLP(headerResult.DLPMatches, ic.Config) {
 						hdrAction = config.ActionBlock
 					}
+					hdrAction = decide.UpgradeAction(hdrAction, interceptEscalationLevel(ic), &ic.Config.AdaptiveEnforcement)
 				}
 				ic.Proxy.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 					Subsurface:        "dlp_header_intercept",
@@ -1202,16 +1203,40 @@ func newInterceptHandler(
 				if headerHardBlock {
 					action = config.ActionBlock
 				}
+				originalAction := action
+				level := interceptEscalationLevel(ic)
+				action = decide.UpgradeAction(action, level, &ic.Config.AdaptiveEnforcement)
+				escalatedBlock := action == config.ActionBlock && originalAction != config.ActionBlock
+				if action != originalAction {
+					sessionKey := sessionKeyFor(ic.Agent, ic.ClientIP)
+					var metricSet *metrics.Metrics
+					if ic.Proxy != nil {
+						metricSet = ic.Proxy.metrics
+					}
+					recordAdaptiveUpgrade(ic.Logger, metricSet, adaptiveUpgrade{
+						SessionKey: sessionKey,
+						Level:      session.EscalationLabel(level),
+						FromAction: originalAction,
+						ToAction:   action,
+						Scanner:    scanner.ScannerDLP,
+						ClientIP:   ic.ClientIP,
+						RequestID:  ic.RequestID,
+					})
+				}
+				reason := "request header contains secret"
+				if escalatedBlock && !ic.Config.EnforceEnabled() {
+					reason += " (escalated)"
+				}
 				// ActionAsk: no HITL terminal in intercepted tunnels, fail closed.
-				if headerHardBlock || action == config.ActionAsk || (action == config.ActionBlock && ic.Config.EnforceEnabled()) {
+				if headerHardBlock || action == config.ActionAsk || (action == config.ActionBlock && (ic.Config.EnforceEnabled() || escalatedBlock)) {
 					interceptRecordSignal(ic, session.SignalBlock)
-					ic.Logger.LogBlocked(actx, "header_dlp", "request header contains secret")
+					ic.Logger.LogBlocked(actx, "header_dlp", reason)
 					ic.Metrics.RecordTLSRequestBlocked("header_dlp")
 					_ = interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{
 						ActionID:  actionID,
 						Verdict:   config.ActionBlock,
 						Layer:     "header_dlp",
-						Pattern:   "request header contains secret",
+						Pattern:   reason,
 						Transport: "intercept",
 						Method:    r.Method,
 						Target:    targetURL,
@@ -1220,11 +1245,11 @@ func newInterceptHandler(
 					}))
 					writeBlockedError(w,
 						blockInfoFor(blockreason.DLPMatch, "header_dlp"),
-						"blocked: request header contains secret", http.StatusForbidden)
+						"blocked: "+reason, http.StatusForbidden)
 					return
 				}
 				// Audit mode: log but forward.
-				ic.Logger.LogAnomaly(actx, "header_dlp", "request header contains secret", 0.8) // 0.8: high confidence DLP match
+				ic.Logger.LogAnomaly(actx, "header_dlp", reason, 0.8) // 0.8: high confidence DLP match
 			}
 		}
 

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -89,6 +89,7 @@ func TestInterceptEmitReceiptOrBlockRequiresReceipt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
+	t.Cleanup(p.Close)
 	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
 	if err := rph.rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -850,58 +850,60 @@ func interceptAndRequestWithProxy(
 	return resp
 }
 
+type interceptRequestOptions struct {
+	Upstream *httptest.Server
+	Cache    *certgen.CertCache
+	Pool     *x509.CertPool
+	Config   *config.Config
+	Scanner  *scanner.Scanner
+	Logger   *audit.Logger
+	Metrics  *metrics.Metrics
+	Request  *http.Request
+	Recorder session.Recorder
+	Proxy    *Proxy
+}
+
 // interceptAndRequestWithRecorder is like interceptAndRequest but accepts a
 // session.Recorder for adaptive enforcement signal testing.
-func interceptAndRequestWithRecorder(
-	t *testing.T,
-	upstream *httptest.Server,
-	cache *certgen.CertCache,
-	pool *x509.CertPool,
-	cfg *config.Config,
-	sc *scanner.Scanner,
-	logger *audit.Logger,
-	m *metrics.Metrics,
-	req *http.Request,
-	rec session.Recorder,
-) *http.Response {
+func interceptAndRequestWithRecorder(t *testing.T, opts interceptRequestOptions) *http.Response {
 	t.Helper()
 
 	clientConn, proxyConn := net.Pipe()
 	t.Cleanup(func() { _ = clientConn.Close() })
 
-	host := upstream.Listener.Addr().(*net.TCPAddr).IP.String()
-	port := fmt.Sprintf("%d", upstream.Listener.Addr().(*net.TCPAddr).Port)
+	host := opts.Upstream.Listener.Addr().(*net.TCPAddr).IP.String()
+	port := fmt.Sprintf("%d", opts.Upstream.Listener.Addr().(*net.TCPAddr).Port)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-
 	go func() {
 		_ = interceptTunnel(ctx, proxyConn, &InterceptContext{
 			TargetHost: host,
 			TargetPort: port,
-			Config:     cfg,
-			Scanner:    sc,
-			CertCache:  cache,
-			Logger:     logger,
-			Metrics:    m,
+			Config:     opts.Config,
+			Scanner:    opts.Scanner,
+			CertCache:  opts.Cache,
+			Logger:     opts.Logger,
+			Metrics:    opts.Metrics,
 			ClientIP:   "10.0.0.1",
 			RequestID:  "test-req-1",
-			UpstreamRT: upstream.Client().Transport,
-			Recorder:   rec,
+			UpstreamRT: opts.Upstream.Client().Transport,
+			Recorder:   opts.Recorder,
+			Proxy:      opts.Proxy,
 		})
 	}()
 
 	tlsConn := tls.Client(clientConn, &tls.Config{
-		RootCAs:    pool,
+		RootCAs:    opts.Pool,
 		ServerName: host,
 	})
 	t.Cleanup(func() { _ = tlsConn.Close() })
 
-	if err := req.Write(tlsConn); err != nil {
+	if err := opts.Request.Write(tlsConn); err != nil {
 		t.Fatalf("write request: %v", err)
 	}
 
-	resp, err := http.ReadResponse(bufio.NewReader(tlsConn), req)
+	resp, err := http.ReadResponse(bufio.NewReader(tlsConn), opts.Request)
 	if err != nil {
 		t.Fatalf("read response: %v", err)
 	}
@@ -982,7 +984,17 @@ func TestInterceptTunnel_ConfigMismatch_NearMissSignal(t *testing.T) {
 	addr := upstream.Listener.Addr().String()
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://"+addr+"/api", nil)
 
-	resp := interceptAndRequestWithRecorder(t, upstream, cache, pool, cfg, sc, logger, m, req, rec)
+	resp := interceptAndRequestWithRecorder(t, interceptRequestOptions{
+		Upstream: upstream,
+		Cache:    cache,
+		Pool:     pool,
+		Config:   cfg,
+		Scanner:  sc,
+		Logger:   logger,
+		Metrics:  m,
+		Request:  req,
+		Recorder: rec,
+	})
 	defer func() { _ = resp.Body.Close() }()
 
 	// Request should be blocked (SSRF on internal IP).
@@ -1580,6 +1592,60 @@ func TestInterceptTunnel_HeaderDLPSuppressedCriticalAllowed(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200 (suppressed critical header DLP should forward)", resp.StatusCode)
+	}
+}
+
+func TestInterceptTunnel_HeaderDLPAdaptiveWarnUpgradeBlocks(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+		_, _ = fmt.Fprint(w, "unexpected")
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, _, logger, m := testInterceptSetup(t)
+	enforce := false
+	cfg.Enforce = &enforce
+	cfg.RequestBodyScanning.Enabled = true
+	cfg.RequestBodyScanning.ScanHeaders = true
+	cfg.RequestBodyScanning.Action = config.ActionWarn
+	cfg.RequestBodyScanning.HeaderMode = config.HeaderModeSensitive
+	cfg.RequestBodyScanning.SensitiveHeaders = []string{"Authorization"}
+	cfg.RequestBodyScanning.PatternActions = map[string]string{testBodyDLPPatternName: config.ActionWarn}
+	cfg.AdaptiveEnforcement.Enabled = true
+	cfg.AdaptiveEnforcement.Levels.Elevated.UpgradeWarn = ptrStr(config.ActionBlock)
+	addBodyDLPTestPattern(cfg)
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(func() { sc.Close() })
+
+	addr := upstream.Listener.Addr().String()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://"+addr+"/api", nil)
+	req.Header.Set("Authorization", "Bearer "+fakeBodyDLPSecret())
+
+	proxy := &Proxy{captureObs: capture.NopObserver{}, metrics: m}
+	resp := interceptAndRequestWithRecorder(t, interceptRequestOptions{
+		Upstream: upstream,
+		Cache:    cache,
+		Pool:     pool,
+		Config:   cfg,
+		Scanner:  sc,
+		Logger:   logger,
+		Metrics:  m,
+		Request:  req,
+		Recorder: &interceptMockRecorder{level: 1},
+		Proxy:    proxy,
+	})
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for adaptive header warn->block; body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "escalated") {
+		t.Fatalf("body = %q, want escalated adaptive block reason", body)
+	}
+	if upstreamHit.Load() {
+		t.Fatal("upstream was reached; adaptive header DLP block should fail closed before forwarding")
 	}
 }
 
@@ -4345,7 +4411,17 @@ func TestInterceptTunnel_RecordCleanAfterCleanRequest(t *testing.T) {
 	addr := upstream.Listener.Addr().String()
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://"+addr+"/clean", nil)
 
-	resp := interceptAndRequestWithRecorder(t, upstream, cache, pool, cfg, sc, logger, m, req, rec)
+	resp := interceptAndRequestWithRecorder(t, interceptRequestOptions{
+		Upstream: upstream,
+		Cache:    cache,
+		Pool:     pool,
+		Config:   cfg,
+		Scanner:  sc,
+		Logger:   logger,
+		Metrics:  m,
+		Request:  req,
+		Recorder: rec,
+	})
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/proxy/intercept_test.go
+++ b/internal/proxy/intercept_test.go
@@ -3490,6 +3490,44 @@ func TestInterceptTunnel_RequireReceiptsUpstreamErrorEmitsOutcome(t *testing.T) 
 	}
 }
 
+func TestInterceptTunnel_SSRFDialBlockEmitsSSRFOutcome(t *testing.T) {
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	cfg.FlightRecorder.RequireReceipts = true
+	p, err := New(cfg, logger, sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+	p.receiptEmitterPtr.Store(rph.emitter)
+
+	host := testLoopbackIP
+	port := "9999"
+	blockIP := net.ParseIP("127.0.0.1")
+	rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, newSSRFDialBlockError(req.Context(), "rebind.test", blockIP, ssrfDialBlockDetail("rebind.test", blockIP))
+	})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"https://"+net.JoinHostPort(host, port)+"/ssrf-dial-block", nil)
+
+	resp := interceptWithRT(t, cache, pool, cfg, sc, logger, m, rt,
+		&InterceptContext{Proxy: p, TargetHost: host, TargetPort: port}, req)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.SSRFPrivateIP) {
+		t.Fatalf("%s = %q, want %q", blockreason.HeaderReason, got, blockreason.SSRFPrivateIP)
+	}
+	outcome := requireSingleInterceptIntentOutcome(t, rph.findReceipts(t))
+	if outcome.ActionRecord.Verdict != config.ActionBlock {
+		t.Fatalf("outcome verdict = %q, want %q", outcome.ActionRecord.Verdict, config.ActionBlock)
+	}
+	if !strings.Contains(outcome.ActionRecord.Pattern, "status=403") ||
+		!strings.Contains(outcome.ActionRecord.Pattern, "reason="+string(blockreason.SSRFPrivateIP)) {
+		t.Fatalf("outcome pattern = %q, want status=403 reason=%s", outcome.ActionRecord.Pattern, blockreason.SSRFPrivateIP)
+	}
+}
+
 func TestInterceptTunnel_RequireReceiptsResponseBlockEmitsOutcome(t *testing.T) {
 	cache, pool, cfg, _, logger, m := testInterceptSetup(t)
 	cfg.FlightRecorder.RequireReceipts = true

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -118,6 +118,12 @@ const (
 	// the transport that originated the request rather than the
 	// hardcoded default. See Info 2 on the envelope-signing review.
 	ctxKeyRedirectTransport
+
+	// ctxKeySSRFDialScanSnapshot carries the DNS answers from an allowed
+	// scanner SSRF pass into the later dial-time re-resolution. The safe
+	// dialer uses it only to label public-to-internal changes as DNS
+	// rebinding; blocking itself does not depend on the snapshot.
+	ctxKeySSRFDialScanSnapshot
 )
 
 type envelopeEmitterSnapshot struct {
@@ -664,7 +670,9 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			} else {
 				redirectWarnCtx.Transport = TransportFetch
 			}
-			result := currentScanner.Scan(scanner.WithDLPWarnContext(req.Context(), redirectWarnCtx), redirectURL)
+			redirectScanCtx := scanner.WithDLPWarnContext(req.Context(), redirectWarnCtx)
+			result := currentScanner.Scan(redirectScanCtx, redirectURL)
+			*req = *req.WithContext(withAllowedSSRFDialScanSnapshot(redirectScanCtx, currentScanner, req.URL.Hostname(), result))
 			if !result.Allowed {
 				actx := newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName)
 				if currentCfg.EnforceEnabled() {
@@ -3122,7 +3130,7 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 			ip = v4
 		}
 		if currentSc := p.scannerPtr.Load(); currentSc.IsInternalIP(ip) && !currentSc.IsIPAllowlisted(ip) {
-			return nil, fmt.Errorf("SSRF blocked: connection to internal IP %s", host)
+			return nil, newSSRFDialBlockError(ctx, host, ip, ssrfDialBlockDetail(host, ip))
 		}
 		return p.dialer.DialContext(ctx, network, addr)
 	}
@@ -3157,7 +3165,7 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 				// allow/deny decision and logging.
 				continue
 			}
-			return nil, fmt.Errorf("SSRF blocked: %s resolves to internal IP %s", host, ipStr)
+			return nil, newSSRFDialBlockError(ctx, host, ip, ssrfDialBlockDetail(host, ip))
 		}
 	}
 
@@ -4181,6 +4189,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	ctx = context.WithValue(ctx, ctxKeyAgentScanner, sc)
 	ctx = context.WithValue(ctx, ctxKeyAgentContractLoader, snapshotContractLoader)
 	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportFetch)
+	ctx = withAllowedSSRFDialScanSnapshot(ctx, sc, parsed.Hostname(), result)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	if err != nil {
 		log.LogError(actx, err)
@@ -4303,6 +4312,42 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := p.client.Do(req) //nolint:gosec // G704: URL validated by scanner pipeline before reaching here
 	if err != nil {
+		var ssrfErr *ssrfDialBlockError
+		if errors.As(err, &ssrfErr) {
+			log.LogBlocked(actx, scanner.ScannerSSRF, ssrfErr.logDetail())
+			p.metrics.RecordBlocked(parsed.Hostname(), scanner.ScannerSSRF, time.Since(start), agentLabel)
+			emitFetchReceipt(receipt.EmitOpts{
+				ActionID:            actionID,
+				Verdict:             config.ActionBlock,
+				Layer:               scanner.ScannerSSRF,
+				Pattern:             string(ssrfErr.reason),
+				Transport:           "fetch",
+				Method:              http.MethodGet,
+				Target:              displayURL,
+				RequestID:           requestID,
+				Agent:               agent,
+				SessionTaintLevel:   fetchTaint.Risk.Level.String(),
+				SessionContaminated: fetchTaint.Risk.Contaminated,
+				RecentTaintSources:  fetchTaint.Risk.Sources,
+				SessionTaskID:       fetchTaint.Task.CurrentTaskID,
+				SessionTaskLabel:    fetchTaint.Task.CurrentTaskLabel,
+				AuthorityKind:       fetchTaint.Authority.String(),
+				TaintDecision:       fetchTaint.Result.Decision.String(),
+				TaintDecisionReason: fetchTaint.Result.Reason,
+				TaskOverrideApplied: fetchTaint.TaskOverrideApplied,
+			})
+			writeBlockedJSON(w,
+				ssrfErr.blockInfo(),
+				http.StatusForbidden, FetchResponse{
+					URL:         displayURL,
+					Agent:       agent,
+					Blocked:     true,
+					BlockReason: string(ssrfErr.reason),
+				})
+			outcomeStatus = strconv.Itoa(http.StatusForbidden)
+			outcomeReason = string(ssrfErr.reason)
+			return
+		}
 		// Detect fail-closed blocks from CheckRedirect and report them as blocked.
 		if blockedErr, ok := blockedRequestErrorFrom(err); ok {
 			log.LogBlocked(actx, blockedErr.layer, blockedErr.detail)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3115,6 +3115,11 @@ func isShieldExempt(hostname string, exempts []string) bool {
 // Used by both the HTTP client transport and CONNECT tunnel dialing.
 // Trusted domains (from config.trusted_domains) bypass the internal-IP check.
 func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	currentSc, _ := ctx.Value(ctxKeyAgentScanner).(*scanner.Scanner)
+	if currentSc == nil {
+		currentSc = p.scannerPtr.Load()
+	}
+
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, fmt.Errorf("ssrfSafeDialContext: split addr %q: %w", addr, err)
@@ -3129,7 +3134,7 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 		if v4 := ip.To4(); v4 != nil {
 			ip = v4
 		}
-		if currentSc := p.scannerPtr.Load(); currentSc.IsInternalIP(ip) && !currentSc.IsIPAllowlisted(ip) {
+		if currentSc.IsInternalIP(ip) && !currentSc.IsIPAllowlisted(ip) {
 			return nil, newSSRFDialBlockError(ctx, host, ip, ssrfDialBlockDetail(host, ip))
 		}
 		return p.dialer.DialContext(ctx, network, addr)
@@ -3138,7 +3143,6 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 	// Resolve DNS and validate every IP before connecting. Use the scanner's
 	// resolver so dns.host_overrides applies uniformly to both the SSRF
 	// scanner check and this dial-time check, preventing TOCTOU drift.
-	currentSc := p.scannerPtr.Load()
 	ips, err := currentSc.HostResolver().LookupHost(ctx, host)
 	if err != nil {
 		return nil, fmt.Errorf("ssrfSafeDialContext: DNS lookup %q: %w", host, err)

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -724,8 +724,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			if action == "" {
 				action = config.ActionBlock
 			}
-			requestEffectiveAction = action
-			requestScannerVerdict = scannerVerdictForContinuingAction(action, cfg.EnforceEnabled())
+			requestEffectiveAction = strongestRequestAction(requestEffectiveAction, action)
+			requestScannerVerdict = scannerVerdictForContinuingAction(requestEffectiveAction, cfg.EnforceEnabled())
 			patternNames := dlpMatchNames(pathDLP.Matches)
 			rp.logger.LogBodyDLP(newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, ""),
 				action,
@@ -766,8 +766,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			if headerHardBlock {
 				action = config.ActionBlock
 			}
-			requestEffectiveAction = action
-			requestScannerVerdict = scannerVerdictForContinuingAction(action, cfg.EnforceEnabled())
+			requestEffectiveAction = strongestRequestAction(requestEffectiveAction, action)
+			requestScannerVerdict = scannerVerdictForContinuingAction(requestEffectiveAction, cfg.EnforceEnabled())
 			patternNames := dlpMatchNames(headerResult.DLPMatches)
 			rp.logger.LogHeaderDLP(newHTTPAuditContext(rp.logger, r.Method, r.URL.String(), clientIP, requestID, ""), headerResult.HeaderName,
 				action, patternNames, nil)
@@ -804,8 +804,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			forwardedVerdict = verdict
 		}
 		if bodyFinding && verdict != "" {
-			requestEffectiveAction = verdict
-			requestScannerVerdict = scannerVerdictForContinuingAction(verdict, cfg.EnforceEnabled())
+			requestEffectiveAction = strongestRequestAction(requestEffectiveAction, verdict)
+			requestScannerVerdict = scannerVerdictForContinuingAction(requestEffectiveAction, cfg.EnforceEnabled())
 		}
 		reverseBodyBytes = bodyBytes
 	}
@@ -2154,4 +2154,24 @@ func reverseCaptureAgent(r *http.Request) string {
 		return agentAnonymous
 	}
 	return agent
+}
+
+func strongestRequestAction(current, next string) string {
+	if requestActionRank(next) > requestActionRank(current) {
+		return next
+	}
+	return current
+}
+
+func requestActionRank(action string) int {
+	switch action {
+	case config.ActionBlock:
+		return 3
+	case config.ActionAsk:
+		return 2
+	case config.ActionWarn:
+		return 1
+	default:
+		return 0
+	}
 }

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -755,11 +755,14 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		headerResult := scanRequestHeadersForTarget(r.Context(), r.Header, cfg, sc, dlpTarget.String())
 		if headerResult != nil {
 			hasFinding = true
-			action := cfg.RequestBodyScanning.Action
+			action := headerResult.Action
+			if action == "" {
+				action = cfg.RequestBodyScanning.Action
+			}
 			if action == "" {
 				action = config.ActionBlock
 			}
-			headerHardBlock := shouldHardBlockCriticalDLP(headerResult.DLPMatches, cfg.EnforceEnabled())
+			headerHardBlock := shouldHardBlockRequestDLP(headerResult.DLPMatches, cfg)
 			if headerHardBlock {
 				action = config.ActionBlock
 			}
@@ -1137,6 +1140,9 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 		Path:            r.URL.Path,
 		Target:          receiptInput.Target,
 		Suppress:        cfg.Suppress,
+		Action:          cfg.RequestBodyScanning.Action,
+		DisablePatterns: cfg.RequestBodyScanning.DisablePatterns,
+		PatternActions:  cfg.RequestBodyScanning.PatternActions,
 	}
 	applyBodyScanRedaction(&bodyReq, redaction)
 	bodyBytes, result := scanRequestBody(r.Context(), bodyReq)

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -2030,11 +2030,8 @@ func (rp *ReverseProxyHandler) errorHandler(w http.ResponseWriter, r *http.Reque
 			RequestID: requestID,
 			Agent:     agent,
 		}
-		if rp.cfgPtr != nil {
-			cfg := rp.cfgPtr.Load()
-			if cfg != nil {
-				opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
-			}
+		if cfg, _ := r.Context().Value(ctxKeyReverseEnvelopeCfg).(*config.Config); cfg != nil {
+			opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 		}
 		_ = rp.emitReceipt(opts)
 		written := writeReverseProxyBlock(w, http.StatusForbidden, ssrfErr.blockInfo(), string(ssrfErr.reason))

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -2009,6 +2009,38 @@ func (rp *ReverseProxyHandler) errorHandler(w http.ResponseWriter, r *http.Reque
 		recordErrorOutcome(http.StatusForbidden, written, blockedErr.layer)
 		return
 	}
+	var ssrfErr *ssrfDialBlockError
+	if errors.As(err, &ssrfErr) {
+		rp.metrics.RecordReverseProxyRequest(r.Method, "403")
+		rp.metrics.RecordReverseProxyScanBlocked(scanDirectionRequest, scanner.ScannerSSRF)
+		rp.logger.LogBlocked(actx, scanner.ScannerSSRF, ssrfErr.logDetail())
+		actionID, _ := r.Context().Value(ctxKeyReverseActionID).(string)
+		if actionID == "" {
+			actionID = receipt.NewActionID()
+		}
+		agent, _ := r.Context().Value(ctxKeyAgent).(string)
+		opts := receipt.EmitOpts{
+			ActionID:  actionID,
+			Verdict:   config.ActionBlock,
+			Layer:     scanner.ScannerSSRF,
+			Pattern:   string(ssrfErr.reason),
+			Transport: TransportReverse,
+			Method:    r.Method,
+			Target:    r.URL.String(),
+			RequestID: requestID,
+			Agent:     agent,
+		}
+		if rp.cfgPtr != nil {
+			cfg := rp.cfgPtr.Load()
+			if cfg != nil {
+				opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
+			}
+		}
+		_ = rp.emitReceipt(opts)
+		written := writeReverseProxyBlock(w, http.StatusForbidden, ssrfErr.blockInfo(), string(ssrfErr.reason))
+		recordErrorOutcome(http.StatusForbidden, written, string(ssrfErr.reason))
+		return
+	}
 
 	rp.metrics.RecordReverseProxyRequest(r.Method, "502")
 	rp.logger.LogError(actx, err)

--- a/internal/proxy/reverse_submit_dialer_test.go
+++ b/internal/proxy/reverse_submit_dialer_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
@@ -177,6 +178,40 @@ func TestProxy_SafeDialerBlocksInternalIP(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "SSRF blocked") {
 		t.Fatalf("SafeDialer error = %v, want SSRF blocked", err)
+	}
+}
+
+func TestSubmitProfile_SafeDialerCoreCIDRBlockFailsClosedAsUpstreamError(t *testing.T) {
+	cfg, upstreamURL := submitProfileTestConfig("http://submit-rebind.test:1")
+	cfg.Internal = nil
+	cfg.DNS.HostOverrides = map[string][]string{
+		"submit-rebind.test": {"10.0.0.1"},
+	}
+
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New())
+	if err != nil {
+		t.Fatalf("New proxy: %v", err)
+	}
+
+	handlerProxy := submitProfileReverseProxyWithDialer(t, cfg, upstreamURL, p.SafeDialer())
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, handlerProxy.URL+"/v1/batch", strings.NewReader(`{"clean":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post through reverse proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
+	}
+	if got := resp.Header.Get(blockreason.HeaderReason); got != "" {
+		t.Fatalf("%s = %q, want empty generic upstream error", blockreason.HeaderReason, got)
 	}
 }
 

--- a/internal/proxy/reverse_submit_dialer_test.go
+++ b/internal/proxy/reverse_submit_dialer_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
@@ -181,9 +183,10 @@ func TestProxy_SafeDialerBlocksInternalIP(t *testing.T) {
 	}
 }
 
-func TestSubmitProfile_SafeDialerCoreCIDRBlockFailsClosedAsUpstreamError(t *testing.T) {
+func TestSubmitProfile_SafeDialerCoreCIDRBlockPreservesSSRFReason(t *testing.T) {
 	cfg, upstreamURL := submitProfileTestConfig("http://submit-rebind.test:1")
 	cfg.Internal = nil
+	cfg.FlightRecorder.RequireReceipts = true
 	cfg.DNS.HostOverrides = map[string][]string{
 		"submit-rebind.test": {"10.0.0.1"},
 	}
@@ -196,7 +199,21 @@ func TestSubmitProfile_SafeDialerCoreCIDRBlockFailsClosedAsUpstreamError(t *test
 		t.Fatalf("New proxy: %v", err)
 	}
 
-	handlerProxy := submitProfileReverseProxyWithDialer(t, cfg, upstreamURL, p.SafeDialer())
+	var cfgPtr atomic.Pointer[config.Config]
+	var scPtr atomic.Pointer[scanner.Scanner]
+	cfgPtr.Store(cfg)
+	scPtr.Store(sc)
+
+	logger := audit.NewNop()
+	handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, logger, metrics.New(), killswitch.New(cfg), nil, nil)
+	handler.SetSafeDialer(p.SafeDialer())
+	dir := t.TempDir()
+	emitter, rec, _ := newCoverageEmitter(t, dir)
+	var emPtr atomic.Pointer[receipt.Emitter]
+	emPtr.Store(emitter)
+	handler.SetReceiptEmitter(&emPtr)
+	handlerProxy := newIPv4Server(t, handler)
+	t.Cleanup(handlerProxy.Close)
 
 	req, _ := http.NewRequestWithContext(context.Background(),
 		http.MethodPost, handlerProxy.URL+"/v1/batch", strings.NewReader(`{"clean":true}`))
@@ -207,11 +224,49 @@ func TestSubmitProfile_SafeDialerCoreCIDRBlockFailsClosedAsUpstreamError(t *test
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusBadGateway {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
 	}
-	if got := resp.Header.Get(blockreason.HeaderReason); got != "" {
-		t.Fatalf("%s = %q, want empty generic upstream error", blockreason.HeaderReason, got)
+	if got := resp.Header.Get(blockreason.HeaderReason); got != string(blockreason.SSRFPrivateIP) {
+		t.Fatalf("%s = %q, want %q", blockreason.HeaderReason, got, blockreason.SSRFPrivateIP)
+	}
+
+	waitForReceiptOrTimeout(t, dir)
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
+	receipts := extractReceiptsFromDir(t, dir)
+	admission := findReverseAdmissionAllowReceipt(t, receipts)
+	var blockCount, outcomeCount int
+	var outcome receipt.Receipt
+	for _, rcpt := range receipts {
+		ar := rcpt.ActionRecord
+		if ar.Transport == TransportReverse &&
+			ar.Verdict == config.ActionBlock &&
+			ar.Layer == scanner.ScannerSSRF &&
+			ar.Pattern == string(blockreason.SSRFPrivateIP) {
+			blockCount++
+		}
+		if ar.DecisionPhase == receipt.DecisionPhaseOutcome &&
+			ar.Transport == TransportReverse {
+			outcome = rcpt
+			outcomeCount++
+		}
+	}
+	if blockCount != 1 {
+		t.Fatalf("reverse SSRF block receipt count = %d, want 1", blockCount)
+	}
+	if outcomeCount != 1 {
+		t.Fatalf("reverse outcome receipt count = %d, want 1", outcomeCount)
+	}
+	if outcome.ActionRecord.ActionID != admission.ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %q, want admission action_id %q",
+			outcome.ActionRecord.ActionID, admission.ActionRecord.ActionID)
+	}
+	for _, want := range []string{"status=403", "reason=" + string(blockreason.SSRFPrivateIP)} {
+		if !strings.Contains(outcome.ActionRecord.Pattern, want) {
+			t.Fatalf("reverse outcome pattern = %q, want %s", outcome.ActionRecord.Pattern, want)
+		}
 	}
 }
 

--- a/internal/proxy/reverse_submit_dialer_test.go
+++ b/internal/proxy/reverse_submit_dialer_test.go
@@ -198,6 +198,7 @@ func TestSubmitProfile_SafeDialerCoreCIDRBlockPreservesSSRFReason(t *testing.T) 
 	if err != nil {
 		t.Fatalf("New proxy: %v", err)
 	}
+	t.Cleanup(p.Close)
 
 	var cfgPtr atomic.Pointer[config.Config]
 	var scPtr atomic.Pointer[scanner.Scanner]

--- a/internal/proxy/reverse_test.go
+++ b/internal/proxy/reverse_test.go
@@ -368,6 +368,70 @@ func TestReverseLiveLock_AuditScannerBlockContinuesAsWarn(t *testing.T) {
 	}
 }
 
+func TestReverseLiveLock_HeaderWarnDoesNotDowngradeURLBlockEffectiveAction(t *testing.T) {
+	var hits atomic.Int32
+	cfg := reverseTestConfig()
+	enforce := false
+	cfg.Enforce = &enforce
+	cfg.RequestBodyScanning.ScanHeaders = true
+	cfg.RequestBodyScanning.HeaderMode = "all"
+	cfg.RequestBodyScanning.Action = config.ActionBlock
+	cfg.RequestBodyScanning.PatternActions = map[string]string{testBodyDLPPatternName: config.ActionWarn}
+	addBodyDLPTestPattern(cfg)
+
+	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodGet)
+	rule.Selector["effective_action"] = config.ActionBlock
+	proxy := reverseLiveLockSetupWithConfig(t, cfg, "api.example.com", testContractLoader(t, contractruntime.ModeLive, rule), nil,
+		func(w http.ResponseWriter, r *http.Request) {
+			hits.Add(1)
+			if got := r.Header.Get("Authorization"); !strings.Contains(got, fakeBodyDLPSecret()) {
+				t.Fatalf("Authorization header = %q, want test DLP fixture", got)
+			}
+			_, _ = fmt.Fprint(w, "forwarded")
+		})
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, proxy.URL+"/v1/chat?secret="+fakeBodyDLPSecret(), nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+fakeBodyDLPSecret())
+	req.Header.Set(AgentHeader, "agent-a")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestStrongestRequestAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		next    string
+		want    string
+	}{
+		{name: "block beats warn", current: config.ActionBlock, next: config.ActionWarn, want: config.ActionBlock},
+		{name: "ask beats warn", current: config.ActionWarn, next: config.ActionAsk, want: config.ActionAsk},
+		{name: "block beats ask", current: config.ActionAsk, next: config.ActionBlock, want: config.ActionBlock},
+		{name: "allow stays lowest", current: config.ActionAllow, next: "", want: config.ActionAllow},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := strongestRequestAction(tc.current, tc.next); got != tc.want {
+				t.Fatalf("strongestRequestAction(%q, %q) = %q, want %q", tc.current, tc.next, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestReverseLiveLock_ShadowModeObservesWithoutBlocking(t *testing.T) {
 	var hits atomic.Int32
 	rule := contractruntimetest.HTTPEnforceRule("r-chat", "api.example.com", "/v1/chat", http.MethodPost)

--- a/internal/proxy/ssrf_dial_block.go
+++ b/internal/proxy/ssrf_dial_block.go
@@ -66,13 +66,19 @@ func withSSRFDialScanSnapshot(ctx context.Context, host string, ips []string) co
 }
 
 func withAllowedSSRFDialScanSnapshot(ctx context.Context, sc *scanner.Scanner, host string, result scanner.Result) context.Context {
-	if ctx == nil || sc == nil || !result.Allowed || len(result.SSRFResolvedIPs) == 0 {
-		return ctx
+	if ctx == nil {
+		return nil
+	}
+	clearSnapshot := func() context.Context {
+		return context.WithValue(ctx, ctxKeySSRFDialScanSnapshot, ssrfDialScanSnapshot{})
+	}
+	if sc == nil || !result.Allowed || len(result.SSRFResolvedIPs) == 0 {
+		return clearSnapshot()
 	}
 	for _, ipStr := range result.SSRFResolvedIPs {
 		ip := normalizeSSRFDialIP(net.ParseIP(strings.TrimSpace(stripIPv6Zone(ipStr))))
 		if ip == nil || scanner.IsCloudMetadataIP(ip) || sc.IsInternalIP(ip) {
-			return ctx
+			return clearSnapshot()
 		}
 	}
 	return withSSRFDialScanSnapshot(ctx, host, result.SSRFResolvedIPs)

--- a/internal/proxy/ssrf_dial_block.go
+++ b/internal/proxy/ssrf_dial_block.go
@@ -71,7 +71,7 @@ func withAllowedSSRFDialScanSnapshot(ctx context.Context, sc *scanner.Scanner, h
 	}
 	for _, ipStr := range result.SSRFResolvedIPs {
 		ip := normalizeSSRFDialIP(net.ParseIP(strings.TrimSpace(stripIPv6Zone(ipStr))))
-		if ip == nil || scanner.IsCloudMetadataIP(ip) || sc.IsInternalIP(ip) || sc.IsIPAllowlisted(ip) {
+		if ip == nil || scanner.IsCloudMetadataIP(ip) || sc.IsInternalIP(ip) {
 			return ctx
 		}
 	}

--- a/internal/proxy/ssrf_dial_block.go
+++ b/internal/proxy/ssrf_dial_block.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+type ssrfDialScanSnapshot struct {
+	host string
+	ips  map[string]struct{}
+}
+
+type ssrfDialBlockError struct {
+	reason blockreason.Reason
+	detail string
+}
+
+func (e *ssrfDialBlockError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.detail
+}
+
+func (e *ssrfDialBlockError) blockInfo() blockreason.Info {
+	if e == nil {
+		return blockInfoFor(blockreason.SSRFPrivateIP, scanner.ScannerSSRF)
+	}
+	return blockInfoFor(e.reason, scanner.ScannerSSRF)
+}
+
+func (e *ssrfDialBlockError) logDetail() string {
+	if e == nil {
+		return ""
+	}
+	return string(e.reason) + ": " + e.detail
+}
+
+func withSSRFDialScanSnapshot(ctx context.Context, host string, ips []string) context.Context {
+	if ctx == nil || host == "" || len(ips) == 0 {
+		return ctx
+	}
+	snapshot := ssrfDialScanSnapshot{
+		host: normalizeSSRFDialHost(host),
+		ips:  make(map[string]struct{}, len(ips)),
+	}
+	for _, ipStr := range ips {
+		ip := normalizeSSRFDialIP(net.ParseIP(strings.TrimSpace(stripIPv6Zone(ipStr))))
+		if ip == nil {
+			continue
+		}
+		snapshot.ips[ip.String()] = struct{}{}
+	}
+	if snapshot.host == "" || len(snapshot.ips) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeySSRFDialScanSnapshot, snapshot)
+}
+
+func withAllowedSSRFDialScanSnapshot(ctx context.Context, sc *scanner.Scanner, host string, result scanner.Result) context.Context {
+	if ctx == nil || sc == nil || !result.Allowed || len(result.SSRFResolvedIPs) == 0 {
+		return ctx
+	}
+	for _, ipStr := range result.SSRFResolvedIPs {
+		ip := normalizeSSRFDialIP(net.ParseIP(strings.TrimSpace(stripIPv6Zone(ipStr))))
+		if ip == nil || scanner.IsCloudMetadataIP(ip) || sc.IsInternalIP(ip) || sc.IsIPAllowlisted(ip) {
+			return ctx
+		}
+	}
+	return withSSRFDialScanSnapshot(ctx, host, result.SSRFResolvedIPs)
+}
+
+func newSSRFDialBlockError(ctx context.Context, host string, ip net.IP, detail string) *ssrfDialBlockError {
+	reason := blockreason.SSRFPrivateIP
+	if scanner.IsCloudMetadataIP(ip) {
+		reason = blockreason.SSRFMetadata
+	}
+	if isSSRFDNSRebind(ctx, host, ip) {
+		reason = blockreason.SSRFDNSRebind
+	}
+	return &ssrfDialBlockError{reason: reason, detail: detail}
+}
+
+func isSSRFDNSRebind(ctx context.Context, host string, ip net.IP) bool {
+	if ctx == nil || ip == nil {
+		return false
+	}
+	snapshot, ok := ctx.Value(ctxKeySSRFDialScanSnapshot).(ssrfDialScanSnapshot)
+	if !ok || snapshot.host == "" || len(snapshot.ips) == 0 {
+		return false
+	}
+	if normalizeSSRFDialHost(host) != snapshot.host {
+		return false
+	}
+	ip = normalizeSSRFDialIP(ip)
+	if ip == nil {
+		return false
+	}
+	_, seenAtScanTime := snapshot.ips[ip.String()]
+	return !seenAtScanTime
+}
+
+func normalizeSSRFDialHost(host string) string {
+	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+}
+
+func normalizeSSRFDialIP(ip net.IP) net.IP {
+	if ip == nil {
+		return nil
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip
+}
+
+func stripIPv6Zone(ipStr string) string {
+	if idx := strings.Index(ipStr, "%"); idx != -1 {
+		return ipStr[:idx]
+	}
+	return ipStr
+}
+
+func ssrfDialBlockDetail(host string, ip net.IP) string {
+	if scanner.IsCloudMetadataIP(ip) {
+		return fmt.Sprintf("SSRF blocked: %s resolves to cloud metadata endpoint %s", host, ip)
+	}
+	return fmt.Sprintf("SSRF blocked: %s resolves to internal IP %s", host, ip)
+}

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -262,6 +262,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	})
 	r = r.WithContext(wsScanCtx)
 	result := sc.Scan(wsScanCtx, scanURL)
+	r = r.WithContext(withAllowedSSRFDialScanSnapshot(r.Context(), sc, parsed.Hostname(), result))
 
 	// Capture observer: record WebSocket URL verdict for policy replay.
 	{
@@ -804,6 +805,27 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Dial upstream via SSRF-safe dialer.
 	upstreamConn, dialErr := p.wsDialUpstream(r.Context(), targetURL, fwdHeaders, cfg)
 	if dialErr != nil {
+		var ssrfErr *ssrfDialBlockError
+		if errors.As(dialErr, &ssrfErr) {
+			log.LogBlocked(actx, scanner.ScannerSSRF, ssrfErr.logDetail())
+			p.metrics.RecordWSBlocked()
+			emitWebSocketReceipt(receipt.EmitOpts{
+				ActionID:  actionID,
+				Verdict:   config.ActionBlock,
+				Layer:     scanner.ScannerSSRF,
+				Pattern:   string(ssrfErr.reason),
+				Transport: TransportWS,
+				Method:    "WS",
+				Target:    targetURL,
+				RequestID: requestID,
+				Agent:     agent,
+			})
+			plwsutil.WriteCloseFrame(clientConn, ws.StatusPolicyViolation, ssrfErr.blockInfo().CloseFramePayload())
+			outcomeStatus = strconv.Itoa(int(ws.StatusPolicyViolation))
+			outcomeBytes = 0
+			outcomeReason = string(ssrfErr.reason)
+			return
+		}
 		log.LogError(actx, fmt.Errorf("upstream dial: %w", dialErr))
 		plwsutil.WriteCloseFrame(clientConn, ws.StatusInternalServerError, "upstream dial failed")
 		outcomeStatus = strconv.Itoa(int(ws.StatusInternalServerError))

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -444,6 +444,26 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// DLP-scan forwarded header values regardless of destination or enforce mode.
 	// In audit mode, findings are logged as anomalies but traffic is allowed.
 	if blocked, hardBlock, action, reason := p.dlpScanWSHeaders(r.Context(), fwdHeaders, sc, cfg, targetURL); blocked {
+		captureHeaderDLP := func(effectiveAction, skipReason string) {
+			p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
+				Subsurface:        "dlp_ws_header",
+				Transport:         TransportWS,
+				SessionID:         captureSessionKey(agent, clientIP),
+				SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
+				RequestID:         requestID,
+				ConfigHash:        cfg.CanonicalPolicyHash(),
+				Agent:             agent,
+				Profile:           id.Profile,
+				// Header DLP captures describe the HTTP upgrade handshake, not
+				// later bidirectional frame semantics.
+				ActionClass:     captureHTTPActionClass(r.Method),
+				Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
+				TransformKind:   capture.TransformHeaderValue,
+				EffectiveAction: effectiveAction,
+				Outcome:         captureOutcome(effectiveAction, false),
+				SkipReason:      skipReason,
+			})
+		}
 		if action == "" {
 			action = cfg.RequestBodyScanning.Action
 		}
@@ -453,25 +473,6 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		} else {
 			action = config.ActionWarn
 		}
-		// Capture observer: record WS header DLP verdict for policy replay.
-		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
-			Subsurface:        "dlp_ws_header",
-			Transport:         TransportWS,
-			SessionID:         captureSessionKey(agent, clientIP),
-			SessionIDOriginal: captureSessionKeyOriginal(agent, clientIP),
-			RequestID:         requestID,
-			ConfigHash:        cfg.CanonicalPolicyHash(),
-			Agent:             agent,
-			Profile:           id.Profile,
-			// Header DLP captures describe the HTTP upgrade handshake, not
-			// later bidirectional frame semantics.
-			ActionClass:     captureHTTPActionClass(r.Method),
-			Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
-			TransformKind:   capture.TransformHeaderValue,
-			EffectiveAction: action,
-			Outcome:         captureOutcome(action, false),
-			SkipReason:      reason,
-		})
 		wsHasFinding = true
 		// Record session activity so adaptive enforcement sees header-DLP hits.
 		headerSR := p.recordSessionActivityWithUserAgent(sessionActivityOptions{
@@ -485,6 +486,17 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			Logger:     log,
 			DeferClean: false,
 		})
+		if !wsHeaderBlocked && cfg.AdaptiveEnforcement.Enabled && headerSR.Level > 0 {
+			effectiveAction := decide.UpgradeAction(action, headerSR.Level, &cfg.AdaptiveEnforcement)
+			if effectiveAction == config.ActionBlock {
+				sessionKey := sessionKeyFor(agent, clientIP)
+				recordAdaptiveUpgrade(log, p.metrics, adaptiveUpgrade{SessionKey: sessionKey, Level: session.EscalationLabel(headerSR.Level), FromAction: action, ToAction: effectiveAction, Scanner: audit.ScannerDLP, ClientIP: clientIP, RequestID: requestID})
+				action = effectiveAction
+				reason += " (escalated)"
+				wsHeaderBlocked = true
+			}
+		}
+		captureHeaderDLP(action, reason)
 		if wsHeaderBlocked {
 			log.LogWSBlocked(targetURL, audit.DirectionClientToServer, audit.ScannerDLP, reason, clientIP, requestID)
 			p.metrics.RecordWSBlocked()

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -497,6 +497,24 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		captureHeaderDLP(action, reason)
+		if !wsHeaderBlocked && headerSR.Blocked {
+			p.metrics.RecordWSBlocked()
+			emitWebSocketReceipt(receipt.EmitOpts{
+				ActionID:  receipt.NewActionID(),
+				Verdict:   config.ActionBlock,
+				Layer:     "session_profiling",
+				Pattern:   headerSR.Detail,
+				Transport: TransportWS,
+				Method:    "WS",
+				Target:    targetURL,
+				RequestID: requestID,
+				Agent:     agent,
+			})
+			writeBlockedError(w,
+				blockInfoFor(blockreason.SessionAnomaly, "session_profiling"),
+				headerSR.Detail, http.StatusForbidden)
+			return
+		}
 		if wsHeaderBlocked {
 			log.LogWSBlocked(targetURL, audit.DirectionClientToServer, audit.ScannerDLP, reason, clientIP, requestID)
 			p.metrics.RecordWSBlocked()

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -1011,6 +1011,8 @@ func (p *Proxy) dlpScanWSHeaders(ctx context.Context, headers http.Header, sc *s
 	// Scan all headers that buildWSForwardHeaders may forward. This covers
 	// auth headers, cookies, origin, subprotocol, and user-agent. An agent
 	// can exfiltrate data in any of these values.
+	var allMatches []scanner.TextDLPMatch
+	matchedHeaders := make([]string, 0, 2)
 	for _, key := range []string{
 		"Authorization", "X-Api-Key", "X-Goog-Api-Key", "Cookie",
 		"Origin", "Sec-WebSocket-Protocol", "User-Agent",
@@ -1025,15 +1027,30 @@ func (p *Proxy) dlpScanWSHeaders(ctx context.Context, headers http.Header, sc *s
 			if len(matches) == 0 {
 				continue
 			}
-			names := make([]string, len(matches))
-			for i, m := range matches {
-				names[i] = m.PatternName
-			}
-			action := requestBodyDLPAction(matches, cfg.RequestBodyScanning.Action, cfg.RequestBodyScanning.PatternActions)
-			return true, shouldHardBlockRequestDLP(matches, cfg), action, fmt.Sprintf("DLP match in %s header: %s", key, strings.Join(names, ", "))
+			allMatches = append(allMatches, matches...)
+			matchedHeaders = append(matchedHeaders, key)
 		}
 	}
+	allMatches = uniqueBodyDLPMatches(allMatches)
+	if len(allMatches) > 0 {
+		names := make([]string, len(allMatches))
+		for i, m := range allMatches {
+			names[i] = m.PatternName
+		}
+		action := requestBodyDLPAction(allMatches, cfg.RequestBodyScanning.Action, cfg.RequestBodyScanning.PatternActions)
+		return true, shouldHardBlockRequestDLP(allMatches, cfg), action, fmt.Sprintf("DLP match in %s header: %s", wsHeaderDLPSource(matchedHeaders), strings.Join(names, ", "))
+	}
 	return false, false, "", ""
+}
+
+func wsHeaderDLPSource(headers []string) string {
+	switch len(headers) {
+	case 0:
+		return ""
+	case 1:
+		return headers[0]
+	}
+	return "multiple"
 }
 
 // isHostAllowlisted checks if a hostname matches any pattern in the allowlist.

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -442,7 +442,16 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	// DLP-scan forwarded header values regardless of destination or enforce mode.
 	// In audit mode, findings are logged as anomalies but traffic is allowed.
-	if blocked, hardBlock, reason := p.dlpScanWSHeaders(r.Context(), fwdHeaders, sc, cfg, targetURL); blocked {
+	if blocked, hardBlock, action, reason := p.dlpScanWSHeaders(r.Context(), fwdHeaders, sc, cfg, targetURL); blocked {
+		if action == "" {
+			action = cfg.RequestBodyScanning.Action
+		}
+		wsHeaderBlocked := hardBlock || (action == config.ActionBlock && cfg.EnforceEnabled())
+		if wsHeaderBlocked {
+			action = config.ActionBlock
+		} else {
+			action = config.ActionWarn
+		}
 		// Capture observer: record WS header DLP verdict for policy replay.
 		p.captureObs.ObserveDLPVerdict(r.Context(), &capture.DLPVerdictRecord{
 			Subsurface:        "dlp_ws_header",
@@ -458,8 +467,8 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			ActionClass:     captureHTTPActionClass(r.Method),
 			Request:         capture.CaptureRequest{Method: r.Method, URL: targetURL},
 			TransformKind:   capture.TransformHeaderValue,
-			EffectiveAction: config.ActionBlock,
-			Outcome:         capture.OutcomeBlocked,
+			EffectiveAction: action,
+			Outcome:         captureOutcome(action, false),
 			SkipReason:      reason,
 		})
 		wsHasFinding = true
@@ -470,12 +479,12 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			Hostname:   parsed.Hostname(),
 			RequestID:  requestID,
 			UserAgent:  r.UserAgent(),
-			Result:     scanner.Result{Allowed: false, Score: 0.9},
+			Result:     scanner.Result{Allowed: !wsHeaderBlocked, Score: 0.9},
 			Config:     cfg,
 			Logger:     log,
 			DeferClean: false,
 		})
-		if hardBlock || cfg.EnforceEnabled() {
+		if wsHeaderBlocked {
 			log.LogWSBlocked(targetURL, audit.DirectionClientToServer, audit.ScannerDLP, reason, clientIP, requestID)
 			p.metrics.RecordWSBlocked()
 			emitWebSocketReceipt(receipt.EmitOpts{
@@ -975,7 +984,8 @@ func (p *Proxy) buildWSForwardHeaders(r *http.Request, parsed *url.URL, cfg *con
 // dlpScanWSHeaders runs DLP scanning on all forwarded header values before the
 // upstream handshake. Headers are scanned regardless of destination (no
 // allowlist skip) because agents can exfiltrate secrets in any header value.
-func (p *Proxy) dlpScanWSHeaders(ctx context.Context, headers http.Header, sc *scanner.Scanner, cfg *config.Config, targetURL string) (blocked bool, hardBlock bool, reason string) {
+func (p *Proxy) dlpScanWSHeaders(ctx context.Context, headers http.Header, sc *scanner.Scanner, cfg *config.Config, targetURL string) (blocked bool, hardBlock bool, action string, reason string) {
+	disabled := bodyDLPDisabledSet(cfg.RequestBodyScanning.DisablePatterns)
 	// Scan all headers that buildWSForwardHeaders may forward. This covers
 	// auth headers, cookies, origin, subprotocol, and user-agent. An agent
 	// can exfiltrate data in any of these values.
@@ -989,7 +999,7 @@ func (p *Proxy) dlpScanWSHeaders(ctx context.Context, headers http.Header, sc *s
 		}
 		result := sc.ScanTextForDLP(ctx, val)
 		if !result.Clean {
-			matches := unsuppressedDLPMatches(result.Matches, targetURL, cfg.Suppress)
+			matches := filterBodyDLPMatches(result.Matches, targetURL, cfg.Suppress, disabled)
 			if len(matches) == 0 {
 				continue
 			}
@@ -997,10 +1007,11 @@ func (p *Proxy) dlpScanWSHeaders(ctx context.Context, headers http.Header, sc *s
 			for i, m := range matches {
 				names[i] = m.PatternName
 			}
-			return true, shouldHardBlockCriticalDLP(matches, cfg.EnforceEnabled()), fmt.Sprintf("DLP match in %s header: %s", key, strings.Join(names, ", "))
+			action := requestBodyDLPAction(matches, cfg.RequestBodyScanning.Action, cfg.RequestBodyScanning.PatternActions)
+			return true, shouldHardBlockRequestDLP(matches, cfg), action, fmt.Sprintf("DLP match in %s header: %s", key, strings.Join(names, ", "))
 		}
 	}
-	return false, false, ""
+	return false, false, "", ""
 }
 
 // isHostAllowlisted checks if a hostname matches any pattern in the allowlist.
@@ -1130,16 +1141,19 @@ func (r *wsRelay) scanClientMessageBody(ctx context.Context, msg []byte) ([]byte
 	}
 
 	bodyReq := BodyScanRequest{
-		Body:        bytes.NewReader(msg),
-		Method:      http.MethodGet,
-		ContentType: contentType,
-		MaxBytes:    maxBytes,
-		Scanner:     r.scanner,
-		AgentID:     r.agent,
-		Host:        r.hostname,
-		Path:        r.path,
-		Target:      r.targetURL,
-		Suppress:    r.cfg.Suppress,
+		Body:            bytes.NewReader(msg),
+		Method:          http.MethodGet,
+		ContentType:     contentType,
+		MaxBytes:        maxBytes,
+		Scanner:         r.scanner,
+		AgentID:         r.agent,
+		Host:            r.hostname,
+		Path:            r.path,
+		Target:          r.targetURL,
+		Suppress:        r.cfg.Suppress,
+		Action:          r.cfg.RequestBodyScanning.Action,
+		DisablePatterns: r.cfg.RequestBodyScanning.DisablePatterns,
+		PatternActions:  r.cfg.RequestBodyScanning.PatternActions,
 	}
 	applyBodyScanRedaction(&bodyReq, r.redaction)
 	return scanRequestBody(ctx, bodyReq)

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -1780,6 +1780,88 @@ func TestWSProxyHeaderDLPBlock(t *testing.T) {
 	}
 }
 
+func TestWSProxyHeaderDLPDisablePatternAllowsNonCore(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+
+	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		addBodyDLPTestPattern(cfg)
+		cfg.RequestBodyScanning.DisablePatterns = []string{testBodyDLPPatternName}
+	})
+	defer proxyCleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wsURL := fmt.Sprintf("ws://%s/ws?url=ws://%s", proxyAddr, backendAddr)
+	dialer := ws.Dialer{
+		Header: ws.HandshakeHeaderHTTP(http.Header{
+			"Authorization": []string{"Bearer " + fakeBodyDLPSecret()},
+		}),
+		Timeout: 5 * time.Second,
+	}
+
+	conn, _, _, err := dialer.Dial(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("disabled non-core header DLP should allow websocket dial: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck // test
+}
+
+func TestWSProxyHeaderDLPPatternWarnOverrideAllowsNonCore(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+
+	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		addBodyDLPTestPattern(cfg)
+		cfg.RequestBodyScanning.PatternActions = map[string]string{testBodyDLPPatternName: config.ActionWarn}
+	})
+	defer proxyCleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wsURL := fmt.Sprintf("ws://%s/ws?url=ws://%s", proxyAddr, backendAddr)
+	dialer := ws.Dialer{
+		Header: ws.HandshakeHeaderHTTP(http.Header{
+			"Authorization": []string{"Bearer " + fakeBodyDLPSecret()},
+		}),
+		Timeout: 5 * time.Second,
+	}
+
+	conn, _, _, err := dialer.Dial(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("warn-only non-core header DLP should allow websocket dial: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck // test
+}
+
+func TestWSProxyHeaderDLPDisabledPatternDoesNotMaskCoreMatch(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+
+	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		addBodyDLPTestPattern(cfg)
+		cfg.RequestBodyScanning.DisablePatterns = []string{testBodyDLPPatternName}
+	})
+	defer proxyCleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wsURL := fmt.Sprintf("ws://%s/ws?url=ws://%s", proxyAddr, backendAddr)
+	dialer := ws.Dialer{
+		Header: ws.HandshakeHeaderHTTP(http.Header{
+			"Authorization": []string{"Bearer " + fakeBodyDLPSecret()},
+			"X-Api-Key":     []string{fakeAPIKey()},
+		}),
+		Timeout: 5 * time.Second,
+	}
+
+	conn, _, _, err := dialer.Dial(ctx, wsURL)
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("expected core header DLP match to block despite disabled non-core pattern")
+	}
+}
+
 func TestWSProxyHeaderDLPBlocksAllowlistedHost(t *testing.T) {
 	backendAddr, backendCleanup := wsEchoServer(t)
 	defer backendCleanup()

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -834,6 +834,83 @@ func TestWSProxyRequireReceipts_UpstreamDialFailureEmitsOutcome(t *testing.T) {
 	}
 }
 
+func TestWSProxySSRFDialBlockWritesPolicyClose(t *testing.T) {
+	const rebindHost = "rebind.test"
+
+	cfg := config.Defaults()
+	cfg.WebSocketProxy.Enabled = true
+	cfg.DNS.HostOverrides = map[string][]string{rebindHost: {"8.8.8.8"}}
+	logger := audit.NewNop()
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	dialCfg := config.Defaults()
+	dialCfg.DNS.HostOverrides = map[string][]string{rebindHost: {"127.0.0.1"}}
+	dialSc := scanner.MustNew(dialCfg)
+	t.Cleanup(dialSc.Close)
+
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxKeyAgentScanner, dialSc))
+	t.Cleanup(cancel)
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			p.handleWebSocket(w, r)
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
+	}
+	t.Cleanup(func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutdownCancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+	go func() {
+		if serveErr := srv.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			t.Errorf("serve websocket proxy: %v", serveErr)
+		}
+	}()
+
+	conn, err := dialWSConn(ln.Addr().String(), net.JoinHostPort(rebindHost, "443"))
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	if deadlineErr := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); deadlineErr != nil {
+		t.Fatalf("set read deadline: %v", deadlineErr)
+	}
+
+	hdr, err := ws.ReadHeader(conn)
+	if err != nil {
+		t.Fatalf("read close frame header: %v", err)
+	}
+	if hdr.OpCode != ws.OpClose {
+		t.Fatalf("opcode = %v, want OpClose", hdr.OpCode)
+	}
+	payload := make([]byte, hdr.Length)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		t.Fatalf("read close frame payload: %v", err)
+	}
+	if len(payload) < 2 {
+		t.Fatalf("close frame payload length = %d, want status code", len(payload))
+	}
+	if got := ws.StatusCode(binary.BigEndian.Uint16(payload[:2])); got != ws.StatusPolicyViolation {
+		t.Fatalf("close code = %v, want %v", got, ws.StatusPolicyViolation)
+	}
+	if !strings.Contains(string(payload[2:]), string(blockreason.SSRFDNSRebind)) {
+		t.Fatalf("close payload = %q, want %s", string(payload[2:]), blockreason.SSRFDNSRebind)
+	}
+}
+
 func TestWSProxyRequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {
 	var upstreamHits atomic.Int32
 	lc := net.ListenConfig{}

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1830,6 +1831,22 @@ func TestWSProxyHeaderDLPDisablePatternAllowsNonCore(t *testing.T) {
 	backendAddr, backendCleanup := wsEchoServer(t)
 	defer backendCleanup()
 
+	blockingProxyAddr, blockingProxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		addBodyDLPTestPattern(cfg)
+	})
+	defer blockingProxyCleanup()
+
+	blockedResp := requestWSHandshake(t, blockingProxyAddr, backendAddr, http.Header{
+		"Authorization": []string{"Bearer " + fakeBodyDLPSecret()},
+	})
+	defer func() { _ = blockedResp.Body.Close() }()
+	if blockedResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("control status = %d, want %d", blockedResp.StatusCode, http.StatusForbidden)
+	}
+	if got := blockedResp.Header.Get("X-Pipelock-Block-Reason"); got != string(blockreason.DLPMatch) {
+		t.Fatalf("control X-Pipelock-Block-Reason = %q, want %q", got, blockreason.DLPMatch)
+	}
+
 	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
 		addBodyDLPTestPattern(cfg)
 		cfg.RequestBodyScanning.DisablePatterns = []string{testBodyDLPPatternName}
@@ -1851,6 +1868,43 @@ func TestWSProxyHeaderDLPDisablePatternAllowsNonCore(t *testing.T) {
 		t.Fatalf("disabled non-core header DLP should allow websocket dial: %v", err)
 	}
 	defer func() { _ = conn.Close() }()
+}
+
+func TestWSProxyHeaderDLPAdaptiveWarnUpgradeBlocks(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+
+	cfg := adaptiveConfig()
+	cfg.WebSocketProxy.Enabled = true
+	addBodyDLPTestPattern(cfg)
+	cfg.RequestBodyScanning.PatternActions = map[string]string{testBodyDLPPatternName: config.ActionWarn}
+
+	logger := audit.NewNop()
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+	m := metrics.New()
+	p, err := New(cfg, logger, sc, m)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	defer p.Close()
+
+	sm := p.sessionMgrPtr.Load()
+	rec := sm.GetOrCreate(adaptiveSessionKeyHTTPTest)
+	escalateRec(rec, 1)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/ws?url=ws://"+backendAddr, nil)
+	req.Header.Set("Authorization", "Bearer "+fakeBodyDLPSecret())
+	w := httptest.NewRecorder()
+
+	p.handleWebSocket(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusForbidden, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "escalated") {
+		t.Fatalf("body = %q, want escalated DLP block", w.Body.String())
+	}
 }
 
 func TestWSProxyHeaderDLPPatternWarnOverrideAllowsNonCore(t *testing.T) {

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -1804,7 +1804,7 @@ func TestWSProxyHeaderDLPDisablePatternAllowsNonCore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("disabled non-core header DLP should allow websocket dial: %v", err)
 	}
-	defer conn.Close() //nolint:errcheck // test
+	defer func() { _ = conn.Close() }()
 }
 
 func TestWSProxyHeaderDLPPatternWarnOverrideAllowsNonCore(t *testing.T) {
@@ -1831,7 +1831,7 @@ func TestWSProxyHeaderDLPPatternWarnOverrideAllowsNonCore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("warn-only non-core header DLP should allow websocket dial: %v", err)
 	}
-	defer conn.Close() //nolint:errcheck // test
+	defer func() { _ = conn.Close() }()
 }
 
 func TestWSProxyHeaderDLPDisabledPatternDoesNotMaskCoreMatch(t *testing.T) {

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -1907,6 +1907,46 @@ func TestWSProxyHeaderDLPAdaptiveWarnUpgradeBlocks(t *testing.T) {
 	}
 }
 
+func TestWSProxyHeaderDLPSessionAnomalyBlocksHandshake(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+
+	obs := newWSDLPRecordObserver()
+	proxyAddr, p, proxyCleanup := setupWSProxyDefaultWithCaptureAndProxy(t, func(cfg *config.Config) {
+		addBodyDLPTestPattern(cfg)
+		cfg.RequestBodyScanning.PatternActions = map[string]string{testBodyDLPPatternName: config.ActionWarn}
+		cfg.SessionProfiling.Enabled = true
+		cfg.SessionProfiling.AnomalyAction = config.ActionWarn
+		cfg.SessionProfiling.DomainBurst = 100
+		cfg.BehavioralBaseline = *testBaselineBlockConfig(t)
+		cfg.BehavioralBaseline.LockDimensions = []string{"requests"}
+	}, obs)
+	defer proxyCleanup()
+
+	sm := p.sessionMgrPtr.Load()
+	lockHTTPBaseline(t, sm, "agent-a")
+
+	resp := requestWSHandshake(t, proxyAddr, backendAddr, http.Header{
+		"Authorization": []string{"Bearer " + fakeBodyDLPSecret()},
+		AgentHeader:     []string{"agent-a"},
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	if got := resp.Header.Get("X-Pipelock-Block-Reason"); got != string(blockreason.SessionAnomaly) {
+		t.Fatalf("X-Pipelock-Block-Reason = %q, want %q", got, blockreason.SessionAnomaly)
+	}
+
+	rec := waitWSDLPRecord(t, obs)
+	if rec.EffectiveAction != config.ActionWarn {
+		t.Fatalf("EffectiveAction = %q, want %q", rec.EffectiveAction, config.ActionWarn)
+	}
+	if !strings.Contains(rec.SkipReason, testBodyDLPPatternName) {
+		t.Fatalf("SkipReason = %q, want pattern %q", rec.SkipReason, testBodyDLPPatternName)
+	}
+}
+
 func TestWSProxyHeaderDLPPatternWarnOverrideAllowsNonCore(t *testing.T) {
 	backendAddr, backendCleanup := wsEchoServer(t)
 	defer backendCleanup()

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -287,6 +287,9 @@ func requestWSHandshake(t *testing.T, proxyAddr, backendAddr string, headers htt
 		t.Fatalf("dial proxy: %v", err)
 	}
 	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set handshake deadline: %v", err)
+	}
 	_, _ = fmt.Fprintf(conn, "GET /ws?url=ws://%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n", backendAddr, proxyAddr)
 	for name, values := range headers {
 		for _, value := range values {

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/addressprotect"
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
@@ -155,6 +157,10 @@ func setupWSProxy(t *testing.T, cfgMod func(*config.Config)) (string, func()) {
 }
 
 func setupWSProxyDefaultWithProxy(t *testing.T, cfgMod func(*config.Config)) (string, *Proxy, func()) {
+	return setupWSProxyDefaultWithCaptureAndProxy(t, cfgMod, nil)
+}
+
+func setupWSProxyDefaultWithCaptureAndProxy(t *testing.T, cfgMod func(*config.Config), obs capture.CaptureObserver) (string, *Proxy, func()) {
 	t.Helper()
 
 	cfg := config.Defaults()
@@ -175,7 +181,11 @@ func setupWSProxyDefaultWithProxy(t *testing.T, cfgMod func(*config.Config)) (st
 	logger := audit.NewNop()
 	sc := scanner.MustNew(cfg)
 	m := metrics.New()
-	p, err := New(cfg, logger, sc, m)
+	var opts []Option
+	if obs != nil {
+		opts = append(opts, WithCaptureObserver(obs))
+	}
+	p, err := New(cfg, logger, sc, m, opts...)
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
@@ -257,20 +267,7 @@ func dialWS(t *testing.T, proxyAddr, backendAddr string) net.Conn {
 func assertWSHandshakeStatus(t *testing.T, proxyAddr, backendAddr string, want int) {
 	t.Helper()
 
-	conn, err := (&net.Dialer{}).DialContext(t.Context(), "tcp4", proxyAddr)
-	if err != nil {
-		t.Fatalf("dial proxy: %v", err)
-	}
-	defer func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			t.Errorf("proxy connection close: %v", closeErr)
-		}
-	}()
-	_, _ = fmt.Fprintf(conn, "GET /ws?url=ws://%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n", backendAddr, proxyAddr)
-	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
-	if err != nil {
-		t.Fatalf("read websocket handshake response: %v", err)
-	}
+	resp := requestWSHandshake(t, proxyAddr, backendAddr, nil)
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
 			t.Errorf("response body close: %v", closeErr)
@@ -278,6 +275,55 @@ func assertWSHandshakeStatus(t *testing.T, proxyAddr, backendAddr string, want i
 	}()
 	if resp.StatusCode != want {
 		t.Fatalf("websocket handshake status = %d, want %d", resp.StatusCode, want)
+	}
+}
+
+func requestWSHandshake(t *testing.T, proxyAddr, backendAddr string, headers http.Header) *http.Response {
+	t.Helper()
+
+	conn, err := (&net.Dialer{}).DialContext(t.Context(), "tcp4", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	_, _ = fmt.Fprintf(conn, "GET /ws?url=ws://%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n", backendAddr, proxyAddr)
+	for name, values := range headers {
+		for _, value := range values {
+			_, _ = fmt.Fprintf(conn, "%s: %s\r\n", name, value)
+		}
+	}
+	_, _ = fmt.Fprint(conn, "\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read websocket handshake response: %v", err)
+	}
+	return resp
+}
+
+type wsDLPRecordObserver struct {
+	capture.NopObserver
+	ch chan capture.DLPVerdictRecord
+}
+
+func newWSDLPRecordObserver() *wsDLPRecordObserver {
+	return &wsDLPRecordObserver{ch: make(chan capture.DLPVerdictRecord, 4)}
+}
+
+func (o *wsDLPRecordObserver) ObserveDLPVerdict(_ context.Context, rec *capture.DLPVerdictRecord) {
+	if rec == nil || rec.Subsurface != "dlp_ws_header" {
+		return
+	}
+	o.ch <- *rec
+}
+
+func waitWSDLPRecord(t *testing.T, obs *wsDLPRecordObserver) capture.DLPVerdictRecord {
+	t.Helper()
+	select {
+	case rec := <-obs.ch:
+		return rec
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for websocket header DLP capture record")
+		return capture.DLPVerdictRecord{}
 	}
 }
 
@@ -1811,10 +1857,11 @@ func TestWSProxyHeaderDLPPatternWarnOverrideAllowsNonCore(t *testing.T) {
 	backendAddr, backendCleanup := wsEchoServer(t)
 	defer backendCleanup()
 
-	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+	obs := newWSDLPRecordObserver()
+	proxyAddr, _, proxyCleanup := setupWSProxyDefaultWithCaptureAndProxy(t, func(cfg *config.Config) {
 		addBodyDLPTestPattern(cfg)
 		cfg.RequestBodyScanning.PatternActions = map[string]string{testBodyDLPPatternName: config.ActionWarn}
-	})
+	}, obs)
 	defer proxyCleanup()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -1832,6 +1879,17 @@ func TestWSProxyHeaderDLPPatternWarnOverrideAllowsNonCore(t *testing.T) {
 		t.Fatalf("warn-only non-core header DLP should allow websocket dial: %v", err)
 	}
 	defer func() { _ = conn.Close() }()
+
+	rec := waitWSDLPRecord(t, obs)
+	if rec.EffectiveAction != config.ActionWarn {
+		t.Fatalf("EffectiveAction = %q, want %q", rec.EffectiveAction, config.ActionWarn)
+	}
+	if rec.Outcome != capture.OutcomeWarned {
+		t.Fatalf("Outcome = %q, want %q", rec.Outcome, capture.OutcomeWarned)
+	}
+	if !strings.Contains(rec.SkipReason, testBodyDLPPatternName) {
+		t.Fatalf("SkipReason = %q, want pattern %q", rec.SkipReason, testBodyDLPPatternName)
+	}
 }
 
 func TestWSProxyHeaderDLPDisabledPatternDoesNotMaskCoreMatch(t *testing.T) {
@@ -1844,21 +1902,16 @@ func TestWSProxyHeaderDLPDisabledPatternDoesNotMaskCoreMatch(t *testing.T) {
 	})
 	defer proxyCleanup()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	wsURL := fmt.Sprintf("ws://%s/ws?url=ws://%s", proxyAddr, backendAddr)
-	dialer := ws.Dialer{
-		Header: ws.HandshakeHeaderHTTP(http.Header{
-			"Authorization": []string{"Bearer " + fakeBodyDLPSecret()},
-			"X-Api-Key":     []string{fakeAPIKey()},
-		}),
-		Timeout: 5 * time.Second,
+	resp := requestWSHandshake(t, proxyAddr, backendAddr, http.Header{
+		"Authorization": []string{"Bearer " + fakeBodyDLPSecret()},
+		"X-Api-Key":     []string{fakeAPIKey()},
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
 	}
-
-	conn, _, _, err := dialer.Dial(ctx, wsURL)
-	if err == nil {
-		_ = conn.Close()
-		t.Fatal("expected core header DLP match to block despite disabled non-core pattern")
+	if got := resp.Header.Get("X-Pipelock-Block-Reason"); got != string(blockreason.DLPMatch) {
+		t.Fatalf("X-Pipelock-Block-Reason = %q, want %q", got, blockreason.DLPMatch)
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -129,15 +129,16 @@ const (
 
 // Result describes the outcome of scanning a URL.
 type Result struct {
-	Allowed      bool         `json:"allowed"`
-	Reason       string       `json:"reason,omitempty"`
-	Scanner      string       `json:"scanner,omitempty"` // which scanner triggered
-	Hint         string       `json:"hint,omitempty"`    // actionable guidance when blocked
-	Score        float64      `json:"score"`             // anomaly score 0.0-1.0
-	Class        ResultClass  `json:"-"`                 // internal: threat vs protective classification
-	DNSErrorKind DNSErrorKind `json:"-"`                 // internal: DNS resolver failure subtype (set only when Class == ClassInfrastructureError on the DNS path)
-	WarnMatches  []WarnMatch  `json:"warn_matches,omitempty"`
-	spans        []MatchSpan
+	Allowed         bool         `json:"allowed"`
+	Reason          string       `json:"reason,omitempty"`
+	Scanner         string       `json:"scanner,omitempty"` // which scanner triggered
+	Hint            string       `json:"hint,omitempty"`    // actionable guidance when blocked
+	Score           float64      `json:"score"`             // anomaly score 0.0-1.0
+	Class           ResultClass  `json:"-"`                 // internal: threat vs protective classification
+	DNSErrorKind    DNSErrorKind `json:"-"`                 // internal: DNS resolver failure subtype (set only when Class == ClassInfrastructureError on the DNS path)
+	SSRFResolvedIPs []string     `json:"-"`                 // internal: DNS answers observed by the SSRF scan on an allowed URL, for dial-time rebind detection
+	WarnMatches     []WarnMatch  `json:"warn_matches,omitempty"`
+	spans           []MatchSpan
 }
 
 // Spans returns retained scanner match coordinates for this result.
@@ -604,13 +605,16 @@ func (s *Scanner) AddressChecker() *addressprotect.Checker {
 	return s.addressChecker
 }
 
-// IsInternalIP checks whether the given IP falls within any configured
-// internal CIDR. Returns false when SSRF protection is disabled (no CIDRs).
+// IsInternalIP checks whether the given IP falls within immutable core CIDRs
+// or any configured internal CIDR.
 func (s *Scanner) IsInternalIP(ip net.IP) bool {
 	// Normalize IPv4-mapped IPv6 addresses (e.g., ::ffff:127.0.0.1) to
 	// their 4-byte IPv4 form so they match IPv4 CIDRs like 127.0.0.0/8.
 	if v4 := ip.To4(); v4 != nil {
 		ip = v4
+	}
+	if s.isCoreCIDRBlocked(ip) {
+		return true
 	}
 	for _, cidr := range s.internalCIDRs {
 		if cidr.Contains(ip) {
@@ -973,8 +977,9 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 	// When active, core CIDRs are always included via mergedSSRFCIDRs()
 	// so private ranges (10.x, 172.16.x, 192.168.x, loopback, link-local)
 	// cannot be removed from the check set via config alone.
-	if result := s.checkSSRF(ctx, hostname); !result.Allowed {
-		return result
+	ssrfResult := s.checkSSRF(ctx, hostname)
+	if !ssrfResult.Allowed {
+		return ssrfResult
 	}
 
 	// Rate limit check (per-domain)
@@ -998,7 +1003,7 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 		}
 	}
 
-	return Result{Allowed: true, Scanner: ScannerAll, Score: 0.0}
+	return Result{Allowed: true, Scanner: ScannerAll, Score: 0.0, SSRFResolvedIPs: ssrfResult.SSRFResolvedIPs}
 }
 
 // parseAlternativeIP decodes non-standard IP address notations that
@@ -1245,7 +1250,7 @@ func (s *Scanner) checkSSRF(ctx context.Context, hostname string) Result {
 
 	}
 
-	return Result{Allowed: true}
+	return Result{Allowed: true, SSRFResolvedIPs: append([]string(nil), ips...)}
 }
 
 // checkAllowlist rejects requests to domains not in the allowlist.

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -2281,6 +2281,7 @@ func TestIsInternalIP_EmptyConfigStillBlocksCoreCIDRs(t *testing.T) {
 	cfg.Internal = nil
 	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
 	s := MustNew(cfg)
+	t.Cleanup(s.Close)
 
 	tests := []struct {
 		name     string

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -2233,7 +2233,7 @@ func TestIsInternalIP_MatchesConfiguredCIDR(t *testing.T) {
 		{"10.255.255.255", true},
 		{"127.0.0.1", true},
 		{"8.8.8.8", false},
-		{"192.168.1.1", false},
+		{"192.168.1.1", true},
 	}
 
 	for _, tt := range tests {
@@ -2261,7 +2261,7 @@ func TestIsInternalIP_IPv4MappedIPv6(t *testing.T) {
 		{"::ffff:127.0.0.1", true},
 		{"::ffff:10.0.0.1", true},
 		{"::ffff:8.8.8.8", false},
-		{"::ffff:192.168.1.1", false}, // 192.168.0.0/16 not in this config
+		{"::ffff:192.168.1.1", true},
 	}
 
 	for _, tt := range tests {
@@ -2276,14 +2276,29 @@ func TestIsInternalIP_IPv4MappedIPv6(t *testing.T) {
 	}
 }
 
-func TestIsInternalIP_DisabledReturnsAlwaysFalse(t *testing.T) {
+func TestIsInternalIP_EmptyConfigStillBlocksCoreCIDRs(t *testing.T) {
 	cfg := testConfig()
 	cfg.Internal = nil
 	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
 	s := MustNew(cfg)
 
-	if s.IsInternalIP(net.ParseIP("127.0.0.1")) {
-		t.Error("expected false when SSRF is disabled")
+	tests := []struct {
+		name     string
+		ip       string
+		internal bool
+	}{
+		{name: "loopback", ip: "127.0.0.1", internal: true},
+		{name: "metadata", ip: "169.254.169.254", internal: true},
+		{name: "private", ip: "10.0.0.1", internal: true},
+		{name: "public", ip: "8.8.8.8", internal: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.IsInternalIP(net.ParseIP(tt.ip)); got != tt.internal {
+				t.Fatalf("IsInternalIP(%s) = %v, want %v", tt.ip, got, tt.internal)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Two independent proxy hardening changes that share the request-scanning surface.

Request-body DLP gains two operability knobs for safe false-positive tuning. `request_body_scanning.disable_patterns` skips named DLP patterns on the body and header paths, and `request_body_scanning.pattern_actions` overrides warn or block per pattern. Both are validated at load: an unknown pattern name or an invalid action is rejected, and a pattern listed in both knobs is rejected as inert. The immutable core DLP floor cannot be weakened through either knob; a core credential pattern is rejected at config load and ignored at runtime, so the knobs only tune non-core patterns. Disabling one pattern never masks a different unsuppressed match in the same body or header, and a per-pattern warn still feeds adaptive escalation. Coverage spans the forward, CONNECT, reverse, and WebSocket header paths.

The SSRF-safe dialer now emits a distinct `ssrf_dns_rebind` block reason when a destination that resolved to a public address at scan time resolves to a private or metadata address at dial time, instead of collapsing that rebind onto a generic dial failure. The block decision is unchanged and stays fail closed; this only makes the reason observable in the audit log and receipts. A related gap is closed in the same change: the dial-time internal-IP check now includes the immutable core CIDRs even when configured SSRF resolution is disabled, so a rebind to a core private range is blocked at dial time to match the scanner's literal-IP floor. A destination that was private from the start still reports the private-IP reason, and an explicitly allowlisted internal IP is still reachable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-pattern DLP controls for request-body and request-header scanning: `disable_patterns` (non-core only) and `pattern_actions` (warn/block overrides).
* **Bug Fixes**
  * Immutable core DLP patterns can’t be downgraded/disabled; adaptive enforcement can still upgrade warn → block.
  * DLP enforcement now uses the strongest effective action across URL, headers, and body, preventing warn/disables from masking core matches.
  * SSRF dial-block handling is consistent across redirects, forward/reverse proxy, and WebSocket, preserving DNS-rebind block reasons and returning correct 403 outcomes.
* **Documentation**
  * Updated configuration docs with enforcement and escalation semantics.
* **Tests**
  * Expanded validation, canonical-hash, enforcement, and SSRF/DLP regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->