### PR TITLE
feat(mcp): add data-class label taxonomy and config foundation

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -388,6 +388,10 @@ mcp_tool_scanning:
   action: warn
   detect_drift: true
 
+mcp_data_class_labels:
+  enabled: false
+  unknown_class: secret  # foundation only; no runtime effect until derivation wiring lands
+
 mcp_tool_policy:
   enabled: true
   action: warn

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -424,6 +424,10 @@ mcp_tool_scanning:
   action: warn
   detect_drift: true
 
+mcp_data_class_labels:
+  enabled: false
+  unknown_class: secret  # foundation only; no runtime effect until derivation wiring lands
+
 mcp_tool_policy:
   enabled: true
   action: warn

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -418,6 +418,10 @@ mcp_tool_scanning:
   action: block
   detect_drift: true
 
+mcp_data_class_labels:
+  enabled: false
+  unknown_class: secret  # foundation only; no runtime effect until derivation wiring lands
+
 mcp_tool_policy:
   enabled: true
   action: warn

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -419,6 +419,10 @@ mcp_tool_scanning:
   action: block
   detect_drift: true
 
+mcp_data_class_labels:
+  enabled: false
+  unknown_class: secret  # foundation only; no runtime effect until derivation wiring lands
+
 mcp_tool_policy:
   enabled: true
   action: warn

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -426,6 +426,10 @@ mcp_tool_scanning:
   action: warn
   detect_drift: true
 
+mcp_data_class_labels:
+  enabled: false
+  unknown_class: secret  # foundation only; no runtime effect until derivation wiring lands
+
 mcp_tool_policy:
   enabled: true
   action: warn

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -404,6 +404,10 @@ mcp_tool_scanning:
   action: block
   detect_drift: true
 
+mcp_data_class_labels:
+  enabled: false
+  unknown_class: secret  # foundation only; no runtime effect until derivation wiring lands
+
 mcp_tool_policy:
   enabled: true
   action: block

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -409,6 +409,10 @@ mcp_tool_scanning:
   action: block
   detect_drift: true
 
+mcp_data_class_labels:
+  enabled: false
+  unknown_class: secret  # foundation only; no runtime effect until derivation wiring lands
+
 mcp_tool_policy:
   enabled: true
   action: block

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -540,6 +540,7 @@ func implausibleReloadTeardownReasons(oldCfg, newCfg *config.Config) []string {
 	appendDisabled("tls_interception.enabled", oldCfg.TLSInterception.Enabled, newCfg.TLSInterception.Enabled)
 	appendDisabled("mcp_input_scanning.enabled", oldCfg.MCPInputScanning.Enabled, newCfg.MCPInputScanning.Enabled)
 	appendDisabled("mcp_tool_scanning.enabled", oldCfg.MCPToolScanning.Enabled, newCfg.MCPToolScanning.Enabled)
+	appendDisabled("mcp_data_class_labels.enabled", oldCfg.MCPDataClassLabels.Enabled, newCfg.MCPDataClassLabels.Enabled)
 	appendDisabled("mcp_tool_policy.enabled", oldCfg.MCPToolPolicy.Enabled, newCfg.MCPToolPolicy.Enabled)
 	appendDisabled("session_profiling.enabled", oldCfg.SessionProfiling.Enabled, newCfg.SessionProfiling.Enabled)
 	appendDisabled("adaptive_enforcement.enabled", oldCfg.AdaptiveEnforcement.Enabled, newCfg.AdaptiveEnforcement.Enabled)

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -540,7 +540,6 @@ func implausibleReloadTeardownReasons(oldCfg, newCfg *config.Config) []string {
 	appendDisabled("tls_interception.enabled", oldCfg.TLSInterception.Enabled, newCfg.TLSInterception.Enabled)
 	appendDisabled("mcp_input_scanning.enabled", oldCfg.MCPInputScanning.Enabled, newCfg.MCPInputScanning.Enabled)
 	appendDisabled("mcp_tool_scanning.enabled", oldCfg.MCPToolScanning.Enabled, newCfg.MCPToolScanning.Enabled)
-	appendDisabled("mcp_data_class_labels.enabled", oldCfg.MCPDataClassLabels.Enabled, newCfg.MCPDataClassLabels.Enabled)
 	appendDisabled("mcp_tool_policy.enabled", oldCfg.MCPToolPolicy.Enabled, newCfg.MCPToolPolicy.Enabled)
 	appendDisabled("session_profiling.enabled", oldCfg.SessionProfiling.Enabled, newCfg.SessionProfiling.Enabled)
 	appendDisabled("adaptive_enforcement.enabled", oldCfg.AdaptiveEnforcement.Enabled, newCfg.AdaptiveEnforcement.Enabled)

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -194,6 +194,11 @@ func (c *Config) policySemanticView() Config {
 	// view because those do affect detection.
 	view.MCPToolPolicy.QuarantineDir = ""
 
+	// MCPDataClassLabels is a foundation-only config surface until the
+	// derivation path populates receipt fields. Exclude it from the semantic
+	// policy hash while it has no runtime decision effect.
+	view.MCPDataClassLabels = MCPDataClassLabels{}
+
 	// HealthWatchdog is excluded from the canonical hash via the `json:"-"`
 	// tag on the Config field - operational liveness, not policy. Whether
 	// the watchdog is enabled or what tick interval it uses does not change

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/luckyPipewrench/pipelock/internal/datalabel"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 )
 
@@ -152,6 +153,28 @@ func TestCanonicalPolicyHash_NoiseFieldsDoNotAffect(t *testing.T) {
 					tc.name, base, got)
 			}
 		})
