### PR TITLE
fix(proxy): gate receipt headers on successful recording

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -449,7 +449,9 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		RequestID:   requestID,
 		Agent:       agent,
 		AuditCtx:    targetCtx,
-		Emit:        emitConnectReceipt,
+		Emit: func(opts receipt.EmitOpts) error {
+			return p.emitRequestPolicyReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+		},
 	}
 	if rp := p.applyRequestPolicy(connectRPInput); rp.Block {
 		p.metrics.RecordTunnelBlocked(agentLabel)
@@ -1677,7 +1679,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		RequestID:   requestID,
 		Agent:       agent,
 		AuditCtx:    actx,
-		Emit:        emitForwardReceipt,
+		Emit: func(opts receipt.EmitOpts) error {
+			return p.emitRequestPolicyReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+		},
 	}
 	if rp := p.prepareRequestPolicyBody(r, &rpInput); rp.Block {
 		p.metrics.RecordBlocked(r.URL.Hostname(), blockLayerRequestPolicy, time.Since(start), agentLabel)

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1498,7 +1498,11 @@ func newInterceptHandler(
 				RequestID:   ic.RequestID,
 				Agent:       ic.Agent,
 				AuditCtx:    actx,
-				Emit:        func(o receipt.EmitOpts) error { return interceptEmitReceipt(ic, o) },
+				Emit: func(o receipt.EmitOpts) error {
+					return ic.Proxy.emitRequestPolicyReceipt(
+						withReceiptPolicyHash(o, ic.Config.CanonicalPolicyHash()),
+					)
+				},
 			}
 			if rp := ic.Proxy.prepareRequestPolicyBody(r, &rpInput); rp.Block {
 				ic.Metrics.RecordTLSRequestBlocked(blockLayerRequestPolicy)

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1498,7 +1498,7 @@ func newInterceptHandler(
 				RequestID:   ic.RequestID,
 				Agent:       ic.Agent,
 				AuditCtx:    actx,
-				Emit:        func(o receipt.EmitOpts) { _ = interceptEmitReceipt(ic, o) },
+				Emit:        func(o receipt.EmitOpts) error { return interceptEmitReceipt(ic, o) },
 			}
 			if rp := ic.Proxy.prepareRequestPolicyBody(r, &rpInput); rp.Block {
 				ic.Metrics.RecordTLSRequestBlocked(blockLayerRequestPolicy)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1033,14 +1033,25 @@ func (p *Proxy) emitReceipt(opts receipt.EmitOpts) error {
 // that was never recorded. The enforced block remains independent of this
 // error.
 func (p *Proxy) emitRequestPolicyReceipt(opts receipt.EmitOpts) error {
-	e := p.receiptEmitterPtr.Load()
-	if e == nil {
-		return errReceiptEmitterUnavailable
-	}
-	return p.emitReceiptWithEmitter(opts, e)
+	return emitRequestPolicyReceiptWithEmitter(
+		opts,
+		p.receiptEmitterPtr.Load(),
+		p.emitReceiptWithEmitter,
+	)
 }
 
 var errReceiptEmitterUnavailable = errors.New("receipt emitter unavailable")
+
+func emitRequestPolicyReceiptWithEmitter(
+	opts receipt.EmitOpts,
+	e *receipt.Emitter,
+	emit func(receipt.EmitOpts, *receipt.Emitter) error,
+) error {
+	if e == nil {
+		return errReceiptEmitterUnavailable
+	}
+	return emit(opts, e)
+}
 
 func requiredReceiptBlockMetricReason(err error) string {
 	if errors.Is(err, errReceiptEmitterUnavailable) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1033,11 +1033,19 @@ func (p *Proxy) emitReceipt(opts receipt.EmitOpts) error {
 // that was never recorded. The enforced block remains independent of this
 // error.
 func (p *Proxy) emitRequestPolicyReceipt(opts receipt.EmitOpts) error {
+	e := p.receiptEmitterPtr.Load()
+	if e == nil && requestPolicyReceiptsConfigured(p.cfgPtr.Load()) {
+		return p.recordReceiptEmitterUnavailable(opts)
+	}
 	return emitRequestPolicyReceiptWithEmitter(
 		opts,
-		p.receiptEmitterPtr.Load(),
+		e,
 		p.emitReceiptWithEmitter,
 	)
+}
+
+func requestPolicyReceiptsConfigured(cfg *config.Config) bool {
+	return cfg != nil && cfg.FlightRecorder.Enabled && strings.TrimSpace(cfg.FlightRecorder.SigningKeyPath) != ""
 }
 
 var errReceiptEmitterUnavailable = errors.New("receipt emitter unavailable")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1045,7 +1045,9 @@ func (p *Proxy) emitRequestPolicyReceipt(opts receipt.EmitOpts) error {
 }
 
 func requestPolicyReceiptsConfigured(cfg *config.Config) bool {
-	return cfg != nil && cfg.FlightRecorder.Enabled && strings.TrimSpace(cfg.FlightRecorder.SigningKeyPath) != ""
+	return cfg != nil && cfg.FlightRecorder.Enabled &&
+		strings.TrimSpace(cfg.FlightRecorder.Dir) != "" &&
+		strings.TrimSpace(cfg.FlightRecorder.SigningKeyPath) != ""
 }
 
 var errReceiptEmitterUnavailable = errors.New("receipt emitter unavailable")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -719,8 +719,8 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 				RequestID:   requestID,
 				Agent:       agentName,
 				AuditCtx:    newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName),
-				Emit: func(opts receipt.EmitOpts) {
-					_ = p.emitReceipt(withReceiptPolicyHash(opts, currentCfg.CanonicalPolicyHash()))
+				Emit: func(opts receipt.EmitOpts) error {
+					return p.emitRequestPolicyReceipt(withReceiptPolicyHash(opts, currentCfg.CanonicalPolicyHash()))
 				},
 			}); rpRes.Block {
 				return newRedirectBlockedRequest(blockLayerRequestPolicy, rpRes.Reason)
@@ -1024,6 +1024,20 @@ func (p *Proxy) emitReceipt(opts receipt.EmitOpts) error {
 		opts = withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash())
 	}
 	return p.emitReceiptWithEmitter(opts, p.receiptEmitterPtr.Load())
+}
+
+// emitRequestPolicyReceipt records one request_policy receipt through exactly
+// the emitter loaded for this call. Unlike emitReceipt's optional no-op
+// behavior, an unavailable emitter is an error here so request_policy can omit
+// its optional receipt-reference header rather than advertising an action ID
+// that was never recorded. The enforced block remains independent of this
+// error.
+func (p *Proxy) emitRequestPolicyReceipt(opts receipt.EmitOpts) error {
+	e := p.receiptEmitterPtr.Load()
+	if e == nil {
+		return errReceiptEmitterUnavailable
+	}
+	return p.emitReceiptWithEmitter(opts, e)
 }
 
 var errReceiptEmitterUnavailable = errors.New("receipt emitter unavailable")
@@ -4298,7 +4312,9 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		RequestID: requestID,
 		Agent:     agent,
 		AuditCtx:  actx,
-		Emit:      emitFetchReceipt,
+		Emit: func(opts receipt.EmitOpts) error {
+			return p.emitRequestPolicyReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+		},
 	}); rpRes.Block {
 		p.metrics.RecordBlocked(parsed.Hostname(), blockLayerRequestPolicy, time.Since(start), agentLabel)
 		writeBlockedJSON(w, rpRes.Info, http.StatusForbidden, FetchResponse{

--- a/internal/proxy/requestpolicy.go
+++ b/internal/proxy/requestpolicy.go
@@ -64,7 +64,9 @@ type requestPolicyInput struct {
 	RequestID string
 	Agent     string
 	AuditCtx  audit.LogContext
-	Emit      func(receipt.EmitOpts) error // transport's receipt emitter (e.g. p.emitReceipt)
+	// Emit must return an error when no receipt is recorded; optional emitters
+	// that treat an unavailable recorder as a successful no-op are invalid here.
+	Emit func(receipt.EmitOpts) error
 
 	// DeferBodyPredicate evaluates route-only rules and skips body-predicate
 	// (GraphQL / discriminator) evaluation for this call. The WebSocket

--- a/internal/proxy/requestpolicy.go
+++ b/internal/proxy/requestpolicy.go
@@ -64,7 +64,7 @@ type requestPolicyInput struct {
 	RequestID string
 	Agent     string
 	AuditCtx  audit.LogContext
-	Emit      func(receipt.EmitOpts) // transport's receipt emitter (e.g. p.emitReceipt)
+	Emit      func(receipt.EmitOpts) error // transport's receipt emitter (e.g. p.emitReceipt)
 
 	// DeferBodyPredicate evaluates route-only rules and skips body-predicate
 	// (GraphQL / discriminator) evaluation for this call. The WebSocket
@@ -355,13 +355,15 @@ func (p *Proxy) finalizeRequestPolicyDecision(in requestPolicyInput, d reqpolicy
 		return requestPolicyResult{}
 	}
 
-	// Enforced block.
+	// Enforced block. Receipt recording is best effort: an emission failure
+	// never weakens the policy decision, but it must not leave a response header
+	// pointing at a receipt that was not recorded.
 	p.logger.LogBlocked(in.AuditCtx, blockLayerRequestPolicy, d.RuleName)
 	actionID := ""
-	if in.Emit != nil && p.receiptEmitterPtr.Load() != nil {
-		actionID = receipt.NewActionID()
-		in.Emit(receipt.EmitOpts{
-			ActionID:  actionID,
+	if in.Emit != nil {
+		candidateActionID := receipt.NewActionID()
+		if err := in.Emit(receipt.EmitOpts{
+			ActionID:  candidateActionID,
 			Verdict:   config.ActionBlock,
 			Layer:     blockLayerRequestPolicy,
 			Pattern:   d.RuleName,
@@ -370,7 +372,9 @@ func (p *Proxy) finalizeRequestPolicyDecision(in requestPolicyInput, d reqpolicy
 			Target:    in.Target,
 			RequestID: in.RequestID,
 			Agent:     in.Agent,
-		})
+		}); err == nil {
+			actionID = candidateActionID
+		}
 	}
 	reason := d.Reason
 	if reason == "" {
@@ -388,18 +392,16 @@ func (p *Proxy) finalizeRequestPolicyDecision(in requestPolicyInput, d reqpolicy
 // layer header and let the reason code convey the layer (the same convention
 // the MCP and contract layers follow).
 //
-// Receipt correlation is gated on a configured receipt emitter, mirroring
-// emitReceipt's nil check. When an emitter is configured, actionID - which MUST
-// be the real receipt action_id (receipt.NewActionID) recorded for this same
-// block - is stamped into the receipt header so the agent can fetch the
-// matching receipt. A decorrelated identifier must never be passed here: an
-// action_id that points at no emitted receipt would make the header lie. When
-// no emitter is configured, or actionID is empty or malformed, the receipt slot
-// stays unset and the block still emits its required headers - the receipt is
-// optional metadata, so dropping it never weakens the block itself.
+// actionID is populated only after the transport receipt callback reports a
+// successful record. It MUST be the real receipt action_id (receipt.NewActionID)
+// recorded for this same block; a decorrelated identifier would make the header
+// lie. When receipt emission is unavailable or fails, actionID stays empty and
+// the receipt slot stays unset while the block still emits its required headers.
+// Receipt correlation is optional metadata, so dropping it never weakens the
+// block itself.
 func (p *Proxy) requestPolicyBlockInfo(actionID string) blockreason.Info {
 	info := blockInfoFor(blockreason.RequestPolicyDeny, "")
-	if actionID == "" || p.receiptEmitterPtr.Load() == nil {
+	if actionID == "" {
 		return info
 	}
 	withReceipt, err := info.WithReceipt(actionID)

--- a/internal/proxy/requestpolicy_enforcement_test.go
+++ b/internal/proxy/requestpolicy_enforcement_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -22,6 +23,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 const (
@@ -464,12 +466,18 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 		wantReceipt      bool
 		wantEmitErr      bool
 		configured       bool
+		keyWithoutDir    bool
 		wantUnavailable  bool
 		wantRecord       bool
 	}{
 		{
 			name:        "emitter absent blocks without receipt header",
 			wantEmitErr: true,
+		},
+		{
+			name:          "key without recorder directory is intentionally inert",
+			keyWithoutDir: true,
+			wantEmitErr:   true,
 		},
 		{
 			name:           "forward recorder success surfaces receipt header",
@@ -498,7 +506,7 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 			wantRecord:     true,
 		},
 		{
-			name:             "reload removes forward emitter before request-policy emission",
+			name:             "configured forward emitter disappears before request-policy emission",
 			installEmitter:   true,
 			removeBeforeEmit: true,
 			wantEmitErr:      true,
@@ -506,7 +514,7 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 			wantUnavailable:  true,
 		},
 		{
-			name:             "reload removes reverse emitter before request-policy emission",
+			name:             "configured reverse emitter disappears before request-policy emission",
 			installEmitter:   true,
 			removeBeforeEmit: true,
 			reverseEmit:      true,
@@ -518,8 +526,11 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := reqPolicyConfig(blockRule(http.MethodDelete))
+			if tc.keyWithoutDir {
+				cfg.FlightRecorder.SigningKeyPath = "/configured/test-receipt-key"
+			}
 			if tc.configured {
-				cfg.FlightRecorder.Enabled = true
+				cfg.FlightRecorder.Dir = "/configured/test-recorder"
 				cfg.FlightRecorder.SigningKeyPath = "/configured/test-receipt-key"
 			}
 			p := newTestProxyWithConfig(t, cfg)
@@ -575,6 +586,89 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRequestPolicy_ReceiptBehaviorAcrossHotReload(t *testing.T) {
+	recDir := t.TempDir()
+	keyPath := filepath.Join(t.TempDir(), "receipt.key")
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                recDir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+
+	initialCfg := reqPolicyConfig(blockRule(http.MethodDelete))
+	initialCfg.FlightRecorder.Dir = recDir
+	m := metrics.New()
+	p, err := New(initialCfg, audit.NewNop(), scanner.MustNew(initialCfg), m, WithRecorder(rec))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { p.Close() })
+
+	apply := func(requestID string) requestPolicyResult {
+		t.Helper()
+		return p.applyRequestPolicy(requestPolicyInput{
+			Host: rpTestHost, Method: http.MethodDelete, Path: "/v1/jobs/1",
+			Transport: TransportForward, Target: "https://" + rpTestHost + "/v1/jobs/1",
+			RequestID: requestID, AuditCtx: audit.NewRequestLogContext(requestID), Emit: p.emitRequestPolicyReceipt,
+		})
+	}
+	assertBlockReceipt := func(stage string, got requestPolicyResult, wantReceipt bool) {
+		t.Helper()
+		if !got.Block {
+			t.Fatalf("%s: request-policy block weakened across reload", stage)
+		}
+		if hasReceipt := got.Info.Receipt != ""; hasReceipt != wantReceipt {
+			t.Fatalf("%s: receipt reference present = %t, want %t", stage, hasReceipt, wantReceipt)
+		}
+	}
+
+	assertBlockReceipt("first load without signer", apply("reload-initial"), false)
+	assertMetricsNotContain(t, m, `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`)
+
+	enabledCfg := reqPolicyConfig(blockRule(http.MethodDelete))
+	enabledCfg.FlightRecorder.Dir = recDir
+	enabledCfg.FlightRecorder.SigningKeyPath = keyPath
+	if !p.Reload(enabledCfg, scanner.MustNew(enabledCfg)) {
+		t.Fatal("enabling receipt reload returned false")
+	}
+	assertBlockReceipt("first receipt-enabling reload", apply("reload-enabled"), true)
+
+	unrelatedCfg := reqPolicyConfig(blockRule(http.MethodDelete))
+	unrelatedCfg.FlightRecorder.Dir = recDir
+	unrelatedCfg.FlightRecorder.SigningKeyPath = keyPath
+	unrelatedCfg.Logging.IncludeAllowed = false
+	if !p.Reload(unrelatedCfg, scanner.MustNew(unrelatedCfg)) {
+		t.Fatal("unrelated reload returned false")
+	}
+	assertBlockReceipt("unrelated reload", apply("reload-unrelated"), true)
+
+	badCfg := reqPolicyConfig(blockRule(http.MethodDelete))
+	badCfg.FlightRecorder.Dir = recDir
+	badCfg.FlightRecorder.SigningKeyPath = filepath.Join(t.TempDir(), "missing.key")
+	if p.Reload(badCfg, scanner.MustNew(badCfg)) {
+		t.Fatal("bad signing-key reload unexpectedly succeeded")
+	}
+	assertBlockReceipt("failed reload preserves live signer", apply("reload-failed"), true)
+
+	downgradeCfg := reqPolicyConfig(blockRule(http.MethodDelete))
+	downgradeCfg.FlightRecorder.Dir = recDir
+	if !p.Reload(downgradeCfg, scanner.MustNew(downgradeCfg)) {
+		t.Fatal("receipt-removal reload returned false")
+	}
+	assertBlockReceipt("intentional receipt downgrade", apply("reload-downgrade"), false)
+	assertMetricsNotContain(t, m, `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`)
 }
 
 // newRequestPolicyReceiptEmitter returns a real signed receipt emitter. Closing

--- a/internal/proxy/requestpolicy_enforcement_test.go
+++ b/internal/proxy/requestpolicy_enforcement_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -598,6 +599,14 @@ func TestRequestPolicy_ReceiptBehaviorAcrossHotReload(t *testing.T) {
 	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
 		t.Fatalf("SavePrivateKey: %v", err)
 	}
+	rotatedKeyPath := filepath.Join(t.TempDir(), "receipt-rotated.key")
+	_, rotatedPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey rotated: %v", err)
+	}
+	if err := signing.SavePrivateKey(rotatedPriv, rotatedKeyPath); err != nil {
+		t.Fatalf("SavePrivateKey rotated: %v", err)
+	}
 	rec, err := recorder.New(recorder.Config{
 		Enabled:            true,
 		Dir:                recDir,
@@ -606,6 +615,7 @@ func TestRequestPolicy_ReceiptBehaviorAcrossHotReload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("recorder.New: %v", err)
 	}
+	t.Cleanup(func() { _ = rec.Close() })
 
 	initialCfg := reqPolicyConfig(blockRule(http.MethodDelete))
 	initialCfg.FlightRecorder.Dir = recDir
@@ -653,6 +663,17 @@ func TestRequestPolicy_ReceiptBehaviorAcrossHotReload(t *testing.T) {
 		t.Fatal("unrelated reload returned false")
 	}
 	assertBlockReceipt("unrelated reload", apply("reload-unrelated"), true)
+
+	rotatedCfg := reqPolicyConfig(blockRule(http.MethodDelete))
+	rotatedCfg.FlightRecorder.Dir = recDir
+	rotatedCfg.FlightRecorder.SigningKeyPath = rotatedKeyPath
+	if !p.Reload(rotatedCfg, scanner.MustNew(rotatedCfg)) {
+		t.Fatal("signing-key rotation reload returned false")
+	}
+	if got, want := p.receiptEmitterPtr.Load().SignerKeyHex(), hex.EncodeToString(rotatedPriv.Public().(ed25519.PublicKey)); got != want {
+		t.Fatalf("rotated signer = %q, want %q", got, want)
+	}
+	assertBlockReceipt("signing-key rotation", apply("reload-rotated"), true)
 
 	badCfg := reqPolicyConfig(blockRule(http.MethodDelete))
 	badCfg.FlightRecorder.Dir = recDir

--- a/internal/proxy/requestpolicy_enforcement_test.go
+++ b/internal/proxy/requestpolicy_enforcement_test.go
@@ -454,29 +454,139 @@ func TestApplyRequestPolicy_OpaqueWithMethodOverrideFailsClosed(t *testing.T) {
 	}
 }
 
-func TestApplyRequestPolicy_BlockCarriesReceiptWhenEmitterConfigured(t *testing.T) {
-	t.Parallel()
-	p := newTestProxyWithConfig(t, reqPolicyConfig(blockRule(http.MethodDelete)))
-	// A configured receipt emitter makes the block stamp the real action_id
-	// into the receipt header and emit a correlated receipt. The gating only
-	// reads the pointer for non-nil presence, so a zero-value emitter suffices.
-	p.receiptEmitterPtr.Store(&receipt.Emitter{})
+func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
+	tests := []struct {
+		name             string
+		installEmitter   bool
+		closeBefore      bool
+		removeBeforeEmit bool
+		reverseEmit      bool
+		wantReceipt      bool
+		wantEmitErr      bool
+	}{
+		{
+			name:        "emitter absent blocks without receipt header",
+			wantEmitErr: true,
+		},
+		{
+			name:           "forward recorder success surfaces receipt header",
+			installEmitter: true,
+			wantReceipt:    true,
+		},
+		{
+			name:           "forward closed recorder keeps block but omits nonexistent receipt header",
+			installEmitter: true,
+			closeBefore:    true,
+			wantEmitErr:    true,
+		},
+		{
+			name:           "reverse recorder success surfaces receipt header",
+			installEmitter: true,
+			reverseEmit:    true,
+			wantReceipt:    true,
+		},
+		{
+			name:           "reverse closed recorder keeps block but omits nonexistent receipt header",
+			installEmitter: true,
+			closeBefore:    true,
+			reverseEmit:    true,
+			wantEmitErr:    true,
+		},
+		{
+			name:             "reload removes forward emitter before request-policy emission",
+			installEmitter:   true,
+			removeBeforeEmit: true,
+			wantEmitErr:      true,
+		},
+		{
+			name:             "reload removes reverse emitter before request-policy emission",
+			installEmitter:   true,
+			removeBeforeEmit: true,
+			reverseEmit:      true,
+			wantEmitErr:      true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := reqPolicyConfig(blockRule(http.MethodDelete))
+			p := newTestProxyWithConfig(t, cfg)
+			var emitErr error
+			emitReceipt := p.emitRequestPolicyReceipt
+			if tc.installEmitter {
+				emitter := newRequestPolicyReceiptEmitter(t, cfg, tc.closeBefore)
+				p.receiptEmitterPtr.Store(emitter)
+				if tc.reverseEmit {
+					rp := &ReverseProxyHandler{
+						cfgPtr:            &p.cfgPtr,
+						logger:            p.logger,
+						metrics:           p.metrics,
+						receiptEmitterPtr: p.ReceiptEmitterPtr(),
+					}
+					emitReceipt = rp.emitRequestPolicyReceipt
+				}
+			}
+			emit := func(opts receipt.EmitOpts) error {
+				if tc.removeBeforeEmit {
+					p.receiptEmitterPtr.Store(nil)
+				}
+				emitErr = emitReceipt(opts)
+				return emitErr
+			}
 
-	emitted := 0
-	res := p.applyRequestPolicy(requestPolicyInput{
-		Host: rpTestHost, Method: http.MethodDelete, Path: "/v1/jobs/1",
-		Transport: TransportForward, AuditCtx: audit.LogContext{},
-		Emit: func(receipt.EmitOpts) { emitted++ },
+			res := p.applyRequestPolicy(requestPolicyInput{
+				Host: rpTestHost, Method: http.MethodDelete, Path: "/v1/jobs/1",
+				Transport: TransportForward, Target: "https://" + rpTestHost + "/v1/jobs/1",
+				RequestID: "request-policy-receipt", Agent: "test-agent", AuditCtx: audit.LogContext{}, Emit: emit,
+			})
+			if !res.Block {
+				t.Fatal("request_policy block must not depend on optional receipt recording")
+			}
+			if (emitErr != nil) != tc.wantEmitErr {
+				t.Fatalf("receipt emission error = %v, want error=%t", emitErr, tc.wantEmitErr)
+			}
+			gotReceipt := res.Info.Receipt != ""
+			if gotReceipt != tc.wantReceipt {
+				t.Fatalf("receipt header present = %t, want %t", gotReceipt, tc.wantReceipt)
+			}
+		})
+	}
+}
+
+// newRequestPolicyReceiptEmitter returns a real signed receipt emitter. Closing
+// its recorder before returning forces an actual persistence failure rather
+// than a synthetic callback error, which proves the request-policy header gate
+// follows recorder success while preserving the enforced block.
+func newRequestPolicyReceiptEmitter(t *testing.T, cfg *config.Config, closeBefore bool) *receipt.Emitter {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                t.TempDir(),
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: cfg.CanonicalPolicyHash(),
+		Principal:  "test-principal",
+		Actor:      "test-actor",
 	})
-	if !res.Block {
-		t.Fatal("expected block")
+	if emitter == nil {
+		t.Fatal("receipt.NewEmitter returned nil")
 	}
-	if emitted != 1 {
-		t.Fatalf("expected exactly one receipt emission, got %d", emitted)
+	if closeBefore {
+		if err := rec.Close(); err != nil {
+			t.Fatalf("recorder.Close: %v", err)
+		}
 	}
-	if res.Info.Receipt == "" {
-		t.Error("receipt header should be populated when an emitter is configured")
-	}
+	return emitter
 }
 
 func TestSetupRequestPolicy_InvalidPatternFailsStartup(t *testing.T) {

--- a/internal/proxy/requestpolicy_enforcement_test.go
+++ b/internal/proxy/requestpolicy_enforcement_test.go
@@ -463,6 +463,9 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 		reverseEmit      bool
 		wantReceipt      bool
 		wantEmitErr      bool
+		configured       bool
+		wantUnavailable  bool
+		wantRecord       bool
 	}{
 		{
 			name:        "emitter absent blocks without receipt header",
@@ -478,6 +481,7 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 			installEmitter: true,
 			closeBefore:    true,
 			wantEmitErr:    true,
+			wantRecord:     true,
 		},
 		{
 			name:           "reverse recorder success surfaces receipt header",
@@ -491,12 +495,15 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 			closeBefore:    true,
 			reverseEmit:    true,
 			wantEmitErr:    true,
+			wantRecord:     true,
 		},
 		{
 			name:             "reload removes forward emitter before request-policy emission",
 			installEmitter:   true,
 			removeBeforeEmit: true,
 			wantEmitErr:      true,
+			configured:       true,
+			wantUnavailable:  true,
 		},
 		{
 			name:             "reload removes reverse emitter before request-policy emission",
@@ -504,16 +511,22 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 			removeBeforeEmit: true,
 			reverseEmit:      true,
 			wantEmitErr:      true,
+			configured:       true,
+			wantUnavailable:  true,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := reqPolicyConfig(blockRule(http.MethodDelete))
+			if tc.configured {
+				cfg.FlightRecorder.Enabled = true
+				cfg.FlightRecorder.SigningKeyPath = "/configured/test-receipt-key"
+			}
 			p := newTestProxyWithConfig(t, cfg)
 			var emitErr error
 			emitReceipt := p.emitRequestPolicyReceipt
 			if tc.installEmitter {
-				emitter := newRequestPolicyReceiptEmitter(t, cfg, tc.closeBefore)
+				emitter := newRequestPolicyReceiptEmitter(t, cfg, p.metrics, tc.closeBefore)
 				p.receiptEmitterPtr.Store(emitter)
 				if tc.reverseEmit {
 					rp := &ReverseProxyHandler{
@@ -548,6 +561,18 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 			if gotReceipt != tc.wantReceipt {
 				t.Fatalf("receipt header present = %t, want %t", gotReceipt, tc.wantReceipt)
 			}
+			unavailableMetric := `pipelock_receipt_emit_failures_total{reason="unavailable"} 1`
+			if tc.wantUnavailable {
+				assertMetricsContain(t, p.metrics, unavailableMetric)
+			} else {
+				assertMetricsNotContain(t, p.metrics, unavailableMetric)
+			}
+			recordMetric := `pipelock_receipt_emit_failures_total{reason="record"} 1`
+			if tc.wantRecord {
+				assertMetricsContain(t, p.metrics, recordMetric)
+			} else {
+				assertMetricsNotContain(t, p.metrics, recordMetric)
+			}
 		})
 	}
 }
@@ -556,7 +581,7 @@ func TestApplyRequestPolicy_ReceiptHeaderRequiresRecordedReceipt(t *testing.T) {
 // its recorder before returning forces an actual persistence failure rather
 // than a synthetic callback error, which proves the request-policy header gate
 // follows recorder success while preserving the enforced block.
-func newRequestPolicyReceiptEmitter(t *testing.T, cfg *config.Config, closeBefore bool) *receipt.Emitter {
+func newRequestPolicyReceiptEmitter(t *testing.T, cfg *config.Config, m receipt.MetricsSink, closeBefore bool) *receipt.Emitter {
 	t.Helper()
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -577,6 +602,7 @@ func newRequestPolicyReceiptEmitter(t *testing.T, cfg *config.Config, closeBefor
 		ConfigHash: cfg.CanonicalPolicyHash(),
 		Principal:  "test-principal",
 		Actor:      "test-actor",
+		Metrics:    m,
 	})
 	if emitter == nil {
 		t.Fatal("receipt.NewEmitter returned nil")

--- a/internal/proxy/requestpolicy_test.go
+++ b/internal/proxy/requestpolicy_test.go
@@ -59,46 +59,31 @@ func TestRequestPolicyBlockInfo_HeaderShape(t *testing.T) {
 	}
 }
 
-// TestRequestPolicyBlockInfo_ReceiptGatedOnEmitter asserts the receipt header
-// is populated with the real receipt action_id iff a receipt emitter is
-// configured, and that a missing, empty, or malformed action_id leaves the
-// slot unset without dropping the block's required headers.
-//
-// The fixture uses a zero-value *receipt.Emitter because requestPolicyBlockInfo
-// only consults receiptEmitterPtr.Load() for non-nil presence (mirroring
-// emitReceipt's nil check) - it never calls Emit, so no recorder or signing key
-// is needed to exercise the gating.
-func TestRequestPolicyBlockInfo_ReceiptGatedOnEmitter(t *testing.T) {
+// TestRequestPolicyBlockInfo_ReceiptRequiresRecordedActionID asserts that the
+// block-info helper accepts only a valid action ID. Its caller supplies one
+// solely after receipt emission succeeds; unavailable and failed emitters pass
+// an empty ID and are covered at the enforced request-policy path.
+func TestRequestPolicyBlockInfo_ReceiptRequiresRecordedActionID(t *testing.T) {
 	t.Parallel()
-	realActionID := receipt.NewActionID() // UUIDv7, the form a live block path stamps
+	realActionID := receipt.NewActionID() // UUIDv7, the form a recorded block stamps
 
 	cases := []struct {
 		name        string
-		emitter     *receipt.Emitter
 		actionID    string
 		wantReceipt string
 	}{
 		{
-			name:        "emitter configured: real action_id surfaces in receipt header",
-			emitter:     &receipt.Emitter{},
+			name:        "recorded action_id surfaces in receipt header",
 			actionID:    realActionID,
 			wantReceipt: realActionID,
 		},
 		{
-			name:        "no emitter: receipt header stays unset even with a valid id",
-			emitter:     nil,
-			actionID:    realActionID,
-			wantReceipt: "",
-		},
-		{
-			name:        "emitter configured but empty action_id: receipt header unset",
-			emitter:     &receipt.Emitter{},
+			name:        "empty action_id leaves receipt header unset",
 			actionID:    "",
 			wantReceipt: "",
 		},
 		{
-			name:        "emitter configured but malformed action_id: receipt dropped, block intact",
-			emitter:     &receipt.Emitter{},
+			name:        "malformed action_id is dropped while block remains intact",
 			actionID:    "not-a-valid-receipt-id",
 			wantReceipt: "",
 		},
@@ -106,9 +91,6 @@ func TestRequestPolicyBlockInfo_ReceiptGatedOnEmitter(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &Proxy{}
-			if tc.emitter != nil {
-				p.receiptEmitterPtr.Store(tc.emitter)
-			}
 			info := p.requestPolicyBlockInfo(tc.actionID)
 
 			h := make(http.Header)

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -262,9 +262,13 @@ func (rp *ReverseProxyHandler) emitReceipt(opts receipt.EmitOpts) error {
 // shared request-policy finalizer does not surface a receipt reference without
 // evidence; ordinary optional receipt emission remains a no-op when disabled.
 func (rp *ReverseProxyHandler) emitRequestPolicyReceipt(opts receipt.EmitOpts) error {
+	e := rp.receiptEmitter()
+	if e == nil && rp != nil && rp.cfgPtr != nil && requestPolicyReceiptsConfigured(rp.cfgPtr.Load()) {
+		return rp.recordReceiptEmitterUnavailable(opts)
+	}
 	return emitRequestPolicyReceiptWithEmitter(
 		opts,
-		rp.receiptEmitter(),
+		e,
 		rp.emitReceiptWithEmitter,
 	)
 }

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -257,6 +257,18 @@ func (rp *ReverseProxyHandler) emitReceipt(opts receipt.EmitOpts) error {
 	return rp.emitReceiptWithEmitter(opts, e)
 }
 
+// emitRequestPolicyReceipt records one request_policy receipt through exactly
+// the emitter loaded for this call. An unavailable emitter is reported so the
+// shared request-policy finalizer does not surface a receipt reference without
+// evidence; ordinary optional receipt emission remains a no-op when disabled.
+func (rp *ReverseProxyHandler) emitRequestPolicyReceipt(opts receipt.EmitOpts) error {
+	e := rp.receiptEmitter()
+	if e == nil {
+		return errReceiptEmitterUnavailable
+	}
+	return rp.emitReceiptWithEmitter(opts, e)
+}
+
 func (rp *ReverseProxyHandler) emitRequiredReceipt(opts receipt.EmitOpts) error {
 	e := rp.receiptEmitter()
 	if e == nil {
@@ -841,7 +853,12 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			RequestID:   requestID,
 			Agent:       agent,
 			AuditCtx:    newHTTPAuditContext(rp.logger, r.Method, targetURL, clientIP, requestID, agent),
-			Emit:        emitReverseReceipt,
+			Emit: func(opts receipt.EmitOpts) error {
+				if snap.cfg != nil {
+					opts = withReceiptPolicyHash(opts, snap.cfg.CanonicalPolicyHash())
+				}
+				return rp.emitRequestPolicyReceipt(opts)
+			},
 		}
 		if rp.reqPolicyPrepareFn != nil {
 			if rpRes := rp.reqPolicyPrepareFn(r, &rpInput); rpRes.Block {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -262,11 +262,11 @@ func (rp *ReverseProxyHandler) emitReceipt(opts receipt.EmitOpts) error {
 // shared request-policy finalizer does not surface a receipt reference without
 // evidence; ordinary optional receipt emission remains a no-op when disabled.
 func (rp *ReverseProxyHandler) emitRequestPolicyReceipt(opts receipt.EmitOpts) error {
-	e := rp.receiptEmitter()
-	if e == nil {
-		return errReceiptEmitterUnavailable
-	}
-	return rp.emitReceiptWithEmitter(opts, e)
+	return emitRequestPolicyReceiptWithEmitter(
+		opts,
+		rp.receiptEmitter(),
+		rp.emitReceiptWithEmitter,
+	)
 }
 
 func (rp *ReverseProxyHandler) emitRequiredReceipt(opts receipt.EmitOpts) error {

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -566,18 +566,20 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// to per-frame evaluation in the relay; only route-only rules gate the
 	// handshake here.
 	if rpRes := p.applyRequestPolicy(requestPolicyInput{
-		Host:               parsed.Hostname(),
-		Method:             http.MethodGet,
-		Path:               parsed.EscapedPath(),
-		ContentType:        r.Header.Get(headerContentType),
-		Headers:            r.Header,
-		BodyRead:           true,
-		Transport:          TransportWS,
-		Target:             targetURL,
-		RequestID:          requestID,
-		Agent:              agent,
-		AuditCtx:           actx,
-		Emit:               emitWebSocketReceipt,
+		Host:        parsed.Hostname(),
+		Method:      http.MethodGet,
+		Path:        parsed.EscapedPath(),
+		ContentType: r.Header.Get(headerContentType),
+		Headers:     r.Header,
+		BodyRead:    true,
+		Transport:   TransportWS,
+		Target:      targetURL,
+		RequestID:   requestID,
+		Agent:       agent,
+		AuditCtx:    actx,
+		Emit: func(opts receipt.EmitOpts) error {
+			return p.emitRequestPolicyReceipt(withReceiptPolicyHash(opts, cfg.CanonicalPolicyHash()))
+		},
 		DeferBodyPredicate: true,
 	}); rpRes.Block {
 		p.metrics.RecordWSBlocked()
@@ -1185,8 +1187,8 @@ func (r *wsRelay) applyFrameRequestPolicy(log *audit.Logger, msg []byte) bool {
 	in.RequestID = r.requestID
 	in.Agent = r.agent
 	in.AuditCtx = newHTTPAuditContext(log, "WS", r.targetURL, r.clientIP, r.requestID, r.agent)
-	in.Emit = func(opts receipt.EmitOpts) {
-		_ = r.emitReceipt(opts)
+	in.Emit = func(opts receipt.EmitOpts) error {
+		return r.proxy.emitRequestPolicyReceipt(withReceiptPolicyHash(opts, r.cfg.CanonicalPolicyHash()))
 	}
 	res := r.proxy.applyRequestPolicy(in)
 	if !res.Block {


### PR DESCRIPTION
## Summary

- propagate request-policy receipt recording failures through every mediated transport
- attach the optional receipt reference only after the recorder reports success
- preserve the policy block when recording is unavailable or fails
- cover absent, closed-recorder, and hot-reload removal states with real signed-receipt regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request-policy blocking remains enforced when receipt recording is unavailable or fails.
  * Receipt references are included only after successful receipt recording.
  * Policy receipts now consistently use the correct policy information across HTTP, CONNECT, redirect, fetch, reverse, and WebSocket requests.
  * Receipt-emission errors are handled consistently, improving policy-enforcement reliability.

* **Tests**
  * Expanded coverage for successful, unavailable, and failed receipt-emission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->