### PR TITLE
feat(dashboard): record the authenticated principal on dashboard audit lines

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -342,8 +342,16 @@ the server is running stops serving.
   subject only as `auth_subject_sha256` plus mapped roles. mTLS requests record
   the leaf certificate SPKI fingerprint as `mtls_spki_sha256` plus the mapped
   role. Denied authentication and permission checks include a bounded failure
-  category such as `no_credential`, `unknown_principal`, `role_lacks_permission`,
-  `expired`, or `invalid_token`.
+  category such as `missing_token`, `missing_client_certificate`,
+  `unmapped_client_certificate`, `permission_denied`, `expired`, or
+  `invalid_token`.
+  Audit log compatibility note: this release replaces raw `auth_subject` output
+  with `auth_subject_sha256` and adds `mtls_spki_sha256` and `permission`
+  fields on denial records. SIEM parsers that key on the old raw subject field
+  must migrate to the hashed subject field. Existing denial `reason=` values
+  for missing tokens, missing client certificates, unverified client
+  certificates, unmapped client certificates, and role permission denial remain
+  stable.
 - **Exemptions is inventory only.** `/exemptions` is GET-only and reads the
   already-loaded config snapshot. It has no POST route, no apply/remove/renew
   controls, no config write path, and no hot-reload hook.

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -125,7 +125,7 @@ startup error.
 | `--oidc-role-claim` | none | Verified token claim containing role or group values. Required with `--oidc-issuer`. |
 | `--oidc-role-map` | none | JSON mapping of verified claim values to bounded dashboard permissions. Required with `--oidc-issuer`. |
 | `--require-client-cert` | `false` | Require a verified client certificate on every TLS connection and authorize it through the role map. Requires all three mTLS file flags below. |
-| `--client-ca-file` | none | PEM bundle of trust anchors used by TLS to verify client certificates. |
+| `--client-ca-file` | none | PEM bundle of trust anchors used by TLS to verify client certificates. The bundle is capped at 1 MiB at startup. |
 | `--client-cert-role-map` | none | YAML file mapping client-certificate SPKI SHA-256 fingerprints to roles and bounded dashboard permissions. |
 | `--conductor-url` | none | Optional Conductor HTTPS base URL for read-only live fleet status. When omitted, live fleet panels render the explicit "no conductor source configured" state. |
 | `--conductor-token-file` | none | File containing the Conductor read bearer token. Required with `--conductor-url`; must authorize the configured org/fleet read. |
@@ -151,6 +151,10 @@ SubjectPublicKeyInfo (SPKI). This identity remains stable when a certificate is
 renewed with the same key. Role permissions must come from the dashboard's
 bounded permission vocabulary. Grant `dashboard:raw:read` only to roles that
 may view raw destinations and signed payloads.
+
+Client certificates with RSA public keys larger than 8192 bits are rejected
+after normal TLS verification and before the request reaches dashboard route
+authorization. EC and Ed25519 client certificates are unaffected.
 
 <!-- dashboard-mtls-role-map-start -->
 ```yaml
@@ -231,6 +235,13 @@ sets, such as `account`), so the "aud contains `--oidc-audience`" check passes.
 A token that then carries multiple audiences must also set `azp` to the client
 ID, which Keycloak does for the client that obtained the token; the dashboard
 requires that `azp` match when more than one audience is present.
+
+Discovery and JWKS documents are size-bounded, duplicate JSON members are
+rejected, only RS256 signing keys are accepted, and token claims are decoded
+only after the signature verifies. An unknown JWT `kid` triggers at most one
+bounded JWKS refresh per refresh window. Additional unknown-key requests inside
+that window fail closed without refetching the JWKS endpoint; a throttled
+refresh never authenticates the request.
 
 Pick a role source with `--oidc-role-claim` and map it to bounded dashboard
 permissions with `--oidc-role-map`. The role claim can be `azp` (the client ID,
@@ -324,8 +335,15 @@ the server is running stops serving.
   metadata-view response. The scorecard — the actual proof — does not depend
   on the raw fields.
 - **Access is audited.** Every authenticated request is written to an access log
-  on stderr (role `metadata` or `raw`, method, path, session, remote address).
-  Viewing evidence is itself a recorded action.
+  on stderr (role `metadata` or `raw`, dashboard permission, method, path,
+  session, remote address, auth method, mapped roles, and redacted principal
+  attribution). Token requests record `auth_method=token` or
+  `auth_method=raw-access-token` without token bytes. OIDC requests record the
+  subject only as `auth_subject_sha256` plus mapped roles. mTLS requests record
+  the leaf certificate SPKI fingerprint as `mtls_spki_sha256` plus the mapped
+  role. Denied authentication and permission checks include a bounded failure
+  category such as `no_credential`, `unknown_principal`, `role_lacks_permission`,
+  `expired`, or `invalid_token`.
 - **Exemptions is inventory only.** `/exemptions` is GET-only and reads the
   already-loaded config snapshot. It has no POST route, no apply/remove/renew
   controls, no config write path, and no hot-reload hook.

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -152,9 +152,10 @@ renewed with the same key. Role permissions must come from the dashboard's
 bounded permission vocabulary. Grant `dashboard:raw:read` only to roles that
 may view raw destinations and signed payloads.
 
-Client certificates with RSA public keys larger than 8192 bits are rejected
-after normal TLS verification and before the request reaches dashboard route
-authorization. EC and Ed25519 client certificates are unaffected.
+Client certificates with RSA public keys smaller than 2048 bits or larger than
+8192 bits are rejected after normal TLS verification and before the request
+reaches dashboard route authorization. EC and Ed25519 client certificates are
+unaffected.
 
 <!-- dashboard-mtls-role-map-start -->
 ```yaml

