### PR TITLE
fix(security): harden local state and opaque CONNECT

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -36,6 +36,7 @@ forward_proxy:
   max_tunnel_seconds: 300
   idle_timeout_seconds: 120
   sni_verification: true
+  sni_require_tls: true
 
 request_body_scanning:
   enabled: true

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -49,6 +49,7 @@ forward_proxy:
   max_tunnel_seconds: 300
   idle_timeout_seconds: 120
   sni_verification: true
+  sni_require_tls: true
 
 request_body_scanning:
   enabled: true

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -66,6 +66,7 @@ forward_proxy:
   max_tunnel_seconds: 300
   idle_timeout_seconds: 120
   sni_verification: true
+  sni_require_tls: true
 
 request_body_scanning:
   enabled: true

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -67,6 +67,7 @@ forward_proxy:
   max_tunnel_seconds: 300
   idle_timeout_seconds: 120
   sni_verification: true
+  sni_require_tls: true
 
 request_body_scanning:
   enabled: true

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -74,6 +74,7 @@ forward_proxy:
   max_tunnel_seconds: 300
   idle_timeout_seconds: 120
   sni_verification: true
+  sni_require_tls: true
 
 request_body_scanning:
   enabled: true

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -52,6 +52,10 @@ forward_proxy:
   max_tunnel_seconds: 120
   idle_timeout_seconds: 30
   sni_verification: true
+  # Refuse CONNECT protocol smuggling: the tunnel must begin with TLS and the
+  # ClientHello must carry SNI. This does not decrypt or DLP-scan tunnel bodies;
+  # enable TLS interception when payload visibility is required.
+  sni_require_tls: true
 
 request_body_scanning:
   enabled: true

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -48,6 +48,10 @@ forward_proxy:
   max_tunnel_seconds: 300
   idle_timeout_seconds: 120
   sni_verification: true
+  # Refuse CONNECT protocol smuggling: the tunnel must begin with TLS and the
+  # ClientHello must carry SNI. This does not decrypt or DLP-scan tunnel bodies;
+  # enable TLS interception when payload visibility is required.
+  sni_require_tls: true
 
 request_body_scanning:
   enabled: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,6 +230,7 @@ forward_proxy:
   max_tunnel_seconds: 300
   idle_timeout_seconds: 120
   sni_verification: true        # Verify TLS SNI matches CONNECT target
