### PR TITLE
feat(scripts): add a repository-owned PR convergence command

### DIFF
--- a/scripts/pr-convergence.py
+++ b/scripts/pr-convergence.py
@@ -64,8 +64,19 @@ BLOCKED_MERGE_STATES = {"BLOCKED", "DRAFT", "UNKNOWN"}
 FINAL_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED"}
 
 
-class GhReadError(RuntimeError):
+class DataSourceError(RuntimeError):
+    """Raised when a required read source cannot be gathered."""
+
+    def __init__(self, source: str, message: str) -> None:
+        super().__init__(message)
+        self.source = source
+
+
+class GhReadError(DataSourceError):
     """Raised when a read-only GitHub source cannot be gathered."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__("gh", message)
 
 
 def parse_iso8601(value: Any) -> dt.datetime | None:
@@ -110,8 +121,9 @@ def gh_args_are_read_only(args: list[str]) -> bool:
         if arg in {"-X", "--method"}:
             if idx + 1 >= len(args) or args[idx + 1].upper() != "GET":
                 return False
-        if arg.startswith("-X") and arg != "-XGET":
-            return False
+        if arg.startswith("-X") and arg != "-X":
+            if arg[2:].upper() != "GET":
+                return False
         if arg.startswith("--method=") and arg.split("=", 1)[1].upper() != "GET":
             return False
     return True
@@ -147,7 +159,7 @@ class GhClient:
             raise GhReadError(f"gh returned invalid JSON: {exc}") from exc
 
     def api(self, path: str, *, paginate: bool = False, accept: str | None = None) -> Any:
-        args = ["api", path, "-X", "GET"]
+        args = ["api", path]
         if accept:
             args.extend(["-H", f"Accept: {accept}"])
         if paginate:
@@ -188,7 +200,6 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
               path
               line
               originalLine
-              diffSide
               commit { oid }
               originalCommit { oid }
             }
@@ -827,8 +838,18 @@ def classify_pr_state(
 def load_snapshot(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
-    with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
+    try:
+        if path.stat().st_mode & 0o022:
+            raise DataSourceError("snapshot", f"snapshot is group/other writable: {path}")
+        with path.open("r", encoding="utf-8") as handle:
+            snapshot = json.load(handle)
+    except DataSourceError:
+        raise
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DataSourceError("snapshot", f"failed to read snapshot {path}: {exc}") from exc
+    if not isinstance(snapshot, dict):
+        raise DataSourceError("snapshot", "snapshot root was not an object")
+    return snapshot
 
 
 def write_snapshot(path: Path, snapshot: dict[str, Any]) -> None:
@@ -836,6 +857,7 @@ def write_snapshot(path: Path, snapshot: dict[str, Any]) -> None:
     with path.open("w", encoding="utf-8") as handle:
         json.dump(snapshot, handle, indent=2, sort_keys=True)
         handle.write("\n")
+    path.chmod(0o600)
 
 
 def compact_summary(result: dict[str, Any]) -> str:
@@ -939,12 +961,12 @@ def main(argv: list[str]) -> int:
 if __name__ == "__main__":
     try:
         raise SystemExit(main(sys.argv[1:]))
-    except GhReadError as exc:
+    except DataSourceError as exc:
         error_result = {
             "status": "DATA_SOURCE_UNAVAILABLE",
             "ready": False,
             "status_reason": STATUS_DOCS["DATA_SOURCE_UNAVAILABLE"],
-            "errors": [{"source": "gh", "message": str(exc)}],
+            "errors": [{"source": exc.source, "message": str(exc)}],
         }
         print(json.dumps(error_result, indent=2, sort_keys=True))
         raise SystemExit(1) from exc

--- a/scripts/pr-convergence.py
+++ b/scripts/pr-convergence.py
@@ -897,8 +897,7 @@ def compact_summary(result: dict[str, Any]) -> str:
             f"previous_snapshot_found={change['previous_snapshot_found']}"
         ),
     ]
-    if result["errors"]:
-        lines.append(f"errors: {len(result['errors'])} source(s) unavailable")
+    lines.append(f"errors: {len(result['errors'])} source(s) unavailable")
     return "\n".join(lines)
 
 

--- a/scripts/pr-convergence.py
+++ b/scripts/pr-convergence.py
@@ -65,7 +65,7 @@ BLOCKED_MERGE_STATES = {"BLOCKED", "DRAFT", "UNKNOWN"}
 FINAL_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED"}
 GH_READ_TIMEOUT_SECONDS = 30
 SNAPSHOT_SCHEMA_VERSION = 2
-GRAPHQL_ALLOWED_FIELDS = {"query", "owner", "name", "number", "after"}
+GRAPHQL_ALLOWED_FIELDS = {"query", "owner", "name", "number", "after", "headRefName"}
 GH_API_FIELD_FLAGS = {"-f", "-F", "--field", "--raw-field"}
 GH_API_HEADER_FLAGS = {"-H", "--header"}
 
@@ -343,6 +343,75 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
             if not after:
                 raise GhReadError("GraphQL pagination omitted endCursor")
 
+    def graphql_open_pulls_by_head_ref(self, head_ref_name: str) -> list[dict[str, Any]]:
+        query = """
+query($owner: String!, $name: String!, $headRefName: String!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: 100, states: OPEN, headRefName: $headRefName, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        state
+        title
+        url
+        headRefName
+        headRepository { nameWithOwner }
+      }
+    }
+  }
+}
+"""
+        after: str | None = None
+        nodes: list[dict[str, Any]] = []
+        while True:
+            args = [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={self.owner}",
+                "-F",
+                f"name={self.name}",
+                "-F",
+                f"headRefName={head_ref_name}",
+            ]
+            if after:
+                args.extend(["-F", f"after={after}"])
+            data = self.run(args)
+            if not isinstance(data, dict):
+                raise GhReadError("GraphQL response was not an object")
+            data_root = as_dict(data.get("data"))
+            repository = as_dict(data_root.get("repository"))
+            pulls = repository.get("pullRequests")
+            if not isinstance(pulls, dict):
+                raise GhReadError("GraphQL response did not include pullRequests")
+            page_nodes = pulls.get("nodes") or []
+            if not isinstance(page_nodes, list):
+                raise GhReadError("GraphQL pullRequests nodes was not a list")
+            for node_value in page_nodes:
+                node = as_dict(node_value)
+                nodes.append(
+                    {
+                        "number": node.get("number"),
+                        "state": str(node.get("state") or "").lower(),
+                        "title": node.get("title"),
+                        "html_url": node.get("url"),
+                        "head": {
+                            "ref": node.get("headRefName"),
+                            "repo": {
+                                "full_name": dotted_get(node, "headRepository", "nameWithOwner"),
+                            },
+                        },
+                    }
+                )
+            page_info = as_dict(pulls.get("pageInfo"))
+            if not page_info.get("hasNextPage"):
+                return nodes
+            after = page_info.get("endCursor")
+            if not after:
+                raise GhReadError("GraphQL pagination omitted endCursor")
+
 
 def gather_pr_state(repo: str, pr_number: int) -> dict[str, Any]:
     client = GhClient(repo)
@@ -362,6 +431,7 @@ def gather_pr_state(repo: str, pr_number: int) -> dict[str, Any]:
     data["pull"] = pull or {}
     pull_data = as_dict(data["pull"])
     base_ref = str(dotted_get(pull_data, "base", "ref") or "")
+    default_branch = str(dotted_get(pull_data, "base", "repo", "default_branch") or "")
     head_sha = str(dotted_get(pull_data, "head", "sha") or "")
     base_sha = str(dotted_get(pull_data, "base", "sha") or "")
 
@@ -407,13 +477,10 @@ def gather_pr_state(repo: str, pr_number: int) -> dict[str, Any]:
         data["check_runs"] = {"check_runs": []}
         data["status"] = {"statuses": []}
 
-    if base_ref:
+    if base_ref and base_ref != default_branch:
         data["base_pull_candidates"] = read_source(
             "base_pull_candidates",
-            lambda: client.api(
-                f"repos/{repo}/pulls?state=open&per_page=100",
-                paginate=True,
-            ),
+            lambda: client.graphql_open_pulls_by_head_ref(base_ref),
         ) or []
     else:
         data["base_pull_candidates"] = []

--- a/scripts/pr-convergence.py
+++ b/scripts/pr-convergence.py
@@ -1,0 +1,950 @@
+#!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Report whether a GitHub pull request has converged.
+
+The command is read-only. It gathers PR metadata, review threads, top-level
+comments, review summaries, commits, and current-head checks through the `gh`
+CLI, then emits one structured convergence result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+STATUS_DOCS: dict[str, str] = {
+    "READY": "Current head has no detected blockers after an unchanged snapshot window.",
+    "CHECKS_PENDING": "At least one current-head check or status context is queued or in progress.",
+    "CHECKS_FAILING": "At least one current-head check or status context failed, errored, or was cancelled.",
+    "UNRESOLVED_THREADS": "At least one review thread is unresolved, including outside-diff/null-line comments.",
+    "UNREVIEWED_AI_FINDINGS": "A current-head top-level AI Review comment appears to contain findings.",
+    "STALE_REVIEW": "The only approval evidence is tied to an older head SHA.",
+    "STALE_CHECK": "A collected check run or status context is tied to an older head SHA.",
+    "REVIEW_CHANGES_REQUESTED": "A current-head review requested changes.",
+    "CONFLICTED": "GitHub reports merge conflicts or a dirty merge state.",
+    "BEHIND_BASE": "The PR head is behind its base branch or stacked base PR.",
+    "MERGE_BLOCKED": "GitHub reports a blocked, draft, closed, or unknown merge state.",
+    "CHANGED_DURING_WINDOW": "A comment, review, check, or commit changed since the prior snapshot.",
+    "SNAPSHOT_MISSING": "A snapshot path was requested but no prior snapshot existed yet.",
+    "DATA_SOURCE_UNAVAILABLE": "At least one required read source failed, so readiness is unknown.",
+}
+
+ACTIONABLE_RE = re.compile(
+    r"Actionable\s+comments\s+posted:\s*(\d+)",
+    re.IGNORECASE,
+)
+AI_REVIEW_RE = re.compile(r"^\s*##\s+AI Review\b", re.IGNORECASE)
+CLEAN_AI_MARKERS = (
+    "No material security or correctness issues found",
+    "Test coverage is adequate",
+    "Documentation accurately reflects the codebase in this diff",
+    "No actionable comments posted",
+)
+PENDING_CHECK_STATES = {"queued", "requested", "waiting", "pending", "in_progress"}
+FAILING_CHECK_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "startup_failure",
+    "timed_out",
+}
+PASSING_CHECK_CONCLUSIONS = {"neutral", "skipped", "success"}
+CONFLICT_MERGE_STATES = {"DIRTY"}
+BLOCKED_MERGE_STATES = {"BLOCKED", "DRAFT", "UNKNOWN"}
+FINAL_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED"}
+
+
+class GhReadError(RuntimeError):
+    """Raised when a read-only GitHub source cannot be gathered."""
+
+
+def parse_iso8601(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def parse_repo(repo: str) -> tuple[str, str]:
+    parts = repo.split("/", 1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError("repo must use owner/name format")
+    return parts[0], parts[1]
+
+
+def sorted_dict_list(values: list[dict[str, Any]], key: str) -> list[dict[str, Any]]:
+    return sorted(values, key=lambda item: str(item.get(key, "")))
+
+
+def gh_args_are_read_only(args: list[str]) -> bool:
+    if not args:
+        return False
+    if args[0] in {"pr", "repo"}:
+        return len(args) > 1 and args[1] == "view"
+    if args[0] != "api":
+        return False
+    if len(args) > 1 and args[1] == "graphql":
+        query_args = [arg for arg in args if arg.startswith("query=") or arg.startswith("-fquery=")]
+        query_text = " ".join(query_args).lower()
+        if "mutation" in query_text:
+            return False
+    for idx, arg in enumerate(args):
+        if arg in {"-X", "--method"}:
+            if idx + 1 >= len(args) or args[idx + 1].upper() != "GET":
+                return False
+        if arg.startswith("-X") and arg != "-XGET":
+            return False
+        if arg.startswith("--method=") and arg.split("=", 1)[1].upper() != "GET":
+            return False
+    return True
+
+
+class GhClient:
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+        self.owner, self.name = parse_repo(repo)
+
+    def run(self, args: list[str]) -> Any:
+        if not gh_args_are_read_only(args):
+            raise GhReadError(f"refusing non-read-only gh invocation: gh {' '.join(args)}")
+        try:
+            proc = subprocess.run(
+                ["gh", *args],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except OSError as exc:
+            raise GhReadError(f"failed to execute gh: {exc}") from exc
+        if proc.returncode != 0:
+            message = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
+            raise GhReadError(message)
+        output = proc.stdout.strip()
+        if not output:
+            return None
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError as exc:
+            raise GhReadError(f"gh returned invalid JSON: {exc}") from exc
+
+    def api(self, path: str, *, paginate: bool = False, accept: str | None = None) -> Any:
+        args = ["api", path, "-X", "GET"]
+        if accept:
+            args.extend(["-H", f"Accept: {accept}"])
+        if paginate:
+            args.extend(["--paginate", "--slurp"])
+            pages = self.run(args)
+            if pages is None:
+                return []
+            if isinstance(pages, list) and all(isinstance(page, list) for page in pages):
+                flattened: list[Any] = []
+                for page in pages:
+                    flattened.extend(page)
+                return flattened
+            return pages
+        return self.run(args)
+
+    def graphql_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
+        query = """
+query($owner: String!, $name: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          originalLine
+          comments(first: 50) {
+            nodes {
+              id
+              author { login }
+              body
+              createdAt
+              updatedAt
+              url
+              path
+              line
+              originalLine
+              diffSide
+              commit { oid }
+              originalCommit { oid }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+        after: str | None = None
+        nodes: list[dict[str, Any]] = []
+        while True:
+            args = [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={self.owner}",
+                "-F",
+                f"name={self.name}",
+                "-F",
+                f"number={pr_number}",
+            ]
+            if after:
+                args.extend(["-F", f"after={after}"])
+            data = self.run(args)
+            if not isinstance(data, dict):
+                raise GhReadError("GraphQL response was not an object")
+            pull = (
+                data.get("data", {})
+                .get("repository", {})
+                .get("pullRequest")
+            )
+            if not isinstance(pull, dict):
+                raise GhReadError("GraphQL response did not include pullRequest")
+            threads = pull.get("reviewThreads")
+            if not isinstance(threads, dict):
+                raise GhReadError("GraphQL response did not include reviewThreads")
+            page_nodes = threads.get("nodes") or []
+            if not isinstance(page_nodes, list):
+                raise GhReadError("GraphQL reviewThreads nodes was not a list")
+            nodes.extend(page_nodes)
+            page_info = threads.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                return nodes
+            after = page_info.get("endCursor")
+            if not after:
+                raise GhReadError("GraphQL pagination omitted endCursor")
+
+
+def gather_pr_state(repo: str, pr_number: int) -> dict[str, Any]:
+    client = GhClient(repo)
+    data: dict[str, Any] = {"repo": repo, "pr_number": pr_number, "errors": []}
+
+    def read_source(name: str, fn: Any) -> Any:
+        try:
+            return fn()
+        except GhReadError as exc:
+            data["errors"].append({"source": name, "message": str(exc)})
+            return None
+
+    pull = read_source(
+        "pull",
+        lambda: client.api(f"repos/{repo}/pulls/{pr_number}"),
+    )
+    data["pull"] = pull or {}
+    base_ref = data["pull"].get("base", {}).get("ref", "")
+    head_sha = data["pull"].get("head", {}).get("sha", "")
+    base_sha = data["pull"].get("base", {}).get("sha", "")
+
+    data["issue_comments"] = read_source(
+        "issue_comments",
+        lambda: client.api(
+            f"repos/{repo}/issues/{pr_number}/comments?per_page=100",
+            paginate=True,
+        ),
+    ) or []
+    data["reviews"] = read_source(
+        "reviews",
+        lambda: client.api(f"repos/{repo}/pulls/{pr_number}/reviews?per_page=100", paginate=True),
+    ) or []
+    data["review_comments"] = read_source(
+        "review_comments",
+        lambda: client.api(f"repos/{repo}/pulls/{pr_number}/comments?per_page=100", paginate=True),
+    ) or []
+    data["commits"] = read_source(
+        "commits",
+        lambda: client.api(f"repos/{repo}/pulls/{pr_number}/commits?per_page=100", paginate=True),
+    ) or []
+    data["review_threads"] = read_source(
+        "review_threads",
+        lambda: client.graphql_review_threads(pr_number),
+    ) or []
+
+    if head_sha:
+        data["check_runs"] = read_source(
+            "check_runs",
+            lambda: client.api(
+                f"repos/{repo}/commits/{head_sha}/check-runs?per_page=100",
+                paginate=True,
+                accept="application/vnd.github+json",
+            ),
+        ) or {"check_runs": []}
+        data["status"] = read_source(
+            "status",
+            lambda: client.api(f"repos/{repo}/commits/{head_sha}/status"),
+        ) or {"statuses": []}
+    else:
+        data["errors"].append({"source": "checks", "message": "pull head SHA unavailable"})
+        data["check_runs"] = {"check_runs": []}
+        data["status"] = {"statuses": []}
+
+    if base_ref:
+        owner, _ = parse_repo(repo)
+        data["base_pull_candidates"] = read_source(
+            "base_pull_candidates",
+            lambda: client.api(
+                f"repos/{repo}/pulls?state=open&head={owner}:{base_ref}&per_page=100",
+                paginate=True,
+            ),
+        ) or []
+    else:
+        data["base_pull_candidates"] = []
+
+    if base_sha and head_sha:
+        data["compare"] = read_source(
+            "compare",
+            lambda: client.api(f"repos/{repo}/compare/{base_sha}...{head_sha}"),
+        ) or {}
+    else:
+        data["errors"].append({"source": "compare", "message": "base or head SHA unavailable"})
+        data["compare"] = {}
+
+    return data
+
+
+def head_commit_time(commits: list[dict[str, Any]], head_sha: str) -> dt.datetime | None:
+    for commit in commits:
+        if commit.get("sha") != head_sha:
+            continue
+        raw_commit = commit.get("commit") or {}
+        committer = raw_commit.get("committer") or {}
+        author = raw_commit.get("author") or {}
+        return parse_iso8601(committer.get("date")) or parse_iso8601(author.get("date"))
+    if commits:
+        raw_commit = (commits[-1].get("commit") or {})
+        committer = raw_commit.get("committer") or {}
+        author = raw_commit.get("author") or {}
+        return parse_iso8601(committer.get("date")) or parse_iso8601(author.get("date"))
+    return None
+
+
+def normalize_review_threads(threads: list[dict[str, Any]]) -> dict[str, Any]:
+    unresolved: list[dict[str, Any]] = []
+    null_line_comments: list[dict[str, Any]] = []
+    for thread in threads:
+        comments = ((thread.get("comments") or {}).get("nodes") or [])
+        normalized_comments: list[dict[str, Any]] = []
+        for comment in comments:
+            line = comment.get("line")
+            original_line = comment.get("originalLine")
+            item = {
+                "id": comment.get("id"),
+                "author": (comment.get("author") or {}).get("login"),
+                "path": comment.get("path") or thread.get("path"),
+                "line": line,
+                "original_line": original_line,
+                "url": comment.get("url"),
+                "created_at": comment.get("createdAt"),
+                "updated_at": comment.get("updatedAt"),
+            }
+            normalized_comments.append(item)
+            if line is None or original_line is None:
+                null_line_comments.append(item)
+        if not thread.get("isResolved", False):
+            unresolved.append(
+                {
+                    "id": thread.get("id"),
+                    "path": thread.get("path"),
+                    "line": thread.get("line"),
+                    "original_line": thread.get("originalLine"),
+                    "is_outdated": bool(thread.get("isOutdated", False)),
+                    "comments": normalized_comments,
+                }
+            )
+    return {
+        "total_count": len(threads),
+        "unresolved_count": len(unresolved),
+        "threads": unresolved,
+        "outside_diff_or_null_line_count": len(null_line_comments),
+        "outside_diff_or_null_line_comments": null_line_comments,
+    }
+
+
+def normalize_review_comments(comments: list[dict[str, Any]]) -> dict[str, Any]:
+    null_line_comments: list[dict[str, Any]] = []
+    for comment in comments:
+        if comment.get("line") is not None and comment.get("original_line") is not None:
+            continue
+        null_line_comments.append(
+            {
+                "id": comment.get("id"),
+                "author": (comment.get("user") or {}).get("login"),
+                "path": comment.get("path"),
+                "line": comment.get("line"),
+                "original_line": comment.get("original_line"),
+                "position": comment.get("position"),
+                "url": comment.get("html_url"),
+                "created_at": comment.get("created_at"),
+                "updated_at": comment.get("updated_at"),
+            }
+        )
+    return {
+        "total_count": len(comments),
+        "outside_diff_or_null_line_count": len(null_line_comments),
+        "outside_diff_or_null_line_comments": null_line_comments,
+    }
+
+
+def ai_review_has_findings(body: str) -> bool:
+    if not AI_REVIEW_RE.search(body):
+        return False
+    return not any(marker in body for marker in CLEAN_AI_MARKERS)
+
+
+def normalize_issue_comments(
+    comments: list[dict[str, Any]],
+    latest_head_commit_at: dt.datetime | None,
+) -> dict[str, Any]:
+    ai_comments: list[dict[str, Any]] = []
+    unreviewed: list[dict[str, Any]] = []
+    for comment in comments:
+        body = str(comment.get("body") or "")
+        created_at = parse_iso8601(comment.get("created_at"))
+        if not AI_REVIEW_RE.search(body):
+            continue
+        item = {
+            "id": comment.get("id"),
+            "author": (comment.get("user") or {}).get("login"),
+            "created_at": comment.get("created_at"),
+            "updated_at": comment.get("updated_at"),
+            "url": comment.get("html_url"),
+            "has_findings": ai_review_has_findings(body),
+        }
+        ai_comments.append(item)
+        is_current_head_comment = (
+            latest_head_commit_at is None
+            or created_at is None
+            or created_at >= latest_head_commit_at
+        )
+        if item["has_findings"] and is_current_head_comment:
+            unreviewed.append(item)
+    return {
+        "count": len(comments),
+        "ai_review_count": len(ai_comments),
+        "ai_review_comments": ai_comments,
+        "unreviewed_ai_finding_count": len(unreviewed),
+        "unreviewed_ai_findings": unreviewed,
+    }
+
+
+def actionable_count(body: str) -> int:
+    total = 0
+    for match in ACTIONABLE_RE.finditer(body):
+        total += int(match.group(1))
+    return total
+
+
+def normalize_reviews(reviews: list[dict[str, Any]], head_sha: str) -> dict[str, Any]:
+    normalized: list[dict[str, Any]] = []
+    actionable_total = 0
+    current_head_reviews: list[dict[str, Any]] = []
+    stale_reviews: list[dict[str, Any]] = []
+    approvals_current = 0
+    approvals_stale = 0
+    current_changes_requested = 0
+
+    for review in reviews:
+        body = str(review.get("body") or "")
+        count = actionable_count(body)
+        actionable_total += count
+        state = str(review.get("state") or "").upper()
+        commit_id = review.get("commit_id")
+        item = {
+            "id": review.get("id"),
+            "author": (review.get("user") or {}).get("login"),
+            "state": state,
+            "commit_id": commit_id,
+            "submitted_at": review.get("submitted_at"),
+            "html_url": review.get("html_url"),
+            "actionable_comments_posted": count,
+            "is_current_head": commit_id == head_sha,
+        }
+        normalized.append(item)
+        if commit_id == head_sha:
+            current_head_reviews.append(item)
+            if state == "APPROVED":
+                approvals_current += 1
+            if state == "CHANGES_REQUESTED":
+                current_changes_requested += 1
+        elif commit_id:
+            stale_reviews.append(item)
+            if state == "APPROVED":
+                approvals_stale += 1
+
+    latest_final_state = ""
+    final_reviews = [item for item in normalized if item["state"] in FINAL_REVIEW_STATES]
+    if final_reviews:
+        final_reviews.sort(key=lambda item: str(item.get("submitted_at") or ""))
+        latest_final_state = str(final_reviews[-1]["state"])
+
+    return {
+        "count": len(reviews),
+        "current_head_count": len(current_head_reviews),
+        "stale_count": len(stale_reviews),
+        "stale_reviews": stale_reviews,
+        "actionable_comments_total": actionable_total,
+        "approvals_current_head": approvals_current,
+        "approvals_stale": approvals_stale,
+        "stale_approval_without_current_approval": approvals_stale > 0 and approvals_current == 0,
+        "current_head_changes_requested_count": current_changes_requested,
+        "latest_final_state": latest_final_state,
+        "reviews": normalized,
+    }
+
+
+def check_runs_from_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        runs = payload.get("check_runs") or []
+        return runs if isinstance(runs, list) else []
+    if isinstance(payload, list):
+        runs: list[dict[str, Any]] = []
+        for item in payload:
+            if isinstance(item, dict) and "check_runs" in item:
+                page_runs = item.get("check_runs") or []
+                if isinstance(page_runs, list):
+                    runs.extend(page_runs)
+            elif isinstance(item, dict):
+                runs.append(item)
+        return runs
+    return []
+
+
+def classify_check(name: str, status: str, conclusion: str) -> tuple[str, dict[str, str]]:
+    item = {"name": name, "status": status, "conclusion": conclusion}
+    normalized_status = status.lower()
+    normalized_conclusion = conclusion.lower()
+    if normalized_status in PENDING_CHECK_STATES or (
+        normalized_status != "completed" and not normalized_conclusion
+    ):
+        return "pending", item
+    if normalized_conclusion in FAILING_CHECK_CONCLUSIONS:
+        return "failing", item
+    if normalized_conclusion in PASSING_CHECK_CONCLUSIONS:
+        return "passing", item
+    if normalized_conclusion:
+        return "failing", item
+    return "pending", item
+
+
+def normalize_checks(check_runs_payload: Any, status_payload: Any, head_sha: str) -> dict[str, Any]:
+    pending: list[dict[str, str]] = []
+    failing: list[dict[str, str]] = []
+    passing: list[dict[str, str]] = []
+    stale: list[dict[str, Any]] = []
+
+    for run in check_runs_from_payload(check_runs_payload):
+        name = str(run.get("name") or run.get("check_suite", {}).get("app", {}).get("slug") or "")
+        item_sha = run.get("head_sha")
+        if item_sha and item_sha != head_sha:
+            stale.append({"type": "check_run", "name": name, "head_sha": item_sha})
+            continue
+        bucket, item = classify_check(
+            name,
+            str(run.get("status") or ""),
+            str(run.get("conclusion") or ""),
+        )
+        {"pending": pending, "failing": failing, "passing": passing}[bucket].append(item)
+
+    statuses = []
+    if isinstance(status_payload, dict):
+        statuses = status_payload.get("statuses") or []
+    for status in statuses:
+        name = str(status.get("context") or "")
+        item_sha = status.get("sha")
+        if item_sha and item_sha != head_sha:
+            stale.append({"type": "status", "name": name, "head_sha": item_sha})
+            continue
+        state = str(status.get("state") or "")
+        if state == "success":
+            passing.append({"name": name, "status": state, "conclusion": "success"})
+        elif state in {"pending", "expected"}:
+            pending.append({"name": name, "status": state, "conclusion": ""})
+        else:
+            failing.append({"name": name, "status": state, "conclusion": state})
+
+    return {
+        "head_sha": head_sha,
+        "pending": sorted_dict_list(pending, "name"),
+        "failing": sorted_dict_list(failing, "name"),
+        "passing": sorted_dict_list(passing, "name"),
+        "stale": sorted_dict_list(stale, "name"),
+        "pending_count": len(pending),
+        "failing_count": len(failing),
+        "passing_count": len(passing),
+        "stale_count": len(stale),
+    }
+
+
+def normalize_stack(data: dict[str, Any], pr_number: int) -> dict[str, Any]:
+    pull = data.get("pull") or {}
+    base = pull.get("base") or {}
+    head = pull.get("head") or {}
+    candidates = data.get("base_pull_candidates") or []
+    base_pr = None
+    for candidate in candidates:
+        if candidate.get("number") == pr_number:
+            continue
+        base_pr = {
+            "number": candidate.get("number"),
+            "state": candidate.get("state"),
+            "title": candidate.get("title"),
+            "head_ref": (candidate.get("head") or {}).get("ref"),
+            "url": candidate.get("html_url"),
+        }
+        break
+    compare = data.get("compare") or {}
+    behind_by = int(compare.get("behind_by") or 0)
+    return {
+        "base_ref": base.get("ref"),
+        "base_sha": base.get("sha"),
+        "base_repo": (base.get("repo") or {}).get("full_name"),
+        "head_ref": head.get("ref"),
+        "head_sha": head.get("sha"),
+        "head_repo": (head.get("repo") or {}).get("full_name"),
+        "base_is_open_pr": base_pr is not None,
+        "base_pr": base_pr,
+        "head_behind_base": behind_by > 0,
+        "compare_status": compare.get("status"),
+        "behind_by": behind_by,
+        "ahead_by": int(compare.get("ahead_by") or 0),
+    }
+
+
+def build_snapshot(result: dict[str, Any]) -> dict[str, Any]:
+    comments = result["top_level_comments"]
+    reviews = result["review_summaries"]
+    checks = result["required_checks"]
+    raw_review_comments = result.get("_raw_review_comments", [])
+    raw_review_threads = result.get("_raw_review_threads", [])
+    thread_fingerprints = []
+    for thread in raw_review_threads:
+        thread_comments = ((thread.get("comments") or {}).get("nodes") or [])
+        thread_fingerprints.append(
+            {
+                "id": thread.get("id"),
+                "is_resolved": thread.get("isResolved"),
+                "comments": [
+                    {
+                        "id": comment.get("id"),
+                        "updated_at": comment.get("updatedAt") or comment.get("createdAt"),
+                    }
+                    for comment in thread_comments
+                ],
+            }
+        )
+    return {
+        "schema_version": 1,
+        "repo": result["repo"],
+        "pr_number": result["pr"]["number"],
+        "head_sha": result["pr"]["head_sha"],
+        "comments": [
+            {"id": item.get("id"), "updated_at": item.get("updated_at")}
+            for item in result.get("_raw_issue_comments", [])
+        ]
+        + [
+            {"id": item.get("id"), "updated_at": item.get("updated_at")}
+            for item in raw_review_comments
+        ],
+        "reviews": [
+            {
+                "id": item.get("id"),
+                "state": item.get("state"),
+                "commit_id": item.get("commit_id"),
+                "submitted_at": item.get("submitted_at"),
+            }
+            for item in reviews["reviews"]
+        ],
+        "threads": thread_fingerprints,
+        "checks": checks["pending"] + checks["failing"] + checks["passing"] + checks["stale"],
+        "commits": [item.get("sha") for item in result.get("_raw_commits", [])],
+        "ai_review_comments": comments["ai_review_comments"],
+    }
+
+
+def indexed(items: list[dict[str, Any]], key: str = "id") -> dict[str, dict[str, Any]]:
+    output: dict[str, dict[str, Any]] = {}
+    for idx, item in enumerate(items):
+        value = item.get(key)
+        output[str(value if value is not None else idx)] = item
+    return output
+
+
+def changed_keys(previous: list[dict[str, Any]], current: list[dict[str, Any]], key: str = "id") -> list[str]:
+    prev = indexed(previous, key)
+    cur = indexed(current, key)
+    changed = sorted(set(cur) - set(prev))
+    for item_key in sorted(set(cur) & set(prev)):
+        if cur[item_key] != prev[item_key]:
+            changed.append(item_key)
+    return changed
+
+
+def compare_snapshots(previous: dict[str, Any] | None, current: dict[str, Any]) -> dict[str, Any]:
+    if previous is None:
+        return {
+            "enabled": False,
+            "previous_snapshot_found": False,
+            "changed": False,
+            "categories": {},
+        }
+
+    categories = {
+        "comments": changed_keys(previous.get("comments", []), current.get("comments", [])),
+        "reviews": changed_keys(previous.get("reviews", []), current.get("reviews", [])),
+        "checks": changed_keys(previous.get("checks", []), current.get("checks", []), "name"),
+        "commits": sorted(
+            set(str(item) for item in current.get("commits", []))
+            - set(str(item) for item in previous.get("commits", []))
+        ),
+    }
+    changed = any(categories.values()) or previous.get("head_sha") != current.get("head_sha")
+    if previous.get("head_sha") != current.get("head_sha"):
+        categories["head_sha"] = [str(current.get("head_sha"))]
+    return {
+        "enabled": True,
+        "previous_snapshot_found": True,
+        "changed": changed,
+        "categories": categories,
+    }
+
+
+def choose_status(result: dict[str, Any], snapshot_missing: bool) -> str:
+    merge = result["merge"]
+    merge_state = str(merge.get("merge_state_status") or "").upper()
+    if result["errors"]:
+        return "DATA_SOURCE_UNAVAILABLE"
+    if result["change_detection"]["changed"]:
+        return "CHANGED_DURING_WINDOW"
+    if merge.get("mergeable") is False or merge_state in CONFLICT_MERGE_STATES:
+        return "CONFLICTED"
+    if result["stack"]["head_behind_base"]:
+        return "BEHIND_BASE"
+    if result["required_checks"]["stale_count"] > 0:
+        return "STALE_CHECK"
+    if result["required_checks"]["failing_count"] > 0:
+        return "CHECKS_FAILING"
+    if result["required_checks"]["pending_count"] > 0:
+        return "CHECKS_PENDING"
+    if result["review_summaries"]["stale_approval_without_current_approval"]:
+        return "STALE_REVIEW"
+    if result["review_summaries"]["current_head_changes_requested_count"] > 0:
+        return "REVIEW_CHANGES_REQUESTED"
+    if result["review_threads"]["unresolved_count"] > 0:
+        return "UNRESOLVED_THREADS"
+    if result["top_level_comments"]["unreviewed_ai_finding_count"] > 0:
+        return "UNREVIEWED_AI_FINDINGS"
+    if merge_state in BLOCKED_MERGE_STATES or merge.get("is_draft") or merge.get("state") != "open":
+        return "MERGE_BLOCKED"
+    if snapshot_missing:
+        return "SNAPSHOT_MISSING"
+    return "READY"
+
+
+def classify_pr_state(
+    data: dict[str, Any],
+    *,
+    previous_snapshot: dict[str, Any] | None = None,
+    snapshot_requested: bool = False,
+) -> dict[str, Any]:
+    pull = data.get("pull") or {}
+    pr_number = int(data.get("pr_number") or pull.get("number") or 0)
+    head_sha = (pull.get("head") or {}).get("sha") or ""
+    commits = data.get("commits") or []
+    latest_head_commit_at = head_commit_time(commits, head_sha)
+
+    result: dict[str, Any] = {
+        "repo": data.get("repo"),
+        "pr": {
+            "number": pr_number,
+            "url": pull.get("html_url"),
+            "title": pull.get("title"),
+            "base_ref": (pull.get("base") or {}).get("ref"),
+            "head_ref": (pull.get("head") or {}).get("ref"),
+            "base_sha": (pull.get("base") or {}).get("sha"),
+            "head_sha": head_sha,
+        },
+        "stack": normalize_stack(data, pr_number),
+        "review_threads": normalize_review_threads(data.get("review_threads") or []),
+        "inline_comments": normalize_review_comments(data.get("review_comments") or []),
+        "top_level_comments": normalize_issue_comments(
+            data.get("issue_comments") or [],
+            latest_head_commit_at,
+        ),
+        "review_summaries": normalize_reviews(data.get("reviews") or [], head_sha),
+        "required_checks": normalize_checks(data.get("check_runs") or {}, data.get("status") or {}, head_sha),
+        "merge": {
+            "mergeable": pull.get("mergeable"),
+            "merge_state_status": pull.get("mergeable_state") or pull.get("merge_state_status"),
+            "is_draft": bool(pull.get("draft", False)),
+            "state": str(pull.get("state") or "").lower(),
+        },
+        "errors": data.get("errors") or [],
+        "_raw_issue_comments": data.get("issue_comments") or [],
+        "_raw_review_comments": data.get("review_comments") or [],
+        "_raw_review_threads": data.get("review_threads") or [],
+        "_raw_commits": commits,
+    }
+    current_snapshot = build_snapshot(result)
+    snapshot_missing = snapshot_requested and previous_snapshot is None
+    result["change_detection"] = compare_snapshots(previous_snapshot, current_snapshot)
+    result["snapshot"] = current_snapshot
+    status = choose_status(result, snapshot_missing)
+    result["status"] = status
+    result["ready"] = status == "READY"
+    result["status_reason"] = STATUS_DOCS[status]
+    result.pop("_raw_issue_comments", None)
+    result.pop("_raw_review_comments", None)
+    result.pop("_raw_review_threads", None)
+    result.pop("_raw_commits", None)
+    return result
+
+
+def load_snapshot(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_snapshot(path: Path, snapshot: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(snapshot, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def compact_summary(result: dict[str, Any]) -> str:
+    checks = result["required_checks"]
+    threads = result["review_threads"]
+    comments = result["top_level_comments"]
+    reviews = result["review_summaries"]
+    stack = result["stack"]
+    change = result["change_detection"]
+    lines = [
+        f"status: {result['status']} - {result['status_reason']}",
+        f"pr: #{result['pr']['number']} head={result['pr']['head_sha']} base={result['pr']['base_ref']}",
+        (
+            "stack: "
+            f"base_is_open_pr={stack['base_is_open_pr']} "
+            f"behind_base={stack['head_behind_base']} "
+            f"compare={stack['compare_status']}"
+        ),
+        (
+            "reviews: "
+            f"unresolved_threads={threads['unresolved_count']} "
+            f"stale={reviews['stale_count']} "
+            f"actionable_summary_total={reviews['actionable_comments_total']} "
+            f"ai_findings={comments['unreviewed_ai_finding_count']}"
+        ),
+        (
+            "checks: "
+            f"passing={checks['passing_count']} "
+            f"pending={checks['pending_count']} "
+            f"failing={checks['failing_count']} "
+            f"stale={checks['stale_count']}"
+        ),
+        (
+            "change_detection: "
+            f"enabled={change['enabled']} "
+            f"changed={change['changed']} "
+            f"previous_snapshot_found={change['previous_snapshot_found']}"
+        ),
+    ]
+    if result["errors"]:
+        lines.append(f"errors: {len(result['errors'])} source(s) unavailable")
+    return "\n".join(lines)
+
+
+def status_epilog() -> str:
+    lines = ["Status values:"]
+    for name, description in STATUS_DOCS.items():
+        lines.append(f"  {name}: {description}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Return one structured PR convergence result.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=status_epilog(),
+    )
+    parser.add_argument("pr", nargs="?", help="pull request number; defaults to PR_NUMBER")
+    parser.add_argument("--repo", default=os.environ.get("REPO", ""), help="owner/repo")
+    parser.add_argument("--json", action="store_true", help="print a single JSON object")
+    parser.add_argument(
+        "--snapshot",
+        type=Path,
+        help="read a previous snapshot if present, then write the current snapshot",
+    )
+    return parser.parse_args(argv)
+
+
+def infer_repo() -> str:
+    data = GhClient("owner/repo").run(["repo", "view", "--json", "nameWithOwner"])
+    if not isinstance(data, dict) or not data.get("nameWithOwner"):
+        raise GhReadError("could not infer repository from gh repo view")
+    return str(data["nameWithOwner"])
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo = args.repo or infer_repo()
+    pr_raw = args.pr or os.environ.get("PR_NUMBER")
+    if not pr_raw:
+        raise SystemExit("PR number required as argument or PR_NUMBER")
+    try:
+        pr_number = int(pr_raw)
+    except ValueError as exc:
+        raise SystemExit("PR number must be an integer") from exc
+
+    previous_snapshot = load_snapshot(args.snapshot) if args.snapshot else None
+    data = gather_pr_state(repo, pr_number)
+    result = classify_pr_state(
+        data,
+        previous_snapshot=previous_snapshot,
+        snapshot_requested=args.snapshot is not None,
+    )
+    if args.snapshot:
+        write_snapshot(args.snapshot, result["snapshot"])
+    output = json.dumps(result, indent=2, sort_keys=True) if args.json else compact_summary(result)
+    print(output)
+    return 0 if result["status"] == "READY" else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except GhReadError as exc:
+        error_result = {
+            "status": "DATA_SOURCE_UNAVAILABLE",
+            "ready": False,
+            "status_reason": STATUS_DOCS["DATA_SOURCE_UNAVAILABLE"],
+            "errors": [{"source": "gh", "message": str(exc)}],
+        }
+        print(json.dumps(error_result, indent=2, sort_keys=True))
+        raise SystemExit(1) from exc

--- a/scripts/pr-convergence.py
+++ b/scripts/pr-convergence.py
@@ -19,6 +19,7 @@ import re
 import subprocess
 import sys
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -64,6 +65,7 @@ CONFLICT_MERGE_STATES = {"DIRTY"}
 BLOCKED_MERGE_STATES = {"BLOCKED", "DRAFT", "UNKNOWN"}
 FINAL_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED"}
 GH_READ_TIMEOUT_SECONDS = 30
+GRAPHQL_MAX_PAGES = 100
 SNAPSHOT_SCHEMA_VERSION = 2
 GRAPHQL_ALLOWED_FIELDS = {"query", "owner", "name", "number", "after", "headRefName"}
 GH_API_FIELD_FLAGS = {"-f", "-F", "--field", "--raw-field"}
@@ -124,6 +126,22 @@ def dotted_get(value: Any, *keys: str) -> Any:
     for key in keys:
         current = as_dict(current).get(key)
     return current
+
+
+def map_open_pull_node(node_value: Any) -> dict[str, Any]:
+    node = as_dict(node_value)
+    return {
+        "number": node.get("number"),
+        "state": str(node.get("state") or "").lower(),
+        "title": node.get("title"),
+        "html_url": node.get("url"),
+        "head": {
+            "ref": node.get("headRefName"),
+            "repo": {
+                "full_name": dotted_get(node, "headRepository", "nameWithOwner"),
+            },
+        },
+    }
 
 
 def option_value(args: list[str], idx: int, names: set[str]) -> tuple[str | None, int] | None:
@@ -269,6 +287,57 @@ class GhClient:
             return pages
         return self.run(args)
 
+    def graphql_paginated_nodes(
+        self,
+        *,
+        query: str,
+        variables: dict[str, Any],
+        connection_path: tuple[str, ...],
+        connection_name: str,
+        nodes_name: str,
+        node_mapper: Callable[[Any], dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        after: str | None = None
+        nodes: list[dict[str, Any]] = []
+        seen_cursors: set[str] = set()
+        for _ in range(GRAPHQL_MAX_PAGES):
+            args = [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-f",
+                f"owner={self.owner}",
+                "-f",
+                f"name={self.name}",
+            ]
+            for name, value in variables.items():
+                flag = "-F" if isinstance(value, int) else "-f"
+                args.extend([flag, f"{name}={value}"])
+            if after:
+                args.extend(["-f", f"after={after}"])
+            data = self.run(args)
+            if not isinstance(data, dict):
+                raise GhReadError("GraphQL response was not an object")
+            repository = as_dict(dotted_get(data, "data", "repository"))
+            connection = dotted_get(repository, *connection_path)
+            if not isinstance(connection, dict):
+                raise GhReadError(f"GraphQL response did not include {connection_name}")
+            page_nodes = connection.get("nodes") or []
+            if not isinstance(page_nodes, list):
+                raise GhReadError(f"GraphQL {nodes_name} nodes was not a list")
+            nodes.extend(node_mapper(node_value) for node_value in page_nodes)
+            page_info = as_dict(connection.get("pageInfo"))
+            if not page_info.get("hasNextPage"):
+                return nodes
+            after = page_info.get("endCursor")
+            if not after:
+                raise GhReadError("GraphQL pagination omitted endCursor")
+            if after in seen_cursors:
+                raise GhReadError(f"GraphQL pagination repeated cursor for {connection_name}")
+            seen_cursors.add(after)
+        raise GhReadError(f"GraphQL pagination exceeded {GRAPHQL_MAX_PAGES} pages for {connection_name}")
+
     def graphql_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
         query = """
 query($owner: String!, $name: String!, $number: Int!, $after: String) {
@@ -304,44 +373,14 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
   }
 }
 """
-        after: str | None = None
-        nodes: list[dict[str, Any]] = []
-        while True:
-            args = [
-                "api",
-                "graphql",
-                "-f",
-                f"query={query}",
-                "-F",
-                f"owner={self.owner}",
-                "-F",
-                f"name={self.name}",
-                "-F",
-                f"number={pr_number}",
-            ]
-            if after:
-                args.extend(["-F", f"after={after}"])
-            data = self.run(args)
-            if not isinstance(data, dict):
-                raise GhReadError("GraphQL response was not an object")
-            data_root = as_dict(data.get("data"))
-            repository = as_dict(data_root.get("repository"))
-            pull = repository.get("pullRequest")
-            if not isinstance(pull, dict):
-                raise GhReadError("GraphQL response did not include pullRequest")
-            threads = pull.get("reviewThreads")
-            if not isinstance(threads, dict):
-                raise GhReadError("GraphQL response did not include reviewThreads")
-            page_nodes = threads.get("nodes") or []
-            if not isinstance(page_nodes, list):
-                raise GhReadError("GraphQL reviewThreads nodes was not a list")
-            nodes.extend(page_nodes)
-            page_info = as_dict(threads.get("pageInfo"))
-            if not page_info.get("hasNextPage"):
-                return nodes
-            after = page_info.get("endCursor")
-            if not after:
-                raise GhReadError("GraphQL pagination omitted endCursor")
+        return self.graphql_paginated_nodes(
+            query=query,
+            variables={"number": pr_number},
+            connection_path=("pullRequest", "reviewThreads"),
+            connection_name="reviewThreads",
+            nodes_name="reviewThreads",
+            node_mapper=as_dict,
+        )
 
     def graphql_open_pulls_by_head_ref(self, head_ref_name: str) -> list[dict[str, Any]]:
         query = """
@@ -361,56 +400,14 @@ query($owner: String!, $name: String!, $headRefName: String!, $after: String) {
   }
 }
 """
-        after: str | None = None
-        nodes: list[dict[str, Any]] = []
-        while True:
-            args = [
-                "api",
-                "graphql",
-                "-f",
-                f"query={query}",
-                "-F",
-                f"owner={self.owner}",
-                "-F",
-                f"name={self.name}",
-                "-F",
-                f"headRefName={head_ref_name}",
-            ]
-            if after:
-                args.extend(["-F", f"after={after}"])
-            data = self.run(args)
-            if not isinstance(data, dict):
-                raise GhReadError("GraphQL response was not an object")
-            data_root = as_dict(data.get("data"))
-            repository = as_dict(data_root.get("repository"))
-            pulls = repository.get("pullRequests")
-            if not isinstance(pulls, dict):
-                raise GhReadError("GraphQL response did not include pullRequests")
-            page_nodes = pulls.get("nodes") or []
-            if not isinstance(page_nodes, list):
-                raise GhReadError("GraphQL pullRequests nodes was not a list")
-            for node_value in page_nodes:
-                node = as_dict(node_value)
-                nodes.append(
-                    {
-                        "number": node.get("number"),
-                        "state": str(node.get("state") or "").lower(),
-                        "title": node.get("title"),
-                        "html_url": node.get("url"),
-                        "head": {
-                            "ref": node.get("headRefName"),
-                            "repo": {
-                                "full_name": dotted_get(node, "headRepository", "nameWithOwner"),
-                            },
-                        },
-                    }
-                )
-            page_info = as_dict(pulls.get("pageInfo"))
-            if not page_info.get("hasNextPage"):
-                return nodes
-            after = page_info.get("endCursor")
-            if not after:
-                raise GhReadError("GraphQL pagination omitted endCursor")
+        return self.graphql_paginated_nodes(
+            query=query,
+            variables={"headRefName": head_ref_name},
+            connection_path=("pullRequests",),
+            connection_name="pullRequests",
+            nodes_name="pullRequests",
+            node_mapper=map_open_pull_node,
+        )
 
 
 def gather_pr_state(repo: str, pr_number: int) -> dict[str, Any]:

--- a/scripts/pr-convergence.py
+++ b/scripts/pr-convergence.py
@@ -18,6 +18,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -43,7 +44,7 @@ ACTIONABLE_RE = re.compile(
     r"Actionable\s+comments\s+posted:\s*(\d+)",
     re.IGNORECASE,
 )
-AI_REVIEW_RE = re.compile(r"^\s*##\s+AI Review\b", re.IGNORECASE)
+AI_REVIEW_RE = re.compile(r"^\s*##\s+AI Review\b", re.IGNORECASE | re.MULTILINE)
 CLEAN_AI_MARKERS = (
     "No material security or correctness issues found",
     "Test coverage is adequate",
@@ -62,6 +63,11 @@ PASSING_CHECK_CONCLUSIONS = {"neutral", "skipped", "success"}
 CONFLICT_MERGE_STATES = {"DIRTY"}
 BLOCKED_MERGE_STATES = {"BLOCKED", "DRAFT", "UNKNOWN"}
 FINAL_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED"}
+GH_READ_TIMEOUT_SECONDS = 30
+SNAPSHOT_SCHEMA_VERSION = 2
+GRAPHQL_ALLOWED_FIELDS = {"query", "owner", "name", "number", "after"}
+GH_API_FIELD_FLAGS = {"-f", "-F", "--field", "--raw-field"}
+GH_API_HEADER_FLAGS = {"-H", "--header"}
 
 
 class DataSourceError(RuntimeError):
@@ -105,6 +111,54 @@ def sorted_dict_list(values: list[dict[str, Any]], key: str) -> list[dict[str, A
     return sorted(values, key=lambda item: str(item.get(key, "")))
 
 
+def as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def dotted_get(value: Any, *keys: str) -> Any:
+    current = value
+    for key in keys:
+        current = as_dict(current).get(key)
+    return current
+
+
+def option_value(args: list[str], idx: int, names: set[str]) -> tuple[str | None, int] | None:
+    arg = args[idx]
+    if arg in names:
+        if idx + 1 >= len(args):
+            return None
+        return args[idx + 1], idx + 2
+    for name in names:
+        if arg.startswith(f"{name}="):
+            return arg.split("=", 1)[1], idx + 1
+        if name.startswith("-") and len(name) == 2 and arg.startswith(name) and arg != name:
+            return arg[len(name):], idx + 1
+    return None
+
+
+def field_name(value: str) -> str | None:
+    if "=" not in value:
+        return None
+    name, _ = value.split("=", 1)
+    return name or None
+
+
+def graphql_query_is_read_only(query: str) -> bool:
+    stripped = query.lstrip()
+    if not stripped:
+        return False
+    if stripped.startswith("{"):
+        return True
+    match = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\b", stripped)
+    if not match:
+        return False
+    return match.group(1).lower() == "query"
+
+
 def gh_args_are_read_only(args: list[str]) -> bool:
     if not args:
         return False
@@ -112,11 +166,12 @@ def gh_args_are_read_only(args: list[str]) -> bool:
         return len(args) > 1 and args[1] == "view"
     if args[0] != "api":
         return False
-    if len(args) > 1 and args[1] == "graphql":
-        query_args = [arg for arg in args if arg.startswith("query=") or arg.startswith("-fquery=")]
-        query_text = " ".join(query_args).lower()
-        if "mutation" in query_text:
-            return False
+    if len(args) < 2:
+        return False
+    is_graphql = args[1] == "graphql"
+    graphql_query = ""
+    if not is_graphql and args[1].startswith("-"):
+        return False
     for idx, arg in enumerate(args):
         if arg in {"-X", "--method"}:
             if idx + 1 >= len(args) or args[idx + 1].upper() != "GET":
@@ -126,6 +181,42 @@ def gh_args_are_read_only(args: list[str]) -> bool:
                 return False
         if arg.startswith("--method=") and arg.split("=", 1)[1].upper() != "GET":
             return False
+        if arg == "--input" or arg.startswith("--input="):
+            return False
+    idx = 2
+    while idx < len(args):
+        arg = args[idx]
+        if arg in {"--paginate", "--slurp"}:
+            idx += 1
+            continue
+        header = option_value(args, idx, GH_API_HEADER_FLAGS)
+        if header is not None:
+            if header[0] is None:
+                return False
+            idx = header[1]
+            continue
+        method = option_value(args, idx, {"-X", "--method"})
+        if method is not None:
+            if method[0] is None or method[0].upper() != "GET":
+                return False
+            idx = method[1]
+            continue
+        field = option_value(args, idx, GH_API_FIELD_FLAGS)
+        if field is not None:
+            if not is_graphql or field[0] is None:
+                return False
+            name = field_name(field[0])
+            if name not in GRAPHQL_ALLOWED_FIELDS:
+                return False
+            if name == "query":
+                graphql_query = field[0].split("=", 1)[1]
+            idx = field[1]
+            continue
+        if arg.startswith("-"):
+            return False
+        return False
+    if is_graphql and not graphql_query_is_read_only(graphql_query):
+        return False
     return True
 
 
@@ -144,7 +235,10 @@ class GhClient:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                timeout=GH_READ_TIMEOUT_SECONDS,
             )
+        except subprocess.TimeoutExpired as exc:
+            raise GhReadError(f"gh timed out after {GH_READ_TIMEOUT_SECONDS}s") from exc
         except OSError as exc:
             raise GhReadError(f"failed to execute gh: {exc}") from exc
         if proc.returncode != 0:
@@ -230,11 +324,9 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
             data = self.run(args)
             if not isinstance(data, dict):
                 raise GhReadError("GraphQL response was not an object")
-            pull = (
-                data.get("data", {})
-                .get("repository", {})
-                .get("pullRequest")
-            )
+            data_root = as_dict(data.get("data"))
+            repository = as_dict(data_root.get("repository"))
+            pull = repository.get("pullRequest")
             if not isinstance(pull, dict):
                 raise GhReadError("GraphQL response did not include pullRequest")
             threads = pull.get("reviewThreads")
@@ -244,7 +336,7 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
             if not isinstance(page_nodes, list):
                 raise GhReadError("GraphQL reviewThreads nodes was not a list")
             nodes.extend(page_nodes)
-            page_info = threads.get("pageInfo") or {}
+            page_info = as_dict(threads.get("pageInfo"))
             if not page_info.get("hasNextPage"):
                 return nodes
             after = page_info.get("endCursor")
@@ -268,9 +360,10 @@ def gather_pr_state(repo: str, pr_number: int) -> dict[str, Any]:
         lambda: client.api(f"repos/{repo}/pulls/{pr_number}"),
     )
     data["pull"] = pull or {}
-    base_ref = data["pull"].get("base", {}).get("ref", "")
-    head_sha = data["pull"].get("head", {}).get("sha", "")
-    base_sha = data["pull"].get("base", {}).get("sha", "")
+    pull_data = as_dict(data["pull"])
+    base_ref = str(dotted_get(pull_data, "base", "ref") or "")
+    head_sha = str(dotted_get(pull_data, "head", "sha") or "")
+    base_sha = str(dotted_get(pull_data, "base", "sha") or "")
 
     data["issue_comments"] = read_source(
         "issue_comments",
@@ -315,11 +408,10 @@ def gather_pr_state(repo: str, pr_number: int) -> dict[str, Any]:
         data["status"] = {"statuses": []}
 
     if base_ref:
-        owner, _ = parse_repo(repo)
         data["base_pull_candidates"] = read_source(
             "base_pull_candidates",
             lambda: client.api(
-                f"repos/{repo}/pulls?state=open&head={owner}:{base_ref}&per_page=100",
+                f"repos/{repo}/pulls?state=open&per_page=100",
                 paginate=True,
             ),
         ) or []
@@ -342,14 +434,14 @@ def head_commit_time(commits: list[dict[str, Any]], head_sha: str) -> dt.datetim
     for commit in commits:
         if commit.get("sha") != head_sha:
             continue
-        raw_commit = commit.get("commit") or {}
-        committer = raw_commit.get("committer") or {}
-        author = raw_commit.get("author") or {}
+        raw_commit = as_dict(commit.get("commit"))
+        committer = as_dict(raw_commit.get("committer"))
+        author = as_dict(raw_commit.get("author"))
         return parse_iso8601(committer.get("date")) or parse_iso8601(author.get("date"))
     if commits:
-        raw_commit = (commits[-1].get("commit") or {})
-        committer = raw_commit.get("committer") or {}
-        author = raw_commit.get("author") or {}
+        raw_commit = as_dict(commits[-1].get("commit"))
+        committer = as_dict(raw_commit.get("committer"))
+        author = as_dict(raw_commit.get("author"))
         return parse_iso8601(committer.get("date")) or parse_iso8601(author.get("date"))
     return None
 
@@ -358,14 +450,15 @@ def normalize_review_threads(threads: list[dict[str, Any]]) -> dict[str, Any]:
     unresolved: list[dict[str, Any]] = []
     null_line_comments: list[dict[str, Any]] = []
     for thread in threads:
-        comments = ((thread.get("comments") or {}).get("nodes") or [])
+        comments = as_list(dotted_get(thread, "comments", "nodes"))
         normalized_comments: list[dict[str, Any]] = []
-        for comment in comments:
+        for comment_value in comments:
+            comment = as_dict(comment_value)
             line = comment.get("line")
             original_line = comment.get("originalLine")
             item = {
                 "id": comment.get("id"),
-                "author": (comment.get("author") or {}).get("login"),
+                "author": dotted_get(comment, "author", "login"),
                 "path": comment.get("path") or thread.get("path"),
                 "line": line,
                 "original_line": original_line,
@@ -398,13 +491,14 @@ def normalize_review_threads(threads: list[dict[str, Any]]) -> dict[str, Any]:
 
 def normalize_review_comments(comments: list[dict[str, Any]]) -> dict[str, Any]:
     null_line_comments: list[dict[str, Any]] = []
-    for comment in comments:
+    for comment_value in comments:
+        comment = as_dict(comment_value)
         if comment.get("line") is not None and comment.get("original_line") is not None:
             continue
         null_line_comments.append(
             {
                 "id": comment.get("id"),
-                "author": (comment.get("user") or {}).get("login"),
+                "author": dotted_get(comment, "user", "login"),
                 "path": comment.get("path"),
                 "line": comment.get("line"),
                 "original_line": comment.get("original_line"),
@@ -424,6 +518,8 @@ def normalize_review_comments(comments: list[dict[str, Any]]) -> dict[str, Any]:
 def ai_review_has_findings(body: str) -> bool:
     if not AI_REVIEW_RE.search(body):
         return False
+    if actionable_count(body) > 0:
+        return True
     return not any(marker in body for marker in CLEAN_AI_MARKERS)
 
 
@@ -433,14 +529,15 @@ def normalize_issue_comments(
 ) -> dict[str, Any]:
     ai_comments: list[dict[str, Any]] = []
     unreviewed: list[dict[str, Any]] = []
-    for comment in comments:
+    for comment_value in comments:
+        comment = as_dict(comment_value)
         body = str(comment.get("body") or "")
         created_at = parse_iso8601(comment.get("created_at"))
         if not AI_REVIEW_RE.search(body):
             continue
         item = {
             "id": comment.get("id"),
-            "author": (comment.get("user") or {}).get("login"),
+            "author": dotted_get(comment, "user", "login"),
             "created_at": comment.get("created_at"),
             "updated_at": comment.get("updated_at"),
             "url": comment.get("html_url"),
@@ -479,7 +576,8 @@ def normalize_reviews(reviews: list[dict[str, Any]], head_sha: str) -> dict[str,
     approvals_stale = 0
     current_changes_requested = 0
 
-    for review in reviews:
+    for review_value in reviews:
+        review = as_dict(review_value)
         body = str(review.get("body") or "")
         count = actionable_count(body)
         actionable_total += count
@@ -487,7 +585,7 @@ def normalize_reviews(reviews: list[dict[str, Any]], head_sha: str) -> dict[str,
         commit_id = review.get("commit_id")
         item = {
             "id": review.get("id"),
-            "author": (review.get("user") or {}).get("login"),
+            "author": dotted_get(review, "user", "login"),
             "state": state,
             "commit_id": commit_id,
             "submitted_at": review.get("submitted_at"),
@@ -568,8 +666,9 @@ def normalize_checks(check_runs_payload: Any, status_payload: Any, head_sha: str
     passing: list[dict[str, str]] = []
     stale: list[dict[str, Any]] = []
 
-    for run in check_runs_from_payload(check_runs_payload):
-        name = str(run.get("name") or run.get("check_suite", {}).get("app", {}).get("slug") or "")
+    for run_value in check_runs_from_payload(check_runs_payload):
+        run = as_dict(run_value)
+        name = str(run.get("name") or dotted_get(run, "check_suite", "app", "slug") or "")
         item_sha = run.get("head_sha")
         if item_sha and item_sha != head_sha:
             stale.append({"type": "check_run", "name": name, "head_sha": item_sha})
@@ -584,7 +683,8 @@ def normalize_checks(check_runs_payload: Any, status_payload: Any, head_sha: str
     statuses = []
     if isinstance(status_payload, dict):
         statuses = status_payload.get("statuses") or []
-    for status in statuses:
+    for status_value in statuses:
+        status = as_dict(status_value)
         name = str(status.get("context") or "")
         item_sha = status.get("sha")
         if item_sha and item_sha != head_sha:
@@ -612,31 +712,37 @@ def normalize_checks(check_runs_payload: Any, status_payload: Any, head_sha: str
 
 
 def normalize_stack(data: dict[str, Any], pr_number: int) -> dict[str, Any]:
-    pull = data.get("pull") or {}
-    base = pull.get("base") or {}
-    head = pull.get("head") or {}
-    candidates = data.get("base_pull_candidates") or []
+    pull = as_dict(data.get("pull"))
+    base = as_dict(pull.get("base"))
+    head = as_dict(pull.get("head"))
+    candidates = as_list(data.get("base_pull_candidates"))
+    base_ref = base.get("ref")
+    default_branch = dotted_get(base, "repo", "default_branch")
     base_pr = None
-    for candidate in candidates:
-        if candidate.get("number") == pr_number:
-            continue
-        base_pr = {
-            "number": candidate.get("number"),
-            "state": candidate.get("state"),
-            "title": candidate.get("title"),
-            "head_ref": (candidate.get("head") or {}).get("ref"),
-            "url": candidate.get("html_url"),
-        }
-        break
-    compare = data.get("compare") or {}
+    if base_ref and base_ref != default_branch:
+        for candidate_value in candidates:
+            candidate = as_dict(candidate_value)
+            candidate_head = as_dict(candidate.get("head"))
+            if candidate.get("number") == pr_number or candidate_head.get("ref") != base_ref:
+                continue
+            base_pr = {
+                "number": candidate.get("number"),
+                "state": candidate.get("state"),
+                "title": candidate.get("title"),
+                "head_ref": candidate_head.get("ref"),
+                "head_repo": dotted_get(candidate_head, "repo", "full_name"),
+                "url": candidate.get("html_url"),
+            }
+            break
+    compare = as_dict(data.get("compare"))
     behind_by = int(compare.get("behind_by") or 0)
     return {
-        "base_ref": base.get("ref"),
+        "base_ref": base_ref,
         "base_sha": base.get("sha"),
-        "base_repo": (base.get("repo") or {}).get("full_name"),
+        "base_repo": dotted_get(base, "repo", "full_name"),
         "head_ref": head.get("ref"),
         "head_sha": head.get("sha"),
-        "head_repo": (head.get("repo") or {}).get("full_name"),
+        "head_repo": dotted_get(head, "repo", "full_name"),
         "base_is_open_pr": base_pr is not None,
         "base_pr": base_pr,
         "head_behind_base": behind_by > 0,
@@ -653,32 +759,35 @@ def build_snapshot(result: dict[str, Any]) -> dict[str, Any]:
     raw_review_comments = result.get("_raw_review_comments", [])
     raw_review_threads = result.get("_raw_review_threads", [])
     thread_fingerprints = []
-    for thread in raw_review_threads:
-        thread_comments = ((thread.get("comments") or {}).get("nodes") or [])
+    for thread_value in raw_review_threads:
+        thread = as_dict(thread_value)
+        thread_comments = as_list(dotted_get(thread, "comments", "nodes"))
         thread_fingerprints.append(
             {
                 "id": thread.get("id"),
+                "kind": "review_thread",
                 "is_resolved": thread.get("isResolved"),
                 "comments": [
                     {
-                        "id": comment.get("id"),
-                        "updated_at": comment.get("updatedAt") or comment.get("createdAt"),
+                        "id": as_dict(comment).get("id"),
+                        "kind": "thread_comment",
+                        "updated_at": as_dict(comment).get("updatedAt") or as_dict(comment).get("createdAt"),
                     }
                     for comment in thread_comments
                 ],
             }
         )
     return {
-        "schema_version": 1,
+        "schema_version": SNAPSHOT_SCHEMA_VERSION,
         "repo": result["repo"],
         "pr_number": result["pr"]["number"],
         "head_sha": result["pr"]["head_sha"],
         "comments": [
-            {"id": item.get("id"), "updated_at": item.get("updated_at")}
+            {"kind": "issue_comment", "id": item.get("id"), "updated_at": item.get("updated_at")}
             for item in result.get("_raw_issue_comments", [])
         ]
         + [
-            {"id": item.get("id"), "updated_at": item.get("updated_at")}
+            {"kind": "review_comment", "id": item.get("id"), "updated_at": item.get("updated_at")}
             for item in raw_review_comments
         ],
         "reviews": [
@@ -699,19 +808,25 @@ def build_snapshot(result: dict[str, Any]) -> dict[str, Any]:
 
 def indexed(items: list[dict[str, Any]], key: str = "id") -> dict[str, dict[str, Any]]:
     output: dict[str, dict[str, Any]] = {}
-    for idx, item in enumerate(items):
+    for idx, item_value in enumerate(items):
+        item = as_dict(item_value)
         value = item.get(key)
-        output[str(value if value is not None else idx)] = item
+        item_key = str(value if value is not None else idx)
+        kind = item.get("kind")
+        if kind:
+            item_key = f"{kind}:{item_key}"
+        output[item_key] = item
     return output
 
 
 def changed_keys(previous: list[dict[str, Any]], current: list[dict[str, Any]], key: str = "id") -> list[str]:
     prev = indexed(previous, key)
     cur = indexed(current, key)
-    changed = sorted(set(cur) - set(prev))
+    changed = [f"added:{item_key}" for item_key in sorted(set(cur) - set(prev))]
+    changed.extend(f"removed:{item_key}" for item_key in sorted(set(prev) - set(cur)))
     for item_key in sorted(set(cur) & set(prev)):
         if cur[item_key] != prev[item_key]:
-            changed.append(item_key)
+            changed.append(f"modified:{item_key}")
     return changed
 
 
@@ -725,14 +840,19 @@ def compare_snapshots(previous: dict[str, Any] | None, current: dict[str, Any]) 
         }
 
     categories = {
-        "comments": changed_keys(previous.get("comments", []), current.get("comments", [])),
-        "reviews": changed_keys(previous.get("reviews", []), current.get("reviews", [])),
-        "checks": changed_keys(previous.get("checks", []), current.get("checks", []), "name"),
+        "comments": changed_keys(as_list(previous.get("comments")), as_list(current.get("comments"))),
+        "reviews": changed_keys(as_list(previous.get("reviews")), as_list(current.get("reviews"))),
+        "threads": changed_keys(as_list(previous.get("threads")), as_list(current.get("threads"))),
+        "checks": changed_keys(as_list(previous.get("checks")), as_list(current.get("checks")), "name"),
         "commits": sorted(
             set(str(item) for item in current.get("commits", []))
             - set(str(item) for item in previous.get("commits", []))
         ),
     }
+    if previous.get("schema_version") != current.get("schema_version"):
+        categories["schema_version"] = [
+            f"modified:{previous.get('schema_version')}->{current.get('schema_version')}"
+        ]
     changed = any(categories.values()) or previous.get("head_sha") != current.get("head_sha")
     if previous.get("head_sha") != current.get("head_sha"):
         categories["head_sha"] = [str(current.get("head_sha"))]
@@ -782,9 +902,9 @@ def classify_pr_state(
     previous_snapshot: dict[str, Any] | None = None,
     snapshot_requested: bool = False,
 ) -> dict[str, Any]:
-    pull = data.get("pull") or {}
+    pull = as_dict(data.get("pull"))
     pr_number = int(data.get("pr_number") or pull.get("number") or 0)
-    head_sha = (pull.get("head") or {}).get("sha") or ""
+    head_sha = dotted_get(pull, "head", "sha") or ""
     commits = data.get("commits") or []
     latest_head_commit_at = head_commit_time(commits, head_sha)
 
@@ -794,9 +914,9 @@ def classify_pr_state(
             "number": pr_number,
             "url": pull.get("html_url"),
             "title": pull.get("title"),
-            "base_ref": (pull.get("base") or {}).get("ref"),
-            "head_ref": (pull.get("head") or {}).get("ref"),
-            "base_sha": (pull.get("base") or {}).get("sha"),
+            "base_ref": dotted_get(pull, "base", "ref"),
+            "head_ref": dotted_get(pull, "head", "ref"),
+            "base_sha": dotted_get(pull, "base", "sha"),
             "head_sha": head_sha,
         },
         "stack": normalize_stack(data, pr_number),
@@ -839,8 +959,17 @@ def load_snapshot(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
     try:
-        if path.stat().st_mode & 0o022:
-            raise DataSourceError("snapshot", f"snapshot is group/other writable: {path}")
+        if path.is_symlink():
+            raise DataSourceError("snapshot", f"snapshot must not be a symlink: {path}")
+        stat_result = path.stat()
+        if stat_result.st_uid != os.geteuid():
+            raise DataSourceError("snapshot", f"snapshot is not owned by the current user: {path}")
+        if stat_result.st_mode & 0o077:
+            raise DataSourceError("snapshot", f"snapshot is group/other accessible: {path}")
+        parent_stat = path.parent.stat()
+        parent_is_sticky = bool(parent_stat.st_mode & 0o1000)
+        if parent_stat.st_mode & 0o022 and not parent_is_sticky:
+            raise DataSourceError("snapshot", f"snapshot directory is group/other writable: {path.parent}")
         with path.open("r", encoding="utf-8") as handle:
             snapshot = json.load(handle)
     except DataSourceError:
@@ -849,15 +978,34 @@ def load_snapshot(path: Path) -> dict[str, Any] | None:
         raise DataSourceError("snapshot", f"failed to read snapshot {path}: {exc}") from exc
     if not isinstance(snapshot, dict):
         raise DataSourceError("snapshot", "snapshot root was not an object")
+    schema_version = snapshot.get("schema_version")
+    if schema_version not in {1, SNAPSHOT_SCHEMA_VERSION}:
+        raise DataSourceError("snapshot", f"unsupported snapshot schema_version: {schema_version}")
+    for key in ("repo", "pr_number", "head_sha"):
+        if key not in snapshot:
+            raise DataSourceError("snapshot", f"snapshot missing required field: {key}")
+    for key in ("comments", "reviews", "threads", "checks", "commits", "ai_review_comments"):
+        if key in snapshot and not isinstance(snapshot[key], list):
+            raise DataSourceError("snapshot", f"snapshot field must be a list: {key}")
     return snapshot
 
 
 def write_snapshot(path: Path, snapshot: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as handle:
-        json.dump(snapshot, handle, indent=2, sort_keys=True)
-        handle.write("\n")
-    path.chmod(0o600)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o750)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent, text=True)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(snapshot, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_path, path)
+        path.chmod(0o600)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
 
 
 def compact_summary(result: dict[str, Any]) -> str:

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -128,6 +128,10 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertEqual(result["status"], "READY")
         self.assertTrue(result["ready"])
 
+    def test_compact_summary_reports_zero_unavailable_sources(self) -> None:
+        result = classify(load_fixture())
+        self.assertIn("errors: 0 source(s) unavailable", pr_convergence.compact_summary(result))
+
     def test_two_consecutive_clean_snapshots_are_ready(self) -> None:
         data = load_fixture()
         first = classify(data, snapshot_requested=True)

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -100,6 +100,9 @@ class PrConvergenceStatusTest(unittest.TestCase):
                 ["api", "graphql", "-f", "query=mutation { addComment(input: {}) { clientMutationId } }"]
             )
         )
+        self.assertFalse(
+            pr_convergence.gh_args_are_read_only(["api", "graphql", "-f", "query=@file.graphql"])
+        )
         self.assertFalse(pr_convergence.gh_args_are_read_only(["pr", "merge", "7"]))
         self.assertFalse(pr_convergence.gh_args_are_read_only(["pr", "comment", "7"]))
         self.assertFalse(pr_convergence.gh_args_are_read_only(["pr", "close", "7"]))

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -261,9 +261,10 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertEqual(raised.exception.source, "snapshot")
 
     def test_group_accessible_snapshot_is_refused(self) -> None:
+        data = classify(load_fixture())["snapshot"]
         with tempfile.TemporaryDirectory() as tmpdir:
             path = pathlib.Path(tmpdir) / "snapshot.json"
-            path.write_text("{}", encoding="utf-8")
+            path.write_text(json.dumps(data), encoding="utf-8")
             path.chmod(0o640)
             with self.assertRaises(pr_convergence.DataSourceError) as raised:
                 pr_convergence.load_snapshot(path)

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -7,9 +7,12 @@
 from __future__ import annotations
 
 import copy
+import ast
 import importlib.util
 import json
+import os
 import pathlib
+import subprocess
 import tempfile
 import unittest
 from unittest import mock
@@ -39,24 +42,34 @@ def classify(data: dict, previous: dict | None = None, snapshot_requested: bool 
 
 
 class PrConvergenceStatusTest(unittest.TestCase):
+    def asserted_status_values(self) -> set[str]:
+        source = pathlib.Path(__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        statuses: set[str] = set()
+
+        def is_status_lookup(node: ast.AST) -> bool:
+            return (
+                isinstance(node, ast.Subscript)
+                and isinstance(node.slice, ast.Constant)
+                and node.slice.value == "status"
+            )
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute) or node.func.attr != "assertEqual":
+                continue
+            if len(node.args) < 2:
+                continue
+            left, right = node.args[0], node.args[1]
+            if is_status_lookup(left) and isinstance(right, ast.Constant) and isinstance(right.value, str):
+                statuses.add(right.value)
+            if is_status_lookup(right) and isinstance(left, ast.Constant) and isinstance(left.value, str):
+                statuses.add(left.value)
+        return statuses
+
     def test_every_status_value_has_explicit_test_coverage(self) -> None:
-        covered = {
-            "BEHIND_BASE",
-            "CHANGED_DURING_WINDOW",
-            "CHECKS_FAILING",
-            "CHECKS_PENDING",
-            "CONFLICTED",
-            "DATA_SOURCE_UNAVAILABLE",
-            "MERGE_BLOCKED",
-            "READY",
-            "REVIEW_CHANGES_REQUESTED",
-            "SNAPSHOT_MISSING",
-            "STALE_CHECK",
-            "STALE_REVIEW",
-            "UNRESOLVED_THREADS",
-            "UNREVIEWED_AI_FINDINGS",
-        }
-        self.assertEqual(set(pr_convergence.STATUS_DOCS), covered)
+        self.assertEqual(set(pr_convergence.STATUS_DOCS), self.asserted_status_values())
 
     def test_gh_invocation_guard_rejects_mutating_api_calls(self) -> None:
         self.assertTrue(
@@ -66,6 +79,21 @@ class PrConvergenceStatusTest(unittest.TestCase):
         )
         self.assertFalse(
             pr_convergence.gh_args_are_read_only(["api", "repos/owner/repo/issues/1", "-X", "POST"])
+        )
+        self.assertFalse(
+            pr_convergence.gh_args_are_read_only(
+                ["api", "repos/owner/repo/issues/7/comments", "-f", "body=hi"]
+            )
+        )
+        self.assertFalse(
+            pr_convergence.gh_args_are_read_only(
+                ["api", "repos/owner/repo/issues/7/comments", "--input", "body.json"]
+            )
+        )
+        self.assertFalse(
+            pr_convergence.gh_args_are_read_only(
+                ["api", "repos/owner/repo/issues/7/comments", "--field=body=hi"]
+            )
         )
         self.assertFalse(
             pr_convergence.gh_args_are_read_only(
@@ -101,6 +129,18 @@ class PrConvergenceStatusTest(unittest.TestCase):
                 ["api", "repos/owner/repo/pulls/7", "--method=GET"]
             )
         )
+        self.assertTrue(
+            pr_convergence.gh_args_are_read_only(
+                [
+                    "api",
+                    "graphql",
+                    "-f",
+                    "query=query($owner: String!) { repository(owner: $owner, name: \"repo\") { id } }",
+                    "-F",
+                    "owner=owner",
+                ]
+            )
+        )
 
     def test_gh_client_api_constructs_plain_read_call(self) -> None:
         calls: list[list[str]] = []
@@ -123,10 +163,34 @@ class PrConvergenceStatusTest(unittest.TestCase):
                 )
         run.assert_not_called()
 
+    def test_gh_client_timeout_becomes_read_error(self) -> None:
+        with mock.patch.object(
+            pr_convergence.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["gh"], pr_convergence.GH_READ_TIMEOUT_SECONDS),
+        ):
+            with self.assertRaises(pr_convergence.GhReadError):
+                pr_convergence.GhClient("owner/repo").run(["api", "repos/owner/repo/pulls/7"])
+
+    def test_gh_client_uses_read_timeout(self) -> None:
+        completed = subprocess.CompletedProcess(["gh"], 0, "{}", "")
+        with mock.patch.object(pr_convergence.subprocess, "run", return_value=completed) as run:
+            pr_convergence.GhClient("owner/repo").run(["api", "repos/owner/repo/pulls/7"])
+
+        self.assertEqual(run.call_args.kwargs["timeout"], pr_convergence.GH_READ_TIMEOUT_SECONDS)
+
     def test_clean_state_without_snapshot_is_ready(self) -> None:
         result = classify(load_fixture())
         self.assertEqual(result["status"], "READY")
         self.assertTrue(result["ready"])
+
+    def test_no_checks_is_ready_when_other_sources_are_clean(self) -> None:
+        data = load_fixture()
+        data["check_runs"] = {"check_runs": []}
+        data["status"] = {"statuses": []}
+        result = classify(data)
+        self.assertEqual(result["status"], "READY")
+        self.assertEqual(result["required_checks"]["passing_count"], 0)
 
     def test_compact_summary_reports_zero_unavailable_sources(self) -> None:
         result = classify(load_fixture())
@@ -161,6 +225,32 @@ class PrConvergenceStatusTest(unittest.TestCase):
             pr_convergence.write_snapshot(path, classify(data)["snapshot"])
             self.assertEqual(path.stat().st_mode & 0o777, 0o600)
 
+    def test_snapshot_write_is_private_during_json_dump(self) -> None:
+        data = load_fixture()
+        observed_modes: list[int] = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = pathlib.Path(tmpdir) / "snapshot.json"
+            old_umask = os.umask(0)
+            real_dump = pr_convergence.json.dump
+
+            def record_mode(obj: object, handle: object, **kwargs: object) -> None:
+                temp_files = list(pathlib.Path(tmpdir).glob(f".{path.name}.*"))
+                self.assertEqual(len(temp_files), 1)
+                observed_modes.append(temp_files[0].stat().st_mode & 0o777)
+                real_dump(obj, handle, **kwargs)
+
+            try:
+                with mock.patch.object(pr_convergence.json, "dump", side_effect=record_mode):
+                    pr_convergence.write_snapshot(path, classify(data)["snapshot"])
+            finally:
+                os.umask(old_umask)
+
+        self.assertEqual(observed_modes, [0o600])
+
+    def test_snapshot_schema_version_is_current(self) -> None:
+        result = classify(load_fixture())
+        self.assertEqual(result["snapshot"]["schema_version"], pr_convergence.SNAPSHOT_SCHEMA_VERSION)
+
     def test_corrupt_snapshot_fails_closed_as_data_source_unavailable(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = pathlib.Path(tmpdir) / "snapshot.json"
@@ -170,11 +260,35 @@ class PrConvergenceStatusTest(unittest.TestCase):
 
         self.assertEqual(raised.exception.source, "snapshot")
 
-    def test_group_writable_snapshot_is_refused(self) -> None:
+    def test_group_accessible_snapshot_is_refused(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = pathlib.Path(tmpdir) / "snapshot.json"
             path.write_text("{}", encoding="utf-8")
-            path.chmod(0o660)
+            path.chmod(0o640)
+            with self.assertRaises(pr_convergence.DataSourceError) as raised:
+                pr_convergence.load_snapshot(path)
+
+        self.assertEqual(raised.exception.source, "snapshot")
+
+    def test_unsupported_snapshot_schema_is_refused(self) -> None:
+        data = classify(load_fixture())["snapshot"]
+        data["schema_version"] = 999
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = pathlib.Path(tmpdir) / "snapshot.json"
+            path.write_text(json.dumps(data), encoding="utf-8")
+            path.chmod(0o600)
+            with self.assertRaises(pr_convergence.DataSourceError) as raised:
+                pr_convergence.load_snapshot(path)
+
+        self.assertEqual(raised.exception.source, "snapshot")
+
+    def test_hand_edited_snapshot_collection_type_is_refused(self) -> None:
+        data = classify(load_fixture())["snapshot"]
+        data["comments"] = "not a list"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = pathlib.Path(tmpdir) / "snapshot.json"
+            path.write_text(json.dumps(data), encoding="utf-8")
+            path.chmod(0o600)
             with self.assertRaises(pr_convergence.DataSourceError) as raised:
                 pr_convergence.load_snapshot(path)
 
@@ -186,6 +300,15 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertEqual(result["top_level_comments"]["ai_review_count"], 1)
         self.assertEqual(result["top_level_comments"]["unreviewed_ai_finding_count"], 1)
 
+    def test_ai_review_mid_body_heading_is_explicitly_blocking(self) -> None:
+        data = load_fixture("pr_convergence_ai_review.json")
+        data["issue_comments"][0]["body"] = (
+            "Review summary\n\n## AI Review\n\n1. medium: scripts/example.py - fix this finding."
+        )
+        result = classify(data)
+        self.assertEqual(result["status"], "UNREVIEWED_AI_FINDINGS")
+        self.assertEqual(result["top_level_comments"]["ai_review_count"], 1)
+
     def test_clean_ai_review_comment_does_not_block(self) -> None:
         data = load_fixture("pr_convergence_ai_review.json")
         data["issue_comments"][0]["body"] = (
@@ -195,6 +318,18 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertEqual(result["status"], "READY")
         self.assertEqual(result["top_level_comments"]["ai_review_count"], 1)
         self.assertEqual(result["top_level_comments"]["unreviewed_ai_finding_count"], 0)
+
+    def test_ai_review_actionable_count_overrides_clean_marker(self) -> None:
+        data = load_fixture("pr_convergence_ai_review.json")
+        data["issue_comments"][0]["body"] = (
+            "## AI Review\n\n"
+            "Actionable comments posted: 1\n\n"
+            "Test coverage is adequate.\n\n"
+            "1. high: scripts/example.py - fix this finding."
+        )
+        result = classify(data)
+        self.assertEqual(result["status"], "UNREVIEWED_AI_FINDINGS")
+        self.assertEqual(result["top_level_comments"]["unreviewed_ai_finding_count"], 1)
 
     def test_multiple_review_bodies_sum_actionable_counts(self) -> None:
         data = load_fixture()
@@ -254,6 +389,32 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertEqual(result["status"], "UNRESOLVED_THREADS")
         self.assertEqual(result["review_threads"]["outside_diff_or_null_line_count"], 1)
 
+    def test_multiple_unresolved_threads_block(self) -> None:
+        data = load_fixture()
+        data["review_threads"] = [
+            {
+                "comments": {"nodes": []},
+                "id": "thread-1",
+                "isOutdated": False,
+                "isResolved": False,
+                "line": 12,
+                "originalLine": 12,
+                "path": "scripts/example.py",
+            },
+            {
+                "comments": {"nodes": []},
+                "id": "thread-2",
+                "isOutdated": False,
+                "isResolved": False,
+                "line": 20,
+                "originalLine": 20,
+                "path": "scripts/example.py",
+            },
+        ]
+        result = classify(data)
+        self.assertEqual(result["status"], "UNRESOLVED_THREADS")
+        self.assertEqual(result["review_threads"]["unresolved_count"], 2)
+
     def test_rest_inline_null_line_is_reported(self) -> None:
         data = load_fixture()
         data["review_comments"] = [
@@ -305,6 +466,14 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertEqual(result["required_checks"]["passing_count"], 1)
         self.assertEqual(result["required_checks"]["stale_count"], 1)
 
+    def test_null_check_suite_app_does_not_crash(self) -> None:
+        data = load_fixture()
+        data["check_runs"]["check_runs"][0].pop("name")
+        data["check_runs"]["check_runs"][0]["check_suite"] = None
+        result = classify(data)
+        self.assertEqual(result["status"], "READY")
+        self.assertEqual(result["required_checks"]["passing_count"], 2)
+
     def test_behind_base_blocks(self) -> None:
         data = load_fixture()
         data["compare"]["behind_by"] = 2
@@ -326,12 +495,50 @@ class PrConvergenceStatusTest(unittest.TestCase):
         result = classify(data)
         self.assertEqual(result["status"], "MERGE_BLOCKED")
 
+    def test_draft_closed_and_merged_prs_block(self) -> None:
+        for state_patch in (
+            {"draft": True},
+            {"state": "closed"},
+            {"state": "closed", "merged": True},
+        ):
+            with self.subTest(state_patch=state_patch):
+                data = load_fixture()
+                data["pull"].update(state_patch)
+                result = classify(data)
+                self.assertEqual(result["status"], "MERGE_BLOCKED")
+
     def test_data_source_error_fails_closed(self) -> None:
         data = load_fixture()
         data["errors"] = [{"source": "review_threads", "message": "rate limited"}]
         result = classify(data)
         self.assertEqual(result["status"], "DATA_SOURCE_UNAVAILABLE")
         self.assertFalse(result["ready"])
+
+    def test_pull_read_error_fails_closed_for_missing_or_unauthenticated_pr(self) -> None:
+        class FailingGhClient:
+            def __init__(self, repo: str) -> None:
+                self.repo = repo
+                self.owner, self.name = pr_convergence.parse_repo(repo)
+
+            def api(self, path: str, *, paginate: bool = False, accept: str | None = None) -> object:
+                del path, paginate, accept
+                raise pr_convergence.GhReadError("not found or unauthenticated")
+
+            def graphql_review_threads(self, pr_number: int) -> list[dict[str, object]]:
+                del pr_number
+                raise pr_convergence.GhReadError("not found or unauthenticated")
+
+        with mock.patch.object(pr_convergence, "GhClient", FailingGhClient):
+            result = classify(pr_convergence.gather_pr_state("owner/repo", 7))
+
+        self.assertEqual(result["status"], "DATA_SOURCE_UNAVAILABLE")
+        self.assertFalse(result["ready"])
+
+    def test_graphql_null_data_becomes_gh_read_error(self) -> None:
+        client = pr_convergence.GhClient("owner/repo")
+        with mock.patch.object(client, "run", return_value={"data": None}):
+            with self.assertRaises(pr_convergence.GhReadError):
+                client.graphql_review_threads(7)
 
     def test_new_comment_since_snapshot_reports_changed_window(self) -> None:
         data = load_fixture()
@@ -348,7 +555,10 @@ class PrConvergenceStatusTest(unittest.TestCase):
         )
         result = classify(data, previous=previous, snapshot_requested=True)
         self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
-        self.assertEqual(result["change_detection"]["categories"]["comments"], ["23"])
+        self.assertEqual(
+            result["change_detection"]["categories"]["comments"],
+            ["added:issue_comment:23"],
+        )
 
     def test_new_inline_comment_since_snapshot_reports_changed_window(self) -> None:
         data = load_fixture()
@@ -367,7 +577,64 @@ class PrConvergenceStatusTest(unittest.TestCase):
         )
         result = classify(data, previous=previous, snapshot_requested=True)
         self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
-        self.assertEqual(result["change_detection"]["categories"]["comments"], ["33"])
+        self.assertEqual(
+            result["change_detection"]["categories"]["comments"],
+            ["added:review_comment:33"],
+        )
+
+    def test_removed_comment_since_snapshot_reports_changed_window(self) -> None:
+        data = load_fixture()
+        data["issue_comments"].append(
+            {
+                "body": "Please check this case.",
+                "created_at": "2026-01-01T10:20:00Z",
+                "html_url": "https://github.com/owner/repo/pull/7#issuecomment-23",
+                "id": 23,
+                "updated_at": "2026-01-01T10:20:00Z",
+                "user": {"login": "reviewer-a"},
+            }
+        )
+        previous = classify(data)["snapshot"]
+        data["issue_comments"] = []
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(
+            result["change_detection"]["categories"]["comments"],
+            ["removed:issue_comment:23"],
+        )
+
+    def test_issue_and_review_comment_id_collision_reports_changed_window(self) -> None:
+        data = load_fixture()
+        data["issue_comments"] = [
+            {
+                "body": "Please check this case.",
+                "created_at": "2026-01-01T10:20:00Z",
+                "html_url": "https://github.com/owner/repo/pull/7#issuecomment-33",
+                "id": 33,
+                "updated_at": "2026-01-01T10:20:00Z",
+                "user": {"login": "reviewer-a"},
+            }
+        ]
+        previous = classify(data)["snapshot"]
+        data["issue_comments"] = []
+        data["review_comments"] = [
+            {
+                "html_url": "https://github.com/owner/repo/pull/7#discussion_r33",
+                "id": 33,
+                "line": 12,
+                "original_line": 12,
+                "path": "scripts/example.py",
+                "position": 4,
+                "updated_at": "2026-01-01T10:20:00Z",
+                "user": {"login": "reviewer-a"},
+            }
+        ]
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(
+            result["change_detection"]["categories"]["comments"],
+            ["added:review_comment:33", "removed:issue_comment:33"],
+        )
 
     def test_new_review_since_snapshot_reports_changed_window(self) -> None:
         data = load_fixture()
@@ -385,7 +652,7 @@ class PrConvergenceStatusTest(unittest.TestCase):
         )
         result = classify(data, previous=previous, snapshot_requested=True)
         self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
-        self.assertEqual(result["change_detection"]["categories"]["reviews"], ["4"])
+        self.assertEqual(result["change_detection"]["categories"]["reviews"], ["added:4"])
 
     def test_new_commit_since_snapshot_reports_changed_window(self) -> None:
         data = load_fixture()
@@ -409,14 +676,101 @@ class PrConvergenceStatusTest(unittest.TestCase):
         data["check_runs"]["check_runs"][0]["conclusion"] = "failure"
         result = classify(data, previous=previous, snapshot_requested=True)
         self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
-        self.assertEqual(result["change_detection"]["categories"]["checks"], ["unit"])
+        self.assertEqual(result["change_detection"]["categories"]["checks"], ["modified:unit"])
+
+    def test_new_thread_since_snapshot_reports_changed_window(self) -> None:
+        data = load_fixture()
+        previous = classify(data)["snapshot"]
+        data["review_threads"] = [
+            {
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-01-01T10:20:00Z",
+                            "id": "comment-1",
+                            "updatedAt": "2026-01-01T10:20:00Z",
+                        }
+                    ]
+                },
+                "id": "thread-1",
+                "isOutdated": False,
+                "isResolved": True,
+                "line": 12,
+                "originalLine": 12,
+                "path": "scripts/example.py",
+            }
+        ]
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(
+            result["change_detection"]["categories"]["threads"],
+            ["added:review_thread:thread-1"],
+        )
+
+    def test_removed_thread_since_snapshot_reports_changed_window(self) -> None:
+        data = load_fixture()
+        data["review_threads"] = [
+            {
+                "comments": {"nodes": []},
+                "id": "thread-1",
+                "isOutdated": False,
+                "isResolved": True,
+                "line": 12,
+                "originalLine": 12,
+                "path": "scripts/example.py",
+            }
+        ]
+        previous = classify(data)["snapshot"]
+        data["review_threads"] = []
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(
+            result["change_detection"]["categories"]["threads"],
+            ["removed:review_thread:thread-1"],
+        )
+
+    def test_thread_reply_since_snapshot_reports_changed_window(self) -> None:
+        data = load_fixture()
+        data["review_threads"] = [
+            {
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-01-01T10:20:00Z",
+                            "id": "comment-1",
+                            "updatedAt": "2026-01-01T10:20:00Z",
+                        }
+                    ]
+                },
+                "id": "thread-1",
+                "isOutdated": False,
+                "isResolved": True,
+                "line": 12,
+                "originalLine": 12,
+                "path": "scripts/example.py",
+            }
+        ]
+        previous = classify(data)["snapshot"]
+        data["review_threads"][0]["comments"]["nodes"].append(
+            {
+                "createdAt": "2026-01-01T10:21:00Z",
+                "id": "comment-2",
+                "updatedAt": "2026-01-01T10:21:00Z",
+            }
+        )
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(
+            result["change_detection"]["categories"]["threads"],
+            ["modified:review_thread:thread-1"],
+        )
 
     def test_stacked_pr_base_is_distinct_from_main_base(self) -> None:
         data = load_fixture()
         data["pull"]["base"]["ref"] = "feature-base"
         data["base_pull_candidates"] = [
             {
-                "head": {"ref": "feature-base"},
+                "head": {"ref": "feature-base", "repo": {"full_name": "contributor/repo"}},
                 "html_url": "https://github.com/owner/repo/pull/6",
                 "number": 6,
                 "state": "open",
@@ -427,6 +781,58 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertEqual(result["status"], "READY")
         self.assertTrue(result["stack"]["base_is_open_pr"])
         self.assertEqual(result["stack"]["base_pr"]["number"], 6)
+        self.assertEqual(result["stack"]["base_pr"]["head_repo"], "contributor/repo")
+
+    def test_default_branch_base_is_not_treated_as_stacked_pr(self) -> None:
+        data = load_fixture()
+        data["pull"]["base"]["repo"]["default_branch"] = "main"
+        data["base_pull_candidates"] = [
+            {
+                "head": {"ref": "main", "repo": {"full_name": "contributor/repo"}},
+                "html_url": "https://github.com/owner/repo/pull/6",
+                "number": 6,
+                "state": "open",
+                "title": "Unrelated PR from a branch named main",
+            }
+        ]
+        result = classify(data)
+        self.assertEqual(result["status"], "READY")
+        self.assertFalse(result["stack"]["base_is_open_pr"])
+
+    def test_base_pull_candidate_read_does_not_filter_to_repo_owner(self) -> None:
+        fixture = load_fixture()
+        fixture["pull"]["base"]["ref"] = "feature-base"
+        calls: list[str] = []
+
+        class RecordingGhClient:
+            def __init__(self, repo: str) -> None:
+                self.repo = repo
+                self.owner, self.name = pr_convergence.parse_repo(repo)
+
+            def api(self, path: str, *, paginate: bool = False, accept: str | None = None) -> object:
+                del paginate, accept
+                calls.append(path)
+                if path == "repos/owner/repo/pulls/7":
+                    return fixture["pull"]
+                if path.endswith("/check-runs?per_page=100"):
+                    return {"check_runs": []}
+                if path.endswith("/status"):
+                    return {"statuses": []}
+                if path.endswith("/compare/base111...head222"):
+                    return {"behind_by": 0, "ahead_by": 1, "status": "ahead"}
+                if path == "repos/owner/repo/pulls?state=open&per_page=100":
+                    return []
+                return []
+
+            def graphql_review_threads(self, pr_number: int) -> list[dict[str, object]]:
+                del pr_number
+                return []
+
+        with mock.patch.object(pr_convergence, "GhClient", RecordingGhClient):
+            pr_convergence.gather_pr_state("owner/repo", 7)
+
+        self.assertIn("repos/owner/repo/pulls?state=open&per_page=100", calls)
+        self.assertNotIn("repos/owner/repo/pulls?state=open&head=owner:feature-base&per_page=100", calls)
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -141,6 +141,8 @@ class PrConvergenceStatusTest(unittest.TestCase):
                     "query=query($owner: String!) { repository(owner: $owner, name: \"repo\") { id } }",
                     "-F",
                     "owner=owner",
+                    "-F",
+                    "headRefName=feature-base",
                 ]
             )
         )
@@ -825,10 +827,11 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertEqual(result["status"], "READY")
         self.assertFalse(result["stack"]["base_is_open_pr"])
 
-    def test_base_pull_candidate_read_does_not_filter_to_repo_owner(self) -> None:
+    def test_base_pull_candidate_read_uses_head_ref_graphql_without_owner_filter(self) -> None:
         fixture = load_fixture()
         fixture["pull"]["base"]["ref"] = "feature-base"
         calls: list[str] = []
+        head_ref_reads: list[str] = []
 
         class RecordingGhClient:
             def __init__(self, repo: str) -> None:
@@ -846,19 +849,70 @@ class PrConvergenceStatusTest(unittest.TestCase):
                     return {"statuses": []}
                 if path.endswith("/compare/base111...head222"):
                     return {"behind_by": 0, "ahead_by": 1, "status": "ahead"}
-                if path == "repos/owner/repo/pulls?state=open&per_page=100":
-                    return []
                 return []
 
             def graphql_review_threads(self, pr_number: int) -> list[dict[str, object]]:
                 del pr_number
                 return []
 
-        with mock.patch.object(pr_convergence, "GhClient", RecordingGhClient):
-            pr_convergence.gather_pr_state("owner/repo", 7)
+            def graphql_open_pulls_by_head_ref(self, head_ref_name: str) -> list[dict[str, object]]:
+                head_ref_reads.append(head_ref_name)
+                return [
+                    {
+                        "head": {"ref": head_ref_name, "repo": {"full_name": "contributor/repo"}},
+                        "html_url": "https://github.com/owner/repo/pull/6",
+                        "number": 6,
+                        "state": "open",
+                        "title": "Base PR",
+                    }
+                ]
 
-        self.assertIn("repos/owner/repo/pulls?state=open&per_page=100", calls)
+        with mock.patch.object(pr_convergence, "GhClient", RecordingGhClient):
+            data = pr_convergence.gather_pr_state("owner/repo", 7)
+
+        self.assertEqual(head_ref_reads, ["feature-base"])
+        self.assertEqual(data["base_pull_candidates"][0]["head"]["repo"]["full_name"], "contributor/repo")
+        self.assertNotIn("repos/owner/repo/pulls?state=open&per_page=100", calls)
         self.assertNotIn("repos/owner/repo/pulls?state=open&head=owner:feature-base&per_page=100", calls)
+
+    def test_default_branch_base_skips_base_pull_candidate_read(self) -> None:
+        fixture = load_fixture()
+        fixture["pull"]["base"]["repo"]["default_branch"] = "main"
+        calls: list[str] = []
+        head_ref_reads: list[str] = []
+
+        class RecordingGhClient:
+            def __init__(self, repo: str) -> None:
+                self.repo = repo
+                self.owner, self.name = pr_convergence.parse_repo(repo)
+
+            def api(self, path: str, *, paginate: bool = False, accept: str | None = None) -> object:
+                del paginate, accept
+                calls.append(path)
+                if path == "repos/owner/repo/pulls/7":
+                    return fixture["pull"]
+                if path.endswith("/check-runs?per_page=100"):
+                    return {"check_runs": []}
+                if path.endswith("/status"):
+                    return {"statuses": []}
+                if path.endswith("/compare/base111...head222"):
+                    return {"behind_by": 0, "ahead_by": 1, "status": "ahead"}
+                return []
+
+            def graphql_review_threads(self, pr_number: int) -> list[dict[str, object]]:
+                del pr_number
+                return []
+
+            def graphql_open_pulls_by_head_ref(self, head_ref_name: str) -> list[dict[str, object]]:
+                head_ref_reads.append(head_ref_name)
+                return []
+
+        with mock.patch.object(pr_convergence, "GhClient", RecordingGhClient):
+            data = pr_convergence.gather_pr_state("owner/repo", 7)
+
+        self.assertEqual(data["base_pull_candidates"], [])
+        self.assertEqual(head_ref_reads, [])
+        self.assertNotIn("repos/owner/repo/pulls?state=open&per_page=100", calls)
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for scripts/pr-convergence.py."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("pr-convergence.py")
+SPEC = importlib.util.spec_from_file_location("pr_convergence", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load {SCRIPT_PATH}")
+pr_convergence = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(pr_convergence)
+
+TESTDATA = pathlib.Path(__file__).with_name("testdata")
+
+
+def load_fixture(name: str = "pr_convergence_clean.json") -> dict:
+    with (TESTDATA / name).open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def classify(data: dict, previous: dict | None = None, snapshot_requested: bool = False) -> dict:
+    return pr_convergence.classify_pr_state(
+        copy.deepcopy(data),
+        previous_snapshot=copy.deepcopy(previous),
+        snapshot_requested=snapshot_requested,
+    )
+
+
+class PrConvergenceStatusTest(unittest.TestCase):
+    def test_every_status_value_has_explicit_test_coverage(self) -> None:
+        covered = {
+            "BEHIND_BASE",
+            "CHANGED_DURING_WINDOW",
+            "CHECKS_FAILING",
+            "CHECKS_PENDING",
+            "CONFLICTED",
+            "DATA_SOURCE_UNAVAILABLE",
+            "MERGE_BLOCKED",
+            "READY",
+            "REVIEW_CHANGES_REQUESTED",
+            "SNAPSHOT_MISSING",
+            "STALE_CHECK",
+            "STALE_REVIEW",
+            "UNRESOLVED_THREADS",
+            "UNREVIEWED_AI_FINDINGS",
+        }
+        self.assertEqual(set(pr_convergence.STATUS_DOCS), covered)
+
+    def test_gh_invocation_guard_rejects_mutating_api_calls(self) -> None:
+        self.assertTrue(
+            pr_convergence.gh_args_are_read_only(
+                ["api", "graphql", "-f", "query=query { viewer { login } }"]
+            )
+        )
+        self.assertFalse(
+            pr_convergence.gh_args_are_read_only(["api", "repos/owner/repo/issues/1", "-X", "POST"])
+        )
+        self.assertFalse(
+            pr_convergence.gh_args_are_read_only(
+                ["api", "graphql", "-f", "query=mutation { addComment(input: {}) { clientMutationId } }"]
+            )
+        )
+
+    def test_clean_state_without_snapshot_is_ready(self) -> None:
+        result = classify(load_fixture())
+        self.assertEqual(result["status"], "READY")
+        self.assertTrue(result["ready"])
+
+    def test_two_consecutive_clean_snapshots_are_ready(self) -> None:
+        data = load_fixture()
+        first = classify(data, snapshot_requested=True)
+        self.assertEqual(first["status"], "SNAPSHOT_MISSING")
+
+        second = classify(data, previous=first["snapshot"], snapshot_requested=True)
+        self.assertEqual(second["status"], "READY")
+        self.assertFalse(second["change_detection"]["changed"])
+
+    def test_snapshot_path_round_trips_ready_after_second_clean_run(self) -> None:
+        data = load_fixture()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = pathlib.Path(tmpdir) / "snapshot.json"
+            first = classify(data, snapshot_requested=True)
+            pr_convergence.write_snapshot(path, first["snapshot"])
+
+            previous = pr_convergence.load_snapshot(path)
+            second = classify(data, previous=previous, snapshot_requested=True)
+            pr_convergence.write_snapshot(path, second["snapshot"])
+
+        self.assertEqual(second["status"], "READY")
+
+    def test_ai_review_top_level_comment_is_explicitly_blocking(self) -> None:
+        result = classify(load_fixture("pr_convergence_ai_review.json"))
+        self.assertEqual(result["status"], "UNREVIEWED_AI_FINDINGS")
+        self.assertEqual(result["top_level_comments"]["ai_review_count"], 1)
+        self.assertEqual(result["top_level_comments"]["unreviewed_ai_finding_count"], 1)
+
+    def test_clean_ai_review_comment_does_not_block(self) -> None:
+        data = load_fixture("pr_convergence_ai_review.json")
+        data["issue_comments"][0]["body"] = (
+            "## AI Review\n\nNo material security or correctness issues found in this diff."
+        )
+        result = classify(data)
+        self.assertEqual(result["status"], "READY")
+        self.assertEqual(result["top_level_comments"]["ai_review_count"], 1)
+        self.assertEqual(result["top_level_comments"]["unreviewed_ai_finding_count"], 0)
+
+    def test_multiple_review_bodies_sum_actionable_counts(self) -> None:
+        data = load_fixture()
+        data["reviews"].append(
+            {
+                "body": "Actionable comments posted: 2\nActionable comments posted: 3",
+                "commit_id": "head222",
+                "html_url": "https://github.com/owner/repo/pull/7#pullrequestreview-2",
+                "id": 2,
+                "state": "COMMENTED",
+                "submitted_at": "2026-01-01T10:06:00Z",
+                "user": {"login": "reviewer-b"},
+            }
+        )
+        data["reviews"].append(
+            {
+                "body": "Actionable comments posted: 4",
+                "commit_id": "head222",
+                "html_url": "https://github.com/owner/repo/pull/7#pullrequestreview-3",
+                "id": 3,
+                "state": "COMMENTED",
+                "submitted_at": "2026-01-01T10:07:00Z",
+                "user": {"login": "reviewer-c"},
+            }
+        )
+        result = classify(data)
+        self.assertEqual(result["status"], "READY")
+        self.assertEqual(result["review_summaries"]["actionable_comments_total"], 9)
+
+    def test_outside_diff_null_line_unresolved_thread_blocks(self) -> None:
+        data = load_fixture()
+        data["review_threads"] = [
+            {
+                "comments": {
+                    "nodes": [
+                        {
+                            "author": {"login": "reviewer-a"},
+                            "createdAt": "2026-01-01T10:10:00Z",
+                            "id": "comment-1",
+                            "line": None,
+                            "originalLine": None,
+                            "path": "scripts/example.py",
+                            "updatedAt": "2026-01-01T10:10:00Z",
+                            "url": "https://github.com/owner/repo/pull/7#discussion_r1",
+                        }
+                    ]
+                },
+                "id": "thread-1",
+                "isOutdated": False,
+                "isResolved": False,
+                "line": None,
+                "originalLine": None,
+                "path": "scripts/example.py",
+            }
+        ]
+        result = classify(data)
+        self.assertEqual(result["status"], "UNRESOLVED_THREADS")
+        self.assertEqual(result["review_threads"]["outside_diff_or_null_line_count"], 1)
+
+    def test_rest_inline_null_line_is_reported(self) -> None:
+        data = load_fixture()
+        data["review_comments"] = [
+            {
+                "html_url": "https://github.com/owner/repo/pull/7#discussion_r2",
+                "id": 10,
+                "line": None,
+                "original_line": None,
+                "path": "scripts/example.py",
+                "position": None,
+                "user": {"login": "reviewer-a"},
+            }
+        ]
+        result = classify(data)
+        self.assertEqual(result["status"], "READY")
+        self.assertEqual(result["inline_comments"]["outside_diff_or_null_line_count"], 1)
+
+    def test_stale_review_against_older_head_blocks(self) -> None:
+        data = load_fixture()
+        data["reviews"][0]["commit_id"] = "old111"
+        result = classify(data)
+        self.assertEqual(result["status"], "STALE_REVIEW")
+        self.assertEqual(result["review_summaries"]["stale_count"], 1)
+
+    def test_current_head_changes_requested_blocks(self) -> None:
+        data = load_fixture()
+        data["reviews"][0]["state"] = "CHANGES_REQUESTED"
+        result = classify(data)
+        self.assertEqual(result["status"], "REVIEW_CHANGES_REQUESTED")
+
+    def test_pending_check_blocks(self) -> None:
+        data = load_fixture()
+        data["check_runs"]["check_runs"][0]["status"] = "in_progress"
+        data["check_runs"]["check_runs"][0]["conclusion"] = None
+        result = classify(data)
+        self.assertEqual(result["status"], "CHECKS_PENDING")
+
+    def test_failing_check_blocks(self) -> None:
+        data = load_fixture()
+        data["check_runs"]["check_runs"][0]["conclusion"] = "failure"
+        result = classify(data)
+        self.assertEqual(result["status"], "CHECKS_FAILING")
+
+    def test_stale_check_is_not_counted_as_current_head_check(self) -> None:
+        data = load_fixture()
+        data["check_runs"]["check_runs"][0]["head_sha"] = "old111"
+        result = classify(data)
+        self.assertEqual(result["status"], "STALE_CHECK")
+        self.assertEqual(result["required_checks"]["passing_count"], 1)
+        self.assertEqual(result["required_checks"]["stale_count"], 1)
+
+    def test_behind_base_blocks(self) -> None:
+        data = load_fixture()
+        data["compare"]["behind_by"] = 2
+        data["compare"]["status"] = "diverged"
+        result = classify(data)
+        self.assertEqual(result["status"], "BEHIND_BASE")
+        self.assertTrue(result["stack"]["head_behind_base"])
+
+    def test_conflicted_blocks(self) -> None:
+        data = load_fixture()
+        data["pull"]["mergeable"] = False
+        data["pull"]["mergeable_state"] = "dirty"
+        result = classify(data)
+        self.assertEqual(result["status"], "CONFLICTED")
+
+    def test_merge_blocked_blocks(self) -> None:
+        data = load_fixture()
+        data["pull"]["mergeable_state"] = "blocked"
+        result = classify(data)
+        self.assertEqual(result["status"], "MERGE_BLOCKED")
+
+    def test_data_source_error_fails_closed(self) -> None:
+        data = load_fixture()
+        data["errors"] = [{"source": "review_threads", "message": "rate limited"}]
+        result = classify(data)
+        self.assertEqual(result["status"], "DATA_SOURCE_UNAVAILABLE")
+        self.assertFalse(result["ready"])
+
+    def test_new_comment_since_snapshot_reports_changed_window(self) -> None:
+        data = load_fixture()
+        previous = classify(data)["snapshot"]
+        data["issue_comments"].append(
+            {
+                "body": "Please check this case.",
+                "created_at": "2026-01-01T10:20:00Z",
+                "html_url": "https://github.com/owner/repo/pull/7#issuecomment-23",
+                "id": 23,
+                "updated_at": "2026-01-01T10:20:00Z",
+                "user": {"login": "reviewer-a"},
+            }
+        )
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(result["change_detection"]["categories"]["comments"], ["23"])
+
+    def test_new_inline_comment_since_snapshot_reports_changed_window(self) -> None:
+        data = load_fixture()
+        previous = classify(data)["snapshot"]
+        data["review_comments"].append(
+            {
+                "html_url": "https://github.com/owner/repo/pull/7#discussion_r3",
+                "id": 33,
+                "line": 12,
+                "original_line": 12,
+                "path": "scripts/example.py",
+                "position": 4,
+                "updated_at": "2026-01-01T10:21:00Z",
+                "user": {"login": "reviewer-a"},
+            }
+        )
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(result["change_detection"]["categories"]["comments"], ["33"])
+
+    def test_new_review_since_snapshot_reports_changed_window(self) -> None:
+        data = load_fixture()
+        previous = classify(data)["snapshot"]
+        data["reviews"].append(
+            {
+                "body": "Looks good.",
+                "commit_id": "head222",
+                "html_url": "https://github.com/owner/repo/pull/7#pullrequestreview-4",
+                "id": 4,
+                "state": "APPROVED",
+                "submitted_at": "2026-01-01T10:20:00Z",
+                "user": {"login": "reviewer-d"},
+            }
+        )
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(result["change_detection"]["categories"]["reviews"], ["4"])
+
+    def test_new_commit_since_snapshot_reports_changed_window(self) -> None:
+        data = load_fixture()
+        previous = classify(data)["snapshot"]
+        data["pull"]["head"]["sha"] = "head333"
+        data["check_runs"]["check_runs"][0]["head_sha"] = "head333"
+        data["status"]["statuses"][0]["sha"] = "head333"
+        data["commits"].append(
+            {
+                "commit": {"committer": {"date": "2026-01-01T10:30:00Z"}},
+                "sha": "head333",
+            }
+        )
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(result["change_detection"]["categories"]["commits"], ["head333"])
+
+    def test_check_change_since_snapshot_reports_changed_window(self) -> None:
+        data = load_fixture()
+        previous = classify(data)["snapshot"]
+        data["check_runs"]["check_runs"][0]["conclusion"] = "failure"
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(result["change_detection"]["categories"]["checks"], ["unit"])
+
+    def test_stacked_pr_base_is_distinct_from_main_base(self) -> None:
+        data = load_fixture()
+        data["pull"]["base"]["ref"] = "feature-base"
+        data["base_pull_candidates"] = [
+            {
+                "head": {"ref": "feature-base"},
+                "html_url": "https://github.com/owner/repo/pull/6",
+                "number": 6,
+                "state": "open",
+                "title": "Base PR",
+            }
+        ]
+        result = classify(data)
+        self.assertEqual(result["status"], "READY")
+        self.assertTrue(result["stack"]["base_is_open_pr"])
+        self.assertEqual(result["stack"]["base_pr"]["number"], 6)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -41,6 +41,41 @@ def classify(data: dict, previous: dict | None = None, snapshot_requested: bool 
     )
 
 
+def recording_base_candidate_client(
+    fixture: dict[str, object],
+    candidates: list[dict[str, object]],
+    calls: list[str],
+    head_ref_reads: list[str],
+) -> type:
+    class RecordingGhClient:
+        def __init__(self, repo: str) -> None:
+            self.repo = repo
+            self.owner, self.name = pr_convergence.parse_repo(repo)
+
+        def api(self, path: str, *, paginate: bool = False, accept: str | None = None) -> object:
+            del paginate, accept
+            calls.append(path)
+            if path == "repos/owner/repo/pulls/7":
+                return fixture["pull"]
+            if path.endswith("/check-runs?per_page=100"):
+                return {"check_runs": []}
+            if path.endswith("/status"):
+                return {"statuses": []}
+            if path.endswith("/compare/base111...head222"):
+                return {"behind_by": 0, "ahead_by": 1, "status": "ahead"}
+            return []
+
+        def graphql_review_threads(self, pr_number: int) -> list[dict[str, object]]:
+            del pr_number
+            return []
+
+        def graphql_open_pulls_by_head_ref(self, head_ref_name: str) -> list[dict[str, object]]:
+            head_ref_reads.append(head_ref_name)
+            return candidates
+
+    return RecordingGhClient
+
+
 class PrConvergenceStatusTest(unittest.TestCase):
     def asserted_status_values(self) -> set[str]:
         source = pathlib.Path(__file__).read_text(encoding="utf-8")
@@ -546,6 +581,119 @@ class PrConvergenceStatusTest(unittest.TestCase):
             with self.assertRaises(pr_convergence.GhReadError):
                 client.graphql_review_threads(7)
 
+    def test_graphql_open_pulls_paginates_and_maps_nodes(self) -> None:
+        client = pr_convergence.GhClient("owner/repo")
+        pages = [
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "nodes": [
+                                {
+                                    "number": 6,
+                                    "state": "OPEN",
+                                    "title": "Base PR",
+                                    "url": "https://github.com/owner/repo/pull/6",
+                                    "headRefName": "feature-base",
+                                    "headRepository": {"nameWithOwner": "contributor/repo"},
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                        }
+                    }
+                }
+            },
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "nodes": [
+                                {
+                                    "number": 8,
+                                    "state": "OPEN",
+                                    "title": "Other Base PR",
+                                    "url": "https://github.com/owner/repo/pull/8",
+                                    "headRefName": "feature-base",
+                                    "headRepository": {"nameWithOwner": "fork/repo"},
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False},
+                        }
+                    }
+                }
+            },
+        ]
+
+        with mock.patch.object(client, "run", side_effect=pages) as run:
+            pulls = client.graphql_open_pulls_by_head_ref("feature-base")
+
+        self.assertEqual([pull["number"] for pull in pulls], [6, 8])
+        self.assertEqual(pulls[0]["state"], "open")
+        self.assertEqual(pulls[1]["head"]["repo"]["full_name"], "fork/repo")
+        first_args = run.call_args_list[0].args[0]
+        second_args = run.call_args_list[1].args[0]
+        self.assertEqual(first_args[first_args.index("headRefName=feature-base") - 1], "-f")
+        self.assertEqual(second_args[second_args.index("after=cursor-1") - 1], "-f")
+
+    def test_graphql_open_pulls_rejects_non_list_nodes(self) -> None:
+        client = pr_convergence.GhClient("owner/repo")
+        response = {
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "nodes": {"number": 6},
+                        "pageInfo": {"hasNextPage": False},
+                    }
+                }
+            }
+        }
+
+        with mock.patch.object(client, "run", return_value=response), self.assertRaises(
+            pr_convergence.GhReadError
+        ):
+            client.graphql_open_pulls_by_head_ref("feature-base")
+
+    def test_graphql_open_pulls_rejects_repeated_cursor(self) -> None:
+        client = pr_convergence.GhClient("owner/repo")
+        response = {
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                    }
+                }
+            }
+        }
+
+        with mock.patch.object(client, "run", return_value=response), self.assertRaises(
+            pr_convergence.GhReadError
+        ):
+            client.graphql_open_pulls_by_head_ref("feature-base")
+
+    def test_graphql_open_pulls_rejects_page_limit_overflow(self) -> None:
+        client = pr_convergence.GhClient("owner/repo")
+
+        def page(index: int) -> dict[str, object]:
+            return {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "nodes": [],
+                            "pageInfo": {"hasNextPage": True, "endCursor": f"cursor-{index}"},
+                        }
+                    }
+                }
+            }
+
+        pages = [page(index) for index in range(pr_convergence.GRAPHQL_MAX_PAGES + 1)]
+        with mock.patch.object(client, "run", side_effect=pages) as run, self.assertRaises(
+            pr_convergence.GhReadError
+        ):
+            client.graphql_open_pulls_by_head_ref("feature-base")
+
+        self.assertEqual(run.call_count, pr_convergence.GRAPHQL_MAX_PAGES)
+
     def test_new_comment_since_snapshot_reports_changed_window(self) -> None:
         data = load_fixture()
         previous = classify(data)["snapshot"]
