### PR TITLE
fix(playground): support self-managed containment capture

### DIFF
--- a/cmd/pipelock-playground-demo/main.go
+++ b/cmd/pipelock-playground-demo/main.go
@@ -17,9 +17,11 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -167,12 +169,15 @@ Output goes to --out (default: stdout).`,
 
 func newRunCmd() *cobra.Command {
 	var (
-		contained   bool
-		runDir      string
-		scenario    string
-		color       bool
-		runNonce    string
-		orchKeyFile string
+		contained              bool
+		selfManagedContainment bool
+		toyAgentBin            string
+		proxyPort              int
+		runDir                 string
+		scenario               string
+		color                  bool
+		runNonce               string
+		orchKeyFile            string
 	)
 	cmd := &cobra.Command{
 		Use:   "run",
@@ -184,16 +189,27 @@ an offline-verifiable Audit Packet, and renders the mediator timeline.
 Exit 0 = run verified successfully. Non-zero = verification failed or run error.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			w := cmd.OutOrStdout()
+			if contained && !selfManagedContainment {
+				return errors.New("--contained requires --self-managed-containment; the stock contain service already owns its authorized proxy port")
+			}
+			if selfManagedContainment && !contained {
+				return errors.New("--self-managed-containment requires --contained")
+			}
+			if selfManagedContainment && strings.TrimSpace(toyAgentBin) == "" {
+				return errors.New("--self-managed-containment requires --toyagent-bin")
+			}
+			if selfManagedContainment && (proxyPort < 1 || proxyPort > 65535) &&
+				cmd.Flags().Changed("proxy-port") {
+				return errors.New("--proxy-port must be 1-65535")
+			}
+			effectiveProxyPort := demoProxyPort(contained, selfManagedContainment, proxyPort, cmd.Flags().Changed("proxy-port"))
 			if contained {
-				// Register the real (host-only) containment hook. Its Setup
-				// requires root + an installed `pipelock contain`; the
-				// host-containment witness probe runs as the contained agent
-				// user and fails loudly rather than silently running
-				// uncontained.
-				playground.SetContainmentHook(playground.NewRealContainmentHook(""))
+				playground.SetContainmentHook(demoContainmentHook(selfManagedContainment, toyAgentBin))
 			}
 			rep, err := playground.RunDemo(cmd.Context(), w, playground.DemoOpts{
 				Contained:           contained,
+				ProxyPort:           effectiveProxyPort,
+				ToyAgentBin:         toyAgentBin,
 				ScenarioID:          scenario,
 				RunNonce:            runNonce,
 				RunDir:              runDir,
@@ -209,7 +225,10 @@ Exit 0 = run verified successfully. Non-zero = verification failed or run error.
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&contained, "contained", false, "run in kernel-containment mode (requires Task 7 hook)")
+	cmd.Flags().BoolVar(&contained, "contained", false, "run in kernel-containment mode")
+	cmd.Flags().BoolVar(&selfManagedContainment, "self-managed-containment", false, "prove a deployment-managed canonical containment ruleset without requiring `pipelock contain install` (requires --contained and --toyagent-bin)")
+	cmd.Flags().StringVar(&toyAgentBin, "toyagent-bin", "", "toy-agent probe binary used by --self-managed-containment")
+	cmd.Flags().IntVar(&proxyPort, "proxy-port", 0, "fixed loopback proxy port authorized by the containment policy (contained default 8888; ignored when uncontained)")
 	cmd.Flags().StringVar(&orchKeyFile, "orchestrator-key-file", "", "path to the stable orchestrator signing key (default: the installed published demo key, else an ephemeral per-run key)")
 	cmd.Flags().StringVar(&runDir, "run-dir", "", "directory for run artifacts (required)")
 	cmd.Flags().StringVar(&scenario, "scenario", playground.LiveDemoScenarioID, "scenario ID to run")
@@ -217,6 +236,23 @@ Exit 0 = run verified successfully. Non-zero = verification failed or run error.
 	cmd.Flags().StringVar(&runNonce, "run-nonce", "", "unique run identifier (default: generated)")
 	_ = cmd.MarkFlagRequired("run-dir")
 	return cmd
+}
+
+func demoContainmentHook(selfManaged bool, toyAgentBin string) playground.ContainmentHook {
+	if selfManaged {
+		return playground.NewInVMContainmentHook(toyAgentBin)
+	}
+	return playground.NewRealContainmentHook("")
+}
+
+func demoProxyPort(contained, selfManaged bool, configured int, explicitlySet bool) int {
+	if !contained || !selfManaged {
+		return 0
+	}
+	if explicitlySet {
+		return configured
+	}
+	return playground.DefaultContainedProxyPort
 }
 
 func newResetCmd() *cobra.Command {

--- a/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
+++ b/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
@@ -66,3 +66,107 @@ func TestRunCmd_Uncontained_ExitZero(t *testing.T) {
 		t.Fatalf("output must contain VERIFY OK, got:\n%s", out)
 	}
 }
+
+func TestRunCmd_SelfManagedContainmentRequiresContained(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"run",
+		"--run-dir", t.TempDir(),
+		"--self-managed-containment",
+		"--toyagent-bin", "/tmp/probe",
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires --contained") {
+		t.Fatalf("error = %v, want --contained requirement", err)
+	}
+}
+
+func TestRunCmd_ContainedRejectsImpossibleStockPortCollision(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"run", "--run-dir", t.TempDir(), "--contained"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "stock contain service") {
+		t.Fatalf("error = %v, want stock proxy collision explanation", err)
+	}
+}
+
+func TestRunCmd_SelfManagedContainmentRequiresProbeBinary(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"run",
+		"--run-dir", t.TempDir(),
+		"--contained",
+		"--self-managed-containment",
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires --toyagent-bin") {
+		t.Fatalf("error = %v, want --toyagent-bin requirement", err)
+	}
+}
+
+func TestRunCmd_SelfManagedContainmentRejectsExplicitZeroProxyPort(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"run",
+		"--run-dir", t.TempDir(),
+		"--contained",
+		"--self-managed-containment",
+		"--toyagent-bin", "/tmp/probe",
+		"--proxy-port", "0",
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "1-65535") {
+		t.Fatalf("error = %v, want proxy-port range error", err)
+	}
+}
+
+func TestRunCmd_SelfManagedContainmentSelectsHookBeforeFailingProbe(t *testing.T) {
+	playground.SetContainmentHook(nil)
+	t.Cleanup(func() { playground.SetContainmentHook(nil) })
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"run", "--run-dir", t.TempDir(), "--contained", "--self-managed-containment",
+		"--toyagent-bin", "/nonexistent/toyagent", "--proxy-port", "8888",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("unproven self-managed containment should fail closed")
+	}
+}
+
+func TestDemoProxyPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		contained     bool
+		selfManaged   bool
+		configured    int
+		explicitlySet bool
+		want          int
+	}{
+		{name: "uncontained stays ephemeral", configured: 8899, explicitlySet: true, want: 0},
+		{name: "stock contained preserves existing behavior", contained: true, want: 0},
+		{name: "self-managed defaults to managed port", contained: true, selfManaged: true, want: playground.DefaultContainedProxyPort},
+		{name: "self-managed custom policy", contained: true, selfManaged: true, configured: 8899, explicitlySet: true, want: 8899},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := demoProxyPort(tc.contained, tc.selfManaged, tc.configured, tc.explicitlySet); got != tc.want {
+				t.Fatalf("demoProxyPort() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDemoContainmentHookSelection(t *testing.T) {
+	t.Parallel()
+	const probe = "/usr/local/bin/probe"
+	self, ok := demoContainmentHook(true, probe).(*playground.InVMContainmentHook)
+	if !ok || self.ToyAgentBin != probe {
+		t.Fatalf("self-managed hook = %#v", self)
+	}
+	if _, ok := demoContainmentHook(false, probe).(*playground.RealContainmentHook); !ok {
+		t.Fatal("stock mode did not select RealContainmentHook")
+	}
+}

--- a/cmd/pipelock-playground-live/main.go
+++ b/cmd/pipelock-playground-live/main.go
@@ -241,9 +241,6 @@ func buildServer(out io.Writer, f *serveFlags) (*livechat.Server, http.Handler, 
 		if err := validateModelAgentRuntime(llmAgent); err != nil {
 			return nil, nil, err
 		}
-		// Contained serve binds a fixed proxy port to match the kernel owner-match
-		// rule. Default it to the stock `pipelock contain install` port; an
-		// operator who installed containment on a custom port passes --proxy-port.
 	}
 
 	srv, err := livechat.NewServer(livechat.ServerConfig{

--- a/cmd/pipelock-playground-live/main.go
+++ b/cmd/pipelock-playground-live/main.go
@@ -69,6 +69,8 @@ type serveFlags struct {
 	toyAgentBin            string
 	webToolBin             string
 	proxyPort              int
+	operatorUID            int
+	proxyUID               int
 	sessionTTL             time.Duration
 	maxInputBytes          int
 	ipRate                 float64
@@ -98,7 +100,10 @@ type serveFlags struct {
 // defaultMaxPerCode is the safe default lifetime session budget per invite code.
 // Unlimited reuse (0) must be opted into explicitly so a leaked code cannot mint
 // sessions forever.
-const defaultMaxPerCode = 25
+const (
+	defaultMaxPerCode = 25
+	defaultAgentUser  = "pipelock-agent"
+)
 
 func newServeCmd() *cobra.Command {
 	f := &serveFlags{}
@@ -122,6 +127,8 @@ func newServeCmd() *cobra.Command {
 	fl.StringVar(&f.toyAgentBin, "toyagent-bin", "", "toy-agent binary path (needed for the contained host-containment witness)")
 	fl.StringVar(&f.webToolBin, "webtool-bin", "", "web-tool binary path (needed for the contained host-containment witness)")
 	fl.IntVar(&f.proxyPort, "proxy-port", 0, "fixed loopback port the in-process proxy binds; must match `pipelock contain install --proxy-port` (defaults to 8888 in contained mode). 0 = ephemeral, dev/test only")
+	fl.IntVar(&f.operatorUID, "operator-uid", 0, "operator uid accepted by a self-managed containment ruleset")
+	fl.IntVar(&f.proxyUID, "proxy-uid", 0, "proxy uid accepted by a self-managed containment ruleset")
 	fl.DurationVar(&f.sessionTTL, "session-ttl", 600*time.Second, "per-session wall-clock cap")
 	fl.IntVar(&f.maxInputBytes, "max-input-bytes", 2048, "per-message input size cap")
 	fl.Float64Var(&f.ipRate, "ip-rate", 0.5, "per-IP sustained request rate (tokens/sec)")
@@ -184,6 +191,9 @@ func buildServer(out io.Writer, f *serveFlags) (*livechat.Server, http.Handler, 
 		requireContainment = false
 		_, _ = fmt.Fprintln(out, "WARNING: --dev set: running UNCONTAINED. Visitors are not kernel-isolated. Never use for public exposure.")
 	}
+	if requireContainment {
+		f.proxyPort = containedProxyPort(f.proxyPort)
+	}
 
 	secret, err := resolveSecret(f.secretB64, f.secretFile)
 	if err != nil {
@@ -211,7 +221,7 @@ func buildServer(out io.Writer, f *serveFlags) (*livechat.Server, http.Handler, 
 			// owner-match rule; verify the egress drop empirically rather than
 			// asking `pipelock contain verify` whether `pipelock contain install`
 			// ran on this host.
-			verifier = inVMContainVerifier{toyAgentBin: f.toyAgentBin}
+			verifier = selfManagedContainmentVerifier(f)
 		} else {
 			verifier = containVerifier{}
 		}
@@ -234,13 +244,6 @@ func buildServer(out io.Writer, f *serveFlags) (*livechat.Server, http.Handler, 
 		// Contained serve binds a fixed proxy port to match the kernel owner-match
 		// rule. Default it to the stock `pipelock contain install` port; an
 		// operator who installed containment on a custom port passes --proxy-port.
-		f.proxyPort = containedProxyPort(f.proxyPort)
-		if f.concurrency != 1 {
-			// One fixed proxy port can host one contained session at a time; the
-			// second concurrent session fails its bind and returns 503. Warn rather
-			// than block (the runtime is fail-safe), and point at the fix.
-			_, _ = fmt.Fprintf(out, "warning: contained serve binds one fixed proxy port (%d); concurrent sessions past the first fail to start. Set --concurrency 1 to avoid 503s.\n", f.proxyPort)
-		}
 	}
 
 	srv, err := livechat.NewServer(livechat.ServerConfig{
@@ -325,12 +328,18 @@ func validateServeSafety(f *serveFlags, modelBacked bool) error {
 	if !f.dev && !f.requireContainment {
 		return errors.New("non-dev serve requires containment; use --dev for local uncontained testing")
 	}
+	if !f.dev && f.concurrency != 1 {
+		return errors.New("contained serve requires --concurrency 1 because one fixed proxy port can host only one session")
+	}
 	if f.selfManagedContainment {
 		if f.dev {
 			return errors.New("--self-managed-containment cannot be combined with --dev (it IS a contained mode)")
 		}
 		if strings.TrimSpace(f.toyAgentBin) == "" {
 			return errors.New("--self-managed-containment requires --toyagent-bin (the start-gate egress probe binary)")
+		}
+		if f.operatorUID < 0 || f.proxyUID < 0 {
+			return errors.New("--operator-uid and --proxy-uid must be non-negative")
 		}
 	}
 	if f.proxyPort < 0 || f.proxyPort > 65535 {
@@ -550,7 +559,7 @@ func newPrintNFTCmd() *cobra.Command {
 	return cmd
 }
 
-// newVerifyContainmentCmd runs the install-agnostic in-VM containment start gate
+// newVerifyContainmentCmd runs the installer-independent in-VM containment start gate
 // (playground.VerifyInVMContainment) and exits non-zero if the contained agent
 // uid's direct egress is not proven blocked. A per-visitor microVM boot
 // entrypoint runs this AFTER loading the nft rule and BEFORE starting the
@@ -561,20 +570,26 @@ func newVerifyContainmentCmd() *cobra.Command {
 	var (
 		toyAgentBin string
 		agentUser   string
+		proxyPort   int
+		operatorUID int
+		proxyUID    int
 	)
 	cmd := &cobra.Command{
 		Use:   "verify-containment",
 		Short: "Prove the contained agent uid's egress/local escape surfaces are blocked (fail-closed boot gate for self-managed containment)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := playground.VerifyInVMContainment(cmd.Context(), toyAgentBin, agentUser); err != nil {
+			if err := playground.VerifyInVMContainmentWithUIDs(cmd.Context(), toyAgentBin, agentUser, proxyPort, operatorUID, proxyUID); err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "containment verified: contained agent egress/local escape surfaces are blocked; operator + proxy paths intact")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "containment verified: contained agent egress and local escape checks passed; operator + proxy paths intact")
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&toyAgentBin, "toyagent-bin", "", "probe binary (the pipelock-playground-toyagent path); required")
 	cmd.Flags().StringVar(&agentUser, "agent-user", "pipelock-agent", "contained agent username")
+	cmd.Flags().IntVar(&proxyPort, "proxy-port", playground.DefaultContainedProxyPort, "fixed loopback proxy port authorized by the loaded owner-match rule")
+	cmd.Flags().IntVar(&operatorUID, "operator-uid", 0, "operator uid accepted by the loaded owner-match rule")
+	cmd.Flags().IntVar(&proxyUID, "proxy-uid", 0, "proxy uid accepted by the loaded owner-match rule")
 	return cmd
 }
 
@@ -622,8 +637,21 @@ func (containVerifier) Verify(_ context.Context) error {
 type inVMContainVerifier struct {
 	toyAgentBin string
 	agentUser   string
+	proxyPort   int
+	operatorUID int
+	proxyUID    int
+}
+
+func selfManagedContainmentVerifier(f *serveFlags) inVMContainVerifier {
+	return inVMContainVerifier{
+		toyAgentBin: f.toyAgentBin,
+		agentUser:   defaultAgentUser,
+		proxyPort:   f.proxyPort,
+		operatorUID: f.operatorUID,
+		proxyUID:    f.proxyUID,
+	}
 }
 
 func (v inVMContainVerifier) Verify(ctx context.Context) error {
-	return playground.VerifyInVMContainment(ctx, v.toyAgentBin, v.agentUser)
+	return playground.VerifyInVMContainmentWithUIDs(ctx, v.toyAgentBin, v.agentUser, v.proxyPort, v.operatorUID, v.proxyUID)
 }

--- a/cmd/pipelock-playground-live/main_test.go
+++ b/cmd/pipelock-playground-live/main_test.go
@@ -317,6 +317,13 @@ func TestBuildServer_SelfManagedContainmentSelectsInVMVerifier(t *testing.T) {
 	f.toyAgentBin = "/usr/local/bin/pipelock-playground-toyagent"
 	f.orchestratorKey = testOrchestratorKeyPath(t)
 	f.concurrency = 1
+	f.proxyPort = playground.DefaultContainedProxyPort
+	f.operatorUID = 1000
+	f.proxyUID = 1001
+	selected := selfManagedContainmentVerifier(f)
+	if selected.toyAgentBin != f.toyAgentBin || selected.agentUser != defaultAgentUser || selected.proxyPort != f.proxyPort || selected.operatorUID != 1000 || selected.proxyUID != 1001 {
+		t.Fatalf("self-managed verifier wiring = %+v", selected)
+	}
 	var out bytes.Buffer
 	srv, handler, err := buildServer(&out, f)
 	if err != nil {
@@ -365,6 +372,7 @@ func TestBuildServer_PublicModelRequiresDailyBudget(t *testing.T) {
 	f := devServeFlags()
 	f.dev = false
 	f.requireContainment = true
+	f.concurrency = 1
 	f.codes = []string{"good"}
 	f.llmAgentBin = testExecutablePath(t)
 	f.modelBaseURL = "http://provider.example/v1"
@@ -393,6 +401,7 @@ func TestBuildServer_RequireModelFailsClosedWithoutModelConfig(t *testing.T) {
 	f := devServeFlags()
 	f.dev = false
 	f.requireContainment = true
+	f.concurrency = 1
 	f.requireModel = true
 	f.codes = []string{"good"}
 	f.orchestratorKey = testOrchestratorKeyPath(t)
@@ -408,6 +417,7 @@ func TestBuildServer_PublicModelValidatesRuntimeFiles(t *testing.T) {
 	f := devServeFlags()
 	f.dev = false
 	f.requireContainment = true
+	f.concurrency = 1
 	f.codes = []string{"good"}
 	f.llmAgentBin = testExecutablePath(t)
 	f.modelBaseURL = "http://provider.example/v1"
@@ -445,6 +455,7 @@ func TestBuildServer_NonDevValidatesOrchestratorKey(t *testing.T) {
 	f := devServeFlags()
 	f.dev = false
 	f.requireContainment = true
+	f.concurrency = 1
 	f.codes = []string{"good"}
 	f.orchestratorKey = filepath.Join(t.TempDir(), "missing.key")
 	var out bytes.Buffer
@@ -455,7 +466,7 @@ func TestBuildServer_NonDevValidatesOrchestratorKey(t *testing.T) {
 
 func TestValidateServeSafety_NonDevRequiresOrchestratorKey(t *testing.T) {
 	t.Parallel()
-	f := serveFlags{requireContainment: true}
+	f := serveFlags{requireContainment: true, concurrency: 1}
 	if err := validateServeSafety(&f, false); err == nil {
 		t.Fatal("non-dev server without orchestrator key should fail closed")
 	}
@@ -491,6 +502,9 @@ func TestValidateServeSafety_SelfManagedContainment(t *testing.T) {
 	}{
 		{name: "dev_conflict", f: serveFlags{dev: true, selfManagedContainment: true}},
 		{name: "missing_toyagent", f: serveFlags{requireContainment: true, selfManagedContainment: true}},
+		{name: "multiple_sessions_share_one_proxy_port", f: serveFlags{requireContainment: true, selfManagedContainment: true, toyAgentBin: "/agent", concurrency: 2}},
+		{name: "stock_containment_multiple_sessions_share_one_proxy_port", f: serveFlags{requireContainment: true, concurrency: 2}},
+		{name: "negative_self_managed_uid", f: serveFlags{requireContainment: true, selfManagedContainment: true, toyAgentBin: "/agent", concurrency: 1, operatorUID: -1}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := validateServeSafety(&tc.f, false); err == nil {

--- a/cmd/pipelock-playground-toyagent/probe_test.go
+++ b/cmd/pipelock-playground-toyagent/probe_test.go
@@ -129,8 +129,8 @@ func TestRunLocalProbe_UnavailableUnixSocket(t *testing.T) {
 	if len(results) != 1 {
 		t.Fatalf("got %d results, want 1", len(results))
 	}
-	if results[0].Target != target || results[0].Open || !results[0].Blocked {
-		t.Fatalf("local probe = %+v, want unavailable socket classified as blocked", results[0])
+	if results[0].Target != target || results[0].Open || results[0].Blocked || !results[0].Absent {
+		t.Fatalf("local probe = %+v, want missing socket classified as absent", results[0])
 	}
 }
 

--- a/deploy/fly-playground/entrypoint.sh
+++ b/deploy/fly-playground/entrypoint.sh
@@ -27,8 +27,16 @@ LLM_AGENT_BIN=/usr/local/bin/pipelock-playground-llm-agent
 VERIFIER_LINUX=/usr/local/bin/pipelock-verifier-linux
 VERIFIER_MACOS=/usr/local/bin/pipelock-verifier-macos
 VERIFIER_WINDOWS=/usr/local/bin/pipelock-verifier-windows.exe
+NFT_BIN=/usr/sbin/nft
+[ -x "${NFT_BIN}" ] || NFT_BIN=/usr/bin/nft
 
 log() { printf '[entrypoint] %s\n' "$*" >&2; }
+
+ACTUAL_AGENT_UID="$(id -u "${AGENT_USER}")"
+if [ "${AGENT_USER}" != "pipelock-agent" ] || [ "${AGENT_UID}" != "${ACTUAL_AGENT_UID}" ]; then
+	log "agent identity mismatch: deployment requires pipelock-agent uid 10001 (got ${AGENT_USER} uid ${ACTUAL_AGENT_UID}, configured uid ${AGENT_UID})"
+	exit 1
+fi
 
 # --- 0. Disable unprivileged user namespaces when the kernel exposes the knob ---
 # The LLM agent has a real shell. It does not need user namespaces, and a visitor
@@ -65,11 +73,13 @@ fi
 
 # --- 1. Load the proven owner-match egress rule (shipped renderer) --------------
 log "loading containment nft rule (agent uid ${AGENT_UID} -> only 127.0.0.1:${PROXY_PORT})"
-"${BIN}" print-containment-nft --agent-uid "${AGENT_UID}" --proxy-port "${PROXY_PORT}" | nft -f -
+RULES_FILE="${SECRET_DIR}/containment.nft"
+"${BIN}" print-containment-nft --agent-uid "${AGENT_UID}" --proxy-port "${PROXY_PORT}" >"${RULES_FILE}"
+"${NFT_BIN}" -f "${RULES_FILE}"
 
 # --- 2. Prove the drop is live BEFORE serving (fail-closed boot gate) ------------
-log "proving containment (aborts the VM if the agent uid can still egress or use local escape surfaces)"
-"${BIN}" verify-containment --toyagent-bin "${TOYAGENT_BIN}" --agent-user "${AGENT_USER}"
+log "proving containment (aborts the VM if egress or local escape checks fail)"
+"${BIN}" verify-containment --toyagent-bin "${TOYAGENT_BIN}" --agent-user "${AGENT_USER}" --proxy-port "${PROXY_PORT}"
 
 # --- 3. Per-session serve flags from broker-provided env ------------------------
 # The broker sets these PLAYGROUND_* env vars per machine; map the ones present to
@@ -104,6 +114,8 @@ exec "${BIN}" serve \
 	--require-model \
 	--listen "${LISTEN}" \
 	--proxy-port "${PROXY_PORT}" \
+	--operator-uid 0 \
+	--proxy-uid 0 \
 	--concurrency 1 \
 	--toyagent-bin "${TOYAGENT_BIN}" \
 	--webtool-bin "${WEBTOOL_BIN}" \

--- a/docs/guides/playground-demo.md
+++ b/docs/guides/playground-demo.md
@@ -56,7 +56,10 @@ contained. The tool's contribution is to *attest* that property for a specific r
 offline-verifiable host-containment witness records what was probed from the contained position
 and proves the operator-vs-agent differential. Verifying the witness confirms the attestation;
 the underlying egress block remains host-enforced, not something this binary can guarantee on its
-own.
+own. In self-managed deployments, startup additionally validates the live nftables chain against
+the canonical Pipelock boundary before any agent runs. That structural startup check is a
+fail-closed execution gate; the signed witness records the run-specific empirical probes, not a
+copy or digest of the nftables ruleset.
 
 ## Run it
 
@@ -78,11 +81,16 @@ kernel boundary to attest, and the tool says so rather than implying one.
 ### Contained (the real demo — requires a prepared host)
 
 ```bash
