### PR TITLE
feat(counterparty): enterprise counterparty-attestation verifier

### DIFF
--- a/enterprise/counterparty/counterparty.go
+++ b/enterprise/counterparty/counterparty.go
@@ -421,25 +421,7 @@ func VerifyCounterparty(req VerifyRequest) VerificationResult {
 
 // UnmarshalRecord strictly parses a counterparty side record.
 func UnmarshalRecord(data []byte) (Record, error) {
-	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
-		return Record{}, fmt.Errorf("unmarshal counterparty receipt: %w", err)
-	}
-	var r Record
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&r); err != nil {
-		if strings.Contains(err.Error(), "unknown field") {
-			return Record{}, fmt.Errorf("unmarshal counterparty receipt: %w: %w", ErrUnknownField, err)
-		}
-		return Record{}, fmt.Errorf("unmarshal counterparty receipt: %w", err)
-	}
-	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
-		if err != nil {
-			return Record{}, fmt.Errorf("unmarshal counterparty receipt: %w: %w", ErrTrailingTokens, err)
-		}
-		return Record{}, fmt.Errorf("unmarshal counterparty receipt: %w", ErrTrailingTokens)
-	}
-	return r, nil
+	return unmarshalStrict[Record](data, "counterparty receipt")
 }
 
 // UnmarshalPayloadCapture strictly parses a raw payload-capture record. Callers
