### PR TITLE
fix: warn on provider opaque GitHub token matches

### DIFF
--- a/internal/config/dlp_patterns.go
+++ b/internal/config/dlp_patterns.go
@@ -34,6 +34,8 @@ var defaultDLPPatternSet = []DLPPattern{
 	{Name: "Stripe Webhook Secret", Regex: `whsec_[a-zA-Z0-9_\-]{20,}`, Severity: SeverityCritical},
 
 	// Source control tokens
+	// GitHub tokens are base64url-ish after a short "gh?_"/"github_pat_"
+	// prefix. Keep these unanchored so glued-key exfiltration still matches.
 	{Name: "GitHub Token", Regex: `gh[pousr]_[A-Za-z0-9_]{36,}`, Severity: SeverityCritical},
 	{Name: "GitHub Fine-Grained PAT", Regex: `github_pat_[a-zA-Z0-9_]{36,}`, Severity: SeverityCritical},
 	// GitLab personal access tokens: "glpat-" prefix, 20+ chars.

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -403,7 +403,7 @@ func shouldHardBlockCriticalDLP(matches []scanner.TextDLPMatch, enforceEnabled b
 		return false
 	}
 	for _, match := range matches {
-		if match.Warn {
+		if match.Warn || match.ProviderOpaque {
 			continue
 		}
 		if strings.EqualFold(match.Severity, config.SeverityCritical) {
@@ -418,7 +418,7 @@ func shouldHardBlockRequestDLP(matches []scanner.TextDLPMatch, cfg *config.Confi
 		return false
 	}
 	for _, match := range matches {
-		if match.Warn {
+		if match.Warn || match.ProviderOpaque {
 			continue
 		}
 		if !strings.EqualFold(match.Severity, config.SeverityCritical) {
@@ -631,16 +631,17 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 		}
 	}
 
-	// Extract text strings from body based on content type.
-	texts, parseErr := extractBodyText(buf, req)
-	if parseErr != "" {
-		// Multipart limit exceeded: fail-closed block.
+	// Extract text strings from body based on content type. The DLP extractor
+	// also returns generic ordered text so JSON bodies are traversed once here.
+	dlpExtracted := extractBodyTextForDLP(buf, req)
+	if dlpExtracted.Err != "" {
 		return nil, BodyScanResult{
 			Clean:  false,
 			Action: config.ActionBlock,
-			Reason: parseErr,
+			Reason: dlpExtracted.Err,
 		}
 	}
+	texts := dlpExtracted.GenericTexts
 
 	if len(texts) == 0 {
 		if len(preRedactionDLP) > 0 {
@@ -659,14 +660,6 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 	var action string
 
 	// Scan each extracted string individually (catches per-field encoded secrets).
-	dlpExtracted := extractBodyTextForDLP(buf, req)
-	if dlpExtracted.Err != "" {
-		return nil, BodyScanResult{
-			Clean:  false,
-			Action: config.ActionBlock,
-			Reason: dlpExtracted.Err,
-		}
-	}
 	disabledDLP := bodyDLPDisabledSet(req.DisablePatterns)
 	matches := scanBodyTextsForDLP(ctx, req.Scanner, dlpExtracted.Texts, req.suppressTarget(), req.Suppress, disabledDLP)
 	matches = append(matches, scanProviderOpaqueTextsForDLP(ctx, req.Scanner, dlpExtracted.ProviderOpaqueTexts, req.suppressTarget(), req.Suppress, disabledDLP)...)
@@ -764,6 +757,7 @@ type jsonBodyDLPFrame struct {
 }
 
 type bodyDLPTextExtraction struct {
+	GenericTexts        []string
 	Texts               []string
 	ProviderOpaqueTexts []string
 	Err                 string
@@ -773,27 +767,25 @@ func extractBodyTextForDLP(body []byte, req BodyScanRequest) bodyDLPTextExtracti
 	mediaType, _, _ := mime.ParseMediaType(req.ContentType)
 	if mediaType != contentTypeJSON && !strings.HasSuffix(mediaType, "+json") {
 		texts, errText := extractBodyText(body, req)
-		return bodyDLPTextExtraction{Texts: texts, Err: errText}
+		return bodyDLPTextExtraction{GenericTexts: texts, Texts: texts, Err: errText}
 	}
-	if !json.Valid(body) {
-		return bodyDLPTextExtraction{Err: "invalid JSON body"}
-	}
-	textStrings, providerOpaqueTexts, truncated, err := extractJSONBodyDLPStrings(body, req)
+	textStrings, providerOpaqueTexts, genericTexts, truncated, err := extractJSONBodyDLPStrings(body, req)
 	if err != nil {
 		return bodyDLPTextExtraction{Err: err.Error()}
 	}
 	if truncated {
 		return bodyDLPTextExtraction{Err: "JSON body exceeds maximum inspectable nesting depth"}
 	}
-	return bodyDLPTextExtraction{Texts: textStrings, ProviderOpaqueTexts: providerOpaqueTexts}
+	return bodyDLPTextExtraction{GenericTexts: genericTexts, Texts: textStrings, ProviderOpaqueTexts: providerOpaqueTexts}
 }
 
-func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []string, bool, error) {
+func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []string, []string, bool, error) {
 	dec := json.NewDecoder(bytes.NewReader(body))
 	dec.UseNumber()
 
 	var result []string
 	var providerOpaque []string
+	var generic []string
 	var stack []jsonBodyDLPFrame
 	depth := 0
 	truncated := false
@@ -801,10 +793,13 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 	for {
 		tok, err := dec.Token()
 		if err == io.EOF {
+			if depth > 0 || len(stack) > 0 {
+				return nil, nil, nil, false, fmt.Errorf("decoding JSON body for DLP: %w", io.ErrUnexpectedEOF)
+			}
 			break
 		}
 		if err != nil {
-			return nil, nil, false, fmt.Errorf("decoding JSON body for DLP: %w", err)
+			return nil, nil, nil, false, fmt.Errorf("decoding JSON body for DLP: %w", err)
 		}
 
 		switch v := tok.(type) {
@@ -833,12 +828,14 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 			if len(stack) > 0 && stack[len(stack)-1].kind == '{' && stack[len(stack)-1].expectKey {
 				if depth <= extractJSONMaxDepth {
 					result = append(result, v)
+					generic = append(generic, v)
 				}
 				stack[len(stack)-1].currentKey = v
 				stack[len(stack)-1].expectKey = false
 				continue
 			}
 			if depth <= extractJSONMaxDepth {
+				generic = append(generic, v)
 				if isTrustedProviderOpaqueDLPField(req, currentJSONBodyDLPPath(stack), v) {
 					providerOpaque = append(providerOpaque, v)
 				} else {
@@ -848,19 +845,23 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 			markJSONBodyDLPValueConsumed(stack)
 		case json.Number:
 			if depth <= extractJSONMaxDepth {
-				result = append(result, v.String())
+				text := v.String()
+				result = append(result, text)
+				generic = append(generic, text)
 			}
 			markJSONBodyDLPValueConsumed(stack)
 		case bool:
 			if depth <= extractJSONMaxDepth {
-				result = append(result, strconv.FormatBool(v))
+				text := strconv.FormatBool(v)
+				result = append(result, text)
+				generic = append(generic, text)
 			}
 			markJSONBodyDLPValueConsumed(stack)
 		case nil:
 			markJSONBodyDLPValueConsumed(stack)
 		}
 	}
-	return result, providerOpaque, truncated, nil
+	return result, providerOpaque, generic, truncated, nil
 }
 
 const extractJSONMaxDepth = 64
@@ -994,7 +995,7 @@ func scanProviderOpaqueTextsForDLP(ctx context.Context, sc *scanner.Scanner, tex
 	}
 	matches := scanBodyTextsForDLP(ctx, sc, texts, target, suppress, disabled)
 	for i := range matches {
-		matches[i].Warn = true
+		matches[i].ProviderOpaque = true
 	}
 	return matches
 }
@@ -1049,7 +1050,7 @@ func uniqueBodyDLPMatches(matches []scanner.TextDLPMatch) []scanner.TextDLPMatch
 	seen := make(map[string]struct{}, len(matches))
 	unique := make([]scanner.TextDLPMatch, 0, len(matches))
 	for _, match := range matches {
-		key := match.PatternName + "\x00" + match.Encoded
+		key := match.PatternName + "\x00" + match.Encoded + "\x00" + strconv.FormatBool(match.Warn) + "\x00" + strconv.FormatBool(match.ProviderOpaque)
 		if _, ok := seen[key]; ok {
 			continue
 		}
@@ -1062,7 +1063,7 @@ func uniqueBodyDLPMatches(matches []scanner.TextDLPMatch) []scanner.TextDLPMatch
 func requestBodyDLPAction(matches []scanner.TextDLPMatch, defaultAction string, patternActions map[string]string) string {
 	action := ""
 	for _, match := range matches {
-		if match.Warn {
+		if match.ProviderOpaque {
 			action = config.StrongestAction(action, config.ActionWarn)
 			continue
 		}

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -19,6 +19,7 @@ import (
 	"net/textproto"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -577,9 +578,11 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 
 	var preRedactionDLP []scanner.TextDLPMatch
 	if req.RedactMatcher != nil {
-		texts, parseErr := extractBodyText(buf, req)
-		if parseErr == "" {
-			preRedactionDLP = scanBodyTextsForDLP(ctx, req.Scanner, texts, req.suppressTarget(), req.Suppress, bodyDLPDisabledSet(req.DisablePatterns))
+		extracted := extractBodyTextForDLP(buf, req)
+		if extracted.Err == "" {
+			disabled := bodyDLPDisabledSet(req.DisablePatterns)
+			preRedactionDLP = scanBodyTextsForDLP(ctx, req.Scanner, extracted.Texts, req.suppressTarget(), req.Suppress, disabled)
+			preRedactionDLP = append(preRedactionDLP, scanProviderOpaqueTextsForDLP(ctx, req.Scanner, extracted.ProviderOpaqueTexts, req.suppressTarget(), req.Suppress, disabled)...)
 		}
 	}
 
@@ -656,7 +659,18 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 	var action string
 
 	// Scan each extracted string individually (catches per-field encoded secrets).
-	matches := scanBodyTextsForDLP(ctx, req.Scanner, texts, req.suppressTarget(), req.Suppress, bodyDLPDisabledSet(req.DisablePatterns))
+	dlpExtracted := extractBodyTextForDLP(buf, req)
+	if dlpExtracted.Err != "" {
+		return nil, BodyScanResult{
+			Clean:  false,
+			Action: config.ActionBlock,
+			Reason: dlpExtracted.Err,
+		}
+	}
+	disabledDLP := bodyDLPDisabledSet(req.DisablePatterns)
+	matches := scanBodyTextsForDLP(ctx, req.Scanner, dlpExtracted.Texts, req.suppressTarget(), req.Suppress, disabledDLP)
+	matches = append(matches, scanProviderOpaqueTextsForDLP(ctx, req.Scanner, dlpExtracted.ProviderOpaqueTexts, req.suppressTarget(), req.Suppress, disabledDLP)...)
+	matches = uniqueBodyDLPMatches(matches)
 	if len(matches) > 0 {
 		result.DLPMatches = matches
 		action = config.StrongestAction(action, requestBodyDLPAction(matches, req.Action, req.PatternActions))
@@ -740,6 +754,201 @@ func scanBodyTextsForContentEntropy(texts []string, req BodyScanRequest) *Conten
 	})
 }
 
+const providerOpaqueCiphertextMinBytes = 256
+
+type jsonBodyDLPFrame struct {
+	kind       json.Delim
+	expectKey  bool
+	currentKey string
+	path       []string
+}
+
+type bodyDLPTextExtraction struct {
+	Texts               []string
+	ProviderOpaqueTexts []string
+	Err                 string
+}
+
+func extractBodyTextForDLP(body []byte, req BodyScanRequest) bodyDLPTextExtraction {
+	mediaType, _, _ := mime.ParseMediaType(req.ContentType)
+	if mediaType != contentTypeJSON && !strings.HasSuffix(mediaType, "+json") {
+		texts, errText := extractBodyText(body, req)
+		return bodyDLPTextExtraction{Texts: texts, Err: errText}
+	}
+	if !json.Valid(body) {
+		return bodyDLPTextExtraction{Err: "invalid JSON body"}
+	}
+	textStrings, providerOpaqueTexts, truncated, err := extractJSONBodyDLPStrings(body, req)
+	if err != nil {
+		return bodyDLPTextExtraction{Err: err.Error()}
+	}
+	if truncated {
+		return bodyDLPTextExtraction{Err: "JSON body exceeds maximum inspectable nesting depth"}
+	}
+	return bodyDLPTextExtraction{Texts: textStrings, ProviderOpaqueTexts: providerOpaqueTexts}
+}
+
+func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []string, bool, error) {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+
+	var result []string
+	var providerOpaque []string
+	var stack []jsonBodyDLPFrame
+	depth := 0
+	truncated := false
+
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("decoding JSON body for DLP: %w", err)
+		}
+
+		switch v := tok.(type) {
+		case json.Delim:
+			switch v {
+			case '{', '[':
+				depth++
+				if depth > extractJSONMaxDepth {
+					truncated = true
+				}
+				stack = append(stack, jsonBodyDLPFrame{
+					kind:      v,
+					expectKey: v == '{',
+					path:      currentJSONBodyDLPPath(stack),
+				})
+			case '}', ']':
+				if len(stack) > 0 {
+					stack = stack[:len(stack)-1]
+				}
+				if depth > 0 {
+					depth--
+				}
+				markJSONBodyDLPValueConsumed(stack)
+			}
+		case string:
+			if len(stack) > 0 && stack[len(stack)-1].kind == '{' && stack[len(stack)-1].expectKey {
+				if depth <= extractJSONMaxDepth {
+					result = append(result, v)
+				}
+				stack[len(stack)-1].currentKey = v
+				stack[len(stack)-1].expectKey = false
+				continue
+			}
+			if depth <= extractJSONMaxDepth {
+				if isTrustedProviderOpaqueDLPField(req, currentJSONBodyDLPPath(stack), v) {
+					providerOpaque = append(providerOpaque, v)
+				} else {
+					result = append(result, v)
+				}
+			}
+			markJSONBodyDLPValueConsumed(stack)
+		case json.Number:
+			if depth <= extractJSONMaxDepth {
+				result = append(result, v.String())
+			}
+			markJSONBodyDLPValueConsumed(stack)
+		case bool:
+			if depth <= extractJSONMaxDepth {
+				result = append(result, strconv.FormatBool(v))
+			}
+			markJSONBodyDLPValueConsumed(stack)
+		case nil:
+			markJSONBodyDLPValueConsumed(stack)
+		}
+	}
+	return result, providerOpaque, truncated, nil
+}
+
+const extractJSONMaxDepth = 64
+
+func currentJSONBodyDLPPath(stack []jsonBodyDLPFrame) []string {
+	if len(stack) == 0 {
+		return nil
+	}
+	top := stack[len(stack)-1]
+	path := append([]string(nil), top.path...)
+	if top.kind == '{' && top.currentKey != "" {
+		path = append(path, top.currentKey)
+	}
+	return path
+}
+
+func markJSONBodyDLPValueConsumed(stack []jsonBodyDLPFrame) {
+	if len(stack) == 0 {
+		return
+	}
+	top := &stack[len(stack)-1]
+	if top.kind == '{' {
+		top.expectKey = true
+		top.currentKey = ""
+	}
+}
+
+func isTrustedProviderOpaqueDLPField(req BodyScanRequest, path []string, value string) bool {
+	if !isTrustedOpenAIRequest(req.Host, req.Path) || !isOpenAIOpaqueReasoningFieldPath(path) {
+		return false
+	}
+	return isProviderOpaqueCiphertext(value)
+}
+
+func isTrustedOpenAIRequest(host, path string) bool {
+	host = canonicalBodyScanHost(host)
+	switch host {
+	case "api.openai.com":
+		return strings.HasPrefix(path, "/v1/responses") || strings.HasPrefix(path, "/v1/chat/completions")
+	case "chatgpt.com":
+		return strings.HasPrefix(path, "/backend-api/codex/responses")
+	default:
+		return false
+	}
+}
+
+func canonicalBodyScanHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.TrimSuffix(host, ".")
+}
+
+func isOpenAIOpaqueReasoningFieldPath(path []string) bool {
+	if len(path) == 0 || path[len(path)-1] != "encrypted_content" {
+		return false
+	}
+	return pathContainsJSONKey(path, "content") && (pathContainsJSONKey(path, "input") || pathContainsJSONKey(path, "messages"))
+}
+
+func pathContainsJSONKey(path []string, key string) bool {
+	for _, part := range path {
+		if part == key {
+			return true
+		}
+	}
+	return false
+}
+
+func isProviderOpaqueCiphertext(value string) bool {
+	if len(value) < providerOpaqueCiphertextMinBytes {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		b := value[i]
+		switch {
+		case b >= 'a' && b <= 'z':
+		case b >= 'A' && b <= 'Z':
+		case b >= '0' && b <= '9':
+		case b == '_' || b == '-' || b == '=' || b == '+' || b == '/' || b == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 func contentEntropyReason(f *ContentEntropyFinding) string {
 	return contententropy.Reason(f)
 }
@@ -777,6 +986,17 @@ func scanBodyTextsForDLP(ctx context.Context, sc *scanner.Scanner, texts []strin
 		}
 	}
 	return uniqueBodyDLPMatches(allMatches)
+}
+
+func scanProviderOpaqueTextsForDLP(ctx context.Context, sc *scanner.Scanner, texts []string, target string, suppress []config.SuppressEntry, disabled map[string]struct{}) []scanner.TextDLPMatch {
+	if len(texts) == 0 {
+		return nil
+	}
+	matches := scanBodyTextsForDLP(ctx, sc, texts, target, suppress, disabled)
+	for i := range matches {
+		matches[i].Warn = true
+	}
+	return matches
 }
 
 func (req BodyScanRequest) suppressTarget() string {
@@ -842,6 +1062,10 @@ func uniqueBodyDLPMatches(matches []scanner.TextDLPMatch) []scanner.TextDLPMatch
 func requestBodyDLPAction(matches []scanner.TextDLPMatch, defaultAction string, patternActions map[string]string) string {
 	action := ""
 	for _, match := range matches {
+		if match.Warn {
+			action = config.StrongestAction(action, config.ActionWarn)
+			continue
+		}
 		matchAction := defaultAction
 		if override := patternActions[match.PatternName]; override != "" && !config.IsCoreDLPPatternName(match.PatternName) {
 			matchAction = override

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -515,6 +515,9 @@ type BodyScanRequest struct {
 	Host string
 	// Path is the upstream request path, used for provider parser selection.
 	Path string
+	// TrustedProviderOpaqueRequest overrides provider-opaque request recognition.
+	// Nil uses the production OpenAI/ChatGPT host and path allowlist.
+	TrustedProviderOpaqueRequest func(host, path string) bool
 	// Target is the full request URL used to evaluate scoped suppress rules.
 	// When empty, Host/Path are joined into a best-effort target.
 	Target string
@@ -789,11 +792,16 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 	var stack []jsonBodyDLPFrame
 	depth := 0
 	truncated := false
+	rootStarted := false
+	rootComplete := false
 
 	for {
 		tok, err := dec.Token()
 		if err == io.EOF {
-			if depth > 0 || len(stack) > 0 {
+			if !rootStarted {
+				return nil, nil, nil, false, fmt.Errorf("decoding JSON body for DLP: empty JSON body")
+			}
+			if depth > 0 || len(stack) > 0 || !rootComplete {
 				return nil, nil, nil, false, fmt.Errorf("decoding JSON body for DLP: %w", io.ErrUnexpectedEOF)
 			}
 			break
@@ -801,6 +809,10 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 		if err != nil {
 			return nil, nil, nil, false, fmt.Errorf("decoding JSON body for DLP: %w", err)
 		}
+		if rootComplete {
+			return nil, nil, nil, false, fmt.Errorf("decoding JSON body for DLP: multiple JSON values")
+		}
+		rootStarted = true
 
 		switch v := tok.(type) {
 		case json.Delim:
@@ -821,6 +833,9 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 				}
 				if depth > 0 {
 					depth--
+				}
+				if depth == 0 {
+					rootComplete = true
 				}
 				markJSONBodyDLPValueConsumed(stack)
 			}
@@ -843,6 +858,9 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 				}
 			}
 			markJSONBodyDLPValueConsumed(stack)
+			if depth == 0 {
+				rootComplete = true
+			}
 		case json.Number:
 			if depth <= extractJSONMaxDepth {
 				text := v.String()
@@ -850,6 +868,9 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 				generic = append(generic, text)
 			}
 			markJSONBodyDLPValueConsumed(stack)
+			if depth == 0 {
+				rootComplete = true
+			}
 		case bool:
 			if depth <= extractJSONMaxDepth {
 				text := strconv.FormatBool(v)
@@ -857,8 +878,14 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 				generic = append(generic, text)
 			}
 			markJSONBodyDLPValueConsumed(stack)
+			if depth == 0 {
+				rootComplete = true
+			}
 		case nil:
 			markJSONBodyDLPValueConsumed(stack)
+			if depth == 0 {
+				rootComplete = true
+			}
 		}
 	}
 	return result, providerOpaque, generic, truncated, nil
@@ -890,7 +917,11 @@ func markJSONBodyDLPValueConsumed(stack []jsonBodyDLPFrame) {
 }
 
 func isTrustedProviderOpaqueDLPField(req BodyScanRequest, path []string, value string) bool {
-	if !isTrustedOpenAIRequest(req.Host, req.Path) || !isOpenAIOpaqueReasoningFieldPath(path) {
+	trustedRequest := req.TrustedProviderOpaqueRequest
+	if trustedRequest == nil {
+		trustedRequest = isTrustedOpenAIRequest
+	}
+	if !trustedRequest(req.Host, req.Path) || !isOpenAIOpaqueReasoningFieldPath(path) {
 		return false
 	}
 	return isProviderOpaqueCiphertext(value)

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -28,15 +28,13 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contententropy"
-	"github.com/luckyPipewrench/pipelock/internal/extract"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
 const (
 	// contentTypeJSON is the canonical JSON media type. Used in multiple
-	// places (redaction content-type gate, existing body-text extract
-	// path); extracted to satisfy goconst.
+	// redaction and body-text extraction gates; extracted to satisfy goconst.
 	contentTypeJSON = "application/json"
 
 	// maxMultipartParts caps the number of multipart form parts parsed.
@@ -582,6 +580,9 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 	var preRedactionDLP []scanner.TextDLPMatch
 	if req.RedactMatcher != nil {
 		extracted := extractBodyTextForDLP(buf, req)
+		// Do not scan partial pre-redaction extraction results. Redaction and
+		// the mandatory post-redaction extraction below both fail closed when
+		// this body cannot be parsed.
 		if extracted.Err == "" {
 			disabled := bodyDLPDisabledSet(req.DisablePatterns)
 			preRedactionDLP = scanBodyTextsForDLP(ctx, req.Scanner, extracted.Texts, req.suppressTarget(), req.Suppress, disabled)
@@ -912,16 +913,28 @@ func isTrustedProviderOpaqueDLPField(req BodyScanRequest, path []string, value s
 	if !trustedRequest(req.Host, req.Path) || !isOpenAIOpaqueReasoningFieldPath(path) {
 		return false
 	}
+	// The provider does not expose a local MAC or structural verifier for this
+	// ciphertext. The downgrade therefore relies on the trusted endpoint,
+	// expected field path, ciphertext alphabet, and size floor. A deliberately
+	// padded secret can still be warn-capped; callers must preserve provenance
+	// and must not widen any of these gates.
 	return isProviderOpaqueCiphertext(value)
+}
+
+func trustedProviderPathMatch(path, endpoint string) bool {
+	return path == endpoint ||
+		strings.HasPrefix(path, endpoint+"/") ||
+		strings.HasPrefix(path, endpoint+"?")
 }
 
 func isTrustedOpenAIRequest(host, path string) bool {
 	host = canonicalBodyScanHost(host)
 	switch host {
 	case "api.openai.com":
-		return strings.HasPrefix(path, "/v1/responses") || strings.HasPrefix(path, "/v1/chat/completions")
+		return trustedProviderPathMatch(path, "/v1/responses") ||
+			trustedProviderPathMatch(path, "/v1/chat/completions")
 	case "chatgpt.com":
-		return strings.HasPrefix(path, "/backend-api/codex/responses")
+		return trustedProviderPathMatch(path, "/backend-api/codex/responses")
 	default:
 		return false
 	}
@@ -1316,16 +1329,6 @@ func extractBodyText(body []byte, req BodyScanRequest) ([]string, string) {
 	mediaType, params, _ := mime.ParseMediaType(req.ContentType)
 
 	switch {
-	case mediaType == contentTypeJSON || strings.HasSuffix(mediaType, "+json"):
-		if !json.Valid(body) {
-			return nil, "invalid JSON body"
-		}
-		extracted := extract.AllStringsFromJSONOrderedResult(json.RawMessage(body))
-		if extracted.Truncated {
-			return nil, "JSON body exceeds maximum inspectable nesting depth"
-		}
-		return extracted.Strings, ""
-
 	case mediaType == "application/x-www-form-urlencoded":
 		return extractFormURLEncoded(body)
 

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -834,9 +834,6 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 				if depth > 0 {
 					depth--
 				}
-				if depth == 0 {
-					rootComplete = true
-				}
 				markJSONBodyDLPValueConsumed(stack)
 			}
 		case string:
@@ -858,9 +855,6 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 				}
 			}
 			markJSONBodyDLPValueConsumed(stack)
-			if depth == 0 {
-				rootComplete = true
-			}
 		case json.Number:
 			if depth <= extractJSONMaxDepth {
 				text := v.String()
@@ -868,9 +862,6 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 				generic = append(generic, text)
 			}
 			markJSONBodyDLPValueConsumed(stack)
-			if depth == 0 {
-				rootComplete = true
-			}
 		case bool:
 			if depth <= extractJSONMaxDepth {
 				text := strconv.FormatBool(v)
@@ -878,14 +869,11 @@ func extractJSONBodyDLPStrings(body []byte, req BodyScanRequest) ([]string, []st
 				generic = append(generic, text)
 			}
 			markJSONBodyDLPValueConsumed(stack)
-			if depth == 0 {
-				rootComplete = true
-			}
 		case nil:
 			markJSONBodyDLPValueConsumed(stack)
-			if depth == 0 {
-				rootComplete = true
-			}
+		}
+		if depth == 0 {
+			rootComplete = true
 		}
 	}
 	return result, providerOpaque, generic, truncated, nil

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -1583,6 +1583,127 @@ func TestExtractBodyTextForDLP_ProviderOpaqueWrongValueShapeScansNormally(t *tes
 	}
 }
 
+func TestScanRequestBody_ProviderOpaqueDowngradeGates(t *testing.T) {
+	cfg := testScannerConfig()
+
+	opaqueValue := func(totalBytes int) string {
+		t.Helper()
+		suffix := "." + fakeGitHubToken() + "."
+		if totalBytes < len(suffix) {
+			t.Fatalf("test ciphertext length %d is smaller than suffix %d", totalBytes, len(suffix))
+		}
+		value := strings.Repeat("A", totalBytes-len(suffix)) + suffix
+		if len(value) != totalBytes {
+			t.Fatalf("ciphertext length = %d, want %d", len(value), totalBytes)
+		}
+		return value
+	}
+
+	tests := []struct {
+		name           string
+		host           string
+		path           string
+		valueBytes     int
+		useDefaultGate bool
+		wantWarn       bool
+	}{
+		{
+			name:       "trusted host non-allowlisted path blocks",
+			host:       testTrustedProviderHost,
+			path:       "/v1/provider/other",
+			valueBytes: providerOpaqueCiphertextMinBytes,
+		},
+		{
+			name:       "255 byte value blocks",
+			host:       testTrustedProviderHost,
+			path:       testTrustedProviderPath,
+			valueBytes: providerOpaqueCiphertextMinBytes - 1,
+		},
+		{
+			name:       "256 byte value warns",
+			host:       testTrustedProviderHost,
+			path:       testTrustedProviderPath,
+			valueBytes: providerOpaqueCiphertextMinBytes,
+			wantWarn:   true,
+		},
+		{
+			name:           "nil gate uses production allowlist",
+			host:           "api.openai.com",
+			path:           "/v1/responses",
+			valueBytes:     providerOpaqueCiphertextMinBytes,
+			useDefaultGate: true,
+			wantWarn:       true,
+		},
+		{
+			name:           "nil gate rejects sibling endpoint",
+			host:           "api.openai.com",
+			path:           "/v1/responsesfoo",
+			valueBytes:     providerOpaqueCiphertextMinBytes,
+			useDefaultGate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := scanner.MustNew(cfg)
+			defer sc.Close()
+
+			value := opaqueValue(tt.valueBytes)
+			body := `{"input":[{"content":[{"type":"reasoning","encrypted_content":"` + value + `"}]}]}`
+			req := BodyScanRequest{
+				Body:        strings.NewReader(body),
+				ContentType: contentTypeJSON,
+				Host:        tt.host,
+				Path:        tt.path,
+				MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+				Scanner:     sc,
+				Action:      cfg.RequestBodyScanning.Action,
+			}
+			if !tt.useDefaultGate {
+				req.TrustedProviderOpaqueRequest = testTrustedProviderOpaqueRequest
+			}
+
+			_, result := scanRequestBody(context.Background(), req)
+			if result.Clean {
+				t.Fatal("expected GitHub token finding")
+			}
+			if tt.wantWarn {
+				if result.Action != config.ActionWarn {
+					t.Fatalf("Action = %q, want warn; matches=%+v", result.Action, result.DLPMatches)
+				}
+				if len(result.DLPMatches) == 0 || !result.DLPMatches[0].ProviderOpaque {
+					t.Fatalf("matches = %+v, want provider-opaque provenance", result.DLPMatches)
+				}
+				return
+			}
+			assertBodyDLPBlocksWithoutProviderOpaque(t, result, tt.name)
+		})
+	}
+}
+
+func TestTrustedProviderPathMatch(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "exact", path: "/v1/responses", want: true},
+		{name: "subpath", path: "/v1/responses/compact", want: true},
+		{name: "query", path: "/v1/responses?stream=true", want: true},
+		{name: "sibling", path: "/v1/responsesfoo"},
+		{name: "prefix only", path: "/v1/response"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := trustedProviderPathMatch(tt.path, "/v1/responses"); got != tt.want {
+				t.Fatalf("trustedProviderPathMatch(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExtractBodyTextForDLP_JSONErrorsFailClosed(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -1413,19 +1413,19 @@ func TestScanRequestBody_JSONImageDataURLWithoutImageMagicStillScansPayloadText(
 	}
 }
 
-func TestScanRequestBody_ModelProviderOpaqueReasoningFieldsStillScanned(t *testing.T) {
+func TestScanRequestBody_ModelProviderOpaqueReasoningFieldEmbeddedTokenSubstringWarns(t *testing.T) {
 	cfg := testScannerConfig()
 	sc := scanner.MustNew(cfg)
 	defer sc.Close()
 
-	token := "fw_" + strings.Repeat("A", 22)
+	token := fakeGitHubToken()
+	ciphertext := strings.Repeat("A", 260) + "." + token + "." + strings.Repeat("B", 260)
 	body := `{
 		"input": [{
 			"role": "assistant",
 			"content": [{
 				"type": "reasoning",
-				"encrypted_content": "` + token + `",
-				"thinkingSignature": "{\"encrypted_content\":\"` + token + `\"}"
+				"encrypted_content": "` + ciphertext + `"
 			}]
 		}]
 	}`
@@ -1439,10 +1439,21 @@ func TestScanRequestBody_ModelProviderOpaqueReasoningFieldsStillScanned(t *testi
 		Scanner:     sc,
 	})
 	if result.Clean {
-		t.Fatal("expected DLP match in provider opaque reasoning fields")
+		t.Fatal("expected embedded token-shaped substring in opaque provider field to stay visible as warn")
+	}
+	if result.Action != config.ActionWarn {
+		t.Fatalf("expected warn action for provider opaque field, got action=%q matches=%v reason=%q", result.Action, result.DLPMatches, result.Reason)
 	}
 	if len(result.DLPMatches) == 0 {
-		t.Fatal("expected non-empty DLP matches")
+		t.Fatal("expected provider opaque field DLP matches to remain visible")
+	}
+	for _, match := range result.DLPMatches {
+		if !match.Warn {
+			t.Fatalf("expected provider opaque field match to be warn-only, got %+v", match)
+		}
+	}
+	if shouldHardBlockBodyCriticalDLP(result, "chatgpt.com", cfg) {
+		t.Fatal("provider opaque field warn-only match must not hard-block")
 	}
 }
 
@@ -1471,7 +1482,7 @@ func TestScanRequestBody_OpaqueReasoningFieldNamesDoNotBypassOtherHosts(t *testi
 	sc := scanner.MustNew(cfg)
 	defer sc.Close()
 
-	body := `{"encrypted_content":"` + "fw_" + strings.Repeat("A", 22) + `"}`
+	body := `{"encrypted_content":"` + strings.Repeat("A", 260) + "." + fakeGitHubToken() + "." + strings.Repeat("B", 260) + `"}`
 
 	_, result := scanRequestBody(context.Background(), BodyScanRequest{
 		Body:        strings.NewReader(body),
@@ -1482,8 +1493,82 @@ func TestScanRequestBody_OpaqueReasoningFieldNamesDoNotBypassOtherHosts(t *testi
 		Scanner:     sc,
 	})
 	if result.Clean {
-		t.Fatal("expected DLP match for opaque field name on non-provider host")
+		t.Fatal("expected real delimited token in opaque field name on non-provider host to block")
 	}
+}
+
+func TestScanRequestBody_OpenAITopLevelOpaqueFieldNameDoesNotBypassDLP(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	body := `{"encrypted_content":"` + strings.Repeat("A", 260) + "." + fakeGitHubToken() + "." + strings.Repeat("B", 260) + `"}`
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		Host:        "api.openai.com",
+		Path:        "/v1/responses",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+	})
+	if result.Clean {
+		t.Fatal("expected top-level encrypted_content to block outside provider reasoning schema")
+	}
+}
+
+func TestExtractBodyTextForDLP_ProviderOpaqueReasoningFieldSeparated(t *testing.T) {
+	ciphertext := strings.Repeat("A", 260) + "." + fakeGitHubToken() + "." + strings.Repeat("B", 260)
+	body := []byte(`{"input":[{"content":[{"type":"reasoning","encrypted_content":"` + ciphertext + `"}]}]}`)
+
+	extracted := extractBodyTextForDLP(body, BodyScanRequest{
+		ContentType: "application/json",
+		Host:        "CHATGPT.COM:443",
+		Path:        "/backend-api/codex/responses",
+	})
+	if extracted.Err != "" {
+		t.Fatalf("Err = %q", extracted.Err)
+	}
+	if len(extracted.ProviderOpaqueTexts) != 1 || extracted.ProviderOpaqueTexts[0] != ciphertext {
+		t.Fatalf("ProviderOpaqueTexts = %#v, want ciphertext", extracted.ProviderOpaqueTexts)
+	}
+	for _, text := range extracted.Texts {
+		if text == ciphertext {
+			t.Fatalf("ciphertext should be separated from normal DLP texts: %#v", extracted.Texts)
+		}
+	}
+	if !bodyScanTestStringsContain(extracted.Texts, "encrypted_content") {
+		t.Fatalf("expected JSON keys to remain scannable, got %#v", extracted.Texts)
+	}
+}
+
+func TestExtractBodyTextForDLP_ProviderOpaqueWrongValueShapeScansNormally(t *testing.T) {
+	value := strings.Repeat("A", 260) + ":" + fakeGitHubToken()
+	body := []byte(`{"input":[{"content":[{"type":"reasoning","encrypted_content":"` + value + `"}]}]}`)
+
+	extracted := extractBodyTextForDLP(body, BodyScanRequest{
+		ContentType: "application/json",
+		Host:        "chatgpt.com",
+		Path:        "/backend-api/codex/responses",
+	})
+	if extracted.Err != "" {
+		t.Fatalf("Err = %q", extracted.Err)
+	}
+	if len(extracted.ProviderOpaqueTexts) != 0 {
+		t.Fatalf("ProviderOpaqueTexts = %#v, want none", extracted.ProviderOpaqueTexts)
+	}
+	if !bodyScanTestStringsContain(extracted.Texts, value) {
+		t.Fatalf("wrong-shape value should stay in normal DLP texts, got %#v", extracted.Texts)
+	}
+}
+
+func bodyScanTestStringsContain(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestScanRequestBody_CompressedGzip(t *testing.T) {

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -1448,8 +1448,11 @@ func TestScanRequestBody_ModelProviderOpaqueReasoningFieldEmbeddedTokenSubstring
 		t.Fatal("expected provider opaque field DLP matches to remain visible")
 	}
 	for _, match := range result.DLPMatches {
-		if !match.Warn {
-			t.Fatalf("expected provider opaque field match to be warn-only, got %+v", match)
+		if !match.ProviderOpaque {
+			t.Fatalf("expected provider opaque field match provenance, got %+v", match)
+		}
+		if match.Warn {
+			t.Fatalf("provider opaque provenance must not reuse scanner warn state: %+v", match)
 		}
 	}
 	if shouldHardBlockBodyCriticalDLP(result, "chatgpt.com", cfg) {
@@ -1491,10 +1494,12 @@ func TestScanRequestBody_OpaqueReasoningFieldNamesDoNotBypassOtherHosts(t *testi
 		Path:        "/collect",
 		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
 		Scanner:     sc,
+		Action:      cfg.RequestBodyScanning.Action,
 	})
 	if result.Clean {
 		t.Fatal("expected real delimited token in opaque field name on non-provider host to block")
 	}
+	assertBodyDLPBlocksWithoutProviderOpaque(t, result, "non-provider opaque field name")
 }
 
 func TestScanRequestBody_OpenAITopLevelOpaqueFieldNameDoesNotBypassDLP(t *testing.T) {
@@ -1511,10 +1516,12 @@ func TestScanRequestBody_OpenAITopLevelOpaqueFieldNameDoesNotBypassDLP(t *testin
 		Path:        "/v1/responses",
 		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
 		Scanner:     sc,
+		Action:      cfg.RequestBodyScanning.Action,
 	})
 	if result.Clean {
 		t.Fatal("expected top-level encrypted_content to block outside provider reasoning schema")
 	}
+	assertBodyDLPBlocksWithoutProviderOpaque(t, result, "top-level provider opaque field name")
 }
 
 func TestExtractBodyTextForDLP_ProviderOpaqueReasoningFieldSeparated(t *testing.T) {
@@ -1540,6 +1547,9 @@ func TestExtractBodyTextForDLP_ProviderOpaqueReasoningFieldSeparated(t *testing.
 	if !bodyScanTestStringsContain(extracted.Texts, "encrypted_content") {
 		t.Fatalf("expected JSON keys to remain scannable, got %#v", extracted.Texts)
 	}
+	if !bodyScanTestStringsContain(extracted.GenericTexts, ciphertext) {
+		t.Fatalf("generic texts should retain provider opaque value for non-DLP scans, got %#v", extracted.GenericTexts)
+	}
 }
 
 func TestExtractBodyTextForDLP_ProviderOpaqueWrongValueShapeScansNormally(t *testing.T) {
@@ -1562,6 +1572,109 @@ func TestExtractBodyTextForDLP_ProviderOpaqueWrongValueShapeScansNormally(t *tes
 	}
 }
 
+func TestExtractBodyTextForDLP_JSONErrorsFailClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		want string
+	}{
+		{
+			name: "malformed JSON",
+			body: []byte(`{"input":`),
+			want: "decoding JSON body for DLP",
+		},
+		{
+			name: "over-depth JSON",
+			body: []byte(deepProxyJSONObject("depth-regression-sentinel", extractJSONMaxDepth+1)),
+			want: "JSON body exceeds maximum inspectable nesting depth",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extracted := extractBodyTextForDLP(tt.body, BodyScanRequest{ContentType: "application/json"})
+			if extracted.Err == "" {
+				t.Fatal("Err = empty, want fail-closed extraction error")
+			}
+			if !strings.Contains(extracted.Err, tt.want) {
+				t.Fatalf("Err = %q, want to contain %q", extracted.Err, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanRequestBody_ProviderOpaqueAndNormalDLPBlockPrecedence(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	ciphertext := strings.Repeat("A", 260) + "." + fakeGitHubToken() + "." + strings.Repeat("B", 260)
+	body := `{
+		"input": [{
+			"content": [{
+				"type": "reasoning",
+				"encrypted_content": "` + ciphertext + `"
+			}]
+		}],
+		"normal_secret": "` + fakeAPIKey() + `"
+	}`
+
+	_, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:        strings.NewReader(body),
+		ContentType: "application/json",
+		Host:        "chatgpt.com",
+		Path:        "/backend-api/codex/responses",
+		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:     sc,
+		Action:      cfg.RequestBodyScanning.Action,
+	})
+	if result.Clean {
+		t.Fatal("expected mixed provider opaque and normal DLP matches")
+	}
+	if result.Action != config.ActionBlock {
+		t.Fatalf("Action = %q, want %q; matches=%v", result.Action, config.ActionBlock, result.DLPMatches)
+	}
+	if !hasDLPMatchName(result.DLPMatches, "AWS Access ID") {
+		t.Fatalf("DLPMatches = %v, want AWS Access ID normal match", dlpMatchNames(result.DLPMatches))
+	}
+	foundProviderOpaque := false
+	for _, match := range result.DLPMatches {
+		if match.ProviderOpaque {
+			foundProviderOpaque = true
+		}
+	}
+	if !foundProviderOpaque {
+		t.Fatalf("DLPMatches = %+v, want provider opaque provenance match", result.DLPMatches)
+	}
+	if !shouldHardBlockBodyCriticalDLP(result, "chatgpt.com", cfg) {
+		t.Fatal("normal critical DLP match must still hard-block when provider opaque match is warn-capped")
+	}
+}
+
+func TestUniqueBodyDLPMatches_PreservesProviderOpaqueAndEnforcedDuplicate(t *testing.T) {
+	matches := []scanner.TextDLPMatch{
+		{PatternName: "GitHub Token", Severity: config.SeverityCritical, Encoded: "raw", ProviderOpaque: true},
+		{PatternName: "GitHub Token", Severity: config.SeverityCritical, Encoded: "raw"},
+	}
+
+	got := uniqueBodyDLPMatches(matches)
+	if len(got) != 2 {
+		t.Fatalf("len(uniqueBodyDLPMatches) = %d, want 2; matches=%+v", len(got), got)
+	}
+	hasProviderOpaque := false
+	hasEnforced := false
+	for _, match := range got {
+		if match.ProviderOpaque {
+			hasProviderOpaque = true
+		} else {
+			hasEnforced = true
+		}
+	}
+	if !hasProviderOpaque || !hasEnforced {
+		t.Fatalf("uniqueBodyDLPMatches = %+v, want provider opaque and enforced copies", got)
+	}
+}
+
 func bodyScanTestStringsContain(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
@@ -1569,6 +1682,18 @@ func bodyScanTestStringsContain(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func assertBodyDLPBlocksWithoutProviderOpaque(t *testing.T, result BodyScanResult, label string) {
+	t.Helper()
+	if result.Action != config.ActionBlock {
+		t.Fatalf("%s Action = %q, want %q; matches=%v", label, result.Action, config.ActionBlock, result.DLPMatches)
+	}
+	for _, match := range result.DLPMatches {
+		if match.ProviderOpaque || match.Warn {
+			t.Fatalf("%s match outside provider schema must be enforceable, got %+v", label, match)
+		}
+	}
 }
 
 func TestScanRequestBody_CompressedGzip(t *testing.T) {

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -28,7 +28,9 @@ import (
 )
 
 const (
-	testMultipartBoundary = "----testboundary"
+	testMultipartBoundary   = "----testboundary"
+	testTrustedProviderHost = "api.vendor.example"
+	testTrustedProviderPath = "/v1/provider/responses"
 )
 
 // testScannerConfig returns a config suitable for body scan tests.
@@ -69,6 +71,10 @@ func addBodyDLPTestPattern(cfg *config.Config) {
 		Regex:    `REQDLPTEST-[A-Z0-9]{12}`,
 		Severity: config.SeverityCritical,
 	})
+}
+
+func testTrustedProviderOpaqueRequest(host, path string) bool {
+	return canonicalBodyScanHost(host) == testTrustedProviderHost && strings.HasPrefix(path, testTrustedProviderPath)
 }
 
 func opaqueHighEntropyBodyValue() string {
@@ -1431,12 +1437,13 @@ func TestScanRequestBody_ModelProviderOpaqueReasoningFieldEmbeddedTokenSubstring
 	}`
 
 	_, result := scanRequestBody(context.Background(), BodyScanRequest{
-		Body:        strings.NewReader(body),
-		ContentType: "application/json",
-		Host:        "chatgpt.com",
-		Path:        "/backend-api/codex/responses",
-		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
-		Scanner:     sc,
+		Body:                         strings.NewReader(body),
+		ContentType:                  "application/json",
+		Host:                         testTrustedProviderHost,
+		Path:                         testTrustedProviderPath,
+		MaxBytes:                     cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:                      sc,
+		TrustedProviderOpaqueRequest: testTrustedProviderOpaqueRequest,
 	})
 	if result.Clean {
 		t.Fatal("expected embedded token-shaped substring in opaque provider field to stay visible as warn")
@@ -1455,7 +1462,7 @@ func TestScanRequestBody_ModelProviderOpaqueReasoningFieldEmbeddedTokenSubstring
 			t.Fatalf("provider opaque provenance must not reuse scanner warn state: %+v", match)
 		}
 	}
-	if shouldHardBlockBodyCriticalDLP(result, "chatgpt.com", cfg) {
+	if shouldHardBlockBodyCriticalDLP(result, testTrustedProviderHost, cfg) {
 		t.Fatal("provider opaque field warn-only match must not hard-block")
 	}
 }
@@ -1468,12 +1475,13 @@ func TestScanRequestBody_ModelProviderStillScansPromptText(t *testing.T) {
 	body := `{"input":"leak ` + "fw_" + strings.Repeat("A", 22) + `"}`
 
 	_, result := scanRequestBody(context.Background(), BodyScanRequest{
-		Body:        strings.NewReader(body),
-		ContentType: "application/json",
-		Host:        "chatgpt.com",
-		Path:        "/backend-api/codex/responses",
-		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
-		Scanner:     sc,
+		Body:                         strings.NewReader(body),
+		ContentType:                  "application/json",
+		Host:                         testTrustedProviderHost,
+		Path:                         testTrustedProviderPath,
+		MaxBytes:                     cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:                      sc,
+		TrustedProviderOpaqueRequest: testTrustedProviderOpaqueRequest,
 	})
 	if result.Clean {
 		t.Fatal("expected DLP match in prompt text for model provider request")
@@ -1502,7 +1510,7 @@ func TestScanRequestBody_OpaqueReasoningFieldNamesDoNotBypassOtherHosts(t *testi
 	assertBodyDLPBlocksWithoutProviderOpaque(t, result, "non-provider opaque field name")
 }
 
-func TestScanRequestBody_OpenAITopLevelOpaqueFieldNameDoesNotBypassDLP(t *testing.T) {
+func TestScanRequestBody_ProviderTopLevelOpaqueFieldNameDoesNotBypassDLP(t *testing.T) {
 	cfg := testScannerConfig()
 	sc := scanner.MustNew(cfg)
 	defer sc.Close()
@@ -1510,13 +1518,14 @@ func TestScanRequestBody_OpenAITopLevelOpaqueFieldNameDoesNotBypassDLP(t *testin
 	body := `{"encrypted_content":"` + strings.Repeat("A", 260) + "." + fakeGitHubToken() + "." + strings.Repeat("B", 260) + `"}`
 
 	_, result := scanRequestBody(context.Background(), BodyScanRequest{
-		Body:        strings.NewReader(body),
-		ContentType: "application/json",
-		Host:        "api.openai.com",
-		Path:        "/v1/responses",
-		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
-		Scanner:     sc,
-		Action:      cfg.RequestBodyScanning.Action,
+		Body:                         strings.NewReader(body),
+		ContentType:                  "application/json",
+		Host:                         testTrustedProviderHost,
+		Path:                         testTrustedProviderPath,
+		MaxBytes:                     cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:                      sc,
+		Action:                       cfg.RequestBodyScanning.Action,
+		TrustedProviderOpaqueRequest: testTrustedProviderOpaqueRequest,
 	})
 	if result.Clean {
 		t.Fatal("expected top-level encrypted_content to block outside provider reasoning schema")
@@ -1529,9 +1538,10 @@ func TestExtractBodyTextForDLP_ProviderOpaqueReasoningFieldSeparated(t *testing.
 	body := []byte(`{"input":[{"content":[{"type":"reasoning","encrypted_content":"` + ciphertext + `"}]}]}`)
 
 	extracted := extractBodyTextForDLP(body, BodyScanRequest{
-		ContentType: "application/json",
-		Host:        "CHATGPT.COM:443",
-		Path:        "/backend-api/codex/responses",
+		ContentType:                  "application/json",
+		Host:                         "API.VENDOR.EXAMPLE:443",
+		Path:                         testTrustedProviderPath,
+		TrustedProviderOpaqueRequest: testTrustedProviderOpaqueRequest,
 	})
 	if extracted.Err != "" {
 		t.Fatalf("Err = %q", extracted.Err)
@@ -1557,9 +1567,10 @@ func TestExtractBodyTextForDLP_ProviderOpaqueWrongValueShapeScansNormally(t *tes
 	body := []byte(`{"input":[{"content":[{"type":"reasoning","encrypted_content":"` + value + `"}]}]}`)
 
 	extracted := extractBodyTextForDLP(body, BodyScanRequest{
-		ContentType: "application/json",
-		Host:        "chatgpt.com",
-		Path:        "/backend-api/codex/responses",
+		ContentType:                  "application/json",
+		Host:                         testTrustedProviderHost,
+		Path:                         testTrustedProviderPath,
+		TrustedProviderOpaqueRequest: testTrustedProviderOpaqueRequest,
 	})
 	if extracted.Err != "" {
 		t.Fatalf("Err = %q", extracted.Err)
@@ -1584,6 +1595,16 @@ func TestExtractBodyTextForDLP_JSONErrorsFailClosed(t *testing.T) {
 			want: "decoding JSON body for DLP",
 		},
 		{
+			name: "whitespace-only JSON",
+			body: []byte(`   `),
+			want: "empty JSON body",
+		},
+		{
+			name: "multiple-root JSON",
+			body: []byte(`{} {}`),
+			want: "multiple JSON values",
+		},
+		{
 			name: "over-depth JSON",
 			body: []byte(deepProxyJSONObject("depth-regression-sentinel", extractJSONMaxDepth+1)),
 			want: "JSON body exceeds maximum inspectable nesting depth",
@@ -1598,6 +1619,49 @@ func TestExtractBodyTextForDLP_JSONErrorsFailClosed(t *testing.T) {
 			}
 			if !strings.Contains(extracted.Err, tt.want) {
 				t.Fatalf("Err = %q, want to contain %q", extracted.Err, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanRequestBody_JSONRootValidationFailClosed(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "whitespace-only JSON",
+			body: `   `,
+			want: "empty JSON body",
+		},
+		{
+			name: "multiple-root JSON",
+			body: `{} {}`,
+			want: "multiple JSON values",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, result := scanRequestBody(context.Background(), BodyScanRequest{
+				Body:        strings.NewReader(tt.body),
+				ContentType: "application/json",
+				MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
+				Scanner:     sc,
+			})
+			if result.Clean {
+				t.Fatal("expected fail-closed block")
+			}
+			if result.Action != config.ActionBlock {
+				t.Fatalf("Action = %q, want %q", result.Action, config.ActionBlock)
+			}
+			if !strings.Contains(result.Reason, tt.want) {
+				t.Fatalf("Reason = %q, want to contain %q", result.Reason, tt.want)
 			}
 		})
 	}
@@ -1620,13 +1684,14 @@ func TestScanRequestBody_ProviderOpaqueAndNormalDLPBlockPrecedence(t *testing.T)
 	}`
 
 	_, result := scanRequestBody(context.Background(), BodyScanRequest{
-		Body:        strings.NewReader(body),
-		ContentType: "application/json",
-		Host:        "chatgpt.com",
-		Path:        "/backend-api/codex/responses",
-		MaxBytes:    cfg.RequestBodyScanning.MaxBodyBytes,
-		Scanner:     sc,
-		Action:      cfg.RequestBodyScanning.Action,
+		Body:                         strings.NewReader(body),
+		ContentType:                  "application/json",
+		Host:                         testTrustedProviderHost,
+		Path:                         testTrustedProviderPath,
+		MaxBytes:                     cfg.RequestBodyScanning.MaxBodyBytes,
+		Scanner:                      sc,
+		Action:                       cfg.RequestBodyScanning.Action,
+		TrustedProviderOpaqueRequest: testTrustedProviderOpaqueRequest,
 	})
 	if result.Clean {
 		t.Fatal("expected mixed provider opaque and normal DLP matches")
@@ -1646,7 +1711,7 @@ func TestScanRequestBody_ProviderOpaqueAndNormalDLPBlockPrecedence(t *testing.T)
 	if !foundProviderOpaque {
 		t.Fatalf("DLPMatches = %+v, want provider opaque provenance match", result.DLPMatches)
 	}
-	if !shouldHardBlockBodyCriticalDLP(result, "chatgpt.com", cfg) {
+	if !shouldHardBlockBodyCriticalDLP(result, testTrustedProviderHost, cfg) {
 		t.Fatal("normal critical DLP match must still hard-block when provider opaque match is warn-capped")
 	}
 }

--- a/internal/redact/classes.go
+++ b/internal/redact/classes.go
@@ -97,7 +97,7 @@ func tokenClasses() []classPattern {
 		{class: ClassAWSAccessKey, pattern: regexp.MustCompile(`\b(?:AKIA|ASIA|AIDA|AGPA|AROA)[A-Z0-9]{16}\b`), priority: 100, skipTrailing: sigV4CredentialScope, skipLeading: sigV4CredentialPrefix},
 		{class: ClassAWSSecretKey, pattern: regexp.MustCompile(`(?i)\b(?:aws_secret_access_key|secret.?access.?key|SecretAccessKey)\s*["'=:\s]{1,5}\s*[A-Za-z0-9/+=]{40}\b`), priority: 100},
 		{class: ClassGoogleAPIKey, pattern: regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}\b`), priority: 100},
-		{class: ClassGitHubToken, pattern: regexp.MustCompile(`(?:(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{36,})`), priority: 100},
+		{class: ClassGitHubToken, pattern: regexp.MustCompile(`(?i)(?:(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{36,})`), priority: 100},
 		// All documented GitLab token prefixes (token overview: glpat-,
 		// gloas-, gldt-, glrt-/glrtr-, glcbt-, glptt-, glft-, glimt-,
 		// glagent-, glwt-, glsoat-, glffct-) share the gl<type>- + base64url

--- a/internal/redact/classes.go
+++ b/internal/redact/classes.go
@@ -97,7 +97,7 @@ func tokenClasses() []classPattern {
 		{class: ClassAWSAccessKey, pattern: regexp.MustCompile(`\b(?:AKIA|ASIA|AIDA|AGPA|AROA)[A-Z0-9]{16}\b`), priority: 100, skipTrailing: sigV4CredentialScope, skipLeading: sigV4CredentialPrefix},
 		{class: ClassAWSSecretKey, pattern: regexp.MustCompile(`(?i)\b(?:aws_secret_access_key|secret.?access.?key|SecretAccessKey)\s*["'=:\s]{1,5}\s*[A-Za-z0-9/+=]{40}\b`), priority: 100},
 		{class: ClassGoogleAPIKey, pattern: regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}\b`), priority: 100},
-		{class: ClassGitHubToken, pattern: regexp.MustCompile(`(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b`), priority: 100},
+		{class: ClassGitHubToken, pattern: regexp.MustCompile(`(?:(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{36,})`), priority: 100},
 		// All documented GitLab token prefixes (token overview: glpat-,
 		// gloas-, gldt-, glrt-/glrtr-, glcbt-, glptt-, glft-, glimt-,
 		// glagent-, glwt-, glsoat-, glffct-) share the gl<type>- + base64url

--- a/internal/redact/classes_test.go
+++ b/internal/redact/classes_test.go
@@ -224,20 +224,32 @@ func TestDefaultMatcher_GitHubTokenInOpaqueRunStillMatches(t *testing.T) {
 	t.Parallel()
 	m := NewDefaultMatcher()
 
-	for _, input := range []string{
-		strings.Repeat("A", 260) + "." + "ghp_" + strings.Repeat("B", 40) + "." + strings.Repeat("C", 260),
-		strings.Repeat("A", 260) + "." + "github_pat_" + strings.Repeat("B", 40) + "." + strings.Repeat("C", 260),
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "classic",
+			input: strings.Repeat("A", 260) + "." + "ghp_" + strings.Repeat("B", 40) + "." + strings.Repeat("C", 260),
+		},
+		{
+			name:  "fine-grained",
+			input: strings.Repeat("A", 260) + "." + "github_pat_" + strings.Repeat("B", 40) + "." + strings.Repeat("C", 260),
+		},
+		{
+			name:  "uppercase classic",
+			input: strings.Repeat("A", 260) + "." + "GHP_" + strings.Repeat("B", 40) + "." + strings.Repeat("C", 260),
+		},
 	} {
-		found := false
-		for _, got := range m.Scan(input) {
-			if got.Class == ClassGitHubToken {
-				found = true
-				break
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, got := range m.Scan(tc.input) {
+				if got.Class == ClassGitHubToken {
+					return
+				}
 			}
-		}
-		if !found {
-			t.Fatalf("expected GitHub token in opaque run to match: %q", input)
-		}
+			t.Fatalf("expected %s token in opaque run to match", tc.name)
+		})
 	}
 }
 

--- a/internal/redact/classes_test.go
+++ b/internal/redact/classes_test.go
@@ -220,6 +220,27 @@ func TestDefaultMatcher_ProviderTokenBoundaries(t *testing.T) {
 	}
 }
 
+func TestDefaultMatcher_GitHubTokenInOpaqueRunStillMatches(t *testing.T) {
+	t.Parallel()
+	m := NewDefaultMatcher()
+
+	for _, input := range []string{
+		strings.Repeat("A", 260) + "." + "ghp_" + strings.Repeat("B", 40) + "." + strings.Repeat("C", 260),
+		strings.Repeat("A", 260) + "." + "github_pat_" + strings.Repeat("B", 40) + "." + strings.Repeat("C", 260),
+	} {
+		found := false
+		for _, got := range m.Scan(input) {
+			if got.Class == ClassGitHubToken {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected GitHub token in opaque run to match: %q", input)
+		}
+	}
+}
+
 func TestDefaultMatcher_ProviderKeyGlueParity(t *testing.T) {
 	t.Parallel()
 	m := NewDefaultMatcher()

--- a/internal/scanner/core.go
+++ b/internal/scanner/core.go
@@ -525,7 +525,6 @@ func (s *Scanner) scanCoreDLP(text string) []TextDLPMatch {
 			})
 		}
 	}
-
 	// URL-decoded variant.
 	if decoded := IterativeDecode(cleaned); decoded != cleaned {
 		matches = append(matches, s.matchCoreDLPPatterns(decoded, "url")...)

--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -271,13 +271,14 @@ func isLowConfidenceInboundAWSAccessID(ctx inboundAWSAccessIDContext, match Text
 
 // TextDLPMatch describes a single DLP pattern match in arbitrary text.
 type TextDLPMatch struct {
-	PatternName   string `json:"pattern_name"`
-	Severity      string `json:"severity"`
-	Encoded       string `json:"encoded,omitempty"` // "", "base64", "hex", "base32", "env", "url", "subdomain", "whitespace"
-	Bundle        string `json:"bundle,omitempty"`
-	BundleVersion string `json:"bundle_version,omitempty"`
-	Warn          bool   `json:"warn,omitempty"` // true for warn-mode patterns (informational only)
-	span          MatchSpan
+	PatternName    string `json:"pattern_name"`
+	Severity       string `json:"severity"`
+	Encoded        string `json:"encoded,omitempty"` // "", "base64", "hex", "base32", "env", "url", "subdomain", "whitespace"
+	Bundle         string `json:"bundle,omitempty"`
+	BundleVersion  string `json:"bundle_version,omitempty"`
+	Warn           bool   `json:"warn,omitempty"`            // true for warn-mode patterns (informational only)
+	ProviderOpaque bool   `json:"provider_opaque,omitempty"` // true when proxy scoped this match to trusted provider opaque ciphertext
+	span           MatchSpan
 }
 
 // Span returns retained coordinates for this match in the normalized scanner

--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -492,7 +492,6 @@ func (s *Scanner) scanTextForDLP(ctx context.Context, text string, opts textDLPO
 			})
 		}
 	}
-
 	// Iterative URL-decode and re-check DLP patterns (catches %2D → - etc.).
 	// Uses IterativeDecode to defeat multi-layer encoding.
 	if decoded := IterativeDecode(cleaned); decoded != cleaned {

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -1364,6 +1364,74 @@ func TestScanTextForDLP_Deduplication(t *testing.T) {
 	}
 }
 
+func TestScanTextForDLP_GitHubTokensInLongOpaqueRunsStillBlock(t *testing.T) {
+	cfg := testConfig()
+	s := MustNew(cfg)
+	defer s.Close()
+
+	classic := "ghp_" + strings.Repeat("D", 40)
+	fineGrained := "github_pat_" + strings.Repeat("E", 40)
+
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "classic token delimited by prose",
+			text: "token=" + classic,
+			want: "GitHub Token",
+		},
+		{
+			name: "fine grained token delimited by prose",
+			text: "token=" + fineGrained,
+			want: "GitHub Fine-Grained PAT",
+		},
+		{
+			name: "classic glued token still blocks",
+			text: "prefixZ" + classic,
+			want: "GitHub Token",
+		},
+		{
+			name: "fine grained glued token still blocks",
+			text: "prefixZ" + fineGrained,
+			want: "GitHub Fine-Grained PAT",
+		},
+		{
+			name: "classic token-shaped substring inside opaque run",
+			text: strings.Repeat("A", 260) + classic + strings.Repeat("B", 260),
+			want: "GitHub Token",
+		},
+		{
+			name: "classic token-shaped substring inside dotted opaque run",
+			text: strings.Repeat("A", 260) + "." + classic + "." + strings.Repeat("B", 260),
+			want: "GitHub Token",
+		},
+		{
+			name: "fine grained token-shaped substring inside opaque run",
+			text: strings.Repeat("C", 260) + fineGrained + strings.Repeat("F", 260),
+			want: "GitHub Fine-Grained PAT",
+		},
+		{
+			name: "credential context in long opaque run still blocks",
+			text: strings.Repeat("A", 260) + ".token." + classic + "." + strings.Repeat("B", 260),
+			want: "GitHub Token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), tt.text)
+			if result.Clean {
+				t.Fatalf("expected %q match, got clean", tt.want)
+			}
+			if !hasTextDLPMatch(result.Matches, tt.want, "") {
+				t.Fatalf("missing %q in matches: %v", tt.want, result.Matches)
+			}
+		})
+	}
+}
+
 func TestScanTextForDLP_MultiplePatterns(t *testing.T) {
 	cfg := testConfig()
 	s := MustNew(cfg)


### PR DESCRIPTION
## Summary

- keep GitHub token detection enforceable in generic content while downgrading matches only within validated provider opaque fields
- preserve opaque-field provenance through request-body extraction and reject malformed or multiple-root JSON fail closed
- add regression coverage for trusted provider paths, ordinary-content blocking, critical-match precedence, and JSON root handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced DLP scanning for trusted provider-opaque JSON content, extracting it separately and scanning it with dedicated provenance.
* **Bug Fixes**
  * Provider-opaque findings now consistently cap as warnings (not hard blocks) while normal sensitive-data still blocks with priority.
  * Strengthened handling of malformed/unexpected JSON with fail-closed behavior and improved duplicate-match deduplication.
* **Security / Detection**
  * Improved GitHub token detection, including tokens embedded in very long or opaque/dotted text runs.
* **Tests**
  * Expanded coverage for provider-opaque downgrades, precedence, and long-opaque token cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->