### PR TITLE
feat(release): gate a release on the embedded keyring being present

### DIFF
--- a/internal/cli/selfupdate/update.go
+++ b/internal/cli/selfupdate/update.go
@@ -189,6 +189,17 @@ func (o *Options) fillDefaults() error {
 	if o.ReleaseKeyringHex == "" {
 		o.ReleaseKeyringHex = releasetrust.PublicKeyringHex
 	}
+	// NOTE: the keyring preflight deliberately does NOT run here.
+	//
+	// validate() runs for every selfupdate operation, including rollback, which
+	// needs no keyring at all. Gating it here made a development build unable to
+	// roll back, which is the over-strict direction: a gate that blocks a
+	// legitimate operation gets disabled by the operator, and on a recovery path
+	// that is worse than the late failure it was replacing.
+	//
+	// The preflight's real subject is a RELEASE CANDIDATE being deployed to
+	// prove self-update, so its caller belongs in the release process, not in
+	// the update command. See CheckKeyringPreflight in internal/release.
 	if o.Stdout == nil {
 		o.Stdout = os.Stdout
 	}

--- a/internal/release/verify.go
+++ b/internal/release/verify.go
@@ -69,9 +69,23 @@ func CheckKeyringPreflight(candidateKeyringHex, expectKeyringHex string, customB
 	candidateKeyringHex = strings.TrimSpace(candidateKeyringHex)
 
 	// Empty keyring: fail unless explicitly custom-build-acknowledged.
+	//
+	// The acknowledgement waives the REQUIREMENT for a keyring, never a parity
+	// check that the caller explicitly asked for. When an expected keyring is
+	// supplied, an empty candidate cannot match it, so returning success here
+	// would answer "yes, parity holds" to a question whose answer is plainly
+	// no. Custom-build is an admission that this binary has no keyring, not a
+	// claim that it has the right one.
 	if candidateKeyringHex == "" {
-		if customBuild {
+		if customBuild && strings.TrimSpace(expectKeyringHex) == "" {
 			return KeyringPreflightResult{KeyCount: 0, CustomBuild: true}, nil
+		}
+		if customBuild {
+			return KeyringPreflightResult{}, fmt.Errorf(
+				"%w: candidate binary has no embedded release keyring, so it cannot "+
+					"match the expected keyring; a custom build waives the keyring "+
+					"requirement, not a parity check",
+				ErrKeyringParity)
 		}
 		return KeyringPreflightResult{}, fmt.Errorf(
 			"%w: candidate binary has no embedded release keyring; "+

--- a/internal/release/verify.go
+++ b/internal/release/verify.go
@@ -35,7 +35,95 @@ var (
 	ErrReleaseManifest   = errors.New("release manifest invalid")
 	ErrReleaseAsset      = errors.New("release manifest asset invalid")
 	ErrReleaseTrustInput = errors.New("release trust input invalid")
+	ErrKeyringParity     = errors.New("release keyring parity check failed")
 )
+
+// KeyringPreflightResult reports whether a candidate binary's embedded release
+// keyring satisfies the parity contract required before an RC can be used to
+// prove self-update.
+type KeyringPreflightResult struct {
+	// KeyCount is the number of valid Ed25519 public keys parsed from the
+	// candidate keyring. Zero means the keyring was empty or unset.
+	KeyCount int
+
+	// CustomBuild is true when the caller explicitly acknowledged that the
+	// binary is an unofficial/custom build and opted into out-of-band
+	// verification. The preflight still validates keyring format when a
+	// keyring is present, but does not require a non-empty keyring.
+	CustomBuild bool
+}
+
+// CheckKeyringPreflight validates that candidateKeyringHex is non-empty and
+// contains only well-formed Ed25519 public keys. When expectKeyringHex is
+// non-empty the candidate must match it exactly (order-sensitive).
+//
+// For legitimately unofficial/custom builds where the keyring is intentionally
+// absent, pass customBuild=true. The preflight will succeed with an empty
+// keyring ONLY in that mode, and the caller is responsible for out-of-band
+// verification. A non-empty but malformed keyring always fails regardless of
+// customBuild.
+//
+// Failure direction: empty, malformed, mismatched, or any ambiguity fails
+// closed. An unknown state is never a passing state.
+func CheckKeyringPreflight(candidateKeyringHex, expectKeyringHex string, customBuild bool) (KeyringPreflightResult, error) {
+	candidateKeyringHex = strings.TrimSpace(candidateKeyringHex)
+
+	// Empty keyring: fail unless explicitly custom-build-acknowledged.
+	if candidateKeyringHex == "" {
+		if customBuild {
+			return KeyringPreflightResult{KeyCount: 0, CustomBuild: true}, nil
+		}
+		return KeyringPreflightResult{}, fmt.Errorf(
+			"%w: candidate binary has no embedded release keyring; "+
+				"official RC builds must embed the release keyring via ldflags",
+			ErrKeyringParity)
+	}
+
+	// Parse and validate every key in the candidate keyring.
+	candidateKeys, err := parseKeyring(candidateKeyringHex)
+	if err != nil {
+		return KeyringPreflightResult{}, fmt.Errorf(
+			"%w: candidate keyring is malformed: %w", ErrKeyringParity, err)
+	}
+
+	result := KeyringPreflightResult{
+		KeyCount:    len(candidateKeys),
+		CustomBuild: customBuild,
+	}
+
+	// When an expected keyring is provided, require exact parity.
+	expectKeyringHex = strings.TrimSpace(expectKeyringHex)
+	if expectKeyringHex != "" {
+		expectKeys, err := parseKeyring(expectKeyringHex)
+		if err != nil {
+			return KeyringPreflightResult{}, fmt.Errorf(
+				"%w: expected keyring is malformed: %w", ErrKeyringParity, err)
+		}
+		if len(candidateKeys) != len(expectKeys) {
+			return KeyringPreflightResult{}, fmt.Errorf(
+				"%w: keyring length mismatch: candidate has %d keys, expected %d",
+				ErrKeyringParity, len(candidateKeys), len(expectKeys))
+		}
+		for i := range candidateKeys {
+			if hex.EncodeToString(candidateKeys[i]) != hex.EncodeToString(expectKeys[i]) {
+				return KeyringPreflightResult{}, fmt.Errorf(
+					"%w: key %d mismatch: candidate=%s expected=%s",
+					ErrKeyringParity, i,
+					hex.EncodeToString(candidateKeys[i]),
+					hex.EncodeToString(expectKeys[i]))
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// EmbeddedKeyringPreflight is a convenience that runs CheckKeyringPreflight
+// against the process's own PublicKeyringHex. It is the one-call gate for
+// release tooling to verify whether this binary has a real keyring.
+func EmbeddedKeyringPreflight(expectKeyringHex string, customBuild bool) (KeyringPreflightResult, error) {
+	return CheckKeyringPreflight(PublicKeyringHex, expectKeyringHex, customBuild)
+}
 
 type Manifest struct {
 	Schema             string  `json:"schema"`

--- a/internal/release/verify_test.go
+++ b/internal/release/verify_test.go
@@ -192,3 +192,126 @@ func TestFindAssetBindsPlatformAndDigest(t *testing.T) {
 		t.Fatalf("FindAsset invalid digest error = %v, want ErrReleaseAsset", err)
 	}
 }
+
+func TestCheckKeyringPreflight(t *testing.T) {
+	validKeyA := hex.EncodeToString(testPubA)
+	validKeyB := hex.EncodeToString(testPubB)
+	twoKeyring := validKeyA + "," + validKeyB
+
+	tests := []struct {
+		name        string
+		candidate   string
+		expect      string
+		customBuild bool
+		wantErr     error
+		wantCount   int
+		wantCustom  bool
+	}{
+		{
+			name:      "empty keyring fails closed",
+			candidate: "",
+			wantErr:   ErrKeyringParity,
+		},
+		{
+			name:      "whitespace-only keyring fails closed",
+			candidate: "   ",
+			wantErr:   ErrKeyringParity,
+		},
+		{
+			name:        "empty keyring custom build succeeds",
+			candidate:   "",
+			customBuild: true,
+			wantCount:   0,
+			wantCustom:  true,
+		},
+		{
+			name:      "valid single key passes",
+			candidate: validKeyA,
+			wantCount: 1,
+		},
+		{
+			name:      "valid two-key keyring passes",
+			candidate: twoKeyring,
+			wantCount: 2,
+		},
+		{
+			name:      "malformed keyring fails closed",
+			candidate: "not-hex-at-all",
+			wantErr:   ErrKeyringParity,
+		},
+		{
+			name:      "truncated key fails closed",
+			candidate: validKeyA[:32],
+			wantErr:   ErrKeyringParity,
+		},
+		{
+			name:        "malformed keyring fails even with custom build",
+			candidate:   "zzzz",
+			customBuild: true,
+			wantErr:     ErrKeyringParity,
+		},
+		{
+			name:      "parity match succeeds",
+			candidate: validKeyA,
+			expect:    validKeyA,
+			wantCount: 1,
+		},
+		{
+			name:      "parity mismatch fails closed",
+			candidate: validKeyA,
+			expect:    validKeyB,
+			wantErr:   ErrKeyringParity,
+		},
+		{
+			name:      "parity length mismatch fails closed",
+			candidate: twoKeyring,
+			expect:    validKeyA,
+			wantErr:   ErrKeyringParity,
+		},
+		{
+			name:      "malformed expected keyring fails closed",
+			candidate: validKeyA,
+			expect:    "bad",
+			wantErr:   ErrKeyringParity,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := CheckKeyringPreflight(tt.candidate, tt.expect, tt.customBuild)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("got err=%v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.KeyCount != tt.wantCount {
+				t.Errorf("KeyCount=%d, want %d", result.KeyCount, tt.wantCount)
+			}
+			if result.CustomBuild != tt.wantCustom {
+				t.Errorf("CustomBuild=%v, want %v", result.CustomBuild, tt.wantCustom)
+			}
+		})
+	}
+}
+
+func TestEmbeddedKeyringPreflight(t *testing.T) {
+	// The test binary has no ldflags, so PublicKeyringHex is "".
+	// Without customBuild, it must fail closed.
+	_, err := EmbeddedKeyringPreflight("", false)
+	if !errors.Is(err, ErrKeyringParity) {
+		t.Fatalf("empty embedded keyring without customBuild: got err=%v, want ErrKeyringParity", err)
+	}
+
+	// With customBuild, empty embedded keyring is accepted.
+	result, err := EmbeddedKeyringPreflight("", true)
+	if err != nil {
+		t.Fatalf("empty embedded keyring with customBuild: unexpected error: %v", err)
+	}
+	if result.KeyCount != 0 || !result.CustomBuild {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}

--- a/internal/release/verify_test.go
+++ b/internal/release/verify_test.go
@@ -315,3 +315,48 @@ func TestEmbeddedKeyringPreflight(t *testing.T) {
 		t.Fatalf("unexpected result: %+v", result)
 	}
 }
+
+// TestCheckKeyringPreflight_CustomBuildDoesNotWaiveParity covers the
+// interaction between the custom-build acknowledgement and an explicitly
+// requested parity check.
+//
+// The acknowledgement waives the REQUIREMENT for a keyring, never a parity
+// check the caller asked for. An empty candidate cannot match a non-empty
+// expected keyring, so passing here would answer "yes, parity holds" to a
+// question whose answer is plainly no.
+func TestCheckKeyringPreflight_CustomBuildDoesNotWaiveParity(t *testing.T) {
+	validKeyring := strings.Repeat("ab", 32)
+
+	if _, err := CheckKeyringPreflight("", validKeyring, true); err == nil {
+		t.Fatal("an empty candidate passed a parity check against a real expected " +
+			"keyring because custom-build short-circuited first; custom-build admits " +
+			"there is no keyring, it does not claim the right one is present")
+	}
+
+	// With no parity requested, the acknowledgement still works as intended.
+	if _, err := CheckKeyringPreflight("", "", true); err != nil {
+		t.Fatalf("custom build with no expected keyring should pass: %v", err)
+	}
+
+	// And the acknowledgement never excuses a broken keyring.
+	if _, err := CheckKeyringPreflight("zzzz", "", true); err == nil {
+		t.Fatal("custom build must not excuse a malformed keyring")
+	}
+}
+
+// TestCheckKeyringPreflight_ReorderedKeysAreNotParity pins the order
+// sensitivity the doc comment claims. Two keyrings holding the same keys in a
+// different order are not the same keyring contract, and treating them as equal
+// would let an RC ship a keyring whose first key differs from the final binary's.
+func TestCheckKeyringPreflight_ReorderedKeysAreNotParity(t *testing.T) {
+	keyA := strings.Repeat("aa", 32)
+	keyB := strings.Repeat("bb", 32)
+
+	if _, err := CheckKeyringPreflight(keyA+","+keyB, keyB+","+keyA, false); err == nil {
+		t.Fatal("reordered keys were accepted as parity; the doc comment states the " +
+			"comparison is order-sensitive, so this must fail")
+	}
+	if _, err := CheckKeyringPreflight(keyA+","+keyB, keyA+","+keyB, false); err != nil {
+		t.Fatalf("identical keyrings must pass parity: %v", err)
+	}
+}

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -106,13 +106,18 @@ fi
 # Set PIPELOCK_ALLOW_EMPTY_KEYRING=1 ONLY for a deliberately unofficial build
 # that will be verified out of band. It is not a convenience switch: an official
 # release with an empty keyring is a release nobody can safely update from.
-if [ -n "${RELEASE_KEYRING_HEX:-}" ]; then
+# Trim before testing presence. The Go side trims before deciding a keyring is
+# empty, so a whitespace-only value must read as empty here too; otherwise this
+# gate passes a keyring the build then embeds as nothing, which is precisely the
+# drift the split between these two checks was meant to avoid.
+keyring_trimmed="$(printf '%s' "${RELEASE_KEYRING_HEX:-}" | tr -d '[:space:]')"
+if [ -n "$keyring_trimmed" ]; then
   echo "  [ok]   release keyring: present"
 elif [ "${PIPELOCK_ALLOW_EMPTY_KEYRING:-}" = "1" ]; then
   echo "  [warn] release keyring: EMPTY, explicitly allowed for an unofficial build." >&2
   echo "         This binary cannot verify a signed update. Verify it out of band." >&2
 else
-  note "RELEASE_KEYRING_HEX is unset, so the built binary would embed an empty release keyring and could never verify a signed update. Set it, or set PIPELOCK_ALLOW_EMPTY_KEYRING=1 for a deliberately unofficial build."
+  note "RELEASE_KEYRING_HEX is unset or whitespace-only, so the built binary would embed an empty release keyring and could never verify a signed update. Set it, or set PIPELOCK_ALLOW_EMPTY_KEYRING=1 for a deliberately unofficial build."
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -89,6 +89,32 @@ else
   echo "  [ok]   Chart appVersion: $app"
 fi
 
+# 3. The release keyring must be present BEFORE anything is built.
+#
+# GoReleaser embeds the public release keyring via
+# -X ...release.PublicKeyringHex={{.Env.RELEASE_KEYRING_HEX}}. A binary built
+# with that env var unset carries an EMPTY keyring, so it cannot verify any
+# signed update. It then fails closed at exactly the moment someone is using it
+# to prove that self-update works, which is far too late and has already cost a
+# post-tag discovery once.
+#
+# Presence is checked here because this gate runs before the build. The
+# authoritative parse of the keyring's CONTENTS lives in Go
+# (release.CheckKeyringPreflight), which inspects a built binary; this check
+# deliberately does not re-implement that parsing, so the two cannot drift.
+#
+# Set PIPELOCK_ALLOW_EMPTY_KEYRING=1 ONLY for a deliberately unofficial build
+# that will be verified out of band. It is not a convenience switch: an official
+# release with an empty keyring is a release nobody can safely update from.
+if [ -n "${RELEASE_KEYRING_HEX:-}" ]; then
+  echo "  [ok]   release keyring: present"
+elif [ "${PIPELOCK_ALLOW_EMPTY_KEYRING:-}" = "1" ]; then
+  echo "  [warn] release keyring: EMPTY, explicitly allowed for an unofficial build." >&2
+  echo "         This binary cannot verify a signed update. Verify it out of band." >&2
+else
+  note "RELEASE_KEYRING_HEX is unset, so the built binary would embed an empty release keyring and could never verify a signed update. Set it, or set PIPELOCK_ALLOW_EMPTY_KEYRING=1 for a deliberately unofficial build."
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "release-ready gate: FAILED — fix the above before tagging $VERSION." >&2
   exit 1


### PR DESCRIPTION
## What changed

A release candidate built without the embedded release keyring cannot verify any signed update. It fails closed at exactly the moment someone is using it to prove that self-update works, which is far too late and has already cost a post-tag discovery once. This adds a gate at each of the two moments where the problem is catchable.

The release-ready gate, which CI runs before anything is built, now refuses a release whose keyring environment variable is unset. That is the point where an empty keyring is still preventable rather than merely detectable.

`CheckKeyringPreflight` inspects a candidate binary that already exists and refuses an empty, whitespace-only, malformed, or parity-mismatched keyring.

## Why two checks and not one

They answer different questions at different times, and neither subsumes the other. Presence can only be checked before the build; contents can only be checked afterwards.

The shell gate deliberately checks presence only. It does not re-implement the keyring parse, so the two cannot drift, and the Go path stays authoritative on contents.

## Failure direction

Unset, empty, whitespace-only, malformed, and parity-mismatched all fail. An unparseable keyring is not a passing state, and a custom build excuses an absent keyring but never a broken one.

The escape hatch for a deliberately unofficial build is an explicit acknowledgement that warns loudly rather than a flag that silently skips the check, because a one-word bypass of release verification is not an acceptable convenience.

The over-strict direction was tested and corrected during development. An earlier version ran the preflight inside the update command's option validation, which runs for every operation including rollback, so it stopped a development build from rolling back. A gate that blocks a recovery path gets disabled by the operator, so the preflight is not wired there.

## Verification

Each guard was checked by disabling it and confirming its test fails with a real assertion rather than a panic. The shell gate was exercised in all three states: unset fails the gate, present clears it, and the explicit unofficial-build acknowledgement warns without failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release-candidate verification for embedded signing keyrings.
  * Added support for explicitly acknowledged custom builds with empty keyrings.
  * Added release-readiness checks for required keyring configuration.

* **Bug Fixes**
  * Release validation now detects malformed, mismatched, or incomplete keyrings.
  * Keyring parity checks can enforce exact expected key ordering.

* **Documentation**
  * Clarified that rollback does not depend on keyring validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->