### PR TITLE
fix(contain): fail-closed containment self-test integrity

### DIFF
--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -134,7 +134,7 @@ pipelock contain verify
 | 5 | `ca_bundle_present` | `/etc/pipelock/combined-ca.pem` is readable by the agent user. |
 | 6 | `pipelock_listening_loopback` | Pipelock is accepting connections on `127.0.0.1:<proxy-port>`. |
 | 7 | `no_proxy_env_correct` | `plk-launch` sets `NO_PROXY` to the loopback set documented in policy. |
-| 8 | `cc_agent_egress_denied` | A DNS-free direct outbound canary from `pipelock-agent` coincides with an increment in the exact managed catch-all nftables DROP counter. |
+| 8 | `cc_agent_egress_denied` | A DNS-free direct outbound canary from `pipelock-agent` reports that its TCP dial did not complete and coincides with an increment in the exact managed catch-all nftables DROP counter. |
 | 9 | `operator_egress_reachable` | The same canary from the operator user is allowed (proves the rule scopes correctly). |
 | 10 | `binary_integrity_pin` | The installed pipelock binary hash matches `/etc/pipelock/integrity/binary-pin.sha256`. |
 | 11 | `cc_launch_allow_list_enforced` | `plk-launch` rejects tools that are not in the registered allow-list. |
@@ -205,7 +205,7 @@ Checks:
 | 3 | `python_through_proxy` | `python` reaches an allowed host via the `pipelock-python` wrapper. |
 | 4 | `node_through_proxy` | node's `fetch()` reaches an allowed host via the `pipelock-node` wrapper + undici shim. |
 | 5 | `dns_failure_clean` | An unresolvable host fails fast with a clean proxy error — no hang, no bypass. |
-| 6 | `raw_egress_blocked` | A DNS-free direct, proxy-bypassing canary coincides with an increment in the managed catch-all DROP counter. This is also the root cause a proxy-unaware tool surfaces, so the remediation names the fix. |
+| 6 | `raw_egress_blocked` | A DNS-free direct, proxy-bypassing canary reports that its TCP dial did not complete and coincides with an increment in the managed catch-all DROP counter. This is also the root cause a proxy-unaware tool surfaces, so the remediation names the fix. |
 
 Checks print a one-line, class-tagged remediation when an operator action or compatibility note is useful; this can accompany either a non-passing result or a PASS that diagnoses expected containment behavior. For example, a proxy-unaware tool produces:
 

--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -118,7 +118,8 @@ The nftables step checks the installed `nft` version before generating rules. Th
 
 ## `pipelock contain verify`
 
-Verify is read-only. It walks 12 probes in order and prints pass / fail / skip per probe. It does not require root.
+Verify is read-only. It walks 12 probes in order and prints pass / fail / skip /
+unknown per probe. It does not require root.
 
 ```bash
 pipelock contain verify
@@ -133,7 +134,7 @@ pipelock contain verify
 | 5 | `ca_bundle_present` | `/etc/pipelock/combined-ca.pem` is readable by the agent user. |
 | 6 | `pipelock_listening_loopback` | Pipelock is accepting connections on `127.0.0.1:<proxy-port>`. |
 | 7 | `no_proxy_env_correct` | `plk-launch` sets `NO_PROXY` to the loopback set documented in policy. |
-| 8 | `cc_agent_egress_denied` | A direct outbound canary from `pipelock-agent` is blocked by nftables. |
+| 8 | `cc_agent_egress_denied` | A DNS-free direct outbound canary from `pipelock-agent` coincides with an increment in the exact managed catch-all nftables DROP counter. |
 | 9 | `operator_egress_reachable` | The same canary from the operator user is allowed (proves the rule scopes correctly). |
 | 10 | `binary_integrity_pin` | The installed pipelock binary hash matches `/etc/pipelock/integrity/binary-pin.sha256`. |
 | 11 | `cc_launch_allow_list_enforced` | `plk-launch` rejects tools that are not in the registered allow-list. |
@@ -146,7 +147,14 @@ Flags:
 | `--json` | false | Emit newline-delimited JSON records instead of text output. |
 | `--port` | `8888` | Loopback port to probe for the listener check (matches `--proxy-port` from install). |
 
-Exit code is 0 if every probe passed, 1 if any probe failed, and 2 if verification was incomplete because one or more probes skipped. Each failing probe prints a structured one-line detail so operators can dashboard the output.
+Exit code is 0 if every probe passed, 1 if any probe failed, and 2 if
+verification was incomplete because one or more probes skipped or were
+inconclusive (`unknown`). Probe 8 uses a literal TEST-NET IPv4 target and a
+two-second ceiling so DNS/TLS failures cannot produce a pass. Its managed
+counter is scoped to the contained UID rather than the individual curl process,
+so unrelated simultaneous traffic under that same UID can still contribute a
+counter increment; verify remains read-only and does not install a temporary
+probe-specific rule.
 
 ## Runtime contract
 
@@ -197,12 +205,12 @@ Checks:
 | 3 | `python_through_proxy` | `python` reaches an allowed host via the `pipelock-python` wrapper. |
 | 4 | `node_through_proxy` | node's `fetch()` reaches an allowed host via the `pipelock-node` wrapper + undici shim. |
 | 5 | `dns_failure_clean` | An unresolvable host fails fast with a clean proxy error — no hang, no bypass. |
-| 6 | `raw_egress_blocked` | Direct, proxy-bypassing egress from the agent is blocked. This is also the root cause a proxy-unaware tool surfaces, so the remediation names the fix. |
+| 6 | `raw_egress_blocked` | A DNS-free direct, proxy-bypassing canary coincides with an increment in the managed catch-all DROP counter. This is also the root cause a proxy-unaware tool surfaces, so the remediation names the fix. |
 
 Each non-passing check prints a one-line remediation tagged with its class. For example, a proxy-unaware tool produces:
 
 ```text
-  [PASS] check 6: direct (proxy-bypassing) egress is blocked for the agent — direct egress blocked at dial (curl exit 7); proxy-unaware tools fail here
+  [PASS] check 6: direct (proxy-bypassing) egress is blocked for the agent — direct egress blocked at managed nftables DROP (curl exit 7, counter 12 -> 13); proxy-unaware tools fail here
           ↳ [proxy-compat] a tool that 'can't reach the internet' is ignoring the proxy, NOT broken — run it via pipelock-curl / pipelock-python / pipelock-node, or export HTTPS_PROXY=http://127.0.0.1:8888
 ```
 
@@ -214,7 +222,10 @@ Flags:
 | `--port` | `8888` | Loopback proxy port to test (matches `--proxy-port` from install). |
 | `--url` | `https://example.com/` | Allowed canary URL the agent should be able to reach. |
 