-sudo pipelock-playground-demo run --contained --run-dir ./demo-run --scenario secret-exfil-body-blocked
+sudo pipelock-playground-demo run --contained --self-managed-containment \
+  --toyagent-bin /usr/local/bin/pipelock-playground-toyagent \
+  --proxy-port 8888 --run-dir ./demo-run --scenario secret-exfil-body-blocked
 ```
 
-Contained mode requires root, the `pipelock-agent` OS user, and a host where
-`pipelock contain install` has been run. Under the **split-proof** model the mediated steps
+Contained capture mode requires root, the `pipelock-agent` OS user, and a
+deployment-managed canonical owner-match boundary. The stock workstation
+service already owns its authorized proxy port, so deterministic contained
+capture uses `--self-managed-containment` rather than colliding with that
+listener. Under the **split-proof** model the mediated steps
 (allow, block) run as the operator through the lab proxy — exactly as in uncontained mode — and
 a separate probe phase drops to the `pipelock-agent` uid to build the signed host-containment
 witness. This split is deliberate: the proxy's allow/block decision does not depend on the
@@ -90,6 +98,15 @@ agent's uid, and on a host with global owner-match containment the contained use
 the demo's ephemeral lab proxy at all, so running the mediated steps contained would simply
 time out. Off a prepared host, the contained run fails loudly — it never silently falls back to
 uncontained while claiming containment.
+
+Deployments that manage an equivalent owner-match boundary themselves can use
+`--self-managed-containment --toyagent-bin /path/to/pipelock-playground-toyagent`.
+That mode does not require the stock installer, but it does require the live
+canonical `inet` owner-match ruleset and independently proves it empirically.
+It confirms the agent UID cannot reach a non-proxy loopback control port, the
+direct-egress suite, or local escape surfaces. Pass `--proxy-port` when the deployment
+authorizes a port other than the stock `8888`; the signed witness requires the
+contained agent to reach that exact proxy port and rejects every other route.
 
 ## Verify it yourself
 

--- a/internal/cli/contain/selfmanaged_verify.go
+++ b/internal/cli/contain/selfmanaged_verify.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+)
+
+type nftCommandOutput func(context.Context, string, ...string) ([]byte, error)
+
+// VerifySelfManagedNFTRules confirms that live kernel state contains the
+// canonical inet owner-match boundary for the supplied identities and port.
+func VerifySelfManagedNFTRules(ctx context.Context, operatorUID, proxyUID, agentUID, proxyPort int) error {
+	return verifySelfManagedNFTRules(ctx, operatorUID, proxyUID, agentUID, proxyPort, os.Stat, runNFTCommand)
+}
+
+func verifySelfManagedNFTRules(
+	ctx context.Context,
+	operatorUID, proxyUID, agentUID, proxyPort int,
+	statFn func(string) (fs.FileInfo, error),
+	run nftCommandOutput,
+) error {
+	nftPath, err := trustedNFTPath(statFn)
+	if err != nil {
+		return err
+	}
+	out, err := run(ctx, nftPath, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain)
+	if err != nil {
+		return fmt.Errorf("read live containment nft chain: %w: %s", err, oneLine(string(out)))
+	}
+	return validateSelfManagedNFTRules(string(out), operatorUID, proxyUID, agentUID, proxyPort)
+}
+
+func runNFTCommand(ctx context.Context, nftPath string, args ...string) ([]byte, error) {
+	// #nosec G204 -- trustedNFTPath restricts execution to a root-owned,
+	// non-writable binary at one of two fixed absolute system paths.
+	return exec.CommandContext(ctx, nftPath, args...).CombinedOutput()
+}
+
+func trustedNFTPath(statFn func(string) (fs.FileInfo, error)) (string, error) {
+	for _, path := range []string{"/usr/sbin/nft", "/usr/bin/nft"} {
+		if _, err := statFn(path); err != nil {
+			continue
+		}
+		if err := expectPrivilegedExecutablePath(statFn, "nft", path); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+	return "", fmt.Errorf("trusted nft executable not found at /usr/sbin/nft or /usr/bin/nft")
+}
+
+func validateSelfManagedNFTRules(out string, operatorUID, proxyUID, agentUID, proxyPort int) error {
+	if !nftTableDumpDeclaresExpectedTable(out, defaultNFTTable) ||
+		!liveNFTContainmentMatches(out, defaultNFTChain, operatorUID, proxyUID, agentUID, proxyPort) {
+		return fmt.Errorf("live containment nft chain does not match the canonical owner-match boundary for agent uid %d and proxy port %d", agentUID, proxyPort)
+	}
+	return nil
+}

--- a/internal/cli/contain/selfmanaged_verify.go
+++ b/internal/cli/contain/selfmanaged_verify.go
@@ -9,31 +9,44 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"time"
 )
 
 type nftCommandOutput func(context.Context, string, ...string) ([]byte, error)
 
+const selfManagedNFTTimeout = 5 * time.Second
+
+type selfManagedNFTVerifyOptions struct {
+	ctx         context.Context
+	operatorUID int
+	proxyUID    int
+	agentUID    int
+	proxyPort   int
+	statFn      func(string) (fs.FileInfo, error)
+	run         nftCommandOutput
+}
+
 // VerifySelfManagedNFTRules confirms that live kernel state contains the
 // canonical inet owner-match boundary for the supplied identities and port.
 func VerifySelfManagedNFTRules(ctx context.Context, operatorUID, proxyUID, agentUID, proxyPort int) error {
-	return verifySelfManagedNFTRules(ctx, operatorUID, proxyUID, agentUID, proxyPort, os.Stat, runNFTCommand)
+	return verifySelfManagedNFTRules(selfManagedNFTVerifyOptions{
+		ctx: ctx, operatorUID: operatorUID, proxyUID: proxyUID,
+		agentUID: agentUID, proxyPort: proxyPort, statFn: os.Stat, run: runNFTCommand,
+	})
 }
 
-func verifySelfManagedNFTRules(
-	ctx context.Context,
-	operatorUID, proxyUID, agentUID, proxyPort int,
-	statFn func(string) (fs.FileInfo, error),
-	run nftCommandOutput,
-) error {
-	nftPath, err := trustedNFTPath(statFn)
+func verifySelfManagedNFTRules(opts selfManagedNFTVerifyOptions) error {
+	nftPath, err := trustedNFTPath(opts.statFn)
 	if err != nil {
 		return err
 	}
-	out, err := run(ctx, nftPath, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain)
+	ctx, cancel := context.WithTimeout(opts.ctx, selfManagedNFTTimeout)
+	defer cancel()
+	out, err := opts.run(ctx, nftPath, "-n", "-a", "list", "chain", "inet", defaultNFTTable, defaultNFTChain)
 	if err != nil {
 		return fmt.Errorf("read live containment nft chain: %w: %s", err, oneLine(string(out)))
 	}
-	return validateSelfManagedNFTRules(string(out), operatorUID, proxyUID, agentUID, proxyPort)
+	return validateSelfManagedNFTRules(string(out), opts.operatorUID, opts.proxyUID, opts.agentUID, opts.proxyPort)
 }
 
 func runNFTCommand(ctx context.Context, nftPath string, args ...string) ([]byte, error) {

--- a/internal/cli/contain/selfmanaged_verify_test.go
+++ b/internal/cli/contain/selfmanaged_verify_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type rootFileInfo struct{ mode fs.FileMode }
+
+func (rootFileInfo) Name() string { return "nft" }
+func (rootFileInfo) Size() int64  { return 1 }
+func (f rootFileInfo) Mode() fs.FileMode {
+	if f.mode == 0 {
+		return 0o755
+	}
+	return f.mode
+}
+func (rootFileInfo) ModTime() time.Time { return time.Time{} }
+func (rootFileInfo) IsDir() bool        { return false }
+func (rootFileInfo) Sys() any           { return &syscall.Stat_t{Uid: 0} }
+
+func TestValidateSelfManagedNFTRules(t *testing.T) {
+	t.Parallel()
+
+	const operatorUID, proxyUID, agentUID, proxyPort = 0, 0, 10001, 8888
+	canonical := renderNFTRules(operatorUID, proxyUID, agentUID, proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := validateSelfManagedNFTRules(canonical, operatorUID, proxyUID, agentUID, proxyPort); err != nil {
+		t.Fatalf("canonical rules rejected: %v", err)
+	}
+	readback := strings.ReplaceAll(canonical, "counter ", "counter packets 0 bytes 0 ")
+	readback = strings.ReplaceAll(readback, " accept\n", " accept # handle 10\n")
+	readback = strings.ReplaceAll(readback, " drop\n", " drop # handle 11\n")
+	if err := validateSelfManagedNFTRules(readback, operatorUID, proxyUID, agentUID, proxyPort); err != nil {
+		t.Fatalf("nft-style readback rejected: %v", err)
+	}
+
+	nonDefault := renderNFTRules(1000, 1001, agentUID, proxyPort, defaultNFTTable, defaultNFTChain)
+	if err := validateSelfManagedNFTRules(nonDefault, 1000, 1001, agentUID, proxyPort); err != nil {
+		t.Fatalf("non-default operator/proxy UIDs rejected: %v", err)
+	}
+
+	t.Run("wrong proxy port", func(t *testing.T) {
+		t.Parallel()
+		if err := validateSelfManagedNFTRules(canonical, operatorUID, proxyUID, agentUID, 8899); err == nil {
+			t.Fatal("wrong proxy port accepted")
+		}
+	})
+	t.Run("tcp-only drop", func(t *testing.T) {
+		t.Parallel()
+		weakened := strings.Replace(canonical,
+			"meta skuid 10001 counter log prefix \"pipelock-contain class=not_routing_through_pipelock \" drop",
+			"meta skuid 10001 meta l4proto tcp counter drop", 1)
+		if err := validateSelfManagedNFTRules(weakened, operatorUID, proxyUID, agentUID, proxyPort); err == nil {
+			t.Fatal("TCP-only catch-all accepted")
+		}
+	})
+	t.Run("IPv4-only table", func(t *testing.T) {
+		t.Parallel()
+		weakened := strings.Replace(canonical, "table inet ", "table ip ", 1)
+		if err := validateSelfManagedNFTRules(weakened, operatorUID, proxyUID, agentUID, proxyPort); err == nil {
+			t.Fatal("IPv4-only table accepted")
+		}
+	})
+}
+
+func TestVerifySelfManagedNFTRulesWithDependencies(t *testing.T) {
+	t.Parallel()
+	canonical := renderNFTRules(1000, 1001, 10001, 8888, defaultNFTTable, defaultNFTChain)
+	statSecondPath := func(path string) (fs.FileInfo, error) {
+		if path == "/usr/sbin/nft" {
+			return nil, os.ErrNotExist
+		}
+		return rootFileInfo{}, nil
+	}
+
+	var gotPath string
+	run := func(ctx context.Context, path string, args ...string) ([]byte, error) {
+		gotPath = path
+		if err := context.Cause(ctx); err != nil {
+			return nil, err
+		}
+		if strings.Join(args, " ") != "-n -a list chain inet pipelock_containment output_filter" {
+			t.Fatalf("args = %q", args)
+		}
+		return []byte(canonical), nil
+	}
+	if err := verifySelfManagedNFTRules(context.Background(), 1000, 1001, 10001, 8888, statSecondPath, run); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if gotPath != "/usr/bin/nft" {
+		t.Fatalf("nft path = %q", gotPath)
+	}
+
+	t.Run("command failure includes output", func(t *testing.T) {
+		runErr := func(context.Context, string, ...string) ([]byte, error) {
+			return []byte("permission denied\n"), errors.New("exit 1")
+		}
+		err := verifySelfManagedNFTRules(context.Background(), 1000, 1001, 10001, 8888, statSecondPath, runErr)
+		if err == nil || !strings.Contains(err.Error(), "permission denied") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("trusted executable absent", func(t *testing.T) {
+		missing := func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist }
+		if err := verifySelfManagedNFTRules(context.Background(), 0, 0, 10001, 8888, missing, run); err == nil {
+			t.Fatal("missing nft executable accepted")
+		}
+	})
+
+	t.Run("untrusted executable rejected", func(t *testing.T) {
+		writable := func(string) (fs.FileInfo, error) { return rootFileInfo{mode: 0o777}, nil }
+		if err := verifySelfManagedNFTRules(context.Background(), 0, 0, 10001, 8888, writable, run); err == nil {
+			t.Fatal("world-writable nft executable accepted")
+		}
+	})
+}
+
+func TestRunNFTCommand(t *testing.T) {
+	t.Parallel()
+	out, err := runNFTCommand(context.Background(), "/bin/sh", "-c", "printf nft-ok")
+	if err != nil || string(out) != "nft-ok" {
+		t.Fatalf("runNFTCommand output=%q err=%v", out, err)
+	}
+}
+
+func TestVerifySelfManagedNFTRules_CanceledContextFailsClosed(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := VerifySelfManagedNFTRules(ctx, 0, 0, 10001, 8888); err == nil {
+		t.Fatal("canceled live nft verification accepted")
+	}
+}

--- a/internal/cli/contain/selfmanaged_verify_test.go
+++ b/internal/cli/contain/selfmanaged_verify_test.go
@@ -93,7 +93,11 @@ func TestVerifySelfManagedNFTRulesWithDependencies(t *testing.T) {
 		}
 		return []byte(canonical), nil
 	}
-	if err := verifySelfManagedNFTRules(context.Background(), 1000, 1001, 10001, 8888, statSecondPath, run); err != nil {
+	baseOpts := selfManagedNFTVerifyOptions{
+		ctx: context.Background(), operatorUID: 1000, proxyUID: 1001,
+		agentUID: 10001, proxyPort: 8888, statFn: statSecondPath, run: run,
+	}
+	if err := verifySelfManagedNFTRules(baseOpts); err != nil {
 		t.Fatalf("verify: %v", err)
 	}
 	if gotPath != "/usr/bin/nft" {
@@ -104,7 +108,9 @@ func TestVerifySelfManagedNFTRulesWithDependencies(t *testing.T) {
 		runErr := func(context.Context, string, ...string) ([]byte, error) {
 			return []byte("permission denied\n"), errors.New("exit 1")
 		}
-		err := verifySelfManagedNFTRules(context.Background(), 1000, 1001, 10001, 8888, statSecondPath, runErr)
+		opts := baseOpts
+		opts.run = runErr
+		err := verifySelfManagedNFTRules(opts)
 		if err == nil || !strings.Contains(err.Error(), "permission denied") {
 			t.Fatalf("error = %v", err)
 		}
@@ -112,15 +118,33 @@ func TestVerifySelfManagedNFTRulesWithDependencies(t *testing.T) {
 
 	t.Run("trusted executable absent", func(t *testing.T) {
 		missing := func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist }
-		if err := verifySelfManagedNFTRules(context.Background(), 0, 0, 10001, 8888, missing, run); err == nil {
+		opts := baseOpts
+		opts.statFn = missing
+		if err := verifySelfManagedNFTRules(opts); err == nil {
 			t.Fatal("missing nft executable accepted")
 		}
 	})
 
 	t.Run("untrusted executable rejected", func(t *testing.T) {
 		writable := func(string) (fs.FileInfo, error) { return rootFileInfo{mode: 0o777}, nil }
-		if err := verifySelfManagedNFTRules(context.Background(), 0, 0, 10001, 8888, writable, run); err == nil {
+		opts := baseOpts
+		opts.statFn = writable
+		if err := verifySelfManagedNFTRules(opts); err == nil {
 			t.Fatal("world-writable nft executable accepted")
+		}
+	})
+
+	t.Run("command receives bounded context", func(t *testing.T) {
+		opts := baseOpts
+		opts.run = func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok || time.Until(deadline) > selfManagedNFTTimeout {
+				t.Fatalf("bounded deadline missing or too long: %v, %v", deadline, ok)
+			}
+			return []byte(canonical), nil
+		}
+		if err := verifySelfManagedNFTRules(opts); err != nil {
+			t.Fatalf("verify with bounded context: %v", err)
 		}
 	})
 }

--- a/internal/playground/bundle_build.go
+++ b/internal/playground/bundle_build.go
@@ -127,13 +127,14 @@ func buildDecisions(narr scenarioNarrative, receipts []receipt.Receipt, rep Veri
 
 	// --- HOST CONTAINMENT (contained runs only) ---
 	if hcw != nil {
+		localDenied, localAbsent := hcw.LocalProbeCounts()
 		decisions = append(decisions, BundleDecision{
 			Beat:     narr.containDecision.beat,
 			Class:    string(ClassHostContainment),
 			Color:    narr.containDecision.color,
 			Headline: narr.containDecision.headline,
-			Body: fmt.Sprintf("%d direct-egress routes and %d local escape surfaces blocked for the contained agent; the same control target stayed reachable for the operator.",
-				len(hcw.AgentProbes), len(hcw.LocalAgentProbes)),
+			Body: fmt.Sprintf("%d direct-egress routes blocked; %d local escape operations denied and %d host-specific surfaces absent for the contained agent; the same control target stayed reachable for the operator.",
+				len(hcw.AgentProbes), localDenied, localAbsent),
 			Meta:     "owner-match drop · local hardening · enforced by the host kernel",
 			Signer:   bundleSignerOrch,
 			Key:      shortKey(rep.OrchestratorKey),

--- a/internal/playground/bundle_internal_test.go
+++ b/internal/playground/bundle_internal_test.go
@@ -165,10 +165,11 @@ func TestHydrateAgentActs(t *testing.T) {
 
 func bundleTestHCW() HostContainmentWitness {
 	return HostContainmentWitness{
-		RunNonce:    "n",
-		AgentProbes: []ProbeResult{{Target: "169.254.169.254:80", Blocked: true}, {Target: "10.0.0.1:443", Blocked: true}},
-		ProbedAt:    time.Unix(testFixtureTS, 0).UTC(),
-		Signature:   "hcw-sig",
+		ProbeSuiteVersion: currentContainmentProbeSuite,
+		RunNonce:          "n",
+		AgentProbes:       []ProbeResult{{Target: "169.254.169.254:80", Blocked: true}, {Target: "10.0.0.1:443", Blocked: true}},
+		ProbedAt:          time.Unix(testFixtureTS, 0).UTC(),
+		Signature:         "hcw-sig",
 	}
 }
 
@@ -217,7 +218,7 @@ func TestBuildDecisions(t *testing.T) {
 	if got := strings.Join(dc[2].Envelope, "\n"); !strings.Contains(got, "hcw-sig") || !strings.Contains(got, "agent_probes") {
 		t.Fatalf("host-containment decision must carry the signed witness envelope:\n%s", got)
 	}
-	if !strings.Contains(dc[2].Body, "2 direct-egress routes and 0 local escape surfaces") {
+	if !strings.Contains(dc[2].Body, "2 direct-egress routes blocked; 0 local escape operations denied and 0 host-specific surfaces absent") {
 		t.Fatalf("containment body should reflect probe count: %q", dc[2].Body)
 	}
 }

--- a/internal/playground/containment.go
+++ b/internal/playground/containment.go
@@ -103,7 +103,10 @@ func probeUnixSocket(ctx context.Context, target, path string) ProbeResult {
 
 	conn, err := (&net.Dialer{Timeout: probeTimeout}).DialContext(dialCtx, "unix", path)
 	if err != nil {
-		blocked := !isConnectionRefusedError(err)
+		if errors.Is(err, os.ErrNotExist) {
+			return ProbeResult{Target: target, Absent: true, Detail: fmt.Sprintf("absent: %v", err)}
+		}
+		blocked := errors.Is(err, os.ErrPermission)
 		return ProbeResult{
 			Target:  target,
 			Open:    false,
@@ -137,11 +140,15 @@ func isConnectionRefusedError(err error) bool {
 func probeDeviceNode(target, path string) ProbeResult {
 	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ProbeResult{Target: target, Absent: true, Detail: fmt.Sprintf("absent: %v", err)}
+		}
+		blocked := errors.Is(err, os.ErrPermission)
 		return ProbeResult{
 			Target:  target,
 			Open:    false,
-			Blocked: true,
-			Detail:  fmt.Sprintf("blocked/unavailable: %v", err),
+			Blocked: blocked,
+			Detail:  localProbeErrorDetail(err, blocked),
 		}
 	}
 	_ = f.Close()

--- a/internal/playground/containment_invm.go
+++ b/internal/playground/containment_invm.go
@@ -209,20 +209,24 @@ func VerifyInVMContainmentWithUIDs(ctx context.Context, toyAgentBin, agentUser s
 	defer func() { _ = proxyLn.Close() }()
 	go acceptProbeConnections(proxyLn)
 
-	// Operator probe of the control target (current process is the operator):
-	// proves the probe can detect a reachable target.
-	operatorProbes, err := spawnEgressProbe(ctx, toyAgentBin, agentUser, []string{ctrlTarget}, false)
-	if err != nil {
-		return fmt.Errorf("%w: operator control probe: %w", ErrInVMContainmentNotProven, err)
-	}
+	// Probe the control target in-process as the operator. Never execute the
+	// configured helper binary with root credentials; only contained-agent
+	// probes cross the subprocess boundary and they always drop privileges.
+	operatorControl := ProbeDirectEgress(ctx, ctrlTarget)
 
-	// Contained-agent probes, in order: the control target (must be blocked) then
-	// the real direct-egress suite (all must be blocked).
+	// Contained-agent probes, in order: the permitted proxy target (must be open),
+	// the different loopback control target (must be blocked), then the exact
+	// DirectEgressTargets suite (all must be blocked). decodeProbeResults enforces
+	// this count and order before these index-based partitions are reachable.
 	proxyTarget := proxyLn.Addr().String()
 	agentTargets := append([]string{proxyTarget, ctrlTarget}, DirectEgressTargets()...)
 	agentProbes, err := spawnAgentEgressProbe(ctx, toyAgentBin, agentUser, agentTargets)
 	if err != nil {
 		return fmt.Errorf("%w: contained agent probe: %w", ErrInVMContainmentNotProven, err)
+	}
+	if len(agentProbes) != len(agentTargets) {
+		return fmt.Errorf("%w: contained agent probe returned %d results, want %d",
+			ErrInVMContainmentNotProven, len(agentProbes), len(agentTargets))
 	}
 	localProbes, err := spawnAgentLocalEscapeProbe(ctx, toyAgentBin, agentUser)
 	if err != nil {
@@ -232,7 +236,7 @@ func VerifyInVMContainmentWithUIDs(ctx context.Context, toyAgentBin, agentUser s
 	if err := evalProxyStartContract(proxyTarget, agentProbes[0]); err != nil {
 		return err
 	}
-	return evalStartContainment(operatorProbes[0], agentProbes[1], agentProbes[2:], localProbes)
+	return evalStartContainment(operatorControl, agentProbes[1], agentProbes[2:], localProbes)
 }
 
 func acceptProbeConnections(ln net.Listener) {
@@ -261,17 +265,15 @@ func spawnAgentEgressProbe(ctx context.Context, toyAgentBin, agentUser string, t
 	if os.Geteuid() != 0 {
 		return nil, fmt.Errorf("contained egress probe requires root (euid=%d)", os.Geteuid())
 	}
-	return spawnEgressProbe(ctx, toyAgentBin, agentUser, targets, true)
+	return spawnEgressProbe(ctx, toyAgentBin, agentUser, targets)
 }
 
-func spawnEgressProbe(ctx context.Context, toyAgentBin, agentUser string, targets []string, asAgent bool) ([]ProbeResult, error) {
+func spawnEgressProbe(ctx context.Context, toyAgentBin, agentUser string, targets []string) ([]ProbeResult, error) {
 	args := []string{"--probe-targets", strings.Join(targets, ",")}
 	cmd := exec.CommandContext(ctx, toyAgentBin, args...)
 	cmd.Env = []string{"PATH=/usr/local/bin:/usr/bin:/bin"}
-	if asAgent {
-		if err := configureContainedCommand(cmd, agentUser); err != nil {
-			return nil, fmt.Errorf("configure contained egress probe: %w", err)
-		}
+	if err := configureContainedCommand(cmd, agentUser); err != nil {
+		return nil, fmt.Errorf("configure contained egress probe: %w", err)
 	}
 
 	var stdout bytes.Buffer

--- a/internal/playground/containment_invm.go
+++ b/internal/playground/containment_invm.go
@@ -13,7 +13,11 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/user"
+	"strconv"
 	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/cli/contain"
 )
 
 // --------------------------------------------------------------------------
@@ -26,9 +30,10 @@ import (
 // entrypoint, so `pipelock contain install` never runs and `pipelock contain
 // verify` is not applicable.
 //
