### PR TITLE
fix(build): restore WASM verifier compilation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -333,6 +333,37 @@ jobs:
       - name: internal/config test package builds on Windows
         run: go test -count=1 -run "TestWindows" ./internal/config/...
 
+  # Exercise the browser target's concrete fail-closed filesystem fallbacks,
+  # then compile the same contracts for WASI and AIX so build-tag gaps cannot
+  # silently remove their implementations.
+  test-unsupported-filesystems:
+    needs: [security-scan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.26'
+
+      - name: Run browser target fallback contracts
+        run: GOOS=js GOARCH=wasm go test -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec" -count=1 -run "TestOpenRegularNonblockingFailsClosedOnUnsupportedPlatform|TestEvidenceFileOperationsFailClosedOnUnsupportedPlatform" ./internal/securefile/... ./internal/recorder/...
+
+      - name: Compile WASI fallback contracts
+        run: |
+          GOOS=wasip1 GOARCH=wasm go test -c -o /tmp/securefile-wasi.test ./internal/securefile
+          GOOS=wasip1 GOARCH=wasm go test -c -o /tmp/recorder-wasi.test ./internal/recorder
+          GOOS=wasip1 GOARCH=wasm go test -c -o /tmp/license-wasi.test ./internal/license
+
+      - name: Compile AIX fallback contracts
+        run: |
+          GOOS=aix GOARCH=ppc64 go test -c -o /tmp/recorder-aix.test ./internal/recorder
+          GOOS=aix GOARCH=ppc64 go test -c -o /tmp/license-aix.test ./internal/license
+
   lint:
     needs: [security-scan]
     runs-on: ubuntu-latest

--- a/internal/license/crl_highwater_lock_unix.go
+++ b/internal/license/crl_highwater_lock_unix.go
@@ -1,7 +1,7 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !windows && !js
+//go:build unix && !aix
 
 package license
 

--- a/internal/license/crl_highwater_lock_unsupported.go
+++ b/internal/license/crl_highwater_lock_unsupported.go
@@ -1,0 +1,13 @@
+//go:build aix || (wasip1 && wasm)
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import "errors"
+
+// acquireCRLHighWaterLock fails closed where cross-process locking is absent.
+func acquireCRLHighWaterLock(_ string) (func(), error) {
+	return nil, errors.New("license CRL high-water locking unsupported on this platform")
+}

--- a/internal/license/crl_highwater_lock_unsupported_test.go
+++ b/internal/license/crl_highwater_lock_unsupported_test.go
@@ -1,0 +1,18 @@
+//go:build aix || (wasip1 && wasm)
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package license
+
+import "testing"
+
+func TestCRLHighWaterLockFailsClosedOnUnsupportedPlatform(t *testing.T) {
+	release, err := acquireCRLHighWaterLock("unused")
+	if release != nil {
+		t.Fatal("release function is non-nil on unsupported platform")
+	}
+	if err == nil {
+		t.Fatal("acquireCRLHighWaterLock returned nil error on unsupported platform")
+	}
+}

--- a/internal/recorder/evidence_read.go
+++ b/internal/recorder/evidence_read.go
@@ -38,7 +38,12 @@ const (
 // ErrEvidenceReadLimitExceeded marks a fail-closed evidence read cap hit.
 var ErrEvidenceReadLimitExceeded = errors.New("evidence read limit exceeded")
 
-func openRegularEvidenceFile(path, label string) (*os.File, os.FileInfo, error) {
+// openRegularEvidenceFile opens an unchanged regular evidence file after the
+// platform access policy has accepted the operation.
+func openRegularEvidenceFile(path, label string, accessErr error) (*os.File, os.FileInfo, error) {
+	if accessErr != nil {
+		return nil, nil, accessErr
+	}
 	cleanPath := filepath.Clean(path)
 	before, err := os.Lstat(cleanPath)
 	if err != nil {
@@ -73,7 +78,7 @@ func readBoundedEvidence(path string, maxBytes int64, sink io.Writer) error {
 	if maxBytes <= 0 {
 		maxBytes = MaxEvidenceReadFileBytes
 	}
-	file, info, err := openRegularEvidenceFile(path, "evidence file")
+	file, info, err := openRegularEvidenceFile(path, "evidence file", validateEvidenceFileAccess())
 	if err != nil {
 		return err
 	}

--- a/internal/recorder/evidence_read_bounds_test.go
+++ b/internal/recorder/evidence_read_bounds_test.go
@@ -41,6 +41,17 @@ func TestReadEvidenceFileBounded_HappyPathAndHash(t *testing.T) {
 	}
 }
 
+func TestOpenRegularEvidenceFileRejectsUnsupportedPlatform(t *testing.T) {
+	want := errors.New("unsupported evidence access")
+	file, info, err := openRegularEvidenceFile("unused", "evidence file", want)
+	if file != nil || info != nil {
+		t.Fatalf("open result = (%v, %v), want nil handles", file, info)
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("open error = %v, want %v", err, want)
+	}
+}
+
 func TestReadEvidenceFileBounded_NonPositiveMaxUsesDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/recorder/evidence_read_unix.go
+++ b/internal/recorder/evidence_read_unix.go
@@ -1,7 +1,7 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !windows
+//go:build unix && !aix
 
 package recorder
 
@@ -16,14 +16,23 @@ const (
 	evidenceReadNonblockFlag = syscall.O_NONBLOCK
 )
 
+// validateEvidenceFileAccess permits evidence access where no-follow,
+// nonblocking opens and advisory locks are available.
+func validateEvidenceFileAccess() error {
+	return nil
+}
+
+// lockEvidenceFileForWrite advertises a live writer with a shared lock.
 func lockEvidenceFileForWrite(f *os.File) error {
 	return syscall.Flock(int(f.Fd()), syscall.LOCK_SH)
 }
 
+// unlockEvidenceFile releases a writer-presence lock.
 func unlockEvidenceFile(f *os.File) error {
 	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 }
 
+// tryLockEvidenceFileForExpiry claims exclusive ownership without blocking.
 func tryLockEvidenceFileForExpiry(f *os.File) (bool, error) {
 	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 	if err == nil {

--- a/internal/recorder/evidence_read_unsupported.go
+++ b/internal/recorder/evidence_read_unsupported.go
@@ -1,0 +1,38 @@
+//go:build aix || (js && wasm) || (wasip1 && wasm)
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package recorder
+
+import (
+	"errors"
+	"os"
+)
+
+var errEvidenceFileAccessUnsupported = errors.New("evidence file access unsupported on this platform")
+
+const (
+	evidenceReadNoFollowFlag = 0
+	evidenceReadNonblockFlag = 0
+)
+
+// validateEvidenceFileAccess rejects filesystem evidence operations.
+func validateEvidenceFileAccess() error {
+	return errEvidenceFileAccessUnsupported
+}
+
+// lockEvidenceFileForWrite rejects writes without a real platform lock.
+func lockEvidenceFileForWrite(_ *os.File) error {
+	return errEvidenceFileAccessUnsupported
+}
+
+// unlockEvidenceFile rejects the unsupported lock lifecycle.
+func unlockEvidenceFile(_ *os.File) error {
+	return errEvidenceFileAccessUnsupported
+}
+
+// tryLockEvidenceFileForExpiry refuses exclusive ownership without a platform lock.
+func tryLockEvidenceFileForExpiry(_ *os.File) (bool, error) {
+	return false, errEvidenceFileAccessUnsupported
+}

--- a/internal/recorder/evidence_read_unsupported_test.go
+++ b/internal/recorder/evidence_read_unsupported_test.go
@@ -1,0 +1,43 @@
+//go:build aix || (js && wasm) || (wasip1 && wasm)
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package recorder
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestEvidenceFileOperationsFailClosedOnUnsupportedPlatform(t *testing.T) {
+	accessErr := validateEvidenceFileAccess()
+	if !errors.Is(accessErr, errEvidenceFileAccessUnsupported) {
+		t.Fatalf("access error = %v, want %v", accessErr, errEvidenceFileAccessUnsupported)
+	}
+
+	file, info, err := openRegularEvidenceFile("unused", "evidence file", accessErr)
+	if file != nil || info != nil {
+		t.Fatalf("open result = (%v, %v), want nil handles", file, info)
+	}
+	if !errors.Is(err, errEvidenceFileAccessUnsupported) {
+		t.Fatalf("open error = %v, want %v", err, errEvidenceFileAccessUnsupported)
+	}
+
+	for name, lockErr := range map[string]error{
+		"lock":   lockEvidenceFileForWrite(nil),
+		"unlock": unlockEvidenceFile(nil),
+	} {
+		if !errors.Is(lockErr, errEvidenceFileAccessUnsupported) {
+			t.Errorf("%s error = %v, want %v", name, lockErr, errEvidenceFileAccessUnsupported)
+		}
+	}
+
+	locked, err := tryLockEvidenceFileForExpiry(nil)
+	if locked {
+		t.Error("expiry lock reported acquired on unsupported platform")
+	}
+	if !errors.Is(err, errEvidenceFileAccessUnsupported) {
+		t.Fatalf("expiry lock error = %v, want %v", err, errEvidenceFileAccessUnsupported)
+	}
+}

--- a/internal/recorder/evidence_read_windows.go
+++ b/internal/recorder/evidence_read_windows.go
@@ -12,6 +12,12 @@ const (
 	evidenceReadNonblockFlag = 0
 )
 
+// validateEvidenceFileAccess permits evidence access through the Windows
+// descriptor-identity validation path.
+func validateEvidenceFileAccess() error {
+	return nil
+}
+
 // Windows has no advisory whole-file lock equivalent to flock here, so the
 // writer-presence lock is a no-op. That is safe on its own: it only means
 // writers advertise nothing.
@@ -19,6 +25,7 @@ func lockEvidenceFileForWrite(_ *os.File) error {
 	return nil
 }
 
+// unlockEvidenceFile mirrors the no-op Windows writer lock.
 func unlockEvidenceFile(_ *os.File) error {
 	return nil
 }

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -1215,7 +1215,7 @@ func (r *Recorder) ExpireOldFiles() (int, error) {
 // directories are created 0o750 and owned by the service, so no other
 // unprivileged principal can rename entries within them.
 func removeExpiredEvidenceFile(path string, cutoff time.Time) (bool, error) {
-	file, info, err := openRegularEvidenceFile(path, "evidence file")
+	file, info, err := openRegularEvidenceFile(path, "evidence file", validateEvidenceFileAccess())
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil

--- a/internal/securefile/mkfifo_unix_test.go
+++ b/internal/securefile/mkfifo_unix_test.go
@@ -1,4 +1,4 @@
-//go:build unix
+//go:build unix && !aix && !js && !wasip1
 
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0

--- a/internal/securefile/open_other.go
+++ b/internal/securefile/open_other.go
@@ -1,0 +1,14 @@
+//go:build !unix && !windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package securefile
+
+import "os"
+
+// openRegularNonblocking fails closed where equivalent nonblocking, no-follow
+// open primitives are unavailable.
+func openRegularNonblocking(path string) (*os.File, error) {
+	return nil, ErrUnsupportedSecureOpen
+}

--- a/internal/securefile/open_other_test.go
+++ b/internal/securefile/open_other_test.go
@@ -1,0 +1,21 @@
+//go:build !unix && !windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package securefile
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestOpenRegularNonblockingFailsClosedOnUnsupportedPlatform(t *testing.T) {
+	file, err := openRegularNonblocking("unused")
+	if file != nil {
+		t.Fatalf("open result = %v, want nil", file)
+	}
+	if !errors.Is(err, ErrUnsupportedSecureOpen) {
+		t.Fatalf("open error = %v, want %v", err, ErrUnsupportedSecureOpen)
+	}
+}

--- a/internal/securefile/open_unix_test.go
+++ b/internal/securefile/open_unix_test.go
@@ -1,4 +1,4 @@
-//go:build unix
+//go:build unix && !aix && !js && !wasip1
 
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0

--- a/internal/securefile/securefile.go
+++ b/internal/securefile/securefile.go
@@ -6,6 +6,7 @@
 package securefile
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -15,6 +16,10 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/secperm"
 )
+
+// ErrUnsupportedSecureOpen means the current platform cannot provide the
+// nonblocking, no-follow open required by Read's security contract.
+var ErrUnsupportedSecureOpen = errors.New("secure file open unsupported on this platform")
 
 // Options defines the filesystem boundary enforced by Read.
 type Options struct {


### PR DESCRIPTION
Adds explicit js/wasm fallbacks for secure file opening and evidence locking. WASM evidence expiry fails closed instead of claiming unavailable exclusive ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-aware secure file handling with clear failure behavior where safe file access is unavailable.
  * Added support checks for evidence file access and retention operations across additional platforms.

* **Bug Fixes**
  * Prevented unsupported platforms from attempting unsafe file operations.
  * Improved fail-closed behavior for evidence access and cross-process locking.

* **Tests**
  * Added coverage confirming unsupported evidence access returns an error without opening files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->