### PR TITLE
fix(verifiers): reject untrusted audit packet evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Audit Packet verification now requires external trust.** The Go, Rust, and
+  TypeScript verifiers reject empty receipt chains and no longer accept a
+  packet's embedded signer key as its own trust anchor. Supply `--key` or an
+  out-of-band `--expect-sha256` pin; explicitly weaker structural modes remain
+  available where documented.
+
+### ⚠️ Breaking Changes / Upgrade Notes
+
+- **Trusted Audit Packet verification requires `--key` or
+  `--expect-sha256`.** Existing automation that invokes `audit-packet` without
+  an external trust anchor now fails closed. Add the trusted signer public key
+  or a separately obtained SHA-256 digest of `packet.json`.
+
 ## [3.2.0] - 2026-07-17
 
 ### Added

--- a/cmd/pipelock-verifier/auditpacket.go
+++ b/cmd/pipelock-verifier/auditpacket.go
@@ -181,7 +181,14 @@ func runAuditPacket(stdout, stderr io.Writer, target string, opts auditPacketOpt
 		return nil
 	}
 
-	chainResult, chainReceipts, chainErr := reverifyChain(baseDir, &packet, opts.signerKey)
+	signerKey, keyErr := auditPacketSignerKey(&packet, opts)
+	if keyErr != nil {
+		report.ChainCheck = statusFail
+		report.Errors = append(report.Errors, fmt.Sprintf("chain: %v", keyErr))
+		emitReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, keyErr)
+	}
+	chainResult, chainReceipts, chainErr := reverifyChain(baseDir, &packet, signerKey)
 	if chainErr != nil {
 		report.ChainCheck = statusFail
 		report.Errors = append(report.Errors, fmt.Sprintf("chain: %v", chainErr))
@@ -312,15 +319,31 @@ func reverifyChain(baseDir string, packet *auditpacket.Packet, signerOverride st
 	if err != nil {
 		return receipt.ChainResult{}, nil, fmt.Errorf("extract receipts: %w", err)
 	}
-	keyHex := strings.TrimSpace(signerOverride)
-	if keyHex == "" {
-		keyHex = strings.TrimSpace(packet.Verifier.SignerKey)
+	if len(receipts) == 0 {
+		return receipt.ChainResult{}, nil, errors.New("empty chain")
 	}
+	keyHex := strings.TrimSpace(signerOverride)
 	resolvedKey, err := resolveSignerKey(keyHex)
 	if err != nil {
 		return receipt.ChainResult{}, nil, fmt.Errorf("resolve signer key: %w", err)
 	}
 	return receipt.VerifyChain(receipts, resolvedKey), receipts, nil
+}
+
+// auditPacketSignerKey selects only trust material the relying party explicitly
+// anchored. A packet's own signer_key is not external trust unless the packet
+// bytes were hash-pinned or the caller deliberately requested a weaker mode.
+func auditPacketSignerKey(packet *auditpacket.Packet, opts auditPacketOptions) (string, error) {
+	if key := strings.TrimSpace(opts.signerKey); key != "" {
+		return key, nil
+	}
+	if strings.TrimSpace(opts.expectedSHA) != "" || opts.relaxTrust {
+		return strings.TrimSpace(packet.Verifier.SignerKey), nil
+	}
+	if packet.Verifier.Verdict == auditpacket.VerdictSelfConsistentOnly && opts.allowSCO {
+		return strings.TrimSpace(packet.Verifier.SignerKey), nil
+	}
+	return "", errors.New("trusted Audit Packet verification requires --key or --expect-sha256")
 }
 
 // crossCheck enforces that the packet's claimed totals, receipt_count, and
@@ -355,7 +378,8 @@ func crossCheck(packet *auditpacket.Packet, chain receipt.ChainResult, receipts 
 	if packet.Verifier.RootHash != "" && packet.Verifier.RootHash != chain.RootHash {
 		errs = append(errs, fmt.Errorf("root_hash mismatch: chain=%s packet=%s", chain.RootHash, packet.Verifier.RootHash))
 	}
-	if packet.Verifier.FinalSeq != 0 && (packet.Verifier.FinalSeq < 0 || uint64(packet.Verifier.FinalSeq) != chain.FinalSeq) {
+	if (packet.Verifier.FinalSeqPresent || packet.Verifier.FinalSeq != 0) &&
+		(packet.Verifier.FinalSeq < 0 || uint64(packet.Verifier.FinalSeq) != chain.FinalSeq) {
 		errs = append(errs, fmt.Errorf("final_seq mismatch: chain=%d packet=%d", chain.FinalSeq, packet.Verifier.FinalSeq))
 	}
 

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -324,18 +324,40 @@ func runRoot(t *testing.T, args ...string) (string, string, int) {
 	return stdout.String(), stderr.String(), exitCodeFor(err)
 }
 
+func runAuditPacketWithKey(t *testing.T, key string, args ...string) (string, string, int) {
+	t.Helper()
+	fullArgs := []string{"audit-packet", "--key", key}
+	fullArgs = append(fullArgs, args...)
+	return runRoot(t, fullArgs...)
+}
+
 func TestAuditPacket_HappyPath(t *testing.T) {
 	t.Parallel()
 	fix := newFixture(t, 3)
 	dir := t.TempDir()
 	fix.writePacketDir(t, dir, nil)
 
-	stdout, stderr, code := runRoot(t, "audit-packet", dir)
+	stdout, stderr, code := runAuditPacketWithKey(t, fix.keyHex, dir)
 	if code != cliutil.ExitOK {
 		t.Fatalf("exit code = %d, stdout=%q stderr=%q", code, stdout, stderr)
 	}
 	if !strings.Contains(stdout, "VALID") {
 		t.Errorf("stdout missing VALID: %s", stdout)
+	}
+}
+
+func TestAuditPacket_ValidVerdictRequiresExternalTrustAnchor(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+
+	_, stderr, code := runRoot(t, "audit-packet", dir)
+	if code == cliutil.ExitOK {
+		t.Fatal("packet-supplied signer key must not establish external trust")
+	}
+	if !strings.Contains(stderr, "requires --key or --expect-sha256") {
+		t.Fatalf("unexpected error: %q", stderr)
 	}
 }
 
@@ -367,7 +389,7 @@ func TestAuditPacket_SchemaViolation(t *testing.T) {
 		p.SchemaVersion = "pipelock.audit_packet.v999" // forbidden
 	})
 
-	stdout, stderr, code := runRoot(t, "audit-packet", dir)
+	stdout, stderr, code := runAuditPacketWithKey(t, fix.keyHex, dir)
 	if code == cliutil.ExitOK {
 		t.Fatalf("expected non-zero exit on schema violation, stdout=%q stderr=%q", stdout, stderr)
 	}
@@ -386,7 +408,7 @@ func TestAuditPacket_TotalsMismatch(t *testing.T) {
 		p.Summary.Totals.Block = 1
 	})
 
-	stdout, stderr, code := runRoot(t, "audit-packet", dir)
+	stdout, stderr, code := runAuditPacketWithKey(t, fix.keyHex, dir)
 	if code == cliutil.ExitOK {
 		t.Fatalf("expected mismatch failure, stdout=%q stderr=%q", stdout, stderr)
 	}
@@ -406,7 +428,7 @@ func TestAuditPacket_ReceiptCountMismatch(t *testing.T) {
 		p.Summary.Totals.Allow = 2
 	})
 
-	_, stderr, code := runRoot(t, "audit-packet", dir)
+	_, stderr, code := runAuditPacketWithKey(t, fix.keyHex, dir)
 	if code == cliutil.ExitOK {
 		t.Fatalf("expected receipt_count mismatch failure, stderr=%q", stderr)
 	}
@@ -426,7 +448,7 @@ func TestAuditPacket_VerdictTamperedToInvalid(t *testing.T) {
 		p.Verifier.Trusted = false
 	})
 
