### PR TITLE
ci: stabilize Codecov reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,7 +189,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ./coverage-${{ matrix.shard }}.out
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   test-subprocess-coverage:
     needs: [security-scan]
@@ -218,7 +218,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ./coverage-subprocess.out
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   test:
     needs: [test-oss, test-enterprise, test-subprocess-coverage]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,21 @@
+codecov:
+  require_ci_to_pass: true
+  notify:
+    # CI uploads five coverage reports on successful runs: the four Go 1.25
+    # enterprise shards plus the merged sandbox subprocess profile. Without
+    # this, Codecov posts statuses and updates badges after the first partial
+    # upload, then revises the result as later shards arrive.
+    after_n_builds: 5
+    wait_for_ci: true
+
+parsers:
+  go:
+    # Go profiles are statement-based. A physical line can contain both covered
+    # and uncovered statements; counting Codecov partials as hits keeps the
+    # badge aligned with Go's own coverage model instead of treating those
+    # lines as fully missed.
+    partials_as_hits: true
+
 coverage:
   status:
     project:
@@ -43,7 +61,7 @@ ignore:
   # live-proxy flows. They are validated through integration/demo tests and
   # published audit-packet verification rather than treated as core library
   # unit-coverage denominator for the OpenSSF badge.
-  - "cmd/pipelock-playground-*"
+  - "cmd/pipelock-playground-*/**"
   - "internal/playground/**"
   - "internal/filesentry/lineage_other.go"  # build-tagged !linux, untestable on Linux CI
   # Remaining sandbox paths require kernel capabilities unavailable on GitHub's


### PR DESCRIPTION
## Summary
- wait for all five coverage uploads before Codecov publishes statuses
- align Go partial-line parsing with Go statement coverage
- fix the playground command ignore glob so demo harnesses stay outside badge scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting to wait for all CI coverage uploads before publishing results.
  * Added stricter CI success requirements for coverage checks, with Go coverage uploads failing the job on reporting errors.
  * Improved Go coverage handling for partial uploads and expanded coverage exclusions for playground code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->