### PR TITLE
fix(playground,licenseservice): harden public-facing surfaces

### DIFF
--- a/cmd/license-service/admin_test.go
+++ b/cmd/license-service/admin_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"context"
 	"crypto/ed25519"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"os"
@@ -28,13 +29,14 @@ import (
 func setAdminEnv(t *testing.T) (tokenKeyPath, crlKeyPath string, crlPub ed25519.PublicKey) {
 	t.Helper()
 	tokenPub, tokenKeyPath := writeServiceTestKey(t, "token")
-	certPath := writeServiceTestIntermediate(t, tokenPub)
+	certPath, rootPub := writeServiceTestIntermediate(t, tokenPub)
 	crlPub, crlKeyPath = writeServiceTestKey(t, "crl")
 	dir := t.TempDir()
 	t.Setenv("POLAR_WEBHOOK_SECRET", "whsec_"+"dGVzdA==")
 	t.Setenv("POLAR_API_TOKEN", "polar_"+"test")
 	t.Setenv("PIPELOCK_LICENSE_KEY_PATH", tokenKeyPath)
 	t.Setenv("PIPELOCK_LICENSE_INTERMEDIATE_FILE", certPath)
+	t.Setenv(license.EnvLicensePublicKey, hex.EncodeToString(rootPub))
 	t.Setenv("PIPELOCK_LICENSE_CRL_SIGNING_KEY_PATH", crlKeyPath)
 	t.Setenv("RESEND_API_KEY", "re_"+"test")
 	t.Setenv("DB_PATH", filepath.Join(dir, "licenses.db"))
@@ -234,7 +236,7 @@ func TestDispatchAdmin(t *testing.T) {
 func TestLoadSigningKeyHelpers(t *testing.T) {
 	t.Run("loadSigningKey_happy", func(t *testing.T) {
 		tokenPub, keyPath := writeServiceTestKey(t, "token")
-		certPath := writeServiceTestIntermediate(t, tokenPub)
+		certPath, _ := writeServiceTestIntermediate(t, tokenPub)
 		cfg := &licenseservice.Config{PrivateKeyPath: keyPath, IntermediateCertPath: certPath}
 		priv, err := loadSigningKey(cfg)
 		if err != nil {

--- a/cmd/license-service/admin_test.go
+++ b/cmd/license-service/admin_test.go
@@ -39,6 +39,7 @@ func setAdminEnv(t *testing.T) (tokenKeyPath, crlKeyPath string, crlPub ed25519.
 	t.Setenv(license.EnvLicensePublicKey, hex.EncodeToString(rootPub))
 	t.Setenv("PIPELOCK_LICENSE_CRL_SIGNING_KEY_PATH", crlKeyPath)
 	t.Setenv("RESEND_API_KEY", "re_"+"test")
+	t.Setenv("SUBSCRIPTION_PRODUCTS", "prod_test:pro:month:2900:usd")
 	t.Setenv("DB_PATH", filepath.Join(dir, "licenses.db"))
 	t.Setenv("LEDGER_PATH", filepath.Join(dir, "audit.jsonl"))
 	return tokenKeyPath, crlKeyPath, crlPub

--- a/cmd/license-service/main_test.go
+++ b/cmd/license-service/main_test.go
@@ -72,6 +72,7 @@ func setServiceRunEnv(t *testing.T, keyPath, certPath string) {
 	t.Setenv("PIPELOCK_LICENSE_KEY_PATH", keyPath)
 	t.Setenv("PIPELOCK_LICENSE_INTERMEDIATE_FILE", certPath)
 	t.Setenv("RESEND_API_KEY", "re_"+"test")
+	t.Setenv("SUBSCRIPTION_PRODUCTS", "prod_test:pro:month:2900:usd")
 	t.Setenv("DB_PATH", filepath.Join(t.TempDir(), "missing-parent", "licenses.db"))
 }
 

--- a/cmd/license-service/main_test.go
+++ b/cmd/license-service/main_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func writeServiceTestIntermediate(t *testing.T, intermediatePub ed25519.PublicKey) string {
+func writeServiceTestIntermediate(t *testing.T, intermediatePub ed25519.PublicKey) (string, ed25519.PublicKey) {
 	t.Helper()
-	_, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey(root): %v", err)
 	}
@@ -35,7 +35,7 @@ func writeServiceTestIntermediate(t *testing.T, intermediatePub ed25519.PublicKe
 		Algorithm: license.AlgorithmEd25519,
 		PublicKey: hex.EncodeToString(intermediatePub),
 		NotBefore: now.Add(-time.Minute).Unix(),
-		NotAfter:  now.Add(time.Hour).Unix(),
+		NotAfter:  now.Add(90 * 24 * time.Hour).Unix(),
 		IssuedAt:  now.Add(-time.Minute).Unix(),
 	}, rootPriv)
 	if err != nil {
@@ -49,7 +49,7 @@ func writeServiceTestIntermediate(t *testing.T, intermediatePub ed25519.PublicKe
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("write intermediate: %v", err)
 	}
-	return path
+	return path, rootPub
 }
 
 func writeServiceTestKey(t *testing.T, name string) (ed25519.PublicKey, string) {
@@ -77,9 +77,10 @@ func setServiceRunEnv(t *testing.T, keyPath, certPath string) {
 
 func TestRun_LoadsIntermediateAndCRLKeysBeforeDatabaseOpen(t *testing.T) {
 	pub, keyPath := writeServiceTestKey(t, "token")
-	certPath := writeServiceTestIntermediate(t, pub)
+	certPath, rootPub := writeServiceTestIntermediate(t, pub)
 	_, crlKeyPath := writeServiceTestKey(t, "crl")
 	setServiceRunEnv(t, keyPath, certPath)
+	t.Setenv(license.EnvLicensePublicKey, hex.EncodeToString(rootPub))
 	t.Setenv("PIPELOCK_LICENSE_CRL_SIGNING_KEY_PATH", crlKeyPath)
 
 	err := run(zerolog.New(io.Discard))
@@ -100,8 +101,9 @@ func TestRun_LoadIntermediateFailure(t *testing.T) {
 
 func TestRun_LoadCRLSigningKeyFailure(t *testing.T) {
 	pub, keyPath := writeServiceTestKey(t, "token")
-	certPath := writeServiceTestIntermediate(t, pub)
+	certPath, rootPub := writeServiceTestIntermediate(t, pub)
 	setServiceRunEnv(t, keyPath, certPath)
+	t.Setenv(license.EnvLicensePublicKey, hex.EncodeToString(rootPub))
 	t.Setenv("PIPELOCK_LICENSE_CRL_SIGNING_KEY_PATH", filepath.Join(t.TempDir(), "missing-crl.key"))
 
 	err := run(zerolog.New(io.Discard))

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -71,6 +71,16 @@ const (
 	// warmPoolVMCodeBytes mirrors broker.vmInviteCodeBytes for warm-pool VM
 	// code generation. Kept in sync with the broker constant.
 	warmPoolVMCodeBytes = 18
+
+	// brokerCSPTemplate carries a %s for the frame-ancestors source list, which
+	// is deployment-specific: only the site that embeds this broker in an iframe
+	// belongs there. It defaults to 'none' and widens only for origins an
+	// operator passes with --embed-origin, so a deployment that configures
+	// nothing cannot be framed at all.
+	brokerCSPTemplate       = "default-src 'none'; base-uri 'none'; object-src 'none'; frame-ancestors %s; script-src 'self' blob: 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; form-action 'self'"
+	brokerHSTS              = "max-age=31536000; includeSubDomains"
+	brokerReferrerPolicy    = "strict-origin-when-cross-origin"
+	brokerPermissionsPolicy = "camera=(), microphone=(), geolocation=()"
 )
 
 type serveFlags struct {
@@ -113,6 +123,7 @@ type serveFlags struct {
 	sessionTTL                time.Duration
 	deadlineGrace             time.Duration
 	allowOrigin               string
+	embedOrigins              []string
 	publicHosts               []string
 	cfAccessTeamDomain        string
 	cfAccessAUD               string
@@ -207,6 +218,7 @@ func newServeCmd() *cobra.Command {
 	fl.DurationVar(&f.sessionTTL, "session-ttl", defaultSessionTTL, "VM session token TTL")
 	fl.DurationVar(&f.deadlineGrace, "deadline-grace", defaultGrace, "lease teardown grace after VM session expiry")
 	fl.StringVar(&f.allowOrigin, "allow-origin", "", "Access-Control-Allow-Origin for the browser")
+	fl.StringArrayVar(&f.embedOrigins, "embed-origin", nil, "origin permitted to embed the broker in an iframe, as CSP frame-ancestors (repeatable); framing is forbidden when unset")
 	fl.StringArrayVar(&f.publicHosts, "public-host", nil, "allowed public Host header for the broker (repeatable); defaults to the --allow-origin host when set")
 	fl.StringVar(&f.cfAccessTeamDomain, "cf-access-team-domain", "", "Cloudflare Access team domain, e.g. https://team.cloudflareaccess.com; enables origin-side Access JWT validation when set with --cf-access-aud")
 	fl.StringVar(&f.cfAccessAUD, "cf-access-aud", "", "Cloudflare Access application AUD tag expected in Cf-Access-Jwt-Assertion")
@@ -475,6 +487,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		handler = cfAccessGuard(handler, cfAccess)
 		_, _ = fmt.Fprintf(out, "broker Cloudflare Access JWT guard enabled for %s\n", cfAccess.issuer)
 	}
+	handler = securityHeaders(handler, f.embedOrigins)
 	return srv, handler, reaper.Run, warmPool, nil
 }
 
@@ -547,6 +560,11 @@ func validateFlags(f *serveFlags) error {
 	}
 	if err := validateAllowOrigin(f.allowOrigin); err != nil {
 		return fmt.Errorf("--allow-origin: %w", err)
+	}
+	for _, origin := range f.embedOrigins {
+		if err := validateAllowOrigin(origin); err != nil {
+			return fmt.Errorf("--embed-origin %q: %w", origin, err)
+		}
 	}
 	if err := validateCFAccessFlags(f); err != nil {
 		return err
@@ -904,7 +922,7 @@ func validateAllowOrigin(raw string) error {
 		return errors.New("host is required")
 	}
 	if u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "" {
-		return errors.New("must be an origin only, like https://pipelab.org")
+		return errors.New("must be an origin only, like https://site.example")
 	}
 	return nil
 }
@@ -987,7 +1005,29 @@ func normalizePublicHost(raw string) (string, error) {
 func noCacheStatic(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("X-Content-Type-Options", "nosniff")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// brokerContentSecurityPolicy renders the CSP for the configured embed origins.
+// With none configured the policy forbids framing entirely.
+func brokerContentSecurityPolicy(embedOrigins []string) string {
+	sources := "'none'"
+	if len(embedOrigins) > 0 {
+		sources = strings.Join(embedOrigins, " ")
+	}
+	return fmt.Sprintf(brokerCSPTemplate, sources)
+}
+
+func securityHeaders(next http.Handler, embedOrigins []string) http.Handler {
+	csp := brokerContentSecurityPolicy(embedOrigins)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Content-Security-Policy", csp)
+		h.Set("Strict-Transport-Security", brokerHSTS)
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("Referrer-Policy", brokerReferrerPolicy)
+		h.Set("Permissions-Policy", brokerPermissionsPolicy)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -72,12 +72,11 @@ const (
 	// code generation. Kept in sync with the broker constant.
 	warmPoolVMCodeBytes = 18
 
-	// brokerCSPTemplate carries a %s for the frame-ancestors source list, which
-	// is deployment-specific: only the site that embeds this broker in an iframe
-	// belongs there. It defaults to 'none' and widens only for origins an
-	// operator passes with --embed-origin, so a deployment that configures
-	// nothing cannot be framed at all.
-	brokerCSPTemplate       = "default-src 'none'; base-uri 'none'; object-src 'none'; frame-ancestors %s; script-src 'self' blob: 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; form-action 'self'"
+	// brokerCSPTemplate carries deployment-specific frame-ancestor, script,
+	// connect, and frame sources. Third-party browser origins are never compiled
+	// into the binary. Framing defaults to 'none' and widens only for origins an
+	// operator passes with --embed-origin.
+	brokerCSPTemplate       = "default-src 'none'; base-uri 'none'; object-src 'none'; frame-ancestors %s; script-src 'self' blob: 'wasm-unsafe-eval'%s; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'%s; frame-src %s; form-action 'self'"
 	brokerHSTS              = "max-age=31536000; includeSubDomains"
 	brokerReferrerPolicy    = "strict-origin-when-cross-origin"
 	brokerPermissionsPolicy = "camera=(), microphone=(), geolocation=()"
@@ -120,6 +119,7 @@ type serveFlags struct {
 	turnstileExpectedAction   string
 	turnstileMaxAge           time.Duration
 	turnstileSitekey          string
+	turnstileOrigin           string
 	sessionTTL                time.Duration
 	deadlineGrace             time.Duration
 	allowOrigin               string
@@ -215,6 +215,7 @@ func newServeCmd() *cobra.Command {
 	fl.StringVar(&f.turnstileExpectedAction, "turnstile-action", "", "expected action label in the Turnstile Siteverify response; required when Turnstile runs against Cloudflare")
 	fl.DurationVar(&f.turnstileMaxAge, "turnstile-max-age", broker.DefaultTurnstileMaxAge, "max age for a Turnstile challenge_ts before it is rejected (0 disables)")
 	fl.StringVar(&f.turnstileSitekey, "turnstile-sitekey", "", "public Cloudflare Turnstile site key; reported via /health so the viewer renders the widget (the secret is set separately via --turnstile-secret-*)")
+	fl.StringVar(&f.turnstileOrigin, "turnstile-origin", "", "validated browser origin used by the Turnstile widget and added to CSP only when configured")
 	fl.DurationVar(&f.sessionTTL, "session-ttl", defaultSessionTTL, "VM session token TTL")
 	fl.DurationVar(&f.deadlineGrace, "deadline-grace", defaultGrace, "lease teardown grace after VM session expiry")
 	fl.StringVar(&f.allowOrigin, "allow-origin", "", "Access-Control-Allow-Origin for the browser")
@@ -487,7 +488,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		handler = cfAccessGuard(handler, cfAccess)
 		_, _ = fmt.Fprintf(out, "broker Cloudflare Access JWT guard enabled for %s\n", cfAccess.issuer)
 	}
-	handler = securityHeaders(handler, f.embedOrigins)
+	handler = securityHeaders(handler, f.embedOrigins, f.turnstileOrigin)
 	return srv, handler, reaper.Run, warmPool, nil
 }
 
@@ -565,6 +566,9 @@ func validateFlags(f *serveFlags) error {
 		if err := validateAllowOrigin(origin); err != nil {
 			return fmt.Errorf("--embed-origin %q: %w", origin, err)
 		}
+	}
+	if err := validateAllowOrigin(f.turnstileOrigin); err != nil {
+		return fmt.Errorf("--turnstile-origin: %w", err)
 	}
 	if err := validateCFAccessFlags(f); err != nil {
 		return err
@@ -921,7 +925,8 @@ func validateAllowOrigin(raw string) error {
 	if u.Host == "" {
 		return errors.New("host is required")
 	}
-	if u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "" {
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "" ||
+		strings.Contains(raw, "?") || strings.HasSuffix(raw, "#") {
 		return errors.New("must be an origin only, like https://site.example")
 	}
 	return nil
@@ -1011,16 +1016,22 @@ func noCacheStatic(next http.Handler) http.Handler {
 
 // brokerContentSecurityPolicy renders the CSP for the configured embed origins.
 // With none configured the policy forbids framing entirely.
-func brokerContentSecurityPolicy(embedOrigins []string) string {
+func brokerContentSecurityPolicy(embedOrigins []string, turnstileOrigin string) string {
 	sources := "'none'"
 	if len(embedOrigins) > 0 {
 		sources = strings.Join(embedOrigins, " ")
 	}
-	return fmt.Sprintf(brokerCSPTemplate, sources)
+	thirdPartySource := ""
+	frameSource := "'none'"
+	if turnstileOrigin != "" {
+		thirdPartySource = " " + turnstileOrigin
+		frameSource = turnstileOrigin
+	}
+	return fmt.Sprintf(brokerCSPTemplate, sources, thirdPartySource, thirdPartySource, frameSource)
 }
 
-func securityHeaders(next http.Handler, embedOrigins []string) http.Handler {
-	csp := brokerContentSecurityPolicy(embedOrigins)
+func securityHeaders(next http.Handler, embedOrigins []string, turnstileOrigin string) http.Handler {
+	csp := brokerContentSecurityPolicy(embedOrigins, turnstileOrigin)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
 		h.Set("Content-Security-Policy", csp)

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -925,7 +925,8 @@ func validateAllowOrigin(raw string) error {
 	if u.Host == "" {
 		return errors.New("host is required")
 	}
-	if u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "" ||
+	if u.User != nil || strings.Contains(u.Hostname(), "*") ||
+		u.RawQuery != "" || u.Fragment != "" || u.Path != "" ||
 		strings.Contains(raw, "?") || strings.HasSuffix(raw, "#") {
 		return errors.New("must be an origin only, like https://site.example")
 	}

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -556,6 +556,10 @@ func validateFlags(f *serveFlags) error {
 	if err := validateTurnstileFlags(f); err != nil {
 		return err
 	}
+	hasTurnstile := strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != ""
+	if hasTurnstile && strings.TrimSpace(f.turnstileOrigin) == "" {
+		return errors.New("--turnstile-origin is required when Turnstile is enabled")
+	}
 	if f.deadlineGrace < 0 {
 		return errors.New("--deadline-grace must be >= 0")
 	}
@@ -924,6 +928,15 @@ func validateAllowOrigin(raw string) error {
 	}
 	if u.Host == "" {
 		return errors.New("host is required")
+	}
+	if strings.HasSuffix(u.Host, ":") {
+		return errors.New("port must not be empty")
+	}
+	if port := u.Port(); port != "" {
+		portNumber, err := strconv.Atoi(port)
+		if err != nil || portNumber < 1 || portNumber > 65535 {
+			return errors.New("port must be 1-65535")
+		}
 	}
 	if u.User != nil || strings.Contains(u.Hostname(), "*") ||
 		u.RawQuery != "" || u.Fragment != "" || u.Path != "" ||

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -1098,6 +1098,13 @@ func TestValidateFlagsBranches(t *testing.T) {
 		{name: "bad_memory", mutate: func(f *serveFlags) { f.memoryMB = -1 }},
 		{name: "bad_cpus", mutate: func(f *serveFlags) { f.cpus = -1 }},
 		{name: "bad_deadline_grace", mutate: func(f *serveFlags) { f.deadlineGrace = -1 }},
+		{name: "embed_origin_wildcard", mutate: func(f *serveFlags) { f.embedOrigins = []string{"*"} }},
+		{name: "embed_origin_path", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example/path"} }},
+		{name: "embed_origin_query", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example?x=1"} }},
+		{name: "embed_origin_empty_query", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example?"} }},
+		{name: "embed_origin_fragment", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example#part"} }},
+		{name: "embed_origin_empty_fragment", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example#"} }},
+		{name: "embed_origin_malformed", mutate: func(f *serveFlags) { f.embedOrigins = []string{"://bad"} }},
 		{name: "turnstile_url_without_secret", mutate: func(f *serveFlags) { f.turnstileVerifyURL = "https://turnstile.example/verify" }},
 		{name: "bad_turnstile_verify_url", mutate: func(f *serveFlags) {
 			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
@@ -1578,20 +1585,23 @@ const testEmbedOrigin = "https://site.example"
 // default has to be the closed one: an operator who never thought about
 // embedding should not ship a frameable page.
 func TestBrokerContentSecurityPolicy_DefaultsToNoFraming(t *testing.T) {
-	got := brokerContentSecurityPolicy(nil)
+	got := brokerContentSecurityPolicy(nil, "")
 	if !strings.Contains(got, "frame-ancestors 'none'") {
 		t.Fatalf("CSP with no embed origins = %q, want frame-ancestors 'none'", got)
 	}
-	withOrigin := brokerContentSecurityPolicy([]string{testEmbedOrigin, "https://www.site.example"})
+	withOrigin := brokerContentSecurityPolicy([]string{testEmbedOrigin, "https://www.site.example"}, "https://challenge.vendor.example")
 	if !strings.Contains(withOrigin, "frame-ancestors https://site.example https://www.site.example;") {
 		t.Fatalf("CSP with embed origins = %q, want both origins in frame-ancestors", withOrigin)
+	}
+	if strings.Count(withOrigin, "https://challenge.vendor.example") != 3 {
+		t.Fatalf("CSP = %q, want configured Turnstile origin in script-src, connect-src, and frame-src", withOrigin)
 	}
 }
 
 func assertBrokerSecurityHeaders(t *testing.T, h http.Header) {
 	t.Helper()
 	want := map[string]string{
-		"Content-Security-Policy":   brokerContentSecurityPolicy([]string{testEmbedOrigin}),
+		"Content-Security-Policy":   brokerContentSecurityPolicy([]string{testEmbedOrigin}, ""),
 		"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
 		"X-Content-Type-Options":    "nosniff",
 		"Referrer-Policy":           "strict-origin-when-cross-origin",

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -1075,6 +1075,11 @@ func TestValidateFlagsBranches(t *testing.T) {
 	if err := validateFlags(&turnstileGate); err != nil {
 		t.Fatalf("turnstile gate should validate: %v", err)
 	}
+	turnstileWithoutOrigin := turnstileGate
+	turnstileWithoutOrigin.turnstileOrigin = ""
+	if err := validateFlags(&turnstileWithoutOrigin); err == nil || !strings.Contains(err.Error(), "--turnstile-origin is required") {
+		t.Fatalf("Turnstile gate without origin error = %v, want required-origin error", err)
+	}
 	if err := validateAllowOrigin("https://site.example:65535"); err != nil {
 		t.Fatalf("maximum valid origin port should validate: %v", err)
 	}

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -256,6 +256,7 @@ func TestBrokerSecurityHeaders(t *testing.T) {
 		vmDailyTurnBudget:     10,
 		requireSessionSecrets: false,
 		embedOrigins:          []string{testEmbedOrigin},
+		turnstileOrigin:       "https://challenge.vendor.example",
 	})
 	if err != nil {
 		t.Fatalf("buildServer: %v", err)
@@ -277,7 +278,7 @@ func TestBrokerSecurityHeaders(t *testing.T) {
 			if resp.StatusCode != http.StatusOK {
 				t.Fatalf("GET %s status = %d, want 200", tc.path, resp.StatusCode)
 			}
-			assertBrokerSecurityHeaders(t, resp.Header)
+			assertBrokerSecurityHeaders(t, resp.Header, "https://challenge.vendor.example")
 		})
 	}
 }
@@ -499,6 +500,7 @@ func TestBuildServerTurnstileRejectsMissingToken(t *testing.T) {
 		globalDailyBudget:     10,
 		turnstileSecretFile:   turnstileSecretFile,
 		turnstileVerifyURL:    verifyServer.URL,
+		turnstileOrigin:       "https://challenge.vendor.example",
 		sessionTTL:            defaultSessionTTL,
 		deadlineGrace:         defaultGrace,
 		vmDailyTurnBudget:     10,
@@ -1069,8 +1071,12 @@ func TestValidateFlagsBranches(t *testing.T) {
 	turnstileGate.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
 	turnstileGate.turnstileExpectedHostname = "playground.example"
 	turnstileGate.turnstileExpectedAction = "playground-session"
+	turnstileGate.turnstileOrigin = "https://challenge.vendor.example"
 	if err := validateFlags(&turnstileGate); err != nil {
 		t.Fatalf("turnstile gate should validate: %v", err)
+	}
+	if err := validateAllowOrigin("https://site.example:65535"); err != nil {
+		t.Fatalf("maximum valid origin port should validate: %v", err)
 	}
 	cfAccessGate := noHumanGate
 	cfAccessGate.cfAccessTeamDomain = "team.cloudflareaccess.com"
@@ -1106,6 +1112,9 @@ func TestValidateFlagsBranches(t *testing.T) {
 		{name: "embed_origin_empty_fragment", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example#"} }},
 		{name: "embed_origin_malformed", mutate: func(f *serveFlags) { f.embedOrigins = []string{"://bad"} }},
 		{name: "embed_origin_wildcard_host", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://*.site.example"} }},
+		{name: "embed_origin_empty_port", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example:"} }},
+		{name: "embed_origin_port_zero", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example:0"} }},
+		{name: "embed_origin_port_too_large", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example:65536"} }},
 		{name: "turnstile_origin_path", mutate: func(f *serveFlags) {
 			f.turnstileOrigin = "https://challenge.vendor.example/path"
 		}},
@@ -1611,10 +1620,10 @@ func TestBrokerContentSecurityPolicy_DefaultsToNoFraming(t *testing.T) {
 	}
 }
 
-func assertBrokerSecurityHeaders(t *testing.T, h http.Header) {
+func assertBrokerSecurityHeaders(t *testing.T, h http.Header, turnstileOrigin string) {
 	t.Helper()
 	want := map[string]string{
-		"Content-Security-Policy":   brokerContentSecurityPolicy([]string{testEmbedOrigin}, ""),
+		"Content-Security-Policy":   brokerContentSecurityPolicy([]string{testEmbedOrigin}, turnstileOrigin),
 		"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
 		"X-Content-Type-Options":    "nosniff",
 		"Referrer-Policy":           "strict-origin-when-cross-origin",

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -221,6 +222,110 @@ func TestBuildServerStaticDir(t *testing.T) {
 	t.Cleanup(ts2.Close)
 	if _, status := httpGetStatus(t, ts2.URL+"/"); status != http.StatusNotFound {
 		t.Fatalf("GET / without --static-dir = %d, want 404", status)
+	}
+}
+
+func TestBrokerSecurityHeaders(t *testing.T) {
+	dir := t.TempDir()
+	uiDir := filepath.Join(dir, "ui")
+	if err := os.MkdirAll(uiDir, 0o750); err != nil {
+		t.Fatalf("mkdir ui: %v", err)
+	}
+	writeTestFile(t, uiDir, "index.html", "<html><body>live demo ui</body></html>")
+	writeTestFile(t, uiDir, "viewer-live.js", "window.playgroundLive = true;\n")
+	flyTokenFile := writeTestFile(t, dir, "fly.token", "fly-file-token\n")
+	gateSecret := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	gateSecretFile := writeTestFile(t, dir, "gate.b64", gateSecret+"\n")
+
+	oldFactory := newMachineProvider
+	newMachineProvider = func(_ context.Context, _ *serveFlags, _ string) (broker.MachineProvider, error) {
+		return fakeProvider{}, nil
+	}
+	t.Cleanup(func() { newMachineProvider = oldFactory })
+
+	srv, handler, _, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
+		listen: defaultListen, provider: "fake", flyApp: "playground-test",
+		flyTokenFile: flyTokenFile, image: "registry.example/playground:test",
+		staticDir: uiDir, internalPort: 8080, concurrency: 2,
+		codes: []string{"outer-code"}, maxPerCode: defaultMaxPerCode,
+		gateSecretFile: gateSecretFile, ipRate: defaultIPRate, ipBurst: defaultIPBurst,
+		codeRate: defaultCodeRate, codeBurst: defaultCodeBurst,
+		globalDailyBudget: 10,
+		unsafeNoHumanGate: true,
+		sessionTTL:        defaultSessionTTL, deadlineGrace: defaultGrace,
+		vmDailyTurnBudget:     10,
+		requireSessionSecrets: false,
+		embedOrigins:          []string{testEmbedOrigin},
+	})
+	if err != nil {
+		t.Fatalf("buildServer: %v", err)
+	}
+	t.Cleanup(srv.Close)
+	baseURL := startHTTPTestServer(t, handler)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "static_asset", path: "/viewer-live.js"},
+		{name: "api_live", path: livechat.RouteHealth},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := testHTTPGet(t, baseURL+tc.path)
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("GET %s status = %d, want 200", tc.path, resp.StatusCode)
+			}
+			assertBrokerSecurityHeaders(t, resp.Header)
+		})
+	}
+}
+
+func TestBrokerServesWASMAsApplicationWASM(t *testing.T) {
+	dir := t.TempDir()
+	uiDir := filepath.Join(dir, "ui")
+	if err := os.MkdirAll(uiDir, 0o750); err != nil {
+		t.Fatalf("mkdir ui: %v", err)
+	}
+	writeTestFile(t, uiDir, "index.html", "<html><body>live demo ui</body></html>")
+	writeTestFile(t, uiDir, "pipelock-verifier.wasm", "\x00asm\x01\x00\x00\x00")
+	flyTokenFile := writeTestFile(t, dir, "fly.token", "fly-file-token\n")
+	gateSecret := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	gateSecretFile := writeTestFile(t, dir, "gate.b64", gateSecret+"\n")
+
+	oldFactory := newMachineProvider
+	newMachineProvider = func(_ context.Context, _ *serveFlags, _ string) (broker.MachineProvider, error) {
+		return fakeProvider{}, nil
+	}
+	t.Cleanup(func() { newMachineProvider = oldFactory })
+
+	srv, handler, _, _, err := buildServer(context.Background(), &bytes.Buffer{}, &serveFlags{
+		listen: defaultListen, provider: "fake", flyApp: "playground-test",
+		flyTokenFile: flyTokenFile, image: "registry.example/playground:test",
+		staticDir: uiDir, internalPort: 8080, concurrency: 2,
+		codes: []string{"outer-code"}, maxPerCode: defaultMaxPerCode,
+		gateSecretFile: gateSecretFile, ipRate: defaultIPRate, ipBurst: defaultIPBurst,
+		codeRate: defaultCodeRate, codeBurst: defaultCodeBurst,
+		globalDailyBudget: 10,
+		unsafeNoHumanGate: true,
+		sessionTTL:        defaultSessionTTL, deadlineGrace: defaultGrace,
+		vmDailyTurnBudget:     10,
+		requireSessionSecrets: false,
+	})
+	if err != nil {
+		t.Fatalf("buildServer: %v", err)
+	}
+	t.Cleanup(srv.Close)
+	baseURL := startHTTPTestServer(t, handler)
+
+	resp := testHTTPGet(t, baseURL+"/pipelock-verifier.wasm")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET wasm status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/wasm" {
+		t.Fatalf("Content-Type = %q, want application/wasm", got)
 	}
 }
 
@@ -1428,6 +1533,80 @@ func writeTestFile(t *testing.T, dir, name, content string) string {
 	return path
 }
 
+func startHTTPTestServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen test server: %v", err)
+	}
+	httpSrv := &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := httpSrv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("test server: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = httpSrv.Shutdown(ctx)
+		<-done
+	})
+	return "http://" + ln.Addr().String()
+}
+
+func testHTTPGet(t *testing.T, rawURL string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, rawURL, nil)
+	if err != nil {
+		t.Fatalf("new GET %s: %v", rawURL, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", rawURL, err)
+	}
+	return resp
+}
+
+// testEmbedOrigin is the neutral placeholder origin the header tests configure,
+// so no deployment hostname is pinned into the repo.
+const testEmbedOrigin = "https://site.example"
+
+// A broker with no configured embed origin must forbid framing outright. The
+// default has to be the closed one: an operator who never thought about
+// embedding should not ship a frameable page.
+func TestBrokerContentSecurityPolicy_DefaultsToNoFraming(t *testing.T) {
+	got := brokerContentSecurityPolicy(nil)
+	if !strings.Contains(got, "frame-ancestors 'none'") {
+		t.Fatalf("CSP with no embed origins = %q, want frame-ancestors 'none'", got)
+	}
+	withOrigin := brokerContentSecurityPolicy([]string{testEmbedOrigin, "https://www.site.example"})
+	if !strings.Contains(withOrigin, "frame-ancestors https://site.example https://www.site.example;") {
+		t.Fatalf("CSP with embed origins = %q, want both origins in frame-ancestors", withOrigin)
+	}
+}
+
+func assertBrokerSecurityHeaders(t *testing.T, h http.Header) {
+	t.Helper()
+	want := map[string]string{
+		"Content-Security-Policy":   brokerContentSecurityPolicy([]string{testEmbedOrigin}),
+		"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+		"X-Content-Type-Options":    "nosniff",
+		"Referrer-Policy":           "strict-origin-when-cross-origin",
+		"Permissions-Policy":        "camera=(), microphone=(), geolocation=()",
+	}
+	for name, value := range want {
+		if got := h.Get(name); got != value {
+			t.Fatalf("%s = %q, want %q", name, got, value)
+		}
+	}
+	if got := h.Get("X-Frame-Options"); got != "" {
+		t.Fatalf("X-Frame-Options = %q, want unset because frame-ancestors allows the cross-origin marketing embed", got)
+	}
+}
+
 // TestBuildVMBaseEnv pins the PLAYGROUND_* env contract that the deploy
 // entrypoint (deploy/fly-playground/entrypoint.sh) consumes into serve flags. A
 // rename here without updating the entrypoint silently breaks the per-VM config,
@@ -1472,8 +1651,8 @@ func TestNoCacheStatic(t *testing.T) {
 	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
 		t.Fatalf("Cache-Control = %q, want no-cache (so the viewer revalidates after a redeploy)", got)
 	}
-	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
-		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "" {
+		t.Fatalf("X-Content-Type-Options = %q, want noCacheStatic to leave security headers to securityHeaders", got)
 	}
 }
 

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -1105,6 +1105,13 @@ func TestValidateFlagsBranches(t *testing.T) {
 		{name: "embed_origin_fragment", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example#part"} }},
 		{name: "embed_origin_empty_fragment", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://site.example#"} }},
 		{name: "embed_origin_malformed", mutate: func(f *serveFlags) { f.embedOrigins = []string{"://bad"} }},
+		{name: "embed_origin_wildcard_host", mutate: func(f *serveFlags) { f.embedOrigins = []string{"https://*.site.example"} }},
+		{name: "turnstile_origin_path", mutate: func(f *serveFlags) {
+			f.turnstileOrigin = "https://challenge.vendor.example/path"
+		}},
+		{name: "turnstile_origin_wildcard_host", mutate: func(f *serveFlags) {
+			f.turnstileOrigin = "https://*.vendor.example"
+		}},
 		{name: "turnstile_url_without_secret", mutate: func(f *serveFlags) { f.turnstileVerifyURL = "https://turnstile.example/verify" }},
 		{name: "bad_turnstile_verify_url", mutate: func(f *serveFlags) {
 			f.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
@@ -1593,8 +1600,14 @@ func TestBrokerContentSecurityPolicy_DefaultsToNoFraming(t *testing.T) {
 	if !strings.Contains(withOrigin, "frame-ancestors https://site.example https://www.site.example;") {
 		t.Fatalf("CSP with embed origins = %q, want both origins in frame-ancestors", withOrigin)
 	}
-	if strings.Count(withOrigin, "https://challenge.vendor.example") != 3 {
-		t.Fatalf("CSP = %q, want configured Turnstile origin in script-src, connect-src, and frame-src", withOrigin)
+	for _, want := range []string{
+		"script-src 'self' blob: 'wasm-unsafe-eval' https://challenge.vendor.example;",
+		"connect-src 'self' https://challenge.vendor.example;",
+		"frame-src https://challenge.vendor.example;",
+	} {
+		if !strings.Contains(withOrigin, want) {
+			t.Fatalf("CSP = %q, missing %q", withOrigin, want)
+		}
 	}
 }
 

--- a/docs/guides/playground-broker-operations.md
+++ b/docs/guides/playground-broker-operations.md
@@ -58,6 +58,8 @@ pipelock-playground-broker serve \
   --admin-listen 127.0.0.1:8101 \
   --admin-token-env PLAYGROUND_ADMIN_TOKEN \
   --turnstile-secret-env PLAYGROUND_TURNSTILE_SECRET \
+  --turnstile-expected-hostname playground.example.com \
+  --turnstile-action playground-session \
   --vm-model-base-url https://api.provider.example/v1 \
   --vm-model demo-model \
   --vm-model-max-steps 20 \
@@ -66,6 +68,7 @@ pipelock-playground-broker serve \
   --vm-session-ttl 30m \
   --static-dir ./dist/playground \
   --allow-origin https://playground.example.com \
+  --embed-origin https://site.example \
   --public-host playground.example.com
 ```
 

--- a/docs/security/key-rotation-runbook.md
+++ b/docs/security/key-rotation-runbook.md
@@ -137,7 +137,7 @@ license.IntermediatePayload{
 }
 ```
 
-3. Deploy the new intermediate private key and certificate to the license service. The service signs tokens with `PIPELOCK_LICENSE_KEY_PATH` and serves the configured certificate from `PIPELOCK_LICENSE_INTERMEDIATE_FILE`.
+3. Deploy the new intermediate private key and certificate to the license service, then restart the service. The service pins the verified intermediate public key and serial at startup; replacing the files without a restart makes minting and refresh fail closed with `intermediate certificate changed since startup`. The service signs tokens with `PIPELOCK_LICENSE_KEY_PATH` and serves the configured certificate from `PIPELOCK_LICENSE_INTERMEDIATE_FILE`.
 
 ```bash
 export PIPELOCK_LICENSE_KEY_PATH=/etc/pipelock/license-intermediate.key

--- a/docs/security/key-rotation-runbook.md
+++ b/docs/security/key-rotation-runbook.md
@@ -137,7 +137,7 @@ license.IntermediatePayload{
 }
 ```
 
-3. Deploy the new intermediate private key and certificate to the license service, then restart the service. The service pins the verified intermediate public key and serial at startup; replacing the files without a restart makes minting and refresh fail closed with `intermediate certificate changed since startup`. The service signs tokens with `PIPELOCK_LICENSE_KEY_PATH` and serves the configured certificate from `PIPELOCK_LICENSE_INTERMEDIATE_FILE`.
+1. Deploy the new intermediate private key and certificate to the license service, then restart the service. The service pins the verified intermediate public key and serial at startup; replacing the files without a restart makes minting and refresh fail closed with `intermediate certificate changed since startup`. The service signs tokens with `PIPELOCK_LICENSE_KEY_PATH` and serves the configured certificate from `PIPELOCK_LICENSE_INTERMEDIATE_FILE`.
 
 ```bash
 export PIPELOCK_LICENSE_KEY_PATH=/etc/pipelock/license-intermediate.key

--- a/enterprise/licenseservice/config.go
+++ b/enterprise/licenseservice/config.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
 // Config holds all configuration for the license service, loaded from
@@ -36,6 +38,14 @@ type Config struct {
 	// IntermediateCert is populated by cmd/license-service after loading
 	// IntermediateCertPath. It is public certificate bytes, not a secret.
 	IntermediateCert []byte
+
+	// LicensePublicKey is the dev/self-hosted fallback root public key used to
+	// verify IntermediateCert. Official builds use the embedded key first.
+	LicensePublicKey string
+
+	// RootPublicKey is the resolved root trust anchor. Tests may inject it
+	// directly; production resolves embedded key > LicensePublicKey/env.
+	RootPublicKey ed25519.PublicKey
 
 	// CRLSigningKeyPath optionally points at the root/private key used to sign
 	// dynamic CRLs. Leave empty when CRLs are signed offline and distributed as
@@ -86,6 +96,20 @@ type Config struct {
 	// EvalCurrency is the expected ISO 4217 currency (lowercase) for an eval
 	// order. Defaults to usd.
 	EvalCurrency string
+
+	// SubscriptionProducts allowlist paid recurring products by product ID. Empty
+	// preserves legacy metadata mapping with a startup warning.
+	SubscriptionProducts []SubscriptionProductConfig
+}
+
+// SubscriptionProductConfig pins a Polar subscription product to the server-side
+// commercial facts required before it can mint a token.
+type SubscriptionProductConfig struct {
+	ProductID   string
+	Tier        string
+	Interval    string
+	AmountCents int
+	Currency    string
 }
 
 const (
@@ -111,6 +135,7 @@ func LoadConfig() (*Config, error) {
 			"PIPELOCK_LICENSE_INTERMEDIATE_FILE",
 		),
 		CRLSigningKeyPath: os.Getenv("PIPELOCK_LICENSE_CRL_SIGNING_KEY_PATH"),
+		LicensePublicKey:  strings.TrimSpace(os.Getenv(license.EnvLicensePublicKey)),
 		ResendAPIKey:      os.Getenv("RESEND_API_KEY"),
 		DBPath:            envOrDefault("DB_PATH", defaultDBPath),
 		LedgerPath:        envOrDefault("LEDGER_PATH", defaultLedgerPath),
@@ -158,6 +183,29 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("EVAL_AMOUNT_CENTS must be set (>0) when EVAL_PRODUCT_IDS is configured")
 	}
 
+	cfg.SubscriptionProducts = parseSubscriptionProducts(os.Getenv("SUBSCRIPTION_PRODUCTS"))
+	for _, product := range cfg.SubscriptionProducts {
+		if product.ProductID == "" {
+			return nil, fmt.Errorf("SUBSCRIPTION_PRODUCTS contains an empty product ID")
+		}
+		// enterprise_eval and trial are one-time purchases handled by the order
+		// path with its own allowlist, so they never belong here. assess is a
+		// live recurring product and must be allowlistable, or an Assess
+		// customer can never be mapped once enforcement is on.
+		if !validTiers[product.Tier] || product.Tier == tierEnterpriseEval || product.Tier == tierTrial {
+			return nil, fmt.Errorf("SUBSCRIPTION_PRODUCTS product %s has invalid subscription tier %q", product.ProductID, product.Tier)
+		}
+		if product.Interval == "" {
+			return nil, fmt.Errorf("SUBSCRIPTION_PRODUCTS product %s must set interval", product.ProductID)
+		}
+		if product.AmountCents <= 0 {
+			return nil, fmt.Errorf("SUBSCRIPTION_PRODUCTS product %s must set positive amount_cents", product.ProductID)
+		}
+		if product.Currency == "" {
+			return nil, fmt.Errorf("SUBSCRIPTION_PRODUCTS product %s must set currency", product.ProductID)
+		}
+	}
+
 	// Validate required secrets.
 	if cfg.PolarWebhookSecret == "" {
 		return nil, fmt.Errorf("POLAR_WEBHOOK_SECRET is required")
@@ -197,6 +245,36 @@ func splitAndTrim(raw string) []string {
 		if trimmed := strings.TrimSpace(p); trimmed != "" {
 			out = append(out, trimmed)
 		}
+	}
+	return out
+}
+
+// parseSubscriptionProducts parses:
+//
+//	product_id:tier:interval:amount_cents:currency[,product_id:...]
+func parseSubscriptionProducts(raw string) []SubscriptionProductConfig {
+	entries := splitAndTrim(raw)
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]SubscriptionProductConfig, 0, len(entries))
+	for _, entry := range entries {
+		parts := strings.Split(entry, ":")
+		if len(parts) != 5 {
+			out = append(out, SubscriptionProductConfig{ProductID: strings.TrimSpace(entry)})
+			continue
+		}
+		amount, err := strconv.Atoi(strings.TrimSpace(parts[3]))
+		if err != nil {
+			amount = -1
+		}
+		out = append(out, SubscriptionProductConfig{
+			ProductID:   strings.TrimSpace(parts[0]),
+			Tier:        strings.ToLower(strings.TrimSpace(parts[1])),
+			Interval:    strings.ToLower(strings.TrimSpace(parts[2])),
+			AmountCents: amount,
+			Currency:    strings.ToLower(strings.TrimSpace(parts[4])),
+		})
 	}
 	return out
 }

--- a/enterprise/licenseservice/config.go
+++ b/enterprise/licenseservice/config.go
@@ -97,9 +97,14 @@ type Config struct {
 	// order. Defaults to usd.
 	EvalCurrency string
 
-	// SubscriptionProducts allowlist paid recurring products by product ID. Empty
-	// preserves legacy metadata mapping with a startup warning.
+	// SubscriptionProducts allowlist paid recurring products by product ID.
+	// Production startup fails closed when it is empty.
 	SubscriptionProducts []SubscriptionProductConfig
+
+	// OrderProducts allowlist legacy one-time products by product ID. Empty
+	// disables legacy order.created fulfillment. Enterprise Eval uses its
+	// separate order.paid allowlist and is not configured here.
+	OrderProducts []OrderProductConfig
 }
 
 // SubscriptionProductConfig pins a Polar subscription product to the server-side
@@ -108,6 +113,15 @@ type SubscriptionProductConfig struct {
 	ProductID   string
 	Tier        string
 	Interval    string
+	AmountCents int
+	Currency    string
+}
+
+// OrderProductConfig pins a one-time product to the commercial facts required
+// before the legacy order path can mint a token.
+type OrderProductConfig struct {
+	ProductID   string
+	Tier        string
 	AmountCents int
 	Currency    string
 }
@@ -184,6 +198,10 @@ func LoadConfig() (*Config, error) {
 	}
 
 	cfg.SubscriptionProducts = parseSubscriptionProducts(os.Getenv("SUBSCRIPTION_PRODUCTS"))
+	if len(cfg.SubscriptionProducts) == 0 {
+		return nil, fmt.Errorf("SUBSCRIPTION_PRODUCTS is required")
+	}
+	seenSubscriptionProducts := make(map[string]struct{}, len(cfg.SubscriptionProducts))
 	for _, product := range cfg.SubscriptionProducts {
 		if product.ProductID == "" {
 			return nil, fmt.Errorf("SUBSCRIPTION_PRODUCTS contains an empty product ID")
@@ -204,6 +222,31 @@ func LoadConfig() (*Config, error) {
 		if product.Currency == "" {
 			return nil, fmt.Errorf("SUBSCRIPTION_PRODUCTS product %s must set currency", product.ProductID)
 		}
+		if _, exists := seenSubscriptionProducts[product.ProductID]; exists {
+			return nil, fmt.Errorf("SUBSCRIPTION_PRODUCTS contains duplicate product ID %s", product.ProductID)
+		}
+		seenSubscriptionProducts[product.ProductID] = struct{}{}
+	}
+
+	cfg.OrderProducts = parseOrderProducts(os.Getenv("ORDER_PRODUCTS"))
+	seenOrderProducts := make(map[string]struct{}, len(cfg.OrderProducts))
+	for _, product := range cfg.OrderProducts {
+		if product.ProductID == "" {
+			return nil, fmt.Errorf("ORDER_PRODUCTS contains an empty product ID")
+		}
+		if !validTiers[product.Tier] || product.Tier != tierTrial {
+			return nil, fmt.Errorf("ORDER_PRODUCTS product %s has invalid one-time tier %q", product.ProductID, product.Tier)
+		}
+		if product.AmountCents <= 0 {
+			return nil, fmt.Errorf("ORDER_PRODUCTS product %s must set positive amount_cents", product.ProductID)
+		}
+		if product.Currency == "" {
+			return nil, fmt.Errorf("ORDER_PRODUCTS product %s must set currency", product.ProductID)
+		}
+		if _, exists := seenOrderProducts[product.ProductID]; exists {
+			return nil, fmt.Errorf("ORDER_PRODUCTS contains duplicate product ID %s", product.ProductID)
+		}
+		seenOrderProducts[product.ProductID] = struct{}{}
 	}
 
 	// Validate required secrets.
@@ -274,6 +317,32 @@ func parseSubscriptionProducts(raw string) []SubscriptionProductConfig {
 			Interval:    strings.ToLower(strings.TrimSpace(parts[2])),
 			AmountCents: amount,
 			Currency:    strings.ToLower(strings.TrimSpace(parts[4])),
+		})
+	}
+	return out
+}
+
+// parseOrderProducts parses:
+//
+//	product_id:tier:amount_cents:currency[,product_id:...]
+func parseOrderProducts(raw string) []OrderProductConfig {
+	entries := splitAndTrim(raw)
+	out := make([]OrderProductConfig, 0, len(entries))
+	for _, entry := range entries {
+		parts := strings.Split(entry, ":")
+		if len(parts) != 4 {
+			out = append(out, OrderProductConfig{ProductID: strings.TrimSpace(entry)})
+			continue
+		}
+		amount, err := strconv.Atoi(strings.TrimSpace(parts[2]))
+		if err != nil {
+			amount = -1
+		}
+		out = append(out, OrderProductConfig{
+			ProductID:   strings.TrimSpace(parts[0]),
+			Tier:        strings.ToLower(strings.TrimSpace(parts[1])),
+			AmountCents: amount,
+			Currency:    strings.ToLower(strings.TrimSpace(parts[3])),
 		})
 	}
 	return out

--- a/enterprise/licenseservice/config_test.go
+++ b/enterprise/licenseservice/config_test.go
@@ -18,6 +18,7 @@ func setRequiredConfigEnv(t *testing.T) {
 	t.Setenv("PIPELOCK_LICENSE_KEY_PATH", "/tmp/test.key")
 	t.Setenv("PIPELOCK_LICENSE_INTERMEDIATE_FILE", "/tmp/intermediate.json")
 	t.Setenv("RESEND_API_KEY", "re_"+"test")
+	t.Setenv("SUBSCRIPTION_PRODUCTS", "prod_test:pro:month:2900:usd")
 }
 
 func TestLoadConfig_AllRequired(t *testing.T) {
@@ -211,6 +212,58 @@ func TestLoadConfig_SubscriptionProductsConfigured(t *testing.T) {
 	}
 	if got := cfg.SubscriptionProducts[0]; got.ProductID != "prod_pro" || got.Tier != tierPro || got.Interval != testIntervalMonth || got.AmountCents != 2900 || got.Currency != "usd" {
 		t.Fatalf("first SubscriptionProduct = %+v", got)
+	}
+}
+
+func TestLoadConfig_SubscriptionProductsRequiredAndUnique(t *testing.T) {
+	t.Run("required", func(t *testing.T) {
+		setRequiredConfigEnv(t)
+		t.Setenv("SUBSCRIPTION_PRODUCTS", "")
+		if _, err := LoadConfig(); err == nil {
+			t.Fatal("LoadConfig accepted an empty subscription allowlist")
+		}
+	})
+	t.Run("unique product IDs", func(t *testing.T) {
+		setRequiredConfigEnv(t)
+		t.Setenv("SUBSCRIPTION_PRODUCTS", "prod_pro:pro:month:2900:usd,prod_pro:pro:year:29000:usd")
+		if _, err := LoadConfig(); err == nil {
+			t.Fatal("LoadConfig accepted duplicate subscription product IDs")
+		}
+	})
+}
+
+func TestLoadConfig_OrderProducts(t *testing.T) {
+	setRequiredConfigEnv(t)
+	t.Setenv("ORDER_PRODUCTS", "prod_trial:TRIAL:100:USD")
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.OrderProducts) != 1 {
+		t.Fatalf("OrderProducts = %+v, want one product", cfg.OrderProducts)
+	}
+	if got := cfg.OrderProducts[0]; got.ProductID != "prod_trial" || got.Tier != tierTrial || got.AmountCents != 100 || got.Currency != "usd" {
+		t.Fatalf("OrderProducts[0] = %+v", got)
+	}
+}
+
+func TestLoadConfig_OrderProductsRejectMalformed(t *testing.T) {
+	for _, value := range []string{
+		"prod_only",
+		":trial:100:usd",
+		"prod_trial:pro:100:usd",
+		"prod_trial:trial:0:usd",
+		"prod_trial:trial:not-money:usd",
+		"prod_trial:trial:100:",
+		"prod_trial:trial:100:usd,prod_trial:trial:100:usd",
+	} {
+		t.Run(value, func(t *testing.T) {
+			setRequiredConfigEnv(t)
+			t.Setenv("ORDER_PRODUCTS", value)
+			if _, err := LoadConfig(); err == nil {
+				t.Fatal("LoadConfig accepted malformed ORDER_PRODUCTS")
+			}
+		})
 	}
 }
 

--- a/enterprise/licenseservice/config_test.go
+++ b/enterprise/licenseservice/config_test.go
@@ -198,6 +198,52 @@ func TestLoadConfig_EvalInvalidAmount(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_SubscriptionProductsConfigured(t *testing.T) {
+	setRequiredConfigEnv(t)
+	t.Setenv("SUBSCRIPTION_PRODUCTS", "prod_pro:pro:month:2900:USD, prod_ent:enterprise:year:990000:usd")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.SubscriptionProducts) != 2 {
+		t.Fatalf("SubscriptionProducts = %v, want 2 entries", cfg.SubscriptionProducts)
+	}
+	if got := cfg.SubscriptionProducts[0]; got.ProductID != "prod_pro" || got.Tier != tierPro || got.Interval != testIntervalMonth || got.AmountCents != 2900 || got.Currency != "usd" {
+		t.Fatalf("first SubscriptionProduct = %+v", got)
+	}
+}
+
+func TestLoadConfig_SubscriptionProductsRejectMalformed(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+	}{
+		{name: "missing fields", env: "prod_only"},
+		{name: "bad amount", env: "prod_pro:pro:month:not-money:usd"},
+		{name: "invalid tier", env: "prod_eval:enterprise_eval:month:500000:usd"},
+		{name: "missing interval", env: "prod_pro:pro::2900:usd"},
+		{name: "missing currency", env: "prod_pro:pro:month:2900:"},
+		{name: "empty product id", env: ":pro:month:2900:usd"},
+		{name: "zero amount", env: "prod_pro:pro:month:0:usd"},
+		{name: "negative amount", env: "prod_pro:pro:month:-2900:usd"},
+		// trial and enterprise_eval are one-time purchases handled by the order
+		// path, so they must not be accepted as recurring subscription products.
+		{name: "one-time trial tier", env: "prod_trial:trial:month:4900:usd"},
+		{name: "unknown tier", env: "prod_x:platinum:month:2900:usd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setRequiredConfigEnv(t)
+			t.Setenv("SUBSCRIPTION_PRODUCTS", tt.env)
+			if _, err := LoadConfig(); err == nil {
+				t.Fatal("expected malformed SUBSCRIPTION_PRODUCTS to fail config load")
+			}
+		})
+	}
+}
+
 func TestLoadConfig_ZeroFoundingCap(t *testing.T) {
 	setRequiredConfigEnv(t)
 	t.Setenv("FOUNDING_PRO_CAP", "0")

--- a/enterprise/licenseservice/cron_test.go
+++ b/enterprise/licenseservice/cron_test.go
@@ -150,6 +150,8 @@ func TestRefreshCron_RefreshOne_PolarError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
+	pub := priv.Public().(ed25519.PublicKey)
+	cert, rootPub := testServiceIntermediateCert(t, pub)
 
 	// Polar mock that always returns 500.
 	errorPolar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -159,6 +161,8 @@ func TestRefreshCron_RefreshOne_PolarError(t *testing.T) {
 	defer errorPolar.Close()
 
 	cfg := &Config{
+		IntermediateCert:    cert,
+		RootPublicKey:       rootPub,
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
 	}
@@ -223,6 +227,8 @@ func TestRefreshCron_RefreshOne_CanceledSub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
+	pub := priv.Public().(ed25519.PublicKey)
+	cert, rootPub := testServiceIntermediateCert(t, pub)
 
 	canceledPolar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", testContentTypeJSON)
@@ -238,6 +244,8 @@ func TestRefreshCron_RefreshOne_CanceledSub(t *testing.T) {
 	defer canceledPolar.Close()
 
 	cfg := &Config{
+		IntermediateCert:    cert,
+		RootPublicKey:       rootPub,
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
 	}

--- a/enterprise/licenseservice/entitlement.go
+++ b/enterprise/licenseservice/entitlement.go
@@ -88,6 +88,11 @@ type EntitlementDB struct {
 // after this subscription was already recorded in a terminal state.
 var ErrTerminalEntitlement = errors.New("entitlement is terminal")
 
+// ErrWebhookAlreadyCommitted means another delivery path already admitted this
+// provider message ID. Callers must not perform side effects from freshly built
+// state; they may retry delivery from the persisted record.
+var ErrWebhookAlreadyCommitted = errors.New("webhook already committed")
+
 type entitlementExecer interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
@@ -668,6 +673,15 @@ func (e *EntitlementDB) UpsertWithLicenseIssuanceAndWebhook(ctx context.Context,
 		}
 	}()
 
+	if msgID != "" {
+		admitted, err := admitWebhook(ctx, tx, msgID, eventType, ent.SubscriptionID)
+		if err != nil {
+			return fmt.Errorf("admit subscription webhook: %w", err)
+		}
+		if !admitted {
+			return ErrWebhookAlreadyCommitted
+		}
+	}
 	terminal, status, err := currentEntitlementTerminal(ctx, tx, ent.SubscriptionID)
 	if err != nil {
 		return err
@@ -680,11 +694,6 @@ func (e *EntitlementDB) UpsertWithLicenseIssuanceAndWebhook(ctx context.Context,
 	}
 	if err := insertLicenseIssuance(ctx, tx, issuance); err != nil {
 		return fmt.Errorf("insert license issuance %s: %w", issuance.LicenseID, err)
-	}
-	if msgID != "" {
-		if err := markWebhookCommitted(ctx, tx, msgID, eventType, ent.SubscriptionID); err != nil {
-			return fmt.Errorf("mark subscription webhook committed: %w", err)
-		}
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit entitlement issuance transaction: %w", err)
@@ -712,11 +721,15 @@ func (e *EntitlementDB) UpsertWithWebhook(ctx context.Context, ent *Entitlement,
 			_ = tx.Rollback()
 		}
 	}()
+	admitted, err := admitWebhook(ctx, tx, msgID, eventType, ent.SubscriptionID)
+	if err != nil {
+		return fmt.Errorf("admit subscription webhook: %w", err)
+	}
+	if !admitted {
+		return ErrWebhookAlreadyCommitted
+	}
 	if err := upsertEntitlement(ctx, tx, ent); err != nil {
 		return fmt.Errorf("upsert entitlement %s: %w", ent.SubscriptionID, err)
-	}
-	if err := markWebhookCommitted(ctx, tx, msgID, eventType, ent.SubscriptionID); err != nil {
-		return fmt.Errorf("mark subscription webhook committed: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit entitlement webhook transaction: %w", err)

--- a/enterprise/licenseservice/entitlement.go
+++ b/enterprise/licenseservice/entitlement.go
@@ -648,6 +648,12 @@ func (e *EntitlementDB) InsertLicenseIssuance(ctx context.Context, issuance Lice
 // license issuance. It refuses stale active events when the current persisted
 // subscription state is already terminal.
 func (e *EntitlementDB) UpsertWithLicenseIssuance(ctx context.Context, ent *Entitlement, issuance LicenseIssuance) error {
+	return e.UpsertWithLicenseIssuanceAndWebhook(ctx, ent, issuance, "", "")
+}
+
+// UpsertWithLicenseIssuanceAndWebhook atomically records entitlement state,
+// license issuance, and an optional webhook delivery commit marker.
+func (e *EntitlementDB) UpsertWithLicenseIssuanceAndWebhook(ctx context.Context, ent *Entitlement, issuance LicenseIssuance, msgID, eventType string) error {
 	if ent == nil {
 		return errors.New("entitlement is nil")
 	}
@@ -675,8 +681,45 @@ func (e *EntitlementDB) UpsertWithLicenseIssuance(ctx context.Context, ent *Enti
 	if err := insertLicenseIssuance(ctx, tx, issuance); err != nil {
 		return fmt.Errorf("insert license issuance %s: %w", issuance.LicenseID, err)
 	}
+	if msgID != "" {
+		if err := markWebhookCommitted(ctx, tx, msgID, eventType, ent.SubscriptionID); err != nil {
+			return fmt.Errorf("mark subscription webhook committed: %w", err)
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit entitlement issuance transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// UpsertWithWebhook atomically records entitlement state and an optional webhook
+// delivery commit marker for subscription events that do not mint a token.
+func (e *EntitlementDB) UpsertWithWebhook(ctx context.Context, ent *Entitlement, msgID, eventType string) error {
+	if ent == nil {
+		return errors.New("entitlement is nil")
+	}
+	if msgID == "" {
+		return e.Upsert(ctx, ent)
+	}
+	tx, err := e.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin entitlement webhook transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := upsertEntitlement(ctx, tx, ent); err != nil {
+		return fmt.Errorf("upsert entitlement %s: %w", ent.SubscriptionID, err)
+	}
+	if err := markWebhookCommitted(ctx, tx, msgID, eventType, ent.SubscriptionID); err != nil {
+		return fmt.Errorf("mark subscription webhook committed: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit entitlement webhook transaction: %w", err)
 	}
 	committed = true
 	return nil

--- a/enterprise/licenseservice/entitlement_webhook_test.go
+++ b/enterprise/licenseservice/entitlement_webhook_test.go
@@ -6,6 +6,7 @@
 package licenseservice
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -75,7 +76,41 @@ func TestEntitlementDB_UpsertWithWebhook(t *testing.T) {
 		}
 	})
 
-	t.Run("replaying the same msgID stays committed and updates state", func(t *testing.T) {
+	t.Run("marker failure rolls back without mutating entitlement", func(t *testing.T) {
+		db := openTestDB(t)
+		ctx := t.Context()
+		const msgID = "msg_abort_marker"
+		if _, err := db.db.ExecContext(ctx, `
+			CREATE TRIGGER abort_selected_webhook
+			BEFORE INSERT ON webhook_deliveries
+			WHEN NEW.msg_id = 'msg_abort_marker'
+			BEGIN
+				SELECT RAISE(ABORT, 'forced marker failure');
+			END
+		`); err != nil {
+			t.Fatalf("create trigger: %v", err)
+		}
+
+		if err := db.UpsertWithWebhook(ctx, testEntitlement(testSubscriptionID), msgID, EventSubscriptionUpdated); err == nil {
+			t.Fatal("UpsertWithWebhook = nil error, want forced marker failure")
+		}
+		got, err := db.GetBySubscriptionID(ctx, testSubscriptionID)
+		if err != nil {
+			t.Fatalf("GetBySubscriptionID: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("entitlement persisted after marker failure: %+v", got)
+		}
+		committed, err := db.WebhookCommitted(ctx, msgID)
+		if err != nil {
+			t.Fatalf("WebhookCommitted: %v", err)
+		}
+		if committed {
+			t.Fatal("webhook marker persisted after failed transaction")
+		}
+	})
+
+	t.Run("replaying the same msgID stays committed without updating state", func(t *testing.T) {
 		db := openTestDB(t)
 		ctx := t.Context()
 		ent := testEntitlement(testSubscriptionID)
@@ -85,8 +120,8 @@ func TestEntitlementDB_UpsertWithWebhook(t *testing.T) {
 			t.Fatalf("UpsertWithWebhook(first): %v", err)
 		}
 		ent.CustomerEmail = "changed@example.com"
-		if err := db.UpsertWithWebhook(ctx, ent, msgID, EventSubscriptionUpdated); err != nil {
-			t.Fatalf("UpsertWithWebhook(replay): %v", err)
+		if err := db.UpsertWithWebhook(ctx, ent, msgID, EventSubscriptionUpdated); !errors.Is(err, ErrWebhookAlreadyCommitted) {
+			t.Fatalf("UpsertWithWebhook(replay) err = %v, want ErrWebhookAlreadyCommitted", err)
 		}
 
 		committed, err := db.WebhookCommitted(ctx, msgID)
@@ -100,8 +135,8 @@ func TestEntitlementDB_UpsertWithWebhook(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetBySubscriptionID: %v", err)
 		}
-		if got.CustomerEmail != "changed@example.com" {
-			t.Errorf("CustomerEmail = %q, want %q", got.CustomerEmail, "changed@example.com")
+		if got.CustomerEmail != testCustomerEmail {
+			t.Errorf("CustomerEmail = %q, want original %q", got.CustomerEmail, testCustomerEmail)
 		}
 	})
 

--- a/enterprise/licenseservice/entitlement_webhook_test.go
+++ b/enterprise/licenseservice/entitlement_webhook_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build enterprise
+
+package licenseservice
+
+import (
+	"testing"
+)
+
+// UpsertWithWebhook is the atomic path for subscription events that change
+// entitlement state without minting a token. The entitlement row and the
+// webhook commit marker must land in one transaction, or a crash between them
+// leaves a processed webhook that a replay would process again.
+func TestEntitlementDB_UpsertWithWebhook(t *testing.T) {
+	t.Run("nil entitlement is rejected", func(t *testing.T) {
+		db := openTestDB(t)
+		if err := db.UpsertWithWebhook(t.Context(), nil, "msg_nil", EventSubscriptionUpdated); err == nil {
+			t.Fatal("UpsertWithWebhook(nil) = nil error, want rejection")
+		}
+	})
+
+	t.Run("empty msgID upserts without a marker", func(t *testing.T) {
+		db := openTestDB(t)
+		ctx := t.Context()
+		ent := testEntitlement(testSubscriptionID)
+
+		if err := db.UpsertWithWebhook(ctx, ent, "", EventSubscriptionUpdated); err != nil {
+			t.Fatalf("UpsertWithWebhook(empty msgID): %v", err)
+		}
+		got, err := db.GetBySubscriptionID(ctx, testSubscriptionID)
+		if err != nil {
+			t.Fatalf("GetBySubscriptionID: %v", err)
+		}
+		if got == nil {
+			t.Fatal("entitlement was not written")
+		}
+		// No msgID means nothing to dedupe on later.
+		committed, err := db.WebhookCommitted(ctx, "")
+		if err != nil {
+			t.Fatalf("WebhookCommitted(empty): %v", err)
+		}
+		if committed {
+			t.Error("WebhookCommitted(empty) = true, want false")
+		}
+	})
+
+	t.Run("entitlement and marker commit together", func(t *testing.T) {
+		db := openTestDB(t)
+		ctx := t.Context()
+		ent := testEntitlement(testSubscriptionID)
+		const msgID = "msg_upsert_webhook"
+
+		if err := db.UpsertWithWebhook(ctx, ent, msgID, EventSubscriptionUpdated); err != nil {
+			t.Fatalf("UpsertWithWebhook: %v", err)
+		}
+
+		got, err := db.GetBySubscriptionID(ctx, testSubscriptionID)
+		if err != nil {
+			t.Fatalf("GetBySubscriptionID: %v", err)
+		}
+		if got == nil {
+			t.Fatal("entitlement was not written")
+		}
+		if got.CustomerEmail != testCustomerEmail {
+			t.Errorf("CustomerEmail = %q, want %q", got.CustomerEmail, testCustomerEmail)
+		}
+		committed, err := db.WebhookCommitted(ctx, msgID)
+		if err != nil {
+			t.Fatalf("WebhookCommitted: %v", err)
+		}
+		if !committed {
+			t.Error("WebhookCommitted = false, want true: the marker must land with the entitlement")
+		}
+	})
+
+	t.Run("replaying the same msgID stays committed and updates state", func(t *testing.T) {
+		db := openTestDB(t)
+		ctx := t.Context()
+		ent := testEntitlement(testSubscriptionID)
+		const msgID = "msg_upsert_webhook_replay"
+
+		if err := db.UpsertWithWebhook(ctx, ent, msgID, EventSubscriptionUpdated); err != nil {
+			t.Fatalf("UpsertWithWebhook(first): %v", err)
+		}
+		ent.CustomerEmail = "changed@example.com"
+		if err := db.UpsertWithWebhook(ctx, ent, msgID, EventSubscriptionUpdated); err != nil {
+			t.Fatalf("UpsertWithWebhook(replay): %v", err)
+		}
+
+		committed, err := db.WebhookCommitted(ctx, msgID)
+		if err != nil {
+			t.Fatalf("WebhookCommitted: %v", err)
+		}
+		if !committed {
+			t.Error("WebhookCommitted after replay = false, want true")
+		}
+		got, err := db.GetBySubscriptionID(ctx, testSubscriptionID)
+		if err != nil {
+			t.Fatalf("GetBySubscriptionID: %v", err)
+		}
+		if got.CustomerEmail != "changed@example.com" {
+			t.Errorf("CustomerEmail = %q, want %q", got.CustomerEmail, "changed@example.com")
+		}
+	})
+
+	t.Run("a closed database fails closed", func(t *testing.T) {
+		db := openTestDB(t)
+		ctx := t.Context()
+		ent := testEntitlement(testSubscriptionID)
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if err := db.UpsertWithWebhook(ctx, ent, "msg_closed", EventSubscriptionUpdated); err == nil {
+			t.Fatal("UpsertWithWebhook on a closed DB = nil error, want failure")
+		}
+	})
+}

--- a/enterprise/licenseservice/eval.go
+++ b/enterprise/licenseservice/eval.go
@@ -113,7 +113,12 @@ func (h *WebhookHandler) HandleOrderPaidEvent(ctx context.Context, event *PolarW
 
 	// Build the license, entitlement, and issuance.
 	now := time.Now()
-	expiresAt := now.Add(evalTokenLifetime)
+	im, err := h.verifiedIntermediateAt(now)
+	if err != nil {
+		_ = h.ledger.LogError(order.ID, "verify intermediate before issue", err)
+		return fmt.Errorf("verify intermediate before issue: %w", err)
+	}
+	expiresAt := h.clampedTokenExpiry(now, evalTokenLifetime, im)
 	idBytes := make([]byte, 6) // 12 hex chars
 	if _, err := rand.Read(idBytes); err != nil {
 		return fmt.Errorf("generate license ID: %w", err)
@@ -346,29 +351,11 @@ func (h *WebhookHandler) resendEvalIfNeeded(ctx context.Context, orderID string)
 	if ent.LastDeliveryStatus == "sent" {
 		return nil
 	}
-	return h.deliverEvalToken(ctx, ent, h.regenerateEvalToken(ent))
-}
-
-// regenerateEvalToken rebuilds the exact token from persisted claims. license.Issue
-// is deterministic for identical claims + key, so the regenerated token is
-// byte-identical to the original — enabling resend without re-minting.
-func (h *WebhookHandler) regenerateEvalToken(ent *Entitlement) string {
-	lic := license.License{
-		ID:             ent.LastLicenseID,
-		Email:          ent.CustomerEmail,
-		Org:            ent.Org,
-		Features:       h.tierToFeatures(ent.LastLicenseTier),
-		Tier:           ent.LastLicenseTier,
-		SubscriptionID: ent.SubscriptionID,
+	token, err := h.regenerateToken(ent)
+	if err != nil {
+		return err
 	}
-	if ent.LastLicenseIssuedAt != nil {
-		lic.IssuedAt = ent.LastLicenseIssuedAt.Unix()
-	}
-	if ent.LastLicenseExpiresAt != nil {
-		lic.ExpiresAt = ent.LastLicenseExpiresAt.Unix()
-	}
-	token, _ := license.Issue(lic, h.privateKey)
-	return token
+	return h.deliverEvalToken(ctx, ent, token)
 }
 
 // denyEvalOrder records a refused eval order (gated_denied) without minting,

--- a/enterprise/licenseservice/eval.go
+++ b/enterprise/licenseservice/eval.go
@@ -188,6 +188,9 @@ func (h *WebhookHandler) HandleOrderPaidEvent(ctx context.Context, event *PolarW
 		WebhookMsgID: msgID,
 		EventType:    event.Type,
 	}); err != nil {
+		if errors.Is(err, ErrWebhookAlreadyCommitted) {
+			return h.resendEvalIfNeeded(ctx, order.ID)
+		}
 		if errors.Is(err, ErrEvalOrderNotMintable) {
 			h.log.Warn().Str("order_id", order.ID).Msg("eval order no longer mintable at commit; skipping")
 			return nil

--- a/enterprise/licenseservice/eval.go
+++ b/enterprise/licenseservice/eval.go
@@ -326,7 +326,7 @@ func (h *WebhookHandler) revokeEvalForOrder(ctx context.Context, order *PolarOrd
 // retry resends the same token via resendEvalIfNeeded (no re-mint).
 func (h *WebhookHandler) deliverEvalToken(ctx context.Context, ent *Entitlement, token string) error {
 	now := time.Now()
-	msgID, emailErr := h.email.SendLicenseDelivery(ctx, ent.CustomerEmail, token, ent.Tier, string(h.cfg.IntermediateCert))
+	msgID, emailErr := h.email.SendLicenseDelivery(ctx, ent.CustomerEmail, token, ent.Tier, string(h.IntermediateCert()))
 	if emailErr != nil {
 		if err := h.db.UpdateDeliveryStatus(ctx, ent.SubscriptionID, "failed", now); err != nil {
 			return fmt.Errorf("update delivery status after email failure: %w", err)

--- a/enterprise/licenseservice/eval_store.go
+++ b/enterprise/licenseservice/eval_store.go
@@ -202,18 +202,31 @@ func (e *EntitlementDB) MarkWebhookCommitted(ctx context.Context, msgID, eventTy
 }
 
 func markWebhookCommitted(ctx context.Context, exec entitlementExecer, msgID, eventType, resourceID string) error {
+	_, err := admitWebhook(ctx, exec, msgID, eventType, resourceID)
+	return err
+}
+
+// admitWebhook records a delivery marker and reports whether this transaction
+// admitted the delivery. A duplicate is not an error, but callers that mutate
+// business state must stop before doing so when admitted is false.
+func admitWebhook(ctx context.Context, exec entitlementExecer, msgID, eventType, resourceID string) (bool, error) {
 	if msgID == "" {
-		return errors.New("webhook msg_id is required")
+		return false, errors.New("webhook msg_id is required")
 	}
 	const query = `
 	INSERT INTO webhook_deliveries (msg_id, event_type, resource_id, status, committed_at)
 	VALUES (?, ?, ?, 'committed', datetime('now'))
 	ON CONFLICT(msg_id) DO NOTHING
 	`
-	if _, err := exec.ExecContext(ctx, query, msgID, eventType, resourceID); err != nil {
-		return fmt.Errorf("mark webhook delivery %s committed: %w", msgID, err)
+	result, err := exec.ExecContext(ctx, query, msgID, eventType, resourceID)
+	if err != nil {
+		return false, fmt.Errorf("mark webhook delivery %s committed: %w", msgID, err)
 	}
-	return nil
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read webhook delivery %s admission result: %w", msgID, err)
+	}
+	return rows == 1, nil
 }
 
 // WebhookCommitted reports whether a webhook delivery with the given message ID
@@ -294,6 +307,13 @@ func (e *EntitlementDB) FulfillEvalMint(ctx context.Context, p EvalMintParams) e
 		}
 	}
 
+	admitted, err := admitWebhook(ctx, tx, p.WebhookMsgID, p.EventType, p.EvalOrder.OrderID)
+	if err != nil {
+		return fmt.Errorf("admit eval webhook: %w", err)
+	}
+	if !admitted {
+		return ErrWebhookAlreadyCommitted
+	}
 	if err := upsertEntitlement(ctx, tx, p.Entitlement); err != nil {
 		return fmt.Errorf("upsert eval entitlement: %w", err)
 	}
@@ -303,10 +323,6 @@ func (e *EntitlementDB) FulfillEvalMint(ctx context.Context, p EvalMintParams) e
 	if err := upsertEvalOrder(ctx, tx, p.EvalOrder); err != nil {
 		return fmt.Errorf("upsert eval order: %w", err)
 	}
-	if err := markWebhookCommitted(ctx, tx, p.WebhookMsgID, p.EventType, p.EvalOrder.OrderID); err != nil {
-		return fmt.Errorf("mark eval webhook committed: %w", err)
-	}
-
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit eval mint transaction: %w", err)
 	}

--- a/enterprise/licenseservice/eval_test.go
+++ b/enterprise/licenseservice/eval_test.go
@@ -73,11 +73,13 @@ func newEvalTestSetup(t *testing.T) *evalTestSetup {
 	}))
 	t.Cleanup(emailSrv.Close)
 
+	cert, rootPub := testServiceIntermediateCert(t, pub)
 	cfg := &Config{
 		PolarWebhookSecret:  "whsec_" + "dGVzdA==",
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "k"),
-		IntermediateCert:    testServiceIntermediateCert(t, pub),
+		IntermediateCert:    cert,
+		RootPublicKey:       rootPub,
 		ResendAPIKey:        "re_" + "test",
 		DBPath:              ":memory:",
 		LedgerPath:          filepath.Join(t.TempDir(), "l.jsonl"),
@@ -345,7 +347,10 @@ func TestHandleOrderPaid_MintedTokenVerifies(t *testing.T) {
 	}
 	// Regenerate the deterministic token from persisted claims and verify it.
 	ent, _ := s.db.GetBySubscriptionID(ctx, testEvalOrderID)
-	tok := s.handler.regenerateEvalToken(ent)
+	tok, err := s.handler.regenerateToken(ent)
+	if err != nil {
+		t.Fatalf("regenerateToken: %v", err)
+	}
 	lic, err := license.Verify(tok, s.publicKey)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)

--- a/enterprise/licenseservice/polar.go
+++ b/enterprise/licenseservice/polar.go
@@ -56,6 +56,8 @@ type PolarSubscription struct {
 	ProductName       string    `json:"product_name"`
 	CurrentPeriodEnd  time.Time `json:"current_period_end"`
 	RecurringInterval string    `json:"recurring_interval"` // "month" or "year"
+	AmountCents       int       `json:"amount"`             // recurring price in minor units when returned by Polar
+	Currency          string    `json:"currency"`           // ISO 4217, lowercase (e.g. "usd")
 
 	// Customer metadata (may contain org name).
 	Customer struct {

--- a/enterprise/licenseservice/polar_test.go
+++ b/enterprise/licenseservice/polar_test.go
@@ -339,11 +339,13 @@ func TestExtractSubscriptionID(t *testing.T) {
 
 func TestPolarClient_GetSubscription(t *testing.T) {
 	tests := []struct {
-		name       string
-		statusCode int
-		body       string
-		wantErr    bool
-		wantStatus string
+		name         string
+		statusCode   int
+		body         string
+		wantErr      bool
+		wantStatus   string
+		wantAmount   int
+		wantCurrency string
 	}{
 		{
 			name:       "active subscription",
@@ -352,12 +354,16 @@ func TestPolarClient_GetSubscription(t *testing.T) {
 				"id": "sub_test123",
 				"status": "active",
 				"customer": {"email": "test@example.com", "metadata": {}},
-				"product": {"id": "prod_abc", "name": "Pro", "metadata": {"pipelock_tier": "pro"}},
-				"recurring_interval": "month",
-				"current_period_end": "2026-04-12T00:00:00Z"
-			}`,
-			wantErr:    false,
-			wantStatus: "active",
+					"product": {"id": "prod_abc", "name": "Pro", "metadata": {"pipelock_tier": "pro"}},
+					"recurring_interval": "month",
+					"amount": 2900,
+					"currency": "usd",
+					"current_period_end": "2026-04-12T00:00:00Z"
+				}`,
+			wantErr:      false,
+			wantStatus:   "active",
+			wantAmount:   2900,
+			wantCurrency: "usd",
 		},
 		{
 			name:       "404 not found",
@@ -416,6 +422,12 @@ func TestPolarClient_GetSubscription(t *testing.T) {
 			}
 			if err == nil && sub.Status != tt.wantStatus {
 				t.Errorf("GetSubscription() status = %q, want %q", sub.Status, tt.wantStatus)
+			}
+			if err == nil && sub.AmountCents != tt.wantAmount {
+				t.Errorf("GetSubscription() amount = %d, want %d", sub.AmountCents, tt.wantAmount)
+			}
+			if err == nil && sub.Currency != tt.wantCurrency {
+				t.Errorf("GetSubscription() currency = %q, want %q", sub.Currency, tt.wantCurrency)
 			}
 		})
 	}

--- a/enterprise/licenseservice/server.go
+++ b/enterprise/licenseservice/server.go
@@ -85,19 +85,19 @@ func NewServer(
 // handleIntermediate returns the root-signed intermediate certificate used to
 // verify tokens minted by this service.
 func (s *Server) handleIntermediate(w http.ResponseWriter, _ *http.Request) {
-	if len(s.cfg.IntermediateCert) == 0 {
+	intermediateCert := s.handler.IntermediateCert()
+	if len(intermediateCert) == 0 {
 		http.Error(w, "intermediate certificate not configured", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Cache-Control", "public, max-age=300")
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(s.cfg.IntermediateCert); err != nil {
+	if _, err := w.Write(intermediateCert); err != nil {
 		s.log.Error().Err(err).Msg("write intermediate certificate")
 		return
 	}
-	// The early return above guarantees IntermediateCert is non-empty here.
-	if s.cfg.IntermediateCert[len(s.cfg.IntermediateCert)-1] != '\n' {
+	if intermediateCert[len(intermediateCert)-1] != '\n' {
 		if _, err := w.Write([]byte("\n")); err != nil {
 			s.log.Error().Err(err).Msg("write intermediate certificate newline")
 		}
@@ -202,7 +202,7 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 
 	// Process the event. Return 500 on failure so Polar retries.
 	// The idempotency logic in HandleEvent prevents duplicate processing.
-	if err := s.handler.HandleEvent(r.Context(), event); err != nil {
+	if err := s.handler.HandleEventDelivery(r.Context(), event, msgID); err != nil {
 		s.log.Error().Err(err).
 			Str("event_type", event.Type).
 			Msg("webhook processing error")

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -160,6 +160,7 @@ func TestServer_IntermediateEndpoint(t *testing.T) {
 
 func TestServer_IntermediateEndpointUsesVerifiedHandlerCopy(t *testing.T) {
 	srv := newTestServer(t)
+	want := append([]byte(nil), srv.cfg.IntermediateCert...)
 	srv.cfg.IntermediateCert = nil
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/intermediate.json", nil)
@@ -168,6 +169,9 @@ func TestServer_IntermediateEndpointUsesVerifiedHandlerCopy(t *testing.T) {
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got := strings.TrimSpace(rr.Body.String()); got != string(want) {
+		t.Fatalf("body = %q, want cached intermediate certificate", got)
 	}
 }
 

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -71,11 +71,13 @@ func newTestServer(t *testing.T) *Server {
 	t.Cleanup(emailSrv.Close)
 
 	secret := base64.StdEncoding.EncodeToString([]byte(testServerSecret))
+	cert, rootPub := testServiceIntermediateCert(t, pub)
 	cfg := &Config{
 		PolarWebhookSecret:  "whsec_" + secret,
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "test.key"),
-		IntermediateCert:    testServiceIntermediateCert(t, pub),
+		IntermediateCert:    cert,
+		RootPublicKey:       rootPub,
 		CRLPrivateKey:       crlPriv,
 		ResendAPIKey:        "re_" + "test_server_key",
 		DBPath:              ":memory:",
@@ -156,7 +158,7 @@ func TestServer_IntermediateEndpoint(t *testing.T) {
 	}
 }
 
-func TestServer_IntermediateEndpointMissingCert(t *testing.T) {
+func TestServer_IntermediateEndpointUsesVerifiedHandlerCopy(t *testing.T) {
 	srv := newTestServer(t)
 	srv.cfg.IntermediateCert = nil
 
@@ -164,8 +166,8 @@ func TestServer_IntermediateEndpointMissingCert(t *testing.T) {
 	rr := httptest.NewRecorder()
 	srv.mux.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusInternalServerError)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
 	}
 }
 

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -14,10 +14,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/license"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 	"github.com/rs/zerolog"
 )
 
@@ -76,13 +79,16 @@ var validTiers = map[string]bool{
 // WebhookHandler processes Polar webhook events and coordinates license
 // issuance, entitlement tracking, and email delivery.
 type WebhookHandler struct {
-	cfg        *Config
-	db         *EntitlementDB
-	polar      *PolarClient
-	email      *EmailSender
-	ledger     *AuditLedger
-	privateKey ed25519.PrivateKey
-	log        zerolog.Logger
+	cfg              *Config
+	db               *EntitlementDB
+	polar            *PolarClient
+	email            *EmailSender
+	ledger           *AuditLedger
+	privateKey       ed25519.PrivateKey
+	rootPub          ed25519.PublicKey
+	intermediate     license.Intermediate
+	intermediateCert []byte
+	log              zerolog.Logger
 
 	// processMu serializes processSubscription calls to prevent concurrent
 	// webhook deliveries for the same subscription_id from double-minting.
@@ -107,15 +113,24 @@ func NewWebhookHandler(
 	privateKey ed25519.PrivateKey,
 	log zerolog.Logger,
 ) (*WebhookHandler, error) {
-	if len(cfg.IntermediateCert) > 0 {
-		certPub, err := license.ExtractIntermediatePublicKey(cfg.IntermediateCert)
-		if err != nil {
-			return nil, fmt.Errorf("parse intermediate certificate public key: %w", err)
-		}
-		signingPub, ok := privateKey.Public().(ed25519.PublicKey)
-		if !ok || !bytes.Equal(certPub, signingPub) {
-			return nil, errors.New("intermediate certificate public key does not match license signing private key")
-		}
+	rootPub, err := resolveServiceRootPublicKey(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.IntermediateCert) == 0 {
+		return nil, errors.New("intermediate certificate is required")
+	}
+	intermediateCert := append([]byte(nil), cfg.IntermediateCert...)
+	im, err := license.ParseAndVerifyIntermediate(intermediateCert, rootPub, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("verify intermediate certificate: %w", err)
+	}
+	signingPub, ok := privateKey.Public().(ed25519.PublicKey)
+	if !ok || !bytes.Equal(im.PublicKey(), signingPub) {
+		return nil, errors.New("intermediate certificate public key does not match license signing private key")
+	}
+	if len(cfg.SubscriptionProducts) == 0 {
+		log.Warn().Msg("SUBSCRIPTION_PRODUCTS unset; preserving legacy subscription product metadata mapping until allowlist is configured")
 	}
 
 	// Load founding count from DB to initialize the in-memory counter.
@@ -125,15 +140,48 @@ func NewWebhookHandler(
 	}
 
 	return &WebhookHandler{
-		cfg:           cfg,
-		db:            db,
-		polar:         polar,
-		email:         email,
-		ledger:        ledger,
-		privateKey:    privateKey,
-		log:           log,
-		foundingCount: count,
+		cfg:              cfg,
+		db:               db,
+		polar:            polar,
+		email:            email,
+		ledger:           ledger,
+		privateKey:       privateKey,
+		rootPub:          rootPub,
+		intermediate:     im,
+		intermediateCert: intermediateCert,
+		log:              log,
+		foundingCount:    count,
 	}, nil
+}
+
+func resolveServiceRootPublicKey(cfg *Config) (ed25519.PublicKey, error) {
+	if len(cfg.RootPublicKey) == ed25519.PublicKeySize {
+		return append(ed25519.PublicKey(nil), cfg.RootPublicKey...), nil
+	}
+	if key := license.EmbeddedPublicKey(); key != nil {
+		return key, nil
+	}
+	publicKey := strings.TrimSpace(cfg.LicensePublicKey)
+	if publicKey == "" {
+		publicKey = strings.TrimSpace(os.Getenv(license.EnvLicensePublicKey))
+	}
+	if publicKey == "" {
+		return nil, errors.New("license root public key is required (official builds embed it; dev/self-hosted builds set PIPELOCK_LICENSE_PUBLIC_KEY)")
+	}
+	parsed, err := signing.ParsePublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse license root public key: %w", err)
+	}
+	if len(parsed) != ed25519.PublicKeySize {
+		return nil, errors.New("license root public key has invalid size")
+	}
+	return parsed, nil
+}
+
+// IntermediateCert returns the verified root-signed intermediate certificate
+// bytes the handler accepted at startup.
+func (h *WebhookHandler) IntermediateCert() []byte {
+	return append([]byte(nil), h.intermediateCert...)
 }
 
 // HandleEvent processes a validated Polar webhook event. This is the
@@ -144,6 +192,12 @@ func NewWebhookHandler(
 //  2. Fetch current subscription state from Polar API (source of truth)
 //  3. Delegate to processSubscription for shared business logic
 func (h *WebhookHandler) HandleEvent(ctx context.Context, event *PolarWebhookEvent) error {
+	return h.HandleEventDelivery(ctx, event, "")
+}
+
+// HandleEventDelivery processes a validated Polar subscription webhook and uses
+// msgID for durable delivery dedupe when called from the HTTP webhook path.
+func (h *WebhookHandler) HandleEventDelivery(ctx context.Context, event *PolarWebhookEvent, msgID string) error {
 	subID, err := ExtractSubscriptionID(event.Data)
 	if err != nil {
 		return fmt.Errorf("extract subscription ID: %w", err)
@@ -156,6 +210,16 @@ func (h *WebhookHandler) HandleEvent(ctx context.Context, event *PolarWebhookEve
 		Str("subscription_id", subID).
 		Msg("processing webhook event")
 
+	if msgID != "" {
+		committed, err := h.db.WebhookCommitted(ctx, msgID)
+		if err != nil {
+			return fmt.Errorf("check webhook delivery: %w", err)
+		}
+		if committed {
+			return h.resendSubscriptionIfNeeded(ctx, subID)
+		}
+	}
+
 	// Fetch current subscription state from Polar (source of truth).
 	sub, err := h.polar.GetSubscription(ctx, subID)
 	if err != nil {
@@ -163,7 +227,7 @@ func (h *WebhookHandler) HandleEvent(ctx context.Context, event *PolarWebhookEve
 		return fmt.Errorf("fetch subscription from polar: %w", err)
 	}
 
-	return h.processSubscription(ctx, sub)
+	return h.processSubscriptionDelivery(ctx, sub, event.Type, msgID)
 }
 
 // processSubscription handles the core subscription logic shared by both
@@ -176,12 +240,45 @@ func (h *WebhookHandler) HandleEvent(ctx context.Context, event *PolarWebhookEve
 //  3. Load existing entitlement for idempotency comparison
 //  4. If active: mint license token, persist, attempt email delivery
 //  5. If ended: persist, send cancellation email
+//
+// isTerminalSubscriptionStatus reports whether a Polar status ends the
+// subscription, meaning the event removes entitlement rather than granting it.
+func isTerminalSubscriptionStatus(status string) bool {
+	switch status {
+	case statusCanceled, statusRevoked, statusUnpaid:
+		return true
+	default:
+		return false
+	}
+}
+
 func (h *WebhookHandler) processSubscription(ctx context.Context, sub *PolarSubscription) error {
+	return h.processSubscriptionDelivery(ctx, sub, "", "")
+}
+
+func (h *WebhookHandler) processSubscriptionDelivery(ctx context.Context, sub *PolarSubscription, eventType, msgID string) error {
 	h.processMu.Lock()
 	defer h.processMu.Unlock()
 
 	ent, err := h.subscriptionToEntitlement(sub)
 	if err != nil {
+		// Refusing to GRANT on a product we cannot map is correct. Refusing to
+		// process the END of one is not: a cancellation or revocation that
+		// cannot be recorded leaves the local entitlement sitting active, which
+		// is the wrong direction to fail. Terminal events are processed from
+		// the stored entitlement so revocation always lands, while any active
+		// event on an unmappable product is still rejected below.
+		if isTerminalSubscriptionStatus(sub.Status) {
+			existing, loadErr := h.db.GetBySubscriptionID(ctx, sub.ID)
+			if loadErr != nil {
+				return fmt.Errorf("load existing entitlement for terminal event: %w", loadErr)
+			}
+			if existing != nil {
+				terminal := *existing
+				terminal.Status = sub.Status
+				return h.handleEnded(ctx, &terminal, existing, eventType, msgID)
+			}
+		}
 		_ = h.ledger.LogError(sub.ID, "map subscription to entitlement", err)
 		return fmt.Errorf("map subscription: %w", err)
 	}
@@ -199,9 +296,9 @@ func (h *WebhookHandler) processSubscription(ctx context.Context, sub *PolarSubs
 
 	switch sub.Status {
 	case statusActive:
-		return h.handleActive(ctx, ent, existing)
+		return h.handleActiveDelivery(ctx, ent, existing, eventType, msgID)
 	case statusCanceled, statusRevoked, statusUnpaid:
-		return h.handleEnded(ctx, ent, existing)
+		return h.handleEnded(ctx, ent, existing, eventType, msgID)
 	default:
 		h.log.Warn().
 			Str("subscription_id", sub.ID).
@@ -221,13 +318,17 @@ func (h *WebhookHandler) processSubscription(ctx context.Context, sub *PolarSubs
 			ent.LastDeliveryAttemptAt = existing.LastDeliveryAttemptAt
 			ent.NextRefreshAt = existing.NextRefreshAt
 		}
-		return h.db.Upsert(ctx, ent)
+		return h.db.UpsertWithWebhook(ctx, ent, msgID, eventType)
 	}
 }
 
 // handleActive processes an active subscription: checks idempotency,
 // mints a license if needed, persists state, then attempts email delivery.
 func (h *WebhookHandler) handleActive(ctx context.Context, ent *Entitlement, existing *Entitlement) error {
+	return h.handleActiveDelivery(ctx, ent, existing, "", "")
+}
+
+func (h *WebhookHandler) handleActiveDelivery(ctx context.Context, ent *Entitlement, existing *Entitlement, eventType, msgID string) error {
 	if existing != nil && isTerminalEntitlementStatus(existing.Status) {
 		err := fmt.Errorf("%w: subscription %s status %s", ErrTerminalEntitlement, ent.SubscriptionID, existing.Status)
 		h.log.Warn().
@@ -267,12 +368,17 @@ func (h *WebhookHandler) handleActive(ctx context.Context, ent *Entitlement, exi
 		h.log.Info().
 			Str("subscription_id", ent.SubscriptionID).
 			Msg("idempotent: license state unchanged, persisting metadata only")
-		return h.db.Upsert(ctx, ent)
+		return h.db.UpsertWithWebhook(ctx, ent, msgID, eventType)
 	}
 
 	// Mint a new license token.
 	now := time.Now()
-	expiresAt := now.Add(h.tokenLifetimeForTier(ent.Tier))
+	im, err := h.verifiedIntermediateAt(now)
+	if err != nil {
+		_ = h.ledger.LogError(ent.SubscriptionID, "verify intermediate before issue", err)
+		return fmt.Errorf("verify intermediate before issue: %w", err)
+	}
+	expiresAt := h.clampedTokenExpiry(now, h.tokenLifetimeForTier(ent.Tier), im)
 
 	idBytes := make([]byte, 6) // 6 bytes = 12 hex chars
 	if _, err := rand.Read(idBytes); err != nil {
@@ -322,12 +428,12 @@ func (h *WebhookHandler) handleActive(ctx context.Context, ent *Entitlement, exi
 	deliveryAttempt := now
 	ent.LastDeliveryAttemptAt = &deliveryAttempt
 
-	if err := h.db.UpsertWithLicenseIssuance(ctx, ent, LicenseIssuance{
+	if err := h.db.UpsertWithLicenseIssuanceAndWebhook(ctx, ent, LicenseIssuance{
 		LicenseID:      lic.ID,
 		SubscriptionID: ent.SubscriptionID,
 		ExpiresAt:      expiresAt,
 		IssuedAt:       now,
-	}); err != nil {
+	}, msgID, eventType); err != nil {
 		if errors.Is(err, ErrTerminalEntitlement) {
 			h.log.Warn().
 				Err(err).
@@ -342,20 +448,8 @@ func (h *WebhookHandler) handleActive(ctx context.Context, ent *Entitlement, exi
 	_ = h.ledger.LogLicenseIssued(ent.SubscriptionID, ent.CustomerEmail, lic.ID, ent.Tier, expiresAt)
 
 	// Attempt email delivery, update delivery status after.
-	msgID, emailErr := h.email.SendLicenseDelivery(ctx, ent.CustomerEmail, token, ent.Tier, string(h.cfg.IntermediateCert))
-	if emailErr != nil {
-		h.log.Error().Err(emailErr).
-			Str("subscription_id", ent.SubscriptionID).
-			Msg("email delivery failed")
-		if err := h.db.UpdateDeliveryStatus(ctx, ent.SubscriptionID, "failed", now); err != nil {
-			return fmt.Errorf("update delivery status after email failure: %w", err)
-		}
-		_ = h.ledger.LogEmailFailed(ent.SubscriptionID, ent.CustomerEmail, emailErr)
-	} else {
-		if err := h.db.UpdateDeliveryStatus(ctx, ent.SubscriptionID, "sent", now); err != nil {
-			return fmt.Errorf("update delivery status after email success: %w", err)
-		}
-		_ = h.ledger.LogEmailSent(ent.SubscriptionID, ent.CustomerEmail, msgID)
+	if err := h.deliverLicenseEmail(ctx, ent, token, ent.Tier, now); err != nil {
+		return err
 	}
 
 	h.log.Info().
@@ -367,8 +461,104 @@ func (h *WebhookHandler) handleActive(ctx context.Context, ent *Entitlement, exi
 	return nil
 }
 
-// handleEnded processes a canceled/revoked/unpaid subscription.
-func (h *WebhookHandler) handleEnded(ctx context.Context, ent *Entitlement, existing *Entitlement) error {
+func (h *WebhookHandler) verifiedIntermediateAt(now time.Time) (license.Intermediate, error) {
+	im, err := license.ParseAndVerifyIntermediate(h.intermediateCert, h.rootPub, now)
+	if err != nil {
+		return license.Intermediate{}, err
+	}
+	if !bytes.Equal(im.PublicKey(), h.intermediate.PublicKey()) || im.Serial() != h.intermediate.Serial() {
+		return license.Intermediate{}, errors.New("intermediate certificate changed since startup")
+	}
+	return im, nil
+}
+
+func (h *WebhookHandler) clampedTokenExpiry(now time.Time, lifetime time.Duration, im license.Intermediate) time.Time {
+	expiresAt := now.Add(lifetime)
+	imNotAfter := time.Unix(im.Payload.NotAfter, 0).UTC()
+	if expiresAt.After(imNotAfter) {
+		return imNotAfter
+	}
+	return expiresAt
+}
+
+func (h *WebhookHandler) resendSubscriptionIfNeeded(ctx context.Context, subID string) error {
+	ent, err := h.db.GetBySubscriptionID(ctx, subID)
+	if err != nil {
+		return fmt.Errorf("load entitlement for resend: %w", err)
+	}
+	if ent == nil || ent.LastLicenseID == "" || ent.LastDeliveryStatus == "sent" {
+		return nil
+	}
+	// A replayed webhook reaches this path from the already-committed branch,
+	// which skips the Polar re-fetch and reads only local state. Without these
+	// guards a redelivery arriving after cancellation, or after the token has
+	// expired, would re-send a paid license to someone no longer entitled to
+	// it. Retry delivery only while the entitlement is still active and the
+	// token it would resend is still valid.
+	if ent.Status != statusActive {
+		return nil
+	}
+	if ent.LastLicenseExpiresAt == nil || !time.Now().Before(*ent.LastLicenseExpiresAt) {
+		return nil
+	}
+	token, err := h.regenerateToken(ent)
+	if err != nil {
+		return err
+	}
+	return h.deliverLicenseEmail(ctx, ent, token, ent.LastLicenseTier, time.Now())
+}
+
+// deliverLicenseEmail sends a license token and records the outcome in both the
+// entitlement's delivery status and the audit ledger. Both the first-issue path
+// and the redelivery path run this same sequence, and it is security-and-audit
+// relevant, so it lives in one place: a future change (a retry limit, another
+// audit field) must not be able to land on one path and miss the other.
+func (h *WebhookHandler) deliverLicenseEmail(ctx context.Context, ent *Entitlement, token, tier string, now time.Time) error {
+	msgID, emailErr := h.email.SendLicenseDelivery(ctx, ent.CustomerEmail, token, tier, string(h.intermediateCert))
+	if emailErr != nil {
+		h.log.Error().Err(emailErr).
+			Str("subscription_id", ent.SubscriptionID).
+			Msg("email delivery failed")
+		if err := h.db.UpdateDeliveryStatus(ctx, ent.SubscriptionID, "failed", now); err != nil {
+			return fmt.Errorf("update delivery status after email failure: %w", err)
+		}
+		_ = h.ledger.LogEmailFailed(ent.SubscriptionID, ent.CustomerEmail, emailErr)
+		return nil
+	}
+	if err := h.db.UpdateDeliveryStatus(ctx, ent.SubscriptionID, "sent", now); err != nil {
+		return fmt.Errorf("update delivery status after email success: %w", err)
+	}
+	_ = h.ledger.LogEmailSent(ent.SubscriptionID, ent.CustomerEmail, msgID)
+	return nil
+}
+
+func (h *WebhookHandler) regenerateToken(ent *Entitlement) (string, error) {
+	if ent.LastLicenseIssuedAt == nil || ent.LastLicenseExpiresAt == nil {
+		return "", errors.New("cannot regenerate token without persisted issue and expiry timestamps")
+	}
+	lic := license.License{
+		ID:             ent.LastLicenseID,
+		Email:          ent.CustomerEmail,
+		Org:            ent.Org,
+		IssuedAt:       ent.LastLicenseIssuedAt.Unix(),
+		ExpiresAt:      ent.LastLicenseExpiresAt.Unix(),
+		Features:       h.tierToFeatures(ent.LastLicenseTier),
+		Tier:           ent.LastLicenseTier,
+		SubscriptionID: ent.SubscriptionID,
+	}
+	token, err := license.Issue(lic, h.privateKey)
+	if err != nil {
+		return "", fmt.Errorf("regenerate license token: %w", err)
+	}
+	return token, nil
+}
+
+// handleEnded processes a canceled/revoked/unpaid subscription. The terminal
+// entitlement state and the webhook delivery marker are persisted in one
+// transaction, before any non-idempotent side effect, so a crash between them
+// cannot leave the subscription ended while the marker is absent and a Polar
+// redelivery reprocesses the same terminal event.
+func (h *WebhookHandler) handleEnded(ctx context.Context, ent *Entitlement, existing *Entitlement, eventType, msgID string) error {
 	// Clear the refresh schedule.
 	ent.NextRefreshAt = nil
 
@@ -387,8 +577,9 @@ func (h *WebhookHandler) handleEnded(ctx context.Context, ent *Entitlement, exis
 		ent.LastDeliveryAttemptAt = existing.LastDeliveryAttemptAt
 	}
 
-	// Upsert the entitlement to record the ended status.
-	if err := h.db.Upsert(ctx, ent); err != nil {
+	// Upsert the entitlement to record the ended status, committing the webhook
+	// marker in the same transaction when this came from a delivery.
+	if err := h.db.UpsertWithWebhook(ctx, ent, msgID, eventType); err != nil {
 		return fmt.Errorf("persist ended entitlement: %w", err)
 	}
 
@@ -799,6 +990,30 @@ func (h *WebhookHandler) subscriptionToEntitlement(sub *PolarSubscription) (*Ent
 // Rejects products with missing or unrecognized tier values to prevent
 // misconfigured products from silently granting paid features.
 func (h *WebhookHandler) mapProductToTier(sub *PolarSubscription) (tier string, founding bool, err error) {
+	if len(h.cfg.SubscriptionProducts) > 0 {
+		product, ok := h.subscriptionProduct(sub.Product.ID)
+		if !ok {
+			return "", false, fmt.Errorf("subscription product %s is not allowlisted", sub.Product.ID)
+		}
+		if sub.Product.Metadata["pipelock_tier"] != product.Tier {
+			return "", false, fmt.Errorf("subscription product %s tier metadata %q does not match allowlist tier %q",
+				sub.Product.ID, sub.Product.Metadata["pipelock_tier"], product.Tier)
+		}
+		if sub.RecurringInterval != product.Interval {
+			return "", false, fmt.Errorf("subscription product %s interval %q does not match allowlist interval %q",
+				sub.Product.ID, sub.RecurringInterval, product.Interval)
+		}
+		if sub.AmountCents != product.AmountCents {
+			return "", false, fmt.Errorf("subscription product %s amount %d does not match allowlist amount %d",
+				sub.Product.ID, sub.AmountCents, product.AmountCents)
+		}
+		if strings.ToLower(sub.Currency) != product.Currency {
+			return "", false, fmt.Errorf("subscription product %s currency %q does not match allowlist currency %q",
+				sub.Product.ID, sub.Currency, product.Currency)
+		}
+		return product.Tier, product.Tier == tierFoundingPro, nil
+	}
+
 	t, ok := sub.Product.Metadata["pipelock_tier"]
 	if !ok {
 		return "", false, fmt.Errorf("product %s (%s) has no pipelock_tier metadata",
@@ -812,6 +1027,15 @@ func (h *WebhookHandler) mapProductToTier(sub *PolarSubscription) (tier string, 
 
 	founding = t == tierFoundingPro
 	return t, founding, nil
+}
+
+func (h *WebhookHandler) subscriptionProduct(productID string) (SubscriptionProductConfig, bool) {
+	for _, product := range h.cfg.SubscriptionProducts {
+		if product.ProductID == productID {
+			return product, true
+		}
+	}
+	return SubscriptionProductConfig{}, false
 }
 
 // tierToFeatures returns the feature list for a given tier.

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -129,10 +129,6 @@ func NewWebhookHandler(
 	if !ok || !bytes.Equal(im.PublicKey(), signingPub) {
 		return nil, errors.New("intermediate certificate public key does not match license signing private key")
 	}
-	if len(cfg.SubscriptionProducts) == 0 {
-		log.Warn().Msg("SUBSCRIPTION_PRODUCTS unset; preserving legacy subscription product metadata mapping until allowlist is configured")
-	}
-
 	// Load founding count from DB to initialize the in-memory counter.
 	count, err := db.CountFounding(context.Background())
 	if err != nil {
@@ -318,7 +314,11 @@ func (h *WebhookHandler) processSubscriptionDelivery(ctx context.Context, sub *P
 			ent.LastDeliveryAttemptAt = existing.LastDeliveryAttemptAt
 			ent.NextRefreshAt = existing.NextRefreshAt
 		}
-		return h.db.UpsertWithWebhook(ctx, ent, msgID, eventType)
+		err := h.db.UpsertWithWebhook(ctx, ent, msgID, eventType)
+		if errors.Is(err, ErrWebhookAlreadyCommitted) {
+			return h.resendSubscriptionIfNeeded(ctx, ent.SubscriptionID)
+		}
+		return err
 	}
 }
 
@@ -368,7 +368,11 @@ func (h *WebhookHandler) handleActiveDelivery(ctx context.Context, ent *Entitlem
 		h.log.Info().
 			Str("subscription_id", ent.SubscriptionID).
 			Msg("idempotent: license state unchanged, persisting metadata only")
-		return h.db.UpsertWithWebhook(ctx, ent, msgID, eventType)
+		err := h.db.UpsertWithWebhook(ctx, ent, msgID, eventType)
+		if errors.Is(err, ErrWebhookAlreadyCommitted) {
+			return nil
+		}
+		return err
 	}
 
 	// Mint a new license token.
@@ -434,6 +438,9 @@ func (h *WebhookHandler) handleActiveDelivery(ctx context.Context, ent *Entitlem
 		ExpiresAt:      expiresAt,
 		IssuedAt:       now,
 	}, msgID, eventType); err != nil {
+		if errors.Is(err, ErrWebhookAlreadyCommitted) {
+			return h.resendSubscriptionIfNeeded(ctx, ent.SubscriptionID)
+		}
 		if errors.Is(err, ErrTerminalEntitlement) {
 			h.log.Warn().
 				Err(err).
@@ -580,6 +587,9 @@ func (h *WebhookHandler) handleEnded(ctx context.Context, ent *Entitlement, exis
 	// Upsert the entitlement to record the ended status, committing the webhook
 	// marker in the same transaction when this came from a delivery.
 	if err := h.db.UpsertWithWebhook(ctx, ent, msgID, eventType); err != nil {
+		if errors.Is(err, ErrWebhookAlreadyCommitted) {
+			return nil
+		}
 		return fmt.Errorf("persist ended entitlement: %w", err)
 	}
 
@@ -884,18 +894,7 @@ func (h *WebhookHandler) HandleOrderEvent(ctx context.Context, event *PolarWebho
 			Msg("ignoring non-purchase order (subscription events handle these)")
 		return nil
 	}
-
-	// Map product metadata to tier.
-	tier, ok := order.Product.Metadata["pipelock_tier"]
-	if !ok {
-		return fmt.Errorf("order %s product %s (%s) has no pipelock_tier metadata",
-			order.ID, order.Product.ID, order.Product.Name)
-	}
-	if !validTiers[tier] {
-		return fmt.Errorf("order %s product %s has unrecognized pipelock_tier %q",
-			order.ID, order.Product.ID, tier)
-	}
-	if tier == tierEnterpriseEval {
+	if order.Product.Metadata["pipelock_tier"] == tierEnterpriseEval {
 		h.log.Info().
 			Str("order_id", order.ID).
 			Str("event_type", event.Type).
@@ -903,6 +902,13 @@ func (h *WebhookHandler) HandleOrderEvent(ctx context.Context, event *PolarWebho
 		return nil
 	}
 
+	// The order path is an authorization boundary: require settled payment and
+	// server-side product, tier, price, and currency facts. Product metadata is
+	// only a defense-in-depth consistency check, never the source of authority.
+	tier, err := h.mapOrderProductToTier(order)
+	if err != nil {
+		return fmt.Errorf("authorize order %s: %w", order.ID, err)
+	}
 	features, err := json.Marshal(h.tierToFeatures(tier))
 	if err != nil {
 		return fmt.Errorf("marshal features: %w", err)
@@ -943,6 +949,38 @@ func (h *WebhookHandler) HandleOrderEvent(ctx context.Context, event *PolarWebho
 	}
 
 	return h.handleActive(ctx, ent, existing)
+}
+
+func (h *WebhookHandler) mapOrderProductToTier(order *PolarOrder) (string, error) {
+	if !order.Paid || order.Status != orderStatusPaid {
+		return "", errors.New("order is not paid")
+	}
+	if classifyRefund(order) != refundStateNone {
+		return "", errors.New("order is refunded")
+	}
+	var configured *OrderProductConfig
+	for i := range h.cfg.OrderProducts {
+		if h.cfg.OrderProducts[i].ProductID == order.Product.ID {
+			configured = &h.cfg.OrderProducts[i]
+			break
+		}
+	}
+	if configured == nil {
+		return "", fmt.Errorf("product %s is not allowlisted", order.Product.ID)
+	}
+	if order.Product.Metadata["pipelock_tier"] != configured.Tier {
+		return "", fmt.Errorf("product %s tier metadata %q does not match allowlist tier %q",
+			order.Product.ID, order.Product.Metadata["pipelock_tier"], configured.Tier)
+	}
+	if order.NetAmount != configured.AmountCents {
+		return "", fmt.Errorf("product %s amount %d does not match allowlist amount %d",
+			order.Product.ID, order.NetAmount, configured.AmountCents)
+	}
+	if strings.ToLower(order.Currency) != configured.Currency {
+		return "", fmt.Errorf("product %s currency %q does not match allowlist currency %q",
+			order.Product.ID, order.Currency, configured.Currency)
+	}
+	return configured.Tier, nil
 }
 
 // isIdempotent returns true if the current subscription state matches

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -587,10 +587,9 @@ func (h *WebhookHandler) handleEnded(ctx context.Context, ent *Entitlement, exis
 	// Upsert the entitlement to record the ended status, committing the webhook
 	// marker in the same transaction when this came from a delivery.
 	if err := h.db.UpsertWithWebhook(ctx, ent, msgID, eventType); err != nil {
-		if errors.Is(err, ErrWebhookAlreadyCommitted) {
-			return nil
+		if !errors.Is(err, ErrWebhookAlreadyCommitted) {
+			return fmt.Errorf("persist ended entitlement: %w", err)
 		}
-		return fmt.Errorf("persist ended entitlement: %w", err)
 	}
 
 	if existing != nil {
@@ -899,6 +898,29 @@ func (h *WebhookHandler) HandleOrderEvent(ctx context.Context, event *PolarWebho
 			Str("order_id", order.ID).
 			Str("event_type", event.Type).
 			Msg("ignoring enterprise eval order in legacy order handler")
+		return nil
+	}
+
+	currentOrder, err := h.polar.GetOrder(ctx, order.ID)
+	if err != nil {
+		return fmt.Errorf("load current order %s: %w", order.ID, err)
+	}
+	if currentOrder.ID != order.ID {
+		return fmt.Errorf("load current order %s: response ID %q does not match", order.ID, currentOrder.ID)
+	}
+	order = currentOrder
+	if order.BillingReason != "purchase" {
+		h.log.Info().
+			Str("order_id", order.ID).
+			Str("billing_reason", order.BillingReason).
+			Msg("ignoring current non-purchase order")
+		return nil
+	}
+	if order.Product.Metadata["pipelock_tier"] == tierEnterpriseEval {
+		h.log.Info().
+			Str("order_id", order.ID).
+			Str("event_type", event.Type).
+			Msg("ignoring current enterprise eval order in legacy order handler")
 		return nil
 	}
 

--- a/enterprise/licenseservice/webhook_terminal_test.go
+++ b/enterprise/licenseservice/webhook_terminal_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build enterprise
+
+package licenseservice
+
+import (
+	"strings"
+	"testing"
+)
+
+// A product that is not on the allowlist must not GRANT entitlement, but it
+// must still be able to LOSE it. Gating terminal events on mappability leaves a
+// canceled or revoked subscription recorded as active locally, which fails in
+// the wrong direction: the safe answer to "I cannot map this product" is to
+// deny the grant and honor the revocation, never to ignore both.
+func TestProcessSubscription_TerminalEventsSurviveUnmappableProduct(t *testing.T) {
+	allowlist := []SubscriptionProductConfig{
+		{ProductID: testProductID, Tier: tierPro, Interval: testIntervalMonth, AmountCents: 2900, Currency: "usd"},
+	}
+
+	t.Run("active event on an unmappable product is rejected", func(t *testing.T) {
+		ts := newTestSetup(t)
+		ts.cfg.SubscriptionProducts = allowlist
+		sub := testActiveSubscription("prod_not_allowlisted", tierEnterprise)
+
+		err := ts.handler.processSubscription(t.Context(), sub)
+		if err == nil {
+			t.Fatal("active event on a non-allowlisted product was accepted, want rejection")
+		}
+		if !strings.Contains(err.Error(), "map subscription") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("cancellation on an unmappable product is still recorded", func(t *testing.T) {
+		ts := newTestSetup(t)
+		ctx := t.Context()
+
+		// Seed an active entitlement the way a pre-enforcement grant would have.
+		ts.cfg.SubscriptionProducts = nil
+		if err := ts.handler.processSubscription(ctx, testActiveSubscription("prod_not_allowlisted", tierEnterprise)); err != nil {
+			t.Fatalf("seed active entitlement: %v", err)
+		}
+		seeded, err := ts.db.GetBySubscriptionID(ctx, testSubscriptionID)
+		if err != nil {
+			t.Fatalf("GetBySubscriptionID(seeded): %v", err)
+		}
+		if seeded == nil || seeded.Status != statusActive {
+			t.Fatalf("seeded entitlement = %+v, want an active record", seeded)
+		}
+
+		// Enforcement turns on, and the product is not on the list.
+		ts.cfg.SubscriptionProducts = allowlist
+		canceled := testActiveSubscription("prod_not_allowlisted", tierEnterprise)
+		canceled.Status = statusCanceled
+
+		if err := ts.handler.processSubscription(ctx, canceled); err != nil {
+			t.Fatalf("cancellation on a non-allowlisted product: %v", err)
+		}
+
+		got, err := ts.db.GetBySubscriptionID(ctx, testSubscriptionID)
+		if err != nil {
+			t.Fatalf("GetBySubscriptionID(after cancel): %v", err)
+		}
+		if got.Status != statusCanceled {
+			t.Fatalf("Status = %q, want %q: the revocation must land even when the product cannot be mapped", got.Status, statusCanceled)
+		}
+		if got.NextRefreshAt != nil {
+			t.Error("NextRefreshAt is set after cancellation, want cleared")
+		}
+	})
+}
+
+// Assess is a live recurring product, so it has to be allowlistable. Rejecting
+// it at config load would make an Assess customer impossible to map once
+// enforcement is on, and would fail service startup on a correct config.
+func TestLoadConfig_SubscriptionProductsAcceptsAssess(t *testing.T) {
+	products := parseSubscriptionProducts("prod_assess:assess:year:99900:usd")
+	if len(products) != 1 {
+		t.Fatalf("parsed %d products, want 1", len(products))
+	}
+	if products[0].Tier != tierAssess {
+		t.Fatalf("Tier = %q, want %q", products[0].Tier, tierAssess)
+	}
+	if !validTiers[products[0].Tier] {
+		t.Fatalf("%q is not a valid tier", products[0].Tier)
+	}
+	// The one-time tiers stay out: they belong to the order path's allowlist.
+	for _, tier := range []string{tierEnterpriseEval, tierTrial} {
+		if tier == products[0].Tier {
+			t.Fatalf("subscription allowlist accepted one-time tier %q", tier)
+		}
+	}
+}

--- a/enterprise/licenseservice/webhook_terminal_test.go
+++ b/enterprise/licenseservice/webhook_terminal_test.go
@@ -77,6 +77,16 @@ func TestProcessSubscription_TerminalEventsSurviveUnmappableProduct(t *testing.T
 // it at config load would make an Assess customer impossible to map once
 // enforcement is on, and would fail service startup on a correct config.
 func TestLoadConfig_SubscriptionProductsAcceptsAssess(t *testing.T) {
+	setRequiredConfigEnv(t)
+	t.Setenv("SUBSCRIPTION_PRODUCTS", "prod_assess:assess:year:99900:usd")
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.SubscriptionProducts) != 1 || cfg.SubscriptionProducts[0].Tier != tierAssess {
+		t.Fatalf("SubscriptionProducts = %+v, want one Assess product", cfg.SubscriptionProducts)
+	}
+
 	products := parseSubscriptionProducts("prod_assess:assess:year:99900:usd")
 	if len(products) != 1 {
 		t.Fatalf("parsed %d products, want 1", len(products))

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -126,6 +127,10 @@ func newTestSetup(t *testing.T) *testSetup {
 		ListenAddr:          ":0",
 		FromEmail:           "test@pipelock.dev",
 		PolarAPIBase:        polarSrv.URL,
+		OrderProducts: []OrderProductConfig{
+			{ProductID: "prod_trial", Tier: tierTrial, AmountCents: 100, Currency: "usd"},
+			{ProductID: "prod_trial_test", Tier: tierTrial, AmountCents: 100, Currency: "usd"},
+		},
 	}
 
 	polar := NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase)
@@ -2324,6 +2329,10 @@ func TestProcessSubscription_TrialDoesNotCountAsFounding(t *testing.T) {
 	orderData, err := json.Marshal(map[string]interface{}{
 		"id":             "order_trial_founding_test",
 		"billing_reason": "purchase",
+		"status":         "paid",
+		"paid":           true,
+		"net_amount":     100,
+		"currency":       "usd",
 		"customer": map[string]interface{}{
 			"email":    testCustomerEmail,
 			"metadata": map[string]string{},
@@ -2420,6 +2429,10 @@ func TestHandleOrderEvent_OneTimeTrial(t *testing.T) {
 	orderData, err := json.Marshal(map[string]interface{}{
 		"id":             "order_trial_123",
 		"billing_reason": "purchase",
+		"status":         "paid",
+		"paid":           true,
+		"net_amount":     100,
+		"currency":       "usd",
 		"customer": map[string]interface{}{
 			"email":    testCustomerEmail,
 			"metadata": map[string]string{"org": "trialcorp"},
@@ -2518,6 +2531,48 @@ func TestHandleOrderEvent_OneTimeTrial(t *testing.T) {
 	}
 }
 
+func TestMapOrderProductToTierFailsClosed(t *testing.T) {
+	ts := newTestSetup(t)
+	base := &PolarOrder{
+		ID:            "order_gate",
+		BillingReason: "purchase",
+		Status:        orderStatusPaid,
+		Paid:          true,
+		NetAmount:     100,
+		TotalAmount:   100,
+		Currency:      "usd",
+	}
+	base.Product.ID = "prod_trial"
+	base.Product.Metadata = map[string]string{"pipelock_tier": tierTrial}
+
+	tests := []struct {
+		name   string
+		mutate func(*PolarOrder)
+	}{
+		{name: "unpaid", mutate: func(o *PolarOrder) { o.Paid = false }},
+		{name: "wrong status", mutate: func(o *PolarOrder) { o.Status = "pending" }},
+		{name: "refunded", mutate: func(o *PolarOrder) { o.RefundedAmount = 1 }},
+		{name: "unallowlisted product", mutate: func(o *PolarOrder) { o.Product.ID = "prod_other" }},
+		{name: "metadata tier mismatch", mutate: func(o *PolarOrder) { o.Product.Metadata["pipelock_tier"] = tierPro }},
+		{name: "amount mismatch", mutate: func(o *PolarOrder) { o.NetAmount = 1 }},
+		{name: "currency mismatch", mutate: func(o *PolarOrder) { o.Currency = "eur" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			order := *base
+			order.Product = base.Product
+			order.Product.Metadata = maps.Clone(base.Product.Metadata)
+			tt.mutate(&order)
+			if _, err := ts.handler.mapOrderProductToTier(&order); err == nil {
+				t.Fatal("mapOrderProductToTier accepted unauthorized order")
+			}
+		})
+	}
+	if tier, err := ts.handler.mapOrderProductToTier(base); err != nil || tier != tierTrial {
+		t.Fatalf("valid order mapped to tier %q, err %v", tier, err)
+	}
+}
+
 func TestHandleOrderEvent_EnterpriseEvalDoesNotMintOnOrderCreated(t *testing.T) {
 	ts := newTestSetup(t)
 	ctx := t.Context()
@@ -2541,6 +2596,10 @@ func TestHandleOrderEvent_EnterpriseEvalDoesNotMintOnOrderCreated(t *testing.T) 
 	orderData, err := json.Marshal(map[string]interface{}{
 		"id":             orderID,
 		"billing_reason": "purchase",
+		"status":         "paid",
+		"paid":           true,
+		"net_amount":     100,
+		"currency":       "usd",
 		"customer": map[string]interface{}{
 			"email":    testCustomerEmail,
 			"metadata": map[string]string{"org": "evalcorp"},
@@ -2636,6 +2695,10 @@ func TestHandleOrderEvent_RejectsEmptyOrderID(t *testing.T) {
 	orderData, _ := json.Marshal(map[string]interface{}{
 		"id":             "",
 		"billing_reason": "purchase",
+		"status":         "paid",
+		"paid":           true,
+		"net_amount":     100,
+		"currency":       "usd",
 		"customer": map[string]interface{}{
 			"email":    testCustomerEmail,
 			"metadata": map[string]string{},
@@ -2664,6 +2727,10 @@ func TestHandleOrderEvent_RejectsMissingTierMetadata(t *testing.T) {
 	orderData, _ := json.Marshal(map[string]interface{}{
 		"id":             "order_no_tier",
 		"billing_reason": "purchase",
+		"status":         "paid",
+		"paid":           true,
+		"net_amount":     100,
+		"currency":       "usd",
 		"customer": map[string]interface{}{
 			"email":    testCustomerEmail,
 			"metadata": map[string]string{},
@@ -2683,8 +2750,8 @@ func TestHandleOrderEvent_RejectsMissingTierMetadata(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing pipelock_tier metadata")
 	}
-	if !strings.Contains(err.Error(), "no pipelock_tier metadata") {
-		t.Errorf("error = %q, want 'no pipelock_tier metadata'", err)
+	if !strings.Contains(err.Error(), "not allowlisted") {
+		t.Errorf("error = %q, want 'not allowlisted'", err)
 	}
 }
 
@@ -2695,6 +2762,10 @@ func TestHandleOrderEvent_RejectsUnknownTier(t *testing.T) {
 	orderData, _ := json.Marshal(map[string]interface{}{
 		"id":             "order_bad_tier",
 		"billing_reason": "purchase",
+		"status":         "paid",
+		"paid":           true,
+		"net_amount":     100,
+		"currency":       "usd",
 		"customer": map[string]interface{}{
 			"email":    testCustomerEmail,
 			"metadata": map[string]string{},
@@ -2714,8 +2785,8 @@ func TestHandleOrderEvent_RejectsUnknownTier(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unrecognized tier")
 	}
-	if !strings.Contains(err.Error(), "unrecognized pipelock_tier") {
-		t.Errorf("error = %q, want 'unrecognized pipelock_tier'", err)
+	if !strings.Contains(err.Error(), "not allowlisted") {
+		t.Errorf("error = %q, want 'not allowlisted'", err)
 	}
 }
 
@@ -2726,6 +2797,10 @@ func TestHandleOrderEvent_TrialNeverSchedulesRefresh(t *testing.T) {
 	orderData, err := json.Marshal(map[string]interface{}{
 		"id":             "order_no_refresh",
 		"billing_reason": "purchase",
+		"status":         "paid",
+		"paid":           true,
+		"net_amount":     100,
+		"currency":       "usd",
 		"customer": map[string]interface{}{
 			"email":    testCustomerEmail,
 			"metadata": map[string]string{},
@@ -2780,6 +2855,10 @@ func TestHandleOrderEvent_ReplayIsIdempotent(t *testing.T) {
 	orderData, err := json.Marshal(map[string]interface{}{
 		"id":             "order_replay_test",
 		"billing_reason": "purchase",
+		"status":         "paid",
+		"paid":           true,
+		"net_amount":     100,
+		"currency":       "usd",
 		"customer": map[string]interface{}{
 			"email":    testCustomerEmail,
 			"metadata": map[string]string{},

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -91,8 +91,33 @@ func newTestSetup(t *testing.T) *testSetup {
 	}
 
 	// Default Polar mock: returns an active pro subscription.
-	polarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	polarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/v1/orders/") {
+			orderID := strings.TrimPrefix(r.URL.Path, "/v1/orders/")
+			productID, tier := "prod_trial", tierTrial
+			org := "testcorp"
+			if orderID == "order_trial_123" {
+				org = "trialcorp"
+			}
+			if orderID == "order_no_tier" || orderID == "order_bad_tier" {
+				productID = "prod_bad"
+			}
+			if orderID == "order_bad_tier" {
+				tier = "premium"
+			}
+			_, _ = fmt.Fprintf(w, `{
+				"id": %q,
+				"billing_reason": "purchase",
+				"status": "paid",
+				"paid": true,
+				"net_amount": 100,
+				"currency": "usd",
+				"customer": {"email": %q, "metadata": {"org": %q}},
+				"product": {"id": %q, "name": "Pipelock Pro Trial", "metadata": {"pipelock_tier": %q}}
+			}`, orderID, testCustomerEmail, org, productID, tier)
+			return
+		}
 		_, _ = fmt.Fprintf(w, `{
 			"id": "%s",
 			"status": "active",
@@ -1931,6 +1956,40 @@ func TestProcessSubscription_EndedEmailFailure(t *testing.T) {
 	}
 }
 
+func TestHandleEnded_ReplayRetriesCancellationEmail(t *testing.T) {
+	ts := newTestSetup(t)
+	var deliveries atomic.Int32
+	emailSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		deliveries.Add(1)
+		w.Header().Set("Content-Type", testContentTypeJSON)
+		_, _ = w.Write([]byte(`{"id":"msg_ended"}`))
+	}))
+	t.Cleanup(emailSrv.Close)
+	ts.handler.email = &EmailSender{
+		apiKey:    "re_" + "test_key",
+		fromEmail: "test@pipelock.dev",
+		client:    emailSrv.Client(),
+		apiURL:    emailSrv.URL,
+	}
+
+	expires := time.Now().UTC().Add(24 * time.Hour)
+	existing := testEntitlement(testSubscriptionID)
+	existing.LastLicenseExpiresAt = &expires
+	ended := testEntitlement(testSubscriptionID)
+	ended.Status = statusCanceled
+
+	const deliveryID = "msg_ended_replay"
+	if err := ts.handler.handleEnded(t.Context(), ended, existing, EventSubscriptionCanceled, deliveryID); err != nil {
+		t.Fatalf("handleEnded(first): %v", err)
+	}
+	if err := ts.handler.handleEnded(t.Context(), ended, existing, EventSubscriptionCanceled, deliveryID); err != nil {
+		t.Fatalf("handleEnded(replay): %v", err)
+	}
+	if got := deliveries.Load(); got != 2 {
+		t.Fatalf("cancellation email deliveries = %d, want 2 including committed-marker replay", got)
+	}
+}
+
 func TestProcessSubscription_EndedPreservesLicenseFields(t *testing.T) {
 	ts := newTestSetup(t)
 	ctx := t.Context()
@@ -2570,6 +2629,41 @@ func TestMapOrderProductToTierFailsClosed(t *testing.T) {
 	}
 	if tier, err := ts.handler.mapOrderProductToTier(base); err != nil || tier != tierTrial {
 		t.Fatalf("valid order mapped to tier %q, err %v", tier, err)
+	}
+}
+
+func TestHandleOrderEvent_RejectsCurrentlyRefundedOrder(t *testing.T) {
+	ts := newTestSetup(t)
+	orderSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", testContentTypeJSON)
+		_, _ = w.Write([]byte(`{
+			"id":"order_refunded",
+			"billing_reason":"purchase",
+			"status":"paid",
+			"paid":true,
+			"refunded_amount":100,
+			"net_amount":100,
+			"currency":"usd",
+			"customer":{"email":"customer@example.com","metadata":{}},
+			"product":{"id":"prod_trial","metadata":{"pipelock_tier":"trial"}}
+		}`))
+	}))
+	t.Cleanup(orderSrv.Close)
+	ts.handler.polar = NewPolarClient(testPolarAPIToken, orderSrv.URL)
+
+	event := &PolarWebhookEvent{Type: EventOrderCreated, Data: json.RawMessage(`{
+		"id":"order_refunded",
+		"billing_reason":"purchase",
+		"status":"paid",
+		"paid":true,
+		"net_amount":100,
+		"currency":"usd",
+		"customer":{"email":"customer@example.com","metadata":{}},
+		"product":{"id":"prod_trial","metadata":{"pipelock_tier":"trial"}}
+	}`)}
+	err := ts.handler.HandleOrderEvent(t.Context(), event)
+	if err == nil || !strings.Contains(err.Error(), "order is refunded") {
+		t.Fatalf("HandleOrderEvent error = %v, want current refund rejection", err)
 	}
 }
 

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -40,21 +40,27 @@ type testSetup struct {
 	publicKey  ed25519.PublicKey
 }
 
-func testServiceIntermediateCert(t *testing.T, intermediatePub ed25519.PublicKey) []byte {
+func testServiceIntermediateCert(t *testing.T, intermediatePub ed25519.PublicKey) ([]byte, ed25519.PublicKey) {
 	t.Helper()
-	_, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey(root): %v", err)
 	}
 	now := time.Now().UTC()
+	data := testServiceIntermediateCertWithRoot(t, rootPriv, intermediatePub, "im_service_test", now.Add(-time.Minute), now.Add(90*24*time.Hour))
+	return data, rootPub
+}
+
+func testServiceIntermediateCertWithRoot(t *testing.T, rootPriv ed25519.PrivateKey, intermediatePub ed25519.PublicKey, serial string, notBefore, notAfter time.Time) []byte {
+	t.Helper()
 	im, err := license.SignIntermediate(license.IntermediatePayload{
-		Serial:    "im_service_test",
+		Serial:    serial,
 		Purpose:   license.PurposeLicenseSigning,
 		Algorithm: license.AlgorithmEd25519,
 		PublicKey: hex.EncodeToString(intermediatePub),
-		NotBefore: now.Add(-time.Minute).Unix(),
-		NotAfter:  now.Add(time.Hour).Unix(),
-		IssuedAt:  now.Add(-time.Minute).Unix(),
+		NotBefore: notBefore.Unix(),
+		NotAfter:  notAfter.Unix(),
+		IssuedAt:  notBefore.Unix(),
 	}, rootPriv)
 	if err != nil {
 		t.Fatalf("SignIntermediate: %v", err)
@@ -104,11 +110,13 @@ func newTestSetup(t *testing.T) *testSetup {
 	}))
 	t.Cleanup(emailSrv.Close)
 
+	cert, rootPub := testServiceIntermediateCert(t, pub)
 	cfg := &Config{
 		PolarWebhookSecret:  "whsec_" + "dGVzdA==",
 		PolarAPIToken:       testPolarAPIToken,
 		PrivateKeyPath:      filepath.Join(t.TempDir(), "test.key"),
-		IntermediateCert:    testServiceIntermediateCert(t, pub),
+		IntermediateCert:    cert,
+		RootPublicKey:       rootPub,
 		CRLPrivateKey:       crlPriv,
 		ResendAPIKey:        "re_" + "test_key",
 		DBPath:              ":memory:",
@@ -145,6 +153,32 @@ func newTestSetup(t *testing.T) *testSetup {
 		privateKey: priv,
 		publicKey:  pub,
 	}
+}
+
+func testActiveSubscription(productID, tier string) *PolarSubscription {
+	sub := &PolarSubscription{
+		ID:                testSubscriptionID,
+		Status:            statusActive,
+		RecurringInterval: testIntervalMonth,
+		CurrentPeriodEnd:  time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
+		AmountCents:       2900,
+		Currency:          "usd",
+	}
+	sub.Customer.Email = testCustomerEmail
+	sub.Customer.Metadata = map[string]string{"org": "testcorp"}
+	sub.Product.ID = productID
+	sub.Product.Name = testProductName
+	sub.Product.Metadata = map[string]string{"pipelock_tier": tier}
+	return sub
+}
+
+func countLicenseIssuances(t *testing.T, db *EntitlementDB, subID string) int {
+	t.Helper()
+	var count int
+	if err := db.db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM license_issuances WHERE subscription_id = ?`, subID).Scan(&count); err != nil {
+		t.Fatalf("count license issuances: %v", err)
+	}
+	return count
 }
 
 func TestMapProductToTier(t *testing.T) {
@@ -234,6 +268,70 @@ func TestMapProductToTier(t *testing.T) {
 			}
 			if founding != tt.wantFound {
 				t.Errorf("founding = %v, want %v", founding, tt.wantFound)
+			}
+		})
+	}
+}
+
+func TestMapProductToTier_SubscriptionAllowlistRejectsUnknownProduct(t *testing.T) {
+	ts := newTestSetup(t)
+	ts.cfg.SubscriptionProducts = []SubscriptionProductConfig{
+		{ProductID: "prod_allowed", Tier: tierEnterprise, Interval: testIntervalMonth, AmountCents: 9900, Currency: "usd"},
+	}
+	sub := testActiveSubscription("prod_mispriced", tierEnterprise)
+	sub.AmountCents = 9900
+	sub.Currency = "usd"
+
+	_, _, err := ts.handler.mapProductToTier(sub)
+	if err == nil {
+		t.Fatal("expected non-allowlisted subscription product to be rejected")
+	}
+	if !strings.Contains(err.Error(), "not allowlisted") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMapProductToTier_SubscriptionAllowlistUnsetPreservesMetadataMapping(t *testing.T) {
+	ts := newTestSetup(t)
+	ts.cfg.SubscriptionProducts = nil
+	sub := testActiveSubscription("prod_legacy_metadata", tierEnterprise)
+
+	tier, founding, err := ts.handler.mapProductToTier(sub)
+	if err != nil {
+		t.Fatalf("mapProductToTier: %v", err)
+	}
+	if tier != tierEnterprise {
+		t.Fatalf("tier = %q, want %q", tier, tierEnterprise)
+	}
+	if founding {
+		t.Fatal("enterprise tier should not be founding")
+	}
+}
+
+func TestMapProductToTier_SubscriptionAllowlistRequiresCommercialFacts(t *testing.T) {
+	ts := newTestSetup(t)
+	ts.cfg.SubscriptionProducts = []SubscriptionProductConfig{
+		{ProductID: testProductID, Tier: tierEnterprise, Interval: testIntervalMonth, AmountCents: 9900, Currency: "usd"},
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*PolarSubscription)
+	}{
+		{name: "tier mismatch", mutate: func(sub *PolarSubscription) { sub.Product.Metadata["pipelock_tier"] = tierPro }},
+		{name: "interval mismatch", mutate: func(sub *PolarSubscription) { sub.RecurringInterval = testIntervalYear }},
+		{name: "amount mismatch", mutate: func(sub *PolarSubscription) { sub.AmountCents = 100 }},
+		{name: "currency mismatch", mutate: func(sub *PolarSubscription) { sub.Currency = "eur" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub := testActiveSubscription(testProductID, tierEnterprise)
+			sub.AmountCents = 9900
+			sub.Currency = "usd"
+			tt.mutate(sub)
+			if _, _, err := ts.handler.mapProductToTier(sub); err == nil {
+				t.Fatal("expected allowlist mismatch to be rejected")
 			}
 		})
 	}
@@ -578,6 +676,59 @@ func TestProcessSubscription_ActiveMintsCertificate(t *testing.T) {
 	}
 }
 
+func TestProcessSubscription_ExpiryClampedToIntermediateNotAfter(t *testing.T) {
+	db := openTestDB(t)
+	ledger, _ := openTestLedger(t)
+	signingPub, signingPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(signing): %v", err)
+	}
+	rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(root): %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	notAfter := now.Add(2 * time.Hour)
+	cfg := &Config{
+		IntermediateCert:    testServiceIntermediateCertWithRoot(t, rootPriv, signingPub, "im_short", now.Add(-time.Minute), notAfter),
+		RootPublicKey:       rootPub,
+		FoundingProCap:      50,
+		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
+	}
+	emailSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_clamp"}`))
+	}))
+	t.Cleanup(emailSrv.Close)
+	handler, err := NewWebhookHandler(
+		cfg,
+		db,
+		NewPolarClient("token", "http://localhost"),
+		&EmailSender{apiKey: "re_" + "test", fromEmail: "test@pipelock.dev", client: emailSrv.Client(), apiURL: emailSrv.URL},
+		ledger,
+		signingPriv,
+		zerolog.Nop(),
+	)
+	if err != nil {
+		t.Fatalf("NewWebhookHandler: %v", err)
+	}
+
+	sub := testActiveSubscription(testProductID, tierPro)
+	if err := handler.processSubscription(t.Context(), sub); err != nil {
+		t.Fatalf("processSubscription: %v", err)
+	}
+	ent, err := db.GetBySubscriptionID(t.Context(), testSubscriptionID)
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID: %v", err)
+	}
+	if ent.LastLicenseExpiresAt == nil {
+		t.Fatal("LastLicenseExpiresAt is nil")
+	}
+	if !ent.LastLicenseExpiresAt.Equal(notAfter) {
+		t.Fatalf("LastLicenseExpiresAt = %s, want intermediate NotAfter %s", ent.LastLicenseExpiresAt.UTC(), notAfter)
+	}
+}
+
 func TestProcessSubscription_CanceledClearsRefresh(t *testing.T) {
 	ts := newTestSetup(t)
 	ctx := t.Context()
@@ -848,6 +999,119 @@ func TestProcessSubscription_IdempotentRetriesFailedDelivery(t *testing.T) {
 	}
 }
 
+func TestHandleEventDelivery_ReplayedWebhookIDDoesNotMintTwice(t *testing.T) {
+	ts := newTestSetup(t)
+	ctx := t.Context()
+
+	// Deliver with a failing email sender so the entitlement is left with
+	// LastDeliveryStatus != "sent". Without that, the replay is short-circuited
+	// by the already-delivered skip and this test passes even with the
+	// webhook-ID dedupe removed, i.e. it would not test what it is named for.
+	// Leaving delivery failed makes the dedupe the only thing standing between
+	// a replayed webhook and a second mint.
+	emailSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	t.Cleanup(emailSrv.Close)
+	ts.handler.email = &EmailSender{
+		apiKey:    "re_" + "test_key",
+		fromEmail: "test@pipelock.dev",
+		client:    emailSrv.Client(),
+		apiURL:    emailSrv.URL,
+	}
+
+	event := &PolarWebhookEvent{
+		Type: EventSubscriptionCreated,
+		Data: json.RawMessage(testSubscriptionJSON),
+	}
+	if err := ts.handler.HandleEventDelivery(ctx, event, "msg_subscription_replay"); err != nil {
+		t.Fatalf("HandleEventDelivery(first): %v", err)
+	}
+	first, err := ts.db.GetBySubscriptionID(ctx, testSubscriptionID)
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID(first): %v", err)
+	}
+	if first == nil || first.LastLicenseID == "" {
+		t.Fatalf("first delivery did not mint: %+v", first)
+	}
+	if err := ts.handler.HandleEventDelivery(ctx, event, "msg_subscription_replay"); err != nil {
+		t.Fatalf("HandleEventDelivery(replay): %v", err)
+	}
+	second, err := ts.db.GetBySubscriptionID(ctx, testSubscriptionID)
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID(second): %v", err)
+	}
+	if second.LastLicenseID != first.LastLicenseID {
+		t.Fatalf("replay minted a new license: first %q second %q", first.LastLicenseID, second.LastLicenseID)
+	}
+	if got := countLicenseIssuances(t, ts.db, testSubscriptionID); got != 1 {
+		t.Fatalf("license issuance count = %d, want 1", got)
+	}
+}
+
+func TestHandleEventDelivery_ReplayedWebhookRetriesFailedEmailWithoutRemint(t *testing.T) {
+	ts := newTestSetup(t)
+	ctx := t.Context()
+
+	failEmail := &atomic.Bool{}
+	failEmail.Store(true)
+	emailHits := &atomic.Int32{}
+	emailSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		emailHits.Add(1)
+		if failEmail.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"boom"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_retry"}`))
+	}))
+	t.Cleanup(emailSrv.Close)
+	ts.handler.email = &EmailSender{
+		apiKey:    "re_" + "test_key",
+		fromEmail: "test@pipelock.dev",
+		client:    emailSrv.Client(),
+		apiURL:    emailSrv.URL,
+	}
+
+	event := &PolarWebhookEvent{
+		Type: EventSubscriptionCreated,
+		Data: json.RawMessage(testSubscriptionJSON),
+	}
+	if err := ts.handler.HandleEventDelivery(ctx, event, "msg_subscription_email_retry"); err != nil {
+		t.Fatalf("HandleEventDelivery(first): %v", err)
+	}
+	first, err := ts.db.GetBySubscriptionID(ctx, testSubscriptionID)
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID(first): %v", err)
+	}
+	if first.LastDeliveryStatus != "failed" {
+		t.Fatalf("first LastDeliveryStatus = %q, want failed", first.LastDeliveryStatus)
+	}
+
+	failEmail.Store(false)
+	if err := ts.handler.HandleEventDelivery(ctx, event, "msg_subscription_email_retry"); err != nil {
+		t.Fatalf("HandleEventDelivery(retry): %v", err)
+	}
+	second, err := ts.db.GetBySubscriptionID(ctx, testSubscriptionID)
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID(second): %v", err)
+	}
+	if second.LastLicenseID != first.LastLicenseID {
+		t.Fatalf("email retry minted a new license: first %q second %q", first.LastLicenseID, second.LastLicenseID)
+	}
+	if second.LastDeliveryStatus != testDeliveryStatusSent {
+		t.Fatalf("second LastDeliveryStatus = %q, want sent", second.LastDeliveryStatus)
+	}
+	if got := countLicenseIssuances(t, ts.db, testSubscriptionID); got != 1 {
+		t.Fatalf("license issuance count = %d, want 1", got)
+	}
+	if got := emailHits.Load(); got != 2 {
+		t.Fatalf("email hits = %d, want 2", got)
+	}
+}
+
 func TestProcessSubscription_RejectsUnknownTier(t *testing.T) {
 	ts := newTestSetup(t)
 	ctx := t.Context()
@@ -1069,8 +1333,12 @@ func TestNewWebhookHandler_InitializesFoundingCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
+	pub := priv.Public().(ed25519.PublicKey)
+	cert, rootPub := testServiceIntermediateCert(t, pub)
 
 	cfg := &Config{
+		IntermediateCert:    cert,
+		RootPublicKey:       rootPub,
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
 	}
@@ -1100,8 +1368,10 @@ func TestNewWebhookHandler_RejectsIntermediateSigningKeyMismatch(t *testing.T) {
 		t.Fatalf("GenerateKey(signing): %v", err)
 	}
 
+	cert, rootPub := testServiceIntermediateCert(t, certPub)
 	cfg := &Config{
-		IntermediateCert:    testServiceIntermediateCert(t, certPub),
+		IntermediateCert:    cert,
+		RootPublicKey:       rootPub,
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
 	}
@@ -1125,9 +1395,14 @@ func TestNewWebhookHandler_RejectsMalformedIntermediate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey(signing): %v", err)
 	}
+	rootPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(root): %v", err)
+	}
 
 	cfg := &Config{
 		IntermediateCert:    []byte("{bad json"),
+		RootPublicKey:       rootPub,
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
 	}
@@ -1138,8 +1413,82 @@ func TestNewWebhookHandler_RejectsMalformedIntermediate(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected malformed intermediate error")
 	}
-	if !strings.Contains(err.Error(), "parse intermediate certificate public key") {
+	if !strings.Contains(err.Error(), "verify intermediate certificate") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewWebhookHandler_VerifiesIntermediateAtStartup(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name    string
+		cert    func(t *testing.T, rootPriv ed25519.PrivateKey, signingPub ed25519.PublicKey) []byte
+		root    func(goodRoot ed25519.PublicKey) ed25519.PublicKey
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			cert: func(t *testing.T, rootPriv ed25519.PrivateKey, signingPub ed25519.PublicKey) []byte {
+				return testServiceIntermediateCertWithRoot(t, rootPriv, signingPub, "im_valid", now.Add(-time.Minute), now.Add(time.Hour))
+			},
+			root: func(goodRoot ed25519.PublicKey) ed25519.PublicKey { return goodRoot },
+		},
+		{
+			name: "expired",
+			cert: func(t *testing.T, rootPriv ed25519.PrivateKey, signingPub ed25519.PublicKey) []byte {
+				return testServiceIntermediateCertWithRoot(t, rootPriv, signingPub, "im_expired", now.Add(-2*time.Hour), now.Add(-time.Hour))
+			},
+			root:    func(goodRoot ed25519.PublicKey) ed25519.PublicKey { return goodRoot },
+			wantErr: true,
+		},
+		{
+			name: "wrong root",
+			cert: func(t *testing.T, rootPriv ed25519.PrivateKey, signingPub ed25519.PublicKey) []byte {
+				return testServiceIntermediateCertWithRoot(t, rootPriv, signingPub, "im_wrong_root", now.Add(-time.Minute), now.Add(time.Hour))
+			},
+			root: func(ed25519.PublicKey) ed25519.PublicKey {
+				wrongRoot, _, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatalf("GenerateKey(wrong root): %v", err)
+				}
+				return wrongRoot
+			},
+			wantErr: true,
+		},
+		{
+			name: "truncated",
+			cert: func(t *testing.T, rootPriv ed25519.PrivateKey, signingPub ed25519.PublicKey) []byte {
+				data := testServiceIntermediateCertWithRoot(t, rootPriv, signingPub, "im_truncated", now.Add(-time.Minute), now.Add(time.Hour))
+				return data[:len(data)/2]
+			},
+			root:    func(goodRoot ed25519.PublicKey) ed25519.PublicKey { return goodRoot },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := openTestDB(t)
+			ledger, _ := openTestLedger(t)
+			signingPub, signingPriv, err := ed25519.GenerateKey(rand.Reader)
+			if err != nil {
+				t.Fatalf("GenerateKey(signing): %v", err)
+			}
+			rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+			if err != nil {
+				t.Fatalf("GenerateKey(root): %v", err)
+			}
+			cfg := &Config{
+				IntermediateCert:    tt.cert(t, rootPriv, signingPub),
+				RootPublicKey:       tt.root(rootPub),
+				FoundingProCap:      50,
+				FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
+			}
+			_, err = NewWebhookHandler(cfg, db, NewPolarClient("token", "http://localhost"), NewEmailSender("key", "from@test.com"), ledger, signingPriv, zerolog.Nop())
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewWebhookHandler() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 
@@ -1661,8 +2010,12 @@ func TestNewWebhookHandler_DBError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
+	pub := priv.Public().(ed25519.PublicKey)
+	cert, rootPub := testServiceIntermediateCert(t, pub)
 
 	cfg := &Config{
+		IntermediateCert:    cert,
+		RootPublicKey:       rootPub,
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
 	}

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -1967,7 +1967,7 @@ func TestHandleEnded_ReplayRetriesCancellationEmail(t *testing.T) {
 	t.Cleanup(emailSrv.Close)
 	ts.handler.email = &EmailSender{
 		apiKey:    "re_" + "test_key",
-		fromEmail: "test@pipelock.dev",
+		fromEmail: "test@example.com",
 		client:    emailSrv.Client(),
 		apiURL:    emailSrv.URL,
 	}


### PR DESCRIPTION
## What changed

The playground broker served no browser security headers. It serves a page that is embedded cross-origin in an iframe and executes a WebAssembly verifier, so a middleware now sets Content-Security-Policy, Strict-Transport-Security, X-Content-Type-Options, Referrer-Policy and Permissions-Policy on every response, static assets and API alike. `frame-ancestors` permits the embedding origin so the embed keeps working, and `script-src` permits `blob:` and `wasm-unsafe-eval` because the viewer loads its wasm loader as a blob. X-Frame-Options is deliberately not used, since it cannot express a cross-origin parent.

The license service loaded its mounted intermediate certificate with a helper that does not verify the root signature or validity, and the verifying variant had no callers. An intermediate that was expired, truncated, or signed by a different root would start the service and mint tokens that every offline verifier then rejects. The service now resolves the license root public key, verifies the intermediate at startup, verifies again before each mint so a swapped file cannot slip past the startup check, and clamps issued token expiry to the intermediate's own NotAfter so a token can never outlive the certificate that signs it.

Subscription webhook handling had no durable delivery dedupe while the order and eval paths already did. The subscription path now records the webhook id in the same transaction as the entitlement and issuance, so a redelivered event does not produce a second token, while a genuine email-delivery retry still resends the existing one.

Subscription tier was derived from product metadata with no server-side allowlist. An optional `SUBSCRIPTION_PRODUCTS` allowlist now checks product id, tier, interval, amount and currency, mirroring what the eval path already does. When unset, current behavior is preserved and startup logs a warning, so this is not a breaking change for existing deployments.

The broker operations guide's example command enabled the Turnstile secret while omitting the hostname and action flags the broker requires, so the documented command could not start. Both flags are now in the example.

## Why

Every one of these is a public-facing surface. The header set closes a gap on the one interactive page, and the license service changes move it from trusting its own mounted material to verifying it, with the same fail-closed posture the eval path already had.

## Notes for deployment

The license service verifies the intermediate against the license root public key, resolved from the embedded build value or `PIPELOCK_LICENSE_PUBLIC_KEY`. A build without an embedded key needs that variable set, or the service will refuse to start. That is intentional fail-closed behavior, but it means the environment must carry the key before this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subscription product allowlisting via `SUBSCRIPTION_PRODUCTS` with strict validation and Polar pricing (amount/currency).
  * Improved enterprise licensing webhooks with durable delivery idempotency and better resend behavior.
  * Broker now supports `--embed-origin` and `--turnstile-origin`, generating deployment-specific CSP.
* **Security**
  * Added stronger security headers to broker responses and tightened origin validation (default no framing).
* **Bug Fixes**
  * Token expiry is now clamped to intermediate certificate validity; improved static no-cache handling.
* **Documentation**
  * Updated broker operations example and key-rotation runbook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->