+	}
+}
+
+func TestCanonicalPolicyHash_MCPDataClassLabelsFoundationInert(t *testing.T) {
+	t.Parallel()
+
+	base := canonicalHashOf(t, nil)
+
+	enabled := canonicalHashOf(t, func(c *Config) {
+		c.MCPDataClassLabels.Enabled = true
+		c.MCPDataClassLabels.UnknownClass = string(datalabel.DataClassSecret)
+	})
+	if enabled != base {
+		t.Fatalf("CanonicalPolicyHash() changed when inert mcp_data_class_labels.enabled was set: got %s want %s", enabled, base)
+	}
+
+	nonDefaultRawValue := canonicalHashOf(t, func(c *Config) {
+		c.MCPDataClassLabels.Enabled = true
+		c.MCPDataClassLabels.UnknownClass = string(datalabel.DataClassPII)
+	})
+	if nonDefaultRawValue != base {
+		t.Fatalf("CanonicalPolicyHash() changed when inert mcp_data_class_labels.unknown_class was set: got %s want %s", nonDefaultRawValue, base)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/datalabel"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"gopkg.in/yaml.v3"
@@ -5022,6 +5023,93 @@ func TestValidateReload_MCPToolScanningDisabled(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected warning for MCP tool scanning disabled")
+	}
+}
+
+// --- MCPDataClassLabels Tests ---
+
+func TestMCPDataClassLabelsDefaults(t *testing.T) {
+	cfg := Defaults()
+	cfg.ApplyDefaults()
+
+	if cfg.MCPDataClassLabels.Enabled {
+		t.Fatal("mcp_data_class_labels.enabled default = true, want false until derivation is wired")
+	}
+	if cfg.MCPDataClassLabels.UnknownClass != string(datalabel.DataClassSecret) {
+		t.Fatalf("unknown_class = %q, want %q", cfg.MCPDataClassLabels.UnknownClass, datalabel.DataClassSecret)
+	}
+}
+
+func TestLoad_MCPDataClassLabelsEnabledSixStates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	loadBody := func(name, body string) *Config {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("%s: write config: %v", name, err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("%s: Load() error = %v", name, err)
+		}
+		return cfg
+	}
+
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "omitted",
+			body: "mode: balanced\n",
+			want: false,
+		},
+		{
+			name: "yaml null blank",
+			body: "mode: balanced\nmcp_data_class_labels:\n  enabled:\n",
+			want: false,
+		},
+		{
+			name: "explicit false",
+			body: "mode: balanced\nmcp_data_class_labels:\n  enabled: false\n",
+			want: false,
+		},
+		{
+			name: "explicit true",
+			body: "mode: balanced\nmcp_data_class_labels:\n  enabled: true\n",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := loadBody(tt.name, tt.body)
+			if cfg.MCPDataClassLabels.Enabled != tt.want {
+				t.Fatalf("enabled = %v, want %v", cfg.MCPDataClassLabels.Enabled, tt.want)
+			}
+			if cfg.MCPDataClassLabels.UnknownClass != string(datalabel.DataClassSecret) {
+				t.Fatalf("unknown_class = %q, want %q", cfg.MCPDataClassLabels.UnknownClass, datalabel.DataClassSecret)
+			}
+		})
+	}
+
+	old := loadBody("reload old true", "mode: balanced\nmcp_data_class_labels:\n  enabled: true\n")
+	updated := loadBody("reload new false", "mode: balanced\nmcp_data_class_labels:\n  enabled: false\n")
+	if !hasReloadWarning(ValidateReload(old, updated), "mcp_data_class_labels.enabled") {
+		t.Fatal("reload-with-change should warn when mcp_data_class_labels.enabled is disabled")
+	}
+
+	unchanged := loadBody("reload unchanged true", "mode: balanced\nmcp_data_class_labels:\n  enabled: true\n")
+	if hasReloadWarning(ValidateReload(old, unchanged), "mcp_data_class_labels.enabled") {
+		t.Fatal("reload-without-change should not warn for unchanged mcp_data_class_labels.enabled")
+	}
+}
+
+func TestValidate_MCPDataClassLabelsRejectsBadUnknownClass(t *testing.T) {
+	cfg := Defaults()
+	cfg.MCPDataClassLabels.UnknownClass = string(datalabel.DataClassBenign)
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "mcp_data_class_labels.unknown_class") {
+		t.Fatalf("Validate() error = %v, want mcp_data_class_labels.unknown_class rejection", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5040,52 +5040,29 @@ func TestMCPDataClassLabelsDefaults(t *testing.T) {
 	}
 }
 
-func TestLoad_MCPDataClassLabelsEnabledSixStates(t *testing.T) {
+func TestLoad_MCPDataClassLabelsEnabledRejectedUntilWired(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "pipelock.yaml")
-	loadBody := func(name, body string) *Config {
+	write := func(t *testing.T, body string) {
 		t.Helper()
 		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-			t.Fatalf("%s: write config: %v", name, err)
+			t.Fatalf("write config: %v", err)
 		}
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("%s: Load() error = %v", name, err)
-		}
-		return cfg
 	}
 
-	tests := []struct {
-		name string
-		body string
-		want bool
-	}{
-		{
-			name: "omitted",
-			body: "mode: balanced\n",
-			want: false,
-		},
-		{
-			name: "yaml null blank",
-			body: "mode: balanced\nmcp_data_class_labels:\n  enabled:\n",
-			want: false,
-		},
-		{
-			name: "explicit false",
-			body: "mode: balanced\nmcp_data_class_labels:\n  enabled: false\n",
-			want: false,
-		},
-		{
-			name: "explicit true",
-			body: "mode: balanced\nmcp_data_class_labels:\n  enabled: true\n",
-			want: true,
-		},
-	}
-
-	for _, tt := range tests {
+	// Disabled states load and resolve to the reserved fail-closed defaults.
+	for _, tt := range []struct{ name, body string }{
+		{"omitted", "mode: balanced\n"},
+		{"yaml null blank", "mode: balanced\nmcp_data_class_labels:\n  enabled:\n"},
+		{"explicit false", "mode: balanced\nmcp_data_class_labels:\n  enabled: false\n"},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := loadBody(tt.name, tt.body)
-			if cfg.MCPDataClassLabels.Enabled != tt.want {
-				t.Fatalf("enabled = %v, want %v", cfg.MCPDataClassLabels.Enabled, tt.want)
+			write(t, tt.body)
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.MCPDataClassLabels.Enabled {
+				t.Fatal("enabled should resolve to false")
 			}
 			if cfg.MCPDataClassLabels.UnknownClass != string(datalabel.DataClassSecret) {
 				t.Fatalf("unknown_class = %q, want %q", cfg.MCPDataClassLabels.UnknownClass, datalabel.DataClassSecret)
@@ -5093,16 +5070,20 @@ func TestLoad_MCPDataClassLabelsEnabledSixStates(t *testing.T) {
 		})
 	}
 
-	old := loadBody("reload old true", "mode: balanced\nmcp_data_class_labels:\n  enabled: true\n")
-	updated := loadBody("reload new false", "mode: balanced\nmcp_data_class_labels:\n  enabled: false\n")
-	if !hasReloadWarning(ValidateReload(old, updated), "mcp_data_class_labels.enabled") {
-		t.Fatal("reload-with-change should warn when mcp_data_class_labels.enabled is disabled")
-	}
-
-	unchanged := loadBody("reload unchanged true", "mode: balanced\nmcp_data_class_labels:\n  enabled: true\n")
-	if hasReloadWarning(ValidateReload(old, unchanged), "mcp_data_class_labels.enabled") {
-		t.Fatal("reload-without-change should not warn for unchanged mcp_data_class_labels.enabled")
-	}
+	// enabled: true is rejected. The feature has no runtime effect yet, so the
+	// knob fails closed at load rather than advertising protection it cannot
+	// provide. reload-with/without-change states do not apply while the field
+	// cannot be enabled.
+	t.Run("explicit true rejected", func(t *testing.T) {
+		write(t, "mode: balanced\nmcp_data_class_labels:\n  enabled: true\n")
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load() should reject mcp_data_class_labels.enabled: true")
+		}
+		if !strings.Contains(err.Error(), "not supported yet") {
+			t.Fatalf("error = %v, want it to mention 'not supported yet'", err)
+		}
+	})
 }
 
 func TestValidate_MCPDataClassLabelsRejectsBadUnknownClass(t *testing.T) {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/luckyPipewrench/pipelock/internal/datalabel"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 )
@@ -325,6 +326,10 @@ func Defaults() *Config {
 		},
 		MCPToolScanning: MCPToolScanning{
 			Enabled: false,
+		},
+		MCPDataClassLabels: MCPDataClassLabels{
+			Enabled:      false,
+			UnknownClass: string(datalabel.DataClassSecret),
 		},
 		MCPToolPolicy: MCPToolPolicy{
 			Enabled:       false,

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -293,6 +293,9 @@ func (c *Config) ApplyDefaults() {
 	if c.MCPToolScanning.Enabled && c.MCPToolScanning.Action == "" {
 		c.MCPToolScanning.Action = ActionWarn
 	}
+	if c.MCPDataClassLabels.UnknownClass == "" {
+		c.MCPDataClassLabels.UnknownClass = Defaults().MCPDataClassLabels.UnknownClass
+	}
 	if c.MCPToolPolicy.Enabled && c.MCPToolPolicy.Action == "" {
 		c.MCPToolPolicy.Action = ActionWarn
 	}

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -148,6 +148,14 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 		})
 	}
 
+	// MCP data-class labels disabled
+	if old.MCPDataClassLabels.Enabled && !updated.MCPDataClassLabels.Enabled {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "mcp_data_class_labels.enabled",
+			Message: "MCP data-class receipt labels disabled",
+		})
+	}
+
 	// MCP tool policy disabled
 	if old.MCPToolPolicy.Enabled && !updated.MCPToolPolicy.Enabled {
 		warnings = append(warnings, ReloadWarning{

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -392,6 +392,7 @@ type Config struct {
 	ResponseScanning         ResponseScanning        `yaml:"response_scanning"`
 	MCPInputScanning         MCPInputScanning        `yaml:"mcp_input_scanning"`
 	MCPToolScanning          MCPToolScanning         `yaml:"mcp_tool_scanning"`
+	MCPDataClassLabels       MCPDataClassLabels      `yaml:"mcp_data_class_labels" json:"-"`
 	MCPToolPolicy            MCPToolPolicy           `yaml:"mcp_tool_policy"`
 	Defer                    DeferConfig             `yaml:"defer"`
 	GitProtection            GitProtection           `yaml:"git_protection"`
@@ -625,6 +626,17 @@ type MCPToolScanning struct {
 	Enabled     bool   `yaml:"enabled"`
 	Action      string `yaml:"action"`       // warn, block
 	DetectDrift bool   `yaml:"detect_drift"` // rug pull detection
+}
+
+// MCPDataClassLabels reserves the config surface for DLP-derived MCP receipt
+// data-class labels. This foundation intentionally does not wire derivation or
+// populate receipt fields; enabling this section has no runtime effect until
+// that follow-up lands. Later derivation must synthesize labels from scanner
+// findings only, never parse them from agent payloads. Unknown, truncated, or
+// uncertain output is classified as "secret" fail-closed.
+type MCPDataClassLabels struct {
+	Enabled      bool   `yaml:"enabled"`
+	UnknownClass string `yaml:"unknown_class"` // reserved fail-closed label; must be "secret" in this foundation slice
 }
 
 // MCPResponseServerTrust assigns a response trust class to one named MCP

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1241,6 +1241,14 @@ func (c *Config) validateMCPToolScanning() error {
 }
 
 func (c *Config) validateMCPDataClassLabels() error {
+	// Fail closed on enable until derivation is wired. This is a reserved
+	// config surface with no runtime effect yet: nothing derives or attaches
+	// data-class labels. Accepting enabled: true would let an operator believe
+	// MCP receipt labeling is active when no labels are produced. Reject it so
+	// the knob cannot advertise protection it does not provide.
+	if c.MCPDataClassLabels.Enabled {
+		return fmt.Errorf("mcp_data_class_labels.enabled is not supported yet: data-class label derivation is not wired; leave it unset until a release enables it")
+	}
 	if c.MCPDataClassLabels.UnknownClass != string(datalabel.DataClassSecret) {
 		return fmt.Errorf("invalid mcp_data_class_labels.unknown_class %q: must be secret", c.MCPDataClassLabels.UnknownClass)
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/publicsuffix"
 	"gopkg.in/yaml.v3"
 
+	"github.com/luckyPipewrench/pipelock/internal/datalabel"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/secperm"
@@ -220,6 +221,9 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 		return warnings, err
 	}
 	if err := c.validateMCPToolScanning(); err != nil {
+		return warnings, err
+	}
+	if err := c.validateMCPDataClassLabels(); err != nil {
 		return warnings, err
 	}
 	if err := c.validateMCPToolPolicy(); err != nil {
@@ -1232,6 +1236,13 @@ func (c *Config) validateMCPToolScanning() error {
 		default:
 			return fmt.Errorf("invalid mcp_tool_scanning action %q: must be warn or block", c.MCPToolScanning.Action)
 		}
+	}
+	return nil
+}
+
+func (c *Config) validateMCPDataClassLabels() error {
+	if c.MCPDataClassLabels.UnknownClass != string(datalabel.DataClassSecret) {
+		return fmt.Errorf("invalid mcp_data_class_labels.unknown_class %q: must be secret", c.MCPDataClassLabels.UnknownClass)
 	}
 	return nil
 }

--- a/internal/datalabel/class.go
+++ b/internal/datalabel/class.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package datalabel defines the MCP receipt data-class labels derived from
+// internal scanner findings.
+package datalabel
+
+import "github.com/luckyPipewrench/pipelock/internal/redact"
+
+// DataClass is a closed, receipt-facing label synthesized from internal DLP
+// classes. These labels are never parsed from agent payloads.
+type DataClass string
+
+const (
+	DataClassBenign     DataClass = "benign"
+	DataClassCredential DataClass = "credential"
+	DataClassSecret     DataClass = "secret"
+	DataClassHash       DataClass = "hash"
+	DataClassNetwork    DataClass = "network"
+	DataClassIdentity   DataClass = "identity"
+	DataClassPII        DataClass = "pii"
+)
+
+// Valid reports whether c is one of the closed receipt data-class labels.
+func (c DataClass) Valid() bool {
+	switch c {
+	case DataClassBenign,
+		DataClassCredential,
+		DataClassSecret,
+		DataClassHash,
+		DataClassNetwork,
+		DataClassIdentity,
+		DataClassPII:
+		return true
+	default:
+		return false
+	}
+}
+
+// DataClassFor maps a redaction class to its receipt data-class label.
+// Unknown classes fail closed to secret because future or operator-defined
+// redaction classes may represent sensitive material. The later derivation
+// slice must also treat truncated or uncertain outputs as secret.
+func DataClassFor(class redact.Class) DataClass {
+	switch class {
+	case redact.ClassAWSAccessKey,
+		redact.ClassGoogleAPIKey,
+		redact.ClassGitHubToken,
+		redact.ClassGitLabToken,
+		redact.ClassSlackToken,
+		redact.ClassFireworksAPIKey,
+		redact.ClassAIProviderKey,
+		redact.ClassHuggingFaceToken,
+		redact.ClassReplicateAPIToken,
+		redact.ClassTogetherAIKey,
+		redact.ClassVaultToken,
+		redact.ClassVercelToken,
+		redact.ClassSupabaseKey,
+		redact.ClassDatabricksPAT,
+		redact.ClassOpenAIAPIKey,
+		redact.ClassAnthropicKey,
+		redact.ClassNPMToken,
+		redact.ClassPyPIToken,
+		redact.ClassLinearAPIKey,
+		redact.ClassNotionAPIKey,
+		redact.ClassSentryAuthToken,
+		redact.ClassTelegramToken,
+		redact.ClassDiscordToken,
+		redact.ClassTwilioAPIKey,
+		redact.ClassMailgunAPIKey,
+		redact.ClassSendGridAPIKey,
+		redact.ClassDBConnString,
+		redact.ClassAzureStorageKey,
+		redact.ClassAzureSAS,
+		redact.ClassJWT,
+		redact.ClassBearer,
+		redact.ClassCredential:
+		return DataClassCredential
+	case redact.ClassAWSSecretKey,
+		redact.ClassSSHPrivateKey,
+		redact.ClassEnvSecret,
+		redact.ClassSeedPhrase,
+		redact.ClassKnownSecret:
+		return DataClassSecret
+	case redact.ClassHashMD5,
+		redact.ClassHashSHA1,
+		redact.ClassHashSHA256,
+		redact.ClassHashSHA512,
+		redact.ClassHashNTLM:
+		return DataClassHash
+	case redact.ClassIPv4,
+		redact.ClassIPv6,
+		redact.ClassCIDR,
+		redact.ClassMAC:
+		return DataClassNetwork
+	case redact.ClassEmail,
+		redact.ClassFQDN,
+		redact.ClassADUser:
+		return DataClassIdentity
+	case redact.ClassSSN,
+		redact.ClassCreditCard:
+		return DataClassPII
+	default:
+		return DataClassSecret
+	}
+}

--- a/internal/datalabel/class_test.go
+++ b/internal/datalabel/class_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package datalabel
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/redact"
+)
+
+func TestDataClassForRedactClass(t *testing.T) {
+	tests := []struct {
+		name string
+		in   redact.Class
+		want DataClass
+	}{
+		{"ipv4", redact.ClassIPv4, DataClassNetwork},
+		{"ipv6", redact.ClassIPv6, DataClassNetwork},
+		{"cidr", redact.ClassCIDR, DataClassNetwork},
+		{"mac", redact.ClassMAC, DataClassNetwork},
+		{"email", redact.ClassEmail, DataClassIdentity},
+		{"fqdn", redact.ClassFQDN, DataClassIdentity},
+		{"ad user", redact.ClassADUser, DataClassIdentity},
+		{"aws access key", redact.ClassAWSAccessKey, DataClassCredential},
+		{"google api key", redact.ClassGoogleAPIKey, DataClassCredential},
+		{"github token", redact.ClassGitHubToken, DataClassCredential},
+		{"gitlab token", redact.ClassGitLabToken, DataClassCredential},
+		{"slack token", redact.ClassSlackToken, DataClassCredential},
+		{"fireworks api key", redact.ClassFireworksAPIKey, DataClassCredential},
+		{"ai provider key", redact.ClassAIProviderKey, DataClassCredential},
+		{"huggingface token", redact.ClassHuggingFaceToken, DataClassCredential},
+		{"replicate api token", redact.ClassReplicateAPIToken, DataClassCredential},
+		{"together ai key", redact.ClassTogetherAIKey, DataClassCredential},
+		{"vault token", redact.ClassVaultToken, DataClassCredential},
+		{"vercel token", redact.ClassVercelToken, DataClassCredential},
+		{"supabase key", redact.ClassSupabaseKey, DataClassCredential},
+		{"databricks pat", redact.ClassDatabricksPAT, DataClassCredential},
+		{"openai api key", redact.ClassOpenAIAPIKey, DataClassCredential},
+		{"anthropic key", redact.ClassAnthropicKey, DataClassCredential},
+		{"npm token", redact.ClassNPMToken, DataClassCredential},
+		{"pypi token", redact.ClassPyPIToken, DataClassCredential},
+		{"linear api key", redact.ClassLinearAPIKey, DataClassCredential},
+		{"notion api key", redact.ClassNotionAPIKey, DataClassCredential},
+		{"sentry auth token", redact.ClassSentryAuthToken, DataClassCredential},
+		{"telegram token", redact.ClassTelegramToken, DataClassCredential},
+		{"discord token", redact.ClassDiscordToken, DataClassCredential},
+		{"twilio api key", redact.ClassTwilioAPIKey, DataClassCredential},
+		{"mailgun api key", redact.ClassMailgunAPIKey, DataClassCredential},
+		{"sendgrid api key", redact.ClassSendGridAPIKey, DataClassCredential},
+		{"db connection string", redact.ClassDBConnString, DataClassCredential},
+		{"azure storage key", redact.ClassAzureStorageKey, DataClassCredential},
+		{"azure sas", redact.ClassAzureSAS, DataClassCredential},
+		{"jwt", redact.ClassJWT, DataClassCredential},
+		{"bearer", redact.ClassBearer, DataClassCredential},
+		{"credential", redact.ClassCredential, DataClassCredential},
+		{"aws secret key", redact.ClassAWSSecretKey, DataClassSecret},
+		{"ssh private key", redact.ClassSSHPrivateKey, DataClassSecret},
+		{"env secret", redact.ClassEnvSecret, DataClassSecret},
+		{"seed phrase", redact.ClassSeedPhrase, DataClassSecret},
+		{"known secret", redact.ClassKnownSecret, DataClassSecret},
+		{"hash md5", redact.ClassHashMD5, DataClassHash},
+		{"hash sha1", redact.ClassHashSHA1, DataClassHash},
+		{"hash sha256", redact.ClassHashSHA256, DataClassHash},
+		{"hash sha512", redact.ClassHashSHA512, DataClassHash},
+		{"hash ntlm", redact.ClassHashNTLM, DataClassHash},
+		{"ssn", redact.ClassSSN, DataClassPII},
+		{"credit card", redact.ClassCreditCard, DataClassPII},
+		{"unknown future class", redact.Class("future-sensitive-class"), DataClassSecret},
+		{"empty class", redact.Class(""), DataClassSecret},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DataClassFor(tt.in); got != tt.want {
+				t.Fatalf("DataClassFor(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDataClassValid(t *testing.T) {
+	for _, class := range []DataClass{
+		DataClassBenign,
+		DataClassCredential,
+		DataClassSecret,
+		DataClassHash,
+		DataClassNetwork,
+		DataClassIdentity,
+		DataClassPII,
+	} {
+		if !class.Valid() {
+			t.Fatalf("%q should be valid", class)
+		}
+	}
+	if DataClass("public").Valid() {
+		t.Fatal("contract privacy data class must not be valid for MCP labels")
+	}
+}

--- a/internal/datalabel/class_test.go
+++ b/internal/datalabel/class_test.go
@@ -89,11 +89,15 @@ func TestDataClassValid(t *testing.T) {
 		DataClassIdentity,
 		DataClassPII,
 	} {
-		if !class.Valid() {
-			t.Fatalf("%q should be valid", class)
+		t.Run(string(class), func(t *testing.T) {
+			if !class.Valid() {
+				t.Fatalf("%q should be valid", class)
+			}
+		})
+	}
+	t.Run("unknown label rejected", func(t *testing.T) {
+		if DataClass("public").Valid() {
+			t.Fatal("contract privacy data class must not be valid for MCP labels")
 		}
-	}
-	if DataClass("public").Valid() {
-		t.Fatal("contract privacy data class must not be valid for MCP labels")
-	}
+	})
 }

--- a/scripts/config-consumption-allowlist.txt
+++ b/scripts/config-consumption-allowlist.txt
@@ -37,6 +37,8 @@ Added  # (B) audit-provenance date on ReverseProxy trusted_upstream, format-vali
 StalePolicy  # RESERVED conductor follower knob; DecideStale exists with 0 callers (verified 2026-06-10); documented reserved
 MaxMinVersionMajorSkew  # RESERVED conductor follower knob; documented reserved
 MaxMinVersionMinorSkew  # RESERVED conductor follower knob; documented reserved
+MCPDataClassLabels  # RESERVED foundation; follow-up slice wires scanner-derived labels into MCP receipts
+UnknownClass  # RESERVED foundation; hard-validated fail-closed label for unknown/truncated/uncertain derivation
 
 # --- INERT-BASELINE (2026-06-10 audit; wire or remove, tracked in ops state.md) ---
 OnSeverity  # INERT airlock severity trigger; recordSessionActivityWithUserAgent wires only OnElevated/OnHigh/OnCritical


### PR DESCRIPTION
## What changed

Adds the foundation for DLP-derived data-class labels on MCP receipts: a new `internal/datalabel` package with a closed `DataClass` taxonomy (benign, credential, secret, hash, network, identity, pii) and a pure `DataClassFor(redact.Class)` mapping that fails closed to `secret` for any unknown class. Adds a disabled-by-default `mcp_data_class_labels` config section with full load, validation, and hot-reload handling across all presets.

## Scope

This is the taxonomy and config surface only. It has no runtime effect yet: nothing derives or attaches labels, and the receipt fields stay empty. The derivation path that reads scanner findings and populates the receipt `data_classes_in`/`data_classes_out` fields lands in a follow-up. The config knob is inert by design until then, and it stays out of the canonical policy hash so enabling it does not change signed receipt bytes.

## Why split it out

Landing the taxonomy, the fail-closed mapping, and the config lifecycle first keeps the follow-up focused on the derivation wiring in the scan path, which is the higher-risk change. Labels are always synthesized internally from scanner findings and are never parsed from an agent payload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP “data-class labels” configuration block across presets, disabled by default.
  * Introduced a fail-closed fallback label for unknown classifications (`secret`).
  * Added configuration schema and validation (defaults, allowed values, and rejection of `enabled: true` as not supported yet).

* **Bug Fixes**
  * Ensured the disabled setting does not affect stable policy fingerprints.
  * Added a reload warning when data-class labeling is turned off between configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->