### PR TITLE
fix(metrics): cap current_ael at the honestly-earned ceiling

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2481,7 +2481,7 @@ dashboard_snapshot:
 | `completeness.heartbeat_interval` | `60s` | Restart-only interval for signed session heartbeat records. Must parse as a positive duration and be no more than 24h. |
 | `evidence_health.enabled` | `true` | Enable observability-only evidence health grading and `/stats` evidence-health output. This does not gate traffic. |
 | `evidence_health.self_audit_interval` | `30s` | Evidence self-audit interval. Must be between 5s and 10m. |
-| `evidence_health.max_anchor_lag` | `24h` | Maximum accepted age/lag window for anchor freshness reporting. A stale or missing anchor lowers the reported grade; it cannot fabricate health. |
+| `evidence_health.max_anchor_lag` | `24h` | Maximum accepted age/lag window for anchor freshness reporting. A stale or missing anchor lowers the `anchoring_fresh` health diagnostic; anchoring does not raise `current_ael` above the single-recorder ceiling. |
 | `anchor.rekor_url` | (empty) | Rekor v1 base URL. Setting it activates the Rekor auto-anchor backend. There is no public default. Mutually exclusive with `anchor.local_log`. |
 | `anchor.rekor_key_path` | (empty) | Ed25519 private key that signs Rekor entry submissions. Required with `anchor.rekor_url`; loaded again on every attempt so file replacement is picked up without restart. |
 | `anchor.local_log` | (empty) | Deterministic local anchor-log JSONL path. Setting it activates the local test/development backend. Mutually exclusive with `anchor.rekor_url`; not an operator-independent witness. |

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -369,16 +369,19 @@ loop never submits an unchanged or empty receipt head.
 
 Rekor submission uses the v1 `hashedrekord` API. Only the checkpoint's SHA-512
 digest and signature leave the box; receipt content is never submitted. The
-separate `rekor_key_path` Ed25519 key signs the log entry and is reloaded for
+configured `rekor_key_path` Ed25519 key signs the log entry and is reloaded for
 each attempt so replacing the key file does not require restarting Pipelock.
+Pipelock does not currently verify that this key differs from the receipt
+signing key.
 
 Anchoring is fail-degraded, not a traffic gate. An unavailable log, unreadable
 entry key, invalid chain, or write failure increments
 `pipelock_evidence_auto_anchor_failures_total`, records the last error in the
 `/stats` evidence-health JSON, and prints a `CRITICAL` line to stderr. Proxy
 traffic and receipt emission continue without waiting for the retry, which runs
-on a later pass. Successful markers feed the existing `anchoring_fresh` evidence
-health grade and anchor-lag metrics.
+on a later pass. Successful markers feed the `anchoring_fresh` evidence-health
+diagnostic and anchor-lag metrics; they do not raise `current_ael` above the
+single-recorder ceiling.
 
 The log operator determines the ceiling of the proof. A self-hosted Rekor log
 adds tamper evidence and durability, but it is not independent from its

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -127,8 +127,8 @@ health sampler is not measuring that fact in the current runtime.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `pipelock_evidence_current_ael` | gauge | (none) | Current evidence assurance level, 0 through 4. The level is a minimum over enabled requirements and must not be read as a green completeness claim. |
-| `pipelock_evidence_ael_requirement_ok` | gauge | `requirement` | One when a bounded evidence requirement is currently satisfied. Requirement labels are `recorder_enabled`, `emitter_healthy`, `durability_gate`, `heartbeats`, `anchoring_fresh`, `cpc_active`, and `selfaudit_ok`. |
+| `pipelock_evidence_current_ael` | gauge | (none) | Current evidence assurance level, currently 0 through 1. Pipelock has one recorder, so no health or anchoring signal can establish AEL-2's separately keyed second recorder or any cumulative higher rung. The level is not a green completeness claim. |
+| `pipelock_evidence_ael_requirement_ok` | gauge | `requirement` | One when a bounded evidence-health signal is currently satisfied. Requirement labels are `recorder_enabled`, `emitter_healthy`, `durability_gate`, `heartbeats`, `anchoring_fresh`, `cpc_active`, and `selfaudit_ok`; these diagnostics do not independently award an AEL rung. |
 | `pipelock_evidence_chain_head_seq` | gauge | (none) | Last emitted in-memory receipt sequence, omitted when evidence health is not measured. |
 | `pipelock_evidence_chain_head_age_seconds` | gauge | (none) | Seconds since the last durable chain entry, omitted when evidence health is not measured. |
 | `pipelock_evidence_heartbeat_interval_seconds` | gauge | (none) | Configured receipt heartbeat interval in seconds; absent from JSON stats until heartbeats are enabled. |

