### PR TITLE
fix(rules): fail closed on unclassified bundle-load errors

### DIFF
--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1973,7 +1973,8 @@ func TestReportStartupRuleBundleResultAggregatesStrictIntegrityFailures(t *testi
 			{Name: "bundle-a", Reason: "hash mismatch", Class: rules.BundleErrorClassIntegrity},
 			{Name: "bundle-b", Reason: "expired", Class: rules.BundleErrorClassIntegrity},
 			{Name: "bundle-c", Reason: "requires future feature", Class: rules.BundleErrorClassAvailability},
-			// Zero-value classes preserve older availability semantics.
+			// An unclassified (zero-value) class now defaults to integrity so it
+			// fails CLOSED in strict startup instead of silently booting degraded.
 			{Name: "bundle-legacy", Reason: "legacy zero-value class"},
 		},
 		Degraded: true,
@@ -1984,15 +1985,14 @@ func TestReportStartupRuleBundleResultAggregatesStrictIntegrityFailures(t *testi
 		t.Fatal("strict startup should reject integrity failures")
 	}
 	msg := err.Error()
-	for _, want := range []string{"bundle-a: hash mismatch", "bundle-b: expired"} {
+	for _, want := range []string{"bundle-a: hash mismatch", "bundle-b: expired", "bundle-legacy: legacy zero-value class"} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("error = %q, want %q", msg, want)
 		}
 	}
-	for _, wantNot := range []string{"bundle-c", "bundle-legacy"} {
-		if strings.Contains(msg, wantNot) {
-			t.Fatalf("error = %q, should not include availability-only failure %q", msg, wantNot)
-		}
+	// Only the explicitly-availability failure must be tolerated in strict mode.
+	if strings.Contains(msg, "bundle-c") {
+		t.Fatalf("error = %q, should not include availability-only failure %q", msg, "bundle-c")
 	}
 	if got := cfg.Rules.DegradedBundles; !reflect.DeepEqual(got, []string{"bundle-a", "bundle-b", "bundle-c", "bundle-legacy"}) {
 		t.Fatalf("degraded bundles = %+v, want all degraded names", got)

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -145,11 +145,15 @@ func (r *LoadResult) errorsByClass(class BundleErrorClass) []BundleError {
 	return out
 }
 
-// ClassOrDefault returns the recorded class, treating older zero-value
-// BundleError instances as availability failures to preserve compatibility.
+// ClassOrDefault returns the recorded class. A zero-value (unclassified)
+// BundleError defaults to integrity so an unclassified failure fails CLOSED in
+// strict startup rather than silently booting degraded. Every loader
+// constructor sets Class explicitly (see TestBundleErrorConstructorsSetClass),
+// so this default is a fail-safe backstop for a future error path that forgets
+// to classify itself, never a value real code relies on.
 func (e BundleError) ClassOrDefault() BundleErrorClass {
 	if e.Class == "" {
-		return BundleErrorClassAvailability
+		return BundleErrorClassIntegrity
 	}
 	return e.Class
 }

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -145,17 +145,21 @@ func (r *LoadResult) errorsByClass(class BundleErrorClass) []BundleError {
 	return out
 }
 
-// ClassOrDefault returns the recorded class. A zero-value (unclassified)
-// BundleError defaults to integrity so an unclassified failure fails CLOSED in
-// strict startup rather than silently booting degraded. Every loader
-// constructor sets Class explicitly (see TestBundleErrorConstructorsSetClass),
-// so this default is a fail-safe backstop for a future error path that forgets
-// to classify itself, never a value real code relies on.
+// ClassOrDefault returns the recorded class, failing CLOSED for anything that
+// is not an explicitly recognized class. A zero-value (unclassified) OR an
+// unrecognized/typo'd class value defaults to integrity, so an unclassified
+// failure refuses strict startup rather than silently booting degraded — and a
+// future value the strict-startup integrity filter would not recognize can't
+// slip through as tolerated. Every loader constructor sets a known class
+// explicitly (see TestBundleErrorConstructorsSetClass), so this default is a
+// fail-safe backstop, never a value real code relies on.
 func (e BundleError) ClassOrDefault() BundleErrorClass {
-	if e.Class == "" {
+	switch e.Class {
+	case BundleErrorClassAvailability, BundleErrorClassIntegrity:
+		return e.Class
+	default:
 		return BundleErrorClassIntegrity
 	}
-	return e.Class
 }
 
 // DegradedBundleNames returns a stable, de-duplicated list of bundles or state

--- a/internal/rules/loader_class_lint_test.go
+++ b/internal/rules/loader_class_lint_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestBundleErrorConstructorsSetClass is a construction-time lint: every
+// BundleError composite literal in loader.go must set the Class field
+// explicitly. ClassOrDefault fails CLOSED (integrity) for an unclassified
+// error, but that default is only a fail-safe backstop — a real loader path
+// must always classify its failure so an availability-only condition (a missing
+// optional store, a permission blip) is not misreported as an integrity failure
+// that refuses strict startup. This test catches a future constructor that
+// forgets Class before it ships a fail-open (or over-strict) regression.
+func TestBundleErrorConstructorsSetClass(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "loader.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse loader.go: %v", err)
+	}
+
+	var found int
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		ident, ok := lit.Type.(*ast.Ident)
+		if !ok || ident.Name != "BundleError" {
+			return true
+		}
+		found++
+		hasClass := false
+		for _, el := range lit.Elts {
+			kv, ok := el.(*ast.KeyValueExpr)
+			if !ok {
+				// A positional literal would set every field including Class;
+				// treat it as satisfying the invariant but flag it, since keyed
+				// literals are the project convention.
+				t.Errorf("BundleError literal at %s is positional; use a keyed literal with an explicit Class", fset.Position(lit.Pos()))
+				hasClass = true
+				continue
+			}
+			if key, ok := kv.Key.(*ast.Ident); ok && key.Name == "Class" {
+				hasClass = true
+			}
+		}
+		if !hasClass {
+			t.Errorf("BundleError literal at %s does not set Class explicitly; every loader failure must classify itself (availability vs integrity)", fset.Position(lit.Pos()))
+		}
+		return true
+	})
+
+	if found == 0 {
+		t.Fatal("found no BundleError composite literals in loader.go; did the file move or change form?")
+	}
+}

