### PR TITLE
fix(playground): support human-gated codeless sessions

### DIFF
--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -204,7 +204,7 @@ func newServeCmd() *cobra.Command {
 	fl.IntVar(&f.cpus, "cpus", 1, "per-visitor VM shared CPUs")
 	fl.IntVar(&f.internalPort, "internal-port", 8080, "per-visitor VM internal HTTP port")
 	fl.IntVar(&f.concurrency, "concurrency", defaultConcurrency, "global cap on live per-visitor machines")
-	fl.StringArrayVar(&f.codes, "code", nil, "public invite code (repeatable)")
+	fl.StringArrayVar(&f.codes, "code", nil, "public invite code (repeatable); omit when Turnstile or Cloudflare Access is the authorization gate")
 	fl.IntVar(&f.maxPerCode, "max-per-code", defaultMaxPerCode, "max broker sessions per invite code (0 = unlimited)")
 	fl.StringVar(&f.gateSecretFile, "gate-secret-file", "", "path to base64 broker gate secret")
 	fl.StringVar(&f.gateSecretEnv, "gate-secret-env", "", "environment variable containing base64 broker gate secret")
@@ -269,7 +269,7 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 		return err
 	}
 	if f.checkConfig {
-		if _, err := resolveCodes(f.codes, f.maxPerCode); err != nil {
+		if _, _, err := resolveBrokerCodes(f); err != nil {
 			return err
 		}
 		if _, err := brokerPublicHosts(f); err != nil {
@@ -278,7 +278,7 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 		if _, err := newCFAccessVerifier(f); err != nil {
 			return err
 		}
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "broker flags, invite codes, public hosts, access policy, and static UI valid; secrets and provider not contacted")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "broker flags, access gates, public hosts, access policy, and static UI valid; secrets and provider not contacted")
 		return nil
 	}
 	srv, handler, startReaper, pool, err := buildServer(ctx, cmd.OutOrStdout(), f)
@@ -342,7 +342,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	codes, err := resolveCodes(f.codes, f.maxPerCode)
+	codes, defaultCode, err := resolveBrokerCodes(f)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -425,7 +425,8 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		Leases:             lm,
 		WarmPool:           warmPool,
 		Gate:               gate,
-		DefaultCode:        effectiveDefaultCode(f),
+		DefaultCode:        defaultCode,
+		DisableCodeLimits:  len(f.codes) == 0,
 		TurnstileSitekey:   f.turnstileSitekey,
 		HumanVerifier:      humanVerifier,
 		IPRate:             livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
@@ -478,7 +479,7 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		return nil, nil, nil, nil, err
 	}
 
-	_, _ = fmt.Fprintf(out, "broker configured: %d code(s), capacity %d, image %s\n", len(codes), f.concurrency, f.image)
+	_, _ = fmt.Fprintf(out, "broker configured: %d public code(s), capacity %d, image %s\n", len(f.codes), f.concurrency, f.image)
 
 	// The broker API lives under /api/live/*. When a static UI directory is
 	// configured, serve it at / on the SAME origin so the live viewer's
