### PR TITLE
feat(contain): add a containment-aware upgrade command

### DIFF
--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -7,6 +7,7 @@ The subcommands are:
 | Subcommand | What it does | Mutates state |
 |---|---|---|
 | `install` | Create users, systemd unit, nftables rules, wrappers, sudoers entry, CA bundle, runtime contract | yes (root only) |
+| `upgrade` | Download, verify, replace, re-pin integrity, restart, and verify in one fail-closed command | yes (root only) |
 | `run` | Verify the containment boundary, emit a signed posture capsule, then launch a registered tool as `pipelock-agent` | writes proof + starts process |
 | `verify` | Read-only probes that report pass / fail / skip for the 12 invariants below | no |
 | `doctor` | Live self-test that proves common tooling reaches the internet *through* the proxy, with per-check remediation | no |
@@ -115,6 +116,42 @@ On success, `install` prints a **Next steps** block with:
 ### nftables version compatibility
 
 The nftables step checks the installed `nft` version before generating rules. The containment ruleset requires nftables >= 0.8 (for `meta skuid`, inline `counter log prefix ... drop` syntax, and the `-c`/`--check` validation mode used by the install and rollback paths). On hosts with an older `nft` (seen on some older enterprise Linux images), install fails with a clear error naming the minimum version and the distro-appropriate upgrade command, rather than a cryptic parse error at load time.