-// This file provides the install-AGNOSTIC start gate for that model: it does not
-// trust any installer; it empirically confirms, before the agent runs, that the
-// contained agent uid's direct egress is actually dropped. It is the start-time
+// This file provides the installer-independent start gate for that model. It
+// requires the deployment to load the same canonical ruleset shape emitted by
+// Pipelock, then empirically confirms before the agent runs that the contained
+// agent uid's direct egress is actually dropped. It is the start-time
 // counterpart to the cryptographic HostContainmentWitness produced at finalize
 // (buildHostContainmentWitness / Enforced), and uses the SAME differential
 // methodology so the two cannot diverge: the operator reaches a host-local
@@ -43,12 +48,43 @@ import (
 // the caller must refuse to start the session.
 // --------------------------------------------------------------------------
 
-// ErrInVMContainmentNotProven signals that the install-agnostic start gate could
+// ErrInVMContainmentNotProven signals that the installer-independent start gate could
 // not prove the contained agent uid's direct egress is dropped, so a session
 // claiming containment must not begin.
 var ErrInVMContainmentNotProven = errors.New(
 	"playground: in-VM containment not proven: the contained agent uid's egress/local escape surfaces are not blocked; " +
 		"refusing to start (set the nft owner-match egress rule in the deployment, e.g. the microVM boot entrypoint)")
+
+// InVMContainmentHook adapts the installer-independent containment gate to
+// the deterministic demo's ContainmentHook seam. It is intended for hosts whose
+// deployment manages the kernel boundary itself instead of using the exact
+// stock `pipelock contain install` ruleset.
+type InVMContainmentHook struct {
+	ToyAgentBin string
+	AgentUser   string
+}
+
+// NewInVMContainmentHook creates a containment hook that proves the boundary
+// with the supplied toy-agent probe binary.
+func NewInVMContainmentHook(toyAgentBin string) *InVMContainmentHook {
+	return &InVMContainmentHook{ToyAgentBin: toyAgentBin}
+}
+
+// Setup proves the configured contained uid cannot escape through direct
+// network or local platform surfaces. It does not trust installer state.
+func (h *InVMContainmentHook) Setup(ctx context.Context, opts DemoOpts) error {
+	agentUser := h.AgentUser
+	if agentUser == "" {
+		agentUser = defaultContainedAgentUser
+	}
+	return VerifyInVMContainment(ctx, h.ToyAgentBin, agentUser, opts.ProxyPort)
+}
+
+// Teardown is a no-op because the deployment owns the persistent containment
+// boundary and the probe creates no lasting firewall state.
+func (h *InVMContainmentHook) Teardown(_ string) error {
+	return nil
+}
 
 // evalStartContainment is the pure decision over a start-gate probe set: it
 // returns nil ONLY when the operator reached the control target (proving the
@@ -82,18 +118,25 @@ func evalStartContainment(operatorControl, agentControl ProbeResult, agentDirect
 	if len(agentLocal) == 0 {
 		return fmt.Errorf("%w: no local escape probes ran", ErrInVMContainmentNotProven)
 	}
+	deniedLocal := 0
 	for _, p := range agentLocal {
-		if p.Open || !p.Blocked {
-			return fmt.Errorf("%w: contained agent reached local escape target %q (%s)",
+		if p.Open || (!p.Blocked && !p.Absent) {
+			return fmt.Errorf("%w: local escape target %q was open or could not be proven denied/absent (%s)",
 				ErrInVMContainmentNotProven, p.Target, p.Detail)
 		}
+		if p.Blocked {
+			deniedLocal++
+		}
+	}
+	if deniedLocal == 0 {
+		return fmt.Errorf("%w: local escape suite contained only absent surfaces and proved no enforced denial", ErrInVMContainmentNotProven)
 	}
 	return nil
 }
 
-// VerifyInVMContainment empirically confirms the contained agent uid's direct
-// egress is dropped, WITHOUT depending on `pipelock contain install` /
-// `pipelock contain verify`. It is the start gate for the self-managed
+// VerifyInVMContainment confirms the canonical live nft ruleset and empirically
+// proves the contained agent uid's direct egress is dropped, WITHOUT depending
+// on `pipelock contain install` / `pipelock contain verify`. It is the start gate for the self-managed
 // (in-VM/Fly) containment model where the deployment sets the nft owner-match
 // rule itself.
 //
@@ -109,13 +152,39 @@ func evalStartContainment(operatorControl, agentControl ProbeResult, agentDirect
 // toyAgentBin is the probe binary (the live command's --toyagent-bin); it is the
 // same binary the finalize-time HostContainmentWitness uses, so the start gate
 // and the signed proof exercise an identical probe path.
-func VerifyInVMContainment(ctx context.Context, toyAgentBin, agentUser string) error {
+func VerifyInVMContainment(ctx context.Context, toyAgentBin, agentUser string, proxyPort int) error {
+	return VerifyInVMContainmentWithUIDs(ctx, toyAgentBin, agentUser, proxyPort, 0, 0)
+}
+
+// VerifyInVMContainmentWithUIDs verifies a deployment whose operator and proxy
+// processes use explicitly configured UIDs.
+func VerifyInVMContainmentWithUIDs(ctx context.Context, toyAgentBin, agentUser string, proxyPort, operatorUID, proxyUID int) error {
 	if os.Geteuid() != 0 {
 		return fmt.Errorf("%w: requires root to drop the probe to the agent uid (euid=%d)",
 			ErrInVMContainmentNotProven, os.Geteuid())
 	}
 	if strings.TrimSpace(toyAgentBin) == "" {
 		return fmt.Errorf("%w: no probe binary configured (set --toyagent-bin)", ErrInVMContainmentNotProven)
+	}
+	if proxyPort < 1 || proxyPort > 65535 {
+		return fmt.Errorf("%w: proxy port must be 1-65535", ErrInVMContainmentNotProven)
+	}
+	if agentUser == "" {
+		agentUser = defaultContainedAgentUser
+	}
+	agent, err := user.Lookup(agentUser)
+	if err != nil {
+		return fmt.Errorf("%w: lookup agent user %q: %w", ErrInVMContainmentNotProven, agentUser, err)
+	}
+	agentUID, err := strconv.Atoi(agent.Uid)
+	if err != nil || agentUID <= 0 {
+		return fmt.Errorf("%w: invalid agent uid %q", ErrInVMContainmentNotProven, agent.Uid)
+	}
+	if operatorUID < 0 || proxyUID < 0 {
+		return fmt.Errorf("%w: operator and proxy UIDs must be non-negative", ErrInVMContainmentNotProven)
+	}
+	if err := contain.VerifySelfManagedNFTRules(ctx, operatorUID, proxyUID, agentUID, proxyPort); err != nil {
+		return fmt.Errorf("%w: %w", ErrInVMContainmentNotProven, err)
 	}
 
 	ctrlLn, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
@@ -133,14 +202,24 @@ func VerifyInVMContainment(ctx context.Context, toyAgentBin, agentUser string) e
 		}
 	}()
 	ctrlTarget := ctrlLn.Addr().String()
+	proxyLn, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort))
+	if err != nil {
+		return fmt.Errorf("%w: proxy contract listener: %w", ErrInVMContainmentNotProven, err)
+	}
+	defer func() { _ = proxyLn.Close() }()
+	go acceptProbeConnections(proxyLn)
 
 	// Operator probe of the control target (current process is the operator):
 	// proves the probe can detect a reachable target.
-	operatorControl := ProbeDirectEgress(ctx, ctrlTarget)
+	operatorProbes, err := spawnEgressProbe(ctx, toyAgentBin, agentUser, []string{ctrlTarget}, false)
+	if err != nil {
+		return fmt.Errorf("%w: operator control probe: %w", ErrInVMContainmentNotProven, err)
+	}
 
 	// Contained-agent probes, in order: the control target (must be blocked) then
 	// the real direct-egress suite (all must be blocked).
-	agentTargets := append([]string{ctrlTarget}, DirectEgressTargets()...)
+	proxyTarget := proxyLn.Addr().String()
+	agentTargets := append([]string{proxyTarget, ctrlTarget}, DirectEgressTargets()...)
 	agentProbes, err := spawnAgentEgressProbe(ctx, toyAgentBin, agentUser, agentTargets)
 	if err != nil {
 		return fmt.Errorf("%w: contained agent probe: %w", ErrInVMContainmentNotProven, err)
@@ -150,7 +229,27 @@ func VerifyInVMContainment(ctx context.Context, toyAgentBin, agentUser string) e
 		return fmt.Errorf("%w: contained agent local escape probe: %w", ErrInVMContainmentNotProven, err)
 	}
 
-	return evalStartContainment(operatorControl, agentProbes[0], agentProbes[1:], localProbes)
+	if err := evalProxyStartContract(proxyTarget, agentProbes[0]); err != nil {
+		return err
+	}
+	return evalStartContainment(operatorProbes[0], agentProbes[1], agentProbes[2:], localProbes)
+}
+
+func acceptProbeConnections(ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}
+}
+
+func evalProxyStartContract(target string, probe ProbeResult) error {
+	if probe.Target != target || !probe.Open || probe.Blocked {
+		return fmt.Errorf("%w: contained agent could not reach configured proxy target %q (%s)", ErrInVMContainmentNotProven, target, probe.Detail)
+	}
+	return nil
 }
 
 // spawnAgentEgressProbe runs toyAgentBin in --probe-targets mode dropped to the