-	_, stderr, code := runRoot(t, "audit-packet", dir)
+	_, stderr, code := runAuditPacketWithKey(t, fix.keyHex, dir)
 	if code == cliutil.ExitOK {
 		t.Fatalf("expected verdict-vs-chain mismatch failure, stderr=%q", stderr)
 	}
@@ -522,6 +544,20 @@ func TestAuditPacket_ExpectedSHAMatch(t *testing.T) {
 	}
 }
 
+func TestAuditPacket_RejectsEmptyChain(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 0)
+	pkt := fix.writePacketDir(t, t.TempDir(), nil)
+
+	_, stderr, code := runRoot(t, "audit-packet", "--key", fix.keyHex, pkt)
+	if code == cliutil.ExitOK {
+		t.Fatalf("empty audit-packet chain should fail, stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "empty chain") {
+		t.Fatalf("expected empty-chain error, got %q", stderr)
+	}
+}
+
 func TestAuditPacket_PathContainmentRejected(t *testing.T) {
 	t.Parallel()
 	fix := newFixture(t, 1)
@@ -534,7 +570,7 @@ func TestAuditPacket_PathContainmentRejected(t *testing.T) {
 		p.Artifacts.Evidence = "../../../etc/passwd"
 	})
 
-	_, stderr, code := runRoot(t, "audit-packet", dir)
+	_, stderr, code := runAuditPacketWithKey(t, fix.keyHex, dir)
 	if code == cliutil.ExitOK {
 		t.Fatalf("expected containment rejection, stderr=%q", stderr)
 	}
@@ -546,7 +582,7 @@ func TestAuditPacket_JSONOutput(t *testing.T) {
 	dir := t.TempDir()
 	fix.writePacketDir(t, dir, nil)
 
-	stdout, _, code := runRoot(t, "audit-packet", "--json", dir)
+	stdout, _, code := runAuditPacketWithKey(t, fix.keyHex, "--json", dir)
 	if code != cliutil.ExitOK {
 		t.Fatalf("happy path failed under --json: code=%d", code)
 	}
@@ -568,7 +604,7 @@ func TestAuditPacket_PacketAsFileArg(t *testing.T) {
 	dir := t.TempDir()
 	pkt := fix.writePacketDir(t, dir, nil)
 
-	_, stderr, code := runRoot(t, "audit-packet", pkt)
+	_, stderr, code := runAuditPacketWithKey(t, fix.keyHex, pkt)
 	if code != cliutil.ExitOK {
 		t.Fatalf("file-arg form should pass, stderr=%q", stderr)
 	}
@@ -1691,7 +1727,7 @@ func TestAuditPacket_VerdictTamperedToValidWithBrokenChain(t *testing.T) {
 		t.Fatalf("write tampered evidence: %v", err)
 	}
 
-	_, stderr, code := runRoot(t, "audit-packet", dir)
+	_, stderr, code := runAuditPacketWithKey(t, fix.keyHex, dir)
 	if code == cliutil.ExitOK {
 		t.Fatalf("broken chain with valid claim should fail, stderr=%q", stderr)
 	}
@@ -1893,7 +1929,7 @@ func TestAuditPacket_BadEvidence(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "evidence.jsonl"), []byte("not a recorder line\n"), 0o600); err != nil {
 		t.Fatalf("write bad evidence: %v", err)
 	}
-	_, _, code := runRoot(t, "audit-packet", dir)
+	_, _, code := runAuditPacketWithKey(t, fix.keyHex, dir)
 	if code == cliutil.ExitOK {
 		t.Fatalf("bad evidence should fail")
 	}
@@ -1927,7 +1963,7 @@ func TestAuditPacket_FinalSeqAndRootHashCrossCheck(t *testing.T) {
 		// when set it must match the chain.
 		p.Verifier.FinalSeq = 99
 	})
-	_, stderr, code := runRoot(t, "audit-packet", dir)
+	_, stderr, code := runAuditPacketWithKey(t, fix.keyHex, dir)
 	if code == cliutil.ExitOK {
 		t.Fatalf("final_seq mismatch should fail")
 	}
@@ -1939,12 +1975,40 @@ func TestAuditPacket_FinalSeqAndRootHashCrossCheck(t *testing.T) {
 	fix.writePacketDir(t, dir2, func(p *auditpacket.Packet) {
 		p.Verifier.RootHash = strings.Repeat("a", 64)
 	})
-	_, stderr, code = runRoot(t, "audit-packet", dir2)
+	_, stderr, code = runAuditPacketWithKey(t, fix.keyHex, dir2)
 	if code == cliutil.ExitOK {
 		t.Fatalf("root_hash mismatch should fail")
 	}
 	if !strings.Contains(stderr, "root_hash mismatch") {
 		t.Errorf("expected root_hash mismatch error, got %q", stderr)
+	}
+}
+
+func TestAuditPacket_PresentFinalSeqZeroIsCrossChecked(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 3)
+	dir := t.TempDir()
+	pktPath := fix.writePacketDir(t, dir, nil)
+	raw, err := os.ReadFile(filepath.Clean(pktPath))
+	if err != nil {
+		t.Fatalf("read packet: %v", err)
+	}
+	needle := []byte(`"signer_key":`)
+	replacement := []byte(`"final_seq": 0, "signer_key":`)
+	raw = bytes.Replace(raw, needle, replacement, 1)
+	if !bytes.Contains(raw, replacement) {
+		t.Fatal("fixture did not gain an explicit final_seq=0")
+	}
+	if err := os.WriteFile(pktPath, raw, 0o600); err != nil {
+		t.Fatalf("rewrite packet: %v", err)
+	}
+
+	_, stderr, code := runAuditPacketWithKey(t, fix.keyHex, dir)
+	if code == cliutil.ExitOK {
+		t.Fatal("present final_seq=0 must be compared with the nonempty chain")
+	}
+	if !strings.Contains(stderr, "final_seq mismatch") {
+		t.Fatalf("expected final_seq mismatch, got %q", stderr)
 	}
 }
 
