### PR TITLE
fix(release): bind release verification to one tag predicate and exact identity

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -147,10 +147,13 @@ runs:
         if [ -s "$COSIGN_SIG" ] && [ -s "$COSIGN_PEM" ]; then
           if command -v cosign &>/dev/null; then
             echo "Verifying cosign signature..."
+            # Bind the certificate to the exact release whose assets were
+            # downloaded. Accepting any valid-looking release tag here would
+            # prove the signer ran for some release, not necessarily this one.
             if ! cosign verify-blob \
               --certificate "$COSIGN_PEM" \
               --signature "$COSIGN_SIG" \
-              --certificate-identity-regexp "^https://github\\.com/luckyPipewrench/pipelock/\\.github/workflows/release\\.yaml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$" \
+              --certificate-identity "https://github.com/luckyPipewrench/pipelock/.github/workflows/release.yaml@refs/tags/v${VERSION}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               "${INSTALL_DIR}/checksums.txt"; then
               echo "::error::Cosign signature verification failed for checksums.txt"

--- a/internal/cli/selfupdate/errorpath_test.go
+++ b/internal/cli/selfupdate/errorpath_test.go
@@ -41,6 +41,29 @@ func TestFetchRelease_MissingTag(t *testing.T) {
 	}
 }
 
+func TestFetchRelease_InvalidProductTag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.3+build.1","assets":[]}`))
+	}))
+	defer srv.Close()
+	opts := &Options{APIBase: srv.URL, HTTPClient: srv.Client(), TargetPath: writeTargetBinary(t, "x")}
+	_ = opts.fillDefaults()
+	// Assert the sentinel rather than the message text: callers distinguish a
+	// malformed-metadata failure from a transport or signature failure with
+	// errors.Is, and matching on wording would pass even if the error class
+	// were wrong.
+	_, err := opts.fetchRelease(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for a tag that is not a product release tag")
+	}
+	if !errors.Is(err, ErrInvalidReleaseTag) {
+		t.Fatalf("expected ErrInvalidReleaseTag, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "v1.2.3+build.1") {
+		t.Errorf("error should name the offending tag so an operator can see it, got %v", err)
+	}
+}
+
 func TestFetchRelease_HTTPStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/cli/selfupdate/update.go
+++ b/internal/cli/selfupdate/update.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	releasetrust "github.com/luckyPipewrench/pipelock/internal/release"
 )
 
@@ -95,6 +96,12 @@ var (
 	ErrSignatureUnavailable = errors.New("publisher signature verification unavailable")
 	// ErrUnsupportedPlatform is returned for an OS/arch with no published asset.
 	ErrUnsupportedPlatform = errors.New("no release asset for this OS/architecture")
+	// ErrInvalidReleaseTag is returned when release metadata carries a tag that
+	// is not a valid Pipelock product release tag. Callers distinguish this from
+	// a transport or signature failure: it means the metadata itself is
+	// malformed or does not describe a product release, so no asset from it
+	// should be trusted.
+	ErrInvalidReleaseTag = errors.New("release metadata tag is not a valid product release tag")
 	// ErrAssetNotFound is returned when the release has no matching archive asset.
 	ErrAssetNotFound = errors.New("release asset not found")
 	// ErrNotWritable is returned when the target binary or its directory is not
@@ -284,6 +291,9 @@ func (o *Options) fetchRelease(ctx context.Context) (*release, error) {
 	}
 	if rel.TagName == "" {
 		return nil, errors.New("release metadata missing tag_name")
+	}
+	if !cliutil.IsProductReleaseTag(rel.TagName) {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidReleaseTag, rel.TagName)
 	}
 	return &rel, nil
 }

