### PR TITLE
ci(review): route reviews to GPT-5.6 tiers

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: pr-review-${{ github.repository }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
     # Restrict to the repository owner account. Some /review modes execute
@@ -29,7 +33,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
-          ref: refs/heads/main
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Check out PR for stats mode
@@ -55,6 +59,9 @@ jobs:
       - name: Install dependencies
         run: pip install --require-hashes -r .github/requirements-pr-review.txt
 
+      - name: Test trusted review runner
+        run: python -m unittest scripts/pr_review_test.py
+
       - name: Determine review mode
         id: mode
         env:
@@ -71,11 +78,16 @@ jobs:
       - name: Run PR review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           REVIEW_MODE: ${{ steps.mode.outputs.mode }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           STATS_REPO_PATH: pr
-          PR_REVIEW_MODEL_FAST: gpt-5.4-mini
-          PR_REVIEW_MODEL_DEEP: gpt-5.5
+          # Optional repository variables. Empty values fall back to the
+          # reviewed constants in scripts/pr-review.py, the single source of
+          # truth for model defaults.
+          PR_REVIEW_MODEL_FAST: ${{ vars.PR_REVIEW_MODEL_FAST }}
+          PR_REVIEW_MODEL_DEEP: ${{ vars.PR_REVIEW_MODEL_DEEP }}
         run: python scripts/pr-review.py

--- a/docs/guides/pr-review.md
+++ b/docs/guides/pr-review.md
@@ -6,9 +6,8 @@ Manual-trigger AI security review for pull requests. Comment `/review` on any PR
 
 | Command | Model | Use When |
 |---------|-------|----------|
-| `/review` | Fast (default: gpt-5.4-mini) | Quick check, most PRs |
-| `/review fast` | Fast (default: gpt-5.4-mini) | Same as `/review` |
-| `/review deep` | Deep (default: gpt-5.4) | Complex changes, security-sensitive code |
+| `/review` | Efficient (default: gpt-5.6-luna, low reasoning) | Quick check, most PRs |
+| `/review deep` | Balanced (default: gpt-5.6-terra, medium reasoning) | Complex changes, security-sensitive code |
 
 ## What It Reviews
 
@@ -36,10 +35,21 @@ Set these in **Settings > Secrets and variables > Actions**:
 | `LITELLM_BASE_URL` | If using LiteLLM | Your LiteLLM proxy URL (e.g., `https://litellm.example.com/v1`) |
 | `LITELLM_API_KEY` | If using LiteLLM | API key for LiteLLM proxy |
 | `OPENAI_API_KEY` | If not using LiteLLM | Direct OpenAI API key (fallback) |
-| `PR_REVIEW_MODEL_FAST` | No | Model for `/review`, `/review fast`, `/review tests`, `/review docs`, `/review stats` (default: `gpt-5.4-mini`) |
-| `PR_REVIEW_MODEL_DEEP` | No | Model for `/review deep` (default: `gpt-5.4`) |
 
 `GITHUB_TOKEN` is provided automatically by GitHub Actions.
+
+### Optional GitHub Variables
+
+Set these in **Settings > Secrets and variables > Actions > Variables** only
+when intentionally overriding the reviewed defaults:
+
+| Variable | Default | Used By |
+|----------|---------|---------|
+| `PR_REVIEW_MODEL_FAST` | `gpt-5.6-luna` | `/review`, `/review tests`, `/review docs` |
+| `PR_REVIEW_MODEL_DEEP` | `gpt-5.6-terra` | `/review deep` |
+
+The defaults live in `scripts/pr-review.py`; the workflow passes optional
+repository variables through without maintaining another copy.
 
 ### LiteLLM vs Direct OpenAI
 
@@ -51,11 +61,11 @@ If both are set, LiteLLM takes priority.
 
 ### Switching Models
 
-Override the model via secrets:
+Override the model via repository variables:
 
-```
-PR_REVIEW_MODEL_FAST=gpt-5.4-mini     # fast (~$0.02/review)
-PR_REVIEW_MODEL_DEEP=gpt-5.4          # thorough (~$0.07/review)
+```text
+PR_REVIEW_MODEL_FAST=gpt-5.6-luna
+PR_REVIEW_MODEL_DEEP=gpt-5.6-terra
 ```
 
 With LiteLLM, use any model your proxy supports:
@@ -69,7 +79,7 @@ PR_REVIEW_MODEL_FAST=groq/llama-3.3-70b-versatile
 
 - Only runs when manually triggered (no auto-review on push)
 - Diff is truncated to ~100k chars (~25k tokens) to cap costs
-- `/review fast` uses a cheaper model by default
+- `/review` uses the efficient model by default
 - `/review deep` is opt-in for thorough analysis
 
 ## Files

--- a/scripts/pr-review.py
+++ b/scripts/pr-review.py
@@ -199,8 +199,11 @@ def summarize_usage(data: dict) -> str:
     return ", ".join(parts)
 
 
-def extract_chat_content(data: dict) -> str:
+def extract_chat_content(data: object) -> str:
     """Extract visible text from a chat-completions response."""
+    if not isinstance(data, dict):
+        raise LLMReviewError("LLM returned an invalid response shape.")
+
     choices = data.get("choices", [])
     if not isinstance(choices, list) or not choices:
         raise LLMReviewError("LLM returned no choices.")

--- a/scripts/pr-review.py
+++ b/scripts/pr-review.py
@@ -22,12 +22,12 @@ LLM configuration (one of, not needed for /review stats):
   OPENAI_API_KEY                       - Direct OpenAI API
 
 Model selection:
-  PR_REVIEW_MODEL_FAST  - Model for default/tests/docs (default: gpt-5.4-mini)
-  PR_REVIEW_MODEL_DEEP  - Model for /review deep (default: gpt-5.5)
+  PR_REVIEW_MODEL_FAST  - Model for default/tests/docs (default: gpt-5.6-luna)
+  PR_REVIEW_MODEL_DEEP  - Model for /review deep (default: gpt-5.6-terra)
 
 The PR_REVIEW_MODEL_FAST env var keeps its name for backwards compatibility
-with any existing repo-secrets overrides; the user-facing /review fast
-alias was dropped 2026-04-23 because the default mode is fast enough.
+with existing environment overrides; the user-facing /review fast alias was
+dropped 2026-04-23 because the default mode is fast enough.
 """
 
 import json
@@ -42,10 +42,10 @@ import requests
 # --- Constants ---
 
 MAX_DIFF_CHARS = 100_000
-DEFAULT_MODEL_FAST = "gpt-5.4-mini"
-DEFAULT_MODEL_DEEP = "gpt-5.5"
+DEFAULT_MODEL_FAST = "gpt-5.6-luna"
+DEFAULT_MODEL_DEEP = "gpt-5.6-terra"
 DEFAULT_TEMPERATURE = 0.2
-DEFAULT_MAX_COMPLETION_TOKENS = 4096
+DEFAULT_MAX_COMPLETION_TOKENS = 8192
 DEEP_MAX_COMPLETION_TOKENS = 25000
 DEFAULT_LLM_TIMEOUT_SECONDS = 120
 DEEP_LLM_TIMEOUT_SECONDS = 300
@@ -202,13 +202,11 @@ def summarize_usage(data: dict) -> str:
 def extract_chat_content(data: dict) -> str:
     """Extract visible text from a chat-completions response."""
     choices = data.get("choices", [])
-    if not choices:
-        raise LLMReviewError(
-            "LLM returned no choices. Raw response: " + json.dumps(data)[:500]
-        )
+    if not isinstance(choices, list) or not choices:
+        raise LLMReviewError("LLM returned no choices.")
 
-    choice = choices[0]
-    message = choice.get("message", {})
+    choice = choices[0] if isinstance(choices[0], dict) else {}
+    message = choice.get("message") if isinstance(choice.get("message"), dict) else {}
     content = message.get("content", "")
     if isinstance(content, list):
         content = "".join(
@@ -230,16 +228,20 @@ def extract_chat_content(data: dict) -> str:
     )
 
 
+def model_for_mode(mode: str) -> str:
+    """Return the configured model for a review mode, with Python defaults."""
+    if mode == "deep":
+        return os.environ.get("PR_REVIEW_MODEL_DEEP") or DEFAULT_MODEL_DEEP
+    return os.environ.get("PR_REVIEW_MODEL_FAST") or DEFAULT_MODEL_FAST
+
+
 def call_llm(diff: str, mode: str, system_prompt: str) -> str:
     """Send the diff to the LLM and return the review."""
     litellm_url = os.environ.get("LITELLM_BASE_URL", "")
     litellm_key = os.environ.get("LITELLM_API_KEY", "")
     openai_key = os.environ.get("OPENAI_API_KEY", "")
 
-    if mode == "deep":
-        model = os.environ.get("PR_REVIEW_MODEL_DEEP") or DEFAULT_MODEL_DEEP
-    else:
-        model = os.environ.get("PR_REVIEW_MODEL_FAST") or DEFAULT_MODEL_FAST
+    model = model_for_mode(mode)
 
     if litellm_url and litellm_key:
         api_url = litellm_url.rstrip("/") + "/chat/completions"
@@ -273,11 +275,8 @@ def call_llm(diff: str, mode: str, system_prompt: str) -> str:
     timeout = DEEP_LLM_TIMEOUT_SECONDS if is_deep else DEFAULT_LLM_TIMEOUT_SECONDS
     resp = requests.post(api_url, headers=headers, json=payload, timeout=timeout)
     if resp.status_code != 200:
-        body = resp.text[:500]
         raise LLMReviewError(
-            f"LLM API returned {resp.status_code}.\n\n"
-            f"**Model:** `{model}`\n\n"
-            f"**Response:**\n```\n{body}\n```"
+            f"LLM API returned {resp.status_code} for model `{model}`."
         )
     data = resp.json()
     return extract_chat_content(data)
@@ -510,10 +509,7 @@ def main() -> None:
         post_comment(repo, pr_number, token, f"**AI Review Error:** {e}")
         sys.exit(1)
 
-    model_name = (
-        os.environ.get("PR_REVIEW_MODEL_DEEP" if mode == "deep" else "PR_REVIEW_MODEL_FAST")
-        or (DEFAULT_MODEL_DEEP if mode == "deep" else DEFAULT_MODEL_FAST)
-    )
+    model_name = model_for_mode(mode)
 
     mode_labels = {
         "default": "security",

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -121,6 +121,14 @@ class ModelRoutingTest(unittest.TestCase):
 
 
 class ResponseParsingTest(unittest.TestCase):
+    def test_nonobject_response_roots_fail_closed(self) -> None:
+        for data in ([], "response", None, 1):
+            with self.subTest(data=data):
+                with self.assertRaisesRegex(
+                    pr_review.LLMReviewError, "invalid response shape"
+                ):
+                    pr_review.extract_chat_content(data)
+
     def test_shape_errors_are_generic_and_fail_closed(self) -> None:
         with self.assertRaises(pr_review.LLMReviewError) as ctx:
             pr_review.extract_chat_content(

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 
 SCRIPT_PATH = pathlib.Path(__file__).with_name("pr-review.py")
+WORKFLOW_PATH = SCRIPT_PATH.parents[1] / ".github" / "workflows" / "pr-review.yaml"
 SPEC = importlib.util.spec_from_file_location("pr_review", SCRIPT_PATH)
 if SPEC is None or SPEC.loader is None:
     raise RuntimeError(f"failed to load {SCRIPT_PATH}")
@@ -69,7 +70,68 @@ class PayloadTest(unittest.TestCase):
         self.assertNotIn("reasoning_effort", payload)
 
 
+class ModelRoutingTest(unittest.TestCase):
+    def test_defaults_use_cost_routed_gpt56_models(self) -> None:
+        self.assertEqual(pr_review.DEFAULT_MODEL_FAST, "gpt-5.6-luna")
+        self.assertEqual(pr_review.DEFAULT_MODEL_DEEP, "gpt-5.6-terra")
+
+    def test_empty_overrides_fall_back_to_python_defaults(self) -> None:
+        with mock.patch.dict(
+            pr_review.os.environ,
+            {"PR_REVIEW_MODEL_FAST": "", "PR_REVIEW_MODEL_DEEP": ""},
+            clear=True,
+        ):
+            self.assertEqual(pr_review.model_for_mode("default"), "gpt-5.6-luna")
+            self.assertEqual(pr_review.model_for_mode("deep"), "gpt-5.6-terra")
+
+    def test_nonempty_overrides_are_honored(self) -> None:
+        with mock.patch.dict(
+            pr_review.os.environ,
+            {
+                "PR_REVIEW_MODEL_FAST": "provider/ordinary",
+                "PR_REVIEW_MODEL_DEEP": "provider/deep",
+            },
+            clear=True,
+        ):
+            self.assertEqual(pr_review.model_for_mode("default"), "provider/ordinary")
+            self.assertEqual(pr_review.model_for_mode("deep"), "provider/deep")
+
+    def test_workflow_delegates_defaults_to_runner(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "PR_REVIEW_MODEL_FAST: ${{ vars.PR_REVIEW_MODEL_FAST }}",
+            workflow,
+        )
+        self.assertIn(
+            "PR_REVIEW_MODEL_DEEP: ${{ vars.PR_REVIEW_MODEL_DEEP }}",
+            workflow,
+        )
+        self.assertNotRegex(workflow, r"PR_REVIEW_MODEL_(?:FAST|DEEP): gpt-")
+
+    def test_workflow_passes_documented_llm_credentials(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}", workflow)
+        self.assertIn("LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}", workflow)
+        self.assertIn("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}", workflow)
+        self.assertIn("group: pr-review-${{ github.repository }}-${{ github.event.issue.number }}", workflow)
+        self.assertIn("cancel-in-progress: true", workflow)
+        self.assertIn("python -m unittest scripts/pr_review_test.py", workflow)
+
+
 class ResponseParsingTest(unittest.TestCase):
+    def test_shape_errors_are_generic_and_fail_closed(self) -> None:
+        with self.assertRaises(pr_review.LLMReviewError) as ctx:
+            pr_review.extract_chat_content(
+                {"choices": [], "private": "provider detail"}
+            )
+        self.assertIn("no choices", str(ctx.exception))
+        self.assertNotIn("provider detail", str(ctx.exception))
+
+        with self.assertRaisesRegex(pr_review.LLMReviewError, "empty content"):
+            pr_review.extract_chat_content({"choices": [None]})
+
     def test_extract_chat_content_accepts_string_content(self) -> None:
         data = {"choices": [{"message": {"content": "review body"}}]}
         self.assertEqual(pr_review.extract_chat_content(data), "review body")
@@ -185,7 +247,7 @@ class CallLLMTest(unittest.TestCase):
         message = str(ctx.exception)
         self.assertIn("LLM API returned 500", message)
         self.assertIn("gpt-5.4-mini", message)
-        self.assertIn("boom", message)
+        self.assertNotIn("boom", message)
 
     def test_call_llm_raises_when_no_api_is_configured(self) -> None:
         with mock.patch.dict(pr_review.os.environ, {}, clear=True):

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -129,6 +129,12 @@ class ResponseParsingTest(unittest.TestCase):
                 ):
                     pr_review.extract_chat_content(data)
 
+    def test_nonlist_choices_fail_closed(self) -> None:
+        for choices in ({}, "invalid", None, 1):
+            with self.subTest(choices=choices):
+                with self.assertRaisesRegex(pr_review.LLMReviewError, "no choices"):
+                    pr_review.extract_chat_content({"choices": choices})
+
     def test_shape_errors_are_generic_and_fail_closed(self) -> None:
         with self.assertRaises(pr_review.LLMReviewError) as ctx:
             pr_review.extract_chat_content(


### PR DESCRIPTION
Route ordinary PR reviews to GPT-5.6 Luna with low reasoning and deep reviews to GPT-5.6 Terra with medium reasoning. Centralize default selection in the runner, accept optional repository-variable overrides, harden trusted workflow invocation, and add regression coverage for routing and API-response failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated pull request review defaults to use the latest efficient and balanced models.
  * Optional repository settings can override model selections, with reliable fallbacks.
  * Review workflows now use the configured default branch and support trusted test execution.

* **Bug Fixes**
  * Prevented overlapping reviews for the same issue.
  * Improved handling of incomplete responses and service errors.

* **Documentation**
  * Updated review commands, configuration guidance, credentials setup, and cost information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->