@@ -832,42 +980,18 @@ class PrConvergenceStatusTest(unittest.TestCase):
         fixture["pull"]["base"]["ref"] = "feature-base"
         calls: list[str] = []
         head_ref_reads: list[str] = []
+        candidates = [
+            {
+                "head": {"ref": "feature-base", "repo": {"full_name": "contributor/repo"}},
+                "html_url": "https://github.com/owner/repo/pull/6",
+                "number": 6,
+                "state": "open",
+                "title": "Base PR",
+            }
+        ]
 
-        class RecordingGhClient:
-            def __init__(self, repo: str) -> None:
-                self.repo = repo
-                self.owner, self.name = pr_convergence.parse_repo(repo)
-
-            def api(self, path: str, *, paginate: bool = False, accept: str | None = None) -> object:
-                del paginate, accept
-                calls.append(path)
-                if path == "repos/owner/repo/pulls/7":
-                    return fixture["pull"]
-                if path.endswith("/check-runs?per_page=100"):
-                    return {"check_runs": []}
-                if path.endswith("/status"):
-                    return {"statuses": []}
-                if path.endswith("/compare/base111...head222"):
-                    return {"behind_by": 0, "ahead_by": 1, "status": "ahead"}
-                return []
-
-            def graphql_review_threads(self, pr_number: int) -> list[dict[str, object]]:
-                del pr_number
-                return []
-
-            def graphql_open_pulls_by_head_ref(self, head_ref_name: str) -> list[dict[str, object]]:
-                head_ref_reads.append(head_ref_name)
-                return [
-                    {
-                        "head": {"ref": head_ref_name, "repo": {"full_name": "contributor/repo"}},
-                        "html_url": "https://github.com/owner/repo/pull/6",
-                        "number": 6,
-                        "state": "open",
-                        "title": "Base PR",
-                    }
-                ]
-
-        with mock.patch.object(pr_convergence, "GhClient", RecordingGhClient):
+        client = recording_base_candidate_client(fixture, candidates, calls, head_ref_reads)
+        with mock.patch.object(pr_convergence, "GhClient", client):
             data = pr_convergence.gather_pr_state("owner/repo", 7)
 
         self.assertEqual(head_ref_reads, ["feature-base"])
