### PR TITLE
fix(recorder): bound evidence read paths and report truncation

### DIFF
--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -242,7 +242,12 @@ The first entry in a chain has `prev_hash: "genesis"`. Each subsequent entry's `
 To verify a chain:
 
 ```go
-entries, _ := recorder.ReadEntries("evidence-abc123-0.jsonl")
+entries, err := recorder.ReadEntries("evidence-abc123-0.jsonl")
+if err != nil {
+    // Treat ErrEvidenceReadLimitExceeded as incomplete evidence, not as a
+    // successful partial read.
+    return err
+}
 err := recorder.VerifyChain(entries)
 ```
 
@@ -270,7 +275,10 @@ The signature covers the `prev_hash` of the checkpoint entry, which represents t
 To verify checkpoints independently:
 
 ```go
-entries, _ := recorder.ReadEntries(path)
+entries, err := recorder.ReadEntries(path)
+if err != nil {
+    return err
+}
 err := recorder.VerifyCheckpoints(entries, pubKey)
 ```
 
@@ -350,12 +358,24 @@ Filter fields:
 | `Before` | Include entries before this time. |
 | `MinSeq` | Include entries at or above this sequence number. |
 | `MaxSeq` | Include entries at or below this sequence number. |
+| `MaxEntriesRead` | Optional parsed-entry ceiling. If reached, `QueryResult.Truncated` is true. |
+| `MaxDirectoryEntries` | Optional evidence-directory entry ceiling. Zero uses the default ceiling. |
+| `MaxBytesRead` | Optional total byte ceiling across scanned evidence files. If reached, `QueryResult.Truncated` is true. |
+
+Recorder reads are bounded. `ReadEntries` and `ReadEntriesFromReader` return an
+error if the default evidence size or entry-count ceiling is exceeded. Query
+APIs that can return read metadata set `QueryResult.Truncated` instead of
+silently returning a partial session as complete.
 
 List sessions with recorded evidence:
 
 ```go
 sessions, err := recorder.ListSessions("/var/lib/pipelock/evidence")
 ```
+
+Session listing is also bounded by default. Use `ListSessionsBoundedResult` when
+a UI can display an explicit truncation warning; strict helpers return an error
+when the directory entry cap is exceeded.
 
 ## File Rotation and Retention
 

--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -358,9 +358,9 @@ Filter fields:
 | `Before` | Include entries before this time. |
 | `MinSeq` | Include entries at or above this sequence number. |
 | `MaxSeq` | Include entries at or below this sequence number. |
-| `MaxEntriesRead` | Optional parsed-entry ceiling. If reached, `QueryResult.Truncated` is true. |
+| `MaxEntriesRead` | Optional parsed-entry ceiling. Positive values apply across the session query. Zero uses the default per-file parsed-entry ceiling. If reached, `QueryResult.Truncated` is true. |
 | `MaxDirectoryEntries` | Optional evidence-directory entry ceiling. Zero uses the default ceiling. |
-| `MaxBytesRead` | Optional total byte ceiling across scanned evidence files. If reached, `QueryResult.Truncated` is true. |
+| `MaxBytesRead` | Optional byte ceiling. Positive values apply across scanned evidence files. Zero uses the default per-file byte ceiling. If reached, `QueryResult.Truncated` is true. |
 
 Recorder reads are bounded. `ReadEntries` and `ReadEntriesFromReader` return an
 error if the default evidence size or entry-count ceiling is exceeded. Query

--- a/enterprise/dashboard/exemption_store_test.go
+++ b/enterprise/dashboard/exemption_store_test.go
@@ -725,7 +725,11 @@ func TestExemptions_OverlayJoinsStoreRecords(t *testing.T) {
 		TrustedDomains: []string{"internal.vendor.example"},
 	}
 
-	inventory := NewReadModel(Options{Config: cfg, ExemptionStore: store}).Exemptions()
+	inventory := NewReadModel(Options{
+		Config:         cfg,
+		ExemptionStore: store,
+		Now:            func() time.Time { return now },
+	}).Exemptions()
 	if !inventory.ConfigLoaded {
 		t.Fatal("ConfigLoaded = false, want true")
 	}

--- a/enterprise/dashboard/operability_errors_test.go
+++ b/enterprise/dashboard/operability_errors_test.go
@@ -658,8 +658,14 @@ func TestBuildReadModelIndex_ErrorPaths(t *testing.T) {
 		if err := os.WriteFile(path, bytes.Repeat([]byte{' '}, 8<<20+1), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := buildReadModelIndex([]string{path}, time.Unix(100, 0).UTC()); err == nil || !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		_, err := buildReadModelIndex([]string{path}, time.Unix(100, 0).UTC())
+		if err == nil || !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
 			t.Fatalf("oversized source error = %v, want bounded-read rejection", err)
+		}
+		// Pin WHICH bound tripped: the sentinel alone passes even if the wrong
+		// cap fires, which would misdiagnose the truncation for an operator.
+		if !strings.Contains(err.Error(), "bytes") || strings.Contains(err.Error(), "entries") {
+			t.Fatalf("oversized source error = %v, want the byte limit named", err)
 		}
 	})
 
@@ -672,8 +678,12 @@ func TestBuildReadModelIndex_ErrorPaths(t *testing.T) {
 		if err := os.WriteFile(path, []byte(data.String()), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := buildReadModelIndex([]string{path}, time.Unix(100, 0).UTC()); err == nil || !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		_, err := buildReadModelIndex([]string{path}, time.Unix(100, 0).UTC())
+		if err == nil || !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
 			t.Fatalf("too-many-entries source error = %v, want bounded-read rejection", err)
+		}
+		if !strings.Contains(err.Error(), "entries") || strings.Contains(err.Error(), "bytes") {
+			t.Fatalf("too-many-entries source error = %v, want the entry limit named", err)
 		}
 	})
 

--- a/enterprise/dashboard/operability_errors_test.go
+++ b/enterprise/dashboard/operability_errors_test.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
 
 type failAfterWriter struct {
@@ -658,6 +660,20 @@ func TestBuildReadModelIndex_ErrorPaths(t *testing.T) {
 		}
 		if _, err := buildReadModelIndex([]string{path}, time.Unix(100, 0).UTC()); err == nil || !strings.Contains(err.Error(), "read limit exceeded") {
 			t.Fatalf("oversized source error = %v, want bounded-read rejection", err)
+		}
+	})
+
+	t.Run("too many source entries", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "evidence-agent-0.jsonl")
+		var data strings.Builder
+		for seq := range recorder.MaxEvidenceReadEntries + 1 {
+			data.WriteString(fmt.Sprintf(`{"v":2,"seq":%d,"ts":"2026-01-01T00:00:00Z","session_id":"agent-a","type":"request"}`+"\n", seq))
+		}
+		if err := os.WriteFile(path, []byte(data.String()), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := buildReadModelIndex([]string{path}, time.Unix(100, 0).UTC()); err == nil || !strings.Contains(err.Error(), "read limit exceeded") {
+			t.Fatalf("too-many-entries source error = %v, want bounded-read rejection", err)
 		}
 	})
 

--- a/enterprise/dashboard/operability_errors_test.go
+++ b/enterprise/dashboard/operability_errors_test.go
@@ -667,7 +667,7 @@ func TestBuildReadModelIndex_ErrorPaths(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "evidence-agent-0.jsonl")
 		var data strings.Builder
 		for seq := range recorder.MaxEvidenceReadEntries + 1 {
-			data.WriteString(fmt.Sprintf(`{"v":2,"seq":%d,"ts":"2026-01-01T00:00:00Z","session_id":"agent-a","type":"request"}`+"\n", seq))
+			_, _ = fmt.Fprintf(&data, `{"v":2,"seq":%d,"ts":"2026-01-01T00:00:00Z","session_id":"agent-a","type":"request"}`+"\n", seq)
 		}
 		if err := os.WriteFile(path, []byte(data.String()), 0o600); err != nil {
 			t.Fatal(err)

--- a/enterprise/dashboard/operability_errors_test.go
+++ b/enterprise/dashboard/operability_errors_test.go
@@ -664,7 +664,7 @@ func TestBuildReadModelIndex_ErrorPaths(t *testing.T) {
 		}
 		// Pin WHICH bound tripped: the sentinel alone passes even if the wrong
 		// cap fires, which would misdiagnose the truncation for an operator.
-		if !strings.Contains(err.Error(), "bytes") || strings.Contains(err.Error(), "entries") {
+		if !strings.Contains(err.Error(), fmt.Sprintf("exceeds %d bytes", recorder.MaxEvidenceReadFileBytes)) || strings.Contains(err.Error(), "entries") {
 			t.Fatalf("oversized source error = %v, want the byte limit named", err)
 		}
 	})
@@ -682,7 +682,7 @@ func TestBuildReadModelIndex_ErrorPaths(t *testing.T) {
 		if err == nil || !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
 			t.Fatalf("too-many-entries source error = %v, want bounded-read rejection", err)
 		}
-		if !strings.Contains(err.Error(), "entries") || strings.Contains(err.Error(), "bytes") {
+		if !strings.Contains(err.Error(), fmt.Sprintf("exceeds %d entries", recorder.MaxEvidenceReadEntries)) || strings.Contains(err.Error(), "bytes") {
 			t.Fatalf("too-many-entries source error = %v, want the entry limit named", err)
 		}
 	})

--- a/enterprise/dashboard/operability_errors_test.go
+++ b/enterprise/dashboard/operability_errors_test.go
@@ -658,7 +658,7 @@ func TestBuildReadModelIndex_ErrorPaths(t *testing.T) {
 		if err := os.WriteFile(path, bytes.Repeat([]byte{' '}, 8<<20+1), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := buildReadModelIndex([]string{path}, time.Unix(100, 0).UTC()); err == nil || !strings.Contains(err.Error(), "read limit exceeded") {
+		if _, err := buildReadModelIndex([]string{path}, time.Unix(100, 0).UTC()); err == nil || !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
 			t.Fatalf("oversized source error = %v, want bounded-read rejection", err)
 		}
 	})
