### PR TITLE
feat(emit): webhook delivery failure accounting, shared format allowlist

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/datalabel"
+	"github.com/luckyPipewrench/pipelock/internal/emitformat"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"gopkg.in/yaml.v3"
@@ -8042,8 +8043,15 @@ func TestValidate_EmitSyslogInvalidFormat(t *testing.T) {
 	cfg.ApplyDefaults()
 	cfg.Emit.Syslog.Address = testSyslogAddr
 	cfg.Emit.Syslog.Format = "xml"
-	if err := cfg.Validate(); err == nil {
+	err := cfg.Validate()
+	if err == nil {
 		t.Fatal("expected error for invalid syslog format")
+	}
+	// Build the expected allowed-format list from the shared source of truth so
+	// this assertion does not break when a new syslog format is added.
+	expected := fmt.Sprintf(`invalid emit.syslog.format "xml": must be %s`, emitformat.AllowedSet())
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/luckyPipewrench/pipelock/internal/datalabel"
+	"github.com/luckyPipewrench/pipelock/internal/emitformat"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/secperm"
@@ -2642,11 +2643,8 @@ func (c *Config) validateEmit() error {
 				return fmt.Errorf("invalid emit.syslog.facility %q", c.Emit.Syslog.Facility)
 			}
 		}
-		switch c.Emit.Syslog.Format {
-		case EmitFormatJSON, EmitFormatCEF, EmitFormatOCSF:
-			// valid
-		default:
-			return fmt.Errorf("invalid emit.syslog.format %q: must be json, cef, or ocsf", c.Emit.Syslog.Format)
+		if !emitformat.Supported(c.Emit.Syslog.Format) {
+			return fmt.Errorf("invalid emit.syslog.format %q: must be %s", c.Emit.Syslog.Format, emitformat.AllowedSet())
 		}
 	}
 

--- a/internal/emit/syslog.go
+++ b/internal/emit/syslog.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/emitformat"
 )
 
 const (
@@ -187,7 +189,7 @@ func NewSyslogSink(address string, opts ...SyslogOption) (*SyslogSink, error) {
 }
 
 func validateSyslogFormat(format string) error {
-	if format == "" || format == FormatJSON || format == FormatCEF || format == FormatOCSF {
+	if format == "" || emitformat.Supported(format) {
 		return nil
 	}
 	return fmt.Errorf("emit: unsupported syslog format %q", format)
@@ -378,6 +380,10 @@ func makeSyslogMessage(event Event, format, deviceVersion string) (syslogMessage
 			message:   msg,
 		}, nil
 	}
+	// Deliberately stricter than emitformat.Supported: every format needs an
+	// explicit render branch above; an allowlisted-but-unrendered format must
+	// error loudly here (accounted as a delivery failure), never fall through
+	// to JSON rendering.
 	if format != FormatJSON {
 		return syslogMessage{}, fmt.Errorf("emit: unsupported syslog format %q", format)
 	}

--- a/internal/emit/syslog_test.go
+++ b/internal/emit/syslog_test.go
@@ -14,7 +14,12 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/emitformat"
 )
+
+const testConfigSyslogAddr = "udp://syslog.example.com:514"
 
 func TestParseSyslogAddress(t *testing.T) {
 	tests := []struct {
@@ -750,6 +755,46 @@ func TestMakeSyslogMessage_InvalidFormat(t *testing.T) {
 	}
 }
 
+func TestSyslogFormatValidationParity(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    string
+		supported bool
+	}{
+		{name: "json", format: FormatJSON, supported: true},
+		{name: "cef", format: FormatCEF, supported: true},
+		{name: "bogus", format: "xml", supported: false},
+	}
+
+	// Every format emitformat declares supported must be accepted by ALL
+	// consuming surfaces; a format added to emitformat but missed by one
+	// surface is exactly the drift this test exists to catch.
+	for _, supported := range emitformat.SupportedFormats() {
+		tests = append(tests, struct {
+			name      string
+			format    string
+			supported bool
+		}{name: "listed/" + supported, format: supported, supported: true})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := emitformat.Supported(tt.format); got != tt.supported {
+				t.Fatalf("emitformat.Supported(%q) = %v, want %v", tt.format, got, tt.supported)
+			}
+			if got := validateSyslogFormat(tt.format) == nil; got != tt.supported {
+				t.Fatalf("validateSyslogFormat(%q) success = %v, want %v", tt.format, got, tt.supported)
+			}
+			if got := makeSyslogMessageAcceptsFormat(tt.format); got != tt.supported {
+				t.Fatalf("makeSyslogMessage(%q) success = %v, want %v", tt.format, got, tt.supported)
+			}
+			if got := configValidateAcceptsSyslogFormat(tt.format); got != tt.supported {
+				t.Fatalf("config Validate syslog format %q success = %v, want %v", tt.format, got, tt.supported)
+			}
+		})
+	}
+}
+
 func TestSyslogSink_Emit_MarshalError(t *testing.T) {
 	writer := &countingSyslogWriter{}
 	sink := newSyslogSink(writer, &syslogConfig{queueLen: 1})
@@ -796,6 +841,24 @@ func TestSyslogOptions(t *testing.T) {
 
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func makeSyslogMessageAcceptsFormat(format string) bool {
+	_, err := makeSyslogMessage(Event{
+		Severity:  SeverityWarn,
+		Type:      EventHeaderDLP,
+		Timestamp: time.Now(),
+		Fields:    map[string]any{},
+	}, format, "1.2.3")
+	return err == nil
+}
+
+func configValidateAcceptsSyslogFormat(format string) bool {
+	cfg := config.Defaults()
+	cfg.ApplyDefaults()
+	cfg.Emit.Syslog.Address = testConfigSyslogAddr
+	cfg.Emit.Syslog.Format = format
+	return cfg.Validate() == nil
 }
 
 func searchSubstring(s, substr string) bool {

--- a/internal/emit/webhook.go
+++ b/internal/emit/webhook.go
@@ -10,8 +10,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -24,6 +26,23 @@ const (
 
 // ErrQueueFull is returned when the event queue is at capacity.
 var ErrQueueFull = errors.New("emit: webhook queue full, event dropped")
+
+// ErrWebhookDegraded is returned after a prior async delivery failure.
+// The event may still be accepted for queueing; this error signals that the
+// sink is not currently proving successful delivery.
+var ErrWebhookDegraded = errors.New("emit: webhook sink degraded")
+
+// WebhookStats reports delivery health for a WebhookSink.
+type WebhookStats struct {
+	Delivered uint64
+	Failed    uint64
+	Dropped   uint64
+	Abandoned uint64
+	Degraded  bool
+	LastError string
+	QueueLen  int
+	QueueCap  int
+}
 
 // webhookPayload is the JSON structure sent to the webhook endpoint.
 type webhookPayload struct {
@@ -43,8 +62,18 @@ type WebhookSink struct {
 	client    *http.Client
 	queue     chan Event
 	done      chan struct{}
+	closeMu   sync.Mutex
+	closed    bool
 	closeWG   sync.WaitGroup
 	closeOnce sync.Once
+
+	delivered atomic.Uint64
+	failed    atomic.Uint64
+	dropped   atomic.Uint64
+	abandoned atomic.Uint64
+	degraded  atomic.Bool
+	lastErrMu sync.Mutex
+	lastErr   string
 }
 
 // WebhookOption configures a WebhookSink.
@@ -103,24 +132,29 @@ func NewWebhookSink(url string, opts ...WebhookOption) *WebhookSink {
 
 // Emit enqueues an event for async delivery.
 // Events below the minimum severity are silently dropped.
-// Returns ErrQueueFull if the queue is at capacity, or an error if the sink is closed.
+// Returns ErrQueueFull if the queue is at capacity, ErrWebhookDegraded if
+// a prior async delivery failed, or an error if the sink is closed.
 func (w *WebhookSink) Emit(_ context.Context, event Event) error {
 	if event.Severity < w.minSev {
 		return nil
 	}
 
-	select {
-	case <-w.done:
+	degraded := w.degraded.Load()
+	w.closeMu.Lock()
+	if w.closed {
+		w.closeMu.Unlock()
 		return errors.New("emit: webhook sink closed")
-	default:
 	}
-
 	select {
 	case w.queue <- event:
+		w.closeMu.Unlock()
+		if degraded {
+			return ErrWebhookDegraded
+		}
 		return nil
-	case <-w.done:
-		return errors.New("emit: webhook sink closed")
 	default:
+		w.closeMu.Unlock()
+		w.recordDropped("queue_full", event, nil)
 		return ErrQueueFull
 	}
 }
@@ -130,6 +164,9 @@ func (w *WebhookSink) Emit(_ context.Context, event Event) error {
 // Close is safe to call multiple times.
 func (w *WebhookSink) Close() error {
 	w.closeOnce.Do(func() {
+		w.closeMu.Lock()
+		w.closed = true
+		w.closeMu.Unlock()
 		close(w.done)
 	})
 	w.closeWG.Wait()
@@ -141,14 +178,14 @@ func (w *WebhookSink) run() {
 	defer w.closeWG.Done()
 	defer func() {
 		if r := recover(); r != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "emit: webhook goroutine panic: %v\n", r)
+			w.recordFailure("panic", Event{Type: "unknown"}, fmt.Errorf("%v", r))
 		}
 	}()
 
 	for {
 		select {
 		case event := <-w.queue:
-			w.send(event)
+			w.safeSend(event)
 		case <-w.done:
 			w.drain()
 			return
@@ -162,8 +199,9 @@ func (w *WebhookSink) drain() {
 	for {
 		select {
 		case event := <-w.queue:
-			w.send(event)
+			w.safeSend(event)
 		case <-deadline:
+			w.recordAbandoned("drain_timeout", len(w.queue))
 			return
 		default:
 			return
@@ -171,8 +209,24 @@ func (w *WebhookSink) drain() {
 	}
 }
 
+func (w *WebhookSink) safeSend(event Event) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.recordFailure("panic", event, fmt.Errorf("%v", r))
+		}
+	}()
+	w.send(event)
+}
+
 // send POSTs a single event as JSON to the webhook URL.
 func (w *WebhookSink) send(event Event) {
+	// Snapshot the failure/drop count before the send so a successful delivery
+	// only clears the degraded flag if no failure or drop was recorded while
+	// this send was in flight. Without this, a concurrent queue-full drop (which
+	// sets degraded=true) could be silently erased by this send's success,
+	// leaving Dropped>0 while Degraded reported false.
+	failSnapshot := w.failed.Load() + w.dropped.Load()
+
 	payload := webhookPayload{
 		Severity:  event.Severity.String(),
 		Type:      event.Type,
@@ -183,13 +237,13 @@ func (w *WebhookSink) send(event Event) {
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "emit: webhook marshal error: %v\n", err)
+		w.recordFailure("marshal_error", event, err)
 		return
 	}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, w.url, bytes.NewReader(body))
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "emit: webhook request error: %v\n", err)
+		w.recordFailure("request_error", event, err)
 		return
 	}
 
@@ -200,11 +254,126 @@ func (w *WebhookSink) send(event Event) {
 
 	resp, err := w.client.Do(req)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "emit: webhook send error: %v\n", err)
+		w.recordFailure("send_error", event, err)
 		return
 	}
 	_ = resp.Body.Close()
-	if resp.StatusCode >= 300 {
-		_, _ = fmt.Fprintf(os.Stderr, "emit: webhook returned HTTP %d for event %s\n", resp.StatusCode, event.Type)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		w.recordFailure("http_status", event, fmt.Errorf("HTTP %d", resp.StatusCode))
+		return
 	}
+	w.delivered.Add(1)
+	// Only clear degraded if no failure/drop landed while this send was in
+	// flight; otherwise a concurrent drop's degraded signal would be lost.
+	if w.failed.Load()+w.dropped.Load() == failSnapshot {
+		w.degraded.Store(false)
+	}
+}
+
+// Stats returns a consistent snapshot of webhook sink delivery health.
+func (w *WebhookSink) Stats() WebhookStats {
+	if w == nil {
+		return WebhookStats{}
+	}
+	w.lastErrMu.Lock()
+	lastErr := w.lastErr
+	w.lastErrMu.Unlock()
+	stats := WebhookStats{
+		Delivered: w.delivered.Load(),
+		Failed:    w.failed.Load(),
+		Dropped:   w.dropped.Load(),
+		Abandoned: w.abandoned.Load(),
+		Degraded:  w.degraded.Load(),
+		LastError: lastErr,
+	}
+	if w.queue != nil {
+		stats.QueueLen = len(w.queue)
+		stats.QueueCap = cap(w.queue)
+	}
+	return stats
+}
+
+// sanitizeWebhookErr returns an error message safe to store and log. net/http
+// returns a *url.Error whose Error() embeds the full request URL, which for a
+// webhook endpoint can carry a secret path or query token; strip the URL and
+// keep only the operation and underlying cause so LastError and stderr
+// diagnostics never leak it.
+func sanitizeWebhookErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Err != nil {
+			return fmt.Sprintf("%s: %v", urlErr.Op, sanitizeWebhookErr(urlErr.Err))
+		}
+		return urlErr.Op
+	}
+	return err.Error()
+}
+
+func (w *WebhookSink) recordFailure(reason string, event Event, err error) {
+	w.failed.Add(1)
+	w.degraded.Store(true)
+	if err != nil {
+		w.lastErrMu.Lock()
+		w.lastErr = sanitizeWebhookErr(err)
+		w.lastErrMu.Unlock()
+	}
+	w.logDiagnostic("delivery_failed", reason, event, err, 0)
+}
+
+func (w *WebhookSink) recordDropped(reason string, event Event, err error) {
+	w.dropped.Add(1)
+	w.degraded.Store(true)
+	lastErr := reason
+	if err != nil {
+		lastErr = sanitizeWebhookErr(err)
+	}
+	w.lastErrMu.Lock()
+	w.lastErr = lastErr
+	w.lastErrMu.Unlock()
+	w.logDiagnostic("event_dropped", reason, event, err, 0)
+}
+
+func (w *WebhookSink) recordAbandoned(reason string, count int) {
+	if count < 1 {
+		return
+	}
+	w.abandoned.Add(uint64(count))
+	w.degraded.Store(true)
+	w.lastErrMu.Lock()
+	w.lastErr = reason
+	w.lastErrMu.Unlock()
+	w.logDiagnostic("events_abandoned", reason, Event{Type: "unknown"}, nil, count)
+}
+
+func (w *WebhookSink) logDiagnostic(eventName, reason string, event Event, err error, count int) {
+	defer func() {
+		_ = recover()
+	}()
+	fields := map[string]any{
+		"component":  "emit.webhook",
+		"event":      eventName,
+		"reason":     reason,
+		"event_type": event.Type,
+		"delivered":  w.delivered.Load(),
+		"failed":     w.failed.Load(),
+		"dropped":    w.dropped.Load(),
+		"abandoned":  w.abandoned.Load(),
+		"queue_len":  len(w.queue),
+		"queue_cap":  cap(w.queue),
+	}
+	if err != nil {
+		fields["error"] = sanitizeWebhookErr(err)
+	}
+	if count > 0 {
+		fields["count"] = count
+	}
+	encoded, marshalErr := json.Marshal(fields)
+	if marshalErr != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "emit: webhook diagnostic marshal error: %v\n", marshalErr)
+		return
+	}
+	_, _ = fmt.Fprintln(os.Stderr, string(encoded))
 }

--- a/internal/emit/webhook_test.go
+++ b/internal/emit/webhook_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -214,6 +215,13 @@ func TestWebhookSink_QueueFull(t *testing.T) {
 	if !queueFullSeen {
 		t.Error("expected ErrQueueFull after filling queue")
 	}
+	stats := sink.Stats()
+	if stats.Dropped != 1 || !stats.Degraded || stats.LastError != "queue_full" {
+		t.Fatalf("stats = %+v, want queue_full drop", stats)
+	}
+	if stats.QueueCap != 2 {
+		t.Fatalf("QueueCap = %d, want 2", stats.QueueCap)
+	}
 
 	// Unblock the server so Close can drain without hanging.
 	close(blocker)
@@ -250,6 +258,9 @@ func TestWebhookSink_CloseDrainsPending(t *testing.T) {
 	if got != 5 {
 		t.Errorf("expected 5 events delivered, got %d", got)
 	}
+	if stats := sink.Stats(); stats.Delivered != 5 || stats.Failed != 0 || stats.Degraded {
+		t.Fatalf("stats = %+v, want 5 delivered and healthy", stats)
+	}
 }
 
 func TestWebhookSink_ServerErrorDoesNotBlock(t *testing.T) {
@@ -281,6 +292,10 @@ func TestWebhookSink_ServerErrorDoesNotBlock(t *testing.T) {
 	got := count.Load()
 	if got != 3 {
 		t.Errorf("expected 3 requests attempted, got %d", got)
+	}
+	stats := sink.Stats()
+	if stats.Failed != 3 || !stats.Degraded || stats.LastError != "HTTP 500" {
+		t.Fatalf("stats = %+v, want 3 failed HTTP status deliveries", stats)
 	}
 }
 
@@ -442,22 +457,32 @@ func TestWebhookSink_SendMarshalError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Emit returned error: %v", err)
 	}
+	// Wait for the async marshal failure to be accounted so the follow-up
+	// Emit deterministically observes the degraded state.
+	waitWebhookStats(t, sink, func(stats WebhookStats) bool {
+		return stats.Failed == 1 && stats.Degraded
+	})
 
-	// Follow up with a valid event to prove the goroutine survived.
+	// Follow up with a valid event to prove the goroutine survived. The
+	// degraded advisory is expected; the event is still enqueued.
 	err = sink.Emit(context.Background(), Event{
 		Severity:   SeverityWarn,
 		Type:       testEventBlocked,
 		Timestamp:  time.Now(),
 		InstanceID: testStr,
 	})
-	if err != nil {
-		t.Fatalf("Emit returned error: %v", err)
+	if !errors.Is(err, ErrWebhookDegraded) {
+		t.Fatalf("Emit after failure = %v, want ErrWebhookDegraded", err)
 	}
 
 	_ = sink.Close()
 
 	if got := count.Load(); got != 1 {
 		t.Errorf("expected 1 successful request (bad event skipped), got %d", got)
+	}
+	stats := sink.Stats()
+	if stats.Delivered != 1 || stats.Failed != 1 || stats.Degraded || stats.LastError == "" {
+		t.Fatalf("stats = %+v, want one marshal failure and recovered delivery", stats)
 	}
 }
 
@@ -478,6 +503,10 @@ func TestWebhookSink_SendInvalidURL(t *testing.T) {
 
 	// Close should not hang even with errors.
 	_ = sink.Close()
+	stats := sink.Stats()
+	if stats.Failed != 1 || !stats.Degraded || stats.LastError == "" {
+		t.Fatalf("stats = %+v, want request-build failure accounting", stats)
+	}
 }
 
 func TestWebhookSink_SendConnectionRefused(t *testing.T) {
@@ -500,6 +529,10 @@ func TestWebhookSink_SendConnectionRefused(t *testing.T) {
 
 	// Close should drain without hanging despite connection errors.
 	_ = sink.Close()
+	stats := sink.Stats()
+	if stats.Failed != 1 || !stats.Degraded || stats.LastError == "" {
+		t.Fatalf("stats = %+v, want send failure accounting", stats)
+	}
 }
 
 func TestWebhookSink_EmitClosedDuringQueueWait(t *testing.T) {
@@ -543,5 +576,243 @@ func TestWebhookSink_EmitClosedDuringQueueWait(t *testing.T) {
 	err := sink.Emit(context.Background(), event)
 	if err == nil {
 		t.Error("expected error when emitting to closed sink")
+	}
+}
+
+func TestWebhookSink_EmitSignalsPriorDegradedStateThenRecovers(t *testing.T) {
+	requests := make(chan int, 2)
+	var count atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := int(count.Add(1))
+		requests <- n
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sink := NewWebhookSink(srv.URL, WithQueueSize(2))
+	defer func() { _ = sink.Close() }()
+
+	event := Event{
+		Severity:   SeverityWarn,
+		Type:       testEventBlocked,
+		Timestamp:  time.Now(),
+		InstanceID: testStr,
+	}
+	if err := sink.Emit(context.Background(), event); err != nil {
+		t.Fatalf("first Emit: %v", err)
+	}
+	waitWebhookStats(t, sink, func(stats WebhookStats) bool {
+		return stats.Failed == 1 && stats.Degraded
+	})
+
+	if err := sink.Emit(context.Background(), event); !errors.Is(err, ErrWebhookDegraded) {
+		t.Fatalf("second Emit error = %v, want ErrWebhookDegraded", err)
+	}
+	waitWebhookStats(t, sink, func(stats WebhookStats) bool {
+		return stats.Delivered == 1 && stats.Failed == 1 && !stats.Degraded
+	})
+
+	for i := 1; i <= 2; i++ {
+		select {
+		case got := <-requests:
+			if got != i {
+				t.Fatalf("request order = %d, want %d", got, i)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for request %d", i)
+		}
+	}
+}
+
+func TestWebhookSink_StatsNilAndAbandoned(t *testing.T) {
+	var nilSink *WebhookSink
+	if got := nilSink.Stats(); got != (WebhookStats{}) {
+		t.Fatalf("nil Stats() = %+v, want zero value", got)
+	}
+
+	sink := &WebhookSink{queue: make(chan Event, 2)}
+	sink.recordAbandoned("drain_timeout", 2)
+	stats := sink.Stats()
+	if stats.Abandoned != 2 || !stats.Degraded || stats.LastError != "drain_timeout" || stats.QueueCap != 2 {
+		t.Fatalf("stats = %+v, want abandoned degraded snapshot", stats)
+	}
+}
+
+func TestWebhookSink_SafeSendAccountsPanic(t *testing.T) {
+	sink := &WebhookSink{
+		url:   "https://api.vendor.example/hook",
+		queue: make(chan Event, 1),
+	}
+	sink.safeSend(Event{
+		Severity:  SeverityWarn,
+		Type:      testEventBlocked,
+		Timestamp: time.Now(),
+	})
+	stats := sink.Stats()
+	if stats.Failed != 1 || !stats.Degraded || stats.LastError == "" {
+		t.Fatalf("stats = %+v, want panic failure accounting", stats)
+	}
+}
+
+func waitWebhookStats(t *testing.T, sink *WebhookSink, accept func(WebhookStats) bool) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		stats := sink.Stats()
+		if accept(stats) {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for webhook stats, last stats = %+v", stats)
+		case <-ticker.C:
+		}
+	}
+}
+
+func TestWebhookSink_ConcurrentEmitCloseAccountsEveryAcceptedEvent(t *testing.T) {
+	// Accounting invariant under concurrent Emit/Close: an event accepted by
+	// Emit (nil or ErrWebhookDegraded) must never be silently lost. After
+	// Close returns, every accepted event is delivered, failed, or abandoned.
+	// The closeMu admission guard (mirroring the syslog sink) is what makes
+	// this hold; the historical lost-event interleaving is too narrow to
+	// reproduce deterministically, so this asserts the invariant, not the
+	// specific race.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	const emitters = 8
+	const perEmitter = 50
+
+	sink := NewWebhookSink(srv.URL, WithQueueSize(emitters*perEmitter))
+
+	var accepted atomic.Uint64
+	start := make(chan struct{})
+	admitted := make(chan struct{})
+	var admitOnce sync.Once
+	var wg sync.WaitGroup
+	for range emitters {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range perEmitter {
+				err := sink.Emit(context.Background(), Event{
+					Severity:   SeverityWarn,
+					Type:       testEventBlocked,
+					Timestamp:  time.Now(),
+					InstanceID: testStr,
+				})
+				if err == nil || errors.Is(err, ErrWebhookDegraded) {
+					accepted.Add(1)
+					admitOnce.Do(func() { close(admitted) })
+				}
+			}
+		}()
+	}
+	close(start)
+	// Guarantee overlap: wait until at least one event has actually been
+	// admitted before racing Close, so the test cannot pass vacuously with
+	// accepted==accounted==0.
+	select {
+	case <-admitted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no event was admitted before timeout")
+	}
+	// Race Close against the emitters so admission overlaps shutdown.
+	closeErr := sink.Close()
+	wg.Wait()
+	// Close is idempotent; a second call after all emitters finished makes
+	// sure the worker fully drained before we snapshot stats.
+	_ = sink.Close()
+	if closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
+	}
+
+	stats := sink.Stats()
+	if accepted.Load() == 0 {
+		t.Fatalf("no events were accepted; test would be vacuous (stats = %+v)", stats)
+	}
+	accounted := stats.Delivered + stats.Failed + stats.Abandoned
+	if accounted != accepted.Load() {
+		t.Fatalf("accepted %d events but accounted for %d (stats = %+v): accepted events were silently lost",
+			accepted.Load(), accounted, stats)
+	}
+}
+
+func TestWebhookSink_ErrorStringsRedactWebhookURL(t *testing.T) {
+	// A send failure to an unreachable URL carrying a secret query token must
+	// not leak that token into Stats().LastError or the stderr diagnostics.
+	const canary = "supersecret-canary-token"
+	sink := NewWebhookSink("http://127.0.0.1:0/hook?token=" + canary)
+	defer func() { _ = sink.Close() }()
+
+	err := sink.Emit(context.Background(), Event{
+		Severity:   SeverityWarn,
+		Type:       testEventBlocked,
+		Timestamp:  time.Now(),
+		InstanceID: testStr,
+	})
+	if err != nil && !errors.Is(err, ErrWebhookDegraded) {
+		t.Fatalf("Emit: %v", err)
+	}
+	waitWebhookStats(t, sink, func(s WebhookStats) bool { return s.Failed >= 1 })
+	if got := sink.Stats().LastError; strings.Contains(got, canary) {
+		t.Fatalf("LastError leaked the webhook URL token: %q", got)
+	}
+}
+
+func TestWebhookSink_SuccessDoesNotEraseConcurrentDropDegraded(t *testing.T) {
+	// A successful send must not clear the degraded flag when a drop is
+	// recorded while that send is in flight. Drive the real send path: the
+	// server records a queue-full drop (which sets degraded and advances the
+	// drop counter) before returning 204, so send's post-success snapshot
+	// guard observes the counter moved and must leave degraded set. This
+	// exercises the production failSnapshot guard rather than re-implementing
+	// it inline.
+	var sink *WebhookSink
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		sink.recordDropped("queue_full", Event{Type: testEventBlocked}, nil)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sink = NewWebhookSink(srv.URL)
+	defer func() { _ = sink.Close() }()
+
+	sink.send(Event{Type: testEventBlocked, Timestamp: time.Now()})
+
+	stats := sink.Stats()
+	if stats.Delivered != 1 {
+		t.Fatalf("delivered = %d, want 1", stats.Delivered)
+	}
+	if stats.Dropped != 1 {
+		t.Fatalf("dropped = %d, want 1", stats.Dropped)
+	}
+	if !stats.Degraded {
+		t.Fatal("degraded was erased despite a concurrent drop during the send")
+	}
+}
+
+func TestWebhookSink_RecordDroppedWithErrorAndAbandonedZeroCount(t *testing.T) {
+	sink := &WebhookSink{queue: make(chan Event, 1)}
+
+	sink.recordDropped("test_reason", Event{Type: testEventBlocked}, errors.New("boom"))
+	if stats := sink.Stats(); stats.Dropped != 1 || stats.LastError != "boom" {
+		t.Fatalf("stats after dropped-with-error = %+v, want Dropped=1 LastError=boom", stats)
+	}
+
+	// A zero or negative abandon count must be a no-op.
+	sink.recordAbandoned("drain_timeout", 0)
+	if stats := sink.Stats(); stats.Abandoned != 0 {
+		t.Fatalf("stats after zero-count abandon = %+v, want Abandoned=0", stats)
 	}
 }

--- a/internal/emitformat/format.go
+++ b/internal/emitformat/format.go
@@ -4,12 +4,38 @@
 // Package emitformat defines shared event export wire formats.
 package emitformat
 
+import "strings"
+
 const (
 	JSON = "json"
 	CEF  = "cef"
 	OCSF = "ocsf"
 )
 
+var supportedFormats = []string{JSON, CEF, OCSF}
+
+// SupportedFormats returns the canonical ordered list of event export wire formats.
+func SupportedFormats() []string {
+	return append([]string(nil), supportedFormats...)
+}
+
 func Supported(format string) bool {
-	return format == JSON || format == CEF || format == OCSF
+	for _, supported := range supportedFormats {
+		if format == supported {
+			return true
+		}
+	}
+	return false
+}
+
+// AllowedSet returns the supported formats as human-readable validation text.
+func AllowedSet() string {
+	switch len(supportedFormats) {
+	case 0:
+		return ""
+	case 1:
+		return supportedFormats[0]
+	default:
+		return strings.Join(supportedFormats[:len(supportedFormats)-1], ", ") + " or " + supportedFormats[len(supportedFormats)-1]
+	}
 }

--- a/internal/emitformat/format_test.go
+++ b/internal/emitformat/format_test.go
@@ -26,3 +26,49 @@ func TestSupported(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportedFormats(t *testing.T) {
+	got := SupportedFormats()
+	want := []string{JSON, CEF, OCSF}
+	if len(got) != len(want) {
+		t.Fatalf("SupportedFormats() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("SupportedFormats() = %v, want %v", got, want)
+		}
+	}
+
+	got[0] = "mutated"
+	if !Supported(JSON) {
+		t.Fatal("mutating returned SupportedFormats slice changed Supported(JSON)")
+	}
+}
+
+func TestAllowedSet(t *testing.T) {
+	if got := AllowedSet(); got != "json, cef or ocsf" {
+		t.Fatalf("AllowedSet() = %q, want %q", got, "json, cef or ocsf")
+	}
+}
+
+func TestAllowedSetSmallLists(t *testing.T) {
+	orig := supportedFormats
+	t.Cleanup(func() { supportedFormats = orig })
+
+	tests := []struct {
+		name    string
+		formats []string
+		want    string
+	}{
+		{name: "empty", formats: nil, want: ""},
+		{name: "single", formats: []string{JSON}, want: JSON},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			supportedFormats = tt.formats
+			if got := AllowedSet(); got != tt.want {
+				t.Fatalf("AllowedSet() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

Stacks on #1054 (same emit-format surfaces); this PR retargets to main automatically once that merges.

The webhook sink previously reported payload marshal, request build, send, and non-2xx failures to stderr only, after `Emit` had already returned nil, so a dropped webhook event was invisible to delivery accounting. The sink now tracks delivered, failed, dropped, and abandoned counts with a degraded flag, returns an advisory `ErrWebhookDegraded` after a prior async failure while still enqueueing the event, exposes a `Stats()` snapshot mirroring the syslog sink, emits structured JSON diagnostics that include the counters, and recovers per-event panics without killing the delivery worker. Queue admission is now serialized with `Close` (the same guard the syslog sink uses) so an event accepted during shutdown can never be silently lost, and a concurrency test asserts the accounting invariant that every accepted event ends up delivered, failed, or abandoned.

The syslog output format allowlist previously lived in three places (the format package, the syslog sink validator, and config validation), which meant a new format had to be hand-synced across all of them. `internal/emitformat` is now the single source of truth consulted by the other two, and a parity test runs every supported format through all consuming surfaces so any future drift fails CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook delivery statistics via `Stats()` (delivered, failed, dropped, abandoned, and degraded).
  * Webhook sinks now expose an `ErrWebhookDegraded` indicator and structured diagnostic output, and they can recover automatically after successful delivery.

* **Bug Fixes**
  * Standardized syslog format validation and “must be …” allowed-options wording across configuration and delivery paths.
  * Improved webhook failure handling: clearer error/degraded transitions, safer panic handling, redacted last-error details, and more accurate accounting during close/drain and queue-full conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->