### PR TITLE
docs(anchor): publish anchor bundle v1 format spec and schema

### DIFF
--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -387,6 +387,11 @@ flight_recorder:
 `rekor_url` and `local_log` are mutually exclusive. The local backend exercises
 the same checkpoint, bundle, and marker flow but is not an independent witness.
 
+External systems can parse the emitted JSON using the experimental [Anchor
+Bundle v1 specification](../specs/anchor-bundle-v1.md). The published shape is
+not an anchor-backend plugin API and does not make an external proof verifiable
+by `pipelock-verifier`.
+
 ## How the chain works
 
 Each receipt contains:

--- a/docs/specs/anchor-bundle-v1.md
+++ b/docs/specs/anchor-bundle-v1.md
@@ -1,0 +1,114 @@
+# Anchor Bundle v1
+
+`pipelock anchor receipts` verifies a signed receipt chain, builds a checkpoint,
+submits that checkpoint to the selected backend, and writes a machine-readable
+JSON bundle with `--out`. The published schema is
+[`sdk/anchor-bundle/v1.json`](../../sdk/anchor-bundle/v1.json), with a fully
+populated structural fixture at
+[`sdk/anchor-bundle/example.json`](../../sdk/anchor-bundle/example.json).
+
+## Stability status
+
+**Experimental compatibility notice:** This document and `v1.json` describe the
+anchor bundle emitted by current Pipelock builds when `version` is `1`. They are
+an interoperability snapshot, not a promise of long-term wire compatibility.
+Until this format is declared stable, Pipelock may revise v1 in place, including
+changes that break producers or consumers. Pin the exact Pipelock release or
+commit and the exact schema revision you build against, and test against a real
+bundle emitted by that build. Do not infer support for an anchor backend from
+this schema. No backward- or forward-compatibility guarantee is made yet.
+
+The real-checkpoint end-to-end test is the gate for declaring this format
+stable. Publishing the current shape does not make that stability claim.
+
+## Field reference
+
+All objects reject unknown fields when Pipelock loads a bundle. JSON numbers
+used by `final_seq`, `receipt_count`, `log_index`, and `tree_size` are Go
+`uint64` values; consumers must preserve integer precision across the full
+unsigned 64-bit range.
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `version` | integer | Bundle format version. v1 is exactly `1`. |
+| `backend` | string | Backend identifier copied from `proof.backend`. Pipelock verification requires the two values to match. A name here is not proof that the running Pipelock binary supports that backend. |
+| `created_at` | RFC 3339 timestamp | Bundle assembly time from the Pipelock process clock. It is not a trusted or independently witnessed timestamp. |
+| `checkpoint` | object | Receipt-chain checkpoint covered by the backend proof. |
+| `proof` | object | Generic proof coordinates plus optional built-in-backend material. |
+| `limits` | string array | Human-readable limitations emitted for the selected backend. Pipelock verification reports canonical built-in limits and does not trust claims inserted into this array. |
+
+### `checkpoint`
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `session_id` | string | Receipt-chain session identifier. |
+| `final_seq` | uint64 | Sequence number of the final covered receipt. |
+| `root_hash` | string | Lowercase hexadecimal SHA-256 hash of the final covered receipt. Because receipts are hash-linked, it commits to the covered prefix when the receipt chain verifies. |
+| `receipt_count` | uint64 | Number of receipts covered by the checkpoint. |
+| `start_time` | RFC 3339 timestamp | Timestamp signed into the first covered receipt. It is evidence from the receipt signer, not an independent wall-clock attestation. |
+| `end_time` | RFC 3339 timestamp | Timestamp signed into the final covered receipt. It has the same trust boundary as `start_time`. |
+| `signer_keys` | string array | Ordered, de-duplicated trusted Ed25519 public keys for the covered chain segments, encoded as lowercase hexadecimal. A relying party still has to establish that these are the expected keys. |
+
+### `proof`
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `backend` | string | Backend identifier. The verifier selects backend-specific proof semantics; the schema does not. |
+| `log_id` | string | Backend-defined log or witness identifier. |
+| `log_index` | uint64 | Backend-defined entry position. |
+| `entry_hash` | string | Backend-defined entry digest. Its algorithm and preimage are backend semantics. |
+| `log_root_hash` | string | Backend-defined log root or checkpoint digest. |
+| `rekor` | object, optional | Proof material emitted by the built-in Rekor backend. Other backend names do not gain a generic extension object in v1. |
+
+The generic fields are a common envelope, not a universal proof protocol. v1
+does not define a backend-neutral canonical serialization or digest for
+`checkpoint`. External witnesses must publish exactly which bytes or digest
+they anchor and how a verifier recomputes it.
+
+### `proof.rekor`
+
+This optional object documents the current built-in Rekor output. Its presence
+does not make the overall format Rekor-specific.
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `url` | URI | Explicit Rekor base URL used for submission. |
+| `uuid` | string | Rekor entry UUID. |
+| `body` | base64 string | Encoded Rekor entry body. The body contains a digest of the checkpoint, not plaintext checkpoint fields. |
+| `public_key` | string | PEM public key paired with the Rekor entry signature. |
+| `signature` | base64 string | Signature over the Rekor checkpoint digest. |
+| `integrated_time` | int64 | Rekor integrated time in Unix seconds. It is backend evidence, not `created_at`. |
+| `signed_entry_timestamp` | base64 string | Rekor Signed Entry Timestamp. |
+| `inclusion_proof` | object | Merkle inclusion material returned by Rekor. |
+
+### `proof.rekor.inclusion_proof`
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `root_hash` | hexadecimal string | Merkle-tree root. Rekor verification requires it to match `proof.log_root_hash`. |
+| `log_index` | uint64 | Included entry index. Rekor verification requires it to match `proof.log_index`. |
+| `tree_size` | uint64 | Size of the tree covered by the proof. |
+| `hashes` | string array | Merkle audit-path hashes. |
+| `checkpoint` | string | Signed Rekor checkpoint text. |
+
+## What verification proves
+
+Schema validation proves only that a document has the expected JSON shape. A
+valid anchor verification additionally requires:
+
+1. the receipt chain to verify under keys the relying party trusts;
+2. the recomputed receipt checkpoint to match `checkpoint`;
+3. top-level `backend` to match `proof.backend`; and
+4. the selected backend verifier to authenticate and validate the proof.
+
+Successful anchoring constrains undetected rewriting or omission after the
+anchored point. It does not prove that receipt timestamps are truthful, that the
+signer did not fabricate evidence before anchoring, that no conflicting
+checkpoint was also anchored, or that traffic outside Pipelock's mediated
+boundary did not happen.
+
+The local backend is deterministic development plumbing, not an
+operator-independent witness. Rekor verification requires a pinned log public
+key. An external chain, transparency log, or other witness can consume an
+emitted bundle without a Pipelock code change, but its proof remains external
+unless Pipelock gains explicit backend and verifier support for it.

