### PR TITLE
feat(receipt): declare payload capability maturity and fail the build on a live kind with no producer

### DIFF
--- a/internal/contract/receipt/maturity.go
+++ b/internal/contract/receipt/maturity.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+// PayloadMaturity describes whether a registered EvidenceReceipt v2 payload
+// kind has a production producer.
+type PayloadMaturity string
+
+const (
+	// PayloadMaturityLive means a non-test production path emits this kind.
+	PayloadMaturityLive PayloadMaturity = "live"
+	// PayloadMaturityFixtureOnly means schema and verifier support exists, but
+	// no production path emits this kind.
+	PayloadMaturityFixtureOnly PayloadMaturity = "fixture_only"
+	// PayloadMaturityReserved means the registry knows this kind but rejects it
+	// with ErrPayloadKindNotImplemented.
+	PayloadMaturityReserved PayloadMaturity = "reserved"
+)
+
+type payloadProducerReference struct {
+	packagePath string
+	function    string
+}
+
+type payloadMaturityDeclaration struct {
+	maturity PayloadMaturity
+	producer *payloadProducerReference
+}
+
+// payloadMaturity is the machine-readable capability declaration for every
+// registered EvidenceReceipt v2 payload kind. Live entries name the concrete
+// non-test producer function that the maturity test statically traces to the
+// corresponding PayloadKind reference.
+var payloadMaturity = map[PayloadKind]payloadMaturityDeclaration{
+	PayloadProxyDecision: {maturity: PayloadMaturityLive, producer: &payloadProducerReference{
+		packagePath: "github.com/luckyPipewrench/pipelock/internal/contract/proxydecision", function: "(*Emitter).Emit",
+	}},
+	PayloadProxyDecisionWithSpans: {maturity: PayloadMaturityFixtureOnly},
+	PayloadContractRatified: {maturity: PayloadMaturityLive, producer: &payloadProducerReference{
+		packagePath: "github.com/luckyPipewrench/pipelock/internal/cli/learn", function: "runRatify",
+	}},
+	PayloadContractPromoteIntent: {maturity: PayloadMaturityLive, producer: &payloadProducerReference{
+		packagePath: "github.com/luckyPipewrench/pipelock/internal/cli/learn", function: "runPromote",
+	}},
+	PayloadContractPromoteCommitted: {maturity: PayloadMaturityLive, producer: &payloadProducerReference{
+		packagePath: "github.com/luckyPipewrench/pipelock/internal/cli/learn", function: "runPromote",
+	}},
+	PayloadContractRollbackAuthorized: {maturity: PayloadMaturityLive, producer: &payloadProducerReference{
+		packagePath: "github.com/luckyPipewrench/pipelock/internal/cli/learn", function: "runRollback",
+	}},
+	PayloadContractRollbackCommitted: {maturity: PayloadMaturityLive, producer: &payloadProducerReference{
+		packagePath: "github.com/luckyPipewrench/pipelock/internal/cli/learn", function: "runRollback",
+	}},
+	PayloadContractDemoted: {maturity: PayloadMaturityFixtureOnly},
+	PayloadContractExpired: {maturity: PayloadMaturityFixtureOnly},
+	PayloadContractDrift:   {maturity: PayloadMaturityFixtureOnly},
+	PayloadShadowDelta: {maturity: PayloadMaturityLive, producer: &payloadProducerReference{
+		packagePath: "github.com/luckyPipewrench/pipelock/internal/contract/shadow", function: "(*Emitter).EmitBatch",
+	}},
+	PayloadOpportunityMissing: {maturity: PayloadMaturityFixtureOnly},
+	PayloadKeyRotation:        {maturity: PayloadMaturityFixtureOnly},
+	PayloadContractRedactionRequest: {maturity: PayloadMaturityLive, producer: &payloadProducerReference{
+		packagePath: "github.com/luckyPipewrench/pipelock/internal/cli/learn", function: "runForget",
+	}},
+	PayloadDeferOpened:   {maturity: PayloadMaturityReserved},
+	PayloadDeferResolved: {maturity: PayloadMaturityReserved},
+}

--- a/internal/contract/receipt/maturity_closure_test.go
+++ b/internal/contract/receipt/maturity_closure_test.go
@@ -4,66 +4,81 @@
 package receipt
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"testing"
 )
 
-// TestReachability_IgnoresUncalledClosures guards the closure hole: a reference
-// to a payload constant inside a function literal that is never invoked is not
-// a production path, and must not satisfy the live-producer check.
+// TestReachability_ClosureHandling pins how the producer-reachability walk
+// treats function literals, in BOTH directions.
 //