@@ -1993,7 +2057,7 @@ func TestAuditPacket_ReportContainsRunMetadata(t *testing.T) {
 		p.Run.SHA = "deadbeefcafebabe"
 	})
 
-	stdout, _, code := runRoot(t, "audit-packet", "--json", dir)
+	stdout, _, code := runAuditPacketWithKey(t, fix.keyHex, "--json", dir)
 	if code != cliutil.ExitOK {
 		t.Fatalf("happy path failed: stdout=%q", stdout)
 	}

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -493,8 +493,8 @@ pipelock-verifier chain evidence-proxy-0.jsonl \
   --expect-payload-kind shadow_delta \
   --expect-contract sha256:...
 
-# Verify an Audit Packet directory or packet.json file
-pipelock-verifier audit-packet ./audit-packet
+# Verify an Audit Packet with a signer key obtained outside the packet
+pipelock-verifier audit-packet ./audit-packet --key ./trusted-signing-key.pub
 ```
 
 For EvidenceReceipt v2, `--key` pins the trusted Ed25519 receipt-signing public

--- a/internal/replaycapture/units_test.go
+++ b/internal/replaycapture/units_test.go
@@ -259,6 +259,10 @@ func TestVerifyPacketBytes_BrowserBundlePath(t *testing.T) {
 	if err := VerifyPacketBytes(packetJSON, evidenceJSONL, eng.PublicKeyHex()); err != nil {
 		t.Fatalf("VerifyPacketBytes valid bundle: %v", err)
 	}
+	if err := VerifyPacketBytes(packetJSON, evidenceJSONL, ""); err == nil ||
+		!strings.Contains(err.Error(), "external signer key is required") {
+		t.Fatalf("missing external signer key error = %v", err)
+	}
 	if err := VerifyPacketBytes([]byte("{"), evidenceJSONL, eng.PublicKeyHex()); err == nil ||
 		!strings.Contains(err.Error(), "parsing packet.json") {
 		t.Fatalf("malformed packet error = %v", err)

--- a/internal/replaycapture/units_test.go
+++ b/internal/replaycapture/units_test.go
@@ -259,9 +259,16 @@ func TestVerifyPacketBytes_BrowserBundlePath(t *testing.T) {
 	if err := VerifyPacketBytes(packetJSON, evidenceJSONL, eng.PublicKeyHex()); err != nil {
 		t.Fatalf("VerifyPacketBytes valid bundle: %v", err)
 	}
+	if err := VerifyPacketBytes(packetJSON, evidenceJSONL, "  "+eng.PublicKeyHex()+"\n"); err != nil {
+		t.Fatalf("VerifyPacketBytes key with surrounding whitespace: %v", err)
+	}
 	if err := VerifyPacketBytes(packetJSON, evidenceJSONL, ""); err == nil ||
 		!strings.Contains(err.Error(), "external signer key is required") {
 		t.Fatalf("missing external signer key error = %v", err)
+	}
+	if err := VerifyPacketBytes(packetJSON, nil, eng.PublicKeyHex()); err == nil ||
+		!strings.Contains(err.Error(), "empty chain") {
+		t.Fatalf("empty evidence error = %v", err)
 	}
 	if err := VerifyPacketBytes([]byte("{"), evidenceJSONL, eng.PublicKeyHex()); err == nil ||
 		!strings.Contains(err.Error(), "parsing packet.json") {

--- a/internal/replaycapture/verify.go
+++ b/internal/replaycapture/verify.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
@@ -102,6 +103,9 @@ func validateInMemoryPacketArtifacts(pkt auditpacket.Packet) error {
 }
 
 func verifyPacket(pkt auditpacket.Packet, evidenceJSONL []byte, keyHex string) error {
+	if strings.TrimSpace(keyHex) == "" {
+		return fmt.Errorf("external signer key is required")
+	}
 	if err := jsonscan.RejectUnsafeNumbers(evidenceJSONL); err != nil {
 		return fmt.Errorf("extracting evidence: %w", err)
 	}
@@ -109,11 +113,10 @@ func verifyPacket(pkt auditpacket.Packet, evidenceJSONL []byte, keyHex string) e
 	if err != nil {
 		return fmt.Errorf("extracting evidence: %w", err)
 	}
-	key := keyHex
-	if key == "" {
-		key = pkt.Verifier.SignerKey
+	if len(receipts) == 0 {
+		return fmt.Errorf("chain verification failed: empty chain")
 	}
-	chain := receipt.VerifyChain(receipts, key)
+	chain := receipt.VerifyChain(receipts, keyHex)
 	if !chain.Valid {
 		return fmt.Errorf("chain verification failed: %s", chain.Error)
 	}
@@ -127,7 +130,8 @@ func verifyPacket(pkt auditpacket.Packet, evidenceJSONL []byte, keyHex string) e
 	if pkt.Verifier.RootHash != "" && pkt.Verifier.RootHash != chain.RootHash {
 		return fmt.Errorf("root_hash mismatch: packet=%s chain=%s", pkt.Verifier.RootHash, chain.RootHash)
 	}
-	if pkt.Verifier.FinalSeq != 0 && (pkt.Verifier.FinalSeq < 0 || uint64(pkt.Verifier.FinalSeq) != chain.FinalSeq) {
+	if (pkt.Verifier.FinalSeqPresent || pkt.Verifier.FinalSeq != 0) &&
+		(pkt.Verifier.FinalSeq < 0 || uint64(pkt.Verifier.FinalSeq) != chain.FinalSeq) {
 		return fmt.Errorf("final_seq mismatch: packet=%d chain=%d", pkt.Verifier.FinalSeq, chain.FinalSeq)
 	}
 	if err := crossCheckTotals(pkt.Summary, receipts); err != nil {

--- a/internal/replaycapture/verify.go
+++ b/internal/replaycapture/verify.go
@@ -103,7 +103,8 @@ func validateInMemoryPacketArtifacts(pkt auditpacket.Packet) error {
 }
 
 func verifyPacket(pkt auditpacket.Packet, evidenceJSONL []byte, keyHex string) error {
-	if strings.TrimSpace(keyHex) == "" {
+	keyHex = strings.TrimSpace(keyHex)
+	if keyHex == "" {
 		return fmt.Errorf("external signer key is required")
 	}
 	if err := jsonscan.RejectUnsafeNumbers(evidenceJSONL); err != nil {

--- a/internal/signing/signing.go
+++ b/internal/signing/signing.go
@@ -332,6 +332,13 @@ func LoadPublicKey(pathOrValue string) (ed25519.PublicKey, error) {
 		return nil, fmt.Errorf("public key is empty")
 	}
 
+	// Inline key material is unambiguous and must win over filesystem lookup.
+	// Otherwise an untrusted working directory can replace a pinned literal
+	// with a same-named file.
+	if key, err := ParsePublicKey(input); err == nil {
+		return key, nil
+	}
+
 	cleanPath := filepath.Clean(input)
 	if _, err := os.Stat(cleanPath); err == nil {
 		data, readErr := os.ReadFile(cleanPath)

--- a/internal/signing/signing_test.go
+++ b/internal/signing/signing_test.go
@@ -1226,6 +1226,26 @@ func TestLoadPublicKey(t *testing.T) {
 			t.Error("same-named file replaced the inline key")
 		}
 	})
+
+	t.Run("inline_versioned_key_wins_over_same_named_file", func(t *testing.T) {
+		dir := t.TempDir()
+		otherPub, _, _ := GenerateKeyPair()
+		shadow := filepath.Join(dir, versioned)
+		if err := os.MkdirAll(filepath.Dir(shadow), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(shadow, []byte(hex.EncodeToString(otherPub)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(dir)
+		key, err := LoadPublicKey(versioned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(key, pub) {
+			t.Error("same-named file replaced the inline versioned key")
+		}
+	})
 }
 
 func TestAtomicWrite_RenameError(t *testing.T) {

--- a/internal/signing/signing_test.go
+++ b/internal/signing/signing_test.go
@@ -1206,6 +1206,26 @@ func TestLoadPublicKey(t *testing.T) {
 			t.Error("inline hex key does not match")
 		}
 	})
+
+	t.Run("inline_hex_wins_over_same_named_file", func(t *testing.T) {
+		dir := t.TempDir()
+		otherPub, _, _ := GenerateKeyPair()
+		if err := os.WriteFile(
+			filepath.Join(dir, hexKey),
+			[]byte(hex.EncodeToString(otherPub)),
+			0o600,
+		); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(dir)
+		key, err := LoadPublicKey(hexKey)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(key, pub) {
+			t.Error("same-named file replaced the inline key")
+		}
+	})
 }
 
 func TestAtomicWrite_RenameError(t *testing.T) {

--- a/sdk/audit-packet/audit_packet.go
+++ b/sdk/audit-packet/audit_packet.go
@@ -5,6 +5,7 @@ package auditpacket
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -211,9 +212,61 @@ type Verifier struct {
 	ReceiptCount int    `json:"receipt_count,omitempty"`
 	RootHash     string `json:"root_hash,omitempty"`
 	FinalSeq     int    `json:"final_seq,omitempty"`
-	SignerKey    string `json:"signer_key,omitempty"`
-	OutputFile   string `json:"output_file,omitempty"`
-	Error        string `json:"error,omitempty"`
+	// FinalSeqPresent preserves the distinction between an omitted optional
+	// field and an explicitly supplied zero for verifier cross-checks.
+	FinalSeqPresent bool   `json:"-"`
+	SignerKey       string `json:"signer_key,omitempty"`
+	OutputFile      string `json:"output_file,omitempty"`
+	Error           string `json:"error,omitempty"`
+}
+
+// UnmarshalJSON records whether final_seq was present. A plain int cannot
+// distinguish an omitted optional value from an attacker-supplied zero.
+func (v *Verifier) UnmarshalJSON(data []byte) error {
+	type verifierAlias Verifier
+	var decoded verifierAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*v = Verifier(decoded)
+	canonicalNames := [...]string{
+		"verdict",
+		"trusted",
+		"receipt_count",
+		"root_hash",
+		"final_seq",
+		"signer_key",
+		"output_file",
+		"error",
+	}
+	for name := range fields {
+		for _, canonical := range canonicalNames {
+			if strings.EqualFold(name, canonical) && name != canonical {
+				return fmt.Errorf("verifier field %q must use canonical name %s", name, canonical)
+			}
+		}
+	}
+	_, v.FinalSeqPresent = fields["final_seq"]
+	return nil
+}
+
+// MarshalJSON preserves an explicitly present final_seq=0 during round trips.
+func (v Verifier) MarshalJSON() ([]byte, error) {
+	type verifierAlias Verifier
+	if !v.FinalSeqPresent || v.FinalSeq != 0 {
+		return json.Marshal(verifierAlias(v))
+	}
+	return json.Marshal(struct {
+		verifierAlias
+		FinalSeq int `json:"final_seq"`
+	}{
+		verifierAlias: verifierAlias(v),
+		FinalSeq:      v.FinalSeq,
+	})
 }
 
 // Receipt is the inline form of a receipt entry. Consumers SHOULD prefer

--- a/sdk/audit-packet/audit_packet_test.go
+++ b/sdk/audit-packet/audit_packet_test.go
@@ -70,6 +70,37 @@ func TestExampleConformsToV0(t *testing.T) {
 	}
 }
 
+func TestVerifierUnmarshalTracksPresentFinalSeqZero(t *testing.T) {
+	var present auditpacket.Verifier
+	if err := json.Unmarshal([]byte(`{"verdict":"invalid","trusted":false,"final_seq":0}`), &present); err != nil {
+		t.Fatalf("unmarshal present final_seq: %v", err)
+	}
+	if !present.FinalSeqPresent {
+		t.Fatal("explicit final_seq=0 must be distinguishable from omission")
+	}
+	roundTrip, err := json.Marshal(present)
+	if err != nil {
+		t.Fatalf("marshal present final_seq: %v", err)
+	}
+	if !bytes.Contains(roundTrip, []byte(`"final_seq":0`)) {
+		t.Fatalf("explicit final_seq=0 was lost during round trip: %s", roundTrip)
+	}
+
+	var omitted auditpacket.Verifier
+	if err := json.Unmarshal([]byte(`{"verdict":"invalid","trusted":false}`), &omitted); err != nil {
+		t.Fatalf("unmarshal omitted final_seq: %v", err)
+	}
+	if omitted.FinalSeqPresent {
+		t.Fatal("omitted final_seq must remain absent")
+	}
+
+	var nonCanonical auditpacket.Verifier
+	err = json.Unmarshal([]byte(`{"verdict":"invalid","trusted":false,"Final_Seq":0}`), &nonCanonical)
+	if err == nil || !strings.Contains(err.Error(), "canonical name final_seq") {
+		t.Fatalf("non-canonical final_seq error = %v", err)
+	}
+}
+
 // TestSchemaFileIsValidJSON guards against the schema file becoming malformed
 // during edits. We do NOT invoke a full JSON Schema validator (that would
 // require a third-party dep). The schema's job is enforced externally; here we

--- a/sdk/verifiers/rust/README.md
+++ b/sdk/verifiers/rust/README.md
@@ -49,5 +49,5 @@ Trusted Audit Packet verification requires an external `--key` or an
 out-of-band `--expect-sha256` packet digest. A packet's embedded signer key
 cannot establish its own provenance. The explicitly weaker
 `--allow-self-consistent-only` and `--no-trust-required` modes retain their
-documented opt-in behavior. `--offline` is schema-only and deliberately skips
-receipt-chain verification.
+documented opt-in behavior. `--offline` skips receipt-chain verification while
+still validating the schema and packet-level trust fields.

--- a/sdk/verifiers/rust/README.md
+++ b/sdk/verifiers/rust/README.md
@@ -45,3 +45,9 @@ Exit codes match the Go and TypeScript verifiers:
 The verifier embeds the Audit Packet v0 schema at compile time, validates structural invariants, verifies Ed25519 receipt signatures, replays receipt chains with the `genesis` root, and cross-checks packet totals, receipt count, root hash, final sequence, and verdict consistency. The `receipt` command also verifies EvidenceReceipt v2 `proxy_decision_with_spans` receipts with a pinned `--key`, including the JCS preimage and strict source-span payload shape.
 
 Signer keys may be raw 32-byte hex, the versioned `pipelock-ed25519-public-v1` text format, or a file containing either form.
+Trusted Audit Packet verification requires an external `--key` or an
+out-of-band `--expect-sha256` packet digest. A packet's embedded signer key
+cannot establish its own provenance. The explicitly weaker
+`--allow-self-consistent-only` and `--no-trust-required` modes retain their
+documented opt-in behavior. `--offline` is schema-only and deliberately skips
+receipt-chain verification.

--- a/sdk/verifiers/rust/src/audit_packet.rs
+++ b/sdk/verifiers/rust/src/audit_packet.rs
@@ -43,13 +43,10 @@ pub fn verify_audit_packet(target: &str, opts: &AuditPacketOptions) -> Result<Au
         }
     }
 
-    let packet_text = match std::fs::read_to_string(&packet_path) {
+    let packet_text = match String::from_utf8(raw_packet) {
         Ok(text) => text,
         Err(err) => {
-            push_error(
-                &mut report,
-                format!("packet json: read {}: {err}", packet_path.display()),
-            );
+            push_error(&mut report, format!("packet json: invalid UTF-8: {err}"));
             return Ok(report);
         }
     };
@@ -104,10 +101,23 @@ pub fn verify_audit_packet(target: &str, opts: &AuditPacketOptions) -> Result<Au
             return Ok(report);
         }
     };
-    let key_input = if opts.signer_key.trim().is_empty() {
-        string_at(&packet, &["verifier", "signer_key"]).unwrap_or("")
-    } else {
+    let packet_key = string_at(&packet, &["verifier", "signer_key"]).unwrap_or("");
+    let packet_key_allowed = !opts.expect_sha256.trim().is_empty()
+        || opts.no_trust_required
+        || (string_at(&packet, &["verifier", "verdict"]) == Some("self_consistent_only")
+            && opts.allow_self_consistent_only);
+    let key_input = if !opts.signer_key.trim().is_empty() {
         opts.signer_key.as_str()
+    } else if packet_key_allowed {
+        packet_key
+    } else {
+        report.chain_check = "fail".to_string();
+        push_error(
+            &mut report,
+            "chain: trusted Audit Packet verification requires --key or --expect-sha256"
+                .to_string(),
+        );
+        return Ok(report);
     };
     let key_hex = match resolve_signer_key(key_input) {
         Ok(key) => key,

--- a/sdk/verifiers/rust/src/chain.rs
+++ b/sdk/verifiers/rust/src/chain.rs
@@ -44,11 +44,11 @@ pub fn verify_chain_with_options(
 ) -> ChainResult {
     if receipts.is_empty() {
         return ChainResult {
-            valid: true,
+            valid: false,
             receipt_count: 0,
             final_seq: 0,
             root_hash: String::new(),
-            error: None,
+            error: Some("empty chain".to_string()),
             broken_at_seq: None,
         };
     }

--- a/sdk/verifiers/rust/src/util.rs
+++ b/sdk/verifiers/rust/src/util.rs
@@ -234,25 +234,44 @@ pub fn resolve_signer_key(input: &str) -> Result<String> {
         return Ok(String::new());
     }
 
-    let mut value = trimmed.to_string();
-    let path = Path::new(trimmed);
-    if path.exists() {
-        value = fs::read_to_string(path)
-            .map_err(|err| VerifierError::Runtime(format!("read {}: {err}", path.display())))?
-            .trim()
-            .to_string();
+    // Both supported literal forms are unambiguously key material. Parse them
+    // before consulting the filesystem so an untrusted working directory
+    // cannot replace a pinned literal with a same-named file.
+    if (trimmed.len() == 64 && trimmed.chars().all(|c| c.is_ascii_hexdigit()))
+        || trimmed
+            .lines()
+            .next()
+            .is_some_and(|line| line.trim_end_matches('\r') == "pipelock-ed25519-public-v1")
+    {
+        return parse_signer_key_value(trimmed);
     }
 
+    let path = Path::new(trimmed);
+    let value = if path.exists() {
+        fs::read_to_string(path)
+            .map_err(|err| VerifierError::Runtime(format!("read {}: {err}", path.display())))?
+            .trim()
+            .to_string()
+    } else {
+        trimmed.to_string()
+    };
+
+    parse_signer_key_value(&value)
+}
+
+fn parse_signer_key_value(value: &str) -> Result<String> {
     let mut lines = value.lines();
     if lines.next().map(|line| line.trim_end_matches('\r')) == Some("pipelock-ed25519-public-v1") {
         let body = lines.next().unwrap_or("").trim();
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(body)
             .map_err(|err| VerifierError::Runtime(format!("decode public key: {err}")))?;
-        value = hex::encode(bytes);
+        let decoded = hex::encode(bytes);
+        decode_hex(&decoded, 32, "public key").map_err(VerifierError::Runtime)?;
+        return Ok(decoded);
     }
 
-    decode_hex(&value, 32, "public key").map_err(VerifierError::Runtime)?;
+    decode_hex(value, 32, "public key").map_err(VerifierError::Runtime)?;
     Ok(value.to_ascii_lowercase())
 }
 

--- a/sdk/verifiers/rust/tests/audit_packet.rs
+++ b/sdk/verifiers/rust/tests/audit_packet.rs
@@ -4,12 +4,16 @@
 mod common;
 
 use pipelock_verifier_rs::audit_packet::{verify_audit_packet, AuditPacketOptions};
+use pipelock_verifier_rs::util::sha256_hex;
 use serde_json::{json, Value};
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 const PUBLIC_KEY: &str = "4655a7e605c12ebb00a46037881c33c5bca5eb74b45a02e8e7261a7ff5a21678";
+const VERSIONED_PUBLIC_KEY: &str =
+    "pipelock-ed25519-public-v1\nRlWn5gXBLrsApGA3iBwzxbyl63S0WgLo5yYaf/WiFng=";
 const ROOT_HASH: &str = "be904bd5ca82adc26c2969872c23925f22ff24e33faf44a1185b9ffc0e2c2b5a";
 static NEXT_DIR: AtomicU64 = AtomicU64::new(0);
 
@@ -40,6 +44,139 @@ fn audit_packet_verifies_end_to_end() {
     assert_eq!(report.schema_check, "pass");
     assert_eq!(report.chain_check, "pass");
     assert_eq!(report.cross_check, "pass");
+}
+
+#[test]
+fn audit_packet_requires_external_trust_for_valid_verdict() {
+    let packet_dir = write_packet(None);
+    let report = verify_audit_packet(
+        packet_dir.to_str().unwrap(),
+        &AuditPacketOptions {
+            signer_key: String::new(),
+            ..default_options()
+        },
+    )
+    .unwrap();
+    assert!(!report.valid);
+    assert_eq!(report.chain_check, "fail");
+    assert!(has_error(
+        &report.errors,
+        "requires --key or --expect-sha256"
+    ));
+}
+
+#[test]
+fn packet_hash_can_anchor_embedded_signer_key() {
+    let packet_dir = write_packet(None);
+    let packet_bytes = fs::read(packet_dir.join("packet.json")).unwrap();
+    let report = verify_audit_packet(
+        packet_dir.to_str().unwrap(),
+        &AuditPacketOptions {
+            signer_key: String::new(),
+            expect_sha256: sha256_hex(&packet_bytes),
+            ..default_options()
+        },
+    )
+    .unwrap();
+    assert!(report.valid, "{:?}", report.errors);
+}
+
+#[test]
+fn wrong_packet_hash_cannot_anchor_embedded_signer_key() {
+    let packet_dir = write_packet(None);
+    let report = verify_audit_packet(
+        packet_dir.to_str().unwrap(),
+        &AuditPacketOptions {
+            signer_key: String::new(),
+            expect_sha256: "a".repeat(64),
+            ..default_options()
+        },
+    )
+    .unwrap();
+    assert!(!report.valid);
+    assert!(has_error(&report.errors, "packet sha256 mismatch"));
+}
+
+#[test]
+fn explicit_self_consistent_mode_uses_unpinned_chain() {
+    let packet_dir = write_packet(Some(|packet| {
+        packet["verifier"]["verdict"] = Value::from("self_consistent_only");
+        packet["verifier"]["trusted"] = Value::from(false);
+        packet["verifier"]
+            .as_object_mut()
+            .unwrap()
+            .remove("signer_key");
+    }));
+    let report = verify_audit_packet(
+        packet_dir.to_str().unwrap(),
+        &AuditPacketOptions {
+            signer_key: String::new(),
+            allow_self_consistent_only: true,
+            ..default_options()
+        },
+    )
+    .unwrap();
+    assert!(report.valid, "{:?}", report.errors);
+}
+
+#[test]
+fn explicit_no_trust_mode_can_use_packet_key() {
+    let packet_dir = write_packet(Some(|packet| {
+        packet["verifier"]["verdict"] = Value::from("error");
+        packet["verifier"]["trusted"] = Value::from(false);
+    }));
+    let report = verify_audit_packet(
+        packet_dir.to_str().unwrap(),
+        &AuditPacketOptions {
+            signer_key: String::new(),
+            no_trust_required: true,
+            ..default_options()
+        },
+    )
+    .unwrap();
+    assert!(report.valid, "{:?}", report.errors);
+}
+
+#[test]
+fn audit_packet_rejects_empty_chain() {
+    let packet_dir = write_packet(Some(|packet| {
+        packet["summary"]["receipt_count"] = Value::from(0);
+        packet["summary"]["totals"]["allow"] = Value::from(0);
+        packet["verifier"]["receipt_count"] = Value::from(0);
+        packet["verifier"]["root_hash"] = Value::from("");
+        packet["verifier"]["final_seq"] = Value::from(0);
+    }));
+    fs::write(packet_dir.join("evidence.jsonl"), "\n").unwrap();
+    let report = verify_audit_packet(packet_dir.to_str().unwrap(), &default_options()).unwrap();
+    assert!(!report.valid);
+    assert_eq!(report.chain_check, "fail");
+    assert!(has_error(&report.errors, "empty chain"));
+}
+
+#[test]
+fn literal_signer_key_wins_over_same_named_cwd_file() {
+    let packet_dir = write_packet(None);
+    fs::write(packet_dir.join(PUBLIC_KEY), "0".repeat(64)).unwrap();
+    let status = Command::new(env!("CARGO_BIN_EXE_pipelock-verifier-rs"))
+        .current_dir(&packet_dir)
+        .args(["audit-packet", ".", "--key", PUBLIC_KEY])
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
+#[test]
+fn versioned_literal_signer_key_wins_over_same_named_cwd_file() {
+    let packet_dir = write_packet(None);
+    let shadow = packet_dir.join(VERSIONED_PUBLIC_KEY);
+    fs::create_dir_all(shadow.parent().unwrap()).unwrap();
+    fs::write(shadow, "0".repeat(64)).unwrap();
+    let status = Command::new(env!("CARGO_BIN_EXE_pipelock-verifier-rs"))
+        .current_dir(&packet_dir)
+        .args(["audit-packet", ".", "--key", VERSIONED_PUBLIC_KEY])
+        .status()
+        .unwrap();
+    assert!(status.success());
 }
 
 #[test]
@@ -216,7 +353,7 @@ fn write_packet(mutator: Option<fn(&mut Value)>) -> PathBuf {
 
 fn default_options() -> AuditPacketOptions {
     AuditPacketOptions {
-        signer_key: String::new(),
+        signer_key: PUBLIC_KEY.to_string(),
         offline: false,
         allow_self_consistent_only: false,
         no_trust_required: false,

--- a/sdk/verifiers/ts/README.md
+++ b/sdk/verifiers/ts/README.md
@@ -49,6 +49,13 @@ Exit codes match the Go verifier:
 
 `audit-packet` validates `packet.json` against `sdk/audit-packet/v0.json`, applies the structural v0 checks, and re-verifies the referenced receipt chain unless `--offline` is set. `chain` accepts either an `evidence.jsonl` file or a recorder session directory with `--dir`. `receipt` verifies one receipt JSON file. For EvidenceReceipt v2, `receipt` requires a pinned `--key`, verifies the JCS preimage, and enforces strict validation for supported v2 payload kinds, including source-span rules for `proxy_decision_with_spans`.
 
+Trusted Audit Packet verification requires an external `--key` or an
+out-of-band `--expect-sha256` packet digest. A packet's embedded signer key
+cannot establish its own provenance. The explicitly weaker
+`--allow-self-consistent-only` and `--no-trust-required` modes retain their
+documented opt-in behavior. `--offline` is schema-only and deliberately skips
+receipt-chain verification.
+
 ## Development
 
 ```bash

