### PR TITLE
fix(release): restore compatible cosign signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,7 +172,9 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: 'v3.1.1'
+          # GoReleaser still emits separate checksums.txt.sig/.pem assets.
+          # Cosign v3 requires the new bundle format and rejects those flags.
+          cosign-release: 'v2.6.1'
 
       - name: Set GOVERSION
         run: echo "GOVERSION=$(go env GOVERSION)" >> "$GITHUB_ENV"

--- a/scripts/test_ci_test_packages.py
+++ b/scripts/test_ci_test_packages.py
@@ -13,6 +13,24 @@ from scripts.ci_test_packages import SHARDS, package_in_tree, package_suffix, se
 
 
 class TestPackageSharding(unittest.TestCase):
+    def test_release_cosign_matches_goreleaser_signature_format(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        workflow = (root / ".github/workflows/release.yaml").read_text(encoding="utf-8")
+        goreleaser = (root / ".goreleaser.yaml").read_text(encoding="utf-8")
+
+        version_match = re.search(r"^\s*cosign-release:\s*['\"]v(\d+)\.", workflow, re.MULTILINE)
+        self.assertIsNotNone(version_match, "release workflow cosign version not found")
+
+        uses_legacy_outputs = (
+            "--output-certificate=" in goreleaser and "--output-signature=" in goreleaser
+        )
+        if uses_legacy_outputs:
+            self.assertLess(
+                int(version_match.group(1)),
+                3,
+                "Cosign v3 requires bundle output; legacy .sig/.pem flags fail during release",
+            )
+
     def test_release_workflow_uses_every_supported_shard(self) -> None:
         workflow = (Path(__file__).resolve().parents[1] / ".github/workflows/release.yaml").read_text(
             encoding="utf-8",


### PR DESCRIPTION
## Summary

- restore Cosign v2.6.1 while GoReleaser emits separate checksum signature and certificate assets
- fail release preflight when a Cosign major is incompatible with the configured GoReleaser signing format
- preserve the existing `checksums.txt.sig` and `checksums.txt.pem` contract used by release verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release signing compatibility to ensure generated signatures and certificates remain usable with the release tooling.

* **Tests**
  * Added automated validation to prevent incompatible signing-tool versions from being introduced in future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->