--- a/enterprise/cli/conductor/client.go
+++ b/enterprise/cli/conductor/client.go
@@ -138,7 +138,7 @@ func (c *ReadClient) ReplayDecision(ctx context.Context, orgID, fleetID, artifac
 		strings.IndexFunc(artifactHash, unicode.IsControl) >= 0 {
 		return nil, false, errors.New("org_id, fleet_id, and artifact_hash must not contain control characters")
 	}
-	if err := validateCanonicalSHA256Hex("artifact_hash", artifactHash); err != nil {
+	if err := ValidateCanonicalSHA256Hex("artifact_hash", artifactHash); err != nil {
 		return nil, false, err
 	}
 	params := map[string]string{
@@ -149,7 +149,9 @@ func (c *ReadClient) ReplayDecision(ctx context.Context, orgID, fleetID, artifac
 	return c.client.getJSONMaybeNotFound(ctx, controlplane.DecisionReplayPath+encodeQuery(params))
 }
 
-func validateCanonicalSHA256Hex(name, value string) error {
+// ValidateCanonicalSHA256Hex requires value to be the canonical lowercase hex
+// representation of a SHA-256 digest.
+func ValidateCanonicalSHA256Hex(name, value string) error {
 	if len(value) != sha256.Size*2 {
 		return fmt.Errorf("%s must be a 64-character lowercase sha256 hex string", name)
 	}

--- a/enterprise/cli/conductor/client.go
+++ b/enterprise/cli/conductor/client.go
@@ -8,8 +8,10 @@ package conductor
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -136,12 +138,28 @@ func (c *ReadClient) ReplayDecision(ctx context.Context, orgID, fleetID, artifac
 		strings.IndexFunc(artifactHash, unicode.IsControl) >= 0 {
 		return nil, false, errors.New("org_id, fleet_id, and artifact_hash must not contain control characters")
 	}
+	if err := validateCanonicalSHA256Hex("artifact_hash", artifactHash); err != nil {
+		return nil, false, err
+	}
 	params := map[string]string{
 		"org_id":        orgID,
 		"fleet_id":      fleetID,
 		"artifact_hash": artifactHash,
 	}
 	return c.client.getJSONMaybeNotFound(ctx, controlplane.DecisionReplayPath+encodeQuery(params))
+}
+
+func validateCanonicalSHA256Hex(name, value string) error {
+	if len(value) != sha256.Size*2 {
+		return fmt.Errorf("%s must be a 64-character lowercase sha256 hex string", name)
+	}
+	if strings.ToLower(value) != value {
+		return fmt.Errorf("%s must be lowercase", name)
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return fmt.Errorf("%s must be hex: %w", name, err)
+	}
+	return nil
 }
 
 func (o *clientOptions) bindFlags(cmd *cobra.Command) {
@@ -290,6 +308,9 @@ func (c *conductorClient) getJSONStatus(ctx context.Context, path string, allowe
 		if resp.StatusCode == status {
 			return conductorClientResponse{status: resp.StatusCode, body: body}, nil
 		}
+	}
+	if len(allowed) > 0 {
+		return conductorClientResponse{}, fmt.Errorf("conductor returned status %d: %s", resp.StatusCode, clientSnippet(body, c.token))
 	}
 	if err := checkClientStatus(resp, body, c.token); err != nil {
 		return conductorClientResponse{}, err

--- a/enterprise/cli/conductor/client_test.go
+++ b/enterprise/cli/conductor/client_test.go
@@ -412,6 +412,9 @@ func TestConductorReadClientReplayDecisionRejectsInvalidScope(t *testing.T) {
 		{name: "control org", client: client, orgID: "org\nmain", fleetID: "prod", artifactHash: artifactHash, wantErr: "control characters"},
 		{name: "control fleet", client: client, orgID: "org-main", fleetID: "prod\rwest", artifactHash: artifactHash, wantErr: "control characters"},
 		{name: "control artifact", client: client, orgID: "org-main", fleetID: "prod", artifactHash: artifactHash[:32] + "\n" + artifactHash[32:], wantErr: "control characters"},
+		{name: "short artifact", client: client, orgID: "org-main", fleetID: "prod", artifactHash: strings.Repeat("a", 63), wantErr: "64-character"},
+		{name: "uppercase artifact", client: client, orgID: "org-main", fleetID: "prod", artifactHash: strings.Repeat("A", 64), wantErr: "lowercase"},
+		{name: "non hex artifact", client: client, orgID: "org-main", fleetID: "prod", artifactHash: strings.Repeat("g", 64), wantErr: "hex"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -467,7 +470,7 @@ func TestConductorClientGetJSONStatusErrorPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("ok status not explicitly allowed still accepted", func(t *testing.T) {
+	t.Run("ok status not explicitly allowed is rejected", func(t *testing.T) {
 		client := &conductorClient{
 			httpClient: &http.Client{Transport: conductorReadRoundTripFunc(func(*http.Request) (*http.Response, error) {
 				return &http.Response{
@@ -478,12 +481,9 @@ func TestConductorClientGetJSONStatusErrorPaths(t *testing.T) {
 			baseURL: "https://conductor.example",
 			token:   "operator-token",
 		}
-		resp, err := client.getJSONStatus(context.Background(), controlplane.DecisionReplayPath, http.StatusCreated)
-		if err != nil {
-			t.Fatalf("getJSONStatus() error = %v", err)
-		}
-		if resp.status != http.StatusOK || len(resp.body) != 0 {
-			t.Fatalf("response = %+v, want empty 200 response", resp)
+		_, err := client.getJSONStatus(context.Background(), controlplane.DecisionReplayPath, http.StatusCreated)
+		if err == nil || !strings.Contains(err.Error(), "status 200") {
+			t.Fatalf("getJSONStatus() error = %v, want status 200 rejection", err)
 		}
 	})
 }

--- a/enterprise/cli/conductor/dryrun_replay_cli_test.go
+++ b/enterprise/cli/conductor/dryrun_replay_cli_test.go
@@ -676,7 +676,7 @@ func TestRunReplayRemoteKillPostsEndpointShapeAndDoesNotApply(t *testing.T) {
 	rig.opts.transport = recorder
 
 	opts := replayOptions{
-		mode:            replayModeRemoteKill,
+		mode:            replayActionRemoteKill,
 		kill:            rig.opts,
 		remoteKillState: string(conductorcore.KillSwitchActive),
 	}
@@ -730,7 +730,7 @@ func TestRunReplayRemoteKillPostsEndpointShapeAndDoesNotApply(t *testing.T) {
 func TestRunReplayRemoteKillRequiresExplicitState(t *testing.T) {
 	rig := newKillRig(t, 0)
 	opts := replayOptions{
-		mode: replayModeRemoteKill,
+		mode: replayActionRemoteKill,
 		kill: rig.opts,
 	}
 	cmd, _ := replayCobra(t)
@@ -782,7 +782,7 @@ func TestRunReplayRollbackPostsEndpointShapeAndDoesNotApply(t *testing.T) {
 	rb.transport = recorder
 
 	opts := replayOptions{
-		mode:     replayModeRollback,
+		mode:     replayActionRollback,
 		rollback: rb,
 	}
 	cmd, out := replayCobra(t)
@@ -851,7 +851,7 @@ func TestPostDecisionReplayRejectsResponseModeMismatches(t *testing.T) {
 			name:     "publish action mismatch",
 			artifact: decisionReplayArtifact{Bundle: &conductorcore.PolicyBundle{}},
 			result: controlplane.DecisionReplayResult{
-				ActionKind:   replayModeRemoteKill,
+				ActionKind:   replayActionRemoteKill,
 				ArtifactHash: strings.Repeat("a", 64),
 				ReplayedAt:   resultTime,
 				RemoteKill:   &controlplane.RemoteKillEvaluation{Valid: true},
@@ -883,7 +883,7 @@ func TestPostDecisionReplayRejectsResponseModeMismatches(t *testing.T) {
 			name:     "remote kill missing evaluation",
 			artifact: decisionReplayArtifact{RemoteKill: &conductorcore.RemoteKillMessage{}},
 			result: controlplane.DecisionReplayResult{
-				ActionKind:   replayModeRemoteKill,
+				ActionKind:   replayActionRemoteKill,
 				ArtifactHash: strings.Repeat("d", 64),
 				ReplayedAt:   resultTime,
 			},
@@ -893,7 +893,7 @@ func TestPostDecisionReplayRejectsResponseModeMismatches(t *testing.T) {
 			name:     "rollback action mismatch",
 			artifact: decisionReplayArtifact{Rollback: &conductorcore.RollbackAuthorization{}},
 			result: controlplane.DecisionReplayResult{
-				ActionKind:   replayModeRemoteKill,
+				ActionKind:   replayActionRemoteKill,
 				ArtifactHash: strings.Repeat("e", 64),
 				ReplayedAt:   resultTime,
 				RemoteKill:   &controlplane.RemoteKillEvaluation{Valid: true},
@@ -904,7 +904,7 @@ func TestPostDecisionReplayRejectsResponseModeMismatches(t *testing.T) {
 			name:     "rollback missing evaluation",
 			artifact: decisionReplayArtifact{Rollback: &conductorcore.RollbackAuthorization{}},
 			result: controlplane.DecisionReplayResult{
-				ActionKind:   replayModeRollback,
+				ActionKind:   replayActionRollback,
 				ArtifactHash: strings.Repeat("f", 64),
 				ReplayedAt:   resultTime,
 			},
@@ -926,7 +926,7 @@ func TestPostDecisionReplayRejectsResponseModeMismatches(t *testing.T) {
 			name:     "remote kill response included extra publish evaluation",
 			artifact: decisionReplayArtifact{RemoteKill: &conductorcore.RemoteKillMessage{}},
 			result: controlplane.DecisionReplayResult{
-				ActionKind:        replayModeRemoteKill,
+				ActionKind:        replayActionRemoteKill,
 				ArtifactHash:      strings.Repeat("h", 64),
 				ReplayedAt:        resultTime,
 				RemoteKill:        &controlplane.RemoteKillEvaluation{Valid: true},
@@ -938,7 +938,7 @@ func TestPostDecisionReplayRejectsResponseModeMismatches(t *testing.T) {
 			name:     "rollback response included extra emergency evaluation",
 			artifact: decisionReplayArtifact{Rollback: &conductorcore.RollbackAuthorization{}},
 			result: controlplane.DecisionReplayResult{
-				ActionKind:   replayModeRollback,
+				ActionKind:   replayActionRollback,
 				ArtifactHash: strings.Repeat("i", 64),
 				ReplayedAt:   resultTime,
 				Rollback:     &controlplane.RollbackEvaluation{Valid: true},
@@ -1016,7 +1016,7 @@ func TestPostDecisionReplayRejectsArtifactHashMismatch(t *testing.T) {
 		t.Fatal("test fixture unexpectedly matched mismatch hash")
 	}
 	result := controlplane.DecisionReplayResult{
-		ActionKind:   replayModeRemoteKill,
+		ActionKind:   replayActionRemoteKill,
 		ArtifactHash: strings.Repeat("0", 64),
 		ReplayedAt:   testFixedNow(t),
 		RemoteKill:   &controlplane.RemoteKillEvaluation{Valid: true},

--- a/enterprise/cli/conductor/dryrun_replay_cli_test.go
+++ b/enterprise/cli/conductor/dryrun_replay_cli_test.go
@@ -1032,6 +1032,33 @@ func TestPostDecisionReplayRejectsArtifactHashMismatch(t *testing.T) {
 	}
 }
 
+func TestPostDecisionReplayRejectsUppercaseArtifactHashResponse(t *testing.T) {
+	msg := conductorcore.RemoteKillMessage{MessageID: "kill-uppercase"}
+	expectedHash, err := msg.CanonicalHash()
+	if err != nil {
+		t.Fatalf("CanonicalHash(remote kill): %v", err)
+	}
+	uppercaseHash := strings.ToUpper(expectedHash)
+	if uppercaseHash == expectedHash {
+		t.Fatalf("test fixture hash %q has no lowercase hex letters", expectedHash)
+	}
+	result := controlplane.DecisionReplayResult{
+		ActionKind:   replayActionRemoteKill,
+		ArtifactHash: uppercaseHash,
+		ReplayedAt:   testFixedNow(t),
+		RemoteKill:   &controlplane.RemoteKillEvaluation{Valid: true},
+	}
+	body, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	client := &staticEmergencyTransport{status: http.StatusOK, body: string(body)}
+	_, err = postDecisionReplay(t.Context(), client, "https://conductor.example", testAdminToken, decisionReplayArtifact{RemoteKill: &msg})
+	if err == nil || !strings.Contains(err.Error(), "artifact_hash") {
+		t.Fatalf("postDecisionReplay() error = %v, want artifact_hash mismatch", err)
+	}
+}
+
 func TestRunReplayBundleArtifactPostsExactBundle(t *testing.T) {
 	dir := t.TempDir()
 	buildOpts := publishDryRunTestOptions(t, dir)

--- a/enterprise/cli/conductor/replay.go
+++ b/enterprise/cli/conductor/replay.go
@@ -441,7 +441,7 @@ func validateDecisionReplayResultForArtifact(result controlplane.DecisionReplayR
 	if result.ActionKind != expectedAction {
 		return fmt.Errorf("replay response action_kind=%q does not match requested action %q", result.ActionKind, expectedAction)
 	}
-	if !strings.EqualFold(result.ArtifactHash, expectedHash) {
+	if result.ArtifactHash != expectedHash {
 		return fmt.Errorf("replay response artifact_hash=%q does not match submitted artifact hash %q", result.ArtifactHash, expectedHash)
 	}
 	switch expectedAction {

--- a/enterprise/cli/conductor/replay.go
+++ b/enterprise/cli/conductor/replay.go
@@ -30,11 +30,10 @@ const (
 	replayMaxStateSnapshotBytes  = conductorcore.MaxConfigYAMLBytes
 	replayMaxBundleArtifactBytes = conductorcore.MaxConfigYAMLBytes * 2
 
-	replayModePolicyBundle = "policy_bundle"
-	replayModeRemoteKill   = controlplane.ActionKindRemoteKill
-	replayModeRollback     = controlplane.ActionKindRollback
-
-	replayActionPublish = controlplane.ActionKindPublish
+	replayActionPolicyBundle = "policy_bundle"
+	replayActionRemoteKill   = controlplane.ActionKindRemoteKill
+	replayActionRollback     = controlplane.ActionKindRollback
+	replayActionPublish      = controlplane.ActionKindPublish
 )
 
 type replayOptions struct {
@@ -49,7 +48,7 @@ type replayOptions struct {
 
 func replayCmd() *cobra.Command {
 	opts := replayOptions{
-		mode:    replayModePolicyBundle,
+		mode:    replayActionPolicyBundle,
 		publish: publishOptions{validity: defaultPublishValidity},
 	}
 	cmd := &cobra.Command{
@@ -84,14 +83,14 @@ decisions against the same decision-replay endpoint without applying them.`,
 func runReplay(cmd *cobra.Command, opts replayOptions) error {
 	mode := strings.TrimSpace(opts.mode)
 	if mode == "" {
-		mode = replayModePolicyBundle
+		mode = replayActionPolicyBundle
 	}
 	switch mode {
-	case replayModePolicyBundle:
+	case replayActionPolicyBundle:
 		return runPolicyBundleReplay(cmd, opts)
-	case replayModeRemoteKill:
+	case replayActionRemoteKill:
 		return runRemoteKillReplay(cmd, opts)
-	case replayModeRollback:
+	case replayActionRollback:
 		return runRollbackReplay(cmd, opts)
 	default:
 		return fmt.Errorf("unsupported replay mode %q", opts.mode)
@@ -100,7 +99,7 @@ func runReplay(cmd *cobra.Command, opts replayOptions) error {
 
 func replayRemoteKillCmd() *cobra.Command {
 	opts := replayOptions{
-		mode: replayModeRemoteKill,
+		mode: replayActionRemoteKill,
 		kill: killOptions{ttl: remoteKillDefaultTTL},
 	}
 	cmd := &cobra.Command{
@@ -125,7 +124,7 @@ publishing or applying the message.`,
 
 func replayRollbackCmd() *cobra.Command {
 	opts := replayOptions{
-		mode:     replayModeRollback,
+		mode:     replayActionRollback,
 		rollback: rollbackOptions{ttl: rollbackDefaultTTL},
 	}
 	cmd := &cobra.Command{
@@ -417,13 +416,13 @@ func validateDecisionReplayArtifact(artifact decisionReplayArtifact) (string, er
 			return "", fmt.Errorf("hash replay bundle artifact: %w", err)
 		}
 		return hash, nil
-	case replayModeRemoteKill:
+	case replayActionRemoteKill:
 		hash, err := artifact.RemoteKill.CanonicalHash()
 		if err != nil {
 			return "", fmt.Errorf("hash replay remote-kill artifact: %w", err)
 		}
 		return hash, nil
-	case replayModeRollback:
+	case replayActionRollback:
 		hash, err := artifact.Rollback.CanonicalHash()
 		if err != nil {
 			return "", fmt.Errorf("hash replay rollback artifact: %w", err)
@@ -453,14 +452,14 @@ func validateDecisionReplayResultForArtifact(result controlplane.DecisionReplayR
 		if result.RemoteKill != nil || result.Rollback != nil {
 			return errors.New("replay response for publish included an emergency evaluation")
 		}
-	case replayModeRemoteKill:
+	case replayActionRemoteKill:
 		if result.RemoteKill == nil {
 			return errors.New("replay response missing remote_kill_evaluation")
 		}
 		if result.PublishEvaluation != nil || result.Rollback != nil {
 			return errors.New("replay response for remote_kill included a different evaluation")
 		}
-	case replayModeRollback:
+	case replayActionRollback:
 		if result.Rollback == nil {
 			return errors.New("replay response missing rollback_evaluation")
 		}
@@ -481,11 +480,11 @@ func replayResponseActionForArtifact(artifact decisionReplayArtifact) (string, e
 		seen++
 	}
 	if artifact.RemoteKill != nil {
-		expected = replayModeRemoteKill
+		expected = replayActionRemoteKill
 		seen++
 	}
 	if artifact.Rollback != nil {
-		expected = replayModeRollback
+		expected = replayActionRollback
 		seen++
 	}
 	if seen != 1 {

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -572,19 +572,19 @@ func dashboardAuthHandler(
 func dashboardClientCertAuthAuditInfo(auth *dashboardClientCertAuthorizer, r *http.Request) dashboard.AuthAuditInfo {
 	info := dashboard.AuthAuditInfo{
 		Method:        "mtls",
-		FailureReason: "no_credential",
+		FailureReason: "missing_client_certificate",
 	}
 	if r == nil || r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
 		return info
 	}
 	info.MTLSSPKISHA256 = dashboardClientCertSPKIFingerprint(r.TLS.PeerCertificates[0])
 	if len(r.TLS.VerifiedChains) == 0 || len(r.TLS.VerifiedChains[0]) == 0 {
-		info.FailureReason = "invalid_credential"
+		info.FailureReason = "unverified_client_certificate"
 		return info
 	}
 	principal, ok := auth.principal(r)
 	if !ok {
-		info.FailureReason = "unknown_principal"
+		info.FailureReason = "unmapped_client_certificate"
 		return info
 	}
 	info.Roles = []string{principal.role}
@@ -596,7 +596,7 @@ func recordDashboardAuthDenied(auditWriter io.Writer, r *http.Request, authInfo 
 	if auditWriter == nil {
 		return
 	}
-	info := dashboard.AuthAuditInfo{Method: "none", FailureReason: "no_credential"}
+	info := dashboard.AuthAuditInfo{Method: "none", FailureReason: "missing_token"}
 	if authInfo != nil {
 		info = authInfo(r)
 	}

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -603,7 +603,7 @@ func recordDashboardAuthDenied(auditWriter io.Writer, r *http.Request, authInfo 
 	if info.FailureReason == "" {
 		info.FailureReason = "unauthorized"
 	}
-	_, _ = fmt.Fprintf(auditWriter, "%s pipelock-dashboard denied permission=%q method=%s path=%q auth_method=%s auth_subject_sha256=%s mtls_spki_sha256=%s auth_roles=%q reason=%s remote=%s\n",
+	_, _ = fmt.Fprintf(auditWriter, "%s pipelock-dashboard denied permission=%q method=%s path=%q auth_method=%s auth_subject_sha256=%q mtls_spki_sha256=%q auth_roles=%q reason=%s remote=%s\n",
 		time.Now().UTC().Format(time.RFC3339), "-", r.Method, r.URL.Path,
 		dashboard.AuditLogValue(info.Method), dashboard.AuditLogValue(info.SubjectSHA256),
 		dashboard.AuditLogValue(info.MTLSSPKISHA256),

--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -437,6 +437,7 @@ func dashboardTLSConfig(opts dashboardServeOptions) (*tls.Config, error) {
 		}
 		config.ClientAuth = tls.RequireAndVerifyClientCert
 		config.ClientCAs = clientCAs
+		config.VerifyConnection = verifyDashboardClientCertificateKeySizes
 	}
 	return config, nil
 }
@@ -571,19 +572,19 @@ func dashboardAuthHandler(
 func dashboardClientCertAuthAuditInfo(auth *dashboardClientCertAuthorizer, r *http.Request) dashboard.AuthAuditInfo {
 	info := dashboard.AuthAuditInfo{
 		Method:        "mtls",
-		FailureReason: "missing_client_certificate",
+		FailureReason: "no_credential",
 	}
 	if r == nil || r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
 		return info
 	}
-	info.Subject = dashboardClientCertSPKIFingerprint(r.TLS.PeerCertificates[0])
+	info.MTLSSPKISHA256 = dashboardClientCertSPKIFingerprint(r.TLS.PeerCertificates[0])
 	if len(r.TLS.VerifiedChains) == 0 || len(r.TLS.VerifiedChains[0]) == 0 {
-		info.FailureReason = "unverified_client_certificate"
+		info.FailureReason = "invalid_credential"
 		return info
 	}
 	principal, ok := auth.principal(r)
 	if !ok {
-		info.FailureReason = "unmapped_client_certificate"
+		info.FailureReason = "unknown_principal"
 		return info
 	}
 	info.Roles = []string{principal.role}
@@ -595,16 +596,17 @@ func recordDashboardAuthDenied(auditWriter io.Writer, r *http.Request, authInfo 
 	if auditWriter == nil {
 		return
 	}
-	info := dashboard.AuthAuditInfo{Method: "none", FailureReason: "missing_token"}
+	info := dashboard.AuthAuditInfo{Method: "none", FailureReason: "no_credential"}
 	if authInfo != nil {
 		info = authInfo(r)
 	}
 	if info.FailureReason == "" {
 		info.FailureReason = "unauthorized"
 	}
-	_, _ = fmt.Fprintf(auditWriter, "%s pipelock-dashboard denied method=%s path=%q auth_method=%s auth_subject=%q auth_roles=%q reason=%s remote=%s\n",
-		time.Now().UTC().Format(time.RFC3339), r.Method, r.URL.Path,
-		dashboard.AuditLogValue(info.Method), dashboard.AuditLogValue(info.Subject),
+	_, _ = fmt.Fprintf(auditWriter, "%s pipelock-dashboard denied permission=%q method=%s path=%q auth_method=%s auth_subject_sha256=%s mtls_spki_sha256=%s auth_roles=%q reason=%s remote=%s\n",
+		time.Now().UTC().Format(time.RFC3339), "-", r.Method, r.URL.Path,
+		dashboard.AuditLogValue(info.Method), dashboard.AuditLogValue(info.SubjectSHA256),
+		dashboard.AuditLogValue(info.MTLSSPKISHA256),
 		strings.Join(dashboardAuditLogValues(info.Roles), ","), dashboard.AuditLogValue(info.FailureReason), r.RemoteAddr)
 }
 

--- a/enterprise/cli/dashboard_conductor_source.go
+++ b/enterprise/cli/dashboard_conductor_source.go
@@ -8,8 +8,6 @@ package entcli
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -171,7 +169,7 @@ func (s *dashboardConductorSource) ReplayDecision(ctx context.Context, scope das
 	if scope.ArtifactHash == "" {
 		return dashboard.DecisionReplayView{}, false, errors.New("artifact hash is required")
 	}
-	if err := validateDashboardReplayArtifactHash(scope.ArtifactHash); err != nil {
+	if err := conductorcli.ValidateCanonicalSHA256Hex("artifact hash", scope.ArtifactHash); err != nil {
 		return dashboard.DecisionReplayView{}, false, err
 	}
 	body, found, err := s.client.ReplayDecision(ctx, scope.OrgID, scope.FleetID, scope.ArtifactHash)
@@ -209,19 +207,6 @@ func applyConductorCompleteness(page *dashboard.FleetFollowerPage, resp dashboar
 	}
 	if !page.CompletenessKnown {
 		page.HasMore = false
-	}
-	return nil
-}
-
-func validateDashboardReplayArtifactHash(artifactHash string) error {
-	if len(artifactHash) != sha256.Size*2 {
-		return errors.New("artifact hash must be a 64-character lowercase sha256 hex string")
-	}
-	if strings.ToLower(artifactHash) != artifactHash {
-		return errors.New("artifact hash must be lowercase")
-	}
-	if _, err := hex.DecodeString(artifactHash); err != nil {
-		return fmt.Errorf("artifact hash must be hex: %w", err)
 	}
 	return nil
 }

--- a/enterprise/cli/dashboard_conductor_source.go
+++ b/enterprise/cli/dashboard_conductor_source.go
@@ -8,6 +8,8 @@ package entcli
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -169,6 +171,9 @@ func (s *dashboardConductorSource) ReplayDecision(ctx context.Context, scope das
 	if scope.ArtifactHash == "" {
 		return dashboard.DecisionReplayView{}, false, errors.New("artifact hash is required")
 	}
+	if err := validateDashboardReplayArtifactHash(scope.ArtifactHash); err != nil {
+		return dashboard.DecisionReplayView{}, false, err
+	}
 	body, found, err := s.client.ReplayDecision(ctx, scope.OrgID, scope.FleetID, scope.ArtifactHash)
 	if err != nil || !found {
 		return dashboard.DecisionReplayView{}, found, err
@@ -204,6 +209,19 @@ func applyConductorCompleteness(page *dashboard.FleetFollowerPage, resp dashboar
 	}
 	if !page.CompletenessKnown {
 		page.HasMore = false
+	}
+	return nil
+}
+
+func validateDashboardReplayArtifactHash(artifactHash string) error {
+	if len(artifactHash) != sha256.Size*2 {
+		return errors.New("artifact hash must be a 64-character lowercase sha256 hex string")
+	}
+	if strings.ToLower(artifactHash) != artifactHash {
+		return errors.New("artifact hash must be lowercase")
+	}
+	if _, err := hex.DecodeString(artifactHash); err != nil {
+		return fmt.Errorf("artifact hash must be hex: %w", err)
 	}
 	return nil
 }
@@ -300,7 +318,7 @@ func dashboardDecisionReplayView(body []byte, requestedHash string) (dashboard.D
 	if err := dec.Decode(&extra); err != io.EOF {
 		return dashboard.DecisionReplayView{}, errors.New("decode conductor decision replay response: trailing JSON data")
 	}
-	if !strings.EqualFold(result.ArtifactHash, strings.TrimSpace(requestedHash)) {
+	if result.ArtifactHash != strings.TrimSpace(requestedHash) {
 		return dashboard.DecisionReplayView{}, fmt.Errorf("conductor replay response artifact_hash=%q does not match requested artifact hash", result.ArtifactHash)
 	}
 	if result.Recorded == nil || !result.Recorded.Present {
@@ -323,6 +341,9 @@ func dashboardDecisionReplayView(body []byte, requestedHash string) (dashboard.D
 		if result.PublishEvaluation == nil || result.RemoteKill != nil || result.Rollback != nil {
 			return dashboard.DecisionReplayView{}, errors.New("conductor replay response has invalid publish evaluation shape")
 		}
+		if err := validateDashboardReplayConflict(controlplane.ActionKindPublish, result.PublishEvaluation.Conflict); err != nil {
+			return dashboard.DecisionReplayView{}, err
+		}
 		view.Valid = result.PublishEvaluation.Valid
 		view.Conflict = result.PublishEvaluation.Conflict
 		view.ResultVersion = result.PublishEvaluation.ResultVersion
@@ -330,6 +351,9 @@ func dashboardDecisionReplayView(body []byte, requestedHash string) (dashboard.D
 	case controlplane.ActionKindRemoteKill:
 		if result.RemoteKill == nil || result.PublishEvaluation != nil || result.Rollback != nil {
 			return dashboard.DecisionReplayView{}, errors.New("conductor replay response has invalid remote-kill evaluation shape")
+		}
+		if err := validateDashboardReplayConflict(controlplane.ActionKindRemoteKill, result.RemoteKill.Conflict); err != nil {
+			return dashboard.DecisionReplayView{}, err
 		}
 		view.Valid = result.RemoteKill.Valid
 		view.Conflict = result.RemoteKill.Conflict
@@ -339,6 +363,9 @@ func dashboardDecisionReplayView(body []byte, requestedHash string) (dashboard.D
 		if result.Rollback == nil || result.PublishEvaluation != nil || result.RemoteKill != nil {
 			return dashboard.DecisionReplayView{}, errors.New("conductor replay response has invalid rollback evaluation shape")
 		}
+		if err := validateDashboardReplayConflict(controlplane.ActionKindRollback, result.Rollback.Conflict); err != nil {
+			return dashboard.DecisionReplayView{}, err
+		}
 		view.Valid = result.Rollback.Valid
 		view.Conflict = result.Rollback.Conflict
 		view.ResultVersion = result.Rollback.WouldRollToVersion
@@ -347,6 +374,37 @@ func dashboardDecisionReplayView(body []byte, requestedHash string) (dashboard.D
 		return dashboard.DecisionReplayView{}, fmt.Errorf("conductor replay response action_kind=%q is unsupported", result.ActionKind)
 	}
 	return view, nil
+}
+
+func validateDashboardReplayConflict(actionKind, conflict string) error {
+	if strings.TrimSpace(conflict) == "" {
+		return nil
+	}
+	switch actionKind {
+	case controlplane.ActionKindPublish:
+		switch conflict {
+		case controlplane.PublishConflictRollbackAttempt,
+			controlplane.PublishConflictVersionBelowStreamMax,
+			controlplane.PublishConflictPreviousHashMismatch,
+			controlplane.PublishConflictOther,
+			controlplane.PublishConflictFleetSkew:
+			return nil
+		}
+	case controlplane.ActionKindRemoteKill:
+		switch conflict {
+		case controlplane.EmergencyConflictIDConflict,
+			controlplane.EmergencyConflictStaleCounter:
+			return nil
+		}
+	case controlplane.ActionKindRollback:
+		switch conflict {
+		case controlplane.EmergencyConflictIDConflict,
+			controlplane.EmergencyConflictStaleCounter,
+			controlplane.RollbackConflictHeadPreviewFailed:
+			return nil
+		}
+	}
+	return fmt.Errorf("conductor replay response has invalid %s conflict code %q", actionKind, conflict)
 }
 
 func dashboardConductorFleetScopeAuthorizer(orgID, fleetID string) func(*http.Request, dashboard.DecisionScope, bool) error {

--- a/enterprise/cli/dashboard_conductor_source_test.go
+++ b/enterprise/cli/dashboard_conductor_source_test.go
@@ -802,13 +802,8 @@ func TestNewDashboardConductorSource_UnconfiguredStaysNilInterface(t *testing.T)
 		t.Fatalf("source = %v, want nil for an unset conductor URL", source)
 	}
 
-	var iface dashboard.ConductorDecisionSource
-	iface = dashboardConductorDecisionSource(source)
+	iface := dashboardConductorDecisionSource(source)
 	if iface != nil {
 		t.Fatal("unconfigured conductor source was stored as a non-nil ConductorDecisionSource")
-	}
-	iface = nil
-	if iface != nil {
-		t.Fatal("zero ConductorDecisionSource is unexpectedly non-nil")
 	}
 }

--- a/enterprise/cli/dashboard_conductor_source_test.go
+++ b/enterprise/cli/dashboard_conductor_source_test.go
@@ -478,6 +478,20 @@ func TestDashboardConductorSourceReplayDecisionFailsClosed(t *testing.T) {
 			mustNotCallClient: true,
 		},
 		{
+			name:              "uppercase artifact",
+			scope:             dashboard.DecisionScope{OrgID: "org-main", FleetID: "prod", ArtifactHash: strings.Repeat("A", 64)},
+			client:            &fakeDashboardConductorClient{replayFound: true},
+			wantErr:           "lowercase",
+			mustNotCallClient: true,
+		},
+		{
+			name:              "non hex artifact",
+			scope:             dashboard.DecisionScope{OrgID: "org-main", FleetID: "prod", ArtifactHash: strings.Repeat("g", 64)},
+			client:            &fakeDashboardConductorClient{replayFound: true},
+			wantErr:           "hex",
+			mustNotCallClient: true,
+		},
+		{
 			name:    "client error",
 			scope:   dashboard.DecisionScope{OrgID: "org-main", FleetID: "prod", ArtifactHash: artifactHash},
 			client:  &fakeDashboardConductorClient{replayErr: errors.New("status 503"), replayFound: true},
@@ -558,6 +572,39 @@ func TestDashboardConductorSourceReplayDecisionFailsClosed(t *testing.T) {
 				Recorded:     validRecorded,
 			})},
 			wantErr: "unsupported",
+		},
+		{
+			name:  "unknown publish conflict code",
+			scope: dashboard.DecisionScope{OrgID: "org-main", FleetID: "prod", ArtifactHash: artifactHash},
+			client: &fakeDashboardConductorClient{replayFound: true, replayBody: mustJSON(t, controlplane.DecisionReplayResult{
+				ActionKind:        controlplane.ActionKindPublish,
+				ArtifactHash:      artifactHash,
+				PublishEvaluation: &controlplane.PublishEvaluation{Valid: false, Conflict: "surprise"},
+				Recorded:          validRecorded,
+			})},
+			wantErr: "invalid publish conflict",
+		},
+		{
+			name:  "unknown remote kill conflict code",
+			scope: dashboard.DecisionScope{OrgID: "org-main", FleetID: "prod", ArtifactHash: artifactHash},
+			client: &fakeDashboardConductorClient{replayFound: true, replayBody: mustJSON(t, controlplane.DecisionReplayResult{
+				ActionKind:   controlplane.ActionKindRemoteKill,
+				ArtifactHash: artifactHash,
+				RemoteKill:   &controlplane.RemoteKillEvaluation{Valid: false, Conflict: "surprise"},
+				Recorded:     validRecorded,
+			})},
+			wantErr: "invalid remote_kill conflict",
+		},
+		{
+			name:  "unknown rollback conflict code",
+			scope: dashboard.DecisionScope{OrgID: "org-main", FleetID: "prod", ArtifactHash: artifactHash},
+			client: &fakeDashboardConductorClient{replayFound: true, replayBody: mustJSON(t, controlplane.DecisionReplayResult{
+				ActionKind:   controlplane.ActionKindRollback,
+				ArtifactHash: artifactHash,
+				Rollback:     &controlplane.RollbackEvaluation{Valid: false, Conflict: "surprise"},
+				Recorded:     validRecorded,
+			})},
+			wantErr: "invalid rollback conflict",
 		},
 	}
 	for _, tc := range tests {
@@ -756,9 +803,11 @@ func TestNewDashboardConductorSource_UnconfiguredStaysNilInterface(t *testing.T)
 	}
 
 	var iface dashboard.ConductorDecisionSource
-	if assigned := dashboardConductorDecisionSource(source); assigned != nil {
+	iface = dashboardConductorDecisionSource(source)
+	if iface != nil {
 		t.Fatal("unconfigured conductor source was stored as a non-nil ConductorDecisionSource")
 	}
+	iface = nil
 	if iface != nil {
 		t.Fatal("zero ConductorDecisionSource is unexpectedly non-nil")
 	}

--- a/enterprise/cli/dashboard_mtls.go
+++ b/enterprise/cli/dashboard_mtls.go
@@ -6,7 +6,9 @@
 package entcli
 
 import (
+	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
@@ -23,7 +25,11 @@ import (
 	"github.com/luckyPipewrench/pipelock/enterprise/dashboard"
 )
 
-const dashboardClientCertRoleMapMaxBytes = 1 << 20
+const (
+	dashboardClientCertRoleMapMaxBytes = 1 << 20
+	dashboardClientCAMaxBytes          = 1 << 20
+	dashboardClientCertRSAMaxBits      = 8192
+)
 
 type dashboardClientCertRoleMapFile struct {
 	Version      int                                `yaml:"version"`
@@ -261,9 +267,17 @@ func loadDashboardClientCAs(path string) (*x509.CertPool, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, errors.New("--client-ca-file is required when --require-client-cert is set")
 	}
-	pemBytes, err := os.ReadFile(filepath.Clean(path))
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, fmt.Errorf("read --client-ca-file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	pemBytes, err := io.ReadAll(io.LimitReader(file, dashboardClientCAMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read --client-ca-file: %w", err)
+	}
+	if len(pemBytes) > dashboardClientCAMaxBytes {
+		return nil, fmt.Errorf("--client-ca-file exceeds %d bytes", dashboardClientCAMaxBytes)
 	}
 	// Parse every certificate block explicitly instead of AppendCertsFromPEM,
 	// which silently skips malformed blocks and would start the dashboard with a
@@ -290,4 +304,20 @@ func loadDashboardClientCAs(path string) (*x509.CertPool, error) {
 		return nil, errors.New("--client-ca-file contains no valid PEM certificates")
 	}
 	return pool, nil
+}
+
+func verifyDashboardClientCertificateKeySizes(state tls.ConnectionState) error {
+	for _, cert := range state.PeerCertificates {
+		if cert == nil {
+			continue
+		}
+		key, ok := cert.PublicKey.(*rsa.PublicKey)
+		if !ok {
+			continue
+		}
+		if key.N.BitLen() > dashboardClientCertRSAMaxBits {
+			return fmt.Errorf("dashboard client certificate RSA modulus is %d bits; maximum is %d", key.N.BitLen(), dashboardClientCertRSAMaxBits)
+		}
+	}
+	return nil
 }

--- a/enterprise/cli/dashboard_mtls.go
+++ b/enterprise/cli/dashboard_mtls.go
@@ -6,6 +6,7 @@
 package entcli
 
 import (
+	"bytes"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/tls"
@@ -284,12 +285,12 @@ func loadDashboardClientCAs(path string) (*x509.CertPool, error) {
 	// partial trust set. A trust anchor bundle must load completely or fail loud.
 	pool := x509.NewCertPool()
 	var added int
-	for rest := pemBytes; ; {
-		var block *pem.Block
-		block, rest = pem.Decode(rest)
+	for rest := pemBytes; len(bytes.TrimSpace(rest)) > 0; {
+		block, remaining := pem.Decode(rest)
 		if block == nil {
-			break
+			return nil, errors.New("--client-ca-file contains malformed PEM data")
 		}
+		rest = remaining
 		if block.Type != "CERTIFICATE" {
 			return nil, fmt.Errorf("--client-ca-file contains a non-certificate PEM block %q", block.Type)
 		}

--- a/enterprise/cli/dashboard_mtls.go
+++ b/enterprise/cli/dashboard_mtls.go
@@ -288,6 +288,9 @@ func loadDashboardClientCAs(path string) (*x509.CertPool, error) {
 	for rest := pemBytes; len(bytes.TrimSpace(rest)) > 0; {
 		block, remaining := pem.Decode(rest)
 		if block == nil {
+			if dashboardClientCABundleTrailingCommentsOnly(rest) {
+				break
+			}
 			return nil, errors.New("--client-ca-file contains malformed PEM data")
 		}
 		rest = remaining
@@ -305,6 +308,17 @@ func loadDashboardClientCAs(path string) (*x509.CertPool, error) {
 		return nil, errors.New("--client-ca-file contains no valid PEM certificates")
 	}
 	return pool, nil
+}
+
+func dashboardClientCABundleTrailingCommentsOnly(data []byte) bool {
+	for _, line := range bytes.Split(data, []byte{'\n'}) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || bytes.HasPrefix(line, []byte("#")) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func verifyDashboardClientCertificateKeySizes(state tls.ConnectionState) error {

--- a/enterprise/cli/dashboard_mtls.go
+++ b/enterprise/cli/dashboard_mtls.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -29,7 +30,8 @@ import (
 const (
 	dashboardClientCertRoleMapMaxBytes = 1 << 20
 	dashboardClientCAMaxBytes          = 1 << 20
-	dashboardClientCertRSAMinBits      = 2048
+	dashboardTrustedRSAMinBits         = 2048
+	dashboardClientCertRSAMinBits      = dashboardTrustedRSAMinBits
 	dashboardClientCertRSAMaxBits      = 8192
 )
 
@@ -343,12 +345,23 @@ func verifyDashboardClientCertificateKeySizes(state tls.ConnectionState) error {
 		if !ok {
 			continue
 		}
-		if key.N.BitLen() > dashboardClientCertRSAMaxBits {
-			return fmt.Errorf("dashboard client certificate RSA modulus is %d bits; maximum is %d", key.N.BitLen(), dashboardClientCertRSAMaxBits)
+		if err := validateRSAModulusBits(key.N, dashboardClientCertRSAMinBits, dashboardClientCertRSAMaxBits); err != nil {
+			return fmt.Errorf("dashboard client certificate RSA modulus: %w", err)
 		}
-		if key.N.BitLen() < dashboardClientCertRSAMinBits {
-			return fmt.Errorf("dashboard client certificate RSA modulus is %d bits; minimum is %d", key.N.BitLen(), dashboardClientCertRSAMinBits)
-		}
+	}
+	return nil
+}
+
+func validateRSAModulusBits(n *big.Int, minBits, maxBits int) error {
+	if n == nil {
+		return errors.New("missing modulus")
+	}
+	bits := n.BitLen()
+	if bits < minBits {
+		return fmt.Errorf("is %d bits; minimum is %d", bits, minBits)
+	}
+	if bits > maxBits {
+		return fmt.Errorf("is %d bits; maximum is %d", bits, maxBits)
 	}
 	return nil
 }

--- a/enterprise/cli/dashboard_mtls.go
+++ b/enterprise/cli/dashboard_mtls.go
@@ -29,6 +29,7 @@ import (
 const (
 	dashboardClientCertRoleMapMaxBytes = 1 << 20
 	dashboardClientCAMaxBytes          = 1 << 20
+	dashboardClientCertRSAMinBits      = 2048
 	dashboardClientCertRSAMaxBits      = 8192
 )
 
@@ -285,12 +286,16 @@ func loadDashboardClientCAs(path string) (*x509.CertPool, error) {
 	// partial trust set. A trust anchor bundle must load completely or fail loud.
 	pool := x509.NewCertPool()
 	var added int
-	for rest := pemBytes; len(bytes.TrimSpace(rest)) > 0; {
+	for rest := pemBytes; ; {
+		rest = dashboardClientCATrimAllowedSeparators(rest)
+		if len(rest) == 0 {
+			break
+		}
+		if !bytes.HasPrefix(rest, []byte("-----BEGIN CERTIFICATE-----")) {
+			return nil, errors.New("--client-ca-file contains non-PEM data")
+		}
 		block, remaining := pem.Decode(rest)
 		if block == nil {
-			if dashboardClientCABundleTrailingCommentsOnly(rest) {
-				break
-			}
 			return nil, errors.New("--client-ca-file contains malformed PEM data")
 		}
 		rest = remaining
@@ -310,15 +315,23 @@ func loadDashboardClientCAs(path string) (*x509.CertPool, error) {
 	return pool, nil
 }
 
-func dashboardClientCABundleTrailingCommentsOnly(data []byte) bool {
-	for _, line := range bytes.Split(data, []byte{'\n'}) {
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 || bytes.HasPrefix(line, []byte("#")) {
+func dashboardClientCATrimAllowedSeparators(data []byte) []byte {
+	for len(data) > 0 {
+		switch data[0] {
+		case ' ', '\t', '\r', '\n':
+			data = data[1:]
 			continue
+		case '#':
+			if idx := bytes.IndexByte(data, '\n'); idx >= 0 {
+				data = data[idx+1:]
+				continue
+			}
+			return nil
+		default:
+			return data
 		}
-		return false
 	}
-	return true
+	return data
 }
 
 func verifyDashboardClientCertificateKeySizes(state tls.ConnectionState) error {
@@ -332,6 +345,9 @@ func verifyDashboardClientCertificateKeySizes(state tls.ConnectionState) error {
 		}
 		if key.N.BitLen() > dashboardClientCertRSAMaxBits {
 			return fmt.Errorf("dashboard client certificate RSA modulus is %d bits; maximum is %d", key.N.BitLen(), dashboardClientCertRSAMaxBits)
+		}
+		if key.N.BitLen() < dashboardClientCertRSAMinBits {
+			return fmt.Errorf("dashboard client certificate RSA modulus is %d bits; minimum is %d", key.N.BitLen(), dashboardClientCertRSAMinBits)
 		}
 	}
 	return nil

--- a/enterprise/cli/dashboard_mtls_test.go
+++ b/enterprise/cli/dashboard_mtls_test.go
@@ -422,6 +422,12 @@ func TestVerifyDashboardClientCertificateKeySizes(t *testing.T) {
 			}},
 		},
 		{
+			name: "maximum RSA accepted",
+			certs: []*x509.Certificate{{
+				PublicKey: &rsa.PublicKey{N: new(big.Int).Lsh(big.NewInt(1), dashboardClientCertRSAMaxBits-1), E: 65537},
+			}},
+		},
+		{
 			name:  "nil certificate skipped",
 			certs: []*x509.Certificate{nil},
 		},

--- a/enterprise/cli/dashboard_mtls_test.go
+++ b/enterprise/cli/dashboard_mtls_test.go
@@ -290,6 +290,22 @@ func TestLoadDashboardClientCAs(t *testing.T) {
 		}
 	})
 
+	t.Run("valid bundle with comments CRLF and text loads", func(t *testing.T) {
+		crlfPEM := strings.ReplaceAll(string(validPEM), "\n", "\r\n")
+		bundle := []byte("# generated CA bundle\r\n" +
+			crlfPEM +
+			"Certificate:\r\n    Data:\r\n        Version: 3\r\n" +
+			crlfPEM +
+			"# end of bundle\r\n\r\n")
+		path := filepath.Join(t.TempDir(), "commented-ca.pem")
+		if err := os.WriteFile(path, bundle, 0o600); err != nil {
+			t.Fatalf("write commented bundle: %v", err)
+		}
+		if _, err := loadDashboardClientCAs(path); err != nil {
+			t.Fatalf("commented CA bundle rejected: %v", err)
+		}
+	})
+
 	t.Run("valid bundle at exact size cap loads", func(t *testing.T) {
 		if len(validPEM) > dashboardClientCAMaxBytes {
 			t.Fatalf("test CA bundle is %d bytes, larger than cap %d", len(validPEM), dashboardClientCAMaxBytes)

--- a/enterprise/cli/dashboard_mtls_test.go
+++ b/enterprise/cli/dashboard_mtls_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -306,6 +307,77 @@ func TestLoadDashboardClientCAs(t *testing.T) {
 			t.Fatal("empty --client-ca-file path accepted")
 		}
 	})
+
+	t.Run("missing file rejected", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing-ca.pem")
+		if _, err := loadDashboardClientCAs(path); err == nil || !strings.Contains(err.Error(), "read --client-ca-file") {
+			t.Fatalf("missing CA bundle: want read error, got %v", err)
+		}
+	})
+
+	t.Run("oversize bundle rejected", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "oversize-ca.pem")
+		data := strings.Repeat(" ", dashboardClientCAMaxBytes+1)
+		if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+			t.Fatalf("write oversize bundle: %v", err)
+		}
+		if _, err := loadDashboardClientCAs(path); err == nil || !strings.Contains(err.Error(), "exceeds") {
+			t.Fatalf("oversize CA bundle: want size error, got %v", err)
+		}
+	})
+}
+
+func TestVerifyDashboardClientCertificateKeySizes(t *testing.T) {
+	tests := []struct {
+		name    string
+		certs   []*x509.Certificate
+		wantErr bool
+	}{
+		{
+			name: "non RSA accepted",
+			certs: []*x509.Certificate{{
+				PublicKey: ed25519.PublicKey(make([]byte, ed25519.PublicKeySize)),
+			}},
+		},
+		{
+			name: "bounded RSA accepted",
+			certs: []*x509.Certificate{{
+				PublicKey: &rsa.PublicKey{N: new(big.Int).Lsh(big.NewInt(1), dashboardClientCertRSAMaxBits-1), E: 65537},
+			}},
+		},
+		{
+			name:  "nil certificate skipped",
+			certs: []*x509.Certificate{nil},
+		},
+		{
+			name: "oversize RSA rejected",
+			certs: []*x509.Certificate{{
+				PublicKey: &rsa.PublicKey{N: new(big.Int).Lsh(big.NewInt(1), dashboardClientCertRSAMaxBits), E: 65537},
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyDashboardClientCertificateKeySizes(tls.ConnectionState{PeerCertificates: tc.certs})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("verifyDashboardClientCertificateKeySizes = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDashboardClientCertAuthorizers_NilFallbackPermissionFailsClosed(t *testing.T) {
+	_, authorizePermission, _ := dashboardClientCertAuthorizers(
+		nil,
+		func(*http.Request) bool { return false },
+		nil,
+		func(*http.Request) bool { return false },
+	)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil)
+	if err := authorizePermission(req, dashboard.PermissionEvidenceRead); err == nil {
+		t.Fatal("nil fallback permission authorizer allowed a route")
+	}
 }
 
 func TestDashboardClientCertAuthAuditInfo(t *testing.T) {
@@ -326,34 +398,34 @@ func TestDashboardClientCertAuthAuditInfo(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		req         *http.Request
-		wantReason  string
-		wantSubject string
-		wantRoles   []string
+		name       string
+		req        *http.Request
+		wantReason string
+		wantSPKI   string
+		wantRoles  []string
 	}{
 		{
 			name:       "missing certificate",
 			req:        httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil),
-			wantReason: "missing_client_certificate",
+			wantReason: "no_credential",
 		},
 		{
-			name:        "unverified certificate",
-			req:         dashboardMTLSTestRequest(t, mappedLeaf, false),
-			wantReason:  "unverified_client_certificate",
-			wantSubject: dashboardClientCertSPKIFingerprint(mappedLeaf),
+			name:       "unverified certificate",
+			req:        dashboardMTLSTestRequest(t, mappedLeaf, false),
+			wantReason: "invalid_credential",
+			wantSPKI:   dashboardClientCertSPKIFingerprint(mappedLeaf),
 		},
 		{
-			name:        "verified unmapped certificate",
-			req:         dashboardMTLSTestRequest(t, unmappedLeaf, true),
-			wantReason:  "unmapped_client_certificate",
-			wantSubject: dashboardClientCertSPKIFingerprint(unmappedLeaf),
+			name:       "verified unmapped certificate",
+			req:        dashboardMTLSTestRequest(t, unmappedLeaf, true),
+			wantReason: "unknown_principal",
+			wantSPKI:   dashboardClientCertSPKIFingerprint(unmappedLeaf),
 		},
 		{
-			name:        "verified mapped certificate",
-			req:         dashboardMTLSTestRequest(t, mappedLeaf, true),
-			wantSubject: dashboardClientCertSPKIFingerprint(mappedLeaf),
-			wantRoles:   []string{"metadata"},
+			name:      "verified mapped certificate",
+			req:       dashboardMTLSTestRequest(t, mappedLeaf, true),
+			wantSPKI:  dashboardClientCertSPKIFingerprint(mappedLeaf),
+			wantRoles: []string{"metadata"},
 		},
 	}
 	for _, tc := range tests {
@@ -365,8 +437,11 @@ func TestDashboardClientCertAuthAuditInfo(t *testing.T) {
 			if got.FailureReason != tc.wantReason {
 				t.Fatalf("FailureReason = %q, want %q", got.FailureReason, tc.wantReason)
 			}
-			if got.Subject != tc.wantSubject {
-				t.Fatalf("Subject = %q, want %q", got.Subject, tc.wantSubject)
+			if got.Subject != "" {
+				t.Fatalf("Subject = %q, want empty raw subject", got.Subject)
+			}
+			if got.MTLSSPKISHA256 != tc.wantSPKI {
+				t.Fatalf("MTLSSPKISHA256 = %q, want %q", got.MTLSSPKISHA256, tc.wantSPKI)
 			}
 			if strings.Join(got.Roles, ",") != strings.Join(tc.wantRoles, ",") {
 				t.Fatalf("Roles = %v, want %v", got.Roles, tc.wantRoles)
@@ -638,10 +713,9 @@ func TestDashboardMTLS_RoutePermissionsAndRaw(t *testing.T) {
 
 	tokenMetaAuthorized := func(r *http.Request) bool { return dashboardTokenMatches(r, dashTestToken) }
 	tokenRawAuthorized := func(r *http.Request) bool { return dashboardTokenMatches(r, "raw-token") }
+	tokenAuthorizePermission := dashboardAuthorizePermissionFunc(tokenMetaAuthorized, tokenRawAuthorized)
 	metaAuthorized, authorizePermission, rawAuthorized := dashboardClientCertAuthorizers(
-		authorizer, tokenMetaAuthorized,
-		dashboardAuthorizePermissionFunc(tokenMetaAuthorized, tokenRawAuthorized),
-		tokenRawAuthorized,
+		authorizer, tokenMetaAuthorized, tokenAuthorizePermission, tokenRawAuthorized,
 	)
 	inner := dashboard.New(dashboard.Options{
 		ReceiptDir:          t.TempDir(),

--- a/enterprise/cli/dashboard_mtls_test.go
+++ b/enterprise/cli/dashboard_mtls_test.go
@@ -290,11 +290,11 @@ func TestLoadDashboardClientCAs(t *testing.T) {
 		}
 	})
 
-	t.Run("valid bundle with comments CRLF and text loads", func(t *testing.T) {
+	t.Run("valid bundle with comments and CRLF loads", func(t *testing.T) {
 		crlfPEM := strings.ReplaceAll(string(validPEM), "\n", "\r\n")
 		bundle := []byte("# generated CA bundle\r\n" +
 			crlfPEM +
-			"Certificate:\r\n    Data:\r\n        Version: 3\r\n" +
+			"# second certificate\r\n" +
 			crlfPEM +
 			"# end of bundle\r\n\r\n")
 		path := filepath.Join(t.TempDir(), "commented-ca.pem")
@@ -303,6 +303,29 @@ func TestLoadDashboardClientCAs(t *testing.T) {
 		}
 		if _, err := loadDashboardClientCAs(path); err != nil {
 			t.Fatalf("commented CA bundle rejected: %v", err)
+		}
+	})
+
+	t.Run("leading non PEM data is rejected", func(t *testing.T) {
+		bundle := append([]byte("Certificate:\n    Data:\n"), validPEM...)
+		path := filepath.Join(t.TempDir(), "leading-junk-ca.pem")
+		if err := os.WriteFile(path, bundle, 0o600); err != nil {
+			t.Fatalf("write leading junk bundle: %v", err)
+		}
+		if _, err := loadDashboardClientCAs(path); err == nil {
+			t.Fatal("CA bundle with leading non-PEM data accepted")
+		}
+	})
+
+	t.Run("interstitial non PEM data is rejected", func(t *testing.T) {
+		bundle := append(append([]byte{}, validPEM...), []byte("Certificate:\n    Data:\n")...)
+		bundle = append(bundle, validPEM...)
+		path := filepath.Join(t.TempDir(), "interstitial-junk-ca.pem")
+		if err := os.WriteFile(path, bundle, 0o600); err != nil {
+			t.Fatalf("write interstitial junk bundle: %v", err)
+		}
+		if _, err := loadDashboardClientCAs(path); err == nil {
+			t.Fatal("CA bundle with interstitial non-PEM data accepted")
 		}
 	})
 
@@ -395,12 +418,19 @@ func TestVerifyDashboardClientCertificateKeySizes(t *testing.T) {
 		{
 			name: "bounded RSA accepted",
 			certs: []*x509.Certificate{{
-				PublicKey: &rsa.PublicKey{N: new(big.Int).Lsh(big.NewInt(1), dashboardClientCertRSAMaxBits-1), E: 65537},
+				PublicKey: &rsa.PublicKey{N: new(big.Int).Lsh(big.NewInt(1), dashboardClientCertRSAMinBits-1), E: 65537},
 			}},
 		},
 		{
 			name:  "nil certificate skipped",
 			certs: []*x509.Certificate{nil},
+		},
+		{
+			name: "undersize RSA rejected",
+			certs: []*x509.Certificate{{
+				PublicKey: &rsa.PublicKey{N: new(big.Int).Lsh(big.NewInt(1), dashboardClientCertRSAMinBits-2), E: 65537},
+			}},
+			wantErr: true,
 		},
 		{
 			name: "oversize RSA rejected",

--- a/enterprise/cli/dashboard_mtls_test.go
+++ b/enterprise/cli/dashboard_mtls_test.go
@@ -290,6 +290,21 @@ func TestLoadDashboardClientCAs(t *testing.T) {
 		}
 	})
 
+	t.Run("valid bundle at exact size cap loads", func(t *testing.T) {
+		if len(validPEM) > dashboardClientCAMaxBytes {
+			t.Fatalf("test CA bundle is %d bytes, larger than cap %d", len(validPEM), dashboardClientCAMaxBytes)
+		}
+		bundle := append([]byte{}, validPEM...)
+		bundle = append(bundle, []byte(strings.Repeat(" ", dashboardClientCAMaxBytes-len(bundle)))...)
+		path := filepath.Join(t.TempDir(), "exact-cap-ca.pem")
+		if err := os.WriteFile(path, bundle, 0o600); err != nil {
+			t.Fatalf("write exact cap bundle: %v", err)
+		}
+		if _, err := loadDashboardClientCAs(path); err != nil {
+			t.Fatalf("exact cap CA bundle rejected: %v", err)
+		}
+	})
+
 	t.Run("mixed valid and malformed bundle is rejected", func(t *testing.T) {
 		malformed := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a DER certificate")})
 		bundle := append(append([]byte{}, validPEM...), malformed...)
@@ -299,6 +314,28 @@ func TestLoadDashboardClientCAs(t *testing.T) {
 		}
 		if _, err := loadDashboardClientCAs(path); err == nil {
 			t.Fatal("mixed valid/malformed CA bundle accepted; a malformed certificate must fail loud")
+		}
+	})
+
+	t.Run("trailing non PEM data is rejected", func(t *testing.T) {
+		bundle := append(append([]byte{}, validPEM...), []byte("not pem")...)
+		path := filepath.Join(t.TempDir(), "trailing-junk-ca.pem")
+		if err := os.WriteFile(path, bundle, 0o600); err != nil {
+			t.Fatalf("write trailing junk bundle: %v", err)
+		}
+		if _, err := loadDashboardClientCAs(path); err == nil {
+			t.Fatal("CA bundle with trailing non-PEM data accepted")
+		}
+	})
+
+	t.Run("truncated trailing PEM is rejected", func(t *testing.T) {
+		bundle := append(append([]byte{}, validPEM...), []byte("-----BEGIN CERTIFICATE-----\ntruncated")...)
+		path := filepath.Join(t.TempDir(), "truncated-ca.pem")
+		if err := os.WriteFile(path, bundle, 0o600); err != nil {
+			t.Fatalf("write truncated bundle: %v", err)
+		}
+		if _, err := loadDashboardClientCAs(path); err == nil {
+			t.Fatal("CA bundle with truncated trailing PEM accepted")
 		}
 	})
 
@@ -407,18 +444,18 @@ func TestDashboardClientCertAuthAuditInfo(t *testing.T) {
 		{
 			name:       "missing certificate",
 			req:        httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil),
-			wantReason: "no_credential",
+			wantReason: "missing_client_certificate",
 		},
 		{
 			name:       "unverified certificate",
 			req:        dashboardMTLSTestRequest(t, mappedLeaf, false),
-			wantReason: "invalid_credential",
+			wantReason: "unverified_client_certificate",
 			wantSPKI:   dashboardClientCertSPKIFingerprint(mappedLeaf),
 		},
 		{
 			name:       "verified unmapped certificate",
 			req:        dashboardMTLSTestRequest(t, unmappedLeaf, true),
-			wantReason: "unknown_principal",
+			wantReason: "unmapped_client_certificate",
 			wantSPKI:   dashboardClientCertSPKIFingerprint(unmappedLeaf),
 		},
 		{

--- a/enterprise/cli/dashboard_oidc.go
+++ b/enterprise/cli/dashboard_oidc.go
@@ -388,7 +388,37 @@ type dashboardJWK struct {
 
 func (c *dashboardJWKSCache) key(ctx context.Context, keyID string) (*rsa.PublicKey, error) {
 	c.mu.Lock()
-	if c.keys == nil || !c.now().Before(c.expiresAt) {
+	now := c.now()
+	if c.keys != nil {
+		if key := c.keys[keyID]; key != nil && now.Before(c.expiresAt) {
+			c.mu.Unlock()
+			return key, nil
+		}
+		if c.keys[keyID] == nil {
+			// An unknown kid commonly means the provider rotated keys before this
+			// cache entry expired. Refresh at a bounded rate; attacker-chosen kids must
+			// not turn the dashboard into a JWKS request amplifier. This check runs
+			// before stale-cache refresh too, so a burst of unknown kids cannot bypass
+			// the gate just by waiting for cache expiry.
+			if !c.lastMiss.IsZero() && now.Before(c.lastMiss.Add(dashboardOIDCMinKeyRefresh)) {
+				c.mu.Unlock()
+				return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
+			}
+			c.lastMiss = now
+			c.mu.Unlock()
+			if err := c.refresh(ctx); err != nil {
+				return nil, err
+			}
+			c.mu.Lock()
+			key := c.keys[keyID]
+			c.mu.Unlock()
+			if key == nil {
+				return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
+			}
+			return key, nil
+		}
+	}
+	if c.keys == nil || !now.Before(c.expiresAt) {
 		c.mu.Unlock()
 		if err := c.refresh(ctx); err != nil {
 			return nil, err
@@ -399,25 +429,8 @@ func (c *dashboardJWKSCache) key(ctx context.Context, keyID string) (*rsa.Public
 		c.mu.Unlock()
 		return key, nil
 	}
-	// An unknown kid commonly means the provider rotated keys before this
-	// cache entry expired. Refresh at a bounded rate; attacker-chosen kids must
-	// not turn the dashboard into a JWKS request amplifier.
-	if !c.lastMiss.IsZero() && c.now().Before(c.lastMiss.Add(dashboardOIDCMinKeyRefresh)) {
-		c.mu.Unlock()
-		return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
-	}
-	c.lastMiss = c.now()
 	c.mu.Unlock()
-	if err := c.refresh(ctx); err != nil {
-		return nil, err
-	}
-	c.mu.Lock()
-	key := c.keys[keyID]
-	c.mu.Unlock()
-	if key == nil {
-		return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
-	}
-	return key, nil
+	return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
 }
 
 func (c *dashboardJWKSCache) refresh(ctx context.Context) error {
@@ -856,13 +869,15 @@ func dashboardOIDCFailureCategory(err error) string {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "bearer token is missing"):
-		return "missing_token"
+		return "no_credential"
 	case strings.Contains(msg, "signature"):
 		return "invalid_signature"
 	case strings.Contains(msg, "expired"):
 		return "expired"
 	case strings.Contains(msg, "role claim has no mapped value"):
-		return "permission_denied"
+		return "unknown_principal"
+	case strings.Contains(msg, "signing key"):
+		return "unknown_principal"
 	default:
 		return "invalid_token"
 	}
@@ -925,14 +940,27 @@ func (a *dashboardRequestAuthorization) authAuditInfo(r *http.Request) dashboard
 	}
 	switch {
 	case dashboardConfiguredTokenMatches(r, a.rawToken):
-		return dashboard.AuthAuditInfo{Method: "static-raw-token"}
+		return dashboard.AuthAuditInfo{Method: "raw-access-token", Roles: []string{"raw"}}
 	case dashboardConfiguredTokenMatches(r, a.metadataToken):
-		return dashboard.AuthAuditInfo{Method: "static-metadata-token"}
+		return dashboard.AuthAuditInfo{Method: "token", Roles: []string{"metadata"}}
 	case dashboardOIDCFailureReasonFromRequest(r) != "":
 		return dashboard.AuthAuditInfo{Method: "oidc", FailureReason: dashboardOIDCFailureReasonFromRequest(r)}
+	case dashboardCredentialAttempted(r):
+		return dashboard.AuthAuditInfo{Method: "token", FailureReason: "unknown_principal"}
 	default:
-		return dashboard.AuthAuditInfo{Method: "none", FailureReason: "missing_token"}
+		return dashboard.AuthAuditInfo{Method: "none", FailureReason: "no_credential"}
 	}
+}
+
+func dashboardCredentialAttempted(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if strings.TrimSpace(r.Header.Get("Authorization")) != "" {
+		return true
+	}
+	_, _, ok := r.BasicAuth()
+	return ok
 }
 
 func (a *dashboardRequestAuthorization) wrap(next http.Handler, auditWriter io.Writer) http.Handler {

--- a/enterprise/cli/dashboard_oidc.go
+++ b/enterprise/cli/dashboard_oidc.go
@@ -428,10 +428,6 @@ func (c *dashboardJWKSCache) key(ctx context.Context, keyID string) (*rsa.Public
 	// turn the dashboard into a JWKS request amplifier. Stale caches refresh
 	// before this gate so normal TTL expiry cannot skip the authorization check
 	// path that would learn a legitimate rotated key.
-	if !c.lastMiss.IsZero() && now.Before(c.lastMiss.Add(dashboardOIDCMinKeyRefresh)) {
-		c.mu.Unlock()
-		return nil, dashboardOIDCSigningKeyNotFound(keyID)
-	}
 	c.lastMiss = now
 	c.mu.Unlock()
 	if err := c.refresh(ctx); err != nil {
@@ -453,8 +449,10 @@ func (c *dashboardJWKSCache) recordMiss() {
 }
 
 func dashboardOIDCSigningKeyNotFound(keyID string) error {
-	return fmt.Errorf("OIDC signing key %q not found", keyID)
+	return fmt.Errorf("%w: OIDC signing key %q not found", errDashboardOIDCSigningKeyNotFound, keyID)
 }
+
+var errDashboardOIDCSigningKeyNotFound = errors.New("OIDC signing key not found")
 
 func (c *dashboardJWKSCache) refresh(ctx context.Context) error {
 	c.mu.Lock()
@@ -894,6 +892,8 @@ func dashboardOIDCFailureCategory(err error) string {
 	}
 	msg := err.Error()
 	switch {
+	case errors.Is(err, errDashboardOIDCSigningKeyNotFound):
+		return "unknown_principal"
 	case strings.Contains(msg, "bearer token is missing"):
 		return "missing_token"
 	case strings.Contains(msg, "signature"):
@@ -902,8 +902,6 @@ func dashboardOIDCFailureCategory(err error) string {
 		return "expired"
 	case strings.Contains(msg, "role claim has no mapped value"):
 		return "permission_denied"
-	case strings.Contains(msg, "signing key"):
-		return "unknown_principal"
 	default:
 		return "invalid_token"
 	}

--- a/enterprise/cli/dashboard_oidc.go
+++ b/enterprise/cli/dashboard_oidc.go
@@ -39,6 +39,7 @@ const (
 	dashboardOIDCMaxRoleLength   = 256
 	dashboardOIDCMaxJSONDepth    = 64
 	dashboardOIDCMinKeyRefresh   = 30 * time.Second
+	dashboardOIDCRSAMaxBits      = 8192
 )
 
 type dashboardOIDCOptions struct {
@@ -389,48 +390,70 @@ type dashboardJWK struct {
 func (c *dashboardJWKSCache) key(ctx context.Context, keyID string) (*rsa.PublicKey, error) {
 	c.mu.Lock()
 	now := c.now()
-	if c.keys != nil {
-		if key := c.keys[keyID]; key != nil && now.Before(c.expiresAt) {
-			c.mu.Unlock()
-			return key, nil
-		}
-		if c.keys[keyID] == nil {
-			// An unknown kid commonly means the provider rotated keys before this
-			// cache entry expired. Refresh at a bounded rate; attacker-chosen kids must
-			// not turn the dashboard into a JWKS request amplifier. This check runs
-			// before stale-cache refresh too, so a burst of unknown kids cannot bypass
-			// the gate just by waiting for cache expiry.
-			if !c.lastMiss.IsZero() && now.Before(c.lastMiss.Add(dashboardOIDCMinKeyRefresh)) {
-				c.mu.Unlock()
-				return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
-			}
-			c.lastMiss = now
-			c.mu.Unlock()
-			if err := c.refresh(ctx); err != nil {
-				return nil, err
-			}
-			c.mu.Lock()
-			key := c.keys[keyID]
-			c.mu.Unlock()
-			if key == nil {
-				return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
-			}
-			return key, nil
-		}
+	if key := c.keys[keyID]; key != nil && now.Before(c.expiresAt) {
+		c.mu.Unlock()
+		return key, nil
 	}
-	if c.keys == nil || !now.Before(c.expiresAt) {
+	cacheExpired := c.keys == nil || !now.Before(c.expiresAt)
+	keyUnknown := c.keys != nil && c.keys[keyID] == nil
+	recentMiss := !c.lastMiss.IsZero() && now.Before(c.lastMiss.Add(dashboardOIDCMinKeyRefresh))
+	missSinceExpiry := !c.lastMiss.IsZero() && !c.lastMiss.Before(c.expiresAt)
+	if keyUnknown && recentMiss && (!cacheExpired || missSinceExpiry) {
+		c.mu.Unlock()
+		return nil, dashboardOIDCSigningKeyNotFound(keyID)
+	}
+	if cacheExpired {
 		c.mu.Unlock()
 		if err := c.refresh(ctx); err != nil {
+			if keyUnknown {
+				c.recordMiss()
+			}
 			return nil, err
 		}
 		c.mu.Lock()
+		if key := c.keys[keyID]; key != nil {
+			c.mu.Unlock()
+			return key, nil
+		}
+		c.lastMiss = c.now()
+		c.mu.Unlock()
+		return nil, dashboardOIDCSigningKeyNotFound(keyID)
 	}
 	if key := c.keys[keyID]; key != nil {
 		c.mu.Unlock()
 		return key, nil
 	}
+	// An unknown kid commonly means the provider rotated keys before this cache
+	// entry expired. Refresh at a bounded rate; attacker-chosen kids must not
+	// turn the dashboard into a JWKS request amplifier. Stale caches refresh
+	// before this gate so normal TTL expiry cannot skip the authorization check
+	// path that would learn a legitimate rotated key.
+	if !c.lastMiss.IsZero() && now.Before(c.lastMiss.Add(dashboardOIDCMinKeyRefresh)) {
+		c.mu.Unlock()
+		return nil, dashboardOIDCSigningKeyNotFound(keyID)
+	}
+	c.lastMiss = now
 	c.mu.Unlock()
-	return nil, fmt.Errorf("OIDC signing key %q not found", keyID)
+	if err := c.refresh(ctx); err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	key := c.keys[keyID]
+	c.mu.Unlock()
+	if key == nil {
+		return nil, dashboardOIDCSigningKeyNotFound(keyID)
+	}
+	return key, nil
+}
+
+func (c *dashboardJWKSCache) recordMiss() {
+	c.mu.Lock()
+	c.lastMiss = c.now()
+	c.mu.Unlock()
+}
+
+func dashboardOIDCSigningKeyNotFound(keyID string) error {
+	return fmt.Errorf("OIDC signing key %q not found", keyID)
 }
 
 func (c *dashboardJWKSCache) refresh(ctx context.Context) error {
@@ -513,6 +536,9 @@ func parseDashboardRSAJWK(jwk dashboardJWK) (*rsa.PublicKey, bool, error) {
 	eBig := new(big.Int).SetBytes(eBytes)
 	if n.BitLen() < 2048 {
 		return nil, false, fmt.Errorf("OIDC JWK %q RSA modulus is smaller than 2048 bits", jwk.KeyID)
+	}
+	if n.BitLen() > dashboardOIDCRSAMaxBits {
+		return nil, false, fmt.Errorf("OIDC JWK %q RSA modulus is %d bits; maximum is %d", jwk.KeyID, n.BitLen(), dashboardOIDCRSAMaxBits)
 	}
 	if !eBig.IsInt64() {
 		return nil, false, fmt.Errorf("OIDC JWK %q exponent is out of range", jwk.KeyID)
@@ -869,13 +895,13 @@ func dashboardOIDCFailureCategory(err error) string {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "bearer token is missing"):
-		return "no_credential"
+		return "missing_token"
 	case strings.Contains(msg, "signature"):
 		return "invalid_signature"
 	case strings.Contains(msg, "expired"):
 		return "expired"
 	case strings.Contains(msg, "role claim has no mapped value"):
-		return "unknown_principal"
+		return "permission_denied"
 	case strings.Contains(msg, "signing key"):
 		return "unknown_principal"
 	default:
@@ -948,7 +974,7 @@ func (a *dashboardRequestAuthorization) authAuditInfo(r *http.Request) dashboard
 	case dashboardCredentialAttempted(r):
 		return dashboard.AuthAuditInfo{Method: "token", FailureReason: "unknown_principal"}
 	default:
-		return dashboard.AuthAuditInfo{Method: "none", FailureReason: "no_credential"}
+		return dashboard.AuthAuditInfo{Method: "none", FailureReason: "missing_token"}
 	}
 }
 

--- a/enterprise/cli/dashboard_oidc.go
+++ b/enterprise/cli/dashboard_oidc.go
@@ -532,11 +532,8 @@ func parseDashboardRSAJWK(jwk dashboardJWK) (*rsa.PublicKey, bool, error) {
 	}
 	n := new(big.Int).SetBytes(nBytes)
 	eBig := new(big.Int).SetBytes(eBytes)
-	if n.BitLen() < 2048 {
-		return nil, false, fmt.Errorf("OIDC JWK %q RSA modulus is smaller than 2048 bits", jwk.KeyID)
-	}
-	if n.BitLen() > dashboardOIDCRSAMaxBits {
-		return nil, false, fmt.Errorf("OIDC JWK %q RSA modulus is %d bits; maximum is %d", jwk.KeyID, n.BitLen(), dashboardOIDCRSAMaxBits)
+	if err := validateRSAModulusBits(n, dashboardTrustedRSAMinBits, dashboardOIDCRSAMaxBits); err != nil {
+		return nil, false, fmt.Errorf("OIDC JWK %q RSA modulus: %w", jwk.KeyID, err)
 	}
 	if !eBig.IsInt64() {
 		return nil, false, fmt.Errorf("OIDC JWK %q exponent is out of range", jwk.KeyID)

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -40,13 +40,14 @@ func TestDashboardOIDCFailureCategory(t *testing.T) {
 		want string
 	}{
 		{"nil", nil, "-"},
-		{"missing bearer", errors.New("bearer token is missing"), "missing_token"},
+		{"missing bearer", errors.New("bearer token is missing"), "no_credential"},
 		{"missing issuer claim is invalid token", errors.New("OIDC issuer claim is missing or does not match"), "invalid_token"},
 		{"missing audience claim is invalid token", errors.New("OIDC audience claim is missing or does not match"), "invalid_token"},
 		{"missing subject claim is invalid token", errors.New("OIDC subject claim is missing or invalid"), "invalid_token"},
 		{"signature", errors.New("token signature is invalid"), "invalid_signature"},
 		{"expired", errors.New("token has expired"), "expired"},
-		{"permission denied", errors.New("role claim has no mapped value"), "permission_denied"},
+		{"unmapped role", errors.New("role claim has no mapped value"), "unknown_principal"},
+		{"unknown signing key", errors.New("OIDC signing key \"kid-a\" not found"), "unknown_principal"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -61,6 +62,7 @@ type oidcTestProvider struct {
 	server    *httptest.Server
 	private   *rsa.PrivateKey
 	mu        sync.Mutex
+	jwksFail  bool
 	jwksBlock <-chan struct{}
 	jwksStart chan<- struct{}
 	jwksReads atomic.Int32
@@ -80,6 +82,10 @@ func newOIDCTestProvider(t *testing.T) *oidcTestProvider {
 				p.server.URL, p.server.URL+"/jwks", p.server.URL+"/authorize")
 		case "/jwks":
 			p.jwksReads.Add(1)
+			if p.jwksShouldFail() {
+				http.Error(w, "JWKS unavailable", http.StatusServiceUnavailable)
+				return
+			}
 			if err := p.waitForJWKSBlock(r.Context()); err != nil {
 				http.Error(w, err.Error(), http.StatusGatewayTimeout)
 				return
@@ -95,6 +101,18 @@ func newOIDCTestProvider(t *testing.T) *oidcTestProvider {
 	}))
 	t.Cleanup(p.server.Close)
 	return p
+}
+
+func (p *oidcTestProvider) setJWKSFail(fail bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.jwksFail = fail
+}
+
+func (p *oidcTestProvider) jwksShouldFail() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.jwksFail
 }
 
 func (p *oidcTestProvider) setJWKSBlock(block <-chan struct{}, start chan<- struct{}) {
@@ -173,6 +191,11 @@ func oidcTestRoleMap() string {
 	return `{"claim_values":{"evidence-team":"evidence-reader","raw-team":"raw-reader"},` +
 		`"roles":{"evidence-reader":["dashboard:evidence:read"],` +
 		`"raw-reader":["dashboard:evidence:read","dashboard:raw:read"]}}`
+}
+
+func oidcTestAuditHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", sum[:])
 }
 
 func newOIDCTestAuthenticator(t *testing.T, p *oidcTestProvider, now time.Time) *dashboardOIDCAuthenticator {
@@ -485,6 +508,71 @@ func TestDashboardOIDC_RoutePermissionsOnly(t *testing.T) {
 	}
 }
 
+func TestDashboardRequestAuthorization_AuthAuditInfoTokenMethodsAndFailures(t *testing.T) {
+	authorization := newDashboardRequestAuthorization("metadata-token", "raw-token", nil)
+
+	tests := []struct {
+		name       string
+		setup      func(*http.Request)
+		wantMethod string
+		wantRoles  []string
+		wantReason string
+	}{
+		{
+			name: "metadata token",
+			setup: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer metadata-token")
+			},
+			wantMethod: "token",
+			wantRoles:  []string{"metadata"},
+		},
+		{
+			name: "raw access token",
+			setup: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer raw-token")
+			},
+			wantMethod: "raw-access-token",
+			wantRoles:  []string{"raw"},
+		},
+		{
+			name: "wrong token attempted",
+			setup: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer wrong-token")
+			},
+			wantMethod: "token",
+			wantReason: "unknown_principal",
+		},
+		{
+			name:       "no credential",
+			setup:      func(*http.Request) {},
+			wantMethod: "none",
+			wantReason: "no_credential",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/", nil)
+			tc.setup(req)
+			got := authorization.authAuditInfo(req)
+			if got.Method != tc.wantMethod {
+				t.Fatalf("Method = %q, want %q", got.Method, tc.wantMethod)
+			}
+			if strings.Join(got.Roles, ",") != strings.Join(tc.wantRoles, ",") {
+				t.Fatalf("Roles = %v, want %v", got.Roles, tc.wantRoles)
+			}
+			if got.FailureReason != tc.wantReason {
+				t.Fatalf("FailureReason = %q, want %q", got.FailureReason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestDashboardCredentialAttemptedNilRequest(t *testing.T) {
+	if dashboardCredentialAttempted(nil) {
+		t.Fatal("nil request reported a credential attempt")
+	}
+}
+
 func TestDashboardOIDC_OIDCOnlyModeRejectsEmptyCredentials(t *testing.T) {
 	now := time.Unix(2_000_000_000, 0)
 	p := newOIDCTestProvider(t)
@@ -561,7 +649,8 @@ func TestDashboardOIDC_AuditRecordsPrincipalAndDeniedOIDCFailure(t *testing.T) {
 		"pipelock-dashboard access",
 		"permission=\"dashboard:evidence:read\"",
 		"auth_method=oidc",
-		"auth_subject=\"operator-a\"",
+		"auth_subject_sha256=" + oidcTestAuditHash("operator-a"),
+		"mtls_spki_sha256=-",
 		"auth_roles=\"evidence-reader\"",
 	} {
 		if !strings.Contains(log, want) {
@@ -570,6 +659,9 @@ func TestDashboardOIDC_AuditRecordsPrincipalAndDeniedOIDCFailure(t *testing.T) {
 	}
 	if strings.Contains(log, p.token(t, p.validClaims(now))) {
 		t.Fatalf("audit log leaked bearer token: %s", log)
+	}
+	if strings.Contains(log, "auth_subject=\"operator-a\"") {
+		t.Fatalf("audit log leaked raw OIDC subject: %s", log)
 	}
 
 	rr = httptest.NewRecorder()
@@ -581,6 +673,7 @@ func TestDashboardOIDC_AuditRecordsPrincipalAndDeniedOIDCFailure(t *testing.T) {
 	for _, want := range []string{
 		"pipelock-dashboard denied",
 		"auth_method=oidc",
+		"auth_subject_sha256=-",
 		"reason=invalid_token",
 	} {
 		if !strings.Contains(log, want) {
@@ -637,15 +730,54 @@ func TestDashboardOIDC_UnknownKeyRefreshIsRateLimited(t *testing.T) {
 	now := time.Unix(2_000_000_000, 0)
 	p := newOIDCTestProvider(t)
 	auth := newOIDCTestAuthenticator(t, p, now)
-	token := p.tokenWithHeader(t, map[string]any{"alg": "RS256", "kid": "unknown-key"}, p.validClaims(now), true)
+	p.setJWKSFail(true)
+	auth.keys.mu.Lock()
+	auth.keys.expiresAt = now.Add(-time.Second)
+	auth.keys.mu.Unlock()
 
-	for range 2 {
+	for _, kid := range []string{"unknown-key-a", "unknown-key-b", "unknown-key-c"} {
+		token := p.tokenWithHeader(t, map[string]any{"alg": "RS256", "kid": kid}, p.validClaims(now), true)
 		if principal, err := auth.authenticate(requestWithBearer(t, token)); err == nil || principal != nil {
 			t.Fatalf("unknown signing key authenticate = (%+v, %v), want denial", principal, err)
 		}
 	}
 	if got := p.jwksReads.Load(); got != 2 {
-		t.Fatalf("JWKS reads = %d, want initial fetch plus one rate-limited miss refresh", got)
+		t.Fatalf("JWKS reads = %d, want initial fetch plus one gated unknown-kid refresh", got)
+	}
+}
+
+func TestDashboardOIDC_UnknownKeyRefreshCanFindRotatedKey(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+
+	auth.keys.mu.Lock()
+	auth.keys.keys = map[string]*rsa.PublicKey{}
+	auth.keys.expiresAt = now.Add(time.Hour)
+	auth.keys.mu.Unlock()
+
+	if _, err := auth.authenticate(requestWithBearer(t, p.token(t, p.validClaims(now)))); err != nil {
+		t.Fatalf("authenticate after refresh restored key: %v", err)
+	}
+	if got := p.jwksReads.Load(); got != 2 {
+		t.Fatalf("JWKS reads = %d, want initial fetch plus rotation refresh", got)
+	}
+}
+
+func TestDashboardOIDC_JWKSCacheMissingKeyAfterInitialRefreshFailsClosed(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	cache := &dashboardJWKSCache{
+		uri:    p.server.URL + "/jwks",
+		client: p.server.Client(),
+		now:    func() time.Time { return now },
+		ttl:    time.Hour,
+	}
+	if key, err := cache.key(context.Background(), "missing-key"); err == nil || key != nil {
+		t.Fatalf("cache.key missing key = (%v, %v), want fail-closed miss", key, err)
+	}
+	if got := p.jwksReads.Load(); got != 1 {
+		t.Fatalf("JWKS reads = %d, want one initial refresh", got)
 	}
 }
 

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -1332,7 +1332,10 @@ func TestDashboardOIDC_RunServeCompositionUsesMappedRoutePermissions(t *testing.
 		"pipelock-dashboard denied",
 		"permission=\"dashboard:exemptions:read\"",
 		"auth_method=oidc",
-		"auth_subject=\"operator-a\"",
+		// The subject is recorded hashed rather than in the clear. Derive the
+		// expected digest from the subject so this still pins WHICH principal
+		// was denied, not merely that some digest was written.
+		fmt.Sprintf("auth_subject_sha256=%x", sha256.Sum256([]byte("operator-a"))),
 		"auth_roles=\"evidence-reader\"",
 		"reason=permission_denied",
 	} {

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -40,13 +40,13 @@ func TestDashboardOIDCFailureCategory(t *testing.T) {
 		want string
 	}{
 		{"nil", nil, "-"},
-		{"missing bearer", errors.New("bearer token is missing"), "no_credential"},
+		{"missing bearer", errors.New("bearer token is missing"), "missing_token"},
 		{"missing issuer claim is invalid token", errors.New("OIDC issuer claim is missing or does not match"), "invalid_token"},
 		{"missing audience claim is invalid token", errors.New("OIDC audience claim is missing or does not match"), "invalid_token"},
 		{"missing subject claim is invalid token", errors.New("OIDC subject claim is missing or invalid"), "invalid_token"},
 		{"signature", errors.New("token signature is invalid"), "invalid_signature"},
 		{"expired", errors.New("token has expired"), "expired"},
-		{"unmapped role", errors.New("role claim has no mapped value"), "unknown_principal"},
+		{"unmapped role", errors.New("role claim has no mapped value"), "permission_denied"},
 		{"unknown signing key", errors.New("OIDC signing key \"kid-a\" not found"), "unknown_principal"},
 	}
 	for _, tc := range tests {
@@ -546,7 +546,7 @@ func TestDashboardRequestAuthorization_AuthAuditInfoTokenMethodsAndFailures(t *t
 			name:       "no credential",
 			setup:      func(*http.Request) {},
 			wantMethod: "none",
-			wantReason: "no_credential",
+			wantReason: "missing_token",
 		},
 	}
 	for _, tc := range tests {
@@ -764,6 +764,25 @@ func TestDashboardOIDC_UnknownKeyRefreshCanFindRotatedKey(t *testing.T) {
 	}
 }
 
+func TestDashboardOIDC_ExpiredJWKSRefreshIgnoresPriorUnknownKeyThrottle(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth := newOIDCTestAuthenticator(t, p, now)
+
+	auth.keys.mu.Lock()
+	auth.keys.keys = map[string]*rsa.PublicKey{}
+	auth.keys.expiresAt = now.Add(-time.Second)
+	auth.keys.lastMiss = now.Add(-2 * time.Second)
+	auth.keys.mu.Unlock()
+
+	if _, err := auth.authenticate(requestWithBearer(t, p.token(t, p.validClaims(now)))); err != nil {
+		t.Fatalf("authenticate after expired cache refresh with prior unknown-kid miss: %v", err)
+	}
+	if got := p.jwksReads.Load(); got != 2 {
+		t.Fatalf("JWKS reads = %d, want initial fetch plus expired-cache refresh", got)
+	}
+}
+
 func TestDashboardOIDC_JWKSCacheMissingKeyAfterInitialRefreshFailsClosed(t *testing.T) {
 	now := time.Unix(2_000_000_000, 0)
 	p := newOIDCTestProvider(t)
@@ -954,6 +973,7 @@ func TestParseDashboardRSAJWK(t *testing.T) {
 		{"bad modulus encoding", func(j *dashboardJWK) { j.N = "!" }, false, true},
 		{"bad exponent encoding", func(j *dashboardJWK) { j.E = "!" }, false, true},
 		{"weak modulus", func(j *dashboardJWK) { j.N = encodeInt(big.NewInt(17)) }, false, true},
+		{"oversize modulus", func(j *dashboardJWK) { j.N = encodeInt(new(big.Int).Lsh(big.NewInt(1), dashboardOIDCRSAMaxBits)) }, false, true},
 		{"even exponent", func(j *dashboardJWK) { j.E = encodeInt(big.NewInt(4)) }, false, true},
 		{"huge exponent", func(j *dashboardJWK) { j.E = encodeInt(new(big.Int).Lsh(big.NewInt(1), 80)) }, false, true},
 	}

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -678,8 +678,8 @@ func TestDashboardOIDC_AuditRecordsPrincipalAndDeniedOIDCFailure(t *testing.T) {
 		"pipelock-dashboard access",
 		"permission=\"dashboard:evidence:read\"",
 		"auth_method=oidc",
-		"auth_subject_sha256=" + oidcTestAuditHash("operator-a"),
-		"mtls_spki_sha256=-",
+		fmt.Sprintf("auth_subject_sha256=%q", oidcTestAuditHash("operator-a")),
+		`mtls_spki_sha256="-"`,
 		"auth_roles=\"evidence-reader\"",
 	} {
 		if !strings.Contains(log, want) {
@@ -702,7 +702,7 @@ func TestDashboardOIDC_AuditRecordsPrincipalAndDeniedOIDCFailure(t *testing.T) {
 	for _, want := range []string{
 		"pipelock-dashboard denied",
 		"auth_method=oidc",
-		"auth_subject_sha256=-",
+		`auth_subject_sha256="-"`,
 		"reason=invalid_token",
 	} {
 		if !strings.Contains(log, want) {
@@ -1049,6 +1049,7 @@ func TestParseDashboardRSAJWK(t *testing.T) {
 		{"bad modulus encoding", func(j *dashboardJWK) { j.N = "!" }, false, true},
 		{"bad exponent encoding", func(j *dashboardJWK) { j.E = "!" }, false, true},
 		{"weak modulus", func(j *dashboardJWK) { j.N = encodeInt(big.NewInt(17)) }, false, true},
+		{"maximum modulus", func(j *dashboardJWK) { j.N = encodeInt(new(big.Int).Lsh(big.NewInt(1), dashboardOIDCRSAMaxBits-1)) }, true, false},
 		{"oversize modulus", func(j *dashboardJWK) { j.N = encodeInt(new(big.Int).Lsh(big.NewInt(1), dashboardOIDCRSAMaxBits)) }, false, true},
 		{"even exponent", func(j *dashboardJWK) { j.E = encodeInt(big.NewInt(4)) }, false, true},
 		{"huge exponent", func(j *dashboardJWK) { j.E = encodeInt(new(big.Int).Lsh(big.NewInt(1), 80)) }, false, true},
@@ -1337,7 +1338,7 @@ func TestDashboardOIDC_RunServeCompositionUsesMappedRoutePermissions(t *testing.
 		// The subject is recorded hashed rather than in the clear. Derive the
 		// expected digest from the subject so this still pins WHICH principal
 		// was denied, not merely that some digest was written.
-		fmt.Sprintf("auth_subject_sha256=%x", sha256.Sum256([]byte("operator-a"))),
+		fmt.Sprintf("auth_subject_sha256=%q", fmt.Sprintf("%x", sha256.Sum256([]byte("operator-a")))),
 		"auth_roles=\"evidence-reader\"",
 		"reason=permission_denied",
 	} {

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -61,6 +61,7 @@ func TestDashboardOIDCFailureCategory(t *testing.T) {
 type oidcTestProvider struct {
 	server    *httptest.Server
 	private   *rsa.PrivateKey
+	keyID     string
 	mu        sync.Mutex
 	jwksFail  bool
 	jwksBlock <-chan struct{}
@@ -74,7 +75,7 @@ func newOIDCTestProvider(t *testing.T) *oidcTestProvider {
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
-	p := &oidcTestProvider{private: private}
+	p := &oidcTestProvider{private: private, keyID: oidcTestKeyID}
 	p.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/.well-known/openid-configuration":
@@ -91,16 +92,41 @@ func newOIDCTestProvider(t *testing.T) *oidcTestProvider {
 				return
 			}
 			w.Header().Set("Cache-Control", "max-age=3600")
-			n := base64.RawURLEncoding.EncodeToString(private.N.Bytes())
-			e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(private.PublicKey.E)).Bytes())
+			keyID, public := p.jwksKey()
+			n := base64.RawURLEncoding.EncodeToString(public.N.Bytes())
+			e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(public.E)).Bytes())
 			_, _ = fmt.Fprintf(w, `{"keys":[{"kty":"RSA","kid":%q,"use":"sig","alg":"RS256","n":%q,"e":%q,"x5c":[]}]}`,
-				oidcTestKeyID, n, e)
+				keyID, n, e)
 		default:
 			http.NotFound(w, r)
 		}
 	}))
 	t.Cleanup(p.server.Close)
 	return p
+}
+
+func (p *oidcTestProvider) jwksKey() (string, rsa.PublicKey) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.keyID, p.private.PublicKey
+}
+
+func (p *oidcTestProvider) signingKey() *rsa.PrivateKey {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.private
+}
+
+func (p *oidcTestProvider) rotateSigningKey(t *testing.T, keyID string) {
+	t.Helper()
+	private, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey(rotated): %v", err)
+	}
+	p.mu.Lock()
+	p.private = private
+	p.keyID = keyID
+	p.mu.Unlock()
 }
 
 func (p *oidcTestProvider) setJWKSFail(fail bool) {
@@ -146,7 +172,8 @@ func (p *oidcTestProvider) waitForJWKSBlock(ctx context.Context) error {
 
 func (p *oidcTestProvider) token(t *testing.T, claims map[string]any) string {
 	t.Helper()
-	return p.tokenWithHeader(t, map[string]any{"alg": "RS256", "kid": oidcTestKeyID, "typ": "JWT"}, claims, true)
+	keyID, _ := p.jwksKey()
+	return p.tokenWithHeader(t, map[string]any{"alg": "RS256", "kid": keyID, "typ": "JWT"}, claims, true)
 }
 
 func (p *oidcTestProvider) tokenWithHeader(t *testing.T, header, claims map[string]any, sign bool) string {
@@ -168,7 +195,7 @@ func (p *oidcTestProvider) tokenWithHeader(t *testing.T, header, claims map[stri
 func (p *oidcTestProvider) signInput(t *testing.T, signingInput string) string {
 	t.Helper()
 	digest := sha256.Sum256([]byte(signingInput))
-	sig, err := rsa.SignPKCS1v15(rand.Reader, p.private, crypto.SHA256, digest[:])
+	sig, err := rsa.SignPKCS1v15(rand.Reader, p.signingKey(), crypto.SHA256, digest[:])
 	if err != nil {
 		t.Fatalf("SignPKCS1v15: %v", err)
 	}
@@ -761,6 +788,53 @@ func TestDashboardOIDC_UnknownKeyRefreshCanFindRotatedKey(t *testing.T) {
 	}
 	if got := p.jwksReads.Load(); got != 2 {
 		t.Fatalf("JWKS reads = %d, want initial fetch plus rotation refresh", got)
+	}
+}
+
+func TestDashboardOIDC_UnknownKidAttackerCannotPersistentlyStarveRotatedKey(t *testing.T) {
+	currentNow := time.Unix(2_000_000_000, 0)
+	p := newOIDCTestProvider(t)
+	auth, err := newDashboardOIDCAuthenticator(context.Background(), dashboardOIDCOptions{
+		Issuer:       p.server.URL,
+		Audience:     oidcTestAudience,
+		RoleClaim:    "groups",
+		RoleMapJSON:  oidcTestRoleMap(),
+		HTTPClient:   p.server.Client(),
+		Now:          func() time.Time { return currentNow },
+		JWKSCacheTTL: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("newDashboardOIDCAuthenticator: %v", err)
+	}
+
+	attackerToken := p.tokenWithHeader(t, map[string]any{"alg": "RS256", "kid": "attacker-bogus-a"}, p.validClaims(currentNow), true)
+	if principal, err := auth.authenticate(requestWithBearer(t, attackerToken)); err == nil || principal != nil {
+		t.Fatalf("attacker unknown kid authenticate = (%+v, %v), want denial", principal, err)
+	}
+	if got := p.jwksReads.Load(); got != 2 {
+		t.Fatalf("JWKS reads after attacker miss = %d, want initial fetch plus attacker-triggered refresh", got)
+	}
+
+	p.rotateSigningKey(t, "rotated-legitimate-key")
+	legitimateToken := p.token(t, p.validClaims(currentNow))
+	if principal, err := auth.authenticate(requestWithBearer(t, legitimateToken)); err == nil || principal != nil {
+		t.Fatalf("legitimate rotated kid inside attacker window = (%+v, %v), want bounded denial", principal, err)
+	}
+	if got := p.jwksReads.Load(); got != 2 {
+		t.Fatalf("JWKS reads inside attacker miss window = %d, want no throttled refresh", got)
+	}
+
+	currentNow = currentNow.Add(dashboardOIDCMinKeyRefresh)
+	nextAttackerToken := p.tokenWithHeader(t, map[string]any{"alg": "RS256", "kid": "attacker-bogus-b"}, p.validClaims(currentNow), true)
+	if principal, err := auth.authenticate(requestWithBearer(t, nextAttackerToken)); err == nil || principal != nil {
+		t.Fatalf("next attacker unknown kid authenticate = (%+v, %v), want denial", principal, err)
+	}
+	if got := p.jwksReads.Load(); got != 3 {
+		t.Fatalf("JWKS reads after next attacker window = %d, want another bounded refresh", got)
+	}
+
+	if _, err := auth.authenticate(requestWithBearer(t, p.token(t, p.validClaims(currentNow)))); err != nil {
+		t.Fatalf("legitimate rotated kid after attacker-triggered refresh: %v", err)
 	}
 }
 

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -47,7 +47,9 @@ func TestDashboardOIDCFailureCategory(t *testing.T) {
 		{"signature", errors.New("token signature is invalid"), "invalid_signature"},
 		{"expired", errors.New("token has expired"), "expired"},
 		{"unmapped role", errors.New("role claim has no mapped value"), "permission_denied"},
-		{"unknown signing key", errors.New("OIDC signing key \"kid-a\" not found"), "unknown_principal"},
+		{"unknown signing key", dashboardOIDCSigningKeyNotFound("kid-a"), "unknown_principal"},
+		{"unknown signing key kid cannot steer expired category", dashboardOIDCSigningKeyNotFound("expired"), "unknown_principal"},
+		{"unknown signing key kid cannot steer signature category", dashboardOIDCSigningKeyNotFound("bad signature"), "unknown_principal"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -760,8 +760,8 @@ func TestDashboardAuthDeniedAuditPreservesMissingTokenReason(t *testing.T) {
 		"pipelock-dashboard denied",
 		"permission=\"-\"",
 		"auth_method=none",
-		"auth_subject_sha256=-",
-		"mtls_spki_sha256=-",
+		`auth_subject_sha256="-"`,
+		`mtls_spki_sha256="-"`,
 		"reason=missing_token",
 	} {
 		if !strings.Contains(log, want) {

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -735,6 +736,40 @@ func TestDashboardAuthorizeFunc(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+dashTestToken)
 	if err := authorize(req); err != nil {
 		t.Fatalf("authenticated request: want nil, got %v", err)
+	}
+}
+
+func TestDashboardAuthDeniedAuditPreservesMissingTokenReason(t *testing.T) {
+	var audit strings.Builder
+	handler := dashboardAuthHandler(
+		func(*http.Request) bool { return false },
+		nil,
+		&audit,
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://dashboard.example/evidence", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	log := audit.String()
+	for _, want := range []string{
+		"pipelock-dashboard denied",
+		"permission=\"-\"",
+		"auth_method=none",
+		"auth_subject_sha256=-",
+		"mtls_spki_sha256=-",
+		"reason=missing_token",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("auth-denied audit missing %q: %s", want, log)
+		}
+	}
+	if strings.Contains(log, "reason=no_credential") {
+		t.Fatalf("auth-denied audit used collapsed reason: %s", log)
 	}
 }
 

--- a/enterprise/conductor/controlplane/dryrun.go
+++ b/enterprise/conductor/controlplane/dryrun.go
@@ -488,6 +488,9 @@ func (h *Handler) replayRemoteKillByHash(w http.ResponseWriter, r *http.Request,
 			return found, err
 		}
 		msg := record.Message
+		if !remoteKillRecordMatchesHash(record, query.ArtifactHash) {
+			return false, nil
+		}
 		if msg.OrgID != query.OrgID || msg.FleetID != query.FleetID {
 			return false, nil
 		}
@@ -504,7 +507,7 @@ func (h *Handler) replayRemoteKillByHash(w http.ResponseWriter, r *http.Request,
 	}
 	for _, record := range records {
 		msg := record.Message
-		if record.MessageHash == query.ArtifactHash && msg.OrgID == query.OrgID && msg.FleetID == query.FleetID {
+		if remoteKillRecordMatchesHash(record, query.ArtifactHash) && msg.OrgID == query.OrgID && msg.FleetID == query.FleetID {
 			h.replayResolvedRemoteKill(w, r, msg, now)
 			return true, nil
 		}
@@ -519,6 +522,9 @@ func (h *Handler) replayRollbackByHash(w http.ResponseWriter, r *http.Request, q
 			return found, err
 		}
 		auth := record.Authorization
+		if !rollbackRecordMatchesHash(record, query.ArtifactHash) {
+			return false, nil
+		}
 		if auth.OrgID != query.OrgID || auth.FleetID != query.FleetID {
 			return false, nil
 		}
@@ -535,7 +541,7 @@ func (h *Handler) replayRollbackByHash(w http.ResponseWriter, r *http.Request, q
 	}
 	for _, record := range records {
 		auth := record.Authorization
-		if record.AuthorizationHash == query.ArtifactHash && auth.OrgID == query.OrgID && auth.FleetID == query.FleetID {
+		if rollbackRecordMatchesHash(record, query.ArtifactHash) && auth.OrgID == query.OrgID && auth.FleetID == query.FleetID {
 			h.replayResolvedRollback(w, r, auth, now)
 			return true, nil
 		}
@@ -730,6 +736,9 @@ func (h *Handler) recordedRemoteKill(ctx context.Context, hash string) (*Recorde
 		if err != nil || !found {
 			return nil, err
 		}
+		if !remoteKillRecordMatchesHash(record, hash) {
+			return nil, nil
+		}
 		return &RecordedDecision{
 			Present:      true,
 			Accepted:     true,
@@ -743,7 +752,7 @@ func (h *Handler) recordedRemoteKill(ctx context.Context, hash string) (*Recorde
 			return nil, err
 		}
 		for _, record := range records {
-			if record.MessageHash == hash {
+			if remoteKillRecordMatchesHash(record, hash) {
 				return &RecordedDecision{
 					Present:      true,
 					Accepted:     true,
@@ -763,7 +772,7 @@ func (h *Handler) recordedRemoteKill(ctx context.Context, hash string) (*Recorde
 		return nil, err
 	}
 	for _, record := range records {
-		if record.MessageHash == hash {
+		if remoteKillRecordMatchesHash(record, hash) {
 			return &RecordedDecision{
 				Present:      true,
 				Accepted:     true,
@@ -875,6 +884,9 @@ func (h *Handler) recordedRollback(ctx context.Context, hash string) (*RecordedD
 		if err != nil || !found {
 			return nil, err
 		}
+		if !rollbackRecordMatchesHash(record, hash) {
+			return nil, nil
+		}
 		return &RecordedDecision{
 			Present:      true,
 			Accepted:     true,
@@ -888,7 +900,7 @@ func (h *Handler) recordedRollback(ctx context.Context, hash string) (*RecordedD
 			return nil, err
 		}
 		for _, record := range records {
-			if record.AuthorizationHash == hash {
+			if rollbackRecordMatchesHash(record, hash) {
 				return &RecordedDecision{
 					Present:      true,
 					Accepted:     true,
@@ -908,7 +920,7 @@ func (h *Handler) recordedRollback(ctx context.Context, hash string) (*RecordedD
 		return nil, err
 	}
 	for _, record := range records {
-		if record.AuthorizationHash == hash {
+		if rollbackRecordMatchesHash(record, hash) {
 			return &RecordedDecision{
 				Present:      true,
 				Accepted:     true,

--- a/enterprise/conductor/controlplane/dryrun_test.go
+++ b/enterprise/conductor/controlplane/dryrun_test.go
@@ -1576,12 +1576,40 @@ func TestReplayByHashDirectLookupErrorsAndScope(t *testing.T) {
 			wantStatus: http.StatusNotFound,
 		},
 		{
+			name: "remote direct record hash mismatch",
+			emergency: replayByHashReaderStore{
+				emergencyStoreNoPreview: emergencyStoreNoPreview{inner: baseEmergency},
+				remoteRecord: StoredRemoteKill{
+					Message:     msg,
+					MessageHash: strings.Repeat("f", 64),
+					PublishedAt: testNow,
+				},
+				remoteFound: true,
+			},
+			hash:       remoteHash,
+			wantStatus: http.StatusNotFound,
+		},
+		{
 			name: "rollback direct record outside scope",
 			emergency: replayByHashReaderStore{
 				emergencyStoreNoPreview: emergencyStoreNoPreview{inner: baseEmergency},
 				rollbackRecord: StoredRollbackAuthorization{
 					Authorization:     rollbackOutOfScope,
 					AuthorizationHash: rollbackHash,
+					PublishedAt:       testNow,
+				},
+				rollbackFound: true,
+			},
+			hash:       rollbackHash,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "rollback direct record hash mismatch",
+			emergency: replayByHashReaderStore{
+				emergencyStoreNoPreview: emergencyStoreNoPreview{inner: baseEmergency},
+				rollbackRecord: StoredRollbackAuthorization{
+					Authorization:     auth,
+					AuthorizationHash: strings.Repeat("e", 64),
 					PublishedAt:       testNow,
 				},
 				rollbackFound: true,
@@ -1746,7 +1774,7 @@ func TestReplayByHashFailsClosed(t *testing.T) {
 			wantBody:   ErrDecisionReplayArtifactNotFound.Error(),
 		},
 		{
-			name:       "scope mismatch is not found",
+			name:       "out-of-scope fleet rejected by stream authorization",
 			target:     DecisionReplayPath + "?org_id=org-main&fleet_id=staging&artifact_hash=" + record.BundleHash,
 			streamAuth: true,
 			wantStatus: http.StatusForbidden,

--- a/enterprise/conductor/controlplane/emergency_verified.go
+++ b/enterprise/conductor/controlplane/emergency_verified.go
@@ -454,6 +454,9 @@ func (v *verifiedEmergencyStore) RecordedRemoteKillByHash(ctx context.Context, h
 	return StoredRemoteKill{}, false, nil
 }
 
+// The canonical hash is compared exactly because callers pass a lowercase
+// validated digest. The persisted hash field uses EqualFold only to tolerate
+// legacy records written with uppercase hex; do not relax the canonical check.
 func rollbackRecordMatchesHash(record StoredRollbackAuthorization, hash string) bool {
 	canonical, err := record.Authorization.CanonicalHash()
 	if err != nil {
@@ -462,6 +465,9 @@ func rollbackRecordMatchesHash(record StoredRollbackAuthorization, hash string) 
 	return canonical == hash && strings.EqualFold(record.AuthorizationHash, hash)
 }
 
+// The canonical hash is compared exactly because callers pass a lowercase
+// validated digest. The persisted hash field uses EqualFold only to tolerate
+// legacy records written with uppercase hex; do not relax the canonical check.
 func remoteKillRecordMatchesHash(record StoredRemoteKill, hash string) bool {
 	canonical, err := record.Message.CanonicalHash()
 	if err != nil {

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -405,10 +405,12 @@ func (r routeAccessResult) allowed() bool {
 // logs. Callers must pass only sanitized values, never bearer tokens or raw
 // claims.
 type AuthAuditInfo struct {
-	Method        string
-	Subject       string
-	Roles         []string
-	FailureReason string
+	Method         string
+	Subject        string
+	SubjectSHA256  string
+	MTLSSPKISHA256 string
+	Roles          []string
+	FailureReason  string
 }
 
 // WithAuthAuditInfo attaches dashboard authentication metadata to a request
@@ -444,7 +446,12 @@ func navFromContext(r *http.Request) NavContext {
 func authAuditInfoFromRequest(r *http.Request) AuthAuditInfo {
 	info, _ := r.Context().Value(authAuditInfoContextKey{}).(AuthAuditInfo)
 	info.Method = AuditLogValue(info.Method)
-	info.Subject = AuditLogValue(info.Subject)
+	if info.SubjectSHA256 == "" {
+		info.SubjectSHA256 = auditHashField(info.Subject)
+	} else {
+		info.SubjectSHA256 = AuditLogValue(info.SubjectSHA256)
+	}
+	info.MTLSSPKISHA256 = AuditLogValue(info.MTLSSPKISHA256)
 	if len(info.Roles) == 0 {
 		info.Roles = []string{"-"}
 	}
@@ -470,10 +477,10 @@ func (d *dashboardHandler) recordAudit(r *http.Request, raw bool, permission Per
 	auth := authAuditInfoFromRequest(r)
 	d.auditMu.Lock()
 	defer d.auditMu.Unlock()
-	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s permission=%q method=%s path=%q session=%q session_sha256=%s org_sha256=%s fleet_sha256=%s artifact_sha256=%s auth_method=%s auth_subject=%q auth_roles=%q remote=%s\n",
+	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s permission=%q method=%s path=%q session=%q session_sha256=%s org_sha256=%s fleet_sha256=%s artifact_sha256=%s auth_method=%s auth_subject_sha256=%s mtls_spki_sha256=%s auth_roles=%q remote=%s\n",
 		time.Now().UTC().Format(time.RFC3339), role, permission, r.Method, r.URL.Path, sessionDisplay, sessionHash,
 		auditHashField(r.URL.Query().Get("org_id")), auditHashField(r.URL.Query().Get("fleet_id")),
-		auditHashField(r.URL.Query().Get("artifact_hash")), auth.Method, auth.Subject, strings.Join(auth.Roles, ","), r.RemoteAddr)
+		auditHashField(r.URL.Query().Get("artifact_hash")), auth.Method, auth.SubjectSHA256, auth.MTLSSPKISHA256, strings.Join(auth.Roles, ","), r.RemoteAddr)
 }
 
 func (d *dashboardHandler) recordPermissionDeniedAudit(r *http.Request, permission Permission) {
@@ -483,11 +490,15 @@ func (d *dashboardHandler) recordPermissionDeniedAudit(r *http.Request, permissi
 	session := sessionFromRequest(r)
 	sessionDisplay, sessionHash := auditSessionField(session)
 	auth := authAuditInfoFromRequest(r)
+	reason := auth.FailureReason
+	if reason == "-" {
+		reason = "role_lacks_permission"
+	}
 	d.auditMu.Lock()
 	defer d.auditMu.Unlock()
-	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard denied permission=%q method=%s path=%q session=%q session_sha256=%s auth_method=%s auth_subject=%q auth_roles=%q reason=permission_denied remote=%s\n",
+	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard denied permission=%q method=%s path=%q session=%q session_sha256=%s auth_method=%s auth_subject_sha256=%s mtls_spki_sha256=%s auth_roles=%q reason=%s remote=%s\n",
 		time.Now().UTC().Format(time.RFC3339), permission, r.Method, r.URL.Path,
-		sessionDisplay, sessionHash, auth.Method, auth.Subject, strings.Join(auth.Roles, ","), r.RemoteAddr)
+		sessionDisplay, sessionHash, auth.Method, auth.SubjectSHA256, auth.MTLSSPKISHA256, strings.Join(auth.Roles, ","), reason, r.RemoteAddr)
 }
 
 func sessionFromRequest(r *http.Request) string {

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -477,7 +477,7 @@ func (d *dashboardHandler) recordAudit(r *http.Request, raw bool, permission Per
 	auth := authAuditInfoFromRequest(r)
 	d.auditMu.Lock()
 	defer d.auditMu.Unlock()
-	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s permission=%q method=%s path=%q session=%q session_sha256=%s org_sha256=%s fleet_sha256=%s artifact_sha256=%s auth_method=%s auth_subject_sha256=%s mtls_spki_sha256=%s auth_roles=%q remote=%s\n",
+	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard access role=%s permission=%q method=%s path=%q session=%q session_sha256=%s org_sha256=%s fleet_sha256=%s artifact_sha256=%s auth_method=%s auth_subject_sha256=%q mtls_spki_sha256=%q auth_roles=%q remote=%s\n",
 		time.Now().UTC().Format(time.RFC3339), role, permission, r.Method, r.URL.Path, sessionDisplay, sessionHash,
 		auditHashField(r.URL.Query().Get("org_id")), auditHashField(r.URL.Query().Get("fleet_id")),
 		auditHashField(r.URL.Query().Get("artifact_hash")), auth.Method, auth.SubjectSHA256, auth.MTLSSPKISHA256, strings.Join(auth.Roles, ","), r.RemoteAddr)
@@ -499,7 +499,7 @@ func (d *dashboardHandler) recordPermissionDeniedAudit(r *http.Request, permissi
 	}
 	d.auditMu.Lock()
 	defer d.auditMu.Unlock()
-	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard denied permission=%q method=%s path=%q session=%q session_sha256=%s auth_method=%s auth_subject_sha256=%s mtls_spki_sha256=%s auth_roles=%q reason=%s remote=%s\n",
+	_, _ = fmt.Fprintf(d.auditWriter, "%s pipelock-dashboard denied permission=%q method=%s path=%q session=%q session_sha256=%s auth_method=%s auth_subject_sha256=%q mtls_spki_sha256=%q auth_roles=%q reason=%s remote=%s\n",
 		time.Now().UTC().Format(time.RFC3339), permission, r.Method, r.URL.Path,
 		sessionDisplay, sessionHash, auth.Method, auth.SubjectSHA256, auth.MTLSSPKISHA256, strings.Join(auth.Roles, ","), reason, r.RemoteAddr)
 }

--- a/enterprise/dashboard/handler.go
+++ b/enterprise/dashboard/handler.go
@@ -492,7 +492,10 @@ func (d *dashboardHandler) recordPermissionDeniedAudit(r *http.Request, permissi
 	auth := authAuditInfoFromRequest(r)
 	reason := auth.FailureReason
 	if reason == "-" {
-		reason = "role_lacks_permission"
+		// Keep the reason value operators already alert on. Earlier releases
+		// emitted permission_denied on this line, so renaming it would break
+		// existing SIEM rules silently.
+		reason = "permission_denied"
 	}
 	d.auditMu.Lock()
 	defer d.auditMu.Unlock()

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -8,6 +8,7 @@ package dashboard
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -1878,10 +1879,11 @@ func TestHandler_AuditWrittenForPermissionDenied(t *testing.T) {
 		},
 		AuditWriter: &buf,
 	})
+	spkiHash := strings.Repeat("a", sha256.Size*2)
 	ctx := WithAuthAuditInfo(context.Background(), AuthAuditInfo{
-		Method:  "mtls",
-		Subject: "spki-sha256",
-		Roles:   []string{"metadata"},
+		Method:         "mtls",
+		MTLSSPKISHA256: spkiHash,
+		Roles:          []string{"metadata"},
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequestWithContext(ctx, http.MethodGet, "/session/"+testSessionID, nil))
@@ -1893,9 +1895,10 @@ func TestHandler_AuditWrittenForPermissionDenied(t *testing.T) {
 		"pipelock-dashboard denied",
 		"permission=\"dashboard:evidence:read\"",
 		"auth_method=mtls",
-		"auth_subject=\"spki-sha256\"",
+		"auth_subject_sha256=-",
+		"mtls_spki_sha256=" + spkiHash,
 		"auth_roles=\"metadata\"",
-		"reason=permission_denied",
+		"reason=role_lacks_permission",
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("permission-denied audit missing %q: %s", want, log)
@@ -1929,9 +1932,10 @@ func TestHandler_AuditWrittenForPermissionDeniedWithoutAuthInfo(t *testing.T) {
 	for _, want := range []string{
 		"pipelock-dashboard denied",
 		"auth_method=-",
-		"auth_subject=\"-\"",
+		"auth_subject_sha256=-",
+		"mtls_spki_sha256=-",
 		"auth_roles=\"-\"",
-		"reason=permission_denied",
+		"reason=role_lacks_permission",
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("permission-denied audit missing %q: %s", want, log)
@@ -1939,6 +1943,57 @@ func TestHandler_AuditWrittenForPermissionDeniedWithoutAuthInfo(t *testing.T) {
 	}
 	if strings.Contains(log, "pipelock-dashboard access") {
 		t.Fatalf("permission-denied request must not be audited as access: %s", log)
+	}
+}
+
+func TestHandler_PermissionDeniedAuditUsesAuthFailureReason(t *testing.T) {
+	t.Parallel()
+	dir, trusted := writeTrustedHandlerSession(t)
+
+	var buf strings.Builder
+	handler := New(Options{
+		ReceiptDir:  dir,
+		TrustedKeys: trusted,
+		HasFeature:  allowAgentsFeature,
+		AuthorizePermission: func(*http.Request, Permission) error {
+			return errors.New("permission denied")
+		},
+		AuditWriter: &buf,
+	})
+	ctx := WithAuthAuditInfo(context.Background(), AuthAuditInfo{
+		Method:        "oidc",
+		FailureReason: "expired",
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(ctx, http.MethodGet, "/session/"+testSessionID, nil))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	log := buf.String()
+	for _, want := range []string{
+		"pipelock-dashboard denied",
+		"permission=\"dashboard:evidence:read\"",
+		"auth_method=oidc",
+		"reason=expired",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("permission-denied audit missing %q: %s", want, log)
+		}
+	}
+}
+
+func TestAuthAuditInfoFromRequestPreservesPrehashedSubject(t *testing.T) {
+	t.Parallel()
+	prehashed := strings.Repeat("b", sha256.Size*2)
+	req := httptest.NewRequestWithContext(
+		WithAuthAuditInfo(context.Background(), AuthAuditInfo{Subject: "raw-subject", SubjectSHA256: prehashed}),
+		http.MethodGet,
+		"https://dashboard.example/",
+		nil,
+	)
+	got := authAuditInfoFromRequest(req)
+	if got.SubjectSHA256 != prehashed {
+		t.Fatalf("SubjectSHA256 = %q, want prehashed %q", got.SubjectSHA256, prehashed)
 	}
 }
 

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -1762,7 +1762,7 @@ func TestHandler_DecisionScopeAuditStates(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name          string
-		page          WorkbenchPage
+		page          any
 		wantFragments []string
 	}{
 		{
@@ -1811,6 +1811,48 @@ func TestHandler_DecisionScopeAuditStates(t *testing.T) {
 				`decision_missing=false`,
 				`divergence=true`,
 				`conflict="fleet_skew"`,
+			},
+		},
+		{
+			name: "incident replay error",
+			page: IncidentPage{DecisionSourceConfigured: true, DecisionError: true, DecisionErrorReason: "canceled", FleetSourceConfigured: true},
+			wantFragments: []string{
+				`decision_state="unavailable"`,
+				`decision_error_reason="canceled"`,
+				`decision_found=false`,
+				`decision_error=true`,
+				`decision_missing=false`,
+				`fleet_source=true`,
+				`fleet_found=false`,
+			},
+		},
+		{
+			name: "incident not found",
+			page: IncidentPage{DecisionSourceConfigured: true, DecisionMissing: true, FleetSourceConfigured: true, HasFleet: true},
+			wantFragments: []string{
+				`decision_state="not_found"`,
+				`decision_found=false`,
+				`decision_error=false`,
+				`decision_missing=true`,
+				`fleet_source=true`,
+				`fleet_found=true`,
+			},
+		},
+		{
+			name: "incident replay found",
+			page: IncidentPage{DecisionSourceConfigured: true, FleetSourceConfigured: true, HasFleet: true, HasDecision: true, Decision: DecisionReplayView{
+				Divergence: true,
+				Conflict:   "stale_counter",
+			}},
+			wantFragments: []string{
+				`decision_state="found"`,
+				`decision_found=true`,
+				`decision_error=false`,
+				`decision_missing=false`,
+				`fleet_source=true`,
+				`fleet_found=true`,
+				`divergence=true`,
+				`conflict="stale_counter"`,
 			},
 		},
 		{

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -1898,7 +1898,7 @@ func TestHandler_AuditWrittenForPermissionDenied(t *testing.T) {
 		"auth_subject_sha256=-",
 		"mtls_spki_sha256=" + spkiHash,
 		"auth_roles=\"metadata\"",
-		"reason=role_lacks_permission",
+		"reason=permission_denied",
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("permission-denied audit missing %q: %s", want, log)
@@ -1935,7 +1935,7 @@ func TestHandler_AuditWrittenForPermissionDeniedWithoutAuthInfo(t *testing.T) {
 		"auth_subject_sha256=-",
 		"mtls_spki_sha256=-",
 		"auth_roles=\"-\"",
-		"reason=role_lacks_permission",
+		"reason=permission_denied",
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("permission-denied audit missing %q: %s", want, log)

--- a/enterprise/dashboard/handler_test.go
+++ b/enterprise/dashboard/handler_test.go
@@ -1694,6 +1694,30 @@ func TestHandler_AuditWriterRecordsAccess(t *testing.T) {
 			t.Errorf("audit log should record raw role; got %q", raw.String())
 		}
 	})
+
+	t.Run("auth_digest_fields_are_quoted", func(t *testing.T) {
+		var audit strings.Builder
+		handler := New(Options{
+			TrustedOuterAuth: true,
+			ReceiptDir:       dir, TrustedKeys: trusted, HasFeature: allowAgentsFeature,
+			AuditWriter: &audit,
+		})
+		ctx := WithAuthAuditInfo(context.Background(), AuthAuditInfo{
+			Method:         "oidc",
+			SubjectSHA256:  "subject injected=value",
+			MTLSSPKISHA256: "spki extra=field",
+		})
+		handler.ServeHTTP(httptest.NewRecorder(),
+			httptest.NewRequestWithContext(ctx, http.MethodGet, "/session/"+testSessionID, nil))
+		for _, want := range []string{
+			`auth_subject_sha256="subject injected=value"`,
+			`mtls_spki_sha256="spki extra=field"`,
+		} {
+			if !strings.Contains(audit.String(), want) {
+				t.Errorf("audit log should quote auth digest field %q; got %q", want, audit.String())
+			}
+		}
+	})
 }
 
 func TestAuditSessionFieldNormalizesAndBoundsDisplay(t *testing.T) {
@@ -1937,8 +1961,8 @@ func TestHandler_AuditWrittenForPermissionDenied(t *testing.T) {
 		"pipelock-dashboard denied",
 		"permission=\"dashboard:evidence:read\"",
 		"auth_method=mtls",
-		"auth_subject_sha256=-",
-		"mtls_spki_sha256=" + spkiHash,
+		`auth_subject_sha256="-"`,
+		fmt.Sprintf("mtls_spki_sha256=%q", spkiHash),
 		"auth_roles=\"metadata\"",
 		"reason=permission_denied",
 	} {
@@ -1974,8 +1998,8 @@ func TestHandler_AuditWrittenForPermissionDeniedWithoutAuthInfo(t *testing.T) {
 	for _, want := range []string{
 		"pipelock-dashboard denied",
 		"auth_method=-",
-		"auth_subject_sha256=-",
-		"mtls_spki_sha256=-",
+		`auth_subject_sha256="-"`,
+		`mtls_spki_sha256="-"`,
 		"auth_roles=\"-\"",
 		"reason=permission_denied",
 	} {

--- a/enterprise/dashboard/workbench_test.go
+++ b/enterprise/dashboard/workbench_test.go
@@ -489,6 +489,27 @@ func TestWorkbench_SourceErrorRendersUnavailablePanel(t *testing.T) {
 	}
 }
 
+func TestDecisionReplayErrorReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "deadline", err: context.DeadlineExceeded, want: "deadline_exceeded"},
+		{name: "canceled", err: context.Canceled, want: "canceled"},
+		{name: "source", err: errors.New("backend failure"), want: "source_error"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decisionReplayErrorReason(tc.err); got != tc.want {
+				t.Fatalf("reason = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWorkbench_RejectsInvalidScope(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Dashboard audit lines name the principal behind each access and each denial. Every line carries the auth method, the mapped roles, and the permission under evaluation. An OIDC subject is recorded as a SHA-256 digest and a client certificate as its SPKI SHA-256 digest, so an operator can correlate activity to an identity without the audit log holding the identifier in the clear. A denial also carries a failure category.

Three bounds land alongside the attribution. The client CA bundle read is capped, an oversized RSA client-certificate key is rejected, and an unknown key ID cannot drive repeated JWKS refetches. A CA bundle that carries comments or trailing text between certificates still loads, while a truncated or malformed bundle is rejected instead of loading as a partial trust set.

The `auth_subject` field becomes `auth_subject_sha256`. An operator rule that reads the subject value needs updating. The `reason` values are unchanged, so alerting keyed on those keeps matching.

This branch builds on `fix/dashboard-oidc-route-permission-enforcement` and should merge after it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added artifact-hash decision replay for publish, remote-kill, and rollback actions.
  * Dashboard replay now integrates with the configured Conductor source and reports unavailable decisions clearly.
* **Security**
  * Hardened mTLS certificate, CA bundle, OIDC token, and JWKS validation.
  * Replay requests now enforce canonical hashes and strict scope authorization.
* **Audit**
  * Access and denial logs now use hashed identity fields, mTLS fingerprints, permissions, and categorized failure reasons.
* **Documentation**
  * Clarified dashboard startup, authentication, replay, and audit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->