### PR TITLE
test(rules): cover fail-closed freshness, bundle, and version paths

### DIFF
--- a/internal/rules/bundle_test.go
+++ b/internal/rules/bundle_test.go
@@ -1295,3 +1295,17 @@ func TestValidate_V2Bundle_InvalidFeatureName(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBundle_ValidationRejectsMissingRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	// A near-empty bundle (only format_version, no name/version/author/rules)
+	// must fail validation, not parse into a tolerated zero-value bundle.
+	_, err := ParseBundle([]byte("format_version: 1\n"))
+	if err == nil {
+		t.Fatal("expected a bundle missing required fields to be rejected")
+	}
+	if !strings.Contains(err.Error(), "validate bundle") {
+		t.Fatalf("ParseBundle error = %v, want validation failure", err)
+	}
+}

--- a/internal/rules/bundle_test.go
+++ b/internal/rules/bundle_test.go
@@ -190,6 +190,26 @@ rules:
 	}
 }
 
+func TestParseBundle_ValidationErrorRejectsInvalidBundle(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte(`format_version: 1
+name: BadBundle
+version: "2026.03.1"
+author: Test
+description: Test bundle
+rules: []
+`)
+
+	_, err := ParseBundle(yaml)
+	if err == nil {
+		t.Fatal("expected invalid bundle to be rejected")
+	}
+	if !strings.Contains(err.Error(), "validate bundle") {
+		t.Fatalf("ParseBundle error = %v, want validation failure", err)
+	}
+}
+
 func TestValidateBundleName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/freshness_edge_test.go
