### PR TITLE
fix(emit): counter-only sink drop path and atomic sink health snapshot

### DIFF
--- a/internal/emit/emitter.go
+++ b/internal/emit/emitter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"time"
 )
@@ -73,10 +74,29 @@ func (e *Emitter) EmitWithSeverity(ctx context.Context, sev Severity, eventType 
 	e.mu.RUnlock()
 
 	for _, s := range sinks {
-		if err := s.Emit(ctx, event); err != nil {
+		if err := s.Emit(ctx, event); err != nil && !isExpectedSinkStatus(err) {
 			fmt.Fprintf(os.Stderr, "emit: sink error (event=%s): %v\n", eventType, err)
 		}
 	}
+}
+
+// isExpectedSinkStatus reports whether err is an exact routine, already-accounted
+// sink status: a queue-full drop or a degraded advisory. Each built-in sink
+// returns these sentinels directly after reflecting the status in Stats(). A
+// wrapped or joined error may carry a distinct failure and must remain visible.
+func isExpectedSinkStatus(err error) bool {
+	// Exact identity match, deliberately NOT errors.Is: a wrapped or joined error
+	// (e.g. errors.Join(ErrQueueFull, realErr)) may carry a distinct failure and
+	// must stay visible. slices.Contains compares by ==, so only a bare sentinel
+	// is treated as a routine, already-accounted status.
+	return slices.Contains(routineSinkStatuses, err)
+}
+
+// routineSinkStatuses are the exact sentinels a sink returns for a queue-full
+// drop or a degraded advisory, both already reflected in the sink's Stats().
+var routineSinkStatuses = []error{
+	ErrQueueFull, ErrSyslogQueueFull, ErrOTLPQueueFull,
+	ErrWebhookDegraded, ErrSyslogDegraded, ErrOTLPDegraded,
 }
 
 // ReloadSinks atomically replaces the sink set and returns the old sinks.

--- a/internal/emit/emitter_test.go
+++ b/internal/emit/emitter_test.go
@@ -4,8 +4,12 @@
 package emit
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"errors"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -364,4 +368,72 @@ func TestEmitter_FieldsPassedThrough(t *testing.T) {
 	}
 
 	_ = em.Close()
+}
+
+// captureEmitterStderr runs fn with os.Stderr redirected to a pipe and returns
+// whatever fn wrote to stderr. It reads on a goroutine so a large write cannot
+// deadlock on the pipe buffer.
+func captureEmitterStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+	done := make(chan []byte, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(bufio.NewReader(r))
+		done <- buf.Bytes()
+	}()
+	fn()
+	os.Stderr = old
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	return string(out)
+}
+
+// TestEmitter_ExpectedSinkStatusNoStderr proves the fan-out does not write a
+// synchronous stderr diagnostic when a sink reports a routine, already-accounted
+// status (queue-full drop or degraded advisory) — those fire on the Emit hot
+// path and are observable via Stats(). An UNEXPECTED sink error still prints.
+func TestEmitter_ExpectedSinkStatusNoStderr(t *testing.T) {
+	expected := []error{
+		ErrQueueFull, ErrSyslogQueueFull, ErrOTLPQueueFull,
+		ErrWebhookDegraded, ErrSyslogDegraded, ErrOTLPDegraded,
+	}
+	for _, se := range expected {
+		se := se
+		t.Run(se.Error(), func(t *testing.T) {
+			em := NewEmitter(testStr, &mockSink{err: se})
+			out := captureEmitterStderr(t, func() {
+				em.Emit(context.Background(), testEventBlocked, map[string]any{"k": "v"})
+			})
+			if out != "" {
+				t.Fatalf("expected sink status %v wrote hot-path stderr: %q", se, out)
+			}
+		})
+	}
+
+	t.Run("unexpected error still prints", func(t *testing.T) {
+		em := NewEmitter(testStr, &mockSink{err: errors.New("unexpected boom")})
+		out := captureEmitterStderr(t, func() {
+			em.Emit(context.Background(), testEventBlocked, map[string]any{"k": "v"})
+		})
+		if !strings.Contains(out, "unexpected boom") {
+			t.Fatalf("unexpected sink error was not surfaced to stderr: %q", out)
+		}
+	})
+
+	t.Run("joined status and unexpected error still prints", func(t *testing.T) {
+		em := NewEmitter(testStr, &mockSink{err: errors.Join(ErrQueueFull, errors.New("unexpected joined boom"))})
+		out := captureEmitterStderr(t, func() {
+			em.Emit(context.Background(), testEventBlocked, map[string]any{"k": "v"})
+		})
+		if !strings.Contains(out, "unexpected joined boom") {
+			t.Fatalf("unexpected error joined with sink status was suppressed: %q", out)
+		}
+	})
 }

