### PR TITLE
fix(gitprotect): scan-diff accepts whole-file deletion hunks

### DIFF
--- a/internal/gitprotect/diffscan.go
+++ b/internal/gitprotect/diffscan.go
@@ -237,10 +237,39 @@ func parseHunkNewStartOK(hunkLine string) (int, bool) {
 	}
 
 	n, err := strconv.Atoi(rest[:end])
-	if err != nil || n < 1 || n > maxDiffLineNumber {
+	if err != nil || n < 0 || n > maxDiffLineNumber {
+		return 1, false
+	}
+	// A whole-file deletion emits "@@ -X,Y +0,0 @@": new_start 0 with new_count 0.
+	// Such a hunk adds no lines, so it is a valid hunk that contributes nothing to
+	// attribute. Accept it so a legitimate file deletion is not rejected as
+	// unattributed content. new_start 0 is only valid when new_count is also 0
+	// (there is no line 0 to add content at), so a "+0,N" with N > 0 stays rejected.
+	if n == 0 {
+		if hunkNewCountZero(rest, end) {
+			return n, true
+		}
 		return 1, false
 	}
 	return n, true
+}
+
+// hunkNewCountZero reports whether the new-side count in a hunk header is
+// explicitly zero, which marks a deletion hunk. rest is the substring after the
+// "+" in the header and startEnd is the index in rest where the new_start token
+// ends. A header with no explicit count (e.g. "+0 ") is not a deletion hunk
+// because the count then defaults to 1.
+func hunkNewCountZero(rest string, startEnd int) bool {
+	if startEnd >= len(rest) || rest[startEnd] != ',' {
+		return false
+	}
+	countStr := rest[startEnd+1:]
+	countEnd := strings.IndexAny(countStr, " @")
+	if countEnd < 0 {
+		countEnd = len(countStr)
+	}
+	c, err := strconv.Atoi(countStr[:countEnd])
+	return err == nil && c == 0
 }
 
 // CompiledDLPPattern is a pre-compiled DLP regex for scanning diffs.

--- a/internal/gitprotect/diffscan_test.go
+++ b/internal/gitprotect/diffscan_test.go
@@ -222,6 +222,82 @@ func TestScanDiff_FindsSecret(t *testing.T) {
 	}
 }
 
+func TestScanDiff_WholeFileDeletion(t *testing.T) {
+	// A whole-file deletion emits "@@ -N,M +0,0 @@". It adds no lines, so it must
+	// scan clean rather than fail as unattributed content. Deleting a file that
+	// contained a secret is not a leak - there are no added lines to flag.
+	key := fakeKey("EXAMPLE")
+	diff := "diff --git a/secrets.txt b/secrets.txt\n" +
+		"deleted file mode 100644\n" +
+		"index abc1234..0000000\n" +
+		"--- a/secrets.txt\n" +
+		"+++ /dev/null\n" +
+		"@@ -1,3 +0,0 @@\n" +
+		"-first line\n" +
+		"-key = \"" + key + "\"\n" +
+		"-third line\n"
+	result, err := ScanDiff(diff, testPatterns())
+	if err != nil {
+		t.Fatalf("whole-file deletion should scan clean, got error: %v", err)
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("deletion has no added lines, expected 0 findings, got %d", len(result.Findings))
+	}
+}
+
+func TestParseHunkNewStartOK(t *testing.T) {
+	tests := []struct {
+		name   string
+		hunk   string
+		wantN  int
+		wantOK bool
+	}{
+		{"normal add", "@@ -1,3 +1,5 @@", 1, true},
+		{"add at later line", "@@ -0,0 +5,2 @@", 5, true},
+		{"whole-file deletion", "@@ -1,3 +0,0 @@", 0, true},
+		{"mid-file deletion", "@@ -3,2 +2,0 @@", 2, true},
+		{"malformed zero-start with content", "@@ -1,1 +0,5 @@", 1, false},
+		{"nonnumeric zero-start count", "@@ -1,1 +0,invalid @@", 1, false},
+		{"deletion count at end of header", "@@ -1,1 +0,0", 0, true},
+		{"zero-start no explicit count", "@@ -1,1 +0 @@", 1, false},
+		{"no plus token", "@@ nonsense @@", 1, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, ok := parseHunkNewStartOK(tt.hunk)
+			if n != tt.wantN || ok != tt.wantOK {
+				t.Fatalf("parseHunkNewStartOK(%q) = (%d, %v), want (%d, %v)", tt.hunk, n, ok, tt.wantN, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestScanDiff_MalformedZeroStartHunkNotAcceptedAsDeletion(t *testing.T) {
+	// A "+0,N" with N > 0 is not a valid deletion hunk (there is no line 0 to add
+	// at), so the fix must not accept it as one. Added content under such a hunk
+	// must never be silently accepted: it is either scanned and flagged, or the
+	// input fails closed as unattributed content.
+	secretDiff := "diff --git a/x.go b/x.go\n" +
+		"--- a/x.go\n" +
+		"+++ b/x.go\n" +
+		"@@ -1,1 +0,5 @@\n" +
+		"+" + `var key = "` + fakeKey("EXAMPLE") + `"` + "\n"
+	result, err := ScanDiff(secretDiff, testPatterns())
+	if err == nil && len(result.Findings) == 0 {
+		t.Fatal("malformed +0,N hunk carrying a secret must not be silently accepted")
+	}
+
+	// The same malformed hunk with benign content fails closed as unattributed.
+	benignDiff := "diff --git a/x.go b/x.go\n" +
+		"--- a/x.go\n" +
+		"+++ b/x.go\n" +
+		"@@ -1,1 +0,5 @@\n" +
+		"+harmless configuration value\n"
+	if _, err := ScanDiff(benignDiff, testPatterns()); !errors.Is(err, ErrUnattributedAddedLines) {
+		t.Fatalf("malformed +0,N hunk with benign content should fail closed, got: %v", err)
+	}
+}
+
 func TestCompileDLPPatterns_InvalidRegexWithKnownClassFallback(t *testing.T) {
 	patterns := CompileDLPPatterns([]config.DLPPattern{{
 		Name:     testPatternAWSKey,


### PR DESCRIPTION
`pipelock git scan-diff` failed on a whole-file deletion. Git emits a `@@ -N,M +0,0 @@` hunk header for a deleted file, whose new_start is 0. `parseHunkNewStartOK` rejected `new_start < 1`, so the header was classified as content outside a valid hunk and the scan returned `unverifiable input: content outside unified diff hunks`. In the GitHub Action that runs with `fail-on-findings`, that fails CI on any PR that deletes a file.

The fix accepts `new_start 0` only when `new_count` is also 0, which is exactly the shape of a deletion hunk (it adds no lines to attribute). A malformed `+0,N` with N greater than 0 stays rejected, and added content under any malformed hunk is still scanned or fails closed, so the anti-evasion guard is unchanged.

Adds tests for a whole-file deletion scanning clean, the `parseHunkNewStartOK` boundary cases, and that a malformed zero-start hunk is never accepted as a deletion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of whole-file deletion changes during diff scanning.
  * Correctly validates zero-line diff hunks and rejects malformed additions.
  * Prevents unrecognized or unattributed changes from being silently ignored.
  * Ensures malformed changes are flagged or rejected instead of passing unnoticed.
* **Tests**
  * Added coverage for valid deletion-only diffs, explicit zero-start hunks, and malformed hunk formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->