@@ -448,25 +430,29 @@ func UnmarshalRecord(data []byte) (Record, error) {
 // trailing tokens cannot collapse into a pass-shaped struct while the raw
 // artifact stays ambiguous for audit.
 func UnmarshalPayloadCapture(data []byte) (PayloadCapture, error) {
+	return unmarshalStrict[PayloadCapture](data, "payload capture")
+}
+
+func unmarshalStrict[T any](data []byte, label string) (T, error) {
+	var v T
 	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
-		return PayloadCapture{}, fmt.Errorf("unmarshal payload capture: %w", err)
+		return v, fmt.Errorf("unmarshal %s: %w", label, err)
 	}
-	var c PayloadCapture
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
-	if err := dec.Decode(&c); err != nil {
+	if err := dec.Decode(&v); err != nil {
 		if strings.Contains(err.Error(), "unknown field") {
-			return PayloadCapture{}, fmt.Errorf("unmarshal payload capture: %w: %w", ErrUnknownField, err)
+			return v, fmt.Errorf("unmarshal %s: %w: %w", label, ErrUnknownField, err)
 		}
-		return PayloadCapture{}, fmt.Errorf("unmarshal payload capture: %w", err)
+		return v, fmt.Errorf("unmarshal %s: %w", label, err)
 	}
 	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
 		if err != nil {
-			return PayloadCapture{}, fmt.Errorf("unmarshal payload capture: %w: %w", ErrTrailingTokens, err)
+			return v, fmt.Errorf("unmarshal %s: %w: %w", label, ErrTrailingTokens, err)
 		}
-		return PayloadCapture{}, fmt.Errorf("unmarshal payload capture: %w", ErrTrailingTokens)
+		return v, fmt.Errorf("unmarshal %s: %w", label, ErrTrailingTokens)
 	}
-	return c, nil
+	return v, nil
 }
 
 func newReplayEntry(r Record, nonce NonceKey, sender, receiver receipt.Receipt) (ReplayEntry, error) {

--- a/enterprise/counterparty/counterparty.go
+++ b/enterprise/counterparty/counterparty.go
@@ -1,0 +1,858 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+// Package counterparty verifies enterprise-only side records that bind two
+// already-existing receipts to the same transmitted payload.
+//
+// The binding lives beside the core receipt stream as its own signed side
+// record (counterparty_receipt_v1). No field here is added to the v1
+// ActionRecord schema, so the cross-language receipt verifiers are unaffected.
+package counterparty
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+const (
+	RecordType = "counterparty_receipt_v1"
+	Version    = 1
+
+	signatureAlg    = "ed25519"
+	signaturePrefix = "ed25519:"
+	hashPrefix      = "sha256:"
+
+	// PayloadCaptureRecordType tags a party's signed payload-capture record.
+	PayloadCaptureRecordType = "payload_capture_v1"
+
+	// DirectionEgress and DirectionIngress name the side that captured a payload:
+	// the sender captures on egress, the receiver captures on ingress.
+	DirectionEgress  = "egress"
+	DirectionIngress = "ingress"
+
+	// maxTokenLen bounds identity, nonce, and receipt-id fields. These are
+	// internal fleet identifiers, not free text; a tight bound cuts DoS and
+	// normalization risk. The charset is restricted to printable, non-space
+	// ASCII so NFC normalization is a no-op (see rejectNonASCII / B1 defense).
+	maxTokenLen = 256
+)
+
+var (
+	ErrUnknownField           = errors.New("unknown field on counterparty receipt")
+	ErrTrailingTokens         = errors.New("trailing tokens after counterparty receipt")
+	ErrFleetRequired          = errors.New("counterparty verification requires fleet feature")
+	ErrTrustedReceiptKey      = errors.New("trusted receipt key required")
+	ErrVerificationError      = errors.New("counterparty verification failed")
+	ErrReceiptIdentity        = errors.New("receipt identity mismatch")
+	ErrSideRecordKeyReuse     = errors.New("side-record signing key must be separate from receipt signing keys")
+	ErrUntrustedSideRecordKey = errors.New("side-record signature must match the receiver's enrolled counterparty key")
+	ErrMalformedBinding       = errors.New("counterparty binding is malformed")
+	ErrReplayStoreRequired    = errors.New("counterparty verification requires a replay store")
+	ErrFreshnessConfig        = errors.New("counterparty verification requires a verify time and positive age bounds")
+	ErrPayloadCapture         = errors.New("payload capture is invalid")
+)
+
+// Binding is the signed counterparty assertion. It intentionally lives beside
+// the core receipt stream; no field here is added to v1 ActionRecord.
+type Binding struct {
+	PayloadHash         string    `json:"payload_hash"`
+	SenderIdentity      string    `json:"sender_identity"`
+	ReceiverIdentity    string    `json:"receiver_identity"`
+	Nonce               string    `json:"nonce"`
+	SenderReceiptID     string    `json:"sender_receipt_id"`
+	SenderReceiptHash   string    `json:"sender_receipt_hash"`
+	ReceiverReceiptID   string    `json:"receiver_receipt_id"`
+	ReceiverReceiptHash string    `json:"receiver_receipt_hash"`
+	Timestamp           time.Time `json:"ts"`
+	Version             int       `json:"version"`
+}
+
+// Signature is the receiver signature over the canonical RecordType+Binding
+// hash. KeyID names the receiver's enrolled counterparty key.
+type Signature struct {
+	Alg   string `json:"alg"`
+	KeyID string `json:"key_id"`
+	Sig   string `json:"sig"`
+}
+
+// Record is a signed counterparty side record.
+type Record struct {
+	RecordType string    `json:"record_type"`
+	Binding    Binding   `json:"binding"`
+	Signature  Signature `json:"signature"`
+}
+
+// PayloadCapture is a party's signed attestation that it handled a specific
+// on-the-wire payload for a specific signed action and counterparty. The core v1
+// receipt schema has no payload-hash field and cannot gain one without breaking
+// the cross-language verifiers, so each party commits to the payload here
+// instead, signed by the same key that signs its receipts. Because BOTH the
+// sender (egress) and the receiver (ingress) sign their own capture, no single
+// party can fabricate the payload the other observed.
+//
+// Signature.KeyID on a capture is informational and NOT authenticated: the
+// capture signature is verified against the caller-enrolled receipt public key,
+// not against the KeyID. Audit or display code must not treat a capture's KeyID
+// as a trusted identity; the enrolled key is the sole authority.
+type PayloadCapture struct {
+	RecordType           string    `json:"record_type"`
+	ActionID             string    `json:"action_id"`
+	ActionHash           string    `json:"action_hash"`
+	PayloadHash          string    `json:"payload_hash"`
+	Direction            string    `json:"direction"`
+	PartyIdentity        string    `json:"party_identity"`
+	CounterpartyIdentity string    `json:"counterparty_identity"`
+	Signature            Signature `json:"signature"`
+}
+
+// BoundReceipt pairs a receipt with the party's signed payload capture. The
+// verifier derives the payload hash from the verified capture, never from an
+// unsigned caller-supplied value or unsigned receipt Ext data.
+type BoundReceipt struct {
+	Receipt receipt.Receipt
+	Capture PayloadCapture
+}
+
+// NonceKey is the replay key for one signed side record. It scopes the nonce to
+// the enrolled side-record key and both parties, so the same signed record
+// cannot be re-counted. All fields are validated ASCII, so the raw string used
+// here matches the NFC-normalized bytes the signature was computed over.
+type NonceKey struct {
+	SideRecordKeyID  string `json:"side_record_key_id"`
+	SenderIdentity   string `json:"sender_identity"`
+	ReceiverIdentity string `json:"receiver_identity"`
+	Nonce            string `json:"nonce"`
+}
+
+// TransferKey is the replay key for one transfer regardless of nonce. It uses
+// the signed action-record hashes, not the mutable receipt envelope hashes, so
+// unsigned/canonical envelope changes (for example Ext or signature hex casing)
+// cannot turn the same transfer into a new replay key.
+type TransferKey struct {
+	SenderIdentity     string
+	ReceiverIdentity   string
+	PayloadHash        string
+	SenderReceiptID    string
+	ReceiverReceiptID  string
+	SenderActionHash   string
+	ReceiverActionHash string
+}
+
+// VerifyRequest carries all inputs for cross-party verification.
+type VerifyRequest struct {
+	License license.License
+
+	Sender   *BoundReceipt
+	Receiver *BoundReceipt
+	Record   *Record
+
+	// SenderReceiptKey and ReceiverReceiptKey are the caller's trusted
+	// identity-to-key anchors for the two receipt signers. Receipt envelopes are
+	// self-describing, so verification must not trust an embedded signer_key
+	// without checking it against these enrolled keys.
+	SenderReceiptKey   ed25519.PublicKey
+	ReceiverReceiptKey ed25519.PublicKey
+
+	// ReceiverSideRecordKey and ReceiverSideRecordKeyID are the receiver's
+	// enrolled counterparty side-record key. The receiver is the party that
+	// co-signs "I received exactly this", so the side record must be signed by
+	// the receiver's key, not by any globally trusted key (closes the
+	// any-trusted-key attests-any-identity hole).
+	ReceiverSideRecordKey   ed25519.PublicKey
+	ReceiverSideRecordKeyID string
+
+	// Freshness bounds. Now is the caller-injected verify time (the verifier
+	// never reads the wall clock). A record older than MaxAge or further in the
+	// future than MaxFutureSkew fails closed. All three are required (> 0).
+	Now           time.Time
+	MaxAge        time.Duration
+	MaxFutureSkew time.Duration
+
+	// ReplayStore is required. A record only passes after CommitIfNew accepts
+	// it, so a replayed record (same nonce) or a re-signed same-transfer record
+	// fails closed. A nil store fails closed.
+	ReplayStore ReplayStore
+}
+
+type FailureCode string
+
+const (
+	FailureNone                FailureCode = ""
+	FailureLicense             FailureCode = "license"
+	FailureMissingInput        FailureCode = "missing_input"
+	FailureMalformedBinding    FailureCode = "malformed_binding"
+	FailureInvalidReceipt      FailureCode = "invalid_receipt"
+	FailurePayloadCapture      FailureCode = "payload_capture"
+	FailurePayloadHashMismatch FailureCode = "payload_hash_mismatch"
+	FailureReceiptIDMismatch   FailureCode = "receipt_id_mismatch"
+	FailureReceiptHashMismatch FailureCode = "receipt_hash_mismatch"
+	FailureIdentityMismatch    FailureCode = "identity_mismatch"
+	FailureStale               FailureCode = "stale"
+	FailureFuture              FailureCode = "future"
+	FailureReplay              FailureCode = "replay"
+	FailureReplayStore         FailureCode = "replay_store"
+	FailureSignature           FailureCode = "signature"
+	FailureTrust               FailureCode = "trust"
+	FailureSelfCounterparty    FailureCode = "self_counterparty"
+)
+
+// VerificationResult is structured so callers can distinguish a pass from the
+// exact fail-closed reason without parsing text.
+type VerificationResult struct {
+	Passed      bool        `json:"passed"`
+	FailureCode FailureCode `json:"failure_code,omitempty"`
+	Error       string      `json:"error,omitempty"`
+	Nonce       *NonceKey   `json:"nonce,omitempty"`
+	SignerKeyID string      `json:"signer_key_id,omitempty"`
+}
+
+// PayloadHash returns the canonical labeled SHA-256 hash for transmitted bytes.
+func PayloadHash(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hashPrefix + hex.EncodeToString(sum[:])
+}
+
+// SignRecord signs the record's canonical side-record hash with Ed25519.
+func SignRecord(lic license.License, r Record, keyID string, privKey ed25519.PrivateKey) (Record, error) {
+	if !lic.HasFeature(license.FeatureFleet) {
+		return Record{}, ErrFleetRequired
+	}
+	if len(privKey) != ed25519.PrivateKeySize {
+		return Record{}, fmt.Errorf("invalid private key size: got %d, want %d", len(privKey), ed25519.PrivateKeySize)
+	}
+	if keyID == "" {
+		return Record{}, errors.New("key_id is required")
+	}
+	r.RecordType = RecordType
+	r.Signature = Signature{}
+	if err := validateBinding(r.Binding); err != nil {
+		return Record{}, err
+	}
+	sum, err := canonicalRecordHash(r)
+	if err != nil {
+		return Record{}, err
+	}
+	sig := ed25519.Sign(privKey, sum[:])
+	r.Signature = Signature{
+		Alg:   signatureAlg,
+		KeyID: keyID,
+		Sig:   signaturePrefix + base64.StdEncoding.EncodeToString(sig),
+	}
+	return r, nil
+}
+
+// VerifyRecordSignature verifies only the side-record structure and signature
+// against the receiver's enrolled key. It does not check the paired receipts;
+// callers wanting the full cross-party proof use VerifyCounterparty.
+func VerifyRecordSignature(lic license.License, r Record, expectedKeyID string, pubKey ed25519.PublicKey) error {
+	if !lic.HasFeature(license.FeatureFleet) {
+		return ErrFleetRequired
+	}
+	if r.RecordType != RecordType {
+		return fmt.Errorf("unsupported record_type %q", r.RecordType)
+	}
+	if err := validateBinding(r.Binding); err != nil {
+		return err
+	}
+	if r.Signature.Alg != signatureAlg {
+		return fmt.Errorf("unsupported signature alg %q", r.Signature.Alg)
+	}
+	if r.Signature.KeyID == "" {
+		return errors.New("signature key_id is required")
+	}
+	if expectedKeyID == "" {
+		return fmt.Errorf("%w: no enrolled side-record key id", ErrUntrustedSideRecordKey)
+	}
+	if r.Signature.KeyID != expectedKeyID {
+		return fmt.Errorf("%w: record key_id %q is not the receiver's enrolled key %q", ErrUntrustedSideRecordKey, r.Signature.KeyID, expectedKeyID)
+	}
+	if len(pubKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("%w: enrolled key size = %d, want %d", ErrUntrustedSideRecordKey, len(pubKey), ed25519.PublicKeySize)
+	}
+	rawSig, err := decodeSignature(r.Signature.Sig)
+	if err != nil {
+		return err
+	}
+	sum, err := canonicalRecordHash(Record{RecordType: r.RecordType, Binding: r.Binding})
+	if err != nil {
+		return err
+	}
+	if !ed25519.Verify(pubKey, sum[:], rawSig) {
+		return errors.New("signature verification failed")
+	}
+	return nil
+}
+
+// VerifyCounterpartyBytes strictly parses a raw side record and then verifies
+// it. Callers handling untrusted bytes MUST use this entry point so duplicate
+// keys, unknown fields, and trailing tokens cannot collapse into a pass-shaped
+// Record. req.Record is ignored and set from the parsed bytes.
+func VerifyCounterpartyBytes(req VerifyRequest, rawRecord []byte) VerificationResult {
+	rec, err := UnmarshalRecord(rawRecord)
+	if err != nil {
+		return fail(FailureMalformedBinding, err)
+	}
+	req.Record = &rec
+	return VerifyCounterparty(req)
+}
+
+// VerifyCounterparty appraises a counterparty side record against two existing
+// receipts and the receiver's enrolled side-record key. It fails closed on
+// license loss, missing configuration, malformed inputs, mismatched bindings,
+// staleness, replay, untrusted keys, and signature failure. Replay state is
+// only committed after every non-mutating check passes, so a rejected record
+// never consumes a nonce.
+func VerifyCounterparty(req VerifyRequest) VerificationResult {
+	if !req.License.HasFeature(license.FeatureFleet) {
+		return fail(FailureLicense, ErrFleetRequired)
+	}
+	if req.Sender == nil || req.Receiver == nil || req.Record == nil {
+		return fail(FailureMissingInput, errors.New("sender receipt, receiver receipt, and counterparty record are required"))
+	}
+	if req.ReplayStore == nil {
+		return fail(FailureMissingInput, ErrReplayStoreRequired)
+	}
+	if req.Now.IsZero() || req.MaxAge <= 0 || req.MaxFutureSkew <= 0 {
+		return fail(FailureMissingInput, ErrFreshnessConfig)
+	}
+
+	r := *req.Record
+	if err := validateBinding(r.Binding); err != nil {
+		return fail(FailureMalformedBinding, err)
+	}
+	if r.Binding.SenderIdentity == r.Binding.ReceiverIdentity {
+		return fail(FailureSelfCounterparty, errors.New("sender and receiver identities are the same"))
+	}
+
+	senderPayloadHash, err := verifyBoundReceipt("sender", *req.Sender, req.SenderReceiptKey, DirectionEgress, r.Binding.ReceiverIdentity)
+	if err != nil {
+		return fail(classifyBoundReceiptErr(err), err)
+	}
+	receiverPayloadHash, err := verifyBoundReceipt("receiver", *req.Receiver, req.ReceiverReceiptKey, DirectionIngress, r.Binding.SenderIdentity)
+	if err != nil {
+		return fail(classifyBoundReceiptErr(err), err)
+	}
+
+	if err := VerifyRecordSignature(req.License, r, req.ReceiverSideRecordKeyID, req.ReceiverSideRecordKey); err != nil {
+		if errors.Is(err, ErrUntrustedSideRecordKey) {
+			return fail(FailureTrust, err)
+		}
+		return fail(FailureSignature, err)
+	}
+	if err := rejectSideRecordKeyReuse(req.ReceiverSideRecordKey, req.SenderReceiptKey, req.ReceiverReceiptKey); err != nil {
+		return fail(FailureTrust, err)
+	}
+
+	if senderPayloadHash != r.Binding.PayloadHash {
+		return fail(FailurePayloadHashMismatch, fmt.Errorf("sender-attested payload hash %q does not match record payload_hash %q", senderPayloadHash, r.Binding.PayloadHash))
+	}
+	if receiverPayloadHash != r.Binding.PayloadHash {
+		return fail(FailurePayloadHashMismatch, fmt.Errorf("receiver-attested payload hash %q does not match record payload_hash %q", receiverPayloadHash, r.Binding.PayloadHash))
+	}
+	if req.Sender.Receipt.ActionRecord.ActionID != r.Binding.SenderReceiptID {
+		return fail(FailureReceiptIDMismatch, fmt.Errorf("sender receipt action_id %q does not match record sender_receipt_id %q", req.Sender.Receipt.ActionRecord.ActionID, r.Binding.SenderReceiptID))
+	}
+	if req.Receiver.Receipt.ActionRecord.ActionID != r.Binding.ReceiverReceiptID {
+		return fail(FailureReceiptIDMismatch, fmt.Errorf("receiver receipt action_id %q does not match record receiver_receipt_id %q", req.Receiver.Receipt.ActionRecord.ActionID, r.Binding.ReceiverReceiptID))
+	}
+	if err := compareReceiptHash("sender", req.Sender.Receipt, r.Binding.SenderReceiptHash); err != nil {
+		return fail(FailureReceiptHashMismatch, err)
+	}
+	if err := compareReceiptHash("receiver", req.Receiver.Receipt, r.Binding.ReceiverReceiptHash); err != nil {
+		return fail(FailureReceiptHashMismatch, err)
+	}
+
+	if req.Sender.Receipt.SignerKey == req.Receiver.Receipt.SignerKey {
+		return fail(FailureSelfCounterparty, errors.New("sender and receiver receipt signer keys are the same"))
+	}
+	if err := compareReceiptIdentity("sender", req.Sender.Receipt, r.Binding.SenderIdentity); err != nil {
+		return fail(FailureIdentityMismatch, err)
+	}
+	if err := compareReceiptIdentity("receiver", req.Receiver.Receipt, r.Binding.ReceiverIdentity); err != nil {
+		return fail(FailureIdentityMismatch, err)
+	}
+
+	if r.Binding.Timestamp.Before(req.Now.Add(-req.MaxAge)) {
+		return fail(FailureStale, fmt.Errorf("record ts %s is older than max age %s before %s", r.Binding.Timestamp.UTC(), req.MaxAge, req.Now.UTC()))
+	}
+	if r.Binding.Timestamp.After(req.Now.Add(req.MaxFutureSkew)) {
+		return fail(FailureFuture, fmt.Errorf("record ts %s is beyond max future skew %s after %s", r.Binding.Timestamp.UTC(), req.MaxFutureSkew, req.Now.UTC()))
+	}
+
+	nonce := NonceKey{
+		SideRecordKeyID:  r.Signature.KeyID,
+		SenderIdentity:   r.Binding.SenderIdentity,
+		ReceiverIdentity: r.Binding.ReceiverIdentity,
+		Nonce:            r.Binding.Nonce,
+	}
+	entry, err := newReplayEntry(r, nonce, req.Sender.Receipt, req.Receiver.Receipt)
+	if err != nil {
+		return failWithNonce(FailureReplayStore, err, &nonce, r.Signature.KeyID)
+	}
+	if err := req.ReplayStore.CommitIfNew(entry); err != nil {
+		if errors.Is(err, ErrReplayConflict) {
+			return failWithNonce(FailureReplay, err, &nonce, r.Signature.KeyID)
+		}
+		return failWithNonce(FailureReplayStore, err, &nonce, r.Signature.KeyID)
+	}
+
+	return VerificationResult{
+		Passed:      true,
+		Nonce:       &nonce,
+		SignerKeyID: r.Signature.KeyID,
+	}
+}
+
+// UnmarshalRecord strictly parses a counterparty side record.
+func UnmarshalRecord(data []byte) (Record, error) {
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		return Record{}, fmt.Errorf("unmarshal counterparty receipt: %w", err)
+	}
+	var r Record
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&r); err != nil {
+		if strings.Contains(err.Error(), "unknown field") {
+			return Record{}, fmt.Errorf("unmarshal counterparty receipt: %w: %w", ErrUnknownField, err)
+		}
+		return Record{}, fmt.Errorf("unmarshal counterparty receipt: %w", err)
+	}
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return Record{}, fmt.Errorf("unmarshal counterparty receipt: %w: %w", ErrTrailingTokens, err)
+		}
+		return Record{}, fmt.Errorf("unmarshal counterparty receipt: %w", ErrTrailingTokens)
+	}
+	return r, nil
+}
+
+// UnmarshalPayloadCapture strictly parses a raw payload-capture record. Callers
+// handling untrusted capture bytes MUST use this (not encoding/json directly)
+// before building a BoundReceipt, so duplicate keys, unknown fields, and
+// trailing tokens cannot collapse into a pass-shaped struct while the raw
+// artifact stays ambiguous for audit.
+func UnmarshalPayloadCapture(data []byte) (PayloadCapture, error) {
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		return PayloadCapture{}, fmt.Errorf("unmarshal payload capture: %w", err)
+	}
+	var c PayloadCapture
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
+		if strings.Contains(err.Error(), "unknown field") {
+			return PayloadCapture{}, fmt.Errorf("unmarshal payload capture: %w: %w", ErrUnknownField, err)
+		}
+		return PayloadCapture{}, fmt.Errorf("unmarshal payload capture: %w", err)
+	}
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return PayloadCapture{}, fmt.Errorf("unmarshal payload capture: %w: %w", ErrTrailingTokens, err)
+		}
+		return PayloadCapture{}, fmt.Errorf("unmarshal payload capture: %w", ErrTrailingTokens)
+	}
+	return c, nil
+}
+
+func newReplayEntry(r Record, nonce NonceKey, sender, receiver receipt.Receipt) (ReplayEntry, error) {
+	sum, err := canonicalRecordHash(r)
+	if err != nil {
+		return ReplayEntry{}, err
+	}
+	senderActionHash, err := signedActionHash(sender)
+	if err != nil {
+		return ReplayEntry{}, fmt.Errorf("sender signed action hash: %w", err)
+	}
+	receiverActionHash, err := signedActionHash(receiver)
+	if err != nil {
+		return ReplayEntry{}, fmt.Errorf("receiver signed action hash: %w", err)
+	}
+	return ReplayEntry{
+		NonceKey: nonce,
+		TransferKey: TransferKey{
+			SenderIdentity:     r.Binding.SenderIdentity,
+			ReceiverIdentity:   r.Binding.ReceiverIdentity,
+			PayloadHash:        r.Binding.PayloadHash,
+			SenderReceiptID:    r.Binding.SenderReceiptID,
+			ReceiverReceiptID:  r.Binding.ReceiverReceiptID,
+			SenderActionHash:   senderActionHash,
+			ReceiverActionHash: receiverActionHash,
+		},
+		RecordHash: hashPrefix + hex.EncodeToString(sum[:]),
+		Timestamp:  r.Binding.Timestamp,
+	}, nil
+}
+
+func signedActionHash(r receipt.Receipt) (string, error) {
+	hash, err := r.ActionRecord.Hash()
+	if err != nil {
+		return "", err
+	}
+	return hashPrefix + hash, nil
+}
+
+func canonicalRecordHash(r Record) ([sha256.Size]byte, error) {
+	canonical, err := canonicalRecordBytes(r)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	return sha256.Sum256(canonical), nil
+}
+
+func canonicalRecordBytes(r Record) ([]byte, error) {
+	unsigned := struct {
+		RecordType string  `json:"record_type"`
+		Binding    Binding `json:"binding"`
+	}{
+		RecordType: r.RecordType,
+		Binding:    r.Binding,
+	}
+	raw, err := json.Marshal(unsigned)
+	if err != nil {
+		return nil, fmt.Errorf("marshal canonical counterparty record: %w", err)
+	}
+	tree, err := contract.ParseJSONStrict(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse canonical counterparty record: %w", err)
+	}
+	return contract.Canonicalize(tree)
+}
+
+func validateBinding(b Binding) error {
+	if b.Version != Version {
+		return fmt.Errorf("%w: unsupported binding version %d", ErrMalformedBinding, b.Version)
+	}
+	if err := validateHash("payload_hash", b.PayloadHash); err != nil {
+		return err
+	}
+	if err := validateToken("sender_identity", b.SenderIdentity); err != nil {
+		return err
+	}
+	if err := validateToken("receiver_identity", b.ReceiverIdentity); err != nil {
+		return err
+	}
+	if err := validateToken("nonce", b.Nonce); err != nil {
+		return err
+	}
+	if err := validateToken("sender_receipt_id", b.SenderReceiptID); err != nil {
+		return err
+	}
+	if err := validateHash("sender_receipt_hash", b.SenderReceiptHash); err != nil {
+		return err
+	}
+	if err := validateToken("receiver_receipt_id", b.ReceiverReceiptID); err != nil {
+		return err
+	}
+	if err := validateHash("receiver_receipt_hash", b.ReceiverReceiptHash); err != nil {
+		return err
+	}
+	if b.Timestamp.IsZero() {
+		return fmt.Errorf("%w: ts is required", ErrMalformedBinding)
+	}
+	return nil
+}
+
+func classifyBoundReceiptErr(err error) FailureCode {
+	switch {
+	case errors.Is(err, ErrTrustedReceiptKey):
+		return FailureTrust
+	case errors.Is(err, ErrPayloadCapture):
+		return FailurePayloadCapture
+	default:
+		return FailureInvalidReceipt
+	}
+}
+
+// verifyBoundReceipt verifies the receipt and its signed payload capture against
+// the party's enrolled key, then returns the payload hash the party attested.
+func verifyBoundReceipt(name string, br BoundReceipt, expectedKey ed25519.PublicKey, direction, counterpartyIdentity string) (string, error) {
+	expectedKeyHex, err := trustedReceiptKeyHex(name, expectedKey)
+	if err != nil {
+		return "", err
+	}
+	if br.Receipt.SignerKey != expectedKeyHex {
+		return "", fmt.Errorf("%w: %s receipt signer_key %q does not match trusted key %q", ErrTrustedReceiptKey, name, br.Receipt.SignerKey, expectedKeyHex)
+	}
+	if err := receipt.VerifyWithKey(br.Receipt, expectedKeyHex); err != nil {
+		return "", fmt.Errorf("%s receipt: %w", name, err)
+	}
+	actionHash, err := signedActionHash(br.Receipt)
+	if err != nil {
+		return "", fmt.Errorf("%s signed action hash: %w", name, err)
+	}
+	payloadHash, err := verifyPayloadCapture(name, br.Capture, expectedKey, captureExpectation{
+		direction:            direction,
+		actionID:             br.Receipt.ActionRecord.ActionID,
+		actionHash:           actionHash,
+		actor:                br.Receipt.ActionRecord.Actor,
+		counterpartyIdentity: counterpartyIdentity,
+	})
+	if err != nil {
+		return "", err
+	}
+	return payloadHash, nil
+}
+
+// SignPayloadCapture signs a party's payload-capture record with its Ed25519
+// key. The signer is the same key that signs the party's receipts.
+func SignPayloadCapture(c PayloadCapture, keyID string, privKey ed25519.PrivateKey) (PayloadCapture, error) {
+	if len(privKey) != ed25519.PrivateKeySize {
+		return PayloadCapture{}, fmt.Errorf("invalid private key size: got %d, want %d", len(privKey), ed25519.PrivateKeySize)
+	}
+	if keyID == "" {
+		return PayloadCapture{}, errors.New("key_id is required")
+	}
+	c.RecordType = PayloadCaptureRecordType
+	c.Signature = Signature{}
+	if err := validateCaptureFields(c); err != nil {
+		return PayloadCapture{}, err
+	}
+	sum, err := canonicalCaptureHash(c)
+	if err != nil {
+		return PayloadCapture{}, err
+	}
+	sig := ed25519.Sign(privKey, sum[:])
+	c.Signature = Signature{
+		Alg:   signatureAlg,
+		KeyID: keyID,
+		Sig:   signaturePrefix + base64.StdEncoding.EncodeToString(sig),
+	}
+	return c, nil
+}
+
+// captureExpectation carries the receipt- and binding-derived values a payload
+// capture must match. It keeps verifyPayloadCapture within the parameter-count
+// guideline and names each expected field at the call site.
+type captureExpectation struct {
+	direction            string
+	actionID             string
+	actionHash           string
+	actor                string
+	counterpartyIdentity string
+}
+
+// verifyPayloadCapture checks a payload capture is well-formed, matches its
+// receipt (action id, action hash, party identity, direction) and counterparty,
+// and is signed by the party's enrolled key; it returns the attested payload hash.
+func verifyPayloadCapture(name string, c PayloadCapture, enrolledKey ed25519.PublicKey, exp captureExpectation) (string, error) {
+	if c.RecordType != PayloadCaptureRecordType {
+		return "", fmt.Errorf("%w: %s capture record_type %q", ErrPayloadCapture, name, c.RecordType)
+	}
+	if err := validateCaptureFields(c); err != nil {
+		return "", err
+	}
+	if c.Direction != exp.direction {
+		return "", fmt.Errorf("%w: %s capture direction %q, want %q", ErrPayloadCapture, name, c.Direction, exp.direction)
+	}
+	if c.ActionID != exp.actionID {
+		return "", fmt.Errorf("%w: %s capture action_id %q does not match receipt action_id %q", ErrPayloadCapture, name, c.ActionID, exp.actionID)
+	}
+	if c.ActionHash != exp.actionHash {
+		return "", fmt.Errorf("%w: %s capture action_hash %q does not match receipt action hash %q", ErrPayloadCapture, name, c.ActionHash, exp.actionHash)
+	}
+	if c.PartyIdentity != exp.actor {
+		return "", fmt.Errorf("%w: %s capture party_identity %q does not match receipt actor %q", ErrPayloadCapture, name, c.PartyIdentity, exp.actor)
+	}
+	if c.CounterpartyIdentity != exp.counterpartyIdentity {
+		return "", fmt.Errorf("%w: %s capture counterparty_identity %q does not match binding counterparty %q", ErrPayloadCapture, name, c.CounterpartyIdentity, exp.counterpartyIdentity)
+	}
+	if c.Signature.Alg != signatureAlg {
+		return "", fmt.Errorf("%w: %s capture unsupported signature alg %q", ErrPayloadCapture, name, c.Signature.Alg)
+	}
+	if len(enrolledKey) != ed25519.PublicKeySize {
+		return "", fmt.Errorf("%w: %s enrolled key size = %d, want %d", ErrPayloadCapture, name, len(enrolledKey), ed25519.PublicKeySize)
+	}
+	rawSig, err := decodeSignature(c.Signature.Sig)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s capture: %s", ErrPayloadCapture, name, err.Error())
+	}
+	sum, err := canonicalCaptureHash(c)
+	if err != nil {
+		return "", err
+	}
+	if !ed25519.Verify(enrolledKey, sum[:], rawSig) {
+		return "", fmt.Errorf("%w: %s capture signature verification failed", ErrPayloadCapture, name)
+	}
+	return c.PayloadHash, nil
+}
+
+func validateCaptureFields(c PayloadCapture) error {
+	if err := validateToken("capture action_id", c.ActionID); err != nil {
+		return fmt.Errorf("%w: %s", ErrPayloadCapture, err.Error())
+	}
+	if err := validateHash("capture action_hash", c.ActionHash); err != nil {
+		return fmt.Errorf("%w: %s", ErrPayloadCapture, err.Error())
+	}
+	if err := validateToken("capture party_identity", c.PartyIdentity); err != nil {
+		return fmt.Errorf("%w: %s", ErrPayloadCapture, err.Error())
+	}
+	if err := validateToken("capture counterparty_identity", c.CounterpartyIdentity); err != nil {
+		return fmt.Errorf("%w: %s", ErrPayloadCapture, err.Error())
+	}
+	if err := validateHash("capture payload_hash", c.PayloadHash); err != nil {
+		return fmt.Errorf("%w: %s", ErrPayloadCapture, err.Error())
+	}
+	if c.Direction != DirectionEgress && c.Direction != DirectionIngress {
+		return fmt.Errorf("%w: capture direction %q must be %q or %q", ErrPayloadCapture, c.Direction, DirectionEgress, DirectionIngress)
+	}
+	return nil
+}
+
+func canonicalCaptureHash(c PayloadCapture) ([sha256.Size]byte, error) {
+	unsigned := struct {
+		RecordType           string `json:"record_type"`
+		ActionID             string `json:"action_id"`
+		ActionHash           string `json:"action_hash"`
+		PayloadHash          string `json:"payload_hash"`
+		Direction            string `json:"direction"`
+		PartyIdentity        string `json:"party_identity"`
+		CounterpartyIdentity string `json:"counterparty_identity"`
+	}{
+		RecordType:           c.RecordType,
+		ActionID:             c.ActionID,
+		ActionHash:           c.ActionHash,
+		PayloadHash:          c.PayloadHash,
+		Direction:            c.Direction,
+		PartyIdentity:        c.PartyIdentity,
+		CounterpartyIdentity: c.CounterpartyIdentity,
+	}
+	raw, err := json.Marshal(unsigned)
+	if err != nil {
+		return [sha256.Size]byte{}, fmt.Errorf("marshal canonical payload capture: %w", err)
+	}
+	tree, err := contract.ParseJSONStrict(raw)
+	if err != nil {
+		return [sha256.Size]byte{}, fmt.Errorf("parse canonical payload capture: %w", err)
+	}
+	canonical, err := contract.Canonicalize(tree)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	return sha256.Sum256(canonical), nil
+}
+
+func trustedReceiptKeyHex(name string, key ed25519.PublicKey) (string, error) {
+	if len(key) != ed25519.PublicKeySize {
+		return "", fmt.Errorf("%w: %s receipt key length = %d, want %d", ErrTrustedReceiptKey, name, len(key), ed25519.PublicKeySize)
+	}
+	return hex.EncodeToString(key), nil
+}
+
+func rejectSideRecordKeyReuse(sideKey, senderKey, receiverKey ed25519.PublicKey) error {
+	if len(sideKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("%w: side-record key size = %d, want %d", ErrUntrustedSideRecordKey, len(sideKey), ed25519.PublicKeySize)
+	}
+	if bytes.Equal(sideKey, senderKey) || bytes.Equal(sideKey, receiverKey) {
+		return ErrSideRecordKeyReuse
+	}
+	return nil
+}
+
+func compareReceiptIdentity(name string, r receipt.Receipt, want string) error {
+	if r.ActionRecord.Actor != want {
+		return fmt.Errorf("%w: %s receipt actor %q does not match record identity %q", ErrReceiptIdentity, name, r.ActionRecord.Actor, want)
+	}
+	return nil
+}
+
+func compareReceiptHash(name string, r receipt.Receipt, want string) error {
+	got, err := receipt.ReceiptHash(r)
+	if err != nil {
+		return fmt.Errorf("%s receipt hash: %w", name, err)
+	}
+	got = hashPrefix + got
+	if got != want {
+		return fmt.Errorf("%s receipt hash %q does not match record hash %q", name, got, want)
+	}
+	return nil
+}
+
+func validateHash(field, value string) error {
+	if !strings.HasPrefix(value, hashPrefix) {
+		return fmt.Errorf("%w: %s must have %s prefix", ErrMalformedBinding, field, hashPrefix)
+	}
+	raw := strings.TrimPrefix(value, hashPrefix)
+	decoded, err := hex.DecodeString(raw)
+	if err != nil {
+		return fmt.Errorf("%w: %s must be lowercase hex SHA-256: %s", ErrMalformedBinding, field, err.Error())
+	}
+	if len(decoded) != sha256.Size {
+		return fmt.Errorf("%w: %s length = %d, want %d", ErrMalformedBinding, field, len(decoded), sha256.Size)
+	}
+	if hex.EncodeToString(decoded) != raw {
+		return fmt.Errorf("%w: %s must be lowercase hex SHA-256", ErrMalformedBinding, field)
+	}
+	return nil
+}
+
+// validateToken enforces a printable, non-space ASCII grammar with a length
+// bound on identity/nonce/receipt-id fields. Restricting to ASCII guarantees
+// NFC normalization is a no-op, so the raw field used for the replay key matches
+// the normalized bytes the signature covers (closes the Unicode-normalization
+// replay bypass).
+func validateToken(field, value string) error {
+	if value == "" {
+		return fmt.Errorf("%w: %s is required", ErrMalformedBinding, field)
+	}
+	if len(value) > maxTokenLen {
+		return fmt.Errorf("%w: %s length = %d, want <= %d", ErrMalformedBinding, field, len(value), maxTokenLen)
+	}
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if c < 0x21 || c > 0x7e {
+			return fmt.Errorf("%w: %s must be printable non-space ASCII", ErrMalformedBinding, field)
+		}
+	}
+	return nil
+}
+
+func decodeSignature(value string) ([]byte, error) {
+	if !strings.HasPrefix(value, signaturePrefix) {
+		return nil, fmt.Errorf("signature must have %s prefix", signaturePrefix)
+	}
+	encoded := strings.TrimPrefix(value, signaturePrefix)
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode signature: %w", err)
+	}
+	if len(raw) != ed25519.SignatureSize {
+		return nil, fmt.Errorf("invalid signature length: got %d, want %d", len(raw), ed25519.SignatureSize)
+	}
+	if base64.StdEncoding.EncodeToString(raw) != encoded {
+		return nil, errors.New("signature must be canonical base64")
+	}
+	return raw, nil
+}
+
+func fail(code FailureCode, err error) VerificationResult {
+	return failWithNonce(code, err, nil, "")
+}
+
+func failWithNonce(code FailureCode, err error, nonce *NonceKey, signerKeyID string) VerificationResult {
+	msg := ""
+	if err != nil {
+		msg = fmt.Errorf("%w: %w", ErrVerificationError, err).Error()
+	}
+	return VerificationResult{
+		Passed:      false,
+		FailureCode: code,
+		Error:       msg,
+		Nonce:       nonce,
+		SignerKeyID: signerKeyID,
+	}
+}

