### PR TITLE
feat(config): warn when content scanners don't cover HTTPS with TLS interception off

### DIFF
--- a/docs/guides/tls-interception.md
+++ b/docs/guides/tls-interception.md
@@ -4,6 +4,23 @@ Pipelock can intercept CONNECT tunnel traffic by performing a TLS MITM: it termi
 
 Without TLS interception, CONNECT tunnels only get hostname-level scanning (blocklist, SSRF, rate limiting). With it, you get full DLP on request bodies/headers and response injection detection.
 
+## What is enforced when interception is off
+
+An HTTPS request through a CONNECT tunnel is encrypted end to end, so with interception disabled Pipelock sees the CONNECT host and handshake, but cannot read the inner request path, query, body, or response. For HTTPS traffic in that mode:
+
+- **Enforced (from CONNECT metadata or tunnel accounting):** destination allowlist/blocklist, SSRF on the CONNECT host, URL DLP/entropy checks that apply to the CONNECT host, connection rate limits, data budget, CONNECT handshake-header DLP, kill switch, and receipt gates. A `request_policy` or contract rule is enforced only to the extent it matches CONNECT metadata (the synthetic `https://host/`); any rule that matches inner HTTPS method, path, query, headers, or body requires interception.
+- **Not applied to the encrypted HTTPS content:** path/query entropy, body DLP, `request_body_scanning`, and `response_scanning`. These operate on plaintext the proxy never sees for HTTPS, so they silently do not inspect HTTPS request paths, bodies, or responses.
+
+This is expected behavior, not a bypass: tunnel-level controls still apply, but HTTPS content visibility does not exist unless Pipelock terminates TLS. Plaintext HTTP through the forward proxy is unaffected (its full URL and body are visible, so all scanners apply).
+
+When the forward proxy accepts CONNECT tunnels and interception is off, Pipelock prints a startup and hot-reload advisory so the coverage gap is never silent:
+
+```text
+WARNING: tls_interception: TLS interception is disabled while the forward proxy accepts CONNECT tunnels. HTTPS traffic is not decrypted, so content scanning (request_body_scanning, response_scanning, path/query entropy, and body DLP) does not inspect HTTPS request paths, bodies, or responses. Pipelock still enforces controls that evaluate from CONNECT metadata or tunnel accounting (destination allowlist/blocklist, SSRF on the CONNECT host, rate limits, data budget, CONNECT handshake-header DLP, kill switch, and receipt gates); request_policy and contract rules that match inner HTTPS method, path, query, headers, or body require tls_interception. Enable tls_interception (and distribute its CA) to scan HTTPS content, or accept tunnel-level-only visibility for HTTPS content as a deliberate posture.
+```
+
+Enable interception (below) to scan HTTPS content, or accept tunnel-level-only HTTPS content visibility as a deliberate posture.
+
 ## Quick Start
 
 ```bash

--- a/internal/cli/diag/check.go
+++ b/internal/cli/diag/check.go
@@ -123,6 +123,12 @@ func checkConfigAdvisories(cfg *config.Config) []string {
 		advisories = append(advisories, "flight_recorder is enabled but dir is unset; no receipts will be written")
 	}
 
+	// Content scanners don't cover HTTPS when the forward proxy accepts CONNECT
+	// tunnels but TLS interception is off (opaque tunnel, host-level only).
+	if msg, ok := cfg.TLSInterceptionCoverageAdvisory(); ok {
+		advisories = append(advisories, msg)
+	}
+
 	if cfg.Conductor.Enabled {
 		_, err := license.VerifyFleetWithOptions(fleetVerifyInputsFromConfig(cfg))
 		if err != nil {

--- a/internal/cli/diag/check_tls_coverage_advisory_test.go
+++ b/internal/cli/diag/check_tls_coverage_advisory_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// TestCheckConfigAdvisoriesTLSInterceptionCoverage proves the HTTPS coverage-gap
+// advisory reaches the check/doctor surface (not just the startup warning)
+// whenever the forward proxy accepts CONNECT tunnels with interception off, and
+// stays silent otherwise. It fires regardless of which content scanners are on.
+func TestCheckConfigAdvisoriesTLSInterceptionCoverage(t *testing.T) {
+	const marker = "does not inspect HTTPS request paths, bodies, or responses"
+
+	tests := []struct {
+		name   string
+		mutate func(c *config.Config)
+		want   bool
+	}{
+		{
+			name:   "forward proxy off (default) does not advise",
+			mutate: func(c *config.Config) {},
+			want:   false,
+		},
+		{
+			name:   "forward proxy on, interception off advises",
+			mutate: func(c *config.Config) { c.ForwardProxy.Enabled = true },
+			want:   true,
+		},
+		{
+			name: "forward proxy on, interception on does not advise",
+			mutate: func(c *config.Config) {
+				c.ForwardProxy.Enabled = true
+				c.TLSInterception.Enabled = true
+			},
+			want: false,
+		},
+		{
+			name: "forward proxy on, interception off, content scanners off still advises",
+			mutate: func(c *config.Config) {
+				c.ForwardProxy.Enabled = true
+				c.RequestBodyScanning.Enabled = false
+				c.ResponseScanning.Enabled = false
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			tt.mutate(cfg)
+			var found bool
+			for _, advisory := range checkConfigAdvisories(cfg) {
+				if strings.Contains(advisory, marker) {
+					found = true
+					break
+				}
+			}
+			if found != tt.want {
+				t.Fatalf("tls interception coverage advisory present = %v, want %v", found, tt.want)
+			}
+		})
+	}
+}
+
+// TestDoctorTLSInterceptionCoverageAdvisory proves the dedicated doctor check
+// warns with an accurate detail when interception is off, and clears to OK when
+// interception is enabled.
+func TestDoctorTLSInterceptionCoverageAdvisory(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.ForwardProxy.Enabled = true
+
+	report := buildDoctorReport(cfg, configLabelDefaults)
+	check := doctorCheckFor(report, "tls_interception_coverage")
+	if check.Status != doctorStatusWarn {
+		t.Fatalf("doctor tls_interception_coverage status = %q, want %q; check=%+v", check.Status, doctorStatusWarn, check)
+	}
+	for _, want := range []string{"request_body_scanning", "response_scanning", "data budget", "require tls_interception"} {
+		if !strings.Contains(check.Detail, want) {
+			t.Fatalf("doctor tls_interception_coverage detail missing %q: %s", want, check.Detail)
+		}
+	}
+
+	cfg.TLSInterception.Enabled = true
+	report = buildDoctorReport(cfg, configLabelDefaults)
+	check = doctorCheckFor(report, "tls_interception_coverage")
+	if check.Status != doctorStatusOK {
+		t.Fatalf("doctor tls_interception_coverage status with interception = %q, want %q; check=%+v", check.Status, doctorStatusOK, check)
+	}
+}

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -141,6 +141,7 @@ func buildDoctorReport(cfg *config.Config, cfgLabel string) doctorReport {
 	report.Checks = []doctorReportCheck{
 		checkDoctorHTTPProxy(cfg),
 		checkDoctorTLSInterception(cfg),
+		checkDoctorTLSInterceptionCoverage(cfg),
 		checkDoctorRequestBodyScanning(cfg),
 		checkDoctorBrowserShield(cfg),
 		checkDoctorMCPWrapperFeatures(cfg),
@@ -385,6 +386,27 @@ func checkDoctorTLSInterception(cfg *config.Config) doctorReportCheck {
 		Enforcing:  true,
 		Detail:     "CA material is readable; clients still need to trust the CA",
 		Next:       "verify agent and browser trust stores use this CA",
+	}
+}
+
+func checkDoctorTLSInterceptionCoverage(cfg *config.Config) doctorReportCheck {
+	msg, ok := cfg.TLSInterceptionCoverageAdvisory()
+	if !ok {
+		return doctorReportCheck{
+			Name:    "tls_interception_coverage",
+			Surface: doctorSurfaceHTTP,
+			Status:  doctorStatusOK,
+			Detail:  "CONNECT HTTPS content visibility matches enabled TLS interception and content scanners",
+		}
+	}
+	return doctorReportCheck{
+		Name:       "tls_interception_coverage",
+		Surface:    doctorSurfaceHTTP,
+		Status:     doctorStatusWarn,
+		Configured: true,
+		Reachable:  true,
+		Detail:     msg,
+		Next:       "enable tls_interception and install the Pipelock CA, or document tunnel-level-only HTTPS content visibility as an intentional posture",
 	}
 }
 

--- a/internal/config/tls_interception_coverage_test.go
+++ b/internal/config/tls_interception_coverage_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTLSInterceptionCoverageAdvisory covers the predicate directly (no CA file
+// dependency): the advisory fires whenever the forward proxy accepts CONNECT
+// tunnels and TLS interception is off, and stays silent otherwise. It fires
+// regardless of which content scanners are enabled, because every
+// content-dependent control is blind to HTTPS-over-CONNECT without interception.
+func TestTLSInterceptionCoverageAdvisory(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(c *Config)
+		want   bool
+	}{
+		{
+			name:   "forward proxy off (default) does not advise",
+			mutate: func(c *Config) {},
+			want:   false,
+		},
+		{
+			name:   "forward proxy on, interception off advises",
+			mutate: func(c *Config) { c.ForwardProxy.Enabled = true },
+			want:   true,
+		},
+		{
+			name: "forward proxy on, interception on does not advise",
+			mutate: func(c *Config) {
+				c.ForwardProxy.Enabled = true
+				c.TLSInterception.Enabled = true
+			},
+			want: false,
+		},
+		{
+			name: "forward proxy on, interception off, all content scanners off still advises",
+			mutate: func(c *Config) {
+				c.ForwardProxy.Enabled = true
+				c.RequestBodyScanning.Enabled = false
+				c.ResponseScanning.Enabled = false
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Defaults()
+			tt.mutate(cfg)
+			msg, ok := cfg.TLSInterceptionCoverageAdvisory()
+			if ok != tt.want {
+				t.Fatalf("TLSInterceptionCoverageAdvisory ok = %v, want %v", ok, tt.want)
+			}
+			if !ok {
+				if msg != "" {
+					t.Errorf("advisory not warranted but message non-empty: %q", msg)
+				}
+				return
+			}
+			// The message must name the blind content scanners AND state that
+			// request_policy/contract rules matching inner HTTPS content require
+			// interception, so it does not overstate protection (both directions).
+			for _, want := range []string{
+				"request_body_scanning",
+				"response_scanning",
+				"path/query entropy",
+				"require tls_interception",
+				"data budget",
+			} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("advisory message missing %q; got: %s", want, msg)
+				}
+			}
+		})
+	}
+}
+
+// TestValidate_TLSInterceptionCoverageWarningIntegration proves the advisory
+// flows through ValidateWithWarnings as a non-fatal warning on the firing config
+// (interception off, so no CA file is required).
+func TestValidate_TLSInterceptionCoverageWarningIntegration(t *testing.T) {
+	cfg := Defaults()
+	cfg.ForwardProxy.Enabled = true
+
+	warnings, err := cfg.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings: %v", err)
+	}
+	for _, w := range warnings {
+		if w.Field == "tls_interception" {
+			return
+		}
+	}
+	t.Fatalf("missing tls_interception coverage warning in %#v", warnings)
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -264,6 +264,7 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateTLSInterception(); err != nil {
 		return warnings, err
 	}
+	c.validateTLSInterceptionCoverage(&warnings)
 	if err := c.validateToolChainDetection(); err != nil {
 		return warnings, err
 	}
@@ -2316,6 +2317,45 @@ func (c *Config) validateTLSInterception() error {
 		return fmt.Errorf("CA key %s is too permissive (mode %04o): restrict to 0600 or 0640", keyPath, keyInfo.Mode().Perm())
 	}
 	return nil
+}
+
+// tlsInterceptionCoverageMessage is the shared advisory text for the HTTPS
+// content-visibility gap. It is honest in both directions: it names what content
+// scanning cannot see for HTTPS, lists only the controls that can be evaluated
+// from CONNECT metadata or tunnel accounting as still-enforced, and states that
+// request_policy and contract rules matching inner HTTPS content require
+// interception (they run on the CONNECT host, not the decrypted request).
+const tlsInterceptionCoverageMessage = "TLS interception is disabled while the forward proxy accepts CONNECT tunnels. " +
+	"HTTPS traffic is not decrypted, so content scanning (request_body_scanning, response_scanning, path/query entropy, and body DLP) " +
+	"does not inspect HTTPS request paths, bodies, or responses. Pipelock still enforces controls that evaluate from CONNECT metadata " +
+	"or tunnel accounting (destination allowlist/blocklist, SSRF on the CONNECT host, rate limits, data budget, CONNECT handshake-header DLP, " +
+	"kill switch, and receipt gates); request_policy and contract rules that match inner HTTPS method, path, query, headers, or body require " +
+	"tls_interception. Enable tls_interception (and distribute its CA) to scan HTTPS content, or accept tunnel-level-only visibility for " +
+	"HTTPS content as a deliberate posture."
+
+// TLSInterceptionCoverageAdvisory returns an operator advisory, and true, when
+// the forward proxy accepts CONNECT tunnels but TLS interception is off. Without
+// interception, HTTPS over CONNECT is an opaque tunnel: Pipelock sees the CONNECT
+// host and handshake, but not the inner HTTPS request path, query, body, or
+// response. Every content-dependent control (request/response body scanning,
+// path/query entropy, body DLP, and any request_policy/contract rule matching
+// inner HTTPS content) is therefore blind, so the advisory fires whenever the
+// forward proxy is on and interception is off, not only for body/response
+// scanners. Shared by the startup/reload warning and the `check`/`doctor`
+// advisory so both surfaces stay in sync.
+func (c *Config) TLSInterceptionCoverageAdvisory() (string, bool) {
+	if !c.ForwardProxy.Enabled || c.TLSInterception.Enabled {
+		return "", false
+	}
+	return tlsInterceptionCoverageMessage, true
+}
+
+// validateTLSInterceptionCoverage surfaces TLSInterceptionCoverageAdvisory as a
+// non-fatal Validate warning. It changes no enforcement behavior.
+func (c *Config) validateTLSInterceptionCoverage(warnings *[]Warning) {
+	if msg, ok := c.TLSInterceptionCoverageAdvisory(); ok {
+		*warnings = append(*warnings, Warning{Field: "tls_interception", Message: msg})
+	}
 }
 
 func (c *Config) validateToolChainDetection() error {


### PR DESCRIPTION
When the forward proxy accepts CONNECT tunnels but TLS interception is off, an HTTPS request is an opaque encrypted tunnel. The proxy sees only the CONNECT host, so `request_body_scanning`, `response_scanning`, path/query entropy, and body DLP do not inspect HTTPS request paths, bodies, or responses. Operators had no signal that content scanners they enabled do not cover their HTTPS traffic.

This adds a shared `TLSInterceptionCoverageAdvisory` helper on `Config`, surfaced three ways: a non-fatal config validation warning that renders at startup and on hot reload, a `check` advisory, and a dedicated `doctor` check with a remediation next-step. It fires only when a request-body or response scanner is enabled, so a deliberate host-allowlist-only posture for HTTPS is not flagged.

The advisory is honest in both directions. It names what content scanning does not cover for HTTPS, and it also states what Pipelock does still enforce at the CONNECT-tunnel level (host allowlist/blocklist, SSRF on the destination host, rate limits, data budget, CONNECT handshake-header DLP, request policy, contracts, kill switch, and receipt gates). Every item in that list was verified against the `handleConnect` path.

This is advisory only and changes no enforcement behavior. Plaintext HTTP through the forward proxy is unaffected, since its full URL and body are visible, so all scanners apply. The reverse-proxy, WebSocket, and fetch paths do not share the gap, since Pipelock owns the client side there and sees plaintext.

The TLS interception guide now documents exactly what is and is not enforced for HTTPS when interception is off, and shows the advisory text.

Tests: table-driven coverage of the validation warning and the check/doctor surfaces across the on/off matrix (forward proxy on/off, interception on/off, body/response scanners on/off), plus a guard that the message names only the scanners actually enabled. The three new functions are at 100% line coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a non-fatal HTTPS coverage warning when a forward proxy uses CONNECT tunneling but TLS interception is disabled.
  * Added CLI diagnostic and “doctor” checks to report whether HTTPS inspection coverage matches the enabled configuration.
  * Warning details include guidance to enable TLS interception (and related setup) or acknowledge tunnel-level-only visibility.

* **Documentation**
  * Expanded the TLS interception guide with a section explaining what enforcement remains active when interception is off, and what encrypted-content scanners are not applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->