### PR TITLE
fix(certgen): fail closed on nil CA in leaf certificate generation

### DIFF
--- a/internal/certgen/certgen.go
+++ b/internal/certgen/certgen.go
@@ -108,6 +108,16 @@ func GenerateLeaf(ca *x509.Certificate, caKey crypto.PrivateKey, host string, tt
 // (DNS/IP/URI) must be present; a leaf with no SAN is not usable by modern TLS
 // verifiers and is rejected rather than silently issued.
 func GenerateLeafCert(ca *x509.Certificate, caKey crypto.PrivateKey, opts LeafOptions) (*tls.Certificate, error) {
+	// Fail closed on a missing CA: x509.CreateCertificate dereferences the
+	// parent certificate and signing key, so a nil CA/key would panic mid-mint
+	// rather than return an error. These are public entry points (conductor
+	// mTLS material, TLS-interception leaves), so guard the same way NewCertCache does.
+	if ca == nil {
+		return nil, errors.New("certgen: nil CA certificate")
+	}
+	if caKey == nil {
+		return nil, errors.New("certgen: nil CA private key")
+	}
 	if opts.TTL <= 0 {
 		return nil, errors.New("leaf certificate TTL must be positive")
 	}

--- a/internal/certgen/coverage_test.go
+++ b/internal/certgen/coverage_test.go
@@ -4,6 +4,7 @@
 package certgen
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -82,5 +83,48 @@ func TestGenerateLeaf_NegativeTTL(t *testing.T) {
 	_, err = GenerateLeaf(ca, caKey, testHost, -time.Hour)
 	if err == nil {
 		t.Fatal("expected error for negative TTL, got nil")
+	}
+}
+
+func TestGenerateLeafCert_NilCA(t *testing.T) {
+	t.Parallel()
+
+	_, caKey, _, err := GenerateCA(testOrg, testValidityDay)
+	if err != nil {
+		t.Fatalf("GenerateCA error: %v", err)
+	}
+	opts := LeafOptions{CommonName: testHost, DNSNames: []string{testHost}, TTL: time.Hour}
+	_, err = GenerateLeafCert(nil, caKey, opts)
+	if err == nil || !strings.Contains(err.Error(), "nil CA certificate") {
+		t.Fatalf("expected nil CA certificate error, got %v", err)
+	}
+}
+
+func TestGenerateLeafCert_NilCAKey(t *testing.T) {
+	t.Parallel()
+
+	ca, _, _, err := GenerateCA(testOrg, testValidityDay)
+	if err != nil {
+		t.Fatalf("GenerateCA error: %v", err)
+	}
+	opts := LeafOptions{CommonName: testHost, DNSNames: []string{testHost}, TTL: time.Hour}
+	_, err = GenerateLeafCert(ca, nil, opts)
+	if err == nil || !strings.Contains(err.Error(), "nil CA private key") {
+		t.Fatalf("expected nil CA private key error, got %v", err)
+	}
+}
+
+func TestGenerateLeaf_NilCA(t *testing.T) {
+	t.Parallel()
+
+	_, caKey, _, err := GenerateCA(testOrg, testValidityDay)
+	if err != nil {
+		t.Fatalf("GenerateCA error: %v", err)
+	}
+	// GenerateLeaf is a thin wrapper; the nil-CA guard must propagate through it
+	// rather than panicking inside x509.CreateCertificate.
+	_, err = GenerateLeaf(nil, caKey, testHost, time.Hour)
+	if err == nil || !strings.Contains(err.Error(), "nil CA certificate") {
+		t.Fatalf("expected nil CA certificate error, got %v", err)
 	}
 }


### PR DESCRIPTION
GenerateLeafCert and its GenerateLeaf wrapper are public entry points that mint mutual-TLS material and TLS-interception leaves, but neither checked the CA certificate or signing key for nil. A nil CA reaches x509.CreateCertificate, which dereferences the parent certificate and signing key and panics mid-mint instead of returning an error, so a caller that lost its CA to an earlier failure crashes rather than degrading cleanly.

Guard both arguments at the top of GenerateLeafCert, matching the nil checks the certificate cache already performs, so the leaf-generation path fails closed with a clear error on a missing CA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate generation now handles missing CA certificates or private keys safely.
  * Returns clear validation errors instead of risking an application crash.

* **Tests**
  * Added coverage for missing CA certificate and private key scenarios.
  * Verified consistent error handling through certificate-generation APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->