--- a/enterprise/counterparty/counterparty_test.go
+++ b/enterprise/counterparty/counterparty_test.go
@@ -1,0 +1,1004 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package counterparty
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+func TestVerifyCounterpartyValidBoundPair(t *testing.T) {
+	fx := newFixture(t)
+	res := VerifyCounterparty(fx.request())
+	if !res.Passed {
+		t.Fatalf("VerifyCounterparty() failed: code=%s err=%s", res.FailureCode, res.Error)
+	}
+	wantNonce := NonceKey{
+		SideRecordKeyID:  "receiver-counterparty-key",
+		SenderIdentity:   "agent-a",
+		ReceiverIdentity: "agent-b",
+		Nonce:            "nonce-001",
+	}
+	if res.Nonce == nil || *res.Nonce != wantNonce {
+		t.Fatalf("nonce = %+v, want %+v", res.Nonce, wantNonce)
+	}
+	if res.SignerKeyID != "receiver-counterparty-key" {
+		t.Fatalf("signer key id = %q", res.SignerKeyID)
+	}
+}
+
+func TestVerifyCounterpartyRejectsUnilateralFabricationWithSelfSignedSender(t *testing.T) {
+	fx := newFixture(t)
+	_, fakeSenderPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(fake sender): %v", err)
+	}
+	fakeSenderReceipt := signReceipt(t, fakeSenderPriv, fx.sender.Receipt.ActionRecord.ActionID, "agent-a")
+
+	req := fx.request()
+	req.Sender = &BoundReceipt{Receipt: fakeSenderReceipt, Capture: fx.sender.Capture}
+	req.Record = fx.resign(func(b *Binding) {
+		b.SenderReceiptHash = mustReceiptHashLabel(t, fakeSenderReceipt)
+	})
+
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() accepted a self-signed fake sender receipt, want fail closed")
+	}
+	if res.FailureCode != FailureTrust {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureTrust)
+	}
+}
+
+// TestVerifyCounterpartyRejectsRogueSideRecordKey proves the receiver-scoped key
+// fix: a record signed by any other enrolled counterparty key cannot attest a
+// transfer to a receiver whose enrolled key is different. Before the fix, any
+// key in a flat trusted-key map could attest any identity.
+func TestVerifyCounterpartyRejectsRogueSideRecordKey(t *testing.T) {
+	fx := newFixture(t)
+	roguePub, roguePriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(rogue): %v", err)
+	}
+	req := fx.request()
+	// A different, otherwise-valid counterparty key signs the real receiver's
+	// binding. The receiver's enrolled key id/pub stays the honest one.
+	req.Record = fx.signWith(func(_ *Binding) {}, "rogue-counterparty-key", roguePriv)
+
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() accepted a rogue side-record key, want fail closed")
+	}
+	if res.FailureCode != FailureTrust {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureTrust)
+	}
+	if !strings.Contains(res.Error, "enrolled") {
+		t.Fatalf("error %q does not describe an enrolled-key mismatch", res.Error)
+	}
+	_ = roguePub
+}
+
+// TestVerifyCounterpartyRejectsRogueKeyForgingEnrolledKeyID proves the second
+// layer: even if the attacker labels the record with the receiver's enrolled
+// key id, the signature is verified against the receiver's real public key.
+func TestVerifyCounterpartyRejectsRogueKeyForgingEnrolledKeyID(t *testing.T) {
+	fx := newFixture(t)
+	_, roguePriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(rogue): %v", err)
+	}
+	req := fx.request()
+	// Attacker forges the enrolled key id but signs with a rogue key.
+	req.Record = fx.signWith(func(_ *Binding) {}, "receiver-counterparty-key", roguePriv)
+
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() accepted a forged-key-id rogue signature, want fail closed")
+	}
+	if res.FailureCode != FailureSignature {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureSignature)
+	}
+}
+
+// TestVerifyCounterpartyRequiresSenderPayloadAttestation proves the payload is
+// attested by BOTH parties: a receiver cannot bind a payload the sender never
+// signed. The receiver signs a capture + binding for a forged payload; the
+// sender's honest capture still attests the real payload, so verification fails.
+func TestVerifyCounterpartyRequiresSenderPayloadAttestation(t *testing.T) {
+	fx := newFixture(t)
+	req := fx.request()
+	forged := PayloadHash([]byte("payload the sender never sent"))
+	rcv := *req.Receiver
+	rcv.Capture = signCapture(t, fx.recvPriv, rcv.Receipt, captureTestSpec{keyID: "receiver-receipt-key", payloadHash: forged, direction: DirectionIngress, party: "agent-b", counterparty: "agent-a"})
+	req.Receiver = &rcv
+	req.Record = fx.resign(func(b *Binding) { b.PayloadHash = forged })
+
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() accepted a payload the sender never attested, want fail closed")
+	}
+	if res.FailureCode != FailurePayloadHashMismatch {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailurePayloadHashMismatch)
+	}
+}
+
+func TestVerifyCounterpartyRejectsForgedSenderCapture(t *testing.T) {
+	fx := newFixture(t)
+	_, roguePriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(rogue): %v", err)
+	}
+	req := fx.request()
+	snd := *req.Sender
+	snd.Capture = signCapture(t, roguePriv, snd.Receipt, captureTestSpec{keyID: "sender-receipt-key", payloadHash: fx.payloadHash, direction: DirectionEgress, party: "agent-a", counterparty: "agent-b"})
+	req.Sender = &snd
+	res := VerifyCounterparty(req)
+	if res.Passed || res.FailureCode != FailurePayloadCapture {
+		t.Fatalf("passed=%v code=%s err=%s, want fail %s", res.Passed, res.FailureCode, res.Error, FailurePayloadCapture)
+	}
+}
+
+func TestVerifyCounterpartyRejectsCaptureDirectionAndActionMismatch(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		capture func(fx *fixture) PayloadCapture
+	}{
+		{
+			name: "wrong direction",
+			capture: func(fx *fixture) PayloadCapture {
+				return signCapture(t, fx.senderPriv, fx.sender.Receipt, captureTestSpec{keyID: "sender-receipt-key", payloadHash: fx.payloadHash, direction: DirectionIngress, party: "agent-a", counterparty: "agent-b"})
+			},
+		},
+		{
+			name: "wrong action id",
+			capture: func(fx *fixture) PayloadCapture {
+				actionHash, err := signedActionHash(fx.sender.Receipt)
+				if err != nil {
+					t.Fatalf("signedActionHash: %v", err)
+				}
+				return signCaptureForAction(t, fx.senderPriv, captureTestSpec{keyID: "sender-receipt-key", actionID: "different-action", actionHash: actionHash, payloadHash: fx.payloadHash, direction: DirectionEgress, party: "agent-a", counterparty: "agent-b"})
+			},
+		},
+		{
+			name: "wrong party identity",
+			capture: func(fx *fixture) PayloadCapture {
+				return signCapture(t, fx.senderPriv, fx.sender.Receipt, captureTestSpec{keyID: "sender-receipt-key", payloadHash: fx.payloadHash, direction: DirectionEgress, party: "agent-x", counterparty: "agent-b"})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newFixture(t)
+			req := fx.request()
+			snd := *req.Sender
+			snd.Capture = tc.capture(fx)
+			req.Sender = &snd
+			res := VerifyCounterparty(req)
+			if res.Passed || res.FailureCode != FailurePayloadCapture {
+				t.Fatalf("passed=%v code=%s err=%s, want fail %s", res.Passed, res.FailureCode, res.Error, FailurePayloadCapture)
+			}
+		})
+	}
+}
+
+func TestVerifyCounterpartyRejectsCaptureReusedForSameActionIDDifferentSignedAction(t *testing.T) {
+	fx := newFixture(t)
+	req := fx.request()
+
+	ar := req.Sender.Receipt.ActionRecord
+	ar.Target = "https://api.vendor.example/v1/different-target"
+	ar.Intent = "different signed action with reused action id"
+	wrongReceipt, err := receipt.Sign(ar, fx.senderPriv)
+	if err != nil {
+		t.Fatalf("receipt.Sign(wrong action): %v", err)
+	}
+	req.Sender.Receipt = wrongReceipt
+	req.Record = fx.resign(func(b *Binding) {
+		b.SenderReceiptHash = mustReceiptHashLabel(t, wrongReceipt)
+	})
+
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() accepted a capture reused against a different signed action with the same action_id")
+	}
+	if res.FailureCode != FailurePayloadCapture {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailurePayloadCapture)
+	}
+}
+
+func TestVerifyCounterpartyRejectsSenderCaptureReusedForDifferentCounterparty(t *testing.T) {
+	fx := newFixture(t)
+	recvCPub, recvCPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(receiver-c): %v", err)
+	}
+	sideCPub, sideCPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(receiver-c side): %v", err)
+	}
+	receiverCReceipt := signReceipt(t, recvCPriv, "receiver-c-action", "agent-c")
+	receiverCCapture := signCapture(t, recvCPriv, receiverCReceipt, captureTestSpec{keyID: "receiver-c-receipt-key", payloadHash: fx.payloadHash, direction: DirectionIngress, party: "agent-c", counterparty: "agent-a"})
+	record, err := SignRecord(fleetLicense(), Record{Binding: Binding{
+		PayloadHash:         fx.payloadHash,
+		SenderIdentity:      "agent-a",
+		ReceiverIdentity:    "agent-c",
+		Nonce:               "nonce-001",
+		SenderReceiptID:     fx.sender.Receipt.ActionRecord.ActionID,
+		SenderReceiptHash:   mustReceiptHashLabel(t, fx.sender.Receipt),
+		ReceiverReceiptID:   receiverCReceipt.ActionRecord.ActionID,
+		ReceiverReceiptHash: mustReceiptHashLabel(t, receiverCReceipt),
+		Timestamp:           fx.record.Binding.Timestamp,
+		Version:             Version,
+	}}, "receiver-c-counterparty-key", sideCPriv)
+	if err != nil {
+		t.Fatalf("SignRecord(receiver-c): %v", err)
+	}
+
+	req := fx.request()
+	req.Receiver = &BoundReceipt{Receipt: receiverCReceipt, Capture: receiverCCapture}
+	req.Record = &record
+	req.ReceiverReceiptKey = recvCPub
+	req.ReceiverSideRecordKey = sideCPub
+	req.ReceiverSideRecordKeyID = "receiver-c-counterparty-key"
+
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() accepted an agent-a->agent-b sender capture inside an agent-a->agent-c transfer")
+	}
+	if res.FailureCode != FailurePayloadCapture {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailurePayloadCapture)
+	}
+}
+
+// TestBindingRejectsNonASCIIToken closes the Unicode-normalization replay
+// bypass: the signed hash NFC-normalizes strings, but the replay key uses the
+// raw string. Restricting identity/nonce/id fields to ASCII makes NFC a no-op,
+// so the two forms that collided can no longer both be built or accepted.
+func TestBindingRejectsNonASCIIToken(t *testing.T) {
+	fx := newFixture(t)
+
+	// SignRecord refuses to even create a record with a non-ASCII nonce.
+	rec := fx.record
+	rec.Binding.Nonce = "é" // "e" + combining acute; NFC-equals "é"
+	if _, err := SignRecord(fleetLicense(), Record{Binding: rec.Binding}, "receiver-counterparty-key", fx.cpPriv); !errors.Is(err, ErrMalformedBinding) {
+		t.Fatalf("SignRecord(non-ascii nonce) error = %v, want ErrMalformedBinding", err)
+	}
+
+	// A hand-crafted record (bypassing SignRecord) is rejected before signature.
+	req := fx.request()
+	req.Record.Binding.Nonce = "é"
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() accepted a non-ASCII nonce, want fail closed")
+	}
+	if res.FailureCode != FailureMalformedBinding {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureMalformedBinding)
+	}
+}
+
+func TestVerifyCounterpartyFreshness(t *testing.T) {
+	base := time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC)
+	testCases := []struct {
+		name string
+		mut  func(*VerifyRequest)
+		want FailureCode
+	}{
+		{
+			name: "stale beyond max age",
+			mut: func(req *VerifyRequest) {
+				req.Now = base.Add(48 * time.Hour) // ts is base; MaxAge is 24h
+			},
+			want: FailureStale,
+		},
+		{
+			name: "too far in the future",
+			mut: func(req *VerifyRequest) {
+				req.Now = base.Add(-time.Hour) // ts is base, 1h ahead; skew is 5m
+			},
+			want: FailureFuture,
+		},
+		{
+			name: "missing verify time",
+			mut: func(req *VerifyRequest) {
+				req.Now = time.Time{}
+			},
+			want: FailureMissingInput,
+		},
+		{
+			name: "non-positive max age",
+			mut: func(req *VerifyRequest) {
+				req.MaxAge = 0
+			},
+			want: FailureMissingInput,
+		},
+		{
+			name: "non-positive future skew",
+			mut: func(req *VerifyRequest) {
+				req.MaxFutureSkew = 0
+			},
+			want: FailureMissingInput,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newFixture(t)
+			req := fx.request()
+			tc.mut(&req)
+			res := VerifyCounterparty(req)
+			if res.Passed {
+				t.Fatal("VerifyCounterparty() passed, want fail closed")
+			}
+			if res.FailureCode != tc.want {
+				t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerifyCounterpartyExactAgeBoundaryPasses(t *testing.T) {
+	fx := newFixture(t)
+	req := fx.request()
+	// ts is exactly MaxAge old and exactly MaxFutureSkew is unused here.
+	req.Now = fx.record.Binding.Timestamp.Add(req.MaxAge)
+	res := VerifyCounterparty(req)
+	if !res.Passed {
+		t.Fatalf("VerifyCounterparty() at exact max-age boundary failed: code=%s err=%s", res.FailureCode, res.Error)
+	}
+}
+
+func TestVerifyCounterpartyRequiresReplayStore(t *testing.T) {
+	fx := newFixture(t)
+	req := fx.request()
+	req.ReplayStore = nil
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() passed without a replay store, want fail closed")
+	}
+	if res.FailureCode != FailureMissingInput {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureMissingInput)
+	}
+}
+
+func TestVerifyCounterpartyRejectsReplayedRecord(t *testing.T) {
+	fx := newFixture(t)
+	store := NewMemReplayStore()
+	req := fx.request()
+	req.ReplayStore = store
+	if res := VerifyCounterparty(req); !res.Passed {
+		t.Fatalf("first VerifyCounterparty() failed: %s", res.Error)
+	}
+
+	replay := fx.request()
+	replay.ReplayStore = store
+	res := VerifyCounterparty(replay)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() re-accepted the identical record, want fail closed")
+	}
+	if res.FailureCode != FailureReplay {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureReplay)
+	}
+}
+
+// TestVerifyCounterpartyRejectsReSignedTransfer proves the TransferKey dedup:
+// the same two receipts + payload re-signed under a fresh nonce cannot inflate a
+// coverage count.
+func TestVerifyCounterpartyRejectsReSignedTransfer(t *testing.T) {
+	fx := newFixture(t)
+	store := NewMemReplayStore()
+	req := fx.request()
+	req.ReplayStore = store
+	if res := VerifyCounterparty(req); !res.Passed {
+		t.Fatalf("first VerifyCounterparty() failed: %s", res.Error)
+	}
+
+	replay := fx.request()
+	replay.ReplayStore = store
+	replay.Record = fx.resign(func(b *Binding) { b.Nonce = "nonce-002" })
+	res := VerifyCounterparty(replay)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() accepted the same transfer under a new nonce, want fail closed")
+	}
+	if res.FailureCode != FailureReplay {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureReplay)
+	}
+}
+
+// TestVerifyCounterpartyRejectsReSignedTransferWithMutableReceiptEnvelope proves
+// TransferKey is based on signed receipt content rather than mutable envelope
+// bytes. The receipt signature hex string can be re-cased without changing the
+// Ed25519 signature bytes; that must not let the same real transfer pass again
+// under a fresh side-record nonce.
+func TestVerifyCounterpartyRejectsReSignedTransferWithMutableReceiptEnvelope(t *testing.T) {
+	fx := newFixture(t)
+	store := NewMemReplayStore()
+	req := fx.request()
+	req.ReplayStore = store
+	if res := VerifyCounterparty(req); !res.Passed {
+		t.Fatalf("first VerifyCounterparty() failed: %s", res.Error)
+	}
+
+	replay := fx.request()
+	replay.ReplayStore = store
+	mutatedSender := fx.sender
+	replay.Sender = &mutatedSender
+	replay.Sender.Receipt.Signature = "ed25519:" + strings.ToUpper(strings.TrimPrefix(replay.Sender.Receipt.Signature, "ed25519:"))
+	if replay.Sender.Receipt.Signature == fx.sender.Receipt.Signature {
+		t.Skip("fixture signature had no lowercase hex letters to mutate")
+	}
+	replay.Record = fx.resign(func(b *Binding) {
+		b.Nonce = "nonce-002"
+		b.SenderReceiptHash = mustReceiptHashLabel(t, replay.Sender.Receipt)
+	})
+
+	res := VerifyCounterparty(replay)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() accepted the same transfer with a mutable receipt envelope, want fail closed")
+	}
+	if res.FailureCode != FailureReplay {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureReplay)
+	}
+}
+
+// TestVerifyCounterpartyRejectedRecordDoesNotConsumeReplayState proves a record
+// that fails a non-mutating check (staleness) never inserts its nonce, so a
+// later honest record with the same nonce still passes.
+func TestVerifyCounterpartyRejectedRecordDoesNotConsumeReplayState(t *testing.T) {
+	fx := newFixture(t)
+	store := NewMemReplayStore()
+
+	stale := fx.request()
+	stale.ReplayStore = store
+	stale.Now = fx.record.Binding.Timestamp.Add(48 * time.Hour)
+	if res := VerifyCounterparty(stale); res.FailureCode != FailureStale {
+		t.Fatalf("stale record: code=%s err=%s, want %s", res.FailureCode, res.Error, FailureStale)
+	}
+
+	honest := fx.request()
+	honest.ReplayStore = store
+	if res := VerifyCounterparty(honest); !res.Passed {
+		t.Fatalf("honest record after a rejected one failed: code=%s err=%s (rejected record consumed replay state)", res.FailureCode, res.Error)
+	}
+}
+
+func TestVerifyCounterpartyBytesStrictParsing(t *testing.T) {
+	fx := newFixture(t)
+
+	honest, err := json.Marshal(fx.record)
+	if err != nil {
+		t.Fatalf("Marshal record: %v", err)
+	}
+	req := fx.request()
+	req.Record = nil
+	if res := VerifyCounterpartyBytes(req, honest); !res.Passed {
+		t.Fatalf("VerifyCounterpartyBytes(honest) failed: code=%s err=%s", res.FailureCode, res.Error)
+	}
+
+	dup := []byte(`{"record_type":"counterparty_receipt_v1","record_type":"x"}`)
+	if res := VerifyCounterpartyBytes(fx.request(), dup); res.Passed || res.FailureCode != FailureMalformedBinding {
+		t.Fatalf("VerifyCounterpartyBytes(dup keys): passed=%v code=%s, want fail %s", res.Passed, res.FailureCode, FailureMalformedBinding)
+	}
+
+	unknown := append(honest[:len(honest)-1:len(honest)-1], []byte(`,"extra":true}`)...)
+	if res := VerifyCounterpartyBytes(fx.request(), unknown); res.Passed || res.FailureCode != FailureMalformedBinding {
+		t.Fatalf("VerifyCounterpartyBytes(unknown field): passed=%v code=%s, want fail %s", res.Passed, res.FailureCode, FailureMalformedBinding)
+	}
+}
+
+func TestVerifyCounterpartyFailClosedNegatives(t *testing.T) {
+	testCases := []struct {
+		name string
+		mut  func(*fixture, *VerifyRequest)
+		want FailureCode
+	}{
+		{
+			name: "TestCounterpartyVerifyRejectsTamperedPayloadHashSender",
+			mut: func(fx *fixture, req *VerifyRequest) {
+				// Sender validly attests a DIFFERENT payload than the binding.
+				capture := *req.Sender
+				capture.Capture = signCapture(t, fx.senderPriv, capture.Receipt, captureTestSpec{keyID: "sender-receipt-key", payloadHash: PayloadHash([]byte("different sender bytes")), direction: DirectionEgress, party: "agent-a", counterparty: "agent-b"})
+				req.Sender = &capture
+			},
+			want: FailurePayloadHashMismatch,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsTamperedPayloadHashReceiver",
+			mut: func(fx *fixture, req *VerifyRequest) {
+				capture := *req.Receiver
+				capture.Capture = signCapture(t, fx.recvPriv, capture.Receipt, captureTestSpec{keyID: "receiver-receipt-key", payloadHash: PayloadHash([]byte("different receiver bytes")), direction: DirectionIngress, party: "agent-b", counterparty: "agent-a"})
+				req.Receiver = &capture
+			},
+			want: FailurePayloadHashMismatch,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsMissingSenderReceipt",
+			mut: func(_ *fixture, req *VerifyRequest) {
+				req.Sender = nil
+			},
+			want: FailureMissingInput,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsMissingReceiverSideRecord",
+			mut: func(_ *fixture, req *VerifyRequest) {
+				req.Record = nil
+			},
+			want: FailureMissingInput,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsInvalidSenderReceipt",
+			mut: func(_ *fixture, req *VerifyRequest) {
+				req.Sender.Receipt.Signature = "ed25519:" + base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+			},
+			want: FailureInvalidReceipt,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsInvalidReceiverReceipt",
+			mut: func(_ *fixture, req *VerifyRequest) {
+				req.Receiver.Receipt.SignerKey = strings.Repeat("0", ed25519.PublicKeySize*2)
+				req.ReceiverReceiptKey = ed25519.PublicKey(make([]byte, ed25519.PublicKeySize))
+			},
+			want: FailureInvalidReceipt,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsSenderReceiptIDMismatch",
+			mut: func(fx *fixture, req *VerifyRequest) {
+				req.Record = fx.resign(func(b *Binding) { b.SenderReceiptID = "wrong-sender-receipt" })
+			},
+			want: FailureReceiptIDMismatch,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsSenderReceiptHashMismatch",
+			mut: func(fx *fixture, req *VerifyRequest) {
+				req.Record = fx.resign(func(b *Binding) { b.SenderReceiptHash = PayloadHash([]byte("wrong sender receipt")) })
+			},
+			want: FailureReceiptHashMismatch,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsReceiverReceiptIDMismatch",
+			mut: func(fx *fixture, req *VerifyRequest) {
+				req.Record = fx.resign(func(b *Binding) { b.ReceiverReceiptID = "wrong-receiver-receipt" })
+			},
+			want: FailureReceiptIDMismatch,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsReceiverReceiptHashMismatch",
+			mut: func(fx *fixture, req *VerifyRequest) {
+				req.Record = fx.resign(func(b *Binding) { b.ReceiverReceiptHash = PayloadHash([]byte("wrong receiver receipt")) })
+			},
+			want: FailureReceiptHashMismatch,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsWrongEnrolledSideRecordKeyID",
+			mut: func(_ *fixture, req *VerifyRequest) {
+				req.ReceiverSideRecordKeyID = "not-the-enrolled-key"
+			},
+			want: FailureTrust,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsInvalidSideRecordSignature",
+			mut: func(_ *fixture, req *VerifyRequest) {
+				req.Record.Signature.Sig = "ed25519:" + base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+			},
+			want: FailureSignature,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsSameIdentity",
+			mut: func(fx *fixture, req *VerifyRequest) {
+				req.Record = fx.resign(func(b *Binding) { b.ReceiverIdentity = b.SenderIdentity })
+			},
+			want: FailureSelfCounterparty,
+		},
+		{
+			name: "TestCounterpartyVerifyRejectsSameReceiptSignerKey",
+			mut: func(fx *fixture, req *VerifyRequest) {
+				req.Receiver.Receipt = signReceipt(t, fx.senderPriv, "receiver-action", "agent-b")
+				req.Receiver.Capture = signCapture(t, fx.senderPriv, req.Receiver.Receipt, captureTestSpec{keyID: "receiver-receipt-key", payloadHash: fx.payloadHash, direction: DirectionIngress, party: "agent-b", counterparty: "agent-a"})
+				req.ReceiverReceiptKey = fx.senderPub
+				req.Record = fx.resign(func(b *Binding) {
+					b.ReceiverReceiptHash = mustReceiptHashLabel(t, req.Receiver.Receipt)
+				})
+			},
+			want: FailureSelfCounterparty,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newFixture(t)
+			req := fx.request()
+			tc.mut(fx, &req)
+			res := VerifyCounterparty(req)
+			if res.Passed {
+				t.Fatal("VerifyCounterparty() passed, want fail closed")
+			}
+			if res.FailureCode != tc.want {
+				t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, tc.want)
+			}
+		})
+	}
+}
+
+func TestCounterpartyVerifyRejectsMissingTrustedReceiptKeys(t *testing.T) {
+	fx := newFixture(t)
+	for _, tc := range []struct {
+		name string
+		mut  func(*VerifyRequest)
+	}{
+		{
+			name: "missing sender key",
+			mut: func(req *VerifyRequest) {
+				req.SenderReceiptKey = nil
+			},
+		},
+		{
+			name: "missing receiver key",
+			mut: func(req *VerifyRequest) {
+				req.ReceiverReceiptKey = nil
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := fx.request()
+			tc.mut(&req)
+			res := VerifyCounterparty(req)
+			if res.Passed {
+				t.Fatal("VerifyCounterparty() passed without a trusted receipt key, want fail closed")
+			}
+			if res.FailureCode != FailureTrust {
+				t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureTrust)
+			}
+		})
+	}
+}
+
+func TestCounterpartyVerifyRejectsReceiptIdentityMismatch(t *testing.T) {
+	fx := newFixture(t)
+	req := fx.request()
+	req.Sender.Receipt = signReceipt(t, fx.senderPriv, "sender-action", "agent-x")
+	req.Sender.Capture = signCapture(t, fx.senderPriv, req.Sender.Receipt, captureTestSpec{keyID: "sender-receipt-key", payloadHash: fx.payloadHash, direction: DirectionEgress, party: "agent-x", counterparty: "agent-b"})
+	req.Record = fx.resign(func(b *Binding) {
+		b.SenderReceiptHash = mustReceiptHashLabel(t, req.Sender.Receipt)
+	})
+
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() passed with mismatched sender receipt identity, want fail closed")
+	}
+	if res.FailureCode != FailureIdentityMismatch {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureIdentityMismatch)
+	}
+}
+
+func TestCounterpartyVerifyRejectsSideRecordKeyReuse(t *testing.T) {
+	fx := newFixture(t)
+	req := fx.request()
+	// Enroll the sender's receipt key as the receiver's side-record key: the
+	// side record must be signed by a key separate from both receipt keys.
+	req.ReceiverSideRecordKey = fx.senderPub
+	req.ReceiverSideRecordKeyID = "sender-counterparty-key"
+	req.Record = fx.signWith(func(_ *Binding) {}, "sender-counterparty-key", fx.senderPriv)
+
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() passed with side-record key reused as a receipt key, want fail closed")
+	}
+	if res.FailureCode != FailureTrust {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureTrust)
+	}
+}
+
+func TestCounterpartyRecordStrictParsingRejectsUnknownFields(t *testing.T) {
+	fx := newFixture(t)
+	raw, err := json.Marshal(fx.record)
+	if err != nil {
+		t.Fatalf("Marshal record: %v", err)
+	}
+	raw = append(raw[:len(raw)-1], []byte(`,"extra":true}`)...)
+	_, err = UnmarshalRecord(raw)
+	if !errors.Is(err, ErrUnknownField) {
+		t.Fatalf("UnmarshalRecord unknown field error = %v, want ErrUnknownField", err)
+	}
+}
+
+func TestUnmarshalPayloadCaptureStrict(t *testing.T) {
+	fx := newFixture(t)
+	raw, err := json.Marshal(fx.sender.Capture)
+	if err != nil {
+		t.Fatalf("Marshal capture: %v", err)
+	}
+	if _, err := UnmarshalPayloadCapture(raw); err != nil {
+		t.Fatalf("UnmarshalPayloadCapture(valid) = %v", err)
+	}
+	if _, err := UnmarshalPayloadCapture([]byte(`{"record_type":"x","record_type":"y"}`)); !errors.Is(err, receipt.ErrDuplicateKey) {
+		t.Fatalf("dup keys = %v", err)
+	}
+	unknown := append(raw[:len(raw)-1:len(raw)-1], []byte(`,"extra":true}`)...)
+	if _, err := UnmarshalPayloadCapture(unknown); !errors.Is(err, ErrUnknownField) {
+		t.Fatalf("unknown field = %v", err)
+	}
+	trailing := append(append([]byte{}, raw...), []byte(" junk")...)
+	if _, err := UnmarshalPayloadCapture(trailing); !errors.Is(err, ErrTrailingTokens) {
+		t.Fatalf("trailing tokens = %v", err)
+	}
+}
+
+func TestCounterpartyRecordStrictParsingRejectsDuplicateKeys(t *testing.T) {
+	_, err := UnmarshalRecord([]byte(`{"record_type":"counterparty_receipt_v1","record_type":"counterparty_receipt_v1"}`))
+	if !errors.Is(err, receipt.ErrDuplicateKey) {
+		t.Fatalf("UnmarshalRecord duplicate key error = %v, want duplicate-key sentinel", err)
+	}
+}
+
+func TestCounterpartyRecordSignatureRejectsNonCanonicalBase64(t *testing.T) {
+	fx := newFixture(t)
+	req := fx.request()
+	req.Record.Signature.Sig = strings.Replace(req.Record.Signature.Sig, "ed25519:", "ed25519:\n", 1)
+
+	res := VerifyCounterparty(req)
+	if res.Passed {
+		t.Fatal("VerifyCounterparty() passed with non-canonical base64 signature, want fail closed")
+	}
+	if res.FailureCode != FailureSignature {
+		t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureSignature)
+	}
+}
+
+func TestCounterpartySignAndSignatureVerifyRequireFleetFeatureFailClosed(t *testing.T) {
+	fx := newFixture(t)
+	for _, lic := range []license.License{
+		{},
+		{Features: []string{license.FeatureAgents}},
+	} {
+		if _, err := SignRecord(lic, Record{Binding: fx.record.Binding}, "receiver-counterparty-key", fx.cpPriv); !errors.Is(err, ErrFleetRequired) {
+			t.Fatalf("SignRecord() error = %v, want ErrFleetRequired", err)
+		}
+		if err := VerifyRecordSignature(lic, fx.record, "receiver-counterparty-key", fx.cpPub); !errors.Is(err, ErrFleetRequired) {
+			t.Fatalf("VerifyRecordSignature() error = %v, want ErrFleetRequired", err)
+		}
+	}
+}
+
+func TestCounterpartyCoSignRequiresFleetFeatureFailClosed(t *testing.T) {
+	fx := newFixture(t)
+	for _, tc := range []struct {
+		name string
+		lic  license.License
+	}{
+		{name: "no license", lic: license.License{}},
+		{name: "wrong tier agents only", lic: license.License{Features: []string{license.FeatureAgents}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := fx.request()
+			req.License = tc.lic
+			res := VerifyCounterparty(req)
+			if res.Passed {
+				t.Fatal("VerifyCounterparty() passed without fleet license, want fail closed")
+			}
+			if res.FailureCode != FailureLicense {
+				t.Fatalf("failure code = %s err=%s, want %s", res.FailureCode, res.Error, FailureLicense)
+			}
+		})
+	}
+
+	if err := receipt.VerifyWithKey(fx.sender.Receipt, fx.sender.Receipt.SignerKey); err != nil {
+		t.Fatalf("free receipt verification changed: %v", err)
+	}
+}
+
+func TestMemReplayStoreConcurrentCommitExactlyOnce(t *testing.T) {
+	store := NewMemReplayStore()
+	entry := ReplayEntry{
+		NonceKey:    NonceKey{SideRecordKeyID: "k", SenderIdentity: "a", ReceiverIdentity: "b", Nonce: "n"},
+		TransferKey: TransferKey{SenderIdentity: "a", ReceiverIdentity: "b", PayloadHash: replayHashA, SenderReceiptID: "s", ReceiverReceiptID: "r", SenderActionHash: replayHashC, ReceiverActionHash: replayHashD},
+		RecordHash:  replayHashE,
+		Timestamp:   time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC),
+	}
+	const workers = 32
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	successes := 0
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			if err := store.CommitIfNew(entry); err == nil {
+				mu.Lock()
+				successes++
+				mu.Unlock()
+			} else if !errors.Is(err, ErrReplayConflict) {
+				t.Errorf("CommitIfNew unexpected error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if successes != 1 {
+		t.Fatalf("concurrent CommitIfNew succeeded %d times, want exactly 1", successes)
+	}
+}
+
+type fixture struct {
+	senderPub  ed25519.PublicKey
+	senderPriv ed25519.PrivateKey
+	recvPub    ed25519.PublicKey
+	recvPriv   ed25519.PrivateKey
+	cpPriv     ed25519.PrivateKey
+	cpPub      ed25519.PublicKey
+
+	sender      BoundReceipt
+	receiver    BoundReceipt
+	payloadHash string
+	record      Record
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	senderPub, senderPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(sender): %v", err)
+	}
+	recvPub, recvPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(receiver): %v", err)
+	}
+	cpPub, cpPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(counterparty): %v", err)
+	}
+	payloadHash := PayloadHash([]byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"url":"https://api.vendor.example/v1/tasks"}}`))
+	senderReceipt := signReceipt(t, senderPriv, "sender-action", "agent-a")
+	receiverReceipt := signReceipt(t, recvPriv, "receiver-action", "agent-b")
+	senderCapture := signCapture(t, senderPriv, senderReceipt, captureTestSpec{keyID: "sender-receipt-key", payloadHash: payloadHash, direction: DirectionEgress, party: "agent-a", counterparty: "agent-b"})
+	receiverCapture := signCapture(t, recvPriv, receiverReceipt, captureTestSpec{keyID: "receiver-receipt-key", payloadHash: payloadHash, direction: DirectionIngress, party: "agent-b", counterparty: "agent-a"})
+	fx := &fixture{
+		senderPub:   senderPub,
+		senderPriv:  senderPriv,
+		recvPub:     recvPub,
+		recvPriv:    recvPriv,
+		cpPriv:      cpPriv,
+		cpPub:       cpPub,
+		payloadHash: payloadHash,
+		sender:      BoundReceipt{Receipt: senderReceipt, Capture: senderCapture},
+		receiver:    BoundReceipt{Receipt: receiverReceipt, Capture: receiverCapture},
+	}
+	rec := Record{
+		Binding: Binding{
+			PayloadHash:         payloadHash,
+			SenderIdentity:      "agent-a",
+			ReceiverIdentity:    "agent-b",
+			Nonce:               "nonce-001",
+			SenderReceiptID:     senderReceipt.ActionRecord.ActionID,
+			SenderReceiptHash:   mustReceiptHashLabel(t, senderReceipt),
+			ReceiverReceiptID:   receiverReceipt.ActionRecord.ActionID,
+			ReceiverReceiptHash: mustReceiptHashLabel(t, receiverReceipt),
+			Timestamp:           time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC),
+			Version:             Version,
+		},
+	}
+	signed, err := SignRecord(fleetLicense(), rec, "receiver-counterparty-key", cpPriv)
+	if err != nil {
+		t.Fatalf("SignRecord: %v", err)
+	}
+	fx.record = signed
+	return fx
+}
+
+func (fx *fixture) request() VerifyRequest {
+	return VerifyRequest{
+		License:                 license.License{Features: []string{license.FeatureFleet}},
+		Sender:                  &fx.sender,
+		Receiver:                &fx.receiver,
+		Record:                  &fx.record,
+		SenderReceiptKey:        fx.senderPub,
+		ReceiverReceiptKey:      fx.recvPub,
+		ReceiverSideRecordKey:   fx.cpPub,
+		ReceiverSideRecordKeyID: "receiver-counterparty-key",
+		Now:                     fx.record.Binding.Timestamp,
+		MaxAge:                  24 * time.Hour,
+		MaxFutureSkew:           5 * time.Minute,
+		ReplayStore:             NewMemReplayStore(),
+	}
+}
+
+func (fx *fixture) resign(mut func(*Binding)) *Record {
+	return fx.signWith(mut, "receiver-counterparty-key", fx.cpPriv)
+}
+
+func (fx *fixture) signWith(mut func(*Binding), keyID string, privKey ed25519.PrivateKey) *Record {
+	rec := fx.record
+	mut(&rec.Binding)
+	signed, err := SignRecord(fleetLicense(), Record{Binding: rec.Binding}, keyID, privKey)
+	if err != nil {
+		panic(err)
+	}
+	return &signed
+}
+
+// captureTestSpec holds the inputs for signing a test payload capture, keeping
+// the signing helpers within the parameter-count guideline.
+type captureTestSpec struct {
+	keyID        string
+	actionID     string
+	actionHash   string
+	payloadHash  string
+	direction    string
+	party        string
+	counterparty string
+}
+
+// signCapture signs a payload capture, deriving action id and action hash from r.
+func signCapture(t *testing.T, priv ed25519.PrivateKey, r receipt.Receipt, spec captureTestSpec) PayloadCapture {
+	t.Helper()
+	actionHash, err := signedActionHash(r)
+	if err != nil {
+		t.Fatalf("signedActionHash: %v", err)
+	}
+	spec.actionID = r.ActionRecord.ActionID
+	spec.actionHash = actionHash
+	return signCaptureForAction(t, priv, spec)
+}
+
+func signCaptureForAction(t *testing.T, priv ed25519.PrivateKey, spec captureTestSpec) PayloadCapture {
+	t.Helper()
+	c, err := SignPayloadCapture(PayloadCapture{
+		ActionID:             spec.actionID,
+		ActionHash:           spec.actionHash,
+		PayloadHash:          spec.payloadHash,
+		Direction:            spec.direction,
+		PartyIdentity:        spec.party,
+		CounterpartyIdentity: spec.counterparty,
+	}, spec.keyID, priv)
+	if err != nil {
+		t.Fatalf("SignPayloadCapture: %v", err)
+	}
+	return c
+}
+
+func signReceipt(t *testing.T, priv ed25519.PrivateKey, actionID, actor string) receipt.Receipt {
+	t.Helper()
+	r, err := receipt.Sign(receipt.ActionRecord{
+		Version:         receipt.ActionRecordVersion,
+		ActionID:        actionID,
+		ActionType:      receipt.ActionWrite,
+		Timestamp:       time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC),
+		Principal:       actor,
+		Actor:           actor,
+		DelegationChain: []string{actor},
+		Target:          "https://api.vendor.example/v1/tasks",
+		Intent:          "counterparty fixture",
+		SideEffectClass: receipt.SideEffectExternalWrite,
+		Reversibility:   receipt.ReversibilityCompensatable,
+		PolicyHash:      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Verdict:         "allow",
+		Transport:       "a2a-http",
+		Method:          "POST",
+		ChainPrevHash:   receipt.GenesisHash,
+	}, priv)
+	if err != nil {
+		t.Fatalf("receipt.Sign: %v", err)
+	}
+	return r
+}
+
+func mustReceiptHashLabel(t *testing.T, r receipt.Receipt) string {
+	t.Helper()
+	h, err := receipt.ReceiptHash(r)
+	if err != nil {
+		t.Fatalf("ReceiptHash: %v", err)
+	}
+	return hashPrefix + h
+}
+
+func fleetLicense() license.License {
+	return license.License{Features: []string{license.FeatureFleet}}
+}

--- a/enterprise/counterparty/replaystore.go
+++ b/enterprise/counterparty/replaystore.go
@@ -1,0 +1,348 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package counterparty
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+)
+
+// ErrReplayConflict is returned by CommitIfNew when a record's nonce or transfer
+// has already been committed. It is a fail-closed replay rejection, distinct
+// from a store I/O error.
+var ErrReplayConflict = errors.New("counterparty record replays a committed nonce or transfer")
+
+// ReplayEntry is the durable unit of replay state for one accepted record. Two
+// uniqueness constraints are enforced: NonceKey rejects the identical signed
+// record, TransferKey rejects the same two receipts + payload re-signed under a
+// fresh nonce (coverage-count inflation).
+type ReplayEntry struct {
+	NonceKey    NonceKey    `json:"nonce_key"`
+	TransferKey TransferKey `json:"transfer_key"`
+	RecordHash  string      `json:"record_hash"`
+	Timestamp   time.Time   `json:"ts"`
+}
+
+// ReplayStore records accepted counterparty records and rejects replays. The
+// verifier calls CommitIfNew only after every non-mutating check has passed, so
+// a rejected record never consumes state. Implementations must be safe for
+// concurrent use and must fail closed (return a non-conflict error) on any
+// condition where they cannot prove non-replay.
+type ReplayStore interface {
+	// CommitIfNew atomically rejects the entry if either its NonceKey or its
+	// TransferKey was already committed (ErrReplayConflict), otherwise persists
+	// it and returns nil. On any I/O, lock, or corruption failure it returns a
+	// non-ErrReplayConflict error so the verifier fails closed.
+	CommitIfNew(entry ReplayEntry) error
+}
+
+// MemReplayStore is a thread-safe in-memory replay set. It provides no
+// durability across process restarts; use FileReplayStore for that.
+type MemReplayStore struct {
+	mu        sync.Mutex
+	nonces    map[NonceKey]struct{}
+	transfers map[TransferKey]struct{}
+}
+
+// NewMemReplayStore returns an empty in-memory replay store.
+func NewMemReplayStore() *MemReplayStore {
+	return &MemReplayStore{
+		nonces:    make(map[NonceKey]struct{}),
+		transfers: make(map[TransferKey]struct{}),
+	}
+}
+
+// CommitIfNew implements ReplayStore.
+func (s *MemReplayStore) CommitIfNew(entry ReplayEntry) error {
+	if err := validateReplayEntry(entry); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.nonces[entry.NonceKey]; ok {
+		return fmt.Errorf("%w: nonce already committed", ErrReplayConflict)
+	}
+	if _, ok := s.transfers[entry.TransferKey]; ok {
+		return fmt.Errorf("%w: transfer already committed", ErrReplayConflict)
+	}
+	s.nonces[entry.NonceKey] = struct{}{}
+	s.transfers[entry.TransferKey] = struct{}{}
+	return nil
+}
+
+// FileReplayStore is a durable, append-only replay store backed by a JSONL file.
+// Each accepted entry is written as one line and fsync'd before CommitIfNew
+// returns, so a committed record survives a restart. A malformed line at open
+// makes the store unhealthy and every CommitIfNew fails closed rather than
+// silently dropping replay history.
+type FileReplayStore struct {
+	mu         sync.Mutex
+	path       string
+	file       *os.File
+	nonces     map[NonceKey]struct{}
+	transfers  map[TransferKey]struct{}
+	readOffset int64
+	healthy    bool
+}
+
+// OpenFileReplayStore opens (creating if needed) a durable replay store at path.
+// It loads and indexes every existing entry; a corrupt line returns an error and
+// leaves no usable store, so callers fail closed instead of losing history.
+//
+// The store is safe to share across processes: each CommitIfNew re-indexes any
+// entries other processes appended under an exclusive cross-process file lock
+// before deciding, so two processes cannot both accept the same entry.
+//
+// Durability limitation: the newly created store file's directory entry is
+// fsync'd best-effort (directory fsync is not portable). On a platform without
+// directory fsync, a power loss in the narrow window between first creation and
+// the first committed entry becoming durable could lose the file. Operators
+// requiring strict first-write durability there should pre-create the store file.
+//
+// Enforcement limitation: this store treats a missing or empty file at open as a
+// fresh store (O_CREATE). Truncation WHILE a store is running is detected and
+// fails closed (see reindexLocked), but if the file is deleted or truncated
+// out-of-band while no process holds it open, previously accepted nonces are
+// forgotten on the next open and could be re-accepted. A deployment that must
+// survive out-of-band deletion/truncation should keep the store on
+// non-truncating persistent storage or pair it with an external checkpoint.
+func OpenFileReplayStore(path string) (*FileReplayStore, error) {
+	if path == "" {
+		return nil, errors.New("replay store path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return nil, fmt.Errorf("create replay store dir: %w", err)
+	}
+	f, err := os.OpenFile(filepath.Clean(path), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open replay store: %w", err)
+	}
+	fsyncDir(filepath.Dir(path)) // best-effort: persist the new dir entry where supported
+	s := &FileReplayStore{
+		path:      path,
+		file:      f,
+		nonces:    make(map[NonceKey]struct{}),
+		transfers: make(map[TransferKey]struct{}),
+	}
+	release, err := acquireReplayStoreLock(s.file)
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	err = s.reindexLocked()
+	release()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	s.healthy = true
+	return s, nil
+}
+
+// reindexLocked indexes every complete line appended since the last read offset.
+// The caller must hold both the in-process mutex and the cross-process file lock.
+// A corrupt or torn (newline-less) trailing line fails closed rather than being
+// silently dropped or overwritten.
+func (s *FileReplayStore) reindexLocked() error {
+	info, err := s.file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat replay store: %w", err)
+	}
+	if info.Size() < s.readOffset {
+		return fmt.Errorf("replay store %s shrank from %d to %d bytes; refusing to lose replay history", s.path, s.readOffset, info.Size())
+	}
+	if _, err := s.file.Seek(s.readOffset, io.SeekStart); err != nil {
+		return fmt.Errorf("seek replay store: %w", err)
+	}
+	reader := bufio.NewReader(s.file)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			if line[len(line)-1] != '\n' {
+				return fmt.Errorf("replay store %s has an incomplete trailing line", s.path)
+			}
+			if indexErr := s.indexLine(line[:len(line)-1]); indexErr != nil {
+				return indexErr
+			}
+			s.readOffset += int64(len(line))
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read replay store: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *FileReplayStore) indexLine(raw []byte) error {
+	if err := jsonscan.RejectDuplicateKeys(raw); err != nil {
+		return fmt.Errorf("replay store %s is corrupt: %w", s.path, err)
+	}
+	var entry ReplayEntry
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&entry); err != nil {
+		return fmt.Errorf("replay store %s is corrupt: %w", s.path, err)
+	}
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return fmt.Errorf("replay store %s has trailing tokens: %w", s.path, err)
+		}
+		return fmt.Errorf("replay store %s has trailing tokens", s.path)
+	}
+	if err := validateReplayEntry(entry); err != nil {
+		return fmt.Errorf("replay store %s has an invalid entry: %w", s.path, err)
+	}
+	s.nonces[entry.NonceKey] = struct{}{}
+	s.transfers[entry.TransferKey] = struct{}{}
+	return nil
+}
+
+// CommitIfNew implements ReplayStore with durable, fsync'd, cross-process-safe
+// persistence. Under an exclusive file lock it re-indexes entries appended by
+// other processes, checks for a nonce or transfer conflict, then appends and
+// fsyncs, so concurrent processes sharing one store cannot both accept an entry.
+func (s *FileReplayStore) CommitIfNew(entry ReplayEntry) error {
+	if err := validateReplayEntry(entry); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.healthy {
+		return errors.New("replay store is unhealthy")
+	}
+	release, err := acquireReplayStoreLock(s.file)
+	if err != nil {
+		return fmt.Errorf("lock replay store: %w", err)
+	}
+	defer release()
+
+	if err := verifyStorePathInode(s.file, s.path); err != nil {
+		s.healthy = false
+		return err
+	}
+	if err := s.reindexLocked(); err != nil {
+		s.healthy = false
+		return err
+	}
+	if _, ok := s.nonces[entry.NonceKey]; ok {
+		return fmt.Errorf("%w: nonce already committed", ErrReplayConflict)
+	}
+	if _, ok := s.transfers[entry.TransferKey]; ok {
+		return fmt.Errorf("%w: transfer already committed", ErrReplayConflict)
+	}
+	encodedLen, err := s.appendEntryLocked(entry)
+	if err != nil {
+		s.healthy = false
+		return err
+	}
+	s.nonces[entry.NonceKey] = struct{}{}
+	s.transfers[entry.TransferKey] = struct{}{}
+	s.readOffset += int64(encodedLen)
+	return nil
+}
+
+func (s *FileReplayStore) appendEntryLocked(entry ReplayEntry) (int, error) {
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		return 0, fmt.Errorf("marshal replay entry: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	n, err := s.file.Write(encoded)
+	if err != nil {
+		return 0, fmt.Errorf("write replay entry: %w", err)
+	}
+	if n != len(encoded) {
+		return 0, fmt.Errorf("write replay entry: %w", io.ErrShortWrite)
+	}
+	if err := s.file.Sync(); err != nil {
+		return 0, fmt.Errorf("fsync replay entry: %w", err)
+	}
+	if err := verifyStorePathInode(s.file, s.path); err != nil {
+		return 0, err
+	}
+	return len(encoded), nil
+}
+
+// fsyncDir best-effort flushes a directory entry to disk. Directory fsync is not
+// portable (it is a no-op or unsupported on some platforms), so failures are
+// ignored; on Linux it persists a newly created store file's directory entry.
+func fsyncDir(dir string) {
+	d, err := os.Open(filepath.Clean(dir)) // #nosec G304 -- dir derives from the operator-configured replay store path
+	if err != nil {
+		return
+	}
+	defer func() { _ = d.Close() }()
+	_ = d.Sync()
+}
+
+func validateReplayEntry(entry ReplayEntry) error {
+	if err := validateToken("replay nonce side_record_key_id", entry.NonceKey.SideRecordKeyID); err != nil {
+		return err
+	}
+	if err := validateToken("replay nonce sender_identity", entry.NonceKey.SenderIdentity); err != nil {
+		return err
+	}
+	if err := validateToken("replay nonce receiver_identity", entry.NonceKey.ReceiverIdentity); err != nil {
+		return err
+	}
+	if err := validateToken("replay nonce nonce", entry.NonceKey.Nonce); err != nil {
+		return err
+	}
+	if err := validateToken("replay transfer sender_identity", entry.TransferKey.SenderIdentity); err != nil {
+		return err
+	}
+	if err := validateToken("replay transfer receiver_identity", entry.TransferKey.ReceiverIdentity); err != nil {
+		return err
+	}
+	if err := validateHash("replay transfer payload_hash", entry.TransferKey.PayloadHash); err != nil {
+		return err
+	}
+	if err := validateToken("replay transfer sender_receipt_id", entry.TransferKey.SenderReceiptID); err != nil {
+		return err
+	}
+	if err := validateToken("replay transfer receiver_receipt_id", entry.TransferKey.ReceiverReceiptID); err != nil {
+		return err
+	}
+	if err := validateHash("replay transfer sender_action_hash", entry.TransferKey.SenderActionHash); err != nil {
+		return err
+	}
+	if err := validateHash("replay transfer receiver_action_hash", entry.TransferKey.ReceiverActionHash); err != nil {
+		return err
+	}
+	if err := validateHash("replay record_hash", entry.RecordHash); err != nil {
+		return err
+	}
+	if entry.Timestamp.IsZero() {
+		return fmt.Errorf("%w: replay timestamp is required", ErrMalformedBinding)
+	}
+	return nil
+}
+
+// Close releases the underlying file.
+func (s *FileReplayStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.healthy = false
+	if s.file == nil {
+		return nil
+	}
+	err := s.file.Close()
+	s.file = nil
+	return err
+}

--- a/enterprise/counterparty/replaystore.go
+++ b/enterprise/counterparty/replaystore.go
@@ -25,6 +25,11 @@ import (
 // from a store I/O error.
 var ErrReplayConflict = errors.New("counterparty record replays a committed nonce or transfer")
 
+var (
+	replayStoreLockTimeout       = 5 * time.Second
+	replayStoreLockRetryInterval = 10 * time.Millisecond
+)
+
 // ReplayEntry is the durable unit of replay state for one accepted record. Two
 // uniqueness constraints are enforced: NonceKey rejects the identical signed
 // record, TransferKey rejects the same two receipts + payload re-signed under a

--- a/enterprise/counterparty/replaystore_lock_unix.go
+++ b/enterprise/counterparty/replaystore_lock_unix.go
@@ -1,0 +1,46 @@
+//go:build enterprise && !windows && !js
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package counterparty
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// acquireReplayStoreLock takes an exclusive, cross-process advisory lock on the
+// OPEN store file descriptor. Locking the fd (not a path-derived sibling) ties
+// the lock to the same inode the store reads and writes, so path aliases
+// (symlinks, relative paths, hardlinks) contend on the same inode and the lock
+// cannot drift from the I/O target. The returned release closure unlocks.
+func acquireReplayStoreLock(f *os.File) (func(), error) {
+	fd := int(f.Fd()) // #nosec G115 -- file descriptors fit in int on supported Unix targets
+	if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
+		return nil, fmt.Errorf("acquire replay store lock: %w", err)
+	}
+	return func() { _ = syscall.Flock(fd, syscall.LOCK_UN) }, nil
+}
+
+// verifyStorePathInode fails closed if the configured path no longer resolves to
+// the open file's inode (for example the store file was renamed away and a fresh
+// file created in its place). Without this check the lock would guard the open
+// inode while a second process operates on the replacement inode, splitting
+// replay state and double-accepting records.
+func verifyStorePathInode(f *os.File, path string) error {
+	var fdStat, pathStat syscall.Stat_t
+	if err := syscall.Fstat(int(f.Fd()), &fdStat); err != nil { // #nosec G115 -- fd fits in int
+		return fmt.Errorf("fstat replay store: %w", err)
+	}
+	if err := syscall.Stat(filepath.Clean(path), &pathStat); err != nil {
+		return fmt.Errorf("stat replay store path: %w", err)
+	}
+	if fdStat.Dev != pathStat.Dev || fdStat.Ino != pathStat.Ino {
+		return errors.New("replay store path no longer resolves to the open store file")
+	}
+	return nil
+}

--- a/enterprise/counterparty/replaystore_lock_unix.go
+++ b/enterprise/counterparty/replaystore_lock_unix.go
@@ -11,19 +11,32 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 )
 
 // acquireReplayStoreLock takes an exclusive, cross-process advisory lock on the
 // OPEN store file descriptor. Locking the fd (not a path-derived sibling) ties
 // the lock to the same inode the store reads and writes, so path aliases
 // (symlinks, relative paths, hardlinks) contend on the same inode and the lock
-// cannot drift from the I/O target. The returned release closure unlocks.
+// cannot drift from the I/O target. The returned release closure unlocks. Lock
+// acquisition is bounded so verification fails closed instead of hanging
+// indefinitely behind a wedged peer.
 func acquireReplayStoreLock(f *os.File) (func(), error) {
 	fd := int(f.Fd()) // #nosec G115 -- file descriptors fit in int on supported Unix targets
-	if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
-		return nil, fmt.Errorf("acquire replay store lock: %w", err)
+	deadline := time.Now().Add(replayStoreLockTimeout)
+	for {
+		err := syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return func() { _ = syscall.Flock(fd, syscall.LOCK_UN) }, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			return nil, fmt.Errorf("acquire replay store lock: %w", err)
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("acquire replay store lock: timed out after %s: %w", replayStoreLockTimeout, err)
+		}
+		time.Sleep(replayStoreLockRetryInterval)
 	}
-	return func() { _ = syscall.Flock(fd, syscall.LOCK_UN) }, nil
 }
 
 // verifyStorePathInode fails closed if the configured path no longer resolves to

--- a/enterprise/counterparty/replaystore_lock_unix_test.go
+++ b/enterprise/counterparty/replaystore_lock_unix_test.go
@@ -13,11 +13,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
 
-const replayLockAliasHelperEnv = "PIPELOCK_COUNTERPARTY_LOCK_ALIAS_HELPER"
+const replayLockTimeoutHelperEnv = "PIPELOCK_COUNTERPARTY_LOCK_TIMEOUT_HELPER"
 
 func TestReplayStoreUnixLockFollowsSymlinkAlias(t *testing.T) {
 	dir := t.TempDir()
@@ -39,43 +40,37 @@ func TestReplayStoreUnixLockFollowsSymlinkAlias(t *testing.T) {
 	if err != nil {
 		t.Fatalf("acquire primary lock: %v", err)
 	}
-	released := false
+	primaryReleased := false
 	defer func() {
-		if !released {
+		if !primaryReleased {
 			release()
 		}
 	}()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestReplayStoreUnixLockAliasHelper$", "--", alias) // #nosec G204 G702 -- test re-execs its own binary with a t.TempDir() alias path
-	cmd.Env = append(os.Environ(), replayLockAliasHelperEnv+"=1")
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestReplayStoreUnixLockTimeoutHelper$", "--", alias) // #nosec G204 G702 -- test re-execs its own binary with a t.TempDir() alias path
+	cmd.Env = append(os.Environ(), replayLockTimeoutHelperEnv+"=1")
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start helper: %v", err)
-	}
-	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
-
-	select {
-	case err := <-done:
-		t.Fatalf("alias lock acquired while primary lock was held: err=%v output=%s", err, output.String())
-	case <-time.After(150 * time.Millisecond):
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("timeout helper on alias failed: %v output=%s", err, output.String())
 	}
 
 	release()
-	released = true
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("helper after release: %v output=%s", err, output.String())
-		}
-	case <-time.After(2 * time.Second):
-		_ = cmd.Process.Kill()
-		t.Fatalf("helper did not acquire alias lock after primary release; output=%s", output.String())
+	primaryReleased = true
+
+	aliasFile, err := os.OpenFile(alias, os.O_RDWR, 0o600) // #nosec G304 -- test path from t.TempDir()
+	if err != nil {
+		t.Fatalf("open alias for free lock: %v", err)
 	}
+	defer func() { _ = aliasFile.Close() }()
+	releaseAlias, err := acquireReplayStoreLock(aliasFile)
+	if err != nil {
+		t.Fatalf("acquire alias lock after primary release: %v", err)
+	}
+	releaseAlias()
 }
 
 // TestFileReplayStoreFailsClosedAfterPathReplacement proves the inode-consistency
@@ -147,27 +142,63 @@ func TestFileReplayStoreFailsClosedAfterPathReplacementDuringCommit(t *testing.T
 	}
 }
 
-func TestReplayStoreUnixLockAliasHelper(t *testing.T) {
-	if os.Getenv(replayLockAliasHelperEnv) == "" {
+func TestReplayStoreUnixLockTimeoutFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "replay.jsonl")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("seed replay store: %v", err)
+	}
+
+	lockFile, err := os.OpenFile(path, os.O_RDWR, 0o600) // #nosec G304 -- test path from t.TempDir()
+	if err != nil {
+		t.Fatalf("open store for lock: %v", err)
+	}
+	defer func() { _ = lockFile.Close() }()
+	release, err := acquireReplayStoreLock(lockFile)
+	if err != nil {
+		t.Fatalf("acquire primary lock: %v", err)
+	}
+	defer release()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestReplayStoreUnixLockTimeoutHelper$", "--", path) // #nosec G204 G702 -- test re-execs its own binary with a t.TempDir() path
+	cmd.Env = append(os.Environ(), replayLockTimeoutHelperEnv+"=1")
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("timeout helper failed: %v output=%s", err, output.String())
+	}
+}
+
+func TestReplayStoreUnixLockTimeoutHelper(t *testing.T) {
+	if os.Getenv(replayLockTimeoutHelperEnv) == "" {
 		return
 	}
 	if len(os.Args) == 0 {
 		fmt.Fprintln(os.Stderr, "missing args")
 		os.Exit(2)
 	}
+	replayStoreLockTimeout = 75 * time.Millisecond
+	replayStoreLockRetryInterval = 5 * time.Millisecond
 	path := os.Args[len(os.Args)-1]
 	lockFile, err := os.OpenFile(path, os.O_RDWR, 0o600) // #nosec G304 -- test path from the parent test's t.TempDir()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "open alias for lock: %v\n", err)
+		fmt.Fprintf(os.Stderr, "open contender for lock: %v\n", err)
 		os.Exit(2)
 	}
 	defer func() { _ = lockFile.Close() }()
 	release, err := acquireReplayStoreLock(lockFile)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "acquire alias lock: %v\n", err)
+	if err == nil {
+		release()
+		fmt.Fprintln(os.Stderr, "lock unexpectedly acquired")
 		os.Exit(2)
 	}
-	release()
-	_, _ = fmt.Fprintln(os.Stdout, "acquired")
+	if !strings.Contains(err.Error(), "timed out") {
+		fmt.Fprintf(os.Stderr, "acquire lock error = %v, want timeout\n", err)
+		os.Exit(2)
+	}
+	_, _ = fmt.Fprintln(os.Stdout, "timed out")
 	os.Exit(0)
 }

--- a/enterprise/counterparty/replaystore_lock_unix_test.go
+++ b/enterprise/counterparty/replaystore_lock_unix_test.go
@@ -1,0 +1,173 @@
+//go:build enterprise && !windows && !js
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package counterparty
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const replayLockAliasHelperEnv = "PIPELOCK_COUNTERPARTY_LOCK_ALIAS_HELPER"
+
+func TestReplayStoreUnixLockFollowsSymlinkAlias(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "replay.jsonl")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("seed replay store: %v", err)
+	}
+	alias := filepath.Join(dir, "alias.jsonl")
+	if err := os.Symlink(path, alias); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	lockFile, err := os.OpenFile(path, os.O_RDWR, 0o600) // #nosec G304 -- test path from t.TempDir()
+	if err != nil {
+		t.Fatalf("open store for lock: %v", err)
+	}
+	defer func() { _ = lockFile.Close() }()
+	release, err := acquireReplayStoreLock(lockFile)
+	if err != nil {
+		t.Fatalf("acquire primary lock: %v", err)
+	}
+	released := false
+	defer func() {
+		if !released {
+			release()
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestReplayStoreUnixLockAliasHelper$", "--", alias) // #nosec G204 G702 -- test re-execs its own binary with a t.TempDir() alias path
+	cmd.Env = append(os.Environ(), replayLockAliasHelperEnv+"=1")
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("alias lock acquired while primary lock was held: err=%v output=%s", err, output.String())
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	release()
+	released = true
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("helper after release: %v output=%s", err, output.String())
+		}
+	case <-time.After(2 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatalf("helper did not acquire alias lock after primary release; output=%s", output.String())
+	}
+}
+
+// TestFileReplayStoreFailsClosedAfterPathReplacement proves the inode-consistency
+// guard: if the store file is renamed away and replaced, CommitIfNew fails closed
+// instead of operating on a split inode (which would double-accept).
+func TestFileReplayStoreFailsClosedAfterPathReplacement(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "replay.jsonl")
+	store, err := OpenFileReplayStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileReplayStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.CommitIfNew(sampleEntry("nonce-1", replayHashA)); err != nil {
+		t.Fatalf("first CommitIfNew: %v", err)
+	}
+
+	// Replace the store file with a fresh inode at the same path.
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove store: %v", err)
+	}
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("recreate store: %v", err)
+	}
+
+	err = store.CommitIfNew(sampleEntry("nonce-2", replayHashB))
+	if err == nil || errors.Is(err, ErrReplayConflict) {
+		t.Fatalf("CommitIfNew after path replacement = %v, want a non-conflict fail-closed error", err)
+	}
+}
+
+// TestFileReplayStoreFailsClosedAfterPathReplacementDuringCommit proves the
+// post-fsync inode guard: replacing the configured path after the pre-commit
+// inode check but before the append must not return a pass-shaped commit for an
+// entry written to the old, now-unlinked inode.
+func TestFileReplayStoreFailsClosedAfterPathReplacementDuringCommit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "replay.jsonl")
+	store, err := OpenFileReplayStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileReplayStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	release, err := acquireReplayStoreLock(store.file)
+	if err != nil {
+		t.Fatalf("acquireReplayStoreLock: %v", err)
+	}
+	defer release()
+	if err := verifyStorePathInode(store.file, store.path); err != nil {
+		t.Fatalf("pre-commit verifyStorePathInode: %v", err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove store: %v", err)
+	}
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("recreate store: %v", err)
+	}
+	if err := store.reindexLocked(); err != nil {
+		t.Fatalf("reindexLocked: %v", err)
+	}
+
+	_, err = store.appendEntryLocked(sampleEntry("nonce-1", replayHashA))
+	if err == nil || errors.Is(err, ErrReplayConflict) {
+		t.Fatalf("append after mid-commit path replacement = %v, want a non-conflict fail-closed error", err)
+	}
+}
+
+func TestReplayStoreUnixLockAliasHelper(t *testing.T) {
+	if os.Getenv(replayLockAliasHelperEnv) == "" {
+		return
+	}
+	if len(os.Args) == 0 {
+		fmt.Fprintln(os.Stderr, "missing args")
+		os.Exit(2)
+	}
+	path := os.Args[len(os.Args)-1]
+	lockFile, err := os.OpenFile(path, os.O_RDWR, 0o600) // #nosec G304 -- test path from the parent test's t.TempDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open alias for lock: %v\n", err)
+		os.Exit(2)
+	}
+	defer func() { _ = lockFile.Close() }()
+	release, err := acquireReplayStoreLock(lockFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "acquire alias lock: %v\n", err)
+		os.Exit(2)
+	}
+	release()
+	_, _ = fmt.Fprintln(os.Stdout, "acquired")
+	os.Exit(0)
+}

--- a/enterprise/counterparty/replaystore_lock_windows.go
+++ b/enterprise/counterparty/replaystore_lock_windows.go
@@ -11,12 +11,15 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 	"unsafe"
 )
 
 const (
-	lockfileExclusiveLock = 0x00000002
-	fileShareDelete       = 0x00000004
+	lockfileExclusiveLock   = 0x00000002
+	lockfileFailImmediately = 0x00000001
+	fileShareDelete         = 0x00000004
+	windowsLockViolation    = syscall.Errno(33)
 )
 
 var (
@@ -28,14 +31,25 @@ var (
 // acquireReplayStoreLock takes an exclusive, cross-process byte-range lock on the
 // OPEN store handle so two processes sharing one store cannot both accept the
 // same entry. Locking the handle (not a path-derived sibling) ties the lock to
-// the same file the store reads and writes.
+// the same file the store reads and writes. Lock acquisition is bounded so
+// verification fails closed instead of hanging indefinitely behind a wedged peer.
 func acquireReplayStoreLock(f *os.File) (func(), error) {
 	handle := syscall.Handle(f.Fd())
 	overlapped := &syscall.Overlapped{}
-	if err := lockFileEx(handle, lockfileExclusiveLock, 0xffffffff, 0xffffffff, overlapped); err != nil {
-		return nil, fmt.Errorf("acquire replay store lock: %w", err)
+	deadline := time.Now().Add(replayStoreLockTimeout)
+	for {
+		err := lockFileEx(handle, lockfileExclusiveLock|lockfileFailImmediately, 0xffffffff, 0xffffffff, overlapped)
+		if err == nil {
+			return func() { _ = unlockFileEx(handle, 0xffffffff, 0xffffffff, overlapped) }, nil
+		}
+		if !errors.Is(err, windowsLockViolation) {
+			return nil, fmt.Errorf("acquire replay store lock: %w", err)
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("acquire replay store lock: timed out after %s: %w", replayStoreLockTimeout, err)
+		}
+		time.Sleep(replayStoreLockRetryInterval)
 	}
-	return func() { _ = unlockFileEx(handle, 0xffffffff, 0xffffffff, overlapped) }, nil
 }
 
 // verifyStorePathInode fails closed if the configured path no longer resolves to

--- a/enterprise/counterparty/replaystore_lock_windows.go
+++ b/enterprise/counterparty/replaystore_lock_windows.go
@@ -1,0 +1,122 @@
+//go:build enterprise && windows
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package counterparty
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	lockfileExclusiveLock = 0x00000002
+	fileShareDelete       = 0x00000004
+)
+
+var (
+	kernel32Proc     = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = kernel32Proc.NewProc("LockFileEx")
+	procUnlockFileEx = kernel32Proc.NewProc("UnlockFileEx")
+)
+
+// acquireReplayStoreLock takes an exclusive, cross-process byte-range lock on the
+// OPEN store handle so two processes sharing one store cannot both accept the
+// same entry. Locking the handle (not a path-derived sibling) ties the lock to
+// the same file the store reads and writes.
+func acquireReplayStoreLock(f *os.File) (func(), error) {
+	handle := syscall.Handle(f.Fd())
+	overlapped := &syscall.Overlapped{}
+	if err := lockFileEx(handle, lockfileExclusiveLock, 0xffffffff, 0xffffffff, overlapped); err != nil {
+		return nil, fmt.Errorf("acquire replay store lock: %w", err)
+	}
+	return func() { _ = unlockFileEx(handle, 0xffffffff, 0xffffffff, overlapped) }, nil
+}
+
+// verifyStorePathInode fails closed if the configured path no longer resolves to
+// the open file's identity (volume serial + file index), the Windows equivalent
+// of the Unix dev+inode check. Any inability to obtain the identity is treated
+// as a mismatch and fails closed rather than silently accepting a split store.
+func verifyStorePathInode(f *os.File, path string) error {
+	openID, err := windowsFileIdentity(syscall.Handle(f.Fd()))
+	if err != nil {
+		return fmt.Errorf("replay store handle identity: %w", err)
+	}
+	pathp, err := syscall.UTF16PtrFromString(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("encode replay store path: %w", err)
+	}
+	h, err := syscall.CreateFile(
+		pathp,
+		syscall.GENERIC_READ,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE|fileShareDelete,
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("open replay store path for identity check: %w", err)
+	}
+	defer func() { _ = syscall.CloseHandle(h) }()
+	pathID, err := windowsFileIdentity(h)
+	if err != nil {
+		return fmt.Errorf("replay store path identity: %w", err)
+	}
+	if openID != pathID {
+		return errors.New("replay store path no longer resolves to the open store file")
+	}
+	return nil
+}
+
+type windowsFileID struct {
+	volumeSerial uint32
+	indexHigh    uint32
+	indexLow     uint32
+}
+
+func windowsFileIdentity(h syscall.Handle) (windowsFileID, error) {
+	var info syscall.ByHandleFileInformation
+	if err := syscall.GetFileInformationByHandle(h, &info); err != nil {
+		return windowsFileID{}, err
+	}
+	return windowsFileID{
+		volumeSerial: info.VolumeSerialNumber,
+		indexHigh:    info.FileIndexHigh,
+		indexLow:     info.FileIndexLow,
+	}, nil
+}
+
+func lockFileEx(handle syscall.Handle, flags, lowBytes, highBytes uint32, overlapped *syscall.Overlapped) error {
+	r1, _, err := procLockFileEx.Call(
+		uintptr(handle),
+		uintptr(flags),
+		0,
+		uintptr(lowBytes),
+		uintptr(highBytes),
+		uintptr(unsafe.Pointer(overlapped)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func unlockFileEx(handle syscall.Handle, lowBytes, highBytes uint32, overlapped *syscall.Overlapped) error {
+	r1, _, err := procUnlockFileEx.Call(
+		uintptr(handle),
+		0,
+		uintptr(lowBytes),
+		uintptr(highBytes),
+		uintptr(unsafe.Pointer(overlapped)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}

--- a/enterprise/counterparty/replaystore_test.go
+++ b/enterprise/counterparty/replaystore_test.go
@@ -1,0 +1,290 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package counterparty
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	replayHashA = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	replayHashB = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	replayHashC = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	replayHashD = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	replayHashE = "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+)
+
+func sampleEntry(nonce, transferPayload string) ReplayEntry {
+	return ReplayEntry{
+		NonceKey: NonceKey{SideRecordKeyID: "k", SenderIdentity: "a", ReceiverIdentity: "b", Nonce: nonce},
+		TransferKey: TransferKey{
+			SenderIdentity:     "a",
+			ReceiverIdentity:   "b",
+			PayloadHash:        transferPayload,
+			SenderReceiptID:    "s",
+			ReceiverReceiptID:  "r",
+			SenderActionHash:   replayHashC,
+			ReceiverActionHash: replayHashD,
+		},
+		RecordHash: replayHashE,
+		Timestamp:  time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestFileReplayStoreRejectsDuplicateNonceAndTransfer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	store, err := OpenFileReplayStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileReplayStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	entry := sampleEntry("nonce-1", replayHashA)
+	if err := store.CommitIfNew(entry); err != nil {
+		t.Fatalf("first CommitIfNew: %v", err)
+	}
+	if err := store.CommitIfNew(entry); !errors.Is(err, ErrReplayConflict) {
+		t.Fatalf("duplicate nonce CommitIfNew error = %v, want ErrReplayConflict", err)
+	}
+
+	// Same transfer, new nonce -> transfer conflict.
+	reSigned := sampleEntry("nonce-2", replayHashA)
+	if err := store.CommitIfNew(reSigned); !errors.Is(err, ErrReplayConflict) {
+		t.Fatalf("duplicate transfer CommitIfNew error = %v, want ErrReplayConflict", err)
+	}
+
+	// A genuinely new transfer + nonce succeeds.
+	if err := store.CommitIfNew(sampleEntry("nonce-3", replayHashB)); err != nil {
+		t.Fatalf("new entry CommitIfNew: %v", err)
+	}
+}
+
+func TestFileReplayStoreDurableAcrossReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	store, err := OpenFileReplayStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileReplayStore: %v", err)
+	}
+	entry := sampleEntry("nonce-1", replayHashA)
+	if err := store.CommitIfNew(entry); err != nil {
+		t.Fatalf("CommitIfNew: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := OpenFileReplayStore(path)
+	if err != nil {
+		t.Fatalf("reopen OpenFileReplayStore: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	if err := reopened.CommitIfNew(entry); !errors.Is(err, ErrReplayConflict) {
+		t.Fatalf("committed entry not durable across reopen: err = %v, want ErrReplayConflict", err)
+	}
+}
+
+func TestFileReplayStoreCorruptLineFailsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	if err := os.WriteFile(path, []byte("{not valid json\n"), 0o600); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+	if _, err := OpenFileReplayStore(path); err == nil {
+		t.Fatal("OpenFileReplayStore accepted a corrupt line, want fail closed")
+	}
+}
+
+func TestFileReplayStoreUnknownFieldFailsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	if err := os.WriteFile(path, []byte(`{"nonce_key":{},"transfer_key":{},"unexpected":true}`+"\n"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := OpenFileReplayStore(path); err == nil {
+		t.Fatal("OpenFileReplayStore accepted an unknown field, want fail closed")
+	}
+}
+
+func TestFileReplayStoreTrailingTokensFailClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	encoded, err := json.Marshal(sampleEntry("nonce-1", replayHashA))
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	if err := os.WriteFile(path, append(encoded, []byte(` trailing-junk`+"\n")...), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := OpenFileReplayStore(path); err == nil {
+		t.Fatal("OpenFileReplayStore accepted trailing tokens after an entry, want fail closed")
+	}
+}
+
+func TestFileReplayStoreCommitAfterCloseFailsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	store, err := OpenFileReplayStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileReplayStore: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	err = store.CommitIfNew(sampleEntry("nonce-1", replayHashA))
+	if err == nil || errors.Is(err, ErrReplayConflict) {
+		t.Fatalf("CommitIfNew after Close error = %v, want a non-conflict fail-closed error", err)
+	}
+}
+
+func TestOpenFileReplayStoreErrors(t *testing.T) {
+	if _, err := OpenFileReplayStore(""); err == nil {
+		t.Fatal("OpenFileReplayStore(empty path) = nil, want error")
+	}
+	// Parent path is a regular file, so MkdirAll for the store dir fails.
+	dir := t.TempDir()
+	fileAsParent := filepath.Join(dir, "afile")
+	if err := os.WriteFile(fileAsParent, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := OpenFileReplayStore(filepath.Join(fileAsParent, "sub", "replay.jsonl")); err == nil {
+		t.Fatal("OpenFileReplayStore(file-as-parent) = nil, want error")
+	}
+	// Path is an existing directory, so OpenFile fails.
+	if _, err := OpenFileReplayStore(dir); err == nil {
+		t.Fatal("OpenFileReplayStore(dir path) = nil, want error")
+	}
+}
+
+// TestFileReplayStoreCrossProcessRejectsDuplicate proves the cross-process
+// fail-open fix: two store handles on the same file (standing in for two
+// processes, each with its own in-memory index) cannot both accept the same
+// entry, because CommitIfNew re-indexes under an exclusive file lock first.
+func TestFileReplayStoreCrossProcessRejectsDuplicate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	a, err := OpenFileReplayStore(path)
+	if err != nil {
+		t.Fatalf("open A: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+	b, err := OpenFileReplayStore(path)
+	if err != nil {
+		t.Fatalf("open B: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Close() })
+
+	entry := sampleEntry("nonce-1", replayHashA)
+	if err := a.CommitIfNew(entry); err != nil {
+		t.Fatalf("A CommitIfNew: %v", err)
+	}
+	if err := b.CommitIfNew(entry); !errors.Is(err, ErrReplayConflict) {
+		t.Fatalf("B CommitIfNew of A's entry = %v, want ErrReplayConflict (cross-process fail-open)", err)
+	}
+	// A genuinely new entry through B still succeeds after re-indexing A's line.
+	if err := b.CommitIfNew(sampleEntry("nonce-2", replayHashB)); err != nil {
+		t.Fatalf("B CommitIfNew new entry: %v", err)
+	}
+	if err := a.CommitIfNew(sampleEntry("nonce-2", replayHashB)); !errors.Is(err, ErrReplayConflict) {
+		t.Fatalf("A CommitIfNew of B's entry = %v, want ErrReplayConflict", err)
+	}
+}
+
+func TestFileReplayStoreTruncatedWhileRunningFailsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	store, err := OpenFileReplayStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileReplayStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.CommitIfNew(sampleEntry("nonce-1", replayHashA)); err != nil {
+		t.Fatalf("first CommitIfNew: %v", err)
+	}
+	// Truncate the store out from under the running process.
+	if err := os.Truncate(path, 0); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	err = store.CommitIfNew(sampleEntry("nonce-2", replayHashB))
+	if err == nil || errors.Is(err, ErrReplayConflict) {
+		t.Fatalf("CommitIfNew after truncation = %v, want a non-conflict fail-closed error", err)
+	}
+}
+
+func TestValidateReplayEntryRejects(t *testing.T) {
+	valid := sampleEntry("nonce-1", replayHashA)
+	mutations := map[string]func(*ReplayEntry){
+		"empty side key id":         func(e *ReplayEntry) { e.NonceKey.SideRecordKeyID = "" },
+		"empty nonce sender":        func(e *ReplayEntry) { e.NonceKey.SenderIdentity = "" },
+		"empty nonce receiver":      func(e *ReplayEntry) { e.NonceKey.ReceiverIdentity = "" },
+		"empty nonce":               func(e *ReplayEntry) { e.NonceKey.Nonce = "" },
+		"empty transfer sender":     func(e *ReplayEntry) { e.TransferKey.SenderIdentity = "" },
+		"empty transfer receiver":   func(e *ReplayEntry) { e.TransferKey.ReceiverIdentity = "" },
+		"bad payload hash":          func(e *ReplayEntry) { e.TransferKey.PayloadHash = "x" },
+		"empty sender receipt id":   func(e *ReplayEntry) { e.TransferKey.SenderReceiptID = "" },
+		"empty receiver receipt id": func(e *ReplayEntry) { e.TransferKey.ReceiverReceiptID = "" },
+		"bad sender action hash":    func(e *ReplayEntry) { e.TransferKey.SenderActionHash = "x" },
+		"bad receiver action hash":  func(e *ReplayEntry) { e.TransferKey.ReceiverActionHash = "x" },
+		"bad record hash":           func(e *ReplayEntry) { e.RecordHash = "x" },
+		"zero timestamp":            func(e *ReplayEntry) { e.Timestamp = time.Time{} },
+	}
+	for name, mut := range mutations {
+		t.Run(name, func(t *testing.T) {
+			e := valid
+			mut(&e)
+			if err := validateReplayEntry(e); err == nil {
+				t.Fatalf("validateReplayEntry(%s) = nil, want error", name)
+			}
+		})
+	}
+	if err := validateReplayEntry(valid); err != nil {
+		t.Fatalf("validateReplayEntry(valid) = %v", err)
+	}
+}
+
+func TestFileReplayStoreEmptyEntryLineFailsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := OpenFileReplayStore(path); err == nil {
+		t.Fatal("OpenFileReplayStore accepted a semantically empty entry, want fail closed")
+	}
+}
+
+func TestFileReplayStoreIncompleteEntryLineFailsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	raw := []byte(`{"nonce_key":{"Nonce":"nonce-1"},"transfer_key":{"PayloadHash":"` + replayHashA + `"},"record_hash":"` + replayHashB + `"}` + "\n")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := OpenFileReplayStore(path); err == nil {
+		t.Fatal("OpenFileReplayStore accepted an incomplete replay entry, want fail closed")
+	}
+}
+
+func TestFileReplayStoreDuplicateKeyLineFailsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	if err := os.WriteFile(path, []byte(`{"record_hash":"sha256:aa","record_hash":"sha256:bb"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := OpenFileReplayStore(path); err == nil {
+		t.Fatal("OpenFileReplayStore accepted a duplicate-key line, want fail closed")
+	}
+}
+
+func TestFileReplayStoreIncompleteTrailingLineFailsClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "replay.jsonl")
+	encoded, err := json.Marshal(sampleEntry("nonce-1", replayHashA))
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	// A complete JSON object with NO trailing newline = a torn/partial write.
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := OpenFileReplayStore(path); err == nil {
+		t.Fatal("OpenFileReplayStore accepted an incomplete trailing line, want fail closed")
+	}
+}

