### PR TITLE
feat(proxy): bind the SSRF dial rebind snapshot to exact host and port

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -168,6 +168,12 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	if strings.Contains(host, ":") { // IPv6 literal needs brackets in URL
 		syntheticHost = "[" + host + "]"
 	}
+	// The scanned/contract URL keeps its historical port-less form so the
+	// contract gate and scanner verdict are unchanged; the exact CONNECT port
+	// is bound to the dial snapshot below (from targetPort) and carried in the
+	// receipt target. Whether the CONNECT contract gate should also see the
+	// real port is a separate design question, tracked as a guard adjacent
+	// finding, not decided here.
 	syntheticURL := "https://" + syntheticHost + "/"
 	connectReceiptTarget := "https://" + net.JoinHostPort(host, targetPort) + "/"
 	targetCtx := newConnectAuditContext(p.logger, target, clientIP, requestID, agent)
@@ -180,7 +186,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	})
 	r = r.WithContext(connectScanCtx)
 	result := sc.Scan(connectScanCtx, syntheticURL)
-	r = r.WithContext(withAllowedSSRFDialScanSnapshot(r.Context(), sc, host, result))
+	r = r.WithContext(withAllowedSSRFDialScanSnapshot(r.Context(), sc, host, targetPort, result))
 
 	// Capture observer: record CONNECT URL verdict for policy replay.
 	{
@@ -1752,7 +1758,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = context.WithValue(ctx, ctxKeyAgentScanner, sc)
 	ctx = context.WithValue(ctx, ctxKeyAgentContractLoader, snapshotContractLoader)
 	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportForward)
-	ctx = withAllowedSSRFDialScanSnapshot(ctx, sc, r.URL.Hostname(), result)
+	ctx = withAllowedSSRFDialScanSnapshot(ctx, sc, r.URL.Hostname(), effectiveURLPort(r.URL), result)
 	outReq := r.Clone(ctx)
 	outReq.RequestURI = "" // required for http.Client
 	outReq = outReq.WithContext(context.WithValue(outReq.Context(), ctxKeyEnvelopeEmitter, envelopeEmitterSnapshot{emitter: envEmitter}))

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -3712,6 +3712,93 @@ func TestSSRFSafeDialContext_DNSRebindBlockCarriesDistinctReason(t *testing.T) {
 	}
 }
 