@@ -881,33 +1005,8 @@ class PrConvergenceStatusTest(unittest.TestCase):
         calls: list[str] = []
         head_ref_reads: list[str] = []
 
-        class RecordingGhClient:
-            def __init__(self, repo: str) -> None:
-                self.repo = repo
-                self.owner, self.name = pr_convergence.parse_repo(repo)
-
-            def api(self, path: str, *, paginate: bool = False, accept: str | None = None) -> object:
-                del paginate, accept
-                calls.append(path)
-                if path == "repos/owner/repo/pulls/7":
-                    return fixture["pull"]
-                if path.endswith("/check-runs?per_page=100"):
-                    return {"check_runs": []}
-                if path.endswith("/status"):
-                    return {"statuses": []}
-                if path.endswith("/compare/base111...head222"):
-                    return {"behind_by": 0, "ahead_by": 1, "status": "ahead"}
-                return []
-
-            def graphql_review_threads(self, pr_number: int) -> list[dict[str, object]]:
-                del pr_number
-                return []
-
-            def graphql_open_pulls_by_head_ref(self, head_ref_name: str) -> list[dict[str, object]]:
-                head_ref_reads.append(head_ref_name)
-                return []
-
-        with mock.patch.object(pr_convergence, "GhClient", RecordingGhClient):
+        client = recording_base_candidate_client(fixture, [], calls, head_ref_reads)
+        with mock.patch.object(pr_convergence, "GhClient", client):
             data = pr_convergence.gather_pr_state("owner/repo", 7)
 
         self.assertEqual(data["base_pull_candidates"], [])

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -12,6 +12,7 @@ import json
 import pathlib
 import tempfile
 import unittest
