### PR TITLE
fix(contain): attribute nft enforcement positively and validate scripts before applying

### DIFF
--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -129,7 +129,7 @@ pipelock contain verify
 |---|---|---|
 | 1 | `system_users_exist` | `pipelock-proxy` and `pipelock-agent` UIDs exist. |
 | 2 | `pipelock_systemd_unit` | `pipelock.service` is running as `pipelock-proxy`. |
-| 3 | `nftables_containment_ruleset` | The containment ruleset is loaded and matches the expected shape. |
+| 3 | `nftables_containment_ruleset` | The exact managed nftables chain is loaded as the active output base chain and contains the required attributed owner-match rules. |
 | 4 | `wrapper_scripts_installed` | `plk-launch` plus the registered tool wrappers exist with correct mode. |
 | 5 | `ca_bundle_present` | `/etc/pipelock/combined-ca.pem` is readable by the agent user. |
 | 6 | `pipelock_listening_loopback` | Pipelock is accepting connections on `127.0.0.1:<proxy-port>`. |
@@ -139,6 +139,11 @@ pipelock contain verify
 | 10 | `binary_integrity_pin` | The installed pipelock binary hash matches `/etc/pipelock/integrity/binary-pin.sha256`. |
 | 11 | `cc_launch_allow_list_enforced` | `plk-launch` rejects tools that are not in the registered allow-list. |
 | 12 | `listed_tool_targets_resolvable` | Every entry in `tools.list` resolves to an executable absolute path in the agent user's PATH. |
+
+The nftables probes fail closed when attribution is ambiguous. A regular
+lookalike chain, a table-wide listing that happens to contain matching-looking
+rules, or an unreadable managed DROP counter is reported as not enforced rather
+than treated as probable containment.
 
 Flags:
 
@@ -205,7 +210,7 @@ Checks:
 | 3 | `python_through_proxy` | `python` reaches an allowed host via the `pipelock-python` wrapper. |
 | 4 | `node_through_proxy` | node's `fetch()` reaches an allowed host via the `pipelock-node` wrapper + undici shim. |
 | 5 | `dns_failure_clean` | An unresolvable host fails fast with a clean proxy error — no hang, no bypass. |
-| 6 | `raw_egress_blocked` | A DNS-free direct, proxy-bypassing canary reports that its TCP dial did not complete and coincides with an increment in the managed catch-all DROP counter. This is also the root cause a proxy-unaware tool surfaces, so the remediation names the fix. |
+| 6 | `raw_egress_blocked` | A DNS-free direct, proxy-bypassing canary reports that its TCP dial did not complete and coincides with an increment in the positively attributed managed catch-all DROP counter. This is also the root cause a proxy-unaware tool surfaces, so the remediation names the fix. |
 
 Checks print a one-line, class-tagged remediation when an operator action or compatibility note is useful; this can accompany either a non-passing result or a PASS that diagnoses expected containment behavior. For example, a proxy-unaware tool produces:
 

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1321,16 +1321,28 @@ func stepInstallNFTRules() step {
 			body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, env.nftTableOrDefault(), env.nftChainOrDefault())
 
 			rulesMatch := false
+			existingRulesManaged := false
 			if existing, err := env.readFile(env.nftRulesPath); err == nil {
-				rulesMatch = string(existing) == body
+				existingBody := string(existing)
+				rulesMatch = existingBody == body
+				existingRulesManaged = nftRulesTextHasManagedHeader(existingBody)
 			} else if !errors.Is(err, os.ErrNotExist) {
 				return false, fmt.Errorf("read %s: %w", env.nftRulesPath, err)
 			}
 			tableLoaded := false
+			liveChainAttributed := false
 			liveRulesDrifted := false
+			liveRulesManaged := false
 			if out, code, _ := env.runCmd(ctx, nftExecutable(env), "-n", "-a", "list", "chain", "inet", env.nftTableOrDefault(), env.nftChainOrDefault()); code == 0 {
 				tableLoaded = true
+				if _, err := attributedNFTChainLines(out, env.nftChainOrDefault()); err == nil {
+					liveChainAttributed = true
+				}
 				liveRulesDrifted = !liveNFTContainmentMatches(out, env.nftChainOrDefault(), operatorUID, proxyUID, agentUID, env.proxyPort)
+				liveRulesManaged = liveNFTContainmentLooksManaged(out, env.nftChainOrDefault(), operatorUID, proxyUID, agentUID, env.proxyPort)
+			}
+			if tableLoaded && liveChainAttributed && (!rulesMatch || liveRulesDrifted) && !existingRulesManaged && !liveRulesManaged {
+				return false, fmt.Errorf("existing nft chain inet %s %s is not attributable to Pipelock; refusing to replace it", env.nftTableOrDefault(), env.nftChainOrDefault())
 			}
 
 			rulesChanged := false
@@ -1442,6 +1454,10 @@ func restorePreviousNFTState(ctx context.Context, env *installEnv) error {
 	return nil
 }
 