--- a/internal/emit/emitter_test.go
+++ b/internal/emit/emitter_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -434,6 +435,20 @@ func TestEmitter_ExpectedSinkStatusNoStderr(t *testing.T) {
 		})
 		if !strings.Contains(out, "unexpected joined boom") {
 			t.Fatalf("unexpected error joined with sink status was suppressed: %q", out)
+		}
+	})
+
+	t.Run("wrapped routine status still prints", func(t *testing.T) {
+		// The suppression is an exact-identity match, so a wrapped sentinel is
+		// NOT a routine status and must stay visible: it may carry added context
+		// or a distinct failure the bare sentinel does not.
+		wrapped := fmt.Errorf("delivering to remote: %w", ErrQueueFull)
+		em := NewEmitter(testStr, &mockSink{err: wrapped})
+		out := captureEmitterStderr(t, func() {
+			em.Emit(context.Background(), testEventBlocked, map[string]any{"k": "v"})
+		})
+		if !strings.Contains(out, "delivering to remote") {
+			t.Fatalf("wrapped routine status was suppressed: %q", out)
 		}
 	})
 }

--- a/internal/emit/syslog.go
+++ b/internal/emit/syslog.go
@@ -316,7 +316,7 @@ func (s *SyslogSink) Emit(_ context.Context, event Event) error {
 		return nil
 	default:
 		s.closeMu.Unlock()
-		s.recordDropped("queue_full", msg, nil)
+		s.recordDropped("queue_full", nil)
 		return ErrSyslogQueueFull
 	}
 }