+from unittest import mock
 
 
 SCRIPT_PATH = pathlib.Path(__file__).with_name("pr-convergence.py")
@@ -71,6 +72,56 @@ class PrConvergenceStatusTest(unittest.TestCase):
                 ["api", "graphql", "-f", "query=mutation { addComment(input: {}) { clientMutationId } }"]
             )
         )
+        self.assertFalse(pr_convergence.gh_args_are_read_only(["pr", "merge", "7"]))
+        self.assertFalse(pr_convergence.gh_args_are_read_only(["pr", "comment", "7"]))
+        self.assertFalse(pr_convergence.gh_args_are_read_only(["pr", "close", "7"]))
+        self.assertFalse(pr_convergence.gh_args_are_read_only(["pr", "edit", "7"]))
+        self.assertFalse(pr_convergence.gh_args_are_read_only(["pr", "review", "7", "--approve"]))
+
+    def test_gh_invocation_guard_allows_plain_reads(self) -> None:
+        self.assertTrue(pr_convergence.gh_args_are_read_only(["api", "repos/owner/repo/pulls/7"]))
+        self.assertTrue(
+            pr_convergence.gh_args_are_read_only(
+                ["api", "repos/owner/repo/pulls/7", "--paginate", "--slurp"]
+            )
+        )
+        self.assertTrue(
+            pr_convergence.gh_args_are_read_only(
+                ["api", "repos/owner/repo/pulls/7", "-H", "Accept: application/vnd.github+json"]
+            )
+        )
+        self.assertTrue(
+            pr_convergence.gh_args_are_read_only(["api", "repos/owner/repo/pulls/7", "-X", "GET"])
+        )
+        self.assertTrue(
+            pr_convergence.gh_args_are_read_only(["api", "repos/owner/repo/pulls/7", "-XGET"])
+        )
+        self.assertTrue(
+            pr_convergence.gh_args_are_read_only(
+                ["api", "repos/owner/repo/pulls/7", "--method=GET"]
+            )
+        )
+
+    def test_gh_client_api_constructs_plain_read_call(self) -> None:
+        calls: list[list[str]] = []
+
+        class RecordingGhClient(pr_convergence.GhClient):
+            def run(self, args: list[str]) -> object:
+                calls.append(args)
+                return {"number": 7}
+
+        payload = RecordingGhClient("owner/repo").api("repos/owner/repo/pulls/7")
+        self.assertEqual(payload, {"number": 7})
+        self.assertEqual(calls, [["api", "repos/owner/repo/pulls/7"]])
+        self.assertTrue(pr_convergence.gh_args_are_read_only(calls[0]))
+
+    def test_gh_client_blocks_mutation_before_executing_gh(self) -> None:
+        with mock.patch.object(pr_convergence.subprocess, "run") as run:
+            with self.assertRaises(pr_convergence.GhReadError):
+                pr_convergence.GhClient("owner/repo").run(
+                    ["api", "repos/owner/repo/issues/7/comments", "-X", "POST"]
+                )
+        run.assert_not_called()
 
     def test_clean_state_without_snapshot_is_ready(self) -> None:
         result = classify(load_fixture())
