### PR TITLE
fix(diag): report the exact artifact MCP integrity probes verify

### DIFF
--- a/docs/cli/verify-install.md
+++ b/docs/cli/verify-install.md
@@ -41,8 +41,8 @@ Scanning and local enforcement checks:
 | `scanning_websocket` | WebSocket frame scanning catches a hostile text frame. |
 | `browser_shield` | Browser Shield rewrites shieldable browser content. |
 | `file_sentry` | file_sentry detects a secret written to a watched workspace. |
-| `mcp_binary_integrity_smoke` | MCP binary-integrity manifest loading and hash verification work. |
-| `mcp_tool_provenance_smoke` | MCP tool-provenance signing and verification work offline. |
+| `mcp_binary_integrity_smoke` | MCP binary-integrity manifest loading and hash verification work against the current Pipelock executable. It uses that executable's configured entry when present, otherwise an ephemeral self-test entry. This does not verify configured MCP server binaries. |
+| `mcp_tool_provenance_smoke` | MCP tool-provenance signing and verification work offline using a synthetic tool and ephemeral key. This does not verify upstream tools. |
 
 Containment checks:
 

--- a/internal/cli/diag/verify_install.go
+++ b/internal/cli/diag/verify_install.go
@@ -692,27 +692,61 @@ func checkMCPBinaryIntegrity(env *VerifyEnv) VerifyResult {
 	if err != nil {
 		return VerifyResult{Status: verifyStatusFail, Detail: fmt.Sprintf("resolving current executable: %v", err)}
 	}
-	result, err := mcpintegrity.Verify([]string{exe}, &mcpintegrity.Config{Manifests: manifest.Entries}, "")
+	resolved, err := mcpintegrity.Resolve([]string{exe}, "")
+	if err != nil {
+		return VerifyResult{Status: verifyStatusFail, Detail: fmt.Sprintf("hashing current executable for MCP binary integrity self-test: %v", err)}
+	}
+	_, subjectInManifest := manifest.Entries[resolved.ResolvedPath]
+	verifyEntries := manifest.Entries
+	manifestMatch := "not_tested"
+	if !subjectInManifest {
+		// A real MCP manifest normally contains server binaries, not Pipelock.
+		// Use an in-memory entry to exercise the hash comparison without
+		// pretending the configured manifest made a claim about this subject.
+		verifyEntries = map[string]string{resolved.ResolvedPath: resolved.ActualHash}
+	}
+	result, err := mcpintegrity.Verify([]string{exe}, &mcpintegrity.Config{Manifests: verifyEntries}, "")
 	if err != nil {
 		return VerifyResult{Status: verifyStatusFail, Detail: fmt.Sprintf("resolving MCP binary integrity probe: %v", err)}
+	}
+	if subjectInManifest {
+		manifestMatch = fmt.Sprintf("%t", result.Verified)
 	}
 	hashPrefix := result.ActualHash
 	if len(hashPrefix) > 12 {
 		hashPrefix = hashPrefix[:12]
 	}
-	manifestMatch := fmt.Sprintf("%t", result.Verified)
-	detail := "MCP binary integrity manifest parsed and binary hash path succeeded"
-	if result.Verified {
-		detail = "MCP binary integrity smoke target verified against manifest"
+	evidence := map[string]string{
+		"manifest_entries":               fmt.Sprintf("%d", len(manifest.Entries)),
+		"manifest_match":                 manifestMatch,
+		"smoke_match":                    fmt.Sprintf("%t", result.Verified),
+		"subject_in_configured_manifest": fmt.Sprintf("%t", subjectInManifest),
+		"hash_prefix":                    hashPrefix,
+		"verified_artifact":              result.ResolvedPath,
+	}
+	if !result.Verified {
+		detail := fmt.Sprintf("Pipelock executable self-test mismatch: actual %s does not match manifest entry", hashPrefix)
+		if result.ExpectedHash != "" {
+			expected := result.ExpectedHash
+			if len(expected) > 12 {
+				expected = expected[:12]
+			}
+			detail = fmt.Sprintf("Pipelock executable self-test mismatch: actual %s vs manifest %s", hashPrefix, expected)
+		}
+		return VerifyResult{
+			Status:   verifyStatusFail,
+			Detail:   detail,
+			Evidence: evidence,
+		}
+	}
+	detail := "MCP binary-integrity mechanism verified against the current Pipelock executable using an ephemeral self-test entry; the configured manifest did not list this executable, and configured MCP servers were not checked"
+	if subjectInManifest {
+		detail = "MCP binary-integrity mechanism verified the current Pipelock executable against its configured manifest entry; configured MCP servers were not checked"
 	}
 	return VerifyResult{
-		Status: verifyStatusPass,
-		Detail: detail,
-		Evidence: map[string]string{
-			"manifest_entries": fmt.Sprintf("%d", len(manifest.Entries)),
-			"manifest_match":   manifestMatch,
-			"hash_prefix":      hashPrefix,
-		},
+		Status:   verifyStatusPass,
+		Detail:   detail,
+		Evidence: evidence,
 	}
 }
 
@@ -755,10 +789,11 @@ func checkMCPToolProvenance(env *VerifyEnv) VerifyResult {
 	}
 	return VerifyResult{
 		Status: verifyStatusPass,
-		Detail: "MCP tool provenance signed and verified offline",
+		Detail: "MCP tool-provenance mechanism verified with a synthetic local tool and ephemeral key; upstream tools were not checked",
 		Evidence: map[string]string{
-			"mode":   provenance.ModePipelock,
-			"status": result.Status,
+			"mode":             provenance.ModePipelock,
+			"status":           result.Status,
+			"verified_subject": "synthetic_local_tool",
 		},
 	}
 }

