### PR TITLE
feat(emit): audit-sink delivery health metrics and OCSF over HTTP

### DIFF
--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -542,6 +542,7 @@ mcp_session_binding:
 #     auth_token: ""       # Bearer token for Authorization header
 #     timeout_seconds: 5
 #     queue_size: 64
+#     format: json          # json, cef, or ocsf
 #   syslog:
 #     address: "udp://syslog.example.com:514"
 #     min_severity: warn

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -530,6 +530,7 @@ mcp_session_binding:
 #     auth_token: ""
 #     timeout_seconds: 5
 #     queue_size: 64
+#     format: json             # json, cef, or ocsf
 #   syslog:
 #     address: ""
 #     min_severity: warn

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1415,6 +1415,7 @@ emit:
     auth_token: ""
     timeout_seconds: 5
     queue_size: 64
+    format: json          # json, cef, or ocsf
   syslog:
     address: "udp://syslog.example.com:514"
     min_severity: warn
@@ -1439,6 +1440,7 @@ emit:
 | `webhook.auth_token` | `""` | Bearer token for webhook |
 | `webhook.timeout_seconds` | `5` | HTTP timeout |
 | `webhook.queue_size` | `64` | Async buffer size (overflow = drop + metric) |
+| `webhook.format` | `"json"` | HTTP body format: json, cef, or ocsf |
 | `syslog.address` | `""` | Syslog address (e.g., `udp://host:514`) |
 | `syslog.min_severity` | `"warn"` | info, warn, or critical |
 | `syslog.facility` | `"local0"` | Syslog facility |

--- a/docs/guides/siem-integration.md
+++ b/docs/guides/siem-integration.md
@@ -9,7 +9,7 @@ platforms, detection rule examples, and automated kill switch response.
 
 ## Event Schema
 
-All three sinks emit the same JSON envelope (OTLP wraps it as an OTLP LogRecord):
+All three sinks default to the same JSON envelope (OTLP wraps it as an OTLP LogRecord); the webhook and syslog sinks can also emit CEF (`format: cef`) or OCSF (`format: ocsf`) instead of JSON (see the format options below):
 
 ```json
 {
@@ -100,6 +100,7 @@ emit:
     auth_token: "your-bearer-token"   # optional Authorization header
     timeout_seconds: 5
     queue_size: 64                    # async buffer capacity
+    format: "ocsf"                   # json, cef, or ocsf
 
   syslog:
     address: "udp://syslog.example.com:514"
@@ -230,6 +231,14 @@ events. All other info-level events are local-only and never sent to sinks.
 control is the emission *threshold* (`min_severity`). This is intentional: it
 prevents misconfiguration from silently hiding critical events.
 
+### OCSF over HTTP
+
+Set `emit.webhook.format: ocsf` for SIEM HTTP ingestion endpoints that accept
+OCSF Detection Finding JSON. Webhook and syslog use the same OCSF encoder, so
+the class, severity, finding, network, and Pipelock extension fields stay
+identical across transports. OCSF webhook requests use
+`Content-Type: application/json`.
+
 ## Forwarding Patterns
 
 ### Webhook to Splunk HEC
@@ -240,6 +249,7 @@ emit:
     url: "https://splunk.example.com:8088/services/collector/event"
     auth_token: "your-splunk-hec-token"
     min_severity: "warn"
+    format: "json"
 ```
 
 Splunk HEC expects `Authorization: Splunk <token>`, but pipelock sends
@@ -648,4 +658,12 @@ check:
 1. Is `emit.webhook.url` (or `emit.syslog.address`) reachable from the
    pipelock host?
 2. Is `min_severity` set low enough? A `blocked` event is severity `warn`.
-3. Check pipelock's stderr for sink errors (`emit: webhook send error: ...`).
+3. Scrape the sink-health metrics below and inspect stderr for the matching
+   sanitized delivery diagnostic.
+
+The Prometheus endpoint exposes current delivery accounting for every built-in
+audit sink under `pipelock_audit_sink_*`, labeled only by `sink` (`webhook`,
+`syslog`, or `otlp`). Alert on `pipelock_audit_sink_degraded == 1` or increases
+in the `failed_total`, `dropped_total`, and `abandoned_total` series. The
+`last_error_present` gauge reports unresolved error state without exporting
+error text or endpoint secrets as labels.

--- a/internal/cli/runtime/emit_forwarder_enterprise_test.go
+++ b/internal/cli/runtime/emit_forwarder_enterprise_test.go
@@ -114,9 +114,11 @@ func TestServerReloadActivationFailureRetainsOldSinkAndReportsFailure(t *testing
 	t.Parallel()
 	s, buf := newTestServer(t, nil)
 	oldSink := &runtimeActivationSink{}
-	for _, sink := range s.emitter.ReloadSinks([]emit.Sink{oldSink}) {
+	retired := s.emitter.ReloadSinks([]emit.Sink{oldSink})
+	for _, sink := range retired.Sinks() {
 		_ = sink.Close()
 	}
+	s.emitter.FinalizeRetiredSinks(retired)
 	s.emitSinks = []emit.Sink{oldSink}
 
 	dir := t.TempDir()

--- a/internal/cli/runtime/run.go
+++ b/internal/cli/runtime/run.go
@@ -258,6 +258,7 @@ func buildEmitSinks(cfg *config.Config, observer emitDeliveryObserver, appendEnt
 		if cfg.Emit.Webhook.TimeoutSecs > 0 {
 			opts = append(opts, emit.WithWebhookTimeout(time.Duration(cfg.Emit.Webhook.TimeoutSecs)*time.Second))
 		}
+		opts = append(opts, emit.WithWebhookFormat(cfg.Emit.Webhook.Format, cliutil.Version))
 		sinks = append(sinks, emit.NewWebhookSink(cfg.Emit.Webhook.URL, opts...))
 	}
 

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -283,6 +283,52 @@ func TestBuildEmitSinks_WebhookWithAllOptions(t *testing.T) {
 	}
 }
 
+func TestBuildEmitSinksWebhookOCSFOverHTTP(t *testing.T) {
+	bodyCh := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		bodyCh <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.Emit.Webhook.URL = srv.URL
+	cfg.Emit.Webhook.MinSeverity = config.SeverityInfo
+	cfg.Emit.Webhook.Format = config.EmitFormatOCSF
+	sinks, err := BuildEmitSinks(cfg)
+	if err != nil {
+		t.Fatalf("BuildEmitSinks: %v", err)
+	}
+	emitter := emit.NewEmitter("test-instance", sinks...)
+	emitter.EmitWithSeverity(t.Context(), emit.SeverityWarn, emit.EventBodyDLP, map[string]any{
+		"action": "block",
+		"reason": "secret detected",
+	})
+	if err := emitter.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case body := <-bodyCh:
+		var got map[string]any
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("webhook OCSF is not JSON: %v\n%s", err, body)
+		}
+		if got["class_uid"] != float64(2004) || got["type_uid"] != float64(200401) {
+			t.Fatalf("webhook OCSF identity fields = %#v", got)
+		}
+		if got["message"] != "body_dlp: secret detected" {
+			t.Fatalf("webhook OCSF message = %#v", got["message"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OCSF webhook delivery")
+	}
+}
+
 func TestBuildEmitSinks_SyslogOnly(t *testing.T) {
 	conn := listenUDP(t)
 
@@ -1538,6 +1584,7 @@ type runtimeActivationSink struct {
 	activated     atomic.Bool
 	started       atomic.Bool
 	closed        atomic.Bool
+	closeCount    atomic.Int32
 	emitted       atomic.Int32
 }
 
@@ -1547,6 +1594,7 @@ func (s *runtimeActivationSink) Emit(context.Context, emit.Event) error {
 }
 
 func (s *runtimeActivationSink) Close() error {
+	s.closeCount.Add(1)
 	s.closed.Store(true)
 	return nil
 }
@@ -1637,6 +1685,34 @@ func TestFailedReplacementActivationDoesNotSwapOldSink(t *testing.T) {
 		t.Fatalf("emit counts old=%d new=%d, want old sink retained", oldSink.emitted.Load(), newSink.emitted.Load())
 	}
 	_ = emitter.Close()
+}
+
+func TestRetiredSinkFinalizerRunsOnPanicAndIsIdempotent(t *testing.T) {
+	preclosed := &runtimeActivationSink{}
+	draining := &runtimeActivationSink{}
+	emitter := emit.NewEmitter("test", preclosed, draining)
+	generation := emitter.ReloadSinks(nil)
+	finalize := newRetiredSinkFinalizer(emitter, generation, map[int]bool{0: true}, nil)
+
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != "post-swap panic" {
+				t.Fatalf("recover() = %v, want post-swap panic", recovered)
+			}
+		}()
+		defer finalize()
+		panic("post-swap panic")
+	}()
+
+	// The normal-path call and deferred fallback can both run safely: the
+	// preclosed sink remains untouched and the draining sink closes only once.
+	finalize()
+	if got := preclosed.closeCount.Load(); got != 0 {
+		t.Fatalf("preclosed sink Close calls = %d, want 0", got)
+	}
+	if got := draining.closeCount.Load(); got != 1 {
+		t.Fatalf("draining sink Close calls = %d, want 1", got)
+	}
 }
 
 func TestSameSpoolReloadWindowRejectsLoudlyWithoutSwappingFailedReplacement(t *testing.T) {

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -358,6 +358,7 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		return nil, activationErr
 	}
 	emitter := emit.NewEmitter(instanceID, emitSinks...)