@@ -98,6 +149,32 @@ class PrConvergenceStatusTest(unittest.TestCase):
             pr_convergence.write_snapshot(path, second["snapshot"])
 
         self.assertEqual(second["status"], "READY")
+
+    def test_snapshot_write_uses_owner_only_permissions(self) -> None:
+        data = load_fixture()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = pathlib.Path(tmpdir) / "snapshot.json"
+            pr_convergence.write_snapshot(path, classify(data)["snapshot"])
+            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+
+    def test_corrupt_snapshot_fails_closed_as_data_source_unavailable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = pathlib.Path(tmpdir) / "snapshot.json"
+            path.write_text("{bad", encoding="utf-8")
+            with self.assertRaises(pr_convergence.DataSourceError) as raised:
+                pr_convergence.load_snapshot(path)
+
+        self.assertEqual(raised.exception.source, "snapshot")
+
+    def test_group_writable_snapshot_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = pathlib.Path(tmpdir) / "snapshot.json"
+            path.write_text("{}", encoding="utf-8")
+            path.chmod(0o660)
+            with self.assertRaises(pr_convergence.DataSourceError) as raised:
+                pr_convergence.load_snapshot(path)
+
+        self.assertEqual(raised.exception.source, "snapshot")
 
     def test_ai_review_top_level_comment_is_explicitly_blocking(self) -> None:
         result = classify(load_fixture("pr_convergence_ai_review.json"))

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -769,6 +769,28 @@ class PrConvergenceStatusTest(unittest.TestCase):
             ["modified:review_thread:thread-1"],
         )
 
