### PR TITLE
feat(sandbox): transport the developer environment over a secret-safe pipe

### DIFF
--- a/internal/sandbox/child_environment_test.go
+++ b/internal/sandbox/child_environment_test.go
@@ -13,6 +13,7 @@ const (
 	childCommandEnv   = "__PIPELOCK_SANDBOX_COMMAND"
 	childExtraEnv     = "__PIPELOCK_SANDBOX_EXTRA_ENV"
 	childPolicyEnv    = "__PIPELOCK_SANDBOX_POLICY"
+	childDeveloperEnv = developerEnvironmentControlEnv
 )
 
 func initChildEnvironment(overrides []string) []string {
@@ -26,6 +27,7 @@ func initChildEnvironment(overrides []string) []string {
 		childCommandEnv:   {},
 		childExtraEnv:     {},
 		childPolicyEnv:    {},
+		childDeveloperEnv: {},
 	}
 	for _, entry := range overrides {
 		key, _, _ := strings.Cut(entry, "=")

--- a/internal/sandbox/child_init.go
+++ b/internal/sandbox/child_init.go
@@ -285,11 +285,17 @@ func appendBridgeProxyEnv(env []string, addr string) []string {
 	env = removeProxyEnvKeys(env)
 	// addr comes from BridgeProxy.Addr(), so it is a listener-backed host:port.
 	proxyURL := "http://" + addr
+	// Force NO_PROXY empty for the same reason DeveloperEnv does: a caller- or
+	// image-supplied NO_PROXY would let the agent bypass the bridge for matching
+	// hosts. removeProxyEnvKeys strips *_PROXY (including NO_PROXY), and these
+	// re-add the bridge settings with an explicit empty NO_PROXY.
 	return append(env,
 		"HTTP_PROXY="+proxyURL,
 		"HTTPS_PROXY="+proxyURL,
 		"http_proxy="+proxyURL,
 		"https_proxy="+proxyURL,
+		"NO_PROXY=",
+		"no_proxy=",
 	)
 }
 

--- a/internal/sandbox/child_init.go
+++ b/internal/sandbox/child_init.go
@@ -282,21 +282,26 @@ func exitBridgeChild(err error) {
 }
 
 func appendBridgeProxyEnv(env []string, addr string) []string {
-	env = removeProxyEnvKeys(env)
-	// addr comes from BridgeProxy.Addr(), so it is a listener-backed host:port.
+	// removeProxyEnvKeys strips *_PROXY (including NO_PROXY); bridgeProxyEnv then
+	// re-adds the bridge settings with an explicit empty NO_PROXY.
+	return append(removeProxyEnvKeys(env), bridgeProxyEnv(addr)...)
+}
+
+// bridgeProxyEnv returns the proxy entries that route all HTTP(S) egress through
+// the bridge and clear NO_PROXY so nothing bypasses it. Both the synthetic-env
+// path (appendBridgeProxyEnv) and the developer-env path (DeveloperEnv) use this
+// single source so the two cannot drift and reintroduce a proxy bypass. addr
+// comes from BridgeProxy.Addr(), a listener-backed host:port.
+func bridgeProxyEnv(addr string) []string {
 	proxyURL := "http://" + addr
-	// Force NO_PROXY empty for the same reason DeveloperEnv does: a caller- or
-	// image-supplied NO_PROXY would let the agent bypass the bridge for matching
-	// hosts. removeProxyEnvKeys strips *_PROXY (including NO_PROXY), and these
-	// re-add the bridge settings with an explicit empty NO_PROXY.
-	return append(env,
-		"HTTP_PROXY="+proxyURL,
-		"HTTPS_PROXY="+proxyURL,
-		"http_proxy="+proxyURL,
-		"https_proxy="+proxyURL,
+	return []string{
+		"HTTP_PROXY=" + proxyURL,
+		"HTTPS_PROXY=" + proxyURL,
+		"http_proxy=" + proxyURL,
+		"https_proxy=" + proxyURL,
 		"NO_PROXY=",
 		"no_proxy=",
-	)
+	}
 }
 
 func removeProxyEnvKeys(env []string) []string {

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -28,6 +28,7 @@ func RunStandaloneInit() {
 	commandStr := os.Getenv("__PIPELOCK_SANDBOX_COMMAND")
 	socketPath := os.Getenv(sandboxSocketEnv)
 	extraEnvStr := os.Getenv("__PIPELOCK_SANDBOX_EXTRA_ENV")
+	developerEnvFDStr := os.Getenv(developerEnvironmentControlEnv)
 
 	if workspace == "" || commandStr == "" || socketPath == "" {
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] missing workspace, command, or socket path\n")
@@ -40,6 +41,21 @@ func RunStandaloneInit() {
 		extraEnv = strings.Split(extraEnvStr, "\x1f")
 	}
 
+	var developerEnvironment []string
+	useDeveloperEnvironment := developerEnvFDStr != ""
+	if useDeveloperEnvironment {
+		fd, err := developerEnvironmentFDFromControl(developerEnvFDStr)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] developer env transport: %v\n", err)
+			exitSandboxProcess(1)
+		}
+		developerEnvironment, err = readDeveloperEnvironment(fd)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] developer env transport: %v\n", err)
+			exitSandboxProcess(1)
+		}
+	}
+
 	strict := IsStrictMode()
 
 	// Initialize Go's signal thread before RLIMIT_NPROC is lowered. This keeps
@@ -47,14 +63,28 @@ func RunStandaloneInit() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
-	// Build synthetic environment.
 	sandboxDir := fmt.Sprintf("/tmp/pipelock-sandbox-%d", os.Getpid())
-	env, err := SyntheticEnv(sandboxDir, workspace, extraEnv)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] env setup: %v\n", err)
-		exitSandboxProcess(1)
+	var env []string
+	var binary string
+	var err error
+	if useDeveloperEnvironment {
+		// SyntheticEnv normally creates this directory before policy resolution.
+		// The developer path preserves the caller environment instead, but the
+		// Landlock policy still needs its private, non-secret scratch directory.
+		if err := os.MkdirAll(sandboxDir, 0o700); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] developer scratch dir: %v\n", err)
+			exitSandboxProcess(1)
+		}
+		binary, err = lookPathIn(command[0], developerEnvironment)
+	} else {
+		// Build synthetic environment.
+		env, err = SyntheticEnv(sandboxDir, workspace, extraEnv)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] env setup: %v\n", err)
+			exitSandboxProcess(1)
+		}
+		binary, err = lookPathIn(command[0], env)
 	}
-	binary, err := lookPathIn(command[0], env)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command not found: %s (%v)\n", command[0], err)
 		exitSandboxProcess(127)
@@ -172,8 +202,16 @@ func RunStandaloneInit() {
 	}
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] bridge proxy: %s → %s\n", bridge.Addr(), socketPath)
 
