### PR TITLE
fix(emit): make degraded-signal delivery tests deterministic + guard OTLP health-clear

### DIFF
--- a/internal/emit/otlp.go
+++ b/internal/emit/otlp.go
@@ -291,6 +291,14 @@ func (s *OTLPSink) safeSend(event Event) {
 func (s *OTLPSink) send(event Event) {
 	record := s.eventToLogRecord(event)
 
+	// Snapshot the health-change counters before the send so a successful
+	// delivery only clears degraded health if no failure, drop, or abandonment
+	// was recorded while this send was in flight (mirrors WebhookSink.send);
+	// otherwise a concurrent queue-full drop would be silently erased.
+	failedSnapshot := s.failed.Load()
+	droppedSnapshot := s.dropped.Load()
+	abandonedSnapshot := s.abandoned.Load()
+
 	// Build ExportLogsServiceRequest without importing collector/logs/v1
 	// (which pulls in gRPC). The wire format is just field 1 = ResourceLogs.
 	body, err := otlpMarshalExportLogsRequest(s.resource, record)
@@ -317,12 +325,18 @@ func (s *OTLPSink) send(event Event) {
 		return
 	}
 	s.delivered.Add(1)
-	s.degraded.Store(false)
-	// A successful delivery clears the degraded state, so clear the paired
-	// LastError too; otherwise Stats() would report Degraded=false with a stale
-	// error from an earlier failure.
+	// Clear paired health only if no newer failure, drop, or abandonment was
+	// recorded while this request was in flight. Rechecking under the same lock
+	// that guards health updates closes the check-then-clear race; otherwise a
+	// concurrent queue-full drop would be silently erased and Stats() would
+	// report Degraded=false with a stale error.
 	s.lastErrMu.Lock()
-	s.lastErr = ""
+	if s.failed.Load() == failedSnapshot &&
+		s.dropped.Load() == droppedSnapshot &&
+		s.abandoned.Load() == abandonedSnapshot {
+		s.degraded.Store(false)
+		s.lastErr = ""
+	}
 	s.lastErrMu.Unlock()
 }
 

--- a/internal/emit/otlp_accounting_test.go
+++ b/internal/emit/otlp_accounting_test.go
@@ -406,7 +406,7 @@ func TestOTLPSink_PanicDropsOnlyCurrentEvent(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("panic Emit: %v", err)
 	}
-	if err := sink.Emit(context.Background(), Event{Severity: SeverityCritical, Type: "after-panic", Timestamp: time.Now()}); err != nil {
+	if err := sink.Emit(context.Background(), Event{Severity: SeverityCritical, Type: "after-panic", Timestamp: time.Now()}); err != nil && !errors.Is(err, ErrOTLPDegraded) {
 		t.Fatalf("post-panic Emit: %v", err)
 	}
 
@@ -628,5 +628,61 @@ func TestOTLPSink_LogDiagnosticMarshalErrorDoesNotPanic(t *testing.T) {
 	}
 	if !strings.Contains(stats.LastError, "diagnostic error string panic") {
 		t.Fatalf("LastError = %q, want recovered error string panic", stats.LastError)
+	}
+}
+
+func TestOTLPSink_SuccessDoesNotEraseConcurrentDropDegraded(t *testing.T) {
+	// Mirrors WebhookSink protection: a successful send must not clear the
+	// degraded flag when a failure, drop, or abandonment is recorded while that
+	// send is in flight. Covers all three counter classes the snapshot guard
+	// compares (failed, dropped, abandoned).
+	cases := []struct {
+		name    string
+		inject  func(s *OTLPSink)
+		wantErr string
+		count   func(st OTLPStats) uint64
+	}{
+		{"drop", func(s *OTLPSink) { s.recordDropped("queue_full", nil) }, "queue_full", func(st OTLPStats) uint64 { return st.Dropped }},
+		{"failure", func(s *OTLPSink) { s.recordFailure("send_error", Event{}, errors.New("send failed")) }, "", func(st OTLPStats) uint64 { return st.Failed }},
+		{"abandon", func(s *OTLPSink) { s.recordAbandoned("drain_timeout", Event{}, 1) }, "drain_timeout", func(st OTLPStats) uint64 { return st.Abandoned }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sink *OTLPSink
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				tc.inject(sink)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			var err error
+			sink, err = NewOTLPSink(srv.URL, "1.0.0", SeverityInfo, nil, 5*time.Second, 4, false)
+			if err != nil {
+				t.Fatalf("NewOTLPSink: %v", err)
+			}
+			defer func() { _ = sink.Close() }()
+
+			sink.send(Event{Type: "blocked", Timestamp: time.Now()})
+
+			st := sink.Stats()
+			if st.Delivered != 1 {
+				t.Fatalf("delivered = %d, want 1", st.Delivered)
+			}
+			if got := tc.count(st); got != 1 {
+				t.Fatalf("%s counter = %d, want 1", tc.name, got)
+			}
+			if !st.Degraded {
+				t.Fatalf("degraded was erased despite a concurrent %s during the send", tc.name)
+			}
+			// recordFailure derives LastError from the error (not the reason),
+			// so the failure case only asserts a non-empty preserved error;
+			// drop/abandon assert the exact reason.
+			if tc.wantErr != "" && st.LastError != tc.wantErr {
+				t.Fatalf("LastError = %q, want %q preserved", st.LastError, tc.wantErr)
+			}
+			if st.LastError == "" {
+				t.Fatalf("LastError was cleared; want the concurrent %s error preserved", tc.name)
+			}
+		})
 	}
 }

--- a/internal/emit/webhook_test.go
+++ b/internal/emit/webhook_test.go
@@ -298,7 +298,7 @@ func TestWebhookSink_ServerErrorDoesNotBlock(t *testing.T) {
 			Timestamp:  time.Now(),
 			InstanceID: testStr,
 		})
-		if err != nil {
+		if err != nil && !errors.Is(err, ErrWebhookDegraded) {
 			t.Fatalf("Emit %d returned error: %v", i, err)
 		}
 	}


### PR DESCRIPTION
## What changed

Two audit-sink delivery tests were non-deterministic: the sinks return a degraded advisory after an async delivery failure (the event is still queued and delivered, per the documented sink contract), but the tests treated that advisory as a fatal error, so they passed or failed depending on async scheduling. This accepts the degraded sentinel in the two affected tests so they assert the real behavior deterministically, and it fixes a related OTLP health bug where a successful send unconditionally cleared the degraded flag and could erase a concurrent queue-full drop, by adopting the same counter-snapshot guard the webhook sink already uses, plus a regression test.

## Why it is safe

Accepting the degraded sentinel does not mask a lost event: the sentinel is only returned from the successful-enqueue path, while a rejected event returns a distinct queue-full or closed error, and each test still asserts the real delivery outcome (attempt counts, received counts, and stats). The OTLP guard only clears degraded health when no newer failure, drop, or abandonment landed during the in-flight send, so health can no longer report recovery while a drop is unaccounted. The two previously-flaky tests pass 50 times under the race detector after the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery health tracking so successful exports no longer erase newer queue-drop or abandonment errors.
  * Preserved degraded status and the latest error when failures occur during an in-flight delivery.
  * Improved resilience when delivery operations encounter marshal or server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->