### PR TITLE
fix(ci): align release test shards

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
             tags: ''
           - name: enterprise
             tags: enterprise
-        shard: ['proxy', 'scanner', 'mcp', 'rest']
+        shard: ['proxy', 'scanner', 'mcp', 'rest-0', 'rest-1', 'rest-2']
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -89,7 +89,7 @@ jobs:
           fi
 
           : > "$tmpdir/shards.txt"
-          for shard in proxy scanner mcp rest; do
+          for shard in proxy scanner mcp rest-0 rest-1 rest-2; do
             if [ -n "$GO_TEST_TAGS" ]; then
               python3 scripts/ci_test_packages.py --tags "$GO_TEST_TAGS" --shard "$shard"
             else

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -56,6 +56,12 @@ note() { printf '  [FAIL] %s\n' "$1" >&2; fail=1; }
 
 echo "release-ready gate: version=$VER"
 
+# 0a. The release workflow's test matrix and its coverage loop must consume
+# exactly the shards accepted by ci_test_packages.py. Ordinary CI and release CI
+# are separate workflow surfaces; keeping this assertion in the preflight stops
+# a stale release-only shard name before the tag workflow fans out.
+(cd "$REPO_ROOT" && python3 -m unittest scripts.test_ci_test_packages)
+
 # 1. CHANGELOG: a "## [<ver>] - <YYYY-MM-DD>" heading must exist with a real date.
 # Match the version LITERALLY (grep -F) so metacharacters in a version string
 # (e.g. the '+' in '3.2.0+build.1') are never interpreted as regex; validate the

--- a/scripts/test_ci_test_packages.py
+++ b/scripts/test_ci_test_packages.py
@@ -5,12 +5,32 @@
 
 from __future__ import annotations
 
+import re
 import unittest
+from pathlib import Path
 
-from scripts.ci_test_packages import package_in_tree, package_suffix, select_packages
+from scripts.ci_test_packages import SHARDS, package_in_tree, package_suffix, select_packages
 
 
 class TestPackageSharding(unittest.TestCase):
+    def test_release_workflow_uses_every_supported_shard(self) -> None:
+        workflow = (Path(__file__).resolve().parents[1] / ".github/workflows/release.yaml").read_text(
+            encoding="utf-8",
+        )
+
+        matrix_match = re.search(r"^\s*shard:\s*\[([^\]]+)\]\s*$", workflow, re.MULTILINE)
+        self.assertIsNotNone(matrix_match, "release workflow shard matrix not found")
+        matrix_shards = tuple(
+            value.strip().strip("'\"") for value in matrix_match.group(1).split(",")
+        )
+
+        loop_match = re.search(r"^\s*for shard in ([^;]+); do\s*$", workflow, re.MULTILINE)
+        self.assertIsNotNone(loop_match, "release workflow coverage loop not found")
+        loop_shards = tuple(loop_match.group(1).split())
+
+        self.assertEqual(matrix_shards, SHARDS)
+        self.assertEqual(loop_shards, SHARDS)
+
     def test_every_package_is_selected_exactly_once(self) -> None:
         packages = [
             "example.test/pipelock/cmd/pipelock",


### PR DESCRIPTION
## Summary

- align the release test matrix and coverage loop with all six supported package shards
- make release preflight assert that the workflow remains synchronized with the shard selector

## Context

The release-only workflow still referenced the retired `rest` shard after ordinary CI split it into `rest-0`, `rest-1`, and `rest-2`, causing tagged releases to stop before tests or publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved release test sharding by splitting REST tests across three parallel shards.
  * Added validation to ensure configured release shards match coverage checks.
  * Release readiness checks now run CI test-package validation before reviewing changelog and chart metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->