### PR TITLE
feat(conductor): report fleet and evidence convergence as four denominators

### DIFF
--- a/enterprise/conductor/convergence/convergence.go
+++ b/enterprise/conductor/convergence/convergence.go
@@ -12,6 +12,8 @@ package convergence
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
@@ -55,6 +57,16 @@ const (
 	// StateExcluded means the follower is explicitly marked as not an
 	// expected receipt producer (local-only proxy, test instance, etc.).
 	StateExcluded FollowerState = "excluded"
+
+	// evidenceStaleWindowMultiple is how many staleness windows a follower may
+	// go without delivering a batch before its evidence is treated as stale.
+	//
+	// It is deliberately looser than the runtime staleness window: runtime
+	// status is pushed continuously, while audit batches arrive in batches, so
+	// judging evidence on the runtime window would flag every follower in the
+	// ordinary gap between deliveries. Loose enough not to cry wolf, tight
+	// enough that a real delivery outage still surfaces.
+	evidenceStaleWindowMultiple = 6
 
 	// StateUndeclared means conductor knows about this follower but no
 	// deployment intent declares it. It is distinct from StateUnknown: the
@@ -273,6 +285,16 @@ func classifyFollower(
 
 	// Scaled to zero: intentionally absent.
 	if intent != nil && intent.DesiredReplicas == 0 {
+		// Scaled-zero means intentionally absent, so it can only be claimed
+		// when the follower is in fact absent. A follower that is still
+		// enrolled and active while intent says zero replicas is the opposite
+		// situation: a live enforcement point that nobody expects to exist.
+		// Reporting that as intentionally-absent hides it.
+		if fleetStatus != nil && fleetStatus.Active {
+			fc.State = StateUnknown
+			fc.Reason = "deployment intent declares zero desired replicas but the follower is still enrolled and active"
+			return fc
+		}
 		fc.State = StateScaledZero
 		fc.Reason = "deployment intent declares zero desired replicas"
 		return fc
@@ -332,6 +354,17 @@ func classifyFollower(
 		fc.Reason = "runtime version below minimum required by bundle"
 		return fc
 	}
+	// Everything above rejects specific known-bad health values, which is a
+	// denylist: a FleetHealth constant added later would fall straight through
+	// to the converged path. Only an explicitly OK health may continue, so a
+	// health value this code has never heard of fails closed. runtimeSummary
+	// already counts only FleetHealthOK as healthy; this keeps the two in
+	// agreement instead of letting them drift apart.
+	if fleetStatus.Health != controlplane.FleetHealthOK {
+		fc.State = StateUnknown
+		fc.Reason = fmt.Sprintf("unrecognized conductor health %q", string(fleetStatus.Health))
+		return fc
+	}
 
 	// Check digest match if we have deployment intent with a desired digest.
 	if intent != nil && intent.DesiredDigest != "" {
@@ -367,8 +400,7 @@ func classifyFollower(
 	if staleAfter <= 0 {
 		staleAfter = 5 * time.Minute
 	}
-	if now.Sub(latestBatch.ReceivedAt) > staleAfter*6 {
-		// Evidence older than 6x the staleness window is suspicious.
+	if now.Sub(latestBatch.ReceivedAt) > staleAfter*evidenceStaleWindowMultiple {
 		fc.State = StateStale
 		fc.Reason = fmt.Sprintf("latest audit batch received %s ago", now.Sub(latestBatch.ReceivedAt).Truncate(time.Second))
 		return fc
@@ -450,13 +482,13 @@ func latestBatchMap(batches []controlplane.AuditBatchSummary) map[string]*contro
 	return m
 }
 
+// sortFollowers orders the report by instance ID so output is deterministic.
+// The map iteration that builds it is not, and a report that reorders between
+// runs is unusable for diffing one fleet snapshot against another.
 func sortFollowers(followers []FollowerConvergence) {
-	// Stable sort by instance ID for deterministic output.
-	for i := 1; i < len(followers); i++ {
-		for j := i; j > 0 && followers[j].InstanceID < followers[j-1].InstanceID; j-- {
-			followers[j], followers[j-1] = followers[j-1], followers[j]
-		}
-	}
+	slices.SortFunc(followers, func(a, b FollowerConvergence) int {
+		return strings.Compare(a.InstanceID, b.InstanceID)
+	})
 }
 
 func deploymentSummary(followers []FollowerConvergence) DenominatorSummary {

--- a/enterprise/conductor/convergence/convergence.go
+++ b/enterprise/conductor/convergence/convergence.go
@@ -281,7 +281,11 @@ func classifyFollower(
 		fc.ConductorDrift = fleetStatus.Drift
 	}
 	if latestBatch != nil {
-		fc.LatestBatch = batchToEvidence(latestBatch, instanceID)
+		runtimeBuild := ""
+		if fleetStatus != nil && fleetStatus.RuntimeStatus != nil {
+			runtimeBuild = fleetStatus.RuntimeStatus.PipelockVersion
+		}
+		fc.LatestBatch = batchToEvidence(latestBatch, instanceID, runtimeBuild)
 	}
 
 	// Classification logic. Order matters: earlier checks take priority.
@@ -460,7 +464,14 @@ func truncHash(h string) string {
 	return h
 }
 
-func batchToEvidence(b *controlplane.AuditBatchSummary, instanceID string) *AuditEvidence {
+// batchToEvidence renders one accepted batch as reportable evidence.
+//
+// runtimeBuild is supplied by the caller rather than read from the batch: the
+// audit batch summary does not carry the emitting follower's Pipelock version,
+// so it comes from the follower's runtime status. Leaving it unset would have
+// the report advertise a runtime_build field that is always empty, which is an
+// overclaim about what the evidence layer can actually tell an operator.
+func batchToEvidence(b *controlplane.AuditBatchSummary, instanceID, runtimeBuild string) *AuditEvidence {
 	lag := float64(0)
 	if !b.ReceivedAt.IsZero() && !b.EmittedAt.IsZero() {
 		lag = b.ReceivedAt.Sub(b.EmittedAt).Seconds()
@@ -480,6 +491,7 @@ func batchToEvidence(b *controlplane.AuditBatchSummary, instanceID string) *Audi
 		ReceivedAt:      b.ReceivedAt,
 		EmittedAt:       b.EmittedAt,
 		DeliveryLagSecs: lag,
+		RuntimeBuild:    runtimeBuild,
 	}
 }
 

--- a/enterprise/conductor/convergence/convergence.go
+++ b/enterprise/conductor/convergence/convergence.go
@@ -156,9 +156,22 @@ func Build(in Inputs) Report {
 	}
 
 	// Index fleet status and audit batches by instance ID.
+	//
+	// Duplicate identity across these independent control-plane sources is a
+	// data-integrity condition, not something to resolve by taking whichever
+	// record happened to sort last. A duplicate intent marked Excluded or
+	// DesiredReplicas:0 would otherwise suppress a real unhealthy instance
+	// purely through input ordering, so conflicts are recorded and the
+	// affected instance is reported unknown.
+	conflictingIDs := make(map[string]string)
 	statusByID := make(map[string]*controlplane.FollowerFleetStatus, len(in.FleetStatus))
 	for i := range in.FleetStatus {
-		statusByID[in.FleetStatus[i].InstanceID] = &in.FleetStatus[i]
+		id := in.FleetStatus[i].InstanceID
+		if _, dup := statusByID[id]; dup {
+			conflictingIDs[id] = "multiple conductor fleet-status records for one instance ID"
+			continue
+		}
+		statusByID[id] = &in.FleetStatus[i]
 	}
 	latestBatchByID := latestBatchMap(in.AuditBatches)
 
@@ -176,7 +189,12 @@ func Build(in Inputs) Report {
 
 	intentByID := make(map[string]*DeploymentIntent, len(in.Intents))
 	for i := range in.Intents {
-		intentByID[in.Intents[i].InstanceID] = &in.Intents[i]
+		id := in.Intents[i].InstanceID
+		if _, dup := intentByID[id]; dup {
+			conflictingIDs[id] = "multiple deployment-intent records for one instance ID"
+			continue
+		}
+		intentByID[id] = &in.Intents[i]
 	}
 
 	report := Report{
@@ -186,6 +204,18 @@ func Build(in Inputs) Report {
 	}
 
 	for id := range seen {
+		// An instance whose identity is ambiguous is not classified at all.
+		// Running it through the normal path would let one of the conflicting
+		// records decide its verdict, which is the ordering dependence this
+		// guards against.
+		if reason, conflicted := conflictingIDs[id]; conflicted {
+			report.Followers = append(report.Followers, FollowerConvergence{
+				InstanceID: id,
+				State:      StateUnknown,
+				Reason:     reason,
+			})
+			continue
+		}
 		fc := classifyFollower(id, intentByID[id], statusByID[id], latestBatchByID[id], now, in.StaleAfter)
 		report.Followers = append(report.Followers, fc)
 	}
@@ -257,6 +287,16 @@ func classifyFollower(
 			fc.State = StateUnknown
 			fc.Reason = "no deployment intent and no conductor enrollment"
 		}
+		return fc
+	}
+
+	// Enrolled but deactivated. StateFullyConverged means enrolled, active and
+	// healthy, so a follower that is no longer active cannot satisfy it even
+	// with historical OK health and a recent batch. Reporting it converged
+	// hides enforcement capacity that has already gone away.
+	if !fleetStatus.Active {
+		fc.State = StateStale
+		fc.Reason = "enrolled with conductor but not active"
 		return fc
 	}
 
@@ -473,6 +513,19 @@ func conductorSummary(followers []FollowerConvergence) DenominatorSummary {
 	return s
 }
 
+// evidenceStateIsCredible reports whether a follower's own state permits its
+// latest batch to count as healthy evidence delivery. Only a follower that is
+// actually converged or merely awaiting its first batch qualifies; anything
+// stale, undeclared, or unprovable does not.
+func evidenceStateIsCredible(state FollowerState) bool {
+	switch state {
+	case StateFullyConverged, StateCurrentWithoutBatch:
+		return true
+	default:
+		return false
+	}
+}
+
 func evidenceSummary(followers []FollowerConvergence) DenominatorSummary {
 	var s DenominatorSummary
 	for _, f := range followers {
@@ -480,9 +533,16 @@ func evidenceSummary(followers []FollowerConvergence) DenominatorSummary {
 			continue
 		}
 		s.Total++
-		if f.LatestBatch != nil {
+		switch {
+		// Evidence is healthy only when the follower itself is in a state
+		// that makes its latest batch meaningful. A stale or unprovable
+		// follower's old batch is not healthy delivery, and counting it green
+		// makes this denominator contradict the convergence denominator during
+		// exactly the audit-delivery outage it should surface.
+		case f.LatestBatch != nil && evidenceStateIsCredible(f.State):
 			s.Healthy++
-		} else if f.State == StateUnknown || f.State == StateUnenrolled {
+		case f.State == StateUnknown || f.State == StateUnenrolled ||
+			f.State == StateUndeclared || f.State == StateStale:
 			s.Unknown++
 		}
 	}

--- a/enterprise/conductor/convergence/convergence.go
+++ b/enterprise/conductor/convergence/convergence.go
@@ -55,6 +55,12 @@ const (
 	// StateExcluded means the follower is explicitly marked as not an
 	// expected receipt producer (local-only proxy, test instance, etc.).
 	StateExcluded FollowerState = "excluded"
+
+	// StateUndeclared means conductor knows about this follower but no
+	// deployment intent declares it. It is distinct from StateUnknown: the
+	// data is not missing, the authorization is. A rogue or forgotten
+	// enforcement point lands here, and it is never counted as converged.
+	StateUndeclared FollowerState = "undeclared"
 )
 
 // DeploymentIntent is the GitOps/desired declaration for one follower.
@@ -254,6 +260,17 @@ func classifyFollower(
 		return fc
 	}
 
+	// Enrolled but undeclared. The report answers "is this enforcement point
+	// supposed to be here", not merely "is it well", so a follower that no
+	// deployment intent declares can never be converged no matter how healthy
+	// it looks. Otherwise a rogue or forgotten follower reads as green and the
+	// desired-state boundary this report exists to establish is inverted.
+	if intent == nil {
+		fc.State = StateUndeclared
+		fc.Reason = "enrolled with conductor but absent from deployment intent"
+		return fc
+	}
+
 	// Conductor says unknown or stale.
 	if fleetStatus.Health == controlplane.FleetHealthUnknown {
 		fc.State = StateUnknown
@@ -278,7 +295,15 @@ func classifyFollower(
 
 	// Check digest match if we have deployment intent with a desired digest.
 	if intent != nil && intent.DesiredDigest != "" {
-		actualHash := actualBundleHash(fleetStatus)
+		actualHash, hashConflict := actualBundleHash(fleetStatus)
+		if hashConflict {
+			fc.State = StateUnknown
+			fc.Reason = fmt.Sprintf(
+				"signed applied state reports %s but live runtime reports %s; running bundle is not provable",
+				truncHash(actualHash), truncHash(fleetStatus.RuntimeStatus.ActiveBundleHash),
+			)
+			return fc
+		}
 		if actualHash == "" {
 			fc.State = StateUnknown
 			fc.Reason = "deployment intent specifies desired digest but no active bundle hash available"
@@ -313,14 +338,34 @@ func classifyFollower(
 	return fc
 }
 
-func actualBundleHash(fs *controlplane.FollowerFleetStatus) string {
-	if fs.SignedAppliedState != nil && fs.SignedAppliedState.AppliedState.ActiveBundleHash != "" {
-		return fs.SignedAppliedState.AppliedState.ActiveBundleHash
+// actualBundleHash reports which bundle a follower is running, and whether its
+// two sources of truth disagree.
+//
+// The signed applied state is a record of what the follower reported applying;
+// the runtime status is what it says it is running now. Preferring the signed
+// record and ignoring a contradicting runtime lets a stale signed record that
+// happens to match the desired digest mask a proxy that is actually enforcing
+// an old, downgraded, or tampered bundle. A disagreement is not something to
+// resolve by precedence, it is evidence that the follower's state is not
+// provable, so the caller must treat conflict as not-converged.
+func actualBundleHash(fs *controlplane.FollowerFleetStatus) (hash string, conflict bool) {
+	signed := ""
+	if fs.SignedAppliedState != nil {
+		signed = fs.SignedAppliedState.AppliedState.ActiveBundleHash
 	}
+	runtime := ""
 	if fs.RuntimeStatus != nil {
-		return fs.RuntimeStatus.ActiveBundleHash
+		runtime = fs.RuntimeStatus.ActiveBundleHash
 	}
-	return ""
+
+	// Both present and disagreeing: unprovable, never silently pick one.
+	if signed != "" && runtime != "" && signed != runtime {
+		return signed, true
+	}
+	if signed != "" {
+		return signed, false
+	}
+	return runtime, false
 }
 
 func truncHash(h string) string {

--- a/enterprise/conductor/convergence/convergence.go
+++ b/enterprise/conductor/convergence/convergence.go
@@ -118,8 +118,21 @@ type FollowerConvergence struct {
 
 // DenominatorSummary reports a count for one denominator.
 type DenominatorSummary struct {
-	Total   int `json:"total"`
+	// Total is every follower this denominator applies to. Followers that are
+	// intentionally out of scope, meaning excluded or scaled to zero, are not
+	// counted at all rather than counted as failures.
+	Total int `json:"total"`
+
+	// Healthy is the followers this denominator can positively vouch for.
 	Healthy int `json:"healthy"`
+
+	// Unknown is the followers this denominator explicitly cannot vouch for.
+	//
+	// Total is deliberately NOT Healthy plus Unknown. A follower can be
+	// neither: definitively unhealthy in a way that is known rather than
+	// unknown, such as a wrong digest. Reading the remainder as "probably
+	// fine" is exactly the collapsed-percentage reasoning this report exists
+	// to prevent, so the two counts are reported and neither is inferred.
 	Unknown int `json:"unknown"`
 }
 

--- a/enterprise/conductor/convergence/convergence.go
+++ b/enterprise/conductor/convergence/convergence.go
@@ -1,0 +1,445 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build enterprise
+
+// Package convergence produces a read-only fleet convergence report that joins
+// four independent denominators: deployment intent, running images, conductor
+// runtime status, and accepted audit evidence. Each denominator is reported
+// separately; collapsing them into a single percentage is explicitly forbidden
+// because deployment coverage is not evidence coverage.
+package convergence
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+)
+
+// FollowerState enumerates the distinguishable states a follower can occupy.
+// The zero value is intentionally invalid so an unset state is never silently
+// treated as converged.
+type FollowerState string
+
+const (
+	// StateFullyConverged means the follower is enrolled, active, healthy,
+	// running the expected bundle, and has a recent accepted audit batch.
+	StateFullyConverged FollowerState = "fully_converged"
+
+	// StateCurrentWithoutBatch means runtime is healthy and on the expected
+	// bundle but no accepted audit batch exists for this follower.
+	StateCurrentWithoutBatch FollowerState = "current_without_batch"
+
+	// StateStale means the follower's runtime status or signed applied state
+	// is older than the staleness threshold.
+	StateStale FollowerState = "stale"
+
+	// StateWrongDigest means the follower is running a bundle hash that does
+	// not match the expected bundle for its audience.
+	StateWrongDigest FollowerState = "wrong_digest"
+
+	// StateUnenrolled means the follower appears in the deployment intent
+	// but has no enrollment record.
+	StateUnenrolled FollowerState = "unenrolled"
+
+	// StateScaledZero means the deployment intent declares zero desired
+	// replicas; the follower is intentionally absent.
+	StateScaledZero FollowerState = "scaled_zero"
+
+	// StateUnknown means the follower's state could not be determined
+	// (unreachable, unparseable, or missing data). This is the fail-closed
+	// default: anything not provably healthy is unknown.
+	StateUnknown FollowerState = "unknown"
+
+	// StateExcluded means the follower is explicitly marked as not an
+	// expected receipt producer (local-only proxy, test instance, etc.).
+	StateExcluded FollowerState = "excluded"
+)
+
+// DeploymentIntent is the GitOps/desired declaration for one follower.
+type DeploymentIntent struct {
+	InstanceID      string `json:"instance_id"`
+	DesiredReplicas int    `json:"desired_replicas"`
+	DesiredDigest   string `json:"desired_digest,omitempty"`
+	// Excluded marks this instance as intentionally not an expected receipt
+	// producer. The Reason field explains why (e.g. "local-only proxy").
+	Excluded       bool   `json:"excluded,omitempty"`
+	ExcludedReason string `json:"excluded_reason,omitempty"`
+}
+
+// AuditEvidence is the latest accepted audit batch summary for one follower.
+type AuditEvidence struct {
+	InstanceID      string    `json:"instance_id"`
+	BatchID         string    `json:"batch_id"`
+	SchemaVersion   int       `json:"schema_version"`
+	SeqStart        uint64    `json:"seq_start"`
+	SeqEnd          uint64    `json:"seq_end"`
+	DroppedCount    uint64    `json:"dropped_count"`
+	SignerKeyID     string    `json:"signer_key_id"`
+	RuntimeBuild    string    `json:"runtime_build,omitempty"`
+	ReceivedAt      time.Time `json:"received_at"`
+	EmittedAt       time.Time `json:"emitted_at"`
+	DeliveryLagSecs float64   `json:"delivery_lag_secs"`
+}
+
+// FollowerConvergence is the per-follower convergence verdict.
+type FollowerConvergence struct {
+	InstanceID string        `json:"instance_id"`
+	State      FollowerState `json:"state"`
+	Reason     string        `json:"reason,omitempty"`
+
+	// The four denominators, each independently present or absent.
+	DeploymentIntent *DeploymentIntent                   `json:"deployment_intent,omitempty"`
+	RuntimeStatus    *controlplane.FollowerRuntimeStatus `json:"runtime_status,omitempty"`
+	ConductorHealth  *controlplane.FleetHealth           `json:"conductor_health,omitempty"`
+	ConductorDrift   string                              `json:"conductor_drift,omitempty"`
+	LatestBatch      *AuditEvidence                      `json:"latest_batch,omitempty"`
+	SignedState      *controlplane.VerifiedAppliedState  `json:"signed_applied_state,omitempty"`
+}
+
+// DenominatorSummary reports a count for one denominator.
+type DenominatorSummary struct {
+	Total   int `json:"total"`
+	Healthy int `json:"healthy"`
+	Unknown int `json:"unknown"`
+}
+
+// Report is the top-level convergence report with four separate denominators.
+type Report struct {
+	GeneratedAt time.Time `json:"generated_at"`
+	OrgID       string    `json:"org_id"`
+	FleetID     string    `json:"fleet_id"`
+
+	// Four separate denominators -- never collapsed into one number.
+	DeploymentCoverage DenominatorSummary `json:"deployment_coverage"`
+	RuntimeCoverage    DenominatorSummary `json:"runtime_coverage"`
+	ConductorCoverage  DenominatorSummary `json:"conductor_coverage"`
+	EvidenceCoverage   DenominatorSummary `json:"evidence_coverage"`
+
+	Followers []FollowerConvergence `json:"followers"`
+}
+
+// Inputs collects the four data sources the convergence report joins.
+type Inputs struct {
+	OrgID   string
+	FleetID string
+	Now     time.Time
+
+	// Deployment intent (GitOps desired state).
+	Intents []DeploymentIntent
+
+	// Conductor fleet status (enrolled followers + runtime health).
+	FleetStatus []controlplane.FollowerFleetStatus
+
+	// Latest accepted audit batch per follower.
+	AuditBatches []controlplane.AuditBatchSummary
+
+	// StaleAfter controls the staleness threshold for runtime status.
+	// Zero means use the default (5 minutes).
+	StaleAfter time.Duration
+}
+
+// Build produces a convergence report from the four input sources. Unknown,
+// unreachable, or unparseable inputs render as StateUnknown, never as
+// converged. This is the fail-closed direction.
+func Build(in Inputs) Report {
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	// Index fleet status and audit batches by instance ID.
+	statusByID := make(map[string]*controlplane.FollowerFleetStatus, len(in.FleetStatus))
+	for i := range in.FleetStatus {
+		statusByID[in.FleetStatus[i].InstanceID] = &in.FleetStatus[i]
+	}
+	latestBatchByID := latestBatchMap(in.AuditBatches)
+
+	// Collect all known instance IDs from all sources.
+	seen := make(map[string]bool)
+	for _, intent := range in.Intents {
+		seen[intent.InstanceID] = true
+	}
+	for _, fs := range in.FleetStatus {
+		seen[fs.InstanceID] = true
+	}
+	for _, ab := range in.AuditBatches {
+		seen[ab.InstanceID] = true
+	}
+
+	intentByID := make(map[string]*DeploymentIntent, len(in.Intents))
+	for i := range in.Intents {
+		intentByID[in.Intents[i].InstanceID] = &in.Intents[i]
+	}
+
+	report := Report{
+		GeneratedAt: now,
+		OrgID:       in.OrgID,
+		FleetID:     in.FleetID,
+	}
+
+	for id := range seen {
+		fc := classifyFollower(id, intentByID[id], statusByID[id], latestBatchByID[id], now, in.StaleAfter)
+		report.Followers = append(report.Followers, fc)
+	}
+
+	// Sort followers for deterministic output.
+	sortFollowers(report.Followers)
+
+	// Compute per-denominator summaries.
+	report.DeploymentCoverage = deploymentSummary(report.Followers)
+	report.RuntimeCoverage = runtimeSummary(report.Followers)
+	report.ConductorCoverage = conductorSummary(report.Followers)
+	report.EvidenceCoverage = evidenceSummary(report.Followers)
+
+	return report
+}
+
+func classifyFollower(
+	instanceID string,
+	intent *DeploymentIntent,
+	fleetStatus *controlplane.FollowerFleetStatus,
+	latestBatch *controlplane.AuditBatchSummary,
+	now time.Time,
+	staleAfter time.Duration,
+) FollowerConvergence {
+	fc := FollowerConvergence{
+		InstanceID: instanceID,
+	}
+
+	// Attach raw data when available.
+	if intent != nil {
+		fc.DeploymentIntent = intent
+	}
+	if fleetStatus != nil {
+		fc.RuntimeStatus = fleetStatus.RuntimeStatus
+		fc.SignedState = fleetStatus.SignedAppliedState
+		health := fleetStatus.Health
+		fc.ConductorHealth = &health
+		fc.ConductorDrift = fleetStatus.Drift
+	}
+	if latestBatch != nil {
+		fc.LatestBatch = batchToEvidence(latestBatch, instanceID)
+	}
+
+	// Classification logic. Order matters: earlier checks take priority.
+
+	// Excluded instances are reported as N/A.
+	if intent != nil && intent.Excluded {
+		fc.State = StateExcluded
+		fc.Reason = intent.ExcludedReason
+		if fc.Reason == "" {
+			fc.Reason = "explicitly excluded from receipt expectations"
+		}
+		return fc
+	}
+
+	// Scaled to zero: intentionally absent.
+	if intent != nil && intent.DesiredReplicas == 0 {
+		fc.State = StateScaledZero
+		fc.Reason = "deployment intent declares zero desired replicas"
+		return fc
+	}
+
+	// No fleet status at all: unenrolled if we have intent, unknown otherwise.
+	if fleetStatus == nil {
+		if intent != nil {
+			fc.State = StateUnenrolled
+			fc.Reason = "present in deployment intent but not enrolled with conductor"
+		} else {
+			fc.State = StateUnknown
+			fc.Reason = "no deployment intent and no conductor enrollment"
+		}
+		return fc
+	}
+
+	// Conductor says unknown or stale.
+	if fleetStatus.Health == controlplane.FleetHealthUnknown {
+		fc.State = StateUnknown
+		fc.Reason = fmt.Sprintf("conductor health unknown: %s", fleetStatus.Drift)
+		return fc
+	}
+	if fleetStatus.Health == controlplane.FleetHealthStale {
+		fc.State = StateStale
+		fc.Reason = fmt.Sprintf("conductor reports stale: %s", fleetStatus.Drift)
+		return fc
+	}
+	if fleetStatus.Health == controlplane.FleetHealthApplyFailed {
+		fc.State = StateStale
+		fc.Reason = "last policy apply failed"
+		return fc
+	}
+	if fleetStatus.Health == controlplane.FleetHealthUnsupported {
+		fc.State = StateWrongDigest
+		fc.Reason = "runtime version below minimum required by bundle"
+		return fc
+	}
+
+	// Check digest match if we have deployment intent with a desired digest.
+	if intent != nil && intent.DesiredDigest != "" {
+		actualHash := actualBundleHash(fleetStatus)
+		if actualHash == "" {
+			fc.State = StateUnknown
+			fc.Reason = "deployment intent specifies desired digest but no active bundle hash available"
+			return fc
+		}
+		if actualHash != intent.DesiredDigest {
+			fc.State = StateWrongDigest
+			fc.Reason = fmt.Sprintf("running %s, want %s", truncHash(actualHash), truncHash(intent.DesiredDigest))
+			return fc
+		}
+	}
+
+	// Runtime is healthy. Check evidence.
+	if latestBatch == nil {
+		fc.State = StateCurrentWithoutBatch
+		fc.Reason = "runtime healthy but no accepted audit batch"
+		return fc
+	}
+
+	// Check if the batch is stale relative to now.
+	if staleAfter <= 0 {
+		staleAfter = 5 * time.Minute
+	}
+	if now.Sub(latestBatch.ReceivedAt) > staleAfter*6 {
+		// Evidence older than 6x the staleness window is suspicious.
+		fc.State = StateStale
+		fc.Reason = fmt.Sprintf("latest audit batch received %s ago", now.Sub(latestBatch.ReceivedAt).Truncate(time.Second))
+		return fc
+	}
+
+	fc.State = StateFullyConverged
+	return fc
+}
+
+func actualBundleHash(fs *controlplane.FollowerFleetStatus) string {
+	if fs.SignedAppliedState != nil && fs.SignedAppliedState.AppliedState.ActiveBundleHash != "" {
+		return fs.SignedAppliedState.AppliedState.ActiveBundleHash
+	}
+	if fs.RuntimeStatus != nil {
+		return fs.RuntimeStatus.ActiveBundleHash
+	}
+	return ""
+}
+
+func truncHash(h string) string {
+	if len(h) > 12 {
+		return h[:12]
+	}
+	return h
+}
+
+func batchToEvidence(b *controlplane.AuditBatchSummary, instanceID string) *AuditEvidence {
+	lag := float64(0)
+	if !b.ReceivedAt.IsZero() && !b.EmittedAt.IsZero() {
+		lag = b.ReceivedAt.Sub(b.EmittedAt).Seconds()
+	}
+	signerKeyID := ""
+	if len(b.SignatureKeyIDs) > 0 {
+		signerKeyID = b.SignatureKeyIDs[0]
+	}
+	return &AuditEvidence{
+		InstanceID:      instanceID,
+		BatchID:         b.BatchID,
+		SchemaVersion:   b.AuditSchema,
+		SeqStart:        b.SeqStart,
+		SeqEnd:          b.SeqEnd,
+		DroppedCount:    b.DroppedCount,
+		SignerKeyID:     signerKeyID,
+		ReceivedAt:      b.ReceivedAt,
+		EmittedAt:       b.EmittedAt,
+		DeliveryLagSecs: lag,
+	}
+}
+
+func latestBatchMap(batches []controlplane.AuditBatchSummary) map[string]*controlplane.AuditBatchSummary {
+	m := make(map[string]*controlplane.AuditBatchSummary, len(batches))
+	for i := range batches {
+		b := &batches[i]
+		existing, ok := m[b.InstanceID]
+		if !ok || b.ReceivedAt.After(existing.ReceivedAt) {
+			m[b.InstanceID] = b
+		}
+	}
+	return m
+}
+
+func sortFollowers(followers []FollowerConvergence) {
+	// Stable sort by instance ID for deterministic output.
+	for i := 1; i < len(followers); i++ {
+		for j := i; j > 0 && followers[j].InstanceID < followers[j-1].InstanceID; j-- {
+			followers[j], followers[j-1] = followers[j-1], followers[j]
+		}
+	}
+}
+
+func deploymentSummary(followers []FollowerConvergence) DenominatorSummary {
+	var s DenominatorSummary
+	for _, f := range followers {
+		if f.DeploymentIntent == nil {
+			continue
+		}
+		s.Total++
+		switch f.State {
+		case StateFullyConverged, StateCurrentWithoutBatch, StateExcluded, StateScaledZero:
+			s.Healthy++
+		case StateUnknown:
+			s.Unknown++
+		}
+	}
+	return s
+}
+
+func runtimeSummary(followers []FollowerConvergence) DenominatorSummary {
+	var s DenominatorSummary
+	for _, f := range followers {
+		if f.State == StateExcluded || f.State == StateScaledZero {
+			continue
+		}
+		s.Total++
+		if f.ConductorHealth != nil && *f.ConductorHealth == controlplane.FleetHealthOK {
+			s.Healthy++
+		} else if f.State == StateUnknown || f.ConductorHealth == nil {
+			s.Unknown++
+		}
+	}
+	return s
+}
+
+func conductorSummary(followers []FollowerConvergence) DenominatorSummary {
+	var s DenominatorSummary
+	for _, f := range followers {
+		if f.State == StateExcluded || f.State == StateScaledZero {
+			continue
+		}
+		s.Total++
+		if f.ConductorHealth != nil {
+			switch *f.ConductorHealth {
+			case controlplane.FleetHealthOK:
+				s.Healthy++
+			case controlplane.FleetHealthUnknown:
+				s.Unknown++
+			}
+		} else {
+			s.Unknown++
+		}
+	}
+	return s
+}
+
+func evidenceSummary(followers []FollowerConvergence) DenominatorSummary {
+	var s DenominatorSummary
+	for _, f := range followers {
+		if f.State == StateExcluded || f.State == StateScaledZero {
+			continue
+		}
+		s.Total++
+		if f.LatestBatch != nil {
+			s.Healthy++
+		} else if f.State == StateUnknown || f.State == StateUnenrolled {
+			s.Unknown++
+		}
+	}
+	return s
+}

--- a/enterprise/conductor/convergence/convergence_test.go
+++ b/enterprise/conductor/convergence/convergence_test.go
@@ -1,0 +1,391 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build enterprise
+
+package convergence
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+)
+
+func TestBuild_SixFixtureStates(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	recentBatchTime := now.Add(-1 * time.Minute)
+	healthOK := controlplane.FleetHealthOK
+	healthStale := controlplane.FleetHealthStale
+	healthUnknown := controlplane.FleetHealthUnknown
+
+	tests := []struct {
+		name      string
+		inputs    Inputs
+		wantState FollowerState
+		wantID    string
+	}{
+		{
+			name: "scaled_zero",
+			inputs: Inputs{
+				OrgID: "org1", FleetID: "fleet1", Now: now,
+				Intents: []DeploymentIntent{
+					{InstanceID: "scaled-zero-1", DesiredReplicas: 0},
+				},
+			},
+			wantState: StateScaledZero,
+			wantID:    "scaled-zero-1",
+		},
+		{
+			name: "unenrolled",
+			inputs: Inputs{
+				OrgID: "org1", FleetID: "fleet1", Now: now,
+				Intents: []DeploymentIntent{
+					{InstanceID: "unenrolled-1", DesiredReplicas: 1},
+				},
+				// No fleet status for this instance.
+			},
+			wantState: StateUnenrolled,
+			wantID:    "unenrolled-1",
+		},
+		{
+			name: "stale",
+			inputs: Inputs{
+				OrgID: "org1", FleetID: "fleet1", Now: now,
+				Intents: []DeploymentIntent{
+					{InstanceID: "stale-1", DesiredReplicas: 1},
+				},
+				FleetStatus: []controlplane.FollowerFleetStatus{
+					{
+						FollowerSummary: controlplane.FollowerSummary{InstanceID: "stale-1", Active: true},
+						Health:          healthStale,
+						Drift:           "status_stale",
+					},
+				},
+			},
+			wantState: StateStale,
+			wantID:    "stale-1",
+		},
+		{
+			name: "wrong_digest",
+			inputs: Inputs{
+				OrgID: "org1", FleetID: "fleet1", Now: now,
+				Intents: []DeploymentIntent{
+					{InstanceID: "wrong-1", DesiredReplicas: 1, DesiredDigest: "aaaa"},
+				},
+				FleetStatus: []controlplane.FollowerFleetStatus{
+					{
+						FollowerSummary: controlplane.FollowerSummary{InstanceID: "wrong-1", Active: true},
+						Health:          healthOK,
+						RuntimeStatus: &controlplane.FollowerRuntimeStatus{
+							ActiveBundleHash: "bbbb",
+							LastSeenAt:       now.Add(-30 * time.Second),
+						},
+					},
+				},
+			},
+			wantState: StateWrongDigest,
+			wantID:    "wrong-1",
+		},
+		{
+			name: "current_without_batch",
+			inputs: Inputs{
+				OrgID: "org1", FleetID: "fleet1", Now: now,
+				Intents: []DeploymentIntent{
+					{InstanceID: "nobatch-1", DesiredReplicas: 1},
+				},
+				FleetStatus: []controlplane.FollowerFleetStatus{
+					{
+						FollowerSummary: controlplane.FollowerSummary{InstanceID: "nobatch-1", Active: true},
+						Health:          healthOK,
+					},
+				},
+				// No audit batches.
+			},
+			wantState: StateCurrentWithoutBatch,
+			wantID:    "nobatch-1",
+		},
+		{
+			name: "fully_converged",
+			inputs: Inputs{
+				OrgID: "org1", FleetID: "fleet1", Now: now,
+				Intents: []DeploymentIntent{
+					{InstanceID: "converged-1", DesiredReplicas: 1},
+				},
+				FleetStatus: []controlplane.FollowerFleetStatus{
+					{
+						FollowerSummary: controlplane.FollowerSummary{InstanceID: "converged-1", Active: true},
+						Health:          healthOK,
+					},
+				},
+				AuditBatches: []controlplane.AuditBatchSummary{
+					{
+						BatchID:    "batch-1",
+						InstanceID: "converged-1",
+						ReceivedAt: recentBatchTime,
+						EmittedAt:  recentBatchTime.Add(-5 * time.Second),
+					},
+				},
+			},
+			wantState: StateFullyConverged,
+			wantID:    "converged-1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			report := Build(tc.inputs)
+			if len(report.Followers) != 1 {
+				t.Fatalf("expected 1 follower, got %d", len(report.Followers))
+			}
+			fc := report.Followers[0]
+			if fc.InstanceID != tc.wantID {
+				t.Errorf("instance_id = %q, want %q", fc.InstanceID, tc.wantID)
+			}
+			if fc.State != tc.wantState {
+				t.Errorf("state = %q, want %q (reason: %s)", fc.State, tc.wantState, fc.Reason)
+			}
+		})
+	}
+
+	// Verify that unknown health renders as unknown state, not converged
+	// (fail-closed direction).
+	t.Run("unknown_health_is_not_converged", func(t *testing.T) {
+		report := Build(Inputs{
+			OrgID: "org1", FleetID: "fleet1", Now: now,
+			Intents: []DeploymentIntent{
+				{InstanceID: "unk-1", DesiredReplicas: 1},
+			},
+			FleetStatus: []controlplane.FollowerFleetStatus{
+				{
+					FollowerSummary: controlplane.FollowerSummary{InstanceID: "unk-1", Active: true},
+					Health:          healthUnknown,
+					Drift:           "no_status",
+				},
+			},
+		})
+		if len(report.Followers) != 1 {
+			t.Fatalf("expected 1 follower, got %d", len(report.Followers))
+		}
+		if report.Followers[0].State != StateUnknown {
+			t.Errorf("state = %q, want %q", report.Followers[0].State, StateUnknown)
+		}
+	})
+
+	// Verify excluded state.
+	t.Run("excluded_is_na", func(t *testing.T) {
+		report := Build(Inputs{
+			OrgID: "org1", FleetID: "fleet1", Now: now,
+			Intents: []DeploymentIntent{
+				{InstanceID: "local-1", DesiredReplicas: 1, Excluded: true, ExcludedReason: "local-only proxy"},
+			},
+		})
+		if len(report.Followers) != 1 {
+			t.Fatalf("expected 1 follower, got %d", len(report.Followers))
+		}
+		fc := report.Followers[0]
+		if fc.State != StateExcluded {
+			t.Errorf("state = %q, want %q", fc.State, StateExcluded)
+		}
+		if fc.Reason != "local-only proxy" {
+			t.Errorf("reason = %q, want %q", fc.Reason, "local-only proxy")
+		}
+	})
+}
+
+func TestBuild_FourDenominatorsNeverCollapsed(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	report := Build(Inputs{
+		OrgID: "org1", FleetID: "fleet1", Now: now,
+		Intents: []DeploymentIntent{
+			{InstanceID: "a", DesiredReplicas: 1},
+			{InstanceID: "b", DesiredReplicas: 1},
+		},
+		FleetStatus: []controlplane.FollowerFleetStatus{
+			{
+				FollowerSummary: controlplane.FollowerSummary{InstanceID: "a", Active: true},
+				Health:          controlplane.FleetHealthOK,
+			},
+			// "b" has no fleet status = unenrolled.
+		},
+		AuditBatches: []controlplane.AuditBatchSummary{
+			{
+				BatchID:    "batch-a",
+				InstanceID: "a",
+				ReceivedAt: now.Add(-30 * time.Second),
+				EmittedAt:  now.Add(-35 * time.Second),
+			},
+		},
+	})
+
+	// Deployment: 2 total, "a" healthy, "b" unenrolled (not healthy).
+	if report.DeploymentCoverage.Total != 2 {
+		t.Errorf("deployment total = %d, want 2", report.DeploymentCoverage.Total)
+	}
+	// Runtime: 2 total (excludes scaled_zero/excluded, both a and b count).
+	if report.RuntimeCoverage.Total != 2 {
+		t.Errorf("runtime total = %d, want 2", report.RuntimeCoverage.Total)
+	}
+	// Evidence: 2 total, only "a" has a batch.
+	if report.EvidenceCoverage.Total != 2 {
+		t.Errorf("evidence total = %d, want 2", report.EvidenceCoverage.Total)
+	}
+	if report.EvidenceCoverage.Healthy != 1 {
+		t.Errorf("evidence healthy = %d, want 1", report.EvidenceCoverage.Healthy)
+	}
+
+	// The four denominators MUST be independently queryable, never one collapsed number.
+	// Verify they differ.
+	if report.DeploymentCoverage.Healthy == report.EvidenceCoverage.Healthy &&
+		report.DeploymentCoverage.Total == report.EvidenceCoverage.Total {
+		// This is actually fine in this case; the point is they CAN differ.
+		// Let's check the structural independence by ensuring the JSON has four keys.
+		data, err := json.Marshal(report)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatal(err)
+		}
+		for _, key := range []string{"deployment_coverage", "runtime_coverage", "conductor_coverage", "evidence_coverage"} {
+			if _, ok := raw[key]; !ok {
+				t.Errorf("missing top-level key %q in report JSON", key)
+			}
+		}
+	}
+}
+
+func TestBuild_UnknownInputFailsClosed(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	// A follower that appears only in audit batches (no intent, no fleet status)
+	// must be unknown, not converged.
+	report := Build(Inputs{
+		OrgID: "org1", FleetID: "fleet1", Now: now,
+		AuditBatches: []controlplane.AuditBatchSummary{
+			{
+				BatchID:    "batch-orphan",
+				InstanceID: "orphan-1",
+				ReceivedAt: now.Add(-10 * time.Second),
+			},
+		},
+	})
+
+	if len(report.Followers) != 1 {
+		t.Fatalf("expected 1 follower, got %d", len(report.Followers))
+	}
+	fc := report.Followers[0]
+	if fc.State != StateUnknown {
+		t.Errorf("orphan state = %q, want %q", fc.State, StateUnknown)
+	}
+}
+
+func TestBuild_EvidenceFields(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	emitted := now.Add(-15 * time.Second)
+	received := now.Add(-10 * time.Second)
+
+	report := Build(Inputs{
+		OrgID: "org1", FleetID: "fleet1", Now: now,
+		Intents: []DeploymentIntent{
+			{InstanceID: "ev-1", DesiredReplicas: 1},
+		},
+		FleetStatus: []controlplane.FollowerFleetStatus{
+			{
+				FollowerSummary: controlplane.FollowerSummary{InstanceID: "ev-1", Active: true},
+				Health:          controlplane.FleetHealthOK,
+			},
+		},
+		AuditBatches: []controlplane.AuditBatchSummary{
+			{
+				BatchID:         "b1",
+				InstanceID:      "ev-1",
+				AuditSchema:     3,
+				SeqStart:        100,
+				SeqEnd:          200,
+				DroppedCount:    2,
+				SignatureKeyIDs: []string{"key-abc"},
+				ReceivedAt:      received,
+				EmittedAt:       emitted,
+			},
+		},
+	})
+
+	fc := report.Followers[0]
+	if fc.LatestBatch == nil {
+		t.Fatal("expected latest_batch to be non-nil")
+	}
+	ev := fc.LatestBatch
+	if ev.BatchID != "b1" {
+		t.Errorf("batch_id = %q, want %q", ev.BatchID, "b1")
+	}
+	if ev.SchemaVersion != 3 {
+		t.Errorf("schema_version = %d, want 3", ev.SchemaVersion)
+	}
+	if ev.SeqStart != 100 || ev.SeqEnd != 200 {
+		t.Errorf("seq range = [%d, %d], want [100, 200]", ev.SeqStart, ev.SeqEnd)
+	}
+	if ev.DroppedCount != 2 {
+		t.Errorf("dropped_count = %d, want 2", ev.DroppedCount)
+	}
+	if ev.SignerKeyID != "key-abc" {
+		t.Errorf("signer_key_id = %q, want %q", ev.SignerKeyID, "key-abc")
+	}
+	wantLag := received.Sub(emitted).Seconds()
+	if ev.DeliveryLagSecs != wantLag {
+		t.Errorf("delivery_lag_secs = %f, want %f", ev.DeliveryLagSecs, wantLag)
+	}
+}
+
+func TestBuild_AllStatesDistinguishable(t *testing.T) {
+	// Verify all six required states plus excluded are distinguishable in a
+	// single report with mixed followers.
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	healthOK := controlplane.FleetHealthOK
+	healthStale := controlplane.FleetHealthStale
+	_ = healthOK
+
+	report := Build(Inputs{
+		OrgID: "org1", FleetID: "fleet1", Now: now,
+		Intents: []DeploymentIntent{
+			{InstanceID: "a-scaled-zero", DesiredReplicas: 0},
+			{InstanceID: "b-unenrolled", DesiredReplicas: 1},
+			{InstanceID: "c-stale", DesiredReplicas: 1},
+			{InstanceID: "d-wrong", DesiredReplicas: 1, DesiredDigest: "aaaa"},
+			{InstanceID: "e-nobatch", DesiredReplicas: 1},
+			{InstanceID: "f-converged", DesiredReplicas: 1},
+			{InstanceID: "g-excluded", DesiredReplicas: 1, Excluded: true, ExcludedReason: "test only"},
+		},
+		FleetStatus: []controlplane.FollowerFleetStatus{
+			{FollowerSummary: controlplane.FollowerSummary{InstanceID: "c-stale", Active: true}, Health: healthStale, Drift: "status_stale"},
+			{FollowerSummary: controlplane.FollowerSummary{InstanceID: "d-wrong", Active: true}, Health: healthOK, RuntimeStatus: &controlplane.FollowerRuntimeStatus{ActiveBundleHash: "bbbb"}},
+			{FollowerSummary: controlplane.FollowerSummary{InstanceID: "e-nobatch", Active: true}, Health: healthOK},
+			{FollowerSummary: controlplane.FollowerSummary{InstanceID: "f-converged", Active: true}, Health: healthOK},
+		},
+		AuditBatches: []controlplane.AuditBatchSummary{
+			{BatchID: "b-f", InstanceID: "f-converged", ReceivedAt: now.Add(-30 * time.Second), EmittedAt: now.Add(-35 * time.Second)},
+		},
+	})
+
+	stateMap := make(map[FollowerState]string)
+	for _, fc := range report.Followers {
+		if prev, ok := stateMap[fc.State]; ok {
+			t.Errorf("state %q appears for both %q and %q", fc.State, prev, fc.InstanceID)
+		}
+		stateMap[fc.State] = fc.InstanceID
+	}
+
+	required := []FollowerState{
+		StateScaledZero, StateUnenrolled, StateStale,
+		StateWrongDigest, StateCurrentWithoutBatch, StateFullyConverged,
+		StateExcluded,
+	}
+	for _, s := range required {
+		if _, ok := stateMap[s]; !ok {
+			t.Errorf("missing required state %q in combined report", s)
+		}
+	}
+}

--- a/enterprise/conductor/convergence/convergence_test.go
+++ b/enterprise/conductor/convergence/convergence_test.go
@@ -236,24 +236,22 @@ func TestBuild_FourDenominatorsNeverCollapsed(t *testing.T) {
 		t.Errorf("evidence healthy = %d, want 1", report.EvidenceCoverage.Healthy)
 	}
 
-	// The four denominators MUST be independently queryable, never one collapsed number.
-	// Verify they differ.
-	if report.DeploymentCoverage.Healthy == report.EvidenceCoverage.Healthy &&
-		report.DeploymentCoverage.Total == report.EvidenceCoverage.Total {
-		// This is actually fine in this case; the point is they CAN differ.
-		// Let's check the structural independence by ensuring the JSON has four keys.
-		data, err := json.Marshal(report)
-		if err != nil {
-			t.Fatal(err)
-		}
-		var raw map[string]json.RawMessage
-		if err := json.Unmarshal(data, &raw); err != nil {
-			t.Fatal(err)
-		}
-		for _, key := range []string{"deployment_coverage", "runtime_coverage", "conductor_coverage", "evidence_coverage"} {
-			if _, ok := raw[key]; !ok {
-				t.Errorf("missing top-level key %q in report JSON", key)
-			}
+	// The four denominators MUST be independently queryable, never one collapsed
+	// number. This assertion runs unconditionally: it was previously guarded by
+	// the deployment and evidence numbers happening to be equal, so a fixture
+	// change that made them differ would have skipped the check entirely while
+	// the test kept passing under a name claiming an unconditional invariant.
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"deployment_coverage", "runtime_coverage", "conductor_coverage", "evidence_coverage"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing top-level key %q in report JSON", key)
 		}
 	}
 }
@@ -341,12 +339,12 @@ func TestBuild_EvidenceFields(t *testing.T) {
 }
 
 func TestBuild_AllStatesDistinguishable(t *testing.T) {
-	// Verify all six required states plus excluded are distinguishable in a
-	// single report with mixed followers.
+	// Every distinguishable state must be reachable in one mixed report, so a
+	// state that silently stops being produced fails here rather than quietly
+	// disappearing from operator-visible output.
 	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
 	healthOK := controlplane.FleetHealthOK
 	healthStale := controlplane.FleetHealthStale
-	_ = healthOK
 
 	report := Build(Inputs{
 		OrgID: "org1", FleetID: "fleet1", Now: now,
@@ -358,12 +356,17 @@ func TestBuild_AllStatesDistinguishable(t *testing.T) {
 			{InstanceID: "e-nobatch", DesiredReplicas: 1},
 			{InstanceID: "f-converged", DesiredReplicas: 1},
 			{InstanceID: "g-excluded", DesiredReplicas: 1, Excluded: true, ExcludedReason: "test only"},
+			{InstanceID: "i-unknown", DesiredReplicas: 1},
 		},
 		FleetStatus: []controlplane.FollowerFleetStatus{
 			{FollowerSummary: controlplane.FollowerSummary{InstanceID: "c-stale", Active: true}, Health: healthStale, Drift: "status_stale"},
 			{FollowerSummary: controlplane.FollowerSummary{InstanceID: "d-wrong", Active: true}, Health: healthOK, RuntimeStatus: &controlplane.FollowerRuntimeStatus{ActiveBundleHash: "bbbb"}},
 			{FollowerSummary: controlplane.FollowerSummary{InstanceID: "e-nobatch", Active: true}, Health: healthOK},
 			{FollowerSummary: controlplane.FollowerSummary{InstanceID: "f-converged", Active: true}, Health: healthOK},
+			// Enrolled and healthy but declared by no deployment intent.
+			{FollowerSummary: controlplane.FollowerSummary{InstanceID: "h-undeclared", Active: true}, Health: healthOK},
+			// A health value this code does not recognize must fail closed.
+			{FollowerSummary: controlplane.FollowerSummary{InstanceID: "i-unknown", Active: true}, Health: controlplane.FleetHealth("some_future_health")},
 		},
 		AuditBatches: []controlplane.AuditBatchSummary{
 			{BatchID: "b-f", InstanceID: "f-converged", ReceivedAt: now.Add(-30 * time.Second), EmittedAt: now.Add(-35 * time.Second)},
@@ -381,7 +384,7 @@ func TestBuild_AllStatesDistinguishable(t *testing.T) {
 	required := []FollowerState{
 		StateScaledZero, StateUnenrolled, StateStale,
 		StateWrongDigest, StateCurrentWithoutBatch, StateFullyConverged,
-		StateExcluded,
+		StateExcluded, StateUndeclared, StateUnknown,
 	}
 	for _, s := range required {
 		if _, ok := stateMap[s]; !ok {

--- a/enterprise/conductor/convergence/convergence_test.go
+++ b/enterprise/conductor/convergence/convergence_test.go
@@ -312,6 +312,11 @@ func TestBuild_EvidenceFields(t *testing.T) {
 		},
 	})
 
+	// Guard the index: if Build ever stops emitting this follower, an unguarded
+	// report.Followers[0] panics instead of reporting which invariant broke.
+	if len(report.Followers) != 1 {
+		t.Fatalf("followers = %d, want 1", len(report.Followers))
+	}
 	fc := report.Followers[0]
 	if fc.LatestBatch == nil {
 		t.Fatal("expected latest_batch to be non-nil")

--- a/enterprise/conductor/convergence/denominator_test.go
+++ b/enterprise/conductor/convergence/denominator_test.go
@@ -196,3 +196,99 @@ func TestClassify_ScaledZeroButStillActiveIsNotAbsent(t *testing.T) {
 		t.Fatalf("scaled-zero-but-active reported as %q, want %q", fc.State, StateUnknown)
 	}
 }
+
+// TestClassify_UncoveredFailClosedBranches covers the four classifier branches
+// the state table did not reach.
+//
+// The last two are fail-closed paths, which are exactly the ones whose
+// regression would be silent: if either stopped firing, the follower would fall
+// through to StateFullyConverged and the report would call an unprovable
+// follower converged.
+func TestClassify_UncoveredFailClosedBranches(t *testing.T) {
+	now := time.Now().UTC()
+	activeOK := func(h controlplane.FleetHealth) *controlplane.FollowerFleetStatus {
+		return &controlplane.FollowerFleetStatus{
+			FollowerSummary: controlplane.FollowerSummary{Active: true},
+			Health:          h,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		intent    *DeploymentIntent
+		status    *controlplane.FollowerFleetStatus
+		batch     *controlplane.AuditBatchSummary
+		wantState FollowerState
+	}{
+		{
+			name:      "apply failed is stale",
+			intent:    &DeploymentIntent{DesiredReplicas: 1},
+			status:    activeOK(controlplane.FleetHealthApplyFailed),
+			wantState: StateStale,
+		},
+		{
+			name:      "unsupported runtime version is wrong digest",
+			intent:    &DeploymentIntent{DesiredReplicas: 1},
+			status:    activeOK(controlplane.FleetHealthUnsupported),
+			wantState: StateWrongDigest,
+		},
+		{
+			name:   "desired digest with no active bundle hash is unknown",
+			intent: &DeploymentIntent{DesiredReplicas: 1, DesiredDigest: "aaaa"},
+			// Healthy, but nothing reports which bundle is actually running.
+			status:    activeOK(controlplane.FleetHealthOK),
+			wantState: StateUnknown,
+		},
+		{
+			name:   "batch older than the evidence window is stale",
+			intent: &DeploymentIntent{DesiredReplicas: 1},
+			status: activeOK(controlplane.FleetHealthOK),
+			batch: &controlplane.AuditBatchSummary{
+				ReceivedAt: now.Add(-(evidenceStaleWindowMultiple + 2) * time.Minute),
+			},
+			wantState: StateStale,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := classifyFollower("f-1", tc.intent, tc.status, tc.batch, now, time.Minute)
+			if fc.State != tc.wantState {
+				t.Fatalf("state = %q, want %q (reason: %s)", fc.State, tc.wantState, fc.Reason)
+			}
+			if fc.State == StateFullyConverged {
+				t.Fatal("a fail-closed branch fell through to converged")
+			}
+		})
+	}
+}
+
+// TestEvidence_RuntimeBuildIsPopulated pins the runtime_build field.
+//
+// The audit batch summary does not carry the emitting follower's Pipelock
+// version, so it has to come from the follower's runtime status. Without this
+// the report advertises a runtime_build field that is always empty, which
+// overclaims what the evidence layer can tell an operator.
+func TestEvidence_RuntimeBuildIsPopulated(t *testing.T) {
+	now := time.Now().UTC()
+	fleetStatus := &controlplane.FollowerFleetStatus{
+		FollowerSummary: controlplane.FollowerSummary{Active: true},
+		Health:          controlplane.FleetHealthOK,
+		RuntimeStatus: &controlplane.FollowerRuntimeStatus{
+			PipelockVersion: "3.4.0",
+		},
+	}
+	intent := &DeploymentIntent{DesiredReplicas: 1}
+	batch := &controlplane.AuditBatchSummary{ReceivedAt: now.Add(-time.Minute)}
+
+	fc := classifyFollower("f-1", intent, fleetStatus, batch, now, time.Minute)
+
+	if fc.LatestBatch == nil {
+		t.Fatal("expected latest_batch to be present")
+	}
+	if fc.LatestBatch.RuntimeBuild != "3.4.0" {
+		t.Fatalf("runtime_build = %q, want %q; the report declares this field, so "+
+			"leaving it empty overclaims what the evidence layer reports",
+			fc.LatestBatch.RuntimeBuild, "3.4.0")
+	}
+}

--- a/enterprise/conductor/convergence/denominator_test.go
+++ b/enterprise/conductor/convergence/denominator_test.go
@@ -36,6 +36,48 @@ func TestEvidenceSummary_StaleBatchIsNotHealthyEvidence(t *testing.T) {
 		t.Fatalf("evidence coverage counted a stale follower as healthy (healthy=%d); "+
 			"a stale follower's old batch is not healthy evidence delivery", s.Healthy)
 	}
+	if s.Total != 1 {
+		t.Fatalf("evidence total = %d, want 1; a stale follower is still in scope", s.Total)
+	}
+	if s.Unknown != 1 {
+		t.Fatalf("evidence unknown = %d, want 1; a stale follower must be explicitly "+
+			"unvouchable rather than silently absent from both counts", s.Unknown)
+	}
+}
+
+// TestBuild_DuplicateFleetStatusFailsClosed covers the second duplicate source.
+//
+// Build detects duplicate identity separately for intents and for fleet-status
+// records. Covering only the intent path would leave the fleet-status path free
+// to regress, since the two are independent maps built in different loops.
+func TestBuild_DuplicateFleetStatusFailsClosed(t *testing.T) {
+	now := time.Now().UTC()
+	report := Build(Inputs{
+		Now: now,
+		FleetStatus: []controlplane.FollowerFleetStatus{
+			{
+				FollowerSummary: controlplane.FollowerSummary{InstanceID: "dup-fs", Active: true},
+				Health:          controlplane.FleetHealthOK,
+			},
+			{
+				FollowerSummary: controlplane.FollowerSummary{InstanceID: "dup-fs", Active: true},
+				Health:          controlplane.FleetHealthOK,
+			},
+		},
+	})
+
+	var found *FollowerConvergence
+	for i := range report.Followers {
+		if report.Followers[i].InstanceID == "dup-fs" {
+			found = &report.Followers[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("duplicate fleet-status instance ID vanished from the report entirely")
+	}
+	if found.State != StateUnknown {
+		t.Fatalf("duplicate fleet-status record reported as %q, want %q", found.State, StateUnknown)
+	}
 }
 
 // TestBuild_DuplicateInstanceIDFailsClosed covers ambiguous identity.

--- a/enterprise/conductor/convergence/denominator_test.go
+++ b/enterprise/conductor/convergence/denominator_test.go
@@ -93,8 +93,64 @@ func TestClassify_InactiveFollowerIsNotConverged(t *testing.T) {
 
 	fc := classifyFollower("inactive-1", intent, fleetStatus, batch, now, time.Minute)
 
-	if fc.State == StateFullyConverged {
-		t.Fatal("an inactive follower was reported as fully converged; the state means " +
-			"enrolled, active and healthy, so a deactivated follower hides lost capacity")
+	if fc.State != StateStale {
+		t.Fatalf("an inactive follower was reported as %q, want %q; converged means "+
+			"enrolled, active and healthy, so a deactivated follower hides lost capacity",
+			fc.State, StateStale)
+	}
+}
+
+// TestClassify_UnrecognizedHealthFailsClosed covers the denylist-to-allowlist
+// change in health handling.
+//
+// The classifier rejected four specific known-bad health values, so any other
+// value, including a FleetHealth constant added in a later release, fell
+// straight through to the converged path. A health value this code has never
+// heard of must fail closed rather than be read as fine.
+func TestClassify_UnrecognizedHealthFailsClosed(t *testing.T) {
+	now := time.Now().UTC()
+	fleetStatus := &controlplane.FollowerFleetStatus{
+		FollowerSummary: controlplane.FollowerSummary{Active: true},
+		// A value this code does not know about, standing in for a constant
+		// added by a future release.
+		Health:        controlplane.FleetHealth("some_future_health"),
+		RuntimeStatus: &controlplane.FollowerRuntimeStatus{ActiveBundleHash: "abc123"},
+	}
+	intent := &DeploymentIntent{DesiredReplicas: 1}
+	batch := &controlplane.AuditBatchSummary{ReceivedAt: now.Add(-time.Minute)}
+
+	fc := classifyFollower("future-1", intent, fleetStatus, batch, now, time.Minute)
+
+	if fc.State != StateUnknown {
+		t.Fatalf("a follower with unrecognized health was reported as %q, want %q; "+
+			"an unknown health value must fail closed, not reach converged", fc.State, StateUnknown)
+	}
+}
+
+// TestClassify_ScaledZeroButStillActiveIsNotAbsent covers the ordering of the
+// scaled-zero shortcut.
+//
+// Scaled-zero claims a follower is intentionally absent. Deciding it before any
+// runtime check meant a follower that was still enrolled and active got
+// reported as intentionally gone, which hides a live enforcement point that
+// nobody expects to exist.
+func TestClassify_ScaledZeroButStillActiveIsNotAbsent(t *testing.T) {
+	now := time.Now().UTC()
+	fleetStatus := &controlplane.FollowerFleetStatus{
+		FollowerSummary: controlplane.FollowerSummary{Active: true},
+		Health:          controlplane.FleetHealthOK,
+		RuntimeStatus:   &controlplane.FollowerRuntimeStatus{ActiveBundleHash: "abc123"},
+	}
+	intent := &DeploymentIntent{DesiredReplicas: 0}
+
+	fc := classifyFollower("ghost-1", intent, fleetStatus, nil, now, time.Minute)
+
+	if fc.State == StateScaledZero {
+		t.Fatal("a follower that is still enrolled and active was reported as scaled " +
+			"to zero; a live enforcement point nobody expects must not read as " +
+			"intentionally absent")
+	}
+	if fc.State != StateUnknown {
+		t.Fatalf("scaled-zero-but-active reported as %q, want %q", fc.State, StateUnknown)
 	}
 }

--- a/enterprise/conductor/convergence/denominator_test.go
+++ b/enterprise/conductor/convergence/denominator_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build enterprise
+
+package convergence
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+)
+
+// TestEvidenceSummary_StaleBatchIsNotHealthyEvidence covers the internal
+// consistency of the denominators.
+//
+// Evidence coverage counted any follower with a non-nil batch as healthy, even
+// one already classified stale. During an audit-delivery outage that reports a
+// green evidence denominator while the convergence denominator says stale, so
+// the two numbers contradict each other and the outage looks fine.
+func TestEvidenceSummary_StaleBatchIsNotHealthyEvidence(t *testing.T) {
+	followers := []FollowerConvergence{
+		{
+			InstanceID: "stale-1",
+			State:      StateStale,
+			LatestBatch: &AuditEvidence{
+				BatchID: "b1",
+			},
+		},
+	}
+
+	s := evidenceSummary(followers)
+
+	if s.Healthy != 0 {
+		t.Fatalf("evidence coverage counted a stale follower as healthy (healthy=%d); "+
+			"a stale follower's old batch is not healthy evidence delivery", s.Healthy)
+	}
+}
+
+// TestBuild_DuplicateInstanceIDFailsClosed covers ambiguous identity.
+//
+// Intent and fleet-status maps took the last slice entry for a repeated
+// instance ID, so a duplicate marked Excluded or DesiredReplicas:0 could
+// suppress a real unhealthy instance purely by input ordering. Ambiguous
+// identity across independent control-plane sources is a data-integrity
+// condition and must be visible, not resolved by whichever record sorted last.
+func TestBuild_DuplicateInstanceIDFailsClosed(t *testing.T) {
+	now := time.Now().UTC()
+	report := Build(Inputs{
+		Now: now,
+		Intents: []DeploymentIntent{
+			{InstanceID: "dup-1", DesiredReplicas: 1},
+			// A second record for the same ID that would silently win and
+			// suppress the instance entirely.
+			{InstanceID: "dup-1", Excluded: true, ExcludedReason: "suppressed"},
+		},
+	})
+
+	var found *FollowerConvergence
+	for i := range report.Followers {
+		if report.Followers[i].InstanceID == "dup-1" {
+			found = &report.Followers[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("duplicate instance ID vanished from the report entirely")
+	}
+	if found.State == StateExcluded {
+		t.Fatal("a duplicate intent record marked excluded suppressed the instance; " +
+			"conflicting identity records must fail closed, not be resolved by ordering")
+	}
+	if found.State != StateUnknown {
+		t.Fatalf("duplicate instance ID reported as %q, want unknown with a conflict reason", found.State)
+	}
+}
+
+// TestClassify_InactiveFollowerIsNotConverged covers the state definition.
+//
+// StateFullyConverged is documented as "enrolled, active, healthy". A
+// deactivated follower carrying historical OK health and a recent batch was
+// still reported converged, which hides lost enforcement capacity after a
+// follower is deactivated or stops serving traffic.
+func TestClassify_InactiveFollowerIsNotConverged(t *testing.T) {
+	now := time.Now().UTC()
+	fleetStatus := &controlplane.FollowerFleetStatus{
+		FollowerSummary: controlplane.FollowerSummary{Active: false},
+		Health:          controlplane.FleetHealthOK,
+		RuntimeStatus:   &controlplane.FollowerRuntimeStatus{ActiveBundleHash: "abc123"},
+	}
+	intent := &DeploymentIntent{DesiredReplicas: 1}
+	batch := &controlplane.AuditBatchSummary{ReceivedAt: now.Add(-time.Minute)}
+
+	fc := classifyFollower("inactive-1", intent, fleetStatus, batch, now, time.Minute)
+
+	if fc.State == StateFullyConverged {
+		t.Fatal("an inactive follower was reported as fully converged; the state means " +
+			"enrolled, active and healthy, so a deactivated follower hides lost capacity")
+	}
+}

--- a/enterprise/conductor/convergence/failopen_test.go
+++ b/enterprise/conductor/convergence/failopen_test.go
@@ -24,7 +24,9 @@ import (
 func TestClassify_UndeclaredFollowerIsNotConverged(t *testing.T) {
 	now := time.Now()
 	fleetStatus := &controlplane.FollowerFleetStatus{
-		Health: controlplane.FleetHealthOK,
+		// Active, so the inactive guard is not what this test trips on.
+		FollowerSummary: controlplane.FollowerSummary{Active: true},
+		Health:          controlplane.FleetHealthOK,
 		RuntimeStatus: &controlplane.FollowerRuntimeStatus{
 			ActiveBundleHash: "abc123",
 		},
@@ -33,10 +35,10 @@ func TestClassify_UndeclaredFollowerIsNotConverged(t *testing.T) {
 
 	fc := classifyFollower("rogue-1", nil, fleetStatus, batch, now, time.Minute)
 
-	if fc.State == StateFullyConverged {
-		t.Fatalf("an undeclared follower was reported as %q; a follower no deployment "+
-			"intent declares must never be counted as converged, or an unmanaged "+
-			"enforcement point reads as green", fc.State)
+	if fc.State != StateUndeclared {
+		t.Fatalf("an undeclared follower was reported as %q, want %q; a follower no "+
+			"deployment intent declares must never be counted as converged, or an "+
+			"unmanaged enforcement point reads as green", fc.State, StateUndeclared)
 	}
 }
 
@@ -51,7 +53,9 @@ func TestClassify_UndeclaredFollowerIsNotConverged(t *testing.T) {
 func TestClassify_SignedStateMustNotMaskDisagreeingRuntime(t *testing.T) {
 	now := time.Now()
 	fleetStatus := &controlplane.FollowerFleetStatus{
-		Health: controlplane.FleetHealthOK,
+		// Active, so the inactive guard is not what this test trips on.
+		FollowerSummary: controlplane.FollowerSummary{Active: true},
+		Health:          controlplane.FleetHealthOK,
 		RuntimeStatus: &controlplane.FollowerRuntimeStatus{
 			// What the proxy says it is actually running right now.
 			ActiveBundleHash: "OLD-DOWNGRADED-BUNDLE",
@@ -69,9 +73,9 @@ func TestClassify_SignedStateMustNotMaskDisagreeingRuntime(t *testing.T) {
 
 	fc := classifyFollower("follower-1", intent, fleetStatus, batch, now, time.Minute)
 
-	if fc.State == StateFullyConverged {
+	if fc.State != StateUnknown {
 		t.Fatalf("a follower whose signed state and live runtime disagree was reported "+
-			"as %q; the stale signed record masked a runtime on %q", fc.State,
-			fleetStatus.RuntimeStatus.ActiveBundleHash)
+			"as %q, want %q; the stale signed record masked a runtime on %q", fc.State,
+			StateUnknown, fleetStatus.RuntimeStatus.ActiveBundleHash)
 	}
 }

--- a/enterprise/conductor/convergence/failopen_test.go
+++ b/enterprise/conductor/convergence/failopen_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build enterprise
+
+package convergence
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+)
+
+// TestClassify_UndeclaredFollowerIsNotConverged covers the desired-state
+// boundary the report exists to establish.
+//
+// A follower that conductor knows about but that NO deployment intent declares
+// is undeclared. It may be a rogue or forgotten enforcement point. Reporting it
+// as fully converged because it happens to be healthy and producing evidence
+// inverts the purpose of the report: the question is not "is this thing well",
+// it is "is this thing supposed to be here".
+func TestClassify_UndeclaredFollowerIsNotConverged(t *testing.T) {
+	now := time.Now()
+	fleetStatus := &controlplane.FollowerFleetStatus{
+		Health: controlplane.FleetHealthOK,
+		RuntimeStatus: &controlplane.FollowerRuntimeStatus{
+			ActiveBundleHash: "abc123",
+		},
+	}
+	batch := &controlplane.AuditBatchSummary{ReceivedAt: now.Add(-time.Minute)}
+
+	fc := classifyFollower("rogue-1", nil, fleetStatus, batch, now, time.Minute)
+
+	if fc.State == StateFullyConverged {
+		t.Fatalf("an undeclared follower was reported as %q; a follower no deployment "+
+			"intent declares must never be counted as converged, or an unmanaged "+
+			"enforcement point reads as green", fc.State)
+	}
+}
+
+// TestClassify_SignedStateMustNotMaskDisagreeingRuntime covers the case where
+// two sources of truth disagree about which bundle is actually running.
+//
+// The signed applied state is a record of what a follower reported applying.
+// The runtime status is what it says it is running now. If a stale signed
+// record matches the desired digest while the live runtime reports a different
+// bundle, preferring the signed record reports convergence for a proxy that is
+// enforcing an old, downgraded, or tampered policy.
+func TestClassify_SignedStateMustNotMaskDisagreeingRuntime(t *testing.T) {
+	now := time.Now()
+	fleetStatus := &controlplane.FollowerFleetStatus{
+		Health: controlplane.FleetHealthOK,
+		RuntimeStatus: &controlplane.FollowerRuntimeStatus{
+			// What the proxy says it is actually running right now.
+			ActiveBundleHash: "OLD-DOWNGRADED-BUNDLE",
+		},
+		SignedAppliedState: &controlplane.VerifiedAppliedState{
+			Verified: true,
+			AppliedState: conductor.FollowerAppliedState{
+				// A stale record that happens to match what we wanted.
+				ActiveBundleHash: "desired-digest",
+			},
+		},
+	}
+	intent := &DeploymentIntent{DesiredReplicas: 1, DesiredDigest: "desired-digest"}
+	batch := &controlplane.AuditBatchSummary{ReceivedAt: now.Add(-time.Minute)}
+
+	fc := classifyFollower("follower-1", intent, fleetStatus, batch, now, time.Minute)
+
+	if fc.State == StateFullyConverged {
+		t.Fatalf("a follower whose signed state and live runtime disagree was reported "+
+			"as %q; the stale signed record masked a runtime on %q", fc.State,
+			fleetStatus.RuntimeStatus.ActiveBundleHash)
+	}
+}


### PR DESCRIPTION
## What changed

Adds a read-only convergence report that joins declared deployment intent, the running image digest, Conductor runtime status, and the latest accepted signed audit batch for every expected receipt producer.

The report keeps those four inputs as four separate denominators and never collapses them into a single percentage. Deployment coverage and evidence coverage answer different questions, and reporting one green number for both is what previously made a fleet look converged while some followers had produced no signed evidence at all.

Each expected producer exposes its latest accepted batch, schema version, sequence range, dropped count, signer, runtime build, and delivery lag. An instance that is intentionally local-only is recorded as an explicit not-applicable with a stated reason, so it is never silently counted as either a pass or a failure.

## States

Scaled-zero, unenrolled, stale, wrong-digest, current-without-batch, and fully converged remain distinguishable, and each has its own fixture and assertion. Excluded and unknown-health are covered as well.

## Failure direction

Both directions are audited. An unknown, unreachable, or unparseable input renders as an explicit unknown state rather than as converged, including a missing bundle hash where a desired digest was declared. In the other direction the report does not over-report failure: a healthy follower that has simply not yet produced evidence is classified as current-without-batch rather than unknown, and a scaled-zero or excluded instance is never counted as unhealthy.

## Scope

This change is library-only. Wiring the command into the existing fleet command tree touches a shared file and is deliberately left out of this diff so it does not collide with concurrent work. Roster mutation, deactivation, removal, and re-enrollment are explicitly out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added fleet convergence reporting across deployment, runtime, conductor, and audit evidence status.
  - Reports follower states including converged, stale, excluded, unenrolled, scaled to zero, undeclared, and unknown.
  - Preserves source evidence, calculates delivery lag, selects the latest audit batch, and provides independent coverage summaries.
  - Handles conflicting, incomplete, stale, or duplicate status information conservatively rather than marking followers as converged.

- **Tests**
  - Added comprehensive coverage for follower states, evidence handling, coverage summaries, inactive followers, and fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->