### PR TITLE
docs(receipts): clarify post-activation recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,11 +104,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recorder session, then verify from the original pinned root. Missing,
   replayed, malformed, cross-session, duplicate, boundary-mismatched, or
   concurrently advanced ceremonies fail closed. Deployment-specific stop, key
-  replacement, restart, and rollback steps remain operator-run. Successors must
-  use purpose-bound `receipt-signing` JSON keys; legacy retiring keys remain
-  accepted for migration from existing recorder deployments. Cross-process
-  ceremony locking currently requires Unix `flock` and fails closed on Windows;
-  the artifact output filesystem must support hard links.
+  replacement, and restart steps remain operator-run. Rollback is safe only
+  before the successor emits; after activation, recover forward to a fresh key
+  because reinstalling a retired signer creates an unendorsable trust cycle.
+  Successors must use purpose-bound `receipt-signing` JSON keys; legacy retiring
+  keys remain accepted for migration from existing recorder deployments.
+  Cross-process ceremony locking currently requires Unix `flock` and fails
+  closed on Windows; the artifact output filesystem must support hard links.
 - **Installable receipt-verifier parity for endorsed rotations.** The TypeScript
   and Rust verifier packages now accept repeatable rotation endorsements and
   verify a rotated ActionReceipt v1 chain from one pinned root. Their `0.2.0`

--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -208,6 +208,13 @@ sudo install -m 0600 \
 sudo systemctl start pipelock
 ```
 
+Rollback is safe only before the restarted process emits with the successor:
+restore the retiring key and restart. Once the successor has emitted, do not
+reinstall an earlier signer. That creates an `A -> B -> A` cycle which cannot be
+authorized by the endorsement ceremony. If the activated successor must be
+replaced, generate a fresh key and rotate forward from `B -> C`, passing the
+earlier endorsement when preparing and verifying the new boundary.
+
 The endorsement command does not stop, restart, or replace keys. It refuses an
 open chain, an unpinned root, a retiring key that does not sign the closed tail,
 a successor that signed any earlier segment, and an existing output file. The


### PR DESCRIPTION
Clarifies that receipt-signing-key rollback is safe only before the successor emits. After activation, operators recover forward to a fresh key because reinstalling a retired signer creates an unendorsable trust cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for safely rolling back signing-key rotations.
  * Clarified that restoring a retiring key is only safe before the successor key has been used.
  * Documented forward-rotation requirements after successor use, including preserving prior endorsements.
  * Expanded ceremony-locking and artifact-output guidance with platform and filesystem constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->