### PR TITLE
fix(release): close v3.3 operator lifecycle gaps

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -36,7 +36,6 @@ forward_proxy:
   max_tunnel_seconds: 300
   idle_timeout_seconds: 120
   sni_verification: true
-  sni_require_tls: true
 
 request_body_scanning:
   enabled: true

--- a/docs/security/current-unsupported-paths.md
+++ b/docs/security/current-unsupported-paths.md
@@ -36,9 +36,11 @@ MCP servers spoken to over a child-process stdio pipe are not on the network. Pi
 
 ## UDP and direct DNS egress
 
-Pipelock inspects HTTP and HTTPS. It does not inspect DNS lookups or arbitrary UDP. DNS is allowed to leave the host so that name resolution works at all.
+Pipelock inspects HTTP and HTTPS. It does not inspect DNS lookups or arbitrary UDP payloads.
 
-**Integrator action.** If DNS-based exfiltration is in the threat model, use a DNS-layer firewall such as `dnsdist`, `unbound` with a blocklist, or AdGuard Home. Alternatively, run the agent inside a network namespace where DNS is constrained to a known resolver. UDP egress to non-DNS destinations should be blocked at the host firewall.
+The behavior depends on deployment mode. Under `pipelock contain`, the nftables ruleset drops agent-owned `udp dport 53` and `tcp dport 53` across IPv4 and IPv6, so direct DNS does **not** leave the host from the agent UID. Name resolution for the contained agent is expected to use the mediated proxy path. Outside `pipelock contain`—for example, sidecar and reverse-proxy deployments without that ruleset—DNS may leave the workload so name resolution works.
+
+**Integrator action.** Under `pipelock contain`, confirm the direct-DNS drop rules with `pipelock contain verify`. For non-contained deployments where DNS exfiltration is in scope, use a DNS-layer firewall such as `dnsdist`, `unbound` with a blocklist, or AdGuard Home, or constrain the agent to a known resolver in its network namespace. Block UDP egress to non-DNS destinations at the host or workload firewall.
 
 ## Processes that mint their own CA trust
 

