### PR TITLE
feat(audit): attach remediation hints to WebSocket, body-DLP, and denial-of-wallet events

### DIFF
--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -1345,6 +1345,7 @@ func (l *Logger) LogWSBlocked(target, direction, scannerName, reason, clientIP, 
 		str("reason", reason).
 		str("client_ip", clientIP).
 		str("request_id", requestID).
+		optStr("remediation_hint", scannerpkg.OperatorHintForResult(scannerName, reason)).
 		optStr("mitre_technique", technique)
 
 	// includeBlocked gates local audit log only - external emission always fires.
@@ -1604,6 +1605,7 @@ func (l *Logger) LogBodyDLP(ctx LogContext, action string, matchCount int, patte
 		optStr("agent", ctx.agent).
 		intField("match_count", matchCount).
 		strs("patterns", patternNames).
+		optStr("remediation_hint", scannerpkg.OperatorHintForResult(scannerpkg.ScannerBodyDLP, "")).
 		str("mitre_technique", technique)
 	if len(bundleRules) > 0 {
 		e.bundleRulesField(bundleRules)

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/emit"
+	scannerpkg "github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
 const (
@@ -29,6 +30,7 @@ const (
 	testConfigHash = "testhash"
 	testVersion    = "0.1.0-dev"
 	testAgentName  = "claude-code"
+	testDoWTarget  = "expensive_tool"
 	testMethodGet  = "GET"
 	mitreT1048     = "T1048"
 	mitreT1053     = "T1053"
@@ -1609,6 +1611,10 @@ func TestLogWSBlocked_JSONFormat(t *testing.T) {
 	if entry["reason"] != "secret detected" {
 		t.Errorf("expected reason='secret detected', got %v", entry["reason"])
 	}
+	hint, _ := entry["remediation_hint"].(string)
+	if !strings.Contains(hint, "dlp.patterns[].exempt_domains") {
+		t.Fatalf("remediation_hint = %q, want DLP operator knob", hint)
+	}
 }
 
 func TestLogWSBlocked_Filtered(t *testing.T) {
@@ -2554,6 +2560,53 @@ func TestEmit_LogAnomaly(t *testing.T) {
 	}
 }
 
+func TestEmit_LogDenialOfWalletRemediationHint(t *testing.T) {
+	tests := []struct {
+		name      string
+		log       func(*Logger)
+		wantEvent EventType
+	}{
+		{
+			name: "blocked",
+			log: func(logger *Logger) {
+				logger.LogBlocked(LogContext{method: "MCP", target: testDoWTarget}, scannerpkg.ScannerDenialOfWallet, "tool call limit exceeded: 11/10")
+			},
+			wantEvent: EventBlocked,
+		},
+		{
+			name: "anomaly",
+			log: func(logger *Logger) {
+				logger.LogAnomaly(LogContext{method: "MCP", target: testDoWTarget}, scannerpkg.ScannerDenialOfWallet, "tool call limit exceeded: 11/10", 0)
+			},
+			wantEvent: EventAnomaly,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, sink := newLoggerWithEmitter(t)
+			defer logger.Close()
+
+			tt.log(logger)
+
+			ev, ok := sink.lastEvent()
+			if !ok {
+				t.Fatal("expected emitted event")
+			}
+			if ev.Type != string(tt.wantEvent) {
+				t.Fatalf("type = %q, want %s", ev.Type, tt.wantEvent)
+			}
+			if ev.Fields["scanner"] != scannerpkg.ScannerDenialOfWallet {
+				t.Fatalf("fields[scanner] = %v, want %s", ev.Fields["scanner"], scannerpkg.ScannerDenialOfWallet)
+			}
+			hint, _ := ev.Fields["remediation_hint"].(string)
+			if !strings.Contains(hint, "agents._default.budget.max_tool_calls_per_session") {
+				t.Fatalf("fields[remediation_hint] = %q, want exact tool-call budget knob", hint)
+			}
+		})
+	}
+}
+
 func TestEmit_LogResponseScanExempt(t *testing.T) {
 	logger, sink := newLoggerWithEmitter(t)
 	defer logger.Close()
@@ -2726,6 +2779,10 @@ func TestEmit_LogWSBlocked(t *testing.T) {
 	}
 	if ev.Fields["mitre_technique"] != mitreT1048 {
 		t.Errorf("fields[mitre_technique] = %v, want T1048", ev.Fields["mitre_technique"])
+	}
+	hint, _ := ev.Fields["remediation_hint"].(string)
+	if !strings.Contains(hint, "dlp.patterns[].exempt_domains") {
+		t.Fatalf("fields[remediation_hint] = %q, want DLP operator knob", hint)
 	}
 }
 
@@ -2974,6 +3031,10 @@ func TestLogBodyDLP_JSONFormat(t *testing.T) {
 	}
 	if entry["mitre_technique"] != mitreT1048 {
 		t.Errorf("expected mitre_technique=T1048, got %v", entry["mitre_technique"])
+	}
+	hint, _ := entry["remediation_hint"].(string)
+	if !strings.Contains(hint, "suppress:") {
+		t.Fatalf("remediation_hint = %q, want body-DLP suppress guidance", hint)
 	}
 }
 
@@ -3251,6 +3312,13 @@ func TestEmit_LogBodyDLP(t *testing.T) {
 	}
 	if ev.Fields["match_count"] != 1 {
 		t.Errorf("fields[match_count] = %v, want 1", ev.Fields["match_count"])
+	}
+	if ev.Fields["action"] != actionBlock {
+		t.Errorf("fields[action] = %v, want block", ev.Fields["action"])
+	}
+	hint, _ := ev.Fields["remediation_hint"].(string)
+	if !strings.Contains(hint, "suppress:") {
+		t.Fatalf("fields[remediation_hint] = %q, want body-DLP suppress guidance", hint)
 	}
 }
 

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -692,7 +692,7 @@ func ForwardScannedInput(
 			continue
 		case blockingGateDoW:
 			if auditLogger != nil {
-				auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), "denial_of_wallet", eval.DoWReason)
+				auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), scanner.ScannerDenialOfWallet, eval.DoWReason)
 			}
 			if m != nil {
 				m.RecordBlocked("mcp", "denial_of_wallet", 0, "")
@@ -774,7 +774,7 @@ func ForwardScannedInput(
 		}
 		if !eval.DoWAllowed && eval.DoWAction != "" {
 			if auditLogger != nil {
-				auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), "denial_of_wallet", eval.DoWReason, 0)
+				auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), scanner.ScannerDenialOfWallet, eval.DoWReason, 0)
 			}
 			recordAdaptiveSignal(session.SignalNearMiss)
 		}

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -13,6 +13,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -4306,6 +4308,68 @@ func TestForwardScannedInput_DoWWarn(t *testing.T) {
 
 	if !strings.Contains(logW.String(), "DoW") {
 		t.Errorf("expected DoW log in warn mode, got: %s", logW.String())
+	}
+}
+
+func TestForwardScannedInput_DoWAuditEventsIncludeRemediationHint(t *testing.T) {
+	tests := []struct {
+		name      string
+		action    string
+		wantEvent string
+	}{
+		{name: "blocked", action: config.ActionBlock, wantEvent: string(audit.EventBlocked)},
+		{name: "anomaly", action: config.ActionWarn, wantEvent: string(audit.EventAnomaly)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := testInputScanner(t)
+			auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+			auditLogger, err := audit.New("json", "file", auditPath, false, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			reason := "tool call limit exceeded: 11/10"
+			opts := testOpts(sc)
+			opts.AuditLogger = auditLogger
+			opts.DoWCheck = func(_, _ string) (bool, string, string, string) {
+				return false, tt.action, reason, "tool_call_limit"
+			}
+
+			request := makeRequest(101, "tools/call", map[string]interface{}{
+				"name":      testDoWToolName,
+				"arguments": map[string]string{"q": "hello"},
+			}) + "\n"
+			var serverIn bytes.Buffer
+			var logW bytes.Buffer
+			blockedCh := make(chan BlockedRequest, 1)
+			ForwardScannedInput(
+				transport.NewStdioReader(strings.NewReader(request)),
+				transport.NewStdioWriter(&serverIn),
+				&logW, config.ActionWarn, config.ActionBlock, blockedCh, nil, nil, opts,
+			)
+			auditLogger.Close()
+
+			data, err := os.ReadFile(filepath.Clean(auditPath))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var entry map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(data), &entry); err != nil {
+				t.Fatalf("decode audit event: %v; data=%q", err, data)
+			}
+			if entry["event"] != tt.wantEvent {
+				t.Fatalf("event = %v, want %s", entry["event"], tt.wantEvent)
+			}
+			if entry["scanner"] != scanner.ScannerDenialOfWallet {
+				t.Fatalf("scanner = %v, want %s", entry["scanner"], scanner.ScannerDenialOfWallet)
+			}
+			hint, _ := entry["remediation_hint"].(string)
+			if !strings.Contains(hint, "agents._default.budget.max_tool_calls_per_session") {
+				t.Fatalf("remediation_hint = %q, want exact tool-call budget knob", hint)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -441,7 +441,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		_, _ = fmt.Fprintf(logW, "pipelock: %s %q DoW %s: %s (%s)\n",
 			enforcementKind, enforcementTarget, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
 		if auditLogger != nil {
-			auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), "denial_of_wallet", eval.DoWReason)
+			auditLogger.LogBlocked(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), scanner.ScannerDenialOfWallet, eval.DoWReason)
 		}
 		if m != nil {
 			m.RecordBlocked("mcp", "denial_of_wallet", 0, "")
@@ -507,7 +507,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		_, _ = fmt.Fprintf(logW, "pipelock: %s %q DoW %s: %s (%s)\n",
 			enforcementKind, enforcementTarget, eval.DoWAction, eval.DoWReason, eval.DoWBudgetType)
 		if auditLogger != nil {
-			auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), "denial_of_wallet", eval.DoWReason, 0)
+			auditLogger.LogAnomaly(mustMCPAuditContext(auditLogger, "MCP", enforcementTarget), scanner.ScannerDenialOfWallet, eval.DoWReason, 0)
 		}
 		recordAdaptiveSignal(session.SignalNearMiss)
 	}

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -5749,6 +5749,64 @@ func TestScanHTTPInput_DoWWarn(t *testing.T) {
 	}
 }
 
