### PR TITLE
fix(playground): honor configured containment UIDs

### DIFF
--- a/cmd/pipelock-playground-demo/main.go
+++ b/cmd/pipelock-playground-demo/main.go
@@ -173,6 +173,8 @@ func newRunCmd() *cobra.Command {
 		selfManagedContainment bool
 		toyAgentBin            string
 		proxyPort              int
+		operatorUID            int
+		proxyUID               int
 		runDir                 string
 		scenario               string
 		color                  bool
@@ -202,9 +204,18 @@ Exit 0 = run verified successfully. Non-zero = verification failed or run error.
 				cmd.Flags().Changed("proxy-port") {
 				return errors.New("--proxy-port must be 1-65535")
 			}
+			if selfManagedContainment && (operatorUID < 0 || proxyUID < 0) {
+				return errors.New("--operator-uid and --proxy-uid must be non-negative")
+			}
+			if !selfManagedContainment &&
+				(cmd.Flags().Changed("operator-uid") || cmd.Flags().Changed("proxy-uid")) {
+				return errors.New("--operator-uid and --proxy-uid require --self-managed-containment")
+			}
 			effectiveProxyPort := demoProxyPort(contained, selfManagedContainment, proxyPort, cmd.Flags().Changed("proxy-port"))
 			if contained {
-				playground.SetContainmentHook(demoContainmentHook(selfManagedContainment, toyAgentBin))
+				playground.SetContainmentHook(newDemoContainmentHook(
+					selfManagedContainment, toyAgentBin, operatorUID, proxyUID,
+				))
 			}
 			rep, err := playground.RunDemo(cmd.Context(), w, playground.DemoOpts{
 				Contained:           contained,
@@ -229,6 +240,8 @@ Exit 0 = run verified successfully. Non-zero = verification failed or run error.
 	cmd.Flags().BoolVar(&selfManagedContainment, "self-managed-containment", false, "prove a deployment-managed canonical containment ruleset without requiring `pipelock contain install` (requires --contained and --toyagent-bin)")
 	cmd.Flags().StringVar(&toyAgentBin, "toyagent-bin", "", "toy-agent probe binary used by --self-managed-containment")
 	cmd.Flags().IntVar(&proxyPort, "proxy-port", 0, "fixed loopback proxy port authorized by the containment policy (contained default 8888; ignored when uncontained)")
+	cmd.Flags().IntVar(&operatorUID, "operator-uid", 0, "operator uid accepted by the self-managed containment rules (default 0/root)")
+	cmd.Flags().IntVar(&proxyUID, "proxy-uid", 0, "proxy uid accepted by the self-managed containment rules (default 0/root)")
 	cmd.Flags().StringVar(&orchKeyFile, "orchestrator-key-file", "", "path to the stable orchestrator signing key (default: the installed published demo key, else an ephemeral per-run key)")
 	cmd.Flags().StringVar(&runDir, "run-dir", "", "directory for run artifacts (required)")
 	cmd.Flags().StringVar(&scenario, "scenario", playground.LiveDemoScenarioID, "scenario ID to run")
@@ -238,12 +251,17 @@ Exit 0 = run verified successfully. Non-zero = verification failed or run error.
 	return cmd
 }
 
-func demoContainmentHook(selfManaged bool, toyAgentBin string) playground.ContainmentHook {
+func demoContainmentHook(selfManaged bool, toyAgentBin string, operatorUID, proxyUID int) playground.ContainmentHook {
 	if selfManaged {
-		return playground.NewInVMContainmentHook(toyAgentBin)
+		hook := playground.NewInVMContainmentHook(toyAgentBin)
+		hook.OperatorUID = operatorUID
+		hook.ProxyUID = proxyUID
+		return hook
 	}
 	return playground.NewRealContainmentHook("")
 }
+
+var newDemoContainmentHook = demoContainmentHook
 
 func demoProxyPort(contained, selfManaged bool, configured int, explicitlySet bool) int {
 	if !contained || !selfManaged {

--- a/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
+++ b/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
@@ -137,11 +137,20 @@ func TestRunCmd_SelfManagedContainmentRejectsNegativeUIDs(t *testing.T) {
 }
 
 func TestRunCmd_UIDFlagsRequireSelfManagedContainment(t *testing.T) {
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"run", "--run-dir", t.TempDir(), "--operator-uid", "1000"})
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "require --self-managed-containment") {
-		t.Fatalf("error = %v, want mode requirement", err)
+	for _, tc := range []struct {
+		name, flag, value string
+	}{
+		{name: "operator uid", flag: "--operator-uid", value: "1000"},
+		{name: "proxy uid", flag: "--proxy-uid", value: "967"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newRootCmd()
+			cmd.SetArgs([]string{"run", "--run-dir", t.TempDir(), tc.flag, tc.value})
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), "require --self-managed-containment") {
+				t.Fatalf("error = %v, want mode requirement", err)
+			}
+		})
 	}
 }
 

