### PR TITLE
fix(release,ci): scope tag triggers and version discovery to product tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -391,6 +391,17 @@ jobs:
       - name: Python pin policy
         run: bash scripts/check-python-pins.sh
 
+      # These modules had no PR-time runner and were only executed by the
+      # release workflow, so a break in them stayed invisible until tag time.
+      # Modules are named explicitly because scripts/ is not an importable
+      # package, so unittest discovery cannot walk it.
+      - name: Release tooling unit tests
+        run: |
+          python3 -m unittest \
+            scripts.test_ci_test_packages \
+            scripts.test_ci_test_with_retry \
+            scripts.test_git_version
+
       - name: Test stability policy
         run: bash scripts/check-test-stability.sh
 
@@ -500,7 +511,7 @@ jobs:
 
       - name: Build binary
         run: |
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "0.0.0-dev.unknown")
+          VERSION=$(./scripts/git-version.sh)
           go build -trimpath -ldflags "-s -w \
             -X github.com/luckyPipewrench/pipelock/internal/cliutil.Version=$VERSION \
             -X github.com/luckyPipewrench/pipelock/internal/proxy.Version=$VERSION" \
@@ -511,7 +522,7 @@ jobs:
 
       - name: Build binary (enterprise)
         run: |
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "0.0.0-dev.unknown")
+          VERSION=$(./scripts/git-version.sh)
           go build -tags enterprise -trimpath -ldflags "-s -w \
             -X github.com/luckyPipewrench/pipelock/internal/cliutil.Version=$VERSION \
             -X github.com/luckyPipewrench/pipelock/internal/proxy.Version=$VERSION" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -391,16 +391,10 @@ jobs:
       - name: Python pin policy
         run: bash scripts/check-python-pins.sh
 
-      # These modules had no PR-time runner and were only executed by the
-      # release workflow, so a break in them stayed invisible until tag time.
-      # Modules are named explicitly because scripts/ is not an importable
-      # package, so unittest discovery cannot walk it.
+      # Release-tooling tests had no PR-time runner, so breaks stayed invisible
+      # until tag time. The pattern covers both test_*.py and *_test.py modules.
       - name: Release tooling unit tests
-        run: |
-          python3 -m unittest \
-            scripts.test_ci_test_packages \
-            scripts.test_ci_test_with_retry \
-            scripts.test_git_version
+        run: python3 -m unittest discover -s scripts -p '*test*.py'
 
       - name: Test stability policy
         run: bash scripts/check-test-stability.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,18 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'  # Coarse prefilter: v-prefixed with at least two dots (the wildcards also match extra dots like v1.2.3.4; excludes floating v1/v2). Strict SemVer is enforced in the release-preflight gate (check-release-ready.sh).
+      # Coarse prefilter. The leading `[0-9]` is load-bearing: a bare `v*` also
+      # matches tags that merely CONTAIN a dotted version later in the name,
+      # because `*` happily spans the rest of the prefix. `verifier-v0.2.0`
+      # matched the old `v*.*.*` as v + "erifier-v0" + . + "2" + . + "0", which
+      # started a full release run for a verifier tag. Requiring a digit
+      # immediately after the `v` excludes every non-product tag prefix.
+      #
+      # Still deliberately coarse: the wildcards accept extra dots (v1.2.3.4) and
+      # hyphenated prerelease suffixes (v1.2.3-beta.1), and exclude the floating
+      # v1/v2 pointers. Strict SemVer remains enforced in the release-preflight
+      # gate (check-release-ready.sh), which is the fail-closed check.
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 # Serialize release publications so two overlapping tag pushes cannot race on the
 # GoReleaser uploads or the shared force-updated v2 tag (an older run could

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -409,8 +409,8 @@ jobs:
           exit 1
 
       # Move the v2 floating tag so `uses: luckyPipewrench/pipelock@v2`