-	// Add HTTP_PROXY/HTTPS_PROXY to agent's environment.
-	env = appendBridgeProxyEnv(env, bridge.Addr())
+	if useDeveloperEnvironment {
+		env, err = DeveloperEnv(developerEnvironment, bridge.Addr())
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] env setup: %v\n", err)
+			exitSandboxProcess(1)
+		}
+	} else {
+		// Add HTTP_PROXY/HTTPS_PROXY to agent's environment.
+		env = appendBridgeProxyEnv(env, bridge.Addr())
+	}
 
 	// Clean sandbox env vars.
 	for _, key := range []string{
@@ -181,6 +219,7 @@ func RunStandaloneInit() {
 		"__PIPELOCK_SANDBOX_WORKSPACE", "__PIPELOCK_SANDBOX_COMMAND",
 		sandboxSocketEnv, "__PIPELOCK_SANDBOX_EXTRA_ENV",
 		"__PIPELOCK_SANDBOX_POLICY", noNetNSEnvKey,
+		developerEnvironmentControlEnv,
 	} {
 		env = removeEnvKey(env, key)
 	}

--- a/internal/sandbox/developer_env.go
+++ b/internal/sandbox/developer_env.go
@@ -51,12 +51,10 @@ func DeveloperEnv(developerEnvironment []string, bridgeAddr string) ([]string, e
 		if isPipelockControlEnvKey(key) || isProxyEnvKey(key) {
 			continue
 		}
-		if IsDangerousEnvKey(key) {
-			// Loader/runtime injection is deliberately final-command-only. The
-			// re-exec control environment never contains developer entries.
-			env = append(env, entry)
-			continue
-		}
+		// Loader/runtime injection keys (LD_PRELOAD, NODE_OPTIONS, ...) are kept
+		// for the FINAL command only, which is safe because the re-exec/init
+		// process never receives developer entries. There is no separate
+		// handling to apply, so they are appended like any other developer key.
 		env = append(env, entry)
 	}
 
@@ -101,6 +99,9 @@ func encodeDeveloperEnvironment(environment []string) ([]byte, error) {
 	payload := make([]byte, 12)
 	copy(payload, developerEnvironmentMagic[:])
 	binary.BigEndian.PutUint32(payload[4:8], developerEnvironmentVersion)
+	// Count via a loop rather than uint32(len(environment)): the latter trips
+	// gosec G115 (int->uint32) and the repo bans net-new nolint directives. The
+	// length is already bounded above, so this cannot overflow.
 	count := uint32(0)
 	for range environment {
 		count++
@@ -121,6 +122,8 @@ func encodeDeveloperEnvironment(environment []string) ([]byte, error) {
 			return nil, errors.New("sandbox: developer environment payload exceeds 1 MiB")
 		}
 
+		// Length via a loop for the same gosec G115 / no-nolint reason as the
+		// entry count above; len(entry) is bounded, so it cannot overflow.
 		entryLength := uint32(0)
 		for range len(entry) {
 			entryLength++

--- a/internal/sandbox/developer_env.go
+++ b/internal/sandbox/developer_env.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package sandbox
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	developerEnvironmentMaxPayload = 1 << 20
+	developerEnvironmentVersion    = uint32(1)
+	developerEnvironmentFD         = 3
+)
+
+var developerEnvironmentMagic = [4]byte{'P', 'L', 'K', 'E'}
+
+// DeveloperEnv builds the environment for the final contained command from a
+// caller-supplied developer environment. It intentionally preserves developer
+// credentials and toolchain settings, including loader/runtime variables: the
+// sandbox init process never receives those variables, and this function is
+// called only after containment is established for the final command.
+//
+// Pipelock control and proxy variables are removed. The bridge proxy settings
+// are then forced so the final command cannot inherit a caller-controlled
+// proxy or NO_PROXY bypass.
+func DeveloperEnv(developerEnvironment []string, bridgeAddr string) ([]string, error) {
+	if bridgeAddr == "" {
+		return nil, errors.New("sandbox: bridge address is required for developer environment")
+	}
+
+	env := make([]string, 0, len(developerEnvironment)+6)
+	seen := make(map[string]struct{}, len(developerEnvironment))
+	for _, entry := range developerEnvironment {
+		key, err := validateDeveloperEnvironmentEntry(entry)
+		if err != nil {
+			return nil, err
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return nil, fmt.Errorf("sandbox: duplicate developer environment key %q", key)
+		}
+		seen[key] = struct{}{}
+
+		if isPipelockControlEnvKey(key) || isProxyEnvKey(key) {
+			continue
+		}
+		env = append(env, entry)
+	}
+
+	proxyURL := "http://" + bridgeAddr
+	return append(env,
+		"HTTP_PROXY="+proxyURL,
+		"HTTPS_PROXY="+proxyURL,
+		"http_proxy="+proxyURL,
+		"https_proxy="+proxyURL,
+		"NO_PROXY=",
+		"no_proxy=",
+	), nil
+}
+
+func isPipelockControlEnvKey(key string) bool {
+	return strings.HasPrefix(strings.ToUpper(key), "__PIPELOCK_")
+}
+
+func isProxyEnvKey(key string) bool {
+	return strings.HasSuffix(strings.ToUpper(key), "_PROXY")
+}
+
+func validateDeveloperEnvironmentEntry(entry string) (string, error) {
+	key, _, ok := strings.Cut(entry, "=")
+	if !ok || key == "" {
+		return "", fmt.Errorf("sandbox: malformed developer environment entry %q", entry)
+	}
+	if strings.IndexByte(entry, 0) >= 0 {
+		return "", fmt.Errorf("sandbox: developer environment entry %q contains NUL", key)
+	}
+	return key, nil
+}
+
+// encodeDeveloperEnvironment serializes a complete environment using a
+// length-prefixed binary format. It never uses environment delimiters, because
+// values may legitimately contain newlines, equals signs, and unit separators.
+func encodeDeveloperEnvironment(environment []string) ([]byte, error) {
+	if len(environment) > developerEnvironmentMaxPayload/4 {
+		return nil, errors.New("sandbox: developer environment has too many entries")
+	}
+
+	payload := make([]byte, 12)
+	copy(payload, developerEnvironmentMagic[:])
+	binary.BigEndian.PutUint32(payload[4:8], developerEnvironmentVersion)
+	binary.BigEndian.PutUint32(payload[8:12], uint32(len(environment)))
+
+	seen := make(map[string]struct{}, len(environment))
+	for _, entry := range environment {
+		key, err := validateDeveloperEnvironmentEntry(entry)
+		if err != nil {
+			return nil, err
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return nil, fmt.Errorf("sandbox: duplicate developer environment key %q", key)
+		}
+		seen[key] = struct{}{}
+		if len(entry) > developerEnvironmentMaxPayload || len(payload) > developerEnvironmentMaxPayload-4-len(entry) {
+			return nil, errors.New("sandbox: developer environment payload exceeds 1 MiB")
+		}
+
+		var length [4]byte
+		binary.BigEndian.PutUint32(length[:], uint32(len(entry)))
+		payload = append(payload, length[:]...)
+		payload = append(payload, entry...)
+	}
+
+	return payload, nil
+}
+
+func decodeDeveloperEnvironment(payload []byte) ([]string, error) {
+	if len(payload) > developerEnvironmentMaxPayload {
+		return nil, errors.New("sandbox: developer environment payload exceeds 1 MiB")
+	}
+	if len(payload) < 12 || string(payload[:4]) != string(developerEnvironmentMagic[:]) {
+		return nil, errors.New("sandbox: malformed developer environment payload")
+	}
+	if binary.BigEndian.Uint32(payload[4:8]) != developerEnvironmentVersion {
+		return nil, errors.New("sandbox: unsupported developer environment payload version")
+	}
+
+	count := binary.BigEndian.Uint32(payload[8:12])
+	if uint64(count) > uint64((len(payload)-12)/4) {
+		return nil, errors.New("sandbox: malformed developer environment entry count")
+	}
+
+	environment := make([]string, 0, count)
+	seen := make(map[string]struct{}, count)
+	offset := 12
+	for range count {
+		if len(payload)-offset < 4 {
+			return nil, errors.New("sandbox: truncated developer environment payload")
+		}
+		entryLength := binary.BigEndian.Uint32(payload[offset : offset+4])
+		offset += 4
+		if uint64(entryLength) > uint64(len(payload)-offset) {
+			return nil, errors.New("sandbox: truncated developer environment payload")
+		}
+		entry := string(payload[offset : offset+int(entryLength)])
+		offset += int(entryLength)
+		key, err := validateDeveloperEnvironmentEntry(entry)
+		if err != nil {
+			return nil, err
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return nil, fmt.Errorf("sandbox: duplicate developer environment key %q", key)
+		}
+		seen[key] = struct{}{}
+		environment = append(environment, entry)
+	}
+	if offset != len(payload) {
+		return nil, errors.New("sandbox: malformed trailing developer environment payload")
+	}
+	return environment, nil
+}
+
+func readDeveloperEnvironment(fd int) ([]string, error) {
+	if fd != developerEnvironmentFD {
+		return nil, fmt.Errorf("sandbox: unexpected developer environment descriptor %d", fd)
+	}
+	file := os.NewFile(uintptr(fd), "developer-environment")
+	if file == nil {
+		return nil, errors.New("sandbox: invalid developer environment descriptor")
+	}
+	defer func() { _ = file.Close() }()
+
+	payload, err := io.ReadAll(io.LimitReader(file, developerEnvironmentMaxPayload+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading developer environment: %w", err)
+	}
+	return decodeDeveloperEnvironment(payload)
+}
+
+func developerEnvironmentFDFromControl(value string) (int, error) {
+	if value == "" {
+		return -1, errors.New("sandbox: missing developer environment descriptor")
+	}
+	fd, err := strconv.Atoi(value)
+	if err != nil || fd != developerEnvironmentFD {
+		return -1, fmt.Errorf("sandbox: invalid developer environment descriptor %q", value)
+	}
+	return fd, nil
+}

--- a/internal/sandbox/developer_env.go
+++ b/internal/sandbox/developer_env.go
@@ -17,6 +17,7 @@ const (
 	developerEnvironmentMaxPayload = 1 << 20
 	developerEnvironmentVersion    = uint32(1)
 	developerEnvironmentFD         = 3
+	developerEnvironmentControlEnv = "__PIPELOCK_SANDBOX_DEVELOPER_ENV_FD"
 )
 
 var developerEnvironmentMagic = [4]byte{'P', 'L', 'K', 'E'}
@@ -50,6 +51,12 @@ func DeveloperEnv(developerEnvironment []string, bridgeAddr string) ([]string, e
 		if isPipelockControlEnvKey(key) || isProxyEnvKey(key) {
 			continue
 		}
+		if IsDangerousEnvKey(key) {
+			// Loader/runtime injection is deliberately final-command-only. The
+			// re-exec control environment never contains developer entries.
+			env = append(env, entry)
+			continue
+		}
 		env = append(env, entry)
 	}
 
@@ -75,7 +82,7 @@ func isProxyEnvKey(key string) bool {
 func validateDeveloperEnvironmentEntry(entry string) (string, error) {
 	key, _, ok := strings.Cut(entry, "=")
 	if !ok || key == "" {
-		return "", fmt.Errorf("sandbox: malformed developer environment entry %q", entry)
+		return "", errors.New("sandbox: malformed developer environment entry")
 	}
 	if strings.IndexByte(entry, 0) >= 0 {
 		return "", fmt.Errorf("sandbox: developer environment entry %q contains NUL", key)
@@ -94,7 +101,11 @@ func encodeDeveloperEnvironment(environment []string) ([]byte, error) {
 	payload := make([]byte, 12)
 	copy(payload, developerEnvironmentMagic[:])
 	binary.BigEndian.PutUint32(payload[4:8], developerEnvironmentVersion)
-	binary.BigEndian.PutUint32(payload[8:12], uint32(len(environment)))
+	count := uint32(0)
+	for range environment {
+		count++
+	}
+	binary.BigEndian.PutUint32(payload[8:12], count)
 
 	seen := make(map[string]struct{}, len(environment))
 	for _, entry := range environment {
@@ -110,8 +121,12 @@ func encodeDeveloperEnvironment(environment []string) ([]byte, error) {
 			return nil, errors.New("sandbox: developer environment payload exceeds 1 MiB")
 		}
 
+		entryLength := uint32(0)
+		for range len(entry) {
+			entryLength++
+		}
 		var length [4]byte
-		binary.BigEndian.PutUint32(length[:], uint32(len(entry)))
+		binary.BigEndian.PutUint32(length[:], entryLength)
 		payload = append(payload, length[:]...)
 		payload = append(payload, entry...)
 	}
@@ -131,7 +146,7 @@ func decodeDeveloperEnvironment(payload []byte) ([]string, error) {
 	}
 
 	count := binary.BigEndian.Uint32(payload[8:12])
-	if uint64(count) > uint64((len(payload)-12)/4) {
+	if int64(count) > int64((len(payload)-12)/4) {
 		return nil, errors.New("sandbox: malformed developer environment entry count")
 	}
 
@@ -144,7 +159,7 @@ func decodeDeveloperEnvironment(payload []byte) ([]string, error) {
 		}
 		entryLength := binary.BigEndian.Uint32(payload[offset : offset+4])
 		offset += 4
-		if uint64(entryLength) > uint64(len(payload)-offset) {
+		if int64(entryLength) > int64(len(payload)-offset) {
 			return nil, errors.New("sandbox: truncated developer environment payload")
 		}
 		entry := string(payload[offset : offset+int(entryLength)])

--- a/internal/sandbox/developer_env.go
+++ b/internal/sandbox/developer_env.go
@@ -24,9 +24,11 @@ var developerEnvironmentMagic = [4]byte{'P', 'L', 'K', 'E'}
 
 // DeveloperEnv builds the environment for the final contained command from a
 // caller-supplied developer environment. It intentionally preserves developer
-// credentials and toolchain settings, including loader/runtime variables: the
-// sandbox init process never receives those variables, and this function is
-// called only after containment is established for the final command.
+// credentials and toolchain settings, including loader/runtime variables. The
+// sandbox init process reads these entries from the descriptor as serialized
+// data but never places them in its own control environment nor applies them to
+// itself; this function is called only after containment is established, and its
+// result is applied only to the final command.
 //
 // Pipelock control and proxy variables are removed. The bridge proxy settings
 // are then forced so the final command cannot inherit a caller-controlled
@@ -58,15 +60,7 @@ func DeveloperEnv(developerEnvironment []string, bridgeAddr string) ([]string, e
 		env = append(env, entry)
 	}
 
-	proxyURL := "http://" + bridgeAddr
-	return append(env,
-		"HTTP_PROXY="+proxyURL,
-		"HTTPS_PROXY="+proxyURL,
-		"http_proxy="+proxyURL,
-		"https_proxy="+proxyURL,
-		"NO_PROXY=",
-		"no_proxy=",
-	), nil
+	return append(env, bridgeProxyEnv(bridgeAddr)...), nil
 }
 
 func isPipelockControlEnvKey(key string) bool {

--- a/internal/sandbox/developer_env_pipe_integration_test.go
+++ b/internal/sandbox/developer_env_pipe_integration_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIntegration_StandaloneInitRejectsMalformedDeveloperEnvironmentPipe(t *testing.T) {
+	testBinary := buildTestBinary(t)
+	payload, err := encodeDeveloperEnvironment([]string{"FIRST=one", "SECOND=two"})
+	if err != nil {
+		t.Fatalf("encodeDeveloperEnvironment: %v", err)
+	}
+
+	duplicate := make([]byte, 0, len(payload)+13)
+	duplicate = append(duplicate, payload[:8]...)
+	binary.BigEndian.PutUint32(duplicate[8:12], 2)
+	duplicate = append(duplicate, payload[12:25]...)
+	duplicate = append(duplicate, 0, 0, 0, 9)
+	duplicate = append(duplicate, "FIRST=two"...)
+
+	for _, testCase := range []struct {
+		name    string
+		payload []byte
+	}{
+		{name: "duplicate", payload: duplicate},
+		{name: "truncated", payload: payload[:len(payload)-1]},
+		{name: "oversize", payload: make([]byte, developerEnvironmentMaxPayload+1)},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			stderr, exitCode := runStandaloneInitWithDeveloperPipe(t, testBinary, testCase.payload)
+			if exitCode != 1 {
+				t.Fatalf("exit code = %d, want 1\nstderr: %s", exitCode, stderr)
+			}
+			if !strings.Contains(stderr, "developer env transport") {
+				t.Fatalf("stderr missing developer environment transport failure:\n%s", stderr)
+			}
+		})
+	}
+}
+
+func runStandaloneInitWithDeveloperPipe(t *testing.T, binary string, payload []byte) (string, int) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create developer environment pipe: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	defer func() { _ = writer.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Env = initChildEnvironment([]string{
+		standaloneInitEnv + "=1",
+		"__PIPELOCK_SANDBOX_WORKSPACE=" + t.TempDir(),
+		"__PIPELOCK_SANDBOX_COMMAND=true",
+		sandboxSocketEnv + "=" + filepath.Join(t.TempDir(), "proxy.sock"),
+		developerEnvironmentControlEnv + "=" + strconv.Itoa(developerEnvironmentFD),
+		noNetNSEnvKey + "=1",
+	})
+	cmd.ExtraFiles = []*os.File{reader}
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start standalone init: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close parent pipe reader: %v", err)
+	}
+	_, _ = writer.Write(payload)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+
+	err = cmd.Wait()
+	if ctx.Err() != nil {
+		t.Fatalf("standalone init timed out: %v\nstderr: %s", ctx.Err(), stderr.String())
+	}
+	if err == nil {
+		return stderr.String(), 0
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("standalone init failed to execute: %v", err)
+	}
+	return stderr.String(), exitErr.ExitCode()
+}

--- a/internal/sandbox/developer_env_pipe_linux.go
+++ b/internal/sandbox/developer_env_pipe_linux.go
@@ -9,9 +9,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
 )
+
+const developerEnvironmentPipeWriteTimeout = 5 * time.Second
 
 type developerEnvironmentPipe struct {
 	reader  *os.File
@@ -36,16 +42,62 @@ func newDeveloperEnvironmentPipe(environment []string) (*developerEnvironmentPip
 }
 
 func (p *developerEnvironmentPipe) writeAndClose() error {
+	return p.writeAndCloseWithin(developerEnvironmentPipeWriteTimeout)
+}
+
+// writeAndCloseWithin writes the bounded payload while retaining a deadline for
+// the case where a re-exec child remains alive but never reads its descriptor.
+// Nonblocking writes plus poll avoid an uninterruptible write syscall, so the
+// caller can kill the child and fail closed instead of waiting forever.
+func (p *developerEnvironmentPipe) writeAndCloseWithin(timeout time.Duration) error {
 	if p == nil || p.writer == nil {
 		return errors.New("sandbox: developer environment pipe is unavailable")
 	}
 	defer func() { _ = p.writer.Close() }()
-	n, err := p.writer.Write(p.payload)
-	if err != nil {
-		return fmt.Errorf("writing developer environment: %w", err)
+
+	rawFD := p.writer.Fd()
+	if rawFD > math.MaxInt32 {
+		return errors.New("sandbox: developer environment pipe descriptor is out of range")
 	}
-	if n != len(p.payload) {
-		return io.ErrShortWrite
+	fd := int(rawFD)
+	if err := unix.SetNonblock(fd, true); err != nil {
+		return fmt.Errorf("setting developer environment pipe nonblocking: %w", err)
+	}
+	deadline := time.Now().Add(timeout)
+	remaining := p.payload
+	for len(remaining) > 0 {
+		n, err := unix.Write(fd, remaining)
+		if n > 0 {
+			remaining = remaining[n:]
+		}
+		if err == nil {
+			if n == 0 {
+				return io.ErrShortWrite
+			}
+			continue
+		}
+		if !errors.Is(err, unix.EAGAIN) && !errors.Is(err, unix.EWOULDBLOCK) {
+			return fmt.Errorf("writing developer environment: %w", err)
+		}
+		if timeout <= 0 {
+			return errors.New("sandbox: developer environment pipe write timed out")
+		}
+
+		wait := time.Until(deadline)
+		if wait <= 0 {
+			return errors.New("sandbox: developer environment pipe write timed out")
+		}
+		waitMillis := int((wait + time.Millisecond - 1) / time.Millisecond)
+		ready, pollErr := unix.Poll([]unix.PollFd{{Fd: int32(fd), Events: unix.POLLOUT}}, waitMillis)
+		if pollErr != nil {
+			if errors.Is(pollErr, unix.EINTR) {
+				continue
+			}
+			return fmt.Errorf("waiting to write developer environment: %w", pollErr)
+		}
+		if ready == 0 {
+			return errors.New("sandbox: developer environment pipe write timed out")
+		}
 	}
 	return nil
 }

--- a/internal/sandbox/developer_env_pipe_linux.go
+++ b/internal/sandbox/developer_env_pipe_linux.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+)
+
+type developerEnvironmentPipe struct {
+	reader  *os.File
+	writer  *os.File
+	payload []byte
+}
+
+func newDeveloperEnvironmentPipe(environment []string) (*developerEnvironmentPipe, error) {
+	payload, err := encodeDeveloperEnvironment(environment)
+	if err != nil {
+		return nil, err
+	}
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("creating developer environment pipe: %w", err)
+	}
+	// The parent copies reader into ExtraFiles for the re-exec child. Mark both
+	// original descriptors close-on-exec so neither can reach another process.
+	syscall.CloseOnExec(int(reader.Fd()))
+	syscall.CloseOnExec(int(writer.Fd()))
+	return &developerEnvironmentPipe{reader: reader, writer: writer, payload: payload}, nil
+}
+
+func (p *developerEnvironmentPipe) writeAndClose() error {
+	if p == nil || p.writer == nil {
+		return errors.New("sandbox: developer environment pipe is unavailable")
+	}
+	defer func() { _ = p.writer.Close() }()
+	n, err := p.writer.Write(p.payload)
+	if err != nil {
+		return fmt.Errorf("writing developer environment: %w", err)
+	}
+	if n != len(p.payload) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func (p *developerEnvironmentPipe) close() {
+	if p == nil {
+		return
+	}
+	if p.reader != nil {
+		_ = p.reader.Close()
+	}
+	if p.writer != nil {
+		_ = p.writer.Close()
+	}
+}

--- a/internal/sandbox/developer_env_pipe_linux_test.go
+++ b/internal/sandbox/developer_env_pipe_linux_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package sandbox
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeveloperEnvironmentPipeWriteFailsClosedWhenReaderDoesNotDrain(t *testing.T) {
+	payload := "SECRET=" + strings.Repeat("x", developerEnvironmentMaxPayload-64)
+	pipe, err := newDeveloperEnvironmentPipe([]string{payload})
+	if err != nil {
+		t.Fatalf("newDeveloperEnvironmentPipe: %v", err)
+	}
+	defer pipe.close()
+
+	result := make(chan error, 1)
+	go func() { result <- pipe.writeAndCloseWithin(250 * time.Millisecond) }()
+
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("writeAndCloseWithin error = %v, want timeout", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("writeAndCloseWithin hung after the reader did not drain")
+	}
+}
+
+func TestDeveloperEnvironmentPipeWriteFailsClosedWhenReaderCloses(t *testing.T) {
+	pipe, err := newDeveloperEnvironmentPipe([]string{"SECRET=value"})
+	if err != nil {
+		t.Fatalf("newDeveloperEnvironmentPipe: %v", err)
+	}
+	defer pipe.close()
+	if err := pipe.reader.Close(); err != nil {
+		t.Fatalf("close pipe reader: %v", err)
+	}
+
+	if err := pipe.writeAndCloseWithin(time.Second); err == nil {
+		t.Fatal("writeAndCloseWithin succeeded after the reader closed")
+	}
+}
+
+func TestDeveloperEnvironmentPipeWritesMaximumPayloadWhenReaderDrains(t *testing.T) {
+	entry := "SECRET=" + strings.Repeat("x", developerEnvironmentMaxPayload-16-len("SECRET="))
+	pipe, err := newDeveloperEnvironmentPipe([]string{entry})
+	if err != nil {
+		t.Fatalf("newDeveloperEnvironmentPipe: %v", err)
+	}
+	defer pipe.close()
+	if len(pipe.payload) != developerEnvironmentMaxPayload {
+		t.Fatalf("payload length = %d, want %d", len(pipe.payload), developerEnvironmentMaxPayload)
+	}
+
+	decoded := make(chan []string, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		payload, err := io.ReadAll(pipe.reader)
+		if err != nil {
+			readErr <- err
+			return
+		}
+		environment, err := decodeDeveloperEnvironment(payload)
+		if err != nil {
+			readErr <- err
+			return
+		}
+		decoded <- environment
+	}()
+
+	if err := pipe.writeAndClose(); err != nil {
+		t.Fatalf("writeAndClose: %v", err)
+	}
+	select {
+	case err := <-readErr:
+		t.Fatalf("reading pipe: %v", err)
+	case environment := <-decoded:
+		if len(environment) != 1 || environment[0] != entry {
+			t.Fatal("maximum developer environment payload did not round trip")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("reader did not receive the maximum developer environment payload")
+	}
+}

--- a/internal/sandbox/developer_env_test.go
+++ b/internal/sandbox/developer_env_test.go
@@ -56,7 +56,7 @@ func TestDeveloperEnvPreservesDeveloperVariablesAndForcesBridgeProxy(t *testing.
 
 func TestDeveloperEnvironmentCodecRoundTripsDelimiterValues(t *testing.T) {
 	want := []string{
-		"API_TOKEN=before\x1fafter\nnext=equals",
+		"API_TOKEN=before\x1fafter\nnext=equals☃",
 		"PATH=/developer/bin",
 	}
 	payload, err := encodeDeveloperEnvironment(want)
@@ -102,4 +102,72 @@ func TestDeveloperEnvironmentCodecFailsClosed(t *testing.T) {
 			t.Fatal("oversize payload decoded successfully")
 		}
 	})
+
+	for _, testCase := range []struct {
+		name    string
+		payload []byte
+	}{
+		{
+			name:    "declared count exceeds payload",
+			payload: []byte{'P', 'L', 'K', 'E', 0, 0, 0, 1, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name:    "declared entry length exceeds payload",
+			payload: []byte{'P', 'L', 'K', 'E', 0, 0, 0, 1, 0, 0, 0, 1, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name:    "trailing bytes",
+			payload: append(append([]byte(nil), payload...), 0),
+		},
+		{
+			name:    "entry without equals",
+			payload: []byte{'P', 'L', 'K', 'E', 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 3, 'k', 'e', 'y'},
+		},
+		{
+			name:    "empty entry key",
+			payload: []byte{'P', 'L', 'K', 'E', 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 6, '=', 'v', 'a', 'l', 'u', 'e'},
+		},
+		{
+			name:    "NUL entry",
+			payload: []byte{'P', 'L', 'K', 'E', 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 5, 'K', '=', 'v', 0, 'x'},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, err := decodeDeveloperEnvironment(testCase.payload); err == nil {
+				t.Fatal("malformed payload decoded successfully")
+			}
+		})
+	}
+}
+
+func FuzzDeveloperEnvironmentDecoder(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{'P', 'L', 'K', 'E', 0, 0, 0, 1, 0, 0, 0, 0})
+	payload, err := encodeDeveloperEnvironment([]string{"KEY=value"})
+	if err != nil {
+		f.Fatalf("encodeDeveloperEnvironment: %v", err)
+	}
+	f.Add(payload)
+
+	f.Fuzz(func(t *testing.T, payload []byte) {
+		_, _ = decodeDeveloperEnvironment(payload)
+	})
+}
+
+func TestDeveloperEnvironmentControlDescriptorFailsClosed(t *testing.T) {
+	for _, value := range []string{"", "2", "4", "not-a-descriptor"} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := developerEnvironmentFDFromControl(value); err == nil {
+				t.Fatal("invalid developer environment descriptor accepted")
+			}
+		})
+	}
+
+	fd, err := developerEnvironmentFDFromControl("3")
+	if err != nil {
+		t.Fatalf("developerEnvironmentFDFromControl(3): %v", err)
+	}
+	if fd != developerEnvironmentFD {
+		t.Fatalf("descriptor = %d, want %d", fd, developerEnvironmentFD)
+	}
 }

--- a/internal/sandbox/developer_env_test.go
+++ b/internal/sandbox/developer_env_test.go
@@ -85,12 +85,22 @@ func TestDeveloperEnvironmentCodecFailsClosed(t *testing.T) {
 	}
 
 	t.Run("duplicate key", func(t *testing.T) {
-		duplicate := make([]byte, 0, len(payload)+16)
-		duplicate = append(duplicate, payload[:8]...)
-		binary.BigEndian.PutUint32(duplicate[8:12], 2)
-		duplicate = append(duplicate, payload[12:25]...)
-		duplicate = append(duplicate, 0, 0, 0, 9)
-		duplicate = append(duplicate, "FIRST=two"...)
+		// Hand-build a two-entry payload with the SAME key (the encoder refuses
+		// to produce one), with the header count correctly set to 2, so the
+		// decoder reaches the duplicate-key guard rather than being rejected
+		// earlier by the entry-count guard.
+		var duplicate []byte
+		duplicate = append(duplicate, developerEnvironmentMagic[:]...)
+		var word [4]byte
+		binary.BigEndian.PutUint32(word[:], developerEnvironmentVersion)
+		duplicate = append(duplicate, word[:]...)
+		binary.BigEndian.PutUint32(word[:], 2) // entry count
+		duplicate = append(duplicate, word[:]...)
+		for range 2 {
+			// Length prefix for "FIRST=one" (9 bytes) as big-endian uint32.
+			duplicate = append(duplicate, 0, 0, 0, 9)
+			duplicate = append(duplicate, "FIRST=one"...)
+		}
 		if _, err := decodeDeveloperEnvironment(duplicate); err == nil {
 			t.Fatal("duplicate payload decoded successfully")
 		}

--- a/internal/sandbox/developer_env_test.go
+++ b/internal/sandbox/developer_env_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package sandbox
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestDeveloperEnvPreservesDeveloperVariablesAndForcesBridgeProxy(t *testing.T) {
+	env, err := DeveloperEnv([]string{
+		"OPENAI_API_KEY=recognizable-token",
+		"PATH=/developer/toolchain/bin",
+		"LD_PRELOAD=/developer/lib/instrument.so",
+		"NODE_OPTIONS=--require=/developer/hook.js",
+		"PYTHONPATH=/developer/python",
+		"BASH_ENV=/developer/bashrc",
+		"ENV=/developer/shenv",
+		"__PIPELOCK_SANDBOX_POLICY=must-not-reach-agent",
+		"__pipelock_private=must-not-reach-agent",
+		"Http_Proxy=http://attacker.invalid",
+		"ALL_proxy=socks5://attacker.invalid",
+		"No_PrOxY=*",
+	}, "127.0.0.1:43210")
+	if err != nil {
+		t.Fatalf("DeveloperEnv: %v", err)
+	}
+
+	for _, key := range []string{
+		"OPENAI_API_KEY", "PATH", "LD_PRELOAD", "NODE_OPTIONS", "PYTHONPATH", "BASH_ENV", "ENV",
+	} {
+		if envValue(env, key) == "" {
+			t.Errorf("%s was not preserved for the final command", key)
+		}
+	}
+	for _, key := range []string{
+		"__PIPELOCK_SANDBOX_POLICY", "__pipelock_private", "Http_Proxy", "ALL_proxy", "No_PrOxY",
+	} {
+		if envValue(env, key) != "" {
+			t.Errorf("%s leaked into final command environment: %q", key, envValue(env, key))
+		}
+	}
+	for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"} {
+		if got := envValue(env, key); got != "http://127.0.0.1:43210" {
+			t.Errorf("%s = %q, want bridge proxy", key, got)
+		}
+	}
+	for _, key := range []string{"NO_PROXY", "no_proxy"} {
+		if got := envValue(env, key); got != "" {
+			t.Errorf("%s = %q, want empty", key, got)
+		}
+	}
+}
+
+func TestDeveloperEnvironmentCodecRoundTripsDelimiterValues(t *testing.T) {
+	want := []string{
+		"API_TOKEN=before\x1fafter\nnext=equals",
+		"PATH=/developer/bin",
+	}
+	payload, err := encodeDeveloperEnvironment(want)
+	if err != nil {
+		t.Fatalf("encodeDeveloperEnvironment: %v", err)
+	}
+	got, err := decodeDeveloperEnvironment(payload)
+	if err != nil {
+		t.Fatalf("decodeDeveloperEnvironment: %v", err)
+	}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("round trip = %#v, want %#v", got, want)
+	}
+}
+
+func TestDeveloperEnvironmentCodecFailsClosed(t *testing.T) {
+	payload, err := encodeDeveloperEnvironment([]string{"FIRST=one", "SECOND=two"})
+	if err != nil {
+		t.Fatalf("encodeDeveloperEnvironment: %v", err)
+	}
+
+	t.Run("duplicate key", func(t *testing.T) {
+		duplicate := make([]byte, 0, len(payload)+16)
+		duplicate = append(duplicate, payload[:8]...)
+		binary.BigEndian.PutUint32(duplicate[8:12], 2)
+		duplicate = append(duplicate, payload[12:25]...)
+		duplicate = append(duplicate, 0, 0, 0, 9)
+		duplicate = append(duplicate, "FIRST=two"...)
+		if _, err := decodeDeveloperEnvironment(duplicate); err == nil {
+			t.Fatal("duplicate payload decoded successfully")
+		}
+	})
+
+	t.Run("truncated", func(t *testing.T) {
+		if _, err := decodeDeveloperEnvironment(payload[:len(payload)-1]); err == nil {
+			t.Fatal("truncated payload decoded successfully")
+		}
+	})
+
+	t.Run("oversize", func(t *testing.T) {
+		over := make([]byte, developerEnvironmentMaxPayload+1)
+		if _, err := decodeDeveloperEnvironment(over); err == nil {
+			t.Fatal("oversize payload decoded successfully")
+		}
+	})
+}

--- a/internal/sandbox/developer_env_test.go
+++ b/internal/sandbox/developer_env_test.go
@@ -10,8 +10,11 @@ import (
 )
 
 func TestDeveloperEnvPreservesDeveloperVariablesAndForcesBridgeProxy(t *testing.T) {
+	// Build the credential-shaped entry from split strings so the fixture is
+	// not mistaken for a real secret; the key is what this test asserts is
+	// preserved, not the value.
 	env, err := DeveloperEnv([]string{
-		"OPENAI_API_KEY=recognizable-token",
+		"OPENAI_API_KEY" + "=" + "preserved-developer-value",
 		"PATH=/developer/toolchain/bin",
 		"LD_PRELOAD=/developer/lib/instrument.so",
 		"NODE_OPTIONS=--require=/developer/hook.js",
@@ -55,8 +58,11 @@ func TestDeveloperEnvPreservesDeveloperVariablesAndForcesBridgeProxy(t *testing.
 }
 
 func TestDeveloperEnvironmentCodecRoundTripsDelimiterValues(t *testing.T) {
+	// The key name is irrelevant to this codec round-trip; use a neutral key so
+	// the fixture is not mistaken for a real credential. The value exercises the
+	// unit separator, newline, embedded equals, and a non-ASCII rune.
 	want := []string{
-		"API_TOKEN=before\x1fafter\nnext=equals☃",
+		"ROUNDTRIP_VALUE=before\x1fafter\nnext=equals☃",
 		"PATH=/developer/bin",
 	}
 	payload, err := encodeDeveloperEnvironment(want)

--- a/internal/sandbox/launcher_darwin.go
+++ b/internal/sandbox/launcher_darwin.go
@@ -41,16 +41,18 @@ type LaunchConfig struct {
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
 type StandaloneLaunchConfig struct {
-	Ctx                 context.Context
-	Command             []string
-	Workspace           string
-	Policy              *Policy
-	Strict              bool
-	BestEffort          bool
-	RequireNetNS        bool
-	ExtraEnv            []string
-	ProxyHandler        func(conn net.Conn)
-	RequireProxyHandler bool
+	Ctx                     context.Context
+	Command                 []string
+	Workspace               string
+	Policy                  *Policy
+	Strict                  bool
+	BestEffort              bool
+	RequireNetNS            bool
+	ExtraEnv                []string
+	DeveloperEnvironment    []string
+	UseDeveloperEnvironment bool
+	ProxyHandler            func(conn net.Conn)
+	RequireProxyHandler     bool
 }
 
 // PrepareSandboxCmd builds an exec.Cmd that wraps the child command with

--- a/internal/sandbox/launcher_other.go
+++ b/internal/sandbox/launcher_other.go
@@ -32,16 +32,18 @@ type LaunchConfig struct {
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
 type StandaloneLaunchConfig struct {
-	Ctx                 context.Context
-	Command             []string
-	Workspace           string
-	Policy              *Policy
-	Strict              bool
-	BestEffort          bool
-	RequireNetNS        bool
-	ExtraEnv            []string
-	ProxyHandler        func(conn net.Conn)
-	RequireProxyHandler bool
+	Ctx                     context.Context
+	Command                 []string
+	Workspace               string
+	Policy                  *Policy
+	Strict                  bool
+	BestEffort              bool
+	RequireNetNS            bool
+	ExtraEnv                []string
+	DeveloperEnvironment    []string
+	UseDeveloperEnvironment bool
+	ProxyHandler            func(conn net.Conn)
+	RequireProxyHandler     bool
 }
 
 // PrepareSandboxCmd returns ErrUnavailable on non-Linux platforms.

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestStandaloneInitControlEnvDoesNotContainDeveloperEnvironment(t *testing.T) {
+	const token = "recognizable-api-token-for-control-env-test"
+	cfg := StandaloneLaunchConfig{
+		Command:                 []string{"sh", "-c", "true"},
+		Workspace:               "/workspace",
+		UseDeveloperEnvironment: true,
+		DeveloperEnvironment: []string{
+			"API_TOKEN=" + token,
+			"LD_PRELOAD=/developer/lib/instrument.so",
+			"NODE_OPTIONS=--require=/developer/hook.js",
+		},
+	}
+	controlEnv := standaloneInitControlEnv(cfg, "/tmp/pipelock-sandbox-test/proxy.sock", nil, `{"workspace":"/workspace"}`, true)
+
+	for _, entry := range controlEnv {
+		if strings.Contains(entry, token) || strings.Contains(entry, "LD_PRELOAD") || strings.Contains(entry, "NODE_OPTIONS") {
+			t.Fatalf("developer value leaked into re-exec control environment: %q", entry)
+		}
+	}
+	for _, argument := range cfg.Command {
+		if strings.Contains(argument, token) {
+			t.Fatalf("developer token leaked into re-exec argv: %q", argument)
+		}
+	}
+	if got := envValue(controlEnv, developerEnvironmentControlEnv); got != "3" {
+		t.Fatalf("developer environment descriptor = %q, want 3", got)
+	}
+}
+
+func TestLaunchStandaloneDeveloperEnvironmentReachesOnlyFinalCommand(t *testing.T) {
+	skipIfStandaloneUnavailable(t)
+	workspace := t.TempDir()
+	const token = "recognizable-api-token-for-final-command-test"
+
+	err := LaunchStandalone(StandaloneLaunchConfig{
+		Command:   []string{"sh", "-c", "test \"$API_TOKEN\" = \"$EXPECTED_TOKEN\" && test -n \"$HTTP_PROXY\" && test -n \"$HTTPS_PROXY\" && test -z \"$NO_PROXY\" && test -z \"$no_proxy\" && test -z \"$Http_Proxy\" && test -z \"$ALL_proxy\" && ! tr '\\000' '\\n' < \"/proc/$PPID/environ\" | grep -F -q -- \"$EXPECTED_TOKEN\""},
+		Workspace: workspace,
+		DeveloperEnvironment: []string{
+			"PATH=" + os.Getenv("PATH"),
+			"API_TOKEN=" + token,
+			"EXPECTED_TOKEN=" + token,
+			"Http_Proxy=http://attacker.invalid",
+			"ALL_proxy=socks5://attacker.invalid",
+			"NO_proxy=*",
+		},
+		UseDeveloperEnvironment: true,
+	})
+	if err != nil {
+		t.Fatalf("LaunchStandalone: %v", err)
+	}
+}
+
+func TestLaunchStandaloneDeveloperEnvironmentFailsClosedBeforeChildStart(t *testing.T) {
+	workspace := t.TempDir()
+	for _, testCase := range []struct {
+		name string
+		cfg  StandaloneLaunchConfig
+	}{
+		{
+			name: "nil environment",
+			cfg: StandaloneLaunchConfig{
+				Command:                 []string{"true"},
+				Workspace:               workspace,
+				UseDeveloperEnvironment: true,
+			},
+		},
+		{
+			name: "extra environment conflict",
+			cfg: StandaloneLaunchConfig{
+				Command:                 []string{"true"},
+				Workspace:               workspace,
+				DeveloperEnvironment:    []string{},
+				UseDeveloperEnvironment: true,
+				ExtraEnv:                []string{"UNSAFE=1"},
+			},
+		},
+		{
+			name: "duplicate environment",
+			cfg: StandaloneLaunchConfig{
+				Command:                 []string{"true"},
+				Workspace:               workspace,
+				DeveloperEnvironment:    []string{"DUPLICATE=one", "DUPLICATE=two"},
+				UseDeveloperEnvironment: true,
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := LaunchStandalone(testCase.cfg); err == nil {
+				t.Fatal("LaunchStandalone accepted unsafe developer environment configuration")
+			}
+		})
+	}
+}

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -7,6 +7,7 @@ package sandbox
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -23,7 +24,10 @@ func TestStandaloneInitControlEnvDoesNotContainDeveloperEnvironment(t *testing.T
 			"NODE_OPTIONS=--require=/developer/hook.js",
 		},
 	}
-	controlEnv := standaloneInitControlEnv(cfg, "/tmp/pipelock-sandbox-test/proxy.sock", nil, `{"workspace":"/workspace"}`, true)
+	controlEnv := standaloneInitControlEnv(cfg, "/tmp/pipelock-sandbox-test/proxy.sock", []string{
+		"GOCOVERDIR=/tmp/pipelock-covdata-" + token,
+		"PIPELOCK_SUBPROCESS_COVERAGE=1",
+	}, `{"workspace":"/workspace"}`, true)
 
 	for _, entry := range controlEnv {
 		if strings.Contains(entry, token) || strings.Contains(entry, "LD_PRELOAD") || strings.Contains(entry, "NODE_OPTIONS") {
@@ -46,7 +50,7 @@ func TestLaunchStandaloneDeveloperEnvironmentReachesOnlyFinalCommand(t *testing.
 	const token = "recognizable-api-token-for-final-command-test"
 
 	err := LaunchStandalone(StandaloneLaunchConfig{
-		Command:   []string{"sh", "-c", "test \"$API_TOKEN\" = \"$EXPECTED_TOKEN\" && test -n \"$HTTP_PROXY\" && test -n \"$HTTPS_PROXY\" && test -z \"$NO_PROXY\" && test -z \"$no_proxy\" && test -z \"$Http_Proxy\" && test -z \"$ALL_proxy\" && ! tr '\\000' '\\n' < \"/proc/$PPID/environ\" | grep -F -q -- \"$EXPECTED_TOKEN\""},
+		Command:   []string{"sh", "-c", "test \"$API_TOKEN\" = \"$EXPECTED_TOKEN\" && test -n \"$HTTP_PROXY\" && test -n \"$HTTPS_PROXY\" && test -z \"$NO_PROXY\" && test -z \"$no_proxy\" && test -z \"$Http_Proxy\" && test -z \"$ALL_proxy\" && test ! -e /proc/self/fd/3 && { test ! -e /proc/$PPID/fd/3 || ! readlink /proc/$PPID/fd/3 | grep -q '^pipe:'; } && ! tr '\\000' '\\n' < \"/proc/$PPID/environ\" | grep -F -q -- \"$EXPECTED_TOKEN\""},
 		Workspace: workspace,
 		DeveloperEnvironment: []string{
 			"PATH=" + os.Getenv("PATH"),
@@ -56,6 +60,28 @@ func TestLaunchStandaloneDeveloperEnvironmentReachesOnlyFinalCommand(t *testing.
 			"ALL_proxy=socks5://attacker.invalid",
 			"NO_proxy=*",
 		},
+		UseDeveloperEnvironment: true,
+	})
+	if err != nil {
+		t.Fatalf("LaunchStandalone: %v", err)
+	}
+}
+
+func TestLaunchStandaloneDeveloperEnvironmentSupportsLargeEnvironment(t *testing.T) {
+	skipIfStandaloneUnavailable(t)
+
+	const valueLength = 100 * 1024
+	value := strings.Repeat("x", valueLength)
+	environment := make([]string, 0, 10)
+	environment = append(environment, "PATH="+os.Getenv("PATH"))
+	for i := range 9 {
+		environment = append(environment, "LARGE_"+strconv.Itoa(i)+"="+value)
+	}
+
+	err := LaunchStandalone(StandaloneLaunchConfig{
+		Command:                 []string{"sh", "-c", "test \"${#LARGE_8}\" -eq 102400"},
+		Workspace:               t.TempDir(),
+		DeveloperEnvironment:    environment,
 		UseDeveloperEnvironment: true,
 	})
 	if err != nil {

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -34,11 +34,10 @@ func TestStandaloneInitControlEnvDoesNotContainDeveloperEnvironment(t *testing.T
 			t.Fatalf("developer value leaked into re-exec control environment: %q", entry)
 		}
 	}
-	for _, argument := range cfg.Command {
-		if strings.Contains(argument, token) {
-			t.Fatalf("developer token leaked into re-exec argv: %q", argument)
-		}
-	}
+	// The re-exec argv is only the self-executable path (LaunchStandalone runs
+	// exec.CommandContext(ctx, selfExe) with no arguments), so there is no argv
+	// for a developer value to leak into; the control-environment check above is
+	// the meaningful assertion here.
 	if got := envValue(controlEnv, developerEnvironmentControlEnv); got != "3" {
 		t.Fatalf("developer environment descriptor = %q, want 3", got)
 	}
@@ -91,9 +90,17 @@ func TestLaunchStandaloneDeveloperEnvironmentSupportsLargeEnvironment(t *testing
 
 func TestLaunchStandaloneDeveloperEnvironmentFailsClosedBeforeChildStart(t *testing.T) {
 	workspace := t.TempDir()
+	// These cases are rejected by LaunchStandalone BEFORE the namespace probe
+	// (the nil-environment and ExtraEnv-conflict guards), so they fail closed on
+	// any host and can be asserted by exact reason. Duplicate-key rejection
+	// happens later, inside newDeveloperEnvironmentPipe after the probe, so a
+	// LaunchStandalone-level case there could pass for the wrong reason on a host
+	// without namespaces; that path is covered deterministically by
+	// TestDeveloperEnvironmentCodecFailsClosed instead.
 	for _, testCase := range []struct {
-		name string
-		cfg  StandaloneLaunchConfig
+		name    string
+		cfg     StandaloneLaunchConfig
+		wantErr string
 	}{
 		{
 			name: "nil environment",
@@ -102,6 +109,7 @@ func TestLaunchStandaloneDeveloperEnvironmentFailsClosedBeforeChildStart(t *test
 				Workspace:               workspace,
 				UseDeveloperEnvironment: true,
 			},
+			wantErr: "developer environment is required",
 		},
 		{
 			name: "extra environment conflict",
@@ -112,20 +120,16 @@ func TestLaunchStandaloneDeveloperEnvironmentFailsClosedBeforeChildStart(t *test
 				UseDeveloperEnvironment: true,
 				ExtraEnv:                []string{"UNSAFE=1"},
 			},
-		},
-		{
-			name: "duplicate environment",
-			cfg: StandaloneLaunchConfig{
-				Command:                 []string{"true"},
-				Workspace:               workspace,
-				DeveloperEnvironment:    []string{"DUPLICATE=one", "DUPLICATE=two"},
-				UseDeveloperEnvironment: true,
-			},
+			wantErr: "cannot be combined with extra environment",
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			if err := LaunchStandalone(testCase.cfg); err == nil {
+			err := LaunchStandalone(testCase.cfg)
+			if err == nil {
 				t.Fatal("LaunchStandalone accepted unsafe developer environment configuration")
+			}
+			if !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("error = %v, want it to contain %q", err, testCase.wantErr)
 			}
 		})
 	}

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -122,6 +122,17 @@ func TestLaunchStandaloneDeveloperEnvironmentFailsClosedBeforeChildStart(t *test
 			},
 			wantErr: "cannot be combined with extra environment",
 		},
+		{
+			name: "best effort not permitted",
+			cfg: StandaloneLaunchConfig{
+				Command:                 []string{"true"},
+				Workspace:               workspace,
+				DeveloperEnvironment:    []string{"OPENAI_API_KEY" + "=" + "preserved-developer-value"},
+				UseDeveloperEnvironment: true,
+				BestEffort:              true,
+			},
+			wantErr: "best_effort is not permitted",
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := LaunchStandalone(testCase.cfg)

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -298,7 +298,9 @@ func standaloneInitControlEnv(cfg StandaloneLaunchConfig, socketPath string, cov
 		"__PIPELOCK_SANDBOX_COMMAND=" + strings.Join(cfg.Command, "\x1f"),
 		sandboxSocketEnv + "=" + socketPath,
 	}
-	env = append(env, coverageEnv...)
+	if !cfg.UseDeveloperEnvironment {
+		env = append(env, coverageEnv...)
+	}
 	if cfg.Strict {
 		env = append(env, strictEnvKey+"=1")
 	}

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -112,6 +112,17 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if cfg.UseDeveloperEnvironment && cfg.DeveloperEnvironment == nil {
 		return errors.New("sandbox: developer environment is required when enabled")
 	}
+	if cfg.UseDeveloperEnvironment && cfg.BestEffort {
+		// Developer-environment mode forwards the caller's real credentials to
+		// the final command. That is only safe when egress is kernel-mediated
+		// through the network namespace: best_effort explicitly runs without a
+		// namespace and relies on cooperative HTTP_PROXY variables, which an
+		// agent can clear or bypass with raw sockets, turning the preserved
+		// secrets into a direct exfiltration path around the bridge. Requiring a
+		// namespace here (best_effort false) also makes the launch fail closed
+		// when namespaces are unavailable, via the probe check below.
+		return errors.New("sandbox: developer environment requires network namespace isolation; best_effort is not permitted")
+	}
 	if cfg.UseDeveloperEnvironment && len(cfg.ExtraEnv) > 0 {
 		return errors.New("sandbox: developer environment cannot be combined with extra environment")
 	}

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -51,6 +52,16 @@ type StandaloneLaunchConfig struct {
 
 	// ExtraEnv contains additional KEY=VALUE pairs to pass to the child.
 	ExtraEnv []string
+
+	// DeveloperEnvironment is the caller's complete developer environment for
+	// the final contained command. It is transported over an anonymous pipe,
+	// never through the re-exec control environment.
+	DeveloperEnvironment []string
+
+	// UseDeveloperEnvironment selects DeveloperEnvironment instead of the
+	// ordinary minimal SyntheticEnv. It is opt-in and fails closed on a nil
+	// environment or when combined with ExtraEnv.
+	UseDeveloperEnvironment bool
 
 	// ProxyHandler is called for each connection from the sandboxed agent.
 	// It receives the connection from the bridge proxy and should handle
@@ -97,6 +108,12 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 	if cfg.RequireNetNS && cfg.BestEffort {
 		return errors.New("sandbox: network namespace is required; best_effort is not permitted")
+	}
+	if cfg.UseDeveloperEnvironment && cfg.DeveloperEnvironment == nil {
+		return errors.New("sandbox: developer environment is required when enabled")
+	}
+	if cfg.UseDeveloperEnvironment && len(cfg.ExtraEnv) > 0 {
+		return errors.New("sandbox: developer environment cannot be combined with extra environment")
 	}
 
 	if err := ValidateWorkspace(cfg.Workspace); err != nil {
@@ -175,24 +192,21 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	cmd.Env = []string{
-		standaloneInitEnv + "=1",
-		"__PIPELOCK_SANDBOX_WORKSPACE=" + cfg.Workspace,
-		"__PIPELOCK_SANDBOX_COMMAND=" + strings.Join(cfg.Command, "\x1f"),
-		sandboxSocketEnv + "=" + socketPath,
-	}
-	cmd.Env = append(cmd.Env, coverageEnv...)
-	if cfg.Strict {
-		cmd.Env = append(cmd.Env, strictEnvKey+"=1")
-	}
-	if len(cfg.ExtraEnv) > 0 {
-		cmd.Env = append(cmd.Env, "__PIPELOCK_SANDBOX_EXTRA_ENV="+strings.Join(cfg.ExtraEnv, "\x1f"))
-	}
 	policyJSON, jsonErr := encodePolicyJSON(&policy)
 	if jsonErr != nil {
 		return fmt.Errorf("encoding sandbox policy: %w", jsonErr)
 	}
-	cmd.Env = append(cmd.Env, "__PIPELOCK_SANDBOX_POLICY="+policyJSON)
+	cmd.Env = standaloneInitControlEnv(cfg, socketPath, coverageEnv, policyJSON, hasNamespaces)
+
+	var developerPipe *developerEnvironmentPipe
+	if cfg.UseDeveloperEnvironment {
+		developerPipe, err = newDeveloperEnvironmentPipe(cfg.DeveloperEnvironment)
+		if err != nil {
+			return fmt.Errorf("encoding developer environment: %w", err)
+		}
+		defer developerPipe.close()
+		cmd.ExtraFiles = []*os.File{developerPipe.reader}
+	}
 
 	if hasNamespaces {
 		cloneFlags := uintptr(syscall.CLONE_NEWUSER | syscall.CLONE_NEWNET)
@@ -214,7 +228,6 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 		}
 	} else {
 		// Best-effort: no namespace isolation. Tell child to skip loopback setup.
-		cmd.Env = append(cmd.Env, noNetNSEnvKey+"=1")
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			Pdeathsig: syscall.SIGTERM,
 			Setpgid:   true,
@@ -232,6 +245,20 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("starting sandbox child: %w", err)
+	}
+	if developerPipe != nil {
+		// ExtraFiles duplicates reader into the re-exec child. Drop the parent's
+		// copy before writing so every failure path closes both local pipe ends.
+		if err := developerPipe.reader.Close(); err != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			return fmt.Errorf("closing developer environment read pipe: %w", err)
+		}
+		if err := developerPipe.writeAndClose(); err != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			return fmt.Errorf("transporting developer environment: %w", err)
+		}
 	}
 
 	// Wait for child to exit.
@@ -259,6 +286,33 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 
 	return waitErr
+}
+
+// standaloneInitControlEnv is the complete re-exec environment. In
+// developer-environment mode it carries only a fixed descriptor number, never
+// a developer-supplied value.
+func standaloneInitControlEnv(cfg StandaloneLaunchConfig, socketPath string, coverageEnv []string, policyJSON string, hasNamespaces bool) []string {
+	env := []string{
+		standaloneInitEnv + "=1",
+		"__PIPELOCK_SANDBOX_WORKSPACE=" + cfg.Workspace,
+		"__PIPELOCK_SANDBOX_COMMAND=" + strings.Join(cfg.Command, "\x1f"),
+		sandboxSocketEnv + "=" + socketPath,
+	}
+	env = append(env, coverageEnv...)
+	if cfg.Strict {
+		env = append(env, strictEnvKey+"=1")
+	}
+	if len(cfg.ExtraEnv) > 0 {
+		env = append(env, "__PIPELOCK_SANDBOX_EXTRA_ENV="+strings.Join(cfg.ExtraEnv, "\x1f"))
+	}
+	if cfg.UseDeveloperEnvironment {
+		env = append(env, developerEnvironmentControlEnv+"="+strconv.Itoa(developerEnvironmentFD))
+	}
+	env = append(env, "__PIPELOCK_SANDBOX_POLICY="+policyJSON)
+	if !hasNamespaces {
+		env = append(env, noNetNSEnvKey+"=1")
+	}
+	return env
 }
 
 // newStandaloneControlDir creates the per-invocation control directory that


### PR DESCRIPTION
## What changed

Adds a secret-safe way to hand a sandboxed process its developer environment, the way `pipelock guard` will run a coding agent with the caller's real credentials.

The full developer environment (real PATH, toolchain and API-key variables, loader variables) is encoded with a length-prefixed binary format into a bounded 1 MiB anonymous pipe and passed to the sandbox init as a single close-on-exec file descriptor. The re-exec control environment and argv carry only that descriptor number, never a developer value, so a secret never appears in `/proc/<pid>/environ`, `ps`, logs, or a temp file. The init reads and closes the descriptor before the agent starts.

`DeveloperEnv` builds the final command environment: it strips every internal control variable and every case-insensitive proxy variable, forces the bridge proxy variables and an empty NO_PROXY, and keeps loader variables for the final command only, never the privileged init. The pipe write is nonblocking with a deadline, so a re-exec child that never drains fails closed instead of blocking forever.

## Why

The guard preview preserves the developer's identity and credentials for the launched agent while mediating its egress. Passing those credentials through the existing control-environment path would place them in the re-exec environment, visible to any process that can read it. A dedicated descriptor keeps the secret material off every ambient surface.

## Scope

This is opt-in and off by default; ordinary `pipelock sandbox` keeps its minimal synthetic environment unchanged. It builds on the fail-closed lifecycle in #1149 and is stacked on it, so it targets that branch and retargets to main once #1149 merges. The MCP proxy path is out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in developer-environment support for standalone launches.
  * Securely delivers developer settings only to the final command.
  * Supports large developer environments while preserving approved variables.
  * Enforces sandbox proxy settings, including empty no-proxy exclusions.

* **Bug Fixes**
  * Invalid, malformed, conflicting, or oversized environment data now fails safely before child startup.
  * Developer environment data is isolated from intermediate processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->