--- a/enterprise/conductor/controlplane/dryrun_test.go
+++ b/enterprise/conductor/controlplane/dryrun_test.go
@@ -1005,7 +1005,7 @@ func TestPreviewRemoteKill_StaleCounterParity(t *testing.T) {
 }
 
 func TestRemoteKillDryRun_ExpiredNoWrite(t *testing.T) {
-	msg, resolver := signedRemoteKillMessageWithTTL(t, "kill-expired", 1, conductor.KillSwitchActive, testNow.Add(-2*time.Hour), time.Hour)
+	msg, resolver := signedRemoteKillMessageWithTTL(t, "kill-expired", 1, testNow.Add(-2*time.Hour), time.Hour)
 	sh := newSpyHandler(t, resolver)
 	before := dirDigest(t, sh.emergencyDir)
 	w := remoteKillJSON(t, sh.handler, publishRemoteKillRequest{Message: msg, DryRun: true})
@@ -2425,7 +2425,7 @@ func TestReplay_Unauthorized(t *testing.T) {
 }
 
 func TestReplayEmergency_RejectsSnapshotTimeOverride(t *testing.T) {
-	msg, resolver := signedRemoteKillMessageWithTTL(t, "kill-replay-expired", 1, conductor.KillSwitchActive, testNow.Add(-2*time.Hour), time.Hour)
+	msg, resolver := signedRemoteKillMessageWithTTL(t, "kill-replay-expired", 1, testNow.Add(-2*time.Hour), time.Hour)
 	handler := newTestHandlerWithOptions(t, mustStore(t), nil, resolver)
 	snapshot := &decisionReplaySnapshot{Now: msg.NotBefore.Add(30 * time.Minute)}
 
@@ -2458,7 +2458,7 @@ func TestReplayEmergency_RejectsSnapshotTimeOverride(t *testing.T) {
 
 func TestReplayEmergency_EnforcesPublishValidation(t *testing.T) {
 	t.Run("remote kill max validity", func(t *testing.T) {
-		msg, resolver := signedRemoteKillMessageWithTTL(t, "kill-replay-long", 1, conductor.KillSwitchActive, testNow, DefaultRemoteKillMaxValidity+time.Minute)
+		msg, resolver := signedRemoteKillMessageWithTTL(t, "kill-replay-long", 1, testNow, DefaultRemoteKillMaxValidity+time.Minute)
 		handler := newTestHandlerWithOptions(t, mustStore(t), nil, resolver)
 
 		w := replayJSON(t, handler, decisionReplayRequest{RemoteKill: &msg}, true, false)

--- a/enterprise/conductor/controlplane/emergency_store_test.go
+++ b/enterprise/conductor/controlplane/emergency_store_test.go
@@ -501,17 +501,27 @@ func signedRemoteKillMessage(t *testing.T, id string, counter uint64, state cond
 
 func signedRemoteKillMessageWithResolver(t *testing.T, id string, counter uint64, state conductor.KillSwitchState, created time.Time) (conductor.RemoteKillMessage, conductor.SignatureKeyResolver) {
 	t.Helper()
-	return signedRemoteKillMessageWithTTL(t, id, counter, state, created, time.Hour)
+	return signedRemoteKillMessageWithAudienceAndTTL(t, id, counter, state, created, conductor.Audience{InstanceIDs: []string{"pl-prod-1"}}, time.Hour)
 }
 
-func signedRemoteKillMessageWithTTL(t *testing.T, id string, counter uint64, state conductor.KillSwitchState, created time.Time, ttl time.Duration) (conductor.RemoteKillMessage, conductor.SignatureKeyResolver) {
+func signedRemoteKillMessageWithTTL(t *testing.T, id string, counter uint64, created time.Time, ttl time.Duration) (conductor.RemoteKillMessage, conductor.SignatureKeyResolver) {
+	t.Helper()
+	return signedRemoteKillMessageWithAudienceAndTTL(t, id, counter, conductor.KillSwitchActive, created, conductor.Audience{InstanceIDs: []string{"pl-prod-1"}}, ttl)
+}
+
+func signedRemoteKillMessageWithAudience(t *testing.T, id string, counter uint64, state conductor.KillSwitchState, created time.Time, audience conductor.Audience) (conductor.RemoteKillMessage, conductor.SignatureKeyResolver) {
+	t.Helper()
+	return signedRemoteKillMessageWithAudienceAndTTL(t, id, counter, state, created, audience, time.Hour)
+}
+
+func signedRemoteKillMessageWithAudienceAndTTL(t *testing.T, id string, counter uint64, state conductor.KillSwitchState, created time.Time, audience conductor.Audience, ttl time.Duration) (conductor.RemoteKillMessage, conductor.SignatureKeyResolver) {
 	t.Helper()
 	msg := conductor.RemoteKillMessage{
 		SchemaVersion: conductor.SchemaVersion,
 		MessageID:     id,
 		OrgID:         "org-main",
 		FleetID:       "prod",
-		Audience:      conductor.Audience{InstanceIDs: []string{"pl-prod-1"}},
+		Audience:      audience,
 		State:         state,
 		Counter:       counter,
 		Reason:        "operator emergency stop",

--- a/enterprise/conductor/controlplane/handler_test.go
+++ b/enterprise/conductor/controlplane/handler_test.go
@@ -846,7 +846,7 @@ func TestHandlerPublishesAndServesEmergencyControls(t *testing.T) {
 }
 
 func TestHandlerRejectsOverlongEmergencyValidity(t *testing.T) {
-	msg, killResolver := signedRemoteKillMessageWithTTL(t, "kill-long", 3, conductor.KillSwitchActive, testNow, DefaultRemoteKillMaxValidity+time.Minute)
+	msg, killResolver := signedRemoteKillMessageWithTTL(t, "kill-long", 3, testNow, DefaultRemoteKillMaxValidity+time.Minute)
 	auth, rollbackResolver := signedRollbackAuthorizationWithTTL(t, "rollback-long", 4, testNow, DefaultRollbackMaxValidity+time.Minute)
 	handler := newTestHandlerWithEmergencyKeys(t, killResolver, rollbackResolver)
 

--- a/enterprise/conductor/controlplane/stream_status.go
+++ b/enterprise/conductor/controlplane/stream_status.go
@@ -162,7 +162,9 @@ func (h *Handler) activeEmergencyControls(ctx context.Context, q StreamStatusQue
 			}
 			replaced := false
 			for i := range effective {
-				if conductor.AudiencesEqual(effective[i].Message.Audience, msg.Audience) {
+				effectiveMsg := effective[i].Message
+				if effectiveMsg.OrgID == msg.OrgID && effectiveMsg.FleetID == msg.FleetID &&
+					conductor.AudiencesEqual(effectiveMsg.Audience, msg.Audience) {
 					if newerRemoteKill(record, effective[i]) {
 						effective[i] = record
 					}
@@ -182,6 +184,8 @@ func (h *Handler) activeEmergencyControls(ctx context.Context, q StreamStatusQue
 			shadowed := false
 			for _, candidate := range effective {
 				if candidate.Message.State == conductor.KillSwitchInactive &&
+					candidate.Message.OrgID == msg.OrgID &&
+					candidate.Message.FleetID == msg.FleetID &&
 					newerRemoteKill(candidate, record) &&
 					remoteKillAudienceCovers(candidate.Message.Audience, msg.Audience) {
 					shadowed = true

--- a/enterprise/conductor/controlplane/stream_status.go
+++ b/enterprise/conductor/controlplane/stream_status.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
@@ -145,6 +146,12 @@ func (h *Handler) activeEmergencyControls(ctx context.Context, q StreamStatusQue
 		if err != nil {
 			return nil, nil, false, err
 		}
+		// A resume is a newer inactive message for the same audience, not a
+		// deletion of the earlier active record. Mirror follower selection here:
+		// first select the newest valid record per identical audience, then report
+		// it only when that effective record is active. Otherwise status lies until
+		// the superseded active record's TTL expires even though followers resumed.
+		effective := make([]StoredRemoteKill, 0, len(records))
 		for _, record := range records {
 			msg := record.Message
 			if !emergencyInScope(msg.OrgID, msg.FleetID, q) {
@@ -153,7 +160,35 @@ func (h *Handler) activeEmergencyControls(ctx context.Context, q StreamStatusQue
 			if err := msg.ValidateAtTime(now); err != nil {
 				continue
 			}
+			replaced := false
+			for i := range effective {
+				if conductor.AudiencesEqual(effective[i].Message.Audience, msg.Audience) {
+					if newerRemoteKill(record, effective[i]) {
+						effective[i] = record
+					}
+					replaced = true
+					break
+				}
+			}
+			if !replaced {
+				effective = append(effective, record)
+			}
+		}
+		for _, record := range effective {
+			msg := record.Message
 			if msg.State != conductor.KillSwitchActive {
+				continue
+			}
+			shadowed := false
+			for _, candidate := range effective {
+				if candidate.Message.State == conductor.KillSwitchInactive &&
+					newerRemoteKill(candidate, record) &&
+					remoteKillAudienceCovers(candidate.Message.Audience, msg.Audience) {
+					shadowed = true
+					break
+				}
+			}
+			if shadowed {
 				continue
 			}
 			kills = append(kills, ActiveRemoteKill{
@@ -204,6 +239,37 @@ func (h *Handler) activeEmergencyControls(ctx context.Context, q StreamStatusQue
 		}
 	}
 	return kills, rollbacks, read, nil
+}
+
+// remoteKillAudienceCovers reports whether every follower matched by target is
+// also matched by covering. Audience matching is the union of an instance-ID
+// selector and a label selector, so both target branches must be covered. This
+// lets a newer wildcard resume shadow an older targeted kill without letting a
+// narrow resume falsely clear a broader kill from operator status.
+func remoteKillAudienceCovers(covering, target conductor.Audience) bool {
+	if slices.Contains(covering.InstanceIDs, "*") {
+		return true
+	}
+	if slices.Contains(target.InstanceIDs, "*") {
+		return false
+	}
+	for _, id := range target.InstanceIDs {
+		if !slices.Contains(covering.InstanceIDs, id) {
+			return false
+		}
+	}
+	if len(target.Labels) == 0 {
+		return true
+	}
+	if len(covering.Labels) == 0 {
+		return false
+	}
+	for key, want := range covering.Labels {
+		if target.Labels[key] != want {
+			return false
+		}
+	}
+	return true
 }
 
 // emergencyInScope reports whether an org/fleet-keyed emergency control matches

--- a/enterprise/conductor/controlplane/stream_status_test.go
+++ b/enterprise/conductor/controlplane/stream_status_test.go
@@ -474,10 +474,7 @@ func TestHandlerStreamStatusInactiveDoesNotShadowDifferentAudience(t *testing.T)
 	if _, _, err := emergency.PublishRemoteKill(t.Context(), active, testNow.Add(-time.Minute)); err != nil {
 		t.Fatalf("PublishRemoteKill(active) error = %v", err)
 	}
-	inactive, _ := signedRemoteKillMessageWithResolver(t, "kill-inactive", 2, conductor.KillSwitchInactive, testNow)
-	inactive.Audience = conductor.Audience{InstanceIDs: []string{"other-instance"}}
-	var inactiveResolver conductor.SignatureKeyResolver
-	inactive.Signatures, inactiveResolver = signConductorPreimage(t, inactive.SignablePreimage, signing.PurposeRemoteKillSigning, "other-kill-signer-1", "other-kill-signer-2")
+	inactive, inactiveResolver := signedRemoteKillMessageWithAudience(t, "kill-inactive", 2, conductor.KillSwitchInactive, testNow, conductor.Audience{InstanceIDs: []string{"other-instance"}})
 	if _, _, err := emergency.PublishRemoteKill(t.Context(), inactive, testNow); err != nil {
 		t.Fatalf("PublishRemoteKill(inactive) error = %v", err)
 	}
@@ -493,6 +490,36 @@ func TestHandlerStreamStatusInactiveDoesNotShadowDifferentAudience(t *testing.T)
 	}
 	if len(resp.ActiveRemoteKills) != 1 || resp.ActiveRemoteKills[0].MessageID != "kill-active" {
 		t.Fatalf("active kills = %+v, want active record for unaffected audience", resp.ActiveRemoteKills)
+	}
+}
+
+func TestHandlerStreamStatusNewerInactiveWildcardShadowsNarrowerActiveAudience(t *testing.T) {
+	store := mustStore(t)
+	publishStreamFixture(t, store)
+	emergency := mustEmergencyStore(t)
+
+	active, activeResolver := signedRemoteKillMessageWithAudience(t, "kill-active", 1, conductor.KillSwitchActive, testNow.Add(-time.Minute), conductor.Audience{InstanceIDs: []string{"pl-prod-1"}})
+	if _, _, err := emergency.PublishRemoteKill(t.Context(), active, testNow.Add(-time.Minute)); err != nil {
+		t.Fatalf("PublishRemoteKill(active) error = %v", err)
+	}
+	inactive, _ := signedRemoteKillMessageWithAudience(t, "kill-inactive", 2, conductor.KillSwitchInactive, testNow, conductor.Audience{InstanceIDs: []string{"*"}})
+	var inactiveResolver conductor.SignatureKeyResolver
+	inactive.Signatures, inactiveResolver = signConductorPreimage(t, inactive.SignablePreimage, signing.PurposeRemoteKillSigning, "wildcard-resume-signer-1", "wildcard-resume-signer-2")
+	if _, _, err := emergency.PublishRemoteKill(t.Context(), inactive, testNow); err != nil {
+		t.Fatalf("PublishRemoteKill(inactive wildcard) error = %v", err)
+	}
+
+	handler := newStreamStatusTestHandler(t, store, emergency, activeResolver, inactiveResolver)
+	w := getStreamStatus(t, handler, StreamStatusPath+"?org_id=org-main", streamAdminToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	var resp streamStatusResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.ActiveRemoteKills) != 0 {
+		t.Fatalf("active kills = %+v, want none after newer wildcard resume", resp.ActiveRemoteKills)
 	}
 }
 

--- a/enterprise/conductor/controlplane/stream_status_test.go
+++ b/enterprise/conductor/controlplane/stream_status_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 const (
@@ -431,6 +432,95 @@ func TestHandlerStreamStatusDropsInactiveRemoteKill(t *testing.T) {
 	}
 	if !resp.EmergencyControlsRead {
 		t.Fatal("EmergencyControlsRead = false, want true with enumerable emergency store")
+	}
+}
+
+func TestHandlerStreamStatusNewerInactiveShadowsActiveForSameAudience(t *testing.T) {
+	store := mustStore(t)
+	publishStreamFixture(t, store)
+	emergency := mustEmergencyStore(t)
+
+	active, activeResolver := signedRemoteKillMessageWithResolver(t, "kill-active", 1, conductor.KillSwitchActive, testNow.Add(-time.Minute))
+	if _, _, err := emergency.PublishRemoteKill(t.Context(), active, testNow.Add(-time.Minute)); err != nil {
+		t.Fatalf("PublishRemoteKill(active) error = %v", err)
+	}
+	inactive, _ := signedRemoteKillMessageWithResolver(t, "kill-inactive", 2, conductor.KillSwitchInactive, testNow)
+	var inactiveResolver conductor.SignatureKeyResolver
+	inactive.Signatures, inactiveResolver = signConductorPreimage(t, inactive.SignablePreimage, signing.PurposeRemoteKillSigning, "resume-signer-1", "resume-signer-2")
+	if _, _, err := emergency.PublishRemoteKill(t.Context(), inactive, testNow); err != nil {
+		t.Fatalf("PublishRemoteKill(inactive) error = %v", err)
+	}
+
+	handler := newStreamStatusTestHandler(t, store, emergency, activeResolver, inactiveResolver)
+	w := getStreamStatus(t, handler, StreamStatusPath+"?org_id=org-main", streamAdminToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	var resp streamStatusResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.ActiveRemoteKills) != 0 {
+		t.Fatalf("active kills = %+v, want none after newer resume for same audience", resp.ActiveRemoteKills)
+	}
+}
+
+func TestHandlerStreamStatusInactiveDoesNotShadowDifferentAudience(t *testing.T) {
+	store := mustStore(t)
+	publishStreamFixture(t, store)
+	emergency := mustEmergencyStore(t)
+
+	active, activeResolver := signedRemoteKillMessageWithResolver(t, "kill-active", 1, conductor.KillSwitchActive, testNow.Add(-time.Minute))
+	if _, _, err := emergency.PublishRemoteKill(t.Context(), active, testNow.Add(-time.Minute)); err != nil {
+		t.Fatalf("PublishRemoteKill(active) error = %v", err)
+	}
+	inactive, _ := signedRemoteKillMessageWithResolver(t, "kill-inactive", 2, conductor.KillSwitchInactive, testNow)
+	inactive.Audience = conductor.Audience{InstanceIDs: []string{"other-instance"}}
+	var inactiveResolver conductor.SignatureKeyResolver
+	inactive.Signatures, inactiveResolver = signConductorPreimage(t, inactive.SignablePreimage, signing.PurposeRemoteKillSigning, "other-kill-signer-1", "other-kill-signer-2")
+	if _, _, err := emergency.PublishRemoteKill(t.Context(), inactive, testNow); err != nil {
+		t.Fatalf("PublishRemoteKill(inactive) error = %v", err)
+	}
+
+	handler := newStreamStatusTestHandler(t, store, emergency, activeResolver, inactiveResolver)
+	w := getStreamStatus(t, handler, StreamStatusPath+"?org_id=org-main", streamAdminToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	var resp streamStatusResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.ActiveRemoteKills) != 1 || resp.ActiveRemoteKills[0].MessageID != "kill-active" {
+		t.Fatalf("active kills = %+v, want active record for unaffected audience", resp.ActiveRemoteKills)
+	}
+}
+
+func TestRemoteKillAudienceCovers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		covering conductor.Audience
+		target   conductor.Audience
+		want     bool
+	}{
+		{name: "wildcard covers targeted id", covering: conductor.Audience{InstanceIDs: []string{"*"}}, target: conductor.Audience{InstanceIDs: []string{"one"}}, want: true},
+		{name: "targeted id does not cover wildcard", covering: conductor.Audience{InstanceIDs: []string{"one"}}, target: conductor.Audience{InstanceIDs: []string{"*"}}, want: false},
+		{name: "id superset", covering: conductor.Audience{InstanceIDs: []string{"one", "two"}}, target: conductor.Audience{InstanceIDs: []string{"two"}}, want: true},
+		{name: "id subset", covering: conductor.Audience{InstanceIDs: []string{"one"}}, target: conductor.Audience{InstanceIDs: []string{"one", "two"}}, want: false},
+		{name: "weaker labels cover stronger labels", covering: conductor.Audience{Labels: map[string]string{"ring": "stable"}}, target: conductor.Audience{Labels: map[string]string{"ring": "stable", "zone": "east"}}, want: true},
+		{name: "stronger labels do not cover weaker labels", covering: conductor.Audience{Labels: map[string]string{"ring": "stable", "zone": "east"}}, target: conductor.Audience{Labels: map[string]string{"ring": "stable"}}, want: false},
+		{name: "label mismatch", covering: conductor.Audience{Labels: map[string]string{"ring": "canary"}}, target: conductor.Audience{Labels: map[string]string{"ring": "stable"}}, want: false},
+		{name: "covering ids do not cover target labels", covering: conductor.Audience{InstanceIDs: []string{"one"}}, target: conductor.Audience{Labels: map[string]string{"ring": "stable"}}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := remoteKillAudienceCovers(tt.covering, tt.target); got != tt.want {
+				t.Fatalf("remoteKillAudienceCovers() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/enterprise/conductor/controlplane/stream_status_test.go
+++ b/enterprise/conductor/controlplane/stream_status_test.go
@@ -523,6 +523,37 @@ func TestHandlerStreamStatusNewerInactiveWildcardShadowsNarrowerActiveAudience(t
 	}
 }
 
+func TestHandlerStreamStatusInactiveInAnotherFleetDoesNotShadowActiveKill(t *testing.T) {
+	store := mustStore(t)
+	publishStreamFixture(t, store)
+	emergency := mustEmergencyStore(t)
+
+	active, activeResolver := signedRemoteKillMessageWithAudience(t, "kill-prod", 1, conductor.KillSwitchActive, testNow.Add(-time.Minute), conductor.Audience{InstanceIDs: []string{"pl-prod-1"}})
+	if _, _, err := emergency.PublishRemoteKill(t.Context(), active, testNow.Add(-time.Minute)); err != nil {
+		t.Fatalf("PublishRemoteKill(active prod) error = %v", err)
+	}
+	inactive, _ := signedRemoteKillMessageWithAudience(t, "resume-staging", 2, conductor.KillSwitchInactive, testNow, conductor.Audience{InstanceIDs: []string{"*"}})
+	inactive.FleetID = "staging"
+	var inactiveResolver conductor.SignatureKeyResolver
+	inactive.Signatures, inactiveResolver = signConductorPreimage(t, inactive.SignablePreimage, signing.PurposeRemoteKillSigning, "staging-resume-signer-1", "staging-resume-signer-2")
+	if _, _, err := emergency.PublishRemoteKill(t.Context(), inactive, testNow); err != nil {
+		t.Fatalf("PublishRemoteKill(inactive staging) error = %v", err)
+	}
+
+	handler := newStreamStatusTestHandler(t, store, emergency, activeResolver, inactiveResolver)
+	w := getStreamStatus(t, handler, StreamStatusPath+"?org_id=org-main", streamAdminToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	var resp streamStatusResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.ActiveRemoteKills) != 1 || resp.ActiveRemoteKills[0].MessageID != "kill-prod" {
+		t.Fatalf("active kills = %+v, want prod kill unaffected by staging resume", resp.ActiveRemoteKills)
+	}
+}
+
 func TestRemoteKillAudienceCovers(t *testing.T) {
 	t.Parallel()
 

--- a/enterprise/conductor/controlplane/stream_status_test.go
+++ b/enterprise/conductor/controlplane/stream_status_test.go
@@ -534,8 +534,14 @@ func TestHandlerStreamStatusInactiveInAnotherFleetDoesNotShadowActiveKill(t *tes
 	}
 	inactive, _ := signedRemoteKillMessageWithAudience(t, "resume-staging", 2, conductor.KillSwitchInactive, testNow, conductor.Audience{InstanceIDs: []string{"*"}})
 	inactive.FleetID = "staging"
+	inactivePreimage, err := inactive.SignablePreimage()
+	if err != nil {
+		t.Fatalf("SignablePreimage(inactive staging) error = %v", err)
+	}
 	var inactiveResolver conductor.SignatureKeyResolver
-	inactive.Signatures, inactiveResolver = signConductorPreimage(t, inactive.SignablePreimage, signing.PurposeRemoteKillSigning, "staging-resume-signer-1", "staging-resume-signer-2")
+	inactive.Signatures, inactiveResolver = signConductorPreimage(t, func() ([]byte, error) {
+		return inactivePreimage, nil
+	}, signing.PurposeRemoteKillSigning, "staging-resume-signer-1", "staging-resume-signer-2")
 	if _, _, err := emergency.PublishRemoteKill(t.Context(), inactive, testNow); err != nil {
 		t.Fatalf("PublishRemoteKill(inactive staging) error = %v", err)
 	}

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -8,8 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/signing"
@@ -49,6 +52,9 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 		return nil, nil, fmt.Errorf("resolve operator home for config migration: %w", err)
 	}
 	ctx.operatorHome = home
+	if err := migrateFileSentryWatchPaths(ctx, mapping); err != nil {
+		return nil, nil, err
+	}
 
 	if err := migrateScalarFile(ctx, mapping, []string{"license_file"}, filepath.Join(env.configDir, "license.token"), modeConfigSecret); err != nil {
 		return nil, nil, err
@@ -76,8 +82,11 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 	// blocked destinations, and anomaly categories. Put observability on a
 	// distinct loopback listener; the containment rules allow only the proxy
 	// port and drop agent-owned traffic to other loopback ports.
-	if strings.TrimSpace(scalarValue(mappingValue(mapping, "metrics_listen"))) == "" {
+	metricsListen := strings.TrimSpace(scalarValue(mappingValue(mapping, "metrics_listen")))
+	if metricsListen == "" {
 		setMappingScalar(mapping, "metrics_listen", containMetricsListen)
+	} else if err := validateContainMetricsListen(metricsListen, env.proxyPort); err != nil {
+		return nil, nil, err
 	}
 
 	if err := migrateScalarDir(ctx, mapping, []string{"rules", "rules_dir"}, filepath.Join(env.dataDir, "rules")); err != nil {
@@ -102,12 +111,121 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 		return nil, nil, err
 	}
 	migrateRedirectProfiles(ctx, mapping)
+	paths, err := containHomeReadOnlyPathsFromMapping(mapping)
+	if err != nil {
+		return nil, nil, err
+	}
+	env.serviceHomeReadOnlyPaths = paths
 
 	out, err := encodeYAML(root)
 	if err != nil {
 		return nil, nil, err
 	}
 	return out, ctx.artifacts, nil
+}
+
+func migrateFileSentryWatchPaths(ctx *configMigrationContext, root *yaml.Node) error {
+	paths := getMappingPath(root, []string{"file_sentry", "watch_paths"})
+	if paths == nil {
+		return nil
+	}
+	if paths.Kind != yaml.SequenceNode {
+		return nil // the selected binary's config preflight reports the schema error
+	}
+	for i, item := range paths.Content {
+		pathNode := item
+		if item.Kind == yaml.MappingNode {
+			pathNode = mappingValue(item, "path")
+		}
+		if pathNode == nil || pathNode.Kind != yaml.ScalarNode || strings.TrimSpace(pathNode.Value) == "" {
+			continue
+		}
+		path := strings.TrimSpace(pathNode.Value)
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(ctx.configDir, path)
+		}
+		path = filepath.Clean(path)
+		if strings.ContainsAny(path, "\x00\r\n:") {
+			return fmt.Errorf("file_sentry.watch_paths[%d] %q cannot be represented safely in a systemd bind path", i, path)
+		}
+		pathNode.Value = path
+	}
+	return nil
+}
+
+func containHomeReadOnlyPaths(data []byte) ([]string, error) {
+	root, err := parseSingleYAMLDocument(data)
+	if err != nil {
+		return nil, err
+	}
+	mapping := documentMapping(root)
+	if mapping == nil {
+		return nil, errors.New("pipelock config must be a YAML mapping")
+	}
+	return containHomeReadOnlyPathsFromMapping(mapping)
+}
+
+func containHomeReadOnlyPathsFromMapping(root *yaml.Node) ([]string, error) {
+	fileSentry := getMappingPath(root, []string{"file_sentry"})
+	if fileSentry == nil || !yamlBool(mappingValue(fileSentry, "enabled")) {
+		return nil, nil
+	}
+	watchPaths := mappingValue(fileSentry, "watch_paths")
+	if watchPaths == nil || watchPaths.Kind != yaml.SequenceNode {
+		return nil, nil
+	}
+	seen := make(map[string]struct{})
+	for i, item := range watchPaths.Content {
+		pathNode := item
+		if item.Kind == yaml.MappingNode {
+			pathNode = mappingValue(item, "path")
+		}
+		path := scalarValue(pathNode)
+		if path == "" {
+			continue
+		}
+		if !filepath.IsAbs(path) {
+			return nil, fmt.Errorf("file_sentry.watch_paths[%d] %q must be absolute in the managed config", i, path)
+		}
+		path = filepath.Clean(path)
+		if strings.ContainsAny(path, "\x00\r\n:") {
+			return nil, fmt.Errorf("file_sentry.watch_paths[%d] %q cannot be represented safely in a systemd bind path", i, path)
+		}
+		if isProtectedHomePath(path) {
+			seen[path] = struct{}{}
+		}
+	}
+	paths := make([]string, 0, len(seen))
+	for path := range seen {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func isProtectedHomePath(path string) bool {
+	for _, root := range []string{"/home", "/root", "/run/user"} {
+		if path == root || strings.HasPrefix(path, root+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateContainMetricsListen(listen string, proxyPort int) error {
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		return fmt.Errorf("metrics_listen %q is unsafe for containment: %w", listen, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a numeric loopback address on a dedicated port", listen)
+	}
+	parsedPort, err := strconv.Atoi(port)
+	if err != nil || parsedPort == proxyPort {
+		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a port other than the agent-accessible proxy port %d", listen, proxyPort)
+	}
+	return nil
 }
 
 func parseSingleYAMLDocument(data []byte) (*yaml.Node, error) {

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -139,11 +139,11 @@ func migrateFileSentryWatchPaths(ctx *configMigrationContext, root *yaml.Node) e
 		if !filepath.IsAbs(path) {
 			path = filepath.Join(ctx.configDir, path)
 		}
-		path = filepath.Clean(path)
-		if strings.ContainsAny(path, "\x00\r\n:") {
-			return fmt.Errorf("file_sentry.watch_paths[%d] %q cannot be represented safely in a systemd bind path", i, path)
+		cleaned, err := sanitizeSystemdBindPath(path)
+		if err != nil {
+			return fmt.Errorf("file_sentry.watch_paths[%d] %q: %w", i, path, err)
 		}
-		pathNode.Value = path
+		pathNode.Value = cleaned
 	}
 	return nil
 }
@@ -189,12 +189,12 @@ func containServiceReadOnlyPathsFromMapping(root *yaml.Node) ([]string, error) {
 		if !filepath.IsAbs(path) {
 			return nil, fmt.Errorf("file_sentry.watch_paths[%d] %q must be absolute in the managed config", i, path)
 		}
-		path = filepath.Clean(path)
-		if strings.ContainsAny(path, "\x00\r\n:") {
-			return nil, fmt.Errorf("file_sentry.watch_paths[%d] %q cannot be represented safely in a systemd bind path", i, path)
+		cleaned, err := sanitizeSystemdBindPath(path)
+		if err != nil {
+			return nil, fmt.Errorf("file_sentry.watch_paths[%d] %q: %w", i, path, err)
 		}
-		if isServiceSandboxHiddenPath(path) {
-			seen[path] = struct{}{}
+		if isServiceSandboxHiddenPath(cleaned) {
+			seen[cleaned] = struct{}{}
 		}
 	}
 	paths := make([]string, 0, len(seen))
@@ -203,6 +203,14 @@ func containServiceReadOnlyPathsFromMapping(root *yaml.Node) ([]string, error) {
 	}
 	sort.Strings(paths)
 	return paths, nil
+}
+
+func sanitizeSystemdBindPath(path string) (string, error) {
+	cleaned := filepath.Clean(path)
+	if strings.ContainsAny(cleaned, "\x00\r\n:") {
+		return "", errors.New("cannot be represented safely in a systemd bind path")
+	}
+	return cleaned, nil
 }
 
 func isServiceSandboxHiddenPath(path string) bool {

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -16,6 +16,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const containMetricsListen = "127.0.0.1:9091"
+
 type migratedConfigArtifact struct {
 	path string
 	dir  bool
@@ -68,6 +70,14 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 	}
 	if err := migrateTLSCA(ctx, mapping); err != nil {
 		return nil, nil, err
+	}
+	// The agent can reach the main proxy listener by design. Keeping /metrics
+	// and /stats there gives a contained process an oracle for scanner hits,
+	// blocked destinations, and anomaly categories. Put observability on a
+	// distinct loopback listener; the containment rules allow only the proxy
+	// port and drop agent-owned traffic to other loopback ports.
+	if strings.TrimSpace(scalarValue(mappingValue(mapping, "metrics_listen"))) == "" {
+		setMappingScalar(mapping, "metrics_listen", containMetricsListen)
 	}
 
 	if err := migrateScalarDir(ctx, mapping, []string{"rules", "rules_dir"}, filepath.Join(env.dataDir, "rules")); err != nil {

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -221,8 +221,8 @@ func validateContainMetricsListen(listen string, proxyPort int) error {
 	if ip == nil || !ip.IsLoopback() {
 		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a numeric loopback address on a dedicated port", listen)
 	}
-	parsedPort, err := strconv.Atoi(port)
-	if err != nil || parsedPort == proxyPort {
+	parsedPort, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || parsedPort == 0 || int(parsedPort) == proxyPort {
 		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a port other than the agent-accessible proxy port %d", listen, proxyPort)
 	}
 	return nil

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -148,7 +148,7 @@ func migrateFileSentryWatchPaths(ctx *configMigrationContext, root *yaml.Node) e
 	return nil
 }
 
-func containHomeReadOnlyPaths(data []byte) ([]string, error) {
+func containServiceReadOnlyPaths(data []byte, proxyPort int) ([]string, error) {
 	root, err := parseSingleYAMLDocument(data)
 	if err != nil {
 		return nil, err
@@ -157,10 +157,17 @@ func containHomeReadOnlyPaths(data []byte) ([]string, error) {
 	if mapping == nil {
 		return nil, errors.New("pipelock config must be a YAML mapping")
 	}
-	return containHomeReadOnlyPathsFromMapping(mapping)
+	metricsListen := strings.TrimSpace(scalarValue(mappingValue(mapping, "metrics_listen")))
+	if metricsListen == "" {
+		return nil, errors.New("metrics_listen must use a dedicated loopback port; rerun contain install with --config to migrate the managed config safely")
+	}
+	if err := validateContainMetricsListen(metricsListen, proxyPort); err != nil {
+		return nil, err
+	}
+	return containServiceReadOnlyPathsFromMapping(mapping)
 }
 
-func containHomeReadOnlyPathsFromMapping(root *yaml.Node) ([]string, error) {
+func containServiceReadOnlyPathsFromMapping(root *yaml.Node) ([]string, error) {
 	fileSentry := getMappingPath(root, []string{"file_sentry"})
 	if fileSentry == nil || !yamlBool(mappingValue(fileSentry, "enabled")) {
 		return nil, nil
@@ -186,7 +193,7 @@ func containHomeReadOnlyPathsFromMapping(root *yaml.Node) ([]string, error) {
 		if strings.ContainsAny(path, "\x00\r\n:") {
 			return nil, fmt.Errorf("file_sentry.watch_paths[%d] %q cannot be represented safely in a systemd bind path", i, path)
 		}
-		if isProtectedHomePath(path) {
+		if isServiceSandboxHiddenPath(path) {
 			seen[path] = struct{}{}
 		}
 	}
@@ -196,6 +203,11 @@ func containHomeReadOnlyPathsFromMapping(root *yaml.Node) ([]string, error) {
 	}
 	sort.Strings(paths)
 	return paths, nil
+}
+
+func isServiceSandboxHiddenPath(path string) bool {
+	return isProtectedHomePath(path) || path == "/tmp" || strings.HasPrefix(path, "/tmp/") ||
+		path == "/var/tmp" || strings.HasPrefix(path, "/var/tmp/")
 }
 
 func isProtectedHomePath(path string) bool {

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -111,11 +111,6 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 		return nil, nil, err
 	}
 	migrateRedirectProfiles(ctx, mapping)
-	paths, err := containHomeReadOnlyPathsFromMapping(mapping)
-	if err != nil {
-		return nil, nil, err
-	}
-	env.serviceHomeReadOnlyPaths = paths
 
 	out, err := encodeYAML(root)
 	if err != nil {

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"gopkg.in/yaml.v3"
 )
 
 func TestMigratePipelockConfigForContain_RewritesHomePaths(t *testing.T) {
@@ -142,7 +143,7 @@ learn_lock:
 	}
 }
 
-func TestMigratePipelockConfigForContain_EmptyMappingIsNoOp(t *testing.T) {
+func TestMigratePipelockConfigForContain_EmptyMappingSeparatesObservability(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	home := t.TempDir()
 	origLookup := env.lookupUser
@@ -159,8 +160,31 @@ func TestMigratePipelockConfigForContain_EmptyMappingIsNoOp(t *testing.T) {
 	if len(artifacts) != 0 {
 		t.Fatalf("expected no artifacts, got %+v", artifacts)
 	}
-	if strings.TrimSpace(string(out)) != "{}" {
-		t.Fatalf("output: %q", out)
+	var cfg map[string]any
+	if err := yaml.Unmarshal(out, &cfg); err != nil {
+		t.Fatalf("decode migrated config: %v", err)
+	}
+	if got := cfg["metrics_listen"]; got != containMetricsListen {
+		t.Fatalf("metrics_listen = %v, want %q", got, containMetricsListen)
+	}
+}
+
+func TestMigratePipelockConfigForContain_PreservesExplicitMetricsListener(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	out, _, err := migratePipelockConfigForContain(env, filepath.Join(home, "pipelock.yaml"), []byte("metrics_listen: 127.0.0.1:9191\n"))
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !strings.Contains(string(out), "127.0.0.1:9191") {
+		t.Fatalf("explicit metrics listener changed: %s", out)
 	}
 }
 

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -227,8 +227,12 @@ func TestMigratePipelockConfigForContain_NarrowsFileSentryHomeVisibility(t *test
 	if !strings.Contains(string(out), wantHome) {
 		t.Fatalf("relative watch path was not made absolute: %s", out)
 	}
-	if len(env.serviceHomeReadOnlyPaths) != 1 || env.serviceHomeReadOnlyPaths[0] != wantHome {
-		t.Fatalf("service home paths = %#v, want [%q]", env.serviceHomeReadOnlyPaths, wantHome)
+	paths, err := containHomeReadOnlyPaths(out)
+	if err != nil {
+		t.Fatalf("containHomeReadOnlyPaths: %v", err)
+	}
+	if len(paths) != 1 || paths[0] != wantHome {
+		t.Fatalf("service home paths = %#v, want [%q]", paths, wantHome)
 	}
 }
 

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -198,7 +198,7 @@ func TestMigratePipelockConfigForContain_RejectsAgentReachableMetricsListener(t 
 		}
 		return origLookup(name)
 	}
-	for _, listen := range []string{"0.0.0.0:9191", "[::]:9191", "localhost:9191", "127.0.0.1:8888"} {
+	for _, listen := range []string{"0.0.0.0:9191", "[::]:9191", "localhost:9191", "127.0.0.1:8888", "127.0.0.1:-1", "127.0.0.1:0", "127.0.0.1:65536"} {
 		t.Run(listen, func(t *testing.T) {
 			_, _, err := migratePipelockConfigForContain(env, filepath.Join(home, "pipelock.yaml"), []byte("metrics_listen: \""+listen+"\"\n"))
 			if err == nil || !strings.Contains(err.Error(), "unsafe for containment") {

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -198,7 +198,7 @@ func TestMigratePipelockConfigForContain_RejectsAgentReachableMetricsListener(t 
 		}
 		return origLookup(name)
 	}
-	for _, listen := range []string{"0.0.0.0:9191", "[::]:9191", "localhost:9191", "127.0.0.1:8888", "127.0.0.1:-1", "127.0.0.1:0", "127.0.0.1:65536"} {
+	for _, listen := range []string{"127.0.0.1", "0.0.0.0:9191", "[::]:9191", "localhost:9191", "127.0.0.1:8888", "127.0.0.1:-1", "127.0.0.1:0", "127.0.0.1:65536"} {
 		t.Run(listen, func(t *testing.T) {
 			_, _, err := migratePipelockConfigForContain(env, filepath.Join(home, "pipelock.yaml"), []byte("metrics_listen: \""+listen+"\"\n"))
 			if err == nil || !strings.Contains(err.Error(), "unsafe for containment") {
@@ -227,12 +227,71 @@ func TestMigratePipelockConfigForContain_NarrowsFileSentryHomeVisibility(t *test
 	if !strings.Contains(string(out), wantHome) {
 		t.Fatalf("relative watch path was not made absolute: %s", out)
 	}
-	paths, err := containHomeReadOnlyPaths(out)
+	paths, err := containServiceReadOnlyPaths(out, env.proxyPort)
 	if err != nil {
-		t.Fatalf("containHomeReadOnlyPaths: %v", err)
+		t.Fatalf("containServiceReadOnlyPaths: %v", err)
 	}
-	if len(paths) != 1 || paths[0] != wantHome {
-		t.Fatalf("service home paths = %#v, want [%q]", paths, wantHome)
+	wantTmp := "/tmp/outside-home"
+	if len(paths) != 2 || paths[0] != wantHome || paths[1] != wantTmp {
+		t.Fatalf("service read-only paths = %#v, want [%q %q]", paths, wantHome, wantTmp)
+	}
+}
+
+func TestContainServiceReadOnlyPaths_ValidationAndFiltering(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "invalid yaml", body: ":\n", want: "parse pipelock config"},
+		{name: "non mapping", body: "- item\n", want: "YAML mapping"},
+		{name: "missing metrics", body: "mode: balanced\n", want: "dedicated loopback port"},
+		{name: "unsafe metrics", body: "metrics_listen: 0.0.0.0:9091\n", want: "unsafe for containment"},
+		{name: "relative path", body: "metrics_listen: 127.0.0.1:9091\nfile_sentry:\n  enabled: true\n  watch_paths: [relative]\n", want: "must be absolute"},
+		{name: "unsafe bind path", body: "metrics_listen: 127.0.0.1:9091\nfile_sentry:\n  enabled: true\n  watch_paths: [\"/tmp/bad:path\"]\n", want: "cannot be represented safely"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := containServiceReadOnlyPaths([]byte(tc.body), 8888); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("containServiceReadOnlyPaths error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "disabled", body: "metrics_listen: 127.0.0.1:9091\nfile_sentry:\n  enabled: false\n"},
+		{name: "non sequence", body: "metrics_listen: 127.0.0.1:9091\nfile_sentry:\n  enabled: true\n  watch_paths: invalid\n"},
+		{name: "unhidden and blank", body: "metrics_listen: 127.0.0.1:9091\nfile_sentry:\n  enabled: true\n  watch_paths: [\"\", /srv/project]\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paths, err := containServiceReadOnlyPaths([]byte(tc.body), 8888)
+			if err != nil || len(paths) != 0 {
+				t.Fatalf("containServiceReadOnlyPaths paths=%v error=%v, want empty nil", paths, err)
+			}
+		})
+	}
+}
+
+func TestMigrateFileSentryWatchPaths_EdgeCases(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	source := filepath.Join(t.TempDir(), "pipelock.yaml")
+	for _, tc := range []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{name: "non sequence", body: "file_sentry:\n  watch_paths: invalid\n"},
+		{name: "blank items", body: "file_sentry:\n  watch_paths: [\"\", {}]\n"},
+		{name: "unsafe path", body: "file_sentry:\n  watch_paths: [\"/tmp/bad:path\"]\n", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := migratePipelockConfigForContain(env, source, []byte(tc.body))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("migrate error = %v, wantErr=%v", err, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -188,6 +188,50 @@ func TestMigratePipelockConfigForContain_PreservesExplicitMetricsListener(t *tes
 	}
 }
 
+func TestMigratePipelockConfigForContain_RejectsAgentReachableMetricsListener(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	for _, listen := range []string{"0.0.0.0:9191", "[::]:9191", "localhost:9191", "127.0.0.1:8888"} {
+		t.Run(listen, func(t *testing.T) {
+			_, _, err := migratePipelockConfigForContain(env, filepath.Join(home, "pipelock.yaml"), []byte("metrics_listen: \""+listen+"\"\n"))
+			if err == nil || !strings.Contains(err.Error(), "unsafe for containment") {
+				t.Fatalf("migrate error = %v, want containment refusal", err)
+			}
+		})
+	}
+}
+
+func TestMigratePipelockConfigForContain_NarrowsFileSentryHomeVisibility(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := "/home/operator"
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	sourceDir := filepath.Join(home, "config")
+	out, _, err := migratePipelockConfigForContain(env, filepath.Join(sourceDir, "pipelock.yaml"), []byte("file_sentry:\n  enabled: true\n  watch_paths:\n    - ../project\n    - path: /tmp/outside-home\n      required: true\n"))
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	wantHome := filepath.Join(home, "project")
+	if !strings.Contains(string(out), wantHome) {
+		t.Fatalf("relative watch path was not made absolute: %s", out)
+	}
+	if len(env.serviceHomeReadOnlyPaths) != 1 || env.serviceHomeReadOnlyPaths[0] != wantHome {
+		t.Fatalf("service home paths = %#v, want [%q]", env.serviceHomeReadOnlyPaths, wantHome)
+	}
+}
+
 func TestMigratePipelockConfigForContainRejectsInvalidDocuments(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	tests := []struct {

--- a/internal/cli/contain/contain_hardening_test.go
+++ b/internal/cli/contain/contain_hardening_test.go
@@ -5,6 +5,7 @@ package contain
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -338,12 +339,45 @@ func TestStepStagePipelockConfigExplicitCandidatePreservesHomeSentryPaths(t *tes
 	if _, err := step.apply(t.Context(), env); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	if len(env.serviceHomeReadOnlyPaths) != 1 || env.serviceHomeReadOnlyPaths[0] != "/home/operator/project" {
-		t.Fatalf("service home paths = %#v, want explicit candidate path", env.serviceHomeReadOnlyPaths)
+	if len(env.serviceReadOnlyPaths) != 1 || env.serviceReadOnlyPaths[0] != "/home/operator/project" {
+		t.Fatalf("service read-only paths = %#v, want explicit candidate path", env.serviceReadOnlyPaths)
 	}
 	unit := renderSystemUnit(env)
 	if !strings.Contains(unit, `BindReadOnlyPaths=-"/home/operator/project"`) {
 		t.Fatalf("system unit does not preserve explicit candidate path:\n%s", unit)
+	}
+}
+
+func TestStepStagePipelockConfigManagedRerunRejectsExposedMetrics(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	mustWriteFile(t, managedPipelockConfigPath(env), "mode: balanced\nmetrics_listen: \"\"\n")
+
+	if _, err := stepStagePipelockConfig(installOpts{}).apply(t.Context(), env); err == nil || !strings.Contains(err.Error(), "metrics_listen must use a dedicated loopback port") {
+		t.Fatalf("managed rerun error = %v, want exposed-metrics refusal", err)
+	}
+}
+
+func TestStepStagePipelockConfigManagedRerunReportsReadFailure(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.readFile = func(string) ([]byte, error) { return nil, errors.New("read failed") }
+	if _, err := stepStagePipelockConfig(installOpts{}).apply(t.Context(), env); err == nil || !strings.Contains(err.Error(), "read managed config") {
+		t.Fatalf("managed rerun read error = %v, want contextual refusal", err)
+	}
+}
+
+func TestStepStagePipelockConfigManagedRerunPreservesPrivateTmpSentryPaths(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	mustWriteFile(t, managedPipelockConfigPath(env), "metrics_listen: 127.0.0.1:9091\nfile_sentry:\n  enabled: true\n  watch_paths:\n    - /tmp/project\n")
+
+	applied, err := stepStagePipelockConfig(installOpts{}).apply(t.Context(), env)
+	if err != nil || applied {
+		t.Fatalf("managed rerun apply = %v, %v; want false, nil", applied, err)
+	}
+	if len(env.serviceReadOnlyPaths) != 1 || env.serviceReadOnlyPaths[0] != "/tmp/project" {
+		t.Fatalf("service read-only paths = %#v, want [/tmp/project]", env.serviceReadOnlyPaths)
+	}
+	if unit := renderSystemUnit(env); !strings.Contains(unit, `BindReadOnlyPaths=-"/tmp/project"`) {
+		t.Fatalf("system unit does not preserve /tmp watch path:\n%s", unit)
 	}
 }
 

--- a/internal/cli/contain/contain_hardening_test.go
+++ b/internal/cli/contain/contain_hardening_test.go
@@ -323,6 +323,30 @@ func TestStepWritePipelockConfigUndoRestoresMigratedArtifacts(t *testing.T) {
 	}
 }
 
+func TestStepStagePipelockConfigExplicitCandidatePreservesHomeSentryPaths(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := "/home/operator"
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return &user.User{Uid: "988", Gid: "988", Username: name, HomeDir: "/tmp"}, nil
+	}
+	src := filepath.Join(t.TempDir(), "pipelock.yaml")
+	mustWriteFile(t, src, "file_sentry:\n  enabled: true\n  watch_paths:\n    - /home/operator/project\n")
+	step := stepStagePipelockConfig(installOpts{configSource: src})
+	if _, err := step.apply(t.Context(), env); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(env.serviceHomeReadOnlyPaths) != 1 || env.serviceHomeReadOnlyPaths[0] != "/home/operator/project" {
+		t.Fatalf("service home paths = %#v, want explicit candidate path", env.serviceHomeReadOnlyPaths)
+	}
+	unit := renderSystemUnit(env)
+	if !strings.Contains(unit, `BindReadOnlyPaths=-"/home/operator/project"`) {
+		t.Fatalf("system unit does not preserve explicit candidate path:\n%s", unit)
+	}
+}
+
 func TestStepExportPipelockCAUndoAndErrorBranches(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	step := stepExportPipelockCA()

--- a/internal/cli/contain/doctor.go
+++ b/internal/cli/contain/doctor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -384,9 +385,11 @@ const dnsFailureHost = "pipelock-doctor-nonexistent.invalid"
 // than succeeding, hanging, or failing without proxy attribution.
 func checkDNSFailure(ctx context.Context, env *doctorEnv) doctorResult {
 	// %{http_connect} is the proxy's CONNECT response. It gives this check a
-	// positive attribution signal: a 5xx proves Pipelock handled the request and
-	// rejected the unresolvable target. A bare nonzero curl exit could instead be
-	// a dead proxy, TLS failure, or unrelated transport error.
+	// positive attribution signal: the local Pipelock CONNECT response proves the
+	// proxy handled the request. Pipelock returns 403 for a scanner/policy denial
+	// (including DNS resolution failure) and 5xx for upstream failures. A bare
+	// nonzero curl exit could instead be a dead proxy, TLS failure, or unrelated
+	// transport error.
 	name, args := env.sudoAgent(env.curlProxyArgsWithWriteOut("https://"+dnsFailureHost+"/", "%{http_connect}")...)
 	out, code, err := env.runCmd(ctx, name, args...)
 	if res, done := classifyAgentRun(out, err, "curl"); done {
@@ -396,7 +399,7 @@ func checkDNSFailure(ctx context.Context, env *doctorEnv) doctorResult {
 		return skip("curl not available for the agent", "install curl on the host")
 	}
 	connectCode, ok := trailingHTTPCode(out)
-	if code != 0 && ok && connectCode >= 500 && connectCode < 600 {
+	if code != 0 && ok && (connectCode == http.StatusForbidden || connectCode >= 500 && connectCode < 600) {
 		return pass(fmt.Sprintf("proxy CONNECT returned HTTP %d for the unresolvable host (curl exit %d, clean failure)", connectCode, code))
 	}
 	if code == 0 && ok && connectCode == 200 {

--- a/internal/cli/contain/doctor_test.go
+++ b/internal/cli/contain/doctor_test.go
@@ -219,6 +219,17 @@ func TestCheckNodeThroughProxy(t *testing.T) {
 }
 
 func TestCheckDNSFailure(t *testing.T) {
+	t.Run("clean failure via Pipelock policy denial 403", func(t *testing.T) {
+		env := newDoctorEnv(t, func(args []string) (string, int, error) {
+			if !argsContain(args, dnsFailureHost, "%{http_connect}") {
+				t.Fatalf("did not target nxdomain: %v", args)
+			}
+			return "curl: (56) CONNECT tunnel failed, response 403\n403", 56, nil
+		})
+		if res := checkDNSFailure(context.Background(), env); res.status != statusPass {
+			t.Fatalf("got %q (%s)", res.status, res.detail)
+		}
+	})
 	t.Run("clean failure via attributed proxy CONNECT 5xx", func(t *testing.T) {
 		env := newDoctorEnv(t, func(args []string) (string, int, error) {
 			if !argsContain(args, dnsFailureHost, "%{http_connect}") {
@@ -238,6 +249,8 @@ func TestCheckDNSFailure(t *testing.T) {
 		}{
 			{name: "proxy unavailable", out: "curl: (7) Failed to connect\n000", code: 7},
 			{name: "TLS failure after CONNECT", out: "curl: (35) TLS error\n200", code: 35},
+			{name: "proxy authentication required", out: "curl: (56) CONNECT failed\n407", code: 56},
+			{name: "unrelated client denial", out: "curl: (56) CONNECT failed\n404", code: 56},
 			{name: "no status", out: "curl failed", code: 56},
 		} {
 			t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -121,6 +121,11 @@ func runInstall(ctx context.Context, env *installEnv, opts installOpts) error {
 		ctx = context.Background()
 	}
 	env.archivedBackups = make(map[string][]string)
+	env.serviceBinaryChanged = false
+	env.serviceConfigChanged = false
+	env.serviceUnitChanged = false
+	env.installServiceWasActive = false
+	env.installServiceStateKnown = false
 	if opts.operatorUser != "" {
 		env.operatorUser = opts.operatorUser
 	}
@@ -315,6 +320,27 @@ func installSteps(opts installOpts) []step {
 		stepWriteAgentToolConfigs(),
 		stepWriteWrapperInventory(),
 		stepInstallSudoers(),
+		stepWaitPipelockReady(),
+	}
+}
+
+func stepWaitPipelockReady() step {
+	return step{
+		name: "wait-pipelock-ready",
+		desc: "confirm the installed proxy is accepting connections before declaring success",
+		apply: func(ctx context.Context, env *installEnv) (bool, error) {
+			status, detail := probeLoopbackListen(ctx, &probeEnv{
+				serviceName: "pipelock",
+				port:        env.proxyPort,
+				runCmd:      env.runCmd,
+				dialCtx:     env.dialCtx,
+				wait:        env.wait,
+			})
+			if status != statusPass {
+				return false, fmt.Errorf("installed proxy failed readiness: %s", detail)
+			}
+			return false, nil
+		},
 	}
 }
 
@@ -932,6 +958,7 @@ func stepPromotePipelockConfig(opts installOpts) step {
 		desc: "promote the accepted config to /etc/pipelock/pipelock.yaml",
 		apply: func(_ context.Context, env *installEnv) (bool, error) {
 			configWritten = false
+			env.serviceConfigChanged = false
 			if opts.configSource == "" {
 				return false, nil
 			}
@@ -958,13 +985,17 @@ func stepPromotePipelockConfig(opts installOpts) step {
 				return false, err
 			}
 			configWritten = true
+			env.serviceConfigChanged = true
 			return true, discardStagedPipelockConfig(env)
 		},
-		undo: func(_ context.Context, env *installEnv) error {
+		undo: func(ctx context.Context, env *installEnv) error {
 			if !configWritten {
 				return nil
 			}
-			return restoreBackup(env, managedPipelockConfigPath(env))
+			if err := restoreBackup(env, managedPipelockConfigPath(env)); err != nil {
+				return err
+			}
+			return restartRestoredServiceIfNeeded(ctx, env)
 		},
 	}
 }
@@ -1173,6 +1204,7 @@ func stepInstallPipelockBinary() step {
 		name: "install-pipelock-binary",
 		desc: "install pipelock binary to /usr/local/bin/pipelock (0o755)",
 		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			env.serviceBinaryChanged = false
 			if env.preflightBinaryHash != "" {
 				srcHash, err := env.hashFile(env.pipelockBinary)
 				if err != nil {
@@ -1209,10 +1241,14 @@ func stepInstallPipelockBinary() step {
 			if err := backupAndWrite(env, env.pipelockTarget, data, modeWrapperExec); err != nil {
 				return false, err
 			}
+			env.serviceBinaryChanged = true
 			return true, nil
 		},
-		undo: func(_ context.Context, env *installEnv) error {
-			return restoreBackup(env, env.pipelockTarget)
+		undo: func(ctx context.Context, env *installEnv) error {
+			if err := restoreBackup(env, env.pipelockTarget); err != nil {
+				return err
+			}
+			return restartRestoredServiceIfNeeded(ctx, env)
 		},
 	}
 }
@@ -1328,6 +1364,7 @@ func stepWriteSystemUnit() step {
 		name: "write-system-unit",
 		desc: "write /etc/systemd/system/pipelock.service",
 		apply: func(_ context.Context, env *installEnv) (bool, error) {
+			env.serviceUnitChanged = false
 			body := renderSystemUnit(env)
 			// Idempotency: only write if content differs.
 			if existing, err := env.readFile(env.systemUnitPath); err == nil && string(existing) == body {
@@ -1336,14 +1373,17 @@ func stepWriteSystemUnit() step {
 			if err := backupAndWrite(env, env.systemUnitPath, []byte(body), modeUnitFile); err != nil {
 				return false, err
 			}
+			env.serviceUnitChanged = true
 			return true, nil
 		},
 		undo: func(ctx context.Context, env *installEnv) error {
 			if err := restoreBackup(env, env.systemUnitPath); err != nil {
 				return err
 			}
-			_, _, _ = env.runCmd(ctx, "systemctl", "daemon-reload")
-			return nil
+			if err := runOrErr(ctx, env, "systemctl", "daemon-reload"); err != nil {
+				return err
+			}
+			return restartRestoredServiceIfNeeded(ctx, env)
 		},
 	}
 }
@@ -1372,7 +1412,10 @@ func renderSystemUnit(env *installEnv) string {
 		"",
 		"NoNewPrivileges=true",
 		"ProtectSystem=strict",
-		"ProtectHome=true",
+		// The proxy needs read access to explicitly DAC/ACL-authorized file-sentry
+		// paths under /home. read-only keeps the mount immutable while Unix
+		// permissions still hide every path not granted to pipelock-proxy.
+		"ProtectHome=read-only",
 		"ReadWritePaths=" + env.dataDir,
 		"PrivateTmp=true",
 		"ProtectKernelTunables=true",
@@ -1410,10 +1453,23 @@ func stepEnableSystemUnit() step {
 			wasActive = strings.TrimSpace(activeOut) == systemctlActive
 			wasEnabled = strings.TrimSpace(enabledOut) == systemctlEnabled
 			preStateKnown = true
+			env.installServiceWasActive = wasActive
+			env.installServiceStateKnown = true
+			runtimeChanged := env.serviceBinaryChanged || env.serviceConfigChanged || env.serviceUnitChanged
 			if wasActive && wasEnabled {
-				// Re-issuing enable when already enabled is a no-op anyway,
-				// but skip to keep the dry-run/run output clean.
-				return false, nil
+				if !runtimeChanged {
+					return false, nil
+				}
+				return true, runOrErr(ctx, env, "systemctl", "restart", "pipelock")
+			}
+			if wasActive {
+				if err := runOrErr(ctx, env, "systemctl", "enable", "pipelock"); err != nil {
+					return true, err
+				}
+				if runtimeChanged {
+					return true, runOrErr(ctx, env, "systemctl", "restart", "pipelock")
+				}
+				return true, nil
 			}
 			return true, runOrErr(ctx, env, "systemctl", "enable", "--now", "pipelock")
 		},
@@ -1435,6 +1491,13 @@ func stepEnableSystemUnit() step {
 			return nil
 		},
 	}
+}
+
+func restartRestoredServiceIfNeeded(ctx context.Context, env *installEnv) error {
+	if !env.installServiceStateKnown || !env.installServiceWasActive {
+		return nil
+	}
+	return runOrErr(ctx, env, "systemctl", "restart", "pipelock")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -126,6 +126,7 @@ func runInstall(ctx context.Context, env *installEnv, opts installOpts) error {
 	env.serviceUnitChanged = false
 	env.installServiceWasActive = false
 	env.installServiceStateKnown = false
+	env.serviceHomeReadOnlyPaths = nil
 	if opts.operatorUser != "" {
 		env.operatorUser = opts.operatorUser
 	}
@@ -914,6 +915,18 @@ func stepStagePipelockConfig(opts installOpts) step {
 			migrated = nil
 			staged = false
 			if opts.configSource == "" {
+				data, err := env.readFile(managedPipelockConfigPath(env))
+				if errors.Is(err, os.ErrNotExist) {
+					return false, nil
+				}
+				if err != nil {
+					return false, fmt.Errorf("read managed config for service sandbox: %w", err)
+				}
+				paths, err := containHomeReadOnlyPaths(data)
+				if err != nil {
+					return false, fmt.Errorf("read file_sentry paths for service sandbox: %w", err)
+				}
+				env.serviceHomeReadOnlyPaths = paths
 				return false, nil
 			}
 			data, err := env.readFile(opts.configSource)
@@ -1395,7 +1408,7 @@ func stepWriteSystemUnit() step {
 func renderSystemUnit(env *installEnv) string {
 	configPath := managedPipelockConfigPath(env)
 	capturePath := filepath.Join(env.dataDir, "captures")
-	return strings.Join([]string{
+	body := strings.Join([]string{
 		"[Unit]",
 		"Description=Pipelock AI Egress Proxy",
 		"Documentation=https://github.com/luckyPipewrench/pipelock",
@@ -1412,10 +1425,18 @@ func renderSystemUnit(env *installEnv) string {
 		"",
 		"NoNewPrivileges=true",
 		"ProtectSystem=strict",
-		// The proxy needs read access to explicitly DAC/ACL-authorized file-sentry
-		// paths under /home. read-only keeps the mount immutable while Unix
-		// permissions still hide every path not granted to pipelock-proxy.
-		"ProtectHome=read-only",
+	}, "\n")
+	if len(env.serviceHomeReadOnlyPaths) == 0 {
+		body += "\nProtectHome=true"
+	} else {
+		// tmpfs hides every home path, then the bind allow-list exposes only the
+		// configured file-sentry roots. DAC/ACL checks still apply inside them.
+		body += "\nProtectHome=tmpfs"
+		for _, path := range env.serviceHomeReadOnlyPaths {
+			body += "\nBindReadOnlyPaths=-" + strconv.Quote(strings.ReplaceAll(path, "%", "%%"))
+		}
+	}
+	return body + "\n" + strings.Join([]string{
 		"ReadWritePaths=" + env.dataDir,
 		"PrivateTmp=true",
 		"ProtectKernelTunables=true",

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -331,11 +331,12 @@ func stepWaitPipelockReady() step {
 		desc: "confirm the installed proxy is accepting connections before declaring success",
 		apply: func(ctx context.Context, env *installEnv) (bool, error) {
 			status, detail := probeLoopbackListen(ctx, &probeEnv{
-				serviceName: "pipelock",
-				port:        env.proxyPort,
-				runCmd:      env.runCmd,
-				dialCtx:     env.dialCtx,
-				wait:        env.wait,
+				serviceName:      defaultServiceName,
+				port:             env.proxyPort,
+				readinessTimeout: installReadinessTimeout,
+				runCmd:           env.runCmd,
+				dialCtx:          env.dialCtx,
+				wait:             env.wait,
 			})
 			if status != statusPass {
 				return false, fmt.Errorf("installed proxy failed readiness: %s", detail)

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -1532,6 +1532,18 @@ func restartRestoredServiceIfNeeded(ctx context.Context, env *installEnv) error 
 	if !env.installServiceStateKnown || !env.installServiceWasActive {
 		return nil
 	}
+	if env.deferServiceRestart {
+		env.serviceRestartPending = true
+		return nil
+	}
+	return runOrErr(ctx, env, "systemctl", "restart", "pipelock")
+}
+
+func restartRestoredServiceAfterRollback(ctx context.Context, env *installEnv) error {
+	if !env.serviceRestartPending {
+		return nil
+	}
+	env.serviceRestartPending = false
 	return runOrErr(ctx, env, "systemctl", "restart", "pipelock")
 }
 

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -126,7 +126,7 @@ func runInstall(ctx context.Context, env *installEnv, opts installOpts) error {
 	env.serviceUnitChanged = false
 	env.installServiceWasActive = false
 	env.installServiceStateKnown = false
-	env.serviceHomeReadOnlyPaths = nil
+	env.serviceReadOnlyPaths = nil
 	if opts.operatorUser != "" {
 		env.operatorUser = opts.operatorUser
 	}
@@ -923,11 +923,11 @@ func stepStagePipelockConfig(opts installOpts) step {
 				if err != nil {
 					return false, fmt.Errorf("read managed config for service sandbox: %w", err)
 				}
-				paths, err := containHomeReadOnlyPaths(data)
+				paths, err := containServiceReadOnlyPaths(data, env.proxyPort)
 				if err != nil {
-					return false, fmt.Errorf("read file_sentry paths for service sandbox: %w", err)
+					return false, fmt.Errorf("validate managed config for service sandbox: %w", err)
 				}
-				env.serviceHomeReadOnlyPaths = paths
+				env.serviceReadOnlyPaths = paths
 				return false, nil
 			}
 			data, err := env.readFile(opts.configSource)
@@ -939,7 +939,7 @@ func stepStagePipelockConfig(opts installOpts) step {
 				_ = cleanupMigratedConfigArtifacts(env, migrated)
 				return false, err
 			}
-			paths, err := containHomeReadOnlyPaths(data)
+			paths, err := containServiceReadOnlyPaths(data, env.proxyPort)
 			if err != nil {
 				_ = cleanupMigratedConfigArtifacts(env, migrated)
 				return false, fmt.Errorf("read file_sentry paths for service sandbox: %w", err)
@@ -948,7 +948,7 @@ func stepStagePipelockConfig(opts installOpts) step {
 				_ = cleanupMigratedConfigArtifacts(env, migrated)
 				return false, fmt.Errorf("stage config candidate: %w", err)
 			}
-			env.serviceHomeReadOnlyPaths = paths
+			env.serviceReadOnlyPaths = paths
 			staged = true
 			// Report the mutation even when nothing was migrated. Staging
 			// writes a file, and a step that reports no mutation is left off
@@ -1433,15 +1433,22 @@ func renderSystemUnit(env *installEnv) string {
 		"NoNewPrivileges=true",
 		"ProtectSystem=strict",
 	}, "\n")
-	if len(env.serviceHomeReadOnlyPaths) == 0 {
+	hasProtectedHomePath := false
+	for _, path := range env.serviceReadOnlyPaths {
+		if isProtectedHomePath(path) {
+			hasProtectedHomePath = true
+			break
+		}
+	}
+	if !hasProtectedHomePath {
 		body += "\nProtectHome=true"
 	} else {
-		// tmpfs hides every home path, then the bind allow-list exposes only the
+		// tmpfs hides every home path; the bind allow-list below exposes only
 		// configured file-sentry roots. DAC/ACL checks still apply inside them.
 		body += "\nProtectHome=tmpfs"
-		for _, path := range env.serviceHomeReadOnlyPaths {
-			body += "\nBindReadOnlyPaths=-" + strconv.Quote(strings.ReplaceAll(path, "%", "%%"))
-		}
+	}
+	for _, path := range env.serviceReadOnlyPaths {
+		body += "\nBindReadOnlyPaths=-" + strconv.Quote(strings.ReplaceAll(path, "%", "%%"))
 	}
 	return body + "\n" + strings.Join([]string{
 		"ReadWritePaths=" + env.dataDir,

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -939,10 +939,16 @@ func stepStagePipelockConfig(opts installOpts) step {
 				_ = cleanupMigratedConfigArtifacts(env, migrated)
 				return false, err
 			}
+			paths, err := containHomeReadOnlyPaths(data)
+			if err != nil {
+				_ = cleanupMigratedConfigArtifacts(env, migrated)
+				return false, fmt.Errorf("read file_sentry paths for service sandbox: %w", err)
+			}
 			if err := env.writeFile(stagedPipelockConfigPath(env), data, modeConfigSecret); err != nil {
 				_ = cleanupMigratedConfigArtifacts(env, migrated)
 				return false, fmt.Errorf("stage config candidate: %w", err)
 			}
+			env.serviceHomeReadOnlyPaths = paths
 			staged = true
 			// Report the mutation even when nothing was migrated. Staging
 			// writes a file, and a step that reports no mutation is left off

--- a/internal/cli/contain/install_config_preflight_test.go
+++ b/internal/cli/contain/install_config_preflight_test.go
@@ -194,7 +194,7 @@ func TestRunInstall_ConfigPreflightAllowsCleanConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read managed config: %v", err)
 	}
-	if string(got) != "mode: balanced\n" {
+	if string(got) != "mode: balanced\nmetrics_listen: 127.0.0.1:9091\n" {
 		t.Fatalf("managed config = %q, want the promoted candidate", got)
 	}
 }

--- a/internal/cli/contain/install_config_preflight_test.go
+++ b/internal/cli/contain/install_config_preflight_test.go
@@ -97,7 +97,7 @@ func TestRunInstall_ConfigPreflightRefusesMissingManagedConfigBeforeServiceMutat
 func TestRunInstall_ConfigPreflightCoversUpgradeWithoutConfigFlag(t *testing.T) {
 	env, runner, _ := newPreflightInstallEnv(t)
 	target := managedPipelockConfigPath(env)
-	if err := os.WriteFile(target, []byte("agents:\n  _default:\n    budget:\n      fan_out_limit: 4\n"), 0o600); err != nil {
+	if err := os.WriteFile(target, []byte("metrics_listen: 127.0.0.1:9091\nagents:\n  _default:\n    budget:\n      fan_out_limit: 4\n"), 0o600); err != nil {
 		t.Fatalf("write existing config: %v", err)
 	}
 	runner.on(argvFor(env.pipelockBinary, "check", "--config", target),
@@ -502,7 +502,7 @@ func writePreflightConfig(t *testing.T, name, body string) string {
 func seedManagedConfig(t *testing.T, env *installEnv) string {
 	t.Helper()
 	target := managedPipelockConfigPath(env)
-	if err := os.WriteFile(target, []byte("mode: balanced\n"), 0o600); err != nil {
+	if err := os.WriteFile(target, []byte("mode: balanced\nmetrics_listen: 127.0.0.1:9091\n"), 0o600); err != nil {
 		t.Fatalf("write managed config: %v", err)
 	}
 	return target

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -190,7 +190,7 @@ func TestStepWaitPipelockReadyFailsWhenServiceExited(t *testing.T) {
 	env.dialCtx = func(context.Context, string, string, time.Duration) (net.Conn, error) {
 		return nil, errors.New("connection refused")
 	}
-	runner.on("systemctl show pipelock --property=ActiveState,SubState",
+	runner.on("systemctl show pipelock.service --property=ActiveState,SubState",
 		"ActiveState=failed\nSubState=failed\n", 0, nil)
 
 	applied, err := stepWaitPipelockReady().apply(t.Context(), env)
@@ -199,6 +199,31 @@ func TestStepWaitPipelockReadyFailsWhenServiceExited(t *testing.T) {
 	}
 	if err == nil || !strings.Contains(err.Error(), "service exited before readiness") {
 		t.Fatalf("readiness error = %v, want exited-service refusal", err)
+	}
+}
+
+func TestStepWaitPipelockReadyUsesInstallBudget(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	runner.on("systemctl show pipelock.service --property=ActiveState,SubState",
+		"ActiveState=active\nSubState=running\n", 0, nil)
+	attempts := 0
+	env.dialCtx = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+		attempts++
+		if attempts > int(readinessTimeout/readinessInterval)+1 {
+			return &fakeConn{}, nil
+		}
+		return nil, errors.New("connection refused")
+	}
+
+	applied, err := stepWaitPipelockReady().apply(t.Context(), env)
+	if err != nil {
+		t.Fatalf("readiness with slow healthy startup: %v", err)
+	}
+	if applied {
+		t.Fatal("readiness step reported a mutation")
+	}
+	if attempts <= int(readinessTimeout/readinessInterval)+1 {
+		t.Fatalf("dial attempts = %d, want beyond diagnostic budget", attempts)
 	}
 }
 

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -350,9 +350,22 @@ func TestStepEnableSystemUnit_ActiveDisabledChangeEnablesAndRestarts(t *testing.
 	}
 }
 
+func TestStepEnableSystemUnit_ActiveDisabledReportsEnableFailure(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	env.serviceBinaryChanged = true
+	runner.on(argvFor(testSystemctl, "daemon-reload"), "", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-active", "pipelock"), "active\n", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-enabled", "pipelock"), "disabled\n", 1, nil)
+	runner.on(argvFor(testSystemctl, "enable", "pipelock"), "failed", 1, errors.New("enable failed"))
+
+	if applied, err := stepEnableSystemUnit().apply(t.Context(), env); err == nil || !applied {
+		t.Fatalf("apply = %v, %v; want true, error", applied, err)
+	}
+}
+
 func TestRenderSystemUnit_FileSentryHomeIsNarrowlyVisibleReadOnly(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
-	env.serviceHomeReadOnlyPaths = []string{"/home/operator/project", "/home/operator/project with spaces"}
+	env.serviceReadOnlyPaths = []string{"/home/operator/project", "/home/operator/project with spaces"}
 	body := renderSystemUnit(env)
 	if !strings.Contains(body, "ProtectHome=tmpfs") {
 		t.Fatalf("system unit does not hide unlisted home paths:\n%s", body)
@@ -369,6 +382,20 @@ func TestRenderSystemUnit_WithoutFileSentryKeepsHomeInaccessible(t *testing.T) {
 	body := renderSystemUnit(env)
 	if !strings.Contains(body, "ProtectHome=true") || strings.Contains(body, "BindReadOnlyPaths=") {
 		t.Fatalf("system unit weakens home isolation without file-sentry paths:\n%s", body)
+	}
+}
+
+func TestRenderSystemUnit_FileSentryPrivateTmpPathIsVisibleReadOnly(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.serviceReadOnlyPaths = []string{"/tmp/pipelock-watch", "/var/tmp/pipelock-watch"}
+	body := renderSystemUnit(env)
+	if !strings.Contains(body, "ProtectHome=true") {
+		t.Fatalf("system unit weakens home isolation for tmp-only paths:\n%s", body)
+	}
+	for _, want := range []string{`BindReadOnlyPaths=-"/tmp/pipelock-watch"`, `BindReadOnlyPaths=-"/var/tmp/pipelock-watch"`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("system unit missing %q:\n%s", want, body)
+		}
 	}
 }
 

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // Extra coverage for the install step builders that hit error / undo paths
@@ -120,7 +122,7 @@ func TestStepWritePipelockConfig_CopiesFromSource(t *testing.T) {
 	}
 	dst := filepath.Join(env.configDir, "pipelock.yaml")
 	got, _ := os.ReadFile(dst) //nolint:gosec // tmpdir-scoped test path
-	if string(got) != "mode: balanced\n" {
+	if string(got) != "mode: balanced\nmetrics_listen: 127.0.0.1:9091\n" {
 		t.Errorf("dst: %q", got)
 	}
 }
@@ -144,7 +146,7 @@ func TestStepWritePipelockConfig_SkipsWhenIdentical(t *testing.T) {
 	if err := os.MkdirAll(env.configDir, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	if err := os.WriteFile(dst, body, 0o600); err != nil {
+	if err := os.WriteFile(dst, []byte("mode: balanced\nmetrics_listen: 127.0.0.1:9091\n"), 0o600); err != nil {
 		t.Fatalf("write dst: %v", err)
 	}
 	applied := applyStagePromote(t, env, installOpts{configSource: src})
@@ -171,7 +173,7 @@ func TestStepWritePipelockConfig_OverwritesAndWarnsOnDifference(t *testing.T) {
 		t.Errorf("expected overwrite when --config differs")
 	}
 	got, _ := os.ReadFile(dst) //nolint:gosec // tmpdir-scoped test path
-	if string(got) != "mode: strict\n" {
+	if string(got) != "mode: strict\nmetrics_listen: 127.0.0.1:9091\n" {
 		t.Errorf("dst not overwritten: %q", got)
 	}
 	bak, _ := os.ReadFile(dst + ".bak") //nolint:gosec // tmpdir-scoped test path
@@ -180,6 +182,23 @@ func TestStepWritePipelockConfig_OverwritesAndWarnsOnDifference(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "WARN: --config") {
 		t.Errorf("expected warning in output, got %q", buf.String())
+	}
+}
+
+func TestStepWaitPipelockReadyFailsWhenServiceExited(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	env.dialCtx = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+		return nil, errors.New("connection refused")
+	}
+	runner.on("systemctl show pipelock --property=ActiveState,SubState",
+		"ActiveState=failed\nSubState=failed\n", 0, nil)
+
+	applied, err := stepWaitPipelockReady().apply(t.Context(), env)
+	if applied {
+		t.Fatal("readiness step reported a mutation")
+	}
+	if err == nil || !strings.Contains(err.Error(), "service exited before readiness") {
+		t.Fatalf("readiness error = %v, want exited-service refusal", err)
 	}
 }
 
@@ -257,6 +276,147 @@ func TestStepEnableSystemUnit_SkipsWhenActive(t *testing.T) {
 	if applied {
 		t.Errorf("expected skip when unit already active")
 	}
+}
+
+func TestStepEnableSystemUnit_RestartsActiveServiceAfterRuntimeChange(t *testing.T) {
+	for _, changed := range []struct {
+		name  string
+		apply func(*installEnv)
+	}{
+		{name: "binary", apply: func(env *installEnv) { env.serviceBinaryChanged = true }},
+		{name: "config", apply: func(env *installEnv) { env.serviceConfigChanged = true }},
+		{name: "unit", apply: func(env *installEnv) { env.serviceUnitChanged = true }},
+	} {
+		t.Run(changed.name, func(t *testing.T) {
+			env, runner, _ := newFakeEnv(t)
+			changed.apply(env)
+			runner.on(argvFor(testSystemctl, "daemon-reload"), "", 0, nil)
+			runner.on(argvFor(testSystemctl, "is-active", "pipelock"), "active\n", 0, nil)
+			runner.on(argvFor(testSystemctl, "is-enabled", "pipelock"), "enabled\n", 0, nil)
+			runner.on(argvFor(testSystemctl, "restart", "pipelock"), "", 0, nil)
+
+			applied, err := stepEnableSystemUnit().apply(context.Background(), env)
+			if err != nil || !applied {
+				t.Fatalf("apply = %v, %v; want true, nil", applied, err)
+			}
+			if !runnerSawSystemctl(runner, "restart", "pipelock") {
+				t.Fatalf("changed %s did not restart active service: %v", changed.name, runner.calls)
+			}
+		})
+	}
+}
+
+func TestStepEnableSystemUnit_ActiveDisabledChangeEnablesAndRestarts(t *testing.T) {
+	env, runner, _ := newFakeEnv(t)
+	env.serviceBinaryChanged = true
+	runner.on(argvFor(testSystemctl, "daemon-reload"), "", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-active", "pipelock"), "active\n", 0, nil)
+	runner.on(argvFor(testSystemctl, "is-enabled", "pipelock"), "disabled\n", 1, nil)
+
+	applied, err := stepEnableSystemUnit().apply(context.Background(), env)
+	if err != nil || !applied {
+		t.Fatalf("apply = %v, %v; want true, nil", applied, err)
+	}
+	if !runnerSawSystemctl(runner, "enable", "pipelock") || !runnerSawSystemctl(runner, "restart", "pipelock") {
+		t.Fatalf("active disabled changed service was not enabled and restarted: %v", runner.calls)
+	}
+	if runnerSawSystemctl(runner, "enable", "--now", "pipelock") {
+		t.Fatalf("active service should not use enable --now: %v", runner.calls)
+	}
+}
+
+func TestRenderSystemUnit_FileSentryHomeIsVisibleReadOnly(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	body := renderSystemUnit(env)
+	if !strings.Contains(body, "ProtectHome=read-only") {
+		t.Fatalf("system unit does not expose DAC-authorized home paths read-only:\n%s", body)
+	}
+	if strings.Contains(body, "ProtectHome=true") || strings.Contains(body, "ProtectHome=false") {
+		t.Fatalf("system unit has unsafe/inaccessible ProtectHome mode:\n%s", body)
+	}
+}
+
+func TestChangedRuntimeArtifacts_RollbackRestoresAndRestartsPriorService(t *testing.T) {
+	t.Run("binary", func(t *testing.T) {
+		env, runner, _ := newFakeEnv(t)
+		if err := os.WriteFile(filepath.Clean(env.pipelockTarget), []byte("old binary"), 0o600); err != nil {
+			t.Fatalf("WriteFile old binary: %v", err)
+		}
+		step := stepInstallPipelockBinary()
+		if applied, err := step.apply(context.Background(), env); err != nil || !applied {
+			t.Fatalf("apply = %v, %v", applied, err)
+		}
+		env.installServiceStateKnown = true
+		env.installServiceWasActive = true
+		if err := step.undo(context.Background(), env); err != nil {
+			t.Fatalf("undo: %v", err)
+		}
+		assertRestoredFileAndRestart(t, env.pipelockTarget, "old binary", runner)
+	})
+
+	t.Run("config", func(t *testing.T) {
+		env, runner, _ := newFakeEnv(t)
+		managed := managedPipelockConfigPath(env)
+		if err := os.WriteFile(managed, []byte("old config"), 0o600); err != nil {
+			t.Fatalf("WriteFile old config: %v", err)
+		}
+		if err := os.WriteFile(stagedPipelockConfigPath(env), []byte("new config"), 0o600); err != nil {
+			t.Fatalf("WriteFile staged config: %v", err)
+		}
+		step := stepPromotePipelockConfig(installOpts{configSource: "/candidate.yaml"})
+		if applied, err := step.apply(context.Background(), env); err != nil || !applied {
+			t.Fatalf("apply = %v, %v", applied, err)
+		}
+		env.installServiceStateKnown = true
+		env.installServiceWasActive = true
+		if err := step.undo(context.Background(), env); err != nil {
+			t.Fatalf("undo: %v", err)
+		}
+		assertRestoredFileAndRestart(t, managed, "old config", runner)
+	})
+
+	t.Run("unit", func(t *testing.T) {
+		env, runner, _ := newFakeEnv(t)
+		if err := os.WriteFile(env.systemUnitPath, []byte("old unit"), 0o600); err != nil {
+			t.Fatalf("WriteFile old unit: %v", err)
+		}
+		step := stepWriteSystemUnit()
+		if applied, err := step.apply(context.Background(), env); err != nil || !applied {
+			t.Fatalf("apply = %v, %v", applied, err)
+		}
+		env.installServiceStateKnown = true
+		env.installServiceWasActive = true
+		if err := step.undo(context.Background(), env); err != nil {
+			t.Fatalf("undo: %v", err)
+		}
+		assertRestoredFileAndRestart(t, env.systemUnitPath, "old unit", runner)
+		if !runnerSawSystemctl(runner, "daemon-reload") {
+			t.Fatalf("unit rollback did not reload systemd: %v", runner.calls)
+		}
+	})
+}
+
+func assertRestoredFileAndRestart(t *testing.T, path, want string, runner *fakeRunner) {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("ReadFile restored artifact: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("restored artifact = %q, want %q", got, want)
+	}
+	if !runnerSawSystemctl(runner, "restart", "pipelock") {
+		t.Fatalf("rollback did not restart prior active service: %v", runner.calls)
+	}
+}
+
+func runnerSawSystemctl(runner *fakeRunner, args ...string) bool {
+	for _, call := range runner.calls {
+		if call.name == testSystemctl && strings.Join(call.args, "\x00") == strings.Join(args, "\x00") {
+			return true
+		}
+	}
+	return false
 }
 
 func TestStepEnableSystemUnit_EnablesWhenActiveButDisabled(t *testing.T) {

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -325,14 +325,25 @@ func TestStepEnableSystemUnit_ActiveDisabledChangeEnablesAndRestarts(t *testing.
 	}
 }
 
-func TestRenderSystemUnit_FileSentryHomeIsVisibleReadOnly(t *testing.T) {
+func TestRenderSystemUnit_FileSentryHomeIsNarrowlyVisibleReadOnly(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.serviceHomeReadOnlyPaths = []string{"/home/operator/project", "/home/operator/project with spaces"}
+	body := renderSystemUnit(env)
+	if !strings.Contains(body, "ProtectHome=tmpfs") {
+		t.Fatalf("system unit does not hide unlisted home paths:\n%s", body)
+	}
+	for _, want := range []string{`BindReadOnlyPaths=-"/home/operator/project"`, `BindReadOnlyPaths=-"/home/operator/project with spaces"`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("system unit missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestRenderSystemUnit_WithoutFileSentryKeepsHomeInaccessible(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	body := renderSystemUnit(env)
-	if !strings.Contains(body, "ProtectHome=read-only") {
-		t.Fatalf("system unit does not expose DAC-authorized home paths read-only:\n%s", body)
-	}
-	if strings.Contains(body, "ProtectHome=true") || strings.Contains(body, "ProtectHome=false") {
-		t.Fatalf("system unit has unsafe/inaccessible ProtectHome mode:\n%s", body)
+	if !strings.Contains(body, "ProtectHome=true") || strings.Contains(body, "BindReadOnlyPaths=") {
+		t.Fatalf("system unit weakens home isolation without file-sentry paths:\n%s", body)
 	}
 }
 

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -168,8 +169,14 @@ func newFakeEnv(t *testing.T) (*installEnv, *fakeRunner, *bytes.Buffer) {
 	out := &bytes.Buffer{}
 	env := &installEnv{
 		runCmd: runner.run,
-		stat:   os.Stat,
-		lstat:  os.Lstat,
+		dialCtx: func(_ context.Context, _, _ string, _ time.Duration) (net.Conn, error) {
+			client, server := net.Pipe()
+			_ = server.Close()
+			return client, nil
+		},
+		wait:  func(context.Context, time.Duration) error { return nil },
+		stat:  os.Stat,
+		lstat: os.Lstat,
 		readFile: func(p string) ([]byte, error) {
 			return os.ReadFile(filepath.Clean(p))
 		},
@@ -2123,13 +2130,12 @@ func TestStepCreateDirRejectsSymlinkParent(t *testing.T) {
 }
 
 func TestInstallSteps_Count(t *testing.T) {
-	// Sanity: the install flow has 30 steps total after combining the runtime
-	// contract steps with the credential guard and the operator evidence ACL
-	// step. Changing this count is a documented breaking change for the
-	// dry-run / verify probe-4 inventory.
+	// Sanity: the install flow has 31 steps total after combining the runtime
+	// contract steps, credential guard, operator evidence ACL, and final
+	// readiness gate. Changing this count changes documented dry-run output.
 	steps := installSteps(installOpts{})
-	if len(steps) != 30 {
-		t.Errorf("installSteps count: got %d, want 30", len(steps))
+	if len(steps) != 31 {
+		t.Errorf("installSteps count: got %d, want 31", len(steps))
 	}
 }
 

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -114,6 +114,7 @@ type installEnv struct {
 	serviceUnitChanged       bool
 	installServiceWasActive  bool
 	installServiceStateKnown bool
+	serviceHomeReadOnlyPaths []string
 }
 
 // defaultInstallEnv wires installEnv to the real OS. Callers fill in

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -114,6 +114,8 @@ type installEnv struct {
 	serviceUnitChanged       bool
 	installServiceWasActive  bool
 	installServiceStateKnown bool
+	deferServiceRestart      bool
+	serviceRestartPending    bool
 	serviceReadOnlyPaths     []string
 }
 

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -28,7 +28,9 @@ type installEnv struct {
 	// runCmd shells out. Returns merged stdout+stderr (bounded), the
 	// process exit code, and a startup error (nil if the binary ran even
 	// when it exited non-zero). Same contract as verify.go's runCommand.
-	runCmd runCommand
+	runCmd  runCommand
+	dialCtx dialFunc
+	wait    waitFunc
 
 	// stat / readFile / writeFile / removeFile mirror the os package. They
 	// are abstracted only so tests can run on a tmpdir without sudo. Path
@@ -107,6 +109,11 @@ type installEnv struct {
 	prevNFTPersistStateKnown bool
 	preflightBinaryHash      string
 	archivedBackups          map[string][]string
+	serviceBinaryChanged     bool
+	serviceConfigChanged     bool
+	serviceUnitChanged       bool
+	installServiceWasActive  bool
+	installServiceStateKnown bool
 }
 
 // defaultInstallEnv wires installEnv to the real OS. Callers fill in
@@ -118,6 +125,8 @@ func defaultInstallEnv(out io.Writer) *installEnv {
 	platform := detectContainPlatform(os.ReadFile, os.Stat, exec.LookPath)
 	return &installEnv{
 		runCmd:             realRunCommand,
+		dialCtx:            realDial,
+		wait:               waitForReadiness,
 		stat:               os.Stat,
 		lstat:              os.Lstat,
 		readFile:           os.ReadFile,

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -114,7 +114,7 @@ type installEnv struct {
 	serviceUnitChanged       bool
 	installServiceWasActive  bool
 	installServiceStateKnown bool
-	serviceHomeReadOnlyPaths []string
+	serviceReadOnlyPaths     []string
 }
 
 // defaultInstallEnv wires installEnv to the real OS. Callers fill in

--- a/internal/cli/contain/step.go
+++ b/internal/cli/contain/step.go
@@ -85,6 +85,8 @@ func rollbackApplied(ctx context.Context, env *installEnv, w io.Writer, applied 
 	if len(applied) == 0 {
 		return
 	}
+	env.deferServiceRestart = true
+	env.serviceRestartPending = false
 	_, _ = fmt.Fprintln(w, "rolling back applied steps:")
 	for i := len(applied) - 1; i >= 0; i-- {
 		s := applied[i]
@@ -97,6 +99,13 @@ func rollbackApplied(ctx context.Context, env *installEnv, w io.Writer, applied 
 			continue
 		}
 		_, _ = fmt.Fprintf(w, "  [ OK ] undo %s\n", s.name)
+	}
+	env.deferServiceRestart = false
+	restartPending := env.serviceRestartPending
+	if err := restartRestoredServiceAfterRollback(ctx, env); err != nil {
+		_, _ = fmt.Fprintf(w, "  [FAIL] restart restored pipelock service: %v\n", err)
+	} else if restartPending {
+		_, _ = fmt.Fprintln(w, "  [ OK ] restart restored pipelock service")
 	}
 }
 

--- a/internal/cli/contain/step_test.go
+++ b/internal/cli/contain/step_test.go
@@ -105,6 +105,59 @@ func TestRunSteps_SkippedStepNotRolledBack(t *testing.T) {
 	}
 }
 
+func TestRunSteps_ReadinessFailureRestartsActiveServiceAfterRollbackCompletes(t *testing.T) {
+	var order []string
+	restarts := 0
+	env := &installEnv{
+		installServiceStateKnown: true,
+		installServiceWasActive:  true,
+		runCmd: func(_ context.Context, name string, args ...string) (string, int, error) {
+			if name == "systemctl" && strings.Join(args, " ") == "restart pipelock" {
+				restarts++
+				order = append(order, "restart")
+			}
+			return "", 0, nil
+		},
+	}
+	restoreStep := func(name string) step {
+		return step{
+			name: name,
+			desc: name,
+			apply: func(context.Context, *installEnv) (bool, error) {
+				order = append(order, "apply-"+name)
+				return true, nil
+			},
+			undo: func(ctx context.Context, env *installEnv) error {
+				order = append(order, "restore-"+name)
+				return restartRestoredServiceIfNeeded(ctx, env)
+			},
+		}
+	}
+	steps := []step{
+		restoreStep("config"),
+		restoreStep("binary"),
+		{
+			name: "wait-pipelock-ready",
+			desc: "readiness",
+			apply: func(context.Context, *installEnv) (bool, error) {
+				order = append(order, "readiness-failed")
+				return false, errors.New("connection refused")
+			},
+		},
+	}
+	var out bytes.Buffer
+	if _, err := runSteps(context.Background(), env, &out, steps); err == nil {
+		t.Fatal("runSteps readiness error = nil")
+	}
+	want := "apply-config,apply-binary,readiness-failed,restore-binary,restore-config,restart"
+	if got := strings.Join(order, ","); got != want {
+		t.Fatalf("rollback order = %q, want %q", got, want)
+	}
+	if restarts != 1 {
+		t.Fatalf("restart count = %d, want exactly 1 after all restores", restarts)
+	}
+}
+
 func TestRunSteps_FailureMidwayRollsBackInReverse(t *testing.T) {
 	var order []string
 	mkApply := func(label string) func(context.Context, *installEnv) (bool, error) {

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -43,9 +43,10 @@ const (
 	defaultNFTTable     = "pipelock_containment"
 	defaultNFTChain     = "output_filter"
 
-	probeDialTimeout  = 2 * time.Second
-	readinessTimeout  = 5 * time.Second
-	readinessInterval = 100 * time.Millisecond
+	probeDialTimeout        = 2 * time.Second
+	readinessTimeout        = 5 * time.Second
+	installReadinessTimeout = 30 * time.Second
+	readinessInterval       = 100 * time.Millisecond
 
 	// curl flags shared between the egress canary and the operator
 	// reachability probe. Connect timeout is intentionally lower than
@@ -137,6 +138,7 @@ type probeEnv struct {
 	nftPersistUnitPath string
 	nftPath            string
 	serviceName        string
+	readinessTimeout   time.Duration
 	curlPath           string
 	pinPath            string
 	wrapperInvPath     string
@@ -1628,9 +1630,13 @@ func scanPipelockCertCN(data []byte) (int, string, error) {
 func probeLoopbackListen(ctx context.Context, env *probeEnv) (string, string) {
 	addr := net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", env.port))
 	start := time.Now()
-	readyCtx, cancel := context.WithTimeout(ctx, readinessTimeout)
+	timeout := env.readinessTimeout
+	if timeout <= 0 {
+		timeout = readinessTimeout
+	}
+	readyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	maxAttempts := int(readinessTimeout/readinessInterval) + 1
+	maxAttempts := int(timeout/readinessInterval) + 1
 	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		conn, err := env.dialCtx(readyCtx, "tcp", addr, min(probeDialTimeout, readinessInterval))
@@ -1658,7 +1664,7 @@ func probeLoopbackListen(ctx context.Context, env *probeEnv) (string, string) {
 			break
 		}
 	}
-	return statusFail, fmt.Sprintf("dial %s: service did not become ready within %s (last error: %v)", addr, readinessTimeout, lastErr)
+	return statusFail, fmt.Sprintf("dial %s: service did not become ready within %s (last error: %v)", addr, timeout, lastErr)
 }
 
 // formatDialDuration renders an elapsed dial time at millisecond

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1637,6 +1637,7 @@ func probeLoopbackListen(ctx context.Context, env *probeEnv) (string, string) {
 	readyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	maxAttempts := int(timeout/readinessInterval) + 1
+	const serviceStatePollEvery = 5
 	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		conn, err := env.dialCtx(readyCtx, "tcp", addr, min(probeDialTimeout, readinessInterval))
@@ -1647,14 +1648,16 @@ func probeLoopbackListen(ctx context.Context, env *probeEnv) (string, string) {
 		}
 		lastErr = err
 
-		out, code, showErr := env.runCmd(readyCtx, "systemctl", "show", env.serviceName,
-			"--property=ActiveState,SubState",
-		)
-		if showErr == nil && code == 0 {
-			fields := parseSystemdShow(out)
-			if fields["ActiveState"] != systemctlActive || fields["SubState"] != "running" {
-				return statusFail, fmt.Sprintf("dial %s: %v; service exited before readiness (ActiveState=%s SubState=%s)",
-					addr, err, fields["ActiveState"], fields["SubState"])
+		if attempt%serviceStatePollEvery == 0 || attempt == maxAttempts-1 {
+			out, code, showErr := env.runCmd(readyCtx, "systemctl", "show", env.serviceName,
+				"--property=ActiveState,SubState",
+			)
+			if showErr == nil && code == 0 {
+				fields := parseSystemdShow(out)
+				if fields["ActiveState"] != systemctlActive || fields["SubState"] != "running" {
+					return statusFail, fmt.Sprintf("dial %s: %v; service exited before readiness (ActiveState=%s SubState=%s)",
+						addr, err, fields["ActiveState"], fields["SubState"])
+				}
 			}
 		}
 		if attempt == maxAttempts-1 {

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -43,7 +43,9 @@ const (
 	defaultNFTTable     = "pipelock_containment"
 	defaultNFTChain     = "output_filter"
 
-	probeDialTimeout = 2 * time.Second
+	probeDialTimeout  = 2 * time.Second
+	readinessTimeout  = 5 * time.Second
+	readinessInterval = 100 * time.Millisecond
 
 	// curl flags shared between the egress canary and the operator
 	// reachability probe. Connect timeout is intentionally lower than
@@ -104,6 +106,8 @@ type runCommand func(ctx context.Context, name string, args ...string) (output s
 // net.Dialer.DialContext + a timeout.
 type dialFunc func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error)
 
+type waitFunc func(ctx context.Context, duration time.Duration) error
+
 // lookupUserFunc is the os/user.Lookup signature, factored so tests can
 // substitute a deterministic lookup.
 type lookupUserFunc func(name string) (*user.User, error)
@@ -147,6 +151,7 @@ type probeEnv struct {
 	runCmd      runCommand
 	dropCounter dropCounterFunc
 	dialCtx     dialFunc
+	wait        waitFunc
 	lookupUser  lookupUserFunc
 	groupIDs    groupIDsFunc
 	stat        func(path string) (os.FileInfo, error)
@@ -183,6 +188,7 @@ func defaultProbeEnv() *probeEnv {
 		runCmd:             realRunCommand,
 		dropCounter:        readContainmentDropCounter,
 		dialCtx:            realDial,
+		wait:               waitForReadiness,
 		lookupUser:         user.Lookup,
 		groupIDs:           realGroupIDs,
 		stat:               os.Stat,
@@ -283,6 +289,17 @@ func (w *errorTrackingWriter) Err() error {
 func realDial(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error) {
 	d := net.Dialer{Timeout: timeout}
 	return d.DialContext(ctx, network, address)
+}
+
+func waitForReadiness(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // probe is one verification step. Probes are walked in slice order;
@@ -1611,13 +1628,37 @@ func scanPipelockCertCN(data []byte) (int, string, error) {
 func probeLoopbackListen(ctx context.Context, env *probeEnv) (string, string) {
 	addr := net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", env.port))
 	start := time.Now()
-	conn, err := env.dialCtx(ctx, "tcp", addr, probeDialTimeout)
-	if err != nil {
-		return statusFail, fmt.Sprintf("dial %s: %v", addr, err)
+	readyCtx, cancel := context.WithTimeout(ctx, readinessTimeout)
+	defer cancel()
+	maxAttempts := int(readinessTimeout/readinessInterval) + 1
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		conn, err := env.dialCtx(readyCtx, "tcp", addr, min(probeDialTimeout, readinessInterval))
+		if err == nil {
+			elapsed := time.Since(start)
+			_ = conn.Close()
+			return statusPass, fmt.Sprintf("%s accepted TCP within %s", addr, formatDialDuration(elapsed))
+		}
+		lastErr = err
+
+		out, code, showErr := env.runCmd(readyCtx, "systemctl", "show", env.serviceName,
+			"--property=ActiveState,SubState",
+		)
+		if showErr == nil && code == 0 {
+			fields := parseSystemdShow(out)
+			if fields["ActiveState"] != systemctlActive || fields["SubState"] != "running" {
+				return statusFail, fmt.Sprintf("dial %s: %v; service exited before readiness (ActiveState=%s SubState=%s)",
+					addr, err, fields["ActiveState"], fields["SubState"])
+			}
+		}
+		if attempt == maxAttempts-1 {
+			break
+		}
+		if err := env.wait(readyCtx, readinessInterval); err != nil {
+			break
+		}
 	}
-	elapsed := time.Since(start)
-	_ = conn.Close()
-	return statusPass, fmt.Sprintf("%s accepted TCP within %s", addr, formatDialDuration(elapsed))
+	return statusFail, fmt.Sprintf("dial %s: service did not become ready within %s (last error: %v)", addr, readinessTimeout, lastErr)
 }
 
 // formatDialDuration renders an elapsed dial time at millisecond

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -208,12 +208,15 @@ func makeProbeEnv(t *testing.T, opts ...func(*probeEnv)) *probeEnv {
 		runCmd:        rejectAllRun,
 		dropCounter:   rejectAllDropCounter,
 		dialCtx:       rejectAllDial,
-		lookupUser:    rejectAllLookup,
-		groupIDs:      rejectAllGroupIDs,
-		stat:          os.Stat,
-		readFile:      rejectAllReadFile,
-		selfPath:      rejectAllSelfPath,
-		hashFile:      rejectAllHashFile,
+		wait: func(context.Context, time.Duration) error {
+			return nil
+		},
+		lookupUser: rejectAllLookup,
+		groupIDs:   rejectAllGroupIDs,
+		stat:       os.Stat,
+		readFile:   rejectAllReadFile,
+		selfPath:   rejectAllSelfPath,
+		hashFile:   rejectAllHashFile,
 	}
 	env.launchPath = filepath.Join(env.wrapperDir, "plk-launch")
 	for _, opt := range opts {
@@ -1657,6 +1660,44 @@ func TestProbeLoopbackListen(t *testing.T) {
 		}
 		if !strings.Contains(gotDetail, "refused") {
 			t.Fatalf("detail: got %q, want substring refused", gotDetail)
+		}
+	})
+
+	t.Run("slow startup becomes ready", func(t *testing.T) {
+		attempts := 0
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.dialCtx = func(_ context.Context, _, _ string, _ time.Duration) (net.Conn, error) {
+				attempts++
+				if attempts < 3 {
+					return nil, errors.New("connection refused")
+				}
+				return &fakeConn{}, nil
+			}
+			e.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+				if name != "systemctl" || !containsArg(args, "show") {
+					t.Fatalf("unexpected readiness command: %s %v", name, args)
+				}
+				return "ActiveState=active\nSubState=running\n", 0, nil
+			}
+		})
+		gotStatus, _ := probeLoopbackListen(context.Background(), env)
+		if gotStatus != statusPass || attempts != 3 {
+			t.Fatalf("status=%q attempts=%d, want pass after 3", gotStatus, attempts)
+		}
+	})
+
+	t.Run("service exits before binding", func(t *testing.T) {
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.dialCtx = func(_ context.Context, _, _ string, _ time.Duration) (net.Conn, error) {
+				return nil, errors.New("connection refused")
+			}
+			e.runCmd = func(context.Context, string, ...string) (string, int, error) {
+				return "ActiveState=failed\nSubState=failed\n", 0, nil
+			}
+		})
+		gotStatus, gotDetail := probeLoopbackListen(context.Background(), env)
+		if gotStatus != statusFail || !strings.Contains(gotDetail, "exited before readiness") {
+			t.Fatalf("status=%q detail=%q, want failed-service diagnosis", gotStatus, gotDetail)
 		}
 	})
 }

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -1686,6 +1686,34 @@ func TestProbeLoopbackListen(t *testing.T) {
 		}
 	})
 
+	t.Run("service state polling is throttled while dialing stays frequent", func(t *testing.T) {
+		dials := 0
+		statePolls := 0
+		env := makeProbeEnv(t, func(e *probeEnv) {
+			e.dialCtx = func(_ context.Context, _, _ string, _ time.Duration) (net.Conn, error) {
+				dials++
+				if dials < 7 {
+					return nil, errors.New("connection refused")
+				}
+				return &fakeConn{}, nil
+			}
+			e.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+				if name != "systemctl" || !containsArg(args, "show") {
+					t.Fatalf("unexpected readiness command: %s %v", name, args)
+				}
+				statePolls++
+				return "ActiveState=active\nSubState=running\n", 0, nil
+			}
+		})
+		gotStatus, _ := probeLoopbackListen(context.Background(), env)
+		if gotStatus != statusPass || dials != 7 {
+			t.Fatalf("status=%q dials=%d, want pass after 7", gotStatus, dials)
+		}
+		if statePolls != 2 {
+			t.Fatalf("systemctl state polls=%d, want 2 for 6 failed dials", statePolls)
+		}
+	})
+
 	t.Run("service exits before binding", func(t *testing.T) {
 		env := makeProbeEnv(t, func(e *probeEnv) {
 			e.dialCtx = func(_ context.Context, _, _ string, _ time.Duration) (net.Conn, error) {

--- a/internal/config/sni_require_tls_test.go
+++ b/internal/config/sni_require_tls_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -27,6 +28,23 @@ func TestForwardProxySNIRequireTLSValidation(t *testing.T) {
 	cfg.ForwardProxy.SNIRequireTLS = &requireTLS
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("explicit legacy opt-out with SNI verification disabled: %v", err)
+	}
+}
+
+func TestAuditPresetDoesNotEnforceSNIRequireTLS(t *testing.T) {
+	path, err := filepath.Abs("../../configs/audit.yaml")
+	if err != nil {
+		t.Fatalf("Abs(audit preset): %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(audit preset): %v", err)
+	}
+	if cfg.EnforceEnabled() {
+		t.Fatal("audit preset unexpectedly enables enforcement")
+	}
+	if cfg.ForwardProxy.SNIRequireTLSEnabled() {
+		t.Fatal("audit preset unexpectedly enforces TLS-only CONNECT")
 	}
 }
 

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -88,6 +88,7 @@ type Emitter struct {
 	actor      string
 	metrics    MetricsSink
 	onReceipt  func(rcpt *Receipt)
+	now        func() time.Time
 	initErr    error
 	healthMu   sync.RWMutex
 	healthErr  error
@@ -188,6 +189,7 @@ func NewEmitter(cfg EmitterConfig) *Emitter {
 		actor:            cfg.Actor,
 		metrics:          cfg.Metrics,
 		onReceipt:        cfg.OnReceipt,
+		now:              time.Now,
 		runNonce:         runNonce,
 		chainPrevHash:    GenesisHash,
 		postureBinding:   cfg.PostureBinding,
@@ -559,7 +561,7 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 		ActionID:              opts.ActionID,
 		ParentActionID:        opts.ParentActionID,
 		ActionType:            actionType,
-		Timestamp:             time.Now().UTC(),
+		Timestamp:             e.now().UTC(),
 		Principal:             e.principal,
 		Actor:                 e.actorLabel(opts),
 		DelegationChain:       nil, // Populated when delegation tracking ships
@@ -731,7 +733,7 @@ func (e *Emitter) prepareSessionControlLocked(in *SessionControl) (*SessionContr
 				Beat:             e.heartbeatBeat,
 				ChainHead:        e.chainPrevHash,
 				ChainSeqHead:     PreviousChainSeq(e.chainSeq),
-				HeartbeatTime:    time.Now().UTC().Format(time.RFC3339Nano),
+				HeartbeatTime:    e.now().UTC().Format(time.RFC3339Nano),
 				FsyncErrorsGated: e.recorder.FsyncErrorsGated(),
 				DurabilityBlocks: e.DurabilityBlocks(),
 			},
@@ -1047,41 +1049,17 @@ func (e *Emitter) resumeChain() error {
 
 	var lastReceipt *Receipt
 	for i := len(files) - 1; i >= 0 && lastReceipt == nil; i-- {
-		entries, truncated, readErr := recorder.ReadTailEntriesBounded(
-			files[i], recorder.MaxEvidenceReadEntries, recorder.MaxEvidenceReadFileBytes,
-		)
+		entry, found, readErr := recorder.FindLastEntry(files[i], func(entry recorder.Entry) bool {
+			return entry.Type == recorderEntryType
+		})
 		if readErr != nil {
 			return fmt.Errorf("reading existing evidence file %s: %w", filepath.Base(files[i]), readErr)
 		}
-		for j := range entries {
-			switch entries[j].Type {
-			case transcriptRootEntryType:
-				// A transcript root is a clean-shutdown checkpoint that seals the
-				// receipts emitted up to that point IN THIS PROCESS. It is not a
-				// permanent on-disk seal: skip it and keep scanning back for the
-				// last action receipt so the next start resumes emission into the
-				// same hash-linked chain (a continuous chain still verifies, and
-				// the root's historical claim over seq 0..N stays true). The old
-				// behavior set rootEmitted=true here, which made every subsequent
-				// Emit return ErrChainSealed - silently bricking receipts after
-				// the first clean shutdown once EmitTranscriptRoot has a caller.
-				// Skipping it is also evidence-suppression-resistant: an attacker
-				// who appends a transcript_root to the evidence file cannot use it
-				// to stop the proxy from recording (the tail action receipt is
-				// still signature-verified below before we trust its chain state).
-			case recorderEntryType:
-				rcpt, unmarshalErr := receiptFromEntry(entries[j])
-				if unmarshalErr != nil {
-					return unmarshalErr
-				}
-				lastReceipt = rcpt
+		if found {
+			lastReceipt, readErr = receiptFromEntry(entry)
+			if readErr != nil {
+				return readErr
 			}
-			if lastReceipt != nil {
-				break
-			}
-		}
-		if lastReceipt == nil && truncated {
-			return fmt.Errorf("reading existing evidence file %s: %w: no action receipt found in bounded tail", filepath.Base(files[i]), recorder.ErrEvidenceReadLimitExceeded)
 		}
 	}
 	if lastReceipt == nil {
@@ -1090,7 +1068,7 @@ func (e *Emitter) resumeChain() error {
 
 	var firstReceipt *Receipt
 	for _, file := range files {
-		entries, truncated, readErr := recorder.ReadHeadEntriesBounded(
+		entries, _, readErr := recorder.ReadHeadEntriesBounded(
 			file, recorder.MaxEvidenceReadEntries, recorder.MaxEvidenceReadFileBytes,
 		)
 		if readErr != nil {
@@ -1110,9 +1088,9 @@ func (e *Emitter) resumeChain() error {
 		if firstReceipt != nil {
 			break
 		}
-		if truncated {
-			return fmt.Errorf("reading existing evidence file %s: %w: no action receipt found in bounded head", filepath.Base(file), recorder.ErrEvidenceReadLimitExceeded)
-		}
+		// chainStart is informational. If an oversized legacy prefix has no
+		// receipt in the bounded head, leave it unset instead of disabling new
+		// receipt emission; the fully verified tail above remains authoritative.
 	}
 
 	// Trust model for resuming an on-disk chain across a possible signing-key

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -1047,11 +1047,13 @@ func (e *Emitter) resumeChain() error {
 
 	var lastReceipt *Receipt
 	for i := len(files) - 1; i >= 0 && lastReceipt == nil; i-- {
-		entries, readErr := recorder.ReadEntries(files[i])
+		entries, truncated, readErr := recorder.ReadTailEntriesBounded(
+			files[i], recorder.MaxEvidenceReadEntries, recorder.MaxEvidenceReadFileBytes,
+		)
 		if readErr != nil {
 			return fmt.Errorf("reading existing evidence file %s: %w", filepath.Base(files[i]), readErr)
 		}
-		for j := len(entries) - 1; j >= 0; j-- {
+		for j := range entries {
 			switch entries[j].Type {
 			case transcriptRootEntryType:
 				// A transcript root is a clean-shutdown checkpoint that seals the
@@ -1078,6 +1080,9 @@ func (e *Emitter) resumeChain() error {
 				break
 			}
 		}
+		if lastReceipt == nil && truncated {
+			return fmt.Errorf("reading existing evidence file %s: %w: no action receipt found in bounded tail", filepath.Base(files[i]), recorder.ErrEvidenceReadLimitExceeded)
+		}
 	}
 	if lastReceipt == nil {
 		return nil
@@ -1085,7 +1090,9 @@ func (e *Emitter) resumeChain() error {
 
 	var firstReceipt *Receipt
 	for _, file := range files {
-		entries, readErr := recorder.ReadEntries(file)
+		entries, truncated, readErr := recorder.ReadHeadEntriesBounded(
+			file, recorder.MaxEvidenceReadEntries, recorder.MaxEvidenceReadFileBytes,
+		)
 		if readErr != nil {
 			return fmt.Errorf("reading existing evidence file %s: %w", filepath.Base(file), readErr)
 		}
@@ -1102,6 +1109,9 @@ func (e *Emitter) resumeChain() error {
 		}
 		if firstReceipt != nil {
 			break
+		}
+		if truncated {
+			return fmt.Errorf("reading existing evidence file %s: %w: no action receipt found in bounded head", filepath.Base(file), recorder.ErrEvidenceReadLimitExceeded)
 		}
 	}
 

--- a/internal/receipt/emitter_resume_test.go
+++ b/internal/receipt/emitter_resume_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
@@ -155,6 +156,17 @@ func TestResume_SelectsOldestHeadAndNewestTail(t *testing.T) {
 	_, priv := generateTestKey(t)
 	rec1 := newTestRecorder(t, dir, priv)
 	e1 := NewEmitter(EmitterConfig{Recorder: rec1, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	timestamps := []time.Time{
+		time.Date(2026, time.July, 29, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, time.July, 29, 12, 0, 1, 0, time.UTC),
+		time.Date(2026, time.July, 29, 12, 0, 2, 0, time.UTC),
+	}
+	nextTimestamp := 0
+	e1.now = func() time.Time {
+		got := timestamps[nextTimestamp]
+		nextTimestamp++
+		return got
+	}
 	emitOne(t, e1)
 	emitOne(t, e1)
 	emitOne(t, e1)
@@ -165,8 +177,10 @@ func TestResume_SelectsOldestHeadAndNewestTail(t *testing.T) {
 	if len(receipts) != 3 {
 		t.Fatalf("receipt count = %d, want 3", len(receipts))
 	}
-	if receipts[0].ActionRecord.Timestamp.Equal(receipts[2].ActionRecord.Timestamp) {
-		t.Fatal("test setup produced indistinguishable head and tail timestamps")
+	for i, want := range timestamps {
+		if !receipts[i].ActionRecord.Timestamp.Equal(want) {
+			t.Fatalf("receipt %d timestamp = %s, want %s", i, receipts[i].ActionRecord.Timestamp, want)
+		}
 	}
 
 	rec2 := newTestRecorder(t, dir, priv)
@@ -253,6 +267,38 @@ func TestResume_LegacyOversizedShardUsesBoundedHeadAndTail(t *testing.T) {
 	if err := encoder.Encode(receiptEntry); err != nil {
 		_ = file.Close()
 		t.Fatalf("Encode receipt tail: %v", err)
+	}
+	receiptInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		t.Fatalf("Stat receipt position: %v", err)
+	}
+	for {
+		entry := recorder.Entry{
+			Version:   recorder.EntryVersion,
+			Sequence:  seq + 1,
+			Timestamp: receiptEntry.Timestamp,
+			SessionID: "proxy",
+			Type:      "request",
+			Transport: testTransport,
+			Summary:   padding,
+			Detail:    map[string]string{"safe": "value"},
+			PrevHash:  "legacy-prev",
+			Hash:      "legacy-hash",
+		}
+		if err := encoder.Encode(entry); err != nil {
+			_ = file.Close()
+			t.Fatalf("Encode trailing non-receipt: %v", err)
+		}
+		seq++
+		info, statErr := file.Stat()
+		if statErr != nil {
+			_ = file.Close()
+			t.Fatalf("Stat trailing entries: %v", statErr)
+		}
+		if info.Size()-receiptInfo.Size() > recorder.MaxEvidenceReadFileBytes+(1<<20) {
+			break
+		}
 	}
 	if err := file.Close(); err != nil {
 		t.Fatalf("Close legacy shard: %v", err)

--- a/internal/receipt/emitter_resume_test.go
+++ b/internal/receipt/emitter_resume_test.go
@@ -150,6 +150,39 @@ func TestResume_SameKeyValidTail_ResumesUnchanged(t *testing.T) {
 	}
 }
 
+func TestResume_SelectsOldestHeadAndNewestTail(t *testing.T) {
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec1 := newTestRecorder(t, dir, priv)
+	e1 := NewEmitter(EmitterConfig{Recorder: rec1, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	emitOne(t, e1)
+	emitOne(t, e1)
+	emitOne(t, e1)
+	if err := rec1.Close(); err != nil {
+		t.Fatalf("close rec1: %v", err)
+	}
+	receipts := allReceiptsRaw(t, dir)
+	if len(receipts) != 3 {
+		t.Fatalf("receipt count = %d, want 3", len(receipts))
+	}
+	if receipts[0].ActionRecord.Timestamp.Equal(receipts[2].ActionRecord.Timestamp) {
+		t.Fatal("test setup produced indistinguishable head and tail timestamps")
+	}
+
+	rec2 := newTestRecorder(t, dir, priv)
+	defer func() { _ = rec2.Close() }()
+	e2 := NewEmitter(EmitterConfig{Recorder: rec2, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	if err := e2.InitError(); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if e2.chainSeq != receipts[2].ActionRecord.ChainSeq+1 {
+		t.Fatalf("chainSeq = %d, want newest tail + 1 (%d)", e2.chainSeq, receipts[2].ActionRecord.ChainSeq+1)
+	}
+	if !e2.chainStart.Equal(receipts[0].ActionRecord.Timestamp) {
+		t.Fatalf("chainStart = %s, want oldest head %s", e2.chainStart, receipts[0].ActionRecord.Timestamp)
+	}
+}
+
 // Legacy recorder shards may be larger than the current 8 MiB rotation cap.
 // Receipt resume needs the first receipt for chainStart and the last receipt
 // for live chain state; neither lookup requires loading the entire shard.

--- a/internal/receipt/emitter_resume_test.go
+++ b/internal/receipt/emitter_resume_test.go
@@ -150,6 +150,93 @@ func TestResume_SameKeyValidTail_ResumesUnchanged(t *testing.T) {
 	}
 }
 
+// Legacy recorder shards may be larger than the current 8 MiB rotation cap.
+// Receipt resume needs the first receipt for chainStart and the last receipt
+// for live chain state; neither lookup requires loading the entire shard.
+func TestResume_LegacyOversizedShardUsesBoundedHeadAndTail(t *testing.T) {
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+
+	rec1 := newTestRecorder(t, dir, priv)
+	e1 := NewEmitter(EmitterConfig{Recorder: rec1, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	emitOne(t, e1)
+	if err := rec1.Close(); err != nil {
+		t.Fatalf("close rec1: %v", err)
+	}
+
+	path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+	entries, err := recorder.ReadEntries(path)
+	if err != nil {
+		t.Fatalf("ReadEntries initial shard: %v", err)
+	}
+	var receiptEntry recorder.Entry
+	for _, entry := range entries {
+		if entry.Type == recorderEntryType {
+			receiptEntry = entry
+			break
+		}
+	}
+	if receiptEntry.Type == "" {
+		t.Fatal("initial shard has no action receipt")
+	}
+
+	file, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatalf("OpenFile append: %v", err)
+	}
+	encoder := json.NewEncoder(file)
+	padding := strings.Repeat("x", 512<<10)
+	seq := receiptEntry.Sequence + 1
+	for {
+		entry := recorder.Entry{
+			Version:   recorder.EntryVersion,
+			Sequence:  seq,
+			Timestamp: receiptEntry.Timestamp,
+			SessionID: "proxy",
+			Type:      "request",
+			Transport: testTransport,
+			Summary:   padding,
+			Detail:    map[string]string{"safe": "value"},
+			PrevHash:  "legacy-prev",
+			Hash:      "legacy-hash",
+		}
+		if err := encoder.Encode(entry); err != nil {
+			_ = file.Close()
+			t.Fatalf("Encode padding: %v", err)
+		}
+		seq++
+		info, statErr := file.Stat()
+		if statErr != nil {
+			_ = file.Close()
+			t.Fatalf("Stat: %v", statErr)
+		}
+		if info.Size() > recorder.MaxEvidenceReadFileBytes+(1<<20) {
+			break
+		}
+	}
+	receiptEntry.Sequence = seq
+	receiptEntry.PrevHash = "legacy-prev"
+	receiptEntry.Hash = "legacy-tail-hash"
+	if err := encoder.Encode(receiptEntry); err != nil {
+		_ = file.Close()
+		t.Fatalf("Encode receipt tail: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close legacy shard: %v", err)
+	}
+
+	rec2 := newTestRecorder(t, dir, priv)
+	defer func() { _ = rec2.Close() }()
+	e2 := NewEmitter(EmitterConfig{Recorder: rec2, PrivKey: priv, Principal: testPrincipal, Actor: testActor})
+	if err := e2.InitError(); err != nil {
+		t.Fatalf("InitError after legacy oversized shard: %v", err)
+	}
+	if e2.chainSeq != 1 {
+		t.Fatalf("chainSeq = %d, want 1 from resumed signed receipt", e2.chainSeq)
+	}
+	emitOne(t, e2)
+}
+
 // TestResume_RotatedKeySelfValidTail_OpensNewSegment is case 2: a tail signed
 // by a DIFFERENT key whose own signature is valid is treated as a legitimate
 // rotation. A new segment opens, no error, and the new segment's genesis

--- a/internal/recorder/entry_directional.go
+++ b/internal/recorder/entry_directional.go
@@ -19,7 +19,7 @@ import (
 // an availability gate.
 func ReadHeadEntriesBounded(path string, maxEntries int, maxBytes int64) ([]Entry, bool, error) {
 	limits := directionalEntryReadLimits(maxEntries, maxBytes)
-	file, info, err := openRegularEvidenceFile(path, "evidence file", validateEvidenceFileAccess())
+	file, info, err := openRegularEvidenceFile(path, validateEvidenceFileAccess())
 	if err != nil {
 		return nil, false, err
 	}
@@ -45,7 +45,7 @@ func ReadHeadEntriesBounded(path string, maxEntries int, maxBytes int64) ([]Entr
 // Truncated reports that older bytes or entries were not returned.
 func ReadTailEntriesBounded(path string, maxEntries int, maxBytes int64) ([]Entry, bool, error) {
 	limits := directionalEntryReadLimits(maxEntries, maxBytes)
-	file, info, err := openRegularEvidenceFile(path, "evidence file", validateEvidenceFileAccess())
+	file, info, err := openRegularEvidenceFile(path, validateEvidenceFileAccess())
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/recorder/entry_directional.go
+++ b/internal/recorder/entry_directional.go
@@ -157,6 +157,9 @@ func FindLastEntry(path string, match func(Entry) bool) (Entry, bool, error) {
 				return Entry{}, false, fmt.Errorf("tail line exceeds %d-byte recorder entry limit", MaxEntryLineBytes)
 			}
 			boundary = newline + 1
+			if boundary >= len(data) {
+				return Entry{}, false, fmt.Errorf("tail line exceeds %d-byte recorder entry limit", MaxEntryLineBytes)
+			}
 		}
 
 		for lineEnd := len(data); lineEnd > boundary; {
@@ -188,7 +191,11 @@ func FindLastEntry(path string, match func(Entry) bool) (Entry, bool, error) {
 			}
 			lineEnd = lineStart
 		}
-		end = start + int64(boundary)
+		nextEnd := start + int64(boundary)
+		if nextEnd >= end {
+			return Entry{}, false, errors.New("finding last evidence entry: tail scan made no progress")
+		}
+		end = nextEnd
 	}
 	if err := ensureEvidenceFileUnchanged(file, info); err != nil {
 		return Entry{}, false, err

--- a/internal/recorder/entry_directional.go
+++ b/internal/recorder/entry_directional.go
@@ -115,6 +115,87 @@ func ReadTailEntriesBounded(path string, maxEntries int, maxBytes int64) ([]Entr
 	return entries, truncated, nil
 }
 
+// FindLastEntry opens an evidence shard once and scans complete entries from
+// newest to oldest until match accepts one. The scan may read the whole shard,
+// but memory stays bounded to one MaxEvidenceReadFileBytes window plus one
+// maximum-size entry. This is intended for upgrade recovery where refusing an
+// oversized legacy shard would disable new evidence, while trusting an older
+// entry before the true tail would fork the chain.
+func FindLastEntry(path string, match func(Entry) bool) (Entry, bool, error) {
+	if match == nil {
+		return Entry{}, false, errors.New("finding last evidence entry: match function is required")
+	}
+	file, info, err := openRegularEvidenceFile(path, validateEvidenceFileAccess())
+	if err != nil {
+		return Entry{}, false, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Size() == 0 {
+		return Entry{}, false, nil
+	}
+
+	end := info.Size()
+	window := MaxEvidenceReadFileBytes
+	extra := int64(maxEntryWireLineBytes + 1)
+	if window > math.MaxInt64-extra {
+		window = math.MaxInt64
+	} else {
+		window += extra
+	}
+	for end > 0 {
+		readLen := min(end, window)
+		start := end - readLen
+		data := make([]byte, readLen)
+		if _, err := io.ReadFull(io.NewSectionReader(file, start, readLen), data); err != nil {
+			return Entry{}, false, fmt.Errorf("reading evidence tail window: %w", err)
+		}
+
+		boundary := 0
+		if start > 0 {
+			newline := bytes.IndexByte(data, '\n')
+			if newline < 0 {
+				return Entry{}, false, fmt.Errorf("tail line exceeds %d-byte recorder entry limit", MaxEntryLineBytes)
+			}
+			boundary = newline + 1
+		}
+
+		for lineEnd := len(data); lineEnd > boundary; {
+			if data[lineEnd-1] == '\n' {
+				lineEnd--
+			}
+			lineStart := bytes.LastIndexByte(data[boundary:lineEnd], '\n') + boundary + 1
+			line := data[lineStart:lineEnd]
+			if len(line) > 0 && line[len(line)-1] == '\r' {
+				line = line[:len(line)-1]
+			}
+			if len(line) > MaxEntryLineBytes {
+				return Entry{}, false, fmt.Errorf("tail line exceeds %d-byte recorder entry limit", MaxEntryLineBytes)
+			}
+			if len(bytes.TrimSpace(line)) != 0 {
+				entry, parseErr := parseDirectionalEntry(line)
+				if parseErr != nil {
+					return Entry{}, false, parseErr
+				}
+				if match(entry) {
+					if err := ensureEvidenceFileUnchanged(file, info); err != nil {
+						return Entry{}, false, err
+					}
+					return entry, true, nil
+				}
+			}
+			if lineStart == boundary {
+				break
+			}
+			lineEnd = lineStart
+		}
+		end = start + int64(boundary)
+	}
+	if err := ensureEvidenceFileUnchanged(file, info); err != nil {
+		return Entry{}, false, err
+	}
+	return Entry{}, false, nil
+}
+
 func directionalEntryReadLimits(maxEntries int, maxBytes int64) entryReadLimits {
 	if maxEntries <= 0 {
 		maxEntries = MaxEvidenceReadEntries

--- a/internal/recorder/entry_directional.go
+++ b/internal/recorder/entry_directional.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package recorder
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+)
+
+// ReadHeadEntriesBounded reads a bounded prefix of an evidence shard. Unlike
+// ReadEntries, an oversized file is not rejected merely for having more bytes
+// after the prefix; Truncated reports that unseen suffix. This is for callers
+// that need an earliest entry without treating a legacy shard's total size as
+// an availability gate.
+func ReadHeadEntriesBounded(path string, maxEntries int, maxBytes int64) ([]Entry, bool, error) {
+	limits := directionalEntryReadLimits(maxEntries, maxBytes)
+	file, info, err := openRegularEvidenceFile(path, "evidence file", validateEvidenceFileAccess())
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = file.Close() }()
+
+	readLimit := limits.MaxBytes
+	if readLimit < math.MaxInt64 {
+		readLimit++
+	}
+	entries, truncated, _, err := readEntriesFromReader(io.LimitReader(file, readLimit), limits)
+	if err != nil {
+		return nil, false, fmt.Errorf("reading evidence head: %w", err)
+	}
+	if err := ensureEvidenceFileUnchanged(file, info); err != nil {
+		return nil, false, err
+	}
+	return entries, truncated || info.Size() > limits.MaxBytes, nil
+}
+
+// ReadTailEntriesBounded reads complete entries from a bounded suffix of an
+// evidence shard and returns them newest-first. It reads at most maxBytes plus
+// one maximum-size entry so the suffix can begin at a trusted newline boundary.
+// Truncated reports that older bytes or entries were not returned.
+func ReadTailEntriesBounded(path string, maxEntries int, maxBytes int64) ([]Entry, bool, error) {
+	limits := directionalEntryReadLimits(maxEntries, maxBytes)
+	file, info, err := openRegularEvidenceFile(path, "evidence file", validateEvidenceFileAccess())
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Size() == 0 {
+		return nil, false, nil
+	}
+
+	window := limits.MaxBytes
+	extra := int64(maxEntryWireLineBytes + 1)
+	if window > math.MaxInt64-extra {
+		window = math.MaxInt64
+	} else {
+		window += extra
+	}
+	readLen := min(info.Size(), window)
+	start := info.Size() - readLen
+	data := make([]byte, readLen)
+	if _, err := io.ReadFull(io.NewSectionReader(file, start, readLen), data); err != nil {
+		return nil, false, fmt.Errorf("reading evidence tail: %w", err)
+	}
+	if err := ensureEvidenceFileUnchanged(file, info); err != nil {
+		return nil, false, err
+	}
+
+	entries := make([]Entry, 0, min(limits.MaxEntries, 64))
+	truncated := start > 0
+	var consumed int64
+	end := len(data)
+	for end > 0 {
+		lineEnd := end
+		wireBytes := int64(0)
+		if data[lineEnd-1] == '\n' {
+			lineEnd--
+			wireBytes++
+		}
+		lineStart := bytes.LastIndexByte(data[:lineEnd], '\n') + 1
+		line := data[lineStart:lineEnd]
+		wireBytes += int64(len(line))
+		if len(line) > 0 && line[len(line)-1] == '\r' {
+			line = line[:len(line)-1]
+		}
+		consumed += wireBytes
+		if consumed > limits.MaxBytes || len(entries) >= limits.MaxEntries {
+			truncated = true
+			break
+		}
+		if len(line) > MaxEntryLineBytes {
+			return nil, false, fmt.Errorf("tail line exceeds %d-byte recorder entry limit", MaxEntryLineBytes)
+		}
+		if len(bytes.TrimSpace(line)) != 0 {
+			if start > 0 && lineStart == 0 {
+				truncated = true
+				break
+			}
+			parsed, parseErr := parseDirectionalEntry(line)
+			if parseErr != nil {
+				return nil, false, parseErr
+			}
+			entries = append(entries, parsed)
+		}
+		if lineStart == 0 {
+			break
+		}
+		end = lineStart
+	}
+	return entries, truncated, nil
+}
+
+func directionalEntryReadLimits(maxEntries int, maxBytes int64) entryReadLimits {
+	if maxEntries <= 0 {
+		maxEntries = MaxEvidenceReadEntries
+	}
+	if maxBytes <= 0 {
+		maxBytes = MaxEvidenceReadFileBytes
+	}
+	return entryReadLimits{MaxEntries: maxEntries, MaxBytes: maxBytes}
+}
+
+func parseDirectionalEntry(line []byte) (Entry, error) {
+	entries, truncated, _, err := readEntriesFromReader(bytes.NewReader(line), entryReadLimits{
+		MaxEntries: 1,
+		MaxBytes:   int64(maxEntryWireLineBytes),
+	})
+	if err != nil {
+		return Entry{}, fmt.Errorf("parsing evidence tail entry: %w", err)
+	}
+	if truncated || len(entries) != 1 {
+		return Entry{}, errors.New("parsing evidence tail entry: expected exactly one complete entry")
+	}
+	return entries[0], nil
+}
+
+func ensureEvidenceFileUnchanged(file *os.File, before os.FileInfo) error {
+	after, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !after.Mode().IsRegular() || !os.SameFile(before, after) || after.Size() != before.Size() || after.ModTime() != before.ModTime() {
+		return errors.New("evidence file changed during read")
+	}
+	return nil
+}

--- a/internal/recorder/entry_directional_test.go
+++ b/internal/recorder/entry_directional_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package recorder
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeDirectionalEntries(t *testing.T, path string, count int) {
+	t.Helper()
+	file, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	encoder := json.NewEncoder(file)
+	for i := range count {
+		entry := Entry{
+			Version:   EntryVersion,
+			Sequence:  uint64(i),
+			Timestamp: time.Unix(1712345678, 0).UTC(),
+			SessionID: "directional",
+			Type:      "request",
+			Transport: "http",
+			Summary:   "bounded directional fixture",
+			Detail:    map[string]string{"safe": "value"},
+			PrevHash:  "prev",
+			Hash:      "hash",
+		}
+		if err := encoder.Encode(entry); err != nil {
+			_ = file.Close()
+			t.Fatalf("Encode: %v", err)
+		}
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestReadDirectionalEntriesBounded_OrderAndTruncation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "evidence-directional-0.jsonl")
+	writeDirectionalEntries(t, path, 5)
+
+	head, headTruncated, err := ReadHeadEntriesBounded(path, 2, MaxEvidenceReadFileBytes)
+	if err != nil {
+		t.Fatalf("ReadHeadEntriesBounded: %v", err)
+	}
+	if !headTruncated || len(head) != 2 || head[0].Sequence != 0 || head[1].Sequence != 1 {
+		t.Fatalf("head = seqs %v truncated=%v, want [0 1] true", entrySequences(head), headTruncated)
+	}
+
+	tail, tailTruncated, err := ReadTailEntriesBounded(path, 2, MaxEvidenceReadFileBytes)
+	if err != nil {
+		t.Fatalf("ReadTailEntriesBounded: %v", err)
+	}
+	if !tailTruncated || len(tail) != 2 || tail[0].Sequence != 4 || tail[1].Sequence != 3 {
+		t.Fatalf("tail = seqs %v truncated=%v, want [4 3] true", entrySequences(tail), tailTruncated)
+	}
+}
+
+func TestReadTailEntriesBounded_SkipsPartialBoundaryButRejectsMalformedTail(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence-directional-0.jsonl")
+	writeDirectionalEntries(t, path, 1)
+	validTail, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	prefix := strings.Repeat("x", MaxEntryLineBytes+128) + "\n"
+	if err := os.WriteFile(path, append([]byte(prefix), validTail...), 0o600); err != nil {
+		t.Fatalf("WriteFile partial-boundary fixture: %v", err)
+	}
+
+	entries, truncated, err := ReadTailEntriesBounded(path, 1, int64(len(validTail)))
+	if err != nil {
+		t.Fatalf("ReadTailEntriesBounded after partial boundary: %v", err)
+	}
+	if !truncated || len(entries) != 1 || entries[0].Sequence != 0 {
+		t.Fatalf("entries = seqs %v truncated=%v, want [0] true", entrySequences(entries), truncated)
+	}
+
+	if err := os.WriteFile(path, []byte(`{"v":2,"seq":9`), 0o600); err != nil {
+		t.Fatalf("WriteFile malformed tail: %v", err)
+	}
+	if _, _, err := ReadTailEntriesBounded(path, 1, MaxEvidenceReadFileBytes); err == nil {
+		t.Fatal("ReadTailEntriesBounded malformed tail = nil error, want refusal")
+	}
+}
+
+func TestReadDirectionalEntriesBounded_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "evidence-target-0.jsonl")
+	link := filepath.Join(dir, "evidence-link-0.jsonl")
+	writeDirectionalEntries(t, target, 1)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if _, _, err := ReadHeadEntriesBounded(link, 1, MaxEvidenceReadFileBytes); err == nil {
+		t.Fatal("ReadHeadEntriesBounded symlink = nil error, want refusal")
+	}
+	if _, _, err := ReadTailEntriesBounded(link, 1, MaxEvidenceReadFileBytes); err == nil {
+		t.Fatal("ReadTailEntriesBounded symlink = nil error, want refusal")
+	}
+}
+
+func entrySequences(entries []Entry) []uint64 {
+	sequences := make([]uint64, 0, len(entries))
+	for _, entry := range entries {
+		sequences = append(sequences, entry.Sequence)
+	}
+	return sequences
+}

--- a/internal/recorder/entry_directional_test.go
+++ b/internal/recorder/entry_directional_test.go
@@ -64,31 +64,121 @@ func TestReadDirectionalEntriesBounded_OrderAndTruncation(t *testing.T) {
 }
 
 func TestReadTailEntriesBounded_SkipsPartialBoundaryButRejectsMalformedTail(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "evidence-directional-0.jsonl")
+	t.Run("skips partial boundary", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "evidence-directional-0.jsonl")
+		writeDirectionalEntries(t, path, 1)
+		validTail, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		prefix := strings.Repeat("x", MaxEntryLineBytes+128) + "\n"
+		if err := os.WriteFile(path, append([]byte(prefix), validTail...), 0o600); err != nil {
+			t.Fatalf("WriteFile partial-boundary fixture: %v", err)
+		}
+
+		entries, truncated, err := ReadTailEntriesBounded(path, 1, int64(len(validTail)))
+		if err != nil {
+			t.Fatalf("ReadTailEntriesBounded after partial boundary: %v", err)
+		}
+		if !truncated || len(entries) != 1 || entries[0].Sequence != 0 {
+			t.Fatalf("entries = seqs %v truncated=%v, want [0] true", entrySequences(entries), truncated)
+		}
+	})
+
+	t.Run("rejects malformed tail", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "evidence-directional-0.jsonl")
+		if err := os.WriteFile(path, []byte(`{"v":2,"seq":9`), 0o600); err != nil {
+			t.Fatalf("WriteFile malformed tail: %v", err)
+		}
+		if _, _, err := ReadTailEntriesBounded(path, 1, MaxEvidenceReadFileBytes); err == nil {
+			t.Fatal("ReadTailEntriesBounded malformed tail = nil error, want refusal")
+		}
+	})
+}
+
+func TestFindLastEntry_ScansPastBoundedTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "evidence-directional-0.jsonl")
+	file, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	encoder := json.NewEncoder(file)
+	want := Entry{Version: EntryVersion, Sequence: 7, Timestamp: time.Unix(1712345678, 0).UTC(), SessionID: "directional", Type: "receipt", Transport: "http", Summary: "target", Detail: map[string]string{"safe": "value"}, PrevHash: "prev", Hash: "hash"}
+	if err := encoder.Encode(want); err != nil {
+		t.Fatalf("Encode target: %v", err)
+	}
+	padding := strings.Repeat("x", 512<<10)
+	for seq := uint64(8); ; seq++ {
+		entry := want
+		entry.Sequence = seq
+		entry.Type = "request"
+		entry.Summary = padding
+		if err := encoder.Encode(entry); err != nil {
+			t.Fatalf("Encode padding: %v", err)
+		}
+		info, statErr := file.Stat()
+		if statErr != nil {
+			t.Fatalf("Stat: %v", statErr)
+		}
+		if info.Size() > MaxEvidenceReadFileBytes+(1<<20) {
+			break
+		}
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got, found, err := FindLastEntry(path, func(entry Entry) bool { return entry.Type == "receipt" })
+	if err != nil {
+		t.Fatalf("FindLastEntry: %v", err)
+	}
+	if !found || got.Sequence != want.Sequence {
+		t.Fatalf("FindLastEntry = seq %d found=%v, want seq %d true", got.Sequence, found, want.Sequence)
+	}
+}
+
+func TestFindLastEntry_FailsClosedOnMalformedNewerEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "evidence-directional-0.jsonl")
 	writeDirectionalEntries(t, path, 1)
-	validTail, err := os.ReadFile(filepath.Clean(path))
+	file, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_APPEND, 0)
 	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
+		t.Fatalf("OpenFile: %v", err)
 	}
-	prefix := strings.Repeat("x", MaxEntryLineBytes+128) + "\n"
-	if err := os.WriteFile(path, append([]byte(prefix), validTail...), 0o600); err != nil {
-		t.Fatalf("WriteFile partial-boundary fixture: %v", err)
+	if _, err := file.WriteString(`{"v":2,"seq":9`); err != nil {
+		_ = file.Close()
+		t.Fatalf("WriteString malformed tail: %v", err)
 	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, _, err := FindLastEntry(path, func(Entry) bool { return true }); err == nil {
+		t.Fatal("FindLastEntry malformed newer entry = nil error, want refusal")
+	}
+}
 
-	entries, truncated, err := ReadTailEntriesBounded(path, 1, int64(len(validTail)))
+func TestFindLastEntry_RequiresMatcher(t *testing.T) {
+	if _, _, err := FindLastEntry(filepath.Join(t.TempDir(), "missing.jsonl"), nil); err == nil {
+		t.Fatal("FindLastEntry nil matcher = nil error, want refusal")
+	}
+}
+
+func TestEnsureEvidenceFileUnchanged_RejectsMutation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "evidence-directional-0.jsonl")
+	writeDirectionalEntries(t, path, 1)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
-		t.Fatalf("ReadTailEntriesBounded after partial boundary: %v", err)
+		t.Fatalf("Open: %v", err)
 	}
-	if !truncated || len(entries) != 1 || entries[0].Sequence != 0 {
-		t.Fatalf("entries = seqs %v truncated=%v, want [0] true", entrySequences(entries), truncated)
+	defer func() { _ = file.Close() }()
+	before, err := file.Stat()
+	if err != nil {
+		t.Fatalf("Stat before: %v", err)
 	}
-
-	if err := os.WriteFile(path, []byte(`{"v":2,"seq":9`), 0o600); err != nil {
-		t.Fatalf("WriteFile malformed tail: %v", err)
+	if err := os.Truncate(path, before.Size()-1); err != nil {
+		t.Fatalf("Truncate: %v", err)
 	}
-	if _, _, err := ReadTailEntriesBounded(path, 1, MaxEvidenceReadFileBytes); err == nil {
-		t.Fatal("ReadTailEntriesBounded malformed tail = nil error, want refusal")
+	if err := ensureEvidenceFileUnchanged(file, before); err == nil {
+		t.Fatal("ensureEvidenceFileUnchanged after mutation = nil error, want refusal")
 	}
 }
 

--- a/internal/recorder/entry_directional_test.go
+++ b/internal/recorder/entry_directional_test.go
@@ -4,6 +4,7 @@
 package recorder
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -156,6 +157,35 @@ func TestFindLastEntry_FailsClosedOnMalformedNewerEntry(t *testing.T) {
 	}
 }
 
+func TestFindLastEntry_RejectsOversizedLineAtWindowBoundary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "evidence-directional-0.jsonl")
+	window := MaxEvidenceReadFileBytes + int64(maxEntryWireLineBytes+1)
+	data := strings.Repeat("x", int(window)) + "\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("WriteFile oversized line: %v", err)
+	}
+
+	if _, _, err := FindLastEntry(path, func(Entry) bool { return true }); err == nil || !strings.Contains(err.Error(), "tail line exceeds") {
+		t.Fatalf("FindLastEntry oversized line error = %v, want bounded refusal", err)
+	}
+}
+
+func TestFindLastEntry_EmptyAndNoMatch(t *testing.T) {
+	empty := filepath.Join(t.TempDir(), "evidence-directional-0.jsonl")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile empty shard: %v", err)
+	}
+	if _, found, err := FindLastEntry(empty, func(Entry) bool { return true }); err != nil || found {
+		t.Fatalf("FindLastEntry(empty) found=%v error=%v, want false nil", found, err)
+	}
+
+	populated := filepath.Join(t.TempDir(), "evidence-directional-1.jsonl")
+	writeDirectionalEntries(t, populated, 2)
+	if _, found, err := FindLastEntry(populated, func(entry Entry) bool { return entry.Type == "receipt" }); err != nil || found {
+		t.Fatalf("FindLastEntry(no match) found=%v error=%v, want false nil", found, err)
+	}
+}
+
 func TestFindLastEntry_RequiresMatcher(t *testing.T) {
 	if _, _, err := FindLastEntry(filepath.Join(t.TempDir(), "missing.jsonl"), nil); err == nil {
 		t.Fatal("FindLastEntry nil matcher = nil error, want refusal")
@@ -196,6 +226,110 @@ func TestReadDirectionalEntriesBounded_RejectsSymlink(t *testing.T) {
 	if _, _, err := ReadTailEntriesBounded(link, 1, MaxEvidenceReadFileBytes); err == nil {
 		t.Fatal("ReadTailEntriesBounded symlink = nil error, want refusal")
 	}
+}
+
+func TestDirectionalEntryReaders_EdgeCases(t *testing.T) {
+	t.Run("missing paths", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing.jsonl")
+		if _, _, err := ReadHeadEntriesBounded(path, 1, 1); err == nil {
+			t.Fatal("ReadHeadEntriesBounded(missing) error = nil")
+		}
+		if _, _, err := ReadTailEntriesBounded(path, 1, 1); err == nil {
+			t.Fatal("ReadTailEntriesBounded(missing) error = nil")
+		}
+		if _, _, err := FindLastEntry(path, func(Entry) bool { return true }); err == nil {
+			t.Fatal("FindLastEntry(missing) error = nil")
+		}
+	})
+
+	t.Run("empty tail", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.jsonl")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		entries, truncated, err := ReadTailEntriesBounded(path, 0, 0)
+		if err != nil || truncated || len(entries) != 0 {
+			t.Fatalf("ReadTailEntriesBounded(empty) entries=%v truncated=%v error=%v", entries, truncated, err)
+		}
+	})
+
+	t.Run("default limits and CRLF", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "crlf.jsonl")
+		writeDirectionalEntries(t, path, 1)
+		data, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		data = bytes.ReplaceAll(data, []byte("\n"), []byte("\r\n"))
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if entries, _, err := ReadHeadEntriesBounded(path, 0, 0); err != nil || len(entries) != 1 {
+			t.Fatalf("ReadHeadEntriesBounded(CRLF) entries=%v error=%v", entries, err)
+		}
+		if entries, _, err := ReadTailEntriesBounded(path, 0, 0); err != nil || len(entries) != 1 {
+			t.Fatalf("ReadTailEntriesBounded(CRLF) entries=%v error=%v", entries, err)
+		}
+		if _, found, err := FindLastEntry(path, func(Entry) bool { return true }); err != nil || !found {
+			t.Fatalf("FindLastEntry(CRLF) found=%v error=%v", found, err)
+		}
+	})
+
+	t.Run("malformed head", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "malformed.jsonl")
+		if err := os.WriteFile(path, []byte("{bad\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := ReadHeadEntriesBounded(path, 1, MaxEvidenceReadFileBytes); err == nil {
+			t.Fatal("ReadHeadEntriesBounded(malformed) error = nil")
+		}
+	})
+
+	t.Run("oversized complete line", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "oversized.jsonl")
+		if err := os.WriteFile(path, []byte(strings.Repeat("x", MaxEntryLineBytes+1)+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := ReadTailEntriesBounded(path, 1, MaxEvidenceReadFileBytes); err == nil || !strings.Contains(err.Error(), "tail line exceeds") {
+			t.Fatalf("ReadTailEntriesBounded(oversized) error=%v", err)
+		}
+		if _, _, err := FindLastEntry(path, func(Entry) bool { return true }); err == nil || !strings.Contains(err.Error(), "tail line exceeds") {
+			t.Fatalf("FindLastEntry(oversized) error=%v", err)
+		}
+	})
+
+	t.Run("oversized boundary without newline", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "oversized-boundary.jsonl")
+		window := MaxEvidenceReadFileBytes + int64(maxEntryWireLineBytes+1)
+		if err := os.WriteFile(path, []byte(strings.Repeat("x", int(window+1))), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := FindLastEntry(path, func(Entry) bool { return true }); err == nil || !strings.Contains(err.Error(), "tail line exceeds") {
+			t.Fatalf("FindLastEntry(no newline) error=%v", err)
+		}
+	})
+
+	t.Run("parser and stat failures", func(t *testing.T) {
+		if _, err := parseDirectionalEntry(nil); err == nil {
+			t.Fatal("parseDirectionalEntry(empty) error = nil")
+		}
+		path := filepath.Join(t.TempDir(), "closed.jsonl")
+		writeDirectionalEntries(t, path, 1)
+		file, err := os.Open(filepath.Clean(path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		before, err := file.Stat()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureEvidenceFileUnchanged(file, before); err == nil {
+			t.Fatal("ensureEvidenceFileUnchanged(closed) error = nil")
+		}
+	})
 }
 
 func entrySequences(entries []Entry) []uint64 {

--- a/internal/recorder/entry_directional_test.go
+++ b/internal/recorder/entry_directional_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -213,6 +214,9 @@ func TestEnsureEvidenceFileUnchanged_RejectsMutation(t *testing.T) {
 }
 
 func TestReadDirectionalEntriesBounded_RejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
 	dir := t.TempDir()
 	target := filepath.Join(dir, "evidence-target-0.jsonl")
 	link := filepath.Join(dir, "evidence-link-0.jsonl")

--- a/internal/recorder/evidence_read.go
+++ b/internal/recorder/evidence_read.go
@@ -57,7 +57,7 @@ var ErrEvidenceReadLimitExceeded = errors.New("evidence read limit exceeded")
 
 // openRegularEvidenceFile opens an unchanged regular evidence file after the
 // platform access policy has accepted the operation.
-func openRegularEvidenceFile(path, label string, accessErr error) (*os.File, os.FileInfo, error) {
+func openRegularEvidenceFile(path string, accessErr error) (*os.File, os.FileInfo, error) {
 	if accessErr != nil {
 		return nil, nil, accessErr
 	}
@@ -67,7 +67,7 @@ func openRegularEvidenceFile(path, label string, accessErr error) (*os.File, os.
 		return nil, nil, err
 	}
 	if before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
-		return nil, nil, fmt.Errorf("%s is symlinked or non-regular", label)
+		return nil, nil, errors.New("evidence file is symlinked or non-regular")
 	}
 	file, err := os.OpenFile(cleanPath, os.O_RDONLY|evidenceReadNoFollowFlag|evidenceReadNonblockFlag, 0)
 	if err != nil {
@@ -80,7 +80,7 @@ func openRegularEvidenceFile(path, label string, accessErr error) (*os.File, os.
 	}
 	if !info.Mode().IsRegular() || !os.SameFile(before, info) {
 		_ = file.Close()
-		return nil, nil, fmt.Errorf("%s changed or is non-regular", label)
+		return nil, nil, errors.New("evidence file changed or is non-regular")
 	}
 	return file, info, nil
 }
@@ -95,7 +95,7 @@ func readBoundedEvidence(path string, maxBytes int64, sink io.Writer) error {
 	if maxBytes <= 0 {
 		maxBytes = MaxEvidenceReadFileBytes
 	}
-	file, info, err := openRegularEvidenceFile(path, "evidence file", validateEvidenceFileAccess())
+	file, info, err := openRegularEvidenceFile(path, validateEvidenceFileAccess())
 	if err != nil {
 		return err
 	}

--- a/internal/recorder/evidence_read.go
+++ b/internal/recorder/evidence_read.go
@@ -17,7 +17,9 @@ import (
 const (
 	// MaxEvidenceReadFileBytes matches the bounded dashboard evidence
 	// verification ceiling: one evidence source may contribute at most 8 MiB
-	// to in-memory verifier/resume reads.
+	// to in-memory verifier and online UI reads. Recorder resume uses a
+	// separately bounded single-entry tail read so legacy shards larger than
+	// this whole-file ceiling remain upgradeable.
 	MaxEvidenceReadFileBytes int64 = 8 << 20
 
 	// MaxEvidenceReadDirectoryEntries matches the bounded dashboard evidence

--- a/internal/recorder/evidence_read_bounds_test.go
+++ b/internal/recorder/evidence_read_bounds_test.go
@@ -43,7 +43,7 @@ func TestReadEvidenceFileBounded_HappyPathAndHash(t *testing.T) {
 
 func TestOpenRegularEvidenceFileRejectsUnsupportedPlatform(t *testing.T) {
 	want := errors.New("unsupported evidence access")
-	file, info, err := openRegularEvidenceFile("unused", "evidence file", want)
+	file, info, err := openRegularEvidenceFile("unused", want)
 	if file != nil || info != nil {
 		t.Fatalf("open result = (%v, %v), want nil handles", file, info)
 	}

--- a/internal/recorder/evidence_read_unsupported_test.go
+++ b/internal/recorder/evidence_read_unsupported_test.go
@@ -16,7 +16,7 @@ func TestEvidenceFileOperationsFailClosedOnUnsupportedPlatform(t *testing.T) {
 		t.Fatalf("access error = %v, want %v", accessErr, errEvidenceFileAccessUnsupported)
 	}
 
-	file, info, err := openRegularEvidenceFile("unused", "evidence file", accessErr)
+	file, info, err := openRegularEvidenceFile("unused", accessErr)
 	if file != nil || info != nil {
 		t.Fatalf("open result = (%v, %v), want nil handles", file, info)
 	}

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -1292,7 +1292,7 @@ func (r *Recorder) ExpireOldFiles() (int, error) {
 // directories are created 0o750 and owned by the service, so no other
 // unprivileged principal can rename entries within them.
 func removeExpiredEvidenceFile(path string, cutoff time.Time) (bool, error) {
-	file, info, err := openRegularEvidenceFile(path, "evidence file", validateEvidenceFileAccess())
+	file, info, err := openRegularEvidenceFile(path, validateEvidenceFileAccess())
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -5,7 +5,6 @@ package recorder
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -1007,17 +1006,12 @@ func (r *Recorder) sessionResumeCandidates(sessionID string) ([]resumeCandidate,
 }
 
 func readEntriesForResume(path string) ([]Entry, error) {
-	limits := defaultEntryReadLimits()
-	data, err := ReadEvidenceFileBounded(path, limits.MaxBytes)
+	entries, truncated, err := ReadTailEntriesBounded(path, 1, int64(maxEntryWireLineBytes))
 	if err != nil {
 		return nil, err
 	}
-	entries, truncated, bytesRead, err := readEntriesFromReader(bytes.NewReader(data), limits)
-	if err != nil {
-		return nil, err
-	}
-	if truncated {
-		return nil, readLimitExceededError(path, limits, bytesRead)
+	if len(entries) == 0 && truncated {
+		return nil, fmt.Errorf("%w: no complete evidence tail entry within %d bytes", ErrEvidenceReadLimitExceeded, maxEntryWireLineBytes)
 	}
 	return entries, nil
 }

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -859,7 +859,10 @@ func (r *Recorder) resumeSessionLocked(sessionID string) error {
 		if len(entries) == 0 {
 			continue
 		}
-		last := entries[len(entries)-1]
+		// Directional tail reads return newest-first. Resume explicitly from the
+		// first entry so a future increase to the bounded window cannot select an
+		// older sequence and fork the chain.
+		last := entries[0]
 
 		// NOTE: We do NOT recompute and verify the tail hash here because
 		// ComputeHash is not round-trip stable for entries whose Detail was

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -1161,7 +1161,7 @@ func TestRecorder_ResumeIsNotCappedByMatchingSessionFileCount(t *testing.T) {
 	}
 }
 
-func TestRecorder_ResumeRejectsOverCapTailRead(t *testing.T) {
+func TestRecorder_ResumeAcceptsOverCapLegacyTailRead(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "evidence-resume-tail-cap-0.jsonl")
 	file, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePermissions)
@@ -1213,18 +1213,15 @@ func TestRecorder_ResumeRejectsOverCapTailRead(t *testing.T) {
 		SessionID: "resume-tail-cap",
 		Type:      testType,
 		Transport: testTransport,
-		Summary:   "must fail closed before unbounded tail read",
+		Summary:   "must resume through a bounded tail read",
 		Detail:    map[string]string{"safe": "value"},
 	})
-	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
-		t.Fatalf("Record error = %v, want ErrEvidenceReadLimitExceeded", err)
-	}
-	if got := err.Error(); !strings.Contains(got, "bytes") || strings.Contains(got, "entries") {
-		t.Fatalf("Record error = %q, want byte-limit diagnosis only", got)
+	if err != nil {
+		t.Fatalf("Record after over-cap legacy shard: %v", err)
 	}
 }
 
-func TestRecorder_ResumeRejectsOverCapTailEntriesReportsEntryLimit(t *testing.T) {
+func TestRecorder_ResumeAcceptsLegacyShardPastEntryReadCap(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "evidence-resume-entry-cap-0.jsonl")
 
@@ -1267,14 +1264,11 @@ func TestRecorder_ResumeRejectsOverCapTailEntriesReportsEntryLimit(t *testing.T)
 		SessionID: "resume-entry-cap",
 		Type:      testType,
 		Transport: testTransport,
-		Summary:   "must fail closed on over-cap tail entries",
+		Summary:   "must resume from one bounded tail entry",
 		Detail:    map[string]string{"safe": "value"},
 	})
-	if !errors.Is(err, recorder.ErrEvidenceReadLimitExceeded) {
-		t.Fatalf("Record error = %v, want ErrEvidenceReadLimitExceeded", err)
-	}
-	if got := err.Error(); !strings.Contains(got, "entries") || strings.Contains(got, "bytes") {
-		t.Fatalf("Record error = %q, want entry-limit diagnosis only", got)
+	if err != nil {
+		t.Fatalf("Record after legacy shard past entry read cap: %v", err)
 	}
 }
 

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -1270,6 +1270,10 @@ func TestRecorder_ResumeAcceptsLegacyShardPastEntryReadCap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Record after legacy shard past entry read cap: %v", err)
 	}
+	nextPath := filepath.Join(dir, fmt.Sprintf("evidence-resume-entry-cap-%d.jsonl", recorder.MaxEvidenceReadEntries+1))
+	if _, err := os.Stat(nextPath); err != nil {
+		t.Fatalf("next resumed shard %q: %v", filepath.Base(nextPath), err)
+	}
 }
 
 func TestComputeFileHash(t *testing.T) {

--- a/internal/recorder/resume_availability_test.go
+++ b/internal/recorder/resume_availability_test.go
@@ -92,6 +92,102 @@ func TestRecorder_ResumeSucceedsPastDirectoryCap(t *testing.T) {
 	}
 }
 
+// Legacy releases could write shards larger than the current 8 MiB rotation
+// ceiling. Upgrade resume needs only the final entry, so a valid historical
+// shard above the whole-file reader cap must not disable all future receipts.
+//
+// Neutralization: restore the whole-file ReadEvidenceFileBounded call in
+// readEntriesForResume and this fails with ErrEvidenceReadLimitExceeded.
+func TestRecorder_ResumeSucceedsFromLegacyShardAboveReadCap(t *testing.T) {
+	dir := t.TempDir()
+	const session = "legacy-large"
+	path := filepath.Join(dir, "evidence-"+session+"-0.jsonl")
+	file, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePermissions)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	encoder := json.NewEncoder(file)
+	detail := map[string]string{"padding": strings.Repeat("x", 2048)}
+	var lastSeq uint64
+	for seq := uint64(0); ; seq++ {
+		entry := recorder.Entry{
+			Version:   recorder.EntryVersion,
+			Sequence:  seq,
+			Timestamp: time.Unix(1712345678, 0).UTC(),
+			SessionID: session,
+			Type:      testType,
+			Transport: testTransport,
+			Summary:   "legacy oversized shard fixture",
+			Detail:    detail,
+			PrevHash:  fmt.Sprintf("prev-%d", seq),
+			Hash:      fmt.Sprintf("hash-%d", seq),
+		}
+		if err := encoder.Encode(entry); err != nil {
+			_ = file.Close()
+			t.Fatalf("Encode seq %d: %v", seq, err)
+		}
+		lastSeq = seq
+		if seq%128 == 0 {
+			info, statErr := file.Stat()
+			if statErr != nil {
+				_ = file.Close()
+				t.Fatalf("Stat: %v", statErr)
+			}
+			if info.Size() > recorder.MaxEvidenceReadFileBytes+(1<<20) {
+				break
+			}
+		}
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	rec := newResumeRecorder(t, dir)
+	if err := rec.Record(recorder.Entry{
+		SessionID: session,
+		Type:      testType,
+		Transport: testTransport,
+		Summary:   "must resume from a legacy oversized shard",
+		Detail:    map[string]string{"safe": "value"},
+	}); err != nil {
+		t.Fatalf("Record after legacy oversized shard: %v", err)
+	}
+	nextPath := filepath.Join(dir, fmt.Sprintf("evidence-%s-%d.jsonl", session, lastSeq+1))
+	if _, err := os.Stat(nextPath); err != nil {
+		t.Fatalf("next resumed shard %q: %v", filepath.Base(nextPath), err)
+	}
+}
+
+func TestRecorder_ResumeRejectsMalformedAndOverlongTail(t *testing.T) {
+	tests := []struct {
+		name string
+		tail []byte
+	}{
+		{name: "truncated json", tail: []byte(`{"v":2,"seq":9`)},
+		{name: "overlong line", tail: []byte(strings.Repeat("x", recorder.MaxEntryLineBytes+1))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "evidence-bad-tail-0.jsonl")
+			if err := os.WriteFile(path, tt.tail, filePermissions); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			rec := newResumeRecorder(t, dir)
+			err := rec.Record(recorder.Entry{
+				SessionID: "bad-tail",
+				Type:      testType,
+				Transport: testTransport,
+				Summary:   "malformed tail must fail closed",
+				Detail:    map[string]string{"safe": "value"},
+			})
+			if err == nil {
+				t.Fatal("Record succeeded; want malformed tail refusal")
+			}
+		})
+	}
+}
+
 // Resume must keep walking down past empty newest shards. A one-shot "highest
 // few names" scan would hand resume only the empty files, fall through to
 // genesis, and fork the chain from sequence 0.

--- a/internal/scanner/remediation.go
+++ b/internal/scanner/remediation.go
@@ -379,6 +379,29 @@ func GuidanceForResult(label, reason string) (RemediationGuidance, bool) {
 		label = AuditA2AScan
 	}
 
+	// Most scanner labels have static guidance. Return before normalizing the
+	// reason so hot-path blocks such as URL length do not allocate a lowercase
+	// copy that no branch will inspect.
+	switch label {
+	case AuditCrossRequestEntropy,
+		AuditResponseScan,
+		AuditMediaPolicy,
+		AuditRequestPolicy,
+		AuditReverseSubmit,
+		AuditRedaction,
+		AuditA2AScan,
+		AuditAgentBudget,
+		AuditSessionAnomaly,
+		ScannerEntropy,
+		ScannerDenialOfWallet,
+		ScannerSSRF,
+		ScannerSSRFMetadata,
+		ScannerCoreSSRF:
+		// These labels route on reason below.
+	default:
+		return GuidanceFor(label)
+	}
+
 	lowerReason := strings.ToLower(reason)
 	if label == AuditCrossRequestEntropy && strings.Contains(lowerReason, "cross-request entropy") {
 		return RemediationGuidance{

--- a/internal/scanner/remediation_test.go
+++ b/internal/scanner/remediation_test.go
@@ -116,7 +116,7 @@ func TestRemediationGuidanceCoversAllLabels(t *testing.T) {
 		{"ssrf metadata", ScannerSSRF, "metadata endpoint blocked", "non-overridable SSRF deny", true},
 		{"ssrf metadata label", ScannerSSRFMetadata, "metadata endpoint blocked", "non-overridable SSRF deny", true},
 		{"core ssrf metadata", ScannerCoreSSRF, "metadata endpoint blocked", "non-overridable SSRF deny", true},
-		{"static dlp", ScannerDLP, "reason is irrelevant", remediationGuidance[ScannerDLP].OperatorKnob, remediationGuidance[ScannerDLP].Immutable},
+		{"static dlp", ScannerDLP, "reason is irrelevant", "dlp.patterns[].exempt_domains", false},
 	}
 	for _, tt := range routed {
 		t.Run("routing/"+tt.name, func(t *testing.T) {

--- a/internal/scanner/remediation_test.go
+++ b/internal/scanner/remediation_test.go
@@ -94,6 +94,41 @@ func TestRemediationGuidanceCoversAllLabels(t *testing.T) {
 			t.Errorf("remediationGuidance has label %q not enumerated in the canonical block-label set", label)
 		}
 	}
+
+	routed := []struct {
+		name      string
+		label     string
+		reason    string
+		want      string
+		immutable bool
+	}{
+		{"cross-request entropy", AuditCrossRequestEntropy, "cross-request entropy exceeded", "bits_per_window", false},
+		{"response integrity", AuditResponseScan, "compressed response cannot be scanned", "scan-integrity failure", false},
+		{"media policy", AuditMediaPolicy, "image exceeds limit", "max_image_bytes", false},
+		{"request policy", AuditRequestPolicy, "body exceeds max_body_bytes", "request_body_scanning.max_body_bytes", false},
+		{"reverse submit", AuditReverseSubmit, "method not in allowed_methods", "reverse_proxy.allowed_methods", false},
+		{"redaction", AuditRedaction, "non_json_body", "allowlist_unparseable_routes", false},
+		{"a2a", AuditA2AScan, "invalid JSON", "no exemption knob", false},
+		{"agent budget", AuditAgentBudget, "request budget exceeded", "max_requests_per_session", false},
+		{"session anomaly", AuditSessionAnomaly, "baseline_deviation", "baseline show", false},
+		{"query entropy", ScannerEntropy, "high entropy query value", "query_entropy_param_exclusions", false},
+		{"denial of wallet", ScannerDenialOfWallet, "tool call limit exceeded", "max_tool_calls_per_session", false},
+		{"ssrf metadata", ScannerSSRF, "metadata endpoint blocked", "non-overridable SSRF deny", true},
+		{"ssrf metadata label", ScannerSSRFMetadata, "metadata endpoint blocked", "non-overridable SSRF deny", true},
+		{"core ssrf metadata", ScannerCoreSSRF, "metadata endpoint blocked", "non-overridable SSRF deny", true},
+		{"static dlp", ScannerDLP, "reason is irrelevant", remediationGuidance[ScannerDLP].OperatorKnob, remediationGuidance[ScannerDLP].Immutable},
+	}
+	for _, tt := range routed {
+		t.Run("routing/"+tt.name, func(t *testing.T) {
+			got, ok := GuidanceForResult(tt.label, tt.reason)
+			if !ok {
+				t.Fatalf("GuidanceForResult(%q) not found", tt.label)
+			}
+			if !strings.Contains(got.OperatorKnob, tt.want) || got.Immutable != tt.immutable {
+				t.Fatalf("GuidanceForResult(%q, %q) = %#v, want knob containing %q immutable=%v", tt.label, tt.reason, got, tt.want, tt.immutable)
+			}
+		})
+	}
 }
 
 func TestRemediationGuidanceAgentReasonsAreNonProcedural(t *testing.T) {

--- a/scripts/check-bench-regression.sh
+++ b/scripts/check-bench-regression.sh
@@ -101,7 +101,9 @@ current="$(mktemp "$TMPDIR/pipelock-bench-current.XXXXXX")"
 summary="$(mktemp "$TMPDIR/pipelock-benchstat.XXXXXX")"
 failures="$(mktemp "$TMPDIR/pipelock-bench-failures.XXXXXX")"
 benchstat_warnings="$(mktemp "$TMPDIR/pipelock-benchstat-warnings.XXXXXX")"
-trap 'rm -f "$current" "$summary" "$failures" "$benchstat_warnings"' EXIT
+baseline_normalized="$(mktemp "$TMPDIR/pipelock-bench-baseline-normalized.XXXXXX")"
+current_normalized="$(mktemp "$TMPDIR/pipelock-bench-current-normalized.XXXXXX")"
+trap 'rm -f "$current" "$summary" "$failures" "$benchstat_warnings" "$baseline_normalized" "$current_normalized"' EXIT
 
 printf 'bench-regression: baseline=%s threshold=+%s%% count=%s benchtime=%s\n' "$BENCH_BASELINE" "$threshold" "$BENCH_COUNT" "$BENCH_TIME"
 printf 'bench-regression: running:'
@@ -110,9 +112,15 @@ printf '\n'
 
 "${bench_cmd[@]}" >"$current"
 
+# Benchmark names end in the effective GOMAXPROCS (for example -4 or -16).
+# Normalize that run metadata for both the display and the enforced comparison
+# so a baseline remains comparable on a machine with a different CPU count.
+awk '{ if ($1 ~ /^Benchmark/) sub(/-[0-9]+$/, "", $1); print }' "$BENCH_BASELINE" >"$baseline_normalized"
+awk '{ if ($1 ~ /^Benchmark/) sub(/-[0-9]+$/, "", $1); print }' "$current" >"$current_normalized"
+
 # Optional human-readable summary; display-only, never gates the result.
 if [[ -n "$benchstat_bin" ]]; then
-	if "$benchstat_bin" -alpha "$BENCHSTAT_ALPHA" "$BENCH_BASELINE" "$current" >"$summary" 2>"$benchstat_warnings"; then
+	if "$benchstat_bin" -alpha "$BENCHSTAT_ALPHA" "$baseline_normalized" "$current_normalized" >"$summary" 2>"$benchstat_warnings"; then
 		cat "$summary"
 	else
 		echo "bench-regression: benchstat summary unavailable (continuing with raw comparison):" >&2
@@ -133,6 +141,12 @@ fi
 # the code without disabling errexit globally.
 awk_status=0
 awk -v threshold="$threshold" '
+	function benchmark_name(raw) {
+		# Go appends the effective GOMAXPROCS (for example -4 or -16) to
+		# benchmark names. It is run metadata, not benchmark identity.
+		sub(/-[0-9]+$/, "", raw)
+		return raw
+	}
 	function nsop(   i, v) {
 		for (i = 1; i <= NF; i++) {
 			if ($i == "ns/op") {
@@ -143,14 +157,16 @@ awk -v threshold="$threshold" '
 	}
 	FNR == NR {
 		if ($1 ~ /^Benchmark/) {
+			name = benchmark_name($1)
 			v = nsop()
-			if (v >= 0 && (!($1 in base) || v < base[$1])) base[$1] = v
+			if (v >= 0 && (!(name in base) || v < base[name])) base[name] = v
 		}
 		next
 	}
 	$1 ~ /^Benchmark/ {
+		name = benchmark_name($1)
 		v = nsop()
-		if (v >= 0 && (!($1 in cur) || v < cur[$1])) cur[$1] = v
+		if (v >= 0 && (!(name in cur) || v < cur[name])) cur[name] = v
 	}
 	END {
 		for (name in cur) {


### PR DESCRIPTION
## Summary

- preserve receipt emission when resuming valid large legacy evidence shards
- make containment reinstall restart changed managed inputs, roll back failures, and wait for proxy readiness
- report the newest effective remote-kill state for each follower audience
- stabilize benchmark comparisons across CPU-count suffixes and avoid remediation-label allocations

## Release impact

Closes upgrade and operator-lifecycle failures that could suppress receipts, report installation success before the proxy is ready, misreport a resumed fleet, or produce unstable benchmark comparisons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Containment config now auto-migrates/normalizes `file_sentry.watch_paths` and enforces loopback-only `metrics_listen`.
  * Install/verify now include improved loopback readiness checks and retries to catch late failures.
* **Bug Fixes**
  * Emergency remote-kill “active” status is more accurate across resume/supersede overlaps.
  * DNS failure diagnostics better attribute policy/denial outcomes (including proxy `403`).
  * Evidence/resume handling is more robust for legacy oversize shards and malformed tails.
* **Documentation**
  * Updated guidance for “UDP and direct DNS egress” behavior and revised contained verification checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->