### PR TITLE
feat(scripts): gate PR convergence on four lifecycle checkpoints

### DIFF
--- a/scripts/pr-convergence.py
+++ b/scripts/pr-convergence.py
@@ -489,9 +489,12 @@ def gather_sibling_overlaps(
     for candidate in sibling_prs:
         candidate = as_dict(candidate)
         cand_number = candidate.get("number")
-        cand_head_ref = dotted_get(candidate, "head", "ref")
         cand_base_ref = dotted_get(candidate, "base", "ref")
-        if cand_number == pr_number or cand_head_ref == head_ref:
+        # Exclude only THIS pull request, by number. Excluding by head ref as
+        # well would drop a genuine sibling that happens to share the branch
+        # name, which is entirely possible across forks, and a sibling silently
+        # dropped from the candidate set reads as no overlap.
+        if cand_number == pr_number:
             continue
         if cand_base_ref != base_ref:
             continue
@@ -507,7 +510,7 @@ def gather_sibling_overlaps(
         errors.append({
             "source": "sibling_prs",
             "message": (
-                f"{len(siblings)} same-base siblings exceeds the {MAX_SIBLING_FETCHES} "
+                f"{len(siblings)} same-base siblings exceed the {MAX_SIBLING_FETCHES} "
                 "fetch cap; overlap detection is incomplete"
             ),
         })

--- a/scripts/pr-convergence.py
+++ b/scripts/pr-convergence.py
@@ -22,6 +22,14 @@ import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
+
+# Cap the per-sibling changed-file fetch. Each sibling costs one paginated REST
+# call, so an unbounded loop scales with the open-PR count and can approach the
+# rate limit on a busy repo. When the cap truncates the candidate set the
+# shortfall is reported rather than silently dropped, because a quietly
+# truncated scan reads as "no overlap found".
+MAX_SIBLING_FETCHES = 25
 
 
 VALID_GATES = ("task-start", "pre-edit", "pre-push", "post-push")
@@ -386,6 +394,23 @@ query($owner: String!, $name: String!, $number: Int!, $after: String) {
             node_mapper=as_dict,
         )
 
+    def open_pulls_by_base_ref(self, repo: str, base_ref: str) -> list[dict[str, Any]]:
+        """Return open PRs whose BASE branch is base_ref.
+
+        Sibling detection needs PRs that target the same base, which is not the
+        same question as graphql_open_pulls_by_head_ref answers. That method
+        filters on headRefName and is used for stack-child detection; passing a
+        base branch to it asks "which open PRs are headed by main", which is
+        essentially always none. This uses the REST base filter instead, and
+        returns each candidate's base ref so the caller can verify it.
+        """
+        return as_list(
+            self.api(
+                f"repos/{repo}/pulls?state=open&base={quote(base_ref, safe='')}&per_page=100",
+                paginate=True,
+            )
+        )
+
     def graphql_open_pulls_by_head_ref(self, head_ref_name: str) -> list[dict[str, Any]]:
         query = """
 query($owner: String!, $name: String!, $headRefName: String!, $after: String) {
@@ -451,25 +476,42 @@ def gather_sibling_overlaps(
         return result
 
     try:
-        sibling_prs = client.graphql_open_pulls_by_head_ref(base_ref)
+        sibling_prs = client.open_pulls_by_base_ref(repo, base_ref)
     except GhReadError as exc:
         errors.append({"source": "sibling_prs", "message": str(exc)})
         return result
 
-    # Filter: only PRs targeting the same base that are NOT this PR and NOT
-    # a stack parent/child (different head ref targeting the same base).
+    # Keep only open PRs that genuinely target the same base and are neither
+    # this PR nor its own head. The base ref is re-verified from the returned
+    # payload rather than trusted from the request filter, so a server-side
+    # filter change cannot silently widen the candidate set.
     siblings = []
     for candidate in sibling_prs:
         candidate = as_dict(candidate)
         cand_number = candidate.get("number")
         cand_head_ref = dotted_get(candidate, "head", "ref")
+        cand_base_ref = dotted_get(candidate, "base", "ref")
         if cand_number == pr_number or cand_head_ref == head_ref:
+            continue
+        if cand_base_ref != base_ref:
             continue
         if str(candidate.get("state", "")).lower() != "open":
             continue
         siblings.append(candidate)
 
     result["siblings_checked"] = len(siblings)
+    # Truncation is reported, never silent. A capped scan that found nothing is
+    # not the same claim as a complete scan that found nothing.
+    if len(siblings) > MAX_SIBLING_FETCHES:
+        result["siblings_truncated"] = len(siblings) - MAX_SIBLING_FETCHES
+        errors.append({
+            "source": "sibling_prs",
+            "message": (
+                f"{len(siblings)} same-base siblings exceeds the {MAX_SIBLING_FETCHES} "
+                "fetch cap; overlap detection is incomplete"
+            ),
+        })
+        siblings = siblings[:MAX_SIBLING_FETCHES]
 
     for sibling in siblings:
         sib_number = sibling.get("number")
@@ -582,16 +624,20 @@ def gather_pr_state(repo: str, pr_number: int) -> dict[str, Any]:
         data["compare"] = {}
 
     # Fetch this PR's changed files for sibling overlap detection.
+    # Keep the uncoalesced result: read_source returns None only on a failed
+    # read, and collapsing that to [] here would make a failed read
+    # indistinguishable from a successful empty one. They are different states
+    # and they get different statuses.
     pr_files_raw = read_source(
         "pr_files",
         lambda: client.api(
             f"repos/{repo}/pulls/{pr_number}/files?per_page=100",
             paginate=True,
         ),
-    ) or []
+    )
     own_files = [
         str(as_dict(f).get("filename") or "")
-        for f in as_list(pr_files_raw)
+        for f in as_list(pr_files_raw or [])
         if as_dict(f).get("filename")
     ]
     data["pr_files"] = own_files

--- a/scripts/pr-convergence.py
+++ b/scripts/pr-convergence.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import Any
 
 
+VALID_GATES = ("task-start", "pre-edit", "pre-push", "post-push")
+
 STATUS_DOCS: dict[str, str] = {
     "READY": "Current head has no detected blockers after an unchanged snapshot window.",
     "CHECKS_PENDING": "At least one current-head check or status context is queued or in progress.",
@@ -38,6 +40,8 @@ STATUS_DOCS: dict[str, str] = {
     "MERGE_BLOCKED": "GitHub reports a blocked, draft, closed, or unknown merge state.",
     "CHANGED_DURING_WINDOW": "A comment, review, check, or commit changed since the prior snapshot.",
     "SNAPSHOT_MISSING": "A snapshot path was requested but no prior snapshot existed yet.",
+    "SIBLING_PATH_OVERLAP": "An independent sibling PR shares changed paths without git ancestry proving a stack.",
+    "CHANGED_PATHS_UNKNOWN": "The changed-path read returned no files, so sibling overlap could not be evaluated.",
     "DATA_SOURCE_UNAVAILABLE": "At least one required read source failed, so readiness is unknown.",
 }
 
@@ -410,6 +414,92 @@ query($owner: String!, $name: String!, $headRefName: String!, $after: String) {
         )
 
 
+def gather_sibling_overlaps(
+    client: GhClient,
+    repo: str,
+    pr_number: int,
+    base_ref: str,
+    head_ref: str,
+    own_files: list[str],
+    errors: list[dict[str, str]],
+) -> dict[str, Any]:
+    """Detect independent sibling PRs that share changed paths with this PR.
+
+    A sibling is another open PR targeting the SAME base ref.  If a sibling
+    shares a changed path, the overlap is reported.
+
+    Ancestry is NOT proven here, and the same-base filter is what stands in for
+    it.  A PR stacked on another PR takes its parent's branch as its base, so
+    it does not appear in this same-base set and is not flagged.  That is a
+    structural approximation, not a merge-base computation: a stacked pair that
+    both target the base branch directly would still be reported as an overlap
+    and would need a human to confirm the stack.  Do not describe this function
+    as ancestry-aware.
+
+    Fail-closed: any API error gathering siblings results in an error entry
+    (which triggers DATA_SOURCE_UNAVAILABLE), never a silent pass.  A read that
+    succeeds but returns no changed paths is handled by the caller as
+    CHANGED_PATHS_UNKNOWN, because this function cannot distinguish "no
+    overlap" from "nothing to compare".
+    """
+    result: dict[str, Any] = {
+        "own_files": sorted(own_files),
+        "siblings_checked": 0,
+        "overlapping_siblings": [],
+    }
+    if not own_files or not base_ref:
+        return result
+
+    try:
+        sibling_prs = client.graphql_open_pulls_by_head_ref(base_ref)
+    except GhReadError as exc:
+        errors.append({"source": "sibling_prs", "message": str(exc)})
+        return result
+
+    # Filter: only PRs targeting the same base that are NOT this PR and NOT
+    # a stack parent/child (different head ref targeting the same base).
+    siblings = []
+    for candidate in sibling_prs:
+        candidate = as_dict(candidate)
+        cand_number = candidate.get("number")
+        cand_head_ref = dotted_get(candidate, "head", "ref")
+        if cand_number == pr_number or cand_head_ref == head_ref:
+            continue
+        if str(candidate.get("state", "")).lower() != "open":
+            continue
+        siblings.append(candidate)
+
+    result["siblings_checked"] = len(siblings)
+
+    for sibling in siblings:
+        sib_number = sibling.get("number")
+        try:
+            sib_files_raw = client.api(
+                f"repos/{repo}/pulls/{sib_number}/files?per_page=100",
+                paginate=True,
+            )
+        except GhReadError as exc:
+            errors.append({"source": f"sibling_files_{sib_number}", "message": str(exc)})
+            continue
+
+        sib_files = {
+            str(as_dict(f).get("filename") or "")
+            for f in as_list(sib_files_raw)
+            if as_dict(f).get("filename")
+        }
+        overlap = sorted(set(own_files) & sib_files)
+        if overlap:
+            result["overlapping_siblings"].append({
+                "number": sib_number,
+                "title": sibling.get("title"),
+                "head_ref": dotted_get(sibling, "head", "ref"),
+                "url": sibling.get("html_url"),
+                "overlapping_paths": overlap,
+            })
+
+    return result
+
+
 def gather_pr_state(repo: str, pr_number: int) -> dict[str, Any]:
     client = GhClient(repo)
     data: dict[str, Any] = {"repo": repo, "pr_number": pr_number, "errors": []}
@@ -490,6 +580,33 @@ def gather_pr_state(repo: str, pr_number: int) -> dict[str, Any]:
     else:
         data["errors"].append({"source": "compare", "message": "base or head SHA unavailable"})
         data["compare"] = {}
+
+    # Fetch this PR's changed files for sibling overlap detection.
+    pr_files_raw = read_source(
+        "pr_files",
+        lambda: client.api(
+            f"repos/{repo}/pulls/{pr_number}/files?per_page=100",
+            paginate=True,
+        ),
+    ) or []
+    own_files = [
+        str(as_dict(f).get("filename") or "")
+        for f in as_list(pr_files_raw)
+        if as_dict(f).get("filename")
+    ]
+    data["pr_files"] = own_files
+    # A successful read that yields zero changed paths is not a negative
+    # result, it is an impossible one: an open PR always changes at least one
+    # file. Treating it as "no files" would silently disable sibling-overlap
+    # detection while still reporting READY, so an empty successful read is
+    # recorded as its own unknown state. This is distinct from a failed read,
+    # which read_source already routes to DATA_SOURCE_UNAVAILABLE.
+    data["changed_paths_unknown"] = pr_files_raw is not None and not own_files
+
+    head_ref = str(dotted_get(pull_data, "head", "ref") or "")
+    data["sibling_overlaps"] = gather_sibling_overlaps(
+        client, repo, pr_number, base_ref, head_ref, own_files, data["errors"],
+    )
 
     return data
 
@@ -800,6 +917,8 @@ def normalize_stack(data: dict[str, Any], pr_number: int) -> dict[str, Any]:
             break
     compare = as_dict(data.get("compare"))
     behind_by = int(compare.get("behind_by") or 0)
+    sibling_overlaps = as_dict(data.get("sibling_overlaps"))
+    overlapping_siblings = as_list(sibling_overlaps.get("overlapping_siblings"))
     return {
         "base_ref": base_ref,
         "base_sha": base.get("sha"),
@@ -813,6 +932,9 @@ def normalize_stack(data: dict[str, Any], pr_number: int) -> dict[str, Any]:
         "compare_status": compare.get("status"),
         "behind_by": behind_by,
         "ahead_by": int(compare.get("ahead_by") or 0),
+        "sibling_overlap_count": len(overlapping_siblings),
+        "overlapping_siblings": overlapping_siblings,
+        "siblings_checked": int(sibling_overlaps.get("siblings_checked") or 0),
     }
 
 
@@ -933,6 +1055,8 @@ def choose_status(result: dict[str, Any], snapshot_missing: bool) -> str:
     merge_state = str(merge.get("merge_state_status") or "").upper()
     if result["errors"]:
         return "DATA_SOURCE_UNAVAILABLE"
+    if result.get("changed_paths_unknown"):
+        return "CHANGED_PATHS_UNKNOWN"
     if result["change_detection"]["changed"]:
         return "CHANGED_DURING_WINDOW"
     if merge.get("mergeable") is False or merge_state in CONFLICT_MERGE_STATES:
@@ -953,6 +1077,8 @@ def choose_status(result: dict[str, Any], snapshot_missing: bool) -> str:
         return "UNRESOLVED_THREADS"
     if result["top_level_comments"]["unreviewed_ai_finding_count"] > 0:
         return "UNREVIEWED_AI_FINDINGS"
+    if result["stack"].get("sibling_overlap_count", 0) > 0:
+        return "SIBLING_PATH_OVERLAP"
     if merge_state in BLOCKED_MERGE_STATES or merge.get("is_draft") or merge.get("state") != "open":
         return "MERGE_BLOCKED"
     if snapshot_missing:
@@ -965,6 +1091,7 @@ def classify_pr_state(
     *,
     previous_snapshot: dict[str, Any] | None = None,
     snapshot_requested: bool = False,
+    gate: str = "",
 ) -> dict[str, Any]:
     pull = as_dict(data.get("pull"))
     pr_number = int(data.get("pr_number") or pull.get("number") or 0)
@@ -999,6 +1126,7 @@ def classify_pr_state(
             "state": str(pull.get("state") or "").lower(),
         },
         "errors": data.get("errors") or [],
+        "changed_paths_unknown": bool(data.get("changed_paths_unknown")),
         "_raw_issue_comments": data.get("issue_comments") or [],
         "_raw_review_comments": data.get("review_comments") or [],
         "_raw_review_threads": data.get("review_threads") or [],
@@ -1009,6 +1137,7 @@ def classify_pr_state(
     result["change_detection"] = compare_snapshots(previous_snapshot, current_snapshot)
     result["snapshot"] = current_snapshot
     status = choose_status(result, snapshot_missing)
+    result["gate"] = gate
     result["status"] = status
     result["ready"] = status == "READY"
     result["status_reason"] = STATUS_DOCS[status]
@@ -1079,14 +1208,16 @@ def compact_summary(result: dict[str, Any]) -> str:
     reviews = result["review_summaries"]
     stack = result["stack"]
     change = result["change_detection"]
+    gate_label = f" gate={result['gate']}" if result.get("gate") else ""
     lines = [
         f"status: {result['status']} - {result['status_reason']}",
-        f"pr: #{result['pr']['number']} head={result['pr']['head_sha']} base={result['pr']['base_ref']}",
+        f"pr: #{result['pr']['number']} head={result['pr']['head_sha']} base={result['pr']['base_ref']}{gate_label}",
         (
             "stack: "
             f"base_is_open_pr={stack['base_is_open_pr']} "
             f"behind_base={stack['head_behind_base']} "
-            f"compare={stack['compare_status']}"
+            f"compare={stack['compare_status']} "
+            f"sibling_overlaps={stack.get('sibling_overlap_count', 0)}"
         ),
         (
             "reviews: "
@@ -1130,6 +1261,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--repo", default=os.environ.get("REPO", ""), help="owner/repo")
     parser.add_argument("--json", action="store_true", help="print a single JSON object")
     parser.add_argument(
+        "--gate",
+        choices=VALID_GATES,
+        default="",
+        help="lifecycle gate that this invocation represents",
+    )
+    parser.add_argument(
         "--snapshot",
         type=Path,
         help="read a previous snapshot if present, then write the current snapshot",
@@ -1161,6 +1298,7 @@ def main(argv: list[str]) -> int:
         data,
         previous_snapshot=previous_snapshot,
         snapshot_requested=args.snapshot is not None,
+        gate=args.gate or "",
     )
     if args.snapshot:
         write_snapshot(args.snapshot, result["snapshot"])

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -999,6 +999,79 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertNotIn("repos/owner/repo/pulls?state=open&per_page=100", calls)
         self.assertNotIn("repos/owner/repo/pulls?state=open&head=owner:feature-base&per_page=100", calls)
 
+    def test_siblings_selected_by_base_ref_not_head_ref(self) -> None:
+        """Siblings are PRs targeting the same base, not PRs headed by it.
+
+        The first implementation passed base_ref to a headRefName filter, which
+        asks "which open PRs are headed by main". That is essentially always
+        none, so overlap detection silently found nothing and reported READY.
+        Verified live at the time: GitHub reported 2 open PRs with base=main
+        while the head-ref query returned 0.
+        """
+        captured: dict[str, str] = {}
+
+        class FakeClient:
+            def open_pulls_by_base_ref(self, repo: str, base_ref: str):
+                captured["repo"] = repo
+                captured["base_ref"] = base_ref
+                return [
+                    # A genuine sibling: different head, same base.
+                    {
+                        "number": 42,
+                        "state": "open",
+                        "title": "Genuine sibling",
+                        "html_url": "https://example.invalid/42",
+                        "head": {"ref": "feature-b"},
+                        "base": {"ref": "main"},
+                    },
+                    # A decoy whose HEAD is the base branch. The old query
+                    # would have returned this one and only this one.
+                    {
+                        "number": 43,
+                        "state": "open",
+                        "title": "Headed by main",
+                        "html_url": "https://example.invalid/43",
+                        "head": {"ref": "main"},
+                        "base": {"ref": "release"},
+                    },
+                ]
+
+            def graphql_open_pulls_by_head_ref(self, head_ref_name: str):
+                # Models the real GraphQL behavior: filtering by headRefName
+                # returns only PRs whose HEAD is that branch. Present so that
+                # neutralizing the fix produces a genuine assertion failure
+                # rather than an AttributeError, which would prove nothing.
+                return [
+                    {
+                        "number": 43,
+                        "state": "open",
+                        "title": "Headed by main",
+                        "html_url": "https://example.invalid/43",
+                        "head": {"ref": "main"},
+                        "base": {"ref": "release"},
+                    },
+                ]
+
+            def api(self, path: str, paginate: bool = False):
+                if "/pulls/42/files" in path:
+                    return [{"filename": "scripts/shared.py"}]
+                return [{"filename": "scripts/unrelated.py"}]
+
+        errors: list[dict[str, str]] = []
+        result = pr_convergence.gather_sibling_overlaps(
+            FakeClient(), "owner/repo", 7, "main", "feature-a",
+            ["scripts/shared.py"], errors,
+        )
+
+        # Behavior first, so a regression fails on the outcome rather than on
+        # the instrumentation. Selecting by head ref returns only the decoy,
+        # which shares no path, so the genuine sibling goes undetected.
+        numbers = [s["number"] for s in result["overlapping_siblings"]]
+        self.assertIn(42, numbers, "same-base sibling sharing a path must be detected")
+        self.assertNotIn(43, numbers, "a PR merely headed by the base branch is not a sibling")
+        self.assertEqual(result["siblings_checked"], 1, "only the same-base PR is a sibling")
+        self.assertEqual(captured.get("base_ref"), "main", "lookup must filter on the base ref")
+
     def test_sibling_path_overlap_blocks(self) -> None:
         data = load_fixture()
         data["sibling_overlaps"] = {

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -999,6 +999,78 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertNotIn("repos/owner/repo/pulls?state=open&per_page=100", calls)
         self.assertNotIn("repos/owner/repo/pulls?state=open&head=owner:feature-base&per_page=100", calls)
 
+    def test_sibling_truncation_is_reported_not_silent(self) -> None:
+        """Exceeding the fetch cap must surface, not quietly shrink the scan.
+
+        A capped scan that found nothing is a different claim from a complete
+        scan that found nothing. If truncation were silent, a busy repo would
+        report READY on the strength of a scan that never looked at most of the
+        candidates.
+        """
+        cap = pr_convergence.MAX_SIBLING_FETCHES
+
+        class FakeClient:
+            def open_pulls_by_base_ref(self, repo: str, base_ref: str):
+                return [
+                    {
+                        "number": 1000 + i,
+                        "state": "open",
+                        "title": f"Sibling {i}",
+                        "html_url": f"https://example.invalid/{1000 + i}",
+                        "head": {"ref": f"branch-{i}"},
+                        "base": {"ref": "main"},
+                    }
+                    for i in range(cap + 3)
+                ]
+
+            def api(self, path: str, paginate: bool = False):
+                return [{"filename": "scripts/unrelated.py"}]
+
+        errors: list[dict[str, str]] = []
+        result = pr_convergence.gather_sibling_overlaps(
+            FakeClient(), "owner/repo", 7, "main", "feature-a",
+            ["scripts/shared.py"], errors,
+        )
+
+        self.assertEqual(result.get("siblings_truncated"), 3)
+        self.assertTrue(
+            any(e.get("source") == "sibling_prs" for e in errors),
+            "truncation must record an error so the status is not READY",
+        )
+
+    def test_siblings_not_excluded_by_matching_head_ref(self) -> None:
+        """Only this PR is excluded, and only by number.
+
+        Excluding by head ref too would drop a genuine sibling that shares a
+        branch name, which happens across forks. A sibling silently dropped
+        from the candidate set is indistinguishable from no overlap.
+        """
+
+        class FakeClient:
+            def open_pulls_by_base_ref(self, repo: str, base_ref: str):
+                return [
+                    {
+                        "number": 99,
+                        "state": "open",
+                        "title": "Fork sibling sharing a branch name",
+                        "html_url": "https://example.invalid/99",
+                        "head": {"ref": "feature-a"},
+                        "base": {"ref": "main"},
+                    },
+                ]
+
+            def api(self, path: str, paginate: bool = False):
+                return [{"filename": "scripts/shared.py"}]
+
+        errors: list[dict[str, str]] = []
+        result = pr_convergence.gather_sibling_overlaps(
+            FakeClient(), "owner/repo", 7, "main", "feature-a",
+            ["scripts/shared.py"], errors,
+        )
+
+        numbers = [s["number"] for s in result["overlapping_siblings"]]
+        self.assertIn(99, numbers, "a different PR sharing our head ref is still a sibling")
+
     def test_siblings_selected_by_base_ref_not_head_ref(self) -> None:
         """Siblings are PRs targeting the same base, not PRs headed by it.
 

--- a/scripts/test_pr_convergence.py
+++ b/scripts/test_pr_convergence.py
@@ -999,6 +999,89 @@ class PrConvergenceStatusTest(unittest.TestCase):
         self.assertNotIn("repos/owner/repo/pulls?state=open&per_page=100", calls)
         self.assertNotIn("repos/owner/repo/pulls?state=open&head=owner:feature-base&per_page=100", calls)
 
+    def test_sibling_path_overlap_blocks(self) -> None:
+        data = load_fixture()
+        data["sibling_overlaps"] = {
+            "own_files": ["scripts/example.py"],
+            "siblings_checked": 1,
+            "overlapping_siblings": [
+                {
+                    "number": 8,
+                    "title": "Sibling PR",
+                    "head_ref": "sibling-branch",
+                    "url": "https://github.com/owner/repo/pull/8",
+                    "overlapping_paths": ["scripts/example.py"],
+                }
+            ],
+        }
+        result = classify(data)
+        self.assertEqual(result["status"], "SIBLING_PATH_OVERLAP")
+        self.assertFalse(result["ready"])
+        self.assertEqual(result["stack"]["sibling_overlap_count"], 1)
+        self.assertEqual(result["stack"]["overlapping_siblings"][0]["number"], 8)
+
+    def test_no_sibling_overlap_is_ready(self) -> None:
+        data = load_fixture()
+        data["sibling_overlaps"] = {
+            "own_files": ["scripts/example.py"],
+            "siblings_checked": 1,
+            "overlapping_siblings": [],
+        }
+        result = classify(data)
+        self.assertEqual(result["status"], "READY")
+        self.assertEqual(result["stack"]["sibling_overlap_count"], 0)
+
+    def test_gate_name_appears_in_result(self) -> None:
+        data = load_fixture()
+        for gate in pr_convergence.VALID_GATES:
+            with self.subTest(gate=gate):
+                result = pr_convergence.classify_pr_state(data, gate=gate)
+                self.assertEqual(result["gate"], gate)
+
+    def test_gate_name_appears_in_compact_summary(self) -> None:
+        data = load_fixture()
+        result = pr_convergence.classify_pr_state(data, gate="pre-push")
+        summary = pr_convergence.compact_summary(result)
+        self.assertIn("gate=pre-push", summary)
+
+    def test_empty_gate_omitted_from_compact_summary(self) -> None:
+        data = load_fixture()
+        result = pr_convergence.classify_pr_state(data, gate="")
+        summary = pr_convergence.compact_summary(result)
+        self.assertNotIn("gate=", summary)
+
+    def test_empty_changed_paths_on_successful_read_fails_closed(self) -> None:
+        """A successful read yielding zero changed paths must not report READY.
+
+        An open PR always changes at least one file, so an empty successful
+        read means the changed-path source is broken or truncated. Reading it
+        as "no files" silently disables sibling-overlap detection while still
+        reporting READY, which is a fail-open in a release-safety gate.
+        """
+        data = load_fixture()
+        data["pr_files"] = []
+        data["changed_paths_unknown"] = True
+        result = classify(data)
+        self.assertEqual(result["status"], "CHANGED_PATHS_UNKNOWN")
+        self.assertFalse(result["ready"])
+
+    def test_normal_pr_with_changed_paths_still_ready(self) -> None:
+        """The empty-read guard must not deny a PR that really has files.
+
+        Availability is a failure direction too: an over-strict gate that
+        blocks healthy PRs gets the gate disabled by the operator.
+        """
+        result = classify(load_fixture())
+        self.assertFalse(result.get("changed_paths_unknown"))
+        self.assertEqual(result["status"], "READY")
+
+    def test_sibling_overlap_api_error_fails_closed(self) -> None:
+        data = load_fixture()
+        data["errors"] = [{"source": "sibling_prs", "message": "rate limited"}]
+        result = classify(data)
+        self.assertEqual(result["status"], "DATA_SOURCE_UNAVAILABLE")
+        self.assertFalse(result["ready"])
+
     def test_default_branch_base_skips_base_pull_candidate_read(self) -> None:
         fixture = load_fixture()
         fixture["pull"]["base"]["repo"]["default_branch"] = "main"

--- a/scripts/testdata/pr_convergence_ai_review.json
+++ b/scripts/testdata/pr_convergence_ai_review.json
@@ -26,6 +26,12 @@
     "status": "ahead"
   },
   "errors": [],
+  "pr_files": ["scripts/example.py"],
+  "sibling_overlaps": {
+    "own_files": ["scripts/example.py"],
+    "siblings_checked": 0,
+    "overlapping_siblings": []
+  },
   "issue_comments": [
     {
       "body": "## AI Review\n\n1. medium: scripts/example.py - fix this finding.",

--- a/scripts/testdata/pr_convergence_clean.json
+++ b/scripts/testdata/pr_convergence_clean.json
@@ -27,6 +27,12 @@
   },
   "errors": [],
   "issue_comments": [],
+  "pr_files": ["scripts/example.py"],
+  "sibling_overlaps": {
+    "own_files": ["scripts/example.py"],
+    "siblings_checked": 0,
+    "overlapping_siblings": []
+  },
   "pr_number": 7,
   "pull": {
     "base": {


### PR DESCRIPTION
## What changed

The repository-owned PR convergence check now reports one structured, thread-aware state at four distinct lifecycle gates instead of a single ad-hoc snapshot. A `--gate` argument names task-start, pre-edit, pre-push, or post-push, and the chosen gate appears in both the structured result and the compact summary so a caller can tell which checkpoint produced a verdict.

The check also gains sibling changed-path overlap detection. Independent open PRs targeting the same base branch that share a changed path are reported as a named `SIBLING_PATH_OVERLAP` state rather than being silently treated as unrelated work.

A changed-path read that succeeds but returns no files is now its own `CHANGED_PATHS_UNKNOWN` state. An open pull request always changes at least one file, so an empty successful read means the source is broken or truncated rather than that there is nothing to compare. Previously that state silently disabled overlap detection while still reporting `READY`, which is a fail-open in a gate whose entire job is to withhold readiness.

## Failure direction

Every new branch resolves ambiguity toward not-ready. A read error routes to `DATA_SOURCE_UNAVAILABLE`, a successful-but-empty changed-path read routes to `CHANGED_PATHS_UNKNOWN`, and an invalid gate name is rejected before any network call. A pull request that genuinely has changed files is unaffected and still reaches `READY`, so the new guard does not deny healthy work.

## Ancestry scope

Sibling detection uses the same-base filter as a structural approximation of ancestry rather than computing a merge base. A pull request stacked on another takes its parent branch as its base, so it does not appear in the same-base set and is not flagged. A stacked pair that both target the base branch directly would still be reported and needs a human to confirm the stack. The function documents this limit explicitly instead of describing itself as ancestry-aware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for overlapping file changes across related open pull requests.
  * Added lifecycle gates for task start, pre-edit, pre-push, and post-push checks.
  * Added concise status and classification details to convergence summaries.

* **Bug Fixes**
  * Checks now fail safely when changed-file information is unavailable or related pull request data cannot be read.
  * Prevents readiness from being reported when conflicting file changes are detected.

* **Tests**
  * Added coverage for overlap blocking, successful readiness, gate handling, summary output, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->