### PR TITLE
fix(mcp): fail closed on tampered rule bundles in strict mcp proxy

### DIFF
--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -822,6 +822,13 @@ Key-free evidence capture:
 			if bundleResult.Degraded {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: DEGRADED — standard pack failed, running core patterns only\n")
 			}
+			// Fail closed in strict mode on installed-bundle integrity loss,
+			// matching the main proxy server's startup path. Without this a
+			// strict `mcp proxy` would silently boot on core patterns only when
+			// a tampered bundle failed verification.
+			if err := strictRuleBundleIntegrityError(cfg, bundleResult); err != nil {
+				return err
+			}
 			extraPoison := rules.ConvertToolPoison(bundleResult.ToolPoison)
 
 			// Rebuild scanner with the (possibly modified) resolved config.

--- a/internal/cli/runtime/mcp_strict_bundle_test.go
+++ b/internal/cli/runtime/mcp_strict_bundle_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMCPProxyCmd_StrictBundleIntegrityFailsClosed proves `pipelock mcp proxy`
+// refuses to start in strict mode when an installed rule bundle fails integrity
+// verification, matching the main proxy server's startup behavior. Without the
+// fail-closed check the proxy would silently boot on core patterns only. The
+// refusal returns before any upstream dial, so the closed upstream port never
+// matters.
+func TestMCPProxyCmd_StrictBundleIntegrityFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	rulesDir := filepath.Join(dir, "rules")
+	bundleDir := filepath.Join(rulesDir, "pipelock-standard")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// bundle.yaml present but bundle.lock absent => integrity-class load error.
+	if err := os.WriteFile(filepath.Join(bundleDir, "bundle.yaml"), []byte("name: pipelock-standard\nversion: 2026.01.1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	cfgYAML := "mode: strict\napi_allowlist:\n  - api.vendor.example\nrules:\n  rules_dir: " + rulesDir + "\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := mcpProxyCmd()
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--config", cfgPath, "--upstream", "http://127.0.0.1:1/mcp"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "rule bundle integrity failure in strict mode") {
+		t.Fatalf("strict mcp proxy with integrity-failed bundle: err = %v, want integrity refusal\noutput:\n%s", err, out.String())
+	}
+}

--- a/internal/cli/runtime/mcp_strict_bundle_test.go
+++ b/internal/cli/runtime/mcp_strict_bundle_test.go
@@ -35,15 +35,32 @@ func TestMCPProxyCmd_StrictBundleIntegrityFailsClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := mcpProxyCmd()
-	cmd.SilenceUsage = true
-	cmd.SetArgs([]string{"--config", cfgPath, "--upstream", "http://127.0.0.1:1/mcp"})
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
+	// The strict integrity refusal fires in the shared runtime path after
+	// config resolve but before any upstream dial or subprocess spawn, so every
+	// transport mode must fail closed identically. Prove it on each rather than
+	// claim parity: HTTP/WebSocket upstream and stdio subprocess. The closed
+	// port / never-run command never matters because the refusal returns first.
+	transports := []struct {
+		name string
+		args []string
+	}{
+		{name: "http upstream", args: []string{"--upstream", "http://127.0.0.1:1/mcp"}},
+		{name: "websocket upstream", args: []string{"--upstream", "ws://127.0.0.1:1/mcp"}},
+		{name: "stdio subprocess", args: []string{"--", "cat"}},
+	}
+	for _, tc := range transports {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := mcpProxyCmd()
+			cmd.SilenceUsage = true
+			cmd.SetArgs(append([]string{"--config", cfgPath}, tc.args...))
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
 
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "rule bundle integrity failure in strict mode") {
-		t.Fatalf("strict mcp proxy with integrity-failed bundle: err = %v, want integrity refusal\noutput:\n%s", err, out.String())
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), "rule bundle integrity failure in strict mode") {
+				t.Fatalf("strict mcp proxy with integrity-failed bundle: err = %v, want integrity refusal\noutput:\n%s", err, out.String())
+			}
+		})
 	}
 }

