### PR TITLE
fix(conductor): make audit queue keyring optional with opt-in encryption

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3141,6 +3141,8 @@ conductor:
   client_key_path: /etc/pipelock/follower.key
   bundle_cache_dir: /var/lib/pipelock/bundles
   durable_audit_queue_dir: /var/lib/pipelock/audit-queue
+  # Optional: set to enable AES-GCM encryption for durable audit queue records.
+  # When unset, the queue remains plaintext-compatible and validation emits a warning.
   durable_audit_queue_keyring: /etc/pipelock/secrets/audit-queue-keyring.json
   enrollment_token_path: /etc/pipelock/conductor/enrollment-token
   poll_interval: 30s
@@ -3159,7 +3161,7 @@ conductor:
 | `client_cert_path` / `client_key_path` | (required) | Follower mTLS client certificate and private key. |
 | `bundle_cache_dir` | (required) | Directory caching verified policy bundles across restarts. |
 | `durable_audit_queue_dir` | (required) | On-disk queue for signed evidence batches awaiting delivery to the audit sink. |
-| `durable_audit_queue_keyring` | (required) | Encryption keyring for durable queue records. Must be outside `durable_audit_queue_dir`; mount it from a separate Secret or volume. |
+| `durable_audit_queue_keyring` | (none) | Optional encryption keyring for durable queue records. When unset, the follower keeps the plaintext-compatible queue format and emits an advisory warning that records are unencrypted at rest. Set this absolute path to enable AES-GCM encryption; it must be outside `durable_audit_queue_dir` and mounted from a separate Secret or volume. |
 | `audit_signing_key_id` | `instance_id` | Key ID the follower signs audit batches with. |
 | `recorder_key_id` | `instance_id` | Key ID for the follower's flight-recorder checkpoints. |
 | `enrollment_token_path` | (none) | Path to a single-use enrollment token file. When set, the follower auto-enrolls on startup, registering its audit public key with Conductor so it appears in `fleet status` and its evidence is ingested. Enrollment is best-effort (a failed enroll logs a warning and never blocks enforcement); a marker under `bundle_cache_dir` skips normal restart retries. If the leader accepts the token but the marker write fails, the next restart may retry the already-consumed token and log a warning while enforcement continues. Must be an absolute path with no world-writable ancestor. Unset means no auto-enroll (enroll out of band with `pipelock conductor enroll`). |
@@ -3173,7 +3175,7 @@ conductor:
 | `stale_policy.grace_multiplier` | `1` | Number of original bundle-validity windows added after expiry before the after-grace action applies. Must be greater than zero. |
 | `stale_policy.after_grace` | `strict_deny_all` | Runtime action after the grace window. `strict_deny_all` engages the independent `conductor_stale` kill-switch source; `continue_last_known_good` keeps serving the expired last-applied bundle and emits an advisory warning. |
 