-Exit code is 0 if every check passed, 1 if any check failed, and 2 if the diagnosis was incomplete because a check skipped (for example, not run as root, or a tool isn't installed). Checks that can't proceed skip with remediation rather than failing.
+Exit code is 0 if every check passed, 1 if any check failed, and 2 if the
+diagnosis was incomplete because a check skipped or was inconclusive. Missing
+tools skip; unattributable raw-egress failures report `unknown` rather than
+claiming containment.
 
 After the result summary, `doctor` prints the resolved evidence paths so operators know where to find audit logs and signed receipts:
 

--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -207,7 +207,7 @@ Checks:
 | 5 | `dns_failure_clean` | An unresolvable host fails fast with a clean proxy error — no hang, no bypass. |
 | 6 | `raw_egress_blocked` | A DNS-free direct, proxy-bypassing canary coincides with an increment in the managed catch-all DROP counter. This is also the root cause a proxy-unaware tool surfaces, so the remediation names the fix. |
 
-Each non-passing check prints a one-line remediation tagged with its class. For example, a proxy-unaware tool produces:
+Checks print a one-line, class-tagged remediation when an operator action or compatibility note is useful; this can accompany either a non-passing result or a PASS that diagnoses expected containment behavior. For example, a proxy-unaware tool produces:
 
 ```text
   [PASS] check 6: direct (proxy-bypassing) egress is blocked for the agent — direct egress blocked at managed nftables DROP (curl exit 7, counter 12 -> 13); proxy-unaware tools fail here

--- a/internal/cli/contain/conformance.go
+++ b/internal/cli/contain/conformance.go
@@ -13,8 +13,9 @@ import (
 // This file is the ONLY exported surface the containment-conformance
 // artifact under sdk/conformance/ depends on. It deliberately exposes the
 // minimum needed to drive the egress-containment probes (probe 8 / probe 9)
-// against a canned command-runner, with NO access to the real sudo/curl/nft
-// execution path and NO leak of the unexported probe/probeEnv internals.
+// against canned command and DROP-counter readers, with NO access to the real
+// sudo/curl/nft execution path and NO leak of the unexported probe/probeEnv
+// internals.
 //
 // DESIGN NOTE (why this shape):
 //   - The probe registry, probeEnv, and probeRecord types are unexported and
@@ -24,10 +25,10 @@ import (
 //   - The conformance artifact only needs to prove the DIRECT-EGRESS probes:
 //     probe 8 (pipelock-agent must NOT reach the internet directly) and
 //     probe 9 (the operator must still reach the internet). Those two probes
-//     depend solely on the injected command runner plus the agent/operator
-//     usernames — none of the filesystem/dialer/hasher seams.
-//   - So we export exactly one options struct (ConformanceEnv) carrying just an
-//     injected runner, and one driver (RunContainmentConformance) returning
+//     depend solely on the injected command and DROP-counter readers plus the
+//     agent/operator usernames — none of the filesystem/dialer/hasher seams.
+//   - So we export exactly one options struct (ConformanceEnv) carrying those
+//     two narrow readers, and one driver (RunContainmentConformance) returning
 //     exported result records plus the same aggregate exit code runVerify would
 //     produce for these probes. The sdk/conformance test imports this, drives it
 //     from JSON fixtures, and asserts per-probe status + exit code. This mirrors
@@ -40,6 +41,11 @@ import (
 // Fixtures map a (name, argv) invocation to a canned (stdout, exitCode).
 type ConformanceRunCommand func(ctx context.Context, name string, args ...string) (stdout string, exitCode int, err error)
 
+// ConformanceDropCounter is the canned managed nftables DROP-counter reader
+// used by the offline conformance harness. Probe 8 reads it immediately before
+// and after the canned curl invocation.
+type ConformanceDropCounter func(ctx context.Context) (uint64, error)
+
 // ConformanceEnv carries the minimal inputs the egress-containment probes need.
 // It is an options struct (not a long parameter list) so future conformance
 // knobs are added as fields, never as new positional arguments.
@@ -48,6 +54,10 @@ type ConformanceEnv struct {
 	// (RunContainmentConformance returns an error rather than silently
 	// passing, matching pipelock's fail-closed default).
 	RunCommand ConformanceRunCommand
+
+	// DropCounter is required for probe 8 to return PASS. A nil reader or a
+	// non-increasing sequence produces UNKNOWN/exit 2, matching live verify.
+	DropCounter ConformanceDropCounter
 
 	// AgentUser is the unprivileged agent account probe 8 must prove is
 	// blocked from direct egress. Defaults to the production agent user when
@@ -61,7 +71,7 @@ type ConformanceEnv struct {
 }
 
 // ConformanceProbeResult is one exported per-probe outcome. Status is one of
-// the canonical "pass" / "fail" / "skip" strings the verify command emits.
+// the canonical "pass" / "fail" / "skip" / "unknown" strings verify emits.
 type ConformanceProbeResult struct {
 	Probe  int    `json:"probe"`
 	Name   string `json:"name"`
@@ -72,16 +82,17 @@ type ConformanceProbeResult struct {
 // Exported status constants so the conformance artifact can assert against
 // them without re-declaring the unexported originals.
 const (
-	ConformanceStatusPass = statusPass
-	ConformanceStatusFail = statusFail
-	ConformanceStatusSkip = statusSkip
+	ConformanceStatusPass    = statusPass
+	ConformanceStatusFail    = statusFail
+	ConformanceStatusSkip    = statusSkip
+	ConformanceStatusUnknown = statusUnknown
 )
 
 // Exit codes mirror the verify command's aggregate contract:
 //
 //	0  every driven probe passed,
 //	1  at least one probe FAILED (containment is broken),
-//	2  no failures but at least one probe SKIPPED (incomplete verification).
+//	2  no failures but at least one probe SKIPPED or UNKNOWN (incomplete).
 //
 // These are re-exported from cliutil so callers (and the gate script) do not
 // have to import cliutil just to read the numbers.
@@ -103,11 +114,11 @@ const (
 // against the injected command runner in env, and returns the per-probe
 // results plus the aggregate exit code.
 //
-// The aggregate exit code follows the same fail > skip > pass precedence the
-// real `contain verify` driver uses (runVerify): a single FAIL yields exit 1
-// regardless of how many probes passed, because a broken containment boundary
-// is never offset by other green probes. This is the property the must-fail
-// "leaky-egress" fixture exercises.
+// The aggregate exit code follows the same fail > incomplete > pass precedence
+// the real `contain verify` driver uses (runVerify): a single FAIL yields exit 1
+// regardless of how many probes passed, while SKIP/UNKNOWN without a failure
+// yields exit 2. This is the property the must-fail "leaky-egress" fixture
+// exercises.
 //
 // A nil runner (misconfigured fixture) fails closed: the function returns a
 // non-nil error and the invalid exit code, never a silent pass.
@@ -127,6 +138,11 @@ func RunContainmentConformance(ctx context.Context, env ConformanceEnv) ([]Confo
 		operatorUser:  env.OperatorUser,
 		runCmd:        runCommand(env.RunCommand),
 	}
+	if env.DropCounter != nil {
+		internalEnv.dropCounter = func(ctx context.Context, _ *probeEnv) (uint64, error) {
+			return env.DropCounter(ctx)
+		}
+	}
 	if internalEnv.agentUserName == "" {
 		internalEnv.agentUserName = defaultAgentUser
 	}
@@ -138,7 +154,7 @@ func RunContainmentConformance(ctx context.Context, env ConformanceEnv) ([]Confo
 	}
 
 	results := make([]ConformanceProbeResult, 0, len(egressProbes))
-	var passN, failN, skipN int
+	var passN, failN, skipN, unknownN int
 	for _, p := range egressProbes {
 		status, detail := p.fn(ctx, internalEnv)
 		switch status {
@@ -148,6 +164,8 @@ func RunContainmentConformance(ctx context.Context, env ConformanceEnv) ([]Confo
 			failN++
 		case statusSkip:
 			skipN++
+		case statusUnknown:
+			unknownN++
 		default:
 			// Unknown status coerces to fail and carries the value forward,
 			// exactly as runVerify does. A probe must never vanish silently.
@@ -167,7 +185,7 @@ func RunContainmentConformance(ctx context.Context, env ConformanceEnv) ([]Confo
 	switch {
 	case failN > 0:
 		exitCode = ConformanceExitFail
-	case skipN > 0:
+	case skipN > 0 || unknownN > 0:
 		exitCode = ConformanceExitSkip
 	}
 	return results, exitCode, nil

--- a/internal/cli/contain/conformance_test.go
+++ b/internal/cli/contain/conformance_test.go
@@ -28,6 +28,18 @@ func conformanceRunner(probe8, probe9 cannedResp) ConformanceRunCommand {
 	}
 }
 
+func conformanceDropCounters(values ...uint64) ConformanceDropCounter {
+	next := 0
+	return func(context.Context) (uint64, error) {
+		if next >= len(values) {
+			return 0, errors.New("canned DROP counter exhausted")
+		}
+		value := values[next]
+		next++
+		return value, nil
+	}
+}
+
 func TestRunContainmentConformance_NilRunnerFailsClosed(t *testing.T) {
 	results, exit, err := RunContainmentConformance(context.Background(), ConformanceEnv{})
 	if err == nil {
@@ -51,17 +63,31 @@ func TestRunContainmentConformance_Outcomes(t *testing.T) {
 		probe8     cannedResp // sudo -u agent -- curl
 		probe9     cannedResp // curl (operator, empty user -> direct)
 		wantExit   int
+		dropCounts []uint64
 		wantStatus map[int]string // probe number -> expected status
 	}{
 		{
-			name:      "both_pass_nil_ctx_default_agent_user",
-			ctx:       nil, // exercises the ctx == nil default
-			agentUser: "",  // exercises the defaultAgentUser fallback
-			probe8:    cannedResp{out: "curl: (7) refused", code: blockedExit},
-			probe9:    cannedResp{out: "200", code: 0},
-			wantExit:  ConformanceExitOK,
+			name:       "both_pass_nil_ctx_default_agent_user",
+			ctx:        nil, // exercises the ctx == nil default
+			agentUser:  "",  // exercises the defaultAgentUser fallback
+			probe8:     cannedResp{out: "curl: (7) refused", code: blockedExit},
+			probe9:     cannedResp{out: "200", code: 0},
+			dropCounts: []uint64{12, 13},
+			wantExit:   ConformanceExitOK,
 			wantStatus: map[int]string{
 				8: ConformanceStatusPass,
+				9: ConformanceStatusPass,
+			},
+		},
+		{
+			name:      "blocked_curl_without_counter_is_unknown",
+			ctx:       context.Background(),
+			agentUser: "pipelock-agent",
+			probe8:    cannedResp{out: "curl: (7) refused", code: blockedExit},
+			probe9:    cannedResp{out: "200", code: 0},
+			wantExit:  ConformanceExitSkip,
+			wantStatus: map[int]string{
+				8: ConformanceStatusUnknown,
 				9: ConformanceStatusPass,
 			},
 		},
@@ -75,6 +101,30 @@ func TestRunContainmentConformance_Outcomes(t *testing.T) {
 			wantStatus: map[int]string{
 				8: ConformanceStatusFail,
 				9: ConformanceStatusPass,
+			},
+		},
+		{
+			name:      "agent_leak_overrides_operator_skip",
+			ctx:       context.Background(),
+			agentUser: "pipelock-agent",
+			probe8:    cannedResp{out: "200", code: 0},
+			probe9:    cannedResp{err: errors.New("curl unavailable")},
+			wantExit:  ConformanceExitFail,
+			wantStatus: map[int]string{
+				8: ConformanceStatusFail,
+				9: ConformanceStatusSkip,
+			},
+		},
+		{
+			name:      "operator_failure_overrides_unknown_agent_attribution",
+			ctx:       context.Background(),
+			agentUser: "pipelock-agent",
+			probe8:    cannedResp{out: "curl: (7) refused", code: blockedExit},
+			probe9:    cannedResp{out: "curl: (22) HTTP 500", code: 22},
+			wantExit:  ConformanceExitFail,
+			wantStatus: map[int]string{
+				8: ConformanceStatusUnknown,
+				9: ConformanceStatusFail,
 			},
 		},
 		{
@@ -96,6 +146,9 @@ func TestRunContainmentConformance_Outcomes(t *testing.T) {
 			env := ConformanceEnv{
 				RunCommand: conformanceRunner(tc.probe8, tc.probe9),
 				AgentUser:  tc.agentUser,
+			}
+			if tc.dropCounts != nil {
+				env.DropCounter = conformanceDropCounters(tc.dropCounts...)
 			}
 			results, exit, err := RunContainmentConformance(tc.ctx, env)
 			if err != nil {

--- a/internal/cli/contain/conformance_test.go
+++ b/internal/cli/contain/conformance_test.go
@@ -70,7 +70,7 @@ func TestRunContainmentConformance_Outcomes(t *testing.T) {
 			name:       "both_pass_nil_ctx_default_agent_user",
 			ctx:        nil, // exercises the ctx == nil default
 			agentUser:  "",  // exercises the defaultAgentUser fallback
-			probe8:     cannedResp{out: "curl: (7) refused", code: blockedExit},
+			probe8:     cannedResp{out: "curl: (7) refused\nPLK_TIME_CONNECT=0.000000\n000", code: blockedExit},
 			probe9:     cannedResp{out: "200", code: 0},
 			dropCounts: []uint64{12, 13},
 			wantExit:   ConformanceExitOK,
@@ -83,7 +83,7 @@ func TestRunContainmentConformance_Outcomes(t *testing.T) {
 			name:      "blocked_curl_without_counter_is_unknown",
 			ctx:       context.Background(),
 			agentUser: "pipelock-agent",
-			probe8:    cannedResp{out: "curl: (7) refused", code: blockedExit},
+			probe8:    cannedResp{out: "curl: (7) refused\nPLK_TIME_CONNECT=0.000000\n000", code: blockedExit},
 			probe9:    cannedResp{out: "200", code: 0},
 			wantExit:  ConformanceExitSkip,
 			wantStatus: map[int]string{
@@ -119,7 +119,7 @@ func TestRunContainmentConformance_Outcomes(t *testing.T) {
 			name:      "operator_failure_overrides_unknown_agent_attribution",
 			ctx:       context.Background(),
 			agentUser: "pipelock-agent",
-			probe8:    cannedResp{out: "curl: (7) refused", code: blockedExit},
+			probe8:    cannedResp{out: "curl: (7) refused\nPLK_TIME_CONNECT=0.000000\n000", code: blockedExit},
 			probe9:    cannedResp{out: "curl: (22) HTTP 500", code: 22},
 			wantExit:  ConformanceExitFail,
 			wantStatus: map[int]string{

--- a/internal/cli/contain/doctor.go
+++ b/internal/cli/contain/doctor.go
@@ -66,6 +66,8 @@ type doctorEnv struct {
 // wiring without spawning real processes or touching the network.
 var doctorEnvFactory = defaultDoctorEnv
 
+// defaultDoctorEnv builds the production doctor environment and its live
+// managed DROP-counter reader.
 func defaultDoctorEnv() *doctorEnv {
 	platform := detectContainPlatform(os.ReadFile, os.Stat, exec.LookPath)
 	counterEnv := defaultProbeEnv()
@@ -82,16 +84,24 @@ func defaultDoctorEnv() *doctorEnv {
 		readFile:       os.ReadFile,
 		stat:           os.Stat,
 	}
-	env.dropCounter = func(ctx context.Context) (uint64, error) {
-		// doctor flags are applied after the factory returns. Copy their live
-		// values into the verify environment on each read so a non-default
-		// installed proxy port is not mistaken for an unsafe loopback allow.
-		probe := doctorCounterProbeEnv(counterEnv, env)
-		return readContainmentDropCounter(ctx, &probe)
-	}
+	env.dropCounter = doctorDropCounterReader(counterEnv, env)
 	return env
 }
 
+// doctorDropCounterReader binds the verify counter reader to live doctor flag
+// values at each read, while retaining an injectable base environment for tests.
+func doctorDropCounterReader(base *probeEnv, env *doctorEnv) func(context.Context) (uint64, error) {
+	return func(ctx context.Context) (uint64, error) {
+		// doctor flags are applied after the factory returns. Copy their live
+		// values into the verify environment on each read so a non-default
+		// installed proxy port is not mistaken for an unsafe loopback allow.
+		probe := doctorCounterProbeEnv(base, env)
+		return probe.dropCounter(ctx, &probe)
+	}
+}
+
+// doctorCounterProbeEnv copies live doctor flag overrides into a probe
+// environment without mutating the shared defaults.
 func doctorCounterProbeEnv(base *probeEnv, env *doctorEnv) probeEnv {
 	probe := *base
 	probe.port = env.port
@@ -118,6 +128,7 @@ func skip(detail, remediation string) doctorResult {
 	return doctorResult{status: statusSkip, detail: detail, remediation: remediation}
 }
 
+// unknown returns an inconclusive result that must never count as a pass.
 func unknown(class, detail, remediation string) doctorResult {
 	return doctorResult{
 		status:      statusUnknown,
@@ -127,6 +138,7 @@ func unknown(class, detail, remediation string) doctorResult {
 	}
 }
 
+// unknownInfra returns an inconclusive infrastructure-attribution result.
 func unknownInfra(detail string) doctorResult {
 	return unknown(classInfra, detail, rawEgressAttributionRemediation)
 }
@@ -188,6 +200,8 @@ func (env *doctorEnv) curlProxyArgs(url string) []string {
 	return env.curlProxyArgsWithWriteOut(url, "%{http_code}")
 }
 
+// curlProxyArgsWithWriteOut builds the explicit proxy curl command with the
+// requested curl write-out signal.
 func (env *doctorEnv) curlProxyArgsWithWriteOut(url, writeOut string) []string {
 	curl := env.curlPath
 	if curl == "" {
@@ -366,6 +380,8 @@ func checkNodeThroughProxy(ctx context.Context, env *doctorEnv) doctorResult {
 // resolved or the agent bypassed the proxy).
 const dnsFailureHost = "pipelock-doctor-nonexistent.invalid"
 
+// checkDNSFailure proves an invalid hostname is rejected by the proxy rather
+// than succeeding, hanging, or failing without proxy attribution.
 func checkDNSFailure(ctx context.Context, env *doctorEnv) doctorResult {
 	// %{http_connect} is the proxy's CONNECT response. It gives this check a
 	// positive attribution signal: a 5xx proves Pipelock handled the request and
@@ -394,6 +410,7 @@ func checkDNSFailure(ctx context.Context, env *doctorEnv) doctorResult {
 		"confirm the proxy is healthy, then inspect Pipelock logs for the "+dnsFailureHost+" resolution failure")
 }
 
+// formatObservedHTTPCode renders a parsed status or an explicit parse failure.
 func formatObservedHTTPCode(code int, ok bool) string {
 	if !ok {
 		return "unparseable"
@@ -405,10 +422,13 @@ func formatObservedHTTPCode(code int, ok bool) string {
 // Check 6: raw-egress diagnostics
 // ---------------------------------------------------------------------------
 
+// curlDirectArgs builds the bounded DNS-free direct-egress probe.
 func (env *doctorEnv) curlDirectArgs() []string {
 	return curlDirectCanaryArgsFor(env.curlPath)
 }
 
+// checkRawEgressBlocked requires positive DROP-counter attribution before a
+// dial-level curl failure can pass; post-connect failures always fail closed.
 func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
 	var before uint64
 	var beforeErr error
@@ -432,6 +452,11 @@ func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
 		}
 		return fail(classInfra, detail,
 			"the nftables owner-match egress rule is missing or broken; run `pipelock contain verify` and re-install")
+	}
+	if isPostConnectCurlExit(code) {
+		return fail(classInfra,
+			fmt.Sprintf("CONTAINMENT HOLE: direct egress reached the network before curl failed (exit %d): %s", code, oneLine(out)),
+			"verify the nftables owner-match drop is present (`pipelock contain verify`); a post-connect error means the outbound dial escaped containment")
 	}
 
 	if env.dropCounter == nil {
@@ -469,6 +494,7 @@ type doctorOpts struct {
 	url        string
 }
 
+// doctorCmd builds the live containment-diagnostics command.
 func doctorCmd() *cobra.Command {
 	var opts doctorOpts
 
@@ -528,6 +554,8 @@ type doctorRecord struct {
 	Class       string `json:"class,omitempty"`
 }
 
+// runDoctor executes all checks, writes fail-closed output, and returns the
+// aggregate CLI exit contract.
 func runDoctor(cmd *cobra.Command, env *doctorEnv, opts doctorOpts) error {
 	ctx := cmd.Context()
 	if ctx == nil {

--- a/internal/cli/contain/doctor.go
+++ b/internal/cli/contain/doctor.go
@@ -453,34 +453,32 @@ func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
 		return fail(classInfra, detail,
 			"the nftables owner-match egress rule is missing or broken; run `pipelock contain verify` and re-install")
 	}
-	if isPostConnectCurlExit(code) {
+	outcome, after, afterErr := classifyDirectEgressAttribution(code, env.dropCounter != nil, before, beforeErr, func() (uint64, error) {
+		return env.dropCounter(ctx)
+	})
+	switch outcome {
+	case egressAttrFailPostConnect:
 		return fail(classInfra,
 			fmt.Sprintf("CONTAINMENT HOLE: direct egress reached the network before curl failed (exit %d): %s", code, oneLine(out)),
 			"verify the nftables owner-match drop is present (`pipelock contain verify`); a post-connect error means the outbound dial escaped containment")
-	}
-
-	if env.dropCounter == nil {
+	case egressAttrUnknownNoCounter:
 		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but no DROP counter reader is available; containment attribution is inconclusive", code))
-	}
-	after, afterErr := env.dropCounter(ctx)
-	if beforeErr != nil {
+	case egressAttrUnknownBeforeErr:
 		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but reading the DROP counter before the probe failed: %v", code, beforeErr))
-	}
-	if afterErr != nil {
+	case egressAttrUnknownAfterErr:
 		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but reading the DROP counter after the probe failed: %v", code, afterErr))
-	}
-	if after <= before {
+	case egressAttrUnknownNoDelta:
 		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but the managed DROP counter did not increase (%d -> %d)", code, before, after))
-	}
-	if !isDirectEgressBlockedCurlExit(code) {
+	case egressAttrUnknownUnexpectedExit:
 		return unknownInfra(fmt.Sprintf("direct egress curl failed with unexpected exit %d despite a counter delta; the DNS-free HTTP canary expected a connect refusal or timeout", code))
-	}
-	return doctorResult{
-		status: statusPass,
-		detail: fmt.Sprintf("direct egress blocked at managed nftables DROP (curl exit %d, counter %d -> %d); proxy-unaware tools fail here", code, before, after),
-		remediation: "a tool that 'can't reach the internet' is ignoring the proxy, NOT broken — " +
-			"run it via pipelock-curl / pipelock-python / pipelock-node, or export HTTPS_PROXY=" + proxyURLFor(env.port),
-		class: classProxyCompat,
+	default: // egressAttrPass
+		return doctorResult{
+			status: statusPass,
+			detail: fmt.Sprintf("direct egress blocked at managed nftables DROP (curl exit %d, counter %d -> %d); proxy-unaware tools fail here", code, before, after),
+			remediation: "a tool that 'can't reach the internet' is ignoring the proxy, NOT broken — " +
+				"run it via pipelock-curl / pipelock-python / pipelock-node, or export HTTPS_PROXY=" + proxyURLFor(env.port),
+			class: classProxyCompat,
+		}
 	}
 }
 

--- a/internal/cli/contain/doctor.go
+++ b/internal/cli/contain/doctor.go
@@ -471,7 +471,7 @@ func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
 		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but the managed DROP counter did not increase (%d -> %d)", code, before, after))
 	case egressAttrUnknownUnexpectedExit:
 		return unknownInfra(fmt.Sprintf("direct egress curl failed with unexpected exit %d despite a counter delta; the DNS-free HTTP canary expected a connect refusal or timeout", code))
-	default: // egressAttrPass
+	case egressAttrPass:
 		return doctorResult{
 			status: statusPass,
 			detail: fmt.Sprintf("direct egress blocked at managed nftables DROP (curl exit %d, counter %d -> %d); proxy-unaware tools fail here", code, before, after),
@@ -479,6 +479,9 @@ func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
 				"run it via pipelock-curl / pipelock-python / pipelock-node, or export HTTPS_PROXY=" + proxyURLFor(env.port),
 			class: classProxyCompat,
 		}
+	default:
+		// Fail closed: an unhandled attribution outcome must never claim PASS.
+		return unknownInfra(fmt.Sprintf("unexpected direct-egress attribution outcome %d (exit %d); refusing to claim containment", outcome, code))
 	}
 }
 

--- a/internal/cli/contain/doctor.go
+++ b/internal/cli/contain/doctor.go
@@ -31,7 +31,7 @@ import (
 //	local-context — Pipelock misclassified harmless local context
 //	infra         — infra protection tripped (DNS failure, gateway down)
 //
-// Each check reports pass/fail/skip plus an operator-readable remediation.
+// Each check reports pass/fail/skip/unknown plus an operator-readable remediation.
 const (
 	classNone        = ""
 	classPolicy      = "policy"
@@ -52,10 +52,13 @@ type doctorEnv struct {
 	canaryURL      string
 	curlPath       string
 
-	runCmd   runCommand
-	dialCtx  dialFunc
-	readFile func(path string) ([]byte, error)
-	stat     func(path string) (os.FileInfo, error)
+	runCmd runCommand
+	// dropCounter reads the same managed catch-all nftables counter used by
+	// contain verify. Nil means attribution is unavailable, never PASS.
+	dropCounter func(ctx context.Context) (uint64, error)
+	dialCtx     dialFunc
+	readFile    func(path string) ([]byte, error)
+	stat        func(path string) (os.FileInfo, error)
 }
 
 // doctorEnvFactory builds the live doctor environment. It is a package var so
@@ -65,7 +68,8 @@ var doctorEnvFactory = defaultDoctorEnv
 
 func defaultDoctorEnv() *doctorEnv {
 	platform := detectContainPlatform(os.ReadFile, os.Stat, exec.LookPath)
-	return &doctorEnv{
+	counterEnv := defaultProbeEnv()
+	env := &doctorEnv{
 		port:           defaultProxyPort,
 		agentUserName:  defaultAgentUser,
 		wrapperDir:     defaultWrapperDir,
@@ -78,6 +82,21 @@ func defaultDoctorEnv() *doctorEnv {
 		readFile:       os.ReadFile,
 		stat:           os.Stat,
 	}
+	env.dropCounter = func(ctx context.Context) (uint64, error) {
+		// doctor flags are applied after the factory returns. Copy their live
+		// values into the verify environment on each read so a non-default
+		// installed proxy port is not mistaken for an unsafe loopback allow.
+		probe := doctorCounterProbeEnv(counterEnv, env)
+		return readContainmentDropCounter(ctx, &probe)
+	}
+	return env
+}
+
+func doctorCounterProbeEnv(base *probeEnv, env *doctorEnv) probeEnv {
+	probe := *base
+	probe.port = env.port
+	probe.agentUserName = env.agentUserName
+	return probe
 }
 
 // doctorResult is one check outcome. remediation is the operator's next step
@@ -97,6 +116,19 @@ func fail(class, detail, remediation string) doctorResult {
 
 func skip(detail, remediation string) doctorResult {
 	return doctorResult{status: statusSkip, detail: detail, remediation: remediation}
+}
+
+func unknown(class, detail, remediation string) doctorResult {
+	return doctorResult{
+		status:      statusUnknown,
+		detail:      detail,
+		remediation: remediation,
+		class:       class,
+	}
+}
+
+func unknownInfra(detail string) doctorResult {
+	return unknown(classInfra, detail, rawEgressAttributionRemediation)
 }
 
 type doctorCheck struct {
@@ -125,6 +157,8 @@ const remediationRunAsRoot = "re-run as root: sudo pipelock contain doctor"
 
 const remediationInstall = "run `pipelock contain install` first"
 
+const rawEgressAttributionRemediation = "verify the managed nftables owner-match DROP counter is readable and increasing (`pipelock contain verify`)"
+
 // sudoAgent prefixes a command so it runs as the contained agent. doctor is an
 // operator/root diagnostic; root can sudo to the agent without a password.
 func (env *doctorEnv) sudoAgent(args ...string) (string, []string) {
@@ -151,6 +185,10 @@ func classifyAgentRun(out string, err error, tool string) (doctorResult, bool) {
 // --proxy/--cacert (rather than relying on env) makes the check definitive:
 // success means the proxy + CA path itself works, independent of env plumbing.
 func (env *doctorEnv) curlProxyArgs(url string) []string {
+	return env.curlProxyArgsWithWriteOut(url, "%{http_code}")
+}
+
+func (env *doctorEnv) curlProxyArgsWithWriteOut(url, writeOut string) []string {
 	curl := env.curlPath
 	if curl == "" {
 		curl = defaultCurlPath
@@ -163,7 +201,7 @@ func (env *doctorEnv) curlProxyArgs(url string) []string {
 		"--max-time", curlMaxTime,
 		"-sS",
 		"-o", "/dev/null",
-		"-w", "%{http_code}",
+		"-w", writeOut,
 		url,
 	}
 }
@@ -329,7 +367,11 @@ func checkNodeThroughProxy(ctx context.Context, env *doctorEnv) doctorResult {
 const dnsFailureHost = "pipelock-doctor-nonexistent.invalid"
 
 func checkDNSFailure(ctx context.Context, env *doctorEnv) doctorResult {
-	name, args := env.sudoAgent(env.curlProxyArgs("https://" + dnsFailureHost + "/")...)
+	// %{http_connect} is the proxy's CONNECT response. It gives this check a
+	// positive attribution signal: a 5xx proves Pipelock handled the request and
+	// rejected the unresolvable target. A bare nonzero curl exit could instead be
+	// a dead proxy, TLS failure, or unrelated transport error.
+	name, args := env.sudoAgent(env.curlProxyArgsWithWriteOut("https://"+dnsFailureHost+"/", "%{http_connect}")...)
 	out, code, err := env.runCmd(ctx, name, args...)
 	if res, done := classifyAgentRun(out, err, "curl"); done {
 		return res
@@ -337,46 +379,44 @@ func checkDNSFailure(ctx context.Context, env *doctorEnv) doctorResult {
 	if isSudoTargetCommandMissing(out) {
 		return skip("curl not available for the agent", "install curl on the host")
 	}
-	// curl returning non-zero (proxy CONNECT failure) is the clean,
-	// fast-failure path.
-	if code != 0 {
-		return pass(fmt.Sprintf("unresolvable host failed cleanly (curl exit %d), no hang", code))
+	connectCode, ok := trailingHTTPCode(out)
+	if code != 0 && ok && connectCode >= 500 && connectCode < 600 {
+		return pass(fmt.Sprintf("proxy CONNECT returned HTTP %d for the unresolvable host (curl exit %d, clean failure)", connectCode, code))
 	}
-	httpCode, ok := trailingHTTPCode(out)
-	if ok && httpCode >= 500 {
-		return pass(fmt.Sprintf("proxy returned a %d error for the unresolvable host (clean failure)", httpCode))
-	}
-	if ok && is2xx3xx(httpCode) {
+	if code == 0 && ok && connectCode == 200 {
 		return fail(classInfra,
-			fmt.Sprintf("an unresolvable host returned HTTP %d — a bogus name resolved or egress bypassed the proxy", httpCode),
+			fmt.Sprintf("an unresolvable host completed proxy CONNECT with HTTP %d — a bogus name resolved or DNS was intercepted", connectCode),
 			"investigate DNS interception / captive portal; the agent should never reach "+dnsFailureHost)
 	}
-	return pass(fmt.Sprintf("unresolvable host produced a non-success response: %s", oneLine(out)))
+	return unknown(classInfra,
+		fmt.Sprintf("DNS-failure probe was inconclusive (curl exit %d, proxy CONNECT status %s): %s",
+			code, formatObservedHTTPCode(connectCode, ok), oneLine(out)),
+		"confirm the proxy is healthy, then inspect Pipelock logs for the "+dnsFailureHost+" resolution failure")
+}
+
+func formatObservedHTTPCode(code int, ok bool) string {
+	if !ok {
+		return "unparseable"
+	}
+	return strconv.Itoa(code)
 }
 
 // ---------------------------------------------------------------------------
 // Check 6: raw-egress diagnostics
 // ---------------------------------------------------------------------------
 
-func (env *doctorEnv) curlDirectArgs(url string) []string {
-	curl := env.curlPath
-	if curl == "" {
-		curl = defaultCurlPath
-	}
-	return []string{
-		curl,
-		"--connect-timeout", curlConnectTimeout,
-		"--max-time", curlMaxTime,
-		"--noproxy", "*",
-		"-sS",
-		"-o", "/dev/null",
-		"-w", "%{http_code}",
-		url,
-	}
+func (env *doctorEnv) curlDirectArgs() []string {
+	return curlDirectCanaryArgsFor(env.curlPath)
 }
 
 func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
-	name, args := env.sudoAgent(env.curlDirectArgs(env.canaryURL)...)
+	var before uint64
+	var beforeErr error
+	if env.dropCounter != nil {
+		before, beforeErr = env.dropCounter(ctx)
+	}
+
+	name, args := env.sudoAgent(env.curlDirectArgs()...)
 	out, code, err := env.runCmd(ctx, name, args...)
 	if res, done := classifyAgentRun(out, err, "curl"); done {
 		return res
@@ -384,44 +424,40 @@ func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
 	if isSudoTargetCommandMissing(out) {
 		return skip("curl not available for the agent", "install curl on the host")
 	}
-	// Fail closed: only an exit code that proves the local dial or DNS was
-	// refused counts as "blocked." Exit 0 means the agent got an HTTP response
-	// (egress succeeded), and a post-connect failure (TLS error, etc.) means
-	// the TCP connection was established — both are holes, not a clean block.
-	if isDialBlockedCurlExit(code) {
-		return doctorResult{
-			status: statusPass,
-			detail: fmt.Sprintf("direct egress blocked at dial (curl exit %d); proxy-unaware tools fail here", code),
-			remediation: "a tool that 'can't reach the internet' is ignoring the proxy, NOT broken — " +
-				"run it via pipelock-curl / pipelock-python / pipelock-node, or export HTTPS_PROXY=" + proxyURLFor(env.port),
-			class: classProxyCompat,
-		}
-	}
 	if code == 0 {
 		httpCode, ok := trailingHTTPCode(out)
 		detail := "agent completed a direct HTTP request, bypassing the proxy"
 		if ok {
-			detail = fmt.Sprintf("CONTAINMENT HOLE: agent reached %s directly (HTTP %d), bypassing the proxy", env.canaryURL, httpCode)
+			detail = fmt.Sprintf("CONTAINMENT HOLE: agent reached %s directly (HTTP %d), bypassing the proxy", directEgressCanaryURL, httpCode)
 		}
 		return fail(classInfra, detail,
 			"the nftables owner-match egress rule is missing or broken; run `pipelock contain verify` and re-install")
 	}
-	// Non-zero, but not a dial-level refusal: the connection likely
-	// established before failing (e.g. a TLS error), so egress was NOT blocked.
-	// Do not claim PASS — surface it as an inconclusive hole.
-	return fail(classInfra,
-		fmt.Sprintf("direct egress was not cleanly blocked (curl exit %d): the connection may have reached the host before failing: %s", code, oneLine(out)),
-		"verify the nftables owner-match drop is present (`pipelock contain verify`); a TLS/post-connect error here means the TCP dial was not blocked")
+
+	if env.dropCounter == nil {
+		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but no DROP counter reader is available; containment attribution is inconclusive", code))
+	}
+	after, afterErr := env.dropCounter(ctx)
+	if beforeErr != nil {
+		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but reading the DROP counter before the probe failed: %v", code, beforeErr))
+	}
+	if afterErr != nil {
+		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but reading the DROP counter after the probe failed: %v", code, afterErr))
+	}
+	if after <= before {
+		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but the managed DROP counter did not increase (%d -> %d)", code, before, after))
+	}
+	if !isDirectEgressBlockedCurlExit(code) {
+		return unknownInfra(fmt.Sprintf("direct egress curl failed with unexpected exit %d despite a counter delta; the DNS-free HTTP canary expected a connect refusal or timeout", code))
+	}
+	return doctorResult{
+		status: statusPass,
+		detail: fmt.Sprintf("direct egress blocked at managed nftables DROP (curl exit %d, counter %d -> %d); proxy-unaware tools fail here", code, before, after),
+		remediation: "a tool that 'can't reach the internet' is ignoring the proxy, NOT broken — " +
+			"run it via pipelock-curl / pipelock-python / pipelock-node, or export HTTPS_PROXY=" + proxyURLFor(env.port),
+		class: classProxyCompat,
+	}
 }
-
-// dialBlockedCurlExitCodes are the curl exit codes that prove the agent's
-// outbound dial or DNS resolution was refused (the nftables owner-match drop
-// working): 6 (couldn't resolve host), 7 (couldn't connect), 28 (operation
-// timed out — a silently dropped SYN). Any other outcome means the connection
-// got further, so it must not be read as a blocked dial.
-var dialBlockedCurlExitCodes = map[int]bool{6: true, 7: true, 28: true}
-
-func isDialBlockedCurlExit(code int) bool { return dialBlockedCurlExitCodes[code] }
 
 // ---------------------------------------------------------------------------
 // Command wiring + runner
@@ -458,7 +494,7 @@ mutates state. Run it as root (it sudoes to the agent for the live probes).
 Exit codes:
   0  All checks passed.
   1  At least one check failed.
-  2  Incomplete (a check was skipped — e.g. not run as root, tool missing).`,
+  2  Incomplete (a check was skipped or inconclusive).`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
@@ -499,13 +535,21 @@ func runDoctor(cmd *cobra.Command, env *doctorEnv, opts doctorOpts) error {
 	}
 
 	w := cmd.OutOrStdout()
+	var textWriter *errorTrackingWriter
+	if !opts.jsonOutput {
+		textWriter = &errorTrackingWriter{w: w}
+		w = textWriter
+	}
 	enc := json.NewEncoder(w)
 
 	if !opts.jsonOutput {
 		_, _ = fmt.Fprintln(w, "pipelock contain doctor")
+		if err := textWriter.Err(); err != nil {
+			return fmt.Errorf("writing doctor header: %w", err)
+		}
 	}
 
-	var passN, failN, skipN int
+	var passN, failN, skipN, unknownN int
 	for _, c := range allDoctorChecks() {
 		res := c.fn(ctx, env)
 		switch res.status {
@@ -515,6 +559,8 @@ func runDoctor(cmd *cobra.Command, env *doctorEnv, opts doctorOpts) error {
 			failN++
 		case statusSkip:
 			skipN++
+		case statusUnknown:
+			unknownN++
 		default:
 			failN++
 			res.detail = fmt.Sprintf("invalid status %q (detail: %s)", res.status, res.detail)
@@ -535,13 +581,16 @@ func runDoctor(cmd *cobra.Command, env *doctorEnv, opts doctorOpts) error {
 			continue
 		}
 		writeDoctorLine(w, c, res)
+		if err := textWriter.Err(); err != nil {
+			return fmt.Errorf("writing check %d text: %w", c.n, err)
+		}
 	}
 
 	exitCode := cliutil.ExitOK
 	switch {
 	case failN > 0:
 		exitCode = cliutil.ExitGeneral
-	case skipN > 0:
+	case skipN > 0 || unknownN > 0:
 		exitCode = cliutil.ExitConfig
 	}
 
@@ -550,14 +599,22 @@ func runDoctor(cmd *cobra.Command, env *doctorEnv, opts doctorOpts) error {
 			Pass:     passN,
 			Fail:     failN,
 			Skip:     skipN,
+			Unknown:  unknownN,
 			Total:    len(allDoctorChecks()),
 			ExitCode: exitCode,
 		}}); err != nil {
 			return fmt.Errorf("encoding aggregate JSON: %w", err)
 		}
 	} else {
-		_, _ = fmt.Fprintf(w, "Result: %d PASS / %d FAIL / %d SKIP — exit %d\n", passN, failN, skipN, exitCode)
+		if unknownN > 0 {
+			_, _ = fmt.Fprintf(w, "Result: %d PASS / %d FAIL / %d SKIP / %d UNKNOWN — exit %d\n", passN, failN, skipN, unknownN, exitCode)
+		} else {
+			_, _ = fmt.Fprintf(w, "Result: %d PASS / %d FAIL / %d SKIP — exit %d\n", passN, failN, skipN, exitCode)
+		}
 		printEvidencePaths(w)
+		if err := textWriter.Err(); err != nil {
+			return fmt.Errorf("writing doctor aggregate: %w", err)
+		}
 	}
 
 	if exitCode == cliutil.ExitOK {
@@ -565,6 +622,9 @@ func runDoctor(cmd *cobra.Command, env *doctorEnv, opts doctorOpts) error {
 	}
 	if failN > 0 {
 		return cliutil.ExitCodeError(exitCode, fmt.Errorf("%d check(s) failed", failN))
+	}
+	if unknownN > 0 {
+		return cliutil.ExitCodeError(exitCode, fmt.Errorf("%d check(s) inconclusive; diagnosis incomplete", unknownN))
 	}
 	return cliutil.ExitCodeError(exitCode, fmt.Errorf("%d check(s) skipped; diagnosis incomplete", skipN))
 }
@@ -578,6 +638,8 @@ func writeDoctorLine(w io.Writer, c doctorCheck, res doctorResult) {
 		tag = "[FAIL]"
 	case statusSkip:
 		tag = "[SKIP]"
+	case statusUnknown:
+		tag = "[UNKNOWN]"
 	}
 	line := fmt.Sprintf("  %s check %d: %s", tag, c.n, c.desc)
 	if res.detail != "" {

--- a/internal/cli/contain/doctor.go
+++ b/internal/cli/contain/doctor.go
@@ -427,8 +427,9 @@ func (env *doctorEnv) curlDirectArgs() []string {
 	return curlDirectCanaryArgsFor(env.curlPath)
 }
 
-// checkRawEgressBlocked requires positive DROP-counter attribution before a
-// dial-level curl failure can pass; post-connect failures always fail closed.
+// checkRawEgressBlocked requires probe-specific time_connect evidence plus a
+// positive DROP-counter delta before a dial-level curl failure can pass;
+// completed dials and post-connect failures always fail closed.
 func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
 	var before uint64
 	var beforeErr error
@@ -453,7 +454,8 @@ func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
 		return fail(classInfra, detail,
 			"the nftables owner-match egress rule is missing or broken; run `pipelock contain verify` and re-install")
 	}
-	outcome, after, afterErr := classifyDirectEgressAttribution(code, env.dropCounter != nil, before, beforeErr, func() (uint64, error) {
+	dialCompletion := parseDirectCurlDialCompletion(out)
+	outcome, after, afterErr := classifyDirectEgressAttribution(code, dialCompletion, env.dropCounter != nil, before, beforeErr, func() (uint64, error) {
 		return env.dropCounter(ctx)
 	})
 	switch outcome {
@@ -461,6 +463,8 @@ func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
 		return fail(classInfra,
 			fmt.Sprintf("CONTAINMENT HOLE: direct egress reached the network before curl failed (exit %d): %s", code, oneLine(out)),
 			"verify the nftables owner-match drop is present (`pipelock contain verify`); a post-connect error means the outbound dial escaped containment")
+	case egressAttrUnknownDialCompletion:
+		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but probe-specific time_connect was missing or unparseable; refusing to claim containment", code))
 	case egressAttrUnknownNoCounter:
 		return unknownInfra(fmt.Sprintf("direct egress curl failed (exit %d), but no DROP counter reader is available; containment attribution is inconclusive", code))
 	case egressAttrUnknownBeforeErr:
@@ -474,7 +478,7 @@ func checkRawEgressBlocked(ctx context.Context, env *doctorEnv) doctorResult {
 	case egressAttrPass:
 		return doctorResult{
 			status: statusPass,
-			detail: fmt.Sprintf("direct egress blocked at managed nftables DROP (curl exit %d, counter %d -> %d); proxy-unaware tools fail here", code, before, after),
+			detail: fmt.Sprintf("direct egress dial did not complete (curl exit %d, time_connect=0) and managed nftables DROP counter increased (%d -> %d); proxy-unaware tools fail here", code, before, after),
 			remediation: "a tool that 'can't reach the internet' is ignoring the proxy, NOT broken — " +
 				"run it via pipelock-curl / pipelock-python / pipelock-node, or export HTTPS_PROXY=" + proxyURLFor(env.port),
 			class: classProxyCompat,

--- a/internal/cli/contain/doctor_test.go
+++ b/internal/cli/contain/doctor_test.go
@@ -6,6 +6,7 @@ package contain
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"os"
@@ -14,6 +15,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 )
 
 // scriptedRun is an injectable runCommand whose output/exit/err are decided by
@@ -28,12 +31,33 @@ func newDoctorEnv(t *testing.T, run scriptedRun) *doctorEnv {
 	t.Helper()
 	env := defaultDoctorEnv()
 	env.runCmd = run.cmd
+	counter := uint64(10)
+	env.dropCounter = func(context.Context) (uint64, error) {
+		counter++
+		return counter, nil
+	}
 	env.dialCtx = func(_ context.Context, _, _ string, _ time.Duration) (net.Conn, error) {
 		return &fakeConn{}, nil
 	}
 	env.readFile = func(string) ([]byte, error) { return nil, errors.New("no read") }
 	env.stat = func(string) (os.FileInfo, error) { return nil, nil } // shim present
 	return env
+}
+
+func TestDoctorCounterProbeEnvUsesLiveDoctorOverrides(t *testing.T) {
+	base := &probeEnv{port: defaultProxyPort, agentUserName: defaultAgentUser}
+	doctor := &doctorEnv{port: 9443, agentUserName: "custom-agent"}
+
+	got := doctorCounterProbeEnv(base, doctor)
+	if got.port != doctor.port {
+		t.Fatalf("counter probe port = %d, want live doctor port %d", got.port, doctor.port)
+	}
+	if got.agentUserName != doctor.agentUserName {
+		t.Fatalf("counter probe agent = %q, want live doctor agent %q", got.agentUserName, doctor.agentUserName)
+	}
+	if base.port != defaultProxyPort || base.agentUserName != defaultAgentUser {
+		t.Fatalf("base probe env was mutated: port=%d agent=%q", base.port, base.agentUserName)
+	}
 }
 
 // argsContain reports whether the joined args contain every needle.
@@ -174,21 +198,36 @@ func TestCheckNodeThroughProxy(t *testing.T) {
 }
 
 func TestCheckDNSFailure(t *testing.T) {
-	t.Run("clean failure via non-zero exit", func(t *testing.T) {
+	t.Run("clean failure via attributed proxy CONNECT 5xx", func(t *testing.T) {
 		env := newDoctorEnv(t, func(args []string) (string, int, error) {
-			if !argsContain(args, dnsFailureHost) {
+			if !argsContain(args, dnsFailureHost, "%{http_connect}") {
 				t.Fatalf("did not target nxdomain: %v", args)
 			}
-			return "curl: (6) Could not resolve", 6, nil
+			return "curl: (56) CONNECT tunnel failed, response 502\n502", 56, nil
 		})
 		if res := checkDNSFailure(context.Background(), env); res.status != statusPass {
 			t.Fatalf("got %q (%s)", res.status, res.detail)
 		}
 	})
-	t.Run("clean failure via 5xx", func(t *testing.T) {
-		env := newDoctorEnv(t, func([]string) (string, int, error) { return "502", 0, nil })
-		if res := checkDNSFailure(context.Background(), env); res.status != statusPass {
-			t.Fatalf("got %q", res.status)
+	t.Run("unattributed nonzero exits are unknown", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			out  string
+			code int
+		}{
+			{name: "proxy unavailable", out: "curl: (7) Failed to connect\n000", code: 7},
+			{name: "TLS failure after CONNECT", out: "curl: (35) TLS error\n200", code: 35},
+			{name: "no status", out: "curl failed", code: 56},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				env := newDoctorEnv(t, func([]string) (string, int, error) {
+					return tc.out, tc.code, nil
+				})
+				res := checkDNSFailure(context.Background(), env)
+				if res.status != statusUnknown || res.class != classInfra {
+					t.Fatalf("got status=%q class=%q detail=%q", res.status, res.class, res.detail)
+				}
+			})
 		}
 	})
 	t.Run("bogus host resolved -> fail", func(t *testing.T) {
@@ -203,7 +242,9 @@ func TestCheckDNSFailure(t *testing.T) {
 func TestCheckRawEgressBlocked(t *testing.T) {
 	t.Run("blocked -> pass with proxy-compat remediation", func(t *testing.T) {
 		env := newDoctorEnv(t, func(args []string) (string, int, error) {
-			if !argsContain(args, "--noproxy") {
+			if !argsContain(args, "--noproxy", directEgressCanaryURL,
+				"--connect-timeout", directCurlConnectTimeout,
+				"--max-time", directCurlMaxTime) {
 				t.Fatalf("did not attempt direct egress: %v", args)
 			}
 			return "curl: (7) refused", 7, nil
@@ -307,6 +348,88 @@ func TestRunDoctor_JSONAndFailExit(t *testing.T) {
 	}
 }
 
+func TestRunDoctor_UnknownIsIncompleteInTextAndJSON(t *testing.T) {
+	for _, jsonOutput := range []bool{false, true} {
+		t.Run(map[bool]string{false: "text", true: "json"}[jsonOutput], func(t *testing.T) {
+			env := allPassDoctorEnv(t)
+			env.dropCounter = func(context.Context) (uint64, error) { return 12, nil }
+
+			var buf bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&buf)
+			cmd.SetContext(context.Background())
+			err := runDoctor(cmd, env, doctorOpts{jsonOutput: jsonOutput})
+			if code := cliutil.ExitCodeOf(err); code != cliutil.ExitConfig {
+				t.Fatalf("exit code = %d, want %d (err=%v)", code, cliutil.ExitConfig, err)
+			}
+
+			out := buf.String()
+			if jsonOutput {
+				if !strings.Contains(out, `"check":6`) ||
+					!strings.Contains(out, `"status":"unknown"`) ||
+					!strings.Contains(out, `"unknown":1`) ||
+					!strings.Contains(out, `"exit_code":2`) {
+					t.Fatalf("JSON did not preserve UNKNOWN as incomplete:\n%s", out)
+				}
+				return
+			}
+			if !strings.Contains(out, "[UNKNOWN]") ||
+				!strings.Contains(out, "1 UNKNOWN") ||
+				!strings.Contains(out, "exit 2") {
+				t.Fatalf("text did not preserve UNKNOWN as incomplete:\n%s", out)
+			}
+		})
+	}
+}
+
+func TestRunDoctor_MixedOutcomesPreserveWorstResultInTextAndJSON(t *testing.T) {
+	for _, jsonOutput := range []bool{false, true} {
+		t.Run(map[bool]string{false: "text", true: "json"}[jsonOutput], func(t *testing.T) {
+			env := newDoctorEnv(t, func(args []string) (string, int, error) {
+				switch {
+				case argsContain(args, "--noproxy"):
+					return "curl: (7) refused", 7, nil
+				case argsContain(args, dnsFailureHost):
+					return "curl: (7) proxy unavailable\n000", 7, nil
+				case argsContain(args, "pipelock-python"):
+					return "not found", 127, nil
+				case argsContain(args, "pipelock-node"):
+					return "200", 0, nil
+				default:
+					return "curl: (60) certificate problem", 60, nil
+				}
+			})
+
+			var buf bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&buf)
+			cmd.SetContext(context.Background())
+			err := runDoctor(cmd, env, doctorOpts{jsonOutput: jsonOutput})
+			if code := cliutil.ExitCodeOf(err); code != cliutil.ExitGeneral {
+				t.Fatalf("exit code = %d, want fail precedence %d (err=%v)", code, cliutil.ExitGeneral, err)
+			}
+
+			out := buf.String()
+			if jsonOutput {
+				lines := strings.Split(strings.TrimSpace(out), "\n")
+				var agg aggregateRecord
+				if err := json.Unmarshal([]byte(lines[len(lines)-1]), &agg); err != nil {
+					t.Fatalf("decode aggregate: %v\n%s", err, out)
+				}
+				if agg.Aggregate.Pass != 3 || agg.Aggregate.Fail != 1 ||
+					agg.Aggregate.Skip != 1 || agg.Aggregate.Unknown != 1 ||
+					agg.Aggregate.ExitCode != cliutil.ExitGeneral {
+					t.Fatalf("mixed aggregate = %+v, want 3 pass / 1 fail / 1 skip / 1 unknown / exit 1", agg.Aggregate)
+				}
+				return
+			}
+			if !strings.Contains(out, "3 PASS / 1 FAIL / 1 SKIP / 1 UNKNOWN — exit 1") {
+				t.Fatalf("text lost a mixed outcome or fail precedence:\n%s", out)
+			}
+		})
+	}
+}
+
 // errWriter fails every write, to exercise JSON-encode error paths.
 type errWriter struct{}
 
@@ -319,6 +442,15 @@ func TestRunDoctor_NilContextAndEncodeError(t *testing.T) {
 	// Intentionally do NOT SetContext, exercising the ctx==nil fallback.
 	if err := runDoctor(cmd, env, doctorOpts{jsonOutput: true}); err == nil {
 		t.Fatalf("expected encode error to surface")
+	}
+}
+
+func TestRunDoctor_TextWriteFailureFailsClosed(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(errWriter{})
+	if err := runDoctor(cmd, allPassDoctorEnv(t), doctorOpts{}); err == nil ||
+		!strings.Contains(err.Error(), "writing doctor header") {
+		t.Fatalf("text output failure = %v, want surfaced header write error", err)
 	}
 }
 
@@ -380,8 +512,8 @@ func TestCheckCurl_NoHTTPCode(t *testing.T) {
 
 func TestCheckDNSFailure_NonSuccessFallback(t *testing.T) {
 	env := newDoctorEnv(t, func([]string) (string, int, error) { return "404", 0, nil })
-	if res := checkDNSFailure(context.Background(), env); res.status != statusPass {
-		t.Fatalf("404 on nxdomain should pass cleanly: got %q", res.status)
+	if res := checkDNSFailure(context.Background(), env); res.status != statusUnknown {
+		t.Fatalf("unattributed 404 on nxdomain should be unknown: got %q", res.status)
 	}
 }
 
@@ -405,22 +537,91 @@ func TestCheckRawEgress_CompletedRequestIsHole(t *testing.T) {
 	}
 }
 
-func TestCheckRawEgress_DialBlockedExitsPass(t *testing.T) {
-	for _, code := range []int{6, 7, 28} {
+func TestCheckRawEgress_AttributedDialBlockedExitsPass(t *testing.T) {
+	for _, code := range []int{7, 28} {
 		env := newDoctorEnv(t, func([]string) (string, int, error) { return "curl error", code, nil })
 		if res := checkRawEgressBlocked(context.Background(), env); res.status != statusPass {
-			t.Errorf("curl exit %d should prove a blocked dial: got %q", code, res.status)
+			t.Errorf("curl exit %d plus counter delta should prove a blocked dial: got %q", code, res.status)
 		}
 	}
 }
 
-func TestCheckRawEgress_PostConnectFailureIsNotPass(t *testing.T) {
-	// curl exit 35 (TLS connect error) means the TCP dial succeeded, so egress
-	// was NOT cleanly blocked. Fail closed rather than claim PASS.
-	env := newDoctorEnv(t, func([]string) (string, int, error) { return "curl: (35) TLS error", 35, nil })
-	res := checkRawEgressBlocked(context.Background(), env)
-	if res.status != statusFail || res.class != classInfra {
-		t.Fatalf("post-connect failure must not pass: status=%q class=%q", res.status, res.class)
+func TestCheckRawEgress_UnattributableFailuresAreUnknown(t *testing.T) {
+	tests := []struct {
+		name  string
+		code  int
+		setup func(*doctorEnv)
+		want  string
+	}{
+		{
+			name: "DNS failure cannot match literal-IP canary",
+			code: 6,
+			want: "unexpected exit 6",
+		},
+		{
+			name: "TLS failure cannot match HTTP canary",
+			code: 35,
+			want: "unexpected exit 35",
+		},
+		{
+			name: "timeout without counter delta",
+			code: 28,
+			setup: func(env *doctorEnv) {
+				env.dropCounter = func(context.Context) (uint64, error) { return 12, nil }
+			},
+			want: "did not increase",
+		},
+		{
+			name: "no counter reader",
+			code: 7,
+			setup: func(env *doctorEnv) {
+				env.dropCounter = nil
+			},
+			want: "no DROP counter reader",
+		},
+		{
+			name: "counter read fails before probe",
+			code: 7,
+			setup: func(env *doctorEnv) {
+				env.dropCounter = func(context.Context) (uint64, error) {
+					return 0, errors.New("operation not permitted")
+				}
+			},
+			want: "before the probe failed",
+		},
+		{
+			name: "counter read fails after probe",
+			code: 7,
+			setup: func(env *doctorEnv) {
+				reads := 0
+				env.dropCounter = func(context.Context) (uint64, error) {
+					reads++
+					if reads == 1 {
+						return 12, nil
+					}
+					return 0, errors.New("table disappeared")
+				}
+			},
+			want: "after the probe failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newDoctorEnv(t, func([]string) (string, int, error) {
+				return "curl failed", tc.code, nil
+			})
+			if tc.setup != nil {
+				tc.setup(env)
+			}
+			res := checkRawEgressBlocked(context.Background(), env)
+			if res.status != statusUnknown || res.class != classInfra {
+				t.Fatalf("unattributable failure must be unknown: status=%q class=%q", res.status, res.class)
+			}
+			if !strings.Contains(res.detail, tc.want) {
+				t.Fatalf("detail = %q, want substring %q", res.detail, tc.want)
+			}
+		})
 	}
 }
 
@@ -477,7 +678,7 @@ func allPassDoctorEnv(t *testing.T) *doctorEnv {
 		case argsContain(args, "--noproxy"):
 			return "curl: (7) refused", 7, nil // direct egress blocked
 		case argsContain(args, dnsFailureHost):
-			return "curl: (6) could not resolve", 6, nil // clean DNS failure
+			return "curl: (56) CONNECT tunnel failed, response 502\n502", 56, nil // attributed proxy DNS failure
 		default:
 			return "200", 0, nil // proxied curl/python/node
 		}

--- a/internal/cli/contain/doctor_test.go
+++ b/internal/cli/contain/doctor_test.go
@@ -265,10 +265,11 @@ func TestCheckRawEgressBlocked(t *testing.T) {
 		env := newDoctorEnv(t, func(args []string) (string, int, error) {
 			if !argsContain(args, "--noproxy", directEgressCanaryURL,
 				"--connect-timeout", directCurlConnectTimeout,
-				"--max-time", directCurlMaxTime) {
+				"--max-time", directCurlMaxTime,
+				directCurlTimeConnectPrefix+"%{time_connect}") {
 				t.Fatalf("did not attempt direct egress: %v", args)
 			}
-			return "curl: (7) refused", 7, nil
+			return "curl: (7) refused\nPLK_TIME_CONNECT=0.000000\n000", 7, nil
 		})
 		res := checkRawEgressBlocked(context.Background(), env)
 		if res.status != statusPass || res.class != classProxyCompat {
@@ -409,7 +410,7 @@ func TestRunDoctor_MixedOutcomesPreserveWorstResultInTextAndJSON(t *testing.T) {
 			env := newDoctorEnv(t, func(args []string) (string, int, error) {
 				switch {
 				case argsContain(args, "--noproxy"):
-					return "curl: (7) refused", 7, nil
+					return "curl: (7) refused\nPLK_TIME_CONNECT=0.000000\n000", 7, nil
 				case argsContain(args, dnsFailureHost):
 					return "curl: (7) proxy unavailable\n000", 7, nil
 				case argsContain(args, "pipelock-python"):
@@ -592,9 +593,51 @@ func TestCheckRawEgress_CompletedRequestIsHole(t *testing.T) {
 func TestCheckRawEgress_AttributedDialBlockedExitsPass(t *testing.T) {
 	for _, code := range []int{7, 28} {
 		t.Run(strconv.Itoa(code), func(t *testing.T) {
-			env := newDoctorEnv(t, func([]string) (string, int, error) { return "curl error", code, nil })
+			env := newDoctorEnv(t, func([]string) (string, int, error) {
+				return "curl error\nPLK_TIME_CONNECT=0.000000\n000", code, nil
+			})
 			if res := checkRawEgressBlocked(context.Background(), env); res.status != statusPass {
 				t.Errorf("curl exit %d plus counter delta should prove a blocked dial: got %q", code, res.status)
+			}
+		})
+	}
+}
+
+func TestCheckRawEgress_ProbeSpecificDialAttribution(t *testing.T) {
+	tests := []struct {
+		name       string
+		out        string
+		code       int
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name:       "completed dial timeout fails despite UID-wide counter delta",
+			out:        "curl: (28) Operation timed out\nPLK_TIME_CONNECT=0.125381\n000",
+			code:       28,
+			wantStatus: statusFail,
+			wantDetail: "CONTAINMENT HOLE",
+		},
+		{
+			name:       "unknown dial timing cannot pass from UID-wide counter delta",
+			out:        "curl: (7) Failed to connect\nPLK_TIME_CONNECT=unparseable\n000",
+			code:       7,
+			wantStatus: statusUnknown,
+			wantDetail: "time_connect was missing or unparseable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newDoctorEnv(t, func([]string) (string, int, error) {
+				return tc.out, tc.code, nil
+			})
+			res := checkRawEgressBlocked(context.Background(), env)
+			if res.status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q (detail=%q)", res.status, tc.wantStatus, res.detail)
+			}
+			if !strings.Contains(res.detail, tc.wantDetail) {
+				t.Fatalf("detail = %q, want substring %q", res.detail, tc.wantDetail)
 			}
 		})
 	}
@@ -632,17 +675,20 @@ func TestCheckRawEgress_PostConnectExitsFailClosed(t *testing.T) {
 func TestCheckRawEgress_UnattributableFailuresAreUnknown(t *testing.T) {
 	tests := []struct {
 		name  string
+		out   string
 		code  int
 		setup func(*doctorEnv)
 		want  string
 	}{
 		{
 			name: "DNS failure cannot match literal-IP canary",
+			out:  "curl failed\nPLK_TIME_CONNECT=0.000000\n000",
 			code: 6,
 			want: "unexpected exit 6",
 		},
 		{
 			name: "timeout without counter delta",
+			out:  "curl failed\nPLK_TIME_CONNECT=0.000000\n000",
 			code: 28,
 			setup: func(env *doctorEnv) {
 				env.dropCounter = func(context.Context) (uint64, error) { return 12, nil }
@@ -651,6 +697,7 @@ func TestCheckRawEgress_UnattributableFailuresAreUnknown(t *testing.T) {
 		},
 		{
 			name: "no counter reader",
+			out:  "curl failed\nPLK_TIME_CONNECT=0.000000\n000",
 			code: 7,
 			setup: func(env *doctorEnv) {
 				env.dropCounter = nil
@@ -659,6 +706,7 @@ func TestCheckRawEgress_UnattributableFailuresAreUnknown(t *testing.T) {
 		},
 		{
 			name: "counter read fails before probe",
+			out:  "curl failed\nPLK_TIME_CONNECT=0.000000\n000",
 			code: 7,
 			setup: func(env *doctorEnv) {
 				env.dropCounter = func(context.Context) (uint64, error) {
@@ -669,6 +717,7 @@ func TestCheckRawEgress_UnattributableFailuresAreUnknown(t *testing.T) {
 		},
 		{
 			name: "counter read fails after probe",
+			out:  "curl failed\nPLK_TIME_CONNECT=0.000000\n000",
 			code: 7,
 			setup: func(env *doctorEnv) {
 				reads := 0
@@ -687,7 +736,7 @@ func TestCheckRawEgress_UnattributableFailuresAreUnknown(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			env := newDoctorEnv(t, func([]string) (string, int, error) {
-				return "curl failed", tc.code, nil
+				return tc.out, tc.code, nil
 			})
 			if tc.setup != nil {
 				tc.setup(env)
@@ -754,7 +803,7 @@ func allPassDoctorEnv(t *testing.T) *doctorEnv {
 	return newDoctorEnv(t, func(args []string) (string, int, error) {
 		switch {
 		case argsContain(args, "--noproxy"):
-			return "curl: (7) refused", 7, nil // direct egress blocked
+			return "curl: (7) refused\nPLK_TIME_CONNECT=0.000000\n000", 7, nil // direct egress blocked
 		case argsContain(args, dnsFailureHost):
 			return "curl: (56) CONNECT tunnel failed, response 502\n502", 56, nil // attributed proxy DNS failure
 		default:

--- a/internal/cli/contain/doctor_test.go
+++ b/internal/cli/contain/doctor_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -57,6 +58,26 @@ func TestDoctorCounterProbeEnvUsesLiveDoctorOverrides(t *testing.T) {
 	}
 	if base.port != defaultProxyPort || base.agentUserName != defaultAgentUser {
 		t.Fatalf("base probe env was mutated: port=%d agent=%q", base.port, base.agentUserName)
+	}
+}
+
+func TestDoctorDropCounterReaderUsesLiveDoctorOverrides(t *testing.T) {
+	base := &probeEnv{}
+	doctor := &doctorEnv{port: 9443, agentUserName: "custom-agent"}
+	base.dropCounter = func(_ context.Context, got *probeEnv) (uint64, error) {
+		if got.port != doctor.port || got.agentUserName != doctor.agentUserName {
+			t.Fatalf("counter env = port %d agent %q, want port %d agent %q",
+				got.port, got.agentUserName, doctor.port, doctor.agentUserName)
+		}
+		return 42, nil
+	}
+
+	got, err := doctorDropCounterReader(base, doctor)(context.Background())
+	if err != nil {
+		t.Fatalf("counter read: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("counter = %d, want 42", got)
 	}
 }
 
@@ -452,6 +473,37 @@ func TestRunDoctor_TextWriteFailureFailsClosed(t *testing.T) {
 		!strings.Contains(err.Error(), "writing doctor header") {
 		t.Fatalf("text output failure = %v, want surfaced header write error", err)
 	}
+
+	jsonCmd := &cobra.Command{}
+	jsonCmd.SetOut(errWriter{})
+	if err := runDoctor(jsonCmd, allPassDoctorEnv(t), doctorOpts{jsonOutput: true}); err == nil ||
+		!strings.Contains(err.Error(), "encoding check 1 JSON") {
+		t.Fatalf("JSON output failure = %v, want surfaced check 1 encode error", err)
+	}
+}
+
+func TestRunDoctor_RecordAndAggregateWriteFailuresFailClosed(t *testing.T) {
+	tests := []struct {
+		name             string
+		jsonOutput       bool
+		successfulWrites int
+		want             string
+	}{
+		{name: "text check", successfulWrites: 1, want: "writing check 1 text"},
+		{name: "text aggregate", successfulWrites: 8, want: "writing doctor aggregate"},
+		{name: "JSON aggregate", jsonOutput: true, successfulWrites: 6, want: "encoding aggregate JSON"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.SetOut(&failAfterWriter{successfulWrites: tc.successfulWrites})
+			err := runDoctor(cmd, allPassDoctorEnv(t), doctorOpts{jsonOutput: tc.jsonOutput})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("output failure = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
 }
 
 func TestDoctorCmd_RunEHappyPath(t *testing.T) {
@@ -539,10 +591,41 @@ func TestCheckRawEgress_CompletedRequestIsHole(t *testing.T) {
 
 func TestCheckRawEgress_AttributedDialBlockedExitsPass(t *testing.T) {
 	for _, code := range []int{7, 28} {
-		env := newDoctorEnv(t, func([]string) (string, int, error) { return "curl error", code, nil })
-		if res := checkRawEgressBlocked(context.Background(), env); res.status != statusPass {
-			t.Errorf("curl exit %d plus counter delta should prove a blocked dial: got %q", code, res.status)
-		}
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			env := newDoctorEnv(t, func([]string) (string, int, error) { return "curl error", code, nil })
+			if res := checkRawEgressBlocked(context.Background(), env); res.status != statusPass {
+				t.Errorf("curl exit %d plus counter delta should prove a blocked dial: got %q", code, res.status)
+			}
+		})
+	}
+}
+
+func TestCheckRawEgress_PostConnectExitsFailClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+	}{
+		{name: "TLS handshake", code: 35},
+		{name: "empty reply", code: 52},
+		{name: "send error", code: 55},
+		{name: "receive error", code: 56},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// newDoctorEnv supplies an increasing counter. A post-connect exit
+			// must still FAIL; unrelated same-UID traffic cannot convert it to PASS.
+			env := newDoctorEnv(t, func([]string) (string, int, error) {
+				return "curl reached peer then failed", tc.code, nil
+			})
+			res := checkRawEgressBlocked(context.Background(), env)
+			if res.status != statusFail || res.class != classInfra {
+				t.Fatalf("post-connect exit %d = status %q class %q, want fail/infra", tc.code, res.status, res.class)
+			}
+			if !strings.Contains(res.detail, "CONTAINMENT HOLE") {
+				t.Fatalf("post-connect detail = %q, want containment-hole evidence", res.detail)
+			}
+		})
 	}
 }
 
@@ -557,11 +640,6 @@ func TestCheckRawEgress_UnattributableFailuresAreUnknown(t *testing.T) {
 			name: "DNS failure cannot match literal-IP canary",
 			code: 6,
 			want: "unexpected exit 6",
-		},
-		{
-			name: "TLS failure cannot match HTTP canary",
-			code: 35,
-			want: "unexpected exit 35",
 		},
 		{
 			name: "timeout without counter delta",

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"os/exec"
@@ -56,10 +57,14 @@ const (
 	// Probe 8 uses a DNS-free, non-routable TEST-NET-1 address on a normally
 	// unused port. This forces the probe packet through the managed catch-all
 	// agent DROP rule and removes DNS/TLS as alternate causes of failure. The
-	// shorter budget also narrows the same-UID counter-attribution window.
-	directEgressCanaryURL    = "http://192.0.2.1:9/"
-	directCurlConnectTimeout = "1"
-	directCurlMaxTime        = "2"
+	// curl's own time_connect measurement provides probe-specific evidence of
+	// whether this canary established TCP; the UID-wide DROP counter only
+	// corroborates a dial that did not complete.
+	directEgressCanaryURL       = "http://192.0.2.1:9/"
+	directCurlConnectTimeout    = "1"
+	directCurlMaxTime           = "2"
+	directCurlTimeConnectPrefix = "PLK_TIME_CONNECT="
+	directCurlWriteOut          = "\n" + directCurlTimeConnectPrefix + "%{time_connect}\n%{http_code}"
 
 	// Probe status values. Strings (not an enum type) so JSON
 	// serialization is identity and tests can compare cheaply.
@@ -1710,7 +1715,7 @@ func curlDirectCanaryArgsFor(curl string) []string {
 		"--noproxy", "*",
 		"-sS",
 		"-o", "/dev/null",
-		"-w", "%{http_code}",
+		"-w", directCurlWriteOut,
 		directEgressCanaryURL,
 	}
 }
@@ -1826,13 +1831,10 @@ func managedContainmentDropPacketCount(out, chainName string, agentUID int) (uin
 	return packets, nil
 }
 
-// probeCCAgentEgressDenied verifies that a failed direct-egress curl coincides
-// with an increment in the exact managed catch-all DROP counter. The counter is
-// UID-wide, not process-exclusive: the literal-IP target, single-rule match,
-// and two-second ceiling reduce but cannot eliminate attribution from other
-// concurrent traffic under the contained UID. A fully exclusive counter would
-// require temporarily mutating nftables, which would violate verify's read-only
-// contract.
+// probeCCAgentEgressDenied verifies that curl's probe-specific time_connect
+// reports no completed TCP dial and that the exact managed catch-all DROP
+// counter also increased. The counter is UID-wide corroboration only: it cannot
+// turn a completed or unattributable canary dial into PASS.
 func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, string) {
 	var before uint64
 	var beforeErr error
@@ -1858,12 +1860,15 @@ func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, strin
 	if code == 0 {
 		return statusFail, fmt.Sprintf("unexpected curl success: HTTP %s from direct canary %s", oneLine(out), directEgressCanaryURL)
 	}
-	outcome, after, afterErr := classifyDirectEgressAttribution(code, env.dropCounter != nil, before, beforeErr, func() (uint64, error) {
+	dialCompletion := parseDirectCurlDialCompletion(out)
+	outcome, after, afterErr := classifyDirectEgressAttribution(code, dialCompletion, env.dropCounter != nil, before, beforeErr, func() (uint64, error) {
 		return env.dropCounter(ctx, env)
 	})
 	switch outcome {
 	case egressAttrFailPostConnect:
 		return statusFail, fmt.Sprintf("CONTAINMENT HOLE: direct egress reached the network before curl failed (exit=%d): %s", code, oneLine(out))
+	case egressAttrUnknownDialCompletion:
+		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but probe-specific time_connect was missing or unparseable; refusing to claim containment", code)
 	case egressAttrUnknownNoCounter:
 		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but no DROP counter reader is available; containment attribution is inconclusive", code)
 	case egressAttrUnknownBeforeErr:
@@ -1875,7 +1880,7 @@ func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, strin
 	case egressAttrUnknownUnexpectedExit:
 		return statusUnknown, fmt.Sprintf("curl failed with unexpected exit=%d despite a counter delta; the DNS-free HTTP canary expected a connect refusal or timeout", code)
 	case egressAttrPass:
-		return statusPass, fmt.Sprintf("curl blocked (exit=%d); managed DROP counter increased (%d -> %d) — containment enforced", code, before, after)
+		return statusPass, fmt.Sprintf("curl dial did not complete (exit=%d, time_connect=0); managed DROP counter increased (%d -> %d) — containment enforced", code, before, after)
 	default:
 		// Fail closed: an unhandled attribution outcome (e.g. a future enum
 		// value) must never fall through to PASS.
@@ -1889,6 +1894,7 @@ type egressAttribution int
 
 const (
 	egressAttrFailPostConnect       egressAttribution = iota // connection established -> containment hole
+	egressAttrUnknownDialCompletion                          // probe-specific dial completion is missing/unparseable
 	egressAttrUnknownNoCounter                               // no DROP counter reader available
 	egressAttrUnknownBeforeErr                               // reading the counter before the probe failed
 	egressAttrUnknownAfterErr                                // reading the counter after the probe failed
@@ -1903,13 +1909,21 @@ const (
 // (checkRawEgressBlocked) so the two can never silently disagree about whether
 // containment held. Callers handle skip cases and the code==0 unexpected-success
 // case first, then map the returned attribution to their own result type and
-// wording. Branch order is security-critical: a post-connect exit is a
-// containment hole regardless of the counter, and PASS requires BOTH a
-// dial-blocked exit and a positive managed DROP-counter delta. readAfter is
-// invoked lazily so the post-connect and no-counter paths perform no counter read.
-func classifyDirectEgressAttribution(code int, hasCounter bool, before uint64, beforeErr error, readAfter func() (uint64, error)) (outcome egressAttribution, after uint64, afterErr error) {
+// wording. Branch order is security-critical: probe-specific evidence that the
+// dial completed, or an independently post-connect exit, is a containment hole
+// regardless of the counter. Missing probe-specific timing stays UNKNOWN. PASS
+// requires a dial that did not complete, a dial-blocked exit, and a positive
+// managed DROP-counter delta. readAfter is invoked lazily so completed,
+// post-connect, unknown-timing, and no-counter paths perform no counter read.
+func classifyDirectEgressAttribution(code int, dialCompletion directDialCompletion, hasCounter bool, before uint64, beforeErr error, readAfter func() (uint64, error)) (outcome egressAttribution, after uint64, afterErr error) {
+	if dialCompletion == directDialCompleted {
+		return egressAttrFailPostConnect, 0, nil
+	}
 	if isPostConnectCurlExit(code) {
 		return egressAttrFailPostConnect, 0, nil
+	}
+	if dialCompletion != directDialNotCompleted {
+		return egressAttrUnknownDialCompletion, 0, nil
 	}
 	if !hasCounter {
 		return egressAttrUnknownNoCounter, 0, nil
@@ -1930,17 +1944,46 @@ func classifyDirectEgressAttribution(code int, hasCounter bool, before uint64, b
 	return egressAttrPass, after, afterErr
 }
 
+// directDialCompletion is curl's probe-specific account of whether its TCP
+// connection completed. Unknown is deliberately distinct from not-completed:
+// missing or malformed write-out evidence can never support PASS.
+type directDialCompletion int
+
+const (
+	directDialUnknown directDialCompletion = iota
+	directDialNotCompleted
+	directDialCompleted
+)
+
+// parseDirectCurlDialCompletion reads curl's stable time_connect sentinel.
+// strconv.ParseFloat is locale-independent, and curl's write-out variables use
+// a dot decimal separator. Exactly zero means TCP never connected; any finite
+// positive value means the direct dial escaped containment.
+func parseDirectCurlDialCompletion(out string) directDialCompletion {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, directCurlTimeConnectPrefix) {
+			continue
+		}
+		raw := strings.TrimSpace(strings.TrimPrefix(line, directCurlTimeConnectPrefix))
+		value, err := strconv.ParseFloat(raw, 64)
+		if err != nil || value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+			return directDialUnknown
+		}
+		if value == 0 {
+			return directDialNotCompleted
+		}
+		return directDialCompleted
+	}
+	return directDialUnknown
+}
+
 // isDirectEgressBlockedCurlExit identifies dial outcomes consistent with either
 // an explicit rejection (7) or a silently dropped SYN that times out (28).
-// Exit 28 is a GENERIC curl timeout and cannot, from the exit code alone, be
-// distinguished as a pre-connect vs post-connect timeout. That ambiguity is
-// bounded by two independent guarantees the caller enforces: the direct canary
-// targets an unroutable TEST-NET-1 black hole (192.0.2.1:9) where no connection
-// can establish, so a timeout there is necessarily a dial-level outcome, not a
-// post-connect one; and PASS additionally requires a managed DROP-counter delta
-// that attributes the block to our own nft rule. The residual case — concurrent
-// same-UID traffic supplying the counter delta — is the UID-wide-counter
-// limitation tracked as a separate follow-up, not a new hole introduced here.
+// Exit 28 is a generic curl timeout, so the caller separately requires this
+// canary's time_connect to be exactly zero before either exit can support PASS.
+// The UID-wide managed DROP-counter delta then corroborates that no-dial result;
+// it is never treated as probe attribution on its own.
 func isDirectEgressBlockedCurlExit(code int) bool {
 	return code == 7 || code == 28
 }

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1874,8 +1874,12 @@ func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, strin
 		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but managed DROP counter did not increase (%d -> %d); failure may be unrelated to containment", code, before, after)
 	case egressAttrUnknownUnexpectedExit:
 		return statusUnknown, fmt.Sprintf("curl failed with unexpected exit=%d despite a counter delta; the DNS-free HTTP canary expected a connect refusal or timeout", code)
-	default: // egressAttrPass
+	case egressAttrPass:
 		return statusPass, fmt.Sprintf("curl blocked (exit=%d); managed DROP counter increased (%d -> %d) — containment enforced", code, before, after)
+	default:
+		// Fail closed: an unhandled attribution outcome (e.g. a future enum
+		// value) must never fall through to PASS.
+		return statusUnknown, fmt.Sprintf("unexpected direct-egress attribution outcome %d (exit=%d); refusing to claim containment", outcome, code)
 	}
 }
 
@@ -1927,7 +1931,16 @@ func classifyDirectEgressAttribution(code int, hasCounter bool, before uint64, b
 }
 
 // isDirectEgressBlockedCurlExit identifies dial outcomes consistent with either
-// an explicit rejection or a silently dropped SYN.
+// an explicit rejection (7) or a silently dropped SYN that times out (28).
+// Exit 28 is a GENERIC curl timeout and cannot, from the exit code alone, be
+// distinguished as a pre-connect vs post-connect timeout. That ambiguity is
+// bounded by two independent guarantees the caller enforces: the direct canary
+// targets an unroutable TEST-NET-1 black hole (192.0.2.1:9) where no connection
+// can establish, so a timeout there is necessarily a dial-level outcome, not a
+// post-connect one; and PASS additionally requires a managed DROP-counter delta
+// that attributes the block to our own nft rule. The residual case — concurrent
+// same-UID traffic supplying the counter delta — is the UID-wide-counter
+// limitation tracked as a separate follow-up, not a new hole introduced here.
 func isDirectEgressBlockedCurlExit(code int) bool {
 	return code == 7 || code == 28
 }

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -253,6 +253,7 @@ type errorTrackingWriter struct {
 	err error
 }
 
+// Write forwards p while recording the first error or short write.
 func (w *errorTrackingWriter) Write(p []byte) (int, error) {
 	if w.err != nil {
 		return 0, w.err
@@ -267,6 +268,7 @@ func (w *errorTrackingWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
+// Err returns the first write failure observed by Write.
 func (w *errorTrackingWriter) Err() error {
 	return w.err
 }
@@ -351,6 +353,8 @@ func probeWorkspaceAccess(ctx context.Context, env *probeEnv) (string, string) {
 	return statusPass, fmt.Sprintf("%d workspace path(s) readable by %s", len(env.workspacePaths), env.agentUserName)
 }
 
+// probeListedToolTargets verifies each configured wrapper target exists and is
+// executable from the contained agent's user context.
 func probeListedToolTargets(ctx context.Context, env *probeEnv) (string, string) {
 	data, err := env.readFile(env.toolsListPath)
 	if err != nil {
@@ -849,6 +853,8 @@ func parseSystemdShow(out string) map[string]string {
 // Probe 3: nftables_containment_ruleset
 // ---------------------------------------------------------------------------
 
+// probeNFTContainment verifies the installed nftables boundary structure,
+// ordering, UID ownership, and persistence wiring.
 func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 	out, code, err := env.runCmd(ctx, probeNFTExecutable(env), "list", "table", "inet", env.nftTable)
 	if err != nil {
@@ -1076,6 +1082,8 @@ func chainHasAgentDNSDropBeforeCatchAll(out, chainName string, agentUID int, pro
 	})
 }
 
+// chainHasUnsafeVerdictBeforeAgentDrop detects an unmanaged verdict that can
+// bypass or intercept traffic before the contained agent's catch-all DROP.
 func chainHasUnsafeVerdictBeforeAgentDrop(out, chainName string, uids containmentUIDs, proxyPort int) bool {
 	return chainHasLineBeforeAgentDrop(out, chainName, uids.agentUID, func(line string) bool {
 		// Before the agent catch-all drop, only the managed operator/proxy
@@ -1108,6 +1116,7 @@ func chainHasUnsafeVerdictBeforeAgentDrop(out, chainName string, uids containmen
 	})
 }
 
+// terminalSkuidUIDVerdict extracts the UID from an exact skuid verdict rule.
 func terminalSkuidUIDVerdict(line, verdict string) (int, bool) {
 	fields := nftLineFields(line)
 	for i := 0; i+1 < len(fields); i++ {
@@ -1126,6 +1135,7 @@ func terminalSkuidUIDVerdict(line, verdict string) (int, bool) {
 	return 0, false
 }
 
+// lineHasSkuid reports whether an nft rule matches uid via skuid.
 func lineHasSkuid(line string, uid int) bool {
 	want := strconv.Itoa(uid)
 	fields := nftLineFields(line)
@@ -1137,6 +1147,7 @@ func lineHasSkuid(line string, uid int) bool {
 	return false
 }
 
+// lineHasTerminalSkuidVerdict matches an exact UID with a terminal verdict.
 func lineHasTerminalSkuidVerdict(line string, uid int, verdict string) bool {
 	fields := nftLineFields(line)
 	uidText := strconv.Itoa(uid)
@@ -1151,6 +1162,7 @@ func lineHasTerminalSkuidVerdict(line string, uid int, verdict string) bool {
 	return fieldsAreNFTBookkeeping(fields[skuidAt+1 : verdictAt])
 }
 
+// lineHasSkuidProtocolDPortVerdict matches the canonical UID/protocol/port rule.
 func lineHasSkuidProtocolDPortVerdict(line string, uid int, protocol string, port int, verdict string) bool {
 	fields := nftLineFields(line)
 	skuidAt := indexSkuidUID(fields, strconv.Itoa(uid))
@@ -1185,6 +1197,8 @@ func indexTokenAfter(fields []string, want string, start int) int {
 	return -1
 }
 
+// fieldsAreNFTBookkeeping accepts only counter and log tokens between the
+// managed rule's UID predicate and DROP verdict.
 func fieldsAreNFTBookkeeping(fields []string) bool {
 	inPrefix := false
 	seenCounter := false
@@ -1225,6 +1239,7 @@ func fieldsAreNFTBookkeeping(fields []string) bool {
 	return !inPrefix && !expectCount
 }
 
+// lineHasIPDAddr reports whether an nft rule contains an exact IPv4 destination.
 func lineHasIPDAddr(line, addr string) bool {
 	fields := nftLineFields(line)
 	for i := 0; i+2 < len(fields); i++ {
@@ -1235,6 +1250,7 @@ func lineHasIPDAddr(line, addr string) bool {
 	return false
 }
 
+// lineHasDPort reports whether an nft rule contains an exact destination port.
 func lineHasDPort(line string, port int) bool {
 	want := strconv.Itoa(port)
 	fields := nftLineFields(line)
@@ -1246,6 +1262,7 @@ func lineHasDPort(line string, port int) bool {
 	return false
 }
 
+// lineHasToken finds an exact unquoted nft syntax token.
 func lineHasToken(line, want string) bool {
 	for _, field := range nftLineFields(line) {
 		if field == want {
@@ -1255,6 +1272,7 @@ func lineHasToken(line, want string) bool {
 	return false
 }
 
+// lineHasAnyToken finds any requested unquoted nft syntax token.
 func lineHasAnyToken(line string, wants ...string) bool {
 	for _, field := range nftLineFields(line) {
 		for _, want := range wants {
@@ -1375,6 +1393,7 @@ func nftLineHasBalancedQuotes(line string) bool {
 	return !inQuote
 }
 
+// isNFTChainDeclaration reports whether line declares exactly chainName.
 func isNFTChainDeclaration(line, chainName string) bool {
 	if !nftLineHasBalancedQuotes(line) {
 		return false
@@ -1388,6 +1407,7 @@ func isNFTChainDeclaration(line, chainName string) bool {
 	return line == "chain "+chainName+"{"
 }
 
+// outputHasNFTChainDeclaration finds an exact chain declaration in nft output.
 func outputHasNFTChainDeclaration(out, chainName string) bool {
 	for _, raw := range strings.Split(out, "\n") {
 		if isNFTChainDeclaration(strings.TrimSpace(raw), chainName) {
@@ -1397,6 +1417,7 @@ func outputHasNFTChainDeclaration(out, chainName string) bool {
 	return false
 }
 
+// chainHasLineBeforeAgentDrop applies match only before the managed agent DROP.
 func chainHasLineBeforeAgentDrop(out, chainName string, agentUID int, match func(string) bool) bool {
 	inChain := false
 	depth := 0
@@ -1429,6 +1450,7 @@ func chainHasLineBeforeAgentDrop(out, chainName string, agentUID int, match func
 	return false
 }
 
+// chainHasLine applies match only within the requested, structurally valid chain.
 func chainHasLine(out, chainName string, match func(string) bool) bool {
 	inChain := false
 	depth := 0
@@ -1676,6 +1698,7 @@ func curlNoProxyArgsFor(curl string) []string {
 	}
 }
 
+// curlDirectCanaryArgsFor builds the bounded DNS-free direct-egress probe.
 func curlDirectCanaryArgsFor(curl string) []string {
 	if curl == "" {
 		curl = defaultCurlPath
@@ -1835,6 +1858,9 @@ func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, strin
 	if code == 0 {
 		return statusFail, fmt.Sprintf("unexpected curl success: HTTP %s from direct canary %s", oneLine(out), directEgressCanaryURL)
 	}
+	if isPostConnectCurlExit(code) {
+		return statusFail, fmt.Sprintf("CONTAINMENT HOLE: direct egress reached the network before curl failed (exit=%d): %s", code, oneLine(out))
+	}
 	if env.dropCounter == nil {
 		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but no DROP counter reader is available; containment attribution is inconclusive", code)
 	}
@@ -1854,8 +1880,28 @@ func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, strin
 	return statusPass, fmt.Sprintf("curl blocked (exit=%d); managed DROP counter increased (%d -> %d) — containment enforced", code, before, after)
 }
 
+// isDirectEgressBlockedCurlExit identifies dial outcomes consistent with either
+// an explicit rejection or a silently dropped SYN.
 func isDirectEgressBlockedCurlExit(code int) bool {
 	return code == 7 || code == 28
+}
+
+// isPostConnectCurlExit identifies curl failures that require a connection to
+// have progressed beyond the outbound dial. These are containment failures even
+// if unrelated same-UID traffic also increments the managed DROP counter.
+func isPostConnectCurlExit(code int) bool {
+	switch code {
+	// Server/protocol responses or completed transfer setup.
+	case 8, 16, 18, 21, 22, 23, 25, 30, 31, 33, 36, 38, 39, 47,
+		52, 61, 63, 64, 67, 68, 69, 70, 71, 72, 73, 74, 78, 79,
+		84, 85, 86, 87, 88, 92, 94, 95, 96:
+		return true
+	// TLS peer/handshake evidence or network I/O after connect.
+	case 35, 51, 55, 56, 60, 80, 83, 90, 91, 97:
+		return true
+	default:
+		return false
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1858,26 +1858,72 @@ func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, strin
 	if code == 0 {
 		return statusFail, fmt.Sprintf("unexpected curl success: HTTP %s from direct canary %s", oneLine(out), directEgressCanaryURL)
 	}
-	if isPostConnectCurlExit(code) {
+	outcome, after, afterErr := classifyDirectEgressAttribution(code, env.dropCounter != nil, before, beforeErr, func() (uint64, error) {
+		return env.dropCounter(ctx, env)
+	})
+	switch outcome {
+	case egressAttrFailPostConnect:
 		return statusFail, fmt.Sprintf("CONTAINMENT HOLE: direct egress reached the network before curl failed (exit=%d): %s", code, oneLine(out))
-	}
-	if env.dropCounter == nil {
+	case egressAttrUnknownNoCounter:
 		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but no DROP counter reader is available; containment attribution is inconclusive", code)
-	}
-	after, afterErr := env.dropCounter(ctx, env)
-	if beforeErr != nil {
+	case egressAttrUnknownBeforeErr:
 		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but containment attribution is inconclusive: read DROP counter before probe: %v", code, beforeErr)
+	case egressAttrUnknownAfterErr:
+		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but containment attribution is inconclusive: read DROP counter after probe: %v", code, afterErr)
+	case egressAttrUnknownNoDelta:
+		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but managed DROP counter did not increase (%d -> %d); failure may be unrelated to containment", code, before, after)
+	case egressAttrUnknownUnexpectedExit:
+		return statusUnknown, fmt.Sprintf("curl failed with unexpected exit=%d despite a counter delta; the DNS-free HTTP canary expected a connect refusal or timeout", code)
+	default: // egressAttrPass
+		return statusPass, fmt.Sprintf("curl blocked (exit=%d); managed DROP counter increased (%d -> %d) — containment enforced", code, before, after)
+	}
+}
+
+// egressAttribution is the transport-neutral verdict of the shared direct-egress
+// counter-attribution decision tree. Callers map it to their own result type.
+type egressAttribution int
+
+const (
+	egressAttrFailPostConnect       egressAttribution = iota // connection established -> containment hole
+	egressAttrUnknownNoCounter                               // no DROP counter reader available
+	egressAttrUnknownBeforeErr                               // reading the counter before the probe failed
+	egressAttrUnknownAfterErr                                // reading the counter after the probe failed
+	egressAttrUnknownNoDelta                                 // counter did not increase -> unattributable
+	egressAttrUnknownUnexpectedExit                          // counter delta but a non-dial-blocked exit
+	egressAttrPass                                           // dial-blocked exit AND positive counter delta
+)
+
+// classifyDirectEgressAttribution is the SINGLE source of truth for the
+// direct-egress containment verdict on a NON-ZERO canary exit, shared by
+// `contain verify` (probeCCAgentEgressDenied) and `contain doctor`
+// (checkRawEgressBlocked) so the two can never silently disagree about whether
+// containment held. Callers handle skip cases and the code==0 unexpected-success
+// case first, then map the returned attribution to their own result type and
+// wording. Branch order is security-critical: a post-connect exit is a
+// containment hole regardless of the counter, and PASS requires BOTH a
+// dial-blocked exit and a positive managed DROP-counter delta. readAfter is
+// invoked lazily so the post-connect and no-counter paths perform no counter read.
+func classifyDirectEgressAttribution(code int, hasCounter bool, before uint64, beforeErr error, readAfter func() (uint64, error)) (outcome egressAttribution, after uint64, afterErr error) {
+	if isPostConnectCurlExit(code) {
+		return egressAttrFailPostConnect, 0, nil
+	}
+	if !hasCounter {
+		return egressAttrUnknownNoCounter, 0, nil
+	}
+	after, afterErr = readAfter()
+	if beforeErr != nil {
+		return egressAttrUnknownBeforeErr, after, afterErr
 	}
 	if afterErr != nil {
-		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but containment attribution is inconclusive: read DROP counter after probe: %v", code, afterErr)
+		return egressAttrUnknownAfterErr, after, afterErr
 	}
 	if after <= before {
-		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but managed DROP counter did not increase (%d -> %d); failure may be unrelated to containment", code, before, after)
+		return egressAttrUnknownNoDelta, after, afterErr
 	}
 	if !isDirectEgressBlockedCurlExit(code) {
-		return statusUnknown, fmt.Sprintf("curl failed with unexpected exit=%d despite a counter delta; the DNS-free HTTP canary expected a connect refusal or timeout", code)
+		return egressAttrUnknownUnexpectedExit, after, afterErr
 	}
-	return statusPass, fmt.Sprintf("curl blocked (exit=%d); managed DROP counter increased (%d -> %d) — containment enforced", code, before, after)
+	return egressAttrPass, after, afterErr
 }
 
 // isDirectEgressBlockedCurlExit identifies dial outcomes consistent with either

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -52,11 +53,20 @@ const (
 	curlPath           = defaultCurlPath
 	canaryURL          = "https://example.com/"
 
+	// Probe 8 uses a DNS-free, non-routable TEST-NET-1 address on a normally
+	// unused port. This forces the probe packet through the managed catch-all
+	// agent DROP rule and removes DNS/TLS as alternate causes of failure. The
+	// shorter budget also narrows the same-UID counter-attribution window.
+	directEgressCanaryURL    = "http://192.0.2.1:9/"
+	directCurlConnectTimeout = "1"
+	directCurlMaxTime        = "2"
+
 	// Probe status values. Strings (not an enum type) so JSON
 	// serialization is identity and tests can compare cheaply.
-	statusPass = "pass"
-	statusFail = "fail"
-	statusSkip = "skip"
+	statusPass    = "pass"
+	statusFail    = "fail"
+	statusSkip    = "skip"
+	statusUnknown = "unknown"
 
 	// Internal: cap on stdout/stderr we keep from a subprocess so a
 	// runaway command can't blow the runner's heap.
@@ -95,6 +105,10 @@ type lookupUserFunc func(name string) (*user.User, error)
 
 type groupIDsFunc func(*user.User) ([]string, error)
 
+// dropCounterFunc reads the total packet count for the managed nftables DROP
+// rules that apply to the contained agent user.
+type dropCounterFunc func(ctx context.Context, env *probeEnv) (uint64, error)
+
 // probeEnv carries the inputs every probe needs. Everything is
 // addressable from outside the package so tests can populate it
 // directly without going through the cobra layer.
@@ -125,14 +139,15 @@ type probeEnv struct {
 	// run produced, even when --posture-output points off the default path.
 	postureProofPath string
 
-	runCmd     runCommand
-	dialCtx    dialFunc
-	lookupUser lookupUserFunc
-	groupIDs   groupIDsFunc
-	stat       func(path string) (os.FileInfo, error)
-	readFile   func(path string) ([]byte, error)
-	selfPath   func() (string, error)
-	hashFile   func(path string) (string, error)
+	runCmd      runCommand
+	dropCounter dropCounterFunc
+	dialCtx     dialFunc
+	lookupUser  lookupUserFunc
+	groupIDs    groupIDsFunc
+	stat        func(path string) (os.FileInfo, error)
+	readFile    func(path string) ([]byte, error)
+	selfPath    func() (string, error)
+	hashFile    func(path string) (string, error)
 }
 
 // defaultProbeEnv returns the production environment. The operator user
@@ -161,6 +176,7 @@ func defaultProbeEnv() *probeEnv {
 		wrapperInvPath:     defaultWrapperInvPath,
 		toolsListPath:      defaultToolsListPath,
 		runCmd:             realRunCommand,
+		dropCounter:        readContainmentDropCounter,
 		dialCtx:            realDial,
 		lookupUser:         user.Lookup,
 		groupIDs:           realGroupIDs,
@@ -227,6 +243,33 @@ func (c *cappedBuffer) Write(p []byte) (int, error) {
 }
 
 func (c *cappedBuffer) String() string { return c.buf.String() }
+
+// errorTrackingWriter preserves the first output error even when a text
+// renderer intentionally ignores individual fmt write results. Command drivers
+// check Err after each logical record so a broken output stream can never be
+// reported as a successful verification.
+type errorTrackingWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (w *errorTrackingWriter) Write(p []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	n, err := w.w.Write(p)
+	if err == nil && n != len(p) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		w.err = err
+	}
+	return n, err
+}
+
+func (w *errorTrackingWriter) Err() error {
+	return w.err
+}
 
 // realDial dials network+address with a fixed timeout, honoring ctx
 // cancellation. Tests inject a deterministic dialer.
@@ -308,7 +351,7 @@ func probeWorkspaceAccess(ctx context.Context, env *probeEnv) (string, string) {
 	return statusPass, fmt.Sprintf("%d workspace path(s) readable by %s", len(env.workspacePaths), env.agentUserName)
 }
 
-func probeListedToolTargets(_ context.Context, env *probeEnv) (string, string) {
+func probeListedToolTargets(ctx context.Context, env *probeEnv) (string, string) {
 	data, err := env.readFile(env.toolsListPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -351,6 +394,22 @@ func probeListedToolTargets(_ context.Context, env *probeEnv) (string, string) {
 		}
 		if info.Mode().Perm()&0o111 == 0 {
 			bad = append(bad, fmt.Sprintf("%s target %s is not executable", entry.name, target))
+			continue
+		}
+
+		out, code, runErr := env.runCmd(ctx, "sudo", "-n", "-u", env.agentUserName, "--", "test", "-x", target)
+		if runErr != nil {
+			return statusSkip, fmt.Sprintf("could not verify %s as %s: %v", target, env.agentUserName, runErr)
+		}
+		if isSudoUserMissing(out) {
+			return statusSkip, fmt.Sprintf("%s user missing (install never ran)", env.agentUserName)
+		}
+		if isSudoRefusal(out) {
+			return statusSkip, fmt.Sprintf("sudo -n refused agent-context executable check for %s", target)
+		}
+		if code != 0 {
+			bad = append(bad, fmt.Sprintf("%s target %s is not executable/traversable by %s: %s",
+				entry.name, target, env.agentUserName, oneLine(out)))
 		}
 	}
 	if len(bad) > 0 {
@@ -496,6 +555,7 @@ type aggregateBody struct {
 	Pass     int `json:"pass"`
 	Fail     int `json:"fail"`
 	Skip     int `json:"skip"`
+	Unknown  int `json:"unknown,omitempty"`
 	Total    int `json:"total"`
 	ExitCode int `json:"exit_code"`
 }
@@ -535,8 +595,8 @@ verify never mutates state. Probes that require root visibility
 Exit codes:
   0  All probes passed.
   1  At least one probe failed (containment is broken or partially installed).
-  2  Verification incomplete (one or more probes skipped, curl/sudo missing,
-     context cancelled).`,
+  2  Verification incomplete (one or more probes skipped or inconclusive,
+     curl/sudo missing, context cancelled).`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
@@ -576,6 +636,11 @@ func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
 	}
 
 	w := cmd.OutOrStdout()
+	var textWriter *errorTrackingWriter
+	if !opts.jsonOutput {
+		textWriter = &errorTrackingWriter{w: w}
+		w = textWriter
+	}
 	enc := json.NewEncoder(w)
 
 	if !opts.jsonOutput {
@@ -584,13 +649,16 @@ func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
 			header += " --enforcement-only"
 		}
 		_, _ = fmt.Fprintln(w, header)
+		if err := textWriter.Err(); err != nil {
+			return fmt.Errorf("writing verify header: %w", err)
+		}
 	}
 
 	probes := probesForEnv(env)
 	if opts.enforcementOnly {
 		probes = enforcementProbes(probes)
 	}
-	var passN, failN, skipN int
+	var passN, failN, skipN, unknownN int
 
 	for _, p := range probes {
 		status, detail := p.fn(ctx, env)
@@ -601,6 +669,8 @@ func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
 			failN++
 		case statusSkip:
 			skipN++
+		case statusUnknown:
+			unknownN++
 		default:
 			// A probe returned something unexpected. Coerce to fail
 			// and carry the value forward so we don't silently drop it.
@@ -622,13 +692,16 @@ func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
 		}
 
 		writeTextLine(w, p, status, detail)
+		if err := textWriter.Err(); err != nil {
+			return fmt.Errorf("writing probe %d text: %w", p.n, err)
+		}
 	}
 
 	exitCode := cliutil.ExitOK
 	switch {
 	case failN > 0:
 		exitCode = cliutil.ExitGeneral
-	case skipN > 0:
+	case skipN > 0 || unknownN > 0:
 		exitCode = cliutil.ExitConfig
 	}
 
@@ -637,13 +710,21 @@ func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
 			Pass:     passN,
 			Fail:     failN,
 			Skip:     skipN,
+			Unknown:  unknownN,
 			Total:    len(probes),
 			ExitCode: exitCode,
 		}}); err != nil {
 			return fmt.Errorf("encoding aggregate JSON: %w", err)
 		}
 	} else {
-		_, _ = fmt.Fprintf(w, "Result: %d PASS / %d FAIL / %d SKIP — exit %d\n", passN, failN, skipN, exitCode)
+		if unknownN > 0 {
+			_, _ = fmt.Fprintf(w, "Result: %d PASS / %d FAIL / %d SKIP / %d UNKNOWN — exit %d\n", passN, failN, skipN, unknownN, exitCode)
+		} else {
+			_, _ = fmt.Fprintf(w, "Result: %d PASS / %d FAIL / %d SKIP — exit %d\n", passN, failN, skipN, exitCode)
+		}
+		if err := textWriter.Err(); err != nil {
+			return fmt.Errorf("writing verify aggregate: %w", err)
+		}
 	}
 
 	if exitCode == cliutil.ExitOK {
@@ -651,6 +732,9 @@ func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
 	}
 	if failN > 0 {
 		return cliutil.ExitCodeError(exitCode, fmt.Errorf("%d probe(s) failed", failN))
+	}
+	if unknownN > 0 {
+		return cliutil.ExitCodeError(exitCode, fmt.Errorf("%d probe(s) inconclusive; verification incomplete", unknownN))
 	}
 	return cliutil.ExitCodeError(exitCode, fmt.Errorf("%d probe(s) skipped; verification incomplete", skipN))
 }
@@ -678,6 +762,8 @@ func writeTextLine(w io.Writer, p probe, status, detail string) {
 		tag = "[FAIL]"
 	case statusSkip:
 		tag = "[SKIP]"
+	case statusUnknown:
+		tag = "[UNKNOWN]"
 	}
 
 	line := fmt.Sprintf("  %s probe %d: %s", tag, p.n, p.desc)
@@ -779,7 +865,7 @@ func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 		return statusFail, fmt.Sprintf("nft exit=%d: %s", code, oneLine(out))
 	}
 
-	if !strings.Contains(out, "chain "+env.nftChain) {
+	if !outputHasNFTChainDeclaration(out, env.nftChain) {
 		return statusFail, fmt.Sprintf("chain %s missing from table", env.nftChain)
 	}
 
@@ -807,6 +893,9 @@ func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 	}
 	if chainHasUnsafeVerdictBeforeAgentDrop(out, env.nftChain, current, env.port) {
 		return statusFail, "chain contains unexpected verdict before agent drop"
+	}
+	if !chainHasManagedOutputBaseChain(out, env.nftChain) {
+		return statusFail, fmt.Sprintf("chain %s is not the managed output base chain (want type filter hook output priority filter/0 policy accept)", env.nftChain)
 	}
 	if env.nftPersistUnitPath != "" && env.nftRulesPath != "" {
 		if err := verifyNFTPersistence(env); err != nil {
@@ -992,8 +1081,9 @@ func chainHasUnsafeVerdictBeforeAgentDrop(out, chainName string, uids containmen
 		// Before the agent catch-all drop, only the managed operator/proxy
 		// accepts, the agent's proxy loopback allow, and DNS drops are safe.
 		// Any other terminal/control-flow verdict can bypass containment under
-		// the base-chain "policy accept" default.
-		if !lineHasAnyToken(line, "accept", "return", "jump", "goto", "queue") {
+		// the base-chain "policy accept" default or intercept the direct canary
+		// before it reaches the counter used for attribution.
+		if !lineHasAnyToken(line, "accept", "drop", "reject", "return", "jump", "goto", "queue") {
 			return false
 		}
 		if uids.operatorKnown && lineHasTerminalSkuidVerdict(line, uids.operatorUID, "accept") {
@@ -1009,15 +1099,17 @@ func chainHasUnsafeVerdictBeforeAgentDrop(out, chainName string, uids containmen
 			lineHasSkuidProtocolDPortVerdict(line, uids.agentUID, "tcp", 53, "drop") {
 			return false
 		}
-		if uid, ok := terminalSkuidUIDVerdict(line, "accept"); ok && uid != uids.agentUID {
-			return false
+		for _, verdict := range []string{"accept", "drop", "reject"} {
+			if uid, ok := terminalSkuidUIDVerdict(line, verdict); ok && uid != uids.agentUID {
+				return false
+			}
 		}
 		return true
 	})
 }
 
 func terminalSkuidUIDVerdict(line, verdict string) (int, bool) {
-	fields := strings.Fields(line)
+	fields := nftLineFields(line)
 	for i := 0; i+1 < len(fields); i++ {
 		if fields[i] != "skuid" {
 			continue
@@ -1036,7 +1128,7 @@ func terminalSkuidUIDVerdict(line, verdict string) (int, bool) {
 
 func lineHasSkuid(line string, uid int) bool {
 	want := strconv.Itoa(uid)
-	fields := strings.Fields(line)
+	fields := nftLineFields(line)
 	for i, field := range fields {
 		if field == "skuid" && i+1 < len(fields) && fields[i+1] == want {
 			return true
@@ -1046,7 +1138,7 @@ func lineHasSkuid(line string, uid int) bool {
 }
 
 func lineHasTerminalSkuidVerdict(line string, uid int, verdict string) bool {
-	fields := strings.Fields(line)
+	fields := nftLineFields(line)
 	uidText := strconv.Itoa(uid)
 	skuidAt := indexSkuidUID(fields, uidText)
 	if skuidAt == -1 {
@@ -1060,7 +1152,7 @@ func lineHasTerminalSkuidVerdict(line string, uid int, verdict string) bool {
 }
 
 func lineHasSkuidProtocolDPortVerdict(line string, uid int, protocol string, port int, verdict string) bool {
-	fields := strings.Fields(line)
+	fields := nftLineFields(line)
 	skuidAt := indexSkuidUID(fields, strconv.Itoa(uid))
 	if skuidAt == -1 || skuidAt+3 >= len(fields) {
 		return false
@@ -1109,7 +1201,7 @@ func fieldsAreNFTBookkeeping(fields []string) bool {
 			// "counter packets <n> bytes <n>"; consume the numeric
 			// argument that follows the packets/bytes keyword.
 			expectCount = false
-			if _, err := strconv.Atoi(field); err == nil {
+			if _, err := strconv.ParseUint(field, 10, 64); err == nil {
 				continue
 			}
 			return false
@@ -1134,7 +1226,7 @@ func fieldsAreNFTBookkeeping(fields []string) bool {
 }
 
 func lineHasIPDAddr(line, addr string) bool {
-	fields := strings.Fields(line)
+	fields := nftLineFields(line)
 	for i := 0; i+2 < len(fields); i++ {
 		if fields[i] == "ip" && fields[i+1] == "daddr" && fields[i+2] == addr {
 			return true
@@ -1145,7 +1237,7 @@ func lineHasIPDAddr(line, addr string) bool {
 
 func lineHasDPort(line string, port int) bool {
 	want := strconv.Itoa(port)
-	fields := strings.Fields(line)
+	fields := nftLineFields(line)
 	for i, field := range fields {
 		if field == "dport" && i+1 < len(fields) && fields[i+1] == want {
 			return true
@@ -1155,7 +1247,7 @@ func lineHasDPort(line string, port int) bool {
 }
 
 func lineHasToken(line, want string) bool {
-	for _, field := range strings.Fields(line) {
+	for _, field := range nftLineFields(line) {
 		if field == want {
 			return true
 		}
@@ -1164,11 +1256,142 @@ func lineHasToken(line, want string) bool {
 }
 
 func lineHasAnyToken(line string, wants ...string) bool {
-	for _, field := range strings.Fields(line) {
+	for _, field := range nftLineFields(line) {
 		for _, want := range wants {
 			if field == want {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// nftLineFields tokenizes one nft list-output line without treating whitespace
+// or verdict-looking words inside quoted strings as rule syntax. A trailing
+// "# handle N" annotation is a comment and is omitted. This is intentionally a
+// small list-output tokenizer, not a general nft parser: the verifier only
+// needs stable tokens for the canonical rules renderNFTRules emits.
+func nftLineFields(line string) []string {
+	fields := make([]string, 0, 16)
+	var field strings.Builder
+	inQuote := false
+	escaped := false
+	flush := func() {
+		if field.Len() == 0 {
+			return
+		}
+		fields = append(fields, field.String())
+		field.Reset()
+	}
+
+	for _, r := range line {
+		if inQuote {
+			field.WriteRune(r)
+			switch {
+			case escaped:
+				escaped = false
+			case r == '\\':
+				escaped = true
+			case r == '"':
+				inQuote = false
+			}
+			continue
+		}
+
+		switch r {
+		case '#':
+			flush()
+			return fields
+		case '"':
+			inQuote = true
+			field.WriteRune(r)
+		case ' ', '\t', '\r', '\n', '\v', '\f':
+			flush()
+		default:
+			field.WriteRune(r)
+		}
+	}
+	flush()
+	return fields
+}
+
+// nftLineBraceDelta counts structural braces while ignoring braces inside
+// quoted comments/log prefixes and trailing "# handle N" annotations.
+func nftLineBraceDelta(line string) int {
+	delta := 0
+	inQuote := false
+	escaped := false
+	for _, r := range line {
+		if inQuote {
+			switch {
+			case escaped:
+				escaped = false
+			case r == '\\':
+				escaped = true
+			case r == '"':
+				inQuote = false
+			}
+			continue
+		}
+		switch r {
+		case '#':
+			return delta
+		case '"':
+			inQuote = true
+		case '{':
+			delta++
+		case '}':
+			delta--
+		}
+	}
+	return delta
+}
+
+// nftLineHasBalancedQuotes rejects malformed list output before chain traversal.
+// Without this check, an unterminated quoted comment could hide the target
+// chain's closing brace and make rules in a later chain look attributable to it.
+func nftLineHasBalancedQuotes(line string) bool {
+	inQuote := false
+	escaped := false
+	for _, r := range line {
+		if inQuote {
+			switch {
+			case escaped:
+				escaped = false
+			case r == '\\':
+				escaped = true
+			case r == '"':
+				inQuote = false
+			}
+			continue
+		}
+		switch r {
+		case '#':
+			return true
+		case '"':
+			inQuote = true
+		}
+	}
+	return !inQuote
+}
+
+func isNFTChainDeclaration(line, chainName string) bool {
+	if !nftLineHasBalancedQuotes(line) {
+		return false
+	}
+	fields := nftLineFields(line)
+	if len(fields) == 3 {
+		return fields[0] == "chain" && fields[1] == chainName && fields[2] == "{"
+	}
+	// Retain support for compact synthetic listings used by older tests while
+	// requiring an exact name rather than a prefix match.
+	return line == "chain "+chainName+"{"
+}
+
+func outputHasNFTChainDeclaration(out, chainName string) bool {
+	for _, raw := range strings.Split(out, "\n") {
+		if isNFTChainDeclaration(strings.TrimSpace(raw), chainName) {
+			return true
 		}
 	}
 	return false
@@ -1182,27 +1405,25 @@ func chainHasLineBeforeAgentDrop(out, chainName string, agentUID int, match func
 		if line == "" {
 			continue
 		}
-		if !inChain && (strings.HasPrefix(line, "chain "+chainName+" ") || line == "chain "+chainName+"{") {
+		if !inChain && isNFTChainDeclaration(line, chainName) {
 			inChain = true
 		}
 		if !inChain {
 			continue
 		}
-		if strings.Contains(line, "{") {
-			depth += strings.Count(line, "{")
+		if !nftLineHasBalancedQuotes(line) {
+			return false
 		}
+		depth += nftLineBraceDelta(line)
 		if lineHasTerminalSkuidVerdict(line, agentUID, "drop") {
 			return false
 		}
 		if match(line) {
 			return true
 		}
-		if strings.Contains(line, "}") {
-			depth -= strings.Count(line, "}")
-			if depth <= 0 {
-				inChain = false
-				depth = 0
-			}
+		if depth <= 0 {
+			inChain = false
+			depth = 0
 		}
 	}
 	return false
@@ -1216,24 +1437,22 @@ func chainHasLine(out, chainName string, match func(string) bool) bool {
 		if line == "" {
 			continue
 		}
-		if !inChain && (strings.HasPrefix(line, "chain "+chainName+" ") || line == "chain "+chainName+"{") {
+		if !inChain && isNFTChainDeclaration(line, chainName) {
 			inChain = true
 		}
 		if !inChain {
 			continue
 		}
-		if strings.Contains(line, "{") {
-			depth += strings.Count(line, "{")
+		if !nftLineHasBalancedQuotes(line) {
+			return false
 		}
+		depth += nftLineBraceDelta(line)
 		if match(line) {
 			return true
 		}
-		if strings.Contains(line, "}") {
-			depth -= strings.Count(line, "}")
-			if depth <= 0 {
-				inChain = false
-				depth = 0
-			}
+		if depth <= 0 {
+			inChain = false
+			depth = 0
 		}
 	}
 	return false
@@ -1457,8 +1676,147 @@ func curlNoProxyArgsFor(curl string) []string {
 	}
 }
 
+func curlDirectCanaryArgsFor(curl string) []string {
+	if curl == "" {
+		curl = defaultCurlPath
+	}
+	return []string{
+		curl,
+		"--connect-timeout", directCurlConnectTimeout,
+		"--max-time", directCurlMaxTime,
+		"--noproxy", "*",
+		"-sS",
+		"-o", "/dev/null",
+		"-w", "%{http_code}",
+		directEgressCanaryURL,
+	}
+}
+
+// readContainmentDropCounter reads the packet counter on the single managed
+// catch-all DROP rule for the current contained-agent UID. Probe 8 uses a
+// literal IP and therefore must reach this rule rather than either DNS rule.
+func readContainmentDropCounter(ctx context.Context, env *probeEnv) (uint64, error) {
+	current, err := containmentUIDsFromProbeEnv(env)
+	if err != nil {
+		return 0, err
+	}
+	out, code, err := env.runCmd(ctx, probeNFTExecutable(env), "-n", "list", "chain", "inet", env.nftTable, env.nftChain)
+	if err != nil {
+		return 0, fmt.Errorf("list nft chain: %w", err)
+	}
+	if code != 0 {
+		return 0, fmt.Errorf("list nft chain exit=%d: %s", code, oneLine(out))
+	}
+	if !chainHasManagedOutputBaseChain(out, env.nftChain) {
+		return 0, fmt.Errorf("chain %s is not the managed output base chain (want type filter hook output priority filter/0 policy accept)", env.nftChain)
+	}
+	if chainHasUnsafeVerdictBeforeAgentDrop(out, env.nftChain, current, env.port) {
+		return 0, fmt.Errorf("chain %s has an unexpected verdict before managed catch-all DROP; direct-canary attribution is unsafe", env.nftChain)
+	}
+	return managedContainmentDropPacketCount(out, env.nftChain, current.agentUID)
+}
+
+// chainHasManagedOutputBaseChain confirms the requested chain is attached to
+// the local-output hook with the declaration renderNFTRules installs. nft may
+// print the standard "filter" priority symbolically or as its numeric value 0.
+// Without this check, a regular/unhooked lookalike chain could provide a benign
+// counter that the direct-canary packet never traverses.
+func chainHasManagedOutputBaseChain(out, chainName string) bool {
+	return chainHasLine(out, chainName, func(line string) bool {
+		fields := nftLineFields(strings.ReplaceAll(line, ";", " "))
+		if len(fields) != 8 {
+			return false
+		}
+		return fields[0] == "type" &&
+			fields[1] == "filter" &&
+			fields[2] == "hook" &&
+			fields[3] == "output" &&
+			fields[4] == "priority" &&
+			(fields[5] == "filter" || fields[5] == "0") &&
+			fields[6] == "policy" &&
+			fields[7] == "accept"
+	})
+}
+
+// managedContainmentDropPacketCount extracts the packet count from exactly one
+// canonical managed agent catch-all DROP rule in the requested chain. Duplicate
+// lookalikes, wrong-chain rules, DNS counters, and rules with extra predicates
+// are rejected rather than accepted as attribution evidence.
+func managedContainmentDropPacketCount(out, chainName string, agentUID int) (uint64, error) {
+	var packets uint64
+	var parseErr error
+	matched := 0
+	_ = chainHasLine(out, chainName, func(line string) bool {
+		if parseErr != nil ||
+			!strings.Contains(line, `log prefix "`+nftLogPrefix(EgressClassNotRoutingThroughPipelock)+` "`) {
+			return false
+		}
+
+		fields := nftLineFields(line)
+		uidAt := indexSkuidUID(fields, strconv.Itoa(agentUID))
+		// renderNFTRules emits the catch-all expression as the complete
+		// `meta skuid <uid>` predicate. Requiring it at the start rejects a
+		// destination/interface/etc. predicate placed before skuid; such a
+		// lookalike would not necessarily see the direct-canary packet.
+		if uidAt != 2 || fields[0] != "meta" || fields[1] != "skuid" {
+			return false
+		}
+		dropAt := indexTokenAfter(fields, "drop", uidAt+1)
+		if dropAt == -1 || uidAt+1 >= dropAt || fields[uidAt+1] != "counter" {
+			return false
+		}
+		packetsAt := -1
+		for i := uidAt + 1; i+2 < dropAt; i++ {
+			if fields[i] == "counter" && fields[i+1] == "packets" {
+				if packetsAt != -1 {
+					parseErr = fmt.Errorf("managed catch-all DROP rule has multiple packet counters: %s", oneLine(line))
+					return false
+				}
+				packetsAt = i + 2
+			}
+		}
+		if packetsAt == -1 {
+			parseErr = fmt.Errorf("managed catch-all DROP rule has no expanded packet counter: %s", oneLine(line))
+			return false
+		}
+		parsed, err := strconv.ParseUint(fields[packetsAt], 10, 64)
+		if err != nil {
+			parseErr = fmt.Errorf("parse managed catch-all DROP packet counter %q: %w", fields[packetsAt], err)
+			return false
+		}
+		if !fieldsAreNFTBookkeeping(fields[uidAt+1 : dropAt]) {
+			return false
+		}
+		packets = parsed
+		matched++
+		return false
+	})
+	if parseErr != nil {
+		return 0, parseErr
+	}
+	if matched == 0 {
+		return 0, fmt.Errorf("no managed catch-all DROP packet counter found in chain %s for agent uid %d", chainName, agentUID)
+	}
+	if matched != 1 {
+		return 0, fmt.Errorf("found %d managed catch-all DROP packet counters in chain %s for agent uid %d; want exactly one", matched, chainName, agentUID)
+	}
+	return packets, nil
+}
+
+// probeCCAgentEgressDenied verifies that a failed direct-egress curl coincides
+// with an increment in the exact managed catch-all DROP counter. The counter is
+// UID-wide, not process-exclusive: the literal-IP target, single-rule match,
+// and two-second ceiling reduce but cannot eliminate attribution from other
+// concurrent traffic under the contained UID. A fully exclusive counter would
+// require temporarily mutating nftables, which would violate verify's read-only
+// contract.
 func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, string) {
-	curlArgs := curlNoProxyArgsFor(env.curlPath)
+	var before uint64
+	var beforeErr error
+	if env.dropCounter != nil {
+		before, beforeErr = env.dropCounter(ctx, env)
+	}
+	curlArgs := curlDirectCanaryArgsFor(env.curlPath)
 	curlPath := curlArgs[0]
 	args := append([]string{"-n", "-u", env.agentUserName, "--"}, curlArgs...)
 	out, code, err := env.runCmd(ctx, "sudo", args...)
@@ -1475,9 +1833,29 @@ func probeCCAgentEgressDenied(ctx context.Context, env *probeEnv) (string, strin
 		return statusSkip, fmt.Sprintf("sudo could not execute %s; install curl to enable canary", curlPath)
 	}
 	if code == 0 {
-		return statusFail, fmt.Sprintf("unexpected curl success: HTTP %s from example.com", oneLine(out))
+		return statusFail, fmt.Sprintf("unexpected curl success: HTTP %s from direct canary %s", oneLine(out), directEgressCanaryURL)
 	}
-	return statusPass, fmt.Sprintf("curl blocked (exit=%d) — containment enforced", code)
+	if env.dropCounter == nil {
+		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but no DROP counter reader is available; containment attribution is inconclusive", code)
+	}
+	after, afterErr := env.dropCounter(ctx, env)
+	if beforeErr != nil {
+		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but containment attribution is inconclusive: read DROP counter before probe: %v", code, beforeErr)
+	}
+	if afterErr != nil {
+		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but containment attribution is inconclusive: read DROP counter after probe: %v", code, afterErr)
+	}
+	if after <= before {
+		return statusUnknown, fmt.Sprintf("curl failed (exit=%d), but managed DROP counter did not increase (%d -> %d); failure may be unrelated to containment", code, before, after)
+	}
+	if !isDirectEgressBlockedCurlExit(code) {
+		return statusUnknown, fmt.Sprintf("curl failed with unexpected exit=%d despite a counter delta; the DNS-free HTTP canary expected a connect refusal or timeout", code)
+	}
+	return statusPass, fmt.Sprintf("curl blocked (exit=%d); managed DROP counter increased (%d -> %d) — containment enforced", code, before, after)
+}
+
+func isDirectEgressBlockedCurlExit(code int) bool {
+	return code == 7 || code == 28
 }
 
 // ---------------------------------------------------------------------------
@@ -1566,11 +1944,12 @@ func isSudoTargetCommandMissing(out string) bool {
 		strings.Contains(low, "no such file or directory")
 }
 
-// oneLine trims trailing whitespace and collapses internal newlines so
-// detail lines don't break text output.
+// oneLine trims and collapses whitespace, and removes control/format runes so
+// subprocess output cannot inject terminal escapes or bidirectional formatting
+// into text-mode evidence.
 func oneLine(s string) string {
-	s = strings.TrimSpace(s)
-	s = strings.ReplaceAll(s, "\n", " ")
-	s = strings.ReplaceAll(s, "\r", " ")
-	return s
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r) || unicode.In(r, unicode.Cf)
+	})
+	return strings.Join(fields, " ")
 }

--- a/internal/cli/contain/verify_probe11_test.go
+++ b/internal/cli/contain/verify_probe11_test.go
@@ -188,6 +188,12 @@ func TestProbeListedToolTargets_PassWithExplicitTarget(t *testing.T) {
 	env := makeProbeEnv(t)
 	target := filepath.Join(t.TempDir(), "claude")
 	writeFakeWrapper(t, target, 0o755)
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name != "sudo" || !containsArg(args, "test") || !containsArg(args, "-x") || !containsArg(args, target) {
+			t.Fatalf("unexpected agent executable check: %s %v", name, args)
+		}
+		return "", 0, nil
+	}
 	env.readFile = func(path string) ([]byte, error) {
 		if path == env.toolsListPath {
 			return []byte("claude\t" + target + "\n"), nil
@@ -237,6 +243,13 @@ func TestProbeListedToolTargets_PassWithAgentPathLookup(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	writeFakeWrapper(t, filepath.Join(agentHomeBin, "claude"), 0o755)
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name != "sudo" || !containsArg(args, "test") || !containsArg(args, "-x") ||
+			!containsArg(args, "/home/"+testAgentUser+"/.local/bin/claude") {
+			t.Fatalf("unexpected agent executable check: %s %v", name, args)
+		}
+		return "", 0, nil
+	}
 	env.readFile = func(path string) ([]byte, error) {
 		if path == env.toolsListPath {
 			return []byte("claude\t\n"), nil
@@ -246,6 +259,32 @@ func TestProbeListedToolTargets_PassWithAgentPathLookup(t *testing.T) {
 	status, detail := probeListedToolTargets(context.Background(), env)
 	if status != statusPass {
 		t.Fatalf("status: %s detail=%s", status, detail)
+	}
+}
+
+func TestProbeListedToolTargets_FailsWhenOnlyRootCanTraverseTarget(t *testing.T) {
+	env := makeProbeEnv(t)
+	target := filepath.Join(t.TempDir(), "root-only", "claude")
+	if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+		t.Fatalf("mkdir target parent: %v", err)
+	}
+	writeFakeWrapper(t, target, 0o755)
+	env.readFile = func(path string) ([]byte, error) {
+		if path == env.toolsListPath {
+			return []byte("claude\t" + target + "\n"), nil
+		}
+		return nil, fmt.Errorf("unexpected readFile %s", path)
+	}
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name != "sudo" || !containsArg(args, target) {
+			t.Fatalf("unexpected agent executable check: %s %v", name, args)
+		}
+		return "test: " + target + ": Permission denied", 1, nil
+	}
+
+	status, detail := probeListedToolTargets(context.Background(), env)
+	if status != statusFail || !strings.Contains(detail, "not executable/traversable by") {
+		t.Fatalf("probe = (%q, %q), want agent-context traversal failure", status, detail)
 	}
 }
 

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -49,6 +49,7 @@ const (
 
 const goodNFTContainmentOutput = `table inet pipelock_containment {
 	chain output_filter {
+		type filter hook output priority filter; policy accept;
 		meta skuid 1000 accept
 		meta skuid 988 accept
 		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
@@ -166,6 +167,7 @@ func makeProbeEnv(t *testing.T, opts ...func(*probeEnv)) *probeEnv {
 		pinPath:       filepath.Join(t.TempDir(), "binary-pin.sha256"),
 		toolsListPath: filepath.Join(t.TempDir(), "tools.list"),
 		runCmd:        rejectAllRun,
+		dropCounter:   rejectAllDropCounter,
 		dialCtx:       rejectAllDial,
 		lookupUser:    rejectAllLookup,
 		groupIDs:      rejectAllGroupIDs,
@@ -187,6 +189,12 @@ func rejectAllGroupIDs(u *user.User) ([]string, error) {
 
 func rejectAllRun(_ context.Context, name string, args ...string) (string, int, error) {
 	return "", -1, fmt.Errorf("unstubbed run: %s %v", name, args)
+}
+
+// rejectAllDropCounter fails tests that invoke the containment counter without
+// installing a deterministic counter stub.
+func rejectAllDropCounter(_ context.Context, _ *probeEnv) (uint64, error) {
+	return 0, errors.New("unstubbed containment DROP counter")
 }
 
 func rejectAllDial(_ context.Context, _, address string, _ time.Duration) (net.Conn, error) {
@@ -386,6 +394,23 @@ func TestProbeNFTContainment(t *testing.T) {
 			wantDetail: "skuid drop rule",
 		},
 		{
+			name: "otherwise canonical regular chain is not containment",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+			`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "not the managed output base chain",
+		},
+		{
 			name:       "permission denied",
 			stdout:     "Error: Operation not permitted\n",
 			code:       1,
@@ -444,6 +469,24 @@ func TestProbeNFTContainment(t *testing.T) {
 			code:       0,
 			wantStatus: statusFail,
 			wantDetail: "skuid-drop rule missing",
+		},
+		{
+			name: "canary-specific drop before catch all is unexpected",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 ip daddr 192.0.2.1 drop
+			meta skuid 987 drop
+		}
+	}
+			`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "unexpected verdict",
 		},
 		{
 			name: "broad loopback accept",
@@ -1621,22 +1664,435 @@ func TestExtractNoProxy(t *testing.T) {
 
 // Probe 8 + 9: egress canary + operator reachability -------------------------
 
-func TestProbeCCAgentEgressDenied(t *testing.T) {
+func TestManagedContainmentDropPacketCount(t *testing.T) {
 	tests := []struct {
-		name       string
-		stdout     string
-		code       int
-		runErr     error
-		curlPath   string
-		wantStatus string
-		wantDetail string
+		name    string
+		output  string
+		chain   string
+		uid     int
+		want    uint64
+		wantErr string
 	}{
 		{
-			name:       "egress blocked (curl exit 7)",
-			stdout:     "curl: (7) Failed to connect",
-			code:       7,
-			wantStatus: statusPass,
-			wantDetail: "containment enforced",
+			name:   "reads exact managed catch-all rule",
+			output: goodNFTContainmentOutputRealListing,
+			chain:  testChain,
+			uid:    987,
+			want:   12,
+		},
+		{
+			name: "rejects unexpanded counter",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 counter log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			chain:   testChain,
+			uid:     987,
+			wantErr: "no expanded packet counter",
+		},
+		{
+			name:    "rejects different uid",
+			output:  goodNFTContainmentOutputRealListing,
+			chain:   testChain,
+			uid:     986,
+			wantErr: "no managed catch-all DROP packet counter",
+		},
+		{
+			name: "rejects malformed packet count",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 counter packets nope bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			chain:   testChain,
+			uid:     987,
+			wantErr: "parse managed catch-all DROP packet counter",
+		},
+		{
+			name: "accepts maximum uint64 packet count",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 counter packets 18446744073709551615 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			chain: testChain,
+			uid:   987,
+			want:  ^uint64(0),
+		},
+		{
+			name: "rejects packet count overflow",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 counter packets 18446744073709551616 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			chain:   testChain,
+			uid:     987,
+			wantErr: "value out of range",
+		},
+		{
+			name: "rejects matching lookalike in wrong chain",
+			output: `table inet pipelock_containment {
+	chain decoy {
+		meta skuid 987 counter packets 44 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+	chain output_filter {
+		meta skuid 987 counter packets 12 bytes 0 drop
+	}
+}`,
+			chain:   testChain,
+			uid:     987,
+			wantErr: "no managed catch-all DROP packet counter",
+		},
+		{
+			name: "rejects duplicate managed catch-all counters",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 counter packets 12 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+		meta skuid 987 counter packets 13 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			chain:   testChain,
+			uid:     987,
+			wantErr: "found 2 managed catch-all DROP packet counters",
+		},
+		{
+			name: "rejects destination-specific lookalike",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 ip daddr 192.0.2.1 counter packets 12 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			chain:   testChain,
+			uid:     987,
+			wantErr: "no managed catch-all DROP packet counter",
+		},
+		{
+			name: "rejects destination predicate before skuid",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+		ip daddr 203.0.113.10 meta skuid 987 counter packets 12 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			chain:   testChain,
+			uid:     987,
+			wantErr: "no managed catch-all DROP packet counter",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := managedContainmentDropPacketCount(tc.output, tc.chain, tc.uid)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("managedContainmentDropPacketCount: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("packet count = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNFTChainTraversalRejectsCraftedNamesAndMalformedComments(t *testing.T) {
+	const managedRule = `meta skuid 987 counter packets 44 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop`
+	tests := []struct {
+		name string
+		out  string
+	}{
+		{
+			name: "chain-name prefix is not the managed chain",
+			out: `table inet pipelock_containment {
+	chain output_filter decoy {
+		` + managedRule + `
+	}
+}`,
+		},
+		{
+			name: "unterminated quoted comment cannot bleed into later chain",
+			out: `table inet pipelock_containment {
+	chain output_filter {
+		comment "unterminated }
+	chain decoy {
+		` + managedRule + `
+	}
+}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if outputHasNFTChainDeclaration(tc.out, testChain) && tc.name == "chain-name prefix is not the managed chain" {
+				t.Fatal("crafted prefix was accepted as an exact chain declaration")
+			}
+			if got, err := managedContainmentDropPacketCount(tc.out, testChain, 987); err == nil {
+				t.Fatalf("crafted output attributed packet count %d to %s", got, testChain)
+			}
+		})
+	}
+}
+
+func TestReadContainmentDropCounter(t *testing.T) {
+	tests := []struct {
+		name       string
+		lookupErr  error
+		output     string
+		code       int
+		runErr     error
+		want       uint64
+		wantErr    string
+		wantRunCmd bool
+	}{
+		{name: "reads live managed counters", output: goodNFTContainmentOutputRealListing, want: 12, wantRunCmd: true},
+		{
+			name: "rejects unhooked regular chain",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+			meta skuid 987 counter packets 12 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			wantErr:    "not the managed output base chain",
+			wantRunCmd: true,
+		},
+		{
+			name: "accepts harmless quoted nft comments and handle annotations",
+			output: `table inet pipelock_containment {
+	chain output_filter { # handle 1
+		comment "managed drop evidence }"
+		type filter hook output priority 0; policy accept;
+		meta skuid 1000 accept comment "operator accept" # handle 2
+		meta skuid 988 accept comment "proxy accept" # handle 3
+		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept comment "loopback } allow" # handle 4
+		meta skuid 987 udp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked " drop # handle 5
+		meta skuid 987 tcp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked " drop # handle 6
+		meta skuid 987 counter packets 12 bytes 840 log prefix "pipelock-contain class=not_routing_through_pipelock " drop comment "canonical drop evidence" # handle 7
+	}
+}`,
+			want:       12,
+			wantRunCmd: true,
+		},
+		{
+			name: "rejects unexpected nft json instead of misaggregating it",
+			output: `{"nftables":[
+{"chain":{"family":"inet","table":"pipelock_containment","name":"output_filter","type":"filter","hook":"output","prio":0,"policy":"accept"}},
+{"rule":{"family":"inet","table":"pipelock_containment","chain":"output_filter","expr":[
+{"match":{"op":"==","left":{"meta":{"key":"skuid"}},"right":987}},
+{"counter":{"packets":12,"bytes":840}},
+{"log":{"prefix":"pipelock-contain class=not_routing_through_pipelock "}},
+{"drop":null}
+]}}
+]}`,
+			wantErr:    "not the managed output base chain",
+			wantRunCmd: true,
+		},
+		{
+			name: "rejects canary interception before managed counter",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+			type filter hook output priority 0; policy accept;
+		meta skuid 987 ip daddr 192.0.2.1 drop
+		meta skuid 987 counter packets 12 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			wantErr:    "unexpected verdict before managed catch-all DROP",
+			wantRunCmd: true,
+		},
+		{name: "agent lookup failure", lookupErr: errors.New("missing user"), wantErr: "lookup agent uid"},
+		{name: "nft invocation failure", runErr: errors.New("nft missing"), wantErr: "list nft chain", wantRunCmd: true},
+		{name: "nft nonzero exit", output: "operation not permitted", code: 1, wantErr: "exit=1", wantRunCmd: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runCalled := false
+			env := makeProbeEnv(t, func(e *probeEnv) {
+				e.lookupUser = func(name string) (*user.User, error) {
+					switch name {
+					case testProxyUser:
+						return &user.User{Uid: "988", Username: testProxyUser}, nil
+					case testAgentUser:
+						return &user.User{Uid: "987", Username: testAgentUser}, tc.lookupErr
+					default:
+						t.Fatalf("unexpected lookup user %q", name)
+						return nil, nil
+					}
+				}
+				e.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+					runCalled = true
+					if name != testNFT {
+						t.Fatalf("command = %q, want %q", name, testNFT)
+					}
+					wantArgs := []string{"-n", "list", "chain", "inet", testTable, testChain}
+					if strings.Join(args, " ") != strings.Join(wantArgs, " ") {
+						t.Fatalf("args = %v, want %v", args, wantArgs)
+					}
+					return tc.output, tc.code, tc.runErr
+				}
+			})
+
+			got, err := readContainmentDropCounter(context.Background(), env)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tc.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("readContainmentDropCounter: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("counter = %d, want %d", got, tc.want)
+			}
+			if runCalled != tc.wantRunCmd {
+				t.Fatalf("run called = %t, want %t", runCalled, tc.wantRunCmd)
+			}
+		})
+	}
+}
+
+func TestChainHasManagedOutputBaseChain(t *testing.T) {
+	tests := []struct {
+		name string
+		decl string
+		want bool
+	}{
+		{
+			name: "symbolic filter priority emitted by nft",
+			decl: "type filter hook output priority filter; policy accept;",
+			want: true,
+		},
+		{
+			name: "numeric filter priority emitted by nft",
+			decl: "type filter hook output priority 0; policy accept;",
+			want: true,
+		},
+		{name: "regular chain is unattached", want: false},
+		{
+			name: "wrong hook",
+			decl: "type filter hook input priority filter; policy accept;",
+			want: false,
+		},
+		{
+			name: "wrong priority",
+			decl: "type filter hook output priority 10; policy accept;",
+			want: false,
+		},
+		{
+			name: "wrong policy",
+			decl: "type filter hook output priority filter; policy drop;",
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := "table inet pipelock_containment {\n\tchain output_filter {\n\t\t" + tc.decl +
+				"\n\t}\n}"
+			if got := chainHasManagedOutputBaseChain(out, testChain); got != tc.want {
+				t.Fatalf("chainHasManagedOutputBaseChain() = %t, want %t for %q", got, tc.want, tc.decl)
+			}
+		})
+	}
+}
+
+func TestProbeCCAgentEgressDenied(t *testing.T) {
+	tests := []struct {
+		name             string
+		stdout           string
+		code             int
+		runErr           error
+		curlPath         string
+		counterBefore    uint64
+		counterAfter     uint64
+		counterBeforeErr error
+		counterAfterErr  error
+		noCounterReader  bool
+		wantStatus       string
+		wantDetail       string
+	}{
+		{
+			name:          "attributable egress block passes",
+			stdout:        "curl: (7) Failed to connect",
+			code:          7,
+			counterBefore: 12,
+			counterAfter:  13,
+			wantStatus:    statusPass,
+			wantDetail:    "managed DROP counter increased",
+		},
+		{
+			name:          "DNS failure without counter delta is inconclusive",
+			stdout:        "curl: (6) Could not resolve host: example.com",
+			code:          6,
+			counterBefore: 12,
+			counterAfter:  12,
+			wantStatus:    statusUnknown,
+			wantDetail:    "may be unrelated to containment",
+		},
+		{
+			name:          "timeout without counter delta is inconclusive",
+			stdout:        "curl: (28) Connection timed out",
+			code:          28,
+			counterBefore: 12,
+			counterAfter:  12,
+			wantStatus:    statusUnknown,
+			wantDetail:    "may be unrelated to containment",
+		},
+		{
+			name:          "counter reset or wrap is inconclusive",
+			stdout:        "curl: (28) Connection timed out",
+			code:          28,
+			counterBefore: ^uint64(0),
+			counterAfter:  0,
+			wantStatus:    statusUnknown,
+			wantDetail:    "did not increase",
+		},
+		{
+			name:          "TLS failure without counter delta is inconclusive",
+			stdout:        "curl: (35) TLS connect error",
+			code:          35,
+			counterBefore: 12,
+			counterAfter:  12,
+			wantStatus:    statusUnknown,
+			wantDetail:    "may be unrelated to containment",
+		},
+		{
+			name:          "TLS failure with unrelated counter delta is still inconclusive",
+			stdout:        "curl: (35) TLS connect error",
+			code:          35,
+			counterBefore: 12,
+			counterAfter:  13,
+			wantStatus:    statusUnknown,
+			wantDetail:    "unexpected exit=35 despite a counter delta",
+		},
+		{
+			name:            "no counter reader is inconclusive even for refused connection",
+			stdout:          "curl: (7) Failed to connect: Connection refused",
+			code:            7,
+			noCounterReader: true,
+			wantStatus:      statusUnknown,
+			wantDetail:      "no DROP counter reader",
+		},
+		{
+			name:             "counter unavailable before probe is inconclusive",
+			stdout:           "curl: (7) Failed to connect",
+			code:             7,
+			counterBeforeErr: errors.New("operation not permitted"),
+			counterAfter:     13,
+			wantStatus:       statusUnknown,
+			wantDetail:       "before probe",
+		},
+		{
+			name:            "counter unavailable after probe is inconclusive",
+			stdout:          "curl: (7) Failed to connect",
+			code:            7,
+			counterBefore:   12,
+			counterAfterErr: errors.New("table disappeared"),
+			wantStatus:      statusUnknown,
+			wantDetail:      "after probe",
 		},
 		{
 			name:       "egress succeeded (regression)",
@@ -1701,6 +2157,18 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := makeProbeEnv(t, func(e *probeEnv) {
 				e.curlPath = tc.curlPath
+				if tc.noCounterReader {
+					e.dropCounter = nil
+				} else {
+					counterReads := 0
+					e.dropCounter = func(_ context.Context, _ *probeEnv) (uint64, error) {
+						counterReads++
+						if counterReads == 1 {
+							return tc.counterBefore, tc.counterBeforeErr
+						}
+						return tc.counterAfter, tc.counterAfterErr
+					}
+				}
 				e.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
 					if name != testSudoCmd {
 						t.Fatalf("unexpected cmd %q", name)
@@ -1709,6 +2177,13 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 					joined := strings.Join(args, " ")
 					if !strings.Contains(joined, "-u "+testAgentUser) {
 						t.Fatalf("argv missing -u %s: %v", testAgentUser, args)
+					}
+					if !strings.Contains(joined, directEgressCanaryURL) || strings.Contains(joined, canaryURL) {
+						t.Fatalf("argv does not use DNS-free direct canary %q: %v", directEgressCanaryURL, args)
+					}
+					if !strings.Contains(joined, "--connect-timeout "+directCurlConnectTimeout) ||
+						!strings.Contains(joined, "--max-time "+directCurlMaxTime) {
+						t.Fatalf("argv does not use bounded direct-canary timeouts: %v", args)
 					}
 					return tc.stdout, tc.code, tc.runErr
 				}
@@ -2126,6 +2601,203 @@ func TestRunVerify_SkipExitCode(t *testing.T) {
 	}
 }
 
+func TestRunVerify_UnknownExitCode(t *testing.T) {
+	env := allPassEnv(t)
+	env.dropCounter = func(_ context.Context, _ *probeEnv) (uint64, error) {
+		return 12, nil
+	}
+
+	cmd := newVerifyCmd(t)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := runVerify(cmd, env, verifyOpts{jsonOutput: false})
+	if err == nil {
+		t.Fatal("expected error for inconclusive egress attribution")
+	}
+	if code := cliutil.ExitCodeOf(err); code != cliutil.ExitConfig {
+		t.Errorf("exit code: got %d, want %d", code, cliutil.ExitConfig)
+	}
+	if !strings.Contains(buf.String(), "[UNKNOWN]") || !strings.Contains(buf.String(), "1 UNKNOWN") {
+		t.Errorf("missing unknown result in output: %q", buf.String())
+	}
+}
+
+func TestRunVerify_JSONUnknownIsIncomplete(t *testing.T) {
+	env := allPassEnv(t)
+	env.dropCounter = func(_ context.Context, _ *probeEnv) (uint64, error) {
+		return 12, nil
+	}
+
+	cmd := newVerifyCmd(t)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := runVerify(cmd, env, verifyOpts{jsonOutput: true})
+	if code := cliutil.ExitCodeOf(err); code != cliutil.ExitConfig {
+		t.Fatalf("exit code = %d, want %d (err=%v)", code, cliutil.ExitConfig, err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 13 {
+		t.Fatalf("JSON record count = %d, want 13: %q", len(lines), buf.String())
+	}
+	var canary probeRecord
+	if err := json.Unmarshal([]byte(lines[7]), &canary); err != nil {
+		t.Fatalf("decode canary: %v", err)
+	}
+	if canary.Probe != 8 || canary.Status != statusUnknown {
+		t.Fatalf("canary record = %+v, want probe 8 unknown", canary)
+	}
+	var agg aggregateRecord
+	if err := json.Unmarshal([]byte(lines[12]), &agg); err != nil {
+		t.Fatalf("decode aggregate: %v", err)
+	}
+	if agg.Aggregate.Unknown != 1 || agg.Aggregate.Pass != 11 || agg.Aggregate.ExitCode != cliutil.ExitConfig {
+		t.Fatalf("aggregate = %+v, want 11 pass / 1 unknown / exit 2", agg.Aggregate)
+	}
+}
+
+func TestRunVerify_MixedOutcomesPreserveWorstResultInTextAndJSON(t *testing.T) {
+	for _, jsonOutput := range []bool{false, true} {
+		t.Run(map[bool]string{false: "text", true: "json"}[jsonOutput], func(t *testing.T) {
+			env := allPassEnv(t)
+			env.dropCounter = func(_ context.Context, _ *probeEnv) (uint64, error) {
+				return 12, nil
+			}
+			env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+				switch {
+				case name == testSystemctl:
+					return "", -1, errors.New("systemctl unavailable")
+				case name == testSudoCmd && containsArg(args, testOperatorUser) && containsArg(args, curlPath):
+					return "curl: (22) HTTP 500", 22, nil
+				default:
+					return defaultRunForAllPass(name, args)
+				}
+			}
+
+			cmd := newVerifyCmd(t)
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			err := runVerify(cmd, env, verifyOpts{jsonOutput: jsonOutput})
+			if code := cliutil.ExitCodeOf(err); code != cliutil.ExitGeneral {
+				t.Fatalf("exit code = %d, want fail precedence %d (err=%v)", code, cliutil.ExitGeneral, err)
+			}
+
+			out := buf.String()
+			if jsonOutput {
+				lines := strings.Split(strings.TrimSpace(out), "\n")
+				var agg aggregateRecord
+				if err := json.Unmarshal([]byte(lines[len(lines)-1]), &agg); err != nil {
+					t.Fatalf("decode aggregate: %v\n%s", err, out)
+				}
+				if agg.Aggregate.Pass != 9 || agg.Aggregate.Fail != 1 ||
+					agg.Aggregate.Skip != 1 || agg.Aggregate.Unknown != 1 ||
+					agg.Aggregate.ExitCode != cliutil.ExitGeneral {
+					t.Fatalf("mixed aggregate = %+v, want 9 pass / 1 fail / 1 skip / 1 unknown / exit 1", agg.Aggregate)
+				}
+				return
+			}
+			if !strings.Contains(out, "9 PASS / 1 FAIL / 1 SKIP / 1 UNKNOWN — exit 1") {
+				t.Fatalf("text lost a mixed outcome or fail precedence:\n%s", out)
+			}
+		})
+	}
+}
+
+func TestRunVerify_TextWriteFailureFailsClosed(t *testing.T) {
+	cmd := newVerifyCmd(t)
+	cmd.SetOut(errWriter{})
+	if err := runVerify(cmd, allPassEnv(t), verifyOpts{}); err == nil ||
+		!strings.Contains(err.Error(), "writing verify header") {
+		t.Fatalf("text output failure = %v, want surfaced header write error", err)
+	}
+}
+
+func TestRunVerify_NFTStructuralAndCounterCompositionFailsClosed(t *testing.T) {
+	tests := []struct {
+		name     string
+		rules    string
+		wantExit int
+	}{
+		{
+			name: "unhooked lookalike chain",
+			rules: `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 1000 accept
+		meta skuid 988 accept
+		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+		meta skuid 987 udp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked " drop
+		meta skuid 987 tcp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked " drop
+		meta skuid 987 counter packets %d bytes 840 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			wantExit: cliutil.ExitGeneral,
+		},
+		{
+			name: "structural probe fooled by predicate before skuid",
+			rules: `table inet pipelock_containment {
+	chain output_filter {
+		type filter hook output priority 0; policy accept;
+		meta skuid 1000 accept
+		meta skuid 988 accept
+		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+		meta skuid 987 udp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked " drop
+		meta skuid 987 tcp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked " drop
+		ip daddr 192.0.2.1 meta skuid 987 counter packets %d bytes 840 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			wantExit: cliutil.ExitConfig,
+		},
+		{
+			name: "canary intercepted before attributed counter",
+			rules: `table inet pipelock_containment {
+	chain output_filter {
+		type filter hook output priority 0; policy accept;
+		meta skuid 1000 accept
+		meta skuid 988 accept
+		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+		meta skuid 987 udp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked " drop
+		meta skuid 987 tcp dport 53 counter packets 0 bytes 0 log prefix "pipelock-contain class=direct_dns_blocked " drop
+		meta skuid 987 ip daddr 192.0.2.1 drop
+		meta skuid 987 counter packets %d bytes 840 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			wantExit: cliutil.ExitGeneral,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := allPassEnv(t)
+			chainReads := 0
+			env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+				if name != testNFT {
+					return defaultRunForAllPass(name, args)
+				}
+				packets := 12
+				if containsArg(args, "chain") {
+					packets += chainReads
+					chainReads++
+				}
+				return fmt.Sprintf(tc.rules, packets), 0, nil
+			}
+			env.dropCounter = readContainmentDropCounter
+
+			cmd := newVerifyCmd(t)
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			err := runVerify(cmd, env, verifyOpts{})
+			if code := cliutil.ExitCodeOf(err); code != tc.wantExit {
+				t.Fatalf("exit code = %d, want %d (err=%v, output=%q)", code, tc.wantExit, err, buf.String())
+			}
+			if strings.Contains(buf.String(), "— exit 0") {
+				t.Fatalf("broken nftables state reported aggregate PASS: %q", buf.String())
+			}
+		})
+	}
+}
+
 func TestVerifyCmd_Wiring(t *testing.T) {
 	root := Cmd()
 	verify := findSubcmd(t, root, "verify")
@@ -2283,6 +2955,11 @@ func allPassEnv(t *testing.T) *probeEnv {
 	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
 		return defaultRunForAllPass(name, args)
 	}
+	var counterReads uint64
+	env.dropCounter = func(_ context.Context, _ *probeEnv) (uint64, error) {
+		counterReads++
+		return 11 + counterReads, nil
+	}
 
 	// Filesystem state for probes 4, 5, 7, 12.
 	writeFakeWrapper(t, env.launchPath, 0o755)
@@ -2337,6 +3014,10 @@ func defaultRunForAllPass(name string, args []string) (string, int, error) {
 		if containsArg(args, "plk-launch") || containsArg(args, probe11Sentinel) {
 			return "plk-launch: tool " + probe11Sentinel + " not in pipelock contain allow-list", 5, nil
 		}
+		// Probe 12: positive agent-context executability/traversal check.
+		if containsArg(args, "test") && containsArg(args, "-x") {
+			return "", 0, nil
+		}
 		// Either pipelock-agent (probe 8) or operator (probe 9). Match by argv.
 		if containsArg(args, testAgentUser) {
 			return "curl: (7) Failed to connect", 7, nil
@@ -2355,6 +3036,7 @@ func TestOneLine(t *testing.T) {
 	}{
 		{"hello\nworld\r\n", "hello world"},
 		{"  trim me\n", "trim me"},
+		{"before\x1b[2J after\u202e forged", "before [2J after forged"},
 		{"", ""},
 	}
 	for _, c := range cases {

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -146,6 +146,45 @@ func TestEnforcementProbesSkipsByStableName(t *testing.T) {
 	}
 }
 
+func TestProbeListedToolTargets_AgentContextFailuresSkip(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		runErr error
+		want   string
+	}{
+		{name: "runner failure", runErr: errors.New("sudo unavailable"), want: "could not verify"},
+		{name: "agent missing", output: "sudo: unknown user pipelock-agent", want: "user missing"},
+		{name: "sudo refusal", output: testSudoNeedsPwd, want: "sudo -n refused"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			target := filepath.Join(t.TempDir(), "tool")
+			writeFakeWrapper(t, target, 0o755)
+			env := makeProbeEnv(t, func(e *probeEnv) {
+				e.readFile = func(path string) ([]byte, error) {
+					if path != e.toolsListPath {
+						t.Fatalf("read path = %q, want %q", path, e.toolsListPath)
+					}
+					return []byte("tool\t" + target + "\n"), nil
+				}
+				e.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+					if name != testSudoCmd || !containsArg(args, target) {
+						t.Fatalf("command = %q %v, want sudo test of %q", name, args, target)
+					}
+					return tc.output, 1, tc.runErr
+				}
+			})
+
+			status, detail := probeListedToolTargets(context.Background(), env)
+			if status != statusSkip || !strings.Contains(detail, tc.want) {
+				t.Fatalf("result = %q %q, want skip containing %q", status, detail, tc.want)
+			}
+		})
+	}
+}
+
 // makeProbeEnv builds a probeEnv with sane defaults plus overrides.
 // The pure-Go probes (1, 4, 5, 6, 7) get filesystem and lookup stubs;
 // the shell-out probes (2, 3, 8, 9) get runCmd.
@@ -1225,6 +1264,43 @@ func containTestLookup(name string) (*user.User, error) {
 	}
 }
 
+func TestNFTLineParsers_HandleEscapedQuotesFailClosed(t *testing.T) {
+	line := `comment "escaped \" quote and \\ slash { }" {`
+	fields := nftLineFields(line)
+	if len(fields) != 3 || fields[0] != "comment" || fields[2] != "{" {
+		t.Fatalf("fields = %q, want quoted comment plus structural brace", fields)
+	}
+	if delta := nftLineBraceDelta(line); delta != 1 {
+		t.Fatalf("brace delta = %d, want 1 with quoted braces ignored", delta)
+	}
+	if !nftLineHasBalancedQuotes(line) {
+		t.Fatal("escaped quote sequence was treated as an unterminated quote")
+	}
+	if isNFTChainDeclaration(`chain output_filter { comment "unterminated`, testChain) {
+		t.Fatal("unterminated chain declaration was accepted")
+	}
+
+	malformedChain := `table inet pipelock_containment {
+	chain output_filter {
+		comment "unterminated
+		meta skuid 987 drop
+	}
+}`
+	candidateMatched := false
+	if chainHasLineBeforeAgentDrop(malformedChain, testChain, 987, func(line string) bool {
+		if strings.Contains(line, "meta skuid") {
+			candidateMatched = true
+			return true
+		}
+		return false
+	}) {
+		t.Fatal("malformed chain output produced a match")
+	}
+	if candidateMatched {
+		t.Fatal("matcher was invoked on a rule after an unterminated quote")
+	}
+}
+
 // Probe 4: wrapper_scripts_installed -----------------------------------------
 
 func TestProbeWrapperScripts(t *testing.T) {
@@ -1710,6 +1786,28 @@ func TestManagedContainmentDropPacketCount(t *testing.T) {
 			wantErr: "parse managed catch-all DROP packet counter",
 		},
 		{
+			name: "rejects multiple counters in one managed rule",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 counter packets 12 bytes 0 counter packets 13 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			chain:   testChain,
+			uid:     987,
+			wantErr: "multiple packet counters",
+		},
+		{
+			name: "rejects extra bookkeeping predicates",
+			output: `table inet pipelock_containment {
+	chain output_filter {
+		meta skuid 987 counter packets 12 bytes 0 meta mark 1 log prefix "pipelock-contain class=not_routing_through_pipelock " drop
+	}
+}`,
+			chain:   testChain,
+			uid:     987,
+			wantErr: "no managed catch-all DROP packet counter",
+		},
+		{
 			name: "accepts maximum uint64 packet count",
 			output: `table inet pipelock_containment {
 	chain output_filter {
@@ -2033,6 +2131,15 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 			wantDetail:    "may be unrelated to containment",
 		},
 		{
+			name:          "DNS failure with unrelated counter delta is inconclusive",
+			stdout:        "curl: (6) Could not resolve host: example.com",
+			code:          6,
+			counterBefore: 12,
+			counterAfter:  13,
+			wantStatus:    statusUnknown,
+			wantDetail:    "unexpected exit=6 despite a counter delta",
+		},
+		{
 			name:          "timeout without counter delta is inconclusive",
 			stdout:        "curl: (28) Connection timed out",
 			code:          28,
@@ -2051,22 +2158,22 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 			wantDetail:    "did not increase",
 		},
 		{
-			name:          "TLS failure without counter delta is inconclusive",
+			name:          "TLS handshake proves post-connect breach without counter delta",
 			stdout:        "curl: (35) TLS connect error",
 			code:          35,
 			counterBefore: 12,
 			counterAfter:  12,
-			wantStatus:    statusUnknown,
-			wantDetail:    "may be unrelated to containment",
+			wantStatus:    statusFail,
+			wantDetail:    "reached the network",
 		},
 		{
-			name:          "TLS failure with unrelated counter delta is still inconclusive",
-			stdout:        "curl: (35) TLS connect error",
-			code:          35,
+			name:          "post-connect empty reply fails despite counter delta",
+			stdout:        "curl: (52) Empty reply from server",
+			code:          52,
 			counterBefore: 12,
 			counterAfter:  13,
-			wantStatus:    statusUnknown,
-			wantDetail:    "unexpected exit=35 despite a counter delta",
+			wantStatus:    statusFail,
+			wantDetail:    "CONTAINMENT HOLE",
 		},
 		{
 			name:            "no counter reader is inconclusive even for refused connection",
@@ -2436,6 +2543,46 @@ func TestCappedBuffer(t *testing.T) {
 	})
 }
 
+type shortWriteRecorder struct {
+	calls int
+}
+
+func (w *shortWriteRecorder) Write(p []byte) (int, error) {
+	w.calls++
+	return len(p) - 1, nil
+}
+
+type failAfterWriter struct {
+	successfulWrites int
+	writes           int
+}
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	if w.writes >= w.successfulWrites {
+		return 0, errors.New("write blew up")
+	}
+	w.writes++
+	return len(p), nil
+}
+
+func TestErrorTrackingWriter_ShortWriteIsSticky(t *testing.T) {
+	dst := &shortWriteRecorder{}
+	w := &errorTrackingWriter{w: dst}
+
+	if _, err := w.Write([]byte("record")); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("short write error = %v, want %v", err, io.ErrShortWrite)
+	}
+	if !errors.Is(w.Err(), io.ErrShortWrite) {
+		t.Fatalf("tracked error = %v, want %v", w.Err(), io.ErrShortWrite)
+	}
+	if _, err := w.Write([]byte("second")); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("sticky write error = %v, want %v", err, io.ErrShortWrite)
+	}
+	if dst.calls != 1 {
+		t.Fatalf("underlying writer calls = %d, want 1 after sticky failure", dst.calls)
+	}
+}
+
 // Runner ---------------------------------------------------------------------
 
 func TestRunVerify_TextOutput_AllPass(t *testing.T) {
@@ -2711,6 +2858,31 @@ func TestRunVerify_TextWriteFailureFailsClosed(t *testing.T) {
 	if err := runVerify(cmd, allPassEnv(t), verifyOpts{}); err == nil ||
 		!strings.Contains(err.Error(), "writing verify header") {
 		t.Fatalf("text output failure = %v, want surfaced header write error", err)
+	}
+}
+
+func TestRunVerify_RecordAndAggregateWriteFailuresFailClosed(t *testing.T) {
+	tests := []struct {
+		name             string
+		jsonOutput       bool
+		successfulWrites int
+		want             string
+	}{
+		{name: "text probe", successfulWrites: 1, want: "writing probe 1 text"},
+		{name: "text aggregate", successfulWrites: 13, want: "writing verify aggregate"},
+		{name: "JSON probe", jsonOutput: true, want: "encoding probe 1 JSON"},
+		{name: "JSON aggregate", jsonOutput: true, successfulWrites: 12, want: "encoding aggregate JSON"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newVerifyCmd(t)
+			cmd.SetOut(&failAfterWriter{successfulWrites: tc.successfulWrites})
+			err := runVerify(cmd, allPassEnv(t), verifyOpts{jsonOutput: tc.jsonOutput})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("output failure = %v, want substring %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -2097,6 +2097,32 @@ func TestChainHasManagedOutputBaseChain(t *testing.T) {
 	}
 }
 
+func TestParseDirectCurlDialCompletion(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want directDialCompletion
+	}{
+		{name: "zero means dial did not complete", out: "curl: (7) refused\nPLK_TIME_CONNECT=0.000000\n000", want: directDialNotCompleted},
+		{name: "positive means dial completed", out: "curl: (28) timed out\nPLK_TIME_CONNECT=0.125381\n000", want: directDialCompleted},
+		{name: "missing sentinel", out: "curl: (7) refused", want: directDialUnknown},
+		{name: "empty value", out: "PLK_TIME_CONNECT=\n000", want: directDialUnknown},
+		{name: "malformed value", out: "PLK_TIME_CONNECT=not-a-number\n000", want: directDialUnknown},
+		{name: "locale comma is not guessed", out: "PLK_TIME_CONNECT=0,125381\n000", want: directDialUnknown},
+		{name: "negative value", out: "PLK_TIME_CONNECT=-0.1\n000", want: directDialUnknown},
+		{name: "nan value", out: "PLK_TIME_CONNECT=NaN\n000", want: directDialUnknown},
+		{name: "infinite value", out: "PLK_TIME_CONNECT=+Inf\n000", want: directDialUnknown},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseDirectCurlDialCompletion(tc.out); got != tc.want {
+				t.Fatalf("parseDirectCurlDialCompletion(%q) = %d, want %d", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProbeCCAgentEgressDenied(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -2114,7 +2140,7 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 	}{
 		{
 			name:          "attributable egress block passes",
-			stdout:        "curl: (7) Failed to connect",
+			stdout:        "curl: (7) Failed to connect\nPLK_TIME_CONNECT=0.000000\n000",
 			code:          7,
 			counterBefore: 12,
 			counterAfter:  13,
@@ -2122,8 +2148,35 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 			wantDetail:    "managed DROP counter increased",
 		},
 		{
+			name:          "attributable connect timeout before dial passes",
+			stdout:        "curl: (28) Connection timed out\nPLK_TIME_CONNECT=0.000000\n000",
+			code:          28,
+			counterBefore: 12,
+			counterAfter:  13,
+			wantStatus:    statusPass,
+			wantDetail:    "time_connect=0",
+		},
+		{
+			name:          "completed dial timeout fails despite UID-wide counter delta",
+			stdout:        "curl: (28) Operation timed out\nPLK_TIME_CONNECT=0.125381\n000",
+			code:          28,
+			counterBefore: 12,
+			counterAfter:  13,
+			wantStatus:    statusFail,
+			wantDetail:    "CONTAINMENT HOLE",
+		},
+		{
+			name:          "unknown dial timing cannot pass from UID-wide counter delta",
+			stdout:        "curl: (7) Failed to connect\nPLK_TIME_CONNECT=unparseable\n000",
+			code:          7,
+			counterBefore: 12,
+			counterAfter:  13,
+			wantStatus:    statusUnknown,
+			wantDetail:    "time_connect was missing or unparseable",
+		},
+		{
 			name:          "DNS failure without counter delta is inconclusive",
-			stdout:        "curl: (6) Could not resolve host: example.com",
+			stdout:        "curl: (6) Could not resolve host: example.com\nPLK_TIME_CONNECT=0.000000\n000",
 			code:          6,
 			counterBefore: 12,
 			counterAfter:  12,
@@ -2132,7 +2185,7 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 		},
 		{
 			name:          "DNS failure with unrelated counter delta is inconclusive",
-			stdout:        "curl: (6) Could not resolve host: example.com",
+			stdout:        "curl: (6) Could not resolve host: example.com\nPLK_TIME_CONNECT=0.000000\n000",
 			code:          6,
 			counterBefore: 12,
 			counterAfter:  13,
@@ -2141,7 +2194,7 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 		},
 		{
 			name:          "timeout without counter delta is inconclusive",
-			stdout:        "curl: (28) Connection timed out",
+			stdout:        "curl: (28) Connection timed out\nPLK_TIME_CONNECT=0.000000\n000",
 			code:          28,
 			counterBefore: 12,
 			counterAfter:  12,
@@ -2150,7 +2203,7 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 		},
 		{
 			name:          "counter reset or wrap is inconclusive",
-			stdout:        "curl: (28) Connection timed out",
+			stdout:        "curl: (28) Connection timed out\nPLK_TIME_CONNECT=0.000000\n000",
 			code:          28,
 			counterBefore: ^uint64(0),
 			counterAfter:  0,
@@ -2177,7 +2230,7 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 		},
 		{
 			name:            "no counter reader is inconclusive even for refused connection",
-			stdout:          "curl: (7) Failed to connect: Connection refused",
+			stdout:          "curl: (7) Failed to connect: Connection refused\nPLK_TIME_CONNECT=0.000000\n000",
 			code:            7,
 			noCounterReader: true,
 			wantStatus:      statusUnknown,
@@ -2185,7 +2238,7 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 		},
 		{
 			name:             "counter unavailable before probe is inconclusive",
-			stdout:           "curl: (7) Failed to connect",
+			stdout:           "curl: (7) Failed to connect\nPLK_TIME_CONNECT=0.000000\n000",
 			code:             7,
 			counterBeforeErr: errors.New("operation not permitted"),
 			counterAfter:     13,
@@ -2194,7 +2247,7 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 		},
 		{
 			name:            "counter unavailable after probe is inconclusive",
-			stdout:          "curl: (7) Failed to connect",
+			stdout:          "curl: (7) Failed to connect\nPLK_TIME_CONNECT=0.000000\n000",
 			code:            7,
 			counterBefore:   12,
 			counterAfterErr: errors.New("table disappeared"),
@@ -2291,6 +2344,9 @@ func TestProbeCCAgentEgressDenied(t *testing.T) {
 					if !strings.Contains(joined, "--connect-timeout "+directCurlConnectTimeout) ||
 						!strings.Contains(joined, "--max-time "+directCurlMaxTime) {
 						t.Fatalf("argv does not use bounded direct-canary timeouts: %v", args)
+					}
+					if !strings.Contains(joined, directCurlTimeConnectPrefix+"%{time_connect}") {
+						t.Fatalf("argv does not capture probe-specific time_connect: %v", args)
 					}
 					return tc.stdout, tc.code, tc.runErr
 				}
@@ -3192,7 +3248,7 @@ func defaultRunForAllPass(name string, args []string) (string, int, error) {
 		}
 		// Either pipelock-agent (probe 8) or operator (probe 9). Match by argv.
 		if containsArg(args, testAgentUser) {
-			return "curl: (7) Failed to connect", 7, nil
+			return "curl: (7) Failed to connect\nPLK_TIME_CONNECT=0.000000\n000", 7, nil
 		}
 		return "200", 0, nil
 	case curlPath:

--- a/internal/sandbox/coverage_deep_test.go
+++ b/internal/sandbox/coverage_deep_test.go
@@ -180,7 +180,7 @@ func TestHandleDirectForward_ValidCONNECTRoundTrip(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleDirectForward(serverConn)
+		handleDirectForward(serverConn, true)
 	}()
 
 	_, _ = fmt.Fprintf(clientConn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n",
@@ -1108,7 +1108,7 @@ func TestHandleDirectForward_502BadGateway(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleDirectForward(serverConn)
+		handleDirectForward(serverConn, true)
 	}()
 
 	_, _ = fmt.Fprintf(clientConn, "CONNECT 192.0.2.1:99999 HTTP/1.1\r\nHost: 192.0.2.1:99999\r\n\r\n")
@@ -1130,7 +1130,7 @@ func TestHandleDirectForward_ShortCONNECT(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleDirectForward(serverConn)
+		handleDirectForward(serverConn, true)
 	}()
 
 	_, _ = fmt.Fprintf(clientConn, "CONNECT\r\n")
@@ -1144,7 +1144,7 @@ func TestHandleDirectForward_ReadEOF(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleDirectForward(serverConn)
+		handleDirectForward(serverConn, true)
 	}()
 
 	_ = clientConn.Close()

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -49,8 +49,16 @@ type StandaloneLaunchConfig struct {
 	// ProxyHandler is called for each connection from the sandboxed agent.
 	// It receives the connection from the bridge proxy and should handle
 	// it as an HTTP forward proxy (CONNECT tunneling, DLP scanning, etc.).
-	// If nil, connections are forwarded directly (no scanning).
+	// If nil, connections are closed without forwarding.
 	ProxyHandler func(conn net.Conn)
+}
+
+// standaloneProxyConnectionConfig controls how one accepted bridge connection
+// is dispatched. Unscanned forwarding is an internal debug-only opt-in whose
+// zero value is fail closed.
+type standaloneProxyConnectionConfig struct {
+	ProxyHandler                func(net.Conn)
+	AllowUnscannedDirectForward bool
 }
 
 // LaunchStandalone runs a command in a full sandbox with network traffic
@@ -144,12 +152,9 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 			proxyWg.Add(1)
 			go func() {
 				defer proxyWg.Done()
-				if cfg.ProxyHandler != nil {
-					cfg.ProxyHandler(conn)
-				} else {
-					// Default: direct forwarding (no scanning).
-					handleDirectForward(conn)
-				}
+				handleStandaloneProxyConnection(conn, standaloneProxyConnectionConfig{
+					ProxyHandler: cfg.ProxyHandler,
+				})
 			}()
 		}
 	}()
@@ -262,12 +267,25 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	return waitErr
 }
 
+// handleStandaloneProxyConnection dispatches a bridge connection to the
+// scanning handler. A missing handler fails closed unless an internal caller
+// explicitly opts into the unscanned debug-only forwarding path.
+func handleStandaloneProxyConnection(conn net.Conn, cfg standaloneProxyConnectionConfig) {
+	if cfg.ProxyHandler != nil {
+		cfg.ProxyHandler(conn)
+		return
+	}
+	handleDirectForward(conn, cfg.AllowUnscannedDirectForward)
+}
+
 // handleDirectForward bridges a Unix socket connection to a direct TCP
-// connection. DEBUG ONLY - no scanning, no SSRF protection. Production
-// code paths always use cfg.ProxyHandler which routes through pipelock's
-// full scanner pipeline.
-func handleDirectForward(conn net.Conn) {
+// connection only when allowUnscannedDirectForward is explicitly true.
+// This is DEBUG ONLY: it performs no scanning or SSRF protection.
+func handleDirectForward(conn net.Conn, allowUnscannedDirectForward bool) {
 	defer func() { _ = conn.Close() }()
+	if !allowUnscannedDirectForward {
+		return
+	}
 
 	// Read the first line to get the CONNECT target.
 	// For now, just close - the real handler is provided by the CLI.

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -7,7 +7,9 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -175,8 +177,69 @@ func TestLaunchStandalone_BridgeProxyListens(t *testing.T) {
 	}
 }
 
+func TestHandleStandaloneProxyConnection_NilHandlerFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  standaloneProxyConnectionConfig
+	}{
+		{name: "nil handler defaults to deny"},
+		{
+			name: "explicit unscanned opt-in false denies",
+			cfg: standaloneProxyConnectionConfig{
+				AllowUnscannedDirectForward: false,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			targetLn, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("target listen: %v", err)
+			}
+			defer func() { _ = targetLn.Close() }()
+
+			accepted := make(chan struct{}, 1)
+			acceptDone := make(chan struct{})
+			go func() {
+				defer close(acceptDone)
+				conn, acceptErr := targetLn.Accept()
+				if acceptErr != nil {
+					return
+				}
+				defer func() { _ = conn.Close() }()
+				accepted <- struct{}{}
+			}()
+
+			clientConn, serverConn := net.Pipe()
+			handlerDone := make(chan struct{})
+			go func() {
+				defer close(handlerDone)
+				handleStandaloneProxyConnection(serverConn, tc.cfg)
+			}()
+
+			_, _ = fmt.Fprintf(clientConn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", targetLn.Addr(), targetLn.Addr())
+			_ = clientConn.SetReadDeadline(time.Now().Add(time.Second))
+			buf := make([]byte, 1)
+			if _, readErr := clientConn.Read(buf); !errors.Is(readErr, io.EOF) {
+				t.Fatalf("bridge read error = %v, want EOF from fail-closed connection", readErr)
+			}
+			_ = clientConn.Close()
+			<-handlerDone
+
+			_ = targetLn.Close()
+			<-acceptDone
+			select {
+			case <-accepted:
+				t.Fatal("nil-handler bridge forwarded to target")
+			default:
+			}
+		})
+	}
+}
+
 func TestHandleDirectForward_CONNECT(t *testing.T) {
-	// Test the fallback CONNECT handler used when no ProxyHandler is set.
+	// Test the debug-only CONNECT handler with its explicit opt-in enabled.
 	// Set up a target server.
 	targetLn, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
@@ -201,7 +264,9 @@ func TestHandleDirectForward_CONNECT(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleDirectForward(serverConn)
+		handleStandaloneProxyConnection(serverConn, standaloneProxyConnectionConfig{
+			AllowUnscannedDirectForward: true,
+		})
 	}()
 
 	// Send CONNECT request.
@@ -235,7 +300,9 @@ func TestHandleDirectForward_BadRequest(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleDirectForward(serverConn)
+		handleStandaloneProxyConnection(serverConn, standaloneProxyConnectionConfig{
+			AllowUnscannedDirectForward: true,
+		})
 	}()
 
 	// Send non-CONNECT request.

--- a/sdk/conformance/containment_conformance_test.go
+++ b/sdk/conformance/containment_conformance_test.go
@@ -120,6 +120,7 @@ func validateContainmentProbeFixture(fx containmentProbeFixture) error {
 		"--connect-timeout 1",
 		"--max-time 2",
 		"--noproxy *",
+		"PLK_TIME_CONNECT=%{time_connect}",
 		directCanaryURL,
 	}
 	operatorInvocation := fixtureCurlPath
@@ -537,6 +538,7 @@ func TestValidateContainmentProbeFixtureRequiresExactCanaryCommands(t *testing.T
 		"--connect-timeout 1",
 		"--max-time 2",
 		"--noproxy *",
+		"PLK_TIME_CONNECT=%{time_connect}",
 		directCanaryURL,
 	}}
 	operatorRule := containmentRunRule{Match: []string{

--- a/sdk/conformance/containment_conformance_test.go
+++ b/sdk/conformance/containment_conformance_test.go
@@ -48,10 +48,18 @@ type containmentRunRule struct {
 
 // containmentProbeFixture is the parsed *.probe.json input.
 type containmentProbeFixture struct {
-	AgentUser    string               `json:"agent_user"`
-	OperatorUser string               `json:"operator_user"`
-	Runs         []containmentRunRule `json:"runs"`
+	AgentUser        string               `json:"agent_user"`
+	OperatorUser     string               `json:"operator_user"`
+	DropCounterReads []uint64             `json:"drop_counter_reads"`
+	Runs             []containmentRunRule `json:"runs"`
 }
+
+const (
+	defaultFixtureAgentUser = "pipelock-agent"
+	fixtureCurlPath         = "/usr/bin/curl"
+	directCanaryURL         = "http://192.0.2.1:9/"
+	operatorCanaryURL       = "https://example.com/"
+)
 
 // containmentExpectProbe is one expected per-probe outcome.
 type containmentExpectProbe struct {
@@ -91,7 +99,74 @@ func loadContainmentProbe(t *testing.T, path string) containmentProbeFixture {
 			t.Fatalf("probe fixture %s: runs[%d] has an empty match (would match every command)", path, i)
 		}
 	}
+	if err := validateContainmentProbeFixture(fx); err != nil {
+		t.Fatalf("invalid probe fixture %s: %v", path, err)
+	}
 	return fx
+}
+
+// validateContainmentProbeFixture makes the canned runner prove the actual
+// canary command contract, not merely that sudo/curl ran under two usernames.
+// Without these exact anchors, a probe-8 regression back to the proxy-capable
+// operator URL (or loss of --noproxy) could still match a broad fixture rule and
+// let the standalone conformance gate report PASS.
+func validateContainmentProbeFixture(fx containmentProbeFixture) error {
+	agentUser := fx.AgentUser
+	if agentUser == "" {
+		agentUser = defaultFixtureAgentUser
+	}
+	directRequired := []string{
+		"sudo -n -u " + agentUser + " -- " + fixtureCurlPath,
+		"--connect-timeout 1",
+		"--max-time 2",
+		"--noproxy *",
+		directCanaryURL,
+	}
+	operatorInvocation := fixtureCurlPath
+	if fx.OperatorUser != "" {
+		operatorInvocation = "sudo -n -u " + fx.OperatorUser + " -- " + fixtureCurlPath
+	}
+	operatorRequired := []string{
+		operatorInvocation,
+		"--connect-timeout 3",
+		"--max-time 5",
+		"--noproxy *",
+		operatorCanaryURL,
+	}
+
+	if matches := countRulesWithExactAnchors(fx.Runs, directRequired); matches != 1 {
+		return fmt.Errorf("has %d exact probe-8 command rule(s), want 1 with match anchors %q", matches, directRequired)
+	}
+	if matches := countRulesWithExactAnchors(fx.Runs, operatorRequired); matches != 1 {
+		return fmt.Errorf("has %d exact probe-9 command rule(s), want 1 with match anchors %q", matches, operatorRequired)
+	}
+	return nil
+}
+
+func countRulesWithExactAnchors(rules []containmentRunRule, required []string) int {
+	matches := 0
+	for _, rule := range rules {
+		if containsAllExact(rule.Match, required) {
+			matches++
+		}
+	}
+	return matches
+}
+
+func containsAllExact(got, required []string) bool {
+	for _, want := range required {
+		found := false
+		for _, value := range got {
+			if value == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // loadContainmentExpect reads and parses a *.expect.json fixture. Fail-closed:
@@ -138,7 +213,7 @@ func validateContainmentExpect(fx containmentExpectFixture) error {
 			return fmt.Errorf("probes[%d] name = %q, want %q", i, p.Name, wantName)
 		}
 		if !isContainmentStatus(p.Status) {
-			return fmt.Errorf("probes[%d] status = %q, want pass/fail/skip", i, p.Status)
+			return fmt.Errorf("probes[%d] status = %q, want pass/fail/skip/unknown", i, p.Status)
 		}
 	}
 	for probe := range expectedContainmentProbes {
@@ -151,7 +226,7 @@ func validateContainmentExpect(fx containmentExpectFixture) error {
 
 func isContainmentStatus(status string) bool {
 	switch status {
-	case contain.ConformanceStatusPass, contain.ConformanceStatusFail, contain.ConformanceStatusSkip:
+	case contain.ConformanceStatusPass, contain.ConformanceStatusFail, contain.ConformanceStatusSkip, contain.ConformanceStatusUnknown:
 		return true
 	default:
 		return false
@@ -257,6 +332,7 @@ func runContainmentFixture(t *testing.T, name string) ([]contain.ConformanceProb
 		RunCommand:   runner.Run,
 		AgentUser:    probeFx.AgentUser,
 		OperatorUser: probeFx.OperatorUser,
+		DropCounter:  fixtureDropCounter(probeFx.DropCounterReads),
 	}
 	results, exit, err := contain.RunContainmentConformance(context.Background(), env)
 	if err != nil {
@@ -266,6 +342,21 @@ func runContainmentFixture(t *testing.T, name string) ([]contain.ConformanceProb
 		t.Fatalf("%s: invalid canned command-runner fixture: %v", name, err)
 	}
 	return results, exit
+}
+
+func fixtureDropCounter(values []uint64) contain.ConformanceDropCounter {
+	if len(values) == 0 {
+		return nil
+	}
+	next := 0
+	return func(context.Context) (uint64, error) {
+		if next >= len(values) {
+			return 0, fmt.Errorf("DROP counter fixture exhausted after %d read(s)", next)
+		}
+		value := values[next]
+		next++
+		return value, nil
+	}
 }
 
 // assertMatchesExpect checks per-probe status and aggregate exit code against
@@ -433,6 +524,82 @@ func TestContainmentConformance_InvalidExpectFailsClosed(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tc.wantErr) {
 				t.Fatalf("invalid expect fixture error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateContainmentProbeFixtureRequiresExactCanaryCommands(t *testing.T) {
+	t.Parallel()
+
+	directRule := containmentRunRule{Match: []string{
+		"sudo -n -u pipelock-agent -- /usr/bin/curl",
+		"--connect-timeout 1",
+		"--max-time 2",
+		"--noproxy *",
+		directCanaryURL,
+	}}
+	operatorRule := containmentRunRule{Match: []string{
+		"sudo -n -u operator -- /usr/bin/curl",
+		"--connect-timeout 3",
+		"--max-time 5",
+		"--noproxy *",
+		operatorCanaryURL,
+	}}
+	valid := containmentProbeFixture{
+		AgentUser:    defaultFixtureAgentUser,
+		OperatorUser: "operator",
+		Runs:         []containmentRunRule{directRule, operatorRule},
+	}
+	if err := validateContainmentProbeFixture(valid); err != nil {
+		t.Fatalf("valid fixture rejected: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*containmentProbeFixture)
+		wantErr string
+	}{
+		{
+			name: "broad username-only agent rule",
+			mutate: func(fx *containmentProbeFixture) {
+				fx.Runs[0].Match = []string{"sudo", "pipelock-agent", fixtureCurlPath}
+			},
+			wantErr: "exact probe-8 command",
+		},
+		{
+			name: "agent rule missing no-proxy bypass",
+			mutate: func(fx *containmentProbeFixture) {
+				fx.Runs[0].Match = append([]string(nil), directRule.Match[:3]...)
+				fx.Runs[0].Match = append(fx.Runs[0].Match, directCanaryURL)
+			},
+			wantErr: "exact probe-8 command",
+		},
+		{
+			name: "agent rule points at operator canary",
+			mutate: func(fx *containmentProbeFixture) {
+				fx.Runs[0].Match = append([]string(nil), directRule.Match...)
+				fx.Runs[0].Match[len(fx.Runs[0].Match)-1] = operatorCanaryURL
+			},
+			wantErr: "exact probe-8 command",
+		},
+		{
+			name: "operator rule missing reachability URL",
+			mutate: func(fx *containmentProbeFixture) {
+				fx.Runs[1].Match = append([]string(nil), operatorRule.Match[:len(operatorRule.Match)-1]...)
+			},
+			wantErr: "exact probe-9 command",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := valid
+			fx.Runs = append([]containmentRunRule(nil), valid.Runs...)
+			tc.mutate(&fx)
+			err := validateContainmentProbeFixture(fx)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tc.wantErr)
 			}
 		})
 	}

--- a/sdk/conformance/testdata/containment/README.md
+++ b/sdk/conformance/testdata/containment/README.md
@@ -55,10 +55,11 @@ Each fixture is a pair:
         "--connect-timeout 1",
         "--max-time 2",
         "--noproxy *",
+        "PLK_TIME_CONNECT=%{time_connect}",
         "http://192.0.2.1:9/"
       ],
-      "stdout": "200",
-      "exit_code": 0
+      "stdout": "curl: (7) Failed to connect\nPLK_TIME_CONNECT=0.000000\n000",
+      "exit_code": 7
     }
   ]
 }
@@ -78,11 +79,14 @@ probe.
   harness requires exact invocation, timeout, `--noproxy *`, and URL anchors
   for both probes so a raw-egress canary regression cannot keep matching a
   broad username-only rule.
-- `stdout`: the merged stdout/stderr the probe sees. Probe 8 keys off the exit
-  code; probe 9 reads the trailing whitespace-separated token as the HTTP code.
+- `stdout`: the merged stdout/stderr the probe sees. Probe 8 parses the
+  `PLK_TIME_CONNECT=` sentinel and combines it with the exit code and DROP
+  counter; probe 9 reads the trailing whitespace-separated token as the HTTP
+  code.
 - `exit_code`: the process exit code. `0` means curl succeeded.
 - `drop_counter_reads`: the managed catch-all DROP-counter values returned to
-  probe 8. A missing reader, read error, or non-increasing pair is inconclusive.
+  probe 8. The UID-wide counter only corroborates this canary's time_connect
+  result; a missing reader, read error, or non-increasing pair is inconclusive.
 
 ## `*.expect.json` schema
 

--- a/sdk/conformance/testdata/containment/README.md
+++ b/sdk/conformance/testdata/containment/README.md
@@ -15,16 +15,16 @@ The two probes under test:
 
 - **Probe 8 — `cc_agent_egress_denied`**: the unprivileged agent user
   (`pipelock-agent`) must NOT reach the internet directly. The probe runs a
-  `curl --noproxy * https://example.com/` canary as the agent user. If curl
-  exits 0 (egress succeeded), containment is BROKEN → `fail`. If curl exits
-  non-zero (blocked), containment is enforced → `pass`.
+  DNS-free `curl --noproxy * http://192.0.2.1:9/` canary as the agent user.
+  If curl exits 0 (egress succeeded), containment is BROKEN → `fail`. A
+  connection refusal/timeout is `pass` only when the managed catch-all DROP
+  counter increases across the probe; otherwise the result is `unknown`.
 - **Probe 9 — `operator_egress_reachable`**: the operator user must still reach
   the internet (proves the containment rule is scoped to the agent, not a blanket
   network outage). A 2xx/3xx HTTP code → `pass`.
 
 No real network, sudo, curl, or nftables is touched. The probes run against a
-**canned command runner** built from the fixture: every `(name, argv)` the probe
-would execute is matched to a pre-recorded `(stdout, exit_code)`.
+**canned command runner and DROP-counter reader** built from the fixture.
 
 ## File pairs
 
@@ -46,10 +46,17 @@ Each fixture is a pair:
   "description": "free text",
   "agent_user": "pipelock-agent",   // optional; defaults to pipelock-agent
   "operator_user": "operator",      // optional; empty => probe 9 runs curl directly
+  "drop_counter_reads": [12, 13],   // probe 8 before/after reads
   "runs": [
     {
       "comment": "free text (ignored by the loader)",
-      "match": ["sudo", "pipelock-agent", "/usr/bin/curl"],
+      "match": [
+        "sudo -n -u pipelock-agent -- /usr/bin/curl",
+        "--connect-timeout 1",
+        "--max-time 2",
+        "--noproxy *",
+        "http://192.0.2.1:9/"
+      ],
       "stdout": "200",
       "exit_code": 0
     }
@@ -67,19 +74,22 @@ fixture cannot be blessed by a matching expectation through a broad, duplicate,
 or dead rule. The selected rule's `stdout` and `exit_code` are returned to the
 probe.
 
-- `match`: substrings that ALL must appear in the joined command line. Use the
-  agent vs operator username to disambiguate probe 8 from probe 9 (both shell
-  out to the same `/usr/bin/curl`).
+- `match`: substrings that ALL must appear in the joined command line. The
+  harness requires exact invocation, timeout, `--noproxy *`, and URL anchors
+  for both probes so a raw-egress canary regression cannot keep matching a
+  broad username-only rule.
 - `stdout`: the merged stdout/stderr the probe sees. Probe 8 keys off the exit
   code; probe 9 reads the trailing whitespace-separated token as the HTTP code.
 - `exit_code`: the process exit code. `0` means curl succeeded.
+- `drop_counter_reads`: the managed catch-all DROP-counter values returned to
+  probe 8. A missing reader, read error, or non-increasing pair is inconclusive.
 
 ## `*.expect.json` schema
 
 ```jsonc
 {
   "description": "free text",
-  "exit_code": 1,                   // aggregate: 0 pass, 1 any fail, 2 skip-only
+  "exit_code": 1,                   // aggregate: 0 pass, 1 any fail, 2 incomplete
   "probes": [
     { "probe": 8, "name": "cc_agent_egress_denied",   "status": "fail" },
     { "probe": 9, "name": "operator_egress_reachable", "status": "pass" }
@@ -87,10 +97,10 @@ probe.
 }
 ```
 
-Status is one of `pass` / `fail` / `skip`. The aggregate `exit_code` follows the
-`fail > skip > pass` precedence the real `contain verify` uses: a single `fail`
-yields exit 1 regardless of how many probes passed — a broken boundary is never
-offset by green siblings.
+Status is one of `pass` / `fail` / `skip` / `unknown`. The aggregate
+`exit_code` follows the `fail > incomplete > pass` precedence the real
+`contain verify` uses: a single `fail` yields exit 1 regardless of how many
+probes passed; `skip` or `unknown` without a failure yields exit 2.
 
 ## How they run
 

--- a/sdk/conformance/testdata/containment/leaky-egress.probe.json
+++ b/sdk/conformance/testdata/containment/leaky-egress.probe.json
@@ -6,8 +6,8 @@
   "runs": [
     {
       "comment": "probe 8: agent egress canary LEAKS. curl succeeds (exit 0, HTTP 200) — direct egress was NOT contained.",
-      "match": ["sudo -n -u pipelock-agent -- /usr/bin/curl", "--connect-timeout 1", "--max-time 2", "--noproxy *", "http://192.0.2.1:9/"],
-      "stdout": "200",
+      "match": ["sudo -n -u pipelock-agent -- /usr/bin/curl", "--connect-timeout 1", "--max-time 2", "--noproxy *", "PLK_TIME_CONNECT=%{time_connect}", "http://192.0.2.1:9/"],
+      "stdout": "\nPLK_TIME_CONNECT=0.125381\n200",
       "exit_code": 0
     },
     {

--- a/sdk/conformance/testdata/containment/leaky-egress.probe.json
+++ b/sdk/conformance/testdata/containment/leaky-egress.probe.json
@@ -1,17 +1,18 @@
 {
-  "description": "Containment BROKEN: probe 8 (agent egress) SUCCEEDS — the agent reached example.com directly. This is the must-fail fixture: probe 8 must report 'fail' and the overall exit code must be non-zero. If this ever passes, the egress-denied test is not real.",
+  "description": "Containment BROKEN: probe 8's DNS-free direct canary SUCCEEDS. This is the must-fail fixture: probe 8 must report 'fail' and the overall exit code must be non-zero. If this ever passes, the egress-denied test is not real.",
   "agent_user": "pipelock-agent",
   "operator_user": "operator",
+  "drop_counter_reads": [12],
   "runs": [
     {
       "comment": "probe 8: agent egress canary LEAKS. curl succeeds (exit 0, HTTP 200) — direct egress was NOT contained.",
-      "match": ["sudo", "pipelock-agent", "/usr/bin/curl"],
+      "match": ["sudo -n -u pipelock-agent -- /usr/bin/curl", "--connect-timeout 1", "--max-time 2", "--noproxy *", "http://192.0.2.1:9/"],
       "stdout": "200",
       "exit_code": 0
     },
     {
       "comment": "probe 9: operator egress canary still reaches example.com (unchanged).",
-      "match": ["sudo", "operator", "/usr/bin/curl"],
+      "match": ["sudo -n -u operator -- /usr/bin/curl", "--connect-timeout 3", "--max-time 5", "--noproxy *", "https://example.com/"],
       "stdout": "200",
       "exit_code": 0
     }

--- a/sdk/conformance/testdata/containment/pass-all.probe.json
+++ b/sdk/conformance/testdata/containment/pass-all.probe.json
@@ -1,13 +1,13 @@
 {
-  "description": "Containment intact: probe 8's DNS-free TEST-NET direct canary is BLOCKED with an attributable DROP-counter delta, and probe 9 (operator egress) reaches example.com. This is the clean baseline the gate must PASS.",
+  "description": "Containment intact: probe 8's DNS-free TEST-NET direct canary reports time_connect=0 and a corroborating DROP-counter delta, and probe 9 (operator egress) reaches example.com. This is the clean baseline the gate must PASS.",
   "agent_user": "pipelock-agent",
   "operator_user": "operator",
   "drop_counter_reads": [12, 13],
   "runs": [
     {
-      "comment": "probe 8: DNS-free agent egress canary. curl is BLOCKED and the managed DROP counter increases from 12 to 13.",
-      "match": ["sudo -n -u pipelock-agent -- /usr/bin/curl", "--connect-timeout 1", "--max-time 2", "--noproxy *", "http://192.0.2.1:9/"],
-      "stdout": "curl: (7) Failed to connect to 192.0.2.1 port 9: Connection refused",
+      "comment": "probe 8: DNS-free agent egress canary. curl reports no completed dial and the managed DROP counter increases from 12 to 13.",
+      "match": ["sudo -n -u pipelock-agent -- /usr/bin/curl", "--connect-timeout 1", "--max-time 2", "--noproxy *", "PLK_TIME_CONNECT=%{time_connect}", "http://192.0.2.1:9/"],
+      "stdout": "curl: (7) Failed to connect to 192.0.2.1 port 9: Connection refused\nPLK_TIME_CONNECT=0.000000\n000",
       "exit_code": 7
     },
     {

--- a/sdk/conformance/testdata/containment/pass-all.probe.json
+++ b/sdk/conformance/testdata/containment/pass-all.probe.json
@@ -1,17 +1,18 @@
 {
-  "description": "Containment intact: probe 8 (agent egress) is BLOCKED, probe 9 (operator egress) reaches example.com. This is the clean baseline the gate must PASS.",
+  "description": "Containment intact: probe 8's DNS-free TEST-NET direct canary is BLOCKED with an attributable DROP-counter delta, and probe 9 (operator egress) reaches example.com. This is the clean baseline the gate must PASS.",
   "agent_user": "pipelock-agent",
   "operator_user": "operator",
+  "drop_counter_reads": [12, 13],
   "runs": [
     {
-      "comment": "probe 8: agent egress canary. curl is BLOCKED, returns non-zero exit (containment enforced).",
-      "match": ["sudo", "pipelock-agent", "/usr/bin/curl"],
-      "stdout": "curl: (7) Failed to connect to example.com port 443: Connection refused",
+      "comment": "probe 8: DNS-free agent egress canary. curl is BLOCKED and the managed DROP counter increases from 12 to 13.",
+      "match": ["sudo -n -u pipelock-agent -- /usr/bin/curl", "--connect-timeout 1", "--max-time 2", "--noproxy *", "http://192.0.2.1:9/"],
+      "stdout": "curl: (7) Failed to connect to 192.0.2.1 port 9: Connection refused",
       "exit_code": 7
     },
     {
       "comment": "probe 9: operator egress canary. curl succeeds, prints HTTP 200.",
-      "match": ["sudo", "operator", "/usr/bin/curl"],
+      "match": ["sudo -n -u operator -- /usr/bin/curl", "--connect-timeout 3", "--max-time 5", "--noproxy *", "https://example.com/"],
       "stdout": "200",
       "exit_code": 0
     }


### PR DESCRIPTION
Hardens Pipelock's containment self-test so it never reports "contained" without positive proof.

- The direct-egress canary in `contain verify` and `contain doctor` previously treated any failed egress attempt as proof of containment, so an unrelated DNS, TLS, or timeout failure could report a false all-clear. It now requires an attributable signal (a managed nftables DROP-counter increase against a DNS/TLS-free target) and returns UNKNOWN (exit 2) when it cannot attribute the failure.
- The standalone sandbox bridge now fails closed when no scanning handler is configured, instead of forwarding unscanned. Unscanned forwarding requires an explicit test-only opt-in.
- Structural verification now requires the managed chain to be a real hooked output base chain and rejects lookalike or unhooked chains, predicates before the owner match, and intercepting rules, so a benign counter cannot be read as containment evidence.
- The offline conformance harness no longer has a hidden nil-counter pass and requires the exact canary invocation.
- Text and JSON output fail closed on write errors, nftables parsing is quote and comment aware, and diagnostic text is sanitized.
- Outcome aggregation is honest across text, JSON, and conformance: FAIL over UNKNOWN or SKIP over PASS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pipelock contain verify` and `doctor` now surface inconclusive probe outcomes as `UNKNOWN` (text includes `[UNKNOWN]`; JSON includes `unknown`).
  * Exit code `2` now covers incomplete verification when any probes are skipped **or** inconclusive; exit code `1` remains for failures.
  * Direct egress verification uses DNS-free canary traffic with managed firewall counter attribution.
* **Bug Fixes**
  * Improved fail-closed nftables parsing/attribution to prevent misclassification on malformed or ambiguous data.
  * CLI output rendering now fails closed on write/short-write errors.
  * Standalone proxy connections fail closed when no proxy handler is configured.
* **Documentation**
  * Updated `contain verify`/`doctor` documentation and exit-code descriptions for `UNKNOWN` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->