### PR TITLE
feat(conductor): encrypt durable audit queue records

### DIFF
--- a/charts/pipelock/README.md
+++ b/charts/pipelock/README.md
@@ -100,6 +100,7 @@ Enterprise server modes use the license Secret as `PIPELOCK_LICENSE_KEY` because
 | `conductorFollower.serverCASecretRef.name` | `""` | Existing Secret containing the Conductor server CA |
 | `conductorFollower.clientSecretRef.name` | `""` | Existing Kubernetes TLS Secret for follower mTLS client identity; must contain `tls.crt` and `tls.key`, mounted at `client_cert_path` and `client_key_path` |
 | `conductorFollower.trustRosterSecretRef.name` | `""` | Existing Secret containing the signed trust roster |
+| `conductorFollower.auditQueueKeyringSecretRef.name` | `""` | Existing Secret containing the audit-queue encryption keyring; mounted separately from the queue PVC |
 | `conductorFollower.persistence.bundleCache.enabled` | `false` | PVC for signed policy bundle cache |
 | `conductorFollower.persistence.auditQueue.enabled` | `false` | PVC for durable audit queue |
 
@@ -107,6 +108,8 @@ The follower audit queue is single-writer. Pipelock uses an advisory lock for
 one host / local-filesystem scope, but it is not a distributed lock for shared
 RWX, network, or overlay PVCs. Use ReadWriteOnce storage, leader election, or a
 separate audit queue per pod when running multiple followers.
+Records on that PVC are encrypted; the keyring Secret is mandatory for
+followers and must not be stored on the queue PVC.
 
 ### Fleet sink
 

--- a/charts/pipelock/examples/values-enterprise-follower.yaml
+++ b/charts/pipelock/examples/values-enterprise-follower.yaml
@@ -41,6 +41,9 @@ conductorFollower:
   trustRosterSecretRef:
     name: conductor-trust-roster
     key: trust-roster.json
+  auditQueueKeyringSecretRef:
+    name: follower-audit-queue-keyring
+    key: audit-queue-keyring.json
   persistence:
     bundleCache:
       enabled: true