+  sni_require_tls: false        # Security profiles set true
   redirect_websocket_hosts: []  # Redirect WS hosts to /ws proxy
 ```
 
@@ -239,6 +240,7 @@ forward_proxy:
 | `max_tunnel_seconds` | `300` | No | CONNECT setup/dial deadline before the tunnel is established |
 | `idle_timeout_seconds` | `120` | No | Kill established tunnels after this much inactivity |
 | `sni_verification` | `true` | No | Verify TLS ClientHello SNI matches the CONNECT target hostname. Blocks domain fronting (MITRE T1090.004). Set to `false` to disable. |
+| `sni_require_tls` | `false` | No | Require the tunnel to begin with a TLS ClientHello carrying SNI. Official security profiles enable it. This prevents raw/no-SNI protocol smuggling but does not decrypt or scan the tunnel body. Requires `sni_verification: true`. |
 | `redirect_websocket_hosts` | `[]` | No | Redirect matching hosts to /ws |
 
 ## TLS Interception

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -305,7 +305,8 @@ const (
 	// policy semantics, so removing the compiled official keyring must change ph.
 	// Re-bumped for request body/WebSocket content entropy warn-by-default
 	// posture in ApplyDefaults.
-	goldenHashDefaults = "bcaa6bf3d9439b5449a7e4fa6bc8dbd23aa2d762b37c180ff329b6803d736127"
+	// Re-bumped for the policy-semantic forward_proxy.sni_require_tls field.
+	goldenHashDefaults = "f0a90dcdbb792983d0e90babd96db0f28189e7d44cf0c13cbe151fd5007cca61"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -452,7 +453,9 @@ const (
 	// Re-bumped for rules.trust_embedded_keys: see goldenHashDefaults note above.
 	// Re-bumped for request body/WebSocket content entropy warn-by-default
 	// posture in ApplyDefaults: see goldenHashDefaults note above.
-	goldenHashRichConfig = "b6a94ce291f1ce1b2843898df0bf299c2b635afa2693e288de78a04d3b070658"
+	// Re-bumped for forward_proxy.sni_require_tls; the rich fixture omits the
+	// field, whose compatibility default is false.
+	goldenHashRichConfig = "829f65ad00b257f4511a046afdde22b75f657516057e691ace971275c7abfee5"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -424,6 +424,13 @@ func TestCanonicalPolicyHash_PolicyFieldsDoAffect(t *testing.T) {
 			},
 		},
 		{
+			name: "forward_proxy.sni_require_tls disabled",
+			mut: func(c *Config) {
+				f := false
+				c.ForwardProxy.SNIRequireTLS = &f
+			},
+		},
+		{
 			// A request_policy discriminator predicate is policy: two
 			// configs differing only by it must produce different ph, or
 			// emitted receipts would not reflect the rail.

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -829,6 +829,7 @@ type ForwardProxy struct {
 	MaxTunnelSeconds       int      `yaml:"max_tunnel_seconds"`
 	IdleTimeoutSeconds     int      `yaml:"idle_timeout_seconds"`
 	SNIVerification        *bool    `yaml:"sni_verification"`
+	SNIRequireTLS          *bool    `yaml:"sni_require_tls"`
 	RedirectWebSocketHosts []string `yaml:"redirect_websocket_hosts"`
 }
 

--- a/internal/config/schema_receiver_methods.go
+++ b/internal/config/schema_receiver_methods.go
@@ -257,6 +257,20 @@ func (f ForwardProxy) SNIVerificationEnabled() bool {
 	return *f.SNIVerification
 }
 
+// SNIRequireTLSEnabled returns whether opaque CONNECT tunnels must present a
+// TLS ClientHello carrying an SNI extension. When true, the SNI verifier
+// fail-closes on the `not_tls` and `no_extension` categories instead of
+// splicing an opaque tunnel. Defaults to false for compatibility with
+// intentional non-TLS CONNECT protocols; security profiles enable it
+// explicitly. This guard authenticates the initial protocol/name only and
+// does not provide tunnel-body visibility without TLS interception.
+func (f ForwardProxy) SNIRequireTLSEnabled() bool {
+	if f.SNIRequireTLS == nil {
+		return false
+	}
+	return *f.SNIRequireTLS
+}
+
 // EnforceEnabled returns whether blocking is enabled.
 // Defaults to true when Enforce is nil (not set in config).
 func (c *Config) EnforceEnabled() bool {

--- a/internal/config/sni_require_tls_test.go
+++ b/internal/config/sni_require_tls_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestForwardProxySNIRequireTLSValidation(t *testing.T) {
+	cfg := Defaults()
+	cfg.ForwardProxy.Enabled = true
+	verification := false
+	requireTLS := true
+	cfg.ForwardProxy.SNIVerification = &verification
+	cfg.ForwardProxy.SNIRequireTLS = &requireTLS
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "sni_require_tls requires") {
+		t.Fatalf("Validate() error = %v, want require-TLS dependency refusal", err)
+	}
+
+	requireTLS = false
+	cfg.ForwardProxy.SNIRequireTLS = &requireTLS
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("explicit legacy opt-out with SNI verification disabled: %v", err)
+	}
+}
+
+func TestForwardProxySNIRequireTLSBooleanLifecycle(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "omitted", body: "forward_proxy: {}\n", want: false},
+		{name: "yaml null", body: "forward_proxy:\n  sni_require_tls:\n", want: false},
+		{name: "explicit false", body: "forward_proxy:\n  sni_require_tls: false\n", want: false},
+		{name: "explicit true", body: "forward_proxy:\n  sni_require_tls: true\n", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg Config
+			if err := yaml.Unmarshal([]byte(tc.body), &cfg); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if got := cfg.ForwardProxy.SNIRequireTLSEnabled(); got != tc.want {
+				t.Fatalf("SNIRequireTLSEnabled() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+
+	var first Config
+	if err := yaml.Unmarshal([]byte("forward_proxy:\n  sni_require_tls: false\n"), &first); err != nil {
+		t.Fatal(err)
+	}
+	var unchanged Config
+	if err := yaml.Unmarshal([]byte("forward_proxy:\n  sni_require_tls: false\n"), &unchanged); err != nil {
+		t.Fatal(err)
+	}
+	if first.ForwardProxy.SNIRequireTLSEnabled() != unchanged.ForwardProxy.SNIRequireTLSEnabled() {
+		t.Fatal("reload without change drifted")
+	}
+	var changed Config
+	if err := yaml.Unmarshal([]byte("forward_proxy:\n  sni_require_tls: true\n"), &changed); err != nil {
+		t.Fatal(err)
+	}
+	if !changed.ForwardProxy.SNIRequireTLSEnabled() {
+		t.Fatal("reload with change did not enable sni_require_tls")
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1849,6 +1849,9 @@ func (c *Config) validateForwardProxy() error {
 	if !c.ForwardProxy.Enabled {
 		return nil
 	}
+	if c.ForwardProxy.SNIRequireTLSEnabled() && !c.ForwardProxy.SNIVerificationEnabled() {
+		return fmt.Errorf("forward_proxy.sni_require_tls requires forward_proxy.sni_verification")
+	}
 	if c.ForwardProxy.MaxTunnelSeconds <= 0 {
 		return fmt.Errorf("forward_proxy.max_tunnel_seconds must be positive")
 	}

--- a/internal/integrity/manifest.go
+++ b/internal/integrity/manifest.go
@@ -48,7 +48,7 @@ type FileEntry struct {
 
 // Load reads and parses a manifest from disk.
 func Load(path string) (*Manifest, error) {
-	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxManifestBytes})
+	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxManifestBytes, DisallowedPerms: 0o022})
 	if err != nil {
 		return nil, fmt.Errorf("reading manifest: %w", err)
 	}

--- a/internal/integrity/manifest.go
+++ b/internal/integrity/manifest.go
@@ -48,7 +48,7 @@ type FileEntry struct {
 
 // Load reads and parses a manifest from disk.
 func Load(path string) (*Manifest, error) {
-	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxManifestBytes, DisallowedPerms: 0o022})
+	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxManifestBytes, DisallowedPerms: securefile.DisallowGroupOrWorldWrite})
 	if err != nil {
 		return nil, fmt.Errorf("reading manifest: %w", err)
 	}

--- a/internal/integrity/manifest_test.go
+++ b/internal/integrity/manifest_test.go
@@ -211,6 +211,33 @@ func TestLoad_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestLoad_PermissionPolicy(t *testing.T) {
+	body := []byte(`{"version":1,"files":{}}`)
+	for _, tt := range []struct {
+		name    string
+		mode    os.FileMode
+		wantErr bool
+	}{
+		{name: "world readable is allowed", mode: 0o644},
+		{name: "group writable is rejected", mode: 0o620, wantErr: true},
+		{name: "world writable is rejected", mode: 0o602, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "manifest.json")
+			if err := os.WriteFile(path, body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(path, tt.mode); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Load mode %04o error = %v, wantErr=%v", tt.mode, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestLoad_RejectsDuplicateAndOversizedManifest(t *testing.T) {
 	for _, tt := range []struct {
 		name string

--- a/internal/integrity/manifest_test.go
+++ b/internal/integrity/manifest_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -212,6 +213,9 @@ func TestLoad_InvalidJSON(t *testing.T) {
 }
 
 func TestLoad_PermissionPolicy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not enforced on Windows")
+	}
 	body := []byte(`{"version":1,"files":{}}`)
 	for _, tt := range []struct {
 		name    string

--- a/internal/mcp/integrity/integrity.go
+++ b/internal/mcp/integrity/integrity.go
@@ -116,7 +116,7 @@ type VerifyResult struct {
 
 // LoadManifest reads a binary integrity manifest from disk.
 func LoadManifest(path string) (*Manifest, error) {
-	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxManifestFileSize})
+	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxManifestFileSize, DisallowedPerms: 0o022})
 	if err != nil {
 		return nil, fmt.Errorf("reading manifest: %w", err)
 	}

--- a/internal/mcp/integrity/integrity.go
+++ b/internal/mcp/integrity/integrity.go
@@ -116,7 +116,7 @@ type VerifyResult struct {
 
 // LoadManifest reads a binary integrity manifest from disk.
 func LoadManifest(path string) (*Manifest, error) {
-	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxManifestFileSize, DisallowedPerms: 0o022})
+	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxManifestFileSize, DisallowedPerms: securefile.DisallowGroupOrWorldWrite})
 	if err != nil {
 		return nil, fmt.Errorf("reading manifest: %w", err)
 	}

--- a/internal/mcp/integrity/integrity_test.go
+++ b/internal/mcp/integrity/integrity_test.go
@@ -117,6 +117,9 @@ func TestLoadManifest_InvalidJSON(t *testing.T) {
 }
 
 func TestLoadManifest_PermissionPolicy(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("POSIX permission bits are not enforced on Windows")
+	}
 	body := []byte(`{"version":1,"entries":{}}`)
 	for _, tt := range []struct {
 		name    string

--- a/internal/mcp/integrity/integrity_test.go
+++ b/internal/mcp/integrity/integrity_test.go
@@ -116,6 +116,33 @@ func TestLoadManifest_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestLoadManifest_PermissionPolicy(t *testing.T) {
+	body := []byte(`{"version":1,"entries":{}}`)
+	for _, tt := range []struct {
+		name    string
+		mode    os.FileMode
+		wantErr bool
+	}{
+		{name: "world readable is allowed", mode: 0o644},
+		{name: "group writable is rejected", mode: 0o620, wantErr: true},
+		{name: "world writable is rejected", mode: 0o602, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "manifest.json")
+			if err := os.WriteFile(path, body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(path, tt.mode); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadManifest(path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("LoadManifest mode %04o error = %v, wantErr=%v", tt.mode, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestLoadManifest_RejectsDuplicateAndOversizedJSON(t *testing.T) {
 	for _, tt := range []struct {
 		name string

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -636,12 +636,22 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	if cfg.ForwardProxy.SNIVerificationEnabled() {
 		resized, sniHost, category, sniErr := verifySNI(clientReader, clientConn, host, sniReadTimeoutDefault)
 		clientReader = resized
+		if sniErr == nil && cfg.ForwardProxy.SNIRequireTLSEnabled() &&
+			(category == sniCategoryNotTLS || category == sniCategoryNoExtension) {
+			// sni_require_tls: refuse to splice an opaque, unscanned tunnel. A
+			// non-TLS payload or a ClientHello with no SNI extension would bypass
+			// DLP entirely, giving the agent a one-tunnel exfiltration channel.
+			// Fail closed: audit and tear down both connections.
+			sniErr = fmt.Errorf(
+				"sni_require_tls: opaque CONNECT tunnel refused (category=%q); TLS with SNI required", category)
+		}
 		p.metrics.RecordSNI(category, agentLabel)
 		if sniErr != nil {
 			p.logger.LogSNIMismatch(host, sniHost, clientIP, requestID, agent, category)
+			p.metrics.RecordTunnelBlocked(agentLabel)
 			outcomeStatus = strconv.Itoa(http.StatusOK)
 			outcomeBytes = 0
-			outcomeReason = "sni_mismatch"
+			outcomeReason = "sni_" + category
 			return // close both connections via deferred Close()
 		}
 	}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -636,7 +636,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	if cfg.ForwardProxy.SNIVerificationEnabled() {
 		resized, sniHost, category, sniErr := verifySNI(clientReader, clientConn, host, sniReadTimeoutDefault)
 		clientReader = resized
-		if sniErr == nil && cfg.ForwardProxy.SNIRequireTLSEnabled() &&
+		if sniErr == nil && cfg.ForwardProxy.SNIRequireTLS != nil && *cfg.ForwardProxy.SNIRequireTLS &&
 			(category == sniCategoryNotTLS || category == sniCategoryNoExtension) {
 			// sni_require_tls: refuse to splice an opaque, unscanned tunnel. A
 			// non-TLS payload or a ClientHello with no SNI extension would bypass

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -636,7 +636,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	if cfg.ForwardProxy.SNIVerificationEnabled() {
 		resized, sniHost, category, sniErr := verifySNI(clientReader, clientConn, host, sniReadTimeoutDefault)
 		clientReader = resized
-		if sniErr == nil && cfg.ForwardProxy.SNIRequireTLS != nil && *cfg.ForwardProxy.SNIRequireTLS &&
+		if sniErr == nil && cfg.ForwardProxy.SNIRequireTLSEnabled() &&
 			(category == sniCategoryNotTLS || category == sniCategoryNoExtension) {
 			// sni_require_tls: refuse to splice an opaque, unscanned tunnel. A
 			// non-TLS payload or a ClientHello with no SNI extension would bypass

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -4231,12 +4231,16 @@ func TestConnectSNIMismatch(t *testing.T) {
 	}
 }
 
-func TestConnectSNINonTLS(t *testing.T) {
-	// CONNECT + non-TLS data: should pass through without blocking.
+func TestConnectSNINonTLSExplicitOptOut(t *testing.T) {
+	// CONNECT + non-TLS data is available only through the explicit legacy
+	// opt-out. The secure default is covered by TestSNIRequireTLS_ProductionConnectPath.
 	echoLn := listenEcho(t)
 	defer func() { _ = echoLn.Close() }()
 
-	proxyAddr, cleanup := setupForwardProxy(t, nil)
+	requireTLS := false
+	proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
+		cfg.ForwardProxy.SNIRequireTLS = &requireTLS
+	})
 	defer cleanup()
 
 	conn := dialProxy(t, proxyAddr)

--- a/internal/proxy/sni_require_tls_test.go
+++ b/internal/proxy/sni_require_tls_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestSNIRequireTLS_ProductionConnectPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		requireTLS *bool
+		payload    []byte
+		wantEcho   bool
+	}{
+		{name: "enabled blocks non TLS", requireTLS: boolPointer(true), payload: []byte("opaque secret bytes")},
+		{name: "enabled blocks ClientHello without SNI", requireTLS: boolPointer(true), payload: buildClientHelloNoExtensions()},
+		{name: "explicit opt out permits non TLS", requireTLS: boolPointer(false), payload: []byte("legacy protocol"), wantEcho: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			echoLn := listenEcho(t)
+			defer func() { _ = echoLn.Close() }()
+			proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
+				cfg.ForwardProxy.SNIRequireTLS = tc.requireTLS
+			})
+			defer cleanup()
+
+			conn := dialProxy(t, proxyAddr)
+			defer func() { _ = conn.Close() }()
+			target := echoLn.Addr().String()
+			_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+			reader := bufio.NewReader(conn)
+			resp, err := http.ReadResponse(reader, nil)
+			if err != nil {
+				t.Fatalf("read CONNECT response: %v", err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+			}
+			if _, err := conn.Write(tc.payload); err != nil {
+				t.Fatalf("write tunnel payload: %v", err)
+			}
+			_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+			got := make([]byte, len(tc.payload))
+			_, err = io.ReadFull(reader, got)
+			if tc.wantEcho {
+				if err != nil || string(got) != string(tc.payload) {
+					t.Fatalf("opt-out tunnel echo = %q, err=%v", got, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("opaque tunnel payload reached upstream; want fail-closed connection")
+			}
+		})
+	}
+}
+
+// TestSNIRequireTLS_DoesNotClaimPayloadVisibility pins the honest boundary:
+// matching SNI authenticates the tunnel destination name, but the tunnel is
+// still opaque unless TLS interception is active. The bytes after ClientHello
+// are relayed without DLP inspection. This hardening must never be advertised
+// as closing CONNECT body blindness.
+func TestSNIRequireTLS_DoesNotClaimPayloadVisibility(t *testing.T) {
+	echoLn := listenEcho(t)
+	defer func() { _ = echoLn.Close() }()
+	proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
+		cfg.ForwardProxy.SNIRequireTLS = boolPointer(true)
+	})
+	defer cleanup()
+
+	conn := dialProxy(t, proxyAddr)
+	defer func() { _ = conn.Close() }()
+	target := echoLn.Addr().String()
+	_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	_ = resp.Body.Close()
+	host, _, err := net.SplitHostPort(target)
+	if err != nil {
+		t.Fatalf("split target: %v", err)
+	}
+	payload := append(buildClientHello(host), []byte("synthetic-secret-after-matching-sni")...)
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write opaque tunnel: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(reader, got); err != nil {
+		t.Fatalf("read opaque tunnel echo: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatal("opaque tunnel bytes did not round-trip")
+	}
+}
+
+// TestForwardProxy_SNIRequireTLSEnabled covers the config accessor defaults:
+// nil (unset) must default to false for backward compatibility; explicit
+// true/false must round-trip.
+func TestForwardProxy_SNIRequireTLSEnabled(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	if (config.ForwardProxy{}).SNIRequireTLSEnabled() {
+		t.Error("unset SNIRequireTLS must default to false")
+	}
+	if !(config.ForwardProxy{SNIRequireTLS: boolPtr(true)}).SNIRequireTLSEnabled() {
+		t.Error("SNIRequireTLS=true must return true")
+	}
+	if (config.ForwardProxy{SNIRequireTLS: boolPtr(false)}).SNIRequireTLSEnabled() {
+		t.Error("SNIRequireTLS=false must return false")
+	}
+}
+
+func boolPointer(v bool) *bool { return &v }

--- a/internal/proxy/sni_require_tls_test.go
+++ b/internal/proxy/sni_require_tls_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
 func TestSNIRequireTLS_ProductionConnectPath(t *testing.T) {
@@ -123,6 +124,74 @@ func TestForwardProxy_SNIRequireTLSEnabled(t *testing.T) {
 	if (config.ForwardProxy{SNIRequireTLS: boolPtr(false)}).SNIRequireTLSEnabled() {
 		t.Error("SNIRequireTLS=false must return false")
 	}
+}
+
+func TestSNIRequireTLS_HotReloadLifecycle(t *testing.T) {
+	echoLn := listenEcho(t)
+	defer func() { _ = echoLn.Close() }()
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.ForwardProxy.SNIRequireTLS = boolPointer(false)
+	})
+	defer cleanup()
+
+	assertOpaque := func(wantEcho bool) {
+		t.Helper()
+		conn := dialProxy(t, proxyAddr)
+		defer func() { _ = conn.Close() }()
+		target := echoLn.Addr().String()
+		_, _ = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+		reader := bufio.NewReader(conn)
+		resp, err := http.ReadResponse(reader, nil)
+		if err != nil {
+			t.Fatalf("read CONNECT response: %v", err)
+		}
+		_ = resp.Body.Close()
+		payload := []byte("opaque reload probe")
+		if _, err := conn.Write(payload); err != nil {
+			t.Fatalf("write tunnel payload: %v", err)
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		got := make([]byte, len(payload))
+		_, err = io.ReadFull(reader, got)
+		if wantEcho {
+			if err != nil || string(got) != string(payload) {
+				t.Fatalf("legacy tunnel echo = %q, err=%v", got, err)
+			}
+			return
+		}
+		if err == nil {
+			t.Fatal("opaque tunnel payload survived fail-closed reload")
+		}
+	}
+
+	reload := func(requireTLS bool, unrelatedMode string) {
+		t.Helper()
+		cfg := config.Defaults()
+		cfg.Internal = nil
+		cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+		cfg.APIAllowlist = nil
+		cfg.ForwardProxy.Enabled = true
+		cfg.ForwardProxy.MaxTunnelSeconds = 10
+		cfg.ForwardProxy.IdleTimeoutSeconds = 2
+		cfg.FetchProxy.TimeoutSeconds = 5
+		cfg.ForwardProxy.SNIRequireTLS = boolPointer(requireTLS)
+		if unrelatedMode != "" {
+			cfg.Mode = unrelatedMode
+		}
+		cfg.ApplyDefaults()
+		cfg.Internal = nil
+		if !p.Reload(cfg, scanner.MustNew(cfg)) {
+			t.Fatal("Reload returned false")
+		}
+	}
+
+	assertOpaque(true)
+	reload(true, "")
+	assertOpaque(false)
+	reload(true, "")
+	assertOpaque(false)
+	reload(true, config.ModeStrict)
+	assertOpaque(false)
 }
 
 func boolPointer(v bool) *bool { return &v }

--- a/internal/proxy/sni_require_tls_test.go
+++ b/internal/proxy/sni_require_tls_test.go
@@ -23,9 +23,9 @@ func TestSNIRequireTLS_ProductionConnectPath(t *testing.T) {
 		payload    []byte
 		wantEcho   bool
 	}{
-		{name: "enabled blocks non TLS", requireTLS: boolPointer(true), payload: []byte("opaque secret bytes")},
-		{name: "enabled blocks ClientHello without SNI", requireTLS: boolPointer(true), payload: buildClientHelloNoExtensions()},
-		{name: "explicit opt out permits non TLS", requireTLS: boolPointer(false), payload: []byte("legacy protocol"), wantEcho: true},
+		{name: "enabled blocks non TLS", requireTLS: ptrBool(true), payload: []byte("opaque secret bytes")},
+		{name: "enabled blocks ClientHello without SNI", requireTLS: ptrBool(true), payload: buildClientHelloNoExtensions()},
+		{name: "explicit opt out permits non TLS", requireTLS: ptrBool(false), payload: []byte("legacy protocol"), wantEcho: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -54,15 +54,15 @@ func TestSNIRequireTLS_ProductionConnectPath(t *testing.T) {
 			}
 			_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
 			got := make([]byte, len(tc.payload))
-			_, err = io.ReadFull(reader, got)
+			n, err := io.ReadFull(reader, got)
 			if tc.wantEcho {
 				if err != nil || string(got) != string(tc.payload) {
 					t.Fatalf("opt-out tunnel echo = %q, err=%v", got, err)
 				}
 				return
 			}
-			if err == nil {
-				t.Fatal("opaque tunnel payload reached upstream; want fail-closed connection")
+			if err == nil || n > 0 {
+				t.Fatalf("opaque tunnel leaked %d byte(s) upstream; want zero-byte fail-closed connection", n)
 			}
 		})
 	}
@@ -77,7 +77,7 @@ func TestSNIRequireTLS_DoesNotClaimPayloadVisibility(t *testing.T) {
 	echoLn := listenEcho(t)
 	defer func() { _ = echoLn.Close() }()
 	proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
-		cfg.ForwardProxy.SNIRequireTLS = boolPointer(true)
+		cfg.ForwardProxy.SNIRequireTLS = ptrBool(true)
 	})
 	defer cleanup()
 
@@ -113,15 +113,13 @@ func TestSNIRequireTLS_DoesNotClaimPayloadVisibility(t *testing.T) {
 // nil (unset) must default to false for backward compatibility; explicit
 // true/false must round-trip.
 func TestForwardProxy_SNIRequireTLSEnabled(t *testing.T) {
-	boolPtr := func(b bool) *bool { return &b }
-
 	if (config.ForwardProxy{}).SNIRequireTLSEnabled() {
 		t.Error("unset SNIRequireTLS must default to false")
 	}
-	if !(config.ForwardProxy{SNIRequireTLS: boolPtr(true)}).SNIRequireTLSEnabled() {
+	if !(config.ForwardProxy{SNIRequireTLS: ptrBool(true)}).SNIRequireTLSEnabled() {
 		t.Error("SNIRequireTLS=true must return true")
 	}
-	if (config.ForwardProxy{SNIRequireTLS: boolPtr(false)}).SNIRequireTLSEnabled() {
+	if (config.ForwardProxy{SNIRequireTLS: ptrBool(false)}).SNIRequireTLSEnabled() {
 		t.Error("SNIRequireTLS=false must return false")
 	}
 }
@@ -130,7 +128,7 @@ func TestSNIRequireTLS_HotReloadLifecycle(t *testing.T) {
 	echoLn := listenEcho(t)
 	defer func() { _ = echoLn.Close() }()
 	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
-		cfg.ForwardProxy.SNIRequireTLS = boolPointer(false)
+		cfg.ForwardProxy.SNIRequireTLS = ptrBool(false)
 	})
 	defer cleanup()
 
@@ -152,15 +150,15 @@ func TestSNIRequireTLS_HotReloadLifecycle(t *testing.T) {
 		}
 		_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
 		got := make([]byte, len(payload))
-		_, err = io.ReadFull(reader, got)
+		n, err := io.ReadFull(reader, got)
 		if wantEcho {
 			if err != nil || string(got) != string(payload) {
 				t.Fatalf("legacy tunnel echo = %q, err=%v", got, err)
 			}
 			return
 		}
-		if err == nil {
-			t.Fatal("opaque tunnel payload survived fail-closed reload")
+		if err == nil || n > 0 {
+			t.Fatalf("opaque tunnel leaked %d byte(s) after fail-closed reload", n)
 		}
 	}
 
@@ -174,7 +172,7 @@ func TestSNIRequireTLS_HotReloadLifecycle(t *testing.T) {
 		cfg.ForwardProxy.MaxTunnelSeconds = 10
 		cfg.ForwardProxy.IdleTimeoutSeconds = 2
 		cfg.FetchProxy.TimeoutSeconds = 5
-		cfg.ForwardProxy.SNIRequireTLS = boolPointer(requireTLS)
+		cfg.ForwardProxy.SNIRequireTLS = ptrBool(requireTLS)
 		if unrelatedMode != "" {
 			cfg.Mode = unrelatedMode
 		}
@@ -192,6 +190,10 @@ func TestSNIRequireTLS_HotReloadLifecycle(t *testing.T) {
 	assertOpaque(false)
 	reload(true, config.ModeStrict)
 	assertOpaque(false)
+	reload(false, "")
+	assertOpaque(true)
+	reload(false, config.ModeStrict)
+	assertOpaque(true)
+	reload(true, "")
+	assertOpaque(false)
 }
-
-func boolPointer(v bool) *bool { return &v }

--- a/internal/securefile/securefile.go
+++ b/internal/securefile/securefile.go
@@ -21,6 +21,10 @@ import (
 // nonblocking, no-follow open required by Read's security contract.
 var ErrUnsupportedSecureOpen = errors.New("secure file open unsupported on this platform")
 
+// DisallowGroupOrWorldWrite is the shared integrity-material policy: public
+// read access is permitted, but no non-owner may modify the trusted file.
+const DisallowGroupOrWorldWrite fs.FileMode = 0o022
+
 // Options defines the filesystem boundary enforced by Read.
 type Options struct {
 	MaxBytes        int64

--- a/internal/svidsidecar/svidsidecar.go
+++ b/internal/svidsidecar/svidsidecar.go
@@ -137,7 +137,7 @@ func (s *Sidecar) Options() (aarp.SVIDVerifyOptions, error) {
 // evidence and the verifier-pinned options. It is the CLI's one-call entry; the
 // conformance corpus uses Parse + Options directly on in-memory sidecars.
 func Load(path string) (*aarp.SVIDEvidence, aarp.SVIDVerifyOptions, error) {
-	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxSidecarBytes, DisallowedPerms: 0o022})
+	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxSidecarBytes, DisallowedPerms: securefile.DisallowGroupOrWorldWrite})
 	if err != nil {
 		return nil, aarp.SVIDVerifyOptions{}, fmt.Errorf("read svid file: %w", err)
 	}

--- a/internal/svidsidecar/svidsidecar.go
+++ b/internal/svidsidecar/svidsidecar.go
@@ -137,7 +137,7 @@ func (s *Sidecar) Options() (aarp.SVIDVerifyOptions, error) {
 // evidence and the verifier-pinned options. It is the CLI's one-call entry; the
 // conformance corpus uses Parse + Options directly on in-memory sidecars.
 func Load(path string) (*aarp.SVIDEvidence, aarp.SVIDVerifyOptions, error) {
-	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxSidecarBytes})
+	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxSidecarBytes, DisallowedPerms: 0o022})
 	if err != nil {
 		return nil, aarp.SVIDVerifyOptions{}, fmt.Errorf("read svid file: %w", err)
 	}

--- a/internal/svidsidecar/svidsidecar_test.go
+++ b/internal/svidsidecar/svidsidecar_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -285,28 +286,33 @@ func TestLoad(t *testing.T) {
 		}
 	})
 
-	for _, tt := range []struct {
-		name    string
-		mode    os.FileMode
-		wantErr bool
-	}{
-		{name: "world readable is allowed", mode: 0o644},
-		{name: "group writable is rejected", mode: 0o620, wantErr: true},
-		{name: "world writable is rejected", mode: 0o602, wantErr: true},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			path := filepath.Join(t.TempDir(), "sidecar.svid.json")
-			if err := os.WriteFile(path, []byte(validSidecarJSON(ca)), 0o600); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.Chmod(path, tt.mode); err != nil {
-				t.Fatal(err)
-			}
-			_, _, err := svidsidecar.Load(path)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Load mode %04o error = %v, wantErr=%v", tt.mode, err, tt.wantErr)
-			}
-		})
-	}
+	t.Run("permission policy", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("POSIX permission bits are not enforced on Windows")
+		}
+		for _, tt := range []struct {
+			name    string
+			mode    os.FileMode
+			wantErr bool
+		}{
+			{name: "world readable is allowed", mode: 0o644},
+			{name: "group writable is rejected", mode: 0o620, wantErr: true},
+			{name: "world writable is rejected", mode: 0o602, wantErr: true},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				path := filepath.Join(t.TempDir(), "sidecar.svid.json")
+				if err := os.WriteFile(path, []byte(validSidecarJSON(ca)), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(path, tt.mode); err != nil {
+					t.Fatal(err)
+				}
+				_, _, err := svidsidecar.Load(path)
+				if (err != nil) != tt.wantErr {
+					t.Fatalf("Load mode %04o error = %v, wantErr=%v", tt.mode, err, tt.wantErr)
+				}
+			})
+		}
+	})
 }

--- a/internal/svidsidecar/svidsidecar_test.go
+++ b/internal/svidsidecar/svidsidecar_test.go
@@ -284,4 +284,29 @@ func TestLoad(t *testing.T) {
 			t.Fatal("Load(oversized) = nil error, want error")
 		}
 	})
+
+	for _, tt := range []struct {
+		name    string
+		mode    os.FileMode
+		wantErr bool
+	}{
+		{name: "world readable is allowed", mode: 0o644},
+		{name: "group writable is rejected", mode: 0o620, wantErr: true},
+		{name: "world writable is rejected", mode: 0o602, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "sidecar.svid.json")
+			if err := os.WriteFile(path, []byte(validSidecarJSON(ca)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(path, tt.mode); err != nil {
+				t.Fatal(err)
+			}
+			_, _, err := svidsidecar.Load(path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Load mode %04o error = %v, wantErr=%v", tt.mode, err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/scripts/check-config-consumption.sh
+++ b/scripts/check-config-consumption.sh
@@ -10,8 +10,10 @@ set -euo pipefail
 # runtime code reads is a silent lie to the operator (2026-06: five conductor
 # follower knobs shipped validated-but-inert, and the guide claimed behavior).
 #
-# Heuristic: a field counts as consumed when `.FieldName` appears in any
-# non-test Go file outside internal/config/. Common field names (Enabled,
+# Heuristic: a field counts as consumed when `.FieldName` or a conventional
+# `.FieldNameEnabled()` accessor call appears in any non-test Go file outside
+# internal/config/. The accessor form keeps tri-state/default semantics in one
+# place without making this gate misclassify a live field as inert. Common field names (Enabled,
 # Action, ...) are shared across many structs, so they always count as
 # consumed — false negatives are accepted; the tripwire exists to catch
 # uniquely-named fields with ZERO references, which is exactly how dead knobs
@@ -41,7 +43,7 @@ FIELDS="$(grep -P '^\t[A-Z][A-Za-z0-9]*\s+\S+.*yaml:"' "$SCHEMA" \
 
 fail=0
 while IFS= read -r field; do
-  if ! grep -qE "\.${field}\b" "$CORPUS"; then
+  if ! grep -qE "\.${field}\b" "$CORPUS" && ! grep -qE "\.${field}Enabled\(" "$CORPUS"; then
     if [ -f "$ALLOWLIST" ] && grep -qE "^${field}([[:space:]]|$)" "$ALLOWLIST"; then
       continue
     fi


### PR DESCRIPTION
## Summary

- apply explicit permission policies to integrity manifests, MCP integrity state, and SVID sidecar state
- add a forward-proxy option requiring CONNECT traffic to begin with TLS and include SNI
- enable that protection in shipped profiles while retaining an explicit compatibility opt-out
- cover raw, missing-SNI, matching-SNI, reload, and permission-boundary behavior

## Security boundary

This prevents opaque protocol smuggling through CONNECT. Matching-SNI passthrough tunnels remain payload-opaque unless TLS interception is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `forward_proxy.sni_require_tls` to require TLS with SNI for forwarded CONNECT tunnels.
  * Enforced dependency on `forward_proxy.sni_verification` (validation fails if used without it).
  * Fail-closed behavior for non-TLS or SNI-missing tunnels, with an explicit opt-out supported.

* **Security**
  * Hardened permission checks when reading manifest and sidecar files by rejecting group- or world-writable files.

* **Documentation**
  * Documented the new `sni_require_tls` forward proxy setting and its requirements.

* **Tests**
  * Expanded coverage for TLS/SNI behavior and file-permission enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->