-When `enabled: true`, validation additionally requires the [flight recorder](#flight-recorder-v21) enabled with `sign_checkpoints: true` and a configured `signing_key_path` (a follower must produce signed evidence to participate), all file paths absolute, and no world-writable ancestor directory on any configured path.
+When `enabled: true`, validation additionally requires the [flight recorder](#flight-recorder-v21) enabled with `sign_checkpoints: true` and a configured `signing_key_path` (a follower must produce signed evidence to participate), all required file paths absolute, and no world-writable ancestor directory on any configured path. `durable_audit_queue_keyring` is validated only when set; an unset keyring is valid but warns because the durable queue is unencrypted at rest.
 
 **Stale-policy enforcement.** The follower evaluates the active bundle
 immediately at startup and on the runtime check interval. A missing, unreadable,

--- a/docs/guides/conductor-production-runbook.md
+++ b/docs/guides/conductor-production-runbook.md
@@ -344,6 +344,8 @@ conductor:
   client_key_path: /etc/pipelock/follower.key
   bundle_cache_dir: /var/lib/pipelock/bundles
   durable_audit_queue_dir: /var/lib/pipelock/audit-queue
+  # Optional: omit to keep the existing plaintext-compatible durable queue.
+  # Set only after provisioning the keyring outside the queue directory.
   durable_audit_queue_keyring: /etc/pipelock/secrets/audit-queue-keyring.json
   # audit_signing_key_id and recorder_key_id default to instance_id when omitted; override only if the audit sink expects a different key id
   # audit_signing_key_id: edge-01-audit
@@ -365,9 +367,14 @@ example; do not copy its paths into Helm-generated configuration. On Kubernetes,
 use
 [`values-enterprise-follower.yaml`](../../charts/pipelock/examples/values-enterprise-follower.yaml):
 
-Create a writable operator-owned source keyring before the first start, then
-import it into a Kubernetes Secret mounted separately from the queue PVC. The
-chart renders `durable_audit_queue_keyring` from
+Existing followers can upgrade with no queue-keyring change: when
+`durable_audit_queue_keyring` is unset, the follower keeps using the
+plaintext-compatible durable audit queue and emits a warning that queued records
+are unencrypted at rest.
+
+To enable encryption, create a writable operator-owned source keyring outside
+the queue directory, then import it into a Kubernetes Secret mounted separately
+from the queue PVC. The chart renders `durable_audit_queue_keyring` from
 `auditQueueKeyringSecretRef.mountPath` and `.key` (the example resolves to
 `/etc/pipelock/conductor/audit-queue-key/audit-queue-keyring.json`). The mounted
 copy is runtime-only and read-only. Keep the operator source directory at
@@ -379,6 +386,20 @@ pipelock conductor audit-queue-key init \
   --keyring "$PWD/operator-secrets/audit-queue-keyring.json"
 kubectl -n pipelock create secret generic follower-audit-queue-keyring \
   --from-file=audit-queue-keyring.json="$PWD/operator-secrets/audit-queue-keyring.json"
+```
+
+For a live follower, scale down before providing the Secret and setting
+`durable_audit_queue_keyring`, then scale back up. On first start with the
+keyring configured, legacy plaintext queue records auto-encrypt under the active
+key before delivery resumes:
+
+```bash
+kubectl -n pipelock scale deployment pipelock-follower --replicas=0
+kubectl -n pipelock create secret generic follower-audit-queue-keyring \
+  --from-file=audit-queue-keyring.json="$PWD/operator-secrets/audit-queue-keyring.json"
+# Update the follower config or Helm values to set durable_audit_queue_keyring
+# to the mounted Secret path, then apply the rollout.
+kubectl -n pipelock scale deployment pipelock-follower --replicas=1
 ```
 
 Day-2 lifecycle commands require the follower to be stopped and must run in an

--- a/docs/guides/conductor.md
+++ b/docs/guides/conductor.md
@@ -236,6 +236,8 @@ conductor:
   client_key_path: /etc/pipelock/follower.key
   bundle_cache_dir: /var/lib/pipelock/bundles
   durable_audit_queue_dir: /var/lib/pipelock/audit-queue
+  # Optional. Set it to encrypt the durable audit queue at rest (AES-GCM). When
+  # unset, the queue runs unencrypted and the proxy warns at startup.
   durable_audit_queue_keyring: /etc/pipelock/secrets/audit-queue-keyring.json
   audit_signing_key_id: edge-01-audit
   recorder_key_id: edge-01-recorder

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -808,6 +808,8 @@ conductor:
   client_key_path: "/etc/pipelock/conductor/client.key"
   bundle_cache_dir: "/var/lib/pipelock/conductor/bundles"
   durable_audit_queue_dir: "/var/lib/pipelock/conductor/audit-queue"
+  # Optional. Set it to encrypt the durable audit queue at rest (AES-GCM). When
+  # unset, the queue runs unencrypted and the proxy warns at startup.
   durable_audit_queue_keyring: "/etc/pipelock/secrets/audit-queue-keyring.json"
   audit_signing_key_id: "instance-audit-1"
   recorder_key_id: "instance-recorder-1"

--- a/enterprise/cli/conductor/audit_queue_key.go
+++ b/enterprise/cli/conductor/audit_queue_key.go
@@ -86,7 +86,7 @@ func createAuditQueueKeyring(cmd *cobra.Command, path string) error {
 // at-rest encryption boundary, so init refuses it up front rather than deferring
 // to config validation at proxy start.
 func keyringWithinQueueDir(queueDir, keyring string) bool {
-	rel, err := filepath.Rel(filepath.Clean(queueDir), filepath.Clean(keyring))
+	rel, err := filepath.Rel(canonicalContainmentPath(queueDir), canonicalContainmentPath(keyring))
 	if err != nil {
 		return false
 	}
@@ -94,6 +94,35 @@ func keyringWithinQueueDir(queueDir, keyring string) bool {
 		return false
 	}
 	return true
+}
+
+// canonicalContainmentPath returns an absolute, symlink-resolved path so a
+// relative path or a symlinked parent cannot defeat the queue/keyring
+// separation check. The keyring file itself may not exist yet, so it resolves
+// symlinks on the deepest existing ancestor and re-appends the remaining
+// components physically.
+func canonicalContainmentPath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	abs = filepath.Clean(abs)
+	rest := ""
+	cur := abs
+	for {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			if rest == "" {
+				return resolved
+			}
+			return filepath.Join(resolved, rest)
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return abs
+		}
+		rest = filepath.Join(filepath.Base(cur), rest)
+		cur = parent
+	}
 }
 
 func auditQueueKeyInspectCmd() *cobra.Command {

--- a/enterprise/cli/conductor/audit_queue_key.go
+++ b/enterprise/cli/conductor/audit_queue_key.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -44,6 +45,9 @@ func auditQueueKeyInitCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if strings.TrimSpace(opts.queueDir) != "" {
+				if keyringWithinQueueDir(opts.queueDir, opts.keyring) {
+					return fmt.Errorf("keyring %q must be outside the audit queue directory %q; a keyring on the queue volume defeats at-rest encryption", opts.keyring, opts.queueDir)
+				}
 				return auditbatcher.WithQueueMaintenanceLock(opts.queueDir, func() error {
 					return createAuditQueueKeyring(cmd, opts.keyring)
 				})
@@ -75,6 +79,21 @@ func createAuditQueueKeyring(cmd *cobra.Command, path string) error {
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "created audit queue keyring %s (active %s)\n", path, keyring.ActiveKeyID())
 	return nil
+}
+
+// keyringWithinQueueDir reports whether keyring resolves to the queue directory
+// itself or a descendant of it. A keyring stored on the queue volume defeats the
+// at-rest encryption boundary, so init refuses it up front rather than deferring
+// to config validation at proxy start.
+func keyringWithinQueueDir(queueDir, keyring string) bool {
+	rel, err := filepath.Rel(filepath.Clean(queueDir), filepath.Clean(keyring))
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
 }
 
 func auditQueueKeyInspectCmd() *cobra.Command {

--- a/enterprise/cli/conductor/audit_queue_key.go
+++ b/enterprise/cli/conductor/audit_queue_key.go
@@ -43,28 +43,38 @@ func auditQueueKeyInitCmd() *cobra.Command {
 		Short: "Create a new audit-queue keyring",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if _, err := os.Lstat(opts.keyring); err == nil {
-				return fmt.Errorf("audit queue keyring already exists: %s", opts.keyring)
-			} else if !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("inspect audit queue keyring: %w", err)
+			if strings.TrimSpace(opts.queueDir) != "" {
+				return auditbatcher.WithQueueMaintenanceLock(opts.queueDir, func() error {
+					return createAuditQueueKeyring(cmd, opts.keyring)
+				})
 			}
-			keyring, err := auditbatcher.NewKeyring()
-			if err != nil {
-				return err
-			}
-			if err := auditbatcher.EnsureKeyringParent(opts.keyring); err != nil {
-				return err
-			}
-			if err := keyring.Save(opts.keyring); err != nil {
-				return err
-			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "created audit queue keyring %s (active %s)\n", opts.keyring, keyring.ActiveKeyID())
-			return nil
+			return createAuditQueueKeyring(cmd, opts.keyring)
 		},
 	}
 	cmd.Flags().StringVar(&opts.keyring, "keyring", "", "path to the keyring file (required; keep outside the audit queue volume)")
 	_ = cmd.MarkFlagRequired("keyring")
+	cmd.Flags().StringVar(&opts.queueDir, "queue-dir", "", "initialized durable audit queue directory to lock while preparing this keyring")
 	return cmd
+}
+
+func createAuditQueueKeyring(cmd *cobra.Command, path string) error {
+	if _, err := os.Lstat(path); err == nil {
+		return fmt.Errorf("audit queue keyring already exists: %s; use rotate or recover instead of clobbering it", path)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect audit queue keyring: %w", err)
+	}
+	keyring, err := auditbatcher.NewKeyring()
+	if err != nil {
+		return err
+	}
+	if err := auditbatcher.EnsureKeyringParent(path); err != nil {
+		return err
+	}
+	if err := keyring.Save(path); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "created audit queue keyring %s (active %s)\n", path, keyring.ActiveKeyID())
+	return nil
 }
 
 func auditQueueKeyInspectCmd() *cobra.Command {

--- a/enterprise/cli/conductor/audit_queue_key_test.go
+++ b/enterprise/cli/conductor/audit_queue_key_test.go
@@ -115,6 +115,16 @@ func TestAuditQueueKeyCommandsRespectQueueLock(t *testing.T) {
 	if !errors.Is(err, auditbatcher.ErrQueueLocked) {
 		t.Fatalf("migrate while queue live error = %v, want ErrQueueLocked", err)
 	}
+
+	initPath := filepath.Join(root, "secrets", "second-keyring.json")
+	cmd = auditQueueKeyCmd()
+	cmd.SetArgs([]string{"init", "--keyring", initPath, "--queue-dir", queueDir})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err = cmd.Execute()
+	if !errors.Is(err, auditbatcher.ErrQueueLocked) {
+		t.Fatalf("init while queue live error = %v, want ErrQueueLocked", err)
+	}
 }
 
 func TestAuditQueueKeyInspectReportsUnreadableRecords(t *testing.T) {
@@ -153,8 +163,12 @@ func TestAuditQueueKeyInitRefusesOverwrite(t *testing.T) {
 	cmd.SetArgs([]string{"init", "--keyring", path})
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
-	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "already exists") {
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
 		t.Fatalf("second init error = %v, want overwrite refusal", err)
+	}
+	if !strings.Contains(err.Error(), "rotate or recover") {
+		t.Fatalf("second init error = %v, want lifecycle guidance", err)
 	}
 }
 

--- a/enterprise/cli/conductor/audit_queue_key_test.go
+++ b/enterprise/cli/conductor/audit_queue_key_test.go
@@ -173,6 +173,33 @@ func TestAuditQueueKeyInitRefusesSymlinkedKeyringIntoQueueDir(t *testing.T) {
 	}
 }
 
+func TestAuditQueueKeyInitRefusesRelativeKeyringInsideQueueDir(t *testing.T) {
+	root := t.TempDir()
+	// A relative --queue-dir and a relative keyring path that resolves inside it.
+	// The old lexical filepath.Rel between a relative and an absolute path errored
+	// and returned "outside"; canonicalizing both to absolute physical paths
+	// catches it.
+	t.Chdir(root)
+	if err := os.MkdirAll("queue", 0o750); err != nil {
+		t.Fatalf("MkdirAll(queue) error = %v", err)
+	}
+	// Relative --queue-dir with an ABSOLUTE keyring inside it: the exact bypass a
+	// lexical filepath.Rel misses (Rel of a relative parent against an absolute
+	// candidate errors, so the old check reported "outside").
+	absKeyring := filepath.Join(root, "queue", "keyring.json")
+	cmd := auditQueueKeyCmd()
+	cmd.SetArgs([]string{"init", "--keyring", absKeyring, "--queue-dir", "queue"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "must be outside") {
+		t.Fatalf("init relative keyring inside queue error = %v, want \"must be outside\"", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(root, "queue", "keyring.json")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("refused init must not create the relative keyring inside the queue; stat err = %v", statErr)
+	}
+}
+
 func TestAuditQueueKeyInspectReportsUnreadableRecords(t *testing.T) {
 	root := t.TempDir()
 	keyringPath := filepath.Join(root, "secrets", "keyring.json")

--- a/enterprise/cli/conductor/audit_queue_key_test.go
+++ b/enterprise/cli/conductor/audit_queue_key_test.go
@@ -127,6 +127,26 @@ func TestAuditQueueKeyCommandsRespectQueueLock(t *testing.T) {
 	}
 }
 
+func TestAuditQueueKeyInitRefusesKeyringInsideQueueDir(t *testing.T) {
+	root := t.TempDir()
+	queueDir := filepath.Join(root, "queue")
+	if err := os.MkdirAll(queueDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll(queueDir) error = %v", err)
+	}
+	insideKeyring := filepath.Join(queueDir, "keyring.json")
+	cmd := auditQueueKeyCmd()
+	cmd.SetArgs([]string{"init", "--keyring", insideKeyring, "--queue-dir", queueDir})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "must be outside") {
+		t.Fatalf("init keyring inside queue error = %v, want \"must be outside\"", err)
+	}
+	if _, statErr := os.Lstat(insideKeyring); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("refused init must not create the keyring file; stat err = %v", statErr)
+	}
+}
+
 func TestAuditQueueKeyInspectReportsUnreadableRecords(t *testing.T) {
 	root := t.TempDir()
 	keyringPath := filepath.Join(root, "secrets", "keyring.json")

--- a/enterprise/cli/conductor/audit_queue_key_test.go
+++ b/enterprise/cli/conductor/audit_queue_key_test.go
@@ -147,6 +147,32 @@ func TestAuditQueueKeyInitRefusesKeyringInsideQueueDir(t *testing.T) {
 	}
 }
 
+func TestAuditQueueKeyInitRefusesSymlinkedKeyringIntoQueueDir(t *testing.T) {
+	root := t.TempDir()
+	queueDir := filepath.Join(root, "queue")
+	if err := os.MkdirAll(queueDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll(queueDir) error = %v", err)
+	}
+	// A symlink whose target is the queue directory: lexically the keyring path
+	// is outside queueDir, but it physically resolves inside it.
+	linkDir := filepath.Join(root, "link-to-queue")
+	if err := os.Symlink(queueDir, linkDir); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	smuggled := filepath.Join(linkDir, "keyring.json")
+	cmd := auditQueueKeyCmd()
+	cmd.SetArgs([]string{"init", "--keyring", smuggled, "--queue-dir", queueDir})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "must be outside") {
+		t.Fatalf("init symlinked keyring into queue error = %v, want \"must be outside\"", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(queueDir, "keyring.json")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("refused init must not create the keyring through the symlink; stat err = %v", statErr)
+	}
+}
+
 func TestAuditQueueKeyInspectReportsUnreadableRecords(t *testing.T) {
 	root := t.TempDir()
 	keyringPath := filepath.Join(root, "secrets", "keyring.json")

--- a/enterprise/conductor/auditbatcher/key_usage.go
+++ b/enterprise/conductor/auditbatcher/key_usage.go
@@ -178,6 +178,15 @@ func RecoverQueueKeyring(queueDir, livePath, backupPath string) (string, error) 
 	return backup.ActiveKeyID(), nil
 }
 
+func WithQueueMaintenanceLock(dir string, fn func() error) error {
+	q, err := lockQueueForKeyMaintenance(dir, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = q.releaseLock() }()
+	return fn()
+}
+
 func lockQueueForKeyMaintenance(dir string, maxPayloadBytes uint64) (*Queue, error) {
 	if maxPayloadBytes == 0 {
 		maxPayloadBytes = conductor.MaxAuditPayloadBytes

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -506,8 +506,30 @@ func (q *Queue) verifyPlaintextRecordsLocked() error {
 		}
 		for _, id := range files {
 			path := filepath.Join(dir, id)
-			if _, _, _, err := readRecordWithKeyring(path, q.maxPayloadBytes, nil); err != nil {
+			_, _, _, err := readRecordWithKeyring(path, q.maxPayloadBytes, nil)
+			if err == nil {
+				continue
+			}
+			// Fail closed on a v2 encrypted record found in plaintext mode (a
+			// keyring was configured and then removed): errQueueKeyUnavailable is
+			// not ErrCorruptRecord, so it takes this branch and blocks startup
+			// rather than silently dropping still-encrypted evidence.
+			if errors.Is(err, errQueueKeyUnavailable) || !errors.Is(err, ErrCorruptRecord) {
 				return fmt.Errorf("auditbatcher: plaintext queue record %s: %w", id, err)
+			}
+			// A corrupt record already quarantined in dead/ must not turn a later
+			// restart into a permanent availability failure. Mirror encrypted-mode
+			// migration: skip dead-letter corruption, quarantine a corrupt live
+			// record so the remaining queue can still open.
+			if dir == q.deadDir {
+				continue
+			}
+			deadPath, pathErr := uniqueDeadPath(q.deadDir, id)
+			if pathErr != nil {
+				return fmt.Errorf("auditbatcher: quarantine queue record %s: %w", id, errors.Join(err, pathErr))
+			}
+			if moveErr := moveToDead(path, deadPath); moveErr != nil {
+				return fmt.Errorf("auditbatcher: quarantine queue record %s: %w", id, errors.Join(err, moveErr))
 			}
 		}
 	}

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -47,7 +47,12 @@ const (
 	recordExt              = ".json"
 )
 
-const lockFileName = ".lock"
+const (
+	lockFileName       = ".lock"
+	queueStateFileName = "queue-state.json"
+)
+
+const maxQueueStateBytes = 1024
 
 var (
 	ErrQueueEmpty    = errors.New("auditbatcher: queue empty")
@@ -56,6 +61,8 @@ var (
 	ErrQueueLocked   = errors.New("auditbatcher: queue already locked by another process")
 	ErrQueueClosed   = errors.New("auditbatcher: queue closed")
 )
+
+var errQueueEncryptionPreviouslySeen = errors.New("auditbatcher: durable audit queue previously ran encrypted; refusing plaintext open without a keyring")
 
 type Config struct {
 	Dir             string
@@ -116,6 +123,10 @@ type diskRecord struct {
 	DroppedReason string                       `json:"dropped_reason,omitempty"`
 }
 
+type queueState struct {
+	EncryptionSeen bool `json:"encryption_seen"`
+}
+
 func Open(cfg Config) (*Queue, error) {
 	if strings.TrimSpace(cfg.Dir) == "" {
 		return nil, errors.New("auditbatcher: queue dir required")
@@ -163,10 +174,17 @@ func Open(cfg Config) (*Queue, error) {
 	// so they're invisible to claim but visible to df). Opening fresh is the
 	// only safe time to remove them - no other writer could legitimately
 	// have a .tmp-* in flight before Open returns.
-	for _, dir := range []string{q.pendingDir, q.inflightDir, q.deadDir} {
+	for _, dir := range []string{q.dir, q.pendingDir, q.inflightDir, q.deadDir} {
 		if err := sweepStaleTempsLocked(dir); err != nil {
 			return nil, err
 		}
+	}
+	if q.keyring == nil {
+		if err := q.verifyPlaintextOpenAllowedLocked(); err != nil {
+			return nil, err
+		}
+	} else if err := q.markEncryptionSeenLocked(); err != nil {
+		return nil, err
 	}
 	if err := q.migrateRecordsLocked(); err != nil {
 		return nil, err
@@ -534,6 +552,62 @@ func (q *Queue) verifyPlaintextRecordsLocked() error {
 		}
 	}
 	return nil
+}
+
+func (q *Queue) verifyPlaintextOpenAllowedLocked() error {
+	seen, err := q.queueEncryptionSeenLocked()
+	if err != nil {
+		return err
+	}
+	if seen {
+		return errQueueEncryptionPreviouslySeen
+	}
+	return nil
+}
+
+func (q *Queue) markEncryptionSeenLocked() error {
+	seen, err := q.queueEncryptionSeenLocked()
+	if err != nil {
+		return err
+	}
+	if seen {
+		return nil
+	}
+	// Defense-in-depth against accidental downgrade-after-encryption, such as a
+	// config or Secret regression after the queue drains empty. This is not a
+	// cryptographic guarantee: a writer on the queue volume can delete the marker.
+	// Encrypted v2 records remain the strong signal when any records exist.
+	data, err := json.Marshal(queueState{EncryptionSeen: true})
+	if err != nil {
+		return fmt.Errorf("auditbatcher: marshal queue state: %w", err)
+	}
+	if err := durableWrite(q.queueStatePath(), append(data, '\n')); err != nil {
+		return fmt.Errorf("auditbatcher: write queue state: %w", err)
+	}
+	return nil
+}
+
+func (q *Queue) queueEncryptionSeenLocked() (bool, error) {
+	data, err := securefile.Read(q.queueStatePath(), securefile.Options{
+		MaxBytes:      maxQueueStateBytes,
+		RejectSymlink: true,
+		OwnedState:    true,
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("auditbatcher: read queue state: %w", err)
+	}
+	var state queueState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return false, fmt.Errorf("auditbatcher: decode queue state: %w", err)
+	}
+	return state.EncryptionSeen, nil
+}
+
+func (q *Queue) queueStatePath() string {
+	return filepath.Join(q.dir, queueStateFileName)
 }
 
 // uniqueRecoveryPath finds a free filename in pendingDir for a recovered

--- a/enterprise/conductor/auditbatcher/queue.go
+++ b/enterprise/conductor/auditbatcher/queue.go
@@ -21,6 +21,7 @@ package auditbatcher
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -61,6 +62,7 @@ type Config struct {
 	MaxPending      int
 	MaxPayloadBytes uint64
 	Keyring         *Keyring
+	AllowPlaintext  bool
 }
 
 type Batch struct {
@@ -125,7 +127,7 @@ func Open(cfg Config) (*Queue, error) {
 	if cfg.MaxPayloadBytes == 0 {
 		cfg.MaxPayloadBytes = conductor.MaxAuditPayloadBytes
 	}
-	if cfg.Keyring == nil {
+	if cfg.Keyring == nil && !cfg.AllowPlaintext {
 		return nil, errors.New("auditbatcher: queue encryption keyring required")
 	}
 	dir, pendingDir, inflightDir, deadDir, err := ensurePrivateQueueDirs(cleanDir)
@@ -229,7 +231,7 @@ func (q *Queue) Enqueue(batch Batch) (string, error) {
 		Envelope:   batch.Envelope,
 		Payload:    append([]byte(nil), batch.Payload...),
 	}
-	data, err := encryptDiskRecord(record, q.keyring)
+	data, err := marshalQueueRecord(record, q.keyring)
 	if err != nil {
 		return "", fmt.Errorf("auditbatcher: marshal record: %w", err)
 	}
@@ -449,6 +451,9 @@ func (q *Queue) recoverInflightLocked() error {
 // a partially migrated queue. Each replacement is individually atomic and
 // durable; a crash simply resumes from the remaining records on next Open.
 func (q *Queue) migrateRecordsLocked() error {
+	if q.keyring == nil {
+		return q.verifyPlaintextRecordsLocked()
+	}
 	active := q.keyring.ActiveKeyID()
 	for _, dir := range []string{q.pendingDir, q.inflightDir, q.deadDir} {
 		files, err := listRecordFiles(dir)
@@ -487,6 +492,22 @@ func (q *Queue) migrateRecordsLocked() error {
 			}
 			if err := durableWrite(path, data); err != nil {
 				return fmt.Errorf("auditbatcher: migrate queue record %s: %w", id, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (q *Queue) verifyPlaintextRecordsLocked() error {
+	for _, dir := range []string{q.pendingDir, q.inflightDir, q.deadDir} {
+		files, err := listRecordFiles(dir)
+		if err != nil {
+			return err
+		}
+		for _, id := range files {
+			path := filepath.Join(dir, id)
+			if _, _, _, err := readRecordWithKeyring(path, q.maxPayloadBytes, nil); err != nil {
+				return fmt.Errorf("auditbatcher: plaintext queue record %s: %w", id, err)
 			}
 		}
 	}
@@ -642,9 +663,11 @@ func readRecordWithKeyring(path string, maxPayloadBytes uint64, keyring *Keyring
 	// becomes ErrCorruptRecord and Claim moves the record to dead/, so strictness
 	// costs delivery of that audit data rather than merely delaying it.
 	//
-	// Queue records are encrypted before durableWrite under a keyring required to
-	// live outside this queue directory. Group access to the widened volume can
-	// therefore expose ciphertext and metadata, but not the audit payload.
+	// When a keyring is configured, queue records are encrypted before
+	// durableWrite under a keyring required to live outside this queue directory.
+	// Group access to the widened volume can therefore expose ciphertext and
+	// metadata, but not the audit payload. Plaintext compatibility mode is
+	// explicit and keeps the pre-encryption v1 record format.
 	data, err := securefile.Read(path, securefile.Options{
 		MaxBytes:      limit,
 		RejectSymlink: true,
@@ -725,7 +748,7 @@ func (q *Queue) updateInflightRecordLocked(id string, mutate func(*diskRecord)) 
 		return fmt.Errorf("auditbatcher: annotate inflight %s: %w", id, err)
 	}
 	mutate(&record)
-	data, err := encryptDiskRecord(record, q.keyring)
+	data, err := marshalQueueRecord(record, q.keyring)
 	if err != nil {
 		return fmt.Errorf("auditbatcher: marshal annotated record %s: %w", id, err)
 	}
@@ -733,6 +756,13 @@ func (q *Queue) updateInflightRecordLocked(id string, mutate func(*diskRecord)) 
 		return fmt.Errorf("auditbatcher: write annotated record %s: %w", id, err)
 	}
 	return nil
+}
+
+func marshalQueueRecord(record diskRecord, keyring *Keyring) ([]byte, error) {
+	if keyring == nil {
+		return json.Marshal(record)
+	}
+	return encryptDiskRecord(record, keyring)
 }
 
 func normalizeAccountingReason(reason string) string {

--- a/enterprise/conductor/auditbatcher/queue_test.go
+++ b/enterprise/conductor/auditbatcher/queue_test.go
@@ -208,10 +208,10 @@ func TestQueueOperationsFailAfterClose(t *testing.T) {
 	}
 }
 
-// TestQueueLockFileNotTreatedAsRecord proves the .lock file lives under the
-// queue root but is invisible to Claim/Stats (it is not a .json record) and is
-// not swept as a stale temp.
-func TestQueueLockFileNotTreatedAsRecord(t *testing.T) {
+// TestQueueRootStateFilesNotTreatedAsRecords proves root-local queue state is
+// invisible to Claim/Stats. Record enumeration scans only pending/, inflight/,
+// and dead/, so root files such as .lock and queue-state.json are not records.
+func TestQueueRootStateFilesNotTreatedAsRecords(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)
@@ -226,6 +226,9 @@ func TestQueueLockFileNotTreatedAsRecord(t *testing.T) {
 	// Lock file exists at the queue root.
 	if _, err := os.Stat(filepath.Join(q.dir, lockFileName)); err != nil {
 		t.Fatalf("Stat(lock file) error = %v, want present", err)
+	}
+	if _, err := os.Stat(filepath.Join(q.dir, queueStateFileName)); err != nil {
+		t.Fatalf("Stat(queue state) error = %v, want present", err)
 	}
 	// Fresh queue is empty - the lock file must not count as a record.
 	assertStats(t, q, Stats{})

--- a/enterprise/conductor/auditbatcher/record_crypto.go
+++ b/enterprise/conductor/auditbatcher/record_crypto.go
@@ -95,6 +95,9 @@ func decryptDiskRecord(data []byte, keyring *Keyring) (diskRecord, string, bool,
 		if err := contract.DecodeStrictJSON(data, &encrypted); err != nil {
 			return diskRecord{}, "", false, fmt.Errorf("auditbatcher: decode encrypted record: %w", err)
 		}
+		if keyring == nil {
+			return diskRecord{}, encrypted.KeyID, false, fmt.Errorf("%w: %q", errQueueKeyUnavailable, encrypted.KeyID)
+		}
 		key, ok := keyring.key(encrypted.KeyID)
 		if !ok {
 			return diskRecord{}, encrypted.KeyID, false, fmt.Errorf("%w: %q", errQueueKeyUnavailable, encrypted.KeyID)

--- a/enterprise/conductor/auditbatcher/record_crypto_test.go
+++ b/enterprise/conductor/auditbatcher/record_crypto_test.go
@@ -80,7 +80,7 @@ func TestQueuePlaintextModeWritesLegacyRecords(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Enqueue(plaintext) error = %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(q.pendingDir, id))
+	data, err := os.ReadFile(filepath.Clean(filepath.Join(q.pendingDir, id)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func TestQueuePlaintextModeWritesLegacyRecords(t *testing.T) {
 		t.Fatalf("Open(plaintext reopen) error = %v", err)
 	}
 	defer func() { _ = reopened.Close() }()
-	reopenedData, err := os.ReadFile(filepath.Join(reopened.pendingDir, id))
+	reopenedData, err := os.ReadFile(filepath.Clean(filepath.Join(reopened.pendingDir, id)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/conductor/auditbatcher/record_crypto_test.go
+++ b/enterprise/conductor/auditbatcher/record_crypto_test.go
@@ -157,6 +157,40 @@ func TestPlaintextModeFailsClosedOnEncryptedRecord(t *testing.T) {
 	}
 }
 
+func TestPlaintextModeToleratesCorruptDeadLetterAndQuarantinesCorruptLive(t *testing.T) {
+	dir := t.TempDir()
+	q, err := Open(Config{Dir: dir, AllowPlaintext: true})
+	if err != nil {
+		t.Fatalf("Open(plaintext) error = %v", err)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close error = %v", err)
+	}
+	// A corrupt record already quarantined in dead/ must not block startup.
+	deadFile := filepath.Join(dir, "dead", "00000000000000000001-corrupt"+recordExt)
+	if err := os.WriteFile(deadFile, []byte("{ not a valid record"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A corrupt live record must be quarantined to dead/, not block startup.
+	liveFile := filepath.Join(dir, "pending", "00000000000000000002-corrupt"+recordExt)
+	if err := os.WriteFile(liveFile, []byte("{ also not a valid record"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(Config{Dir: dir, AllowPlaintext: true})
+	if err != nil {
+		t.Fatalf("Open(plaintext with corrupt dead + live records) error = %v, want success", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	pending, _ := listRecordFiles(filepath.Join(dir, "pending"))
+	dead, _ := listRecordFiles(filepath.Join(dir, "dead"))
+	if len(pending) != 0 {
+		t.Fatalf("corrupt live record not quarantined: pending=%d, want 0", len(pending))
+	}
+	if len(dead) != 2 {
+		t.Fatalf("dead-letter records after open = %d, want 2 (pre-existing corrupt + quarantined live)", len(dead))
+	}
+}
+
 func TestEncryptedRecordMaxPayloadSurvivesRestartAndClaim(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {

--- a/enterprise/conductor/auditbatcher/record_crypto_test.go
+++ b/enterprise/conductor/auditbatcher/record_crypto_test.go
@@ -58,6 +58,37 @@ func TestQueueEncryptsRecordsAtRest(t *testing.T) {
 	}
 }
 
+func TestEncryptedOpenWritesEncryptionSeenMarker(t *testing.T) {
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := Open(Config{Dir: t.TempDir(), Keyring: keyring})
+	if err != nil {
+		t.Fatalf("Open(encrypted) error = %v", err)
+	}
+	defer func() { _ = q.Close() }()
+
+	data, err := os.ReadFile(filepath.Clean(q.queueStatePath()))
+	if err != nil {
+		t.Fatalf("ReadFile(queue state) error = %v", err)
+	}
+	var state queueState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("Unmarshal(queue state) error = %v", err)
+	}
+	if !state.EncryptionSeen {
+		t.Fatalf("queue state encryption_seen = false, want true: %s", data)
+	}
+	info, err := os.Stat(q.queueStatePath())
+	if err != nil {
+		t.Fatalf("Stat(queue state) error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != fileMode {
+		t.Fatalf("queue state mode = %#o, want %#o", got, fileMode)
+	}
+}
+
 func TestQueuePlaintextModeWritesLegacyRecords(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -119,6 +150,63 @@ func TestQueuePlaintextModeWritesLegacyRecords(t *testing.T) {
 	}
 }
 
+func TestPlaintextModeOpensNeverEncryptedQueueWithoutMarker(t *testing.T) {
+	dir := t.TempDir()
+	q, err := Open(Config{Dir: dir, AllowPlaintext: true})
+	if err != nil {
+		t.Fatalf("Open(never encrypted plaintext) error = %v", err)
+	}
+	defer func() { _ = q.Close() }()
+
+	if _, err := os.Stat(filepath.Join(q.dir, queueStateFileName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Stat(queue state) error = %v, want missing marker", err)
+	}
+}
+
+func TestPlaintextModeFailsClosedAfterEncryptedQueueDrainsEmpty(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	encrypted, err := Open(Config{Dir: dir, Keyring: keyring})
+	if err != nil {
+		t.Fatalf("Open(encrypted) error = %v", err)
+	}
+	if _, err := encrypted.Enqueue(signedTestBatch(t, "batch-encrypted-drained", priv)); err != nil {
+		t.Fatalf("Enqueue(encrypted) error = %v", err)
+	}
+	lease, err := encrypted.Claim()
+	if err != nil {
+		t.Fatalf("Claim(encrypted) error = %v", err)
+	}
+	if err := encrypted.Ack(lease.ID); err != nil {
+		t.Fatalf("Ack(encrypted) error = %v", err)
+	}
+	assertStats(t, encrypted, Stats{})
+	if err := encrypted.Close(); err != nil {
+		t.Fatalf("Close(encrypted) error = %v", err)
+	}
+
+	_, err = Open(Config{Dir: dir, AllowPlaintext: true})
+	if !errors.Is(err, errQueueEncryptionPreviouslySeen) {
+		t.Fatalf("Open(plaintext after drained encrypted queue) error = %v, want errQueueEncryptionPreviouslySeen", err)
+	}
+	for _, sub := range []string{"pending", "inflight", "dead"} {
+		files, listErr := listRecordFiles(filepath.Join(dir, sub))
+		if listErr != nil {
+			t.Fatalf("listRecordFiles(%s) error = %v", sub, listErr)
+		}
+		if len(files) != 0 {
+			t.Fatalf("%s records = %d, want drained empty queue", sub, len(files))
+		}
+	}
+}
+
 func TestPlaintextModeFailsClosedOnEncryptedRecord(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -138,6 +226,12 @@ func TestPlaintextModeFailsClosedOnEncryptedRecord(t *testing.T) {
 	}
 	if err := encrypted.Close(); err != nil {
 		t.Fatalf("Close(encrypted) error = %v", err)
+	}
+	// Simulate an upgraded queue that contains pre-marker encrypted records. The
+	// record-level v2 guard must remain fail-closed even when the new marker is
+	// absent.
+	if err := os.Remove(filepath.Join(dir, queueStateFileName)); err != nil {
+		t.Fatalf("Remove(queue state) error = %v", err)
 	}
 
 	_, err = Open(Config{Dir: dir, AllowPlaintext: true})

--- a/enterprise/conductor/auditbatcher/record_crypto_test.go
+++ b/enterprise/conductor/auditbatcher/record_crypto_test.go
@@ -58,6 +58,105 @@ func TestQueueEncryptsRecordsAtRest(t *testing.T) {
 	}
 }
 
+func TestQueuePlaintextModeWritesLegacyRecords(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	q, err := Open(Config{Dir: dir, AllowPlaintext: true})
+	if err != nil {
+		t.Fatalf("Open(plaintext) error = %v", err)
+	}
+	defer func() { _ = q.Close() }()
+
+	payload := []byte(`{"events":[{"message":"plaintext-sentinel"}]}`)
+	envelope := validUnsignedEnvelope(t, "batch-plaintext-at-rest", payload)
+	signed, err := SignEnvelope(envelope, "audit-key-1", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := q.Enqueue(Batch{Envelope: signed, Payload: payload})
+	if err != nil {
+		t.Fatalf("Enqueue(plaintext) error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(q.pendingDir, id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(data, []byte(`"version":2`)) || bytes.Contains(data, []byte(`"ciphertext"`)) {
+		t.Fatalf("plaintext-mode durable record used encrypted envelope: %s", data)
+	}
+	record, _, legacy, err := readRecordWithKeyring(filepath.Join(q.pendingDir, id), q.maxPayloadBytes, nil)
+	if err != nil {
+		t.Fatalf("readRecordWithKeyring(plaintext) error = %v", err)
+	}
+	if !legacy || !bytes.Equal(record.Payload, payload) {
+		t.Fatalf("plaintext record legacy=%t payload=%q, want legacy v1 payload %q", legacy, record.Payload, payload)
+	}
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close(plaintext) error = %v", err)
+	}
+
+	reopened, err := Open(Config{Dir: dir, AllowPlaintext: true})
+	if err != nil {
+		t.Fatalf("Open(plaintext reopen) error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedData, err := os.ReadFile(filepath.Join(reopened.pendingDir, id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(reopenedData, data) {
+		t.Fatal("plaintext reopen migrated or rewrote a legacy v1 record")
+	}
+	lease, err := reopened.Claim()
+	if err != nil {
+		t.Fatalf("Claim(plaintext) error = %v", err)
+	}
+	if !bytes.Equal(lease.Batch.Payload, payload) {
+		t.Fatalf("Claim(plaintext) payload = %q, want %q", lease.Batch.Payload, payload)
+	}
+}
+
+func TestPlaintextModeFailsClosedOnEncryptedRecord(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyring, err := NewKeyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	encrypted, err := Open(Config{Dir: dir, Keyring: keyring})
+	if err != nil {
+		t.Fatalf("Open(encrypted) error = %v", err)
+	}
+	if _, err := encrypted.Enqueue(signedTestBatch(t, "batch-encrypted-before-removal", priv)); err != nil {
+		t.Fatalf("Enqueue(encrypted) error = %v", err)
+	}
+	if err := encrypted.Close(); err != nil {
+		t.Fatalf("Close(encrypted) error = %v", err)
+	}
+
+	_, err = Open(Config{Dir: dir, AllowPlaintext: true})
+	if !errors.Is(err, errQueueKeyUnavailable) {
+		t.Fatalf("Open(plaintext with encrypted record) error = %v, want errQueueKeyUnavailable", err)
+	}
+	pending, listErr := listRecordFiles(filepath.Join(dir, "pending"))
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	dead, listErr := listRecordFiles(filepath.Join(dir, "dead"))
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(pending) != 1 || len(dead) != 0 {
+		t.Fatalf("after fail-closed plaintext open pending=%d dead=%d, want pending record retained and no quarantine/drop", len(pending), len(dead))
+	}
+}
+
 func TestEncryptedRecordMaxPayloadSurvivesRestartAndClaim(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {

--- a/internal/cli/diag/check.go
+++ b/internal/cli/diag/check.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -144,6 +145,16 @@ func checkConfigAdvisories(cfg *config.Config) []string {
 				"conductor.enabled is true but no license granting the \"fleet\" feature was found; "+
 					"the proxy will refuse to start (install an Enterprise license with fleet or set PIPELOCK_LICENSE_KEY)")
 		}
+	}
+
+	// A conductor follower with no keyring configured runs its durable audit
+	// queue UNENCRYPTED at rest. That is a supported compatibility posture, but
+	// the operator must see it here before deploy, not infer it from the runtime
+	// startup log.
+	if cfg.Conductor.Enabled && strings.TrimSpace(cfg.Conductor.DurableAuditQueueKeyring) == "" {
+		advisories = append(advisories,
+			"conductor.durable_audit_queue_keyring is unset; the durable audit queue runs UNENCRYPTED at rest "+
+				"(set it to enable AES-GCM encryption of queued audit records)")
 	}
 
 	if cfg.Conductor.Enabled && cfg.FlightRecorder.SigningKeyPath != "" {

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -194,6 +194,12 @@ func buildConductorAuditTransport(cfg *config.Config, m *metrics.Metrics) (*audi
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening conductor audit queue: %w", err)
 	}
+	if allowPlaintext {
+		slog.Warn("conductor durable audit queue running unencrypted at rest",
+			"component", "conductor_audit_queue",
+			"queue_dir", cfg.Conductor.DurableAuditQueueDir,
+		)
+	}
 	opened := false
 	defer func() {
 		if !opened {

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -174,17 +174,22 @@ func buildConductorAuditTransport(cfg *config.Config, m *metrics.Metrics) (*audi
 	if cfg == nil || !cfg.Conductor.Enabled {
 		return nil, nil, nil
 	}
+	var keyring *auditbatcher.Keyring
+	allowPlaintext := false
 	if strings.TrimSpace(cfg.Conductor.DurableAuditQueueKeyring) == "" {
-		return nil, nil, errors.New("conductor durable audit queue keyring is required")
-	}
-	keyring, err := auditbatcher.LoadKeyring(cfg.Conductor.DurableAuditQueueKeyring)
-	if err != nil {
-		return nil, nil, fmt.Errorf("loading conductor audit queue keyring: %w", err)
+		allowPlaintext = true
+	} else {
+		var err error
+		keyring, err = auditbatcher.LoadKeyring(cfg.Conductor.DurableAuditQueueKeyring)
+		if err != nil {
+			return nil, nil, fmt.Errorf("loading conductor audit queue keyring: %w", err)
+		}
 	}
 	q, err := auditbatcher.Open(auditbatcher.Config{
 		Dir:             cfg.Conductor.DurableAuditQueueDir,
 		MaxPayloadBytes: conductor.MaxAuditPayloadBytes,
 		Keyring:         keyring,
+		AllowPlaintext:  allowPlaintext,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening conductor audit queue: %w", err)

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -6,6 +6,7 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -19,6 +20,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -388,6 +390,10 @@ func TestBuildConductorAuditTransportRejectsMissingQueueKeyring(t *testing.T) {
 
 func TestBuildConductorAuditTransportOpensPlaintextWhenQueueKeyringEmpty(t *testing.T) {
 	dir := t.TempDir()
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
 	cfg := &config.Config{
 		Conductor: config.Conductor{
 			Enabled:                  true,
@@ -399,6 +405,12 @@ func TestBuildConductorAuditTransportOpensPlaintextWhenQueueKeyringEmpty(t *test
 	}
 	if _, _, err := buildConductorAuditTransport(cfg, nil); err == nil || strings.Contains(err.Error(), "queue keyring is required") {
 		t.Fatalf("buildConductorAuditTransport() error = %v, want later constructor failure after plaintext queue open", err)
+	}
+	gotLogs := logs.String()
+	if !strings.Contains(gotLogs, "level=WARN") ||
+		!strings.Contains(gotLogs, "conductor durable audit queue running unencrypted at rest") ||
+		!strings.Contains(gotLogs, "component=conductor_audit_queue") {
+		t.Fatalf("plaintext queue warning log = %q, want WARN unencrypted advisory", gotLogs)
 	}
 	// The plaintext-mode Open must actually have run: it lays down the private
 	// queue subdirectories. If the keyring check had blocked, these would not exist.

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -386,17 +386,28 @@ func TestBuildConductorAuditTransportRejectsMissingQueueKeyring(t *testing.T) {
 	}
 }
 
-func TestBuildConductorAuditTransportRejectsEmptyQueueKeyring(t *testing.T) {
+func TestBuildConductorAuditTransportOpensPlaintextWhenQueueKeyringEmpty(t *testing.T) {
+	dir := t.TempDir()
 	cfg := &config.Config{
 		Conductor: config.Conductor{
 			Enabled:                  true,
-			DurableAuditQueueDir:     filepath.Join(t.TempDir(), "audit-queue"),
+			ConductorURL:             "https://conductor.example",
+			ServerCAFile:             filepath.Join(dir, "missing-ca.pem"),
+			DurableAuditQueueDir:     filepath.Join(dir, "audit-queue"),
 			DurableAuditQueueKeyring: "",
 		},
 	}
-	if _, _, err := buildConductorAuditTransport(cfg, nil); err == nil || !strings.Contains(err.Error(), "queue keyring is required") {
-		t.Fatalf("buildConductorAuditTransport() error = %v, want empty keyring refusal", err)
+	if _, _, err := buildConductorAuditTransport(cfg, nil); err == nil || strings.Contains(err.Error(), "queue keyring is required") {
+		t.Fatalf("buildConductorAuditTransport() error = %v, want later constructor failure after plaintext queue open", err)
 	}
+	reopened, err := auditbatcher.Open(auditbatcher.Config{
+		Dir:            cfg.Conductor.DurableAuditQueueDir,
+		AllowPlaintext: true,
+	})
+	if err != nil {
+		t.Fatalf("Open(queue after plaintext build) error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
 }
 
 // TestBuildConductorBundlePollerDisabled confirms the poller is a no-op (nil,

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -400,6 +400,13 @@ func TestBuildConductorAuditTransportOpensPlaintextWhenQueueKeyringEmpty(t *test
 	if _, _, err := buildConductorAuditTransport(cfg, nil); err == nil || strings.Contains(err.Error(), "queue keyring is required") {
 		t.Fatalf("buildConductorAuditTransport() error = %v, want later constructor failure after plaintext queue open", err)
 	}
+	// The plaintext-mode Open must actually have run: it lays down the private
+	// queue subdirectories. If the keyring check had blocked, these would not exist.
+	for _, sub := range []string{"pending", "inflight", "dead"} {
+		if _, statErr := os.Stat(filepath.Join(cfg.Conductor.DurableAuditQueueDir, sub)); statErr != nil {
+			t.Fatalf("plaintext queue subdir %q not created (Open did not run in plaintext mode): %v", sub, statErr)
+		}
+	}
 	reopened, err := auditbatcher.Open(auditbatcher.Config{
 		Dir:            cfg.Conductor.DurableAuditQueueDir,
 		AllowPlaintext: true,

--- a/internal/config/conductor.go
+++ b/internal/config/conductor.go
@@ -92,20 +92,32 @@ func (c *Config) validateConductor(warnings *[]Warning) error {
 		return fmt.Errorf("conductor.trust_roster_root_fingerprint: %w", err)
 	}
 	for field, value := range map[string]string{
-		"conductor.trust_roster_path":           cfg.TrustRosterPath,
-		"conductor.server_ca_file":              cfg.ServerCAFile,
-		"conductor.client_cert_path":            cfg.ClientCertPath,
-		"conductor.client_key_path":             cfg.ClientKeyPath,
-		"conductor.bundle_cache_dir":            cfg.BundleCacheDir,
-		"conductor.durable_audit_queue_dir":     cfg.DurableAuditQueueDir,
-		"conductor.durable_audit_queue_keyring": cfg.DurableAuditQueueKeyring,
+		"conductor.trust_roster_path":       cfg.TrustRosterPath,
+		"conductor.server_ca_file":          cfg.ServerCAFile,
+		"conductor.client_cert_path":        cfg.ClientCertPath,
+		"conductor.client_key_path":         cfg.ClientKeyPath,
+		"conductor.bundle_cache_dir":        cfg.BundleCacheDir,
+		"conductor.durable_audit_queue_dir": cfg.DurableAuditQueueDir,
 	} {
 		if err := validateConductorAbsolutePath(field, value); err != nil {
 			return err
 		}
 	}
-	if pathWithin(cfg.DurableAuditQueueDir, cfg.DurableAuditQueueKeyring) {
-		return fmt.Errorf("conductor.durable_audit_queue_keyring must be outside conductor.durable_audit_queue_dir")
+	if strings.TrimSpace(cfg.DurableAuditQueueKeyring) == "" {
+		*warnings = append(*warnings, Warning{
+			Field:   "conductor.durable_audit_queue_keyring",
+			Message: "conductor.durable_audit_queue_keyring is unset; the durable audit queue runs UNENCRYPTED at rest. Set it to enable AES-GCM encryption.",
+		})
+	} else {
+		if err := validateConductorAbsolutePath("conductor.durable_audit_queue_keyring", cfg.DurableAuditQueueKeyring); err != nil {
+			return err
+		}
+		if pathWithin(cfg.DurableAuditQueueDir, cfg.DurableAuditQueueKeyring) {
+			return fmt.Errorf("conductor.durable_audit_queue_keyring must be outside conductor.durable_audit_queue_dir")
+		}
+		if err := validateConductorPrivateParent("conductor.durable_audit_queue_keyring", cfg.DurableAuditQueueKeyring); err != nil {
+			return err
+		}
 	}
 	if strings.TrimSpace(cfg.EnrollmentTokenPath) != "" {
 		if err := validateConductorAbsolutePath("conductor.enrollment_token_path", cfg.EnrollmentTokenPath); err != nil {
@@ -116,9 +128,8 @@ func (c *Config) validateConductor(warnings *[]Warning) error {
 		}
 	}
 	for field, value := range map[string]string{
-		"conductor.bundle_cache_dir":            cfg.BundleCacheDir,
-		"conductor.durable_audit_queue_dir":     cfg.DurableAuditQueueDir,
-		"conductor.durable_audit_queue_keyring": cfg.DurableAuditQueueKeyring,
+		"conductor.bundle_cache_dir":        cfg.BundleCacheDir,
+		"conductor.durable_audit_queue_dir": cfg.DurableAuditQueueDir,
 	} {
 		if err := validateConductorPrivateParent(field, value); err != nil {
 			return err

--- a/internal/config/conductor_test.go
+++ b/internal/config/conductor_test.go
@@ -65,6 +65,25 @@ func TestValidateConductor_Enabled(t *testing.T) {
 	}
 }
 
+func TestValidateConductor_QueueKeyringOptionalWarning(t *testing.T) {
+	cfg := Defaults()
+	cfg.Conductor = validConductorConfig(t)
+	cfg.Conductor.DurableAuditQueueKeyring = ""
+	configureConductorRecorder(t, cfg)
+
+	warnings, err := cfg.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() error = %v", err)
+	}
+	for _, warning := range warnings {
+		if warning.Field == "conductor.durable_audit_queue_keyring" &&
+			strings.Contains(warning.Message, "UNENCRYPTED at rest") {
+			return
+		}
+	}
+	t.Fatalf("warnings = %+v, want unencrypted durable queue warning", warnings)
+}
+
 // TestValidateConductor_RequiresFingerprintRegardlessOfHonor locks in the
 // contract that a pinned trust-roster root fingerprint is mandatory whenever
 // conductor.enabled, INDEPENDENT of honor_remote_kill_switch. The honor flag
@@ -568,6 +587,7 @@ func TestValidateConductor_QueueKeyringOutsideQueue(t *testing.T) {
 		{name: "equal", keyring: func(queue string) string { return queue }, wantErr: true},
 		{name: "descendant", keyring: func(queue string) string { return filepath.Join(queue, "keyring.json") }, wantErr: true},
 		{name: "sibling", keyring: func(queue string) string { return filepath.Join(filepath.Dir(queue), "secrets", "keyring.json") }},
+		{name: "omitted", keyring: func(string) string { return "" }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := Defaults()


### PR DESCRIPTION
## What changed

The conductor durable audit-queue keyring is now optional. Encryption is enabled only when `conductor.durable_audit_queue_keyring` is set; when it is unset, the follower runs a plaintext durable queue and the proxy warns at startup that the queue is unencrypted at rest.

Previously the keyring was required whenever `conductor.enabled` was true. That made a binary upgrade a breaking change: an existing follower with a durable queue but no keyring failed config validation and could not start. This restores the prior plaintext behavior as the default while keeping encryption a deliberate opt-in.

## Fail-closed behavior is preserved

A nil keyring is still rejected unless plaintext mode is explicitly selected, so a keyring omitted by mistake in a path that expects one fails closed rather than silently running unencrypted. In plaintext mode, encountering a v2 encrypted record fails closed with a key-unavailable error rather than quarantining or dropping it. When a keyring is configured, all existing behavior is unchanged: a missing or invalid keyring fails closed, legacy plaintext records auto-encrypt on open, and an authentication failure blocks startup.

## Operator surfacing

`pipelock check` and the runtime startup both emit an advisory when a conductor follower runs its audit queue unencrypted, so the posture is visible before deploy, not only in the runtime log.

## Key init hardening

`conductor audit-queue-key init` now refuses to overwrite an existing keyring file, refuses a keyring path inside the audit queue directory, and takes the queue maintenance lock when a queue directory is provided so two inits cannot race.

## Docs

The configuration reference and the conductor production runbook mark the keyring optional and describe the upgrade path: an existing follower keeps its plaintext queue with no change, and enabling encryption is a deliberate step that provisions a keyring outside the queue directory.

## Tests

New coverage for config validation with the keyring omitted, set inside the queue directory, and set outside; runtime selection of plaintext versus encrypted mode; queue open refusing a nil keyring without the explicit plaintext flag; plaintext mode failing closed on an encrypted record; encrypted mode still auto-migrating legacy records; and the init overwrite and inside-queue guards. Each fail-closed guard was verified non-vacuous by neutralizing it and confirming its test fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Durable audit queues can run in a plaintext-compatible mode when no durable audit queue keyring is configured, with startup warnings.
  - AES-GCM at-rest encryption is enabled when a durable audit queue keyring is provided.
  - Enterprise CLI enhancements for `audit-queue-key init`, including safe handling of the target key location.

- **Bug Fixes**
  - Improved plaintext compatibility robustness, including safer handling/quarantining of corrupt records and stricter fail-closed behavior after encrypted queues drain.

- **Documentation**
  - Updated configuration docs, runbook steps, and YAML examples to clarify optional keyring behavior, encryption enablement steps, and additional validation expectations (including Flight Recorder signed checkpoints).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->