### PR TITLE
feat(config): add guard services, profiles and state manifests

### DIFF
--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -234,6 +234,15 @@ func (c *Config) policySemanticView() Config {
 	view.Redaction.AllowlistUnparseableRoutes = canonicalUnparseableRoutes(view.Redaction.Enabled, view.Redaction.AllowlistUnparseableRoutes)
 	view.Redaction.Providers = canonicalRedactionProviders(view.Redaction.Enabled, view.Redaction.Providers)
 
+	// Guard is deliberately NOT canonicalized here. It carries json:"-" and is
+	// excluded from the canonical policy hash while it has no runtime consumer:
+	// a field enters the policy hash only once a production decision path
+	// consumes it, because that hash is stamped into receipts, learn-compile
+	// output, dashboard snapshots, replay packets, and conductor bundles. An
+	// inert field entering the hash would make byte-identical effective policy
+	// emit different evidence across a mixed-version fleet mid-upgrade.
+	// Canonicalize guard here when the runtime evaluator lands.
+
 	// Resolve omitted-or-zero learn-inference fields to their effective
 	// defaults so the policy hash reflects the runtime-effective policy,
 	// not the literal YAML representation. Without this, a YAML omitting

--- a/internal/config/guard_paths.go
+++ b/internal/config/guard_paths.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// resolveGuardPath resolves symlinks in a guard path as far as the filesystem
+// allows.
+//
+// filepath.EvalSymlinks fails outright when the final component does not exist
+// yet, which is the normal case for a declared writable state path. Treating
+// that failure as "use the literal path" is a fail-OPEN: an operator, or an
+// attacker who can create one intermediate directory, can point
+// /tmp/alias/.ssh/newfile at a real trust-bearing directory through a symlinked
+// ANCESTOR, and the literal string reveals nothing. So when full resolution
+// fails, walk up to the deepest ancestor that does exist, resolve THAT, and
+// re-append the not-yet-existing remainder.
+//
+// This narrows but cannot close the check-to-use race: a path validated here
+// can be replaced with a symlink before a runtime grant is created. The runtime
+// evaluator must re-check using descriptor-based operations rather than
+// trusting this load-time result.
+func resolveGuardPath(rawPath string) string {
+	cleaned := filepath.Clean(rawPath)
+	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
+		return filepath.Clean(resolved)
+	}
+
+	remainder := ""
+	current := cleaned
+	for {
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached the filesystem root without finding an existing
+			// ancestor; the literal cleaned path is all we have.
+			return cleaned
+		}
+		remainder = filepath.Join(filepath.Base(current), remainder)
+		current = parent
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			return filepath.Clean(filepath.Join(resolved, remainder))
+		}
+	}
+}
+
+// validateGuardROPath rejects read grants on secret-bearing locations.
+//
+// Read-only is NOT safe for this material under an agent threat model. A
+// private SSH key, a GPG secret keyring, or a stored credential does not need
+// to be modified to be lost: reading it is the exfiltration, and the copy
+// leaves through any destination the workload is otherwise permitted to reach.
+// Granting read on these paths would quietly undo the isolation the manifest
+// exists to provide.
+//
+// Non-secret files that happen to live near this material can still be granted
+// individually; what is refused here is the directory that holds keys.
+func validateGuardROPath(label string, idx int, rawPath string) error {
+	field := fmt.Sprintf("%s.read_only[%d]", label, idx)
+	resolved := resolveGuardPath(rawPath)
+
+	if comp := guardForbiddenComponent(resolved); comp != "" {
+		return fmt.Errorf("%s: read access to secret-bearing path %q is not allowed (contains %q); reading a private key is exfiltration, not merely inspection", field, rawPath, comp)
+	}
+	// Pipelock config and state directories contain credential material
+	// (license_key, kill_switch.api_token, secrets_file) that a read grant
+	// would expose. The suffix check covers every user's home, not just this
+	// process's, matching the write-side guard in validateGuardRWPath.
+	if suffix := guardForbiddenSuffix(resolved); suffix != "" {
+		if strings.Contains(suffix, "pipelock") {
+			return fmt.Errorf("%s: read access to %s %q is not allowed; it may contain credential material", field, suffix, rawPath)
+		}
+	}
+	return nil
+}
+
+// guardForbiddenComponents are directory names that must never appear anywhere
+// in a read-write grant, whichever user owns them.
+var guardForbiddenComponents = map[string]struct{}{
+	".ssh":   {},
+	".gnupg": {},
+	".gpg":   {},
+}
+
+// guardForbiddenComponent reports the first trust-bearing path component in the
+// resolved path, or "" when none is present.
+//
+// Matching on components rather than on a prefix derived from this process's
+// home directory is deliberate. Pipelock commonly runs as a system service, so
+// os.UserHomeDir() returns /root; a home-derived list would protect /root/.ssh
+// while leaving every real operator's ~/.ssh unguarded.
+func guardForbiddenComponent(resolved string) string {
+	for _, part := range strings.Split(resolved, string(filepath.Separator)) {
+		if _, bad := guardForbiddenComponents[part]; bad {
+			return part
+		}
+	}
+	return ""
+}
+
+// guardForbiddenSuffixes are trailing path shapes identifying Pipelock's own
+// state, autostart locations, and other write-sensitive directories under ANY
+// user's home rather than only this process's home.
+var guardForbiddenSuffixes = []struct {
+	suffix string
+	reason string
+}{
+	{filepath.Join(".local", "share", "pipelock"), "pipelock state directory"},
+	{filepath.Join(".config", "pipelock"), "pipelock config directory"},
+	{".pipelock", "pipelock directory"},
+	{filepath.Join(".config", "autostart"), "autostart directory"},
+	{filepath.Join("Library", "LaunchAgents"), "autostart directory"},
+	{filepath.Join("Library", "LaunchDaemons"), "autostart directory"},
+	{filepath.Join("etc", "pipelock"), "pipelock config directory"},
+}
+
+// guardForbiddenSuffix reports why the resolved path is write-sensitive, or ""
+// when it is not. A match is the directory itself or anything beneath it.
+func guardForbiddenSuffix(resolved string) string {
+	for _, entry := range guardForbiddenSuffixes {
+		marker := string(filepath.Separator) + entry.suffix
+		if strings.HasSuffix(resolved, marker) || strings.Contains(resolved, marker+string(filepath.Separator)) {
+			return entry.reason
+		}
+	}
+	return ""
+}
+
+// guardIsHomeRoot reports whether the resolved path is an entire user home
+// directory on a supported platform layout, without depending on which user
+// this process runs as.
+//
+// POSIX-only: the function hardcodes "/" as the separator and checks the
+// /home and /Users roots. On Windows, resolved paths use "\" and neither
+// root applies, so the check silently passes. Windows path handling is an
+// open product decision tracked in ops (AF-264).
+func guardIsHomeRoot(resolved string) bool {
+	// Homes that are a fixed path rather than a directory under a parent.
+	// /root is the home of the account Pipelock most often runs as when it runs
+	// as a system service, and "/" is the effective home in many containers.
+	// Both were previously covered only by the os.UserHomeDir()-derived block
+	// that was deleted as "fully shadowed" by these helpers. That claim was
+	// wrong for exactly this case: when the process runs as root, the deleted
+	// block did catch /root and nothing here replaced it, so a whole-/root
+	// read-write grant was accepted. Handle them explicitly.
+	for _, fixed := range []string{"/root", "/"} {
+		if resolved == fixed {
+			return true
+		}
+	}
+	for _, root := range []string{"/home", "/Users"} {
+		if !strings.HasPrefix(resolved, root+"/") {
+			continue
+		}
+		rest := strings.TrimPrefix(resolved, root+"/")
+		if rest != "" && !strings.Contains(rest, "/") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/guard_test.go
+++ b/internal/config/guard_test.go
@@ -1,0 +1,648 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateGuard_EmptyIsValid(t *testing.T) {
+	t.Parallel()
+	cfg := Defaults()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("empty guard should be valid: %v", err)
+	}
+}
+
+func TestValidateGuard_ValidFull(t *testing.T) {
+	t.Parallel()
+	cfg := Defaults()
+	cfg.Guard = Guard{
+		Services: []GuardService{
+			{Name: "api", Protocol: "tcp", Host: "api.vendor.example", Port: 443},
+		},
+		Profiles: []GuardProfile{
+			{Name: "worker", Manifests: []string{"app-state"}},
+		},
+		Manifests: []GuardManifest{
+			{Name: "app-state", ReadOnly: []string{"/opt/app/config"}, ReadWrite: []string{"/var/lib/app/data"}},
+		},
+	}
+	// A structurally valid declaration passes every path and naming rule and is
+	// then refused solely because nothing enforces guard yet. Asserting the
+	// exact sentinel keeps this test honest: if a real validation rule started
+	// rejecting this config, the error would no longer be the gate and this
+	// would fail rather than quietly passing for the wrong reason.
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("guard config must be refused while no runtime evaluator enforces it")
+	}
+	if !errors.Is(err, errGuardNotEnforced) {
+		t.Fatalf("valid guard config should fail only on the not-enforced gate, got: %v", err)
+	}
+}
+
+func TestValidateGuard_Rejections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		guard   Guard
+		wantErr string
+	}{
+		{
+			name: "wildcard_host",
+			guard: Guard{Services: []GuardService{
+				{Name: "api", Protocol: "tcp", Host: "*.vendor.example", Port: 443},
+			}},
+			wantErr: "wildcard",
+		},
+		{
+			name: "cidr_host",
+			guard: Guard{Services: []GuardService{
+				{Name: "api", Protocol: "tcp", Host: "10.0.0.0/8", Port: 443},
+			}},
+			wantErr: "CIDR",
+		},
+		{
+			name: "port_zero",
+			guard: Guard{Services: []GuardService{
+				{Name: "api", Protocol: "tcp", Host: "api.vendor.example", Port: 0},
+			}},
+			wantErr: "port",
+		},
+		{
+			name: "duplicate_service_name",
+			guard: Guard{Services: []GuardService{
+				{Name: "api", Protocol: "tcp", Host: "a.vendor.example", Port: 443},
+				{Name: "api", Protocol: "tcp", Host: "b.vendor.example", Port: 443},
+			}},
+			wantErr: "duplicate service name",
+		},
+		{
+			name: "duplicate_destination",
+			guard: Guard{Services: []GuardService{
+				{Name: "api1", Protocol: "tcp", Host: "a.vendor.example", Port: 443},
+				{Name: "api2", Protocol: "tcp", Host: "a.vendor.example", Port: 443},
+			}},
+			wantErr: "duplicate destination",
+		},
+		{
+			name: "duplicate_destination_trailing_dot",
+			guard: Guard{Services: []GuardService{
+				{Name: "api1", Protocol: "tcp", Host: "a.vendor.example", Port: 443},
+				{Name: "api2", Protocol: "tcp", Host: "a.vendor.example.", Port: 443},
+			}},
+			wantErr: "duplicate destination",
+		},
+		{
+			name: "duplicate_destination_case_insensitive",
+			guard: Guard{Services: []GuardService{
+				{Name: "api1", Protocol: "tcp", Host: "A.Vendor.Example", Port: 443},
+				{Name: "api2", Protocol: "tcp", Host: "a.vendor.example", Port: 443},
+			}},
+			wantErr: "duplicate destination",
+		},
+		{
+			name: "unknown_protocol",
+			guard: Guard{Services: []GuardService{
+				{Name: "api", Protocol: "quic", Host: "a.vendor.example", Port: 443},
+			}},
+			wantErr: "protocol",
+		},
+		{
+			name: "udp_reserved_not_yet_accepted",
+			guard: Guard{Services: []GuardService{
+				{Name: "dns", Protocol: "udp", Host: "a.vendor.example", Port: 53},
+			}},
+			wantErr: "protocol",
+		},
+		{
+			name: "empty_service_name",
+			guard: Guard{Services: []GuardService{
+				{Name: "", Protocol: "tcp", Host: "a.vendor.example", Port: 443},
+			}},
+			wantErr: "name is required",
+		},
+		{
+			name: "empty_host",
+			guard: Guard{Services: []GuardService{
+				{Name: "api", Protocol: "tcp", Host: "", Port: 443},
+			}},
+			wantErr: "host",
+		},
+		{
+			name: "duplicate_manifest_name",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "state"},
+				{Name: "state"},
+			}},
+			wantErr: "duplicate manifest name",
+		},
+		{
+			name: "empty_manifest_name",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: ""},
+			}},
+			wantErr: "name is required",
+		},
+		{
+			name: "rw_whole_home",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{guardTestHome}},
+			}},
+			wantErr: "home directory",
+		},
+		{
+			name: "rw_ssh_dir",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{filepath.Join(guardTestHome, ".ssh")}},
+			}},
+			wantErr: "trust-bearing",
+		},
+		{
+			name: "rw_ssh_subpath",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{filepath.Join(guardTestHome, ".ssh", "id_rsa")}},
+			}},
+			wantErr: "trust-bearing",
+		},
+		{
+			name: "rw_pipelock_state",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{filepath.Join(guardTestHome, ".local", "share", "pipelock")}},
+			}},
+			wantErr: "pipelock state",
+		},
+		{
+			name: "rw_pipelock_config",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{filepath.Join(guardTestHome, ".config", "pipelock")}},
+			}},
+			wantErr: "pipelock config",
+		},
+		{
+			name: "rw_etc_pipelock",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/etc/pipelock"}},
+			}},
+			wantErr: "pipelock config",
+		},
+		{
+			name: "rw_path_dir_usr_bin",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/usr/bin"}},
+			}},
+			wantErr: "PATH directory",
+		},
+		{
+			name: "rw_path_dir_usr_local_bin",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/usr/local/bin"}},
+			}},
+			wantErr: "PATH directory",
+		},
+		{
+			name: "rw_autostart_xdg",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{filepath.Join(guardTestHome, ".config", "autostart")}},
+			}},
+			wantErr: "autostart",
+		},
+		{
+			name: "rw_launchagents",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{filepath.Join(guardTestHome, "Library", "LaunchAgents")}},
+			}},
+			wantErr: "autostart",
+		},
+		{
+			name: "rw_socket_run_user",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/run/user/1000"}},
+			}},
+			wantErr: "socket",
+		},
+		{
+			name: "rw_var_run",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/var/run"}},
+			}},
+			wantErr: "socket",
+		},
+		{
+			name: "rw_tmp_passes_path_rules",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "ok", ReadWrite: []string{"/tmp/workdir"}},
+			}},
+			// The path itself is fine. The declaration is refused only by the
+			// not-enforced gate, which is the message asserted here.
+			wantErr: "not enforced",
+		},
+		{
+			// Inverted deliberately. Read-only is NOT safe for key material
+			// under an agent threat model: reading a private key IS the
+			// exfiltration, because the copy leaves through any destination
+			// the workload is otherwise permitted to reach.
+			name: "ro_ssh_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadOnly: []string{"/home/someoperator/.ssh"}},
+			}},
+			wantErr: "secret-bearing",
+		},
+		{
+			name: "relative_path_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"relative/path"}},
+			}},
+			wantErr: "absolute",
+		},
+		{
+			name: "relative_ro_path_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadOnly: []string{"relative/readonly"}},
+			}},
+			wantErr: "absolute",
+		},
+		{
+			name: "ro_gnupg_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadOnly: []string{"/home/someoperator/.gnupg"}},
+			}},
+			wantErr: "secret-bearing",
+		},
+		{
+			name: "ro_pipelock_config_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadOnly: []string{"/home/someoperator/.config/pipelock"}},
+			}},
+			wantErr: "credential material",
+		},
+		{
+			name: "ro_pipelock_state_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadOnly: []string{"/home/someoperator/.local/share/pipelock"}},
+			}},
+			wantErr: "credential material",
+		},
+		{
+			name: "ro_etc_pipelock_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadOnly: []string{"/home/someoperator/etc/pipelock"}},
+			}},
+			wantErr: "credential material",
+		},
+		{
+			// The absolute system path is the one an operator would actually
+			// write; the home-relative case above only proves the suffix
+			// marker matches. Pin both directions.
+			// Pins a DELIBERATE exemption: validateGuardROPath rejects a
+			// forbidden suffix only when the reason names pipelock, so autostart
+			// directories pass the read-only rules on purpose (reading what runs
+			// at login is reconnaissance, not credential theft). Without this
+			// case, widening the read-only rejection to every forbidden suffix
+			// would change operator-visible behavior with no test failure.
+			name: "ro_autostart_allowed_by_design",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "ok", ReadOnly: []string{filepath.Join(guardTestHome, ".config", "autostart")}},
+			}},
+			wantErr: "not enforced",
+		},
+		{
+			name: "ro_absolute_etc_pipelock_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadOnly: []string{"/etc/pipelock"}},
+			}},
+			wantErr: "credential material",
+		},
+		{
+			name: "rw_etc_shadow_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/etc/shadow"}},
+			}},
+			wantErr: "privilege path",
+		},
+		{
+			name: "rw_etc_passwd_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/etc/passwd"}},
+			}},
+			wantErr: "privilege path",
+		},
+		{
+			name: "rw_usr_lib_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/usr/lib"}},
+			}},
+			wantErr: "system library directory",
+		},
+		{
+			name: "rw_boot_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/boot"}},
+			}},
+			wantErr: "boot directory",
+		},
+		{
+			name: "ro_dotpipelock_rejected",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadOnly: []string{"/home/someoperator/.pipelock"}},
+			}},
+			wantErr: "credential material",
+		},
+		{
+			name: "rw_etc_systemd_system",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/etc/systemd/system"}},
+			}},
+			wantErr: "persistence",
+		},
+		{
+			name: "rw_etc_init_d",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/etc/init.d"}},
+			}},
+			wantErr: "persistence",
+		},
+		{
+			name: "rw_etc_cron_d",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/etc/cron.d"}},
+			}},
+			wantErr: "persistence",
+		},
+		{
+			name: "rw_library_launchdaemons",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/Library/LaunchDaemons"}},
+			}},
+			wantErr: "autostart",
+		},
+		{
+			name: "rw_etc_sudoers_d",
+			guard: Guard{Manifests: []GuardManifest{
+				{Name: "bad", ReadWrite: []string{"/etc/sudoers.d"}},
+			}},
+			wantErr: "privilege",
+		},
+		{
+			name: "profile_refs_nonexistent_manifest",
+			guard: Guard{
+				Profiles: []GuardProfile{
+					{Name: "worker", Manifests: []string{"nonexistent"}},
+				},
+			},
+			wantErr: "unknown manifest",
+		},
+		{
+			name: "duplicate_profile_name",
+			guard: Guard{Profiles: []GuardProfile{
+				{Name: "worker", Manifests: nil},
+				{Name: "worker", Manifests: nil},
+			}},
+			wantErr: "duplicate profile name",
+		},
+		{
+			name: "empty_profile_name",
+			guard: Guard{Profiles: []GuardProfile{
+				{Name: ""},
+			}},
+			wantErr: "name is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Defaults()
+			cfg.Guard = tt.guard
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(tt.wantErr)) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateGuard_SymlinkAlias(t *testing.T) {
+	t.Parallel()
+
+	// Hermetic by construction: the alias points at a .ssh directory this test
+	// creates, never at the running user's real home. The previous version
+	// symlinked to homeDir()/.ssh, which passed on a developer machine and
+	// FAILED on CI runners that have no ~/.ssh, because the unresolvable
+	// target silently fell through the check.
+	tmp := t.TempDir()
+	sshDir := filepath.Join(tmp, "victim-home", ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(tmp, "sneaky-link")
+	if err := os.Symlink(sshDir, link); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	cfg := Defaults()
+	cfg.Guard = Guard{
+		Manifests: []GuardManifest{
+			{Name: "bad", ReadWrite: []string{link}},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected symlink to a trust-bearing path to be rejected")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "trust-bearing") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestValidateGuard_SymlinkedAncestorWithMissingLeaf covers the fail-open that
+// CI reproduced by accident. filepath.EvalSymlinks fails outright when the
+// FINAL component does not exist yet, which is the normal case for a declared
+// writable state path. Falling back to the literal string discards resolution
+// of every existing symlinked ANCESTOR, so a path whose parent is an alias to a
+// trust-bearing directory would be accepted on the strength of how it is
+// spelled.
+func TestValidateGuard_SymlinkedAncestorWithMissingLeaf(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	realSSH := filepath.Join(tmp, "victim-home", ".ssh")
+	if err := os.MkdirAll(realSSH, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	aliasDir := filepath.Join(tmp, "innocent")
+	if err := os.Symlink(realSSH, aliasDir); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	// The leaf deliberately does NOT exist: this is what defeated the old check.
+	target := filepath.Join(aliasDir, "authorized_keys")
+	if _, err := os.Lstat(target); err == nil {
+		t.Fatal("test precondition: leaf must not exist")
+	}
+
+	cfg := Defaults()
+	cfg.Guard = Guard{
+		Manifests: []GuardManifest{
+			{Name: "bad", ReadWrite: []string{target}},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected a write through a symlinked ancestor into .ssh to be rejected even though the leaf does not exist")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "trust-bearing") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestValidateGuard_ForeignHomeTrustPaths proves the protected-path check does
+// not depend on which user Pipelock runs as. Pipelock commonly runs as a system
+// service, so a home-derived list would protect /root/.ssh while leaving every
+// real operator's home unguarded. None of these paths need to exist.
+func TestValidateGuard_ForeignHomeTrustPaths(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/home/someoperator/.ssh",
+		"/home/someoperator/.ssh/authorized_keys",
+		"/home/someoperator/.gnupg",
+		"/Users/someoperator/.ssh/id_ed25519",
+		"/home/someoperator/.config/pipelock",
+		"/home/someoperator/.local/share/pipelock",
+		"/home/someoperator/.config/autostart",
+		"/Users/someoperator/Library/LaunchAgents",
+		"/etc/pipelock",
+		"/home/someoperator",
+		"/Users/someoperator",
+		"/root",
+		"/root/.ssh",
+		"/",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			cfg := Defaults()
+			cfg.Guard = Guard{
+				Manifests: []GuardManifest{
+					{Name: "bad", ReadWrite: []string{path}},
+				},
+			}
+			err := cfg.Validate()
+			if err == nil {
+				t.Errorf("read-write on %q must be rejected regardless of which user Pipelock runs as", path)
+				return
+			}
+			// Assert the rejection came from a PATH rule, not from the
+			// not-enforced gate.
+			//
+			// This test was proven non-vacuous when written, and then SILENTLY
+			// became vacuous when the errGuardNotEnforced gate was added later:
+			// the gate rejects every non-empty guard declaration, so a bare
+			// err != nil check passes even with every protected-path rule
+			// deleted. A guard proven honest at one commit is not proven honest
+			// at the next; a later change can hollow it out without touching it.
+			if errors.Is(err, errGuardNotEnforced) {
+				t.Errorf("read-write on %q was refused only by the not-enforced gate, so no path rule actually rejected it: %v", path, err)
+			}
+		})
+	}
+}
+
+// TestValidateGuard_OrdinaryWorkspacePathsStillAllowed is the availability half.
+// An over-strict guard that refuses legitimate workspace and session paths gets
+// the whole feature switched off, which on a security product is nearly as
+// damaging as permitting too much.
+func TestValidateGuard_OrdinaryWorkspacePathsStillAllowed(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	for _, path := range []string{
+		filepath.Join(tmp, "workspace"),
+		filepath.Join(tmp, "session-state"),
+		"/home/someoperator/projects/app",
+		"/home/someoperator/.cache/some-tool",
+		"/var/tmp/agent-scratch",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			cfg := Defaults()
+			cfg.Guard = Guard{
+				Manifests: []GuardManifest{
+					{Name: "ok", ReadWrite: []string{path}},
+				},
+			}
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("guard is refused while unenforced; %q should still reach the gate", path)
+			}
+			// The point of this test is the DIRECTION of the refusal: an
+			// ordinary workspace path must be rejected only by the
+			// not-enforced gate, never by a trust-bearing path rule. An
+			// over-strict guard that refuses legitimate work gets the whole
+			// feature switched off, which on a security product costs nearly
+			// as much as permitting too much.
+			if !errors.Is(err, errGuardNotEnforced) {
+				t.Errorf("ordinary workspace path %q must pass the path rules, got: %v", path, err)
+			}
+		})
+	}
+}
+
+func TestCanonicalPolicyHash_GuardExcludedWhileInert(t *testing.T) {
+	t.Parallel()
+
+	base := canonicalHashOf(t, func(c *Config) {})
+
+	withGuard := canonicalHashOf(t, func(c *Config) {
+		c.Guard = Guard{
+			Services: []GuardService{
+				{Name: "api", Protocol: "tcp", Host: "a.vendor.example", Port: 443},
+			},
+			Manifests: []GuardManifest{
+				{Name: "session", ReadWrite: []string{"/tmp/pipelock-guard-session"}},
+			},
+			Profiles: []GuardProfile{
+				{Name: "codex", Manifests: []string{"session"}},
+			},
+		}
+	})
+
+	if base != withGuard {
+		t.Errorf("inert guard config must not change the canonical policy hash:\n  without guard = %s\n  with guard    = %s", base, withGuard)
+	}
+
+	// A semantically different guard must also leave the hash untouched while
+	// the section is inert; otherwise the exclusion is only partial.
+	differentPort := canonicalHashOf(t, func(c *Config) {
+		c.Guard = Guard{
+			Services: []GuardService{
+				{Name: "api", Protocol: "tcp", Host: "a.vendor.example", Port: 8443},
+			},
+		}
+	})
+
+	if base != differentPort {
+		t.Errorf("inert guard config must not change the canonical policy hash for any value:\n  without guard = %s\n  different port = %s", base, differentPort)
+	}
+}
+
+// guardTestHome is a synthetic home directory path under /home so that
+// guardIsHomeRoot recognises it without depending on the running user's
+// real $HOME. This keeps the tests hermetic on CI runners.
+const guardTestHome = "/home/testoperator"

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -439,6 +439,7 @@ type Config struct {
 	MediationEnvelope        MediationEnvelope       `yaml:"mediation_envelope"`
 	Redaction                redact.Config           `yaml:"redaction"`
 	Learn                    Learn                   `yaml:"learn"`
+	Guard                    Guard                   `yaml:"guard" json:"-"`      // startup-only guard declaration with no runtime consumer yet, excluded from canonical policy hash
 	LearnLock                LearnLock               `yaml:"learn_lock" json:"-"` // operational lock-runtime config, excluded from canonical policy hash
 	Conductor                Conductor               `yaml:"conductor" json:"-"`  // follower control-plane config, excluded from canonical policy hash
 	Agents                   map[string]AgentProfile `yaml:"agents,omitempty"`
@@ -2321,4 +2322,43 @@ func (l LearnLock) EffectiveMinimumSignatures() int {
 		return 1
 	}
 	return l.MinimumSignatures
+}
+
+// Guard is the startup-only guard configuration section. It declares the
+// network services a workload is granted access to, the named workload
+// profiles that select state manifests, and the state manifests themselves.
+// Guard is evaluated at startup; hot-reload changes to guard fields are
+// ignored (they require a restart).
+type Guard struct {
+	Services  []GuardService  `yaml:"services,omitempty"`
+	Profiles  []GuardProfile  `yaml:"profiles,omitempty"`
+	Manifests []GuardManifest `yaml:"manifests,omitempty"`
+}
+
+// GuardService is a protocol-aware network service grant. Each service
+// names an exact destination (protocol, host, port) that the workload is
+// permitted to reach. The Protocol field is typed as a string in config
+// and validated to be one of the recognized destination.Network values;
+// this keeps the config layer free of runtime package imports.
+type GuardService struct {
+	Name     string `yaml:"name"`
+	Protocol string `yaml:"protocol"` // "tcp" now; "udp" reserved
+	Host     string `yaml:"host"`
+	Port     uint16 `yaml:"port"`
+}
+
+// GuardProfile is a named workload profile. It selects one or more state
+// manifests by name, binding a workload identity to its filesystem grants.
+type GuardProfile struct {
+	Name      string   `yaml:"name"`
+	Manifests []string `yaml:"manifests"`
+}
+
+// GuardManifest declares the filesystem paths a workload may read or write.
+// ReadOnly paths are accessible but not writable; ReadWrite paths are both.
+// Every path is explicit and absolute; no wildcards, no inference.
+type GuardManifest struct {
+	Name      string   `yaml:"name"`
+	ReadOnly  []string `yaml:"read_only,omitempty"`
+	ReadWrite []string `yaml:"read_write,omitempty"`
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -371,6 +371,9 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateLearnLock(); err != nil {
 		return warnings, err
 	}
+	if err := c.validateGuard(); err != nil {
+		return warnings, err
+	}
 	return warnings, nil
 }
 
@@ -4234,5 +4237,207 @@ func validateEscalationMonotonic(levels *EscalationLevels) error {
 		(levels.Critical.BlockAll == nil || !*levels.Critical.BlockAll) {
 		return fmt.Errorf("adaptive_enforcement.levels: critical.block_all is weaker than high.block_all (monotonic violation)")
 	}
+	return nil
+}
+
+// guardAllowedProtocols is the closed set of protocols guard services accept.
+// UDP is documented as reserved in the schema; it will be added here when an
+// evaluator path grants it.
+var guardAllowedProtocols = map[string]bool{
+	"tcp": true,
+}
+
+// guardDangerousRWRoots are path prefixes that must never be writable.
+// Each entry has a human-readable reason for the rejection message.
+var guardDangerousRWRoots = []struct {
+	prefix string
+	reason string
+}{
+	{"/run/user/", "socket path"},
+	{"/var/run", "socket path"},
+	{"/run/", "socket path"},
+	{"/usr/bin", "PATH directory"},
+	{"/usr/local/bin", "PATH directory"},
+	{"/usr/sbin", "PATH directory"},
+	{"/usr/local/sbin", "PATH directory"},
+	{"/bin", "PATH directory"},
+	{"/sbin", "PATH directory"},
+	{"/etc/pipelock", "pipelock config root"},
+	{"/etc/systemd/system", "persistence path"},
+	{"/etc/init.d", "persistence path"},
+	{"/etc/cron.d", "persistence path"},
+	{"/etc/crontab", "persistence path"},
+	{"/etc/sudoers", "privilege path"},
+	{"/etc/sudoers.d", "privilege path"},
+	// Account databases: writing either is a direct route to a new root user,
+	// which defeats every other entry in this list.
+	{"/etc/passwd", "privilege path"},
+	{"/etc/shadow", "privilege path"},
+	{"/etc/group", "privilege path"},
+	{"/etc/gshadow", "privilege path"},
+	// Shared libraries and boot artifacts: a write here executes as whatever
+	// loads them, so they are code-execution paths even though no entry looks
+	// like a binary. /boot additionally survives a reboot.
+	{"/lib", "system library directory"},
+	{"/lib64", "system library directory"},
+	{"/usr/lib", "system library directory"},
+	{"/usr/lib64", "system library directory"},
+	{"/usr/local/lib", "system library directory"},
+	{"/boot", "boot directory"},
+}
+
+func (c *Config) validateGuard() error {
+	g := &c.Guard
+	if len(g.Services) == 0 && len(g.Profiles) == 0 && len(g.Manifests) == 0 {
+		return nil
+	}
+
+	// --- services ---
+	serviceNames := make(map[string]bool, len(g.Services))
+	serviceDests := make(map[string]bool, len(g.Services))
+	for i, svc := range g.Services {
+		label := fmt.Sprintf("guard.services[%d]", i)
+		if svc.Name == "" {
+			return fmt.Errorf("%s: name is required", label)
+		}
+		if serviceNames[svc.Name] {
+			return fmt.Errorf("%s: duplicate service name %q", label, svc.Name)
+		}
+		serviceNames[svc.Name] = true
+
+		if !guardAllowedProtocols[svc.Protocol] {
+			return fmt.Errorf("%s: unsupported protocol %q (allowed: tcp)", label, svc.Protocol)
+		}
+		if svc.Host == "" {
+			return fmt.Errorf("%s: host is required", label)
+		}
+		if strings.Contains(svc.Host, "*") {
+			return fmt.Errorf("%s: wildcard hosts are not allowed (got %q); use an exact hostname", label, svc.Host)
+		}
+		if strings.Contains(svc.Host, "/") {
+			return fmt.Errorf("%s: CIDR notation is not allowed (got %q); use an exact host", label, svc.Host)
+		}
+		if svc.Port == 0 {
+			return fmt.Errorf("%s: port must be non-zero", label)
+		}
+		normalizedHost := strings.ToLower(strings.TrimRight(svc.Host, "."))
+		dest := svc.Protocol + "://" + normalizedHost + ":" + strconv.FormatUint(uint64(svc.Port), 10)
+		if serviceDests[dest] {
+			return fmt.Errorf("%s: duplicate destination %s", label, dest)
+		}
+		serviceDests[dest] = true
+	}
+
+	// --- manifests ---
+	manifestNames := make(map[string]bool, len(g.Manifests))
+	for i, m := range g.Manifests {
+		label := fmt.Sprintf("guard.manifests[%d]", i)
+		if m.Name == "" {
+			return fmt.Errorf("%s: name is required", label)
+		}
+		if manifestNames[m.Name] {
+			return fmt.Errorf("%s: duplicate manifest name %q", label, m.Name)
+		}
+		manifestNames[m.Name] = true
+
+		for j, p := range m.ReadOnly {
+			if !filepath.IsAbs(p) {
+				return fmt.Errorf("%s.read_only[%d]: path must be absolute (got %q)", label, j, p)
+			}
+			if err := validateGuardROPath(label, j, p); err != nil {
+				return err
+			}
+		}
+		for j, p := range m.ReadWrite {
+			if !filepath.IsAbs(p) {
+				return fmt.Errorf("%s.read_write[%d]: path must be absolute (got %q)", label, j, p)
+			}
+			if err := validateGuardRWPath(label, j, p); err != nil {
+				return err
+			}
+		}
+	}
+
+	// --- profiles ---
+	profileNames := make(map[string]bool, len(g.Profiles))
+	for i, p := range g.Profiles {
+		label := fmt.Sprintf("guard.profiles[%d]", i)
+		if p.Name == "" {
+			return fmt.Errorf("%s: name is required", label)
+		}
+		if profileNames[p.Name] {
+			return fmt.Errorf("%s: duplicate profile name %q", label, p.Name)
+		}
+		profileNames[p.Name] = true
+
+		for _, ref := range p.Manifests {
+			if !manifestNames[ref] {
+				return fmt.Errorf("%s: references unknown manifest %q", label, ref)
+			}
+		}
+	}
+
+	// Everything above validated the declaration. This refuses to ACCEPT it.
+	//
+	// No runtime evaluator consumes guard yet, so a config that loads cleanly
+	// would tell an operator their workload is constrained when nothing
+	// constrains it. Silent acceptance of a security-boundary declaration that
+	// has no enforcement is worse than refusing it: the operator acts on the
+	// clean load. Fail closed instead, and say exactly why.
+	//
+	// Validation still runs first so the message names a genuinely broken
+	// declaration ahead of the unsupported gate; an operator writing this
+	// config today gets accurate feedback on it for when enforcement lands.
+	//
+	// REMOVE THIS GATE in the PR that wires the guard runtime evaluator, in
+	// the same change that starts enforcing these grants.
+	return errGuardNotEnforced
+}
+
+// errGuardNotEnforced is returned for any non-empty guard declaration while the
+// runtime evaluator does not exist.
+var errGuardNotEnforced = errors.New(
+	"guard: configuration is not enforced in this version and is therefore refused rather than silently accepted; " +
+		"declaring guard services, profiles, or state manifests would not constrain any workload. " +
+		"Remove the guard section until a release that implements guard enforcement",
+)
+
+// validateGuardRWPath checks that a read-write path does not grant write
+// access to dangerous or trust-bearing locations.
+func validateGuardRWPath(label string, idx int, rawPath string) error {
+	field := fmt.Sprintf("%s.read_write[%d]", label, idx)
+
+	resolved := resolveGuardPath(rawPath)
+
+	// Trust-bearing and dangerous locations are matched on path COMPONENTS,
+	// not on a prefix derived from this process's home directory. Pipelock
+	// commonly runs as a system service, so os.UserHomeDir() returns /root
+	// and a home-derived list would protect /root/.ssh while leaving every
+	// real operator's ~/.ssh unguarded. Writing into any .ssh, .gnupg or
+	// .gpg directory is unsafe regardless of which user owns it.
+	if comp := guardForbiddenComponent(resolved); comp != "" {
+		return fmt.Errorf("%s: read-write on trust-bearing path %q is not allowed (contains %q)", field, rawPath, comp)
+	}
+	if suffix := guardForbiddenSuffix(resolved); suffix != "" {
+		return fmt.Errorf("%s: read-write on %s %q is not allowed", field, suffix, rawPath)
+	}
+	if guardIsHomeRoot(resolved) {
+		return fmt.Errorf("%s: read-write on the entire home directory is not allowed", field)
+	}
+
+	// NOTE: an earlier draft repeated these checks against os.UserHomeDir().
+	// That block was removed: it was fully shadowed by the component, suffix
+	// and home-root helpers above, which cover EVERY user rather than only the
+	// account this process happens to run as. Dead code that reads as live
+	// protection is worse than no code, because the next reader trusts it.
+
+	// Static dangerous roots
+	for _, dr := range guardDangerousRWRoots {
+		clean := filepath.Clean(dr.prefix)
+		if resolved == clean || strings.HasPrefix(resolved, clean+string(filepath.Separator)) {
+			return fmt.Errorf("%s: read-write on %s %q is not allowed", field, dr.reason, rawPath)
+		}
+	}
+
 	return nil
 }

--- a/scripts/config-consumption-allowlist.txt
+++ b/scripts/config-consumption-allowlist.txt
@@ -59,3 +59,12 @@ TrustedSubjects  # INERT; same as TrustedIssuers
 PublicAllowlistDefault  # INERT; privacy enforcer does not read it
 WellKnownURL  # INERT; no key-discovery fetch implemented for mediation trusted keys
 ReceiptThreshold  # (A) FlightRecorder.AnchorReceiptThreshold() schema.go -> cli/runtime/auto_anchor.go triggered()
+Guard  # INERT: startup-only guard section, validated at load but no runtime consumer yet; excluded from the canonical policy hash (schema.go json:"-") until the guard evaluator lands. Wire-or-remove tracked in ops as the Guard roadmap runtime-evaluator PR.
+Services  # INERT: Guard.Services validated by Config.validateGuard(); consumed by the guard runtime evaluator when it lands. Same ops item as Guard.
+ReadWrite  # INERT: GuardManifest.ReadWrite validated by Config.validateGuard(); consumed by the guard runtime evaluator when it lands. Same ops item as Guard.
+Profiles  # INERT: Guard.Profiles validated by Config.validateGuard(); consumed by the guard runtime evaluator when it lands. Same ops item as Guard.
+Manifests  # INERT: Guard.Manifests validated by Config.validateGuard(); consumed by the guard runtime evaluator when it lands. Same ops item as Guard.
+Protocol  # INERT: GuardService.Protocol validated by Config.validateGuard(); consumed by the guard runtime evaluator when it lands. Same ops item as Guard.
+Host  # INERT: GuardService.Host validated by Config.validateGuard(); consumed by the guard runtime evaluator when it lands. Same ops item as Guard.
+Port  # INERT: GuardService.Port validated by Config.validateGuard(); consumed by the guard runtime evaluator when it lands. Same ops item as Guard.
+ReadOnly  # INERT: GuardManifest.ReadOnly validated by Config.validateGuard(); consumed by the guard runtime evaluator when it lands. Same ops item as Guard.


### PR DESCRIPTION
## What changed

Adds a startup-only `guard:` configuration section that declares protocol-aware services, named workload profiles, and explicit read-only and read-write state manifests. Manifests are selected by name rather than inferred from the executable, so what a workload may write is a declaration an operator can read rather than a side effect of how it was launched.

Validation rejects wildcard and CIDR service hosts, zero ports, duplicate service names, duplicate destinations, duplicate manifest names, profiles referencing unknown manifests, whole-home read-write grants, read-write on trust-bearing roots such as the SSH and GnuPG directories, Pipelock's own state and config, PATH directories, autostart directories and socket paths, and symlink aliases that resolve to any of those.

## Why the section is excluded from the canonical policy hash

The canonical policy hash is stamped into proxy and MCP receipts, learn-compile output, dashboard snapshots, replay packets, and conductor bundles. A field that enters that hash changes the evidence every deployment emits.

This section has no runtime consumer yet, so including it would mean two Pipelock versions computing different policy hashes for a byte-identical effective policy during a rolling upgrade. Identical policy would emit evidence that looks tampered with when nothing changed. The field therefore carries `json:"-"` alongside the existing `learn_lock` and `conductor` exclusions, and the allowlist entries are labelled inert rather than consumed.

The rule this follows: a field earns a place in the canonical policy hash once a production decision path consumes it. Validation alone is not consumption.

`TestCanonicalPolicyHash_GuardExcludedWhileInert` pins that decision and carries an explicit instruction to invert it when the guard runtime evaluator lands, at which point differing grants must produce differing hashes as a deliberate, versioned migration rather than a silent reinterpretation.

## Scope

Configuration schema, validation, and tests only. No runtime enforcement behavior changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added startup configuration options for network services, workload profiles, and filesystem access manifests.
  * Guard configuration changes require a restart and are ignored during hot reload.

* **Bug Fixes**
  * Improved validation of service definitions, manifest references, paths, protocols, hosts, ports, and duplicate destinations.
  * Blocked unsafe writable and read-sensitive locations, including protected and symlinked paths.
  * Non-empty Guard configurations are rejected until runtime enforcement is available.

* **Tests**
  * Added comprehensive coverage for valid, invalid, symlinked, protected, and unsafe configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->