### PR TITLE
feat(rules): fail closed on bundle integrity degradation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ kill-switch state is preserved, including the API, signal, Conductor remote,
 and Conductor stale-bundle sources. Existing MCP sessions retain the old
 scanner until the next request.
 
-If a reload fails validation (invalid regex, security downgrade), the old config is retained and a warning is logged. A reload is also rejected, in any mode, when a rule-bundle resolution error (bad signature, missing lock file, version mismatch, filesystem error) would drop detection rules that are currently live: the previous config is kept so a transient bundle failure cannot silently weaken coverage. An unrelated bundle error that does not remove any live rule does not block the reload. At startup there is no prior config to preserve, so a bundle resolution error is surfaced loudly and the proxy runs on its remaining (core plus compiled) patterns rather than refusing to start.
+If a reload fails validation (invalid regex, security downgrade), the old config is retained and a warning is logged. A reload is also rejected, in any mode, when a rule-bundle resolution error (bad signature, missing lock file, version mismatch, filesystem error) would drop detection rules that are currently live: the previous config is kept so a transient bundle failure cannot silently weaken coverage. A clean bundle deletion has no loader error, so it is handled separately: strict mode rejects the reload and keeps the running config unless `rules.allow_degraded: true` is set, while non-strict modes allow it and emit a `rule_bundle_degraded` audit event naming the bundle and dropped pattern count. An unrelated bundle error that does not remove any live rule does not block the reload. At startup, strict mode refuses installed-bundle integrity failures unless `rules.allow_degraded: true` is set; non-strict modes and availability failures start degraded with structured audit events and degraded state on `/stats` and `pipelock_rule_bundles_degraded`.
 
 **Reload exceptions:** the Sentry crash-report sanitizer captures the DLP pattern list at startup and does **not** update on reload. If you add DLP patterns used to scrub Sentry events, restart pipelock to propagate them. A warning is logged on any reload that changes `dlp.patterns` while Sentry is enabled: `DLP patterns changed; Sentry scrubber uses init-time patterns until restart`.
 
@@ -2185,6 +2185,7 @@ rules:
   rules_dir: ~/.local/share/pipelock/rules  # default ($XDG_DATA_HOME/pipelock/rules)
   min_confidence: medium          # skip low-confidence (experimental) rules
   include_experimental: false     # only load stable rules by default
+  allow_degraded: false           # emergency strict-mode degraded startup/reload override
   trusted_keys:                   # additional signing keys (beyond embedded keyring)
     - name: "vendor-security"
       public_key: "64-char-hex-encoded-ed25519-public-key"
@@ -2195,9 +2196,10 @@ rules:
 | `rules_dir` | `~/.local/share/pipelock/rules` | Directory for installed bundles (`$XDG_DATA_HOME/pipelock/rules`) |
 | `min_confidence` | `""` (all) | Skip rules below this confidence level |
 | `include_experimental` | `false` | Include experimental rules from bundles |
+| `allow_degraded` | `false` | Explicit emergency override that lets strict mode start or reload with degraded rule-bundle integrity/coverage after emitting warnings and audit events |
 | `trusted_keys` | `[]` | Additional Ed25519 public keys to trust for signature verification |
 
-**Hot reload:** rule directory changes are not detected via hot-reload. Restart pipelock after installing or updating bundles.
+**Hot reload:** rule directory changes are re-resolved when config reload runs. A clean uninstall that removes live bundle patterns is rejected in strict mode unless `allow_degraded` is set; non-strict modes allow it and emit degraded-state telemetry. Installing or updating bundles still normally uses the `pipelock rules` commands and a config reload or restart to re-resolve the runtime policy.
 
 ## Sandbox
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -106,10 +106,26 @@ rules:
   rules_dir: ~/.local/share/pipelock/rules  # default ($XDG_DATA_HOME/pipelock/rules)
   min_confidence: medium                    # skip experimental rules (low confidence)
   include_experimental: false               # default: only stable rules are active
