### PR TITLE
fix(playground): report machine-provider health and back off failed provider calls

### DIFF
--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -325,6 +325,8 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+	providerHealth := broker.NewProviderHealth(nil, out)
+	provider = broker.NewHealthTrackingProvider(provider, providerHealth)
 	sessionEnv, err := resolveSessionEnv(f)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -371,8 +373,9 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 					InternalPort: f.internalPort,
 				}
 			},
-			Size: f.warmPoolSize,
-			Log:  out,
+			Size:   f.warmPoolSize,
+			Log:    out,
+			Health: providerHealth,
 		})
 		if poolErr != nil {
 			return nil, nil, nil, nil, poolErr
@@ -398,6 +401,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		DeadlineGrace:      f.deadlineGrace,
 		TrustForwardedFor:  f.trustForwardedFor,
 		AllowOrigin:        f.allowOrigin,
+		ProviderHealth:     providerHealth,
 	})
 	if err != nil {
 		return nil, nil, nil, nil, err

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -45,6 +46,75 @@ func (fakeProvider) DestroyMachine(_ context.Context, _ string) error {
 
 func (fakeProvider) ListManagedMachines(_ context.Context) ([]broker.Machine, error) {
 	return nil, nil
+}
+
+type trackingProvider struct {
+	mu          sync.Mutex
+	createErr   error
+	listErr     error
+	createCalls int
+	listCalls   int
+	createCh    chan struct{}
+	listCh      chan struct{}
+}
+
+func (p *trackingProvider) CreateMachine(_ context.Context, _ broker.MachineSpec) (*broker.Machine, error) {
+	p.mu.Lock()
+	p.createCalls++
+	ch := p.createCh
+	err := p.createErr
+	p.mu.Unlock()
+	signalTestCall(ch)
+	if err != nil {
+		return nil, err
+	}
+	return &broker.Machine{ID: "tracked-create", State: "started", PrivateIP: "fdaa::1"}, nil
+}
+
+func (p *trackingProvider) WaitReady(_ context.Context, _ string) error {
+	return nil
+}
+
+func (p *trackingProvider) DestroyMachine(_ context.Context, _ string) error {
+	return nil
+}
+
+func (p *trackingProvider) ListManagedMachines(_ context.Context) ([]broker.Machine, error) {
+	p.mu.Lock()
+	p.listCalls++
+	ch := p.listCh
+	err := p.listErr
+	p.mu.Unlock()
+	signalTestCall(ch)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (p *trackingProvider) setListErr(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.listErr = err
+}
+
+func signalTestCall(ch chan struct{}) {
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
+func waitTestCall(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
 }
 
 type lockedBuffer struct {
@@ -161,6 +231,105 @@ func TestMergeSessionAndBaseEnvLayersSessionOverBase(t *testing.T) {
 	}
 	if _, ok := baseEnv["PLAYGROUND_CODE"]; ok {
 		t.Fatal("base env mutated with PLAYGROUND_CODE")
+	}
+}
+
+func TestBuildServerWiresProviderHealthToWarmPoolAndHealthEndpoint(t *testing.T) {
+	provider := &trackingProvider{
+		createErr: errors.New("provider rejected credential"),
+		createCh:  make(chan struct{}, 1),
+	}
+	oldFactory := newMachineProvider
+	newMachineProvider = func(_ context.Context, _ *serveFlags, _ string) (broker.MachineProvider, error) {
+		return provider, nil
+	}
+	t.Cleanup(func() { newMachineProvider = oldFactory })
+
+	var out bytes.Buffer
+	srv, handler, _, pool, err := buildServer(context.Background(), &out, testServeFlags(t, 1))
+	if err != nil {
+		t.Fatalf("buildServer: %v", err)
+	}
+	t.Cleanup(srv.Close)
+	if pool == nil {
+		t.Fatal("warm pool is nil, want enabled pool")
+	}
+	poolHealth := reflect.ValueOf(pool).Elem().FieldByName("health")
+	if !poolHealth.IsValid() || poolHealth.IsNil() {
+		t.Fatal("warm pool health is nil; PoolConfig.Health must share provider backoff state")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pool.Run(ctx)
+	}()
+	waitTestCall(t, provider.createCh, "warm-pool create")
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for warm pool maintainer to exit")
+	}
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	health := getMainHealth(t, ts)
+	if health["provider_state"] != string(broker.ProviderStateDegraded) {
+		t.Fatalf("provider_state = %v, want degraded", health["provider_state"])
+	}
+	if health["provider_failures"] != float64(1) {
+		t.Fatalf("provider_failures = %v, want 1", health["provider_failures"])
+	}
+	if strings.Contains(out.String(), "fly-file-token") {
+		t.Fatalf("operator output leaked token: %q", out.String())
+	}
+}
+
+func TestBuildServerWarmPoolDisabledReaperFeedsProviderHealth(t *testing.T) {
+	provider := &trackingProvider{
+		listErr: errors.New("provider rejected credential"),
+		listCh:  make(chan struct{}, 4),
+	}
+	oldFactory := newMachineProvider
+	newMachineProvider = func(_ context.Context, _ *serveFlags, _ string) (broker.MachineProvider, error) {
+		return provider, nil
+	}
+	t.Cleanup(func() { newMachineProvider = oldFactory })
+
+	srv, handler, startReaper, pool, err := buildServer(context.Background(), io.Discard, testServeFlags(t, 0))
+	if err != nil {
+		t.Fatalf("buildServer: %v", err)
+	}
+	t.Cleanup(srv.Close)
+	if pool != nil {
+		t.Fatal("warm pool should be disabled for this test")
+	}
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	if health := getMainHealth(t, ts); health["provider_state"] != string(broker.ProviderStateUnknown) {
+		t.Fatalf("initial provider_state = %v, want unknown", health["provider_state"])
+	}
+
+	runReaperStartupOnce(t, startReaper, provider.listCh)
+	health := getMainHealth(t, ts)
+	if health["provider_state"] != string(broker.ProviderStateDegraded) {
+		t.Fatalf("provider_state after reaper failure = %v, want degraded", health["provider_state"])
+	}
+	if health["provider_failures"] != float64(1) {
+		t.Fatalf("provider_failures after reaper failure = %v, want 1", health["provider_failures"])
+	}
+
+	provider.setListErr(nil)
+	runReaperStartupOnce(t, startReaper, provider.listCh)
+	health = getMainHealth(t, ts)
+	if health["provider_state"] != string(broker.ProviderStateOK) {
+		t.Fatalf("provider_state after reaper recovery = %v, want ok", health["provider_state"])
+	}
+	if health["provider_failures"] != float64(0) {
+		t.Fatalf("provider_failures after reaper recovery = %v, want 0", health["provider_failures"])
 	}
 }
 
@@ -591,6 +760,67 @@ func httpGetStatus(t *testing.T, rawURL string) (string, int) {
 		t.Fatalf("read body: %v", err)
 	}
 	return string(b), resp.StatusCode
+}
+
+func getMainHealth(t *testing.T, ts *httptest.Server) map[string]any {
+	t.Helper()
+	body, status := httpGetStatus(t, ts.URL+livechat.RouteHealth)
+	if status != http.StatusOK {
+		t.Fatalf("health status = %d, want 200; body=%q", status, body)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	return out
+}
+
+func runReaperStartupOnce(t *testing.T, startReaper func(context.Context), listCh <-chan struct{}) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		startReaper(ctx)
+	}()
+	waitTestCall(t, listCh, "reaper list")
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for reaper to exit")
+	}
+}
+
+func testServeFlags(t *testing.T, warmPoolSize int) *serveFlags {
+	t.Helper()
+	dir := t.TempDir()
+	flyTokenFile := writeTestFile(t, dir, "fly.token", "fly-file-token\n")
+	gateSecret := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	gateSecretFile := writeTestFile(t, dir, "gate.b64", gateSecret+"\n")
+	return &serveFlags{
+		listen:                defaultListen,
+		provider:              "fake",
+		flyApp:                "playground-test",
+		flyTokenFile:          flyTokenFile,
+		image:                 "registry.example/playground:test",
+		internalPort:          8080,
+		concurrency:           2,
+		codes:                 []string{"outer-code"},
+		maxPerCode:            defaultMaxPerCode,
+		gateSecretFile:        gateSecretFile,
+		ipRate:                defaultIPRate,
+		ipBurst:               defaultIPBurst,
+		codeRate:              defaultCodeRate,
+		codeBurst:             defaultCodeBurst,
+		globalDailyBudget:     10,
+		unsafeNoHumanGate:     true,
+		sessionTTL:            defaultSessionTTL,
+		deadlineGrace:         defaultGrace,
+		vmDailyTurnBudget:     10,
+		requireSessionSecrets: false,
+		warmPoolSize:          warmPoolSize,
+	}
 }
 
 func TestBuildServerValidation(t *testing.T) {

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -17,7 +17,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -254,11 +253,6 @@ func TestBuildServerWiresProviderHealthToWarmPoolAndHealthEndpoint(t *testing.T)
 	if pool == nil {
 		t.Fatal("warm pool is nil, want enabled pool")
 	}
-	poolHealth := reflect.ValueOf(pool).Elem().FieldByName("health")
-	if !poolHealth.IsValid() || poolHealth.IsNil() {
-		t.Fatal("warm pool health is nil; PoolConfig.Health must share provider backoff state")
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {

--- a/internal/playground/broker/pool.go
+++ b/internal/playground/broker/pool.go
@@ -67,6 +67,10 @@ type PoolConfig struct {
 	Now func() time.Time
 	// Log receives one-line audit messages. Nil discards.
 	Log io.Writer
+	// Health, when non-nil, is consulted before each maintain round so a
+	// persistently failing provider is retried with exponential backoff instead
+	// of every poolMaintainInterval. Nil disables backoff (retry every tick).
+	Health *ProviderHealth
 }
 
 // ConcurrencyAcquirer is the interface the pool needs from the shared
@@ -86,6 +90,7 @@ type Pool struct {
 	maxWarmAge time.Duration
 	now        func() time.Time
 	log        io.Writer
+	health     *ProviderHealth
 
 	mu      sync.Mutex
 	entries []warmEntry
@@ -145,6 +150,7 @@ func NewPool(cfg PoolConfig) (*Pool, error) {
 		maxWarmAge: maxWarmAge,
 		now:        now,
 		log:        log,
+		health:     cfg.Health,
 		quarantine: make(map[string]warmEntry),
 		handoff:    make(map[string]struct{}),
 	}, nil
@@ -307,7 +313,18 @@ func (p *Pool) Resume() {
 }
 
 // maintain recycles stale entries and fills the pool up to Size.
+//
+// While the provider is in backoff this round is skipped entirely. That is safe
+// in BOTH directions: skipping only defers warm-VM housekeeping (a cost and
+// start-latency optimisation). It never denies a visitor a session — the
+// visitor's cold-lease path does not consult backoff — and it never skips a
+// security control. A deferred quarantine retry leaves an already-stuck VM stuck
+// slightly longer; the orphan reaper still reclaims it once the provider
+// recovers.
 func (p *Pool) maintain(ctx context.Context) {
+	if _, active := p.health.BackoffActive(); active {
+		return
+	}
 	p.retryQuarantine(ctx)
 	p.recycleStale(ctx)
 	p.fill(ctx)

--- a/internal/playground/broker/pool.go
+++ b/internal/playground/broker/pool.go
@@ -314,19 +314,19 @@ func (p *Pool) Resume() {
 
 // maintain recycles stale entries and fills the pool up to Size.
 //
-// While the provider is in backoff this round is skipped entirely. That is safe
-// in BOTH directions: skipping only defers warm-VM housekeeping (a cost and
-// start-latency optimisation). It never denies a visitor a session — the
-// visitor's cold-lease path does not consult backoff — and it never skips a
-// security control. A deferred quarantine retry leaves an already-stuck VM stuck
-// slightly longer; the orphan reaper still reclaims it once the provider
-// recovers.
+// Stale entries are removed before consulting provider backoff so Acquire can
+// never hand out an expired VM. Their destruction is attempted once; a failure
+// quarantines the VM and retains its limiter slot until a later retry proves the
+// machine is gone. Backoff skips only quarantine retries and pool refills.
 func (p *Pool) maintain(ctx context.Context) {
+	_, backedOff := p.health.BackoffActive()
+	if !backedOff {
+		p.retryQuarantine(ctx)
+	}
+	p.recycleStale(ctx)
 	if _, active := p.health.BackoffActive(); active {
 		return
 	}
-	p.retryQuarantine(ctx)
-	p.recycleStale(ctx)
 	p.fill(ctx)
 }
 

--- a/internal/playground/broker/pool_test.go
+++ b/internal/playground/broker/pool_test.go
@@ -58,6 +58,50 @@ func newTestPool(t *testing.T, provider MachineProvider, limiter *livechat.Concu
 	return p
 }
 
+type poolCountingProvider struct {
+	inner MachineProvider
+
+	mu           sync.Mutex
+	createCalls  int
+	waitCalls    int
+	destroyCalls int
+	listCalls    int
+}
+
+func (p *poolCountingProvider) CreateMachine(ctx context.Context, spec MachineSpec) (*Machine, error) {
+	p.mu.Lock()
+	p.createCalls++
+	p.mu.Unlock()
+	return p.inner.CreateMachine(ctx, spec)
+}
+
+func (p *poolCountingProvider) WaitReady(ctx context.Context, id string) error {
+	p.mu.Lock()
+	p.waitCalls++
+	p.mu.Unlock()
+	return p.inner.WaitReady(ctx, id)
+}
+
+func (p *poolCountingProvider) DestroyMachine(ctx context.Context, id string) error {
+	p.mu.Lock()
+	p.destroyCalls++
+	p.mu.Unlock()
+	return p.inner.DestroyMachine(ctx, id)
+}
+
+func (p *poolCountingProvider) ListManagedMachines(ctx context.Context) ([]Machine, error) {
+	p.mu.Lock()
+	p.listCalls++
+	p.mu.Unlock()
+	return p.inner.ListManagedMachines(ctx)
+}
+
+func (p *poolCountingProvider) calls() (create, wait, destroy, list int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.createCalls, p.waitCalls, p.destroyCalls, p.listCalls
+}
+
 // TestPoolAcquireReturnsWarmVM verifies Acquire returns a warm VM when one is
 // ready, and ok=false when the pool is empty.
 func TestPoolAcquireReturnsWarmVM(t *testing.T) {
@@ -641,6 +685,116 @@ func TestPoolPauseDestroyFailureQuarantinesVM(t *testing.T) {
 	}
 	if limiter.InUse() != 0 {
 		t.Fatalf("InUse after paused quarantine retry = %d, want 0", limiter.InUse())
+	}
+}
+
+func TestPoolMaintainSkipsProviderCallsWhileBackedOffAndResumes(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	health := NewProviderHealth(func() time.Time { return now }, nil)
+	counter := &poolCountingProvider{inner: &fakeProvider{}}
+	limiter := livechat.NewConcurrencyLimiter(1)
+	pool, err := NewPool(PoolConfig{
+		Provider:    counter,
+		Concurrency: limiter,
+		NewVMCode:   testVMCode(),
+		BuildSpec:   testBuildSpec,
+		Size:        1,
+		Now:         func() time.Time { return now },
+		Health:      health,
+	})
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+
+	health.RecordFailure(errors.New("provider rejected credential"))
+	pool.maintain(context.Background())
+	if create, wait, destroy, list := counter.calls(); create != 0 || wait != 0 || destroy != 0 || list != 0 {
+		t.Fatalf("provider calls while backed off = create:%d wait:%d destroy:%d list:%d, want all zero", create, wait, destroy, list)
+	}
+
+	now = now.Add(providerBackoffBase)
+	pool.maintain(context.Background())
+	if create, wait, destroy, list := counter.calls(); create != 1 || wait != 1 || destroy != 0 || list != 0 {
+		t.Fatalf("provider calls after backoff = create:%d wait:%d destroy:%d list:%d, want create:1 wait:1 destroy:0 list:0", create, wait, destroy, list)
+	}
+}
+
+func TestPoolNilHealthRetriesEveryMaintainTick(t *testing.T) {
+	counter := &poolCountingProvider{inner: &fakeProvider{createErr: errors.New("provider rejected credential")}}
+	limiter := livechat.NewConcurrencyLimiter(1)
+	pool, err := NewPool(PoolConfig{
+		Provider:    counter,
+		Concurrency: limiter,
+		NewVMCode:   testVMCode(),
+		BuildSpec:   testBuildSpec,
+		Size:        1,
+	})
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+
+	pool.maintain(context.Background())
+	pool.maintain(context.Background())
+	if create, _, _, _ := counter.calls(); create != 2 {
+		t.Fatalf("create calls with nil Health = %d, want 2", create)
+	}
+	if limiter.InUse() != 0 {
+		t.Fatalf("InUse after repeated create failures = %d, want 0", limiter.InUse())
+	}
+}
+
+func TestPoolQuarantineBackoffHoldsSlotAndRecoversAfterWindow(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	health := NewProviderHealth(func() time.Time { return now }, nil)
+	inner := &destroyErrProvider{fakeProvider: &fakeProvider{}}
+	counter := &poolCountingProvider{inner: inner}
+	provider := NewHealthTrackingProvider(counter, health)
+	limiter := livechat.NewConcurrencyLimiter(1)
+	pool, err := NewPool(PoolConfig{
+		Provider:    provider,
+		Concurrency: limiter,
+		NewVMCode:   testVMCode(),
+		BuildSpec:   testBuildSpec,
+		Size:        1,
+		MaxWarmAge:  time.Minute,
+		Now:         func() time.Time { return now },
+		Health:      health,
+	})
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+
+	pool.maintain(context.Background())
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse after fill = %d, want 1", limiter.InUse())
+	}
+
+	inner.destroyErr = errors.New("provider rejected destroy")
+	now = now.Add(2 * time.Minute)
+	pool.maintain(context.Background())
+	if _, _, destroy, _ := counter.calls(); destroy != 1 {
+		t.Fatalf("destroy calls after failed stale recycle = %d, want 1", destroy)
+	}
+	if _, _, _, ok := pool.Acquire(); ok {
+		t.Fatal("fully quarantined VM was handed out; want no warm handout")
+	}
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse while quarantined = %d, want 1 (slot held for maybe-live VM)", limiter.InUse())
+	}
+
+	pool.maintain(context.Background())
+	if create, wait, destroy, list := counter.calls(); create != 1 || wait != 1 || destroy != 1 || list != 0 {
+		t.Fatalf("provider calls during backoff = create:%d wait:%d destroy:%d list:%d, want original counts 1/1/1/0", create, wait, destroy, list)
+	}
+
+	inner.destroyErr = nil
+	now = now.Add(providerBackoffBase)
+	pool.maintain(context.Background())
+	if create, wait, destroy, _ := counter.calls(); create != 2 || wait != 2 || destroy != 2 {
+		t.Fatalf("provider calls after quarantine recovery = create:%d wait:%d destroy:%d, want 2/2/2", create, wait, destroy)
+	}
+	if limiter.InUse() != 1 {
+		t.Fatalf("InUse after quarantine recovery/refill = %d, want 1", limiter.InUse())
 	}
 }
 

--- a/internal/playground/broker/pool_test.go
+++ b/internal/playground/broker/pool_test.go
@@ -719,6 +719,40 @@ func TestPoolMaintainSkipsProviderCallsWhileBackedOffAndResumes(t *testing.T) {
 	}
 }
 
+func TestPoolMaintainNeverHandsOutStaleVMWhileBackedOff(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	health := NewProviderHealth(func() time.Time { return now }, nil)
+	counter := &poolCountingProvider{inner: &fakeProvider{}}
+	limiter := livechat.NewConcurrencyLimiter(1)
+	pool, err := NewPool(PoolConfig{
+		Provider:    counter,
+		Concurrency: limiter,
+		NewVMCode:   testVMCode(),
+		BuildSpec:   testBuildSpec,
+		Size:        1,
+		MaxWarmAge:  time.Minute,
+		Now:         func() time.Time { return now },
+		Health:      health,
+	})
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+
+	pool.maintain(context.Background())
+	for range 6 {
+		health.RecordFailure(errors.New("provider rejected credential"))
+	}
+	now = now.Add(2 * time.Minute)
+	pool.maintain(context.Background())
+
+	if _, _, _, ok := pool.Acquire(); ok {
+		t.Fatal("stale warm VM was handed out while provider was backed off")
+	}
+	if _, _, destroy, _ := counter.calls(); destroy != 1 {
+		t.Fatalf("stale destroy attempts = %d, want 1", destroy)
+	}
+}
+
 func TestPoolNilHealthRetriesEveryMaintainTick(t *testing.T) {
 	counter := &poolCountingProvider{inner: &fakeProvider{createErr: errors.New("provider rejected credential")}}
 	limiter := livechat.NewConcurrencyLimiter(1)

--- a/internal/playground/broker/providerhealth.go
+++ b/internal/playground/broker/providerhealth.go
@@ -79,6 +79,10 @@ type ProviderHealth struct {
 	lastErrAt           time.Time
 	lastOKAt            time.Time
 	backoffUntil        time.Time
+	// provisioningFailure is set when CreateMachine failed. A successful
+	// list/destroy proves API reachability, but it does not prove the provider
+	// can create a visitor sandbox, so background success must not clear it.
+	provisioningFailure bool
 	// announcedFailing ensures the transition into "failing" is logged once,
 	// not on every retry. Without this the loud signal is itself the log spam.
 	announcedFailing bool
@@ -102,15 +106,39 @@ func (h *ProviderHealth) RecordSuccess() {
 		return
 	}
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	recovered := h.announcedFailing
 	h.consecutiveFailures = 0
 	h.lastErr = ""
 	h.backoffUntil = time.Time{}
 	h.lastOKAt = h.now()
 	h.announcedFailing = false
+	h.provisioningFailure = false
+	h.mu.Unlock()
 	if recovered {
 		_, _ = fmt.Fprintf(h.log, "provider: recovered; machine provider reachable again\n")
+	}
+}
+
+// RecordBackgroundSuccess clears failures caused by background provider work,
+// but never lets list/destroy success hide a failed sandbox creation.
+func (h *ProviderHealth) RecordBackgroundSuccess() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	if h.provisioningFailure {
+		h.mu.Unlock()
+		return
+	}
+	recovered := h.announcedFailing
+	h.consecutiveFailures = 0
+	h.lastErr = ""
+	h.backoffUntil = time.Time{}
+	h.lastOKAt = h.now()
+	h.announcedFailing = false
+	h.mu.Unlock()
+	if recovered {
+		_, _ = fmt.Fprint(h.log, "provider: recovered; machine provider reachable again\n")
 	}
 }
 
@@ -120,6 +148,16 @@ func (h *ProviderHealth) RecordSuccess() {
 // down or a caller timing out, not evidence that the provider is unusable.
 // Counting it would mark a healthy provider as failing during every shutdown.
 func (h *ProviderHealth) RecordFailure(err error) {
+	h.recordFailure(err, true)
+}
+
+// RecordBackgroundFailure records list/destroy failures without classifying
+// them as a failed provisioning attempt.
+func (h *ProviderHealth) RecordBackgroundFailure(err error) {
+	h.recordFailure(err, false)
+}
+
+func (h *ProviderHealth) recordFailure(err error, provisioning bool) {
 	if h == nil || err == nil {
 		return
 	}
@@ -127,18 +165,23 @@ func (h *ProviderHealth) RecordFailure(err error) {
 		return
 	}
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	h.consecutiveFailures++
+	if provisioning {
+		h.provisioningFailure = true
+	}
 	h.lastErr = truncateProviderErr(err.Error())
 	h.lastErrAt = h.now()
 	h.backoffUntil = h.now().Add(backoffFor(h.consecutiveFailures))
-	if h.consecutiveFailures >= providerFailingThreshold && !h.announcedFailing {
+	announce := h.consecutiveFailures >= providerFailingThreshold && !h.announcedFailing
+	failures := h.consecutiveFailures
+	if announce {
 		h.announcedFailing = true
-		// Loud, once. This is the signal whose absence let a five-day outage
-		// stay invisible.
+	}
+	h.mu.Unlock()
+	if announce {
 		_, _ = fmt.Fprintf(h.log,
 			"provider: FAILING after %d consecutive errors; broker cannot create sandboxes\n",
-			h.consecutiveFailures)
+			failures)
 	}
 }
 
@@ -249,19 +292,23 @@ func NewHealthTrackingProvider(inner MachineProvider, health *ProviderHealth) Ma
 
 func (p *healthTrackingProvider) CreateMachine(ctx context.Context, spec MachineSpec) (*Machine, error) {
 	m, err := p.inner.CreateMachine(ctx, spec)
-	p.record(err)
+	if err != nil {
+		p.health.RecordFailure(err)
+	} else {
+		p.health.RecordSuccess()
+	}
 	return m, err
 }
 
 func (p *healthTrackingProvider) DestroyMachine(ctx context.Context, id string) error {
 	err := p.inner.DestroyMachine(ctx, id)
-	p.record(err)
+	p.recordBackground(err)
 	return err
 }
 
 func (p *healthTrackingProvider) ListManagedMachines(ctx context.Context) ([]Machine, error) {
 	ms, err := p.inner.ListManagedMachines(ctx)
-	p.record(err)
+	p.recordBackground(err)
 	return ms, err
 }
 
@@ -274,10 +321,10 @@ func (p *healthTrackingProvider) WaitReady(ctx context.Context, id string) error
 	return p.inner.WaitReady(ctx, id)
 }
 
-func (p *healthTrackingProvider) record(err error) {
+func (p *healthTrackingProvider) recordBackground(err error) {
 	if err != nil {
-		p.health.RecordFailure(err)
+		p.health.RecordBackgroundFailure(err)
 		return
 	}
-	p.health.RecordSuccess()
+	p.health.RecordBackgroundSuccess()
 }

--- a/internal/playground/broker/providerhealth.go
+++ b/internal/playground/broker/providerhealth.go
@@ -177,14 +177,19 @@ func (h *ProviderHealth) recordFailure(err error, provisioning bool) {
 	h.backoffUntil = h.now().Add(backoffFor(h.consecutiveFailures))
 	announce := h.consecutiveFailures >= providerFailingThreshold && !h.announcedFailing
 	failures := h.consecutiveFailures
+	provisioningFailure := h.provisioningFailure
 	if announce {
 		h.announcedFailing = true
 	}
 	h.mu.Unlock()
 	if announce {
-		h.writeLog(
-			"provider: FAILING after %d consecutive errors; broker cannot create sandboxes\n",
-			failures)
+		if provisioningFailure {
+			h.writeLog(
+				"provider: FAILING after %d consecutive errors; broker cannot create sandboxes\n",
+				failures)
+		} else {
+			h.writeLog("provider: FAILING after %d consecutive background errors\n", failures)
+		}
 	}
 }
 

--- a/internal/playground/broker/providerhealth.go
+++ b/internal/playground/broker/providerhealth.go
@@ -115,7 +115,7 @@ func (h *ProviderHealth) RecordSuccess() {
 	h.provisioningFailure = false
 	h.mu.Unlock()
 	if recovered {
-		_, _ = fmt.Fprintf(h.log, "provider: recovered; machine provider reachable again\n")
+		h.logRecovered()
 	}
 }
 
@@ -138,15 +138,16 @@ func (h *ProviderHealth) RecordBackgroundSuccess() {
 	h.announcedFailing = false
 	h.mu.Unlock()
 	if recovered {
-		_, _ = fmt.Fprint(h.log, "provider: recovered; machine provider reachable again\n")
+		h.logRecovered()
 	}
 }
 
 // RecordFailure counts a failed provider call and extends the backoff window.
 //
 // Context cancellation is NOT counted: a cancelled call is the broker shutting
-// down or a caller timing out, not evidence that the provider is unusable.
-// Counting it would mark a healthy provider as failing during every shutdown.
+// down, not evidence that the provider is unusable. DeadlineExceeded IS counted:
+// a provider operation that cannot finish inside its bounded deadline is an
+// availability failure and must not leave provider health looking OK.
 func (h *ProviderHealth) RecordFailure(err error) {
 	h.recordFailure(err, true)
 }
@@ -183,6 +184,10 @@ func (h *ProviderHealth) recordFailure(err error, provisioning bool) {
 			"provider: FAILING after %d consecutive errors; broker cannot create sandboxes\n",
 			failures)
 	}
+}
+
+func (h *ProviderHealth) logRecovered() {
+	_, _ = fmt.Fprint(h.log, "provider: recovered; machine provider reachable again\n")
 }
 
 // BackoffActive reports whether the caller should skip this round of background

--- a/internal/playground/broker/providerhealth.go
+++ b/internal/playground/broker/providerhealth.go
@@ -1,0 +1,283 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// ProviderState is the coarse, operator-facing verdict on whether the broker can
+// currently reach and use its machine provider.
+type ProviderState string
+
+const (
+	// ProviderStateUnknown means no provider call has completed yet. It is a
+	// startup-only state: the orphan reaper reconciles unconditionally, so a
+	// running broker leaves "unknown" within one reaper interval even when the
+	// warm pool is disabled.
+	ProviderStateUnknown ProviderState = "unknown"
+	// ProviderStateOK means the last provider call succeeded.
+	ProviderStateOK ProviderState = "ok"
+	// ProviderStateDegraded means calls are failing but not yet enough
+	// consecutive failures to call the provider unusable.
+	ProviderStateDegraded ProviderState = "degraded"
+	// ProviderStateFailing means providerFailingThreshold consecutive calls have
+	// failed. The broker cannot create sandboxes; visitor sessions are failing.
+	ProviderStateFailing ProviderState = "failing"
+)
+
+const (
+	// providerFailingThreshold is how many consecutive provider failures before
+	// the broker declares itself unable to serve. Kept small so a genuine
+	// outage surfaces in seconds, but above 1 so a single transient blip does
+	// not page an operator.
+	providerFailingThreshold = 3
+
+	// providerBackoffBase is the first backoff delay after a failure, and
+	// providerBackoffMax caps the exponential growth.
+	//
+	// WHY THIS EXISTS: a persistently rejected credential previously produced a
+	// 2-second retry loop that ran for five days (~86k rejected API calls/day).
+	// Backoff converts that into ~288 calls/day at the cap while still
+	// recovering automatically within five minutes of the provider returning.
+	providerBackoffBase = 5 * time.Second
+	providerBackoffMax  = 5 * time.Minute
+
+	// providerErrMaxLen bounds the stored error string. It is kept in the
+	// snapshot for internal callers, so it is truncated and never assumed short.
+	providerErrMaxLen = 200
+)
+
+// ProviderHealth records the outcome of machine-provider calls so that
+//
+//  1. /api/live/health can report whether the broker can actually create
+//     sandboxes, instead of reporting only on its own internal counters, and
+//  2. the warm-pool maintainer can back off instead of hot-looping against a
+//     failure that will not clear on its own.
+//
+// It is safe for concurrent use.
+//
+// DELIBERATELY NOT A CIRCUIT BREAKER ON THE VISITOR PATH: this type records and
+// advises, it never blocks a call. The warm pool consults it; the visitor's
+// cold-lease path does not. Denying a visitor's session because earlier
+// background calls failed would turn a cost optimisation into an outage, and a
+// visitor request may well be the call that succeeds. A visitor still gets a
+// real attempt and, if it genuinely fails, a real error.
+type ProviderHealth struct {
+	now func() time.Time
+	log io.Writer
+
+	mu                  sync.Mutex
+	consecutiveFailures int
+	lastErr             string
+	lastErrAt           time.Time
+	lastOKAt            time.Time
+	backoffUntil        time.Time
+	// announcedFailing ensures the transition into "failing" is logged once,
+	// not on every retry. Without this the loud signal is itself the log spam.
+	announcedFailing bool
+}
+
+// NewProviderHealth returns a tracker. now may be nil (uses time.Now); log may
+// be nil (discards).
+func NewProviderHealth(now func() time.Time, log io.Writer) *ProviderHealth {
+	if now == nil {
+		now = time.Now
+	}
+	if log == nil {
+		log = io.Discard
+	}
+	return &ProviderHealth{now: now, log: log}
+}
+
+// RecordSuccess clears the failure streak and any active backoff.
+func (h *ProviderHealth) RecordSuccess() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	recovered := h.announcedFailing
+	h.consecutiveFailures = 0
+	h.lastErr = ""
+	h.backoffUntil = time.Time{}
+	h.lastOKAt = h.now()
+	h.announcedFailing = false
+	if recovered {
+		_, _ = fmt.Fprintf(h.log, "provider: recovered; machine provider reachable again\n")
+	}
+}
+
+// RecordFailure counts a failed provider call and extends the backoff window.
+//
+// Context cancellation is NOT counted: a cancelled call is the broker shutting
+// down or a caller timing out, not evidence that the provider is unusable.
+// Counting it would mark a healthy provider as failing during every shutdown.
+func (h *ProviderHealth) RecordFailure(err error) {
+	if h == nil || err == nil {
+		return
+	}
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.consecutiveFailures++
+	h.lastErr = truncateProviderErr(err.Error())
+	h.lastErrAt = h.now()
+	h.backoffUntil = h.now().Add(backoffFor(h.consecutiveFailures))
+	if h.consecutiveFailures >= providerFailingThreshold && !h.announcedFailing {
+		h.announcedFailing = true
+		// Loud, once. This is the signal whose absence let a five-day outage
+		// stay invisible.
+		_, _ = fmt.Fprintf(h.log,
+			"provider: FAILING after %d consecutive errors; broker cannot create sandboxes\n",
+			h.consecutiveFailures)
+	}
+}
+
+// BackoffActive reports whether the caller should skip this round of background
+// provider work, and until when.
+func (h *ProviderHealth) BackoffActive() (until time.Time, active bool) {
+	if h == nil {
+		return time.Time{}, false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.backoffUntil.IsZero() {
+		return time.Time{}, false
+	}
+	if h.now().Before(h.backoffUntil) {
+		return h.backoffUntil, true
+	}
+	return h.backoffUntil, false
+}
+
+// ProviderHealthSnapshot is an immutable view for the health endpoint.
+type ProviderHealthSnapshot struct {
+	OK                  bool
+	State               ProviderState
+	ConsecutiveFailures int
+	LastErr             string
+	LastErrAt           time.Time
+	LastOKAt            time.Time
+	BackoffUntil        time.Time
+}
+
+// Snapshot returns the current provider health.
+//
+// OK is true unless the provider is FAILING. "unknown" and "degraded" report OK
+// so that a broker restart, or one transient blip, does not read as an outage;
+// State carries the finer detail for an operator.
+func (h *ProviderHealth) Snapshot() ProviderHealthSnapshot {
+	if h == nil {
+		return ProviderHealthSnapshot{OK: true, State: ProviderStateUnknown}
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	state := ProviderStateUnknown
+	switch {
+	case h.consecutiveFailures >= providerFailingThreshold:
+		state = ProviderStateFailing
+	case h.consecutiveFailures > 0:
+		state = ProviderStateDegraded
+	case !h.lastOKAt.IsZero():
+		state = ProviderStateOK
+	}
+	return ProviderHealthSnapshot{
+		OK:                  state != ProviderStateFailing,
+		State:               state,
+		ConsecutiveFailures: h.consecutiveFailures,
+		LastErr:             h.lastErr,
+		LastErrAt:           h.lastErrAt,
+		LastOKAt:            h.lastOKAt,
+		BackoffUntil:        h.backoffUntil,
+	}
+}
+
+func backoffFor(failures int) time.Duration {
+	if failures <= 0 {
+		return 0
+	}
+	d := providerBackoffBase
+	for i := 1; i < failures; i++ {
+		d *= 2
+		if d >= providerBackoffMax {
+			return providerBackoffMax
+		}
+	}
+	if d > providerBackoffMax {
+		return providerBackoffMax
+	}
+	return d
+}
+
+func truncateProviderErr(s string) string {
+	if len(s) <= providerErrMaxLen {
+		return s
+	}
+	return s[:providerErrMaxLen] + "..."
+}
+
+// healthTrackingProvider wraps a MachineProvider and feeds every reachability-
+// relevant call outcome into a ProviderHealth.
+//
+// WHY A WRAPPER: the three independent consumers of the provider (warm pool,
+// lease manager, orphan reaper) would otherwise each need their own bookkeeping
+// calls, and any future consumer would silently not report. Wrapping means the
+// reaper alone — which runs unconditionally every couple of minutes — is enough
+// to keep provider health fresh even when the warm pool is disabled.
+type healthTrackingProvider struct {
+	inner  MachineProvider
+	health *ProviderHealth
+}
+
+// NewHealthTrackingProvider wraps inner so its call outcomes update health.
+// Returns inner unchanged when health is nil.
+func NewHealthTrackingProvider(inner MachineProvider, health *ProviderHealth) MachineProvider {
+	if health == nil {
+		return inner
+	}
+	return &healthTrackingProvider{inner: inner, health: health}
+}
+
+func (p *healthTrackingProvider) CreateMachine(ctx context.Context, spec MachineSpec) (*Machine, error) {
+	m, err := p.inner.CreateMachine(ctx, spec)
+	p.record(err)
+	return m, err
+}
+
+func (p *healthTrackingProvider) DestroyMachine(ctx context.Context, id string) error {
+	err := p.inner.DestroyMachine(ctx, id)
+	p.record(err)
+	return err
+}
+
+func (p *healthTrackingProvider) ListManagedMachines(ctx context.Context) ([]Machine, error) {
+	ms, err := p.inner.ListManagedMachines(ctx)
+	p.record(err)
+	return ms, err
+}
+
+// WaitReady is deliberately NOT tracked. Its failure means a VM did not boot in
+// time, which is a guest problem, not evidence that the provider API is
+// unreachable or unauthorised. Counting it would let slow boots trip the
+// provider-failing signal and mask the credential class of failure this tracker
+// exists to catch.
+func (p *healthTrackingProvider) WaitReady(ctx context.Context, id string) error {
+	return p.inner.WaitReady(ctx, id)
+}
+
+func (p *healthTrackingProvider) record(err error) {
+	if err != nil {
+		p.health.RecordFailure(err)
+		return
+	}
+	p.health.RecordSuccess()
+}

--- a/internal/playground/broker/providerhealth.go
+++ b/internal/playground/broker/providerhealth.go
@@ -186,6 +186,7 @@ func (h *ProviderHealth) recordFailure(err error, provisioning bool) {
 	}
 }
 
+// logRecovered emits the shared recovery transition after the state lock is released.
 func (h *ProviderHealth) logRecovered() {
 	_, _ = fmt.Fprint(h.log, "provider: recovered; machine provider reachable again\n")
 }

--- a/internal/playground/broker/providerhealth.go
+++ b/internal/playground/broker/providerhealth.go
@@ -73,7 +73,9 @@ type ProviderHealth struct {
 	now func() time.Time
 	log io.Writer
 
-	mu                  sync.Mutex
+	mu    sync.Mutex
+	logMu sync.Mutex
+
 	consecutiveFailures int
 	lastErr             string
 	lastErrAt           time.Time
@@ -180,7 +182,7 @@ func (h *ProviderHealth) recordFailure(err error, provisioning bool) {
 	}
 	h.mu.Unlock()
 	if announce {
-		_, _ = fmt.Fprintf(h.log,
+		h.writeLog(
 			"provider: FAILING after %d consecutive errors; broker cannot create sandboxes\n",
 			failures)
 	}
@@ -188,7 +190,13 @@ func (h *ProviderHealth) recordFailure(err error, provisioning bool) {
 
 // logRecovered emits the shared recovery transition after the state lock is released.
 func (h *ProviderHealth) logRecovered() {
-	_, _ = fmt.Fprint(h.log, "provider: recovered; machine provider reachable again\n")
+	h.writeLog("provider: recovered; machine provider reachable again\n")
+}
+
+func (h *ProviderHealth) writeLog(format string, args ...any) {
+	h.logMu.Lock()
+	defer h.logMu.Unlock()
+	_, _ = fmt.Fprintf(h.log, format, args...)
 }
 
 // BackoffActive reports whether the caller should skip this round of background

--- a/internal/playground/broker/providerhealth_test.go
+++ b/internal/playground/broker/providerhealth_test.go
@@ -173,6 +173,23 @@ func TestProviderHealthBackgroundSuccessDoesNotHideCreateFailure(t *testing.T) {
 	}
 }
 
+func TestProviderHealthBackgroundFailureLogDoesNotClaimCreateFailure(t *testing.T) {
+	var log bytes.Buffer
+	health := NewProviderHealth(nil, &log)
+
+	for range providerFailingThreshold {
+		health.RecordBackgroundFailure(errors.New("provider unavailable"))
+	}
+
+	got := log.String()
+	if !strings.Contains(got, "consecutive background errors") {
+		t.Fatalf("background failure log = %q, want generic background failure", got)
+	}
+	if strings.Contains(got, "cannot create sandboxes") {
+		t.Fatalf("background failure log falsely claims create failure: %q", got)
+	}
+}
+
 func TestProviderHealthBackgroundSuccessClearsBackgroundFailure(t *testing.T) {
 	health := NewProviderHealth(func() time.Time {
 		return time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)

--- a/internal/playground/broker/providerhealth_test.go
+++ b/internal/playground/broker/providerhealth_test.go
@@ -13,6 +13,17 @@ import (
 	"time"
 )
 
+type blockingProviderLog struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (w *blockingProviderLog) Write(p []byte) (int, error) {
+	close(w.entered)
+	<-w.release
+	return len(p), nil
+}
+
 func TestProviderHealthPersistentFailureLogsOnce(t *testing.T) {
 	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
 	var log bytes.Buffer
@@ -57,6 +68,33 @@ func TestProviderHealthFailingLogOmitsRawProviderError(t *testing.T) {
 	if strings.Contains(got, errText) || strings.Contains(got, "secret-token-value") || strings.Contains(got, "outer-code") {
 		t.Fatalf("failure log exposed raw provider error: %q", got)
 	}
+}
+
+func TestProviderHealthLoggingDoesNotHoldStateMutex(t *testing.T) {
+	log := &blockingProviderLog{entered: make(chan struct{}), release: make(chan struct{})}
+	health := NewProviderHealth(nil, log)
+	for range providerFailingThreshold - 1 {
+		health.RecordFailure(errors.New("provider unavailable"))
+	}
+	done := make(chan struct{})
+	go func() {
+		health.RecordFailure(errors.New("provider unavailable"))
+		close(done)
+	}()
+	<-log.entered
+
+	snapshotDone := make(chan struct{})
+	go func() {
+		_ = health.Snapshot()
+		close(snapshotDone)
+	}()
+	select {
+	case <-snapshotDone:
+	case <-time.After(time.Second):
+		t.Fatal("Snapshot blocked behind provider log write")
+	}
+	close(log.release)
+	<-done
 }
 
 func TestProviderHealthBackoffGrowthAndCap(t *testing.T) {
@@ -113,6 +151,44 @@ func TestProviderHealthRecoveryResetsBackoffAndLogsOnce(t *testing.T) {
 	}
 	if got := strings.Count(log.String(), "machine provider reachable again"); got != 1 {
 		t.Fatalf("recovery log count = %d, want 1; log=%q", got, log.String())
+	}
+}
+
+func TestProviderHealthBackgroundSuccessDoesNotHideCreateFailure(t *testing.T) {
+	health := NewProviderHealth(func() time.Time {
+		return time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	}, nil)
+	provider := NewHealthTrackingProvider(&fakeProvider{createErr: errors.New("create denied")}, health)
+
+	for range providerFailingThreshold {
+		_, _ = provider.CreateMachine(context.Background(), MachineSpec{Image: testImage})
+	}
+	if _, err := provider.ListManagedMachines(context.Background()); err != nil {
+		t.Fatalf("ListManagedMachines: %v", err)
+	}
+
+	snap := health.Snapshot()
+	if snap.OK || snap.State != ProviderStateFailing || snap.ConsecutiveFailures != providerFailingThreshold {
+		t.Fatalf("background success hid create failure: %+v", snap)
+	}
+}
+
+func TestProviderHealthBackgroundSuccessClearsBackgroundFailure(t *testing.T) {
+	health := NewProviderHealth(func() time.Time {
+		return time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	}, nil)
+	inner := &fakeProvider{listErr: errors.New("list denied")}
+	provider := NewHealthTrackingProvider(inner, health)
+
+	_, _ = provider.ListManagedMachines(context.Background())
+	inner.listErr = nil
+	if _, err := provider.ListManagedMachines(context.Background()); err != nil {
+		t.Fatalf("ListManagedMachines recovery: %v", err)
+	}
+
+	snap := health.Snapshot()
+	if !snap.OK || snap.State != ProviderStateOK || snap.ConsecutiveFailures != 0 {
+		t.Fatalf("background recovery did not clear background failure: %+v", snap)
 	}
 }
 
@@ -173,6 +249,8 @@ func TestProviderHealthConcurrentAccessRace(t *testing.T) {
 			defer wg.Done()
 			for range 100 {
 				health.RecordFailure(errors.New("provider unavailable"))
+				health.RecordBackgroundFailure(errors.New("provider unavailable"))
+				health.RecordBackgroundSuccess()
 				health.RecordSuccess()
 				_, _ = health.BackoffActive()
 				_ = health.Snapshot()

--- a/internal/playground/broker/providerhealth_test.go
+++ b/internal/playground/broker/providerhealth_test.go
@@ -298,9 +298,10 @@ func TestNewHealthTrackingProviderNilHealthReturnsInner(t *testing.T) {
 }
 
 func TestProviderHealthConcurrentAccessRace(t *testing.T) {
+	var log bytes.Buffer
 	health := NewProviderHealth(func() time.Time {
 		return time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
-	}, nil)
+	}, &log)
 
 	var wg sync.WaitGroup
 	for range 8 {

--- a/internal/playground/broker/providerhealth_test.go
+++ b/internal/playground/broker/providerhealth_test.go
@@ -209,6 +209,22 @@ func TestProviderHealthContextCanceledDoesNotCount(t *testing.T) {
 	}
 }
 
+func TestProviderHealthDeadlineExceededCounts(t *testing.T) {
+	health := NewProviderHealth(func() time.Time {
+		return time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	}, nil)
+
+	health.RecordFailure(context.DeadlineExceeded)
+
+	snap := health.Snapshot()
+	if snap.State != ProviderStateDegraded || !snap.OK || snap.ConsecutiveFailures != 1 {
+		t.Fatalf("snapshot after deadline exceeded = %+v, want degraded/ok/one failure", snap)
+	}
+	if _, active := health.BackoffActive(); !active {
+		t.Fatal("deadline exceeded did not activate backoff")
+	}
+}
+
 func TestHealthTrackingProviderWaitReadyFailureDoesNotAffectHealth(t *testing.T) {
 	health := NewProviderHealth(func() time.Time {
 		return time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)

--- a/internal/playground/broker/providerhealth_test.go
+++ b/internal/playground/broker/providerhealth_test.go
@@ -246,6 +246,50 @@ func TestHealthTrackingProviderWaitReadyFailureDoesNotAffectHealth(t *testing.T)
 	}
 }
 
+func TestHealthTrackingProviderDestroyMachineTracksAndPropagates(t *testing.T) {
+	health := NewProviderHealth(nil, nil)
+	destroyErr := errors.New("destroy denied")
+	inner := &destroyErrProvider{fakeProvider: &fakeProvider{}, destroyErr: destroyErr}
+	provider := NewHealthTrackingProvider(inner, health)
+
+	if err := provider.DestroyMachine(context.Background(), "vm-1"); !errors.Is(err, destroyErr) {
+		t.Fatalf("DestroyMachine error = %v, want %v", err, destroyErr)
+	}
+	if snap := health.Snapshot(); snap.State != ProviderStateDegraded || snap.ConsecutiveFailures != 1 {
+		t.Fatalf("snapshot after destroy failure = %+v, want degraded/one failure", snap)
+	}
+
+	inner.destroyErr = nil
+	if err := provider.DestroyMachine(context.Background(), "vm-1"); err != nil {
+		t.Fatalf("DestroyMachine recovery: %v", err)
+	}
+	if snap := health.Snapshot(); snap.State != ProviderStateOK || snap.ConsecutiveFailures != 0 {
+		t.Fatalf("snapshot after destroy recovery = %+v, want ok/no failures", snap)
+	}
+}
+
+func TestHealthTrackingProviderListMachinesTracksAndPropagates(t *testing.T) {
+	health := NewProviderHealth(nil, nil)
+	listErr := errors.New("list denied")
+	inner := &fakeProvider{listErr: listErr}
+	provider := NewHealthTrackingProvider(inner, health)
+
+	if _, err := provider.ListManagedMachines(context.Background()); !errors.Is(err, listErr) {
+		t.Fatalf("ListManagedMachines error = %v, want %v", err, listErr)
+	}
+	if snap := health.Snapshot(); snap.State != ProviderStateDegraded || snap.ConsecutiveFailures != 1 {
+		t.Fatalf("snapshot after list failure = %+v, want degraded/one failure", snap)
+	}
+
+	inner.listErr = nil
+	if _, err := provider.ListManagedMachines(context.Background()); err != nil {
+		t.Fatalf("ListManagedMachines recovery: %v", err)
+	}
+	if snap := health.Snapshot(); snap.State != ProviderStateOK || snap.ConsecutiveFailures != 0 {
+		t.Fatalf("snapshot after list recovery = %+v, want ok/no failures", snap)
+	}
+}
+
 func TestNewHealthTrackingProviderNilHealthReturnsInner(t *testing.T) {
 	inner := &fakeProvider{}
 	if got := NewHealthTrackingProvider(inner, nil); got != inner {

--- a/internal/playground/broker/providerhealth_test.go
+++ b/internal/playground/broker/providerhealth_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestProviderHealthPersistentFailureLogsOnce(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	var log bytes.Buffer
+	health := NewProviderHealth(func() time.Time { return now }, &log)
+	provider := NewHealthTrackingProvider(&fakeProvider{createErr: errors.New("provider rejected credential")}, health)
+
+	for range providerFailingThreshold + 5 {
+		if _, err := provider.CreateMachine(context.Background(), MachineSpec{Image: testImage}); err == nil {
+			t.Fatal("CreateMachine succeeded, want failure")
+		}
+	}
+
+	snap := health.Snapshot()
+	if snap.OK {
+		t.Fatal("Snapshot.OK = true after persistent failures, want false")
+	}
+	if snap.State != ProviderStateFailing {
+		t.Fatalf("state = %s, want %s", snap.State, ProviderStateFailing)
+	}
+	if snap.ConsecutiveFailures != providerFailingThreshold+5 {
+		t.Fatalf("failures = %d, want %d", snap.ConsecutiveFailures, providerFailingThreshold+5)
+	}
+	if got := strings.Count(log.String(), "broker cannot create sandboxes"); got != 1 {
+		t.Fatalf("broker-cannot-create-sandboxes log count = %d, want 1; log=%q", got, log.String())
+	}
+}
+
+func TestProviderHealthFailingLogOmitsRawProviderError(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	var log bytes.Buffer
+	health := NewProviderHealth(func() time.Time { return now }, &log)
+	errText := "provider rejected token secret-token-value for invite outer-code"
+
+	for range providerFailingThreshold {
+		health.RecordFailure(errors.New(errText))
+	}
+
+	got := log.String()
+	if !strings.Contains(got, "broker cannot create sandboxes") {
+		t.Fatalf("failure log missing outage signal: %q", got)
+	}
+	if strings.Contains(got, errText) || strings.Contains(got, "secret-token-value") || strings.Contains(got, "outer-code") {
+		t.Fatalf("failure log exposed raw provider error: %q", got)
+	}
+}
+
+func TestProviderHealthBackoffGrowthAndCap(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	health := NewProviderHealth(func() time.Time { return now }, nil)
+	want := []time.Duration{
+		5 * time.Second,
+		10 * time.Second,
+		20 * time.Second,
+		40 * time.Second,
+		80 * time.Second,
+		160 * time.Second,
+		providerBackoffMax,
+		providerBackoffMax,
+	}
+
+	for i, delay := range want {
+		health.RecordFailure(errors.New("provider unavailable"))
+		until, active := health.BackoffActive()
+		if !active {
+			t.Fatalf("failure %d: backoff inactive, want active", i+1)
+		}
+		if got := until.Sub(now); got != delay {
+			t.Fatalf("failure %d: backoff = %s, want %s", i+1, got, delay)
+		}
+	}
+}
+
+func TestProviderHealthRecoveryResetsBackoffAndLogsOnce(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	var log bytes.Buffer
+	health := NewProviderHealth(func() time.Time { return now }, &log)
+
+	for range providerFailingThreshold {
+		health.RecordFailure(errors.New("provider unavailable"))
+	}
+	if snap := health.Snapshot(); snap.State != ProviderStateFailing {
+		t.Fatalf("state before recovery = %s, want failing", snap.State)
+	}
+
+	now = now.Add(time.Minute)
+	health.RecordSuccess()
+	health.RecordSuccess()
+
+	snap := health.Snapshot()
+	if !snap.OK || snap.State != ProviderStateOK {
+		t.Fatalf("snapshot after recovery = ok:%v state:%s, want ok:true state:ok", snap.OK, snap.State)
+	}
+	if snap.ConsecutiveFailures != 0 {
+		t.Fatalf("failures after recovery = %d, want 0", snap.ConsecutiveFailures)
+	}
+	if _, active := health.BackoffActive(); active {
+		t.Fatal("backoff active after recovery")
+	}
+	if got := strings.Count(log.String(), "machine provider reachable again"); got != 1 {
+		t.Fatalf("recovery log count = %d, want 1; log=%q", got, log.String())
+	}
+}
+
+func TestProviderHealthContextCanceledDoesNotCount(t *testing.T) {
+	health := NewProviderHealth(func() time.Time {
+		return time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	}, nil)
+
+	health.RecordFailure(context.Canceled)
+	health.RecordFailure(errors.Join(errors.New("wrapped"), context.Canceled))
+
+	snap := health.Snapshot()
+	if snap.State != ProviderStateUnknown || !snap.OK || snap.ConsecutiveFailures != 0 {
+		t.Fatalf("snapshot after context cancellation = %+v, want unknown/ok/no failures", snap)
+	}
+	if _, active := health.BackoffActive(); active {
+		t.Fatal("context cancellation activated backoff")
+	}
+}
+
+func TestHealthTrackingProviderWaitReadyFailureDoesNotAffectHealth(t *testing.T) {
+	health := NewProviderHealth(func() time.Time {
+		return time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	}, nil)
+	inner := &fakeProvider{waitErr: errors.New("guest never started")}
+	provider := NewHealthTrackingProvider(inner, health)
+
+	m, err := provider.CreateMachine(context.Background(), MachineSpec{Image: testImage})
+	if err != nil {
+		t.Fatalf("CreateMachine: %v", err)
+	}
+	if err := provider.WaitReady(context.Background(), m.ID); err == nil {
+		t.Fatal("WaitReady succeeded, want failure")
+	}
+
+	snap := health.Snapshot()
+	if snap.State != ProviderStateOK || !snap.OK || snap.ConsecutiveFailures != 0 {
+		t.Fatalf("snapshot after WaitReady failure = %+v, want ok/no failures", snap)
+	}
+}
+
+func TestNewHealthTrackingProviderNilHealthReturnsInner(t *testing.T) {
+	inner := &fakeProvider{}
+	if got := NewHealthTrackingProvider(inner, nil); got != inner {
+		t.Fatalf("NewHealthTrackingProvider nil health returned %T, want original provider", got)
+	}
+}
+
+func TestProviderHealthConcurrentAccessRace(t *testing.T) {
+	health := NewProviderHealth(func() time.Time {
+		return time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	}, nil)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				health.RecordFailure(errors.New("provider unavailable"))
+				health.RecordSuccess()
+				_, _ = health.BackoffActive()
+				_ = health.Snapshot()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -135,6 +135,10 @@ type ServerConfig struct {
 	TrustForwardedFor bool
 	// AllowOrigin sets Access-Control-Allow-Origin. Empty disables CORS headers.
 	AllowOrigin string
+	// ProviderHealth, when non-nil, lets /api/live/health report whether the
+	// broker can actually reach its machine provider. Nil reports the provider
+	// as "unknown", preserving the previous response shape's meaning.
+	ProviderHealth *ProviderHealth
 }
 
 // Server is the broker HTTP front door. It is safe for concurrent use.
@@ -442,8 +446,28 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		writeBrokerErr(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
+	ph := s.cfg.ProviderHealth.Snapshot()
+	// HTTP 200 and the meaning of "ok" are BOTH preserved deliberately.
+	//
+	// "ok" continues to report only the broker's own gates (demo enabled, budget
+	// left, kill switch off) because the browser viewer and the pipelab.org
+	// iframe already consume it; redefining it would change their behaviour as a
+	// side effect of adding observability. Provider reachability is reported
+	// alongside it as provider_ok, which is what an uptime monitor should watch.
+	//
+	// Status stays 200 even when the provider is failing: the machine config
+	// currently defines no platform health check, but if one were ever added, a
+	// non-2xx here would make the platform restart or de-list the broker — an
+	// honest signal causing a self-inflicted outage. Report the failure in the
+	// body, not the status line.
 	writeBrokerJSON(w, http.StatusOK, map[string]any{
 		"ok":                         s.cfg.Gate.Open() && s.global.Open() && !s.killed.Load(),
+		"provider_ok":                ph.OK,
+		"provider_state":             string(ph.State),
+		"provider_failures":          ph.ConsecutiveFailures,
+		"last_provider_error_at":     nullableRFC3339(ph.LastErrAt),
+		"last_provider_success_at":   nullableRFC3339(ph.LastOKAt),
+		"pool_backoff_until":         nullableRFC3339(ph.BackoffUntil),
 		"in_use":                     s.cfg.Leases.ActiveLeases(),
 		"capacity":                   s.cfg.Leases.cfg.Concurrency.Cap(),
 		"budget_remaining":           s.global.Remaining(),
@@ -457,6 +481,15 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		// the viewer renders the widget and sends turnstile_token when present.
 		"turnstile_sitekey": s.cfg.TurnstileSitekey,
 	})
+}
+
+// nullableRFC3339 renders t as an RFC3339 string, or JSON null when unset, so a
+// consumer can distinguish "never happened" from a zero-value timestamp.
+func nullableRFC3339(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t.UTC().Format(time.RFC3339)
 }
 
 func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -515,6 +515,124 @@ func TestServerHealthCORSKillAndResume(t *testing.T) {
 	}
 }
 
+func TestServerHealthProviderFieldsByState(t *testing.T) {
+	base := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		mutate      func(*ProviderHealth)
+		wantOK      bool
+		wantState   string
+		wantFails   float64
+		wantErrAt   any
+		wantOKAt    any
+		wantBackoff any
+	}{
+		{
+			name:        "first_boot_unknown",
+			wantOK:      true,
+			wantState:   string(ProviderStateUnknown),
+			wantFails:   0,
+			wantErrAt:   nil,
+			wantOKAt:    nil,
+			wantBackoff: nil,
+		},
+		{
+			name: "reachable_ok",
+			mutate: func(h *ProviderHealth) {
+				h.RecordSuccess()
+			},
+			wantOK:      true,
+			wantState:   string(ProviderStateOK),
+			wantFails:   0,
+			wantErrAt:   nil,
+			wantOKAt:    base.Format(time.RFC3339),
+			wantBackoff: nil,
+		},
+		{
+			name: "intermittently_failing_degraded",
+			mutate: func(h *ProviderHealth) {
+				h.RecordFailure(errors.New("provider rejected credential"))
+			},
+			wantOK:      true,
+			wantState:   string(ProviderStateDegraded),
+			wantFails:   1,
+			wantErrAt:   base.Format(time.RFC3339),
+			wantOKAt:    nil,
+			wantBackoff: base.Add(providerBackoffBase).Format(time.RFC3339),
+		},
+		{
+			name: "persistently_rejecting_failing",
+			mutate: func(h *ProviderHealth) {
+				for range providerFailingThreshold {
+					h.RecordFailure(errors.New("provider rejected credential"))
+				}
+			},
+			wantOK:      false,
+			wantState:   string(ProviderStateFailing),
+			wantFails:   providerFailingThreshold,
+			wantErrAt:   base.Format(time.RFC3339),
+			wantOKAt:    nil,
+			wantBackoff: base.Add(20 * time.Second).Format(time.RFC3339),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			health := NewProviderHealth(func() time.Time { return base }, nil)
+			if tt.mutate != nil {
+				tt.mutate(health)
+			}
+			_, ts := newBrokerTestServer(t, &serverFakeProvider{}, ServerConfig{ProviderHealth: health})
+
+			body := getBrokerHealth(t, ts)
+			if body["ok"] != true {
+				t.Fatalf("ok = %v, want true; provider state must not change original ok meaning", body["ok"])
+			}
+			if body["provider_ok"] != tt.wantOK {
+				t.Fatalf("provider_ok = %v, want %v", body["provider_ok"], tt.wantOK)
+			}
+			if body["provider_state"] != tt.wantState {
+				t.Fatalf("provider_state = %v, want %s", body["provider_state"], tt.wantState)
+			}
+			if body["provider_failures"] != tt.wantFails {
+				t.Fatalf("provider_failures = %v, want %v", body["provider_failures"], tt.wantFails)
+			}
+			if body["last_provider_error_at"] != tt.wantErrAt {
+				t.Fatalf("last_provider_error_at = %#v, want %#v", body["last_provider_error_at"], tt.wantErrAt)
+			}
+			if body["last_provider_success_at"] != tt.wantOKAt {
+				t.Fatalf("last_provider_success_at = %#v, want %#v", body["last_provider_success_at"], tt.wantOKAt)
+			}
+			if body["pool_backoff_until"] != tt.wantBackoff {
+				t.Fatalf("pool_backoff_until = %#v, want %#v", body["pool_backoff_until"], tt.wantBackoff)
+			}
+		})
+	}
+}
+
+func TestServerProviderBackoffDoesNotBlockColdLease(t *testing.T) {
+	base := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	health := NewProviderHealth(func() time.Time { return base }, nil)
+	for range providerFailingThreshold {
+		health.RecordFailure(errors.New("previous background provider failure"))
+	}
+	if _, active := health.BackoffActive(); !active {
+		t.Fatal("test setup: backoff should be active")
+	}
+
+	vm := newFakeVM(t, "cold-lease-token")
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{ProviderHealth: health})
+
+	status, _ := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("cold lease status while provider backoff active = %d, want 200", status)
+	}
+	if got := provider.createdCount(); got != 1 {
+		t.Fatalf("provider create calls = %d, want 1; cold path must not consult backoff", got)
+	}
+}
+
 func getBrokerHealth(t *testing.T, ts *httptest.Server) map[string]any {
 	t.Helper()
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+livechat.RouteHealth, nil)

--- a/internal/sandbox/bridge.go
+++ b/internal/sandbox/bridge.go
@@ -125,6 +125,11 @@ func (bp *BridgeProxy) Close() {
 		bp.wg.Wait()
 		if waitForWatcher {
 			<-bp.watcherDone
+		} else {
+			// Serve may not have started yet even though the listener already
+			// accepted a queued connection. Complete the watcher lifecycle so
+			// a later Serve observes closed and callers never wait forever.
+			bp.watcherDoneOnce.Do(func() { close(bp.watcherDone) })
 		}
 	})
 }

--- a/internal/sandbox/bridge_test.go
+++ b/internal/sandbox/bridge_test.go
@@ -254,6 +254,11 @@ func TestBridgeProxy_CloseBeforeServeRejectsDial(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Close blocked before Serve started")
 	}
+	select {
+	case <-bp.watcherDone:
+	default:
+		t.Fatal("Close before Serve did not complete watcher lifecycle")
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()


### PR DESCRIPTION
## What changed

The playground broker's `/api/live/health` computed `ok` from its own gates, daily budget and kill switch alone. It never consulted the machine provider, so it reported healthy while the broker could not create sandboxes and every visitor session start returned 503. The warm-pool maintainer also retried a persistently failing provider every two seconds with no backoff.

This adds a shared provider-health tracker fed by a `MachineProvider` decorator, so the warm pool, lease manager and orphan reaper all contribute reachability signal without each needing its own bookkeeping. The orphan reaper runs unconditionally, which means provider health stays fresh even in deployments that disable the warm pool.

`/api/live/health` now reports `provider_ok`, `provider_state` (`unknown` / `ok` / `degraded` / `failing`), `provider_failures`, `last_provider_error_at`, `last_provider_success_at` and `pool_backoff_until`.

Background pool maintenance now backs off exponentially from five seconds to a five minute cap while the provider is failing, and recovers on the first success.

## Deliberate choices

`ok` keeps its original meaning and the endpoint keeps returning 200 even when the provider is failing. Existing consumers already read `ok`, so redefining it would change their behaviour as a side effect of adding observability. A non-2xx would also let any platform health check restart or de-list the broker, turning an honest signal into a self-inflicted outage. Provider state is reported in the body instead.

Backoff advises, it never blocks. It gates only background pool maintenance, never the visitor's cold-lease path, so a session start still gets a real attempt rather than being denied because earlier background calls failed. Skipping a maintenance round only defers warm-VM housekeeping; it cannot skip a security control, and the orphan reaper still reclaims deferred cleanup once the provider recovers.

Context cancellation is not counted as a provider failure, since a cancelled call is a shutdown or a caller timeout rather than evidence the provider is unusable. `WaitReady` is excluded for the same reason in the other direction: a slow guest boot is not a provider outage, and counting it would let boot latency mask the credential class of failure this is meant to catch.

The provider error string is recorded for operators but is not written to the failing-provider log line and is not serialised into the health response, so a future provider error cannot leak credential material through either surface.

## Behaviour compatibility

`ProviderHealth` is nil-safe throughout. A nil tracker reports `unknown`, disables backoff and preserves the previous retry cadence exactly, so existing callers and tests are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added provider health monitoring with states: unknown, ok, degraded, and failing, including backoff behavior.
  - Expanded the live health endpoint with provider-specific fields: provider_ok, provider_state, provider_failures, last provider success/error timestamps, and pool backoff status.
  - Warm-pool maintenance now reacts to active provider backoff/quarantine; when warm pool is disabled, provider health is driven by reaper behavior.
- **Bug Fixes**
  - Provider backoff no longer blocks cold session creation/initial leasing.
- **Tests**
  - Added coverage for provider health tracking, backoff/quarantine behavior, warm-pool vs reaper wiring, and health endpoint fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->