### PR TITLE
fix(deps): update fast-uri to 3.1.5

### DIFF
--- a/sdk/verifiers/ts/package-lock.json
+++ b/sdk/verifiers/ts/package-lock.json
@@ -84,9 +84,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Update the TypeScript verifier lockfile from `fast-uri` 3.1.4 to 3.1.5.

This resolves GHSA-7p8r-x3mc-p8w7 / CVE-2026-18446, which can cause host interpretation differences for backslash-based authority introducers.