+  allow_degraded: false                     # strict mode refuses installed-bundle integrity failures
   # trusted_keys:                           # additional trusted public keys (beyond embedded keyring)
   #   - name: "vendor-security"
   #     public_key: "64-char-hex-encoded-ed25519-public-key"
 ```
+
+## Degraded Bundle State
+
+Pipelock separates rule-bundle load failures into two operator classes:
+
+- **Integrity failures:** bad signatures, missing or mismatched `bundle.lock`, bundle hash mismatch, malformed installed bundle content, signer/tier mismatch, and freshness rollback state tampering.
+- **Availability failures:** missing optional rules directory, bundle file read/stat failures, freshness lock failures, or a bundle that requires a newer engine feature.
+
+In `mode: strict`, an integrity failure for an installed bundle refuses startup unless `rules.allow_degraded: true` is explicitly set. The error names the bundle and class so the operator can verify or reinstall the bundle before retrying. Availability failures keep the process available but mark the bundle state degraded.
+
+In non-strict modes, Pipelock starts with the remaining rules but emits a structured `rule_bundle_degraded` audit event and a startup warning. `/stats` reports degraded bundle count and names under `rule_bundles`; `/metrics` exposes `pipelock_rule_bundles_degraded`.
+
+On hot reload, a clean deletion of a previously live bundle is treated as a coverage drop. Strict mode rejects that reload and keeps the running config unless `rules.allow_degraded: true` is set on the candidate config. Non-strict modes allow the reload but emit a warning and audit event naming the bundle and pattern count dropped.
+
+`rules.allow_degraded` is an emergency override, not a normal operating mode. Use it only after confirming the bundle store is intentionally unavailable or after choosing to continue while restoring bundle integrity.
 
 ## Trust Model
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -116,7 +116,7 @@ rules:
 
 Pipelock separates rule-bundle load failures into two operator classes:
 
-- **Integrity failures:** bad signatures, missing or mismatched `bundle.lock`, bundle hash mismatch, malformed installed bundle content, signer/tier mismatch, and freshness rollback state tampering.
+- **Integrity failures:** bad signatures, missing or mismatched `bundle.lock`, bundle hash mismatch, malformed installed bundle content, expired bundles, signer/tier mismatch, and freshness rollback state tampering.
 - **Availability failures:** missing optional rules directory, bundle file read/stat failures, freshness lock failures, or a bundle that requires a newer engine feature.
 
 In `mode: strict`, an integrity failure for an installed bundle refuses startup unless `rules.allow_degraded: true` is explicitly set. The error names the bundle and class so the operator can verify or reinstall the bundle before retrying. Availability failures keep the process available but mark the bundle state degraded.

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -1173,24 +1173,37 @@ func (l *Logger) LogConfigReload(status, detail, configHash string) {
 	}
 }
 
+// RuleBundleDegradedEvent bundles the fields emitted for rule-bundle coverage
+// degradation or rejection events.
+type RuleBundleDegradedEvent struct {
+	Bundle          string
+	FailureClass    string
+	Reason          string
+	Phase           string
+	Outcome         string
+	Severity        string
+	AllowDegraded   bool
+	DroppedPatterns int
+}
+
 // LogRuleBundleDegraded logs a rule-bundle coverage degradation or rejection.
-func (l *Logger) LogRuleBundleDegraded(bundle, failureClass, reason, phase, outcome, severity string, allowDegraded bool, droppedPatterns int) {
+func (l *Logger) LogRuleBundleDegraded(ev RuleBundleDegradedEvent) {
 	level := l.zl.Warn()
 	emitSeverity := emit.SeverityWarn
-	if severity == severityCritical || severity == "error" {
+	if ev.Severity == severityCritical || ev.Severity == "error" {
 		level = l.zl.Error()
 		emitSeverity = emit.SeverityCritical
 	}
 	e := newLogEntry(level, EventRuleBundleDegraded).
-		str("bundle", bundle).
-		str("failure_class", failureClass).
-		str("reason", reason).
-		str("phase", phase).
-		str("outcome", outcome)
-	e.event = e.event.Bool("allow_degraded", allowDegraded)
-	e.fields["allow_degraded"] = allowDegraded
-	if droppedPatterns > 0 {
-		e.intField("dropped_patterns", droppedPatterns)
+		str("bundle", ev.Bundle).
+		str("failure_class", ev.FailureClass).
+		str("reason", ev.Reason).
+		str("phase", ev.Phase).
+		str("outcome", ev.Outcome)
+	e.event = e.event.Bool("allow_degraded", ev.AllowDegraded)
+	e.fields["allow_degraded"] = ev.AllowDegraded
+	if ev.DroppedPatterns > 0 {
+		e.intField("dropped_patterns", ev.DroppedPatterns)
 	}
 	e.msg("rule bundle coverage degraded")
 

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -328,12 +328,13 @@ const (
 	EventResponseScanExempt EventType = "response_scan_exempt"
 	EventTaintDecision      EventType = "taint_decision"
 
-	EventAirlockEnter      EventType = "airlock_enter"
-	EventAirlockDeny       EventType = "airlock_deny"
-	EventAirlockDeescalate EventType = "airlock_deescalate"
-	EventShieldRewrite     EventType = "shield_rewrite"
-	EventMediaExposure     EventType = "media_exposure"
-	EventLicenseExpiry     EventType = "license_expiry"
+	EventAirlockEnter       EventType = "airlock_enter"
+	EventAirlockDeny        EventType = "airlock_deny"
+	EventAirlockDeescalate  EventType = "airlock_deescalate"
+	EventShieldRewrite      EventType = "shield_rewrite"
+	EventMediaExposure      EventType = "media_exposure"
+	EventLicenseExpiry      EventType = "license_expiry"
+	EventRuleBundleDegraded EventType = "rule_bundle_degraded"
 )
 
 const responseScanExemptFullTrustEffect = "response_scanning.exempt_domains is a full-trust valve: injection scanning is disabled for ALL responses from this host, including oversized over-cap responses that stream unscanned"
@@ -1169,6 +1170,32 @@ func (l *Logger) LogConfigReload(status, detail, configHash string) {
 
 	if l.emitter != nil {
 		l.emitter.Emit(context.Background(), string(EventConfigReload), e.fields)
+	}
+}
+
+// LogRuleBundleDegraded logs a rule-bundle coverage degradation or rejection.
+func (l *Logger) LogRuleBundleDegraded(bundle, failureClass, reason, phase, outcome, severity string, allowDegraded bool, droppedPatterns int) {
+	level := l.zl.Warn()
+	emitSeverity := emit.SeverityWarn
+	if severity == severityCritical || severity == "error" {
+		level = l.zl.Error()
+		emitSeverity = emit.SeverityCritical
+	}
+	e := newLogEntry(level, EventRuleBundleDegraded).
+		str("bundle", bundle).
+		str("failure_class", failureClass).
+		str("reason", reason).
+		str("phase", phase).
+		str("outcome", outcome)
+	e.event = e.event.Bool("allow_degraded", allowDegraded)
+	e.fields["allow_degraded"] = allowDegraded
+	if droppedPatterns > 0 {
+		e.intField("dropped_patterns", droppedPatterns)
+	}
+	e.msg("rule bundle coverage degraded")
+
+	if l.emitter != nil {
+		l.emitter.EmitWithSeverity(context.Background(), emitSeverity, string(EventRuleBundleDegraded), e.fields)
 	}
 }
 

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -1830,6 +1830,31 @@ func assertEmitterFields(t *testing.T, ev emit.Event, wantType EventType, wantSe
 	}
 }
 
+func TestEmit_RuleBundleDegradedEventUsesConfiguredFields(t *testing.T) {
+	logger, sink := newLoggerWithEmitter(t)
+	logger.LogRuleBundleDegraded(RuleBundleDegradedEvent{
+		Bundle:          "community-rules",
+		FailureClass:    "coverage_drop",
+		Reason:          "clean bundle removal dropped live patterns: dlp=2",
+		Phase:           "reload",
+		Outcome:         "rejected",
+		Severity:        severityCritical,
+		AllowDegraded:   true,
+		DroppedPatterns: 2,
+	})
+
+	ev := sink.onlyEvent(t)
+	assertEmitterFields(t, ev, EventRuleBundleDegraded, emit.SeverityCritical, map[string]any{
+		"bundle":           "community-rules",
+		"failure_class":    "coverage_drop",
+		"reason":           "clean bundle removal dropped live patterns: dlp=2",
+		"phase":            "reload",
+		"outcome":          "rejected",
+		"allow_degraded":   true,
+		"dropped_patterns": 2,
+	})
+}
+
 func TestEmit_OperationalLifecycleEvents(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -126,18 +126,6 @@ func awaitReloadCycleResult(reloaded <-chan struct{}, buf *cliTestBuffer, errCh 
 	}
 }
 
-// requireCLIOutputAfterReload blocks until one config reload cycle completes,
-// then asserts want was emitted. The reload warning is always written before the
-// cycle-complete signal fires, so the assertion is deterministic — no polling
-// against a wall-clock deadline.
-func requireCLIOutputAfterReload(t *testing.T, reloaded <-chan struct{}, buf *cliTestBuffer, errCh <-chan error, cancel context.CancelFunc, want string) {
-	t.Helper()
-	if err := requireCLIOutputAfterReloadResult(reloaded, buf, errCh, want); err != nil {
-		cancel()
-		t.Fatal(err)
-	}
-}
-
 func requireCLIOutputAfterReloadResult(reloaded <-chan struct{}, buf *cliTestBuffer, errCh <-chan error, want string) error {
 	if err := awaitReloadCycleResult(reloaded, buf, errCh); err != nil {
 		return err
@@ -2351,7 +2339,10 @@ fetch_proxy:
 			t.Fatal(writeErr)
 		}
 
-		requireCLIOutputAfterReload(t, reloaded, stderr, errCh, cancel, "license key inputs changed")
+		if err := requireCLIOutputAfterReloadResult(reloaded, stderr, errCh, "license key inputs changed"); err != nil {
+			cancel()
+			return err
+		}
 
 		cancel()
 		select {
@@ -2427,7 +2418,10 @@ fetch_proxy:
 			t.Fatal(writeErr)
 		}
 
-		requireCLIOutputAfterReload(t, reloaded, stderr, errCh, cancel, "mode downgraded from balanced to audit")
+		if err := requireCLIOutputAfterReloadResult(reloaded, stderr, errCh, "mode downgraded from balanced to audit"); err != nil {
+			cancel()
+			return err
+		}
 
 		cancel()
 		select {
@@ -2508,7 +2502,10 @@ fetch_proxy:
 			t.Fatal(writeErr)
 		}
 
-		requireCLIOutputAfterReload(t, reloaded, stderr, errCh, cancel, "license key inputs changed")
+		if err := requireCLIOutputAfterReloadResult(reloaded, stderr, errCh, "license key inputs changed"); err != nil {
+			cancel()
+			return err
+		}
 
 		cancel()
 		select {

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -366,19 +366,9 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		},
 		DefaultToolPolicyRules: policy.DefaultToolPolicyRules,
 	}, opts.Stderr, "listener")
-	for _, e := range bundleResult.Errors {
-		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: warning: bundle %s: %s\n", e.Name, e.Reason)
-	}
-	for _, w := range bundleResult.Warnings {
-		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: %s\n", w)
-	}
-	if bundleResult.Degraded {
-		// Startup has no previous live bundle-resolved config to preserve, so a
-		// corrupt installed bundle is surfaced loudly but does not hard-fail the
-		// proxy. Hard-failing here would let one bad optional bundle deny service
-		// for the whole control. Hot reload has a separate activation-boundary
-		// gate that rejects bundle errors only when they would drop live coverage.
-		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: DEGRADED — standard pack failed, running core patterns only\n")
+	if err := s.reportStartupRuleBundleResult(cfg, bundleResult); err != nil {
+		s.cleanup()
+		return nil, err
 	}
 	if hasMCPListen {
 		if err := validateMCPDeferSurface(deferred.SurfaceMCPHTTPListener, cfg); err != nil {

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -338,10 +338,10 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
 			return rejectErr
 		}
-		var cleanDrops []bundleCoverageDrop
-		if len(reloadBundleResult.Errors) == 0 {
-			cleanDrops = cleanBundleCoverageDrops(oldCfg, newCfg, s.currentMCPToolExtraPoison(), reloadBundleResult.ToolPoison)
-		}
+		cleanDrops := cleanDropsWithoutBundleErrors(
+			cleanBundleCoverageDrops(oldCfg, newCfg, s.currentMCPToolExtraPoison(), reloadBundleResult.ToolPoison),
+			reloadBundleResult,
+		)
 		if len(cleanDrops) > 0 {
 			for _, drop := range cleanDrops {
 				outcome := ruleBundleOutcomeDegraded
@@ -352,7 +352,16 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 				}
 				_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: rule bundle %s cleanly removed %d live pattern(s) (%s)\n",
 					drop.Name, drop.Total(), drop.Reason())
-				s.logger.LogRuleBundleDegraded(drop.Name, "coverage_drop", drop.Reason(), ruleBundlePhaseReload, outcome, severity, newCfg.Rules.AllowDegraded, drop.Total())
+				s.logger.LogRuleBundleDegraded(audit.RuleBundleDegradedEvent{
+					Bundle:          drop.Name,
+					FailureClass:    "coverage_drop",
+					Reason:          drop.Reason(),
+					Phase:           ruleBundlePhaseReload,
+					Outcome:         outcome,
+					Severity:        severity,
+					AllowDegraded:   newCfg.Rules.AllowDegraded,
+					DroppedPatterns: drop.Total(),
+				})
 			}
 			if strictRuleBundleDegradationDisallowed(oldCfg, newCfg) {
 				rejectErr := fmt.Errorf("rejected: strict mode rule bundle coverage drop: %s", bundleCoverageDropSummary(cleanDrops))
@@ -453,6 +462,26 @@ func strictRuleBundleDegradationDisallowed(oldCfg, newCfg *config.Config) bool {
 		return false
 	}
 	return newCfg.Mode == config.ModeStrict || (oldCfg != nil && oldCfg.Mode == config.ModeStrict)
+}
+
+func cleanDropsWithoutBundleErrors(drops []bundleCoverageDrop, result *rules.LoadResult) []bundleCoverageDrop {
+	if len(drops) == 0 || result == nil || len(result.Errors) == 0 {
+		return drops
+	}
+	errorBundles := make(map[string]struct{}, len(result.Errors))
+	for _, e := range result.Errors {
+		if e.Name != "" {
+			errorBundles[e.Name] = struct{}{}
+		}
+	}
+	clean := drops[:0]
+	for _, drop := range drops {
+		if _, errored := errorBundles[drop.Name]; errored {
+			continue
+		}
+		clean = append(clean, drop)
+	}
+	return clean
 }
 
 func boolPtrEqual(a, b *bool) bool {
@@ -731,7 +760,7 @@ type bundlePatternIdentity struct {
 }
 
 func dlpPatternEnforcementIdentity(p config.DLPPattern) string {
-	return p.Severity + "\x00" + p.Validator + "\x00" + p.Action
+	return p.Severity + "\x00" + p.Validator + "\x00" + p.Action + "\x00" + strings.Join(p.ExemptDomains, "\x00")
 }
 
 func bundlePatternDropNames(drops []bundlePatternDropDetail) []string {

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -327,15 +327,7 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		},
 		DefaultToolPolicyRules: policy.DefaultToolPolicyRules,
 	}, s.opts.Stderr, reloadRuntimeModeLabel(s.runtimeMode))
-	for _, e := range reloadBundleResult.Errors {
-		_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: bundle %s: %s\n", e.Name, e.Reason)
-	}
-	for _, w := range reloadBundleResult.Warnings {
-		_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: %s\n", w)
-	}
-	if reloadBundleResult.Degraded {
-		_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: DEGRADED — standard pack failed after reload, running core patterns only\n")
-	}
+	reportReloadRuleBundleResult(s.opts.Stderr, s.logger, newCfg, reloadBundleResult)
 	if oldCfg != nil {
 		// Compare resolved-vs-resolved configs so bundle merges and
 		// MCP listener auto-enable do not look like policy downgrades
@@ -346,7 +338,36 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
 			return rejectErr
 		}
+		var cleanDrops []bundleCoverageDrop
+		if len(reloadBundleResult.Errors) == 0 {
+			cleanDrops = cleanBundleCoverageDrops(oldCfg, newCfg, s.currentMCPToolExtraPoison(), reloadBundleResult.ToolPoison)
+		}
+		if len(cleanDrops) > 0 {
+			for _, drop := range cleanDrops {
+				outcome := ruleBundleOutcomeDegraded
+				severity := config.SeverityWarn
+				if strictRuleBundleDegradationDisallowed(oldCfg, newCfg) {
+					outcome = ruleBundleOutcomeRejected
+					severity = config.SeverityCritical
+				}
+				_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: rule bundle %s cleanly removed %d live pattern(s) (%s)\n",
+					drop.Name, drop.Total(), drop.Reason())
+				s.logger.LogRuleBundleDegraded(drop.Name, "coverage_drop", drop.Reason(), ruleBundlePhaseReload, outcome, severity, newCfg.Rules.AllowDegraded, drop.Total())
+			}
+			if strictRuleBundleDegradationDisallowed(oldCfg, newCfg) {
+				rejectErr := fmt.Errorf("rejected: strict mode rule bundle coverage drop: %s", bundleCoverageDropSummary(cleanDrops))
+				_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload rejected: %v\n", rejectErr)
+				s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
+				return rejectErr
+			}
+			if newCfg.Rules.AllowDegraded {
+				_, _ = fmt.Fprintln(s.opts.Stderr, "WARNING: config reload: rules.allow_degraded=true; accepting degraded rule-bundle coverage after explicit operator opt-in")
+			}
+		}
 		warnings := config.ValidateReload(oldCfg, newCfg)
+		if newCfg.Rules.AllowDegraded && len(cleanDrops) > 0 {
+			warnings = filterAllowedRuleBundleCoverageWarnings(oldCfg, newCfg, warnings)
+		}
 		for _, w := range warnings {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: %s - %s\n", w.Field, w.Message)
 		}
@@ -370,6 +391,14 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
 			return rejectErr
 		}
+		if len(cleanDrops) > 0 {
+			applyDegradedRuleBundleState(newCfg, appendBundleDropNames(reloadBundleResult.DegradedBundleNames(), cleanDrops))
+		} else {
+			applyDegradedRuleBundleState(newCfg, reloadBundleResult.DegradedBundleNames())
+		}
+	}
+	if oldCfg == nil {
+		applyDegradedRuleBundleState(newCfg, reloadBundleResult.DegradedBundleNames())
 	}
 	newSc, err := scanner.New(newCfg)
 	if err != nil {
@@ -386,6 +415,7 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 	}
 	fireReloadAfterProxySwapHook(s)
 	s.refreshRuntimeState(oldCfg, newCfg, reloadBundleResult, s.proxy.ScannerPtr().Load())
+	publishDegradedRuleBundleMetrics(s.metrics, newCfg)
 	if reloadErr := s.proxy.LoadCertCache(newCfg); reloadErr != nil {
 		s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile),
 			fmt.Errorf("TLS cert cache reload failed: %w", reloadErr))
@@ -416,6 +446,13 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 	s.logger.LogConfigReload("success", fmt.Sprintf("mode=%s", newCfg.Mode), reloadHash)
 	s.recordReloadSuccess(reloadHash)
 	return nil
+}
+
+func strictRuleBundleDegradationDisallowed(oldCfg, newCfg *config.Config) bool {
+	if newCfg == nil || newCfg.Rules.AllowDegraded {
+		return false
+	}
+	return newCfg.Mode == config.ModeStrict || (oldCfg != nil && oldCfg.Mode == config.ModeStrict)
 }
 
 func boolPtrEqual(a, b *bool) bool {
@@ -583,48 +620,86 @@ func bundleResolutionRejectReason(
 }
 
 func removedBundleDLPPatterns(old, updated []config.DLPPattern) []string {
-	return removedBundleNamedRegexPatterns(old, updated,
+	return bundlePatternDropNames(removedBundleNamedRegexPatternDrops(old, updated,
 		func(p config.DLPPattern) string { return p.Name },
 		func(p config.DLPPattern) string { return p.Regex },
-		func(p config.DLPPattern) string { return p.Bundle })
+		func(p config.DLPPattern) string { return p.Bundle },
+		dlpPatternEnforcementIdentity))
 }
 
 func removedBundleResponsePatterns(old, updated []config.ResponseScanPattern) []string {
-	return removedBundleNamedRegexPatterns(old, updated,
+	return bundlePatternDropNames(removedBundleNamedRegexPatternDrops(old, updated,
 		func(p config.ResponseScanPattern) string { return p.Name },
 		func(p config.ResponseScanPattern) string { return p.Regex },
-		func(p config.ResponseScanPattern) string { return p.Bundle })
+		func(p config.ResponseScanPattern) string { return p.Bundle },
+		func(config.ResponseScanPattern) string { return "" }))
 }
 
-func removedBundleNamedRegexPatterns[T any](
+type bundlePatternDropDetail struct {
+	Name   string
+	Bundle string
+	Reason string
+}
+
+func removedBundleDLPPatternDrops(old, updated []config.DLPPattern) []bundlePatternDropDetail {
+	return removedBundleNamedRegexPatternDrops(old, updated,
+		func(p config.DLPPattern) string { return p.Name },
+		func(p config.DLPPattern) string { return p.Regex },
+		func(p config.DLPPattern) string { return p.Bundle },
+		dlpPatternEnforcementIdentity)
+}
+
+func removedBundleResponsePatternDrops(old, updated []config.ResponseScanPattern) []bundlePatternDropDetail {
+	return removedBundleNamedRegexPatternDrops(old, updated,
+		func(p config.ResponseScanPattern) string { return p.Name },
+		func(p config.ResponseScanPattern) string { return p.Regex },
+		func(p config.ResponseScanPattern) string { return p.Bundle },
+		func(config.ResponseScanPattern) string { return "" })
+}
+
+func removedBundleNamedRegexPatternDrops[T any](
 	old, updated []T,
 	nameOf func(T) string,
 	regexOf func(T) string,
 	bundleOf func(T) string,
-) []string {
-	updatedByName := make(map[string]string, len(updated))
+	enforcementIdentityOf func(T) string,
+) []bundlePatternDropDetail {
+	updatedByName := make(map[string]bundlePatternIdentity, len(updated))
 	for _, p := range updated {
-		updatedByName[nameOf(p)] = regexOf(p)
+		updatedByName[nameOf(p)] = bundlePatternIdentity{
+			Regex:               regexOf(p),
+			Bundle:              bundleOf(p),
+			EnforcementIdentity: enforcementIdentityOf(p),
+		}
 	}
 
-	var removed []string
+	var removed []bundlePatternDropDetail
 	for _, p := range old {
-		if bundleOf(p) == "" {
+		bundle := bundleOf(p)
+		if bundle == "" {
 			continue
 		}
 		name := nameOf(p)
-		newRegex, ok := updatedByName[name]
+		newIdentity, ok := updatedByName[name]
 		switch {
 		case !ok:
-			removed = append(removed, name)
-		case newRegex != regexOf(p):
-			removed = append(removed, name+" (regex changed)")
+			removed = append(removed, bundlePatternDropDetail{Name: name, Bundle: bundle})
+		case newIdentity.Bundle != bundle:
+			removed = append(removed, bundlePatternDropDetail{Name: name, Bundle: bundle, Reason: "bundle changed"})
+		case newIdentity.Regex != regexOf(p):
+			removed = append(removed, bundlePatternDropDetail{Name: name, Bundle: bundle, Reason: "regex changed"})
+		case newIdentity.EnforcementIdentity != enforcementIdentityOf(p):
+			removed = append(removed, bundlePatternDropDetail{Name: name, Bundle: bundle, Reason: "enforcement fields changed"})
 		}
 	}
 	return removed
 }
 
 func removedBundleToolPoisonPatterns(old, updated []*tools.ExtraPoisonPattern) []string {
+	return bundlePatternDropNames(removedBundleToolPoisonPatternDrops(old, updated))
+}
+
+func removedBundleToolPoisonPatternDrops(old, updated []*tools.ExtraPoisonPattern) []bundlePatternDropDetail {
 	updatedByName := make(map[string]string, len(updated))
 	for _, p := range updated {
 		if p == nil {
@@ -633,7 +708,7 @@ func removedBundleToolPoisonPatterns(old, updated []*tools.ExtraPoisonPattern) [
 		updatedByName[p.Name] = toolPoisonPatternIdentity(p)
 	}
 
-	var removed []string
+	var removed []bundlePatternDropDetail
 	for _, p := range old {
 		if p == nil || p.Bundle == "" {
 			continue
@@ -641,12 +716,37 @@ func removedBundleToolPoisonPatterns(old, updated []*tools.ExtraPoisonPattern) [
 		identity, ok := updatedByName[p.Name]
 		switch {
 		case !ok:
-			removed = append(removed, p.Name)
+			removed = append(removed, bundlePatternDropDetail{Name: p.Name, Bundle: p.Bundle})
 		case identity != toolPoisonPatternIdentity(p):
-			removed = append(removed, p.Name+" (regex or scan_field changed)")
+			removed = append(removed, bundlePatternDropDetail{Name: p.Name, Bundle: p.Bundle, Reason: "regex, scan_field, or bundle changed"})
 		}
 	}
 	return removed
+}
+
+type bundlePatternIdentity struct {
+	Regex               string
+	Bundle              string
+	EnforcementIdentity string
+}
+
+func dlpPatternEnforcementIdentity(p config.DLPPattern) string {
+	return p.Severity + "\x00" + p.Validator + "\x00" + p.Action
+}
+
+func bundlePatternDropNames(drops []bundlePatternDropDetail) []string {
+	if len(drops) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(drops))
+	for _, drop := range drops {
+		if drop.Reason != "" {
+			names = append(names, drop.Name+" ("+drop.Reason+")")
+			continue
+		}
+		names = append(names, drop.Name)
+	}
+	return names
 }
 
 func toolPoisonPatternIdentity(p *tools.ExtraPoisonPattern) string {
@@ -657,7 +757,7 @@ func toolPoisonPatternIdentity(p *tools.ExtraPoisonPattern) string {
 	if p.Re != nil {
 		regex = p.Re.String()
 	}
-	return regex + "\x00" + p.ScanField
+	return regex + "\x00" + p.ScanField + "\x00" + p.Bundle
 }
 
 func hasRejectableDowngradeWarning(warnings []config.ReloadWarning) bool {

--- a/internal/cli/runtime/server_rule_bundles.go
+++ b/internal/cli/runtime/server_rule_bundles.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/rules"
@@ -39,7 +40,15 @@ func (s *Server) reportStartupRuleBundleResult(cfg *config.Config, result *rules
 			severity = config.SeverityCritical
 		}
 		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: SECURITY WARNING: rule bundle %s degraded (%s): %s\n", e.Name, class, e.Reason)
-		s.logger.LogRuleBundleDegraded(e.Name, string(class), e.Reason, ruleBundlePhaseStartup, outcome, severity, cfg.Rules.AllowDegraded, 0)
+		s.logger.LogRuleBundleDegraded(audit.RuleBundleDegradedEvent{
+			Bundle:        e.Name,
+			FailureClass:  string(class),
+			Reason:        e.Reason,
+			Phase:         ruleBundlePhaseStartup,
+			Outcome:       outcome,
+			Severity:      severity,
+			AllowDegraded: cfg.Rules.AllowDegraded,
+		})
 	}
 	for _, w := range result.Warnings {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: %s\n", w)
@@ -70,7 +79,15 @@ func reportReloadRuleBundleResult(stderr io.Writer, logger ruleBundleAuditLogger
 	for _, e := range result.Errors {
 		class := e.ClassOrDefault()
 		_, _ = fmt.Fprintf(stderr, "WARNING: config reload: rule bundle %s degraded (%s): %s\n", e.Name, class, e.Reason)
-		logger.LogRuleBundleDegraded(e.Name, string(class), e.Reason, ruleBundlePhaseReload, ruleBundleOutcomeDegraded, config.SeverityWarn, cfg.Rules.AllowDegraded, 0)
+		logger.LogRuleBundleDegraded(audit.RuleBundleDegradedEvent{
+			Bundle:        e.Name,
+			FailureClass:  string(class),
+			Reason:        e.Reason,
+			Phase:         ruleBundlePhaseReload,
+			Outcome:       ruleBundleOutcomeDegraded,
+			Severity:      config.SeverityWarn,
+			AllowDegraded: cfg.Rules.AllowDegraded,
+		})
 	}
 	for _, w := range result.Warnings {
 		_, _ = fmt.Fprintf(stderr, "WARNING: config reload: %s\n", w)
@@ -82,7 +99,7 @@ func reportReloadRuleBundleResult(stderr io.Writer, logger ruleBundleAuditLogger
 }
 
 type ruleBundleAuditLogger interface {
-	LogRuleBundleDegraded(bundle, failureClass, reason, phase, outcome, severity string, allowDegraded bool, droppedPatterns int)
+	LogRuleBundleDegraded(audit.RuleBundleDegradedEvent)
 }
 
 func applyDegradedRuleBundleState(cfg *config.Config, names []string) {
@@ -222,36 +239,49 @@ func filterAllowedRuleBundleCoverageWarnings(oldCfg, newCfg *config.Config, warn
 }
 
 func removedOrWeakenedDLPIsBundleOnly(old, updated []config.DLPPattern) bool {
-	return removedOrWeakenedIsBundleOnly(old, updated,
-		func(p config.DLPPattern) string { return p.Name },
-		func(p config.DLPPattern) string { return p.Regex },
-		func(p config.DLPPattern) string { return p.Bundle })
+	updatedByName := make(map[string]config.DLPPattern, len(updated))
+	for _, p := range updated {
+		updatedByName[p.Name] = p
+	}
+	var bundleOnlyChange, nonBundleChange bool
+	for _, p := range old {
+		updatedPattern, ok := updatedByName[p.Name]
+		if ok && dlpPatternCoverageIdentity(updatedPattern) == dlpPatternCoverageIdentity(p) {
+			continue
+		}
+		if p.Bundle == "" {
+			nonBundleChange = true
+			continue
+		}
+		bundleOnlyChange = true
+	}
+	return bundleOnlyChange && !nonBundleChange
 }
 
 func removedOrWeakenedResponseIsBundleOnly(old, updated []config.ResponseScanPattern) bool {
-	return removedOrWeakenedIsBundleOnly(old, updated,
-		func(p config.ResponseScanPattern) string { return p.Name },
-		func(p config.ResponseScanPattern) string { return p.Regex },
-		func(p config.ResponseScanPattern) string { return p.Bundle })
+	updatedByName := make(map[string]config.ResponseScanPattern, len(updated))
+	for _, p := range updated {
+		updatedByName[p.Name] = p
+	}
+	var bundleOnlyChange, nonBundleChange bool
+	for _, p := range old {
+		updatedPattern, ok := updatedByName[p.Name]
+		if ok && responsePatternCoverageIdentity(updatedPattern) == responsePatternCoverageIdentity(p) {
+			continue
+		}
+		if p.Bundle == "" {
+			nonBundleChange = true
+			continue
+		}
+		bundleOnlyChange = true
+	}
+	return bundleOnlyChange && !nonBundleChange
 }
 
-func removedOrWeakenedIsBundleOnly[T any](old, updated []T, nameOf, regexOf, bundleOf func(T) string) bool {
-	updatedByName := make(map[string]string, len(updated))
-	for _, p := range updated {
-		updatedByName[nameOf(p)] = regexOf(p)
-	}
-	var removedBundle, removedNonBundle bool
-	for _, p := range old {
-		name := nameOf(p)
-		updatedRegex, ok := updatedByName[name]
-		if ok && updatedRegex == regexOf(p) {
-			continue
-		}
-		if bundleOf(p) == "" {
-			removedNonBundle = true
-			continue
-		}
-		removedBundle = true
-	}
-	return removedBundle && !removedNonBundle
+func dlpPatternCoverageIdentity(p config.DLPPattern) string {
+	return p.Regex + "\x00" + dlpPatternEnforcementIdentity(p) + "\x00" + p.Bundle
+}
+
+func responsePatternCoverageIdentity(p config.ResponseScanPattern) string {
+	return p.Regex + "\x00" + p.Bundle
 }

--- a/internal/cli/runtime/server_rule_bundles.go
+++ b/internal/cli/runtime/server_rule_bundles.go
@@ -1,0 +1,257 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/tools"
+	"github.com/luckyPipewrench/pipelock/internal/rules"
+)
+
+const (
+	ruleBundlePhaseStartup = "startup"
+	ruleBundlePhaseReload  = "reload"
+
+	ruleBundleOutcomeDegraded = "degraded"
+	ruleBundleOutcomeRefused  = "refused"
+	ruleBundleOutcomeRejected = "rejected"
+)
+
+func (s *Server) reportStartupRuleBundleResult(cfg *config.Config, result *rules.LoadResult) error {
+	if result == nil {
+		return nil
+	}
+	applyDegradedRuleBundleState(cfg, result.DegradedBundleNames())
+	publishDegradedRuleBundleMetrics(s.metrics, cfg)
+
+	for _, e := range result.Errors {
+		class := e.ClassOrDefault()
+		outcome := ruleBundleOutcomeDegraded
+		severity := config.SeverityWarn
+		if cfg.Mode == config.ModeStrict && class == rules.BundleErrorClassIntegrity && !cfg.Rules.AllowDegraded {
+			outcome = ruleBundleOutcomeRefused
+			severity = config.SeverityCritical
+		}
+		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: SECURITY WARNING: rule bundle %s degraded (%s): %s\n", e.Name, class, e.Reason)
+		s.logger.LogRuleBundleDegraded(e.Name, string(class), e.Reason, ruleBundlePhaseStartup, outcome, severity, cfg.Rules.AllowDegraded, 0)
+	}
+	for _, w := range result.Warnings {
+		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: %s\n", w)
+	}
+	if result.Degraded {
+		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: DEGRADED — %d rule bundle(s) unavailable: %s\n",
+			len(cfg.Rules.DegradedBundles), strings.Join(cfg.Rules.DegradedBundles, ", "))
+		if cfg.Mode == config.ModeStrict && cfg.Rules.AllowDegraded && len(result.IntegrityErrors()) > 0 {
+			_, _ = fmt.Fprintln(s.opts.Stderr, "pipelock: SECURITY WARNING: rules.allow_degraded=true; strict mode is booting with degraded rule-bundle integrity after explicit operator opt-in")
+		}
+	}
+	if cfg.Mode != config.ModeStrict || cfg.Rules.AllowDegraded {
+		return nil
+	}
+	for _, e := range result.Errors {
+		if e.ClassOrDefault() == rules.BundleErrorClassIntegrity {
+			return fmt.Errorf("rule bundle integrity failure in strict mode: bundle %s failed with class %s: %s (verify or reinstall the bundle, or set rules.allow_degraded: true only as an emergency override)",
+				e.Name, e.ClassOrDefault(), e.Reason)
+		}
+	}
+	return nil
+}
+
+func reportReloadRuleBundleResult(stderr io.Writer, logger ruleBundleAuditLogger, cfg *config.Config, result *rules.LoadResult) {
+	if result == nil {
+		return
+	}
+	for _, e := range result.Errors {
+		class := e.ClassOrDefault()
+		_, _ = fmt.Fprintf(stderr, "WARNING: config reload: rule bundle %s degraded (%s): %s\n", e.Name, class, e.Reason)
+		logger.LogRuleBundleDegraded(e.Name, string(class), e.Reason, ruleBundlePhaseReload, ruleBundleOutcomeDegraded, config.SeverityWarn, cfg.Rules.AllowDegraded, 0)
+	}
+	for _, w := range result.Warnings {
+		_, _ = fmt.Fprintf(stderr, "WARNING: config reload: %s\n", w)
+	}
+	if result.Degraded {
+		names := result.DegradedBundleNames()
+		_, _ = fmt.Fprintf(stderr, "WARNING: config reload: DEGRADED — %d rule bundle(s) unavailable: %s\n", len(names), strings.Join(names, ", "))
+	}
+}
+
+type ruleBundleAuditLogger interface {
+	LogRuleBundleDegraded(bundle, failureClass, reason, phase, outcome, severity string, allowDegraded bool, droppedPatterns int)
+}
+
+func applyDegradedRuleBundleState(cfg *config.Config, names []string) {
+	if cfg == nil {
+		return
+	}
+	copied := append([]string(nil), names...)
+	sort.Strings(copied)
+	cfg.Rules.DegradedBundles = copied
+}
+
+func publishDegradedRuleBundleMetrics(m ruleBundleMetrics, cfg *config.Config) {
+	if m == nil || cfg == nil {
+		return
+	}
+	m.SetRuleBundlesDegraded(cfg.Rules.DegradedBundles)
+}
+
+type ruleBundleMetrics interface {
+	SetRuleBundlesDegraded(names []string)
+}
+
+type bundleCoverageDrop struct {
+	Name       string
+	DLP        int
+	Response   int
+	ToolPoison int
+}
+
+func (d bundleCoverageDrop) Total() int {
+	return d.DLP + d.Response + d.ToolPoison
+}
+
+func (d bundleCoverageDrop) Reason() string {
+	var parts []string
+	if d.DLP > 0 {
+		parts = append(parts, fmt.Sprintf("dlp=%d", d.DLP))
+	}
+	if d.Response > 0 {
+		parts = append(parts, fmt.Sprintf("response=%d", d.Response))
+	}
+	if d.ToolPoison > 0 {
+		parts = append(parts, fmt.Sprintf("tool_poison=%d", d.ToolPoison))
+	}
+	return "clean bundle removal dropped live patterns: " + strings.Join(parts, ", ")
+}
+
+func cleanBundleCoverageDrops(oldCfg, newCfg *config.Config, oldToolPoison []*tools.ExtraPoisonPattern, newToolPoison []rules.CompiledToolPoisonRule) []bundleCoverageDrop {
+	if oldCfg == nil || newCfg == nil {
+		return nil
+	}
+	dropsByBundle := make(map[string]*bundleCoverageDrop)
+	for _, dropped := range removedBundleDLPPatternDrops(oldCfg.DLP.Patterns, newCfg.DLP.Patterns) {
+		drop := coverageDropForBundle(dropsByBundle, dropped.Bundle)
+		drop.DLP++
+	}
+	for _, dropped := range removedBundleResponsePatternDrops(oldCfg.ResponseScanning.Patterns, newCfg.ResponseScanning.Patterns) {
+		drop := coverageDropForBundle(dropsByBundle, dropped.Bundle)
+		drop.Response++
+	}
+	for _, dropped := range removedBundleToolPoisonPatternDrops(oldToolPoison, rules.ConvertToolPoison(newToolPoison)) {
+		drop := coverageDropForBundle(dropsByBundle, dropped.Bundle)
+		drop.ToolPoison++
+	}
+	drops := make([]bundleCoverageDrop, 0, len(dropsByBundle))
+	for _, drop := range dropsByBundle {
+		drops = append(drops, *drop)
+	}
+	sort.Slice(drops, func(i, j int) bool {
+		return drops[i].Name < drops[j].Name
+	})
+	return drops
+}
+
+func coverageDropForBundle(drops map[string]*bundleCoverageDrop, name string) *bundleCoverageDrop {
+	drop := drops[name]
+	if drop == nil {
+		drop = &bundleCoverageDrop{Name: name}
+		drops[name] = drop
+	}
+	return drop
+}
+
+func appendBundleDropNames(base []string, drops []bundleCoverageDrop) []string {
+	seen := make(map[string]struct{}, len(base)+len(drops))
+	for _, name := range base {
+		if name != "" {
+			seen[name] = struct{}{}
+		}
+	}
+	for _, drop := range drops {
+		if drop.Name != "" {
+			seen[drop.Name] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func bundleCoverageDropSummary(drops []bundleCoverageDrop) string {
+	parts := make([]string, 0, len(drops))
+	for _, drop := range drops {
+		parts = append(parts, fmt.Sprintf("%s dropped %d pattern(s)", drop.Name, drop.Total()))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func filterAllowedRuleBundleCoverageWarnings(oldCfg, newCfg *config.Config, warnings []config.ReloadWarning) []config.ReloadWarning {
+	if len(warnings) == 0 {
+		return warnings
+	}
+	dlpBundleOnly := removedOrWeakenedDLPIsBundleOnly(oldCfg.DLP.Patterns, newCfg.DLP.Patterns)
+	responseBundleOnly := removedOrWeakenedResponseIsBundleOnly(oldCfg.ResponseScanning.Patterns, newCfg.ResponseScanning.Patterns)
+	filtered := make([]config.ReloadWarning, 0, len(warnings))
+	for _, w := range warnings {
+		switch w.Field {
+		case "dlp.patterns":
+			if dlpBundleOnly {
+				continue
+			}
+		case "sentry":
+			if dlpBundleOnly && strings.Contains(w.Message, "DLP patterns changed") {
+				continue
+			}
+		case "response_scanning.patterns":
+			if responseBundleOnly {
+				continue
+			}
+		}
+		filtered = append(filtered, w)
+	}
+	return filtered
+}
+
+func removedOrWeakenedDLPIsBundleOnly(old, updated []config.DLPPattern) bool {
+	return removedOrWeakenedIsBundleOnly(old, updated,
+		func(p config.DLPPattern) string { return p.Name },
+		func(p config.DLPPattern) string { return p.Regex },
+		func(p config.DLPPattern) string { return p.Bundle })
+}
+
+func removedOrWeakenedResponseIsBundleOnly(old, updated []config.ResponseScanPattern) bool {
+	return removedOrWeakenedIsBundleOnly(old, updated,
+		func(p config.ResponseScanPattern) string { return p.Name },
+		func(p config.ResponseScanPattern) string { return p.Regex },
+		func(p config.ResponseScanPattern) string { return p.Bundle })
+}
+
+func removedOrWeakenedIsBundleOnly[T any](old, updated []T, nameOf, regexOf, bundleOf func(T) string) bool {
+	updatedByName := make(map[string]string, len(updated))
+	for _, p := range updated {
+		updatedByName[nameOf(p)] = regexOf(p)
+	}
+	var removedBundle, removedNonBundle bool
+	for _, p := range old {
+		name := nameOf(p)
+		updatedRegex, ok := updatedByName[name]
+		if ok && updatedRegex == regexOf(p) {
+			continue
+		}
+		if bundleOf(p) == "" {
+			removedNonBundle = true
+			continue
+		}
+		removedBundle = true
+	}
+	return removedBundle && !removedNonBundle
+}

--- a/internal/cli/runtime/server_rule_bundles.go
+++ b/internal/cli/runtime/server_rule_bundles.go
@@ -63,11 +63,13 @@ func (s *Server) reportStartupRuleBundleResult(cfg *config.Config, result *rules
 	if cfg.Mode != config.ModeStrict || cfg.Rules.AllowDegraded {
 		return nil
 	}
-	for _, e := range result.Errors {
-		if e.ClassOrDefault() == rules.BundleErrorClassIntegrity {
-			return fmt.Errorf("rule bundle integrity failure in strict mode: bundle %s failed with class %s: %s (verify or reinstall the bundle, or set rules.allow_degraded: true only as an emergency override)",
-				e.Name, e.ClassOrDefault(), e.Reason)
+	if integrityErrs := result.IntegrityErrors(); len(integrityErrs) > 0 {
+		details := make([]string, 0, len(integrityErrs))
+		for _, e := range integrityErrs {
+			details = append(details, fmt.Sprintf("%s: %s", e.Name, e.Reason))
 		}
+		return fmt.Errorf("rule bundle integrity failure in strict mode: %s (verify or reinstall the bundle(s), or set rules.allow_degraded: true only as an emergency override)",
+			strings.Join(details, "; "))
 	}
 	return nil
 }

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1937,6 +1937,8 @@ func TestReportStartupRuleBundleResultAggregatesStrictIntegrityFailures(t *testi
 			{Name: "bundle-a", Reason: "hash mismatch", Class: rules.BundleErrorClassIntegrity},
 			{Name: "bundle-b", Reason: "expired", Class: rules.BundleErrorClassIntegrity},
 			{Name: "bundle-c", Reason: "requires future feature", Class: rules.BundleErrorClassAvailability},
+			// Zero-value classes preserve older availability semantics.
+			{Name: "bundle-legacy", Reason: "legacy zero-value class"},
 		},
 		Degraded: true,
 	}
@@ -1951,13 +1953,15 @@ func TestReportStartupRuleBundleResultAggregatesStrictIntegrityFailures(t *testi
 			t.Fatalf("error = %q, want %q", msg, want)
 		}
 	}
-	if strings.Contains(msg, "bundle-c") {
-		t.Fatalf("error = %q, should not include availability-only failure", msg)
+	for _, wantNot := range []string{"bundle-c", "bundle-legacy"} {
+		if strings.Contains(msg, wantNot) {
+			t.Fatalf("error = %q, should not include availability-only failure %q", msg, wantNot)
+		}
 	}
-	if got := cfg.Rules.DegradedBundles; !reflect.DeepEqual(got, []string{"bundle-a", "bundle-b", "bundle-c"}) {
+	if got := cfg.Rules.DegradedBundles; !reflect.DeepEqual(got, []string{"bundle-a", "bundle-b", "bundle-c", "bundle-legacy"}) {
 		t.Fatalf("degraded bundles = %+v, want all degraded names", got)
 	}
-	for _, want := range []string{"bundle bundle-a degraded", "bundle bundle-b degraded", "bundle bundle-c degraded"} {
+	for _, want := range []string{"bundle bundle-a degraded", "bundle bundle-b degraded", "bundle bundle-c degraded", "bundle bundle-legacy degraded"} {
 		if !buf.contains(want) {
 			t.Fatalf("stderr missing %q:\n%s", want, buf.String())
 		}

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	mcptools "github.com/luckyPipewrench/pipelock/internal/mcp/tools"
@@ -1063,8 +1064,9 @@ func TestNewServer_StrictStartupRejectsMissingBundleLockfile(t *testing.T) {
 	if err == nil {
 		t.Fatal("strict startup with missing bundle lockfile should fail closed")
 	}
-	if !strings.Contains(err.Error(), "class integrity") || !strings.Contains(err.Error(), rules.StandardBundleName) {
-		t.Fatalf("error = %v, want integrity class naming bundle", err)
+	if !strings.Contains(err.Error(), "rule bundle integrity failure in strict mode") ||
+		!strings.Contains(err.Error(), rules.StandardBundleName+": reading lock file") {
+		t.Fatalf("error = %v, want strict integrity failure naming missing lockfile", err)
 	}
 }
 
@@ -1090,8 +1092,9 @@ func TestNewServer_StrictStartupRejectsMissingBundleManifest(t *testing.T) {
 	if err == nil {
 		t.Fatal("strict startup with missing installed bundle manifest should fail closed")
 	}
-	if !strings.Contains(err.Error(), "class integrity") || !strings.Contains(err.Error(), rules.StandardBundleName) {
-		t.Fatalf("error = %v, want integrity class naming bundle", err)
+	if !strings.Contains(err.Error(), "rule bundle integrity failure in strict mode") ||
+		!strings.Contains(err.Error(), rules.StandardBundleName+": stat bundle file") {
+		t.Fatalf("error = %v, want strict integrity failure naming missing manifest", err)
 	}
 	if !buf.contains("SECURITY WARNING: rule bundle " + rules.StandardBundleName + " degraded (integrity)") {
 		t.Fatalf("stderr missing integrity degradation warning:\n%s", buf.String())
@@ -1920,6 +1923,147 @@ func TestServer_Reload_StrictAllowDegradedAcceptsCleanBundleRemoval(t *testing.T
 	}
 }
 
+func TestReportStartupRuleBundleResultAggregatesStrictIntegrityFailures(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Mode = config.ModeStrict
+	buf := &syncBuffer{}
+	s := &Server{
+		opts:    ServerOpts{Stderr: buf},
+		logger:  audit.NewNop(),
+		metrics: metrics.New(),
+	}
+	result := &rules.LoadResult{
+		Errors: []rules.BundleError{
+			{Name: "bundle-a", Reason: "hash mismatch", Class: rules.BundleErrorClassIntegrity},
+			{Name: "bundle-b", Reason: "expired", Class: rules.BundleErrorClassIntegrity},
+			{Name: "bundle-c", Reason: "requires future feature", Class: rules.BundleErrorClassAvailability},
+		},
+		Degraded: true,
+	}
+
+	err := s.reportStartupRuleBundleResult(cfg, result)
+	if err == nil {
+		t.Fatal("strict startup should reject integrity failures")
+	}
+	msg := err.Error()
+	for _, want := range []string{"bundle-a: hash mismatch", "bundle-b: expired"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error = %q, want %q", msg, want)
+		}
+	}
+	if strings.Contains(msg, "bundle-c") {
+		t.Fatalf("error = %q, should not include availability-only failure", msg)
+	}
+	if got := cfg.Rules.DegradedBundles; !reflect.DeepEqual(got, []string{"bundle-a", "bundle-b", "bundle-c"}) {
+		t.Fatalf("degraded bundles = %+v, want all degraded names", got)
+	}
+	for _, want := range []string{"bundle bundle-a degraded", "bundle bundle-b degraded", "bundle bundle-c degraded"} {
+		if !buf.contains(want) {
+			t.Fatalf("stderr missing %q:\n%s", want, buf.String())
+		}
+	}
+}
+
+func TestReportStartupRuleBundleResultNilWarningsAndAllowDegraded(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Mode = config.ModeStrict
+	cfg.Rules.AllowDegraded = true
+	buf := &syncBuffer{}
+	s := &Server{
+		opts:    ServerOpts{Stderr: buf},
+		logger:  audit.NewNop(),
+		metrics: metrics.New(),
+	}
+	if err := s.reportStartupRuleBundleResult(cfg, nil); err != nil {
+		t.Fatalf("nil startup bundle result error = %v, want nil", err)
+	}
+
+	err := s.reportStartupRuleBundleResult(cfg, &rules.LoadResult{
+		Errors: []rules.BundleError{
+			{Name: "integrity-bundle", Reason: "hash mismatch", Class: rules.BundleErrorClassIntegrity},
+		},
+		Warnings: []string{"expired soon"},
+		Degraded: true,
+	})
+	if err != nil {
+		t.Fatalf("allow-degraded strict startup error = %v, want nil", err)
+	}
+	for _, want := range []string{
+		"pipelock: expired soon",
+		"strict mode is booting with degraded rule-bundle integrity",
+	} {
+		if !buf.contains(want) {
+			t.Fatalf("stderr missing %q:\n%s", want, buf.String())
+		}
+	}
+}
+
+func TestReportReloadRuleBundleResultNilWarningsAndDegraded(t *testing.T) {
+	cfg := config.Defaults()
+	buf := &syncBuffer{}
+	reportReloadRuleBundleResult(buf, audit.NewNop(), cfg, nil)
+	if got := buf.String(); got != "" {
+		t.Fatalf("nil reload bundle result wrote %q, want empty", got)
+	}
+
+	reportReloadRuleBundleResult(buf, audit.NewNop(), cfg, &rules.LoadResult{
+		Errors: []rules.BundleError{
+			{Name: "community-rules", Reason: "bundle expired", Class: rules.BundleErrorClassAvailability},
+		},
+		Warnings: []string{"signature expires soon"},
+		Degraded: true,
+	})
+	for _, want := range []string{
+		"WARNING: config reload: rule bundle community-rules degraded (availability): bundle expired",
+		"WARNING: config reload: signature expires soon",
+		"WARNING: config reload: DEGRADED — 1 rule bundle(s) unavailable: community-rules",
+	} {
+		if !buf.contains(want) {
+			t.Fatalf("stderr missing %q:\n%s", want, buf.String())
+		}
+	}
+}
+
+func TestRuleBundleStateHelpersNilAndDropSummaries(t *testing.T) {
+	applyDegradedRuleBundleState(nil, []string{"ignored"})
+	publishDegradedRuleBundleMetrics(nil, config.Defaults())
+	publishDegradedRuleBundleMetrics(metrics.New(), nil)
+
+	cfg := config.Defaults()
+	applyDegradedRuleBundleState(cfg, []string{"z-bundle", "a-bundle"})
+	if got := strings.Join(cfg.Rules.DegradedBundles, ","); got != "a-bundle,z-bundle" {
+		t.Fatalf("degraded bundles = %q, want sorted names", got)
+	}
+
+	oldCfg := config.Defaults()
+	oldCfg.DLP.Patterns = []config.DLPPattern{
+		{Name: "dlp-z", Regex: "secret-z", Severity: config.SeverityHigh, Bundle: "z-bundle"},
+	}
+	newCfg := oldCfg.Clone()
+	newCfg.DLP.Patterns = nil
+	oldCfg.ResponseScanning.Patterns = []config.ResponseScanPattern{
+		{Name: "response-a", Regex: "old", Bundle: "a-bundle"},
+	}
+	newCfg.ResponseScanning.Patterns = []config.ResponseScanPattern{
+		{Name: "response-a", Regex: "new", Bundle: "a-bundle"},
+	}
+	drops := cleanBundleCoverageDrops(oldCfg, newCfg, []*mcptools.ExtraPoisonPattern{
+		{Name: "tool-m", Bundle: "m-bundle", ScanField: "description"},
+	}, nil)
+	if got := bundleCoverageDropSummary(drops); got != "a-bundle dropped 1 pattern(s), m-bundle dropped 1 pattern(s), z-bundle dropped 1 pattern(s)" {
+		t.Fatalf("drop summary = %q, want sorted per-bundle summary", got)
+	}
+	if got := strings.Join(appendBundleDropNames([]string{"z-bundle", ""}, []bundleCoverageDrop{
+		{Name: ""},
+		{Name: "a-bundle"},
+	}), ","); got != "a-bundle,z-bundle" {
+		t.Fatalf("appended drop names = %q, want sorted de-duped non-empty names", got)
+	}
+	if got := cleanBundleCoverageDrops(nil, newCfg, nil, nil); got != nil {
+		t.Fatalf("nil old config drops = %+v, want nil", got)
+	}
+}
+
 func TestServer_Reload_StrictRejectsCleanToolPoisonDropWithUnrelatedBundleError(t *testing.T) {
 	xdgDataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", xdgDataHome)
@@ -2341,6 +2485,31 @@ func TestFilterAllowedRuleBundleCoverageWarningsKeepsLocalDLPWeakening(t *testin
 	filtered := filterAllowedRuleBundleCoverageWarnings(oldCfg, newCfg, warnings)
 	if len(filtered) != len(warnings) {
 		t.Fatalf("filtered warnings = %+v, want local DLP weakening warnings preserved", filtered)
+	}
+}
+
+func TestFilterAllowedRuleBundleCoverageWarningsKeepsLocalResponseWeakening(t *testing.T) {
+	oldCfg := config.Defaults()
+	newCfg := oldCfg.Clone()
+	warnings := []config.ReloadWarning(nil)
+	if got := filterAllowedRuleBundleCoverageWarnings(oldCfg, newCfg, warnings); got != nil {
+		t.Fatalf("nil warnings filtered to %+v, want nil", got)
+	}
+
+	oldCfg.ResponseScanning.Patterns = []config.ResponseScanPattern{
+		{Name: "bundle-response", Regex: "bundle-response", Bundle: "community-response"},
+		{Name: "local-response", Regex: "local-response"},
+	}
+	newCfg.ResponseScanning.Patterns = []config.ResponseScanPattern{
+		{Name: "local-response", Regex: "weakened-local-response"},
+	}
+	warnings = []config.ReloadWarning{
+		{Field: "response_scanning.patterns", Message: "response patterns changed from 2 to 1"},
+	}
+
+	filtered := filterAllowedRuleBundleCoverageWarnings(oldCfg, newCfg, warnings)
+	if len(filtered) != len(warnings) {
+		t.Fatalf("filtered warnings = %+v, want local response weakening warning preserved", filtered)
 	}
 }
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -190,6 +190,74 @@ rules: []
 	}
 }
 
+func installServerTestUnavailableFeatureBundle(t *testing.T, xdgDataHome string) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate unavailable bundle signing key: %v", err)
+	}
+	oldKeyring := rules.KeyringHex
+	rules.KeyringHex = strings.Join(nonEmptyStrings(oldKeyring, hex.EncodeToString(pub)), ",")
+	t.Cleanup(func() {
+		rules.KeyringHex = oldKeyring
+	})
+
+	bundleDir := filepath.Join(xdgDataHome, "pipelock", "rules", "needs-future-engine")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("mkdir unavailable bundle dir: %v", err)
+	}
+	bundleYAML := `format_version: 2
+name: needs-future-engine
+version: "2026.07.0"
+author: Test Author
+description: Test availability-failing bundle
+license: Apache-2.0
+tier: community
+monotonic_version: 1
+published_at: "2026-04-01T00:00:00Z"
+expires_at: "2027-04-01T00:00:00Z"
+key_id: ` + rules.KeyFingerprint(pub) + `
+required_features:
+  - dlp
+  - quantum_crypto
+rules:
+  - id: dlp-future-secret
+    type: dlp
+    status: stable
+    name: Future Secret
+    description: Requires a future engine feature
+    severity: critical
+    confidence: high
+    pattern:
+      regex: 'future-secret-[0-9]+'
+`
+	bundlePath := filepath.Join(bundleDir, "bundle.yaml")
+	if err := os.WriteFile(bundlePath, []byte(bundleYAML), 0o600); err != nil {
+		t.Fatalf("write unavailable bundle.yaml: %v", err)
+	}
+	sig, err := signing.SignFile(bundlePath, priv)
+	if err != nil {
+		t.Fatalf("sign unavailable bundle.yaml: %v", err)
+	}
+	sigPath := bundlePath + signing.SigExtension
+	if err := signing.SaveSignature(sig, sigPath); err != nil {
+		t.Fatalf("save unavailable bundle signature: %v", err)
+	}
+	if err := os.Chmod(sigPath, 0o600); err != nil {
+		t.Fatalf("chmod unavailable bundle signature: %v", err)
+	}
+	sum := sha256.Sum256([]byte(bundleYAML))
+	if err := rules.WriteLockFile(filepath.Join(bundleDir, "bundle.lock"), &rules.LockFile{
+		InstalledVersion:  "2026.07.0",
+		Source:            "test",
+		BundleSHA256:      hex.EncodeToString(sum[:]),
+		SignerFingerprint: rules.KeyFingerprint(pub),
+	}); err != nil {
+		t.Fatalf("write unavailable bundle.lock: %v", err)
+	}
+}
+
 func installServerTestDLPBundle(t *testing.T, xdgDataHome, validator string) string {
 	t.Helper()
 
@@ -1852,6 +1920,55 @@ func TestServer_Reload_StrictAllowDegradedAcceptsCleanBundleRemoval(t *testing.T
 	}
 }
 
+func TestServer_Reload_StrictRejectsCleanToolPoisonDropWithUnrelatedBundleError(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	bundleDir := installServerTestToolPoisonBundle(t, xdgDataHome)
+	installServerTestUnavailableFeatureBundle(t, xdgDataHome)
+
+	s, buf := newTestServer(t, func(o *ServerOpts) {
+		o.Mode = config.ModeStrict
+		o.ModeChanged = true
+	})
+	oldLive := s.proxy.CurrentConfig()
+	oldScanner := s.proxy.ScannerPtr().Load()
+	oldPoison := s.currentMCPToolExtraPoison()
+	if len(oldPoison) != 1 || oldPoison[0].Name != "community-tool-poison:tool-poison-shell" {
+		t.Fatalf("live tool-poison patterns = %+v, want installed bundle pattern", oldPoison)
+	}
+	if err := os.RemoveAll(bundleDir); err != nil {
+		t.Fatalf("remove clean tool-poison bundle: %v", err)
+	}
+	buf.reset()
+
+	reloaded := config.Defaults()
+	reloaded.Mode = config.ModeStrict
+	reloaded.KillSwitch.APIToken = "should-not-activate-with-unrelated-bundle-error"
+	err := s.Reload(reloaded)
+	if err == nil {
+		t.Fatal("strict reload should reject clean tool-poison drop even with an unrelated bundle error")
+	}
+	if !strings.Contains(err.Error(), "strict mode rule bundle coverage drop") ||
+		!strings.Contains(err.Error(), "community-tool-poison") {
+		t.Fatalf("error = %q, want strict clean tool-poison coverage-drop rejection", err.Error())
+	}
+	if s.proxy.CurrentConfig() != oldLive {
+		t.Fatal("live config pointer changed after rejected mixed bundle reload")
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("scanner swapped despite rejected mixed bundle reload")
+	}
+	if live := s.proxy.CurrentConfig(); live.KillSwitch.APIToken == "should-not-activate-with-unrelated-bundle-error" {
+		t.Fatal("rejected mixed bundle reload activated unrelated config edit")
+	}
+	if got := s.currentMCPToolExtraPoison(); len(got) != 1 || got[0].Name != oldPoison[0].Name {
+		t.Fatalf("tool-poison patterns after rejection = %+v, want preserved bundle pattern", got)
+	}
+	if !buf.contains("needs-future-engine") || !buf.contains("cleanly removed") {
+		t.Fatalf("stderr missing unrelated bundle error and clean removal warning:\n%s", buf.String())
+	}
+}
+
 func TestServer_Reload_StrictBundleResolutionErrorStillUsesStrictDowngradeGate(t *testing.T) {
 	xdgDataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", xdgDataHome)
@@ -2190,6 +2307,40 @@ func TestServer_Reload_StrictWithRuleBundleRejectsResponsePatternRemoval(t *test
 	}
 	if !buf.contains("response_scanning.patterns") {
 		t.Fatalf("stderr missing response pattern downgrade warning:\n%s", buf.String())
+	}
+}
+
+func TestFilterAllowedRuleBundleCoverageWarningsKeepsLocalDLPWeakening(t *testing.T) {
+	oldCfg := config.Defaults()
+	oldCfg.DLP.Patterns = []config.DLPPattern{
+		{
+			Name:     "bundle-secret",
+			Regex:    "bundle-secret-[0-9]+",
+			Severity: config.SeverityCritical,
+			Bundle:   "community-dlp",
+		},
+		{
+			Name:     "local-secret",
+			Regex:    "local-secret-[0-9]+",
+			Severity: config.SeverityCritical,
+		},
+	}
+	newCfg := oldCfg.Clone()
+	newCfg.DLP.Patterns = []config.DLPPattern{
+		{
+			Name:     "local-secret",
+			Regex:    "local-secret-[0-9]+",
+			Severity: config.SeverityLow,
+		},
+	}
+	warnings := []config.ReloadWarning{
+		{Field: "dlp.patterns", Message: "DLP patterns changed from 2 to 1"},
+		{Field: "sentry", Message: "DLP patterns changed under Sentry coverage"},
+	}
+
+	filtered := filterAllowedRuleBundleCoverageWarnings(oldCfg, newCfg, warnings)
+	if len(filtered) != len(warnings) {
+		t.Fatalf("filtered warnings = %+v, want local DLP weakening warnings preserved", filtered)
 	}
 }
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -9,8 +9,11 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -128,6 +131,13 @@ func installServerTestToolPoisonBundle(t *testing.T, xdgDataHome string) string 
 	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
 		t.Fatalf("mkdir tool-poison bundle dir: %v", err)
 	}
+	writeServerTestToolPoisonBundle(t, bundleDir, "test-tool-poison")
+	return bundleDir
+}
+
+func writeServerTestToolPoisonBundle(t *testing.T, bundleDir, regex string) {
+	t.Helper()
+
 	bundleYAML := `format_version: 1
 name: community-tool-poison
 version: "2026.07.0"