-      # always resolves to the latest release. Safe because the trigger
-      # is v*.*.* which won't re-fire on the v2 push.
+      # always resolves to the latest release. Safe because the trigger requires
+      # two dotted components, so a bare `v2` push cannot re-fire this workflow.
       - name: Update v2 floating tag for GitHub Action
         env:
           TAG_NAME: ${{ github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY := pipelock
 MODULE := github.com/luckyPipewrench/pipelock
-VERSION    ?= $(shell (git describe --tags --always --dirty 2>/dev/null || echo "v0.0.0-dev.unknown") | sed 's/^v//')
+VERSION    ?= $(shell ./scripts/git-version.sh 2>/dev/null || echo "0.0.0-dev.unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GO_VERSION := $(shell go version | awk '{print $$3}')

--- a/internal/rules/bundle.go
+++ b/internal/rules/bundle.go
@@ -546,7 +546,7 @@ func isDevelopmentCurrentVersion(s string) bool {
 	if err == nil && prereleaseHasIdentifier(v.prerelease, "dev") {
 		return true
 	}
-	return isGitDescribeVersion(s)
+	return isGitDescribeVersion(s) || isBareGitCommitVersion(s)
 }
 
 func prereleaseHasIdentifier(prerelease, ident string) bool {
@@ -579,6 +579,13 @@ func isGitDescribeVersion(s string) bool {
 		return false
 	}
 	return isHexString(shorthash[1:])
+}
+
+func isBareGitCommitVersion(s string) bool {
+	// `git describe --always` emits a bare abbreviated commit id when no matching
+	// tag is reachable, which is still a source build with no orderable release.
+	const minShortHashLen = 7
+	return len(s) >= minShortHashLen && isHexString(s)
 }
 
 func isHexString(s string) bool {

--- a/internal/rules/bundle.go
+++ b/internal/rules/bundle.go
@@ -584,6 +584,16 @@ func isGitDescribeVersion(s string) bool {
 func isBareGitCommitVersion(s string) bool {
 	// `git describe --always` emits a bare abbreviated commit id when no matching
 	// tag is reachable, which is still a source build with no orderable release.
+	//
+	// Deliberately accepts an all-DIGIT string, which is why this looks looser
+	// than it needs to be. An abbreviated commit id is hexadecimal, so roughly
+	// one in twenty-seven real short hashes contains no a-f letter at all;
+	// requiring a letter would misclassify those legitimate source builds as
+	// malformed and refuse them outright. The accepted cost is that an all-digit
+	// version scheme this project does not use (a CalVer stamp such as 20260731)
+	// is read as a commit id, which downgrades it from a hard refusal to the
+	// unverifiable-source-build path. Do not "tighten" this to require a hex
+	// letter without first weighing that availability regression.
 	const minShortHashLen = 7
 	return len(s) >= minShortHashLen && isHexString(s)
 }

--- a/internal/rules/unverifiable_version_test.go
+++ b/internal/rules/unverifiable_version_test.go
@@ -28,6 +28,7 @@ func TestErrUnverifiableVersionOnlyMarksTheUnknownCase(t *testing.T) {
 		{"devel", "3.0.0", "devel", true, true},
 		{"unset", "3.0.0", "", true, true},
 		{"git describe", "3.0.0", "2.0.0-147-gf1c242a0", true, true},
+		{"git describe always bare commit", "3.0.0", "9cc0fe5", true, true},
 
 		// Checked and genuinely NOT met: must never be downgraded.
 		{"release below min", "3.0.0", "2.9.0", true, false},
@@ -35,6 +36,7 @@ func TestErrUnverifiableVersionOnlyMarksTheUnknownCase(t *testing.T) {
 
 		// Checked and malformed: fails closed, and is not the unknown case.
 		{"malformed version", "3.0.0", "not-a-version", true, false},
+		{"short hex version", "3.0.0", "abc123", true, false},
 
 		// Requirement satisfied: no error at all.
 		{"release meets min", "2.0.0", "3.0.0", false, false},

--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,13 @@
       "enabled": false
     },
     {
+      "description": "Hold cosign at 2.x in the release workflow. GoReleaser emits separate checksums.txt.sig/.pem assets; cosign 3.x requires the new bundle format and rejects the flags that produce them. Advancing it needs a release-signing migration we have not scoped, and a major bump here breaks artifact signing at tag time rather than in PR CI. Only the cosign-release version is held; the cosign-installer action itself still updates.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["sigstore/cosign"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "description": "Hold jsonschema at 0.18.x in the Rust verifier. 0.19+ renames JSONSchema to Validator and changes the compile/validate API, needs manual migration.",
       "matchManagers": ["cargo"],
       "matchFileNames": ["sdk/verifiers/rust/**"],

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -28,9 +28,10 @@ fi
 # OPTIONAL prerelease and NO build metadata: '+' is invalid in an OCI/Docker tag
 # (tagChars is [A-Za-z0-9_.-]), so a '+build' version would pass an abstract-SemVer
 # check yet break the container publish or mismatch the provenance subject. This
-# gate is the real guard (the 'v*.*.*' release trigger is only a coarse prefilter
-# that also matches v1.2.beta and v1.2.3.4), so a malformed tag fails
-# closed BEFORE anything is built or pushed.
+# gate is the real guard (the 'v[0-9]*.[0-9]*.[0-9]*' release trigger is only a
+# coarse prefilter: it rejects non-product prefixes like verifier-v0.2.0 and bare
+# floating pointers like v2, but still admits v1.2.3.4 and v3.2.0+build.1), so a
+# malformed tag fails closed BEFORE anything is built or pushed.
 release_tag_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?$'
 if ! printf '%s\n' "$VERSION" | grep -qE "$release_tag_re"; then
   echo "check-release-ready: tag '$VERSION' must be vMAJOR.MINOR.PATCH[-prerelease] with no build metadata" >&2

--- a/scripts/check-reproducible-build.sh
+++ b/scripts/check-reproducible-build.sh
@@ -14,7 +14,7 @@ for command in git go cmp sha256sum; do
 	fi
 done
 
-version="${VERSION:-$(git describe --tags --always --dirty | sed 's/^v//')}"
+version="${VERSION:-$(./scripts/git-version.sh)}"
 build_date="$(git show -s --format=%cI HEAD)"
 git_commit="$(git rev-parse --short HEAD)"
 go_version="$(go env GOVERSION)"

--- a/scripts/git-version.sh
+++ b/scripts/git-version.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Resolve the product version from git tags. Single source of truth for every
+# local and CI build that stamps a version into the binary.
+#
+# Only product release tags are considered. The repository also carries
+# independently-versioned tags for the published verifiers (for example
+# `verifier-v0.2.0`), and an unfiltered `git describe --tags` selects whichever
+# tag is nearest in history regardless of series. Because callers then strip one
+# leading "v", a nearby verifier tag produced malformed versions such as
+# `erifier-v0.2.0-1-gabc1234`. Matching `v[0-9]*` requires a digit immediately
+# after the "v", which excludes every non-product tag prefix.
+#
+# When no product tag is reachable this prints the abbreviated commit rather
+# than guessing a version number: an honest commit id is preferable to a version
+# borrowed from an unrelated release series.
+
+set -euo pipefail
+
+if version="$(git describe --tags --always --dirty --match 'v[0-9]*' 2>/dev/null)" &&
+	[ -n "$version" ]; then
+	# Strip at most one leading "v" so `v3.3.0` reports as `3.3.0`. Abbreviated
+	# commit ids are hexadecimal and therefore never start with "v".
+	printf '%s\n' "${version#v}"
+else
+	printf '%s\n' "0.0.0-dev.unknown"
+fi

--- a/scripts/git-version.sh
+++ b/scripts/git-version.sh
@@ -10,8 +10,8 @@
 # `verifier-v0.2.0`), and an unfiltered `git describe --tags` selects whichever
 # tag is nearest in history regardless of series. Because callers then strip one
 # leading "v", a nearby verifier tag produced malformed versions such as
-# `erifier-v0.2.0-1-gabc1234`. Matching `v[0-9]*` requires a digit immediately
-# after the "v", which excludes every non-product tag prefix.
+# `erifier-v0.2.0-1-gabc1234`. Matching dotted product tags excludes both
+# non-product tag prefixes and floating action pointer tags such as `v1`/`v2`.
 #
 # When no product tag is reachable this prints the abbreviated commit rather
 # than guessing a version number: an honest commit id is preferable to a version
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-if version="$(git describe --tags --always --dirty --match 'v[0-9]*' 2>/dev/null)" &&
+if version="$(git describe --tags --always --dirty --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null)" &&
 	[ -n "$version" ]; then
 	# Strip at most one leading "v" so `v3.3.0` reports as `3.3.0`. Abbreviated
 	# commit ids are hexadecimal and therefore never start with "v".

--- a/scripts/test_ci_test_packages.py
+++ b/scripts/test_ci_test_packages.py
@@ -31,15 +31,19 @@ def _defines_unittest_testcase(path: Path) -> bool:
     """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    except (OSError, SyntaxError):
-        # Unreadable or unparseable: assume it may hold tests rather than
-        # quietly shrinking the inventory this guard is built from.
+    except (OSError, SyntaxError, UnicodeError, ValueError):
+        # Unreadable, undecodable, or unparseable: assume it may hold tests
+        # rather than quietly shrinking the inventory this guard is built from.
+        # UnicodeError matters because read_text raises it BEFORE ast.parse ever
+        # runs, so a file that is not valid UTF-8 would otherwise abort the whole
+        # CI check rather than fall back.
         return True
 
-    # Resolve how this module refers to unittest.TestCase, so an unrelated class
-    # that merely happens to be named TestCase is not mistaken for one.
-    testcase_names = set()
-    unittest_names = {"unittest"}
+    # Resolve how this module refers to unittest.TestCase, so a class that merely
+    # happens to be named TestCase, or a module that binds the name `unittest` to
+    # something unrelated, is not mistaken for the standard library.
+    testcase_names: set[str] = set()
+    unittest_names: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.module == "unittest":
             for alias in node.names:
@@ -48,11 +52,31 @@ def _defines_unittest_testcase(path: Path) -> bool:
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.name == "unittest":
-                    unittest_names.add(alias.asname or alias.name)
+                    unittest_names.add(alias.asname or "unittest")
+                elif alias.name.startswith("unittest.") and alias.asname is None:
+                    # `import unittest.mock` also binds the name `unittest`.
+                    unittest_names.add("unittest")
 
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.ClassDef):
-            continue
+    def class_defs_in_module_scope(body: list[ast.stmt]):
+        """Yield classes reachable in the module namespace at import time.
+
+        Descends through module-level control flow, because a class declared
+        inside `if`/`try`/`with` at module level IS bound in the module namespace
+        and IS collected by unittest. Does NOT descend into class or function
+        bodies, because a class nested there is not a module-level test case and
+        counting it would put non-test helpers in the inventory.
+        """
+        for node in body:
+            if isinstance(node, ast.ClassDef):
+                yield node
+            elif isinstance(node, (ast.If, ast.Try, ast.With, ast.For, ast.While)):
+                yield from class_defs_in_module_scope(node.body)
+                yield from class_defs_in_module_scope(getattr(node, "orelse", []))
+                yield from class_defs_in_module_scope(getattr(node, "finalbody", []))
+                for handler in getattr(node, "handlers", []):
+                    yield from class_defs_in_module_scope(handler.body)
+
+    for node in class_defs_in_module_scope(tree.body):
         for base in node.bases:
             # `unittest.TestCase`, including an aliased `import unittest as ut`.
             if isinstance(base, ast.Attribute) and base.attr == "TestCase":

--- a/scripts/test_ci_test_packages.py
+++ b/scripts/test_ci_test_packages.py
@@ -20,6 +20,14 @@ def _defines_unittest_testcase(path: Path) -> bool:
     Parses rather than imports, so surveying the tree cannot execute module-level
     code, and so a module that fails to import is still counted rather than
     silently dropped from the inventory.
+
+    Deliberately errs toward INCLUDING a module. The two mistakes are not
+    symmetric: over-including a non-test module fails this guard loudly with a
+    message a human resolves in seconds, while under-including a real test module
+    silently restores the bug the guard exists to catch. That is why the search
+    walks the whole tree rather than only module-level classes: a TestCase
+    subclass declared inside a module-level `if` is still collected by unittest
+    at import time, but it does not appear in `tree.body`.
     """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
@@ -27,14 +35,32 @@ def _defines_unittest_testcase(path: Path) -> bool:
         # Unreadable or unparseable: assume it may hold tests rather than
         # quietly shrinking the inventory this guard is built from.
         return True
+
+    # Resolve how this module refers to unittest.TestCase, so an unrelated class
+    # that merely happens to be named TestCase is not mistaken for one.
+    testcase_names = set()
+    unittest_names = {"unittest"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "unittest":
+            for alias in node.names:
+                if alias.name == "TestCase":
+                    testcase_names.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "unittest":
+                    unittest_names.add(alias.asname or alias.name)
+
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
             continue
         for base in node.bases:
-            # Matches `unittest.TestCase` and a bare imported `TestCase`.
+            # `unittest.TestCase`, including an aliased `import unittest as ut`.
             if isinstance(base, ast.Attribute) and base.attr == "TestCase":
-                return True
-            if isinstance(base, ast.Name) and base.id == "TestCase":
+                value = base.value
+                if isinstance(value, ast.Name) and value.id in unittest_names:
+                    return True
+            # A bare `TestCase` that this module actually imported from unittest.
+            if isinstance(base, ast.Name) and base.id in testcase_names:
                 return True
     return False
 

--- a/scripts/test_ci_test_packages.py
+++ b/scripts/test_ci_test_packages.py
@@ -5,12 +5,38 @@
 
 from __future__ import annotations
 
+import ast
 import re
 import unittest
 from fnmatch import fnmatchcase
 from pathlib import Path
 
 from scripts.ci_test_packages import SHARDS, package_in_tree, package_suffix, select_packages
+
+
+def _defines_unittest_testcase(path: Path) -> bool:
+    """Report whether a module defines a unittest.TestCase subclass.
+
+    Parses rather than imports, so surveying the tree cannot execute module-level
+    code, and so a module that fails to import is still counted rather than
+    silently dropped from the inventory.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError):
+        # Unreadable or unparseable: assume it may hold tests rather than
+        # quietly shrinking the inventory this guard is built from.
+        return True
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for base in node.bases:
+            # Matches `unittest.TestCase` and a bare imported `TestCase`.
+            if isinstance(base, ast.Attribute) and base.attr == "TestCase":
+                return True
+            if isinstance(base, ast.Name) and base.id == "TestCase":
+                return True
+    return False
 
 
 class TestPackageSharding(unittest.TestCase):
@@ -57,13 +83,31 @@ class TestPackageSharding(unittest.TestCase):
         command = "python3 -m unittest discover -s scripts -p '*test*.py'"
         self.assertIn(command, workflow)
 
-        test_files = sorted(
+        # Build the inventory of real test modules INDEPENDENTLY of the naming
+        # convention, by asking which files actually define a unittest.TestCase.
+        # Deriving the inventory from a name filter makes the assertion vacuous:
+        # every name matching `startswith("test")` or `endswith("_test.py")`
+        # necessarily contains "test", so it always matches the CI pattern and
+        # the check can never fail. A module named `TestHelpers.py` or
+        # `helpers_check.py` is the case that actually matters, and a
+        # name-derived inventory cannot see it.
+        defines_tests = sorted(
             path.name
-            for path in (root / "scripts").glob("*.py")
-            if path.name.startswith("test") or path.name.endswith("_test.py")
+            for path in (root / "scripts").rglob("*.py")
+            if _defines_unittest_testcase(path)
         )
-        missed = [name for name in test_files if not fnmatchcase(name, "*test*.py")]
-        self.assertEqual(missed, [])
+        self.assertTrue(
+            defines_tests,
+            "found no unittest.TestCase modules under scripts/, so this guard is inert",
+        )
+        missed = [name for name in defines_tests if not fnmatchcase(name, "*test*.py")]
+        self.assertEqual(
+            missed,
+            [],
+            "these modules define tests that CI discovery would never collect: "
+            f"{missed}. Either rename them to match '*test*.py' or widen the "
+            "discovery pattern in the CI lint job.",
+        )
 
     def test_every_package_is_selected_exactly_once(self) -> None:
         packages = [

--- a/scripts/test_ci_test_packages.py
+++ b/scripts/test_ci_test_packages.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 import unittest
+from fnmatch import fnmatchcase
 from pathlib import Path
 
 from scripts.ci_test_packages import SHARDS, package_in_tree, package_suffix, select_packages
@@ -48,6 +49,21 @@ class TestPackageSharding(unittest.TestCase):
 
         self.assertEqual(matrix_shards, SHARDS)
         self.assertEqual(loop_shards, SHARDS)
+
+    def test_pr_ci_runs_all_script_unittests(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        workflow = (root / ".github/workflows/ci.yaml").read_text(encoding="utf-8")
+
+        command = "python3 -m unittest discover -s scripts -p '*test*.py'"
+        self.assertIn(command, workflow)
+
+        test_files = sorted(
+            path.name
+            for path in (root / "scripts").glob("*.py")
+            if path.name.startswith("test") or path.name.endswith("_test.py")
+        )
+        missed = [name for name in test_files if not fnmatchcase(name, "*test*.py")]
+        self.assertEqual(missed, [])
 
     def test_every_package_is_selected_exactly_once(self) -> None:
         packages = [

--- a/scripts/test_ci_test_packages.py
+++ b/scripts/test_ci_test_packages.py
@@ -45,7 +45,12 @@ def _defines_unittest_testcase(path: Path) -> bool:
     testcase_names: set[str] = set()
     unittest_names: set[str] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module == "unittest":
+        # `node.level == 0` means an absolute import. `ImportFrom.module` is
+        # "unittest" for both `from unittest import ...` and the relative
+        # `from .unittest import ...`, so without the level check a package with
+        # its own local unittest module would be read as importing the standard
+        # library and could fail this guard for an unrelated reason.
+        if isinstance(node, ast.ImportFrom) and node.module == "unittest" and node.level == 0:
             for alias in node.names:
                 if alias.name == "TestCase":
                     testcase_names.add(alias.asname or alias.name)

--- a/scripts/test_ci_test_packages.py
+++ b/scripts/test_ci_test_packages.py
@@ -49,6 +49,14 @@ def _defines_unittest_testcase(path: Path) -> bool:
             for alias in node.names:
                 if alias.name == "TestCase":
                     testcase_names.add(alias.asname or alias.name)
+                elif alias.name == "*":
+                    # `from unittest import *` yields a single alias named "*",
+                    # so which names it binds cannot be resolved statically. It
+                    # may well bind TestCase. Include the module rather than let
+                    # an unresolvable import silently drop a real test file,
+                    # which is the exact under-inclusion this guard exists to
+                    # prevent.
+                    return True
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.name == "unittest":

--- a/scripts/test_git_version.py
+++ b/scripts/test_git_version.py
@@ -51,8 +51,17 @@ class GitVersionScriptTest(unittest.TestCase):
         self._git("add", "file.txt")
         self._git("commit", "-qm", message)
 
-    def _tag(self, name: str) -> None:
-        self._git("tag", "-a", name, "-m", name)
+    def _tag(self, name: str, *, tagger_date: str | None = None) -> None:
+        env = None
+        if tagger_date is not None:
+            env = {**os.environ, "GIT_COMMITTER_DATE": tagger_date}
+        subprocess.run(
+            ("git", "-C", str(self.repo), "tag", "-a", name, "-m", name),
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
 
     def _version(self) -> str:
         """Run the script with the throwaway repo as the working directory."""
@@ -91,7 +100,7 @@ class GitVersionScriptTest(unittest.TestCase):
         self.assertNotIn("erifier", version)
 
     def test_prerelease_product_tag_is_preserved(self) -> None:
-        """`v[0-9]*` must not exclude a legitimate prerelease tag.
+        """The dotted product glob must not exclude a legitimate prerelease tag.
 
         The suffix text is irrelevant to tag selection; what matters is that a
         hyphenated suffix after the patch digit survives intact.
@@ -99,6 +108,22 @@ class GitVersionScriptTest(unittest.TestCase):
         self._commit("one")
         self._tag("v1.2.3-beta.1")
         self.assertEqual(self._version(), "1.2.3-beta.1")
+
+    def test_floating_action_tag_does_not_shadow_product_version(self) -> None:
+        """The repo carries floating v1/v2 tags for the GitHub Action."""
+        self._commit("one")
+        self._tag("v3.3.0", tagger_date="2026-07-01T00:00:00Z")
+        self._tag("v2", tagger_date="2026-07-02T00:00:00Z")
+        self._commit("two")
+
+        version = self._version()
+
+        self.assertTrue(
+            version.startswith("3.3.0-1-g"),
+            f"expected a 3.3.0 development version, got {version!r}",
+        )
+        self.assertNotEqual(version, "2")
+        self.assertFalse(version.startswith("2-"), f"floating action tag shadowed product tag: {version!r}")
 
     def test_no_product_tag_falls_back_to_a_commit_id(self) -> None:
         """A verifier-only repo must not borrow that unrelated version."""

--- a/scripts/test_git_version.py
+++ b/scripts/test_git_version.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for scripts/git-version.sh product-version discovery.
+
+The regression this guards: the repository carries independently-versioned
+verifier tags (`verifier-v0.2.0`) alongside product tags (`v3.3.0`). An
+unfiltered `git describe --tags` selects whichever tag is nearest in history, so
+once a verifier tag landed after the last release, local and CI builds stamped a
+version from the wrong release series -- and because callers strip one leading
+"v", the result was the malformed `erifier-v0.2.0-1-gabc1234`.
+
+Each test builds a real throwaway repository rather than mocking git, because
+the bug lived in git's tag-selection behaviour and a mock would have reproduced
+the assumption instead of the behaviour.
+"""
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent / "git-version.sh"
+
+
+class GitVersionScriptTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="pipelock-gitversion-")
+        self.repo = pathlib.Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self._git("init", "-q", ".")
+        # Pin identity and disable signing so the test never depends on the
+        # developer's global git configuration.
+        self._git("config", "user.email", "test@example.com")
+        self._git("config", "user.name", "test")
+        self._git("config", "commit.gpgSign", "false")
+        self._git("config", "tag.gpgSign", "false")
+
+    def _git(self, *args: str) -> str:
+        return subprocess.run(
+            ("git", "-C", str(self.repo)) + args,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def _commit(self, message: str) -> None:
+        target = self.repo / "file.txt"
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(message + "\n")
+        self._git("add", "file.txt")
+        self._git("commit", "-qm", message)
+
+    def _tag(self, name: str) -> None:
+        self._git("tag", "-a", name, "-m", name)
+
+    def _version(self) -> str:
+        """Run the script with the throwaway repo as the working directory."""
+        result = subprocess.run(
+            ["bash", str(SCRIPT)],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null"},
+        )
+        return result.stdout.strip()
+
+    def test_product_tag_at_head_reports_that_version(self) -> None:
+        self._commit("one")
+        self._tag("v3.3.0")
+        self.assertEqual(self._version(), "3.3.0")
+
+    def test_nearer_verifier_tag_does_not_shadow_the_product_version(self) -> None:
+        """The exact regression: a verifier tag newer than the last release."""
+        self._commit("one")
+        self._tag("v3.3.0")
+        self._commit("two")
+        self._tag("verifier-v0.2.0")
+        self._commit("three")
+
+        version = self._version()
+
+        # Must describe from the product tag, counting all commits since it.
+        self.assertTrue(
+            version.startswith("3.3.0-2-g"),
+            f"expected a 3.3.0 development version, got {version!r}",
+        )
+        # The historical malformation, asserted directly so a regression is
+        # unmistakable in the failure output rather than merely "wrong prefix".
+        self.assertNotIn("erifier", version)
+
+    def test_prerelease_product_tag_is_preserved(self) -> None:
+        """`v[0-9]*` must not exclude a legitimate prerelease tag.
+
+        The suffix text is irrelevant to tag selection; what matters is that a
+        hyphenated suffix after the patch digit survives intact.
+        """
+        self._commit("one")
+        self._tag("v1.2.3-beta.1")
+        self.assertEqual(self._version(), "1.2.3-beta.1")
+
+    def test_no_product_tag_falls_back_to_a_commit_id(self) -> None:
+        """A verifier-only repo must not borrow that unrelated version."""
+        self._commit("one")
+        self._tag("verifier-v0.2.0")
+
+        version = self._version()
+
+        self.assertNotIn("erifier", version)
+        self.assertNotIn("0.2.0", version)
+        # An abbreviated commit id: hexadecimal, and never version-shaped.
+        self.assertRegex(version, r"^[0-9a-f]{7,}$")
+
+    def test_untagged_repo_falls_back_to_a_commit_id(self) -> None:
+        self._commit("one")
+        self.assertRegex(self._version(), r"^[0-9a-f]{7,}$")
+
+    def test_dirty_worktree_is_marked(self) -> None:
+        """Release tooling relies on the -dirty marker to spot unclean builds."""
+        self._commit("one")
+        self._tag("v3.3.0")
+        (self.repo / "file.txt").write_text("uncommitted\n", encoding="utf-8")
+        self.assertEqual(self._version(), "3.3.0-dirty")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

The release workflow's `v*.*.*` tag filter also matched `verifier-v0.2.0`. Glob `*` is permissive rather than anchored, so the tag matched as v + "erifier-v0" + . + "2" + . + "0". Pushing a signed verifier tag therefore started a full release run, which the SemVer preflight correctly failed closed, skipping every build and publish job. The trigger now requires a digit immediately after the `v`, which excludes non-product tag prefixes and bare floating pointers while still admitting prerelease and extra-dot forms. The strict preflight remains the fail-closed guard.

The same premise, that a leading `v` means a product release tag, also broke version discovery. Four call sites ran an unfiltered `git describe --tags` and stripped one leading `v`, so a verifier tag nearer than the last release produced malformed versions such as `erifier-v0.2.0-1-gabc1234`. Those call sites, the Makefile, both CI build steps, and the reproducible-build check, now share a new `scripts/git-version.sh` that matches product release tags only. Where no product tag is reachable it returns the abbreviated commit id rather than borrowing a version from an unrelated release series.

That new helper needed the same tag pattern as the trigger, not merely a digit after the `v`. The repository carries annotated floating `v1` and `v2` pointer tags for the GitHub Action, and a floating tag at or near a release commit would otherwise win `git describe` and yield a version of `2` or `2-1-g<sha>`.

A bare abbreviated commit id is a newly reachable version shape, so `internal/rules` now classifies it as an unverifiable source build rather than a malformed version. The runtime bundle load path already refused both, so this is not a behaviour change there; what it restores is the operator install path's intended warning, which a malformed classification suppressed. The check deliberately accepts an all-digit string, and the comment records why: roughly one in twenty-seven real abbreviated hashes contains no `a-f` letter, so requiring one would refuse those legitimate source builds outright.

Renovate now holds cosign at 2.x. GoReleaser emits separate `checksums.txt.sig` and `.pem` assets, and cosign 3.x requires the new bundle format and rejects the flags that produce them, so a major bump breaks artifact signing at tag time rather than in pull request CI. Only the `cosign-release` version is held; the installer action itself still updates.

Release tooling unit tests now run in pull request CI. Three of the four modules under `scripts/` had no pull request runner and were executed only by the release workflow, so a break in them stayed invisible until tag time. That mattered most for the flake-retry wrapper's guard against greening a retry that hides a data race, which had never executed. A guard test asserts the workflow uses the discovery form so a future module cannot be silently omitted.

Two stale comments that described the previous trigger are corrected. The floating-tag step's safety reasoning was already sound, since neither the old nor the new pattern matches a bare `v2`, so only the pattern name was wrong.

## Follow-ups not in this change

The release path carries several independent opinions about what a product tag looks like and they do not fully agree. In particular `action.yml`'s cosign certificate identity regex accepts only a final `vMAJOR.MINOR.PATCH`, while the trigger and the release-readiness gate both deliberately admit prerelease tags, so a prerelease tag would satisfy the preflight and then fail identity verification. Version derivation also remains separate in GoReleaser, the Action install path, and self-update. Both are tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Management**
  * Improved version detection for product releases, prereleases, source builds, and dirty workspaces.
  * Release workflows now ignore non-product and invalid version tags.

* **Bug Fixes**
  * Bare commit-based versions are correctly recognized as development builds.
  * Release readiness checks now enforce stricter version formatting.

* **Tests**
  * Expanded automated coverage for version detection, tag selection, dirty builds, and CI test discovery.

* **Chores**
  * Added safeguards to limit major updates for the signing tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->