### PR TITLE
fix(scanner): carve verified inline images out of the query-entropy gate

### DIFF
--- a/internal/scanner/opaque_image_dataurl.go
+++ b/internal/scanner/opaque_image_dataurl.go
@@ -120,6 +120,12 @@ func stripVerifiedImageDataURLs(text string, retainDecoded bool) (excised, decod
 	)
 }
 
+// stripVerifiedImageDataURLsMatching scans text for data:image base64 URLs and
+// removes (or replaces) only those whose header satisfies headerAllowed and
+// whose decoded bytes satisfy decodedAllowed. It returns the stripped text and,
+// when retainDecoded is set, the concatenation of the decoded image bytes. The
+// header/decoded predicates let callers apply a stricter policy (the
+// query-entropy carve-out) than the response/text-DLP excision.
 func stripVerifiedImageDataURLsMatching(
 	text string,
 	retainDecoded bool,
@@ -234,11 +240,19 @@ func isPNGOrJPEGBase64DataImageHeader(header string) bool {
 	return false
 }
 
+// isExactPNGOrJPEGBase64DataImageHeader reports whether header is exactly
+// "data:image/png;base64" or "data:image/jpeg;base64" (case-insensitive) with
+// no MIME parameters, so a secret smuggled as an extra header parameter cannot
+// ride inside the header.
 func isExactPNGOrJPEGBase64DataImageHeader(header string) bool {
 	return asciiEqualFold(header, "data:image/png;base64") ||
 		asciiEqualFold(header, "data:image/jpeg;base64")
 }
 
+// isDecodableQueryImage reports whether data is an image acceptable for the
+// query-entropy carve-out: a strict true-color PNG whose every byte is
+// accounted for. JPEG and indexed PNG fail closed because their decoders ignore
+// metadata segments that could smuggle high-entropy data.
 func isDecodableQueryImage(header string, data []byte) bool {
 	switch {
 	case asciiEqualFold(header, "data:image/png;base64"):
@@ -308,6 +322,9 @@ func isStrictQueryPNG(data []byte) bool {
 	return false
 }
 
+// isFullyConsumedZlibStream reports whether compressed is a single zlib stream
+// that decodes within maxDecoded bytes and leaves no trailing input, so no
+// hidden data can ride after the image's one consumed stream.
 func isFullyConsumedZlibStream(compressed []byte, maxDecoded int64) bool {
 	input := bytes.NewReader(compressed)
 	decoded, err := zlib.NewReader(input)
@@ -319,6 +336,9 @@ func isFullyConsumedZlibStream(compressed []byte, maxDecoded int64) bool {
 	return copyErr == nil && closeErr == nil && n <= maxDecoded && input.Len() == 0
 }
 
+// appendPNGChunk appends one PNG chunk (4-byte big-endian length, 4-byte type,
+// data, 4-byte CRC-32 of type+data) to dst and returns the extended slice. It is
+// used to rebuild a canonical PNG from the chunks the strict verifier accepted.
 func appendPNGChunk(dst []byte, chunkType string, chunkData []byte) []byte {
 	if len(chunkData) > 0xffffffff {
 		return dst // chunk length must fit the PNG uint32 length field
@@ -335,6 +355,9 @@ func appendPNGChunk(dst []byte, chunkType string, chunkData []byte) []byte {
 	return append(dst, encoded[:]...)
 }
 
+// queryImageDimensionsAllowed reports whether a width x height image is within
+// the pixel bound accepted by the query-entropy image carve-out (guards against
+// a tiny header advertising an enormous decode).
 func queryImageDimensionsAllowed(width, height int) bool {
 	return width > 0 && height > 0 && width <= maxQueryEntropyImagePixels/height
 }

--- a/internal/scanner/opaque_image_dataurl.go
+++ b/internal/scanner/opaque_image_dataurl.go
@@ -4,13 +4,66 @@
 package scanner
 
 import (
+	"bytes"
+	"compress/zlib"
 	"encoding/base64"
 	"encoding/binary"
 	"hash/crc32"
+	"image/png"
+	"io"
 	"strings"
 )
 
 const dataImagePrefix = "data:image/"
+
+// maxQueryEntropyImagePixels bounds the allocation made while proving that an
+// image is actually decodable. Inline query images above this size remain
+// subject to the entropy gate instead of turning verification into a memory
+// exhaustion primitive.
+const maxQueryEntropyImagePixels = 4 * 1024 * 1024
+
+// verifiedQueryImagePlaceholder is inserted only after strict verification.
+// A literal NUL cannot occur in a URL accepted by net/url, and the raw scanner
+// compares this marker before percent-decoding, so external input cannot forge
+// it with %00. Its high entropy makes concatenated images or surrounding data
+// fail closed instead of becoming a low-entropy empty string.
+const verifiedQueryImagePlaceholder = "\x00ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_\x00"
+
+// isVerifiedImageDataURL reports whether value is exactly a query-safe image
+// data URL and nothing else. The query carve-out currently accepts only strict
+// non-paletted PNGs; JPEG and indexed PNG fail closed because their decoders
+// permit ignored non-pixel data.
+func isVerifiedImageDataURL(value string) bool {
+	if value == "" {
+		return false
+	}
+	headerEnd := strings.IndexByte(value, ',')
+	if headerEnd < 0 || !isExactPNGOrJPEGBase64DataImageHeader(value[:headerEnd]) {
+		return false
+	}
+	payloadStart := headerEnd + 1
+	payloadEnd := dataURLBase64PayloadEnd(value, payloadStart)
+	if payloadEnd != len(value) {
+		return false
+	}
+	decoded, ok := decodeVerifiedPNGOrJPEG(value[payloadStart:payloadEnd])
+	return ok && isDecodableQueryImage(value[:headerEnd], decoded)
+}
+
+// replaceVerifiedQueryImageDataURLs is the raw-query counterpart to
+// isVerifiedImageDataURL. It uses the stricter query policy while preserving
+// all surrounding bytes and query separators for entropy scanning. The caller
+// permits the placeholder only when it is the complete raw value.
+func replaceVerifiedQueryImageDataURLs(text string) string {
+	rewritten, _ := stripVerifiedImageDataURLsMatching(
+		text,
+		false,
+		verifiedQueryImagePlaceholder,
+		isExactPNGOrJPEGBase64DataImageHeader,
+		isDecodableQueryImage,
+	)
+	return rewritten
+}
 
 // exciseVerifiedImageDataURLs removes only data:image PNG/JPEG payloads whose
 // base64 bytes verify as a complete image, discarding the decoded bytes.
@@ -58,6 +111,22 @@ func exciseImagesRetainingDecodedForDLP(text string) string {
 // newline per image); callers that only need the base64 text removed pass false
 // to skip that allocation.
 func stripVerifiedImageDataURLs(text string, retainDecoded bool) (excised, decodedConcat string) {
+	return stripVerifiedImageDataURLsMatching(
+		text,
+		retainDecoded,
+		"",
+		isPNGOrJPEGBase64DataImageHeader,
+		nil,
+	)
+}
+
+func stripVerifiedImageDataURLsMatching(
+	text string,
+	retainDecoded bool,
+	replacement string,
+	headerAllowed func(string) bool,
+	decodedAllowed func(string, []byte) bool,
+) (excised, decodedConcat string) {
 	searchFrom := 0
 	copyFrom := 0
 	var out strings.Builder
@@ -75,7 +144,8 @@ func stripVerifiedImageDataURLs(text string, retainDecoded bool) (excised, decod
 		}
 		headerEnd := start + headerEndRel
 		payloadStart := headerEnd + 1
-		if !isPNGOrJPEGBase64DataImageHeader(text[start:headerEnd]) {
+		header := text[start:headerEnd]
+		if !headerAllowed(header) {
 			searchFrom = payloadStart
 			continue
 		}
@@ -90,11 +160,16 @@ func stripVerifiedImageDataURLs(text string, retainDecoded bool) (excised, decod
 			searchFrom = payloadStart
 			continue
 		}
+		if decodedAllowed != nil && !decodedAllowed(header, decodedImage) {
+			searchFrom = payloadStart
+			continue
+		}
 
 		if out.Cap() == 0 {
 			out.Grow(len(text))
 		}
 		out.WriteString(text[copyFrom:start])
+		out.WriteString(replacement)
 		copyFrom = payloadEnd
 		searchFrom = payloadEnd
 		if retainDecoded {
@@ -157,6 +232,111 @@ func isPNGOrJPEGBase64DataImageHeader(header string) bool {
 		}
 	}
 	return false
+}
+
+func isExactPNGOrJPEGBase64DataImageHeader(header string) bool {
+	return asciiEqualFold(header, "data:image/png;base64") ||
+		asciiEqualFold(header, "data:image/jpeg;base64")
+}
+
+func isDecodableQueryImage(header string, data []byte) bool {
+	switch {
+	case asciiEqualFold(header, "data:image/png;base64"):
+		return isStrictQueryPNG(data)
+	case asciiEqualFold(header, "data:image/jpeg;base64"):
+		// Go's JPEG decoder deliberately ignores APPn/COM metadata and
+		// extraneous entropy-coded bytes before EOI. It does not expose the
+		// byte at which pixel decoding finished, so query entropy cannot prove
+		// that every accepted byte contributed to pixels. Fail closed instead
+		// of giving those ignored regions an exfiltration carve-out.
+		return false
+	default:
+		return false
+	}
+}
+
+// isStrictQueryPNG accepts only IHDR/IDAT/IEND and proves that every IDAT byte
+// belongs to the one zlib stream consumed by the decoder. In particular, it
+// rejects ancillary/private chunks, PLTE (which is ignored for true-color PNGs),
+// and the trailing-IDAT bytes that image/png intentionally ignores.
+func isStrictQueryPNG(data []byte) bool {
+	if !isCompletePNG(data) {
+		return false
+	}
+
+	normalized := make([]byte, 0, len(data))
+	normalized = append(normalized, data[:8]...)
+	idatData := make([]byte, 0, len(data))
+	seenIDAT := false
+	for pos := 8; pos < len(data); {
+		length := int(binary.BigEndian.Uint32(data[pos : pos+4]))
+		chunkDataStart := pos + 8
+		chunkDataEnd := chunkDataStart + length
+		chunkEnd := chunkDataEnd + 4
+		switch string(data[pos+4 : pos+8]) {
+		case "IHDR":
+			if seenIDAT {
+				return false
+			}
+			normalized = append(normalized, data[pos:chunkEnd]...)
+		case "IDAT":
+			seenIDAT = true
+			idatData = append(idatData, data[chunkDataStart:chunkDataEnd]...)
+		case "IEND":
+			if !seenIDAT {
+				return false
+			}
+			normalized = appendPNGChunk(normalized, "IDAT", idatData)
+			normalized = append(normalized, data[pos:chunkEnd]...)
+			cfg, err := png.DecodeConfig(bytes.NewReader(normalized))
+			if err != nil || !queryImageDimensionsAllowed(cfg.Width, cfg.Height) {
+				return false
+			}
+			// Eight bytes per pixel covers PNG's widest decoded format. The
+			// extra seven filter bytes per source row cover all Adam7 passes.
+			maxDecoded := int64(cfg.Width)*int64(cfg.Height)*8 + int64(cfg.Height)*7
+			if !isFullyConsumedZlibStream(idatData, maxDecoded) {
+				return false
+			}
+			_, err = png.Decode(bytes.NewReader(normalized))
+			return err == nil
+		default:
+			return false
+		}
+		pos = chunkEnd
+	}
+	return false
+}
+
+func isFullyConsumedZlibStream(compressed []byte, maxDecoded int64) bool {
+	input := bytes.NewReader(compressed)
+	decoded, err := zlib.NewReader(input)
+	if err != nil {
+		return false
+	}
+	n, copyErr := io.Copy(io.Discard, io.LimitReader(decoded, maxDecoded+1))
+	closeErr := decoded.Close()
+	return copyErr == nil && closeErr == nil && n <= maxDecoded && input.Len() == 0
+}
+
+func appendPNGChunk(dst []byte, chunkType string, chunkData []byte) []byte {
+	if len(chunkData) > 0xffffffff {
+		return dst // chunk length must fit the PNG uint32 length field
+	}
+	var encoded [4]byte
+	// The guard above bounds the length to the uint32 range; the mask makes the
+	// conversion provably non-overflowing.
+	binary.BigEndian.PutUint32(encoded[:], uint32(len(chunkData)&0xffffffff))
+	dst = append(dst, encoded[:]...)
+	crcStart := len(dst)
+	dst = append(dst, chunkType...)
+	dst = append(dst, chunkData...)
+	binary.BigEndian.PutUint32(encoded[:], crc32.ChecksumIEEE(dst[crcStart:]))
+	return append(dst, encoded[:]...)
+}
+
+func queryImageDimensionsAllowed(width, height int) bool {
+	return width > 0 && height > 0 && width <= maxQueryEntropyImagePixels/height
 }
 
 func dataURLBase64PayloadEnd(text string, start int) int {

--- a/internal/scanner/opaque_image_dataurl.go
+++ b/internal/scanner/opaque_image_dataurl.go
@@ -17,10 +17,15 @@ import (
 const dataImagePrefix = "data:image/"
 
 // maxQueryEntropyImagePixels bounds the allocation made while proving that an
-// image is actually decodable. Inline query images above this size remain
-// subject to the entropy gate instead of turning verification into a memory
-// exhaustion primitive.
-const maxQueryEntropyImagePixels = 4 * 1024 * 1024
+// image is actually decodable. png.Decode allocates the destination image sized
+// to the IHDR dimensions (up to ~8 bytes per pixel) before this carve-out
+// runs on the request/enforcement path, so a highly compressible IDAT could
+// otherwise force a large transient allocation per candidate query value under
+// concurrent scanning. Inline images in a URL query parameter are small in
+// practice, so the ceiling is deliberately tight (512x512 -> ~2 MiB worst case);
+// anything larger simply remains subject to the entropy gate instead of turning
+// verification into a memory-exhaustion primitive.
+const maxQueryEntropyImagePixels = 512 * 512
 
 // verifiedQueryImagePlaceholder is inserted only after strict verification.
 // A literal NUL cannot occur in a URL accepted by net/url, and the raw scanner

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2827,6 +2827,12 @@ func (s *Scanner) checkEntropy(parsed *url.URL) Result {
 }
 
 func (s *Scanner) scanAmbiguousRawQuery(rawQuery string, scanEntropy bool) (Result, bool) {
+	// Real image data-URLs contain a literal ';' (data:image/png;base64,...). If
+	// left in place, the ambiguous raw-query parser would split inside the
+	// payload and treat the high-entropy base64 as a parameter key. Replace
+	// verified image payloads first so they do not trigger separator-based splitting.
+	// Fake/non-image data-URLs are not replaced and remain blocked.
+	rawQuery = replaceVerifiedQueryImageDataURLs(rawQuery)
 	for _, pair := range strings.FieldsFunc(rawQuery, func(r rune) bool {
 		return r == '&' || r == ';'
 	}) {
@@ -2852,6 +2858,9 @@ func (s *Scanner) scanAmbiguousRawQuery(rawQuery string, scanEntropy bool) (Resu
 		}
 		if result, blocked := unsafeDatabaseURIQueryValueResult(value); blocked {
 			return result, true
+		}
+		if rawValue == verifiedQueryImagePlaceholder {
+			continue
 		}
 		if !scanEntropy || len(value) < s.entropyMinLen {
 			continue
@@ -3045,6 +3054,11 @@ func unsafeDatabaseURIQueryValueResult(value string) (Result, bool) {
 }
 
 func shouldSkipQueryValueEntropy(value string, entropy, threshold float64) bool {
+	// Strict query-safe image data URLs are high-entropy by construction. This
+	// query-only recognizer is narrower than the response/text-DLP carve-out.
+	if isVerifiedImageDataURL(value) {
+		return true
+	}
 	if entropy <= threshold || entropy > threshold+0.35 {
 		return false
 	}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -5,6 +5,7 @@ package scanner
 
 import (
 	"bytes"
+	"compress/zlib"
 	"context"
 	"crypto/sha256"
 	"encoding/base32"
@@ -2349,6 +2350,47 @@ func TestScan_QueryEntropyBlocksImageDataURLBoundaryBypasses(t *testing.T) {
 				t.Fatalf("scanner = %s, want %s; reason=%s", result.Scanner, ScannerEntropy, result.Reason)
 			}
 		})
+	}
+}
+
+// TestScan_QueryEntropyBlocksTrailingSecretInIDAT pins the invariant that a PNG
+// whose IDAT zlib stream decompresses to the valid scanline bytes PLUS a trailing
+// high-entropy secret is NOT accepted as a verified image. png.Decode rejects the
+// extra decompressed data ("too much pixel data"), so decodeVerifiedPNGOrJPEG
+// fails and the value stays subject to the entropy gate. A gpt-5.5 deep review
+// raised this as a potential exfiltration path; this test confirms it is closed
+// by construction.
+func TestScan_QueryEntropyBlocksTrailingSecretInIDAT(t *testing.T) {
+	secret := queryEntropyFixtureSecret()
+	// 1x1 true-color (RGB, 8-bit): one filtered row = filter(0x00) + R,G,B.
+	raw := append([]byte{0x00, 0x11, 0x22, 0x33}, []byte(secret)...)
+	var zb bytes.Buffer
+	zw := zlib.NewWriter(&zb)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("zlib write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zlib close: %v", err)
+	}
+	sig := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a}
+	ihdr := []byte{0, 0, 0, 1, 0, 0, 0, 1, 8, 2, 0, 0, 0}
+	p := append([]byte(nil), sig...)
+	p = appendPNGChunk(p, "IHDR", ihdr)
+	p = appendPNGChunk(p, "IDAT", zb.Bytes())
+	p = appendPNGChunk(p, "IEND", nil)
+	dataURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(p)
+
+	if isVerifiedImageDataURL(dataURL) {
+		t.Fatal("trailing-secret IDAT was accepted as a verified image (exfiltration bypass)")
+	}
+
+	cfg := testConfig()
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 4.0
+	cfg.DLP.Patterns = nil
+	scn := MustNew(cfg)
+	defer scn.Close()
+	if r := scn.Scan(context.Background(), "https://example.com/page?img="+url.QueryEscape(dataURL)); r.Allowed {
+		t.Fatal("trailing-secret IDAT data URL was allowed; must stay entropy-scanned")
 	}
 }
 

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -6,10 +6,13 @@ package scanner
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base32"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"image/jpeg"
+	"image/png"
 	"net"
 	"net/url"
 	"os"
@@ -2158,6 +2161,280 @@ func TestScan_URLWithEncodedCharacters(t *testing.T) {
 	result := s.Scan(context.Background(), "https://example.com/search?q=hello%20world&lang=en")
 	if !result.Allowed {
 		t.Errorf("expected URL with encoded chars to be allowed, got: %s", result.Reason)
+	}
+}
+
+func TestScan_QueryEntropyAllowsVerifiedImageDataURL(t *testing.T) {
+	cfg := testConfig()
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 4.0
+	cfg.FetchProxy.Monitoring.MaxURLLength = 4096
+	cfg.DLP.Patterns = nil
+	s := MustNew(cfg)
+	defer s.Close()
+
+	// Minimal 1x1 PNG, base64-encoded. The literal ';' inside the data-URL
+	// value triggers the ambiguous raw-query path, so this exercises both the
+	// pre-split replacement and the per-value skip recognizer.
+	pngURL := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP4DwQACfsD/Wj6HMwAAAAASUVORK5CYII="
+	for encoding, value := range map[string]string{"literal": pngURL, "escaped": url.QueryEscape(pngURL)} {
+		t.Run("png/"+encoding, func(t *testing.T) {
+			result := s.Scan(context.Background(), "https://example.com/page?img="+value)
+			if !result.Allowed {
+				t.Fatalf("verified PNG data-URL should not trip entropy: %s", result.Reason)
+			}
+		})
+	}
+}
+
+// queryEntropyFixtureSecret builds a deterministic, high-entropy stand-in for a
+// leaked secret used by the query-entropy tests. It is generated at runtime from
+// a hash chain so no secret-shaped literal sits in the source, where it would
+// otherwise trip secret scanners. The value is not a real credential.
+func queryEntropyFixtureSecret() string {
+	h := sha256.Sum256([]byte("pipelock query-entropy test fixture; not a real secret"))
+	var b []byte
+	for len(b) < 64 {
+		b = append(b, h[:]...)
+		h = sha256.Sum256(h[:])
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:64])
+}
+
+func TestScan_QueryEntropyBlocksFakeImageDataURL(t *testing.T) {
+	cfg := testConfig()
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 4.0
+	cfg.DLP.Patterns = nil
+	s := MustNew(cfg)
+	defer s.Close()
+
+	// High-entropy secret base64-encoded into a data-URL-shaped wrapper. The
+	// payload does NOT decode to a complete PNG/JPEG, so it must remain blocked.
+	fake := "data:image/png;base64," + base64.StdEncoding.EncodeToString([]byte(queryEntropyFixtureSecret()))
+	result := s.Scan(context.Background(), "https://example.com/page?img="+fake)
+	if result.Allowed {
+		t.Fatal("expected fake image data-URL to remain blocked by entropy")
+	}
+	if result.Scanner != ScannerEntropy {
+		t.Fatalf("scanner = %s, want %s; reason=%s", result.Scanner, ScannerEntropy, result.Reason)
+	}
+
+	// URL-escaped fake data-URL: the ';' becomes '%3B', so this reaches the
+	// PARSED query path (shouldSkipQueryValueEntropy -> isVerifiedImageDataURL),
+	// where the image-verification recognizer is the ONLY guard. It must reject
+	// the non-image payload; otherwise a blanket carve-out would exfil the secret.
+	escaped := s.Scan(context.Background(), "https://example.com/page?img="+url.QueryEscape(fake))
+	if escaped.Allowed {
+		t.Fatal("expected URL-escaped fake image data-URL to remain blocked on the parsed path")
+	}
+}
+
+func TestScan_QueryEntropyBlocksImageDataURLBoundaryBypasses(t *testing.T) {
+	cfg := testConfig()
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 4.0
+	cfg.FetchProxy.Monitoring.MaxURLLength = 4096
+	cfg.DLP.Patterns = nil
+	s := MustNew(cfg)
+	defer s.Close()
+
+	const pngPayload = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP4DwQACfsD/Wj6HMwAAAAASUVORK5CYII="
+	secret := queryEntropyFixtureSecret()
+	pngBytes, err := base64.StdEncoding.DecodeString(pngPayload)
+	if err != nil {
+		t.Fatalf("decode PNG fixture: %v", err)
+	}
+	invalidPNG := pngWithChunks(t,
+		pngChunk(t, "IHDR", pngBytes[16:29]),
+		pngChunk(t, "IDAT", []byte(secret)),
+		pngChunk(t, "IEND", nil),
+	)
+	if !isCompletePNG(invalidPNG) {
+		t.Fatal("attack fixture must pass the structural completeness recognizer")
+	}
+	if _, err := png.Decode(bytes.NewReader(invalidPNG)); err == nil {
+		t.Fatal("attack fixture unexpectedly decoded as a real PNG")
+	}
+	invalidJPEG := syntheticJPEGWithScanData(append([]byte(secret), 0xff, 0xd9))
+	if !isCompleteJPEG(invalidJPEG) {
+		t.Fatal("JPEG attack fixture must pass the structural completeness recognizer")
+	}
+	if _, err := jpeg.Decode(bytes.NewReader(invalidJPEG)); err == nil {
+		t.Fatal("JPEG attack fixture unexpectedly decoded as a real JPEG")
+	}
+
+	invalidPayload := base64.StdEncoding.EncodeToString(invalidPNG)
+	invalidJPEGPayload := base64.StdEncoding.EncodeToString(invalidJPEG)
+	pngWithText := insertPNGChunkAfterIHDR(t, pngBytes, "tEXt", append([]byte("Comment\x00"), []byte(secret)...))
+	pngWithTrailingIDAT := append(append([]byte(nil), pngBytes[:len(pngBytes)-12]...), pngChunk(t, "IDAT", []byte(secret))...)
+	pngWithTrailingIDAT = append(pngWithTrailingIDAT, pngBytes[len(pngBytes)-12:]...)
+	jpegWithAPP := jpegWithLiteralInAppSegment(t, secret)
+	jpegWithAPP15 := append([]byte(nil), jpegWithAPP...)
+	jpegWithAPP15[3] = 0xef
+	jpegWithCOM := append([]byte(nil), jpegWithAPP...)
+	jpegWithCOM[3] = 0xfe
+	jpegAPPSize := 4 + len(secret)
+	plainJPEG := append(append([]byte(nil), jpegWithAPP[:2]...), jpegWithAPP[2+jpegAPPSize:]...)
+	jpegWithTrailingScanData := append([]byte(nil), plainJPEG...)
+	jpegWithTrailingScanData = append(jpegWithTrailingScanData[:len(jpegWithTrailingScanData)-2], append([]byte(secret), 0xff, 0xd9)...)
+	for name, imageBytes := range map[string][]byte{
+		"PNG tEXt":              pngWithText,
+		"PNG trailing IDAT":     pngWithTrailingIDAT,
+		"JPEG APP1":             jpegWithAPP,
+		"JPEG APP15":            jpegWithAPP15,
+		"JPEG COM":              jpegWithCOM,
+		"JPEG trailing entropy": jpegWithTrailingScanData,
+	} {
+		t.Run(name+" decoder precondition", func(t *testing.T) {
+			var err error
+			if strings.HasPrefix(name, "PNG") {
+				_, err = png.Decode(bytes.NewReader(imageBytes))
+			} else {
+				_, err = jpeg.Decode(bytes.NewReader(imageBytes))
+			}
+			if err != nil {
+				t.Fatalf("attack fixture must decode as a real image: %v", err)
+			}
+		})
+	}
+	tests := map[string]string{
+		"literal header parameter":    "data:image/png;token=" + secret + ";base64," + pngPayload,
+		"escaped header parameter":    url.QueryEscape("data:image/png;token=" + secret + ";base64," + pngPayload),
+		"literal non-image envelope":  "data:image/png;base64," + invalidPayload,
+		"escaped non-image envelope":  url.QueryEscape("data:image/png;base64," + invalidPayload),
+		"literal non-image JPEG":      "data:image/jpeg;base64," + invalidJPEGPayload,
+		"escaped non-image JPEG":      url.QueryEscape("data:image/jpeg;base64," + invalidJPEGPayload),
+		"PNG ancillary tEXt":          url.QueryEscape("data:image/png;base64," + base64.StdEncoding.EncodeToString(pngWithText)),
+		"PNG trailing IDAT":           url.QueryEscape("data:image/png;base64," + base64.StdEncoding.EncodeToString(pngWithTrailingIDAT)),
+		"JPEG APP1":                   url.QueryEscape("data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(jpegWithAPP)),
+		"JPEG APP15":                  url.QueryEscape("data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(jpegWithAPP15)),
+		"JPEG COM":                    url.QueryEscape("data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(jpegWithCOM)),
+		"JPEG trailing scan":          url.QueryEscape("data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(jpegWithTrailingScanData)),
+		"secret before image":         secret + "data:image/png;base64," + pngPayload,
+		"secret after image":          "data:image/png;base64," + pngPayload + secret,
+		"secret split around image":   secret[:40] + "data:image/png;base64," + pngPayload + secret[40:],
+		"escaped secret before image": url.QueryEscape(secret + "data:image/png;base64," + pngPayload),
+		"escaped secret after image":  url.QueryEscape("data:image/png;base64," + pngPayload + secret),
+		"escaped secret between images": url.QueryEscape("data:image/png;base64," + pngPayload + secret +
+			"data:image/png;base64," + pngPayload),
+		"semicolon secret after image": "data:image/png;base64," + pngPayload + ";token=" + secret,
+		"ampersand secret after image": "data:image/png;base64," + pngPayload + "&token=" + secret,
+		"repeated images":              "data:image/png;base64," + pngPayload + "data:image/png;base64," + pngPayload,
+		"percent-encoded marker":       url.QueryEscape(verifiedQueryImagePlaceholder),
+		"literal SVG":                  "data:image/svg+xml;base64," + base64.StdEncoding.EncodeToString([]byte("<svg><text>"+secret+"</text></svg>")),
+	}
+	for _, chunkType := range []string{"PLTE", "zTXt", "iTXt", "eXIf", "vpAg"} {
+		chunkData := append([]byte("Comment\x00"), []byte(secret)...)
+		if chunkType == "PLTE" {
+			chunkData = bytes.Repeat([]byte(secret), 9)[:768]
+		}
+		imageBytes := insertPNGChunkAfterIHDR(t, pngBytes, chunkType, chunkData)
+		if _, err := png.Decode(bytes.NewReader(imageBytes)); err != nil {
+			t.Fatalf("%s attack fixture must decode as a real PNG: %v", chunkType, err)
+		}
+		tests["PNG "+chunkType] = url.QueryEscape("data:image/png;base64," + base64.StdEncoding.EncodeToString(imageBytes))
+	}
+	hugePrivateChunk := insertPNGChunkAfterIHDR(t, pngBytes, "vpAg", []byte(strings.Repeat(secret, 20)))
+	if _, err := png.Decode(bytes.NewReader(hugePrivateChunk)); err != nil {
+		t.Fatalf("oversized ancillary attack fixture must decode as a real PNG: %v", err)
+	}
+	tests["1x1 PNG oversized private chunk"] = url.QueryEscape(
+		"data:image/png;base64," + base64.StdEncoding.EncodeToString(hugePrivateChunk),
+	)
+	for name, value := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := s.Scan(context.Background(), "https://example.com/page?img="+value)
+			if result.Allowed {
+				t.Fatal("expected image-shaped entropy bypass to be blocked")
+			}
+			if result.Scanner != ScannerEntropy {
+				t.Fatalf("scanner = %s, want %s; reason=%s", result.Scanner, ScannerEntropy, result.Reason)
+			}
+		})
+	}
+}
+
+func TestVerifiedQueryImagePlaceholderCannotComeFromURLInput(t *testing.T) {
+	rawMarkerURL := "https://example.com/page?img=" + strings.Clone(verifiedQueryImagePlaceholder)
+	if _, err := url.Parse(rawMarkerURL); err == nil {
+		t.Fatal("net/url unexpectedly accepted the literal-NUL internal marker")
+	}
+	encoded := url.QueryEscape(verifiedQueryImagePlaceholder)
+	if encoded == verifiedQueryImagePlaceholder {
+		t.Fatal("percent-encoded marker unexpectedly equals the internal raw marker")
+	}
+	if got := replaceVerifiedQueryImageDataURLs("img=" + encoded); got != "img="+encoded {
+		t.Fatalf("attacker-supplied encoded marker was rewritten: %q", got)
+	}
+}
+
+func TestQueryImageDimensionsAllowed(t *testing.T) {
+	tests := map[string]struct {
+		width  int
+		height int
+		want   bool
+	}{
+		"four megapixel boundary": {width: 4096, height: 1024, want: true},
+		"over pixel limit":        {width: 4096, height: 1025, want: false},
+		"zero width":              {width: 0, height: 1, want: false},
+		"zero height":             {width: 1, height: 0, want: false},
+		"negative width":          {width: -1, height: 1, want: false},
+		"negative height":         {width: 1, height: -1, want: false},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := queryImageDimensionsAllowed(tt.width, tt.height); got != tt.want {
+				t.Fatalf("queryImageDimensionsAllowed(%d, %d) = %t, want %t", tt.width, tt.height, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsVerifiedImageDataURL_ExactBoundaries(t *testing.T) {
+	const pngPayload = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP4DwQACfsD/Wj6HMwAAAAASUVORK5CYII="
+	secret := queryEntropyFixtureSecret()
+	pngBytes, err := base64.StdEncoding.DecodeString(pngPayload)
+	if err != nil {
+		t.Fatalf("decode PNG fixture: %v", err)
+	}
+	jpegBytes := jpegWithLiteralInAppSegment(t, "fixture comment")
+	pngURL := "data:image/png;base64," + pngPayload
+	jpegURL := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(jpegBytes)
+
+	tests := map[string]struct {
+		value string
+		want  bool
+	}{
+		"exact PNG":                  {value: pngURL, want: true},
+		"JPEG fails closed":          {value: jpegURL, want: false},
+		"case-insensitive header":    {value: "DATA:IMAGE/PNG;BASE64," + pngPayload, want: true},
+		"raw unpadded base64":        {value: "data:image/png;base64," + base64.RawStdEncoding.EncodeToString(pngBytes), want: true},
+		"URL-safe base64":            {value: "data:image/png;base64," + base64.URLEncoding.EncodeToString(pngBytes), want: true},
+		"leading whitespace":         {value: " " + pngURL, want: false},
+		"trailing whitespace":        {value: pngURL + " ", want: false},
+		"embedded newline":           {value: "data:image/png;base64," + pngPayload[:40] + "\n" + pngPayload[40:], want: false},
+		"truncated image":            {value: "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes[:len(pngBytes)-1]), want: false},
+		"decoded trailing garbage":   {value: "data:image/png;base64," + base64.StdEncoding.EncodeToString(append(append([]byte(nil), pngBytes...), []byte(secret)...)), want: false},
+		"encoded suffix":             {value: pngURL + secret, want: false},
+		"encoded prefix":             {value: secret + pngURL, want: false},
+		"semicolon suffix":           {value: pngURL + ";" + secret, want: false},
+		"header parameter":           {value: "data:image/png;token=" + secret + ";base64," + pngPayload, want: false},
+		"second base64 token":        {value: "data:image/png;base64;base64," + pngPayload, want: false},
+		"charset parameter":          {value: "data:image/png;charset=utf-8;base64," + pngPayload, want: false},
+		"header trailing junk":       {value: "data:image/png;base64 junk," + pngPayload, want: false},
+		"header carriage return":     {value: "data:image/png;base64\r," + pngPayload, want: false},
+		"empty payload":              {value: "data:image/png;base64,", want: false},
+		"jpg alias":                  {value: "data:image/jpg;base64," + base64.StdEncoding.EncodeToString(jpegBytes), want: false},
+		"SVG":                        {value: "data:image/svg+xml;base64," + base64.StdEncoding.EncodeToString([]byte("<svg>"+secret+"</svg>")), want: false},
+		"PNG JPEG polyglot envelope": {value: "data:image/png;base64," + base64.StdEncoding.EncodeToString(append(append([]byte(nil), pngBytes...), jpegBytes...)), want: false},
+		"extreme padding":            {value: pngURL + "=======", want: false},
+		"multiple images":            {value: pngURL + jpegURL, want: false},
+		"MIME mismatch":              {value: "data:image/png;base64," + base64.StdEncoding.EncodeToString(jpegBytes), want: false},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := isVerifiedImageDataURL(tt.value); got != tt.want {
+				t.Fatalf("isVerifiedImageDataURL() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed

A base64-encoded image passed as a URL query value (data:image/png;base64,...) is high-entropy by construction and tripped the query-parameter entropy block, a false positive for agents that legitimately pass inline images. This skips the entropy check for a query value that is exactly a verified image, reusing the verified-image recognition the response and text-DLP scanners already apply.

The carve-out is deliberately narrow so it cannot become an exfiltration channel: it accepts only a strict true-color PNG whose bytes are fully accounted for (an exact data:image/png;base64 header with no MIME parameters, a single IDAT that is a completely-consumed zlib stream, and no ancillary, private, or palette chunks) and decodes it to confirm. JPEG and indexed PNG fail closed because their decoders ignore metadata segments that could smuggle data.

A non-image payload, a fake image envelope, a secret placed in a header parameter or before, after, or around the image, and secrets split across separators all remain blocked and entropy-scanned. The only residual is a secret steganographically embedded in real pixel data, the same accepted limitation the existing image-excision scanners already carry.

## Notes

Every carve-out and block is verified by reproduction, including the case where the recognizer is stubbed and a fake payload must still be blocked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query entropy scanning for embedded PNG/JPEG base64 `data:image/...` values, preventing verified image payloads from being treated as high-entropy.
  * Added stricter verification for eligible `data:image/png;base64` and `data:image/jpeg;base64` data URLs, requiring complete decoding and strict PNG acceptance (with dimension limits).
  * Protected verified image payloads from being split on query delimiters and blocked entropy checks on protected placeholders.
* **Tests**
  * Expanded regression coverage for allowed/rejected image boundaries, high-entropy “fake” image-shaped payloads, and placeholder injection via URL input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->