@@ -143,7 +153,7 @@ rules:
     severity: critical
     confidence: high
     pattern:
-      regex: 'test-tool-poison'
+      regex: '` + regex + `'
       scan_field: description
 `
 	bundlePath := filepath.Join(bundleDir, "bundle.yaml")
@@ -159,7 +169,6 @@ rules:
 	}); err != nil {
 		t.Fatalf("write tool-poison bundle.lock: %v", err)
 	}
-	return bundleDir
 }
 
 func installServerTestBrokenBundle(t *testing.T, xdgDataHome string) {
@@ -179,6 +188,124 @@ rules: []
 `), 0o600); err != nil {
 		t.Fatalf("write broken bundle.yaml: %v", err)
 	}
+}
+
+func installServerTestDLPBundle(t *testing.T, xdgDataHome, validator string) string {
+	t.Helper()
+
+	bundleDir := filepath.Join(xdgDataHome, "pipelock", "rules", "community-dlp")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("mkdir DLP bundle dir: %v", err)
+	}
+	writeServerTestDLPBundle(t, bundleDir, validator)
+	return bundleDir
+}
+
+func writeServerTestDLPBundle(t *testing.T, bundleDir, validator string) {
+	t.Helper()
+
+	var validatorLine string
+	if validator != "" {
+		validatorLine = "      validator: " + validator + "\n"
+	}
+	bundleYAML := `format_version: 1
+name: community-dlp
+version: "2026.07.0"
+author: Test Author
+description: Test DLP bundle
+license: Apache-2.0
+rules:
+  - id: dlp-secret
+    type: dlp
+    status: stable
+    name: Test Bundle Secret
+    description: Detects test bundle secrets
+    severity: critical
+    confidence: high
+    pattern:
+      regex: 'test-secret-[0-9]+'
+` + validatorLine
+	bundlePath := filepath.Join(bundleDir, "bundle.yaml")
+	if err := os.WriteFile(bundlePath, []byte(bundleYAML), 0o600); err != nil {
+		t.Fatalf("write DLP bundle.yaml: %v", err)
+	}
+	sum := sha256.Sum256([]byte(bundleYAML))
+	if err := rules.WriteLockFile(filepath.Join(bundleDir, "bundle.lock"), &rules.LockFile{
+		InstalledVersion: "2026.07.0",
+		Source:           "test",
+		BundleSHA256:     hex.EncodeToString(sum[:]),
+		Unsigned:         true,
+	}); err != nil {
+		t.Fatalf("write DLP bundle.lock: %v", err)
+	}
+}
+
+type serverTestWebhookEvent struct {
+	Severity string         `json:"severity"`
+	Type     string         `json:"type"`
+	Fields   map[string]any `json:"fields"`
+}
+
+func newServerTestWebhook(t *testing.T) (string, <-chan serverTestWebhookEvent) {
+	t.Helper()
+	events := make(chan serverTestWebhookEvent, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("webhook method = %s, want POST", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var event serverTestWebhookEvent
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			t.Errorf("decode webhook event: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		events <- event
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, events
+}
+
+func waitForRuleBundleWebhookEvent(t *testing.T, events <-chan serverTestWebhookEvent) serverTestWebhookEvent {
+	t.Helper()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case event := <-events:
+			if event.Type == "rule_bundle_degraded" {
+				return event
+			}
+		case <-timer.C:
+			t.Fatal("timed out waiting for rule_bundle_degraded webhook event")
+		}
+	}
+}
+
+func writeServerTestConfigWithWebhook(t *testing.T, webhookURL, mode string, allowDegraded bool) string {
+	t.Helper()
+	var allowLine string
+	if allowDegraded {
+		allowLine = "  allow_degraded: true\n"
+	}
+	return writeServerTestConfig(t, strings.Join([]string{
+		"version: 1",
+		"mode: " + mode,
+		"api_allowlist:",
+		"  - api.vendor.example",
+		"rules:",
+		"  min_confidence: medium",
+		strings.TrimSuffix(allowLine, "\n"),
+		"emit:",
+		"  webhook:",
+		"    url: " + strconv.Quote(webhookURL),
+		"    min_severity: warn",
+		"    timeout_seconds: 5",
+		"    queue_size: 16",
+		"",
+	}, "\n"))
 }
 
 func nonEmptyStrings(values ...string) []string {
@@ -813,6 +940,138 @@ func TestNewServer_ResolveRuntimeRuns(t *testing.T) {
 	}
 }
 
+func TestNewServer_StrictStartupRejectsTamperedBundleSignature(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+
+	sigPath := filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName, "bundle.yaml"+signing.SigExtension)
+	if err := os.WriteFile(sigPath, []byte("not-a-valid-signature"), 0o600); err != nil {
+		t.Fatalf("tamper signature: %v", err)
+	}
+
+	buf := &syncBuffer{}
+	s, err := NewServer(ServerOpts{
+		Mode:                              config.ModeStrict,
+		ModeChanged:                       true,
+		Stdout:                            buf,
+		Stderr:                            buf,
+		allowEphemeralListenersForTesting: true,
+	})
+	if s != nil {
+		t.Cleanup(func() { s.cleanup() })
+	}
+	if err == nil {
+		t.Fatal("strict startup with tampered bundle signature should fail closed")
+	}
+	if !strings.Contains(err.Error(), "rule bundle integrity failure in strict mode") ||
+		!strings.Contains(err.Error(), rules.StandardBundleName) {
+		t.Fatalf("error = %v, want strict integrity failure naming bundle", err)
+	}
+	if !buf.contains("SECURITY WARNING: rule bundle " + rules.StandardBundleName + " degraded (integrity)") {
+		t.Fatalf("stderr missing integrity degradation warning:\n%s", buf.String())
+	}
+}
+
+func TestNewServer_StrictStartupRejectsMissingBundleLockfile(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+	if err := os.Remove(filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName, "bundle.lock")); err != nil {
+		t.Fatalf("remove lockfile: %v", err)
+	}
+
+	buf := &syncBuffer{}
+	s, err := NewServer(ServerOpts{
+		Mode:                              config.ModeStrict,
+		ModeChanged:                       true,
+		Stdout:                            buf,
+		Stderr:                            buf,
+		allowEphemeralListenersForTesting: true,
+	})
+	if s != nil {
+		t.Cleanup(func() { s.cleanup() })
+	}
+	if err == nil {
+		t.Fatal("strict startup with missing bundle lockfile should fail closed")
+	}
+	if !strings.Contains(err.Error(), "class integrity") || !strings.Contains(err.Error(), rules.StandardBundleName) {
+		t.Fatalf("error = %v, want integrity class naming bundle", err)
+	}
+}
+
+func TestNewServer_StrictStartupRejectsMissingBundleManifest(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+	if err := os.Remove(filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName, "bundle.yaml")); err != nil {
+		t.Fatalf("remove bundle.yaml: %v", err)
+	}
+
+	buf := &syncBuffer{}
+	s, err := NewServer(ServerOpts{
+		Mode:                              config.ModeStrict,
+		ModeChanged:                       true,
+		Stdout:                            buf,
+		Stderr:                            buf,
+		allowEphemeralListenersForTesting: true,
+	})
+	if s != nil {
+		t.Cleanup(func() { s.cleanup() })
+	}
+	if err == nil {
+		t.Fatal("strict startup with missing installed bundle manifest should fail closed")
+	}
+	if !strings.Contains(err.Error(), "class integrity") || !strings.Contains(err.Error(), rules.StandardBundleName) {
+		t.Fatalf("error = %v, want integrity class naming bundle", err)
+	}
+	if !buf.contains("SECURITY WARNING: rule bundle " + rules.StandardBundleName + " degraded (integrity)") {
+		t.Fatalf("stderr missing integrity degradation warning:\n%s", buf.String())
+	}
+}
+
+func TestNewServer_StrictAllowDegradedBootsAndEmitsRuleBundleAudit(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+	if err := os.Remove(filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName, "bundle.lock")); err != nil {
+		t.Fatalf("remove lockfile: %v", err)
+	}
+	webhookURL, events := newServerTestWebhook(t)
+	cfgPath := writeServerTestConfigWithWebhook(t, webhookURL, config.ModeStrict, true)
+
+	buf := &syncBuffer{}
+	s, err := NewServer(ServerOpts{
+		ConfigFile:                        cfgPath,
+		Stdout:                            buf,
+		Stderr:                            buf,
+		allowEphemeralListenersForTesting: true,
+	})
+	if err != nil {
+		t.Fatalf("NewServer with allow_degraded should boot degraded: %v", err)
+	}
+	t.Cleanup(func() { s.cleanup() })
+
+	event := waitForRuleBundleWebhookEvent(t, events)
+	if event.Severity != config.SeverityWarn {
+		t.Fatalf("webhook severity = %q, want %q", event.Severity, config.SeverityWarn)
+	}
+	if event.Fields["bundle"] != rules.StandardBundleName || event.Fields["failure_class"] != string(rules.BundleErrorClassIntegrity) {
+		t.Fatalf("webhook fields = %+v, want bundle integrity event", event.Fields)
+	}
+	if got := s.cfg.Rules.DegradedBundles; !reflect.DeepEqual(got, []string{rules.StandardBundleName}) {
+		t.Fatalf("degraded bundles = %+v, want standard bundle", got)
+	}
+	rec := httptest.NewRecorder()
+	s.metrics.PrometheusHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
+	if !strings.Contains(rec.Body.String(), "pipelock_rule_bundles_degraded 1") {
+		t.Fatalf("metrics missing degraded bundle gauge:\n%s", rec.Body.String())
+	}
+	if !buf.contains("rules.allow_degraded=true") {
+		t.Fatalf("stderr missing allow_degraded warning:\n%s", buf.String())
+	}
+}
+
 // TestServer_StartShutdown verifies that Start blocks, Shutdown releases
 // it, and Start returns nil on clean shutdown. Uses an ephemeral listen
 // address so nothing conflicts with a developer's already-running