+    def test_resolved_thread_since_snapshot_reports_changed_window(self) -> None:
+        data = load_fixture()
+        data["review_threads"] = [
+            {
+                "comments": {"nodes": []},
+                "id": "thread-1",
+                "isOutdated": False,
+                "isResolved": False,
+                "line": 12,
+                "originalLine": 12,
+                "path": "scripts/example.py",
+            }
+        ]
+        previous = classify(data)["snapshot"]
+        data["review_threads"][0]["isResolved"] = True
+        result = classify(data, previous=previous, snapshot_requested=True)
+        self.assertEqual(result["status"], "CHANGED_DURING_WINDOW")
+        self.assertEqual(
+            result["change_detection"]["categories"]["threads"],
+            ["modified:review_thread:thread-1"],
+        )
+
     def test_stacked_pr_base_is_distinct_from_main_base(self) -> None:
         data = load_fixture()
         data["pull"]["base"]["ref"] = "feature-base"

--- a/scripts/testdata/pr_convergence_ai_review.json
+++ b/scripts/testdata/pr_convergence_ai_review.json
@@ -1,0 +1,84 @@
+{
+  "base_pull_candidates": [],
+  "check_runs": {
+    "check_runs": [
+      {
+        "conclusion": "success",
+        "head_sha": "head222",
+        "name": "unit",
+        "status": "completed"
+      }
+    ]
+  },
+  "commits": [
+    {
+      "commit": {
+        "committer": {
+          "date": "2026-01-01T10:00:00Z"
+        }
+      },
+      "sha": "head222"
+    }
+  ],
+  "compare": {
+    "ahead_by": 1,
+    "behind_by": 0,
+    "status": "ahead"
+  },
+  "errors": [],
+  "issue_comments": [
+    {
+      "body": "## AI Review\n\n1. medium: scripts/example.py - fix this finding.",
+      "created_at": "2026-01-01T10:10:00Z",
+      "html_url": "https://github.com/owner/repo/pull/7#issuecomment-22",
+      "id": 22,
+      "updated_at": "2026-01-01T10:10:00Z",
+      "user": {
+        "login": "github-actions[bot]"
+      }
+    }
+  ],
+  "pr_number": 7,
+  "pull": {
+    "base": {
+      "ref": "main",
+      "repo": {
+        "full_name": "owner/repo"
+      },
+      "sha": "base111"
+    },
+    "draft": false,
+    "head": {
+      "ref": "feature",
+      "repo": {
+        "full_name": "owner/repo"
+      },
+      "sha": "head222"
+    },
+    "html_url": "https://github.com/owner/repo/pull/7",
+    "mergeable": true,
+    "mergeable_state": "clean",
+    "number": 7,
+    "state": "open",
+    "title": "Neutral fixture"
+  },
+  "repo": "owner/repo",
+  "review_comments": [],
+  "review_threads": [],
+  "reviews": [
+    {
+      "body": "Looks good.",
+      "commit_id": "head222",
+      "html_url": "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+      "id": 1,
+      "state": "APPROVED",
+      "submitted_at": "2026-01-01T10:05:00Z",
+      "user": {
+        "login": "reviewer-a"
+      }
+    }
+  ],
+  "status": {
+    "statuses": []
+  }
+}