--- a/internal/rules/loader_class_lint_test.go
+++ b/internal/rules/loader_class_lint_test.go
@@ -106,6 +106,11 @@ func TestBundleErrorClassLintDetectsViolations(t *testing.T) {
 			wantNum: 1,
 		},
 		{
+			name:    "positional literal",
+			src:     "package p\nvar _ = BundleError{\"x\"}\n",
+			wantNum: 1,
+		},
+		{
 			name:    "keyed constant class is accepted",
 			src:     "package p\nvar _ = BundleError{Name: \"x\", Class: BundleErrorClassIntegrity}\n",
 			wantNum: 0,

--- a/internal/rules/loader_class_lint_test.go
+++ b/internal/rules/loader_class_lint_test.go
@@ -7,25 +7,29 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
+	"strings"
 	"testing"
 )
 
-// TestBundleErrorConstructorsSetClass is a construction-time lint: every
-// BundleError composite literal in loader.go must set the Class field
-// explicitly. ClassOrDefault fails CLOSED (integrity) for an unclassified
-// error, but that default is only a fail-safe backstop — a real loader path
-// must always classify its failure so an availability-only condition (a missing
-// optional store, a permission blip) is not misreported as an integrity failure
-// that refuses strict startup. This test catches a future constructor that
-// forgets Class before it ships a fail-open (or over-strict) regression.
-func TestBundleErrorConstructorsSetClass(t *testing.T) {
+// bundleErrorClassViolations returns one message per BundleError composite
+// literal in src that does not explicitly set a non-empty Class. It is the core
+// of the construction-time lint below, factored out so the lint itself can be
+// tested against synthetic sources.
+//
+// A literal violates the invariant when it is positional (no keyed Class) or
+// when it sets Class to an explicit empty string literal (""). A Class set via
+// a constant, variable, or classifier call is accepted — only a statically
+// empty class is rejected, since ClassOrDefault fails closed on anything else.
+func bundleErrorClassViolations(t *testing.T, src string) []string {
+	t.Helper()
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "loader.go", nil, 0)
+	file, err := parser.ParseFile(fset, "src.go", src, 0)
 	if err != nil {
-		t.Fatalf("parse loader.go: %v", err)
+		t.Fatalf("parse source: %v", err)
 	}
 
-	var found int
+	var violations []string
 	ast.Inspect(file, func(n ast.Node) bool {
 		lit, ok := n.(*ast.CompositeLit)
 		if !ok {
@@ -35,29 +39,88 @@ func TestBundleErrorConstructorsSetClass(t *testing.T) {
 		if !ok || ident.Name != "BundleError" {
 			return true
 		}
-		found++
 		hasClass := false
 		for _, el := range lit.Elts {
 			kv, ok := el.(*ast.KeyValueExpr)
 			if !ok {
-				// A positional literal would set every field including Class;
-				// treat it as satisfying the invariant but flag it, since keyed
-				// literals are the project convention.
-				t.Errorf("BundleError literal at %s is positional; use a keyed literal with an explicit Class", fset.Position(lit.Pos()))
+				violations = append(violations, "positional BundleError literal (use a keyed literal with an explicit Class)")
 				hasClass = true
 				continue
 			}
 			if key, ok := kv.Key.(*ast.Ident); ok && key.Name == "Class" {
 				hasClass = true
+				if v, ok := kv.Value.(*ast.BasicLit); ok && v.Kind == token.STRING && v.Value == `""` {
+					violations = append(violations, "BundleError sets an empty Class")
+				}
 			}
 		}
 		if !hasClass {
-			t.Errorf("BundleError literal at %s does not set Class explicitly; every loader failure must classify itself (availability vs integrity)", fset.Position(lit.Pos()))
+			violations = append(violations, "BundleError does not set Class explicitly")
 		}
 		return true
 	})
+	return violations
+}
 
-	if found == 0 {
+// TestBundleErrorConstructorsSetClass is a construction-time lint: every
+// BundleError composite literal in loader.go must set Class to a non-empty
+// value. ClassOrDefault fails CLOSED (integrity) for an unclassified or
+// unrecognized error, but that default is a fail-safe backstop — a real loader
+// path must always classify its failure so an availability-only condition (a
+// missing optional store, a permission blip) is not misreported as an integrity
+// failure that refuses strict startup. This catches a future constructor that
+// forgets Class, or sets it empty, before it ships a regression.
+func TestBundleErrorConstructorsSetClass(t *testing.T) {
+	data, err := os.ReadFile("loader.go")
+	if err != nil {
+		t.Fatalf("read loader.go: %v", err)
+	}
+	src := string(data)
+	if v := bundleErrorClassViolations(t, src); len(v) > 0 {
+		t.Errorf("loader.go has unclassified BundleError literals: %s", strings.Join(v, "; "))
+	}
+	// Guard against the file moving or changing form to a shape the lint no
+	// longer recognizes.
+	if !strings.Contains(src, "BundleError{") {
 		t.Fatal("found no BundleError composite literals in loader.go; did the file move or change form?")
+	}
+}
+
+// TestBundleErrorClassLintDetectsViolations proves the lint is non-vacuous: it
+// flags positional literals and explicit empty classes, and accepts a keyed
+// non-empty class (constant or classifier call).
+func TestBundleErrorClassLintDetectsViolations(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		wantNum int
+	}{
+		{
+			name:    "explicit empty class",
+			src:     "package p\nvar _ = BundleError{Name: \"x\", Class: \"\"}\n",
+			wantNum: 1,
+		},
+		{
+			name:    "missing class key",
+			src:     "package p\nvar _ = BundleError{Name: \"x\", Reason: \"y\"}\n",
+			wantNum: 1,
+		},
+		{
+			name:    "keyed constant class is accepted",
+			src:     "package p\nvar _ = BundleError{Name: \"x\", Class: BundleErrorClassIntegrity}\n",
+			wantNum: 0,
+		},
+		{
+			name:    "classifier call is accepted",
+			src:     "package p\nvar _ = BundleError{Name: \"x\", Class: classifyBundleFileReadError(err)}\n",
+			wantNum: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bundleErrorClassViolations(t, tc.src); len(got) != tc.wantNum {
+				t.Fatalf("violations = %v (%d), want %d", got, len(got), tc.wantNum)
+			}
+		})
 	}
 }

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -104,6 +104,12 @@ func TestLoadResultErrorHelpers(t *testing.T) {
 	if got := (BundleError{}).ClassOrDefault(); got != BundleErrorClassIntegrity {
 		t.Fatalf("zero class default = %q, want %q (fail closed)", got, BundleErrorClassIntegrity)
 	}
+	// An unrecognized (e.g. typo'd) class value must also fail closed rather
+	// than pass through unrecognized and be tolerated by the strict integrity
+	// filter.
+	if got := (BundleError{Class: BundleErrorClass("unknown")}).ClassOrDefault(); got != BundleErrorClassIntegrity {
+		t.Fatalf("unknown class default = %q, want %q (fail closed)", got, BundleErrorClassIntegrity)
+	}
 
 	result := &LoadResult{
 		Errors: []BundleError{

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -99,8 +99,10 @@ func TestLoadResultErrorHelpers(t *testing.T) {
 	if got := nilResult.DegradedBundleNames(); got != nil {
 		t.Fatalf("nil DegradedBundleNames = %+v, want nil", got)
 	}
-	if got := (BundleError{}).ClassOrDefault(); got != BundleErrorClassAvailability {
-		t.Fatalf("zero class default = %q, want %q", got, BundleErrorClassAvailability)
+	// An unclassified (zero-value) error must default to integrity so it fails
+	// CLOSED in strict startup rather than silently booting degraded.
+	if got := (BundleError{}).ClassOrDefault(); got != BundleErrorClassIntegrity {
+		t.Fatalf("zero class default = %q, want %q (fail closed)", got, BundleErrorClassIntegrity)
 	}
 
 	result := &LoadResult{


### PR DESCRIPTION
An unclassified (zero-value Class) BundleError defaulted to the availability class, which strict startup tolerates by booting degraded. A future loader path that forgot to classify its failure would therefore weaken strict-mode enforcement silently.

This defaults an unclassified error to the integrity class so it fails closed in strict startup instead. Every current loader constructor already sets Class explicitly, so no existing path changes; it only hardens the fallback for a future error path that forgets to classify itself.

A new AST lint test asserts every BundleError literal in loader.go sets Class explicitly, and the accessor plus the strict-startup consumer test now assert the fail-closed direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strict startup validation by failing closed when bundle load failures are unclassified or have an unknown error class, treating them as integrity issues rather than availability-only degradation.

* **Tests**
  * Updated strict-mode failure aggregation expectations to reflect the new integrity-default behavior.
  * Added AST-based lint tests to ensure all bundle error constructors explicitly set a non-empty classification, and expanded coverage for detecting missing/empty class declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->