### PR TITLE
fix(filesentry): preserve blocking findings under backpressure

### DIFF
--- a/internal/filesentry/consumer.go
+++ b/internal/filesentry/consumer.go
@@ -75,7 +75,9 @@ func ConsumeFindings(opts ConsumerOpts) func() {
 		defer close(done)
 		blockMode := opts.Action == config.ActionBlock
 		cancelled := false
-		for f := range opts.Watcher.Findings() {
+		findings := opts.Watcher.Findings()
+		overflow := opts.Watcher.OverflowFindings()
+		handle := func(f Finding) {
 			writeFindingLog(opts.Log, f)
 			if opts.OnFinding != nil {
 				opts.OnFinding(f.PatternName, f.Severity, f.IsAgent)
@@ -86,6 +88,22 @@ func ConsumeFindings(opts ConsumerOpts) func() {
 					opts.OnBlock(f)
 				}
 				opts.Cancel()
+			}
+		}
+		for findings != nil || overflow != nil {
+			select {
+			case f, ok := <-findings:
+				if !ok {
+					findings = nil
+					continue
+				}
+				handle(f)
+			case f, ok := <-overflow:
+				if !ok {
+					overflow = nil
+					continue
+				}
+				handle(f)
 			}
 		}
 	}()

--- a/internal/filesentry/consumer_test.go
+++ b/internal/filesentry/consumer_test.go
@@ -17,11 +17,17 @@ import (
 // stubWatcher is a Watcher that drives Findings() from a pre-seeded
 // channel. Arm / Start / Close are no-ops sufficient for testing the
 // consumer's enforcement decisions in isolation from fsnotify.
-type stubWatcher struct{ ch chan Finding }
+type stubWatcher struct {
+	ch       chan Finding
+	overflow chan Finding
+}
 
 func (s *stubWatcher) Arm() error                    { return nil }
 func (s *stubWatcher) Start(_ context.Context) error { return nil }
 func (s *stubWatcher) Findings() <-chan Finding      { return s.ch }
+func (s *stubWatcher) OverflowFindings() <-chan Finding {
+	return s.overflow
+}
 func (s *stubWatcher) DegradedPaths() []DegradedPath { return nil }
 func (s *stubWatcher) Close() error                  { return nil }
 
@@ -35,7 +41,34 @@ func makeWatcher(t *testing.T, findings ...Finding) Watcher {
 		ch <- f
 	}
 	close(ch)
-	return &stubWatcher{ch: ch}
+	overflow := make(chan Finding)
+	close(overflow)
+	return &stubWatcher{ch: ch, overflow: overflow}
+}
+
+func TestConsumeFindings_BlockMode_AgentOverflowCancels(t *testing.T) {
+	findings := make(chan Finding)
+	close(findings)
+	overflow := make(chan Finding, 1)
+	overflow <- Finding{
+		Path:        "/tmp/overflow",
+		PatternName: "OverflowSecret",
+		Severity:    "critical",
+		IsAgent:     true,
+	}
+	close(overflow)
+	var cancelCount atomic.Int32
+
+	wait := ConsumeFindings(ConsumerOpts{
+		Watcher: &stubWatcher{ch: findings, overflow: overflow},
+		Action:  config.ActionBlock,
+		Cancel:  func() { cancelCount.Add(1) },
+	})
+	wait()
+
+	if cancelCount.Load() != 1 {
+		t.Fatalf("agent overflow must cancel exactly once, got %d", cancelCount.Load())
+	}
 }
 
 func TestConsumeFindings_WarnMode_NoCancel(t *testing.T) {

--- a/internal/filesentry/watcher.go
+++ b/internal/filesentry/watcher.go
@@ -36,6 +36,11 @@ type Watcher interface {
 	Start(ctx context.Context) error
 	// Findings returns a channel that receives DLP findings as they are detected.
 	Findings() <-chan Finding
+	// OverflowFindings returns a priority lane for findings detected while the
+	// normal buffer is saturated. Long-lived consumers must drain both
+	// channels; agent findings on this lane remain enforcement-relevant in
+	// block mode. Single-probe diagnostics cannot saturate the normal buffer.
+	OverflowFindings() <-chan Finding
 	// DegradedPaths returns the configured watch_paths entries whose Arm()
 	// install failed and whose entry was not marked required:true. Empty
 	// when the watcher is fully armed. Safe to call concurrently.

--- a/internal/filesentry/watcher_impl.go
+++ b/internal/filesentry/watcher_impl.go
@@ -5,6 +5,7 @@ package filesentry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -371,76 +372,11 @@ func (w *fsWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
 	w.mu.Unlock()
 }
 
-// flushScan runs a DLP scan synchronously during Close. Channels remain open
-// until every pending scan finishes, so a saturated normal buffer can use the
-// same agent-priority overflow lane as live scans.
+// flushScan runs a DLP scan synchronously during Close. Close keeps both
+// delivery channels open until every pending and registered scan finishes, so
+// the flush can use the same agent-priority overflow lane as live scans.
 func (w *fsWatcher) flushScan(path string, isAgent bool) {
-	if w.cfg.ScanContent != nil && !*w.cfg.ScanContent {
-		return
-	}
-
-	f, err := os.Open(filepath.Clean(path))
-	if err != nil {
-		w.logError(fmt.Errorf("filesentry: open failed, file left unscanned: %s: %w", path, err))
-		return
-	}
-	defer func() { _ = f.Close() }()
-
-	info, err := f.Stat()
-	if err != nil {
-		w.logError(fmt.Errorf("filesentry: stat failed, file left unscanned: %s: %w", path, err))
-		return
-	}
-	if info.IsDir() || info.Size() == 0 {
-		return
-	}
-	sizeCap := w.effectiveMaxFileSize()
-	if info.Size() > sizeCap {
-		w.logError(fmt.Errorf("filesentry: skipped oversized file, left unscanned (%d bytes > cap %d): %s", info.Size(), sizeCap, path))
-		return
-	}
-
-	data, err := io.ReadAll(io.LimitReader(f, sizeCap+1))
-	if err != nil {
-		w.logError(fmt.Errorf("filesentry: read failed, file left unscanned: %s: %w", path, err))
-		return
-	}
-	if len(data) == 0 {
-		return
-	}
-	if int64(len(data)) > sizeCap {
-		w.logError(fmt.Errorf("filesentry: skipped oversized file, left unscanned (grew beyond cap %d while reading): %s", sizeCap, path))
-		return
-	}
-
-	result := w.scanner.ScanTextForDLP(context.Background(), string(data))
-	if result.Clean {
-		return
-	}
-
-	for _, m := range result.Matches {
-		finding := Finding{
-			Path:        path,
-			PatternName: m.PatternName,
-			Severity:    m.Severity,
-			Encoded:     m.Encoded,
-			IsAgent:     isAgent,
-		}
-		var overflowErr error
-		select {
-		case w.findings <- finding:
-		default:
-			// Close owns channel lifetime while flushes run, and live scan
-			// writers have already observed closed=true. Holding mu preserves
-			// enqueueOverflow's single-writer invariant.
-			w.mu.Lock()
-			overflowErr = w.enqueueOverflow(finding)
-			w.mu.Unlock()
-		}
-		if overflowErr != nil {
-			w.logError(overflowErr)
-		}
-	}
+	w.doScan(context.Background(), path, isAgent, true)
 }
 
 // scanFile reads a file and runs DLP scanning on its content.
@@ -507,8 +443,9 @@ func (w *fsWatcher) doScan(ctx context.Context, path string, isAgent, registered
 			Encoded:     m.Encoded,
 			IsAgent:     isAgent,
 		}
-		// Hold the lock across the closed check AND the send. Without this,
-		// Close() can close w.findings between the check and the send.
+		// Hold the lock across the closed check and delivery. This prevents
+		// Close from closing either channel during a send and serializes every
+		// overflow writer; Close closes channels only after scanWG.Wait.
 		w.mu.Lock()
 		if w.closed && !registered {
 			w.mu.Unlock()
@@ -548,17 +485,37 @@ func (w *fsWatcher) enqueueOverflow(f Finding) error {
 	select {
 	case pending := <-w.overflow:
 		if pending.IsAgent {
-			w.overflow <- pending
+			if !w.tryOverflowSend(pending) {
+				return errors.Join(
+					overflowError(pending, "priority lane refilled concurrently"),
+					overflowError(f, "agent overflow already pending"),
+				)
+			}
 			return overflowError(f, "agent overflow already pending")
 		}
 		displacedErr := overflowError(pending, "replaced by agent-attributed overflow")
-		w.overflow <- f
+		if !w.tryOverflowSend(f) {
+			return errors.Join(displacedErr, overflowError(f, "priority lane refilled concurrently"))
+		}
 		return displacedErr
 	default:
 	}
 
-	w.overflow <- f
+	if !w.tryOverflowSend(f) {
+		return overflowError(f, "priority lane refilled concurrently")
+	}
 	return nil
+}
+
+// tryOverflowSend degrades a lost single-writer invariant to a reported drop
+// instead of blocking while holding w.mu and preventing Close from completing.
+func (w *fsWatcher) tryOverflowSend(f Finding) bool {
+	select {
+	case w.overflow <- f:
+		return true
+	default:
+		return false
+	}
 }
 
 func overflowError(f Finding, reason string) error {

--- a/internal/filesentry/watcher_impl.go
+++ b/internal/filesentry/watcher_impl.go
@@ -485,26 +485,17 @@ func (w *fsWatcher) enqueueOverflow(f Finding) error {
 	select {
 	case pending := <-w.overflow:
 		if pending.IsAgent {
-			if !w.tryOverflowSend(pending) {
-				return errors.Join(
-					overflowError(pending, "priority lane refilled concurrently"),
-					overflowError(f, "agent overflow already pending"),
-				)
-			}
-			return overflowError(f, "agent overflow already pending")
+			return errors.Join(
+				w.tryOverflowSendError(pending, "priority lane refilled concurrently"),
+				overflowError(f, "agent overflow already pending"),
+			)
 		}
 		displacedErr := overflowError(pending, "replaced by agent-attributed overflow")
-		if !w.tryOverflowSend(f) {
-			return errors.Join(displacedErr, overflowError(f, "priority lane refilled concurrently"))
-		}
-		return displacedErr
+		return errors.Join(displacedErr, w.tryOverflowSendError(f, "priority lane refilled concurrently"))
 	default:
 	}
 
-	if !w.tryOverflowSend(f) {
-		return overflowError(f, "priority lane refilled concurrently")
-	}
-	return nil
+	return w.tryOverflowSendError(f, "priority lane refilled concurrently")
 }
 
 // tryOverflowSend degrades a lost single-writer invariant to a reported drop
@@ -516,6 +507,13 @@ func (w *fsWatcher) tryOverflowSend(f Finding) bool {
 	default:
 		return false
 	}
+}
+
+func (w *fsWatcher) tryOverflowSendError(f Finding, reason string) error {
+	if w.tryOverflowSend(f) {
+		return nil
+	}
+	return overflowError(f, reason)
 }
 
 func overflowError(f Finding, reason string) error {

--- a/internal/filesentry/watcher_impl.go
+++ b/internal/filesentry/watcher_impl.go
@@ -26,11 +26,6 @@ const debounceDelay = 50 * time.Millisecond
 // Large enough to avoid blocking the watcher goroutine under burst writes.
 const findingsChanSize = 64
 
-// flushSendTimeout is the maximum time flushScan waits to deliver a finding
-// during Close(). Short enough to prevent test hangs when the consumer has
-// stopped reading, long enough to deliver findings under normal shutdown.
-const flushSendTimeout = 2 * time.Second
-
 // maxFileSize is the default maximum file size to scan when file_sentry
 // max_file_bytes is unset. Files larger than the effective cap are skipped to
 // avoid unbounded memory use from scanning large binaries; the skip is
@@ -44,8 +39,13 @@ type fsWatcher struct {
 	lineage  Lineage
 	watcher  *fsnotify.Watcher
 	findings chan Finding
+	// overflow is a one-entry priority lane used when findings is saturated.
+	// Agent-attributed findings replace a queued non-agent overflow so block
+	// mode cannot be bypassed by filling the normal delivery channel first.
+	overflow chan Finding
 	onError  func(error) // optional callback for non-fatal errors (e.g. runtime watch failures)
 	mu       sync.Mutex
+	scanWG   sync.WaitGroup         // debounce scans that began before Close
 	timers   map[string]*time.Timer // per-path debounce timers
 	pidSnap  map[string]bool        // per-path agent attribution snapshot at event time
 	closed   bool
@@ -81,6 +81,7 @@ func NewWatcher(cfg *config.FileSentry, sc DLPScanner, lin Lineage, onError func
 		lineage:  lin,
 		watcher:  w,
 		findings: make(chan Finding, findingsChanSize),
+		overflow: make(chan Finding, 1),
 		timers:   make(map[string]*time.Timer),
 		pidSnap:  make(map[string]bool),
 		onError:  onError,
@@ -195,6 +196,12 @@ func (w *fsWatcher) Findings() <-chan Finding {
 	return w.findings
 }
 
+// OverflowFindings returns the priority lane for findings detected while the
+// normal delivery buffer is saturated.
+func (w *fsWatcher) OverflowFindings() <-chan Finding {
+	return w.overflow
+}
+
 // Close stops the watcher, flushes pending debounced scans, and closes the
 // findings channel so consumer goroutines exit their range loops.
 // Pending timers are stopped and their scans run synchronously so that
@@ -233,7 +240,13 @@ func (w *fsWatcher) Close() error {
 		w.flushScan(path, pendingAgent[i])
 	}
 
+	// A timer may have removed itself from timers and started scanning just
+	// before Close set closed=true. Wait for those registered scans before
+	// closing their delivery channels.
+	w.scanWG.Wait()
+
 	close(w.findings)
+	close(w.overflow)
 	return err
 }
 
@@ -306,6 +319,10 @@ func (w *fsWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
 	// the quiet period. The snapshot is consumed by scanFile after debounce.
 	if w.lineage != nil {
 		w.mu.Lock()
+		if w.closed {
+			w.mu.Unlock()
+			return
+		}
 		w.pidSnap[ev.Name] = w.lineage.HasFileOpen(ev.Name)
 		w.mu.Unlock()
 	}
@@ -319,6 +336,10 @@ func (w *fsWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
 	// does nothing. Without this, the old callback would delete the new
 	// timer's map entry, causing the new callback to scan without cleanup.
 	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
 	if existing, ok := w.timers[ev.Name]; ok {
 		existing.Stop()
 	}
@@ -328,6 +349,10 @@ func (w *fsWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
 	var timer *time.Timer
 	timer = time.AfterFunc(debounceDelay, func() {
 		w.mu.Lock()
+		if w.closed {
+			w.mu.Unlock()
+			return
+		}
 		// Only proceed if this timer is still the active one for this path.
 		if current, ok := w.timers[path]; !ok || current != timer {
 			w.mu.Unlock()
@@ -337,17 +362,18 @@ func (w *fsWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
 		// Consume the PID snapshot (take the cached value, then clean up).
 		isAgent := w.pidSnap[path]
 		delete(w.pidSnap, path)
+		w.scanWG.Add(1)
 		w.mu.Unlock()
-		w.scanFile(ctx, path, isAgent)
+		defer w.scanWG.Done()
+		w.doScan(ctx, path, isAgent, true)
 	})
 	w.timers[path] = timer
 	w.mu.Unlock()
 }
 
-// flushScan runs a DLP scan synchronously during Close, sending findings
-// with a blocking send (the consumer is still running and the channel is
-// still open at this point). This ensures the last debounced writes are
-// not dropped even if the buffer is full.
+// flushScan runs a DLP scan synchronously during Close. Channels remain open
+// until every pending scan finishes, so a saturated normal buffer can use the
+// same agent-priority overflow lane as live scans.
 func (w *fsWatcher) flushScan(path string, isAgent bool) {
 	if w.cfg.ScanContent != nil && !*w.cfg.ScanContent {
 		return
@@ -393,21 +419,26 @@ func (w *fsWatcher) flushScan(path string, isAgent bool) {
 	}
 
 	for _, m := range result.Matches {
-		select {
-		case w.findings <- Finding{
+		finding := Finding{
 			Path:        path,
 			PatternName: m.PatternName,
 			Severity:    m.Severity,
 			Encoded:     m.Encoded,
 			IsAgent:     isAgent,
-		}:
-		case <-time.After(flushSendTimeout):
-			// Timed out - consumer stopped reading. Log but don't block
-			// shutdown indefinitely. Buffer is 64, so this only fires
-			// when the consumer is truly gone.
-			if w.onError != nil {
-				w.onError(fmt.Errorf("filesentry: flush finding dropped (channel full, consumer stopped): %s", path))
-			}
+		}
+		var overflowErr error
+		select {
+		case w.findings <- finding:
+		default:
+			// Close owns channel lifetime while flushes run, and live scan
+			// writers have already observed closed=true. Holding mu preserves
+			// enqueueOverflow's single-writer invariant.
+			w.mu.Lock()
+			overflowErr = w.enqueueOverflow(finding)
+			w.mu.Unlock()
+		}
+		if overflowErr != nil {
+			w.logError(overflowErr)
 		}
 	}
 }
@@ -415,13 +446,13 @@ func (w *fsWatcher) flushScan(path string, isAgent bool) {
 // scanFile reads a file and runs DLP scanning on its content.
 // isAgent is the PID attribution result snapshotted at event time.
 func (w *fsWatcher) scanFile(ctx context.Context, path string, isAgent bool) {
-	w.doScan(ctx, path, isAgent, true)
+	w.doScan(ctx, path, isAgent, false)
 }
 
-// doScan is the shared scan implementation. When checkClosed is true,
-// it guards channel sends against w.closed (normal event loop path).
-// When false, it sends directly (flush during Close).
-func (w *fsWatcher) doScan(ctx context.Context, path string, isAgent bool, checkClosed bool) {
+// doScan is the shared scan implementation. A registered debounce scan may
+// finish after Close begins because Close waits for scanWG before closing the
+// delivery channels. Direct callers do not have that lifetime guarantee.
+func (w *fsWatcher) doScan(ctx context.Context, path string, isAgent, registered bool) {
 	if w.cfg.ScanContent != nil && !*w.cfg.ScanContent {
 		return
 	}
@@ -476,24 +507,69 @@ func (w *fsWatcher) doScan(ctx context.Context, path string, isAgent bool, check
 			Encoded:     m.Encoded,
 			IsAgent:     isAgent,
 		}
-		if checkClosed {
-			// Hold the lock across the closed check AND the send. Without this,
-			// Close() can close w.findings between the check and the send.
-			w.mu.Lock()
-			if w.closed {
-				w.mu.Unlock()
-				return
-			}
+		// Hold the lock across the closed check AND the send. Without this,
+		// Close() can close w.findings between the check and the send.
+		w.mu.Lock()
+		if w.closed && !registered {
+			w.mu.Unlock()
+			return
 		}
+		var overflowErr error
 		select {
 		case w.findings <- f:
 		default:
-			// Channel full - drop finding rather than blocking the watcher.
+			overflowErr = w.enqueueOverflow(f)
 		}
-		if checkClosed {
-			w.mu.Unlock()
+		w.mu.Unlock()
+		if overflowErr != nil {
+			w.logError(overflowErr)
 		}
 	}
+}
+
+// enqueueOverflow preserves visibility and block-mode enforcement without
+// blocking timer goroutines or growing an unbounded queue. The caller holds
+// w.mu, which also prevents Close from closing overflow during this send.
+func (w *fsWatcher) enqueueOverflow(f Finding) error {
+	select {
+	case w.overflow <- f:
+		return nil
+	default:
+	}
+
+	if !f.IsAgent {
+		return overflowError(f, "priority lane already occupied")
+	}
+
+	// An agent finding is enforcement-relevant. Replace a pending non-agent
+	// sample so ConsumeFindings is guaranteed to observe an agent overflow and
+	// cancel in block mode. If the consumer raced us and drained the lane, the
+	// direct retry below succeeds.
+	select {
+	case pending := <-w.overflow:
+		if pending.IsAgent {
+			w.overflow <- pending
+			return overflowError(f, "agent overflow already pending")
+		}
+		displacedErr := overflowError(pending, "replaced by agent-attributed overflow")
+		w.overflow <- f
+		return displacedErr
+	default:
+	}
+
+	w.overflow <- f
+	return nil
+}
+
+func overflowError(f Finding, reason string) error {
+	return fmt.Errorf(
+		"filesentry: finding delivery overflow (%s): path=%s pattern=%s severity=%s agent=%t",
+		reason,
+		f.Path,
+		f.PatternName,
+		f.Severity,
+		f.IsAgent,
+	)
 }
 
 // isIgnored checks if a path matches any configured ignore pattern.

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -745,6 +745,114 @@ func TestWatcher_TryOverflowSendDoesNotBlockOnFullLane(t *testing.T) {
 	}
 }
 
+func TestWatcher_TryOverflowSendError(t *testing.T) {
+	t.Run("available_lane", func(t *testing.T) {
+		w := &fsWatcher{overflow: make(chan Finding, 1)}
+		incoming := Finding{Path: "incoming-agent", IsAgent: true}
+		if err := w.tryOverflowSendError(incoming, "lane refilled"); err != nil {
+			t.Fatalf("tryOverflowSendError: %v", err)
+		}
+		if got := <-w.overflow; got != incoming {
+			t.Fatalf("overflow finding = %+v, want %+v", got, incoming)
+		}
+	})
+
+	t.Run("full_lane", func(t *testing.T) {
+		w := &fsWatcher{overflow: make(chan Finding, 1)}
+		pending := Finding{Path: "pending-agent", IsAgent: true}
+		w.overflow <- pending
+		err := w.tryOverflowSendError(Finding{Path: "incoming-agent", IsAgent: true}, "lane refilled")
+		if err == nil || !strings.Contains(err.Error(), "lane refilled") {
+			t.Fatalf("tryOverflowSendError error = %v, want lane refilled", err)
+		}
+		if got := <-w.overflow; got != pending {
+			t.Fatalf("pending finding = %+v, want %+v", got, pending)
+		}
+	})
+}
+
+func TestWatcher_ClosedGuardsRejectNewWork(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	if err := os.WriteFile(path, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name    string
+		lineage Lineage
+	}{
+		{name: "before_lineage_snapshot", lineage: &mockLineage{hasFileOpen: true}},
+		{name: "before_timer_registration"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &fsWatcher{
+				cfg:     &config.FileSentry{},
+				lineage: tt.lineage,
+				timers:  make(map[string]*time.Timer),
+				pidSnap: make(map[string]bool),
+				closed:  true,
+			}
+			w.handleEvent(context.Background(), fsnotify.Event{Name: path, Op: fsnotify.Write})
+			if len(w.timers) != 0 || len(w.pidSnap) != 0 {
+				t.Fatalf("closed watcher accepted work: timers=%d pid snapshots=%d", len(w.timers), len(w.pidSnap))
+			}
+		})
+	}
+
+	t.Run("timer_callback", func(t *testing.T) {
+		sc := &countingDLPScanner{}
+		w := &fsWatcher{
+			cfg:      &config.FileSentry{ScanContent: ptrBool(true)},
+			scanner:  sc,
+			findings: make(chan Finding, 1),
+			overflow: make(chan Finding, 1),
+			timers:   make(map[string]*time.Timer),
+			pidSnap:  make(map[string]bool),
+		}
+		w.handleEvent(context.Background(), fsnotify.Event{Name: path, Op: fsnotify.Write})
+		w.mu.Lock()
+		w.closed = true
+		timer := w.timers[path]
+		w.mu.Unlock()
+		if timer == nil {
+			t.Fatal("debounce timer was not registered")
+		}
+
+		deadline := time.Now().Add(5 * debounceDelay)
+		testwait.For(
+			t,
+			filesentryPositiveBackstop,
+			func() bool { return time.Now().After(deadline) },
+			"debounce timer to fire after watcher closure",
+		)
+		if timer.Stop() {
+			t.Fatal("debounce timer had not fired")
+		}
+		if got := sc.calls.Load(); got != 0 {
+			t.Fatalf("closed timer callback ran %d scans", got)
+		}
+	})
+
+	t.Run("direct_scan", func(t *testing.T) {
+		sc := &countingDLPScanner{}
+		w := &fsWatcher{
+			cfg:      &config.FileSentry{ScanContent: ptrBool(true)},
+			scanner:  sc,
+			findings: make(chan Finding, 1),
+			overflow: make(chan Finding, 1),
+			closed:   true,
+		}
+		w.scanFile(context.Background(), path, true)
+		if got := sc.calls.Load(); got != 1 {
+			t.Fatalf("DLP scans = %d, want one scan stopped at delivery", got)
+		}
+		if got := len(w.findings) + len(w.overflow); got != 0 {
+			t.Fatalf("closed watcher delivered %d findings", got)
+		}
+	})
+}
+
 func TestWatcher_EmptyFileSkipped(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -732,6 +732,19 @@ func TestWatcher_OverflowCoalescingPreservesPendingPriority(t *testing.T) {
 	}
 }
 
+func TestWatcher_TryOverflowSendDoesNotBlockOnFullLane(t *testing.T) {
+	w := &fsWatcher{overflow: make(chan Finding, 1)}
+	pending := Finding{Path: "pending-agent", IsAgent: true}
+	w.overflow <- pending
+
+	if w.tryOverflowSend(Finding{Path: "incoming-agent", IsAgent: true}) {
+		t.Fatal("send to a full overflow lane unexpectedly succeeded")
+	}
+	if got := <-w.overflow; got != pending {
+		t.Fatalf("pending finding = %+v, want %+v", got, pending)
+	}
+}
+
 func TestWatcher_EmptyFileSkipped(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
@@ -838,12 +851,13 @@ func (s *countingDLPScanner) ScanTextForDLP(context.Context, string) scanner.Tex
 }
 
 type blockingDLPScanner struct {
+	once    sync.Once
 	entered chan struct{}
 	release chan struct{}
 }
 
 func (s *blockingDLPScanner) ScanTextForDLP(context.Context, string) scanner.TextDLPResult {
-	close(s.entered)
+	s.once.Do(func() { close(s.entered) })
 	<-s.release
 	return scanner.TextDLPResult{
 		Matches: []scanner.TextDLPMatch{{

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	"github.com/luckyPipewrench/pipelock/internal/testwait"
@@ -548,7 +550,7 @@ func TestWatcher_FlushScanReportsSkippedFiles(t *testing.T) {
 	}
 }
 
-func TestWatcher_ScanFileDropsWhenFindingChannelFull(t *testing.T) {
+func TestWatcher_ScanFileUsesOverflowLaneWhenFindingChannelFull(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
@@ -581,6 +583,152 @@ func TestWatcher_ScanFileDropsWhenFindingChannelFull(t *testing.T) {
 	fsw.scanFile(context.Background(), secretPath, false)
 	if got := len(fsw.findings); got != cap(fsw.findings) {
 		t.Fatalf("findings len = %d, want channel to remain full at %d", got, cap(fsw.findings))
+	}
+	select {
+	case finding := <-fsw.overflow:
+		if finding.Path != secretPath {
+			t.Fatalf("overflow path = %q, want %q", finding.Path, secretPath)
+		}
+	default:
+		t.Fatal("saturated finding was not preserved in the overflow lane")
+	}
+}
+
+func TestWatcher_FlushUsesOverflowLaneWhenFindingChannelFull(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		WatchPaths:  []config.WatchPath{{Path: dir}},
+		ScanContent: ptrBool(true),
+	}
+
+	defaults := config.Defaults()
+	defaults.Internal = nil
+	defaults.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	sc := scanner.MustNew(defaults)
+	defer sc.Close()
+
+	w, err := NewWatcher(cfg, sc, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	fsw := w.(*fsWatcher)
+
+	for i := 0; i < cap(fsw.findings); i++ {
+		fsw.findings <- Finding{Path: fmt.Sprintf("preload-%d", i)}
+	}
+
+	secretPath := filepath.Join(dir, "shutdown-secret.txt")
+	secret := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+	if err := os.WriteFile(secretPath, []byte(secret), 0o600); err != nil {
+		t.Fatalf("WriteFile secret: %v", err)
+	}
+	fsw.flushScan(secretPath, true)
+
+	select {
+	case finding := <-fsw.overflow:
+		if !finding.IsAgent || finding.Path != secretPath {
+			t.Fatalf("overflow finding = %+v, want agent flush for %q", finding, secretPath)
+		}
+	default:
+		t.Fatal("saturated shutdown finding was not preserved in overflow lane")
+	}
+}
+
+func TestWatcher_AgentOverflowReplacesNonAgentSample(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		WatchPaths:  []config.WatchPath{{Path: dir}},
+		ScanContent: ptrBool(true),
+	}
+
+	defaults := config.Defaults()
+	defaults.Internal = nil
+	defaults.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	sc := scanner.MustNew(defaults)
+	defer sc.Close()
+
+	var errorsMu sync.Mutex
+	var errorsSeen []string
+	w, err := NewWatcher(cfg, sc, nil, func(err error) {
+		errorsMu.Lock()
+		defer errorsMu.Unlock()
+		errorsSeen = append(errorsSeen, err.Error())
+	})
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	fsw := w.(*fsWatcher)
+
+	for i := 0; i < cap(fsw.findings); i++ {
+		fsw.findings <- Finding{Path: fmt.Sprintf("preload-%d", i)}
+	}
+	fsw.overflow <- Finding{Path: "non-agent-overflow", IsAgent: false}
+
+	secretPath := filepath.Join(dir, "agent-secret.txt")
+	secret := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+	if err := os.WriteFile(secretPath, []byte(secret), 0o600); err != nil {
+		t.Fatalf("WriteFile secret: %v", err)
+	}
+	fsw.scanFile(context.Background(), secretPath, true)
+
+	select {
+	case finding := <-fsw.overflow:
+		if !finding.IsAgent || finding.Path != secretPath {
+			t.Fatalf("overflow finding = %+v, want agent finding for %q", finding, secretPath)
+		}
+	default:
+		t.Fatal("agent finding did not replace non-agent overflow sample")
+	}
+	errorsMu.Lock()
+	defer errorsMu.Unlock()
+	if len(errorsSeen) != 1 || !strings.Contains(errorsSeen[0], "replaced by agent-attributed overflow") {
+		t.Fatalf("displaced finding was not reported: %v", errorsSeen)
+	}
+}
+
+func TestWatcher_OverflowCoalescingPreservesPendingPriority(t *testing.T) {
+	tests := []struct {
+		name       string
+		pending    Finding
+		incoming   Finding
+		wantReason string
+	}{
+		{
+			name:       "non-agent does not replace occupied lane",
+			pending:    Finding{Path: "pending-agent", IsAgent: true},
+			incoming:   Finding{Path: "incoming-non-agent", IsAgent: false},
+			wantReason: "priority lane already occupied",
+		},
+		{
+			name:       "second agent does not replace pending agent",
+			pending:    Finding{Path: "pending-agent", IsAgent: true},
+			incoming:   Finding{Path: "incoming-agent", IsAgent: true},
+			wantReason: "agent overflow already pending",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &fsWatcher{overflow: make(chan Finding, 1)}
+			w.overflow <- tt.pending
+
+			err := w.enqueueOverflow(tt.incoming)
+			if err == nil || !strings.Contains(err.Error(), tt.wantReason) {
+				t.Fatalf("enqueueOverflow error = %v, want %q", err, tt.wantReason)
+			}
+			select {
+			case got := <-w.overflow:
+				if got != tt.pending {
+					t.Fatalf("pending finding = %+v, want %+v", got, tt.pending)
+				}
+			default:
+				t.Fatal("pending priority finding was lost")
+			}
+		})
 	}
 }
 
@@ -686,6 +834,69 @@ func (s *countingDLPScanner) ScanTextForDLP(context.Context, string) scanner.Tex
 			PatternName: "test secret",
 			Severity:    "critical",
 		}},
+	}
+}
+
+type blockingDLPScanner struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingDLPScanner) ScanTextForDLP(context.Context, string) scanner.TextDLPResult {
+	close(s.entered)
+	<-s.release
+	return scanner.TextDLPResult{
+		Matches: []scanner.TextDLPMatch{{
+			PatternName: "shutdown secret",
+			Severity:    "critical",
+		}},
+	}
+}
+
+func TestWatcher_CloseWaitsForInFlightDebounceScan(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "secret.txt")
+	if err := os.WriteFile(secretPath, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	sc := &blockingDLPScanner{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	w, err := NewWatcher(&config.FileSentry{ScanContent: ptrBool(true)}, sc, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	fsw := w.(*fsWatcher)
+	fsw.handleEvent(context.Background(), fsnotify.Event{Name: secretPath, Op: fsnotify.Write})
+
+	select {
+	case <-sc.entered:
+	case <-time.After(filesentryPositiveBackstop):
+		t.Fatal("debounce scan did not start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- w.Close() }()
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before in-flight scan completed: %v", err)
+	case <-time.After(filesentryNegativeObservation / 10):
+	}
+
+	close(sc.release)
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(filesentryPositiveBackstop):
+		t.Fatal("Close did not finish after scan release")
+	}
+
+	finding, ok := <-w.Findings()
+	if !ok || finding.Path != secretPath {
+		t.Fatalf("in-flight finding = %+v, open=%t, want path %q", finding, ok, secretPath)
 	}
 }
 
@@ -1125,8 +1336,8 @@ func TestWatcher_StartContextCancelled(t *testing.T) {
 }
 
 func TestWatcher_FindingsChannelFull(t *testing.T) {
-	// When the findings channel is full, new findings should be dropped
-	// (not block the watcher).
+	// When the findings channel is full, the watcher remains non-blocking and
+	// exposes saturation through the priority overflow lane.
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
@@ -1161,19 +1372,19 @@ func TestWatcher_FindingsChannelFull(t *testing.T) {
 		}
 	}
 
-	// Poll until at least one finding arrives, proving debounce completed
-	// without deadlock. The channel is bounded (findingsChanSize), so
-	// overflow writes are dropped - but at least some should arrive.
+	// Wait until saturation reaches the overflow lane before draining. This
+	// proves burst handling remains non-blocking while making overflow visible.
 	deadline := time.After(filesentryPositiveBackstop)
-	drained := 0
-	for drained == 0 {
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for len(w.(*fsWatcher).overflow) == 0 {
 		select {
-		case <-w.Findings():
-			drained++
+		case <-tick.C:
 		case <-deadline:
-			t.Fatal("timeout: no findings arrived (channel full test)")
+			t.Fatal("timeout: saturation did not reach the overflow lane")
 		}
 	}
+	drained := 0
 	// Drain remaining without blocking.
 	for {
 		select {
@@ -1185,6 +1396,12 @@ func TestWatcher_FindingsChannelFull(t *testing.T) {
 	}
 done:
 	_ = drained // at least 1 guaranteed by waitLoop above
+	select {
+	case <-w.(*fsWatcher).OverflowFindings():
+		// Saturation was visible instead of silently dropping every overflow.
+	default:
+		t.Fatal("expected a finding on the overflow lane")
+	}
 }
 
 func TestWatcher_PermissionDeniedSubdir(t *testing.T) {


### PR DESCRIPTION
## Summary

- preserve agent-attributed findings when delivery channels are saturated
- flush pending and in-flight scans safely during shutdown
- make long-lived file-sentry consumers drain the priority lane

## Why

A full delivery channel could hide file-sentry results and prevent block enforcement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an overflow findings lane so excess detections are retained and can be consumed later.
* **Bug Fixes**
  * Findings are no longer dropped when the primary delivery channel is saturated; overflow results are surfaced reliably.
  * Agent-related overflow findings now follow block-mode replacement/cancel behavior (cancel triggered exactly once).
  * Closing the watcher now waits for any in-progress debounce scan to finish before completing shutdown.
* **Tests**
  * Expanded coverage for overflow lane behavior, replacement/coalescing priority, non-blocking overflow sends, and close timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->