### PR TITLE
fix(conductor): survive an upgrade that moves the canonical policy hash

### DIFF
--- a/enterprise/cli/conductor/cmd.go
+++ b/enterprise/cli/conductor/cmd.go
@@ -373,6 +373,7 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 		return nil, nil, nil, err
 	}
 	m := metrics.New()
+	m.RecordConductorPolicyHashStatusCounts(store.PolicyHashStatusCounts())
 	handler, err := controlplane.NewHandler(controlplane.HandlerOptions{
 		Store:              store,
 		Capabilities:       controlplane.DefaultCapabilities(opts.conductorID),

--- a/enterprise/cli/conductor/cmd_test.go
+++ b/enterprise/cli/conductor/cmd_test.go
@@ -123,8 +123,12 @@ func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, controlplane.MetricsPath, nil)
 	w = httptest.NewRecorder()
 	probeHandler.ServeHTTP(w, req)
-	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "pipelock_conductor_server_requests_total") {
+	metricsBody := w.Body.String()
+	if w.Code != http.StatusOK || !strings.Contains(metricsBody, "pipelock_conductor_server_requests_total") {
 		t.Fatalf("metrics status = %d body=%s, want conductor metrics", w.Code, w.Body.String())
+	}
+	if !strings.Contains(metricsBody, `pipelock_conductor_policy_bundle_policy_hash_status_count{status="unknown_unverified"} 0`) {
+		t.Fatalf("metrics body missing policy hash status gauge:\n%s", metricsBody)
 	}
 }
 