@@ -162,11 +261,17 @@ func spawnAgentEgressProbe(ctx context.Context, toyAgentBin, agentUser string, t
 	if os.Geteuid() != 0 {
 		return nil, fmt.Errorf("contained egress probe requires root (euid=%d)", os.Geteuid())
 	}
+	return spawnEgressProbe(ctx, toyAgentBin, agentUser, targets, true)
+}
+
+func spawnEgressProbe(ctx context.Context, toyAgentBin, agentUser string, targets []string, asAgent bool) ([]ProbeResult, error) {
 	args := []string{"--probe-targets", strings.Join(targets, ",")}
 	cmd := exec.CommandContext(ctx, toyAgentBin, args...)
 	cmd.Env = []string{"PATH=/usr/local/bin:/usr/bin:/bin"}
-	if err := configureContainedCommand(cmd, agentUser); err != nil {
-		return nil, fmt.Errorf("configure contained egress probe: %w", err)
+	if asAgent {
+		if err := configureContainedCommand(cmd, agentUser); err != nil {
+			return nil, fmt.Errorf("configure contained egress probe: %w", err)
+		}
 	}
 
 	var stdout bytes.Buffer

--- a/internal/playground/containment_invm_test.go
+++ b/internal/playground/containment_invm_test.go
@@ -39,6 +39,19 @@ func allBlockedLocal() []ProbeResult {
 	return out
 }
 
+func TestInVMContainmentHookLifecycle(t *testing.T) {
+	hook := NewInVMContainmentHook("/nonexistent/toyagent")
+	if hook.ToyAgentBin != "/nonexistent/toyagent" {
+		t.Fatalf("toy agent = %q", hook.ToyAgentBin)
+	}
+	if err := hook.Setup(t.Context(), DemoOpts{ProxyPort: DefaultContainedProxyPort}); err == nil {
+		t.Fatal("setup without a proven boundary should fail closed")
+	}
+	if err := hook.Teardown(t.TempDir()); err != nil {
+		t.Fatalf("teardown: %v", err)
+	}
+}
+
 func TestEvalStartContainment(t *testing.T) {
 	const ctrl = "127.0.0.1:5005"
 
@@ -142,6 +155,32 @@ func TestEvalStartContainment(t *testing.T) {
 			}(),
 			wantErr: true,
 		},
+		{
+			name:        "absent surface plus real denials passes honestly",
+			operator:    openProbe(ctrl),
+			agentCtrl:   blockedProbe(ctrl),
+			agentDirect: allBlockedDirect(),
+			agentLocal: func() []ProbeResult {
+				l := allBlockedLocal()
+				l[0] = ProbeResult{Target: l[0].Target, Absent: true, Detail: "absent"}
+				return l
+			}(),
+			wantErr: false,
+		},
+		{
+			name:        "all local surfaces absent proves no denial",
+			operator:    openProbe(ctrl),
+			agentCtrl:   blockedProbe(ctrl),
+			agentDirect: allBlockedDirect(),
+			agentLocal: func() []ProbeResult {
+				l := allBlockedLocal()
+				for i := range l {
+					l[i] = ProbeResult{Target: l[i].Target, Absent: true, Detail: "absent"}
+				}
+				return l
+			}(),
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -163,11 +202,28 @@ func TestEvalStartContainment(t *testing.T) {
 	}
 }
 
+func TestEvalProxyStartContract(t *testing.T) {
+	t.Parallel()
+	target := "127.0.0.1:8888"
+	if err := evalProxyStartContract(target, ProbeResult{Target: target, Open: true}); err != nil {
+		t.Fatalf("reachable configured proxy rejected: %v", err)
+	}
+	for _, probe := range []ProbeResult{
+		{Target: target, Blocked: true, Detail: "timeout"},
+		{Target: "127.0.0.1:8899", Open: true},
+		{Target: target},
+	} {
+		if err := evalProxyStartContract(target, probe); err == nil {
+			t.Fatalf("invalid proxy probe accepted: %+v", probe)
+		}
+	}
+}
+
 func TestVerifyInVMContainment_FailsClosedWithoutRoot(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("requires non-root to exercise the euid!=0 fail-closed path")
 	}
-	err := VerifyInVMContainment(context.Background(), "/nonexistent/toyagent", "pipelock-agent")
+	err := VerifyInVMContainment(context.Background(), "/nonexistent/toyagent", "pipelock-agent", DefaultContainedProxyPort)
 	if !errors.Is(err, ErrInVMContainmentNotProven) {
 		t.Fatalf("VerifyInVMContainment without root: want ErrInVMContainmentNotProven, got %v", err)
 	}
@@ -177,7 +233,7 @@ func TestVerifyInVMContainment_FailsClosedWithoutProbeBin(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("the empty-bin check is reached only after the root check passes")
 	}
-	err := VerifyInVMContainment(context.Background(), "", "pipelock-agent")
+	err := VerifyInVMContainment(context.Background(), "", "pipelock-agent", DefaultContainedProxyPort)
 	if !errors.Is(err, ErrInVMContainmentNotProven) {
 		t.Fatalf("VerifyInVMContainment without probe bin: want ErrInVMContainmentNotProven, got %v", err)
 	}

--- a/internal/playground/containment_test.go
+++ b/internal/playground/containment_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/playground"
@@ -215,8 +216,16 @@ func TestLocalEscapeProbe_DeviceTargets(t *testing.T) {
 	}
 
 	missing := playground.ProbeLocalEscape(t.Context(), "device:"+filepath.Join(t.TempDir(), "missing"))
-	if missing.Open || !missing.Blocked {
-		t.Fatalf("missing local path should classify as blocked/unavailable, got: %+v", missing)
+	if missing.Open || missing.Blocked || !missing.Absent {
+		t.Fatalf("missing local path should classify as absent, got: %+v", missing)
+	}
+}
+
+func TestLocalEscapeProbe_MissingUnixSocket(t *testing.T) {
+	t.Parallel()
+	result := playground.ProbeLocalEscape(t.Context(), "unix:"+filepath.Join(t.TempDir(), "missing.sock"))
+	if result.Open || result.Blocked || !result.Absent {
+		t.Fatalf("missing unix socket should be absent: %+v", result)
 	}
 }
 
@@ -290,6 +299,17 @@ func TestDirectEgressTargets_CoversRequiredCategories(t *testing.T) {
 	}
 }
 
+func TestDirectEgressTargets_V2ExactOrder(t *testing.T) {
+	t.Parallel()
+	want := []string{
+		"169.254.169.254:80", "10.0.0.1:443", "8.8.8.8:53",
+		"1.1.1.1:853", "93.184.216.34:443",
+	}
+	if got := playground.DirectEgressTargets(); !slices.Equal(got, want) {
+		t.Fatalf("v2 direct-egress suite = %v, want %v; bump the suite version for changes", got, want)
+	}
+}
+
 func TestLocalEscapeTargets_UserNamespaceMountProbeLast(t *testing.T) {
 	t.Parallel()
 
@@ -305,6 +325,35 @@ func TestLocalEscapeTargets_UserNamespaceMountProbeLast(t *testing.T) {
 		if target == mutatingProbe {
 			t.Fatalf("%s must not appear before final position, found at %d", mutatingProbe, i)
 		}
+	}
+}
+
+func TestLocalEscapeTargets_ProbeCapabilitiesNotFuseReadability(t *testing.T) {
+	t.Parallel()
+
+	found := map[string]bool{}
+	for _, target := range playground.LocalEscapeTargets() {
+		found[target] = true
+	}
+	if found["device:/dev/fuse"] {
+		t.Fatal("opening /dev/fuse does not prove a mount or host escape")
+	}
+	for _, want := range []string{"cap:mount", "cap:userns-mount"} {
+		if !found[want] {
+			t.Fatalf("LocalEscapeTargets missing real mount capability probe %q", want)
+		}
+	}
+}
+
+func TestLocalEscapeTargets_V2ExactOrder(t *testing.T) {
+	t.Parallel()
+	want := []string{
+		"unix:/.fly/api", "unix:/var/run/docker.sock", "device:/dev/vda",
+		"device:/dev/vdb", "device:/dev/root", "device:/dev/nvme0n1",
+		"device:/dev/sda", "cap:mknod", "cap:mount", "cap:userns-mount",
+	}
+	if got := playground.LocalEscapeTargets(); !slices.Equal(got, want) {
+		t.Fatalf("v2 local escape suite = %v, want %v; bump the suite version for changes", got, want)
 	}
 }
 

--- a/internal/playground/containment_types.go
+++ b/internal/playground/containment_types.go
@@ -3,6 +3,8 @@
 
 package playground
 
+const currentContainmentProbeSuite = "v2"
+
 // ProbeResult holds the outcome of a single direct-egress probe. It is
 // serialized into the signed HostContainmentWitness, so its JSON shape is part
 // of the evidence model: the field tags must stay stable for SignedBytes
@@ -17,6 +19,9 @@ type ProbeResult struct {
 	// refused) are NOT blocked: they prove packets escaped far enough to get a
 	// response.
 	Blocked bool `json:"blocked"`
+	// Absent is true when a local escape surface does not exist on this host.
+	// Absence is acceptable coverage but is not misreported as an enforced deny.
+	Absent bool `json:"absent,omitempty"`
 	// Detail is a human-readable classification (e.g. "connected", "connection refused").
 	Detail string `json:"detail"`
 }
@@ -33,6 +38,16 @@ func DirectEgressTargets() []string {
 	}
 }
 