+func nftRulesTextHasManagedHeader(body string) bool {
+	return strings.Contains(body, "# Pipelock containment ruleset (managed by pipelock contain install).")
+}
+
 func liveNFTContainmentMatches(out, chainName string, operatorUID, proxyUID, agentUID, proxyPort int) bool {
 	lines, err := attributedNFTChainLines(out, chainName)
 	if err != nil {
@@ -1460,6 +1476,19 @@ func liveNFTContainmentMatches(out, chainName string, operatorUID, proxyUID, age
 			proxyUID:      proxyUID,
 			agentUID:      agentUID,
 		}, proxyPort)
+}
+
+func liveNFTContainmentLooksManaged(out, chainName string, operatorUID, proxyUID, agentUID, proxyPort int) bool {
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return false
+	}
+	return chainLinesHaveSkuidAcceptForUID(lines, operatorUID) &&
+		chainLinesHaveSkuidAcceptForUID(lines, proxyUID) &&
+		chainLinesHaveAgentCatchAllDrop(lines, agentUID) &&
+		chainLinesHaveAgentProxyLoopbackAllowBeforeDrop(lines, agentUID, proxyPort) &&
+		chainLinesHaveAgentDNSDropBeforeCatchAll(lines, agentUID, "udp") &&
+		chainLinesHaveAgentDNSDropBeforeCatchAll(lines, agentUID, "tcp")
 }
 
 func nftRulesIncludeLine(path string) string {

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1302,9 +1302,9 @@ func stepInstallNFTRules() step {
 		desc: "write + load /etc/nftables.d/50-pipelock-containment.nft + persist via pipelock-containment-nft.service",
 		apply: func(ctx context.Context, env *installEnv) (bool, error) {
 			// Check nft version before generating rules. The containment
-			// ruleset requires "meta skuid" (available since nftables 0.4)
-			// and "counter log prefix ... drop" inline syntax (0.6+). Hosts
-			// with nft < 0.5 (rare but seen on AL2-era images) fail at load
+			// ruleset requires "meta skuid" (available since nftables 0.4),
+			// "counter log prefix ... drop" inline syntax (0.6+), and nft
+			// check mode (-c/--check, 0.8+). Hosts below that fail at load
 			// time with a cryptic parse error. Detect early and fail with a
 			// clear minimum-version message.
 			if err := checkNFTVersion(ctx, env); err != nil {
@@ -1372,17 +1372,14 @@ func stepInstallNFTRules() step {
 			if !tableLoaded || rulesChanged || liveRulesDrifted {
 				captureNFTPreState(ctx, env)
 			}
+			reloadedManagedChain := false
 			if tableLoaded && (rulesChanged || liveRulesDrifted) {
-				// nft -f merges into an existing table. Drop only the managed
-				// chain first so stale Pipelock rules cannot survive beside
-				// the new ruleset, while operator co-located chains in the
-				// table remain untouched.
-				if err := runOrErr(ctx, env, nftExecutable(env), "delete", "chain", "inet", env.nftTableOrDefault(), env.nftChainOrDefault()); err != nil {
-					return false, fmt.Errorf("delete stale nft chain inet %s %s: %w", env.nftTableOrDefault(), env.nftChainOrDefault(), err)
+				if err := reloadNFTManagedChain(ctx, env, body); err != nil {
+					return false, err
 				}
-				tableLoaded = false
+				reloadedManagedChain = true
 			}
-			if !tableLoaded || rulesChanged || liveRulesDrifted {
+			if !reloadedManagedChain && (!tableLoaded || rulesChanged || liveRulesDrifted) {
 				if err := runOrErr(ctx, env, nftExecutable(env), "-f", env.nftRulesPath); err != nil {
 					return false, fmt.Errorf("nft load failed: %w", err)
 				}
@@ -1450,6 +1447,9 @@ func restorePreviousNFTState(ctx context.Context, env *installEnv) error {
 	if strings.TrimSpace(env.prevNFTTableDump) == "" {
 		return nil
 	}
+	if !nftTableDumpDeclaresExpectedTable(env.prevNFTTableDump, env.nftTableOrDefault()) {
+		return fmt.Errorf("captured nft table dump is not table inet %s", env.nftTableOrDefault())
+	}
 	restorePath := env.nftRulesPath + ".restore"
 	restoreScript := "delete table inet " + env.nftTableOrDefault() + "\n" + env.prevNFTTableDump
 	if err := env.writeFile(restorePath, []byte(restoreScript), modeConfigSecret); err != nil {
@@ -1463,6 +1463,34 @@ func restorePreviousNFTState(ctx context.Context, env *installEnv) error {
 		return fmt.Errorf("restore previous nft table: %w", err)
 	}
 	return nil
+}
+
+func reloadNFTManagedChain(ctx context.Context, env *installEnv, rulesBody string) error {
+	reloadPath := env.nftRulesPath + ".reload"
+	reloadScript := "delete chain inet " + env.nftTableOrDefault() + " " + env.nftChainOrDefault() + "\n" + rulesBody
+	if err := env.writeFile(reloadPath, []byte(reloadScript), modeConfigSecret); err != nil {
+		return fmt.Errorf("write nft managed chain reload file %s: %w", reloadPath, err)
+	}
+	defer func() { _ = env.removeFile(reloadPath) }()
+	if err := runOrErr(ctx, env, nftExecutable(env), "-c", "-f", reloadPath); err != nil {
+		return fmt.Errorf("validate nft managed chain reload: %w", err)
+	}
+	if err := runOrErr(ctx, env, nftExecutable(env), "-f", reloadPath); err != nil {
+		return fmt.Errorf("reload nft managed chain: %w", err)
+	}
+	return nil
+}
+
+func nftTableDumpDeclaresExpectedTable(dump, table string) bool {
+	for _, raw := range strings.Split(dump, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := nftLineFields(line)
+		return len(fields) >= 4 && fields[0] == "table" && fields[1] == "inet" && fields[2] == table && fields[3] == "{"
+	}
+	return false
 }
 
 func nftRulesTextHasManagedHeader(body string) bool {
@@ -1615,12 +1643,13 @@ func (e *installEnv) nftChainOrDefault() string {
 }
 
 // minNFTMajor and minNFTMinor define the minimum nftables version that
-// supports all syntax used by the containment ruleset: "meta skuid" (0.4+),
-// "counter log prefix ... drop" inline (0.6+), and "table inet" (0.2+).
-// We require 0.6.0 as the floor.
+// supports all syntax used by the containment ruleset and its validated
+// rollback/repair path: "meta skuid" (0.4+), "counter log prefix ... drop"
+// inline (0.6+), "table inet" (0.2+), and nft check mode (-c/--check, 0.8+).
+// We require 0.8.0 as the floor.
 const (
 	minNFTMajor = 0
-	minNFTMinor = 6
+	minNFTMinor = 8
 )
 
 // checkNFTVersion runs `nft -v` and parses the version. Returns nil when the
@@ -1645,7 +1674,7 @@ func checkNFTVersion(ctx context.Context, env *installEnv) error {
 	}
 	return fmt.Errorf(
 		"nft version %d.%d is too old; the containment ruleset requires nftables >= %d.%d "+
-			"(meta skuid + inline counter/log/drop). "+
+			"(meta skuid + inline counter/log/drop + nft check mode). "+
 			"Upgrade nftables: on RHEL/AL2 `yum install nftables`, on Debian/Ubuntu `apt install nftables`",
 		major, minor, minNFTMajor, minNFTMinor)
 }

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1321,11 +1321,9 @@ func stepInstallNFTRules() step {
 			body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, env.nftTableOrDefault(), env.nftChainOrDefault())
 
 			rulesMatch := false
-			existingRulesManaged := false
 			if existing, err := env.readFile(env.nftRulesPath); err == nil {
 				existingBody := string(existing)
 				rulesMatch = existingBody == body
-				existingRulesManaged = nftRulesTextHasManagedHeader(existingBody)
 			} else if !errors.Is(err, os.ErrNotExist) {
 				return false, fmt.Errorf("read %s: %w", env.nftRulesPath, err)
 			}
@@ -1341,7 +1339,7 @@ func stepInstallNFTRules() step {
 				liveRulesDrifted = !liveNFTContainmentMatches(out, env.nftChainOrDefault(), operatorUID, proxyUID, agentUID, env.proxyPort)
 				liveRulesManaged = liveNFTContainmentLooksManaged(out, env.nftChainOrDefault(), operatorUID, proxyUID, agentUID, env.proxyPort)
 			}
-			if tableLoaded && liveChainAttributed && (!rulesMatch || liveRulesDrifted) && !existingRulesManaged && !liveRulesManaged {
+			if tableLoaded && liveChainAttributed && (!rulesMatch || liveRulesDrifted) && !liveRulesManaged {
 				return false, fmt.Errorf("existing nft chain inet %s %s is not attributable to Pipelock; refusing to replace it", env.nftTableOrDefault(), env.nftChainOrDefault())
 			}
 
@@ -1493,10 +1491,6 @@ func nftTableDumpDeclaresExpectedTable(dump, table string) bool {
 	return false
 }
 
-func nftRulesTextHasManagedHeader(body string) bool {
-	return strings.Contains(body, "# Pipelock containment ruleset (managed by pipelock contain install).")
-}
-
 func liveNFTContainmentMatches(out, chainName string, operatorUID, proxyUID, agentUID, proxyPort int) bool {
 	lines, err := attributedNFTChainLines(out, chainName)
 	if err != nil {
@@ -1522,12 +1516,60 @@ func liveNFTContainmentLooksManaged(out, chainName string, operatorUID, proxyUID
 	if err != nil {
 		return false
 	}
-	return chainLinesHaveSkuidAcceptForUID(lines, operatorUID) &&
-		chainLinesHaveSkuidAcceptForUID(lines, proxyUID) &&
-		chainLinesHaveAgentCatchAllDrop(lines, agentUID) &&
-		chainLinesHaveAgentProxyLoopbackAllowBeforeDrop(lines, agentUID, proxyPort) &&
-		chainLinesHaveAgentDNSDropBeforeCatchAll(lines, agentUID, "udp") &&
-		chainLinesHaveAgentDNSDropBeforeCatchAll(lines, agentUID, "tcp")
+	return chainLinesHaveManagedAgentLoopbackBeforeCatchAllDrop(lines, proxyPort) ||
+		chainLinesHaveSkuidAcceptForUID(lines, operatorUID) &&
+			chainLinesHaveSkuidAcceptForUID(lines, proxyUID) &&
+			chainLinesHaveAgentCatchAllDrop(lines, agentUID) &&
+			chainLinesHaveAgentProxyLoopbackAllowBeforeDrop(lines, agentUID, proxyPort) &&
+			chainLinesHaveAgentDNSDropBeforeCatchAll(lines, agentUID, "udp") &&
+			chainLinesHaveAgentDNSDropBeforeCatchAll(lines, agentUID, "tcp")
+}
+
+func chainLinesHaveManagedAgentLoopbackBeforeCatchAllDrop(lines []string, proxyPort int) bool {
+	loopbackUIDs := make(map[int]struct{})
+	for _, line := range lines {
+		if uid, ok := lineAgentProxyLoopbackAllowUID(line, proxyPort); ok {
+			loopbackUIDs[uid] = struct{}{}
+			continue
+		}
+		for uid := range loopbackUIDs {
+			if lineHasTerminalSkuidVerdict(line, uid, "drop") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func lineAgentProxyLoopbackAllowUID(line string, proxyPort int) (int, bool) {
+	fields := nftLineFields(line)
+	wantPrefix := []string{
+		"meta", "skuid",
+	}
+	wantSuffix := []string{
+		"ip", "daddr", "127.0.0.1",
+		"tcp", "dport", strconv.Itoa(proxyPort),
+		"accept",
+	}
+	if len(fields) < len(wantPrefix)+1+len(wantSuffix) {
+		return 0, false
+	}
+	for i, field := range wantPrefix {
+		if fields[i] != field {
+			return 0, false
+		}
+	}
+	uid, err := strconv.Atoi(fields[len(wantPrefix)])
+	if err != nil {
+		return 0, false
+	}
+	suffixAt := len(wantPrefix) + 1
+	for i, field := range wantSuffix {
+		if fields[suffixAt+i] != field {
+			return 0, false
+		}
+	}
+	return uid, nftRuleTailIsCommentOnly(fields[suffixAt+len(wantSuffix):])
 }
 
 func nftRulesIncludeLine(path string) string {

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1373,10 +1373,13 @@ func stepInstallNFTRules() step {
 				captureNFTPreState(ctx, env)
 			}
 			if tableLoaded && (rulesChanged || liveRulesDrifted) {
-				// nft -f merges into an existing table. Drop our managed table
-				// first so stale rules from an older contain install cannot
-				// survive beside the new ruleset.
-				_, _, _ = env.runCmd(ctx, nftExecutable(env), "delete", "table", "inet", env.nftTableOrDefault())
+				// nft -f merges into an existing table. Drop only the managed
+				// chain first so stale Pipelock rules cannot survive beside
+				// the new ruleset, while operator co-located chains in the
+				// table remain untouched.
+				if err := runOrErr(ctx, env, nftExecutable(env), "delete", "chain", "inet", env.nftTableOrDefault(), env.nftChainOrDefault()); err != nil {
+					return false, fmt.Errorf("delete stale nft chain inet %s %s: %w", env.nftTableOrDefault(), env.nftChainOrDefault(), err)
+				}
 				tableLoaded = false
 			}
 			if !tableLoaded || rulesChanged || liveRulesDrifted {
@@ -1394,11 +1397,15 @@ func stepInstallNFTRules() step {
 			return true, nil
 		},
 		undo: func(ctx context.Context, env *installEnv) error {
-			// Drop the managed table best-effort, restore any previous live
-			// table captured during this install attempt, then restore files.
-			_, _, _ = env.runCmd(ctx, nftExecutable(env), "delete", "table", "inet", env.nftTableOrDefault())
-			if err := restorePreviousNFTState(ctx, env); err != nil {
-				return err
+			// Restore any previous live table captured during this install
+			// attempt before deleting the newly installed table. If no
+			// previous table existed, drop the table created by this step.
+			if env.prevNFTTableStateKnown && strings.TrimSpace(env.prevNFTTableDump) != "" {
+				if err := restorePreviousNFTState(ctx, env); err != nil {
+					return err
+				}
+			} else {
+				_, _, _ = env.runCmd(ctx, nftExecutable(env), "delete", "table", "inet", env.nftTableOrDefault())
 			}
 			if err := restoreBackup(env, env.nftRulesPath); err != nil {
 				return err
@@ -1444,10 +1451,14 @@ func restorePreviousNFTState(ctx context.Context, env *installEnv) error {
 		return nil
 	}
 	restorePath := env.nftRulesPath + ".restore"
-	if err := env.writeFile(restorePath, []byte(env.prevNFTTableDump), modeConfigSecret); err != nil {
+	restoreScript := "delete table inet " + env.nftTableOrDefault() + "\n" + env.prevNFTTableDump
+	if err := env.writeFile(restorePath, []byte(restoreScript), modeConfigSecret); err != nil {
 		return fmt.Errorf("write nft restore file %s: %w", restorePath, err)
 	}
 	defer func() { _ = env.removeFile(restorePath) }()
+	if err := runOrErr(ctx, env, nftExecutable(env), "-c", "-f", restorePath); err != nil {
+		return fmt.Errorf("validate previous nft table restore: %w", err)
+	}
 	if err := runOrErr(ctx, env, nftExecutable(env), "-f", restorePath); err != nil {
 		return fmt.Errorf("restore previous nft table: %w", err)
 	}

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1328,7 +1328,7 @@ func stepInstallNFTRules() step {
 			}
 			tableLoaded := false
 			liveRulesDrifted := false
-			if out, code, _ := env.runCmd(ctx, nftExecutable(env), "list", "table", "inet", env.nftTableOrDefault()); code == 0 {
+			if out, code, _ := env.runCmd(ctx, nftExecutable(env), "-n", "-a", "list", "chain", "inet", env.nftTableOrDefault(), env.nftChainOrDefault()); code == 0 {
 				tableLoaded = true
 				liveRulesDrifted = !liveNFTContainmentMatches(out, env.nftChainOrDefault(), operatorUID, proxyUID, agentUID, env.proxyPort)
 			}
@@ -1443,13 +1443,18 @@ func restorePreviousNFTState(ctx context.Context, env *installEnv) error {
 }
 
 func liveNFTContainmentMatches(out, chainName string, operatorUID, proxyUID, agentUID, proxyPort int) bool {
-	return chainHasSkuidAcceptForUID(out, chainName, operatorUID) &&
-		chainHasSkuidAcceptForUID(out, chainName, proxyUID) &&
-		chainHasAgentCatchAllDrop(out, chainName, agentUID) &&
-		chainHasAgentProxyLoopbackAllowBeforeDrop(out, chainName, agentUID, proxyPort) &&
-		chainHasAgentDNSDropBeforeCatchAll(out, chainName, agentUID, "udp") &&
-		chainHasAgentDNSDropBeforeCatchAll(out, chainName, agentUID, "tcp") &&
-		!chainHasUnsafeVerdictBeforeAgentDrop(out, chainName, containmentUIDs{
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return false
+	}
+	return nftChainLinesHaveManagedOutputBaseChain(lines) &&
+		chainLinesHaveSkuidAcceptForUID(lines, operatorUID) &&
+		chainLinesHaveSkuidAcceptForUID(lines, proxyUID) &&
+		chainLinesHaveAgentCatchAllDrop(lines, agentUID) &&
+		chainLinesHaveAgentProxyLoopbackAllowBeforeDrop(lines, agentUID, proxyPort) &&
+		chainLinesHaveAgentDNSDropBeforeCatchAll(lines, agentUID, "udp") &&
+		chainLinesHaveAgentDNSDropBeforeCatchAll(lines, agentUID, "tcp") &&
+		!chainLinesHaveUnsafeVerdictBeforeAgentDrop(lines, containmentUIDs{
 			operatorUID:   operatorUID,
 			operatorKnown: true,
 			proxyUID:      proxyUID,

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -507,7 +507,7 @@ func TestStepInstallNFTRules_UndoDropsTable(t *testing.T) {
 
 func TestStepInstallNFTRules_UndoDoesNotRestoreNewlyCreatedTable(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "", 1, nil)
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), "", 1, nil)
 	runner.on(argvFor(testNFT, "-c", "-f", env.nftRulesPath), "", 0, nil)
 	runner.on(argvFor(testNFT, "-f", env.nftRulesPath), "", 0, nil)
 	runner.on(argvFor(testSystemctl, "daemon-reload"), "", 0, nil)
@@ -543,7 +543,7 @@ func TestStepInstallNFTRules_UndoDoesNotRestoreNewlyCreatedTable(t *testing.T) {
 func TestStepInstallNFTRules_ValidationFailureSurfaces(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	// Force nft validate to fail.
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "", 1, fmt.Errorf("not loaded"))
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), "", 1, fmt.Errorf("not loaded"))
 	runner.on(argvFor(testNFT, "-c", "-f", env.nftRulesPath), "syntax error", 1, nil)
 	s := stepInstallNFTRules()
 	_, err := s.apply(context.Background(), env)

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -1261,8 +1261,8 @@ func TestStepInstallNFTRules_SkipsWhenLoaded(t *testing.T) {
 		t.Fatalf("write rules: %v", err)
 	}
 	writeNFTPersistUnitFixture(t, env)
-	// Make `nft list table` succeed with a healthy live table.
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), body, 0, nil)
+	// Make the exact-chain nft query succeed with a healthy live chain.
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), body, 0, nil)
 
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
@@ -1296,7 +1296,7 @@ func TestStepInstallNFTRules_SkipsWhenLoadedForRootOperator(t *testing.T) {
 		t.Fatalf("write rules: %v", err)
 	}
 	writeNFTPersistUnitFixture(t, env)
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), body, 0, nil)
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), body, 0, nil)
 
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
@@ -1327,7 +1327,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
 		}
 	}
 `
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), drifted, 0, nil)
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), drifted, 0, nil)
 
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
@@ -1349,6 +1349,54 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
 	}
 	if !sawDelete || !sawLoad {
 		t.Fatalf("expected delete+reload for live drift, got %v", runner.calls)
+	}
+}
+
+func TestStepInstallNFTRules_ReloadsWhenLiveChainIsUnhookedLookalike(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	writeNFTPersistUnitFixture(t, env)
+
+	lookalike := `table inet pipelock_containment {
+		chain output_filter {
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+`
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), lookalike, 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected unhooked lookalike chain to trigger rules reload")
+	}
+
+	var sawDelete, sawLoad bool
+	for _, c := range runner.calls {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+			sawDelete = true
+		}
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
+			sawLoad = true
+		}
+	}
+	if !sawDelete || !sawLoad {
+		t.Fatalf("expected delete+reload for lookalike chain, got %v", runner.calls)
 	}
 }
 
@@ -1375,7 +1423,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasUnexpectedAcceptBeforeDrop
 		}
 	}
 `
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), failOpen, 0, nil)
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), failOpen, 0, nil)
 
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
@@ -1450,7 +1498,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasPreDropUnsafeVerdict(t *te
 		}
 	}
 `
-			runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), failOpen, 0, nil)
+			runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), failOpen, 0, nil)
 
 			s := stepInstallNFTRules()
 			applied, err := s.apply(context.Background(), env)
@@ -1489,7 +1537,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasStaleAgentUID(t *testing.T
 	}
 	writeNFTPersistUnitFixture(t, env)
 	stale := renderNFTRules(operatorUID, proxyUID, 986, env.proxyPort, defaultNFTTable, defaultNFTChain)
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), stale, 0, nil)
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), stale, 0, nil)
 
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
@@ -1524,7 +1572,7 @@ func TestStepInstallNFTRules_RepairsMissingPersistenceUnitOnRerun(t *testing.T) 
 	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
 		t.Fatalf("write rules: %v", err)
 	}
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "table inet pipelock_containment {}", 0, nil)
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), "table inet pipelock_containment {}", 0, nil)
 
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
@@ -1546,7 +1594,7 @@ func TestStepInstallNFTRules_RepairsMissingPersistenceUnitOnRerun(t *testing.T) 
 func TestStepInstallNFTRules_LoadsWhenAbsent(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	// nft validate + load + systemctl enable should all succeed by default.
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "", 1, fmt.Errorf("not loaded"))
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), "", 1, fmt.Errorf("not loaded"))
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
 	if err != nil {
@@ -1582,7 +1630,7 @@ func TestStepInstallNFTRules_DropsLoadedTableBeforeChangedReload(t *testing.T) {
 	if err := os.WriteFile(env.nftRulesPath, []byte("old broad-loopback rules\n"), 0o600); err != nil {
 		t.Fatalf("write old rules: %v", err)
 	}
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "table inet pipelock_containment {}", 0, nil)
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), "table inet pipelock_containment {}", 0, nil)
 
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
@@ -1622,7 +1670,7 @@ func TestStepInstallNFTRules_PersistsViaOwnedSystemdUnitAndRestores(t *testing.T
 	if err := os.WriteFile(env.nftPersistUnitPath, []byte(original), 0o600); err != nil {
 		t.Fatalf("write unit: %v", err)
 	}
-	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), "", 1, fmt.Errorf("not loaded"))
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), "", 1, fmt.Errorf("not loaded"))
 
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
@@ -1662,6 +1710,7 @@ func TestStepInstallNFTRules_UndoRestoresPreviousLiveTableAndServiceState(t *tes
 	}
 }
 `
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), previousTable, 0, nil)
 	runner.on(argvFor(testNFT, "list", "table", "inet", defaultNFTTable), previousTable, 0, nil)
 	runner.on(argvFor(testSystemctl, "is-enabled", filepath.Base(env.nftPersistUnitPath)), "disabled\n", 1, nil)
 

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -1340,7 +1340,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
 
 	var sawDelete, sawLoad bool
 	for _, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
 			sawDelete = true
 		}
 		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
@@ -1348,7 +1348,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
 		}
 	}
 	if !sawDelete || !sawLoad {
-		t.Fatalf("expected delete+reload for live drift, got %v", runner.calls)
+		t.Fatalf("expected chain delete+reload for live drift, got %v", runner.calls)
 	}
 }
 
@@ -1388,7 +1388,7 @@ func TestStepInstallNFTRules_ReloadsWhenLiveChainIsUnhookedLookalike(t *testing.
 
 	var sawDelete, sawLoad bool
 	for _, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
 			sawDelete = true
 		}
 		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
@@ -1396,7 +1396,7 @@ func TestStepInstallNFTRules_ReloadsWhenLiveChainIsUnhookedLookalike(t *testing.
 		}
 	}
 	if !sawDelete || !sawLoad {
-		t.Fatalf("expected delete+reload for lookalike chain, got %v", runner.calls)
+		t.Fatalf("expected chain delete+reload for lookalike chain, got %v", runner.calls)
 	}
 }
 
@@ -1420,7 +1420,7 @@ func TestStepInstallNFTRules_RefusesUnattributedLiveChainCollision(t *testing.T)
 		t.Fatal("unattributed collision must not report an applied repair")
 	}
 	for _, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
 			t.Fatalf("unattributed collision deleted nft table: %v", runner.calls)
 		}
 		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
@@ -1465,7 +1465,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasUnexpectedAcceptBeforeDrop
 
 	var sawDelete, sawLoad bool
 	for _, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
 			sawDelete = true
 		}
 		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
