### PR TITLE
chore: add NOTICE attribution

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+Pipelock
+Copyright 2026 Joshua Waldrep
+
+This repository is licensed under two separate licenses.
+
+The core of the project is licensed under the Apache License, Version 2.0.
+See LICENSE for the full license text.
+
+The contents of the enterprise/ directory are NOT covered by the Apache
+License. They are licensed under the Elastic License 2.0 (ELv2). See
+enterprise/LICENSE for the full license text.
+
+Canonical upstream:
+https://github.com/luckyPipewrench/pipelock


### PR DESCRIPTION
## What changed

Adds a NOTICE file at the repository root.

Apache-2.0 section 4(d) requires a derivative work's distribution to reproduce the contents of a NOTICE file when the original has one. Without a NOTICE, attribution rests entirely on per-file copyright headers, which a redistribution is not obliged to surface to end users.

The NOTICE states the dual licensing explicitly so that a reader cannot mistake the Apache-2.0 core for covering the `enterprise/` directory, which is licensed under the Elastic License 2.0. It restates what the README already documents and grants or restricts nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a NOTICE file with copyright, licensing, enterprise licensing, and upstream repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->