+func legacyDirectEgressTargets() []string {
+	return []string{
+		"169.254.169.254:80",
+		"10.0.0.1:443",
+		"8.8.8.8:53",
+		"1.1.1.1:853",
+		"93.184.216.34:443",
+	}
+}
+
 // LocalEscapeTargets returns local, non-network surfaces the contained agent
 // must not be able to use.
 func LocalEscapeTargets() []string {
@@ -44,9 +59,24 @@ func LocalEscapeTargets() []string {
 		"device:/dev/root",          // root block-device alias
 		"device:/dev/nvme0n1",       // common NVMe block device
 		"device:/dev/sda",           // common virt/SCSI block device
-		"device:/dev/fuse",          // unmediated FUSE mount surface
 		"cap:mknod",                 // create new device nodes
 		"cap:mount",                 // mount a filesystem
 		"cap:userns-mount",          // create user namespace root and mount
+	}
+}
+
+func legacyLocalEscapeTargets() []string {
+	return []string{
+		"unix:/.fly/api",
+		"unix:/var/run/docker.sock",
+		"device:/dev/vda",
+		"device:/dev/vdb",
+		"device:/dev/root",
+		"device:/dev/nvme0n1",
+		"device:/dev/sda",
+		"device:/dev/fuse",
+		"cap:mknod",
+		"cap:mount",
+		"cap:userns-mount",
 	}
 }