--- a/internal/anchor/anchor_bundle_format_test.go
+++ b/internal/anchor/anchor_bundle_format_test.go
@@ -124,13 +124,51 @@ func TestAnchorBundleV1SchemaIntegerFieldsAreBounded(t *testing.T) {
 		{"rekor_inclusion_proof", "log_index", uint64Max},
 		{"rekor_inclusion_proof", "tree_size", uint64Max},
 	} {
-		prop, ok := schema.Defs[tc.def].Properties[tc.field]
-		if !ok {
-			t.Fatalf("schema $defs.%s.%s is missing", tc.def, tc.field)
+		t.Run(tc.def+"."+tc.field, func(t *testing.T) {
+			prop, ok := schema.Defs[tc.def].Properties[tc.field]
+			if !ok {
+				t.Fatalf("schema $defs.%s.%s is missing", tc.def, tc.field)
+			}
+			if got := prop.Maximum.String(); got != tc.max {
+				t.Fatalf("schema $defs.%s.%s maximum = %q, want %q", tc.def, tc.field, got, tc.max)
+			}
+		})
+	}
+}
+
+// TestAnchorBundleV1SchemaForbidsRekorOnNonRekorProof guards the proof
+// conditional: rekor material is Rekor-specific, so a non-Rekor proof (e.g. the
+// local backend) must not carry a rekor object. The spec states other backends
+// do not gain the extension object, and the schema must express that.
+func TestAnchorBundleV1SchemaForbidsRekorOnNonRekorProof(t *testing.T) {
+	data, err := os.ReadFile(filepath.Clean(anchorBundleSchemaPath))
+	if err != nil {
+		t.Fatalf("read anchor bundle schema: %v", err)
+	}
+	var schema struct {
+		Defs map[string]struct {
+			AllOf []struct {
+				Else struct {
+					Not struct {
+						Required []string `json:"required"`
+					} `json:"not"`
+				} `json:"else"`
+			} `json:"allOf"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("parse anchor bundle schema: %v", err)
+	}
+	forbidden := false
+	for _, cond := range schema.Defs["proof"].AllOf {
+		for _, req := range cond.Else.Not.Required {
+			if req == "rekor" {
+				forbidden = true
+			}
 		}
-		if got := prop.Maximum.String(); got != tc.max {
-			t.Fatalf("schema $defs.%s.%s maximum = %q, want %q", tc.def, tc.field, got, tc.max)
-		}
+	}
+	if !forbidden {
+		t.Fatal("proof schema must forbid the rekor property when backend is not rekor")
 	}
 }
 

--- a/internal/anchor/anchor_bundle_format_test.go
+++ b/internal/anchor/anchor_bundle_format_test.go
@@ -94,6 +94,46 @@ func assertJSONFieldsMatchSchema(t *testing.T, typ reflect.Type, properties map[
 	}
 }
 
+func TestAnchorBundleV1SchemaIntegerFieldsAreBounded(t *testing.T) {
+	data, err := os.ReadFile(filepath.Clean(anchorBundleSchemaPath))
+	if err != nil {
+		t.Fatalf("read anchor bundle schema: %v", err)
+	}
+	var schema struct {
+		Defs map[string]struct {
+			Properties map[string]struct {
+				Maximum json.Number `json:"maximum"`
+			} `json:"properties"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("parse anchor bundle schema: %v", err)
+	}
+	// Every published integer field must carry the Go decode bound so a future
+	// widening trips this guard instead of silently accepting values the runtime
+	// rejects. JSON numbers stay exact here because json.Number keeps the literal.
+	const (
+		uint64Max = "18446744073709551615"
+		int64Max  = "9223372036854775807"
+	)
+	for _, tc := range []struct{ def, field, max string }{
+		{"checkpoint", "final_seq", uint64Max},
+		{"checkpoint", "receipt_count", uint64Max},
+		{"proof", "log_index", uint64Max},
+		{"rekor_proof", "integrated_time", int64Max},
+		{"rekor_inclusion_proof", "log_index", uint64Max},
+		{"rekor_inclusion_proof", "tree_size", uint64Max},
+	} {
+		prop, ok := schema.Defs[tc.def].Properties[tc.field]
+		if !ok {
+			t.Fatalf("schema $defs.%s.%s is missing", tc.def, tc.field)
+		}
+		if got := prop.Maximum.String(); got != tc.max {
+			t.Fatalf("schema $defs.%s.%s maximum = %q, want %q", tc.def, tc.field, got, tc.max)
+		}
+	}
+}
+
 func goldenAnchorBundleV1() Bundle {
 	return Bundle{
 		Version:   BundleVersion,

--- a/internal/anchor/anchor_bundle_format_test.go
+++ b/internal/anchor/anchor_bundle_format_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package anchor
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+)
+
+const (
+	anchorBundleExamplePath = "../../sdk/anchor-bundle/example.json"
+	anchorBundleSchemaPath  = "../../sdk/anchor-bundle/v1.json"
+)
+
+func TestAnchorBundleV1Golden(t *testing.T) {
+	path := filepath.Clean(anchorBundleExamplePath)
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden anchor bundle: %v", err)
+	}
+
+	loaded, err := LoadBundleBytes(original)
+	if err != nil {
+		t.Fatalf("strict-load golden anchor bundle: %v", err)
+	}
+	want := goldenAnchorBundleV1()
+	if !reflect.DeepEqual(loaded, want) {
+		t.Fatal("golden anchor bundle drifted from the pinned v1 fixture values")
+	}
+
+	roundTrip, err := bundleBytes(loaded)
+	if err != nil {
+		t.Fatalf("marshal golden anchor bundle: %v", err)
+	}
+	if !bytes.Equal(roundTrip, original) {
+		t.Fatalf("golden anchor bundle did not byte-for-byte round-trip\nround-trip:\n%s\noriginal:\n%s", roundTrip, original)
+	}
+}
+
+func TestAnchorBundleV1SchemaTracksGoJSONFields(t *testing.T) {
+	data, err := os.ReadFile(filepath.Clean(anchorBundleSchemaPath))
+	if err != nil {
+		t.Fatalf("read anchor bundle schema: %v", err)
+	}
+	var schema struct {
+		ID         string                     `json:"$id"`
+		Properties map[string]json.RawMessage `json:"properties"`
+		Defs       map[string]struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("parse anchor bundle schema: %v", err)
+	}
+	if schema.ID != "https://pipelab.org/schemas/anchor-bundle-v1.schema.json" {
+		t.Fatalf("anchor bundle schema $id = %q", schema.ID)
+	}
+
+	assertJSONFieldsMatchSchema(t, reflect.TypeFor[Bundle](), schema.Properties)
+	assertJSONFieldsMatchSchema(t, reflect.TypeFor[Checkpoint](), schema.Defs["checkpoint"].Properties)
+	assertJSONFieldsMatchSchema(t, reflect.TypeFor[Proof](), schema.Defs["proof"].Properties)
+	assertJSONFieldsMatchSchema(t, reflect.TypeFor[RekorProof](), schema.Defs["rekor_proof"].Properties)
+	assertJSONFieldsMatchSchema(t, reflect.TypeFor[RekorInclusionProof](), schema.Defs["rekor_inclusion_proof"].Properties)
+}
+
+func assertJSONFieldsMatchSchema(t *testing.T, typ reflect.Type, properties map[string]json.RawMessage) {
+	t.Helper()
+	got := make([]string, 0, typ.NumField())
+	for i := range typ.NumField() {
+		name := typ.Field(i).Tag.Get("json")
+		if comma := bytes.IndexByte([]byte(name), ','); comma >= 0 {
+			name = name[:comma]
+		}
+		if name != "" && name != "-" {
+			got = append(got, name)
+		}
+	}
+	sort.Strings(got)
+
+	want := make([]string, 0, len(properties))
+	for name := range properties {
+		want = append(want, name)
+	}
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s JSON fields = %v, schema properties = %v", typ.Name(), got, want)
+	}
+}
+
+func goldenAnchorBundleV1() Bundle {
+	return Bundle{
+		Version:   BundleVersion,
+		Backend:   RekorBackend,
+		CreatedAt: time.Date(2026, 7, 23, 16, 30, 0, 0, time.UTC),
+		Checkpoint: Checkpoint{
+			SessionID:    "agent-a",
+			FinalSeq:     41,
+			RootHash:     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ReceiptCount: 42,
+			StartTime:    time.Date(2026, 7, 23, 16, 0, 0, 0, time.UTC),
+			EndTime:      time.Date(2026, 7, 23, 16, 29, 30, 0, time.UTC),
+			SignerKeys: []string{
+				"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			},
+		},
+		Proof: Proof{
+			Backend:     RekorBackend,
+			LogID:       "example-log-id",
+			LogIndex:    7,
+			EntryHash:   "1111111111111111111111111111111111111111111111111111111111111111",
+			LogRootHash: "2222222222222222222222222222222222222222222222222222222222222222",
+			Rekor: &RekorProof{
+				URL:                  "https://rekor.vendor.example",
+				UUID:                 "example-entry-uuid",
+				Body:                 "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIn0=",
+				PublicKey:            "-----BEGIN PUBLIC KEY-----\nZXhhbXBsZQ==\n-----END PUBLIC KEY-----\n",
+				Signature:            "ZXhhbXBsZS1zaWduYXR1cmU=",
+				IntegratedTime:       1784824200,
+				SignedEntryTimestamp: "ZXhhbXBsZS1zZXQ=",
+				InclusionProof: &RekorInclusionProof{
+					RootHash: "2222222222222222222222222222222222222222222222222222222222222222",
+					LogIndex: 7,
+					TreeSize: 8,
+					Hashes: []string{
+						"3333333333333333333333333333333333333333333333333333333333333333",
+					},
+					Checkpoint: "example-log.example - 8\nexample-checkpoint-signature\n",
+				},
+			},
+		},
+		Limits: []string{
+			"Rekor verification proves the checkpoint entry has a valid SET and inclusion proof under a pinned Rekor log key.",
+			"Rekor anchoring does not prove the checkpoint was witnessed before every later action unless the anchored checkpoint covers the whole receipt chain being verified.",
+			"Rekor anchoring does not prove the log remained globally consistent after the recorded checkpoint without a later consistency audit.",
+			"Anchoring does not prove real-time truth by whoever held the receipt signing key.",
+		},
+	}
+}

--- a/sdk/anchor-bundle/README.md
+++ b/sdk/anchor-bundle/README.md
@@ -1,0 +1,45 @@
+# Pipelock Anchor Bundle v1
+
+This directory publishes the JSON shape emitted by `pipelock anchor receipts
+--out`. It is for external witnesses, archival systems, and verifiers that need
+to parse a Pipelock-created checkpoint without importing Pipelock's internal Go
+package.
+
+| File | What it is |
+| --- | --- |
+| `v1.json` | JSON Schema draft 2020-12 description of the emitted v1 shape. |
+| `example.json` | Fully populated structural fixture. Its placeholder proof is not cryptographically valid. |
+
+## Stability status
+
+**Experimental compatibility notice:** This document and `v1.json` describe the
+anchor bundle emitted by current Pipelock builds when `version` is `1`. They are
+an interoperability snapshot, not a promise of long-term wire compatibility.
+Until this format is declared stable, Pipelock may revise v1 in place, including
+changes that break producers or consumers. Pin the exact Pipelock release or
+commit and the exact schema revision you build against, and test against a real
+bundle emitted by that build. Do not infer support for an anchor backend from
+this schema. No backward- or forward-compatibility guarantee is made yet.
+
+The real-checkpoint end-to-end test is the gate for declaring this format
+stable. Publishing the current shape does not make that stability claim.
+
+## Scope
+
+The schema describes JSON structure only. It does not:
+
+- verify the covered receipt chain or its signer keys;
+- prove that receipt timestamps or `created_at` are truthful;
+- verify backend signatures, inclusion, consistency, or non-equivocation;
+- define a backend-neutral canonical checkpoint digest;
+- provide an anchor-backend plugin API; or
+- make `example.json` valid cryptographic evidence.
+
+An external witness must state exactly which bytes or digest it anchors and how
+that value is verified. Consuming this JSON does not make the witness a
+Pipelock-supported backend and does not make its proof verifiable by
+`pipelock-verifier`.
+
+See [the field and verification
+specification](../../docs/specs/anchor-bundle-v1.md) for the complete field
+table and trust boundaries.

--- a/sdk/anchor-bundle/example.json
+++ b/sdk/anchor-bundle/example.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "backend": "rekor",
+  "created_at": "2026-07-23T16:30:00Z",
+  "checkpoint": {
+    "session_id": "agent-a",
+    "final_seq": 41,
+    "root_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "receipt_count": 42,
+    "start_time": "2026-07-23T16:00:00Z",
+    "end_time": "2026-07-23T16:29:30Z",
+    "signer_keys": [
+      "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    ]
+  },
+  "proof": {
+    "backend": "rekor",
+    "log_id": "example-log-id",
+    "log_index": 7,
+    "entry_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+    "log_root_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+    "rekor": {
+      "url": "https://rekor.vendor.example",
+      "uuid": "example-entry-uuid",
+      "body": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIn0=",
+      "public_key": "-----BEGIN PUBLIC KEY-----\nZXhhbXBsZQ==\n-----END PUBLIC KEY-----\n",
+      "signature": "ZXhhbXBsZS1zaWduYXR1cmU=",
+      "integrated_time": 1784824200,
+      "signed_entry_timestamp": "ZXhhbXBsZS1zZXQ=",
+      "inclusion_proof": {
+        "root_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+        "log_index": 7,
+        "tree_size": 8,
+        "hashes": [
+          "3333333333333333333333333333333333333333333333333333333333333333"
+        ],
+        "checkpoint": "example-log.example - 8\nexample-checkpoint-signature\n"
+      }
+    }
+  },
+  "limits": [
+    "Rekor verification proves the checkpoint entry has a valid SET and inclusion proof under a pinned Rekor log key.",
+    "Rekor anchoring does not prove the checkpoint was witnessed before every later action unless the anchored checkpoint covers the whole receipt chain being verified.",
+    "Rekor anchoring does not prove the log remained globally consistent after the recorded checkpoint without a later consistency audit.",
+    "Anchoring does not prove real-time truth by whoever held the receipt signing key."
+  ]
+}

--- a/sdk/anchor-bundle/v1.json
+++ b/sdk/anchor-bundle/v1.json
@@ -25,6 +25,7 @@
         "final_seq": {
           "type": "integer",
           "minimum": 0,
+          "maximum": 18446744073709551615,
           "description": "Final receipt sequence number in the verified chain."
         },
         "root_hash": {
@@ -35,6 +36,7 @@
         "receipt_count": {
           "type": "integer",
           "minimum": 1,
+          "maximum": 18446744073709551615,
           "description": "Number of receipts covered by the checkpoint."
         },
         "start_time": {
@@ -83,6 +85,7 @@
         "log_index": {
           "type": "integer",
           "minimum": 0,
+          "maximum": 18446744073709551615,
           "description": "Backend-defined entry position."
         },
         "entry_hash": {
@@ -162,6 +165,7 @@
         "integrated_time": {
           "type": "integer",
           "minimum": 1,
+          "maximum": 9223372036854775807,
           "description": "Rekor integrated time in Unix seconds. This is backend evidence, not the checkpoint creator's created_at value."
         },
         "signed_entry_timestamp": {
@@ -193,11 +197,13 @@
         "log_index": {
           "type": "integer",
           "minimum": 0,
+          "maximum": 18446744073709551615,
           "description": "Entry index covered by the inclusion proof."
         },
         "tree_size": {
           "type": "integer",
           "minimum": 1,
+          "maximum": 18446744073709551615,
           "description": "Merkle-tree size covered by the inclusion proof."
         },
         "hashes": {

--- a/sdk/anchor-bundle/v1.json
+++ b/sdk/anchor-bundle/v1.json
@@ -119,6 +119,13 @@
             "required": [
               "rekor"
             ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "rekor"
+              ]
+            }
           }
         }
       ]

--- a/sdk/anchor-bundle/v1.json
+++ b/sdk/anchor-bundle/v1.json
@@ -1,0 +1,308 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pipelab.org/schemas/anchor-bundle-v1.schema.json",
+  "title": "Pipelock Anchor Bundle v1",
+  "description": "Experimental snapshot of the version 1 anchor-bundle JSON emitted by Pipelock. This schema documents structure; it does not verify receipts, checkpoint truth, or backend proof semantics.",
+  "$defs": {
+    "checkpoint": {
+      "type": "object",
+      "required": [
+        "session_id",
+        "final_seq",
+        "root_hash",
+        "receipt_count",
+        "start_time",
+        "end_time",
+        "signer_keys"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "session_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Receipt-chain session identifier."
+        },
+        "final_seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Final receipt sequence number in the verified chain."
+        },
+        "root_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "Lowercase hexadecimal SHA-256 hash of the final receipt."
+        },
+        "receipt_count": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of receipts covered by the checkpoint."
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp carried by the first covered receipt."
+        },
+        "end_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp carried by the final covered receipt."
+        },
+        "signer_keys": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "description": "Ordered, de-duplicated Ed25519 public keys trusted for the covered receipt-chain segments, encoded as lowercase hexadecimal."
+        }
+      }
+    },
+    "proof": {
+      "type": "object",
+      "required": [
+        "backend",
+        "log_id",
+        "log_index",
+        "entry_hash",
+        "log_root_hash"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "backend": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Backend identifier. Consumers must not infer backend support from this string alone."
+        },
+        "log_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Backend-defined log or witness identifier."
+        },
+        "log_index": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Backend-defined entry position."
+        },
+        "entry_hash": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Backend-defined entry digest."
+        },
+        "log_root_hash": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Backend-defined log root or checkpoint digest."
+        },
+        "rekor": {
+          "$ref": "#/$defs/rekor_proof",
+          "description": "Optional proof material emitted by the built-in Rekor backend."
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "backend": {
+                "const": "rekor"
+              }
+            },
+            "required": [
+              "backend"
+            ]
+          },
+          "then": {
+            "required": [
+              "rekor"
+            ]
+          }
+        }
+      ]
+    },
+    "rekor_proof": {
+      "type": "object",
+      "required": [
+        "url",
+        "uuid",
+        "body",
+        "public_key",
+        "signature",
+        "integrated_time",
+        "signed_entry_timestamp",
+        "inclusion_proof"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Configured Rekor base URL."
+        },
+        "uuid": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Rekor entry UUID."
+        },
+        "body": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Base64-encoded Rekor entry body."
+        },
+        "public_key": {
+          "type": "string",
+          "minLength": 1,
+          "description": "PEM-encoded public key for the Rekor entry signature."
+        },
+        "signature": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Base64-encoded signature over the checkpoint digest."
+        },
+        "integrated_time": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Rekor integrated time in Unix seconds. This is backend evidence, not the checkpoint creator's created_at value."
+        },
+        "signed_entry_timestamp": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Base64-encoded Rekor Signed Entry Timestamp."
+        },
+        "inclusion_proof": {
+          "$ref": "#/$defs/rekor_inclusion_proof"
+        }
+      }
+    },
+    "rekor_inclusion_proof": {
+      "type": "object",
+      "required": [
+        "root_hash",
+        "log_index",
+        "tree_size",
+        "hashes",
+        "checkpoint"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "root_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$",
+          "description": "Rekor Merkle-tree root hash."
+        },
+        "log_index": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Entry index covered by the inclusion proof."
+        },
+        "tree_size": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Merkle-tree size covered by the inclusion proof."
+        },
+        "hashes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$"
+          },
+          "description": "Merkle audit-path hashes."
+        },
+        "checkpoint": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Signed Rekor checkpoint text."
+        }
+      }
+    }
+  },
+  "type": "object",
+  "required": [
+    "version",
+    "backend",
+    "created_at",
+    "checkpoint",
+    "proof",
+    "limits"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "const": 1,
+      "description": "Anchor-bundle format version."
+    },
+    "backend": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Backend identifier. Pipelock verification also requires this value to equal proof.backend."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Bundle assembly time from the Pipelock process clock. It is not a trusted or independently witnessed timestamp."
+    },
+    "checkpoint": {
+      "$ref": "#/$defs/checkpoint"
+    },
+    "proof": {
+      "$ref": "#/$defs/proof"
+    },
+    "limits": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Human-readable limitations emitted for the selected backend. Verifiers use canonical built-in limits rather than trusting this array."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "backend": {
+            "const": "local"
+          }
+        },
+        "required": [
+          "backend"
+        ]
+      },
+      "then": {
+        "properties": {
+          "proof": {
+            "properties": {
+              "backend": {
+                "const": "local"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "backend": {
+            "const": "rekor"
+          }
+        },
+        "required": [
+          "backend"
+        ]
+      },
+      "then": {
+        "properties": {
+          "proof": {
+            "properties": {
+              "backend": {
+                "const": "rekor"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
`pipelock anchor receipts` already emits a versioned JSON bundle, but the shape was never documented, so anything consuming it had to read the Go structs and guess. This publishes it.

Adds a field-level spec at docs/specs/anchor-bundle-v1.md, a Draft 2020-12 JSON Schema plus a structural fixture under sdk/anchor-bundle/, and a Go test that fails if the schema and the Go structs drift apart or the fixture stops round-tripping. Follows the existing audit-packet publishing pattern.

The spec is explicitly experimental: an interoperability snapshot, not a wire-compatibility guarantee. Consumers are told to pin the Pipelock version they build against. The doc is honest about what anchoring proves (inclusion and no post-anchor tampering) and what it does not (truthful timestamps, no pre-anchor fabrication, complete coverage). No anchor behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the “Anchor Bundle v1” specification with a field-by-field schema, experimental compatibility stance, and explicit verification scope/limitations.
  * Clarified receipt verification guidance on parsing “Anchor Bundle v1” output and noted the published JSON is not a backend plugin API.
  * Added an SDK README, plus the v1 JSON schema and a complete example bundle.
* **Tests**
  * Expanded Anchor Bundle v1 conformance checks with a byte-stable golden round-trip, schema-to-field alignment, stricter numeric bounds, and backend-specific validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->