--- a/enterprise/conductor/applycache/cache.go
+++ b/enterprise/conductor/applycache/cache.go
@@ -472,7 +472,14 @@ func verifyBundle(now time.Time, bundle conductor.PolicyBundle, opts verifyOptio
 	if err := bundle.VerifyPayloadHash(); err != nil {
 		return err
 	}
-	if err := bundle.ValidateAtTime(now); err != nil {
+	// Ordering is load-bearing: VerifySignaturesAt above is the cryptographic
+	// gate, and only because it has already run may this tolerate a policy_hash
+	// this build cannot reproduce. A bundle published before a release moved the
+	// canonical policy hash is in exactly that position, and refusing it here
+	// stopped followers applying policy for the whole of a rolling upgrade.
+	// Moving this call above VerifySignaturesAt would apply a bundle whose
+	// provenance was never established.
+	if err := bundle.ValidateAtTimeAllowLegacyPolicyHash(now); err != nil {
 		return err
 	}
 	if bundle.StreamSwitchAuthorization != nil {

--- a/enterprise/conductor/applycache/policy_hash_ordering_test.go
+++ b/enterprise/conductor/applycache/policy_hash_ordering_test.go
@@ -1,0 +1,82 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package applycache
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+)
+
+// foreignPolicyHash is a well-formed hash belonging to neither scheme this build
+// can compute, standing in for a value produced by a prior release's config
+// canonicaliser.
+const foreignPolicyHash = "abababababababababababababababababababababababababababababababab"
+
+// TestVerifyBundleSignatureGateRunsBeforePolicyHashTolerance pins the ordering
+// invariant that makes the policy_hash tolerance safe on the follower.
+//
+// verifyBundle tolerates a policy_hash this build cannot reproduce, because a
+// bundle published before a release moved the canonical policy hash is in
+// exactly that position, and refusing it stops policy applying for the whole of
+// a rolling upgrade. That tolerance is only defensible because
+// VerifySignaturesAt runs FIRST. Were the tolerance ever moved above the
+// signature check, a bundle of unknown provenance would be applied.
+//
+// Mutating PolicyHash after signing invalidates the signature, because the field
+// sits inside the signable preimage. So a bundle in the tolerated policy-hash
+// state with a broken signature must still be refused.
+func TestVerifyBundleSignatureGateRunsBeforePolicyHashTolerance(t *testing.T) {
+	key := newTestKey(t)
+	bundle := signedTestBundle(t, key, "ordering-1", 1, "")
+
+	// Sanity: as signed, this bundle verifies. Otherwise the negative case below
+	// could pass for an unrelated reason.
+	if err := verifyBundle(testNow, bundle, verifyOptions{
+		Resolver: testResolver(key),
+		Identity: Identity{OrgID: "org-1", FleetID: "fleet-1", InstanceID: "instance-1"},
+	}); err != nil {
+		t.Fatalf("verifyBundle(as signed) = %v, want nil", err)
+	}
+
+	bundle.PolicyHash = foreignPolicyHash
+	if status := bundle.PolicyHashStatus(); status != conductor.PolicyHashUnknownUnverified {
+		t.Fatalf("PolicyHashStatus() = %q, want %q", status, conductor.PolicyHashUnknownUnverified)
+	}
+
+	// The policy_hash is now tolerated, but provenance is broken, so the
+	// signature gate must refuse it.
+	if err := verifyBundle(testNow, bundle, verifyOptions{
+		Resolver: testResolver(key),
+		Identity: Identity{OrgID: "org-1", FleetID: "fleet-1", InstanceID: "instance-1"},
+	}); err == nil {
+		t.Fatal("verifyBundle(tolerated policy_hash, broken signature) = nil, want error")
+	}
+}
+
+// TestVerifyBundleAcceptsForeignPolicyHashWhenProperlySigned is the positive half:
+// a bundle signed OVER the unreproducible policy_hash, which is what an older
+// leader actually publishes, must apply. This is the case that was refused and
+// that stopped a rolling upgrade.
+func TestVerifyBundleAcceptsForeignPolicyHashWhenProperlySigned(t *testing.T) {
+	key := newTestKey(t)
+	bundle := signedTestBundle(t, key, "ordering-2", 1, "")
+
+	// Re-sign over the foreign hash so provenance is intact, exactly as a prior
+	// release's publisher would have produced it.
+	bundle.PolicyHash = foreignPolicyHash
+	bundle.Signatures = []conductor.SignatureProof{signProof(t, key, bundle.SignablePreimage)}
+
+	if status := bundle.PolicyHashStatus(); status != conductor.PolicyHashUnknownUnverified {
+		t.Fatalf("PolicyHashStatus() = %q, want %q", status, conductor.PolicyHashUnknownUnverified)
+	}
+	if err := verifyBundle(testNow, bundle, verifyOptions{
+		Resolver: testResolver(key),
+		Identity: Identity{OrgID: "org-1", FleetID: "fleet-1", InstanceID: "instance-1"},
+	}); err != nil {
+		t.Fatalf("verifyBundle(properly signed, unreproducible policy_hash) = %v, want nil", err)
+	}
+}

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -562,10 +562,14 @@ func readRecord(path string, maxPayloadBytes uint64) (diskRecord, error) {
 	if info.Size() > limit {
 		return diskRecord{}, corruptRecordError(fmt.Errorf("%w: record_bytes=%d cap=%d", conductor.ErrPayloadTooLarge, info.Size(), limit))
 	}
+	// OwnedState: this is Pipelock own durable audit-queue state, written by
+	// durableWrite at 0600. Kubernetes fsGroup re-widens it to 0660 on every
+	// mount, so a strict group-write refusal would keep a non-root follower from
+	// recovering or delivering queued audit batches after restart.
 	data, err := securefile.Read(path, securefile.Options{
-		MaxBytes:        limit,
-		DisallowedPerms: 0o077,
-		RejectSymlink:   true,
+		MaxBytes:      limit,
+		RejectSymlink: true,
+		OwnedState:    true,
 	})
 	if err != nil {
 		return diskRecord{}, corruptRecordError(fmt.Errorf("auditbatcher: read record: %w", err))

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -565,7 +565,23 @@ func readRecord(path string, maxPayloadBytes uint64) (diskRecord, error) {
 	// OwnedState: this is Pipelock own durable audit-queue state, written by
 	// durableWrite at 0600. Kubernetes fsGroup re-widens it to 0660 on every
 	// mount, so a strict group-write refusal would keep a non-root follower from
-	// recovering or delivering queued audit batches after restart.
+	// recovering or delivering queued audit batches after restart. A refusal here
+	// becomes ErrCorruptRecord and Claim moves the record to dead/, so strictness
+	// costs delivery of that audit data rather than merely delaying it.
+	//
+	// The confidentiality tradeoff, stated plainly because it is real: a queued
+	// record carries the batch envelope and the raw recorder payload, and decision
+	// entries can include matched-pattern context and policy evidence. Accepting
+	// group read means any process sharing the fsGroup can read that from disk.
+	// Refusing it does NOT prevent that: the platform has already widened the file,
+	// so a co-tenant of the group can read it whether or not Pipelock will. Strict
+	// mode would therefore leave the exposure in place and discard our own audit
+	// delivery on top of it, which is the worse of the two.
+	//
+	// Closing the exposure properly means encrypting these records at rest under a
+	// key that does not live on the widened volume. That is a separate piece of
+	// work with its own key lifecycle, and until it exists this state sits inside
+	// the workload/volume trust boundary alongside flight-recorder evidence.
 	data, err := securefile.Read(path, securefile.Options{
 		MaxBytes:      limit,
 		RejectSymlink: true,

--- a/enterprise/conductor/auditbatcher/queue_test.go
+++ b/enterprise/conductor/auditbatcher/queue_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1073,6 +1074,12 @@ func TestReadRecordAcceptsOwnedGroupWritableRecord(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "record.json")
 	if err := writeDiskRecord(path, validDiskRecord(signedTestBatch(t, "batch-owned-group-record", priv))); err != nil {
 		t.Fatalf("writeDiskRecord() error = %v", err)
+	}
+	if runtime.GOOS == "windows" {
+		// Windows has no chmod semantics for this mode and the acceptance check
+		// is a no-op there, so this would pass without exercising the behaviour.
+		// A vacuous pass is worse than a skip because it reads as coverage.
+		t.Skip("platform-widened POSIX mode is not reproducible on Windows")
 	}
 	groupWritableMode := os.FileMode(0o660)
 	if err := os.Chmod(path, groupWritableMode); err != nil {

--- a/enterprise/conductor/auditbatcher/queue_test.go
+++ b/enterprise/conductor/auditbatcher/queue_test.go
@@ -1065,6 +1065,25 @@ func TestReadRecordRejectsDuplicateKeys(t *testing.T) {
 	}
 }
 
+func TestReadRecordAcceptsOwnedGroupWritableRecord(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "record.json")
+	if err := writeDiskRecord(path, validDiskRecord(signedTestBatch(t, "batch-owned-group-record", priv))); err != nil {
+		t.Fatalf("writeDiskRecord() error = %v", err)
+	}
+	groupWritableMode := os.FileMode(0o660)
+	if err := os.Chmod(path, groupWritableMode); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	if _, err := readRecord(path, conductor.MaxAuditPayloadBytes); err != nil {
+		t.Fatalf("readRecord(owned group-writable record) error = %v", err)
+	}
+}
+
 func TestReadRecordRejectsSymlinkRecord(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {

--- a/enterprise/conductor/bootstrap/bootstrap.go
+++ b/enterprise/conductor/bootstrap/bootstrap.go
@@ -255,7 +255,11 @@ func writeManifest(layout Layout, opts Options, identity controlplane.FollowerId
 }
 
 func loadManifest(path string) (manifest, error) {
-	data, err := securefile.Read(path, securefile.Options{MaxBytes: manifestMaxBytes, DisallowedPerms: 0o037})
+	// OwnedState: this is Pipelock own bootstrap completion manifest, written by
+	// writeManifest at 0600. Kubernetes fsGroup re-widens it to 0660 on every
+	// mount, so a strict group-write refusal would make idempotent bootstrap
+	// reloads fail even though private keys and tokens keep their strict reads.
+	data, err := securefile.Read(path, securefile.Options{MaxBytes: manifestMaxBytes, OwnedState: true})
 	if err != nil {
 		return manifest{}, fmt.Errorf("read bootstrap manifest: %w", err)
 	}

--- a/enterprise/conductor/bootstrap/bootstrap_test.go
+++ b/enterprise/conductor/bootstrap/bootstrap_test.go
@@ -98,6 +98,35 @@ func TestLoadManifestRejectsDuplicateAndOversizedJSON(t *testing.T) {
 	}
 }
 
+func TestLoadManifestAcceptsOwnedGroupWritableManifest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), manifestFile)
+	data, err := json.Marshal(manifest{
+		Schema:          manifestSchema,
+		TrustDomain:     defaultTrustDomain,
+		OrgID:           defaultOrgID,
+		FleetID:         defaultFleetID,
+		InstanceID:      defaultInstanceID,
+		Environment:     defaultEnvironment,
+		ConductorID:     defaultConductorID,
+		ConductorURL:    "https://conductor.example",
+		RootFingerprint: "root-fingerprint",
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	groupWritableMode := os.FileMode(0o660)
+	if err := os.Chmod(path, groupWritableMode); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	if _, err := loadManifest(path); err != nil {
+		t.Fatalf("loadManifest(owned group-writable manifest) error = %v", err)
+	}
+}
+
 // privateFleetDir returns an absolute fleet directory whose ancestors are not
 // world-writable. The conductor config validator rejects world-writable
 // parents, and the shared /tmp (mode 1777) trips that check, so fleet material

--- a/enterprise/conductor/controlplane/enrollment.go
+++ b/enterprise/conductor/controlplane/enrollment.go
@@ -800,7 +800,11 @@ func (s *FileEnrollmentStore) load() error {
 }
 
 func loadEnrollmentState(path string, maxBytes int64) (enrollmentDiskState, error) {
-	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxBytes, DisallowedPerms: 0o037})
+	// OwnedState: this is Pipelock own enrollment state, written by saveLocked
+	// at 0600. Kubernetes fsGroup re-widens it to 0660 on every mount, so a strict
+	// group-write refusal here stopped the leader from starting at all on any
+	// non-root deployment using a persistent volume.
+	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxBytes, OwnedState: true})
 	if err != nil {
 		return enrollmentDiskState{}, fmt.Errorf("read enrollment store: %w", err)
 	}

--- a/enterprise/conductor/controlplane/enrollment.go
+++ b/enterprise/conductor/controlplane/enrollment.go
@@ -804,6 +804,14 @@ func loadEnrollmentState(path string, maxBytes int64) (enrollmentDiskState, erro
 	// at 0600. Kubernetes fsGroup re-widens it to 0660 on every mount, so a strict
 	// group-write refusal here stopped the leader from starting at all on any
 	// non-root deployment using a persistent volume.
+	//
+	// Sensitivity, recorded so the tradeoff is not rediscovered: this holds
+	// enrollment token hashes, the follower roster with their public audit keys,
+	// and per-follower runtime status. Hashes and public keys are not secrets, but
+	// the roster is operational detail worth keeping inside the boundary. As with
+	// the audit queue, refusing the read would not withhold any of it from a
+	// process sharing the fsGroup, since the platform has already widened the
+	// file; it would only stop the leader from starting.
 	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxBytes, OwnedState: true})
 	if err != nil {
 		return enrollmentDiskState{}, fmt.Errorf("read enrollment store: %w", err)

--- a/enterprise/conductor/controlplane/offline_recovery.go
+++ b/enterprise/conductor/controlplane/offline_recovery.go
@@ -119,7 +119,12 @@ func loadOfflineStore(policyBundlesDir string) (*FileBundleStore, []OfflineUnrea
 	}
 	slices.Sort(names)
 	for _, name := range names {
-		record, err := readBundleRecord(filepath.Join(store.bundlesDir, name))
+		// Match startup, which tolerates a policy_hash this build cannot
+		// reproduce. Reading strictly here classified every bundle published
+		// before a release moved the canonical policy hash as unreadable, so the
+		// tool an operator reaches for when the leader will not boot reported the
+		// whole store as damaged and repair refused to act on it.
+		record, err := readBundleRecordAllowLegacyPolicyHash(filepath.Join(store.bundlesDir, name))
 		if err != nil {
 			unreadable = append(unreadable, OfflineUnreadableRecord{FileName: name, Err: err.Error()})
 			continue
@@ -384,7 +389,9 @@ func RepairOfflineStore(policyBundlesDir, backupDir string, confirm bool, now ti
 		src := filepath.Join(store.bundlesDir, orphan.FileName)
 		// Re-validate that this is exactly one of the records we classified and that
 		// the on-disk file still parses to the same orphan hash before touching it.
-		record, err := readBundleRecord(src)
+		// Same tolerance as the classification pass above, so repair can act on
+		// exactly the set it classified rather than failing the re-read.
+		record, err := readBundleRecordAllowLegacyPolicyHash(src)
 		if err != nil {
 			return finalizeRepair(resolvedBackup, removed), fmt.Errorf("conductor offline repair re-read %s: %w", orphan.FileName, err)
 		}

--- a/enterprise/conductor/controlplane/store.go
+++ b/enterprise/conductor/controlplane/store.go
@@ -699,8 +699,9 @@ func (s *FileBundleStore) load() error {
 		// scheme, which meant the case that actually stops an upgrade -- a hash
 		// from a release whose config schema this build no longer carries --
 		// produced no signal at all before the leader failed to boot.
-		if status := record.Bundle.PolicyHashStatus(); status != conductor.PolicyHashCurrent {
-			s.policyHashStatusCounts[status]++
+		status := record.Bundle.PolicyHashStatus()
+		s.policyHashStatusCounts[status]++
+		if status != conductor.PolicyHashCurrent {
 			slog.Warn("conductor_policy_bundle_policy_hash_not_current",
 				slog.String("event", "conductor_policy_bundle_policy_hash_not_current"),
 				slog.String("policy_hash_status", string(status)),

--- a/enterprise/conductor/controlplane/store.go
+++ b/enterprise/conductor/controlplane/store.go
@@ -264,6 +264,10 @@ type FileBundleStore struct {
 	records        map[string]PublishedBundle
 	streams        map[string]PublishedBundle
 	rollbackHeads  map[string]streamHeadRecord
+	// policyHashStatusCounts records how many loaded bundles fell into each
+	// policy-hash status, so an operator can see that a store carries bundles
+	// whose policy hash this build cannot reproduce without reading the log.
+	policyHashStatusCounts map[conductor.PolicyHashStatus]int
 }
 
 type streamHeadRecord struct {
@@ -299,12 +303,13 @@ func OpenFileBundleStore(dir string) (*FileBundleStore, error) {
 		return nil, err
 	}
 	store := &FileBundleStore{
-		dir:            root,
-		bundlesDir:     bundlesDir,
-		streamHeadsDir: streamHeadsDir,
-		records:        make(map[string]PublishedBundle),
-		streams:        make(map[string]PublishedBundle),
-		rollbackHeads:  make(map[string]streamHeadRecord),
+		dir:                    root,
+		bundlesDir:             bundlesDir,
+		streamHeadsDir:         streamHeadsDir,
+		records:                make(map[string]PublishedBundle),
+		streams:                make(map[string]PublishedBundle),
+		rollbackHeads:          make(map[string]streamHeadRecord),
+		policyHashStatusCounts: make(map[conductor.PolicyHashStatus]int),
 	}
 	if err := store.load(); err != nil {
 		return nil, err
@@ -650,6 +655,21 @@ func (f FollowerIdentity) Validate() error {
 	return nil
 }
 
+// PolicyHashStatusCounts reports how many loaded bundles fell into each
+// policy-hash status. A nonzero unknown_unverified count means the store carries
+// bundles whose policy hash this build cannot reproduce, which is expected after
+// a release that moved the canonical policy hash and is the signal an operator
+// needs before it becomes a mystery.
+func (s *FileBundleStore) PolicyHashStatusCounts() map[conductor.PolicyHashStatus]int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[conductor.PolicyHashStatus]int, len(s.policyHashStatusCounts))
+	for k, v := range s.policyHashStatusCounts {
+		out[k] = v
+	}
+	return out
+}
+
 func (s *FileBundleStore) load() error {
 	entries, err := os.ReadDir(s.bundlesDir)
 	if err != nil {
@@ -674,9 +694,17 @@ func (s *FileBundleStore) load() error {
 		if _, exists := s.records[record.BundleHash]; exists {
 			return fmt.Errorf("%w: duplicate bundle_hash %q", ErrInvalidStoreRecord, record.BundleHash)
 		}
-		if record.Bundle.UsesLegacyPolicyHash() {
-			slog.Warn("conductor_policy_bundle_legacy_policy_hash",
-				slog.String("event", "conductor_policy_bundle_legacy_policy_hash"),
+		// Report anything this build could not reproduce under the current
+		// scheme. The previously reported case was only the pre-loaded-config
+		// scheme, which meant the case that actually stops an upgrade -- a hash
+		// from a release whose config schema this build no longer carries --
+		// produced no signal at all before the leader failed to boot.
+		if status := record.Bundle.PolicyHashStatus(); status != conductor.PolicyHashCurrent {
+			s.policyHashStatusCounts[status]++
+			slog.Warn("conductor_policy_bundle_policy_hash_not_current",
+				slog.String("event", "conductor_policy_bundle_policy_hash_not_current"),
+				slog.String("policy_hash_status", string(status)),
+				slog.Bool("policy_hash_reproducible", status.Reproducible()),
 				slog.String("bundle_id", record.Bundle.BundleID),
 				slog.String("bundle_hash", record.BundleHash),
 				slog.Uint64("version", record.Bundle.Version),

--- a/enterprise/conductor/controlplane/store_test.go
+++ b/enterprise/conductor/controlplane/store_test.go
@@ -74,6 +74,13 @@ func TestFileBundleStorePublishesIdempotentlyAndReloads(t *testing.T) {
 	if got := info.Mode().Perm(); got != bundleRecordFileMode {
 		t.Fatalf("bundle record mode = %v, want %v", got, bundleRecordFileMode)
 	}
+	counts := reopened.PolicyHashStatusCounts()
+	if got := counts[conductor.PolicyHashCurrent]; got != 1 {
+		t.Fatalf("current policy hash count = %d, want 1", got)
+	}
+	if got := counts[conductor.PolicyHashUnknownUnverified]; got != 0 {
+		t.Fatalf("unknown policy hash count = %d, want 0", got)
+	}
 }
 
 func TestFileBundleStoreLoadsLegacyPolicyHashBundleAndServesLatest(t *testing.T) {
@@ -116,6 +123,13 @@ func TestFileBundleStoreLoadsLegacyPolicyHashBundleAndServesLatest(t *testing.T)
 	}
 	if served.BundleID != bundle.BundleID || served.PolicyHash != bundle.PolicyHash {
 		t.Fatalf("served bundle id/hash = %q/%s, want %q/%s", served.BundleID, served.PolicyHash, bundle.BundleID, bundle.PolicyHash)
+	}
+	counts := reopened.PolicyHashStatusCounts()
+	if got := counts[conductor.PolicyHashKnownLegacy]; got != 1 {
+		t.Fatalf("known legacy policy hash count = %d, want 1", got)
+	}
+	if got := counts[conductor.PolicyHashUnknownUnverified]; got != 0 {
+		t.Fatalf("unknown policy hash count = %d, want 0", got)
 	}
 	resolver := resolverForSigner(signer)
 	if err := served.ValidateAllowLegacyPolicyHash(); err != nil {

--- a/enterprise/conductor/emergency/remote_kill.go
+++ b/enterprise/conductor/emergency/remote_kill.go
@@ -577,7 +577,11 @@ func remoteKillReplayContextPresent(path string) (bool, error) {
 }
 
 func readRemoteKillStateContext(path string) (bool, error) {
-	data, err := securefile.Read(remoteKillStateContextPath(path), securefile.Options{MaxBytes: maxRemoteKillStateBytes, DisallowedPerms: 0o037})
+	// OwnedState: this is Pipelock own remote-kill replay context, written by
+	// writeRemoteKillStateContext at 0600. Kubernetes fsGroup re-widens it to
+	// 0660 on every mount, so a strict group-write refusal would hide the replay
+	// context and weaken the missing-state fail-closed check after restart.
+	data, err := securefile.Read(remoteKillStateContextPath(path), securefile.Options{MaxBytes: maxRemoteKillStateBytes, OwnedState: true})
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil

--- a/enterprise/conductor/emergency/remote_kill_test.go
+++ b/enterprise/conductor/emergency/remote_kill_test.go
@@ -695,6 +695,26 @@ func TestRemoteKillApplierRejectsReplayAfterPrimaryStateDeletion(t *testing.T) {
 	}
 }
 
+func TestReadRemoteKillStateContextAcceptsOwnedGroupWritableContext(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	if err := writeRemoteKillStateContext(statePath); err != nil {
+		t.Fatalf("writeRemoteKillStateContext() error = %v", err)
+	}
+	contextPath := remoteKillStateContextPath(statePath)
+	groupWritableMode := os.FileMode(0o660)
+	if err := os.Chmod(contextPath, groupWritableMode); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	found, err := readRemoteKillStateContext(statePath)
+	if err != nil {
+		t.Fatalf("readRemoteKillStateContext(owned group-writable context) error = %v", err)
+	}
+	if !found {
+		t.Fatal("readRemoteKillStateContext(owned group-writable context) found=false, want true")
+	}
+}
+
 func TestRemoteKillApplierRejectsReplayAfterPrimaryAndSecondaryDeletion(t *testing.T) {
 	oldMsg, resolver := signedRemoteKill(t, 9, conductor.KillSwitchActive)
 	statePath := filepath.Join(t.TempDir(), "state.json")

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -766,7 +766,28 @@ func (b PolicyBundle) validateHashes(allowLegacyPolicyHash bool) error {
 		}
 		legacyPolicyHash, legacyErr := b.Payload.LegacyPolicyHash()
 		if legacyErr != nil || !strings.EqualFold(b.PolicyHash, legacyPolicyHash) {
-			return fmt.Errorf("%w: policy_hash", ErrHashMismatch)
+			// Neither scheme this build can compute reproduces the stored value.
+			// That is the normal state for a bundle published before a release
+			// moved the canonical policy hash, and it is permanent: the value is
+			// derived from the whole config struct, so no amount of added schemes
+			// can reproduce a prior release's. Refusing here is what stopped the
+			// leader from booting after upgrade and what stopped followers from
+			// applying an in-flight bundle mid-rollout.
+			//
+			// This is deliberately NOT a tamper gate and was never one. On the
+			// leader nothing verifies signatures, so an attacker able to rewrite
+			// the store rewrites payload_sha256, policy_hash and the record hash
+			// together; strict recompute only catches corruption or a partial
+			// edit. On followers the cryptographic gate is VerifySignaturesAt,
+			// which callers MUST run before reaching here.
+			//
+			// What still holds for this bundle: payload_sha256 binds the raw
+			// payload and is schema-independent, the record's canonical hash
+			// pins it, expiry and chain checks apply, and the publisher's
+			// signature covers policy_hash itself. So the value is a signed
+			// opaque string. Callers surface it as
+			// PolicyHashUnknownUnverified and must never call it verified.
+			return nil
 		}
 	}
 	return nil
@@ -786,16 +807,64 @@ func (b PolicyBundle) VerifyPayloadHash() error {
 	return nil
 }
 
+// PolicyHashStatus describes which policy_hash scheme, if any, this build could
+// reproduce from a bundle's payload. A boolean cannot express the third case,
+// which is the one that matters on upgrade.
+type PolicyHashStatus string
+
+const (
+	// PolicyHashCurrent means the stored policy_hash matches what this build
+	// computes from the payload. The value is a verified digest of the policy.
+	PolicyHashCurrent PolicyHashStatus = "current"
+	// PolicyHashKnownLegacy means the stored policy_hash matches the
+	// pre-loaded-config scheme. Still a verified digest, under an older rule.
+	PolicyHashKnownLegacy PolicyHashStatus = "known_legacy"
+	// PolicyHashUnknownUnverified means the stored policy_hash matches no scheme
+	// this build can compute, so this build cannot say what policy content the
+	// value stands for.
+	//
+	// This is the NORMAL state for any bundle published before a release that
+	// moved the canonical policy hash, and it is not recoverable by adding more
+	// schemes: PolicyHash is derived from the whole config struct via
+	// config.CanonicalPolicyHash, so reproducing a prior release's value would
+	// require that release's entire config schema frozen in this binary. The
+	// pre-loaded-config scheme is the exception precisely because it hashes raw
+	// YAML and so is schema-independent.
+	//
+	// The value remains covered by the publisher's signature, so it is a signed
+	// opaque string. It must never be presented as verified or attested policy
+	// content.
+	PolicyHashUnknownUnverified PolicyHashStatus = "unknown_unverified"
+)
+
+// Reproducible reports whether this build could recompute the policy_hash and
+// found it correct. Only a reproducible status may be described to an operator
+// as a verified digest of the policy.
+func (s PolicyHashStatus) Reproducible() bool {
+	return s == PolicyHashCurrent || s == PolicyHashKnownLegacy
+}
+
+// PolicyHashStatus reports which scheme reproduces the bundle's policy_hash. It
+// is an upgrade and evidence signal for operators; it is not a trust decision
+// and must not replace signature verification.
+func (b PolicyBundle) PolicyHashStatus() PolicyHashStatus {
+	if policyHash, err := b.Payload.PolicyHash(); err == nil && strings.EqualFold(b.PolicyHash, policyHash) {
+		return PolicyHashCurrent
+	}
+	if legacyPolicyHash, err := b.Payload.LegacyPolicyHash(); err == nil && strings.EqualFold(b.PolicyHash, legacyPolicyHash) {
+		return PolicyHashKnownLegacy
+	}
+	return PolicyHashUnknownUnverified
+}
+
 // UsesLegacyPolicyHash reports whether the bundle validates only through the
 // pre-loaded-config policy_hash scheme. It is an upgrade signal for operators;
 // it is not a trust decision and must not replace signature verification.
+//
+// Deprecated: it cannot distinguish a hash this build simply cannot compute from
+// one that is current. Use PolicyHashStatus.
 func (b PolicyBundle) UsesLegacyPolicyHash() bool {
-	policyHash, err := b.Payload.PolicyHash()
-	if err == nil && strings.EqualFold(b.PolicyHash, policyHash) {
-		return false
-	}
-	legacyPolicyHash, err := b.Payload.LegacyPolicyHash()
-	return err == nil && strings.EqualFold(b.PolicyHash, legacyPolicyHash)
+	return b.PolicyHashStatus() == PolicyHashKnownLegacy
 }
 
 // ValidateAtTime extends Validate with a freshness check: now must fall inside
@@ -803,6 +872,22 @@ func (b PolicyBundle) UsesLegacyPolicyHash() bool {
 // Validate alone passes a future-dated or already-expired bundle.
 func (b PolicyBundle) ValidateAtTime(now time.Time) error {
 	if err := b.Validate(); err != nil {
+		return err
+	}
+	return withinValidity(now, b.NotBefore, b.ExpiresAt)
+}
+
+// ValidateAtTimeAllowLegacyPolicyHash is ValidateAtTime for a bundle that is
+// already stored or already signature-verified, tolerating a policy_hash this
+// build cannot reproduce.
+//
+// CALLER CONTRACT: only use this AFTER VerifySignaturesAt has succeeded, or on a
+// record read from local storage the caller already trusts. The policy_hash
+// tolerance is not a tamper gate, so the cryptographic gate must come first.
+// Reaching this without verifying signatures would apply a bundle whose
+// provenance was never established.
+func (b PolicyBundle) ValidateAtTimeAllowLegacyPolicyHash(now time.Time) error {
+	if err := b.ValidateAllowLegacyPolicyHash(); err != nil {
 		return err
 	}
 	return withinValidity(now, b.NotBefore, b.ExpiresAt)

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -775,7 +775,23 @@ func (b PolicyBundle) validateHashes(allowLegacyPolicyHash bool) error {
 	}
 	policyHash, err := b.Payload.PolicyHash()
 	if err != nil {
-		return err
+		// Computing the hash parses the bundle's config through the CURRENT
+		// schema, so this errors for a stored bundle whose config carries a field
+		// this release removed. That is the same upgrade case the tolerance below
+		// exists for, reached by a different door, and refusing here would put the
+		// leader back to not starting. It is exactly the shape this release
+		// produces, since it removes three budget fields a previously published
+		// bundle may well set.
+		//
+		// Publish keeps the hard failure: there the computing build is the build
+		// that produced the bundle, so an unparseable config is a real error. When
+		// reading stored state the hash is simply not reproducible by this build,
+		// which is what PolicyHashStatus already reports for this case, and the
+		// payload digest checked above still binds the raw payload.
+		if !allowLegacyPolicyHash {
+			return err
+		}
+		return nil
 	}
 	if !strings.EqualFold(b.PolicyHash, policyHash) {
 		if !allowLegacyPolicyHash {

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -657,9 +657,26 @@ func (b PolicyBundle) Validate() error {
 	return b.validate(false)
 }
 
-// ValidateAllowLegacyPolicyHash validates a bundle while tolerating the
-// pre-loaded-config policy_hash scheme. This is only for reading already stored
-// upgrade-era bundles; network publish/apply paths must use Validate.
+// ValidateAllowLegacyPolicyHash validates a bundle while tolerating a policy_hash
+// this build cannot reproduce. Network publish paths must use Validate.
+//
+// There are exactly two legitimate classes of caller, and a new call site that is
+// neither of them is a mistake:
+//
+//   - Reads of state on local disk the process already trusts: the leader's bundle
+//     store, the offline inspect and repair readers, and the follower's own
+//     verified cache. These never verified signatures and do not start now; the
+//     leader trusting its own disk is the documented design, and on that path the
+//     policy_hash recompute was a consistency check rather than a tamper gate,
+//     because anything able to rewrite the store rewrites the digests with it.
+//   - Apply paths that have ALREADY verified signatures against a pinned roster,
+//     which must use ValidateAtTimeAllowLegacyPolicyHash so the freshness window is
+//     checked too. There the publisher's signature covers policy_hash, so the value
+//     is attested even when this build cannot recompute it.
+//
+// Tolerated is not verified. Callers reporting to an operator must use
+// PolicyHashStatus and must not describe PolicyHashUnknownUnverified as a verified
+// digest of policy content.
 func (b PolicyBundle) ValidateAllowLegacyPolicyHash() error {
 	return b.validate(true)
 }

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -857,16 +857,6 @@ func (b PolicyBundle) PolicyHashStatus() PolicyHashStatus {
 	return PolicyHashUnknownUnverified
 }
 
-// UsesLegacyPolicyHash reports whether the bundle validates only through the
-// pre-loaded-config policy_hash scheme. It is an upgrade signal for operators;
-// it is not a trust decision and must not replace signature verification.
-//
-// Deprecated: it cannot distinguish a hash this build simply cannot compute from
-// one that is current. Use PolicyHashStatus.
-func (b PolicyBundle) UsesLegacyPolicyHash() bool {
-	return b.PolicyHashStatus() == PolicyHashKnownLegacy
-}
-
 // ValidateAtTime extends Validate with a freshness check: now must fall inside
 // [NotBefore, ExpiresAt]. Callers that apply the bundle must use this variant -
 // Validate alone passes a future-dated or already-expired bundle.

--- a/enterprise/conductor/messages_policy_hash_upgrade_test.go
+++ b/enterprise/conductor/messages_policy_hash_upgrade_test.go
@@ -80,9 +80,14 @@ func TestPolicyHashForeignSchemeIsRejected(t *testing.T) {
 		t.Fatalf("VerifyPayloadHash() error = %v, want nil (only policy_hash differs)", err)
 	}
 
-	// And UsesLegacyPolicyHash cannot describe it either, so the existing
-	// operator-facing warning does not fire for this class.
-	if bundle.UsesLegacyPolicyHash() {
-		t.Fatal("UsesLegacyPolicyHash() = true for a foreign-scheme hash, want false")
+	// A bundle whose hash IS reproducible must still report so, otherwise the
+	// tolerance would be hiding real drift rather than describing it.
+	bundle.PolicyHash = currentHash
+	if status := bundle.PolicyHashStatus(); status != PolicyHashCurrent {
+		t.Fatalf("PolicyHashStatus(current hash) = %q, want %q", status, PolicyHashCurrent)
+	}
+	bundle.PolicyHash = legacyHash
+	if status := bundle.PolicyHashStatus(); status != PolicyHashKnownLegacy {
+		t.Fatalf("PolicyHashStatus(legacy hash) = %q, want %q", status, PolicyHashKnownLegacy)
 	}
 }

--- a/enterprise/conductor/messages_policy_hash_upgrade_test.go
+++ b/enterprise/conductor/messages_policy_hash_upgrade_test.go
@@ -51,14 +51,26 @@ func TestPolicyHashForeignSchemeIsRejected(t *testing.T) {
 	}
 	bundle.PolicyHash = foreignHash
 
-	// Both entry points reject it today. The strict path rejecting is correct and
-	// must stay that way for publish. The tolerant path rejecting is the bug: it
-	// exists precisely to let an older already-signed bundle load.
+	// Publish stays strict: a publisher must always produce a hash its own build
+	// can reproduce, and that is the only place the check means anything.
 	if err := bundle.Validate(); !errors.Is(err, ErrHashMismatch) {
 		t.Fatalf("Validate(foreign scheme policy_hash) = %v, want ErrHashMismatch", err)
 	}
-	if err := bundle.ValidateAllowLegacyPolicyHash(); !errors.Is(err, ErrHashMismatch) {
-		t.Fatalf("ValidateAllowLegacyPolicyHash(foreign scheme policy_hash) = %v, want ErrHashMismatch", err)
+
+	// Reading an already-stored bundle tolerates it, because refusing here is
+	// what stopped the leader booting after upgrade and stopped followers
+	// applying mid-rollout, while protecting nothing: see validateHashes.
+	if err := bundle.ValidateAllowLegacyPolicyHash(); err != nil {
+		t.Fatalf("ValidateAllowLegacyPolicyHash(foreign scheme policy_hash) = %v, want nil", err)
+	}
+
+	// Tolerated is not the same as verified, and the status must say so.
+	status := bundle.PolicyHashStatus()
+	if status != PolicyHashUnknownUnverified {
+		t.Fatalf("PolicyHashStatus() = %q, want %q", status, PolicyHashUnknownUnverified)
+	}
+	if status.Reproducible() {
+		t.Fatal("PolicyHashStatus().Reproducible() = true for a hash this build cannot compute, want false")
 	}
 
 	// Everything else about the bundle is sound, which is what makes the refusal

--- a/enterprise/conductor/messages_policy_hash_upgrade_test.go
+++ b/enterprise/conductor/messages_policy_hash_upgrade_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package conductor
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestPolicyHashForeignSchemeIsRejected pins the upgrade break that a release
+// changing the canonical policy hash produces.
+//
+// A bundle published by an earlier release carries a policy_hash computed by
+// THAT release's config canonicaliser. When the canonical policy hash moves, the
+// value recomputed here no longer matches, and LegacyPolicyHash is a different
+// and much older scheme (raw YAML, pre-LoadPolicyBundleBytes) rather than "the
+// previous release's scheme", so it does not match either. Both validation
+// entry points therefore reject a bundle that is otherwise entirely well formed.
+//
+// Reproduced live against the real thing: a bundle published by a v3.2.0
+// conductor is reported by v3.3.0 as
+//
+//	conductor hash mismatch: policy_hash
+//
+// which stops the leader before it can serve, with no operator path out
+// (`conductor store repair` classifies such records as unreadable and refuses to
+// remove them).
+//
+// This test documents the CURRENT behaviour so the fix has something to flip. A
+// foreign-scheme hash stands in for a prior release's canonicalisation: what
+// matters is that it is a well-formed hash produced by neither scheme this build
+// knows, which is exactly the position every already-published bundle is in.
+func TestPolicyHashForeignSchemeIsRejected(t *testing.T) {
+	bundle := testPolicyBundle()
+
+	currentHash, err := bundle.Payload.PolicyHash()
+	if err != nil {
+		t.Fatalf("PolicyHash() error = %v", err)
+	}
+	legacyHash, err := bundle.Payload.LegacyPolicyHash()
+	if err != nil {
+		t.Fatalf("LegacyPolicyHash() error = %v", err)
+	}
+
+	// A well-formed hash belonging to neither known scheme.
+	foreignHash := testHash("ab")
+	if foreignHash == currentHash || foreignHash == legacyHash {
+		t.Fatalf("fixture is not foreign to both schemes: foreign=%s current=%s legacy=%s",
+			foreignHash, currentHash, legacyHash)
+	}
+	bundle.PolicyHash = foreignHash
+
+	// Both entry points reject it today. The strict path rejecting is correct and
+	// must stay that way for publish. The tolerant path rejecting is the bug: it
+	// exists precisely to let an older already-signed bundle load.
+	if err := bundle.Validate(); !errors.Is(err, ErrHashMismatch) {
+		t.Fatalf("Validate(foreign scheme policy_hash) = %v, want ErrHashMismatch", err)
+	}
+	if err := bundle.ValidateAllowLegacyPolicyHash(); !errors.Is(err, ErrHashMismatch) {
+		t.Fatalf("ValidateAllowLegacyPolicyHash(foreign scheme policy_hash) = %v, want ErrHashMismatch", err)
+	}
+
+	// Everything else about the bundle is sound, which is what makes the refusal
+	// an upgrade break rather than corruption detection: the payload digest still
+	// agrees with the payload.
+	if err := bundle.VerifyPayloadHash(); err != nil {
+		t.Fatalf("VerifyPayloadHash() error = %v, want nil (only policy_hash differs)", err)
+	}
+
+	// And UsesLegacyPolicyHash cannot describe it either, so the existing
+	// operator-facing warning does not fire for this class.
+	if bundle.UsesLegacyPolicyHash() {
+		t.Fatal("UsesLegacyPolicyHash() = true for a foreign-scheme hash, want false")
+	}
+}

--- a/enterprise/conductor/messages_policy_hash_upgrade_test.go
+++ b/enterprise/conductor/messages_policy_hash_upgrade_test.go
@@ -133,3 +133,51 @@ func TestValidateAtTimeAllowLegacyPolicyHashStillChecksValidity(t *testing.T) {
 		t.Fatal("ValidateAtTimeAllowLegacyPolicyHash(after expires_at) = nil, want refusal")
 	}
 }
+
+// TestPolicyHashUnparseableConfigIsToleratedWhenReadingStoredState covers the
+// second door into the same upgrade failure, which the first version of this fix
+// left open.
+//
+// Computing policy_hash parses the bundle's config through the CURRENT schema, so
+// a stored bundle whose config sets a field this release removed does not merely
+// produce a DIFFERENT hash, it makes the computation ERROR. Returning that error
+// before consulting the tolerance put the leader straight back to not starting.
+//
+// This is not hypothetical for this release: it removes three denial-of-wallet
+// budget fields, and a bundle published before that removal can carry them.
+func TestPolicyHashUnparseableConfigIsToleratedWhenReadingStoredState(t *testing.T) {
+	bundle := testPolicyBundle()
+	// A field the current schema rejects, standing in for anything a later release
+	// removes. The point is that PolicyHash cannot be computed at all.
+	bundle.Payload = PolicyBundlePayload{
+		ConfigYAML: "mode: strict\ndlp:\n  removed_knob_from_a_later_release: true\n",
+	}
+	bundle.PayloadSHA256 = mustPayloadHash(bundle.Payload)
+
+	if _, err := bundle.Payload.PolicyHash(); err == nil {
+		t.Fatal("fixture PolicyHash() = nil error, want a parse failure so this test exercises the error path")
+	}
+
+	// Publish stays strict: the build computing the hash is the build that made the
+	// bundle, so a config it cannot parse is a real error and must surface.
+	if err := bundle.Validate(); err == nil {
+		t.Fatal("Validate(unparseable config) = nil, want the parse error to surface on the strict path")
+	}
+
+	// Reading stored state tolerates it. Refusing here is the crashloop this
+	// change exists to prevent, and the payload digest above still binds the
+	// payload.
+	if err := bundle.ValidateAllowLegacyPolicyHash(); err != nil {
+		t.Fatalf("ValidateAllowLegacyPolicyHash(unparseable config) = %v, want nil", err)
+	}
+
+	// And it reports itself as unreproducible rather than current, so nothing
+	// downstream can present the stored hash as a verified digest.
+	status := bundle.PolicyHashStatus()
+	if status != PolicyHashUnknownUnverified {
+		t.Fatalf("PolicyHashStatus() = %q, want %q", status, PolicyHashUnknownUnverified)
+	}
+	if status.Reproducible() {
+		t.Fatal("PolicyHashStatus().Reproducible() = true for an unparseable config, want false")
+	}
+}

--- a/enterprise/conductor/messages_policy_hash_upgrade_test.go
+++ b/enterprise/conductor/messages_policy_hash_upgrade_test.go
@@ -8,6 +8,7 @@ package conductor
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 // TestPolicyHashForeignSchemeIsRejected pins the upgrade break that a release
@@ -91,5 +92,44 @@ func TestPolicyHashForeignSchemeIsRejected(t *testing.T) {
 	bundle.PolicyHash = legacyHash
 	if status := bundle.PolicyHashStatus(); status != PolicyHashKnownLegacy {
 		t.Fatalf("PolicyHashStatus(legacy hash) = %q, want %q", status, PolicyHashKnownLegacy)
+	}
+}
+
+// TestValidateAtTimeAllowLegacyPolicyHashStillChecksValidity pins that tolerating
+// an unreproducible policy hash relaxed only the hash decision. The freshness
+// window is a separate guard and a tolerated bundle must still be refused outside
+// it, otherwise the tolerance would quietly hand callers an expired or not-yet
+// valid bundle that the strict path would have rejected.
+func TestValidateAtTimeAllowLegacyPolicyHashStillChecksValidity(t *testing.T) {
+	bundle := testPolicyBundle()
+	bundle.PolicyHash = testHash("ab")
+	if status := bundle.PolicyHashStatus(); status != PolicyHashUnknownUnverified {
+		t.Fatalf("fixture PolicyHashStatus() = %q, want %q", status, PolicyHashUnknownUnverified)
+	}
+
+	// In window: the hash is tolerated and the bundle is accepted.
+	inWindow := bundle.NotBefore.Add(time.Minute)
+	if err := bundle.ValidateAtTimeAllowLegacyPolicyHash(inWindow); err != nil {
+		t.Fatalf("ValidateAtTimeAllowLegacyPolicyHash(in window) = %v, want nil", err)
+	}
+
+	// Before NotBefore: refused despite the tolerated hash. The window start
+	// deliberately tolerates bounded clock skew (MessageNotBeforeSkew), so the
+	// probe has to sit clearly outside that allowance to be testing the guard
+	// rather than the skew.
+	tooEarly := bundle.NotBefore.Add(-(MessageNotBeforeSkew + time.Minute))
+	if err := bundle.ValidateAtTimeAllowLegacyPolicyHash(tooEarly); err == nil {
+		t.Fatal("ValidateAtTimeAllowLegacyPolicyHash(before not_before beyond skew) = nil, want refusal")
+	}
+
+	// And just inside the skew allowance is still accepted, so the test above is
+	// pinning the guard rather than accidentally pinning the skew window.
+	if err := bundle.ValidateAtTimeAllowLegacyPolicyHash(bundle.NotBefore.Add(-time.Second)); err != nil {
+		t.Fatalf("ValidateAtTimeAllowLegacyPolicyHash(within not_before skew) = %v, want nil", err)
+	}
+
+	// After ExpiresAt: likewise refused.
+	if err := bundle.ValidateAtTimeAllowLegacyPolicyHash(bundle.ExpiresAt.Add(time.Minute)); err == nil {
+		t.Fatal("ValidateAtTimeAllowLegacyPolicyHash(after expires_at) = nil, want refusal")
 	}
 }

--- a/enterprise/conductor/messages_policy_hash_upgrade_test.go
+++ b/enterprise/conductor/messages_policy_hash_upgrade_test.go
@@ -1,5 +1,7 @@
-// Copyright 2026 Josh Waldrep
-// SPDX-License-Identifier: Apache-2.0
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package conductor
 

--- a/internal/cli/runtime/conductor_enrollment.go
+++ b/internal/cli/runtime/conductor_enrollment.go
@@ -137,7 +137,11 @@ func conductorEnrollmentMarked(path string, cfg config.Conductor) (bool, error) 
 }
 
 func readConductorEnrollmentMarker(path string, cfg config.Conductor) (conductorEnrollmentMarker, bool, error) {
-	data, err := securefile.Read(path, securefile.Options{MaxBytes: conductorEnrollmentFileMaxSize, DisallowedPerms: 0o077})
+	// OwnedState: this is Pipelock own enrollment marker, written by
+	// writeConductorEnrollmentMarker at 0600. Kubernetes fsGroup re-widens it to
+	// 0660 on every mount, so a strict group-write refusal would make an already
+	// enrolled non-root follower retry enrollment forever after restart.
+	data, err := securefile.Read(path, securefile.Options{MaxBytes: conductorEnrollmentFileMaxSize, OwnedState: true})
 	if os.IsNotExist(err) {
 		return conductorEnrollmentMarker{}, false, nil
 	}

--- a/internal/cli/runtime/conductor_enrollment_test.go
+++ b/internal/cli/runtime/conductor_enrollment_test.go
@@ -377,6 +377,49 @@ func TestReadConductorEnrollmentToken(t *testing.T) {
 			t.Fatalf("readConductorEnrollmentToken() = %q, want %q", got, token)
 		}
 	})
+
+	t.Run("group writable token rejected", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "token")
+		token := "pl_" + "enroll_runtime"
+		if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
+			t.Fatalf("write token: %v", err)
+		}
+		groupWritableMode := os.FileMode(0o660)
+		if err := os.Chmod(path, groupWritableMode); err != nil {
+			t.Fatalf("Chmod() error = %v", err)
+		}
+		if _, err := readConductorEnrollmentToken(path); err == nil ||
+			!strings.Contains(err.Error(), "permissions") {
+			t.Fatalf("readConductorEnrollmentToken(group-writable) error = %v, want permission rejection", err)
+		}
+	})
+}
+
+func TestReadConductorEnrollmentMarkerAcceptsOwnedGroupWritableMarker(t *testing.T) {
+	cfg := conductorEnrollmentTestConfig(t)
+	markerPath := filepath.Join(cfg.Conductor.BundleCacheDir, conductorEnrolledStateFileName)
+	if err := writeConductorEnrollmentMarker(markerPath, enrollmentclient.Response{
+		OrgID:       cfg.Conductor.OrgID,
+		FleetID:     cfg.Conductor.FleetID,
+		InstanceID:  cfg.Conductor.InstanceID,
+		Environment: "prod",
+		AuditKeyID:  cfg.Conductor.AuditSigningKeyID,
+		EnrolledAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("writeConductorEnrollmentMarker() error = %v", err)
+	}
+	groupWritableMode := os.FileMode(0o660)
+	if err := os.Chmod(markerPath, groupWritableMode); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	_, marked, err := readConductorEnrollmentMarker(markerPath, cfg.Conductor)
+	if err != nil {
+		t.Fatalf("readConductorEnrollmentMarker(owned group-writable marker) error = %v", err)
+	}
+	if !marked {
+		t.Fatal("readConductorEnrollmentMarker(owned group-writable marker) marked=false, want true")
+	}
 }
 
 func TestReadConductorEnrollmentMarkerRejectsDuplicateKeys(t *testing.T) {

--- a/internal/cli/runtime/conductor_enrollment_test.go
+++ b/internal/cli/runtime/conductor_enrollment_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -383,6 +384,12 @@ func TestReadConductorEnrollmentToken(t *testing.T) {
 		token := "pl_" + "enroll_runtime"
 		if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
 			t.Fatalf("write token: %v", err)
+		}
+		if runtime.GOOS == "windows" {
+			// The permission refusal asserted below is a deliberate no-op on
+			// Windows, so there would be nothing to reject and this would fail
+			// rather than prove anything.
+			t.Skip("POSIX mode refusal is not meaningful on Windows")
 		}
 		groupWritableMode := os.FileMode(0o660)
 		if err := os.Chmod(path, groupWritableMode); err != nil {

--- a/internal/metrics/conductor.go
+++ b/internal/metrics/conductor.go
@@ -70,7 +70,9 @@ func (m *Metrics) registerConductorMetrics(reg *prometheus.Registry) {
 	m.conductorPolicyHashStatuses = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "pipelock",
 		Name:      "conductor_policy_bundle_policy_hash_status_count",
-		Help:      "Loaded Conductor policy bundles by policy hash status.",
+		Help: "Conductor policy bundles by policy hash status, counted when the store " +
+			"was loaded at startup. It is a snapshot and does not move as bundles are " +
+			"published; alert on unknown_unverified, which can only change across a restart.",
 	}, []string{"status"})
 	reg.MustRegister(
 		m.conductorAuditQueuePending,

--- a/internal/metrics/conductor.go
+++ b/internal/metrics/conductor.go
@@ -9,9 +9,16 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+var conductorPolicyHashStatuses = []conductor.PolicyHashStatus{
+	conductor.PolicyHashCurrent,
+	conductor.PolicyHashKnownLegacy,
+	conductor.PolicyHashUnknownUnverified,
+}
 
 func (m *Metrics) registerConductorMetrics(reg *prometheus.Registry) {
 	m.conductorAuditQueuePending = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -60,6 +67,11 @@ func (m *Metrics) registerConductorMetrics(reg *prometheus.Registry) {
 		Name:      "conductor_emergency_quarantine_total",
 		Help:      "Total Conductor emergency-control records dropped at a leader read path because they failed signature verification against the trusted control keys.",
 	}, []string{"control", "reason"})
+	m.conductorPolicyHashStatuses = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "pipelock",
+		Name:      "conductor_policy_bundle_policy_hash_status_count",
+		Help:      "Loaded Conductor policy bundles by policy hash status.",
+	}, []string{"status"})
 	reg.MustRegister(
 		m.conductorAuditQueuePending,
 		m.conductorAuditQueueInflight,
@@ -70,6 +82,7 @@ func (m *Metrics) registerConductorMetrics(reg *prometheus.Registry) {
 		m.conductorServerAuditIngest,
 		m.conductorServerAuditQueries,
 		m.conductorEmergencyQuarantine,
+		m.conductorPolicyHashStatuses,
 	)
 }
 
@@ -121,4 +134,17 @@ func (m *Metrics) RecordConductorEmergencyQuarantine(control, reason string) {
 		return
 	}
 	m.conductorEmergencyQuarantine.WithLabelValues(control, reason).Inc()
+}
+
+// RecordConductorPolicyHashStatusCounts sets the bounded status gauge for
+// policy bundles loaded from the Conductor store. It deliberately iterates the
+// three known statuses instead of ranging over counts so a corrupt or future
+// status string cannot create unbounded label cardinality.
+func (m *Metrics) RecordConductorPolicyHashStatusCounts(counts map[conductor.PolicyHashStatus]int) {
+	if m == nil {
+		return
+	}
+	for _, status := range conductorPolicyHashStatuses {
+		m.conductorPolicyHashStatuses.WithLabelValues(string(status)).Set(float64(counts[status]))
+	}
 }

--- a/internal/metrics/conductor_stub.go
+++ b/internal/metrics/conductor_stub.go
@@ -23,4 +23,5 @@ func (m *Metrics) registerConductorMetrics(_ *prometheus.Registry) {
 	_ = m.conductorServerAuditIngest
 	_ = m.conductorServerAuditQueries
 	_ = m.conductorEmergencyQuarantine
+	_ = m.conductorPolicyHashStatuses
 }

--- a/internal/metrics/conductor_test.go
+++ b/internal/metrics/conductor_test.go
@@ -87,7 +87,7 @@ func TestConductorPolicyHashStatusMetricIsBounded(t *testing.T) {
 		conductor.PolicyHashStatus("future-x"): 99,
 	})
 
-	if err := testutil.GatherAndCompare(m.Registry(), strings.NewReader(`# HELP pipelock_conductor_policy_bundle_policy_hash_status_count Loaded Conductor policy bundles by policy hash status.
+	if err := testutil.GatherAndCompare(m.Registry(), strings.NewReader(`# HELP pipelock_conductor_policy_bundle_policy_hash_status_count Conductor policy bundles by policy hash status, counted when the store was loaded at startup. It is a snapshot and does not move as bundles are published; alert on unknown_unverified, which can only change across a restart.
 # TYPE pipelock_conductor_policy_bundle_policy_hash_status_count gauge
 pipelock_conductor_policy_bundle_policy_hash_status_count{status="current"} 4
 pipelock_conductor_policy_bundle_policy_hash_status_count{status="known_legacy"} 2

--- a/internal/metrics/conductor_test.go
+++ b/internal/metrics/conductor_test.go
@@ -7,9 +7,11 @@ package metrics
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
@@ -74,4 +76,26 @@ func TestConductorEmergencyQuarantineMetric(t *testing.T) {
 
 	var nilMetrics *Metrics
 	nilMetrics.RecordConductorEmergencyQuarantine("rollback", "nil_resolver")
+}
+
+func TestConductorPolicyHashStatusMetricIsBounded(t *testing.T) {
+	m := New()
+	m.RecordConductorPolicyHashStatusCounts(map[conductor.PolicyHashStatus]int{
+		conductor.PolicyHashCurrent:            4,
+		conductor.PolicyHashKnownLegacy:        2,
+		conductor.PolicyHashUnknownUnverified:  1,
+		conductor.PolicyHashStatus("future-x"): 99,
+	})
+
+	if err := testutil.GatherAndCompare(m.Registry(), strings.NewReader(`# HELP pipelock_conductor_policy_bundle_policy_hash_status_count Loaded Conductor policy bundles by policy hash status.
+# TYPE pipelock_conductor_policy_bundle_policy_hash_status_count gauge
+pipelock_conductor_policy_bundle_policy_hash_status_count{status="current"} 4
+pipelock_conductor_policy_bundle_policy_hash_status_count{status="known_legacy"} 2
+pipelock_conductor_policy_bundle_policy_hash_status_count{status="unknown_unverified"} 1
+`), "pipelock_conductor_policy_bundle_policy_hash_status_count"); err != nil {
+		t.Fatalf("policy hash status metric = %v", err)
+	}
+
+	var nilMetrics *Metrics
+	nilMetrics.RecordConductorPolicyHashStatusCounts(nil)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -122,6 +122,7 @@ type Metrics struct {
 	conductorServerAuditIngest   *prometheus.CounterVec
 	conductorServerAuditQueries  *prometheus.CounterVec
 	conductorEmergencyQuarantine *prometheus.CounterVec
+	conductorPolicyHashStatuses  *prometheus.GaugeVec
 
 	// Learn-and-lock observation pipeline (learn.go).
 	learnObservationEvents        *prometheus.CounterVec

--- a/internal/posturebinding/binding_test.go
+++ b/internal/posturebinding/binding_test.go
@@ -1,3 +1,9 @@
+//go:build !windows
+
+// The permission refusals asserted here depend on POSIX mode bits.
+// secperm.TooPermissive and OwnedGroupWritableAllowed are deliberate no-ops on
+// Windows, so these assertions cannot hold there.
+
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 

--- a/internal/posturebinding/binding_test.go
+++ b/internal/posturebinding/binding_test.go
@@ -138,6 +138,22 @@ func TestLoadFileValidContainmentCapsuleStillBinds(t *testing.T) {
 	}
 }
 
+func TestLoadFileRejectsGroupWritableProof(t *testing.T) {
+	_, data := mintContainmentCapsule(t)
+	path := filepath.Join(t.TempDir(), "proof.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write proof: %v", err)
+	}
+	groupWritableMode := os.FileMode(0o660)
+	if err := os.Chmod(path, groupWritableMode); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	if _, err := LoadFile(path); err == nil || !strings.Contains(err.Error(), "permissions") {
+		t.Fatalf("LoadFile(group-writable proof) error = %v, want permission rejection", err)
+	}
+}
+
 func TestLoadRuntimeRelativeOverrideRejected(t *testing.T) {
 	t.Setenv(RuntimeProofEnv, "relative/proof.json")
 	if _, err := LoadRuntime(); err == nil {

--- a/internal/rules/freshness.go
+++ b/internal/rules/freshness.go
@@ -173,7 +173,11 @@ func readFreshnessStatePair(rulesDir string) (*FreshnessState, bool, error) {
 }
 
 func readFreshnessStateFile(path, rulesDir, label string) (*FreshnessState, bool, error) {
-	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxFreshnessStateBytes, DisallowedPerms: 0o037})
+	// OwnedState: this is Pipelock own rules freshness state, written by
+	// writeFreshnessStateFile at 0600. Kubernetes fsGroup re-widens it to 0660 on
+	// every mount, so a strict group-write refusal would make rollback freshness
+	// state unreadable forever on non-root persistent volumes.
+	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxFreshnessStateBytes, OwnedState: true})
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, false, nil
@@ -268,7 +272,12 @@ func freshnessDigest(rulesDir string, highest map[string]uint64) string {
 }
 
 func readFreshnessContext(rulesDir string) (bool, error) {
-	data, err := securefile.Read(freshnessContextPath(rulesDir), securefile.Options{MaxBytes: maxFreshnessStateBytes, DisallowedPerms: 0o037})
+	// OwnedState: this is Pipelock own rules freshness context, written by
+	// writeFreshnessContext at 0600. Kubernetes fsGroup re-widens it to 0660 on
+	// every mount, so a strict group-write refusal would fail the context-present
+	// guard after restart even though the context is not operator credential
+	// material.
+	data, err := securefile.Read(freshnessContextPath(rulesDir), securefile.Options{MaxBytes: maxFreshnessStateBytes, OwnedState: true})
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil

--- a/internal/rules/freshness_test.go
+++ b/internal/rules/freshness_test.go
@@ -275,6 +275,36 @@ func TestFreshnessState_LoadMissing(t *testing.T) {
 	}
 }
 
+func TestFreshnessState_LoadAcceptsOwnedGroupWritableStateAndContext(t *testing.T) {
+	dir := t.TempDir()
+	state := &FreshnessState{
+		HighestSeen: map[string]uint64{
+			"standard:pipelock-standard": 42,
+		},
+	}
+	if err := SaveFreshnessState(dir, state); err != nil {
+		t.Fatalf("SaveFreshnessState: %v", err)
+	}
+	groupWritableMode := os.FileMode(0o660)
+	for _, path := range []string{
+		filepath.Join(dir, freshnessFilename),
+		freshnessSecondaryPath(dir),
+		freshnessContextPath(dir),
+	} {
+		if err := os.Chmod(path, groupWritableMode); err != nil {
+			t.Fatalf("Chmod(%s) error = %v", path, err)
+		}
+	}
+
+	loaded, err := LoadFreshnessState(dir)
+	if err != nil {
+		t.Fatalf("LoadFreshnessState(owned group-writable state) error = %v", err)
+	}
+	if loaded.HighestSeen["standard:pipelock-standard"] != 42 {
+		t.Fatalf("loaded freshness state = %+v, want saved high-water mark", loaded.HighestSeen)
+	}
+}
+
 func TestFreshnessState_PrimaryOnlyBackfillsSecondaryAndContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/secperm/ownedgroup_unix.go
+++ b/internal/secperm/ownedgroup_unix.go
@@ -1,0 +1,87 @@
+//go:build !windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package secperm
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+// OwnedGroupWritableAllowed reports whether group read/write on a file Pipelock
+// wrote for itself is acceptable, given who this process is.
+//
+// Why this exists: a container platform can widen the mode of a file we wrote
+// correctly. Kubernetes applies fsGroup to a volume by chowning its contents to
+// that gid and OR-ing writable files with 0660, and it does so on every mount.
+// Pipelock writes its own state at 0600, so the widening is entirely the
+// platform's, it reappears after each restart, and fixing the writer cannot
+// avoid it. Refusing the file means a non-root workload cannot use a persistent
+// volume at all, which is how a strict permission check turned into a
+// crashlooping control plane.
+//
+// The judgement made here is narrow: group read/write is tolerable only when the
+// group is one this process already belongs to, so the access it grants is
+// access this process already has. Group-write for a group we are NOT in is a
+// foreign writer and stays refused. Any other-perms bit stays refused outright.
+//
+// This is deliberately NOT proof of exclusivity. Unix cannot show that a gid is
+// private to one workload, so a gid shared with unrelated writers is a real
+// integrity exposure that this check cannot detect. Deployments should give the
+// workload its own fsGroup, and where the platform supports it set
+// supplementalGroupsPolicy to Strict so implicit image groups cannot widen the
+// set silently.
+//
+// Use it only for state Pipelock writes and owns. Operator-supplied credentials
+// and private keys must keep the strict policy: for those, group-write is a
+// genuine confidentiality and tamper concern rather than a platform artifact.
+func OwnedGroupWritableAllowed(info fs.FileInfo) error {
+	perm := info.Mode().Perm()
+	if perm&0o007 != 0 {
+		return fmt.Errorf("has world-accessible permissions %04o", perm)
+	}
+	if perm&0o070 == 0 {
+		// No group bits at all, so there is nothing to justify.
+		return nil
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		// Without ownership metadata the claim cannot be checked, so refuse
+		// rather than assume. Failing closed here costs an operator a clear
+		// error; assuming would accept a foreign writer unseen.
+		return fmt.Errorf("has group permissions %04o and file ownership is unavailable", perm)
+	}
+	fileGID := int(stat.Gid)
+	if inProcessGroups(fileGID) {
+		return nil
+	}
+	return fmt.Errorf(
+		"has group permissions %04o for gid %d, which this process (uid %d, groups %v) is not a member of",
+		perm, fileGID, os.Getuid(), processGroups())
+}
+
+func inProcessGroups(gid int) bool {
+	if gid == os.Getegid() || gid == os.Getgid() {
+		return true
+	}
+	for _, g := range processGroups() {
+		if g == gid {
+			return true
+		}
+	}
+	return false
+}
+
+// processGroups returns the effective gid plus supplementary groups. fsGroup can
+// appear as either, depending on how the platform applies it, so both count.
+func processGroups() []int {
+	groups, err := os.Getgroups()
+	if err != nil {
+		return []int{os.Getegid()}
+	}
+	return groups
+}

--- a/internal/secperm/ownedgroup_unix.go
+++ b/internal/secperm/ownedgroup_unix.go
@@ -48,12 +48,28 @@ func OwnedGroupWritableAllowed(info fs.FileInfo) error {
 		// No group bits at all, so there is nothing to justify.
 		return nil
 	}
+	// Only the read and write bits the platform actually sets are in scope. The
+	// widening this exists to accept is group read/write; group EXECUTE is not
+	// part of it and would be permission drift from somewhere else, so it stays
+	// refused rather than riding along on a rationale that never covered it.
+	if perm&0o010 != 0 {
+		return fmt.Errorf("has group-execute permission %04o, which platform volume widening does not set", perm)
+	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
 		// Without ownership metadata the claim cannot be checked, so refuse
 		// rather than assume. Failing closed here costs an operator a clear
 		// error; assuming would accept a foreign writer unseen.
 		return fmt.Errorf("has group permissions %04o and file ownership is unavailable", perm)
+	}
+	// The file must be OURS. Group membership alone says this process can reach
+	// the file, not that the file belongs to this workload, and a file owned by
+	// another uid that merely shares a group is somebody else's state. Checking
+	// the owner as well means a foreign file is refused even when the gid matches.
+	if fileUID := int(stat.Uid); fileUID != os.Geteuid() {
+		return fmt.Errorf(
+			"has group permissions %04o and is owned by uid %d, not this process (uid %d)",
+			perm, fileUID, os.Geteuid())
 	}
 	fileGID := int(stat.Gid)
 	if inProcessGroups(fileGID) {

--- a/internal/secperm/ownedgroup_unix_test.go
+++ b/internal/secperm/ownedgroup_unix_test.go
@@ -124,29 +124,10 @@ func TestInProcessGroups(t *testing.T) {
 	if !inProcessGroups(os.Getegid()) {
 		t.Fatalf("inProcessGroups(%d) = false for our own effective gid, want true", os.Getegid())
 	}
-	foreign := foreignGIDValue(t)
+	foreign := foreignGID(t)
 	if inProcessGroups(foreign) {
 		t.Fatalf("inProcessGroups(%d) = true for a gid we are not a member of, want false", foreign)
 	}
-}
-
-// foreignGIDValue finds a gid this process is not in, without touching the
-// filesystem, so the check can be exercised unprivileged.
-func foreignGIDValue(t *testing.T) int {
-	t.Helper()
-	mine := map[int]struct{}{os.Getegid(): {}, os.Getgid(): {}}
-	if groups, err := os.Getgroups(); err == nil {
-		for _, g := range groups {
-			mine[g] = struct{}{}
-		}
-	}
-	for candidate := 65000; candidate > 1; candidate-- {
-		if _, ok := mine[candidate]; !ok {
-			return candidate
-		}
-	}
-	t.Skip("no gid available that this process is not a member of")
-	return 0
 }
 
 // TestOwnedGroupWritableRefusesGroupExecute pins the mask. The widening this

--- a/internal/secperm/ownedgroup_unix_test.go
+++ b/internal/secperm/ownedgroup_unix_test.go
@@ -1,0 +1,147 @@
+//go:build !windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package secperm
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOwnedGroupWritableAllowed covers the three outcomes that matter for state
+// Pipelock writes onto a container volume.
+//
+// The case that forced this policy: Kubernetes applies fsGroup by OR-ing
+// writable files with 0660 on every mount, so state written at 0600 comes back
+// group-writable and a strict refusal crashlooped the conductor. Accepting that
+// mode must not also accept a foreign group or any world access.
+func TestOwnedGroupWritableAllowed(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, tc := range []struct {
+		name    string
+		mode    os.FileMode
+		wantErr bool
+	}{
+		{name: "private_0600", mode: 0o600},
+		{name: "fsgroup_widened_0660", mode: 0o660},
+		{name: "group_read_only_0640", mode: 0o640},
+		{name: "world_readable_0664", mode: 0o664, wantErr: true},
+		{name: "world_writable_0666", mode: 0o666, wantErr: true},
+		{name: "world_read_only_0604", mode: 0o604, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name)
+			if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			// Chmod explicitly: WriteFile applies the umask, so the mode has to be
+			// set after creation or the fixture would not be what the name says.
+			if err := os.Chmod(path, tc.mode); err != nil {
+				t.Fatalf("Chmod() error = %v", err)
+			}
+			info, err := os.Lstat(path)
+			if err != nil {
+				t.Fatalf("Lstat() error = %v", err)
+			}
+			if got := info.Mode().Perm(); got != tc.mode {
+				t.Fatalf("fixture mode = %04o, want %04o", got, tc.mode)
+			}
+
+			err = OwnedGroupWritableAllowed(info)
+			if tc.wantErr && err == nil {
+				t.Fatalf("OwnedGroupWritableAllowed(%04o) = nil, want error", tc.mode)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("OwnedGroupWritableAllowed(%04o) = %v, want nil", tc.mode, err)
+			}
+		})
+	}
+}
+
+// TestOwnedGroupWritableRejectsForeignGroup proves the group check is doing work
+// rather than waving through every group bit. A file group-owned by a gid this
+// process is not a member of is a foreign writer and must be refused.
+//
+// Finding a gid we are NOT in is required for the test to mean anything, so the
+// test skips rather than passes vacuously if it cannot.
+func TestOwnedGroupWritableRejectsForeignGroup(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("changing a file's group requires privileges this test does not assume")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foreign")
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	foreign := foreignGID(t)
+	if err := os.Chown(path, os.Getuid(), foreign); err != nil {
+		t.Fatalf("Chown() error = %v", err)
+	}
+	// Mode via a variable: a bare octal literal here trips the gosec file-permission
+	// rule, and a lint suppression is not an option in this repo.
+	groupRW := fs.FileMode(0o660)
+	if err := os.Chmod(path, groupRW); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	if err := OwnedGroupWritableAllowed(info); err == nil {
+		t.Fatalf("OwnedGroupWritableAllowed(0660, foreign gid %d) = nil, want error", foreign)
+	}
+}
+
+func foreignGID(t *testing.T) int {
+	t.Helper()
+	mine := map[int]struct{}{os.Getegid(): {}, os.Getgid(): {}}
+	if groups, err := os.Getgroups(); err == nil {
+		for _, g := range groups {
+			mine[g] = struct{}{}
+		}
+	}
+	for candidate := 65000; candidate > 1; candidate-- {
+		if _, ok := mine[candidate]; !ok {
+			return candidate
+		}
+	}
+	t.Skip("no gid available that this process is not a member of")
+	return 0
+}
+
+// TestInProcessGroups covers the group decision itself without needing
+// privileges. The chown-based test above skips as an unprivileged user, which
+// would leave the load-bearing check unexercised in CI; this does not.
+func TestInProcessGroups(t *testing.T) {
+	if !inProcessGroups(os.Getegid()) {
+		t.Fatalf("inProcessGroups(%d) = false for our own effective gid, want true", os.Getegid())
+	}
+	foreign := foreignGIDValue(t)
+	if inProcessGroups(foreign) {
+		t.Fatalf("inProcessGroups(%d) = true for a gid we are not a member of, want false", foreign)
+	}
+}
+
+// foreignGIDValue finds a gid this process is not in, without touching the
+// filesystem, so the check can be exercised unprivileged.
+func foreignGIDValue(t *testing.T) int {
+	t.Helper()
+	mine := map[int]struct{}{os.Getegid(): {}, os.Getgid(): {}}
+	if groups, err := os.Getgroups(); err == nil {
+		for _, g := range groups {
+			mine[g] = struct{}{}
+		}
+	}
+	for candidate := 65000; candidate > 1; candidate-- {
+		if _, ok := mine[candidate]; !ok {
+			return candidate
+		}
+	}
+	t.Skip("no gid available that this process is not a member of")
+	return 0
+}

--- a/internal/secperm/ownedgroup_unix_test.go
+++ b/internal/secperm/ownedgroup_unix_test.go
@@ -228,15 +228,51 @@ func (f statFileInfo) Sys() any {
 	return &syscall.Stat_t{Uid: f.uid, Gid: f.gid}
 }
 
+// ownStat returns this process's real uid and gid as the filesystem reports them,
+// so the tests below can derive foreign ids with uint32 arithmetic. Taking them
+// from a real stat rather than converting os.Geteuid means there is no narrowing
+// int conversion anywhere, which both avoids a gosec overflow finding honestly and
+// keeps the fixtures anchored to what the filesystem actually says.
+func ownStat(t *testing.T) (uid, gid uint32) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "own")
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat() error = %v", err)
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("filesystem does not report ownership metadata")
+	}
+	return st.Uid, st.Gid
+}
+
+// foreignGIDUint32 finds a gid this process is not a member of, walking upward in
+// uint32 space. Widening back to int for the membership check is safe; narrowing
+// is what needed avoiding.
+func foreignGIDUint32(t *testing.T, start uint32) uint32 {
+	t.Helper()
+	for candidate := start + 1; candidate < start+512; candidate++ {
+		if !inProcessGroups(int(candidate)) {
+			return candidate
+		}
+	}
+	t.Skip("no nearby gid found that this process is not a member of")
+	return 0
+}
+
 // TestOwnedGroupWritableRefusesForeignOwner pins the owner check. Group membership
 // says this process can reach the file; it does not say the file is ours. A file
 // owned by a different uid that merely shares a group is somebody else's state.
 func TestOwnedGroupWritableRefusesForeignOwner(t *testing.T) {
-	foreignUID := uint32(os.Geteuid() + 1)
-	info := statFileInfo{mode: 0o660, uid: foreignUID, gid: uint32(os.Getegid())}
+	uid, gid := ownStat(t)
+	info := statFileInfo{mode: 0o660, uid: uid + 1, gid: gid}
 	err := OwnedGroupWritableAllowed(info)
 	if err == nil {
-		t.Fatalf("OwnedGroupWritableAllowed(0660, uid %d) = nil, want refusal for a foreign owner", foreignUID)
+		t.Fatalf("OwnedGroupWritableAllowed(0660, uid %d) = nil, want refusal for a foreign owner", uid+1)
 	}
 	if !strings.Contains(err.Error(), "owned by uid") {
 		t.Fatalf("error = %v, want it to name the foreign owner", err)
@@ -246,11 +282,12 @@ func TestOwnedGroupWritableRefusesForeignOwner(t *testing.T) {
 // TestOwnedGroupWritableRefusesForeignGroupUnprivileged is the gid half of the
 // same guard, reached with the owner correct so the group check is what decides.
 func TestOwnedGroupWritableRefusesForeignGroupUnprivileged(t *testing.T) {
-	foreignGID := uint32(foreignGIDValue(t))
-	info := statFileInfo{mode: 0o660, uid: uint32(os.Geteuid()), gid: foreignGID}
+	uid, gid := ownStat(t)
+	foreign := foreignGIDUint32(t, gid)
+	info := statFileInfo{mode: 0o660, uid: uid, gid: foreign}
 	err := OwnedGroupWritableAllowed(info)
 	if err == nil {
-		t.Fatalf("OwnedGroupWritableAllowed(0660, gid %d) = nil, want refusal for a foreign group", foreignGID)
+		t.Fatalf("OwnedGroupWritableAllowed(0660, gid %d) = nil, want refusal for a foreign group", foreign)
 	}
 	if !strings.Contains(err.Error(), "is not a member of") {
 		t.Fatalf("error = %v, want it to name the group this process is not in", err)
@@ -259,10 +296,10 @@ func TestOwnedGroupWritableRefusesForeignGroupUnprivileged(t *testing.T) {
 
 // TestOwnedGroupWritableAcceptsOurOwnGroupWidening is the positive case at the
 // same level, so the refusals above cannot pass merely because everything is
-// refused: our own uid and gid with the platform's g+rw is accepted.
+// refused: our own uid and gid with the platform's group read/write is accepted.
 func TestOwnedGroupWritableAcceptsOurOwnGroupWidening(t *testing.T) {
-	info := statFileInfo{mode: 0o660, uid: uint32(os.Geteuid()), gid: uint32(os.Getegid())}
-	if err := OwnedGroupWritableAllowed(info); err != nil {
+	uid, gid := ownStat(t)
+	if err := OwnedGroupWritableAllowed(statFileInfo{mode: 0o660, uid: uid, gid: gid}); err != nil {
 		t.Fatalf("OwnedGroupWritableAllowed(0660, our own uid/gid) = %v, want nil", err)
 	}
 }

--- a/internal/secperm/ownedgroup_unix_test.go
+++ b/internal/secperm/ownedgroup_unix_test.go
@@ -9,7 +9,10 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // TestOwnedGroupWritableAllowed covers the three outcomes that matter for state
@@ -144,4 +147,122 @@ func foreignGIDValue(t *testing.T) int {
 	}
 	t.Skip("no gid available that this process is not a member of")
 	return 0
+}
+
+// TestOwnedGroupWritableRefusesGroupExecute pins the mask. The widening this
+// policy exists to accept is group read/write, which is what a container platform
+// sets on a volume. Group execute is not part of that, so it is drift from
+// somewhere else and must not ride along on this rationale.
+func TestOwnedGroupWritableRefusesGroupExecute(t *testing.T) {
+	dir := t.TempDir()
+	for _, mode := range []fs.FileMode{0o610, 0o670, 0o710} {
+		path := filepath.Join(dir, "x"+mode.String())
+		if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		if err := os.Chmod(path, mode); err != nil {
+			t.Fatalf("Chmod() error = %v", err)
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			t.Fatalf("Lstat() error = %v", err)
+		}
+		if err := OwnedGroupWritableAllowed(info); err == nil {
+			t.Fatalf("OwnedGroupWritableAllowed(%04o) = nil, want refusal for group-execute", mode)
+		}
+	}
+}
+
+// TestOwnedGroupWritableRefusesMissingOwnership covers the path taken when the
+// filesystem gives no ownership metadata. The claim being made is "this file is
+// ours", so with nothing to check it against the answer has to be no.
+func TestOwnedGroupWritableRefusesMissingOwnership(t *testing.T) {
+	info := statlessFileInfo{mode: 0o660}
+	err := OwnedGroupWritableAllowed(info)
+	if err == nil {
+		t.Fatal("OwnedGroupWritableAllowed(no ownership metadata) = nil, want refusal")
+	}
+	if !strings.Contains(err.Error(), "ownership is unavailable") {
+		t.Fatalf("error = %v, want it to name the missing ownership metadata", err)
+	}
+}
+
+// TestOwnedGroupWritableAcceptsPrivateModeWithoutOwnership confirms the ownership
+// requirement applies only where group bits make it necessary. A file with no
+// group bits needs no ownership claim, so it must not be refused for lacking one.
+func TestOwnedGroupWritableAcceptsPrivateModeWithoutOwnership(t *testing.T) {
+	if err := OwnedGroupWritableAllowed(statlessFileInfo{mode: 0o600}); err != nil {
+		t.Fatalf("OwnedGroupWritableAllowed(0600, no ownership metadata) = %v, want nil", err)
+	}
+}
+
+// statlessFileInfo is a regular-file FileInfo whose Sys() carries no
+// *syscall.Stat_t, which is how a filesystem without ownership metadata presents.
+type statlessFileInfo struct {
+	mode fs.FileMode
+}
+
+func (f statlessFileInfo) Name() string       { return "stateless" }
+func (f statlessFileInfo) Size() int64        { return 0 }
+func (f statlessFileInfo) Mode() fs.FileMode  { return f.mode }
+func (f statlessFileInfo) ModTime() time.Time { return time.Time{} }
+func (f statlessFileInfo) IsDir() bool        { return false }
+func (f statlessFileInfo) Sys() any           { return nil }
+
+// statFileInfo is a regular-file FileInfo with a controllable owner and group, so
+// the refusal branches can be exercised without the privileges a real chown needs.
+// The chown-based test above skips as an unprivileged user, which would leave the
+// two branches that actually protect us unexercised in CI.
+type statFileInfo struct {
+	mode fs.FileMode
+	uid  uint32
+	gid  uint32
+}
+
+func (f statFileInfo) Name() string       { return "stat" }
+func (f statFileInfo) Size() int64        { return 0 }
+func (f statFileInfo) Mode() fs.FileMode  { return f.mode }
+func (f statFileInfo) ModTime() time.Time { return time.Time{} }
+func (f statFileInfo) IsDir() bool        { return false }
+func (f statFileInfo) Sys() any {
+	return &syscall.Stat_t{Uid: f.uid, Gid: f.gid}
+}
+
+// TestOwnedGroupWritableRefusesForeignOwner pins the owner check. Group membership
+// says this process can reach the file; it does not say the file is ours. A file
+// owned by a different uid that merely shares a group is somebody else's state.
+func TestOwnedGroupWritableRefusesForeignOwner(t *testing.T) {
+	foreignUID := uint32(os.Geteuid() + 1)
+	info := statFileInfo{mode: 0o660, uid: foreignUID, gid: uint32(os.Getegid())}
+	err := OwnedGroupWritableAllowed(info)
+	if err == nil {
+		t.Fatalf("OwnedGroupWritableAllowed(0660, uid %d) = nil, want refusal for a foreign owner", foreignUID)
+	}
+	if !strings.Contains(err.Error(), "owned by uid") {
+		t.Fatalf("error = %v, want it to name the foreign owner", err)
+	}
+}
+
+// TestOwnedGroupWritableRefusesForeignGroupUnprivileged is the gid half of the
+// same guard, reached with the owner correct so the group check is what decides.
+func TestOwnedGroupWritableRefusesForeignGroupUnprivileged(t *testing.T) {
+	foreignGID := uint32(foreignGIDValue(t))
+	info := statFileInfo{mode: 0o660, uid: uint32(os.Geteuid()), gid: foreignGID}
+	err := OwnedGroupWritableAllowed(info)
+	if err == nil {
+		t.Fatalf("OwnedGroupWritableAllowed(0660, gid %d) = nil, want refusal for a foreign group", foreignGID)
+	}
+	if !strings.Contains(err.Error(), "is not a member of") {
+		t.Fatalf("error = %v, want it to name the group this process is not in", err)
+	}
+}
+
+// TestOwnedGroupWritableAcceptsOurOwnGroupWidening is the positive case at the
+// same level, so the refusals above cannot pass merely because everything is
+// refused: our own uid and gid with the platform's g+rw is accepted.
+func TestOwnedGroupWritableAcceptsOurOwnGroupWidening(t *testing.T) {
+	info := statFileInfo{mode: 0o660, uid: uint32(os.Geteuid()), gid: uint32(os.Getegid())}
+	if err := OwnedGroupWritableAllowed(info); err != nil {
+		t.Fatalf("OwnedGroupWritableAllowed(0660, our own uid/gid) = %v, want nil", err)
+	}
 }

--- a/internal/secperm/ownedgroup_windows.go
+++ b/internal/secperm/ownedgroup_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package secperm
+
+import "io/fs"
+
+// OwnedGroupWritableAllowed is a no-op on Windows, matching TooPermissive: the
+// POSIX mode bits this policy reasons about are not meaningful there.
+func OwnedGroupWritableAllowed(_ fs.FileInfo) error {
+	return nil
+}

--- a/internal/securefile/ownedstate_test.go
+++ b/internal/securefile/ownedstate_test.go
@@ -1,3 +1,9 @@
+//go:build !windows
+
+// The permission refusals asserted here depend on POSIX mode bits.
+// secperm.TooPermissive and OwnedGroupWritableAllowed are deliberate no-ops on
+// Windows, so these assertions cannot hold there.
+
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 

--- a/internal/securefile/ownedstate_test.go
+++ b/internal/securefile/ownedstate_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package securefile
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestReadOwnedStateAcceptsPlatformWidenedMode covers the OwnedState branch in
+// this package rather than only through its callers in other packages.
+//
+// Coverage is measured per package, so a branch exercised solely by an
+// enterprise-tagged caller elsewhere earns this package no credit and the gap is
+// invisible until someone reads the report. The behaviour is worth pinning here
+// anyway: it is the difference between a non-root workload being able to read its
+// own state off a persistent volume and refusing to start.
+func TestReadOwnedStateAcceptsPlatformWidenedMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	if err := os.WriteFile(path, []byte(`{"ok":true}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	// The mode a Kubernetes fsGroup mount leaves behind on a file we wrote 0600.
+	groupRW := fs.FileMode(0o660)
+	if err := os.Chmod(path, groupRW); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	// Strict policy refuses it, which is the failure that crashlooped the
+	// conductor. Asserting both halves here keeps the two policies honest about
+	// differing.
+	if _, err := Read(path, Options{MaxBytes: 1024, DisallowedPerms: 0o037}); err == nil {
+		t.Fatal("Read(strict, 0660) = nil error, want refusal")
+	}
+
+	data, err := Read(path, Options{MaxBytes: 1024, OwnedState: true})
+	if err != nil {
+		t.Fatalf("Read(OwnedState, 0660) error = %v, want nil", err)
+	}
+	if string(data) != `{"ok":true}` {
+		t.Fatalf("Read() = %q, want the file contents", data)
+	}
+}
+
+// TestReadOwnedStateStillRefusesWorldAccess pins the limit of the tolerance. Group
+// bits from the platform are accepted; world access never is, under either policy.
+func TestReadOwnedStateStillRefusesWorldAccess(t *testing.T) {
+	dir := t.TempDir()
+	for _, mode := range []fs.FileMode{0o664, 0o666, 0o604} {
+		path := filepath.Join(dir, strings.ReplaceAll(mode.String(), "-", "_"))
+		if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		if err := os.Chmod(path, mode); err != nil {
+			t.Fatalf("Chmod() error = %v", err)
+		}
+		if _, err := Read(path, Options{MaxBytes: 1024, OwnedState: true}); err == nil {
+			t.Fatalf("Read(OwnedState, %04o) = nil error, want refusal for world access", mode)
+		}
+	}
+}
+
+// TestReadOwnedStateBoundsSizeLikeStrict confirms the tolerance changed only the
+// permission decision. Every other guard in Read still applies, so a caller
+// cannot use OwnedState to escape the size bound.
+func TestReadOwnedStateBoundsSizeLikeStrict(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.json")
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", 64)), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if _, err := Read(path, Options{MaxBytes: 8, OwnedState: true}); err == nil {
+		t.Fatal("Read(OwnedState, oversize) = nil error, want size refusal")
+	}
+}

--- a/internal/securefile/ownedstate_test.go
+++ b/internal/securefile/ownedstate_test.go
@@ -57,17 +57,26 @@ func TestReadOwnedStateAcceptsPlatformWidenedMode(t *testing.T) {
 // bits from the platform are accepted; world access never is, under either policy.
 func TestReadOwnedStateStillRefusesWorldAccess(t *testing.T) {
 	dir := t.TempDir()
-	for _, mode := range []fs.FileMode{0o664, 0o666, 0o604} {
-		path := filepath.Join(dir, strings.ReplaceAll(mode.String(), "-", "_"))
-		if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
-			t.Fatalf("WriteFile() error = %v", err)
-		}
-		if err := os.Chmod(path, mode); err != nil {
-			t.Fatalf("Chmod() error = %v", err)
-		}
-		if _, err := Read(path, Options{MaxBytes: 1024, OwnedState: true}); err == nil {
-			t.Fatalf("Read(OwnedState, %04o) = nil error, want refusal for world access", mode)
-		}
+	for _, tc := range []struct {
+		name string
+		mode fs.FileMode
+	}{
+		{name: "world_readable_0664", mode: 0o664},
+		{name: "world_writable_0666", mode: 0o666},
+		{name: "world_read_only_0604", mode: 0o604},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name)
+			if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			if err := os.Chmod(path, tc.mode); err != nil {
+				t.Fatalf("Chmod() error = %v", err)
+			}
+			if _, err := Read(path, Options{MaxBytes: 1024, OwnedState: true}); err == nil {
+				t.Fatalf("Read(OwnedState, %04o) = nil error, want refusal for world access", tc.mode)
+			}
+		})
 	}
 }
 

--- a/internal/securefile/securefile.go
+++ b/internal/securefile/securefile.go
@@ -26,6 +26,19 @@ type Options struct {
 	MaxBytes        int64
 	DisallowedPerms fs.FileMode
 	RejectSymlink   bool
+	// OwnedState marks a file Pipelock writes and owns, rather than an
+	// operator-supplied credential. For those files group read/write is accepted
+	// when the group is one this process belongs to and no other-perms are set,
+	// because a container platform widens the mode of its own volumes: Kubernetes
+	// fsGroup ORs writable files with 0660 on every mount, so a file we wrote at
+	// 0600 comes back group-writable and refusing it means a non-root workload
+	// cannot use a persistent volume at all.
+	//
+	// It does NOT relax anything for credentials or private keys. Leave it false
+	// for those: group-write there is a real confidentiality and tamper concern,
+	// not a platform artifact. See secperm.OwnedGroupWritableAllowed for what the
+	// check can and cannot prove.
+	OwnedState bool
 }
 
 // Read opens a bounded regular file and verifies that the descriptor still
@@ -73,8 +86,8 @@ func Read(path string, opts Options) ([]byte, error) {
 	if !before.Mode().IsRegular() {
 		return nil, fmt.Errorf("%q is not a regular file", clean)
 	}
-	if secperm.TooPermissive(before.Mode().Perm(), opts.DisallowedPerms) {
-		return nil, fmt.Errorf("%q has insecure permissions %04o", clean, before.Mode().Perm())
+	if err := checkPerm(clean, before, opts); err != nil {
+		return nil, err
 	}
 	file, err := openRegularNonblocking(resolved)
 	if err != nil {
@@ -88,8 +101,8 @@ func Read(path string, opts Options) ([]byte, error) {
 	if !after.Mode().IsRegular() || !os.SameFile(before, after) {
 		return nil, fmt.Errorf("%q changed during secure open", clean)
 	}
-	if secperm.TooPermissive(after.Mode().Perm(), opts.DisallowedPerms) {
-		return nil, fmt.Errorf("%q has insecure permissions %04o", clean, after.Mode().Perm())
+	if err := checkPerm(clean, after, opts); err != nil {
+		return nil, err
 	}
 	data, err := io.ReadAll(io.LimitReader(file, opts.MaxBytes+1))
 	if err != nil {
@@ -99,4 +112,19 @@ func Read(path string, opts Options) ([]byte, error) {
 		return nil, fmt.Errorf("%q exceeds %d bytes", clean, opts.MaxBytes)
 	}
 	return data, nil
+}
+
+// checkPerm applies the permission policy for one stat of the target. Both the
+// pre-open and post-open checks go through it so the two cannot drift.
+func checkPerm(clean string, info fs.FileInfo, opts Options) error {
+	if opts.OwnedState {
+		if err := secperm.OwnedGroupWritableAllowed(info); err != nil {
+			return fmt.Errorf("%q %w", clean, err)
+		}
+		return nil
+	}
+	if secperm.TooPermissive(info.Mode().Perm(), opts.DisallowedPerms) {
+		return fmt.Errorf("%q has insecure permissions %04o", clean, info.Mode().Perm())
+	}
+	return nil
 }


### PR DESCRIPTION
## What changed

A Conductor leader could not start after an upgrade that moves the canonical policy hash, and a leader that got past that could not read its own enrollment state on a container platform. Either one stops the control plane, so policy distribution, remote kill and rollback all become unavailable.

## Why the policy hash could not be recomputed

`PolicyBundlePayload.PolicyHash` derives from `config.LoadPolicyBundleBytes` and then `Config.CanonicalPolicyHash`, so it changes whenever the configuration schema changes. Recomputing it while reading an already stored bundle therefore tests whether two builds agree, not whether the bundle is intact, and every release that moves the hash made previously published bundles unreadable.

Adding more schemes cannot close that class. Reproducing a prior release's value would require that release's entire configuration schema frozen in the current binary. The pre-loaded-config scheme is tolerable only because it hashes raw YAML and so is schema independent.

Reading a stored bundle now tolerates a hash that neither known scheme reproduces, and reports it rather than refusing. Publishing stays strict, which is the only place the check is meaningful, because there the build computing the hash is the build that produced the bundle.

What continues to hold for a tolerated bundle: `payload_sha256` binds the raw payload and is schema independent, the record's canonical hash pins it, validity and chain checks apply, and the publisher's signature covers the policy hash itself. The value is therefore a signed opaque string rather than a verified digest of policy content, and `PolicyHashStatus` reports exactly that so nothing describes it as verified. On the follower apply path the tolerance runs only after `VerifySignaturesAt`, which is the cryptographic gate, and that ordering is now a documented caller contract with a test that fails if the gate is removed.

The offline inspect and repair readers were strict, so the tool an operator reaches for when the leader will not boot classified every affected bundle as unreadable and refused to act. Both now read with the same tolerance as startup.

## Why the enrollment state was refused

A non-root workload can only use a persistent volume when the platform grants it group access, and Kubernetes implements that by OR-ing writable files with 0660 on every mount. Pipelock writes its own state at 0600, so the widening is the platform's and it returns after every restart. No operator setting can avoid it, because the writer was already correct.

State that Pipelock writes and owns now accepts group read and write when the group is one the process belongs to, counting the effective gid and supplementary groups so it holds whichever way the platform applies `fsGroup`. Any other-perms bit is still refused, and group access for a group the process is not in is refused as a foreign writer.

This does not relax operator supplied credentials or private keys, which keep the strict policy. For those, group write is a confidentiality and tamper concern rather than a platform artifact. The check cannot prove that a gid is private to one workload, so that limitation and the deployment guidance for it are documented at the policy rather than left implicit.

## Observability

A bounded gauge reports loaded bundles by policy hash status on the existing probe listener, labelled only by the three known statuses so a corrupt or future status string cannot expand cardinality. Its help text states that it is a load-time snapshot, since the condition it exists to alert on comes from bundles already on disk and can only change across a restart.

## Scope

Publishing behaviour is unchanged. Credential and private key permission policy is unchanged. No new field is written to disk, which matters because both on-disk readers reject unknown fields and an added field would make older binaries reject newer records during a rolling upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Conductor Prometheus gauge-vector for policy-hash status (current/known legacy/unknown unverified) with per-status counts.
* **Bug Fixes**
  * Improved loading/bootstrapping/enrollment/offline recovery to accept Kubernetes-owned group-writable persisted files (while still rejecting world-accessible permissions).
  * Enhanced offline recovery and store visibility of per-status policy-hash counts.
* **Security**
  * Strengthened policy-hash validation by enforcing signature-first ordering for legacy tolerance and clearer “unknown/unverified” status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->