### PR TITLE
fix(ssrf): hard-floor cloud metadata endpoints against every exemption and at dial time

### DIFF
--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -831,6 +831,7 @@ Key-free evidence capture:
 			}
 			defer sc.Close()
 			auditLogger := audit.NewNop()
+			upstreamDialContext := mcp.NewMetadataSafeDialContext(func() *scanner.Scanner { return sc })
 
 			ks := killswitch.New(cfg)
 
@@ -1251,6 +1252,7 @@ Key-free evidence capture:
 						TaintCfg:               &cfg.Taint,
 						ContractLoader:         contractLoader,
 						ContractAgent:          contractAgent,
+						DialContext:            upstreamDialContext,
 					}
 					if listenerAuthTokenFile != "" {
 						listenerOpts.ListenerBearerTokenFn = func() (string, error) {
@@ -1303,6 +1305,7 @@ Key-free evidence capture:
 						TaintCfg:               &cfg.Taint,
 						ContractLoader:         contractLoader,
 						ContractAgent:          contractAgent,
+						DialContext:            upstreamDialContext,
 					}
 					applyMCPResponseSuppressOpts(&wsOpts, cfg, serverName)
 					wsOpts = mcpReceiptParityOpts(wsOpts, receiptEmitter, v2ReceiptEmitter, captureConfigHash, cfg.FlightRecorder.RequireReceipts)
@@ -1355,6 +1358,7 @@ Key-free evidence capture:
 					ContractLoader:         contractLoader,
 					ContractAgent:          contractAgent,
 					DeferManager:           deferManager,
+					DialContext:            upstreamDialContext,
 				}
 				applyMCPResponseSuppressOpts(&httpOpts, cfg, serverName)
 				httpOpts = mcpReceiptParityOpts(httpOpts, receiptEmitter, v2ReceiptEmitter, captureConfigHash, cfg.FlightRecorder.RequireReceipts)

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -968,6 +968,7 @@ func (s *Server) Start(ctx context.Context) error {
 				FrozenToolStableKey:          s.opts.MCPUpstream,
 				ContractLoaderPtr:            s.proxy.ContractLoaderPtr(),
 				ContractAgent:                edition.ProfileDefault,
+				DialContext:                  mcp.NewMetadataSafeDialContext(mcpScannerFn),
 			}
 			if s.opts.MCPAuthTokenFile != "" {
 				listenerOpts.ListenerBearerTokenFn = func() (string, error) {
@@ -1002,12 +1003,14 @@ func (s *Server) Start(ctx context.Context) error {
 		rpHandler.SetRequestPolicyFn(s.proxy.ApplyRequestPolicy)
 		rpHandler.SetRequestPolicyPrepareFn(s.proxy.PrepareRequestPolicyBody)
 		rpHandler.SetRedactionRuntimePtr(s.proxy.RedactionRuntimePtr())
-		// Submit profile dials through the SSRF-safe dial path (resolve +
-		// validate every IP against internal CIDRs before connecting),
-		// matching the fetch/forward transports. Generic reverse-proxy mode
-		// keeps the default dialer: the operator chose that upstream.
+		// Generic reverse-proxy mode keeps operator-selected private/loopback
+		// upstreams reachable, but still applies the metadata hard floor at
+		// dial time. Submit profile is stricter and uses the full SSRF-safe
+		// dialer, matching the fetch/forward transports.
 		if cfg.ReverseProxy.Profile == config.ReverseProxyProfileSubmit {
 			rpHandler.SetSafeDialer(s.proxy.SafeDialer())
+		} else {
+			rpHandler.SetSafeDialer(s.proxy.MetadataSafeDialer())
 		}
 
 		rpLn, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.ReverseProxy.Listen)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2834,14 +2834,15 @@ func (c *Config) validateSSRF() error {
 // scanner.IsNonOverridableSSRFTarget; keep the two in sync.
 var nonOverridableSSRFRanges = func() []*net.IPNet {
 	cidrs := []string{
-		"169.254.0.0/16",    // IPv4 link-local (contains 169.254.169.254 IMDS)
-		"168.63.129.16/32",  // Azure WireServer metadata
-		"fd00:ec2::254/128", // AWS IMDSv6
-		"fe80::/10",         // IPv6 link-local
-		"224.0.0.0/4",       // IPv4 multicast
-		"ff00::/8",          // IPv6 multicast
-		"0.0.0.0/32",        // IPv4 unspecified
-		"::/128",            // IPv6 unspecified
+		"169.254.0.0/16",     // IPv4 link-local (contains 169.254.169.254 IMDS)
+		"168.63.129.16/32",   // Azure WireServer metadata
+		"100.100.100.200/32", // Alibaba Cloud ECS metadata
+		"fd00:ec2::254/128",  // AWS IMDSv6
+		"fe80::/10",          // IPv6 link-local
+		"224.0.0.0/4",        // IPv4 multicast
+		"ff00::/8",           // IPv6 multicast
+		"0.0.0.0/32",         // IPv4 unspecified
+		"::/128",             // IPv6 unspecified
 	}
 	nets := make([]*net.IPNet, 0, len(cidrs))
 	for _, c := range cidrs {

--- a/internal/mcp/contractgate.go
+++ b/internal/mcp/contractgate.go
@@ -71,6 +71,37 @@ func evaluateMCPUpstreamGate(ctx context.Context, upstreamURL string, opts MCPPr
 
 func evaluateMCPUpstreamGateForMethod(ctx context.Context, upstreamURL, method string, opts MCPProxyOpts) (mcpContractGateOutput, error) {
 	loader := opts.contractLoader()
+	gateURL := mcpUpstreamGateURL(upstreamURL)
+	var scanResult scanner.Result
+	var scannerVerdict string
+	var scannerMatched bool
+	sc := opts.scanner()
+	if sc != nil {
+		scanResult = sc.Scan(ctx, gateURL)
+		scannerMatched = !scanResult.Allowed
+		if scannerMatched {
+			scannerVerdict = config.ActionBlock
+		} else {
+			scannerVerdict = config.ActionAllow
+		}
+		// The metadata SSRF hard floor applies even when no live-lock
+		// contract is configured. Preserve the historical no-loader allow
+		// fallback for other upstream scanner results in this narrow path.
+		if scannerMatched && scanResult.Scanner == scanner.ScannerSSRFMetadata {
+			if method == "" {
+				method = http.MethodPost
+			}
+			return evaluateMCPHTTPGate(mcpHTTPGateInput{
+				opts:             opts,
+				targetURL:        gateURL,
+				method:           method,
+				effectiveAction:  mcpContractURLAction,
+				scannerVerdict:   scannerVerdict,
+				scannerMatched:   scannerMatched,
+				killSwitchActive: opts.KillSwitch != nil && opts.KillSwitch.IsActive(),
+			})
+		}
+	}
 	if loader == nil || loader.Current() == nil {
 		return mcpContractGateOutput{
 			Verdict:       config.ActionAllow,
@@ -79,15 +110,8 @@ func evaluateMCPUpstreamGateForMethod(ctx context.Context, upstreamURL, method s
 			WinningSource: contractruntime.WinningSourceScanner,
 		}, nil
 	}
-	sc := opts.scanner()
 	if sc == nil {
 		return mcpContractGateOutput{}, fmt.Errorf("scanner unavailable")
-	}
-	gateURL := mcpUpstreamGateURL(upstreamURL)
-	scanResult := sc.Scan(ctx, gateURL)
-	scannerVerdict := config.ActionAllow
-	if !scanResult.Allowed {
-		scannerVerdict = config.ActionBlock
 	}
 	if method == "" {
 		method = http.MethodPost
@@ -98,7 +122,7 @@ func evaluateMCPUpstreamGateForMethod(ctx context.Context, upstreamURL, method s
 		method:           method,
 		effectiveAction:  mcpContractURLAction,
 		scannerVerdict:   scannerVerdict,
-		scannerMatched:   !scanResult.Allowed,
+		scannerMatched:   scannerMatched,
 		killSwitchActive: opts.KillSwitch != nil && opts.KillSwitch.IsActive(),
 	})
 }

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -117,7 +117,7 @@ func RunHTTPProxy(
 	safeClientOut := &syncWriter{w: clientOut}
 	safeLogW := &syncWriter{w: logW}
 
-	httpClient := transport.NewHTTPClient(upstreamURL, extraHeaders)
+	httpClient := transport.NewHTTPClientWithDialer(upstreamURL, extraHeaders, opts.DialContext)
 	var upstreamMu sync.Mutex
 
 	// Tool scanning baseline for this session. Clone the caller's ToolCfg

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -430,6 +430,33 @@ func RunHTTPListenerProxy(
 			}
 			info.SetHeaders(w.Header())
 		}
+		// handleMetadataDialError recognizes a dial-time metadata refusal
+		// (MetadataDialBlockError from the metadata-safe dialer) and renders it
+		// through the shared block-decision path so it emits a receipt and stamps
+		// the ssrf_metadata block-reason header (403), matching every other
+		// listener block instead of a bare 502. Returns true when it handled the
+		// error, so every listener method (POST, SSE, DELETE) shares identical
+		// metadata-block behavior. Non-metadata dial errors return false and fall
+		// through to the caller's generic handling.
+		handleMetadataDialError := func(dialErr error, id json.RawMessage) bool {
+			var mdErr *MetadataDialBlockError
+			if !errors.As(dialErr, &mdErr) {
+				return false
+			}
+			emitListenerBlockDecision(mcpListenerBlockDecision{
+				reason:          blockreason.SSRFMetadata,
+				headerSeverity:  blockreason.SeverityCritical,
+				retry:           blockreason.RetryNone,
+				layer:           scanner.ScannerSSRF,
+				pattern:         scanner.ScannerSSRFMetadata,
+				target:          upstreamURL,
+				receiptSeverity: config.SeverityHigh,
+			})
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write(upstreamErrorResponse(id, fmt.Errorf("upstream resolves to a cloud metadata endpoint")))
+			return true
+		}
 		blockedByUpstreamContract := func(rpcID json.RawMessage, gateOpts MCPProxyOpts) bool {
 			if gate, gateErr := evaluateMCPUpstreamGateForMethod(r.Context(), upstreamURL, r.Method, gateOpts); gateErr != nil {
 				_, _ = fmt.Fprintf(safeLogW, "pipelock: contract upstream evaluation failed: %v\n", gateErr)
@@ -629,6 +656,9 @@ func RunHTTPListenerProxy(
 
 			upResp, err := upstreamStreamClient.Do(upReq)
 			if err != nil {
+				if handleMetadataDialError(err, nil) {
+					return
+				}
 				logUpstreamRequestError(safeLogW, r.Context())
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadGateway)
@@ -752,6 +782,9 @@ func RunHTTPListenerProxy(
 
 			upResp, err := upstreamClient.Do(upReq)
 			if err != nil {
+				if handleMetadataDialError(err, nil) {
+					return
+				}
 				logUpstreamRequestError(safeLogW, r.Context())
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadGateway)
@@ -1027,6 +1060,9 @@ func RunHTTPListenerProxy(
 
 		upResp, err := upstreamClient.Do(upReq)
 		if err != nil {
+			if handleMetadataDialError(err, frame.ID) {
+				return
+			}
 			logUpstreamRequestError(safeLogW, r.Context())
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadGateway)

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -69,10 +69,13 @@ type mcpListenerBlockDecision struct {
 //     SSRF posture at the call site. Matches the parity of the forward,
 //     reverse, and TLS-intercept transports, which all dial the configured
 //     upstream directly with a nil Proxy.
-func newReverseUpstreamTransport() *http.Transport {
+func newReverseUpstreamTransport(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) *http.Transport {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.DisableCompression = true
 	t.Proxy = nil
+	if dialContext != nil {
+		t.DialContext = dialContext
+	}
 	return t
 }
 
@@ -231,6 +234,7 @@ func RunHTTPListenerProxy(
 		TaintTrustedSourceFn:     opts.TaintTrustedSourceFn,
 		EnvelopeEmitter:          opts.envelopeEmitter(),
 		EnvelopeEmitterFn:        opts.EnvelopeEmitterFn,
+		DialContext:              opts.DialContext,
 	}
 
 	// Shared HTTP client for upstream requests. Redirect-following is disabled
@@ -249,12 +253,12 @@ func RunHTTPListenerProxy(
 	// internal/mcp/transport/httpclient.go:45.
 	upstreamClient := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: newReverseUpstreamTransport(),
+		Transport: newReverseUpstreamTransport(opts.DialContext),
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}
-	upstreamStreamTransport := newReverseUpstreamTransport()
+	upstreamStreamTransport := newReverseUpstreamTransport(opts.DialContext)
 	upstreamStreamTransport.ResponseHeaderTimeout = 30 * time.Second
 	upstreamStreamClient := &http.Client{
 		Timeout:       0,

--- a/internal/mcp/mcp_livelock_test.go
+++ b/internal/mcp/mcp_livelock_test.go
@@ -381,6 +381,35 @@ func TestMCPContractGateFallbacks(t *testing.T) {
 	}
 }
 
+func TestMCPUpstreamGateMetadataHardFloorWithoutContractLoader(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = []string{"169.254.0.0/16"}
+	cfg.SSRF.IPAllowlist = []string{"169.254.0.0/16"}
+	cfg.DNS.HostOverrides = map[string][]string{
+		"metadata-upstream.vendor.example": {"169.254.169.254"},
+	}
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+
+	for _, upstreamURL := range []string{
+		"http://169.254.169.254/mcp",
+		"ws://metadata-upstream.vendor.example/mcp",
+	} {
+		t.Run(upstreamURL, func(t *testing.T) {
+			gate, err := evaluateMCPUpstreamGate(context.Background(), upstreamURL, MCPProxyOpts{Scanner: sc})
+			if err != nil {
+				t.Fatalf("upstream gate err = %v", err)
+			}
+			if gate.Verdict != config.ActionBlock || gate.LiveVerdict != config.ActionBlock {
+				t.Fatalf("metadata upstream gate = %+v, want block", gate)
+			}
+			if gate.WinningSource != contractruntime.WinningSourceScanner {
+				t.Fatalf("winning source = %q, want scanner", gate.WinningSource)
+			}
+		})
+	}
+}
+
 func TestMCPUpstreamGateForMethodRejectsGETWithPOSTOnlyContract(t *testing.T) {
 	opts := mcpLiveLockOpts(t, contractruntime.ModeLive,
 		contractruntimetest.HTTPEnforceRule("r-post-only", "api.example.com", "/", http.MethodPost))

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -78,6 +79,10 @@ type MCPProxyOpts struct {
 	// browser can use Authorization for listener authentication while Pipelock
 	// supplies a separate static Authorization credential to the upstream.
 	UpstreamHeaders http.Header
+	// DialContext is the dial path used for configured HTTP/SSE/WS MCP upstreams.
+	// Long-lived Pipelock servers pass the proxy SSRF-safe dialer here so DNS
+	// rebinding and metadata endpoints are checked again at connection time.
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 
 	// Scanning
 	Scanner        *scanner.Scanner

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -233,6 +233,34 @@ func TestRunHTTPProxy_ForwardsCleanRequest(t *testing.T) {
 	}
 }
 
+func TestRunHTTPProxy_UpstreamUsesConfiguredDialContext(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	errDialBlocked := errors.New("sentinel dial blocked")
+	var dialCalls atomic.Int32
+	stdin := strings.NewReader(jsonToolsCallEcho + "\n")
+	var stdout, stderr bytes.Buffer
+
+	err := RunHTTPProxy(context.Background(), stdin, &stdout, &stderr, "http://api.vendor.example/mcp", nil, MCPProxyOpts{
+		Scanner: sc,
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			dialCalls.Add(1)
+			return nil, errDialBlocked
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunHTTPProxy: %v", err)
+	}
+	if dialCalls.Load() == 0 {
+		t.Fatal("configured dialer was not called")
+	}
+	if !strings.Contains(stderr.String(), "upstream request failed") {
+		t.Fatalf("stderr = %q, want sanitized upstream request failure", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "upstream HTTP request failed") {
+		t.Fatalf("stdout = %q, want upstream error response", stdout.String())
+	}
+}
+
 func TestRunHTTPProxy_RedactsToolCallArguments(t *testing.T) {
 	secret := mcpRedactionSecret()
 	var upstreamBody bytes.Buffer
@@ -2181,6 +2209,76 @@ func TestRunHTTPProxy_NotificationBlocked(t *testing.T) {
 }
 
 // ---------- RunHTTPListenerProxy tests ----------
+
+func TestRunHTTPListenerProxy_UpstreamUsesConfiguredDialContext(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	errDialBlocked := errors.New("sentinel dial blocked")
+	var dialCalls atomic.Int32
+
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var logBuf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunHTTPListenerProxy(ctx, ln, "http://api.vendor.example/mcp", &logBuf, MCPProxyOpts{
+			Scanner: sc,
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				dialCalls.Add(1)
+				return nil, errDialBlocked
+			},
+		})
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+ln.Addr().String()+"/", strings.NewReader(jsonToolsCallEcho))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("listener POST: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, http.StatusBadGateway, body)
+	}
+	if dialCalls.Load() == 0 {
+		t.Fatal("configured dialer was not called")
+	}
+
+	// The SSE stream transport (upstreamStreamTransport) is a separate transport
+	// from the POST path; a GET/SSE request must dial through the same guarded
+	// dialer so the metadata hard floor cannot silently regress on the stream
+	// surface.
+	postDials := dialCalls.Load()
+	streamReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+ln.Addr().String()+"/", nil)
+	if err != nil {
+		t.Fatalf("new SSE request: %v", err)
+	}
+	streamReq.Header.Set("Accept", "text/event-stream")
+	streamResp, err := http.DefaultClient.Do(streamReq)
+	if err != nil {
+		t.Fatalf("listener GET/SSE: %v", err)
+	}
+	streamBody, _ := io.ReadAll(streamResp.Body)
+	_ = streamResp.Body.Close()
+	if streamResp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("SSE status = %d, want %d; body=%s", streamResp.StatusCode, http.StatusBadGateway, streamBody)
+	}
+	if dialCalls.Load() <= postDials {
+		t.Fatal("configured dialer was not called for the SSE stream path")
+	}
+
+	cancel()
+	if err := <-done; err != nil && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "closed network connection") {
+		t.Fatalf("RunHTTPListenerProxy: %v", err)
+	}
+}
 
 // startListenerProxy starts RunHTTPListenerProxy on a free port and returns
 // the base URL (e.g. "http://127.0.0.1:<port>") and a cancel function.
@@ -6992,7 +7090,7 @@ func TestHTTPListener_AuthWarnPreservesListenerWarnMetadata(t *testing.T) {
 // regress. Matches the parity of the forward, reverse, and TLS-intercept
 // transports.
 func TestNewReverseUpstreamTransport_IgnoresAmbientProxyEnv(t *testing.T) {
-	tr := newReverseUpstreamTransport()
+	tr := newReverseUpstreamTransport(nil)
 	if tr.Proxy != nil {
 		t.Error("reverse upstream transport Proxy must be nil (no ambient HTTP_PROXY chaining)")
 	}

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -2280,6 +2280,84 @@ func TestRunHTTPListenerProxy_UpstreamUsesConfiguredDialContext(t *testing.T) {
 	}
 }
 
+func TestRunHTTPListenerProxy_MetadataDialBlockSurfacesReason(t *testing.T) {
+	// A benign upstream URL passes scanning/gating, but the dialer refuses at
+	// connection time (the DNS-rebind backstop) with the typed
+	// MetadataDialBlockError. Both the POST and SSE listener paths must surface a
+	// 403 carrying the ssrf_metadata block reason rather than a generic 502.
+	sc := testScannerForHTTP(t)
+	h := newMCPDecisionReceiptHarness(t)
+	metaDialer := func(_ context.Context, _, _ string) (net.Conn, error) {
+		return nil, &MetadataDialBlockError{Host: "api.vendor.example", IP: net.ParseIP("169.254.169.254")}
+	}
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var logBuf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunHTTPListenerProxy(ctx, ln, "http://api.vendor.example/mcp", &logBuf, MCPProxyOpts{
+			Scanner:          sc,
+			DialContext:      metaDialer,
+			ReceiptEmitter:   h.v1,
+			V2ReceiptEmitter: h.v2,
+			PolicyHash:       mcpTestPolicyHash,
+		})
+	}()
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		accept string
+	}{
+		{"post", http.MethodPost, ""},
+		{"sse", http.MethodGet, "text/event-stream"},
+		{"delete", http.MethodDelete, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var body io.Reader
+			if tc.method == http.MethodPost {
+				body = strings.NewReader(jsonToolsCallEcho)
+			}
+			req, err := http.NewRequestWithContext(ctx, tc.method, "http://"+ln.Addr().String()+"/", body)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			if tc.method == http.MethodPost {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			if tc.accept != "" {
+				req.Header.Set("Accept", tc.accept)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			reason := resp.Header.Get("X-Pipelock-Block-Reason")
+			receiptID := resp.Header.Get("X-Pipelock-Block-Reason-Receipt")
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("%s status = %d, want 403 (metadata dial block)", tc.name, resp.StatusCode)
+			}
+			if reason != "ssrf_metadata" {
+				t.Fatalf("%s X-Pipelock-Block-Reason = %q, want ssrf_metadata", tc.name, reason)
+			}
+			// A non-empty receipt id proves the block routed through the
+			// receipt-emitting decision path, not the bare header-only 502.
+			if receiptID == "" {
+				t.Fatalf("%s: no X-Pipelock-Block-Reason-Receipt; metadata dial block did not emit a receipt", tc.name)
+			}
+		})
+	}
+	cancel()
+	if err := <-done; err != nil && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "closed network connection") {
+		t.Fatalf("RunHTTPListenerProxy: %v", err)
+	}
+}
+
 // startListenerProxy starts RunHTTPListenerProxy on a free port and returns
 // the base URL (e.g. "http://127.0.0.1:<port>") and a cancel function.
 func startListenerProxy(

--- a/internal/mcp/proxy_ws.go
+++ b/internal/mcp/proxy_ws.go
@@ -56,7 +56,7 @@ func RunWSProxy(
 	safeClientOut := &syncWriter{w: clientOut}
 	safeLogW := &syncWriter{w: logW}
 
-	wsClient, err := transport.NewWSClient(innerCtx, upstreamURL)
+	wsClient, err := transport.NewWSClientWithDialer(innerCtx, upstreamURL, opts.DialContext)
 	if err != nil {
 		return fmt.Errorf("connecting to upstream: %w", err)
 	}

--- a/internal/mcp/proxy_ws_test.go
+++ b/internal/mcp/proxy_ws_test.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -166,6 +168,27 @@ func TestRunWSProxy_ForwardsCleanRequest(t *testing.T) {
 	}
 	if rpc.JSONRPC != jsonRPC20 {
 		t.Errorf("jsonrpc = %q, want %q", rpc.JSONRPC, jsonRPC20)
+	}
+}
+
+func TestRunWSProxy_UpstreamUsesConfiguredDialContext(t *testing.T) {
+	sc := testScannerForWS(t)
+	errDialBlocked := errors.New("sentinel dial blocked")
+	var dialCalls atomic.Int32
+	var stdout, stderr bytes.Buffer
+
+	err := RunWSProxy(context.Background(), strings.NewReader(""), &stdout, &stderr, "ws://api.vendor.example/mcp", MCPProxyOpts{
+		Scanner: sc,
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			dialCalls.Add(1)
+			return nil, errDialBlocked
+		},
+	})
+	if !errors.Is(err, errDialBlocked) {
+		t.Fatalf("RunWSProxy error = %v, want sentinel dial error", err)
+	}
+	if dialCalls.Load() == 0 {
+		t.Fatal("configured dialer was not called")
 	}
 }
 

--- a/internal/mcp/transport/httpclient.go
+++ b/internal/mcp/transport/httpclient.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -80,6 +81,13 @@ type HTTPClient struct {
 // If headers is nil, no extra headers are added. Headers are cloned to
 // prevent mutation after construction.
 func NewHTTPClient(url string, headers http.Header) *HTTPClient {
+	return NewHTTPClientWithDialer(url, headers, nil)
+}
+
+// NewHTTPClientWithDialer creates an HTTPClient with an optional custom dialer.
+// The dialer is used for every upstream POST, GET stream, DELETE, and reconnect
+// performed by this client.
+func NewHTTPClientWithDialer(url string, headers http.Header, dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) *HTTPClient {
 	// Clone http.DefaultTransport with DisableCompression: true so the
 	// SSE/JSON upstream's Content-Encoding survives transparent-
 	// decompression stripping. Without this, gzip-compressed MCP
@@ -97,6 +105,9 @@ func NewHTTPClient(url string, headers http.Header) *HTTPClient {
 	// reverse, and TLS-intercept transports, which all dial the configured
 	// upstream directly with a nil Proxy.
 	transport.Proxy = nil
+	if dialContext != nil {
+		transport.DialContext = dialContext
+	}
 	return &HTTPClient{
 		url:     url,
 		headers: headers.Clone(),

--- a/internal/mcp/transport/httpclient_test.go
+++ b/internal/mcp/transport/httpclient_test.go
@@ -197,6 +197,53 @@ func TestHTTPClient_ClientDoCancellationPreserved(t *testing.T) {
 	}
 }
 
+func TestHTTPClientWithDialer_AllRequestTypesUseCustomDialer(t *testing.T) {
+	errDialBlocked := errors.New("sentinel dial blocked")
+
+	t.Run("post", func(t *testing.T) {
+		var calls atomic.Int32
+		c := NewHTTPClientWithDialer("http://api.vendor.example/mcp", nil, func(_ context.Context, _, _ string) (net.Conn, error) {
+			calls.Add(1)
+			return nil, errDialBlocked
+		})
+		_, err := c.SendMessage(context.Background(), []byte(testJSONID2))
+		if !errors.Is(err, ErrUpstreamRequestFailed) {
+			t.Fatalf("SendMessage error = %v, want ErrUpstreamRequestFailed", err)
+		}
+		if calls.Load() == 0 {
+			t.Fatal("custom dialer was not called for POST")
+		}
+	})
+
+	t.Run("get stream", func(t *testing.T) {
+		var calls atomic.Int32
+		c := NewHTTPClientWithDialer("http://api.vendor.example/mcp", nil, func(_ context.Context, _, _ string) (net.Conn, error) {
+			calls.Add(1)
+			return nil, errDialBlocked
+		})
+		_, err := c.OpenGETStream(context.Background())
+		if !errors.Is(err, ErrUpstreamRequestFailed) {
+			t.Fatalf("OpenGETStream error = %v, want ErrUpstreamRequestFailed", err)
+		}
+		if calls.Load() == 0 {
+			t.Fatal("custom dialer was not called for GET stream")
+		}
+	})
+
+	t.Run("delete session", func(t *testing.T) {
+		var calls atomic.Int32
+		c := NewHTTPClientWithDialer("http://api.vendor.example/mcp", nil, func(_ context.Context, _, _ string) (net.Conn, error) {
+			calls.Add(1)
+			return nil, errDialBlocked
+		})
+		c.sessionID = "session-1"
+		c.DeleteSession(io.Discard)
+		if calls.Load() == 0 {
+			t.Fatal("custom dialer was not called for DELETE session")
+		}
+	})
+}
+
 func TestHTTPClient_SessionIDTracking(t *testing.T) {
 	var calls atomic.Int32
 

--- a/internal/mcp/transport/wsclient.go
+++ b/internal/mcp/transport/wsclient.go
@@ -35,7 +35,15 @@ type WSClient struct {
 // a WSClient. The connection is established using gobwas/ws.Dial with the
 // provided context for timeout/cancellation.
 func NewWSClient(ctx context.Context, rawURL string) (*WSClient, error) {
-	conn, br, _, err := ws.Dial(ctx, rawURL)
+	return NewWSClientWithDialer(ctx, rawURL, nil)
+}
+
+// NewWSClientWithDialer establishes a WebSocket connection using an optional
+// custom network dialer. The dialer runs before the TCP connection and WebSocket
+// handshake, so callers can enforce SSRF checks at connection time.
+func NewWSClientWithDialer(ctx context.Context, rawURL string, dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) (*WSClient, error) {
+	dialer := ws.Dialer{NetDial: dialContext}
+	conn, br, _, err := dialer.Dial(ctx, rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("ws dial %s: %w", rawURL, err)
 	}

--- a/internal/mcp/transport/wsclient_test.go
+++ b/internal/mcp/transport/wsclient_test.go
@@ -291,6 +291,21 @@ func TestWSClient_DialFailure(t *testing.T) {
 	}
 }
 
+func TestNewWSClientWithDialer_UsesCustomDialer(t *testing.T) {
+	errDialBlocked := errors.New("sentinel dial blocked")
+	var calls int
+	_, err := NewWSClientWithDialer(context.Background(), "ws://api.vendor.example/mcp", func(_ context.Context, _, _ string) (net.Conn, error) {
+		calls++
+		return nil, errDialBlocked
+	})
+	if !errors.Is(err, errDialBlocked) {
+		t.Fatalf("NewWSClientWithDialer error = %v, want sentinel dial error", err)
+	}
+	if calls == 0 {
+		t.Fatal("custom dialer was not called")
+	}
+}
+
 func TestWSClient_ConnectionClosed(t *testing.T) {
 	srv := wsTestServer(t, func(conn net.Conn) {
 		// Close immediately without sending anything.

--- a/internal/mcp/upstream_dial.go
+++ b/internal/mcp/upstream_dial.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+var defaultMCPDialLookupHost = net.DefaultResolver.LookupHost
+
+// NewMetadataSafeDialContext returns a DialContext for configured MCP upstream
+// transports. It enforces the cloud metadata hard floor at connection time while
+// preserving existing support for legitimate local/private MCP servers.
+func NewMetadataSafeDialContext(scannerFn func() *scanner.Scanner) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	return newMetadataSafeDialContext(scannerFn, dialer.DialContext)
+}
+
+func newMetadataSafeDialContext(
+	scannerFn func() *scanner.Scanner,
+	dialContext func(ctx context.Context, network, addr string) (net.Conn, error),
+) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("mcp upstream dial: split addr %q: %w", addr, err)
+		}
+		if ip := normalizeMCPDialIP(net.ParseIP(stripMCPDialIPv6Zone(host))); ip != nil {
+			if scanner.IsCloudMetadataIP(ip) {
+				return nil, mcpMetadataDialBlock(host, ip)
+			}
+			return dialContext(ctx, network, addr)
+		}
+
+		var sc *scanner.Scanner
+		if scannerFn != nil {
+			sc = scannerFn()
+		}
+		ips, err := lookupMCPDialHost(ctx, sc, host)
+		if err != nil {
+			return nil, fmt.Errorf("mcp upstream dial: DNS lookup %q: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("mcp upstream dial: DNS returned no addresses for %s", host)
+		}
+
+		dialAddrs := make([]string, 0, len(ips))
+		for _, ipStr := range ips {
+			ip := normalizeMCPDialIP(net.ParseIP(stripMCPDialIPv6Zone(strings.TrimSpace(ipStr))))
+			if ip == nil {
+				return nil, fmt.Errorf("mcp upstream dial: unparseable IP %q from DNS for %s", ipStr, host)
+			}
+			if scanner.IsCloudMetadataIP(ip) {
+				return nil, mcpMetadataDialBlock(host, ip)
+			}
+			dialAddrs = append(dialAddrs, net.JoinHostPort(ip.String(), port))
+		}
+
+		var lastErr error
+		for _, dialAddr := range dialAddrs {
+			conn, dialErr := dialContext(ctx, network, dialAddr)
+			if dialErr == nil {
+				return conn, nil
+			}
+			lastErr = dialErr
+		}
+		return nil, fmt.Errorf("mcp upstream dial %s: %w", addr, lastErr)
+	}
+}
+
+func lookupMCPDialHost(ctx context.Context, sc *scanner.Scanner, host string) ([]string, error) {
+	if sc != nil {
+		return sc.HostResolver().LookupHost(ctx, host)
+	}
+	return defaultMCPDialLookupHost(ctx, host)
+}
+
+func mcpMetadataDialBlock(host string, ip net.IP) error {
+	return fmt.Errorf("SSRF blocked: %s resolves to cloud metadata endpoint %s (ssrf_metadata)", host, ip)
+}
+
+func normalizeMCPDialIP(ip net.IP) net.IP {
+	if ip == nil {
+		return nil
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip
+}
+
+func stripMCPDialIPv6Zone(ipStr string) string {
+	if idx := strings.Index(ipStr, "%"); idx != -1 {
+		return ipStr[:idx]
+	}
+	return ipStr
+}

--- a/internal/mcp/upstream_dial.go
+++ b/internal/mcp/upstream_dial.go
@@ -85,8 +85,26 @@ func lookupMCPDialHost(ctx context.Context, sc *scanner.Scanner, host string) ([
 	return defaultMCPDialLookupHost(ctx, host)
 }
 
+// MetadataDialBlockError is returned by the metadata-safe dial guard when a
+// configured MCP upstream (or a generic reverse-proxy upstream) resolves to a
+// cloud instance-metadata endpoint at connection time. It is a typed error so
+// the HTTP-serving transports can classify the refusal and surface the
+// ssrf_metadata block reason in the response header and receipts, rather than
+// letting it fall through as a plain 502. Mirrors the proxy's
+// ssrfDialBlockError pattern across the package boundary.
+type MetadataDialBlockError struct {
+	Host string
+	IP   net.IP
+}
+
+func (e *MetadataDialBlockError) Error() string {
+	return fmt.Sprintf("SSRF blocked: %s resolves to cloud metadata endpoint %s (ssrf_metadata)", e.Host, e.IP)
+}
+
 func mcpMetadataDialBlock(host string, ip net.IP) error {
-	return fmt.Errorf("SSRF blocked: %s resolves to cloud metadata endpoint %s (ssrf_metadata)", host, ip)
+	// Copy the IP so the returned error does not alias the caller's slice,
+	// which is reused across the resolved-address loop.
+	return &MetadataDialBlockError{Host: host, IP: append(net.IP(nil), ip...)}
 }
 
 func normalizeMCPDialIP(ip net.IP) net.IP {

--- a/internal/mcp/upstream_dial_test.go
+++ b/internal/mcp/upstream_dial_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+func TestMetadataSafeDialContext_BlocksMetadataAtDialTime(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DNS.HostOverrides = map[string][]string{
+		"metadata.vendor.example": {"169.254.169.254"},
+		"mapped.vendor.example":   {"::ffff:169.254.169.254"},
+	}
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+	dial := NewMetadataSafeDialContext(func() *scanner.Scanner { return sc })
+
+	tests := []struct {
+		name string
+		addr string
+	}{
+		{name: "literal IPv4 metadata", addr: "169.254.169.254:80"},
+		{name: "DNS metadata", addr: "metadata.vendor.example:80"},
+		{name: "IPv4-mapped DNS metadata", addr: "mapped.vendor.example:80"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := dial(context.Background(), "tcp", tt.addr)
+			if err == nil {
+				t.Fatal("expected metadata dial to fail closed")
+			}
+			if !strings.Contains(err.Error(), "ssrf_metadata") {
+				t.Fatalf("dial error = %v, want ssrf_metadata classification", err)
+			}
+		})
+	}
+}
+
+func TestMetadataSafeDialContext_BlocksMetadataHostnameWithoutScanner(t *testing.T) {
+	origLookup := defaultMCPDialLookupHost
+	defaultMCPDialLookupHost = func(context.Context, string) ([]string, error) {
+		return []string{"169.254.169.254"}, nil
+	}
+	t.Cleanup(func() { defaultMCPDialLookupHost = origLookup })
+
+	dial := NewMetadataSafeDialContext(nil)
+	_, err := dial(context.Background(), "tcp", "metadata.vendor.example:80")
+	if err == nil {
+		t.Fatal("expected metadata hostname dial to fail closed without scanner")
+	}
+	if !strings.Contains(err.Error(), "ssrf_metadata") {
+		t.Fatalf("dial error = %v, want ssrf_metadata classification", err)
+	}
+}
+
+func TestMetadataSafeDialContext_AllowsNonMetadataLoopbackUpstream(t *testing.T) {
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr == nil {
+			accepted <- conn
+		}
+	}()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DNS.HostOverrides = map[string][]string{
+		"local.vendor.example": {"127.0.0.1"},
+	}
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener addr: %v", err)
+	}
+	dial := NewMetadataSafeDialContext(func() *scanner.Scanner { return sc })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	conn, err := dial(ctx, "tcp", net.JoinHostPort("local.vendor.example", port))
+	if err != nil {
+		t.Fatalf("loopback MCP upstream should remain allowed: %v", err)
+	}
+	_ = conn.Close()
+	select {
+	case acceptedConn := <-accepted:
+		_ = acceptedConn.Close()
+	case <-ctx.Done():
+		t.Fatal("listener did not receive loopback dial")
+	}
+}
+
+func TestMetadataSafeDialContext_AllowsNonMetadataPrivateUpstream(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DNS.HostOverrides = map[string][]string{
+		"private.vendor.example": {"10.0.0.8"},
+	}
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+
+	var dialedAddr string
+	dial := newMetadataSafeDialContext(func() *scanner.Scanner { return sc }, func(_ context.Context, _ string, addr string) (net.Conn, error) {
+		dialedAddr = addr
+		client, server := net.Pipe()
+		_ = server.Close()
+		return client, nil
+	})
+
+	conn, err := dial(context.Background(), "tcp", "private.vendor.example:443")
+	if err != nil {
+		t.Fatalf("private non-metadata MCP upstream should remain allowed: %v", err)
+	}
+	_ = conn.Close()
+	if dialedAddr != "10.0.0.8:443" {
+		t.Fatalf("dialed addr = %q, want %q", dialedAddr, "10.0.0.8:443")
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3206,6 +3206,19 @@ func (p *Proxy) SafeDialer() func(ctx context.Context, network, addr string) (ne
 	return p.ssrfSafeDialContext
 }
 
+// MetadataSafeDialer exposes a narrower dial-time guard for operator-selected
+// upstreams that may legitimately live on loopback or private networks but must
+// still never reach cloud instance-metadata endpoints. Generic reverse-proxy
+// mode (Profile == "") uses this so an operator-chosen private/loopback
+// upstream stays reachable while the un-exemptable metadata floor still applies
+// at connection time, closing the DNS-rebinding gap the cloned default dialer
+// left open.
+func (p *Proxy) MetadataSafeDialer() func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return mcp.NewMetadataSafeDialContext(func() *scanner.Scanner {
+		return p.scannerPtr.Load()
+	})
+}
+
 // isShieldExempt checks whether a hostname is in the browser shield exempt list.
 // Uses scanner.MatchDomain so wildcard patterns ("*.example.com") work the same
 // way they do for the SSRF trusted-domain list, the response-scan exempt list,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3214,9 +3214,23 @@ func (p *Proxy) SafeDialer() func(ctx context.Context, network, addr string) (ne
 // at connection time, closing the DNS-rebinding gap the cloned default dialer
 // left open.
 func (p *Proxy) MetadataSafeDialer() func(ctx context.Context, network, addr string) (net.Conn, error) {
-	return mcp.NewMetadataSafeDialContext(func() *scanner.Scanner {
+	inner := mcp.NewMetadataSafeDialContext(func() *scanner.Scanner {
 		return p.scannerPtr.Load()
 	})
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := inner(ctx, network, addr)
+		if err != nil {
+			// Translate the MCP dialer's typed metadata refusal into the proxy's
+			// own ssrfDialBlockError so the reverse errorHandler surfaces
+			// ssrf_metadata in the block-reason header and receipt, identical to
+			// the submit-profile dial path, instead of a generic 502.
+			var mdErr *mcp.MetadataDialBlockError
+			if errors.As(err, &mdErr) {
+				return nil, newSSRFDialBlockError(ctx, mdErr.Host, mdErr.IP, ssrfDialBlockDetail(mdErr.Host, mdErr.IP))
+			}
+		}
+		return conn, err
+	}
 }
 
 // isShieldExempt checks whether a hostname is in the browser shield exempt list.

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -145,16 +145,18 @@ func NewReverseProxy(
 // called before serving requests; it is not safe to call concurrently with
 // ServeHTTP because it replaces proxy.Transport.
 //
-// The submit profile uses this so outbound dials resolve DNS and validate
-// every resolved IP against internal CIDR blocks before connecting, closing
-// the DNS-rebinding / TOCTOU gap the cloned default dialer leaves open. The
-// rebuilt base preserves DisableCompression (so the compressed-response
+// The submit profile uses this with the full SSRF-safe dialer so outbound
+// dials resolve DNS and validate every resolved IP against internal CIDR
+// blocks before connecting, closing the DNS-rebinding / TOCTOU gap the cloned
+// default dialer leaves open. Generic reverse-proxy mode uses a metadata-only
+// dialer so operator-selected private/loopback upstreams remain reachable.
+// The rebuilt base preserves DisableCompression (so the compressed-response
 // fail-closed guard in modifyResponse keeps working) and re-wraps in the
 // signing round tripper so RFC 9421 @target-uri signing is unaffected.
 //
-// A nil dialer is a no-op: the handler keeps its default transport. This
-// keeps generic reverse-proxy mode (Profile == "") on the default dialer,
-// where the operator is presumed to have chosen the upstream already.
+// A nil dialer is a no-op: the handler keeps its default transport. Runtime
+// startup passes a metadata-only dialer for generic reverse-proxy mode and the
+// full SSRF-safe dialer for constrained submit-profile mode.
 func (rp *ReverseProxyHandler) SetSafeDialer(dial func(ctx context.Context, network, addr string) (net.Conn, error)) {
 	if dial == nil {
 		return

--- a/internal/proxy/reverse_submit_dialer_test.go
+++ b/internal/proxy/reverse_submit_dialer_test.go
@@ -81,6 +81,7 @@ func TestReverseProxy_MetadataSafeDialerBlocksMetadataButAllowsLoopback(t *testi
 	if err != nil {
 		t.Fatalf("proxy.New: %v", err)
 	}
+	t.Cleanup(p.Close)
 
 	t.Run("metadata blocked", func(t *testing.T) {
 		upstreamURL, err := url.Parse("http://169.254.169.254")
@@ -104,9 +105,13 @@ func TestReverseProxy_MetadataSafeDialerBlocksMetadataButAllowsLoopback(t *testi
 		if err != nil {
 			t.Fatalf("reverse proxy request: %v", err)
 		}
+		reason := resp.Header.Get("X-Pipelock-Block-Reason")
 		_ = resp.Body.Close()
-		if resp.StatusCode != http.StatusBadGateway {
-			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+		if reason != "ssrf_metadata" {
+			t.Fatalf("X-Pipelock-Block-Reason = %q, want ssrf_metadata", reason)
 		}
 	})
 

--- a/internal/proxy/reverse_submit_dialer_test.go
+++ b/internal/proxy/reverse_submit_dialer_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
+func reverseMetadataTestClient() *http.Client {
+	return &http.Client{Transport: &http.Transport{Proxy: nil}}
+}
+
 // TestSubmitProfile_SetSafeDialerIsUsed proves that after SetSafeDialer,
 // the reverse proxy dials the upstream through the supplied dialer rather
 // than the default transport. A sentinel dialer records that it was
@@ -66,6 +70,82 @@ func TestSubmitProfile_SetSafeDialerIsUsed(t *testing.T) {
 	if dialerCalls.Load() == 0 {
 		t.Error("safe dialer was never invoked; SetSafeDialer did not take effect")
 	}
+}
+
+func TestReverseProxy_MetadataSafeDialerBlocksMetadataButAllowsLoopback(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	t.Run("metadata blocked", func(t *testing.T) {
+		upstreamURL, err := url.Parse("http://169.254.169.254")
+		if err != nil {
+			t.Fatalf("parse upstream: %v", err)
+		}
+		var cfgPtr atomic.Pointer[config.Config]
+		var scPtr atomic.Pointer[scanner.Scanner]
+		cfgPtr.Store(cfg)
+		scPtr.Store(sc)
+		handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, audit.NewNop(), metrics.New(), killswitch.New(cfg), nil, nil)
+		handler.SetSafeDialer(p.MetadataSafeDialer())
+		proxy := newIPv4Server(t, handler)
+		defer proxy.Close()
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, proxy.URL, nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		resp, err := reverseMetadataTestClient().Do(req)
+		if err != nil {
+			t.Fatalf("reverse proxy request: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
+		}
+	})
+
+	t.Run("loopback allowed", func(t *testing.T) {
+		var upstreamHit atomic.Bool
+		upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			upstreamHit.Store(true)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer upstream.Close()
+		upstreamURL, err := url.Parse(upstream.URL)
+		if err != nil {
+			t.Fatalf("parse upstream: %v", err)
+		}
+		var cfgPtr atomic.Pointer[config.Config]
+		var scPtr atomic.Pointer[scanner.Scanner]
+		cfgPtr.Store(cfg)
+		scPtr.Store(sc)
+		handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, audit.NewNop(), metrics.New(), killswitch.New(cfg), nil, nil)
+		handler.SetSafeDialer(p.MetadataSafeDialer())
+		proxy := newIPv4Server(t, handler)
+		defer proxy.Close()
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, proxy.URL, nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		resp, err := reverseMetadataTestClient().Do(req)
+		if err != nil {
+			t.Fatalf("reverse proxy request: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if !upstreamHit.Load() {
+			t.Fatal("loopback upstream was not reached")
+		}
+	})
 }
 
 // TestSubmitProfile_SetSafeDialerNilIsNoop verifies a nil dialer leaves the

--- a/internal/scanner/core_test.go
+++ b/internal/scanner/core_test.go
@@ -1413,6 +1413,7 @@ func TestNonOverridableSSRFConfigValidationMatchesRuntime(t *testing.T) {
 	}{
 		{"ipv4 metadata", "169.254.169.254", "169.254.169.254/32", true, false},
 		{"azure metadata", "168.63.129.16", "168.63.129.16/32", true, false},
+		{"alibaba metadata", "100.100.100.200", "100.100.100.200/32", true, false},
 		{"ipv4 mapped metadata", "::ffff:169.254.169.254", "::ffff:169.254.169.254/128", true, false},
 		{"aws ipv6 metadata", "fd00:ec2::254", "fd00:ec2::254/128", true, false},
 		{"ipv4 link-local", "169.254.1.10", "169.254.1.10/32", true, false},

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1093,12 +1093,14 @@ func parseAlternativeIP(hostname string) net.IP {
 // metadataIPv4s lists the well-known cloud-provider instance-metadata IPv4
 // endpoints that are operationally distinct from generic private-network
 // blocks. AWS / Azure / GCP IMDS all share 169.254.169.254. Azure also exposes
-// the WireServer at 168.63.129.16. Hits on these addresses are reported with
+// the WireServer at 168.63.129.16, and Alibaba Cloud ECS serves metadata at
+// 100.100.100.200. Hits on these addresses are reported with
 // ScannerSSRFMetadata so the block-reason header carries the dedicated
 // `ssrf_metadata` code (vs. the generic `ssrf_private_ip`).
 var metadataIPv4s = map[string]struct{}{
 	"169.254.169.254": {}, // AWS / Azure / GCP IMDS
 	"168.63.129.16":   {}, // Azure WireServer
+	"100.100.100.200": {}, // Alibaba Cloud ECS metadata
 }
 
 // metadataIPv6 lists the canonical IPv6 instance-metadata endpoints.


### PR DESCRIPTION
Cloud instance-metadata endpoints (the link-local IMDS addresses used by major cloud platforms) are the canonical SSRF target for stealing instance credentials, and an application agent has no legitimate reason to reach them through the firewall. They were treated as ordinary internal IPs: an ssrf.ip_allowlist entry or a trusted_domains entry could exempt them, and several transports enforced the SSRF check only at scan time, so a DNS rebind to a metadata address after the check could still be reached at dial time.

This makes the metadata endpoints an un-exemptable hard floor on every path and at both scan time and dial time. A shared classifier holds the metadata IP set; ssrf.ip_allowlist and trusted_domains still exempt every internal range except the metadata endpoints; and the core SSRF floor, the DNS-resolved scanner path, the proxy dial path, the MCP upstream contract gate, the MCP HTTP, SSE, and WebSocket transport dials, and the generic reverse proxy all block a metadata destination and classify it as ssrf_metadata. Legitimate loopback and private upstreams remain reachable, so normal reverse-proxy and local-MCP deployments are unaffected.

The metadata remediation hint no longer recommends ssrf.ip_allowlist, and config load emits a non-fatal warning when an allowlist range contains a metadata IP so the operator learns those IPs stay blocked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added connection-time protection to prevent SSRF to cloud metadata endpoints for HTTP, WebSocket, and streaming upstreams (including reverse-proxy modes).
  * Expanded the SSRF “hard floor” to cover Alibaba Cloud ECS metadata and tightened allowlist overlap validation.
  * Improved MCP metadata blocking so affected requests consistently fail closed with `403`, including `X-Pipelock-Block-Reason: ssrf_metadata` and a receipt.
* **Bug Fixes**
  * Ensured custom upstream dialing settings are always honored, and metadata dial refusals aren’t reported as generic upstream errors.
* **Tests**
  * Added coverage for the metadata hard-floor behavior and dialer (`DialContext`) usage across upstream paths and SSE/POST.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->