@@ -409,6 +409,10 @@ func makeSyslogMessage(event Event, format, deviceVersion string) (syslogMessage
 }
 
 func (s *SyslogSink) send(msg syslogMessage) {
+	failedSnapshot := s.failed.Load()
+	droppedSnapshot := s.dropped.Load()
+	abandonedSnapshot := s.abandoned.Load()
+
 	var writeErr error
 
 	switch msg.severity {
@@ -424,7 +428,17 @@ func (s *SyslogSink) send(msg syslogMessage) {
 		return
 	}
 	s.delivered.Add(1)
-	s.degraded.Store(false)
+	s.lastErrMu.Lock()
+	// Clear paired health only if no newer failure, drop, or abandonment was
+	// recorded while this write was in flight. The lock makes Degraded and
+	// LastError one observable transition for Stats().
+	if s.failed.Load() == failedSnapshot &&
+		s.dropped.Load() == droppedSnapshot &&
+		s.abandoned.Load() == abandonedSnapshot {
+		s.degraded.Store(false)
+		s.lastErr = ""
+	}
+	s.lastErrMu.Unlock()
 }
 
 // Close closes the syslog writer. Safe to call on a nil or already-closed writer.
@@ -476,13 +490,14 @@ func (s *SyslogSink) Stats() SyslogStats {
 	}
 	s.lastErrMu.Lock()
 	lastErr := s.lastErr
+	degraded := s.degraded.Load()
 	s.lastErrMu.Unlock()
 	stats := SyslogStats{
 		Delivered: s.delivered.Load(),
 		Failed:    s.failed.Load(),
 		Dropped:   s.dropped.Load(),
 		Abandoned: s.abandoned.Load(),
-		Degraded:  s.degraded.Load(),
+		Degraded:  degraded,
 		LastError: lastErr,
 	}
 	if s.queue != nil {
@@ -494,26 +509,32 @@ func (s *SyslogSink) Stats() SyslogStats {
 
 func (s *SyslogSink) recordFailure(reason string, msg syslogMessage, err error) {
 	s.failed.Add(1)
+	s.lastErrMu.Lock()
 	s.degraded.Store(true)
 	if err != nil {
-		s.lastErrMu.Lock()
 		s.lastErr = err.Error()
-		s.lastErrMu.Unlock()
 	}
+	s.lastErrMu.Unlock()
 	s.logDiagnostic("delivery_failed", reason, msg, err, 0)
 }
 
-func (s *SyslogSink) recordDropped(reason string, msg syslogMessage, err error) {
+// recordDropped accounts for an event dropped on the Emit hot path (queue full).
+// It only updates atomic counters and lastErr and MUST NOT write a diagnostic
+// synchronously: Emit runs on the request/enforcement path, and a queue-full
+// drop means the system is already under telemetry backpressure, so a synchronous
+// stderr write (which can block on a stalled pipe/journald) could turn that
+// backpressure into request-path blocking. The drop is observable via
+// Stats().Dropped / LastError / Degraded (and, once wired, sink health metrics).
+func (s *SyslogSink) recordDropped(reason string, err error) {
 	s.dropped.Add(1)
-	s.degraded.Store(true)
 	lastErr := reason
 	if err != nil {
 		lastErr = err.Error()
 	}
 	s.lastErrMu.Lock()
+	s.degraded.Store(true)
 	s.lastErr = lastErr
 	s.lastErrMu.Unlock()
-	s.logDiagnostic("event_dropped", reason, msg, err, 0)
 }
 
 func (s *SyslogSink) recordAbandoned(reason string, msg syslogMessage, count int) {
@@ -521,8 +542,8 @@ func (s *SyslogSink) recordAbandoned(reason string, msg syslogMessage, count int
 		count = 1
 	}
 	s.abandoned.Add(uint64(count))
-	s.degraded.Store(true)
 	s.lastErrMu.Lock()
+	s.degraded.Store(true)
 	s.lastErr = reason
 	s.lastErrMu.Unlock()
 	s.logDiagnostic("events_abandoned", reason, msg, nil, count)

--- a/internal/emit/syslog_test.go
+++ b/internal/emit/syslog_test.go
@@ -6,10 +6,13 @@
 package emit
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"log/syslog"
 	"net"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -166,17 +169,33 @@ func TestSyslogSink_EmitQueueFullIsBounded(t *testing.T) {
 	if err := sink.Emit(context.Background(), event); err != nil {
 		t.Fatalf("second Emit: %v", err)
 	}
-	if err := sink.Emit(context.Background(), event); !errors.Is(err, ErrSyslogQueueFull) {
-		t.Fatalf("third Emit error = %v, want ErrSyslogQueueFull", err)
+	readStderr, writeStderr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
 	}
+	oldStderr := os.Stderr
+	os.Stderr = writeStderr
+	dropErr := sink.Emit(context.Background(), event)
+	os.Stderr = oldStderr
+	_ = writeStderr.Close()
+	data, _ := io.ReadAll(readStderr)
+	_ = readStderr.Close()
 	stats := sink.Stats()
+
+	writer.release()
+	closeErr := sink.Close()
+
+	if !errors.Is(dropErr, ErrSyslogQueueFull) {
+		t.Fatalf("third Emit error = %v, want ErrSyslogQueueFull", dropErr)
+	}
+	if len(bytes.TrimSpace(data)) != 0 {
+		t.Fatalf("queue-full drop wrote to stderr on the Emit hot path: %q", data)
+	}
 	if stats.Dropped != 1 || !stats.Degraded || stats.LastError != "queue_full" {
 		t.Fatalf("stats = %+v, want queue_full drop", stats)
 	}
-
-	writer.release()
-	if err := sink.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
+	if closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
 	}
 }
 
@@ -460,6 +479,9 @@ func TestSyslogSink_EmitSignalsPriorDegradedState(t *testing.T) {
 	writer := newBlockingSyslogWriter()
 	sink := newSyslogSink(writer, &syslogConfig{queueLen: 2})
 	sink.degraded.Store(true)
+	sink.lastErrMu.Lock()
+	sink.lastErr = "prior delivery failure"
+	sink.lastErrMu.Unlock()
 
 	err := sink.Emit(context.Background(), Event{
 		Severity:  SeverityWarn,
@@ -475,8 +497,82 @@ func TestSyslogSink_EmitSignalsPriorDegradedState(t *testing.T) {
 	if err := sink.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if stats := sink.Stats(); stats.Delivered != 1 || stats.Degraded {
-		t.Fatalf("stats = %+v, want successful send to clear degraded state", stats)
+	if stats := sink.Stats(); stats.Delivered != 1 || stats.Degraded || stats.LastError != "" {
+		t.Fatalf("stats = %+v, want successful send to clear degraded state and LastError", stats)
+	}
+}
+
+func TestSyslogSink_SuccessHealthTransitionIsAtomic(t *testing.T) {
+	writer := &countingSyslogWriter{}
+	sink := &SyslogSink{writer: writer, queue: make(chan syslogMessage, 1)}
+	sink.degraded.Store(true)
+	sink.lastErr = "prior failure"
+
+	// Hold the LastError lock while the write completes. Degraded must remain
+	// true until the successful recovery can clear both health fields together.
+	sink.lastErrMu.Lock()
+	done := make(chan struct{})
+	go func() {
+		sink.send(syslogMessage{severity: SeverityWarn, eventType: testEventBlocked})
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for writer.count.Load() != 1 {
+		select {
+		case <-deadline:
+			sink.lastErrMu.Unlock()
+			t.Fatal("timeout waiting for syslog write")
+		default:
+		}
+	}
+	if !sink.degraded.Load() {
+		sink.lastErrMu.Unlock()
+		t.Fatal("Degraded cleared before LastError could be cleared")
+	}
+	sink.lastErrMu.Unlock()
+	<-done
+
+	if stats := sink.Stats(); stats.Degraded || stats.LastError != "" {
+		t.Fatalf("stats = %+v, want atomic successful recovery", stats)
+	}
+}
+
+func TestSyslogSink_SuccessDoesNotEraseConcurrentDropDegraded(t *testing.T) {
+	var sink *SyslogSink
+	writer := &callbackSyslogWriter{writeFn: func() {
+		sink.recordDropped("queue_full", nil)
+	}}
+	sink = &SyslogSink{writer: writer, queue: make(chan syslogMessage, 1)}
+
+	sink.send(syslogMessage{severity: SeverityWarn, eventType: testEventBlocked})
+
+	stats := sink.Stats()
+	if stats.Delivered != 1 || stats.Dropped != 1 {
+		t.Fatalf("stats = %+v, want one delivery and one concurrent drop", stats)
+	}
+	if !stats.Degraded || stats.LastError != "queue_full" {
+		t.Fatalf("stats = %+v, concurrent drop health was erased by success", stats)
+	}
+}
+
+func TestSyslogSink_RepeatedDegradeRecoverCycles(t *testing.T) {
+	sink := &SyslogSink{
+		writer: &countingSyslogWriter{},
+		queue:  make(chan syslogMessage, 1),
+	}
+
+	for cycle := 1; cycle <= 3; cycle++ {
+		sink.recordDropped("queue_full", nil)
+		if stats := sink.Stats(); !stats.Degraded || stats.LastError != "queue_full" {
+			t.Fatalf("cycle %d degraded stats = %+v", cycle, stats)
+		}
+
+		sink.send(syslogMessage{severity: SeverityWarn, eventType: testEventBlocked})
+		stats := sink.Stats()
+		if stats.Degraded || stats.LastError != "" || stats.Delivered != uint64(cycle) || stats.Dropped != uint64(cycle) {
+			t.Fatalf("cycle %d recovered stats = %+v", cycle, stats)
+		}
 	}
 }
 
@@ -966,6 +1062,29 @@ func waitSinkClosed(t *testing.T, sink *SyslogSink) {
 type countingSyslogWriter struct {
 	count  atomic.Int64
 	closed atomic.Bool
+}
+
+type callbackSyslogWriter struct {
+	writeFn func()
+}
+
+func (w *callbackSyslogWriter) Crit(string) error {
+	w.writeFn()
+	return nil
+}
+
+func (w *callbackSyslogWriter) Warning(string) error {
+	w.writeFn()
+	return nil
+}
+
+func (w *callbackSyslogWriter) Info(string) error {
+	w.writeFn()
+	return nil
+}
+
+func (*callbackSyslogWriter) Close() error {
+	return nil
 }
 
 func (w *countingSyslogWriter) Crit(msg string) error {

--- a/internal/emit/syslog_windows.go
+++ b/internal/emit/syslog_windows.go
@@ -13,6 +13,15 @@ import (
 // ErrSyslogUnavailable is returned on platforms where log/syslog is not available.
 var ErrSyslogUnavailable = errors.New("emit: syslog is not available on Windows")
 
+// ErrSyslogQueueFull and ErrSyslogDegraded mirror the non-Windows syslog sink's
+// sentinels. The syslog sink itself is stubbed on Windows, but these are defined
+// here too so platform-agnostic code (such as the emitter's routine-sink-status
+// check) can reference them on every platform.
+var (
+	ErrSyslogQueueFull = errors.New("emit: syslog queue full, event dropped")
+	ErrSyslogDegraded  = errors.New("emit: syslog sink degraded")
+)
+
 type syslogConfig struct{}
 
 // SyslogOption configures a SyslogSink on platforms that support syslog.

--- a/internal/emit/webhook.go
+++ b/internal/emit/webhook.go
@@ -154,7 +154,7 @@ func (w *WebhookSink) Emit(_ context.Context, event Event) error {
 		return nil
 	default:
 		w.closeMu.Unlock()
-		w.recordDropped("queue_full", event, nil)
+		w.recordDropped("queue_full", nil)
 		return ErrQueueFull
 	}
 }
@@ -220,12 +220,13 @@ func (w *WebhookSink) safeSend(event Event) {
 
 // send POSTs a single event as JSON to the webhook URL.
 func (w *WebhookSink) send(event Event) {
-	// Snapshot the failure/drop count before the send so a successful delivery
-	// only clears the degraded flag if no failure or drop was recorded while
-	// this send was in flight. Without this, a concurrent queue-full drop (which
-	// sets degraded=true) could be silently erased by this send's success,
-	// leaving Dropped>0 while Degraded reported false.
-	failSnapshot := w.failed.Load() + w.dropped.Load()
+	// Snapshot the health-change counters before the send so a successful
+	// delivery only clears degraded health if no failure, drop, or abandonment
+	// was recorded while this send was in flight. Without this, a concurrent
+	// queue-full drop could be silently erased by this send's success.
+	failedSnapshot := w.failed.Load()
+	droppedSnapshot := w.dropped.Load()
+	abandonedSnapshot := w.abandoned.Load()
 
 	payload := webhookPayload{
 		Severity:  event.Severity.String(),
@@ -263,11 +264,17 @@ func (w *WebhookSink) send(event Event) {
 		return
 	}
 	w.delivered.Add(1)
-	// Only clear degraded if no failure/drop landed while this send was in
-	// flight; otherwise a concurrent drop's degraded signal would be lost.
-	if w.failed.Load()+w.dropped.Load() == failSnapshot {
+	w.lastErrMu.Lock()
+	// Clear paired health only if no newer failure, drop, or abandonment was
+	// recorded while this request was in flight. Rechecking under the same lock
+	// that guards health updates closes the check-then-clear race.
+	if w.failed.Load() == failedSnapshot &&
+		w.dropped.Load() == droppedSnapshot &&
+		w.abandoned.Load() == abandonedSnapshot {
 		w.degraded.Store(false)
+		w.lastErr = ""
 	}
+	w.lastErrMu.Unlock()
 }
 
 // Stats returns a consistent snapshot of webhook sink delivery health.
@@ -277,13 +284,14 @@ func (w *WebhookSink) Stats() WebhookStats {
 	}
 	w.lastErrMu.Lock()
 	lastErr := w.lastErr
+	degraded := w.degraded.Load()
 	w.lastErrMu.Unlock()
 	stats := WebhookStats{
 		Delivered: w.delivered.Load(),
 		Failed:    w.failed.Load(),
 		Dropped:   w.dropped.Load(),
 		Abandoned: w.abandoned.Load(),
-		Degraded:  w.degraded.Load(),
+		Degraded:  degraded,
 		LastError: lastErr,
 	}
 	if w.queue != nil {
@@ -314,26 +322,32 @@ func sanitizeWebhookErr(err error) string {
 
 func (w *WebhookSink) recordFailure(reason string, event Event, err error) {
 	w.failed.Add(1)
+	w.lastErrMu.Lock()
 	w.degraded.Store(true)
 	if err != nil {
-		w.lastErrMu.Lock()
 		w.lastErr = sanitizeWebhookErr(err)
-		w.lastErrMu.Unlock()
 	}
+	w.lastErrMu.Unlock()
 	w.logDiagnostic("delivery_failed", reason, event, err, 0)
 }
 
-func (w *WebhookSink) recordDropped(reason string, event Event, err error) {
+// recordDropped accounts for an event dropped on the Emit hot path (queue full).
+// It only updates atomic counters and lastErr and MUST NOT write a diagnostic
+// synchronously: Emit runs on the request/enforcement path, and a queue-full
+// drop means the system is already under telemetry backpressure, so a synchronous
+// stderr write (which can block on a stalled pipe/journald) could turn that
+// backpressure into request-path blocking. The drop is observable via
+// Stats().Dropped / LastError / Degraded (and, once wired, sink health metrics).
+func (w *WebhookSink) recordDropped(reason string, err error) {
 	w.dropped.Add(1)
-	w.degraded.Store(true)
 	lastErr := reason
 	if err != nil {
 		lastErr = sanitizeWebhookErr(err)
 	}
 	w.lastErrMu.Lock()
+	w.degraded.Store(true)
 	w.lastErr = lastErr
 	w.lastErrMu.Unlock()
-	w.logDiagnostic("event_dropped", reason, event, err, 0)
 }
 
 func (w *WebhookSink) recordAbandoned(reason string, count int) {
@@ -341,8 +355,8 @@ func (w *WebhookSink) recordAbandoned(reason string, count int) {
 		return
 	}
 	w.abandoned.Add(uint64(count))
-	w.degraded.Store(true)
 	w.lastErrMu.Lock()
+	w.degraded.Store(true)
 	w.lastErr = reason
 	w.lastErrMu.Unlock()
 	w.logDiagnostic("events_abandoned", reason, Event{Type: "unknown"}, nil, count)

--- a/internal/emit/webhook_test.go
+++ b/internal/emit/webhook_test.go
@@ -4,11 +4,14 @@
 package emit
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -200,6 +203,12 @@ func TestWebhookSink_QueueFull(t *testing.T) {
 	}
 
 	// Fill the queue. One item may be pulled by the goroutine, so send extra.
+	readStderr, writeStderr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = writeStderr
 	var queueFullSeen bool
 	for i := 0; i < 20; i++ {
 		if err := sink.Emit(context.Background(), event); errors.Is(err, ErrQueueFull) {
@@ -211,21 +220,29 @@ func TestWebhookSink_QueueFull(t *testing.T) {
 		default:
 		}
 	}
+	os.Stderr = oldStderr
+	_ = writeStderr.Close()
+	data, _ := io.ReadAll(readStderr)
+	_ = readStderr.Close()
+	stats := sink.Stats()
+
+	// Unblock the server before assertions so a regression cannot strand the
+	// handler and hang httptest.Server.Close during test cleanup.
+	close(blocker)
+	_ = sink.Close()
 
 	if !queueFullSeen {
 		t.Error("expected ErrQueueFull after filling queue")
 	}
-	stats := sink.Stats()
+	if len(bytes.TrimSpace(data)) != 0 {
+		t.Fatalf("queue-full drop wrote to stderr on the Emit hot path: %q", data)
+	}
 	if stats.Dropped != 1 || !stats.Degraded || stats.LastError != "queue_full" {
 		t.Fatalf("stats = %+v, want queue_full drop", stats)
 	}
 	if stats.QueueCap != 2 {
 		t.Fatalf("QueueCap = %d, want 2", stats.QueueCap)
 	}
-
-	// Unblock the server so Close can drain without hanging.
-	close(blocker)
-	_ = sink.Close()
 }
 
 func TestWebhookSink_CloseDrainsPending(t *testing.T) {
@@ -481,7 +498,7 @@ func TestWebhookSink_SendMarshalError(t *testing.T) {
 		t.Errorf("expected 1 successful request (bad event skipped), got %d", got)
 	}
 	stats := sink.Stats()
-	if stats.Delivered != 1 || stats.Failed != 1 || stats.Degraded || stats.LastError == "" {
+	if stats.Delivered != 1 || stats.Failed != 1 || stats.Degraded || stats.LastError != "" {
 		t.Fatalf("stats = %+v, want one marshal failure and recovered delivery", stats)
 	}
 }
@@ -615,6 +632,9 @@ func TestWebhookSink_EmitSignalsPriorDegradedStateThenRecovers(t *testing.T) {
 	waitWebhookStats(t, sink, func(stats WebhookStats) bool {
 		return stats.Delivered == 1 && stats.Failed == 1 && !stats.Degraded
 	})
+	if stats := sink.Stats(); stats.LastError != "" {
+		t.Fatalf("LastError = %q after recovery, want cleared", stats.LastError)
+	}
 
 	for i := 1; i <= 2; i++ {
 		select {
@@ -780,7 +800,7 @@ func TestWebhookSink_SuccessDoesNotEraseConcurrentDropDegraded(t *testing.T) {
 	// it inline.
 	var sink *WebhookSink
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		sink.recordDropped("queue_full", Event{Type: testEventBlocked}, nil)
+		sink.recordDropped("queue_full", nil)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
@@ -800,12 +820,92 @@ func TestWebhookSink_SuccessDoesNotEraseConcurrentDropDegraded(t *testing.T) {
 	if !stats.Degraded {
 		t.Fatal("degraded was erased despite a concurrent drop during the send")
 	}
+	if stats.LastError != "queue_full" {
+		t.Fatalf("LastError = %q, want concurrent drop error preserved", stats.LastError)
+	}
+}
+
+func TestWebhookSink_SuccessHealthTransitionIsAtomic(t *testing.T) {
+	requestDone := make(chan struct{})
+	sink := &WebhookSink{
+		url: "https://api.vendor.example/hook",
+		client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			close(requestDone)
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Body:       http.NoBody,
+			}, nil
+		})},
+		queue: make(chan Event, 1),
+	}
+	sink.degraded.Store(true)
+	sink.lastErr = "prior failure"
+
+	// Hold the LastError lock while the request completes. Degraded must remain
+	// true until the successful recovery can clear both health fields together.
+	sink.lastErrMu.Lock()
+	done := make(chan struct{})
+	go func() {
+		sink.send(Event{Severity: SeverityWarn, Type: testEventBlocked, Timestamp: time.Now()})
+		close(done)
+	}()
+	select {
+	case <-requestDone:
+	case <-time.After(2 * time.Second):
+		sink.lastErrMu.Unlock()
+		t.Fatal("timeout waiting for webhook request")
+	}
+	deadline := time.After(2 * time.Second)
+	for sink.delivered.Load() != 1 {
+		select {
+		case <-deadline:
+			sink.lastErrMu.Unlock()
+			t.Fatal("timeout waiting for webhook delivery")
+		default:
+		}
+	}
+	if !sink.degraded.Load() {
+		sink.lastErrMu.Unlock()
+		t.Fatal("Degraded cleared before LastError could be cleared")
+	}
+	sink.lastErrMu.Unlock()
+	<-done
+
+	if stats := sink.Stats(); stats.Degraded || stats.LastError != "" {
+		t.Fatalf("stats = %+v, want atomic successful recovery", stats)
+	}
+}
+
+func TestWebhookSink_RepeatedDegradeRecoverCycles(t *testing.T) {
+	sink := &WebhookSink{
+		url: "https://api.vendor.example/hook",
+		client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Body:       http.NoBody,
+			}, nil
+		})},
+		queue: make(chan Event, 1),
+	}
+
+	for cycle := 1; cycle <= 3; cycle++ {
+		sink.recordDropped("queue_full", nil)
+		if stats := sink.Stats(); !stats.Degraded || stats.LastError != "queue_full" {
+			t.Fatalf("cycle %d degraded stats = %+v", cycle, stats)
+		}
+
+		sink.send(Event{Severity: SeverityWarn, Type: testEventBlocked, Timestamp: time.Now()})
+		stats := sink.Stats()
+		if stats.Degraded || stats.LastError != "" || stats.Delivered != uint64(cycle) || stats.Dropped != uint64(cycle) {
+			t.Fatalf("cycle %d recovered stats = %+v", cycle, stats)
+		}
+	}
 }
 
 func TestWebhookSink_RecordDroppedWithErrorAndAbandonedZeroCount(t *testing.T) {
 	sink := &WebhookSink{queue: make(chan Event, 1)}
 
-	sink.recordDropped("test_reason", Event{Type: testEventBlocked}, errors.New("boom"))
+	sink.recordDropped("test_reason", errors.New("boom"))
 	if stats := sink.Stats(); stats.Dropped != 1 || stats.LastError != "boom" {
 		t.Fatalf("stats after dropped-with-error = %+v, want Dropped=1 LastError=boom", stats)
 	}


### PR DESCRIPTION
## What changed

The syslog and webhook async emit sinks now match the OTLP sink's delivery accounting. The queue-full drop path is counter-only: it no longer writes a synchronous stderr diagnostic on the Emit hot path, where a stalled pipe or journald could turn telemetry backpressure into request-path blocking. Drops stay observable through Stats().Dropped, LastError, and Degraded.

A successful delivery clears the paired Degraded and LastError only when no failure, drop, or abandonment was recorded while that write was in flight, so a concurrent queue-full drop's degraded signal is never erased. Degraded and LastError now transition together under the health mutex, so Stats() cannot report a torn pair.

The emitter fan-out suppresses only the exact routine drop and degraded sentinels, matched by identity rather than errors.Is, so a wrapped or joined error that carries a distinct failure stays visible on stderr.

## Notes

Each guard is verified by reproduction: it fails when its check is removed. No delivered-event behavior changes; only how drops and errors are surfaced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy stderr diagnostics for routine queue-full and degraded delivery drops (while still showing unexpected failures).
  * Improved webhook and syslog sink health accounting, including correct degraded/last-error handling under concurrent send, drop, and abandonment scenarios.
  * Ensured recovery clears degraded state and last-error reliably without erasing concurrent drop details.
  * Added consistent syslog “queue full” and “degraded” sentinel errors on Windows.

* **Tests**
  * Expanded stderr-capture and atomic health-transition assertions, including repeated degrade/recover and concurrency scenarios for both syslog and webhook sinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->