--- a/internal/cli/runtime/evidence_health_test.go
+++ b/internal/cli/runtime/evidence_health_test.go
@@ -771,8 +771,8 @@ func TestEvidenceHealthAnchorStateValidMarkerCanOnlyUseAcceptedFreshness(t *test
 	if !stats.Requirements[metrics.EvidenceRequirementAnchoringFresh] {
 		t.Fatal("valid fresh marker did not set anchoring_fresh")
 	}
-	if stats.CurrentAEL != 3 {
-		t.Fatalf("current AEL = %d, want 3 for accepted fresh marker", stats.CurrentAEL)
+	if stats.CurrentAEL != 1 {
+		t.Fatalf("current AEL = %d, want 1; a local anchor cannot supply AEL-2's second recorder", stats.CurrentAEL)
 	}
 
 	older := validEvidenceHealthAnchorState()
@@ -813,8 +813,39 @@ func TestEvidenceHealthAnchorStateValidMarkerCanOnlyUseAcceptedFreshness(t *test
 	if afterStale.Requirements[metrics.EvidenceRequirementAnchoringFresh] {
 		t.Fatal("valid stale marker set anchoring_fresh")
 	}
-	if afterStale.CurrentAEL != 2 {
-		t.Fatalf("current AEL = %d, want 2 for stale marker", afterStale.CurrentAEL)
+	if afterStale.CurrentAEL != 1 {
+		t.Fatalf("current AEL = %d, want 1 for stale marker; a single recorder cannot claim AEL-2", afterStale.CurrentAEL)
+	}
+}
+
+func TestEvidenceHealthRekorMarkerWithReceiptSignerKeyDoesNotRaiseAEL(t *testing.T) {
+	h, _, e, _ := newEvidenceHealthTestMonitor(t, func(cfg *config.Config) {
+		cfg.FlightRecorder.RequireReceipts = true
+	})
+	emitEvidenceHealthTestReceipt(t, e, "https://api.vendor.example/baseline")
+	emitEvidenceHealthTestReceipt(t, e, "https://api.vendor.example/current-head")
+	state := validEvidenceHealthAnchorState()
+	state.Backend = anchorpkg.RekorBackend
+	state.FinalSeq = 1
+	// The checkpoint records the same verified receipt signer. The health
+	// monitor has no separately verified log-key evidence, so Rekor freshness
+	// must not turn this one-recorder run into AEL-2 or AEL-3.
+	state.SignerKey = e.SignerKeyHex()
+	writeEvidenceHealthAnchorState(t, h.recorder.Dir(), state)
+
+	h.runPass()
+	stats, ok := h.stats()
+	if !ok {
+		t.Fatal("stats unavailable")
+	}
+	if stats.Anchor == nil || stats.Anchor.Backend != anchorpkg.RekorBackend {
+		t.Fatalf("anchor = %+v, want accepted Rekor marker", stats.Anchor)
+	}
+	if !stats.Requirements[metrics.EvidenceRequirementAnchoringFresh] {
+		t.Fatal("accepted Rekor marker did not set anchoring_fresh")
+	}
+	if stats.CurrentAEL != 1 {
+		t.Fatalf("current AEL = %d, want 1; a same-key Rekor checkpoint cannot satisfy AEL-2 or AEL-3", stats.CurrentAEL)
 	}
 }
 
@@ -983,10 +1014,11 @@ func writeEvidenceHealthAnchorBundle(t *testing.T, dir string, state anchorState
 	if state.SignerKey == "" {
 		checkpoint.SignerKeys[0] = strings.Repeat("c", 64)
 	}
-	data, err := anchorpkg.WriteBundleUnderDir(dir, state.BundlePath, anchorpkg.NewBundle(checkpoint, anchorpkg.Proof{
-		Backend:  state.Backend,
-		LogIndex: state.LogIndex,
-	}))
+	proof := anchorpkg.Proof{Backend: state.Backend, LogIndex: state.LogIndex}
+	if state.Backend == anchorpkg.RekorBackend {
+		proof.Rekor = &anchorpkg.RekorProof{}
+	}
+	data, err := anchorpkg.WriteBundleUnderDir(dir, state.BundlePath, anchorpkg.NewBundle(checkpoint, proof))
 	if err != nil {
 		t.Fatalf("WriteBundleUnderDir: %v", err)
 	}

--- a/internal/metrics/evidence.go
+++ b/internal/metrics/evidence.go
@@ -18,6 +18,17 @@ const (
 	EvidenceRequirementAnchoringFresh  = "anchoring_fresh"
 	EvidenceRequirementCPCActive       = "cpc_active"
 	EvidenceRequirementSelfAuditOK     = "selfaudit_ok"
+
+	// evidenceMaximumSupportedAEL is deliberately a product-capability ceiling,
+	// not a statement about a particular anchor's current health. Pipelock has
+	// one receipt recorder today. It does not verify a separately keyed second
+	// recorder with declared custody separation (AEL-2), so it cannot honestly
+	// claim AEL-2 or any cumulative rung above it. A local anchor is a test
+	// backend, while the current Rekor path does not establish the required
+	// separate log key or per-payload inclusion proof; neither can raise this
+	// ceiling. Raise it only alongside an implementation that verifies every
+	// prerequisite of the next AEL rung.
+	evidenceMaximumSupportedAEL = 1
 )
 
 var evidenceSequenceGapSources = map[string]bool{
@@ -162,10 +173,23 @@ var evidenceAELRules = []evidenceAELRule{
 func EvidenceCurrentAEL(in EvidenceAELInput) int {
 	level := 0
 	for _, rule := range evidenceAELRules {
+		if rule.rung > evidenceMaximumSupportedAEL {
+			return level
+		}
 		if !rule.ok(in) {
 			return level
 		}
 		level = rule.rung
+	}
+	return level
+}
+
+func clampEvidenceCurrentAEL(level int) int {
+	if level < 0 {
+		return 0
+	}
+	if level > evidenceMaximumSupportedAEL {
+		return evidenceMaximumSupportedAEL
 	}
 	return level
 }
@@ -501,7 +525,15 @@ func (m *Metrics) EvidenceHealthStatsSnapshot() (EvidenceHealthStats, bool) {
 	if fn == nil {
 		return EvidenceHealthStats{}, false
 	}
-	return fn()
+	stats, ok := fn()
+	if !ok {
+		return stats, false
+	}
+	// The callback backs both /stats and the Prometheus collector. Clamp here
+	// as well as in EvidenceCurrentAEL so no alternate producer can publish an
+	// unsupported AEL rung.
+	stats.CurrentAEL = clampEvidenceCurrentAEL(stats.CurrentAEL)
+	return stats, true
 }
 
 func (m *Metrics) SetEvidenceHealthFunc(fn func() (EvidenceHealthStats, bool)) {
@@ -542,7 +574,7 @@ func newEvidenceCollector(m *Metrics) *evidenceCollector {
 		),
 		current: prometheus.NewDesc(
 			"pipelock_evidence_current_ael",
-			"Current evidence assurance level, 0 through 4.",
+			"Current evidence assurance level, capped at 1 until Pipelock verifies higher-rung evidence requirements.",
 			nil, labels,
 		),
 	}

--- a/internal/metrics/evidence_test.go
+++ b/internal/metrics/evidence_test.go
@@ -352,3 +352,65 @@ func TestEvidenceHealthUnmeasuredStatsNullAndDynamicGaugesAbsent(t *testing.T) {
 		t.Fatalf("stats included current_ael while evidence health is unmeasured: %s", rec.Body.String())
 	}
 }
+
+func TestClampEvidenceCurrentAELBounds(t *testing.T) {
+	cases := []struct{ in, want int }{
+		{in: -100, want: 0},
+		{in: -1, want: 0},
+		{in: 0, want: 0},
+		{in: 1, want: 1},
+		{in: 2, want: evidenceMaximumSupportedAEL},
+		{in: 4, want: evidenceMaximumSupportedAEL},
+	}
+	for _, c := range cases {
+		if got := clampEvidenceCurrentAEL(c.in); got != c.want {
+			t.Fatalf("clampEvidenceCurrentAEL(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEvidenceCollectorExportsCappedCurrentAEL(t *testing.T) {
+	m := New()
+	m.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {
+		return EvidenceHealthStats{CurrentAEL: 4, ChainHeadSeq: 9}, true
+	})
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(m.evidenceCollector); err != nil {
+		t.Fatalf("register evidence collector: %v", err)
+	}
+	fams, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	found := false
+	for _, fam := range fams {
+		if fam.GetName() != "pipelock_evidence_current_ael" {
+			continue
+		}
+		found = true
+		if v := fam.GetMetric()[0].GetGauge().GetValue(); v != 1 {
+			t.Fatalf("exported pipelock_evidence_current_ael = %v, want capped 1", v)
+		}
+	}
+	if !found {
+		t.Fatal("pipelock_evidence_current_ael was not exported")
+	}
+}
+
+func TestStatsHandlerUnavailableEvidenceHealthIsNull(t *testing.T) {
+	m := New()
+	m.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {
+		return EvidenceHealthStats{}, false
+	})
+	rec := httptest.NewRecorder()
+	m.StatsHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil))
+	var body struct {
+		EvidenceHealth *EvidenceHealthStats `json:"evidence_health"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("Unmarshal stats: %v", err)
+	}
+	if body.EvidenceHealth != nil {
+		t.Fatalf("evidence_health = %+v, want nil when the snapshot is unavailable", body.EvidenceHealth)
+	}
+}

--- a/internal/metrics/evidence_test.go
+++ b/internal/metrics/evidence_test.go
@@ -354,18 +354,23 @@ func TestEvidenceHealthUnmeasuredStatsNullAndDynamicGaugesAbsent(t *testing.T) {
 }
 
 func TestClampEvidenceCurrentAELBounds(t *testing.T) {
-	cases := []struct{ in, want int }{
-		{in: -100, want: 0},
-		{in: -1, want: 0},
-		{in: 0, want: 0},
-		{in: 1, want: 1},
-		{in: 2, want: evidenceMaximumSupportedAEL},
-		{in: 4, want: evidenceMaximumSupportedAEL},
+	cases := []struct {
+		name     string
+		in, want int
+	}{
+		{name: "below minimum", in: -100, want: 0},
+		{name: "negative", in: -1, want: 0},
+		{name: "zero", in: 0, want: 0},
+		{name: "supported maximum", in: 1, want: 1},
+		{name: "above maximum", in: 2, want: evidenceMaximumSupportedAEL},
+		{name: "far above maximum", in: 4, want: evidenceMaximumSupportedAEL},
 	}
 	for _, c := range cases {
-		if got := clampEvidenceCurrentAEL(c.in); got != c.want {
-			t.Fatalf("clampEvidenceCurrentAEL(%d) = %d, want %d", c.in, got, c.want)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if got := clampEvidenceCurrentAEL(c.in); got != c.want {
+				t.Fatalf("clampEvidenceCurrentAEL(%d) = %d, want %d", c.in, got, c.want)
+			}
+		})
 	}
 }
 
@@ -405,12 +410,12 @@ func TestStatsHandlerUnavailableEvidenceHealthIsNull(t *testing.T) {
 	rec := httptest.NewRecorder()
 	m.StatsHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil))
 	var body struct {
-		EvidenceHealth *EvidenceHealthStats `json:"evidence_health"`
+		EvidenceHealth json.RawMessage `json:"evidence_health"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("Unmarshal stats: %v", err)
 	}
-	if body.EvidenceHealth != nil {
-		t.Fatalf("evidence_health = %+v, want nil when the snapshot is unavailable", body.EvidenceHealth)
+	if got := strings.TrimSpace(string(body.EvidenceHealth)); got != "null" {
+		t.Fatalf("evidence_health = %q, want JSON null when the snapshot is unavailable", got)
 	}
 }

--- a/internal/metrics/evidence_test.go
+++ b/internal/metrics/evidence_test.go
@@ -30,21 +30,21 @@ func TestEvidenceCurrentAELTable(t *testing.T) {
 		{name: "recorder_only", in: EvidenceAELInput{RecorderEnabled: true}, want: 0},
 		{name: "selfaudit_latched_bad", in: EvidenceAELInput{RecorderEnabled: true, EmitterHealthy: true}, want: 0},
 		{name: "best_effort", in: base, want: 1},
-		{name: "durable_heartbeat", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
+		{name: "durable_heartbeat_does_not_claim_second_recorder", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
 			in.DurabilityGate = true
 			in.Heartbeats = true
-		}), want: 2},
-		{name: "anchor_fresh", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
+		}), want: 1},
+		{name: "fresh_anchor_does_not_claim_external_grade", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
 			in.DurabilityGate = true
 			in.Heartbeats = true
 			in.AnchoringFresh = true
-		}), want: 3},
-		{name: "cpc_active", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
+		}), want: 1},
+		{name: "cpc_active_does_not_bypass_cumulative_requirements", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
 			in.DurabilityGate = true
 			in.Heartbeats = true
 			in.AnchoringFresh = true
 			in.CPCActive = true
-		}), want: 4},
+		}), want: 1},
 		{name: "ungated_fsync_failure_degrades_to_zero", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
 			in.UngatedFsyncFail = true
 		}), want: 0},