@@ -1473,7 +1473,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasUnexpectedAcceptBeforeDrop
 		}
 	}
 	if !sawDelete || !sawLoad {
-		t.Fatalf("expected delete+reload for unexpected accept, got %v", runner.calls)
+		t.Fatalf("expected chain delete+reload for unexpected accept, got %v", runner.calls)
 	}
 }
 
@@ -1540,7 +1540,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasPreDropUnsafeVerdict(t *te
 
 			var sawDelete, sawLoad bool
 			for _, c := range runner.calls {
-				if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+				if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
 					sawDelete = true
 				}
 				if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
@@ -1548,7 +1548,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasPreDropUnsafeVerdict(t *te
 				}
 			}
 			if !sawDelete || !sawLoad {
-				t.Fatalf("expected delete+reload for pre-drop %s, got %v", tc.name, runner.calls)
+				t.Fatalf("expected chain delete+reload for pre-drop %s, got %v", tc.name, runner.calls)
 			}
 		})
 	}
@@ -1579,7 +1579,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasStaleAgentUID(t *testing.T
 
 	var sawDelete, sawLoad bool
 	for _, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
 			sawDelete = true
 		}
 		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
@@ -1587,7 +1587,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasStaleAgentUID(t *testing.T
 		}
 	}
 	if !sawDelete || !sawLoad {
-		t.Fatalf("expected delete+reload for stale uid, got %v", runner.calls)
+		t.Fatalf("expected chain delete+reload for stale uid, got %v", runner.calls)
 	}
 }
 
@@ -1651,7 +1651,7 @@ func TestStepInstallNFTRules_LoadsWhenAbsent(t *testing.T) {
 	}
 }
 
-func TestStepInstallNFTRules_DropsLoadedTableBeforeChangedReload(t *testing.T) {
+func TestStepInstallNFTRules_DropsLoadedChainBeforeChangedReload(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o755); err != nil { //nolint:gosec // tmpdir
 		t.Fatalf("mkdir rules parent: %v", err)
@@ -1672,7 +1672,7 @@ func TestStepInstallNFTRules_DropsLoadedTableBeforeChangedReload(t *testing.T) {
 
 	deleteIdx, loadIdx := -1, -1
 	for i, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
 			deleteIdx = i
 		}
 		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
@@ -1680,13 +1680,13 @@ func TestStepInstallNFTRules_DropsLoadedTableBeforeChangedReload(t *testing.T) {
 		}
 	}
 	if deleteIdx == -1 {
-		t.Fatalf("expected nft delete table before reload, got %v", runner.calls)
+		t.Fatalf("expected nft delete chain before reload, got %v", runner.calls)
 	}
 	if loadIdx == -1 {
 		t.Fatalf("expected nft -f reload, got %v", runner.calls)
 	}
 	if deleteIdx > loadIdx {
-		t.Fatalf("delete must precede reload: delete=%d load=%d calls=%v", deleteIdx, loadIdx, runner.calls)
+		t.Fatalf("chain delete must precede reload: delete=%d load=%d calls=%v", deleteIdx, loadIdx, runner.calls)
 	}
 }
 
@@ -1772,8 +1772,11 @@ func TestStepInstallNFTRules_UndoRestoresPreviousLiveTableAndServiceState(t *tes
 	if _, err := os.Stat(restorePath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("restore file should be removed, stat err=%v", err)
 	}
-	var sawRestore, sawDisable bool
+	var sawValidateRestore, sawRestore, sawDisable bool
 	for _, c := range runner.calls {
+		if c.name == testNFT && len(c.args) == 3 && c.args[0] == "-c" && c.args[1] == "-f" && c.args[2] == restorePath {
+			sawValidateRestore = true
+		}
 		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == restorePath {
 			sawRestore = true
 		}
@@ -1784,8 +1787,134 @@ func TestStepInstallNFTRules_UndoRestoresPreviousLiveTableAndServiceState(t *tes
 	if !sawRestore {
 		t.Fatalf("expected nft restore from captured table, got %v", runner.calls)
 	}
+	if !sawValidateRestore {
+		t.Fatalf("expected nft restore validation before applying captured table, got %v", runner.calls)
+	}
 	if !sawDisable {
 		t.Fatalf("expected persistence unit disabled-state restore, got %v", runner.calls)
+	}
+}
+
+func TestStepInstallNFTRules_UndoValidatesCapturedRestoreBeforeDeletingLiveTable(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	env.prevNFTTableStateKnown = true
+	env.prevNFTTableDump = "malformed nft dump\n"
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	restorePath := env.nftRulesPath + ".restore"
+	runner.on(argvFor(testNFT, "-c", "-f", restorePath), "syntax error", 1, nil)
+
+	s := stepInstallNFTRules()
+	err := s.undo(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), "validate previous nft table restore") {
+		t.Fatalf("undo error = %v, want restore validation failure", err)
+	}
+	for _, c := range runner.calls {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+			t.Fatalf("rollback deleted live table before proving captured restore was loadable: %v", runner.calls)
+		}
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == restorePath {
+			t.Fatalf("rollback applied restore after validation failed: %v", runner.calls)
+		}
+	}
+}
+
+func TestStepInstallNFTRules_ReloadDeletesOnlyManagedChain(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	writeNFTPersistUnitFixture(t, env)
+	drifted := `table inet pipelock_containment {
+		chain output_filter {
+			type filter hook output priority filter; policy accept;
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 ip daddr 203.0.113.10 accept
+			meta skuid 987 drop
+		}
+	}
+`
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), drifted, 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected live drift repair")
+	}
+
+	var sawDeleteChain, sawLoad bool
+	for _, c := range runner.calls {
+		if c.name != testNFT {
+			continue
+		}
+		args := strings.Join(c.args, " ")
+		if args == "delete table inet "+defaultNFTTable {
+			t.Fatalf("repair deleted the whole table despite co-located operator chain: %v", runner.calls)
+		}
+		if args == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
+			sawDeleteChain = true
+		}
+		if len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
+			sawLoad = true
+		}
+	}
+	if !sawDeleteChain || !sawLoad {
+		t.Fatalf("expected managed chain delete+reload, got %v", runner.calls)
+	}
+}
+
+func TestStepInstallNFTRules_DeleteChainFailureAbortsReload(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	writeNFTPersistUnitFixture(t, env)
+	drifted := `table inet pipelock_containment {
+		chain output_filter {
+			type filter hook output priority filter; policy accept;
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 accept
+			meta skuid 987 drop
+		}
+	}
+`
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), drifted, 0, nil)
+	runner.on(argvFor(testNFT, "delete", "chain", "inet", defaultNFTTable, defaultNFTChain), "busy", 1, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), "delete stale nft chain") {
+		t.Fatalf("apply error = %v, want delete-chain failure", err)
+	}
+	if applied {
+		t.Fatal("failed chain delete must not report applied")
+	}
+	for _, c := range runner.calls {
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
+			t.Fatalf("reload continued after stale chain delete failed: %v", runner.calls)
+		}
 	}
 }
 

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -1438,6 +1438,44 @@ func TestStepInstallNFTRules_RefusesUnattributedLiveChainCollision(t *testing.T)
 	}
 }
 
+func TestStepInstallNFTRules_RefusesUnattributedLiveChainCollisionOnRerun(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write managed rules: %v", err)
+	}
+	writeNFTPersistUnitFixture(t, env)
+	unrelated := `table inet pipelock_containment {
+		chain output_filter {
+			type filter hook output priority filter; policy accept;
+			ip daddr 203.0.113.10 accept
+		}
+	}
+`
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), unrelated, 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), "not attributable to Pipelock") {
+		t.Fatalf("apply error = %v, want unattributed collision refusal", err)
+	}
+	if applied {
+		t.Fatal("unattributed rerun collision must not report an applied repair")
+	}
+	for _, c := range runner.calls {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
+			t.Fatalf("unattributed rerun collision deleted nft chain: %v", runner.calls)
+		}
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && (c.args[1] == env.nftRulesPath || c.args[1] == managedChainReloadPath(env)) {
+			t.Fatalf("unattributed rerun collision loaded replacement rules: %v", runner.calls)
+		}
+	}
+}
+
 func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasUnexpectedAcceptBeforeDrop(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	operatorUID, proxyUID, agentUID := 1000, 988, 987

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -1400,6 +1400,35 @@ func TestStepInstallNFTRules_ReloadsWhenLiveChainIsUnhookedLookalike(t *testing.
 	}
 }
 