--- a/enterprise/counterparty/validation_internal_test.go
+++ b/enterprise/counterparty/validation_internal_test.go
@@ -1,0 +1,311 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package counterparty
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+const goodHash = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func validBinding() Binding {
+	return Binding{
+		PayloadHash:         goodHash,
+		SenderIdentity:      "agent-a",
+		ReceiverIdentity:    "agent-b",
+		Nonce:               "nonce-001",
+		SenderReceiptID:     "sender-action",
+		SenderReceiptHash:   goodHash,
+		ReceiverReceiptID:   "receiver-action",
+		ReceiverReceiptHash: goodHash,
+		Timestamp:           time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC),
+		Version:             Version,
+	}
+}
+
+func TestValidateBindingRejects(t *testing.T) {
+	cases := map[string]func(*Binding){
+		"bad version":          func(b *Binding) { b.Version = 99 },
+		"bad payload hash":     func(b *Binding) { b.PayloadHash = "nope" },
+		"empty sender id":      func(b *Binding) { b.SenderIdentity = "" },
+		"empty receiver id":    func(b *Binding) { b.ReceiverIdentity = "" },
+		"empty nonce":          func(b *Binding) { b.Nonce = "" },
+		"empty sender rcpt id": func(b *Binding) { b.SenderReceiptID = "" },
+		"bad sender rcpt hash": func(b *Binding) { b.SenderReceiptHash = "x" },
+		"empty recv rcpt id":   func(b *Binding) { b.ReceiverReceiptID = "" },
+		"bad recv rcpt hash":   func(b *Binding) { b.ReceiverReceiptHash = "sha256:zz" },
+		"zero ts":              func(b *Binding) { b.Timestamp = time.Time{} },
+		"non-ascii identity":   func(b *Binding) { b.SenderIdentity = "agént" },
+	}
+	for name, mut := range cases {
+		t.Run(name, func(t *testing.T) {
+			b := validBinding()
+			mut(&b)
+			if err := validateBinding(b); !errors.Is(err, ErrMalformedBinding) {
+				t.Fatalf("validateBinding(%s) = %v, want ErrMalformedBinding", name, err)
+			}
+		})
+	}
+	if err := validateBinding(validBinding()); err != nil {
+		t.Fatalf("validateBinding(valid) = %v, want nil", err)
+	}
+}
+
+func TestValidateHashRejects(t *testing.T) {
+	for name, v := range map[string]string{
+		"no prefix":  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef00",
+		"bad hex":    "sha256:zzzz",
+		"wrong len":  "sha256:00",
+		"upper case": "sha256:0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateHash("f", v); err == nil {
+				t.Fatalf("validateHash(%s) = nil, want error", name)
+			}
+		})
+	}
+	if err := validateHash("f", goodHash); err != nil {
+		t.Fatalf("validateHash(good) = %v", err)
+	}
+}
+
+func TestValidateTokenRejects(t *testing.T) {
+	for name, v := range map[string]string{
+		"empty":     "",
+		"too long":  strings.Repeat("a", maxTokenLen+1),
+		"space":     "a b",
+		"non-ascii": "café",
+		"control":   "a\tb",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateToken("f", v); err == nil {
+				t.Fatalf("validateToken(%s) = nil, want error", name)
+			}
+		})
+	}
+	if err := validateToken("f", "agent-a.1:x/y"); err != nil {
+		t.Fatalf("validateToken(good) = %v", err)
+	}
+}
+
+func TestDecodeSignatureRejects(t *testing.T) {
+	valid := "ed25519:" + base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	for name, v := range map[string]string{
+		"no prefix":     base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)),
+		"bad base64":    "ed25519:!!!!",
+		"wrong len":     "ed25519:" + base64.StdEncoding.EncodeToString(make([]byte, 8)),
+		"non-canonical": strings.Replace(valid, "ed25519:", "ed25519:\n", 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := decodeSignature(v); err == nil {
+				t.Fatalf("decodeSignature(%s) = nil, want error", name)
+			}
+		})
+	}
+	if _, err := decodeSignature(valid); err != nil {
+		t.Fatalf("decodeSignature(valid) = %v", err)
+	}
+}
+
+func TestSignRecordErrors(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	rec := Record{Binding: validBinding()}
+	if _, err := SignRecord(fleetLicense(), rec, "kid", priv[:8]); err == nil {
+		t.Fatal("SignRecord(bad key size) = nil")
+	}
+	if _, err := SignRecord(fleetLicense(), rec, "", priv); err == nil {
+		t.Fatal("SignRecord(empty keyID) = nil")
+	}
+	bad := Record{Binding: validBinding()}
+	bad.Binding.Nonce = ""
+	if _, err := SignRecord(fleetLicense(), bad, "kid", priv); !errors.Is(err, ErrMalformedBinding) {
+		t.Fatalf("SignRecord(bad binding) = %v", err)
+	}
+}
+
+func TestSignPayloadCaptureErrors(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	c := PayloadCapture{ActionID: "a", ActionHash: goodHash, PayloadHash: goodHash, Direction: DirectionEgress, PartyIdentity: "agent-a", CounterpartyIdentity: "agent-b"}
+	if _, err := SignPayloadCapture(c, "kid", priv[:8]); err == nil {
+		t.Fatal("SignPayloadCapture(bad key size) = nil")
+	}
+	if _, err := SignPayloadCapture(c, "", priv); err == nil {
+		t.Fatal("SignPayloadCapture(empty keyID) = nil")
+	}
+	bad := c
+	bad.Direction = "sideways"
+	if _, err := SignPayloadCapture(bad, "kid", priv); !errors.Is(err, ErrPayloadCapture) {
+		t.Fatalf("SignPayloadCapture(bad direction) = %v", err)
+	}
+	bad = c
+	bad.PayloadHash = "nope"
+	if _, err := SignPayloadCapture(bad, "kid", priv); !errors.Is(err, ErrPayloadCapture) {
+		t.Fatalf("SignPayloadCapture(bad hash) = %v", err)
+	}
+}
+
+func TestVerifyRecordSignatureErrors(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	signed, err := SignRecord(fleetLicense(), Record{Binding: validBinding()}, "kid", priv)
+	if err != nil {
+		t.Fatalf("SignRecord: %v", err)
+	}
+	lic := fleetLicense()
+
+	if err := VerifyRecordSignature(lic, signed, "kid", pub); err != nil {
+		t.Fatalf("VerifyRecordSignature(valid) = %v", err)
+	}
+
+	bad := signed
+	bad.RecordType = "other"
+	if err := VerifyRecordSignature(lic, bad, "kid", pub); err == nil {
+		t.Fatal("VerifyRecordSignature(bad record_type) = nil")
+	}
+
+	bad = signed
+	bad.Signature.Alg = "rsa"
+	if err := VerifyRecordSignature(lic, bad, "kid", pub); err == nil {
+		t.Fatal("VerifyRecordSignature(bad alg) = nil")
+	}
+
+	bad = signed
+	bad.Signature.KeyID = ""
+	if err := VerifyRecordSignature(lic, bad, "kid", pub); err == nil {
+		t.Fatal("VerifyRecordSignature(empty keyID) = nil")
+	}
+
+	if err := VerifyRecordSignature(lic, signed, "", pub); !errors.Is(err, ErrUntrustedSideRecordKey) {
+		t.Fatalf("VerifyRecordSignature(empty expected) = %v", err)
+	}
+	if err := VerifyRecordSignature(lic, signed, "other", pub); !errors.Is(err, ErrUntrustedSideRecordKey) {
+		t.Fatalf("VerifyRecordSignature(keyID mismatch) = %v", err)
+	}
+	if err := VerifyRecordSignature(lic, signed, "kid", pub[:8]); !errors.Is(err, ErrUntrustedSideRecordKey) {
+		t.Fatalf("VerifyRecordSignature(bad key size) = %v", err)
+	}
+
+	bad = signed
+	bad.Signature.Sig = "ed25519:" + base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	if err := VerifyRecordSignature(lic, bad, "kid", pub); err == nil {
+		t.Fatal("VerifyRecordSignature(bad sig) = nil")
+	}
+}
+
+func mustCaptureErr(t *testing.T, c PayloadCapture, k ed25519.PublicKey, exp captureExpectation) {
+	t.Helper()
+	if _, err := verifyPayloadCapture("s", c, k, exp); !errors.Is(err, ErrPayloadCapture) {
+		t.Fatalf("verifyPayloadCapture = %v, want ErrPayloadCapture", err)
+	}
+}
+
+func TestVerifyPayloadCaptureErrors(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	good, err := SignPayloadCapture(PayloadCapture{ActionID: "a", ActionHash: goodHash, PayloadHash: goodHash, Direction: DirectionEgress, PartyIdentity: "agent-a", CounterpartyIdentity: "agent-b"}, "kid", priv)
+	if err != nil {
+		t.Fatalf("SignPayloadCapture: %v", err)
+	}
+	exp := captureExpectation{direction: DirectionEgress, actionID: "a", actionHash: goodHash, actor: "agent-a", counterpartyIdentity: "agent-b"}
+	if _, err := verifyPayloadCapture("s", good, pub, exp); err != nil {
+		t.Fatalf("verifyPayloadCapture(valid) = %v", err)
+	}
+
+	badType := good
+	badType.RecordType = "other"
+	mustCaptureErr(t, badType, pub, exp)
+
+	dirWrong := exp
+	dirWrong.direction = DirectionIngress
+	mustCaptureErr(t, good, pub, dirWrong)
+	aidWrong := exp
+	aidWrong.actionID = "b"
+	mustCaptureErr(t, good, pub, aidWrong)
+	ahWrong := exp
+	ahWrong.actionHash = PayloadHash([]byte("other action"))
+	mustCaptureErr(t, good, pub, ahWrong)
+	partyWrong := exp
+	partyWrong.actor = "agent-x"
+	mustCaptureErr(t, good, pub, partyWrong)
+	cpWrong := exp
+	cpWrong.counterpartyIdentity = "agent-c"
+	mustCaptureErr(t, good, pub, cpWrong)
+
+	badAlg := good
+	badAlg.Signature.Alg = "rsa"
+	mustCaptureErr(t, badAlg, pub, exp)
+
+	if _, err := verifyPayloadCapture("s", good, pub[:8], exp); !errors.Is(err, ErrPayloadCapture) {
+		t.Fatalf("bad key size = %v", err)
+	}
+
+	badSig := good
+	badSig.Signature.Sig = "ed25519:" + base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	mustCaptureErr(t, badSig, pub, exp)
+
+	badField := good
+	badField.PayloadHash = "nope"
+	mustCaptureErr(t, badField, pub, exp)
+}
+
+func TestValidateCaptureFieldsRejects(t *testing.T) {
+	base := PayloadCapture{RecordType: PayloadCaptureRecordType, ActionID: "a", ActionHash: goodHash, PayloadHash: goodHash, Direction: DirectionEgress, PartyIdentity: "agent-a", CounterpartyIdentity: "agent-b"}
+	for name, mut := range map[string]func(*PayloadCapture){
+		"bad action":       func(c *PayloadCapture) { c.ActionID = "" },
+		"bad action hash":  func(c *PayloadCapture) { c.ActionHash = "x" },
+		"bad party":        func(c *PayloadCapture) { c.PartyIdentity = "a b" },
+		"bad counterparty": func(c *PayloadCapture) { c.CounterpartyIdentity = "a b" },
+		"bad hash":         func(c *PayloadCapture) { c.PayloadHash = "x" },
+		"bad direction":    func(c *PayloadCapture) { c.Direction = "up" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := base
+			mut(&c)
+			if err := validateCaptureFields(c); !errors.Is(err, ErrPayloadCapture) {
+				t.Fatalf("validateCaptureFields(%s) = %v", name, err)
+			}
+		})
+	}
+	if err := validateCaptureFields(base); err != nil {
+		t.Fatalf("validateCaptureFields(valid) = %v", err)
+	}
+}
+
+func TestRejectSideRecordKeyReuse(t *testing.T) {
+	a, _, _ := ed25519.GenerateKey(rand.Reader)
+	b, _, _ := ed25519.GenerateKey(rand.Reader)
+	c, _, _ := ed25519.GenerateKey(rand.Reader)
+	if err := rejectSideRecordKeyReuse(c, a, b); err != nil {
+		t.Fatalf("distinct keys = %v", err)
+	}
+	if err := rejectSideRecordKeyReuse(a, a, b); !errors.Is(err, ErrSideRecordKeyReuse) {
+		t.Fatalf("reuse sender = %v", err)
+	}
+	if err := rejectSideRecordKeyReuse(b, a, b); !errors.Is(err, ErrSideRecordKeyReuse) {
+		t.Fatalf("reuse receiver = %v", err)
+	}
+	if err := rejectSideRecordKeyReuse(c[:8], a, b); !errors.Is(err, ErrUntrustedSideRecordKey) {
+		t.Fatalf("bad size = %v", err)
+	}
+}
+
+func TestUnmarshalRecordErrors(t *testing.T) {
+	for name, v := range map[string]string{
+		"not json":      "not json",
+		"not object":    "[1,2,3]",
+		"trailing junk": `{"record_type":"counterparty_receipt_v1"} extra`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := UnmarshalRecord([]byte(v)); err == nil {
+				t.Fatalf("UnmarshalRecord(%s) = nil", name)
+			}
+		})
+	}
+}