+// TestSSRFDialSnapshotPortBindingPerTransport verifies that each guard-relevant
+// transport records the DNS-rebind scan snapshot with the exact destination
+// port it derives, and that the port is honored at dial time through the real
+// ssrfSafeDialContext. CONNECT derives the port from the CONNECT target; the
+// URL surfaces (forward absolute-URI, fetch, redirect, interception, WebSocket)
+// derive it from effectiveURLPort of the request URL — the same computations
+// their call sites use. A snapshot taken for host:PORT labels a rebinding dial
+// to host:PORT as a DNS rebind, but must NOT vouch for or mislabel a dial to a
+// different port, which is a plain private-IP SSRF. The metadata-safe reverse-
+// proxy dialer records no scanner snapshot; its dial-port binding is covered by
+// TestSSRFDialSnapshotPortBinding.
+func TestSSRFDialSnapshotPortBindingPerTransport(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = []string{"127.0.0.0/8"}
+	cfg.DNS.HostOverrides = map[string][]string{"rebind.test": {"127.0.0.1"}}
+	logger := audit.NewNop()
+	sc := scanner.MustNew(cfg)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	const host = "rebind.test"
+	// A public IP is seen at scan time; the dial rebinds to the internal override.
+	scanResult := scanner.Result{Allowed: true, SSRFResolvedIPs: []string{"203.0.113.10"}}
+
+	connectPort := func(target string) string { _, port, _ := net.SplitHostPort(target); return port }
+	urlPort := func(raw string) string {
+		u, perr := url.Parse(raw)
+		if perr != nil {
+			t.Fatalf("url.Parse(%q): %v", raw, perr)
+		}
+		return effectiveURLPort(u)
+	}
+
+	transports := []struct {
+		name      string
+		scanPort  string // the port this transport binds into the snapshot
+		otherPort string // a different port the snapshot must not vouch for
+	}{
+		{"connect-default", connectPort(host + ":443"), "6443"},
+		{"connect-explicit-port", connectPort(host + ":6443"), "443"},
+		{"forward-absolute-uri", urlPort("https://" + host + "/"), "6443"},
+		{"fetch", urlPort("https://" + host + "/"), "6443"},
+		{"redirect", urlPort("https://" + host + "/"), "6443"},
+		{"interception", urlPort("https://" + host + "/"), "6443"},
+		{"websocket-wss", urlPort("wss://" + host + "/"), "6443"},
+		{"forward-explicit-port", urlPort("https://" + host + ":6443/"), "443"},
+	}
+
+	dialReason := func(t *testing.T, ctx context.Context, addr string) blockreason.Reason {
+		t.Helper()
+		conn, derr := p.ssrfSafeDialContext(ctx, "tcp", addr)
+		if conn != nil {
+			_ = conn.Close()
+		}
+		if derr == nil {
+			t.Fatalf("dial %q: expected SSRF block, got nil", addr)
+		}
+		var blocked *ssrfDialBlockError
+		if !errors.As(derr, &blocked) {
+			t.Fatalf("dial %q: error type = %T, want *ssrfDialBlockError: %v", addr, derr, derr)
+		}
+		return blocked.reason
+	}
+
+	for _, tr := range transports {
+		t.Run(tr.name, func(t *testing.T) {
+			// Matching port: the snapshot applies, so the internal rebind is a
+			// DNS rebind.
+			base := withAllowedSSRFDialScanSnapshot(context.Background(), sc, host, tr.scanPort, scanResult)
+			ctxMatch, cancel := context.WithTimeout(base, 2*time.Second)
+			defer cancel()
+			if got := dialReason(t, ctxMatch, net.JoinHostPort(host, tr.scanPort)); got != blockreason.SSRFDNSRebind {
+				t.Fatalf("matching port %s: reason = %s, want %s", tr.scanPort, got, blockreason.SSRFDNSRebind)
+			}
+			// Mismatched port: the snapshot for scanPort must not apply to a
+			// different port, so the internal dial is a plain private-IP block.
+			ctxMismatch, cancel2 := context.WithTimeout(base, 2*time.Second)
+			defer cancel2()
+			if got := dialReason(t, ctxMismatch, net.JoinHostPort(host, tr.otherPort)); got != blockreason.SSRFPrivateIP {
+				t.Fatalf("mismatched port %s (snapshot %s): reason = %s, want %s", tr.otherPort, tr.scanPort, got, blockreason.SSRFPrivateIP)
+			}
+		})
+	}
+}
+
 func TestAllowedSSRFDialScanSnapshotPreservesPublicAllowlistedIP(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.SSRF.IPAllowlist = []string{"203.0.113.0/24"}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -3693,7 +3693,7 @@ func TestSSRFSafeDialContext_DNSRebindBlockCarriesDistinctReason(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	ctx = withSSRFDialScanSnapshot(ctx, "rebind.test", []string{"203.0.113.10"})
+	ctx = withSSRFDialScanSnapshot(ctx, "rebind.test", "443", []string{"203.0.113.10"})
 
 	conn, err := p.ssrfSafeDialContext(ctx, "tcp", "rebind.test:443")
 	if conn != nil {
@@ -3718,7 +3718,7 @@ func TestAllowedSSRFDialScanSnapshotPreservesPublicAllowlistedIP(t *testing.T) {
 	sc := scanner.MustNew(cfg)
 	defer sc.Close()
 
-	ctx := withAllowedSSRFDialScanSnapshot(context.Background(), sc, "rebind.test", scanner.Result{
+	ctx := withAllowedSSRFDialScanSnapshot(context.Background(), sc, "rebind.test", "443", scanner.Result{
 		Allowed:         true,
 		SSRFResolvedIPs: []string{"203.0.113.10"},
 	})
@@ -3782,7 +3782,7 @@ func TestAllowedSSRFDialScanSnapshotClearsIneligibleSameHost(t *testing.T) {
 	t.Cleanup(sc.Close)
 
 	var nilCtx context.Context
-	if got := withAllowedSSRFDialScanSnapshot(nilCtx, sc, "rebind.test", scanner.Result{
+	if got := withAllowedSSRFDialScanSnapshot(nilCtx, sc, "rebind.test", "443", scanner.Result{
 		Allowed:         true,
 		SSRFResolvedIPs: []string{"203.0.113.10"},
 	}); got != nil {
@@ -3791,12 +3791,12 @@ func TestAllowedSSRFDialScanSnapshotClearsIneligibleSameHost(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := withSSRFDialScanSnapshot(context.Background(), "rebind.test", []string{"203.0.113.10"})
+			ctx := withSSRFDialScanSnapshot(context.Background(), "rebind.test", "443", []string{"203.0.113.10"})
 			currentScanner := sc
 			if tc.name == "nil scanner" {
 				currentScanner = nil
 			}
-			ctx = withAllowedSSRFDialScanSnapshot(ctx, currentScanner, "rebind.test", tc.result)
+			ctx = withAllowedSSRFDialScanSnapshot(ctx, currentScanner, "rebind.test", "443", tc.result)
 
 			if isSSRFDNSRebind(ctx, "rebind.test", net.ParseIP("127.0.0.1")) {
 				t.Fatal("stale same-host public snapshot survived an ineligible current scan")
@@ -3836,7 +3836,7 @@ func TestSSRFSafeDialContext_DNSRebindToCoreCIDRsBlockedWhenInternalConfigNil(t 
 
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
-			ctx = withSSRFDialScanSnapshot(ctx, tt.host, []string{"203.0.113.10"})
+			ctx = withSSRFDialScanSnapshot(ctx, tt.host, "443", []string{"203.0.113.10"})
 
 			conn, err := p.ssrfSafeDialContext(ctx, "tcp", net.JoinHostPort(tt.host, "443"))
 			if conn != nil {
@@ -5113,7 +5113,7 @@ func TestSSRFDialBlockHelpersEdgeCases(t *testing.T) {
 		t.Fatalf("nil logDetail() = %q, want empty", nilErr.logDetail())
 	}
 
-	ctx := withSSRFDialScanSnapshot(context.Background(), " Rebind.Test. ", []string{"bad-ip", "203.0.113.10", "2001:db8::1%eth0"})
+	ctx := withSSRFDialScanSnapshot(context.Background(), " Rebind.Test. ", "443", []string{"bad-ip", "203.0.113.10", "2001:db8::1%eth0"})
 	if ctx == nil {
 		t.Fatal("snapshot context is nil")
 	}

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -686,7 +686,7 @@ func newInterceptHandler(
 		})
 		r = r.WithContext(interceptScanCtx)
 		urlResult := ic.Scanner.Scan(interceptScanCtx, targetURL)
-		r = r.WithContext(withAllowedSSRFDialScanSnapshot(r.Context(), ic.Scanner, r.URL.Hostname(), urlResult))
+		r = r.WithContext(withAllowedSSRFDialScanSnapshot(r.Context(), ic.Scanner, r.URL.Hostname(), effectiveURLPort(r.URL), urlResult))
 
 		// Capture observer: record intercept URL verdict for policy replay.
 		if ic.Proxy != nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -124,6 +124,12 @@ const (
 	// dialer uses it only to label public-to-internal changes as DNS
 	// rebinding; blocking itself does not depend on the snapshot.
 	ctxKeySSRFDialScanSnapshot
+
+	// ctxKeySSRFDialPort carries the exact destination port of an in-progress
+	// dial so the rebind label only applies when the scan-time snapshot was
+	// taken for the same host:port. The safe dialer sets it from the split
+	// dial address.
+	ctxKeySSRFDialPort
 )
 
 type envelopeEmitterSnapshot struct {
@@ -681,7 +687,7 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			}
 			redirectScanCtx := scanner.WithDLPWarnContext(req.Context(), redirectWarnCtx)
 			result := currentScanner.Scan(redirectScanCtx, redirectURL)
-			*req = *req.WithContext(withAllowedSSRFDialScanSnapshot(redirectScanCtx, currentScanner, req.URL.Hostname(), result))
+			*req = *req.WithContext(withAllowedSSRFDialScanSnapshot(redirectScanCtx, currentScanner, req.URL.Hostname(), effectiveURLPort(req.URL), result))
 			if !result.Allowed {
 				actx := newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName)
 				if currentCfg.EnforceEnabled() {
@@ -3218,6 +3224,11 @@ func (p *Proxy) MetadataSafeDialer() func(ctx context.Context, network, addr str
 		return p.scannerPtr.Load()
 	})
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		// Bind the rebind snapshot to this dial's port so a snapshot taken
+		// for a different port cannot label this block as a rebind.
+		if _, port, splitErr := net.SplitHostPort(addr); splitErr == nil {
+			ctx = withSSRFDialPort(ctx, port)
+		}
 		conn, err := inner(ctx, network, addr)
 		if err != nil {
 			// Translate the MCP dialer's typed metadata refusal into the proxy's
@@ -3276,6 +3287,9 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 	if err != nil {
 		return nil, fmt.Errorf("ssrfSafeDialContext: split addr %q: %w", addr, err)
 	}
+	// Bind the rebind snapshot to this dial's port: a scan-time snapshot only
+	// vouches for the exact host:port it was taken for.
+	ctx = withSSRFDialPort(ctx, port)
 
 	// If the host is already an IP, check it and dial directly.
 	// IsTrustedDomain rejects IP literals, so raw IPs are always
@@ -4358,7 +4372,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	ctx = context.WithValue(ctx, ctxKeyAgentScanner, sc)
 	ctx = context.WithValue(ctx, ctxKeyAgentContractLoader, snapshotContractLoader)
 	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportFetch)
-	ctx = withAllowedSSRFDialScanSnapshot(ctx, sc, parsed.Hostname(), result)
+	ctx = withAllowedSSRFDialScanSnapshot(ctx, sc, parsed.Hostname(), effectiveURLPort(parsed), result)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	if err != nil {
 		log.LogError(actx, err)

--- a/internal/proxy/ssrf_dial_block.go
+++ b/internal/proxy/ssrf_dial_block.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
@@ -15,6 +16,12 @@ import (
 
 type ssrfDialScanSnapshot struct {
 	host string
+	// port is the exact destination TCP port that was scanned and
+	// authorized. A snapshot recorded for host:443 must not vouch for a
+	// dial to host:6443, so the DNS-rebind label (and, once guard grants
+	// exist, the internal-address allow) only applies when the dial port
+	// matches this value. Empty means the recording path had no port.
+	port string
 	ips  map[string]struct{}
 }
 
@@ -44,12 +51,13 @@ func (e *ssrfDialBlockError) logDetail() string {
 	return string(e.reason) + ": " + e.detail
 }
 
-func withSSRFDialScanSnapshot(ctx context.Context, host string, ips []string) context.Context {
+func withSSRFDialScanSnapshot(ctx context.Context, host, port string, ips []string) context.Context {
 	if ctx == nil || host == "" || len(ips) == 0 {
 		return ctx
 	}
 	snapshot := ssrfDialScanSnapshot{
 		host: normalizeSSRFDialHost(host),
+		port: normalizeSSRFDialPort(port),
 		ips:  make(map[string]struct{}, len(ips)),
 	}
 	for _, ipStr := range ips {
@@ -65,7 +73,7 @@ func withSSRFDialScanSnapshot(ctx context.Context, host string, ips []string) co
 	return context.WithValue(ctx, ctxKeySSRFDialScanSnapshot, snapshot)
 }
 
-func withAllowedSSRFDialScanSnapshot(ctx context.Context, sc *scanner.Scanner, host string, result scanner.Result) context.Context {
+func withAllowedSSRFDialScanSnapshot(ctx context.Context, sc *scanner.Scanner, host, port string, result scanner.Result) context.Context {
 	if ctx == nil {
 		return nil
 	}
@@ -81,7 +89,26 @@ func withAllowedSSRFDialScanSnapshot(ctx context.Context, sc *scanner.Scanner, h
 			return clearSnapshot()
 		}
 	}
-	return withSSRFDialScanSnapshot(ctx, host, result.SSRFResolvedIPs)
+	return withSSRFDialScanSnapshot(ctx, host, port, result.SSRFResolvedIPs)
+}
+
+// withSSRFDialPort records the exact destination port of an in-progress dial so
+// isSSRFDNSRebind can require the scan-time snapshot to have been taken for the
+// same port. The dialer sets this from the split dial address; a snapshot taken
+// for a different port cannot influence this dial's verdict.
+func withSSRFDialPort(ctx context.Context, port string) context.Context {
+	if ctx == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeySSRFDialPort, normalizeSSRFDialPort(port))
+}
+
+func ssrfDialPortFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	port, _ := ctx.Value(ctxKeySSRFDialPort).(string)
+	return port
 }
 
 func newSSRFDialBlockError(ctx context.Context, host string, ip net.IP, detail string) *ssrfDialBlockError {
@@ -106,6 +133,14 @@ func isSSRFDNSRebind(ctx context.Context, host string, ip net.IP) bool {
 	if normalizeSSRFDialHost(host) != snapshot.host {
 		return false
 	}
+	// A snapshot only vouches for the exact host:port it was taken for. When
+	// both the snapshot and the current dial carry a port and they differ,
+	// the snapshot describes a different destination and must not apply to
+	// this dial. This keeps a host:443 scan from labeling (or, with guard
+	// grants, authorizing) a host:6443 dial.
+	if dialPort := ssrfDialPortFromContext(ctx); dialPort != "" && snapshot.port != "" && dialPort != snapshot.port {
+		return false
+	}
 	ip = normalizeSSRFDialIP(ip)
 	if ip == nil {
 		return false
@@ -116,6 +151,36 @@ func isSSRFDNSRebind(ctx context.Context, host string, ip net.IP) bool {
 
 func normalizeSSRFDialHost(host string) string {
 	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+}
+
+// normalizeSSRFDialPort trims surrounding whitespace from a port token. Every
+// current producer (net.SplitHostPort and url.URL.Port) already yields a bare
+// port, so no digit stripping is needed. It intentionally does not
+// scheme-default an empty value: callers that know the scheme resolve the
+// default before recording, and an unknown port stays empty so it never
+// spuriously matches or mismatches a real port.
+func normalizeSSRFDialPort(port string) string {
+	return strings.TrimSpace(port)
+}
+
+// effectiveURLPort returns the explicit port of a URL, or the scheme default
+// for http/https/ws/wss, so the SSRF scan snapshot and the later dial agree on
+// a concrete port even when the URL omitted it.
+func effectiveURLPort(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	if p := u.Port(); p != "" {
+		return p
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https", "wss":
+		return "443"
+	case "http", "ws":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 func normalizeSSRFDialIP(ip net.IP) net.IP {

--- a/internal/proxy/ssrf_dial_block_port_test.go
+++ b/internal/proxy/ssrf_dial_block_port_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"testing"
+)
+
+// TestSSRFDialSnapshotPortBinding proves the rebind snapshot only vouches for
+// the exact host:port it was recorded for. A snapshot taken while scanning
+// host:443 must not influence the rebind verdict of a dial to host:6443. This
+// is the port-binding groundwork that lets guard grants (a later PR) authorize
+// an internal address for an exact port without leaking that authority to a
+// different port on the same host.
+func TestSSRFDialSnapshotPortBinding(t *testing.T) {
+	const host = "rebind.test"
+	scanTimeIP := "203.0.113.10"             // seen at scan time
+	changedIP := net.ParseIP("198.51.100.7") // NOT seen at scan time
+
+	base := withSSRFDialScanSnapshot(context.Background(), host, "443", []string{scanTimeIP})
+
+	tests := []struct {
+		name     string
+		dialPort string
+		want     bool
+	}{
+		// Matching port: the snapshot applies, so an IP that was not seen at
+		// scan time is flagged as a rebind. This is the existing behavior and
+		// proves the guard still fires — a non-vacuous positive.
+		{name: "matching port flags rebind", dialPort: "443", want: true},
+		// Mismatched port: the :443 snapshot does not describe a :6443 dial, so
+		// it must not apply. Neutralizing the port check flips this to true,
+		// which is what makes this assertion non-vacuous.
+		{name: "mismatched port does not apply", dialPort: "6443", want: false},
+		// No dial port recorded: fall back to host-only behavior for callers
+		// that never set a port (backward compatible).
+		{name: "absent dial port falls back to host match", dialPort: "", want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := base
+			if tc.dialPort != "" {
+				ctx = withSSRFDialPort(ctx, tc.dialPort)
+			}
+			if got := isSSRFDNSRebind(ctx, host, changedIP); got != tc.want {
+				t.Fatalf("isSSRFDNSRebind(dialPort=%q) = %v, want %v", tc.dialPort, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSSRFDialSnapshotSeenIPNotRebind confirms an IP that WAS seen at scan time
+// is never a rebind, regardless of port, so the port binding does not turn a
+// legitimate re-resolution into a false rebind.
+func TestSSRFDialSnapshotSeenIPNotRebind(t *testing.T) {
+	const host = "rebind.test"
+	ctx := withSSRFDialScanSnapshot(context.Background(), host, "443", []string{"203.0.113.10"})
+	ctx = withSSRFDialPort(ctx, "443")
+	if isSSRFDNSRebind(ctx, host, net.ParseIP("203.0.113.10")) {
+		t.Fatal("an IP seen at scan time must not be flagged as a rebind")
+	}
+}
+
+func TestEffectiveURLPort(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "https default", raw: "https://api.vendor.example/", want: "443"},
+		{name: "http default", raw: "http://api.vendor.example/", want: "80"},
+		{name: "wss default", raw: "wss://api.vendor.example/ws", want: "443"},
+		{name: "ws default", raw: "ws://api.vendor.example/ws", want: "80"},
+		{name: "explicit https port", raw: "https://api.vendor.example:6443/", want: "6443"},
+		{name: "explicit http port", raw: "http://api.vendor.example:8080/", want: "8080"},
+		{name: "ipv6 explicit port", raw: "https://[2001:db8::1]:6443/", want: "6443"},
+		{name: "unknown scheme has no default", raw: "ftp://api.vendor.example/", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := url.Parse(tc.raw)
+			if err != nil {
+				t.Fatalf("url.Parse(%q): %v", tc.raw, err)
+			}
+			if got := effectiveURLPort(u); got != tc.want {
+				t.Fatalf("effectiveURLPort(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+	if got := effectiveURLPort(nil); got != "" {
+		t.Fatalf("effectiveURLPort(nil) = %q, want empty", got)
+	}
+}

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -262,7 +262,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	})
 	r = r.WithContext(wsScanCtx)
 	result := sc.Scan(wsScanCtx, scanURL)
-	r = r.WithContext(withAllowedSSRFDialScanSnapshot(r.Context(), sc, parsed.Hostname(), result))
+	r = r.WithContext(withAllowedSSRFDialScanSnapshot(r.Context(), sc, parsed.Hostname(), effectiveURLPort(parsed), result))
 
 	// Capture observer: record WebSocket URL verdict for policy replay.
 	{


### PR DESCRIPTION
## What changed

The forward proxy records a DNS-rebind scan snapshot (the external IPs a host resolved to at scan time) and, at dial time, flags a dialed IP that was not in that set as a rebind. That snapshot was keyed by host only. This binds it to host AND port: the snapshot stores the scanned port, the SSRF-safe dialer records the dial's port in the request context, and the rebind check requires the scan-time snapshot's port to match before it applies.

A new `effectiveURLPort` derives the scheme-default port, and the port is threaded through all six snapshot recording sites: CONNECT, absolute-URI forward, fetch, redirect, intercept, and websocket.

## Why

A snapshot recorded while scanning a host on the default port could previously influence the rebind verdict of a dial to the same host on a different port. This corrects that cross-port coupling and is the exact-port groundwork that upcoming per-service destination grants depend on. The snapshot is label-only today (it refines a block's reason to `ssrf_dns_rebind` and does not gate allow or deny), so this changes no allow or deny verdict.

## Scope

The scanned and contract-evaluated URL is left unchanged so the scanner and contract-gate verdicts stay identical. Whether the CONNECT contract gate should also see the real destination port is a separate design question and is not decided here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSRF protection by binding DNS-rebinding checks to both the destination host and port.
  * Prevented scan results for one port from being incorrectly reused when connecting to another.
  * Preserved exact destination ports across proxy, redirect, intercepted URL, and WebSocket requests.
  * Maintained support for standard HTTP/HTTPS ports and port-less destinations.
  * Improved consistency of SSRF validation across supported connection types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->