### PR TITLE
fix(dashboard): enforce OIDC mapped role permissions on dashboard routes

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -257,7 +257,20 @@ Example OIDC role map:
 }
 ```
 
-### License resolution
+#### Upgrade note: OIDC route permissions are now enforced
+
+Earlier releases derived dashboard route permissions from the operator-token
+tier alone, so any authenticated OIDC principal reached every metadata-tier
+view regardless of the permissions its mapped role granted. Only raw-view
+access consulted the role map. Route permissions now come from the mapped
+role, which is the behavior this page has always described.
+
+If an OIDC role map was written against the earlier behavior it may be
+narrower than the access its users actually had, and those users will lose
+views they previously reached. Before upgrading, confirm each role in
+`--oidc-role-map` lists every permission its holders need. A principal that
+reaches a view it is not mapped for is denied, and the denial names the
+missing permission in the audit log.
 
 `dashboard serve` loads `--config` only when the flag is provided, using the
 normal Pipelock config loader. The loaded config feeds the `/exemptions` view;

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -326,7 +326,7 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 	// permissions and takes precedence over any token or OIDC principal on the
 	// same request.
 	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
-		clientCertAuth, authorization.metaAuthorized, authorization.rawAuthorized,
+		clientCertAuth, authorization.metaAuthorized, authorization.authorizePermission, authorization.rawAuthorized,
 	)
 	authenticated := metaAuthorized
 

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -325,9 +325,7 @@ func runDashboardServe(cmd *cobra.Command, opts dashboardServeOptions, lic licen
 	// verified certificate's mapped role supplies both route and raw-view
 	// permissions and takes precedence over any token or OIDC principal on the
 	// same request.
-	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
-		clientCertAuth, authorization.metaAuthorized, authorization.authorizePermission, authorization.rawAuthorized,
-	)
+	metaAuthorized, authorizePermission, rawAuthorized := dashboardServeAuthorizers(clientCertAuth, authorization)
 	authenticated := metaAuthorized
 
 	auditWriter := cmd.ErrOrStderr()

--- a/enterprise/cli/dashboard_mtls.go
+++ b/enterprise/cli/dashboard_mtls.go
@@ -190,6 +190,29 @@ func (a *dashboardClientCertAuthorizer) authorizeRaw(r *http.Request) error {
 	return a.authorizePermission(r, dashboard.PermissionRawRead)
 }
 
+// dashboardServeAuthorizers builds the authorizers the serve path installs. It
+// owns WHICH authorization callbacks reach the composer, which is the part that
+// regressed once: deriving route permissions from the metadata and raw booleans
+// grants every metadata-tier permission to any authenticated principal and
+// ignores its mapped role. Route permissions must come from
+// authorization.authorizePermission, which consults the principal's mapped
+// permissions before falling back to the token tier.
+func dashboardServeAuthorizers(
+	clientCertAuth *dashboardClientCertAuthorizer,
+	authorization *dashboardRequestAuthorization,
+) (
+	func(*http.Request) bool,
+	func(*http.Request, dashboard.Permission) error,
+	func(*http.Request) bool,
+) {
+	return dashboardClientCertAuthorizers(
+		clientCertAuth,
+		authorization.metaAuthorized,
+		authorization.authorizePermission,
+		authorization.rawAuthorized,
+	)
+}
+
 func dashboardClientCertAuthorizers(
 	clientCertAuth *dashboardClientCertAuthorizer,
 	tokenMetaAuthorized func(*http.Request) bool,

--- a/enterprise/cli/dashboard_mtls.go
+++ b/enterprise/cli/dashboard_mtls.go
@@ -193,6 +193,7 @@ func (a *dashboardClientCertAuthorizer) authorizeRaw(r *http.Request) error {
 func dashboardClientCertAuthorizers(
 	clientCertAuth *dashboardClientCertAuthorizer,
 	tokenMetaAuthorized func(*http.Request) bool,
+	tokenAuthorizePermission func(*http.Request, dashboard.Permission) error,
 	tokenRawAuthorized func(*http.Request) bool,
 ) (
 	func(*http.Request) bool,
@@ -217,10 +218,16 @@ func dashboardClientCertAuthorizers(
 		}
 		return tokenRawAuthorized(r)
 	}
-	tokenAuthorizePermission := dashboardAuthorizePermissionFunc(tokenMetaAuthorized, tokenRawAuthorized)
+	// The caller supplies the permission authorizer so an OIDC principal's mapped
+	// role decides route permissions. Deriving it here from the metadata/raw
+	// booleans alone would grant every metadata-tier permission to any
+	// authenticated principal, ignoring the configured role map.
 	authorizePermission := func(r *http.Request, permission dashboard.Permission) error {
 		if clientCertAuth != nil {
 			return clientCertAuth.authorizePermission(r, permission)
+		}
+		if tokenAuthorizePermission == nil {
+			return errors.New("dashboard permission authorizer is not configured")
 		}
 		return tokenAuthorizePermission(r, permission)
 	}

--- a/enterprise/cli/dashboard_mtls_test.go
+++ b/enterprise/cli/dashboard_mtls_test.go
@@ -459,6 +459,10 @@ func TestDashboardClientCertAuthorizers_VerifiedChainCannotFallThroughToRawToken
 	_, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
 		authorizer,
 		func(*http.Request) bool { return true },
+		func(*http.Request, dashboard.Permission) error {
+			t.Fatal("mTLS route permission fell through to token authorizer")
+			return nil
+		},
 		func(*http.Request) bool { return true },
 	)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil)
@@ -492,6 +496,10 @@ func TestDashboardClientCertAuthorizers_NoTokenFallbackWhenMTLSEnabled(t *testin
 	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
 		authorizer,
 		func(*http.Request) bool { return true },
+		func(*http.Request, dashboard.Permission) error {
+			t.Fatal("mTLS route permission fell through to token authorizer")
+			return nil
+		},
 		func(*http.Request) bool { return true },
 	)
 	// A request carrying a matching operator token but NO client certificate:
@@ -508,6 +516,101 @@ func TestDashboardClientCertAuthorizers_NoTokenFallbackWhenMTLSEnabled(t *testin
 	}
 	if err := authorizePermission(req, dashboard.PermissionEvidenceRead); err == nil {
 		t.Fatal("mTLS mode granted route permission to a certificate-less request via token fallback")
+	}
+}
+
+func TestDashboardClientCertAuthorizers_TokenOnlyPermissionBehavior(t *testing.T) {
+	reqWithBearer := func(token string) *http.Request {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		return req
+	}
+
+	tests := []struct {
+		name         string
+		metadata     string
+		raw          string
+		token        string
+		wantMeta     bool
+		wantRaw      bool
+		wantEvidence bool
+		wantRawPerm  bool
+		wantTrust    bool
+	}{
+		{
+			name:         "metadata token grants metadata route permissions only",
+			metadata:     dashTestToken,
+			raw:          "raw-token",
+			token:        dashTestToken,
+			wantMeta:     true,
+			wantEvidence: true,
+		},
+		{
+			name:         "raw token grants metadata and raw permissions",
+			metadata:     dashTestToken,
+			raw:          "raw-token",
+			token:        "raw-token",
+			wantMeta:     true,
+			wantRaw:      true,
+			wantEvidence: true,
+			wantRawPerm:  true,
+			wantTrust:    true,
+		},
+		{
+			name:         "raw-only deployment still treats raw token as metadata-capable",
+			raw:          "raw-token",
+			token:        "raw-token",
+			wantMeta:     true,
+			wantRaw:      true,
+			wantEvidence: true,
+			wantRawPerm:  true,
+			wantTrust:    true,
+		},
+		{
+			name:     "unmatched token denied",
+			metadata: dashTestToken,
+			raw:      "raw-token",
+			token:    "wrong-token",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			authorization := newDashboardRequestAuthorization(tc.metadata, tc.raw, nil)
+			metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
+				nil, authorization.metaAuthorized, authorization.authorizePermission, authorization.rawAuthorized,
+			)
+			req := reqWithBearer(tc.token)
+			if got := metaAuthorized(req); got != tc.wantMeta {
+				t.Fatalf("metaAuthorized = %v, want %v", got, tc.wantMeta)
+			}
+			if got := rawAuthorized(req); got != tc.wantRaw {
+				t.Fatalf("rawAuthorized = %v, want %v", got, tc.wantRaw)
+			}
+			if got := authorizePermission(req, dashboard.PermissionEvidenceRead) == nil; got != tc.wantEvidence {
+				t.Fatalf("evidence permission = %v, want %v", got, tc.wantEvidence)
+			}
+			if got := authorizePermission(req, dashboard.PermissionRawRead) == nil; got != tc.wantRawPerm {
+				t.Fatalf("raw permission = %v, want %v", got, tc.wantRawPerm)
+			}
+			if got := authorizePermission(req, dashboard.PermissionTrustKeysRead) == nil; got != tc.wantTrust {
+				t.Fatalf("trust keys permission = %v, want %v", got, tc.wantTrust)
+			}
+		})
+	}
+}
+
+func TestDashboardClientCertAuthorizers_MissingTokenPermissionAuthorizerFailsClosed(t *testing.T) {
+	_, authorizePermission, _ := dashboardClientCertAuthorizers(
+		nil,
+		func(*http.Request) bool { return true },
+		nil,
+		func(*http.Request) bool { return true },
+	)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil)
+	if err := authorizePermission(req, dashboard.PermissionEvidenceRead); err == nil ||
+		!strings.Contains(err.Error(), "permission authorizer is not configured") {
+		t.Fatalf("authorizePermission error = %v, want fail-closed configuration error", err)
 	}
 }
 
@@ -536,7 +639,9 @@ func TestDashboardMTLS_RoutePermissionsAndRaw(t *testing.T) {
 	tokenMetaAuthorized := func(r *http.Request) bool { return dashboardTokenMatches(r, dashTestToken) }
 	tokenRawAuthorized := func(r *http.Request) bool { return dashboardTokenMatches(r, "raw-token") }
 	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
-		authorizer, tokenMetaAuthorized, tokenRawAuthorized,
+		authorizer, tokenMetaAuthorized,
+		dashboardAuthorizePermissionFunc(tokenMetaAuthorized, tokenRawAuthorized),
+		tokenRawAuthorized,
 	)
 	inner := dashboard.New(dashboard.Options{
 		ReceiptDir:          t.TempDir(),

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -1070,9 +1070,10 @@ func TestDashboardOIDC_RunServeCompositionUsesMappedRoutePermissions(t *testing.
 	p := newOIDCTestProvider(t)
 	auth := newOIDCTestAuthenticator(t, p, now)
 	authorization := newDashboardRequestAuthorization("", "", auth)
-	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
-		nil, authorization.metaAuthorized, authorization.authorizePermission, authorization.rawAuthorized,
-	)
+	// Drive the same helper the serve path installs, so a regression in WHICH
+	// authorization callbacks reach the composer fails here instead of passing
+	// because the test rebuilt the wiring itself.
+	metaAuthorized, authorizePermission, rawAuthorized := dashboardServeAuthorizers(nil, authorization)
 	var audit strings.Builder
 	inner := dashboard.New(dashboard.Options{
 		ReceiptDir:          t.TempDir(),

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -1059,3 +1059,61 @@ func TestDashboardOIDCAudienceAlias(t *testing.T) {
 		t.Fatalf("client-id alias = %q", got)
 	}
 }
+
+// TestDashboardOIDC_RunServeCompositionUsesMappedRoutePermissions guards the
+// serve-path composition: an OIDC principal must receive exactly the permissions
+// its mapped role grants. Deriving the permission authorizer from the
+// metadata/raw booleans alone granted every metadata-tier permission to any
+// authenticated principal, ignoring the role map entirely.
+func TestDashboardOIDC_RunServeCompositionUsesMappedRoutePermissions(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+	authorization := newDashboardRequestAuthorization("", "", auth)
+	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
+		nil, authorization.metaAuthorized, authorization.authorizePermission, authorization.rawAuthorized,
+	)
+	var audit strings.Builder
+	inner := dashboard.New(dashboard.Options{
+		ReceiptDir:          t.TempDir(),
+		HasFeature:          func(string) bool { return true },
+		Authorize:           dashboardAuthorizeFunc(metaAuthorized),
+		AuthorizePermission: authorizePermission,
+		AuthorizeRaw:        dashboardAuthorizeFunc(rawAuthorized),
+		AuditWriter:         &audit,
+	})
+	handler := auth.middleware(dashboardAuthHandler(metaAuthorized, authorization.authAuditInfo, &audit, inner))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, requestWithBearer(t, p.token(t, p.validClaims(now))))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("mapped evidence status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if strings.Contains(audit.String(), "permission=\"dashboard:exemptions:read\"") {
+		t.Fatalf("evidence route unexpectedly audited exemptions permission: %s", audit.String())
+	}
+
+	req := requestWithBearer(t, p.token(t, p.validClaims(now)))
+	req.URL.Path = "/exemptions"
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("unmapped exemptions status = %d, want %d; body=%s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	log := audit.String()
+	for _, want := range []string{
+		"pipelock-dashboard denied",
+		"permission=\"dashboard:exemptions:read\"",
+		"auth_method=oidc",
+		"auth_subject=\"operator-a\"",
+		"auth_roles=\"evidence-reader\"",
+		"reason=permission_denied",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("permission-denied audit missing %q: %s", want, log)
+		}
+	}
+	if rawAuthorized(req) {
+		t.Fatal("mapped OIDC principal unexpectedly received raw permission")
+	}
+}


### PR DESCRIPTION
Dashboard route permissions now come from the OIDC principal's mapped role. A principal reaches exactly the views its role grants in `--oidc-role-map`, and a route it is not mapped for is denied with the missing permission named in the audit log.

Earlier releases resolved route permissions from the operator-token tier, so a principal's mapped role governed raw-view access but not the metadata-tier views. A role map written against that behavior can be narrower than the access its holders have today, and those holders will lose views after upgrading. Confirm each role lists every permission its holders need before you upgrade. `docs/cli/dashboard.md` carries an upgrade note with the same guidance.

Mutual TLS deployments are unaffected. A verified client certificate stays authoritative and never falls back to token or OIDC authorization. Token-only deployments keep the existing metadata and raw tier split.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard OIDC route access now follows permissions mapped to the authenticated role.
  * Requests to unavailable routes are denied and logged with the missing permission.
  * Mutual TLS authorization no longer falls back to token-based permission checks.
  * Missing permission authorization configuration now fails closed with a clear error.

* **Documentation**
  * Added upgrade guidance warning that existing OIDC role mappings may provide narrower access after upgrading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->