@@ -597,9 +598,6 @@ func validateFlags(f *serveFlags) error {
 	if f.maxPerCode < 0 {
 		return errors.New("--max-per-code must be >= 0")
 	}
-	if len(f.codes) == 0 {
-		return errors.New("no invite codes: pass --code CODE")
-	}
 	if f.internalPort < 1 || f.internalPort > 65535 {
 		return errors.New("--internal-port must be 1-65535")
 	}
@@ -622,6 +620,12 @@ func validateFlags(f *serveFlags) error {
 	}
 	if err := validateHumanGateFlags(f); err != nil {
 		return err
+	}
+	if len(f.codes) == 0 && !hasConfiguredHumanGate(f) {
+		return errors.New("invite codes may be omitted only when Turnstile or Cloudflare Access is configured")
+	}
+	if len(f.codes) == 0 && f.provider == "fly" && strings.TrimSpace(f.turnstileVerifyURL) != "" {
+		return errors.New("--turnstile-verify-url overrides are not allowed for codeless Fly deployments")
 	}
 	if f.sessionTTL <= 0 {
 		return errors.New("--session-ttl must be > 0")
@@ -727,9 +731,7 @@ func validateDefaultCode(f *serveFlags) error {
 	if cfdc := strings.TrimSpace(f.cfAccessDefaultCode); cfdc != "" && cfdc != dc {
 		return errors.New("set only one of --default-code or --cf-access-default-code")
 	}
-	hasTurnstile := strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != ""
-	hasCFAccess := strings.TrimSpace(f.cfAccessTeamDomain) != "" || strings.TrimSpace(f.cfAccessAUD) != ""
-	if !hasTurnstile && !hasCFAccess {
+	if !hasConfiguredHumanGate(f) {
 		return errors.New("--default-code requires a human gate (--turnstile-secret-file/--turnstile-secret-env or Cloudflare Access); a default code with no human gate would open the broker")
 	}
 	for _, c := range f.codes {
@@ -811,12 +813,16 @@ func isPrivateOrLoopback(addr netip.Addr) bool {
 }
 
 func validateHumanGateFlags(f *serveFlags) error {
-	hasTurnstile := strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != ""
-	hasCFAccess := strings.TrimSpace(f.cfAccessTeamDomain) != "" || strings.TrimSpace(f.cfAccessAUD) != ""
-	if hasTurnstile || hasCFAccess || f.unsafeNoHumanGate {
+	if hasConfiguredHumanGate(f) || f.unsafeNoHumanGate {
 		return nil
 	}
 	return errors.New("--turnstile-secret-file/--turnstile-secret-env or Cloudflare Access is required unless --unsafe-no-human-gate is set")
+}
+
+func hasConfiguredHumanGate(f *serveFlags) bool {
+	hasTurnstile := strings.TrimSpace(f.turnstileSecretFile) != "" || strings.TrimSpace(f.turnstileSecretEnv) != ""
+	hasCFAccess := strings.TrimSpace(f.cfAccessTeamDomain) != "" && strings.TrimSpace(f.cfAccessAUD) != ""
+	return hasTurnstile || hasCFAccess
 }
 
 func validateTurnstileFlags(f *serveFlags) error {
@@ -1641,6 +1647,30 @@ func resolveCodes(codes []string, maxPerCode int) ([]livechat.CodeSpec, error) {
 		specs = append(specs, livechat.CodeSpec{Code: code, MaxSessions: maxPerCode})
 	}
 	return specs, nil
+}
+
+// resolveBrokerCodes keeps the gate's code-based accounting internally while
+// allowing operators to omit public invite codes when a real human gate is
+// configured. The generated code is process-local, unguessable, never logged,
+// and applied server-side only after the human verifier accepts the request.
+func resolveBrokerCodes(f *serveFlags) ([]livechat.CodeSpec, string, error) {
+	defaultCode := effectiveDefaultCode(f)
+	rawCodes := f.codes
+	if len(rawCodes) == 0 {
+		if !hasConfiguredHumanGate(f) {
+			return nil, "", errors.New("cannot generate an internal gate code without Turnstile or Cloudflare Access")
+		}
+		internalCode, err := livechat.NewRandomCode(32)
+		if err != nil {
+			return nil, "", fmt.Errorf("generate internal gate code: %w", err)
+		}
+		return []livechat.CodeSpec{{Code: internalCode}}, internalCode, nil
+	}
+	codes, err := resolveCodes(rawCodes, f.maxPerCode)
+	if err != nil {
+		return nil, "", err
+	}
+	return codes, defaultCode, nil
 }
 
 // buildVMBaseEnv assembles the PLAYGROUND_* environment shared by every

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -698,7 +698,6 @@ func TestBuildServerTurnstileRejectsMissingToken(t *testing.T) {
 		image:                 "registry.example/playground:test",
 		internalPort:          8080,
 		concurrency:           2,
-		codes:                 []string{"outer-code"},
 		maxPerCode:            defaultMaxPerCode,
 		gateSecretFile:        gateSecretFile,
 		ipRate:                defaultIPRate,
@@ -721,11 +720,16 @@ func TestBuildServerTurnstileRejectsMissingToken(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, livechat.RouteSession, strings.NewReader(`{"code":"outer-code"}`))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, livechat.RouteSession, strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	handler.ServeHTTP(rr, req)
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("missing Turnstile token status = %d, want 403", rr.Code)
+	}
+	health := httptest.NewRecorder()
+	handler.ServeHTTP(health, httptest.NewRequestWithContext(context.Background(), http.MethodGet, livechat.RouteHealth, nil))
+	if !strings.Contains(health.Body.String(), `"code_required":false`) {
+		t.Fatalf("codeless health = %s", health.Body.String())
 	}
 }
 
@@ -894,6 +898,17 @@ func TestRunServeCheckConfigDoesNotResolveSecretsOrProvider(t *testing.T) {
 		t.Fatalf("check-config output = %q", out.String())
 	}
 
+	codeless := *f
+	codeless.codes = nil
+	codeless.unsafeNoHumanGate = false
+	codeless.turnstileSecretEnv = "TS_SECRET"
+	codeless.turnstileSitekey = "site-key"
+	codeless.turnstileExpectedHostname = "playground.example"
+	codeless.turnstileExpectedAction = "playground-session"
+	if err := runServe(cmd, &codeless); err != nil {
+		t.Fatalf("codeless Turnstile check-config: %v", err)
+	}
+
 	invalidHost := *f
 	invalidHost.publicHosts = []string{"bad host"}
 	if err := runServe(cmd, &invalidHost); err == nil || !strings.Contains(err.Error(), "--public-host") {
@@ -950,6 +965,77 @@ func TestBuildServerValidation(t *testing.T) {
 			}
 		})
 	}
+
+	codeless := base
+	codeless.codes = nil
+	codeless.unsafeNoHumanGate = false
+	codeless.turnstileSecretEnv = "TS_SECRET"
+	codeless.turnstileSitekey = "site-key"
+	codeless.turnstileExpectedHostname = "playground.example"
+	codeless.turnstileExpectedAction = "playground-session"
+	if err := validateFlags(&codeless); err != nil {
+		t.Fatalf("Turnstile-only flags rejected: %v", err)
+	}
+	codeless.turnstileVerifyURL = "https://verify.example"
+	if err := validateFlags(&codeless); err == nil {
+		t.Fatal("codeless Fly deployment accepted a Turnstile endpoint override")
+	}
+
+	codelessAccess := base
+	codelessAccess.codes = nil
+	codelessAccess.unsafeNoHumanGate = false
+	codelessAccess.cfAccessTeamDomain = "https://team.cloudflareaccess.com"
+	codelessAccess.cfAccessAUD = "aud-tag"
+	if err := validateFlags(&codelessAccess); err != nil {
+		t.Fatalf("Access-only flags rejected: %v", err)
+	}
+	codelessAccess.cfAccessAUD = ""
+	if err := validateFlags(&codelessAccess); err == nil {
+		t.Fatal("partial Access configuration accepted for codeless mode")
+	}
+}
+
+func TestResolveBrokerCodes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("generates process-local default for human-gated codeless mode", func(t *testing.T) {
+		t.Parallel()
+		codes, defaultCode, err := resolveBrokerCodes(&serveFlags{
+			maxPerCode: 7, turnstileSecretEnv: "TS_SECRET",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(codes) != 1 {
+			t.Fatalf("codes = %d, want 1 internal code", len(codes))
+		}
+		if defaultCode == "" || codes[0].Code != defaultCode {
+			t.Fatal("internal code was not applied as the server-side default")
+		}
+		if codes[0].MaxSessions != 0 {
+			t.Fatalf("MaxSessions = %d, want unlimited internal code", codes[0].MaxSessions)
+		}
+	})
+
+	t.Run("refuses generation without a configured human gate", func(t *testing.T) {
+		t.Parallel()
+		if _, _, err := resolveBrokerCodes(&serveFlags{}); err == nil {
+			t.Fatal("resolveBrokerCodes succeeded without a human gate")
+		}
+	})
+
+	t.Run("preserves configured codes and default", func(t *testing.T) {
+		t.Parallel()
+		codes, defaultCode, err := resolveBrokerCodes(&serveFlags{
+			codes: []string{"public"}, defaultCode: "public", maxPerCode: 3,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(codes) != 1 || codes[0].Code != "public" || defaultCode != "public" {
+			t.Fatalf("configured gate changed: codes=%#v default=%q", codes, defaultCode)
+		}
+	})
 }
 
 func TestValidateDefaultCode(t *testing.T) {

--- a/cmd/pipelock-playground-loadtest/main.go
+++ b/cmd/pipelock-playground-loadtest/main.go
@@ -54,7 +54,7 @@ type config struct {
 }
 
 type sessionRequest struct {
-	Code           string `json:"code"`
+	Code           string `json:"code,omitempty"`
 	TurnstileToken string `json:"turnstile_token,omitempty"`
 }
 
@@ -164,7 +164,7 @@ func main() {
 func parseFlags() config {
 	var cfg config
 	flag.StringVar(&cfg.brokerURL, "broker-url", "", "broker base URL, for example https://playground.example")
-	flag.StringVar(&cfg.code, "code", "", "invite code")
+	flag.StringVar(&cfg.code, "code", "", "invite code; omit for a codeless human-gated broker")
 	flag.StringVar(&cfg.turnstileToken, "turnstile-token", "", "Cloudflare Turnstile test-mode token")
 	flag.IntVar(&cfg.concurrency, "concurrency", defaultConcurrency, "number of concurrent virtual users to run")
 	flag.DurationVar(&cfg.ramp, "ramp", 0, "duration to spread user launches over; 0 launches all users at once")
@@ -188,9 +188,6 @@ func validateConfig(cfg config) error {
 	}
 	if u.Host == "" {
 		return errors.New("--broker-url host is required")
-	}
-	if strings.TrimSpace(cfg.code) == "" {
-		return errors.New("--code is required")
 	}
 	if strings.TrimSpace(cfg.turnstileToken) == "" {
 		return errors.New("--turnstile-token is required")

--- a/cmd/pipelock-playground-loadtest/main_test.go
+++ b/cmd/pipelock-playground-loadtest/main_test.go
@@ -255,7 +255,6 @@ func TestValidateConfigRequiredFields(t *testing.T) {
 	}{
 		{name: "broker url", mutate: func(cfg *config) { cfg.brokerURL = "://" }, want: "--broker-url"},
 		{name: "broker host", mutate: func(cfg *config) { cfg.brokerURL = "https://" }, want: "--broker-url host"},
-		{name: "code", mutate: func(cfg *config) { cfg.code = " " }, want: "--code"},
 		{name: "turnstile", mutate: func(cfg *config) { cfg.turnstileToken = "" }, want: "--turnstile-token"},
 		{name: "concurrency", mutate: func(cfg *config) { cfg.concurrency = 0 }, want: "--concurrency"},
 		{name: "ramp", mutate: func(cfg *config) { cfg.ramp = -time.Second }, want: "--ramp"},
@@ -275,6 +274,10 @@ func TestValidateConfigRequiredFields(t *testing.T) {
 	}
 	if err := validateConfig(valid); err != nil {
 		t.Fatalf("valid config rejected: %v", err)
+	}
+	valid.code = ""
+	if err := validateConfig(valid); err != nil {
+		t.Fatalf("codeless config rejected: %v", err)
 	}
 }
 

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -71,7 +71,6 @@ docker run --rm "${BROKER_TAG}" serve \
 	--fly-app preflight \
 	--fly-token-env PREFLIGHT_FLY_TOKEN \
 	--image preflight \
-	--code preflight \
 	--global-daily-budget 1 \
 	--vm-daily-turn-budget 1 \
 	--turnstile-secret-env PREFLIGHT_TURNSTILE_SECRET \

--- a/docs/guides/playground-broker-operations.md
+++ b/docs/guides/playground-broker-operations.md
@@ -21,7 +21,7 @@ controls enabled:
 | Human/bot gate | `--turnstile-secret-file` or `--turnstile-secret-env` |
 | Global broker spend cap | `--global-daily-budget` greater than `0` |
 | Per-VM model spend cap | `--vm-daily-turn-budget` greater than `0` |
-| Abuse buckets | `--per-ip-daily-budget`, `--per-code-daily-budget`, IP/code rates |
+| Abuse buckets | `--per-ip-daily-budget` and IP rate; add per-code controls when invite codes are enabled |
 | Short sessions | `--session-ttl`, `--deadline-grace`, `--vm-session-ttl` |
 | Host protection | `--public-host`, `--allow-origin`, and origin-side Access JWT while private |
 | Provider backstop | Model-provider billing cap or prepaid balance outside Pipelock |
@@ -50,11 +50,8 @@ pipelock-playground-broker serve \
   --cpus 1 \
   --internal-port 8080 \
   --concurrency 20 \
-  --code press-review-code \
-  --max-per-code 25 \
   --global-daily-budget 60 \
   --per-ip-daily-budget 20 \
-  --per-code-daily-budget 60 \
   --admin-listen 127.0.0.1:8101 \
   --admin-token-env PLAYGROUND_ADMIN_TOKEN \
   --turnstile-secret-env PLAYGROUND_TURNSTILE_SECRET \
@@ -73,6 +70,14 @@ pipelock-playground-broker serve \
   --embed-origin https://site.example \
   --public-host playground.example.com
 ```
+
+This example uses Turnstile as the public authorization step and therefore
+needs no invite codes. When no `--code` values are configured, the broker
+creates an unguessable process-local gate value that is never logged or sent to
+the browser. Per-code rate and budget controls are disabled in this mode;
+per-IP, global daily, concurrency, and provider billing controls remain active.
+If public invite codes are configured, the existing per-code controls still
+apply normally.
 
 Secrets are loaded from files or environment variables and are never printed by
 the broker. Do not pass model keys, provider tokens, Turnstile secrets, or invite
@@ -211,7 +216,7 @@ Poll `/api/live/health` and alert on:
 | `ok:false` | Broker is paused, out of global budget, or gate is closed |
 | `budget_remaining` near `0` | The demo is about to stop accepting sessions |
 | `in_use` near `capacity` | Visitors are queued out by the concurrency cap |
-| `session_starts_last_minute` spike | Bot traffic or an invite code shared more broadly than planned |
+| `session_starts_last_minute` spike | Bot traffic, or an invite code shared more broadly than planned when codes are enabled |
 | Repeated HTTP 403 on session creation | Bot traffic, invalid Turnstile tokens, or bad invite flow |
 | Repeated HTTP 429 | Abuse pressure or caps set too low for the audience |
 | Repeated HTTP 503 on `/api/live/message` | Model provider is out of credits, has bad credentials, or is rate-limiting; check provider billing and the model key |
@@ -225,7 +230,7 @@ system.
 1. Pause immediately with `SIGUSR1`.
 2. Confirm health reports `"killed":true`.
 3. Check provider billing and active machine count.
-4. Rotate invite codes if a shared code leaked.
+4. If invite codes are enabled, rotate them when a shared code leaks.
 5. Reduce `--concurrency`, daily budgets, session TTL, or per-IP caps before
    resuming.
 6. Resume with `SIGUSR2` only after the cost ceiling and bot gate are confirmed.

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -94,6 +94,11 @@ type ServerConfig struct {
 	// session creation — the caller (main) enforces that. Empty means a code is
 	// always required. It is never sent to clients.
 	DefaultCode string
+	// DisableCodeLimits skips per-code rate and daily-budget controls when the
+	// deployment has no public invite codes. Per-IP and global controls remain
+	// enforced; applying per-code controls to one process-local internal code
+	// would incorrectly turn them into a second global choke point.
+	DisableCodeLimits bool
 	// TurnstileSitekey is the PUBLIC Cloudflare Turnstile site key, reported via
 	// /health so the viewer can render the widget. Empty means no Turnstile
 	// widget (Access-gated or unsafe-no-gate deploy). The secret is held by
@@ -563,7 +568,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	rollback = append(rollback, func() { s.cfg.Gate.Refund(claims) })
 
 	codeLimiterKey := "code:" + claims.CodeID
-	if !s.codeRate.Allow(codeLimiterKey) {
+	if !s.cfg.DisableCodeLimits && !s.codeRate.Allow(codeLimiterKey) {
 		undo()
 		writeBrokerErr(w, http.StatusTooManyRequests, "rate limited")
 		return
@@ -578,12 +583,14 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	}
 	rollback = append(rollback, func() { s.perIP.Refund(ipBudgetKey, 1) })
 
-	if !s.perCode.Charge(codeBudgetKey, 1) {
+	if !s.cfg.DisableCodeLimits && !s.perCode.Charge(codeBudgetKey, 1) {
 		undo()
 		writeBrokerErr(w, http.StatusTooManyRequests, "daily limit reached for this code")
 		return
 	}
-	rollback = append(rollback, func() { s.perCode.Refund(codeBudgetKey, 1) })
+	if !s.cfg.DisableCodeLimits {
+		rollback = append(rollback, func() { s.perCode.Refund(codeBudgetKey, 1) })
+	}
 
 	if !s.global.Charge(1) {
 		undo()

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -723,6 +723,50 @@ func TestServer_DefaultCodeFallback(t *testing.T) {
 			t.Fatalf("created machines = %d, want 1 after human proof", got)
 		}
 	})
+	t.Run("internal default bypasses public per-code budget", func(t *testing.T) {
+		vm1 := newFakeVM(t, "vm-codeless-1")
+		vm2 := newFakeVM(t, "vm-codeless-2")
+		provider := &serverFakeProvider{targets: []string{vm1.targetHost(t), vm2.targetHost(t)}}
+		_, ts := newBrokerTestServer(t, provider, ServerConfig{
+			DefaultCode:        brokerTestCode,
+			DisableCodeLimits:  true,
+			CodeRate:           livechat.RateConfig{RefillPerSec: 0.0001, Burst: 1},
+			PerCodeDailyBudget: 1,
+			GlobalDailyBudget:  2,
+		})
+		for i := range 2 {
+			resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{})
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("session %d status = %d, want 200", i+1, resp.StatusCode)
+			}
+		}
+		resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{})
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("third session status = %d, want global-budget 503", resp.StatusCode)
+		}
+	})
+	t.Run("codeless mode still enforces per-IP budget", func(t *testing.T) {
+		vm := newFakeVM(t, "vm-codeless-ip")
+		provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+		_, ts := newBrokerTestServer(t, provider, ServerConfig{
+			DefaultCode:       brokerTestCode,
+			DisableCodeLimits: true,
+			PerIPDailyBudget:  1,
+			GlobalDailyBudget: 2,
+		})
+		for i, want := range []int{http.StatusOK, http.StatusTooManyRequests} {
+			resp := postBrokerJSON(t, ts.URL+livechat.RouteSession, sessionRequest{})
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode != want {
+				t.Fatalf("session %d status = %d, want %d", i+1, resp.StatusCode, want)
+			}
+		}
+	})
 }
 
 func TestServer_EndToEndProxyAndRelease(t *testing.T) {


### PR DESCRIPTION
## Summary

- allow public invite codes to be omitted when Turnstile or a complete Cloudflare Access configuration is the authorization gate
- retain the existing gate/token machinery using an unguessable process-local value while keeping per-IP and global limits authoritative
- align the load-test client, image preflight, tests, and operator documentation with codeless deployments

## Why

A Turnstile-only broker currently refuses to start unless at least one obsolete invite code is configured. This removes that startup dependency without allowing codeless operation through the unsafe no-human-gate path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Human-gated brokers can now operate without configured public invite codes.
  * Turnstile and Cloudflare Access deployments support codeless session creation.
  * Codeless sessions retain global and per-IP protections while avoiding per-code limits.
  * Load-test tools now support brokers that do not require invite codes.

* **Bug Fixes**
  * Improved validation and status reporting for codeless configurations.

* **Documentation**
  * Updated setup, monitoring, and incident-response guidance for invite-code and codeless deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->