--- a/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
+++ b/cmd/pipelock-playground-demo/orchestrate_cmd_test.go
@@ -120,6 +120,57 @@ func TestRunCmd_SelfManagedContainmentRejectsExplicitZeroProxyPort(t *testing.T)
 	}
 }
 
+func TestRunCmd_SelfManagedContainmentRejectsNegativeUIDs(t *testing.T) {
+	for _, flag := range []string{"--operator-uid", "--proxy-uid"} {
+		t.Run(flag, func(t *testing.T) {
+			cmd := newRootCmd()
+			cmd.SetArgs([]string{
+				"run", "--run-dir", t.TempDir(), "--contained", "--self-managed-containment",
+				"--toyagent-bin", "/tmp/probe", flag, "-1",
+			})
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), "must be non-negative") {
+				t.Fatalf("error = %v, want uid range error", err)
+			}
+		})
+	}
+}
+
+func TestRunCmd_UIDFlagsRequireSelfManagedContainment(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"run", "--run-dir", t.TempDir(), "--operator-uid", "1000"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "require --self-managed-containment") {
+		t.Fatalf("error = %v, want mode requirement", err)
+	}
+}
+
+func TestRunCmd_ForwardsSelfManagedUIDFlags(t *testing.T) {
+	original := newDemoContainmentHook
+	t.Cleanup(func() { newDemoContainmentHook = original })
+	t.Cleanup(func() { playground.SetContainmentHook(nil) })
+	var gotOperator, gotProxy int
+	newDemoContainmentHook = func(selfManaged bool, toyAgentBin string, operatorUID, proxyUID int) playground.ContainmentHook {
+		if !selfManaged || toyAgentBin != "/nonexistent/toyagent" {
+			t.Fatalf("factory args: selfManaged=%v toyAgentBin=%q", selfManaged, toyAgentBin)
+		}
+		gotOperator, gotProxy = operatorUID, proxyUID
+		return demoContainmentHook(selfManaged, toyAgentBin, operatorUID, proxyUID)
+	}
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"run", "--run-dir", t.TempDir(), "--contained", "--self-managed-containment",
+		"--toyagent-bin", "/nonexistent/toyagent", "--operator-uid", "1000", "--proxy-uid", "967",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("unproven containment should fail closed")
+	}
+	if gotOperator != 1000 || gotProxy != 967 {
+		t.Fatalf("factory received operator=%d proxy=%d", gotOperator, gotProxy)
+	}
+}
+
 func TestRunCmd_SelfManagedContainmentSelectsHookBeforeFailingProbe(t *testing.T) {
 	playground.SetContainmentHook(nil)
 	t.Cleanup(func() { playground.SetContainmentHook(nil) })
@@ -162,11 +213,11 @@ func TestDemoProxyPort(t *testing.T) {
 func TestDemoContainmentHookSelection(t *testing.T) {
 	t.Parallel()
 	const probe = "/usr/local/bin/probe"
-	self, ok := demoContainmentHook(true, probe).(*playground.InVMContainmentHook)
-	if !ok || self.ToyAgentBin != probe {
+	self, ok := demoContainmentHook(true, probe, 1000, 967).(*playground.InVMContainmentHook)
+	if !ok || self.ToyAgentBin != probe || self.OperatorUID != 1000 || self.ProxyUID != 967 {
 		t.Fatalf("self-managed hook = %#v", self)
 	}
-	if _, ok := demoContainmentHook(false, probe).(*playground.RealContainmentHook); !ok {
+	if _, ok := demoContainmentHook(false, probe, 1000, 967).(*playground.RealContainmentHook); !ok {
 		t.Fatal("stock mode did not select RealContainmentHook")
 	}
 }

--- a/docs/guides/playground-demo.md
+++ b/docs/guides/playground-demo.md
@@ -99,7 +99,10 @@ restore_pipelock() {
 }
 trap restore_pipelock EXIT
 if [ "${was_active}" -eq 1 ]; then
-  sudo systemctl stop pipelock
+  if ! sudo systemctl stop pipelock; then
+    echo "failed to stop pipelock; aborting contained capture" >&2
+    exit 1
+  fi
 fi
 sudo pipelock-playground-demo run --contained --self-managed-containment \
   --toyagent-bin /usr/local/bin/pipelock-playground-toyagent \
@@ -110,12 +113,12 @@ sudo pipelock-playground-demo run --contained --self-managed-containment \
 Contained capture mode requires root, the `pipelock-agent` OS user, and a
 deployment-managed canonical owner-match boundary. The stock workstation
 service already owns its authorized proxy port. Stop it for the duration of a
-deterministic contained capture and always restart it afterward; self-managed
-mode verifies the live deployment-owned boundary but does not free an occupied
-port. `--operator-uid` and `--proxy-uid` identify the UIDs accepted by that
-live boundary; their root defaults are for single-process microVMs, so a stock
-workstation capture must pass the installed operator and proxy UIDs explicitly.
-Under the **split-proof** model the mediated steps
+deterministic contained capture and restore its prior state afterward;
+self-managed mode verifies the live deployment-owned boundary but does not free
+an occupied port. `--operator-uid` and `--proxy-uid` identify the UIDs accepted
+by that live boundary; their root defaults are for single-process microVMs, so a
+stock workstation capture must pass the installed operator and proxy UIDs
+explicitly. Under the **split-proof** model the mediated steps
 (allow, block) run as the operator through the lab proxy — exactly as in uncontained mode — and
 a separate probe phase drops to the `pipelock-agent` uid to build the signed host-containment
 witness. This split is deliberate: the proxy's allow/block decision does not depend on the

--- a/docs/guides/playground-demo.md
+++ b/docs/guides/playground-demo.md
@@ -85,16 +85,26 @@ operator_uid="$(id -u)"
 proxy_uid="$(id -u pipelock-proxy)"
 
 # The capture's in-process proxy must temporarily own the policy-authorized port.
-sudo systemctl stop pipelock
-trap 'sudo systemctl start pipelock' EXIT
+was_active=0
+if sudo systemctl is-active --quiet pipelock; then
+  was_active=1
+fi
+restore_pipelock() {
+  capture_status=$?
+  trap - EXIT
+  if [ "${was_active}" -eq 1 ] && ! sudo systemctl start pipelock; then
+    return 1
+  fi
+  return "${capture_status}"
+}
+trap restore_pipelock EXIT
+if [ "${was_active}" -eq 1 ]; then
+  sudo systemctl stop pipelock
+fi
 sudo pipelock-playground-demo run --contained --self-managed-containment \
   --toyagent-bin /usr/local/bin/pipelock-playground-toyagent \
   --operator-uid "${operator_uid}" --proxy-uid "${proxy_uid}" \
   --proxy-port 8888 --run-dir ./demo-run --scenario secret-exfil-body-blocked
-capture_rc=$?
-sudo systemctl start pipelock
-trap - EXIT
-test "${capture_rc}" -eq 0
 ```
 
 Contained capture mode requires root, the `pipelock-agent` OS user, and a

--- a/docs/guides/playground-demo.md
+++ b/docs/guides/playground-demo.md
@@ -81,16 +81,31 @@ kernel boundary to attest, and the tool says so rather than implying one.
 ### Contained (the real demo — requires a prepared host)
 
 ```bash
+operator_uid="$(id -u)"
+proxy_uid="$(id -u pipelock-proxy)"
+
+# The capture's in-process proxy must temporarily own the policy-authorized port.
+sudo systemctl stop pipelock
+trap 'sudo systemctl start pipelock' EXIT
 sudo pipelock-playground-demo run --contained --self-managed-containment \
   --toyagent-bin /usr/local/bin/pipelock-playground-toyagent \
+  --operator-uid "${operator_uid}" --proxy-uid "${proxy_uid}" \
   --proxy-port 8888 --run-dir ./demo-run --scenario secret-exfil-body-blocked
+capture_rc=$?
+sudo systemctl start pipelock
+trap - EXIT
+test "${capture_rc}" -eq 0
 ```
 
 Contained capture mode requires root, the `pipelock-agent` OS user, and a
 deployment-managed canonical owner-match boundary. The stock workstation
-service already owns its authorized proxy port, so deterministic contained
-capture uses `--self-managed-containment` rather than colliding with that
-listener. Under the **split-proof** model the mediated steps
+service already owns its authorized proxy port. Stop it for the duration of a
+deterministic contained capture and always restart it afterward; self-managed
+mode verifies the live deployment-owned boundary but does not free an occupied
+port. `--operator-uid` and `--proxy-uid` identify the UIDs accepted by that
+live boundary; their root defaults are for single-process microVMs, so a stock
+workstation capture must pass the installed operator and proxy UIDs explicitly.
+Under the **split-proof** model the mediated steps
 (allow, block) run as the operator through the lab proxy — exactly as in uncontained mode — and
 a separate probe phase drops to the `pipelock-agent` uid to build the signed host-containment
 witness. This split is deliberate: the proxy's allow/block decision does not depend on the

--- a/docs/guides/playground-demo.md
+++ b/docs/guides/playground-demo.md
@@ -86,9 +86,16 @@ proxy_uid="$(id -u pipelock-proxy)"
 
 # The capture's in-process proxy must temporarily own the policy-authorized port.
 was_active=0
-if sudo systemctl is-active --quiet pipelock; then
-  was_active=1
-fi
+service_state_rc=0
+service_state="$(sudo systemctl is-active pipelock 2>/dev/null)" || service_state_rc=$?
+case "${service_state}:${service_state_rc}" in
+  active:0) was_active=1 ;;
+  inactive:3) ;;
+  *)
+    echo "cannot determine pipelock service state; aborting contained capture" >&2
+    exit 1
+    ;;
+esac
 restore_pipelock() {
   capture_status=$?
   trap - EXIT

--- a/internal/cli/contain/selfmanaged_verify.go
+++ b/internal/cli/contain/selfmanaged_verify.go
@@ -71,7 +71,8 @@ func trustedNFTPath(statFn func(string) (fs.FileInfo, error)) (string, error) {
 func validateSelfManagedNFTRules(out string, operatorUID, proxyUID, agentUID, proxyPort int) error {
 	if !nftTableDumpDeclaresExpectedTable(out, defaultNFTTable) ||
 		!liveNFTContainmentMatches(out, defaultNFTChain, operatorUID, proxyUID, agentUID, proxyPort) {
-		return fmt.Errorf("live containment nft chain does not match the canonical owner-match boundary for agent uid %d and proxy port %d", agentUID, proxyPort)
+		return fmt.Errorf("live containment nft chain does not match the canonical owner-match boundary for operator uid %d, proxy uid %d, agent uid %d, and proxy port %d",
+			operatorUID, proxyUID, agentUID, proxyPort)
 	}
 	return nil
 }

--- a/internal/cli/contain/selfmanaged_verify_test.go
+++ b/internal/cli/contain/selfmanaged_verify_test.go
@@ -47,6 +47,9 @@ func TestValidateSelfManagedNFTRules(t *testing.T) {
 	if err := validateSelfManagedNFTRules(nonDefault, 1000, 1001, agentUID, proxyPort); err != nil {
 		t.Fatalf("non-default operator/proxy UIDs rejected: %v", err)
 	}
+	if err := validateSelfManagedNFTRules(canonical, 1000, 1001, agentUID, proxyPort); err == nil {
+		t.Fatal("root/root chain accepted for non-root operator/proxy UIDs")
+	}
 
 	t.Run("wrong proxy port", func(t *testing.T) {
 		t.Parallel()

--- a/internal/playground/containment_invm.go
+++ b/internal/playground/containment_invm.go
@@ -62,12 +62,18 @@ var ErrInVMContainmentNotProven = errors.New(
 type InVMContainmentHook struct {
 	ToyAgentBin string
 	AgentUser   string
+	OperatorUID int
+	ProxyUID    int
+	verify      func(context.Context, string, string, int, int, int) error
 }
 
 // NewInVMContainmentHook creates a containment hook that proves the boundary
 // with the supplied toy-agent probe binary.
 func NewInVMContainmentHook(toyAgentBin string) *InVMContainmentHook {
-	return &InVMContainmentHook{ToyAgentBin: toyAgentBin}
+	return &InVMContainmentHook{
+		ToyAgentBin: toyAgentBin,
+		verify:      VerifyInVMContainmentWithUIDs,
+	}
 }
 
 // Setup proves the configured contained uid cannot escape through direct
@@ -77,7 +83,13 @@ func (h *InVMContainmentHook) Setup(ctx context.Context, opts DemoOpts) error {
 	if agentUser == "" {
 		agentUser = defaultContainedAgentUser
 	}
-	return VerifyInVMContainment(ctx, h.ToyAgentBin, agentUser, opts.ProxyPort)
+	verify := h.verify
+	if verify == nil {
+		verify = VerifyInVMContainmentWithUIDs
+	}
+	return verify(
+		ctx, h.ToyAgentBin, agentUser, opts.ProxyPort, h.OperatorUID, h.ProxyUID,
+	)
 }
 
 // Teardown is a no-op because the deployment owns the persistent containment
@@ -180,8 +192,8 @@ func VerifyInVMContainmentWithUIDs(ctx context.Context, toyAgentBin, agentUser s
 	if err != nil || agentUID <= 0 {
 		return fmt.Errorf("%w: invalid agent uid %q", ErrInVMContainmentNotProven, agent.Uid)
 	}
-	if operatorUID < 0 || proxyUID < 0 {
-		return fmt.Errorf("%w: operator and proxy UIDs must be non-negative", ErrInVMContainmentNotProven)
+	if err := validateContainmentUIDRoles(operatorUID, proxyUID, agentUID); err != nil {
+		return err
 	}
 	if err := contain.VerifySelfManagedNFTRules(ctx, operatorUID, proxyUID, agentUID, proxyPort); err != nil {
 		return fmt.Errorf("%w: %w", ErrInVMContainmentNotProven, err)
@@ -237,6 +249,17 @@ func VerifyInVMContainmentWithUIDs(ctx context.Context, toyAgentBin, agentUser s
 		return err
 	}
 	return evalStartContainment(operatorControl, agentProbes[1], agentProbes[2:], localProbes)
+}
+
+func validateContainmentUIDRoles(operatorUID, proxyUID, agentUID int) error {
+	if operatorUID < 0 || proxyUID < 0 {
+		return fmt.Errorf("%w: operator and proxy UIDs must be non-negative", ErrInVMContainmentNotProven)
+	}
+	if operatorUID == agentUID || proxyUID == agentUID {
+		return fmt.Errorf("%w: operator uid %d and proxy uid %d must differ from contained agent uid %d",
+			ErrInVMContainmentNotProven, operatorUID, proxyUID, agentUID)
+	}
+	return nil
 }
 
 func acceptProbeConnections(ln net.Listener) {

--- a/internal/playground/containment_invm_test.go
+++ b/internal/playground/containment_invm_test.go
@@ -41,6 +41,8 @@ func allBlockedLocal() []ProbeResult {
 
 func TestInVMContainmentHookLifecycle(t *testing.T) {
 	hook := NewInVMContainmentHook("/nonexistent/toyagent")
+	hook.OperatorUID = 1000
+	hook.ProxyUID = 967
 	if hook.ToyAgentBin != "/nonexistent/toyagent" {
 		t.Fatalf("toy agent = %q", hook.ToyAgentBin)
 	}
@@ -49,6 +51,47 @@ func TestInVMContainmentHookLifecycle(t *testing.T) {
 	}
 	if err := hook.Teardown(t.TempDir()); err != nil {
 		t.Fatalf("teardown: %v", err)
+	}
+}
+
+func TestInVMContainmentHookForwardsUIDs(t *testing.T) {
+	hook := NewInVMContainmentHook("/usr/local/bin/probe")
+	hook.OperatorUID = 1000
+	hook.ProxyUID = 967
+	hook.verify = func(_ context.Context, bin, user string, port, operatorUID, proxyUID int) error {
+		if bin != hook.ToyAgentBin || user != defaultContainedAgentUser ||
+			port != DefaultContainedProxyPort || operatorUID != 1000 || proxyUID != 967 {
+			t.Fatalf("forwarded values: bin=%q user=%q port=%d operator=%d proxy=%d",
+				bin, user, port, operatorUID, proxyUID)
+		}
+		return nil
+	}
+	if err := hook.Setup(t.Context(), DemoOpts{ProxyPort: DefaultContainedProxyPort}); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+}
+
+func TestValidateContainmentUIDRoles(t *testing.T) {
+	t.Parallel()
+	if err := validateContainmentUIDRoles(1000, 967, 966); err != nil {
+		t.Fatalf("distinct roles rejected: %v", err)
+	}
+	for _, tc := range []struct {
+		name            string
+		operator, proxy int
+		agent           int
+	}{
+		{name: "negative operator", operator: -1, proxy: 967, agent: 966},
+		{name: "negative proxy", operator: 1000, proxy: -1, agent: 966},
+		{name: "operator is agent", operator: 966, proxy: 967, agent: 966},
+		{name: "proxy is agent", operator: 1000, proxy: 966, agent: 966},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := validateContainmentUIDRoles(tc.operator, tc.proxy, tc.agent); err == nil {
+				t.Fatal("unsafe uid roles accepted")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- pass configured operator and proxy UIDs through contained demo verification
- reject invalid UID values and contained identity collisions
- improve containment mismatch diagnostics
- document safely pausing an existing proxy during contained capture

## Why

Self-managed demo capture assumed the operator and proxy both used UID 0. That works for single-process deployments but rejects valid containment policies that use separate non-root service identities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `run` support for self-managed containment with `--operator-uid` and `--proxy-uid`, including validation and forwarding into the in-VM containment hook.
* **Bug Fixes**
  * Improved self-managed NFT rule mismatch errors to include the full identity/port set.
  * Strengthened rejection of unsafe UID combinations (negative values and operator/proxy matching the contained agent UID).
* **Documentation**
  * Updated contained-mode demo instructions to compute the correct UIDs and reliably stop/restart the `pipelock` service.
* **Tests**
  * Added tests for flag validation, required-flag behavior, UID forwarding, and UID-role validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->