+	m.SetAuditSinkHealthSnapshot(emitter.SinkHealth)
 	logger.SetEmitter(emitter)
 	s.emitter = emitter
 	s.emitSinks = append([]emit.Sink(nil), emitSinks...)

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -457,17 +457,16 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		s.logger.LogConfigReload("failed", reloadErr.Error(), newCfg.Hash())
 		return reloadErr
 	}
-	oldSinks := s.emitter.ReloadSinks(newSinks)
+	retiredSinks := s.emitter.ReloadSinks(newSinks)
+	finalizeRetiredSinks := newRetiredSinkFinalizer(s.emitter, retiredSinks, preclosed, func(closeErr error) {
+		s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile),
+			fmt.Errorf("closing old emit sink: %w", closeErr))
+	})
+	// Install cleanup immediately after publication. Any later panic still
+	// drains and finalizes exactly this generation before Reload returns.
+	defer finalizeRetiredSinks()
 	s.emitSinks = append([]emit.Sink(nil), newSinks...)
-	for i, old := range oldSinks {
-		if preclosed[i] {
-			continue
-		}
-		if closeErr := old.Close(); closeErr != nil {
-			s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile),
-				fmt.Errorf("closing old emit sink: %w", closeErr))
-		}
-	}
+	finalizeRetiredSinks()
 
 	if needsHITLApprover(newCfg) && !s.hasApprover {
 		_, _ = fmt.Fprintln(s.opts.Stderr, "WARNING: config reloaded to HITL ask mode but approver was not initialized at startup; detections will be blocked")
@@ -476,6 +475,35 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 	s.logger.LogConfigReload("success", fmt.Sprintf("mode=%s", newCfg.Mode), reloadHash)
 	s.recordReloadSuccess(reloadHash)
 	return nil
+}
+
+// newRetiredSinkFinalizer returns idempotent cleanup for one generation. It is
+// called both on the normal reload path and as a deferred panic/error fallback.
+func newRetiredSinkFinalizer(
+	emitter *emit.Emitter,
+	generation *emit.RetiredSinks,
+	preclosed map[int]bool,
+	onCloseError func(error),
+) func() {
+	sinks := generation.Sinks()
+	closed := make([]bool, len(sinks))
+	for index := range sinks {
+		closed[index] = preclosed[index]
+	}
+
+	return func() {
+		for index, sink := range sinks {
+			if closed[index] {
+				continue
+			}
+			closeErr := sink.Close()
+			closed[index] = true
+			if closeErr != nil && onCloseError != nil {
+				onCloseError(closeErr)
+			}
+		}
+		emitter.FinalizeRetiredSinks(generation)
+	}
 }
 
 func strictRuleBundleDegradationDisallowed(oldCfg, newCfg *config.Config) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7905,6 +7905,9 @@ func TestDefaults_EmitFields(t *testing.T) {
 	if cfg.Emit.Webhook.MinSeverity != SeverityWarn {
 		t.Errorf("expected default webhook min_severity warn, got %s", cfg.Emit.Webhook.MinSeverity)
 	}
+	if cfg.Emit.Webhook.Format != EmitFormatJSON {
+		t.Errorf("expected default webhook format json, got %s", cfg.Emit.Webhook.Format)
+	}
 	if cfg.Emit.Syslog.MinSeverity != SeverityWarn {
 		t.Errorf("expected default syslog min_severity warn, got %s", cfg.Emit.Syslog.MinSeverity)
 	}
@@ -7916,6 +7919,51 @@ func TestDefaults_EmitFields(t *testing.T) {
 	}
 	if cfg.Emit.Syslog.Format != EmitFormatJSON {
 		t.Errorf("expected default syslog format json, got %s", cfg.Emit.Syslog.Format)
+	}
+}
+
+func TestLoadEmitWebhookFormatDefaultsAndReloads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	write := func(formatLine string) {
+		t.Helper()
+		content := "version: 1\nemit:\n  webhook:\n    url: " + testWebhookURL + "\n" + formatLine
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+
+	for _, tt := range []struct {
+		name       string
+		formatLine string
+	}{
+		{name: "omitted"},
+		{name: "blank", formatLine: "    format:\n"},
+		{name: "null", formatLine: "    format: null\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			write(tt.formatLine)
+			cfg, err := LoadForRules(path)
+			if err != nil {
+				t.Fatalf("LoadForRules: %v", err)
+			}
+			if cfg.Emit.Webhook.Format != EmitFormatJSON {
+				t.Fatalf("emit.webhook.format = %q, want %q", cfg.Emit.Webhook.Format, EmitFormatJSON)
+			}
+		})
+	}
+
+	write("    format: json\n")
+	first, err := LoadForRules(path)
+	if err != nil {
+		t.Fatalf("first LoadForRules: %v", err)
+	}
+	write("    format: ocsf\n")
+	second, err := LoadForRules(path)
+	if err != nil {
+		t.Fatalf("second LoadForRules: %v", err)
+	}
+	if first.Emit.Webhook.Format != EmitFormatJSON || second.Emit.Webhook.Format != EmitFormatOCSF {
+		t.Fatalf("webhook format reload = %q -> %q, want json -> ocsf", first.Emit.Webhook.Format, second.Emit.Webhook.Format)
 	}
 }
 