@@ -672,7 +672,7 @@ func TestBuildReadModelIndex_ErrorPaths(t *testing.T) {
 		if err := os.WriteFile(path, []byte(data.String()), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := buildReadModelIndex([]string{path}, time.Unix(100, 0).UTC()); err == nil || !strings.Contains(err.Error(), "read limit exceeded") {
+		if _, err := buildReadModelIndex([]string{path}, time.Unix(100, 0).UTC()); err == nil || !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
 			t.Fatalf("too-many-entries source error = %v, want bounded-read rejection", err)
 		}
 	})

--- a/internal/capture/loader.go
+++ b/internal/capture/loader.go
@@ -85,6 +85,9 @@ func LoadAndReplayWithOptions(cfg *config.Config, sessionsDir string, opts Repla
 	totalDropped := 0
 	metaDir := filepath.Join(sessionsDir, metaSessionID)
 	if metaResult, metaErr := recorder.QuerySession(metaDir, metaSessionID, &recorder.QueryFilter{Type: EntryTypeCaptureDrop}); metaErr == nil {
+		if metaResult.Truncated {
+			return nil, 0, 0, "", fmt.Errorf("%w: capture metadata evidence exceeded bounded read limits", recorder.ErrEvidenceReadLimitExceeded)
+		}
 		for _, entry := range metaResult.Entries {
 			detailJSON, marshalErr := json.Marshal(entry.Detail)
 			if marshalErr != nil {
@@ -145,6 +148,10 @@ func LoadAndReplayWithOptions(cfg *config.Config, sessionsDir string, opts Repla
 			if queryErr != nil {
 				sc.Close()
 				return nil, 0, 0, "", fmt.Errorf("querying session %s/%s: %w", sessionName, sessionID, queryErr)
+			}
+			if result.Truncated {
+				sc.Close()
+				return nil, 0, 0, "", fmt.Errorf("%w: capture evidence for session %s/%s exceeded bounded read limits", recorder.ErrEvidenceReadLimitExceeded, sessionName, sessionID)
 			}
 
 			for _, entry := range result.Entries {

--- a/internal/capture/replay_test.go
+++ b/internal/capture/replay_test.go
@@ -762,6 +762,77 @@ func TestLoadAndReplay(t *testing.T) {
 	}
 }
 
+func TestLoadAndReplayRejectsTruncatedCaptureEvidence(t *testing.T) {
+	dir := t.TempDir()
+	sessionDir := filepath.Join(dir, loadReplaySessionID)
+	rec, err := recorder.New(recorder.Config{
+		Enabled:           true,
+		Dir:               sessionDir,
+		MaxEntriesPerFile: recorder.MaxEvidenceReadEntries + 1,
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	summary := CaptureSummary{
+		CaptureSchemaVersion: CaptureSchemaV1,
+		Surface:              SurfaceURL,
+		ConfigHash:           loadReplayOriginalHash,
+		EffectiveAction:      config.ActionAllow,
+		Request: CaptureRequest{
+			URL: "https://safe.example.com/page",
+		},
+	}
+	for range recorder.MaxEvidenceReadEntries + 1 {
+		if err := rec.Record(recorder.Entry{
+			SessionID: loadReplaySessionID,
+			Type:      EntryTypeCapture,
+			Summary:   "fixture",
+			Detail:    summary,
+		}); err != nil {
+			t.Fatalf("rec.Record: %v", err)
+		}
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("rec.Close: %v", err)
+	}
+
+	_, _, _, _, err = LoadAndReplay(config.Defaults(), dir)
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("LoadAndReplay error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+}
+
+func TestLoadAndReplayRejectsTruncatedCaptureMetadata(t *testing.T) {
+	dir := t.TempDir()
+	metaDir := filepath.Join(dir, metaSessionID)
+	rec, err := recorder.New(recorder.Config{
+		Enabled:           true,
+		Dir:               metaDir,
+		MaxEntriesPerFile: recorder.MaxEvidenceReadEntries + 1,
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	for count := range recorder.MaxEvidenceReadEntries + 1 {
+		if err := rec.Record(recorder.Entry{
+			SessionID: metaSessionID,
+			Type:      EntryTypeCaptureDrop,
+			Summary:   DropSummaryCaptureOverflow,
+			Detail:    CaptureDropDetail{Count: count + 1, Reason: "backpressure"},
+		}); err != nil {
+			t.Fatalf("rec.Record: %v", err)
+		}
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("rec.Close: %v", err)
+	}
+
+	_, _, _, _, err = LoadAndReplay(config.Defaults(), dir)
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("LoadAndReplay error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+}
+
 func TestLoadAndReplay_ScannerConstructionFailureIsReturned(t *testing.T) {
 	dir := t.TempDir()
 	writeFixtureSession(t, dir, CaptureSummary{

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -858,6 +858,13 @@ func ExtractReceipts(path string) ([]Receipt, error) {
 	clean := filepath.Clean(path)
 	entries, err := recorder.ReadEntries(clean)
 	if err != nil {
+		// A truncated read must not fall through to the raw-JSONL
+		// compatibility path: that path would return the receipts it managed
+		// to parse as though they were the whole chain. Mirrors
+		// ExtractReceiptsBytes.
+		if errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+			return nil, fmt.Errorf("reading entries: %w", err)
+		}
 		rawReceipts, rawErr := extractRawReceiptsJSONLFile(clean)
 		if rawErr != nil {
 			return nil, rawErr

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -884,6 +884,9 @@ func ExtractReceipts(path string) ([]Receipt, error) {
 func ExtractReceiptsBytes(data []byte) ([]Receipt, error) {
 	entries, err := recorder.ReadEntriesFromReader(bytes.NewReader(data))
 	if err != nil {
+		if errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+			return nil, fmt.Errorf("reading entries: %w", err)
+		}
 		rawReceipts, rawErr := extractRawReceiptsJSONLBytes(data)
 		if rawErr != nil {
 			return nil, rawErr
@@ -949,8 +952,14 @@ func ExtractReceiptsWithSessionID(path string) ([]Receipt, string, error) {
 // ExtractReceiptsFromSessionDir reads all evidence files for a session from a
 // recorder directory and returns the action receipts in chain order.
 func ExtractReceiptsFromSessionDir(dir, sessionID string) ([]Receipt, error) {
-	receipts, _, err := ExtractReceiptsFromSessionDirBounded(dir, sessionID, 0)
-	return receipts, err
+	receipts, truncated, err := ExtractReceiptsFromSessionDirBounded(dir, sessionID, 0)
+	if err != nil {
+		return nil, err
+	}
+	if truncated {
+		return nil, fmt.Errorf("%w: evidence session %s exceeded bounded read limits", recorder.ErrEvidenceReadLimitExceeded, sessionID)
+	}
+	return receipts, nil
 }
 
 // ExtractReceiptsFromSessionDirBounded reads action receipts for a session with

--- a/internal/receipt/chain_test.go
+++ b/internal/receipt/chain_test.go
@@ -816,7 +816,7 @@ func TestExtractReceiptsFromSessionDirRejectsTruncatedQuery(t *testing.T) {
 	_, priv := generateTestKey(t)
 	r := signChainReceipt(t, priv, 0, GenesisHash, time.Now().UTC())
 	path := filepath.Join(dir, "evidence-proxy-0.jsonl")
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	f, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		t.Fatalf("OpenFile: %v", err)
 	}

--- a/internal/receipt/chain_test.go
+++ b/internal/receipt/chain_test.go
@@ -809,6 +809,37 @@ func TestExtractReceipts_RawJSONLRejectsOverCapFile(t *testing.T) {
 	}
 }
 
+func TestExtractReceipts_RejectsRecorderReadLimitBeforeRawFileFallback(t *testing.T) {
+	t.Parallel()
+
+	_, priv := generateTestKey(t)
+	r := signChainReceipt(t, priv, 0, GenesisHash, time.Now().UTC())
+	raw, err := Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var data strings.Builder
+	for data.Len() <= int(recorder.MaxEvidenceReadFileBytes) {
+		data.WriteByte('\n')
+	}
+	data.Write(raw)
+	data.WriteByte('\n')
+
+	path := filepath.Join(t.TempDir(), "receipts.jsonl")
+	if err := os.WriteFile(path, []byte(data.String()), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err = ExtractReceipts(path)
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("ExtractReceipts error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "reading entries") || strings.Contains(got, "raw receipts") {
+		t.Fatalf("ExtractReceipts error = %q, want recorder read-limit rejection before raw fallback", got)
+	}
+}
+
 func TestExtractReceiptsFromSessionDirRejectsTruncatedQuery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/receipt/chain_test.go
+++ b/internal/receipt/chain_test.go
@@ -739,6 +739,30 @@ func TestExtractReceiptsBytes_RejectsUnreadableEvidence(t *testing.T) {
 	}
 }
 
+func TestExtractReceiptsBytes_RejectsRecorderReadLimitBeforeRawFallback(t *testing.T) {
+	t.Parallel()
+
+	_, priv := generateTestKey(t)
+	r := signChainReceipt(t, priv, 0, GenesisHash, time.Now().UTC())
+	raw, err := Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var data strings.Builder
+	for data.Len() <= int(recorder.MaxEvidenceReadFileBytes) {
+		data.WriteString(strings.Repeat(" ", recorder.MaxEntryLineBytes))
+		data.WriteByte('\n')
+	}
+	data.Write(raw)
+	data.WriteByte('\n')
+
+	_, err = ExtractReceiptsBytes([]byte(data.String()))
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("ExtractReceiptsBytes error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+}
+
 func TestExtractReceipts_RawJSONLRejectsMissingFieldsTail(t *testing.T) {
 	t.Parallel()
 
@@ -782,6 +806,46 @@ func TestExtractReceipts_RawJSONLRejectsOverCapFile(t *testing.T) {
 	_, err = ExtractReceipts(path)
 	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
 		t.Fatalf("ExtractReceipts error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+}
+
+func TestExtractReceiptsFromSessionDirRejectsTruncatedQuery(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	r := signChainReceipt(t, priv, 0, GenesisHash, time.Now().UTC())
+	path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	enc := json.NewEncoder(f)
+	for seq := range recorder.MaxEvidenceReadEntries + 1 {
+		entry := recorder.Entry{
+			Version:   recorder.EntryVersion,
+			Sequence:  uint64(seq),
+			Timestamp: time.Now().UTC(),
+			SessionID: "proxy",
+			Type:      recorderEntryType,
+			Transport: chainTestTransport,
+			Summary:   "signed receipt",
+			Detail:    r,
+			PrevHash:  recorder.GenesisHash,
+		}
+		entry.Hash = recorder.ComputeHash(entry)
+		if err := enc.Encode(entry); err != nil {
+			_ = f.Close()
+			t.Fatalf("Encode: %v", err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	_, err = ExtractReceiptsFromSessionDir(dir, "proxy")
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("ExtractReceiptsFromSessionDir error = %v, want ErrEvidenceReadLimitExceeded", err)
 	}
 }
 

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,6 +27,24 @@ import (
 // reject versions outside acceptedEntryVersions; v1 chains continue to
 // verify with the v1 hash projection so pre-upgrade audit logs stay valid.
 const EntryVersion = 2
+
+// MaxEntryLineBytes is the maximum JSONL line payload accepted by recorder
+// entry readers.
+const MaxEntryLineBytes = 1 << 20
+
+const maxEntryWireLineBytes = MaxEntryLineBytes + len("\r\n")
+
+type entryReadLimits struct {
+	MaxEntries int
+	MaxBytes   int64
+}
+
+func defaultEntryReadLimits() entryReadLimits {
+	return entryReadLimits{
+		MaxEntries: MaxEvidenceReadEntries,
+		MaxBytes:   MaxEvidenceReadFileBytes,
+	}
+}
 
 // acceptedEntryVersions is the inclusive set of schema versions ReadEntries
 // and VerifyChain will load. New writes always use EntryVersion; v1 entries
@@ -247,56 +266,102 @@ func VerifyCheckpoints(entries []Entry, pubKey ed25519.PublicKey) error {
 // ReadEntries reads and parses JSONL evidence entries from a file.
 // Accepts the versions in acceptedEntryVersions; rejects unknown versions.
 func ReadEntries(path string) ([]Entry, error) {
-	entries, _, err := readEntries(path, 0)
-	return entries, err
+	entries, truncated, _, err := readEntries(path, defaultEntryReadLimits())
+	if err != nil {
+		return nil, err
+	}
+	if truncated {
+		return nil, readLimitExceededError(path, defaultEntryReadLimits())
+	}
+	return entries, nil
 }
 
-func readEntries(path string, maxEntries int) ([]Entry, bool, error) {
+func readEntries(path string, limits entryReadLimits) ([]Entry, bool, int64, error) {
 	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
-		return nil, false, fmt.Errorf("opening evidence file: %w", err)
+		return nil, false, 0, fmt.Errorf("opening evidence file: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
-	entries, truncated, err := readEntriesFromReader(f, maxEntries)
+	entries, truncated, bytesRead, err := readEntriesFromReader(f, limits)
 	if err != nil {
-		return nil, false, fmt.Errorf("reading evidence file: %w", err)
+		return nil, false, bytesRead, fmt.Errorf("reading evidence file: %w", err)
 	}
-	return entries, truncated, nil
+	return entries, truncated, bytesRead, nil
 }
 
 // ReadEntriesFromReader reads and parses JSONL evidence entries from r.
 // It applies the same duplicate-key and version fences as ReadEntries.
 func ReadEntriesFromReader(r io.Reader) ([]Entry, error) {
-	entries, _, err := readEntriesFromReader(r, 0)
-	return entries, err
+	entries, truncated, _, err := readEntriesFromReader(r, defaultEntryReadLimits())
+	if err != nil {
+		return nil, err
+	}
+	if truncated {
+		return nil, readLimitExceededError("reader", defaultEntryReadLimits())
+	}
+	return entries, nil
 }
 
-func readEntriesFromReader(r io.Reader, maxEntries int) ([]Entry, bool, error) {
+func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, int64, error) {
 	var entries []Entry
-	sc := bufio.NewScanner(r)
+	reader := bufio.NewReader(r)
 
-	// 1MB max line size for entries with large Detail payloads
-	const maxLineSize = 1 << 20
-	sc.Buffer(make([]byte, 0, maxLineSize), maxLineSize)
-
-	lineNum := 0
-	for sc.Scan() {
-		if maxEntries > 0 && len(entries) >= maxEntries {
-			return entries, true, nil
+	var (
+		lineNum   int
+		bytesRead int64
+		line      []byte
+	)
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		if len(fragment) > 0 {
+			bytesRead += int64(len(fragment))
+			if limits.MaxBytes > 0 && bytesRead > limits.MaxBytes {
+				return entries, true, bytesRead, nil
+			}
+			if len(line)+len(fragment) > maxEntryWireLineBytes {
+				return nil, false, bytesRead, fmt.Errorf("line %d: exceeds %d-byte recorder entry limit", lineNum+1, MaxEntryLineBytes)
+			}
+			line = append(line, fragment...)
 		}
-
-		lineNum++
-		line := strings.TrimSpace(sc.Text())
-		if line == "" {
+		if err == nil {
+			// Complete line.
+		} else if errors.Is(err, bufio.ErrBufferFull) {
 			continue
+		} else if errors.Is(err, io.EOF) {
+			if len(line) == 0 {
+				return entries, false, bytesRead, nil
+			}
+		} else {
+			return nil, false, bytesRead, fmt.Errorf("scanning evidence entries: %w", err)
+		}
+		lineNum++
+		if len(line) > 0 && line[len(line)-1] == '\n' {
+			line = line[:len(line)-1]
+			if len(line) > 0 && line[len(line)-1] == '\r' {
+				line = line[:len(line)-1]
+			}
+		}
+		if len(line) > MaxEntryLineBytes {
+			return nil, false, bytesRead, fmt.Errorf("line %d: exceeds %d-byte recorder entry limit", lineNum, MaxEntryLineBytes)
+		}
+		trimmed := strings.TrimSpace(string(line))
+		line = line[:0]
+		if trimmed == "" {
+			if errors.Is(err, io.EOF) {
+				return entries, false, bytesRead, nil
+			}
+			continue
+		}
+		if limits.MaxEntries > 0 && len(entries) >= limits.MaxEntries {
+			return entries, true, bytesRead, nil
 		}
 
 		// Reject duplicate object keys before json.Unmarshal collapses them
 		// last-wins (a parser-differential smuggling vector); shared with the
 		// receipt verify path via internal/jsonscan.
-		if err := jsonscan.RejectDuplicateKeys([]byte(line)); err != nil {
-			return nil, false, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
+		if err := jsonscan.RejectDuplicateKeys([]byte(trimmed)); err != nil {
+			return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
 		}
 
 		var raw struct {
@@ -314,8 +379,8 @@ func readEntriesFromReader(r io.Reader, maxEntries int) ([]Entry, bool, error) {
 			PrevHash  string          `json:"prev_hash"`
 			Hash      string          `json:"hash"`
 		}
-		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			return nil, false, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
+		if err := json.Unmarshal([]byte(trimmed), &raw); err != nil {
+			return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
 		}
 		e := Entry{
 			Version:   raw.Version,
@@ -335,19 +400,35 @@ func readEntriesFromReader(r io.Reader, maxEntries int) ([]Entry, bool, error) {
 			e.RawDetail = append(json.RawMessage(nil), raw.Detail...)
 			detail, err := decodeEntryDetail(raw.Detail)
 			if err != nil {
-				return nil, false, fmt.Errorf("line %d: parsing entry detail: %w", lineNum, err)
+				return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry detail: %w", lineNum, err)
 			}
 			e.Detail = detail
 		}
 		if !acceptedEntryVersions[e.Version] {
-			return nil, false, fmt.Errorf("line %d: unsupported entry version %d (accepted: 1, 2)", lineNum, e.Version)
+			return nil, false, bytesRead, fmt.Errorf("line %d: unsupported entry version %d (accepted: 1, 2)", lineNum, e.Version)
 		}
 		entries = append(entries, e)
+		if errors.Is(err, io.EOF) {
+			return entries, false, bytesRead, nil
+		}
 	}
-	if err := sc.Err(); err != nil {
-		return nil, false, fmt.Errorf("scanning evidence entries: %w", err)
+}
+
+func readLimitExceededError(path string, limits entryReadLimits) error {
+	name := filepath.Base(path)
+	if name == "." || name == string(filepath.Separator) {
+		name = path
 	}
-	return entries, false, nil
+	switch {
+	case limits.MaxEntries > 0 && limits.MaxBytes > 0:
+		return fmt.Errorf("%w: evidence file %s exceeds %d entries or %d bytes", ErrEvidenceReadLimitExceeded, name, limits.MaxEntries, limits.MaxBytes)
+	case limits.MaxEntries > 0:
+		return fmt.Errorf("%w: evidence file %s exceeds %d entries", ErrEvidenceReadLimitExceeded, name, limits.MaxEntries)
+	case limits.MaxBytes > 0:
+		return fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, name, limits.MaxBytes)
+	default:
+		return fmt.Errorf("%w: evidence file %s exceeded bounded read limits", ErrEvidenceReadLimitExceeded, name)
+	}
 }
 
 func decodeEntryDetail(raw json.RawMessage) (any, error) {

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -399,7 +399,9 @@ func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, 
 		if raw.Detail != nil {
 			e.RawDetail = append(json.RawMessage(nil), raw.Detail...)
 			var detail any
-			_ = json.Unmarshal(raw.Detail, &detail)
+			if err := json.Unmarshal(raw.Detail, &detail); err != nil {
+				return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry detail: %w", lineNum, err)
+			}
 			e.Detail = detail
 		}
 		if !acceptedEntryVersions[e.Version] {

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -398,10 +398,8 @@ func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, 
 		}
 		if raw.Detail != nil {
 			e.RawDetail = append(json.RawMessage(nil), raw.Detail...)
-			detail, err := decodeEntryDetail(raw.Detail)
-			if err != nil {
-				return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry detail: %w", lineNum, err)
-			}
+			var detail any
+			_ = json.Unmarshal(raw.Detail, &detail)
 			e.Detail = detail
 		}
 		if !acceptedEntryVersions[e.Version] {
@@ -429,12 +427,4 @@ func readLimitExceededError(path string, limits entryReadLimits, bytesRead int64
 	default:
 		return fmt.Errorf("%w: evidence file %s exceeded bounded read limits", ErrEvidenceReadLimitExceeded, name)
 	}
-}
-
-func decodeEntryDetail(raw json.RawMessage) (any, error) {
-	var detail any
-	if err := json.Unmarshal(raw, &detail); err != nil {
-		return nil, err
-	}
-	return detail, nil
 }

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -266,12 +266,12 @@ func VerifyCheckpoints(entries []Entry, pubKey ed25519.PublicKey) error {
 // ReadEntries reads and parses JSONL evidence entries from a file.
 // Accepts the versions in acceptedEntryVersions; rejects unknown versions.
 func ReadEntries(path string) ([]Entry, error) {
-	entries, truncated, _, err := readEntries(path, defaultEntryReadLimits())
+	entries, truncated, bytesRead, err := readEntries(path, defaultEntryReadLimits())
 	if err != nil {
 		return nil, err
 	}
 	if truncated {
-		return nil, readLimitExceededError(path, defaultEntryReadLimits())
+		return nil, readLimitExceededError(path, defaultEntryReadLimits(), bytesRead)
 	}
 	return entries, nil
 }
@@ -293,12 +293,12 @@ func readEntries(path string, limits entryReadLimits) ([]Entry, bool, int64, err
 // ReadEntriesFromReader reads and parses JSONL evidence entries from r.
 // It applies the same duplicate-key and version fences as ReadEntries.
 func ReadEntriesFromReader(r io.Reader) ([]Entry, error) {
-	entries, truncated, _, err := readEntriesFromReader(r, defaultEntryReadLimits())
+	entries, truncated, bytesRead, err := readEntriesFromReader(r, defaultEntryReadLimits())
 	if err != nil {
 		return nil, err
 	}
 	if truncated {
-		return nil, readLimitExceededError("reader", defaultEntryReadLimits())
+		return nil, readLimitExceededError("reader", defaultEntryReadLimits(), bytesRead)
 	}
 	return entries, nil
 }
@@ -414,14 +414,14 @@ func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, 
 	}
 }
 
-func readLimitExceededError(path string, limits entryReadLimits) error {
+func readLimitExceededError(path string, limits entryReadLimits, bytesRead int64) error {
 	name := filepath.Base(path)
 	if name == "." || name == string(filepath.Separator) {
 		name = path
 	}
 	switch {
-	case limits.MaxEntries > 0 && limits.MaxBytes > 0:
-		return fmt.Errorf("%w: evidence file %s exceeds %d entries or %d bytes", ErrEvidenceReadLimitExceeded, name, limits.MaxEntries, limits.MaxBytes)
+	case limits.MaxBytes > 0 && bytesRead > limits.MaxBytes:
+		return fmt.Errorf("%w: evidence file %s exceeds %d bytes", ErrEvidenceReadLimitExceeded, name, limits.MaxBytes)
 	case limits.MaxEntries > 0:
 		return fmt.Errorf("%w: evidence file %s exceeds %d entries", ErrEvidenceReadLimitExceeded, name, limits.MaxEntries)
 	case limits.MaxBytes > 0:

--- a/internal/recorder/entry_internal_test.go
+++ b/internal/recorder/entry_internal_test.go
@@ -16,14 +16,6 @@ import (
 	"time"
 )
 
-func TestDecodeEntryDetailRejectsMalformedRawJSON(t *testing.T) {
-	t.Parallel()
-
-	if _, err := decodeEntryDetail(json.RawMessage(`{"unterminated":`)); err == nil {
-		t.Fatal("decodeEntryDetail accepted malformed raw detail")
-	}
-}
-
 func TestReadEntriesFromReaderRejectsUnrepresentableRawDetail(t *testing.T) {
 	t.Parallel()
 
@@ -36,6 +28,9 @@ func TestReadEntriesFromReaderRejectsUnrepresentableRawDetail(t *testing.T) {
 	_, err := ReadEntriesFromReader(bytes.NewBufferString(line))
 	if err == nil {
 		t.Fatal("ReadEntriesFromReader accepted detail that cannot decode into the public Detail view")
+	}
+	if !strings.Contains(err.Error(), "parsing entry") {
+		t.Fatalf("ReadEntriesFromReader error = %v, want entry parse error", err)
 	}
 }
 
@@ -75,6 +70,12 @@ func TestReadEntriesFromReaderBounded(t *testing.T) {
 			wantErrSub: "line 1",
 		},
 		{
+			name:       "line size fence trips before eof",
+			input:      strings.Repeat("x", maxEntryWireLineBytes+1) + "\n",
+			limits:     entryReadLimits{MaxBytes: int64(maxEntryWireLineBytes + 2)},
+			wantErrSub: "line 1",
+		},
+		{
 			name:       "duplicate key fence remains active",
 			input:      `{"v":2,"seq":0,"ts":"2026-07-12T12:00:00Z","session_id":"s1","type":"request","type":"response","transport":"fetch","summary":"x","prev_hash":"genesis","hash":"abc"}` + "\n",
 			limits:     entryReadLimits{MaxBytes: 4096},
@@ -110,6 +111,39 @@ func TestReadEntriesFromReaderBounded(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadEntriesFromReaderLineEndingsAndEOF(t *testing.T) {
+	t.Run("trims crlf", func(t *testing.T) {
+		entries, truncated, _, err := readEntriesFromReader(strings.NewReader(testEntryLine(t, 0)+"\r\n"), entryReadLimits{MaxEntries: 1, MaxBytes: 4096})
+		if err != nil {
+			t.Fatalf("readEntriesFromReader: %v", err)
+		}
+		if truncated || len(entries) != 1 {
+			t.Fatalf("entries = %d truncated=%t, want one complete CRLF entry", len(entries), truncated)
+		}
+	})
+
+	t.Run("blank eof returns complete", func(t *testing.T) {
+		entries, truncated, bytesRead, err := readEntriesFromReader(strings.NewReader("   "), entryReadLimits{MaxEntries: 1, MaxBytes: 4096})
+		if err != nil {
+			t.Fatalf("readEntriesFromReader: %v", err)
+		}
+		if truncated || len(entries) != 0 || bytesRead != 3 {
+			t.Fatalf("entries=%d truncated=%t bytes=%d, want blank EOF consumed as complete", len(entries), truncated, bytesRead)
+		}
+	})
+
+	t.Run("entry eof without newline returns complete", func(t *testing.T) {
+		line := strings.TrimSuffix(testEntryLine(t, 0), "\n")
+		entries, truncated, _, err := readEntriesFromReader(strings.NewReader(line), entryReadLimits{MaxEntries: 1, MaxBytes: 4096})
+		if err != nil {
+			t.Fatalf("readEntriesFromReader: %v", err)
+		}
+		if truncated || len(entries) != 1 {
+			t.Fatalf("entries=%d truncated=%t, want entry at EOF without newline", len(entries), truncated)
+		}
+	})
 }
 
 func TestReadEntriesStrictBoundaries(t *testing.T) {
@@ -187,12 +221,18 @@ func TestReadLimitExceededErrorMessages(t *testing.T) {
 		{name: "entry limit with byte ceiling", limits: entryReadLimits{MaxEntries: 1, MaxBytes: 2}, bytesRead: 2, want: "1 entries", wantNot: "bytes"},
 		{name: "byte limit with entry ceiling", limits: entryReadLimits{MaxEntries: 1, MaxBytes: 2}, bytesRead: 3, want: "2 bytes", wantNot: "entries"},
 		{name: "entries", limits: entryReadLimits{MaxEntries: 1}, want: "1 entries"},
-		{name: "bytes", limits: entryReadLimits{MaxBytes: 2}, bytesRead: 3, want: "2 bytes"},
+		{name: "bytes exceeded", limits: entryReadLimits{MaxBytes: 2}, bytesRead: 3, want: "2 bytes"},
+		{name: "bytes fallback", limits: entryReadLimits{MaxBytes: 2}, bytesRead: 2, want: "2 bytes"},
+		{name: "path fallback", limits: entryReadLimits{}, want: "bounded read limits"},
 		{name: "fallback", limits: entryReadLimits{}, want: "bounded read limits"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := readLimitExceededError("evidence.jsonl", test.limits, test.bytesRead)
+			path := "evidence.jsonl"
+			if test.name == "path fallback" {
+				path = "."
+			}
+			err := readLimitExceededError(path, test.limits, test.bytesRead)
 			if !errors.Is(err, ErrEvidenceReadLimitExceeded) || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("readLimitExceededError = %v, want ErrEvidenceReadLimitExceeded containing %q", err, test.want)
 			}

--- a/internal/recorder/entry_internal_test.go
+++ b/internal/recorder/entry_internal_test.go
@@ -122,6 +122,9 @@ func TestReadEntriesStrictBoundaries(t *testing.T) {
 		if !errors.Is(err, ErrEvidenceReadLimitExceeded) {
 			t.Fatalf("ReadEntries error = %v, want ErrEvidenceReadLimitExceeded", err)
 		}
+		if got := err.Error(); !strings.Contains(got, "bytes") || strings.Contains(got, "entries") {
+			t.Fatalf("ReadEntries error = %q, want byte-limit diagnosis only", got)
+		}
 	})
 
 	t.Run("file as parent", func(t *testing.T) {
@@ -160,6 +163,9 @@ func TestReadEntriesStrictBoundaries(t *testing.T) {
 		if !errors.Is(err, ErrEvidenceReadLimitExceeded) {
 			t.Fatalf("ReadEntriesFromReader error = %v, want ErrEvidenceReadLimitExceeded", err)
 		}
+		if got := err.Error(); !strings.Contains(got, "entries") || strings.Contains(got, "bytes") {
+			t.Fatalf("ReadEntriesFromReader error = %q, want entry-limit diagnosis only", got)
+		}
 	})
 }
 
@@ -172,20 +178,26 @@ func TestReadEntriesFromReaderPropagatesReaderError(t *testing.T) {
 
 func TestReadLimitExceededErrorMessages(t *testing.T) {
 	tests := []struct {
-		name   string
-		limits entryReadLimits
-		want   string
+		name      string
+		limits    entryReadLimits
+		bytesRead int64
+		want      string
+		wantNot   string
 	}{
-		{name: "entries and bytes", limits: entryReadLimits{MaxEntries: 1, MaxBytes: 2}, want: "1 entries or 2 bytes"},
+		{name: "entry limit with byte ceiling", limits: entryReadLimits{MaxEntries: 1, MaxBytes: 2}, bytesRead: 2, want: "1 entries", wantNot: "bytes"},
+		{name: "byte limit with entry ceiling", limits: entryReadLimits{MaxEntries: 1, MaxBytes: 2}, bytesRead: 3, want: "2 bytes", wantNot: "entries"},
 		{name: "entries", limits: entryReadLimits{MaxEntries: 1}, want: "1 entries"},
-		{name: "bytes", limits: entryReadLimits{MaxBytes: 2}, want: "2 bytes"},
+		{name: "bytes", limits: entryReadLimits{MaxBytes: 2}, bytesRead: 3, want: "2 bytes"},
 		{name: "fallback", limits: entryReadLimits{}, want: "bounded read limits"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := readLimitExceededError("evidence.jsonl", test.limits)
+			err := readLimitExceededError("evidence.jsonl", test.limits, test.bytesRead)
 			if !errors.Is(err, ErrEvidenceReadLimitExceeded) || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("readLimitExceededError = %v, want ErrEvidenceReadLimitExceeded containing %q", err, test.want)
+			}
+			if test.wantNot != "" && strings.Contains(err.Error(), test.wantNot) {
+				t.Fatalf("readLimitExceededError = %v, want no %q diagnosis", err, test.wantNot)
 			}
 		})
 	}

--- a/internal/recorder/entry_internal_test.go
+++ b/internal/recorder/entry_internal_test.go
@@ -196,7 +196,7 @@ func testEntryLine(t *testing.T, seq uint64) string {
 	entry := Entry{
 		Version:   EntryVersion,
 		Sequence:  seq,
-		Timestamp: time.Date(2026, 7, 12, 12, 0, int(seq), 0, time.UTC),
+		Timestamp: time.Date(2026, 7, 12, 12, 0, int(seq%60), 0, time.UTC),
 		SessionID: "s1",
 		Type:      "request",
 		Transport: "fetch",

--- a/internal/recorder/entry_internal_test.go
+++ b/internal/recorder/entry_internal_test.go
@@ -6,7 +6,12 @@ package recorder
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -32,4 +37,193 @@ func TestReadEntriesFromReaderRejectsUnrepresentableRawDetail(t *testing.T) {
 	if err == nil {
 		t.Fatal("ReadEntriesFromReader accepted detail that cannot decode into the public Detail view")
 	}
+}
+
+func TestReadEntriesFromReaderBounded(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		limits     entryReadLimits
+		wantCount  int
+		wantBytes  int64
+		wantErrSub string
+	}{
+		{
+			name:      "byte limit counts skipped lines",
+			input:     strings.Repeat("\n", 1<<20),
+			limits:    entryReadLimits{MaxEntries: 1, MaxBytes: 128},
+			wantCount: 0,
+			wantBytes: 128,
+		},
+		{
+			name:      "entry limit reports extra record",
+			input:     testEntryLine(t, 0) + testEntryLine(t, 1),
+			limits:    entryReadLimits{MaxEntries: 1, MaxBytes: 4096},
+			wantCount: 1,
+			wantBytes: int64(len(testEntryLine(t, 0))),
+		},
+		{
+			name:      "small input complete",
+			input:     testEntryLine(t, 0),
+			limits:    entryReadLimits{MaxEntries: 1, MaxBytes: 4096},
+			wantCount: 1,
+		},
+		{
+			name:       "line size fence remains active",
+			input:      strings.Repeat("x", MaxEntryLineBytes+1),
+			limits:     entryReadLimits{MaxBytes: int64(MaxEntryLineBytes + 2)},
+			wantErrSub: "line 1",
+		},
+		{
+			name:       "duplicate key fence remains active",
+			input:      `{"v":2,"seq":0,"ts":"2026-07-12T12:00:00Z","session_id":"s1","type":"request","type":"response","transport":"fetch","summary":"x","prev_hash":"genesis","hash":"abc"}` + "\n",
+			limits:     entryReadLimits{MaxBytes: 4096},
+			wantErrSub: "duplicate object key",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			counting := &countingReader{r: strings.NewReader(test.input)}
+			entries, truncated, bytesRead, err := readEntriesFromReader(counting, test.limits)
+			if test.wantErrSub != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErrSub) {
+					t.Fatalf("readEntriesFromReader error = %v, want substring %q", err, test.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readEntriesFromReader: %v", err)
+			}
+			wantTruncated := test.name != "small input complete"
+			if truncated != wantTruncated {
+				t.Fatalf("truncated = %t, want %t", truncated, wantTruncated)
+			}
+			if len(entries) != test.wantCount {
+				t.Fatalf("len(entries) = %d, want %d", len(entries), test.wantCount)
+			}
+			if test.wantBytes > 0 && bytesRead <= test.wantBytes {
+				t.Fatalf("bytesRead = %d, want evidence that read limit was reached past %d", bytesRead, test.wantBytes)
+			}
+			if test.name == "byte limit counts skipped lines" && counting.read >= int64(len(test.input)) {
+				t.Fatalf("reader was drained to EOF: read %d bytes", counting.read)
+			}
+		})
+	}
+}
+
+func TestReadEntriesStrictBoundaries(t *testing.T) {
+	t.Run("public reader errors on byte truncation", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "evidence-s1-0.jsonl")
+		if err := os.WriteFile(path, []byte(strings.Repeat("\n", int(MaxEvidenceReadFileBytes)+1)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := ReadEntries(path)
+		if !errors.Is(err, ErrEvidenceReadLimitExceeded) {
+			t.Fatalf("ReadEntries error = %v, want ErrEvidenceReadLimitExceeded", err)
+		}
+	})
+
+	t.Run("file as parent", func(t *testing.T) {
+		parent := filepath.Join(t.TempDir(), "not-a-directory")
+		if err := os.WriteFile(parent, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReadEntries(filepath.Join(parent, "evidence.jsonl")); err == nil {
+			t.Fatal("ReadEntries accepted file-as-parent path")
+		}
+	})
+
+	t.Run("unreadable file", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root can read chmod 000 files")
+		}
+		path := filepath.Join(t.TempDir(), "evidence.jsonl")
+		if err := os.WriteFile(path, []byte(testEntryLine(t, 0)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+		if _, err := ReadEntries(path); err == nil {
+			t.Fatal("ReadEntries accepted unreadable file")
+		}
+	})
+
+	t.Run("public reader from io errors on entry truncation", func(t *testing.T) {
+		var input strings.Builder
+		for seq := range MaxEvidenceReadEntries + 1 {
+			input.WriteString(testEntryLine(t, uint64(seq)))
+		}
+		_, err := ReadEntriesFromReader(strings.NewReader(input.String()))
+		if !errors.Is(err, ErrEvidenceReadLimitExceeded) {
+			t.Fatalf("ReadEntriesFromReader error = %v, want ErrEvidenceReadLimitExceeded", err)
+		}
+	})
+}
+
+func TestReadEntriesFromReaderPropagatesReaderError(t *testing.T) {
+	_, _, _, err := readEntriesFromReader(errorReader{}, entryReadLimits{MaxBytes: 4096})
+	if err == nil || !strings.Contains(err.Error(), "scanning evidence entries") {
+		t.Fatalf("readEntriesFromReader error = %v, want scanning evidence entries", err)
+	}
+}
+
+func TestReadLimitExceededErrorMessages(t *testing.T) {
+	tests := []struct {
+		name   string
+		limits entryReadLimits
+		want   string
+	}{
+		{name: "entries and bytes", limits: entryReadLimits{MaxEntries: 1, MaxBytes: 2}, want: "1 entries or 2 bytes"},
+		{name: "entries", limits: entryReadLimits{MaxEntries: 1}, want: "1 entries"},
+		{name: "bytes", limits: entryReadLimits{MaxBytes: 2}, want: "2 bytes"},
+		{name: "fallback", limits: entryReadLimits{}, want: "bounded read limits"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := readLimitExceededError("evidence.jsonl", test.limits)
+			if !errors.Is(err, ErrEvidenceReadLimitExceeded) || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("readLimitExceededError = %v, want ErrEvidenceReadLimitExceeded containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func testEntryLine(t *testing.T, seq uint64) string {
+	t.Helper()
+	entry := Entry{
+		Version:   EntryVersion,
+		Sequence:  seq,
+		Timestamp: time.Date(2026, 7, 12, 12, 0, int(seq), 0, time.UTC),
+		SessionID: "s1",
+		Type:      "request",
+		Transport: "fetch",
+		Summary:   fmt.Sprintf("entry %d", seq),
+		PrevHash:  GenesisHash,
+	}
+	entry.Hash = ComputeHash(entry)
+	wire, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	return string(wire) + "\n"
+}
+
+type countingReader struct {
+	r    io.Reader
+	read int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	r.read += int64(n)
+	return n, err
+}
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, errors.New("forced reader error")
 }

--- a/internal/recorder/query.go
+++ b/internal/recorder/query.go
@@ -28,11 +28,15 @@ type QueryFilter struct {
 	HasMaxSeq bool // Distinguishes MaxSeq=0 from unset
 
 	// MaxEntriesRead is a hard ceiling on parsed recorder entries for callers
-	// that render evidence in an online UI. Zero means unbounded.
+	// that render evidence in an online UI. Zero uses the default per-file
+	// evidence ceiling.
 	MaxEntriesRead int
 	// MaxDirectoryEntries is a hard ceiling on evidence directory entries read
-	// before filtering to one session. Zero means unbounded.
+	// before filtering to one session. Zero uses the default ceiling.
 	MaxDirectoryEntries int
+	// MaxBytesRead is a hard ceiling on recorder bytes scanned before filtering.
+	// Zero uses the default per-file evidence ceiling.
+	MaxBytesRead int64
 }
 
 // QueryResult holds the results of an evidence query.
@@ -41,13 +45,14 @@ type QueryResult struct {
 	TotalFiles  int
 	FilesRead   int
 	EntriesRead int
+	BytesRead   int64
 	Truncated   bool
 }
 
 // QuerySession reads evidence files for a session and applies filters.
 func QuerySession(dir, sessionID string, filter *QueryFilter) (*QueryResult, error) {
 	dir = filepath.Clean(dir)
-	dirEntries, err := readDirectoryEntries(dir, maxDirectoryEntries(filter))
+	dirEntries, dirTruncated, err := readDirectoryEntries(dir, maxDirectoryEntries(filter))
 	if err != nil {
 		return nil, fmt.Errorf("reading evidence directory: %w", err)
 	}
@@ -70,10 +75,11 @@ func QuerySession(dir, sessionID string, filter *QueryFilter) (*QueryResult, err
 
 	result := &QueryResult{
 		TotalFiles: len(files),
+		Truncated:  dirTruncated,
 	}
 
 	for _, f := range files {
-		maxEntries := 0
+		maxEntries := MaxEvidenceReadEntries
 		if filter != nil && filter.MaxEntriesRead > 0 {
 			remaining := filter.MaxEntriesRead - result.EntriesRead
 			if remaining <= 0 {
@@ -82,13 +88,23 @@ func QuerySession(dir, sessionID string, filter *QueryFilter) (*QueryResult, err
 			}
 			maxEntries = remaining
 		}
+		maxBytes := MaxEvidenceReadFileBytes
+		if filter != nil && filter.MaxBytesRead > 0 {
+			remaining := filter.MaxBytesRead - result.BytesRead
+			if remaining <= 0 {
+				result.Truncated = true
+				break
+			}
+			maxBytes = remaining
+		}
 
-		entries, truncated, err := readEntries(f, maxEntries)
+		entries, truncated, bytesRead, err := readEntries(f, entryReadLimits{MaxEntries: maxEntries, MaxBytes: maxBytes})
 		if err != nil {
 			return nil, fmt.Errorf("reading %s: %w", filepath.Base(f), err)
 		}
 		result.FilesRead++
 		result.EntriesRead += len(entries)
+		result.BytesRead += bytesRead
 		if truncated {
 			result.Truncated = true
 		}
@@ -112,16 +128,35 @@ func QuerySession(dir, sessionID string, filter *QueryFilter) (*QueryResult, err
 
 // ListSessions returns the unique session IDs found in evidence files.
 func ListSessions(dir string) ([]string, error) {
-	return ListSessionsBounded(dir, 0)
+	return ListSessionsBounded(dir, MaxEvidenceReadDirectoryEntries)
+}
+
+type SessionListResult struct {
+	Sessions  []string
+	Truncated bool
 }
 
 // ListSessionsBounded returns unique session IDs while enforcing a hard ceiling
 // on directory entries read. Zero means unbounded.
 func ListSessionsBounded(dir string, maxEntries int) ([]string, error) {
-	dir = filepath.Clean(dir)
-	dirEntries, err := readDirectoryEntries(dir, maxEntries)
+	result, err := ListSessionsBoundedResult(dir, maxEntries)
 	if err != nil {
-		return nil, fmt.Errorf("reading evidence directory: %w", err)
+		return nil, err
+	}
+	if result.Truncated {
+		return nil, fmt.Errorf("%w: evidence directory exceeds %d entries", ErrEvidenceReadLimitExceeded, maxEntries)
+	}
+	return result.Sessions, nil
+}
+
+// ListSessionsBoundedResult returns unique session IDs and an explicit
+// truncation signal when the directory-entry ceiling is reached. Zero means
+// unbounded.
+func ListSessionsBoundedResult(dir string, maxEntries int) (SessionListResult, error) {
+	dir = filepath.Clean(dir)
+	dirEntries, truncated, err := readDirectoryEntries(dir, maxEntries)
+	if err != nil {
+		return SessionListResult{}, fmt.Errorf("reading evidence directory: %w", err)
 	}
 
 	seen := make(map[string]struct{})
@@ -144,23 +179,24 @@ func ListSessionsBounded(dir string, maxEntries int) ([]string, error) {
 		sessions = append(sessions, s)
 	}
 	sort.Strings(sessions)
-	return sessions, nil
+	return SessionListResult{Sessions: sessions, Truncated: truncated}, nil
 }
 
 func maxDirectoryEntries(filter *QueryFilter) int {
-	if filter == nil {
-		return 0
+	if filter != nil && filter.MaxDirectoryEntries > 0 {
+		return filter.MaxDirectoryEntries
 	}
-	return filter.MaxDirectoryEntries
+	return MaxEvidenceReadDirectoryEntries
 }
 
-func readDirectoryEntries(dir string, maxEntries int) ([]os.DirEntry, error) {
+func readDirectoryEntries(dir string, maxEntries int) ([]os.DirEntry, bool, error) {
 	if maxEntries <= 0 {
-		return os.ReadDir(dir)
+		entries, err := os.ReadDir(dir)
+		return entries, false, err
 	}
 	directory, err := os.Open(filepath.Clean(dir))
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer func() { _ = directory.Close() }()
 	// maxEntries+1 would overflow to a negative value at math.MaxInt, and a
@@ -171,12 +207,12 @@ func readDirectoryEntries(dir string, maxEntries int) ([]os.DirEntry, error) {
 	}
 	entries, err := directory.ReadDir(readLimit)
 	if err != nil && !errors.Is(err, io.EOF) {
-		return nil, err
+		return nil, false, err
 	}
 	if len(entries) > maxEntries {
-		return nil, fmt.Errorf("directory entry count exceeds %d", maxEntries)
+		return entries[:maxEntries], true, nil
 	}
-	return entries, nil
+	return entries, false, nil
 }
 
 func evidenceFileSessionID(name string) (string, bool) {

--- a/internal/recorder/query_internal_test.go
+++ b/internal/recorder/query_internal_test.go
@@ -6,6 +6,7 @@
 package recorder
 
 import (
+	"errors"
 	"math"
 	"os"
 	"path/filepath"
@@ -22,25 +23,27 @@ func TestReadDirectoryEntriesBounded(t *testing.T) {
 		}
 	}
 
-	// Unbounded (maxEntries <= 0) returns every entry.
-	all, err := readDirectoryEntries(dir, 0)
-	if err != nil || len(all) != 3 {
-		t.Fatalf("unbounded readDirectoryEntries = %d entries, err %v; want 3", len(all), err)
+	tests := []struct {
+		name          string
+		maxEntries    int
+		wantEntries   int
+		wantTruncated bool
+	}{
+		{name: "unbounded", maxEntries: 0, wantEntries: 3},
+		{name: "bounded within", maxEntries: 3, wantEntries: 3},
+		{name: "bounded over", maxEntries: 2, wantEntries: 2, wantTruncated: true},
 	}
-
-	// Bounded at or above the entry count succeeds.
-	within, err := readDirectoryEntries(dir, 3)
-	if err != nil || len(within) != 3 {
-		t.Fatalf("bounded-within readDirectoryEntries = %d entries, err %v; want 3", len(within), err)
-	}
-
-	// Bounded below the entry count fails closed.
-	if _, err := readDirectoryEntries(dir, 2); err == nil {
-		t.Fatal("readDirectoryEntries accepted a directory exceeding the entry cap")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entries, truncated, err := readDirectoryEntries(dir, test.maxEntries)
+			if err != nil || truncated != test.wantTruncated || len(entries) != test.wantEntries {
+				t.Fatalf("readDirectoryEntries = %d entries, truncated %t, err %v; want %d, %t, nil", len(entries), truncated, err, test.wantEntries, test.wantTruncated)
+			}
+		})
 	}
 
 	// A missing directory surfaces the open error rather than silently succeeding.
-	if _, err := readDirectoryEntries(filepath.Join(dir, "missing"), 1); err == nil {
+	if _, _, err := readDirectoryEntries(filepath.Join(dir, "missing"), 1); err == nil {
 		t.Fatal("readDirectoryEntries accepted a missing directory")
 	}
 }
@@ -56,8 +59,31 @@ func TestReadDirectoryEntriesMaxIntNoOverflow(t *testing.T) {
 	}
 	// maxEntries at math.MaxInt must not overflow maxEntries+1 into a negative
 	// count (which would make ReadDir read the directory unbounded).
-	entries, err := readDirectoryEntries(dir, math.MaxInt)
-	if err != nil || len(entries) != 2 {
-		t.Fatalf("readDirectoryEntries(MaxInt) = %d entries, err %v; want 2 entries, nil", len(entries), err)
+	entries, truncated, err := readDirectoryEntries(dir, math.MaxInt)
+	if err != nil || truncated || len(entries) != 2 {
+		t.Fatalf("readDirectoryEntries(MaxInt) = %d entries, truncated %t, err %v; want 2, false, nil", len(entries), truncated, err)
+	}
+}
+
+func TestListSessionsBoundedResultReportsTruncation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for _, name := range []string{"evidence-b-0.jsonl", "evidence-a-0.jsonl", "evidence-c-0.jsonl"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0o600); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	result, err := ListSessionsBoundedResult(dir, 2)
+	if err != nil {
+		t.Fatalf("ListSessionsBoundedResult: %v", err)
+	}
+	if !result.Truncated || len(result.Sessions) != 2 {
+		t.Fatalf("result = %+v, want two sessions with truncation", result)
+	}
+
+	if _, err := ListSessionsBounded(dir, 2); !errors.Is(err, ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("ListSessionsBounded error = %v, want ErrEvidenceReadLimitExceeded", err)
 	}
 }

--- a/internal/recorder/query_internal_test.go
+++ b/internal/recorder/query_internal_test.go
@@ -46,6 +46,14 @@ func TestReadDirectoryEntriesBounded(t *testing.T) {
 	if _, _, err := readDirectoryEntries(filepath.Join(dir, "missing"), 1); err == nil {
 		t.Fatal("readDirectoryEntries accepted a missing directory")
 	}
+
+	regularFile := filepath.Join(dir, "regular-file")
+	if err := os.WriteFile(regularFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := readDirectoryEntries(regularFile, 1); err == nil {
+		t.Fatal("readDirectoryEntries accepted a regular file as a directory")
+	}
 }
 
 func TestReadDirectoryEntriesMaxIntNoOverflow(t *testing.T) {
@@ -85,5 +93,14 @@ func TestListSessionsBoundedResultReportsTruncation(t *testing.T) {
 
 	if _, err := ListSessionsBounded(dir, 2); !errors.Is(err, ErrEvidenceReadLimitExceeded) {
 		t.Fatalf("ListSessionsBounded error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+}
+
+func TestMaxDirectoryEntriesUsesExplicitFilterLimit(t *testing.T) {
+	t.Parallel()
+
+	got := maxDirectoryEntries(&QueryFilter{MaxDirectoryEntries: 7})
+	if got != 7 {
+		t.Fatalf("maxDirectoryEntries = %d, want explicit filter limit", got)
 	}
 }

--- a/internal/recorder/query_test.go
+++ b/internal/recorder/query_test.go
@@ -154,6 +154,36 @@ func TestQuerySession_MaxBytesReadTruncatesAcrossFiles(t *testing.T) {
 	}
 }
 
+func TestQuerySession_MaxBytesReadStopsBeforeNextFile(t *testing.T) {
+	dir := t.TempDir()
+	first := []byte(`{"v":2,"seq":0,"ts":"2026-01-01T00:00:00Z","session_id":"sess-1","type":"request","transport":"fetch","summary":"first"}` + "\n")
+	second := []byte(`{"v":2,"seq":1,"ts":"2026-01-01T00:00:01Z","session_id":"sess-1","type":"response","transport":"fetch","summary":"second"}` + "\n")
+	for path, data := range map[string][]byte{
+		filepath.Join(dir, "evidence-sess-1-0.jsonl"): first,
+		filepath.Join(dir, "evidence-sess-1-1.jsonl"): second,
+	} {
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := recorder.QuerySession(dir, "sess-1", &recorder.QueryFilter{
+		MaxBytesRead: int64(len(first)),
+	})
+	if err != nil {
+		t.Fatalf("QuerySession: %v", err)
+	}
+	if !result.Truncated {
+		t.Fatal("QuerySession did not report truncation before reading the next file")
+	}
+	if result.FilesRead != 1 || result.EntriesRead != 1 || len(result.Entries) != 1 {
+		t.Fatalf("files=%d entriesRead=%d returned=%d, want only first file read", result.FilesRead, result.EntriesRead, len(result.Entries))
+	}
+	if result.BytesRead != int64(len(first)) {
+		t.Fatalf("BytesRead = %d, want exact first file size %d", result.BytesRead, len(first))
+	}
+}
+
 func TestQuerySession_ZeroReadLimitsUseDefaultPerFileCeilings(t *testing.T) {
 	t.Run("entries", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/recorder/query_test.go
+++ b/internal/recorder/query_test.go
@@ -90,6 +90,30 @@ func TestQuerySession_MaxEntriesReadTruncates(t *testing.T) {
 	}
 }
 
+func TestQuerySession_MaxBytesReadTruncatesSkippedLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence-sess-1-0.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Repeat("\n", 1024)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := recorder.QuerySession(dir, "sess-1", &recorder.QueryFilter{
+		MaxBytesRead: 128,
+	})
+	if err != nil {
+		t.Fatalf("QuerySession: %v", err)
+	}
+	if !result.Truncated {
+		t.Fatal("QuerySession did not report byte-limit truncation")
+	}
+	if result.BytesRead <= 128 {
+		t.Fatalf("BytesRead = %d, want evidence that byte limit was reached", result.BytesRead)
+	}
+	if result.EntriesRead != 0 || len(result.Entries) != 0 {
+		t.Fatalf("entries = read %d returned %d, want empty truncated result", result.EntriesRead, len(result.Entries))
+	}
+}
+
 func TestQuerySession_FilterByType(t *testing.T) {
 	dir := t.TempDir()
 	writeTestEntries(t, dir, "sess-1", 6)

--- a/internal/recorder/query_test.go
+++ b/internal/recorder/query_test.go
@@ -200,6 +200,48 @@ func TestQuerySession_ZeroReadLimitsUseDefaultPerFileCeilings(t *testing.T) {
 			t.Fatalf("BytesRead = %d, want evidence that default byte limit was reached", result.BytesRead)
 		}
 	})
+
+	// A zero limit selects the default PER FILE, not a session-wide budget. Each
+	// file here stays under BOTH default ceilings (bytes and entries) while the
+	// pair together exceeds one default byte budget, so a regression that spent a
+	// single shared budget across the session would truncate the second file.
+	t.Run("default byte ceiling applies per file, not per session", func(t *testing.T) {
+		dir := t.TempDir()
+		const entriesPerFile = 6000
+		pad := strings.Repeat("x", 700)
+		targetPerFile := int(recorder.MaxEvidenceReadFileBytes) * 2 / 3
+		for index, name := range []string{"evidence-sess-1-0.jsonl", "evidence-sess-1-1.jsonl"} {
+			var body strings.Builder
+			for n := 0; n < entriesPerFile; n++ {
+				_, _ = fmt.Fprintf(&body,
+					`{"v":2,"seq":%d,"ts":"2026-01-01T00:00:00Z","session_id":"sess-1","type":"request","transport":"fetch","summary":%q}`+"\n",
+					index*entriesPerFile+n, pad)
+			}
+			if body.Len() >= int(recorder.MaxEvidenceReadFileBytes) {
+				t.Fatalf("file %s is %d bytes, must stay under the per-file default %d", name, body.Len(), recorder.MaxEvidenceReadFileBytes)
+			}
+			if body.Len() < targetPerFile/2 {
+				t.Fatalf("file %s is only %d bytes, too small to prove the per-file budget", name, body.Len())
+			}
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(body.String()), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if entriesPerFile >= recorder.MaxEvidenceReadEntries {
+			t.Fatalf("entriesPerFile %d must stay under the entry default %d", entriesPerFile, recorder.MaxEvidenceReadEntries)
+		}
+
+		result, err := recorder.QuerySession(dir, "sess-1", &recorder.QueryFilter{MaxBytesRead: 0})
+		if err != nil {
+			t.Fatalf("QuerySession: %v", err)
+		}
+		if result.Truncated {
+			t.Fatalf("two files each under the default ceilings were truncated: bytes=%d entries=%d", result.BytesRead, result.EntriesRead)
+		}
+		if result.BytesRead <= recorder.MaxEvidenceReadFileBytes {
+			t.Fatalf("BytesRead = %d, want the pair to exceed one default byte ceiling", result.BytesRead)
+		}
+	})
 }
 
 func TestQuerySession_FilterByType(t *testing.T) {

--- a/internal/recorder/query_test.go
+++ b/internal/recorder/query_test.go
@@ -114,6 +114,94 @@ func TestQuerySession_MaxBytesReadTruncatesSkippedLines(t *testing.T) {
 	}
 }
 
+func TestQuerySession_MaxBytesReadTruncatesAcrossFiles(t *testing.T) {
+	dir := t.TempDir()
+	first := []byte(`{"v":2,"seq":0,"ts":"2026-01-01T00:00:00Z","session_id":"sess-1","type":"request","transport":"fetch","summary":"first"}` + "\n")
+	second := []byte(`{"v":2,"seq":1,"ts":"2026-01-01T00:00:01Z","session_id":"sess-1","type":"response","transport":"fetch","summary":"second"}` + "\n")
+	maxBytesRead := int64(len(first) + len(second) - 1)
+	for path, data := range map[string][]byte{
+		filepath.Join(dir, "evidence-sess-1-0.jsonl"): first,
+		filepath.Join(dir, "evidence-sess-1-1.jsonl"): second,
+	} {
+		if len(data) >= int(maxBytesRead) {
+			t.Fatalf("%s length = %d, want below aggregate cap %d", filepath.Base(path), len(data), maxBytesRead)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := recorder.QuerySession(dir, "sess-1", &recorder.QueryFilter{
+		MaxBytesRead: maxBytesRead,
+	})
+	if err != nil {
+		t.Fatalf("QuerySession: %v", err)
+	}
+	if !result.Truncated {
+		t.Fatal("QuerySession did not report cross-file byte-limit truncation")
+	}
+	if result.TotalFiles != 2 || result.FilesRead != 2 {
+		t.Fatalf("files = total %d read %d, want second file to trigger truncation", result.TotalFiles, result.FilesRead)
+	}
+	if result.BytesRead <= maxBytesRead {
+		t.Fatalf("BytesRead = %d, want evidence that aggregate byte limit was reached", result.BytesRead)
+	}
+	if result.EntriesRead != 1 || len(result.Entries) != 1 {
+		t.Fatalf("entries = read %d returned %d, want only first file before truncation", result.EntriesRead, len(result.Entries))
+	}
+	if result.Entries[0].Sequence != 0 {
+		t.Fatalf("entry sequence = %d, want only first file entry", result.Entries[0].Sequence)
+	}
+}
+
+func TestQuerySession_ZeroReadLimitsUseDefaultPerFileCeilings(t *testing.T) {
+	t.Run("entries", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "evidence-sess-1-0.jsonl")
+		var data strings.Builder
+		for seq := range recorder.MaxEvidenceReadEntries + 1 {
+			_, _ = fmt.Fprintf(&data, `{"v":2,"seq":%d,"ts":"2026-01-01T00:00:00Z","session_id":"sess-1","type":"request"}`+"\n", seq)
+		}
+		if err := os.WriteFile(path, []byte(data.String()), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := recorder.QuerySession(dir, "sess-1", &recorder.QueryFilter{
+			MaxEntriesRead: 0,
+		})
+		if err != nil {
+			t.Fatalf("QuerySession: %v", err)
+		}
+		if !result.Truncated {
+			t.Fatal("QuerySession did not report default entry-limit truncation")
+		}
+		if result.EntriesRead != recorder.MaxEvidenceReadEntries {
+			t.Fatalf("EntriesRead = %d, want default ceiling %d", result.EntriesRead, recorder.MaxEvidenceReadEntries)
+		}
+	})
+
+	t.Run("bytes", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "evidence-sess-1-0.jsonl")
+		if err := os.WriteFile(path, []byte(strings.Repeat("\n", int(recorder.MaxEvidenceReadFileBytes)+1)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := recorder.QuerySession(dir, "sess-1", &recorder.QueryFilter{
+			MaxBytesRead: 0,
+		})
+		if err != nil {
+			t.Fatalf("QuerySession: %v", err)
+		}
+		if !result.Truncated {
+			t.Fatal("QuerySession did not report default byte-limit truncation")
+		}
+		if result.BytesRead <= recorder.MaxEvidenceReadFileBytes {
+			t.Fatalf("BytesRead = %d, want evidence that default byte limit was reached", result.BytesRead)
+		}
+	})
+}
+
 func TestQuerySession_FilterByType(t *testing.T) {
 	dir := t.TempDir()
 	writeTestEntries(t, dir, "sess-1", 6)

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -924,19 +924,17 @@ func (r *Recorder) sessionFiles(sessionID string) ([]string, error) {
 }
 
 func readEntriesForResume(path string) ([]Entry, error) {
-	data, err := ReadEvidenceFileBounded(path, MaxEvidenceReadFileBytes)
+	limits := defaultEntryReadLimits()
+	data, err := ReadEvidenceFileBounded(path, limits.MaxBytes)
 	if err != nil {
 		return nil, err
 	}
-	entries, truncated, _, err := readEntriesFromReader(bytes.NewReader(data), entryReadLimits{
-		MaxEntries: MaxEvidenceReadEntries,
-		MaxBytes:   MaxEvidenceReadFileBytes,
-	})
+	entries, truncated, bytesRead, err := readEntriesFromReader(bytes.NewReader(data), limits)
 	if err != nil {
 		return nil, err
 	}
 	if truncated {
-		return nil, fmt.Errorf("%w: evidence file %s exceeds %d entries", ErrEvidenceReadLimitExceeded, filepath.Base(path), MaxEvidenceReadEntries)
+		return nil, readLimitExceededError(path, limits, bytesRead)
 	}
 	return entries, nil
 }

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -928,7 +928,10 @@ func readEntriesForResume(path string) ([]Entry, error) {
 	if err != nil {
 		return nil, err
 	}
-	entries, truncated, err := readEntriesFromReader(bytes.NewReader(data), MaxEvidenceReadEntries)
+	entries, truncated, _, err := readEntriesFromReader(bytes.NewReader(data), entryReadLimits{
+		MaxEntries: MaxEvidenceReadEntries,
+		MaxBytes:   MaxEvidenceReadFileBytes,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -1033,6 +1033,63 @@ func TestRecorder_ResumeRejectsOverCapTailRead(t *testing.T) {
 	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
 		t.Fatalf("Record error = %v, want ErrEvidenceReadLimitExceeded", err)
 	}
+	if got := err.Error(); !strings.Contains(got, "bytes") || strings.Contains(got, "entries") {
+		t.Fatalf("Record error = %q, want byte-limit diagnosis only", got)
+	}
+}
+
+func TestRecorder_ResumeRejectsOverCapTailEntriesReportsEntryLimit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence-resume-entry-cap-0.jsonl")
+
+	var input strings.Builder
+	for seq := uint64(0); seq <= recorder.MaxEvidenceReadEntries; seq++ {
+		entry := recorder.Entry{
+			Version:   recorder.EntryVersion,
+			Sequence:  seq,
+			Timestamp: time.Unix(1712345678, 0).UTC(),
+			SessionID: "resume-entry-cap",
+			Type:      testType,
+			Transport: testTransport,
+			Summary:   "tail entry cap",
+			Detail:    map[string]string{"safe": "value"},
+			PrevHash:  recorder.GenesisHash,
+		}
+		entry.Hash = recorder.ComputeHash(entry)
+		line, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("Marshal entry: %v", err)
+		}
+		input.Write(line)
+		input.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, []byte(input.String()), filePermissions); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 100,
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+
+	err = rec.Record(recorder.Entry{
+		SessionID: "resume-entry-cap",
+		Type:      testType,
+		Transport: testTransport,
+		Summary:   "must fail closed on over-cap tail entries",
+		Detail:    map[string]string{"safe": "value"},
+	})
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("Record error = %v, want ErrEvidenceReadLimitExceeded", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "entries") || strings.Contains(got, "bytes") {
+		t.Fatalf("Record error = %q, want entry-limit diagnosis only", got)
+	}
 }
 
 func TestComputeFileHash(t *testing.T) {

--- a/internal/replaycapture/assemble.go
+++ b/internal/replaycapture/assemble.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	auditpacket "github.com/luckyPipewrench/pipelock/sdk/audit-packet"
 )
 
@@ -276,7 +277,7 @@ func validateSafeHost(host string) error {
 // writePacketFiles writes packet.json, evidence.jsonl (the signed chain),
 // verifier.txt, and summary.md into the packet directory.
 func writePacketFiles(packetDir string, cs *CapturedScenario, pkt *auditpacket.Packet) error {
-	evidenceBytes, err := os.ReadFile(filepath.Clean(cs.EvidenceFile))
+	evidenceBytes, err := recorder.ReadEvidenceFileBounded(filepath.Clean(cs.EvidenceFile), recorder.MaxEvidenceReadFileBytes)
 	if err != nil {
 		return fmt.Errorf("reading evidence: %w", err)
 	}

--- a/internal/replaycapture/assemble_test.go
+++ b/internal/replaycapture/assemble_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	auditpacket "github.com/luckyPipewrench/pipelock/sdk/audit-packet"
 )
 
@@ -113,5 +114,31 @@ func TestValidatePacketEnvelopePublicSafe_Rejections(t *testing.T) {
 				t.Fatalf("expected errEnvelope, got %v", err)
 			}
 		})
+	}
+}
+
+func TestAssemblePacketRejectsOverCapEvidenceRead(t *testing.T) {
+	t.Parallel()
+
+	eng := newTestEngine(t)
+	cs, err := eng.Capture(DefaultScenarios()[0])
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	f, err := os.OpenFile(cs.EvidenceFile, os.O_WRONLY|os.O_APPEND, filePerm)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	if _, err := f.Write(make([]byte, recorder.MaxEvidenceReadFileBytes+1)); err != nil {
+		_ = f.Close()
+		t.Fatalf("Write: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	_, err = AssemblePacket(cs, t.TempDir(), fixedStamp())
+	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
+		t.Fatalf("AssemblePacket error = %v, want ErrEvidenceReadLimitExceeded", err)
 	}
 }


### PR DESCRIPTION
Recorder evidence reads are bounded by bytes and by entry count. A read that reaches a limit reports truncation or returns an error rather than a partial result that looks complete, so a caller cannot treat a shortened read as a whole record.

`QuerySession` tracks bytes read and sets `Truncated` when a byte, entry, or directory limit is reached. `ListSessionsBoundedResult` exposes directory truncation and the strict list helpers return an error on it. Recorder resume, the dashboard read-model rebuild, receipt extraction, capture replay, and replay-capture assembly all read through the bounded path.

Receipt extraction fails closed on a truncated read instead of falling back to the raw receipt format. That keeps a shortened read out of the verifier and signing paths, where it would otherwise understate a chain.

`docs/guides/flight-recorder.md` documents the truncation and error semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bounded-read controls for evidence and session querying, including max entry and max evidence byte limits.
  - Query and session results now surface truncation status (and bytes read), and bounded session listing can explicitly indicate truncation.
- **Bug Fixes**
  - Evidence loading, receipt extraction, and packet assembly now reliably reject truncated evidence/metadata instead of falling back or returning partial results.
- **Documentation**
  - Updated the Flight Recorder guide with the corrected bounded-read and truncation/error semantics.
- **Tests**
  - Added coverage for truncation and limit-boundary behaviors across evidence reads, queries, and resume/replay flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->