### PR TITLE
docs(counterparty): mark the counterparty verifier as reserved foundation

### DIFF
--- a/docs/evidence/hard-limits.md
+++ b/docs/evidence/hard-limits.md
@@ -12,7 +12,7 @@ These limits are not loopholes in receipt verification. They are the boundary of
 
 **Why no rung closes it:** The receipt chain can prove byte integrity, ordering, and signer binding for records it sees. This limit describes a condition outside that in-domain proof.
 
-**Bound:** C2 second recorder / C4 counterparty (separately keyed).
+**Bound:** C2 second recorder / C4 counterparty (separately keyed; reserved and not yet available through an operator entry point).
 
 **How the verifier surfaces it:** Passing verification prints `L-KEYHOLDER-OMIT` with this summary when the verified surface is subject to the limit.
 

--- a/enterprise/counterparty/counterparty.go
+++ b/enterprise/counterparty/counterparty.go
@@ -3,8 +3,13 @@
 // Copyright 2026 Pipelock contributors
 // Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
-// Package counterparty verifies enterprise-only side records that bind two
-// already-existing receipts to the same transmitted payload.
+// Package counterparty is a reserved enterprise verification library for side
+// records that bind two already-existing receipts to the same transmitted
+// payload. The counterparty-attestation verifier and replay store are
+// implemented and unit-tested, but are not wired to an operator entry point:
+// there is no CLI command, API handler, or SDK export for operators to invoke
+// today. This is foundation for a future release, not a shipped operator
+// feature.
 //
 // The binding lives beside the core receipt stream as its own signed side
 // record (counterparty_receipt_v1). No field here is added to the v1

--- a/enterprise/counterparty/replaystore.go
+++ b/enterprise/counterparty/replaystore.go
@@ -124,7 +124,8 @@ func (s *MemReplayStore) CommitIfNew(entry ReplayEntry) error {
 }
 
 // Compact implements CompactableReplayStore; see CompactableReplayStore for the
-// caller's freshness contract.
+// caller's freshness contract. The in-memory store grows unbounded until a
+// caller invokes Compact, so any future operator wiring MUST schedule Compact.
 func (s *MemReplayStore) Compact(before time.Time) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -345,7 +346,8 @@ func (s *FileReplayStore) CommitIfNew(entry ReplayEntry) error {
 // Compact implements CompactableReplayStore. It rewrites the durable JSONL file
 // atomically and keeps any entry whose nonce or transfer key is still inside its
 // retention horizon. See CompactableReplayStore for the caller's freshness
-// contract.
+// contract. The durable store grows unbounded until a caller invokes Compact, so
+// any future operator wiring MUST schedule Compact.
 func (s *FileReplayStore) Compact(before time.Time) (removed int, err error) {
 	s.opMu.Lock()
 	defer s.opMu.Unlock()

--- a/internal/evidence/limits.go
+++ b/internal/evidence/limits.go
@@ -30,7 +30,7 @@ const (
 )
 
 var Limits = []Limit{
-	{ID: LimitKeyholderOmit, Title: "Keyholder Omission", Category: "completeness", Summary: "No in-domain mechanism proves completeness against the party holding the signing key.", Bound: "C2 second recorder / C4 counterparty (separately keyed)."},
+	{ID: LimitKeyholderOmit, Title: "Keyholder Omission", Category: "completeness", Summary: "No in-domain mechanism proves completeness against the party holding the signing key.", Bound: "C2 second recorder / C4 counterparty (separately keyed; reserved and not yet available through an operator entry point)."},
 	{ID: LimitOmitPreAnchor, Title: "Pre-Anchor Omission", Category: "completeness", Summary: "Whole-session omission BEFORE the first anchor is undetectable.", Bound: "Anchor interval + genesis anchor_head binding."},
 	{ID: LimitForgedKey, Title: "Compromised Signing Key", Category: "completeness", Summary: "A record forged under a COMPROMISED signing key is in-domain indistinguishable from a real one.", Bound: "Anchor interval + C2 (attacker lacks the agent-side key)."},
 	{ID: LimitRecorderBinary, Title: "Recorder Binary Trust", Category: "recorder-integrity", Summary: "A malicious/modified recorder binary IS the attacker; its output cannot vouch for itself.", Bound: "Release signing + contain-install binary-hash TOFU pin + external attestation."},


### PR DESCRIPTION
## What changed

The enterprise counterparty-attestation verifier and its replay store are fully implemented and unit-tested, but nothing wires them to an operator entry point: there is no CLI command, API handler, or SDK export, and the caller-driven replay-store compaction has no caller. As shipped, the package reads as an available operator feature when it is not actually reachable in the binary.

This marks the package as reserved foundation rather than a shipped feature. The package doc now states plainly that the verifier and store are implemented and tested but not yet wired to an operator entry point, both replay-store Compact methods document that the store grows unbounded until a caller invokes them, and the one evidence-limit reference that mentioned it is softened to reserved and not yet available. No verification logic or test is changed.

Wiring a real operator entry point (a CLI or API around the existing verifier, with a scheduled Compact) is a separate product decision, deliberately left out of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that certain counterparty verification capabilities are reserved and not currently available through operator interfaces.
  * Documented that replay stores can grow without limit until maintenance is scheduled.
  * Refined hard-limit descriptions with additional details about separate keying and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->