@@ -55,6 +55,40 @@ func TestEvidenceCurrentAELTable(t *testing.T) {
 				t.Fatalf("EvidenceCurrentAEL = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+// This fixture contains every signal the pre-cap ladder mistook for AEL-4.
+// It must remain at the one-recorder ceiling until the runtime can verify the
+// separate recorders, external log, and counterparty evidence that AEL needs.
+// Temporarily raising evidenceMaximumSupportedAEL makes this test fail at 4,
+// proving the ceiling is load-bearing rather than a vacuous assertion.
+func TestEvidenceCurrentAELSingleRecorderCeilingRejectsLegacyOverclaim(t *testing.T) {
+	in := EvidenceAELInput{
+		RecorderEnabled: true,
+		EmitterHealthy:  true,
+		DurabilityGate:  true,
+		Heartbeats:      true,
+		AnchoringFresh:  true,
+		CPCActive:       true,
+		SelfAuditOK:     true,
+	}
+	if got := EvidenceCurrentAEL(in); got != 1 {
+		t.Fatalf("EvidenceCurrentAEL = %d, want one-recorder ceiling 1", got)
+	}
+}
+
+func TestEvidenceHealthStatsSnapshotClampsAlternateAELProducer(t *testing.T) {
+	m := New()
+	m.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {
+		return EvidenceHealthStats{CurrentAEL: 4}, true
+	})
+	stats, ok := m.EvidenceHealthStatsSnapshot()
+	if !ok {
+		t.Fatal("EvidenceHealthStatsSnapshot unavailable")
+	}
+	if stats.CurrentAEL != 1 {
+		t.Fatalf("CurrentAEL = %d, want one-recorder ceiling 1", stats.CurrentAEL)
 	}
 }
 
@@ -214,7 +248,7 @@ func TestEvidenceMetricsSettersSnapshotsAndDynamicCollector(t *testing.T) {
 		return stats, true
 	})
 	gotStats, ok := m.EvidenceHealthStatsSnapshot()