--- a/charts/pipelock/templates/_helpers.tpl
+++ b/charts/pipelock/templates/_helpers.tpl
@@ -140,6 +140,12 @@ Validate mode and security-critical enterprise chart requirements.
 {{- $_ := required "conductorFollower.clientSecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.clientSecretRef.name -}}
 {{- $_ := required "conductorFollower.trustRosterSecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.trustRosterSecretRef.name -}}
 {{- $_ := required "conductorFollower.auditQueueKeyringSecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.auditQueueKeyringSecretRef.name -}}
+{{- $_ := required "conductorFollower.auditQueueKeyringSecretRef.key is required when conductorFollower.enabled=true" .Values.conductorFollower.auditQueueKeyringSecretRef.key -}}
+{{- $keyringMountPath := clean (required "conductorFollower.auditQueueKeyringSecretRef.mountPath is required when conductorFollower.enabled=true" .Values.conductorFollower.auditQueueKeyringSecretRef.mountPath) -}}
+{{- $queueMountPath := clean (required "conductorFollower.persistence.auditQueue.mountPath is required when conductorFollower.enabled=true" .Values.conductorFollower.persistence.auditQueue.mountPath) -}}
+{{- if or (eq $keyringMountPath $queueMountPath) (hasPrefix (printf "%s/" (trimSuffix "/" $queueMountPath)) $keyringMountPath) -}}
+{{- fail "conductorFollower.auditQueueKeyringSecretRef.mountPath must be outside conductorFollower.persistence.auditQueue.mountPath" -}}
+{{- end -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/pipelock/templates/_helpers.tpl
+++ b/charts/pipelock/templates/_helpers.tpl
@@ -139,6 +139,7 @@ Validate mode and security-critical enterprise chart requirements.
 {{- $_ := required "conductorFollower.serverCASecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.serverCASecretRef.name -}}
 {{- $_ := required "conductorFollower.clientSecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.clientSecretRef.name -}}
 {{- $_ := required "conductorFollower.trustRosterSecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.trustRosterSecretRef.name -}}
+{{- $_ := required "conductorFollower.auditQueueKeyringSecretRef.name is required when conductorFollower.enabled=true" .Values.conductorFollower.auditQueueKeyringSecretRef.name -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/pipelock/templates/configmap.yaml
+++ b/charts/pipelock/templates/configmap.yaml
@@ -38,6 +38,7 @@ data:
       "trust_roster_path" (printf "%s/%s" .Values.conductorFollower.trustRosterSecretRef.mountPath .Values.conductorFollower.trustRosterSecretRef.key)
       "bundle_cache_dir" .Values.conductorFollower.persistence.bundleCache.mountPath
       "durable_audit_queue_dir" .Values.conductorFollower.persistence.auditQueue.mountPath
+      "durable_audit_queue_keyring" (printf "%s/%s" .Values.conductorFollower.auditQueueKeyringSecretRef.mountPath .Values.conductorFollower.auditQueueKeyringSecretRef.key)
       "trust_roster_root_fingerprint" .Values.conductorFollower.trustRosterRootFingerprint
       "audit_signing_key_id" .Values.conductorFollower.auditSigningKeyID
       "recorder_key_id" .Values.conductorFollower.recorderKeyID

--- a/charts/pipelock/templates/deployment.yaml
+++ b/charts/pipelock/templates/deployment.yaml
@@ -157,6 +157,11 @@ spec:
               mountPath: {{ .Values.conductorFollower.trustRosterSecretRef.mountPath | quote }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.auditQueueKeyringSecretRef.name }}
+            - name: conductor-audit-queue-keyring
+              mountPath: {{ .Values.conductorFollower.auditQueueKeyringSecretRef.mountPath | quote }}
+              readOnly: true
+            {{- end }}
             {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.persistence.bundleCache.enabled }}
             - name: conductor-bundle-cache
               mountPath: {{ .Values.conductorFollower.persistence.bundleCache.mountPath | quote }}
@@ -210,6 +215,15 @@ spec:
             items:
               - key: {{ .Values.conductorFollower.trustRosterSecretRef.key | quote }}
                 path: {{ .Values.conductorFollower.trustRosterSecretRef.key | quote }}
+        {{- end }}
+        {{- if and .Values.conductorFollower.enabled .Values.conductorFollower.auditQueueKeyringSecretRef.name }}
+        - name: conductor-audit-queue-keyring
+          secret:
+            secretName: {{ .Values.conductorFollower.auditQueueKeyringSecretRef.name | quote }}
+            defaultMode: 0440
+            items:
+              - key: {{ .Values.conductorFollower.auditQueueKeyringSecretRef.key | quote }}
+                path: {{ .Values.conductorFollower.auditQueueKeyringSecretRef.key | quote }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/pipelock/values.yaml
+++ b/charts/pipelock/values.yaml
@@ -151,6 +151,13 @@ conductorFollower:
     name: ""
     key: "trust-roster.json"
     mountPath: "/etc/pipelock/conductor/trust"
+  # Existing Secret created from `pipelock conductor audit-queue-key init`.
+  # Keep this separate from the auditQueue PVC: access to the queue volume
+  # alone must expose only ciphertext.
+  auditQueueKeyringSecretRef:
+    name: ""
+    key: "audit-queue-keyring.json"
+    mountPath: "/etc/pipelock/conductor/audit-queue-key"
   persistence:
     bundleCache:
       enabled: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3141,6 +3141,7 @@ conductor:
   client_key_path: /etc/pipelock/follower.key
   bundle_cache_dir: /var/lib/pipelock/bundles
   durable_audit_queue_dir: /var/lib/pipelock/audit-queue
+  durable_audit_queue_keyring: /etc/pipelock/secrets/audit-queue-keyring.json
   enrollment_token_path: /etc/pipelock/conductor/enrollment-token
   poll_interval: 30s
   honor_remote_kill_switch: true
@@ -3158,6 +3159,7 @@ conductor:
 | `client_cert_path` / `client_key_path` | (required) | Follower mTLS client certificate and private key. |
 | `bundle_cache_dir` | (required) | Directory caching verified policy bundles across restarts. |
 | `durable_audit_queue_dir` | (required) | On-disk queue for signed evidence batches awaiting delivery to the audit sink. |
+| `durable_audit_queue_keyring` | (required) | Encryption keyring for durable queue records. Must be outside `durable_audit_queue_dir`; mount it from a separate Secret or volume. |
 | `audit_signing_key_id` | `instance_id` | Key ID the follower signs audit batches with. |
 | `recorder_key_id` | `instance_id` | Key ID for the follower's flight-recorder checkpoints. |
 | `enrollment_token_path` | (none) | Path to a single-use enrollment token file. When set, the follower auto-enrolls on startup, registering its audit public key with Conductor so it appears in `fleet status` and its evidence is ingested. Enrollment is best-effort (a failed enroll logs a warning and never blocks enforcement); a marker under `bundle_cache_dir` skips normal restart retries. If the leader accepts the token but the marker write fails, the next restart may retry the already-consumed token and log a warning while enforcement continues. Must be an absolute path with no world-writable ancestor. Unset means no auto-enroll (enroll out of band with `pipelock conductor enroll`). |

--- a/docs/guides/conductor-production-runbook.md
+++ b/docs/guides/conductor-production-runbook.md
@@ -342,6 +342,7 @@ conductor:
   client_key_path: /etc/pipelock/follower.key
   bundle_cache_dir: /var/lib/pipelock/bundles
   durable_audit_queue_dir: /var/lib/pipelock/audit-queue
+  durable_audit_queue_keyring: /etc/pipelock/secrets/audit-queue-keyring.json
   # audit_signing_key_id and recorder_key_id default to instance_id when omitted; override only if the audit sink expects a different key id
   # audit_signing_key_id: edge-01-audit
   # recorder_key_id: edge-01-recorder
@@ -359,6 +360,44 @@ A follower **must produce signed evidence** to participate: config validation
 rejects `conductor.enabled: true` unless the flight recorder is enabled with
 signing checkpoints and a `signing_key_path`. On Kubernetes, use
 [`values-enterprise-follower.yaml`](../../charts/pipelock/examples/values-enterprise-follower.yaml):
+
+Create the queue keyring before the first start, then store it on a separate
+secret mount rather than the queue PVC:
+
+```bash
+pipelock conductor audit-queue-key init \
+  --keyring /etc/pipelock/secrets/audit-queue-keyring.json
+```
+
+Day-2 lifecycle commands require the follower to be stopped so they can take
+the queue's exclusive lock:
+
+```bash
+pipelock conductor audit-queue-key inspect --keyring /etc/pipelock/secrets/audit-queue-keyring.json --queue-dir /var/lib/pipelock/audit-queue
+pipelock conductor audit-queue-key rotate --keyring /etc/pipelock/secrets/audit-queue-keyring.json --queue-dir /var/lib/pipelock/audit-queue
+pipelock conductor audit-queue-key migrate --keyring /etc/pipelock/secrets/audit-queue-keyring.json --queue-dir /var/lib/pipelock/audit-queue
+pipelock conductor audit-queue-key revoke sha256:0123456789abcdef --keyring /etc/pipelock/secrets/audit-queue-keyring.json --queue-dir /var/lib/pipelock/audit-queue
+pipelock conductor audit-queue-key recover --backup /etc/pipelock/secrets/audit-queue-keyring.json.bak --keyring /etc/pipelock/secrets/audit-queue-keyring.json --queue-dir /var/lib/pipelock/audit-queue
+```
+
+Rotation saves the pre-rotation keyring as `KEYRING.bak.previous`, then writes
+the rotated keyring—with both old and new decryptors—to the live file and
+`KEYRING.bak` before re-encrypting records. An interruption therefore retains
+both decryptors; rerun `migrate` to converge. Revocation refuses the active key
+and any key still referenced by a pending, inflight, or dead-letter record.
+Recovery first proves `KEYRING.bak` decrypts every queued record before
+replacing the live file.
+Use the inactive key ID printed by `inspect` in place of the example
+`sha256:0123456789abcdef` value.
+
+Kubernetes Secret mounts are read-only, so keep an operator-owned source copy
+of the keyring. Rotate that source against an empty temporary queue, update the
+Secret while the follower Deployment is scaled to zero, then scale it back up:
+startup holds the queue lock and migrates every PVC record before delivery
+resumes. The rotated keyring retains the old key during that migration. After
+`inspect` reports zero records for the old ID, revoke it in the source file and
+update the Secret again. Never delete the old key from the Secret before the
+PVC migration has completed.
 
 ```bash
 helm install pipelock-follower ./charts/pipelock \

--- a/docs/guides/conductor-production-runbook.md
+++ b/docs/guides/conductor-production-runbook.md
@@ -375,14 +375,14 @@ kubectl -n pipelock create secret generic follower-audit-queue-keyring \
 
 Day-2 lifecycle commands require the follower to be stopped and must run in an
 operator maintenance environment that mounts the real queue PVC at
-`/var/lib/pipelock/audit-queue` while keeping the operator source keyring on a
+`/var/lib/pipelock/conductor/audit-queue` while keeping the operator source keyring on a
 different writable volume. Inspection may use the read-only runtime mount;
 rotate, revoke, and recover must never target that Secret mount:
 
 ```bash
 kubectl -n pipelock scale deployment pipelock-follower --replicas=0
 export KEYRING="$PWD/operator-secrets/audit-queue-keyring.json"
-export QUEUE_DIR=/var/lib/pipelock/audit-queue
+export QUEUE_DIR=/var/lib/pipelock/conductor/audit-queue
 pipelock conductor audit-queue-key inspect --keyring "$KEYRING" --queue-dir "$QUEUE_DIR"
 pipelock conductor audit-queue-key rotate --keyring "$KEYRING" --queue-dir "$QUEUE_DIR"
 pipelock conductor audit-queue-key migrate --keyring "$KEYRING" --queue-dir "$QUEUE_DIR"

--- a/docs/guides/conductor-production-runbook.md
+++ b/docs/guides/conductor-production-runbook.md
@@ -326,6 +326,8 @@ remote-kill, but it does **not** appear in `conductor fleet status` and the audi
 sink cannot verify its evidence — the Conductor has no audit key registered for
 it. Enrollment is what turns both on.
 
+For a direct follower deployment, mount each path exactly as configured:
+
 ```yaml
 # pipelock-enterprise-skip-id: conductor-production-follower
 conductor:
@@ -358,12 +360,18 @@ flight_recorder:
 
 A follower **must produce signed evidence** to participate: config validation
 rejects `conductor.enabled: true` unless the flight recorder is enabled with
-signing checkpoints and a `signing_key_path`. On Kubernetes, use
+signing checkpoints and a `signing_key_path`. The YAML above is a manual-mount
+example; do not copy its paths into Helm-generated configuration. On Kubernetes,
+use
 [`values-enterprise-follower.yaml`](../../charts/pipelock/examples/values-enterprise-follower.yaml):
 
 Create a writable operator-owned source keyring before the first start, then
 import it into a Kubernetes Secret mounted separately from the queue PVC. The
-mounted copy is runtime-only and read-only:
+chart renders `durable_audit_queue_keyring` from
+`auditQueueKeyringSecretRef.mountPath` and `.key` (the example resolves to
+`/etc/pipelock/conductor/audit-queue-key/audit-queue-keyring.json`). The mounted
+copy is runtime-only and read-only. Keep the operator source directory at
+`0700`: it contains the raw symmetric key and has no group consumer.
 
 ```bash
 install -d -m 700 "$PWD/operator-secrets"

--- a/docs/guides/conductor-production-runbook.md
+++ b/docs/guides/conductor-production-runbook.md
@@ -361,23 +361,37 @@ rejects `conductor.enabled: true` unless the flight recorder is enabled with
 signing checkpoints and a `signing_key_path`. On Kubernetes, use
 [`values-enterprise-follower.yaml`](../../charts/pipelock/examples/values-enterprise-follower.yaml):
 
-Create the queue keyring before the first start, then store it on a separate
-secret mount rather than the queue PVC:
+Create a writable operator-owned source keyring before the first start, then
+import it into a Kubernetes Secret mounted separately from the queue PVC. The
+mounted copy is runtime-only and read-only:
 
 ```bash
+install -d -m 700 "$PWD/operator-secrets"
 pipelock conductor audit-queue-key init \
-  --keyring /etc/pipelock/secrets/audit-queue-keyring.json
+  --keyring "$PWD/operator-secrets/audit-queue-keyring.json"
+kubectl -n pipelock create secret generic follower-audit-queue-keyring \
+  --from-file=audit-queue-keyring.json="$PWD/operator-secrets/audit-queue-keyring.json"
 ```
 
-Day-2 lifecycle commands require the follower to be stopped so they can take
-the queue's exclusive lock:
+Day-2 lifecycle commands require the follower to be stopped and must run in an
+operator maintenance environment that mounts the real queue PVC at
+`/var/lib/pipelock/audit-queue` while keeping the operator source keyring on a
+different writable volume. Inspection may use the read-only runtime mount;
+rotate, revoke, and recover must never target that Secret mount:
 
 ```bash
-pipelock conductor audit-queue-key inspect --keyring /etc/pipelock/secrets/audit-queue-keyring.json --queue-dir /var/lib/pipelock/audit-queue
-pipelock conductor audit-queue-key rotate --keyring /etc/pipelock/secrets/audit-queue-keyring.json --queue-dir /var/lib/pipelock/audit-queue
-pipelock conductor audit-queue-key migrate --keyring /etc/pipelock/secrets/audit-queue-keyring.json --queue-dir /var/lib/pipelock/audit-queue
-pipelock conductor audit-queue-key revoke sha256:0123456789abcdef --keyring /etc/pipelock/secrets/audit-queue-keyring.json --queue-dir /var/lib/pipelock/audit-queue
-pipelock conductor audit-queue-key recover --backup /etc/pipelock/secrets/audit-queue-keyring.json.bak --keyring /etc/pipelock/secrets/audit-queue-keyring.json --queue-dir /var/lib/pipelock/audit-queue
+kubectl -n pipelock scale deployment pipelock-follower --replicas=0
+export KEYRING="$PWD/operator-secrets/audit-queue-keyring.json"
+export QUEUE_DIR=/var/lib/pipelock/audit-queue
+pipelock conductor audit-queue-key inspect --keyring "$KEYRING" --queue-dir "$QUEUE_DIR"
+pipelock conductor audit-queue-key rotate --keyring "$KEYRING" --queue-dir "$QUEUE_DIR"
+pipelock conductor audit-queue-key migrate --keyring "$KEYRING" --queue-dir "$QUEUE_DIR"
+pipelock conductor audit-queue-key revoke sha256:0123456789abcdef --keyring "$KEYRING" --queue-dir "$QUEUE_DIR"
+pipelock conductor audit-queue-key recover --backup "$KEYRING.bak" --keyring "$KEYRING" --queue-dir "$QUEUE_DIR"
+kubectl -n pipelock create secret generic follower-audit-queue-keyring \
+  --from-file=audit-queue-keyring.json="$KEYRING" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n pipelock scale deployment pipelock-follower --replicas=1
 ```
 
 Rotation saves the pre-rotation keyring as `KEYRING.bak.previous`, then writes
@@ -385,19 +399,21 @@ the rotated keyring—with both old and new decryptors—to the live file and
 `KEYRING.bak` before re-encrypting records. An interruption therefore retains
 both decryptors; rerun `migrate` to converge. Revocation refuses the active key
 and any key still referenced by a pending, inflight, or dead-letter record.
-Recovery first proves `KEYRING.bak` decrypts every queued record before
-replacing the live file.
+Recovery first proves `KEYRING.bak` decrypts every queued record, preserves the
+current live keyring as `KEYRING.pre-recover`, then restores the backup
+verbatim. That intentionally reinstates any keys revoked after the backup; use
+the pre-recovery snapshot to reverse an accidental recovery.
 Use the inactive key ID printed by `inspect` in place of the example
 `sha256:0123456789abcdef` value.
 
-Kubernetes Secret mounts are read-only, so keep an operator-owned source copy
-of the keyring. Rotate that source against an empty temporary queue, update the
-Secret while the follower Deployment is scaled to zero, then scale it back up:
-startup holds the queue lock and migrates every PVC record before delivery
-resumes. The rotated keyring retains the old key during that migration. After
-`inspect` reports zero records for the old ID, revoke it in the source file and
-update the Secret again. Never delete the old key from the Secret before the
-PVC migration has completed.
+Kubernetes Secret mounts are read-only, so retain the operator-owned source
+copy. Never rotate against an empty temporary queue: maintenance commands now
+require the initialized real queue layout and inspect every durable state before
+mutation. Update the Secret only after the command succeeds, then scale the
+Deployment back up. Startup verifies and migrates every PVC record before
+delivery resumes. After `inspect` reports zero records for the old ID, revoke it
+in the source file and repeat the scale-down/update/scale-up flow. Never delete
+the old key from the Secret before PVC migration has completed.
 
 ```bash
 helm install pipelock-follower ./charts/pipelock \

--- a/docs/guides/conductor.md
+++ b/docs/guides/conductor.md
@@ -236,6 +236,7 @@ conductor:
   client_key_path: /etc/pipelock/follower.key
   bundle_cache_dir: /var/lib/pipelock/bundles
   durable_audit_queue_dir: /var/lib/pipelock/audit-queue
+  durable_audit_queue_keyring: /etc/pipelock/secrets/audit-queue-keyring.json
   audit_signing_key_id: edge-01-audit
   recorder_key_id: edge-01-recorder
   poll_interval: 30s

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -808,6 +808,7 @@ conductor:
   client_key_path: "/etc/pipelock/conductor/client.key"
   bundle_cache_dir: "/var/lib/pipelock/conductor/bundles"
   durable_audit_queue_dir: "/var/lib/pipelock/conductor/audit-queue"
+  durable_audit_queue_keyring: "/etc/pipelock/secrets/audit-queue-keyring.json"
   audit_signing_key_id: "instance-audit-1"
   recorder_key_id: "instance-recorder-1"
   poll_interval: "30s"
@@ -836,6 +837,12 @@ opening the same queue at the same time. That lock is not a distributed lock.
 Cross-host single-writer safety on shared RWX, network, or overlay PVCs is a
 deployment responsibility: use ReadWriteOnce storage, Kubernetes leader
 election, or give each pod its own durable audit queue.
+
+Queue records are AES-256-GCM encrypted. Keep
+`durable_audit_queue_keyring` outside the queue volume so a widened or copied
+PVC exposes ciphertext rather than the audit payload. Startup migrates legacy
+plaintext records and records written under retained keys to the active key;
+an unavailable key or authentication failure blocks queue startup.
 
 Upgrade note: `honor_remote_kill_switch` defaults to true. Existing
 Conductor-enabled followers that only use audit batching must either set

--- a/enterprise/cli/conductor/audit_queue_key.go
+++ b/enterprise/cli/conductor/audit_queue_key.go
@@ -1,0 +1,196 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
+)
+
+type auditQueueKeyOptions struct {
+	keyring  string
+	queueDir string
+	backup   string
+}
+
+func auditQueueKeyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "audit-queue-key",
+		Short: "Manage follower audit-queue encryption keys",
+	}
+	cmd.AddCommand(auditQueueKeyInitCmd())
+	cmd.AddCommand(auditQueueKeyInspectCmd())
+	cmd.AddCommand(auditQueueKeyRotateCmd())
+	cmd.AddCommand(auditQueueKeyMigrateCmd())
+	cmd.AddCommand(auditQueueKeyRevokeCmd())
+	cmd.AddCommand(auditQueueKeyRecoverCmd())
+	return cmd
+}
+
+func auditQueueKeyInitCmd() *cobra.Command {
+	var opts auditQueueKeyOptions
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Create a new audit-queue keyring",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := os.Lstat(opts.keyring); err == nil {
+				return fmt.Errorf("audit queue keyring already exists: %s", opts.keyring)
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("inspect audit queue keyring: %w", err)
+			}
+			keyring, err := auditbatcher.NewKeyring()
+			if err != nil {
+				return err
+			}
+			if err := auditbatcher.EnsureKeyringParent(opts.keyring); err != nil {
+				return err
+			}
+			if err := keyring.Save(opts.keyring); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "created audit queue keyring %s (active %s)\n", opts.keyring, keyring.ActiveKeyID())
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.keyring, "keyring", "", "path to the keyring file (required; keep outside the audit queue volume)")
+	_ = cmd.MarkFlagRequired("keyring")
+	return cmd
+}
+
+func auditQueueKeyInspectCmd() *cobra.Command {
+	var opts auditQueueKeyOptions
+	cmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "Show key IDs and durable-record usage without exposing key material",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			keyring, usage, err := loadAndInspectQueueKeys(opts)
+			if err != nil {
+				return err
+			}
+			for _, id := range keyring.KeyIDs() {
+				active := ""
+				if id == keyring.ActiveKeyID() {
+					active = " active"
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s records=%d%s\n", id, usage[id], active)
+			}
+			if usage[auditbatcher.LegacyKeyID] > 0 {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s records=%d\n", auditbatcher.LegacyKeyID, usage[auditbatcher.LegacyKeyID])
+			}
+			return nil
+		},
+	}
+	addAuditQueueKeyFlags(cmd, &opts)
+	return cmd
+}
+
+func auditQueueKeyRotateCmd() *cobra.Command {
+	var opts auditQueueKeyOptions
+	cmd := &cobra.Command{
+		Use:   "rotate",
+		Short: "Activate a new key, preserve a backup, and re-encrypt queued records",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.TrimSpace(opts.backup) == "" {
+				opts.backup = opts.keyring + ".bak"
+			}
+			oldID, newID, err := auditbatcher.RotateQueueKeyring(opts.queueDir, opts.keyring, opts.backup)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "rotated audit queue key %s -> %s; recovery backup %s; previous backup %s.previous\n", oldID, newID, opts.backup, opts.backup)
+			return nil
+		},
+	}
+	addAuditQueueKeyFlags(cmd, &opts)
+	cmd.Flags().StringVar(&opts.backup, "backup", "", "pre-rotation backup path (default KEYRING.bak)")
+	return cmd
+}
+
+func auditQueueKeyMigrateCmd() *cobra.Command {
+	var opts auditQueueKeyOptions
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Encrypt legacy records and re-encrypt old-key records under the active key",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			activeID, err := auditbatcher.MigrateQueueKeyring(opts.queueDir, opts.keyring)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "audit queue records converged to active key %s\n", activeID)
+			return nil
+		},
+	}
+	addAuditQueueKeyFlags(cmd, &opts)
+	return cmd
+}
+
+func auditQueueKeyRevokeCmd() *cobra.Command {
+	var opts auditQueueKeyOptions
+	cmd := &cobra.Command{
+		Use:   "revoke KEY_ID",
+		Short: "Remove an inactive key only when no durable record uses it",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := auditbatcher.RevokeQueueKeyringKey(opts.queueDir, opts.keyring, args[0]); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "revoked audit queue key %s\n", args[0])
+			return nil
+		},
+	}
+	addAuditQueueKeyFlags(cmd, &opts)
+	return cmd
+}
+
+func auditQueueKeyRecoverCmd() *cobra.Command {
+	var opts auditQueueKeyOptions
+	cmd := &cobra.Command{
+		Use:   "recover",
+		Short: "Restore a backup keyring after proving it decrypts every queued record",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			activeID, err := auditbatcher.RecoverQueueKeyring(opts.queueDir, opts.keyring, opts.backup)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "recovered audit queue keyring %s from %s (active %s)\n", opts.keyring, opts.backup, activeID)
+			return nil
+		},
+	}
+	addAuditQueueKeyFlags(cmd, &opts)
+	cmd.Flags().StringVar(&opts.backup, "backup", "", "validated backup keyring to restore (required)")
+	_ = cmd.MarkFlagRequired("backup")
+	return cmd
+}
+
+func addAuditQueueKeyFlags(cmd *cobra.Command, opts *auditQueueKeyOptions) {
+	cmd.Flags().StringVar(&opts.keyring, "keyring", "", "path to the keyring file (required)")
+	_ = cmd.MarkFlagRequired("keyring")
+	cmd.Flags().StringVar(&opts.queueDir, "queue-dir", "", "durable audit queue directory (required)")
+	_ = cmd.MarkFlagRequired("queue-dir")
+}
+
+func loadAndInspectQueueKeys(opts auditQueueKeyOptions) (*auditbatcher.Keyring, map[string]int, error) {
+	keyring, err := auditbatcher.LoadKeyring(opts.keyring)
+	if err != nil {
+		return nil, nil, err
+	}
+	usage, err := auditbatcher.InspectQueueKeys(opts.queueDir, 0, keyring)
+	if err != nil {
+		return nil, nil, err
+	}
+	return keyring, usage, nil
+}

--- a/enterprise/cli/conductor/audit_queue_key.go
+++ b/enterprise/cli/conductor/audit_queue_key.go
@@ -88,6 +88,9 @@ func auditQueueKeyInspectCmd() *cobra.Command {
 			if usage[auditbatcher.LegacyKeyID] > 0 {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s records=%d\n", auditbatcher.LegacyKeyID, usage[auditbatcher.LegacyKeyID])
 			}
+			if usage[auditbatcher.UnreadableRecordID] > 0 {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s records=%d\n", auditbatcher.UnreadableRecordID, usage[auditbatcher.UnreadableRecordID])
+			}
 			return nil
 		},
 	}

--- a/enterprise/cli/conductor/audit_queue_key.go
+++ b/enterprise/cli/conductor/audit_queue_key.go
@@ -117,7 +117,7 @@ func auditQueueKeyRotateCmd() *cobra.Command {
 		},
 	}
 	addAuditQueueKeyFlags(cmd, &opts)
-	cmd.Flags().StringVar(&opts.backup, "backup", "", "pre-rotation backup path (default KEYRING.bak)")
+	cmd.Flags().StringVar(&opts.backup, "backup", "", "post-rotation recovery backup path; pre-rotation state uses BACKUP.previous (default KEYRING.bak)")
 	return cmd
 }
 

--- a/enterprise/cli/conductor/audit_queue_key_test.go
+++ b/enterprise/cli/conductor/audit_queue_key_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestAuditQueueKeyLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("keyring mode = %o, want 600", info.Mode().Perm())
 	}
 	original, err := auditbatcher.LoadKeyring(keyringPath)
@@ -34,6 +35,13 @@ func TestAuditQueueKeyLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 	oldID := original.ActiveKeyID()
+	queue, err := auditbatcher.Open(auditbatcher.Config{Dir: queueDir, Keyring: original})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := queue.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	out := runAuditQueueKeyCommand(t, "inspect", "--keyring", keyringPath, "--queue-dir", queueDir)
 	if !strings.Contains(out, oldID+" records=0 active") {

--- a/enterprise/cli/conductor/audit_queue_key_test.go
+++ b/enterprise/cli/conductor/audit_queue_key_test.go
@@ -1,0 +1,180 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package conductor
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
+)
+
+func TestAuditQueueKeyLifecycle(t *testing.T) {
+	root := t.TempDir()
+	keyringPath := filepath.Join(root, "secrets", "keyring.json")
+	queueDir := filepath.Join(root, "queue")
+
+	runAuditQueueKeyCommand(t, "init", "--keyring", keyringPath)
+	info, err := os.Stat(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("keyring mode = %o, want 600", info.Mode().Perm())
+	}
+	original, err := auditbatcher.LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldID := original.ActiveKeyID()
+
+	out := runAuditQueueKeyCommand(t, "inspect", "--keyring", keyringPath, "--queue-dir", queueDir)
+	if !strings.Contains(out, oldID+" records=0 active") {
+		t.Fatalf("inspect output = %q", out)
+	}
+
+	out = runAuditQueueKeyCommand(t, "rotate", "--keyring", keyringPath, "--queue-dir", queueDir)
+	if !strings.Contains(out, "rotated audit queue key") {
+		t.Fatalf("rotate output = %q", out)
+	}
+	rotated, err := auditbatcher.LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotated.ActiveKeyID() == oldID {
+		t.Fatal("rotation did not change active key")
+	}
+	newID := rotated.ActiveKeyID()
+	if _, err := os.Stat(keyringPath + ".bak"); err != nil {
+		t.Fatalf("rotation backup: %v", err)
+	}
+	if _, err := os.Stat(keyringPath + ".bak.previous"); err != nil {
+		t.Fatalf("pre-rotation backup: %v", err)
+	}
+
+	runAuditQueueKeyCommand(t, "revoke", oldID, "--keyring", keyringPath, "--queue-dir", queueDir)
+	revoked, err := auditbatcher.LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range revoked.KeyIDs() {
+		if id == oldID {
+			t.Fatalf("revoked key %s remains", oldID)
+		}
+	}
+
+	runAuditQueueKeyCommand(t, "recover", "--backup", keyringPath+".bak", "--keyring", keyringPath, "--queue-dir", queueDir)
+	recovered, err := auditbatcher.LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.ActiveKeyID() != newID {
+		t.Fatalf("recovered active key = %s, want %s", recovered.ActiveKeyID(), newID)
+	}
+}
+
+func TestAuditQueueKeyCommandsRespectQueueLock(t *testing.T) {
+	root := t.TempDir()
+	keyringPath := filepath.Join(root, "secrets", "keyring.json")
+	queueDir := filepath.Join(root, "queue")
+	runAuditQueueKeyCommand(t, "init", "--keyring", keyringPath)
+	keyring, err := auditbatcher.LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queue, err := auditbatcher.Open(auditbatcher.Config{Dir: queueDir, Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = queue.Close() }()
+
+	cmd := auditQueueKeyCmd()
+	cmd.SetArgs([]string{"migrate", "--keyring", keyringPath, "--queue-dir", queueDir})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err = cmd.Execute()
+	if !errors.Is(err, auditbatcher.ErrQueueLocked) {
+		t.Fatalf("migrate while queue live error = %v, want ErrQueueLocked", err)
+	}
+}
+
+func TestAuditQueueKeyInitRefusesOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	runAuditQueueKeyCommand(t, "init", "--keyring", path)
+
+	cmd := auditQueueKeyCmd()
+	cmd.SetArgs([]string{"init", "--keyring", path})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("second init error = %v, want overwrite refusal", err)
+	}
+}
+
+func TestAuditQueueKeyCommandErrorPaths(t *testing.T) {
+	root := t.TempDir()
+	keyringPath := filepath.Join(root, "secrets", "keyring.json")
+	queueDir := filepath.Join(root, "queue")
+
+	runAuditQueueKeyCommandWantError(t, "inspect", "--keyring", filepath.Join(root, "missing.json"), "--queue-dir", queueDir)
+
+	parentFile := filepath.Join(root, "not-a-directory")
+	if err := os.WriteFile(parentFile, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runAuditQueueKeyCommandWantError(t, "init", "--keyring", filepath.Join(parentFile, "keyring.json"))
+
+	runAuditQueueKeyCommand(t, "init", "--keyring", keyringPath)
+	keyring, err := auditbatcher.LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queue, err := auditbatcher.Open(auditbatcher.Config{Dir: queueDir, Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"inspect", "--keyring", keyringPath, "--queue-dir", queueDir},
+		{"rotate", "--keyring", keyringPath, "--queue-dir", queueDir},
+		{"migrate", "--keyring", keyringPath, "--queue-dir", queueDir},
+	} {
+		runAuditQueueKeyCommandWantError(t, args...)
+	}
+	if err := queue.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	runAuditQueueKeyCommandWantError(t, "revoke", keyring.ActiveKeyID(), "--keyring", keyringPath, "--queue-dir", queueDir)
+	runAuditQueueKeyCommandWantError(t, "recover", "--backup", filepath.Join(root, "missing-backup.json"), "--keyring", keyringPath, "--queue-dir", queueDir)
+}
+
+func runAuditQueueKeyCommand(t *testing.T, args ...string) string {
+	t.Helper()
+	var out bytes.Buffer
+	cmd := auditQueueKeyCmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("audit-queue-key %s: %v\n%s", strings.Join(args, " "), err, out.String())
+	}
+	return out.String()
+}
+
+func runAuditQueueKeyCommandWantError(t *testing.T, args ...string) {
+	t.Helper()
+	cmd := auditQueueKeyCmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("audit-queue-key %s error = nil", strings.Join(args, " "))
+	}
+}

--- a/enterprise/cli/conductor/audit_queue_key_test.go
+++ b/enterprise/cli/conductor/audit_queue_key_test.go
@@ -39,6 +39,10 @@ func TestAuditQueueKeyLifecycle(t *testing.T) {
 	if !strings.Contains(out, oldID+" records=0 active") {
 		t.Fatalf("inspect output = %q", out)
 	}
+	out = runAuditQueueKeyCommand(t, "migrate", "--keyring", keyringPath, "--queue-dir", queueDir)
+	if !strings.Contains(out, "converged to active key "+oldID) {
+		t.Fatalf("migrate output = %q", out)
+	}
 
 	out = runAuditQueueKeyCommand(t, "rotate", "--keyring", keyringPath, "--queue-dir", queueDir)
 	if !strings.Contains(out, "rotated audit queue key") {
@@ -102,6 +106,34 @@ func TestAuditQueueKeyCommandsRespectQueueLock(t *testing.T) {
 	err = cmd.Execute()
 	if !errors.Is(err, auditbatcher.ErrQueueLocked) {
 		t.Fatalf("migrate while queue live error = %v, want ErrQueueLocked", err)
+	}
+}
+
+func TestAuditQueueKeyInspectReportsUnreadableRecords(t *testing.T) {
+	root := t.TempDir()
+	keyringPath := filepath.Join(root, "secrets", "keyring.json")
+	queueDir := filepath.Join(root, "queue")
+	runAuditQueueKeyCommand(t, "init", "--keyring", keyringPath)
+	keyring, err := auditbatcher.LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queue, err := auditbatcher.Open(auditbatcher.Config{Dir: queueDir, Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := queue.Close(); err != nil {
+		t.Fatal(err)
+	}
+	deadPath := filepath.Join(queueDir, "dead", "00000000000000000001-corrupt.json")
+	if err := os.WriteFile(deadPath, []byte("{bad"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out := runAuditQueueKeyCommand(t, "inspect", "--keyring", keyringPath, "--queue-dir", queueDir)
+	want := auditbatcher.UnreadableRecordID + " records=1"
+	if !strings.Contains(out, want) {
+		t.Fatalf("inspect output = %q, want %q", out, want)
 	}
 }
 

--- a/enterprise/cli/conductor/cmd.go
+++ b/enterprise/cli/conductor/cmd.go
@@ -105,6 +105,7 @@ func Cmd() *cobra.Command {
 	cmd.AddCommand(enrollmentTokenCmd())
 	cmd.AddCommand(storeCmd())
 	cmd.AddCommand(followerCmd())
+	cmd.AddCommand(auditQueueKeyCmd())
 	return cmd
 }
 

--- a/enterprise/conductor/auditbatcher/applied_state_test.go
+++ b/enterprise/conductor/auditbatcher/applied_state_test.go
@@ -26,7 +26,7 @@ func newAppliedStateProducer(t *testing.T, cfg ProducerConfig) (*Producer, *Queu
 	if err != nil {
 		t.Fatalf("GenerateKey recorder: %v", err)
 	}
-	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
 	if err != nil {
 		t.Fatalf("Open queue: %v", err)
 	}

--- a/enterprise/conductor/auditbatcher/key_usage.go
+++ b/enterprise/conductor/auditbatcher/key_usage.go
@@ -6,13 +6,17 @@
 package auditbatcher
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 )
 
-const LegacyKeyID = "legacy-plaintext"
+const (
+	LegacyKeyID        = "legacy-plaintext"
+	UnreadableRecordID = "unreadable-record"
+)
 
 // InspectQueueKeys takes the queue's exclusive lock and reports which key
 // protects every durable record. It never rewrites queue state.
@@ -42,6 +46,10 @@ func (q *Queue) keyUsageLocked() (map[string]int, error) {
 		for _, name := range names {
 			_, keyID, legacy, err := readRecordWithKeyring(filepath.Join(recordDir, name), q.maxPayloadBytes, q.keyring)
 			if err != nil {
+				if errors.Is(err, ErrCorruptRecord) {
+					usage[UnreadableRecordID]++
+					continue
+				}
 				return nil, fmt.Errorf("auditbatcher: inspect queue record %s: %w", name, err)
 			}
 			if legacy {
@@ -64,8 +72,12 @@ func RotateQueueKeyring(queueDir, keyringPath, backupPath string) (string, strin
 		return "", "", err
 	}
 	q.keyring = keyring
-	if _, err := q.keyUsageLocked(); err != nil {
+	usage, err := q.keyUsageLocked()
+	if err != nil {
 		return "", "", err
+	}
+	if usage[UnreadableRecordID] > 0 {
+		return "", "", fmt.Errorf("auditbatcher: rotate refused: %d unreadable queue record(s)", usage[UnreadableRecordID])
 	}
 	oldID := keyring.ActiveKeyID()
 	if err := keyring.Save(backupPath + ".previous"); err != nil {
@@ -122,6 +134,9 @@ func RevokeQueueKeyringKey(queueDir, keyringPath, keyID string) error {
 	if err != nil {
 		return err
 	}
+	if usage[UnreadableRecordID] > 0 {
+		return fmt.Errorf("auditbatcher: revoke refused: %d unreadable queue record(s) may still use the key", usage[UnreadableRecordID])
+	}
 	if err := keyring.Revoke(keyID, usage); err != nil {
 		return err
 	}
@@ -139,8 +154,12 @@ func RecoverQueueKeyring(queueDir, livePath, backupPath string) (string, error) 
 		return "", fmt.Errorf("load recovery keyring: %w", err)
 	}
 	q.keyring = backup
-	if _, err := q.keyUsageLocked(); err != nil {
+	usage, err := q.keyUsageLocked()
+	if err != nil {
 		return "", fmt.Errorf("recovery keyring cannot decrypt the queue: %w", err)
+	}
+	if usage[UnreadableRecordID] > 0 {
+		return "", fmt.Errorf("recovery keyring cannot decrypt %d queue record(s)", usage[UnreadableRecordID])
 	}
 	if err := backup.Save(livePath); err != nil {
 		return "", err

--- a/enterprise/conductor/auditbatcher/key_usage.go
+++ b/enterprise/conductor/auditbatcher/key_usage.go
@@ -95,7 +95,7 @@ func RotateQueueKeyring(queueDir, keyringPath, backupPath string) (string, strin
 	// The ordinary recovery backup is post-rotation and can therefore decrypt
 	// both old records and records written under the new active key.
 	if err := keyring.Save(backupPath); err != nil {
-		return "", "", fmt.Errorf("save rotated keyring backup: %w", err)
+		return oldID, newID, fmt.Errorf("new key saved but rotated keyring backup failed; rerun with a valid backup path: %w", err)
 	}
 	if err := q.migrateRecordsLocked(); err != nil {
 		return oldID, newID, fmt.Errorf("new key saved but queue migration incomplete; rerun migrate: %w", err)

--- a/enterprise/conductor/auditbatcher/key_usage.go
+++ b/enterprise/conductor/auditbatcher/key_usage.go
@@ -1,0 +1,171 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package auditbatcher
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+)
+
+const LegacyKeyID = "legacy-plaintext"
+
+// InspectQueueKeys takes the queue's exclusive lock and reports which key
+// protects every durable record. It never rewrites queue state.
+func InspectQueueKeys(dir string, maxPayloadBytes uint64, keyring *Keyring) (map[string]int, error) {
+	if keyring == nil {
+		return nil, fmt.Errorf("auditbatcher: queue encryption keyring required")
+	}
+	if maxPayloadBytes == 0 {
+		maxPayloadBytes = conductor.MaxAuditPayloadBytes
+	}
+	q, err := lockQueueForKeyMaintenance(dir, maxPayloadBytes)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = q.releaseLock() }()
+	q.keyring = keyring
+	return q.keyUsageLocked()
+}
+
+func (q *Queue) keyUsageLocked() (map[string]int, error) {
+	usage := make(map[string]int)
+	for _, recordDir := range []string{q.pendingDir, q.inflightDir, q.deadDir} {
+		names, err := listRecordFiles(recordDir)
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range names {
+			_, keyID, legacy, err := readRecordWithKeyring(filepath.Join(recordDir, name), q.maxPayloadBytes, q.keyring)
+			if err != nil {
+				return nil, fmt.Errorf("auditbatcher: inspect queue record %s: %w", name, err)
+			}
+			if legacy {
+				keyID = LegacyKeyID
+			}
+			usage[keyID]++
+		}
+	}
+	return usage, nil
+}
+
+func RotateQueueKeyring(queueDir, keyringPath, backupPath string) (string, string, error) {
+	q, err := lockQueueForKeyMaintenance(queueDir, 0)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() { _ = q.releaseLock() }()
+	keyring, err := LoadKeyring(keyringPath)
+	if err != nil {
+		return "", "", err
+	}
+	q.keyring = keyring
+	if _, err := q.keyUsageLocked(); err != nil {
+		return "", "", err
+	}
+	oldID := keyring.ActiveKeyID()
+	if err := keyring.Save(backupPath + ".previous"); err != nil {
+		return "", "", fmt.Errorf("save pre-rotation keyring backup: %w", err)
+	}
+	newID, err := keyring.Rotate()
+	if err != nil {
+		return "", "", err
+	}
+	// Persist both decryptors before any record uses the new key.
+	if err := keyring.Save(keyringPath); err != nil {
+		return "", "", err
+	}
+	// The ordinary recovery backup is post-rotation and can therefore decrypt
+	// both old records and records written under the new active key.
+	if err := keyring.Save(backupPath); err != nil {
+		return "", "", fmt.Errorf("save rotated keyring backup: %w", err)
+	}
+	if err := q.migrateRecordsLocked(); err != nil {
+		return oldID, newID, fmt.Errorf("new key saved but queue migration incomplete; rerun migrate: %w", err)
+	}
+	return oldID, newID, nil
+}
+
+func MigrateQueueKeyring(queueDir, keyringPath string) (string, error) {
+	q, err := lockQueueForKeyMaintenance(queueDir, 0)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = q.releaseLock() }()
+	keyring, err := LoadKeyring(keyringPath)
+	if err != nil {
+		return "", err
+	}
+	q.keyring = keyring
+	if err := q.migrateRecordsLocked(); err != nil {
+		return "", err
+	}
+	return keyring.ActiveKeyID(), nil
+}
+
+func RevokeQueueKeyringKey(queueDir, keyringPath, keyID string) error {
+	q, err := lockQueueForKeyMaintenance(queueDir, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = q.releaseLock() }()
+	keyring, err := LoadKeyring(keyringPath)
+	if err != nil {
+		return err
+	}
+	q.keyring = keyring
+	usage, err := q.keyUsageLocked()
+	if err != nil {
+		return err
+	}
+	if err := keyring.Revoke(keyID, usage); err != nil {
+		return err
+	}
+	return keyring.Save(keyringPath)
+}
+
+func RecoverQueueKeyring(queueDir, livePath, backupPath string) (string, error) {
+	q, err := lockQueueForKeyMaintenance(queueDir, 0)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = q.releaseLock() }()
+	backup, err := LoadKeyring(backupPath)
+	if err != nil {
+		return "", fmt.Errorf("load recovery keyring: %w", err)
+	}
+	q.keyring = backup
+	if _, err := q.keyUsageLocked(); err != nil {
+		return "", fmt.Errorf("recovery keyring cannot decrypt the queue: %w", err)
+	}
+	if err := backup.Save(livePath); err != nil {
+		return "", err
+	}
+	return backup.ActiveKeyID(), nil
+}
+
+func lockQueueForKeyMaintenance(dir string, maxPayloadBytes uint64) (*Queue, error) {
+	if maxPayloadBytes == 0 {
+		maxPayloadBytes = conductor.MaxAuditPayloadBytes
+	}
+	root, pending, inflight, dead, err := ensurePrivateQueueDirs(filepath.Clean(dir))
+	if err != nil {
+		return nil, err
+	}
+	lock, err := acquireQueueLock(root)
+	if err != nil {
+		return nil, err
+	}
+	return &Queue{
+		dir:             root,
+		pendingDir:      pending,
+		inflightDir:     inflight,
+		deadDir:         dead,
+		maxPayloadBytes: maxPayloadBytes,
+		lockFile:        lock,
+	}, nil
+}

--- a/enterprise/conductor/auditbatcher/key_usage.go
+++ b/enterprise/conductor/auditbatcher/key_usage.go
@@ -8,6 +8,7 @@ package auditbatcher
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
@@ -161,6 +162,16 @@ func RecoverQueueKeyring(queueDir, livePath, backupPath string) (string, error) 
 	if usage[UnreadableRecordID] > 0 {
 		return "", fmt.Errorf("recovery keyring cannot decrypt %d queue record(s)", usage[UnreadableRecordID])
 	}
+	// Recovery intentionally reinstates the backup verbatim, including any key
+	// revoked after that backup was taken. Preserve the current live keyring so
+	// the operator can reverse an accidental or stale recovery.
+	live, err := LoadKeyring(livePath)
+	if err != nil {
+		return "", fmt.Errorf("load live keyring before recovery: %w", err)
+	}
+	if err := live.Save(livePath + ".pre-recover"); err != nil {
+		return "", fmt.Errorf("preserve live keyring before recovery: %w", err)
+	}
 	if err := backup.Save(livePath); err != nil {
 		return "", err
 	}
@@ -171,7 +182,17 @@ func lockQueueForKeyMaintenance(dir string, maxPayloadBytes uint64) (*Queue, err
 	if maxPayloadBytes == 0 {
 		maxPayloadBytes = conductor.MaxAuditPayloadBytes
 	}
-	root, pending, inflight, dead, err := ensurePrivateQueueDirs(filepath.Clean(dir))
+	cleanDir := filepath.Clean(dir)
+	for _, required := range []string{cleanDir, filepath.Join(cleanDir, "pending"), filepath.Join(cleanDir, "inflight"), filepath.Join(cleanDir, "dead")} {
+		info, err := os.Lstat(required)
+		if err != nil {
+			return nil, fmt.Errorf("auditbatcher: maintenance requires an initialized queue at %s: %w", cleanDir, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return nil, fmt.Errorf("auditbatcher: maintenance queue path %s must be a real directory", required)
+		}
+	}
+	root, pending, inflight, dead, err := ensurePrivateQueueDirs(cleanDir)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/conductor/auditbatcher/key_usage_test.go
+++ b/enterprise/conductor/auditbatcher/key_usage_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -147,5 +148,216 @@ func TestQueueKeyMaintenanceLifecycleAcrossRecordStates(t *testing.T) {
 	defer func() { _ = live.Close() }()
 	if _, err := InspectQueueKeys(queueDir, 0, rotated); !errors.Is(err, ErrQueueLocked) {
 		t.Fatalf("InspectQueueKeys(live queue) error = %v, want ErrQueueLocked", err)
+	}
+}
+
+func TestQueueKeyMaintenanceReportsUnreadableRecordsAndRefusesDestructiveChanges(t *testing.T) {
+	root := t.TempDir()
+	queueDir := filepath.Join(root, "queue")
+	keyringPath := filepath.Join(root, "keys", "keyring.json")
+	backupPath := filepath.Join(root, "keys", "backup.json")
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldID := keyring.ActiveKeyID()
+	if _, err := keyring.Rotate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureKeyringParent(keyringPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := keyring.Save(keyringPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := keyring.Save(backupPath); err != nil {
+		t.Fatal(err)
+	}
+	q, err := Open(Config{Dir: queueDir, Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(q.deadDir, "00000000000000000001-corrupt.json"), []byte("{bad"), fileMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	usage, err := InspectQueueKeys(queueDir, 0, keyring)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage[UnreadableRecordID] != 1 {
+		t.Fatalf("unreadable usage = %#v, want 1", usage)
+	}
+	if _, _, err := RotateQueueKeyring(queueDir, keyringPath, backupPath); err == nil || !strings.Contains(err.Error(), "unreadable") {
+		t.Fatalf("RotateQueueKeyring error = %v, want unreadable refusal", err)
+	}
+	if err := RevokeQueueKeyringKey(queueDir, keyringPath, oldID); err == nil || !strings.Contains(err.Error(), "unreadable") {
+		t.Fatalf("RevokeQueueKeyringKey error = %v, want unreadable refusal", err)
+	}
+	if _, err := RecoverQueueKeyring(queueDir, keyringPath, backupPath); err == nil || !strings.Contains(err.Error(), "cannot decrypt") {
+		t.Fatalf("RecoverQueueKeyring error = %v, want unreadable refusal", err)
+	}
+}
+
+func TestQueueKeyMaintenanceErrorPaths(t *testing.T) {
+	root := t.TempDir()
+	queueDir := filepath.Join(root, "queue")
+	keyringPath := filepath.Join(root, "keys", "keyring.json")
+	backupPath := filepath.Join(root, "backup", "keyring.json")
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureKeyringParent(keyringPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := keyring.Save(keyringPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureKeyringParent(backupPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := keyring.Save(backupPath); err != nil {
+		t.Fatal(err)
+	}
+	q, err := Open(Config{Dir: queueDir, Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, run := range map[string]func() error{
+		"rotate":  func() error { _, _, err := RotateQueueKeyring(queueDir, keyringPath, backupPath); return err },
+		"migrate": func() error { _, err := MigrateQueueKeyring(queueDir, keyringPath); return err },
+		"revoke":  func() error { return RevokeQueueKeyringKey(queueDir, keyringPath, "missing") },
+		"recover": func() error { _, err := RecoverQueueKeyring(queueDir, keyringPath, backupPath); return err },
+	} {
+		t.Run("locked "+name, func(t *testing.T) {
+			if err := run(); !errors.Is(err, ErrQueueLocked) {
+				t.Fatalf("error = %v, want ErrQueueLocked", err)
+			}
+		})
+	}
+	if err := q.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	missing := filepath.Join(root, "missing-keyring.json")
+	for name, run := range map[string]func() error{
+		"rotate":  func() error { _, _, err := RotateQueueKeyring(queueDir, missing, backupPath); return err },
+		"migrate": func() error { _, err := MigrateQueueKeyring(queueDir, missing); return err },
+		"revoke":  func() error { return RevokeQueueKeyringKey(queueDir, missing, "missing") },
+		"recover": func() error { _, err := RecoverQueueKeyring(queueDir, keyringPath, missing); return err },
+	} {
+		t.Run("missing keyring "+name, func(t *testing.T) {
+			if err := run(); err == nil {
+				t.Fatal("error = nil")
+			}
+		})
+	}
+
+	parentFile := filepath.Join(root, "backup-parent-file")
+	if err := os.WriteFile(parentFile, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := RotateQueueKeyring(queueDir, keyringPath, filepath.Join(parentFile, "backup.json")); err == nil || !strings.Contains(err.Error(), "pre-rotation") {
+		t.Fatalf("RotateQueueKeyring(pre-rotation backup) error = %v", err)
+	}
+
+	backupDir := filepath.Join(root, "backup-as-directory")
+	if err := os.MkdirAll(backupDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := RotateQueueKeyring(queueDir, keyringPath, backupDir); err == nil || !strings.Contains(err.Error(), "rotated keyring backup") {
+		t.Fatalf("RotateQueueKeyring(directory backup) error = %v", err)
+	}
+
+	if _, err := RecoverQueueKeyring(queueDir, backupDir, backupPath); err == nil {
+		t.Fatal("RecoverQueueKeyring(directory live path) error = nil")
+	}
+}
+
+func TestKeyUsageLockedReportsFilesystemAndLimitErrors(t *testing.T) {
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := Open(Config{Dir: t.TempDir(), Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = q.Close() }()
+	if err := os.RemoveAll(q.deadDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := q.keyUsageLocked(); err == nil {
+		t.Fatal("keyUsageLocked(missing dir) error = nil")
+	}
+	if err := os.MkdirAll(q.deadDir, dirMode); err != nil {
+		t.Fatal(err)
+	}
+	name := "00000000000000000001-record.json"
+	if err := os.WriteFile(filepath.Join(q.pendingDir, name), []byte("{}"), fileMode); err != nil {
+		t.Fatal(err)
+	}
+	q.maxPayloadBytes = ^uint64(0)
+	if _, err := q.keyUsageLocked(); err == nil || errors.Is(err, ErrCorruptRecord) {
+		t.Fatalf("keyUsageLocked(limit) error = %v, want non-corrupt configuration error", err)
+	}
+}
+
+func TestLockQueueForKeyMaintenanceReportsDirectoryFailure(t *testing.T) {
+	parentFile := filepath.Join(t.TempDir(), "parent-file")
+	if err := os.WriteFile(parentFile, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lockQueueForKeyMaintenance(filepath.Join(parentFile, "queue"), 0); err == nil {
+		t.Fatal("lockQueueForKeyMaintenance(file parent) error = nil")
+	}
+}
+
+func TestMigrateQueueKeyringRejectsRecordsEncryptedByAnotherKey(t *testing.T) {
+	root := t.TempDir()
+	queueDir := filepath.Join(root, "queue")
+	writer, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := Open(Config{Dir: queueDir, Keyring: writer})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := q.Enqueue(signedTestBatch(t, "wrong-key-record", privateKey)); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	wrong, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongPath := filepath.Join(root, "wrong", "keyring.json")
+	if err := EnsureKeyringParent(wrongPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := wrong.Save(wrongPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MigrateQueueKeyring(queueDir, wrongPath); !errors.Is(err, errQueueKeyUnavailable) {
+		t.Fatalf("MigrateQueueKeyring(wrong key) error = %v, want errQueueKeyUnavailable", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(queueDir, "pending"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("pending records = %d, want original record preserved", len(entries))
 	}
 }

--- a/enterprise/conductor/auditbatcher/key_usage_test.go
+++ b/enterprise/conductor/auditbatcher/key_usage_test.go
@@ -291,8 +291,20 @@ func TestQueueKeyMaintenanceErrorPaths(t *testing.T) {
 	if err := os.MkdirAll(backupDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := RotateQueueKeyring(queueDir, keyringPath, backupDir); err == nil || !strings.Contains(err.Error(), "rotated keyring backup") {
+	activeBeforeRotation := keyring.ActiveKeyID()
+	oldID, newID, err := RotateQueueKeyring(queueDir, keyringPath, backupDir)
+	if err == nil || !strings.Contains(err.Error(), "rotated keyring backup") {
 		t.Fatalf("RotateQueueKeyring(directory backup) error = %v", err)
+	}
+	if oldID != activeBeforeRotation || newID == "" || newID == oldID {
+		t.Fatalf("RotateQueueKeyring(directory backup) IDs = (%q, %q), want (%q, new non-empty ID)", oldID, newID, activeBeforeRotation)
+	}
+	rotated, err := LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotated.ActiveKeyID() != newID {
+		t.Fatalf("persisted active key = %q, want returned new ID %q", rotated.ActiveKeyID(), newID)
 	}
 
 	if _, err := RecoverQueueKeyring(queueDir, backupDir, backupPath); err == nil {

--- a/enterprise/conductor/auditbatcher/key_usage_test.go
+++ b/enterprise/conductor/auditbatcher/key_usage_test.go
@@ -1,0 +1,151 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package auditbatcher
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestQueueKeyMaintenanceLifecycleAcrossRecordStates(t *testing.T) {
+	root := t.TempDir()
+	queueDir := filepath.Join(root, "queue")
+	keyringPath := filepath.Join(root, "secrets", "keyring.json")
+	backupPath := filepath.Join(root, "backups", "keyring.json")
+	if _, err := InspectQueueKeys(queueDir, 0, nil); err == nil {
+		t.Fatal("InspectQueueKeys(nil keyring) error = nil")
+	}
+
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureKeyringParent(keyringPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := keyring.Save(keyringPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureKeyringParent(backupPath); err != nil {
+		t.Fatal(err)
+	}
+	oldID := keyring.ActiveKeyID()
+
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := Open(Config{Dir: queueDir, Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := q.Enqueue(signedTestBatch(t, "batch-dead", priv)); err != nil {
+		t.Fatal(err)
+	}
+	deadLease, err := q.Claim()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Drop(deadLease.ID, "maintenance-test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := q.Enqueue(signedTestBatch(t, "batch-inflight", priv)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := q.Claim(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := q.Enqueue(signedTestBatch(t, "batch-pending", priv)); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	legacyName := "00000000000000000004-batch-legacy-0000000000000000.json"
+	legacyPath := filepath.Join(queueDir, "pending", legacyName)
+	if err := writeDiskRecord(legacyPath, validDiskRecord(signedTestBatch(t, "batch-legacy-maintenance", priv))); err != nil {
+		t.Fatal(err)
+	}
+
+	usage, err := InspectQueueKeys(queueDir, 0, keyring)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage[oldID] != 3 || usage[LegacyKeyID] != 1 {
+		t.Fatalf("initial key usage = %#v, want active=3 legacy=1", usage)
+	}
+
+	rotatedOldID, newID, err := RotateQueueKeyring(queueDir, keyringPath, backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotatedOldID != oldID || newID == oldID {
+		t.Fatalf("rotation IDs old=%q new=%q, want old=%q and distinct new", rotatedOldID, newID, oldID)
+	}
+	for _, path := range []string{backupPath, backupPath + ".previous"} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("rotation backup %s: %v", path, err)
+		}
+	}
+
+	rotated, err := LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage, err = InspectQueueKeys(queueDir, 0, rotated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage[newID] != 4 || usage[oldID] != 0 || usage[LegacyKeyID] != 0 {
+		t.Fatalf("rotated key usage = %#v, want new active=4", usage)
+	}
+	migratedID, err := MigrateQueueKeyring(queueDir, keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if migratedID != newID {
+		t.Fatalf("MigrateQueueKeyring active = %q, want %q", migratedID, newID)
+	}
+	if err := RevokeQueueKeyringKey(queueDir, keyringPath, newID); err == nil {
+		t.Fatal("RevokeQueueKeyringKey(active) error = nil")
+	}
+	if err := RevokeQueueKeyringKey(queueDir, keyringPath, oldID); err != nil {
+		t.Fatal(err)
+	}
+
+	recoveredID, err := RecoverQueueKeyring(queueDir, keyringPath, backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recoveredID != newID {
+		t.Fatalf("RecoverQueueKeyring active = %q, want %q", recoveredID, newID)
+	}
+
+	wrong, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongPath := filepath.Join(root, "secrets", "wrong.json")
+	if err := wrong.Save(wrongPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RecoverQueueKeyring(queueDir, keyringPath, wrongPath); err == nil {
+		t.Fatal("RecoverQueueKeyring(wrong key) error = nil")
+	}
+
+	live, err := Open(Config{Dir: queueDir, Keyring: rotated})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = live.Close() }()
+	if _, err := InspectQueueKeys(queueDir, 0, rotated); !errors.Is(err, ErrQueueLocked) {
+		t.Fatalf("InspectQueueKeys(live queue) error = %v, want ErrQueueLocked", err)
+	}
+}

--- a/enterprise/conductor/auditbatcher/key_usage_test.go
+++ b/enterprise/conductor/auditbatcher/key_usage_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -120,6 +121,13 @@ func TestQueueKeyMaintenanceLifecycleAcrossRecordStates(t *testing.T) {
 	if err := RevokeQueueKeyringKey(queueDir, keyringPath, oldID); err != nil {
 		t.Fatal(err)
 	}
+	revoked, err := LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(revoked.KeyIDs(), oldID) {
+		t.Fatalf("revoked key %q remains before recovery", oldID)
+	}
 
 	recoveredID, err := RecoverQueueKeyring(queueDir, keyringPath, backupPath)
 	if err != nil {
@@ -127,6 +135,20 @@ func TestQueueKeyMaintenanceLifecycleAcrossRecordStates(t *testing.T) {
 	}
 	if recoveredID != newID {
 		t.Fatalf("RecoverQueueKeyring active = %q, want %q", recoveredID, newID)
+	}
+	recovered, err := LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(recovered.KeyIDs(), oldID) {
+		t.Fatalf("recovery did not intentionally reinstate backup key %q", oldID)
+	}
+	preRecover, err := LoadKeyring(keyringPath + ".pre-recover")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(preRecover.KeyIDs(), oldID) {
+		t.Fatalf("pre-recover snapshot unexpectedly contains revoked key %q", oldID)
 	}
 
 	wrong, err := NewKeyring()
@@ -275,6 +297,28 @@ func TestQueueKeyMaintenanceErrorPaths(t *testing.T) {
 
 	if _, err := RecoverQueueKeyring(queueDir, backupDir, backupPath); err == nil {
 		t.Fatal("RecoverQueueKeyring(directory live path) error = nil")
+	}
+}
+
+func TestQueueKeyMaintenanceRefusesUninitializedQueue(t *testing.T) {
+	root := t.TempDir()
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyringPath := filepath.Join(root, "keys", "keyring.json")
+	if err := EnsureKeyringParent(keyringPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := keyring.Save(keyringPath); err != nil {
+		t.Fatal(err)
+	}
+	queueDir := filepath.Join(root, "mistyped-queue")
+	if err := RevokeQueueKeyringKey(queueDir, keyringPath, "missing"); err == nil || !strings.Contains(err.Error(), "initialized queue") {
+		t.Fatalf("RevokeQueueKeyringKey(uninitialized) error = %v", err)
+	}
+	if _, err := os.Stat(queueDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("maintenance created typo queue: %v", err)
 	}
 }
 

--- a/enterprise/conductor/auditbatcher/keyring.go
+++ b/enterprise/conductor/auditbatcher/keyring.go
@@ -129,6 +129,9 @@ func (k *Keyring) marshal() ([]byte, error) {
 		return nil, fmt.Errorf("auditbatcher: encode queue keyring: %w", err)
 	}
 	data = append(data, '\n')
+	if len(data) > keyringMaxSize {
+		return nil, fmt.Errorf("auditbatcher: queue keyring size %d exceeds %d-byte limit; revoke unused keys before rotating further", len(data), keyringMaxSize)
+	}
 	return data, nil
 }
 
@@ -201,8 +204,14 @@ func (k *Keyring) Rotate() (string, error) {
 	if k.keys == nil {
 		k.keys = make(map[string][queueKeyBytes]byte)
 	}
+	oldActive := k.active
 	k.keys[id] = key
 	k.active = id
+	if _, err := k.marshal(); err != nil {
+		delete(k.keys, id)
+		k.active = oldActive
+		return "", err
+	}
 	return id, nil
 }
 

--- a/enterprise/conductor/auditbatcher/keyring.go
+++ b/enterprise/conductor/auditbatcher/keyring.go
@@ -1,0 +1,219 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package auditbatcher
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/securefile"
+)
+
+const (
+	keyringVersion = 1
+	queueKeyBytes  = 32
+	keyringMaxSize = 64 * 1024
+)
+
+// KeyringFile is the durable operator format for audit-queue encryption keys.
+// The active key encrypts new records; retained keys decrypt records written
+// before rotation. Key IDs are derived from key material and cannot be chosen
+// independently.
+type KeyringFile struct {
+	Version     int               `json:"version"`
+	ActiveKeyID string            `json:"active_key_id"`
+	Keys        map[string]string `json:"keys"`
+}
+
+// Keyring is a validated in-memory keyring. Lifecycle commands mutate a
+// private instance and persist it atomically; runtimes only read their loaded
+// instance.
+type Keyring struct {
+	active string
+	keys   map[string][queueKeyBytes]byte
+}
+
+func NewKeyring() (*Keyring, error) {
+	key, err := randomQueueKey()
+	if err != nil {
+		return nil, err
+	}
+	id := queueKeyID(key[:])
+	return &Keyring{active: id, keys: map[string][queueKeyBytes]byte{id: key}}, nil
+}
+
+func LoadKeyring(path string) (*Keyring, error) {
+	data, err := securefile.Read(filepath.Clean(path), securefile.Options{
+		MaxBytes:        keyringMaxSize,
+		DisallowedPerms: 0o037,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("auditbatcher: read queue keyring: %w", err)
+	}
+	var file KeyringFile
+	if err := contract.DecodeStrictJSON(data, &file); err != nil {
+		return nil, fmt.Errorf("auditbatcher: decode queue keyring: %w", err)
+	}
+	return parseKeyringFile(file)
+}
+
+func parseKeyringFile(file KeyringFile) (*Keyring, error) {
+	if file.Version != keyringVersion {
+		return nil, fmt.Errorf("auditbatcher: queue keyring version=%d want=%d", file.Version, keyringVersion)
+	}
+	if len(file.Keys) == 0 {
+		return nil, errors.New("auditbatcher: queue keyring has no keys")
+	}
+	keys := make(map[string][queueKeyBytes]byte, len(file.Keys))
+	for id, encoded := range file.Keys {
+		raw, err := hex.DecodeString(strings.TrimSpace(encoded))
+		if err != nil || len(raw) != queueKeyBytes {
+			return nil, fmt.Errorf("auditbatcher: queue keyring key %q must be %d-byte hex", id, queueKeyBytes)
+		}
+		derived := queueKeyID(raw)
+		if id != derived {
+			return nil, fmt.Errorf("auditbatcher: queue keyring key id %q does not match derived id %q", id, derived)
+		}
+		var key [queueKeyBytes]byte
+		copy(key[:], raw)
+		keys[id] = key
+	}
+	if _, ok := keys[file.ActiveKeyID]; !ok {
+		return nil, fmt.Errorf("auditbatcher: active queue key %q is absent", file.ActiveKeyID)
+	}
+	return &Keyring{active: file.ActiveKeyID, keys: keys}, nil
+}
+
+func (k *Keyring) File() (KeyringFile, error) {
+	if k == nil || k.active == "" || len(k.keys) == 0 {
+		return KeyringFile{}, errors.New("auditbatcher: invalid empty queue keyring")
+	}
+	keys := make(map[string]string, len(k.keys))
+	for id, key := range k.keys {
+		keys[id] = hex.EncodeToString(key[:])
+	}
+	return KeyringFile{Version: keyringVersion, ActiveKeyID: k.active, Keys: keys}, nil
+}
+
+func (k *Keyring) Save(path string) error {
+	file, err := k.File()
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(file)
+	if err != nil {
+		return fmt.Errorf("auditbatcher: encode queue keyring: %w", err)
+	}
+	data = append(data, '\n')
+	if err := atomicfile.Write(filepath.Clean(path), data, 0o600); err != nil {
+		return fmt.Errorf("auditbatcher: write queue keyring: %w", err)
+	}
+	return nil
+}
+
+func (k *Keyring) Rotate() (string, error) {
+	if k == nil {
+		return "", errors.New("auditbatcher: nil queue keyring")
+	}
+	key, err := randomQueueKey()
+	if err != nil {
+		return "", err
+	}
+	id := queueKeyID(key[:])
+	if k.keys == nil {
+		k.keys = make(map[string][queueKeyBytes]byte)
+	}
+	k.keys[id] = key
+	k.active = id
+	return id, nil
+}
+
+func (k *Keyring) Revoke(id string, inUse map[string]int) error {
+	if k == nil {
+		return errors.New("auditbatcher: nil queue keyring")
+	}
+	if id == k.active {
+		return fmt.Errorf("auditbatcher: cannot revoke active queue key %q", id)
+	}
+	if inUse[id] > 0 {
+		return fmt.Errorf("auditbatcher: cannot revoke queue key %q: %d record(s) still use it", id, inUse[id])
+	}
+	if _, ok := k.keys[id]; !ok {
+		return fmt.Errorf("auditbatcher: queue key %q not found", id)
+	}
+	delete(k.keys, id)
+	return nil
+}
+
+func (k *Keyring) ActiveKeyID() string {
+	if k == nil {
+		return ""
+	}
+	return k.active
+}
+
+func (k *Keyring) KeyIDs() []string {
+	if k == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(k.keys))
+	for id := range k.keys {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (k *Keyring) activeKey() (string, [queueKeyBytes]byte, error) {
+	if k == nil {
+		return "", [queueKeyBytes]byte{}, errors.New("auditbatcher: queue encryption keyring required")
+	}
+	key, ok := k.keys[k.active]
+	if !ok {
+		return "", [queueKeyBytes]byte{}, errors.New("auditbatcher: active queue encryption key unavailable")
+	}
+	return k.active, key, nil
+}
+
+func (k *Keyring) key(id string) ([queueKeyBytes]byte, bool) {
+	if k == nil {
+		return [queueKeyBytes]byte{}, false
+	}
+	key, ok := k.keys[id]
+	return key, ok
+}
+
+func randomQueueKey() ([queueKeyBytes]byte, error) {
+	var key [queueKeyBytes]byte
+	if _, err := rand.Read(key[:]); err != nil {
+		return key, fmt.Errorf("auditbatcher: generate queue encryption key: %w", err)
+	}
+	return key, nil
+}
+
+func queueKeyID(key []byte) string {
+	sum := sha256.Sum256(key)
+	return "sha256:" + hex.EncodeToString(sum[:8])
+}
+
+// EnsureKeyringParent creates the private parent used by lifecycle commands.
+func EnsureKeyringParent(path string) error {
+	dir := filepath.Dir(filepath.Clean(path))
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("auditbatcher: create queue keyring parent: %w", err)
+	}
+	return nil
+}

--- a/enterprise/conductor/auditbatcher/keyring.go
+++ b/enterprise/conductor/auditbatcher/keyring.go
@@ -109,19 +109,84 @@ func (k *Keyring) File() (KeyringFile, error) {
 }
 
 func (k *Keyring) Save(path string) error {
-	file, err := k.File()
+	data, err := k.marshal()
 	if err != nil {
 		return err
 	}
-	data, err := json.Marshal(file)
-	if err != nil {
-		return fmt.Errorf("auditbatcher: encode queue keyring: %w", err)
-	}
-	data = append(data, '\n')
 	if err := atomicfile.Write(filepath.Clean(path), data, 0o600); err != nil {
 		return fmt.Errorf("auditbatcher: write queue keyring: %w", err)
 	}
 	return nil
+}
+
+func (k *Keyring) marshal() ([]byte, error) {
+	file, err := k.File()
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.Marshal(file)
+	if err != nil {
+		return nil, fmt.Errorf("auditbatcher: encode queue keyring: %w", err)
+	}
+	data = append(data, '\n')
+	return data, nil
+}
+
+// LoadOrCreateKeyring reuses a valid durable keyring and creates one only when
+// absent. Creation publishes a fully written temporary file with an atomic
+// no-replace hard link, so concurrent callers cannot overwrite or observe a
+// partially written keyring.
+func LoadOrCreateKeyring(path string) (*Keyring, error) {
+	clean := filepath.Clean(path)
+	keyring, err := LoadKeyring(clean)
+	if err == nil {
+		return keyring, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if err := EnsureKeyringParent(clean); err != nil {
+		return nil, err
+	}
+	keyring, err = NewKeyring()
+	if err != nil {
+		return nil, err
+	}
+	data, err := keyring.marshal()
+	if err != nil {
+		return nil, err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(clean), ".keyring-init-*")
+	if err != nil {
+		return nil, fmt.Errorf("auditbatcher: create queue keyring temporary file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("auditbatcher: chmod queue keyring temporary file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("auditbatcher: write queue keyring temporary file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("auditbatcher: sync queue keyring temporary file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, fmt.Errorf("auditbatcher: close queue keyring temporary file: %w", err)
+	}
+	if err := os.Link(tmpPath, clean); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return LoadKeyring(clean)
+		}
+		return nil, fmt.Errorf("auditbatcher: publish queue keyring exclusively: %w", err)
+	}
+	if err := fsyncDir(filepath.Dir(clean)); err != nil {
+		return nil, fmt.Errorf("auditbatcher: sync queue keyring parent: %w", err)
+	}
+	return keyring, nil
 }
 
 func (k *Keyring) Rotate() (string, error) {

--- a/enterprise/conductor/auditbatcher/keyring_edge_test.go
+++ b/enterprise/conductor/auditbatcher/keyring_edge_test.go
@@ -1,0 +1,175 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package auditbatcher
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestKeyringValidationAndAccessors(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, queueKeyBytes)
+	id := queueKeyID(key)
+	encoded := hex.EncodeToString(key)
+	for _, tc := range []struct {
+		name string
+		file KeyringFile
+	}{
+		{name: "version", file: KeyringFile{Version: 2, ActiveKeyID: id, Keys: map[string]string{id: encoded}}},
+		{name: "empty", file: KeyringFile{Version: keyringVersion}},
+		{name: "invalid hex", file: KeyringFile{Version: keyringVersion, ActiveKeyID: id, Keys: map[string]string{id: "zz"}}},
+		{name: "derived id mismatch", file: KeyringFile{Version: keyringVersion, ActiveKeyID: "wrong", Keys: map[string]string{"wrong": encoded}}},
+		{name: "active absent", file: KeyringFile{Version: keyringVersion, ActiveKeyID: "missing", Keys: map[string]string{id: encoded}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseKeyringFile(tc.file); err == nil {
+				t.Fatal("parseKeyringFile error = nil")
+			}
+		})
+	}
+
+	if _, err := (*Keyring)(nil).File(); err == nil {
+		t.Fatal("nil File error = nil")
+	}
+	if err := (*Keyring)(nil).Save(filepath.Join(t.TempDir(), "keyring.json")); err == nil {
+		t.Fatal("nil Save error = nil")
+	}
+	if _, err := (*Keyring)(nil).Rotate(); err == nil {
+		t.Fatal("nil Rotate error = nil")
+	}
+	if err := (*Keyring)(nil).Revoke("missing", nil); err == nil {
+		t.Fatal("nil Revoke error = nil")
+	}
+	if got := (*Keyring)(nil).ActiveKeyID(); got != "" {
+		t.Fatalf("nil ActiveKeyID = %q", got)
+	}
+	if got := (*Keyring)(nil).KeyIDs(); got != nil {
+		t.Fatalf("nil KeyIDs = %#v", got)
+	}
+	if _, ok := (*Keyring)(nil).key("missing"); ok {
+		t.Fatal("nil key lookup succeeded")
+	}
+	if _, _, err := (*Keyring)(nil).activeKey(); err == nil {
+		t.Fatal("nil activeKey error = nil")
+	}
+
+	empty := &Keyring{}
+	if _, _, err := empty.activeKey(); err == nil {
+		t.Fatal("empty activeKey error = nil")
+	}
+	first, err := empty.Rotate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := empty.Rotate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := empty.KeyIDs()
+	if len(ids) != 2 || !slices.IsSorted(ids) {
+		t.Fatalf("KeyIDs = %#v, want two sorted IDs", ids)
+	}
+	if err := empty.Revoke("missing", nil); err == nil {
+		t.Fatal("Revoke(missing) error = nil")
+	}
+	if err := empty.Revoke(first, nil); err != nil {
+		t.Fatalf("Revoke(retained): %v", err)
+	}
+	if _, ok := empty.key(first); ok {
+		t.Fatal("revoked key remains readable")
+	}
+	if empty.ActiveKeyID() != second {
+		t.Fatalf("ActiveKeyID = %q, want %q", empty.ActiveKeyID(), second)
+	}
+}
+
+func TestKeyringLoadSaveAndParentErrors(t *testing.T) {
+	malformed := filepath.Join(t.TempDir(), "malformed.json")
+	if err := os.WriteFile(malformed, []byte("{bad"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadKeyring(malformed); err == nil || !strings.Contains(err.Error(), "decode queue keyring") {
+		t.Fatalf("LoadKeyring(malformed) error = %v", err)
+	}
+
+	parentFile := filepath.Join(t.TempDir(), "parent-file")
+	if err := os.WriteFile(parentFile, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(parentFile, "keyring.json")
+	if err := EnsureKeyringParent(child); err == nil {
+		t.Fatal("EnsureKeyringParent(file parent) error = nil")
+	}
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := keyring.Save(child); err == nil || !strings.Contains(err.Error(), "write queue keyring") {
+		t.Fatalf("Save(file parent) error = %v", err)
+	}
+}
+
+func TestEncryptedRecordEnvelopeValidation(t *testing.T) {
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := encryptDiskRecord(diskRecord{}, nil); err == nil {
+		t.Fatal("encryptDiskRecord(nil keyring) error = nil")
+	}
+
+	for _, tc := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "malformed", data: []byte("{bad")},
+		{name: "missing version", data: []byte(`{"key_id":"x"}`)},
+		{name: "invalid version", data: []byte(`{"version":"two"}`)},
+		{name: "invalid legacy", data: []byte(`{"version":1,"unexpected":true}`)},
+		{name: "invalid encrypted", data: []byte(`{"version":2,"unexpected":true}`)},
+		{name: "unsupported", data: []byte(`{"version":99}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, _, err := decryptDiskRecord(tc.data, keyring); err == nil {
+				t.Fatal("decryptDiskRecord error = nil")
+			}
+		})
+	}
+
+	badNonce, err := json.Marshal(encryptedDiskRecord{Version: encryptedRecordVersion, KeyID: keyring.ActiveKeyID(), Nonce: []byte{1}, Ciphertext: []byte{2}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := decryptDiskRecord(badNonce, keyring); err == nil || !strings.Contains(err.Error(), "nonce") {
+		t.Fatalf("bad nonce error = %v", err)
+	}
+
+	id, key, err := keyring.activeKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	aead, err := queueAEAD(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := make([]byte, aead.NonceSize())
+	invalidPlaintext, err := json.Marshal(encryptedDiskRecord{
+		Version: encryptedRecordVersion, KeyID: id, Nonce: nonce,
+		Ciphertext: aead.Seal(nil, nonce, []byte("{bad"), recordAAD(id)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := decryptDiskRecord(invalidPlaintext, keyring); err == nil || !strings.Contains(err.Error(), "decode record plaintext") {
+		t.Fatalf("invalid plaintext error = %v", err)
+	}
+}

--- a/enterprise/conductor/auditbatcher/keyring_edge_test.go
+++ b/enterprise/conductor/auditbatcher/keyring_edge_test.go
@@ -7,8 +7,10 @@ package auditbatcher
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -143,6 +145,41 @@ func TestLoadKeyringRejectsOversizedAndPermissiveFiles(t *testing.T) {
 	chmodTestFixture(t, permissive, 0o622)
 	if _, err := LoadKeyring(permissive); err == nil {
 		t.Fatal("LoadKeyring(permissive) error = nil")
+	}
+}
+
+func TestKeyringRefusesUnreloadableRotation(t *testing.T) {
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; ; i++ {
+		key := sha256.Sum256([]byte(fmt.Sprintf("retained-key-%d", i)))
+		id := queueKeyID(key[:])
+		keyring.keys[id] = key
+		if _, err := keyring.marshal(); err != nil {
+			delete(keyring.keys, id)
+			break
+		}
+	}
+	activeBefore := keyring.ActiveKeyID()
+	countBefore := len(keyring.KeyIDs())
+	if _, err := keyring.Rotate(); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("Rotate(oversized) error = %v, want size-limit refusal", err)
+	}
+	if keyring.ActiveKeyID() != activeBefore || len(keyring.KeyIDs()) != countBefore {
+		t.Fatal("failed rotation mutated the keyring")
+	}
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	if err := keyring.Save(path); err != nil {
+		t.Fatalf("Save(keyring after refused rotation): %v", err)
+	}
+	reloaded, err := LoadKeyring(path)
+	if err != nil {
+		t.Fatalf("LoadKeyring(after refused rotation): %v", err)
+	}
+	if reloaded.ActiveKeyID() != activeBefore {
+		t.Fatalf("reloaded active key = %q, want %q", reloaded.ActiveKeyID(), activeBefore)
 	}
 }
 

--- a/enterprise/conductor/auditbatcher/keyring_edge_test.go
+++ b/enterprise/conductor/auditbatcher/keyring_edge_test.go
@@ -11,8 +11,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -115,6 +117,91 @@ func TestKeyringLoadSaveAndParentErrors(t *testing.T) {
 	}
 	if err := keyring.Save(child); err == nil || !strings.Contains(err.Error(), "write queue keyring") {
 		t.Fatalf("Save(file parent) error = %v", err)
+	}
+}
+
+func TestLoadKeyringRejectsOversizedAndPermissiveFiles(t *testing.T) {
+	oversized := filepath.Join(t.TempDir(), "oversized.json")
+	if err := os.WriteFile(oversized, bytes.Repeat([]byte{'x'}, keyringMaxSize+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadKeyring(oversized); err == nil {
+		t.Fatal("LoadKeyring(oversized) error = nil")
+	}
+
+	if runtime.GOOS == "windows" {
+		return
+	}
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	permissive := filepath.Join(t.TempDir(), "permissive.json")
+	if err := keyring.Save(permissive); err != nil {
+		t.Fatal(err)
+	}
+	chmodTestFixture(t, permissive, 0o622)
+	if _, err := LoadKeyring(permissive); err == nil {
+		t.Fatal("LoadKeyring(permissive) error = nil")
+	}
+}
+
+func TestLoadOrCreateKeyringReusesAndConvergesConcurrently(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets", "keyring.json")
+	const callers = 8
+	ids := make(chan string, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			keyring, err := LoadOrCreateKeyring(path)
+			if err != nil {
+				errs <- err
+				return
+			}
+			ids <- keyring.ActiveKeyID()
+		}()
+	}
+	wg.Wait()
+	close(ids)
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	want := ""
+	for id := range ids {
+		if want == "" {
+			want = id
+		}
+		if id != want {
+			t.Fatalf("concurrent keyring id = %q, want %q", id, want)
+		}
+	}
+	loaded, err := LoadOrCreateKeyring(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.ActiveKeyID() != want {
+		t.Fatalf("reused keyring id = %q, want %q", loaded.ActiveKeyID(), want)
+	}
+}
+
+func TestLoadOrCreateKeyringFailsClosedOnInvalidExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	if err := os.WriteFile(path, []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadOrCreateKeyring(path); err == nil || !strings.Contains(err.Error(), "decode queue keyring") {
+		t.Fatalf("LoadOrCreateKeyring(invalid) error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "not-json" {
+		t.Fatalf("invalid durable keyring was overwritten: %q", data)
 	}
 }
 

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -34,7 +34,7 @@ func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey recorder: %v", err)
 	}
-	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
 	if err != nil {
 		t.Fatalf("Open queue: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestProducer_CloseRacesWithObserver(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
-	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
 	if err != nil {
 		t.Fatalf("Open queue: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestNewProducer_RequiresRecorderPublicKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
-	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
 	if err != nil {
 		t.Fatalf("Open queue: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestNewProducer_RejectsInvalidConfig(t *testing.T) {
 		t.Fatalf("GenerateKey: %v", err)
 	}
 	pub := priv.Public().(ed25519.PublicKey)
-	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
 	if err != nil {
 		t.Fatalf("Open queue: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestProducer_AdvancesChainTailOnDroppedSegment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
-	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue"), MaxPending: 1})
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue"), MaxPending: 1})
 	if err != nil {
 		t.Fatalf("Open queue: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestProducer_AdvancesTailAndRecordsMetricOnInvalidCheckpoint(t *testing.T) 
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
-	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
 	if err != nil {
 		t.Fatalf("Open queue: %v", err)
 	}
@@ -355,7 +355,7 @@ func TestProducer_ReleaseDroppedPreservesConcurrentDrops(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
-	q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
 	if err != nil {
 		t.Fatalf("Open queue: %v", err)
 	}
@@ -421,7 +421,7 @@ func TestProducer_EnqueueSegmentDropPaths(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			q, err := Open(Config{Dir: filepath.Join(t.TempDir(), "queue")})
+			q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
 			if err != nil {
 				t.Fatalf("Open queue: %v", err)
 			}

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -19,7 +19,6 @@
 package auditbatcher
 
 import (
-	"crypto/aes"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -657,6 +656,9 @@ func readRecordWithKeyring(path string, maxPayloadBytes uint64, keyring *Keyring
 
 	record, keyID, legacy, err := decryptDiskRecord(data, keyring)
 	if err != nil {
+		if errors.Is(err, errQueueKeyUnavailable) || errors.Is(err, ErrRecordAuthFailed) {
+			return diskRecord{}, keyID, legacy, err
+		}
 		return diskRecord{}, keyID, legacy, corruptRecordError(err)
 	}
 	if record.Version != recordVersion {
@@ -692,10 +694,10 @@ func encryptedRecordReadLimit(plaintextLimit int64) (int64, error) {
 		return 0, fmt.Errorf("auditbatcher: encrypted record plaintext limit must not be negative: %d", plaintextLimit)
 	}
 	plaintextBytes := uint64(plaintextLimit)
-	if plaintextBytes > maxRecordReadBytes-aes.BlockSize {
+	if plaintextBytes > maxRecordReadBytes-queueAEADOverheadBytes {
 		return 0, fmt.Errorf("auditbatcher: encrypted record plaintext limit too large: %d", plaintextLimit)
 	}
-	ciphertextBytes := plaintextBytes + aes.BlockSize
+	ciphertextBytes := plaintextBytes + queueAEADOverheadBytes
 	// encoding/json represents []byte as padded standard base64. Check before
 	// multiplying so a hostile configured limit cannot wrap the calculation.
 	if ciphertextBytes > ((maxRecordReadBytes-encryptedRecordMetadataBytes)/4)*3-2 {

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -460,7 +460,24 @@ func (q *Queue) migrateRecordsLocked() error {
 			path := filepath.Join(dir, id)
 			record, keyID, legacy, err := readRecordWithKeyring(path, q.maxPayloadBytes, q.keyring)
 			if err != nil {
-				return fmt.Errorf("auditbatcher: migrate queue record %s: %w", id, err)
+				if errors.Is(err, errQueueKeyUnavailable) || !errors.Is(err, ErrCorruptRecord) {
+					return fmt.Errorf("auditbatcher: migrate queue record %s: %w", id, err)
+				}
+				// Dead-letter records are already quarantined evidence. An unreadable
+				// one must not turn a later restart into a permanent availability
+				// failure. Corrupt live records are quarantined atomically here so
+				// the remaining queue can migrate and start.
+				if dir == q.deadDir {
+					continue
+				}
+				deadPath, pathErr := uniqueDeadPath(q.deadDir, id)
+				if pathErr != nil {
+					return fmt.Errorf("auditbatcher: quarantine queue record %s: %w", id, errors.Join(err, pathErr))
+				}
+				if moveErr := moveToDead(path, deadPath); moveErr != nil {
+					return fmt.Errorf("auditbatcher: quarantine queue record %s: %w", id, errors.Join(err, moveErr))
+				}
+				continue
 			}
 			if !legacy && keyID == active {
 				continue

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -19,9 +19,9 @@
 package auditbatcher
 
 import (
+	"crypto/aes"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
-	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/securefile"
 )
 
@@ -62,6 +61,7 @@ type Config struct {
 	Dir             string
 	MaxPending      int
 	MaxPayloadBytes uint64
+	Keyring         *Keyring
 }
 
 type Batch struct {
@@ -92,6 +92,7 @@ type Queue struct {
 	deadDir         string
 	maxPending      int
 	maxPayloadBytes uint64
+	keyring         *Keyring
 	now             func() time.Time
 	mu              sync.Mutex
 	closed          bool
@@ -125,6 +126,9 @@ func Open(cfg Config) (*Queue, error) {
 	if cfg.MaxPayloadBytes == 0 {
 		cfg.MaxPayloadBytes = conductor.MaxAuditPayloadBytes
 	}
+	if cfg.Keyring == nil {
+		return nil, errors.New("auditbatcher: queue encryption keyring required")
+	}
 	dir, pendingDir, inflightDir, deadDir, err := ensurePrivateQueueDirs(cleanDir)
 	if err != nil {
 		return nil, err
@@ -140,6 +144,7 @@ func Open(cfg Config) (*Queue, error) {
 		deadDir:         deadDir,
 		maxPending:      cfg.MaxPending,
 		maxPayloadBytes: cfg.MaxPayloadBytes,
+		keyring:         cfg.Keyring,
 		now:             func() time.Time { return time.Now().UTC() },
 		lockFile:        lockFile,
 	}
@@ -161,6 +166,9 @@ func Open(cfg Config) (*Queue, error) {
 		if err := sweepStaleTempsLocked(dir); err != nil {
 			return nil, err
 		}
+	}
+	if err := q.migrateRecordsLocked(); err != nil {
+		return nil, err
 	}
 	if err := q.recoverInflightLocked(); err != nil {
 		return nil, err
@@ -222,7 +230,7 @@ func (q *Queue) Enqueue(batch Batch) (string, error) {
 		Envelope:   batch.Envelope,
 		Payload:    append([]byte(nil), batch.Payload...),
 	}
-	data, err := json.Marshal(record)
+	data, err := encryptDiskRecord(record, q.keyring)
 	if err != nil {
 		return "", fmt.Errorf("auditbatcher: marshal record: %w", err)
 	}
@@ -266,7 +274,7 @@ func (q *Queue) Claim() (*Lease, error) {
 		if err := fsyncDir(q.inflightDir); err != nil {
 			return nil, err
 		}
-		record, err := readRecord(inflightPath, q.maxPayloadBytes)
+		record, _, _, err := readRecordWithKeyring(inflightPath, q.maxPayloadBytes, q.keyring)
 		if err != nil {
 			if !errors.Is(err, ErrCorruptRecord) {
 				return nil, err
@@ -436,6 +444,39 @@ func (q *Queue) recoverInflightLocked() error {
 	return fsyncDir(q.pendingDir)
 }
 
+// migrateRecordsLocked encrypts legacy plaintext records and re-encrypts
+// records written under retained rotation keys. It runs while Open holds the
+// exclusive queue lock and before inflight recovery, so no worker can observe
+// a partially migrated queue. Each replacement is individually atomic and
+// durable; a crash simply resumes from the remaining records on next Open.
+func (q *Queue) migrateRecordsLocked() error {
+	active := q.keyring.ActiveKeyID()
+	for _, dir := range []string{q.pendingDir, q.inflightDir, q.deadDir} {
+		files, err := listRecordFiles(dir)
+		if err != nil {
+			return err
+		}
+		for _, id := range files {
+			path := filepath.Join(dir, id)
+			record, keyID, legacy, err := readRecordWithKeyring(path, q.maxPayloadBytes, q.keyring)
+			if err != nil {
+				return fmt.Errorf("auditbatcher: migrate queue record %s: %w", id, err)
+			}
+			if !legacy && keyID == active {
+				continue
+			}
+			data, err := encryptDiskRecord(record, q.keyring)
+			if err != nil {
+				return fmt.Errorf("auditbatcher: encrypt queue record %s: %w", id, err)
+			}
+			if err := durableWrite(path, data); err != nil {
+				return fmt.Errorf("auditbatcher: migrate queue record %s: %w", id, err)
+			}
+		}
+	}
+	return nil
+}
+
 // uniqueRecoveryPath finds a free filename in pendingDir for a recovered
 // inflight record. The plain id is tried first; if taken, recovery suffixes
 // are appended after the full original id so recovered records keep the same
@@ -544,23 +585,39 @@ func validateBatch(batch Batch, maxPayloadBytes uint64) error {
 }
 
 func readRecord(path string, maxPayloadBytes uint64) (diskRecord, error) {
+	record, _, _, err := readRecordWithKeyring(path, maxPayloadBytes, nil)
+	return record, err
+}
+
+func (q *Queue) readRecord(path string) (diskRecord, error) {
+	record, _, _, err := readRecordWithKeyring(path, q.maxPayloadBytes, q.keyring)
+	return record, err
+}
+
+func readRecordWithKeyring(path string, maxPayloadBytes uint64, keyring *Keyring) (diskRecord, string, bool, error) {
 	path = filepath.Clean(path)
 	limit, err := recordReadLimit(maxPayloadBytes)
 	if err != nil {
-		return diskRecord{}, err
+		return diskRecord{}, "", false, err
+	}
+	if keyring != nil {
+		limit, err = encryptedRecordReadLimit(limit)
+		if err != nil {
+			return diskRecord{}, "", false, err
+		}
 	}
 	info, err := os.Lstat(path)
 	if err != nil {
-		return diskRecord{}, fmt.Errorf("auditbatcher: stat record: %w", err)
+		return diskRecord{}, "", false, fmt.Errorf("auditbatcher: stat record: %w", err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return diskRecord{}, corruptRecordError(fmt.Errorf("auditbatcher: record %s must not be a symlink", path))
+		return diskRecord{}, "", false, corruptRecordError(fmt.Errorf("auditbatcher: record %s must not be a symlink", path))
 	}
 	if !info.Mode().IsRegular() {
-		return diskRecord{}, corruptRecordError(fmt.Errorf("auditbatcher: record %s is not a regular file", path))
+		return diskRecord{}, "", false, corruptRecordError(fmt.Errorf("auditbatcher: record %s is not a regular file", path))
 	}
 	if info.Size() > limit {
-		return diskRecord{}, corruptRecordError(fmt.Errorf("%w: record_bytes=%d cap=%d", conductor.ErrPayloadTooLarge, info.Size(), limit))
+		return diskRecord{}, "", false, corruptRecordError(fmt.Errorf("%w: record_bytes=%d cap=%d", conductor.ErrPayloadTooLarge, info.Size(), limit))
 	}
 	// OwnedState: this is Pipelock own durable audit-queue state, written by
 	// durableWrite at 0600. Kubernetes fsGroup re-widens it to 0660 on every
@@ -569,43 +626,33 @@ func readRecord(path string, maxPayloadBytes uint64) (diskRecord, error) {
 	// becomes ErrCorruptRecord and Claim moves the record to dead/, so strictness
 	// costs delivery of that audit data rather than merely delaying it.
 	//
-	// The confidentiality tradeoff, stated plainly because it is real: a queued
-	// record carries the batch envelope and the raw recorder payload, and decision
-	// entries can include matched-pattern context and policy evidence. Accepting
-	// group read means any process sharing the fsGroup can read that from disk.
-	// Refusing it does NOT prevent that: the platform has already widened the file,
-	// so a co-tenant of the group can read it whether or not Pipelock will. Strict
-	// mode would therefore leave the exposure in place and discard our own audit
-	// delivery on top of it, which is the worse of the two.
-	//
-	// Closing the exposure properly means encrypting these records at rest under a
-	// key that does not live on the widened volume. That is a separate piece of
-	// work with its own key lifecycle, and until it exists this state sits inside
-	// the workload/volume trust boundary alongside flight-recorder evidence.
+	// Queue records are encrypted before durableWrite under a keyring required to
+	// live outside this queue directory. Group access to the widened volume can
+	// therefore expose ciphertext and metadata, but not the audit payload.
 	data, err := securefile.Read(path, securefile.Options{
 		MaxBytes:      limit,
 		RejectSymlink: true,
 		OwnedState:    true,
 	})
 	if err != nil {
-		return diskRecord{}, corruptRecordError(fmt.Errorf("auditbatcher: read record: %w", err))
+		return diskRecord{}, "", false, corruptRecordError(fmt.Errorf("auditbatcher: read record: %w", err))
 	}
 
-	var record diskRecord
-	if err := contract.DecodeStrictJSON(data, &record); err != nil {
-		return diskRecord{}, corruptRecordError(fmt.Errorf("auditbatcher: decode record: %w", err))
+	record, keyID, legacy, err := decryptDiskRecord(data, keyring)
+	if err != nil {
+		return diskRecord{}, keyID, legacy, corruptRecordError(err)
 	}
 	if record.Version != recordVersion {
-		return diskRecord{}, corruptRecordError(fmt.Errorf("auditbatcher: record version=%d want=%d", record.Version, recordVersion))
+		return diskRecord{}, keyID, legacy, corruptRecordError(fmt.Errorf("auditbatcher: plaintext version=%d want=%d", record.Version, recordVersion))
 	}
 	if record.EnqueuedAt.IsZero() {
-		return diskRecord{}, corruptRecordError(errors.New("auditbatcher: missing enqueued_at"))
+		return diskRecord{}, keyID, legacy, corruptRecordError(errors.New("auditbatcher: missing enqueued_at"))
 	}
 	batch := Batch{Envelope: record.Envelope, Payload: record.Payload}
 	if err := validateBatch(batch, maxPayloadBytes); err != nil {
-		return diskRecord{}, corruptRecordError(err)
+		return diskRecord{}, keyID, legacy, corruptRecordError(err)
 	}
-	return record, nil
+	return record, keyID, legacy, nil
 }
 
 func corruptRecordError(err error) error {
@@ -623,6 +670,24 @@ func recordReadLimit(maxPayloadBytes uint64) (int64, error) {
 	return uint64ToInt64(encodedPayloadBytes + maxRecordMetadataBytes)
 }
 
+func encryptedRecordReadLimit(plaintextLimit int64) (int64, error) {
+	if plaintextLimit < 0 {
+		return 0, fmt.Errorf("auditbatcher: encrypted record plaintext limit must not be negative: %d", plaintextLimit)
+	}
+	plaintextBytes := uint64(plaintextLimit)
+	if plaintextBytes > maxRecordReadBytes-aes.BlockSize {
+		return 0, fmt.Errorf("auditbatcher: encrypted record plaintext limit too large: %d", plaintextLimit)
+	}
+	ciphertextBytes := plaintextBytes + aes.BlockSize
+	// encoding/json represents []byte as padded standard base64. Check before
+	// multiplying so a hostile configured limit cannot wrap the calculation.
+	if ciphertextBytes > ((maxRecordReadBytes-encryptedRecordMetadataBytes)/4)*3-2 {
+		return 0, fmt.Errorf("auditbatcher: encrypted record ciphertext limit too large: %d", ciphertextBytes)
+	}
+	encodedCiphertextBytes := ((ciphertextBytes + 2) / 3) * 4
+	return uint64ToInt64(encodedCiphertextBytes + encryptedRecordMetadataBytes)
+}
+
 func uint64ToInt64(value uint64) (int64, error) {
 	if value > maxRecordReadBytes {
 		return 0, fmt.Errorf("auditbatcher: record read limit too large: %d", value)
@@ -636,12 +701,12 @@ func uint64ToInt64(value uint64) (int64, error) {
 
 func (q *Queue) updateInflightRecordLocked(id string, mutate func(*diskRecord)) error {
 	path := filepath.Join(q.inflightDir, id)
-	record, err := readRecord(path, q.maxPayloadBytes)
+	record, _, _, err := readRecordWithKeyring(path, q.maxPayloadBytes, q.keyring)
 	if err != nil {
 		return fmt.Errorf("auditbatcher: annotate inflight %s: %w", id, err)
 	}
 	mutate(&record)
-	data, err := json.Marshal(record)
+	data, err := encryptDiskRecord(record, q.keyring)
 	if err != nil {
 		return fmt.Errorf("auditbatcher: marshal annotated record %s: %w", id, err)
 	}

--- a/enterprise/conductor/auditbatcher/queue_test.go
+++ b/enterprise/conductor/auditbatcher/queue_test.go
@@ -17,11 +17,14 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 )
+
+var testQueueKeyrings sync.Map
 
 func TestQueueEnqueueClaimAckRoundTrip(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
@@ -94,7 +97,7 @@ func TestQueuePersistsAcrossOpen(t *testing.T) {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
 	dir := t.TempDir()
-	q, err := Open(Config{Dir: dir})
+	q, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
@@ -107,7 +110,7 @@ func TestQueuePersistsAcrossOpen(t *testing.T) {
 		t.Fatalf("Close() error = %v", err)
 	}
 
-	reopened, err := Open(Config{Dir: dir})
+	reopened, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open(reopen) error = %v", err)
 	}
@@ -126,13 +129,13 @@ func TestQueuePersistsAcrossOpen(t *testing.T) {
 // ErrQueueLocked rather than silently allowing two writers.
 func TestQueueOpenLocksDirectory(t *testing.T) {
 	dir := t.TempDir()
-	q, err := Open(Config{Dir: dir})
+	q, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
 	defer func() { _ = q.Close() }()
 
-	if _, err := Open(Config{Dir: dir}); !errors.Is(err, ErrQueueLocked) {
+	if _, err := testOpen(t, Config{Dir: dir}); !errors.Is(err, ErrQueueLocked) {
 		t.Fatalf("Open(second) error = %v, want ErrQueueLocked", err)
 	}
 }
@@ -142,7 +145,7 @@ func TestQueueOpenLocksDirectory(t *testing.T) {
 // (fd gone) is indistinguishable from an explicit Close here.
 func TestQueueCloseReleasesLock(t *testing.T) {
 	dir := t.TempDir()
-	q, err := Open(Config{Dir: dir})
+	q, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
@@ -154,7 +157,7 @@ func TestQueueCloseReleasesLock(t *testing.T) {
 		t.Fatalf("Close(second) error = %v", err)
 	}
 
-	reopened, err := Open(Config{Dir: dir})
+	reopened, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open(after close) error = %v", err)
 	}
@@ -214,7 +217,7 @@ func TestQueueLockFileNotTreatedAsRecord(t *testing.T) {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
 	dir := t.TempDir()
-	q, err := Open(Config{Dir: dir})
+	q, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
@@ -246,7 +249,7 @@ func TestQueueReleaseAndRecoverInflight(t *testing.T) {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
 	dir := t.TempDir()
-	q, err := Open(Config{Dir: dir})
+	q, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
@@ -268,7 +271,7 @@ func TestQueueReleaseAndRecoverInflight(t *testing.T) {
 	if err := q.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
 	}
-	reopened, err := Open(Config{Dir: dir})
+	reopened, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open(reopen) error = %v", err)
 	}
@@ -282,7 +285,7 @@ func TestQueueReleaseWithRetryPersistsAccounting(t *testing.T) {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
 	dir := t.TempDir()
-	q, err := Open(Config{Dir: dir})
+	q, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
@@ -300,12 +303,12 @@ func TestQueueReleaseWithRetryPersistsAccounting(t *testing.T) {
 		t.Fatalf("Close() error = %v", err)
 	}
 
-	reopened, err := Open(Config{Dir: dir})
+	reopened, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open(reopen) error = %v", err)
 	}
 	defer func() { _ = reopened.Close() }()
-	record, err := readRecord(filepath.Join(reopened.pendingDir, id), conductor.MaxAuditPayloadBytes)
+	record, err := reopened.readRecord(filepath.Join(reopened.pendingDir, id))
 	if err != nil {
 		t.Fatalf("readRecord() error = %v", err)
 	}
@@ -347,7 +350,7 @@ func TestQueueDropMovesInflightToDeadWithReason(t *testing.T) {
 	}
 	assertStats(t, q, Stats{Dead: 1})
 
-	record, err := readRecord(filepath.Join(q.deadDir, id), conductor.MaxAuditPayloadBytes)
+	record, err := q.readRecord(filepath.Join(q.deadDir, id))
 	if err != nil {
 		t.Fatalf("readRecord(dead) error = %v", err)
 	}
@@ -573,7 +576,7 @@ func TestQueueClaimCorruptRecordReportsMoveToDeadErrors(t *testing.T) {
 }
 
 func TestOpenRequiresQueueDir(t *testing.T) {
-	_, err := Open(Config{})
+	_, err := testOpen(t, Config{})
 	if err == nil || !strings.Contains(err.Error(), "queue dir required") {
 		t.Fatalf("Open() = %v, want queue dir required", err)
 	}
@@ -684,7 +687,7 @@ func TestOpenRejectsSymlinkQueueDir(t *testing.T) {
 	if err := os.Symlink(target, link); err != nil {
 		t.Fatalf("Symlink() error = %v", err)
 	}
-	_, err := Open(Config{Dir: link})
+	_, err := testOpen(t, Config{Dir: link})
 	if err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
 		t.Fatalf("Open() = %v, want symlink rejection", err)
 	}
@@ -703,7 +706,7 @@ func TestOpenRejectsSymlinkQueueSubdir(t *testing.T) {
 	if err := os.Symlink(target, filepath.Join(queueDir, "pending")); err != nil {
 		t.Fatalf("Symlink() error = %v", err)
 	}
-	_, err := Open(Config{Dir: queueDir})
+	_, err := testOpen(t, Config{Dir: queueDir})
 	if err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
 		t.Fatalf("Open() = %v, want symlink subdir rejection", err)
 	}
@@ -720,7 +723,7 @@ func TestOpenRejectsSymlinkParent(t *testing.T) {
 		t.Fatalf("Symlink() error = %v", err)
 	}
 
-	_, err := Open(Config{Dir: filepath.Join(linkParent, "queue")})
+	_, err := testOpen(t, Config{Dir: filepath.Join(linkParent, "queue")})
 	if err == nil || !strings.Contains(err.Error(), "ancestor") || !strings.Contains(err.Error(), "must not be a symlink") {
 		t.Fatalf("Open() = %v, want symlink ancestor rejection", err)
 	}
@@ -731,7 +734,7 @@ func TestOpenSweepsStaleTempFiles(t *testing.T) {
 	// be cleaned up on Open. listRecordFiles already filters them so they
 	// won't get claimed, but without sweep they accumulate forever.
 	dir := t.TempDir()
-	q, err := Open(Config{Dir: dir})
+	q, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
@@ -748,7 +751,7 @@ func TestOpenSweepsStaleTempFiles(t *testing.T) {
 		t.Fatalf("Close() error = %v", err)
 	}
 
-	reopened, err := Open(Config{Dir: dir})
+	reopened, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open(reopen) error = %v", err)
 	}
@@ -808,7 +811,7 @@ func TestRecoverInflightHandlesNameCollision(t *testing.T) {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
 	dir := t.TempDir()
-	q, err := Open(Config{Dir: dir})
+	q, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
@@ -824,7 +827,10 @@ func TestRecoverInflightHandlesNameCollision(t *testing.T) {
 	recoveredAgainID := id + "-recovered-1" + recordExt
 	// Simulate prior recovery debris: pending/<id> and pending/<id>-recovered
 	// both exist when the next Open() runs the recovery sweep.
-	originalContent := []byte(`{"version":1,"sentinel":"do-not-clobber"}`)
+	originalContent, err := encryptDiskRecord(validDiskRecord(batch), q.keyring)
+	if err != nil {
+		t.Fatalf("encryptDiskRecord(collision sentinel) error = %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(q.pendingDir, id), originalContent, fileMode); err != nil {
 		t.Fatalf("WriteFile(pending/<id>) error = %v", err)
 	}
@@ -835,7 +841,7 @@ func TestRecoverInflightHandlesNameCollision(t *testing.T) {
 		t.Fatalf("Close() error = %v", err)
 	}
 
-	reopened, err := Open(Config{Dir: dir})
+	reopened, err := testOpen(t, Config{Dir: dir})
 	if err != nil {
 		t.Fatalf("Open(reopen) error = %v", err)
 	}
@@ -985,7 +991,7 @@ func TestReadRecordStrictDecodeFailures(t *testing.T) {
 			name: "unsupported_version",
 			edit: func(t *testing.T, record diskRecord) []byte {
 				t.Helper()
-				record.Version++
+				record.Version = 99
 				data, err := json.Marshal(record)
 				if err != nil {
 					t.Fatalf("Marshal() error = %v", err)
@@ -1254,12 +1260,31 @@ func TestDurableWriteAndMoveToDeadErrorPaths(t *testing.T) {
 func openTestQueue(t *testing.T, cfg Config) *Queue {
 	t.Helper()
 	cfg.Dir = t.TempDir()
-	q, err := Open(cfg)
+	q, err := testOpen(t, cfg)
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
 	t.Cleanup(func() { _ = q.Close() })
 	return q
+}
+
+func testOpen(t *testing.T, cfg Config) (*Queue, error) {
+	t.Helper()
+	if cfg.Keyring == nil {
+		key := t.Name() + "\x00" + filepath.Clean(cfg.Dir)
+		if existing, ok := testQueueKeyrings.Load(key); ok {
+			cfg.Keyring = existing.(*Keyring)
+		} else {
+			keyring, err := NewKeyring()
+			if err != nil {
+				t.Fatalf("NewKeyring() error = %v", err)
+			}
+			actual, _ := testQueueKeyrings.LoadOrStore(key, keyring)
+			cfg.Keyring = actual.(*Keyring)
+			t.Cleanup(func() { testQueueKeyrings.Delete(key) })
+		}
+	}
+	return Open(cfg)
 }
 
 func assertStats(t *testing.T, q *Queue, want Stats) {

--- a/enterprise/conductor/auditbatcher/record_crypto.go
+++ b/enterprise/conductor/auditbatcher/record_crypto.go
@@ -1,0 +1,135 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package auditbatcher
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+)
+
+const (
+	encryptedRecordVersion = 2
+	// encryptedRecordMetadataBytes bounds the v2 JSON fields outside
+	// ciphertext. The ciphertext itself is base64-expanded by encoding/json
+	// and must be accounted for separately.
+	encryptedRecordMetadataBytes = 1024
+)
+
+var queueRecordAAD = []byte("pipelock/conductor/audit-queue/v2")
+
+type encryptedDiskRecord struct {
+	Version    int    `json:"version"`
+	KeyID      string `json:"key_id"`
+	Nonce      []byte `json:"nonce"`
+	Ciphertext []byte `json:"ciphertext"`
+}
+
+func encryptDiskRecord(record diskRecord, keyring *Keyring) ([]byte, error) {
+	plaintext, err := json.Marshal(record)
+	if err != nil {
+		return nil, fmt.Errorf("auditbatcher: marshal record plaintext: %w", err)
+	}
+	id, key, err := keyring.activeKey()
+	if err != nil {
+		return nil, err
+	}
+	aead, err := queueAEAD(key)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("auditbatcher: generate record nonce: %w", err)
+	}
+	ciphertext := aead.Seal(nil, nonce, plaintext, recordAAD(id))
+	data, err := json.Marshal(encryptedDiskRecord{
+		Version:    encryptedRecordVersion,
+		KeyID:      id,
+		Nonce:      nonce,
+		Ciphertext: ciphertext,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("auditbatcher: marshal encrypted record: %w", err)
+	}
+	return data, nil
+}
+
+func decryptDiskRecord(data []byte, keyring *Keyring) (diskRecord, string, bool, error) {
+	var fields map[string]json.RawMessage
+	if err := contract.DecodeStrictJSON(data, &fields); err != nil {
+		return diskRecord{}, "", false, fmt.Errorf("auditbatcher: decode record version: %w", err)
+	}
+	rawVersion, ok := fields["version"]
+	if !ok {
+		return diskRecord{}, "", false, errors.New("auditbatcher: record version missing")
+	}
+	var version int
+	if err := json.Unmarshal(rawVersion, &version); err != nil {
+		return diskRecord{}, "", false, fmt.Errorf("auditbatcher: decode record version: %w", err)
+	}
+	switch version {
+	case recordVersion:
+		var record diskRecord
+		if err := contract.DecodeStrictJSON(data, &record); err != nil {
+			return diskRecord{}, "", true, fmt.Errorf("auditbatcher: decode legacy record: %w", err)
+		}
+		return record, "", true, nil
+	case encryptedRecordVersion:
+		var encrypted encryptedDiskRecord
+		if err := contract.DecodeStrictJSON(data, &encrypted); err != nil {
+			return diskRecord{}, "", false, fmt.Errorf("auditbatcher: decode encrypted record: %w", err)
+		}
+		key, ok := keyring.key(encrypted.KeyID)
+		if !ok {
+			return diskRecord{}, encrypted.KeyID, false, fmt.Errorf("auditbatcher: queue key %q unavailable", encrypted.KeyID)
+		}
+		aead, err := queueAEAD(key)
+		if err != nil {
+			return diskRecord{}, encrypted.KeyID, false, err
+		}
+		if len(encrypted.Nonce) != aead.NonceSize() {
+			return diskRecord{}, encrypted.KeyID, false, errors.New("auditbatcher: invalid record nonce length")
+		}
+		plaintext, err := aead.Open(nil, encrypted.Nonce, encrypted.Ciphertext, recordAAD(encrypted.KeyID))
+		if err != nil {
+			return diskRecord{}, encrypted.KeyID, false, fmt.Errorf("auditbatcher: decrypt record: %w", err)
+		}
+		var record diskRecord
+		if err := contract.DecodeStrictJSON(plaintext, &record); err != nil {
+			return diskRecord{}, encrypted.KeyID, false, fmt.Errorf("auditbatcher: decode record plaintext: %w", err)
+		}
+		return record, encrypted.KeyID, false, nil
+	default:
+		return diskRecord{}, "", false, fmt.Errorf("auditbatcher: record version=%d unsupported", version)
+	}
+}
+
+func queueAEAD(key [queueKeyBytes]byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, fmt.Errorf("auditbatcher: create queue cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("auditbatcher: create queue AEAD: %w", err)
+	}
+	return aead, nil
+}
+
+func recordAAD(keyID string) []byte {
+	aad := make([]byte, 0, len(queueRecordAAD)+1+len(keyID))
+	aad = append(aad, queueRecordAAD...)
+	aad = append(aad, 0)
+	aad = append(aad, keyID...)
+	return aad
+}

--- a/enterprise/conductor/auditbatcher/record_crypto.go
+++ b/enterprise/conductor/auditbatcher/record_crypto.go
@@ -25,6 +25,8 @@ const (
 	encryptedRecordMetadataBytes = 1024
 )
 
+var errQueueKeyUnavailable = errors.New("auditbatcher: queue encryption key unavailable")
+
 var queueRecordAAD = []byte("pipelock/conductor/audit-queue/v2")
 
 type encryptedDiskRecord struct {
@@ -91,7 +93,7 @@ func decryptDiskRecord(data []byte, keyring *Keyring) (diskRecord, string, bool,
 		}
 		key, ok := keyring.key(encrypted.KeyID)
 		if !ok {
-			return diskRecord{}, encrypted.KeyID, false, fmt.Errorf("auditbatcher: queue key %q unavailable", encrypted.KeyID)
+			return diskRecord{}, encrypted.KeyID, false, fmt.Errorf("%w: %q", errQueueKeyUnavailable, encrypted.KeyID)
 		}
 		aead, err := queueAEAD(key)
 		if err != nil {

--- a/enterprise/conductor/auditbatcher/record_crypto.go
+++ b/enterprise/conductor/auditbatcher/record_crypto.go
@@ -19,13 +19,17 @@ import (
 
 const (
 	encryptedRecordVersion = 2
+	queueAEADOverheadBytes = 16
 	// encryptedRecordMetadataBytes bounds the v2 JSON fields outside
 	// ciphertext. The ciphertext itself is base64-expanded by encoding/json
 	// and must be accounted for separately.
 	encryptedRecordMetadataBytes = 1024
 )
 
-var errQueueKeyUnavailable = errors.New("auditbatcher: queue encryption key unavailable")
+var (
+	errQueueKeyUnavailable = errors.New("auditbatcher: queue encryption key unavailable")
+	ErrRecordAuthFailed    = errors.New("auditbatcher: encrypted record authentication failed")
+)
 
 var queueRecordAAD = []byte("pipelock/conductor/audit-queue/v2")
 
@@ -100,11 +104,11 @@ func decryptDiskRecord(data []byte, keyring *Keyring) (diskRecord, string, bool,
 			return diskRecord{}, encrypted.KeyID, false, err
 		}
 		if len(encrypted.Nonce) != aead.NonceSize() {
-			return diskRecord{}, encrypted.KeyID, false, errors.New("auditbatcher: invalid record nonce length")
+			return diskRecord{}, encrypted.KeyID, false, fmt.Errorf("%w: invalid nonce length", ErrRecordAuthFailed)
 		}
 		plaintext, err := aead.Open(nil, encrypted.Nonce, encrypted.Ciphertext, recordAAD(encrypted.KeyID))
 		if err != nil {
-			return diskRecord{}, encrypted.KeyID, false, fmt.Errorf("auditbatcher: decrypt record: %w", err)
+			return diskRecord{}, encrypted.KeyID, false, fmt.Errorf("%w: decrypt record: %w", ErrRecordAuthFailed, err)
 		}
 		var record diskRecord
 		if err := contract.DecodeStrictJSON(plaintext, &record); err != nil {

--- a/enterprise/conductor/auditbatcher/record_crypto_test.go
+++ b/enterprise/conductor/auditbatcher/record_crypto_test.go
@@ -1,0 +1,291 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package auditbatcher
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+)
+
+func TestQueueEncryptsRecordsAtRest(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := openTestQueue(t, Config{})
+	payload := []byte(`{"events":[{"message":"plaintext-sentinel"}]}`)
+	envelope := validUnsignedEnvelope(t, "batch-encrypted-at-rest", payload)
+	signed, err := SignEnvelope(envelope, "audit-key-1", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch := Batch{Envelope: signed, Payload: payload}
+
+	id, err := q.Enqueue(batch)
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(q.pendingDir, id)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(data, []byte("plaintext-sentinel")) {
+		t.Fatal("durable record contains plaintext payload")
+	}
+	if !bytes.Contains(data, []byte(`"version":2`)) || !bytes.Contains(data, []byte(`"ciphertext"`)) {
+		t.Fatalf("durable record is not the encrypted v2 envelope: %s", data)
+	}
+	var encrypted encryptedDiskRecord
+	if err := json.Unmarshal(data, &encrypted); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encrypted.Ciphertext, []byte("plaintext-sentinel")) {
+		t.Fatal("decoded ciphertext field contains plaintext payload")
+	}
+}
+
+func TestEncryptedRecordMaxPayloadSurvivesRestartAndClaim(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	q, err := Open(Config{Dir: dir, Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte{0xff}, conductor.MaxAuditPayloadBytes)
+	envelope := validUnsignedEnvelope(t, "batch-max-payload", payload)
+	signed, err := SignEnvelope(envelope, "audit-key-1", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := q.Enqueue(Batch{Envelope: signed, Payload: payload})
+	if err != nil {
+		t.Fatalf("Enqueue(max payload) error = %v", err)
+	}
+	oldLimit, err := recordReadLimit(conductor.MaxAuditPayloadBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(q.pendingDir, id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() <= oldLimit+encryptedRecordMetadataBytes {
+		t.Fatalf("encrypted record size = %d, want above old flat-overhead ceiling %d", info.Size(), oldLimit+encryptedRecordMetadataBytes)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(Config{Dir: dir, Keyring: keyring})
+	if err != nil {
+		t.Fatalf("Open(max payload record) error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	lease, err := reopened.Claim()
+	if err != nil {
+		t.Fatalf("Claim(max payload record) error = %v", err)
+	}
+	if !bytes.Equal(lease.Batch.Payload, payload) {
+		t.Fatal("claimed max payload differs from enqueued bytes")
+	}
+}
+
+func TestEncryptedRecordTamperFailsClosed(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := openTestQueue(t, Config{})
+	id, err := q.Enqueue(signedTestBatch(t, "batch-tamper", priv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(q.pendingDir, id)
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	needle := []byte(`"ciphertext":"`)
+	start := bytes.Index(data, needle)
+	if start < 0 {
+		t.Fatal("ciphertext field absent")
+	}
+	at := start + len(needle)
+	if data[at] == 'A' {
+		data[at] = 'B'
+	} else {
+		data[at] = 'A'
+	}
+	if err := os.WriteFile(path, data, fileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = q.readRecord(path)
+	if err == nil || !errors.Is(err, ErrCorruptRecord) || !strings.Contains(err.Error(), "decrypt record") {
+		t.Fatalf("tampered read error = %v, want fail-closed decrypt ErrCorruptRecord", err)
+	}
+}
+
+func TestOpenMigratesLegacyAndRotatedRecords(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := Open(Config{Dir: dir, Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch := signedTestBatch(t, "batch-rotate", priv)
+	id, err := q.Enqueue(batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldID := keyring.ActiveKeyID()
+	if _, err := keyring.Rotate(); err != nil {
+		t.Fatal(err)
+	}
+	legacyID := "00000000000000000001-batch-legacy-0000000000000000.json"
+	if err := writeDiskRecord(filepath.Join(q.pendingDir, legacyID), validDiskRecord(signedTestBatch(t, "batch-legacy", priv))); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(Config{Dir: dir, Keyring: keyring})
+	if err != nil {
+		t.Fatalf("Open(migrate) error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	for _, name := range []string{id, legacyID} {
+		_, keyID, legacy, err := readRecordWithKeyring(filepath.Join(reopened.pendingDir, name), reopened.maxPayloadBytes, keyring)
+		if err != nil {
+			t.Fatalf("read migrated %s: %v", name, err)
+		}
+		if legacy || keyID != keyring.ActiveKeyID() {
+			t.Fatalf("migrated %s legacy=%t key=%q, want active %q", name, legacy, keyID, keyring.ActiveKeyID())
+		}
+	}
+	if err := keyring.Revoke(oldID, nil); err != nil {
+		t.Fatalf("Revoke(old key after migration) error = %v", err)
+	}
+}
+
+func TestOpenFailsClosedWhenRecordKeyUnavailable(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	writerKeys, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := Open(Config{Dir: dir, Keyring: writerKeys})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := q.Enqueue(signedTestBatch(t, "batch-missing-key", priv)); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatal(err)
+	}
+	wrongKeys, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Open(Config{Dir: dir, Keyring: wrongKeys})
+	if err == nil || !errors.Is(err, ErrCorruptRecord) || !strings.Contains(err.Error(), "unavailable") {
+		t.Fatalf("Open(wrong keyring) error = %v, want unavailable-key ErrCorruptRecord", err)
+	}
+}
+
+func TestEncryptedRecordsUseDistinctNonces(t *testing.T) {
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := diskRecord{Version: recordVersion}
+	first, err := encryptDiskRecord(record, keyring)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := encryptDiskRecord(record, keyring)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(first, second) {
+		t.Fatal("identical plaintext encrypted to identical record; nonce reuse suspected")
+	}
+}
+
+func TestKeyringRevocationGuards(t *testing.T) {
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	active := keyring.ActiveKeyID()
+	if err := keyring.Revoke(active, nil); err == nil || !strings.Contains(err.Error(), "active") {
+		t.Fatalf("Revoke(active) error = %v, want active-key refusal", err)
+	}
+	old := active
+	if _, err := keyring.Rotate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := keyring.Revoke(old, map[string]int{old: 1}); err == nil || !strings.Contains(err.Error(), "still use") {
+		t.Fatalf("Revoke(in-use) error = %v, want usage refusal", err)
+	}
+}
+
+func TestLoadKeyringRejectsWorldReadableFile(t *testing.T) {
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	if err := keyring.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	chmodTestFixture(t, path, 0o604)
+	if _, err := LoadKeyring(path); err == nil {
+		t.Fatal("LoadKeyring(world-readable) error = nil, want refusal")
+	}
+}
+
+func chmodTestFixture(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	if err := os.Chmod(filepath.Clean(path), mode); err != nil {
+		t.Fatalf("Chmod(%s, %04o) error = %v", path, mode, err)
+	}
+}
+
+func TestOpenRequiresEncryptionKeyring(t *testing.T) {
+	if _, err := Open(Config{Dir: t.TempDir()}); err == nil || !strings.Contains(err.Error(), "keyring required") {
+		t.Fatalf("Open(nil keyring) error = %v, want required refusal", err)
+	}
+}

--- a/enterprise/conductor/auditbatcher/record_crypto_test.go
+++ b/enterprise/conductor/auditbatcher/record_crypto_test.go
@@ -10,10 +10,12 @@ import (
 	"crypto/ed25519"
 	"encoding/json"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 )
@@ -225,6 +227,46 @@ func TestOpenFailsClosedWhenRecordKeyUnavailable(t *testing.T) {
 	}
 }
 
+func TestOpenQuarantinesCorruptLiveRecordAndIgnoresUnreadableDeadRecord(t *testing.T) {
+	dir := t.TempDir()
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := Open(Config{Dir: dir, Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	corruptID := "00000000000000000001-corrupt-0000000000000000.json"
+	if err := os.WriteFile(filepath.Join(q.pendingDir, corruptID), []byte("{bad"), fileMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(Config{Dir: dir, Keyring: keyring})
+	if err != nil {
+		t.Fatalf("Open with corrupt pending record: %v", err)
+	}
+	stats, err := reopened.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Pending != 0 || stats.Dead != 1 {
+		t.Fatalf("Stats after migration quarantine = %+v, want pending=0 dead=1", stats)
+	}
+	if err := reopened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	afterDead, err := Open(Config{Dir: dir, Keyring: keyring})
+	if err != nil {
+		t.Fatalf("Open with unreadable dead-letter record: %v", err)
+	}
+	defer func() { _ = afterDead.Close() }()
+}
+
 func TestEncryptedRecordsUseDistinctNonces(t *testing.T) {
 	keyring, err := NewKeyring()
 	if err != nil {
@@ -287,5 +329,161 @@ func chmodTestFixture(t *testing.T, path string, mode os.FileMode) {
 func TestOpenRequiresEncryptionKeyring(t *testing.T) {
 	if _, err := Open(Config{Dir: t.TempDir()}); err == nil || !strings.Contains(err.Error(), "keyring required") {
 		t.Fatalf("Open(nil keyring) error = %v, want required refusal", err)
+	}
+}
+
+func TestMigrationAndEncryptedReadErrorPaths(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := Open(Config{Dir: t.TempDir(), Keyring: keyring})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = q.Close() }()
+
+	if err := os.RemoveAll(q.deadDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.migrateRecordsLocked(); err == nil {
+		t.Fatal("migrateRecordsLocked(missing dir) error = nil")
+	}
+	if err := os.MkdirAll(q.deadDir, dirMode); err != nil {
+		t.Fatal(err)
+	}
+
+	legacyID := "00000000000000000001-legacy.json"
+	legacyPath := filepath.Join(q.pendingDir, legacyID)
+	if err := writeDiskRecord(legacyPath, validDiskRecord(signedTestBatch(t, "migration-error", priv))); err != nil {
+		t.Fatal(err)
+	}
+	q.keyring = &Keyring{}
+	if err := q.migrateRecordsLocked(); err == nil || !strings.Contains(err.Error(), "encrypt queue record") {
+		t.Fatalf("migrateRecordsLocked(empty keyring) error = %v", err)
+	}
+
+	q.keyring = keyring
+	data, err := encryptDiskRecord(diskRecord{Version: 99, EnqueuedAt: time.Now().UTC()}, keyring)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalidVersionPath := filepath.Join(q.pendingDir, "00000000000000000002-version.json")
+	if err := os.WriteFile(invalidVersionPath, data, fileMode); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := readRecordWithKeyring(invalidVersionPath, conductor.MaxAuditPayloadBytes, keyring); err == nil || !strings.Contains(err.Error(), "plaintext version") {
+		t.Fatalf("readRecordWithKeyring(version) error = %v", err)
+	}
+
+	if _, err := encryptedRecordReadLimit(-1); err == nil {
+		t.Fatal("encryptedRecordReadLimit(negative) error = nil")
+	}
+	if _, err := encryptedRecordReadLimit(math.MaxInt64); err == nil {
+		t.Fatal("encryptedRecordReadLimit(oversized plaintext) error = nil")
+	}
+	threshold := int64(((maxRecordReadBytes-encryptedRecordMetadataBytes)/4)*3 - 2)
+	if _, err := encryptedRecordReadLimit(threshold); err == nil {
+		t.Fatal("encryptedRecordReadLimit(oversized ciphertext) error = nil")
+	}
+}
+
+func TestMigrationQuarantineAndRewriteFailures(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newQueue := func(t *testing.T) (*Queue, *Keyring) {
+		t.Helper()
+		keyring, err := NewKeyring()
+		if err != nil {
+			t.Fatal(err)
+		}
+		q, err := Open(Config{Dir: t.TempDir(), Keyring: keyring})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = q.Close() })
+		return q, keyring
+	}
+
+	t.Run("dead path failure", func(t *testing.T) {
+		q, _ := newQueue(t)
+		id := "00000000000000000001-corrupt.json"
+		if err := os.WriteFile(filepath.Join(q.pendingDir, id), []byte("{bad"), fileMode); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.RemoveAll(q.deadDir); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(q.deadDir, []byte("not a directory"), fileMode); err != nil {
+			t.Fatal(err)
+		}
+		if err := q.migrateRecordsLocked(); err == nil || !strings.Contains(err.Error(), "quarantine queue record") {
+			t.Fatalf("migrateRecordsLocked(dead path) error = %v", err)
+		}
+	})
+
+	t.Run("dead move failure", func(t *testing.T) {
+		q, _ := newQueue(t)
+		id := "00000000000000000001-corrupt.json"
+		if err := os.WriteFile(filepath.Join(q.pendingDir, id), []byte("{bad"), fileMode); err != nil {
+			t.Fatal(err)
+		}
+		restrictDirectoryWrites(t, q.deadDir)
+		if err := q.migrateRecordsLocked(); err == nil || !strings.Contains(err.Error(), "quarantine queue record") {
+			t.Fatalf("migrateRecordsLocked(dead move) error = %v", err)
+		}
+	})
+
+	t.Run("rewrite failure", func(t *testing.T) {
+		q, keyring := newQueue(t)
+		id := "00000000000000000001-legacy.json"
+		if err := writeDiskRecord(filepath.Join(q.pendingDir, id), validDiskRecord(signedTestBatch(t, "rewrite-error", priv))); err != nil {
+			t.Fatal(err)
+		}
+		restrictDirectoryWrites(t, q.pendingDir)
+		q.keyring = keyring
+		if err := q.migrateRecordsLocked(); err == nil || !strings.Contains(err.Error(), "migrate queue record") {
+			t.Fatalf("migrateRecordsLocked(rewrite) error = %v", err)
+		}
+	})
+}
+
+func restrictDirectoryWrites(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := info.Mode().Perm()
+	readOnly := original &^ 0o222
+	if err := os.Chmod(path, readOnly); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, original) })
+}
+
+func TestEncryptedRecordReadLimitAndFileReadFailures(t *testing.T) {
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "record.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, fileMode) })
+	if _, _, _, err := readRecordWithKeyring(path, conductor.MaxAuditPayloadBytes, keyring); err == nil || !errors.Is(err, ErrCorruptRecord) {
+		t.Fatalf("readRecordWithKeyring(unreadable) error = %v", err)
+	}
+
+	maxAcceptedPayload := ((maxRecordReadBytes-maxRecordMetadataBytes)/4)*3 - 2
+	if _, _, _, err := readRecordWithKeyring(path, maxAcceptedPayload, keyring); err == nil {
+		t.Fatal("readRecordWithKeyring(encrypted limit) error = nil")
 	}
 }

--- a/enterprise/conductor/auditbatcher/record_crypto_test.go
+++ b/enterprise/conductor/auditbatcher/record_crypto_test.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -125,6 +126,7 @@ func TestEncryptedRecordTamperFailsClosed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	original := append([]byte(nil), data...)
 	needle := []byte(`"ciphertext":"`)
 	start := bytes.Index(data, needle)
 	if start < 0 {
@@ -141,8 +143,86 @@ func TestEncryptedRecordTamperFailsClosed(t *testing.T) {
 	}
 
 	_, err = q.readRecord(path)
-	if err == nil || !errors.Is(err, ErrCorruptRecord) || !strings.Contains(err.Error(), "decrypt record") {
-		t.Fatalf("tampered read error = %v, want fail-closed decrypt ErrCorruptRecord", err)
+	if err == nil || !errors.Is(err, ErrRecordAuthFailed) || errors.Is(err, ErrCorruptRecord) {
+		t.Fatalf("tampered read error = %v, want dedicated authentication failure", err)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open(Config{Dir: q.dir, Keyring: q.keyring}); !errors.Is(err, ErrRecordAuthFailed) {
+		t.Fatalf("Open(tampered record) error = %v, want ErrRecordAuthFailed", err)
+	}
+	if err := os.WriteFile(path, original, fileMode); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(Config{Dir: q.dir, Keyring: q.keyring})
+	if err != nil {
+		t.Fatalf("Open after failed startup retained queue lock: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+}
+
+func TestEncryptedRecordTamperBlocksStartupInEveryQueueState(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, state := range []string{"pending", "inflight", "dead"} {
+		t.Run(state, func(t *testing.T) {
+			dir := t.TempDir()
+			keyring, err := NewKeyring()
+			if err != nil {
+				t.Fatal(err)
+			}
+			q, err := Open(Config{Dir: dir, Keyring: keyring})
+			if err != nil {
+				t.Fatal(err)
+			}
+			id, err := q.Enqueue(signedTestBatch(t, "batch-tamper-"+state, priv))
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(q.pendingDir, id)
+			switch state {
+			case "inflight":
+				if _, err := q.Claim(); err != nil {
+					t.Fatal(err)
+				}
+				path = filepath.Join(q.inflightDir, id)
+			case "dead":
+				lease, err := q.Claim()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := q.Drop(lease.ID, "tamper fixture"); err != nil {
+					t.Fatal(err)
+				}
+				path = filepath.Join(q.deadDir, id)
+			}
+			data, err := os.ReadFile(filepath.Clean(path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			needle := []byte(`"ciphertext":"`)
+			at := bytes.Index(data, needle) + len(needle)
+			if at < len(needle) || at >= len(data) {
+				t.Fatal("ciphertext field absent")
+			}
+			if data[at] == 'A' {
+				data[at] = 'B'
+			} else {
+				data[at] = 'A'
+			}
+			if err := os.WriteFile(path, data, fileMode); err != nil {
+				t.Fatal(err)
+			}
+			if err := q.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Open(Config{Dir: dir, Keyring: keyring}); !errors.Is(err, ErrRecordAuthFailed) {
+				t.Fatalf("Open(tampered %s record) error = %v, want ErrRecordAuthFailed", state, err)
+			}
+		})
 	}
 }
 
@@ -222,8 +302,8 @@ func TestOpenFailsClosedWhenRecordKeyUnavailable(t *testing.T) {
 	}
 
 	_, err = Open(Config{Dir: dir, Keyring: wrongKeys})
-	if err == nil || !errors.Is(err, ErrCorruptRecord) || !strings.Contains(err.Error(), "unavailable") {
-		t.Fatalf("Open(wrong keyring) error = %v, want unavailable-key ErrCorruptRecord", err)
+	if err == nil || errors.Is(err, ErrCorruptRecord) || !errors.Is(err, errQueueKeyUnavailable) {
+		t.Fatalf("Open(wrong keyring) error = %v, want dedicated unavailable-key failure", err)
 	}
 }
 
@@ -305,6 +385,9 @@ func TestKeyringRevocationGuards(t *testing.T) {
 }
 
 func TestLoadKeyringRejectsWorldReadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not preserve POSIX mode bits")
+	}
 	keyring, err := NewKeyring()
 	if err != nil {
 		t.Fatal(err)
@@ -321,6 +404,9 @@ func TestLoadKeyringRejectsWorldReadableFile(t *testing.T) {
 
 func chmodTestFixture(t *testing.T, path string, mode os.FileMode) {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not preserve POSIX mode bits")
+	}
 	if err := os.Chmod(filepath.Clean(path), mode); err != nil {
 		t.Fatalf("Chmod(%s, %04o) error = %v", path, mode, err)
 	}
@@ -456,6 +542,9 @@ func TestMigrationQuarantineAndRewriteFailures(t *testing.T) {
 
 func restrictDirectoryWrites(t *testing.T, path string) {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not preserve POSIX directory mode bits")
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatal(err)
@@ -469,6 +558,9 @@ func restrictDirectoryWrites(t *testing.T, path string) {
 }
 
 func TestEncryptedRecordReadLimitAndFileReadFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not preserve POSIX unreadable-file mode bits")
+	}
 	keyring, err := NewKeyring()
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/conductor/auditbatcher/transport_test.go
+++ b/enterprise/conductor/auditbatcher/transport_test.go
@@ -94,7 +94,7 @@ func TestTransportDeliverOnceRetryReleasesRecord(t *testing.T) {
 	}
 	assertStats(t, q, Stats{Pending: 1})
 
-	record, err := readRecord(filepath.Join(q.pendingDir, id), q.maxPayloadBytes)
+	record, err := q.readRecord(filepath.Join(q.pendingDir, id))
 	if err != nil {
 		t.Fatalf("readRecord(pending) error = %v", err)
 	}
@@ -131,7 +131,7 @@ func TestTransportDeliverOnceClientErrorDropsRecord(t *testing.T) {
 	}
 	assertStats(t, q, Stats{Dead: 1})
 
-	record, err := readRecord(filepath.Join(q.deadDir, id), q.maxPayloadBytes)
+	record, err := q.readRecord(filepath.Join(q.deadDir, id))
 	if err != nil {
 		t.Fatalf("readRecord(dead) error = %v", err)
 	}
@@ -344,7 +344,7 @@ func TestTransportRun_GracefulShutdown(t *testing.T) {
 	default:
 		t.Fatalf("stats=%+v, want one pending or inflight record", stats)
 	}
-	record, err := readRecord(recordPath, q.maxPayloadBytes)
+	record, err := q.readRecord(recordPath)
 	if err != nil {
 		t.Fatalf("readRecord(%s) error = %v", recordPath, err)
 	}
@@ -409,7 +409,7 @@ func TestTransportDeliverOnceDropsAfterMaxAttempts(t *testing.T) {
 
 	// Poison must now be dead-lettered with reason max_retries.
 	assertStats(t, q, Stats{Pending: 1, Dead: 1})
-	deadRecord, err := readRecord(filepath.Join(q.deadDir, poisonID), q.maxPayloadBytes)
+	deadRecord, err := q.readRecord(filepath.Join(q.deadDir, poisonID))
 	if err != nil {
 		t.Fatalf("readRecord(dead) error = %v", err)
 	}
@@ -498,7 +498,7 @@ func TestTransportDeliverOnceDropsCorruptMaxRetryCountWithoutOverflow(t *testing
 		t.Fatalf("Enqueue() error = %v", err)
 	}
 	path := filepath.Join(q.pendingDir, id)
-	record, err := readRecord(path, q.maxPayloadBytes)
+	record, err := q.readRecord(path)
 	if err != nil {
 		t.Fatalf("readRecord() error = %v", err)
 	}
@@ -529,7 +529,7 @@ func TestTransportDeliverOnceDropsCorruptMaxRetryCountWithoutOverflow(t *testing
 		t.Fatal("DeliverOnce() error = nil, want drop error")
 	}
 	assertStats(t, q, Stats{Dead: 1})
-	deadRecord, err := readRecord(filepath.Join(q.deadDir, id), q.maxPayloadBytes)
+	deadRecord, err := q.readRecord(filepath.Join(q.deadDir, id))
 	if err != nil {
 		t.Fatalf("readRecord(dead) error = %v", err)
 	}

--- a/enterprise/conductor/auditbatcher/transport_test.go
+++ b/enterprise/conductor/auditbatcher/transport_test.go
@@ -503,9 +503,9 @@ func TestTransportDeliverOnceDropsCorruptMaxRetryCountWithoutOverflow(t *testing
 		t.Fatalf("readRecord() error = %v", err)
 	}
 	record.RetryCount = ^uint64(0)
-	data, err := json.Marshal(record)
+	data, err := encryptDiskRecord(record, q.keyring)
 	if err != nil {
-		t.Fatalf("Marshal(record) error = %v", err)
+		t.Fatalf("encryptDiskRecord(record) error = %v", err)
 	}
 	if err := durableWrite(path, data); err != nil {
 		t.Fatalf("durableWrite(record) error = %v", err)

--- a/enterprise/conductor/bootstrap/bootstrap.go
+++ b/enterprise/conductor/bootstrap/bootstrap.go
@@ -450,6 +450,7 @@ func layoutMaterialPaths(layout Layout) []string {
 		layout.FollowerConfigPath,
 		layout.FollowerBundleCacheDir,
 		layout.FollowerAuditQueueDir,
+		layout.FollowerQueueKeyring,
 		layout.FollowerRecorderDir,
 		layout.TrustRosterPath,
 		layout.RosterRootKeyPath,

--- a/enterprise/conductor/bootstrap/config.go
+++ b/enterprise/conductor/bootstrap/config.go
@@ -35,6 +35,7 @@ conductor:
   client_key_path: %q
   bundle_cache_dir: %q
   durable_audit_queue_dir: %q
+  durable_audit_queue_keyring: %q
   audit_signing_key_id: %q
   recorder_key_id: %q
   poll_interval: 30s
@@ -65,6 +66,7 @@ flight_recorder:
 		layout.FollowerClientKeyPath,
 		layout.FollowerBundleCacheDir,
 		layout.FollowerAuditQueueDir,
+		layout.FollowerQueueKeyring,
 		auditKeyID,
 		recorderKeyID,
 		layout.FollowerRecorderDir,

--- a/enterprise/conductor/bootstrap/fault_test.go
+++ b/enterprise/conductor/bootstrap/fault_test.go
@@ -95,6 +95,72 @@ func TestProduceSignedBatch_HonorsCancelledContext(t *testing.T) {
 	}
 }
 
+func TestProduceSignedBatch_FailsWhenQueueKeyringCannotBeCreated(t *testing.T) {
+	_, opts, id, _ := freshMaterial(t)
+	queueParent := filepath.Join(opts.Dir, "proof")
+	if err := os.MkdirAll(queueParent, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(queueParent, "queue-secrets"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := produceSignedBatch(context.Background(), filepath.Join(queueParent, "queue"), filepath.Join(opts.Dir, "recorder"), opts, id, priv, pub); err == nil {
+		t.Fatal("produceSignedBatch with unusable keyring parent should fail")
+	}
+}
+
+func TestProduceSignedBatch_FailsWhenQueueKeyringCannotBeSaved(t *testing.T) {
+	_, opts, id, _ := freshMaterial(t)
+	queueParent := filepath.Join(opts.Dir, "proof-save")
+	keyringTarget := filepath.Join(queueParent, "queue-secrets", "keyring.json")
+	if err := os.MkdirAll(keyringTarget, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := produceSignedBatch(context.Background(), filepath.Join(queueParent, "queue"), filepath.Join(opts.Dir, "recorder"), opts, id, priv, pub); err == nil {
+		t.Fatal("produceSignedBatch with directory keyring target should fail")
+	}
+}
+
+func TestLoadMaterialRejectsMissingQueueKeyring(t *testing.T) {
+	layout, _, _, _ := freshMaterial(t)
+	if err := os.Remove(layout.FollowerQueueKeyring); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadMaterial(layout); err == nil {
+		t.Fatal("loadMaterial with missing queue keyring should fail")
+	}
+}
+
+func TestGenerateMaterialFailsWhenQueueKeyringTargetIsDirectory(t *testing.T) {
+	dir := privateFleetDir(t)
+	opts := Options{Dir: dir}
+	normalize(&opts)
+	layout, err := newLayout(opts.Dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(layout.FollowerQueueKeyring, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	id := controlplane.FollowerIdentity{
+		OrgID:       opts.OrgID,
+		FleetID:     opts.FleetID,
+		InstanceID:  opts.InstanceID,
+		Environment: opts.Environment,
+	}
+	if _, err := generateMaterial(layout, opts, id); err == nil {
+		t.Fatal("generateMaterial with keyring directory target should fail")
+	}
+}
+
 // TestVerifyBatchOffline_RejectsWrongKey: the offline verifier must reject a
 // batch when checked against the wrong audit public key.
 func TestVerifyBatchOffline_RejectsWrongKey(t *testing.T) {

--- a/enterprise/conductor/bootstrap/fault_test.go
+++ b/enterprise/conductor/bootstrap/fault_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
@@ -109,8 +110,8 @@ func TestProduceSignedBatch_FailsWhenQueueKeyringCannotBeCreated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := produceSignedBatch(context.Background(), filepath.Join(queueParent, "queue"), filepath.Join(opts.Dir, "recorder"), opts, id, priv, pub); err == nil {
-		t.Fatal("produceSignedBatch with unusable keyring parent should fail")
+	if _, err := produceSignedBatch(context.Background(), filepath.Join(queueParent, "queue"), filepath.Join(opts.Dir, "recorder"), opts, id, priv, pub); err == nil || !strings.Contains(err.Error(), "load or initialize proof audit queue keyring") {
+		t.Fatalf("produceSignedBatch with unusable keyring parent error = %v, want keyring initialization failure", err)
 	}
 }
 
@@ -125,8 +126,8 @@ func TestProduceSignedBatch_FailsWhenQueueKeyringCannotBeSaved(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := produceSignedBatch(context.Background(), filepath.Join(queueParent, "queue"), filepath.Join(opts.Dir, "recorder"), opts, id, priv, pub); err == nil {
-		t.Fatal("produceSignedBatch with directory keyring target should fail")
+	if _, err := produceSignedBatch(context.Background(), filepath.Join(queueParent, "queue"), filepath.Join(opts.Dir, "recorder"), opts, id, priv, pub); err == nil || !strings.Contains(err.Error(), "load or initialize proof audit queue keyring") {
+		t.Fatalf("produceSignedBatch with directory keyring target error = %v, want keyring initialization failure", err)
 	}
 }
 
@@ -163,8 +164,8 @@ func TestLoadMaterialRejectsMissingQueueKeyring(t *testing.T) {
 	if err := os.Remove(layout.FollowerQueueKeyring); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := loadMaterial(layout); err == nil {
-		t.Fatal("loadMaterial with missing queue keyring should fail")
+	if _, err := loadMaterial(layout); err == nil || !strings.Contains(err.Error(), "load follower audit queue keyring") {
+		t.Fatalf("loadMaterial with missing queue keyring error = %v, want queue keyring load failure", err)
 	}
 }
 
@@ -185,8 +186,8 @@ func TestGenerateMaterialFailsWhenQueueKeyringTargetIsDirectory(t *testing.T) {
 		InstanceID:  opts.InstanceID,
 		Environment: opts.Environment,
 	}
-	if _, err := generateMaterial(layout, opts, id); err == nil {
-		t.Fatal("generateMaterial with keyring directory target should fail")
+	if _, err := generateMaterial(layout, opts, id); err == nil || !strings.Contains(err.Error(), "write follower audit queue keyring") {
+		t.Fatalf("generateMaterial with keyring directory target error = %v, want queue keyring write failure", err)
 	}
 }
 

--- a/enterprise/conductor/bootstrap/fault_test.go
+++ b/enterprise/conductor/bootstrap/fault_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
 )
 
@@ -126,6 +127,34 @@ func TestProduceSignedBatch_FailsWhenQueueKeyringCannotBeSaved(t *testing.T) {
 	}
 	if _, err := produceSignedBatch(context.Background(), filepath.Join(queueParent, "queue"), filepath.Join(opts.Dir, "recorder"), opts, id, priv, pub); err == nil {
 		t.Fatal("produceSignedBatch with directory keyring target should fail")
+	}
+}
+
+func TestProduceSignedBatchReusesDurableQueueKeyring(t *testing.T) {
+	_, opts, id, _ := freshMaterial(t)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queueDir := filepath.Join(opts.Dir, "proof-reuse", "queue")
+	recorderDir := filepath.Join(opts.Dir, "proof-reuse", "recorder")
+	if _, err := produceSignedBatch(context.Background(), queueDir, recorderDir, opts, id, priv, pub); err != nil {
+		t.Fatal(err)
+	}
+	keyringPath := filepath.Join(filepath.Dir(queueDir), "queue-secrets", "keyring.json")
+	before, err := auditbatcher.LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := produceSignedBatch(context.Background(), queueDir, recorderDir, opts, id, priv, pub); err != nil {
+		t.Fatal(err)
+	}
+	after, err := auditbatcher.LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.ActiveKeyID() != before.ActiveKeyID() {
+		t.Fatalf("bootstrap replaced durable queue key %q with %q", before.ActiveKeyID(), after.ActiveKeyID())
 	}
 }
 

--- a/enterprise/conductor/bootstrap/layout.go
+++ b/enterprise/conductor/bootstrap/layout.go
@@ -39,6 +39,7 @@ type Layout struct {
 	FollowerConfigPath     string
 	FollowerBundleCacheDir string
 	FollowerAuditQueueDir  string
+	FollowerQueueKeyring   string
 	FollowerRecorderDir    string
 
 	// Trust roster + its root keypair + the Conductor control keys it pins.
@@ -90,6 +91,7 @@ func newLayout(dir string) (Layout, error) {
 		FollowerConfigPath:     j("follower", "follower.yaml"),
 		FollowerBundleCacheDir: j("follower", "bundles"),
 		FollowerAuditQueueDir:  j("follower", "audit-queue"),
+		FollowerQueueKeyring:   j("follower-secrets", "audit-queue-keyring.json"),
 		FollowerRecorderDir:    j("follower", "recorder"),
 
 		TrustRosterPath:      j("trust", "trust-roster.json"),

--- a/enterprise/conductor/bootstrap/material.go
+++ b/enterprise/conductor/bootstrap/material.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
 	"github.com/luckyPipewrench/pipelock/internal/certgen"
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -59,6 +60,7 @@ func generateMaterial(layout Layout, opts Options, identity controlplane.Followe
 		filepath.Dir(layout.ConductorServerCertPath),
 		layout.ConductorStorageDir,
 		filepath.Dir(layout.FollowerClientCertPath),
+		filepath.Dir(layout.FollowerQueueKeyring),
 		layout.FollowerBundleCacheDir,
 		layout.FollowerAuditQueueDir,
 		layout.FollowerRecorderDir,
@@ -124,6 +126,13 @@ func generateMaterial(layout Layout, opts Options, identity controlplane.Followe
 	if err := writePublicKey(layout.FollowerAuditPubPath, auditPub); err != nil {
 		return nil, err
 	}
+	queueKeyring, err := auditbatcher.NewKeyring()
+	if err != nil {
+		return nil, fmt.Errorf("generate follower audit queue keyring: %w", err)
+	}
+	if err := queueKeyring.Save(layout.FollowerQueueKeyring); err != nil {
+		return nil, fmt.Errorf("write follower audit queue keyring: %w", err)
+	}
 
 	// 5. Conductor control keys + roster-root, then a signed trust roster.
 	rootFingerprint, err := generateTrust(layout, opts)
@@ -182,6 +191,9 @@ func loadMaterial(layout Layout) (*materialSet, error) {
 	auditKey, err := signing.LoadPrivateKeyFile(layout.FollowerAuditKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("load follower audit key: %w", err)
+	}
+	if _, err := auditbatcher.LoadKeyring(layout.FollowerQueueKeyring); err != nil {
+		return nil, fmt.Errorf("load follower audit queue keyring: %w", err)
 	}
 	rootPub, err := signing.LoadPublicKeyFile(layout.RosterRootPubPath)
 	if err != nil {

--- a/enterprise/conductor/bootstrap/roundtrip.go
+++ b/enterprise/conductor/bootstrap/roundtrip.go
@@ -302,9 +302,21 @@ func produceSignedBatch(ctx context.Context, queueDir, recorderDir string, opts 
 	if err := ctx.Err(); err != nil {
 		return auditbatcher.Batch{}, err
 	}
+	queueKeyringPath := filepath.Join(filepath.Dir(queueDir), "queue-secrets", "keyring.json")
+	keyring, err := auditbatcher.NewKeyring()
+	if err != nil {
+		return auditbatcher.Batch{}, fmt.Errorf("generate proof audit queue keyring: %w", err)
+	}
+	if err := auditbatcher.EnsureKeyringParent(queueKeyringPath); err != nil {
+		return auditbatcher.Batch{}, err
+	}
+	if err := keyring.Save(queueKeyringPath); err != nil {
+		return auditbatcher.Batch{}, fmt.Errorf("save proof audit queue keyring: %w", err)
+	}
 	queue, err := auditbatcher.Open(auditbatcher.Config{
 		Dir:             queueDir,
 		MaxPayloadBytes: conductorcore.MaxAuditPayloadBytes,
+		Keyring:         keyring,
 	})
 	if err != nil {
 		return auditbatcher.Batch{}, fmt.Errorf("open audit queue: %w", err)

--- a/enterprise/conductor/bootstrap/roundtrip.go
+++ b/enterprise/conductor/bootstrap/roundtrip.go
@@ -303,15 +303,9 @@ func produceSignedBatch(ctx context.Context, queueDir, recorderDir string, opts 
 		return auditbatcher.Batch{}, err
 	}
 	queueKeyringPath := filepath.Join(filepath.Dir(queueDir), "queue-secrets", "keyring.json")
-	keyring, err := auditbatcher.NewKeyring()
+	keyring, err := auditbatcher.LoadOrCreateKeyring(queueKeyringPath)
 	if err != nil {
-		return auditbatcher.Batch{}, fmt.Errorf("generate proof audit queue keyring: %w", err)
-	}
-	if err := auditbatcher.EnsureKeyringParent(queueKeyringPath); err != nil {
-		return auditbatcher.Batch{}, err
-	}
-	if err := keyring.Save(queueKeyringPath); err != nil {
-		return auditbatcher.Batch{}, fmt.Errorf("save proof audit queue keyring: %w", err)
+		return auditbatcher.Batch{}, fmt.Errorf("load or initialize proof audit queue keyring: %w", err)
 	}
 	queue, err := auditbatcher.Open(auditbatcher.Config{
 		Dir:             queueDir,

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -173,9 +173,14 @@ func buildConductorAuditTransport(cfg *config.Config, m *metrics.Metrics) (*audi
 	if cfg == nil || !cfg.Conductor.Enabled {
 		return nil, nil, nil
 	}
+	keyring, err := auditbatcher.LoadKeyring(cfg.Conductor.DurableAuditQueueKeyring)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading conductor audit queue keyring: %w", err)
+	}
 	q, err := auditbatcher.Open(auditbatcher.Config{
 		Dir:             cfg.Conductor.DurableAuditQueueDir,
 		MaxPayloadBytes: conductor.MaxAuditPayloadBytes,
+		Keyring:         keyring,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening conductor audit queue: %w", err)

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
@@ -172,6 +173,9 @@ func preserveConductorBundleLocalRuntimeState(oldCfg, newCfg *config.Config, bun
 func buildConductorAuditTransport(cfg *config.Config, m *metrics.Metrics) (*auditbatcher.Queue, *auditbatcher.Transport, error) {
 	if cfg == nil || !cfg.Conductor.Enabled {
 		return nil, nil, nil
+	}
+	if strings.TrimSpace(cfg.Conductor.DurableAuditQueueKeyring) == "" {
+		return nil, nil, errors.New("conductor durable audit queue keyring is required")
 	}
 	keyring, err := auditbatcher.LoadKeyring(cfg.Conductor.DurableAuditQueueKeyring)
 	if err != nil {

--- a/internal/cli/runtime/conductor_license_test.go
+++ b/internal/cli/runtime/conductor_license_test.go
@@ -123,6 +123,7 @@ func conductorLicenseGateConfigYAML(t *testing.T) string {
 	trustPath := filepath.Join(certDir, "trust-roster.json")
 	bundleCacheDir := filepath.Join(certDir, "bundles")
 	auditQueueDir := filepath.Join(certDir, "audit-queue")
+	auditQueueKeyring := filepath.Join(tmp, "secrets", "audit-queue-keyring.json")
 	if err := os.WriteFile(caPath, clientPEM, 0o600); err != nil {
 		t.Fatalf("WriteFile(ca): %v", err)
 	}
@@ -156,6 +157,7 @@ func conductorLicenseGateConfigYAML(t *testing.T) string {
 		"  trust_roster_path: " + strconv.Quote(trustPath) + "\n" +
 		"  bundle_cache_dir: " + strconv.Quote(bundleCacheDir) + "\n" +
 		"  durable_audit_queue_dir: " + strconv.Quote(auditQueueDir) + "\n" +
+		"  durable_audit_queue_keyring: " + strconv.Quote(auditQueueKeyring) + "\n" +
 		"  honor_remote_kill_switch: false\n"
 }
 

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -386,6 +386,19 @@ func TestBuildConductorAuditTransportRejectsMissingQueueKeyring(t *testing.T) {
 	}
 }
 
+func TestBuildConductorAuditTransportRejectsEmptyQueueKeyring(t *testing.T) {
+	cfg := &config.Config{
+		Conductor: config.Conductor{
+			Enabled:                  true,
+			DurableAuditQueueDir:     filepath.Join(t.TempDir(), "audit-queue"),
+			DurableAuditQueueKeyring: "",
+		},
+	}
+	if _, _, err := buildConductorAuditTransport(cfg, nil); err == nil || !strings.Contains(err.Error(), "queue keyring is required") {
+		t.Fatalf("buildConductorAuditTransport() error = %v, want empty keyring refusal", err)
+	}
+}
+
 // TestBuildConductorBundlePollerDisabled confirms the poller is a no-op (nil,
 // nil) when conductor is not enabled.
 func TestBuildConductorBundlePollerDisabled(t *testing.T) {

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -346,23 +346,26 @@ func TestBuildConductorBundlePollerRejectsBadRosterEvenWithHonorFalse(t *testing
 func TestBuildConductorAuditTransportReleasesQueueOnConstructorFailure(t *testing.T) {
 	dir := t.TempDir()
 	queueDir := filepath.Join(dir, "audit-queue")
+	queueKeyringPath := filepath.Join(dir, "secrets", "audit-queue-keyring.json")
+	keyring := writeTestQueueKeyring(t, queueKeyringPath)
 	caPath := filepath.Join(dir, "boss-ca.pem")
 	writePrivateTestFile(t, caPath, []byte("not a PEM bundle"))
 
 	cfg := &config.Config{
 		Conductor: config.Conductor{
-			Enabled:              true,
-			ConductorURL:         "https://conductor.example",
-			ServerCAFile:         caPath,
-			ClientCertPath:       filepath.Join(dir, "missing-client.crt"),
-			ClientKeyPath:        filepath.Join(dir, "missing-client.key"),
-			DurableAuditQueueDir: queueDir,
+			Enabled:                  true,
+			ConductorURL:             "https://conductor.example",
+			ServerCAFile:             caPath,
+			ClientCertPath:           filepath.Join(dir, "missing-client.crt"),
+			ClientKeyPath:            filepath.Join(dir, "missing-client.key"),
+			DurableAuditQueueDir:     queueDir,
+			DurableAuditQueueKeyring: queueKeyringPath,
 		},
 	}
 	if _, _, err := buildConductorAuditTransport(cfg, nil); err == nil {
 		t.Fatal("buildConductorAuditTransport() error = nil, want mTLS constructor failure")
 	}
-	reopened, err := auditbatcher.Open(auditbatcher.Config{Dir: queueDir})
+	reopened, err := auditbatcher.Open(auditbatcher.Config{Dir: queueDir, Keyring: keyring})
 	if err != nil {
 		t.Fatalf("Open(queue after failed build) error = %v, want lock released", err)
 	}
@@ -1163,6 +1166,7 @@ func newConductorApplyTestServer(t *testing.T) (*Server, runtimePolicySigner) {
 	caPath := filepath.Join(tmp, "boss-ca.pem")
 	clientCertPath := filepath.Join(tmp, "client.crt")
 	clientKeyPath := filepath.Join(tmp, "client.key")
+	queueKeyringPath := filepath.Join(tmp, "secrets", "audit-queue-keyring.json")
 	// A real signed roster is mandatory whenever conductor.enabled, independent
 	// of honor_remote_kill_switch: the policy-bundle poller must verify signed
 	// bundles against a pinned trust root before applying them.
@@ -1171,6 +1175,7 @@ func newConductorApplyTestServer(t *testing.T) (*Server, runtimePolicySigner) {
 	writePrivateTestFile(t, caPath, clientPEM)
 	writePrivateTestFile(t, clientCertPath, clientPEM)
 	writePrivateTestFile(t, clientKeyPath, clientKeyPEM)
+	writeTestQueueKeyring(t, queueKeyringPath)
 
 	recorderDir := filepath.Join(tmp, "recorder")
 	cfgPath := writeServerTestConfig(t, strings.Join([]string{
@@ -1194,6 +1199,7 @@ func newConductorApplyTestServer(t *testing.T) (*Server, runtimePolicySigner) {
 		"  client_key_path: " + strconv.Quote(clientKeyPath),
 		"  bundle_cache_dir: " + strconv.Quote(filepath.Join(tmp, "bundles")),
 		"  durable_audit_queue_dir: " + strconv.Quote(filepath.Join(tmp, "audit-queue")),
+		"  durable_audit_queue_keyring: " + strconv.Quote(queueKeyringPath),
 		"  audit_signing_key_id: audit-key-1",
 		"  recorder_key_id: recorder-key-1",
 		"  honor_remote_kill_switch: false",

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -372,6 +372,20 @@ func TestBuildConductorAuditTransportReleasesQueueOnConstructorFailure(t *testin
 	defer func() { _ = reopened.Close() }()
 }
 
+func TestBuildConductorAuditTransportRejectsMissingQueueKeyring(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Conductor: config.Conductor{
+			Enabled:                  true,
+			DurableAuditQueueDir:     filepath.Join(dir, "audit-queue"),
+			DurableAuditQueueKeyring: filepath.Join(dir, "missing-keyring.json"),
+		},
+	}
+	if _, _, err := buildConductorAuditTransport(cfg, nil); err == nil || !strings.Contains(err.Error(), "loading conductor audit queue keyring") {
+		t.Fatalf("buildConductorAuditTransport() error = %v, want missing keyring refusal", err)
+	}
+}
+
 // TestBuildConductorBundlePollerDisabled confirms the poller is a no-op (nil,
 // nil) when conductor is not enabled.
 func TestBuildConductorBundlePollerDisabled(t *testing.T) {

--- a/internal/cli/runtime/server_conductor_test.go
+++ b/internal/cli/runtime/server_conductor_test.go
@@ -45,6 +45,7 @@ func TestNewServer_ConductorAuditProducerFromConfig(t *testing.T) {
 	caPath := filepath.Join(tmp, "boss-ca.pem")
 	clientCertPath := filepath.Join(tmp, "client.crt")
 	clientKeyPath := filepath.Join(tmp, "client.key")
+	queueKeyringPath := filepath.Join(tmp, "secrets", "audit-queue-keyring.json")
 	// conductor.enabled requires a real signed roster + pinned fingerprint even
 	// with honor_remote_kill_switch:false - the policy-bundle poller verifies
 	// signed bundles against the pinned trust root.
@@ -53,6 +54,7 @@ func TestNewServer_ConductorAuditProducerFromConfig(t *testing.T) {
 	writePrivateTestFile(t, caPath, clientPEM)
 	writePrivateTestFile(t, clientCertPath, clientPEM)
 	writePrivateTestFile(t, clientKeyPath, clientKeyPEM)
+	writeTestQueueKeyring(t, queueKeyringPath)
 
 	cfgPath := writeServerTestConfig(t, strings.Join([]string{
 		"mode: balanced",
@@ -75,6 +77,7 @@ func TestNewServer_ConductorAuditProducerFromConfig(t *testing.T) {
 		"  client_key_path: " + strconv.Quote(clientKeyPath),
 		"  bundle_cache_dir: " + strconv.Quote(filepath.Join(tmp, "bundles")),
 		"  durable_audit_queue_dir: " + strconv.Quote(filepath.Join(tmp, "audit-queue")),
+		"  durable_audit_queue_keyring: " + strconv.Quote(queueKeyringPath),
 		"  audit_signing_key_id: audit-key-1",
 		"  recorder_key_id: recorder-key-1",
 		"  honor_remote_kill_switch: false",

--- a/internal/cli/runtime/test_file_helpers_enterprise_test.go
+++ b/internal/cli/runtime/test_file_helpers_enterprise_test.go
@@ -8,6 +8,8 @@ package runtime
 import (
 	"os"
 	"testing"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
 )
 
 func writePrivateTestFile(t *testing.T, path string, data []byte) {
@@ -15,4 +17,19 @@ func writePrivateTestFile(t *testing.T, path string, data []byte) {
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("WriteFile(%s) error = %v", path, err)
 	}
+}
+
+func writeTestQueueKeyring(t *testing.T, path string) *auditbatcher.Keyring {
+	t.Helper()
+	keyring, err := auditbatcher.NewKeyring()
+	if err != nil {
+		t.Fatalf("NewKeyring() error = %v", err)
+	}
+	if err := auditbatcher.EnsureKeyringParent(path); err != nil {
+		t.Fatalf("EnsureKeyringParent() error = %v", err)
+	}
+	if err := keyring.Save(path); err != nil {
+		t.Fatalf("Save(keyring) error = %v", err)
+	}
+	return keyring
 }

--- a/internal/config/conductor.go
+++ b/internal/config/conductor.go
@@ -92,16 +92,20 @@ func (c *Config) validateConductor(warnings *[]Warning) error {
 		return fmt.Errorf("conductor.trust_roster_root_fingerprint: %w", err)
 	}
 	for field, value := range map[string]string{
-		"conductor.trust_roster_path":       cfg.TrustRosterPath,
-		"conductor.server_ca_file":          cfg.ServerCAFile,
-		"conductor.client_cert_path":        cfg.ClientCertPath,
-		"conductor.client_key_path":         cfg.ClientKeyPath,
-		"conductor.bundle_cache_dir":        cfg.BundleCacheDir,
-		"conductor.durable_audit_queue_dir": cfg.DurableAuditQueueDir,
+		"conductor.trust_roster_path":           cfg.TrustRosterPath,
+		"conductor.server_ca_file":              cfg.ServerCAFile,
+		"conductor.client_cert_path":            cfg.ClientCertPath,
+		"conductor.client_key_path":             cfg.ClientKeyPath,
+		"conductor.bundle_cache_dir":            cfg.BundleCacheDir,
+		"conductor.durable_audit_queue_dir":     cfg.DurableAuditQueueDir,
+		"conductor.durable_audit_queue_keyring": cfg.DurableAuditQueueKeyring,
 	} {
 		if err := validateConductorAbsolutePath(field, value); err != nil {
 			return err
 		}
+	}
+	if pathWithin(cfg.DurableAuditQueueDir, cfg.DurableAuditQueueKeyring) {
+		return fmt.Errorf("conductor.durable_audit_queue_keyring must be outside conductor.durable_audit_queue_dir")
 	}
 	if strings.TrimSpace(cfg.EnrollmentTokenPath) != "" {
 		if err := validateConductorAbsolutePath("conductor.enrollment_token_path", cfg.EnrollmentTokenPath); err != nil {
@@ -112,8 +116,9 @@ func (c *Config) validateConductor(warnings *[]Warning) error {
 		}
 	}
 	for field, value := range map[string]string{
-		"conductor.bundle_cache_dir":        cfg.BundleCacheDir,
-		"conductor.durable_audit_queue_dir": cfg.DurableAuditQueueDir,
+		"conductor.bundle_cache_dir":            cfg.BundleCacheDir,
+		"conductor.durable_audit_queue_dir":     cfg.DurableAuditQueueDir,
+		"conductor.durable_audit_queue_keyring": cfg.DurableAuditQueueKeyring,
 	} {
 		if err := validateConductorPrivateParent(field, value); err != nil {
 			return err
@@ -130,6 +135,14 @@ func (c *Config) validateConductor(warnings *[]Warning) error {
 		}
 	}
 	return nil
+}
+
+func pathWithin(parent, candidate string) bool {
+	rel, err := filepath.Rel(filepath.Clean(parent), filepath.Clean(candidate))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func validateConductorDurations(cfg Conductor) error {

--- a/internal/config/conductor_test.go
+++ b/internal/config/conductor_test.go
@@ -560,14 +560,31 @@ func validConductorConfig(t *testing.T) Conductor {
 }
 
 func TestValidateConductor_QueueKeyringOutsideQueue(t *testing.T) {
-	cfg := Defaults()
-	cfg.Conductor = validConductorConfig(t)
-	cfg.Conductor.DurableAuditQueueKeyring = filepath.Join(cfg.Conductor.DurableAuditQueueDir, "keyring.json")
-	configureConductorRecorder(t, cfg)
-
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "must be outside") {
-		t.Fatalf("Validate() = %v, want queue-key separation refusal", err)
+	for _, tc := range []struct {
+		name    string
+		keyring func(string) string
+		wantErr bool
+	}{
+		{name: "equal", keyring: func(queue string) string { return queue }, wantErr: true},
+		{name: "descendant", keyring: func(queue string) string { return filepath.Join(queue, "keyring.json") }, wantErr: true},
+		{name: "sibling", keyring: func(queue string) string { return filepath.Join(filepath.Dir(queue), "secrets", "keyring.json") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.Conductor = validConductorConfig(t)
+			cfg.Conductor.DurableAuditQueueKeyring = tc.keyring(cfg.Conductor.DurableAuditQueueDir)
+			configureConductorRecorder(t, cfg)
+			err := cfg.Validate()
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "must be outside") {
+					t.Fatalf("Validate() = %v, want queue-key separation refusal", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Validate() = %v, want sibling keyring accepted", err)
+			}
+		})
 	}
 }
 

--- a/internal/config/conductor_test.go
+++ b/internal/config/conductor_test.go
@@ -547,6 +547,7 @@ func validConductorConfig(t *testing.T) Conductor {
 		ClientKeyPath:              filepath.Join(root, "client.key"),
 		BundleCacheDir:             filepath.Join(root, "bundles"),
 		DurableAuditQueueDir:       filepath.Join(root, "audit-queue"),
+		DurableAuditQueueKeyring:   filepath.Join(root, "secrets", "audit-queue-keyring.json"),
 		PollInterval:               "30s",
 		HonorRemoteKillSwitch:      true,
 		EmergencyStream:            ptrBool(true),
@@ -555,6 +556,18 @@ func validConductorConfig(t *testing.T) Conductor {
 		MaxMinVersionMinorSkew:     1,
 		MaxCapabilityThreshold:     7,
 		StalePolicy:                ConductorStalePolicy{GraceMultiplier: 1, AfterGrace: ConductorStaleStrictDenyAll},
+	}
+}
+
+func TestValidateConductor_QueueKeyringOutsideQueue(t *testing.T) {
+	cfg := Defaults()
+	cfg.Conductor = validConductorConfig(t)
+	cfg.Conductor.DurableAuditQueueKeyring = filepath.Join(cfg.Conductor.DurableAuditQueueDir, "keyring.json")
+	configureConductorRecorder(t, cfg)
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "must be outside") {
+		t.Fatalf("Validate() = %v, want queue-key separation refusal", err)
 	}
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -585,6 +585,7 @@ type Conductor struct {
 	ClientKeyPath              string               `yaml:"client_key_path"`
 	BundleCacheDir             string               `yaml:"bundle_cache_dir"`
 	DurableAuditQueueDir       string               `yaml:"durable_audit_queue_dir"`
+	DurableAuditQueueKeyring   string               `yaml:"durable_audit_queue_keyring"`
 	EnrollmentTokenPath        string               `yaml:"enrollment_token_path"`
 	AuditSigningKeyID          string               `yaml:"audit_signing_key_id"`
 	RecorderKeyID              string               `yaml:"recorder_key_id"`

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -52,6 +52,22 @@ expect_template_error "conductorFollower.auditQueueKeyringSecretRef.name is requ
   -f "$chart/examples/values-enterprise-follower.yaml" \
   --set conductorFollower.auditQueueKeyringSecretRef.name=
 
+expect_template_error "conductorFollower.auditQueueKeyringSecretRef.key is required" \
+  -f "$chart/examples/values-enterprise-follower.yaml" \
+  --set conductorFollower.auditQueueKeyringSecretRef.key=
+
+expect_template_error "conductorFollower.auditQueueKeyringSecretRef.mountPath is required" \
+  -f "$chart/examples/values-enterprise-follower.yaml" \
+  --set conductorFollower.auditQueueKeyringSecretRef.mountPath=
+
+for overlapping_keyring_mount in \
+  /var/lib/pipelock/conductor/audit-queue \
+  /var/lib/pipelock/conductor/audit-queue/keys; do
+  expect_template_error "conductorFollower.auditQueueKeyringSecretRef.mountPath must be outside" \
+    -f "$chart/examples/values-enterprise-follower.yaml" \
+    --set "conductorFollower.auditQueueKeyringSecretRef.mountPath=${overlapping_keyring_mount}"
+done
+
 expect_template_error "enterprise modes require explicit networkPolicy.ingress and networkPolicy.egress rules" \
   --set mode=conductor \
   --set networkPolicy.enabled=true \

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -104,7 +104,8 @@ grep -q -- "pipelock-follower-audit-queue" "$render_dir/values-enterprise-follow
 grep -q -- 'secretName: "follower-audit-queue-keyring"' "$render_dir/values-enterprise-follower.yaml"
 grep -q -- 'key: "audit-queue-keyring.json"' "$render_dir/values-enterprise-follower.yaml"
 grep -q -- 'mountPath: "/etc/pipelock/conductor/audit-queue-key"' "$render_dir/values-enterprise-follower.yaml"
-grep -q -A2 -- 'name: conductor-audit-queue-keyring' "$render_dir/values-enterprise-follower.yaml" | grep -q -- 'readOnly: true'
+keyring_mount_block=$(grep -A2 -- 'name: conductor-audit-queue-keyring' "$render_dir/values-enterprise-follower.yaml" || true)
+[[ "$keyring_mount_block" == *"readOnly: true"* ]]
 grep -q -- 'durable_audit_queue_keyring: /etc/pipelock/conductor/audit-queue-key/audit-queue-keyring.json' "$render_dir/values-enterprise-follower.yaml"
 
 grep -q -- "- conductor" "$render_dir/values-enterprise-conductor.yaml"

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -48,6 +48,10 @@ expect_template_error "/image/digest" \
 expect_template_error "conductorFollower.conductorURL is required" \
   --set conductorFollower.enabled=true
 
+expect_template_error "conductorFollower.auditQueueKeyringSecretRef.name is required" \
+  -f "$chart/examples/values-enterprise-follower.yaml" \
+  --set conductorFollower.auditQueueKeyringSecretRef.name=
+
 expect_template_error "enterprise modes require explicit networkPolicy.ingress and networkPolicy.egress rules" \
   --set mode=conductor \
   --set networkPolicy.enabled=true \
@@ -97,6 +101,8 @@ grep -q -- "- run" "$render_dir/default.yaml"
 grep -q -- "conductor:" "$render_dir/values-enterprise-follower.yaml"
 grep -q -- "pipelock-follower-bundles" "$render_dir/values-enterprise-follower.yaml"
 grep -q -- "pipelock-follower-audit-queue" "$render_dir/values-enterprise-follower.yaml"
+grep -q -- "conductor-audit-queue-keyring" "$render_dir/values-enterprise-follower.yaml"
+grep -q -- "durable_audit_queue_keyring:" "$render_dir/values-enterprise-follower.yaml"
 
 grep -q -- "- conductor" "$render_dir/values-enterprise-conductor.yaml"
 grep -q -- "- serve" "$render_dir/values-enterprise-conductor.yaml"

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -101,8 +101,11 @@ grep -q -- "- run" "$render_dir/default.yaml"
 grep -q -- "conductor:" "$render_dir/values-enterprise-follower.yaml"
 grep -q -- "pipelock-follower-bundles" "$render_dir/values-enterprise-follower.yaml"
 grep -q -- "pipelock-follower-audit-queue" "$render_dir/values-enterprise-follower.yaml"
-grep -q -- "conductor-audit-queue-keyring" "$render_dir/values-enterprise-follower.yaml"
-grep -q -- "durable_audit_queue_keyring:" "$render_dir/values-enterprise-follower.yaml"
+grep -q -- 'secretName: "follower-audit-queue-keyring"' "$render_dir/values-enterprise-follower.yaml"
+grep -q -- 'key: "audit-queue-keyring.json"' "$render_dir/values-enterprise-follower.yaml"
+grep -q -- 'mountPath: "/etc/pipelock/conductor/audit-queue-key"' "$render_dir/values-enterprise-follower.yaml"
+grep -q -A2 -- 'name: conductor-audit-queue-keyring' "$render_dir/values-enterprise-follower.yaml" | grep -q -- 'readOnly: true'
+grep -q -- 'durable_audit_queue_keyring: /etc/pipelock/conductor/audit-queue-key/audit-queue-keyring.json' "$render_dir/values-enterprise-follower.yaml"
 
 grep -q -- "- conductor" "$render_dir/values-enterprise-conductor.yaml"
 grep -q -- "- serve" "$render_dir/values-enterprise-conductor.yaml"


### PR DESCRIPTION
## Summary

- encrypt durable audit-queue records with AES-256-GCM
- add key initialization, inspection, rotation, migration, revocation, and recovery commands
- migrate plaintext and retired-key records during startup while preserving crash recovery
- provision the keyring separately from the queue volume through Helm
- enforce maximum-size encrypted-record recovery across restart and delivery

## Upgrade note

Conductor followers require a separately provisioned audit-queue keyring before enabling this version. Existing plaintext records are migrated on startup after the keyring is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `durable_audit_queue_keyring` to encrypt durable audit-queue records at rest (AES-256-GCM).
  * Helm chart enhancements: enterprise follower supports a Secret-backed, read-only audit-queue keyring mount.
  * Introduced enterprise `audit-queue-key` commands for keyring lifecycle management (init/inspect/rotate/migrate/revoke/recover).
* **Bug Fixes**
  * Stronger fail-closed behavior: startup/reads are blocked when the keyring is missing or authentication fails; corrupt records are quarantined.
  * Added validation to ensure the keyring is mounted outside the durable audit-queue directory, with safer rotation/revocation rules.
* **Documentation**
  * Updated configuration references and runbooks with required settings and day-2 rotation/migration/recovery procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->