### PR TITLE
fix(deps): bump fast-uri to 3.1.4 in the TS verifier (GHSA-4c8g-83qw-93j6)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot configuration.
+#
+# Renovate is the primary dependency bot for this repository and owns routine
+# version updates across every ecosystem. Dependabot is configured ONLY as a
+# security backstop for the one gap Renovate cannot cover as of 2026:
+# remediation of TRANSITIVE npm vulnerabilities. Renovate's OSV remediation
+# covers direct dependencies only, and its `transitiveRemediation` option was
+# removed, so a transitive npm advisory (for example GHSA-4c8g-83qw-93j6 in
+# fast-uri under sdk/verifiers/ts) produces an alert but no Renovate PR.
+#
+# REQUIRED companion setting, which cannot be expressed in this file: a repo
+# admin must enable Settings > Security > Advanced Security > "Dependabot
+# security updates" and leave "Dependabot version updates" OFF. That toggle is
+# what actually opens security PRs; this file only customizes the npm surface.
+# The toggle is repository-wide across ecosystems; Renovate normally reaches
+# non-npm direct-dependency advisories first, so a duplicate is rare and closed
+# manually. Enable it only after the initial fast-uri fix has merged, otherwise
+# Dependabot immediately opens a duplicate PR.
+#
+# open-pull-requests-limit: 0 disables Dependabot version-update PRs so it never
+# competes with Renovate on routine npm bumps; security-update PRs use a
+# separate internal limit and still open.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/sdk/verifiers/ts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "security"

--- a/sdk/verifiers/ts/package-lock.json
+++ b/sdk/verifiers/ts/package-lock.json
@@ -84,9 +84,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What changed

Two related security changes:

1. Bumps the transitive `fast-uri` dependency in the TypeScript verifier from 3.1.2 to 3.1.4 via a lockfile-only update, clearing GHSA-4c8g-83qw-93j6 (high). The existing `^3.0.1` range already permits 3.1.4, so there is no manifest change. The verifier suite (229 tests) passes on 3.1.4 and `npm audit` reports no vulnerabilities.

2. Adds `.github/dependabot.yml` as a security-only npm backstop. Renovate remains the primary bot but cannot remediate transitive npm vulnerabilities as of 2026 (its OSV remediation covers direct dependencies only and `transitiveRemediation` was removed), which is exactly why this advisory produced an alert with no Renovate PR. The config disables Dependabot version-update PRs (`open-pull-requests-limit: 0`) so it never competes with Renovate on routine bumps.

## Required follow-up (repo setting)

The Dependabot config is inert until a repo admin enables Settings > Security > Advanced Security > Dependabot security updates (leave version updates off). Enable it after this PR merges, otherwise Dependabot opens a duplicate fast-uri PR. That toggle is repository-wide; Renovate normally reaches non-npm direct-dependency advisories first, so duplicates are rare and closed manually.