-// Without the *ast.FuncLit skip in reachesPayloadKind, a producer could be
-// declared live on the strength of dead code such as
-// `var _ = func() { _ = PayloadKeyRotation }`.
+// An UNCALLED closure is not a production path. Without the function-literal
+// guards, a producer could be declared live on the strength of dead code such
+// as `var _ = func() { _ = PayloadKeyRotation }`, which is the false-positive
+// this whole check exists to prevent.
 //
-// Non-vacuity: delete the `if _, ok := node.(*ast.FuncLit); ok { return false }`
-// guard in reachesPayloadKind. This test must then FAIL.
-func TestReachability_IgnoresUncalledClosures(t *testing.T) {
+// An IMMEDIATELY INVOKED closure (`func(){ ... }()`) IS a real static call.
+// Pruning it would make a genuinely live producer read as dark, which is the
+// same defect in the opposite direction and would be worse: it turns the check
+// into a source of false alarms that operators learn to ignore.
+//
+// Non-vacuity, per case:
+//   - uncalled cases: delete the corresponding `invoked[lit]` guard (in
+//     reachesPayloadKind for the direct case, in calledProductionFunctions for
+//     the delegated case) so the walk descends unconditionally.
+//   - invoked cases: make either guard `return false` unconditionally.
+//
+// Each neutralization must fail its own cases and only its own.
+func TestReachability_ClosureHandling(t *testing.T) {
 	t.Parallel()
+	receiptPkg := receiptMaturityModulePath + "/internal/contract/receipt"
 	cases := []struct {
-		name string
-		src  string
+		name          string
+		body          string
+		extraDecls    string
+		wantReachable bool
 	}{
 		{
-			// Exercises the FuncLit skip in reachesPayloadKind: the constant is
-			// referenced DIRECTLY inside an uncalled closure.
-			name: "direct reference inside closure",
-			src: `package sample
-
-import contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
-
-func Producer() {
-	_ = func() { _ = contractreceipt.PayloadKeyRotation }
-}
-`,
+			// reachesPayloadKind: constant referenced DIRECTLY inside an
+			// uncalled closure.
+			name:          "uncalled closure, direct reference",
+			body:          "\t_ = func() { _ = contractreceipt.PayloadKeyRotation }\n",
+			wantReachable: false,
 		},
 		{
-			// Exercises the FuncLit skip in calledProductionFunctions: the
-			// closure does not name the constant at all, it CALLS a helper that
-			// does. Without that second guard the helper is collected as a
-			// called function and the delegated reference counts.
-			name: "delegated call inside closure",
-			src: `package sample
-
-import contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
-
-func helper() { _ = contractreceipt.PayloadKeyRotation }
-
-func Producer() {
-	_ = func() { helper() }
-}
-`,
+			// calledProductionFunctions: the closure never names the constant,
+			// it CALLS a helper that does.
+			name:          "uncalled closure, delegated call",
+			extraDecls:    "func helper() { _ = contractreceipt.PayloadKeyRotation }\n",
+			body:          "\t_ = func() { helper() }\n",
+			wantReachable: false,
+		},
+		{
+			// An IIFE is a real static call, so the direct reference inside it
+			// must be found.
+			name:          "invoked closure, direct reference",
+			body:          "\tfunc() { _ = contractreceipt.PayloadKeyRotation }()\n",
+			wantReachable: true,
+		},
+		{
+			// Same, one level of delegation deeper.
+			name:          "invoked closure, delegated call",
+			extraDecls:    "func helper() { _ = contractreceipt.PayloadKeyRotation }\n",
+			body:          "\tfunc() { helper() }()\n",
+			wantReachable: true,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			src := fmt.Sprintf("package sample\n\nimport contractreceipt %q\n\n%sfunc Producer() {\n%s}\n",
+				receiptPkg, tc.extraDecls, tc.body)
 			fset := token.NewFileSet()
-			file, err := parser.ParseFile(fset, "sample.go", tc.src, 0)
+			file, err := parser.ParseFile(fset, "sample.go", src, 0)
 			if err != nil {
-				t.Fatalf("parse fixture: %v", err)
+				t.Fatalf("parse fixture: %v\n%s", err, src)
 			}
 			pkg := receiptMaturityModulePath + "/sample"
 			imports := importPaths(file)
@@ -82,8 +97,9 @@ func Producer() {
 			if producer == nil {
 				t.Fatal("Producer not found in fixture")
 			}
-			if reachesPayloadKind(producer, PayloadKeyRotation, functions, map[string]bool{}) {
-				t.Fatal("a reference reached only through an uncalled closure was treated as a production path")
+			got := reachesPayloadKind(producer, PayloadKeyRotation, functions, map[string]bool{})
+			if got != tc.wantReachable {
+				t.Fatalf("reachesPayloadKind = %v, want %v\nfixture:\n%s", got, tc.wantReachable, src)
 			}
 		})
 	}

--- a/internal/contract/receipt/maturity_closure_test.go
+++ b/internal/contract/receipt/maturity_closure_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestReachability_IgnoresUncalledClosures guards the closure hole: a reference
+// to a payload constant inside a function literal that is never invoked is not
+// a production path, and must not satisfy the live-producer check.
+//
+// Without the *ast.FuncLit skip in reachesPayloadKind, a producer could be
+// declared live on the strength of dead code such as
+// `var _ = func() { _ = PayloadKeyRotation }`.
+//
+// Non-vacuity: delete the `if _, ok := node.(*ast.FuncLit); ok { return false }`
+// guard in reachesPayloadKind. This test must then FAIL.
+func TestReachability_IgnoresUncalledClosures(t *testing.T) {
+	t.Parallel()
+	const src = `package sample
+
+import contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+
+func Producer() {
+	_ = func() { _ = contractreceipt.PayloadKeyRotation }
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sample.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	var decl *ast.FuncDecl
+	for _, d := range file.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if ok && fn.Name.Name == "Producer" {
+			decl = fn
+		}
+	}
+	if decl == nil {
+		t.Fatal("Producer not found in fixture")
+	}
+	fn := &productionFunction{
+		packagePath: receiptMaturityModulePath + "/sample",
+		name:        "Producer",
+		decl:        decl,
+		imports:     importPaths(file),
+	}
+	functions := map[string]*productionFunction{functionKey(fn.packagePath, fn.name): fn}
+	if reachesPayloadKind(fn, PayloadKeyRotation, functions, map[string]bool{}) {
+		t.Fatal("a reference inside an uncalled closure was treated as a production path")
+	}
+}

--- a/internal/contract/receipt/maturity_closure_test.go
+++ b/internal/contract/receipt/maturity_closure_test.go
@@ -22,37 +22,69 @@ import (
 // guard in reachesPayloadKind. This test must then FAIL.
 func TestReachability_IgnoresUncalledClosures(t *testing.T) {
 	t.Parallel()
-	const src = `package sample
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			// Exercises the FuncLit skip in reachesPayloadKind: the constant is
+			// referenced DIRECTLY inside an uncalled closure.
+			name: "direct reference inside closure",
+			src: `package sample
 
 import contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
 
 func Producer() {
 	_ = func() { _ = contractreceipt.PayloadKeyRotation }
 }
-`
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "sample.go", src, 0)
-	if err != nil {
-		t.Fatalf("parse fixture: %v", err)
+`,
+		},
+		{
+			// Exercises the FuncLit skip in calledProductionFunctions: the
+			// closure does not name the constant at all, it CALLS a helper that
+			// does. Without that second guard the helper is collected as a
+			// called function and the delegated reference counts.
+			name: "delegated call inside closure",
+			src: `package sample
+
+import contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+
+func helper() { _ = contractreceipt.PayloadKeyRotation }
+
+func Producer() {
+	_ = func() { helper() }
+}
+`,
+		},
 	}
-	var decl *ast.FuncDecl
-	for _, d := range file.Decls {
-		fn, ok := d.(*ast.FuncDecl)
-		if ok && fn.Name.Name == "Producer" {
-			decl = fn
-		}
-	}
-	if decl == nil {
-		t.Fatal("Producer not found in fixture")
-	}
-	fn := &productionFunction{
-		packagePath: receiptMaturityModulePath + "/sample",
-		name:        "Producer",
-		decl:        decl,
-		imports:     importPaths(file),
-	}
-	functions := map[string]*productionFunction{functionKey(fn.packagePath, fn.name): fn}
-	if reachesPayloadKind(fn, PayloadKeyRotation, functions, map[string]bool{}) {
-		t.Fatal("a reference inside an uncalled closure was treated as a production path")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "sample.go", tc.src, 0)
+			if err != nil {
+				t.Fatalf("parse fixture: %v", err)
+			}
+			pkg := receiptMaturityModulePath + "/sample"
+			imports := importPaths(file)
+			functions := make(map[string]*productionFunction)
+			for _, d := range file.Decls {
+				decl, ok := d.(*ast.FuncDecl)
+				if !ok || decl.Body == nil {
+					continue
+				}
+				name := productionFunctionName(decl)
+				functions[functionKey(pkg, name)] = &productionFunction{
+					packagePath: pkg, name: name, decl: decl, imports: imports,
+				}
+			}
+			producer := functions[functionKey(pkg, "Producer")]
+			if producer == nil {
+				t.Fatal("Producer not found in fixture")
+			}
+			if reachesPayloadKind(producer, PayloadKeyRotation, functions, map[string]bool{}) {
+				t.Fatal("a reference reached only through an uncalled closure was treated as a production path")
+			}
+		})
 	}
 }

--- a/internal/contract/receipt/maturity_test.go
+++ b/internal/contract/receipt/maturity_test.go
@@ -223,12 +223,15 @@ func reachesPayloadKind(fn *productionFunction, kind PayloadKind, functions map[
 	visited[key] = true
 	want := payloadKindConstantName(kind)
 	found := false
+	invoked := invokedFuncLits(fn.decl.Body)
 	ast.Inspect(fn.decl.Body, func(node ast.Node) bool {
-		// An uncalled closure is not a production path. Descending into a
-		// function literal would let `_ = func(){ _ = PayloadX }` satisfy the
-		// reachability check without anything ever emitting that kind.
-		if _, ok := node.(*ast.FuncLit); ok {
-			return false
+		// An UNCALLED closure is not a production path: descending into it
+		// would let `_ = func(){ _ = PayloadX }` satisfy the reachability
+		// check with dead code. An IMMEDIATELY INVOKED closure
+		// (`func(){ ... }()`) is a real static call, so it must still be
+		// traversed or a genuinely live producer would read as dark.
+		if lit, ok := node.(*ast.FuncLit); ok {
+			return invoked[lit]
 		}
 		selector, ok := node.(*ast.SelectorExpr)
 		if !ok || selector.Sel.Name != want {
@@ -254,11 +257,13 @@ func reachesPayloadKind(fn *productionFunction, kind PayloadKind, functions map[
 
 func calledProductionFunctions(fn *productionFunction, functions map[string]*productionFunction) []*productionFunction {
 	var called []*productionFunction
+	invoked := invokedFuncLits(fn.decl.Body)
 	ast.Inspect(fn.decl.Body, func(node ast.Node) bool {
-		// Same reason as reachesPayloadKind: a call sitting inside an uncalled
-		// closure is not on the production path.
-		if _, ok := node.(*ast.FuncLit); ok {
-			return false
+		// Same rule as reachesPayloadKind: a call inside an UNCALLED closure is
+		// not on the production path, but a call inside an immediately invoked
+		// one is.
+		if lit, ok := node.(*ast.FuncLit); ok {
+			return invoked[lit]
 		}
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
@@ -298,4 +303,23 @@ func payloadKindConstantName(kind PayloadKind) string {
 		}
 	}
 	return ""
+}
+
+// invokedFuncLits collects every function literal in body that is immediately
+// invoked, i.e. `func(){ ... }()`. Those ARE production paths and must be
+// traversed. A bare `_ = func(){ ... }` is not, and pruning it is what stops a
+// dead closure from satisfying the reachability check.
+func invokedFuncLits(body *ast.BlockStmt) map[*ast.FuncLit]bool {
+	invoked := make(map[*ast.FuncLit]bool)
+	ast.Inspect(body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if lit, ok := call.Fun.(*ast.FuncLit); ok {
+			invoked[lit] = true
+		}
+		return true
+	})
+	return invoked
 }

--- a/internal/contract/receipt/maturity_test.go
+++ b/internal/contract/receipt/maturity_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"encoding/json"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const receiptMaturityModulePath = "github.com/luckyPipewrench/pipelock"
+
+type productionFunction struct {
+	packagePath string
+	name        string
+	decl        *ast.FuncDecl
+	imports     map[string]string
+}
+
+// TestPayloadMaturityDeclarationIsExhaustive makes registry changes and
+// capability declarations move together. A registered kind without exactly
+// one maturity state fails this test.
+func TestPayloadMaturityDeclarationIsExhaustive(t *testing.T) {
+	if len(payloadMaturity) != len(payloadValidators) {
+		t.Fatalf("payload maturity declarations = %d, registered payload kinds = %d", len(payloadMaturity), len(payloadValidators))
+	}
+	for kind := range payloadValidators {
+		entry, ok := payloadMaturity[kind]
+		if !ok {
+			t.Fatalf("registered payload kind %q has no maturity declaration", kind)
+		}
+		switch entry.maturity {
+		case PayloadMaturityLive:
+			if entry.producer == nil {
+				t.Fatalf("live payload kind %q has no production producer reference", kind)
+			}
+		case PayloadMaturityFixtureOnly:
+			if entry.producer != nil {
+				t.Fatalf("non-live payload kind %q unexpectedly names producer %s.%s", kind, entry.producer.packagePath, entry.producer.function)
+			}
+			if err := payloadValidators[kind](json.RawMessage(`{}`)); errors.Is(err, ErrPayloadKindNotImplemented) {
+				t.Fatalf("fixture-only payload kind %q routes to ErrPayloadKindNotImplemented", kind)
+			}
+		case PayloadMaturityReserved:
+			if entry.producer != nil {
+				t.Fatalf("non-live payload kind %q unexpectedly names producer %s.%s", kind, entry.producer.packagePath, entry.producer.function)
+			}
+			if err := payloadValidators[kind](json.RawMessage(`{}`)); !errors.Is(err, ErrPayloadKindNotImplemented) {
+				t.Fatalf("reserved payload kind %q error = %v, want ErrPayloadKindNotImplemented", kind, err)
+			}
+		default:
+			t.Fatalf("payload kind %q has unknown maturity %q", kind, entry.maturity)
+		}
+	}
+	for kind := range payloadMaturity {
+		if _, ok := payloadValidators[kind]; !ok {
+			t.Fatalf("maturity declaration exists for unregistered payload kind %q", kind)
+		}
+	}
+}
+
+// TestLivePayloadKindsHaveProductionProducers parses every non-test Go file,
+// resolves each declared live producer, and follows direct static calls until
+// it reaches that kind's PayloadKind constant. It catches a false live claim
+// without a declared non-test producer path; schemas, validators, and test
+// fixtures alone cannot satisfy it.
+//
+// This source-level check cannot prove a runtime configuration enables a
+// producer or see reflection and function-value calls; those are integration
+// test concerns.
+func TestLivePayloadKindsHaveProductionProducers(t *testing.T) {
+	functions := loadProductionFunctions(t)
+	for kind, entry := range payloadMaturity {
+		if entry.maturity != PayloadMaturityLive {
+			continue
+		}
+		if entry.producer == nil {
+			t.Fatalf("live payload kind %q has no production producer reference", kind)
+		}
+		root := functions[functionKey(entry.producer.packagePath, entry.producer.function)]
+		if root == nil {
+			t.Fatalf("live payload kind %q producer %s.%s does not exist in non-test source", kind, entry.producer.packagePath, entry.producer.function)
+		}
+		if !reachesPayloadKind(root, kind, functions, map[string]bool{}) {
+			t.Fatalf("live payload kind %q producer %s.%s does not reach contractreceipt.%s", kind, entry.producer.packagePath, entry.producer.function, payloadKindConstantName(kind))
+		}
+	}
+}
+
+func loadProductionFunctions(t *testing.T) map[string]*productionFunction {
+	t.Helper()
+	root := receiptMaturityRepositoryRoot(t)
+	functions := make(map[string]*productionFunction)
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" || d.Name() == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		packagePath := receiptMaturityModulePath
+		if rel != "." {
+			packagePath += "/" + filepath.ToSlash(rel)
+		}
+		imports := importPaths(file)
+		for _, declaration := range file.Decls {
+			fn, ok := declaration.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			name := productionFunctionName(fn)
+			functions[functionKey(packagePath, name)] = &productionFunction{packagePath: packagePath, name: name, decl: fn, imports: imports}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("load non-test production functions: %v", err)
+	}
+	return functions
+}
+
+func receiptMaturityRepositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate maturity test source")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "../../.."))
+}
+
+func importPaths(file *ast.File) map[string]string {
+	imports := make(map[string]string, len(file.Imports))
+	for _, spec := range file.Imports {
+		path := strings.Trim(spec.Path.Value, "\"")
+		name := filepath.Base(path)
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+		imports[name] = path
+	}
+	return imports
+}
+
+func productionFunctionName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return fn.Name.Name
+	}
+	return receiverName(fn.Recv.List[0].Type) + "." + fn.Name.Name
+}
+
+func receiverName(expr ast.Expr) string {
+	switch typed := expr.(type) {
+	case *ast.StarExpr:
+		return "(*" + receiverName(typed.X) + ")"
+	case *ast.Ident:
+		return typed.Name
+	default:
+		return "?"
+	}
+}
+
+func functionKey(packagePath, name string) string {
+	return packagePath + ":" + name
+}
+
+func reachesPayloadKind(fn *productionFunction, kind PayloadKind, functions map[string]*productionFunction, visited map[string]bool) bool {
+	key := functionKey(fn.packagePath, fn.name)
+	if visited[key] {
+		return false
+	}
+	visited[key] = true
+	want := payloadKindConstantName(kind)
+	found := false
+	ast.Inspect(fn.decl.Body, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != want {
+			return true
+		}
+		ident, ok := selector.X.(*ast.Ident)
+		if ok && fn.imports[ident.Name] == receiptMaturityModulePath+"/internal/contract/receipt" {
+			found = true
+			return false
+		}
+		return true
+	})
+	if found {
+		return true
+	}
+	for _, called := range calledProductionFunctions(fn, functions) {
+		if reachesPayloadKind(called, kind, functions, visited) {
+			return true
+		}
+	}
+	return false
+}
+
+func calledProductionFunctions(fn *productionFunction, functions map[string]*productionFunction) []*productionFunction {
+	var called []*productionFunction
+	ast.Inspect(fn.decl.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		key := ""
+		switch callee := call.Fun.(type) {
+		case *ast.Ident:
+			key = functionKey(fn.packagePath, callee.Name)
+		case *ast.SelectorExpr:
+			ident, ok := callee.X.(*ast.Ident)
+			if ok && fn.imports[ident.Name] != "" {
+				key = functionKey(fn.imports[ident.Name], callee.Sel.Name)
+			}
+		}
+		if candidate := functions[key]; candidate != nil {
+			called = append(called, candidate)
+		}
+		return true
+	})
+	return called
+}
+
+func payloadKindConstantName(kind PayloadKind) string {
+	for name, candidate := range map[string]PayloadKind{
+		"PayloadProxyDecision": PayloadProxyDecision, "PayloadProxyDecisionWithSpans": PayloadProxyDecisionWithSpans,
+		"PayloadContractRatified": PayloadContractRatified, "PayloadContractPromoteIntent": PayloadContractPromoteIntent,
+		"PayloadContractPromoteCommitted": PayloadContractPromoteCommitted, "PayloadContractRollbackAuthorized": PayloadContractRollbackAuthorized,
+		"PayloadContractRollbackCommitted": PayloadContractRollbackCommitted, "PayloadContractDemoted": PayloadContractDemoted,
+		"PayloadContractExpired": PayloadContractExpired, "PayloadContractDrift": PayloadContractDrift,
+		"PayloadShadowDelta": PayloadShadowDelta, "PayloadOpportunityMissing": PayloadOpportunityMissing,
+		"PayloadKeyRotation": PayloadKeyRotation, "PayloadContractRedactionRequest": PayloadContractRedactionRequest,
+		"PayloadDeferOpened": PayloadDeferOpened, "PayloadDeferResolved": PayloadDeferResolved,
+	} {
+		if candidate == kind {
+			return name
+		}
+	}
+	return ""
+}

--- a/internal/contract/receipt/maturity_test.go
+++ b/internal/contract/receipt/maturity_test.go
@@ -33,37 +33,52 @@ func TestPayloadMaturityDeclarationIsExhaustive(t *testing.T) {
 		t.Fatalf("payload maturity declarations = %d, registered payload kinds = %d", len(payloadMaturity), len(payloadValidators))
 	}
 	for kind := range payloadValidators {
-		entry, ok := payloadMaturity[kind]
-		if !ok {
-			t.Fatalf("registered payload kind %q has no maturity declaration", kind)
-		}
-		switch entry.maturity {
-		case PayloadMaturityLive:
-			if entry.producer == nil {
-				t.Fatalf("live payload kind %q has no production producer reference", kind)
+		t.Run(string(kind), func(t *testing.T) {
+			entry, ok := payloadMaturity[kind]
+			if !ok {
+				t.Fatalf("registered payload kind %q has no maturity declaration", kind)
 			}
-		case PayloadMaturityFixtureOnly:
-			if entry.producer != nil {
-				t.Fatalf("non-live payload kind %q unexpectedly names producer %s.%s", kind, entry.producer.packagePath, entry.producer.function)
-			}
-			if err := payloadValidators[kind](json.RawMessage(`{}`)); errors.Is(err, ErrPayloadKindNotImplemented) {
-				t.Fatalf("fixture-only payload kind %q routes to ErrPayloadKindNotImplemented", kind)
-			}
-		case PayloadMaturityReserved:
-			if entry.producer != nil {
-				t.Fatalf("non-live payload kind %q unexpectedly names producer %s.%s", kind, entry.producer.packagePath, entry.producer.function)
-			}
-			if err := payloadValidators[kind](json.RawMessage(`{}`)); !errors.Is(err, ErrPayloadKindNotImplemented) {
-				t.Fatalf("reserved payload kind %q error = %v, want ErrPayloadKindNotImplemented", kind, err)
-			}
-		default:
-			t.Fatalf("payload kind %q has unknown maturity %q", kind, entry.maturity)
-		}
+			assertMaturityEntry(t, kind, entry)
+		})
 	}
 	for kind := range payloadMaturity {
 		if _, ok := payloadValidators[kind]; !ok {
 			t.Fatalf("maturity declaration exists for unregistered payload kind %q", kind)
 		}
+	}
+}
+
+// assertMaturityEntry checks one payload kind's declared state against the
+// behavior its registered validator actually exhibits.
+func assertMaturityEntry(t *testing.T, kind PayloadKind, entry payloadMaturityDeclaration) {
+	t.Helper()
+	switch entry.maturity {
+	case PayloadMaturityLive:
+		if entry.producer == nil {
+			t.Fatalf("live payload kind %q has no production producer reference", kind)
+		}
+		// A kind cannot be both emitted in production and routed to the
+		// not-implemented validator; that combination would reject every
+		// receipt the declared producer emits.
+		if err := payloadValidators[kind](json.RawMessage(`{}`)); errors.Is(err, ErrPayloadKindNotImplemented) {
+			t.Fatalf("live payload kind %q routes to ErrPayloadKindNotImplemented", kind)
+		}
+	case PayloadMaturityFixtureOnly:
+		if entry.producer != nil {
+			t.Fatalf("non-live payload kind %q unexpectedly names producer %s.%s", kind, entry.producer.packagePath, entry.producer.function)
+		}
+		if err := payloadValidators[kind](json.RawMessage(`{}`)); errors.Is(err, ErrPayloadKindNotImplemented) {
+			t.Fatalf("fixture-only payload kind %q routes to ErrPayloadKindNotImplemented", kind)
+		}
+	case PayloadMaturityReserved:
+		if entry.producer != nil {
+			t.Fatalf("non-live payload kind %q unexpectedly names producer %s.%s", kind, entry.producer.packagePath, entry.producer.function)
+		}
+		if err := payloadValidators[kind](json.RawMessage(`{}`)); !errors.Is(err, ErrPayloadKindNotImplemented) {
+			t.Fatalf("reserved payload kind %q error = %v, want ErrPayloadKindNotImplemented", kind, err)
+		}
+	default:
+		t.Fatalf("payload kind %q has unknown maturity %q", kind, entry.maturity)
 	}
 }
 
@@ -73,9 +88,24 @@ func TestPayloadMaturityDeclarationIsExhaustive(t *testing.T) {
 // without a declared non-test producer path; schemas, validators, and test
 // fixtures alone cannot satisfy it.
 //
-// This source-level check cannot prove a runtime configuration enables a
-// producer or see reflection and function-value calls; those are integration
-// test concerns.
+// KNOWN LIMITS — read these before trusting a `live` declaration:
+//
+//   - It is SYNTACTIC, not type-resolved. Selector resolution uses the file's
+//     import map rather than go/types, so a same-named symbol from a different
+//     package could in principle satisfy it.
+//   - It proves the producer REFERENCES the kind's constant on a reachable
+//     statement path, not that it constructs, signs, or emits a receipt with
+//     that kind. A reference inside a dead branch such as `if false { _ = X }`
+//     would still count.
+//   - It cannot see reflection or calls through function values, and it cannot
+//     prove a runtime configuration enables the producer at all.
+//
+// So this catches the failure it was built for -- a kind declared `live` with
+// no production producer whatsoever, which is how proxy_decision_with_spans sat
+// dark for two months -- and it does NOT certify that a live path executes.
+// Upgrading to go/packages type resolution plus an assertion on the emitted
+// kind is tracked as follow-up work; treat a `live` label as "a producer exists
+// and references this kind", not as proof of emission.
 func TestLivePayloadKindsHaveProductionProducers(t *testing.T) {
 	functions := loadProductionFunctions(t)
 	for kind, entry := range payloadMaturity {
@@ -194,6 +224,12 @@ func reachesPayloadKind(fn *productionFunction, kind PayloadKind, functions map[
 	want := payloadKindConstantName(kind)
 	found := false
 	ast.Inspect(fn.decl.Body, func(node ast.Node) bool {
+		// An uncalled closure is not a production path. Descending into a
+		// function literal would let `_ = func(){ _ = PayloadX }` satisfy the
+		// reachability check without anything ever emitting that kind.
+		if _, ok := node.(*ast.FuncLit); ok {
+			return false
+		}
 		selector, ok := node.(*ast.SelectorExpr)
 		if !ok || selector.Sel.Name != want {
 			return true
@@ -219,6 +255,11 @@ func reachesPayloadKind(fn *productionFunction, kind PayloadKind, functions map[
 func calledProductionFunctions(fn *productionFunction, functions map[string]*productionFunction) []*productionFunction {
 	var called []*productionFunction
 	ast.Inspect(fn.decl.Body, func(node ast.Node) bool {
+		// Same reason as reachesPayloadKind: a call sitting inside an uncalled
+		// closure is not on the production path.
+		if _, ok := node.(*ast.FuncLit); ok {
+			return false
+		}
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
 			return true

--- a/internal/contract/receipt/registry.go
+++ b/internal/contract/receipt/registry.go
@@ -406,7 +406,8 @@ func validateNotImplemented(json.RawMessage) error {
 
 // SourceSpanMatchHash computes the signer-keyed match_hash for a span. eventID
 // MUST be the signed EvidenceReceipt.event_id for the receipt that will carry
-// the span; verifiers reconstruct the same input from that envelope field.
+// the span. Current verifiers validate match_hash structurally but do not
+// reconstruct or verify this HMAC preimage.
 // matchValue is the normalized/redacted evidence slice, or a class/placeholder
 // value for secret-bearing matches. The key is not serialized into the receipt,
 // which prevents offline confirmation of guessed low-entropy values.

--- a/sdk/audit-packet/audit_packet.go
+++ b/sdk/audit-packet/audit_packet.go
@@ -294,7 +294,8 @@ type Receipt struct {
 // SourceSpan is the inline audit-packet mirror of EvidenceReceipt v2
 // source_spans. Producers still verify the signed EvidenceReceipt bytes; this
 // optional copy lets packet consumers display span metadata without parsing the
-// receipt payload first.
+// receipt payload first. It is currently fixture-only: no production Audit
+// Packet producer populates it.
 type SourceSpan struct {
 	SourceID             string `json:"source_id"`
 	SourceKind           string `json:"source_kind"`


### PR DESCRIPTION
## What changed

Every registered EvidenceReceipt v2 payload kind now carries exactly one declared maturity state, and a test fails the build when a kind declared `live` has no production producer.

The states are `live` (a non-test production path emits this kind), `fixture_only` (schema and verifier exist and are exercised only by fixtures, with no production producer), and `reserved` (known to the schema, deliberately not accepted, routes to `ErrPayloadKindNotImplemented`).

## Why

A payload kind can ship with a schema, validators, cross-language verifiers, fixtures, and a user-facing CLI flag while no production code path ever emits it. Every layer is correct and green, and the last mile of actually calling it is the only step with no test that can fail. Several payload kinds are in that state today.

Nothing in the build could previously notice. This adds the mechanism that notices.

## How the producer check works

`TestLivePayloadKindsHaveProductionProducers` parses every non-test Go file in the module, resolves each declared producer function, and follows direct static calls transitively until it reaches that kind's `PayloadKind` constant. A declared producer that does not exist in non-test source fails, and so does one that exists but cannot reach the constant.

The check is source-level. It cannot prove that a runtime configuration enables a producer, and it does not follow reflection or function-value calls. Those limits are stated in the test comment rather than implied.

`TestPayloadMaturityDeclarationIsExhaustive` keeps the declaration and the dispatch registry moving together, so a payload kind cannot be registered without declaring its maturity, and a declaration cannot outlive its kind.

## Also corrected

The `SourceSpanMatchHash` doc comment claimed that verifiers reconstruct the same HMAC preimage from the envelope field. No shipped verifier reconstructs or verifies that HMAC, so the comment now says what the code actually does.

## What this does not do

No dormant payload kind is implemented or wired to a producer. This declares and enforces the truth about what exists today. Turning any `fixture_only` kind into a `live` one is separate work that requires a real producer, and this test is what will prove it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added maturity classifications for registered receipt payloads: live, fixture-only, and reserved.
  * Reserved payload types are documented as unavailable and rejected.

* **Documentation**
  * Clarified verifier behavior for source-span match hashes.
  * Documented that source spans are fixture-only and not populated in production audit packets.

* **Tests**
  * Added comprehensive validation for payload classifications, production reachability, and closure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->