### PR TITLE
feat(release): add an explicit applicability vocabulary for verification status

### DIFF
--- a/internal/release/status.go
+++ b/internal/release/status.go
@@ -52,7 +52,11 @@ var statusStrings = [...]string{
 
 // String returns the stable wire representation.
 func (s VerificationStatus) String() string {
-	if int(s) < len(statusStrings) {
+	// Two-sided bound. VerificationStatus is an int-based type reachable from
+	// JSON and from arithmetic, so a negative value is not hypothetical, and a
+	// one-sided check indexes out of range and panics. A status this code
+	// cannot name renders as unknown, which is also the fail-closed reading.
+	if s >= 0 && int(s) < len(statusStrings) {
 		return statusStrings[s]
 	}
 	return "unknown"

--- a/internal/release/status.go
+++ b/internal/release/status.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package release
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// VerificationStatus is the four-value vocabulary for release and benchmark
+// verification results.
+//
+// The zero value is StatusUnknown, which is NOT a passing state. An unset,
+// missing, or unparseable status must never resolve to PASS.
+type VerificationStatus int
+
+const (
+	// StatusUnknown is the zero value. It is not PASS and must not appear
+	// in honest output. Its existence ensures that an uninitialised struct
+	// field never silently reads as success.
+	StatusUnknown VerificationStatus = iota
+
+	// StatusPass means the check ran and succeeded.
+	StatusPass
+
+	// StatusFail means the check ran and did not succeed.
+	StatusFail
+
+	// StatusNotApplicable means the customer path genuinely cannot apply
+	// to this check. A recorded Reason is mandatory; an applicability
+	// claim with no stated reason is rejected.
+	StatusNotApplicable
+
+	// StatusNotMeasured means the check IS applicable but no valid
+	// measurement was obtained. This must NEVER be folded into the
+	// numerator or denominator of a success percentage.
+	StatusNotMeasured
+)
+
+// statusStrings maps each VerificationStatus to its stable JSON/wire string.
+// Keep in sync with ParseVerificationStatus.
+var statusStrings = [...]string{
+	StatusUnknown:       "unknown",
+	StatusPass:          "pass",
+	StatusFail:          "fail",
+	StatusNotApplicable: "not_applicable",
+	StatusNotMeasured:   "not_measured",
+}
+
+// String returns the stable wire representation.
+func (s VerificationStatus) String() string {
+	if int(s) < len(statusStrings) {
+		return statusStrings[s]
+	}
+	return "unknown"
+}
+
+// IsTerminal reports whether the status represents a completed measurement
+// that can participate in percentage calculations. Only PASS and FAIL are
+// terminal. NOT_APPLICABLE and NOT_MEASURED are excluded from percentages
+// (for different reasons: N/A genuinely does not apply; NOT_MEASURED has no
+// valid data).
+func (s VerificationStatus) IsTerminal() bool {
+	return s == StatusPass || s == StatusFail
+}
+
+// MarshalJSON encodes the status as a JSON string.
+func (s VerificationStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+// UnmarshalJSON decodes a JSON string into a VerificationStatus.
+// Unknown strings resolve to StatusUnknown (fail-closed).
+func (s *VerificationStatus) UnmarshalJSON(data []byte) error {
+	// A payload that is not a JSON string is not an error here, it is simply a
+	// status we cannot name, and an unnameable status must decode to unknown
+	// rather than abort the surrounding record. Unmarshalling into the empty
+	// string on failure keeps that intent without discarding a checked error:
+	// ParseVerificationStatus maps "" to StatusUnknown, which is the same
+	// fail-closed result, so there is no error to swallow.
+	var raw string
+	if json.Unmarshal(data, &raw) != nil {
+		raw = ""
+	}
+	*s = ParseVerificationStatus(raw)
+	return nil
+}
+
+// ParseVerificationStatus maps a wire string to its typed value.
+// Unrecognised strings return StatusUnknown (fail-closed: never PASS).
+func ParseVerificationStatus(raw string) VerificationStatus {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "pass":
+		return StatusPass
+	case "fail":
+		return StatusFail
+	case "not_applicable":
+		return StatusNotApplicable
+	case "not_measured":
+		return StatusNotMeasured
+	default:
+		return StatusUnknown
+	}
+}
+
+// ErrMissingApplicabilityReason is returned when a NOT_APPLICABLE result
+// does not carry a reason explaining why the path cannot apply.
+var ErrMissingApplicabilityReason = errors.New("not_applicable status requires a reason")
+
+// VerificationResult pairs a status with an optional reason and detail.
+// For StatusNotApplicable the Reason field is mandatory.
+type VerificationResult struct {
+	Status VerificationStatus `json:"status"`
+	Reason string             `json:"reason,omitempty"`
+	Detail string             `json:"detail,omitempty"`
+}
+
+// Validate checks internal consistency. A NOT_APPLICABLE result without a
+// reason is rejected.
+func (r VerificationResult) Validate() error {
+	if r.Status == StatusNotApplicable && strings.TrimSpace(r.Reason) == "" {
+		return ErrMissingApplicabilityReason
+	}
+	return nil
+}
+
+// AggregateResults computes honest summary statistics over a set of results.
+//
+// Percentage is computed ONLY over terminal (PASS + FAIL) results. If any
+// result is NOT_MEASURED the set is flagged and the unmeasured count is
+// reported separately — a percentage over a set containing unmeasured
+// records would be dishonest.
+//
+// Unknown statuses are counted and treated as non-passing (they contribute
+// to the total but not to any success metric).
+func AggregateResults(results []VerificationResult) VerificationSummary {
+	var s VerificationSummary
+	s.Total = len(results)
+	for _, r := range results {
+		switch r.Status {
+		case StatusPass:
+			s.Passed++
+		case StatusFail:
+			s.Failed++
+		case StatusNotApplicable:
+			s.NotApplicable++
+		case StatusNotMeasured:
+			s.NotMeasured++
+		default:
+			s.Unknown++
+		}
+	}
+	s.Measured = s.Passed + s.Failed
+	if s.Measured > 0 {
+		s.PassPercentage = (s.Passed * 100) / s.Measured
+	}
+	return s
+}
+
+// VerificationSummary holds aggregated counts from AggregateResults.
+type VerificationSummary struct {
+	Total         int `json:"total"`
+	Passed        int `json:"passed"`
+	Failed        int `json:"failed"`
+	NotApplicable int `json:"not_applicable"`
+	NotMeasured   int `json:"not_measured"`
+	Unknown       int `json:"unknown"`
+
+	// Measured is Passed + Failed: the denominator for PassPercentage.
+	Measured int `json:"measured"`
+
+	// PassPercentage is (Passed * 100) / Measured. It is zero when
+	// Measured is zero. It is NEVER computed over unmeasured records.
+	PassPercentage int `json:"pass_percentage"`
+}
+
+// HonestPercentage returns the pass percentage and reports whether it is
+// fully trustworthy. When NotMeasured > 0 the percentage is technically
+// correct (computed only over measured records) but the caller should
+// surface the gap. When Measured == 0 the percentage is meaningless.
+func (s VerificationSummary) HonestPercentage() (pct int, hasUnmeasured bool, hasMeasured bool) {
+	return s.PassPercentage, s.NotMeasured > 0, s.Measured > 0
+}
+
+// FormatPercentage returns a human-readable percentage string that honestly
+// discloses unmeasured gaps. Examples:
+//
+//	"75% (3/4 measured; 2 not measured)"
+//	"100% (5/5 measured)"
+//	"no measured results"
+func (s VerificationSummary) FormatPercentage() string {
+	if s.Measured == 0 {
+		return "no measured results"
+	}
+	base := fmt.Sprintf("%d%% (%d/%d measured", s.PassPercentage, s.Passed, s.Measured)
+	if s.NotMeasured > 0 {
+		return base + fmt.Sprintf("; %d not measured)", s.NotMeasured)
+	}
+	return base + ")"
+}

--- a/internal/release/status_test.go
+++ b/internal/release/status_test.go
@@ -360,3 +360,30 @@ func TestVerificationSummary_JSONFields(t *testing.T) {
 		t.Errorf("not_measured = %v, want 1", v)
 	}
 }
+
+// TestVerificationStatus_NegativeValueDoesNotPanic covers the lower bound.
+//
+// VerificationStatus is an int-based type reachable from JSON and from
+// arithmetic, so a negative value is not hypothetical. A one-sided bounds check
+// indexed out of range and panicked, which turns a bad status into a crash of
+// whatever was rendering the report.
+func TestVerificationStatus_NegativeValueDoesNotPanic(t *testing.T) {
+	for _, s := range []VerificationStatus{-1, -100, VerificationStatus(len(statusStrings)), 9999} {
+		got := s.String()
+		if got != "unknown" {
+			t.Errorf("VerificationStatus(%d).String() = %q, want %q", int(s), got, "unknown")
+		}
+		if s.IsTerminal() {
+			t.Errorf("VerificationStatus(%d) must not be terminal", int(s))
+		}
+		// It must also survive the JSON path, which is how an out-of-range
+		// value actually reaches String() in production.
+		b, err := s.MarshalJSON()
+		if err != nil {
+			t.Errorf("MarshalJSON(%d): %v", int(s), err)
+		}
+		if string(b) != `"unknown"` {
+			t.Errorf("MarshalJSON(%d) = %s, want \"unknown\"", int(s), b)
+		}
+	}
+}

--- a/internal/release/status_test.go
+++ b/internal/release/status_test.go
@@ -1,0 +1,362 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package release
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestVerificationStatus_ZeroValueIsNotPass(t *testing.T) {
+	var s VerificationStatus
+	if s == StatusPass {
+		t.Fatal("zero value of VerificationStatus must not be StatusPass")
+	}
+	if s.String() != "unknown" {
+		t.Fatalf("zero value String() = %q, want %q", s.String(), "unknown")
+	}
+}
+
+func TestVerificationStatus_String(t *testing.T) {
+	tests := []struct {
+		status VerificationStatus
+		want   string
+	}{
+		{StatusUnknown, "unknown"},
+		{StatusPass, "pass"},
+		{StatusFail, "fail"},
+		{StatusNotApplicable, "not_applicable"},
+		{StatusNotMeasured, "not_measured"},
+		{VerificationStatus(99), "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerificationStatus_IsTerminal(t *testing.T) {
+	tests := []struct {
+		status VerificationStatus
+		want   bool
+	}{
+		{StatusPass, true},
+		{StatusFail, true},
+		{StatusNotApplicable, false},
+		{StatusNotMeasured, false},
+		{StatusUnknown, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status.String(), func(t *testing.T) {
+			if got := tt.status.IsTerminal(); got != tt.want {
+				t.Errorf("IsTerminal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseVerificationStatus(t *testing.T) {
+	tests := []struct {
+		input string
+		want  VerificationStatus
+	}{
+		{"pass", StatusPass},
+		{"PASS", StatusPass},
+		{" Pass ", StatusPass},
+		{"fail", StatusFail},
+		{"not_applicable", StatusNotApplicable},
+		{"not_measured", StatusNotMeasured},
+		{"", StatusUnknown},
+		{"garbage", StatusUnknown},
+		{"PASSED", StatusUnknown}, // not a valid value
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := ParseVerificationStatus(tt.input); got != tt.want {
+				t.Errorf("ParseVerificationStatus(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerificationStatus_JSONRoundTrip(t *testing.T) {
+	for _, s := range []VerificationStatus{
+		StatusUnknown, StatusPass, StatusFail, StatusNotApplicable, StatusNotMeasured,
+	} {
+		t.Run(s.String(), func(t *testing.T) {
+			data, err := json.Marshal(s)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var got VerificationStatus
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if got != s {
+				t.Errorf("round-trip: got %v, want %v", got, s)
+			}
+		})
+	}
+}
+
+func TestVerificationStatus_UnmarshalUnknownString(t *testing.T) {
+	var s VerificationStatus
+	if err := json.Unmarshal([]byte(`"bogus"`), &s); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if s != StatusUnknown {
+		t.Errorf("unknown JSON string → %v, want StatusUnknown", s)
+	}
+}
+
+func TestVerificationStatus_UnmarshalInvalidJSON(t *testing.T) {
+	var s VerificationStatus
+	// A JSON number is not a string — should resolve to unknown, not error.
+	if err := json.Unmarshal([]byte(`42`), &s); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if s != StatusUnknown {
+		t.Errorf("invalid JSON type → %v, want StatusUnknown", s)
+	}
+}
+
+func TestVerificationResult_Validate_NotApplicableNeedsReason(t *testing.T) {
+	r := VerificationResult{Status: StatusNotApplicable}
+	if err := r.Validate(); !errors.Is(err, ErrMissingApplicabilityReason) {
+		t.Fatalf("Validate() = %v, want ErrMissingApplicabilityReason", err)
+	}
+
+	r.Reason = "host has no network namespace"
+	if err := r.Validate(); err != nil {
+		t.Fatalf("Validate() with reason = %v, want nil", err)
+	}
+}
+
+func TestVerificationResult_Validate_WhitespaceReasonRejected(t *testing.T) {
+	r := VerificationResult{Status: StatusNotApplicable, Reason: "   "}
+	if err := r.Validate(); !errors.Is(err, ErrMissingApplicabilityReason) {
+		t.Fatalf("whitespace-only reason should be rejected, got %v", err)
+	}
+}
+
+func TestVerificationResult_Validate_OtherStatusesNoReason(t *testing.T) {
+	for _, s := range []VerificationStatus{StatusPass, StatusFail, StatusNotMeasured, StatusUnknown} {
+		t.Run(s.String(), func(t *testing.T) {
+			r := VerificationResult{Status: s}
+			if err := r.Validate(); err != nil {
+				t.Fatalf("Validate() = %v for %v with no reason", err, s)
+			}
+		})
+	}
+}
+
+func TestAggregateResults_Basic(t *testing.T) {
+	results := []VerificationResult{
+		{Status: StatusPass},
+		{Status: StatusPass},
+		{Status: StatusFail},
+		{Status: StatusNotApplicable, Reason: "host mode"},
+		{Status: StatusNotMeasured},
+	}
+	s := AggregateResults(results)
+
+	if s.Total != 5 {
+		t.Errorf("Total = %d, want 5", s.Total)
+	}
+	if s.Passed != 2 {
+		t.Errorf("Passed = %d, want 2", s.Passed)
+	}
+	if s.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", s.Failed)
+	}
+	if s.NotApplicable != 1 {
+		t.Errorf("NotApplicable = %d, want 1", s.NotApplicable)
+	}
+	if s.NotMeasured != 1 {
+		t.Errorf("NotMeasured = %d, want 1", s.NotMeasured)
+	}
+	if s.Measured != 3 {
+		t.Errorf("Measured = %d, want 3 (pass+fail only)", s.Measured)
+	}
+	// 2/3 = 66%
+	if s.PassPercentage != 66 {
+		t.Errorf("PassPercentage = %d, want 66", s.PassPercentage)
+	}
+}
+
+func TestAggregateResults_NotMeasuredExcludedFromPercentage(t *testing.T) {
+	// 1 pass, 1 not_measured. If NOT_MEASURED were in the denominator,
+	// percentage would be 50%. Correctly: 100% (1/1 measured).
+	results := []VerificationResult{
+		{Status: StatusPass},
+		{Status: StatusNotMeasured},
+	}
+	s := AggregateResults(results)
+	if s.PassPercentage != 100 {
+		t.Fatalf("PassPercentage = %d, want 100 (not_measured excluded from denominator)", s.PassPercentage)
+	}
+	if s.NotMeasured != 1 {
+		t.Fatalf("NotMeasured = %d, want 1", s.NotMeasured)
+	}
+}
+
+func TestAggregateResults_AllNotMeasured(t *testing.T) {
+	results := []VerificationResult{
+		{Status: StatusNotMeasured},
+		{Status: StatusNotMeasured},
+	}
+	s := AggregateResults(results)
+	if s.Measured != 0 {
+		t.Errorf("Measured = %d, want 0", s.Measured)
+	}
+	if s.PassPercentage != 0 {
+		t.Errorf("PassPercentage = %d, want 0 (no measured results)", s.PassPercentage)
+	}
+}
+
+func TestAggregateResults_UnknownStatusCountedSeparately(t *testing.T) {
+	results := []VerificationResult{
+		{Status: StatusPass},
+		{Status: StatusUnknown},
+	}
+	s := AggregateResults(results)
+	if s.Unknown != 1 {
+		t.Errorf("Unknown = %d, want 1", s.Unknown)
+	}
+	if s.Measured != 1 {
+		t.Errorf("Measured = %d, want 1 (unknown excluded)", s.Measured)
+	}
+	if s.PassPercentage != 100 {
+		t.Errorf("PassPercentage = %d, want 100", s.PassPercentage)
+	}
+}
+
+func TestAggregateResults_Empty(t *testing.T) {
+	s := AggregateResults(nil)
+	if s.Total != 0 || s.Measured != 0 || s.PassPercentage != 0 {
+		t.Errorf("empty aggregate: Total=%d Measured=%d Pct=%d", s.Total, s.Measured, s.PassPercentage)
+	}
+}
+
+func TestVerificationSummary_HonestPercentage(t *testing.T) {
+	tests := []struct {
+		name           string
+		results        []VerificationResult
+		wantPct        int
+		wantUnmeasured bool
+		wantMeasured   bool
+	}{
+		{
+			name:           "clean",
+			results:        []VerificationResult{{Status: StatusPass}, {Status: StatusFail}},
+			wantPct:        50,
+			wantUnmeasured: false,
+			wantMeasured:   true,
+		},
+		{
+			name:           "with unmeasured",
+			results:        []VerificationResult{{Status: StatusPass}, {Status: StatusNotMeasured}},
+			wantPct:        100,
+			wantUnmeasured: true,
+			wantMeasured:   true,
+		},
+		{
+			name:           "no measured",
+			results:        []VerificationResult{{Status: StatusNotMeasured}},
+			wantPct:        0,
+			wantUnmeasured: true,
+			wantMeasured:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := AggregateResults(tt.results)
+			pct, hasUnmeasured, hasMeasured := s.HonestPercentage()
+			if pct != tt.wantPct || hasUnmeasured != tt.wantUnmeasured || hasMeasured != tt.wantMeasured {
+				t.Errorf("HonestPercentage() = (%d, %v, %v), want (%d, %v, %v)",
+					pct, hasUnmeasured, hasMeasured, tt.wantPct, tt.wantUnmeasured, tt.wantMeasured)
+			}
+		})
+	}
+}
+
+func TestVerificationSummary_FormatPercentage(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []VerificationResult
+		want    string
+	}{
+		{
+			name:    "clean",
+			results: []VerificationResult{{Status: StatusPass}, {Status: StatusPass}, {Status: StatusFail}},
+			want:    "66% (2/3 measured)",
+		},
+		{
+			name: "with unmeasured",
+			results: []VerificationResult{
+				{Status: StatusPass}, {Status: StatusPass}, {Status: StatusFail}, {Status: StatusNotMeasured},
+			},
+			want: "66% (2/3 measured; 1 not measured)",
+		},
+		{
+			name:    "no measured",
+			results: []VerificationResult{{Status: StatusNotApplicable, Reason: "n/a"}},
+			want:    "no measured results",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := AggregateResults(tt.results)
+			if got := s.FormatPercentage(); got != tt.want {
+				t.Errorf("FormatPercentage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerificationResult_JSONRoundTrip(t *testing.T) {
+	r := VerificationResult{
+		Status: StatusNotApplicable,
+		Reason: "air-gapped host",
+		Detail: "no network namespace",
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got VerificationResult
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Status != r.Status || got.Reason != r.Reason || got.Detail != r.Detail {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, r)
+	}
+}
+
+func TestVerificationSummary_JSONFields(t *testing.T) {
+	results := []VerificationResult{
+		{Status: StatusPass},
+		{Status: StatusNotMeasured},
+	}
+	s := AggregateResults(results)
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal map: %v", err)
+	}
+	// Verify the not_measured field is present in JSON output.
+	if _, ok := m["not_measured"]; !ok {
+		t.Fatal("not_measured field missing from JSON output")
+	}
+	if v := m["not_measured"].(float64); v != 1 {
+		t.Errorf("not_measured = %v, want 1", v)
+	}
+}


### PR DESCRIPTION
## What changed

Release and benchmark verification status now distinguishes four states rather than two: PASS, FAIL, NOT_APPLICABLE, and NOT_MEASURED.

NOT_APPLICABLE means the customer path genuinely cannot apply, and it requires a recorded reason. An applicability claim nobody has to justify is not auditable, so a not-applicable result without a stated reason is rejected rather than accepted.

NOT_MEASURED means the check does apply and simply has no valid measurement.

## Why the distinction is the whole feature

Collapsing NOT_MEASURED into NOT_APPLICABLE is how an unmeasured gap gets reported as a clean result, and how an inconvenient failure gets laundered into not-applicable. The two states look similar in a summary and mean opposite things about whether anyone has actually checked.

Aggregation therefore excludes unmeasured records from both the numerator and the denominator of a success percentage, and reports their count separately. A percentage computed over a corpus that did not measure the thing is not a measurement of it.

## Failure direction

The zero value is unknown rather than pass, so an unset status can never read as success. An unparseable status resolves to unknown by the same reasoning, and unknown is not counted as measured.

The availability direction was considered as well: all four legitimate outcomes plus unknown are representable, so no real result is forced into the wrong bucket. A vocabulary that cannot express a genuine outcome gets worked around, which defeats it.

## Scope

The existing status strings in the diagnostic and assessment packages are private mirrors of this vocabulary. Migrating them to the typed model touches those packages and is left to a follow-up so this change stays reviewable. Until then those packages keep their own constants, which is a drift risk worth naming rather than hiding.

## Verification

Every guard was checked by disabling it and confirming its test fails with a real assertion. The cases covered include all four statuses, the zero value, an unparseable status, a not-applicable result missing its reason, and an aggregation containing unmeasured records where the percentage must exclude them and the unmeasured count must be reported on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized verification statuses, including pass, fail, not applicable, not measured, and unknown.
  * Added validation requiring a reason when a result is marked not applicable.
  * Added verification summaries with accurate counts and percentages based only on measured results.
  * Added human-readable percentage formatting and reliable JSON representation.

* **Bug Fixes**
  * Unknown or invalid status values now fail safely instead of being treated as successful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->