--- a/scripts/testdata/pr_convergence_clean.json
+++ b/scripts/testdata/pr_convergence_clean.json
@@ -1,0 +1,79 @@
+{
+  "base_pull_candidates": [],
+  "check_runs": {
+    "check_runs": [
+      {
+        "conclusion": "success",
+        "head_sha": "head222",
+        "name": "unit",
+        "status": "completed"
+      }
+    ]
+  },
+  "commits": [
+    {
+      "commit": {
+        "committer": {
+          "date": "2026-01-01T10:00:00Z"
+        }
+      },
+      "sha": "head222"
+    }
+  ],
+  "compare": {
+    "ahead_by": 1,
+    "behind_by": 0,
+    "status": "ahead"
+  },
+  "errors": [],
+  "issue_comments": [],
+  "pr_number": 7,
+  "pull": {
+    "base": {
+      "ref": "main",
+      "repo": {
+        "full_name": "owner/repo"
+      },
+      "sha": "base111"
+    },
+    "draft": false,
+    "head": {
+      "ref": "feature",
+      "repo": {
+        "full_name": "owner/repo"
+      },
+      "sha": "head222"
+    },
+    "html_url": "https://github.com/owner/repo/pull/7",
+    "mergeable": true,
+    "mergeable_state": "clean",
+    "number": 7,
+    "state": "open",
+    "title": "Neutral fixture"
+  },
+  "repo": "owner/repo",
+  "review_comments": [],
+  "review_threads": [],
+  "reviews": [
+    {
+      "body": "Looks good.",
+      "commit_id": "head222",
+      "html_url": "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+      "id": 1,
+      "state": "APPROVED",
+      "submitted_at": "2026-01-01T10:05:00Z",
+      "user": {
+        "login": "reviewer-a"
+      }
+    }
+  ],
+  "status": {
+    "statuses": [
+      {
+        "context": "license",
+        "sha": "head222",
+        "state": "success"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What changed

Adds `scripts/pr-convergence.py`, a read-only command that answers one question in one structured result: has this pull request actually converged.

Review feedback arrives through four independent GitHub surfaces that are invisible to each other. Unresolved inline threads live in one place, collapsed sections of review summary bodies in another, top-level timeline comments in a third, and check runs in a fourth. Reading one surface and reporting a count is the recurring failure this replaces. A top-level comment posted by a bot is the case that hides best, because it is neither a review object nor an inline comment, so tools that read only reviews or only inline comments never see it even when it carries the most substantive finding on the pull request.

Until now that state machine lived outside the repository in a personal helper script, so it could not be versioned with the code, tested in CI, or relied on by anyone else. Every tool that needed it reimplemented it slightly differently and drifted. This makes it repository owned.

The command reports each dimension separately rather than collapsing them into one boolean: stack and base ancestry, unresolved threads including outside-diff and null-line comments, top-level comments with AI review findings called out explicitly, review summary bodies with actionable counts summed across all of them, reviews and checks evaluated against the current head so a stale approval is reported as stale rather than counted as satisfied, mergeability, and whether anything changed since a previous snapshot.

Output is a named status rather than a bare pass or fail, so a non-ready result says which dimension is not ready. `--json` prints a single object for other tooling to consume, and the exit code is zero only for `READY`, so it can gate a script.

## Failure direction

Every path is fail-closed. A source that cannot be read produces `DATA_SOURCE_UNAVAILABLE` rather than a silently incomplete answer, because a command that reports convergence from partial data is worse than one that reports nothing. The command is read-only by construction and refuses any invocation that would mutate repository state.

## Scope

Standard library plus the GitHub CLI, no new dependencies. Tests drive the classifier from recorded fixtures and make no network calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only pull request convergence report covering reviews, comments, threads, commits, checks, conflicts, and branch status.
  * Added compact and JSON output, snapshot comparison, repository and pull request auto-detection, and documented status codes.
  * Highlights unresolved feedback, AI findings, requested changes, failing or pending checks, conflicts, branch divergence, and unavailable data sources.

* **Tests**
  * Added comprehensive coverage for reporting, validation, snapshots, readiness detection, and change tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->