--- a/internal/cli/runtime/sandbox_test.go
+++ b/internal/cli/runtime/sandbox_test.go
@@ -110,8 +110,9 @@ func TestSandboxCmdDryRunJSON(t *testing.T) {
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{"--dry-run", "--json", "--workspace", t.TempDir(), "--", "echo", "ok"})
 	var out bytes.Buffer
+	var stderr bytes.Buffer
 	cmd.SetOut(&out)
-	cmd.SetErr(&out)
+	cmd.SetErr(&stderr)
 
 	execErr := cmd.Execute()
 


### PR DESCRIPTION
Adds a fleet-gated (Enterprise) verifier for a receiver-signed counterparty side record that binds two existing Pipelock receipts plus each party's signed payload capture to one on-the-wire payload. It proves a transfer occurred and its content matched, attested by two separately-keyed parties, so neither operator can unilaterally fabricate the send-or-receive of that payload. The binding is a sidecar record in its own stream and adds no field to the core receipt schema, so the cross-language receipt verifiers are unaffected.

## What changed

- New `enterprise/counterparty` package (`//go:build enterprise`): a verifier for `counterparty_receipt_v1` side records plus per-party `payload_capture_v1` records, with the durable replay store they depend on.
- Verification fails closed on: missing fleet feature, missing inputs or freshness configuration, malformed binding, invalid receipt, an untrusted or reused signing key, a payload hash not attested by both parties, receipt id or hash mismatch, identity mismatch, self-counterparty, staleness or clock skew, and replay.
- Each receipt is checked against a caller-enrolled key rather than its self-describing embedded key, and the side record must be signed by the receiver's enrolled counterparty key, kept separate from both receipt keys.
- Both the sender (egress) and the receiver (ingress) sign a payload capture bound to the exact signed action and to the counterparty, so a payload hash is accepted only when both parties attest it.
- Replay protection is mandatory and durable: a cross-process-locked, fsync-backed store keyed on both the signed record and the transfer, so a record cannot be re-counted across restarts and the same transfer cannot be re-signed under a fresh nonce. Malformed durable state fails closed.
- Freshness uses an injected clock with caller-set age and skew bounds, and replay state is committed only after every other check passes, so a rejected record never consumes a nonce.
- Identity, nonce, and id fields are restricted to printable ASCII so the signed form matches the bytes used for replay keys.

## Scope

Within one fleet whose single control plane signs both sides, this is a two-host, separately-keyed proof: it defeats a single compromised host or key, not a compromised control plane, and it is strongest across different trust domains. It is a receipt-to-receipt transfer proof, not a proof of how the receiver acted on the payload. Emission wiring that produces these records in the reverse-proxy path lands in a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enterprise-only counterparty receipt binding verification, including canonical signing/verification helpers, strict parsing, structured failure codes, and replay-safe acceptance.
  * Introduced fail-closed replay protection with both in-memory and file-backed replay stores, including durable JSONL storage, strict validation, and cross-process locking.
* **Tests**
  * Added extensive adversarial, strict parsing, freshness-boundary, replay-conflict, concurrency, and cross-platform locking/durability coverage.
  * Added internal validation coverage for malformed inputs and signature/capture mismatch rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->