@@ -1433,6 +1692,166 @@ func TestServer_Reload_CleanBundleResolutionStillApplies(t *testing.T) {
 	requireBundlePatternSelected(t, live.DLP.Patterns, live.ResponseScanning.Patterns)
 }
 
+func TestServer_Reload_StrictCleanBundleRemovalRejectsAndKeepsRunningConfig(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+
+	s, buf := newTestServer(t, func(o *ServerOpts) {
+		o.Mode = config.ModeStrict
+		o.ModeChanged = true
+	})
+	oldLive := s.proxy.CurrentConfig()
+	oldScanner := s.proxy.ScannerPtr().Load()
+	requireBundlePatternSelected(t, oldLive.DLP.Patterns, oldLive.ResponseScanning.Patterns)
+
+	if err := os.RemoveAll(filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName)); err != nil {
+		t.Fatalf("remove standard bundle: %v", err)
+	}
+	buf.reset()
+
+	reloaded := config.Defaults()
+	reloaded.Mode = config.ModeStrict
+	reloaded.KillSwitch.APIToken = "should-not-activate-after-clean-removal"
+	err := s.Reload(reloaded)
+	if err == nil {
+		t.Fatal("strict reload after clean bundle removal should reject")
+	}
+	if !strings.Contains(err.Error(), "strict mode rule bundle coverage drop") ||
+		!strings.Contains(err.Error(), rules.StandardBundleName) {
+		t.Fatalf("error = %v, want strict bundle coverage-drop rejection", err)
+	}
+	if s.proxy.CurrentConfig() != oldLive {
+		t.Fatal("live config pointer changed after rejected clean bundle removal")
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("scanner swapped despite rejected clean bundle removal")
+	}
+	if live := s.proxy.CurrentConfig(); live.KillSwitch.APIToken == "should-not-activate-after-clean-removal" {
+		t.Fatal("rejected clean bundle removal activated unrelated config edit")
+	}
+	requireBundlePatternSelected(t, s.proxy.CurrentConfig().DLP.Patterns, s.proxy.CurrentConfig().ResponseScanning.Patterns)
+	if !buf.contains("cleanly removed") || !buf.contains(rules.StandardBundleName) {
+		t.Fatalf("stderr missing clean removal warning:\n%s", buf.String())
+	}
+}
+
+func TestServer_Reload_BalancedToStrictCleanBundleRemovalRejects(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+
+	s, _ := newTestServer(t, nil)
+	oldLive := s.proxy.CurrentConfig()
+	oldScanner := s.proxy.ScannerPtr().Load()
+	requireBundlePatternSelected(t, oldLive.DLP.Patterns, oldLive.ResponseScanning.Patterns)
+
+	if err := os.RemoveAll(filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName)); err != nil {
+		t.Fatalf("remove standard bundle: %v", err)
+	}
+
+	reloaded := config.Defaults()
+	reloaded.Mode = config.ModeStrict
+	reloaded.KillSwitch.APIToken = "should-not-activate-balanced-to-strict"
+	err := s.Reload(reloaded)
+	if err == nil {
+		t.Fatal("balanced-to-strict reload after clean bundle removal should reject")
+	}
+	if !strings.Contains(err.Error(), "strict mode rule bundle coverage drop") {
+		t.Fatalf("error = %v, want strict bundle coverage-drop rejection", err)
+	}
+	if s.proxy.CurrentConfig() != oldLive {
+		t.Fatal("live config pointer changed after rejected balanced-to-strict clean bundle removal")
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("scanner swapped despite rejected balanced-to-strict clean bundle removal")
+	}
+}
+
+func TestServer_Reload_BalancedCleanBundleRemovalAllowsAndEmitsAudit(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+	webhookURL, events := newServerTestWebhook(t)
+	cfgPath := writeServerTestConfigWithWebhook(t, webhookURL, config.ModeBalanced, false)
+
+	buf := &syncBuffer{}
+	s, err := NewServer(ServerOpts{
+		ConfigFile:                        cfgPath,
+		Stdout:                            buf,
+		Stderr:                            buf,
+		allowEphemeralListenersForTesting: true,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { s.cleanup() })
+	requireBundlePatternSelected(t, s.proxy.CurrentConfig().DLP.Patterns, s.proxy.CurrentConfig().ResponseScanning.Patterns)
+
+	if err := os.RemoveAll(filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName)); err != nil {
+		t.Fatalf("remove standard bundle: %v", err)
+	}
+	buf.reset()
+	reloaded := config.Defaults()
+	reloaded.KillSwitch.APIToken = "clean-removal-allowed"
+	if err := s.Reload(reloaded); err != nil {
+		t.Fatalf("balanced clean bundle removal should apply: %v", err)
+	}
+	if live := s.proxy.CurrentConfig(); live.KillSwitch.APIToken != "clean-removal-allowed" {
+		t.Fatalf("api token = %q, want reload to apply", live.KillSwitch.APIToken)
+	}
+	for _, p := range s.proxy.CurrentConfig().DLP.Patterns {
+		if p.Bundle == rules.StandardBundleName {
+			t.Fatalf("standard bundle DLP pattern still live after clean removal: %+v", p)
+		}
+	}
+	if got := s.proxy.CurrentConfig().Rules.DegradedBundles; !reflect.DeepEqual(got, []string{rules.StandardBundleName}) {
+		t.Fatalf("degraded bundles = %+v, want standard bundle", got)
+	}
+	event := waitForRuleBundleWebhookEvent(t, events)
+	if event.Fields["bundle"] != rules.StandardBundleName || event.Fields["failure_class"] != "coverage_drop" {
+		t.Fatalf("webhook fields = %+v, want coverage_drop for standard bundle", event.Fields)
+	}
+	if got, ok := event.Fields["dropped_patterns"].(float64); !ok || got != 2 {
+		t.Fatalf("dropped_patterns = %v (%T), want 2", event.Fields["dropped_patterns"], event.Fields["dropped_patterns"])
+	}
+	if !buf.contains("cleanly removed 2 live pattern") {
+		t.Fatalf("stderr missing clean removal count:\n%s", buf.String())
+	}
+}
+
+func TestServer_Reload_StrictAllowDegradedAcceptsCleanBundleRemoval(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	installServerTestStandardBundle(t, xdgDataHome, true)
+
+	s, buf := newTestServer(t, func(o *ServerOpts) {
+		o.Mode = config.ModeStrict
+		o.ModeChanged = true
+	})
+	if err := os.RemoveAll(filepath.Join(xdgDataHome, "pipelock", "rules", rules.StandardBundleName)); err != nil {
+		t.Fatalf("remove standard bundle: %v", err)
+	}
+	buf.reset()
+
+	reloaded := config.Defaults()
+	reloaded.Mode = config.ModeStrict
+	reloaded.Rules.AllowDegraded = true
+	reloaded.KillSwitch.APIToken = "strict-clean-removal-override"
+	if err := s.Reload(reloaded); err != nil {
+		t.Fatalf("strict allow_degraded clean bundle removal should apply: %v\nstderr:\n%s", err, buf.String())
+	}
+	if live := s.proxy.CurrentConfig(); live.KillSwitch.APIToken != "strict-clean-removal-override" {
+		t.Fatalf("api token = %q, want reload to apply", live.KillSwitch.APIToken)
+	}
+	if got := s.proxy.CurrentConfig().Rules.DegradedBundles; !reflect.DeepEqual(got, []string{rules.StandardBundleName}) {
+		t.Fatalf("degraded bundles = %+v, want standard bundle", got)
+	}
+	if !buf.contains("rules.allow_degraded=true") {
+		t.Fatalf("stderr missing allow_degraded reload warning:\n%s", buf.String())
+	}
+}
+
 func TestServer_Reload_StrictBundleResolutionErrorStillUsesStrictDowngradeGate(t *testing.T) {
 	xdgDataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", xdgDataHome)
@@ -1527,6 +1946,84 @@ func TestServer_Reload_BundleResolutionErrorRejectsToolPoisonCoverageDrop(t *tes
 	}
 	if got := s.currentMCPToolExtraPoison(); len(got) != 1 || got[0].Name != "community-tool-poison:tool-poison-shell" {
 		t.Fatalf("live tool-poison patterns after rejection = %+v, want preserved bundle pattern", got)
+	}
+}
+
+func TestServer_Reload_StrictRejectsCleanToolPoisonIdentityDrop(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	bundleDir := installServerTestToolPoisonBundle(t, xdgDataHome)
+
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.Mode = config.ModeStrict
+		o.ModeChanged = true
+	})
+	oldLive := s.proxy.CurrentConfig()
+	oldScanner := s.proxy.ScannerPtr().Load()
+	oldPoison := s.currentMCPToolExtraPoison()
+	if len(oldPoison) != 1 || oldPoison[0].Name != "community-tool-poison:tool-poison-shell" {
+		t.Fatalf("live tool-poison patterns = %+v, want installed bundle pattern", oldPoison)
+	}
+	writeServerTestToolPoisonBundle(t, bundleDir, "replacement-tool-poison")
+
+	reloaded := config.Defaults()
+	reloaded.Mode = config.ModeStrict
+	reloaded.KillSwitch.APIToken = "tool-poison-clean-replacement"
+	err := s.Reload(reloaded)
+	if err == nil {
+		t.Fatal("strict reload with clean tool-poison identity drop should reject")
+	}
+	if !strings.Contains(err.Error(), "strict mode rule bundle coverage drop") ||
+		!strings.Contains(err.Error(), "community-tool-poison") {
+		t.Fatalf("error = %q, want clean tool-poison coverage-drop rejection", err.Error())
+	}
+	if s.proxy.CurrentConfig() != oldLive {
+		t.Fatal("live config pointer changed after rejected clean tool-poison replacement")
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("scanner swapped despite rejected clean tool-poison replacement")
+	}
+	if got := s.currentMCPToolExtraPoison(); len(got) != 1 || got[0].Re.String() != oldPoison[0].Re.String() {
+		t.Fatalf("tool-poison patterns after rejection = %+v, want old regex %q", got, oldPoison[0].Re.String())
+	}
+}
+
+func TestServer_Reload_StrictRejectsCleanDLPValidatorDrop(t *testing.T) {
+	xdgDataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	bundleDir := installServerTestDLPBundle(t, xdgDataHome, "")
+
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.Mode = config.ModeStrict
+		o.ModeChanged = true
+	})
+	oldLive := s.proxy.CurrentConfig()
+	oldScanner := s.proxy.ScannerPtr().Load()
+	p, ok := dlpByName(oldLive.DLP.Patterns, "community-dlp:dlp-secret")
+	if !ok || p.Bundle != "community-dlp" || p.Validator != "" {
+		t.Fatalf("live DLP pattern = %+v ok=%v, want bundle pattern without validator", p, ok)
+	}
+	writeServerTestDLPBundle(t, bundleDir, config.ValidatorLuhn)
+
+	reloaded := config.Defaults()
+	reloaded.Mode = config.ModeStrict
+	reloaded.KillSwitch.APIToken = "dlp-validator-clean-replacement"
+	err := s.Reload(reloaded)
+	if err == nil {
+		t.Fatal("strict reload with clean DLP validator drop should reject")
+	}
+	if !strings.Contains(err.Error(), "strict mode rule bundle coverage drop") ||
+		!strings.Contains(err.Error(), "community-dlp") {
+		t.Fatalf("error = %q, want clean DLP coverage-drop rejection", err.Error())
+	}
+	if s.proxy.CurrentConfig() != oldLive {
+		t.Fatal("live config pointer changed after rejected clean DLP validator replacement")
+	}
+	if s.proxy.ScannerPtr().Load() != oldScanner {
+		t.Fatal("scanner swapped despite rejected clean DLP validator replacement")
+	}
+	if p, ok := dlpByName(s.proxy.CurrentConfig().DLP.Patterns, "community-dlp:dlp-secret"); !ok || p.Validator != "" {
+		t.Fatalf("DLP pattern after rejection = %+v ok=%v, want old no-validator pattern", p, ok)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12592,6 +12592,86 @@ func TestLoad_RulesIncludeExperimental_BooleanStates(t *testing.T) {
 	}
 }
 