--- a/internal/playground/containment_witness.go
+++ b/internal/playground/containment_witness.go
@@ -40,6 +40,9 @@ import (
 type HostContainmentWitness struct {
 	RunNonce           string `json:"run_nonce"`
 	LaunchManifestHash string `json:"launch_manifest_hash"`
+	// ProbeSuiteVersion identifies the exact target-suite semantics. Empty is
+	// the legacy v1 suite so previously signed witnesses retain identical bytes.
+	ProbeSuiteVersion string `json:"probe_suite_version,omitempty"`
 
 	AgentUser string `json:"agent_user"`
 	AgentUID  int    `json:"agent_uid"`
@@ -106,7 +109,15 @@ func (w HostContainmentWitness) SignedBytes() []byte {
 // weaker statement by signing one easy blocked route while omitting the harder
 // categories.
 func (w HostContainmentWitness) DirectSuiteProven() bool {
-	expected := DirectEgressTargets()
+	var expected []string
+	switch w.ProbeSuiteVersion {
+	case "":
+		expected = legacyDirectEgressTargets()
+	case currentContainmentProbeSuite:
+		expected = DirectEgressTargets()
+	default:
+		return false
+	}
 	if len(w.AgentProbes) != len(expected) {
 		return false
 	}
@@ -123,7 +134,15 @@ func (w HostContainmentWitness) DirectSuiteProven() bool {
 // known local surface (for example the Fly control socket or raw block device)
 // while still claiming host containment.
 func (w HostContainmentWitness) LocalEscapeSuiteProven() bool {
-	expected := LocalEscapeTargets()
+	var expected []string
+	switch w.ProbeSuiteVersion {
+	case "":
+		expected = legacyLocalEscapeTargets()
+	case currentContainmentProbeSuite:
+		expected = LocalEscapeTargets()
+	default:
+		return false
+	}
 	if len(w.LocalAgentProbes) != len(expected) {
 		return false
 	}
@@ -154,12 +173,36 @@ func (w HostContainmentWitness) AllAgentBlocked() bool {
 			return false
 		}
 	}
+	deniedLocal := 0
 	for _, p := range w.LocalAgentProbes {
-		if p.Open || !p.Blocked {
+		if p.Blocked && p.Absent {
 			return false
 		}
+		if p.Open || (!p.Blocked && !p.Absent) {
+			return false
+		}
+		if p.Blocked {
+			deniedLocal++
+		}
 	}
-	return true
+	return deniedLocal > 0
+}
+
+// LocalProbeCounts separates enforced denials from surfaces absent on this
+// host so public renderers do not overstate absence as a kernel block.
+func (w HostContainmentWitness) LocalProbeCounts() (denied, absent int) {
+	for _, probe := range w.LocalAgentProbes {
+		if probe.Blocked && probe.Absent {
+			continue
+		}
+		if probe.Blocked {
+			denied++
+		}
+		if probe.Absent {
+			absent++
+		}
+	}
+	return denied, absent
 }
 
 // DifferentialProven reports whether the control differential holds: the SAME

--- a/internal/playground/containment_witness.go
+++ b/internal/playground/containment_witness.go
@@ -109,13 +109,8 @@ func (w HostContainmentWitness) SignedBytes() []byte {
 // weaker statement by signing one easy blocked route while omitting the harder
 // categories.
 func (w HostContainmentWitness) DirectSuiteProven() bool {
-	var expected []string
-	switch w.ProbeSuiteVersion {
-	case "":
-		expected = legacyDirectEgressTargets()
-	case currentContainmentProbeSuite:
-		expected = DirectEgressTargets()
-	default:
+	expected, ok := expectedProbeTargets(w.ProbeSuiteVersion, legacyDirectEgressTargets, DirectEgressTargets)
+	if !ok {
 		return false
 	}
 	if len(w.AgentProbes) != len(expected) {
@@ -134,13 +129,8 @@ func (w HostContainmentWitness) DirectSuiteProven() bool {
 // known local surface (for example the Fly control socket or raw block device)
 // while still claiming host containment.
 func (w HostContainmentWitness) LocalEscapeSuiteProven() bool {
-	var expected []string
-	switch w.ProbeSuiteVersion {
-	case "":
-		expected = legacyLocalEscapeTargets()
-	case currentContainmentProbeSuite:
-		expected = LocalEscapeTargets()
-	default:
+	expected, ok := expectedProbeTargets(w.ProbeSuiteVersion, legacyLocalEscapeTargets, LocalEscapeTargets)
+	if !ok {
 		return false
 	}
 	if len(w.LocalAgentProbes) != len(expected) {
@@ -152,6 +142,17 @@ func (w HostContainmentWitness) LocalEscapeSuiteProven() bool {
 		}
 	}
 	return true
+}
+
+func expectedProbeTargets(version string, legacy, current func() []string) ([]string, bool) {
+	switch version {
+	case "":
+		return legacy(), true
+	case currentContainmentProbeSuite:
+		return current(), true
+	default:
+		return nil, false
+	}
 }
 
 // AllAgentBlocked reports whether every contained-agent probe -- the control

--- a/internal/playground/containment_witness_test.go
+++ b/internal/playground/containment_witness_test.go
@@ -4,6 +4,7 @@
 package playground_test
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
@@ -55,6 +56,7 @@ func blockedLocalProbes() []playground.ProbeResult {
 // validWitness returns a fully-enforced, unsigned witness for the happy path.
 func validWitness() playground.HostContainmentWitness {
 	return playground.HostContainmentWitness{
+		ProbeSuiteVersion:    "v2",
 		RunNonce:             testRunNonce,
 		LaunchManifestHash:   testManHash,
 		AgentUser:            "pipelock-agent",
@@ -300,6 +302,32 @@ func TestHostContainmentWitness_Enforced(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "absent local surface with other denials",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.LocalAgentProbes[0] = playground.ProbeResult{Target: w.LocalAgentProbes[0].Target, Absent: true}
+				return w
+			},
+			want: true,
+		},
+		{
+			name: "all local surfaces absent proves no denial",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				for i := range w.LocalAgentProbes {
+					w.LocalAgentProbes[i] = playground.ProbeResult{Target: w.LocalAgentProbes[i].Target, Absent: true}
+				}
+				return w
+			},
+			want: false,
+		},
+		{
+			name: "local surface cannot be both denied and absent",
+			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
+				w.LocalAgentProbes[0].Absent = true
+				return w
+			},
+			want: false,
+		},
+		{
 			name: "substituted local escape suite target",
 			mutate: func(w playground.HostContainmentWitness) playground.HostContainmentWitness {
 				w.LocalAgentProbes[0].Target = "unix:/tmp/not-the-fly-api.sock"
@@ -387,6 +415,31 @@ func TestHostContainmentWitness_Enforced(t *testing.T) {
 				t.Fatalf("Enforced()=%v want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestHostContainmentWitness_LegacyProbeSuiteRemainsVerifiable(t *testing.T) {
+	t.Parallel()
+
+	w := validWitness()
+	w.ProbeSuiteVersion = ""
+	fuse := playground.ProbeResult{Target: "device:/dev/fuse", Blocked: true, Detail: "blocked/unavailable"}
+	w.LocalAgentProbes = append(w.LocalAgentProbes[:7], append([]playground.ProbeResult{fuse}, w.LocalAgentProbes[7:]...)...)
+	if !w.Enforced() {
+		t.Fatal("legacy v1 target suite should remain verifiable")
+	}
+	if bytes.Contains(w.SignedBytes(), []byte("probe_suite_version")) {
+		t.Fatal("legacy signed bytes must omit the version field")
+	}
+}
+
+func TestHostContainmentWitness_UnknownProbeSuiteFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	w := validWitness()
+	w.ProbeSuiteVersion = "future"
+	if w.Enforced() {
+		t.Fatal("unknown probe suite version verified")
 	}
 }
 

--- a/internal/playground/containment_witness_test.go
+++ b/internal/playground/containment_witness_test.go
@@ -56,6 +56,7 @@ func blockedLocalProbes() []playground.ProbeResult {
 // validWitness returns a fully-enforced, unsigned witness for the happy path.
 func validWitness() playground.HostContainmentWitness {
 	return playground.HostContainmentWitness{
+		// Keep synchronized with the unexported currentContainmentProbeSuite.
 		ProbeSuiteVersion:    "v2",
 		RunNonce:             testRunNonce,
 		LaunchManifestHash:   testManHash,

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -682,6 +682,7 @@ func (lr *LiveRun) buildHostContainmentWitness(ctx context.Context) (HostContain
 	w := HostContainmentWitness{
 		RunNonce:             lr.opts.RunNonce,
 		LaunchManifestHash:   lr.manifest.Hash(),
+		ProbeSuiteVersion:    currentContainmentProbeSuite,
 		AgentUser:            containedAgentUserName(lr.opts.AgentUser),
 		AgentUID:             containedAgentUID(lr.opts.AgentUser),
 		ControlTarget:        ctrlTarget,

--- a/internal/playground/liverun_internal_test.go
+++ b/internal/playground/liverun_internal_test.go
@@ -3,7 +3,18 @@
 
 package playground
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
+
+func TestGoBuildArgs_DisablesVCSStamping(t *testing.T) {
+	t.Parallel()
+	args := goBuildArgs("./cmd/helper", "/tmp/helper")
+	if !slices.Contains(args, "-buildvcs=false") {
+		t.Fatalf("go build args must avoid mutable Git metadata: %v", args)
+	}
+}
 
 func TestDecodeProbeResults(t *testing.T) {
 	t.Parallel()
@@ -80,6 +91,7 @@ func TestDecodeProbeResults(t *testing.T) {
 func TestAllAgentBlocked_HappyAndEmpty(t *testing.T) {
 	t.Parallel()
 	w := HostContainmentWitness{
+		ProbeSuiteVersion: currentContainmentProbeSuite,
 		ControlAgentProbe: ProbeResult{Open: false, Blocked: true},
 		AgentProbes:       []ProbeResult{{Open: false, Blocked: true}, {Open: false, Blocked: true}},
 		LocalAgentProbes:  []ProbeResult{{Open: false, Blocked: true}},

--- a/internal/playground/local_escape_linux.go
+++ b/internal/playground/local_escape_linux.go
@@ -6,6 +6,7 @@
 package playground
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -78,7 +79,7 @@ func probeMknodCapability(target string) ProbeResult {
 	nodePath := filepath.Join(dir, "probe-null")
 	err = unix.Mknod(nodePath, unix.S_IFCHR|0o600, nullDevice)
 	if err != nil {
-		return ProbeResult{Target: target, Open: false, Blocked: true, Detail: fmt.Sprintf("blocked/unavailable: %v", err)}
+		return localCapabilityError(target, "mknod", err)
 	}
 	return ProbeResult{Target: target, Open: true, Blocked: false, Detail: "mknod succeeded"}
 }
@@ -92,7 +93,7 @@ func probeMountCapability(target string) ProbeResult {
 
 	err = unix.Mount("none", dir, "tmpfs", 0, "")
 	if err != nil {
-		return ProbeResult{Target: target, Open: false, Blocked: true, Detail: fmt.Sprintf("blocked/unavailable: %v", err)}
+		return localCapabilityError(target, "mount", err)
 	}
 	_ = unix.Unmount(dir, 0)
 	return ProbeResult{Target: target, Open: true, Blocked: false, Detail: "mount succeeded"}
@@ -106,7 +107,7 @@ func probeUserNamespaceMountCapabilityWithOps(target string, ops userNamespaceMo
 	ops.lockOSThread()
 	if err := ops.unshare(unix.CLONE_NEWUSER | unix.CLONE_NEWNS); err != nil {
 		ops.unlockOSThread()
-		return ProbeResult{Target: target, Open: false, Blocked: true, Detail: fmt.Sprintf("blocked/unavailable: unshare: %v", err)}
+		return localCapabilityError(target, "unshare", err)
 	}
 	// Do not unlock this OS thread after a successful unshare. The uid/gid map and
 	// Setresuid/Setresgid calls below permanently mutate this thread's namespace
@@ -115,19 +116,19 @@ func probeUserNamespaceMountCapabilityWithOps(target string, ops userNamespaceMo
 	// to the Go scheduler.
 
 	if err := ops.writeFile("/proc/self/setgroups", []byte("deny\n"), 0o600); err != nil && !os.IsNotExist(err) {
-		return ProbeResult{Target: target, Open: false, Blocked: true, Detail: fmt.Sprintf("blocked/unavailable: setgroups map: %v", err)}
+		return ProbeResult{Target: target, Open: true, Blocked: false, Detail: fmt.Sprintf("user namespace created; setgroups map failed afterward: %v", err)}
 	}
 	if err := ops.writeFile("/proc/self/uid_map", []byte("0 "+strconv.Itoa(ops.getuid())+" 1\n"), 0o600); err != nil {
-		return ProbeResult{Target: target, Open: false, Blocked: true, Detail: fmt.Sprintf("blocked/unavailable: uid map: %v", err)}
+		return ProbeResult{Target: target, Open: true, Blocked: false, Detail: fmt.Sprintf("user namespace created; uid map failed afterward: %v", err)}
 	}
 	if err := ops.writeFile("/proc/self/gid_map", []byte("0 "+strconv.Itoa(ops.getgid())+" 1\n"), 0o600); err != nil {
-		return ProbeResult{Target: target, Open: false, Blocked: true, Detail: fmt.Sprintf("blocked/unavailable: gid map: %v", err)}
+		return ProbeResult{Target: target, Open: true, Blocked: false, Detail: fmt.Sprintf("user namespace created; gid map failed afterward: %v", err)}
 	}
 	if err := ops.setresgid(0, 0, 0); err != nil {
-		return ProbeResult{Target: target, Open: false, Blocked: true, Detail: fmt.Sprintf("blocked/unavailable: setresgid: %v", err)}
+		return ProbeResult{Target: target, Open: true, Blocked: false, Detail: fmt.Sprintf("user namespace created; setresgid failed afterward: %v", err)}
 	}
 	if err := ops.setresuid(0, 0, 0); err != nil {
-		return ProbeResult{Target: target, Open: false, Blocked: true, Detail: fmt.Sprintf("blocked/unavailable: setresuid: %v", err)}
+		return ProbeResult{Target: target, Open: true, Blocked: false, Detail: fmt.Sprintf("user namespace created; setresuid failed afterward: %v", err)}
 	}
 
 	dir, err := ops.mkdirTemp("", "pipelock-local-escape-userns-mount-*")
@@ -137,8 +138,21 @@ func probeUserNamespaceMountCapabilityWithOps(target string, ops userNamespaceMo
 	defer func() { _ = ops.removeAll(dir) }()
 
 	if err := ops.mount("none", dir, "tmpfs", 0, ""); err != nil {
-		return ProbeResult{Target: target, Open: false, Blocked: true, Detail: fmt.Sprintf("blocked/unavailable: mount after userns: %v", err)}
+		return localCapabilityError(target, "mount after userns", err)
 	}
 	_ = ops.unmount(dir, 0)
 	return ProbeResult{Target: target, Open: true, Blocked: false, Detail: "user namespace root mounted tmpfs"}
+}
+
+func localCapabilityError(target, operation string, err error) ProbeResult {
+	blocked := errors.Is(err, unix.EPERM) || errors.Is(err, unix.EACCES)
+	absent := errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.ENODEV) || errors.Is(err, unix.EOPNOTSUPP) ||
+		(operation == "unshare" && errors.Is(err, unix.EINVAL))
+	detail := "failed"
+	if blocked {
+		detail = "denied"
+	} else if absent {
+		detail = "unsupported"
+	}
+	return ProbeResult{Target: target, Blocked: blocked, Absent: absent, Detail: fmt.Sprintf("%s: %s: %v", detail, operation, err)}
 }

--- a/internal/playground/local_escape_linux_test.go
+++ b/internal/playground/local_escape_linux_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestProbeLocalCapability_Unknown(t *testing.T) {
@@ -80,7 +82,7 @@ func TestProbeUserNamespaceMountCapabilityWithOps(t *testing.T) {
 
 	t.Run("unshare failure unlocks thread and blocks", func(t *testing.T) {
 		ops, locked, unlocked := newOps()
-		ops.unshare = func(int) error { return errors.New("denied") }
+		ops.unshare = func(int) error { return unix.EPERM }
 
 		result := probeUserNamespaceMountCapabilityWithOps("cap:userns-mount", *ops)
 		if !*locked || !*unlocked {
@@ -88,6 +90,16 @@ func TestProbeUserNamespaceMountCapabilityWithOps(t *testing.T) {
 		}
 		if result.Open || !result.Blocked || !strings.Contains(result.Detail, "unshare") {
 			t.Fatalf("unexpected result: %+v", result)
+		}
+	})
+
+	t.Run("unsupported user namespaces are absent", func(t *testing.T) {
+		ops, _, unlocked := newOps()
+		ops.unshare = func(int) error { return unix.EINVAL }
+
+		result := probeUserNamespaceMountCapabilityWithOps("cap:userns-mount", *ops)
+		if !*unlocked || result.Open || result.Blocked || !result.Absent || !strings.Contains(result.Detail, "unsupported") {
+			t.Fatalf("unexpected result: %+v unlocked=%v", result, *unlocked)
 		}
 	})
 
@@ -109,7 +121,7 @@ func TestProbeUserNamespaceMountCapabilityWithOps(t *testing.T) {
 		}
 	})
 
-	t.Run("uid map failure blocks", func(t *testing.T) {
+	t.Run("uid map failure after unshare stays open", func(t *testing.T) {
 		ops, _, _ := newOps()
 		ops.writeFile = func(name string, _ []byte, _ fs.FileMode) error {
 			if name == "/proc/self/uid_map" {
@@ -119,12 +131,12 @@ func TestProbeUserNamespaceMountCapabilityWithOps(t *testing.T) {
 		}
 
 		result := probeUserNamespaceMountCapabilityWithOps("cap:userns-mount", *ops)
-		if result.Open || !result.Blocked || !strings.Contains(result.Detail, "uid map") {
+		if !result.Open || result.Blocked || !strings.Contains(result.Detail, "uid map") {
 			t.Fatalf("unexpected result: %+v", result)
 		}
 	})
 
-	t.Run("gid map failure blocks", func(t *testing.T) {
+	t.Run("gid map failure after unshare stays open", func(t *testing.T) {
 		ops, _, _ := newOps()
 		ops.writeFile = func(name string, _ []byte, _ fs.FileMode) error {
 			if name == "/proc/self/gid_map" {
@@ -134,34 +146,34 @@ func TestProbeUserNamespaceMountCapabilityWithOps(t *testing.T) {
 		}
 
 		result := probeUserNamespaceMountCapabilityWithOps("cap:userns-mount", *ops)
-		if result.Open || !result.Blocked || !strings.Contains(result.Detail, "gid map") {
+		if !result.Open || result.Blocked || !strings.Contains(result.Detail, "gid map") {
 			t.Fatalf("unexpected result: %+v", result)
 		}
 	})
 
-	t.Run("setresgid failure blocks", func(t *testing.T) {
+	t.Run("setresgid failure after unshare stays open", func(t *testing.T) {
 		ops, _, _ := newOps()
 		ops.setresgid = func(int, int, int) error { return errors.New("setresgid denied") }
 
 		result := probeUserNamespaceMountCapabilityWithOps("cap:userns-mount", *ops)
-		if result.Open || !result.Blocked || !strings.Contains(result.Detail, "setresgid") {
+		if !result.Open || result.Blocked || !strings.Contains(result.Detail, "setresgid") {
 			t.Fatalf("unexpected result: %+v", result)
 		}
 	})
 
-	t.Run("setresuid failure blocks", func(t *testing.T) {
+	t.Run("setresuid failure after unshare stays open", func(t *testing.T) {
 		ops, _, _ := newOps()
 		ops.setresuid = func(int, int, int) error { return errors.New("setresuid denied") }
 
 		result := probeUserNamespaceMountCapabilityWithOps("cap:userns-mount", *ops)
-		if result.Open || !result.Blocked || !strings.Contains(result.Detail, "setresuid") {
+		if !result.Open || result.Blocked || !strings.Contains(result.Detail, "setresuid") {
 			t.Fatalf("unexpected result: %+v", result)
 		}
 	})
 
 	t.Run("mount failure blocks", func(t *testing.T) {
 		ops, _, _ := newOps()
-		ops.mount = func(string, string, string, uintptr, string) error { return errors.New("mount denied") }
+		ops.mount = func(string, string, string, uintptr, string) error { return unix.EPERM }
 
 		result := probeUserNamespaceMountCapabilityWithOps("cap:userns-mount", *ops)
 		if result.Open || !result.Blocked || !strings.Contains(result.Detail, "mount after userns") {

--- a/internal/playground/local_escape_other.go
+++ b/internal/playground/local_escape_other.go
@@ -11,7 +11,7 @@ func probeLocalCapability(target, capability string) ProbeResult {
 	return ProbeResult{
 		Target:  target,
 		Open:    false,
-		Blocked: true,
-		Detail:  fmt.Sprintf("blocked/unavailable: %s capability probe is Linux-only", capability),
+		Blocked: false,
+		Detail:  fmt.Sprintf("unknown: %s capability probe is Linux-only", capability),
 	}
 }

--- a/internal/playground/orchestrate.go
+++ b/internal/playground/orchestrate.go
@@ -21,15 +21,13 @@ import (
 )
 
 // ErrContainmentNotWired is returned when Contained=true but no containment
-// hook has been registered via SetContainmentHook. Task 7 will wire the real
-// implementation; until then, contained mode visibly refuses to run rather
-// than silently falling back to uncontained.
+// hook has been registered. Contained mode visibly refuses to run rather than
+// silently falling back to uncontained.
 var ErrContainmentNotWired = errors.New(
-	"playground: containment mode requested but no containment hook is wired " +
-		"(Task 7 will provide the kernel-containment implementation)")
+	"playground: containment mode requested but no containment hook is wired")
 
-// ContainmentHook is the interface Task 7 must implement to wire kernel
-// containment into the demo orchestrator. The orchestrator calls Setup before
+// ContainmentHook wires a deployment's kernel containment into the demo
+// orchestrator. The orchestrator calls Setup before
 // the live run starts and Teardown during Reset/Close.
 //
 //	Setup: prepare nft chains, agent user, proxy routing. Returns nil on success.
@@ -69,6 +67,17 @@ type DemoOpts struct {
 	// true, the containment hook must be wired via SetContainmentHook.
 	Contained bool
 
+	// ProxyPort is the fixed loopback port used by the in-process proxy. A
+	// contained run must select a port explicitly authorized by its kernel
+	// containment policy so the signed witness can prove the proxy contract.
+	// Zero requests an ephemeral port and is valid only for uncontained runs.
+	ProxyPort int
+
+	// ToyAgentBin, when set, is used for both the self-managed start gate and
+	// the final signed containment witness so mixed probe versions cannot
+	// silently attest different behavior.
+	ToyAgentBin string
+
 	// ScenarioID selects the scenario from DefaultScenarios.
 	ScenarioID string
 
@@ -104,7 +113,7 @@ const defaultScenarioID = LiveDemoScenarioID
 //
 // In uncontained mode (the default, fully working today), the demo runs the
 // toy agent through the proxy without kernel containment. In contained mode,
-// it delegates to the containment hook (Task 7) for nft/agent-user setup.
+// it delegates to the selected containment hook for boundary setup and proof.
 //
 // Returns the VerifyReport so the caller can check .OK and set the exit code.
 func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, error) {
@@ -148,6 +157,9 @@ func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, e
 	if err != nil {
 		return VerifyReport{}, fmt.Errorf("build binaries: %w", err)
 	}
+	if opts.ToyAgentBin != "" {
+		agentBin = filepath.Clean(opts.ToyAgentBin)
+	}
 
 	// --- Timeline events (narration first) ---
 	var timeline []MediatorEvent
@@ -159,6 +171,7 @@ func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, e
 	// --- Start live run ---
 	lr, err := StartLiveRun(ctx, LiveRunOpts{
 		Contained:           opts.Contained,
+		ProxyPort:           opts.ProxyPort,
 		ScenarioID:          opts.ScenarioID,
 		RunNonce:            opts.RunNonce,
 		ToyAgentBin:         agentBin,
@@ -229,8 +242,9 @@ func RunDemo(ctx context.Context, out io.Writer, opts DemoOpts) (VerifyReport, e
 		if hcwData, hcwErr := os.ReadFile(hcwPath); hcwErr == nil {
 			var hcw HostContainmentWitness
 			if json.Unmarshal(hcwData, &hcw) == nil && verified {
-				detail = fmt.Sprintf("%d direct-egress routes and %d local escape surfaces blocked for %s; control target reachable for operator",
-					len(hcw.AgentProbes), len(hcw.LocalAgentProbes), hcw.AgentUser)
+				localDenied, localAbsent := hcw.LocalProbeCounts()
+				detail = fmt.Sprintf("%d direct-egress routes blocked; %d local operations denied and %d surfaces absent for %s; control target reachable for operator",
+					len(hcw.AgentProbes), localDenied, localAbsent, hcw.AgentUser)
 			}
 		}
 		timeline = append(timeline, ContainmentEvent(verified, detail))
@@ -298,8 +312,8 @@ func renderVerifySummary(out io.Writer, rep VerifyReport, runDir string) {
 // nonexistent dir succeeds. Calling it 3x in a row before new runs must
 // produce 3 clean runs.
 //
-// Containment teardown (nft chains, agent processes) is a Task 7 concern;
-// a marked hook is called when wired.
+// A marked containment hook is called when wired so deployment-owned teardown
+// can run before the directory is removed.
 func Reset(runDir string) error {
 	cleanDir := filepath.Clean(runDir)
 
@@ -419,10 +433,13 @@ func findRepoRoot() (string, error) {
 	}
 }
 
-// goBuild runs `go build -o outPath pkg` in the given dir.
+// goBuild runs `go build -buildvcs=false -o outPath pkg` in the given dir.
+// These are ephemeral demo helpers whose exact bytes are pinned in the signed
+// launch manifest. Disabling VCS stamping avoids coupling a live capture to
+// concurrently changing Git worktree metadata.
 func goBuild(ctx context.Context, dir, pkg, outPath string) error {
 	// All arguments are operator-controlled paths from DemoOpts, not untrusted input.
-	args := []string{"build", "-o", outPath, pkg}
+	args := goBuildArgs(pkg, outPath)
 	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
@@ -430,6 +447,10 @@ func goBuild(ctx context.Context, dir, pkg, outPath string) error {
 		return fmt.Errorf("%s: %w\n%s", pkg, err, out)
 	}
 	return nil
+}
+
+func goBuildArgs(pkg, outPath string) []string {
+	return []string{"build", "-buildvcs=false", "-o", outPath, pkg}
 }
 
 // hashDir computes a sha256 hash over the concatenated contents of all files

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -587,6 +587,9 @@ func verifyHostContainmentData(data []byte, lm LaunchManifest, orchestratorPubHe
 }
 
 func hostContainmentEnforcedReason(hcw HostContainmentWitness) string {
+	if hcw.ProbeSuiteVersion != "" && hcw.ProbeSuiteVersion != currentContainmentProbeSuite {
+		return fmt.Sprintf("unsupported host-containment probe suite version %q", hcw.ProbeSuiteVersion)
+	}
 	if hcw.ProxyTarget == "" || hcw.ProxyAgentProbe.Target == "" {
 		return "host-containment witness uses an older format without proxy-contract proof; regenerate the bundle with this release"
 	}

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -197,6 +197,7 @@ func validHostContainmentWitness(nonce, manifestHash string) playground.HostCont
 		proxy = "127.0.0.1:8888"
 	)
 	return playground.HostContainmentWitness{
+		// Keep synchronized with the unexported currentContainmentProbeSuite.
 		ProbeSuiteVersion:    "v2",
 		RunNonce:             nonce,
 		LaunchManifestHash:   manifestHash,

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -197,6 +197,7 @@ func validHostContainmentWitness(nonce, manifestHash string) playground.HostCont
 		proxy = "127.0.0.1:8888"
 	)
 	return playground.HostContainmentWitness{
+		ProbeSuiteVersion:    "v2",
 		RunNonce:             nonce,
 		LaunchManifestHash:   manifestHash,
 		AgentUser:            "pipelock-agent",


### PR DESCRIPTION
## Summary

- add a fail-closed self-managed containment mode for deployment-managed nftables boundaries
- validate the live canonical ruleset and prove contained-process isolation using differential network and local escape probes
- version and tighten the signed host-containment probe suites while preserving legacy witness verification
- wire the Fly playground entrypoint and deterministic demo capture through the same containment contract
- report denied operations separately from host-specific surfaces that are absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-managed containment mode for demo and live playground, including operator/proxy identity support.
  * Added configurable toy-agent binary and proxy port options, plus uid-aware verification.
  * Updated the live “verify-containment” workflow to validate proxy routing and containment readiness before startup.
* **Bug Fixes**
  * Containment now fails closed when required protections can’t be proven.
  * Improved classification and reporting of unavailable local security surfaces.
* **Documentation**
  * Refined playground documentation and demo commands for self-managed containment and host-boundary evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->