--- a/internal/cliutil/version.go
+++ b/internal/cliutil/version.go
@@ -5,6 +5,7 @@ package cliutil
 
 import (
 	"fmt"
+	"regexp"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -14,7 +15,27 @@ import (
 const (
 	defaultVersion       = "0.0.0-dev.unknown"
 	sourceRevisionLength = 12
+
+	// MaxProductReleaseVersionLength is the OCI/Docker tag limit after removing v.
+	MaxProductReleaseVersionLength = 128
 )
+
+// ProductReleaseTagPattern is the canonical regular expression for a valid
+// pipelock product release tag. It accepts v-prefixed SemVer with an optional
+// prerelease suffix and NO build metadata ('+' is invalid in an OCI/Docker tag).
+// The shell copy in check-release-ready.sh cannot import Go, so a parity test
+// (TestProductReleaseTag_ParityWithReleaseSurfaces) fails CI if it diverges.
+const ProductReleaseTagPattern = `^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?$`
+
+// productReleaseTagRE is the compiled form of [ProductReleaseTagPattern].
+var productReleaseTagRE = regexp.MustCompile(ProductReleaseTagPattern)
+
+// IsProductReleaseTag reports whether tag is a valid pipelock product release
+// tag: vMAJOR.MINOR.PATCH with an optional SemVer prerelease suffix and no
+// build metadata. The v-stripped value is capped at the OCI/Docker tag limit.
+func IsProductReleaseTag(tag string) bool {
+	return len(tag) <= MaxProductReleaseVersionLength+1 && productReleaseTagRE.MatchString(tag)
+}
 
 // Build metadata, set at build time via ldflags. Defaults are used when
 // building with plain "go build" (without the Makefile).

--- a/internal/cliutil/version_test.go
+++ b/internal/cliutil/version_test.go
@@ -4,8 +4,11 @@
 package cliutil
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -281,6 +284,139 @@ func TestResolveVersionFromBuildInfoKeepsLDFLagsVersion(t *testing.T) {
 	if got := DisplayVersion(); got != "v9.9.9" {
 		t.Fatalf("DisplayVersion() = %q, want v9.9.9", got)
 	}
+}
+
+func TestIsProductReleaseTag(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want bool
+	}{
+		// Valid final releases
+		{"v0.0.0", true},
+		{"v1.2.3", true},
+		{"v10.20.30", true},
+		{"v3.2.0", true},
+
+		// Valid prereleases (the exact case that was broken: preflight passes, cosign must too)
+		{"v3.2.0-rc1", true},
+		{"v3.2.0-alpha.1", true},
+		{"v3.2.0-0.3.7", true},
+		{"v1.0.0-beta.11", true},
+		{"v1.0.0-x.7.z.92", true},
+		{"v1.2.3-" + strings.Repeat("a", 122), true}, // 128 chars after stripping v
+
+		// Invalid: build metadata (+ is invalid in OCI tags)
+		{"v1.2.3+build", false},
+		{"v1.2.3-rc1+meta", false},
+		{"v1.2.3-" + strings.Repeat("a", 123), false}, // exceeds OCI tag limit
+
+		// Invalid: missing v prefix
+		{"1.2.3", false},
+
+		// Invalid: leading zeros
+		{"v01.2.3", false},
+		{"v1.02.3", false},
+		{"v1.2.03", false},
+
+		// Invalid: too few/many segments
+		{"v1.2", false},
+		{"v1.2.3.4", false},
+
+		// Invalid: non-product prefixes
+		{"verifier-v0.2.0", false},
+
+		// Invalid: misc
+		{"", false},
+		{"v", false},
+		{"vx.y.z", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			if got := IsProductReleaseTag(tt.tag); got != tt.want {
+				t.Fatalf("IsProductReleaseTag(%q) = %v, want %v", tt.tag, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestProductReleaseTag_PrereleaseAccepted guards the release-policy decision
+// that prerelease tags are valid product releases.
+func TestProductReleaseTag_PrereleaseAccepted(t *testing.T) {
+	prereleases := []string{"v3.2.0-rc1", "v1.0.0-alpha.1", "v2.0.0-beta.2"}
+
+	for _, tag := range prereleases {
+		t.Run(tag, func(t *testing.T) {
+			if !IsProductReleaseTag(tag) {
+				t.Fatalf("IsProductReleaseTag(%q) = false; prerelease must pass release policy", tag)
+			}
+		})
+	}
+}
+
+// TestProductReleaseTag_ParityWithReleaseSurfaces binds the shell format/length
+// guards to Go and requires the Action to verify the exact downloaded tag.
+func TestProductReleaseTag_ParityWithReleaseSurfaces(t *testing.T) {
+	// Locate repo root from the test file's package path.
+	// internal/cliutil -> ../../ is the repo root.
+	root := filepath.Join("..", "..")
+	findLines := func(content, prefix string) []string {
+		var matches []string
+		for _, line := range strings.Split(content, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, prefix) {
+				matches = append(matches, trimmed)
+			}
+		}
+		return matches
+	}
+
+	t.Run("check-release-ready.sh", func(t *testing.T) {
+		path := filepath.Join(root, "scripts", "check-release-ready.sh")
+		data, err := os.ReadFile(path) // #nosec G304 -- path is a compile-time constant relative to the repo root
+		if err != nil {
+			t.Fatalf("reading check-release-ready.sh: %v", err)
+		}
+		content := string(data)
+		const patternMarker = "release_tag_re='"
+		start := strings.Index(content, patternMarker)
+		if start < 0 {
+			t.Fatal("check-release-ready.sh does not assign release_tag_re")
+		}
+		rest := content[start+len(patternMarker):]
+		end := strings.IndexByte(rest, '\'')
+		if end < 0 {
+			t.Fatal("check-release-ready.sh has an unterminated release_tag_re")
+		}
+		if got := rest[:end]; got != ProductReleaseTagPattern {
+			t.Fatalf("check-release-ready.sh release_tag_re diverges from canonical.\n  got:  %s\n  want: %s", got, ProductReleaseTagPattern)
+		}
+
+		wantMax := "max_product_release_version_length=" + strconv.Itoa(MaxProductReleaseVersionLength)
+		if got := findLines(content, "max_product_release_version_length="); len(got) != 1 || got[0] != wantMax {
+			t.Fatalf("check-release-ready.sh OCI length assignment diverges: got %q, want [%q]", got, wantMax)
+		}
+		const lengthGuard = `if [ "${#VER}" -gt "$max_product_release_version_length" ]; then`
+		if got := findLines(content, `if [ "${#VER}" -gt `); len(got) != 1 || got[0] != lengthGuard {
+			t.Fatalf("check-release-ready.sh OCI length guard diverges: got %q, want [%q]", got, lengthGuard)
+		}
+	})
+
+	t.Run("action.yml exact cosign identity", func(t *testing.T) {
+		path := filepath.Join(root, "action.yml")
+		data, err := os.ReadFile(path) // #nosec G304 -- path is a compile-time constant relative to the repo root
+		if err != nil {
+			t.Fatalf("reading action.yml: %v", err)
+		}
+		content := string(data)
+		const want = `--certificate-identity "https://github.com/luckyPipewrench/pipelock/.github/workflows/release.yaml@refs/tags/v${VERSION}" \`
+		if got := findLines(content, `--certificate-identity `); len(got) != 1 || got[0] != want {
+			t.Fatalf("action.yml exact cosign identity diverges: got %q, want [%q]", got, want)
+		}
+		if strings.Contains(content, "--certificate-identity-regexp") {
+			t.Fatal("action.yml still uses a broad cosign certificate identity regexp")
+		}
+	})
 }
 
 func TestSourceVersionFromBuildSettingsArtifactSafety(t *testing.T) {

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -33,6 +33,7 @@ fi
 # floating pointers like v2, but still admits v1.2.3.4 and v3.2.0+build.1), so a
 # malformed tag fails closed BEFORE anything is built or pushed.
 release_tag_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?$'
+max_product_release_version_length=128
 if ! printf '%s\n' "$VERSION" | grep -qE "$release_tag_re"; then
   echo "check-release-ready: tag '$VERSION' must be vMAJOR.MINOR.PATCH[-prerelease] with no build metadata" >&2
   exit 2
@@ -43,7 +44,7 @@ VER="${VERSION#v}" # strip leading v -> bare semver used in CHANGELOG/Chart and 
 # The v-stripped version is used verbatim as an OCI/Docker image tag, which is
 # capped at 128 characters; a longer tag passes the format check above yet fails
 # only once container publishing begins.
-if [ "${#VER}" -gt 128 ]; then
+if [ "${#VER}" -gt "$max_product_release_version_length" ]; then
   echo "check-release-ready: tag '$VERSION' exceeds the 128-character OCI image-tag limit" >&2
   exit 2
 fi


### PR DESCRIPTION
## What changed

The release path carried several independent opinions of what a valid product tag is, and they disagreed. The composite action accepted only a final `vMAJOR.MINOR.PATCH` signing identity while the release readiness gate deliberately admits prereleases, so a prerelease tag passed the gate and then failed signature verification later, in consumers, after publishing had already started.

This adds one canonical product-tag predicate in `cliutil` and has the release surfaces consult it. The predicate is strict SemVer with a mandatory leading `v`, an optional prerelease, no build metadata, no leading zeros, and the OCI 128-character tag limit, so a tag cannot pass the gate and then prove unusable as a container tag. The updater is now a real consumer and rejects malformed release metadata before using any asset. Parity tests extract the live shell assignment and the actual action arguments, so text that merely matches somewhere else in those files cannot satisfy them.

## Signing identity

The action now verifies the certificate identity for the exact downloaded tag rather than matching any permitted product tag with a regular expression.

This is strictly narrower than what it replaces. Previously a certificate issued for any release tag satisfied verification of any other; now the identity names the requested tag directly, so cross-tag substitution is no longer accepted. It also removes the reason to widen the accepted identity in order to support pinning a release candidate, because a pinned prerelease is verified against its own tag rather than through a broadened pattern.

## Remaining surfaces

The release workflow trigger stays a deliberately coarse routing prefilter and is not an authorization predicate; the readiness gate behind it makes the real decision. Local version discovery in `git-version.sh` and the bundle-version parser in the rules package answer different questions about different subjects and are intentionally not bound to this predicate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Release verification now requires an exact match between the certificate identity and the downloaded release tag.

* **Bug Fixes**
  * Invalid or unsupported release tags are rejected during self-update.
  * Release tags with build metadata are no longer accepted.

* **Validation**
  * Release tags consistently enforce SemVer formatting, prerelease support, and the 128-character limit across release workflows.
  * Validation rules are aligned across command-line and release tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->