### PR TITLE
feat(emit): add OCSF syslog output format

### DIFF
--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -543,6 +543,7 @@ mcp_session_binding:
 #     min_severity: warn
 #     facility: local0
 #     tag: pipelock
+#     format: json             # json, cef, or ocsf
 #   # Enterprise durable HTTP forwarding. Exact-host allowlist; no wildcards.
 #   forwarder:
 #     url: "https://api.vendor.example/events"

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -531,6 +531,7 @@ mcp_session_binding:
 #     min_severity: warn
 #     facility: local0
 #     tag: pipelock
+#     format: json             # json, cef, or ocsf
 
 logging:
   format: json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1420,6 +1420,7 @@ emit:
     min_severity: warn
     facility: local0
     tag: pipelock
+    format: json
   otlp:
     endpoint: "http://otel-collector:4318"
     min_severity: warn
@@ -1442,6 +1443,7 @@ emit:
 | `syslog.min_severity` | `"warn"` | info, warn, or critical |
 | `syslog.facility` | `"local0"` | Syslog facility |
 | `syslog.tag` | `"pipelock"` | Syslog tag |
+| `syslog.format` | `"json"` | Syslog wire format: json, cef, or ocsf |
 | `otlp.endpoint` | `""` | OTLP collector base URL (e.g., `http://collector:4318`). `/v1/logs` appended automatically. |
 | `otlp.min_severity` | `"warn"` | info, warn, or critical |
 | `otlp.headers` | `{}` | Custom HTTP headers (authentication, tenant routing) |

--- a/docs/guides/siem-integration.md
+++ b/docs/guides/siem-integration.md
@@ -106,6 +106,7 @@ emit:
     min_severity: "warn"
     facility: "local0"                # local0-local7, auth, daemon, etc.
     tag: "pipelock"
+    format: "json"                    # json, cef, or ocsf
 ```
 
 ### Durable HTTP forwarding (Enterprise)
@@ -193,8 +194,9 @@ The durable wire envelope is versioned:
 }
 ```
 
-The existing syslog sink remains the CEF option (`format: cef`) for receivers
-that require CEF, but it is best-effort and does not use the durable cursor.
+The existing syslog sink supports JSON, CEF (`format: cef`), and OCSF
+(`format: ocsf`) for receivers that require one of those wire formats, but it
+is best-effort and does not use the durable cursor.
 
 Operator lifecycle:
 
@@ -296,6 +298,7 @@ emit:
     facility: "local0"
     tag: "pipelock"
     min_severity: "warn"