+func TestLoad_RulesAllowDegraded_BooleanStates(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantVal bool
+	}{
+		{
+			name:    "omitted (no rules section)",
+			yaml:    "mode: balanced\n",
+			wantVal: false,
+		},
+		{
+			name:    "rules section but field omitted",
+			yaml:    "mode: balanced\nrules:\n  min_confidence: medium\n",
+			wantVal: false,
+		},
+		{
+			name:    "explicit null",
+			yaml:    "mode: balanced\nrules:\n  allow_degraded: null\n",
+			wantVal: false,
+		},
+		{
+			name:    "explicit false",
+			yaml:    "mode: balanced\nrules:\n  allow_degraded: false\n",
+			wantVal: false,
+		},
+		{
+			name:    "explicit true",
+			yaml:    "mode: balanced\nrules:\n  allow_degraded: true\n",
+			wantVal: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("unexpected Load error: %v", err)
+			}
+			if cfg.Rules.AllowDegraded != tt.wantVal {
+				t.Errorf("AllowDegraded = %v, want %v", cfg.Rules.AllowDegraded, tt.wantVal)
+			}
+		})
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("mode: balanced\nrules:\n  allow_degraded: false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := Load(path)
+	if err != nil {
+		t.Fatalf("first Load: %v", err)
+	}
+	if first.Rules.AllowDegraded {
+		t.Fatal("first load with explicit false should preserve false")
+	}
+	unchanged, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload without change: %v", err)
+	}
+	if unchanged.Rules.AllowDegraded != first.Rules.AllowDegraded {
+		t.Fatalf("reload without change AllowDegraded = %v, want %v", unchanged.Rules.AllowDegraded, first.Rules.AllowDegraded)
+	}
+	if err := os.WriteFile(path, []byte("mode: balanced\nrules:\n  allow_degraded: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload with change: %v", err)
+	}
+	if !changed.Rules.AllowDegraded {
+		t.Fatal("reload with change should observe allow_degraded=true")
+	}
+}
+
 func TestValidate_RulesDisabledFormat_Tightened(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -199,8 +199,10 @@ type Rules struct {
 	RulesDir            string       `yaml:"rules_dir"`
 	MinConfidence       string       `yaml:"min_confidence"`
 	IncludeExperimental bool         `yaml:"include_experimental"`
+	AllowDegraded       bool         `yaml:"allow_degraded" json:"-"`
 	Disabled            []string     `yaml:"disabled"`
 	TrustedKeys         []TrustedKey `yaml:"trusted_keys"`
+	DegradedBundles     []string     `yaml:"-" json:"-"`
 }
 
 // TrustedKey is a named Ed25519 public key for verifying third-party bundles.

--- a/internal/emit/event.go
+++ b/internal/emit/event.go
@@ -143,6 +143,7 @@ const (
 	EventAirlockDeescalate   = "airlock_deescalate"
 	EventSessionAdmin        = "session_admin"
 	EventShieldRewrite       = "shield_rewrite"
+	EventRuleBundleDegraded  = "rule_bundle_degraded"
 )
 
 // instanceIDFallback is the default instance identifier when hostname lookup fails.
@@ -188,6 +189,7 @@ var EventSeverity = map[string]Severity{
 	EventMediaExposure:      SeverityWarn, // media reached agent; provenance signal for taint system
 	EventTextStego:          SeverityWarn, // suspicious combining-mark density; exposure signal
 	EventLicenseExpiry:      SeverityWarn, // overridden by caller with threshold-specific severity
+	EventRuleBundleDegraded: SeverityWarn, // overridden by caller for startup/reload rejection
 
 	// Info: normal operations
 	EventStartup:           SeverityInfo,

--- a/internal/emit/event_test.go
+++ b/internal/emit/event_test.go
@@ -95,6 +95,7 @@ func TestEventSeverity_CoverExpectedTypes(t *testing.T) {
 		{EventMediaExposure, SeverityWarn},
 		{EventTextStego, SeverityWarn},
 		{EventLicenseExpiry, SeverityWarn},
+		{EventRuleBundleDegraded, SeverityWarn},
 
 		// Info
 		{EventStartup, SeverityInfo},
@@ -154,6 +155,7 @@ func TestEventSeverity_NoUnexpectedEntries(t *testing.T) {
 		EventMediaExposure:       true,
 		EventTextStego:           true,
 		EventLicenseExpiry:       true,
+		EventRuleBundleDegraded:  true,
 		EventStartup:             true,
 		EventShutdown:            true,
 		EventAllowed:             true,

--- a/internal/emit/filter.go
+++ b/internal/emit/filter.go
@@ -210,7 +210,8 @@ func eventTypeAction(eventType string) string {
 		EventAdaptiveUpgrade,
 		EventAnomaly,
 		EventTextStego,
-		EventLicenseExpiry:
+		EventLicenseExpiry,
+		EventRuleBundleDegraded:
 		return conventionActionWarn
 	case EventRedirect, EventToolRedirect:
 		return EventRedirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -182,7 +182,7 @@ type Metrics struct {
 	sessionAnomalyCount    int64
 	sessionEscalationCount int64
 	agentStats             map[string]*agentCounters
-	ruleBundleDegraded     []string
+	degradedRuleBundles    []string
 
 	// Cross-request exfiltration stats callback (for JSON /stats endpoint).
 	// Called on each /stats request to get live CEE state.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -157,6 +157,9 @@ type Metrics struct {
 	evidenceHealthFunc          func() (EvidenceHealthStats, bool)
 	evidenceCollector           *evidenceCollector
 
+	// Rule bundle loading state (rule_bundles.go).
+	ruleBundlesDegraded prometheus.Gauge
+
 	// Enterprise durable SIEM forwarder (siem_forwarder.go).
 	siemForwarderQueued      prometheus.Gauge
 	siemForwarderDelivered   prometheus.Counter
@@ -179,6 +182,7 @@ type Metrics struct {
 	sessionAnomalyCount    int64
 	sessionEscalationCount int64
 	agentStats             map[string]*agentCounters
+	ruleBundleDegraded     []string
 
 	// Cross-request exfiltration stats callback (for JSON /stats endpoint).
 	// Called on each /stats request to get live CEE state.
@@ -235,6 +239,7 @@ func New() *Metrics {
 	m.registerEnvelopeMetrics(reg)
 	m.registerReceiptMetrics(reg)
 	m.registerEvidenceMetrics(reg)
+	m.registerRuleBundleMetrics(reg)
 	m.registerSIEMForwarderMetrics(reg)
 
 	// Built-in Go runtime + process collectors. These expose

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -139,6 +139,9 @@ func TestStatsHandler(t *testing.T) {
 }
 
 func TestRuleBundleDegradedMetricsAndStats(t *testing.T) {
+	var nilMetrics *Metrics
+	nilMetrics.SetRuleBundlesDegraded([]string{"ignored"})
+
 	m := New()
 	m.SetRuleBundlesDegraded([]string{"z-bundle", "a-bundle"})
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -133,6 +133,52 @@ func TestStatsHandler(t *testing.T) {
 	if len(stats.Receipts.RequiredBlocks) != 0 {
 		t.Errorf("expected no required receipt blocks, got %v", stats.Receipts.RequiredBlocks)
 	}
+	if stats.RuleBundles.DegradedCount != 0 {
+		t.Errorf("expected no degraded rule bundles, got %v", stats.RuleBundles)
+	}
+}
+
+func TestRuleBundleDegradedMetricsAndStats(t *testing.T) {
+	m := New()
+	m.SetRuleBundlesDegraded([]string{"z-bundle", "a-bundle"})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil)
+	w := httptest.NewRecorder()
+	m.StatsHandler().ServeHTTP(w, req)
+
+	var stats statsResponse
+	if err := json.NewDecoder(w.Body).Decode(&stats); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+	if stats.RuleBundles.DegradedCount != 2 {
+		t.Fatalf("degraded count = %d, want 2", stats.RuleBundles.DegradedCount)
+	}
+	if got := strings.Join(stats.RuleBundles.DegradedNames, ","); got != "a-bundle,z-bundle" {
+		t.Fatalf("degraded names = %q, want sorted names", got)
+	}
+
+	metricsReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil)
+	metricsRec := httptest.NewRecorder()
+	m.PrometheusHandler().ServeHTTP(metricsRec, metricsReq)
+	if !strings.Contains(metricsRec.Body.String(), "pipelock_rule_bundles_degraded 2") {
+		t.Fatalf("metrics missing degraded gauge:\n%s", metricsRec.Body.String())
+	}
+
+	m.SetRuleBundlesDegraded(nil)
+	clearRec := httptest.NewRecorder()
+	m.StatsHandler().ServeHTTP(clearRec, req)
+	var cleared statsResponse
+	if err := json.NewDecoder(clearRec.Body).Decode(&cleared); err != nil {
+		t.Fatalf("decode cleared stats: %v", err)
+	}
+	if cleared.RuleBundles.DegradedCount != 0 || len(cleared.RuleBundles.DegradedNames) != 0 {
+		t.Fatalf("cleared degraded stats = %+v, want empty", cleared.RuleBundles)
+	}
+	clearMetricsRec := httptest.NewRecorder()
+	m.PrometheusHandler().ServeHTTP(clearMetricsRec, metricsReq)
+	if !strings.Contains(clearMetricsRec.Body.String(), "pipelock_rule_bundles_degraded 0") {
+		t.Fatalf("metrics gauge did not clear:\n%s", clearMetricsRec.Body.String())
+	}
 }
 
 func TestStatsHandler_BlockRate(t *testing.T) {

--- a/internal/metrics/rule_bundles.go
+++ b/internal/metrics/rule_bundles.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"sort"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// RuleBundleStats reports rule-bundle degradation visible through /stats.
+type RuleBundleStats struct {
+	DegradedCount int      `json:"degraded_count"`
+	DegradedNames []string `json:"degraded_names,omitempty"`
+}
+
+func (m *Metrics) registerRuleBundleMetrics(reg *prometheus.Registry) {
+	m.ruleBundlesDegraded = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "pipelock_rule_bundles_degraded",
+		Help: "Number of rule bundles whose live coverage is degraded due to load errors or clean removal.",
+	})
+	reg.MustRegister(m.ruleBundlesDegraded)
+}
+
+// SetRuleBundlesDegraded publishes the current degraded rule-bundle names.
+func (m *Metrics) SetRuleBundlesDegraded(names []string) {
+	if m == nil {
+		return
+	}
+	copied := append([]string(nil), names...)
+	sort.Strings(copied)
+	m.mu.Lock()
+	m.ruleBundleDegraded = copied
+	m.mu.Unlock()
+	if m.ruleBundlesDegraded != nil {
+		m.ruleBundlesDegraded.Set(float64(len(copied)))
+	}
+}

--- a/internal/metrics/rule_bundles.go
+++ b/internal/metrics/rule_bundles.go
@@ -31,7 +31,7 @@ func (m *Metrics) SetRuleBundlesDegraded(names []string) {
 	copied := append([]string(nil), names...)
 	sort.Strings(copied)
 	m.mu.Lock()
-	m.ruleBundleDegraded = copied
+	m.degradedRuleBundles = copied
 	m.mu.Unlock()
 	if m.ruleBundlesDegraded != nil {
 		m.ruleBundlesDegraded.Set(float64(len(copied)))

--- a/internal/metrics/stats_handler.go
+++ b/internal/metrics/stats_handler.go
@@ -46,8 +46,8 @@ func (m *Metrics) StatsHandler() http.HandlerFunc {
 				RequiredBlocks: topRequiredReceiptBlocks(m.requiredReceiptBlocks),
 			},
 			RuleBundles: RuleBundleStats{
-				DegradedCount: len(m.ruleBundleDegraded),
-				DegradedNames: append([]string(nil), m.ruleBundleDegraded...),
+				DegradedCount: len(m.degradedRuleBundles),
+				DegradedNames: append([]string(nil), m.degradedRuleBundles...),
 			},
 		}
 		ceeFunc := m.CEEStatsFunc

--- a/internal/metrics/stats_handler.go
+++ b/internal/metrics/stats_handler.go
@@ -45,6 +45,10 @@ func (m *Metrics) StatsHandler() http.HandlerFunc {
 				EmitFailures:   topN(m.receiptEmitFailureCounts),
 				RequiredBlocks: topRequiredReceiptBlocks(m.requiredReceiptBlocks),
 			},
+			RuleBundles: RuleBundleStats{
+				DegradedCount: len(m.ruleBundleDegraded),
+				DegradedNames: append([]string(nil), m.ruleBundleDegraded...),
+			},
 		}
 		ceeFunc := m.CEEStatsFunc
 		evidenceFunc := m.evidenceHealthFunc
@@ -87,6 +91,7 @@ type statsResponse struct {
 	TopScanners       []rankedEntry            `json:"top_scanners"`
 	Sessions          sessionStats             `json:"sessions"`
 	Receipts          receiptStats             `json:"receipts"`
+	RuleBundles       RuleBundleStats          `json:"rule_bundles"`
 	CEE               CEEStats                 `json:"cross_request_detection"`
 	EvidenceHealth    *EvidenceHealthStats     `json:"evidence_health"`
 	Agents            map[string]agentStatsOut `json:"agents,omitempty"`

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -846,7 +846,8 @@ func TestWSProxySSRFDialBlockWritesPolicyClose(t *testing.T) {
 	logger := audit.NewNop()
 	sc := scanner.MustNew(cfg)
 	t.Cleanup(sc.Close)
-	p, err := New(cfg, logger, sc, metrics.New())
+	m := metrics.New()
+	p, err := New(cfg, logger, sc, m)
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
@@ -893,6 +894,13 @@ func TestWSProxySSRFDialBlockWritesPolicyClose(t *testing.T) {
 	}
 
 	hdr, err := ws.ReadHeader(conn)
+	if errors.Is(err, io.EOF) {
+		// The SSRF dial block writes a close frame, records the block, and then
+		// returns. The deferred socket close can beat the client-side frame
+		// parser under race/Go-version timing; EOF is still fail-closed.
+		requireWSBlockedMetric(t, m)
+		return
+	}
 	if err != nil {
 		t.Fatalf("read close frame header: %v", err)
 	}
@@ -912,6 +920,17 @@ func TestWSProxySSRFDialBlockWritesPolicyClose(t *testing.T) {
 	if !strings.Contains(string(payload[2:]), string(blockreason.SSRFDNSRebind)) {
 		t.Fatalf("close payload = %q, want %s", string(payload[2:]), blockreason.SSRFDNSRebind)
 	}
+	requireWSBlockedMetric(t, m)
+}
+
+func requireWSBlockedMetric(t *testing.T, m *metrics.Metrics) {
+	t.Helper()
+	testwait.For(t, 2*time.Second, func() bool {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil)
+		m.PrometheusHandler().ServeHTTP(rec, req)
+		return strings.Contains(rec.Body.String(), `pipelock_ws_connections_total{result="blocked"} 1`)
+	}, "websocket blocked metric")
 }
 
 func TestWSProxyRequireReceiptsUnavailableEmitterBlocksAndRecordsMetrics(t *testing.T) {

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -477,7 +477,7 @@ func readBundleFile(path string) ([]byte, error) {
 	}
 
 	if info.Size() > MaxBundleFileSize {
-		return nil, fmt.Errorf("%w: size %d exceeds maximum %d bytes", errBundleFileTooLarge, info.Size(), MaxBundleFileSize)
+		return nil, fmt.Errorf("size %d exceeds maximum %d bytes: %w", info.Size(), MaxBundleFileSize, errBundleFileTooLarge)
 	}
 
 	data, err := os.ReadFile(filepath.Clean(path))

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -4,6 +4,7 @@
 package rules
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -25,6 +26,8 @@ var confidenceRank = map[string]int{
 
 // reservedBundlePrefix is the namespace reserved for official bundles.
 const reservedBundlePrefix = "pipelock-"
+
+var errBundleFileTooLarge = errors.New("bundle file exceeds maximum size")
 
 // LoadOptions controls bundle loading behavior.
 type LoadOptions struct {
@@ -61,7 +64,7 @@ type LoadResult struct {
 	ToolPoison       []CompiledToolPoisonRule
 	Errors           []BundleError
 	Loaded           []LoadedBundle
-	Degraded         bool           // standard pack failed to load - core-only mode
+	Degraded         bool           // one or more installed bundles failed to load
 	Warnings         []string       // non-fatal warnings (expired bundles, etc.)
 	StandardDLP      StandardSource // where DLP standard tier came from
 	StandardResponse StandardSource // where response standard tier came from
@@ -81,8 +84,23 @@ type CompiledToolPoisonRule struct {
 type BundleError struct {
 	Name     string
 	Reason   string
+	Class    BundleErrorClass
 	Official bool // true if bundle was signed by an official key (not just name-based)
 }
+
+// BundleErrorClass separates possible tampering from operational availability
+// failures so strict startup can fail closed only on installed bundle integrity
+// loss.
+type BundleErrorClass string
+
+const (
+	// BundleErrorClassAvailability covers missing optional stores and transient
+	// filesystem/read problems where failing startup would create avoidable DoS.
+	BundleErrorClassAvailability BundleErrorClass = "availability"
+	// BundleErrorClassIntegrity covers installed-bundle provenance, hash,
+	// lockfile, freshness, and content failures that can indicate tampering.
+	BundleErrorClassIntegrity BundleErrorClass = "integrity"
+)
 
 // LoadedBundle describes a successfully loaded bundle (for diagnostics).
 type LoadedBundle struct {
@@ -99,10 +117,68 @@ type LoadedBundle struct {
 	Expired          bool // bundle is past expires_at but loaded in stale mode
 }
 
+// IntegrityErrors returns load failures that indicate installed-bundle
+// provenance or freshness integrity loss.
+func (r *LoadResult) IntegrityErrors() []BundleError {
+	if r == nil {
+		return nil
+	}
+	return r.errorsByClass(BundleErrorClassIntegrity)
+}
+
+// AvailabilityErrors returns load failures caused by missing optional stores or
+// operational filesystem/compatibility availability.
+func (r *LoadResult) AvailabilityErrors() []BundleError {
+	if r == nil {
+		return nil
+	}
+	return r.errorsByClass(BundleErrorClassAvailability)
+}
+
+func (r *LoadResult) errorsByClass(class BundleErrorClass) []BundleError {
+	var out []BundleError
+	for _, err := range r.Errors {
+		if err.ClassOrDefault() == class {
+			out = append(out, err)
+		}
+	}
+	return out
+}
+
+// ClassOrDefault returns the recorded class, treating older zero-value
+// BundleError instances as availability failures to preserve compatibility.
+func (e BundleError) ClassOrDefault() BundleErrorClass {
+	if e.Class == "" {
+		return BundleErrorClassAvailability
+	}
+	return e.Class
+}
+
+// DegradedBundleNames returns a stable, de-duplicated list of bundles or state
+// resources that failed during this load.
+func (r *LoadResult) DegradedBundleNames() []string {
+	if r == nil || len(r.Errors) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(r.Errors))
+	for _, err := range r.Errors {
+		if err.Name == "" {
+			continue
+		}
+		seen[err.Name] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // LoadBundles reads all bundles from rulesDir, verifies integrity,
 // filters by options, and returns merged patterns. For v2+ bundles,
 // freshness checks (rollback prevention, expiry) are enforced.
-// If the standard pack fails to load, Degraded is set to true.
+// If any installed bundle fails to load, Degraded is set to true.
 func LoadBundles(rulesDir string, opts LoadOptions) *LoadResult {
 	result := &LoadResult{}
 
@@ -119,6 +195,7 @@ func LoadBundles(rulesDir string, opts LoadOptions) *LoadResult {
 		result.Errors = append(result.Errors, BundleError{
 			Name:   rulesDir,
 			Reason: fmt.Sprintf("reading rules directory: %v", err),
+			Class:  BundleErrorClassAvailability,
 		})
 		return result
 	}
@@ -150,6 +227,7 @@ func LoadBundles(rulesDir string, opts LoadOptions) *LoadResult {
 			result.Errors = append(result.Errors, BundleError{
 				Name:   ".freshness.json",
 				Reason: err.Error(),
+				Class:  BundleErrorClassIntegrity,
 			})
 			result.Degraded = true
 			return nil
@@ -177,17 +255,18 @@ func LoadBundles(rulesDir string, opts LoadOptions) *LoadResult {
 		return nil
 	})
 	if lockErr != nil {
-		result.Errors = append(result.Errors, BundleError{Name: ".freshness.json", Reason: fmt.Sprintf("freshness lock: %v", lockErr)})
+		result.Errors = append(result.Errors, BundleError{Name: ".freshness.json", Reason: fmt.Sprintf("freshness lock: %v", lockErr), Class: BundleErrorClassAvailability})
 		result.Degraded = true
 	}
 
-	// Detect standard pack degradation: if any official bundle failed
-	// to load, set Degraded flag. Uses verified signature status, not
-	// directory name, to prevent attacker-controlled names from triggering
-	// degraded mode.
+	if len(result.Errors) > 0 {
+		result.Degraded = true
+	}
+
+	// Keep the legacy standard-pack warning, but key it only off verified
+	// official status so attacker-controlled names cannot trigger it.
 	for _, be := range result.Errors {
 		if be.Official {
-			result.Degraded = true
 			result.Warnings = append(result.Warnings,
 				fmt.Sprintf("DEGRADED: standard pack %q failed to load: %s — running core-only", be.Name, be.Reason))
 			break
@@ -215,33 +294,33 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 	// Read and size-check bundle.yaml.
 	data, err := readBundleFile(bundlePath)
 	if err != nil {
-		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: err.Error()})
+		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: err.Error(), Class: classifyBundleFileReadError(err)})
 		return
 	}
 
 	// Read lock file.
 	lock, err := ReadLockFile(lockPath)
 	if err != nil {
-		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: fmt.Sprintf("reading lock file: %v", err)})
+		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: fmt.Sprintf("reading lock file: %v", err), Class: BundleErrorClassIntegrity})
 		return
 	}
 
 	// Verify integrity against the exact bytes we just read (no TOCTOU).
 	if err := VerifyIntegrityBytes(data, bundleDir, lock.Unsigned, lock.SignerFingerprint, lock.BundleSHA256, opts.TrustedKeys); err != nil {
-		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: fmt.Sprintf("integrity check: %v", err)})
+		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: fmt.Sprintf("integrity check: %v", err), Class: BundleErrorClassIntegrity})
 		return
 	}
 
 	// Parse and validate bundle YAML.
 	bundle, err := ParseBundle(data)
 	if err != nil {
-		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: fmt.Sprintf("parse error: %v", err)})
+		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: fmt.Sprintf("parse error: %v", err), Class: BundleErrorClassIntegrity})
 		return
 	}
 
 	// Check min_pipelock version requirement.
 	if err := CheckMinPipelock(bundle.MinPipelock, opts.PipelockVersion); err != nil {
-		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: err.Error()})
+		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: err.Error(), Class: BundleErrorClassAvailability})
 		return
 	}
 