+func TestScanHTTPInput_DoWAuditEventsIncludeRemediationHint(t *testing.T) {
+	tests := []struct {
+		name      string
+		action    string
+		wantEvent string
+	}{
+		{name: "blocked", action: config.ActionBlock, wantEvent: string(audit.EventBlocked)},
+		{name: "anomaly", action: config.ActionWarn, wantEvent: string(audit.EventAnomaly)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+			auditLogger, err := audit.New("json", "file", auditPath, false, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			reason := "tool call limit exceeded: 11/10"
+			opts := MCPProxyOpts{
+				Scanner:     testScannerForHTTP(t),
+				AuditLogger: auditLogger,
+				DoWCheck: func(_, _ string) (bool, string, string, string) {
+					return false, tt.action, reason, "tool_call_limit"
+				},
+			}
+			msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + testDoWToolName + `","arguments":{"q":"hello"}}}`)
+			blocked := scanHTTPInput(msg, io.Discard, "", "", opts)
+			if tt.action == config.ActionBlock && blocked == nil {
+				t.Fatal("expected DoW block")
+			}
+			if tt.action == config.ActionWarn && blocked != nil {
+				t.Fatalf("warn action returned block: %+v", blocked)
+			}
+			auditLogger.Close()
+
+			data, err := os.ReadFile(filepath.Clean(auditPath))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var entry map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(data), &entry); err != nil {
+				t.Fatalf("decode audit event: %v; data=%q", err, data)
+			}
+			if entry["event"] != tt.wantEvent {
+				t.Fatalf("event = %v, want %s", entry["event"], tt.wantEvent)
+			}
+			if entry["scanner"] != scanner.ScannerDenialOfWallet {
+				t.Fatalf("scanner = %v, want %s", entry["scanner"], scanner.ScannerDenialOfWallet)
+			}
+			hint, _ := entry["remediation_hint"].(string)
+			if !strings.Contains(hint, "agents._default.budget.max_tool_calls_per_session") {
+				t.Fatalf("remediation_hint = %q, want exact tool-call budget knob", hint)
+			}
+		})
+	}
+}
+
 func TestScanHTTPInput_DoWBlockNotification(t *testing.T) {
 	sc := testScannerForHTTP(t)
 

--- a/internal/scanner/remediation.go
+++ b/internal/scanner/remediation.go
@@ -5,9 +5,12 @@ package scanner
 
 import "strings"
 
-// ScannerBodyDLP identifies request-body DLP blocks emitted outside the URL
-// scanner pipeline.
-const ScannerBodyDLP = "body_dlp"
+// ScannerBodyDLP and ScannerDenialOfWallet identify blocks emitted outside the
+// URL scanner pipeline.
+const (
+	ScannerBodyDLP        = "body_dlp"
+	ScannerDenialOfWallet = "denial_of_wallet"
+)
 
 // Decide*Label values identify non-URL blocks emitted by internal/decide.
 // They are not URL scanner pipeline labels, but they share the remediation
@@ -19,7 +22,12 @@ const (
 )
 
 const (
-	bodyDLPOperatorKnob = "Request body DLP matched. For false positives, add a top-level suppress: entry with rule: set to the matched rule name and path: scoped to the request path."
+	bodyDLPOperatorKnob        = "Request body DLP matched. For false positives, add a top-level suppress: entry with rule: set to the matched rule name and path: scoped to the request path."
+	denialOfWalletOperatorKnob = "Tune the limit identified by the reason under `agents._default.budget` (or the matched `agents.<name>.budget`): `max_tool_calls_per_session`, `max_wall_clock_minutes`, `max_retries_per_tool`, or `loop_detection_window`. " +
+		"To audit instead of block, set that budget's `dow_action` to `warn`; this changes enforcement for all denial-of-wallet findings."
+	denialOfWalletToolCallsOperatorKnob = "Raise `agents._default.budget.max_tool_calls_per_session` (or the matched `agents.<name>.budget.max_tool_calls_per_session`) if the session's tool-call budget is intentionally higher."
+	denialOfWalletWallClockOperatorKnob = "Raise `agents._default.budget.max_wall_clock_minutes` (or the matched `agents.<name>.budget.max_wall_clock_minutes`) if the session is intentionally longer-lived."
+	denialOfWalletRetriesOperatorKnob   = "Raise `agents._default.budget.max_retries_per_tool` (or the matched `agents.<name>.budget.max_retries_per_tool`) if repeated identical calls are expected."
 
 	decideInjectionOperatorKnob  = "Prompt-injection scanning matched content in the action. For shell/file/tool explain blocks, tune `response_scanning` (for example suppress or disable per response-scanning config); MCP request-input injection is tuned by `mcp_input_scanning`."
 	decidePolicyOperatorKnob     = "Tool policy denied the action. Edit the matching `mcp_tool_policy.rules` entry, or narrow/add a rule for the intended tool call."
@@ -58,6 +66,7 @@ const (
 	highEntropyAgentReason        = "Request blocked: high-entropy content resembling exfiltration was detected."
 	protectedAddressAgentReason   = "Request blocked: the destination resolves to protected internal or metadata infrastructure."
 	protectiveCeilingAgentReason  = "Request blocked: a protective request ceiling was exceeded."
+	denialOfWalletAgentReason     = "Request blocked: the MCP action exceeded its denial-of-wallet budget."
 	injectionTraversalAgentReason = "Request blocked: the URL contains an injection/traversal sequence."
 	promptInjectionAgentReason    = "Request blocked: the content matched a prompt-injection pattern."
 	toolPolicyAgentReason         = "Request blocked: the tool call is not permitted by policy."
@@ -180,6 +189,10 @@ var remediationGuidance = map[string]RemediationGuidance{
 		OperatorKnob: bodyDLPOperatorKnob,
 		AgentReason:  secretAgentReason,
 	},
+	ScannerDenialOfWallet: {
+		OperatorKnob: denialOfWalletOperatorKnob,
+		AgentReason:  denialOfWalletAgentReason,
+	},
 	DecideInjectionLabel: {
 		OperatorKnob: decideInjectionOperatorKnob,
 		AgentReason:  promptInjectionAgentReason,
@@ -217,11 +230,10 @@ func OperatorHintFor(label string) string {
 }
 
 // GuidanceForResult returns guidance using the scan Reason to disambiguate
-// same-label variants. Today only ScannerEntropy needs it: query entropy and
-// path/subdomain entropy share the label but need different knobs, and the
-// Reason ("... query ...") is the only signal that separates them. Every other
-// label falls through to the label-keyed table. This is the single place that
-// disambiguation lives, so explain, audit, and any future consumer agree.
+// same-label variants. ScannerEntropy distinguishes query from path/subdomain
+// entropy, while ScannerDenialOfWallet distinguishes budget-limit reasons.
+// Every other label falls through to the label-keyed table. This is the single
+// place that disambiguation lives, so explain, audit, and future consumers agree.
 func GuidanceForResult(label, reason string) (RemediationGuidance, bool) {
 	if label == ScannerEntropy && strings.Contains(reason, "query ") {
 		return RemediationGuidance{
@@ -229,6 +241,23 @@ func GuidanceForResult(label, reason string) (RemediationGuidance, bool) {
 			OperatorBroader: queryEntropyOperatorBroader,
 			AgentReason:     highEntropyAgentReason,
 		}, true
+	}
+	if label == ScannerDenialOfWallet {
+		operatorKnob := ""
+		switch {
+		case strings.Contains(reason, "tool call limit exceeded"):
+			operatorKnob = denialOfWalletToolCallsOperatorKnob
+		case strings.Contains(reason, "wall clock budget exceeded"):
+			operatorKnob = denialOfWalletWallClockOperatorKnob
+		case strings.Contains(reason, "loop detected"):
+			operatorKnob = denialOfWalletRetriesOperatorKnob
+		}
+		if operatorKnob != "" {
+			return RemediationGuidance{
+				OperatorKnob: operatorKnob,
+				AgentReason:  denialOfWalletAgentReason,
+			}, true
+		}
 	}
 	// The dial-time SSRF guard logs metadata blocks under the generic
 	// ScannerSSRF label (the metadata classification lives in the reason

--- a/internal/scanner/remediation_test.go
+++ b/internal/scanner/remediation_test.go
@@ -32,6 +32,7 @@ func TestRemediationGuidanceCoversAllLabels(t *testing.T) {
 		ScannerCoreSSRF,
 		ScannerCoreResponse,
 		ScannerBodyDLP,
+		ScannerDenialOfWallet,
 		DecideInjectionLabel,
 		DecidePolicyLabel,
 		DecideStructuralLabel,
@@ -194,6 +195,55 @@ func TestGuidanceForResultDisambiguatesEntropy(t *testing.T) {
 	t.Run("unknown label is fail-safe", func(t *testing.T) {
 		if _, ok := GuidanceForResult("nonexistent", "query"); ok {
 			t.Fatal("unknown label must return ok=false")
+		}
+	})
+}
+
+func TestOperatorHintForResultResolvesDenialOfWalletReasons(t *testing.T) {
+	tests := []struct {
+		name     string
+		reason   string
+		wantKnob string
+	}{
+		{
+			name:     "tool call budget",
+			reason:   "tool call limit exceeded: 11/10",
+			wantKnob: "max_tool_calls_per_session",
+		},
+		{
+			name:     "wall clock budget",
+			reason:   "wall clock budget exceeded: 31m0s/30m0s",
+			wantKnob: "max_wall_clock_minutes",
+		},
+		{
+			name:     "identical call loop",
+			reason:   "loop detected: expensive_tool called 6 times with same args (limit 5)",
+			wantKnob: "max_retries_per_tool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g, ok := GuidanceForResult(ScannerDenialOfWallet, tt.reason)
+			if !ok {
+				t.Fatal("GuidanceForResult(denial_of_wallet) not ok")
+			}
+			if !strings.Contains(g.OperatorKnob, "agents._default.budget."+tt.wantKnob) {
+				t.Fatalf("operator knob = %q, want agents._default.budget.%s", g.OperatorKnob, tt.wantKnob)
+			}
+			if hint := OperatorHintForResult(ScannerDenialOfWallet, tt.reason); hint != g.OperatorKnob {
+				t.Fatalf("OperatorHintForResult() = %q, want %q", hint, g.OperatorKnob)
+			}
+		})
+	}
+
+	t.Run("unclassified detector uses truthful family fallback", func(t *testing.T) {
+		hint := OperatorHintForResult(ScannerDenialOfWallet, "cycle detected: a -> b -> a -> b")
+		if !strings.Contains(hint, "agents._default.budget") {
+			t.Fatalf("fallback hint = %q, want the denial-of-wallet budget family", hint)
+		}
+		if !strings.Contains(hint, "dow_action") {
+			t.Fatalf("fallback hint = %q, want the verified enforcement knob", hint)
 		}
 	})
 }


### PR DESCRIPTION
## What changed

Blocked audit events already carried a remediation_hint naming the narrowest tuning knob. This extends that coverage to three paths that previously emitted none: WebSocket blocks, the specialized body-DLP warn and block event, and denial-of-wallet MCP blocks and anomalies on both the stdio and HTTP input transports.

Denial-of-wallet gains a remediation-registry entry whose reason-specific guidance names the exact agent budget knob that fired (the per-session tool-call limit, the wall-clock budget, or the per-tool retry limit), with a truthful generic fallback for cycle and runaway detectors.

The change is additive: no block decision, event type, scanner value, severity, or existing field changes, and each hint rides both the local audit entry and the external emitter fields.

## Notes

Each hint is verified against the real config schema, and each is verified by reproduction: the audit event loses its hint when the emit line is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer `remediation_hint` details to audit logs for blocked requests, DLP-related alerts, and denial-of-wallet limits.
  * Denial-of-wallet hints now point to the specific budget knob that was exceeded (tool calls, time, retries, loop detection).
* **Bug Fixes**
  * Standardized denial-of-wallet event labeling across input scanning and HTTP processing (block vs anomaly).
* **Tests**
  * Expanded assertions to confirm `remediation_hint` is present and correct in both file-based and emitted audit logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->