--- a/internal/cli/runtime/server_rule_bundles.go
+++ b/internal/cli/runtime/server_rule_bundles.go
@@ -60,18 +60,31 @@ func (s *Server) reportStartupRuleBundleResult(cfg *config.Config, result *rules
 			_, _ = fmt.Fprintln(s.opts.Stderr, "pipelock: SECURITY WARNING: rules.allow_degraded=true; strict mode is booting with degraded rule-bundle integrity after explicit operator opt-in")
 		}
 	}
-	if cfg.Mode != config.ModeStrict || cfg.Rules.AllowDegraded {
+	return strictRuleBundleIntegrityError(cfg, result)
+}
+
+// strictRuleBundleIntegrityError returns a non-nil error when strict mode must
+// refuse to start because an installed bundle failed INTEGRITY verification and
+// the operator has not opted into rules.allow_degraded. It is the shared
+// fail-closed decision for every long-running runtime that merges rule bundles
+// (the main proxy server and `pipelock mcp proxy`), so a tampered installed
+// bundle cannot silently boot a strict deployment on core patterns only.
+// Availability failures (missing optional stores, transient read errors) never
+// refuse — only integrity loss does.
+func strictRuleBundleIntegrityError(cfg *config.Config, result *rules.LoadResult) error {
+	if result == nil || cfg.Mode != config.ModeStrict || cfg.Rules.AllowDegraded {
 		return nil
 	}
-	if integrityErrs := result.IntegrityErrors(); len(integrityErrs) > 0 {
-		details := make([]string, 0, len(integrityErrs))
-		for _, e := range integrityErrs {
-			details = append(details, fmt.Sprintf("%s: %s", e.Name, e.Reason))
-		}
-		return fmt.Errorf("rule bundle integrity failure in strict mode: %s (verify or reinstall the bundle(s), or set rules.allow_degraded: true only as an emergency override)",
-			strings.Join(details, "; "))
+	integrityErrs := result.IntegrityErrors()
+	if len(integrityErrs) == 0 {
+		return nil
 	}
-	return nil
+	details := make([]string, 0, len(integrityErrs))
+	for _, e := range integrityErrs {
+		details = append(details, fmt.Sprintf("%s: %s", e.Name, e.Reason))
+	}
+	return fmt.Errorf("rule bundle integrity failure in strict mode: %s (verify or reinstall the bundle(s), or set rules.allow_degraded: true only as an emergency override)",
+		strings.Join(details, "; "))
 }
 
 func reportReloadRuleBundleResult(stderr io.Writer, logger ruleBundleAuditLogger, cfg *config.Config, result *rules.LoadResult) {

--- a/internal/cli/runtime/server_rule_bundles_strict_test.go
+++ b/internal/cli/runtime/server_rule_bundles_strict_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/rules"
+)
+
+// TestStrictRuleBundleIntegrityError exercises the shared fail-closed decision
+// used by both the main server startup path and `pipelock mcp proxy`: strict
+// mode refuses to start only on installed-bundle INTEGRITY loss, never on
+// availability failures, and only when the operator has not opted into
+// rules.allow_degraded.
+func TestStrictRuleBundleIntegrityError(t *testing.T) {
+	t.Parallel()
+
+	integrity := rules.BundleError{Name: "pipelock-standard", Reason: "hash mismatch", Class: rules.BundleErrorClassIntegrity}
+	availability := rules.BundleError{Name: "community", Reason: "requires future feature", Class: rules.BundleErrorClassAvailability}
+
+	tests := []struct {
+		name         string
+		mode         string
+		allowDegrade bool
+		result       *rules.LoadResult
+		wantErr      bool
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{name: "nil result", mode: config.ModeStrict, result: nil, wantErr: false},
+		{name: "non-strict integrity tolerated", mode: config.ModeBalanced, result: &rules.LoadResult{Errors: []rules.BundleError{integrity}}, wantErr: false},
+		{name: "strict allow_degraded tolerated", mode: config.ModeStrict, allowDegrade: true, result: &rules.LoadResult{Errors: []rules.BundleError{integrity}}, wantErr: false},
+		{name: "strict availability-only tolerated", mode: config.ModeStrict, result: &rules.LoadResult{Errors: []rules.BundleError{availability}}, wantErr: false},
+		{name: "strict no errors", mode: config.ModeStrict, result: &rules.LoadResult{}, wantErr: false},
+		{
+			name: "strict integrity refuses", mode: config.ModeStrict,
+			result:       &rules.LoadResult{Errors: []rules.BundleError{integrity}},
+			wantErr:      true,
+			wantContains: []string{"strict mode", "pipelock-standard: hash mismatch", "allow_degraded"},
+		},
+		{
+			name: "strict mixed names only integrity", mode: config.ModeStrict,
+			result:       &rules.LoadResult{Errors: []rules.BundleError{integrity, availability}},
+			wantErr:      true,
+			wantContains: []string{"pipelock-standard: hash mismatch"},
+			wantAbsent:   []string{"community"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.Defaults()
+			cfg.Mode = tt.mode
+			cfg.Rules.AllowDegraded = tt.allowDegrade
+
+			err := strictRuleBundleIntegrityError(cfg, tt.result)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("strictRuleBundleIntegrityError err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if err == nil {
+				return
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want substring %q", err.Error(), want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(err.Error(), absent) {
+					t.Errorf("error = %q, must not mention availability-only failure %q", err.Error(), absent)
+				}
+			}
+		})
+	}
+}
+
+// TestStrictRuleBundleIntegrityError_RealBundleLoad proves the decision against
+// a real rules.MergeIntoConfig load of an installed bundle whose lock file is
+// missing (an integrity failure), matching exactly what the runtime feeds the
+// helper. Strict refuses; balanced and strict+allow_degraded tolerate.
+func TestStrictRuleBundleIntegrityError_RealBundleLoad(t *testing.T) {
+	t.Parallel()
+
+	rulesDir := t.TempDir()
+	bundleDir := filepath.Join(rulesDir, "pipelock-standard")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// bundle.yaml present but bundle.lock absent => integrity-class load error.
+	if err := os.WriteFile(filepath.Join(bundleDir, "bundle.yaml"), []byte("name: pipelock-standard\nversion: 2026.01.1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Defaults()
+	cfg.Rules.RulesDir = rulesDir
+	result := rules.MergeIntoConfig(cfg, "3.0.0")
+	if len(result.IntegrityErrors()) == 0 {
+		t.Fatalf("expected an integrity-class load error, got errors: %+v", result.Errors)
+	}
+
+	cfg.Mode = config.ModeStrict
+	if err := strictRuleBundleIntegrityError(cfg, result); err == nil {
+		t.Fatal("strict mode must refuse a real integrity-failed bundle load")
+	} else if !strings.Contains(err.Error(), "pipelock-standard") {
+		t.Fatalf("error = %q, want the failing bundle named", err.Error())
+	}
+
+	cfg.Mode = config.ModeBalanced
+	if err := strictRuleBundleIntegrityError(cfg, result); err != nil {
+		t.Fatalf("balanced mode must tolerate a degraded bundle, got %v", err)
+	}
+
+	cfg.Mode = config.ModeStrict
+	cfg.Rules.AllowDegraded = true
+	if err := strictRuleBundleIntegrityError(cfg, result); err != nil {
+		t.Fatalf("strict + allow_degraded must tolerate, got %v", err)
+	}
+}


### PR DESCRIPTION
`pipelock mcp proxy` is a long-running MCP enforcement boundary, but it loaded rule bundles and only printed a warning plus a DEGRADED notice when an installed bundle failed integrity verification. A strict-mode proxy would therefore silently boot on core patterns only after an installed bundle was tampered with, while the main proxy server's startup path already refuses to start in that case.

This extracts that refusal into a shared strictRuleBundleIntegrityError helper and calls it from both the server startup path (behavior unchanged) and mcp proxy, so both fail closed identically on installed-bundle integrity loss in strict mode unless rules.allow_degraded is set.

`mcp scan` stays warn-only because it is a one-shot stdin diagnostic, not an enforcement boundary. The no-installed-bundles case and availability-only failures still start normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - In strict mode, MCP proxy now fails closed when rule bundle integrity verification fails, rather than proceeding with a partial configuration.
  - Maintains existing behavior for balanced mode, including support for configured “allow degraded” operation.
- **Tests**
  - Added automated coverage for strict-mode integrity fail-closed behavior, including scenarios with missing bundle lockfiles.
  - Expanded CLI tests to validate early failure across supported transport variants.
- **Refactor**
  - Streamlined strict-mode integrity failure handling logic while preserving prior outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->