--- a/internal/cli/diag/verify_install_test.go
+++ b/internal/cli/diag/verify_install_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	mcpintegrity "github.com/luckyPipewrench/pipelock/internal/mcp/integrity"
+
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -753,8 +755,85 @@ func TestCheckMCPBinaryIntegrity_Pass(t *testing.T) {
 	if r.Status != verifyStatusPass {
 		t.Errorf("expected pass for MCP binary integrity smoke, got %s: %s", r.Status, r.Detail)
 	}
-	if r.Evidence["manifest_entries"] == "" || r.Evidence["hash_prefix"] == "" {
+	if r.Evidence["manifest_entries"] == "" || r.Evidence["hash_prefix"] == "" || r.Evidence["verified_artifact"] == "" {
 		t.Errorf("expected MCP binary integrity evidence, got %+v", r.Evidence)
+	}
+	if !strings.Contains(r.Detail, "current Pipelock executable") || !strings.Contains(r.Detail, "configured MCP servers were not checked") {
+		t.Errorf("expected exact smoke-test subject in detail, got %q", r.Detail)
+	}
+	if r.Evidence["subject_in_configured_manifest"] != "true" || r.Evidence["manifest_match"] != "true" {
+		t.Errorf("expected configured self entry to be verified, got %+v", r.Evidence)
+	}
+}
+
+func TestCheckMCPBinaryIntegrity_PassWhenConfiguredManifestDoesNotListSelf(t *testing.T) {
+	env := testScanEnv(t)
+	manifestPath := filepath.Join(t.TempDir(), "mcp-integrity-server-only.json")
+	manifest := &mcpintegrity.Manifest{
+		Version: mcpintegrity.ManifestVersion,
+		Entries: map[string]string{
+			"/opt/mcp/example-server": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		},
+	}
+	if err := mcpintegrity.SaveManifest(manifestPath, manifest); err != nil {
+		t.Fatalf("SaveManifest: %v", err)
+	}
+	env.Cfg.MCPBinaryIntegrity.ManifestPath = manifestPath
+
+	r := checkMCPBinaryIntegrity(env)
+	if r.Status != verifyStatusPass {
+		t.Fatalf("expected mechanism self-test to pass when configured manifest does not list Pipelock, got %s: %s", r.Status, r.Detail)
+	}
+	if r.Evidence["subject_in_configured_manifest"] != "false" || r.Evidence["manifest_match"] != "not_tested" {
+		t.Errorf("configured manifest claim overstated: %+v", r.Evidence)
+	}
+	if r.Evidence["smoke_match"] != "true" || !strings.Contains(r.Detail, "ephemeral self-test entry") {
+		t.Errorf("expected explicit ephemeral self-test evidence, got detail=%q evidence=%+v", r.Detail, r.Evidence)
+	}
+}
+
+func TestCheckMCPBinaryIntegrity_HashMismatch(t *testing.T) {
+	env := testScanEnv(t)
+
+	// Overwrite the manifest with a bogus hash so Verify returns Verified=false.
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	resolved, err := mcpintegrity.Resolve([]string{exe}, "")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	bogusManifest := &mcpintegrity.Manifest{
+		Version: mcpintegrity.ManifestVersion,
+		Entries: map[string]string{
+			resolved.ResolvedPath: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		},
+	}
+	manifestPath := filepath.Join(t.TempDir(), "mcp-integrity-bad.json")
+	if err := mcpintegrity.SaveManifest(manifestPath, bogusManifest); err != nil {
+		t.Fatalf("SaveManifest: %v", err)
+	}
+	env.Cfg.MCPBinaryIntegrity.ManifestPath = manifestPath
+
+	r := checkMCPBinaryIntegrity(env)
+	if r.Status != verifyStatusFail {
+		t.Errorf("expected fail for hash mismatch, got %s: %s", r.Status, r.Detail)
+	}
+	if r.Evidence["manifest_match"] != "false" {
+		t.Errorf("expected manifest_match=false, got %q", r.Evidence["manifest_match"])
+	}
+	// Assert the smoke result too. Without this a regression could report a
+	// failing status alongside smoke_match=true, which is the shape an operator
+	// most easily misreads: a green-looking sub-field next to a red verdict.
+	if r.Evidence["smoke_match"] != "false" {
+		t.Errorf("expected smoke_match=false on the mismatch path, got %q", r.Evidence["smoke_match"])
+	}
+	if r.Evidence["verified_artifact"] != resolved.ResolvedPath {
+		t.Errorf("verified_artifact = %q, want %q", r.Evidence["verified_artifact"], resolved.ResolvedPath)
+	}
+	if !strings.Contains(r.Detail, "mismatch") {
+		t.Errorf("expected detail to mention mismatch, got %q", r.Detail)
 	}
 }
 
@@ -784,6 +863,12 @@ func TestCheckMCPToolProvenance_Pass(t *testing.T) {
 	}
 	if r.Evidence["status"] != "verified" {
 		t.Errorf("expected verified provenance evidence, got %+v", r.Evidence)
+	}
+	if r.Evidence["verified_subject"] != "synthetic_local_tool" {
+		t.Errorf("expected synthetic verified subject, got %+v", r.Evidence)
+	}
+	if !strings.Contains(r.Detail, "synthetic local tool") || !strings.Contains(r.Detail, "upstream tools were not checked") {
+		t.Errorf("expected exact smoke-test subject in detail, got %q", r.Detail)
 	}
 }
 

