### PR TITLE
fix(release): fail closed on incomplete attestation and non-semver tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,15 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'  # Semver only — excludes floating tags like v1, v2
+      - 'v*.*.*'  # Coarse prefilter: v-prefixed with at least two dots (the wildcards also match extra dots like v1.2.3.4; excludes floating v1/v2). Strict SemVer is enforced in the release-preflight gate (check-release-ready.sh).
+
+# Serialize release publications so two overlapping tag pushes cannot race on the
+# GoReleaser uploads or the shared force-updated v2 tag (an older run could
+# otherwise overwrite a newer completed release pointer). Do not cancel a run in
+# progress: a half-finished publish must complete, not be interrupted.
+concurrency:
+  group: release-publication
+  cancel-in-progress: false
 
 permissions: {}
 
@@ -297,6 +305,7 @@ jobs:
           subject-path: dist/checksums.txt
 
       - name: Attest SBOM
+        id: attest-sbom
         continue-on-error: true
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
@@ -367,13 +376,21 @@ jobs:
           subject-digest: ${{ steps.license-service-digest.outputs.digest }}
           push-to-registry: true
 
+      # Fail closed: any attestation that did not SUCCEED blocks the release.
+      # `!= 'success'` (not `== 'failure'`) also catches a SKIPPED container
+      # attest step, which happens when its digest step could not resolve the
+      # image — otherwise a missing-digest container publishes with no
+      # provenance while this gate still reports success. `always()` ensures the
+      # gate runs even if an earlier step failed.
       - name: Verify attestation
         if: >-
-          steps.attest-binaries.outcome == 'failure' ||
-          steps.attest-checksums.outcome == 'failure' ||
-          steps.attest-pipelock-container.outcome == 'failure' ||
-          steps.attest-pipelock-init-container.outcome == 'failure' ||
-          steps.attest-license-service-container.outcome == 'failure'
+          always() && (
+          steps.attest-binaries.outcome != 'success' ||
+          steps.attest-checksums.outcome != 'success' ||
+          steps.attest-sbom.outcome != 'success' ||
+          steps.attest-pipelock-container.outcome != 'success' ||
+          steps.attest-pipelock-init-container.outcome != 'success' ||
+          steps.attest-license-service-container.outcome != 'success' )
         run: |
           echo "::error::Attestation failed — release provenance is incomplete"
           exit 1

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -23,7 +23,29 @@ if [ -z "$VERSION" ]; then
   echo "check-release-ready: no version given and GITHUB_REF_NAME unset" >&2
   exit 2
 fi
-VER="${VERSION#v}" # strip leading v -> bare semver used in CHANGELOG/Chart
+# 0. Release tag format. The version is used verbatim as an OCI/Docker image tag
+# and as attestation subject names, so it must be v-prefixed SemVer with an
+# OPTIONAL prerelease and NO build metadata: '+' is invalid in an OCI/Docker tag
+# (tagChars is [A-Za-z0-9_.-]), so a '+build' version would pass an abstract-SemVer
+# check yet break the container publish or mismatch the provenance subject. This
+# gate is the real guard (the 'v*.*.*' release trigger is only a coarse prefilter
+# that also matches v1.2.beta and v1.2.3.4), so a malformed tag fails
+# closed BEFORE anything is built or pushed.
+release_tag_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?$'
+if ! printf '%s\n' "$VERSION" | grep -qE "$release_tag_re"; then
+  echo "check-release-ready: tag '$VERSION' must be vMAJOR.MINOR.PATCH[-prerelease] with no build metadata" >&2
+  exit 2
+fi
+
+VER="${VERSION#v}" # strip leading v -> bare semver used in CHANGELOG/Chart and as the OCI image tag
+
+# The v-stripped version is used verbatim as an OCI/Docker image tag, which is
+# capped at 128 characters; a longer tag passes the format check above yet fails
+# only once container publishing begins.
+if [ "${#VER}" -gt 128 ]; then
+  echo "check-release-ready: tag '$VERSION' exceeds the 128-character OCI image-tag limit" >&2
+  exit 2
+fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CHANGELOG="$REPO_ROOT/CHANGELOG.md"


### PR DESCRIPTION
## What changed

The release attestation verifier only tripped on `outcome == 'failure'`, so a container whose digest could not be resolved was skipped and the SBOM attestation (which had no step id) was never checked. A release could publish with incomplete provenance while the gate still reported success.

The verifier now checks `!= 'success'` for every attestation step (binaries, checksums, SBOM, and all three container images), the SBOM step gets an id, and it runs under `always()` so it fires even after an earlier failure. A skipped container attestation (unresolved digest) or a failed SBOM attestation now fails the release closed.

Strict SemVer validation is added to the release-preflight gate. The `v*.*.*` trigger glob is only a coarse prefilter that also accepts names like `v1.2.beta` or `v1.2.3.4`, so the gate now rejects any non-SemVer tag before anything is built or pushed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release tags are now strictly validated as `vMAJOR.MINOR.PATCH` (SemVer 2.0.0), allowing an optional prerelease but disallowing build metadata, before any release-readiness checks run (including a length safeguard).
  * Release verification is now fail-closed: the release is blocked unless all required attestation checks succeed.
  * Missing or skipped attestation outcomes—such as absent digests—are treated as unsuccessful, preventing partially verified releases from being approved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->