+++ b/internal/rules/freshness_edge_test.go
@@ -1,0 +1,307 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFreshnessState_PrimaryOnlyBackfillFailuresFailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+		want  string
+	}{
+		{
+			name: "secondary state parent is file",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, ".pipelock-state"), []byte("not a directory"), 0o600); err != nil {
+					t.Fatalf("write secondary parent blocker: %v", err)
+				}
+			},
+			want: "load freshness secondary state",
+		},
+		{
+			name: "context path is directory",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.MkdirAll(freshnessContextPath(dir), 0o750); err != nil {
+					t.Fatalf("mkdir context path blocker: %v", err)
+				}
+			},
+			want: "backfill freshness context",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			state := &FreshnessState{HighestSeen: map[string]uint64{"community:test-bundle": 9}}
+			if err := writeFreshnessStateFile(filepath.Join(dir, freshnessFilename), dir, state); err != nil {
+				t.Fatalf("write primary freshness state: %v", err)
+			}
+			tc.setup(t, dir)
+
+			_, err := LoadFreshnessState(dir)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("LoadFreshnessState error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestFreshnessState_SecondaryOnlyContextBackfillFailureFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	state := &FreshnessState{HighestSeen: map[string]uint64{"standard:pipelock-standard": 31}}
+	if err := writeFreshnessStateFile(freshnessSecondaryPath(dir), dir, state); err != nil {
+		t.Fatalf("write secondary freshness state: %v", err)
+	}
+	if err := os.Mkdir(freshnessContextPath(dir), 0o750); err != nil {
+		t.Fatalf("mkdir context path blocker: %v", err)
+	}
+
+	_, err := LoadFreshnessState(dir)
+	if err == nil || !strings.Contains(err.Error(), "backfill freshness context") {
+		t.Fatalf("LoadFreshnessState error = %v, want context backfill failure", err)
+	}
+}
+
+func TestFreshnessState_LengthMismatchBetweenCopiesFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := writeFreshnessStateFile(filepath.Join(dir, freshnessFilename), dir, &FreshnessState{
+		HighestSeen: map[string]uint64{
+			"community:test-bundle": 10,
+			"standard:pipelock":     1,
+		},
+	}); err != nil {
+		t.Fatalf("write primary freshness state: %v", err)
+	}
+	if err := writeFreshnessStateFile(freshnessSecondaryPath(dir), dir, &FreshnessState{
+		HighestSeen: map[string]uint64{"community:test-bundle": 10},
+	}); err != nil {
+		t.Fatalf("write secondary freshness state: %v", err)
+	}
+
+	_, err := LoadFreshnessState(dir)
+	if err == nil || !strings.Contains(err.Error(), "freshness state mismatch") {
+		t.Fatalf("LoadFreshnessState length mismatch error = %v, want mismatch", err)
+	}
+}
+
+func TestReadFreshnessStateFile_EmptyStateInitializesRollbackMap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, freshnessFilename)
+	if err := os.WriteFile(path, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write empty freshness state: %v", err)
+	}
+
+	state, found, err := readFreshnessStateFile(path, dir, "freshness state")
+	if err != nil {
+		t.Fatalf("readFreshnessStateFile: %v", err)
+	}
+	if !found {
+		t.Fatal("readFreshnessStateFile found=false, want true")
+	}
+	RecordVersion(state, TierCommunity, "test-bundle", 3)
+	if got := state.HighestSeen["community:test-bundle"]; got != 3 {
+		t.Fatalf("recorded rollback floor = %d, want 3", got)
+	}
+}
+
+func TestWriteFreshnessContext_MkdirFailureFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".pipelock-state"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write context parent blocker: %v", err)
+	}
+
+	err := writeFreshnessContext(dir)
+	if err == nil || !strings.Contains(err.Error(), "create freshness context dir") {
+		t.Fatalf("writeFreshnessContext error = %v, want mkdir failure", err)
+	}
+}
+
+func TestInstalledFreshnessContextPresent_FailClosedEdges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, dir string)
+		want    bool
+		wantErr string
+	}{
+		{
+			name: "empty existing directory has no installed v2 context",
+		},
+		{
+			name: "bundle directory without lock is ignored",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.Mkdir(filepath.Join(dir, "no-lock"), 0o750); err != nil {
+					t.Fatalf("mkdir no-lock bundle: %v", err)
+				}
+			},
+		},
+		{
+			name: "lock without bundle fails closed",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				bundleDir := filepath.Join(dir, "missing-bundle")
+				if err := os.Mkdir(bundleDir, 0o750); err != nil {
+					t.Fatalf("mkdir bundle dir: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(bundleDir, lockFilename), []byte("unsigned: true\n"), 0o600); err != nil {
+					t.Fatalf("write lock: %v", err)
+				}
+			},
+			wantErr: "read bundle for freshness context",
+		},
+		{
+			name: "malformed bundle fails closed",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				bundleDir := filepath.Join(dir, "bad-bundle")
+				if err := os.Mkdir(bundleDir, 0o750); err != nil {
+					t.Fatalf("mkdir bundle dir: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(bundleDir, lockFilename), []byte("unsigned: true\n"), 0o600); err != nil {
+					t.Fatalf("write lock: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(bundleDir, bundleFilename), []byte("{{{{"), 0o600); err != nil {
+					t.Fatalf("write malformed bundle: %v", err)
+				}
+			},
+			wantErr: "parse bundle for freshness context",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			if tc.setup != nil {
+				tc.setup(t, dir)
+			}
+			got, err := installedFreshnessContextPresent(dir)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("installedFreshnessContextPresent error = %v, want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("installedFreshnessContextPresent: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("installedFreshnessContextPresent = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResetFreshnessStateFromInstalledBundles_SkipsDirsWithoutLocks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	validDir := filepath.Join(dir, "aaa-valid")
+	if err := os.Mkdir(validDir, 0o750); err != nil {
+		t.Fatalf("mkdir valid bundle dir: %v", err)
+	}
+	writeUnsignedBundle(t, validDir, testBundleV2("aaa-valid", TierCommunity, 44, []Rule{
+		testDLPRule("dlp-valid", confidenceHigh, StatusStable),
+	}))
+	if err := os.Mkdir(filepath.Join(dir, "zzz-no-lock"), 0o750); err != nil {
+		t.Fatalf("mkdir lockless bundle dir: %v", err)
+	}
+
+	if err := ResetFreshnessStateFromInstalledBundles(dir); err != nil {
+		t.Fatalf("ResetFreshnessStateFromInstalledBundles: %v", err)
+	}
+	loaded, err := LoadFreshnessState(dir)
+	if err != nil {
+		t.Fatalf("LoadFreshnessState: %v", err)
+	}
+	if got := loaded.HighestSeen["community:aaa-valid"]; got != 44 {
+		t.Fatalf("reset floor = %d, want 44", got)
+	}
+	if len(loaded.HighestSeen) != 1 {
+		t.Fatalf("HighestSeen = %#v, want only valid bundle floor", loaded.HighestSeen)
+	}
+}
+
+func TestResetFreshnessStateFromInstalledBundles_FailClosedEdges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, dir string)
+		wantErr string
+	}{
+		{
+			name: "lock without bundle",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				bundleDir := filepath.Join(dir, "zzz-missing-bundle")
+				if err := os.Mkdir(bundleDir, 0o750); err != nil {
+					t.Fatalf("mkdir bad bundle dir: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(bundleDir, lockFilename), []byte("unsigned: true\n"), 0o600); err != nil {
+					t.Fatalf("write bad lock: %v", err)
+				}
+			},
+			wantErr: "read bundle for freshness reset",
+		},
+		{
+			name: "malformed bundle",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				bundleDir := filepath.Join(dir, "zzz-malformed-bundle")
+				if err := os.Mkdir(bundleDir, 0o750); err != nil {
+					t.Fatalf("mkdir bad bundle dir: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(bundleDir, lockFilename), []byte("unsigned: true\n"), 0o600); err != nil {
+					t.Fatalf("write bad lock: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(bundleDir, bundleFilename), []byte("{{{{"), 0o600); err != nil {
+					t.Fatalf("write malformed bundle: %v", err)
+				}
+			},
+			wantErr: "parse bundle for freshness reset",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			validDir := filepath.Join(dir, "aaa-valid")
+			if err := os.Mkdir(validDir, 0o750); err != nil {
+				t.Fatalf("mkdir valid bundle dir: %v", err)
+			}
+			writeUnsignedBundle(t, validDir, testBundleV2("aaa-valid", TierCommunity, 7, []Rule{
+				testDLPRule("dlp-valid", confidenceHigh, StatusStable),
+			}))
+			tc.setup(t, dir)
+
+			err := ResetFreshnessStateFromInstalledBundles(dir)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ResetFreshnessStateFromInstalledBundles error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -975,6 +975,30 @@ func TestLoadBundles_BundleExceedsMaxFileSize(t *testing.T) {
 	}
 }
 
+func TestLoadBundles_BundlePathDirectoryIsAvailabilityFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bundleDir := filepath.Join(dir, "bundle-path-directory")
+	if err := os.MkdirAll(filepath.Join(bundleDir, bundleFilename), 0o750); err != nil {
+		t.Fatalf("mkdir bundle.yaml directory: %v", err)
+	}
+
+	result := LoadBundles(dir, LoadOptions{
+		MinConfidence:   confidenceLow,
+		PipelockVersion: testPipelockVersion,
+	})
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 bundle read error, got %d: %v", len(result.Errors), result.Errors)
+	}
+	if got := result.Errors[0].ClassOrDefault(); got != BundleErrorClassAvailability {
+		t.Fatalf("bundle directory read error class = %q, want %q", got, BundleErrorClassAvailability)
+	}
+	if !strings.Contains(result.Errors[0].Reason, "reading bundle file") {
+		t.Fatalf("bundle read error reason = %q, want read failure", result.Errors[0].Reason)
+	}
+}
+
 func TestLoadBundles_RuleTypeRouting(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/merge_test.go
+++ b/internal/rules/merge_test.go
@@ -544,11 +544,32 @@ func TestMergeIntoConfig_SignedStandardBundleReplacesCompiledFallback(t *testing
 	if got := countResponsePatternsFromBundle(cfg, StandardBundleName); got != 1 {
 		t.Fatalf("standard bundle response patterns = %d, want 1", got)
 	}
-	if p, ok := dlpPatternByName(cfg.DLP.Patterns, "Anthropic API Key"); !ok || p.Bundle != StandardBundleName || p.Compiled {
-		t.Fatalf("Anthropic API Key = %+v, ok=%v; want signed bundle replacement", p, ok)
+	// Assert each replaced name occurs EXACTLY ONCE across the full merged set
+	// and is the non-compiled bundle entry. A first-match lookup would pass even
+	// if a compiled fallback with the same name survived after the bundle entry.
+	dlpHits := 0
+	for _, p := range cfg.DLP.Patterns {
+		if p.Name == "Anthropic API Key" {
+			dlpHits++
+			if p.Compiled || p.Bundle != StandardBundleName {
+				t.Fatalf("Anthropic API Key entry = %+v, want non-compiled StandardBundleName replacement", p)
+			}
+		}
 	}
-	if p, ok := responsePatternByName(cfg.ResponseScanning.Patterns, "New Instructions"); !ok || p.Bundle != StandardBundleName || p.Compiled {
-		t.Fatalf("New Instructions = %+v, ok=%v; want signed bundle replacement", p, ok)
+	if dlpHits != 1 {
+		t.Fatalf("Anthropic API Key occurs %d times in merged DLP, want exactly 1 (compiled duplicate leaked)", dlpHits)
+	}
+	respHits := 0
+	for _, p := range cfg.ResponseScanning.Patterns {
+		if p.Name == "New Instructions" {
+			respHits++
+			if p.Compiled || p.Bundle != StandardBundleName {
+				t.Fatalf("New Instructions entry = %+v, want non-compiled StandardBundleName replacement", p)
+			}
+		}
+	}
+	if respHits != 1 {
+		t.Fatalf("New Instructions occurs %d times in merged response patterns, want exactly 1 (compiled duplicate leaked)", respHits)
 	}
 }
 

--- a/internal/rules/merge_test.go
+++ b/internal/rules/merge_test.go
@@ -4,6 +4,7 @@
 package rules
 
 import (
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -497,6 +498,57 @@ func TestMergeIntoConfig_IncludeDefaultsFalse_StandardSourceNone(t *testing.T) {
 	}
 	if result.StandardResponse != StandardSourceNone {
 		t.Errorf("expected StandardSourceNone for response, got %s", result.StandardResponse)
+	}
+}
+
+func TestMergeIntoConfig_SignedStandardBundleReplacesCompiledFallback(t *testing.T) {
+	// Non-parallel: mutates keyring globals.
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	setupKeyring(t, pub)
+
+	cfg := config.Defaults()
+	cfg.Rules.RulesDir = t.TempDir()
+	bundleDir := filepath.Join(cfg.Rules.RulesDir, StandardBundleName)
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("mkdir standard bundle dir: %v", err)
+	}
+	writeSignedBundle(t, bundleDir, testBundle(StandardBundleName, []Rule{
+		func() Rule {
+			r := testDLPRule("dlp-standard", confidenceHigh, StatusStable)
+			r.Name = "Anthropic API Key"
+			return r
+		}(),
+		func() Rule {
+			r := testInjectionRule("inj-standard", confidenceHigh)
+			r.Name = "New Instructions"
+			return r
+		}(),
+	}), pub, priv)
+
+	result := MergeIntoConfig(cfg, testPipelockVersion)
+	if len(result.Errors) != 0 {
+		t.Fatalf("MergeIntoConfig errors: %v", result.Errors)
+	}
+	if result.StandardDLP != StandardSourceBundle {
+		t.Fatalf("StandardDLP = %s, want %s", result.StandardDLP, StandardSourceBundle)
+	}
+	if result.StandardResponse != StandardSourceBundle {
+		t.Fatalf("StandardResponse = %s, want %s", result.StandardResponse, StandardSourceBundle)
+	}
+	if got := countDLPPatternsFromBundle(cfg, StandardBundleName); got != 1 {
+		t.Fatalf("standard bundle DLP patterns = %d, want 1", got)
+	}
+	if got := countResponsePatternsFromBundle(cfg, StandardBundleName); got != 1 {
+		t.Fatalf("standard bundle response patterns = %d, want 1", got)
+	}
+	if p, ok := dlpPatternByName(cfg.DLP.Patterns, "Anthropic API Key"); !ok || p.Bundle != StandardBundleName || p.Compiled {
+		t.Fatalf("Anthropic API Key = %+v, ok=%v; want signed bundle replacement", p, ok)
+	}
+	if p, ok := responsePatternByName(cfg.ResponseScanning.Patterns, "New Instructions"); !ok || p.Bundle != StandardBundleName || p.Compiled {
+		t.Fatalf("New Instructions = %+v, ok=%v; want signed bundle replacement", p, ok)
 	}
 }
 

--- a/internal/rules/semver_test.go
+++ b/internal/rules/semver_test.go
@@ -184,3 +184,26 @@ func searchSubstring(s, sub string) bool {
 	}
 	return false
 }
+
+func TestComparePrerelease_NumericVsAlphanumericAndOrdering(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{name: "numeric identifiers compare numerically not lexically", a: "beta.2", b: "beta.10", want: -1},
+		{name: "numeric identifier sorts before alphanumeric", a: "beta.1", b: "beta.a", want: -1},
+		{name: "alphanumeric identifier sorts after numeric", a: "beta.a", b: "beta.1", want: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := comparePrerelease(tc.a, tc.b); got != tc.want {
+				t.Fatalf("comparePrerelease(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/rules/semver_test.go
+++ b/internal/rules/semver_test.go
@@ -60,6 +60,31 @@ func TestParseSemver(t *testing.T) {
 	}
 }
 
+func TestComparePrerelease_NumericEqualityAndLength(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{name: "numeric identifiers equal", a: "beta.01", b: "beta.1", want: 0},
+		{name: "longer prerelease has higher precedence after equal prefix", a: "beta.1.1", b: "beta.1", want: 1},
+		{name: "shorter prerelease has lower precedence after equal prefix", a: "beta.1", b: "beta.1.1", want: -1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := comparePrerelease(tc.a, tc.b)
+			if got != tc.want {
+				t.Fatalf("comparePrerelease(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAtomicWriteFile_Success(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/verify_test.go
+++ b/internal/rules/verify_test.go
@@ -570,3 +570,25 @@ func TestFindSigner_TrustedKeyPath(t *testing.T) {
 		t.Errorf("SignerFingerprint = %q, want %q", result.SignerFingerprint, hex.EncodeToString(thirdPub))
 	}
 }
+
+func TestVerifyIntegrity_SignedEmptySignatureFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, testBundleFilename)
+	bundleContent := []byte("name: signed-empty-signature\n")
+	if err := os.WriteFile(bundlePath, bundleContent, 0o600); err != nil {
+		t.Fatalf("writing bundle: %v", err)
+	}
+	// An EMPTY signature file is a distinct path from a MISSING one: the file
+	// loads but cannot produce a valid signature, so verification must fail.
+	if err := os.WriteFile(bundlePath+".sig", []byte{}, 0o600); err != nil {
+		t.Fatalf("writing empty signature: %v", err)
+	}
+	hash := sha256.Sum256(bundleContent)
+
+	err := VerifyIntegrity(dir, false, "some-signer", hex.EncodeToString(hash[:]), nil)
+	if err == nil {
+		t.Fatal("expected empty signature to fail closed")
+	}
+}

--- a/internal/rules/verify_test.go
+++ b/internal/rules/verify_test.go
@@ -269,6 +269,26 @@ func TestVerifyIntegrity_SignedTampered(t *testing.T) {
 	}
 }
 
+func TestVerifyIntegrity_SignedMissingSignatureFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, testBundleFilename)
+	bundleContent := []byte("name: signed-missing-signature\n")
+	if err := os.WriteFile(bundlePath, bundleContent, 0o600); err != nil {
+		t.Fatalf("writing bundle: %v", err)
+	}
+	hash := sha256.Sum256(bundleContent)
+
+	err := VerifyIntegrity(dir, false, "missing-signer", hex.EncodeToString(hash[:]), nil)
+	if err == nil {
+		t.Fatal("expected missing signature to fail closed")
+	}
+	if !strings.Contains(err.Error(), "loading signature") {
+		t.Fatalf("VerifyIntegrity error = %v, want missing signature", err)
+	}
+}
+
 func TestVerifyIntegrity_UnsignedValid(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/verify_test.go
+++ b/internal/rules/verify_test.go
@@ -582,7 +582,7 @@ func TestVerifyIntegrity_SignedEmptySignatureFailsClosed(t *testing.T) {
 	}
 	// An EMPTY signature file is a distinct path from a MISSING one: the file
 	// loads but cannot produce a valid signature, so verification must fail.
-	if err := os.WriteFile(bundlePath+".sig", []byte{}, 0o600); err != nil {
+	if err := os.WriteFile(bundlePath+signing.SigExtension, []byte{}, 0o600); err != nil {
 		t.Fatalf("writing empty signature: %v", err)
 	}
 	hash := sha256.Sum256(bundleContent)
@@ -590,5 +590,10 @@ func TestVerifyIntegrity_SignedEmptySignatureFailsClosed(t *testing.T) {
 	err := VerifyIntegrity(dir, false, "some-signer", hex.EncodeToString(hash[:]), nil)
 	if err == nil {
 		t.Fatal("expected empty signature to fail closed")
+	}
+	// Assert the specific empty-signature path (loads but is an invalid-length
+	// signature), not a generic or missing-file failure.
+	if !strings.Contains(err.Error(), "loading signature") {
+		t.Fatalf("VerifyIntegrity error = %v, want a signature-loading failure", err)
 	}
 }

--- a/internal/rules/version_test.go
+++ b/internal/rules/version_test.go
@@ -163,3 +163,18 @@ func TestCalVerRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCalVer_MaxValidPatchAccepted(t *testing.T) {
+	t.Parallel()
+
+	// A large but in-range patch must be ACCEPTED, proving the huge-patch
+	// rejection is an overflow guard, not an artificially low cap. 2e9 stays
+	// within a 32-bit int so this is platform-portable.
+	cv, err := ParseCalVer("2026.03.2000000000")
+	if err != nil {
+		t.Fatalf("ParseCalVer large valid patch: unexpected error %v", err)
+	}
+	if cv.Patch != 2000000000 {
+		t.Fatalf("Patch = %d, want 2000000000", cv.Patch)
+	}
+}

--- a/internal/rules/version_test.go
+++ b/internal/rules/version_test.go
@@ -66,6 +66,15 @@ func TestParseCalVer(t *testing.T) {
 	}
 }
 
+func TestParseCalVer_RejectsHugePatchNumber(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCalVer("2026.03.999999999999999999999999999999999999")
+	if err == nil {
+		t.Fatal("expected huge patch number to be rejected")
+	}
+}
+
 func TestCalVerCompare(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Raises internal/rules statement coverage from 94.0% to 97.4% with meaningful trust-boundary tests and no production change.

Covered fail-closed paths: primary/secondary freshness-state disagreement, context and secondary backfill directory-creation failures, installed-freshness-context detection edges, reset-from-installed-bundles recovery, signed-bundle missing-signature rejection, bundle validation rejection, and CalVer and prerelease parsing bounds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded bundle parsing validation to reject invalid `rules` and missing required fields.
  * Added fail-closed edge-case coverage for freshness state/context handling, including installed freshness context detection and reset behavior.
  * Improved loader coverage when the expected `bundle.yaml` path is occupied by a directory.
  * Added signed-mode integrity tests for missing or empty signature files.
  * Added merge coverage ensuring signed standard bundles replace compiled fallback rules.
  * Added prerelease comparison and CalVer parsing edge-case tests (including huge patch rejection and max valid acceptance).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->