### PR TITLE
fix(mcp): follow hot reload for denial-of-wallet enablement and budgets

### DIFF
--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -207,6 +207,7 @@ type Server struct {
 	mcpChainMatcher    *chains.Matcher
 	mcpCEE             *mcp.CEEDeps
 	mcpToolExtraPoison []*tools.ExtraPoisonPattern
+	mcpDoW             *mcpDoWRuntime
 }
 
 // stderrSyncWriter wraps the operator-facing stderr writer with a mutex so

--- a/internal/cli/runtime/server_builders.go
+++ b/internal/cli/runtime/server_builders.go
@@ -141,6 +141,10 @@ func (r *mcpDoWRuntime) UpdateConfig(cfg *config.Config) {
 	if dowAction == "" {
 		dowAction = config.ActionBlock
 	}
+	var trackerCfg proxy.DoWConfig
+	if budget != nil {
+		trackerCfg = mcpDoWTrackerConfig(*budget)
+	}
 	subjectAgent := r.agentName
 	if subjectAgent == "" && cfg != nil {
 		subjectAgent = cfg.DefaultAgentIdentity
@@ -152,17 +156,14 @@ func (r *mcpDoWRuntime) UpdateConfig(cfg *config.Config) {
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if enabled && r.manager == nil {
-		r.manager = proxy.NewDoWSubjectManager(proxy.DoWSubjectManagerConfig{
-			TrackerConfig: proxy.DoWConfig{
-				MaxToolCallsPerSession: budget.MaxToolCallsPerSession,
-				MaxWallClockMinutes:    budget.MaxWallClockMinutes,
-				WindowMinutes:          budget.WindowMinutes,
-				MaxRetriesPerTool:      budget.MaxRetriesPerTool,
-				LoopDetectionWindow:    budget.LoopDetectionWindow,
-				Action:                 budget.DoWAction,
-			},
-		})
+	if enabled {
+		if r.manager == nil {
+			r.manager = proxy.NewDoWSubjectManager(proxy.DoWSubjectManagerConfig{
+				TrackerConfig: trackerCfg,
+			})
+		} else {
+			r.manager.UpdateConfig(trackerCfg)
+		}
 	}
 	r.enabled = enabled
 	r.action = dowAction
@@ -211,6 +212,17 @@ func (r *mcpDoWRuntime) Wiring() *mcpDoWWiring {
 		KnownSession:     r.trustedSessions.Known,
 		RegisterSession:  r.trustedSessions.Register,
 		ForgetSession:    r.trustedSessions.Forget,
+	}
+}
+
+func mcpDoWTrackerConfig(budget config.BudgetConfig) proxy.DoWConfig {
+	return proxy.DoWConfig{
+		MaxToolCallsPerSession: budget.MaxToolCallsPerSession,
+		MaxWallClockMinutes:    budget.MaxWallClockMinutes,
+		WindowMinutes:          budget.WindowMinutes,
+		MaxRetriesPerTool:      budget.MaxRetriesPerTool,
+		LoopDetectionWindow:    budget.LoopDetectionWindow,
+		Action:                 budget.DoWAction,
 	}
 }
 

--- a/internal/cli/runtime/server_builders.go
+++ b/internal/cli/runtime/server_builders.go
@@ -92,6 +92,7 @@ func buildMCPCEE(cfg *config.Config, m *metrics.Metrics) *mcp.CEEDeps {
 
 type mcpDoWWiring struct {
 	Check            mcp.DoWCheckFunc
+	Enabled          func() bool
 	SubjectAgent     string
 	SubjectAgentAuth envelope.ActorAuth
 	KnownSession     func(string) bool
@@ -100,43 +101,116 @@ type mcpDoWWiring struct {
 }
 
 func buildMCPDoWWiring(cfg *config.Config, agentName string) *mcpDoWWiring {
-	budget := resolveMCPDoWBudget(cfg, agentName)
-	if budget == nil || !budget.HasDoWFields() {
+	runtime := newMCPDoWRuntime(cfg, agentName)
+	if runtime == nil || !runtime.Enabled() {
 		return nil
 	}
-	manager := proxy.NewDoWSubjectManager(proxy.DoWSubjectManagerConfig{
-		TrackerConfig: proxy.DoWConfig{
-			MaxToolCallsPerSession: budget.MaxToolCallsPerSession,
-			MaxWallClockMinutes:    budget.MaxWallClockMinutes,
-			WindowMinutes:          budget.WindowMinutes,
-			MaxRetriesPerTool:      budget.MaxRetriesPerTool,
-			LoopDetectionWindow:    budget.LoopDetectionWindow,
-			Action:                 budget.DoWAction,
-		},
-	})
-	trustedSessions := &mcpTrustedSessionRegistry{sessions: make(map[string]time.Time)}
-	dowAction := budget.DoWAction
+	return runtime.Wiring()
+}
+
+type mcpDoWRuntime struct {
+	mu               sync.RWMutex
+	manager          *proxy.DoWSubjectManager
+	enabled          bool
+	action           string
+	subjectAgent     string
+	subjectAgentAuth envelope.ActorAuth
+	trustedSessions  *mcpTrustedSessionRegistry
+	agentName        string
+}
+
+func newMCPDoWRuntime(cfg *config.Config, agentName string) *mcpDoWRuntime {
+	runtime := &mcpDoWRuntime{
+		trustedSessions: &mcpTrustedSessionRegistry{sessions: make(map[string]time.Time)},
+		agentName:       agentName,
+	}
+	runtime.UpdateConfig(cfg)
+	return runtime
+}
+
+func (r *mcpDoWRuntime) UpdateConfig(cfg *config.Config) {
+	if r == nil {
+		return
+	}
+	budget := resolveMCPDoWBudget(cfg, r.agentName)
+	enabled := budget != nil && budget.HasDoWFields()
+	dowAction := ""
+	if budget != nil {
+		dowAction = budget.DoWAction
+	}
 	if dowAction == "" {
 		dowAction = config.ActionBlock
 	}
-	subjectAgent := agentName
-	if subjectAgent == "" {
+	subjectAgent := r.agentName
+	if subjectAgent == "" && cfg != nil {
 		subjectAgent = cfg.DefaultAgentIdentity
 	}
 	subjectAgentAuth := envelope.ActorAuth("")
 	if subjectAgent != "" {
 		subjectAgentAuth = envelope.ActorAuthConfigDefault
 	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if enabled && r.manager == nil {
+		r.manager = proxy.NewDoWSubjectManager(proxy.DoWSubjectManagerConfig{
+			TrackerConfig: proxy.DoWConfig{
+				MaxToolCallsPerSession: budget.MaxToolCallsPerSession,
+				MaxWallClockMinutes:    budget.MaxWallClockMinutes,
+				WindowMinutes:          budget.WindowMinutes,
+				MaxRetriesPerTool:      budget.MaxRetriesPerTool,
+				LoopDetectionWindow:    budget.LoopDetectionWindow,
+				Action:                 budget.DoWAction,
+			},
+		})
+	}
+	r.enabled = enabled
+	r.action = dowAction
+	r.subjectAgent = subjectAgent
+	r.subjectAgentAuth = subjectAgentAuth
+}
+
+func (r *mcpDoWRuntime) Enabled() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.enabled
+}
+
+func (r *mcpDoWRuntime) Check(subjectKey, toolName, argsJSON string) (bool, string, string, string) {
+	if r == nil {
+		return true, config.ActionBlock, "", ""
+	}
+	r.mu.RLock()
+	enabled := r.enabled
+	manager := r.manager
+	action := r.action
+	r.mu.RUnlock()
+	if !enabled || manager == nil {
+		return true, action, "", ""
+	}
+	result := manager.Check(subjectKey, toolName, argsJSON)
+	return result.Allowed, action, result.Reason, result.BudgetType
+}
+
+func (r *mcpDoWRuntime) Wiring() *mcpDoWWiring {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	subjectAgent := r.subjectAgent
+	subjectAgentAuth := r.subjectAgentAuth
+	r.mu.RUnlock()
 	return &mcpDoWWiring{
-		Check: func(subjectKey, toolName, argsJSON string) (bool, string, string, string) {
-			result := manager.Check(subjectKey, toolName, argsJSON)
-			return result.Allowed, dowAction, result.Reason, result.BudgetType
-		},
+		Check:            r.Check,
+		Enabled:          r.Enabled,
 		SubjectAgent:     subjectAgent,
 		SubjectAgentAuth: subjectAgentAuth,
-		KnownSession:     trustedSessions.Known,
-		RegisterSession:  trustedSessions.Register,
-		ForgetSession:    trustedSessions.Forget,
+		KnownSession:     r.trustedSessions.Known,
+		RegisterSession:  r.trustedSessions.Register,
+		ForgetSession:    r.trustedSessions.Forget,
 	}
 }
 
@@ -240,6 +314,7 @@ func applyMCPDoWOpts(opts *mcp.MCPProxyOpts, wiring *mcpDoWWiring, requireTruste
 		return
 	}
 	opts.DoWCheck = wiring.Check
+	opts.DoWEnabledFn = wiring.Enabled
 	opts.DoWSubjectAgent = wiring.SubjectAgent
 	opts.DoWSubjectAgentAuth = wiring.SubjectAgentAuth
 	if requireTrustedSession {

--- a/internal/cli/runtime/server_builders_test.go
+++ b/internal/cli/runtime/server_builders_test.go
@@ -118,3 +118,91 @@ func TestMCPDoWRuntimeDisabledStartupEnabledByReloadEnforces(t *testing.T) {
 			allowed, action, reason, budgetType)
 	}
 }
+
+func TestMCPDoWRuntimeNilReceiverMethods(t *testing.T) {
+	var runtime *mcpDoWRuntime
+	runtime.UpdateConfig(config.Defaults())
+	if runtime.Enabled() {
+		t.Fatal("nil DoW runtime reported enabled")
+	}
+	if allowed, action, reason, budgetType := runtime.Check("subject-a", "search", "{}"); !allowed || action != config.ActionBlock || reason != "" || budgetType != "" {
+		t.Fatalf("nil DoW runtime check = allowed:%v action:%q reason:%q budget:%q, want clean allow",
+			allowed, action, reason, budgetType)
+	}
+	if wiring := runtime.Wiring(); wiring != nil {
+		t.Fatalf("nil DoW runtime wiring = %+v, want nil", wiring)
+	}
+}
+
+func TestServerRefreshRuntimeStateUpdatesExistingMCPDoWRuntime(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Agents = map[string]config.AgentProfile{"_default": {}}
+	s := &Server{hasMCPListen: true}
+	s.refreshRuntimeState(nil, cfg, nil, nil)
+	if s.mcpDoW == nil {
+		t.Fatal("refreshRuntimeState did not initialize MCP DoW runtime")
+	}
+	first := s.mcpDoW
+
+	reloaded := cfg.Clone()
+	profile := reloaded.Agents["_default"]
+	profile.Budget.MaxToolCallsPerSession = 1
+	profile.Budget.DoWAction = config.ActionBlock
+	reloaded.Agents["_default"] = profile
+	s.refreshRuntimeState(cfg, reloaded, nil, nil)
+
+	if s.mcpDoW != first {
+		t.Fatal("refreshRuntimeState replaced MCP DoW runtime instead of updating it in place")
+	}
+	if !first.Enabled() {
+		t.Fatal("existing MCP DoW runtime was not updated from reloaded config")
+	}
+}
+
+func TestMCPDoWRuntimeReloadUpdatesAction(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Agents = map[string]config.AgentProfile{
+		"_default": {
+			Budget: config.BudgetConfig{
+				MaxToolCallsPerSession: 1,
+				DoWAction:              config.ActionBlock,
+			},
+		},
+	}
+	runtime := newMCPDoWRuntime(cfg, "_default")
+	wiring := runtime.Wiring()
+	if wiring == nil {
+		t.Fatal("DoW runtime did not produce wiring")
+	}
+
+	if allowed, _, reason, _ := wiring.Check("subject-a", "search", `{"q":"one"}`); !allowed || reason != "" {
+		t.Fatalf("first call blocked before budget was spent: allowed=%v reason=%q", allowed, reason)
+	}
+	allowed, action, _, budgetType := wiring.Check("subject-a", "search", `{"q":"two"}`)
+	if allowed || action != config.ActionBlock || budgetType != proxy.BudgetToolCalls {
+		t.Fatalf("startup block action = allowed:%v action:%q budget:%q, want block refusal",
+			allowed, action, budgetType)
+	}
+
+	reloaded := cfg.Clone()
+	profile := reloaded.Agents["_default"]
+	profile.Budget.DoWAction = config.ActionWarn
+	reloaded.Agents["_default"] = profile
+	runtime.UpdateConfig(reloaded)
+
+	allowed, action, _, budgetType = wiring.Check("subject-a", "search", `{"q":"three"}`)
+	if allowed || action != config.ActionWarn || budgetType != proxy.BudgetToolCalls {
+		t.Fatalf("reloaded warn action = allowed:%v action:%q budget:%q, want warn refusal",
+			allowed, action, budgetType)
+	}
+
+	profile.Budget.DoWAction = config.ActionBlock
+	reloaded.Agents["_default"] = profile
+	runtime.UpdateConfig(reloaded)
+
+	allowed, action, _, budgetType = wiring.Check("subject-a", "search", `{"q":"four"}`)
+	if allowed || action != config.ActionBlock || budgetType != proxy.BudgetToolCalls {
+		t.Fatalf("reloaded block action = allowed:%v action:%q budget:%q, want block refusal",
+			allowed, action, budgetType)
+	}
+}

--- a/internal/cli/runtime/server_builders_test.go
+++ b/internal/cli/runtime/server_builders_test.go
@@ -8,6 +8,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
 )
 
 func TestMCPTrustedSessionRegistryConcurrentAccess(t *testing.T) {
@@ -76,5 +79,42 @@ func TestMCPTrustedSessionRegistryRefusesNilAndEmptyKeys(t *testing.T) {
 func TestResolveMCPDoWBudgetNilConfig(t *testing.T) {
 	if got := resolveMCPDoWBudget(nil, "agent-a"); got != nil {
 		t.Fatalf("resolveMCPDoWBudget(nil) = %+v, want nil", got)
+	}
+}
+
+func TestMCPDoWRuntimeDisabledStartupEnabledByReloadEnforces(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Agents = make(map[string]config.AgentProfile)
+	cfg.Agents["_default"] = config.AgentProfile{}
+	runtime := newMCPDoWRuntime(cfg, "_default")
+	wiring := runtime.Wiring()
+	if wiring == nil {
+		t.Fatal("DoW runtime did not produce reusable wiring while disabled")
+	}
+	if wiring.Enabled() {
+		t.Fatal("DoW runtime enabled without configured DoW fields")
+	}
+	if allowed, _, reason, budgetType := wiring.Check("subject-a", "search", `{"q":"one"}`); !allowed || reason != "" || budgetType != "" {
+		t.Fatalf("disabled DoW check = allowed:%v reason:%q budget:%q, want clean skip", allowed, reason, budgetType)
+	}
+
+	reloaded := cfg.Clone()
+	profile := reloaded.Agents["_default"]
+	profile.Budget.MaxToolCallsPerSession = 1
+	profile.Budget.DoWAction = config.ActionBlock
+	reloaded.Agents["_default"] = profile
+	runtime.UpdateConfig(reloaded)
+
+	if !wiring.Enabled() {
+		t.Fatal("DoW runtime stayed disabled after reload enabled a DoW budget")
+	}
+	if allowed, action, reason, budgetType := wiring.Check("subject-a", "search", `{"q":"one"}`); !allowed || action != config.ActionBlock || reason != "" || budgetType != "" {
+		t.Fatalf("first enabled DoW check = allowed:%v action:%q reason:%q budget:%q, want allowed block-mode accounting",
+			allowed, action, reason, budgetType)
+	}
+	allowed, action, reason, budgetType := wiring.Check("subject-a", "search", `{"q":"two"}`)
+	if allowed || action != config.ActionBlock || budgetType != proxy.BudgetToolCalls || reason == "" {
+		t.Fatalf("second enabled DoW check = allowed:%v action:%q reason:%q budget:%q, want tool-call denial",
+			allowed, action, reason, budgetType)
 	}
 }

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -869,7 +869,7 @@ func (s *Server) Start(ctx context.Context) error {
 		// double-counted. p.SessionStore() reads from the atomic
 		// pointer, so it returns the live store even after hot-reloads.
 		mcpStore := s.proxy.SessionStore() // nil when session profiling is disabled
-		mcpDoWWiring := s.mcpDoW.Wiring()
+		mcpDoWWiring := s.currentMCPDoWRuntime().Wiring()
 
 		// Pass a function that reads the adaptive config from the live
 		// proxy config on each request. This ensures the long-lived

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -869,7 +869,7 @@ func (s *Server) Start(ctx context.Context) error {
 		// double-counted. p.SessionStore() reads from the atomic
 		// pointer, so it returns the live store even after hot-reloads.
 		mcpStore := s.proxy.SessionStore() // nil when session profiling is disabled
-		mcpDoWWiring := buildMCPDoWWiring(cfg, "_default")
+		mcpDoWWiring := s.mcpDoW.Wiring()
 
 		// Pass a function that reads the adaptive config from the live
 		// proxy config on each request. This ensures the long-lived

--- a/internal/cli/runtime/server_state.go
+++ b/internal/cli/runtime/server_state.go
@@ -78,6 +78,13 @@ func (s *Server) refreshRuntimeState(
 	s.receiptEmitter = s.liveReceiptEmitter()
 	s.envelopeEmitter = s.liveEnvelopeEmitter()
 	s.toolPolicyCfg = buildToolPolicyCfg(newCfg)
+	if s.hasMCPListen {
+		if s.mcpDoW == nil {
+			s.mcpDoW = newMCPDoWRuntime(newCfg, "_default")
+		} else {
+			s.mcpDoW.UpdateConfig(newCfg)
+		}
+	}
 	if bundleResult != nil {
 		s.mcpToolExtraPoison = rules.ConvertToolPoison(bundleResult.ToolPoison)
 	} else {

--- a/internal/cli/runtime/server_state.go
+++ b/internal/cli/runtime/server_state.go
@@ -41,6 +41,12 @@ func (s *Server) currentToolPolicyCfg() *policy.Config {
 	return s.toolPolicyCfg
 }
 
+func (s *Server) currentMCPDoWRuntime() *mcpDoWRuntime {
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
+	return s.mcpDoW
+}
+
 func (s *Server) currentMCPChainMatcher() *chains.Matcher {
 	s.stateMu.RLock()
 	defer s.stateMu.RUnlock()

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -1523,13 +1523,6 @@ func trustedDoWSubjectKey(r *http.Request, opts MCPProxyOpts) string {
 	return opts.dowSubjectKeyForRequest(r)
 }
 
-func (o MCPProxyOpts) dowEnabled() bool {
-	if o.DoWEnabledFn != nil {
-		return o.DoWEnabledFn()
-	}
-	return o.DoWCheck != nil || o.DoWRequireTrustedSession
-}
-
 func logUpstreamRequestError(logW io.Writer, ctx context.Context) {
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		_, _ = fmt.Fprintf(logW, "pipelock: upstream error: %v\n", ctxErr)

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -221,6 +221,7 @@ func RunHTTPListenerProxy(
 		RedactProfile:             baseRedactionCfg.Profile,
 		RedactionCfgFn:            opts.RedactionCfgFn,
 		DoWCheck:                  opts.DoWCheck,
+		DoWEnabledFn:              opts.DoWEnabledFn,
 		DoWSubjectAgent:           opts.DoWSubjectAgent,
 		DoWSubjectAgentAuth:       opts.DoWSubjectAgentAuth,
 		DoWAuthenticatedPrincipal: opts.DoWAuthenticatedPrincipal,
@@ -1505,7 +1506,7 @@ func validMCPSessionID(values []string) bool {
 }
 
 func trustedDoWSubjectKey(r *http.Request, opts MCPProxyOpts) string {
-	if !opts.DoWRequireTrustedSession {
+	if !opts.dowEnabled() || !opts.DoWRequireTrustedSession {
 		// Both production callers of RunHTTPListenerProxy set the trusted-session
 		// requirement, so this branch is not reached today. Returning an empty
 		// key here would collapse every client on a multi-client listener into
@@ -1520,6 +1521,13 @@ func trustedDoWSubjectKey(r *http.Request, opts MCPProxyOpts) string {
 		return ""
 	}
 	return opts.dowSubjectKeyForRequest(r)
+}
+
+func (o MCPProxyOpts) dowEnabled() bool {
+	if o.DoWEnabledFn != nil {
+		return o.DoWEnabledFn()
+	}
+	return o.DoWCheck != nil || o.DoWRequireTrustedSession
 }
 
 func logUpstreamRequestError(logW io.Writer, ctx context.Context) {

--- a/internal/mcp/mcp_http_reverse_dow_subject_test.go
+++ b/internal/mcp/mcp_http_reverse_dow_subject_test.go
@@ -58,6 +58,22 @@ func TestTrustedDoWSubjectKeyEmptyForUnknownSessionWhenGateOn(t *testing.T) {
 	}
 }
 
+func TestTrustedDoWSubjectKeyUsesClientKeyWhenLiveDoWDisabled(t *testing.T) {
+	opts := MCPProxyOpts{
+		DoWRequireTrustedSession: true,
+		DoWSubjectAgent:          "agent-a",
+		DoWEnabledFn:             func() bool { return false },
+		DoWSessionKnown:          func(string) bool { return false },
+	}
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", nil)
+	req.RemoteAddr = "203.0.113.10:5555"
+	req.Header.Set("Mcp-Session-Id", "not-registered")
+
+	if got := trustedDoWSubjectKey(req, opts); got == "" {
+		t.Fatal("disabled live DoW state still produced an empty subject key for the trusted-session gate")
+	}
+}
+
 // Gate-on coverage cannot be negative-only. An implementation that always
 // returned "" under DoWRequireTrustedSession would satisfy the unknown-session
 // test while turning every tool call from a known session into a fail-closed

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -178,6 +178,10 @@ type MCPProxyOpts struct {
 
 	// Denial-of-wallet tracking (nil-safe).
 	DoWCheck DoWCheckFunc
+	// DoWEnabledFn returns the live denial-of-wallet enabled state for
+	// long-lived listener surfaces. Nil preserves legacy static behavior:
+	// a configured DoWCheck means the gate is enabled.
+	DoWEnabledFn func() bool
 	// DoWSubjectKey is set per request by multi-client transports before
 	// invoking the shared input pipeline. Empty is valid only when
 	// DoWRequireTrustedSession is false.

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -592,3 +592,13 @@ func (o MCPProxyOpts) envelopeEmitter() *envelope.Emitter {
 	}
 	return o.EnvelopeEmitter
 }
+
+// dowEnabled reports the live denial-of-wallet enabled state. It is consulted by
+// both the HTTP listener and the stdio input pipeline, so it lives with the
+// option it reads rather than in either transport's file.
+func (o MCPProxyOpts) dowEnabled() bool {
+	if o.DoWEnabledFn != nil {
+		return o.DoWEnabledFn()
+	}
+	return o.DoWCheck != nil || o.DoWRequireTrustedSession
+}

--- a/internal/mcp/pipeline_gates.go
+++ b/internal/mcp/pipeline_gates.go
@@ -248,6 +248,9 @@ func applyDoWGate(opts MCPProxyOpts, eval *MCPInputEvaluation, enforcementIdenti
 	if opts.DoWCheck == nil || enforcementIdentity == "" {
 		return false
 	}
+	if !opts.dowEnabled() {
+		return false
+	}
 	subjectKey := opts.DoWSubjectKey
 	if subjectKey == "" {
 		subjectKey = opts.DoWSessionKey

--- a/internal/mcp/pipeline_gates_stdio_test.go
+++ b/internal/mcp/pipeline_gates_stdio_test.go
@@ -345,6 +345,42 @@ func TestEvaluateMCPInputGatesStdio_DoWWarnDoesNotShortCircuit(t *testing.T) {
 	}
 }
 
+func TestEvaluateMCPInputGatesStdio_DoWDisabledSkipsTrustedSessionGate(t *testing.T) {
+	t.Parallel()
+
+	sc := testInputScanner(t)
+	opts := testOpts(sc)
+	opts.DoWRequireTrustedSession = true
+	opts.DoWEnabledFn = func() bool {
+		return false
+	}
+	opts.DoWCheck = func(_, _, _ string) (bool, string, string, string) {
+		t.Fatal("DoWCheck called while live DoW state is disabled")
+		return false, config.ActionBlock, "should not run", "test_budget"
+	}
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/tmp/x"}}}`)
+	frame := ParseMCPFrame(msg)
+
+	eval := EvaluateMCPInputGatesStdio(
+		context.Background(),
+		frame,
+		msg,
+		msg,
+		nil,
+		opts,
+		config.ActionWarn,
+		config.ActionBlock,
+	)
+
+	if eval.BlockingGate == blockingGateDoW {
+		t.Fatalf("disabled DoW still blocked on trusted-session gate: %+v", eval)
+	}
+	if eval.DoWReason != "" || eval.DoWBudgetType != "" {
+		t.Fatalf("disabled DoW populated evaluation fields: reason=%q budget=%q", eval.DoWReason, eval.DoWBudgetType)
+	}
+}
+
 func TestEvaluateMCPInputGatesStdio_ParseErrorShortCircuit(t *testing.T) {
 	// Force ContentVerdict.Error via invalid JSON. The frame will
 	// have ParseErr set and ScanRequest returns a parse-error verdict.

--- a/internal/proxy/dow.go
+++ b/internal/proxy/dow.go
@@ -86,6 +86,7 @@ type DoWTracker struct {
 type dowSubjectEntry struct {
 	tracker     *DoWTracker
 	windowStart time.Time
+	expiresAt   time.Time
 }
 
 // DoWSubjectManager owns per-subject DoW trackers for multi-client listeners.
@@ -95,10 +96,11 @@ type DoWSubjectManager struct {
 	mu          sync.Mutex
 	cfg         DoWConfig
 	window      time.Duration
+	idleTTL     time.Duration
 	maxSubjects int
 	now         func() time.Time
 	subjects    map[string]*dowSubjectEntry
-	// nextExpiry is the earliest windowStart+window across subjects. Before it
+	// nextExpiry is the earliest stamped expiry across subjects. Before it
 	// passes, no subject can be expired, so the reap scan can be skipped.
 	nextExpiry time.Time
 }
@@ -121,13 +123,7 @@ func newDoWTracker(cfg DoWConfig, now func() time.Time) *DoWTracker {
 
 // NewDoWSubjectManager creates a bounded per-subject DoW manager.
 func NewDoWSubjectManager(cfg DoWSubjectManagerConfig) *DoWSubjectManager {
-	window := time.Duration(cfg.TrackerConfig.WindowMinutes) * time.Minute
-	if window <= 0 {
-		window = cfg.IdleTTL
-	}
-	if window <= 0 {
-		window = defaultDoWSubjectWindow
-	}
+	window := normalizeDoWSubjectWindow(cfg.TrackerConfig, cfg.IdleTTL)
 	maxSubjects := cfg.MaxSubjects
 	if maxSubjects <= 0 {
 		maxSubjects = defaultDoWSubjectMaxSubjects
@@ -139,9 +135,36 @@ func NewDoWSubjectManager(cfg DoWSubjectManagerConfig) *DoWSubjectManager {
 	return &DoWSubjectManager{
 		cfg:         cfg.TrackerConfig,
 		window:      window,
+		idleTTL:     cfg.IdleTTL,
 		maxSubjects: maxSubjects,
 		now:         now,
 		subjects:    make(map[string]*dowSubjectEntry),
+	}
+}
+
+func normalizeDoWSubjectWindow(cfg DoWConfig, idleTTL time.Duration) time.Duration {
+	window := time.Duration(cfg.WindowMinutes) * time.Minute
+	if window <= 0 {
+		window = idleTTL
+	}
+	if window <= 0 {
+		window = defaultDoWSubjectWindow
+	}
+	return window
+}
+
+// UpdateConfig swaps the manager and tracker limits in place so hot reloads
+// take effect without resetting live subject spend counters.
+func (m *DoWSubjectManager) UpdateConfig(cfg DoWConfig) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cfg = cfg
+	m.window = normalizeDoWSubjectWindow(cfg, m.idleTTL)
+	for _, entry := range m.subjects {
+		entry.tracker.UpdateConfig(cfg)
 	}
 }
 
@@ -188,8 +211,9 @@ func (m *DoWSubjectManager) trackerFor(subjectKey string) (*DoWTracker, bool) {
 		return nil, false
 	}
 	tracker := newDoWTracker(m.cfg, m.now)
-	m.subjects[subjectKey] = &dowSubjectEntry{tracker: tracker, windowStart: now}
-	if expiry := now.Add(m.window); m.nextExpiry.IsZero() || expiry.Before(m.nextExpiry) {
+	expiry := now.Add(m.window)
+	m.subjects[subjectKey] = &dowSubjectEntry{tracker: tracker, windowStart: now, expiresAt: expiry}
+	if m.nextExpiry.IsZero() || expiry.Before(m.nextExpiry) {
 		m.nextExpiry = expiry
 	}
 	return tracker, true
@@ -206,16 +230,26 @@ func (m *DoWSubjectManager) reapExpiredLocked(now time.Time) {
 	}
 	var earliest time.Time
 	for key, entry := range m.subjects {
-		expiry := entry.windowStart.Add(m.window)
-		if !now.Before(expiry) {
+		if !now.Before(entry.expiresAt) {
 			delete(m.subjects, key)
 			continue
 		}
-		if earliest.IsZero() || expiry.Before(earliest) {
-			earliest = expiry
+		if earliest.IsZero() || entry.expiresAt.Before(earliest) {
+			earliest = entry.expiresAt
 		}
 	}
 	m.nextExpiry = earliest
+}
+
+// UpdateConfig swaps limit fields while preserving spend, start time, history,
+// and in-flight call state.
+func (t *DoWTracker) UpdateConfig(cfg DoWConfig) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.cfg = cfg
 }
 
 // RecordToolCall records a tool invocation and checks for loop, runaway,
@@ -315,13 +349,12 @@ func (t *DoWTracker) historyWindow() int {
 // flag and incrementing inflight, which would admit a new acquisition
 // after shutdown.
 func (t *DoWTracker) AcquireConcurrent() DoWResult {
+	t.mu.Lock()
 	cfgLimit := t.cfg.MaxConcurrentToolCalls
 	if cfgLimit <= 0 {
 		cfgLimit = 10 // default limit
 	}
 	limit := int32(min(cfgLimit, 1<<30)) // cap to prevent int32 overflow
-
-	t.mu.Lock()
 	if t.closed {
 		t.mu.Unlock()
 		return DoWResult{Allowed: false, Reason: "tracker closed", BudgetType: BudgetConcurrent}

--- a/internal/proxy/dow_test.go
+++ b/internal/proxy/dow_test.go
@@ -722,6 +722,217 @@ func TestDoWSubjectManager_WindowExpiryPreventsPermanentWedge(t *testing.T) {
 	}
 }
 
+func TestDoWSubjectManager_UpdateConfigTightenedLimitAppliesToExistingSubject(t *testing.T) {
+	manager := NewDoWSubjectManager(DoWSubjectManagerConfig{
+		TrackerConfig: DoWConfig{
+			MaxToolCallsPerSession: 3,
+			Action:                 actionBlock,
+		},
+	})
+
+	for i := range 2 {
+		if result := manager.Check("subject-a", toolGetWeather, fmt.Sprintf(`{"turn":%d}`, i)); !result.Allowed {
+			t.Fatalf("pre-reload call %d blocked: %s", i+1, result.Reason)
+		}
+	}
+
+	manager.UpdateConfig(DoWConfig{
+		MaxToolCallsPerSession: 1,
+		Action:                 actionBlock,
+	})
+
+	result := manager.Check("subject-a", toolGetWeather, `{"turn":3}`)
+	if result.Allowed || result.BudgetType != BudgetToolCalls {
+		t.Fatalf("tightened existing subject check = allowed:%v budget:%q reason:%q, want tool-call refusal",
+			result.Allowed, result.BudgetType, result.Reason)
+	}
+}
+
+func TestDoWSubjectManagerUpdateConfigNilReceivers(t *testing.T) {
+	var manager *DoWSubjectManager
+	manager.UpdateConfig(DoWConfig{MaxToolCallsPerSession: 1})
+
+	var tracker *DoWTracker
+	tracker.UpdateConfig(DoWConfig{MaxToolCallsPerSession: 1})
+}
+
+func TestDoWSubjectManager_UpdateConfigLoosenedLimitPreservesSpendAndAddsHeadroom(t *testing.T) {
+	manager := NewDoWSubjectManager(DoWSubjectManagerConfig{
+		TrackerConfig: DoWConfig{
+			MaxToolCallsPerSession: 2,
+			Action:                 actionBlock,
+		},
+	})
+
+	for i := range 2 {
+		if result := manager.Check("subject-a", toolGetWeather, fmt.Sprintf(`{"turn":%d}`, i)); !result.Allowed {
+			t.Fatalf("pre-reload call %d blocked: %s", i+1, result.Reason)
+		}
+	}
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":3}`); result.Allowed {
+		t.Fatal("third call should spend past the original limit before reload")
+	}
+
+	manager.UpdateConfig(DoWConfig{
+		MaxToolCallsPerSession: 4,
+		Action:                 actionBlock,
+	})
+
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":4}`); !result.Allowed {
+		t.Fatalf("loosened limit did not grant immediate headroom: %s", result.Reason)
+	}
+	tracker, ok := manager.trackerFor("subject-a")
+	if !ok {
+		t.Fatal("existing subject disappeared after loosening limit")
+	}
+	if got := tracker.TotalToolCalls(); got != 4 {
+		t.Fatalf("TotalToolCalls after loosened reload = %d, want 4 preserved calls", got)
+	}
+}
+
+func TestDoWSubjectManager_ReapStoresNextStampedExpiry(t *testing.T) {
+	now := time.Date(2026, 7, 28, 11, 0, 0, 0, time.UTC)
+	manager := NewDoWSubjectManager(DoWSubjectManagerConfig{
+		TrackerConfig: DoWConfig{
+			MaxToolCallsPerSession: 10,
+			Action:                 actionBlock,
+		},
+		IdleTTL: time.Minute,
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":1}`); !result.Allowed {
+		t.Fatalf("subject-a blocked: %s", result.Reason)
+	}
+	now = now.Add(30 * time.Second)
+	if result := manager.Check("subject-b", toolGetWeather, `{"turn":1}`); !result.Allowed {
+		t.Fatalf("subject-b blocked: %s", result.Reason)
+	}
+
+	now = now.Add(31 * time.Second)
+	if got := manager.SubjectCount(); got != 1 {
+		t.Fatalf("SubjectCount after first expiry = %d, want 1", got)
+	}
+	wantNext := time.Date(2026, 7, 28, 11, 1, 30, 0, time.UTC)
+	if !manager.nextExpiry.Equal(wantNext) {
+		t.Fatalf("nextExpiry = %s, want remaining subject expiry %s", manager.nextExpiry, wantNext)
+	}
+}
+
+func TestDoWSubjectManager_UpdateConfigShrinksWindowOnlyForNewEntries(t *testing.T) {
+	now := time.Date(2026, 7, 28, 9, 0, 0, 0, time.UTC)
+	manager := NewDoWSubjectManager(DoWSubjectManagerConfig{
+		TrackerConfig: DoWConfig{
+			MaxToolCallsPerSession: 1,
+			WindowMinutes:          10,
+			Action:                 actionBlock,
+		},
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":1}`); !result.Allowed {
+		t.Fatalf("first call blocked: %s", result.Reason)
+	}
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":2}`); result.Allowed {
+		t.Fatal("second call should spend past the original limit")
+	}
+
+	manager.UpdateConfig(DoWConfig{
+		MaxToolCallsPerSession: 1,
+		WindowMinutes:          1,
+		Action:                 actionBlock,
+	})
+
+	now = now.Add(2 * time.Minute)
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":3}`); result.Allowed {
+		t.Fatal("shrinking the window reset the live subject before its original expiry")
+	}
+
+	now = time.Date(2026, 7, 28, 9, 10, 1, 0, time.UTC)
+	if got := manager.SubjectCount(); got != 0 {
+		t.Fatalf("SubjectCount after original expiry = %d, want 0", got)
+	}
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":4}`); !result.Allowed {
+		t.Fatalf("new window call blocked: %s", result.Reason)
+	}
+	now = now.Add(90 * time.Second)
+	if got := manager.SubjectCount(); got != 0 {
+		t.Fatalf("SubjectCount after new shortened window = %d, want 0", got)
+	}
+}
+
+func TestDoWSubjectManager_RepeatedUpdateConfigDoesNotResetSpend(t *testing.T) {
+	manager := NewDoWSubjectManager(DoWSubjectManagerConfig{
+		TrackerConfig: DoWConfig{
+			MaxToolCallsPerSession: 2,
+			Action:                 actionBlock,
+		},
+	})
+
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":1}`); !result.Allowed {
+		t.Fatalf("first call blocked: %s", result.Reason)
+	}
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":2}`); !result.Allowed {
+		t.Fatalf("second call blocked: %s", result.Reason)
+	}
+	for range 3 {
+		manager.UpdateConfig(DoWConfig{
+			MaxToolCallsPerSession: 2,
+			Action:                 actionBlock,
+		})
+	}
+
+	result := manager.Check("subject-a", toolGetWeather, `{"turn":3}`)
+	if result.Allowed || result.BudgetType != BudgetToolCalls {
+		t.Fatalf("repeated reload reset subject spend: allowed:%v budget:%q reason:%q",
+			result.Allowed, result.BudgetType, result.Reason)
+	}
+}
+
+func TestDoWSubjectManager_SubjectCapFailsClosedAcrossReload(t *testing.T) {
+	now := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
+	manager := NewDoWSubjectManager(DoWSubjectManagerConfig{
+		TrackerConfig: DoWConfig{
+			MaxToolCallsPerSession: 10,
+			Action:                 actionBlock,
+		},
+		IdleTTL:     time.Minute,
+		MaxSubjects: 2,
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":1}`); !result.Allowed {
+		t.Fatalf("subject-a blocked: %s", result.Reason)
+	}
+	if result := manager.Check("subject-b", toolGetWeather, `{"turn":1}`); !result.Allowed {
+		t.Fatalf("subject-b blocked: %s", result.Reason)
+	}
+
+	manager.UpdateConfig(DoWConfig{
+		MaxToolCallsPerSession: 20,
+		Action:                 actionBlock,
+	})
+
+	if result := manager.Check("subject-c", toolGetWeather, `{"turn":1}`); result.Allowed || result.BudgetType != BudgetSubjectCap {
+		t.Fatalf("new subject at cap after reload = allowed:%v budget:%q reason:%q, want subject-cap refusal",
+			result.Allowed, result.BudgetType, result.Reason)
+	}
+	if result := manager.Check("subject-a", toolGetWeather, `{"turn":2}`); !result.Allowed {
+		t.Fatalf("existing subject should keep its live slot after reload: %s", result.Reason)
+	}
+
+	now = now.Add(time.Minute + time.Second)
+	if result := manager.Check("subject-c", toolGetWeather, `{"turn":2}`); !result.Allowed {
+		t.Fatalf("new subject should be admitted after original entries expire: %s", result.Reason)
+	}
+}
+
 func TestDoWSubjectManager_SubjectCapFailsClosedForNewSubjects(t *testing.T) {
 	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
 	manager := NewDoWSubjectManager(DoWSubjectManagerConfig{


### PR DESCRIPTION
## What changed

MCP denial-of-wallet enforcement did not follow hot reload. The wiring was built once from the startup config, so every denial-of-wallet limit stayed frozen for the process lifetime while the live config reported the new values. Both neighbouring MCP controls in the same function already read live config per request, and the comment above one of them states the intent explicitly, so this was the single control that had been left behind rather than a deliberate exception.

Two distinct defects sit behind that, shipped here as two commits.

The first is a fail-open. When denial-of-wallet was disabled at startup the check function was nil and stayed nil, so enabling it by hot reload engaged nothing while configuration reported it active. The mirror case cost availability instead: with the control disabled but a trusted session still required, requests could be refused on behalf of a gate that was not running. The listener is now wired unconditionally through a long-lived runtime handle that answers enablement live, and the trusted-session requirement skips cleanly when the control is off.

The second is that limit changes never reached enforcement. Each tracker holds its own captured configuration, so swapping configuration at the manager alone updates nothing for any subject already being tracked. Rebuilding the manager is not an acceptable alternative because it owns the per-subject spend map, and discarding that map resets every budget, which is the reset bypass this code has been corrected for twice already. Configuration is now pushed into existing trackers in place, preserving spend counters, start time, call history, and in-flight state.

Two semantics decisions are worth calling out because both are security relevant.

A reload that shrinks the budget window does not shorten a window already in flight. Expiry is stamped per entry when the entry is created rather than recomputed from the manager's current window, so a live window runs to its original end and only entries created after the reload use the shorter one. Recomputing live expiry would let repeated reloads expire windows early, and expiry resets the budget, which would hand an attacker a budget reset primitive. The accepted cost is that a shortened window takes up to one old window length to fully take effect.

A reload that tightens a limit below what a subject has already spent refuses that subject on its next check until its window rolls. This fails closed, and it means an operator tightening policy during an incident takes effect immediately rather than after a delay.

Behaviour is unchanged for the standalone `pipelock mcp proxy` runtime mode. That mode loads configuration once and has no reloader, so its wiring is untouched and the new live enablement hook falls back to the previous static behaviour when it is absent.

## Upgrade notes

No configuration changes are required. Deployments that previously edited a denial-of-wallet limit and observed no effect without a restart will now see that edit take effect on reload, which is the intended behaviour but is a change in observable outcome. Deployments that relied on toggling the control off and on again to clear accumulated budgets will no longer see budgets cleared by that sequence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live, long-lived MCP denial-of-wallet enablement control (including dynamic action changes) without restarting.
  * Updated DoW tracking to support hot configuration updates while preserving accumulated spend.

* **Bug Fixes**
  * When DoW is disabled, trusted-session gating and DoW evaluation are skipped.
  * Trusted-session subject key derivation now correctly respects whether DoW is enabled.

* **Tests**
  * Expanded coverage for DoW enable/disable on reload, safe nil handling, action changes, and expiry/limit update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->