@@ -253,6 +332,7 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{
 			Name:   dirName,
 			Reason: fmt.Sprintf("bundle name %q uses reserved prefix %q but signer is not official", bundle.Name, reservedBundlePrefix),
+			Class:  BundleErrorClassIntegrity,
 		})
 		return
 	}
@@ -265,6 +345,7 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{
 				Name:     dirName,
 				Official: official,
+				Class:    BundleErrorClassIntegrity,
 				Reason:   "format_version 2 bundles must be signed (unsigned v2 bundles are rejected)",
 			})
 			return
@@ -272,20 +353,24 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 
 		// Tier-key binding: verify the signing key matches the declared tier.
 		if err := CheckTierKeyBinding(bundle, lock.SignerFingerprint, opts.TierKeyMapping); err != nil {
-			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Official: official, Reason: err.Error()})
+			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Official: official, Reason: err.Error(), Class: BundleErrorClassIntegrity})
 			return
 		}
 
 		// Required features: reject bundles needing engine features we don't support.
 		if err := CheckRequiredFeatures(bundle.RequiredFeatures); err != nil {
-			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Official: official, Reason: err.Error()})
+			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Official: official, Reason: err.Error(), Class: BundleErrorClassAvailability})
 			return
 		}
 
 		// Freshness: rollback prevention and expiry.
 		fr := CheckFreshness(bundle, ctx.FreshnessState, ctx.Now, opts.AllowStale)
 		if !fr.OK {
-			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Official: official, Reason: fr.Message})
+			class := BundleErrorClassAvailability
+			if fr.Rollback || fr.Expired {
+				class = BundleErrorClassIntegrity
+			}
+			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Official: official, Reason: fr.Message, Class: class})
 			return
 		}
 		if fr.Expired {
@@ -392,7 +477,7 @@ func readBundleFile(path string) ([]byte, error) {
 	}
 
 	if info.Size() > MaxBundleFileSize {
-		return nil, fmt.Errorf("bundle file size %d exceeds maximum %d bytes", info.Size(), MaxBundleFileSize)
+		return nil, fmt.Errorf("%w: size %d exceeds maximum %d bytes", errBundleFileTooLarge, info.Size(), MaxBundleFileSize)
 	}
 
 	data, err := os.ReadFile(filepath.Clean(path))
@@ -401,6 +486,13 @@ func readBundleFile(path string) ([]byte, error) {
 	}
 
 	return data, nil
+}
+
+func classifyBundleFileReadError(err error) BundleErrorClass {
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, errBundleFileTooLarge) {
+		return BundleErrorClassIntegrity
+	}
+	return BundleErrorClassAvailability
 }
 
 // isDisabled checks whether a namespaced rule ID matches any entry in the

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -957,6 +957,12 @@ func TestLoadBundles_MissingLockFile(t *testing.T) {
 	if len(result.Errors) != 1 {
 		t.Fatalf("expected 1 error for missing lock file, got %d: %v", len(result.Errors), result.Errors)
 	}
+	if got := result.Errors[0].ClassOrDefault(); got != BundleErrorClassIntegrity {
+		t.Fatalf("missing lock class = %q, want %q", got, BundleErrorClassIntegrity)
+	}
+	if len(result.IntegrityErrors()) != 1 {
+		t.Fatalf("IntegrityErrors len = %d, want 1", len(result.IntegrityErrors()))
+	}
 }
 
 func TestLoadBundles_IntegrityFailure(t *testing.T) {
@@ -993,6 +999,72 @@ func TestLoadBundles_IntegrityFailure(t *testing.T) {
 
 	if len(result.Errors) != 1 {
 		t.Fatalf("expected 1 error for integrity failure, got %d", len(result.Errors))
+	}
+	if got := result.Errors[0].ClassOrDefault(); got != BundleErrorClassIntegrity {
+		t.Fatalf("SHA mismatch class = %q, want %q", got, BundleErrorClassIntegrity)
+	}
+}
+
+func TestLoadBundles_ExpiredV2BundleIsIntegrity(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bundleDir := filepath.Join(dir, "expired")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := testBundleV2("expired", TierCommunity, 1, []Rule{
+		testDLPRule("dlp-001", confidenceHigh, StatusStable),
+	})
+	b.KeyID = KeyFingerprint(pub)
+	b.ExpiresAt = time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+	writeSignedBundle(t, bundleDir, b, pub, priv)
+
+	result := LoadBundles(dir, LoadOptions{
+		MinConfidence:   confidenceLow,
+		PipelockVersion: testPipelockVersion,
+	})
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 error for expired bundle, got %d: %v", len(result.Errors), result.Errors)
+	}
+	if got := result.Errors[0].ClassOrDefault(); got != BundleErrorClassIntegrity {
+		t.Fatalf("expired bundle class = %q, want %q", got, BundleErrorClassIntegrity)
+	}
+}
+
+func TestLoadBundles_MissingInstalledBundleManifestIsIntegrity(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bundleDir := filepath.Join(dir, "missing-manifest")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteLockFile(filepath.Join(bundleDir, lockFilename), &LockFile{
+		InstalledVersion: "2026.07.0",
+		Source:           "test",
+		BundleSHA256:     strings.Repeat("0", 64),
+		Unsigned:         true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result := LoadBundles(dir, LoadOptions{
+		MinConfidence:   confidenceLow,
+		PipelockVersion: testPipelockVersion,
+	})
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 integrity error, got %d: %v", len(result.Errors), result.Errors)
+	}
+	if got := result.Errors[0].ClassOrDefault(); got != BundleErrorClassIntegrity {
+		t.Fatalf("missing installed bundle manifest class = %q, want %q", got, BundleErrorClassIntegrity)
+	}
+	if len(result.IntegrityErrors()) != 1 {
+		t.Fatalf("IntegrityErrors len = %d, want 1", len(result.IntegrityErrors()))
 	}
 }
 

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -1003,6 +1003,9 @@ func TestLoadBundles_IntegrityFailure(t *testing.T) {
 	if got := result.Errors[0].ClassOrDefault(); got != BundleErrorClassIntegrity {
 		t.Fatalf("SHA mismatch class = %q, want %q", got, BundleErrorClassIntegrity)
 	}
+	if len(result.IntegrityErrors()) != 1 {
+		t.Fatalf("IntegrityErrors len = %d, want 1", len(result.IntegrityErrors()))
+	}
 }
 
 func TestLoadBundles_ExpiredV2BundleIsIntegrity(t *testing.T) {
@@ -1033,6 +1036,9 @@ func TestLoadBundles_ExpiredV2BundleIsIntegrity(t *testing.T) {
 	}
 	if got := result.Errors[0].ClassOrDefault(); got != BundleErrorClassIntegrity {
 		t.Fatalf("expired bundle class = %q, want %q", got, BundleErrorClassIntegrity)
+	}
+	if len(result.IntegrityErrors()) != 1 {
+		t.Fatalf("IntegrityErrors len = %d, want 1", len(result.IntegrityErrors()))
 	}
 }
 

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -88,6 +88,52 @@ func TestLoadBundles_PropagatesDLPValidator(t *testing.T) {
 	}
 }
 
