### PR TITLE
fix(verifier): stage source-recheck results so an unauthenticated match cannot read as verified

### DIFF
--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -1422,8 +1422,17 @@ func TestReceipt_EvidenceV2RecheckSourceSpanMismatchReportsInvalid(t *testing.T)
 	if rpt.Valid {
 		t.Fatalf("expected valid=false, got %+v", rpt)
 	}
-	if rpt.Recheck == nil || rpt.Recheck.Overall != recheckOverallFailed {
-		t.Fatalf("expected recheck.overall=failed, got %+v", rpt)
+	if rpt.Recheck == nil {
+		t.Fatalf("expected staged recheck report, got %+v", rpt)
+	}
+	if rpt.Recheck.Location != recheckLocationFailed {
+		t.Fatalf("recheck.location=%q, want %q", rpt.Recheck.Location, recheckLocationFailed)
+	}
+	if rpt.Recheck.Signature != recheckSignatureVerified {
+		t.Fatalf("recheck.signature=%q, want %q", rpt.Recheck.Signature, recheckSignatureVerified)
+	}
+	if rpt.Recheck.Overall != recheckOverallFailed {
+		t.Fatalf("recheck.overall=%q, want %q", rpt.Recheck.Overall, recheckOverallFailed)
 	}
 	if !strings.Contains(rpt.Error, "redacted_sample mismatch") {
 		t.Fatalf("error=%q", rpt.Error)

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -1373,11 +1373,20 @@ func TestReceipt_EvidenceV2RecheckSourceSpan(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &rpt); err != nil {
 		t.Fatalf("parse json: %v", err)
 	}
-	if rpt.RecheckValid == nil || !*rpt.RecheckValid {
-		t.Fatalf("expected recheck_valid=true, got %+v", rpt)
+	if rpt.Recheck == nil {
+		t.Fatalf("expected staged recheck report, got %+v", rpt)
 	}
-	if rpt.RecheckView != contractreceipt.NormalizedViewSanitizedTarget {
-		t.Fatalf("recheck_view=%q", rpt.RecheckView)
+	if rpt.Recheck.Location != recheckLocationExact {
+		t.Fatalf("recheck.location=%q, want %q", rpt.Recheck.Location, recheckLocationExact)
+	}
+	if rpt.Recheck.Signature != recheckSignatureVerified {
+		t.Fatalf("recheck.signature=%q, want %q", rpt.Recheck.Signature, recheckSignatureVerified)
+	}
+	if rpt.Recheck.Overall != recheckOverallVerified {
+		t.Fatalf("recheck.overall=%q, want %q", rpt.Recheck.Overall, recheckOverallVerified)
+	}
+	if rpt.Recheck.View != contractreceipt.NormalizedViewSanitizedTarget {
+		t.Fatalf("recheck.view=%q", rpt.Recheck.View)
 	}
 }
 
@@ -1413,8 +1422,8 @@ func TestReceipt_EvidenceV2RecheckSourceSpanMismatchReportsInvalid(t *testing.T)
 	if rpt.Valid {
 		t.Fatalf("expected valid=false, got %+v", rpt)
 	}
-	if rpt.RecheckValid == nil || *rpt.RecheckValid {
-		t.Fatalf("expected recheck_valid=false, got %+v", rpt)
+	if rpt.Recheck == nil || rpt.Recheck.Overall != recheckOverallFailed {
+		t.Fatalf("expected recheck.overall=failed, got %+v", rpt)
 	}
 	if !strings.Contains(rpt.Error, "redacted_sample mismatch") {
 		t.Fatalf("error=%q", rpt.Error)

--- a/cmd/pipelock-verifier/receipt.go
+++ b/cmd/pipelock-verifier/receipt.go
@@ -60,24 +60,23 @@ required unless --allow-unpinned is used for structural checks only.`,
 }
 
 type receiptReport struct {
-	Path               string `json:"path"`
-	RecordType         string `json:"record_type,omitempty"`
-	Valid              bool   `json:"valid"`
-	SignaturesVerified bool   `json:"signatures_verified"`
-	Unpinned           bool   `json:"unpinned,omitempty"`
-	ActionID           string `json:"action_id,omitempty"`
-	Verdict            string `json:"verdict,omitempty"`
-	Transport          string `json:"transport,omitempty"`
-	SignerKey          string `json:"signer_key,omitempty"`
-	SignerKeyID        string `json:"signer_key_id,omitempty"`
-	PolicyHash         string `json:"policy_hash,omitempty"`
-	PayloadKind        string `json:"payload_kind,omitempty"`
-	ContractHash       string `json:"contract_hash,omitempty"`
-	ActiveManifestHash string `json:"active_manifest_hash,omitempty"`
-	ChainSeq           uint64 `json:"chain_seq,omitempty"`
-	RecheckValid       *bool  `json:"recheck_valid,omitempty"`
-	RecheckView        string `json:"recheck_view,omitempty"`
-	Error              string `json:"error,omitempty"`
+	Path               string         `json:"path"`
+	RecordType         string         `json:"record_type,omitempty"`
+	Valid              bool           `json:"valid"`
+	SignaturesVerified bool           `json:"signatures_verified"`
+	Unpinned           bool           `json:"unpinned,omitempty"`
+	ActionID           string         `json:"action_id,omitempty"`
+	Verdict            string         `json:"verdict,omitempty"`
+	Transport          string         `json:"transport,omitempty"`
+	SignerKey          string         `json:"signer_key,omitempty"`
+	SignerKeyID        string         `json:"signer_key_id,omitempty"`
+	PolicyHash         string         `json:"policy_hash,omitempty"`
+	PayloadKind        string         `json:"payload_kind,omitempty"`
+	ContractHash       string         `json:"contract_hash,omitempty"`
+	ActiveManifestHash string         `json:"active_manifest_hash,omitempty"`
+	ChainSeq           uint64         `json:"chain_seq,omitempty"`
+	Recheck            *recheckReport `json:"recheck,omitempty"`
+	Error              string         `json:"error,omitempty"`
 }
 
 func runReceipt(stdout, stderr io.Writer, target string, opts receiptOptions) error {
@@ -192,8 +191,11 @@ func runEvidenceReceipt(stdout, stderr io.Writer, clean string, data []byte, key
 		}
 		if opts.recheckSource != "" {
 			result, recheckErr := recheckEvidenceReceiptSpan(r, opts.recheckSource, opts.recheckSpanIndex)
-			report.RecheckValid = &result.Valid
-			report.RecheckView = result.View
+			// No key was supplied on this path, so the producer is
+			// unauthenticated by construction: stage the recheck with
+			// signature=not_checked, which caps overall at "incomplete".
+			staged := newRecheckReport(result, false)
+			report.Recheck = &staged
 			if recheckErr != nil {
 				report.Valid = false
 				report.Error = recheckErr.Error()
@@ -219,9 +221,12 @@ func runEvidenceReceipt(stdout, stderr io.Writer, clean string, data []byte, key
 	}
 	report.SignaturesVerified = sigVerified
 	if opts.recheckSource != "" {
+		// Signature verification already ran above and gated this path, so the
+		// staged report carries the real authentication state rather than a
+		// bare positional boolean.
 		result, recheckErr := recheckEvidenceReceiptSpan(r, opts.recheckSource, opts.recheckSpanIndex)
-		report.RecheckValid = &result.Valid
-		report.RecheckView = result.View
+		staged := newRecheckReport(result, sigVerified)
+		report.Recheck = &staged
 		if recheckErr != nil {
 			report.Valid = false
 			report.Error = recheckErr.Error()

--- a/cmd/pipelock-verifier/recheck.go
+++ b/cmd/pipelock-verifier/recheck.go
@@ -28,8 +28,8 @@ const (
 
 // Recheck signature stages. A recheck says nothing about who produced the
 // receipt; that is the signature stage's job. Reported as a sibling of the
-// location result so no consumer can read a positive location without also
-// reading whether the producer was authenticated.
+// location result. A positive location is withheld entirely when the
+// producer is unauthenticated, so it cannot be read as a pass.
 const (
 	recheckSignatureVerified   = "verified"
 	recheckSignatureNotChecked = "not_checked"
@@ -96,15 +96,34 @@ func recheckEvidenceReceiptSpan(r contractreceipt.EvidenceReceipt, sourcePath st
 	return recheckResult{Location: recheckLocationOccurrence, View: span.NormalizedView}, nil
 }
 
-// recheckReport is the staged, machine-readable recheck outcome. There is
-// deliberately no bare boolean: an unqualified "valid" is unrepresentable, so a
-// consumer cannot read a positive source match without also reading whether the
-// producing signature was authenticated.
+// recheckReport is the staged, machine-readable recheck outcome.
+//
+// Only `overall` is authoritative for a gating decision. A positive positional
+// result is structurally UNAVAILABLE at the authoritative path unless the
+// producing signature was verified: when the receipt is unauthenticated the
+// location moves into UnauthenticatedDiagnostic and the top-level Location is
+// empty. Documenting "read signature too" is not enough, because an automation
+// consumer keying off `location != "failed"` would still accept an
+// attacker-supplied unpinned receipt paired with an attacker-chosen source
+// file. Removing the field is what actually prevents that.
 type recheckReport struct {
-	View      string `json:"view,omitempty"`
-	Location  string `json:"location"`
+	View string `json:"view,omitempty"`
+	// Location is populated ONLY when Signature is verified.
+	Location  string `json:"location,omitempty"`
 	Signature string `json:"signature"`
 	Overall   string `json:"overall"`
+	// UnauthenticatedDiagnostic carries the positional result for an
+	// unauthenticated receipt. It is explicitly non-authoritative and must
+	// never be used for a pass/fail decision.
+	UnauthenticatedDiagnostic *recheckDiagnostic `json:"unauthenticated_diagnostic,omitempty"`
+}
+
+// recheckDiagnostic is human-facing detail about an UNAUTHENTICATED recheck.
+// It exists so an operator running --allow-unpinned can still see what was
+// found, without exposing a positive result under a field name an automated
+// gate would trust.
+type recheckDiagnostic struct {
+	Location string `json:"location"`
 }
 
 // newRecheckReport stages a recheck outcome against whether the receipt's
@@ -133,6 +152,18 @@ func newRecheckReport(result recheckResult, signatureVerified bool) recheckRepor
 		// reproduced view but not provably at the signed position.
 		// Authenticated, but not a complete positional claim.
 		overall = recheckOverallIncomplete
+	}
+	if !signatureVerified {
+		// Withhold the positive location from the authoritative field. An
+		// unauthenticated recheck can still be inspected by a human via the
+		// diagnostic, but there is no field an automated gate would read as a
+		// pass.
+		return recheckReport{
+			View:                      result.View,
+			Signature:                 sig,
+			Overall:                   overall,
+			UnauthenticatedDiagnostic: &recheckDiagnostic{Location: result.Location},
+		}
 	}
 	return recheckReport{View: result.View, Location: result.Location, Signature: sig, Overall: overall}
 }

--- a/cmd/pipelock-verifier/recheck.go
+++ b/cmd/pipelock-verifier/recheck.go
@@ -16,55 +16,125 @@ import (
 
 const transformProfileV1 = "pipelock-transform-v1"
 
+// Recheck location strengths. A recheck that matched at the signed coordinates
+// is a strictly stronger claim than one that only found the sample somewhere in
+// the reproduced view, so the two are reported separately instead of collapsing
+// into a single boolean.
+const (
+	recheckLocationExact      = "exact_coordinates"
+	recheckLocationOccurrence = "occurrence_only"
+	recheckLocationFailed     = "failed"
+)
+
+// Recheck signature stages. A recheck says nothing about who produced the
+// receipt; that is the signature stage's job. Reported as a sibling of the
+// location result so no consumer can read a positive location without also
+// reading whether the producer was authenticated.
+const (
+	recheckSignatureVerified   = "verified"
+	recheckSignatureNotChecked = "not_checked"
+)
+
+// Recheck overall verdicts.
+const (
+	recheckOverallVerified   = "verified"
+	recheckOverallIncomplete = "incomplete"
+	recheckOverallFailed     = "failed"
+)
+
 type recheckResult struct {
-	Valid bool
-	View  string
+	// Location is the strength of the positional claim, not an overall
+	// verdict. It is deliberately not a bool: a substring hit and a match at
+	// the signed coordinates are different facts.
+	Location string
+	View     string
 }
 
 func recheckEvidenceReceiptSpan(r contractreceipt.EvidenceReceipt, sourcePath string, spanIndex int) (recheckResult, error) {
 	if r.PayloadKind != contractreceipt.PayloadProxyDecisionWithSpans {
-		return recheckResult{}, fmt.Errorf("--recheck-source requires payload_kind=%s", contractreceipt.PayloadProxyDecisionWithSpans)
+		return recheckResult{Location: recheckLocationFailed}, fmt.Errorf("--recheck-source requires payload_kind=%s", contractreceipt.PayloadProxyDecisionWithSpans)
 	}
 	if spanIndex < 0 {
-		return recheckResult{}, fmt.Errorf("--recheck-span-index must be non-negative")
+		return recheckResult{Location: recheckLocationFailed}, fmt.Errorf("--recheck-span-index must be non-negative")
 	}
 	var payload contractreceipt.PayloadProxyDecisionWithSpansStruct
 	if err := json.Unmarshal(r.Payload, &payload); err != nil {
-		return recheckResult{}, fmt.Errorf("decode spanned payload: %w", err)
+		return recheckResult{Location: recheckLocationFailed}, fmt.Errorf("decode spanned payload: %w", err)
 	}
 	if spanIndex >= len(payload.SourceSpans) {
-		return recheckResult{}, fmt.Errorf("--recheck-span-index=%d outside source_spans length %d", spanIndex, len(payload.SourceSpans))
+		return recheckResult{Location: recheckLocationFailed}, fmt.Errorf("--recheck-span-index=%d outside source_spans length %d", spanIndex, len(payload.SourceSpans))
 	}
 	span := payload.SourceSpans[spanIndex]
 	if span.TransformProfile != transformProfileV1 {
-		return recheckResult{}, fmt.Errorf("unsupported transform_profile %q", span.TransformProfile)
+		return recheckResult{Location: recheckLocationFailed}, fmt.Errorf("unsupported transform_profile %q", span.TransformProfile)
 	}
 	if span.RedactedSample == "" {
-		return recheckResult{}, fmt.Errorf("source_spans[%d].redacted_sample is required for recheck", spanIndex)
+		return recheckResult{Location: recheckLocationFailed}, fmt.Errorf("source_spans[%d].redacted_sample is required for recheck", spanIndex)
 	}
 	source, err := readVerifierFile(sourcePath)
 	if err != nil {
-		return recheckResult{}, fmt.Errorf("read recheck source: %w", err)
+		return recheckResult{Location: recheckLocationFailed}, fmt.Errorf("read recheck source: %w", err)
 	}
 	view, err := reproduceSpanView(string(source), span.NormalizedView)
 	if err != nil {
-		return recheckResult{}, err
+		return recheckResult{Location: recheckLocationFailed}, err
 	}
 	if span.CharOffset != nil && span.CharLength != nil {
 		runes := []rune(view)
 		end := *span.CharOffset + *span.CharLength
 		if *span.CharOffset < 0 || end > len(runes) {
-			return recheckResult{Valid: false, View: span.NormalizedView}, fmt.Errorf("source_spans[%d] coordinates outside reproduced view", spanIndex)
+			return recheckResult{Location: recheckLocationFailed, View: span.NormalizedView}, fmt.Errorf("source_spans[%d] coordinates outside reproduced view", spanIndex)
 		}
 		if string(runes[*span.CharOffset:end]) != span.RedactedSample {
-			return recheckResult{Valid: false, View: span.NormalizedView}, fmt.Errorf("source_spans[%d] redacted_sample mismatch at signed coordinates", spanIndex)
+			return recheckResult{Location: recheckLocationFailed, View: span.NormalizedView}, fmt.Errorf("source_spans[%d] redacted_sample mismatch at signed coordinates", spanIndex)
 		}
-		return recheckResult{Valid: true, View: span.NormalizedView}, nil
+		return recheckResult{Location: recheckLocationExact, View: span.NormalizedView}, nil
 	}
 	if !strings.Contains(view, span.RedactedSample) {
-		return recheckResult{Valid: false, View: span.NormalizedView}, fmt.Errorf("source_spans[%d] redacted_sample not found in reproduced view", spanIndex)
+		return recheckResult{Location: recheckLocationFailed, View: span.NormalizedView}, fmt.Errorf("source_spans[%d] redacted_sample not found in reproduced view", spanIndex)
 	}
-	return recheckResult{Valid: true, View: span.NormalizedView}, nil
+	return recheckResult{Location: recheckLocationOccurrence, View: span.NormalizedView}, nil
+}
+
+// recheckReport is the staged, machine-readable recheck outcome. There is
+// deliberately no bare boolean: an unqualified "valid" is unrepresentable, so a
+// consumer cannot read a positive source match without also reading whether the
+// producing signature was authenticated.
+type recheckReport struct {
+	View      string `json:"view,omitempty"`
+	Location  string `json:"location"`
+	Signature string `json:"signature"`
+	Overall   string `json:"overall"`
+}
+
+// newRecheckReport stages a recheck outcome against whether the receipt's
+// signature was authenticated.
+//
+// Overall is "verified" ONLY when the sample matched at the signed coordinates
+// AND a trusted key authenticated the producer. An unpinned recheck is at best
+// "incomplete", never "verified": locating bytes in a caller-supplied file
+// proves nothing about who asserted them, so a positive location on an
+// unauthenticated receipt must not read as a passing result.
+func newRecheckReport(result recheckResult, signatureVerified bool) recheckReport {
+	sig := recheckSignatureNotChecked
+	if signatureVerified {
+		sig = recheckSignatureVerified
+	}
+	var overall string
+	switch {
+	case result.Location == recheckLocationFailed:
+		overall = recheckOverallFailed
+	case !signatureVerified:
+		overall = recheckOverallIncomplete
+	case result.Location == recheckLocationExact:
+		overall = recheckOverallVerified
+	default:
+		// Located by occurrence only: the sample exists somewhere in the
+		// reproduced view but not provably at the signed position.
+		// Authenticated, but not a complete positional claim.
+		overall = recheckOverallIncomplete
+	}
+	return recheckReport{View: result.View, Location: result.Location, Signature: sig, Overall: overall}
 }
 
 func reproduceSpanView(source, view string) (string, error) {

--- a/cmd/pipelock-verifier/recheck_test.go
+++ b/cmd/pipelock-verifier/recheck_test.go
@@ -66,7 +66,7 @@ func TestRecheckEvidenceReceiptSpan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("recheckEvidenceReceiptSpan: %v", err)
 	}
-	if !result.Valid || result.View != contractreceipt.NormalizedViewSanitizedTarget {
+	if result.Location != recheckLocationExact || result.View != contractreceipt.NormalizedViewSanitizedTarget {
 		t.Fatalf("result = %+v", result)
 	}
 }
@@ -272,5 +272,51 @@ func recheckReceiptFixture(t *testing.T, span contractreceipt.SourceSpan) contra
 	return contractreceipt.EvidenceReceipt{
 		PayloadKind: contractreceipt.PayloadProxyDecisionWithSpans,
 		Payload:     body,
+	}
+}
+
+// TestRecheckReport_UnauthenticatedNeverReadsAsVerified is the guard for the
+// staged recheck contract: a source recheck run WITHOUT a trusted key must
+// never surface a passing result, no matter how strong the positional match.
+//
+// The defect this replaces: the report carried a bare recheck_valid bool while
+// the "this receipt was never authenticated" caveat lived in a separate
+// unpinned field. A machine consumer reading recheck_valid alone got a truthy
+// source match for a receipt whose producer was never verified.
+//
+// Non-vacuity: neutralize by deleting the `case !signatureVerified` arm in
+// newRecheckReport (so an exact match reports verified regardless of
+// authentication). This test must then FAIL.
+func TestRecheckReport_UnauthenticatedNeverReadsAsVerified(t *testing.T) {
+	t.Parallel()
+	for _, loc := range []string{recheckLocationExact, recheckLocationOccurrence, recheckLocationFailed} {
+		got := newRecheckReport(recheckResult{Location: loc, View: "sanitized_target"}, false)
+		if got.Overall == recheckOverallVerified {
+			t.Fatalf("location=%q unauthenticated reported overall=%q; an unauthenticated recheck must never read as verified", loc, got.Overall)
+		}
+		if got.Signature != recheckSignatureNotChecked {
+			t.Fatalf("location=%q reported signature=%q, want %q", loc, got.Signature, recheckSignatureNotChecked)
+		}
+	}
+}
+
+// TestRecheckReport_StrengthIsDistinguishable guards the second half of the
+// contract: a match at the signed coordinates and a bare substring occurrence
+// are different facts and must not collapse into one verdict.
+//
+// Non-vacuity: neutralize by mapping recheckLocationOccurrence to
+// recheckOverallVerified in newRecheckReport. This test must then FAIL.
+func TestRecheckReport_StrengthIsDistinguishable(t *testing.T) {
+	t.Parallel()
+	exact := newRecheckReport(recheckResult{Location: recheckLocationExact}, true)
+	occurrence := newRecheckReport(recheckResult{Location: recheckLocationOccurrence}, true)
+	if exact.Overall != recheckOverallVerified {
+		t.Fatalf("authenticated exact match overall=%q, want %q", exact.Overall, recheckOverallVerified)
+	}
+	if occurrence.Overall == recheckOverallVerified {
+		t.Fatalf("occurrence-only match reported overall=%q; a substring hit is not a positional proof", occurrence.Overall)
+	}
+	if exact.Overall == occurrence.Overall {
+		t.Fatalf("exact and occurrence-only collapsed to the same verdict %q", exact.Overall)
 	}
 }

--- a/cmd/pipelock-verifier/recheck_test.go
+++ b/cmd/pipelock-verifier/recheck_test.go
@@ -329,22 +329,27 @@ func TestRecheckReport_UnauthenticatedNeverReadsAsVerified(t *testing.T) {
 func TestRecheckReport_UnauthenticatedWithholdsAuthoritativeLocation(t *testing.T) {
 	t.Parallel()
 	for _, loc := range []string{recheckLocationExact, recheckLocationOccurrence} {
-		got := newRecheckReport(recheckResult{Location: loc, View: "sanitized_target"}, false)
-		if got.Location != "" {
-			t.Fatalf("unauthenticated recheck exposed authoritative location=%q; a positive positional result must be withheld from the trusted field", got.Location)
+		t.Run("unauthenticated/"+loc, func(t *testing.T) {
+			t.Parallel()
+			got := newRecheckReport(recheckResult{Location: loc, View: "sanitized_target"}, false)
+			if got.Location != "" {
+				t.Fatalf("unauthenticated recheck exposed authoritative location=%q; a positive positional result must be withheld from the trusted field", got.Location)
+			}
+			if got.UnauthenticatedDiagnostic == nil || got.UnauthenticatedDiagnostic.Location != loc {
+				t.Fatalf("expected non-authoritative diagnostic carrying %q, got %+v", loc, got.UnauthenticatedDiagnostic)
+			}
+		})
+	}
+	t.Run("authenticated/reports authoritative location", func(t *testing.T) {
+		t.Parallel()
+		authenticated := newRecheckReport(recheckResult{Location: recheckLocationExact}, true)
+		if authenticated.Location != recheckLocationExact {
+			t.Fatalf("authenticated location=%q, want %q", authenticated.Location, recheckLocationExact)
 		}
-		if got.UnauthenticatedDiagnostic == nil || got.UnauthenticatedDiagnostic.Location != loc {
-			t.Fatalf("expected non-authoritative diagnostic carrying %q, got %+v", loc, got.UnauthenticatedDiagnostic)
+		if authenticated.UnauthenticatedDiagnostic != nil {
+			t.Fatalf("authenticated report carried an unauthenticated diagnostic: %+v", authenticated.UnauthenticatedDiagnostic)
 		}
-	}
-	// The authenticated path still reports the authoritative location.
-	authenticated := newRecheckReport(recheckResult{Location: recheckLocationExact}, true)
-	if authenticated.Location != recheckLocationExact {
-		t.Fatalf("authenticated location=%q, want %q", authenticated.Location, recheckLocationExact)
-	}
-	if authenticated.UnauthenticatedDiagnostic != nil {
-		t.Fatalf("authenticated report carried an unauthenticated diagnostic: %+v", authenticated.UnauthenticatedDiagnostic)
-	}
+	})
 }
 
 // TestRecheckReport_StrengthIsDistinguishable guards the second half of the

--- a/cmd/pipelock-verifier/recheck_test.go
+++ b/cmd/pipelock-verifier/recheck_test.go
@@ -289,14 +289,61 @@ func recheckReceiptFixture(t *testing.T, span contractreceipt.SourceSpan) contra
 // authentication). This test must then FAIL.
 func TestRecheckReport_UnauthenticatedNeverReadsAsVerified(t *testing.T) {
 	t.Parallel()
-	for _, loc := range []string{recheckLocationExact, recheckLocationOccurrence, recheckLocationFailed} {
+	cases := []struct {
+		name        string
+		location    string
+		wantOverall string
+	}{
+		{name: "exact", location: recheckLocationExact, wantOverall: recheckOverallIncomplete},
+		{name: "occurrence", location: recheckLocationOccurrence, wantOverall: recheckOverallIncomplete},
+		{name: "failed", location: recheckLocationFailed, wantOverall: recheckOverallFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := newRecheckReport(recheckResult{Location: tc.location, View: "sanitized_target"}, false)
+			if got.Overall != tc.wantOverall {
+				t.Fatalf("overall=%q, want %q", got.Overall, tc.wantOverall)
+			}
+			if got.Signature != recheckSignatureNotChecked {
+				t.Fatalf("signature=%q, want %q", got.Signature, recheckSignatureNotChecked)
+			}
+		})
+	}
+}
+
+// TestRecheckReport_UnauthenticatedWithholdsAuthoritativeLocation is the guard
+// for the strongest form of the contract: for an unauthenticated receipt, the
+// positive positional result must not appear in ANY field an automated gate
+// would trust.
+//
+// The defect this closes: an earlier revision reported
+// location="exact_coordinates" alongside signature="not_checked". A consumer
+// keying off `location != "failed"` would accept an attacker-supplied unpinned
+// receipt paired with an attacker-chosen source file. Documenting "also read
+// signature" does not prevent that; withholding the field does.
+//
+// Non-vacuity: neutralize by deleting the `if !signatureVerified` early return
+// in newRecheckReport so Location is populated unconditionally. This test must
+// then FAIL.
+func TestRecheckReport_UnauthenticatedWithholdsAuthoritativeLocation(t *testing.T) {
+	t.Parallel()
+	for _, loc := range []string{recheckLocationExact, recheckLocationOccurrence} {
 		got := newRecheckReport(recheckResult{Location: loc, View: "sanitized_target"}, false)
-		if got.Overall == recheckOverallVerified {
-			t.Fatalf("location=%q unauthenticated reported overall=%q; an unauthenticated recheck must never read as verified", loc, got.Overall)
+		if got.Location != "" {
+			t.Fatalf("unauthenticated recheck exposed authoritative location=%q; a positive positional result must be withheld from the trusted field", got.Location)
 		}
-		if got.Signature != recheckSignatureNotChecked {
-			t.Fatalf("location=%q reported signature=%q, want %q", loc, got.Signature, recheckSignatureNotChecked)
+		if got.UnauthenticatedDiagnostic == nil || got.UnauthenticatedDiagnostic.Location != loc {
+			t.Fatalf("expected non-authoritative diagnostic carrying %q, got %+v", loc, got.UnauthenticatedDiagnostic)
 		}
+	}
+	// The authenticated path still reports the authoritative location.
+	authenticated := newRecheckReport(recheckResult{Location: recheckLocationExact}, true)
+	if authenticated.Location != recheckLocationExact {
+		t.Fatalf("authenticated location=%q, want %q", authenticated.Location, recheckLocationExact)
+	}
+	if authenticated.UnauthenticatedDiagnostic != nil {
+		t.Fatalf("authenticated report carried an unauthenticated diagnostic: %+v", authenticated.UnauthenticatedDiagnostic)
 	}
 }
 


### PR DESCRIPTION
## What changed

The receipt report carried a bare `recheck_valid` boolean while the caveat that the receipt was never authenticated lived in a separate `unpinned` field. A machine consumer reading `recheck_valid` alone got a truthy source match for a receipt whose producer was never verified.

`recheck_valid` and `recheck_view` are replaced by a staged `recheck` object carrying `location`, `signature`, and `overall`. An unqualified pass is now unrepresentable: `overall` reaches `verified` only when the sample matched at the signed coordinates AND a trusted key authenticated the producer. Without a key the result caps at `incomplete`, because locating bytes in a caller-supplied file proves nothing about who asserted them.

The same change separates two claims that previously collapsed into one boolean. A match at the signed coordinates and a bare substring occurrence in the reproduced view are different facts, and only the first is a positional proof. They are now reported as `exact_coordinates` and `occurrence_only`.

## Output shape

Before:

```json
{"recheck_valid": true, "recheck_view": "sanitized_target", "unpinned": true}
```

After:

```json
{"recheck": {"view": "sanitized_target", "location": "exact_coordinates", "signature": "not_checked", "overall": "incomplete"}, "unpinned": true}
```

## Why the caveat moved into the claim

A caveat that lives in a sibling field is a footnote, and machine consumers do not read footnotes. Humans see the unpinned banner; a script reads the result field and moves on. Making the unqualified form impossible to construct is what actually closes this, rather than adding another warning next to it.

## Compatibility

No consumer of the removed fields exists anywhere in the tree: no docs, no golden fixtures, and none of the TypeScript, Rust, or Python verifiers reference them. `--recheck-source` only accepts `payload_kind=proxy_decision_with_spans`, which no production path emits today, so this changes the shape of output that only fixtures produce.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recheck results now distinguish exact matches, occurrence-only matches, and failures.
  * Verification reports separately show location, signature authentication, and overall status.
  * Unauthenticated checks can no longer appear fully verified or provide authoritative locations.
  * Failure states now provide explicit, consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->