--- a/internal/cli/runtime/mcp_integrity.go
+++ b/internal/cli/runtime/mcp_integrity.go
@@ -42,9 +42,11 @@ func mcpIntegrityCmd() *cobra.Command {
 		Short: "MCP binary integrity manifest tooling",
 		Long: `Generate and verify the manifest consumed by mcp_binary_integrity.
 
-The manifest pins the resolved binary path Pipelock will spawn. For interpreter
-commands, it also pins the resolved script path so wrapper enforcement can catch
-both interpreter replacement and script drift before launch.`,
+The manifest records the resolved binary path and hash observed at check time.
+For interpreter commands, it also records the resolved script path so wrapper
+enforcement can detect interpreter replacement and script drift. Note that the
+MCP launcher later executes by pathname, so the manifest does not guarantee
+the spawned artifact is identical to the one hashed.`,
 	}
 	cmd.AddCommand(mcpIntegrityManifestCmd())
 	return cmd

--- a/internal/mcp/integrity/integrity.go
+++ b/internal/mcp/integrity/integrity.go
@@ -1,17 +1,20 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-// Package integrity provides pre-spawn binary hash verification for MCP
-// subprocess servers. It resolves symlinks and interpreter shebangs,
-// hashes the actual binary (and script when an interpreter is detected),
-// and compares against a trusted manifest. A second symlink resolution at
-// exec time detects symlink swaps between hash-time and exec-time.
+// Package integrity provides binary hash verification for MCP subprocess
+// servers. It resolves symlinks and interpreter shebangs, hashes the
+// actual binary (and script when an interpreter is detected), and
+// compares against a trusted manifest.
 //
-// NOTE: CheckSymlinkRace detects symlink target changes (path identity)
-// but does NOT detect in-place content replacement after hashing. Full
-// TOCTOU prevention would require fexecve-style fd binding, which Go's
-// os/exec does not support. The gap is documented here and in
-// CheckSymlinkRace so operators understand the threat model.
+// The manifest records the resolved path and hash observed at check time.
+// It does not guarantee the identical artifact is the one eventually
+// spawned, because the MCP launcher later executes by pathname.
+// CheckSymlinkRace can detect symlink target changes (path identity)
+// between hash-time and exec-time, but it currently has no production
+// callers — it is tested and available, not wired into the launch path.
+// In-place content replacement after hashing is not detected by any
+// current mechanism; full TOCTOU prevention would require fexecve-style
+// fd binding, which Go's os/exec does not expose.
 package integrity
 
 import (
@@ -394,11 +397,15 @@ func ResolveAndHash(binary string) (resolvedPath, hash string, err error) {
 // path resolved at hash time. Returns an error if they differ, indicating
 // a symlink swap between hash-time and exec-time.
 //
-// NOTE: This checks path identity (symlink target stability), not content
+// NOTE: This function currently has no production callers — it is tested
+// and available but not wired into the MCP launch path. Wiring it in is
+// tracked separately.
+//
+// This checks path identity (symlink target stability), not content
 // identity. A file whose contents are replaced in-place after hashing
 // will not be detected by this check. Full TOCTOU prevention would
 // require opening the file by fd and using fexecve, which Go's os/exec
-// does not expose. This is a known limitation of the threat model.
+// does not expose.
 func CheckSymlinkRace(originalCommand string, expectedResolved string) error {
 	current, err := resolveBinary(originalCommand)
 	if err != nil {


### PR DESCRIPTION
## What changed

The MCP binary-integrity health probe returned PASS even when its own verification failed, recording the mismatch only as an evidence field. A diagnostic that reports PASS while the binary does not match its manifest is a false health result, so a configured mismatch now fails.

The probe also verified the Pipelock executable rather than any configured MCP server, while reporting under a name an operator would reasonably read as covering their servers. It now names the exact verified artifact, states plainly that configured MCP servers were not checked, and uses a configured manifest entry only when that entry actually names Pipelock. When the manifest legitimately lists only MCP server binaries, the probe runs an explicitly labelled ephemeral self-test and reports the configured match as not tested, rather than raising a false mismatch that would train operators to ignore the check.

The tool-provenance probe now states that it verifies a synthetic local tool with an ephemeral key and does not check upstream tools.

## Corrected claims

Two operator-facing texts described protection the code does not provide. The manifest records the resolved path and hash observed at check time; it does not guarantee the same artifact is the one spawned, because the launcher resolves the command again at launch. The symlink-race helper is now noted as having no production caller, so the next reader is not misled about what runs today.

Closing that gap properly needs the launcher to execute the artifact it verified rather than re-resolving a pathname, which is separate work. This PR makes the claims match the behavior; it does not change the launch path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP installation verification to validate the currently resolved executable and report hash mismatches.
  * Added clearer results when an executable is absent from the configured manifest.
  * Clarified tool-provenance checks, including their verification scope and use of a synthetic local tool.

* **Documentation**
  * Expanded guidance on executable selection, hash verification, resolved paths, and artifact identity.
  * Documented the scope and limitations of symlink-race detection and provenance checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->