+func TestLoadResultErrorHelpers(t *testing.T) {
+	var nilResult *LoadResult
+	if got := nilResult.IntegrityErrors(); got != nil {
+		t.Fatalf("nil IntegrityErrors = %+v, want nil", got)
+	}
+	if got := nilResult.AvailabilityErrors(); got != nil {
+		t.Fatalf("nil AvailabilityErrors = %+v, want nil", got)
+	}
+	if got := nilResult.DegradedBundleNames(); got != nil {
+		t.Fatalf("nil DegradedBundleNames = %+v, want nil", got)
+	}
+	if got := (BundleError{}).ClassOrDefault(); got != BundleErrorClassAvailability {
+		t.Fatalf("zero class default = %q, want %q", got, BundleErrorClassAvailability)
+	}
+
+	result := &LoadResult{
+		Errors: []BundleError{
+			{Name: "z-bundle", Class: BundleErrorClassIntegrity, Reason: "hash mismatch"},
+			{Name: "", Class: BundleErrorClassIntegrity, Reason: "nameless state error"},
+			{Name: "a-bundle", Class: BundleErrorClassAvailability, Reason: "requires future feature"},
+			{Name: "z-bundle", Class: BundleErrorClassIntegrity, Reason: "duplicate"},
+		},
+	}
+	if got := len(result.IntegrityErrors()); got != 3 {
+		t.Fatalf("IntegrityErrors len = %d, want 3", got)
+	}
+	if got := len(result.AvailabilityErrors()); got != 1 {
+		t.Fatalf("AvailabilityErrors len = %d, want 1", got)
+	}
+	if got := strings.Join(result.DegradedBundleNames(), ","); got != "a-bundle,z-bundle" {
+		t.Fatalf("DegradedBundleNames = %q, want sorted de-duped names", got)
+	}
+}
+
+func TestClassifyBundleFileReadError(t *testing.T) {
+	if got := classifyBundleFileReadError(os.ErrNotExist); got != BundleErrorClassIntegrity {
+		t.Fatalf("missing bundle file class = %q, want %q", got, BundleErrorClassIntegrity)
+	}
+	if got := classifyBundleFileReadError(errBundleFileTooLarge); got != BundleErrorClassIntegrity {
+		t.Fatalf("oversized bundle file class = %q, want %q", got, BundleErrorClassIntegrity)
+	}
+	if got := classifyBundleFileReadError(os.ErrPermission); got != BundleErrorClassAvailability {
+		t.Fatalf("permission error class = %q, want %q", got, BundleErrorClassAvailability)
+	}
+}
+
 // testInjectionRule creates a valid injection rule.
 func testInjectionRule(id, confidence string) Rule {
 	return Rule{
@@ -852,6 +898,44 @@ func TestLoadBundles_PipelockPrefixOfficialSigner(t *testing.T) {
 	}
 	if len(result.DLP) != 1 {
 		t.Fatalf("expected 1 DLP rule, got %d", len(result.DLP))
+	}
+}
+
+func TestLoadBundles_V2TierKeyBindingFailureIsIntegrity(t *testing.T) {
+	// Non-parallel: mutates keyring globals.
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	setupKeyring(t, pub)
+
+	dir := t.TempDir()
+	bundleDir := filepath.Join(dir, "tier-mismatch")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	b := testBundleV2("tier-mismatch", TierCommunity, 1, []Rule{
+		testDLPRule("dlp-tier-001", confidenceHigh, StatusStable),
+	})
+	b.KeyID = KeyFingerprint(pub)
+	writeSignedBundle(t, bundleDir, b, pub, priv)
+
+	result := LoadBundles(dir, LoadOptions{
+		MinConfidence:   confidenceLow,
+		PipelockVersion: testPipelockVersion,
+		TierKeyMapping: map[string]string{
+			TierCommunity: "sha256:different-key",
+		},
+	})
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 tier-key error, got %d: %v", len(result.Errors), result.Errors)
+	}
+	if got := result.Errors[0].ClassOrDefault(); got != BundleErrorClassIntegrity {
+		t.Fatalf("tier-key error class = %q, want %q", got, BundleErrorClassIntegrity)
+	}
+	if len(result.IntegrityErrors()) != 1 {
+		t.Fatalf("IntegrityErrors len = %d, want 1", len(result.IntegrityErrors()))
 	}
 }
 