-	if !ok || gotStats.CurrentAEL != 3 || gotStats.ChainHeadSeq != 9 {
+	if !ok || gotStats.CurrentAEL != 1 || gotStats.ChainHeadSeq != 9 {
 		t.Fatalf("EvidenceHealthStatsSnapshot = (%+v, %v), want stats ok", gotStats, ok)
 	}
 	if got := testutil.CollectAndCount(m.evidenceCollector); got != 4 {
@@ -229,8 +263,8 @@ func TestEvidenceMetricsSettersSnapshotsAndDynamicCollector(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("Unmarshal stats: %v", err)
 	}
-	if body.EvidenceHealth == nil || body.EvidenceHealth.CurrentAEL != 3 || body.EvidenceHealth.ChainHeadSeq != 9 {
-		t.Fatalf("stats evidence_health = %+v, want current_ael=3 chain_head_seq=9", body.EvidenceHealth)
+	if body.EvidenceHealth == nil || body.EvidenceHealth.CurrentAEL != 1 || body.EvidenceHealth.ChainHeadSeq != 9 {
+		t.Fatalf("stats evidence_health = %+v, want current_ael=1 chain_head_seq=9", body.EvidenceHealth)
 	}
 
 	m.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {

--- a/internal/metrics/stats_handler.go
+++ b/internal/metrics/stats_handler.go
@@ -51,7 +51,6 @@ func (m *Metrics) StatsHandler() http.HandlerFunc {
 			},
 		}
 		ceeFunc := m.CEEStatsFunc
-		evidenceFunc := m.evidenceHealthFunc
 		if total > 0 {
 			stats.Requests.BlockRate = float64(m.blockedCount) / float64(total)
 		}
@@ -71,10 +70,8 @@ func (m *Metrics) StatsHandler() http.HandlerFunc {
 		if ceeFunc != nil {
 			stats.CEE = ceeFunc()
 		}
-		if evidenceFunc != nil {
-			if evidence, ok := evidenceFunc(); ok {
-				stats.EvidenceHealth = &evidence
-			}
+		if evidence, ok := m.EvidenceHealthStatsSnapshot(); ok {
+			stats.EvidenceHealth = &evidence
 		}
 
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## What changed

The `current_ael` evidence metric could report AEL-2, AEL-3, or AEL-4 from a single receipt recorder based on heartbeat durability, fresh anchoring, or counterparty signals, without meeting the cumulative requirements those levels demand. AEL-2 requires a second, separately-keyed recorder with declared custody separation, and AEL-3 requires an externally-operated anchor whose log key differs from the recorder key. Pipelock runs one receipt recorder today and verifies neither prerequisite, so the honestly-earned ceiling is AEL-1.

This caps the reported level at that ceiling in both the calculator and the `/stats` handler, so no alternate producer can publish an unsupported level, and documents the reasoning at the ceiling constant. Lower-level reporting is unchanged and only the unsupported higher levels are capped down. The metric stays a live health gauge; it is not a formal, independently-checked evidence grade.

Added table tests assert the capped states and a regression that fails if the ceiling is lifted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Metrics**
  * Evidence assurance reporting is capped at AEL 1 for single-recorder deployments.
  * Evidence-health snapshots and statistics consistently apply this assurance limit.
  * Anchor freshness and lag metrics now reflect successful runtime anchoring accurately.

* **Documentation**
  * Clarified anchor behavior, signing-key handling, evidence-health diagnostics, and assurance limits.
  * Updated metric descriptions to document the observed AEL range and single-recorder ceiling.

* **Bug Fixes**
  * Prevented stale or same-key Rekor markers from incorrectly increasing assurance levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->