### PR TITLE
feat(sandbox): make the standalone network lifecycle a fail-closed required service

### DIFF
--- a/internal/sandbox/bridge.go
+++ b/internal/sandbox/bridge.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"sync"
 )
 
@@ -34,6 +33,8 @@ type BridgeProxy struct {
 	wg              sync.WaitGroup
 	mu              sync.Mutex
 	closed          bool
+	failure         error
+	failureOnce     sync.Once
 	done            chan struct{}
 	doneOnce        sync.Once
 	watcherDone     chan struct{}
@@ -70,12 +71,13 @@ func (bp *BridgeProxy) Addr() string {
 }
 
 // Serve accepts connections and bridges them to the parent's Unix socket.
-// Blocks until ctx is cancelled or the listener is closed.
-func (bp *BridgeProxy) Serve(ctx context.Context) {
+// It returns nil only when ctx is cancelled or Close shuts down the listener.
+// An unexpected listener failure or an unavailable parent socket is fatal.
+func (bp *BridgeProxy) Serve(ctx context.Context) error {
 	bp.mu.Lock()
 	if bp.closed {
 		bp.mu.Unlock()
-		return
+		return nil
 	}
 	bp.watcherStarted = true
 	bp.mu.Unlock()
@@ -91,13 +93,19 @@ func (bp *BridgeProxy) Serve(ctx context.Context) {
 	for {
 		conn, err := bp.listener.Accept()
 		if err != nil {
-			return // listener closed
+			if failure := bp.getFailure(); failure != nil {
+				return failure
+			}
+			if bp.isShutdown(ctx) {
+				return nil
+			}
+			return fmt.Errorf("bridge listener accept: %w", err)
 		}
 		bp.mu.Lock()
 		if bp.closed {
 			bp.mu.Unlock()
 			_ = conn.Close()
-			return
+			return nil
 		}
 		bp.trackConnLocked(conn)
 		bp.wg.Add(1)
@@ -108,6 +116,41 @@ func (bp *BridgeProxy) Serve(ctx context.Context) {
 			bp.handleConn(conn)
 		}(conn)
 	}
+}
+
+func (bp *BridgeProxy) isShutdown(ctx context.Context) bool {
+	if ctx.Err() != nil {
+		return true
+	}
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	return bp.closed
+}
+
+func (bp *BridgeProxy) getFailure() error {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	return bp.failure
+}
+
+// fail records the first fatal bridge failure and wakes Serve by closing the
+// listener. It intentionally does not call Close because this may run from an
+// active connection handler that Close waits on.
+func (bp *BridgeProxy) fail(err error) {
+	bp.failureOnce.Do(func() {
+		bp.mu.Lock()
+		if bp.closed {
+			bp.mu.Unlock()
+			return
+		}
+		bp.failure = err
+		bp.doneOnce.Do(func() { close(bp.done) })
+		_ = bp.listener.Close()
+		for conn := range bp.conns {
+			_ = conn.Close()
+		}
+		bp.mu.Unlock()
+	})
 }
 
 // Close shuts down the proxy and waits for active connections.
@@ -163,7 +206,7 @@ func (bp *BridgeProxy) handleConn(conn net.Conn) {
 	// Connect to parent's proxy via Unix socket.
 	parentConn, err := (&net.Dialer{}).DialContext(context.Background(), "unix", bp.socketPath)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "[bridge] connect to parent proxy: %v\n", err)
+		bp.fail(fmt.Errorf("bridge connect to parent proxy: %w", err))
 		return
 	}
 	if !bp.trackConn(parentConn) {

--- a/internal/sandbox/bridge_test.go
+++ b/internal/sandbox/bridge_test.go
@@ -493,6 +493,13 @@ func TestBridgeProxy_FailAfterCloseIsDropped(t *testing.T) {
 	bp.Close()
 	bp.fail(errors.New("late failure after close"))
 
+	// Assert the drop directly rather than only through Serve's result: Close
+	// does not wait for Serve to return, so the Serve read alone could pass even
+	// if fail() had recorded the late error.
+	if got := bp.getFailure(); got != nil {
+		t.Fatalf("fail() recorded a failure after Close: %v", got)
+	}
+
 	select {
 	case err := <-serveErr:
 		if err != nil {

--- a/internal/sandbox/bridge_test.go
+++ b/internal/sandbox/bridge_test.go
@@ -104,6 +104,55 @@ func TestNewBridgeProxy_ListenError(t *testing.T) {
 	}
 }
 
+func TestBridgeProxy_ServeReturnsParentSocketFailure(t *testing.T) {
+	bp, err := NewBridgeProxy("/tmp/pipelock-parent-socket-does-not-exist", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("NewBridgeProxy: %v", err)
+	}
+	defer bp.Close()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- bp.Serve(context.Background()) }()
+
+	conn, err := (&net.Dialer{}).DialContext(context.Background(), "tcp", bp.Addr())
+	if err != nil {
+		t.Fatalf("dial bridge: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	select {
+	case err := <-serveErr:
+		if err == nil || !strings.Contains(err.Error(), "connect to parent proxy") {
+			t.Fatalf("Serve error = %v, want parent socket failure", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not report parent socket failure")
+	}
+}
+
+func TestBridgeProxy_ServeReturnsUnexpectedListenerFailure(t *testing.T) {
+	bp, err := NewBridgeProxy("/tmp/pipelock-parent-socket-does-not-exist", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("NewBridgeProxy: %v", err)
+	}
+	defer bp.Close()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- bp.Serve(context.Background()) }()
+	if err := bp.listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	select {
+	case err := <-serveErr:
+		if err == nil || !strings.Contains(err.Error(), "bridge listener accept") {
+			t.Fatalf("Serve error = %v, want listener failure", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not report listener failure")
+	}
+}
+
 func TestBridgeProxy_Addr(t *testing.T) {
 	dir := shortTempDir(t)
 	socketPath := ProxySocketPath(dir)

--- a/internal/sandbox/bridge_test.go
+++ b/internal/sandbox/bridge_test.go
@@ -465,18 +465,42 @@ func TestBridgeProxy_FailWakesServeWithRecordedError(t *testing.T) {
 	go func() { serveErr <- bp.Serve(context.Background()) }()
 
 	// A connection handler records a fatal parent-socket failure; Serve must
-	// wake and return exactly that error rather than a nil shutdown.
-	bp.fail(errors.New("parent socket lost"))
+	// wake and return exactly that error instance rather than a nil shutdown.
+	wantErr := errors.New("parent socket lost")
+	bp.fail(wantErr)
 
 	select {
 	case err := <-serveErr:
-		if err == nil || !strings.Contains(err.Error(), "parent socket lost") {
-			t.Fatalf("Serve error = %v, want the recorded failure", err)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("Serve error = %v, want the recorded failure %v", err, wantErr)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Serve did not return after fail()")
 	}
 	bp.Close()
+}
+
+func TestBridgeProxy_FailAfterCloseIsDropped(t *testing.T) {
+	bp, err := NewBridgeProxy("/tmp/pipelock-parent-socket-not-used", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("NewBridgeProxy: %v", err)
+	}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- bp.Serve(context.Background()) }()
+
+	// Close wins the once/closed ordering: a failure recorded after Close must
+	// be dropped, and Serve must still return the clean nil shutdown result.
+	bp.Close()
+	bp.fail(errors.New("late failure after close"))
+
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("Serve error = %v, want nil after Close drops a late failure", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after Close")
+	}
 }
 
 func TestBridgeProxy_CloseAndFailAreRaceSafe(t *testing.T) {

--- a/internal/sandbox/bridge_test.go
+++ b/internal/sandbox/bridge_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -64,7 +65,7 @@ func TestBridgeProxy_ForwardsToUnixSocket(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	serveDone := make(chan struct{})
 	go func() {
-		bp.Serve(ctx)
+		_ = bp.Serve(ctx)
 		close(serveDone)
 	}()
 	defer func() {
@@ -209,7 +210,7 @@ func TestBridgeProxy_CloseClosesIdleActiveConnections(t *testing.T) {
 	serveDone := make(chan struct{})
 	go func() {
 		defer close(serveDone)
-		bp.Serve(ctx)
+		_ = bp.Serve(ctx)
 	}()
 	defer func() {
 		cancel()
@@ -264,7 +265,7 @@ func TestBridgeProxy_CloseStopsContextWatcher(t *testing.T) {
 	serveDone := make(chan struct{})
 	go func() {
 		defer close(serveDone)
-		bp.Serve(ctx)
+		_ = bp.Serve(ctx)
 	}()
 
 	conn, err := (&net.Dialer{}).DialContext(context.Background(), "tcp", bp.Addr())
@@ -420,7 +421,7 @@ func TestBridgeProxy_HandleConnFailsGracefully(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	serveDone := make(chan struct{})
 	go func() {
-		bp.Serve(ctx)
+		_ = bp.Serve(ctx)
 		close(serveDone)
 	}()
 	defer func() {
@@ -452,5 +453,54 @@ func TestProxySocketPath(t *testing.T) {
 	}
 	if !strings.HasPrefix(path, "/tmp/sandbox-123") {
 		t.Errorf("expected /tmp/sandbox-123 prefix, got %s", path)
+	}
+}
+
+func TestBridgeProxy_FailWakesServeWithRecordedError(t *testing.T) {
+	bp, err := NewBridgeProxy("/tmp/pipelock-parent-socket-not-used", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("NewBridgeProxy: %v", err)
+	}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- bp.Serve(context.Background()) }()
+
+	// A connection handler records a fatal parent-socket failure; Serve must
+	// wake and return exactly that error rather than a nil shutdown.
+	bp.fail(errors.New("parent socket lost"))
+
+	select {
+	case err := <-serveErr:
+		if err == nil || !strings.Contains(err.Error(), "parent socket lost") {
+			t.Fatalf("Serve error = %v, want the recorded failure", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after fail()")
+	}
+	bp.Close()
+}
+
+func TestBridgeProxy_CloseAndFailAreRaceSafe(t *testing.T) {
+	// fail() runs from a connection handler while Close() runs from the caller.
+	// Neither may panic, double-close, or deadlock, and Serve must always
+	// return. Run under -race to catch a data race on the shared state.
+	for range 50 {
+		bp, err := NewBridgeProxy("/tmp/pipelock-parent-socket-not-used", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("NewBridgeProxy: %v", err)
+		}
+		serveDone := make(chan struct{})
+		go func() { _ = bp.Serve(context.Background()); close(serveDone) }()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); bp.fail(errors.New("parent socket lost")) }()
+		go func() { defer wg.Done(); bp.Close() }()
+		wg.Wait()
+
+		select {
+		case <-serveDone:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Serve did not return under concurrent Close and fail")
+		}
 	}
 }

--- a/internal/sandbox/child_init.go
+++ b/internal/sandbox/child_init.go
@@ -206,7 +206,10 @@ func runInitWithBridge(command, env []string, workspace, socketPath string, sigC
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	go bridge.Serve(ctx)
+	// The MCP bridge does not yet supervise Serve's failure the way the
+	// standalone path does; explicitly discard it here to keep behavior
+	// unchanged. Hardening this path is tracked as a separate follow-up.
+	go func() { _ = bridge.Serve(ctx) }()
 
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] bridge proxy: %s → %s\n", bridge.Addr(), socketPath)
 

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -200,19 +200,14 @@ func RunStandaloneInit() {
 	agentDone := make(chan error, 1)
 	go func() { agentDone <- agentCmd.Wait() }()
 
-	select {
-	case bridgeErr := <-bridgeErr:
-		if bridgeErr != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] FATAL: bridge proxy: %v\n", bridgeErr)
-			// The parent observes this non-zero init exit and terminates the
-			// standalone process group, including this agent and its descendants.
-			exitSandboxProcess(1)
-		}
-		// A clean bridge return is only possible during cancellation or Close.
-		// Wait for the command so its established exit behavior is preserved.
-		err = <-agentDone
-	case err = <-agentDone:
+	agentErr, bridgeFailure := waitStandaloneAgentAndBridge(agentDone, bridgeErr, bridge.Close)
+	if bridgeFailure != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] FATAL: bridge proxy: %v\n", bridgeFailure)
+		// The parent observes this non-zero init exit and terminates the
+		// standalone process group, including this agent and its descendants.
+		exitSandboxProcess(1)
 	}
+	err = agentErr
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -220,5 +215,25 @@ func RunStandaloneInit() {
 		}
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command error: %v\n", err)
 		exitSandboxProcess(1)
+	}
+}
+
+// waitStandaloneAgentAndBridge waits for the agent and its required bridge.
+// When the agent exits first, it shuts the bridge down and consumes its
+// terminal result before returning. This preserves a bridge failure that was
+// already in progress instead of allowing a select race to turn it into a
+// successful agent exit.
+func waitStandaloneAgentAndBridge(agentDone, bridgeErr <-chan error, stopBridge func()) (agentErr, bridgeFailure error) {
+	select {
+	case bridgeFailure = <-bridgeErr:
+		if bridgeFailure != nil {
+			return nil, bridgeFailure
+		}
+		// A clean bridge return is only possible during cancellation or Close.
+		// Wait for the command so its established exit behavior is preserved.
+		return <-agentDone, nil
+	case agentErr = <-agentDone:
+		stopBridge()
+		return agentErr, <-bridgeErr
 	}
 }

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -153,7 +153,8 @@ func RunStandaloneInit() {
 		exitSandboxProcess(1)
 	}
 
-	go bridge.Serve(ctx)
+	bridgeErr := make(chan error, 1)
+	go func() { bridgeErr <- bridge.Serve(ctx) }()
 	defer bridge.Close()
 
 	// Report summary.
@@ -192,7 +193,27 @@ func RunStandaloneInit() {
 	agentCmd.Env = env
 	agentCmd.Dir = workspace
 
-	if err := agentCmd.Run(); err != nil {
+	if err := agentCmd.Start(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command error: %v\n", err)
+		exitSandboxProcess(1)
+	}
+	agentDone := make(chan error, 1)
+	go func() { agentDone <- agentCmd.Wait() }()
+
+	select {
+	case bridgeErr := <-bridgeErr:
+		if bridgeErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] FATAL: bridge proxy: %v\n", bridgeErr)
+			// The parent observes this non-zero init exit and terminates the
+			// standalone process group, including this agent and its descendants.
+			exitSandboxProcess(1)
+		}
+		// A clean bridge return is only possible during cancellation or Close.
+		// Wait for the command so its established exit behavior is preserved.
+		err = <-agentDone
+	case err = <-agentDone:
+	}
+	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			exitSandboxProcess(exitErr.ExitCode())

--- a/internal/sandbox/child_standalone_init_race_test.go
+++ b/internal/sandbox/child_standalone_init_race_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package sandbox
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestBridgeLifecycle_PreservesReadyBridgeFailure(t *testing.T) {
+	for range 10_000 {
+		bridgeErr := make(chan error, 1)
+		agentDone := make(chan error, 1)
+		bridgeErr <- errors.New("parent socket lost")
+		agentDone <- nil
+
+		agentErr, bridgeFailure := waitStandaloneAgentAndBridge(agentDone, bridgeErr, func() {})
+		if agentErr != nil || bridgeFailure == nil {
+			t.Fatalf("agent error = %v, bridge failure = %v; want nil agent error and bridge failure", agentErr, bridgeFailure)
+		}
+	}
+}
+
+func TestBridgeLifecycle_StopsBridgeAfterAgentExit(t *testing.T) {
+	bridgeErr := make(chan error, 1)
+	agentDone := make(chan error, 1)
+	agentDone <- nil
+	stopped := false
+
+	agentErr, bridgeFailure := waitStandaloneAgentAndBridge(agentDone, bridgeErr, func() {
+		stopped = true
+		bridgeErr <- nil
+	})
+	if agentErr != nil || bridgeFailure != nil || !stopped {
+		t.Fatalf("agent error = %v, bridge failure = %v, stopped = %t; want clean stopped bridge", agentErr, bridgeFailure, stopped)
+	}
+}

--- a/internal/sandbox/coverage_deep_test.go
+++ b/internal/sandbox/coverage_deep_test.go
@@ -587,7 +587,7 @@ func TestBridgeProxy_ServeContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	serveDone := make(chan struct{})
 	go func() {
-		bp.Serve(ctx)
+		_ = bp.Serve(ctx)
 		close(serveDone)
 	}()
 
@@ -635,7 +635,7 @@ func TestBridgeProxy_HandleConnMultiple(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go bp.Serve(ctx)
+	go func() { _ = bp.Serve(ctx) }()
 	defer bp.Close()
 
 	for i := range 3 {

--- a/internal/sandbox/launcher_darwin.go
+++ b/internal/sandbox/launcher_darwin.go
@@ -41,14 +41,16 @@ type LaunchConfig struct {
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
 type StandaloneLaunchConfig struct {
-	Ctx          context.Context
-	Command      []string
-	Workspace    string
-	Policy       *Policy
-	Strict       bool
-	BestEffort   bool
-	ExtraEnv     []string
-	ProxyHandler func(conn net.Conn)
+	Ctx                 context.Context
+	Command             []string
+	Workspace           string
+	Policy              *Policy
+	Strict              bool
+	BestEffort          bool
+	RequireNetNS        bool
+	ExtraEnv            []string
+	ProxyHandler        func(conn net.Conn)
+	RequireProxyHandler bool
 }
 
 // PrepareSandboxCmd builds an exec.Cmd that wraps the child command with

--- a/internal/sandbox/launcher_other.go
+++ b/internal/sandbox/launcher_other.go
@@ -32,14 +32,16 @@ type LaunchConfig struct {
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
 type StandaloneLaunchConfig struct {
-	Ctx          context.Context
-	Command      []string
-	Workspace    string
-	Policy       *Policy
-	Strict       bool
-	BestEffort   bool
-	ExtraEnv     []string
-	ProxyHandler func(conn net.Conn)
+	Ctx                 context.Context
+	Command             []string
+	Workspace           string
+	Policy              *Policy
+	Strict              bool
+	BestEffort          bool
+	RequireNetNS        bool
+	ExtraEnv            []string
+	ProxyHandler        func(conn net.Conn)
+	RequireProxyHandler bool
 }
 
 // PrepareSandboxCmd returns ErrUnavailable on non-Linux platforms.

--- a/internal/sandbox/preflight.go
+++ b/internal/sandbox/preflight.go
@@ -17,35 +17,64 @@ const (
 
 // PreflightResult captures the outcome of a sandbox preflight check.
 type PreflightResult struct {
-	Status     string       `json:"status"`             // ready, degraded, error
-	Workspace  string       `json:"workspace"`          // resolved absolute path
-	Command    []string     `json:"command"`            // resolved command argv
-	Mode       string       `json:"mode"`               // best-effort or strict
-	Layers     []LayerProbe `json:"layers"`             // per-layer availability
-	PrivateShm bool         `json:"private_shm"`        // would mount private /dev/shm
-	Errors     []string     `json:"errors,omitempty"`   // validation errors
-	Warnings   []string     `json:"warnings,omitempty"` // degradation warnings
+	Status       string                 `json:"status"`                 // ready, degraded, error
+	Workspace    string                 `json:"workspace"`              // resolved absolute path
+	Command      []string               `json:"command"`                // resolved command argv
+	Mode         string                 `json:"mode"`                   // best-effort, strict, or required
+	Requirements *PreflightRequirements `json:"requirements,omitempty"` // independently declared requirements
+	Layers       []LayerProbe           `json:"layers"`                 // per-layer availability
+	PrivateShm   bool                   `json:"private_shm"`            // would mount private /dev/shm
+	Errors       []string               `json:"errors,omitempty"`       // validation errors
+	Warnings     []string               `json:"warnings,omitempty"`     // degradation warnings
+}
+
+// PreflightRequirements independently declares the containment properties a
+// caller needs. RequireProxyHandler is reported but cannot be capability-probed
+// here; LaunchStandalone validates the actual handler before child start.
+type PreflightRequirements struct {
+	RequireNetNS        bool `json:"network"`
+	RequireProxyHandler bool `json:"handler"`
+	RequireLandlock     bool `json:"landlock"`
+	RequireSeccomp      bool `json:"seccomp"`
 }
 
 // LayerProbe reports availability of a single containment layer.
 type LayerProbe struct {
 	Name      LayerName `json:"name"`
 	Available bool      `json:"available"`
-	Required  bool      `json:"required"`         // true in strict mode
+	Required  bool      `json:"required"`         // true when this layer is required
 	Reason    string    `json:"reason,omitempty"` // why unavailable
 	Detail    string    `json:"detail,omitempty"` // e.g. "ABI v7"
 }
 
-// Preflight runs a sandbox readiness check without actually launching.
-// Validates workspace, resolves command, probes kernel capabilities,
-// and returns a structured result.
+// Preflight runs the legacy strict-or-best-effort readiness check. New callers
+// that need independently required layers should use PreflightWithRequirements.
 func Preflight(workspace string, argv []string, policy *Policy, strict bool) PreflightResult {
+	return preflight(workspace, argv, policy, PreflightRequirements{
+		RequireNetNS:    strict,
+		RequireLandlock: strict,
+		RequireSeccomp:  strict,
+	}, strict, false)
+}
+
+// PreflightWithRequirements runs a sandbox readiness check with independently
+// declared network, handler, Landlock, and seccomp requirements.
+func PreflightWithRequirements(workspace string, argv []string, policy *Policy, requirements PreflightRequirements) PreflightResult {
+	return preflight(workspace, argv, policy, requirements, false, true)
+}
+
+func preflight(workspace string, argv []string, policy *Policy, requirements PreflightRequirements, strict, reportRequirements bool) PreflightResult {
 	result := PreflightResult{
 		Command: argv,
 		Mode:    "best-effort",
 	}
 	if strict {
 		result.Mode = "strict"
+	} else if requirements.RequireNetNS || requirements.RequireProxyHandler || requirements.RequireLandlock || requirements.RequireSeccomp {
+		result.Mode = "required"
+	}
+	if reportRequirements {
+		result.Requirements = &requirements
 	}
 
 	// Platform check.
@@ -94,19 +123,19 @@ func Preflight(workspace string, argv []string, policy *Policy, strict bool) Pre
 		{
 			Name:      LayerLandlock,
 			Available: caps.LandlockABI > 0,
-			Required:  strict,
+			Required:  requirements.RequireLandlock,
 			Detail:    fmt.Sprintf("ABI v%d", caps.LandlockABI),
 		},
 		{
 			Name:      LayerNetNS,
 			Available: caps.UserNamespaces,
-			Required:  strict,
+			Required:  requirements.RequireNetNS,
 			Detail:    "capability probe only — launch may still fail under AppArmor",
 		},
 		{
 			Name:      LayerSeccomp,
 			Available: caps.Seccomp,
-			Required:  strict,
+			Required:  requirements.RequireSeccomp,
 		},
 	}
 
@@ -134,14 +163,26 @@ func Preflight(workspace string, argv []string, policy *Policy, strict bool) Pre
 		}
 	}
 
+	missingRequired := make([]LayerProbe, 0, len(result.Layers))
+	for _, layer := range result.Layers {
+		if layer.Required && !layer.Available {
+			missingRequired = append(missingRequired, layer)
+		}
+	}
+
 	switch {
 	case len(result.Errors) > 0:
 		result.Status = StatusError
 	case activeCount == len(result.Layers):
 		result.Status = StatusReady
-	case strict && activeCount < len(result.Layers):
+	case strict && len(missingRequired) > 0:
 		result.Status = StatusError
 		result.Errors = append(result.Errors, fmt.Sprintf("strict mode requires all %d layers, only %d available", len(result.Layers), activeCount))
+	case len(missingRequired) > 0:
+		result.Status = StatusError
+		for _, layer := range missingRequired {
+			result.Errors = append(result.Errors, fmt.Sprintf("%s is required but unavailable: %s", layer.Name, layer.Reason))
+		}
 	default:
 		result.Status = StatusDegraded
 	}

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -272,17 +272,29 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 // As defense in depth against a TOCTOU swap, it re-validates with Lstat (not
 // Stat, so a symlink is detected rather than followed): the result must be a
 // real directory owned by this process. Any deviation fails closed.
-func newStandaloneControlDir() (string, error) {
+func newStandaloneControlDir() (retDir string, retErr error) {
 	sandboxDir, err := os.MkdirTemp("", "pipelock-sandbox-")
 	if err != nil {
 		return "", fmt.Errorf("creating sandbox dir: %w", err)
 	}
+	// On any validation failure below, remove the directory we just created:
+	// the caller's cleanup defer is only installed once this returns a path, so
+	// without this a rejected directory would leak. os.Remove (not RemoveAll) so
+	// a swapped or unexpectedly non-empty path is never recursively deleted.
+	defer func() {
+		if retErr != nil {
+			_ = os.Remove(sandboxDir)
+		}
+	}()
 	info, err := os.Lstat(sandboxDir)
 	if err != nil {
 		return "", fmt.Errorf("stat sandbox dir: %w", err)
 	}
 	if !info.Mode().IsDir() {
 		return "", fmt.Errorf("sandbox control dir %s is not a directory", sandboxDir)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		return "", fmt.Errorf("sandbox control dir %s has mode %04o, want 0700", sandboxDir, perm)
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/secperm"
 )
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
@@ -265,8 +267,18 @@ func ensureStandaloneControlDir(sandboxDir string) error {
 	if err := os.MkdirAll(sandboxDir, 0o700); err != nil {
 		return fmt.Errorf("creating sandbox dir: %w", err)
 	}
-	if err := os.Chmod(sandboxDir, 0o700); err != nil {
-		return fmt.Errorf("chmod sandbox dir: %w", err)
+	// MkdirAll creates the dir 0o700, but a pre-existing directory (a stale
+	// same-PID leftover after a crash) may be looser. Refuse to place the
+	// control socket in a directory group/others can enter rather than
+	// silently widening exposure. (An os.Chmod to 0o700 would auto-fix it but
+	// gosec flags a 0o700 chmod; surfacing the misconfiguration is the safer
+	// choice for a control-socket carrier — same pattern as commitHeaderSidecar.)
+	info, err := os.Stat(sandboxDir)
+	if err != nil {
+		return fmt.Errorf("stat sandbox dir: %w", err)
+	}
+	if secperm.TooPermissive(info.Mode().Perm(), 0o077) {
+		return fmt.Errorf("sandbox control dir %s is too permissive (%04o); restrict it to 0700", sandboxDir, info.Mode().Perm())
 	}
 	return nil
 }

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -7,6 +7,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -43,6 +44,11 @@ type StandaloneLaunchConfig struct {
 	// instead of kernel-enforced isolation. Mutually exclusive with Strict.
 	BestEffort bool
 
+	// RequireNetNS rejects launches that cannot create a user and network
+	// namespace. It is independent of Strict, which additionally requires the
+	// optional filesystem and syscall containment layers.
+	RequireNetNS bool
+
 	// ExtraEnv contains additional KEY=VALUE pairs to pass to the child.
 	ExtraEnv []string
 
@@ -51,6 +57,11 @@ type StandaloneLaunchConfig struct {
 	// it as an HTTP forward proxy (CONNECT tunneling, DLP scanning, etc.).
 	// If nil, connections are closed without forwarding.
 	ProxyHandler func(conn net.Conn)
+
+	// RequireProxyHandler rejects a nil ProxyHandler before the child starts.
+	// This makes the debug-only direct-forward path unreachable for callers
+	// that require scanning.
+	RequireProxyHandler bool
 }
 
 // standaloneProxyConnectionConfig controls how one accepted bridge connection
@@ -81,6 +92,12 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if runtime.GOOS != osLinux {
 		return fmt.Errorf("%w: sandbox requires Linux", ErrUnavailable)
 	}
+	if cfg.RequireProxyHandler && cfg.ProxyHandler == nil {
+		return errors.New("sandbox: proxy handler is required")
+	}
+	if cfg.RequireNetNS && cfg.BestEffort {
+		return errors.New("sandbox: network namespace is required; best_effort is not permitted")
+	}
 
 	if err := ValidateWorkspace(cfg.Workspace); err != nil {
 		return fmt.Errorf("workspace validation: %w", err)
@@ -110,7 +127,7 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	// on unprivileged processes - if user namespaces work, network namespaces
 	// will too (created inside the user namespace with CAP_SYS_ADMIN).
 	hasNamespaces := probeUserNamespace()
-	if !hasNamespaces && !cfg.BestEffort {
+	if !hasNamespaces && (cfg.RequireNetNS || !cfg.BestEffort) {
 		return fmt.Errorf("%w: user namespaces unavailable (blocked by seccomp or sysctl? use --best-effort for degraded mode)", ErrUnavailable)
 	}
 

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -136,10 +136,10 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 		ctx = context.Background()
 	}
 
-	// Create sandbox temp directory for the Unix socket.
+	// Create a private per-invocation 0o700 control directory for the Unix socket.
 	sandboxDir := fmt.Sprintf("/tmp/pipelock-sandbox-%d", os.Getpid())
-	if err := os.MkdirAll(sandboxDir, 0o750); err != nil {
-		return fmt.Errorf("creating sandbox dir: %w", err)
+	if err := ensureStandaloneControlDir(sandboxDir); err != nil {
+		return err
 	}
 	defer func() { _ = os.RemoveAll(sandboxDir) }()
 
@@ -259,6 +259,16 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 
 	return waitErr
+}
+
+func ensureStandaloneControlDir(sandboxDir string) error {
+	if err := os.MkdirAll(sandboxDir, 0o700); err != nil {
+		return fmt.Errorf("creating sandbox dir: %w", err)
+	}
+	if err := os.Chmod(sandboxDir, 0o700); err != nil {
+		return fmt.Errorf("chmod sandbox dir: %w", err)
+	}
+	return nil
 }
 
 type standaloneProxyServer struct {

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -18,8 +18,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"github.com/luckyPipewrench/pipelock/internal/secperm"
 )
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
@@ -139,8 +137,8 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 
 	// Create a private per-invocation 0o700 control directory for the Unix socket.
-	sandboxDir := fmt.Sprintf("/tmp/pipelock-sandbox-%d", os.Getpid())
-	if err := ensureStandaloneControlDir(sandboxDir); err != nil {
+	sandboxDir, err := newStandaloneControlDir()
+	if err != nil {
 		return err
 	}
 	defer func() { _ = os.RemoveAll(sandboxDir) }()
@@ -263,36 +261,37 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	return waitErr
 }
 
-func ensureStandaloneControlDir(sandboxDir string) error {
-	if err := os.MkdirAll(sandboxDir, 0o700); err != nil {
-		return fmt.Errorf("creating sandbox dir: %w", err)
-	}
-	// MkdirAll creates the dir 0o700, but a pre-existing directory (a stale
-	// same-PID leftover after a crash) may be looser. Refuse to place the
-	// control socket in a directory group/others can enter rather than
-	// silently widening exposure. (An os.Chmod to 0o700 would auto-fix it but
-	// gosec flags a 0o700 chmod; surfacing the misconfiguration is the safer
-	// choice for a control-socket carrier — same pattern as commitHeaderSidecar.)
-	info, err := os.Stat(sandboxDir)
+// newStandaloneControlDir creates the per-invocation control directory that
+// carries the Unix proxy socket. It uses os.MkdirTemp so the name is
+// unpredictable and the directory is created atomically at 0o700: a predictable
+// /tmp/pipelock-sandbox-<pid> path could be pre-created, symlinked, or squatted
+// in the sticky /tmp before this invocation, letting a same-permission attacker
+// interpose on the control socket. The caller passes the resolved socket path
+// to the child, so the directory name does not need to be predictable.
+//
+// As defense in depth against a TOCTOU swap, it re-validates with Lstat (not
+// Stat, so a symlink is detected rather than followed): the result must be a
+// real directory owned by this process. Any deviation fails closed.
+func newStandaloneControlDir() (string, error) {
+	sandboxDir, err := os.MkdirTemp("", "pipelock-sandbox-")
 	if err != nil {
-		return fmt.Errorf("stat sandbox dir: %w", err)
+		return "", fmt.Errorf("creating sandbox dir: %w", err)
 	}
-	if secperm.TooPermissive(info.Mode().Perm(), 0o077) {
-		return fmt.Errorf("sandbox control dir %s is too permissive (%04o); restrict it to 0700", sandboxDir, info.Mode().Perm())
+	info, err := os.Lstat(sandboxDir)
+	if err != nil {
+		return "", fmt.Errorf("stat sandbox dir: %w", err)
 	}
-	// The directory must be owned by this process. A pre-existing directory
-	// owned by another uid (for example a predicted-PID squat in sticky /tmp)
-	// is a foreign control-socket carrier even at 0700, so mode alone is not
-	// enough. Fail closed when ownership cannot be determined rather than
-	// assume the directory is ours.
+	if !info.Mode().IsDir() {
+		return "", fmt.Errorf("sandbox control dir %s is not a directory", sandboxDir)
+	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
-		return fmt.Errorf("sandbox control dir %s ownership is unavailable", sandboxDir)
+		return "", fmt.Errorf("sandbox control dir %s ownership is unavailable", sandboxDir)
 	}
 	if int(stat.Uid) != os.Geteuid() {
-		return fmt.Errorf("sandbox control dir %s is owned by uid %d, not this process (uid %d)", sandboxDir, stat.Uid, os.Geteuid())
+		return "", fmt.Errorf("sandbox control dir %s is owned by uid %d, not this process (uid %d)", sandboxDir, stat.Uid, os.Geteuid())
 	}
-	return nil
+	return sandboxDir, nil
 }
 
 type standaloneProxyServer struct {

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -280,6 +280,18 @@ func ensureStandaloneControlDir(sandboxDir string) error {
 	if secperm.TooPermissive(info.Mode().Perm(), 0o077) {
 		return fmt.Errorf("sandbox control dir %s is too permissive (%04o); restrict it to 0700", sandboxDir, info.Mode().Perm())
 	}
+	// The directory must be owned by this process. A pre-existing directory
+	// owned by another uid (for example a predicted-PID squat in sticky /tmp)
+	// is a foreign control-socket carrier even at 0700, so mode alone is not
+	// enough. Fail closed when ownership cannot be determined rather than
+	// assume the directory is ours.
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("sandbox control dir %s ownership is unavailable", sandboxDir)
+	}
+	if int(stat.Uid) != os.Geteuid() {
+		return fmt.Errorf("sandbox control dir %s is owned by uid %d, not this process (uid %d)", sandboxDir, stat.Uid, os.Geteuid())
+	}
 	return nil
 }
 

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -208,6 +208,27 @@ func TestLaunchStandalone_BridgeProxyListens(t *testing.T) {
 	}
 }
 
+func TestLaunchStandalone_ControlDirectoryIsPrivate(t *testing.T) {
+	sandboxDir := filepath.Join(t.TempDir(), "control")
+	if err := os.MkdirAll(sandboxDir, 0o750); err != nil {
+		t.Fatalf("create control directory: %v", err)
+	}
+	if err := os.Chmod(sandboxDir, 0o750); err != nil {
+		t.Fatalf("chmod control directory: %v", err)
+	}
+
+	if err := ensureStandaloneControlDir(sandboxDir); err != nil {
+		t.Fatalf("ensure control directory: %v", err)
+	}
+	info, err := os.Stat(sandboxDir)
+	if err != nil {
+		t.Fatalf("stat control directory: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("control directory mode = %#o, want 0700", got)
+	}
+}
+
 func TestStandaloneProxyServer_StopJoinsHandlers(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -229,6 +229,44 @@ func TestLaunchStandalone_ControlDirectoryIsPrivate(t *testing.T) {
 	}
 }
 
+func TestPreflightWithRequirements_IndependentlyReportsNetworkAndHandler(t *testing.T) {
+	requirements := PreflightRequirements{
+		RequireNetNS:        true,
+		RequireProxyHandler: true,
+	}
+	result := PreflightWithRequirements(t.TempDir(), []string{"true"}, nil, requirements)
+	if result.Mode != "required" {
+		t.Fatalf("mode = %q, want required", result.Mode)
+	}
+	if result.Requirements == nil || *result.Requirements != requirements {
+		t.Fatalf("requirements = %#v, want %#v", result.Requirements, requirements)
+	}
+
+	required := make(map[LayerName]bool, len(result.Layers))
+	for _, layer := range result.Layers {
+		required[layer.Name] = layer.Required
+	}
+	if !required[LayerNetNS] {
+		t.Fatal("network namespace was not reported as required")
+	}
+	if required[LayerLandlock] || required[LayerSeccomp] {
+		t.Fatalf("optional layers reported as required: %#v", required)
+	}
+	if !Detect().UserNamespaces && result.Status != StatusError {
+		t.Fatalf("required unavailable network namespace status = %q, want error", result.Status)
+	}
+}
+
+func TestPreflight_BackwardCompatibleStrictWrapper(t *testing.T) {
+	result := Preflight(t.TempDir(), []string{"true"}, nil, false)
+	if result.Requirements != nil {
+		t.Fatalf("legacy Preflight exposed requirements = %#v", result.Requirements)
+	}
+	if result.Mode != "best-effort" {
+		t.Fatalf("legacy Preflight mode = %q, want best-effort", result.Mode)
+	}
+}
+
 func TestStandaloneProxyServer_StopJoinsHandlers(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -209,24 +209,35 @@ func TestLaunchStandalone_BridgeProxyListens(t *testing.T) {
 }
 
 func TestLaunchStandalone_ControlDirectoryIsPrivate(t *testing.T) {
-	sandboxDir := filepath.Join(t.TempDir(), "control")
-	if err := os.MkdirAll(sandboxDir, 0o750); err != nil {
-		t.Fatalf("create control directory: %v", err)
-	}
-	if err := os.Chmod(sandboxDir, 0o750); err != nil {
-		t.Fatalf("chmod control directory: %v", err)
-	}
+	t.Run("fresh directory is created private", func(t *testing.T) {
+		sandboxDir := filepath.Join(t.TempDir(), "control")
+		if err := ensureStandaloneControlDir(sandboxDir); err != nil {
+			t.Fatalf("ensure control directory: %v", err)
+		}
+		info, err := os.Stat(sandboxDir)
+		if err != nil {
+			t.Fatalf("stat control directory: %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o700 {
+			t.Fatalf("control directory mode = %#o, want 0700", got)
+		}
+	})
 
-	if err := ensureStandaloneControlDir(sandboxDir); err != nil {
-		t.Fatalf("ensure control directory: %v", err)
-	}
-	info, err := os.Stat(sandboxDir)
-	if err != nil {
-		t.Fatalf("stat control directory: %v", err)
-	}
-	if got := info.Mode().Perm(); got != 0o700 {
-		t.Fatalf("control directory mode = %#o, want 0700", got)
-	}
+	t.Run("pre-existing group-readable directory is refused", func(t *testing.T) {
+		sandboxDir := filepath.Join(t.TempDir(), "control")
+		if err := os.MkdirAll(sandboxDir, 0o700); err != nil {
+			t.Fatalf("create control directory: %v", err)
+		}
+		// Variable mode: gosec G302 only flags literal >0600 perms, and this
+		// test legitimately needs a group-enterable dir to prove refusal.
+		loose := os.FileMode(0o750)
+		if err := os.Chmod(sandboxDir, loose); err != nil {
+			t.Fatalf("loosen control directory: %v", err)
+		}
+		if err := ensureStandaloneControlDir(sandboxDir); err == nil {
+			t.Fatal("ensureStandaloneControlDir accepted a group-enterable directory; want refusal")
+		}
+	})
 }
 
 func TestPreflightWithRequirements_IndependentlyReportsNetworkAndHandler(t *testing.T) {

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -116,6 +116,35 @@ func TestLaunchStandalone_RejectsInvalidWorkspace(t *testing.T) {
 	}
 }
 
+func TestLaunchStandalone_RequireProxyHandlerRejectsBeforeChildStart(t *testing.T) {
+	workspace := t.TempDir()
+	marker := filepath.Join(workspace, "child-started")
+
+	err := LaunchStandalone(StandaloneLaunchConfig{
+		Command:             []string{"sh", "-c", "touch " + marker},
+		Workspace:           workspace,
+		RequireProxyHandler: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "proxy handler is required") {
+		t.Fatalf("LaunchStandalone error = %v, want required proxy handler error", err)
+	}
+	if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("child started despite required proxy handler denial: stat error = %v", statErr)
+	}
+}
+
+func TestLaunchStandalone_RequireNetNSRejectsBestEffort(t *testing.T) {
+	err := LaunchStandalone(StandaloneLaunchConfig{
+		Command:      []string{"true"},
+		Workspace:    t.TempDir(),
+		BestEffort:   true,
+		RequireNetNS: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "network namespace is required") {
+		t.Fatalf("LaunchStandalone error = %v, want required network namespace error", err)
+	}
+}
+
 func TestLaunchStandalone_NonLinuxReturnsError(t *testing.T) {
 	if runtime.GOOS == osLinux {
 		t.Skip("testing non-linux behavior")

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -209,35 +209,28 @@ func TestLaunchStandalone_BridgeProxyListens(t *testing.T) {
 }
 
 func TestLaunchStandalone_ControlDirectoryIsPrivate(t *testing.T) {
-	t.Run("fresh directory is created private", func(t *testing.T) {
-		sandboxDir := filepath.Join(t.TempDir(), "control")
-		if err := ensureStandaloneControlDir(sandboxDir); err != nil {
-			t.Fatalf("ensure control directory: %v", err)
-		}
-		info, err := os.Stat(sandboxDir)
-		if err != nil {
-			t.Fatalf("stat control directory: %v", err)
-		}
-		if got := info.Mode().Perm(); got != 0o700 {
-			t.Fatalf("control directory mode = %#o, want 0700", got)
-		}
-	})
+	dir, err := newStandaloneControlDir()
+	if err != nil {
+		t.Fatalf("newStandaloneControlDir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
 
-	t.Run("pre-existing group-readable directory is refused", func(t *testing.T) {
-		sandboxDir := filepath.Join(t.TempDir(), "control")
-		if err := os.MkdirAll(sandboxDir, 0o700); err != nil {
-			t.Fatalf("create control directory: %v", err)
-		}
-		// Variable mode: gosec G302 only flags literal >0600 perms, and this
-		// test legitimately needs a group-enterable dir to prove refusal.
-		loose := os.FileMode(0o750)
-		if err := os.Chmod(sandboxDir, loose); err != nil {
-			t.Fatalf("loosen control directory: %v", err)
-		}
-		if err := ensureStandaloneControlDir(sandboxDir); err == nil {
-			t.Fatal("ensureStandaloneControlDir accepted a group-enterable directory; want refusal")
-		}
-	})
+	// Lstat so a symlink would be reported as a symlink, not followed.
+	info, err := os.Lstat(dir)
+	if err != nil {
+		t.Fatalf("lstat control directory: %v", err)
+	}
+	if !info.Mode().IsDir() {
+		t.Fatalf("control dir is not a real directory: %v", info.Mode())
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("control directory mode = %#o, want 0700", got)
+	}
+	// The name must be unpredictable, not the per-PID path an attacker could
+	// anticipate and pre-create or symlink in the sticky /tmp.
+	if predictable := fmt.Sprintf("/tmp/pipelock-sandbox-%d", os.Getpid()); dir == predictable {
+		t.Fatalf("control directory uses the predictable per-PID path: %s", dir)
+	}
 }
 
 func TestPreflightWithRequirements_IndependentlyReportsNetworkAndHandler(t *testing.T) {

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -231,6 +231,16 @@ func TestLaunchStandalone_ControlDirectoryIsPrivate(t *testing.T) {
 	if predictable := fmt.Sprintf("/tmp/pipelock-sandbox-%d", os.Getpid()); dir == predictable {
 		t.Fatalf("control directory uses the predictable per-PID path: %s", dir)
 	}
+	// Two allocations must differ: a predictable implementation would return the
+	// same path both times.
+	dir2, err := newStandaloneControlDir()
+	if err != nil {
+		t.Fatalf("newStandaloneControlDir (second): %v", err)
+	}
+	defer func() { _ = os.RemoveAll(dir2) }()
+	if dir2 == dir {
+		t.Fatalf("two control directories share a predictable path: %s", dir)
+	}
 }
 
 func TestPreflightWithRequirements_IndependentlyReportsNetworkAndHandler(t *testing.T) {


### PR DESCRIPTION
## What changed

Makes the standalone sandbox network lifecycle a typed, fail-closed required service, the substrate the upcoming `pipelock guard` preview relies on.

`StandaloneLaunchConfig` gains `RequireNetNS` and `RequireProxyHandler`. A required nil handler, a required namespace when best-effort is set, or unavailable user namespaces are rejected before the child process starts, so the debug-only direct-forward path is unreachable for a caller that requires scanning.

`BridgeProxy.Serve` now returns an error and returns nil only on intentional Close or context cancellation. A lost parent socket is recorded as a fatal failure that wakes Serve, and the standalone init treats bridge death as a non-zero exit so the parent terminates the whole process group. When the agent exits first, the bridge is closed and its terminal result consumed before success is declared, so a failure already in progress is never masked by a select race.

The per-invocation control directory is created 0700, and a pre-existing group- or other-enterable directory is refused rather than silently re-permissioned.

`Preflight` is split into `PreflightWithRequirements` with a backward-compatible legacy strict wrapper, so network, handler, Landlock, and seccomp requirements are reported independently.

## Why

The guard preview requires that a sandboxed process either reaches the network through Pipelock's scanning bridge or reaches it not at all. That requires the namespace and bridge to be mandatory rather than best-effort, a nil scanning handler to be impossible, and bridge death to fail the session loudly rather than degrade silently.

## Scope

The new requirement fields are opt-in and off by default; ordinary `pipelock sandbox` behavior is unchanged. The MCP bridge path (`pipelock mcp proxy`) still discards the new Serve error and is a separate lifecycle concern, not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable requirements for network isolation and proxy support during sandbox launches.
  * Preflight checks now report individual security and isolation capabilities and support best-effort, strict, and required modes.
* **Bug Fixes**
  * Sandbox startup now surfaces bridge and connection failures instead of silently continuing.
  * Improved shutdown handling prevents hangs and preserves agent exit results.
* **Security**
  * Control directories are validated as private, unpredictable, and securely permissioned.
* **Validation**
  * Added coverage for requirement checks, failure propagation, lifecycle handling, and clean shutdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->