@@ -8030,16 +8078,34 @@ func TestValidate_EmitSyslogInvalidSeverity(t *testing.T) {
 
 func TestValidate_EmitWebhookValidConfig(t *testing.T) {
 	for _, sev := range []string{SeverityInfo, SeverityWarn, SeverityCritical} {
-		t.Run(sev, func(t *testing.T) {
-			cfg := Defaults()
-			cfg.Emit.Webhook.URL = testWebhookURL
-			cfg.Emit.Webhook.MinSeverity = sev
-			cfg.Emit.Webhook.TimeoutSecs = 10
-			cfg.Emit.Webhook.QueueSize = 32
-			if err := cfg.Validate(); err != nil {
-				t.Errorf("valid webhook config with severity %q should validate, got: %v", sev, err)
-			}
-		})
+		for _, format := range emitformat.SupportedFormats() {
+			t.Run(sev+"/"+format, func(t *testing.T) {
+				cfg := Defaults()
+				cfg.Emit.Webhook.URL = testWebhookURL
+				cfg.Emit.Webhook.MinSeverity = sev
+				cfg.Emit.Webhook.TimeoutSecs = 10
+				cfg.Emit.Webhook.QueueSize = 32
+				cfg.Emit.Webhook.Format = format
+				if err := cfg.Validate(); err != nil {
+					t.Errorf("valid webhook config severity=%q format=%q should validate, got: %v", sev, format, err)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateEmitWebhookInvalidFormat(t *testing.T) {
+	cfg := Defaults()
+	cfg.ApplyDefaults()
+	cfg.Emit.Webhook.URL = testWebhookURL
+	cfg.Emit.Webhook.Format = "xml"
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid webhook format")
+	}
+	expected := fmt.Sprintf(`invalid emit.webhook.format "xml": must be %s`, emitformat.AllowedSet())
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -481,6 +481,9 @@ func (c *Config) ApplyDefaults() {
 	if c.Emit.Webhook.MinSeverity == "" {
 		c.Emit.Webhook.MinSeverity = SeverityWarn
 	}
+	if c.Emit.Webhook.Format == "" {
+		c.Emit.Webhook.Format = EmitFormatJSON
+	}
 	if c.Emit.Syslog.MinSeverity == "" {
 		c.Emit.Syslog.MinSeverity = SeverityWarn
 	}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1354,6 +1354,7 @@ type WebhookConfig struct {
 	AuthToken   string `yaml:"auth_token"`
 	TimeoutSecs int    `yaml:"timeout_seconds"`
 	QueueSize   int    `yaml:"queue_size"`
+	Format      string `yaml:"format" json:"-"` // json (default), cef, or ocsf
 }
 
 // SyslogConfig configures the syslog emission sink (RFC 5424).

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2616,6 +2616,9 @@ func (c *Config) validateEmit() error {
 		if c.Emit.Webhook.QueueSize <= 0 {
 			return fmt.Errorf("emit.webhook.queue_size must be positive")
 		}
+		if c.Emit.Webhook.Format != "" && !emitformat.Supported(c.Emit.Webhook.Format) {
+			return fmt.Errorf("invalid emit.webhook.format %q: must be %s", c.Emit.Webhook.Format, emitformat.AllowedSet())
+		}
 	}
 	if c.Emit.Syslog.Address != "" {
 		sysU, sysErr := url.Parse(c.Emit.Syslog.Address)

--- a/internal/emit/emitter.go
+++ b/internal/emit/emitter.go
@@ -17,7 +17,23 @@ import (
 type Emitter struct {
 	mu         sync.RWMutex
 	sinks      []Sink
+	retiring   []*RetiredSinks
+	retired    map[string]SinkHealth
 	instanceID string
+}
+
+// RetiredSinks identifies one sink generation replaced by ReloadSinks.
+// Callers close Sinks before passing the generation to FinalizeRetiredSinks.
+type RetiredSinks struct {
+	sinks []Sink
+}
+
+// Sinks returns the sinks owned by this retired generation.
+func (r *RetiredSinks) Sinks() []Sink {
+	if r == nil {
+		return nil
+	}
+	return append([]Sink(nil), r.sinks...)
 }
 
 // NewEmitter creates an Emitter that sends events to all provided sinks.
@@ -99,15 +115,69 @@ var routineSinkStatuses = []error{
 	ErrWebhookDegraded, ErrSyslogDegraded, ErrOTLPDegraded,
 }
 
-// ReloadSinks atomically replaces the sink set and returns the old sinks.
-// The caller is responsible for closing the returned sinks.
+// ReloadSinks atomically replaces the sink set and returns the old generation.
+// The caller is responsible for closing the generation's sinks and finalizing
+// that generation afterward.
 // This enables hot-reload of emit configuration without restarting.
-func (e *Emitter) ReloadSinks(newSinks []Sink) []Sink {
+func (e *Emitter) ReloadSinks(newSinks []Sink) *RetiredSinks {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	old := e.sinks
 	e.sinks = append([]Sink(nil), newSinks...)
-	return old
+	// Keep the old generation visible until its asynchronous queues have been
+	// drained and the caller finalizes it. Otherwise failures and abandonments
+	// recorded by Close after this swap disappear from live sink-health metrics.
+	return e.retireSinksLocked(old)
+}
+
+// FinalizeRetiredSinks snapshots the terminal delivery counters of sink
+// generation returned by ReloadSinks and releases its objects. Callers must
+// invoke it after that generation's sinks have finished closing. Retired
+// counters remain process-lifetime cumulative so Prometheus _total series never
+// reset on a config reload; queue and degraded gauges continue to describe only
+// live or actively draining sinks.
+func (e *Emitter) FinalizeRetiredSinks(generation *RetiredSinks) {
+	if e == nil || generation == nil {
+		return
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	index := slices.Index(e.retiring, generation)
+	if index < 0 {
+		return
+	}
+	if e.retired == nil {
+		e.retired = make(map[string]SinkHealth)
+	}
+	for _, sink := range generation.sinks {
+		provider, ok := sink.(sinkHealthProvider)
+		if !ok {
+			continue
+		}
+		current := provider.SinkHealth()
+		if current.Sink == "" {
+			continue
+		}
+		total := e.retired[current.Sink]
+		total.Sink = current.Sink
+		total.Delivered += current.Delivered
+		total.Failed += current.Failed
+		total.Dropped += current.Dropped
+		total.Abandoned += current.Abandoned
+		e.retired[current.Sink] = total
+	}
+	e.retiring = slices.Delete(e.retiring, index, index+1)
+}
+
+// retireSinksLocked moves sinks into a separately owned draining generation.
+// e.mu must be held by the caller.
+func (e *Emitter) retireSinksLocked(sinks []Sink) *RetiredSinks {
+	generation := &RetiredSinks{sinks: sinks}
+	if len(sinks) > 0 {
+		e.retiring = append(e.retiring, generation)
+	}
+	return generation
 }
 
 // Close closes all sinks and returns the first error encountered.
@@ -119,6 +189,7 @@ func (e *Emitter) Close() error {
 	e.mu.Lock()
 	sinks := e.sinks
 	e.sinks = nil
+	generation := e.retireSinksLocked(sinks)
 	e.mu.Unlock()
 
 	var firstErr error
@@ -127,5 +198,6 @@ func (e *Emitter) Close() error {
 			firstErr = err
 		}
 	}
+	e.FinalizeRetiredSinks(generation)
 	return firstErr
 }

--- a/internal/emit/emitter_test.go
+++ b/internal/emit/emitter_test.go
@@ -245,15 +245,17 @@ func TestEmitter_ReloadSinks(t *testing.T) {
 	// Reload with new sinks
 	new1 := &mockSink{}
 	returned := em.ReloadSinks([]Sink{new1})
+	oldSinks := returned.Sinks()
 
-	if len(returned) != 2 {
-		t.Fatalf("expected 2 old sinks returned, got %d", len(returned))
+	if len(oldSinks) != 2 {
+		t.Fatalf("expected 2 old sinks returned, got %d", len(oldSinks))
 	}
 
 	// Close old sinks (caller responsibility)
-	for _, s := range returned {
+	for _, s := range oldSinks {
 		_ = s.Close()
 	}
+	em.FinalizeRetiredSinks(returned)
 
 	// Emit to new sinks
 	em.Emit(context.Background(), "error", nil)
@@ -273,13 +275,15 @@ func TestEmitter_ReloadSinks_ToEmpty(t *testing.T) {
 	em := NewEmitter(testStr, s)
 
 	// Reload to zero sinks
-	old := em.ReloadSinks(nil)
+	retired := em.ReloadSinks(nil)
+	old := retired.Sinks()
 	if len(old) != 1 {
 		t.Fatalf("expected 1 old sink, got %d", len(old))
 	}
 	for _, o := range old {
 		_ = o.Close()
 	}
+	em.FinalizeRetiredSinks(retired)
 
 	// Should not panic with zero sinks
 	em.Emit(context.Background(), testEventBlocked, nil)
@@ -294,10 +298,12 @@ func TestEmitter_ReloadSinks_FromEmpty(t *testing.T) {
 
 	// Reload to add sinks
 	s := &mockSink{}
-	old := em.ReloadSinks([]Sink{s})
+	retired := em.ReloadSinks([]Sink{s})
+	old := retired.Sinks()
 	if len(old) != 0 {
 		t.Fatalf("expected 0 old sinks, got %d", len(old))
 	}
+	em.FinalizeRetiredSinks(retired)
 
 	em.Emit(context.Background(), "error", nil)
 	if len(s.getEvents()) != 1 {
@@ -334,10 +340,12 @@ func TestEmitter_ReloadSinks_Concurrent(t *testing.T) {
 	// Reloader
 	for range 50 {
 		newSink := &mockSink{}
-		old := em.ReloadSinks([]Sink{newSink})
+		retired := em.ReloadSinks([]Sink{newSink})
+		old := retired.Sinks()
 		for _, o := range old {
 			_ = o.Close()
 		}
+		em.FinalizeRetiredSinks(retired)
 	}
 
 	close(stop)

--- a/internal/emit/format.go
+++ b/internal/emit/format.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emit
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+const (
+	contentTypeJSON = "application/json"
+	contentTypeCEF  = "text/plain; charset=utf-8"
+)
+
+// formatEvent renders every configured export surface through one dispatch
+// path. FormatOCSFEvent and FormatCEFEvent remain the single encoders for their
+// respective wire formats; sinks only select the transport and content type.
+func formatEvent(event Event, format, deviceVersion string) ([]byte, string, error) {
+	if format == "" {
+		format = FormatJSON
+	}
+
+	switch format {
+	case FormatCEF:
+		return []byte(FormatCEFEvent(event, deviceVersion)), contentTypeCEF, nil
+	case FormatOCSF:
+		return []byte(FormatOCSFEvent(event, deviceVersion)), contentTypeJSON, nil
+	case FormatJSON:
+		payload := webhookPayload{
+			Severity:  event.Severity.String(),
+			Type:      event.Type,
+			Timestamp: event.Timestamp.UTC().Format(time.RFC3339Nano),
+			Instance:  event.InstanceID,
+			Fields:    event.Fields,
+		}
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return nil, "", err
+		}
+		return body, contentTypeJSON, nil
+	default:
+		return nil, "", fmt.Errorf("emit: unsupported event format %q", format)
+	}
+}

--- a/internal/emit/health.go
+++ b/internal/emit/health.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emit
+
+import "sort"
+
+const (
+	SinkWebhook = "webhook"
+	SinkSyslog  = "syslog"
+	SinkOTLP    = "otlp"
+)
+
+// SinkHealth is the transport-neutral delivery-health snapshot exposed to
+// observability surfaces. LastErrorPresent deliberately records only state,
+// never error text, so metrics cannot leak endpoint secrets or create
+// attacker-controlled label cardinality.
+type SinkHealth struct {
+	Sink             string
+	Delivered        uint64
+	Failed           uint64
+	Dropped          uint64
+	Abandoned        uint64
+	QueueLen         int
+	QueueCap         int
+	Degraded         bool
+	LastErrorPresent bool
+}
+
+// sinkStats is the common delivery-health shape reported by built-in sinks.
+// The exported per-sink Stats names remain aliases so callers keep their
+// transport-specific vocabulary while health mapping stays centralized.
+type sinkStats struct {
+	Delivered uint64
+	Failed    uint64
+	Dropped   uint64
+	Abandoned uint64
+	Degraded  bool
+	// LastError is the most recent failure, drop, or abandonment reason while
+	// the sink is degraded. Built-in sinks clear it after successful delivery.
+	LastError string
+	QueueLen  int
+	QueueCap  int
+}
+
+type sinkHealthProvider interface {
+	SinkHealth() SinkHealth
+}
+
+// SinkHealth returns an aggregate snapshot of the emitter's built-in audit
+// sinks. Delivery counters include retired generations so they remain
+// process-lifetime monotonic across reloads; gauges include current and actively
+// draining sinks only. It is pull-based and is never called from Emit.
+// Same-type sinks are aggregated to keep the Prometheus label set unique.
+func (e *Emitter) SinkHealth() []SinkHealth {
+	if e == nil {
+		return nil
+	}
+
+	e.mu.RLock()
+	sinks := append([]Sink(nil), e.sinks...)
+	for _, generation := range e.retiring {
+		sinks = append(sinks, generation.sinks...)
+	}
+	retired := make([]SinkHealth, 0, len(e.retired))
+	for _, health := range e.retired {
+		retired = append(retired, health)
+	}
+	e.mu.RUnlock()
+
+	bySink := make(map[string]SinkHealth, len(sinks)+len(retired))
+	for _, health := range retired {
+		bySink[health.Sink] = health
+	}
+	for _, sink := range sinks {
+		provider, ok := sink.(sinkHealthProvider)
+		if !ok {
+			continue
+		}
+		current := provider.SinkHealth()
+		if current.Sink == "" {
+			continue
+		}
+		total := bySink[current.Sink]
+		total.Sink = current.Sink
+		total.Delivered += current.Delivered
+		total.Failed += current.Failed
+		total.Dropped += current.Dropped
+		total.Abandoned += current.Abandoned
+		total.QueueLen += current.QueueLen
+		total.QueueCap += current.QueueCap
+		total.Degraded = total.Degraded || current.Degraded
+		total.LastErrorPresent = total.LastErrorPresent || current.LastErrorPresent
+		bySink[current.Sink] = total
+	}
+
+	result := make([]SinkHealth, 0, len(bySink))
+	for _, health := range bySink {
+		result = append(result, health)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Sink < result[j].Sink })
+	return result
+}
+
+func (w *WebhookSink) SinkHealth() SinkHealth {
+	return sinkHealthFromStats(SinkWebhook, w.Stats())
+}
+
+func (s *SyslogSink) SinkHealth() SinkHealth {
+	return sinkHealthFromStats(SinkSyslog, s.Stats())
+}
+
+func (s *OTLPSink) SinkHealth() SinkHealth {
+	return sinkHealthFromStats(SinkOTLP, s.Stats())
+}
+
+func sinkHealthFromStats(sink string, stats sinkStats) SinkHealth {
+	return SinkHealth{
+		Sink:             sink,
+		Delivered:        stats.Delivered,
+		Failed:           stats.Failed,
+		Dropped:          stats.Dropped,
+		Abandoned:        stats.Abandoned,
+		QueueLen:         stats.QueueLen,
+		QueueCap:         stats.QueueCap,
+		Degraded:         stats.Degraded,
+		LastErrorPresent: stats.LastError != "",
+	}
+}
+
+func (s *FilteringSink) SinkHealth() SinkHealth {
+	if s == nil {
+		return SinkHealth{}
+	}
+	provider, ok := s.sink.(sinkHealthProvider)
+	if !ok {
+		return SinkHealth{}
+	}
+	return provider.SinkHealth()
+}

--- a/internal/emit/health_test.go
+++ b/internal/emit/health_test.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emit
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestEmitterSinkHealthIncludesAllBuiltInSinks(t *testing.T) {
+	webhook := &WebhookSink{queue: make(chan Event, 3)}
+	webhook.delivered.Store(2)
+	webhook.failed.Store(1)
+	webhook.degraded.Store(true)
+	webhook.lastErr = "HTTP 500"
+
+	syslog := &SyslogSink{queue: make(chan syslogMessage, 5)}
+	syslog.dropped.Store(3)
+	syslog.degraded.Store(true)
+	syslog.lastErr = "queue_full"
+
+	otlp := &OTLPSink{queue: make(chan Event, 7)}
+	otlp.abandoned.Store(4)
+	otlp.degraded.Store(true)
+	otlp.lastErr = "drain_timeout"
+
+	emitter := NewEmitter("test", webhook, NewFilteringSink(syslog, Filter{Actions: []string{"block"}}), otlp)
+	got := emitter.SinkHealth()
+	if len(got) != 3 {
+		t.Fatalf("SinkHealth() = %+v, want three built-in sinks", got)
+	}
+
+	byName := make(map[string]SinkHealth, len(got))
+	for _, health := range got {
+		byName[health.Sink] = health
+	}
+	if health := byName[SinkWebhook]; health.Delivered != 2 || health.Failed != 1 || !health.Degraded || !health.LastErrorPresent || health.QueueCap != 3 {
+		t.Errorf("webhook health = %+v", health)
+	}
+	if health := byName[SinkSyslog]; health.Dropped != 3 || !health.Degraded || !health.LastErrorPresent || health.QueueCap != 5 {
+		t.Errorf("syslog health = %+v", health)
+	}
+	if health := byName[SinkOTLP]; health.Abandoned != 4 || !health.Degraded || !health.LastErrorPresent || health.QueueCap != 7 {
+		t.Errorf("otlp health = %+v", health)
+	}
+}
+
+func TestEmitterSinkHealthAggregatesDuplicateSinkTypes(t *testing.T) {
+	first := &WebhookSink{queue: make(chan Event, 2)}
+	first.delivered.Store(2)
+	second := &WebhookSink{queue: make(chan Event, 3)}
+	second.dropped.Store(1)
+	second.degraded.Store(true)
+	second.lastErr = "queue_full"
+
+	got := NewEmitter("test", first, second).SinkHealth()
+	if len(got) != 1 {
+		t.Fatalf("SinkHealth() = %+v, want one aggregated webhook series", got)
+	}
+	if got[0].Sink != SinkWebhook || got[0].Delivered != 2 || got[0].Dropped != 1 || got[0].QueueCap != 5 || !got[0].Degraded || !got[0].LastErrorPresent {
+		t.Fatalf("aggregated health = %+v", got[0])
+	}
+}
+
+func TestEmitterSinkHealthNilAndUnknown(t *testing.T) {
+	var nilEmitter *Emitter
+	if got := nilEmitter.SinkHealth(); got != nil {
+		t.Fatalf("nil emitter health = %+v, want nil", got)
+	}
+	if got := NewEmitter("test", &mockSink{}).SinkHealth(); len(got) != 0 {
+		t.Fatalf("unknown sink health = %+v, want empty", got)
+	}
+	var filtered *FilteringSink
+	if got := filtered.SinkHealth(); got != (SinkHealth{}) {
+		t.Fatalf("nil filtered sink health = %+v, want zero", got)
+	}
+}
+
+func TestEmitterSinkHealthKeepsReloadingSinkVisibleThroughDrain(t *testing.T) {
+	old := &WebhookSink{queue: make(chan Event, 2)}
+	old.delivered.Store(2)
+	current := &WebhookSink{queue: make(chan Event, 3)}
+	current.delivered.Store(1)
+	emitter := NewEmitter("test", old)
+
+	retired := emitter.ReloadSinks([]Sink{current})
+	retiredSinks := retired.Sinks()
+	if len(retiredSinks) != 1 || retiredSinks[0] != old {
+		t.Fatalf("ReloadSinks() retired = %+v, want old webhook", retiredSinks)
+	}
+
+	// This is the real reload ordering: the replacement is published before
+	// the old sink drains. Any abandonment during that drain must remain visible
+	// instead of disappearing behind the fresh sink's zeroed counters.
+	old.recordAbandoned(2)
+	health := emitter.SinkHealth()
+	if len(health) != 1 {
+		t.Fatalf("SinkHealth() = %+v, want one aggregated webhook series", health)
+	}
+	if health[0].Delivered != 3 || health[0].Abandoned != 2 || !health[0].Degraded || !health[0].LastErrorPresent {
+		t.Fatalf("reload drain health = %+v, want old and current sink state aggregated", health[0])
+	}
+
+	emitter.FinalizeRetiredSinks(retired)
+	health = emitter.SinkHealth()
+	if len(health) != 1 || health[0].Delivered != 3 || health[0].Abandoned != 2 {
+		t.Fatalf("finalized reload health = %+v, want process-lifetime counters preserved", health)
+	}
+	if health[0].Degraded || health[0].LastErrorPresent || health[0].QueueCap != 3 {
+		t.Fatalf("finalized reload gauges = %+v, want only current sink state", health[0])
+	}
+}
+
+func TestEmitterFinalizeRetiredSinksDefensiveGuards(t *testing.T) {
+	t.Run("nil generation is a no-op", func(t *testing.T) {
+		emitter := NewEmitter("test")
+		// Keep a nil entry tracked so removing the explicit nil guard would
+		// select and dereference it instead of remaining a no-op.
+		emitter.retiring = []*RetiredSinks{nil}
+
+		emitter.FinalizeRetiredSinks(nil)
+
+		if len(emitter.retiring) != 1 || emitter.retiring[0] != nil {
+			t.Fatalf("retiring generations = %+v, want tracked nil entry unchanged", emitter.retiring)
+		}
+		if emitter.retired != nil {
+			t.Fatalf("retired totals = %+v, want nil", emitter.retired)
+		}
+	})
+
+	t.Run("already finalized generation is ignored", func(t *testing.T) {
+		old := &WebhookSink{queue: make(chan Event, 1)}
+		old.delivered.Store(3)
+		emitter := NewEmitter("test", old)
+		generation := emitter.ReloadSinks(nil)
+
+		emitter.FinalizeRetiredSinks(generation)
+		emitter.FinalizeRetiredSinks(generation)
+
+		health := emitter.SinkHealth()
+		if len(health) != 1 || health[0].Sink != SinkWebhook || health[0].Delivered != 3 {
+			t.Fatalf("SinkHealth() = %+v, want webhook delivered=3 counted once", health)
+		}
+		if len(emitter.retiring) != 0 {
+			t.Fatalf("retiring generations = %+v, want empty", emitter.retiring)
+		}
+	})
+}
+
+func TestEmitterSinkHealthPreservesLateRetiringFailureAcrossShutdown(t *testing.T) {
+	old := &interleavingHealthSink{
+		closeStarted: make(chan struct{}),
+		releaseClose: make(chan struct{}),
+	}
+	current := &interleavingHealthSink{}
+	emitter := NewEmitter("test", old)
+	retired := emitter.ReloadSinks([]Sink{current})
+
+	oldCloseDone := make(chan struct{})
+	go func() {
+		defer close(oldCloseDone)
+		for _, sink := range retired.Sinks() {
+			_ = sink.Close()
+		}
+		emitter.FinalizeRetiredSinks(retired)
+	}()
+
+	select {
+	case <-old.closeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retiring sink did not start closing")
+	}
+	if err := emitter.Close(); err != nil {
+		t.Fatalf("Emitter.Close() error = %v", err)
+	}
+
+	// The retiring generation records these counters only after shutdown has
+	// finished closing and finalizing the current generation.
+	close(old.releaseClose)
+	select {
+	case <-oldCloseDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retiring sink did not finish closing")
+	}
+
+	health := emitter.SinkHealth()
+	if len(health) != 1 || health[0].Failed != 1 || health[0].Abandoned != 2 {
+		t.Fatalf("SinkHealth() = %+v, want late failed=1 and abandoned=2 preserved", health)
+	}
+}
+
+type interleavingHealthSink struct {
+	closeStarted chan struct{}
+	releaseClose chan struct{}
+	failed       atomic.Uint64
+	abandoned    atomic.Uint64
+}
+
+func (*interleavingHealthSink) Emit(context.Context, Event) error { return nil }
+
+func (s *interleavingHealthSink) Close() error {
+	if s.closeStarted == nil {
+		return nil
+	}
+	close(s.closeStarted)
+	<-s.releaseClose
+	s.failed.Add(1)
+	s.abandoned.Add(2)
+	return nil
+}
+
+func (s *interleavingHealthSink) SinkHealth() SinkHealth {
+	return SinkHealth{
+		Sink:      SinkWebhook,
+		Failed:    s.failed.Load(),
+		Abandoned: s.abandoned.Load(),
+	}
+}

--- a/internal/emit/otlp.go
+++ b/internal/emit/otlp.go
@@ -68,19 +68,7 @@ var ErrOTLPDegraded = errors.New("emit: otlp sink degraded")
 const errOTLPClosed = "emit: otlp sink closed"
 
 // OTLPStats reports delivery health for an OTLPSink.
-type OTLPStats struct {
-	Delivered uint64
-	Failed    uint64
-	Dropped   uint64
-	Abandoned uint64
-	Degraded  bool
-	// LastError is the most recent failure, drop, or abandonment reason while
-	// the sink is degraded. It is cleared on the next successful delivery, so a
-	// non-degraded snapshot reports an empty LastError.
-	LastError string
-	QueueLen  int
-	QueueCap  int
-}
+type OTLPStats = sinkStats
 
 // OTLPSink sends audit events as OTLP log records over HTTP/protobuf.
 // Events are queued and sent asynchronously by a single background goroutine.

--- a/internal/emit/otlp_accounting_test.go
+++ b/internal/emit/otlp_accounting_test.go
@@ -406,6 +406,9 @@ func TestOTLPSink_PanicDropsOnlyCurrentEvent(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("panic Emit: %v", err)
 	}
+	// ErrOTLPDegraded means the event WAS accepted for delivery (the prior panic
+	// set the degraded advisory); it is not a failure to emit. Accepting it makes
+	// this deterministic instead of racing the panic event's async failure.
 	if err := sink.Emit(context.Background(), Event{Severity: SeverityCritical, Type: "after-panic", Timestamp: time.Now()}); err != nil && !errors.Is(err, ErrOTLPDegraded) {
 		t.Fatalf("post-panic Emit: %v", err)
 	}

--- a/internal/emit/syslog.go
+++ b/internal/emit/syslog.go
@@ -56,16 +56,7 @@ type syslogMessage struct {
 }
 
 // SyslogStats reports delivery health for a SyslogSink.
-type SyslogStats struct {
-	Delivered uint64
-	Failed    uint64
-	Dropped   uint64
-	Abandoned uint64
-	Degraded  bool
-	LastError string
-	QueueLen  int
-	QueueCap  int
-}
+type SyslogStats = sinkStats
 
 // SyslogSink sends audit events to a syslog server.
 // It maps emit.Severity to syslog priority levels.
@@ -361,42 +352,10 @@ func (s *SyslogSink) safeSend(msg syslogMessage) {
 }
 
 func makeSyslogMessage(event Event, format, deviceVersion string) (syslogMessage, error) {
-	if format == "" {
-		format = FormatJSON
+	if err := validateSyslogFormat(format); err != nil {
+		return syslogMessage{}, err
 	}
-	if format == FormatCEF {
-		msg := FormatCEFEvent(event, deviceVersion)
-		return syslogMessage{
-			severity:  event.Severity,
-			eventType: event.Type,
-			message:   msg,
-		}, nil
-	}
-	if format == FormatOCSF {
-		msg := FormatOCSFEvent(event, deviceVersion)
-		return syslogMessage{
-			severity:  event.Severity,
-			eventType: event.Type,
-			message:   msg,
-		}, nil
-	}
-	// Deliberately stricter than emitformat.Supported: every format needs an
-	// explicit render branch above; an allowlisted-but-unrendered format must
-	// error loudly here (accounted as a delivery failure), never fall through
-	// to JSON rendering.
-	if format != FormatJSON {
-		return syslogMessage{}, fmt.Errorf("emit: unsupported syslog format %q", format)
-	}
-
-	payload := webhookPayload{
-		Severity:  event.Severity.String(),
-		Type:      event.Type,
-		Timestamp: event.Timestamp.UTC().Format(time.RFC3339Nano),
-		Instance:  event.InstanceID,
-		Fields:    event.Fields,
-	}
-
-	msg, err := json.Marshal(payload)
+	payload, _, err := formatEvent(event, format, deviceVersion)
 	if err != nil {
 		return syslogMessage{}, fmt.Errorf("emit: syslog marshal: %w", err)
 	}
@@ -404,7 +363,7 @@ func makeSyslogMessage(event Event, format, deviceVersion string) (syslogMessage
 	return syslogMessage{
 		severity:  event.Severity,
 		eventType: event.Type,
-		message:   string(msg),
+		message:   string(payload),
 	}, nil
 }
 

--- a/internal/emit/syslog_test.go
+++ b/internal/emit/syslog_test.go
@@ -22,7 +22,10 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/emitformat"
 )
 
-const testConfigSyslogAddr = "udp://syslog.example.com:514"
+const (
+	testConfigSyslogAddr = "udp://syslog.example.com:514"
+	testConfigWebhookURL = "https://siem.vendor.example/events"
+)
 
 func TestParseSyslogAddress(t *testing.T) {
 	tests := []struct {
@@ -851,7 +854,7 @@ func TestMakeSyslogMessage_InvalidFormat(t *testing.T) {
 	}
 }
 
-func TestSyslogFormatValidationParity(t *testing.T) {
+func TestExportFormatValidationParity(t *testing.T) {
 	tests := []struct {
 		name      string
 		format    string
@@ -886,6 +889,12 @@ func TestSyslogFormatValidationParity(t *testing.T) {
 			}
 			if got := configValidateAcceptsSyslogFormat(tt.format); got != tt.supported {
 				t.Fatalf("config Validate syslog format %q success = %v, want %v", tt.format, got, tt.supported)
+			}
+			if got := formatEventAcceptsFormat(tt.format); got != tt.supported {
+				t.Fatalf("formatEvent(%q) success = %v, want %v", tt.format, got, tt.supported)
+			}
+			if got := configValidateAcceptsWebhookFormat(tt.format); got != tt.supported {
+				t.Fatalf("config Validate webhook format %q success = %v, want %v", tt.format, got, tt.supported)
 			}
 		})
 	}
@@ -954,6 +963,24 @@ func configValidateAcceptsSyslogFormat(format string) bool {
 	cfg.ApplyDefaults()
 	cfg.Emit.Syslog.Address = testConfigSyslogAddr
 	cfg.Emit.Syslog.Format = format
+	return cfg.Validate() == nil
+}
+
+func formatEventAcceptsFormat(format string) bool {
+	_, _, err := formatEvent(Event{
+		Severity:  SeverityWarn,
+		Type:      EventHeaderDLP,
+		Timestamp: time.Now(),
+		Fields:    map[string]any{},
+	}, format, "1.2.3")
+	return err == nil
+}
+
+func configValidateAcceptsWebhookFormat(format string) bool {
+	cfg := config.Defaults()
+	cfg.ApplyDefaults()
+	cfg.Emit.Webhook.URL = testConfigWebhookURL
+	cfg.Emit.Webhook.Format = format
 	return cfg.Validate() == nil
 }
 

--- a/internal/emit/syslog_windows.go
+++ b/internal/emit/syslog_windows.go
@@ -31,16 +31,7 @@ type SyslogOption func(*syslogConfig)
 type SyslogSink struct{}
 
 // SyslogStats reports delivery health for a SyslogSink.
-type SyslogStats struct {
-	Delivered uint64
-	Failed    uint64
-	Dropped   uint64
-	Abandoned uint64
-	Degraded  bool
-	LastError string
-	QueueLen  int
-	QueueCap  int
-}
+type SyslogStats = sinkStats
 
 // WithSyslogFormat is a no-op option on Windows.
 func WithSyslogFormat(_, _ string) SyslogOption {

--- a/internal/emit/webhook.go
+++ b/internal/emit/webhook.go
@@ -33,16 +33,7 @@ var ErrQueueFull = errors.New("emit: webhook queue full, event dropped")
 var ErrWebhookDegraded = errors.New("emit: webhook sink degraded")
 
 // WebhookStats reports delivery health for a WebhookSink.
-type WebhookStats struct {
-	Delivered uint64
-	Failed    uint64
-	Dropped   uint64
-	Abandoned uint64
-	Degraded  bool
-	LastError string
-	QueueLen  int
-	QueueCap  int
-}
+type WebhookStats = sinkStats
 
 // webhookPayload is the JSON structure sent to the webhook endpoint.
 type webhookPayload struct {
@@ -53,7 +44,7 @@ type webhookPayload struct {
 	Fields    map[string]any `json:"fields"`
 }
 
-// WebhookSink sends audit events as JSON to an HTTP endpoint.
+// WebhookSink sends formatted audit events to an HTTP endpoint.
 // Events are queued and sent asynchronously by a single background goroutine.
 type WebhookSink struct {
 	url       string
@@ -74,6 +65,8 @@ type WebhookSink struct {
 	degraded  atomic.Bool
 	lastErrMu sync.Mutex
 	lastErr   string
+	format    string
+	version   string
 }
 
 // WebhookOption configures a WebhookSink.
@@ -111,11 +104,21 @@ func WithMinSeverity(sev Severity) WebhookOption {
 	}
 }
 
-// NewWebhookSink creates a WebhookSink that POSTs JSON events to the given URL.
+// WithWebhookFormat sets the HTTP event wire format. Format names come from
+// emitformat; rendering is shared with syslog through formatEvent.
+func WithWebhookFormat(format, deviceVersion string) WebhookOption {
+	return func(w *WebhookSink) {
+		w.format = format
+		w.version = deviceVersion
+	}
+}
+
+// NewWebhookSink creates a WebhookSink that POSTs events to the given URL.
 // The background goroutine starts immediately and runs until Close is called.
 func NewWebhookSink(url string, opts ...WebhookOption) *WebhookSink {
 	w := &WebhookSink{
 		url:    url,
+		format: FormatJSON,
 		client: &http.Client{Timeout: DefaultWebhookTimeout},
 		queue:  make(chan Event, DefaultQueueSize),
 		done:   make(chan struct{}),
@@ -201,7 +204,7 @@ func (w *WebhookSink) drain() {
 		case event := <-w.queue:
 			w.safeSend(event)
 		case <-deadline:
-			w.recordAbandoned("drain_timeout", len(w.queue))
+			w.recordAbandoned(len(w.queue))
 			return
 		default:
 			return
@@ -218,7 +221,7 @@ func (w *WebhookSink) safeSend(event Event) {
 	w.send(event)
 }
 
-// send POSTs a single event as JSON to the webhook URL.
+// send formats and POSTs a single event to the webhook URL.
 func (w *WebhookSink) send(event Event) {
 	// Snapshot the health-change counters before the send so a successful
 	// delivery only clears degraded health if no failure, drop, or abandonment
@@ -228,17 +231,13 @@ func (w *WebhookSink) send(event Event) {
 	droppedSnapshot := w.dropped.Load()
 	abandonedSnapshot := w.abandoned.Load()
 
-	payload := webhookPayload{
-		Severity:  event.Severity.String(),
-		Type:      event.Type,
-		Timestamp: event.Timestamp.UTC().Format(time.RFC3339Nano),
-		Instance:  event.InstanceID,
-		Fields:    event.Fields,
-	}
-
-	body, err := json.Marshal(payload)
+	body, contentType, err := formatEvent(event, w.format, w.version)
 	if err != nil {
-		w.recordFailure("marshal_error", event, err)
+		reason := "format_error"
+		if w.format == "" || w.format == FormatJSON {
+			reason = "marshal_error"
+		}
+		w.recordFailure(reason, event, err)
 		return
 	}
 
@@ -248,7 +247,7 @@ func (w *WebhookSink) send(event Event) {
 		return
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentType)
 	if w.token != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", w.token))
 	}
@@ -350,10 +349,11 @@ func (w *WebhookSink) recordDropped(reason string, err error) {
 	w.lastErrMu.Unlock()
 }
 
-func (w *WebhookSink) recordAbandoned(reason string, count int) {
+func (w *WebhookSink) recordAbandoned(count int) {
 	if count < 1 {
 		return
 	}
+	const reason = "drain_timeout" // the only path that abandons webhook events is a drain deadline
 	w.abandoned.Add(uint64(count))
 	w.lastErrMu.Lock()
 	w.degraded.Store(true)

--- a/internal/emit/webhook_test.go
+++ b/internal/emit/webhook_test.go
@@ -111,6 +111,102 @@ func TestWebhookSink_SuccessfulPost(t *testing.T) {
 	}
 }
 
+func TestWebhookSink_OCSFOverHTTP(t *testing.T) {
+	type capture struct {
+		body        []byte
+		contentType string
+	}
+	captures := make(chan capture, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		captures <- capture{body: body, contentType: r.Header.Get("Content-Type")}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sink := NewWebhookSink(srv.URL, WithWebhookFormat(FormatOCSF, "1.2.3"))
+	event := Event{
+		Severity:   SeverityCritical,
+		Type:       EventBodyDLP,
+		Timestamp:  time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+		InstanceID: testInstanceName,
+		Fields: map[string]any{
+			"action":    conventionActionBlock,
+			"agent":     "agent-a",
+			fieldReason: "secret detected",
+		},
+	}
+	if err := sink.Emit(t.Context(), event); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	var gotCapture capture
+	select {
+	case gotCapture = <-captures:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook capture")
+	}
+	if gotCapture.contentType != contentTypeJSON {
+		t.Fatalf("Content-Type = %q, want %q", gotCapture.contentType, contentTypeJSON)
+	}
+	got := parseOCSFEvent(t, string(gotCapture.body))
+	assertNumber(t, got, "class_uid", ocsfClassUIDDetectionFinding)
+	assertString(t, got, "message", "body_dlp: secret detected")
+	assertString(t, got, "action", conventionActionBlock)
+	product := assertMap(t, assertMap(t, got, "metadata"), "product")
+	assertString(t, product, "version", "1.2.3")
+	if stats := sink.Stats(); stats.Delivered != 1 || stats.Failed != 0 {
+		t.Fatalf("delivery stats = %+v", stats)
+	}
+}
+
+func TestWebhookSink_OCSFHostileFieldNeverSendsEmptyPayload(t *testing.T) {
+	captures := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		captures <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := NewWebhookSink(srv.URL, WithWebhookFormat(FormatOCSF, "dev"))
+	if err := sink.Emit(t.Context(), Event{
+		Severity:  SeverityWarn,
+		Type:      EventError,
+		Timestamp: time.Now(),
+		Fields:    map[string]any{"unmarshalable": make(chan int)},
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	var body []byte
+	select {
+	case body = <-captures:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook capture")
+	}
+	if len(body) == 0 || string(body) == "{}" {
+		t.Fatalf("OCSF body failed open: %q", body)
+	}
+	got := parseOCSFEvent(t, string(body))
+	assertNumber(t, got, "class_uid", ocsfClassUIDDetectionFinding)
+	if _, ok := got["finding_info"].(map[string]any); !ok {
+		t.Fatalf("finding_info missing from OCSF fallback-safe body: %#v", got)
+	}
+}
+
 func TestWebhookSink_BearerToken(t *testing.T) {
 	var gotAuth string
 	done := make(chan struct{})
@@ -263,7 +359,10 @@ func TestWebhookSink_CloseDrainsPending(t *testing.T) {
 			Timestamp:  time.Now(),
 			InstanceID: testStr,
 		})
-		if err != nil {
+		// ErrWebhookDegraded means the event WAS queued (a prior async delivery
+		// failed); it is an advisory, not a blocked emit. Accepting it makes this
+		// deterministic instead of racing the async failure.
+		if err != nil && !errors.Is(err, ErrWebhookDegraded) {
 			t.Fatalf("Emit %d returned error: %v", i, err)
 		}
 	}
@@ -298,6 +397,9 @@ func TestWebhookSink_ServerErrorDoesNotBlock(t *testing.T) {
 			Timestamp:  time.Now(),
 			InstanceID: testStr,
 		})
+		// ErrWebhookDegraded means the event WAS queued (a prior async delivery
+		// failed); it is an advisory, not a blocked emit. Accepting it makes this
+		// deterministic instead of racing the async failure.
 		if err != nil && !errors.Is(err, ErrWebhookDegraded) {
 			t.Fatalf("Emit %d returned error: %v", i, err)
 		}
@@ -655,7 +757,7 @@ func TestWebhookSink_StatsNilAndAbandoned(t *testing.T) {
 	}
 
 	sink := &WebhookSink{queue: make(chan Event, 2)}
-	sink.recordAbandoned("drain_timeout", 2)
+	sink.recordAbandoned(2)
 	stats := sink.Stats()
 	if stats.Abandoned != 2 || !stats.Degraded || stats.LastError != "drain_timeout" || stats.QueueCap != 2 {
 		t.Fatalf("stats = %+v, want abandoned degraded snapshot", stats)
@@ -911,7 +1013,7 @@ func TestWebhookSink_RecordDroppedWithErrorAndAbandonedZeroCount(t *testing.T) {
 	}
 
 	// A zero or negative abandon count must be a no-op.
-	sink.recordAbandoned("drain_timeout", 0)
+	sink.recordAbandoned(0)
 	if stats := sink.Stats(); stats.Abandoned != 0 {
 		t.Fatalf("stats after zero-count abandon = %+v, want Abandoned=0", stats)
 	}

--- a/internal/metrics/audit_sinks.go
+++ b/internal/metrics/audit_sinks.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/luckyPipewrench/pipelock/internal/emit"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type auditSinkCollector struct {
+	mu       sync.RWMutex
+	snapshot func() []emit.SinkHealth
+
+	delivered        *prometheus.Desc
+	failed           *prometheus.Desc
+	dropped          *prometheus.Desc
+	abandoned        *prometheus.Desc
+	queueDepth       *prometheus.Desc
+	queueCapacity    *prometheus.Desc
+	degraded         *prometheus.Desc
+	lastErrorPresent *prometheus.Desc
+}
+
+func newAuditSinkCollector() *auditSinkCollector {
+	labels := []string{"sink"}
+	return &auditSinkCollector{
+		delivered: prometheus.NewDesc(
+			"pipelock_audit_sink_delivered_total",
+			"Audit events successfully delivered, cumulative per sink type over the process lifetime (survives sink reload).",
+			labels, nil,
+		),
+		failed: prometheus.NewDesc(
+			"pipelock_audit_sink_failed_total",
+			"Audit event delivery failures recorded, cumulative per sink type over the process lifetime (survives sink reload).",
+			labels, nil,
+		),
+		dropped: prometheus.NewDesc(
+			"pipelock_audit_sink_dropped_total",
+			"Audit events dropped before delivery, cumulative per sink type over the process lifetime (survives sink reload).",
+			labels, nil,
+		),
+		abandoned: prometheus.NewDesc(
+			"pipelock_audit_sink_abandoned_total",
+			"Queued audit events abandoned during shutdown, cumulative per sink type over the process lifetime (survives sink reload).",
+			labels, nil,
+		),
+		queueDepth: prometheus.NewDesc(
+			"pipelock_audit_sink_queue_depth",
+			"Current number of audit events queued for delivery.",
+			labels, nil,
+		),
+		queueCapacity: prometheus.NewDesc(
+			"pipelock_audit_sink_queue_capacity",
+			"Configured audit event delivery queue capacity.",
+			labels, nil,
+		),
+		degraded: prometheus.NewDesc(
+			"pipelock_audit_sink_degraded",
+			"Whether the audit sink has an unresolved delivery failure or drop (1 degraded, 0 healthy).",
+			labels, nil,
+		),
+		lastErrorPresent: prometheus.NewDesc(
+			"pipelock_audit_sink_last_error_present",
+			"Whether the audit sink currently records a last error (1 present, 0 absent); error text is excluded to bound cardinality and prevent secret exposure.",
+			labels, nil,
+		),
+	}
+}
+
+func (c *auditSinkCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.delivered
+	ch <- c.failed
+	ch <- c.dropped
+	ch <- c.abandoned
+	ch <- c.queueDepth
+	ch <- c.queueCapacity
+	ch <- c.degraded
+	ch <- c.lastErrorPresent
+}
+
+func (c *auditSinkCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.RLock()
+	snapshot := c.snapshot
+	c.mu.RUnlock()
+	if snapshot == nil {
+		return
+	}
+
+	for _, health := range snapshot() {
+		if !knownAuditSink(health.Sink) {
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(c.delivered, prometheus.CounterValue, float64(health.Delivered), health.Sink)
+		ch <- prometheus.MustNewConstMetric(c.failed, prometheus.CounterValue, float64(health.Failed), health.Sink)
+		ch <- prometheus.MustNewConstMetric(c.dropped, prometheus.CounterValue, float64(health.Dropped), health.Sink)
+		ch <- prometheus.MustNewConstMetric(c.abandoned, prometheus.CounterValue, float64(health.Abandoned), health.Sink)
+		ch <- prometheus.MustNewConstMetric(c.queueDepth, prometheus.GaugeValue, float64(health.QueueLen), health.Sink)
+		ch <- prometheus.MustNewConstMetric(c.queueCapacity, prometheus.GaugeValue, float64(health.QueueCap), health.Sink)
+		ch <- prometheus.MustNewConstMetric(c.degraded, prometheus.GaugeValue, boolFloat(health.Degraded), health.Sink)
+		ch <- prometheus.MustNewConstMetric(c.lastErrorPresent, prometheus.GaugeValue, boolFloat(health.LastErrorPresent), health.Sink)
+	}
+}
+
+func boolFloat(value bool) float64 {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+// knownAuditSink bounds the Prometheus "sink" label to the built-in sink
+// identities so a hostile or unexpected SinkHealth.Sink value cannot inflate
+// label cardinality.
+func knownAuditSink(name string) bool {
+	switch name {
+	case emit.SinkWebhook, emit.SinkSyslog, emit.SinkOTLP:
+		return true
+	default:
+		return false
+	}
+}
+
+// SetAuditSinkHealthSnapshot connects the live emitter's pull-only health
+// snapshot to Prometheus. The callback runs only during a scrape, never while
+// an event is being emitted.
+func (m *Metrics) SetAuditSinkHealthSnapshot(snapshot func() []emit.SinkHealth) {
+	if m == nil || m.auditSinkCollector == nil {
+		return
+	}
+	m.auditSinkCollector.mu.Lock()
+	m.auditSinkCollector.snapshot = snapshot
+	m.auditSinkCollector.mu.Unlock()
+}

--- a/internal/metrics/audit_sinks_test.go
+++ b/internal/metrics/audit_sinks_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/emit"
+)
+
+func TestAuditSinkDeliveryFailureIsExposedByPrometheus(t *testing.T) {
+	requestSeen := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		requestSeen <- struct{}{}
+	}))
+	defer srv.Close()
+
+	sink := emit.NewWebhookSink(srv.URL)
+	emitter := emit.NewEmitter("test", sink)
+	t.Cleanup(func() { _ = emitter.Close() })
+	m := New()
+	m.SetAuditSinkHealthSnapshot(emitter.SinkHealth)
+
+	emitter.EmitWithSeverity(t.Context(), emit.SeverityWarn, emit.EventBlocked, nil)
+	select {
+	case <-requestSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for simulated sink failure")
+	}
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(2 * time.Second)
+	for sink.Stats().Failed == 0 {
+		select {
+		case <-ticker.C:
+		case <-deadline:
+			t.Fatal("timed out waiting for failure accounting")
+		}
+	}
+	if stats := sink.Stats(); stats.Failed != 1 || !stats.Degraded || stats.LastError == "" {
+		t.Fatalf("simulated failure stats = %+v", stats)
+	}
+
+	rec := httptest.NewRecorder()
+	m.PrometheusHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
+	body := rec.Body.String()
+	for _, want := range []string{
+		`pipelock_audit_sink_failed_total{sink="webhook"} 1`,
+		`pipelock_audit_sink_degraded{sink="webhook"} 1`,
+		`pipelock_audit_sink_last_error_present{sink="webhook"} 1`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "HTTP 500") {
+		t.Fatalf("last error text leaked into Prometheus output:\n%s", body)
+	}
+}
+
+func TestAuditSinkMetricsUseOnlyBoundedSinkLabel(t *testing.T) {
+	m := New()
+	m.SetAuditSinkHealthSnapshot(func() []emit.SinkHealth {
+		return []emit.SinkHealth{
+			{Sink: emit.SinkWebhook, QueueCap: 64},
+			{Sink: emit.SinkSyslog, QueueCap: 64},
+			{Sink: emit.SinkOTLP, QueueCap: 256},
+		}
+	})
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, family := range families {
+		if !strings.HasPrefix(family.GetName(), "pipelock_audit_sink_") {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if len(metric.GetLabel()) != 1 || metric.GetLabel()[0].GetName() != "sink" {
+				t.Fatalf("%s labels = %+v, want only bounded sink label", family.GetName(), metric.GetLabel())
+			}
+		}
+	}
+}
+
+func TestAuditSinkMetricsRejectUnknownSinkLabelValues(t *testing.T) {
+	m := New()
+	m.SetAuditSinkHealthSnapshot(func() []emit.SinkHealth {
+		return []emit.SinkHealth{
+			{Sink: emit.SinkWebhook, Delivered: 1},
+			{Sink: "attacker-" + strings.Repeat("x", 4096), Delivered: 1},
+		}
+	})
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, family := range families {
+		if !strings.HasPrefix(family.GetName(), "pipelock_audit_sink_") {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "sink" && label.GetValue() != emit.SinkWebhook {
+					t.Fatalf("%s accepted unbounded sink label value of %d bytes", family.GetName(), len(label.GetValue()))
+				}
+			}
+		}
+	}
+}
+
+func TestSetAuditSinkHealthSnapshotNilSafe(t *testing.T) {
+	var nilMetrics *Metrics
+	nilMetrics.SetAuditSinkHealthSnapshot(func() []emit.SinkHealth { return nil })
+	New().SetAuditSinkHealthSnapshot(nil)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -168,6 +168,9 @@ type Metrics struct {
 	siemForwarderLastSuccess prometheus.Gauge
 	siemForwarderSpoolBytes  prometheus.Gauge
 
+	// Built-in audit sink delivery health (audit_sinks.go).
+	auditSinkCollector *auditSinkCollector
+
 	// Stats endpoint state (stats_handler.go).
 	mu                     sync.Mutex
 	startTime              time.Time
@@ -241,6 +244,8 @@ func New() *Metrics {
 	m.registerEvidenceMetrics(reg)
 	m.registerRuleBundleMetrics(reg)
 	m.registerSIEMForwarderMetrics(reg)
+	m.auditSinkCollector = newAuditSinkCollector()
+	reg.MustRegister(m.auditSinkCollector)
 
 	// Built-in Go runtime + process collectors. These expose
 	// go_memstats_heap_alloc_bytes, go_goroutines, process_resident_memory_bytes,


### PR DESCRIPTION
## What changed

Audit sink delivery failures were written only to stderr, so a webhook, syslog, or OTLP sink that started dropping or failing deliveries was invisible to monitoring. This exposes a unified set of pipelock_audit_sink_* Prometheus metrics (delivered, failed, dropped, abandoned, queue depth and capacity, degraded, and last-error-present) across all three sinks, with the sink label bounded to the known sink identities. It also adds an OCSF wire format for the webhook and HTTP sink through the shared formatter, so SIEM consumers that ingest over HTTP rather than syslog can receive OCSF.

## Why it is safe

Metrics are gathered only during a scrape and never on the emit hot path, so emission stays non-blocking. Terminal delivery counters stay visible across a config reload while a replaced sink drains, so a failure recorded during shutdown does not disappear from the health surface. The sink label is restricted to a fixed allowlist so a hostile or unexpected sink value cannot inflate metric cardinality, and the OCSF path reuses the single existing OCSF encoder rather than a second copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `emit.webhook.format` to control webhook/syslog encoding (`json` default, `cef`, `ocsf`), including OCSF-over-HTTP with the correct `Content-Type`.
  * Introduced Prometheus audit-sink health metrics (delivery counters) with degraded state and “last error present”.
* **Documentation**
  * Updated configuration and SIEM/webhook guides with allowed formats and revised examples.
* **Bug Fixes**
  * Improved sink health reporting across hot reloads and shutdowns, preserving terminal metrics and avoiding leakage of error text.
* **Tests**
  * Expanded coverage for OCSF-over-HTTP payloads, webhook format validation/defaulting/reload, health lifecycle, and metric label safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->