### PR DESCRIPTION
## What changed

Rule-bundle loading now fails closed when a bundle's integrity is in doubt, instead of silently degrading detection coverage.

Bundle load errors are classified as integrity-class (bad signature, missing or mismatched lockfile, hash mismatch, missing installed manifest, expired freshness, unsigned-v2, rollback, reserved-prefix or key-binding violations) versus availability-class (an absent optional bundle or a transient filesystem read error). In strict mode, an integrity-class failure now refuses to start, naming the bundle and the failure class, rather than booting with reduced coverage. A new `rules.allow_degraded` config knob (default false) is the explicit, audited emergency override that restores boot-degraded behavior; when it is used, startup is loud (a security warning plus a durable audit event).

A clean bundle uninstall that removes live detection patterns on reload is now rejected in strict mode (the running config is kept) unless `rules.allow_degraded` is set. The reload drop detector compares pattern identity, not just count, so a same-name same-regex bundle swap that weakens enforcement (a changed DLP severity, validator, or action, or a tool-poison regex or scan-field change) is caught rather than treated as unchanged.

Degraded bundle state is surfaced three ways: a structured audit event, a field on the `/stats` endpoint, and a `pipelock_rule_bundles_degraded` gauge metric that clears when the bundle recovers.

## Why

Before this change, a tampered or missing installed bundle produced the same warn-and-degrade path as an absent optional community bundle, so an attacker who could corrupt or delete an installed bundle silently reduced live detection coverage without tripping any guard. On a security product the correct posture is to fail closed on integrity doubt and make any degradation loud and operator-visible.

## Behavior notes

Non-strict modes keep boot-degraded behavior (deliberate boot-DoS avoidance) but now emit the loud warning, audit event, and metric on any degradation. `rules.allow_degraded` overrides a clean reload coverage drop but does not force activation of a partially unresolved reload over known-good live coverage; startup has no prior coverage to preserve, a reload does, so the two surfaces differ by design.

## Tests

Fail-closed negative tests cover each path: tampered signature, missing lockfile, and missing manifest at strict startup refuse to boot; the same with `rules.allow_degraded: true` boots degraded with an audit event; a strict reload with a cleanly removed live bundle is rejected and the running config is kept; a balanced-to-strict reload cannot smuggle a degraded config; a same-count bundle replacement that downgrades DLP enforcement is rejected; non-strict allows the drop with a loud warning. Security-sensitive default tests cover the new knob omitted, null, explicit false, explicit true, and reload-with and reload-without change. Each guard was verified by neutralizing it and observing the corresponding test fail.

## Docs

Updated the rules and configuration guides with the degraded-state semantics, strict-mode behavior, and the new `rules.allow_degraded` knob.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `rules.allow_degraded` to enable opt-in degraded strict-mode startup and reload when bundle integrity/coverage checks fail.
  * Introduced `rule_bundle_degraded` structured audit/webhook event details.
  * Extended `/stats` and `/metrics` to expose degraded rule-bundle names and a dedicated degraded health gauge.
* **Bug Fixes**
  * Improved hot-reload behavior for clean bundle removals and bundle-scoped coverage changes: strict mode rejects pattern loss that could drop live detections, preserving the last known-good config unless opted in.
* **Documentation**
  * Updated Hot Reload and Rules docs to describe degraded classes, stricter semantics, and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->