### PR TITLE
test(cli): stop sandbox dry-run JSON test flaking without user namespaces

### DIFF
--- a/internal/cli/runtime/sandbox_test.go
+++ b/internal/cli/runtime/sandbox_test.go
@@ -109,9 +109,12 @@ func TestSandboxCmdDryRunJSON(t *testing.T) {
 	cmd := SandboxCmd()
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{"--dry-run", "--json", "--workspace", t.TempDir(), "--", "echo", "ok"})
-	var out bytes.Buffer
+	var out, stderr bytes.Buffer
 	cmd.SetOut(&out)
-	cmd.SetErr(&out)
+	// Keep stderr separate: on a runner without user namespaces the sandbox
+	// reports "degraded" and the command prints an error to stderr. Mixing it
+	// into out corrupts the JSON and flakes the unmarshal below.
+	cmd.SetErr(&stderr)
 
 	execErr := cmd.Execute()
 


### PR DESCRIPTION
Standalone CI fix: TestSandboxCmdDryRunJSON flakes on runners without user namespaces.

The test piped the command stdout and stderr into one buffer. On a runner without user namespaces the sandbox preflight reports degraded and the command writes an error to stderr, which corrupted the JSON the test then parsed and flaked the unmarshal. Giving stderr its own buffer leaves only the JSON in the parsed output; the test already handles the degraded status path. Test-only change, no production behavior affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved dry-run JSON output validation by separating standard output from error messages.
  * Prevented diagnostic messages from interfering with JSON parsing during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->