+
+## `pipelock contain upgrade`
+
+Upgrade performs a containment-aware binary update in one fail-closed command. It bridges the gap between `pipelock update` (which replaces the binary but leaves the containment integrity pin stale) and `contain install --pipelock-binary` (which re-pins but requires the operator to have already obtained and verified the candidate).
+
+The sequence is:
+
+1. Download and verify the candidate release by invoking the **deployed** binary's `pipelock update --yes` (Ed25519 manifest + checksums + optional cosign), which replaces the binary only after those checks pass.
+2. Re-pin the SHA-256 integrity hash against the newly deployed binary at `/etc/pipelock/integrity/binary-pin.sha256`.
+3. Restart the `pipelock.service` systemd unit and wait for readiness.
+4. Run `contain verify` and require exit 0, which means every probe passed.
+   A failing probe exits 1 and a skipped or inconclusive probe exits 2, so
+   both roll the upgrade back.
+
+If any step after binary replacement fails, the command rolls back both the binary and its integrity pin to the pre-upgrade state, then best-effort restarts the service.
+
+Release-signature verification is performed by the deployed binary at `/usr/local/bin/pipelock`, not by whichever copy of pipelock you invoke this command from. The command deliberately does not pre-check the invoking binary's embedded release keyring: that would decide against one artifact while the upgrade acts on another, and it would refuse a legitimate upgrade whenever an operator runs a custom or RC copy against a healthy deployed binary. A build with no embedded release keyring cannot verify a release, so its `update` step refuses; recover such a host with `contain install --pipelock-binary <path>` after independent signature, checksum, and attestation verification.
+
+Must be run as root.
+
+```bash
+sudo pipelock contain upgrade              # upgrade to the latest release
+sudo pipelock contain upgrade --version v3.2.0  # pin to a specific tag
+```
+
+Flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--version` | (latest) | Install a specific release tag instead of the latest. |
+
+Exit codes:
+
+- **0** — upgrade completed and all verification probes passed.
+- **1** — upgrade failed; previous state was restored.
+- **2** — precondition error (not root, deployed binary missing or not a regular file, or no integrity pin).
 
 ## `pipelock contain verify`
 

--- a/internal/cli/contain/cmd.go
+++ b/internal/cli/contain/cmd.go
@@ -21,6 +21,7 @@ rules to force every agent process through the Pipelock proxy.
 
 Subcommands:
   install     Create users, systemd unit, nft rules, wrappers, sudoers.
+  upgrade     Download, verify, replace, re-pin, restart, verify (one command).
   run         Verify containment, then launch a registered agent tool.
   verify      Run read-only probes; report pass/fail/skip.
   doctor      Live self-test of the runtime contract; report remediation.
@@ -32,8 +33,8 @@ Subcommands:
               Revoke pipelock-agent ACL access from a project directory.
   ca-refresh  Rebuild the combined CA bundle after a CA rotation.
 
-All mutating subcommands accept --dry-run to print the planned actions
-without touching state.`,
+All mutating subcommands except 'upgrade' accept --dry-run to print the
+planned actions without touching state.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -49,6 +50,7 @@ without touching state.`,
 		grantWorkspaceCmd(),
 		revokeWorkspaceCmd(),
 		caRefreshCmd(),
+		upgradeCmd(),
 	)
 
 	return cmd

--- a/internal/cli/contain/upgrade.go
+++ b/internal/cli/contain/upgrade.go
@@ -1,0 +1,509 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// This file implements `pipelock contain upgrade`, a containment-aware
+// one-command upgrade that atomically replaces the deployed binary, re-pins
+// the integrity hash, restarts the service, and verifies the containment
+// boundary — rolling back both binary and pin on any post-replacement failure.
+//
+// Checked 2026-08-03: no existing contain subcommand performs this lifecycle.
+// `pipelock update` (internal/cli/selfupdate) replaces the binary but is
+// unaware of the containment integrity pin, leaving probe 10 stale.
+// `pipelock contain install --pipelock-binary` re-pins but requires the
+// operator to have already obtained and verified the candidate binary.
+// This command bridges the gap.
+
+package contain
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+// upgradeOpts collects flag-derived state for the upgrade subcommand.
+type upgradeOpts struct {
+	version string
+}
+
+// upgradeEnv is the injectable dependency surface for the upgrade orchestration.
+// Every external operation is a function value so tests can exercise the full
+// fail-closed/rollback logic against temp dirs and fake binaries.
+type upgradeEnv struct {
+	out    io.Writer
+	errOut io.Writer
+
+	// Filesystem operations.
+	stat       func(path string) (os.FileInfo, error)
+	readFile   func(path string) ([]byte, error)
+	writeFile  func(path string, contents []byte, mode os.FileMode) error
+	mkdirAll   func(path string, mode os.FileMode) error
+	hashFile   func(path string) (string, error)
+	removeFile func(path string) error
+
+	// Subprocess execution.
+	runCmd runCommand
+
+	// File inspection (Lstat does not follow symlinks).
+	lstat func(path string) (os.FileInfo, error)
+
+	// Ownership operations (nil in unit tests against temp dirs).
+	lookupUser lookupUserFunc
+	chown      func(path string, uid, gid int) error
+	chmod      func(path string, mode os.FileMode) error
+
+	// Paths.
+	proxyUserName  string
+	pipelockTarget string
+	integrityDir   string
+	integrityPin   string
+	serviceName    string
+
+	// Readiness.
+	readinessTimeout time.Duration
+}
+
+func defaultUpgradeEnv(out, errOut io.Writer) *upgradeEnv {
+	return &upgradeEnv{
+		out:              out,
+		errOut:           errOut,
+		stat:             os.Stat,
+		lstat:            os.Lstat,
+		readFile:         os.ReadFile,
+		writeFile:        writeFileAtomic,
+		mkdirAll:         os.MkdirAll,
+		hashFile:         sha256HexOfFile,
+		removeFile:       os.Remove,
+		runCmd:           realRunCommand,
+		lookupUser:       user.Lookup,
+		chown:            os.Chown,
+		chmod:            os.Chmod,
+		proxyUserName:    defaultProxyUser,
+		pipelockTarget:   defaultPipelockTarget,
+		integrityDir:     defaultIntegrityDir,
+		integrityPin:     defaultIntegrityPin,
+		serviceName:      defaultServiceName,
+		readinessTimeout: installReadinessTimeout,
+	}
+}
+
+func upgradeCmd() *cobra.Command {
+	var opts upgradeOpts
+
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Download, verify, and install a new pipelock release with containment integrity re-pin",
+		Long: `Perform a containment-aware upgrade of the pipelock binary.
+
+The upgrade is FAIL-CLOSED at every step:
+
+  1. Download and verify the candidate release by invoking the DEPLOYED
+     binary's 'pipelock update', which verifies the release manifest,
+     checksums, and signatures fail-closed before replacing itself.
+  2. Re-pin the integrity hash against the newly deployed binary.
+  3. Restart the pipelock systemd service and wait for readiness.
+  4. Run 'contain verify' and require exit 0 (every probe passed).
+
+If any step after binary replacement fails, the previous binary AND its
+integrity pin are restored before exit.
+
+This eliminates the gap between 'pipelock update' and the containment
+integrity pin: an ordinary update leaves the pin stale, causing probe 10
+to report a mismatch on a host that is actually healthy.
+
+Release-signature verification is performed by the deployed binary, not by
+whichever copy you invoke this command from. A build with no embedded release
+keyring cannot verify a release and its 'update' step will refuse; recover
+such a host with 'contain install --pipelock-binary <path>' after independent
+signature, checksum, and attestation verification.
+
+Must be run as root.
+
+Exit codes:
+  0  Upgrade completed and verified.
+  1  Upgrade failed; previous state restored.
+  2  Precondition error (not root, deployed binary missing or not a regular file, or no integrity pin).`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if os.Geteuid() != 0 {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, errors.New("upgrade must be run as root (use sudo)"))
+			}
+			env := defaultUpgradeEnv(cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return runUpgrade(cmd.Context(), env, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.version, "version", "", "install a specific release tag (e.g. v3.2.0) instead of the latest")
+
+	return cmd
+}
+
+var (
+	errUpgradeVerify    = errors.New("post-upgrade verification failed")
+	errUpgradeRestart   = errors.New("service restart failed")
+	errUpgradeRepin     = errors.New("integrity re-pin failed")
+	errUpgradeRollback  = errors.New("rollback failed")
+	errUpgradeUpdate    = errors.New("pipelock update failed")
+	errUpgradeIntegrity = errors.New("pre-upgrade integrity check failed")
+)
+
+func runUpgrade(ctx context.Context, env *upgradeEnv, opts upgradeOpts) error {
+	w := env.out
+
+	// NOTE: there is deliberately NO invoker-side release-keyring preflight
+	// here. An earlier draft checked releasetrust.PublicKeyringHex, which is
+	// linked into whichever binary INVOKED this command, and then delegated
+	// the actual verified update to the DEPLOYED binary at env.pipelockTarget.
+	// Those are different artifacts whenever the operator runs a copy that is
+	// not the deployed one, so the check decided about one binary while the
+	// consequence landed on another.
+
+	// ── Step 1: verify the deployed binary is a regular, non-symlink file ─
+	target := filepath.Clean(env.pipelockTarget)
+	info, lstatErr := env.lstat(target)
+	if lstatErr != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf(
+			"deployed binary not found at %s: %w", target, lstatErr))
+	}
+	if !info.Mode().IsRegular() {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf(
+			"deployed binary at %s is not a regular file (mode %s); refusing to execute",
+			target, info.Mode()))
+	}
+
+	// ── Step 2: verify binary against integrity pin BEFORE executing it ──
+	// This is the critical pre-execution check: if the binary has been
+	// tampered with, the pin (written by our own installer at a known-good
+	// time) will not match. We hash with the trusted in-process
+	// implementation and compare with constant-time equality, so a
+	// compromised binary never gets root execution.
+	oldPin, oldPinErr := env.readFile(env.integrityPin)
+	switch {
+	case oldPinErr == nil:
+		// Pin exists — verify the deployed binary against it.
+		pinned := strings.TrimSpace(string(oldPin))
+		if _, decErr := hex.DecodeString(pinned); decErr != nil || len(pinned) != sha256HexLen ||
+			pinned != strings.ToLower(pinned) {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf(
+				"%w: pin file %s contains malformed SHA-256 (length %d)",
+				errUpgradeIntegrity, env.integrityPin, len(pinned)))
+		}
+		currentHash, hashErr := env.hashFile(target)
+		if hashErr != nil {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf(
+				"%w: hash deployed binary %s: %w", errUpgradeIntegrity, target, hashErr))
+		}
+		if subtle.ConstantTimeCompare([]byte(currentHash), []byte(pinned)) != 1 {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf(
+				"%w: deployed binary hash does not match integrity pin (binary may be tampered; "+
+					"recover with 'contain install --pipelock-binary <path>' after independent verification)",
+				errUpgradeIntegrity))
+		}
+		_, _ = fmt.Fprintln(w, "pre-upgrade integrity check passed")
+	case errors.Is(oldPinErr, fs.ErrNotExist):
+		// No pin file — this is a first install or the pin was never written.
+		// FAIL-CLOSED: refuse to execute an unpinned binary as root.
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf(
+			"%w: no integrity pin at %s; cannot verify deployed binary before executing it as root "+
+				"(run 'contain install' first to establish the pin, or "+
+				"'contain install --pipelock-binary <path>' to re-pin a known-good binary)",
+			errUpgradeIntegrity, env.integrityPin))
+	default:
+		// Pin file exists but is unreadable (permission error, I/O error).
+		// FAIL-CLOSED: an unreadable pin could be tamper evidence.
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf(
+			"%w: cannot read integrity pin %s: %w (refusing to proceed; "+
+				"an unreadable pin may indicate tampering)",
+			errUpgradeIntegrity, env.integrityPin, oldPinErr))
+	}
+
+	// ── Step 3: back up the current binary ──────────────────────────────
+	_, _ = fmt.Fprintln(w, "backing up current binary...")
+	backupPath := target + ".upgrade-bak"
+	if err := upgradeCopyFile(env, target, backupPath); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf(
+			"backing up current binary: %w", err))
+	}
+	_, _ = fmt.Fprintf(w, "  backup at %s\n", backupPath)
+
+	// ── Rollback helper ─────────────────────────────────────────────────
+	// Direction: restores binary FIRST (so the pin is always consistent
+	// with whatever is on disk), then pin, then best-effort restart.
+	rollbackAll := func() error {
+		var errs []error
+		_, _ = fmt.Fprintln(w, "restoring previous binary...")
+		if binErr := upgradeCopyFile(env, backupPath, target); binErr != nil {
+			errs = append(errs, fmt.Errorf("restore binary: %w", binErr))
+		}
+		_, _ = fmt.Fprintln(w, "restoring previous integrity pin...")
+		if pinErr := env.writeFile(env.integrityPin, oldPin, modePinSecret); pinErr != nil {
+			errs = append(errs, fmt.Errorf("restore pin: %w", pinErr))
+		} else if ownErr := upgradeRestorePinOwnership(env); ownErr != nil {
+			// The rollback path must hand the pin back to the proxy user for
+			// the same reason the forward path does: this command runs as
+			// root, so a pin written here is root-owned, and the service that
+			// reads it does not run as root. Restoring the contents but not
+			// the ownership would leave a rolled-back host reporting a false
+			// integrity mismatch -- the exact failure this command exists to
+			// eliminate, reintroduced through its own recovery path.
+			errs = append(errs, fmt.Errorf("restore pin ownership: %w", ownErr))
+		}
+		_, _, _ = env.runCmd(ctx, "systemctl", "daemon-reload")
+		if _, code, rErr := env.runCmd(ctx, "systemctl", "restart", env.serviceName); rErr != nil || code != 0 {
+			_, _ = fmt.Fprintf(env.errOut,
+				"warning: best-effort restart of %s after rollback did not succeed (code %d, err %v)\n",
+				env.serviceName, code, rErr)
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("%w: %w", errUpgradeRollback, errors.Join(errs...))
+		}
+		return nil
+	}
+
+	// ── Step 4: download, verify, and install the candidate ─────────────
+	_, _ = fmt.Fprintln(w, "downloading and verifying candidate release...")
+	version, updateErr := upgradeRunUpdate(ctx, env, opts)
+	if updateErr != nil {
+		// Check whether the binary actually changed before doing a full
+		// rollback with service restart. A network/signature failure that
+		// aborted before touching the binary should not restart a healthy
+		// service.
+		newHash, hashErr := env.hashFile(target)
+		backupHash, bkHashErr := env.hashFile(backupPath)
+		binaryChanged := hashErr != nil || bkHashErr != nil || newHash != backupHash
+
+		if binaryChanged {
+			if rbErr := rollbackAll(); rbErr != nil {
+				return cliutil.ExitCodeError(cliutil.ExitGeneral, errors.Join(
+					fmt.Errorf("%w: %w", errUpgradeUpdate, updateErr),
+					fmt.Errorf("%w (backup retained at %s)", rbErr, backupPath)))
+			}
+		}
+		_ = env.removeFile(backupPath)
+		if binaryChanged {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf(
+				"%w: %w (rolled back)", errUpgradeUpdate, updateErr))
+		}
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf(
+			"%w: %w", errUpgradeUpdate, updateErr))
+	}
+	_, _ = fmt.Fprintf(w, "  installed %s\n", version)
+
+	// ── Step 5: re-pin integrity against the new binary ─────────────────
+	_, _ = fmt.Fprintln(w, "re-pinning binary integrity...")
+	if err := upgradeRepinIntegrity(env); err != nil {
+		_, _ = fmt.Fprintf(env.errOut, "re-pin failed: %v\n", err)
+		if rbErr := rollbackAll(); rbErr != nil {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, errors.Join(
+				fmt.Errorf("%w: %w", errUpgradeRepin, err),
+				fmt.Errorf("%w (backup retained at %s)", rbErr, backupPath)))
+		}
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf(
+			"%w: %w (rolled back)", errUpgradeRepin, err))
+	}
+	_, _ = fmt.Fprintln(w, "  integrity pin updated")
+
+	// ── Step 6: restart the pipelock service ────────────────────────────
+	_, _ = fmt.Fprintln(w, "restarting pipelock service...")
+	if err := upgradeRestartAndWait(ctx, env); err != nil {
+		_, _ = fmt.Fprintf(env.errOut, "restart failed: %v\n", err)
+		if rbErr := rollbackAll(); rbErr != nil {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, errors.Join(
+				fmt.Errorf("%w: %w", errUpgradeRestart, err),
+				fmt.Errorf("%w (backup retained at %s)", rbErr, backupPath)))
+		}
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf(
+			"%w: %w (rolled back)", errUpgradeRestart, err))
+	}
+	_, _ = fmt.Fprintln(w, "  service restarted and ready")
+
+	// ── Step 7: final verification ──────────────────────────────────────
+	_, _ = fmt.Fprintln(w, "running post-upgrade verification...")
+	if err := upgradePostVerify(ctx, env); err != nil {
+		_, _ = fmt.Fprintf(env.errOut, "post-upgrade verify failed: %v\n", err)
+		if rbErr := rollbackAll(); rbErr != nil {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, errors.Join(
+				fmt.Errorf("%w: %w", errUpgradeVerify, err),
+				fmt.Errorf("%w (backup retained at %s)", rbErr, backupPath)))
+		}
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf(
+			"%w: %w (rolled back)", errUpgradeVerify, err))
+	}
+	_, _ = fmt.Fprintln(w, "  verification passed")
+
+	// ── Success ─────────────────────────────────────────────────────────
+	_ = env.removeFile(backupPath)
+	_, _ = fmt.Fprintf(w, "upgrade to %s completed successfully\n", version)
+	return nil
+}
+
+// upgradeRunUpdate shells out to the deployed binary's update command.
+func upgradeRunUpdate(ctx context.Context, env *upgradeEnv, opts upgradeOpts) (string, error) {
+	args := []string{"update", "--yes"}
+	if opts.version != "" {
+		args = append(args, "--version", opts.version)
+	}
+
+	out, code, err := env.runCmd(ctx, env.pipelockTarget, args...)
+	if err != nil {
+		return "", fmt.Errorf("exec pipelock update: %w", err)
+	}
+	if code != 0 {
+		return "", fmt.Errorf("pipelock update exited %d: %s", code, truncateForErr(out))
+	}
+	return upgradeExtractVersion(out), nil
+}
+
+// upgradeExtractVersion parses the version from selfupdate output.
+// The matched prefixes ("Updated to ", "latest release. Nothing to do") are
+// the exact strings emitted by internal/cli/selfupdate/cmd.go; keep them in
+// sync and see TestUpgrade_VersionParsing for the parser contract.
+func upgradeExtractVersion(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Updated to ") {
+			rest := strings.TrimPrefix(line, "Updated to ")
+			if fields := strings.Fields(rest); len(fields) > 0 {
+				return strings.TrimRight(fields[0], ".")
+			}
+		}
+		if strings.Contains(line, "latest release. Nothing to do") {
+			return "current (already up to date)"
+		}
+	}
+	return "unknown"
+}
+
+// upgradeRepinIntegrity hashes the deployed binary and writes the pin file.
+func upgradeRepinIntegrity(env *upgradeEnv) error {
+	target := filepath.Clean(env.pipelockTarget)
+	hash, err := env.hashFile(target)
+	if err != nil {
+		return fmt.Errorf("hash deployed binary %s: %w", target, err)
+	}
+	if err := env.mkdirAll(env.integrityDir, modeDirPrivate); err != nil {
+		return fmt.Errorf("mkdir %s: %w", env.integrityDir, err)
+	}
+	contents := []byte(hash + "\n")
+	if err := env.writeFile(env.integrityPin, contents, modePinSecret); err != nil {
+		return fmt.Errorf("write pin %s: %w", env.integrityPin, err)
+	}
+	return upgradeRestorePinOwnership(env)
+}
+
+// upgradeRestorePinOwnership hands the freshly written pin back to the proxy
+// user.
+//
+// The pin is written by this command running as root, so without this it would
+// be left root-owned at 0600. The Pipelock service runs as the proxy user and
+// reads the pin at runtime, so a root-owned pin makes the binary-integrity
+// probe fail on a host that is otherwise perfectly healthy. That is precisely
+// the false mismatch this whole command exists to eliminate, so leaving it
+// would have reintroduced the bug through the fix for it.
+//
+// Mirrors ensureIntegrityOwnership in install.go, which cannot be reused
+// directly because it takes *installEnv.
+func upgradeRestorePinOwnership(env *upgradeEnv) error {
+	u, err := env.lookupUser(env.proxyUserName)
+	if err != nil {
+		return fmt.Errorf("lookup %s: %w", env.proxyUserName, err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return fmt.Errorf("parse uid for %s: %w", env.proxyUserName, err)
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return fmt.Errorf("parse gid for %s: %w", env.proxyUserName, err)
+	}
+	if err := env.chmod(env.integrityPin, modePinSecret); err != nil {
+		return fmt.Errorf("chmod %s: %w", env.integrityPin, err)
+	}
+	if err := env.chown(env.integrityPin, uid, gid); err != nil {
+		return fmt.Errorf("chown %s: %w", env.integrityPin, err)
+	}
+	return nil
+}
+
+// upgradeRestartAndWait does daemon-reload + restart + readiness poll.
+func upgradeRestartAndWait(ctx context.Context, env *upgradeEnv) error {
+	if _, code, err := env.runCmd(ctx, "systemctl", "daemon-reload"); err != nil {
+		return fmt.Errorf("daemon-reload: %w", err)
+	} else if code != 0 {
+		return fmt.Errorf("daemon-reload exited %d", code)
+	}
+
+	out, code, err := env.runCmd(ctx, "systemctl", "restart", env.serviceName)
+	if err != nil {
+		return fmt.Errorf("restart %s: %w", env.serviceName, err)
+	}
+	if code != 0 {
+		return fmt.Errorf("restart %s exited %d: %s", env.serviceName, code, truncateForErr(out))
+	}
+
+	// Poll for active state with a ticker (no time.Sleep).
+	deadline := time.After(env.readinessTimeout)
+	ticker := time.NewTicker(readinessInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("service %s not ready after %s", env.serviceName, env.readinessTimeout)
+		case <-ticker.C:
+			isOut, isCode, isErr := env.runCmd(ctx, "systemctl", "is-active", env.serviceName)
+			if isErr != nil {
+				continue
+			}
+			if isCode == 0 && strings.TrimSpace(isOut) == "active" {
+				return nil
+			}
+		}
+	}
+}
+
+// upgradePostVerify runs the newly deployed binary's contain verify command.
+func upgradePostVerify(ctx context.Context, env *upgradeEnv) error {
+	out, code, err := env.runCmd(ctx, env.pipelockTarget, "contain", "verify")
+	if err != nil {
+		return fmt.Errorf("exec contain verify: %w", err)
+	}
+	if code != 0 {
+		return fmt.Errorf("contain verify exited %d: %s", code, truncateForErr(out))
+	}
+	return nil
+}
+
+// upgradeCopyFile copies src to dst preserving the source permissions. It
+// backs the deployed binary up before replacement and restores it on rollback.
+func upgradeCopyFile(env *upgradeEnv, src, dst string) error {
+	data, err := env.readFile(src)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", src, err)
+	}
+	info, err := env.stat(src)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", src, err)
+	}
+	if err := env.writeFile(dst, data, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+	return nil
+}

--- a/internal/cli/contain/upgrade_test.go
+++ b/internal/cli/contain/upgrade_test.go
@@ -1,0 +1,1103 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testUpgradeEnv returns an upgradeEnv wired to a temp directory with a fake
+// binary and pin already in place (simulating a previously installed system).
+func testUpgradeEnv(t *testing.T) *upgradeEnv {
+	t.Helper()
+	dir := t.TempDir()
+
+	binDir := filepath.Join(dir, "bin")
+	intDir := filepath.Join(dir, "integrity")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(intDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a fake binary.
+	target := filepath.Join(binDir, "pipelock")
+	oldContent := []byte("old-binary-content")
+	if err := writeFileAtomic(target, oldContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write matching pin.
+	pinPath := filepath.Join(intDir, "binary-pin.sha256")
+	h := sha256.Sum256(oldContent)
+	oldHash := hex.EncodeToString(h[:])
+	if err := writeFileAtomic(pinPath, []byte(oldHash+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+
+	env := &upgradeEnv{
+		out:        &out,
+		errOut:     &errOut,
+		stat:       os.Stat,
+		lstat:      os.Lstat,
+		readFile:   os.ReadFile,
+		writeFile:  writeFileAtomic,
+		mkdirAll:   os.MkdirAll,
+		hashFile:   sha256HexOfFile,
+		removeFile: os.Remove,
+		lookupUser: func(string) (*user.User, error) {
+			return &user.User{Uid: "1000", Gid: "1000"}, nil
+		},
+		chown:            func(string, int, int) error { return nil },
+		chmod:            func(string, os.FileMode) error { return nil },
+		proxyUserName:    defaultProxyUser,
+		pipelockTarget:   target,
+		integrityDir:     intDir,
+		integrityPin:     pinPath,
+		serviceName:      "pipelock.service",
+		readinessTimeout: 2 * time.Second,
+	}
+
+	return env
+}
+
+// successRunCmd returns a runCommand that succeeds for update/systemctl/verify.
+func successRunCmd(env *upgradeEnv, newBinary []byte) runCommand {
+	updateCalled := false
+	return func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			if args[0] == "update" && !updateCalled {
+				updateCalled = true
+				_ = writeFileAtomic(env.pipelockTarget, newBinary, 0o755)
+				return "Updated to v9.9.9. Previous binary saved at /tmp/bak", 0, nil
+			}
+			if len(args) >= 2 && args[0] == "contain" && args[1] == "verify" {
+				return "Result: 12 PASS / 0 FAIL / 0 SKIP — exit 0", 0, nil
+			}
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "is-active" {
+				return "active", 0, nil
+			}
+			return "", 0, nil
+		}
+		return "", 0, nil
+	}
+}
+
+func TestUpgrade_BinaryMissing_FailsClosed(t *testing.T) {
+	env := testUpgradeEnv(t)
+	// Remove the target binary.
+	_ = os.Remove(env.pipelockTarget)
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{})
+	if err == nil {
+		t.Fatal("expected error for missing binary, got nil")
+	}
+	if !strings.Contains(err.Error(), "deployed binary not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpgrade_BinaryIsSymlink_FailsClosed(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	// Replace target with a symlink.
+	realPath := env.pipelockTarget + ".real"
+	_ = os.Rename(env.pipelockTarget, realPath)
+	if err := os.Symlink(realPath, env.pipelockTarget); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{})
+	if err == nil {
+		t.Fatal("expected error for symlink binary, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpgrade_TamperedBinary_FailsClosed(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	// Tamper with the binary so hash no longer matches pin.
+	if err := writeFileAtomic(env.pipelockTarget, []byte("tampered-content"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{})
+	if err == nil {
+		t.Fatal("expected error for tampered binary, got nil")
+	}
+	if !errors.Is(err, errUpgradeIntegrity) {
+		t.Fatalf("expected errUpgradeIntegrity, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "does not match integrity pin") {
+		t.Fatalf("error should mention hash mismatch, got: %v", err)
+	}
+}
+
+func TestUpgrade_NoPinFile_FailsClosed(t *testing.T) {
+	env := testUpgradeEnv(t)
+	_ = os.Remove(env.integrityPin)
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{})
+	if err == nil {
+		t.Fatal("expected error for missing pin file")
+	}
+	if !errors.Is(err, errUpgradeIntegrity) {
+		t.Fatalf("expected errUpgradeIntegrity, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no integrity pin") {
+		t.Fatalf("error should mention missing pin, got: %v", err)
+	}
+}
+
+func TestUpgrade_UnreadablePin_FailsClosed(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	// Make the pin unreadable (simulate permission error).
+	env.readFile = func(path string) ([]byte, error) {
+		if path == env.integrityPin {
+			return nil, fmt.Errorf("permission denied: %w", os.ErrPermission)
+		}
+		return os.ReadFile(filepath.Clean(path))
+	}
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{})
+	if err == nil {
+		t.Fatal("expected error for unreadable pin")
+	}
+	if !errors.Is(err, errUpgradeIntegrity) {
+		t.Fatalf("expected errUpgradeIntegrity, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot read integrity pin") {
+		t.Fatalf("error should mention unreadable pin, got: %v", err)
+	}
+}
+
+func TestUpgrade_MalformedPin_FailsClosed(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	// Write a malformed pin.
+	if err := writeFileAtomic(env.integrityPin, []byte("not-a-valid-hex\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{})
+	if err == nil {
+		t.Fatal("expected error for malformed pin")
+	}
+	if !errors.Is(err, errUpgradeIntegrity) {
+		t.Fatalf("expected errUpgradeIntegrity, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "malformed SHA-256") {
+		t.Fatalf("error should mention malformed pin, got: %v", err)
+	}
+}
+
+func TestUpgrade_UpdateFails_RollsBackBinary(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	oldContent, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate: pipelock update fails AFTER changing the binary.
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 && args[0] == "update" {
+			// Change binary then fail.
+			_ = writeFileAtomic(env.pipelockTarget, []byte("partial-update"), 0o755)
+			return "update failed: network error", 1, nil
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from failed update")
+	}
+	if !errors.Is(upgradeErr, errUpgradeUpdate) {
+		t.Fatalf("expected errUpgradeUpdate, got: %v", upgradeErr)
+	}
+
+	// Binary should be restored.
+	got, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatalf("binary should exist after rollback: %v", err)
+	}
+	if !bytes.Equal(got, oldContent) {
+		t.Fatal("binary content should be restored after rollback")
+	}
+}
+
+func TestUpgrade_UpdateFailsWithoutBinaryChange_NoRestart(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	var restartCalled bool
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 && args[0] == "update" {
+			// Fail WITHOUT changing the binary (network failure before replacement).
+			return "update failed: connection refused", 1, nil
+		}
+		if name == "systemctl" && len(args) > 0 && args[0] == "restart" {
+			restartCalled = true
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from failed update")
+	}
+	if !errors.Is(upgradeErr, errUpgradeUpdate) {
+		t.Fatalf("expected errUpgradeUpdate, got: %v", upgradeErr)
+	}
+	if restartCalled {
+		t.Error("service should not be restarted when binary was not changed")
+	}
+}
+
+func TestUpgrade_RepinFails_RollsBackBinaryAndPin(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	oldContent, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldPin, err := os.ReadFile(env.integrityPin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newBinary := []byte("new-binary-content")
+	env.runCmd = successRunCmd(env, newBinary)
+
+	// Make hashFile fail to simulate re-pin failure.
+	origHash := env.hashFile
+	firstCall := true
+	env.hashFile = func(path string) (string, error) {
+		// Allow the pre-execution hash check but fail for repin.
+		if firstCall {
+			firstCall = false
+			return origHash(path)
+		}
+		return "", fmt.Errorf("disk I/O error")
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from failed re-pin")
+	}
+	if !errors.Is(upgradeErr, errUpgradeRepin) {
+		t.Fatalf("expected errUpgradeRepin, got: %v", upgradeErr)
+	}
+
+	// Both binary and pin should be restored.
+	got, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatalf("binary should exist after rollback: %v", err)
+	}
+	if !bytes.Equal(got, oldContent) {
+		t.Fatal("binary should be restored to original content")
+	}
+
+	gotPin, err := os.ReadFile(env.integrityPin)
+	if err != nil {
+		t.Fatalf("pin should exist after rollback: %v", err)
+	}
+	if !bytes.Equal(gotPin, oldPin) {
+		t.Fatalf("pin should be restored: got %q want %q", gotPin, oldPin)
+	}
+}
+
+func TestUpgrade_RestartFails_RollsBack(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	oldContent, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newBinary := []byte("new-binary-v2")
+	updateCalled := false
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			if args[0] == "update" && !updateCalled {
+				updateCalled = true
+				_ = writeFileAtomic(env.pipelockTarget, newBinary, 0o755)
+				return "Updated to v9.9.9. Previous binary saved at /tmp/bak", 0, nil
+			}
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "restart" {
+				return "Job failed", 1, nil
+			}
+			// daemon-reload succeeds
+			return "", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from failed restart")
+	}
+	if !errors.Is(upgradeErr, errUpgradeRestart) {
+		t.Fatalf("expected errUpgradeRestart, got: %v", upgradeErr)
+	}
+
+	// Binary should be restored.
+	got, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatalf("binary should exist after rollback: %v", err)
+	}
+	if !bytes.Equal(got, oldContent) {
+		t.Fatal("binary should be restored")
+	}
+}
+
+func TestUpgrade_VerifyFails_RollsBack(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	oldContent, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newBinary := []byte("new-binary-v3")
+	updateCalled := false
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			if args[0] == "update" && !updateCalled {
+				updateCalled = true
+				_ = writeFileAtomic(env.pipelockTarget, newBinary, 0o755)
+				return "Updated to v9.9.9. Previous binary saved at /tmp/bak", 0, nil
+			}
+			if len(args) >= 2 && args[0] == "contain" && args[1] == "verify" {
+				return "[FAIL] probe 10: binary integrity pin (mismatch)", 1, nil
+			}
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "is-active" {
+				return "active", 0, nil
+			}
+			return "", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from failed verify")
+	}
+	if !errors.Is(upgradeErr, errUpgradeVerify) {
+		t.Fatalf("expected errUpgradeVerify, got: %v", upgradeErr)
+	}
+
+	got, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatalf("binary should exist after rollback: %v", err)
+	}
+	if !bytes.Equal(got, oldContent) {
+		t.Fatal("binary should be restored")
+	}
+}
+
+func TestUpgrade_FullSuccess(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	newBinary := []byte("new-binary-success")
+	env.runCmd = successRunCmd(env, newBinary)
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{})
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+
+	// Pin should match the new binary.
+	pinData, err := os.ReadFile(env.integrityPin)
+	if err != nil {
+		t.Fatalf("pin should exist: %v", err)
+	}
+	got := strings.TrimSpace(string(pinData))
+	h := sha256.Sum256(newBinary)
+	want := hex.EncodeToString(h[:])
+	if got != want {
+		t.Fatalf("pin mismatch: got %s want %s", got, want)
+	}
+
+	// Backup should be cleaned up.
+	backupPath := env.pipelockTarget + ".upgrade-bak"
+	if _, err := os.Stat(backupPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("backup should be removed after successful upgrade")
+	}
+}
+
+func TestUpgrade_VersionParsing(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{
+			name: "standard update",
+			out:  "Updated to v3.2.0. Previous binary saved at /usr/local/bin/pipelock.bak.",
+			want: "v3.2.0",
+		},
+		{
+			name: "already up to date",
+			out:  "You are running the latest release. Nothing to do.",
+			want: "current (already up to date)",
+		},
+		{
+			name: "unrecognized output",
+			out:  "something unexpected",
+			want: "unknown",
+		},
+		{
+			name: "pre-release version",
+			out:  "Updated to v3.2.0-rc1. Previous binary saved at /tmp/bak.",
+			want: "v3.2.0-rc1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := upgradeExtractVersion(tt.out)
+			if got != tt.want {
+				t.Fatalf("upgradeExtractVersion(%q) = %q, want %q", tt.out, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpgradeCmd_Registration(t *testing.T) {
+	cmd := Cmd()
+	found := false
+	for _, sub := range cmd.Commands() {
+		if sub.Use == "upgrade" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("upgrade subcommand not registered on contain command")
+	}
+}
+
+// TestDefaultUpgradeEnv_Wiring pins the production dependency wiring. The
+// upgrade orchestration is only as safe as the real operations behind these
+// function values, so an accidentally nil or mis-pointed default would make
+// every injected-dependency test above prove nothing about production.
+func TestDefaultUpgradeEnv_Wiring(t *testing.T) {
+	t.Parallel()
+
+	var buf, errBuf bytes.Buffer
+	env := defaultUpgradeEnv(&buf, &errBuf)
+
+	if env.out != &buf {
+		t.Error("out should be the writer passed in")
+	}
+	if env.errOut != &errBuf {
+		t.Error("errOut should be the errOut writer passed in")
+	}
+	for name, fn := range map[string]any{
+		"stat": env.stat, "lstat": env.lstat, "readFile": env.readFile,
+		"writeFile": env.writeFile, "mkdirAll": env.mkdirAll,
+		"hashFile": env.hashFile, "removeFile": env.removeFile,
+		"runCmd": env.runCmd, "lookupUser": env.lookupUser,
+		"chown": env.chown, "chmod": env.chmod,
+	} {
+		v := reflect.ValueOf(fn)
+		if !v.IsValid() || v.IsNil() {
+			t.Errorf("%s must be wired to a real implementation", name)
+		}
+	}
+	if env.pipelockTarget != defaultPipelockTarget {
+		t.Errorf("pipelockTarget = %q, want the deployed target %q", env.pipelockTarget, defaultPipelockTarget)
+	}
+	if env.integrityPin != defaultIntegrityPin {
+		t.Errorf("integrityPin = %q, want %q", env.integrityPin, defaultIntegrityPin)
+	}
+	if env.serviceName != defaultServiceName {
+		t.Errorf("serviceName = %q, want %q", env.serviceName, defaultServiceName)
+	}
+	if env.readinessTimeout <= 0 {
+		t.Error("readinessTimeout must be positive or readiness waiting cannot work")
+	}
+}
+
+// TestUpgradeCmd_RequiresRoot proves the command refuses to run unprivileged.
+// The test suite runs as an ordinary user, so this exercises the real guard.
+func TestUpgradeCmd_RequiresRoot(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("test must run as a non-root user to exercise the root guard")
+	}
+
+	cmd := upgradeCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected upgrade to refuse to run as a non-root user")
+	}
+	if !strings.Contains(err.Error(), "root") {
+		t.Fatalf("error should name the root requirement, got: %v", err)
+	}
+}
+
+// TestUpgrade_BackupFails_AbortsBeforeTouchingBinary proves the command stops
+// before any replacement when it cannot take a backup.
+func TestUpgrade_BackupFails_AbortsBeforeTouchingBinary(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	original, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make reading the binary for backup fail (but allow pin reads).
+	origReadFile := env.readFile
+	env.readFile = func(path string) ([]byte, error) {
+		if path == env.pipelockTarget {
+			return nil, errors.New("simulated read failure")
+		}
+		return origReadFile(path)
+	}
+
+	var updateInvoked bool
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 && args[0] == "update" {
+			updateInvoked = true
+		}
+		return "", 0, nil
+	}
+
+	if err := runUpgrade(context.Background(), env, upgradeOpts{}); err == nil {
+		t.Fatal("expected error when the backup cannot be taken")
+	}
+	if updateInvoked {
+		t.Error("update must not run when no backup exists; there would be no rollback path")
+	}
+
+	got, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatalf("deployed binary should be untouched: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Error("deployed binary must be unchanged when backup fails")
+	}
+}
+
+// TestUpgrade_RollbackFailure_ReportsBothErrors covers the worst case: the
+// upgrade failed AND the rollback could not fully restore.
+func TestUpgrade_RollbackFailure_ReportsBothErrors(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	env.writeFile = func(path string, contents []byte, mode os.FileMode) error {
+		if path == env.integrityPin {
+			return errors.New("simulated pin restore failure")
+		}
+		return writeFileAtomic(path, contents, mode)
+	}
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 && args[0] == "update" {
+			// Change binary so rollback is needed.
+			_ = writeFileAtomic(env.pipelockTarget, []byte("changed"), 0o755)
+			return "update failed", 1, nil
+		}
+		return "", 0, nil
+	}
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{})
+	if err == nil {
+		t.Fatal("expected an error when both the upgrade and its rollback fail")
+	}
+	if !errors.Is(err, errUpgradeUpdate) {
+		t.Errorf("original failure must survive in the error chain, got: %v", err)
+	}
+	if !errors.Is(err, errUpgradeRollback) {
+		t.Errorf("rollback failure must be reported to the operator, got: %v", err)
+	}
+}
+
+// TestUpgrade_DaemonReloadFails_RollsBack covers the daemon-reload error path.
+func TestUpgrade_DaemonReloadFails_RollsBack(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	newBinary := []byte("new-binary-dr")
+	updateCalled := false
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			if args[0] == "update" && !updateCalled {
+				updateCalled = true
+				_ = writeFileAtomic(env.pipelockTarget, newBinary, 0o755)
+				return "Updated to v9.9.9. Previous binary saved at /tmp/bak", 0, nil
+			}
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "daemon-reload" {
+				return "", 0, fmt.Errorf("exec failed")
+			}
+			return "", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from failed daemon-reload")
+	}
+	if !errors.Is(upgradeErr, errUpgradeRestart) {
+		t.Fatalf("expected errUpgradeRestart, got: %v", upgradeErr)
+	}
+}
+
+// TestUpgrade_DaemonReloadNonZero_RollsBack covers daemon-reload exiting non-zero.
+func TestUpgrade_DaemonReloadNonZero_RollsBack(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	newBinary := []byte("new-binary-drn")
+	updateCalled := false
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			if args[0] == "update" && !updateCalled {
+				updateCalled = true
+				_ = writeFileAtomic(env.pipelockTarget, newBinary, 0o755)
+				return "Updated to v9.9.9. Previous binary saved at /tmp/bak", 0, nil
+			}
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "daemon-reload" {
+				return "failed", 1, nil
+			}
+			return "", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from non-zero daemon-reload")
+	}
+	if !errors.Is(upgradeErr, errUpgradeRestart) {
+		t.Fatalf("expected errUpgradeRestart, got: %v", upgradeErr)
+	}
+}
+
+// TestUpgrade_ReadinessTimeout_RollsBack covers the service never becoming active.
+func TestUpgrade_ReadinessTimeout_RollsBack(t *testing.T) {
+	env := testUpgradeEnv(t)
+	env.readinessTimeout = 200 * time.Millisecond
+
+	newBinary := []byte("new-binary-rt")
+	updateCalled := false
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			if args[0] == "update" && !updateCalled {
+				updateCalled = true
+				_ = writeFileAtomic(env.pipelockTarget, newBinary, 0o755)
+				return "Updated to v9.9.9. Previous binary saved at /tmp/bak", 0, nil
+			}
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "is-active" {
+				return "activating", 3, nil // never becomes active
+			}
+			return "", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from readiness timeout")
+	}
+	if !errors.Is(upgradeErr, errUpgradeRestart) {
+		t.Fatalf("expected errUpgradeRestart, got: %v", upgradeErr)
+	}
+	if !strings.Contains(upgradeErr.Error(), "not ready after") {
+		t.Fatalf("error should mention readiness timeout, got: %v", upgradeErr)
+	}
+}
+
+// TestUpgrade_ContextCancellation_RollsBack covers the ctx.Done() branch in
+// upgradeRestartAndWait. The context is cancelled before the restart command
+// so the select always has ctx.Done() ready on entry — proving the branch
+// fires deterministically rather than relying on Go's random case selection.
+func TestUpgrade_ContextCancellation_RollsBack(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	newBinary := []byte("new-binary-ctx")
+	updateCalled := false
+	ctx, cancel := context.WithCancel(context.Background())
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			if args[0] == "update" && !updateCalled {
+				updateCalled = true
+				_ = writeFileAtomic(env.pipelockTarget, newBinary, 0o755)
+				return "Updated to v9.9.9. Previous binary saved at /tmp/bak", 0, nil
+			}
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "restart" {
+				// Cancel the context after restart succeeds but before
+				// the readiness poll loop runs. The ticker fires every
+				// readinessInterval, so by the time the select runs,
+				// ctx.Done() is already closed.
+				cancel()
+				return "", 0, nil
+			}
+			if len(args) > 0 && args[0] == "is-active" {
+				// Should never be reached — ctx.Done() fires first.
+				t.Error("is-active polled after context cancellation; ctx.Done() branch did not fire")
+				return "active", 0, nil
+			}
+			return "", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(ctx, env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from context cancellation")
+	}
+	if !errors.Is(upgradeErr, errUpgradeRestart) {
+		t.Fatalf("expected errUpgradeRestart, got: %v", upgradeErr)
+	}
+	if !strings.Contains(upgradeErr.Error(), "context canceled") {
+		t.Fatalf("error should mention context cancellation, got: %v", upgradeErr)
+	}
+}
+
+// TestUpgrade_UpdateExecError covers the runCmd transport error in upgradeRunUpdate.
+func TestUpgrade_UpdateExecError(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 && args[0] == "update" {
+			return "", 0, fmt.Errorf("exec: no such file")
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from exec failure")
+	}
+	if !errors.Is(upgradeErr, errUpgradeUpdate) {
+		t.Fatalf("expected errUpgradeUpdate, got: %v", upgradeErr)
+	}
+}
+
+// TestUpgrade_VerifyExecError covers the runCmd transport error in upgradePostVerify.
+func TestUpgrade_VerifyExecError(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	newBinary := []byte("new-binary-ve")
+	updateCalled := false
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			if args[0] == "update" && !updateCalled {
+				updateCalled = true
+				_ = writeFileAtomic(env.pipelockTarget, newBinary, 0o755)
+				return "Updated to v9.9.9. Previous binary saved at /tmp/bak", 0, nil
+			}
+			if len(args) >= 2 && args[0] == "contain" && args[1] == "verify" {
+				return "", 0, fmt.Errorf("exec: signal: killed")
+			}
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "is-active" {
+				return "active", 0, nil
+			}
+			return "", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error from verify exec failure")
+	}
+	if !errors.Is(upgradeErr, errUpgradeVerify) {
+		t.Fatalf("expected errUpgradeVerify, got: %v", upgradeErr)
+	}
+}
+
+// TestUpgrade_VersionForwarded proves opts.version reaches the child process.
+func TestUpgrade_VersionForwarded(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	var capturedArgs []string
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 && args[0] == "update" {
+			capturedArgs = args
+			return "Updated to v3.2.0. Previous binary saved at /tmp/bak", 0, nil
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "is-active" {
+				return "active", 0, nil
+			}
+			return "", 0, nil
+		}
+		if name == env.pipelockTarget && len(args) >= 2 && args[0] == "contain" && args[1] == "verify" {
+			return "Result: 12 PASS / 0 FAIL / 0 SKIP", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{version: "v3.2.0"})
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+
+	found := false
+	for i, a := range capturedArgs {
+		if a == "--version" && i+1 < len(capturedArgs) && capturedArgs[i+1] == "v3.2.0" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("--version v3.2.0 should be forwarded to pipelock update, got args: %v", capturedArgs)
+	}
+}
+
+// TestUpgrade_RollbackRestartFails_ReportsWarning proves the rollback restart
+// warning is emitted to errOut when the best-effort restart fails.
+func TestUpgrade_RollbackRestartFails_ReportsWarning(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	newBinary := []byte("new-binary-rbr")
+	updateCalled := false
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			if args[0] == "update" && !updateCalled {
+				updateCalled = true
+				_ = writeFileAtomic(env.pipelockTarget, newBinary, 0o755)
+				return "Updated to v9.9.9. Previous binary saved at /tmp/bak", 0, nil
+			}
+			if len(args) >= 2 && args[0] == "contain" && args[1] == "verify" {
+				return "[FAIL]", 1, nil
+			}
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "is-active" {
+				return "active", 0, nil
+			}
+			// Restart during rollback fails.
+			if len(args) > 0 && args[0] == "restart" {
+				return "Job failed", 5, nil
+			}
+			return "", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	upgradeErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upgradeErr == nil {
+		t.Fatal("expected error")
+	}
+
+	errOutput := env.errOut.(*bytes.Buffer).String()
+	if !strings.Contains(errOutput, "warning: best-effort restart") {
+		t.Fatalf("expected rollback restart warning in errOut, got: %q", errOutput)
+	}
+}
+
+// TestUpgrade_RepinRestoresProxyOwnership proves the freshly written integrity
+// pin is handed back to the proxy user.
+//
+// This command runs as root, so without the ownership restore the pin is left
+// root-owned. The Pipelock service runs as the proxy user and reads the pin at
+// runtime, so a root-owned pin makes the binary-integrity probe report a
+// mismatch on a completely healthy host. That false mismatch is the exact
+// failure this command exists to eliminate, so getting it wrong here would
+// reintroduce the bug through its own fix.
+func TestUpgrade_RepinRestoresProxyOwnership(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	const wantUID, wantGID = 4242, 4343
+	env.proxyUserName = "pipelock-proxy"
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name != "pipelock-proxy" {
+			return nil, fmt.Errorf("unexpected user %q", name)
+		}
+		return &user.User{Uid: strconv.Itoa(wantUID), Gid: strconv.Itoa(wantGID)}, nil
+	}
+
+	var chownedPath string
+	var chownedUID, chownedGID int
+	env.chown = func(path string, uid, gid int) error {
+		chownedPath, chownedUID, chownedGID = path, uid, gid
+		return nil
+	}
+	var chmodedPath string
+	env.chmod = func(path string, _ os.FileMode) error {
+		chmodedPath = path
+		return nil
+	}
+
+	env.runCmd = successRunCmd(env, []byte("new-binary-content"))
+
+	if err := runUpgrade(context.Background(), env, upgradeOpts{}); err != nil {
+		t.Fatalf("upgrade should succeed: %v", err)
+	}
+
+	if chownedPath != env.integrityPin {
+		t.Errorf("pin ownership not restored: chowned %q, want %q", chownedPath, env.integrityPin)
+	}
+	if chownedUID != wantUID || chownedGID != wantGID {
+		t.Errorf("pin chowned to %d:%d, want the proxy user %d:%d", chownedUID, chownedGID, wantUID, wantGID)
+	}
+	if chmodedPath != env.integrityPin {
+		t.Errorf("pin mode not reasserted: chmoded %q, want %q", chmodedPath, env.integrityPin)
+	}
+}
+
+// TestUpgrade_RepinOwnershipFailure_FailsClosed proves an ownership failure is
+// reported rather than silently leaving an unreadable pin behind.
+func TestUpgrade_RepinOwnershipFailure_FailsClosed(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	env.proxyUserName = "pipelock-proxy"
+	env.lookupUser = func(string) (*user.User, error) {
+		return nil, errors.New("no such user")
+	}
+	env.chown = func(string, int, int) error { return nil }
+	env.chmod = func(string, os.FileMode) error { return nil }
+	env.runCmd = successRunCmd(env, []byte("new-binary-content"))
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{})
+	if err == nil {
+		t.Fatal("expected an error when the pin owner cannot be resolved")
+	}
+	if !errors.Is(err, errUpgradeRepin) {
+		t.Fatalf("expected errUpgradeRepin, got: %v", err)
+	}
+}
+
+// TestUpgrade_RollbackRestoresPinOwnership proves the ROLLBACK path hands the
+// pin back to the proxy user, not just its contents.
+//
+// The forward path already does this. Restoring the bytes without the
+// ownership would leave a rolled-back host with a root-owned pin that the
+// proxy service cannot read, so it would report a false integrity mismatch --
+// the exact failure this command exists to eliminate, reintroduced through its
+// own recovery path.
+func TestUpgrade_RollbackRestoresPinOwnership(t *testing.T) {
+	env := testUpgradeEnv(t)
+
+	const wantUID, wantGID = 4242, 4343
+	env.proxyUserName = "pipelock-proxy"
+	env.lookupUser = func(string) (*user.User, error) {
+		return &user.User{Uid: strconv.Itoa(wantUID), Gid: strconv.Itoa(wantGID)}, nil
+	}
+
+	oldPin, readErr := os.ReadFile(env.integrityPin)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	// Record an ORDERED event log. Asserting only "the pin was chowned" is
+	// vacuous here, because the forward re-pin chowns the same path earlier in
+	// the same run, so that assertion passes even with the rollback ownership
+	// restore removed entirely (verified: it did). What must be proven is that
+	// a chown follows the rollback's pin RESTORE specifically.
+	var events []string
+	origWrite := env.writeFile
+	env.writeFile = func(path string, contents []byte, mode os.FileMode) error {
+		if path == env.integrityPin {
+			if bytes.Equal(contents, oldPin) {
+				events = append(events, "restore-pin")
+			} else {
+				events = append(events, "repin")
+			}
+		}
+		return origWrite(path, contents, mode)
+	}
+	env.chown = func(path string, uid, gid int) error {
+		if path == env.integrityPin && uid == wantUID && gid == wantGID {
+			events = append(events, "chown-pin")
+		}
+		return nil
+	}
+	env.chmod = func(string, os.FileMode) error { return nil }
+
+	// Fail AFTER the re-pin so the rollback path runs.
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			if args[0] == "update" {
+				_ = writeFileAtomic(env.pipelockTarget, []byte("new-binary-content"), 0o755)
+				return "Updated to v9.9.9.", 0, nil
+			}
+			if len(args) >= 2 && args[0] == "contain" && args[1] == "verify" {
+				return "Result: 11 PASS / 1 FAIL", 1, nil
+			}
+		}
+		if name == "systemctl" && len(args) > 0 && args[0] == "is-active" {
+			return "active", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	upErr := runUpgrade(context.Background(), env, upgradeOpts{})
+	if upErr == nil {
+		t.Fatal("expected the upgrade to fail so the rollback path runs")
+	}
+	if !errors.Is(upErr, errUpgradeVerify) {
+		t.Fatalf("expected errUpgradeVerify, got: %v", upErr)
+	}
+
+	restoreAt := -1
+	for i, e := range events {
+		if e == "restore-pin" {
+			restoreAt = i
+		}
+	}
+	if restoreAt < 0 {
+		t.Fatalf("rollback never restored the pin; events = %v", events)
+	}
+	chownedAfterRestore := false
+	for _, e := range events[restoreAt+1:] {
+		if e == "chown-pin" {
+			chownedAfterRestore = true
+		}
+	}
+	if !chownedAfterRestore {
+		t.Errorf("rollback restored the pin but never handed it back to the proxy user; events = %v", events)
+	}
+}


### PR DESCRIPTION
## What changed

Adds `pipelock contain upgrade`, a single fail-closed command that closes the gap between updating the Pipelock binary and the containment integrity pin.

Today those are separate lifecycles. An ordinary successful update replaces the deployed binary but leaves the integrity pin stale, so the binary-integrity probe then reports a mismatch on a host that is actually healthy. That is an availability failure with a real cost: an operator who learns the verifier cries wolf stops trusting it, and a control nobody trusts is a control nobody runs.

The command verifies and installs the candidate by invoking the deployed binary's update path, re-pins the integrity hash against the newly deployed binary, restarts the service, waits for readiness, and requires a passing `contain verify`. Any failure after binary replacement restores both the previous binary and its previous pin, then best-effort restarts the service.

## Which artifact is verified

Release-signature verification is performed by the deployed binary, not by whichever copy the operator invokes the command from.

There is deliberately no invoker-side release-keyring preflight. Such a check would inspect the keyring compiled into the invoking binary and then hand the actual verified update to a different binary, so it would decide about one artifact while the consequence landed on another. It fails in both directions: a custom or release-candidate copy with no keyring would refuse a legitimate upgrade of a perfectly healthy deployed binary, and a good invoker keyring says nothing about the trust root the deployed updater actually uses. The deployed updater already verifies its release manifest fail-closed, so removing that preflight loses no verification.

A build with no embedded release keyring cannot verify a release, so its update step refuses. Recovering such a host still goes through `contain install --pipelock-binary` after independent signature, checksum, and attestation verification, and the documentation says so.

## Rollback reporting

A rollback failure is reported rather than swallowed. An operator told only that the upgrade failed would reasonably assume the previous state was restored; when the restore itself failed, that assumption is wrong and the host needs attention. In that case the pre-upgrade backup is deliberately retained so the manual recovery path still exists, and its location is named in the error.

## Tests

Covers each fail-closed step and its rollback, including the case where the upgrade and its rollback both fail, the refusal to proceed when no backup could be taken, and the non-root guard. Tests are hermetic against temporary directories and never touch a real service or system path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `pipelock contain upgrade` command for securely upgrading containment components.
  * Verifies downloads, integrity, service readiness, and containment after upgrading.
  * Requires root access and supports automatic rollback when upgrade steps fail.
  * Added command options, examples, and exit code documentation.

* **Bug Fixes**
  * Failed upgrades restore the previous binary and integrity settings when possible.

* **Tests**
  * Added comprehensive coverage for successful upgrades, failures, rollback, verification, and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->