### PR TITLE
fix(contain): verify the deployed binary against the integrity pin

### DIFF
--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -945,6 +945,42 @@ func TestProbeBinaryIntegrity_UppercasePinIsMalformedNotMismatch(t *testing.T) {
 	}
 }
 
+// A stat failure leaves file identity unknown rather than different. Reporting a
+// difference there would assert something unverified, which is the exact class of
+// overstatement this probe was changed to stop making.
+func TestProbeBinaryIntegrity_StatFailureReportsUnknownNotDifference(t *testing.T) {
+	env := makeProbeEnv(t)
+	dir := t.TempDir()
+
+	target := filepath.Join(dir, "pipelock")
+	if err := os.WriteFile(target, []byte("deployed"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	env.pipelockTarget = target
+
+	pinPath := filepath.Join(dir, "pin")
+	digest := "cc" + strings.Repeat("0", 62)
+	if err := os.WriteFile(pinPath, []byte(digest+"\n"), 0o600); err != nil {
+		t.Fatalf("write pin: %v", err)
+	}
+	env.pinPath = pinPath
+	env.readFile = os.ReadFile
+	env.hashFile = func(string) (string, error) { return digest, nil }
+	env.selfPath = func() (string, error) { return filepath.Join(dir, "elsewhere"), nil }
+	env.stat = func(string) (os.FileInfo, error) { return nil, errors.New("stat unavailable") }
+
+	status, detail := probeBinaryIntegrity(context.Background(), env)
+	if status != statusPass {
+		t.Fatalf("status = %s, want pass (the deployed binary still matches its pin)", status)
+	}
+	if !strings.Contains(detail, "could not compare") {
+		t.Errorf("detail = %q, want it to say the comparison was unavailable", detail)
+	}
+	if strings.Contains(detail, "differs") {
+		t.Errorf("detail = %q, must not assert a difference it did not verify", detail)
+	}
+}
+
 func TestActionRemovePath_RemovesFileAndBak(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	target := filepath.Join(t.TempDir(), "f")

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -947,37 +947,71 @@ func TestProbeBinaryIntegrity_UppercasePinIsMalformedNotMismatch(t *testing.T) {
 
 // A stat failure leaves file identity unknown rather than different. Reporting a
 // difference there would assert something unverified, which is the exact class of
-// overstatement this probe was changed to stop making.
+// overstatement this probe was changed to stop making. Each lookup is failed
+// independently, because either one alone is enough to leave identity unknown.
 func TestProbeBinaryIntegrity_StatFailureReportsUnknownNotDifference(t *testing.T) {
-	env := makeProbeEnv(t)
-	dir := t.TempDir()
-
-	target := filepath.Join(dir, "pipelock")
-	if err := os.WriteFile(target, []byte("deployed"), 0o600); err != nil {
-		t.Fatalf("write target: %v", err)
-	}
-	env.pipelockTarget = target
-
-	pinPath := filepath.Join(dir, "pin")
 	digest := "cc" + strings.Repeat("0", 62)
-	if err := os.WriteFile(pinPath, []byte(digest+"\n"), 0o600); err != nil {
-		t.Fatalf("write pin: %v", err)
-	}
-	env.pinPath = pinPath
-	env.readFile = os.ReadFile
-	env.hashFile = func(string) (string, error) { return digest, nil }
-	env.selfPath = func() (string, error) { return filepath.Join(dir, "elsewhere"), nil }
-	env.stat = func(string) (os.FileInfo, error) { return nil, errors.New("stat unavailable") }
 
-	status, detail := probeBinaryIntegrity(context.Background(), env)
-	if status != statusPass {
-		t.Fatalf("status = %s, want pass (the deployed binary still matches its pin)", status)
+	tests := []struct {
+		name string
+		fail string // which path's stat fails
+	}{
+		{name: "deployed binary stat fails", fail: "target"},
+		{name: "invoking binary stat fails", fail: "self"},
+		{name: "both stats fail", fail: "both"},
 	}
-	if !strings.Contains(detail, "could not compare") {
-		t.Errorf("detail = %q, want it to say the comparison was unavailable", detail)
-	}
-	if strings.Contains(detail, "differs") {
-		t.Errorf("detail = %q, must not assert a difference it did not verify", detail)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := makeProbeEnv(t)
+			dir := t.TempDir()
+
+			target := filepath.Join(dir, "pipelock")
+			if err := os.WriteFile(target, []byte("deployed"), 0o600); err != nil {
+				t.Fatalf("write target: %v", err)
+			}
+			self := filepath.Join(dir, "elsewhere")
+			if err := os.WriteFile(self, []byte("operator copy"), 0o600); err != nil {
+				t.Fatalf("write self: %v", err)
+			}
+
+			pinPath := filepath.Join(dir, "pin")
+			if err := os.WriteFile(pinPath, []byte(digest+"\n"), 0o600); err != nil {
+				t.Fatalf("write pin: %v", err)
+			}
+
+			env.pipelockTarget = target
+			env.pinPath = pinPath
+			env.readFile = os.ReadFile
+			env.hashFile = func(string) (string, error) { return digest, nil }
+			env.selfPath = func() (string, error) { return self, nil }
+			env.stat = func(path string) (os.FileInfo, error) {
+				switch tt.fail {
+				case "both":
+					return nil, errors.New("stat unavailable")
+				case "target":
+					if path == target {
+						return nil, errors.New("stat unavailable")
+					}
+				case "self":
+					if path == self {
+						return nil, errors.New("stat unavailable")
+					}
+				}
+				return os.Stat(path)
+			}
+
+			status, detail := probeBinaryIntegrity(context.Background(), env)
+			if status != statusPass {
+				t.Fatalf("status = %s, want pass (the deployed binary still matches its pin)", status)
+			}
+			if !strings.Contains(detail, "could not compare") {
+				t.Errorf("detail = %q, want it to say the comparison was unavailable", detail)
+			}
+			if strings.Contains(detail, "differs") {
+				t.Errorf("detail = %q, must not assert a difference it did not verify", detail)
+			}
+		})
 	}
 }
 

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -918,6 +918,33 @@ func TestProbeBinaryIntegrity_FailsOnMalformedPin(t *testing.T) {
 	}
 }
 
+// An uppercase pin is valid hex and the right length, but hashFile returns a
+// lowercase digest, so it could never match. Reporting it as a hash mismatch
+// would read as a swapped binary and send an operator hunting a compromise that
+// did not happen, so it must be reported as a malformed pin instead. hashFile is
+// left unstubbed so the test also proves the pin is rejected before any hashing.
+func TestProbeBinaryIntegrity_UppercasePinIsMalformedNotMismatch(t *testing.T) {
+	env := makeProbeEnv(t)
+	pinPath := filepath.Join(t.TempDir(), "pin")
+	upper := strings.ToUpper(strings.Repeat("ab", 32))
+	if err := os.WriteFile(pinPath, []byte(upper+"\n"), 0o600); err != nil {
+		t.Fatalf("write pin: %v", err)
+	}
+	env.pinPath = pinPath
+	env.readFile = os.ReadFile
+
+	status, detail := probeBinaryIntegrity(context.Background(), env)
+	if status != statusFail {
+		t.Fatalf("status = %s, want fail", status)
+	}
+	if !strings.Contains(detail, "malformed") {
+		t.Errorf("detail = %q, want it to name the pin as malformed", detail)
+	}
+	if strings.Contains(detail, "mismatch") || strings.Contains(detail, "unstubbed") {
+		t.Errorf("detail = %q, must reject the pin before hashing anything", detail)
+	}
+}
+
 func TestActionRemovePath_RemovesFileAndBak(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	target := filepath.Join(t.TempDir(), "f")

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -144,6 +144,7 @@ type probeEnv struct {
 	wrapperInvPath     string
 	toolsListPath      string
 	workspacePaths     []string
+	pipelockTarget     string
 	// postureProofPath is the resolved path the current `contain run` writes its
 	// signed posture capsule to. It is exported into the contained launch env as
 	// PIPELOCK_POSTURE_PROOF so an in-child emitter binds the exact capsule this
@@ -187,6 +188,7 @@ func defaultProbeEnv() *probeEnv {
 		pinPath:            defaultIntegrityPin,
 		wrapperInvPath:     defaultWrapperInvPath,
 		toolsListPath:      defaultToolsListPath,
+		pipelockTarget:     defaultPipelockTarget,
 		runCmd:             realRunCommand,
 		dropCounter:        readContainmentDropCounter,
 		dialCtx:            realDial,
@@ -520,11 +522,10 @@ func probeCCLaunchAllowList(ctx context.Context, env *probeEnv) (string, string)
 }
 
 // probeBinaryIntegrity reads the integrity pin written at install time and
-// compares it against the SHA-256 of the currently-running binary.
+// compares it against the SHA-256 of the deployed binary systemd executes.
 // Skipped when the pin file is missing (install never happened) or
 // unreadable to this user (run as root to verify). Failure means either
-// the binary was swapped after install OR a different pipelock binary is
-// being used to run verify than the one that was installed.
+// the deployed binary was swapped after install or cannot be verified.
 func probeBinaryIntegrity(_ context.Context, env *probeEnv) (string, string) {
 	data, err := env.readFile(env.pinPath)
 	if err != nil {
@@ -541,20 +542,22 @@ func probeBinaryIntegrity(_ context.Context, env *probeEnv) (string, string) {
 		return statusFail, fmt.Sprintf("%s contains malformed SHA-256 pin (length %d)", env.pinPath, len(pinned))
 	}
 
-	self, err := env.selfPath()
+	target := filepath.Clean(env.pipelockTarget)
+	got, err := env.hashFile(target)
 	if err != nil {
-		return statusFail, fmt.Sprintf("resolve self path: %v", err)
-	}
-	got, err := env.hashFile(self)
-	if err != nil {
-		return statusFail, fmt.Sprintf("hash %s: %v", self, err)
+		return statusFail, fmt.Sprintf("hash deployed binary %s: %v", target, err)
 	}
 	if got != pinned {
 		// Truncate for readability; full hashes are 64 chars.
-		return statusFail, fmt.Sprintf("binary hash mismatch: pin=%s got=%s (binary swapped after install or different binary running verify)",
+		return statusFail, fmt.Sprintf("binary hash mismatch: pin=%s got=%s (deployed binary swapped after install)",
 			shortHash(pinned), shortHash(got))
 	}
-	return statusPass, fmt.Sprintf("binary hash %s matches pin", shortHash(pinned))
+
+	detail := fmt.Sprintf("binary hash %s matches pin", shortHash(pinned))
+	if self, err := env.selfPath(); err == nil && filepath.Clean(self) != target {
+		detail += fmt.Sprintf(" (note: invoking binary %s differs from deployed binary %s)", filepath.Clean(self), target)
+	}
+	return statusPass, detail
 }
 
 const sha256HexLen = 64

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -572,7 +572,13 @@ func probeBinaryIntegrity(_ context.Context, env *probeEnv) (string, string) {
 		self = filepath.Clean(self)
 		targetInfo, targetErr := env.stat(target)
 		selfInfo, selfErr := env.stat(self)
-		if targetErr != nil || selfErr != nil || !os.SameFile(targetInfo, selfInfo) {
+		switch {
+		case targetErr != nil || selfErr != nil:
+			// Identity is unknown, not different. Saying the binaries differ here
+			// would assert something unverified, which is the failure this probe
+			// exists to stop making.
+			detail += fmt.Sprintf(" (note: could not compare invoking binary %s with deployed binary %s)", self, target)
+		case !os.SameFile(targetInfo, selfInfo):
 			detail += fmt.Sprintf(" (note: invoking binary %s differs from deployed binary %s)", self, target)
 		}
 	}

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -522,10 +522,18 @@ func probeCCLaunchAllowList(ctx context.Context, env *probeEnv) (string, string)
 }
 
 // probeBinaryIntegrity reads the integrity pin written at install time and
-// compares it against the SHA-256 of the deployed binary systemd executes.
+// compares it against the SHA-256 of the binary at the deployed install path.
 // Skipped when the pin file is missing (install never happened) or
 // unreadable to this user (run as root to verify). Failure means either
 // the deployed binary was swapped after install or cannot be verified.
+//
+// Two limits, stated because a probe should not imply more than it checks.
+// Nothing here reads the unit's effective ExecStart, so this establishes that
+// the binary at the install path is unchanged, not that the running service
+// has that binary mapped; proving the latter needs the live process image.
+// And the pin is written by our own installer, so this is trust-on-first-use
+// drift detection. It does not survive anyone able to rewrite both the binary
+// and the pin, which root can do.
 func probeBinaryIntegrity(_ context.Context, env *probeEnv) (string, string) {
 	data, err := env.readFile(env.pinPath)
 	if err != nil {
@@ -561,7 +569,12 @@ func probeBinaryIntegrity(_ context.Context, env *probeEnv) (string, string) {
 
 	detail := fmt.Sprintf("binary hash %s matches pin", shortHash(pinned))
 	if self, err := env.selfPath(); err == nil && filepath.Clean(self) != target {
-		detail += fmt.Sprintf(" (note: invoking binary %s differs from deployed binary %s)", filepath.Clean(self), target)
+		self = filepath.Clean(self)
+		targetInfo, targetErr := env.stat(target)
+		selfInfo, selfErr := env.stat(self)
+		if targetErr != nil || selfErr != nil || !os.SameFile(targetInfo, selfInfo) {
+			detail += fmt.Sprintf(" (note: invoking binary %s differs from deployed binary %s)", self, target)
+		}
 	}
 	return statusPass, detail
 }

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -538,7 +538,13 @@ func probeBinaryIntegrity(_ context.Context, env *probeEnv) (string, string) {
 	if pinned == "" {
 		return statusFail, fmt.Sprintf("%s is empty (corrupted pin)", env.pinPath)
 	}
-	if _, err := hex.DecodeString(pinned); err != nil || len(pinned) != sha256HexLen {
+	// Install writes a lowercase hex digest and hashFile returns lowercase, so an
+	// uppercase pin can never match. Rejecting it as malformed here tells the
+	// operator the pin itself is wrong; letting it through reports a hash
+	// mismatch, which reads as a swapped binary and sends them hunting a
+	// compromise that did not happen.
+	if _, err := hex.DecodeString(pinned); err != nil || len(pinned) != sha256HexLen ||
+		pinned != strings.ToLower(pinned) {
 		return statusFail, fmt.Sprintf("%s contains malformed SHA-256 pin (length %d)", env.pinPath, len(pinned))
 	}
 

--- a/internal/cli/contain/verify_lifecycle_failures_test.go
+++ b/internal/cli/contain/verify_lifecycle_failures_test.go
@@ -376,6 +376,61 @@ func TestProbeBinaryIntegrityVerifiesDeployedBinary(t *testing.T) {
 	}
 }
 
+func TestProbeBinaryIntegrity_DoesNotMisreportAliasedInvokingBinary(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		alias func(t *testing.T, target, invoking string)
+	}{
+		{
+			name: "symlink",
+			alias: func(t *testing.T, target, invoking string) {
+				t.Helper()
+				if err := os.Symlink(target, invoking); err != nil {
+					t.Fatalf("symlink invoking binary: %v", err)
+				}
+			},
+		},
+		{
+			name: "hardlink",
+			alias: func(t *testing.T, target, invoking string) {
+				t.Helper()
+				if err := os.Link(target, invoking); err != nil {
+					t.Fatalf("hardlink invoking binary: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "deployed-pipelock")
+			invoking := filepath.Join(dir, "invoking-pipelock")
+			pinPath := filepath.Join(dir, "binary-pin.sha256")
+			mustWriteFile(t, target, "installed binary")
+			pinned, err := sha256HexOfFile(target)
+			if err != nil {
+				t.Fatalf("hash deployed binary: %v", err)
+			}
+			mustWriteFile(t, pinPath, pinned+"\n")
+			tc.alias(t, target, invoking)
+
+			env := makeProbeEnv(t, func(env *probeEnv) {
+				env.pinPath = pinPath
+				env.pipelockTarget = target
+				env.readFile = os.ReadFile
+				env.selfPath = func() (string, error) { return invoking, nil }
+				env.hashFile = sha256HexOfFile
+			})
+			status, detail := probeBinaryIntegrity(context.Background(), env)
+			if status != statusPass {
+				t.Fatalf("status = %q, want pass: %s", status, detail)
+			}
+			if strings.Contains(detail, "note: invoking binary") {
+				t.Fatalf("detail = %q, must not report a path alias as a different binary", detail)
+			}
+		})
+	}
+}
+
 func TestVerificationParsersRejectIncompleteSafetyEvidence(t *testing.T) {
 	t.Run("workspace probe registration", func(t *testing.T) {
 		env := makeProbeEnv(t, func(env *probeEnv) {

--- a/internal/cli/contain/verify_lifecycle_failures_test.go
+++ b/internal/cli/contain/verify_lifecycle_failures_test.go
@@ -254,28 +254,47 @@ func TestListedToolTargetsRejectMalformedOrUnsafeState(t *testing.T) {
 }
 
 func TestVerificationMetadataFailuresAreVisible(t *testing.T) {
-	t.Run("binary self path", func(t *testing.T) {
-		env := makeProbeEnv(t, func(env *probeEnv) {
-			env.readFile = func(string) ([]byte, error) { return []byte(strings.Repeat("a", sha256HexLen)), nil }
-			env.selfPath = func() (string, error) { return "", os.ErrPermission }
+	for _, tc := range []struct {
+		name       string
+		selfPath   func() (string, error)
+		hashFile   func(string) (string, error)
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name:       "invoking binary path unavailable does not prevent deployed binary verification",
+			selfPath:   func() (string, error) { return "", os.ErrPermission },
+			hashFile:   func(string) (string, error) { return strings.Repeat("a", sha256HexLen), nil },
+			wantStatus: statusPass,
+			wantDetail: "matches pin",
+		},
+		{
+			name:       "deployed binary unreadable",
+			selfPath:   func() (string, error) { return "/bin/pipelock", nil },
+			hashFile:   func(string) (string, error) { return "", os.ErrPermission },
+			wantStatus: statusFail,
+			wantDetail: "hash deployed binary",
+		},
+		{
+			name:       "deployed binary absent",
+			selfPath:   func() (string, error) { return "/bin/pipelock", nil },
+			hashFile:   func(string) (string, error) { return "", os.ErrNotExist },
+			wantStatus: statusFail,
+			wantDetail: "hash deployed binary",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := makeProbeEnv(t, func(env *probeEnv) {
+				env.readFile = func(string) ([]byte, error) { return []byte(strings.Repeat("a", sha256HexLen)), nil }
+				env.selfPath = tc.selfPath
+				env.hashFile = tc.hashFile
+			})
+			status, detail := probeBinaryIntegrity(context.Background(), env)
+			if status != tc.wantStatus || !strings.Contains(detail, tc.wantDetail) {
+				t.Fatalf("probe = (%q, %q), want (%q, containing %q)", status, detail, tc.wantStatus, tc.wantDetail)
+			}
 		})
-		status, detail := probeBinaryIntegrity(context.Background(), env)
-		if status != statusFail || !strings.Contains(detail, "resolve self path") {
-			t.Fatalf("probe = (%q, %q)", status, detail)
-		}
-	})
-
-	t.Run("binary hash", func(t *testing.T) {
-		env := makeProbeEnv(t, func(env *probeEnv) {
-			env.readFile = func(string) ([]byte, error) { return []byte(strings.Repeat("a", sha256HexLen)), nil }
-			env.selfPath = func() (string, error) { return "/bin/pipelock", nil }
-			env.hashFile = func(string) (string, error) { return "", os.ErrPermission }
-		})
-		status, detail := probeBinaryIntegrity(context.Background(), env)
-		if status != statusFail || !strings.Contains(detail, "hash /bin/pipelock") {
-			t.Fatalf("probe = (%q, %q)", status, detail)
-		}
-	})
+	}
 
 	for _, tc := range []struct {
 		name string
@@ -295,6 +314,63 @@ func TestVerificationMetadataFailuresAreVisible(t *testing.T) {
 			_, err := wrappersForVerify(env)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestProbeBinaryIntegrityVerifiesDeployedBinary(t *testing.T) {
+	const deployedContents = "deployed binary before mutation"
+
+	tests := []struct {
+		name           string
+		mutateDeployed bool
+		invokingBody   string
+		wantStatus     string
+		wantDetail     string
+	}{
+		{
+			name:           "mutated deployed binary fails even when invoking binary still matches pin",
+			mutateDeployed: true,
+			invokingBody:   deployedContents,
+			wantStatus:     statusFail,
+			wantDetail:     "mismatch",
+		},
+		{
+			name:         "different invoking binary notes but does not fail when deployed binary matches pin",
+			invokingBody: "separate operator binary",
+			wantStatus:   statusPass,
+			wantDetail:   "note: invoking binary",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			deployed := filepath.Join(dir, "deployed-pipelock")
+			invoking := filepath.Join(dir, "invoking-pipelock")
+			pinPath := filepath.Join(dir, "binary-pin.sha256")
+			mustWriteFile(t, deployed, deployedContents)
+			pinned, err := sha256HexOfFile(deployed)
+			if err != nil {
+				t.Fatalf("hash deployed binary before mutation: %v", err)
+			}
+			mustWriteFile(t, pinPath, pinned+"\n")
+			if tc.mutateDeployed {
+				mustWriteFile(t, deployed, "deployed binary after mutation")
+			}
+			mustWriteFile(t, invoking, tc.invokingBody)
+
+			env := makeProbeEnv(t, func(env *probeEnv) {
+				env.pinPath = pinPath
+				env.pipelockTarget = deployed
+				env.readFile = os.ReadFile
+				env.selfPath = func() (string, error) { return invoking, nil }
+				env.hashFile = sha256HexOfFile
+			})
+			status, detail := probeBinaryIntegrity(context.Background(), env)
+			if status != tc.wantStatus || !strings.Contains(detail, tc.wantDetail) {
+				t.Fatalf("probe = (%q, %q), want (%q, containing %q)", status, detail, tc.wantStatus, tc.wantDetail)
 			}
 		})
 	}

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -191,23 +191,24 @@ func TestProbeListedToolTargets_AgentContextFailuresSkip(t *testing.T) {
 func makeProbeEnv(t *testing.T, opts ...func(*probeEnv)) *probeEnv {
 	t.Helper()
 	env := &probeEnv{
-		port:          8888,
-		operatorUser:  "",
-		proxyUserName: testProxyUser,
-		agentUserName: testAgentUser,
-		wrapperDir:    t.TempDir(),
-		toolWrappers:  []string{"plk-claude", "plk-codex"},
-		caBundlePath:  filepath.Join(t.TempDir(), "combined-ca.pem"),
-		launchPath:    "", // populated below
-		nftTable:      testTable,
-		nftChain:      testChain,
-		nftPath:       testNFT,
-		serviceName:   testService,
-		pinPath:       filepath.Join(t.TempDir(), "binary-pin.sha256"),
-		toolsListPath: filepath.Join(t.TempDir(), "tools.list"),
-		runCmd:        rejectAllRun,
-		dropCounter:   rejectAllDropCounter,
-		dialCtx:       rejectAllDial,
+		port:           8888,
+		operatorUser:   "",
+		proxyUserName:  testProxyUser,
+		agentUserName:  testAgentUser,
+		wrapperDir:     t.TempDir(),
+		toolWrappers:   []string{"plk-claude", "plk-codex"},
+		caBundlePath:   filepath.Join(t.TempDir(), "combined-ca.pem"),
+		launchPath:     "", // populated below
+		nftTable:       testTable,
+		nftChain:       testChain,
+		nftPath:        testNFT,
+		serviceName:    testService,
+		pinPath:        filepath.Join(t.TempDir(), "binary-pin.sha256"),
+		toolsListPath:  filepath.Join(t.TempDir(), "tools.list"),
+		pipelockTarget: defaultPipelockTarget,
+		runCmd:         rejectAllRun,
+		dropCounter:    rejectAllDropCounter,
+		dialCtx:        rejectAllDial,
 		wait: func(context.Context, time.Duration) error {
 			return nil
 		},
@@ -3290,7 +3291,7 @@ func allPassEnv(t *testing.T) *probeEnv {
 	}
 	writeFakePEMBundle(t, env.caBundlePath, "Pipelock Test CA")
 
-	// Probe 10: binary integrity. allPassEnv emits matching pin + hash so
+	// Probe 10: deployed binary integrity. allPassEnv emits matching pin + hash so
 	// the probe returns pass. Tests that want to exercise mismatch override
 	// hashFile or readFile after calling allPassEnv.
 	const allPassHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
@@ -3306,9 +3307,9 @@ func allPassEnv(t *testing.T) *probeEnv {
 		}
 		return nil, fmt.Errorf("unexpected readFile %s", path)
 	}
-	env.selfPath = func() (string, error) { return "/usr/local/bin/pipelock", nil }
+	env.selfPath = func() (string, error) { return defaultPipelockTarget, nil }
 	env.hashFile = func(path string) (string, error) {
-		if path == "/usr/local/bin/pipelock" {
+		if path == defaultPipelockTarget {
 			return allPassHash, nil
 		}
 		return "", fmt.Errorf("unexpected hashFile %s", path)


### PR DESCRIPTION
## What changed

The containment verifier's binary integrity probe is named "installed pipelock binary matches TOFU pin" and did not check that. It hashed the binary that invoked the verifier, while install pins the binary at the deployed install path. Those coincide only when the operator happens to run the verifier from the deployed path, so on a host with an operator copy on PATH the probe compared two different files.

Both directions were wrong. A correctly enforced host reported a hash mismatch and exited non-zero, which reads as a swapped binary and teaches an operator to distrust or disable the verifier. In the other direction, if the deployed binary changed while the verifier was invoked from a separate copy that still matched the pin, the probe would report that the installed binary matched while the binary at the install path did not.

The probe now hashes the deployed install path. When the invoking binary is a genuinely different file it passes with an informational note, since that is context rather than a failure. When the deployed binary is absent or unreadable it fails, because a security control must not read as a pass when it cannot verify.

## Two follow-on corrections

An uppercase pin is valid hex of the correct length, but the installer writes a lowercase digest and the file hasher returns lowercase, so such a pin could never match and previously fell through to the comparison and reported a hash mismatch. That sends an operator hunting a compromise that did not happen. It is now rejected as a malformed pin before any hashing, which leaves the pass and fail outcome unchanged and makes the reported reason truthful.

An adversarial review then found the informational note fired when the operator invoked pipelock through a symlink or hardlink to the deployed binary, because it compared cleaned paths rather than file identity. A healthy host was told its invoking binary differed from the same file. It now compares identity, and still emits the note if either stat fails rather than suppressing it.

## Scope of the claim

The doc comment previously said the probe hashes the binary systemd executes. Nothing in the probe reads the unit's effective ExecStart, so that claimed more than the code establishes, which is the same class of overstatement this change exists to remove. The comment now states both limits: this is drift detection on the install path rather than verification of the running process image, and the pin is written by the installer, so it is trust-on-first-use and does not survive anyone able to rewrite both the binary and the pin.

Verifying the running image rather than the install path is a stronger control and is tracked separately.

## Tests

Each new guard was verified by neutralising it and confirming the covering test fails. A mutated deployed binary with a clean invoking binary fails, which is the case the previous implementation passed. A different invoking binary against a correct deployed binary passes with the note. Symlink and hardlink aliases produce no note. An uppercase pin is rejected before any hashing occurs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Binary integrity verification now checks the deployed binary rather than the currently running executable.
  * Malformed and uppercase integrity pins are rejected clearly.
  * Verification distinguishes unavailable comparisons from actual binary differences.
  * Improved reporting for missing, unreadable, modified, symlinked, and hardlinked binaries.
  * Added clearer reporting when the invoking binary differs from the deployed binary while the deployed binary remains valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->