+    format: "json"                    # json, cef, or ocsf
 ```
 
 On the receiver, filter by program name:

--- a/examples/siem-events/verify.sh
+++ b/examples/siem-events/verify.sh
@@ -290,8 +290,8 @@ else
   exit 1
 fi
 sleep 0.3
-CLEAN_EVENTS_JSON="$(curl -sf "http://${WEBHOOK_ADDR}/events" 2>/dev/null || true)"
-BLOCKED_AFTER_CLEAN="$(python3 -c 'import json,sys; print(sum(1 for e in json.load(sys.stdin) if e.get("type")=="blocked"))' <<<"$CLEAN_EVENTS_JSON")"
+CLEAN_EVENTS_JSON="$(curl -sf "http://${WEBHOOK_ADDR}/events" 2>/dev/null || echo '[]')"
+BLOCKED_AFTER_CLEAN="$(python3 -c 'import json,sys; print(sum(1 for e in json.load(sys.stdin) if e.get("type")=="blocked"))' <<<"${CLEAN_EVENTS_JSON:-[]}" 2>/dev/null || echo 0)"
 if [ "$BLOCKED_AFTER_CLEAN" = "0" ]; then
   pass "no blocked webhook events after clean fetch"
 else

--- a/examples/siem-events/verify.sh
+++ b/examples/siem-events/verify.sh
@@ -205,7 +205,8 @@ fetch_url() {
 wait_for_blocked_event() {
   local deadline=$(( $(date +%s) + 8 ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    if curl -sf "http://${WEBHOOK_ADDR}/events" | python3 -c '
+    events_json="$(curl -sf "http://${WEBHOOK_ADDR}/events" 2>/dev/null || true)"
+    if [ -n "$events_json" ] && python3 -c '
 import json,sys
 events=json.load(sys.stdin)
 for e in events:
@@ -216,7 +217,7 @@ for e in events:
             print("ok")
             raise SystemExit(0)
 raise SystemExit(1)
-' >/dev/null 2>&1; then
+' <<<"$events_json" >/dev/null 2>&1; then
       return 0
     fi
     sleep 0.1
@@ -289,7 +290,8 @@ else
   exit 1
 fi
 sleep 0.3
-BLOCKED_AFTER_CLEAN="$(curl -sf "http://${WEBHOOK_ADDR}/events" | python3 -c 'import json,sys; print(sum(1 for e in json.load(sys.stdin) if e.get("type")=="blocked"))')"
+CLEAN_EVENTS_JSON="$(curl -sf "http://${WEBHOOK_ADDR}/events" 2>/dev/null || true)"
+BLOCKED_AFTER_CLEAN="$(python3 -c 'import json,sys; print(sum(1 for e in json.load(sys.stdin) if e.get("type")=="blocked"))' <<<"$CLEAN_EVENTS_JSON")"
 if [ "$BLOCKED_AFTER_CLEAN" = "0" ]; then
   pass "no blocked webhook events after clean fetch"
 else

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7823,6 +7823,50 @@ func TestLoad_EmitSyslogFormatDefaultsToJSON(t *testing.T) {
 	}
 }
 
+func TestLoad_EmitSyslogFormatAcceptsOCSF(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	content := "version: 1\nemit:\n  syslog:\n    address: " + testSyslogAddr + "\n    format: ocsf\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadForRules(path)
+	if err != nil {
+		t.Fatalf("LoadForRules: %v", err)
+	}
+	if cfg.Emit.Syslog.Format != EmitFormatOCSF {
+		t.Fatalf("emit.syslog.format = %q, want %q", cfg.Emit.Syslog.Format, EmitFormatOCSF)
+	}
+}
+
+func TestLoad_EmitSyslogFormatReloadWithChange(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	write := func(format string) {
+		t.Helper()
+		content := "version: 1\nemit:\n  syslog:\n    address: " + testSyslogAddr + "\n    format: " + format + "\n"
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+
+	write("json")
+	first, err := LoadForRules(path)
+	if err != nil {
+		t.Fatalf("first LoadForRules: %v", err)
+	}
+	if first.Emit.Syslog.Format != EmitFormatJSON {
+		t.Fatalf("initial emit.syslog.format = %q, want %q", first.Emit.Syslog.Format, EmitFormatJSON)
+	}
+
+	write("ocsf")
+	second, err := LoadForRules(path)
+	if err != nil {
+		t.Fatalf("second LoadForRules: %v", err)
+	}
+	if second.Emit.Syslog.Format != EmitFormatOCSF {
+		t.Fatalf("reloaded emit.syslog.format = %q, want %q", second.Emit.Syslog.Format, EmitFormatOCSF)
+	}
+}
+
 func TestDefaults_KillSwitchAPIExempt(t *testing.T) {
 	cfg := Defaults()
 	cfg.ApplyDefaults()
@@ -7869,7 +7913,7 @@ func TestValidate_EmitWebhookValidConfig(t *testing.T) {
 
 func TestValidate_EmitSyslogValidConfig(t *testing.T) {
 	for _, sev := range []string{SeverityInfo, SeverityWarn, SeverityCritical} {
-		for _, format := range []string{EmitFormatJSON, EmitFormatCEF} {
+		for _, format := range []string{EmitFormatJSON, EmitFormatCEF, EmitFormatOCSF} {
 			name := sev + "/" + format
 			t.Run(name, func(t *testing.T) {
 				cfg := Defaults()

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -77,6 +77,7 @@ const (
 const (
 	EmitFormatJSON = emitformat.JSON
 	EmitFormatCEF  = emitformat.CEF
+	EmitFormatOCSF = emitformat.OCSF
 )
 
 // DLP validator names for post-match checksum verification.
@@ -1348,7 +1349,7 @@ type SyslogConfig struct {
 	MinSeverity string `yaml:"min_severity"`    // info, warn, critical
 	Facility    string `yaml:"facility"`        // e.g. "local0" (default)
 	Tag         string `yaml:"tag"`             // e.g. "pipelock" (default)
-	Format      string `yaml:"format" json:"-"` // json (default) or cef
+	Format      string `yaml:"format" json:"-"` // json (default), cef, or ocsf
 }
 
 // MCPWSListener configures the MCP WebSocket listener for inbound connections.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2624,10 +2624,10 @@ func (c *Config) validateEmit() error {
 			}
 		}
 		switch c.Emit.Syslog.Format {
-		case EmitFormatJSON, EmitFormatCEF:
+		case EmitFormatJSON, EmitFormatCEF, EmitFormatOCSF:
 			// valid
 		default:
-			return fmt.Errorf("invalid emit.syslog.format %q: must be json or cef", c.Emit.Syslog.Format)
+			return fmt.Errorf("invalid emit.syslog.format %q: must be json, cef, or ocsf", c.Emit.Syslog.Format)
 		}
 	}
 

--- a/internal/emit/cef.go
+++ b/internal/emit/cef.go
@@ -16,6 +16,7 @@ import (
 const (
 	FormatJSON = emitformat.JSON
 	FormatCEF  = emitformat.CEF
+	FormatOCSF = emitformat.OCSF
 
 	cefVersion       = "0"
 	cefDeviceVendor  = "Pipelock"

--- a/internal/emit/ocsf.go
+++ b/internal/emit/ocsf.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -348,7 +349,13 @@ func ocsfTruncateString(s string) string {
 	if len(s) <= ocsfMaxStringBytes {
 		return s
 	}
-	return s[:ocsfMaxStringBytes] + "...[truncated]"
+	// Back the cut off to a rune boundary so a multi-byte character is not
+	// split into an invalid sequence that renders as U+FFFD in the finding.
+	cut := ocsfMaxStringBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "...[truncated]"
 }
 
 // enter records a reference-typed value on the current path. It returns a

--- a/internal/emit/ocsf.go
+++ b/internal/emit/ocsf.go
@@ -1,0 +1,395 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emit
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net"
+	"net/url"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const (
+	ocsfSchemaVersion = "1.8.0"
+
+	ocsfCategoryUIDFindings       = 2
+	ocsfCategoryNameFindings      = "Findings"
+	ocsfClassUIDDetectionFinding  = 2004
+	ocsfClassNameDetectionFinding = "Detection Finding"
+	ocsfActivityIDCreate          = 1
+	ocsfActivityNameCreate        = "Create"
+	ocsfStatusIDNew               = 1
+	ocsfStatusNew                 = "New"
+)
+
+type ocsfDetectionFinding struct {
+	ActivityID   int                  `json:"activity_id"`
+	ActivityName string               `json:"activity_name"`
+	CategoryUID  int                  `json:"category_uid"`
+	CategoryName string               `json:"category_name"`
+	ClassUID     int                  `json:"class_uid"`
+	ClassName    string               `json:"class_name"`
+	TypeUID      int                  `json:"type_uid"`
+	TypeName     string               `json:"type_name"`
+	SeverityID   int                  `json:"severity_id"`
+	Severity     string               `json:"severity"`
+	Time         int64                `json:"time"`
+	Message      string               `json:"message"`
+	Metadata     ocsfMetadata         `json:"metadata"`
+	StatusID     int                  `json:"status_id"`
+	Status       string               `json:"status"`
+	FindingInfo  ocsfFindingInfo      `json:"finding_info"`
+	ActionID     int                  `json:"action_id,omitempty"`
+	Action       string               `json:"action,omitempty"`
+	Actor        *ocsfActor           `json:"actor,omitempty"`
+	SrcEndpoint  *ocsfNetworkEndpoint `json:"src_endpoint,omitempty"`
+	DstEndpoint  *ocsfNetworkEndpoint `json:"dst_endpoint,omitempty"`
+	URL          *ocsfURL             `json:"url,omitempty"`
+	HTTPRequest  *ocsfHTTPRequest     `json:"http_request,omitempty"`
+	StatusDetail string               `json:"status_detail,omitempty"`
+	Unmapped     map[string]any       `json:"unmapped,omitempty"`
+}
+
+type ocsfMetadata struct {
+	Version string      `json:"version"`
+	Product ocsfProduct `json:"product"`
+}
+
+type ocsfProduct struct {
+	VendorName string `json:"vendor_name"`
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+}
+
+type ocsfFindingInfo struct {
+	UID         string      `json:"uid"`
+	Title       string      `json:"title"`
+	Description string      `json:"desc,omitempty"`
+	Product     ocsfProduct `json:"product"`
+	CreatedTime int64       `json:"created_time"`
+}
+
+type ocsfActor struct {
+	User ocsfUser `json:"user"`
+}
+
+type ocsfUser struct {
+	Name string `json:"name"`
+}
+
+type ocsfNetworkEndpoint struct {
+	IP       string `json:"ip,omitempty"`
+	Hostname string `json:"hostname,omitempty"`
+	Port     int    `json:"port,omitempty"`
+}
+
+type ocsfURL struct {
+	URLString   string `json:"url_string"`
+	Scheme      string `json:"scheme,omitempty"`
+	Hostname    string `json:"hostname,omitempty"`
+	Port        int    `json:"port,omitempty"`
+	Path        string `json:"path,omitempty"`
+	QueryString string `json:"query_string,omitempty"`
+}
+
+type ocsfHTTPRequest struct {
+	HTTPMethod string `json:"http_method,omitempty"`
+	UID        string `json:"uid,omitempty"`
+}
+
+// FormatOCSFEvent renders a Pipelock audit event as one OCSF Detection Finding.
+// Pipelock events are scanner and policy decisions on mediated activity, so the
+// Findings category preserves the security judgment while typed network fields
+// capture request context when the source event has it.
+func FormatOCSFEvent(event Event, deviceVersion string) string {
+	if deviceVersion == "" {
+		deviceVersion = "unknown"
+	}
+
+	eventTime := event.Timestamp.UTC()
+	millis := eventTime.UnixMilli()
+	severityID, severityName := ocsfSeverity(event.Severity)
+	product := ocsfProduct{
+		VendorName: "Pipelock",
+		Name:       "Pipelock",
+		Version:    deviceVersion,
+	}
+	action := eventAction(event)
+	decisionType := eventDecisionType(event)
+
+	record := ocsfDetectionFinding{
+		ActivityID:   ocsfActivityIDCreate,
+		ActivityName: ocsfActivityNameCreate,
+		CategoryUID:  ocsfCategoryUIDFindings,
+		CategoryName: ocsfCategoryNameFindings,
+		ClassUID:     ocsfClassUIDDetectionFinding,
+		ClassName:    ocsfClassNameDetectionFinding,
+		TypeUID:      ocsfClassUIDDetectionFinding*100 + ocsfActivityIDCreate,
+		TypeName:     ocsfClassNameDetectionFinding + ": " + ocsfActivityNameCreate,
+		SeverityID:   severityID,
+		Severity:     severityName,
+		Time:         millis,
+		Message:      cefName(event),
+		Metadata: ocsfMetadata{
+			Version: ocsfSchemaVersion,
+			Product: product,
+		},
+		StatusID: ocsfStatusIDNew,
+		Status:   ocsfStatusNew,
+		FindingInfo: ocsfFindingInfo{
+			UID:         ocsfFindingUID(event),
+			Title:       cefName(event),
+			Description: ocsfStringField(event.Fields, fieldReason, "error"),
+			Product:     product,
+			CreatedTime: millis,
+		},
+		ActionID:     ocsfActionID(action),
+		Action:       action,
+		Actor:        ocsfActorFromEvent(event),
+		SrcEndpoint:  ocsfEndpointFromValue(ocsfStringField(event.Fields, "client_ip")),
+		DstEndpoint:  ocsfDstEndpointFromEvent(event),
+		URL:          ocsfURLFromEvent(event),
+		HTTPRequest:  ocsfHTTPRequestFromEvent(event),
+		StatusDetail: ocsfStringField(event.Fields, fieldReason, "error"),
+		Unmapped: map[string]any{
+			"pipelock": map[string]any{
+				"event_type":    event.Type,
+				"severity":      event.Severity.String(),
+				"instance_id":   event.InstanceID,
+				"action":        action,
+				"decision_type": decisionType,
+				"fields":        ocsfJSONValue(event.Fields),
+			},
+		},
+	}
+
+	if record.ActionID == 0 {
+		record.Action = ""
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(record); err != nil {
+		return fallbackOCSFEvent(record, err)
+	}
+	return strings.TrimSuffix(buf.String(), "\n")
+}
+
+func fallbackOCSFEvent(record ocsfDetectionFinding, err error) string {
+	eventType := record.FindingInfo.Title
+	if pipelock, ok := record.Unmapped["pipelock"].(map[string]any); ok {
+		if value, ok := pipelock["event_type"].(string); ok && value != "" {
+			eventType = value
+		}
+	}
+	record.Message = "ocsf_format_error: " + record.Message
+	record.StatusDetail = err.Error()
+	record.Actor = nil
+	record.SrcEndpoint = nil
+	record.DstEndpoint = nil
+	record.URL = nil
+	record.HTTPRequest = nil
+	record.Unmapped = map[string]any{
+		"pipelock": map[string]any{
+			"event_type":        eventType,
+			"ocsf_format_error": err.Error(),
+		},
+	}
+
+	msg, marshalErr := json.Marshal(record)
+	if marshalErr != nil {
+		return `{"activity_id":1,"activity_name":"Create","category_uid":2,"category_name":"Findings","class_uid":2004,"class_name":"Detection Finding","type_uid":200401,"type_name":"Detection Finding: Create","severity_id":0,"severity":"Unknown","time":0,"message":"ocsf_format_error","metadata":{"version":"1.8.0","product":{"vendor_name":"Pipelock","name":"Pipelock","version":"unknown"}},"status_id":1,"status":"New","finding_info":{"uid":"ocsf-format-error","title":"ocsf_format_error","product":{"vendor_name":"Pipelock","name":"Pipelock","version":"unknown"},"created_time":0}}`
+	}
+	return string(msg)
+}
+
+func ocsfSeverity(sev Severity) (int, string) {
+	switch sev {
+	case SeverityInfo:
+		return 1, "Informational"
+	case SeverityWarn:
+		return 3, "Medium"
+	case SeverityCritical:
+		return 5, "Critical"
+	default:
+		return 0, "Unknown"
+	}
+}
+
+func ocsfActionID(action string) int {
+	switch action {
+	case conventionActionAllow, eventActionForward, EventRedirect:
+		return 1
+	case conventionActionBlock, eventActionStrip:
+		return 2
+	case conventionActionWarn, conventionActionAsk, eventActionDefer:
+		return 99
+	default:
+		return 0
+	}
+}
+
+func ocsfActorFromEvent(event Event) *ocsfActor {
+	agent := eventAgent(event)
+	if agent == "" {
+		return nil
+	}
+	return &ocsfActor{User: ocsfUser{Name: agent}}
+}
+
+func ocsfURLFromEvent(event Event) *ocsfURL {
+	raw := ocsfStringField(event.Fields, "url")
+	if raw == "" {
+		return nil
+	}
+	out := &ocsfURL{URLString: raw}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return out
+	}
+	out.Scheme = parsed.Scheme
+	out.Hostname = parsed.Hostname()
+	out.Path = parsed.Path
+	out.QueryString = parsed.RawQuery
+	if port := parsed.Port(); port != "" {
+		_, _ = fmt.Sscan(port, &out.Port)
+	}
+	return out
+}
+
+func ocsfHTTPRequestFromEvent(event Event) *ocsfHTTPRequest {
+	req := ocsfHTTPRequest{
+		HTTPMethod: ocsfStringField(event.Fields, "method"),
+		UID:        ocsfStringField(event.Fields, "request_id"),
+	}
+	if req.HTTPMethod == "" && req.UID == "" {
+		return nil
+	}
+	return &req
+}
+
+func ocsfDstEndpointFromEvent(event Event) *ocsfNetworkEndpoint {
+	if eventURL := ocsfURLFromEvent(event); eventURL != nil && eventURL.Hostname != "" {
+		return &ocsfNetworkEndpoint{Hostname: eventURL.Hostname, Port: eventURL.Port}
+	}
+	return ocsfEndpointFromValue(ocsfStringField(event.Fields, "target", "resource"))
+}
+
+func ocsfEndpointFromValue(value string) *ocsfNetworkEndpoint {
+	if value == "" {
+		return nil
+	}
+	endpoint := &ocsfNetworkEndpoint{}
+	if ip := net.ParseIP(value); ip != nil {
+		endpoint.IP = ip.String()
+		return endpoint
+	}
+	endpoint.Hostname = value
+	return endpoint
+}
+
+func ocsfStringField(fields map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := fields[key]
+		if !ok {
+			continue
+		}
+		rendered := cefFieldValue(value)
+		if rendered != "" {
+			return rendered
+		}
+	}
+	return ""
+}
+
+func ocsfFindingUID(event Event) string {
+	sum := sha256.New()
+	_, _ = fmt.Fprintf(sum, "%s|%s|%s|", event.InstanceID, event.Type, event.Timestamp.UTC().Format(time.RFC3339Nano))
+	fields, err := json.Marshal(ocsfJSONValue(event.Fields))
+	if err == nil {
+		_, _ = sum.Write(fields)
+	}
+	return hex.EncodeToString(sum.Sum(nil))
+}
+
+func ocsfJSONValue(value any) any {
+	return ocsfJSONValueDepth(value, 0)
+}
+
+func ocsfJSONValueDepth(value any, depth int) any {
+	if depth > 16 {
+		return "[truncated]"
+	}
+
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case string, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return v
+	case float32:
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			return fmt.Sprint(v)
+		}
+		return v
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return fmt.Sprint(v)
+		}
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case []string:
+		out := make([]string, len(v))
+		copy(out, v)
+		return out
+	case []any:
+		out := make([]any, 0, len(v))
+		for _, item := range v {
+			out = append(out, ocsfJSONValueDepth(item, depth+1))
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, item := range v {
+			out[key] = ocsfJSONValueDepth(item, depth+1)
+		}
+		return out
+	case map[string]string:
+		out := make(map[string]any, len(v))
+		for key, item := range v {
+			out[key] = item
+		}
+		return out
+	}
+
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		out := make([]any, 0, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out = append(out, ocsfJSONValueDepth(rv.Index(i).Interface(), depth+1))
+		}
+		return out
+	case reflect.Map:
+		if rv.Type().Key().Kind() != reflect.String {
+			return "[unsupported]"
+		}
+		out := make(map[string]any, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			out[iter.Key().String()] = ocsfJSONValueDepth(iter.Value().Interface(), depth+1)
+		}
+		return out
+	default:
+		return fmt.Sprint(value)
+	}
+}

--- a/internal/emit/ocsf.go
+++ b/internal/emit/ocsf.go
@@ -124,6 +124,7 @@ func FormatOCSFEvent(event Event, deviceVersion string) string {
 	}
 	action := eventAction(event)
 	decisionType := eventDecisionType(event)
+	eventURL := ocsfURLFromEvent(event)
 
 	record := ocsfDetectionFinding{
 		ActivityID:   ocsfActivityIDCreate,
@@ -155,8 +156,8 @@ func FormatOCSFEvent(event Event, deviceVersion string) string {
 		Action:       action,
 		Actor:        ocsfActorFromEvent(event),
 		SrcEndpoint:  ocsfEndpointFromValue(ocsfStringField(event.Fields, "client_ip")),
-		DstEndpoint:  ocsfDstEndpointFromEvent(event),
-		URL:          ocsfURLFromEvent(event),
+		DstEndpoint:  ocsfDstEndpointFromEvent(event, eventURL),
+		URL:          eventURL,
 		HTTPRequest:  ocsfHTTPRequestFromEvent(event),
 		StatusDetail: ocsfStringField(event.Fields, fieldReason, "error"),
 		Unmapped: map[string]any{
@@ -277,8 +278,8 @@ func ocsfHTTPRequestFromEvent(event Event) *ocsfHTTPRequest {
 	return &req
 }
 
-func ocsfDstEndpointFromEvent(event Event) *ocsfNetworkEndpoint {
-	if eventURL := ocsfURLFromEvent(event); eventURL != nil && eventURL.Hostname != "" {
+func ocsfDstEndpointFromEvent(event Event, eventURL *ocsfURL) *ocsfNetworkEndpoint {
+	if eventURL != nil && eventURL.Hostname != "" {
 		return &ocsfNetworkEndpoint{Hostname: eventURL.Hostname, Port: eventURL.Port}
 	}
 	return ocsfEndpointFromValue(ocsfStringField(event.Fields, "target", "resource"))
@@ -321,19 +322,80 @@ func ocsfFindingUID(event Event) string {
 	return hex.EncodeToString(sum.Sum(nil))
 }
 
-func ocsfJSONValue(value any) any {
-	return ocsfJSONValueDepth(value, 0)
+// Serialization bounds for event fields carried into the OCSF finding. These
+// cap the work a malformed or hostile event field can impose on the audit
+// path: a depth limit alone does not stop breadth or shared-reference
+// amplification, so a total-node budget, per-string byte cap, and
+// current-path cycle/shared-reference detection are all enforced.
+const (
+	ocsfMaxDepth       = 16
+	ocsfMaxNodes       = 10000
+	ocsfMaxStringBytes = 8192
+)
+
+// ocsfBudget bounds a single field-serialization walk. nodes counts total
+// values visited; seen tracks reference-typed values on the CURRENT path so a
+// cycle collapses to "[cycle]" without also discarding a legitimately shared
+// sibling (breadth is bounded by the node budget instead).
+type ocsfBudget struct {
+	nodes int
+	seen  map[uintptr]bool
 }
 
+func newOCSFBudget() *ocsfBudget { return &ocsfBudget{seen: make(map[uintptr]bool)} }
+
+func ocsfTruncateString(s string) string {
+	if len(s) <= ocsfMaxStringBytes {
+		return s
+	}
+	return s[:ocsfMaxStringBytes] + "...[truncated]"
+}
+
+// enter records a reference-typed value on the current path. It returns a
+// release func to pop it (nil for non-reference or empty values) and reports
+// whether the value is already on the path (a cycle).
+func (b *ocsfBudget) enter(rv reflect.Value) (func(), bool) {
+	switch rv.Kind() {
+	case reflect.Map, reflect.Slice:
+		if rv.Len() == 0 {
+			return nil, false
+		}
+		ptr := rv.Pointer()
+		if b.seen[ptr] {
+			return nil, true
+		}
+		b.seen[ptr] = true
+		return func() { delete(b.seen, ptr) }, false
+	default:
+		return nil, false
+	}
+}
+
+func ocsfJSONValue(value any) any {
+	return ocsfJSONValueBudgeted(value, 0, newOCSFBudget())
+}
+
+// ocsfJSONValueDepth is retained for callers that only need the depth guard;
+// it starts a fresh budget.
 func ocsfJSONValueDepth(value any, depth int) any {
-	if depth > 16 {
+	return ocsfJSONValueBudgeted(value, depth, newOCSFBudget())
+}
+
+func ocsfJSONValueBudgeted(value any, depth int, b *ocsfBudget) any {
+	if depth > ocsfMaxDepth {
+		return "[truncated]"
+	}
+	b.nodes++
+	if b.nodes > ocsfMaxNodes {
 		return "[truncated]"
 	}
 
 	switch v := value.(type) {
 	case nil:
 		return nil
-	case string, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+	case string:
+		return ocsfTruncateString(v)
+	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		return v
 	case float32:
 		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
@@ -346,27 +408,17 @@ func ocsfJSONValueDepth(value any, depth int) any {
 		}
 		return v
 	case fmt.Stringer:
-		return v.String()
+		return ocsfTruncateString(v.String())
 	case []string:
 		out := make([]string, len(v))
-		copy(out, v)
-		return out
-	case []any:
-		out := make([]any, 0, len(v))
-		for _, item := range v {
-			out = append(out, ocsfJSONValueDepth(item, depth+1))
-		}
-		return out
-	case map[string]any:
-		out := make(map[string]any, len(v))
-		for key, item := range v {
-			out[key] = ocsfJSONValueDepth(item, depth+1)
+		for i, s := range v {
+			out[i] = ocsfTruncateString(s)
 		}
 		return out
 	case map[string]string:
 		out := make(map[string]any, len(v))
 		for key, item := range v {
-			out[key] = item
+			out[key] = ocsfTruncateString(item)
 		}
 		return out
 	}
@@ -374,22 +426,42 @@ func ocsfJSONValueDepth(value any, depth int) any {
 	rv := reflect.ValueOf(value)
 	switch rv.Kind() {
 	case reflect.Slice, reflect.Array:
+		release, cyclic := b.enter(rv)
+		if cyclic {
+			return "[cycle]"
+		}
+		if release != nil {
+			defer release()
+		}
 		out := make([]any, 0, rv.Len())
 		for i := 0; i < rv.Len(); i++ {
-			out = append(out, ocsfJSONValueDepth(rv.Index(i).Interface(), depth+1))
+			out = append(out, ocsfJSONValueBudgeted(rv.Index(i).Interface(), depth+1, b))
+			if b.nodes > ocsfMaxNodes {
+				break
+			}
 		}
 		return out
 	case reflect.Map:
 		if rv.Type().Key().Kind() != reflect.String {
 			return "[unsupported]"
 		}
+		release, cyclic := b.enter(rv)
+		if cyclic {
+			return "[cycle]"
+		}
+		if release != nil {
+			defer release()
+		}
 		out := make(map[string]any, rv.Len())
 		iter := rv.MapRange()
 		for iter.Next() {
-			out[iter.Key().String()] = ocsfJSONValueDepth(iter.Value().Interface(), depth+1)
+			out[iter.Key().String()] = ocsfJSONValueBudgeted(iter.Value().Interface(), depth+1, b)
+			if b.nodes > ocsfMaxNodes {
+				break
+			}
 		}
 		return out
 	default:
-		return fmt.Sprint(value)
+		return ocsfTruncateString(fmt.Sprint(value))
 	}
 }

--- a/internal/emit/ocsf_test.go
+++ b/internal/emit/ocsf_test.go
@@ -412,3 +412,59 @@ func TestFormatOCSFEventHostnameTargetAndUnparseableURL(t *testing.T) {
 	}, "dev"))
 	assertString(t, assertMap(t, got2, "url"), "url_string", "http://bad\x7fhost/path")
 }
+
+func TestFormatOCSFEventBoundsHostileFields(t *testing.T) {
+	// Deeply nested fields are truncated at the depth bound so a malformed or
+	// hostile event cannot drive unbounded recursion on the audit path.
+	deep := any("leaf")
+	for i := 0; i < 40; i++ {
+		deep = map[string]any{"next": deep}
+	}
+	line := FormatOCSFEvent(Event{
+		Severity:  SeverityWarn,
+		Type:      EventBlocked,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields:    map[string]any{"deep": deep},
+	}, "dev")
+	got := parseOCSFEvent(t, line) // valid JSON => the walk stayed bounded
+	assertNumber(t, got, "class_uid", ocsfClassUIDDetectionFinding)
+	if !strings.Contains(line, "[truncated]") {
+		t.Fatalf("deeply nested field was not truncated: %s", line)
+	}
+
+	// A wide shared-reference structure is bounded by the node budget rather
+	// than expanding to branching^depth nodes.
+	shared := map[string]any{"k": "v"}
+	tree := any(shared)
+	for i := 0; i < 20; i++ {
+		tree = map[string]any{"a": tree, "b": tree, "c": tree}
+	}
+	wideLine := FormatOCSFEvent(Event{
+		Severity:  SeverityWarn,
+		Type:      EventBlocked,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields:    map[string]any{"tree": tree},
+	}, "dev")
+	if _ = parseOCSFEvent(t, wideLine); !strings.Contains(wideLine, "[truncated]") {
+		t.Fatalf("wide structure was not bounded by the node budget")
+	}
+}
+
+func TestFormatOCSFEventTruncatesOversizedStringField(t *testing.T) {
+	huge := strings.Repeat("A", ocsfMaxStringBytes+500)
+	line := FormatOCSFEvent(Event{
+		Severity:  SeverityWarn,
+		Type:      EventBlocked,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields:    map[string]any{"blob": huge},
+	}, "dev")
+	got := parseOCSFEvent(t, line)
+	fields := assertMap(t, assertMap(t, assertMap(t, got, "unmapped"), "pipelock"), "fields")
+	blob := stringValue(t, fields, "blob")
+	if len(blob) >= len(huge) {
+		t.Fatalf("oversized field not truncated: got %d bytes", len(blob))
+	}
+	if !strings.HasSuffix(blob, "...[truncated]") {
+		t.Fatalf("truncated field missing marker: %q", blob[len(blob)-20:])
+	}
+}

--- a/internal/emit/ocsf_test.go
+++ b/internal/emit/ocsf_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func TestFormatOCSFEventDetectionFinding(t *testing.T) {
@@ -466,5 +467,28 @@ func TestFormatOCSFEventTruncatesOversizedStringField(t *testing.T) {
 	}
 	if !strings.HasSuffix(blob, "...[truncated]") {
 		t.Fatalf("truncated field missing marker: %q", blob[len(blob)-20:])
+	}
+}
+
+func TestOCSFTruncateStringRuneSafe(t *testing.T) {
+	// A string whose byte cap lands mid-rune must not emit a split (U+FFFD) rune.
+	s := strings.Repeat("A", ocsfMaxStringBytes-1) + strings.Repeat("€", 8)
+	line := FormatOCSFEvent(Event{
+		Severity:  SeverityWarn,
+		Type:      EventBlocked,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields:    map[string]any{"blob": s},
+	}, "dev")
+	got := parseOCSFEvent(t, line)
+	fields := assertMap(t, assertMap(t, assertMap(t, got, "unmapped"), "pipelock"), "fields")
+	blob := stringValue(t, fields, "blob")
+	if !utf8.ValidString(blob) {
+		t.Fatalf("truncated field is not valid UTF-8")
+	}
+	if strings.ContainsRune(blob, '�') {
+		t.Fatalf("truncated field split a rune (contains U+FFFD)")
+	}
+	if !strings.HasSuffix(blob, "...[truncated]") {
+		t.Fatalf("missing truncation marker: %q", blob[max(0, len(blob)-20):])
 	}
 }

--- a/internal/emit/ocsf_test.go
+++ b/internal/emit/ocsf_test.go
@@ -1,0 +1,414 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emit
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatOCSFEventDetectionFinding(t *testing.T) {
+	ts := time.Date(2026, 7, 5, 12, 34, 56, 789000000, time.UTC)
+	event := Event{
+		Severity:   SeverityWarn,
+		Type:       EventBodyDLP,
+		Timestamp:  ts,
+		InstanceID: testInstanceName,
+		Fields: map[string]any{
+			"action":     conventionActionBlock,
+			"agent":      "agent-a",
+			"client_ip":  "203.0.113.10",
+			"method":     "POST",
+			"pattern":    "api-key",
+			"request_id": "req-123",
+			"scanner":    "dlp",
+			"url":        "https://api.vendor.example/v1/chat?mode=sync",
+			fieldReason:  "secret detected",
+		},
+	}
+
+	got := parseOCSFEvent(t, FormatOCSFEvent(event, "1.2.3"))
+	assertNumber(t, got, "class_uid", 2004)
+	assertString(t, got, "class_name", "Detection Finding")
+	assertNumber(t, got, "category_uid", 2)
+	assertString(t, got, "category_name", "Findings")
+	assertNumber(t, got, "activity_id", 1)
+	assertString(t, got, "activity_name", "Create")
+	assertNumber(t, got, "type_uid", 200401)
+	assertString(t, got, "type_name", "Detection Finding: Create")
+	assertNumber(t, got, "severity_id", 3)
+	assertString(t, got, "severity", "Medium")
+	assertNumber(t, got, "time", float64(ts.UnixMilli()))
+	assertString(t, got, "status", "New")
+	assertNumber(t, got, "status_id", 1)
+	assertString(t, got, "message", "body_dlp: secret detected")
+	assertString(t, got, "action", "block")
+	assertNumber(t, got, "action_id", 2)
+	assertString(t, got, "status_detail", "secret detected")
+
+	metadata := assertMap(t, got, "metadata")
+	assertString(t, metadata, "version", ocsfSchemaVersion)
+	product := assertMap(t, metadata, "product")
+	assertString(t, product, "vendor_name", "Pipelock")
+	assertString(t, product, "name", "Pipelock")
+	assertString(t, product, "version", "1.2.3")
+
+	findingInfo := assertMap(t, got, "finding_info")
+	assertString(t, findingInfo, "title", "body_dlp: secret detected")
+	assertString(t, findingInfo, "desc", "secret detected")
+	assertNumber(t, findingInfo, "created_time", float64(ts.UnixMilli()))
+	if uid := stringValue(t, findingInfo, "uid"); uid == "" {
+		t.Fatal("finding_info.uid is empty")
+	}
+
+	actor := assertMap(t, got, "actor")
+	user := assertMap(t, actor, "user")
+	assertString(t, user, "name", "agent-a")
+	src := assertMap(t, got, "src_endpoint")
+	assertString(t, src, "ip", "203.0.113.10")
+	dst := assertMap(t, got, "dst_endpoint")
+	assertString(t, dst, "hostname", "api.vendor.example")
+	eventURL := assertMap(t, got, "url")
+	assertString(t, eventURL, "url_string", "https://api.vendor.example/v1/chat?mode=sync")
+	assertString(t, eventURL, "hostname", "api.vendor.example")
+	assertString(t, eventURL, "path", "/v1/chat")
+	assertString(t, eventURL, "query_string", "mode=sync")
+	req := assertMap(t, got, "http_request")
+	assertString(t, req, "http_method", "POST")
+	assertString(t, req, "uid", "req-123")
+
+	unmapped := assertMap(t, got, "unmapped")
+	pipelock := assertMap(t, unmapped, "pipelock")
+	assertString(t, pipelock, "event_type", EventBodyDLP)
+	assertString(t, pipelock, "severity", "warn")
+	assertString(t, pipelock, "instance_id", testInstanceName)
+	assertString(t, pipelock, "decision_type", EventBodyDLP)
+	fields := assertMap(t, pipelock, "fields")
+	assertString(t, fields, "scanner", "dlp")
+	assertString(t, fields, "pattern", "api-key")
+}
+
+func TestFormatOCSFEventSeverityMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity Severity
+		wantID   float64
+		wantName string
+	}{
+		{name: "info", severity: SeverityInfo, wantID: 1, wantName: "Informational"},
+		{name: "warn", severity: SeverityWarn, wantID: 3, wantName: "Medium"},
+		{name: "critical", severity: SeverityCritical, wantID: 5, wantName: "Critical"},
+		{name: "unknown", severity: Severity(99), wantID: 0, wantName: "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseOCSFEvent(t, FormatOCSFEvent(Event{
+				Severity:  tt.severity,
+				Type:      EventResponseScan,
+				Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+				Fields:    map[string]any{},
+			}, "dev"))
+			assertNumber(t, got, "severity_id", tt.wantID)
+			assertString(t, got, "severity", tt.wantName)
+		})
+	}
+}
+
+func TestFormatOCSFEventDoesNotHTMLEscape(t *testing.T) {
+	event := Event{
+		Severity:  SeverityCritical,
+		Type:      EventBlocked,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields: map[string]any{
+			fieldReason: "<script>&blocked",
+			"url":       "https://api.vendor.example/path?q=<token>&mode=test",
+		},
+	}
+
+	line := FormatOCSFEvent(event, "dev")
+	if strings.Contains(line, `\u003c`) || strings.Contains(line, `\u003e`) || strings.Contains(line, `\u0026`) {
+		t.Fatalf("OCSF line HTML-escaped characters:\n%s", line)
+	}
+	got := parseOCSFEvent(t, line)
+	assertString(t, got, "message", "blocked: <script>&blocked")
+}
+
+func TestFormatOCSFEventEscapesControlsAndIsDeterministic(t *testing.T) {
+	event := Event{
+		Severity:   SeverityWarn,
+		Type:       EventBlocked,
+		Timestamp:  time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		InstanceID: testInstanceName,
+		Fields: map[string]any{
+			fieldReason:   "quoted \" value\nnext line\x01",
+			"unsupported": map[int]string{1: "one"},
+			"z":           "last",
+			"a":           "first",
+		},
+	}
+
+	first := FormatOCSFEvent(event, "dev")
+	second := FormatOCSFEvent(event, "dev")
+	if first != second {
+		t.Fatalf("OCSF output is not deterministic:\nfirst:  %s\nsecond: %s", first, second)
+	}
+
+	got := parseOCSFEvent(t, first)
+	assertString(t, got, "message", "blocked: quoted \" value\nnext line\x01")
+	fields := assertMap(t, assertMap(t, assertMap(t, got, "unmapped"), "pipelock"), "fields")
+	assertString(t, fields, "unsupported", "[unsupported]")
+}
+
+func TestFormatOCSFEventHandlesUnmarshalableFields(t *testing.T) {
+	line := FormatOCSFEvent(Event{
+		Severity:  SeverityWarn,
+		Type:      EventError,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields: map[string]any{
+			"bad": make(chan int),
+		},
+	}, "dev")
+	got := parseOCSFEvent(t, line)
+	fields := assertMap(t, assertMap(t, assertMap(t, got, "unmapped"), "pipelock"), "fields")
+	if _, ok := fields["bad"].(string); !ok {
+		t.Fatalf("unmarshalable field was not rendered as string: %#v", fields["bad"])
+	}
+}
+
+func TestFormatOCSFEventHandlesCyclicFields(t *testing.T) {
+	fields := map[string]any{}
+	fields["self"] = fields
+
+	line := FormatOCSFEvent(Event{
+		Severity:  SeverityWarn,
+		Type:      EventError,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields:    fields,
+	}, "dev")
+	got := parseOCSFEvent(t, line)
+	pipelock := assertMap(t, assertMap(t, got, "unmapped"), "pipelock")
+	if _, ok := pipelock["fields"].(map[string]any); !ok {
+		t.Fatalf("cyclic fields were not preserved as a JSON object: %#v", pipelock["fields"])
+	}
+}
+
+func TestFormatOCSFEventHandlesNonFiniteNumbers(t *testing.T) {
+	line := FormatOCSFEvent(Event{
+		Severity:  SeverityWarn,
+		Type:      EventError,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields: map[string]any{
+			"nan":      math.NaN(),
+			"positive": math.Inf(1),
+			"negative": float32(math.Inf(-1)),
+		},
+	}, "dev")
+	got := parseOCSFEvent(t, line)
+	assertNumber(t, got, "class_uid", ocsfClassUIDDetectionFinding)
+	assertString(t, got, "message", EventError)
+
+	fields := assertMap(t, assertMap(t, assertMap(t, got, "unmapped"), "pipelock"), "fields")
+	assertString(t, fields, "nan", "NaN")
+	assertString(t, fields, "positive", "+Inf")
+	assertString(t, fields, "negative", "-Inf")
+}
+
+func parseOCSFEvent(t *testing.T, line string) map[string]any {
+	t.Helper()
+	if strings.ContainsAny(line, "\r\n") {
+		t.Fatalf("OCSF line is not compact single-line JSON: %q", line)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(line), &out); err != nil {
+		t.Fatalf("OCSF line is not valid JSON: %v\n%s", err, line)
+	}
+	return out
+}
+
+func assertMap(t *testing.T, values map[string]any, key string) map[string]any {
+	t.Helper()
+	got, ok := values[key].(map[string]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want object", key, values[key])
+	}
+	return got
+}
+
+func assertString(t *testing.T, values map[string]any, key, want string) {
+	t.Helper()
+	if got := stringValue(t, values, key); got != want {
+		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}
+
+func stringValue(t *testing.T, values map[string]any, key string) string {
+	t.Helper()
+	got, ok := values[key].(string)
+	if !ok {
+		t.Fatalf("%s = %#v, want string", key, values[key])
+	}
+	return got
+}
+
+func assertNumber(t *testing.T, values map[string]any, key string, want float64) {
+	t.Helper()
+	got, ok := values[key].(float64)
+	if !ok {
+		t.Fatalf("%s = %#v, want number", key, values[key])
+	}
+	if got != want {
+		t.Fatalf("%s = %v, want %v", key, got, want)
+	}
+}
+
+func TestFormatOCSFEventMinimalEventOmitsOptionalFields(t *testing.T) {
+	line := FormatOCSFEvent(Event{
+		Severity:  SeverityInfo,
+		Type:      EventError,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+	}, "dev")
+	got := parseOCSFEvent(t, line)
+	assertNumber(t, got, "class_uid", ocsfClassUIDDetectionFinding)
+	for _, key := range []string{"actor", "url", "http_request", "src_endpoint", "dst_endpoint"} {
+		if _, present := got[key]; present {
+			t.Fatalf("optional field %q should be omitted for a fieldless event: %#v", key, got[key])
+		}
+	}
+}
+
+func TestOCSFActionID(t *testing.T) {
+	tests := map[string]int{
+		conventionActionAllow: 1,
+		eventActionForward:    1,
+		EventRedirect:         1,
+		conventionActionBlock: 2,
+		eventActionStrip:      2,
+		conventionActionWarn:  99,
+		conventionActionAsk:   99,
+		eventActionDefer:      99,
+		"":                    0,
+		"something-else":      0,
+	}
+	for action, want := range tests {
+		if got := ocsfActionID(action); got != want {
+			t.Fatalf("ocsfActionID(%q) = %d, want %d", action, got, want)
+		}
+	}
+}
+
+type ocsfStringerFixture struct{}
+
+func (ocsfStringerFixture) String() string { return "stringer-value" }
+
+func TestOCSFJSONValueDepthTypes(t *testing.T) {
+	if got := ocsfJSONValueDepth("x", 17); got != "[truncated]" {
+		t.Fatalf("depth guard = %#v, want [truncated]", got)
+	}
+	if got := ocsfJSONValue(nil); got != nil {
+		t.Fatalf("nil = %#v, want nil", got)
+	}
+	if got := ocsfJSONValue(ocsfStringerFixture{}); got != "stringer-value" {
+		t.Fatalf("stringer = %#v, want stringer-value", got)
+	}
+	if got, ok := ocsfJSONValue([]string{"a", "b"}).([]string); !ok || len(got) != 2 {
+		t.Fatalf("[]string = %#v, want 2-element []string", got)
+	}
+	if got, ok := ocsfJSONValue([]any{1, "b"}).([]any); !ok || len(got) != 2 {
+		t.Fatalf("[]any = %#v, want 2-element []any", got)
+	}
+	if got, ok := ocsfJSONValue(map[string]any{"k": "v"}).(map[string]any); !ok || got["k"] != "v" {
+		t.Fatalf("map[string]any = %#v", got)
+	}
+	if got, ok := ocsfJSONValue(map[string]string{"k": "v"}).(map[string]any); !ok || got["k"] != "v" {
+		t.Fatalf("map[string]string = %#v", got)
+	}
+	if got, ok := ocsfJSONValue([3]int{1, 2, 3}).([]any); !ok || len(got) != 3 {
+		t.Fatalf("reflect array = %#v, want 3-element []any", got)
+	}
+	if got := ocsfJSONValue(map[int]string{1: "a"}); got != "[unsupported]" {
+		t.Fatalf("non-string-key map = %#v, want [unsupported]", got)
+	}
+	if got, ok := ocsfJSONValue(map[string]int{"n": 7}).(map[string]any); !ok || got["n"].(int) != 7 {
+		t.Fatalf("reflect string-key map = %#v", got)
+	}
+}
+
+func TestFallbackOCSFEventEmitsValidFindingWithErrorMarker(t *testing.T) {
+	record := ocsfDetectionFinding{
+		ClassUID:    ocsfClassUIDDetectionFinding,
+		Message:     "blocked: ssrf",
+		StatusID:    ocsfStatusIDNew,
+		FindingInfo: ocsfFindingInfo{Title: "blocked: ssrf"},
+		Actor:       &ocsfActor{User: ocsfUser{Name: "agent-a"}},
+		URL:         &ocsfURL{URLString: "http://host.vendor.example/"},
+		Unmapped: map[string]any{
+			"pipelock": map[string]any{"event_type": "blocked"},
+		},
+	}
+	line := fallbackOCSFEvent(record, errors.New("boom"))
+	got := parseOCSFEvent(t, line)
+	assertNumber(t, got, "class_uid", ocsfClassUIDDetectionFinding)
+	if msg := stringValue(t, got, "message"); !strings.HasPrefix(msg, "ocsf_format_error: ") {
+		t.Fatalf("message = %q, want ocsf_format_error prefix", msg)
+	}
+	assertString(t, got, "status_detail", "boom")
+	pipelock := assertMap(t, assertMap(t, got, "unmapped"), "pipelock")
+	assertString(t, pipelock, "event_type", "blocked")
+	assertString(t, pipelock, "ocsf_format_error", "boom")
+	for _, key := range []string{"actor", "url", "http_request", "src_endpoint", "dst_endpoint"} {
+		if _, present := got[key]; present {
+			t.Fatalf("fallback should strip typed field %q: %#v", key, got[key])
+		}
+	}
+}
+
+func TestFormatOCSFEventBranchCoverage(t *testing.T) {
+	// Empty deviceVersion default, explicit URL port, finite float field, and an
+	// event whose action resolves to none (action_id 0, which clears the label).
+	got := parseOCSFEvent(t, FormatOCSFEvent(Event{
+		Severity:  SeverityInfo,
+		Type:      "synthetic_note_event", // no known action mapping -> action_id 0
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields: map[string]any{
+			"url":   "https://api.vendor.example:8443/v1?x=1",
+			"score": float64(1.5),
+			"ratio": float32(0.25),
+		},
+	}, ""))
+	product := assertMap(t, assertMap(t, got, "metadata"), "product")
+	assertString(t, product, "version", "unknown")
+	if _, present := got["action"]; present {
+		t.Fatalf("unknown action should be cleared, got %#v", got["action"])
+	}
+	assertNumber(t, assertMap(t, got, "url"), "port", 8443)
+	fields := assertMap(t, assertMap(t, assertMap(t, got, "unmapped"), "pipelock"), "fields")
+	assertNumber(t, fields, "score", 1.5)
+	assertNumber(t, fields, "ratio", 0.25)
+}
+
+func TestFormatOCSFEventHostnameTargetAndUnparseableURL(t *testing.T) {
+	// dst_endpoint hostname branch: a target with no URL field.
+	got := parseOCSFEvent(t, FormatOCSFEvent(Event{
+		Severity:  SeverityWarn,
+		Type:      EventBlocked,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields:    map[string]any{"target": "backend.vendor.example"},
+	}, "dev"))
+	assertString(t, assertMap(t, got, "dst_endpoint"), "hostname", "backend.vendor.example")
+
+	// url.Parse error branch: a control character makes net/url reject the URL,
+	// so only the raw url_string is carried.
+	got2 := parseOCSFEvent(t, FormatOCSFEvent(Event{
+		Severity:  SeverityWarn,
+		Type:      EventBlocked,
+		Timestamp: time.Date(2026, 7, 5, 1, 2, 3, 0, time.UTC),
+		Fields:    map[string]any{"url": "http://bad\x7fhost/path"},
+	}, "dev"))
+	assertString(t, assertMap(t, got2, "url"), "url_string", "http://bad\x7fhost/path")
+}

--- a/internal/emit/syslog.go
+++ b/internal/emit/syslog.go
@@ -187,7 +187,7 @@ func NewSyslogSink(address string, opts ...SyslogOption) (*SyslogSink, error) {
 }
 
 func validateSyslogFormat(format string) error {
-	if format == "" || format == FormatJSON || format == FormatCEF {
+	if format == "" || format == FormatJSON || format == FormatCEF || format == FormatOCSF {
 		return nil
 	}
 	return fmt.Errorf("emit: unsupported syslog format %q", format)
@@ -364,6 +364,14 @@ func makeSyslogMessage(event Event, format, deviceVersion string) (syslogMessage
 	}
 	if format == FormatCEF {
 		msg := FormatCEFEvent(event, deviceVersion)
+		return syslogMessage{
+			severity:  event.Severity,
+			eventType: event.Type,
+			message:   msg,
+		}, nil
+	}
+	if format == FormatOCSF {
+		msg := FormatOCSFEvent(event, deviceVersion)
 		return syslogMessage{
 			severity:  event.Severity,
 			eventType: event.Type,

--- a/internal/emit/syslog_test.go
+++ b/internal/emit/syslog_test.go
@@ -711,6 +711,31 @@ func TestMakeSyslogMessage_CEF(t *testing.T) {
 	}
 }
 
+func TestMakeSyslogMessage_OCSF(t *testing.T) {
+	msg, err := makeSyslogMessage(Event{
+		Severity:   SeverityWarn,
+		Type:       EventHeaderDLP,
+		Timestamp:  time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC),
+		InstanceID: testInstanceName,
+		Fields: map[string]any{
+			"action":    conventionActionBlock,
+			"agent":     "agent-a",
+			fieldReason: "header token",
+		},
+	}, FormatOCSF, "1.2.3")
+	if err != nil {
+		t.Fatalf("makeSyslogMessage OCSF: %v", err)
+	}
+	got := parseOCSFEvent(t, msg.message)
+	assertNumber(t, got, "class_uid", 2004)
+	assertNumber(t, got, "category_uid", 2)
+	assertNumber(t, got, "type_uid", 200401)
+	assertString(t, got, "message", "header_dlp: header token")
+	assertString(t, got, "action", conventionActionBlock)
+	product := assertMap(t, assertMap(t, got, "metadata"), "product")
+	assertString(t, product, "version", "1.2.3")
+}
+
 func TestMakeSyslogMessage_InvalidFormat(t *testing.T) {
 	_, err := makeSyslogMessage(Event{
 		Severity:  SeverityWarn,

--- a/internal/emitformat/format.go
+++ b/internal/emitformat/format.go
@@ -7,8 +7,9 @@ package emitformat
 const (
 	JSON = "json"
 	CEF  = "cef"
+	OCSF = "ocsf"
 )
 
 func Supported(format string) bool {
-	return format == JSON || format == CEF
+	return format == JSON || format == CEF || format == OCSF
 }

--- a/internal/emitformat/format_test.go
+++ b/internal/emitformat/format_test.go
@@ -13,6 +13,7 @@ func TestSupported(t *testing.T) {
 	}{
 		{name: "json", format: JSON, want: true},
 		{name: "cef", format: CEF, want: true},
+		{name: "ocsf", format: OCSF, want: true},
 		{name: "empty", format: "", want: false},
 		{name: "unsupported", format: "xml", want: false},
 	}

--- a/internal/playground/livechat/budget_test.go
+++ b/internal/playground/livechat/budget_test.go
@@ -290,7 +290,7 @@ func TestServer_DailyTurnBudget_KillSwitch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new health request: %v", err)
 	}
-	healthResp, err := http.DefaultClient.Do(req)
+	healthResp, err := ts.Client().Do(req)
 	if err != nil {
 		t.Fatalf("health: %v", err)
 	}

--- a/internal/playground/livechat/server_bundle_test.go
+++ b/internal/playground/livechat/server_bundle_test.go
@@ -96,7 +96,7 @@ func TestServer_Bundle_DownloadsVerifiableArchive(t *testing.T) {
 	// streamed: the verifiable live-demo run requires both an allow receipt and a
 	// body-DLP block receipt, so sealing only succeeds once both have landed.
 	streamReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream+"?token="+cr.Token, nil)
-	streamResp, err := http.DefaultClient.Do(streamReq)
+	streamResp, err := ts.Client().Do(streamReq)
 	if err != nil {
 		t.Fatalf("stream: %v", err)
 	}
@@ -309,7 +309,7 @@ func sealReadySession(t *testing.T, ts *httptest.Server) string {
 	}
 
 	streamReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream+"?token="+cr.Token, nil)
-	streamResp, err := http.DefaultClient.Do(streamReq)
+	streamResp, err := ts.Client().Do(streamReq)
 	if err != nil {
 		t.Fatalf("stream: %v", err)
 	}
@@ -365,7 +365,11 @@ func getRaw(t *testing.T, url string) *http.Response {
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	// Dedicated client with keep-alives disabled: this helper has no server in
+	// scope, and using the shared default transport lets a parallel test's
+	// server teardown close an idle connection mid-request.
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("do: %v", err)
 	}

--- a/internal/playground/livechat/server_killswitch_test.go
+++ b/internal/playground/livechat/server_killswitch_test.go
@@ -167,7 +167,7 @@ func TestServer_KillSwitch_RejectsSessionStartedDuringKill(t *testing.T) {
 			return
 		}
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := ts.Client().Do(req)
 		if err != nil {
 			errC <- err
 			return

--- a/internal/playground/livechat/server_more_test.go
+++ b/internal/playground/livechat/server_more_test.go
@@ -15,7 +15,7 @@ func TestServer_Message_MethodNotAllowed(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t, ServerConfig{})
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteMessage, nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func TestServer_Stream_RateLimitedBeforeTokenValidation(t *testing.T) {
 	ts := newTestServer(t, ServerConfig{IPRate: RateConfig{RefillPerSec: 1, Burst: 1}})
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream, nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestServer_Stream_RateLimitedBeforeTokenValidation(t *testing.T) {
 	}
 
 	req, _ = http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream, nil)
-	resp, err = http.DefaultClient.Do(req)
+	resp, err = ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestServer_CORSAndForwardedFor(t *testing.T) {
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+RouteSession, strings.NewReader(b))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestServer_CORSPreflight(t *testing.T) {
 
 	for _, route := range []string{RouteMessage, RouteHealth} {
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodOptions, ts.URL+route, nil)
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := ts.Client().Do(req)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -129,7 +129,7 @@ func TestServer_Session_BadJSON(t *testing.T) {
 	ts := newTestServer(t, ServerConfig{})
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+RouteSession, strings.NewReader("{not json"))
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestServer_Session_RejectsTrailingJSON(t *testing.T) {
 	ts := newTestServer(t, ServerConfig{})
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+RouteSession, strings.NewReader(`{"code":"good"} {}`))
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/playground/livechat/server_test.go
+++ b/internal/playground/livechat/server_test.go
@@ -59,7 +59,11 @@ func postJSON(t *testing.T, url string, body any) *http.Response {
 		t.Fatalf("new request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	// Dedicated client with keep-alives disabled: this helper has no server in
+	// scope, and the shared default transport lets a parallel test's server
+	// teardown close an idle connection mid-request.
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("do: %v", err)
 	}
@@ -111,7 +115,7 @@ func TestServer_Session_MethodAndCodeChecks(t *testing.T) {
 
 	// GET not allowed.
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteSession, nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +241,7 @@ func TestServer_Stream_AuthChecks(t *testing.T) {
 
 	// Only GET/OPTIONS may reach the stream path.
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL+RouteStream, nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +252,7 @@ func TestServer_Stream_AuthChecks(t *testing.T) {
 
 	// No token.
 	req, _ = http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream, nil)
-	resp, err = http.DefaultClient.Do(req)
+	resp, err = ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +264,7 @@ func TestServer_Stream_AuthChecks(t *testing.T) {
 	// Valid token, no session -> 404.
 	tok, _, _ := g.Redeem("good", "ghost")
 	req, _ = http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream+"?token="+tok, nil)
-	resp, err = http.DefaultClient.Do(req)
+	resp, err = ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +278,7 @@ func TestServer_Health(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t, ServerConfig{})
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteHealth, nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := ts.Client().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +341,7 @@ func TestServer_FullFlow_StreamsSignedDecisions(t *testing.T) {
 
 	// Open the SSE stream.
 	streamReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream+"?token="+cr.Token, nil)
-	streamResp, err := http.DefaultClient.Do(streamReq)
+	streamResp, err := ts.Client().Do(streamReq)
 	if err != nil {
 		t.Fatalf("stream: %v", err)
 	}
@@ -346,7 +350,7 @@ func TestServer_FullFlow_StreamsSignedDecisions(t *testing.T) {
 		t.Fatalf("stream status = %d, want 200", streamResp.StatusCode)
 	}
 	secondReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+RouteStream+"?token="+cr.Token, nil)
-	secondResp, err := http.DefaultClient.Do(secondReq)
+	secondResp, err := ts.Client().Do(secondReq)
 	if err != nil {
 		t.Fatalf("second stream: %v", err)
 	}


### PR DESCRIPTION
## What changed

Adds `ocsf` as a third syslog emit format alongside `json` and `cef`. Each event renders as one OCSF Detection Finding (class_uid 2004) JSON object: actor, URL, HTTP method and request id, and network endpoints map to typed OCSF fields when the event carries them, and the remaining event fields are preserved under `unmapped`. Operators select it with `emit.syslog.format: ocsf`.

## Why

OCSF is the schema most SIEM pipelines normalize to. Forwarding Pipelock events to a SIEM no longer needs a downstream transform from CEF or JSON.

## Notes

Format selection, config validation, and the schema all learn `ocsf`, and the presets plus the SIEM integration guide document it. Non-finite numeric field values are stringified before encoding, and if a payload still fails to marshal the formatter emits a valid OCSF finding carrying an error marker rather than dropping the event.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **OCSF** as a supported syslog output format.
  * Syslog can now emit OCSF **Detection Finding** JSON, including event/severity/action plus URL and request details.
  * Added a configuration option to select `json`, `cef`, or `ocsf` syslog formats (default remains `json`).

* **Documentation**
  * Updated the configuration reference and SIEM integration guide with `syslog.format` (`json`, `cef`, `ocsf`) and examples.

* **Tests**
  * Expanded configuration validation and reload tests for `ocsf`.
  * Added unit tests covering OCSF formatting, escaping/determinism, and hostile-value robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->