### PR TITLE
fix(playground-broker): warn when serving a UI with no embeddable origin

### DIFF
--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -510,6 +510,14 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		mux.Handle("/", noCacheStatic(http.FileServer(http.Dir(f.staticDir))))
 		handler = mux
 		_, _ = fmt.Fprintf(out, "serving static UI from %s at /\n", f.staticDir)
+		if len(f.embedOrigins) == 0 {
+			// Serving a UI with no --embed-origin ships frame-ancestors 'none'
+			// (see brokerContentSecurityPolicy), so the page cannot load in an
+			// iframe. That is the correct default for a standalone broker but
+			// silently breaks one meant to be embedded, so say so loudly rather
+			// than let a dropped flag surface only when an embed goes blank.
+			_, _ = fmt.Fprintln(out, "WARNING: serving a static UI with no --embed-origin; frame-ancestors is 'none' and the page will NOT load in an iframe. Pass --embed-origin for each site that embeds this broker.")
+		}
 	}
 	if len(f.externalScriptOrigins) > 0 {
 		_, _ = fmt.Fprintf(out, "trusting external script origin(s): %s\n", strings.Join(f.externalScriptOrigins, ", "))

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -388,6 +388,70 @@ func TestBuildServerStaticDir(t *testing.T) {
 	}
 }
 
+// Serving a UI with no --embed-origin ships frame-ancestors 'none', so the page
+// cannot be iframed. That is a correct default but a silent one: it is exactly
+// how a dropped --embed-origin on a deploy surfaced only as a blank embed. The
+// broker must warn loudly when it serves a UI it cannot embed, and stay quiet
+// (no false alarm) once an embed origin is configured.
+func TestBuildServerStaticDirWarnsWhenNotEmbeddable(t *testing.T) {
+	dir := t.TempDir()
+	uiDir := filepath.Join(dir, "ui")
+	if err := os.MkdirAll(uiDir, 0o750); err != nil {
+		t.Fatalf("mkdir ui: %v", err)
+	}
+	writeTestFile(t, uiDir, "index.html", "<html><body>live demo ui</body></html>")
+	flyTokenFile := writeTestFile(t, dir, "fly.token", "fly-file-token\n")
+	gateSecret := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	gateSecretFile := writeTestFile(t, dir, "gate.b64", gateSecret+"\n")
+
+	oldFactory := newMachineProvider
+	newMachineProvider = func(_ context.Context, _ *serveFlags, _ string) (broker.MachineProvider, error) {
+		return fakeProvider{}, nil
+	}
+	t.Cleanup(func() { newMachineProvider = oldFactory })
+
+	flags := func(embedOrigins []string) *serveFlags {
+		return &serveFlags{
+			listen: defaultListen, provider: "fake", flyApp: "playground-test",
+			flyTokenFile: flyTokenFile, image: "registry.example/playground:test",
+			staticDir: uiDir, internalPort: 8080, concurrency: 2,
+			codes: []string{"outer-code"}, maxPerCode: defaultMaxPerCode,
+			gateSecretFile: gateSecretFile, ipRate: defaultIPRate, ipBurst: defaultIPBurst,
+			codeRate: defaultCodeRate, codeBurst: defaultCodeBurst,
+			globalDailyBudget: 10,
+			unsafeNoHumanGate: true,
+			sessionTTL:        defaultSessionTTL, deadlineGrace: defaultGrace,
+			vmDailyTurnBudget:     10,
+			requireSessionSecrets: false,
+			embedOrigins:          embedOrigins,
+		}
+	}
+
+	const warn = "WARNING: serving a static UI with no --embed-origin"
+
+	cases := []struct {
+		name         string
+		embedOrigins []string
+		wantWarn     bool
+	}{
+		{name: "no_embed_origin_warns", embedOrigins: nil, wantWarn: true},
+		{name: "embed_origin_configured_silent", embedOrigins: []string{testEmbedOrigin}, wantWarn: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			srv, _, _, _, err := buildServer(context.Background(), &out, flags(tc.embedOrigins))
+			if err != nil {
+				t.Fatalf("buildServer: %v", err)
+			}
+			t.Cleanup(srv.Close)
+			if got := strings.Contains(out.String(), warn); got != tc.wantWarn {
+				t.Fatalf("not-embeddable warning present = %v, want %v; output %q", got, tc.wantWarn, out.String())
+			}
+		})
+	}
+}
+
 func TestBrokerSecurityHeaders(t *testing.T) {
 	dir := t.TempDir()
 	uiDir := filepath.Join(dir, "ui")


### PR DESCRIPTION
A broker started with `--static-dir` but no `--embed-origin` ships `frame-ancestors 'none'` and cannot load in an iframe. That is the correct default for a standalone broker but a silent trap for one meant to be embedded, where a dropped flag surfaces only as a blank embed.

This adds a loud non-fatal startup warning when the broker serves a UI it cannot embed, so the misconfiguration is visible at boot instead of only in a browser. Standalone brokers are unaffected and the closed-by-default CSP is unchanged.

Added a test covering both the not-embeddable case (warning present) and the configured case (warning absent).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a startup warning when serving a static UI without an embed origin, clarifying that iframe embedding is blocked by the resulting security policy.
  * Suppressed the warning when an embed origin is configured, avoiding unnecessary alerts.
* **Tests**
  * Added coverage to verify the warning appears only when the static UI is not embeddable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->