### PR TITLE
fix(playground): validate broker deployment contract

### DIFF
--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -254,7 +254,7 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 	if err := validateFlags(f); err != nil {
 		return err
 	}
-	if err := validateStaticUI(f.staticDir); err != nil {
+	if err := validateStaticUI(f.staticDir, effectiveTurnstileOrigin(f)); err != nil {
 		return err
 	}
 	if f.checkConfig {
@@ -324,7 +324,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 	if err := validateFlags(f); err != nil {
 		return nil, nil, nil, nil, err
 	}
-	if err := validateStaticUI(f.staticDir); err != nil {
+	if err := validateStaticUI(f.staticDir, effectiveTurnstileOrigin(f)); err != nil {
 		return nil, nil, nil, nil, err
 	}
 	secret, err := resolveGateSecret(f.gateSecretFile, f.gateSecretEnv)
@@ -592,6 +592,9 @@ func validateFlags(f *serveFlags) error {
 	}
 	if !hasTurnstile && strings.TrimSpace(f.turnstileSitekey) != "" {
 		return errors.New("--turnstile-sitekey requires --turnstile-secret-file or --turnstile-secret-env")
+	}
+	if !hasTurnstile && strings.TrimSpace(f.turnstileOrigin) != "" {
+		return errors.New("--turnstile-origin requires --turnstile-secret-file or --turnstile-secret-env")
 	}
 	if origin := effectiveTurnstileOrigin(f); origin != "" && origin != defaultTurnstileOrigin {
 		return fmt.Errorf("--turnstile-origin must be %s", defaultTurnstileOrigin)
@@ -994,7 +997,7 @@ func validateAllowOrigin(raw string) error {
 // validateStaticUI rejects markup that cannot execute under the broker's
 // no-inline-script CSP. The broker owns both the policy and the served static
 // directory, so it must refuse an incompatible pair before binding a listener.
-func validateStaticUI(staticDir string) error {
+func validateStaticUI(staticDir, turnstileOrigin string) error {
 	if strings.TrimSpace(staticDir) == "" {
 		return nil
 	}
@@ -1031,7 +1034,7 @@ func validateStaticUI(staticDir string) error {
 					}
 				}
 				if source != "" {
-					if err := validateStaticScriptSource(source); err != nil {
+					if err := validateStaticScriptSource(source, turnstileOrigin); err != nil {
 						return err
 					}
 				} else if scriptType != "application/json" && scriptType != "application/ld+json" {
@@ -1049,9 +1052,12 @@ func validateStaticUI(staticDir string) error {
 	return walk(doc)
 }
 
-func validateStaticScriptSource(source string) error {
+func validateStaticScriptSource(source, turnstileOrigin string) error {
+	if strings.HasPrefix(source, "//") {
+		return fmt.Errorf("static UI script source %q is not permitted by broker CSP", source)
+	}
 	if strings.HasPrefix(source, "/") || strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") ||
-		(!strings.Contains(source, ":") && !strings.HasPrefix(source, "//")) {
+		!strings.Contains(source, ":") {
 		return nil
 	}
 	parsed, err := url.Parse(source)
@@ -1059,7 +1065,7 @@ func validateStaticScriptSource(source string) error {
 		return fmt.Errorf("static UI script source %q is not permitted by broker CSP", source)
 	}
 	origin := parsed.Scheme + "://" + parsed.Host
-	if origin != defaultTurnstileOrigin {
+	if origin != turnstileOrigin {
 		return fmt.Errorf("static UI script source %q is not permitted by broker CSP", source)
 	}
 	return nil

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -29,6 +29,7 @@ import (
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/html"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
@@ -76,10 +77,11 @@ const (
 	// connect, and frame sources. Third-party browser origins are never compiled
 	// into the binary. Framing defaults to 'none' and widens only for origins an
 	// operator passes with --embed-origin.
-	brokerCSPTemplate       = "default-src 'none'; base-uri 'none'; object-src 'none'; frame-ancestors %s; script-src 'self' blob: 'wasm-unsafe-eval'%s; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'%s; frame-src %s; form-action 'self'"
+	brokerCSPTemplate       = "default-src 'none'; base-uri 'none'; object-src 'none'; frame-ancestors %s; script-src 'self' blob: 'wasm-unsafe-eval'%s; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'%s; frame-src %s; form-action 'self'"
 	brokerHSTS              = "max-age=31536000; includeSubDomains"
 	brokerReferrerPolicy    = "strict-origin-when-cross-origin"
 	brokerPermissionsPolicy = "camera=(), microphone=(), geolocation=()"
+	defaultTurnstileOrigin  = "https://challenges.cloudflare.com"
 )
 
 type serveFlags struct {
@@ -120,6 +122,7 @@ type serveFlags struct {
 	turnstileMaxAge           time.Duration
 	turnstileSitekey          string
 	turnstileOrigin           string
+	checkConfig               bool
 	sessionTTL                time.Duration
 	deadlineGrace             time.Duration
 	allowOrigin               string
@@ -216,6 +219,7 @@ func newServeCmd() *cobra.Command {
 	fl.DurationVar(&f.turnstileMaxAge, "turnstile-max-age", broker.DefaultTurnstileMaxAge, "max age for a Turnstile challenge_ts before it is rejected (0 disables)")
 	fl.StringVar(&f.turnstileSitekey, "turnstile-sitekey", "", "public Cloudflare Turnstile site key; reported via /health so the viewer renders the widget (the secret is set separately via --turnstile-secret-*)")
 	fl.StringVar(&f.turnstileOrigin, "turnstile-origin", "", "validated browser origin used by the Turnstile widget and added to CSP only when configured")
+	fl.BoolVar(&f.checkConfig, "check-config", false, "validate flags and static UI compatibility, then exit without resolving secrets or contacting providers")
 	fl.DurationVar(&f.sessionTTL, "session-ttl", defaultSessionTTL, "VM session token TTL")
 	fl.DurationVar(&f.deadlineGrace, "deadline-grace", defaultGrace, "lease teardown grace after VM session expiry")
 	fl.StringVar(&f.allowOrigin, "allow-origin", "", "Access-Control-Allow-Origin for the browser")
@@ -246,6 +250,25 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if err := validateFlags(f); err != nil {
+		return err
+	}
+	if err := validateStaticUI(f.staticDir); err != nil {
+		return err
+	}
+	if f.checkConfig {
+		if _, err := resolveCodes(f.codes, f.maxPerCode); err != nil {
+			return err
+		}
+		if _, err := brokerPublicHosts(f); err != nil {
+			return err
+		}
+		if _, err := newCFAccessVerifier(f); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "broker flags, invite codes, public hosts, access policy, and static UI valid; secrets and provider not contacted")
+		return nil
 	}
 	srv, handler, startReaper, pool, err := buildServer(ctx, cmd.OutOrStdout(), f)
 	if err != nil {
@@ -299,6 +322,9 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 
 func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Server, http.Handler, func(context.Context), *broker.Pool, error) {
 	if err := validateFlags(f); err != nil {
+		return nil, nil, nil, nil, err
+	}
+	if err := validateStaticUI(f.staticDir); err != nil {
 		return nil, nil, nil, nil, err
 	}
 	secret, err := resolveGateSecret(f.gateSecretFile, f.gateSecretEnv)
@@ -492,7 +518,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		handler = cfAccessGuard(handler, cfAccess)
 		_, _ = fmt.Fprintf(out, "broker Cloudflare Access JWT guard enabled for %s\n", cfAccess.issuer)
 	}
-	handler = securityHeaders(handler, f.embedOrigins, f.turnstileOrigin)
+	handler = securityHeaders(handler, f.embedOrigins, effectiveTurnstileOrigin(f))
 	return srv, handler, reaper.Run, warmPool, nil
 }
 
@@ -561,8 +587,14 @@ func validateFlags(f *serveFlags) error {
 		return err
 	}
 	hasTurnstile := strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != ""
-	if hasTurnstile && strings.TrimSpace(f.turnstileOrigin) == "" {
-		return errors.New("--turnstile-origin is required when Turnstile is enabled")
+	if hasTurnstile && strings.TrimSpace(f.turnstileSitekey) == "" {
+		return errors.New("--turnstile-sitekey is required when Turnstile is enabled")
+	}
+	if !hasTurnstile && strings.TrimSpace(f.turnstileSitekey) != "" {
+		return errors.New("--turnstile-sitekey requires --turnstile-secret-file or --turnstile-secret-env")
+	}
+	if origin := effectiveTurnstileOrigin(f); origin != "" && origin != defaultTurnstileOrigin {
+		return fmt.Errorf("--turnstile-origin must be %s", defaultTurnstileOrigin)
 	}
 	if f.deadlineGrace < 0 {
 		return errors.New("--deadline-grace must be >= 0")
@@ -575,7 +607,7 @@ func validateFlags(f *serveFlags) error {
 			return fmt.Errorf("--embed-origin %q: %w", origin, err)
 		}
 	}
-	if err := validateAllowOrigin(f.turnstileOrigin); err != nil {
+	if err := validateAllowOrigin(effectiveTurnstileOrigin(f)); err != nil {
 		return fmt.Errorf("--turnstile-origin: %w", err)
 	}
 	if err := validateCFAccessFlags(f); err != nil {
@@ -585,6 +617,15 @@ func validateFlags(f *serveFlags) error {
 		return err
 	}
 	return nil
+}
+
+func effectiveTurnstileOrigin(f *serveFlags) string {
+	if strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != "" {
+		if strings.TrimSpace(f.turnstileOrigin) == "" {
+			return defaultTurnstileOrigin
+		}
+	}
+	return strings.TrimSpace(f.turnstileOrigin)
 }
 
 // effectiveDefaultCode is the server-side invite code auto-applied when a
@@ -946,6 +987,80 @@ func validateAllowOrigin(raw string) error {
 		u.RawQuery != "" || u.Fragment != "" || u.Path != "" ||
 		strings.Contains(raw, "?") || strings.HasSuffix(raw, "#") {
 		return errors.New("must be an origin only, like https://site.example")
+	}
+	return nil
+}
+
+// validateStaticUI rejects markup that cannot execute under the broker's
+// no-inline-script CSP. The broker owns both the policy and the served static
+// directory, so it must refuse an incompatible pair before binding a listener.
+func validateStaticUI(staticDir string) error {
+	if strings.TrimSpace(staticDir) == "" {
+		return nil
+	}
+	path := filepath.Join(filepath.Clean(staticDir), "index.html")
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open static UI index: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	doc, err := html.Parse(file)
+	if err != nil {
+		return fmt.Errorf("parse static UI index: %w", err)
+	}
+	var walk func(*html.Node) error
+	walk = func(node *html.Node) error {
+		if node.Type == html.ElementNode {
+			for _, attr := range node.Attr {
+				if strings.HasPrefix(strings.ToLower(attr.Key), "on") {
+					return fmt.Errorf("static UI contains inline event handler %q", attr.Key)
+				}
+			}
+			if node.Data == "base" {
+				return errors.New("static UI contains base element blocked by broker CSP")
+			}
+			if node.Data == "script" {
+				source := ""
+				scriptType := ""
+				for _, attr := range node.Attr {
+					switch {
+					case strings.EqualFold(attr.Key, "src"):
+						source = strings.TrimSpace(attr.Val)
+					case strings.EqualFold(attr.Key, "type"):
+						scriptType = strings.ToLower(strings.TrimSpace(attr.Val))
+					}
+				}
+				if source != "" {
+					if err := validateStaticScriptSource(source); err != nil {
+						return err
+					}
+				} else if scriptType != "application/json" && scriptType != "application/ld+json" {
+					return errors.New("static UI contains inline script blocked by broker CSP")
+				}
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			if err := walk(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return walk(doc)
+}
+
+func validateStaticScriptSource(source string) error {
+	if strings.HasPrefix(source, "/") || strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") ||
+		(!strings.Contains(source, ":") && !strings.HasPrefix(source, "//")) {
+		return nil
+	}
+	parsed, err := url.Parse(source)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return fmt.Errorf("static UI script source %q is not permitted by broker CSP", source)
+	}
+	origin := parsed.Scheme + "://" + parsed.Host
+	if origin != defaultTurnstileOrigin {
+		return fmt.Errorf("static UI script source %q is not permitted by broker CSP", source)
 	}
 	return nil
 }

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -1061,14 +1061,39 @@ func validateStaticScriptSource(source, turnstileOrigin string) error {
 		return nil
 	}
 	parsed, err := url.Parse(source)
-	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+	if err != nil {
 		return fmt.Errorf("static UI script source %q is not permitted by broker CSP", source)
 	}
-	origin := parsed.Scheme + "://" + parsed.Host
-	if origin != turnstileOrigin {
+	origin, err := canonicalHTTPSOrigin(parsed)
+	if err != nil {
+		return fmt.Errorf("static UI script source %q is not permitted by broker CSP", source)
+	}
+	allowed, err := url.Parse(turnstileOrigin)
+	if err != nil {
+		return fmt.Errorf("static UI script source %q is not permitted by broker CSP", source)
+	}
+	allowedOrigin, err := canonicalHTTPSOrigin(allowed)
+	if err != nil || origin != allowedOrigin {
 		return fmt.Errorf("static UI script source %q is not permitted by broker CSP", source)
 	}
 	return nil
+}
+
+func canonicalHTTPSOrigin(parsed *url.URL) (string, error) {
+	if parsed == nil || !strings.EqualFold(parsed.Scheme, "https") || parsed.Host == "" || parsed.User != nil {
+		return "", errors.New("invalid HTTPS origin")
+	}
+	host := strings.ToLower(parsed.Hostname())
+	port := parsed.Port()
+	if port == "443" {
+		port = ""
+	}
+	if port != "" {
+		host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	return "https://" + host, nil
 }
 
 func brokerPublicHosts(f *serveFlags) ([]string, error) {

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -419,7 +419,6 @@ func TestBrokerSecurityHeaders(t *testing.T) {
 		vmDailyTurnBudget:     10,
 		requireSessionSecrets: false,
 		embedOrigins:          []string{testEmbedOrigin},
-		turnstileOrigin:       defaultTurnstileOrigin,
 	})
 	if err != nil {
 		t.Fatalf("buildServer: %v", err)
@@ -441,7 +440,7 @@ func TestBrokerSecurityHeaders(t *testing.T) {
 			if resp.StatusCode != http.StatusOK {
 				t.Fatalf("GET %s status = %d, want 200", tc.path, resp.StatusCode)
 			}
-			assertBrokerSecurityHeaders(t, resp.Header, defaultTurnstileOrigin)
+			assertBrokerSecurityHeaders(t, resp.Header, "")
 		})
 	}
 }
@@ -815,6 +814,47 @@ func testServeFlags(t *testing.T, warmPoolSize int) *serveFlags {
 		vmDailyTurnBudget:     10,
 		requireSessionSecrets: false,
 		warmPoolSize:          warmPoolSize,
+	}
+}
+
+func TestRunServeCheckConfigDoesNotResolveSecretsOrProvider(t *testing.T) {
+	f := testServeFlags(t, 0)
+	f.checkConfig = true
+	f.flyTokenFile = filepath.Join(t.TempDir(), "missing-fly-token")
+	f.gateSecretFile = filepath.Join(t.TempDir(), "missing-gate-secret")
+	f.staticDir = t.TempDir()
+	if err := os.WriteFile(filepath.Join(f.staticDir, "index.html"), []byte(`<script src="viewer.js"></script>`), 0o600); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+
+	providerCalled := false
+	oldFactory := newMachineProvider
+	newMachineProvider = func(_ context.Context, _ *serveFlags, _ string) (broker.MachineProvider, error) {
+		providerCalled = true
+		return nil, errors.New("provider must not be created during check-config")
+	}
+	t.Cleanup(func() { newMachineProvider = oldFactory })
+
+	cmd := newServeCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runServe(cmd, f); err != nil {
+		t.Fatalf("runServe check-config: %v", err)
+	}
+	if providerCalled {
+		t.Fatal("check-config created the machine provider")
+	}
+	if !strings.Contains(out.String(), "secrets and provider not contacted") {
+		t.Fatalf("check-config output = %q", out.String())
+	}
+
+	invalidHost := *f
+	invalidHost.publicHosts = []string{"bad host"}
+	if err := runServe(cmd, &invalidHost); err == nil || !strings.Contains(err.Error(), "--public-host") {
+		t.Fatalf("check-config invalid public host error = %v", err)
+	}
+	if providerCalled {
+		t.Fatal("invalid check-config created the machine provider")
 	}
 }
 
@@ -1319,6 +1359,11 @@ func TestValidateFlagsBranches(t *testing.T) {
 	sitekeyWithoutSecret.unsafeNoHumanGate = true
 	if err := validateFlags(&sitekeyWithoutSecret); err == nil || !strings.Contains(err.Error(), "--turnstile-sitekey requires") {
 		t.Fatalf("Turnstile sitekey without secret error = %v, want requires-secret error", err)
+	}
+	originWithoutSecret := sitekeyWithoutSecret
+	originWithoutSecret.turnstileSitekey = ""
+	if err := validateFlags(&originWithoutSecret); err == nil || !strings.Contains(err.Error(), "--turnstile-origin requires") {
+		t.Fatalf("Turnstile origin without secret error = %v, want requires-secret error", err)
 	}
 	unsupportedTurnstileOrigin := turnstileGate
 	unsupportedTurnstileOrigin.turnstileOrigin = "https://challenge.vendor.example"
@@ -1884,6 +1929,7 @@ func TestValidateStaticUIRejectsCSPIncompatibleMarkup(t *testing.T) {
 		{name: "inline script", body: `<script>window.bad = true</script>`, want: "inline script"},
 		{name: "inline handler", body: `<button onclick="bad()">go</button>`, want: "inline event handler"},
 		{name: "third-party script", body: `<script src="https://analytics.example/array.js"></script>`, want: "not permitted"},
+		{name: "protocol-relative script", body: `<script src="//challenges.cloudflare.com/x.js"></script>`, want: "not permitted"},
 		{name: "base element", body: `<base href="/">`, want: "base element"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1892,7 +1938,7 @@ func TestValidateStaticUIRejectsCSPIncompatibleMarkup(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(tc.body), 0o600); err != nil {
 				t.Fatalf("write index: %v", err)
 			}
-			err := validateStaticUI(dir)
+			err := validateStaticUI(dir, defaultTurnstileOrigin)
 			if tc.want == "" {
 				if err != nil {
 					t.Fatalf("validateStaticUI: %v", err)
@@ -1903,6 +1949,21 @@ func TestValidateStaticUIRejectsCSPIncompatibleMarkup(t *testing.T) {
 				t.Fatalf("validateStaticUI error = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestValidateStaticUIUsesRuntimeScriptOrigins(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(
+		`<script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>`,
+	), 0o600); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	if err := validateStaticUI(dir, ""); err == nil || !strings.Contains(err.Error(), "not permitted") {
+		t.Fatalf("validateStaticUI without Turnstile origin error = %v, want not permitted", err)
+	}
+	if err := validateStaticUI(dir, defaultTurnstileOrigin); err != nil {
+		t.Fatalf("validateStaticUI with Turnstile origin: %v", err)
 	}
 }
 

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -1924,12 +1924,14 @@ func TestValidateStaticUIRejectsCSPIncompatibleMarkup(t *testing.T) {
 		want string
 	}{
 		{name: "external script", body: `<script src="viewer.js"></script>`},
-		{name: "Turnstile script", body: `<script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>`},
+		{name: "Turnstile script", body: `<script src="` + defaultTurnstileOrigin + `/turnstile/v0/api.js"></script>`},
+		{name: "Turnstile script explicit HTTPS port", body: `<script src="` + defaultTurnstileOrigin + `:443/turnstile/v0/api.js"></script>`},
+		{name: "Turnstile script mixed case", body: `<script src="` + strings.ToUpper(defaultTurnstileOrigin) + `/turnstile/v0/api.js"></script>`},
 		{name: "JSON data block", body: `<script type="application/json">{"safe":true}</script>`},
 		{name: "inline script", body: `<script>window.bad = true</script>`, want: "inline script"},
 		{name: "inline handler", body: `<button onclick="bad()">go</button>`, want: "inline event handler"},
 		{name: "third-party script", body: `<script src="https://analytics.example/array.js"></script>`, want: "not permitted"},
-		{name: "protocol-relative script", body: `<script src="//challenges.cloudflare.com/x.js"></script>`, want: "not permitted"},
+		{name: "protocol-relative script", body: `<script src="` + strings.TrimPrefix(defaultTurnstileOrigin, "https:") + `/x.js"></script>`, want: "not permitted"},
 		{name: "base element", body: `<base href="/">`, want: "base element"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1955,7 +1957,7 @@ func TestValidateStaticUIRejectsCSPIncompatibleMarkup(t *testing.T) {
 func TestValidateStaticUIUsesRuntimeScriptOrigins(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(
-		`<script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>`,
+		`<script src="`+defaultTurnstileOrigin+`/turnstile/v0/api.js"></script>`,
 	), 0o600); err != nil {
 		t.Fatalf("write index: %v", err)
 	}

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -419,7 +419,7 @@ func TestBrokerSecurityHeaders(t *testing.T) {
 		vmDailyTurnBudget:     10,
 		requireSessionSecrets: false,
 		embedOrigins:          []string{testEmbedOrigin},
-		turnstileOrigin:       "https://challenge.vendor.example",
+		turnstileOrigin:       defaultTurnstileOrigin,
 	})
 	if err != nil {
 		t.Fatalf("buildServer: %v", err)
@@ -441,7 +441,7 @@ func TestBrokerSecurityHeaders(t *testing.T) {
 			if resp.StatusCode != http.StatusOK {
 				t.Fatalf("GET %s status = %d, want 200", tc.path, resp.StatusCode)
 			}
-			assertBrokerSecurityHeaders(t, resp.Header, "https://challenge.vendor.example")
+			assertBrokerSecurityHeaders(t, resp.Header, defaultTurnstileOrigin)
 		})
 	}
 }
@@ -662,8 +662,9 @@ func TestBuildServerTurnstileRejectsMissingToken(t *testing.T) {
 		codeBurst:             defaultCodeBurst,
 		globalDailyBudget:     10,
 		turnstileSecretFile:   turnstileSecretFile,
+		turnstileSitekey:      "1x00000000000000000000AA",
 		turnstileVerifyURL:    verifyServer.URL,
-		turnstileOrigin:       "https://challenge.vendor.example",
+		turnstileOrigin:       defaultTurnstileOrigin,
 		sessionTTL:            defaultSessionTTL,
 		deadlineGrace:         defaultGrace,
 		vmDailyTurnBudget:     10,
@@ -1295,14 +1296,34 @@ func TestValidateFlagsBranches(t *testing.T) {
 	turnstileGate.turnstileSecretEnv = "BROKER_TEST_TURNSTILE"
 	turnstileGate.turnstileExpectedHostname = "playground.example"
 	turnstileGate.turnstileExpectedAction = "playground-session"
-	turnstileGate.turnstileOrigin = "https://challenge.vendor.example"
+	turnstileGate.turnstileSitekey = "1x00000000000000000000AA"
+	turnstileGate.turnstileOrigin = defaultTurnstileOrigin
 	if err := validateFlags(&turnstileGate); err != nil {
 		t.Fatalf("turnstile gate should validate: %v", err)
 	}
 	turnstileWithoutOrigin := turnstileGate
 	turnstileWithoutOrigin.turnstileOrigin = ""
-	if err := validateFlags(&turnstileWithoutOrigin); err == nil || !strings.Contains(err.Error(), "--turnstile-origin is required") {
-		t.Fatalf("Turnstile gate without origin error = %v, want required-origin error", err)
+	if err := validateFlags(&turnstileWithoutOrigin); err != nil {
+		t.Fatalf("Turnstile gate without explicit origin should use the Cloudflare default: %v", err)
+	}
+	if got := effectiveTurnstileOrigin(&turnstileWithoutOrigin); got != defaultTurnstileOrigin {
+		t.Fatalf("default Turnstile origin = %q, want %q", got, defaultTurnstileOrigin)
+	}
+	turnstileWithoutSitekey := turnstileGate
+	turnstileWithoutSitekey.turnstileSitekey = ""
+	if err := validateFlags(&turnstileWithoutSitekey); err == nil || !strings.Contains(err.Error(), "--turnstile-sitekey is required") {
+		t.Fatalf("Turnstile gate without sitekey error = %v, want required-sitekey error", err)
+	}
+	sitekeyWithoutSecret := turnstileGate
+	sitekeyWithoutSecret.turnstileSecretEnv = ""
+	sitekeyWithoutSecret.unsafeNoHumanGate = true
+	if err := validateFlags(&sitekeyWithoutSecret); err == nil || !strings.Contains(err.Error(), "--turnstile-sitekey requires") {
+		t.Fatalf("Turnstile sitekey without secret error = %v, want requires-secret error", err)
+	}
+	unsupportedTurnstileOrigin := turnstileGate
+	unsupportedTurnstileOrigin.turnstileOrigin = "https://challenge.vendor.example"
+	if err := validateFlags(&unsupportedTurnstileOrigin); err == nil || !strings.Contains(err.Error(), "--turnstile-origin must be") {
+		t.Fatalf("unsupported Turnstile origin error = %v, want fixed-origin error", err)
 	}
 	if err := validateAllowOrigin("https://site.example:65535"); err != nil {
 		t.Fatalf("maximum valid origin port should validate: %v", err)
@@ -1840,12 +1861,48 @@ func TestBrokerContentSecurityPolicy_DefaultsToNoFraming(t *testing.T) {
 	}
 	for _, want := range []string{
 		"script-src 'self' blob: 'wasm-unsafe-eval' https://challenge.vendor.example;",
+		"script-src-attr 'none';",
 		"connect-src 'self' https://challenge.vendor.example;",
 		"frame-src https://challenge.vendor.example;",
 	} {
 		if !strings.Contains(withOrigin, want) {
 			t.Fatalf("CSP = %q, missing %q", withOrigin, want)
 		}
+	}
+}
+
+func TestValidateStaticUIRejectsCSPIncompatibleMarkup(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "external script", body: `<script src="viewer.js"></script>`},
+		{name: "Turnstile script", body: `<script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>`},
+		{name: "JSON data block", body: `<script type="application/json">{"safe":true}</script>`},
+		{name: "inline script", body: `<script>window.bad = true</script>`, want: "inline script"},
+		{name: "inline handler", body: `<button onclick="bad()">go</button>`, want: "inline event handler"},
+		{name: "third-party script", body: `<script src="https://analytics.example/array.js"></script>`, want: "not permitted"},
+		{name: "base element", body: `<base href="/">`, want: "base element"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(tc.body), 0o600); err != nil {
+				t.Fatalf("write index: %v", err)
+			}
+			err := validateStaticUI(dir)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("validateStaticUI: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validateStaticUI error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -74,7 +74,8 @@ docker run --rm "${BROKER_TAG}" serve \
 	--code preflight \
 	--global-daily-budget 1 \
 	--vm-daily-turn-budget 1 \
-	--unsafe-no-human-gate
+	--unsafe-no-human-gate \
+	--static-dir /srv/ui
 
 if [ "${PLAYGROUND_PUSH:-}" = "1" ]; then
 	echo "[build-images] pushing ${VM_TAG}"

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -74,7 +74,10 @@ docker run --rm "${BROKER_TAG}" serve \
 	--code preflight \
 	--global-daily-budget 1 \
 	--vm-daily-turn-budget 1 \
-	--unsafe-no-human-gate \
+	--turnstile-secret-env PREFLIGHT_TURNSTILE_SECRET \
+	--turnstile-sitekey 1x00000000000000000000AA \
+	--turnstile-expected-hostname preflight.invalid \
+	--turnstile-action preflight-session \
 	--static-dir /srv/ui
 
 if [ "${PLAYGROUND_PUSH:-}" = "1" ]; then

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -65,6 +65,17 @@ docker build -f deploy/fly-playground/Dockerfile.broker \
 	--build-context "ui=${PLAYGROUND_UI_DIR}" \
 	-t "${BROKER_TAG}" .
 
+echo "[build-images] validating broker/viewer image contract"
+docker run --rm "${BROKER_TAG}" serve \
+	--check-config \
+	--fly-app preflight \
+	--fly-token-env PREFLIGHT_FLY_TOKEN \
+	--image preflight \
+	--code preflight \
+	--global-daily-budget 1 \
+	--vm-daily-turn-budget 1 \
+	--unsafe-no-human-gate
+
 if [ "${PLAYGROUND_PUSH:-}" = "1" ]; then
 	echo "[build-images] pushing ${VM_TAG}"
 	docker push "${VM_TAG}"

--- a/docs/guides/playground-broker-operations.md
+++ b/docs/guides/playground-broker-operations.md
@@ -58,6 +58,8 @@ pipelock-playground-broker serve \
   --admin-listen 127.0.0.1:8101 \
   --admin-token-env PLAYGROUND_ADMIN_TOKEN \
   --turnstile-secret-env PLAYGROUND_TURNSTILE_SECRET \
+  --turnstile-sitekey 1x00000000000000000000AA \
+  --turnstile-origin https://challenges.cloudflare.com \
   --turnstile-expected-hostname playground.example.com \
   --turnstile-action playground-session \
   --vm-model-base-url https://api.provider.example/v1 \
@@ -217,8 +219,13 @@ visitor to a broker that does not recognize its token.
 
 Deploy sequence:
 
-1. Build and publish the VM image.
-2. Start the broker with explicit budgets and Turnstile enabled.
+1. Build both images with `deploy/fly-playground/build-images.sh`. The build
+   runs `serve --check-config` inside the broker image and refuses to publish
+   when the baked viewer is incompatible with its CSP or the non-secret
+   configuration is invalid.
+2. Start the broker with explicit budgets, `--turnstile-sitekey`, and Turnstile
+   enabled. The viewer is fixed to Cloudflare's
+   `https://challenges.cloudflare.com` origin.
 3. Check `/api/live/health`.
 4. Run one valid session through the public hostname.
 5. Run one invalid Turnstile/session request and confirm it fails closed.
@@ -227,7 +234,9 @@ Deploy sequence:
 Rollback sequence:
 
 1. Pause the current broker with `SIGUSR1`.
-2. Redeploy the prior broker image or config.
+2. Redeploy the prior broker image and its matching argument configuration
+   together. An old binary can reject flags introduced by a newer config, and
+   a new binary can require settings absent from an older config.
 3. Confirm health and budget values.
 4. Run the invalid-token and pause/resume checks again before sending traffic
    back.


### PR DESCRIPTION
Prevent incompatible broker and viewer configurations from reaching startup.

Add a configuration-only preflight that validates invite codes, public hosts, Access policy, and the baked static viewer without resolving secrets or contacting the machine provider. Run that preflight as part of the broker image build.

Require complete Turnstile configuration, keep its browser origin consistent with the viewer, reject CSP-incompatible static markup, and document image/config rollback as one atomic operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `check-config` preflight mode to validate broker flags and static UI CSP/script compatibility without contacting external providers or resolving secrets.
  - Improved Turnstile handling by enforcing required sitekey settings and strictly validating the effective Turnstile origin.
- **Bug Fixes**
  - Hardened security headers and CSP to better prevent unsupported inline scripts/handlers and incompatible script sources.
- **Documentation**
  - Updated playground broker deployment/rollback instructions with explicit Turnstile and budget configuration, plus clearer binary/config compatibility notes.
- **Chores**
  - Image publishing now fails fast if the new preflight validation does not pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->