--- a/sdk/verifiers/ts/src/audit-packet.ts
+++ b/sdk/verifiers/ts/src/audit-packet.ts
@@ -94,7 +94,7 @@ function crossCheck(packet: AuditPacket, chain: ChainResult, receipts: Receipt[]
   if (packet.verifier?.root_hash && packet.verifier.root_hash !== chain.root_hash) {
     errors.push(`root_hash mismatch: chain=${chain.root_hash} packet=${packet.verifier.root_hash}`);
   }
-  if ((packet.verifier?.final_seq ?? 0) !== 0 && packet.verifier?.final_seq !== chain.final_seq) {
+  if (packet.verifier?.final_seq !== undefined && packet.verifier.final_seq !== chain.final_seq) {
     errors.push(
       `final_seq mismatch: chain=${chain.final_seq} packet=${String(packet.verifier?.final_seq)}`,
     );
@@ -163,8 +163,20 @@ export async function verifyAuditPacket(
   try {
     const evidencePath = resolveArtifactPath(baseDir, packet.artifacts?.evidence ?? "");
     receipts = extractReceipts(evidencePath);
-    const keyInput =
-      opts.signerKey.trim() === "" ? (packet.verifier?.signer_key ?? "") : opts.signerKey;
+    let keyInput = opts.signerKey;
+    if (keyInput.trim() === "") {
+      const packetKey = packet.verifier?.signer_key ?? "";
+      if (opts.expectSha256.trim() !== "" || opts.noTrustRequired) {
+        keyInput = packetKey;
+      } else if (
+        packet.verifier?.verdict === "self_consistent_only" &&
+        opts.allowSelfConsistentOnly
+      ) {
+        keyInput = packetKey;
+      } else {
+        throw new Error("trusted Audit Packet verification requires --key or --expect-sha256");
+      }
+    }
     chain = await verifyChain(receipts, resolveSignerKey(keyInput), {
       allowUnpinned: opts.allowSelfConsistentOnly,
     });

--- a/sdk/verifiers/ts/src/chain.ts
+++ b/sdk/verifiers/ts/src/chain.ts
@@ -30,7 +30,7 @@ export async function verifyChain(
   options: VerifyChainOptions = {},
 ): Promise<ChainResult> {
   if (receipts.length === 0) {
-    return { valid: true, receipt_count: 0, final_seq: 0, root_hash: "" };
+    return broken(0, "empty chain");
   }
 
   if (receipts[0]?.record_type === evidenceRecordType) {

--- a/sdk/verifiers/ts/src/util.ts
+++ b/sdk/verifiers/ts/src/util.ts
@@ -192,6 +192,9 @@ export function resolveSignerKey(input: string): string {
 function parseSignerKeyValue(value: string): string {
   if (/^pipelock-ed25519-public-v1\r?\n/u.test(value)) {
     const body = value.split(/\r?\n/u)[1]?.trim() ?? "";
+    if (!/^[A-Za-z0-9+/]{43}=$/u.test(body)) {
+      throw new Error("invalid public key: malformed base64");
+    }
     value = Buffer.from(body, "base64").toString("hex");
   }
 

--- a/sdk/verifiers/ts/src/util.ts
+++ b/sdk/verifiers/ts/src/util.ts
@@ -174,13 +174,24 @@ export function resolveSignerKey(input: string): string {
   const trimmed = input.trim();
   if (trimmed === "") return "";
 
+  // Both supported literal forms are unambiguously key material. Parse them
+  // before consulting the filesystem so an untrusted working directory
+  // cannot replace a pinned literal with a same-named file.
+  if (/^[0-9a-f]{64}$/iu.test(trimmed) || /^pipelock-ed25519-public-v1\r?\n/u.test(trimmed)) {
+    return parseSignerKeyValue(trimmed);
+  }
+
   let value = trimmed;
   if (existsSync(trimmed)) {
     value = readFileSync(trimmed, "utf8").trim();
   }
 
-  if (value.startsWith("pipelock-ed25519-public-v1\n")) {
-    const body = value.split(/\n/u)[1]?.trim() ?? "";
+  return parseSignerKeyValue(value);
+}
+
+function parseSignerKeyValue(value: string): string {
+  if (/^pipelock-ed25519-public-v1\r?\n/u.test(value)) {
+    const body = value.split(/\r?\n/u)[1]?.trim() ?? "";
     value = Buffer.from(body, "base64").toString("hex");
   }
 

--- a/sdk/verifiers/ts/tests/audit-packet.test.ts
+++ b/sdk/verifiers/ts/tests/audit-packet.test.ts
@@ -9,7 +9,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { verifyAuditPacket } from "../src/audit-packet.js";
 import type { AuditPacket } from "../src/types.js";
-import { sha256Hex } from "../src/util.js";
+import { resolveSignerKey, sha256Hex } from "../src/util.js";
 
 const publicKey = "4655a7e605c12ebb00a46037881c33c5bca5eb74b45a02e8e7261a7ff5a21678";
 const versionedPublicKey =
@@ -198,6 +198,11 @@ test("versioned literal signer key wins over a same-named cwd file", () => {
     },
   );
   assert.equal(result.status, 0, result.stderr);
+});
+
+test("versioned signer keys reject malformed base64", () => {
+  const malformed = versionedPublicKey.replace("RlWn", "Rl!Wn");
+  assert.throws(() => resolveSignerKey(malformed), /malformed base64/u);
 });
 
 test("audit packet detects totals mismatch", async () => {

--- a/sdk/verifiers/ts/tests/audit-packet.test.ts
+++ b/sdk/verifiers/ts/tests/audit-packet.test.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 Pipelock contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -9,8 +9,11 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { verifyAuditPacket } from "../src/audit-packet.js";
 import type { AuditPacket } from "../src/types.js";
+import { sha256Hex } from "../src/util.js";
 
 const publicKey = "4655a7e605c12ebb00a46037881c33c5bca5eb74b45a02e8e7261a7ff5a21678";
+const versionedPublicKey =
+  "pipelock-ed25519-public-v1\nRlWn5gXBLrsApGA3iBwzxbyl63S0WgLo5yYaf/WiFng=";
 const rootHash = "be904bd5ca82adc26c2969872c23925f22ff24e33faf44a1185b9ffc0e2c2b5a";
 
 function basePacket(): AuditPacket {
@@ -81,7 +84,7 @@ function writePacket(mutator?: (packet: AuditPacket) => void): string {
 }
 
 const defaultOptions = {
-  signerKey: "",
+  signerKey: publicKey,
   offline: false,
   allowSelfConsistentOnly: false,
   noTrustRequired: false,
@@ -94,6 +97,107 @@ test("audit packet verifies end to end", async () => {
   assert.equal(report.schema_check, "pass");
   assert.equal(report.chain_check, "pass");
   assert.equal(report.cross_check, "pass");
+});
+
+test("audit packet requires external trust for valid verdict", async () => {
+  const report = await verifyAuditPacket(writePacket(), { ...defaultOptions, signerKey: "" });
+  assert.equal(report.valid, false);
+  assert.equal(report.chain_check, "fail");
+  assert.ok(report.errors?.some((err) => err.includes("requires --key or --expect-sha256")));
+});
+
+test("packet hash can anchor the embedded signer key", async () => {
+  const dir = writePacket();
+  const packetBytes = readFileSync(path.join(dir, "packet.json"));
+  const report = await verifyAuditPacket(dir, {
+    ...defaultOptions,
+    signerKey: "",
+    expectSha256: sha256Hex(packetBytes),
+  });
+  assert.equal(report.valid, true, JSON.stringify(report.errors));
+});
+
+test("wrong packet hash cannot anchor the embedded signer key", async () => {
+  const report = await verifyAuditPacket(writePacket(), {
+    ...defaultOptions,
+    signerKey: "",
+    expectSha256: "a".repeat(64),
+  });
+  assert.equal(report.valid, false);
+  assert.ok(report.errors?.some((err) => err.includes("packet sha256 mismatch")));
+});
+
+test("explicit self-consistent mode uses the unpinned chain", async () => {
+  const dir = writePacket((packet) => {
+    packet.verifier!.verdict = "self_consistent_only";
+    packet.verifier!.trusted = false;
+    delete packet.verifier!.signer_key;
+  });
+  const report = await verifyAuditPacket(dir, {
+    ...defaultOptions,
+    signerKey: "",
+    allowSelfConsistentOnly: true,
+  });
+  assert.equal(report.valid, true, JSON.stringify(report.errors));
+});
+
+test("explicit no-trust mode can use the packet key", async () => {
+  const dir = writePacket((packet) => {
+    packet.verifier!.verdict = "error";
+    packet.verifier!.trusted = false;
+  });
+  const report = await verifyAuditPacket(dir, {
+    ...defaultOptions,
+    signerKey: "",
+    noTrustRequired: true,
+  });
+  assert.equal(report.valid, true, JSON.stringify(report.errors));
+});
+
+test("audit packet rejects an empty chain", async () => {
+  const dir = writePacket((packet) => {
+    packet.summary!.receipt_count = 0;
+    packet.summary!.totals!.allow = 0;
+    packet.verifier!.receipt_count = 0;
+    packet.verifier!.root_hash = "";
+    packet.verifier!.final_seq = 0;
+  });
+  writeFileSync(path.join(dir, "evidence.jsonl"), "\n", { mode: 0o600 });
+
+  const report = await verifyAuditPacket(dir, defaultOptions);
+  assert.equal(report.valid, false);
+  assert.equal(report.chain_check, "fail");
+  assert.ok(report.errors?.some((err) => err.includes("empty chain")));
+});
+
+test("literal signer key wins over a same-named cwd file", () => {
+  const dir = writePacket();
+  writeFileSync(path.join(dir, publicKey), "0".repeat(64), { mode: 0o600 });
+  const result = spawnSync(
+    process.execPath,
+    [path.resolve("dist/src/cli.js"), "audit-packet", ".", "--key", publicKey],
+    {
+      cwd: dir,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("versioned literal signer key wins over a same-named cwd file", () => {
+  const dir = writePacket();
+  const shadow = path.join(dir, versionedPublicKey);
+  mkdirSync(path.dirname(shadow), { recursive: true, mode: 0o700 });
+  writeFileSync(shadow, "0".repeat(64), { mode: 0o600 });
+  const result = spawnSync(
+    process.execPath,
+    [path.resolve("dist/src/cli.js"), "audit-packet", ".", "--key", versionedPublicKey],
+    {
+      cwd: dir,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
 });
 
 test("audit packet detects totals mismatch", async () => {
@@ -136,6 +240,17 @@ test("audit packet detects final_seq mismatch", async () => {
   const report = await verifyAuditPacket(
     writePacket((packet) => {
       packet.verifier!.final_seq = 3;
+    }),
+    defaultOptions,
+  );
+  assert.equal(report.cross_check, "fail");
+  assert.ok(report.errors?.some((err) => err.includes("final_seq")));
+});
+
+test("audit packet detects present final_seq zero mismatch", async () => {
+  const report = await verifyAuditPacket(
+    writePacket((packet) => {
+      packet.verifier!.final_seq = 0;
     }),
     defaultOptions,
   );


### PR DESCRIPTION
## Summary

- require nonempty chains and external trust anchors
- harden pinned-key parsing, packet metadata, and hash-pinned reads
- add cross-language regression coverage and an upgrade note

## Why

Verifier edge cases could promote empty or attacker-controlled evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes / Upgrade Notes**
  * Trusted Audit Packet verification now fails closed unless an external trust anchor is supplied via `--key` or `--expect-sha256` (embedded keys alone no longer establish provenance).
* **Bug Fixes**
  * Empty receipt chains are rejected.
  * `final_seq` is now cross-checked based on explicit presence (including `final_seq: 0`).
  * Inline signer-key literals take precedence over same-named key files; empty external signer keys are rejected.
* **Documentation**
  * Updated verification examples and verifier READMEs to reflect required trust-anchor input and verification modes.
* **Tests**
  * Expanded Rust and TypeScript coverage for trust/anchoring, empty-chain handling, and `final_seq` edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->