+func TestStepInstallNFTRules_RefusesUnattributedLiveChainCollision(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	unrelated := `table inet pipelock_containment {
+		chain output_filter {
+			type filter hook output priority filter; policy accept;
+			ip daddr 203.0.113.10 accept
+		}
+	}
+`
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), unrelated, 0, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), "not attributable to Pipelock") {
+		t.Fatalf("apply error = %v, want unattributed collision refusal", err)
+	}
+	if applied {
+		t.Fatal("unattributed collision must not report an applied repair")
+	}
+	for _, c := range runner.calls {
+		if c.name == testNFT && strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+			t.Fatalf("unattributed collision deleted nft table: %v", runner.calls)
+		}
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
+			t.Fatalf("unattributed collision loaded replacement rules: %v", runner.calls)
+		}
+	}
+}
+
 func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasUnexpectedAcceptBeforeDrop(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	operatorUID, proxyUID, agentUID := 1000, 988, 987
@@ -1703,6 +1732,13 @@ func TestStepInstallNFTRules_PersistsViaOwnedSystemdUnitAndRestores(t *testing.T
 
 func TestStepInstallNFTRules_UndoRestoresPreviousLiveTableAndServiceState(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	staleRules := renderNFTRules(1000, 988, 986, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.WriteFile(env.nftRulesPath, []byte(staleRules), 0o600); err != nil {
+		t.Fatalf("write stale managed rules: %v", err)
+	}
 	previousTable := `table inet pipelock_containment {
 	chain output_filter {
 		meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -126,6 +126,37 @@ func argvFor(name string, args ...string) string {
 	return name + " " + strings.Join(args, " ")
 }
 
+func managedChainReloadPath(env *installEnv) string {
+	return env.nftRulesPath + ".reload"
+}
+
+func assertManagedChainReload(t *testing.T, runner *fakeRunner, env *installEnv) {
+	t.Helper()
+	reloadPath := managedChainReloadPath(env)
+	var sawValidate, sawLoad bool
+	for _, c := range runner.calls {
+		if c.name != testNFT {
+			continue
+		}
+		args := strings.Join(c.args, " ")
+		if args == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
+			t.Fatalf("managed chain reload used standalone chain delete instead of validated reload script: %v", runner.calls)
+		}
+		if args == "delete table inet "+defaultNFTTable {
+			t.Fatalf("managed chain reload deleted the whole table: %v", runner.calls)
+		}
+		if len(c.args) == 3 && c.args[0] == "-c" && c.args[1] == "-f" && c.args[2] == reloadPath {
+			sawValidate = true
+		}
+		if len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == reloadPath {
+			sawLoad = true
+		}
+	}
+	if !sawValidate || !sawLoad {
+		t.Fatalf("expected validated managed chain reload script %s, got %v", reloadPath, runner.calls)
+	}
+}
+
 // newFakeEnv builds an installEnv backed by tmpdirs and fake hooks. The
 // filesystem-side fields (chown, mkdirAll, etc.) are wired to real os
 // calls operating under root, the tmpdir constructed for the test; the
@@ -1338,18 +1369,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableDrifted(t *testing.T) {
 		t.Fatal("expected live drift repair")
 	}
 
-	var sawDelete, sawLoad bool
-	for _, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
-			sawDelete = true
-		}
-		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
-			sawLoad = true
-		}
-	}
-	if !sawDelete || !sawLoad {
-		t.Fatalf("expected chain delete+reload for live drift, got %v", runner.calls)
-	}
+	assertManagedChainReload(t, runner, env)
 }
 
 func TestStepInstallNFTRules_ReloadsWhenLiveChainIsUnhookedLookalike(t *testing.T) {
@@ -1386,18 +1406,7 @@ func TestStepInstallNFTRules_ReloadsWhenLiveChainIsUnhookedLookalike(t *testing.
 		t.Fatal("expected unhooked lookalike chain to trigger rules reload")
 	}
 
-	var sawDelete, sawLoad bool
-	for _, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
-			sawDelete = true
-		}
-		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
-			sawLoad = true
-		}
-	}
-	if !sawDelete || !sawLoad {
-		t.Fatalf("expected chain delete+reload for lookalike chain, got %v", runner.calls)
-	}
+	assertManagedChainReload(t, runner, env)
 }
 
 func TestStepInstallNFTRules_RefusesUnattributedLiveChainCollision(t *testing.T) {
@@ -1421,9 +1430,9 @@ func TestStepInstallNFTRules_RefusesUnattributedLiveChainCollision(t *testing.T)
 	}
 	for _, c := range runner.calls {
 		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
-			t.Fatalf("unattributed collision deleted nft table: %v", runner.calls)
+			t.Fatalf("unattributed collision deleted nft chain: %v", runner.calls)
 		}
-		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
+		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && (c.args[1] == env.nftRulesPath || c.args[1] == managedChainReloadPath(env)) {
 			t.Fatalf("unattributed collision loaded replacement rules: %v", runner.calls)
 		}
 	}
@@ -1463,18 +1472,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasUnexpectedAcceptBeforeDrop
 		t.Fatal("expected fail-open live accept to trigger rules reload")
 	}
 
-	var sawDelete, sawLoad bool
-	for _, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
-			sawDelete = true
-		}
-		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
-			sawLoad = true
-		}
-	}
-	if !sawDelete || !sawLoad {
-		t.Fatalf("expected chain delete+reload for unexpected accept, got %v", runner.calls)
-	}
+	assertManagedChainReload(t, runner, env)
 }
 
 func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasPreDropUnsafeVerdict(t *testing.T) {
@@ -1538,18 +1536,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasPreDropUnsafeVerdict(t *te
 				t.Fatalf("expected pre-drop %s to trigger rules reload", tc.name)
 			}
 
-			var sawDelete, sawLoad bool
-			for _, c := range runner.calls {
-				if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
-					sawDelete = true
-				}
-				if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
-					sawLoad = true
-				}
-			}
-			if !sawDelete || !sawLoad {
-				t.Fatalf("expected chain delete+reload for pre-drop %s, got %v", tc.name, runner.calls)
-			}
+			assertManagedChainReload(t, runner, env)
 		})
 	}
 }
@@ -1577,18 +1564,7 @@ func TestStepInstallNFTRules_ReloadsWhenLoadedTableHasStaleAgentUID(t *testing.T
 		t.Fatal("expected stale live agent uid to trigger rules reload")
 	}
 
-	var sawDelete, sawLoad bool
-	for _, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
-			sawDelete = true
-		}
-		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
-			sawLoad = true
-		}
-	}
-	if !sawDelete || !sawLoad {
-		t.Fatalf("expected chain delete+reload for stale uid, got %v", runner.calls)
-	}
+	assertManagedChainReload(t, runner, env)
 }
 
 func TestStepInstallNFTRules_RepairsMissingPersistenceUnitOnRerun(t *testing.T) {
@@ -1651,7 +1627,7 @@ func TestStepInstallNFTRules_LoadsWhenAbsent(t *testing.T) {
 	}
 }
 
-func TestStepInstallNFTRules_DropsLoadedChainBeforeChangedReload(t *testing.T) {
+func TestStepInstallNFTRules_ReloadsLoadedChainWithValidatedScript(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o755); err != nil { //nolint:gosec // tmpdir
 		t.Fatalf("mkdir rules parent: %v", err)
@@ -1670,24 +1646,7 @@ func TestStepInstallNFTRules_DropsLoadedChainBeforeChangedReload(t *testing.T) {
 		t.Fatal("expected changed rules to apply")
 	}
 
-	deleteIdx, loadIdx := -1, -1
-	for i, c := range runner.calls {
-		if c.name == testNFT && strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
-			deleteIdx = i
-		}
-		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
-			loadIdx = i
-		}
-	}
-	if deleteIdx == -1 {
-		t.Fatalf("expected nft delete chain before reload, got %v", runner.calls)
-	}
-	if loadIdx == -1 {
-		t.Fatalf("expected nft -f reload, got %v", runner.calls)
-	}
-	if deleteIdx > loadIdx {
-		t.Fatalf("chain delete must precede reload: delete=%d load=%d calls=%v", deleteIdx, loadIdx, runner.calls)
-	}
+	assertManagedChainReload(t, runner, env)
 }
 
 func TestStepInstallNFTRules_PersistsViaOwnedSystemdUnitAndRestores(t *testing.T) {
@@ -1798,7 +1757,7 @@ func TestStepInstallNFTRules_UndoRestoresPreviousLiveTableAndServiceState(t *tes
 func TestStepInstallNFTRules_UndoValidatesCapturedRestoreBeforeDeletingLiveTable(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	env.prevNFTTableStateKnown = true
-	env.prevNFTTableDump = "malformed nft dump\n"
+	env.prevNFTTableDump = "table inet " + defaultNFTTable + " {\n"
 	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
 		t.Fatalf("mkdir rules parent: %v", err)
 	}
@@ -1816,6 +1775,31 @@ func TestStepInstallNFTRules_UndoValidatesCapturedRestoreBeforeDeletingLiveTable
 		}
 		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == restorePath {
 			t.Fatalf("rollback applied restore after validation failed: %v", runner.calls)
+		}
+	}
+}
+
+func TestStepInstallNFTRules_UndoRejectsWrongCapturedTableBeforeDeletingLiveTable(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	env.prevNFTTableStateKnown = true
+	env.prevNFTTableDump = `table inet other_containment {
+		chain output_filter {
+			meta skuid 987 drop
+		}
+	}
+`
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+
+	s := stepInstallNFTRules()
+	err := s.undo(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), "captured nft table dump is not table inet "+defaultNFTTable) {
+		t.Fatalf("undo error = %v, want wrong-table restore rejection", err)
+	}
+	for _, c := range runner.calls {
+		if c.name == testNFT {
+			t.Fatalf("wrong-table captured dump must not execute nft command: %v", runner.calls)
 		}
 	}
 }
@@ -1855,28 +1839,10 @@ func TestStepInstallNFTRules_ReloadDeletesOnlyManagedChain(t *testing.T) {
 		t.Fatal("expected live drift repair")
 	}
 
-	var sawDeleteChain, sawLoad bool
-	for _, c := range runner.calls {
-		if c.name != testNFT {
-			continue
-		}
-		args := strings.Join(c.args, " ")
-		if args == "delete table inet "+defaultNFTTable {
-			t.Fatalf("repair deleted the whole table despite co-located operator chain: %v", runner.calls)
-		}
-		if args == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
-			sawDeleteChain = true
-		}
-		if len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
-			sawLoad = true
-		}
-	}
-	if !sawDeleteChain || !sawLoad {
-		t.Fatalf("expected managed chain delete+reload, got %v", runner.calls)
-	}
+	assertManagedChainReload(t, runner, env)
 }
 
-func TestStepInstallNFTRules_DeleteChainFailureAbortsReload(t *testing.T) {
+func TestStepInstallNFTRules_ManagedChainReloadValidationFailureAbortsApply(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
 	operatorUID, proxyUID, agentUID := 1000, 988, 987
 	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
@@ -1901,19 +1867,134 @@ func TestStepInstallNFTRules_DeleteChainFailureAbortsReload(t *testing.T) {
 	}
 `
 	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), drifted, 0, nil)
-	runner.on(argvFor(testNFT, "delete", "chain", "inet", defaultNFTTable, defaultNFTChain), "busy", 1, nil)
+	runner.on(argvFor(testNFT, "-c", "-f", managedChainReloadPath(env)), "syntax error", 1, nil)
 
 	s := stepInstallNFTRules()
 	applied, err := s.apply(context.Background(), env)
-	if err == nil || !strings.Contains(err.Error(), "delete stale nft chain") {
-		t.Fatalf("apply error = %v, want delete-chain failure", err)
+	if err == nil || !strings.Contains(err.Error(), "validate nft managed chain reload") {
+		t.Fatalf("apply error = %v, want managed-chain reload validation failure", err)
 	}
 	if applied {
-		t.Fatal("failed chain delete must not report applied")
+		t.Fatal("failed managed-chain reload validation must not report applied")
 	}
 	for _, c := range runner.calls {
-		if c.name == testNFT && len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == env.nftRulesPath {
-			t.Fatalf("reload continued after stale chain delete failed: %v", runner.calls)
+		if c.name != testNFT {
+			continue
+		}
+		if strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
+			t.Fatalf("validation failure used standalone chain delete: %v", runner.calls)
+		}
+		if len(c.args) == 2 && c.args[0] == "-f" && c.args[1] == managedChainReloadPath(env) {
+			t.Fatalf("reload continued after managed-chain reload validation failed: %v", runner.calls)
+		}
+	}
+}
+
+func TestStepInstallNFTRules_ManagedChainReloadApplyFailureDoesNotDeleteSeparately(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	writeNFTPersistUnitFixture(t, env)
+	drifted := `table inet pipelock_containment {
+		chain output_filter {
+			type filter hook output priority filter; policy accept;
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 accept
+			meta skuid 987 drop
+		}
+	}
+`
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), drifted, 0, nil)
+	runner.on(argvFor(testNFT, "-f", managedChainReloadPath(env)), "netlink apply failed", 1, nil)
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), "reload nft managed chain") {
+		t.Fatalf("apply error = %v, want managed-chain reload apply failure", err)
+	}
+	if applied {
+		t.Fatal("failed managed-chain reload apply must not report applied")
+	}
+	var sawValidate bool
+	for _, c := range runner.calls {
+		if c.name != testNFT {
+			continue
+		}
+		if len(c.args) == 3 && c.args[0] == "-c" && c.args[1] == "-f" && c.args[2] == managedChainReloadPath(env) {
+			sawValidate = true
+		}
+		if strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
+			t.Fatalf("reload apply failure used standalone chain delete: %v", runner.calls)
+		}
+		if strings.Join(c.args, " ") == "delete table inet "+defaultNFTTable {
+			t.Fatalf("reload apply failure deleted table separately: %v", runner.calls)
+		}
+	}
+	if !sawValidate {
+		t.Fatalf("reload apply failure did not validate combined reload script first: %v", runner.calls)
+	}
+}
+
+func TestStepInstallNFTRules_ManagedChainReloadWriteFailureAbortsBeforeNFT(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	operatorUID, proxyUID, agentUID := 1000, 988, 987
+	body := renderNFTRules(operatorUID, proxyUID, agentUID, env.proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := os.MkdirAll(filepath.Dir(env.nftRulesPath), 0o750); err != nil {
+		t.Fatalf("mkdir rules parent: %v", err)
+	}
+	if err := os.WriteFile(env.nftRulesPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+	writeNFTPersistUnitFixture(t, env)
+	drifted := `table inet pipelock_containment {
+		chain output_filter {
+			type filter hook output priority filter; policy accept;
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 accept
+			meta skuid 987 drop
+		}
+	}
+`
+	runner.on(argvFor(testNFT, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain), drifted, 0, nil)
+	originalWriteFile := env.writeFile
+	env.writeFile = func(path string, contents []byte, mode os.FileMode) error {
+		if path == managedChainReloadPath(env) {
+			return stringError("reload write denied")
+		}
+		return originalWriteFile(path, contents, mode)
+	}
+
+	s := stepInstallNFTRules()
+	applied, err := s.apply(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), "write nft managed chain reload file") {
+		t.Fatalf("apply error = %v, want managed-chain reload write failure", err)
+	}
+	if applied {
+		t.Fatal("failed managed-chain reload write must not report applied")
+	}
+	for _, c := range runner.calls {
+		if c.name != testNFT {
+			continue
+		}
+		if len(c.args) >= 2 && c.args[len(c.args)-1] == managedChainReloadPath(env) {
+			t.Fatalf("reload write failure must not invoke nft on reload script: %v", runner.calls)
+		}
+		if strings.Join(c.args, " ") == "delete chain inet "+defaultNFTTable+" "+defaultNFTChain {
+			t.Fatalf("reload write failure used standalone chain delete: %v", runner.calls)
 		}
 	}
 }

--- a/internal/cli/contain/install_ux_test.go
+++ b/internal/cli/contain/install_ux_test.go
@@ -254,8 +254,8 @@ func TestCheckNFTVersion_TooOld(t *testing.T) {
 	if !strings.Contains(err.Error(), "too old") {
 		t.Errorf("error should mention 'too old': %v", err)
 	}
-	if !strings.Contains(err.Error(), "0.6") {
-		t.Errorf("error should mention minimum version 0.6: %v", err)
+	if !strings.Contains(err.Error(), "0.8") {
+		t.Errorf("error should mention minimum version 0.8: %v", err)
 	}
 	if !strings.Contains(err.Error(), "Upgrade nftables") {
 		t.Errorf("error should include upgrade guidance: %v", err)
@@ -274,11 +274,24 @@ func TestCheckNFTVersion_V1Passes(t *testing.T) {
 
 func TestCheckNFTVersion_ExactMinimum(t *testing.T) {
 	env, runner, _ := newFakeEnv(t)
-	runner.on(argvFor("nft", "-v"), "nftables v0.6.0 (Flux)", 0, nil)
+	runner.on(argvFor("nft", "-v"), "nftables v0.8.0 (Joe Btfsplk)", 0, nil)
 
 	err := checkNFTVersion(context.Background(), env)
 	if err != nil {
-		t.Fatalf("expected nil error at exact minimum version 0.6, got: %v", err)
+		t.Fatalf("expected nil error at exact minimum version 0.8, got: %v", err)
+	}
+}
+
+func TestCheckNFTVersion_RejectsVersionWithoutCheckMode(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on(argvFor("nft", "-v"), "nftables v0.7 (Scrooge McDuck)", 0, nil)
+
+	err := checkNFTVersion(context.Background(), env)
+	if err == nil {
+		t.Fatal("expected error for version without nft -c check mode")
+	}
+	if !strings.Contains(err.Error(), "0.8") {
+		t.Errorf("error should mention minimum version 0.8: %v", err)
 	}
 }
 

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1099,11 +1099,22 @@ func chainLinesHaveAgentProxyLoopbackAllowBeforeDrop(lines []string, agentUID, p
 }
 
 func lineHasAgentProxyLoopbackAllow(line string, agentUID, port int) bool {
-	return lineHasSkuid(line, agentUID) &&
-		lineHasIPDAddr(line, "127.0.0.1") &&
-		lineHasToken(line, "tcp") &&
-		lineHasDPort(line, port) &&
-		lineHasToken(line, "accept")
+	fields := nftLineFields(line)
+	want := []string{
+		"meta", "skuid", strconv.Itoa(agentUID),
+		"ip", "daddr", "127.0.0.1",
+		"tcp", "dport", strconv.Itoa(port),
+		"accept",
+	}
+	if len(fields) < len(want) {
+		return false
+	}
+	for i, field := range want {
+		if fields[i] != field {
+			return false
+		}
+	}
+	return nftRuleTailIsCommentOnly(fields[len(want):])
 }
 
 func chainHasAgentDNSDropBeforeCatchAll(out, chainName string, agentUID int, protocol string) bool {
@@ -1306,6 +1317,13 @@ func lineHasDPort(line string, port int) bool {
 		}
 	}
 	return false
+}
+
+func nftRuleTailIsCommentOnly(fields []string) bool {
+	if len(fields) == 0 {
+		return true
+	}
+	return len(fields) == 2 && fields[0] == "comment" && strings.HasPrefix(fields[1], `"`) && strings.HasSuffix(fields[1], `"`)
 }
 
 // lineHasToken finds an exact unquoted nft syntax token.

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1558,15 +1558,6 @@ func chainHasLineBeforeAgentDrop(out, chainName string, agentUID int, match func
 	return chainLinesHaveLineBeforeAgentDrop(lines, agentUID, match)
 }
 
-// chainHasLine applies match only after exact-chain attribution succeeds.
-func chainHasLine(out, chainName string, match func(string) bool) bool {
-	lines, err := attributedNFTChainLines(out, chainName)
-	if err != nil {
-		return false
-	}
-	return chainLinesHaveLine(lines, match)
-}
-
 // ---------------------------------------------------------------------------
 // Probe 4: wrapper_scripts_installed
 // ---------------------------------------------------------------------------

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1780,10 +1780,14 @@ func managedContainmentDropPacketCountFromLines(lines []string, chainName string
 	var packets uint64
 	var parseErr error
 	matched := 0
-	_ = chainLinesHaveLine(lines, func(line string) bool {
+	for _, line := range lines {
+		if !nftLineHasBalancedQuotes(line) {
+			parseErr = fmt.Errorf("managed catch-all DROP rule has malformed quoted rule content: %s", oneLine(line))
+			break
+		}
 		if parseErr != nil ||
 			!strings.Contains(line, `log prefix "`+nftLogPrefix(EgressClassNotRoutingThroughPipelock)+` "`) {
-			return false
+			continue
 		}
 
 		fields := nftLineFields(line)
@@ -1793,38 +1797,40 @@ func managedContainmentDropPacketCountFromLines(lines []string, chainName string
 		// destination/interface/etc. predicate placed before skuid; such a
 		// lookalike would not necessarily see the direct-canary packet.
 		if uidAt != 2 || fields[0] != "meta" || fields[1] != "skuid" {
-			return false
+			continue
 		}
 		dropAt := indexTokenAfter(fields, "drop", uidAt+1)
 		if dropAt == -1 || uidAt+1 >= dropAt || fields[uidAt+1] != "counter" {
-			return false
+			continue
 		}
 		packetsAt := -1
 		for i := uidAt + 1; i+2 < dropAt; i++ {
 			if fields[i] == "counter" && fields[i+1] == "packets" {
 				if packetsAt != -1 {
 					parseErr = fmt.Errorf("managed catch-all DROP rule has multiple packet counters: %s", oneLine(line))
-					return false
+					break
 				}
 				packetsAt = i + 2
 			}
 		}
+		if parseErr != nil {
+			break
+		}
 		if packetsAt == -1 {
 			parseErr = fmt.Errorf("managed catch-all DROP rule has no expanded packet counter: %s", oneLine(line))
-			return false
+			break
 		}
 		parsed, err := strconv.ParseUint(fields[packetsAt], 10, 64)
 		if err != nil {
 			parseErr = fmt.Errorf("parse managed catch-all DROP packet counter %q: %w", fields[packetsAt], err)
-			return false
+			break
 		}
 		if !fieldsAreNFTBookkeeping(fields[uidAt+1 : dropAt]) {
-			return false
+			continue
 		}
 		packets = parsed
 		matched++
-		return false
-	})
+	}
 	if parseErr != nil {
 		return 0, parseErr
 	}

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -861,51 +861,52 @@ func parseSystemdShow(out string) map[string]string {
 // probeNFTContainment verifies the installed nftables boundary structure,
 // ordering, UID ownership, and persistence wiring.
 func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
-	out, code, err := env.runCmd(ctx, probeNFTExecutable(env), "list", "table", "inet", env.nftTable)
+	out, code, err := env.runCmd(ctx, probeNFTExecutable(env), "-n", "-a", "list", "chain", "inet", env.nftTable, env.nftChain)
 	if err != nil {
 		return statusSkip, fmt.Sprintf("nft unavailable: %v", err)
 	}
 	if code != 0 {
 		low := strings.ToLower(out)
 		if strings.Contains(low, "operation not permitted") || strings.Contains(low, "permission denied") {
-			return statusSkip, "nft list table requires root; rerun as root"
+			return statusSkip, "nft list chain requires root; rerun as root"
 		}
 		if strings.Contains(low, "no such file") || strings.Contains(low, "does not exist") {
-			return statusFail, fmt.Sprintf("table inet %s not loaded", env.nftTable)
+			return statusFail, fmt.Sprintf("chain %s missing or not loaded from table inet %s", env.nftChain, env.nftTable)
 		}
 		return statusFail, fmt.Sprintf("nft exit=%d: %s", code, oneLine(out))
 	}
 
-	if !outputHasNFTChainDeclaration(out, env.nftChain) {
-		return statusFail, fmt.Sprintf("chain %s missing from table", env.nftChain)
+	lines, err := attributedNFTChainLines(out, env.nftChain)
+	if err != nil {
+		return statusFail, err.Error()
 	}
 
 	current, err := containmentUIDsFromProbeEnv(env)
 	if err != nil {
 		return statusFail, err.Error()
 	}
-	if current.operatorKnown && !chainHasSkuidAcceptForUID(out, env.nftChain, current.operatorUID) {
+	if current.operatorKnown && !chainLinesHaveSkuidAcceptForUID(lines, current.operatorUID) {
 		return statusFail, fmt.Sprintf("chain present but operator uid %d accept rule missing", current.operatorUID)
 	}
-	if !chainHasSkuidAcceptForUID(out, env.nftChain, current.proxyUID) {
+	if !chainLinesHaveSkuidAcceptForUID(lines, current.proxyUID) {
 		return statusFail, fmt.Sprintf("chain present but proxy uid %d accept rule missing", current.proxyUID)
 	}
-	if !chainHasAgentCatchAllDrop(out, env.nftChain, current.agentUID) {
+	if !chainLinesHaveAgentCatchAllDrop(lines, current.agentUID) {
 		return statusFail, fmt.Sprintf("chain present but current agent uid %d catch-all skuid-drop rule missing", current.agentUID)
 	}
-	if !chainHasAgentProxyLoopbackAllowBeforeDrop(out, env.nftChain, current.agentUID, env.port) {
+	if !chainLinesHaveAgentProxyLoopbackAllowBeforeDrop(lines, current.agentUID, env.port) {
 		return statusFail, fmt.Sprintf("chain present but current agent uid %d loopback allow for 127.0.0.1:%d is missing or appears after the agent catch-all drop", current.agentUID, env.port)
 	}
-	if !chainHasAgentDNSDropBeforeCatchAll(out, env.nftChain, current.agentUID, "udp") {
+	if !chainLinesHaveAgentDNSDropBeforeCatchAll(lines, current.agentUID, "udp") {
 		return statusFail, fmt.Sprintf("chain present but current agent uid %d udp/53 DNS drop rule missing or appears after the agent catch-all drop", current.agentUID)
 	}
-	if !chainHasAgentDNSDropBeforeCatchAll(out, env.nftChain, current.agentUID, "tcp") {
+	if !chainLinesHaveAgentDNSDropBeforeCatchAll(lines, current.agentUID, "tcp") {
 		return statusFail, fmt.Sprintf("chain present but current agent uid %d tcp/53 DNS drop rule missing or appears after the agent catch-all drop", current.agentUID)
 	}
-	if chainHasUnsafeVerdictBeforeAgentDrop(out, env.nftChain, current, env.port) {
+	if chainLinesHaveUnsafeVerdictBeforeAgentDrop(lines, current, env.port) {
 		return statusFail, "chain contains unexpected verdict before agent drop"
 	}
-	if !chainHasManagedOutputBaseChain(out, env.nftChain) {
+	if !nftChainLinesHaveManagedOutputBaseChain(lines) {
 		return statusFail, fmt.Sprintf("chain %s is not the managed output base chain (want type filter hook output priority filter/0 policy accept)", env.nftChain)
 	}
 	if env.nftPersistUnitPath != "" && env.nftRulesPath != "" {
@@ -1056,19 +1057,43 @@ func probeNFTExecutable(env *probeEnv) string {
 }
 
 func chainHasAgentCatchAllDrop(out, chainName string, uid int) bool {
-	return chainHasLine(out, chainName, func(line string) bool {
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return false
+	}
+	return chainLinesHaveAgentCatchAllDrop(lines, uid)
+}
+
+func chainLinesHaveAgentCatchAllDrop(lines []string, uid int) bool {
+	return chainLinesHaveLine(lines, func(line string) bool {
 		return lineHasTerminalSkuidVerdict(line, uid, "drop")
 	})
 }
 
 func chainHasSkuidAcceptForUID(out, chainName string, uid int) bool {
-	return chainHasLine(out, chainName, func(line string) bool {
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return false
+	}
+	return chainLinesHaveSkuidAcceptForUID(lines, uid)
+}
+
+func chainLinesHaveSkuidAcceptForUID(lines []string, uid int) bool {
+	return chainLinesHaveLine(lines, func(line string) bool {
 		return lineHasTerminalSkuidVerdict(line, uid, "accept")
 	})
 }
 
 func chainHasAgentProxyLoopbackAllowBeforeDrop(out, chainName string, agentUID, port int) bool {
-	return chainHasLineBeforeAgentDrop(out, chainName, agentUID, func(line string) bool {
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return false
+	}
+	return chainLinesHaveAgentProxyLoopbackAllowBeforeDrop(lines, agentUID, port)
+}
+
+func chainLinesHaveAgentProxyLoopbackAllowBeforeDrop(lines []string, agentUID, port int) bool {
+	return chainLinesHaveLineBeforeAgentDrop(lines, agentUID, func(line string) bool {
 		return lineHasAgentProxyLoopbackAllow(line, agentUID, port)
 	})
 }
@@ -1082,7 +1107,15 @@ func lineHasAgentProxyLoopbackAllow(line string, agentUID, port int) bool {
 }
 
 func chainHasAgentDNSDropBeforeCatchAll(out, chainName string, agentUID int, protocol string) bool {
-	return chainHasLineBeforeAgentDrop(out, chainName, agentUID, func(line string) bool {
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return false
+	}
+	return chainLinesHaveAgentDNSDropBeforeCatchAll(lines, agentUID, protocol)
+}
+
+func chainLinesHaveAgentDNSDropBeforeCatchAll(lines []string, agentUID int, protocol string) bool {
+	return chainLinesHaveLineBeforeAgentDrop(lines, agentUID, func(line string) bool {
 		return lineHasSkuidProtocolDPortVerdict(line, agentUID, protocol, 53, "drop")
 	})
 }
@@ -1090,7 +1123,15 @@ func chainHasAgentDNSDropBeforeCatchAll(out, chainName string, agentUID int, pro
 // chainHasUnsafeVerdictBeforeAgentDrop detects an unmanaged verdict that can
 // bypass or intercept traffic before the contained agent's catch-all DROP.
 func chainHasUnsafeVerdictBeforeAgentDrop(out, chainName string, uids containmentUIDs, proxyPort int) bool {
-	return chainHasLineBeforeAgentDrop(out, chainName, uids.agentUID, func(line string) bool {
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return true
+	}
+	return chainLinesHaveUnsafeVerdictBeforeAgentDrop(lines, uids, proxyPort)
+}
+
+func chainLinesHaveUnsafeVerdictBeforeAgentDrop(lines []string, uids containmentUIDs, proxyPort int) bool {
+	return chainLinesHaveLineBeforeAgentDrop(lines, uids.agentUID, func(line string) bool {
 		// Before the agent catch-all drop, only the managed operator/proxy
 		// accepts, the agent's proxy loopback allow, and DNS drops are safe.
 		// Any other terminal/control-flow verdict can bypass containment under
@@ -1422,67 +1463,90 @@ func outputHasNFTChainDeclaration(out, chainName string) bool {
 	return false
 }
 
-// chainHasLineBeforeAgentDrop applies match only before the managed agent DROP.
-func chainHasLineBeforeAgentDrop(out, chainName string, agentUID int, match func(string) bool) bool {
-	inChain := false
-	depth := 0
+// attributedNFTChainLines accepts only output from an exact
+// `nft list chain inet <table> <chain>` query. The command itself attributes
+// the following rules to the requested chain; this parser rejects ambiguous
+// table-wide output that includes a different chain and never searches later
+// chains for missing evidence.
+func attributedNFTChainLines(out, chainName string) ([]string, error) {
+	var lines []string
+	declared := false
 	for _, raw := range strings.Split(out, "\n") {
 		line := strings.TrimSpace(raw)
-		if line == "" {
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "table ") || line == "}" {
 			continue
 		}
-		if !inChain && isNFTChainDeclaration(line, chainName) {
-			inChain = true
-		}
-		if !inChain {
+		if strings.HasPrefix(line, "chain ") {
+			if !isNFTChainDeclaration(line, chainName) {
+				return nil, fmt.Errorf("nft output is not positively attributed to chain %s", chainName)
+			}
+			if declared {
+				return nil, fmt.Errorf("nft output declares chain %s more than once", chainName)
+			}
+			declared = true
 			continue
 		}
+		if !declared {
+			return nil, fmt.Errorf("nft output for chain %s has rule content before the chain declaration", chainName)
+		}
+		if !nftLineHasBalancedQuotes(line) {
+			return nil, fmt.Errorf("nft output for chain %s contains malformed quoted rule content", chainName)
+		}
+		lines = append(lines, line)
+	}
+	if !declared {
+		return nil, fmt.Errorf("chain %s missing from nft output", chainName)
+	}
+	return lines, nil
+}
+
+// chainLinesHaveLine applies match only to nft lines already attributed by an
+// exact list-chain command. A malformed line fails closed by not matching.
+func chainLinesHaveLine(lines []string, match func(string) bool) bool {
+	for _, line := range lines {
 		if !nftLineHasBalancedQuotes(line) {
 			return false
 		}
-		depth += nftLineBraceDelta(line)
+		if match(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// chainLinesHaveLineBeforeAgentDrop applies match only before the managed
+// agent DROP in nft lines already attributed to the exact live chain.
+func chainLinesHaveLineBeforeAgentDrop(lines []string, agentUID int, match func(string) bool) bool {
+	for _, line := range lines {
+		if !nftLineHasBalancedQuotes(line) {
+			return false
+		}
 		if lineHasTerminalSkuidVerdict(line, agentUID, "drop") {
 			return false
 		}
 		if match(line) {
 			return true
 		}
-		if depth <= 0 {
-			inChain = false
-			depth = 0
-		}
 	}
 	return false
 }
 
-// chainHasLine applies match only within the requested, structurally valid chain.
-func chainHasLine(out, chainName string, match func(string) bool) bool {
-	inChain := false
-	depth := 0
-	for _, raw := range strings.Split(out, "\n") {
-		line := strings.TrimSpace(raw)
-		if line == "" {
-			continue
-		}
-		if !inChain && isNFTChainDeclaration(line, chainName) {
-			inChain = true
-		}
-		if !inChain {
-			continue
-		}
-		if !nftLineHasBalancedQuotes(line) {
-			return false
-		}
-		depth += nftLineBraceDelta(line)
-		if match(line) {
-			return true
-		}
-		if depth <= 0 {
-			inChain = false
-			depth = 0
-		}
+// chainHasLineBeforeAgentDrop applies match only before the managed agent DROP.
+func chainHasLineBeforeAgentDrop(out, chainName string, agentUID int, match func(string) bool) bool {
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return false
 	}
-	return false
+	return chainLinesHaveLineBeforeAgentDrop(lines, agentUID, match)
+}
+
+// chainHasLine applies match only after exact-chain attribution succeeds.
+func chainHasLine(out, chainName string, match func(string) bool) bool {
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return false
+	}
+	return chainLinesHaveLine(lines, match)
 }
 
 // ---------------------------------------------------------------------------
@@ -1728,20 +1792,24 @@ func readContainmentDropCounter(ctx context.Context, env *probeEnv) (uint64, err
 	if err != nil {
 		return 0, err
 	}
-	out, code, err := env.runCmd(ctx, probeNFTExecutable(env), "-n", "list", "chain", "inet", env.nftTable, env.nftChain)
+	out, code, err := env.runCmd(ctx, probeNFTExecutable(env), "-n", "-a", "list", "chain", "inet", env.nftTable, env.nftChain)
 	if err != nil {
 		return 0, fmt.Errorf("list nft chain: %w", err)
 	}
 	if code != 0 {
 		return 0, fmt.Errorf("list nft chain exit=%d: %s", code, oneLine(out))
 	}
-	if !chainHasManagedOutputBaseChain(out, env.nftChain) {
+	lines, err := attributedNFTChainLines(out, env.nftChain)
+	if err != nil {
+		return 0, err
+	}
+	if !nftChainLinesHaveManagedOutputBaseChain(lines) {
 		return 0, fmt.Errorf("chain %s is not the managed output base chain (want type filter hook output priority filter/0 policy accept)", env.nftChain)
 	}
-	if chainHasUnsafeVerdictBeforeAgentDrop(out, env.nftChain, current, env.port) {
+	if chainLinesHaveUnsafeVerdictBeforeAgentDrop(lines, current, env.port) {
 		return 0, fmt.Errorf("chain %s has an unexpected verdict before managed catch-all DROP; direct-canary attribution is unsafe", env.nftChain)
 	}
-	return managedContainmentDropPacketCount(out, env.nftChain, current.agentUID)
+	return managedContainmentDropPacketCountFromLines(lines, env.nftChain, current.agentUID)
 }
 
 // chainHasManagedOutputBaseChain confirms the requested chain is attached to
@@ -1750,7 +1818,15 @@ func readContainmentDropCounter(ctx context.Context, env *probeEnv) (uint64, err
 // Without this check, a regular/unhooked lookalike chain could provide a benign
 // counter that the direct-canary packet never traverses.
 func chainHasManagedOutputBaseChain(out, chainName string) bool {
-	return chainHasLine(out, chainName, func(line string) bool {
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return false
+	}
+	return nftChainLinesHaveManagedOutputBaseChain(lines)
+}
+
+func nftChainLinesHaveManagedOutputBaseChain(lines []string) bool {
+	return chainLinesHaveLine(lines, func(line string) bool {
 		fields := nftLineFields(strings.ReplaceAll(line, ";", " "))
 		if len(fields) != 8 {
 			return false
@@ -1771,10 +1847,18 @@ func chainHasManagedOutputBaseChain(out, chainName string) bool {
 // lookalikes, wrong-chain rules, DNS counters, and rules with extra predicates
 // are rejected rather than accepted as attribution evidence.
 func managedContainmentDropPacketCount(out, chainName string, agentUID int) (uint64, error) {
+	lines, err := attributedNFTChainLines(out, chainName)
+	if err != nil {
+		return 0, err
+	}
+	return managedContainmentDropPacketCountFromLines(lines, chainName, agentUID)
+}
+
+func managedContainmentDropPacketCountFromLines(lines []string, chainName string, agentUID int) (uint64, error) {
 	var packets uint64
 	var parseErr error
 	matched := 0
-	_ = chainHasLine(out, chainName, func(line string) bool {
+	_ = chainLinesHaveLine(lines, func(line string) bool {
 		if parseErr != nil ||
 			!strings.Contains(line, `log prefix "`+nftLogPrefix(EgressClassNotRoutingThroughPipelock)+` "`) {
 			return false

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1056,40 +1056,16 @@ func probeNFTExecutable(env *probeEnv) string {
 	return "nft"
 }
 
-func chainHasAgentCatchAllDrop(out, chainName string, uid int) bool {
-	lines, err := attributedNFTChainLines(out, chainName)
-	if err != nil {
-		return false
-	}
-	return chainLinesHaveAgentCatchAllDrop(lines, uid)
-}
-
 func chainLinesHaveAgentCatchAllDrop(lines []string, uid int) bool {
 	return chainLinesHaveLine(lines, func(line string) bool {
 		return lineHasTerminalSkuidVerdict(line, uid, "drop")
 	})
 }
 
-func chainHasSkuidAcceptForUID(out, chainName string, uid int) bool {
-	lines, err := attributedNFTChainLines(out, chainName)
-	if err != nil {
-		return false
-	}
-	return chainLinesHaveSkuidAcceptForUID(lines, uid)
-}
-
 func chainLinesHaveSkuidAcceptForUID(lines []string, uid int) bool {
 	return chainLinesHaveLine(lines, func(line string) bool {
 		return lineHasTerminalSkuidVerdict(line, uid, "accept")
 	})
-}
-
-func chainHasAgentProxyLoopbackAllowBeforeDrop(out, chainName string, agentUID, port int) bool {
-	lines, err := attributedNFTChainLines(out, chainName)
-	if err != nil {
-		return false
-	}
-	return chainLinesHaveAgentProxyLoopbackAllowBeforeDrop(lines, agentUID, port)
 }
 
 func chainLinesHaveAgentProxyLoopbackAllowBeforeDrop(lines []string, agentUID, port int) bool {
@@ -1117,28 +1093,10 @@ func lineHasAgentProxyLoopbackAllow(line string, agentUID, port int) bool {
 	return nftRuleTailIsCommentOnly(fields[len(want):])
 }
 
-func chainHasAgentDNSDropBeforeCatchAll(out, chainName string, agentUID int, protocol string) bool {
-	lines, err := attributedNFTChainLines(out, chainName)
-	if err != nil {
-		return false
-	}
-	return chainLinesHaveAgentDNSDropBeforeCatchAll(lines, agentUID, protocol)
-}
-
 func chainLinesHaveAgentDNSDropBeforeCatchAll(lines []string, agentUID int, protocol string) bool {
 	return chainLinesHaveLineBeforeAgentDrop(lines, agentUID, func(line string) bool {
 		return lineHasSkuidProtocolDPortVerdict(line, agentUID, protocol, 53, "drop")
 	})
-}
-
-// chainHasUnsafeVerdictBeforeAgentDrop detects an unmanaged verdict that can
-// bypass or intercept traffic before the contained agent's catch-all DROP.
-func chainHasUnsafeVerdictBeforeAgentDrop(out, chainName string, uids containmentUIDs, proxyPort int) bool {
-	lines, err := attributedNFTChainLines(out, chainName)
-	if err != nil {
-		return true
-	}
-	return chainLinesHaveUnsafeVerdictBeforeAgentDrop(lines, uids, proxyPort)
 }
 
 func chainLinesHaveUnsafeVerdictBeforeAgentDrop(lines []string, uids containmentUIDs, proxyPort int) bool {
@@ -1190,18 +1148,6 @@ func terminalSkuidUIDVerdict(line, verdict string) (int, bool) {
 		}
 	}
 	return 0, false
-}
-
-// lineHasSkuid reports whether an nft rule matches uid via skuid.
-func lineHasSkuid(line string, uid int) bool {
-	want := strconv.Itoa(uid)
-	fields := nftLineFields(line)
-	for i, field := range fields {
-		if field == "skuid" && i+1 < len(fields) && fields[i+1] == want {
-			return true
-		}
-	}
-	return false
 }
 
 // lineHasTerminalSkuidVerdict matches an exact UID with a terminal verdict.
@@ -1296,44 +1242,11 @@ func fieldsAreNFTBookkeeping(fields []string) bool {
 	return !inPrefix && !expectCount
 }
 
-// lineHasIPDAddr reports whether an nft rule contains an exact IPv4 destination.
-func lineHasIPDAddr(line, addr string) bool {
-	fields := nftLineFields(line)
-	for i := 0; i+2 < len(fields); i++ {
-		if fields[i] == "ip" && fields[i+1] == "daddr" && fields[i+2] == addr {
-			return true
-		}
-	}
-	return false
-}
-
-// lineHasDPort reports whether an nft rule contains an exact destination port.
-func lineHasDPort(line string, port int) bool {
-	want := strconv.Itoa(port)
-	fields := nftLineFields(line)
-	for i, field := range fields {
-		if field == "dport" && i+1 < len(fields) && fields[i+1] == want {
-			return true
-		}
-	}
-	return false
-}
-
 func nftRuleTailIsCommentOnly(fields []string) bool {
 	if len(fields) == 0 {
 		return true
 	}
 	return len(fields) == 2 && fields[0] == "comment" && strings.HasPrefix(fields[1], `"`) && strings.HasSuffix(fields[1], `"`)
-}
-
-// lineHasToken finds an exact unquoted nft syntax token.
-func lineHasToken(line, want string) bool {
-	for _, field := range nftLineFields(line) {
-		if field == want {
-			return true
-		}
-	}
-	return false
 }
 
 // lineHasAnyToken finds any requested unquoted nft syntax token.

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1785,8 +1785,7 @@ func managedContainmentDropPacketCountFromLines(lines []string, chainName string
 			parseErr = fmt.Errorf("managed catch-all DROP rule has malformed quoted rule content: %s", oneLine(line))
 			break
 		}
-		if parseErr != nil ||
-			!strings.Contains(line, `log prefix "`+nftLogPrefix(EgressClassNotRoutingThroughPipelock)+` "`) {
+		if !strings.Contains(line, `log prefix "`+nftLogPrefix(EgressClassNotRoutingThroughPipelock)+` "`) {
 			continue
 		}
 

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -743,9 +743,6 @@ func TestProbeNFTContainment(t *testing.T) {
 		{
 			name: "pre-drop jump is fail open",
 			stdout: `table inet pipelock_containment {
-		chain allow_all {
-			accept
-		}
 		chain output_filter {
 			meta skuid 1000 accept
 			meta skuid 988 accept
@@ -759,14 +756,11 @@ func TestProbeNFTContainment(t *testing.T) {
 	`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "not positively attributed",
+			wantDetail: "unexpected verdict",
 		},
 		{
 			name: "pre-drop goto is fail open",
 			stdout: `table inet pipelock_containment {
-		chain allow_all {
-			accept
-		}
 		chain output_filter {
 			meta skuid 1000 accept
 			meta skuid 988 accept
@@ -780,7 +774,7 @@ func TestProbeNFTContainment(t *testing.T) {
 	`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "not positively attributed",
+			wantDetail: "unexpected verdict",
 		},
 		{
 			name: "pre-drop queue is fail open",

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -1954,6 +1954,14 @@ func TestNFTChainTraversalRejectsCraftedNamesAndMalformedComments(t *testing.T) 
 	}
 }
 
+func TestManagedContainmentDropPacketCountFromLinesRejectsMalformedCounterLine(t *testing.T) {
+	lines := []string{`meta skuid 987 counter packets 12 bytes 0 log prefix "pipelock-contain class=not_routing_through_pipelock " drop comment "unterminated`}
+	if _, err := managedContainmentDropPacketCountFromLines(lines, testChain, 987); err == nil ||
+		!strings.Contains(err.Error(), "malformed quoted rule content") {
+		t.Fatalf("error = %v, want malformed quoted rule content", err)
+	}
+}
+
 func TestReadContainmentDropCounter(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -741,7 +741,7 @@ func TestProbeNFTContainment(t *testing.T) {
 	`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "unexpected verdict",
+			wantDetail: "not positively attributed",
 		},
 		{
 			name: "pre-drop goto is fail open",
@@ -762,7 +762,7 @@ func TestProbeNFTContainment(t *testing.T) {
 	`,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "unexpected verdict",
+			wantDetail: "not positively attributed",
 		},
 		{
 			name: "pre-drop queue is fail open",
@@ -950,7 +950,7 @@ func TestProbeNFTContainment(t *testing.T) {
 `,
 			code:       0,
 			wantStatus: statusFail,
-			wantDetail: "skuid-drop rule missing",
+			wantDetail: "not positively attributed",
 		},
 	}
 
@@ -1841,7 +1841,7 @@ func TestManagedContainmentDropPacketCount(t *testing.T) {
 }`,
 			chain:   testChain,
 			uid:     987,
-			wantErr: "no managed catch-all DROP packet counter",
+			wantErr: "not positively attributed",
 		},
 		{
 			name: "rejects duplicate managed catch-all counters",
@@ -1986,7 +1986,7 @@ func TestReadContainmentDropCounter(t *testing.T) {
 {"drop":null}
 ]}}
 ]}`,
-			wantErr:    "not the managed output base chain",
+			wantErr:    "rule content before the chain declaration",
 			wantRunCmd: true,
 		},
 		{
@@ -2026,7 +2026,7 @@ func TestReadContainmentDropCounter(t *testing.T) {
 					if name != testNFT {
 						t.Fatalf("command = %q, want %q", name, testNFT)
 					}
-					wantArgs := []string{"-n", "list", "chain", "inet", testTable, testChain}
+					wantArgs := []string{"-n", "-a", "list", "chain", "inet", testTable, testChain}
 					if strings.Join(args, " ") != strings.Join(wantArgs, " ") {
 						t.Fatalf("args = %v, want %v", args, wantArgs)
 					}

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -633,6 +633,24 @@ func TestProbeNFTContainment(t *testing.T) {
 			wantDetail: "loopback allow",
 		},
 		{
+			name: "constrained proxy loopback allow is not canonical",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			type filter hook output priority filter; policy accept;
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip saddr 127.0.0.2 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 drop
+			meta skuid 987 tcp dport 53 drop
+			meta skuid 987 drop
+		}
+	}
+	`,
+			code:       0,
+			wantStatus: statusFail,
+			wantDetail: "loopback allow",
+		},
+		{
 			name: "agent broad accept before drop is fail open",
 			stdout: `table inet pipelock_containment {
 		chain output_filter {

--- a/internal/sandbox/bridge.go
+++ b/internal/sandbox/bridge.go
@@ -34,6 +34,7 @@ type BridgeProxy struct {
 	wg         sync.WaitGroup
 	mu         sync.Mutex
 	closed     bool
+	conns      map[net.Conn]struct{}
 	closeOnce  sync.Once
 }
 
@@ -52,6 +53,7 @@ func NewBridgeProxy(socketPath string, listenAddr ...string) (*BridgeProxy, erro
 	return &BridgeProxy{
 		listener:   ln,
 		socketPath: socketPath,
+		conns:      make(map[net.Conn]struct{}),
 	}, nil
 }
 
@@ -79,12 +81,14 @@ func (bp *BridgeProxy) Serve(ctx context.Context) {
 			_ = conn.Close()
 			return
 		}
+		bp.trackConnLocked(conn)
 		bp.wg.Add(1)
 		bp.mu.Unlock()
-		go func() {
+		go func(conn net.Conn) {
 			defer bp.wg.Done()
+			defer bp.untrackConn(conn)
 			bp.handleConn(conn)
-		}()
+		}(conn)
 	}
 }
 
@@ -94,9 +98,32 @@ func (bp *BridgeProxy) Close() {
 		bp.mu.Lock()
 		bp.closed = true
 		_ = bp.listener.Close()
+		for conn := range bp.conns {
+			_ = conn.Close()
+		}
 		bp.mu.Unlock()
 		bp.wg.Wait()
 	})
+}
+
+func (bp *BridgeProxy) trackConn(conn net.Conn) bool {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	if bp.closed {
+		return false
+	}
+	bp.trackConnLocked(conn)
+	return true
+}
+
+func (bp *BridgeProxy) trackConnLocked(conn net.Conn) {
+	bp.conns[conn] = struct{}{}
+}
+
+func (bp *BridgeProxy) untrackConn(conn net.Conn) {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	delete(bp.conns, conn)
 }
 
 // handleConn bridges a single TCP connection from the sandbox to the
@@ -111,6 +138,11 @@ func (bp *BridgeProxy) handleConn(conn net.Conn) {
 		_, _ = fmt.Fprintf(os.Stderr, "[bridge] connect to parent proxy: %v\n", err)
 		return
 	}
+	if !bp.trackConn(parentConn) {
+		_ = parentConn.Close()
+		return
+	}
+	defer bp.untrackConn(parentConn)
 	defer func() { _ = parentConn.Close() }()
 
 	// Bridge data bidirectionally.

--- a/internal/sandbox/bridge.go
+++ b/internal/sandbox/bridge.go
@@ -29,13 +29,17 @@ const bridgeListenAddr = "127.0.0.1:8888"
 //	  → Parent (pipelock proxy + scanner, host namespace)
 //	  → Internet
 type BridgeProxy struct {
-	listener   net.Listener
-	socketPath string // parent's Unix domain socket path
-	wg         sync.WaitGroup
-	mu         sync.Mutex
-	closed     bool
-	conns      map[net.Conn]struct{}
-	closeOnce  sync.Once
+	listener        net.Listener
+	socketPath      string // parent's Unix domain socket path
+	wg              sync.WaitGroup
+	mu              sync.Mutex
+	closed          bool
+	done            chan struct{}
+	doneOnce        sync.Once
+	watcherDone     chan struct{}
+	watcherDoneOnce sync.Once
+	conns           map[net.Conn]struct{}
+	closeOnce       sync.Once
 }
 
 // NewBridgeProxy creates a bridge proxy inside the sandbox namespace.
@@ -51,9 +55,11 @@ func NewBridgeProxy(socketPath string, listenAddr ...string) (*BridgeProxy, erro
 		return nil, fmt.Errorf("bridge proxy listen: %w", err)
 	}
 	return &BridgeProxy{
-		listener:   ln,
-		socketPath: socketPath,
-		conns:      make(map[net.Conn]struct{}),
+		listener:    ln,
+		socketPath:  socketPath,
+		done:        make(chan struct{}),
+		watcherDone: make(chan struct{}),
+		conns:       make(map[net.Conn]struct{}),
 	}, nil
 }
 
@@ -66,8 +72,12 @@ func (bp *BridgeProxy) Addr() string {
 // Blocks until ctx is cancelled or the listener is closed.
 func (bp *BridgeProxy) Serve(ctx context.Context) {
 	go func() {
-		<-ctx.Done()
-		_ = bp.listener.Close()
+		defer bp.watcherDoneOnce.Do(func() { close(bp.watcherDone) })
+		select {
+		case <-ctx.Done():
+			_ = bp.listener.Close()
+		case <-bp.done:
+		}
 	}()
 
 	for {
@@ -95,6 +105,7 @@ func (bp *BridgeProxy) Serve(ctx context.Context) {
 // Close shuts down the proxy and waits for active connections.
 func (bp *BridgeProxy) Close() {
 	bp.closeOnce.Do(func() {
+		bp.doneOnce.Do(func() { close(bp.done) })
 		bp.mu.Lock()
 		bp.closed = true
 		_ = bp.listener.Close()

--- a/internal/sandbox/bridge.go
+++ b/internal/sandbox/bridge.go
@@ -38,6 +38,7 @@ type BridgeProxy struct {
 	doneOnce        sync.Once
 	watcherDone     chan struct{}
 	watcherDoneOnce sync.Once
+	watcherStarted  bool
 	conns           map[net.Conn]struct{}
 	closeOnce       sync.Once
 }
@@ -71,6 +72,13 @@ func (bp *BridgeProxy) Addr() string {
 // Serve accepts connections and bridges them to the parent's Unix socket.
 // Blocks until ctx is cancelled or the listener is closed.
 func (bp *BridgeProxy) Serve(ctx context.Context) {
+	bp.mu.Lock()
+	if bp.closed {
+		bp.mu.Unlock()
+		return
+	}
+	bp.watcherStarted = true
+	bp.mu.Unlock()
 	go func() {
 		defer bp.watcherDoneOnce.Do(func() { close(bp.watcherDone) })
 		select {
@@ -108,12 +116,16 @@ func (bp *BridgeProxy) Close() {
 		bp.doneOnce.Do(func() { close(bp.done) })
 		bp.mu.Lock()
 		bp.closed = true
+		waitForWatcher := bp.watcherStarted
 		_ = bp.listener.Close()
 		for conn := range bp.conns {
 			_ = conn.Close()
 		}
 		bp.mu.Unlock()
 		bp.wg.Wait()
+		if waitForWatcher {
+			<-bp.watcherDone
+		}
 	})
 }
 

--- a/internal/sandbox/bridge_test.go
+++ b/internal/sandbox/bridge_test.go
@@ -5,6 +5,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -282,31 +283,48 @@ func TestBridgeProxy_HandleConnAfterCloseDoesNotProxy(t *testing.T) {
 	agentConn, clientConn := net.Pipe()
 	defer func() { _ = clientConn.Close() }()
 
-	parentAccepted := make(chan struct{})
-	parentReadDone := make(chan error, 1)
+	// Two outcomes both satisfy the property under test, and which one occurs is
+	// not ordered: a closed bridge may never dial the parent at all, or it may
+	// dial and then proxy nothing. Only bytes actually reaching the parent is a
+	// failure, so report that directly instead of racing an accept signal
+	// against the read result.
+	type parentOutcome struct {
+		proxied string
+		err     error
+	}
+	outcome := make(chan parentOutcome, 1)
+	if deadliner, ok := parentLn.(interface{ SetDeadline(time.Time) error }); ok {
+		if err := deadliner.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			t.Fatalf("set accept deadline: %v", err)
+		}
+	}
 	go func() {
 		parentConn, acceptErr := parentLn.Accept()
 		if acceptErr != nil {
-			parentReadDone <- fmt.Errorf("accept parent: %w", acceptErr)
+			// A lapsed accept deadline means the closed bridge never dialed.
+			if errors.Is(acceptErr, os.ErrDeadlineExceeded) {
+				outcome <- parentOutcome{}
+				return
+			}
+			outcome <- parentOutcome{err: fmt.Errorf("accept parent: %w", acceptErr)}
 			return
 		}
 		defer func() { _ = parentConn.Close() }()
-		close(parentAccepted)
 		if err := parentConn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
-			parentReadDone <- fmt.Errorf("set parent read deadline: %w", err)
+			outcome <- parentOutcome{err: fmt.Errorf("set parent read deadline: %w", err)}
 			return
 		}
 		buf := make([]byte, 1)
 		n, readErr := parentConn.Read(buf)
 		if n > 0 {
-			parentReadDone <- fmt.Errorf("post-close bridge proxied %q to parent", string(buf[:n]))
+			outcome <- parentOutcome{proxied: string(buf[:n])}
 			return
 		}
 		if readErr == nil {
-			parentReadDone <- fmt.Errorf("parent read returned no data and no error")
+			outcome <- parentOutcome{err: errors.New("parent read returned no data and no error")}
 			return
 		}
-		parentReadDone <- nil
+		outcome <- parentOutcome{}
 	}()
 
 	handleDone := make(chan struct{})
@@ -315,28 +333,24 @@ func TestBridgeProxy_HandleConnAfterCloseDoesNotProxy(t *testing.T) {
 		bp.handleConn(agentConn)
 	}()
 
-	select {
-	case <-parentAccepted:
-	case err := <-parentReadDone:
-		t.Fatalf("parent read completed before accept signal: %v", err)
-	case <-time.After(time.Second):
-		t.Fatal("bridge never connected to parent socket")
-	}
 	if err := clientConn.SetWriteDeadline(time.Now().Add(time.Second)); err == nil {
 		_, _ = clientConn.Write([]byte("x"))
 	}
 
 	select {
-	case err := <-parentReadDone:
-		if err != nil {
-			t.Fatal(err)
+	case got := <-outcome:
+		if got.err != nil {
+			t.Fatal(got.err)
 		}
-	case <-time.After(time.Second):
-		t.Fatal("parent read did not finish after post-close bridge attempt")
+		if got.proxied != "" {
+			t.Fatalf("post-close bridge proxied %q to parent", got.proxied)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("parent never reported an outcome for the post-close bridge attempt")
 	}
 	select {
 	case <-handleDone:
-	case <-time.After(time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("handleConn did not return after post-close rejection")
 	}
 }

--- a/internal/sandbox/bridge_test.go
+++ b/internal/sandbox/bridge_test.go
@@ -237,6 +237,110 @@ func TestBridgeProxy_CloseStopsContextWatcher(t *testing.T) {
 	}
 }
 
+func TestBridgeProxy_CloseBeforeServeRejectsDial(t *testing.T) {
+	bp, err := NewBridgeProxy("/tmp/nonexistent-pipelock-parent.sock", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("NewBridgeProxy: %v", err)
+	}
+	addr := bp.Addr()
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		bp.Close()
+	}()
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("Close blocked before Serve started")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("dial to closed bridge listener succeeded")
+	}
+}
+
+func TestBridgeProxy_HandleConnAfterCloseDoesNotProxy(t *testing.T) {
+	dir := shortTempDir(t)
+	socketPath := ProxySocketPath(dir)
+
+	parentLn, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer func() { _ = parentLn.Close() }()
+
+	bp, err := NewBridgeProxy(socketPath, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("NewBridgeProxy: %v", err)
+	}
+	bp.Close()
+
+	agentConn, clientConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	parentAccepted := make(chan struct{})
+	parentReadDone := make(chan error, 1)
+	go func() {
+		parentConn, acceptErr := parentLn.Accept()
+		if acceptErr != nil {
+			parentReadDone <- fmt.Errorf("accept parent: %w", acceptErr)
+			return
+		}
+		defer func() { _ = parentConn.Close() }()
+		close(parentAccepted)
+		if err := parentConn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			parentReadDone <- fmt.Errorf("set parent read deadline: %w", err)
+			return
+		}
+		buf := make([]byte, 1)
+		n, readErr := parentConn.Read(buf)
+		if n > 0 {
+			parentReadDone <- fmt.Errorf("post-close bridge proxied %q to parent", string(buf[:n]))
+			return
+		}
+		if readErr == nil {
+			parentReadDone <- fmt.Errorf("parent read returned no data and no error")
+			return
+		}
+		parentReadDone <- nil
+	}()
+
+	handleDone := make(chan struct{})
+	go func() {
+		defer close(handleDone)
+		bp.handleConn(agentConn)
+	}()
+
+	select {
+	case <-parentAccepted:
+	case err := <-parentReadDone:
+		t.Fatalf("parent read completed before accept signal: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("bridge never connected to parent socket")
+	}
+	if err := clientConn.SetWriteDeadline(time.Now().Add(time.Second)); err == nil {
+		_, _ = clientConn.Write([]byte("x"))
+	}
+
+	select {
+	case err := <-parentReadDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("parent read did not finish after post-close bridge attempt")
+	}
+	select {
+	case <-handleDone:
+	case <-time.After(time.Second):
+		t.Fatal("handleConn did not return after post-close rejection")
+	}
+}
+
 func TestBridgeProxy_HandleConnFailsGracefully(t *testing.T) {
 	// Bridge proxy with a nonexistent socket path - connections should
 	// fail gracefully (log error, close conn) not panic.

--- a/internal/sandbox/bridge_test.go
+++ b/internal/sandbox/bridge_test.go
@@ -126,6 +126,75 @@ func TestBridgeProxy_Addr(t *testing.T) {
 	}
 }
 
+func TestBridgeProxy_CloseClosesIdleActiveConnections(t *testing.T) {
+	dir := shortTempDir(t)
+	socketPath := ProxySocketPath(dir)
+
+	parentLn, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer func() { _ = parentLn.Close() }()
+
+	parentAccepted := make(chan struct{})
+	releaseParent := make(chan struct{})
+	parentDone := make(chan struct{})
+	go func() {
+		defer close(parentDone)
+		conn, acceptErr := parentLn.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		close(parentAccepted)
+		<-releaseParent
+	}()
+
+	bp, err := NewBridgeProxy(socketPath, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("NewBridgeProxy: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		bp.Serve(ctx)
+	}()
+	defer func() {
+		cancel()
+		bp.Close()
+		_ = parentLn.Close()
+		close(releaseParent)
+		<-serveDone
+		<-parentDone
+	}()
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", bp.Addr())
+	if err != nil {
+		t.Fatalf("dial bridge: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	select {
+	case <-parentAccepted:
+	case <-time.After(time.Second):
+		t.Fatal("bridge never connected to parent socket")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		bp.Close()
+	}()
+
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("BridgeProxy.Close blocked on idle active connection")
+	}
+}
+
 func TestBridgeProxy_HandleConnFailsGracefully(t *testing.T) {
 	// Bridge proxy with a nonexistent socket path - connections should
 	// fail gracefully (log error, close conn) not panic.

--- a/internal/sandbox/bridge_test.go
+++ b/internal/sandbox/bridge_test.go
@@ -195,6 +195,48 @@ func TestBridgeProxy_CloseClosesIdleActiveConnections(t *testing.T) {
 	}
 }
 
+func TestBridgeProxy_CloseStopsContextWatcher(t *testing.T) {
+	dir := shortTempDir(t)
+	socketPath := ProxySocketPath(dir)
+
+	parentLn, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer func() { _ = parentLn.Close() }()
+
+	bp, err := NewBridgeProxy(socketPath, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("NewBridgeProxy: %v", err)
+	}
+
+	ctx := context.Background()
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		bp.Serve(ctx)
+	}()
+
+	conn, err := (&net.Dialer{}).DialContext(context.Background(), "tcp", bp.Addr())
+	if err != nil {
+		t.Fatalf("dial bridge: %v", err)
+	}
+	_ = conn.Close()
+
+	bp.Close()
+
+	select {
+	case <-bp.watcherDone:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not stop Serve context watcher")
+	}
+	select {
+	case <-serveDone:
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not return after Close")
+	}
+}
+
 func TestBridgeProxy_HandleConnFailsGracefully(t *testing.T) {
 	// Bridge proxy with a nonexistent socket path - connections should
 	// fail gracefully (log error, close conn) not panic.

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 )
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
@@ -142,22 +141,10 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 
 	// Accept connections from the bridge proxy in the child.
-	var proxyWg sync.WaitGroup
-	go func() {
-		for {
-			conn, err := unixLn.Accept()
-			if err != nil {
-				return // listener closed
-			}
-			proxyWg.Add(1)
-			go func() {
-				defer proxyWg.Done()
-				handleStandaloneProxyConnection(conn, standaloneProxyConnectionConfig{
-					ProxyHandler: cfg.ProxyHandler,
-				})
-			}()
-		}
-	}()
+	proxyServer := startStandaloneProxyServer(unixLn, standaloneProxyConnectionConfig{
+		ProxyHandler: cfg.ProxyHandler,
+	})
+	defer proxyServer.stop()
 
 	// Fork child in sandbox with standalone init mode.
 	selfExe, err := os.Readlink("/proc/self/exe")
@@ -239,25 +226,14 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 
 	// Strict mode: reap orphaned descendants adopted by subreaper.
-	// Best-effort: use timeout-based drain (existing behavior).
+	// Best-effort relies on process-group termination plus proxy server stop.
 	if cfg.Strict {
 		ReapOrphans()
 	}
 
-	// Close listener to prevent new connections.
-	_ = unixLn.Close()
-
-	// Wait for proxy goroutines to drain.
-	const proxyDrainTimeout = 5 * time.Second
-	done := make(chan struct{})
-	go func() {
-		proxyWg.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(proxyDrainTimeout):
-	}
+	// Stop accepting, close active bridge connections, and join the accept
+	// loop plus all proxy handlers before sandbox directory cleanup.
+	proxyServer.stop()
 
 	// Clean up child's sandbox temp dir.
 	if cmd.Process != nil {
@@ -265,6 +241,79 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 
 	return waitErr
+}
+
+type standaloneProxyServer struct {
+	ln   net.Listener
+	cfg  standaloneProxyConnectionConfig
+	once sync.Once
+
+	mu       sync.Mutex
+	stopping bool
+	conns    map[net.Conn]struct{}
+	wg       sync.WaitGroup
+}
+
+func startStandaloneProxyServer(ln net.Listener, cfg standaloneProxyConnectionConfig) *standaloneProxyServer {
+	s := &standaloneProxyServer{
+		ln:    ln,
+		cfg:   cfg,
+		conns: make(map[net.Conn]struct{}),
+	}
+	s.wg.Add(1)
+	go s.acceptLoop()
+	return s
+}
+
+func (s *standaloneProxyServer) acceptLoop() {
+	defer s.wg.Done()
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		if !s.trackConn(conn) {
+			_ = conn.Close()
+			continue
+		}
+		go s.handleConn(conn)
+	}
+}
+
+func (s *standaloneProxyServer) trackConn(conn net.Conn) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopping {
+		return false
+	}
+	s.conns[conn] = struct{}{}
+	s.wg.Add(1)
+	return true
+}
+
+func (s *standaloneProxyServer) handleConn(conn net.Conn) {
+	defer s.wg.Done()
+	defer s.untrackConn(conn)
+	handleStandaloneProxyConnection(conn, s.cfg)
+}
+
+func (s *standaloneProxyServer) untrackConn(conn net.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.conns, conn)
+}
+
+func (s *standaloneProxyServer) stop() {
+	s.once.Do(func() {
+		s.mu.Lock()
+		s.stopping = true
+		_ = s.ln.Close()
+		for conn := range s.conns {
+			_ = conn.Close()
+		}
+		s.mu.Unlock()
+		s.wg.Wait()
+	})
 }
 
 // handleStandaloneProxyConnection dispatches a bridge connection to the

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -306,8 +306,8 @@ func (s *standaloneProxyServer) untrackConn(conn net.Conn) {
 	delete(s.conns, conn)
 }
 
-func (s *standaloneProxyServer) stop() bool {
-	return s.stopWithin(standaloneProxyDrainTimeout)
+func (s *standaloneProxyServer) stop() {
+	_ = s.stopWithin(standaloneProxyDrainTimeout)
 }
 
 func (s *standaloneProxyServer) stopWithin(timeout time.Duration) bool {

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -310,6 +310,9 @@ func (s *standaloneProxyServer) stop() {
 	_ = s.stopWithin(standaloneProxyDrainTimeout)
 }
 
+// stopWithin performs shutdown once and reports whether that first shutdown
+// drained active handlers before timeout. Subsequent calls are no-ops and return
+// false regardless of the first shutdown's drain outcome.
 func (s *standaloneProxyServer) stopWithin(timeout time.Duration) bool {
 	stopped := false
 	s.once.Do(func() {

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 )
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
@@ -254,6 +255,8 @@ type standaloneProxyServer struct {
 	wg       sync.WaitGroup
 }
 
+const standaloneProxyDrainTimeout = 5 * time.Second
+
 func startStandaloneProxyServer(ln net.Listener, cfg standaloneProxyConnectionConfig) *standaloneProxyServer {
 	s := &standaloneProxyServer{
 		ln:    ln,
@@ -303,7 +306,12 @@ func (s *standaloneProxyServer) untrackConn(conn net.Conn) {
 	delete(s.conns, conn)
 }
 
-func (s *standaloneProxyServer) stop() {
+func (s *standaloneProxyServer) stop() bool {
+	return s.stopWithin(standaloneProxyDrainTimeout)
+}
+
+func (s *standaloneProxyServer) stopWithin(timeout time.Duration) bool {
+	stopped := false
 	s.once.Do(func() {
 		s.mu.Lock()
 		s.stopping = true
@@ -312,8 +320,26 @@ func (s *standaloneProxyServer) stop() {
 			_ = conn.Close()
 		}
 		s.mu.Unlock()
-		s.wg.Wait()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			s.wg.Wait()
+		}()
+		if timeout <= 0 {
+			<-done
+			stopped = true
+			return
+		}
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case <-done:
+			stopped = true
+		case <-timer.C:
+		}
 	})
+	return stopped
 }
 
 // handleStandaloneProxyConnection dispatches a bridge connection to the

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // skipIfStandaloneUnavailable skips tests that require full standalone
@@ -380,11 +382,14 @@ func TestStandaloneProxyServer_StopTimeoutAllowsLateHandlerCleanup(t *testing.T)
 		t.Fatal("proxy handler did not exit after release")
 	}
 
-	server.mu.Lock()
-	defer server.mu.Unlock()
-	if len(server.conns) != 0 {
-		t.Fatalf("timed-out proxy server leaked tracked connections: %d", len(server.conns))
-	}
+	// handlerDone closes inside the handler, while the server untracks the
+	// connection after the handler returns, so the untrack is strictly later and
+	// its timing is not ordered against this goroutine. Poll for the drain.
+	testwait.For(t, 2*time.Second, func() bool {
+		server.mu.Lock()
+		defer server.mu.Unlock()
+		return len(server.conns) == 0
+	}, "timed-out proxy server leaked tracked connections")
 }
 
 func TestHandleStandaloneProxyConnection_NilHandlerFailsClosed(t *testing.T) {

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -200,7 +200,6 @@ func TestStandaloneProxyServer_StopJoinsHandlers(t *testing.T) {
 			handlerEntered := make(chan struct{})
 			releaseHandler := make(chan struct{})
 			handlerDone := make(chan struct{})
-			var shared int
 			server := startStandaloneProxyServer(ln, standaloneProxyConnectionConfig{
 				ProxyHandler: func(conn net.Conn) {
 					defer close(handlerDone)
@@ -211,7 +210,6 @@ func TestStandaloneProxyServer_StopJoinsHandlers(t *testing.T) {
 						case <-releaseHandler:
 							return
 						default:
-							_ = shared
 							runtime.Gosched()
 						}
 					}
@@ -239,10 +237,6 @@ func TestStandaloneProxyServer_StopJoinsHandlers(t *testing.T) {
 
 			select {
 			case <-stopDone:
-				for i := 0; i < 100000; i++ {
-					shared = i
-					runtime.Gosched()
-				}
 				close(releaseHandler)
 				<-handlerDone
 				t.Fatal("stop returned before active proxy handler exited")
@@ -309,6 +303,31 @@ func TestStandaloneProxyServer_StopIsBoundedForBlockedHandler(t *testing.T) {
 	}
 }
 
+func TestStandaloneProxyServer_StopWithinReportsDrainOnlyOnFirstCall(t *testing.T) {
+	socketDir, err := os.MkdirTemp("/tmp", "plk-proxy-*")
+	if err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "proxy.sock")
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("unix listen: %v", err)
+	}
+
+	server := startStandaloneProxyServer(ln, standaloneProxyConnectionConfig{
+		ProxyHandler: func(conn net.Conn) {
+			_ = conn.Close()
+		},
+	})
+	if !server.stopWithin(time.Second) {
+		t.Fatal("first stopWithin call did not report clean drain")
+	}
+	if server.stopWithin(time.Second) {
+		t.Fatal("second stopWithin call reported drain status")
+	}
+}
+
 func TestStandaloneProxyServer_StopTimeoutAllowsLateHandlerCleanup(t *testing.T) {
 	socketDir, err := os.MkdirTemp("/tmp", "plk-proxy-*")
 	if err != nil {
@@ -324,6 +343,11 @@ func TestStandaloneProxyServer_StopTimeoutAllowsLateHandlerCleanup(t *testing.T)
 	handlerEntered := make(chan struct{})
 	releaseHandler := make(chan struct{})
 	handlerDone := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseHandler) })
+	}
+	t.Cleanup(release)
 	server := startStandaloneProxyServer(ln, standaloneProxyConnectionConfig{
 		ProxyHandler: func(conn net.Conn) {
 			defer close(handlerDone)
@@ -349,7 +373,7 @@ func TestStandaloneProxyServer_StopTimeoutAllowsLateHandlerCleanup(t *testing.T)
 		t.Fatal("stop reported a clean drain while proxy handler was still blocked")
 	}
 
-	close(releaseHandler)
+	release()
 	select {
 	case <-handlerDone:
 	case <-time.After(time.Second):

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -177,6 +177,93 @@ func TestLaunchStandalone_BridgeProxyListens(t *testing.T) {
 	}
 }
 
+func TestStandaloneProxyServer_StopJoinsHandlers(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "stop waits for active handler"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			socketDir, err := os.MkdirTemp("/tmp", "plk-proxy-*")
+			if err != nil {
+				t.Fatalf("mkdir socket dir: %v", err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+			socketPath := filepath.Join(socketDir, "proxy.sock")
+			ln, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+			if err != nil {
+				t.Fatalf("unix listen: %v", err)
+			}
+
+			handlerEntered := make(chan struct{})
+			releaseHandler := make(chan struct{})
+			handlerDone := make(chan struct{})
+			var shared int
+			server := startStandaloneProxyServer(ln, standaloneProxyConnectionConfig{
+				ProxyHandler: func(conn net.Conn) {
+					defer close(handlerDone)
+					defer func() { _ = conn.Close() }()
+					close(handlerEntered)
+					for {
+						select {
+						case <-releaseHandler:
+							return
+						default:
+							_ = shared
+							runtime.Gosched()
+						}
+					}
+				},
+			})
+			defer server.stop()
+
+			conn, err := (&net.Dialer{}).DialContext(context.Background(), "unix", socketPath)
+			if err != nil {
+				t.Fatalf("unix dial: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			select {
+			case <-handlerEntered:
+			case <-time.After(time.Second):
+				t.Fatal("proxy handler did not start")
+			}
+
+			stopDone := make(chan struct{})
+			go func() {
+				defer close(stopDone)
+				server.stop()
+			}()
+
+			select {
+			case <-stopDone:
+				for i := 0; i < 100000; i++ {
+					shared = i
+					runtime.Gosched()
+				}
+				close(releaseHandler)
+				<-handlerDone
+				t.Fatal("stop returned before active proxy handler exited")
+			case <-time.After(100 * time.Millisecond):
+				close(releaseHandler)
+			}
+
+			select {
+			case <-handlerDone:
+			case <-time.After(time.Second):
+				t.Fatal("proxy handler did not exit")
+			}
+			select {
+			case <-stopDone:
+			case <-time.After(time.Second):
+				t.Fatal("stop did not return after proxy handler exited")
+			}
+		})
+	}
+}
+
 func TestHandleStandaloneProxyConnection_NilHandlerFailsClosed(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -264,6 +264,51 @@ func TestStandaloneProxyServer_StopJoinsHandlers(t *testing.T) {
 	}
 }
 
+func TestStandaloneProxyServer_StopIsBoundedForBlockedHandler(t *testing.T) {
+	socketDir, err := os.MkdirTemp("/tmp", "plk-proxy-*")
+	if err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "proxy.sock")
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("unix listen: %v", err)
+	}
+
+	handlerEntered := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	handlerDone := make(chan struct{})
+	server := startStandaloneProxyServer(ln, standaloneProxyConnectionConfig{
+		ProxyHandler: func(conn net.Conn) {
+			defer close(handlerDone)
+			defer func() { _ = conn.Close() }()
+			close(handlerEntered)
+			<-releaseHandler
+		},
+	})
+	defer func() {
+		close(releaseHandler)
+		<-handlerDone
+	}()
+
+	conn, err := (&net.Dialer{}).DialContext(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("unix dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	select {
+	case <-handlerEntered:
+	case <-time.After(time.Second):
+		t.Fatal("proxy handler did not start")
+	}
+
+	if server.stopWithin(50 * time.Millisecond) {
+		t.Fatal("stop reported a clean drain while proxy handler was still blocked")
+	}
+}
+
 func TestHandleStandaloneProxyConnection_NilHandlerFailsClosed(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -309,6 +309,60 @@ func TestStandaloneProxyServer_StopIsBoundedForBlockedHandler(t *testing.T) {
 	}
 }
 
+func TestStandaloneProxyServer_StopTimeoutAllowsLateHandlerCleanup(t *testing.T) {
+	socketDir, err := os.MkdirTemp("/tmp", "plk-proxy-*")
+	if err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "proxy.sock")
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("unix listen: %v", err)
+	}
+
+	handlerEntered := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	handlerDone := make(chan struct{})
+	server := startStandaloneProxyServer(ln, standaloneProxyConnectionConfig{
+		ProxyHandler: func(conn net.Conn) {
+			defer close(handlerDone)
+			defer func() { _ = conn.Close() }()
+			close(handlerEntered)
+			<-releaseHandler
+		},
+	})
+
+	conn, err := (&net.Dialer{}).DialContext(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("unix dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	select {
+	case <-handlerEntered:
+	case <-time.After(time.Second):
+		t.Fatal("proxy handler did not start")
+	}
+
+	if server.stopWithin(time.Millisecond) {
+		t.Fatal("stop reported a clean drain while proxy handler was still blocked")
+	}
+
+	close(releaseHandler)
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("proxy handler did not exit after release")
+	}
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.conns) != 0 {
+		t.Fatalf("timed-out proxy server leaked tracked connections: %d", len(server.conns))
+	}
+}
+
 func TestHandleStandaloneProxyConnection_NilHandlerFailsClosed(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
`contain verify` and the shared drop-counter reader require positive attribution of the managed nftables chain plus proof of an active output base chain. Structural resemblance to the managed chain no longer satisfies the probe, so containment evidence reports enforcement only when the required rule is the rule in force.

`contain install` repairs a chain it can attribute as its own and refuses a same-named chain it cannot. Repair replaces the managed chain rather than the whole table, so operator chains co-located in that table survive, and a failed chain delete stops the step instead of merging into stale rules. Repair and rollback both write a script, validate it with nft check mode, and apply it only after the check passes, which keeps a rejected script from leaving the chain deleted with nothing loaded. Rollback also refuses a captured dump that does not declare the expected table.

The minimum nftables version rises to 0.8 because check mode is now required. An older nft reports the version requirement rather than failing later with a parse error.

The standalone sandbox proxy closes accepted connections and joins its goroutines through a single shutdown path, and the bridge stops its context watcher when a caller closes it directly.

`docs/contain-cli.md` documents the attribution behavior operators see.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Containment verification now strictly uses positively attributed managed nftables chain rules and counters, failing closed when attribution is ambiguous.
  - nftables updates are safer: avoids replacing unattributed live chains, reloads only the managed chain when applicable, and restores prior state more reliably on rollback.
  - Sandbox/standalone proxy shutdown now coordinates watchers and active connections to stop promptly and drain safely.
- **Compatibility**
  - Requires nftables **0.8+**.
- **Documentation**
  - Updated containment verification and diagnostic wording to match the new fail-closed behavior.
- **Tests**
  - Expanded coverage for attribution, managed-chain reload/undo safety, and proxy stop/drain behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->